### PR TITLE
[codex] Fix wasm parity and wasm-gc regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,8 @@ jobs:
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
       - name: Build vibe CLI (native)
         run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Set VIBE_BIN for release binary
+        run: echo "VIBE_BIN=$(pwd)/_build/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
       - name: Run wasm parity suite (${{ matrix.name }})
         id: wasm_parity_suite
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,10 +387,10 @@ jobs:
         run: |
           bash scripts/install_wasmtime_release.sh
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
-      - name: Build vibe CLI (native)
-        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
-      - name: Set VIBE_BIN for release binary
-        run: echo "VIBE_BIN=$(pwd)/_build/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
+      - name: Build vibe CLI (native debug)
+        run: VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Set VIBE_BIN for debug binary
+        run: echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
       - name: Run wasm parity suite (${{ matrix.name }})
         id: wasm_parity_suite
         run: |

--- a/scripts/test_component_e2e.sh
+++ b/scripts/test_component_e2e.sh
@@ -63,8 +63,7 @@ decode_js_wasm_result() {
     const wasm = fs.readFileSync(process.argv[1]);
     WebAssembly.instantiate(wasm, {vibe: {}}).then(({instance}) => {
       const result = instance.exports._start();
-      // Raw core Wasm exports still use Vibe's tagged small-int representation.
-      const value = typeof result === 'bigint' ? Number(result >> 2n) : (result >> 2);
+      const value = typeof result === 'bigint' ? Number(result) : result;
       console.log(value);
     });
   " "$1" 2>/dev/null

--- a/scripts/test_handle_exception_wasm_match.sh
+++ b/scripts/test_handle_exception_wasm_match.sh
@@ -39,16 +39,13 @@ run_case() {
     return
   fi
 
-  local wasm_tagged
-  wasm_tagged="$(VIBE_WASMTIME_WASM_FLAGS='exceptions=y' "$WASMTIME_RUN" --invoke _start "$wasm" 2>/dev/null | grep -E '^-?[0-9]+$' | tail -n 1 || true)"
-  if [ -z "$wasm_tagged" ]; then
+  local wasm_result
+  wasm_result="$(VIBE_WASMTIME_WASM_FLAGS='exceptions=y' "$WASMTIME_RUN" --invoke _start "$wasm" 2>/dev/null | grep -E '^-?[0-9]+$' | tail -n 1 || true)"
+  if [ -z "$wasm_result" ]; then
     echo "FAIL: $name (wasmtime output missing)"
     failed=$((failed + 1))
     return
   fi
-
-  local wasm_result
-  wasm_result=$((wasm_tagged >> 2))
 
   if [ "$expected" = "$wasm_result" ]; then
     echo "PASS: $name => $wasm_result"
@@ -56,7 +53,7 @@ run_case() {
   else {
     echo "FAIL: $name"
     echo "  expected: $expected"
-    echo "  wasm:     $wasm_result (tagged: $wasm_tagged)"
+    echo "  wasm:     $wasm_result"
     failed=$((failed + 1))
   }
   fi

--- a/scripts/test_http_wasm_fallback.sh
+++ b/scripts/test_http_wasm_fallback.sh
@@ -60,21 +60,19 @@ VIBE
     return
   fi
 
-  local wasm_tagged
-  wasm_tagged="$(VIBE_WASMTIME_WASM_FLAGS='exceptions=y' "$WASMTIME_RUN" --invoke _start "$wasm" 2>/dev/null | grep -E '^-?[0-9]+$' | tail -n 1 || true)"
-  if [ -z "$wasm_tagged" ]; then
+  local wasm_result
+  wasm_result="$(VIBE_WASMTIME_WASM_FLAGS='exceptions=y' "$WASMTIME_RUN" --invoke _start "$wasm" 2>/dev/null | grep -E '^-?[0-9]+$' | tail -n 1 || true)"
+  if [ -z "$wasm_result" ]; then
     echo "FAIL: $name (wasmtime output missing)"
     failed=$((failed + 1))
     return
   fi
 
-  local wasm_result
-  wasm_result=$((wasm_tagged >> 2))
   if [ "$wasm_result" = "$expected" ]; then
     echo "PASS: $name => $wasm_result"
     passed=$((passed + 1))
   else
-    echo "FAIL: $name (expected=$expected, got=$wasm_result tagged=$wasm_tagged)"
+    echo "FAIL: $name (expected=$expected, got=$wasm_result)"
     failed=$((failed + 1))
   fi
 }

--- a/scripts/test_interpreter_wasm_match.sh
+++ b/scripts/test_interpreter_wasm_match.sh
@@ -199,14 +199,10 @@ for expr in "${test_cases[@]}"; do
   run_output=$($VIBE run "$TEMP_DIR/test.vibe" 2>/dev/null | grep "^last: " | sed 's/last: //')
   run_result="$run_output"
 
-  # Compile and run WASM with wasmtime directly (for tagged integer extraction)
+  # Compile and run WASM with wasmtime directly.
   if $VIBE compile --wasm "$TEMP_DIR/test.vibe" -o "$TEMP_DIR/test.wasm" 2>/dev/null; then
-    # Run with --invoke to get return value, untag integer (divide by 4)
-    wasm_tagged=$(WASMTIME_BIN="$WASMTIME_BIN" "$WASMTIME_RUN" --invoke _start "$TEMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning")
-    if [ -n "$wasm_tagged" ]; then
-      # Untag: shift right 2 bits (divide by 4)
-      wasm_result=$((wasm_tagged >> 2))
-    else
+    wasm_result=$(WASMTIME_BIN="$WASMTIME_BIN" "$WASMTIME_RUN" --invoke _start "$TEMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning")
+    if [ -z "$wasm_result" ]; then
       wasm_result="<no output>"
     fi
   else
@@ -220,7 +216,7 @@ for expr in "${test_cases[@]}"; do
   else
     echo "FAIL: $expr"
     echo "  run:  $run_result"
-    echo "  WASM: $wasm_result (tagged: ${wasm_tagged:-N/A})"
+    echo "  WASM: $wasm_result"
     failed=$((failed + 1))
   fi
 done

--- a/scripts/test_interpreter_wasm_match.sh
+++ b/scripts/test_interpreter_wasm_match.sh
@@ -191,17 +191,19 @@ for expr in "${test_cases[@]}"; do
     fi
   fi
   test_index=$((test_index + 1))
+  case_path="$TEMP_DIR/test_${test_index}.vibe"
+  wasm_path="$TEMP_DIR/test_${test_index}.wasm"
 
   # Create test file
-  echo "$expr" > "$TEMP_DIR/test.vibe"
+  echo "$expr" > "$case_path"
 
   # Get reference result via vibe run
-  run_output=$($VIBE run "$TEMP_DIR/test.vibe" 2>/dev/null | grep "^last: " | sed 's/last: //')
+  run_output=$($VIBE run "$case_path" 2>/dev/null | grep "^last: " | sed 's/last: //')
   run_result="$run_output"
 
   # Compile and run WASM with wasmtime directly.
-  if $VIBE compile --wasm "$TEMP_DIR/test.vibe" -o "$TEMP_DIR/test.wasm" 2>/dev/null; then
-    wasm_result=$(WASMTIME_BIN="$WASMTIME_BIN" "$WASMTIME_RUN" --invoke _start "$TEMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning")
+  if $VIBE compile --wasm "$case_path" -o "$wasm_path" 2>/dev/null; then
+    wasm_result=$(WASMTIME_BIN="$WASMTIME_BIN" "$WASMTIME_RUN" --invoke _start "$wasm_path" 2>/dev/null | grep -v "^warning")
     if [ -z "$wasm_result" ]; then
       wasm_result="<no output>"
     fi

--- a/scripts/test_wasm_compile_wasmtime.sh
+++ b/scripts/test_wasm_compile_wasmtime.sh
@@ -252,7 +252,7 @@ write_program_source() {
   printf "%s\n" "$vibe_code" > "$TMP_DIR/test.vibe"
 }
 
-# Helper: compile .vibe to .wasm, run with wasmtime, compare untagged result
+# Helper: compile .vibe to .wasm, run with wasmtime, compare raw result
 expect_wasmtime_result() {
   # Shard: skip tests not assigned to this shard
   if [ "$SHARD_TOTAL" -gt 1 ]; then
@@ -275,20 +275,18 @@ expect_wasmtime_result() {
     return
   fi
 
-  local wasm_tagged
-  wasm_tagged=$("$WASMTIME_RUN" --invoke _start "$TMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning") || true
+  local wasm_result
+  wasm_result=$("$WASMTIME_RUN" --invoke _start "$TMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning") || true
 
-  if [ -z "$wasm_tagged" ]; then
+  if [ -z "$wasm_result" ]; then
     log_fail "$test_name - wasmtime returned no output"
     return
   fi
 
-  local result=$((wasm_tagged >> 2))
-
-  if [ "$result" = "$expected_value" ]; then
+  if [ "$wasm_result" = "$expected_value" ]; then
     log_pass "$test_name (result: $expected_value)"
   else
-    log_fail "$test_name - expected $expected_value but got $result (tagged: $wasm_tagged)"
+    log_fail "$test_name - expected $expected_value but got $wasm_result"
   fi
 }
 
@@ -313,20 +311,18 @@ expect_wasmtime_program_result() {
     return
   fi
 
-  local wasm_tagged
-  wasm_tagged=$("$WASMTIME_RUN" --invoke _start "$TMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning") || true
+  local wasm_result
+  wasm_result=$("$WASMTIME_RUN" --invoke _start "$TMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning") || true
 
-  if [ -z "$wasm_tagged" ]; then
+  if [ -z "$wasm_result" ]; then
     log_fail "$test_name - wasmtime returned no output"
     return
   fi
 
-  local result=$((wasm_tagged >> 2))
-
-  if [ "$result" = "$expected_value" ]; then
+  if [ "$wasm_result" = "$expected_value" ]; then
     log_pass "$test_name (result: $expected_value)"
   else
-    log_fail "$test_name - expected $expected_value but got $result (tagged: $wasm_tagged)"
+    log_fail "$test_name - expected $expected_value but got $wasm_result"
   fi
 }
 
@@ -2099,20 +2095,18 @@ expect_wasmtime_result_exceptions() {
     return
   fi
 
-  local wasm_tagged
-  wasm_tagged=$(VIBE_WASMTIME_WASM_FLAGS="exceptions=y" "$WASMTIME_RUN" --invoke _start "$TMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning") || true
+  local wasm_result
+  wasm_result=$(VIBE_WASMTIME_WASM_FLAGS="exceptions=y" "$WASMTIME_RUN" --invoke _start "$TMP_DIR/test.wasm" 2>/dev/null | grep -v "^warning") || true
 
-  if [ -z "$wasm_tagged" ]; then
+  if [ -z "$wasm_result" ]; then
     log_fail "$test_name - wasmtime returned no output"
     return
   fi
 
-  local result=$((wasm_tagged >> 2))
-
-  if [ "$result" = "$expected_value" ]; then
+  if [ "$wasm_result" = "$expected_value" ]; then
     log_pass "$test_name (result: $expected_value)"
   else
-    log_fail "$test_name - expected $expected_value but got $result (tagged: $wasm_tagged)"
+    log_fail "$test_name - expected $expected_value but got $wasm_result"
   fi
 }
 

--- a/src/cmd/vibe/cli_cache.mbt
+++ b/src/cmd/vibe/cli_cache.mbt
@@ -92,7 +92,7 @@ fn save_source_hashes(
   hash_cache_path : String,
 ) -> Unit {
   let _ = cache_dir
-  let hashes = collect_source_hash_cache(db, entry, false)
+  let hashes = collect_source_hash_cache(db, entry, true)
   @os_fs.write_string_to_file(
     hash_cache_path,
     serialize_source_hash_cache(hashes),

--- a/src/cmd/vibe/cli_run_cmd.mbt
+++ b/src/cmd/vibe/cli_run_cmd.mbt
@@ -94,12 +94,20 @@ enum WasmRunValue {
 } derive(Show, Eq)
 
 ///|
+let cli_tagged_run_export_name = "_vibe_run_tagged"
+
+///|
 fn run_wasmtime_invoke_run_capture(
   runner : BenchWasmRunner,
   wasm_path : String,
   tmp_prefix : String,
 ) -> WasmtimeInvokeOutput {
-  run_wasmtime_invoke_named_capture(runner, wasm_path, tmp_prefix, "_start")
+  run_wasmtime_invoke_named_capture(
+    runner,
+    wasm_path,
+    tmp_prefix,
+    cli_tagged_run_export_name,
+  )
 }
 
 ///|
@@ -214,7 +222,11 @@ fn build_http_host_run_command(
   runner : HttpHostRunner,
   wasm_path : String,
 ) -> String {
-  build_http_host_run_command_with_invokes(runner, wasm_path, ["_start"])
+  build_http_host_run_command_with_invokes(
+    runner,
+    wasm_path,
+    [cli_tagged_run_export_name],
+  )
 }
 
 ///|
@@ -250,7 +262,7 @@ fn run_http_host_invoke_run_capture(
     runner,
     wasm_path,
     tmp_prefix,
-    ["_start"],
+    [cli_tagged_run_export_name],
   )
 }
 
@@ -814,7 +826,11 @@ fn run_cmd_wasm_linked(
       return Err(err)
     }
   }
-  let mut cmd = build_wasmtime_invoke_command(runner, wasm_path, "_start")
+  let mut cmd = build_wasmtime_invoke_command(
+    runner,
+    wasm_path,
+    cli_tagged_run_export_name,
+  )
   let seen : Map[String, Bool] = {}
   for li in cached_imports {
     if not(seen.contains(li.module_name)) {
@@ -832,7 +848,11 @@ fn run_cmd_wasm_linked(
         shell_quote_command_arg(li.module_name) +
         "=" +
         shell_quote_command_arg(lib_path)
-      cmd = cmd + " --invoke _start " + shell_quote_command_arg(wasm_path)
+      cmd = cmd +
+        " --invoke " +
+        cli_tagged_run_export_name +
+        " " +
+        shell_quote_command_arg(wasm_path)
     }
   }
   let out_path = wasm_path + ".out"

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -194,7 +194,7 @@ test "http host run command quotes default node wasm flag" {
     "/tmp/app.wasm",
   )
   assert_eq(
-    cmd, "\"/tmp/node\" \"--experimental-wasm-exnref\" \"/tmp/runner.js\" --invoke _start \"/tmp/app.wasm\"",
+    cmd, "\"/tmp/node\" \"--experimental-wasm-exnref\" \"/tmp/runner.js\" --invoke _vibe_run_tagged \"/tmp/app.wasm\"",
   )
 }
 
@@ -214,7 +214,7 @@ test "http host run command splits node wasm flags into quoted args" {
     "/tmp/app.wasm",
   )
   assert_eq(
-    cmd, "\"/tmp/node\" \"--experimental-wasm-exnref\" \"--trace-wasm\" \"/tmp/runner.js\" --invoke _start \"/tmp/app.wasm\"",
+    cmd, "\"/tmp/node\" \"--experimental-wasm-exnref\" \"--trace-wasm\" \"/tmp/runner.js\" --invoke _vibe_run_tagged \"/tmp/app.wasm\"",
   )
 }
 
@@ -3629,6 +3629,30 @@ test "source hash cache includes transitive imports" {
 }
 
 ///|
+test "save source hashes includes entry for linked cache" {
+  let root = wbtest_make_temp_dir("save_source_hashes_includes_entry")
+  let cache_dir = root + "/.vibe/debug/test"
+  let hash_path = cache_dir + "/source_hashes.txt"
+  let entry_path = root + "/main.vibe"
+  let dep_path = root + "/dep.vibe"
+  let db = @runtime.VibeDb::new()
+  db.set_source(entry_path, "import ./dep.vibe { dep }\nlet main = dep\n")
+  db.set_source(dep_path, "let dep = 1\n")
+  let _ = c_system(system_command_bytes("mkdir -p " + shell_quote_command_arg(cache_dir)))
+  save_source_hashes(db, entry_path, cache_dir, hash_path)
+  let saved = parse_source_hash_cache(
+    @os_fs.read_file_to_string(hash_path) catch { _ => "" },
+  )
+  assert_true(saved.contains(entry_path))
+  assert_true(saved.contains(dep_path))
+  wbtest_remove_if_exists(hash_path)
+  wbtest_remove_if_exists(cache_dir)
+  wbtest_remove_if_exists(root + "/.vibe/debug")
+  wbtest_remove_if_exists(root + "/.vibe")
+  wbtest_remove_if_exists(root)
+}
+
+///|
 test "run monolithic cache paths separate http mode" {
   let paths1 = run_monolithic_cache_paths("/tmp/project/src/main.vibe", false)
   let paths2 = run_monolithic_cache_paths("/tmp/project/src/main.vibe", true)
@@ -4031,6 +4055,11 @@ test "decode tagged wasm run value" {
   assert_eq(decode_tagged_wasm_run_value(168L), Some(WasmRunValue::Int(42L)))
   assert_eq(decode_tagged_wasm_run_value(7L), Some(WasmRunValue::Bool(true)))
   assert_eq(decode_tagged_wasm_run_value(3L), Some(WasmRunValue::Bool(false)))
+}
+
+///|
+test "cli tagged run export name stays stable" {
+  assert_eq(cli_tagged_run_export_name, "_vibe_run_tagged")
 }
 
 ///|

--- a/src/codegen/wasm_codegen_data.mbt
+++ b/src/codegen/wasm_codegen_data.mbt
@@ -1042,3 +1042,29 @@ fn compile_http_host_string_new_function(
     body: body.to_array(),
   }
 }
+
+///|
+fn compile_public_start_wrapper(run_func_index : Int) -> WasmFunc {
+  let body = ByteBuf::new()
+  let result_local = 0
+  emit_call(body, run_func_index)
+  emit_local_set(body, result_local)
+  // Public `_start` should expose raw integer results for Wasmtime/CLI parity.
+  // Keep non-int tagged values unchanged so object/string paths still work.
+  emit_local_get(body, result_local)
+  emit_i64_const_raw(body, 2L)
+  emit_i64_shr_s(body)
+  emit_local_get(body, result_local)
+  emit_local_get(body, result_local)
+  emit_i64_const_raw(body, tag_mask.to_int64())
+  emit_i64_and(body)
+  emit_i64_eqz(body)
+  emit_select(body)
+  emit_end(body)
+  WasmFunc::{
+    params: [],
+    locals: [ValueKind::I64],
+    results: [ValueKind::I64],
+    body: body.to_array(),
+  }
+}

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -122,7 +122,12 @@ fn collect_emittable_user_exports(ctx : CodegenCtx) -> Array[String] {
 }
 
 ///|
-fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
+fn build_module(
+  ctx : CodegenCtx,
+  funcs : Array[WasmFunc],
+  run_index : Int,
+  start_export_index : Int?,
+) -> Bytes {
   let buf = ByteBuf::new()
   // magic + version
   buf.push((0).to_byte())
@@ -1330,19 +1335,17 @@ fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
     (if export_funcref_table { 1 } else { 0 })
   let export_sec = ByteBuf::new()
   write_u32_leb(export_sec, export_count)
-  let run_index = func_import_count + funcs.length() - 1
-  let start_export_index = run_index - 1
   if emit_start {
+    let start_idx = start_export_index.unwrap_or(run_index)
     write_name(export_sec, "_start")
     export_sec.push((0).to_byte()) // func export
-    write_u32_leb(export_sec, start_export_index)
+    write_u32_leb(export_sec, start_idx)
     write_name(export_sec, "_vibe_run_tagged")
     export_sec.push((0).to_byte()) // func export
     write_u32_leb(export_sec, run_index)
   }
   let helper_count_before_run = (if need_cabi_realloc_export { 1 } else { 0 }) +
-    (if need_http_host_string_new_export { 1 } else { 0 }) +
-    (if emit_start { 1 } else { 0 })
+    (if need_http_host_string_new_export { 1 } else { 0 })
   let helper_base_func_index = run_index - helper_count_before_run
   if need_cabi_realloc_export {
     write_name(export_sec, "cabi_realloc")
@@ -3964,10 +3967,6 @@ fn emit_module_with_coverage(
     let _ = ensure_sig_index(ctx, host_string_new_sig)
     compiled_funcs.push(compile_http_host_string_new_function(ctx))
   }
-  if not(ctx.library_mode) {
-    let run_func_index = func_import_count(ctx) + compiled_funcs.length() + 1
-    compiled_funcs.push(compile_public_start_wrapper(run_func_index))
-  }
   // Set mut_captured_vars for the top-level run function
   ctx.mut_captured_vars = top_mut_captured
   // Restore top-level RC action maps (may have been overwritten by per-function actions)
@@ -3982,6 +3981,7 @@ fn emit_module_with_coverage(
       ctx.rc_post_actions = post
     }
   }
+  let run_func_array_index = compiled_funcs.length()
   compiled_funcs.push(
     compile_function(
       ctx,
@@ -3997,9 +3997,18 @@ fn emit_module_with_coverage(
       emit_rc_stmt_actions=ctx.enable_rc,
     ),
   )
+  let run_func_index = func_import_count(ctx) + run_func_array_index
+  let mut start_export_index = None
+  if not(ctx.library_mode) {
+    let start_idx = func_import_count(ctx) + compiled_funcs.length()
+    compiled_funcs.push(compile_public_start_wrapper(run_func_index))
+    start_export_index = Some(start_idx)
+  }
   @profiler.profiler_leave()
   @profiler.profiler_enter("codegen/build_module")
-  let bytes = build_module(ctx, compiled_funcs)
+  let bytes = build_module(
+    ctx, compiled_funcs, run_func_index, start_export_index,
+  )
   @profiler.profiler_leave()
   {
     bytes,

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -1317,7 +1317,7 @@ fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
   let emit_start = not(ctx.library_mode)
   // Library mode: export funcref table for linked builds
   let export_funcref_table = ctx.library_mode && has_funcref_table
-  let export_count = (if emit_start { 2 } else { 1 }) + // _start + memory, or just memory
+  let export_count = (if emit_start { 3 } else { 1 }) + // _start + _vibe_run_tagged + memory, or just memory
     user_export_count +
     exported_env_global_count +
     (if need_cabi_realloc_export { 1 } else { 0 }) +
@@ -1336,6 +1336,9 @@ fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
     write_name(export_sec, "_start")
     export_sec.push((0).to_byte()) // func export
     write_u32_leb(export_sec, start_export_index)
+    write_name(export_sec, "_vibe_run_tagged")
+    export_sec.push((0).to_byte()) // func export
+    write_u32_leb(export_sec, run_index)
   }
   let helper_count_before_run = (if need_cabi_realloc_export { 1 } else { 0 }) +
     (if need_http_host_string_new_export { 1 } else { 0 }) +

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -1331,13 +1331,15 @@ fn build_module(ctx : CodegenCtx, funcs : Array[WasmFunc]) -> Bytes {
   let export_sec = ByteBuf::new()
   write_u32_leb(export_sec, export_count)
   let run_index = func_import_count + funcs.length() - 1
+  let start_export_index = run_index - 1
   if emit_start {
     write_name(export_sec, "_start")
     export_sec.push((0).to_byte()) // func export
-    write_u32_leb(export_sec, run_index)
+    write_u32_leb(export_sec, start_export_index)
   }
   let helper_count_before_run = (if need_cabi_realloc_export { 1 } else { 0 }) +
-    (if need_http_host_string_new_export { 1 } else { 0 })
+    (if need_http_host_string_new_export { 1 } else { 0 }) +
+    (if emit_start { 1 } else { 0 })
   let helper_base_func_index = run_index - helper_count_before_run
   if need_cabi_realloc_export {
     write_name(export_sec, "cabi_realloc")
@@ -3958,6 +3960,10 @@ fn emit_module_with_coverage(
     }
     let _ = ensure_sig_index(ctx, host_string_new_sig)
     compiled_funcs.push(compile_http_host_string_new_function(ctx))
+  }
+  if not(ctx.library_mode) {
+    let run_func_index = func_import_count(ctx) + compiled_funcs.length() + 1
+    compiled_funcs.push(compile_public_start_wrapper(run_func_index))
   }
   // Set mut_captured_vars for the top-level run function
   ctx.mut_captured_vars = top_mut_captured

--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -8846,7 +8846,7 @@ fn compile_stmt_gc(
         emit_local_get_gc(buf, scrut_idx)
       }
     }
-    @core.Stmt::LetPatElse(pat~, expr~, else_body~, span~) => {
+    @core.Stmt::LetPatElse(pat~, expr~, else_body~, ..) => {
       let kind = infer_expr_kind_gc(ctx, fctx, expr)
       let scrut_idx = alloc_local_gc(fctx, kind)
       compile_expr_gc(ctx, fctx, buf, expr)

--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -1655,6 +1655,37 @@ fn track_closure_binding_gc(
 }
 
 ///|
+fn closure_call_sig_from_kind_gc(
+  ctx : GcCodegenCtx,
+  kind : GcValKind,
+  opname : String,
+) -> (Int, Int, Array[GcValKind], GcValKind) raise WasmGenError {
+  match kind {
+    GcValKind::Ref(struct_type_idx) =>
+      match ctx.types[struct_type_idx] {
+        GcTypeDef::Struct(fields~) =>
+          if fields.length() == 2 {
+            match fields[0] {
+              GcValKind::Ref(fn_type_idx) =>
+                match ctx.types[fn_type_idx] {
+                  GcTypeDef::Func(params~, result~) =>
+                    (struct_type_idx, fn_type_idx, params, result)
+                  _ =>
+                    raise WasmGenError::Unsupported(opname + " closure fn type")
+                }
+              _ =>
+                raise WasmGenError::Unsupported(opname + " closure callee type")
+            }
+          } else {
+            raise WasmGenError::Unsupported(opname + " closure struct arity")
+          }
+        _ => raise WasmGenError::Unsupported(opname + " closure kind")
+      }
+    _ => raise WasmGenError::Unsupported(opname + " expects closure")
+  }
+}
+
+///|
 fn gc_val_kind_from_type(
   ctx : GcCodegenCtx,
   ty : @core.Type,
@@ -1749,8 +1780,8 @@ fn gc_val_kind_from_type(
       GcValKind::Ref(struct_type_idx)
     }
     @core.Type::Param(_) =>
-      // Unresolved type parameter — treat as anyref in GC mode
-      GcValKind::AnyRef
+      // Generic payloads are boxed/ref-cast through eqref in GC mode.
+      GcValKind::EqRef
     @core.Type::Variant(_) => GcValKind::EqRef
     _ => raise WasmGenError::Unsupported("gc type: " + ty.to_string())
   }
@@ -2203,6 +2234,12 @@ fn infer_expr_kind_gc(
         "Double::to_i64_bits" => GcValKind::I64
         "Double::parse" => GcValKind::F64
         "Array::length" => GcValKind::I64
+        "Array::fold" | "fold" => {
+          if pos_args.length() != 3 {
+            raise WasmGenError::Unsupported("arity: Array::fold")
+          }
+          infer_expr_kind_gc(ctx, fctx, pos_args[1])
+        }
         "Array::get" => {
           if pos_args.length() != 2 {
             raise WasmGenError::Unsupported("arity: Array::get")
@@ -5342,6 +5379,90 @@ fn gc_array_elem_kind_from_kind(
 }
 
 ///|
+fn compile_array_fold_gc(
+  ctx : GcCodegenCtx,
+  fctx : GcFuncCtx,
+  buf : GcByteBuf,
+  array_expr : @core.Expr,
+  init_expr : @core.Expr,
+  func_expr : @core.Expr,
+) -> Unit raise WasmGenError {
+  let array_kind = infer_expr_kind_gc(ctx, fctx, array_expr)
+  let array_type_idx = gc_array_type_idx_from_kind(
+    ctx, array_kind, "Array::fold",
+  )
+  let elem_kind = gc_array_elem_kind_from_kind(ctx, array_kind, "Array::fold")
+  let result_kind = infer_expr_kind_gc(ctx, fctx, init_expr)
+  let closure_kind = infer_expr_kind_gc(ctx, fctx, func_expr)
+  let (closure_struct_type, fn_type_idx, fn_param_kinds, fn_result_kind) = closure_call_sig_from_kind_gc(
+    ctx, closure_kind, "Array::fold",
+  )
+  if fn_param_kinds.length() != 3 {
+    raise WasmGenError::Unsupported("Array::fold callback arity")
+  }
+
+  let array_local = alloc_local_gc(fctx, array_kind)
+  let closure_local = alloc_local_gc(fctx, closure_kind)
+  let acc_local = alloc_local_gc(fctx, result_kind)
+  let len_local = alloc_local_gc(fctx, GcValKind::I32)
+  let i_local = alloc_local_gc(fctx, GcValKind::I32)
+
+  compile_expr_gc(ctx, fctx, buf, array_expr)
+  if array_kind != GcValKind::Ref(array_type_idx) {
+    emit_coerce_top_gc(ctx, buf, array_kind, GcValKind::Ref(array_type_idx))
+  }
+  emit_local_set_gc(buf, array_local)
+
+  let init_kind = infer_expr_kind_gc(ctx, fctx, init_expr)
+  compile_expr_gc(ctx, fctx, buf, init_expr)
+  emit_coerce_top_gc(ctx, buf, init_kind, result_kind)
+  emit_local_set_gc(buf, acc_local)
+
+  compile_expr_gc(ctx, fctx, buf, func_expr)
+  emit_local_set_gc(buf, closure_local)
+
+  emit_local_get_gc(buf, array_local)
+  emit_array_len_gc(buf)
+  emit_local_set_gc(buf, len_local)
+
+  emit_i32_const_gc(buf, 0)
+  emit_local_set_gc(buf, i_local)
+
+  emit_block_gc(buf, None)
+  emit_loop_gc(buf, None)
+  emit_local_get_gc(buf, i_local)
+  emit_local_get_gc(buf, len_local)
+  emit_i32_ge_s_gc(buf)
+  emit_br_if_gc(buf, 1)
+
+  emit_local_get_gc(buf, closure_local)
+  emit_struct_get_gc(buf, closure_struct_type, 1)
+
+  emit_local_get_gc(buf, acc_local)
+  emit_coerce_top_gc(ctx, buf, result_kind, fn_param_kinds[1])
+
+  emit_local_get_gc(buf, array_local)
+  emit_local_get_gc(buf, i_local)
+  emit_array_get_gc(buf, array_type_idx)
+  emit_coerce_top_gc(ctx, buf, elem_kind, fn_param_kinds[2])
+
+  emit_local_get_gc(buf, closure_local)
+  emit_struct_get_gc(buf, closure_struct_type, 0)
+  emit_call_ref_gc(buf, fn_type_idx)
+  emit_coerce_top_gc(ctx, buf, fn_result_kind, result_kind)
+  emit_local_set_gc(buf, acc_local)
+
+  emit_local_get_gc(buf, i_local)
+  emit_i32_const_gc(buf, 1)
+  emit_i32_add_gc(buf)
+  emit_local_set_gc(buf, i_local)
+  emit_br_gc(buf, 0)
+  emit_end_gc(buf)
+  emit_end_gc(buf)
+  emit_local_get_gc(buf, acc_local)
+}
+
+///|
 fn compile_array_slice_gc(
   ctx : GcCodegenCtx,
   fctx : GcFuncCtx,
@@ -6787,6 +6908,19 @@ fn compile_expr_gc(
             raise WasmGenError::Unsupported("Array::length arity")
           }
           compile_len_gc(ctx, fctx, buf, pos_args[0])
+        }
+        "Array::fold" | "fold" => {
+          if pos_args.length() != 3 {
+            raise WasmGenError::Unsupported("Array::fold arity")
+          }
+          compile_array_fold_gc(
+            ctx,
+            fctx,
+            buf,
+            pos_args[0],
+            pos_args[1],
+            pos_args[2],
+          )
         }
         "Array::get" => {
           if pos_args.length() != 2 {

--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -1977,6 +1977,29 @@ fn infer_block_kind_gc(
           return kind
         }
       }
+      @core.Stmt::LetPatElse(pat~, expr~, ..) => {
+        let kind = infer_expr_kind_gc(ctx, temp_ctx, expr)
+        fn bind_pat_names(p : @core.Pat, k : GcValKind) -> Unit {
+          match p {
+            @core.Pat::Bind(name~, ..) =>
+              temp_ctx.locals[name] = { idx: 0, kind: k }
+            @core.Pat::Tuple(items~, ..) =>
+              for item in items {
+                bind_pat_names(item, GcValKind::EqRef)
+              }
+            @core.Pat::Ctor(args~, ..) =>
+              for arg in args {
+                bind_pat_names(arg, GcValKind::EqRef)
+              }
+            _ => ()
+          }
+        }
+
+        bind_pat_names(pat, kind)
+        if is_last {
+          return GcValKind::I32
+        }
+      }
       @core.Stmt::Expr(expr~, ..) =>
         if is_last {
           return infer_expr_kind_gc(ctx, temp_ctx, expr)
@@ -8632,6 +8655,27 @@ fn compile_stmt_gc(
       compile_pat_bind_gc(ctx, fctx, buf, scrut_idx, kind, pat)
       if is_last {
         emit_local_get_gc(buf, scrut_idx)
+      }
+    }
+    @core.Stmt::LetPatElse(pat~, expr~, else_body~, span~) => {
+      let kind = infer_expr_kind_gc(ctx, fctx, expr)
+      let scrut_idx = alloc_local_gc(fctx, kind)
+      compile_expr_gc(ctx, fctx, buf, expr)
+      emit_local_set_gc(buf, scrut_idx)
+      let else_kind = infer_block_kind_gc(ctx, fctx, else_body)
+      let match_result_kind = gc_common_kind(GcValKind::I32, else_kind)
+      compile_pat_cond_gc(ctx, fctx, buf, scrut_idx, kind, pat)
+      emit_if_gc(buf, Some(match_result_kind))
+      compile_pat_bind_gc(ctx, fctx, buf, scrut_idx, kind, pat)
+      emit_i32_const_gc(buf, 0)
+      emit_coerce_top_gc(ctx, buf, GcValKind::I32, match_result_kind)
+      emit_else_gc(buf)
+      compile_block_expr_gc(ctx, fctx, buf, else_body)
+      emit_coerce_top_gc(ctx, buf, else_kind, match_result_kind)
+      emit_end_gc(buf)
+      emit_drop_gc(buf)
+      if is_last {
+        emit_i32_const_gc(buf, 0)
       }
     }
     @core.Stmt::IndexAssign(target~, index~, value~, ..) => {

--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -193,6 +193,10 @@ priv struct GcFuncCtx {
   local_kinds : Array[GcValKind]
   param_count : Int
   closure_call_types : Map[String, Int]
+  current_rec_binding : String?
+  direct_rec_call_name : String?
+  direct_rec_call_func_idx : Int
+  direct_rec_call_type_idx : Int
 }
 
 ///|
@@ -1802,7 +1806,16 @@ fn GcFuncCtx::new(
     }
     idx += 1
   }
-  { locals, local_kinds, param_count: idx, closure_call_types }
+  {
+    locals,
+    local_kinds,
+    param_count: idx,
+    closure_call_types,
+    current_rec_binding: None,
+    direct_rec_call_name: None,
+    direct_rec_call_func_idx: -1,
+    direct_rec_call_type_idx: -1,
+  }
 }
 
 ///|
@@ -1847,6 +1860,10 @@ fn infer_block_kind_gc(
     local_kinds: [],
     param_count: fctx.param_count,
     closure_call_types: temp_cct,
+    current_rec_binding: None,
+    direct_rec_call_name: None,
+    direct_rec_call_func_idx: -1,
+    direct_rec_call_type_idx: -1,
   }
   for i in 0..<len {
     let stmt = body.stmts[i]
@@ -7556,208 +7573,240 @@ fn compile_expr_gc(
           emit_end_gc(buf)
           emit_local_get_gc(buf, result_l)
         }
-        _ =>
-          match ctx.func_indices.get(name) {
-            Some(idx) => {
-              // Skip arity check — bundler may produce mismatched counts
-              match ctx.func_param_kinds.get(name) {
-                Some(param_kinds) =>
+        _ => {
+          let handled_direct_rec = match fctx.direct_rec_call_name {
+            Some(rec_name) if name == rec_name => {
+              let call_param_kinds = match
+                ctx.types[fctx.direct_rec_call_type_idx] {
+                GcTypeDef::Func(params~, ..) => params
+                _ =>
+                  raise WasmGenError::Unsupported("direct recursive call type")
+              }
+              emit_local_get_gc(buf, 0)
+              for i in 0..<pos_args.length() {
+                let arg = pos_args[i]
+                let arg_kind = infer_expr_kind_gc(ctx, fctx, arg)
+                compile_expr_gc(ctx, fctx, buf, arg)
+                if i + 1 < call_param_kinds.length() {
+                  emit_coerce_top_gc(
+                    ctx,
+                    buf,
+                    arg_kind,
+                    call_param_kinds[i + 1],
+                  )
+                }
+              }
+              emit_call_gc(buf, fctx.direct_rec_call_func_idx)
+              true
+            }
+            _ => false
+          }
+          if !handled_direct_rec {
+            match ctx.func_indices.get(name) {
+              Some(idx) => {
+                // Skip arity check — bundler may produce mismatched counts
+                match ctx.func_param_kinds.get(name) {
+                  Some(param_kinds) =>
+                    for i in 0..<pos_args.length() {
+                      let arg = pos_args[i]
+                      let arg_kind = infer_expr_kind_gc(ctx, fctx, arg)
+                      compile_expr_gc(ctx, fctx, buf, arg)
+                      if i < param_kinds.length() {
+                        emit_coerce_top_gc(ctx, buf, arg_kind, param_kinds[i])
+                      }
+                    }
+                  None =>
+                    for arg in pos_args {
+                      compile_expr_gc(ctx, fctx, buf, arg)
+                    }
+                }
+                emit_call_gc(buf, idx)
+              }
+              None =>
+                if ctx.enum_ctor_tags.contains(name) {
+                  // Enum constructor call
+                  let tag = ctx.enum_ctor_tags[name]
+                  let type_idx = ctx.enum_ctor_type_indices[name]
+                  let payload_kinds = ctx.enum_ctor_field_kinds[name]
+                  emit_i32_const_gc(buf, tag)
                   for i in 0..<pos_args.length() {
                     let arg = pos_args[i]
                     let arg_kind = infer_expr_kind_gc(ctx, fctx, arg)
                     compile_expr_gc(ctx, fctx, buf, arg)
-                    if i < param_kinds.length() {
-                      emit_coerce_top_gc(ctx, buf, arg_kind, param_kinds[i])
+                    if i < payload_kinds.length() {
+                      emit_coerce_top_gc(ctx, buf, arg_kind, payload_kinds[i])
                     }
                   }
-                None =>
-                  for arg in pos_args {
-                    compile_expr_gc(ctx, fctx, buf, arg)
-                  }
-              }
-              emit_call_gc(buf, idx)
-            }
-            None =>
-              if ctx.enum_ctor_tags.contains(name) {
-                // Enum constructor call
-                let tag = ctx.enum_ctor_tags[name]
-                let type_idx = ctx.enum_ctor_type_indices[name]
-                let payload_kinds = ctx.enum_ctor_field_kinds[name]
-                emit_i32_const_gc(buf, tag)
-                for i in 0..<pos_args.length() {
-                  let arg = pos_args[i]
-                  let arg_kind = infer_expr_kind_gc(ctx, fctx, arg)
-                  compile_expr_gc(ctx, fctx, buf, arg)
-                  if i < payload_kinds.length() {
-                    emit_coerce_top_gc(ctx, buf, arg_kind, payload_kinds[i])
-                  }
-                }
-                emit_struct_new_gc(buf, type_idx)
-              } else {
-                // Check local closure bindings first (they shadow field accessors)
-                match fctx.closure_call_types.get(name) {
-                  Some(fn_type_idx) =>
-                    match fctx.locals.get(name) {
-                      Some(closure_info) => {
-                        let closure_struct_type = match closure_info.kind {
-                          GcValKind::Ref(idx) => idx
-                          _ => raise WasmGenError::Unsupported("closure kind")
-                        }
-                        let call_param_kinds = match ctx.types[fn_type_idx] {
-                          GcTypeDef::Func(params~, ..) => params
-                          _ =>
-                            raise WasmGenError::Unsupported("closure call type")
-                        }
-                        emit_local_get_gc(buf, closure_info.idx)
-                        emit_struct_get_gc(buf, closure_struct_type, 1)
-                        for i in 0..<pos_args.length() {
-                          let arg = pos_args[i]
-                          let arg_kind = infer_expr_kind_gc(ctx, fctx, arg)
-                          compile_expr_gc(ctx, fctx, buf, arg)
-                          if i + 1 < call_param_kinds.length() {
-                            emit_coerce_top_gc(
-                              ctx,
-                              buf,
-                              arg_kind,
-                              call_param_kinds[i + 1],
-                            )
+                  emit_struct_new_gc(buf, type_idx)
+                } else {
+                  // Check local closure bindings first (they shadow field accessors)
+                  match fctx.closure_call_types.get(name) {
+                    Some(fn_type_idx) =>
+                      match fctx.locals.get(name) {
+                        Some(closure_info) => {
+                          let closure_struct_type = match closure_info.kind {
+                            GcValKind::Ref(idx) => idx
+                            _ => raise WasmGenError::Unsupported("closure kind")
                           }
+                          let call_param_kinds = match ctx.types[fn_type_idx] {
+                            GcTypeDef::Func(params~, ..) => params
+                            _ =>
+                              raise WasmGenError::Unsupported(
+                                "closure call type",
+                              )
+                          }
+                          emit_local_get_gc(buf, closure_info.idx)
+                          emit_struct_get_gc(buf, closure_struct_type, 1)
+                          for i in 0..<pos_args.length() {
+                            let arg = pos_args[i]
+                            let arg_kind = infer_expr_kind_gc(ctx, fctx, arg)
+                            compile_expr_gc(ctx, fctx, buf, arg)
+                            if i + 1 < call_param_kinds.length() {
+                              emit_coerce_top_gc(
+                                ctx,
+                                buf,
+                                arg_kind,
+                                call_param_kinds[i + 1],
+                              )
+                            }
+                          }
+                          emit_local_get_gc(buf, closure_info.idx)
+                          emit_struct_get_gc(buf, closure_struct_type, 0)
+                          emit_call_ref_gc(buf, fn_type_idx)
                         }
-                        emit_local_get_gc(buf, closure_info.idx)
-                        emit_struct_get_gc(buf, closure_struct_type, 0)
-                        emit_call_ref_gc(buf, fn_type_idx)
+                        None => {
+                          // Closure type known but not in locals — trap
+                          for arg in pos_args {
+                            compile_expr_gc(ctx, fctx, buf, arg)
+                            emit_drop_gc(buf)
+                          }
+                          emit_unreachable_gc(buf)
+                        }
                       }
-                      None => {
-                        // Closure type known but not in locals — trap
+                    None =>
+                      if is_gc_builtin_name(name) {
+                        // Builtin/effect call — emit unreachable (trap at runtime)
                         for arg in pos_args {
                           compile_expr_gc(ctx, fctx, buf, arg)
                           emit_drop_gc(buf)
                         }
                         emit_unreachable_gc(buf)
-                      }
-                    }
-                  None =>
-                    if is_gc_builtin_name(name) {
-                      // Builtin/effect call — emit unreachable (trap at runtime)
-                      for arg in pos_args {
-                        compile_expr_gc(ctx, fctx, buf, arg)
-                        emit_drop_gc(buf)
-                      }
-                      emit_unreachable_gc(buf)
-                    } else {
-                      // Try to derive closure type from local's struct kind
-                      match fctx.locals.get(name) {
-                        Some(closure_info) =>
-                          match closure_info.kind {
-                            GcValKind::Ref(struct_idx) =>
-                              match ctx.types[struct_idx] {
-                                GcTypeDef::Struct(fields~) =>
-                                  if fields.length() == 2 {
-                                    match fields[0] {
-                                      GcValKind::Ref(fn_idx) =>
-                                        match ctx.types[fn_idx] {
-                                          GcTypeDef::Func(
-                                            params=call_param_kinds,
-                                            ..
-                                          ) => {
-                                            emit_local_get_gc(
-                                              buf,
-                                              closure_info.idx,
-                                            )
-                                            emit_struct_get_gc(
-                                              buf, struct_idx, 1,
-                                            )
-                                            for i in 0..<pos_args.length() {
-                                              let arg = pos_args[i]
-                                              let arg_kind = infer_expr_kind_gc(
-                                                ctx, fctx, arg,
+                      } else {
+                        // Try to derive closure type from local's struct kind
+                        match fctx.locals.get(name) {
+                          Some(closure_info) =>
+                            match closure_info.kind {
+                              GcValKind::Ref(struct_idx) =>
+                                match ctx.types[struct_idx] {
+                                  GcTypeDef::Struct(fields~) =>
+                                    if fields.length() == 2 {
+                                      match fields[0] {
+                                        GcValKind::Ref(fn_idx) =>
+                                          match ctx.types[fn_idx] {
+                                            GcTypeDef::Func(
+                                              params=call_param_kinds,
+                                              ..
+                                            ) => {
+                                              emit_local_get_gc(
+                                                buf,
+                                                closure_info.idx,
                                               )
-                                              compile_expr_gc(
-                                                ctx, fctx, buf, arg,
+                                              emit_struct_get_gc(
+                                                buf, struct_idx, 1,
                                               )
-                                              if i + 1 <
-                                                call_param_kinds.length() {
-                                                emit_coerce_top_gc(
-                                                  ctx,
-                                                  buf,
-                                                  arg_kind,
-                                                  call_param_kinds[i + 1],
+                                              for i in 0..<pos_args.length() {
+                                                let arg = pos_args[i]
+                                                let arg_kind = infer_expr_kind_gc(
+                                                  ctx, fctx, arg,
                                                 )
+                                                compile_expr_gc(
+                                                  ctx, fctx, buf, arg,
+                                                )
+                                                if i + 1 <
+                                                  call_param_kinds.length() {
+                                                  emit_coerce_top_gc(
+                                                    ctx,
+                                                    buf,
+                                                    arg_kind,
+                                                    call_param_kinds[i + 1],
+                                                  )
+                                                }
                                               }
-                                            }
-                                            emit_local_get_gc(
-                                              buf,
-                                              closure_info.idx,
-                                            )
-                                            emit_struct_get_gc(
-                                              buf, struct_idx, 0,
-                                            )
-                                            emit_call_ref_gc(buf, fn_idx)
-                                          }
-                                          _ => {
-                                            for arg in pos_args {
-                                              compile_expr_gc(
-                                                ctx, fctx, buf, arg,
+                                              emit_local_get_gc(
+                                                buf,
+                                                closure_info.idx,
                                               )
-                                              emit_drop_gc(buf)
+                                              emit_struct_get_gc(
+                                                buf, struct_idx, 0,
+                                              )
+                                              emit_call_ref_gc(buf, fn_idx)
                                             }
-                                            emit_unreachable_gc(buf)
+                                            _ => {
+                                              for arg in pos_args {
+                                                compile_expr_gc(
+                                                  ctx, fctx, buf, arg,
+                                                )
+                                                emit_drop_gc(buf)
+                                              }
+                                              emit_unreachable_gc(buf)
+                                            }
                                           }
+                                        _ => {
+                                          for arg in pos_args {
+                                            compile_expr_gc(ctx, fctx, buf, arg)
+                                            emit_drop_gc(buf)
+                                          }
+                                          emit_unreachable_gc(buf)
                                         }
-                                      _ => {
-                                        for arg in pos_args {
-                                          compile_expr_gc(ctx, fctx, buf, arg)
-                                          emit_drop_gc(buf)
-                                        }
-                                        emit_unreachable_gc(buf)
                                       }
+                                    } else {
+                                      for arg in pos_args {
+                                        compile_expr_gc(ctx, fctx, buf, arg)
+                                        emit_drop_gc(buf)
+                                      }
+                                      emit_unreachable_gc(buf)
                                     }
-                                  } else {
+                                  _ => {
                                     for arg in pos_args {
                                       compile_expr_gc(ctx, fctx, buf, arg)
                                       emit_drop_gc(buf)
                                     }
                                     emit_unreachable_gc(buf)
                                   }
-                                _ => {
-                                  for arg in pos_args {
-                                    compile_expr_gc(ctx, fctx, buf, arg)
-                                    emit_drop_gc(buf)
-                                  }
-                                  emit_unreachable_gc(buf)
                                 }
+                              _ => {
+                                for arg in pos_args {
+                                  compile_expr_gc(ctx, fctx, buf, arg)
+                                  emit_drop_gc(buf)
+                                }
+                                emit_unreachable_gc(buf)
                               }
-                            _ => {
+                            }
+                          None =>
+                            if pos_args.length() == 1 &&
+                              try_compile_struct_field_get_gc(
+                                ctx,
+                                fctx,
+                                buf,
+                                name,
+                                pos_args[0],
+                              ) {
+                              // Named struct field access: field_name(record) → struct.get
+                              () // already compiled by try_compile_struct_field_get_gc
+                            } else {
                               for arg in pos_args {
                                 compile_expr_gc(ctx, fctx, buf, arg)
                                 emit_drop_gc(buf)
                               }
                               emit_unreachable_gc(buf)
                             }
-                          }
-                        None =>
-                          if pos_args.length() == 1 &&
-                            try_compile_struct_field_get_gc(
-                              ctx,
-                              fctx,
-                              buf,
-                              name,
-                              pos_args[0],
-                            ) {
-                            // Named struct field access: field_name(record) → struct.get
-                            () // already compiled by try_compile_struct_field_get_gc
-                          } else {
-                            for arg in pos_args {
-                              compile_expr_gc(ctx, fctx, buf, arg)
-                              emit_drop_gc(buf)
-                            }
-                            emit_unreachable_gc(buf)
-                          }
+                        }
                       }
-                    }
+                  }
                 }
-              }
+            }
           }
+        }
       }
     }
     @core.Expr::If(cond~, then_body~, else_body~, span~) => {
@@ -7977,6 +8026,7 @@ fn compile_expr_gc(
       }
       let free : Map[String, Bool] = {}
       collect_free_vars_module_gc(body, bound, free)
+      let rec_binding = fctx.current_rec_binding
       // Also capture closure-typed call targets (let rec self-reference)
       let call_names : Map[String, Bool] = {}
       collect_call_names_module_gc(body, call_names)
@@ -7984,7 +8034,10 @@ fn compile_expr_gc(
         if fctx.closure_call_types.contains(cname) &&
           !bound.contains(cname) &&
           !free.contains(cname) {
-          free[cname] = true
+          match rec_binding {
+            Some(self_name) => if cname != self_name { free[cname] = true }
+            None => free[cname] = true
+          }
         }
       }
       let capture_names : Array[String] = []
@@ -8030,6 +8083,7 @@ fn compile_expr_gc(
       let (fn_type_idx, struct_type_idx) = ensure_closure_types_gc(
         ctx, param_kinds, result_kind,
       )
+      let func_idx = ctx.num_regular_funcs + ctx.closure_lifted_funcs.length()
       // Propagate closure_call_types from parent so let-rec and
       // captured closures can be called inside the lifted body.
       let lifted_closure_types : Map[String, Int] = {}
@@ -8041,6 +8095,10 @@ fn compile_expr_gc(
         local_kinds: [],
         param_count: 1 + params.length(),
         closure_call_types: lifted_closure_types,
+        current_rec_binding: None,
+        direct_rec_call_name: rec_binding,
+        direct_rec_call_func_idx: func_idx,
+        direct_rec_call_type_idx: fn_type_idx,
       }
       for i in 0..<params.length() {
         let k = gc_val_kind_from_type(ctx, params[i].ty)
@@ -8075,7 +8133,6 @@ fn compile_expr_gc(
         params: lifted_sig_params,
         result: result_kind,
       }
-      let func_idx = ctx.num_regular_funcs + ctx.closure_lifted_funcs.length()
       ctx.closure_lifted_funcs.push(GcWasmFunc::{
         sig: lifted_sig,
         locals: lifted_fctx.local_kinds,
@@ -8300,7 +8357,21 @@ fn compile_stmt_gc(
             let idx = bind_local_gc(fctx, name, kind)
             fctx.closure_call_types[name] = fn_type_idx
             track_closure_binding_gc(ctx, fctx, name, expr)
-            compile_expr_gc(ctx, fctx, buf, expr)
+            let rec_compile_cct : Map[String, Int] = {}
+            for k, v in fctx.closure_call_types {
+              rec_compile_cct[k] = v
+            }
+            let rec_compile_fctx = GcFuncCtx::{
+              locals: clone_locals_gc(fctx.locals),
+              local_kinds: [],
+              param_count: fctx.param_count,
+              closure_call_types: rec_compile_cct,
+              current_rec_binding: Some(name),
+              direct_rec_call_name: None,
+              direct_rec_call_func_idx: -1,
+              direct_rec_call_type_idx: -1,
+            }
+            compile_expr_gc(ctx, rec_compile_fctx, buf, expr)
             if is_last {
               emit_local_tee_gc(buf, idx)
             } else {

--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -190,6 +190,7 @@ priv struct GcLocalInfo {
 ///|
 priv struct GcFuncCtx {
   locals : Map[String, GcLocalInfo]
+  map_value_kinds : Map[String, GcValKind]
   local_kinds : Array[GcValKind]
   param_count : Int
   closure_call_types : Map[String, Int]
@@ -1793,6 +1794,7 @@ fn GcFuncCtx::new(
   params : Array[@core.FuncParam],
 ) -> GcFuncCtx raise WasmGenError {
   let locals : Map[String, GcLocalInfo] = {}
+  let map_value_kinds : Map[String, GcValKind] = {}
   let local_kinds : Array[GcValKind] = []
   let closure_call_types : Map[String, Int] = {}
   let mut idx = 0
@@ -1839,6 +1841,7 @@ fn GcFuncCtx::new(
   }
   {
     locals,
+    map_value_kinds,
     local_kinds,
     param_count: idx,
     closure_call_types,
@@ -1847,6 +1850,15 @@ fn GcFuncCtx::new(
     direct_rec_call_func_idx: -1,
     direct_rec_call_type_idx: -1,
   }
+}
+
+///|
+fn clone_kind_map_gc(src : Map[String, GcValKind]) -> Map[String, GcValKind] {
+  let out : Map[String, GcValKind] = {}
+  for k, v in src {
+    out[k] = v
+  }
+  out
 }
 
 ///|
@@ -1888,6 +1900,7 @@ fn infer_block_kind_gc(
   }
   let temp_ctx = GcFuncCtx::{
     locals: clone_locals_gc(fctx.locals),
+    map_value_kinds: clone_kind_map_gc(fctx.map_value_kinds),
     local_kinds: [],
     param_count: fctx.param_count,
     closure_call_types: temp_cct,
@@ -1925,6 +1938,10 @@ fn infer_block_kind_gc(
             _ => {
               let kind = infer_expr_kind_gc(ctx, temp_ctx, expr)
               temp_ctx.locals[name] = { idx: 0, kind }
+              match infer_map_value_kind_from_expr_gc(ctx, temp_ctx, expr) {
+                Some(value_kind) => temp_ctx.map_value_kinds[name] = value_kind
+                None => ()
+              }
               if is_last {
                 return kind
               }
@@ -1933,6 +1950,10 @@ fn infer_block_kind_gc(
         } else {
           let kind = infer_expr_kind_gc(ctx, temp_ctx, expr)
           temp_ctx.locals[name] = { idx: 0, kind }
+          match infer_map_value_kind_from_expr_gc(ctx, temp_ctx, expr) {
+            Some(value_kind) => temp_ctx.map_value_kinds[name] = value_kind
+            None => ()
+          }
           track_closure_binding_gc(ctx, temp_ctx, name, expr)
           if is_last {
             return kind
@@ -1941,6 +1962,10 @@ fn infer_block_kind_gc(
       @core.Stmt::LetMut(name~, expr~, ..) => {
         let kind = infer_expr_kind_gc(ctx, temp_ctx, expr)
         temp_ctx.locals[name] = { idx: 0, kind }
+        match infer_map_value_kind_from_expr_gc(ctx, temp_ctx, expr) {
+          Some(value_kind) => temp_ctx.map_value_kinds[name] = value_kind
+          None => ()
+        }
         track_closure_binding_gc(ctx, temp_ctx, name, expr)
         if is_last {
           return kind
@@ -1949,6 +1974,10 @@ fn infer_block_kind_gc(
       @core.Stmt::Assign(name~, expr~, ..) => {
         let kind = infer_expr_kind_gc(ctx, temp_ctx, expr)
         temp_ctx.locals[name] = { idx: 0, kind }
+        match infer_map_value_kind_from_expr_gc(ctx, temp_ctx, expr) {
+          Some(value_kind) => temp_ctx.map_value_kinds[name] = value_kind
+          None => ()
+        }
         if is_last {
           return kind
         }
@@ -2167,6 +2196,7 @@ fn infer_expr_kind_gc(
             raise WasmGenError::UnknownName(name)
           }
       }
+    @core.Expr::Map(..) => gc_map_builder_kind_gc(ctx)
     @core.Expr::Call(name~, args~, ..) => {
       let name = @core.lower_wasm_intrinsic_name(name)
       let pos_args = extract_positional_exprs(args, name)
@@ -2183,6 +2213,11 @@ fn infer_expr_kind_gc(
             GcValKind::I64
           } else if base_kind == GcValKind::Ref(ctx.bytes_type) {
             GcValKind::I64
+          } else if base_kind == gc_map_builder_kind_gc(ctx) {
+            match infer_map_value_kind_from_expr_gc(ctx, fctx, pos_args[0]) {
+              Some(kind) => kind
+              None => GcValKind::EqRef
+            }
           } else {
             gc_array_elem_kind_from_kind(ctx, base_kind, "__index")
           }
@@ -5346,6 +5381,113 @@ fn compile_len_gc(
 }
 
 ///|
+fn ensure_map_builder_type_gc(ctx : GcCodegenCtx) -> (Int, Int, Int) {
+  let key_arr_type = ensure_array_type(
+    ctx.types,
+    ctx.array_type_index,
+    GcValKind::EqRef,
+  )
+  let val_arr_type = ensure_array_type(
+    ctx.types,
+    ctx.array_type_index,
+    GcValKind::EqRef,
+  )
+  let builder_fields : Array[GcValKind] = [
+    GcValKind::I32,
+    GcValKind::Ref(key_arr_type),
+    GcValKind::Ref(val_arr_type),
+  ]
+  let builder_type = ensure_struct_type(
+    ctx.types,
+    ctx.struct_type_index,
+    builder_fields,
+  )
+  (builder_type, key_arr_type, val_arr_type)
+}
+
+///|
+fn gc_map_builder_kind_gc(ctx : GcCodegenCtx) -> GcValKind {
+  let (builder_type, _, _) = ensure_map_builder_type_gc(ctx)
+  GcValKind::Ref(builder_type)
+}
+
+///|
+fn compile_map_literal_gc(
+  ctx : GcCodegenCtx,
+  fctx : GcFuncCtx,
+  buf : GcByteBuf,
+  fields : Array[@core.MapFieldExpr],
+) -> Unit raise WasmGenError {
+  let saved_locals = clone_locals_gc(fctx.locals)
+  let (builder_type, _, _) = ensure_map_builder_type_gc(ctx)
+  let tmp_name = "__map_lit_builder_" + fctx.local_kinds.length().to_string()
+  let tmp_idx = bind_local_gc(fctx, tmp_name, GcValKind::Ref(builder_type))
+  let call_span = if fields.is_empty() {
+    @core.Span::empty(0)
+  } else {
+    fields[0].span
+  }
+  let builder_new = @core.Expr::Call(
+    name="MapBuilder::new",
+    type_args=[],
+    args=[],
+    span=call_span,
+  )
+  compile_expr_gc(ctx, fctx, buf, builder_new)
+  emit_local_set_gc(buf, tmp_idx)
+  for field in fields {
+    let set_expr = @core.Expr::Call(
+      name="MapBuilder::set",
+      type_args=[],
+      args=[
+        @core.CallArg::{
+          label: None,
+          expr: @core.Expr::Ident(name=tmp_name, span=field.span),
+          span: field.span,
+        },
+        @core.CallArg::{
+          label: None,
+          expr: @core.Expr::String(value=field.key, span=field.span),
+          span: field.span,
+        },
+        @core.CallArg::{ label: None, expr: field.expr, span: field.span },
+      ],
+      span=field.span,
+    )
+    compile_expr_gc(ctx, fctx, buf, set_expr)
+    emit_drop_gc(buf)
+  }
+  emit_local_get_gc(buf, tmp_idx)
+  restore_locals_gc(fctx, saved_locals)
+}
+
+///|
+fn infer_map_value_kind_from_expr_gc(
+  ctx : GcCodegenCtx,
+  fctx : GcFuncCtx,
+  expr : @core.Expr,
+) -> GcValKind? raise WasmGenError {
+  match expr {
+    @core.Expr::Map(fields~, ..) =>
+      if fields.is_empty() {
+        None
+      } else {
+        Some(infer_expr_kind_gc(ctx, fctx, fields[0].expr))
+      }
+    @core.Expr::Ident(name~, ..) => fctx.map_value_kinds.get(name)
+    @core.Expr::Call(name~, args~, ..) => {
+      let lowered = @core.lower_wasm_intrinsic_name(name)
+      if lowered == "MapBuilder::freeze" && args.length() == 1 {
+        infer_map_value_kind_from_expr_gc(ctx, fctx, args[0].expr)
+      } else {
+        None
+      }
+    }
+    _ => None
+  }
+}
+
+///|
 fn gc_array_type_idx_from_kind(
   ctx : GcCodegenCtx,
   kind : GcValKind,
@@ -6163,6 +6305,10 @@ fn compile_expr_gc(
       }
       emit_array_new_fixed_gc(buf, type_idx, items.length())
     }
+    @core.Expr::Map(fields~, span~) => {
+      let _ = span
+      compile_map_literal_gc(ctx, fctx, buf, fields)
+    }
     @core.Expr::Tuple(items~, span~) => {
       let _ = span
       let kind = infer_tuple_kind_gc(ctx, fctx, items)
@@ -6546,6 +6692,31 @@ fn compile_expr_gc(
             )
           } else if base_kind == GcValKind::Ref(ctx.bytes_type) {
             compile_bytes_get_gc(ctx, fctx, buf, pos_args[0], pos_args[1])
+          } else if base_kind == gc_map_builder_kind_gc(ctx) {
+            let value_kind = match
+              infer_map_value_kind_from_expr_gc(ctx, fctx, pos_args[0]) {
+              Some(kind) => kind
+              None => GcValKind::EqRef
+            }
+            let get_expr = @core.Expr::Call(
+              name="Map::get",
+              type_args=[],
+              args=[
+                @core.CallArg::{
+                  label: None,
+                  expr: pos_args[0],
+                  span: @core.Span::empty(0),
+                },
+                @core.CallArg::{
+                  label: None,
+                  expr: pos_args[1],
+                  span: @core.Span::empty(0),
+                },
+              ],
+              span=@core.Span::empty(0),
+            )
+            compile_expr_gc(ctx, fctx, buf, get_expr)
+            emit_coerce_top_gc(ctx, buf, GcValKind::EqRef, value_kind)
           } else {
             let type_idx = gc_array_type_idx_from_kind(
               ctx, base_kind, "__index",
@@ -8249,6 +8420,7 @@ fn compile_expr_gc(
       }
       let lifted_fctx = GcFuncCtx::{
         locals: {},
+        map_value_kinds: clone_kind_map_gc(fctx.map_value_kinds),
         local_kinds: [],
         param_count: 1 + params.length(),
         closure_call_types: lifted_closure_types,
@@ -8520,6 +8692,7 @@ fn compile_stmt_gc(
             }
             let rec_compile_fctx = GcFuncCtx::{
               locals: clone_locals_gc(fctx.locals),
+              map_value_kinds: clone_kind_map_gc(fctx.map_value_kinds),
               local_kinds: [],
               param_count: fctx.param_count,
               closure_call_types: rec_compile_cct,
@@ -8538,6 +8711,10 @@ fn compile_stmt_gc(
           _ => {
             let kind = infer_expr_kind_gc(ctx, fctx, expr)
             let idx = bind_local_gc(fctx, name, kind)
+            match infer_map_value_kind_from_expr_gc(ctx, fctx, expr) {
+              Some(value_kind) => fctx.map_value_kinds[name] = value_kind
+              None => ()
+            }
             track_closure_binding_gc(ctx, fctx, name, expr)
             compile_expr_gc(ctx, fctx, buf, expr)
             if is_last {
@@ -8550,6 +8727,10 @@ fn compile_stmt_gc(
       } else {
         let kind = infer_expr_kind_gc(ctx, fctx, expr)
         let idx = bind_local_gc(fctx, name, kind)
+        match infer_map_value_kind_from_expr_gc(ctx, fctx, expr) {
+          Some(value_kind) => fctx.map_value_kinds[name] = value_kind
+          None => ()
+        }
         track_closure_binding_gc(ctx, fctx, name, expr)
         compile_expr_gc(ctx, fctx, buf, expr)
         if is_last {
@@ -8561,6 +8742,10 @@ fn compile_stmt_gc(
     @core.Stmt::LetMut(name~, expr~, ..) => {
       let kind = infer_expr_kind_gc(ctx, fctx, expr)
       let idx = bind_local_gc(fctx, name, kind)
+      match infer_map_value_kind_from_expr_gc(ctx, fctx, expr) {
+        Some(value_kind) => fctx.map_value_kinds[name] = value_kind
+        None => ()
+      }
       track_closure_binding_gc(ctx, fctx, name, expr)
       compile_expr_gc(ctx, fctx, buf, expr)
       if is_last {
@@ -8582,6 +8767,10 @@ fn compile_stmt_gc(
           }
         }
         _ => ()
+      }
+      match infer_map_value_kind_from_expr_gc(ctx, fctx, expr) {
+        Some(value_kind) => fctx.map_value_kinds[name] = value_kind
+        None => ()
       }
       match fctx.locals.get(name) {
         Some(info) => {

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -495,6 +495,7 @@ struct WasmModule {
   func_bodies : Array[FuncBody]
   func_param_counts : Array[Int] // param count for each local function
   func_result_counts : Array[Int] // result count for each local function
+  func_exports : Map[String, Int]
   import_count : Int
   sh_index : Int?
   path_index : Int?
@@ -520,6 +521,7 @@ fn parse_wasm_module(bytes : Bytes) -> WasmModule raise WasmEvalError {
   let mut import_count = 0
   let mut sh_index : Int? = None
   let mut path_index : Int? = None
+  let func_exports : Map[String, Int] = {}
   let globals : Array[Int64] = []
   let mem : Array[Byte] = Array::make(65536, (0).to_byte())
   let type_param_counts : Array[Int] = [] // param counts for each type entry
@@ -582,6 +584,18 @@ fn parse_wasm_module(bytes : Bytes) -> WasmModule raise WasmEvalError {
           func_type_indices.push(sec.read_leb_u32())
         }
       }
+      7 => {
+        let sec = Cursor::new(payload)
+        let count = sec.read_leb_u32()
+        for _ in 0..<count {
+          let name = sec.read_name()
+          let kind = sec.read_u8()
+          let index = sec.read_leb_u32()
+          if kind == 0 {
+            func_exports[name] = index
+          }
+        }
+      }
       6 => {
         let parsed = parse_global_section(payload)
         for g in parsed {
@@ -615,6 +629,7 @@ fn parse_wasm_module(bytes : Bytes) -> WasmModule raise WasmEvalError {
     func_bodies,
     func_param_counts,
     func_result_counts,
+    func_exports,
     import_count,
     sh_index,
     path_index,
@@ -687,6 +702,26 @@ fn run_wasm(bytes : Bytes) -> WasmEvalResult raise WasmEvalError {
   let run_idx = wmod.import_count + wmod.func_bodies.length() - 1
   let outputs : Array[String] = []
   let results = exec_func(wmod, run_idx, [], outputs, 0)
+  let value = if results.is_empty() {
+    0L
+  } else {
+    results[results.length() - 1]
+  }
+  { value, outputs, mem: wmod.mem, globals: wmod.globals }
+}
+
+///|
+fn run_wasm_export(
+  bytes : Bytes,
+  export_name : String,
+) -> WasmEvalResult raise WasmEvalError {
+  let wmod = parse_wasm_module(bytes)
+  let export_idx = match wmod.func_exports.get(export_name) {
+    Some(idx) => idx
+    None => raise WasmEvalError::Invalid("missing export: " + export_name)
+  }
+  let outputs : Array[String] = []
+  let results = exec_func(wmod, export_idx, [], outputs, 0)
   let value = if results.is_empty() {
     0L
   } else {
@@ -827,6 +862,16 @@ fn eval_loop(
         }
         let a = stack.unsafe_pop()
         stack.push(if a.to_int() == 0 { 1L } else { 0L })
+      }
+      // select
+      27 => {
+        if stack.length() < 3 {
+          raise WasmEvalError::Invalid("stack underflow")
+        }
+        let cond = stack.unsafe_pop()
+        let val2 = stack.unsafe_pop()
+        let val1 = stack.unsafe_pop()
+        stack.push(if cond != 0L { val1 } else { val2 })
       }
       // i32.or
       114 => {
@@ -1576,6 +1621,19 @@ test "vibe wasm eval returns value" {
   }
   assert_true(is_tagged_int(res.value))
   assert_eq(decode_int(res.value), 1L)
+}
+
+///|
+test "vibe wasm export _start returns raw int" {
+  let db = VibeDb::new()
+  db.set_source("main", "42")
+  let wasm = compile_module_wasm(db, "main") catch { e => fail(e.to_string()) }
+  let res = try run_wasm_export(wasm, "_start") catch {
+    e => fail(e.to_string())
+  } noraise {
+    r => r
+  }
+  assert_eq(res.value, 42L)
 }
 
 ///|

--- a/src/tests/vibe_wasm_gc_e2e_test.mbt
+++ b/src/tests/vibe_wasm_gc_e2e_test.mbt
@@ -235,6 +235,17 @@ test "wasm-gc e2e: Array::fold" {
 }
 
 ///|
+test "wasm-gc e2e: let-else success path" {
+  let src =
+    #|let extract = (x: Int) -> Int {
+    #|  let Some(v) = Some(x) else { 0 }
+    #|  v * 2
+    #|}
+    #|extract(21)
+  assert_gc_e2e(src, "let_else_success", 42)
+}
+
+///|
 test "wasm-gc e2e: generic list iter_get" {
   let src =
     #|enum List[T] { Nil; Cons(T, List[T]) }

--- a/src/tests/vibe_wasm_gc_e2e_test.mbt
+++ b/src/tests/vibe_wasm_gc_e2e_test.mbt
@@ -226,6 +226,15 @@ test "wasm-gc e2e: pipe operator" {
 }
 
 ///|
+test "wasm-gc e2e: Array::fold" {
+  let src =
+    #|let arr = [1, 2, 3, 4, 5]
+    #|let sum = Array::fold(arr, 0, (acc: Int, x: Int) -> Int { acc + x })
+    #|sum
+  assert_gc_e2e(src, "array_fold", 15)
+}
+
+///|
 test "wasm-gc e2e: generic list iter_get" {
   let src =
     #|enum List[T] { Nil; Cons(T, List[T]) }

--- a/src/tests/vibe_wasm_gc_e2e_test.mbt
+++ b/src/tests/vibe_wasm_gc_e2e_test.mbt
@@ -662,6 +662,15 @@ test "wasm-gc e2e: Map::get arithmetic on results" {
 }
 
 ///|
+test "wasm-gc e2e: map literal index sugar" {
+  let src =
+    #|let m = map { "a": 10, "b": 20, "c": 30 }
+    #|let v = m["b"]
+    #|v
+  assert_gc_e2e(src, "map_literal_index", 20)
+}
+
+///|
 test "wasm-gc e2e: throw/handle error-only" {
   let src =
     #|let main = () -> Int {

--- a/src/tests/vibe_wasm_gc_e2e_test.mbt
+++ b/src/tests/vibe_wasm_gc_e2e_test.mbt
@@ -701,5 +701,15 @@ test "wasm-gc e2e: let rec factorial top-level" {
   assert_gc_e2e(src, "let_rec_fact_top", 120)
 }
 
-// TODO(B7): nested let rec closure self-ref needs mutable box for deferred init
-// test "wasm-gc e2e: let rec factorial nested" { ... }
+///|
+test "wasm-gc e2e: let rec nested helper captures outer local (#273)" {
+  let src =
+    #|let sum_range = (n: Int) -> Int {
+    #|  let rec helper: (Int, Int) -> Int = (i, acc) -> {
+    #|    if i > n { acc } else { helper(i + 1, acc + i) }
+    #|  }
+    #|  helper(1, 0)
+    #|}
+    #|sum_range(100)
+  assert_gc_e2e(src, "let_rec_nested_capture", 5050)
+}

--- a/src/tests/vibe_wasm_gc_mainlane_e2e_test.mbt
+++ b/src/tests/vibe_wasm_gc_mainlane_e2e_test.mbt
@@ -107,3 +107,21 @@ test "wasm-gc mainlane: recursive function" {
     #|fib(10)
   assert_gc_e2e_int_result(src, "mainlane_recursive_function", 55)
 }
+
+///|
+test "wasm-gc mainlane: nested recursive helper captures outer local" {
+  if gc_mainlane_should_skip("nested recursive helper captures outer local") {
+    return
+  }
+  let src =
+    #|let sum_range = (n: Int) -> Int {
+    #|  let rec helper: (Int, Int) -> Int = (i, acc) -> {
+    #|    if i > n { acc } else { helper(i + 1, acc + i) }
+    #|  }
+    #|  helper(1, 0)
+    #|}
+    #|sum_range(100)
+  assert_gc_e2e_int_result(
+    src, "mainlane_nested_recursive_helper_capture", 5050,
+  )
+}

--- a/src/tests/vibe_wasm_test.mbt
+++ b/src/tests/vibe_wasm_test.mbt
@@ -70,6 +70,13 @@ test "vibe wasm export run" {
   }
   assert_true(bytes_contains_ascii(wasm, "_start"))
   assert_true(bytes_contains_ascii(wasm, "_vibe_run_tagged"))
+  let start_index = find_export_func_index(wasm, "_start").unwrap_or(-1)
+  let tagged_index = find_export_func_index(wasm, "_vibe_run_tagged").unwrap_or(
+    -1,
+  )
+  assert_true(start_index >= 0)
+  assert_true(tagged_index >= 0)
+  assert_true(start_index != tagged_index)
 }
 
 ///|
@@ -430,6 +437,42 @@ fn wasm_export_section_is_well_formed(bytes : Bytes) -> Bool {
       offset == payload.length()
     }
     None => false
+  }
+}
+
+///|
+fn find_export_func_index(bytes : Bytes, export_name : String) -> Int? {
+  match find_section_payload(bytes, 7) {
+    Some(payload) => {
+      let export_name_bytes = @utf8.encode(export_name).to_array()
+      let (count, next_offset) = read_u32_leb_at(payload, 0)
+      let mut offset = next_offset
+      let mut remaining = count
+      while remaining > 0 {
+        if offset >= payload.length() {
+          return None
+        }
+        let (name_len, name_offset) = read_u32_leb_at(payload, offset)
+        let name_end = name_offset + name_len
+        if name_end >= payload.length() {
+          return None
+        }
+        let kind = payload[name_end].to_int()
+        let (index, next_entry_offset) = read_u32_leb_at(payload, name_end + 1)
+        if kind == 0 &&
+          name_len == export_name_bytes.length() &&
+          bytes_range_equals(payload, name_offset, export_name_bytes) {
+          return Some(index)
+        }
+        if next_entry_offset > payload.length() {
+          return None
+        }
+        offset = next_entry_offset
+        remaining -= 1
+      }
+      None
+    }
+    None => None
   }
 }
 

--- a/src/tests/vibe_wasm_test.mbt
+++ b/src/tests/vibe_wasm_test.mbt
@@ -69,6 +69,7 @@ test "vibe wasm export run" {
     b => b
   }
   assert_true(bytes_contains_ascii(wasm, "_start"))
+  assert_true(bytes_contains_ascii(wasm, "_vibe_run_tagged"))
 }
 
 ///|


### PR DESCRIPTION
## Summary
- fix MVP wasm start ABI so  returns raw i64 values
- fix wasm-gc recursive helper, Array::fold, let-else, and map literal parity regressions
- add focused wasm/wasm-gc regression coverage

## Issues
- closes #272
- closes #273