### PR TITLE
Bump mwac to 0.2.1 and revert wac plug workaround (#290)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,6 @@ Completed items are archived in `docs/DONE.md`.
 ### ⚪ upstream / infra 待ち
 
 - #294 MoonBit v0.1.20260409 の 10x compile 遅延（upstream）
-- #290 mwac `plug_components` の typed imports forward バグ（upstream）
 - #293 selfbuild_compile_full の MoonBit RC 2GB 超過（host 側制約）
 
 ### 既知ギャップ（issue として追跡中）

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -13,11 +13,8 @@
     "mizchi/flatbuffers": "0.1.3",
     "mizchi/wite": "0.6.5",
     "mizchi/similarity": "0.2.1",
-    "mizchi/mwac": "0.1.6",
+    "mizchi/mwac": "0.2.1",
     "moonbitlang/parser": "0.2.5"
-  },
-  "overrides": {
-    "mizchi/mwac": { "path": "../mwac" }
   },
   "readme": "README.md",
   "repository": "https://github.com/mizchi/vibe-lang",

--- a/scripts/compose_http_p3_handler.sh
+++ b/scripts/compose_http_p3_handler.sh
@@ -30,7 +30,6 @@ require_cmd() {
 
 require_cmd moon
 require_cmd wasm-tools
-require_cmd wac
 
 INPUT=""
 OUTPUT=""
@@ -63,16 +62,9 @@ else
   echo "[compose] using cached adapter"
 fi
 
-# Step 2: Compile vibe source to a sync component, then compose with the
-# adapter via wac. We use wac rather than `vibe compile --compose-p3` because
-# the built-in mwac plug_components does not forward component type
-# definitions referenced by the socket's imports (issue #267) and produces
-# an invalid component for non-trivial adapter imports.
-PLUG="${OUTPUT%.wasm}.plug.wasm"
-echo "[compose] compiling $INPUT to plug component..."
-$VIBE compile --component-string-lift "$INPUT" -o "$PLUG" 2>/dev/null
-echo "[compose] composing plug into adapter via wac plug..."
-wac plug --plug "$PLUG" -o "$OUTPUT" "$ADAPTER"
+# Step 2: Compile + compose + patch via vibe CLI
+echo "[compose] compiling and composing $INPUT..."
+$VIBE compile --compose-p3 --adapter "$ADAPTER" "$INPUT" -o "$OUTPUT" 2>/dev/null
 
 # Step 3: Validate
 wasm-tools validate --features all "$OUTPUT"

--- a/scripts/test_wasi_p3_e2e.sh
+++ b/scripts/test_wasi_p3_e2e.sh
@@ -64,7 +64,6 @@ fi
 log_info "Using wasmtime: $WASMTIME ($($WASMTIME --version 2>/dev/null || echo unknown))"
 if ! require_cmd wasm-tools; then log_skip "wasm-tools not found"; exit 0; fi
 if ! require_cmd cargo; then log_skip "cargo not found (needed for Rust adapter build)"; exit 0; fi
-if ! require_cmd wac; then log_skip "wac not found (needed for P3 component composition)"; exit 0; fi
 
 # Step 1: Build adapter
 log_info "Building P3 adapter component..."
@@ -88,7 +87,6 @@ fi
 test_scalar_handler() {
   local name="scalar_hello"
   local src="$OUT_DIR/${name}.vibe"
-  local plug_component="$OUT_DIR/${name}.plug.wasm"
   local component="$OUT_DIR/${name}.p3.component.wasm"
 
   cat > "$src" << 'VIBE'
@@ -98,23 +96,9 @@ export let handler = (method: String, url: String) -> Int {
 handler("GET", "/")
 VIBE
 
-  # Compose via wac rather than `vibe compile --compose-p3` because the
-  # built-in mwac plug_components does not forward component type definitions
-  # referenced by the socket's imports (issue #267). wac handles this case
-  # correctly and is already required by the selfhost-cli direct-component
-  # test, so assuming it is on PATH is consistent with the rest of the
-  # component-model test fleet.
-  log_info "Compiling $name plug..."
-  if ! "$VIBE" compile --component-string-lift "$src" -o "$plug_component" 2>/dev/null; then
-    log_fail "$name: component-string-lift compilation failed"
-    return
-  fi
-  log_info "Composing $name with adapter via wac plug..."
-  if ! wac plug \
-        --plug "$plug_component" \
-        -o "$component" \
-        "$ADAPTER_COMPONENT" 2>/dev/null; then
-    log_fail "$name: wac plug composition failed"
+  log_info "Compiling $name..."
+  if ! "$VIBE" compile --compose-p3 "$src" --adapter "$ADAPTER_COMPONENT" -o "$component" 2>/dev/null; then
+    log_fail "$name: compose-p3 compilation failed"
     return
   fi
   log_pass "$name: compiled to P3 component"

--- a/scripts/vibe_serve.sh
+++ b/scripts/vibe_serve.sh
@@ -142,30 +142,15 @@ else
   COMPONENT="$TEMP_COMPONENT"
 fi
 
-TEMP_PLUG="$(mktemp /tmp/vibe_serve_plug_XXXXXX.wasm)"
-
 cleanup() {
   if [ -n "$TEMP_COMPONENT" ] && [ -f "$TEMP_COMPONENT" ]; then
     rm -f "$TEMP_COMPONENT"
   fi
-  rm -f "$TEMP_PLUG"
 }
 trap cleanup EXIT
 
-if ! command -v wac >/dev/null 2>&1; then
-  echo "error: wac not found" >&2
-  echo "install: cargo install wac-cli" >&2
-  exit 1
-fi
-
-# Compile the handler to a sync component, then compose with the adapter via
-# wac. See issue #267: the built-in `vibe compile --compose-p3` mode uses the
-# mwac plug_components routine which does not forward component type
-# definitions referenced by the socket's imports and produces an invalid
-# component for non-trivial adapters.
 echo "[serve] compiling $INPUT..."
-$VIBE compile --component-string-lift "$INPUT" -o "$TEMP_PLUG" 2>/dev/null
-wac plug --plug "$TEMP_PLUG" -o "$COMPONENT" "$ADAPTER"
+$VIBE compile --compose-p3 --adapter "$ADAPTER" "$INPUT" -o "$COMPONENT" 2>/dev/null
 
 if [ "$VALIDATE" = "1" ] && command -v wasm-tools >/dev/null 2>&1; then
   if ! wasm-tools validate --features all "$COMPONENT" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- Bump `mizchi/mwac` 0.1.6 → 0.2.1 (upstream fix for typed-imports forwarding) and drop the local `../mwac` override in `moon.mod.json`.
- Revert the `wac plug` workaround in `scripts/test_wasi_p3_e2e.sh`, `scripts/compose_http_p3_handler.sh`, `scripts/vibe_serve.sh` — they now go back through `vibe compile --compose-p3`.
- Drop the #290 entry from `TODO.md`.

Closes #290.

## Test plan

- [ ] CI: selfhost-gates / p3 e2e (validates `vibe compile --compose-p3` against the WASI P3 HTTP adapter)
- [ ] `scripts/test_wasi_p3_e2e.sh` ends with `scalar_hello: component validates`
- [ ] `moon check` / `just test` green

https://claude.ai/code/session_01SDzQV8tiPCMwV56xEiP61b