### PR TITLE
[codex] Stabilize CI just install and http shard setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,14 @@ jobs:
           restore-keys: moonbit-${{ runner.os }}-
 
       - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
 
       - name: Moon update
         run: moon update
@@ -69,7 +76,14 @@ jobs:
           sudo apt-get install -y ripgrep
 
       - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
 
       - name: Cache MoonBit build
         uses: actions/cache@v4
@@ -115,7 +129,14 @@ jobs:
           sudo apt-get install -y ripgrep
 
       - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
 
       - name: Cache MoonBit build
         uses: actions/cache@v4
@@ -267,6 +288,9 @@ jobs:
         shard: [core, compare, http]
     steps:
       - uses: actions/checkout@v4
+      - name: Init wasmtime submodule
+        if: matrix.shard == 'http'
+        run: git submodule update --init deps/wasmtime
       - name: Install MoonBit CLI
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
@@ -295,7 +319,14 @@ jobs:
           key: cargo-wasm-quick-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml', 'scripts/build_wasi_http_p3*.sh') }}
           restore-keys: cargo-wasm-quick-${{ runner.os }}-
       - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
       - name: Cache MoonBit build
         uses: actions/cache@v4
         with:
@@ -480,7 +511,14 @@ jobs:
             cargo install wac-cli --version 0.9.0 --locked
           fi
       - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
       - name: Build vibe CLI (native)
         run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
       - name: Run selfhost gate shard (${{ matrix.shard }})
@@ -547,7 +585,14 @@ jobs:
         run: moon update
 
       - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
 
       - name: Install wasmtime
         run: |
@@ -589,7 +634,14 @@ jobs:
           node-version: '24'
 
       - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
 
       - name: Install wasmtime
         run: |

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -44,7 +44,14 @@ jobs:
           cache-dependency-path: playground/pnpm-lock.yaml
 
       - name: Install just
-        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+          just --version
 
       - name: Install Playground deps
         run: |


### PR DESCRIPTION
## Summary
- replace the flaky Using cached Yoorkin/ArgParser@0.2.0
Using cached Yoorkin/trie@0.2.6
Using cached moonbitlang/ulex-runtime@0.4.1
Using cached moonbitlang/parser@0.1.15
Using cached moonbitlang/async@0.16.6
Using cached moonbitlang/yacc@0.7.7
Using cached moonbitlang/x@0.4.40
Using cached mizchi/tui@0.6.0
Using cached mizchi/wit@0.2.4
Using cached mizchi/llm@0.2.2
Using cached mizchi/similarity@0.2.1
Using cached mizchi/signals@0.6.1
Using cached mizchi/zlib@0.3.0
Using cached mizchi/x@0.1.5
Using cached mizchi/mwac@0.1.6
Using cached mizchi/ripple@0.1.3
Using cached mizchi/tempfile@0.1.0
Using cached mizchi/bitflow@0.3.1
Using cached mizchi/bit@0.21.2
Using cached mizchi/flatbuffers@0.1.3
Using cached mizchi/oci_wasm@0.3.0
Using cached mizchi/cst@0.1.4
Using cached mizchi/crater@0.4.1
Using cached mizchi/syntree@0.2.0
Using cached mizchi/wite@0.6.5
Using cached mizchi/cbor@0.1.1
lock-check: scanned 26 index.lock files
lock-check: vibe module metadata synchronized
lock-check self-test: ok
=== REPARSED ===
{stmts: [Let(rec=false, name="$0", expr=Int(value=999, span={start: 0, end: 0}), span={start: 0, end: 0})]}
=== EXPECTED ===
{stmts: [Let(rec=false, name="$0", expr=Int(value=1, span={start: 0, end: 0}), span={start: 0, end: 0})]}
=== FORMATTED ===
let x: Int = 999

=== END ===
short: cold_total_us=178628 hot_total_us=13027 hot_ratio_pct=7 cold_module_us=69048 hot_module_us=136 cold_bundle_us=29855 hot_bundle_us=12885 cold_emit_us=79572 hot_emit_us=0
medium: cold_total_us=4291 hot_total_us=776 hot_ratio_pct=18 cold_module_us=2023 hot_module_us=57 cold_bundle_us=937 hot_bundle_us=717 cold_emit_us=1311 hot_emit_us=0
RC binary size analysis:
  int_literal: rc=96 no_rc=75 ratio=1.28
  tuple_alloc: rc=354 no_rc=172 ratio=2.058139534883721
  func_call: rc=114 no_rc=93 ratio=1.2258064516129032
  tuple_access: rc=377 no_rc=191 ratio=1.9738219895287958
  multi_alloc: rc=580 no_rc=491 ratio=1.1812627291242364
  TOTAL: rc=1521 no_rc=1022 ratio=1.4882583170254402
Section breakdown (tuple_alloc):
  type: rc=16 no_rc=7 diff=+9
  func: rc=6 no_rc=4 diff=+2
  global: rc=8 no_rc=0 diff=+8
  export: rc=34 no_rc=21 diff=+13
  code: rc=256 no_rc=106 diff=+150
Total tests: 1004, passed: 1004, failed: 0.
typecheck fixtures: ok (fixtures/typecheck/duplicate_enum_ctor.vibe)
typecheck fixtures: ok (fixtures/typecheck/duplicate_value_decl.vibe)
typecheck fixtures: ok (fixtures/typecheck/effect_explicit_scope_violation.vibe)
typecheck fixtures: ok (fixtures/typecheck/effect_guard_missing_do_boundary_only.vibe)
typecheck fixtures: ok (fixtures/typecheck/effect_guard_missing_effect_and_do_boundary.vibe)
typecheck fixtures: ok (fixtures/typecheck/effect_handler_incomplete.vibe)
typecheck fixtures: ok (fixtures/typecheck/effect_perform_wrong_arg_type.vibe)
typecheck fixtures: ok (fixtures/typecheck/effect_undeclared_op.vibe)
typecheck fixtures: ok (fixtures/typecheck/effect_unknown_op.vibe)
typecheck fixtures: ok (fixtures/typecheck/effect_wrong_effect_name.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_concrete_effect_mismatch.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_matrix_fail_missing_effect_at_caller.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_matrix_fail_missing_wrapper_effect.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_matrix_fail_trait_and_effect_mixed.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_matrix_ok_passthrough_pure.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_matrix_ok_trait_and_effect_bound.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_matrix_ok_with_e_try_catch_localized.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_missing_caller_effect.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_trait_bound_violation.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_try_catch_localizes_error.vibe)
typecheck fixtures: ok (fixtures/typecheck/generic_effect_wrapper_requires_effect_decl.vibe)
typecheck fixtures: ok (fixtures/typecheck/if_condition_non_bool.vibe)
typecheck fixtures: ok (fixtures/typecheck/import_extra_comma.vibe)
typecheck fixtures: ok (fixtures/typecheck/import_malformed_separator.vibe)
typecheck fixtures: ok (fixtures/typecheck/import_missing_from_keyword.vibe)
typecheck fixtures: ok (fixtures/typecheck/let_annotation_type_mismatch.vibe)
typecheck fixtures: ok (fixtures/typecheck/missing_label_call_argument.vibe)
typecheck fixtures: ok (fixtures/typecheck/non_exhaustive_match.vibe)
typecheck fixtures: ok (fixtures/typecheck/ok_add.vibe)
typecheck fixtures: ok (fixtures/typecheck/parse_enum_mutable_payload_unsupported.vibe)
typecheck fixtures: ok (fixtures/typecheck/parse_import_trailing_comma.vibe)
typecheck fixtures: ok (fixtures/typecheck/parse_int_min_literal_boundary.vibe)
typecheck fixtures: ok (fixtures/typecheck/parse_let_annotation_colon.vibe)
typecheck fixtures: ok (fixtures/typecheck/parse_loop_expr.vibe)
typecheck fixtures: ok (fixtures/typecheck/polymorphic_recursion_unsupported.vibe)
typecheck fixtures: ok (fixtures/typecheck/property_access_ambiguous_function_vs_field.vibe)
typecheck fixtures: ok (fixtures/typecheck/scoped_ref_param_decl_forbidden.vibe)
typecheck fixtures: ok (fixtures/typecheck/scoped_ref_param_nested_decl_forbidden.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_brace_ctor_arity_mismatch.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_brace_payload_type_mismatch.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_brace_raise_ok.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_brace_zero_payload_raise_ok.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_duplicate_ctor.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_generic_error_bound_raise_ok.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_generic_try_catch_ok.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_mixed_error_types_raise_ok.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_raise_ctor_arity_mismatch.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_raise_non_error_type.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_raise_payload_type_mismatch.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_raise_string_ok.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_raise_unknown_ctor.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_raise_without_error_effect.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_try_catch_localizes_error_ok.vibe)
typecheck fixtures: ok (fixtures/typecheck/suberror_tuple_raise_ok.vibe)
typecheck fixtures: ok (fixtures/typecheck/type_mismatch_argument.vibe)
typecheck fixtures: ok (fixtures/typecheck/while_condition_non_bool.vibe)
warning fixtures: ok (fixtures/warnings/if_else_chain.vibe)
warning fixtures: ok (fixtures/warnings/if_else_chain_short.vibe)
warning fixtures: ok (fixtures/warnings/ignored_unused_prefixed.vibe)
warning fixtures: ok (fixtures/warnings/mutable_assigned.vibe)
warning fixtures: ok (fixtures/warnings/unnecessary_mutable.vibe)
warning fixtures: ok (fixtures/warnings/unreachable_match_arm.vibe)
warning fixtures: ok (fixtures/warnings/unused_import.vibe)
warning fixtures: ok (fixtures/warnings/unused_let.vibe)
warning fixtures: ok (fixtures/warnings/unused_let_mut.vibe)
warning fixtures: ok (fixtures/warnings/used_import.vibe)
Total tests: 11, passed: 11, failed: 0.
saved: /tmp/cmd_vibe_wbtest_save_fetch_expand_1774926689000/main.vibe -> a95fc1a0 (2 module(s))
updated lock refs: /tmp/cmd_vibe_wbtest_save_fetch_expand_1774926689000/index.lock (2 path refs)
{
  "main_hash": "a95fc1a0a7340e61816e382da291a7529265824b",
  "order": [
    "91a63a0c7c30d0e8c080bc2893ecc61888ef5388",
    "a95fc1a0a7340e61816e382da291a7529265824b"
  ],
  "modules": {
    "a95fc1a0a7340e61816e382da291a7529265824b": {"stmts":[{"Import":{"source":{"Hash":"91a63a0c7c30d0e8c080bc2893ecc61888ef5388"},"spec":[{"kind":"value","name":"inc","rename":null}]}},{"ExportLet":{"expr":{"Call":{"args":[{"expr":{"Int":1},"label":null}],"name":"inc"}},"name":"$0","rec":false}}]},
    "91a63a0c7c30d0e8c080bc2893ecc61888ef5388": {"stmts":[{"ExportLet":{"expr":{"Fn":{"body":{"stmts":[{"Expr":{"Call":{"args":[{"expr":{"Ident":"$0"},"label":null},{"expr":{"Int":1},"label":null}],"name":"__add"}}}]},"effects":[],"params":[{"label":"Positional","name":"$0","ty":{"Named":{"args":[],"name":"Int"}},"bounds":[]}],"ret":{"Named":{"args":[],"name":"Int"}},"type_bounds":{},"type_params":[]}},"name":"$0","rec":false}}]}
  }
}
index build: wrote /tmp/cmd_vibe_wbtest_index_build_cache_1774926690000/advanced-graph-index.json (1 defs), graph_head=f9fd215
[check_debug] resolving: /tmp/cmd_vibe_wbtest_check_resolve_artifacts_1774926690000/main.vibe
[check_debug] resolved: /tmp/cmd_vibe_wbtest_check_resolve_artifacts_1774926690000/main.vibe
[check_debug] starting db.types: /tmp/cmd_vibe_wbtest_check_resolve_artifacts_1774926690000/main.vibe
[check_debug] finished db.types: /tmp/cmd_vibe_wbtest_check_resolve_artifacts_1774926690000/main.vibe
/tmp/cmd_vibe_wbtest_check_resolve_artifacts_1774926690000/main.vibe: ok (graph_head=65910d9)
applied: /tmp/cmd_vibe_wbtest_apply_resolve_artifacts_1774926690000/main.vibe lock=/tmp/cmd_vibe_wbtest_apply_resolve_artifacts_1774926690000/index.lock path_refs=1 graph_head=55dd408 defs=1 cache=/tmp/cmd_vibe_wbtest_apply_resolve_artifacts_1774926690000/.vibe/cache.json
applied: /tmp/cmd_vibe_wbtest_apply_track_fn_version_1774926690000/main.vibe lock=/tmp/cmd_vibe_wbtest_apply_track_fn_version_1774926690000/index.lock path_refs=1 graph_head=bbeb1be defs=1 cache=/tmp/cmd_vibe_wbtest_apply_track_fn_version_1774926690000/.vibe/cache.json
applied: /tmp/cmd_vibe_wbtest_apply_track_fn_version_1774926690000/main.vibe lock=/tmp/cmd_vibe_wbtest_apply_track_fn_version_1774926690000/index.lock path_refs=1 graph_head=ef1ab8c defs=1 cache=/tmp/cmd_vibe_wbtest_apply_track_fn_version_1774926690000/.vibe/cache.json
applied: /tmp/cmd_vibe_wbtest_apply_track_fn_rename_1774926690000/main.vibe lock=/tmp/cmd_vibe_wbtest_apply_track_fn_rename_1774926690000/index.lock path_refs=1 graph_head=b30b6b5 defs=1 cache=/tmp/cmd_vibe_wbtest_apply_track_fn_rename_1774926690000/.vibe/cache.json
applied: /tmp/cmd_vibe_wbtest_apply_track_fn_rename_1774926690000/main.vibe lock=/tmp/cmd_vibe_wbtest_apply_track_fn_rename_1774926690000/index.lock path_refs=1 graph_head=36ef917 defs=1 cache=/tmp/cmd_vibe_wbtest_apply_track_fn_rename_1774926690000/.vibe/cache.json
history reset: namespace=scratch db=/tmp/cmd_vibe_wbtest_history_reset_scratch_1774926690000/scratch.db removed=true hard=false
[{"status":"managed","origin":"index","kind":"function","name":"inc","path":"/tmp/cmd_vibe_wbtest_symbols_status_1774926690000/lib.vibe","hash":"1a2de80ddc2abde233b9c819f4c52256647fa1ac","short_hash":"1a2de80","signature":"(x: Int) -> Int","module_hash":"91a63a0c7c30d0e8c080bc2893ecc61888ef5388"},{"status":"managed","origin":"index","kind":"value","name":"main","path":"/tmp/cmd_vibe_wbtest_symbols_status_1774926690000/main.vibe","hash":"d8444338cb54e6082f88f3621d7e5635db726984","short_hash":"d844433","signature":"Int","module_hash":"7a49fe3dc6b69613dc4ebb29e12cef8bcd64ed38"}]
applied: /tmp/cmd_vibe_wbtest_symbols_shadowed_1774926690000/main.vibe lock=/tmp/cmd_vibe_wbtest_symbols_shadowed_1774926690000/index.lock path_refs=1 graph_head=3a4d624 defs=1 cache=/tmp/cmd_vibe_wbtest_symbols_shadowed_1774926690000/.vibe/cache.json
applied: /tmp/cmd_vibe_wbtest_write_file_selector_name_scratch_1774926690000/main.vibe lock=/tmp/cmd_vibe_wbtest_write_file_selector_name_scratch_1774926690000/index.lock path_refs=1 graph_head=fc4a24f defs=1 cache=/tmp/cmd_vibe_wbtest_write_file_selector_name_scratch_1774926690000/.vibe/cache.json
write_file: scratch:foo	/tmp/cmd_vibe_wbtest_write_file_selector_name_scratch_1774926690000/scratch.db#247a840 -> /tmp/cmd_vibe_wbtest_write_file_selector_name_scratch_1774926690000/foo.vibe no_deps=false
write_file: index:value	/tmp/cmd_vibe_wbtest_write_file_selector_hash_1774926690000/main.vibe#136adac -> /tmp/cmd_vibe_wbtest_write_file_selector_hash_1774926690000/value.vibe no_deps=false
write_file: index:value	/tmp/cmd_vibe_wbtest_write_file_no_deps_1774926690000/main.vibe#7bbf012 -> /tmp/cmd_vibe_wbtest_write_file_no_deps_1774926690000/value-nodeps.vibe no_deps=true
write_file(dry-run): index:value	/tmp/cmd_vibe_wbtest_write_file_dry_run_1774926690000/main.vibe#2e80e98 -> /tmp/cmd_vibe_wbtest_write_file_dry_run_1774926690000/value-dry-run.vibe no_deps=false
{"status":"ok","dry_run":true,"origin":"index","kind":"value","name":"value","path":"/tmp/cmd_vibe_wbtest_write_file_dry_run_1774926690000/main.vibe","hash":"2e80e988aa46d4538958a3ad555eeaf7639b79fd","short_hash":"2e80e98","signature":"Int","module_hash":"1cae1213f26db197713557dc7d0695cd36ef0897","out_path":"/tmp/cmd_vibe_wbtest_write_file_dry_run_1774926690000/value-dry-run.vibe","no_deps":false}
finalize: applied mode=library db=/tmp/cmd_vibe_wbtest_finalize_library_mode_1774926690000/tmp1.db stmts=6->3
finalize: applied mode=safe db=/tmp/cmd_vibe_wbtest_finalize_safe_mode_1774926690000/tmp1.db stmts=5->4
exported: /tmp/cmd_vibe_wbtest_finalize_export_apply_1774926690000/main.vibe
finalize: applied mode=library db=/tmp/cmd_vibe_wbtest_finalize_export_apply_1774926690000/tmp1.db stmts=4->3
updated lock refs: /tmp/cmd_vibe_wbtest_finalize_export_apply_1774926690000/index.lock (1 path refs)
applied: /tmp/cmd_vibe_wbtest_finalize_export_apply_1774926690000/main.vibe lock=/tmp/cmd_vibe_wbtest_finalize_export_apply_1774926690000/index.lock path_refs=1 graph_head=5c447ce defs=2 cache=/tmp/cmd_vibe_wbtest_finalize_export_apply_1774926690000/.vibe/cache.json
finalize: applied mode=library db=/tmp/cmd_vibe_wbtest_finalize_library_mode_reexport_1774926691000/tmp1.db stmts=3->1
Total tests: 72, passed: 72, failed: 0.
Total tests: 17, passed: 17, failed: 0.
Total tests: 5, passed: 5, failed: 0.
parallel cleanup e2e: ok
internal parent watchdog e2e: ok install script with a pinned release download in CI and playground workflows
- initialize  for the  shard before running the P3 adapter checks

## Verification
- yaml-ok
- 
- 

## Expected CI impact
- fixes  failures caused by the  tag resolution flake
- fixes  missing 
- keeps playground deploy off the same flaky installer path