### PR TITLE
[codex] Refactor trait ownership metadata and remove accidental zed-vibe self-submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = deps/wasmtime
 	url = https://github.com/bytecodealliance/wasmtime.git
 	branch = main
-[submodule "integrations/zed-vibe/grammars/vibe"]
-	path = integrations/zed-vibe/grammars/vibe
-	url = https://github.com/mizchi/vibe-lang
-	branch = main

--- a/src/checker/pkg.generated.mbti
+++ b/src/checker/pkg.generated.mbti
@@ -156,13 +156,26 @@ pub impl Show for TopLevelPurityTier
 pub struct TraitDefInfo {
   supertraits : Array[String]
   open_impl : Bool
-  is_local : Bool
+  origin : TraitOrigin
 } derive(Eq, @debug.Debug)
+pub fn TraitDefInfo::allows_impl_here(Self) -> Bool
+pub fn TraitDefInfo::defined_here(Array[String], Bool) -> Self
+pub fn TraitDefInfo::imported(Array[String], Bool) -> Self
+pub fn TraitDefInfo::is_defined_here(Self) -> Bool
+pub fn TraitDefInfo::prelude_seeded() -> Self
+pub fn TraitDefInfo::supertraits_copy(Self) -> Array[String]
+pub fn TraitDefInfo::to_imported(Self, Array[String]) -> Self
 
 pub struct TraitImplDef {
   type_params : Array[String]
   type_bounds : Map[String, Array[String]]
   target : @core.Type
+} derive(Eq, @debug.Debug)
+
+pub enum TraitOrigin {
+  DefinedHere
+  Imported
+  PreludeSeed
 } derive(Eq, @debug.Debug)
 
 pub struct TypeAlias {
@@ -252,7 +265,7 @@ pub fn TypeEnv::get_trait_info(Self, String) -> TraitDefInfo?
 pub fn TypeEnv::get_type_alias(Self, String) -> TypeAlias?
 pub fn TypeEnv::has_scoped_ref_binding_for_capture(Self) -> Bool
 pub fn TypeEnv::has_trait(Self, String) -> Bool
-pub fn TypeEnv::import_trait(Self, String, Bool, Array[String]) -> Unit
+pub fn TypeEnv::import_trait(Self, String, TraitDefInfo, Array[String]) -> Unit
 pub fn TypeEnv::invalidate_normalize_type_cache(Self) -> Unit
 pub fn TypeEnv::invalidate_scoped_ref_contains_cache(Self) -> Unit
 pub fn TypeEnv::is_scoped_ref_checks_enabled(Self) -> Bool
@@ -273,11 +286,9 @@ pub fn TypeEnv::set_struct(Self, String, StructDef) -> Unit
 pub fn TypeEnv::set_trait(Self, String) -> Unit
 pub fn TypeEnv::set_trait_info(Self, String, TraitDefInfo) -> Unit
 pub fn TypeEnv::set_type_alias(Self, String, TypeAlias) -> Unit
+pub fn TypeEnv::trait_accepts_impl_here(Self, String) -> Bool
 pub fn TypeEnv::trait_impls_for(Self, String) -> Array[TraitImplDef]
-pub fn TypeEnv::trait_is_local(Self, String) -> Bool
-pub fn TypeEnv::trait_is_open(Self, String) -> Bool
 pub fn TypeEnv::trait_names(Self) -> Array[String]
-pub fn TypeEnv::trait_supertraits(Self, String) -> Array[String]
 pub fn TypeEnv::variant_namespace_root(Self, Map[String, @core.Type]) -> String?
 
 pub struct TypeScheme {

--- a/src/checker/typecheck_env_traits.mbt
+++ b/src/checker/typecheck_env_traits.mbt
@@ -1,4 +1,11 @@
 ///|
+pub enum TraitOrigin {
+  DefinedHere
+  Imported
+  PreludeSeed
+} derive(Debug, Eq)
+
+///|
 pub struct TraitImplDef {
   type_params : Array[String]
   type_bounds : Map[String, Array[String]]
@@ -9,8 +16,55 @@ pub struct TraitImplDef {
 pub struct TraitDefInfo {
   supertraits : Array[String]
   open_impl : Bool
-  is_local : Bool
+  origin : TraitOrigin
 } derive(Debug, Eq)
+
+///|
+pub fn TraitDefInfo::defined_here(
+  supertraits : Array[String],
+  open_impl : Bool,
+) -> TraitDefInfo {
+  { supertraits, open_impl, origin: TraitOrigin::DefinedHere }
+}
+
+///|
+pub fn TraitDefInfo::imported(
+  supertraits : Array[String],
+  open_impl : Bool,
+) -> TraitDefInfo {
+  { supertraits, open_impl, origin: TraitOrigin::Imported }
+}
+
+///|
+pub fn TraitDefInfo::prelude_seeded() -> TraitDefInfo {
+  { supertraits: [], open_impl: false, origin: TraitOrigin::PreludeSeed }
+}
+
+///|
+pub fn TraitDefInfo::is_defined_here(self : TraitDefInfo) -> Bool {
+  self.origin == TraitOrigin::DefinedHere
+}
+
+///|
+pub fn TraitDefInfo::allows_impl_here(self : TraitDefInfo) -> Bool {
+  match self.origin {
+    TraitOrigin::Imported => self.open_impl
+    TraitOrigin::DefinedHere | TraitOrigin::PreludeSeed => true
+  }
+}
+
+///|
+pub fn TraitDefInfo::to_imported(
+  self : TraitDefInfo,
+  supertraits : Array[String],
+) -> TraitDefInfo {
+  TraitDefInfo::imported(supertraits, self.open_impl)
+}
+
+///|
+pub fn TraitDefInfo::supertraits_copy(self : TraitDefInfo) -> Array[String] {
+  self.supertraits.copy()
+}
 
 ///|
 pub fn TypeEnv::has_trait(self : TypeEnv, name : String) -> Bool {
@@ -19,11 +73,7 @@ pub fn TypeEnv::has_trait(self : TypeEnv, name : String) -> Bool {
 
 ///|
 pub fn TypeEnv::set_trait(self : TypeEnv, name : String) -> Unit {
-  self.set_trait_info(name, TraitDefInfo::{
-    supertraits: [],
-    open_impl: false,
-    is_local: true,
-  })
+  self.set_trait_info(name, TraitDefInfo::defined_here([], false))
 }
 
 ///|
@@ -41,43 +91,20 @@ pub fn TypeEnv::get_trait_info(self : TypeEnv, name : String) -> TraitDefInfo? {
 }
 
 ///|
-pub fn TypeEnv::trait_is_open(self : TypeEnv, name : String) -> Bool {
-  match self.traits.get(name) {
-    Some(info) => info.open_impl
-    None => false
-  }
-}
-
-///|
-pub fn TypeEnv::trait_is_local(self : TypeEnv, name : String) -> Bool {
-  match self.traits.get(name) {
-    Some(info) => info.is_local
-    None => false
-  }
-}
-
-///|
 pub fn TypeEnv::import_trait(
   self : TypeEnv,
   name : String,
-  open_impl : Bool,
+  source_info : TraitDefInfo,
   supertraits : Array[String],
 ) -> Unit {
-  self.set_trait_info(name, TraitDefInfo::{
-    supertraits,
-    open_impl,
-    is_local: false,
-  })
+  self.set_trait_info(name, source_info.to_imported(supertraits))
 }
 
 ///|
-pub fn TypeEnv::trait_supertraits(
-  self : TypeEnv,
-  name : String,
-) -> Array[String] {
+pub fn TypeEnv::trait_accepts_impl_here(self : TypeEnv, name : String) -> Bool {
   match self.traits.get(name) {
-    Some(info) => info.supertraits.copy()
-    None => []
+    Some(info) => info.allows_impl_here()
+    None => false
   }
 }
 

--- a/src/checker/typecheck_env_traits_wbtest.mbt
+++ b/src/checker/typecheck_env_traits_wbtest.mbt
@@ -1,0 +1,57 @@
+///|
+test "TraitDefInfo constructors preserve ownership and hierarchy" {
+  let imported = TraitDefInfo::imported(["Eq", "Hash"], true)
+  assert_true(imported.origin == TraitOrigin::Imported)
+  assert_eq(imported.supertraits, ["Eq", "Hash"])
+  assert_true(imported.open_impl)
+
+  let defined_here = TraitDefInfo::defined_here(["Eq"], false)
+  assert_true(defined_here.origin == TraitOrigin::DefinedHere)
+  assert_eq(defined_here.supertraits, ["Eq"])
+  assert_false(defined_here.open_impl)
+
+  let seeded = TraitDefInfo::prelude_seeded()
+  assert_true(seeded.origin == TraitOrigin::PreludeSeed)
+  assert_eq(seeded.supertraits, [])
+  assert_false(seeded.open_impl)
+}
+
+///|
+test "TraitDefInfo::allows_impl_here follows ownership instead of ad-hoc bool checks" {
+  assert_true(TraitDefInfo::defined_here([], false).allows_impl_here())
+  assert_true(TraitDefInfo::prelude_seeded().allows_impl_here())
+  assert_true(TraitDefInfo::imported([], true).allows_impl_here())
+  assert_false(TraitDefInfo::imported([], false).allows_impl_here())
+}
+
+///|
+test "TypeEnv::trait_accepts_impl_here uses trait ownership model" {
+  let env = TypeEnv::new()
+  env.set_trait_info("Eq", TraitDefInfo::prelude_seeded())
+  env.set_trait_info("LocalEq", TraitDefInfo::defined_here([], false))
+  env.set_trait_info("RemoteEq", TraitDefInfo::imported([], false))
+  env.set_trait_info("RemoteOpenEq", TraitDefInfo::imported([], true))
+
+  assert_true(env.trait_accepts_impl_here("Eq"))
+  assert_true(env.trait_accepts_impl_here("LocalEq"))
+  assert_false(env.trait_accepts_impl_here("RemoteEq"))
+  assert_true(env.trait_accepts_impl_here("RemoteOpenEq"))
+  assert_false(env.trait_accepts_impl_here("Missing"))
+}
+
+///|
+test "TypeEnv::import_trait rewrites ownership without losing openness or hierarchy" {
+  let env = TypeEnv::new()
+  env.import_trait("OrdAlias", TraitDefInfo::defined_here(["Eq"], true), [
+    "EqAlias",
+  ])
+  assert_true(
+    env.get_trait_info("OrdAlias") ==
+    Some(TraitDefInfo::imported(["EqAlias"], true)),
+  )
+
+  env.import_trait("SeededEq", TraitDefInfo::prelude_seeded(), [])
+  assert_true(
+    env.get_trait_info("SeededEq") == Some(TraitDefInfo::imported([], false)),
+  )
+}

--- a/src/checker/typecheck_prelude.mbt
+++ b/src/checker/typecheck_prelude.mbt
@@ -238,11 +238,7 @@ pub fn ensure_prelude_builtin_traits(env : TypeEnv) -> Unit {
   ]
   for name in builtin_trait_names {
     if not(env.has_trait(name)) {
-      env.set_trait_info(name, TraitDefInfo::{
-        supertraits: [],
-        open_impl: false,
-        is_local: true,
-      })
+      env.set_trait_info(name, TraitDefInfo::prelude_seeded())
     }
   }
 }

--- a/src/checker/typecheck_stmts.mbt
+++ b/src/checker/typecheck_stmts.mbt
@@ -966,7 +966,7 @@ fn trait_is_subtrait_inner(
     Some(info) => {
       let next_visiting = visiting.copy()
       next_visiting[sub_trait] = true
-      for parent in info.supertraits {
+      for parent in info.supertraits_copy() {
         if parent == super_trait {
           return true
         }
@@ -1053,11 +1053,10 @@ fn register_trait_def(
     }
   }
   ensure_traits_defined(env, normalized_supertraits, span)
-  env.set_trait_info(name, TraitDefInfo::{
-    supertraits: normalized_supertraits,
-    open_impl,
-    is_local: true,
-  })
+  env.set_trait_info(
+    name,
+    TraitDefInfo::defined_here(normalized_supertraits, open_impl),
+  )
 }
 
 ///|
@@ -1419,7 +1418,7 @@ fn register_trait_impl(
   if not(env.has_trait(trait_name)) {
     raise TypeError::BadTypeDef(message="unknown trait: " + trait_name, span~)
   }
-  if not(env.trait_is_local(trait_name)) && not(env.trait_is_open(trait_name)) {
+  if not(env.trait_accepts_impl_here(trait_name)) {
     raise TypeError::TraitSealed(trait_name~, span~)
   }
   ensure_unique_params(type_params, span)

--- a/src/runtime/db_query.mbt
+++ b/src/runtime/db_query.mbt
@@ -1036,17 +1036,20 @@ pub fn VibeDb::new() -> VibeDb {
                       // Import trait
                       if import_item_accepts_trait(item) &&
                         imported_env.has_trait(source_name) {
-                        let local_supertraits = imported_env.trait_supertraits(
-                          source_name,
-                        )
-                        env.import_trait(
-                          target_name,
-                          imported_env.trait_is_open(source_name),
-                          local_supertraits,
-                        )
-                        let impls = imported_env.trait_impls_for(source_name)
-                        for impl_def in impls {
-                          env.add_trait_impl(target_name, impl_def)
+                        match imported_env.get_trait_info(source_name) {
+                          Some(source_info) => {
+                            let local_supertraits = source_info.supertraits_copy()
+                            env.import_trait(
+                              target_name, source_info, local_supertraits,
+                            )
+                            let impls = imported_env.trait_impls_for(
+                              source_name,
+                            )
+                            for impl_def in impls {
+                              env.add_trait_impl(target_name, impl_def)
+                            }
+                          }
+                          None => ()
                         }
                       }
                     }
@@ -1097,20 +1100,23 @@ pub fn VibeDb::new() -> VibeDb {
                     let mut imported_any = false
                     if import_item_accepts_trait(item) &&
                       imported_env.has_trait(source_name) {
-                      let local_supertraits = resolve_imported_trait_supertraits(
-                        source_name,
-                        target_name,
-                        imported_env.trait_supertraits(source_name),
-                        trait_aliases,
-                      )
-                      env.import_trait(
-                        target_name,
-                        imported_env.trait_is_open(source_name),
-                        local_supertraits,
-                      )
-                      let impls = imported_env.trait_impls_for(source_name)
-                      for impl_def in impls {
-                        env.add_trait_impl(target_name, impl_def)
+                      match imported_env.get_trait_info(source_name) {
+                        Some(source_info) => {
+                          let local_supertraits = resolve_imported_trait_supertraits(
+                            source_name,
+                            target_name,
+                            source_info.supertraits_copy(),
+                            trait_aliases,
+                          )
+                          env.import_trait(
+                            target_name, source_info, local_supertraits,
+                          )
+                          let impls = imported_env.trait_impls_for(source_name)
+                          for impl_def in impls {
+                            env.add_trait_impl(target_name, impl_def)
+                          }
+                        }
+                        None => ()
                       }
                       imported_any = true
                     }

--- a/src/runtime/db_type_import.mbt
+++ b/src/runtime/db_type_import.mbt
@@ -132,7 +132,11 @@ fn import_trait_dependency_for_scheme(
     Some(alias_name) => alias_name
     None => source_trait_name
   }
-  let source_supertraits = imported_env.trait_supertraits(source_trait_name)
+  let source_info = match imported_env.get_trait_info(source_trait_name) {
+    Some(info) => info
+    None => return
+  }
+  let source_supertraits = source_info.supertraits_copy()
   for supertrait in source_supertraits {
     import_trait_dependency_for_scheme(
       env, imported_env, supertrait, trait_aliases, exported_names, visiting,
@@ -142,11 +146,7 @@ fn import_trait_dependency_for_scheme(
     source_trait_name, local_trait_name, source_supertraits, trait_aliases,
   )
   if not(env.has_trait(local_trait_name)) {
-    env.import_trait(
-      local_trait_name,
-      imported_env.trait_is_open(source_trait_name),
-      local_supertraits,
-    )
+    env.import_trait(local_trait_name, source_info, local_supertraits)
   }
   for impl_def in imported_env.trait_impls_for(source_trait_name) {
     maybe_add_trait_impl(env, local_trait_name, impl_def)


### PR DESCRIPTION
## What changed

This PR does two related cleanup passes.

1. Refactors checker trait metadata to model ownership explicitly with `TraitOrigin` instead of the old `is_local`/`open_impl` split.
2. Removes the accidental `integrations/zed-vibe/grammars/vibe` self-submodule from the parent repository.

## Why

The trait model had become hard to reason about because trait ownership, sealing, and hierarchy were represented through ad-hoc booleans.

In particular:
- prelude-seeded builtin traits were pretending to be local definitions
- impl acceptance was derived from a combination of `trait_is_local` and `trait_is_open`
- trait import paths decomposed metadata into separate openness and supertrait parameters and then reconstructed it later

That made the ownership/layering model harder to follow than it needed to be.

Separately, `integrations/zed-vibe/grammars/vibe` was tracked as a gitlink pointing back to this same repository. The Zed extension manifest already references `integrations/treesitter-vibe`, so the nested self-submodule did not match the current extension structure.

## Implementation notes

### Trait ownership refactor

- adds `TraitOrigin` and stores origin on `TraitDefInfo`
- centralizes impl acceptance in `TraitDefInfo::allows_impl_here()` / `TypeEnv::trait_accepts_impl_here()`
- makes trait import carry `TraitDefInfo` directly and convert it with `to_imported()`
- removes the old `trait_is_local` / `trait_is_open` decision split from the checker flow
- adds whitebox tests covering ownership, openness, and imported hierarchy behavior

### Zed cleanup

- removes the accidental `integrations/zed-vibe/grammars/vibe` self-submodule entry from `.gitmodules`
- removes the gitlink from the parent repository index

## Impact

- trait ownership/sealing rules are easier to understand and extend
- imported traits now keep their metadata in a single descriptor rather than being reconstructed from separate parameters
- the repository layout is simpler and no longer includes an unintended self-submodule under `integrations/zed-vibe`

## Validation

Root repo:
- `moon test -p mizchi/vibe/checker -f typecheck_env_traits_wbtest.mbt --target native --warn-list '-1-6-7-9-20-24-29'`
- `moon test -p mizchi/vibe/checker --target native --warn-list '-1-6-7-9-20-24-29'`
- `moon test -p mizchi/vibe/runtime --target native --warn-list '-1-6-7-9-20-24-29'`
- `moon info`
- `flaker run`
- `just check`

Zed mirror checkout:
- `moon update`
- `moon fmt`
- `moon test -p mizchi/vibe/checker -f typecheck_env_traits_wbtest.mbt --target native --warn-list '-1-6-7-9-20-24-29'`
- `moon info`
- `moon test -p mizchi/vibe/checker --target native --warn-list '-1-6-7-9-20-24-29'`
- `moon test -p mizchi/vibe/runtime --target native --warn-list '-1-6-7-9-20-24-29'`

Known warnings remain around existing deprecated `derive(Show)` usage; this PR does not address those.