### PR TITLE
test: use canonical map builder names in runtime snapshot

### DIFF
--- a/src/runtime/runtime_test.mbt
+++ b/src/runtime/runtime_test.mbt
@@ -1602,7 +1602,7 @@ test "vibe array builder freeze snapshot" {
 test "vibe map builder freeze snapshot" {
   let rt = Runtime::new(@capability.CapabilitySet::new())
   let _ = rt.eval_script(
-    "let m = { let b = map_builder()\nmap_builder_set(b, \"a\", 1)\nlet x = map_builder_freeze(b)\nmap_builder_set(b, \"b\", 2)\nlet y = map_builder_freeze(b)\n(x, y) }",
+    "let m = { let b = MapBuilder::new()\nMapBuilder::set(b, \"a\", 1)\nlet x = MapBuilder::freeze(b)\nMapBuilder::set(b, \"b\", 2)\nlet y = MapBuilder::freeze(b)\n(x, y) }",
   )
   match rt.get("m") {
     Some(@core.Value::Tuple(items)) =>


### PR DESCRIPTION
## Summary
- switch the runtime map builder snapshot test input from legacy `map_builder*` calls to canonical `MapBuilder::*`

## Why
The runtime still keeps legacy aliases for compatibility, but this test is no longer alias-specific. Using canonical names here reduces stray legacy call sites while preserving dedicated alias coverage elsewhere.

## Testing
- `moon test src/runtime/runtime_test.mbt --target native --filter 'vibe map builder freeze snapshot' --warn-list '-1-7-24-29'`
