### PR TITLE
Fix #312: align parser_loop_test "parse parameterized loop" with desugar output

### DIFF
--- a/scripts/test_selfhost_bootstrap_gate.sh
+++ b/scripts/test_selfhost_bootstrap_gate.sh
@@ -309,33 +309,13 @@ SELFHOST_COMPILED_TEST_FILES=()
 #      tracked in issue #266 — the original bootstrap gate masked them with
 #      SIGABRT; now that the runner exits cleanly, they need to be excluded
 #      explicitly until the underlying selfhost codegen bugs are fixed.
-#        - parser_loop_test.vibe :: "parse parameterized loop" fails on a
-#                                  long `result == "<expected>"` string
-#                                  equality assertion. The parse/print
-#                                  pipeline itself succeeds in isolation,
-#                                  but the final equality check trips an
-#                                  unreachable trap — probably a selfhost
-#                                  compiler issue with String equality on
-#                                  long literals. (6/7 pass.)
-#                                  NOTE: dce_test.vibe / desugar_test.vibe
-#                                  were previously excluded here; they are
-#                                  fixed in this PR (dce.vibe early-return
-#                                  on empty input, desugar.vibe rewritten
-#                                  without tuple destructuring in for-in
-#                                  loop variable).
 #        - checker_parity_test.vibe :: 172 test cases — the compiled batch
 #                                  wasm for this file never produces any
-#                                  output before the stage timeout. 10+
-#                                  minutes of 90% CPU usage with zero
-#                                  output suggests the selfhost compiler's
-#                                  batch compile or the batch wasm
-#                                  execution is stuck in a near-infinite
-#                                  loop.
-#      Restore remaining files to the shard once #287 follow-up fixes them.
+#                                  output before the stage timeout (see #288).
 for test_path in "$PROJECT_ROOT"/vibe/compiler/*_test.vibe; do
   test_name="$(basename "$test_path")"
   case "$test_name" in
-    selfhost_s5_test.vibe|selfhost_s5_*_test.vibe|codegen_test.vibe|codegen_*_test.vibe|compiler_cache_test.vibe|cli_cache_test.vibe|cli_adapter_cache_test.vibe|cache_probe_*_bench_test.vibe|cache_probe_test.vibe|compiler_fs_test.vibe|module_loader_check_module_test.vibe|fixture_real_selfhost_test.vibe|checker_error_format_test.vibe|compiler_cache_advanced_test.vibe|file_compile_mode_test.vibe|module_loader_collect_sources_test.vibe|persistent_cache_test.vibe|type_db_cross_module_test.vibe|type_db_test.vibe|compiler_cache_prepare_test.vibe|fixture_test.vibe|coverage_selfhost_suite_lib_test.vibe|loader_persistent_cache_test.vibe|wasm_emit_test.vibe|module_loader_test.vibe|fixture_roundtrip_test.vibe|checker_effects_test.vibe|parser_loop_test.vibe|checker_parity_test.vibe)
+    selfhost_s5_test.vibe|selfhost_s5_*_test.vibe|codegen_test.vibe|codegen_*_test.vibe|compiler_cache_test.vibe|cli_cache_test.vibe|cli_adapter_cache_test.vibe|cache_probe_*_bench_test.vibe|cache_probe_test.vibe|compiler_fs_test.vibe|module_loader_check_module_test.vibe|fixture_real_selfhost_test.vibe|checker_error_format_test.vibe|compiler_cache_advanced_test.vibe|file_compile_mode_test.vibe|module_loader_collect_sources_test.vibe|persistent_cache_test.vibe|type_db_cross_module_test.vibe|type_db_test.vibe|compiler_cache_prepare_test.vibe|fixture_test.vibe|coverage_selfhost_suite_lib_test.vibe|loader_persistent_cache_test.vibe|wasm_emit_test.vibe|module_loader_test.vibe|fixture_roundtrip_test.vibe|checker_effects_test.vibe|checker_parity_test.vibe)
       ;;
     *)
       SELFHOST_COMPILED_TEST_FILES+=("$test_path")

--- a/vibe/compiler/parser_loop_test.vibe
+++ b/vibe/compiler/parser_loop_test.vibe
@@ -61,10 +61,13 @@ test "parse loop sugar" {
 }
 
 test "parse parameterized loop" {
+  // Parser desugars `loop (params) { body }` into nested `let mut` + `while true { ... }`;
+  // `break val` becomes `{ __loop_result = val; break }` and `continue(args)` becomes
+  // `{ let __lt0 = <a0>; ...; p0 = __lt0; ...; continue }`.
   let result = handle {
     parse_print("loop (i = 10, acc = 0) { if i <= 0 { break acc } else { continue(i - 1, acc + i) } }")
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
-  assert(result == "loop (i = 10, acc = 0) { if (i <= 0) { break acc } else { continue((i - 1), (acc + i)) } }")
+  assert(result == "{ let mut i = 10; { let mut acc = 0; { let mut __loop_result = 0; { while true { if (i <= 0) { { __loop_result = acc; break } } else { { let __lt0 = (i - 1); { let __lt1 = (acc + i); { i = __lt0; { acc = __lt1; continue } } } } } }; __loop_result } } } }")
 }


### PR DESCRIPTION
## Summary

Closes #312.

`vibe/compiler/parser_loop_test.vibe::"parse parameterized loop"` was asserting the ELoop-preserving sugar form, but `parse_print` (`parser_test_support.vibe → vibe/compiler/parser → syntax/parser_expr → parse_loop_primary`) **always desugars** `loop (params) { body }` into nested `let mut` + `while true { ... }` via `desugar_loop_body`. The legacy `vibe/parser/parser.vibe:1444-1482` ELoop-preserving path is unused by this test pipeline.

The original exclusion-list comment hypothesised "selfhost String equality trap on long literals" — that was wrong; the assertion simply never matched the actual desugared output.

## Fix (option A from #312)

- Update `parser_loop_test.vibe::"parse parameterized loop"` assertion to the actual desugared form. Add a comment summarising the desugar transformation (`break val` → `{ __loop_result = val; break }`, `continue(args)` → `{ let __lt0 = ..; ..; p0 = __lt0; ..; continue }`).
- Remove `parser_loop_test.vibe` from the compiled bootstrap shard exclusion list in `scripts/test_selfhost_bootstrap_gate.sh`.
- Trim the now-stale comment block; keep the shorter `checker_parity_test.vibe` note (referencing #288).

This is consistent with the sibling `parse loop sugar` test in the same file, which already asserts the desugared `while true { break }` form.

## Out of scope

The duplicate loop parsers (`vibe/parser/parser.vibe:1475` builds `ELoop` directly; `vibe/compiler/syntax/parser_expr_primary.vibe:80` desugars) is the deeper inconsistency mentioned in #312 option B. Resolving that would require routing all callers through one parser and either lowering ELoop later or removing it entirely — out of scope here.

## Test plan

- [ ] CI green on `selfhost bootstrap` shard now that `parser_loop_test.vibe` is no longer excluded
- [ ] All 7 tests in `parser_loop_test.vibe` pass on both native and compiled backends

https://claude.ai/code/session_01SDzQV8tiPCMwV56xEiP61b