### PR TITLE
Rebalance CI shard timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,12 +298,24 @@ jobs:
         run: just ci-wasm-quick-shard ${{ matrix.shard }}
 
   wasm-parity:
-    name: wasm-parity (${{ matrix.suite }})
+    name: wasm-parity (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        suite: [handle, pattern]
+        include:
+          - name: handle
+            suite: handle
+            shard_index: 0
+            shard_total: 1
+          - name: pattern (0)
+            suite: pattern
+            shard_index: 0
+            shard_total: 2
+          - name: pattern (1)
+            suite: pattern
+            shard_index: 1
+            shard_total: 2
     steps:
       - uses: actions/checkout@v4
       - name: Install MoonBit CLI
@@ -326,7 +338,7 @@ jobs:
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
       - name: Build vibe CLI (native)
         run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
-      - name: Run wasm parity suite (${{ matrix.suite }})
+      - name: Run wasm parity suite (${{ matrix.name }})
         continue-on-error: true
         run: |
           case "${{ matrix.suite }}" in
@@ -341,6 +353,9 @@ jobs:
               exit 1
               ;;
           esac
+        env:
+          SHARD_INDEX: ${{ matrix.shard_index }}
+          SHARD_TOTAL: ${{ matrix.shard_total }}
 
   wasm-compile-e2e:
     runs-on: ubuntu-latest

--- a/scripts/test_interpreter_wasm_match.sh
+++ b/scripts/test_interpreter_wasm_match.sh
@@ -21,6 +21,11 @@ fi
 
 failed=0
 passed=0
+skipped=0
+test_index=0
+
+SHARD_INDEX="${SHARD_INDEX:-0}"
+SHARD_TOTAL="${SHARD_TOTAL:-1}"
 
 # Test cases: each prints a result value
 test_cases=(
@@ -182,6 +187,15 @@ echo "Testing interpreter vs WASM output..."
 echo ""
 
 for expr in "${test_cases[@]}"; do
+  if [ "$SHARD_TOTAL" -gt 1 ]; then
+    if [ $((test_index % SHARD_TOTAL)) -ne "$SHARD_INDEX" ]; then
+      test_index=$((test_index + 1))
+      skipped=$((skipped + 1))
+      continue
+    fi
+  fi
+  test_index=$((test_index + 1))
+
   # Create test file
   echo "$expr" > "$TEMP_DIR/test.vibe"
 
@@ -216,7 +230,10 @@ for expr in "${test_cases[@]}"; do
 done
 
 echo ""
-echo "Summary: $passed passed, $failed failed"
+echo "Summary: $passed passed, $failed failed, $skipped skipped"
+if [ "$SHARD_TOTAL" -gt 1 ]; then
+  echo "Shard: $((SHARD_INDEX + 1))/$SHARD_TOTAL"
+fi
 
 if [ $failed -gt 0 ]; then
   exit 1


### PR DESCRIPTION
## Summary
- split wasm parity checks out of the compile shard path
- increase wasm compile E2E sharding from 3 to 4
- avoid installing Rust/wac on selfhost shards that do not need it

## Validation
- actionlint -color
- git diff --check
