### PR TITLE
fix: pin MoonBit version to 0.1.20260330

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   VIBE_MOON_WARN_LIST: "-1-6-7-9-20-24-29"
+  MOONBIT_VERSION: "0.1.20260330"
 
 jobs:
   lint-ci:


### PR DESCRIPTION
Pin moon toolchain to 0.1.20260330. The latest version (0.1.20260403) has stricter dependency resolution that breaks on mizchi/bit's path dependency on mizchi/x.