### PR TITLE
chore: canonicalize map builder names in generated docs

### DIFF
--- a/docs/builtin_contract_table.generated.md
+++ b/docs/builtin_contract_table.generated.md
@@ -12,6 +12,7 @@ Legend:
 - `required effects` is the effect-set contract (`with {...}` requirement).
 - `- (do required)` means no effect-set requirement, but current checker
   requires an effect-allowed context (`do { ... }` or effectful function body).
+- legacy builtin aliases are normalized to canonical names in this table.
 - `component` currently shares builtin codegen support with `wasm`.
 
 | name | signature | required effects | interpreter | wasm | component |
@@ -65,9 +66,6 @@ Legend:
 | `i32_trunc_f64_s` | `(Double) -> Int` | `-` | no | yes | yes |
 | `int_to_double` | `(Int) -> Double` | `-` | no | yes | yes |
 | `int_to_float` | `(Int) -> Float` | `-` | no | yes | yes |
-| `map_builder` | `() -> MapBuilder[K, V]` | `-` | yes | yes | yes |
-| `map_builder_freeze` | `(MapBuilder[K, V]) -> Map[K, V]` | `-` | yes | yes | yes |
-| `map_builder_set` | `(MapBuilder[K, V], K, V) -> Unit` | `-` | yes | yes | yes |
 | `map_get` | `(Map[K, V], K) -> V` | `-` | no | yes | yes |
 | `map_has_key` | `(Map[K, V], K) -> Bool` | `-` | no | yes | yes |
 | `map_keys` | `(Map[K, V]) -> Array[K]` | `-` | yes | yes | yes |

--- a/scripts/gen_builtin_contract_table.mjs
+++ b/scripts/gen_builtin_contract_table.mjs
@@ -69,6 +69,15 @@ const union = (...sets) => {
   return out;
 };
 
+const canonical_builtin_aliases = new Map([
+  ["map_builder", "MapBuilder::new"],
+  ["map_builder_set", "MapBuilder::set"],
+  ["map_builder_freeze", "MapBuilder::freeze"],
+]);
+
+const canonicalize_builtin_name = (name) =>
+  canonical_builtin_aliases.get(name) ?? name;
+
 const signatures = {
   path: "(String) -> Path",
   addr: "(String literal) -> T  // address lookup",
@@ -196,27 +205,66 @@ const wasm_supported = union(
   extract_case_names(wasm_builtin_codegen),
 );
 
-const missing_signatures = checker_builtin_names.filter((name) => !signatures[name]);
+const builtin_name_groups = new Map();
+for (const name of checker_builtin_names) {
+  const canonical_name = canonicalize_builtin_name(name);
+  const group = builtin_name_groups.get(canonical_name) ?? [];
+  group.push(name);
+  builtin_name_groups.set(canonical_name, group);
+}
+
+const builtin_names = [...builtin_name_groups.keys()].sort();
+
+const signature_for = (names) => {
+  for (const name of names) {
+    if (signatures[name]) {
+      return signatures[name];
+    }
+  }
+  return null;
+};
+
+const first_match = (names, pred) => {
+  for (const name of names) {
+    if (pred(name)) {
+      return name;
+    }
+  }
+  return null;
+};
+
+const missing_signatures = builtin_names.filter(
+  (name) => signature_for([name, ...(builtin_name_groups.get(name) ?? [])]) == null,
+);
 if (missing_signatures.length > 0) {
   console.warn(
     `skipping ${missing_signatures.length} builtin(s) without signature metadata`,
   );
 }
-const checker_builtins = checker_builtin_names.filter((name) => signatures[name]);
+const checker_builtins = builtin_names.filter(
+  (name) => signature_for([name, ...(builtin_name_groups.get(name) ?? [])]) != null,
+);
 
 const markdown_escape = (s) => s.replaceAll("|", "\\|");
 
 const rows = checker_builtins.map((name) => {
-  const effect = effects.get(name);
-  const effect_text = effect
+  const raw_names = [name, ...(builtin_name_groups.get(name) ?? [])];
+  const effect_name = first_match(raw_names, (raw_name) => effects.has(raw_name));
+  const effect = effect_name == null ? null : effects.get(effect_name);
+  const effect_text = effect != null
     ? `{${effect}}`
-    : do_required.has(name)
+    : raw_names.some((raw_name) => do_required.has(raw_name))
       ? "- (do required)"
       : "-";
-  const interp = interpreter_supported.has(name) ? "yes" : "no";
-  const wasm = wasm_supported.has(name) ? "yes" : "no";
-  const component = wasm_supported.has(name) ? "yes" : "no";
-  return `| \`${name}\` | \`${markdown_escape(signatures[name])}\` | \`${markdown_escape(effect_text)}\` | ${interp} | ${wasm} | ${component} |`;
+  const interp = raw_names.some((raw_name) => interpreter_supported.has(raw_name))
+    ? "yes"
+    : "no";
+  const wasm = raw_names.some((raw_name) => wasm_supported.has(raw_name))
+    ? "yes"
+    : "no";
+  const component = wasm;
+  const signature = signature_for(raw_names);
+  return `| \`${name}\` | \`${markdown_escape(signature ?? "(missing)")}\` | \`${markdown_escape(effect_text)}\` | ${interp} | ${wasm} | ${component} |`;
 });
 
 const out = [
@@ -234,6 +282,7 @@ const out = [
   "- `required effects` is the effect-set contract (`with {...}` requirement).",
   "- `- (do required)` means no effect-set requirement, but current checker",
   "  requires an effect-allowed context (`do { ... }` or effectful function body).",
+  "- legacy builtin aliases are normalized to canonical names in this table.",
   "- `component` currently shares builtin codegen support with `wasm`.",
   "",
   "| name | signature | required effects | interpreter | wasm | component |",

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -2768,10 +2768,10 @@ test "compiled test wrapper overwrites duplicate map builder keys" {
   @os_fs.write_string_to_file(
     source_path,
     "test \"map builder dedupe\" {\n" +
-    "  let b = map_builder()\n" +
-    "  map_builder_set(b, \"name\", 1)\n" +
-    "  map_builder_set(b, \"name\", 2)\n" +
-    "  let m = map_builder_freeze(b)\n" +
+    "  let b = MapBuilder::new()\n" +
+    "  MapBuilder::set(b, \"name\", 1)\n" +
+    "  MapBuilder::set(b, \"name\", 2)\n" +
+    "  let m = MapBuilder::freeze(b)\n" +
     "  assert(eq(array_length(map_keys(m)), 1))\n" +
     "  assert(eq(map_get(m, \"name\"), 2))\n" +
     "}\n",


### PR DESCRIPTION
## Summary
- canonicalize legacy `map_builder*` aliases to `MapBuilder::*` in the generated builtin contract table
- keep runtime/checker/codegen compatibility aliases untouched
- update the compiled wbtest fixture to use canonical `MapBuilder::*` calls

## Why
The runtime still keeps legacy aliases for migration safety, but user-facing generated docs should prefer the canonical type-owned API names. This keeps the contract table aligned with the current docs and ADR direction without removing compatibility yet.

## Changes
- add alias normalization in `scripts/gen_builtin_contract_table.mjs`
- regenerate `docs/builtin_contract_table.generated.md` so legacy `map_builder*` rows no longer appear separately
- rewrite the duplicate map-builder compiled wbtest fixture in `src/cmd/vibe/cli_wbtest.mbt` to use `MapBuilder::*`

## Testing
- `node scripts/gen_builtin_contract_table.mjs`
- `moon test src/cmd/vibe/cli_wbtest.mbt --target native --filter 'compiled test wrapper overwrites duplicate map builder keys' --warn-list '-1-7-24-29'`
