### PR TITLE
Fix selfhost checker pattern Option tests

### DIFF
--- a/vibe/compiler/checker_pattern_test.vibe
+++ b/vibe/compiler/checker_pattern_test.vibe
@@ -24,6 +24,12 @@ let no_args = () -> Array[Type] {
   ], 0, 0)
 }
 
+let empty_pats = () -> Array[Pat] {
+  Array::slice([
+    PWild
+  ], 0, 0)
+}
+
 let empty_defs = () -> Array[TypeDef] {
   Array::slice([
     TDAlias("_dummy", CtUnit)
@@ -197,17 +203,20 @@ test "PCtor Some on CtOption extracts element type" {
 }
 
 test "PCtor None on CtOption binds nothing" {
-  let pat = PCtor("None", [])
+  let pat = PCtor("None", empty_pats())
   let env = check_pattern(pat, CtOption(CtString), EnvEmpty, empty_defs())
   // None has no sub-patterns, env stays empty
-  assert(env_lookup(env, "val") == None)
+  match env_lookup(env, "val") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
 }
 
 test "match CtOption Some arm resolves element" {
   let env = env_bind(EnvEmpty, "x", CtOption(CtInt))
   let expr = EMatch(EIdent("x"), [
     (PCtor("Some", [PBind("n")]), EIdent("n")),
-    (PCtor("None", []), EInt(0))
+    (PCtor("None", empty_pats()), EInt(0))
   ])
   let ty = check(expr, env)
   assert(types_equal(ty, CtInt))


### PR DESCRIPTION
## Summary
- add a shared empty pattern helper for CtOption constructor tests
- avoid relying on bare [] inference in None pattern cases
- rewrite the empty-env assertion to a match form that survives selfhost bootstrap

## Verification
- env VIBE_TEST_BACKEND=compiled target/native/release/build/cmd/vibe/vibe.exe test vibe/compiler/checker_pattern_test.vibe
- just test-selfhost-bootstrap (now gets past checker_pattern_test and later fails in cli_cache_test due an existing Node runtime issue)