### PR TITLE
fix: call init_hooks() in vibe test command

### DIFF
--- a/src/cmd/vibe/cli_test_cmd.mbt
+++ b/src/cmd/vibe/cli_test_cmd.mbt
@@ -733,6 +733,7 @@ fn test_cmd(
   args : Array[String],
   features : @runtime.RuntimeFeatureFlags,
 ) -> Unit {
+  @runtime_compile.init_hooks()
   if has_help_flag(args) {
     print_test_help()
     return


### PR DESCRIPTION
## Problem

`vibe test` crashes with SIGABRT on all freshly built binaries (both debug and release). This causes `coverage-selfhost-suite` CI job to fail and breaks `contract-native` test scripts that use `vibe test`.

## Root Cause

Commit `61b8f5ef` (refactor: decouple runtime from direct parser/checker calls #188) introduced `assert_hooks_initialized()` checks in `hook_init_runtime_type_env()` and other hook functions. These functions abort() if compiler hooks haven't been initialized via `init_hooks()`.

The `test_cmd` function creates a VibeDb → Runtime → calls `hook_init_runtime_type_env()` without first calling `@runtime_compile.init_hooks()`.

Other commands (`compile`, `check`) call `init_hooks()` explicitly, but `test` was missed.

## Fix

Add `@runtime_compile.init_hooks()` at the start of `test_cmd()`.

## Verification

```bash
# Before fix: SIGABRT
vibe test /tmp/test.vibe

# After fix: ok
vibe test /tmp/test.vibe
```