### PR TITLE
Dedup wasm_codegen_rc, drop unused store helpers, wire similarity-mbt CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,6 +721,58 @@ jobs:
             _build/coverage/selfhost-suite/selfhost_suite.report.json
           if-no-files-found: ignore
 
+  similarity-mbt-report:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache similarity-mbt binary
+        id: similarity-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/similarity-mbt
+          key: similarity-mbt-${{ runner.os }}-v0.5.2
+
+      - name: Install similarity-mbt
+        if: steps.similarity-cache.outputs.cache-hit != 'true'
+        run: cargo install similarity-mbt --version 0.5.2 --locked
+
+      - name: Run similarity-mbt
+        id: sim
+        run: |
+          set +e
+          similarity-mbt src/ --threshold 0.98 > sim-report.txt 2>&1
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          lines=$(wc -l < sim-report.txt)
+          echo "lines=$lines" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Similarity summary
+        if: always()
+        run: |
+          {
+            echo "### similarity-mbt duplicate report (threshold 0.98)"
+            echo ""
+            echo "- Report lines: ${{ steps.sim.outputs.lines }}"
+            echo ""
+            echo '```'
+            head -120 sim-report.txt || echo "(no report)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload similarity report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: similarity-mbt-report
+          path: sim-report.txt
+          if-no-files-found: ignore
+
   ci-required:
     if: always()
     needs:
@@ -761,6 +813,7 @@ jobs:
       - coverage-selfhost-suite
       - native-binary-parity
       - selfhost-gates
+      - similarity-mbt-report
       - wasm-codegen-quick
     runs-on: ubuntu-latest
     steps:
@@ -772,6 +825,7 @@ jobs:
           echo "  coverage-selfhost-suite: ${{ needs.coverage-selfhost-suite.result }}"
           echo "  native-binary-parity: ${{ needs.native-binary-parity.result }}"
           echo "  selfhost-gates: ${{ needs.selfhost-gates.result }}"
+          echo "  similarity-mbt-report: ${{ needs.similarity-mbt-report.result }}"
           echo "  wasm-codegen-quick: ${{ needs.wasm-codegen-quick.result }}"
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo ""

--- a/TODO.md
+++ b/TODO.md
@@ -291,15 +291,15 @@ linked debug build を selfhost でも生成するには以下の移植が必要
 
 ノイズを除いた中規模ファイル (5–100 pairs) が現実的な refactor 候補:
 
-- [ ] `src/runtime/store.mbt` (40 pairs) — `get` / `get_by_addr` / `get_alias` / `pure_cache_get` / `get_module` の Map.get + tag チェック同型。共通 helper 抽出
+- [x] `src/runtime/store.mbt` — `get_by_addr` / `get_alias` / `pure_cache_get` / `pure_cache_set` / `get_module` は未使用 helper だったので削除（`Runtime::get` は公開 API で残存）
 - [ ] `src/backend/http_wasm.mbt` vs `src/backend/http_js.mbt` (30 pairs each) — backend 実装が並走。`src/backend/http_impl.mbt` 側に共通化
 - [ ] `src/benches/advanced_graph_bench.mbt` — `parse_graph_{index,delta}_{json,cbor,flexbuffer}` / `bench_graph_watch_*_{cbor,flexbuffer}` の format 軸をパラメータ化
-- [ ] `src/codegen/wasm_codegen_rc.mbt` — `emit_rc_init` / `emit_rc_init_dynamic` (98.8%), `emit_rc_dup_i64` / `emit_rc_drop_i64` (97%) を closure で差分抽出
+- [x] `src/codegen/wasm_codegen_rc.mbt` — `emit_rc_init_impl(emit_size closure)` に共通化、`emit_rc_call_or_inline_i64(emit_inline closure)` で dup/drop の分岐を抽出
 - [x] `src/cmd/vibe/cli_repl.mbt` — `repl_vibe_view_json` / `repl_vibe_peek_json` は `repl_vibe_symbol_lookup_json` に集約、`repl_is_*` は `Array::contains` へ、`compiled_repl_temp_{source,wasm}_path` は共通 `compiled_repl_temp_path(ext)` 経由
 - [x] `src/cmd/vibe/cli_test_cmd.mbt` — `sort_test_entry_paths_for_batching` / `sort_test_entry_batch_units` を `test_entry_selection_sort[T]` 共通 helper に統合
 - [ ] `src/runtime/db.mbt` — `set_source` / `set_binary_source` (99%) の共通化（String/Bytes の差をどう吸収するか要検討）。`set_version_ref` / `set_symbol_ref` / `set_path_ref` は `set_ref` 共通 helper 経由に移行済み
 - [x] `src/runtime_compile/ir_sexp.mbt` — `sort_map_fields_expr` / `sort_record_fields_expr` / `sort_type_ctors` / `sort_record_type_keys` を `sort_by_key[T]` に統合
-- [ ] 計測を CI に載せる (`flaker` か独立 job で閾値 0.98 を回し、新規重複を検出)
+- [x] 計測を CI に載せる — `similarity-mbt-report` job を informational として追加（閾値 0.98、sim-report.txt を artifact、`ci-informational` 集約経由）
 
 ## モジュール分離
 

--- a/src/codegen/wasm_codegen_rc.mbt
+++ b/src/codegen/wasm_codegen_rc.mbt
@@ -82,19 +82,19 @@ fn emit_rc_debug_increment(buf : ByteBuf, global_idx : Int) -> Unit {
 }
 
 ///|
-fn emit_rc_init(
+fn emit_rc_init_impl(
   buf : ByteBuf,
   obj_local : Int,
-  alloc_size : Int,
-  header_size? : Int = 8,
-  debug_alloc_global? : Int = -1,
+  emit_size : (ByteBuf) -> Unit,
+  header_size : Int,
+  debug_alloc_global : Int,
 ) -> Unit {
   // Write alloc_size at obj_ptr - header_size (only when free-list is enabled, header=8)
   if header_size > 4 {
     emit_local_get(buf, obj_local)
     emit_i32_const_raw(buf, header_size)
     emit_i32_sub(buf)
-    emit_i32_const_raw(buf, alloc_size)
+    emit_size(buf)
     emit_i32_store(buf, 0)
   }
   // Write rc_count = 1 at obj_ptr - 4
@@ -110,6 +110,23 @@ fn emit_rc_init(
 }
 
 ///|
+fn emit_rc_init(
+  buf : ByteBuf,
+  obj_local : Int,
+  alloc_size : Int,
+  header_size? : Int = 8,
+  debug_alloc_global? : Int = -1,
+) -> Unit {
+  emit_rc_init_impl(
+    buf,
+    obj_local,
+    fn(b) { emit_i32_const_raw(b, alloc_size) },
+    header_size,
+    debug_alloc_global,
+  )
+}
+
+///|
 /// Emit RC initialization with dynamic alloc_size from a local variable.
 /// Used for variable-length allocations where size is computed at runtime.
 fn emit_rc_init_dynamic(
@@ -119,24 +136,13 @@ fn emit_rc_init_dynamic(
   header_size? : Int = 8,
   debug_alloc_global? : Int = -1,
 ) -> Unit {
-  // Write alloc_size at obj_ptr - header_size (only when free-list enabled, header=8)
-  if header_size > 4 {
-    emit_local_get(buf, obj_local)
-    emit_i32_const_raw(buf, header_size)
-    emit_i32_sub(buf)
-    emit_local_get(buf, size_local) // dynamic size
-    emit_i32_store(buf, 0)
-  }
-  // Write rc_count = 1 at obj_ptr - 4
-  emit_local_get(buf, obj_local)
-  emit_i32_const_raw(buf, 4)
-  emit_i32_sub(buf)
-  emit_i32_const_raw(buf, 1)
-  emit_i32_store(buf, 0)
-  // Debug mode: increment alloc counter
-  if debug_alloc_global >= 0 {
-    emit_rc_debug_increment(buf, debug_alloc_global)
-  }
+  emit_rc_init_impl(
+    buf,
+    obj_local,
+    fn(b) { emit_local_get(b, size_local) },
+    header_size,
+    debug_alloc_global,
+  )
 }
 
 ///|
@@ -592,13 +598,19 @@ fn ensure_rc_locals(ctx : CodegenCtx) -> Unit {
 }
 
 ///|
-/// Emit RC dup for an i64 local.
-/// When helper function is available, emits a call; otherwise inlines.
-fn emit_rc_dup_i64(ctx : CodegenCtx, buf : ByteBuf, local_idx : Int) -> Unit {
-  if ctx.rc_dup_func_idx >= 0 {
-    // Call the helper function: $rc_dup(i64) -> void
+/// Emit RC dup/drop for an i64 local.
+/// When helper function is available, emits a call; otherwise inlines via
+/// the supplied `emit_inline` closure (which receives the val32 temp index).
+fn emit_rc_call_or_inline_i64(
+  ctx : CodegenCtx,
+  buf : ByteBuf,
+  local_idx : Int,
+  helper_func_idx : Int,
+  emit_inline : (Int) -> Unit,
+) -> Unit {
+  if helper_func_idx >= 0 {
     emit_local_get(buf, local_idx)
-    let abs_idx = func_import_count(ctx) + ctx.rc_dup_func_idx
+    let abs_idx = func_import_count(ctx) + helper_func_idx
     emit_call(buf, abs_idx)
     return
   }
@@ -607,26 +619,25 @@ fn emit_rc_dup_i64(ctx : CodegenCtx, buf : ByteBuf, local_idx : Int) -> Unit {
   emit_local_get(buf, local_idx)
   emit_i32_wrap_i64(buf)
   emit_local_set(buf, val32)
-  emit_rc_dup(buf, val32, ctx.rc_tmp_local)
+  emit_inline(val32)
 }
 
 ///|
-/// Emit RC drop for an i64 local.
-/// When helper function is available, emits a call; otherwise inlines.
+fn emit_rc_dup_i64(ctx : CodegenCtx, buf : ByteBuf, local_idx : Int) -> Unit {
+  emit_rc_call_or_inline_i64(ctx, buf, local_idx, ctx.rc_dup_func_idx, fn(
+    val32,
+  ) {
+    emit_rc_dup(buf, val32, ctx.rc_tmp_local)
+  })
+}
+
+///|
 fn emit_rc_drop_i64(ctx : CodegenCtx, buf : ByteBuf, local_idx : Int) -> Unit {
-  if ctx.rc_drop_func_idx >= 0 {
-    // Call the helper function: $rc_drop(i64) -> void
-    emit_local_get(buf, local_idx)
-    let abs_idx = func_import_count(ctx) + ctx.rc_drop_func_idx
-    emit_call(buf, abs_idx)
-    return
-  }
-  ensure_rc_locals(ctx)
-  let val32 = alloc_temp_local(ctx)
-  emit_local_get(buf, local_idx)
-  emit_i32_wrap_i64(buf)
-  emit_local_set(buf, val32)
-  emit_rc_drop(ctx, buf, val32, ctx.rc_tmp_local, ctx.rc_new_rc_local)
+  emit_rc_call_or_inline_i64(ctx, buf, local_idx, ctx.rc_drop_func_idx, fn(
+    val32,
+  ) {
+    emit_rc_drop(ctx, buf, val32, ctx.rc_tmp_local, ctx.rc_new_rc_local)
+  })
 }
 
 ///|

--- a/src/runtime/store.mbt
+++ b/src/runtime/store.mbt
@@ -359,11 +359,6 @@ pub fn Runtime::get(self : Runtime, name : String) -> @core.Value? {
 }
 
 ///|
-fn Runtime::get_by_addr(self : Runtime, addr : String) -> @core.Value? {
-  self.store.get(addr)
-}
-
-///|
 pub fn Runtime::get_addr(self : Runtime, name : String) -> String? {
   self.addr_env.get(name)
 }
@@ -388,25 +383,6 @@ pub fn Runtime::set_alias(
   target : @core.Ref,
 ) -> Unit {
   self.aliases[name] = target
-}
-
-///|
-fn Runtime::get_alias(self : Runtime, name : String) -> @core.Ref? {
-  self.aliases.get(name)
-}
-
-///|
-fn Runtime::pure_cache_get(self : Runtime, key : String) -> @core.Value? {
-  self.pure_cache.get(key)
-}
-
-///|
-fn Runtime::pure_cache_set(
-  self : Runtime,
-  key : String,
-  value : @core.Value,
-) -> Unit {
-  self.pure_cache.set(key, value)
 }
 
 ///|
@@ -513,8 +489,3 @@ pub fn Runtime::register_module(
   self.module_cache.set(hash, mod_ast)
 }
 
-///|
-/// Get a cached module by hash
-fn Runtime::get_module(self : Runtime, hash : String) -> @core.Module? {
-  self.module_cache.get(hash)
-}


### PR DESCRIPTION
## Summary

TODO.md の「similarity-mbt 残り refactor」+「計測を CI に載せる」をまとめて処理。

- **`src/codegen/wasm_codegen_rc.mbt`**:
  - `emit_rc_init` / `emit_rc_init_dynamic` → `emit_rc_init_impl(emit_size closure)`
  - `emit_rc_dup_i64` / `emit_rc_drop_i64` → `emit_rc_call_or_inline_i64(helper_idx, emit_inline closure)`
- **`src/runtime/store.mbt`**: `get_by_addr` / `get_alias` / `pure_cache_get` / `pure_cache_set` / `get_module` を削除（package-private かつ呼び出し元ゼロ）
- **`.github/workflows/ci.yml`**: `similarity-mbt-report` informational job 追加
  - threshold 0.98、crates.io から v0.5.2 を cargo install（バイナリキャッシュ）
  - `sim-report.txt` artifact 保存、`GITHUB_STEP_SUMMARY` に先頭 120 行を展開
  - `ci-informational` 集約 needs に追加

## Test plan

- [ ] `contract-moon` / `contract-native` が pass（store.mbt の削除が package 内外から参照されていないことを確認）
- [ ] `wasm-compile-e2e` / `wasm-parity` shards（rc codegen 挙動に regression が無いこと）
- [ ] `similarity-mbt-report` が artifact をアップロードし summary に重複 report を出力

https://claude.ai/code/session_01V67Kbf1Wufj92XgXaWe8oD