### PR TITLE
Add DCE + normalize coverage for ExternLet / LetMut / Block collapse

### DIFF
--- a/src/core/normalize_export_wbtest.mbt
+++ b/src/core/normalize_export_wbtest.mbt
@@ -206,6 +206,80 @@ test "normalize_module canonicalizes EffectDef export list into ExportEffectDef"
 }
 
 ///|
+test "normalize_expr unwraps single-Stmt::Expr Block to the inner expression" {
+  // `let x = { 42 }` should collapse the one-expr Block to `let x = 42`.
+  let inner = Expr::Block(
+    body=Module::{
+      stmts: [
+        Stmt::Expr(
+          expr=int_expr_for_export_norm_test(42),
+          span=zero_span_for_export_norm_test,
+        ),
+      ],
+    },
+    span=zero_span_for_export_norm_test,
+  )
+  let mod_ast = Module::{
+    stmts: [
+      Stmt::Let(
+        rec=false,
+        name="x",
+        expr=inner,
+        span=zero_span_for_export_norm_test,
+      ),
+    ],
+  }
+  let normalized = normalize_module(mod_ast)
+  assert_eq(normalized.stmts.length(), 1)
+  assert_true(
+    match normalized.stmts[0] {
+      Stmt::Let(expr=Expr::Int(value=42L, ..), ..) => true
+      _ => false
+    },
+  )
+}
+
+///|
+test "normalize_expr keeps Block wrapper when it contains multiple stmts" {
+  // `let x = { let y = 1; y }` should remain a Block (two stmts).
+  let inner = Expr::Block(
+    body=Module::{
+      stmts: [
+        Stmt::Let(
+          rec=false,
+          name="y",
+          expr=int_expr_for_export_norm_test(1),
+          span=zero_span_for_export_norm_test,
+        ),
+        Stmt::Expr(
+          expr=Expr::Ident(name="y", span=zero_span_for_export_norm_test),
+          span=zero_span_for_export_norm_test,
+        ),
+      ],
+    },
+    span=zero_span_for_export_norm_test,
+  )
+  let mod_ast = Module::{
+    stmts: [
+      Stmt::Let(
+        rec=false,
+        name="x",
+        expr=inner,
+        span=zero_span_for_export_norm_test,
+      ),
+    ],
+  }
+  let normalized = normalize_module(mod_ast)
+  assert_eq(normalized.stmts.length(), 1)
+  assert_true(
+    match normalized.stmts[0] {
+      Stmt::Let(expr=Expr::Block(..), ..) => true
+      _ => false
+    },
+  )
+}
+
+///|
 test "normalize_with_imports returns only the main module when resolver always fails" {
   let main_mod = Module::{
     stmts: [

--- a/src/frontend/dce_wbtest.mbt
+++ b/src/frontend/dce_wbtest.mbt
@@ -491,3 +491,96 @@ test "dce keeps TypeAlias when referenced from reachable StructDef field" {
   let filtered = dce_module(mod)
   assert_true(has_type_alias_stmt(filtered.stmts, "UserId"))
 }
+
+///|
+fn has_extern_let_stmt(stmts : Array[@core.Stmt], target : String) -> Bool {
+  for stmt in stmts {
+    match stmt {
+      @core.Stmt::ExternLet(name~, ..) => if name == target { return true }
+      _ => ()
+    }
+  }
+  false
+}
+
+///|
+test "dce keeps LetMut as last-statement entry" {
+  let mod = @core.Module::{
+    stmts: [
+      @core.Stmt::Let(
+        rec=false,
+        name="unused",
+        expr=dce_test_int(1L),
+        span=dce_test_span(),
+      ),
+      @core.Stmt::LetMut(
+        name="counter",
+        expr=dce_test_int(0L),
+        span=dce_test_span(),
+      ),
+    ],
+  }
+  let filtered = dce_module(mod)
+  let names = collect_stmt_names(filtered.stmts)
+  assert_true(names.contains("counter"))
+  assert_false(names.contains("unused"))
+}
+
+///|
+test "dce keeps TypeAlias referenced via reachable ExternLet" {
+  // export let reader = fd  -> fd (ExternLet) -> Handle (TypeAlias)
+  let mod = @core.Module::{
+    stmts: [
+      @core.Stmt::TypeAlias(
+        name="Handle",
+        params=[],
+        target=@core.Type::Int,
+        span=dce_test_span(),
+      ),
+      @core.Stmt::ExternLet(
+        name="fd",
+        ty=@core.Type::Named(name="Handle", args=[]),
+        span=dce_test_span(),
+      ),
+      @core.Stmt::ExportLet(
+        rec=false,
+        name="reader",
+        expr=dce_test_ident("fd"),
+        span=dce_test_span(),
+      ),
+    ],
+  }
+  let filtered = dce_module(mod)
+  assert_true(has_type_alias_stmt(filtered.stmts, "Handle"))
+  assert_true(has_extern_let_stmt(filtered.stmts, "fd"))
+  let names = collect_stmt_names(filtered.stmts)
+  assert_true(names.contains("reader"))
+}
+
+///|
+test "dce drops ExternLet + its TypeAlias when nothing references them" {
+  let mod = @core.Module::{
+    stmts: [
+      @core.Stmt::TypeAlias(
+        name="Handle",
+        params=[],
+        target=@core.Type::Int,
+        span=dce_test_span(),
+      ),
+      @core.Stmt::ExternLet(
+        name="fd",
+        ty=@core.Type::Named(name="Handle", args=[]),
+        span=dce_test_span(),
+      ),
+      @core.Stmt::ExportLet(
+        rec=false,
+        name="reader",
+        expr=dce_test_int(0L),
+        span=dce_test_span(),
+      ),
+    ],
+  }
+  let filtered = dce_module(mod)
+  assert_false(has_type_alias_stmt(filtered.stmts, "Handle"))
+  assert_false(has_extern_let_stmt(filtered.stmts, "fd"))
+}

--- a/src/loader/loader_test.mbt
+++ b/src/loader/loader_test.mbt
@@ -1312,3 +1312,59 @@ test "loader load_db_with_paths_with_fs ignores unlabeled fenced block in markdo
     None => fail("expected extracted markdown source")
   }
 }
+
+///|
+test "loader load_db_with_paths_with_fs joins multiple vibe blocks with blank line" {
+  // Verifies the "\n\n" block separator in extract_vibe_from_markdown
+  // (lib.mbt:42-47) which previously had no direct assertion.
+  let root = "/workspace/docs"
+  let entry = root + "/multi.md"
+  let fs = MemIoAdapter::new(root)
+  match
+    fs.write_string(
+      entry, "```vibe\nlet a = 1\n```\n\n```vibe\nlet b = 2\n```\n\n```vibe\nlet main = a + b\nexport { main }\n```\n",
+    ) {
+    Ok(_) => ()
+    Err(err) => fail(err)
+  }
+  let loaded = match load_db_with_paths_with_fs(entry, fs) {
+    Ok(v) => v
+    Err(err) => fail(err)
+  }
+  let (db, resolved, _) = loaded
+  match db.get_source(resolved) {
+    Some(source) => {
+      assert_true(source.contains("let a = 1\n\nlet b = 2"))
+      assert_true(source.contains("let b = 2\n\nlet main = a + b"))
+    }
+    None => fail("expected extracted markdown source")
+  }
+}
+
+///|
+test "loader load_db_with_paths_with_fs closes vibe block on trimmed fence" {
+  // Verifies that a closing fence with trailing whitespace still terminates
+  // the block (extract_vibe_from_markdown uses line.trim(), lib.mbt:21).
+  let root = "/workspace/docs"
+  let entry = root + "/spacey.md"
+  let fs = MemIoAdapter::new(root)
+  match
+    fs.write_string(
+      entry, "```vibe\nlet main = 1\nexport { main }\n```   \n\nTrailing prose that must not leak.\n",
+    ) {
+    Ok(_) => ()
+    Err(err) => fail(err)
+  }
+  let loaded = match load_db_with_paths_with_fs(entry, fs) {
+    Ok(v) => v
+    Err(err) => fail(err)
+  }
+  let (db, resolved, _) = loaded
+  match db.get_source(resolved) {
+    Some(source) => {
+      assert_true(source.contains("let main = 1"))
+      assert_false(source.contains("Trailing prose"))
+    }
+    None => fail("expected extracted markdown source")
+  }
+}


### PR DESCRIPTION
## Summary

TODO.md の「normalize / DCE / loader テスト拡充 (#298 follow-up)」のうち、直近の ae394b3 / f14e8ec で埋まらなかった 2 箇所に unit test を追加。

### DCE: ExternLet + LetMut reachability (`src/frontend/dce_wbtest.mbt`)
- `LetMut` が最終 stmt の時に entry になることを確認（`collect_entries:375` / `filter_reachable_stmts:547`）
- 到達可能な `ExternLet` の型参照経由で `TypeAlias` が残ることを確認（`collect_stmt_info` ExternLet 分岐, `dce.mbt:252`）
- 逆に nothing-references の場合は両方 drop されることを確認

### Normalize: Block single-Stmt::Expr collapse (`src/core/normalize_export_wbtest.mbt`)
- `Expr::Block` の body が `[Stmt::Expr]` ちょうど1本の時に inner expr へ unwrap される分岐 (`normalize.mbt:524-525`)
- 複数 stmts の時は Block wrapper が残る fall-through 分岐

## Test plan
- [x] `moon check` 0 errors
- [x] `moon test -p mizchi/vibe/frontend -f dce_wbtest.mbt` → 13/13 pass
- [x] `moon test -p mizchi/vibe/core -f normalize_export_wbtest.mbt` → 8/8 pass
- [ ] CI `ci-required` を通す