### PR TITLE
Fix docs: remove Never type, correct Map[K,V] arity (#67)

### DIFF
--- a/docs/language-tour/syntax-reference.md
+++ b/docs/language-tour/syntax-reference.md
@@ -285,8 +285,8 @@ Int, Float, Double, Bool, Char, String, Unit
 i32, f32, f64
 
 // Collections
-Array[T], Map[V]
-ArrayBuilder[T], MapBuilder[V]
+Array[T], Map[K, V]
+ArrayBuilder[T], MapBuilder[K, V]
 
 // Generic
 Option[T], Result[T]

--- a/docs/vibe.md
+++ b/docs/vibe.md
@@ -989,7 +989,7 @@ Current hashing behavior for statements:
 ### Type forms
 
 ```sexp
-Int | Float | Double | Bool | String | @core.Path | Unit | Never
+Int | Float | Double | Bool | String | @core.Path | Unit
 (Named "Option" <type> ...)
 (Param "T")
 (Var 1)


### PR DESCRIPTION
## Summary

docs の型表記を実装に合わせて修正。

- `Never` を primitive type リストから削除（parser/checker で未実装）
- `Map[V]` → `Map[K, V]`、`MapBuilder[V]` → `MapBuilder[K, V]` に修正

Fixes #67

https://claude.ai/code/session_01FBKXNyRwuLRG7ubhF5BrYd