### PR TITLE
Dedup 4 MoonBit host hotspots flagged by similarity-mbt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -295,10 +295,10 @@ linked debug build を selfhost でも生成するには以下の移植が必要
 - [ ] `src/backend/http_wasm.mbt` vs `src/backend/http_js.mbt` (30 pairs each) — backend 実装が並走。`src/backend/http_impl.mbt` 側に共通化
 - [ ] `src/benches/advanced_graph_bench.mbt` — `parse_graph_{index,delta}_{json,cbor,flexbuffer}` / `bench_graph_watch_*_{cbor,flexbuffer}` の format 軸をパラメータ化
 - [ ] `src/codegen/wasm_codegen_rc.mbt` — `emit_rc_init` / `emit_rc_init_dynamic` (98.8%), `emit_rc_dup_i64` / `emit_rc_drop_i64` (97%) を closure で差分抽出
-- [ ] `src/cmd/vibe/cli_repl.mbt` — `repl_vibe_view_json` / `repl_vibe_peek_json` (96.2%), `repl_is_vibe_shell_subcommand` / `repl_is_reserved_shell_command_name` (100%)、`compiled_repl_temp_{source,wasm}_path` (100%)
-- [ ] `src/cmd/vibe/cli_test_cmd.mbt` — `sort_test_entry_paths_for_batching` / `sort_test_entry_batch_units` を共通 sort helper へ
-- [ ] `src/runtime/db.mbt` — `set_version_ref` / `set_symbol_ref` (100%), `set_source` / `set_binary_source` (99%) の ref kind 引数化
-- [ ] `src/runtime_compile/ir_sexp.mbt` — `sort_map_fields_expr` / `sort_record_fields_expr` (100%) を generic sort helper へ
+- [x] `src/cmd/vibe/cli_repl.mbt` — `repl_vibe_view_json` / `repl_vibe_peek_json` は `repl_vibe_symbol_lookup_json` に集約、`repl_is_*` は `Array::contains` へ、`compiled_repl_temp_{source,wasm}_path` は共通 `compiled_repl_temp_path(ext)` 経由
+- [x] `src/cmd/vibe/cli_test_cmd.mbt` — `sort_test_entry_paths_for_batching` / `sort_test_entry_batch_units` を `test_entry_selection_sort[T]` 共通 helper に統合
+- [ ] `src/runtime/db.mbt` — `set_source` / `set_binary_source` (99%) の共通化（String/Bytes の差をどう吸収するか要検討）。`set_version_ref` / `set_symbol_ref` / `set_path_ref` は `set_ref` 共通 helper 経由に移行済み
+- [x] `src/runtime_compile/ir_sexp.mbt` — `sort_map_fields_expr` / `sort_record_fields_expr` / `sort_type_ctors` / `sort_record_type_keys` を `sort_by_key[T]` に統合
 - [ ] 計測を CI に載せる (`flaker` か独立 job で閾値 0.98 を回し、新規重複を検出)
 
 ## モジュール分離

--- a/src/cmd/vibe/cli_repl.mbt
+++ b/src/cmd/vibe/cli_repl.mbt
@@ -171,22 +171,12 @@ fn repl_vibe_shell_subcommand_names() -> Array[String] {
 
 ///|
 fn repl_is_vibe_shell_subcommand(name : String) -> Bool {
-  for subcommand in repl_vibe_shell_subcommand_names() {
-    if subcommand == name {
-      return true
-    }
-  }
-  false
+  repl_vibe_shell_subcommand_names().contains(name)
 }
 
 ///|
 fn repl_is_reserved_shell_command_name(name : String) -> Bool {
-  for cmd in repl_reserved_shell_command_names() {
-    if cmd == name {
-      return true
-    }
-  }
-  false
+  repl_reserved_shell_command_names().contains(name)
 }
 
 ///|
@@ -834,33 +824,50 @@ fn repl_vibe_outline_json(
 }
 
 ///|
-fn repl_vibe_view_json(
+fn repl_vibe_symbol_lookup_json(
+  command : String,
   args : Array[String],
   scratch_db_path : String,
   scratch_source : String,
+  include_snippet : Bool,
 ) -> Json {
   if args.length() != 1 {
-    return repl_vibe_error_json("view", "usage: vibe view <symbol>")
+    return repl_vibe_error_json(command, "usage: vibe " + command + " <symbol>")
   }
   let symbol = args[0]
   let matches = repl_resolve_symbol_matches(
     symbol, scratch_db_path, scratch_source,
   )
   if matches.length() == 0 {
-    return repl_vibe_error_json("view", "symbol not found: " + symbol)
+    return repl_vibe_error_json(command, "symbol not found: " + symbol)
   }
   let obj : Map[String, Json] = {}
-  obj["command"] = Json::string("view")
+  obj["command"] = Json::string(command)
   if matches.length() > 1 {
     obj["ok"] = Json::boolean(false)
     obj["error"] = Json::string("multiple matches")
     obj["query"] = Json::string(symbol)
-    obj["candidates"] = repl_symbol_matches_to_json(matches)
+    obj["candidates"] = repl_symbol_matches_to_json(
+      matches, include_snippet=include_snippet,
+    )
   } else {
     obj["ok"] = Json::boolean(true)
-    obj["item"] = repl_symbol_match_to_json(matches[0])
+    obj["item"] = repl_symbol_match_to_json(
+      matches[0], include_snippet=include_snippet,
+    )
   }
   Json::object(obj)
+}
+
+///|
+fn repl_vibe_view_json(
+  args : Array[String],
+  scratch_db_path : String,
+  scratch_source : String,
+) -> Json {
+  repl_vibe_symbol_lookup_json(
+    "view", args, scratch_db_path, scratch_source, false,
+  )
 }
 
 ///|
@@ -869,31 +876,9 @@ fn repl_vibe_peek_json(
   scratch_db_path : String,
   scratch_source : String,
 ) -> Json {
-  if args.length() != 1 {
-    return repl_vibe_error_json("peek", "usage: vibe peek <symbol>")
-  }
-  let symbol = args[0]
-  let matches = repl_resolve_symbol_matches(
-    symbol, scratch_db_path, scratch_source,
+  repl_vibe_symbol_lookup_json(
+    "peek", args, scratch_db_path, scratch_source, true,
   )
-  if matches.length() == 0 {
-    return repl_vibe_error_json("peek", "symbol not found: " + symbol)
-  }
-  let obj : Map[String, Json] = {}
-  obj["command"] = Json::string("peek")
-  if matches.length() > 1 {
-    obj["ok"] = Json::boolean(false)
-    obj["error"] = Json::string("multiple matches")
-    obj["query"] = Json::string(symbol)
-    obj["candidates"] = repl_symbol_matches_to_json(
-      matches,
-      include_snippet=true,
-    )
-  } else {
-    obj["ok"] = Json::boolean(true)
-    obj["item"] = repl_symbol_match_to_json(matches[0], include_snippet=true)
-  }
-  Json::object(obj)
 }
 
 ///|
@@ -2528,13 +2513,18 @@ struct CompiledReplExec {
 } derive(Debug, Eq)
 
 ///|
+fn compiled_repl_temp_path(ext : String) -> String {
+  "/tmp/vibe-compiled-repl-" + vibe_getpid().to_string() + "." + ext
+}
+
+///|
 fn compiled_repl_temp_source_path() -> String {
-  "/tmp/vibe-compiled-repl-" + vibe_getpid().to_string() + ".vibe"
+  compiled_repl_temp_path("vibe")
 }
 
 ///|
 fn compiled_repl_temp_wasm_path() -> String {
-  "/tmp/vibe-compiled-repl-" + vibe_getpid().to_string() + ".wasm"
+  compiled_repl_temp_path("wasm")
 }
 
 ///|

--- a/src/cmd/vibe/cli_test_cmd.mbt
+++ b/src/cmd/vibe/cli_test_cmd.mbt
@@ -1061,24 +1061,32 @@ fn compare_test_entry_batch_path(a : String, b : String) -> Int {
 }
 
 ///|
-fn sort_test_entry_paths_for_batching(paths : Array[String]) -> Unit {
-  let n = paths.length()
+fn[T] test_entry_selection_sort(
+  items : Array[T],
+  compare : (T, T) -> Int,
+) -> Unit {
+  let n = items.length()
   if n < 2 {
     return
   }
   for i in 0..<(n - 1) {
     let mut min_index = i
     for j in (i + 1)..<n {
-      if compare_test_entry_batch_path(paths[j], paths[min_index]) < 0 {
+      if compare(items[j], items[min_index]) < 0 {
         min_index = j
       }
     }
     if min_index != i {
-      let tmp = paths[i]
-      paths[i] = paths[min_index]
-      paths[min_index] = tmp
+      let tmp = items[i]
+      items[i] = items[min_index]
+      items[min_index] = tmp
     }
   }
+}
+
+///|
+fn sort_test_entry_paths_for_batching(paths : Array[String]) -> Unit {
+  test_entry_selection_sort(paths, compare_test_entry_batch_path)
 }
 
 ///|
@@ -1110,23 +1118,7 @@ fn compare_test_entry_batch_unit(
 
 ///|
 fn sort_test_entry_batch_units(units : Array[TestEntryBatchUnit]) -> Unit {
-  let n = units.length()
-  if n < 2 {
-    return
-  }
-  for i in 0..<(n - 1) {
-    let mut min_index = i
-    for j in (i + 1)..<n {
-      if compare_test_entry_batch_unit(units[j], units[min_index]) < 0 {
-        min_index = j
-      }
-    }
-    if min_index != i {
-      let tmp = units[i]
-      units[i] = units[min_index]
-      units[min_index] = tmp
-    }
-  }
+  test_entry_selection_sort(units, compare_test_entry_batch_unit)
 }
 
 ///|

--- a/src/runtime/db.mbt
+++ b/src/runtime/db.mbt
@@ -247,16 +247,17 @@ pub fn VibeDb::set_binary_source(
 }
 
 ///|
+fn VibeDb::set_ref(self : VibeDb, key : String, hash : String) -> Unit {
+  let _ = self.inputs.sources.set(self.rt, key, normalize_hash(hash))
+}
+
+///|
 pub fn VibeDb::set_version_ref(
   self : VibeDb,
   name : String,
   hash : String,
 ) -> Unit {
-  let _ = self.inputs.sources.set(
-    self.rt,
-    version_ref_key(name),
-    normalize_hash(hash),
-  )
+  self.set_ref(version_ref_key(name), hash)
 }
 
 ///|
@@ -265,12 +266,7 @@ pub fn VibeDb::set_path_ref(
   path : String,
   hash : String,
 ) -> Unit {
-  let normalized = normalize_lock_path(path)
-  let _ = self.inputs.sources.set(
-    self.rt,
-    path_ref_key(normalized),
-    normalize_hash(hash),
-  )
+  self.set_ref(path_ref_key(normalize_lock_path(path)), hash)
 }
 
 ///|
@@ -289,11 +285,7 @@ pub fn VibeDb::set_symbol_ref(
   name : String,
   hash : String,
 ) -> Unit {
-  let _ = self.inputs.sources.set(
-    self.rt,
-    symbol_ref_key(name),
-    normalize_hash(hash),
-  )
+  self.set_ref(symbol_ref_key(name), hash)
 }
 
 ///|

--- a/src/runtime_compile/ir_sexp.mbt
+++ b/src/runtime_compile/ir_sexp.mbt
@@ -762,8 +762,17 @@ fn sort_record_type_keys(fields : Map[String, @core.Type]) -> Array[String] {
   let out : Array[String] = []
   for name, _ in fields {
     out.push(name)
+  }
+  sort_by_key(out, fn(s) { s })
+}
+
+///|
+fn[T] sort_by_key(items : Array[T], key : (T) -> String) -> Array[T] {
+  let out : Array[T] = []
+  for item in items {
+    out.push(item)
     let mut i = out.length() - 1
-    while i > 0 && out[i] < out[i - 1] {
+    while i > 0 && key(out[i]) < key(out[i - 1]) {
       let tmp = out[i - 1]
       out[i - 1] = out[i]
       out[i] = tmp
@@ -777,52 +786,19 @@ fn sort_record_type_keys(fields : Map[String, @core.Type]) -> Array[String] {
 fn sort_map_fields_expr(
   fields : Array[@core.MapFieldExpr],
 ) -> Array[@core.MapFieldExpr] {
-  let out : Array[@core.MapFieldExpr] = []
-  for field in fields {
-    out.push(field)
-    let mut i = out.length() - 1
-    while i > 0 && out[i].key < out[i - 1].key {
-      let tmp = out[i - 1]
-      out[i - 1] = out[i]
-      out[i] = tmp
-      i -= 1
-    }
-  }
-  out
+  sort_by_key(fields, fn(f) { f.key })
 }
 
 ///|
 fn sort_record_fields_expr(
   fields : Array[@core.RecordFieldExpr],
 ) -> Array[@core.RecordFieldExpr] {
-  let out : Array[@core.RecordFieldExpr] = []
-  for field in fields {
-    out.push(field)
-    let mut i = out.length() - 1
-    while i > 0 && out[i].name < out[i - 1].name {
-      let tmp = out[i - 1]
-      out[i - 1] = out[i]
-      out[i] = tmp
-      i -= 1
-    }
-  }
-  out
+  sort_by_key(fields, fn(f) { f.name })
 }
 
 ///|
 fn sort_type_ctors(ctors : Array[@core.TypeCtor]) -> Array[@core.TypeCtor] {
-  let out : Array[@core.TypeCtor] = []
-  for ctor in ctors {
-    out.push(ctor)
-    let mut i = out.length() - 1
-    while i > 0 && out[i].name < out[i - 1].name {
-      let tmp = out[i - 1]
-      out[i - 1] = out[i]
-      out[i] = tmp
-      i -= 1
-    }
-  }
-  out
+  sort_by_key(ctors, fn(c) { c.name })
 }
 
 ///|


### PR DESCRIPTION
## Summary

TODO.md の「MoonBit host 重複削減 (similarity-mbt ベース)」から 4 件を処理。

- `src/runtime_compile/ir_sexp.mbt`: 4 つの insertion sort を generic `sort_by_key[T]` に集約
- `src/runtime/db.mbt`: `set_version_ref` / `set_symbol_ref` / `set_path_ref` を private `set_ref` helper 経由に
- `src/cmd/vibe/cli_test_cmd.mbt`: 2 つの selection sort を `test_entry_selection_sort[T]` に共通化
- `src/cmd/vibe/cli_repl.mbt`:
  - `repl_vibe_view_json` / `repl_vibe_peek_json` → `repl_vibe_symbol_lookup_json`
  - `repl_is_{vibe_shell_subcommand,reserved_shell_command_name}` → `Array::contains`
  - `compiled_repl_temp_{source,wasm}_path` → `compiled_repl_temp_path(ext)`

差分: 5 files, +74/-124。挙動変更なしの純 refactor。

## Test plan

- [ ] `just check` (CI contract-moon / contract-native shard)
- [ ] `just test` (CI test shard)
- [ ] `wasm-compile-e2e` / `selfhost-gates` shards

https://claude.ai/code/session_01V67Kbf1Wufj92XgXaWe8oD