### PR TITLE
Implement String for-in iteration over char codes

### DIFF
--- a/src/checker/typecheck_expr_wbtest.mbt
+++ b/src/checker/typecheck_expr_wbtest.mbt
@@ -226,9 +226,9 @@ test "normalize_type cache: expand and preserve enum caches are isolated" {
 }
 
 ///|
-test "type_check: for-in over String yields String elements" {
+test "type_check: for-in over String yields Int char code elements" {
   let script =
-    #|let main = () -> Array[String] {
+    #|let main = () -> Array[Int] {
     #|  let s = "hello"
     #|  for c in s {
     #|    c
@@ -240,7 +240,7 @@ test "type_check: for-in over String yields String elements" {
   }
   let result : Result[TypeEnv, TypeError] = try? type_check(ast)
   match result {
-    Ok(_) => () // type check passes — String for-in accepted
+    Ok(_) => () // type check passes — String for-in yields Int char codes
     Err(err) => fail("unexpected type error: " + err.to_string())
   }
 }

--- a/src/checker/warning.mbt
+++ b/src/checker/warning.mbt
@@ -548,9 +548,15 @@ fn walk_expr(
       }
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       scopes.push(warning_scope_new())
       walk_module(desugared, scopes, out)
       warning_scope_pop(scopes, out)

--- a/src/cmd/vibe/pkg.generated.mbti
+++ b/src/cmd/vibe/pkg.generated.mbti
@@ -56,14 +56,32 @@ pub fn resolve_test_entry_paths(Array[String]) -> Array[String]
 
 pub fn resolve_vibe_lib_dir(String) -> String
 
+pub fn run(Array[String]) -> Unit
+
 pub fn std_layering_violations_for_source(String, String) -> Array[String]
 
 // Errors
 
 // Types and methods
+type BenchBackend
+pub impl Eq for BenchBackend
+pub impl Show for BenchBackend
+
 type BenchCase
 pub impl Eq for BenchCase
 pub impl Show for BenchCase
+
+type BenchSourceCase
+pub impl Eq for BenchSourceCase
+pub impl Show for BenchSourceCase
+
+type BenchSourcePlan
+pub impl Eq for BenchSourcePlan
+pub impl Show for BenchSourcePlan
+
+type BenchWasmRunner
+pub impl Eq for BenchWasmRunner
+pub impl Show for BenchWasmRunner
 
 type BuiltinDecl
 pub impl Eq for BuiltinDecl
@@ -73,9 +91,29 @@ type BuiltinTypeTag
 pub impl Eq for BuiltinTypeTag
 pub impl Show for BuiltinTypeTag
 
+type CliCheckReport
+
 type CliDispatchArgs
 
+type CliEntryDbCache
+
 type CliRuntimeArgs
+
+type CliSessionRequest
+pub impl Eq for CliSessionRequest
+pub impl Show for CliSessionRequest
+
+type CliSessionRequestKind
+pub impl Eq for CliSessionRequestKind
+pub impl Show for CliSessionRequestKind
+
+type CliTestFailure
+pub impl Eq for CliTestFailure
+pub impl Show for CliTestFailure
+
+type CliTestReport
+pub impl Eq for CliTestReport
+pub impl Show for CliTestReport
 
 type ClosurePayloadFsAdapter
 pub impl @io.FileSystemAdapter for ClosurePayloadFsAdapter
@@ -113,9 +151,27 @@ pub enum CompileMode {
 pub impl Eq for CompileMode
 pub impl Show for CompileMode
 
+type CompiledReplExec
+pub impl Eq for CompiledReplExec
+pub impl Show for CompiledReplExec
+
+type CompiledTestAttempt
+
+type CompiledTestCase
+pub impl Eq for CompiledTestCase
+pub impl Show for CompiledTestCase
+
+type CompiledTestCaseExec
+
+type CompletionAnchor
+
 type CompletionContext
 pub impl Eq for CompletionContext
 pub impl Show for CompletionContext
+
+type EvalScopeSymbol
+pub impl Eq for EvalScopeSymbol
+pub impl Show for EvalScopeSymbol
 
 type FinalizeCmdOptions
 pub impl Eq for FinalizeCmdOptions
@@ -131,6 +187,14 @@ type FunctionTrackingSemver
 
 type FunctionTrackingSnapshot
 
+type HttpHostRunner
+pub impl Eq for HttpHostRunner
+pub impl Show for HttpHostRunner
+
+type IndexRefAction
+
+type IndexWalAction
+
 pub enum LineReplIoMode {
   Plain
   Tty
@@ -144,6 +208,8 @@ pub struct LineReplOptions {
 }
 
 type MethodCompletion
+
+type NormalizeCmdOptions
 
 type NormalizeEngine
 
@@ -161,15 +227,87 @@ type NormalizeStmtGroup
 pub impl Eq for NormalizeStmtGroup
 pub impl Show for NormalizeStmtGroup
 
+type OverlayRect
+
 type PipeCompletion
 
+type PrecompileOptions
+pub impl Eq for PrecompileOptions
+pub impl Show for PrecompileOptions
+
 type RedundantBlockSpan
+
+type ReplMetaCommandResult
+pub impl Eq for ReplMetaCommandResult
+pub impl Show for ReplMetaCommandResult
+
+type ReplSymbolMatch
+
+type ReplSymbolsOptions
+pub impl Eq for ReplSymbolsOptions
+pub impl Show for ReplSymbolsOptions
+
+type ReplSymbolsRow
+pub impl Eq for ReplSymbolsRow
+pub impl Show for ReplSymbolsRow
 
 type ReplViewState
 
 type StdModuleLayer
 
+type SymbolsCmdOptions
+pub impl Eq for SymbolsCmdOptions
+pub impl Show for SymbolsCmdOptions
+
+type SymbolsRow
+pub impl Eq for SymbolsRow
+pub impl Show for SymbolsRow
+
+type TestEntryBatchUnit
+
 type TokenSpan
+
+type VibeShellInvocation
+
+type WasmBenchFailure
+pub impl Eq for WasmBenchFailure
+pub impl Show for WasmBenchFailure
+
+type WasmBenchReport
+pub impl Eq for WasmBenchReport
+pub impl Show for WasmBenchReport
+
+type WasmBenchResult
+pub impl Eq for WasmBenchResult
+pub impl Show for WasmBenchResult
+
+type WasmBenchSummaryReport
+pub impl Eq for WasmBenchSummaryReport
+pub impl Show for WasmBenchSummaryReport
+
+type WasmRunValue
+pub impl Eq for WasmRunValue
+pub impl Show for WasmRunValue
+
+type WasmtimeInvokeOutput
+pub impl Eq for WasmtimeInvokeOutput
+pub impl Show for WasmtimeInvokeOutput
+
+type WriteFileCandidate
+pub impl Eq for WriteFileCandidate
+pub impl Show for WriteFileCandidate
+
+type WriteFileCmdOptions
+pub impl Eq for WriteFileCmdOptions
+pub impl Show for WriteFileCmdOptions
+
+type WriteFileDef
+pub impl Eq for WriteFileDef
+pub impl Show for WriteFileDef
+
+type WriteFileSelector
+pub impl Eq for WriteFileSelector
+pub impl Show for WriteFileSelector
 
 // Type aliases
 

--- a/src/cmd/vibe_wasm/pkg.generated.mbti
+++ b/src/cmd/vibe_wasm/pkg.generated.mbti
@@ -2,10 +2,52 @@
 package "mizchi/vibe/cmd/vibe_wasm"
 
 // Values
+pub fn default_output_path(String, RunMode) -> String
+
+pub fn parse_cmd_args(Array[String]) -> Result[CmdOptions, String]
 
 // Errors
 
 // Types and methods
+pub struct CmdOptions {
+  command : CommandKind
+  mode : RunMode
+  entry_path : String
+  out_path : String?
+  keep_artifact : Bool
+  opt_level : String?
+  http_host_imports : Bool
+  invoke : String?
+}
+pub impl Eq for CmdOptions
+pub impl Show for CmdOptions
+
+pub enum CommandKind {
+  Run
+  Compile
+  Compare
+}
+pub impl Eq for CommandKind
+pub impl Show for CommandKind
+
+type ExecCapture
+pub impl Eq for ExecCapture
+pub impl Show for ExecCapture
+
+type FileSnapshot
+pub impl Eq for FileSnapshot
+pub impl Show for FileSnapshot
+
+pub enum RunMode {
+  CoreWasm
+  Component
+}
+pub impl Eq for RunMode
+pub impl Show for RunMode
+
+type WasmtimeRunner
+pub impl Eq for WasmtimeRunner
+pub impl Show for WasmtimeRunner
 
 // Type aliases
 

--- a/src/codegen/address.mbt
+++ b/src/codegen/address.mbt
@@ -206,9 +206,15 @@ fn expr_to_addr_sexp(ctx : AddrCtx, expr : @core.Expr) -> String {
       buf.to_string()
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       "(block " + block_to_addr_sexp(ctx, desugared) + ")"
     }
     @core.Expr::Handle(body~, arms~, span~) => {

--- a/src/codegen/wasm_codegen_ctx.mbt
+++ b/src/codegen/wasm_codegen_ctx.mbt
@@ -719,9 +719,15 @@ fn collect_captures_expr(
       }
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       collect_captures_block(desugared, bound, outer_bound, captures, seen)
     }
     _ => ()
@@ -990,9 +996,15 @@ fn collect_nested_funcs_expr(
       collect_nested_funcs_block(body, bound, funcs, false)
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       collect_nested_funcs_block(desugared, bound, funcs, false)
     }
     _ => ()
@@ -1351,9 +1363,15 @@ fn collect_fn_span_keys_expr(expr : @core.Expr, out : Array[String]) -> Unit {
       }
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       for s in desugared.stmts {
         collect_fn_span_keys_stmt(s, out)
       }
@@ -1475,9 +1493,15 @@ fn precompute_ref_cell_captures_expr(
       precompute_ref_cell_captures_block(ctx, body.stmts, scope_mcv)
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       precompute_ref_cell_captures_block(ctx, desugared.stmts, scope_mcv)
     }
     @core.Expr::StructLit(fields~, ..) =>

--- a/src/codegen/wasm_codegen_expr.mbt
+++ b/src/codegen/wasm_codegen_expr.mbt
@@ -114,9 +114,15 @@ fn compile_expr(
       compile_expr_match(ctx, buf, scrutinee, arms)
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       compile_block_expr(
         ctx,
         buf,

--- a/src/codegen/wasm_codegen_scan.mbt
+++ b/src/codegen/wasm_codegen_scan.mbt
@@ -245,9 +245,15 @@ fn scan_needs_expr(ctx : CodegenCtx, expr : @core.Expr) -> Unit {
       }
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       scan_needs_block(ctx, desugared)
     }
     @core.Expr::Perform(effect_name="Error", op_name="Throw", args~, ..) => {
@@ -582,9 +588,15 @@ fn scan_strings_expr(ctx : CodegenCtx, expr : @core.Expr) -> Unit {
       scan_strings(ctx, body)
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       scan_strings(ctx, desugared)
     }
     _ => ()

--- a/src/codegen/wasm_codegen_sig.mbt
+++ b/src/codegen/wasm_codegen_sig.mbt
@@ -716,9 +716,15 @@ fn infer_expr_kind_with(
       ValueKind::I64
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       infer_block_kind(ctx, desugared, locals)
     }
     @core.Expr::Fn(params~, ret~, effects~, body~, span~, ..) => {
@@ -1247,9 +1253,15 @@ fn needs_heap_expr(ctx : CodegenCtx, expr : @core.Expr) -> Bool {
       false
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       needs_heap_block(ctx, desugared)
     }
     @core.Expr::Handle(body~, arms~, span~) => {
@@ -2097,9 +2109,15 @@ fn expr_always_returns_tuple(
       true
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       body_always_returns_tuple(desugared, arity, self_name, eligible_fns~)
     }
     @core.Expr::Handle(body~, arms~, span=_) => {

--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -1235,6 +1235,27 @@ fn infer_for_in_parts_gc(
 }
 
 ///|
+/// Infer kinds for string for-in: loop variable is I64 (char code).
+fn infer_string_for_in_parts_gc(
+  ctx : GcCodegenCtx,
+  fctx : GcFuncCtx,
+  value_name : String,
+  index_name : String?,
+  body : @core.Module,
+) -> (GcValKind, GcValKind) raise WasmGenError {
+  let elem_kind = GcValKind::I64
+  let saved_locals = clone_locals_gc(fctx.locals)
+  fctx.locals[value_name] = { idx: 0, kind: elem_kind }
+  match index_name {
+    Some(name) => fctx.locals[name] = { idx: 0, kind: GcValKind::I32 }
+    None => ()
+  }
+  let body_kind = infer_block_kind_gc(ctx, fctx, body)
+  restore_locals_gc(fctx, saved_locals)
+  (elem_kind, body_kind)
+}
+
+///|
 fn infer_expr_kind_gc(
   ctx : GcCodegenCtx,
   fctx : GcFuncCtx,
@@ -1401,15 +1422,27 @@ fn infer_expr_kind_gc(
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
       let _ = span
-      let (_, _, body_kind) = infer_for_in_parts_gc(
-        ctx, fctx, value_name, index_name, iterable, body,
-      )
-      let type_idx = ensure_array_type(
-        ctx.types,
-        ctx.array_type_index,
-        body_kind,
-      )
-      GcValKind::Ref(type_idx)
+      if @core.is_string_for_in(span.start) {
+        let (_, body_kind) = infer_string_for_in_parts_gc(
+          ctx, fctx, value_name, index_name, body,
+        )
+        let type_idx = ensure_array_type(
+          ctx.types,
+          ctx.array_type_index,
+          body_kind,
+        )
+        GcValKind::Ref(type_idx)
+      } else {
+        let (_, _, body_kind) = infer_for_in_parts_gc(
+          ctx, fctx, value_name, index_name, iterable, body,
+        )
+        let type_idx = ensure_array_type(
+          ctx.types,
+          ctx.array_type_index,
+          body_kind,
+        )
+        GcValKind::Ref(type_idx)
+      }
     }
     @core.Expr::Tuple(items~, ..) => infer_tuple_kind_gc(ctx, fctx, items)
     @core.Expr::Record(fields~, ..) => infer_record_kind_gc(ctx, fctx, fields)
@@ -2844,64 +2877,142 @@ fn compile_expr_gc(
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
       let _ = span
-      let (iterable_type_idx, iterable_elem_kind, body_kind) = infer_for_in_parts_gc(
-        ctx, fctx, value_name, index_name, iterable, body,
-      )
-      let result_type_idx = ensure_array_type(
-        ctx.types,
-        ctx.array_type_index,
-        body_kind,
-      )
-      let iterable_idx = alloc_local_gc(fctx, GcValKind::Ref(iterable_type_idx))
-      let len_idx = alloc_local_gc(fctx, GcValKind::I32)
-      let result_idx = alloc_local_gc(fctx, GcValKind::Ref(result_type_idx))
-      let i_idx = alloc_local_gc(fctx, GcValKind::I32)
-      compile_expr_gc(ctx, fctx, buf, iterable)
-      emit_local_set_gc(buf, iterable_idx)
-      emit_local_get_gc(buf, iterable_idx)
-      emit_array_len_gc(buf)
-      emit_local_set_gc(buf, len_idx)
-      emit_local_get_gc(buf, len_idx)
-      emit_array_new_default_gc(buf, result_type_idx)
-      emit_local_set_gc(buf, result_idx)
-      emit_i32_const_gc(buf, 0)
-      emit_local_set_gc(buf, i_idx)
-      let saved_locals = clone_locals_gc(fctx.locals)
-      let value_idx = bind_local_gc(fctx, value_name, iterable_elem_kind)
-      let index_idx : Int? = match index_name {
-        Some(name) => Some(bind_local_gc(fctx, name, GcValKind::I32))
-        None => None
-      }
-      emit_block_gc(buf, None)
-      emit_loop_gc(buf, None)
-      emit_local_get_gc(buf, i_idx)
-      emit_local_get_gc(buf, len_idx)
-      emit_i32_ge_s_gc(buf)
-      emit_br_if_gc(buf, 1)
-      emit_local_get_gc(buf, iterable_idx)
-      emit_local_get_gc(buf, i_idx)
-      emit_array_get_gc(buf, iterable_type_idx)
-      emit_local_set_gc(buf, value_idx)
-      match index_idx {
-        Some(idx) => {
-          emit_local_get_gc(buf, i_idx)
-          emit_local_set_gc(buf, idx)
+      if @core.is_string_for_in(span.start) {
+        // String for-in: iterate char codes (I64)
+        let (elem_kind, body_kind) = infer_string_for_in_parts_gc(
+          ctx, fctx, value_name, index_name, body,
+        )
+        let result_type_idx = ensure_array_type(
+          ctx.types,
+          ctx.array_type_index,
+          body_kind,
+        )
+        let str_idx = alloc_local_gc(fctx, GcValKind::Ref(ctx.string_type))
+        let data_idx = alloc_local_gc(fctx, GcValKind::Ref(ctx.array_i32_type))
+        let len_idx = alloc_local_gc(fctx, GcValKind::I32)
+        let result_idx = alloc_local_gc(fctx, GcValKind::Ref(result_type_idx))
+        let i_idx = alloc_local_gc(fctx, GcValKind::I32)
+        // Evaluate string iterable
+        compile_expr_gc(ctx, fctx, buf, iterable)
+        emit_local_set_gc(buf, str_idx)
+        // Get string length
+        emit_local_get_gc(buf, str_idx)
+        emit_struct_get_gc(buf, ctx.string_type, 0) // length field
+        emit_local_set_gc(buf, len_idx)
+        // Get string data array
+        emit_local_get_gc(buf, str_idx)
+        emit_struct_get_gc(buf, ctx.string_type, 1) // data field
+        emit_local_set_gc(buf, data_idx)
+        // Allocate result array
+        emit_local_get_gc(buf, len_idx)
+        emit_array_new_default_gc(buf, result_type_idx)
+        emit_local_set_gc(buf, result_idx)
+        // Initialize counter
+        emit_i32_const_gc(buf, 0)
+        emit_local_set_gc(buf, i_idx)
+        let saved_locals = clone_locals_gc(fctx.locals)
+        let value_idx = bind_local_gc(fctx, value_name, elem_kind)
+        let index_idx : Int? = match index_name {
+          Some(name) => Some(bind_local_gc(fctx, name, GcValKind::I32))
+          None => None
         }
-        None => ()
+        // Loop
+        emit_block_gc(buf, None)
+        emit_loop_gc(buf, None)
+        emit_local_get_gc(buf, i_idx)
+        emit_local_get_gc(buf, len_idx)
+        emit_i32_ge_s_gc(buf)
+        emit_br_if_gc(buf, 1)
+        // Get char code: data[i] as i64
+        emit_local_get_gc(buf, data_idx)
+        emit_local_get_gc(buf, i_idx)
+        emit_array_get_gc(buf, ctx.array_i32_type)
+        emit_i64_extend_i32_s_gc(buf) // char code as I64
+        emit_local_set_gc(buf, value_idx)
+        // Optional index binding
+        match index_idx {
+          Some(idx) => {
+            emit_local_get_gc(buf, i_idx)
+            emit_local_set_gc(buf, idx)
+          }
+          None => ()
+        }
+        // Store body result
+        emit_local_get_gc(buf, result_idx)
+        emit_local_get_gc(buf, i_idx)
+        compile_block_expr_gc(ctx, fctx, buf, body)
+        emit_array_set_gc(buf, result_type_idx)
+        // Increment
+        emit_local_get_gc(buf, i_idx)
+        emit_i32_const_gc(buf, 1)
+        emit_i32_add_gc(buf)
+        emit_local_set_gc(buf, i_idx)
+        emit_br_gc(buf, 0)
+        emit_end_gc(buf)
+        emit_end_gc(buf)
+        restore_locals_gc(fctx, saved_locals)
+        emit_local_get_gc(buf, result_idx)
+      } else {
+        // Array for-in (existing logic)
+        let (iterable_type_idx, iterable_elem_kind, body_kind) = infer_for_in_parts_gc(
+          ctx, fctx, value_name, index_name, iterable, body,
+        )
+        let result_type_idx = ensure_array_type(
+          ctx.types,
+          ctx.array_type_index,
+          body_kind,
+        )
+        let iterable_idx = alloc_local_gc(fctx, GcValKind::Ref(iterable_type_idx))
+        let len_idx = alloc_local_gc(fctx, GcValKind::I32)
+        let result_idx = alloc_local_gc(fctx, GcValKind::Ref(result_type_idx))
+        let i_idx = alloc_local_gc(fctx, GcValKind::I32)
+        compile_expr_gc(ctx, fctx, buf, iterable)
+        emit_local_set_gc(buf, iterable_idx)
+        emit_local_get_gc(buf, iterable_idx)
+        emit_array_len_gc(buf)
+        emit_local_set_gc(buf, len_idx)
+        emit_local_get_gc(buf, len_idx)
+        emit_array_new_default_gc(buf, result_type_idx)
+        emit_local_set_gc(buf, result_idx)
+        emit_i32_const_gc(buf, 0)
+        emit_local_set_gc(buf, i_idx)
+        let saved_locals = clone_locals_gc(fctx.locals)
+        let value_idx = bind_local_gc(fctx, value_name, iterable_elem_kind)
+        let index_idx : Int? = match index_name {
+          Some(name) => Some(bind_local_gc(fctx, name, GcValKind::I32))
+          None => None
+        }
+        emit_block_gc(buf, None)
+        emit_loop_gc(buf, None)
+        emit_local_get_gc(buf, i_idx)
+        emit_local_get_gc(buf, len_idx)
+        emit_i32_ge_s_gc(buf)
+        emit_br_if_gc(buf, 1)
+        emit_local_get_gc(buf, iterable_idx)
+        emit_local_get_gc(buf, i_idx)
+        emit_array_get_gc(buf, iterable_type_idx)
+        emit_local_set_gc(buf, value_idx)
+        match index_idx {
+          Some(idx) => {
+            emit_local_get_gc(buf, i_idx)
+            emit_local_set_gc(buf, idx)
+          }
+          None => ()
+        }
+        emit_local_get_gc(buf, result_idx)
+        emit_local_get_gc(buf, i_idx)
+        compile_block_expr_gc(ctx, fctx, buf, body)
+        emit_array_set_gc(buf, result_type_idx)
+        emit_local_get_gc(buf, i_idx)
+        emit_i32_const_gc(buf, 1)
+        emit_i32_add_gc(buf)
+        emit_local_set_gc(buf, i_idx)
+        emit_br_gc(buf, 0)
+        emit_end_gc(buf)
+        emit_end_gc(buf)
+        restore_locals_gc(fctx, saved_locals)
+        emit_local_get_gc(buf, result_idx)
       }
-      emit_local_get_gc(buf, result_idx)
-      emit_local_get_gc(buf, i_idx)
-      compile_block_expr_gc(ctx, fctx, buf, body)
-      emit_array_set_gc(buf, result_type_idx)
-      emit_local_get_gc(buf, i_idx)
-      emit_i32_const_gc(buf, 1)
-      emit_i32_add_gc(buf)
-      emit_local_set_gc(buf, i_idx)
-      emit_br_gc(buf, 0)
-      emit_end_gc(buf)
-      emit_end_gc(buf)
-      restore_locals_gc(fctx, saved_locals)
-      emit_local_get_gc(buf, result_idx)
     }
     @core.Expr::Fn(params~, ret~, body~, ..) => {
       let param_kinds : Array[GcValKind] = []

--- a/src/core/for_in_desugar.mbt
+++ b/src/core/for_in_desugar.mbt
@@ -1,4 +1,28 @@
 ///|
+/// Global set of ForIn span starts whose iterable is String-typed.
+/// Populated by the frontend rewrite pass (rewrite_string_add),
+/// consumed by codegen backends to dispatch to string for-in desugar.
+let string_for_in_spans : Map[Int, Bool] = {}
+
+///|
+/// Register a ForIn span as iterating over a String.
+pub fn mark_string_for_in(span_start : Int) -> Unit {
+  string_for_in_spans[span_start] = true
+}
+
+///|
+/// Check whether a ForIn span iterates over a String.
+pub fn is_string_for_in(span_start : Int) -> Bool {
+  string_for_in_spans.contains(span_start)
+}
+
+///|
+/// Clear the string for-in registry (call before each compilation unit).
+pub fn clear_string_for_in_spans() -> Unit {
+  string_for_in_spans.clear()
+}
+
+///|
 /// Desugar ForIn AST node into a Block with array builder pattern.
 ///
 /// for x in iterable { body } →
@@ -163,6 +187,7 @@ pub fn desugar_for_in(
 
 ///|
 /// Desugar ForIn over String into a Block with array builder pattern.
+/// The loop variable receives char codes (Int), not substrings.
 ///
 /// for c in str_expr { body } →
 /// {
@@ -171,7 +196,7 @@ pub fn desugar_for_in(
 ///   let __for_b = array_builder()
 ///   let mut __for_i = 0
 ///   while __for_i < __for_len {
-///     let c = String::substring(__for_str, __for_i, __for_i + 1)
+///     let c = String::char_code_at(__for_str, __for_i)
 ///     [let i = __for_i]
 ///     __for_i = __for_i + 1
 ///     <body init stmts>
@@ -234,22 +259,17 @@ pub fn desugar_for_in_string(
   let (init_stmts, collect_expr) = desugar_split_body_last_expr(body, span)
   // Build while body stmts
   let while_stmts : Array[Stmt] = []
-  // let c = String::substring(__for_str, __for_i, __for_i + 1)
+  // let c = String::char_code_at(__for_str, __for_i)
   while_stmts.push(
     Stmt::Let(
       rec=false,
       name=value_name,
       expr=Expr::Call(
-        name="String::substring",
+        name="String::char_code_at",
         type_args=[],
         args=[
           CallArg::{ label: None, expr: str_ident, span: str_span },
           CallArg::{ label: None, expr: i_ident, span: i_span },
-          CallArg::{
-            label: None,
-            expr: desugar_call2("__add", i_ident, one),
-            span: i_span,
-          },
         ],
         span~,
       ),

--- a/src/core/pkg.generated.mbti
+++ b/src/core/pkg.generated.mbti
@@ -8,6 +8,8 @@ pub fn bind_pattern_names_walker(Map[String, Bool], Pat) -> Unit
 
 pub fn canonical_sort_stmts(Array[Stmt]) -> Array[Stmt]
 
+pub fn clear_string_for_in_spans() -> Unit
+
 pub fn clone_bool_map(Map[String, Bool]) -> Map[String, Bool]
 
 pub fn collect_import_hashes(Module) -> Array[String]
@@ -50,6 +52,8 @@ pub fn is_ctor_name(String) -> Bool
 
 pub fn is_logic_builtin_name(String) -> Bool
 
+pub fn is_string_for_in(Int) -> Bool
+
 pub fn is_wasm_gc_ref_type_name(String) -> Bool
 
 pub fn is_wasm_reserved_type_name(String) -> Bool
@@ -57,6 +61,8 @@ pub fn is_wasm_reserved_type_name(String) -> Bool
 pub fn line_info(String, Int) -> (LineCol, Int, Int)
 
 pub fn lower_wasm_intrinsic_name(String) -> String
+
+pub fn mark_string_for_in(Int) -> Unit
 
 pub fn module_ref_from_hash(String) -> String
 

--- a/src/frontend/rewrite_string_add.mbt
+++ b/src/frontend/rewrite_string_add.mbt
@@ -182,7 +182,10 @@ fn rsa_rewrite_expr(expr : @core.Expr, env : @checker.TypeEnv) -> @core.Expr {
         body=rsa_rewrite_module(body, env),
         span~,
       )
-    @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) =>
+    @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
+      if rsa_is_string_valued(iterable, env) {
+        @core.mark_string_for_in(span.start)
+      }
       @core.Expr::ForIn(
         value_name~,
         index_name~,
@@ -190,6 +193,7 @@ fn rsa_rewrite_expr(expr : @core.Expr, env : @checker.TypeEnv) -> @core.Expr {
         body=rsa_rewrite_module(body, env),
         span~,
       )
+    }
     _ => expr
   }
 }

--- a/src/runtime/compile_bundle.mbt
+++ b/src/runtime/compile_bundle.mbt
@@ -1557,9 +1557,15 @@ fn collect_all_assign_targets_expr(
     }
     @core.Expr::Yield(expr~, ..) => collect_all_assign_targets_expr(expr, out)
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       collect_all_assign_targets_block(desugared, out)
     }
     _ => ()

--- a/src/runtime/compile_ir_sexp.mbt
+++ b/src/runtime/compile_ir_sexp.mbt
@@ -388,9 +388,15 @@ fn expr_to_sexp(expr : @core.Expr, aliases : Map[String, @core.Ref]) -> String {
       buf.to_string()
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = @core.desugar_for_in(
-        value_name, index_name, iterable, body, span,
-      )
+      let desugared = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(
+          value_name, index_name, iterable, body, span,
+        )
+      }
       "(block " + block_to_sexp(desugared, aliases) + ")"
     }
     @core.Expr::Tuple(items~, span~) => {

--- a/src/runtime_compile/compile.mbt
+++ b/src/runtime_compile/compile.mbt
@@ -238,6 +238,7 @@ pub fn compile_module(
   let desugared = @frontend.desugar_method_calls(raw_ast, aliases)
   let ast = @frontend.rewrite_effect_handles(desugared)
   let mono = @frontend.monoify_module(ast, env)
+  @core.clear_string_for_in_spans()
   let rewritten = @frontend.rewrite_string_add(mono.ast, env)
   let resolved_ast = db.rewrite_imports_to_hash(path, rewritten)
   let ir = @runtime.module_to_sexp(resolved_ast, aliases)

--- a/src/tests/vibe_wasm_gc_mainlane_e2e_test.mbt
+++ b/src/tests/vibe_wasm_gc_mainlane_e2e_test.mbt
@@ -53,6 +53,24 @@ test "wasm-gc mainlane: for-in runtime" {
 }
 
 ///|
+test "wasm-gc mainlane: string for-in char codes" {
+  if gc_mainlane_should_skip("string for-in char codes") {
+    return
+  }
+  // 'a'=97 + 'b'=98 + 'c'=99 = 294
+  let src =
+    #|let main = () -> Int {
+    #|  let mut sum = 0
+    #|  for c in "abc" {
+    #|    sum = sum + c
+    #|  }
+    #|  sum
+    #|}
+    #|main()
+  assert_gc_e2e_int_result(src, "mainlane_string_for_in_char_codes", 294)
+}
+
+///|
 test "wasm-gc mainlane: string runtime" {
   if gc_mainlane_should_skip("string runtime") {
     return

--- a/src/x/module_graph/pkg.generated.mbti
+++ b/src/x/module_graph/pkg.generated.mbti
@@ -73,15 +73,25 @@ pub fn multilang_type_key(String, String) -> String
 
 pub fn new_graph_ir_row(String, String, String, String, String, Int, Int, String, Array[String], Array[String], Array[String], Array[String]) -> GraphIrRow
 
+pub fn read_advanced_graph_delta_chain_from_git_ref(String, String) -> Result[Array[AdvancedGraphDelta], String]
+
+pub fn read_advanced_graph_delta_from_git_ref(String, String) -> Result[AdvancedGraphDelta, String]
+
 pub fn read_advanced_graph_delta_jsonl(String) -> Result[Array[AdvancedGraphDelta], String]
 
 pub fn read_advanced_graph_index(String) -> Result[AdvancedGraphIndex, String]
+
+pub fn read_advanced_graph_index_from_git_ref(String, String) -> Result[AdvancedGraphIndex, String]
 
 pub fn replay_advanced_graph_delta_jsonl(AdvancedGraphIndex, String) -> Result[AdvancedGraphIndex, String]
 
 pub fn update_advanced_graph_index_incremental(AdvancedGraphIndex, @runtime.VibeDb, Array[String], base_commit? : String, created_at? : String) -> AdvancedGraphIndex
 
+pub fn write_advanced_graph_delta_to_git_ref(String, String, AdvancedGraphDelta) -> Result[String, String]
+
 pub fn write_advanced_graph_index(String, AdvancedGraphIndex) -> Result[Unit, String]
+
+pub fn write_advanced_graph_index_to_git_ref(String, String, AdvancedGraphIndex) -> Result[String, String]
 
 // Errors
 


### PR DESCRIPTION
## Summary

- `for c in "hello" { ... }` now iterates over character codes (Int), not substrings
- Works in all backends: interpreter, linear memory WASM, and wasm-gc
- Loop variable `c` is Int (char code), e.g. `'a'` = 97, `'b'` = 98

## Implementation

- Changed `desugar_for_in_string` to use `String::char_code_at` instead of `String::substring`
- Added global span registry (`mark_string_for_in`/`is_string_for_in`) for frontend-to-codegen type communication
- Frontend `rewrite_string_add` pass marks String-typed ForIn iterables
- All linear memory codegen ForIn handlers dispatch to string desugar when marked
- wasm-gc codegen handles String for-in natively (reads char codes from string data array)

## Test plan

- [x] Checker test updated: `for c in s { c }` now yields `Array[Int]`
- [x] wasm-gc E2E test: `for c in "abc" { sum = sum + c }` verifies sum = 294 (97+98+99)
- [x] Full test suite passes (1279/1287, 8 pre-existing failures unrelated)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)