### PR TITLE
fix: resolve WASM codegen I32/I64 mismatch for untyped closure returns

### DIFF
--- a/bench/golden/selfhost_runtime_fixture_snapshot.json
+++ b/bench/golden/selfhost_runtime_fixture_snapshot.json
@@ -2,8 +2,8 @@
   "schema_version": 1,
   "timeout_ms": 30000,
   "total_candidates": 206,
-  "passed_count": 7,
-  "failed_count": 199,
+  "passed_count": 164,
+  "failed_count": 42,
   "candidate_paths": [
     "fixtures/array_builder_collect.vibe",
     "fixtures/array_collect_filter.vibe",
@@ -213,13 +213,465 @@
     "fixtures/while_nested_break.vibe"
   ],
   "passed_paths": [
+    "fixtures/array_builder_collect.vibe",
+    "fixtures/array_collect_filter.vibe",
+    "fixtures/array_filter.vibe",
+    "fixtures/array_fold.vibe",
+    "fixtures/array_map.vibe",
+    "fixtures/array_push_index.vibe",
+    "fixtures/assign_compound.vibe",
+    "fixtures/bitwise_ops.vibe",
+    "fixtures/block_expr.vibe",
+    "fixtures/bytes_basic.vibe",
+    "fixtures/bytes_ops.vibe",
+    "fixtures/char_basic.vibe",
     "fixtures/closure_capture.vibe",
+    "fixtures/closure_higher_order.vibe",
+    "fixtures/closure_multi_capture.vibe",
     "fixtures/closure_nested.vibe",
+    "fixtures/closure_recursive.vibe",
+    "fixtures/comparison_ops.vibe",
+    "fixtures/compound_assign.vibe",
+    "fixtures/double_arithmetic.vibe",
+    "fixtures/double_basic.vibe",
+    "fixtures/effect_decl_exported.vibe",
+    "fixtures/effect_subtype_pure_to_effectful.vibe",
+    "fixtures/enum_generic.vibe",
+    "fixtures/enum_option_chain.vibe",
+    "fixtures/enum_recursive.vibe",
+    "fixtures/enum_recursive_tree.vibe",
+    "fixtures/enum_with_methods.vibe",
     "fixtures/err_parse_duplicate_param.vibe",
+    "fixtures/err_type_closure_capture_mut.vibe",
+    "fixtures/err_type_generic_escape.vibe",
+    "fixtures/err_type_generic_in_array.vibe",
+    "fixtures/err_type_generic_no_inference.vibe",
+    "fixtures/err_type_generic_too_few_type_args.vibe",
+    "fixtures/err_type_generic_too_many_type_args.vibe",
+    "fixtures/err_type_generic_wrong_type_arg.vibe",
+    "fixtures/err_type_record_extra_field.vibe",
+    "fixtures/err_type_shadowed_generic.vibe",
+    "fixtures/float_basic.vibe",
+    "fixtures/for_in_accumulate.vibe",
     "fixtures/for_in_basic.vibe",
     "fixtures/for_in_break.vibe",
     "fixtures/for_in_continue.vibe",
-    "fixtures/for_in_index.vibe"
+    "fixtures/for_in_empty.vibe",
+    "fixtures/for_in_flat_sum.vibe",
+    "fixtures/for_in_index.vibe",
+    "fixtures/for_in_index_var.vibe",
+    "fixtures/for_in_map_result.vibe",
+    "fixtures/for_in_nested.vibe",
+    "fixtures/for_in_string.vibe",
+    "fixtures/for_in_var_scope.vibe",
+    "fixtures/from_to_lines.vibe",
+    "fixtures/generic_apply.vibe",
+    "fixtures/generic_compose.vibe",
+    "fixtures/generic_const.vibe",
+    "fixtures/generic_curried.vibe",
+    "fixtures/generic_deep_nesting.vibe",
+    "fixtures/generic_explicit_type_arg.vibe",
+    "fixtures/generic_filter.vibe",
+    "fixtures/generic_first.vibe",
+    "fixtures/generic_flip.vibe",
+    "fixtures/generic_fold.vibe",
+    "fixtures/generic_identity.vibe",
+    "fixtures/generic_identity_string.vibe",
+    "fixtures/generic_map_array.vibe",
+    "fixtures/generic_multiple_calls.vibe",
+    "fixtures/generic_nested_call.vibe",
+    "fixtures/generic_nested_types.vibe",
+    "fixtures/generic_option.vibe",
+    "fixtures/generic_option_map.vibe",
+    "fixtures/generic_pair.vibe",
+    "fixtures/generic_pipeline.vibe",
+    "fixtures/generic_result_chain.vibe",
+    "fixtures/generic_second.vibe",
+    "fixtures/generic_swap.vibe",
+    "fixtures/generic_two_params.vibe",
+    "fixtures/generic_wrap_array.vibe",
+    "fixtures/hello.vibe",
+    "fixtures/hex_literal.vibe",
+    "fixtures/http_p3_client_proxy.vibe",
+    "fixtures/http_p3_handler.vibe",
+    "fixtures/http_p3_handler_string.vibe",
+    "fixtures/if_else_chain.vibe",
+    "fixtures/int_large_literal.vibe",
+    "fixtures/json_parse.vibe",
+    "fixtures/json_stringify.vibe",
+    "fixtures/jsonl.vibe",
+    "fixtures/let_annotation.vibe",
+    "fixtures/let_pat_tuple.vibe",
+    "fixtures/let_rec_large_with_captures.vibe",
+    "fixtures/let_rec_mutual.vibe",
+    "fixtures/let_type_annotation_basic.vibe",
+    "fixtures/let_type_annotation_generic.vibe",
+    "fixtures/loop_continue.vibe",
+    "fixtures/loop_expr_counter.vibe",
+    "fixtures/loop_functional.vibe",
+    "fixtures/loop_with_break.vibe",
+    "fixtures/map_basic.vibe",
+    "fixtures/map_builder.vibe",
+    "fixtures/map_iterate.vibe",
+    "fixtures/map_set_has.vibe",
+    "fixtures/match_enum_nested.vibe",
+    "fixtures/match_guard.vibe",
+    "fixtures/match_guard_complex.vibe",
+    "fixtures/match_int.vibe",
+    "fixtures/match_nested_ctor.vibe",
+    "fixtures/match_nested_option.vibe",
+    "fixtures/match_nested_tuple.vibe",
+    "fixtures/match_or_guard.vibe",
+    "fixtures/match_or_pattern.vibe",
+    "fixtures/match_string.vibe",
+    "fixtures/match_tuple_pattern.vibe",
+    "fixtures/match_wildcard.vibe",
+    "fixtures/nested_closure_capture.vibe",
+    "fixtures/nested_loop.vibe",
+    "fixtures/option_chain.vibe",
+    "fixtures/option_match.vibe",
+    "fixtures/option_unwrap.vibe",
+    "fixtures/pattern_or_bool.vibe",
+    "fixtures/pipe_chain.vibe",
+    "fixtures/pipe_operator.vibe",
+    "fixtures/prelude_to_string_parenthesized_literal_method.vibe",
+    "fixtures/prompttext_coercion_fn_call.vibe",
+    "fixtures/rec_generic_function_basic.vibe",
+    "fixtures/record_pattern.vibe",
+    "fixtures/recursive_data_structure.vibe",
+    "fixtures/show_to_string_method.vibe",
+    "fixtures/spread_array.vibe",
+    "fixtures/string_builder.vibe",
+    "fixtures/string_concat.vibe",
+    "fixtures/string_index.vibe",
+    "fixtures/string_interp_nested.vibe",
+    "fixtures/string_interpolation.vibe",
+    "fixtures/string_join.vibe",
+    "fixtures/string_ops_basic.vibe",
+    "fixtures/string_split_join.vibe",
+    "fixtures/string_starts_ends.vibe",
+    "fixtures/struct_lit_sugar.vibe",
+    "fixtures/struct_method.vibe",
+    "fixtures/trait_basic.vibe",
+    "fixtures/trait_bound_basic.vibe",
+    "fixtures/trait_bound_multi_basic.vibe",
+    "fixtures/trait_export_open_declares_open_trait.vibe",
+    "fixtures/trait_export_sealed_trait_local_impl.vibe",
+    "fixtures/trait_generic_impl_bound_basic.vibe",
+    "fixtures/trait_hierarchy_ord_implies_eq_operator.vibe",
+    "fixtures/trait_hierarchy_transitive_supertrait_operator.vibe",
+    "fixtures/trait_impl_multi_bound_basic.vibe",
+    "fixtures/trait_inline_param_bound_basic.vibe",
+    "fixtures/trait_inline_param_multi_bound_basic.vibe",
+    "fixtures/trait_with_methods.vibe",
+    "fixtures/tuple_destructure.vibe",
+    "fixtures/tuple_nested.vibe",
+    "fixtures/type_alias_basic.vibe",
+    "fixtures/type_member_import_member_int.vibe",
+    "fixtures/type_member_local_int_to_double.vibe",
+    "fixtures/type_member_method_call_int_to_double.vibe",
+    "fixtures/type_param_multi.vibe",
+    "fixtures/type_wasm_primitive_aliases.vibe",
+    "fixtures/unit_value.vibe",
+    "fixtures/while_break_value.vibe",
+    "fixtures/while_loop_basic.vibe",
+    "fixtures/while_mut_capture.vibe",
+    "fixtures/while_nested_break.vibe"
   ],
-  "failed_cases": []
+  "failed_cases": [
+    {
+      "path": "fixtures/derive_struct_eq_marker_impl.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/derive_struct_ord_implies_eq.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/effect_decl_basic.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/effect_decl_generic.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/effect_decl_http.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/effect_decl_multi_param.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/effect_empty_declaration.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/err_export_use_rename.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/err_import_collides_with_local_let.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/err_std_int_prefixed_export_removed.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/export_use_basic.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/forward_reference.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/forward_reference_annotated_let.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/forward_reference_mutual.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/forward_reference_no_ret_annotation.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/import_explicit_kinds.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/import_symbol_ref.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/import_version_ref.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/labeled_arg_basic.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/labeled_arg_optional.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/let_else.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/let_else_fallback.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/let_pat_option.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/let_type_annotation_labeled.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/loop_param_factorial.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/loop_param_sum.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/runtime/effect_sh.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/std_alias_int_short_api.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/std_alias_is_some_import.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/std_alias_option_short_api.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/std_alias_string_short_api.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/std_alias_unwrap_or_import.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/string_char_ops.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/trait_eq_bound.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/trait_eq_operator_accepts_eq_bound_type_parameter.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/trait_eq_string_operator_runtime.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/trait_impl_func_label_no_overlap.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/trait_import_chain.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/trait_ord_bound.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/trait_ord_operator_accepts_ord_bound_type_parameter.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/type_member_import_namespace_int.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    },
+    {
+      "path": "fixtures/type_member_import_namespace_int_typed.vibe",
+      "exit_status": null,
+      "signal": "SIGABRT",
+      "output_excerpt": "",
+      "timeout": false
+    }
+  ]
 }

--- a/src/checker/pkg.generated.mbti
+++ b/src/checker/pkg.generated.mbti
@@ -44,7 +44,7 @@ pub fn purity_expr(TypeEnv, @core.Expr) -> Bool
 
 pub fn purity_for_let(TypeEnv, Bool, String, @core.Expr) -> PurityInfo
 
-pub fn type_check(@core.Module) -> TypeEnv raise TypeError
+pub fn type_check(@core.Module, allow_duplicate_decl? : Bool) -> TypeEnv raise TypeError
 
 pub fn type_check_with_env(TypeEnv, @core.Module, Map[String, @core.Ref]) -> TypeEnv raise TypeError
 

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -3194,7 +3194,7 @@ fn emit_module_with_coverage(
         if top_keys.contains(f.span_key) {
           let default_ret = match f.ret {
             Some(r) => value_kind_from_type(ctx, r)
-            None => ValueKind::I32
+            None => ValueKind::I64
           }
           ctx.fn_returns[name] = default_ret
           // Register return signature if function returns a function type

--- a/src/codegen/wasm_codegen_sig.mbt
+++ b/src/codegen/wasm_codegen_sig.mbt
@@ -618,7 +618,12 @@ fn infer_expr_kind_with(
         "Threads::wait" => ValueKind::I64
         _ if ctx.fn_local_sigs.contains(name) =>
           match ctx.fn_local_sigs.get(name) {
-            Some(sig) => sig.results[0]
+            Some(sig) =>
+              if sig.results.length() > 0 {
+                sig.results[0]
+              } else {
+                ValueKind::I64
+              }
             None => ValueKind::I64
           }
         _ =>

--- a/src/codegen/wasm_codegen_stmt.mbt
+++ b/src/codegen/wasm_codegen_stmt.mbt
@@ -116,7 +116,7 @@ fn compile_stmt(
           let kinds = param_kinds(ctx, fn_params)
           let ret_kind = match fn_ret {
             Some(r) => value_kind_from_type(ctx, r)
-            None => ValueKind::I32
+            None => ValueKind::I64
           }
           ctx.fn_local_sigs[name] = match ctx.fn_multivalue_results.get(name) {
             Some(results) => func_sig_with_env_multi(kinds, results)


### PR DESCRIPTION
## Summary

- Fix WASM codegen defaulting unannotated closure return types to `I32` instead of `I64`, which produced invalid WASM and caused SIGABRT in `vibe test`
- Add bounds check on `sig.results[0]` access in `infer_expr_kind_with` to prevent potential out-of-bounds abort
- Update selfhost runtime fixture snapshot: **7 → 164 passed** (+157 tests, out of 206 total)

## Details

When a closure had no explicit return type annotation (e.g. `() -> { 42 }`), the codegen registered its return kind as `ValueKind::I32` in `fn_local_sigs`, while the actual compiled function body returns `I64`. This type mismatch between `call_indirect` signature and function definition made wasmtime reject the WASM module.

The fix aligns two sites (`wasm_codegen_stmt.mbt:119`, `wasm_codegen_module.mbt:3197`) with the existing default in `wasm_codegen_sig.mbt:171` which already used `I64`.

Remaining 42 failures are pre-existing codegen limitations (labeled args, loop params, let-else, forward references, imports/exports).

Closes #161

## Test plan

- [x] `moon check` passes (0 errors)
- [x] `moon test` passes (1039/1039)
- [x] Selfhost runtime fixture snapshot updated and verified
- [x] Manual verification: `vibe test` with untyped closures no longer SIGABRT

https://claude.ai/code/session_01FTEXo6NxfTuUe9FqjrzXzw