### PR TITLE
fix: add init_hooks() to run, repl, and bench commands

### DIFF
--- a/src/cmd/vibe/cli_bench.mbt
+++ b/src/cmd/vibe/cli_bench.mbt
@@ -143,6 +143,7 @@ fn bench_cmd(
   _syntax_mode : @runtime.ParserMode,
   features : @runtime.RuntimeFeatureFlags,
 ) -> Unit {
+  @runtime_compile.init_hooks()
   ignore(features)
   if has_help_flag(args) {
     print_bench_help()

--- a/src/cmd/vibe/cli_repl.mbt
+++ b/src/cmd/vibe/cli_repl.mbt
@@ -6,6 +6,7 @@ fn repl_cmd(
   enable_llm~ : Bool,
   permissions? : @capability.CapabilitySet? = None,
 ) -> Unit {
+  @runtime_compile.init_hooks()
   let mut tui_mode = false
   let mut ai_mode = false
   let mut posix_mode = true // default: posix mode (shell commands available)

--- a/src/cmd/vibe/cli_run_cmd.mbt
+++ b/src/cmd/vibe/cli_run_cmd.mbt
@@ -1009,6 +1009,7 @@ fn run_cmd(
   _features : @runtime.RuntimeFeatureFlags,
   enable_llm~ : Bool,
 ) -> Unit {
+  @runtime_compile.init_hooks()
   let _ = enable_llm
   if has_help_flag(args) {
     print_run_help()


### PR DESCRIPTION
## Follow-up to #252

PR #252 added `init_hooks()` to `test_cmd` which fixed `vibe test` crashes. But the same issue affects `vibe run`, `vibe repl`, and `vibe bench` — they also create a VibeDb which calls `hook_init_runtime_type_env()`.

## Changes

- `cli_run_cmd.mbt`: add `@runtime_compile.init_hooks()` to `run_cmd`
- `cli_repl.mbt`: add `@runtime_compile.init_hooks()` to `repl_cmd`
- `cli_bench.mbt`: add `@runtime_compile.init_hooks()` to `bench_cmd`

## Fixes

- `contract-native`: e2e-parity and repl-parity tests that use `vibe run` / `vibe repl`
- `selfhost-gates (check)`: if the crash was from hooks, not release binary bug