### PR TITLE
style: port PR119 example new-style syntax

### DIFF
--- a/examples/async.vibe
+++ b/examples/async.vibe
@@ -1,29 +1,29 @@
 //# Functions
 
 // async_id: (Int) -> Int with {Async}
-let async_id = (x: Int) -> Int with { Async } {
+let async_id: (Int) -> Int with { Async } = (x: Int) -> Int with { Async } {
   x
 }
 
 // async_abs: (Int) -> Int with {Async}
-let async_abs = (x: Int) -> Int with { Async } {
+let async_abs: (Int) -> Int with { Async } = (x: Int) -> Int with { Async } {
   if x < 0 {
     0 - x
   } else x
 }
 
 // async_add: (Int, Int) -> Int with {Async}
-let async_add = (a: Int, b: Int) -> Int with { Async } {
+let async_add: (Int, Int) -> Int with { Async } = (a: Int, b: Int) -> Int with { Async } {
   a + b
 }
 
 // async_double: (Int) -> Int with {Async}
-let async_double = (x: Int) -> Int with { Async } {
+let async_double: (Int) -> Int with { Async } = (x: Int) -> Int with { Async } {
   x * 2
 }
 
 // async_safe_div: (Int, Int) -> Int with {Async, Error}
-let async_safe_div = (a: Int, b: Int) -> Int with { Async, Error } {
+let async_safe_div: (Int, Int) -> Int with { Async, Error } = (a: Int, b: Int) -> Int with { Async, Error } {
   if b == 0 {
     throw("division by zero")
   } else a / b

--- a/examples/base64.vibe
+++ b/examples/base64.vibe
@@ -2,11 +2,11 @@
 
 let table: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-let to_b64 = (i: Int) -> String {
+let to_b64: (Int) -> String = (i) -> {
   table|>String::substring(i, i + 1)
 }
 
-let encode_pair = (a: Int, b: Int) -> String {
+let encode_pair: (Int, Int) -> String = (a, b) -> {
   let c0 = to_b64(a / 4)
   let x1 = a % 4 * 16
   let y1 = b / 16
@@ -15,13 +15,13 @@ let encode_pair = (a: Int, b: Int) -> String {
   c0|>String::concat(c1)|>String::concat(c2)|>String::concat("=")
 }
 
-let encode_single = (a: Int) -> String {
+let encode_single: (Int) -> String = (a) -> {
   let c0 = to_b64(a / 4)
   let c1 = to_b64(a % 4 * 16)
   c0|>String::concat(c1)|>String::concat("==")
 }
 
-let encode_triplet = (a: Int, b: Int, c: Int) -> String {
+let encode_triplet: (Int, Int, Int) -> String = (a, b, c) -> {
   let c0 = to_b64(a / 4)
   let x1 = a % 4 * 16
   let y1 = b / 16
@@ -33,7 +33,7 @@ let encode_triplet = (a: Int, b: Int, c: Int) -> String {
   c0|>String::concat(c1)|>String::concat(c2)|>String::concat(c3)
 }
 
-let rec enc_loop = (s: String, i: Int, out: String) -> String {
+let rec enc_loop: (String, Int, String) -> String = (s: String, i: Int, out: String) -> String {
   let len = s|>String::length()
   if i + 3 <= len {
     let j = i + 1
@@ -53,7 +53,7 @@ let rec enc_loop = (s: String, i: Int, out: String) -> String {
   } else out
 }
 
-export let encode = (s: String) -> String {
+export let encode: (String) -> String = (s) -> {
   enc_loop(s, 0, "")
 }
 

--- a/examples/basics.vibe
+++ b/examples/basics.vibe
@@ -9,17 +9,17 @@ enum MaybeInt {
 
 //# Functions
 
-let inc = (x: Int) -> Int {
+let inc: (Int) -> Int = (x) -> {
   x + 1
 }
 
-let rec fact = (n: Int) -> Int {
+let rec fact: (Int) -> Int = (n: Int) -> Int {
   if n < 2 {
     1
   } else n * fact(n - 1)
 }
 
-let classify = (x: Int) -> String {
+let classify: (Int) -> String = (x) -> {
   if x > 0 {
     "pos"
   } else if x == 0 {
@@ -31,7 +31,7 @@ let if_value: Int = if true {
   1
 } else 2
 
-let pair_sum = (p: Pair) -> Int {
+let pair_sum: (Pair) -> Int = (p) -> {
   p.0 + p.1
 }
 
@@ -55,7 +55,7 @@ let block_value: Int = {
   base + 2
 }
 
-let maybe_to_int = (x: MaybeInt) -> Int {
+let maybe_to_int: (MaybeInt) -> Int = (x) -> {
   match x {
     Hit(v) => v,
     Miss => 0,

--- a/examples/effect_test.vibe
+++ b/examples/effect_test.vibe
@@ -1,7 +1,7 @@
 //# Functions
 
 // might_fail: (Int) -> Int with {Error}
-let might_fail = (x: Int) -> Int with { Error } {
+let might_fail: (Int) -> Int with { Error } = (x: Int) -> Int with { Error } {
   if x == 0 {
     throw("zero error")
   } else x

--- a/examples/function_test.vibe
+++ b/examples/function_test.vibe
@@ -1,16 +1,16 @@
 //# Functions
 
-let rec fib = (n: Int) -> Int {
+let rec fib: (Int) -> Int = (n: Int) -> Int {
   if n <= 1 {
     n
   } else fib(n - 1) + fib(n - 2)
 }
 
-let double = (x: Int) -> Int {
+let double: (Int) -> Int = (x) -> {
   x * 2
 }
 
-let add_pair = (a: Int, b: Int) -> Int {
+let add_pair: (Int, Int) -> Int = (a, b) -> {
   a + b
 }
 
@@ -18,7 +18,7 @@ let identity = [T](x: T) -> T {
   x
 }
 
-let rec factorial = (n: Int) -> Int {
+let rec factorial: (Int) -> Int = (n: Int) -> Int {
   if n < 2 {
     1
   } else n * factorial(n - 1)


### PR DESCRIPTION
## Summary
- port the remaining PR119 example syntax updates that are still missing on `main`
- keep the slice small: `examples/async.vibe`, `examples/base64.vibe`, `examples/basics.vibe`, `examples/effect_test.vibe`, `examples/function_test.vibe`
- adapt the old PR119 syntax to the current compiler rules for new-style functions

## Notes
- current compiler rules require extra RHS annotations for some forms:
  - `let rec f: (Int) -> Int = (x: Int) -> Int { ... }`
  - `let f: () -> Int with { Error } = () -> Int with { Error } { ... }`
- `make_adder` in `examples/function_test.vibe` intentionally stays old-style. Converting it to new-style reproduces a wasm validation failure for closure-returning functions (`expected i32, found i64`).

## Verification
- `git diff --check`
- `source scripts/ensure_native_cli.sh && _build/native/debug/build/cmd/vibe/vibe.exe test --unstable-async examples/async.vibe examples/base64.vibe examples/basics.vibe examples/effect_test.vibe examples/function_test.vibe`
- result matches baseline:
  - `async/base64/effect_test/function_test`: green
  - `basics`: existing `lambda and placeholder` failure remains

Refs #119