### PR TITLE
Use mwac.plug_components in-process for --compose-p3, remove wac dependency

### DIFF
--- a/scripts/compose_http_p3_handler.sh
+++ b/scripts/compose_http_p3_handler.sh
@@ -64,7 +64,7 @@ fi
 
 # Step 2: Compile + compose + patch via vibe CLI
 echo "[compose] compiling and composing $INPUT..."
-$VIBE compile --compose-p3 --adapter "$ADAPTER" "$INPUT" -o "$OUTPUT" 2>/dev/null
+$VIBE compile --compose-p3 --adapter "$ADAPTER" "$INPUT" -o "$OUTPUT"
 
 # Step 3: Validate
 wasm-tools validate --features all "$OUTPUT"

--- a/scripts/vibe_serve.sh
+++ b/scripts/vibe_serve.sh
@@ -150,7 +150,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "[serve] compiling $INPUT..."
-$VIBE compile --compose-p3 --adapter "$ADAPTER" "$INPUT" -o "$COMPONENT" 2>/dev/null
+$VIBE compile --compose-p3 --adapter "$ADAPTER" "$INPUT" -o "$COMPONENT"
 
 if [ "$VALIDATE" = "1" ] && command -v wasm-tools >/dev/null 2>&1; then
   if ! wasm-tools validate --features all "$COMPONENT" 2>/dev/null; then

--- a/src/cmd/vibe/cli_compile_cmd.mbt
+++ b/src/cmd/vibe/cli_compile_cmd.mbt
@@ -324,10 +324,21 @@ fn compile_cmd(args : Array[String]) -> Unit {
           ) catch {
             e => abort("compile: " + e.user_message())
           }
-          match
-            compose_p3_component_with_wac(adapter_path, app_bytes, resolved_out) {
+          // Step 2: Compose with P3 adapter via mwac.plug_components (in-process)
+          let adapter_bytes = @os_fs.read_file_to_bytes(adapter_path) catch {
+            e => abort("compile: failed to read adapter: " + e.to_string())
+          }
+          let composed = @runtime_compile.compose_p3_component(
+            app_bytes, adapter_bytes,
+          ) catch {
+            e => abort("compile: " + e.user_message())
+          }
+          match ensure_parent_dir_for_file(resolved_out, "compile") {
             Ok(_) => ()
             Err(err) => abort("compile: " + err)
+          }
+          @os_fs.write_bytes_to_file(resolved_out, composed) catch {
+            e => abort("compile: failed to write output: " + e.to_string())
           }
           println("wrote " + resolved_out)
         }
@@ -369,91 +380,6 @@ fn compile_cmd(args : Array[String]) -> Unit {
         }
       }
     }
-  }
-}
-
-///|
-fn build_p3_compose_command(
-  adapter_path : String,
-  app_path : String,
-  out_path : String,
-) -> String {
-  "wac plug --plug " +
-  shell_quote_command_arg(app_path) +
-  " -o " +
-  shell_quote_command_arg(out_path) +
-  " " +
-  shell_quote_command_arg(adapter_path)
-}
-
-///|
-fn compose_p3_component_with_wac(
-  adapter_path : String,
-  app_bytes : Bytes,
-  out_path : String,
-) -> Result[Unit, String] {
-  if !@backend.exec_available() {
-    return Err(
-      "--compose-p3 requires external process execution on this target",
-    )
-  }
-  match ensure_parent_dir_for_file(out_path, "compile") {
-    Ok(_) => ()
-    Err(err) => return Err(err)
-  }
-  let tmp_dir = match make_cli_temp_dir("compose_p3") {
-    Ok(path) => path
-    Err(err) => return Err(err)
-  }
-  defer remove_path_if_exists(tmp_dir)
-  let app_path = tmp_dir + "/app.component.wasm"
-  @os_fs.write_bytes_to_file(app_path, app_bytes) catch {
-    e => return Err("failed to write temp component: " + e.to_string())
-  }
-  let cmd = build_p3_compose_command(adapter_path, app_path, out_path)
-  match @backend.exec_command_lines(cmd) {
-    Ok(_) => Ok(())
-    Err(err) => Err("wac plug failed: " + err)
-  }
-}
-
-///|
-fn make_cli_temp_dir(prefix : String) -> Result[String, String] {
-  let base = "/tmp/vibe_cli_" +
-    prefix +
-    "_" +
-    @env.now().to_string() +
-    "_" +
-    vibe_getpid().to_string()
-  for i in 0..<1000 {
-    let path = if i == 0 { base } else { base + "_" + i.to_string() }
-    if !@os_fs.path_exists(path) {
-      @os_fs.create_dir(path) catch {
-        e => return Err("create temp dir failed: " + e.to_string())
-      }
-      return Ok(path)
-    }
-  }
-  Err("failed to allocate temp dir")
-}
-
-///|
-fn remove_path_if_exists(path : String) -> Unit {
-  if !@os_fs.path_exists(path) {
-    return
-  }
-  let is_file = @os_fs.is_file(path) catch { _ => false }
-  if is_file {
-    ignore(@os_fs.remove_file(path) catch { _ => () })
-    return
-  }
-  let is_dir = @os_fs.is_dir(path) catch { _ => false }
-  if is_dir {
-    let entries = @os_fs.read_dir(path) catch { _ => [] }
-    for name in entries {
-      remove_path_if_exists(path + "/" + name)
-    }
-    ignore(@os_fs.remove_dir(path) catch { _ => () })
   }
 }
 

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -235,16 +235,6 @@ test "http host run command can invoke multiple exports in order" {
 }
 
 ///|
-test "p3 compose command quotes plug adapter and output paths" {
-  let cmd = build_p3_compose_command(
-    "/tmp/adapter path.wasm", "/tmp/app$plug.component.wasm", "/tmp/out\"component.wasm",
-  )
-  assert_eq(
-    cmd, "wac plug --plug \"/tmp/app\\$plug.component.wasm\" -o \"/tmp/out\\\"component.wasm\" \"/tmp/adapter path.wasm\"",
-  )
-}
-
-///|
 test "resolve repl initial source ignores scratch db by default" {
   let root = wbtest_make_temp_dir("repl_initial_source_fresh")
   let scratch_db_path = root + "/scratch.db"


### PR DESCRIPTION
## Summary

Follow-up to #287 review (Codex flagged `vibe_serve.sh`'s `wac`-preflight removal as unsafe because `vibe compile --compose-p3` still shelled out to `wac plug` internally).

Replace the external `wac plug` invocation with the existing in-process `@mwac.plug_components`-based composer, removing the `wac` dependency from `--compose-p3` entirely.

## Changes

- `src/cmd/vibe/cli_compile_cmd.mbt` — `CompileMode::ComposeP3` now reads adapter bytes and calls `@runtime_compile.compose_p3_component(app_bytes, adapter_bytes)` (which uses `@mwac.plug_components(adapter_bytes, [app_bytes], best_effort=true)` — `src/runtime_compile/compile.mbt:1994`), then writes the composed bytes directly.
- Drop now-dead helpers: `build_p3_compose_command`, `compose_p3_component_with_wac`, `make_cli_temp_dir`, `remove_path_if_exists`.
- `src/cmd/vibe/cli_wbtest.mbt` — drop the corresponding whitebox test for `build_p3_compose_command`.
- `scripts/vibe_serve.sh` and `scripts/compose_http_p3_handler.sh` — remove `2>/dev/null` from the user-facing `$VIBE compile --compose-p3 ...` invocations so compile errors surface with actionable context.

### Net effect

- `wac` is no longer required at runtime for `vibe compile --compose-p3`
- Error messages from the composer surface through `@mwac`'s error type instead of being swallowed by a shelled-out process
- User scripts no longer silently mask compile failures

## Test plan

- [ ] CI all stages pass (same shape as #313)
- [ ] `e2e-component` still passes (exercises the ComposeP3 path in vibe compile)
- [ ] `wasm-compile-e2e` shards pass

## References

- Codex review thread on #313: https://github.com/mizchi/vibe-lang/pull/313#discussion_r3106547682
- `@mwac.plug_components` usage: `src/runtime_compile/compile.mbt:1994`

https://claude.ai/code/session_01SDzQV8tiPCMwV56xEiP61b
