### PR TITLE
Fix codegen: export re-export (#286), builder realloc (#285), decode_tagged_value (#289)

### DIFF
--- a/src/codegen/wasm_codegen_builtin_collection.mbt
+++ b/src/codegen/wasm_codegen_builtin_collection.mbt
@@ -54,10 +54,19 @@ fn compile_builtin_collection(
     }
     "ArrayBuilder::freeze" => {
       // array_builder_freeze(builder) -> return builder as-is (it is already an array obj)
+      // Follow forwarding pointer in case push triggered realloc
       let pos_args = extract_positional_exprs_with_arity(
         args, "ArrayBuilder::freeze", 1,
       )
+      let ptr_local = alloc_temp_local(ctx)
       compile_expr_i32(ctx, buf, pos_args[0])
+      emit_untag_ptr_i32(buf)
+      emit_local_set(buf, ptr_local)
+      emit_builder_follow_forwarding(ctx, buf, ptr_local)
+      emit_local_get(buf, ptr_local)
+      emit_i64_extend_i32_u(buf)
+      emit_i64_const_raw(buf, tag_obj.to_int64())
+      emit_i64_or(buf)
     }
     "Array::push" => {
       // array_push(arr, value) -> store value at [ptr + 8 + len*4], increment len

--- a/src/codegen/wasm_codegen_builtin_string.mbt
+++ b/src/codegen/wasm_codegen_builtin_string.mbt
@@ -2562,6 +2562,8 @@ fn compile_builtin_string(
       compile_expr_i32(ctx, buf, pos_args[0])
       emit_untag_ptr_i32(buf)
       emit_local_set(buf, builder_ptr)
+      // Follow forwarding pointer if builder was relocated by push realloc
+      emit_builder_follow_forwarding(ctx, buf, builder_ptr)
       // read number of strings
       emit_local_get(buf, builder_ptr)
       emit_i32_load(buf, 4)

--- a/src/codegen/wasm_codegen_call_builtin_pre_user.mbt
+++ b/src/codegen/wasm_codegen_call_builtin_pre_user.mbt
@@ -48,6 +48,33 @@ fn emit_builder_alloc(
 /// ptr_local holds the untagged obj pointer (points to tag field).
 /// elem_size is bytes per element (4 for array/string, 8 for map).
 /// After this code, it is safe to write at [ptr + 8 + len * elem_size].
+/// Follow forwarding pointer if the builder was relocated by a previous realloc.
+/// A relocated builder has cap == -1 (sentinel) at ptr[-4] and the new pointer
+/// stored at ptr[0]. This resolves stale caller bindings after realloc.
+fn emit_builder_follow_forwarding(
+  ctx : CodegenCtx,
+  buf : ByteBuf,
+  ptr_local : Int,
+) -> Unit {
+  let _ = ctx
+  // Read capacity from ptr[-4]
+  emit_local_get(buf, ptr_local)
+  emit_i32_const_raw(buf, 4)
+  emit_i32_sub(buf)
+  emit_i32_load(buf, 0)
+  // Check if cap == -1 (forwarding sentinel)
+  emit_i32_const_raw(buf, -1)
+  emit_i32_eq(buf)
+  buf.push((4).to_byte()) // if
+  buf.push((64).to_byte()) // void
+  // Follow forwarding pointer: new_ptr = old_ptr[0]
+  emit_local_get(buf, ptr_local)
+  emit_i32_load(buf, 0)
+  emit_local_set(buf, ptr_local)
+  buf.push((11).to_byte()) // end if
+}
+
+///|
 fn emit_builder_grow_check(
   ctx : CodegenCtx,
   buf : ByteBuf,
@@ -55,6 +82,8 @@ fn emit_builder_grow_check(
   elem_size : Int,
 ) -> Unit {
   require_heap(ctx)
+  // Follow forwarding pointer if the builder was relocated by a prior realloc
+  emit_builder_follow_forwarding(ctx, buf, ptr_local)
   let cap_local = alloc_temp_local(ctx)
   let len_local = alloc_temp_local(ctx)
   let old_end_local = alloc_temp_local(ctx)
@@ -125,6 +154,10 @@ fn emit_builder_grow_check(
   emit_local_get(buf, new_cap_local)
   emit_i32_store(buf, 0)
   buf.push((5).to_byte()) // else (not at heap tip — full realloc)
+  // Save old ptr before realloc (for forwarding header)
+  let old_ptr_local = alloc_temp_local(ctx)
+  emit_local_get(buf, ptr_local)
+  emit_local_set(buf, old_ptr_local)
   // new_cap = cap * 2
   emit_local_get(buf, cap_local)
   emit_i32_const_raw(buf, 1)
@@ -197,6 +230,18 @@ fn emit_builder_grow_check(
   emit_i32_const_raw(buf, 4)
   emit_i32_add(buf)
   emit_local_set(buf, ptr_local)
+  // Write forwarding header at old location so stale caller bindings
+  // can find the new buffer on subsequent operations:
+  // old_ptr[-4] = -1 (sentinel cap, signals forwarding)
+  // old_ptr[0] = new_ptr (forwarding pointer)
+  emit_local_get(buf, old_ptr_local)
+  emit_i32_const_raw(buf, 4)
+  emit_i32_sub(buf)
+  emit_i32_const_raw(buf, -1)
+  emit_i32_store(buf, 0)
+  emit_local_get(buf, old_ptr_local)
+  emit_local_get(buf, ptr_local)
+  emit_i32_store(buf, 0)
   buf.push((11).to_byte()) // end if (at heap tip)
   buf.push((11).to_byte()) // end if (len >= cap)
 }
@@ -213,6 +258,8 @@ fn emit_builder_bulk_grow_check(
   elem_size : Int,
 ) -> Unit {
   require_heap(ctx)
+  // Follow forwarding pointer if the builder was relocated by a prior realloc
+  emit_builder_follow_forwarding(ctx, buf, ptr_local)
   let cap_local = alloc_temp_local(ctx)
   let len_local = alloc_temp_local(ctx)
   let needed_local = alloc_temp_local(ctx)
@@ -292,6 +339,10 @@ fn emit_builder_bulk_grow_check(
   emit_local_get(buf, new_cap_local)
   emit_i32_store(buf, 0)
   buf.push((5).to_byte()) // else (not at heap tip — full realloc)
+  // Save old ptr before realloc (for forwarding header)
+  let old_ptr_local = alloc_temp_local(ctx)
+  emit_local_get(buf, ptr_local)
+  emit_local_set(buf, old_ptr_local)
   // Allocate new buffer
   let new_alloc_size_local = alloc_temp_local(ctx)
   emit_local_get(buf, new_cap_local)
@@ -356,6 +407,15 @@ fn emit_builder_bulk_grow_check(
   emit_i32_const_raw(buf, 4)
   emit_i32_add(buf)
   emit_local_set(buf, ptr_local)
+  // Write forwarding header at old location
+  emit_local_get(buf, old_ptr_local)
+  emit_i32_const_raw(buf, 4)
+  emit_i32_sub(buf)
+  emit_i32_const_raw(buf, -1)
+  emit_i32_store(buf, 0)
+  emit_local_get(buf, old_ptr_local)
+  emit_local_get(buf, ptr_local)
+  emit_i32_store(buf, 0)
   buf.push((11).to_byte()) // end if (at heap tip)
   buf.push((11).to_byte()) // end if (needed > cap)
 }

--- a/src/codegen/wasm_codegen_call_builtin_pre_user.mbt
+++ b/src/codegen/wasm_codegen_call_builtin_pre_user.mbt
@@ -48,15 +48,19 @@ fn emit_builder_alloc(
 /// ptr_local holds the untagged obj pointer (points to tag field).
 /// elem_size is bytes per element (4 for array/string, 8 for map).
 /// After this code, it is safe to write at [ptr + 8 + len * elem_size].
-/// Follow forwarding pointer if the builder was relocated by a previous realloc.
-/// A relocated builder has cap == -1 (sentinel) at ptr[-4] and the new pointer
-/// stored at ptr[0]. This resolves stale caller bindings after realloc.
+/// Follow forwarding pointer chain if the builder was relocated by previous
+/// reallocs. A relocated builder has cap == -1 (sentinel) at ptr[-4] and the
+/// new pointer stored at ptr[0]. Loops to handle multi-hop chains (e.g. when
+/// multiple non-tip reallocations accumulate: old0 -> old1 -> new).
 fn emit_builder_follow_forwarding(
   ctx : CodegenCtx,
   buf : ByteBuf,
   ptr_local : Int,
 ) -> Unit {
   let _ = ctx
+  // Loop until cap != -1 (reached a live builder)
+  emit_block(buf) // block $done
+  emit_loop(buf) // loop $chase
   // Read capacity from ptr[-4]
   emit_local_get(buf, ptr_local)
   emit_i32_const_raw(buf, 4)
@@ -64,14 +68,15 @@ fn emit_builder_follow_forwarding(
   emit_i32_load(buf, 0)
   // Check if cap == -1 (forwarding sentinel)
   emit_i32_const_raw(buf, -1)
-  emit_i32_eq(buf)
-  buf.push((4).to_byte()) // if
-  buf.push((64).to_byte()) // void
+  emit_i32_ne(buf)
+  emit_br_if(buf, 1) // break $done if cap != -1
   // Follow forwarding pointer: new_ptr = old_ptr[0]
   emit_local_get(buf, ptr_local)
   emit_i32_load(buf, 0)
   emit_local_set(buf, ptr_local)
-  buf.push((11).to_byte()) // end if
+  emit_br(buf, 0) // continue $chase
+  emit_end(buf) // end $chase
+  emit_end(buf) // end $done
 }
 
 ///|

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -3333,6 +3333,11 @@ fn emit_module_with_coverage(
           }
           _ => ()
         }
+      // export { name1, name2 } — re-export of imported/local names
+      @core.Stmt::Export(names~, span=_) =>
+        for name in names {
+          ctx.exported_fns[name] = true
+        }
       _ => ()
     }
   }

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -204,10 +204,25 @@ let obj_string = 1
 let obj_path = 2
 
 ///|
+let obj_tuple = 3
+
+///|
+let obj_record = 4
+
+///|
 let obj_array = 5
 
 ///|
 let obj_map = 6
+
+///|
+let obj_float = 8
+
+///|
+let obj_double = 9
+
+///|
+let obj_enum = 10
 
 ///|
 let obj_bytes = 13
@@ -1600,7 +1615,64 @@ fn decode_tagged_value(
     }
     return @core.Value::Map(out)
   }
-  raise WasmEvalError::Unsupported("decode unsupported object type")
+  if ty == obj_tuple {
+    let len = object_len(mem, tagged)
+    let base = untag_ptr(tagged)
+    let out : Array[@core.Value] = []
+    for i in 0..<len {
+      let item = read_u32_le(mem, base + 8 + i * 4).to_int64()
+      out.push(decode_tagged_value(mem, item, depth + 1))
+    }
+    return @core.Value::Tuple(out)
+  }
+  if ty == obj_record {
+    let len = object_len(mem, tagged)
+    let base = untag_ptr(tagged)
+    let out : Map[String, @core.Value] = {}
+    for i in 0..<len {
+      let key_ptr = read_u32_le(mem, base + 8 + i * 8).to_int64()
+      let value = read_u32_le(mem, base + 12 + i * 8).to_int64()
+      let key = read_string_object(mem, key_ptr)
+      out[key] = decode_tagged_value(mem, value, depth + 1)
+    }
+    return @core.Value::Record(out)
+  }
+  if ty == obj_float {
+    let base = untag_ptr(tagged)
+    let bits = read_u32_le(mem, base + 4)
+    return @core.Value::Float(Float::reinterpret_from_int(bits))
+  }
+  if ty == obj_double {
+    let base = untag_ptr(tagged)
+    let lo = read_u32_le(mem, base + 4)
+    let hi = read_u32_le(mem, base + 8)
+    let bits = (hi.to_int64().reinterpret_as_uint64() << 32) |
+      (lo.to_int64() & 0xFFFFFFFFL).reinterpret_as_uint64()
+    return @core.Value::Double(bits.reinterpret_as_double())
+  }
+  if ty == obj_enum {
+    let base = untag_ptr(tagged)
+    let arity = read_u32_le(mem, base + 4)
+    let _ctor_tag = read_u32_le(mem, base + 8)
+    let args : Array[@core.Value] = []
+    for i in 0..<arity {
+      let arg = read_u32_le(mem, base + 12 + i * 4).to_int64()
+      args.push(decode_tagged_value(mem, arg, depth + 1))
+    }
+    return @core.Value::Tuple(args)
+  }
+  if ty == obj_bytes || ty == obj_bytes_view {
+    let len = object_len(mem, tagged)
+    let base = untag_ptr(tagged)
+    let out : Array[Byte] = []
+    for i in 0..<len {
+      out.push(mem[base + 8 + i])
+    }
+    return @core.Value::Bytes(out)
+  }
+  raise WasmEvalError::Unsupported(
+    "decode unsupported object type: " + ty.to_string(),
+  )
 }
 
 ///|

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -1661,12 +1661,28 @@ fn decode_tagged_value(
     }
     return @core.Value::Tuple(args)
   }
-  if ty == obj_bytes || ty == obj_bytes_view {
-    let len = object_len(mem, tagged)
+  if ty == obj_bytes {
+    // Layout: [type:i32][len:i32][cap:i32][data_ptr:i32]
     let base = untag_ptr(tagged)
+    let len = read_u32_le(mem, base + 4)
+    let data_ptr = read_u32_le(mem, base + 12)
     let out : Array[Byte] = []
     for i in 0..<len {
-      out.push(mem[base + 8 + i])
+      out.push(mem[data_ptr + i])
+    }
+    return @core.Value::Bytes(out)
+  }
+  if ty == obj_bytes_view {
+    // Layout: [type:i32][source_ptr:i32][start:i32][end:i32]
+    let base = untag_ptr(tagged)
+    let source_ptr = read_u32_le(mem, base + 4)
+    let start = read_u32_le(mem, base + 8)
+    let end = read_u32_le(mem, base + 12)
+    let len = end - start
+    let source_data_ptr = read_u32_le(mem, source_ptr + 12)
+    let out : Array[Byte] = []
+    for i in 0..<len {
+      out.push(mem[source_data_ptr + start + i])
     }
     return @core.Value::Bytes(out)
   }


### PR DESCRIPTION
## Summary

- **#286**: `export { imported_name }` now emits wasm exports. The codegen only processed `Stmt::ExportLet`, ignoring `Stmt::Export` which remains after module bundling for imported-then-re-exported names.
- **#285**: Builder push realloc writes a forwarding pointer (cap=-1 sentinel + new ptr) at the old buffer. Subsequent push/freeze calls follow the forwarding, fixing silent data loss past capacity 256.
- **#289**: `decode_tagged_value` test helper now handles `obj_tuple`, `obj_record`, `obj_float`, `obj_double`, `obj_enum`, `obj_bytes`, `obj_bytes_view`.

## Test plan

- [ ] `moon check` passes
- [ ] `moon test` passes (especially vibe_wasm_eval_test.mbt index 44)
- [ ] Verify `export { name }` pattern produces wasm exports in selfhost build

https://claude.ai/code/session_013zud6hdCUmtgnMMC2EHgst