### PR TITLE
Add flaker for selective test execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ vibe/compiler/.vibe_test_wasm_*
 docs/language-tour/eval-results/
 node_modules/
 /.claude/
+.flaker/
 index.lock
 *.cwasm
 .vibe_bench_stat_*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,25 @@ gh issue create --title "タイトル" --label bug
 
 設計判断は `docs/adr.md` に記録する。旧個別ファイルは `docs/archive/adr/`。
 
+## Local Test Execution
+
+ローカルでのテスト実行には `flaker run` を使う。全テスト（1162件、~2分）を毎回流す必要はない。
+
+```bash
+# 変更に影響するテストだけ実行（推奨、時間制約120秒）
+flaker run
+
+# CI と同じ hybrid サンプリング（30%）
+flaker run --profile ci
+
+# 全テスト実行（データ蓄積用、定期的に）
+flaker run --profile scheduled
+```
+
+`flaker run` はデフォルトで `--profile local`（affected 戦略）を使い、`git diff` から影響範囲のテストだけを選択する。データが蓄積されるほど選択精度が上がる。
+
+`just test` は全テスト実行。commit 前の最終確認や CI 用。
+
 ## Before Commit
 
 ```bash

--- a/flaker.toml
+++ b/flaker.toml
@@ -1,0 +1,47 @@
+[repo]
+owner = "mizchi"
+name = "vibe-lang"
+
+[storage]
+path = ".flaker/data.duckdb"
+
+[adapter]
+type = "custom"
+command = "moon test --target js"
+
+[runner]
+type = "moontest"
+command = "moon test --target js -v"
+
+[affected]
+resolver = "moon"
+config = ""
+
+[quarantine]
+auto = true
+flaky_rate_threshold = 0.3
+min_runs = 5
+
+[flaky]
+window_days = 14
+detection_threshold = 0.1
+
+[sampling]
+strategy = "hybrid"
+percentage = 30
+holdout_ratio = 0.1
+co_failure_days = 90
+
+[profile.scheduled]
+strategy = "full"
+
+[profile.ci]
+strategy = "hybrid"
+percentage = 30
+adaptive = true
+adaptive_min_percentage = 15
+
+[profile.local]
+strategy = "affected"
+max_duration_seconds = 120
+fallback_strategy = "weighted"

--- a/flaker.toml
+++ b/flaker.toml
@@ -6,8 +6,8 @@ name = "vibe-lang"
 path = ".flaker/data.duckdb"
 
 [adapter]
-type = "custom"
-command = "moon test --target js"
+type = "moontest"
+artifact_name = "moontest-results"
 
 [runner]
 type = "moontest"


### PR DESCRIPTION
## Summary

- `flaker.toml` で moontest runner/resolver と三段階プロファイル（scheduled/ci/local）を設定
- `AGENTS.md` にローカルテスト実行で `flaker run` を使うガイドを追加
- `.gitignore` に `.flaker/` を追加

## Background

テストが 1162 件、フル実行 ~2分。変更のたびに全テストを流すのは非効率。flaker は変更の影響範囲に基づいてテストを選択し、ローカル実行を高速化する。

## Usage

```bash
# 変更に影響するテストだけ実行（推奨）
flaker run

# CI と同じ hybrid サンプリング
flaker run --profile ci

# 全テスト実行（データ蓄積用）
flaker run --profile scheduled
```

## Test plan

- [x] `flaker run --profile scheduled` で全 1162 テスト実行確認
- [x] `flaker sample --profile local` で affected 選択確認
- [ ] 日常の開発で `flaker run` を使って体感を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)