### PR TITLE
[codex] Install just in playground deploy workflow

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -43,6 +43,9 @@ jobs:
           cache: pnpm
           cache-dependency-path: playground/pnpm-lock.yaml
 
+      - name: Install just
+        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
       - name: Install Playground deps
         run: |
           cd playground


### PR DESCRIPTION
## Summary
- install `just` before running `just playground-build` in the Pages deploy workflow
- keep the change scoped to the existing deployment job only

## Verification
- actionlint .github/workflows/playground.yml
