### PR TITLE
fix: implement derive(Eq) by registering builtin traits in prelude seed

### DIFF
--- a/examples/cheatsheet_types_test.vibe
+++ b/examples/cheatsheet_types_test.vibe
@@ -190,10 +190,9 @@ test "match guard" {
 
 // --- KNOWN ISSUES (features from cheatsheet that do not compile) ---
 
-// ISSUE: `derive(Eq)` fails with:
-//   "type definition: unknown trait: Eq"
-// The cheatsheet shows `enum Color { ... } derive(Eq)` and
-// `struct Point { ... } derive(Eq)` but this is not supported.
+// FIXED: `derive(Eq)` now works correctly.
+// `enum Color { ... } derive(Eq)` and `struct Point { ... } derive(Eq)`
+// register the Eq trait impl so `==` can be used on custom types.
 
 // ISSUE: `is` expression - documented in cheatsheet but untested here
 // due to codegen limitations in some contexts.

--- a/fixtures/derive_enum_eq.vibe
+++ b/fixtures/derive_enum_eq.vibe
@@ -1,0 +1,14 @@
+enum Color { Red; Green; Blue } derive(Eq)
+
+let _start = () -> {
+  let mut score = 0
+  if Color::Red == Color::Red { score = score + 1 }
+  if !(Color::Red == Color::Blue) { score = score + 1 }
+  if !(Color::Green == Color::Blue) { score = score + 1 }
+  if Color::Blue == Color::Blue { score = score + 1 }
+  score
+}
+_start()
+
+__DATA__
+{"last": "4"}

--- a/fixtures/derive_struct_eq.vibe
+++ b/fixtures/derive_struct_eq.vibe
@@ -1,0 +1,15 @@
+struct Point { x: Int; y: Int } derive(Eq)
+
+let _start = () -> {
+  let a = Point::{ x: 1, y: 2 }
+  let b = Point::{ x: 1, y: 2 }
+  let c = Point::{ x: 3, y: 4 }
+  let mut score = 0
+  if a == b { score = score + 1 }
+  if !(a == c) { score = score + 1 }
+  score
+}
+_start()
+
+__DATA__
+{"last": "2"}

--- a/src/checker/pkg.generated.mbti
+++ b/src/checker/pkg.generated.mbti
@@ -20,6 +20,8 @@ pub fn completion_param_matches(TypeEnv, @core.Type, @core.Type) -> Bool
 
 pub fn ensure_builtin_modules(TypeEnv, Map[String, @core.Ref]) -> Unit
 
+pub fn ensure_prelude_builtin_traits(TypeEnv) -> Unit
+
 pub fn ensure_prelude_functions(TypeEnv, Map[String, @core.Ref]) -> Unit raise TypeError
 
 pub fn ensure_prelude_option(TypeEnv) -> Unit raise TypeError
@@ -27,6 +29,8 @@ pub fn ensure_prelude_option(TypeEnv) -> Unit raise TypeError
 pub fn get_cached_prelude_env_for_module() -> TypeEnv raise TypeError
 
 pub fn get_prelude_only_env_for_module() -> TypeEnv raise TypeError
+
+pub fn is_prelude_builtin_trait(String) -> Bool
 
 pub fn is_type_subtype(TypeEnv, @core.Type, @core.Type) -> Bool
 

--- a/src/checker/typecheck_export_wbtest.mbt
+++ b/src/checker/typecheck_export_wbtest.mbt
@@ -1,4 +1,22 @@
 ///|
+test "derive(Eq) enum typechecks with builtin Eq trait" {
+  let script =
+    #|enum Color { Red; Green; Blue } derive(Eq)
+    #|let _x = Color::Red == Color::Blue
+  let ast = @parser.parse_ast(script)
+  let _ = type_check(ast)
+}
+
+///|
+test "derive(Eq) struct typechecks with builtin Eq trait" {
+  let script =
+    #|struct Point { x: Int; y: Int } derive(Eq)
+    #|let _x = Point::{ x: 1, y: 2 } == Point::{ x: 3, y: 4 }
+  let ast = @parser.parse_ast(script)
+  let _ = type_check(ast)
+}
+
+///|
 test "typecheck keeps exported schemes for struct-returning functions" {
   let script =
     #|export struct PathRef { raw : String }

--- a/src/checker/typecheck_prelude.mbt
+++ b/src/checker/typecheck_prelude.mbt
@@ -226,3 +226,37 @@ pub fn ensure_builtin_modules(
     }
   }
 }
+
+///|
+/// Register builtin trait names (Eq, Hash, Ord, etc.) so that `derive(Eq)`
+/// works even when the full builtin modules have not been loaded yet.
+/// These are soft-registered: user modules can redefine them via
+/// `export trait Eq` without a duplicate-trait error.
+pub fn ensure_prelude_builtin_traits(env : TypeEnv) -> Unit {
+  let builtin_trait_names = [
+    "Eq", "Hash", "Ord", "Add", "Sub", "Mul", "Div", "Signed",
+  ]
+  for name in builtin_trait_names {
+    if not(env.has_trait(name)) {
+      env.set_trait_info(name, TraitDefInfo::{
+        supertraits: [],
+        open_impl: false,
+        is_local: true,
+      })
+    }
+  }
+}
+
+///|
+/// Known builtin trait names that are soft-registered in the prelude seed.
+/// User modules may redefine these without triggering a duplicate-trait error.
+pub fn is_prelude_builtin_trait(name : String) -> Bool {
+  name == "Eq" ||
+  name == "Hash" ||
+  name == "Ord" ||
+  name == "Add" ||
+  name == "Sub" ||
+  name == "Mul" ||
+  name == "Div" ||
+  name == "Signed"
+}

--- a/src/checker/typecheck_stmts.mbt
+++ b/src/checker/typecheck_stmts.mbt
@@ -44,6 +44,7 @@ fn ensure_prelude_seed(session : TypecheckSession) -> TypeEnv raise TypeError {
       let seed = session.new_env()
       ensure_prelude_option(seed)
       ensure_prelude_functions(seed, {})
+      ensure_prelude_builtin_traits(seed)
       session.cached_prelude_env.val = Some(seed)
       seed
     }
@@ -1035,7 +1036,12 @@ fn register_trait_def(
     if env.session_state.lenient_mode {
       return
     }
-    raise TypeError::BadTypeDef(message="duplicate trait: " + name, span~)
+    // Allow re-defining a prelude builtin trait (e.g. Eq, Hash, Ord).
+    // The prelude seed soft-registers these so derive(Eq) works, but
+    // user modules may redefine them via `export trait Eq`.
+    if not(is_prelude_builtin_trait(name)) {
+      raise TypeError::BadTypeDef(message="duplicate trait: " + name, span~)
+    }
   }
   let normalized_supertraits = dedup_trait_bounds(supertraits)
   for supertrait in normalized_supertraits {


### PR DESCRIPTION
## Summary\n\n- **Root cause**: `get_prelude_only_env_for_module()` (used by runtime DB type queries) did not include builtin trait definitions (Eq, Hash, Ord, etc.), so `derive(Eq)` failed with \"unknown trait: Eq\"\n- **Fix**: Add `ensure_prelude_builtin_traits()` to register builtin trait names in the prelude seed, and allow user modules to redefine them without duplicate-trait errors\n- **Tests**: 2 checker whitebox tests + 2 fixture tests for enum/struct derive(Eq)\n\nCloses #148\n\n## Test plan\n\n- [x] All 1041 existing tests pass\n- [x] New checker tests verify derive(Eq) for enum and struct\n- [x] CLI `vibe check` confirms derive(Eq) no longer errors\n- [x] Runtime DB tests still pass (no regression from trait re-definition)\n\nhttps://claude.ai/code/session_01VSR3aQRA5b3e78kbLvSiJr