### PR TITLE
WASM-GC: emit global.set for LetMut and Assign (#79)

### DIFF
--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -7636,6 +7636,14 @@ fn compile_stmt_gc(
       } else {
         emit_local_set_gc(buf, idx)
       }
+      // Store to mutable global if this is a module-level binding
+      match ctx.global_consts.get(name) {
+        Some((gidx, GcValKind::EqRef)) => {
+          emit_local_get_gc(buf, idx)
+          emit_global_set_gc(buf, gidx)
+        }
+        _ => ()
+      }
     }
     @core.Stmt::Assign(name~, expr~, ..) => {
       // Track closure types for let rec desugar (Assign after Let placeholder)
@@ -7658,6 +7666,14 @@ fn compile_stmt_gc(
             emit_local_tee_gc(buf, info.idx)
           } else {
             emit_local_set_gc(buf, info.idx)
+          }
+          // Update global if this is a module-level mutable binding
+          match ctx.global_consts.get(name) {
+            Some((gidx, GcValKind::EqRef)) => {
+              emit_local_get_gc(buf, info.idx)
+              emit_global_set_gc(buf, gidx)
+            }
+            _ => ()
           }
         }
         None => {


### PR DESCRIPTION
## Summary

`LetMut` と `Assign` で module-level mutable global への `global.set` を emit するように修正。

### 問題

`let mut x = 0; let f = () -> Int { x }` のようなケースで、`f` が top-level 関数として抽出された後、`x` の値が global に書き込まれないため、`f` から `x` を参照すると初期値 (null/0) が返る。

### 修正

- `Stmt::LetMut`: `global_consts` に EqRef エントリがあれば `global.set` を emit
- `Stmt::Assign`: 同上

Fixes #79

https://claude.ai/code/session_01FBKXNyRwuLRG7ubhF5BrYd