### PR TITLE
Add flaker CI workflows for sampled test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,21 @@ jobs:
           just --version
 
 
+      - name: Moon update
+        run: moon update
+
+      - name: Run moon test (verbose, for flaker)
+        run: |
+          moon test --target js -v 2>&1 | tee .flaker-test-output.txt || true
+
+      - name: Upload test results for flaker
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: moontest-results
+          path: .flaker-test-output.txt
+          retention-days: 30
+
       - name: PR contract checks (MoonBit/js)
         run: just ci-contract-moon
 

--- a/.github/workflows/flaker-ci.yml
+++ b/.github/workflows/flaker-ci.yml
@@ -2,6 +2,7 @@ name: flaker-ci
 
 on:
   pull_request:
+  workflow_dispatch:
 
 env:
   VIBE_MOON_WARN_LIST: "-1-6-7-9-20-24-29"

--- a/.github/workflows/flaker-ci.yml
+++ b/.github/workflows/flaker-ci.yml
@@ -1,0 +1,68 @@
+name: flaker-ci
+
+on:
+  pull_request:
+
+env:
+  VIBE_MOON_WARN_LIST: "-1-6-7-9-20-24-29"
+
+jobs:
+  sampled-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install MoonBit
+        run: bash scripts/install_moonbit.sh
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Install just
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install flaker
+        run: pnpm add -g @mizchi/flaker
+
+      - name: Moon update
+        run: moon update
+
+      - name: Cache MoonBit build
+        uses: actions/cache@v5
+        with:
+          path: |
+            _build
+            .mooncakes
+          key: moonbit-${{ runner.os }}-${{ hashFiles('moon.mod.json', 'src/**/*.mbt') }}
+          restore-keys: moonbit-${{ runner.os }}-
+
+      - name: Restore flaker DB
+        uses: actions/cache/restore@v4
+        with:
+          path: .flaker/
+          key: flaker-db-main
+          restore-keys: flaker-db-
+
+      - name: Sampled test run
+        run: flaker run --profile ci
+
+      - name: Save flaker DB
+        uses: actions/cache/save@v4
+        with:
+          path: .flaker/
+          key: flaker-db-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}

--- a/.github/workflows/flaker-scheduled.yml
+++ b/.github/workflows/flaker-scheduled.yml
@@ -2,7 +2,7 @@ name: flaker-scheduled
 
 on:
   schedule:
-    - cron: '0 3 * * 1'  # Weekly Monday 3am UTC
+    - cron: '0 3 * * *'  # Daily 3am UTC
   workflow_dispatch:
 
 env:

--- a/.github/workflows/flaker-scheduled.yml
+++ b/.github/workflows/flaker-scheduled.yml
@@ -1,0 +1,77 @@
+name: flaker-scheduled
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'  # Weekly Monday 3am UTC
+  workflow_dispatch:
+
+env:
+  VIBE_MOON_WARN_LIST: "-1-6-7-9-20-24-29"
+
+jobs:
+  full-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install MoonBit
+        run: bash scripts/install_moonbit.sh
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Install just
+        run: |
+          JUST_VERSION=1.48.1
+          curl -fsSL --retry 5 --retry-all-errors \
+            -o /tmp/just.tar.gz \
+            "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          tar -xzf /tmp/just.tar.gz -C /tmp just
+          sudo install -m 0755 /tmp/just /usr/local/bin/just
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install flaker
+        run: pnpm add -g @mizchi/flaker
+
+      - name: Moon update
+        run: moon update
+
+      - name: Cache MoonBit build
+        uses: actions/cache@v5
+        with:
+          path: |
+            _build
+            .mooncakes
+          key: moonbit-${{ runner.os }}-${{ hashFiles('moon.mod.json', 'src/**/*.mbt') }}
+          restore-keys: moonbit-${{ runner.os }}-
+
+      - name: Restore flaker DB
+        uses: actions/cache/restore@v4
+        with:
+          path: .flaker/
+          key: flaker-db-main
+          restore-keys: flaker-db-
+
+      - name: Full test run
+        run: flaker run --profile scheduled
+
+      - name: Save flaker DB
+        uses: actions/cache/save@v4
+        with:
+          path: .flaker/
+          key: flaker-db-main-${{ github.run_id }}
+
+      - name: Upload DB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaker-db
+          path: .flaker/
+          retention-days: 30


### PR DESCRIPTION
## Summary

- `flaker-scheduled.yml`: 週次フルテスト実行。`.flaker/` DB を cache + artifact に保存
- `flaker-ci.yml`: PR で sampled テスト実行（~30%）。scheduled の cache から DB を復元

## Architecture

```
scheduled (weekly)
  └→ flaker run --profile scheduled (全テスト)
  └→ cache save + artifact upload

PR push
  └→ cache restore (scheduled のデータ)
  └→ flaker run --profile ci (30% サンプリング)
```

flaker の MoonTestRunner が `moon test --filter "..."` を組み立てるので、CI 側でフィルタロジックを持つ必要なし。

## Dependencies

- mizchi/vibe-lang#242 (flaker.toml セットアップ)

## Test plan

- [ ] workflow_dispatch で flaker-scheduled を手動実行して DB が蓄積されることを確認
- [ ] PR で flaker-ci が動いてサンプリング結果が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)