### PR TITLE
Package suite parity: wat_encoder + module wrapping (+30 tests)

### DIFF
--- a/src/cmd/vibe/cli_test_cmd.mbt
+++ b/src/cmd/vibe/cli_test_cmd.mbt
@@ -54,6 +54,36 @@ fn collect_compiled_test_cases(
 }
 
 ///|
+/// Return the module-qualifier prefix of a stmt's binding name, if any.
+/// For `Stmt::Let(name="Math::abs", ...)` → `Some("Math")`; otherwise `None`.
+/// The parser lowers `module Math { export let abs = ... }` into bare
+/// `Let(name="Math::abs", ...)` stmts, dropping the wrapper; the test
+/// batch-source renderer needs to re-inject that wrapper so the sliced
+/// source text (which is the *inner* `export let abs = ...`) parses back
+/// into the same qualified binding.
+fn compiled_test_stmt_module_prefix(stmt : @vibe_core.Stmt) -> String? {
+  let name = match stmt {
+    @vibe_core.Stmt::Let(name~, ..) => name
+    @vibe_core.Stmt::ExportLet(name~, ..) => name
+    @vibe_core.Stmt::InternalExportLet(name~, ..) => name
+    @vibe_core.Stmt::LetMut(name~, ..) => name
+    _ => return None
+  }
+  let idx = name.find("::")
+  match idx {
+    Some(i) => {
+      let prefix = name.substring(start=0, end=i)
+      if prefix.length() == 0 || prefix.contains("::") {
+        None
+      } else {
+        Some(prefix)
+      }
+    }
+    None => None
+  }
+}
+
+///|
 fn render_stmt_snippets(
   source : String,
   stmts : Array[@vibe_core.Stmt],
@@ -66,20 +96,80 @@ fn render_stmt_snippets(
   // in the generated batch source and trigger a spurious "duplicate type"
   // checker error.
   let seen_spans : Map[String, Bool] = {}
-  for stmt in stmts {
+  // Group consecutive stmts that share a `Name::member` qualifier prefix so
+  // they can be re-wrapped in `module Name { ... }`. Without this, the
+  // source-sliced text loses the module wrapper and the inner `export let
+  // abs = ...` re-parses as a bare `abs` binding, making `Math::abs(...)`
+  // unresolvable in test bodies.
+  let mut i = 0
+  let n = stmts.length()
+  while i < n {
+    let stmt = stmts[i]
     let span = stmt.span()
     let span_key = span.start.to_string() + "-" + span.end.to_string()
     if seen_spans.contains(span_key) {
+      i = i + 1
       continue
     }
-    seen_spans[span_key] = true
-    let snippet = source_slice_by_span(source, span.start, span.end)
-    if snippet.trim().to_string().length() == 0 {
-      continue
-    }
-    out.write_string(snippet)
-    if not(snippet.has_suffix("\n")) {
-      out.write_char('\n')
+    let prefix = compiled_test_stmt_module_prefix(stmt)
+    match prefix {
+      Some(mod_name) => {
+        // Scan forward to collect all consecutive stmts sharing the same
+        // module prefix. Intervening stmts from other modules break the run.
+        let group_start = i
+        let mut group_end = i
+        while group_end < n {
+          let peek = stmts[group_end]
+          match compiled_test_stmt_module_prefix(peek) {
+            Some(p) if p == mod_name => group_end = group_end + 1
+            _ => break
+          }
+        }
+        out.write_string("module ")
+        out.write_string(mod_name)
+        out.write_string(" {\n")
+        let mut j = group_start
+        while j < group_end {
+          let inner = stmts[j]
+          let inner_span = inner.span()
+          let inner_key = inner_span.start.to_string() +
+            "-" +
+            inner_span.end.to_string()
+          if seen_spans.contains(inner_key) {
+            j = j + 1
+            continue
+          }
+          seen_spans[inner_key] = true
+          let snippet = source_slice_by_span(
+            source, inner_span.start, inner_span.end,
+          )
+          if snippet.trim().to_string().length() == 0 {
+            j = j + 1
+            continue
+          }
+          out.write_string("  ")
+          out.write_string(snippet)
+          if not(snippet.has_suffix("\n")) {
+            out.write_char('\n')
+          }
+          j = j + 1
+        }
+        out.write_string("}\n")
+        i = group_end
+      }
+      None => {
+        seen_spans[span_key] = true
+        let snippet = source_slice_by_span(source, span.start, span.end)
+        if snippet.trim().to_string().length() == 0 {
+          i = i + 1
+          continue
+        }
+        out.write_string(snippet)
+        if not(snippet.has_suffix("\n")) {
+          out.write_char('\n')
+        }
+        i = i + 1
+      }
     }
   }
   out.to_string()

--- a/src/parser/parser_ast_stmts.mbt
+++ b/src/parser/parser_ast_stmts.mbt
@@ -1504,13 +1504,24 @@ fn rewrite_module_stmt(
   exported_module : Bool,
 ) -> @core.Stmt raise ParseError {
   match stmt {
-    @core.Stmt::Let(rec~, name~, expr~, span~) =>
+    @core.Stmt::Let(rec~, name~, expr~, span~) => {
+      // Only qualify names that appear in the module's top-level decl set.
+      // Nested `Let` stmts inside a RHS block (e.g. the type-assert helper
+      // emitted by `wrap_local_let_with_annotation` for `export let f: T = ...`)
+      // are block-local; qualifying them would break their call-sites which
+      // reference the bare helper name inside the same block.
+      let next_name = if locals.contains(name) {
+        module_qualified_name(module_name, name)
+      } else {
+        name
+      }
       @core.Stmt::Let(
         rec~,
-        name=module_qualified_name(module_name, name),
+        name=next_name,
         expr=rewrite_module_expr(module_name, expr, locals),
         span~,
       )
+    }
     @core.Stmt::ExportLet(rec~, name~, expr~, span~) => {
       let next_expr = rewrite_module_expr(module_name, expr, locals)
       let qualified_name = module_qualified_name(module_name, name)
@@ -1530,12 +1541,18 @@ fn rewrite_module_stmt(
         span~,
       )
     }
-    @core.Stmt::LetMut(name~, expr~, span~) =>
+    @core.Stmt::LetMut(name~, expr~, span~) => {
+      let next_name = if locals.contains(name) {
+        module_qualified_name(module_name, name)
+      } else {
+        name
+      }
       @core.Stmt::LetMut(
-        name=module_qualified_name(module_name, name),
+        name=next_name,
         expr=rewrite_module_expr(module_name, expr, locals),
         span~,
       )
+    }
     @core.Stmt::Assign(name~, expr~, span~) =>
       @core.Stmt::Assign(
         name=local_module_name(module_name, name, locals),

--- a/vibe/wasm/wat_encoder/wat_encoder.vibe
+++ b/vibe/wasm/wat_encoder/wat_encoder.vibe
@@ -463,8 +463,12 @@ let parse_f64_bits = (s: String) -> Int {
       }
       i = i + 1
     }
-    let d = Double::parse(clean)
-    Double::to_i64_bits(d)
+    let parsed = Double::parse(clean)
+    let value = match parsed {
+      Some(v) => v,
+      None => 0.0,
+    }
+    Double::to_i64_bits(value)
   }
 }
 

--- a/vibe/wasm/wat_encoder/wat_encoder.vibe
+++ b/vibe/wasm/wat_encoder/wat_encoder.vibe
@@ -464,11 +464,18 @@ let parse_f64_bits = (s: String) -> Int {
       i = i + 1
     }
     let parsed = Double::parse(clean)
-    let value = match parsed {
-      Some(v) => v,
-      None => 0.0,
+    match parsed {
+      Some(v) => Double::to_i64_bits(v),
+      None => {
+        // Malformed f64 literal: the tokenizer only emits float tokens for
+        // forms that `Double::parse` should accept (nan/inf/signed-nan/signed-inf
+        // are handled by the branches above). Hitting `None` here means the
+        // input is not a valid numeric literal; trap loudly rather than
+        // silently emit zero bytes.
+        assert(false)
+        0
+      },
     }
-    Double::to_i64_bits(value)
   }
 }
 


### PR DESCRIPTION
## Summary

Two package-suite parity fixes bundled together (both on the same branch to keep `claude/review-merge-prs-19DAg` linear):

1. **L (wat_encoder)** — unwrap `Double::parse` Option result in `parse_f64_bits`, trap on malformed input (per Codex P1 review)
2. **G (modules)** — fix compiled-test batch source losing `module Name { ... }` wrapper + limit `rewrite_module_stmt` qualification to top-level module decls

### Impact

`just test-vibe-package-suite` (227 files / 1,422 tests):

|  | Pass | Fail |
|---|---|---|
| Baseline (pre-L) | 1,177 | 249 |
| +L (wat_encoder) | 1,197 | 229 (+20) |
| +G (modules) | **1,207** | **219** (+10) |

Files now fully passing:
- **L**: `vibe/wasm/wat_encoder/wat_encoder_test.vibe` 20/20 (was 0/20)
- **G**: `examples/module_test.vibe` 4/4 (was 0/4), `examples/module_advanced_test.vibe` 6/9 (was 0/9)

---

### L: `wat_encoder` — unwrap `Double::parse` Option result

`Double::parse(String) -> Option[Double]` (per `vibe/builtins/declarations.vibe:142`), but `wat_encoder.vibe:467` passed the option value straight into `Double::to_i64_bits(Double) -> Int`, failing type-check and cascading to 20 test failures.

Fix: explicit `match` with `assert(false)` on `None` (addresses Codex P1 concern about silent `0.0` fallback — the nan/inf branches above already handle all strings the tokenizer is supposed to emit, so `None` here means malformed input and should trap).

### G: modules — batch source wrap + scoped qualification

**G.1 — test batch source loses module wrapper.** The parser fully lowers `module Math { export let abs = ... }` into bare `Stmt::Let(name="Math::abs", ...)` at parse time. The compiled-test backend builds its batch source by slicing the original text span-by-stmt, so the sliced `export let abs = ...` text re-parses as a plain `abs` binding in the batch, making `Math::abs(...)` references in test bodies unresolvable.

Fix: group consecutive stmts that share a `Name::member` qualifier prefix (via new `compiled_test_stmt_module_prefix` helper) and re-emit them wrapped in `module Name { ... }`. Span-dedupe from the derive-trait-impl handling introduced by #317 still applies.

**G.2 — `rewrite_module_stmt` over-qualified nested lets.** `rewrite_module_stmt` was unconditionally prefixing every nested `Stmt::Let` / `Stmt::LetMut` name with the module qualifier, including helper lets introduced by `wrap_local_let_with_annotation` (from #317) inside a `export let f: T = ...` RHS block. The call-site of those helpers stays bare, so prefixing the definition broke the link (`unknown function: __vibe_local_type_assert_148`).

Fix: only qualify names that appear in the module's top-level decl set (`locals` map computed by `collect_module_decl_names`). Block-local `let`/`let mut` stmts are left unqualified.

### Test plan

- [x] `moon test src/parser src/checker` — 201/201
- [x] `moon test src/cmd/vibe` — 581/582 (only pre-existing `mixed iterable fold specializations` failure, confirmed unaffected via git stash)
- [x] `just test-vibe-package-suite` — 1,207/1,422 (+30 vs entry state)
- [ ] CI (ci-required)

### Remaining

The 3 leftover `module_advanced_test` failures (`module string repeat`, `module string reverse`, `module cross-call`) are runtime traps inside String-manipulation tests — separate from the module-wiring fix.

https://claude.ai/code/session_01SDzQV8tiPCMwV56xEiP61b