### PR TITLE
Fix 4 compiler bugs: effect dispatch, guard conds, ForIn scope

### DIFF
--- a/examples/effect_crossfn_test.vibe
+++ b/examples/effect_crossfn_test.vibe
@@ -1,0 +1,68 @@
+//# Effects
+
+effect Transform {
+  Apply(String) -> String
+}
+
+effect Calc {
+  Add(Int) -> Int
+  Mul(Int) -> Int
+}
+
+effect Reader2 {
+  Read() -> String
+}
+
+//# Misc
+
+test "cross-function effect arg passing" {
+  let apply: (String) -> String with { Transform } = (s) -> {
+    perform Transform::Apply(s)
+  }
+  let result = handle {
+    apply("hello")
+  } {
+    Transform::Apply(s) => resume(s + "!")
+  }
+  assert(result == "hello!")
+}
+
+test "cross-function effect no-arg" {
+  let read: () -> String with { Reader2 } = () -> {
+    perform Reader2::Read()
+  }
+  let result = handle {
+    read()
+  } {
+    Reader2::Read() => resume("fixed")
+  }
+  assert(result == "fixed")
+}
+
+test "cross-function effect multiple calls" {
+  let read: () -> String with { Reader2 } = () -> {
+    perform Reader2::Read()
+  }
+  let result = handle {
+    let a = read()
+    let b = read()
+    a + " " + b
+  } {
+    Reader2::Read() => resume("hi")
+  }
+  assert(result == "hi hi")
+}
+
+test "cross-function multi-op dispatch" {
+  let add: (Int) -> Int with { Calc } = (n) -> perform Calc::Add(n)
+  let mul: (Int) -> Int with { Calc } = (n) -> perform Calc::Mul(n)
+  let result = handle {
+    let a = add(5)
+    let b = mul(3)
+    a + b
+  } {
+    Calc::Add(n) => resume(n + 10),
+    Calc::Mul(n) => resume(n * 10)
+  }
+  assert(result == 45)
+}

--- a/src/codegen/wasm_codegen_ctx.mbt
+++ b/src/codegen/wasm_codegen_ctx.mbt
@@ -63,6 +63,7 @@ priv struct CodegenCtx {
   mut effect_resume_idx_global : Int // i32: current read position
   mut effect_resume_count_global : Int // i32: number of stored resume values
   mut effect_resume_buf_global : Int // i32: pointer to resume value buffer
+  mut effect_perform_arg_global : Int // i64: perform argument value for cross-function dispatch
   // Stack switching for async
   mut need_stack_switching : Bool
   mut await_tag_type_index : Int
@@ -248,6 +249,7 @@ fn CodegenCtx::new(
     effect_resume_idx_global: -1,
     effect_resume_count_global: -1,
     effect_resume_buf_global: -1,
+    effect_perform_arg_global: -1,
     need_exceptions: false,
     error_tag_type_index: -1,
     error_tag_index: 0,

--- a/src/codegen/wasm_codegen_expr.mbt
+++ b/src/codegen/wasm_codegen_expr.mbt
@@ -171,11 +171,25 @@ fn compile_expr(
             emit_i32_add(buf)
             emit_global_set(buf, ctx.effect_resume_idx_global)
             buf.push((5).to_byte()) // else
-            // Throw for cross-function dispatch
+            // Store perform arg in global before throwing
+            if args.length() > 0 {
+              compile_expr(ctx, buf, args[0].expr)
+            } else {
+              emit_i64_const_raw(buf, 0L) // Unit
+            }
+            emit_global_set(buf, ctx.effect_perform_arg_global)
+            // Throw op key for cross-function dispatch
             let tag_str = @core.Expr::String(value=key, span~)
             compile_expr_raise(ctx, buf, tag_str)
             buf.push((11).to_byte()) // end if
           } else {
+            // Store perform arg in global before throwing
+            if args.length() > 0 {
+              compile_expr(ctx, buf, args[0].expr)
+            } else {
+              emit_i64_const_raw(buf, 0L) // Unit
+            }
+            emit_global_set(buf, ctx.effect_perform_arg_global)
             let tag_str = @core.Expr::String(value=key, span~)
             compile_expr_raise(ctx, buf, tag_str)
           }

--- a/src/codegen/wasm_codegen_expr_effect.mbt
+++ b/src/codegen/wasm_codegen_expr_effect.mbt
@@ -259,31 +259,59 @@ fn compile_expr_handle_with_resume(
   write_u32_leb(buf, 2) // $exit = loop(1) → exit_block(2)
   // end $catch_target — error value now on stack
   buf.push((11).to_byte())
-  // Handler code: error value is on stack
+  // Handler code: error value (op key string) is on stack
   let caught_local = alloc_temp_local_with_kind(ctx, error_kind)
   emit_local_set(buf, caught_local)
+  // Pre-allocate resume value local shared across all arms
+  let resume_val_local = alloc_temp_local_with_kind(ctx, ValueKind::I64)
   if effect_arms.length() > 0 {
-    let arm = effect_arms[0]
-    let resume_expr = extract_resume_value_expr(arm.expr)
-    // Bind handler param if present
-    match arm.pat {
-      @core.Pat::Ctor(args~, ..) if args.length() > 0 =>
-        match args[0] {
-          @core.Pat::Bind(name~, ..) => {
-            let bind_local = alloc_temp_local_with_kind(ctx, error_kind)
-            emit_local_get(buf, caught_local)
-            emit_local_set(buf, bind_local)
-            ctx.locals[name] = bind_local
-            ctx.local_kinds[name] = error_kind
+    // Dispatch: compare caught op key against each arm's pattern key
+    for arm in effect_arms {
+      let arm_key = match arm.pat {
+        @core.Pat::Ctor(name~, ..) => name
+        _ => continue
+      }
+      // Compare caught_local with arm's op key string
+      if ctx.use_js_strings {
+        ctx.need_js_equals = true
+        emit_local_get(buf, caught_local)
+        let str_idx = ctx.js_strings.intern(arm_key)
+        emit_global_get(buf, str_idx)
+        emit_call(buf, import_index_js_equals(ctx))
+      } else {
+        emit_local_get(buf, caught_local)
+        let arm_key_expr = @core.Expr::String(
+          value=arm_key, span=arm.span,
+        )
+        compile_expr(ctx, buf, arm_key_expr)
+        emit_i64_eq(buf)
+      }
+      buf.push((4).to_byte()) // if
+      buf.push((64).to_byte()) // void
+      adjust_loop_offsets(ctx, 1)
+      // Bind handler param from perform_arg global
+      match arm.pat {
+        @core.Pat::Ctor(args~, ..) if args.length() > 0 =>
+          match args[0] {
+            @core.Pat::Bind(name~, ..) => {
+              let bind_local = alloc_temp_local_with_kind(ctx, ValueKind::I64)
+              emit_global_get(buf, ctx.effect_perform_arg_global)
+              emit_local_set(buf, bind_local)
+              ctx.locals[name] = bind_local
+              ctx.local_kinds[name] = ValueKind::I64
+            }
+            _ => ()
           }
-          _ => ()
-        }
-      _ => ()
+        _ => ()
+      }
+      // Compile resume expression and store in shared local
+      let resume_expr = extract_resume_value_expr(arm.expr)
+      compile_expr(ctx, buf, resume_expr)
+      emit_local_set(buf, resume_val_local)
+      buf.push((11).to_byte()) // end if
+      adjust_loop_offsets(ctx, -1)
     }
-    compile_expr(ctx, buf, resume_expr)
     // Store resume value: buf[count * 8] = value
-    let resume_val_local = alloc_temp_local_with_kind(ctx, ValueKind::I64)
-    emit_local_set(buf, resume_val_local)
     emit_global_get(buf, ctx.effect_resume_buf_global)
     emit_global_get(buf, ctx.effect_resume_count_global)
     emit_i32_const_raw(buf, 8)

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -1144,7 +1144,7 @@ fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
     let global_sec = ByteBuf::new()
     let global_count = (if heap_global_in_section { 1 } else { 0 }) +
       (if ctx.need_stack_switching { 1 } else { 0 }) +
-      (if ctx.need_effect_resume { 3 } else { 0 }) +
+      (if ctx.need_effect_resume { 4 } else { 0 }) +
       (if ctx.coverage_enabled { 2 } else { 0 }) +
       (if need_fs_global { 1 } else { 0 }) +
       (if ctx.need_socket { 1 } else { 0 }) +
@@ -1169,13 +1169,14 @@ fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
       emit_i64_const_raw(global_sec, 0L) // initial value = 0
       global_sec.push((11).to_byte()) // end
     }
-    // Effect resume globals: idx, count, buf_ptr
+    // Effect resume globals: idx, count, buf_ptr, perform_arg
     if ctx.need_effect_resume {
       let base_idx = (if ctx.use_heap_global { 1 } else { 0 }) +
         (if ctx.need_stack_switching { 1 } else { 0 })
       ctx.effect_resume_idx_global = base_idx
       ctx.effect_resume_count_global = base_idx + 1
       ctx.effect_resume_buf_global = base_idx + 2
+      ctx.effect_perform_arg_global = base_idx + 3
       for i in 0..<3 {
         let _ = i
         global_sec.push((127).to_byte()) // i32
@@ -1183,11 +1184,16 @@ fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
         emit_i32_const_raw(global_sec, 0)
         global_sec.push((11).to_byte()) // end
       }
+      // perform_arg global (i64)
+      global_sec.push((126).to_byte()) // i64
+      global_sec.push((1).to_byte()) // mutable
+      emit_i64_const_raw(global_sec, 0L)
+      global_sec.push((11).to_byte()) // end
     }
     if ctx.coverage_enabled {
       ctx.coverage_base_global_index = (if ctx.use_heap_global { 1 } else { 0 }) +
         (if ctx.need_stack_switching { 1 } else { 0 }) +
-        (if ctx.need_effect_resume { 3 } else { 0 })
+        (if ctx.need_effect_resume { 4 } else { 0 })
       ctx.coverage_count_global_index = ctx.coverage_base_global_index + 1
       // Coverage counter base offset (immutable)
       global_sec.push((127).to_byte()) // i32
@@ -1234,7 +1240,7 @@ fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
     if exported_env_global_count > 0 {
       let mut env_global_idx = (if ctx.use_heap_global { 1 } else { 0 }) +
         (if ctx.need_stack_switching { 1 } else { 0 }) +
-        (if ctx.need_effect_resume { 3 } else { 0 }) +
+        (if ctx.need_effect_resume { 4 } else { 0 }) +
         (if ctx.coverage_enabled { 2 } else { 0 }) +
         (if need_fs_global { 1 } else { 0 }) +
         (if ctx.need_socket { 1 } else { 0 }) +
@@ -3463,7 +3469,7 @@ fn emit_module_with_coverage(
   if ctx.exported_fn_env_globals.length() > 0 {
     let mut env_global_idx = (if ctx.use_heap_global { 1 } else { 0 }) +
       (if ctx.need_stack_switching { 1 } else { 0 }) +
-      (if ctx.need_effect_resume { 3 } else { 0 }) +
+      (if ctx.need_effect_resume { 4 } else { 0 }) +
       (if ctx.coverage_enabled { 2 } else { 0 }) +
       (if ctx.need_fs && not(ctx.fs_host_imports) { 1 } else { 0 }) +
       (if ctx.need_socket { 1 } else { 0 }) +
@@ -3503,6 +3509,7 @@ fn emit_module_with_coverage(
     ctx.effect_resume_idx_global = base
     ctx.effect_resume_count_global = base + 1
     ctx.effect_resume_buf_global = base + 2
+    ctx.effect_perform_arg_global = base + 3
   }
   // Pre-compute RC helper function indices before compile loop.
   // Helpers are appended right after user functions in compiled_funcs.
@@ -3528,7 +3535,7 @@ fn emit_module_with_coverage(
       ctx.rc_header_size = 8 // [alloc_size@-8][rc_count@-4]
       ctx.rc_free_list_global = (if ctx.use_heap_global { 1 } else { 0 }) +
         (if ctx.need_stack_switching { 1 } else { 0 }) +
-        (if ctx.need_effect_resume { 3 } else { 0 }) +
+        (if ctx.need_effect_resume { 4 } else { 0 }) +
         (if ctx.coverage_enabled { 2 } else { 0 }) +
         (if ctx.need_fs && not(ctx.fs_host_imports) { 1 } else { 0 }) +
         (if ctx.need_socket { 1 } else { 0 })
@@ -3543,7 +3550,7 @@ fn emit_module_with_coverage(
       } else {
         (if ctx.use_heap_global { 1 } else { 0 }) +
         (if ctx.need_stack_switching { 1 } else { 0 }) +
-        (if ctx.need_effect_resume { 3 } else { 0 }) +
+        (if ctx.need_effect_resume { 4 } else { 0 }) +
         (if ctx.coverage_enabled { 2 } else { 0 }) +
         (if ctx.need_fs && not(ctx.fs_host_imports) { 1 } else { 0 }) +
         (if ctx.need_socket { 1 } else { 0 })

--- a/src/frontend/desugar.mbt
+++ b/src/frontend/desugar.mbt
@@ -955,14 +955,21 @@ fn desugar_expr(
       }
       @core.Expr::Continue(args=next_args, span~)
     }
-    @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) =>
+    @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
+      let next_scope = scope.child()
+      next_scope.bindings[value_name] = true
+      match index_name {
+        Some(name) => next_scope.bindings[name] = true
+        None => ()
+      }
       @core.Expr::ForIn(
         value_name~,
         index_name~,
         iterable=desugar_expr(iterable, scope, aliases),
-        body=desugar_block(body, scope, aliases),
+        body=desugar_block(body, next_scope, aliases),
         span~,
       )
+    }
     @core.Expr::StringInterp(parts~, span~) => {
       // Lower StringInterp to String::concat chain with __to_string calls
       let exprs : Array[@core.Expr] = []

--- a/src/frontend/rewrite_effect_handle.mbt
+++ b/src/frontend/rewrite_effect_handle.mbt
@@ -172,7 +172,7 @@ fn reh_rewrite_expr(expr : @core.Expr) -> @core.Expr {
       for arm in arms {
         next_arms.push(@core.MatchArm::{
           pat: arm.pat,
-          cond: arm.cond,
+          cond: arm.cond.map(fn(c) { reh_rewrite_expr(c) }),
           expr: reh_rewrite_expr(arm.expr),
           span: arm.span,
         })
@@ -545,6 +545,22 @@ fn reh_replace_performs_expr(
         body=reh_replace_performs(body, handlers),
         span~,
       )
+    @core.Expr::Match(scrutinee~, arms~, span~) => {
+      let next_arms : Array[@core.MatchArm] = []
+      for arm in arms {
+        next_arms.push(@core.MatchArm::{
+          pat: arm.pat,
+          cond: arm.cond.map(fn(c) { reh_replace_performs_expr(c, handlers) }),
+          expr: reh_replace_performs_expr(arm.expr, handlers),
+          span: arm.span,
+        })
+      }
+      @core.Expr::Match(
+        scrutinee=reh_replace_performs_expr(scrutinee, handlers),
+        arms=next_arms,
+        span~,
+      )
+    }
     @core.Expr::Handle(body~, arms~, span~) => {
       // Replace performs in the inner handle body, but do NOT re-enter
       // reh_rewrite_handle (which would cause infinite recursion when
@@ -555,7 +571,7 @@ fn reh_replace_performs_expr(
       for arm in arms {
         inner_arms.push(@core.MatchArm::{
           pat: arm.pat,
-          cond: arm.cond,
+          cond: arm.cond.map(fn(c) { reh_replace_performs_expr(c, handlers) }),
           expr: reh_replace_performs_expr(arm.expr, handlers),
           span: arm.span,
         })


### PR DESCRIPTION
## Summary\n\n- **#232**: Fix perform args dropped in cross-function effect dispatch — store arg in a new `effect_perform_arg_global` (i64) before throwing the op key string\n- **#233**: Fix multi-arm effect handler only compiling first arm — dispatch by comparing caught op key against each arm's pattern string\n- **#234**: Fix match guard conditions not rewritten in effect handler transformation — apply `reh_rewrite_expr` / `reh_replace_performs_expr` to `arm.cond`; also add missing `Match` case to `reh_replace_performs_expr`\n- **#235**: Fix ForIn loop variable not added to scope before body desugaring — create child scope with `value_name` / `index_name` bindings (matching `Loop` handling)\n\n## Test plan\n\n- [ ] New `examples/effect_crossfn_test.vibe` with cross-function effect regression tests:\n  - Single-arg effect arg passing (validates #232)\n  - No-arg effect (baseline)\n  - Multiple cross-function calls in one handle\n  - Multi-op dispatch with two different effect operations (validates #233)\n- [ ] All existing selfhost-examples and wasm-compile-e2e tests pass\n- [ ] contract-moon and contract-native pass\n\nCloses #232, #233, #234, #235\n\nhttps://claude.ai/code/session_01429ytPH9FEqsZ4zcQscQq2