### PR TITLE
ci: pin MoonBit version in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   VIBE_MOON_WARN_LIST: "-1-6-7-9-20-24-29"
+  VIBE_CI_MOON_VERSION: "0.1.20260309"
 
 jobs:
   lint-ci:
@@ -27,7 +28,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Install ripgrep
@@ -68,7 +69,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
       - name: Install ripgrep
         run: |
@@ -121,7 +122,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
       - name: Install ripgrep
         run: |
@@ -169,7 +170,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Install wasmtime
@@ -202,7 +203,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Install wasmtime
@@ -257,7 +258,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Moon update
@@ -293,7 +294,7 @@ jobs:
         run: git submodule update --init deps/wasmtime
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
       - name: Install ripgrep
         run: |
@@ -374,7 +375,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
       - name: Cache MoonBit build
         uses: actions/cache@v5
@@ -438,7 +439,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
       - name: Cache MoonBit build
         uses: actions/cache@v5
@@ -489,7 +490,7 @@ jobs:
         run: git submodule update --init deps/wasmtime
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
       - name: Install ripgrep
         run: |
@@ -566,7 +567,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Install wasmtime
@@ -607,7 +608,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Moon update
@@ -664,7 +665,7 @@ jobs:
 
       - name: Install MoonBit CLI
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$VIBE_CI_MOON_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Install ripgrep


### PR DESCRIPTION
## Summary
- pin the MoonBit CLI version used by GitHub Actions via `VIBE_CI_MOON_VERSION`
- route every workflow install step through the pinned version argument
- keep the change scoped to CI workflow configuration only

## Validation
- `actionlint .github/workflows/ci.yml`
- `git diff --check`