### PR TITLE
refactor: normalize host map builder aliases

### DIFF
--- a/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
+++ b/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
@@ -9,7 +9,8 @@ fn type_call_builtin_handler_collection_numeric(
   allow_effect : Bool,
   call_span : @core.Span,
 ) -> @core.Type raise TypeError {
-  match builtin_name {
+  let normalized_builtin_name = @core.normalize_builtin_name(builtin_name)
+  match normalized_builtin_name {
     "string_from_char_code" =>
       check_builtin_simple(
         env,
@@ -288,7 +289,7 @@ fn type_call_builtin_handler_collection_numeric(
       )
       @core.Type::Array(elem_ty)
     }
-    "map_builder" | "MapBuilder::new" =>
+    "MapBuilder::new" =>
       check_builtin_simple(
         env,
         "MapBuilder::new",
@@ -301,7 +302,7 @@ fn type_call_builtin_handler_collection_numeric(
         @core.Type::MapBuilder(fresh_type_var(env), fresh_type_var(env)),
         true,
       )
-    "map_builder_set" | "MapBuilder::set" => {
+    "MapBuilder::set" => {
       let pos_args = prepare_builtin_pos_args(
         env, "MapBuilder::set", args, 3, effects, allow_effect, call_span, true,
       )
@@ -336,7 +337,7 @@ fn type_call_builtin_handler_collection_numeric(
       ensure_type(env, value_ty, elem_ty, pos_args[2].span(), "argument")
       @core.Type::Unit
     }
-    "map_builder_freeze" | "MapBuilder::freeze" => {
+    "MapBuilder::freeze" => {
       let pos_args = prepare_builtin_pos_args(
         env, "MapBuilder::freeze", args, 1, effects, allow_effect, call_span, true,
       )

--- a/src/checker/typecheck_call_builtin_wbtest.mbt
+++ b/src/checker/typecheck_call_builtin_wbtest.mbt
@@ -150,6 +150,29 @@ test "type_call_builtin: array_builder_push returns Unit" {
 }
 
 ///|
+test "type_call_builtin: legacy map_builder alias resolves as MapBuilder" {
+  let env = TypeEnv::new()
+  let span = builtin_test_span()
+  let args : Array[@core.CallArg] = []
+  let aliases : Map[String, @core.Ref] = {}
+  let actual = type_call_builtin(
+    env,
+    "map_builder",
+    args,
+    aliases,
+    effect_scope_all(),
+    true,
+    span,
+  ) catch {
+    err => fail(err.to_string())
+  }
+  match actual {
+    @core.Type::MapBuilder(_, _) => assert_true(true)
+    _ => fail("expected MapBuilder")
+  }
+}
+
+///|
 test "type_call_builtin: json_get returns Json" {
   let env = TypeEnv::new()
   let span = builtin_test_span()

--- a/src/codegen/address.mbt
+++ b/src/codegen/address.mbt
@@ -952,12 +952,7 @@ fn is_builtin(name : String) -> Bool {
   name == "bytes_from_array" ||
   name == "bytes_length" ||
   name == "bytes_get" ||
-  name == "map_builder" ||
-  name == "map_builder_set" ||
-  name == "map_builder_freeze" ||
-  name == "MapBuilder::new" ||
-  name == "MapBuilder::set" ||
-  name == "MapBuilder::freeze" ||
+  @core.is_map_builder_builtin_name(name) ||
   name == "map_keys" ||
   name == "map_values" ||
   name == "map_has_key" ||

--- a/src/codegen/wasm_codegen_call_builtin_pre_user.mbt
+++ b/src/codegen/wasm_codegen_call_builtin_pre_user.mbt
@@ -511,7 +511,7 @@ fn compile_call_builtin_pre_user_inner(
   args : Array[@core.CallArg],
   is_user_fn : Bool,
 ) -> Unit raise WasmGenError {
-  match name {
+  match @core.normalize_builtin_name(name) {
     "sh" => {
       let pos_args = extract_positional_exprs_with_arity(args, "sh", 1)
       compile_expr_i32(ctx, buf, pos_args[0])
@@ -4385,8 +4385,8 @@ fn compile_call_builtin_pre_user_inner(
       emit_i64_const_raw(buf, tag_obj.to_int64())
       emit_i64_or(buf)
     }
-    "map_builder" | "MapBuilder::new" => {
-      // map_builder() -> allocate empty map obj with len=0
+    "MapBuilder::new" => {
+      // MapBuilder::new() -> allocate empty map obj with len=0
       let max_cap = 128
       require_heap(ctx)
       let size = align4(8 + max_cap * 8)
@@ -4403,8 +4403,8 @@ fn compile_call_builtin_pre_user_inner(
       emit_i64_const_raw(buf, tag_obj.to_int64())
       emit_i64_or(buf)
     }
-    "map_builder_set" | "MapBuilder::set" => {
-      // map_builder_set(builder, key, value) -> overwrite existing key or append new pair
+    "MapBuilder::set" => {
+      // MapBuilder::set(builder, key, value) -> overwrite existing key or append new pair
       let pos_args = extract_positional_exprs_with_arity(
         args, "MapBuilder::set", 3,
       )
@@ -4649,8 +4649,8 @@ fn compile_call_builtin_pre_user_inner(
       // return unit
       emit_i64_const_tagged(buf, 0L)
     }
-    "map_builder_freeze" | "MapBuilder::freeze" => {
-      // map_builder_freeze(builder) -> return builder as-is (it is already a map obj)
+    "MapBuilder::freeze" => {
+      // MapBuilder::freeze(builder) -> return builder as-is (it is already a map obj)
       let pos_args = extract_positional_exprs_with_arity(
         args, "MapBuilder::freeze", 1,
       )

--- a/src/codegen/wasm_codegen_data.mbt
+++ b/src/codegen/wasm_codegen_data.mbt
@@ -117,7 +117,7 @@ fn scan_needs_expr(ctx : CodegenCtx, expr : @core.Expr) -> Unit {
   match expr {
     @core.Expr::Call(name~, args~, span~, ..) => {
       let _ = span
-      match name {
+      match @core.normalize_builtin_name(name) {
         "sh" => ctx.need_sh = true
         "path" | "path_ref" => ctx.need_path = true
         "dynamic_path_resolve" => ctx.need_dynamic_path_resolve = true
@@ -143,7 +143,6 @@ fn scan_needs_expr(ctx : CodegenCtx, expr : @core.Expr) -> Unit {
             ctx.need_js_equals = true
           }
         "array_builder"
-        | "map_builder"
         | "MapBuilder::new"
         | "string_builder"
         | "string_join"

--- a/src/codegen/wasm_codegen_sig.mbt
+++ b/src/codegen/wasm_codegen_sig.mbt
@@ -386,7 +386,7 @@ fn infer_expr_kind_with(
       let _ = span
       let name = @core.lower_wasm_intrinsic_name(name)
       let pos_args = extract_positional_exprs(args, name)
-      match name {
+      match @core.normalize_builtin_name(name) {
         "add" | "sub" | "mul" | "div" | "eq" | "lt" => ValueKind::I64
         "__index" => ValueKind::I64
         "__add" | "__sub" | "__mul" | "__div" | "__mod" => {
@@ -531,9 +531,9 @@ fn infer_expr_kind_with(
         "bytes_from_array" => ValueKind::I64
         "bytes_length" => ValueKind::I64
         "bytes_get" => ValueKind::I64
-        "map_builder" | "MapBuilder::new" => ValueKind::I64
-        "map_builder_freeze" | "MapBuilder::freeze" => ValueKind::I64
-        "map_builder_set" | "MapBuilder::set" => ValueKind::I64
+        "MapBuilder::new" => ValueKind::I64
+        "MapBuilder::freeze" => ValueKind::I64
+        "MapBuilder::set" => ValueKind::I64
         "array_length" => ValueKind::I64
         "array_get" => ValueKind::I64
         "map_get" => ValueKind::I64
@@ -1022,12 +1022,7 @@ fn needs_heap_expr(ctx : CodegenCtx, expr : @core.Expr) -> Bool {
         name == "double_to_i64_bits" ||
         name == "i64_bits_to_double" ||
         name == "string_to_data" ||
-        name == "map_builder" ||
-        name == "map_builder_set" ||
-        name == "map_builder_freeze" ||
-        name == "MapBuilder::new" ||
-        name == "MapBuilder::set" ||
-        name == "MapBuilder::freeze" ||
+        @core.is_map_builder_builtin_name(name) ||
         name == "string_builder" ||
         name == "string_join" ||
         name == "string_builder_push" ||

--- a/src/core/ast_walker.mbt
+++ b/src/core/ast_walker.mbt
@@ -342,12 +342,7 @@ pub fn is_builtin_name(name : String) -> Bool {
   name == "array_builder" ||
   name == "array_builder_push" ||
   name == "array_builder_freeze" ||
-  name == "map_builder" ||
-  name == "map_builder_set" ||
-  name == "map_builder_freeze" ||
-  name == "MapBuilder::new" ||
-  name == "MapBuilder::set" ||
-  name == "MapBuilder::freeze" ||
+  is_map_builder_builtin_name(name) ||
   name == "bytes_new" ||
   name == "bytes_push" ||
   name == "bytes_set"

--- a/src/core/builtin_aliases.mbt
+++ b/src/core/builtin_aliases.mbt
@@ -1,0 +1,20 @@
+///|
+pub fn normalize_builtin_name(name : String) -> String {
+  if name == "map_builder" {
+    "MapBuilder::new"
+  } else if name == "map_builder_set" {
+    "MapBuilder::set"
+  } else if name == "map_builder_freeze" {
+    "MapBuilder::freeze"
+  } else {
+    name
+  }
+}
+
+///|
+pub fn is_map_builder_builtin_name(name : String) -> Bool {
+  match normalize_builtin_name(name) {
+    "MapBuilder::new" | "MapBuilder::set" | "MapBuilder::freeze" => true
+    _ => false
+  }
+}

--- a/src/core/builtin_aliases_wbtest.mbt
+++ b/src/core/builtin_aliases_wbtest.mbt
@@ -1,0 +1,16 @@
+///|
+test "normalize_builtin_name rewrites legacy map builder aliases" {
+  assert_eq(normalize_builtin_name("map_builder"), "MapBuilder::new")
+  assert_eq(normalize_builtin_name("map_builder_set"), "MapBuilder::set")
+  assert_eq(normalize_builtin_name("map_builder_freeze"), "MapBuilder::freeze")
+  assert_eq(normalize_builtin_name("map_get"), "map_get")
+}
+
+///|
+test "is_map_builder_builtin_name accepts legacy and canonical names" {
+  assert_true(is_map_builder_builtin_name("map_builder"))
+  assert_true(is_map_builder_builtin_name("MapBuilder::new"))
+  assert_true(is_map_builder_builtin_name("map_builder_set"))
+  assert_true(is_map_builder_builtin_name("MapBuilder::set"))
+  assert_false(is_map_builder_builtin_name("map_get"))
+}

--- a/src/runtime/eval.mbt
+++ b/src/runtime/eval.mbt
@@ -1943,7 +1943,8 @@ fn eval_builtin_call(
   args : Array[@core.CallArg],
   call_span : @core.Span,
 ) -> EvalOutput raise EvalError {
-  match name {
+  let builtin_name = @core.normalize_builtin_name(name)
+  match builtin_name {
     "__perform" => {
       let site_key = perform_site_key(rt, call_span)
       match rt.perform_resume_overrides.get(site_key) {
@@ -3632,7 +3633,7 @@ fn eval_builtin_call(
           )
       }
     }
-    "map_builder" | "MapBuilder::new" => {
+    "MapBuilder::new" => {
       let out = eval_args(rt, args)
       let pos_args = extract_positional_values(out.args, "MapBuilder::new")
       if pos_args.length() != 0 {
@@ -3642,7 +3643,7 @@ fn eval_builtin_call(
       }
       { value: @core.Value::MapBuilder({}), effects: out.effects }
     }
-    "map_builder_set" | "MapBuilder::set" => {
+    "MapBuilder::set" => {
       let out = eval_args(rt, args)
       let pos_args = extract_positional_values(out.args, "MapBuilder::set")
       if pos_args.length() != 3 {
@@ -3661,7 +3662,7 @@ fn eval_builtin_call(
           )
       }
     }
-    "map_builder_freeze" | "MapBuilder::freeze" => {
+    "MapBuilder::freeze" => {
       let out = eval_args(rt, args)
       let pos_args = extract_positional_values(out.args, "MapBuilder::freeze")
       if pos_args.length() != 1 {

--- a/src/runtime/runtime_test.mbt
+++ b/src/runtime/runtime_test.mbt
@@ -1631,6 +1631,22 @@ test "vibe map builder freeze snapshot" {
 }
 
 ///|
+test "vibe legacy map builder aliases still work" {
+  let rt = Runtime::new(@capability.CapabilitySet::new())
+  let _ = rt.eval_script(
+    "let m = { let b = map_builder()\nmap_builder_set(b, \"a\", 1)\nmap_builder_freeze(b) }",
+  )
+  match rt.get("m") {
+    Some(@core.Value::Map(xs)) =>
+      match xs.get("a") {
+        Some(@core.Value::Int(v)) => assert_eq(v, 1)
+        _ => fail("legacy map builder value")
+      }
+    _ => fail("missing legacy map builder result")
+  }
+}
+
+///|
 test "vibe pure cache snapshot" {
   let rt = Runtime::new(@capability.CapabilitySet::new())
   let _ = rt.eval_script("let a = path(\"/a\")")


### PR DESCRIPTION
## Summary
- centralize host-side `map_builder* -> MapBuilder::*` alias normalization in `src/core/builtin_aliases.mbt`
- switch checker/runtime/codegen to use the shared alias helpers instead of duplicating map builder alias branches
- add explicit alias coverage for core, checker, runtime, and keep codegen alias coverage

## Testing
- `moon test src/core/builtin_aliases_wbtest.mbt --target native --warn-list '-1-7-24-29'`
- `moon test src/checker/typecheck_call_builtin_wbtest.mbt --target native --filter 'type_call_builtin: legacy map_builder alias resolves as MapBuilder' --warn-list '-1-7-24-29'`
- `moon test src/runtime/runtime_test.mbt --target native --filter 'vibe legacy map builder aliases still work' --warn-list '-1-7-24-29'`
- `moon test src/codegen/wasm_codegen_call_split_wbtest.mbt --target native --filter 'needs_heap_expr returns true for map_builder aliases' --warn-list '-1-7-24-29'`
- `just check`
