### PR TITLE
fix: prefer debug binary in coverage-selfhost-suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,7 +666,9 @@ jobs:
 
 
       - name: Build vibe CLI (native)
-        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+        run: |
+          VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+          VIBE_CLI_RELEASE=0 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
 
       - name: Run selfhost perf KPI
         env:

--- a/scripts/coverage_selfhost_suite.sh
+++ b/scripts/coverage_selfhost_suite.sh
@@ -26,8 +26,8 @@ resolve_vibe_cmd() {
     return 0
   fi
   candidates+=(
-    "$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
     "$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe"
+    "$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
     "$PROJECT_ROOT/target/native/release/build/cmd/vibe/vibe.exe"
     "$PROJECT_ROOT/target/native/debug/build/cmd/vibe/vibe.exe"
   )
@@ -359,6 +359,11 @@ if suite_cache_valid; then
   fi
 else
   set +e
+  echo "[suite] testing without VIBE_TEST_BACKEND" >&2
+  printf 'test "hello" { assert(1 == 1) }\n' > /tmp/_vibe_diag.vibe
+  "${VIBE_CMD[@]}" test /tmp/_vibe_diag.vibe 2>&1 || true
+  echo "[suite] testing with VIBE_TEST_BACKEND=$TEST_BACKEND" >&2
+  VIBE_TEST_BACKEND="$TEST_BACKEND" "${VIBE_CMD[@]}" test /tmp/_vibe_diag.vibe 2>&1 || true
   VIBE_TEST_BACKEND="$TEST_BACKEND" \
     VIBE_SELFHOST_SUITE_REPORT_LIST="$report_list_path" \
     VIBE_SELFHOST_SUITE_REPORT_JSON="$report_json_path" \


### PR DESCRIPTION
## Finding: vibe test crashes on freshly built binaries

After investigation, the `vibe test` command crashes with SIGABRT on **all freshly built binaries** (both debug and release). The binary order swap alone doesn't fix it.

### Evidence
- Debug binary (cached): `vibe test` → `ok (1/1)` ✓
- Debug binary (freshly built with `VIBE_CLI_FORCE=1`): `vibe test` → `Aborted (core dumped)` ✗
- Release binary (freshly built): `vibe test` → `Aborted (core dumped)` ✗
- `VIBE_TEST_BACKEND` env var has no effect on the crash

### Root cause
The `vibe test` command has a regression that causes SIGABRT on all builds. The `coverage-selfhost-suite` CI job is the only job that uses `vibe test` — other jobs (`contract-native`, `selfhost-examples`) use `vibe run` or custom test scripts.

### Next steps
- Investigate the `vibe test` command implementation in `src/cmd/vibe/cli_test_cmd.mbt`
- The issue has existed on main since at least April 5

## Original fix (still valid)
Swap debug binary before release binary in `resolve_vibe_cmd()`. This doesn't fix the crash but is the correct preference order.