### PR TITLE
[codex] Add stable CI required aggregate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,3 +627,45 @@ jobs:
             _build/coverage/selfhost-suite/selfhost_suite.summary.txt
             _build/coverage/selfhost-suite/selfhost_suite.report.json
           if-no-files-found: ignore
+
+  ci-required:
+    if: ${{ github.event_name == 'pull_request' && always() }}
+    needs:
+      - lint-ci
+      - contract-moon
+      - contract-native
+      - wasm-vibe-smoke
+      - e2e-component
+      - selfhost-examples
+      - coverage-selfhost-suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required CI job results
+        env:
+          LINT_CI_RESULT: ${{ needs.lint-ci.result }}
+          CONTRACT_MOON_RESULT: ${{ needs.contract-moon.result }}
+          CONTRACT_NATIVE_RESULT: ${{ needs.contract-native.result }}
+          WASM_VIBE_SMOKE_RESULT: ${{ needs.wasm-vibe-smoke.result }}
+          E2E_COMPONENT_RESULT: ${{ needs.e2e-component.result }}
+          SELFHOST_EXAMPLES_RESULT: ${{ needs.selfhost-examples.result }}
+          COVERAGE_SELFHOST_SUITE_RESULT: ${{ needs.coverage-selfhost-suite.result }}
+        run: |
+          failures=0
+          for check in \
+            "lint-ci:$LINT_CI_RESULT" \
+            "contract-moon:$CONTRACT_MOON_RESULT" \
+            "contract-native:$CONTRACT_NATIVE_RESULT" \
+            "wasm-vibe-smoke:$WASM_VIBE_SMOKE_RESULT" \
+            "e2e-component:$E2E_COMPONENT_RESULT" \
+            "selfhost-examples:$SELFHOST_EXAMPLES_RESULT" \
+            "coverage-selfhost-suite:$COVERAGE_SELFHOST_SUITE_RESULT"
+          do
+            name="${check%%:*}"
+            result="${check#*:}"
+            echo "$name => $result"
+            if [ "$result" != "success" ]; then
+              echo "::error::$name finished with $result"
+              failures=1
+            fi
+          done
+          exit "$failures"


### PR DESCRIPTION
## Summary
- add a stable `ci-required` aggregate job for pull requests
- make the aggregate job collect the result of the current blocking PR jobs with `always()`
- keep push-only and intentionally non-blocking jobs out of the required set for now

## Why
- `main` currently has no branch protection or ruleset, so required checks are not defined anywhere
- matrix job names and conditional jobs are a poor direct fit for GitHub required status checks
- `ci-required` gives `#120` a stable job name that can later be enforced in a ruleset

## Included in `ci-required`
- `lint-ci`
- `contract-moon`
- `contract-native`
- `wasm-vibe-smoke`
- `e2e-component`
- `selfhost-examples`
- `coverage-selfhost-suite`

## Not included yet
- `wasm-parity`
- `wasm-compile-e2e`
- push-only jobs such as `bundle-size-*`, `native-binary-parity`, `selfhost-gates`, `wasm-codegen-quick`

Those still need a separate decision because of matrix naming and current `continue-on-error` semantics.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml-ok"'`
- `git diff --check`
- `actionlint`

## Related
- #120
- #33
