### PR TITLE
[codex] Stabilize contract-moon CI suite

### DIFF
--- a/justfile
+++ b/justfile
@@ -102,7 +102,7 @@ ci-contract-moon:
     scripts/check_lock_clean_test.sh
     moon check --deny-warn --warn-list '{{moon_warn_list}}' --target js
     bash scripts/test_codegen_contract.sh
-    moon test --target js --warn-list '{{moon_warn_list}}'
+    VIBE_MOON_WARN_LIST='{{moon_warn_list}}' bash scripts/test_contract_moon.sh
 
 # PR-oriented native/runtime contract checks
 ci-contract-native:

--- a/scripts/test_contract_moon.sh
+++ b/scripts/test_contract_moon.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+warn_list="${VIBE_MOON_WARN_LIST:--1-6-7-9-20-24-29}"
+contract_js_packages=(
+  src/core
+  src/frontend
+  src/runtime_compile
+)
+
+for pkg_dir in "${contract_js_packages[@]}"; do
+  NODE_OPTIONS=--max-old-space-size=8192 moon test --target js --warn-list "$warn_list" "$pkg_dir"
+done
+
+moon build src/cmd/warning_fixture/main.mbt --target js --warn-list "$warn_list"
+moon build src/cmd/typecheck_fixture/main.mbt --target native --warn-list "$warn_list"
+moon build src/cmd/parser_contract/main.mbt --target native --warn-list "$warn_list"
+
+warning_fixture_js="_build/js/debug/build/cmd/warning_fixture/warning_fixture.js"
+typecheck_fixture_native="_build/native/debug/build/cmd/typecheck_fixture/typecheck_fixture.exe"
+parser_contract_native="_build/native/debug/build/cmd/parser_contract/parser_contract.exe"
+
+typecheck_contract_files=(
+  fixtures/typecheck/duplicate_enum_ctor.vibe
+  fixtures/typecheck/duplicate_value_decl.vibe
+  fixtures/typecheck/if_condition_non_bool.vibe
+  fixtures/typecheck/let_annotation_type_mismatch.vibe
+  fixtures/typecheck/missing_label_call_argument.vibe
+  fixtures/typecheck/non_exhaustive_match.vibe
+  fixtures/typecheck/ok_add.vibe
+  fixtures/typecheck/parse_int_min_literal_boundary.vibe
+  fixtures/typecheck/parse_loop_expr.vibe
+  fixtures/typecheck/property_access_ambiguous_function_vs_field.vibe
+  fixtures/typecheck/type_mismatch_argument.vibe
+  fixtures/typecheck/while_condition_non_bool.vibe
+)
+
+NODE_OPTIONS=--max-old-space-size=4096 node "$warning_fixture_js"
+"$parser_contract_native"
+for f in "${typecheck_contract_files[@]}"; do
+  "$typecheck_fixture_native" --file "$f"
+done

--- a/src/checker/typecheck_fixture.mbt
+++ b/src/checker/typecheck_fixture.mbt
@@ -100,13 +100,59 @@ fn collect_typecheck_fixture_entries(
 }
 
 ///|
-pub fn verify_typecheck_fixtures(
-  fixture_dir : String,
-) -> Result[Array[TypecheckFixtureMismatch], String] {
-  let entries = match collect_typecheck_fixture_entries(fixture_dir) {
-    Ok(v) => v
-    Err(err) => return Err(err)
+fn collect_typecheck_fixture_entries_from_paths(
+  paths : Array[String],
+) -> Result[Array[TypecheckFixtureEntry], String] {
+  if paths.length() == 0 {
+    return Err("no typecheck fixture paths provided")
   }
+  let files = paths.copy()
+  sort_strings_typecheck_fixture(files)
+  let out : Array[TypecheckFixtureEntry] = []
+  for source_path in files {
+    if !source_path.has_suffix(".vibe") {
+      return Err("[\{source_path}] fixture path must end with .vibe")
+    }
+    let is_file = @os_fs.is_file(source_path) catch {
+      e => return Err("[\{source_path}] stat failed: \{e.to_string()}")
+    }
+    if !is_file {
+      return Err("[\{source_path}] fixture file not found")
+    }
+    out.push({ source_path, diag_path: diag_path_for_fixture(source_path) })
+  }
+  Ok(out)
+}
+
+///|
+fn slice_typecheck_fixture_entries(
+  entries : Array[TypecheckFixtureEntry],
+  offset : Int,
+  limit : Int?,
+) -> Array[TypecheckFixtureEntry] {
+  let start = if offset < 0 { 0 } else { offset }
+  if start >= entries.length() {
+    return []
+  }
+  let end = match limit {
+    Some(n) => {
+      let requested = if n < 0 { 0 } else { n }
+      let next = start + requested
+      if next > entries.length() { entries.length() } else { next }
+    }
+    None => entries.length()
+  }
+  let out : Array[TypecheckFixtureEntry] = []
+  for i in start..<end {
+    out.push(entries[i])
+  }
+  out
+}
+
+///|
+fn verify_typecheck_fixture_entries(
+  entries : Array[TypecheckFixtureEntry],
+) -> Result[Array[TypecheckFixtureMismatch], String] {
   let mismatches : Array[TypecheckFixtureMismatch] = []
   for entry in entries {
     let source = @os_fs.read_file_to_string(entry.source_path) catch {
@@ -135,6 +181,43 @@ pub fn verify_typecheck_fixtures(
     }
   }
   Ok(mismatches)
+}
+
+///|
+pub fn verify_typecheck_fixtures(
+  fixture_dir : String,
+) -> Result[Array[TypecheckFixtureMismatch], String] {
+  let entries = match collect_typecheck_fixture_entries(fixture_dir) {
+    Ok(v) => v
+    Err(err) => return Err(err)
+  }
+  verify_typecheck_fixture_entries(entries)
+}
+
+///|
+pub fn verify_typecheck_fixtures_range(
+  fixture_dir : String,
+  offset : Int,
+  limit : Int?,
+) -> Result[Array[TypecheckFixtureMismatch], String] {
+  let entries = match collect_typecheck_fixture_entries(fixture_dir) {
+    Ok(v) => v
+    Err(err) => return Err(err)
+  }
+  verify_typecheck_fixture_entries(
+    slice_typecheck_fixture_entries(entries, offset, limit),
+  )
+}
+
+///|
+pub fn verify_typecheck_fixture_paths(
+  paths : Array[String],
+) -> Result[Array[TypecheckFixtureMismatch], String] {
+  let entries = match collect_typecheck_fixture_entries_from_paths(paths) {
+    Ok(v) => v
+    Err(err) => return Err(err)
+  }
+  verify_typecheck_fixture_entries(entries)
 }
 
 ///|

--- a/src/cmd/parser_contract/main.mbt
+++ b/src/cmd/parser_contract/main.mbt
@@ -1,0 +1,273 @@
+///|
+fn[A] fail_contract(label : String, msg : String) -> A {
+  abort("parser-contract [" + label + "]: " + msg)
+}
+
+///|
+fn assert_contract(label : String, cond : Bool, msg : String) -> Unit {
+  if !cond {
+    fail_contract(label, msg)
+  }
+}
+
+///|
+fn parse_or_fail(label : String, input : String) -> @core.Module {
+  let parsed = (try? @parser.parse_ast(input))
+  match parsed {
+    Ok(module_) => module_
+    Err(err) => fail_contract(label, "parse failed: " + err.to_string())
+  }
+}
+
+///|
+fn format_roundtrip(
+  label : String,
+  input : String,
+  extra_check : (String, @core.Module, @core.Module) -> Unit,
+) -> Unit {
+  let before = parse_or_fail(label + "/before", input)
+  let formatted = @parser.format_script(input)
+  let after = parse_or_fail(label + "/after", formatted)
+  if @core.normalize_module(after) != @core.normalize_module(before) {
+    fail_contract(label, "normalized AST changed after format roundtrip")
+  }
+  extra_check(formatted, before, after)
+}
+
+///|
+fn assert_eq_string(label : String, actual : String, expected : String) -> Unit {
+  if actual != expected {
+    fail_contract(label, "expected `" + expected + "`, got `" + actual + "`")
+  }
+}
+
+///|
+fn assert_eq_int(label : String, actual : Int, expected : Int) -> Unit {
+  if actual != expected {
+    fail_contract(
+      label,
+      "expected " + expected.to_string() + ", got " + actual.to_string(),
+    )
+  }
+}
+
+///|
+fn assert_eq_syntax_kind(
+  label : String,
+  actual : @cst.SyntaxKind,
+  expected : @cst.SyntaxKind,
+) -> Unit {
+  if actual != expected {
+    fail_contract(label, "unexpected syntax kind")
+  }
+}
+
+///|
+fn check_format_trait_impl_import() -> Unit {
+  let input =
+    #|import ./mod.vibe { type Option, trait Eq, eq }
+    #|trait Eq
+    #|impl Eq for Int
+    #|test "quoted case" {
+    #|  let msg = "hello world"
+    #|  let escaped = "\"ok\""
+    #|  let ch = 'z'
+    #|  assert_true(msg == "hello world")
+    #|}
+  format_roundtrip("format-trait-impl-import", input, fn(formatted, _, _) {
+    assert_contract(
+      "format-trait-impl-import",
+      formatted.contains("trait Eq"),
+      "missing `trait Eq` in formatted output",
+    )
+    assert_contract(
+      "format-trait-impl-import",
+      formatted.contains("impl Eq for Int"),
+      "missing `impl Eq for Int` in formatted output",
+    )
+    assert_contract(
+      "format-trait-impl-import",
+      !formatted.contains("traitEq"),
+      "found joined `traitEq` token",
+    )
+  })
+}
+
+///|
+fn check_format_import_export_models() -> Unit {
+  let import_input =
+    #|import ./math { add, mul as m }
+    #|let x = m(2, 3)
+    #|x
+  format_roundtrip("format-import-list", import_input, fn(formatted, _, _) {
+    assert_contract(
+      "format-import-list",
+      formatted.contains("import ./math"),
+      "formatted import script lost canonical source form",
+    )
+  })
+  let export_input =
+    #|export ./math { add, mul as m }
+    #|export { add, m }
+  format_roundtrip("format-export-list", export_input, fn(formatted, _, _) {
+    assert_contract(
+      "format-export-list",
+      formatted.contains("export ./math"),
+      "formatted export script lost canonical source form",
+    )
+  })
+}
+
+///|
+fn check_syntax_kind_lexer_contract() -> Unit {
+  assert_contract(
+    "syntax-kind",
+    @parser.yield_kw() != @parser.plus_eq(),
+    "yield_kw and plus_eq must differ",
+  )
+  let yield_tokens = @parser.tokenize("yield +=")
+  assert_eq_syntax_kind("yield-token", yield_tokens[0].kind(), @parser.yield_kw())
+  assert_eq_syntax_kind("plus-eq-token", yield_tokens[2].kind(), @parser.plus_eq())
+
+  let map_lit_tokens = @parser.tokenize("map { a: 1 }")
+  assert_eq_syntax_kind("map-literal", map_lit_tokens[0].kind(), @parser.map_kw())
+  let map_call_tokens = @parser.tokenize("map(1)")
+  assert_eq_syntax_kind("map-call", map_call_tokens[0].kind(), @parser.name())
+
+  let raw_ident_tokens = @parser.tokenize("let r#bench = 1\nr#bench")
+  assert_eq_syntax_kind("raw-ident-kind", raw_ident_tokens[2].kind(), @parser.name())
+  assert_eq_string("raw-ident-text", raw_ident_tokens[2].text(), "bench")
+
+  let ns_tokens = @parser.tokenize("std/string::from_char_code(1)")
+  assert_eq_syntax_kind("namespace-head", ns_tokens[0].kind(), @parser.name())
+  assert_eq_syntax_kind("namespace-sep", ns_tokens[1].kind(), @parser.slash())
+  assert_eq_syntax_kind(
+    "namespace-member",
+    ns_tokens[3].kind(),
+    @parser.double_colon(),
+  )
+}
+
+///|
+fn check_parse_for_in() -> Unit {
+  let ast = parse_or_fail("for-in", "for i, x in [10, 20, 30] { i + x }")
+  match ast.stmts[0] {
+    @core.Stmt::Expr(expr=@core.Expr::ForIn(value_name~, index_name~, ..), ..) => {
+      assert_eq_string("for-in-value", value_name, "x")
+      if index_name != Some("i") {
+        fail_contract("for-in-index", "expected index binding `i`")
+      }
+    }
+    _ => fail_contract("for-in", "expected ForIn expression with index")
+  }
+}
+
+///|
+fn check_parse_method_call_sugar() -> Unit {
+  let parsed = try? @parser.parse_ast("obj.method(1)")
+  match parsed {
+    Ok(module_) =>
+      match module_.stmts[0] {
+        @core.Stmt::Expr(expr~, ..) =>
+          match expr {
+            @core.Expr::Call(name="method", args~, ..) =>
+              assert_eq_int("ufcs-arg-count", args.length(), 2)
+            _ => fail_contract("ufcs", "expected desugared method call")
+          }
+        _ => fail_contract("ufcs", "expected expr stmt")
+      }
+    Err(err) => fail_contract("ufcs", err.to_string())
+  }
+
+  let bad_mix = try? @parser.parse_ast("1 + 1 |> double")
+  match bad_mix {
+    Ok(_) => fail_contract("pipe-mix", "expected ambiguous infix+pipe to fail")
+    Err(err) =>
+      assert_contract(
+        "pipe-mix",
+        err.to_string().contains("parenthes"),
+        "missing parenthesize guidance",
+      )
+  }
+}
+
+///|
+fn check_parse_slice_and_raw_string() -> Unit {
+  let module_ = parse_or_fail("slice-range", "let x = s[1:3]")
+  match module_.stmts[0] {
+    @core.Stmt::Let(
+      name="x",
+      expr=@core.Expr::Call(name="__slice", args~, ..),
+      ..
+    ) => assert_eq_int("slice-range-args", args.length(), 3)
+    _ => fail_contract("slice-range", "expected __slice call")
+  }
+
+  let full_slice = parse_or_fail("slice-full", "let x = s[:]")
+  match full_slice.stmts[0] {
+    @core.Stmt::Let(name="x", expr=@core.Expr::Block(body~, ..), ..) =>
+      match body.stmts[1] {
+        @core.Stmt::Expr(expr=@core.Expr::Call(name="__slice", args~, ..), ..) =>
+          match args[2].expr {
+            @core.Expr::Call(name="__len", ..) => ()
+            _ => fail_contract("slice-full", "expected __len end bound")
+          }
+        _ => fail_contract("slice-full", "expected __slice expr")
+      }
+    _ => fail_contract("slice-full", "expected block expr")
+  }
+
+  let raw_string = @parser.Lexer::new("r\"hello\\nworld\"").next_token()
+  assert_eq_syntax_kind("raw-string-kind", raw_string.kind(), @parser.string_lit())
+  assert_eq_string("raw-string-text", raw_string.text(), "hello\\nworld")
+}
+
+///|
+fn check_import_alias_and_pinned_path() -> Unit {
+  let alias_decl = parse_or_fail("alias-decl", "import ../types @types")
+  match alias_decl.stmts[0] {
+    @core.Stmt::AliasDecl(alias_name~, source~, ..) => {
+      assert_eq_string("alias-decl-name", alias_name, "types")
+      match source {
+        @core.ModuleRef::Path(path~) => assert_eq_string("alias-decl-path", path, "../types")
+        _ => fail_contract("alias-decl", "expected path source")
+      }
+    }
+    _ => fail_contract("alias-decl", "expected AliasDecl")
+  }
+
+  let pinned_import = parse_or_fail(
+    "pinned-import",
+    "import ./types#abc123 { Expr }",
+  )
+  match pinned_import.stmts[0] {
+    @core.Stmt::Import(source~, spec~, ..) => {
+      match source {
+        @core.ModuleRef::PinnedPath(path~, hash~) => {
+          assert_eq_string("pinned-import-path", path, "./types")
+          assert_eq_string("pinned-import-hash", hash, "abc123")
+        }
+        _ => fail_contract("pinned-import", "expected pinned path source")
+      }
+      assert_eq_string("pinned-import-item", spec.items[0].name, "Expr")
+    }
+    _ => fail_contract("pinned-import", "expected Import stmt")
+  }
+}
+
+fn run_case(label : String, f : () -> Unit) -> Unit {
+  println("parser contract case: " + label)
+  f()
+}
+
+///|
+fn main {
+  run_case("format-trait-impl-import", check_format_trait_impl_import)
+  run_case("format-import-export-models", check_format_import_export_models)
+  run_case("syntax-kind-lexer", check_syntax_kind_lexer_contract)
+  run_case("for-in", check_parse_for_in)
+  run_case("method-call-sugar", check_parse_method_call_sugar)
+  run_case("slice-and-raw-string", check_parse_slice_and_raw_string)
+  run_case("import-alias-pinned-path", check_import_alias_and_pinned_path)
+  println("parser contract: ok")
+}

--- a/src/cmd/parser_contract/moon.pkg
+++ b/src/cmd/parser_contract/moon.pkg
@@ -1,0 +1,10 @@
+import {
+  "mizchi/cst" @cst,
+  "mizchi/vibe/core" @core,
+  "mizchi/vibe/parser" @parser,
+}
+
+options(
+  "is-main": true,
+  targets: { "main.mbt": [ "native", "js" ] },
+)

--- a/src/cmd/typecheck_fixture/main.mbt
+++ b/src/cmd/typecheck_fixture/main.mbt
@@ -1,10 +1,15 @@
 ///|
 fn usage() -> Unit {
-  println("typecheck-fixture [--update] [--dir <path>]")
+  println(
+    "typecheck-fixture [--update] [--dir <path>] [--offset <n>] [--limit <n>] [--file <path> ...]",
+  )
   println(
     "  --update      rewrite fixtures/*.diag from current typecheck output",
   )
   println("  --dir <path>  fixture directory (default: fixtures/typecheck)")
+  println("  --offset <n>  start index in sorted fixture list")
+  println("  --limit <n>   max number of fixtures to verify")
+  println("  --file <path> verify specific fixture file(s)")
 }
 
 ///|
@@ -15,15 +20,49 @@ fn collect_cli_args() -> Array[String] {
     if i == 0 {
       continue
     }
+    if i == 1 && arg.has_suffix(".js") {
+      continue
+    }
     out.push(arg)
   }
   out
 }
 
 ///|
-fn parse_args(args : Array[String]) -> Result[(Bool, String), String] {
+fn parse_decimal_int_arg(raw : String) -> Result[Int, String] {
+  if raw.length() == 0 {
+    return Err("empty integer")
+  }
+  let chars = raw.to_array()
+  let mut sign = 1
+  let mut start = 0
+  if chars[0] == '-' {
+    sign = -1
+    start = 1
+  }
+  if start >= chars.length() {
+    return Err("empty integer")
+  }
+  let mut value = 0
+  for i in start..<chars.length() {
+    let ch = chars[i]
+    if ch < '0' || ch > '9' {
+      return Err("invalid integer: " + raw)
+    }
+    value = value * 10 + (ch.to_int() - '0'.to_int())
+  }
+  Ok(value * sign)
+}
+
+///|
+fn parse_args(
+  args : Array[String],
+) -> Result[(Bool, String, Int, Int?, Array[String]), String] {
   let mut update = false
   let mut fixture_dir = "fixtures/typecheck"
+  let mut offset = 0
+  let mut limit : Int? = None
+  let files : Array[String] = []
   let mut i = 0
   while i < args.length() {
     let arg = args[i]
@@ -36,6 +75,34 @@ fn parse_args(args : Array[String]) -> Result[(Bool, String), String] {
         }
         fixture_dir = args[i]
       }
+      "--offset" => {
+        i += 1
+        if i >= args.length() {
+          return Err("missing number after --offset")
+        }
+        offset = match parse_decimal_int_arg(args[i]) {
+          Ok(v) => v
+          Err(_) => return Err("invalid --offset: " + args[i])
+        }
+      }
+      "--limit" => {
+        i += 1
+        if i >= args.length() {
+          return Err("missing number after --limit")
+        }
+        let parsed = match parse_decimal_int_arg(args[i]) {
+          Ok(v) => v
+          Err(_) => return Err("invalid --limit: " + args[i])
+        }
+        limit = Some(parsed)
+      }
+      "--file" => {
+        i += 1
+        if i >= args.length() {
+          return Err("missing path after --file")
+        }
+        files.push(args[i])
+      }
       "--help" | "-h" => {
         usage()
         return Err("")
@@ -44,7 +111,7 @@ fn parse_args(args : Array[String]) -> Result[(Bool, String), String] {
     }
     i += 1
   }
-  Ok((update, fixture_dir))
+  Ok((update, fixture_dir, offset, limit, files))
 }
 
 ///|
@@ -61,7 +128,7 @@ fn print_mismatch(mismatch : @checker.TypecheckFixtureMismatch) -> Unit {
 ///|
 fn main {
   let args = collect_cli_args()
-  let (update, fixture_dir) = match parse_args(args) {
+  let (update, fixture_dir, offset, limit, files) = match parse_args(args) {
     Ok(v) => v
     Err(err) =>
       if err.length() == 0 {
@@ -69,6 +136,9 @@ fn main {
       } else {
         abort("typecheck-fixture: " + err)
       }
+  }
+  if update && files.length() > 0 {
+    abort("typecheck-fixture: --update does not support --file")
   }
   if update {
     match @checker.update_typecheck_fixtures(fixture_dir) {
@@ -83,10 +153,21 @@ fn main {
     }
     return
   }
-  match @checker.verify_typecheck_fixtures(fixture_dir) {
+  let verify_result = if files.length() > 0 {
+    @checker.verify_typecheck_fixture_paths(files)
+  } else {
+    @checker.verify_typecheck_fixtures_range(fixture_dir, offset, limit)
+  }
+  match verify_result {
     Ok(mismatches) => {
       if mismatches.length() == 0 {
-        println("typecheck fixtures: ok (\{fixture_dir})")
+        if files.length() > 0 {
+          println(
+            "typecheck fixtures: ok (" + files.length().to_string() + " file(s))",
+          )
+        } else {
+          println("typecheck fixtures: ok (\{fixture_dir})")
+        }
         return
       }
       for mismatch in mismatches {

--- a/src/cmd/warning_fixture/main.mbt
+++ b/src/cmd/warning_fixture/main.mbt
@@ -13,6 +13,9 @@ fn collect_cli_args() -> Array[String] {
     if i == 0 {
       continue
     }
+    if i == 1 && arg.has_suffix(".js") {
+      continue
+    }
     out.push(arg)
   }
   out


### PR DESCRIPTION
## Summary
- replace the monolithic js contract sweep with `scripts/test_contract_moon.sh`
- cover parser regressions via a lightweight parser contract command instead of `src/parser` package js tests
- run representative typecheck fixtures via native `--file` selection to avoid js OOM

## Verification
- `bash scripts/test_contract_moon.sh`
- `just ci-contract-moon`