### PR TITLE
[codex] Init wasmtime submodule explicitly in selfhost gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,8 +425,8 @@ jobs:
         shard: [bootstrap, cli, check]
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - name: Init wasmtime submodule
+        run: git submodule update --init deps/wasmtime
       - name: Install MoonBit CLI
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash


### PR DESCRIPTION
## Summary
- stop recursively checking out nested submodules in the push-only selfhost gates
- initialize only `deps/wasmtime`, which is the actual dependency these gates need

## Verification
- actionlint .github/workflows/ci.yml
- just test-selfhost-check-command-component
- just test-selfhost-cli-command-component
