### PR TITLE
Use wac plug for --compose-p3 composition in cli compile

### DIFF
--- a/src/cmd/vibe/cli_compile_cmd.mbt
+++ b/src/cmd/vibe/cli_compile_cmd.mbt
@@ -324,18 +324,8 @@ fn compile_cmd(args : Array[String]) -> Unit {
           ) catch {
             e => abort("compile: " + e.user_message())
           }
-          // Step 2: Read adapter and compose with mwac plug
-          let adapter_bytes = match @io.read_bytes_with(fs, adapter_path) {
-            Ok(b) => b
-            Err(err) => abort("compile: failed to read adapter: " + err)
-          }
-          // adapter = socket (imports handler), app = plug (exports handler)
-          let composed = @runtime_compile.compose_p3_component(
-            app_bytes, adapter_bytes,
-          ) catch {
-            e => abort("compile: " + e.user_message())
-          }
-          match @io.write_bytes_with(fs, resolved_out, composed) {
+          match
+            compose_p3_component_with_wac(adapter_path, app_bytes, resolved_out) {
             Ok(_) => ()
             Err(err) => abort("compile: " + err)
           }
@@ -379,6 +369,91 @@ fn compile_cmd(args : Array[String]) -> Unit {
         }
       }
     }
+  }
+}
+
+///|
+fn build_p3_compose_command(
+  adapter_path : String,
+  app_path : String,
+  out_path : String,
+) -> String {
+  "wac plug --plug " +
+  shell_quote_command_arg(app_path) +
+  " -o " +
+  shell_quote_command_arg(out_path) +
+  " " +
+  shell_quote_command_arg(adapter_path)
+}
+
+///|
+fn compose_p3_component_with_wac(
+  adapter_path : String,
+  app_bytes : Bytes,
+  out_path : String,
+) -> Result[Unit, String] {
+  if !@backend.exec_available() {
+    return Err(
+      "--compose-p3 requires external process execution on this target",
+    )
+  }
+  match ensure_parent_dir_for_file(out_path, "compile") {
+    Ok(_) => ()
+    Err(err) => return Err(err)
+  }
+  let tmp_dir = match make_cli_temp_dir("compose_p3") {
+    Ok(path) => path
+    Err(err) => return Err(err)
+  }
+  defer remove_path_if_exists(tmp_dir)
+  let app_path = tmp_dir + "/app.component.wasm"
+  @os_fs.write_bytes_to_file(app_path, app_bytes) catch {
+    e => return Err("failed to write temp component: " + e.to_string())
+  }
+  let cmd = build_p3_compose_command(adapter_path, app_path, out_path)
+  match @backend.exec_command_lines(cmd) {
+    Ok(_) => Ok(())
+    Err(err) => Err("wac plug failed: " + err)
+  }
+}
+
+///|
+fn make_cli_temp_dir(prefix : String) -> Result[String, String] {
+  let base = "/tmp/vibe_cli_" +
+    prefix +
+    "_" +
+    @env.now().to_string() +
+    "_" +
+    vibe_getpid().to_string()
+  for i in 0..<1000 {
+    let path = if i == 0 { base } else { base + "_" + i.to_string() }
+    if !@os_fs.path_exists(path) {
+      @os_fs.create_dir(path) catch {
+        e => return Err("create temp dir failed: " + e.to_string())
+      }
+      return Ok(path)
+    }
+  }
+  Err("failed to allocate temp dir")
+}
+
+///|
+fn remove_path_if_exists(path : String) -> Unit {
+  if !@os_fs.path_exists(path) {
+    return
+  }
+  let is_file = @os_fs.is_file(path) catch { _ => false }
+  if is_file {
+    ignore(@os_fs.remove_file(path) catch { _ => () })
+    return
+  }
+  let is_dir = @os_fs.is_dir(path) catch { _ => false }
+  if is_dir {
+    let entries = @os_fs.read_dir(path) catch { _ => [] }
+    for name in entries {
+      remove_path_if_exists(path + "/" + name)
+    }
+    ignore(@os_fs.remove_dir(path) catch { _ => () })
   }
 }
 

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -235,6 +235,16 @@ test "http host run command can invoke multiple exports in order" {
 }
 
 ///|
+test "p3 compose command quotes plug adapter and output paths" {
+  let cmd = build_p3_compose_command(
+    "/tmp/adapter path.wasm", "/tmp/app$plug.component.wasm", "/tmp/out\"component.wasm",
+  )
+  assert_eq(
+    cmd, "wac plug --plug \"/tmp/app\\$plug.component.wasm\" -o \"/tmp/out\\\"component.wasm\" \"/tmp/adapter path.wasm\"",
+  )
+}
+
+///|
 test "resolve repl initial source ignores scratch db by default" {
   let root = wbtest_make_temp_dir("repl_initial_source_fresh")
   let scratch_db_path = root + "/scratch.db"


### PR DESCRIPTION
## Summary

Split from #277. `vibe compile --compose-p3` now shells out to `wac plug` instead of the in-process `@runtime_compile.compose_p3_component` (mwac-based) path, aligning the production CLI with the test scripts introduced by #267.

Other commits from #277 need rework against the post-#298 evaluator-removed base and are out of scope here.

## Changes

- `src/cmd/vibe/cli_compile_cmd.mbt`: replace `@runtime_compile.compose_p3_component` call with a new `compose_p3_component_with_wac` helper that writes the app component to a temp dir, invokes `wac plug --plug <app> -o <out> <adapter>` via `@backend.exec_command_lines`, and cleans up afterwards
- `src/cmd/vibe/cli_wbtest.mbt`: add coverage for the new helper

## Test plan
- [ ] `moon check` passes (confirmed locally)
- [ ] `ci-required` (branch protection) passes
- [ ] `vibe compile --compose-p3` with a P3 adapter produces the same composed component as before on a host with `wac` installed
- [ ] `--compose-p3` falls back with a clear error on a target without `exec` support

🤖 Generated with [Claude Code](https://claude.com/claude-code)