### PR TITLE
fix: centralized init_hooks() in CLI entry point

### DIFF
--- a/src/cmd/vibe/cli.mbt
+++ b/src/cmd/vibe/cli.mbt
@@ -25,6 +25,7 @@ pub fn run(args : Array[String]) -> Unit {
     parsed.unstable_threads,
   )
   let enable_llm = parsed.enable_llm
+  @runtime_compile.init_hooks()
   match cmd {
     "run" => run_cmd(cmd_args, syntax_mode, runtime_features, enable_llm~)
     "eval" => eval_cmd(cmd_args, runtime_features, enable_llm~)


### PR DESCRIPTION
## Follow-up to #252 and #253

PR #253 added `init_hooks()` to `run_cmd`, `repl_cmd`, and `bench_cmd`, but missed `shell-stdin` (`repl_stdin_cmd`), `eval`, and other commands. This caused `contract-native` e2e-parity and repl-parity tests to still fail.

Instead of adding `init_hooks()` to every individual command, this PR adds it once at the top of `cli.mbt:run()` — the centralized CLI dispatcher. This ensures ALL commands have hooks initialized before any VibeDb usage.

The `init_hooks()` function is idempotent (checks `hooks_initialized.val` flag), so the individual calls added in #253 are harmless but now redundant.