### PR TITLE
style: port PR119 checker pattern syntax

### DIFF
--- a/vibe/compiler/checker/checker_pattern.vibe
+++ b/vibe/compiler/checker/checker_pattern.vibe
@@ -37,7 +37,7 @@ let find_ctor_in_defs = (defs: Array[TypeDef], ctor_name: String) -> Option[(Str
   go_defs(0)
 }
 
-export let rec check_pattern = (pat: Pat, scrutinee_ty: Type, env: TypeEnv, defs: Array[TypeDef]) -> TypeEnv {
+export let rec check_pattern: (Pat, Type, TypeEnv, Array[TypeDef]) -> TypeEnv = (pat: Pat, scrutinee_ty: Type, env: TypeEnv, defs: Array[TypeDef]) -> TypeEnv {
   match pat {
     PWild => env,
     PBind(name) => env_bind(env, name, scrutinee_ty),


### PR DESCRIPTION
## Summary
- port one remaining PR119 style slice from `vibe/compiler/checker/checker_pattern.vibe`
- convert `check_pattern` to the current recursive new-style syntax
- keep behavior unchanged

## Notes
- current compiler requires recursive new-style definitions to annotate the RHS as well:
  - `let rec f: (A, B) -> C = (a: A, b: B) -> C { ... }`
- `checker_error` was not included in this slice because its tests are already failing on baseline due to upstream errors in `checker_error.vibe`

## Verification
- `git diff --check`
- `source scripts/ensure_native_cli.sh && _build/native/debug/build/cmd/vibe/vibe.exe test vibe/compiler/checker_pattern_test.vibe`

Refs #119