### PR TITLE
[codex] Fix block-scoped mutable capture ref cells

### DIFF
--- a/scripts/test_wasm_compile_wasmtime.sh
+++ b/scripts/test_wasm_compile_wasmtime.sh
@@ -251,6 +251,11 @@ write_test_source() {
   } > "$TMP_DIR/test.vibe"
 }
 
+write_program_source() {
+  local vibe_code="$1"
+  printf "%s\n" "$vibe_code" > "$TMP_DIR/test.vibe"
+}
+
 # Helper: compile .vibe to .wasm, run with wasmtime, compare untagged result
 expect_wasmtime_result() {
   # Shard: skip tests not assigned to this shard
@@ -268,6 +273,44 @@ expect_wasmtime_result() {
   local expected_value="$3"
 
   write_test_source "$vibe_code"
+
+  if ! $VIBE compile --wasm "$TMP_DIR/test.vibe" -o "$TMP_DIR/test.wasm" 2>/dev/null; then
+    log_fail "$test_name - compilation failed"
+    return
+  fi
+
+  local wasm_tagged
+  wasm_tagged=$("$WASMTIME_RUN" --invoke _start "$TMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning") || true
+
+  if [ -z "$wasm_tagged" ]; then
+    log_fail "$test_name - wasmtime returned no output"
+    return
+  fi
+
+  local result=$((wasm_tagged >> 2))
+
+  if [ "$result" = "$expected_value" ]; then
+    log_pass "$test_name (result: $expected_value)"
+  else
+    log_fail "$test_name - expected $expected_value but got $result (tagged: $wasm_tagged)"
+  fi
+}
+
+expect_wasmtime_program_result() {
+  if [ "$SHARD_TOTAL" -gt 1 ]; then
+    if [ $((TEST_INDEX % SHARD_TOTAL)) -ne "$SHARD_INDEX" ]; then
+      TEST_INDEX=$((TEST_INDEX + 1))
+      SKIPPED=$((SKIPPED + 1))
+      return
+    fi
+  fi
+  TEST_INDEX=$((TEST_INDEX + 1))
+
+  local test_name="$1"
+  local vibe_code="$2"
+  local expected_value="$3"
+
+  write_program_source "$vibe_code"
 
   if ! $VIBE compile --wasm "$TMP_DIR/test.vibe" -o "$TMP_DIR/test.wasm" 2>/dev/null; then
     log_fail "$test_name - compilation failed"
@@ -1356,6 +1399,25 @@ add(20)
 add(30)
 sum' \
 "60"
+
+expect_wasmtime_result "mutable capture: nested block expression" \
+'let result = {
+  let mut total = 0
+  let f = () -> Int { total = total + 1; total }
+  f()
+  f()
+}
+result' \
+"2"
+
+expect_wasmtime_program_result "mutable capture: top-level block" \
+'{
+  let mut total = 0
+  let f = () -> Int { total = total + 1; total }
+  f()
+  f()
+}' \
+"2"
 
 echo ""
 

--- a/src/codegen/wasm_codegen_ctx.mbt
+++ b/src/codegen/wasm_codegen_ctx.mbt
@@ -1255,6 +1255,35 @@ fn compute_mut_captured_for_block(
 }
 
 ///|
+fn scoped_mut_captured_for_block(
+  parent_mcv : Map[String, Bool],
+  stmts : Array[@core.Stmt],
+  fn_closure_captures : Map[String, Array[String]],
+) -> Map[String, Bool] {
+  let scoped = parent_mcv.copy()
+  for stmt in stmts {
+    match stmt {
+      @core.Stmt::LetMut(name~, ..)
+      | @core.Stmt::Let(name~, ..)
+      | @core.Stmt::ExportLet(name~, ..) => scoped.remove(name)
+      @core.Stmt::LetPat(pat~, ..) | @core.Stmt::LetPatElse(pat~, ..) => {
+        let bindings : Array[String] = []
+        collect_pat_bindings_codegen(pat, bindings)
+        for b in bindings {
+          scoped.remove(b)
+        }
+      }
+      _ => ()
+    }
+  }
+  let local_mcv = compute_mut_captured_for_block(stmts, fn_closure_captures)
+  for name, _ in local_mcv {
+    scoped[name] = true
+  }
+  scoped
+}
+
+///|
 fn collect_fn_span_keys_stmt(stmt : @core.Stmt, out : Array[String]) -> Unit {
   match stmt {
     @core.Stmt::Let(expr=@core.Expr::Fn(params~, span~, ..), ..)
@@ -1406,7 +1435,12 @@ fn precompute_ref_cell_captures_block(
         precompute_ref_cell_captures_expr(ctx, expr, scope_mcv)
       @core.Stmt::LetPatElse(expr~, else_body~, ..) => {
         precompute_ref_cell_captures_expr(ctx, expr, scope_mcv)
-        precompute_ref_cell_captures_block(ctx, else_body.stmts, scope_mcv)
+        let else_mcv = scoped_mut_captured_for_block(
+          scope_mcv,
+          else_body.stmts,
+          ctx.fn_closure_captures,
+        )
+        precompute_ref_cell_captures_block(ctx, else_body.stmts, else_mcv)
       }
       @core.Stmt::IndexAssign(target~, index~, value~, ..) => {
         precompute_ref_cell_captures_expr(ctx, target, scope_mcv)
@@ -1451,11 +1485,27 @@ fn precompute_ref_cell_captures_expr(
       }
     @core.Expr::If(cond~, then_body~, else_body~, ..) => {
       precompute_ref_cell_captures_expr(ctx, cond, scope_mcv)
-      precompute_ref_cell_captures_block(ctx, then_body.stmts, scope_mcv)
-      precompute_ref_cell_captures_block(ctx, else_body.stmts, scope_mcv)
+      let then_mcv = scoped_mut_captured_for_block(
+        scope_mcv,
+        then_body.stmts,
+        ctx.fn_closure_captures,
+      )
+      let else_mcv = scoped_mut_captured_for_block(
+        scope_mcv,
+        else_body.stmts,
+        ctx.fn_closure_captures,
+      )
+      precompute_ref_cell_captures_block(ctx, then_body.stmts, then_mcv)
+      precompute_ref_cell_captures_block(ctx, else_body.stmts, else_mcv)
     }
-    @core.Expr::Block(body~, ..) =>
-      precompute_ref_cell_captures_block(ctx, body.stmts, scope_mcv)
+    @core.Expr::Block(body~, ..) => {
+      let body_mcv = scoped_mut_captured_for_block(
+        scope_mcv,
+        body.stmts,
+        ctx.fn_closure_captures,
+      )
+      precompute_ref_cell_captures_block(ctx, body.stmts, body_mcv)
+    }
     @core.Expr::Match(scrutinee~, arms~, ..) => {
       precompute_ref_cell_captures_expr(ctx, scrutinee, scope_mcv)
       for arm in arms {
@@ -1467,7 +1517,12 @@ fn precompute_ref_cell_captures_expr(
       }
     }
     @core.Expr::Handle(body~, arms~, ..) => {
-      precompute_ref_cell_captures_block(ctx, body.stmts, scope_mcv)
+      let body_mcv = scoped_mut_captured_for_block(
+        scope_mcv,
+        body.stmts,
+        ctx.fn_closure_captures,
+      )
+      precompute_ref_cell_captures_block(ctx, body.stmts, body_mcv)
       for arm in arms {
         precompute_ref_cell_captures_expr(ctx, arm.expr, scope_mcv)
         match arm.cond {
@@ -1478,13 +1533,23 @@ fn precompute_ref_cell_captures_expr(
     }
     @core.Expr::While(cond~, body~, ..) => {
       precompute_ref_cell_captures_expr(ctx, cond, scope_mcv)
-      precompute_ref_cell_captures_block(ctx, body.stmts, scope_mcv)
+      let body_mcv = scoped_mut_captured_for_block(
+        scope_mcv,
+        body.stmts,
+        ctx.fn_closure_captures,
+      )
+      precompute_ref_cell_captures_block(ctx, body.stmts, body_mcv)
     }
     @core.Expr::Loop(params~, body~, ..) => {
       for p in params {
         precompute_ref_cell_captures_expr(ctx, p.init, scope_mcv)
       }
-      precompute_ref_cell_captures_block(ctx, body.stmts, scope_mcv)
+      let body_mcv = scoped_mut_captured_for_block(
+        scope_mcv,
+        body.stmts,
+        ctx.fn_closure_captures,
+      )
+      precompute_ref_cell_captures_block(ctx, body.stmts, body_mcv)
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
       let desugared = if @core.is_string_for_in(span.start) {
@@ -1494,7 +1559,12 @@ fn precompute_ref_cell_captures_expr(
       } else {
         @core.desugar_for_in(value_name, index_name, iterable, body, span)
       }
-      precompute_ref_cell_captures_block(ctx, desugared.stmts, scope_mcv)
+      let body_mcv = scoped_mut_captured_for_block(
+        scope_mcv,
+        desugared.stmts,
+        ctx.fn_closure_captures,
+      )
+      precompute_ref_cell_captures_block(ctx, desugared.stmts, body_mcv)
     }
     @core.Expr::StructLit(fields~, ..) =>
       for f in fields {

--- a/src/codegen/wasm_codegen_expr_loop.mbt
+++ b/src/codegen/wasm_codegen_expr_loop.mbt
@@ -9,6 +9,12 @@ fn compile_expr_while(
   let saved_break = ctx.loop_break_offset
   let saved_continue = ctx.loop_continue_offset
   let saved_param_locals = ctx.loop_param_locals
+  let saved_mut_captured = ctx.mut_captured_vars.copy()
+  ctx.mut_captured_vars = scoped_mut_captured_for_block(
+    saved_mut_captured,
+    body.stmts,
+    ctx.fn_closure_captures,
+  )
 
   // while は break 値を返せるため block result を i64 にする。
   emit_block_i64(buf) // block $exit (label 1)
@@ -59,6 +65,7 @@ fn compile_expr_while(
   ctx.loop_break_offset = saved_break
   ctx.loop_continue_offset = saved_continue
   ctx.loop_param_locals = saved_param_locals
+  ctx.mut_captured_vars = saved_mut_captured
 }
 
 ///|
@@ -126,6 +133,7 @@ fn compile_expr_loop(
   let saved_param_locals = ctx.loop_param_locals
   let saved_locals = ctx.locals.copy()
   let saved_kinds = ctx.local_kinds.copy()
+  let saved_mut_captured = ctx.mut_captured_vars.copy()
 
   // Allocate locals for loop params and compile init expressions
   let param_locals : Array[Int] = []
@@ -144,6 +152,11 @@ fn compile_expr_loop(
     param_locals.push(idx)
   }
   ctx.loop_param_locals = param_locals
+  ctx.mut_captured_vars = scoped_mut_captured_for_block(
+    saved_mut_captured,
+    body.stmts,
+    ctx.fn_closure_captures,
+  )
 
   // block $exit (result i64)  -- break value lands here
   //   loop $continue          -- continue jumps here
@@ -177,6 +190,7 @@ fn compile_expr_loop(
   ctx.loop_break_offset = saved_break
   ctx.loop_continue_offset = saved_continue
   ctx.loop_param_locals = saved_param_locals
+  ctx.mut_captured_vars = saved_mut_captured
   restore_locals(ctx, saved_locals)
   restore_local_kinds(ctx, saved_kinds)
 }

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -3566,7 +3566,7 @@ fn emit_module_with_coverage(
   }
   // Pre-compute ref cell capture flags for ALL functions before compile loop.
   // This is needed because compile_function runs before compile_expr_fn.
-  precompute_ref_cell_captures_block(ctx, ast.stmts, top_mut_captured)
+  precompute_ref_cell_captures_block(ctx, run_ast.stmts, top_mut_captured)
   @profiler.profiler_enter("codegen/compile_functions")
   let compiled_funcs : Array[WasmFunc] = []
   for i in 0..<funcs.length() {

--- a/src/codegen/wasm_codegen_stmt.mbt
+++ b/src/codegen/wasm_codegen_stmt.mbt
@@ -1059,7 +1059,13 @@ fn compile_block_expr(
 ) -> Unit raise WasmGenError {
   let saved = ctx.locals.copy()
   let saved_kinds = ctx.local_kinds.copy()
+  let saved_mut_captured = ctx.mut_captured_vars.copy()
   let saved_prefix = ctx.rc_action_prefix
+  ctx.mut_captured_vars = scoped_mut_captured_for_block(
+    saved_mut_captured,
+    body.stmts,
+    ctx.fn_closure_captures,
+  )
   if emit_rc_stmt_actions && rc_prefix.length() > 0 {
     ctx.rc_action_prefix = rc_prefix
   }
@@ -1079,6 +1085,7 @@ fn compile_block_expr(
     }
   }
   ctx.rc_action_prefix = saved_prefix
+  ctx.mut_captured_vars = saved_mut_captured
   restore_locals(ctx, saved)
   restore_local_kinds(ctx, saved_kinds)
 }
@@ -1092,6 +1099,12 @@ fn compile_block_multivalue(
 ) -> Unit raise WasmGenError {
   let saved = ctx.locals.copy()
   let saved_kinds = ctx.local_kinds.copy()
+  let saved_mut_captured = ctx.mut_captured_vars.copy()
+  ctx.mut_captured_vars = scoped_mut_captured_for_block(
+    saved_mut_captured,
+    body.stmts,
+    ctx.fn_closure_captures,
+  )
   let len = body.stmts.length()
   if len == 0 {
     for kind in kinds {
@@ -1116,6 +1129,7 @@ fn compile_block_multivalue(
       // Should not happen — body_always_returns_tuple verified this
     }
   }
+  ctx.mut_captured_vars = saved_mut_captured
   restore_locals(ctx, saved)
   restore_local_kinds(ctx, saved_kinds)
 }


### PR DESCRIPTION
## Summary
- fix block-scoped mutable capture handling in wasm codegen so closures inside block scopes use ref cells consistently
- keep top-level run-function ref-cell precompute aligned with `run_ast.stmts`
- add wasm compile/wasmtime regressions for nested block expressions and raw top-level block programs

## Root cause
Closures created inside `Expr::Block` were analyzed against the parent scope without first deriving the block's own mutable-capture set. As a result, `let mut` bindings declared inside a block were not marked as ref-cell captures, so repeated closure calls in that block observed stale values. The top-level `_start` path also had a precompute mismatch by scanning `ast.stmts` instead of the synthesized `run_ast.stmts`.

## Impact
- top-level block programs now preserve mutable closure state correctly
- nested block expressions inside functions now preserve mutable closure state correctly
- the wasm compile/wasmtime parity suite covers both cases to prevent regressions

## Validation
- `moon fmt`
- `moon check src/codegen --target native`
- `./scripts/test_wasm_compile_wasmtime.sh` (`Passed=304 Failed=0`)
- direct wasm repro for top-level block mutable capture
- direct wasm repro for nested block mutable capture

Fixes #162