### PR TITLE
style: port PR119 set recursion syntax

### DIFF
--- a/vibe/collection/set.vibe
+++ b/vibe/collection/set.vibe
@@ -7,7 +7,7 @@ export enum StringSet {
 
 //# Functions
 
-export let rec size = (s: StringSet) -> Int {
+export let rec size: (StringSet) -> Int = (s: StringSet) -> Int {
   match s {
     Empty => 0,
     Node(_, tail) => 1 + size(tail)
@@ -18,7 +18,7 @@ export let empty: () -> StringSet = () -> {
   Empty
 }
 
-export let rec remove = (s: StringSet, value: String) -> StringSet {
+export let rec remove: (StringSet, String) -> StringSet = (s: StringSet, value: String) -> StringSet {
   match s {
     Empty => Empty,
     Node(head, tail) => if head == value {
@@ -27,7 +27,7 @@ export let rec remove = (s: StringSet, value: String) -> StringSet {
   }
 }
 
-export let rec contains = (s: StringSet, value: String) -> Bool {
+export let rec contains: (StringSet, String) -> Bool = (s: StringSet, value: String) -> Bool {
   match s {
     Empty => false,
     Node(head, tail) => if head == value {


### PR DESCRIPTION
## Summary
- port one remaining PR119 style slice from `vibe/collection/set.vibe`
- convert the top-level recursive helpers `size`, `remove`, and `contains` to the current new-style function syntax
- keep behavior unchanged

## Notes
- current compiler requires recursive new-style definitions to annotate the RHS as well:
  - `let rec f: (A) -> B = (x: A) -> B { ... }`
- this slice avoids broader generic/helper churn and limits itself to the three recursive entrypoints already covered by tests

## Verification
- `git diff --check`
- `source scripts/ensure_native_cli.sh && _build/native/debug/build/cmd/vibe/vibe.exe test vibe/collection/set_test.vibe`

Refs #119