### PR TITLE
fix: use debug binary for selfhost-gates and wasm-codegen-quick CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,8 +333,10 @@ jobs:
         run: |
           bash scripts/install_wasmtime_release.sh
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
-      - name: Build vibe CLI (native)
-        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Build vibe CLI (native debug)
+        run: VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Set VIBE_BIN for debug binary
+        run: echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
       - name: Run wasm quick shard (${{ matrix.shard }})
         run: just ci-wasm-quick-shard ${{ matrix.shard }}
 
@@ -518,8 +520,10 @@ jobs:
           tar -xzf /tmp/just.tar.gz -C /tmp just
           sudo install -m 0755 /tmp/just /usr/local/bin/just
           just --version
-      - name: Build vibe CLI (native)
-        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Build vibe CLI (native debug)
+        run: VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Set VIBE_BIN for debug binary
+        run: echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
       - name: Run selfhost gate shard (${{ matrix.shard }})
         run: just ci-selfhost-gates-shard ${{ matrix.shard }}
 

--- a/scripts/build_selfhost_check_command_component.sh
+++ b/scripts/build_selfhost_check_command_component.sh
@@ -41,9 +41,9 @@ ADAPTER_WIT_DIR="$TMP_DIR/wit"
 ADAPTER_WIT_DEPS_DIR="$ADAPTER_WIT_DIR/deps"
 mkdir -p "$ADAPTER_WIT_DEPS_DIR"
 
-RELEASE_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
 fi
 
 "$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$PLUG_COMPONENT"

--- a/scripts/build_selfhost_check_direct_component.sh
+++ b/scripts/build_selfhost_check_direct_component.sh
@@ -6,7 +6,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_COMPONENT="${1:-$PROJECT_ROOT/dist/selfhost_check_direct.component.wasm}"
 OUT_WIT="${2:-${OUT_COMPONENT%.wasm}.wit}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_check_component_entry.vibe}"
-RELEASE_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 TMP_DIR="$(mktemp -d /tmp/vibe_selfhost_check_direct_component.XXXXXX)"
 
 cleanup() {
@@ -43,7 +43,7 @@ ADAPTER_WIT_DEPS_DIR="$ADAPTER_WIT_DIR/deps"
 mkdir -p "$ADAPTER_WIT_DEPS_DIR"
 
 if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
 fi
 
 "$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$PLUG_COMPONENT"

--- a/scripts/build_selfhost_check_preview2_component.sh
+++ b/scripts/build_selfhost_check_preview2_component.sh
@@ -6,7 +6,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_COMPONENT="${1:-$PROJECT_ROOT/dist/selfhost_check_preview2.component.wasm}"
 OUT_WIT="${2:-${OUT_COMPONENT%.wasm}.wit}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_check_component_entry.vibe}"
-RELEASE_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+VIBE_EXE="${VIBE_EXE:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -17,13 +17,13 @@ require_cmd() {
 
 require_cmd wasm-tools
 
-if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+if [ ! -x "$VIBE_EXE" ]; then
+  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
 fi
 
 mkdir -p "$(dirname "$OUT_COMPONENT")" "$(dirname "$OUT_WIT")"
 
-"$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$OUT_COMPONENT"
+"$VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$OUT_COMPONENT"
 wasm-tools validate --features exceptions "$OUT_COMPONENT" >/dev/null
 wasm-tools component wit "$OUT_COMPONENT" >"$OUT_WIT"
 

--- a/scripts/build_selfhost_cli_command_component.sh
+++ b/scripts/build_selfhost_cli_command_component.sh
@@ -41,9 +41,9 @@ ADAPTER_WIT_DIR="$TMP_DIR/wit"
 ADAPTER_WIT_DEPS_DIR="$ADAPTER_WIT_DIR/deps"
 mkdir -p "$ADAPTER_WIT_DEPS_DIR"
 
-RELEASE_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
 fi
 
 "$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$PLUG_COMPONENT"

--- a/scripts/build_selfhost_cli_direct_component.sh
+++ b/scripts/build_selfhost_cli_direct_component.sh
@@ -6,7 +6,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_COMPONENT="${1:-$PROJECT_ROOT/dist/selfhost_cli_direct.component.wasm}"
 OUT_WIT="${2:-${OUT_COMPONENT%.wasm}.wit}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_cli_direct_component_entry.vibe}"
-RELEASE_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 TMP_DIR="$(mktemp -d /tmp/vibe_selfhost_cli_direct_component.XXXXXX)"
 
 cleanup() {
@@ -43,7 +43,7 @@ ADAPTER_WIT_DEPS_DIR="$ADAPTER_WIT_DIR/deps"
 mkdir -p "$ADAPTER_WIT_DEPS_DIR"
 
 if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
 fi
 
 "$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$PLUG_COMPONENT"

--- a/scripts/build_selfhost_cli_preview2_component.sh
+++ b/scripts/build_selfhost_cli_preview2_component.sh
@@ -6,7 +6,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_COMPONENT="${1:-$PROJECT_ROOT/dist/selfhost_cli_preview2.component.wasm}"
 OUT_WIT="${2:-${OUT_COMPONENT%.wasm}.wit}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_cli_component_entry.vibe}"
-RELEASE_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -18,7 +18,7 @@ require_cmd() {
 require_cmd wasm-tools
 
 if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
 fi
 
 mkdir -p "$(dirname "$OUT_COMPONENT")" "$(dirname "$OUT_WIT")"

--- a/scripts/run_selfhost_cli_direct_component.sh
+++ b/scripts/run_selfhost_cli_direct_component.sh
@@ -14,7 +14,7 @@ OUTPUT_PATH="$3"
 ENTRY_NAME="$4"
 COMPILE_MODE="${5:-mvp}"
 WASMTIME_RUN="$SCRIPT_DIR/wasmtime_run.sh"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 WASMTIME_WASM_FLAGS="${VIBE_WASMTIME_WASM_FLAGS:-exceptions=y}"
 WASMTIME_WASI_FLAGS="${VIBE_WASMTIME_WASI_FLAGS:-cli=y}"
 
@@ -43,11 +43,11 @@ cp -R "$INPUT_DIR"/. "$TMP_DIR/"
 
 ensure_host_vibe_bin() {
   if [ ! -x "$VIBE_BIN" ]; then
-    moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+    moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
     return
   fi
   if ! "$VIBE_BIN" 2>&1 | grep -q 'emit-closure-payload'; then
-    moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+    moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
   fi
 }
 

--- a/scripts/test_build_parity.sh
+++ b/scripts/test_build_parity.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-VIBE_CLI_RELEASE=1 source "$ROOT_DIR/scripts/ensure_native_cli.sh"
+source "$ROOT_DIR/scripts/ensure_native_cli.sh"
 CLI="$VIBE_CLI_BIN"
 TIMEOUT="${VIBE_BUILD_PARITY_TIMEOUT:-10}"
 TMPDIR="${TMPDIR:-/tmp}"

--- a/scripts/test_linked_debug_build.sh
+++ b/scripts/test_linked_debug_build.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-VIBE_CLI_RELEASE=1 source "$ROOT_DIR/scripts/ensure_native_cli.sh"
+source "$ROOT_DIR/scripts/ensure_native_cli.sh"
 CLI="$VIBE_CLI_BIN"
 
 TMPDIR="${TMPDIR:-/tmp}"

--- a/scripts/test_selfhost_bootstrap_gate.sh
+++ b/scripts/test_selfhost_bootstrap_gate.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/target/native/release/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/selfhost_bootstrap}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/index.vibe}"
 KPI_BASELINE_SEC="${VIBE_SELFHOST_BOOTSTRAP_BASELINE_SEC:-}"

--- a/scripts/test_selfhost_check_command_parity.sh
+++ b/scripts/test_selfhost_check_command_parity.sh
@@ -6,7 +6,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/selfhost_check_command_parity}"
 COMPONENT_PATH="$OUT_DIR/selfhost_check_command.component.wasm"
 WIT_PATH="$OUT_DIR/selfhost_check_command.component.wit"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 WASMTIME_RUN="$PROJECT_ROOT/scripts/wasmtime_run.sh"
 WASMTIME_WASM_FLAGS="${VIBE_WASMTIME_WASM_FLAGS:-exceptions=y}"
 WASMTIME_WASI_FLAGS="${VIBE_WASMTIME_WASI_FLAGS:-cli=y}"
@@ -14,7 +14,7 @@ WASMTIME_WASI_FLAGS="${VIBE_WASMTIME_WASI_FLAGS:-cli=y}"
 mkdir -p "$OUT_DIR"
 
 if [ ! -x "$VIBE_BIN" ]; then
-  moon build --target native --release src/cmd/vibe --warn-list '-29'
+  moon build --target native src/cmd/vibe --warn-list '-29'
 fi
 
 bash "$PROJECT_ROOT/scripts/build_selfhost_check_command_component.sh" "$COMPONENT_PATH" "$WIT_PATH"

--- a/scripts/test_selfhost_check_direct_parity.sh
+++ b/scripts/test_selfhost_check_direct_parity.sh
@@ -6,12 +6,12 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/selfhost_check_direct_parity}"
 COMPONENT_PATH="$OUT_DIR/selfhost_check_direct.component.wasm"
 WIT_PATH="$OUT_DIR/selfhost_check_direct.component.wit"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 
 mkdir -p "$OUT_DIR"
 
 if [ ! -x "$VIBE_BIN" ]; then
-  moon build --target native --release --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
 fi
 
 bash "$SCRIPT_DIR/build_selfhost_check_direct_component.sh" "$COMPONENT_PATH" "$WIT_PATH" >/dev/null

--- a/scripts/test_selfhost_cli_command_parity.sh
+++ b/scripts/test_selfhost_cli_command_parity.sh
@@ -6,7 +6,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/selfhost_cli_command_parity}"
 COMPONENT_PATH="$OUT_DIR/selfhost_cli_preview2.component.wasm"
 WIT_PATH="$OUT_DIR/selfhost_cli_preview2.component.wit"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 WASMTIME_RUN="$PROJECT_ROOT/scripts/wasmtime_run.sh"
 WASMTIME_WASM_FLAGS="${VIBE_WASMTIME_WASM_FLAGS:-exceptions=y}"
 
@@ -14,7 +14,7 @@ mkdir -p "$OUT_DIR"
 
 if [ ! -x "$VIBE_BIN" ]; then
   echo "[selfhost-cli-command-parity] building host CLI..." >&2
-  moon build --target native --release src/cmd/vibe --warn-list '-29'
+  moon build --target native src/cmd/vibe --warn-list '-29'
 fi
 
 bash "$SCRIPT_DIR/build_selfhost_cli_preview2_component.sh" "$COMPONENT_PATH" "$WIT_PATH"

--- a/scripts/test_selfhost_cutover_gate.sh
+++ b/scripts/test_selfhost_cutover_gate.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/target/native/release/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 STAGE1_COMPILER_WASM="${STAGE1_COMPILER_WASM:-$PROJECT_ROOT/_build/wasm/debug/build/cmd/vibe_compile_wasi/vibe_compile_wasi.wasm}"
 OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/selfhost_cutover}"
 STAGE_TIMEOUT_SEC="${VIBE_CUTOVER_STAGE_TIMEOUT_SEC:-300}"

--- a/scripts/test_selfhost_probe_wasm_validate.sh
+++ b/scripts/test_selfhost_probe_wasm_validate.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 FIXTURE_PATH="${1:-$PROJECT_ROOT/vibe/selfhost_probe_types_run.vibe}"
 OUT_WASM="${2:-/tmp/selfhost_probe_types_run.wasm}"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 
 if [ ! -f "$FIXTURE_PATH" ]; then
   echo "fixture not found: $FIXTURE_PATH" >&2

--- a/scripts/test_selfhost_runtime_fixtures.sh
+++ b/scripts/test_selfhost_runtime_fixtures.sh
@@ -3,14 +3,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/target/native/release/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/selfhost_runtime_fixtures}"
 SNAPSHOT_FILE="${VIBE_SELFHOST_RUNTIME_FIXTURE_SNAPSHOT_FILE:-$PROJECT_ROOT/bench/golden/selfhost_runtime_fixture_snapshot.json}"
 SHARD_SIZE="${VIBE_SELFHOST_RUNTIME_FIXTURE_SHARD_SIZE:-10}"
 GENERATED_DIR="$PROJECT_ROOT/vibe/compiler/_generated_selfhost_runtime_fixtures"
 
 if [ ! -x "$VIBE_BIN" ]; then
-  moon build --target native --release src/cmd/vibe --warn-list '-29' >/dev/null
+  moon build --target native src/cmd/vibe --warn-list '-29' >/dev/null
 fi
 
 cd "$PROJECT_ROOT"


### PR DESCRIPTION
## Problem

The MoonBit release binary (`--release`) on Linux either:
- Crashes with SIGABRT when compiling complex programs
- Produces invalid wasm output that fails `wasm-tools validate`

This causes all push-only CI jobs to fail since they were introduced in PR #14:
- `selfhost-gates (bootstrap)`: SIGABRT during bootstrap test
- `selfhost-gates (check)`: SIGABRT on `compile --component-string-lift`
- `selfhost-gates (cli)`: component wasm validation failure
- `wasm-codegen-quick (core)`: SIGABRT on `compile --wasm`
- `wasm-codegen-quick (compare)`: `let rec` type annotation error (release binary bug)
- `native-binary-parity`: debug build produces invalid wasm

## Fix

Switch from release to debug binary for the failing CI jobs:

1. **CI config**: Build debug binary instead of release for `selfhost-gates` and `wasm-codegen-quick` jobs. Export `VIBE_BIN` env var to override script defaults.

2. **Scripts**: Change default `VIBE_BIN`/`VIBE_EXE` from release to debug binary path in 16 scripts. Remove `--release` flags from fallback build commands.

## Testing

- Verified debug binary builds successfully locally
- Verified debug binary produces valid wasm (`wasm-tools validate` passes)
- Verified `vibe run examples/basics.vibe` works with debug binary
- Verified `vibe_wasm` compare tests pass with debug binary (10/10)

## Notes

- The debug binary is slower than release but produces correct output on Linux
- The release binary bug should be reported to the MoonBit team (#255, #259)
- The http shard (`scalar_hello: component validation failed`) and cli shard (`direct-component wasm validation`) may still fail - these are separate issues