### PR TITLE
Add ast-grep and similarity-mbt to nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
             # Build tools
             pkgs.just
             pkgs.ripgrep
+            pkgs.ast-grep
           ];
 
           shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,18 @@
         rustToolchain = pkgs.rust-bin.stable."1.91.0".default.override {
           targets = [ "wasm32-wasip1" "wasm32-wasip2" ];
         };
+
+        # MoonBit code duplication detector (crates.io / github:mizchi/similarity)
+        similarity-mbt = pkgs.rustPlatform.buildRustPackage rec {
+          pname = "similarity-mbt";
+          version = "0.5.2";
+          src = pkgs.fetchCrate {
+            inherit pname version;
+            hash = "sha256-PTsTXYk6keh92HHbb8E3XD2qi49sg/JPwFKWzPoeqtw=";
+          };
+          cargoHash = "sha256-U5c+C99+bwCTpkEDV3nLFITmIk+n56eWQoq0oqc7qMI=";
+          doCheck = false;
+        };
       in
       {
         devShells.default = pkgs.mkShell {
@@ -45,6 +57,7 @@
             pkgs.just
             pkgs.ripgrep
             pkgs.ast-grep
+            similarity-mbt
           ];
 
           shellHook = ''


### PR DESCRIPTION
## Summary

Extend the flake's devShell with two structural-analysis tools:

- **ast-grep** (nixpkgs 0.42.1): structural code search.
- **similarity-mbt** (crates.io 0.5.2, github:mizchi/similarity): MoonBit code duplication detector. Packaged via `rustPlatform.buildRustPackage` with pinned `src` + `cargoHash` so the binary lands directly in the shell without `cargo install`.

## Test plan
- [x] `nix flake show` evaluates on all 4 default systems
- [x] `nix develop --command similarity-mbt --version` → `similarity-mbt 0.5.2`
- [x] `nix eval nixpkgs#ast-grep.version` → `0.42.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)