### PR TITLE
Restore in-process mwac for --compose-p3, drop wac plug workarounds

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -13,11 +13,8 @@
     "mizchi/flatbuffers": "0.1.3",
     "mizchi/wite": "0.6.5",
     "mizchi/similarity": "0.2.1",
-    "mizchi/mwac": "0.1.6",
+    "mizchi/mwac": "0.2.1",
     "moonbitlang/parser": "0.2.5"
-  },
-  "overrides": {
-    "mizchi/mwac": { "path": "../mwac" }
   },
   "readme": "README.md",
   "repository": "https://github.com/mizchi/vibe-lang",

--- a/scripts/compose_http_p3_handler.sh
+++ b/scripts/compose_http_p3_handler.sh
@@ -30,7 +30,6 @@ require_cmd() {
 
 require_cmd moon
 require_cmd wasm-tools
-require_cmd wac
 
 INPUT=""
 OUTPUT=""
@@ -63,16 +62,10 @@ else
   echo "[compose] using cached adapter"
 fi
 
-# Step 2: Compile vibe source to a sync component, then compose with the
-# adapter via wac. We use wac rather than `vibe compile --compose-p3` because
-# the built-in mwac plug_components does not forward component type
-# definitions referenced by the socket's imports (issue #267) and produces
-# an invalid component for non-trivial adapter imports.
-PLUG="${OUTPUT%.wasm}.plug.wasm"
-echo "[compose] compiling $INPUT to plug component..."
-$VIBE compile --component-string-lift "$INPUT" -o "$PLUG" 2>/dev/null
-echo "[compose] composing plug into adapter via wac plug..."
-wac plug --plug "$PLUG" -o "$OUTPUT" "$ADAPTER"
+# Step 2: Compile vibe source and compose with the adapter via the built-in
+# mwac plug path (vibe compile --compose-p3).
+echo "[compose] compiling $INPUT and composing with adapter..."
+$VIBE compile --compose-p3 "$INPUT" --adapter "$ADAPTER" -o "$OUTPUT" 2>/dev/null
 
 # Step 3: Validate
 wasm-tools validate --features all "$OUTPUT"

--- a/scripts/test_wasi_p3_e2e.sh
+++ b/scripts/test_wasi_p3_e2e.sh
@@ -88,7 +88,6 @@ fi
 test_scalar_handler() {
   local name="scalar_hello"
   local src="$OUT_DIR/${name}.vibe"
-  local plug_component="$OUT_DIR/${name}.plug.wasm"
   local component="$OUT_DIR/${name}.p3.component.wasm"
 
   cat > "$src" << 'VIBE'
@@ -98,23 +97,9 @@ export let handler = (method: String, url: String) -> Int {
 handler("GET", "/")
 VIBE
 
-  # Compose via wac rather than `vibe compile --compose-p3` because the
-  # built-in mwac plug_components does not forward component type definitions
-  # referenced by the socket's imports (issue #267). wac handles this case
-  # correctly and is already required by the selfhost-cli direct-component
-  # test, so assuming it is on PATH is consistent with the rest of the
-  # component-model test fleet.
-  log_info "Compiling $name plug..."
-  if ! "$VIBE" compile --component-string-lift "$src" -o "$plug_component" 2>/dev/null; then
-    log_fail "$name: component-string-lift compilation failed"
-    return
-  fi
-  log_info "Composing $name with adapter via wac plug..."
-  if ! wac plug \
-        --plug "$plug_component" \
-        -o "$component" \
-        "$ADAPTER_COMPONENT" 2>/dev/null; then
-    log_fail "$name: wac plug composition failed"
+  log_info "Compiling $name and composing with adapter..."
+  if ! "$VIBE" compile --compose-p3 "$src" --adapter "$ADAPTER_COMPONENT" -o "$component" 2>/dev/null; then
+    log_fail "$name: compose-p3 compilation failed"
     return
   fi
   log_pass "$name: compiled to P3 component"

--- a/scripts/vibe_serve.sh
+++ b/scripts/vibe_serve.sh
@@ -142,30 +142,17 @@ else
   COMPONENT="$TEMP_COMPONENT"
 fi
 
-TEMP_PLUG="$(mktemp /tmp/vibe_serve_plug_XXXXXX.wasm)"
-
 cleanup() {
   if [ -n "$TEMP_COMPONENT" ] && [ -f "$TEMP_COMPONENT" ]; then
     rm -f "$TEMP_COMPONENT"
   fi
-  rm -f "$TEMP_PLUG"
 }
 trap cleanup EXIT
 
-if ! command -v wac >/dev/null 2>&1; then
-  echo "error: wac not found" >&2
-  echo "install: cargo install wac-cli" >&2
-  exit 1
-fi
-
-# Compile the handler to a sync component, then compose with the adapter via
-# wac. See issue #267: the built-in `vibe compile --compose-p3` mode uses the
-# mwac plug_components routine which does not forward component type
-# definitions referenced by the socket's imports and produces an invalid
-# component for non-trivial adapters.
+# Compile the handler and compose with the adapter via the built-in
+# mwac plug path (vibe compile --compose-p3).
 echo "[serve] compiling $INPUT..."
-$VIBE compile --component-string-lift "$INPUT" -o "$TEMP_PLUG" 2>/dev/null
-wac plug --plug "$TEMP_PLUG" -o "$COMPONENT" "$ADAPTER"
+$VIBE compile --compose-p3 "$INPUT" --adapter "$ADAPTER" -o "$COMPONENT" 2>/dev/null
 
 if [ "$VALIDATE" = "1" ] && command -v wasm-tools >/dev/null 2>&1; then
   if ! wasm-tools validate --features all "$COMPONENT" 2>/dev/null; then

--- a/src/cmd/vibe/cli_compile_cmd.mbt
+++ b/src/cmd/vibe/cli_compile_cmd.mbt
@@ -324,8 +324,18 @@ fn compile_cmd(args : Array[String]) -> Unit {
           ) catch {
             e => abort("compile: " + e.user_message())
           }
-          match
-            compose_p3_component_with_wac(adapter_path, app_bytes, resolved_out) {
+          // Step 2: Read adapter and compose with mwac plug
+          let adapter_bytes = match @io.read_bytes_with(fs, adapter_path) {
+            Ok(b) => b
+            Err(err) => abort("compile: failed to read adapter: " + err)
+          }
+          // adapter = socket (imports handler), app = plug (exports handler)
+          let composed = @runtime_compile.compose_p3_component(
+            app_bytes, adapter_bytes,
+          ) catch {
+            e => abort("compile: " + e.user_message())
+          }
+          match @io.write_bytes_with(fs, resolved_out, composed) {
             Ok(_) => ()
             Err(err) => abort("compile: " + err)
           }
@@ -369,51 +379,6 @@ fn compile_cmd(args : Array[String]) -> Unit {
         }
       }
     }
-  }
-}
-
-///|
-fn build_p3_compose_command(
-  adapter_path : String,
-  app_path : String,
-  out_path : String,
-) -> String {
-  "wac plug --plug " +
-  shell_quote_command_arg(app_path) +
-  " -o " +
-  shell_quote_command_arg(out_path) +
-  " " +
-  shell_quote_command_arg(adapter_path)
-}
-
-///|
-fn compose_p3_component_with_wac(
-  adapter_path : String,
-  app_bytes : Bytes,
-  out_path : String,
-) -> Result[Unit, String] {
-  if !@backend.exec_available() {
-    return Err(
-      "--compose-p3 requires external process execution on this target",
-    )
-  }
-  match ensure_parent_dir_for_file(out_path, "compile") {
-    Ok(_) => ()
-    Err(err) => return Err(err)
-  }
-  let tmp_dir = match make_cli_temp_dir("compose_p3") {
-    Ok(path) => path
-    Err(err) => return Err(err)
-  }
-  defer remove_path_if_exists(tmp_dir)
-  let app_path = tmp_dir + "/app.component.wasm"
-  @os_fs.write_bytes_to_file(app_path, app_bytes) catch {
-    e => return Err("failed to write temp component: " + e.to_string())
-  }
-  let cmd = build_p3_compose_command(adapter_path, app_path, out_path)
-  match @backend.exec_command_lines(cmd) {
-    Ok(_) => Ok(())
-    Err(err) => Err("wac plug failed: " + err)
   }
 }
 

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -235,16 +235,6 @@ test "http host run command can invoke multiple exports in order" {
 }
 
 ///|
-test "p3 compose command quotes plug adapter and output paths" {
-  let cmd = build_p3_compose_command(
-    "/tmp/adapter path.wasm", "/tmp/app$plug.component.wasm", "/tmp/out\"component.wasm",
-  )
-  assert_eq(
-    cmd, "wac plug --plug \"/tmp/app\\$plug.component.wasm\" -o \"/tmp/out\\\"component.wasm\" \"/tmp/adapter path.wasm\"",
-  )
-}
-
-///|
 test "resolve repl initial source ignores scratch db by default" {
   let root = wbtest_make_temp_dir("repl_initial_source_fresh")
   let scratch_db_path = root + "/scratch.db"


### PR DESCRIPTION
## Summary
Closes #290.

The upstream mwac bug (imports' referenced component type sections not forwarded to the outer composed component) was fixed by [mizchi/mwac@6dc1ae2](https://github.com/mizchi/mwac/commit/6dc1ae2) (type section forwarding for WASI HTTP P3 adapter composition). With that in place we can drop the external `wac plug` workarounds introduced by #267 / #284 / #299.

## Changes
- `src/cmd/vibe/cli_compile_cmd.mbt`: `--compose-p3` goes back through in-process `@runtime_compile.compose_p3_component` (mwac) instead of shelling out to `wac plug`. Removes `compose_p3_component_with_wac` helper.
- `src/cmd/vibe/cli_wbtest.mbt`: drop the wac-command builder test.
- `scripts/test_wasi_p3_e2e.sh`, `scripts/compose_http_p3_handler.sh`, `scripts/vibe_serve.sh`: invoke `vibe compile --compose-p3` instead of assembling `wac plug` commands themselves; `wac` no longer required on `PATH` for these scripts.

## Test plan
- [x] `vibe compile --compose-p3` against the WASI HTTP P3 adapter + a trivial scalar handler plug produces the same bytes as `@mwac.plug_components(adapter, [app], best_effort=true)` run from mwac's own test suite.
- [x] `wasm-tools validate --features all` exits 0 on the composed component.
- [ ] CI (ci-required)
- [ ] `scripts/test_wasi_p3_e2e.sh`

## Follow-up
- Bump `mizchi/mwac` in `moon.mod.json` once 0.2.0 is published to mooncakes (currently the `overrides.path = "../mwac"` resolves against the local checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)