### PR TITLE
Parser: recursively fill nested Fn ret annotation for curried lets (+7 tests)

### DIFF
--- a/src/parser/parser_ast_stmts.mbt
+++ b/src/parser/parser_ast_stmts.mbt
@@ -227,17 +227,51 @@ fn fill_fn_ret_from_annotation(
       } else {
         effects
       }
+      // If the annotation's return type is itself a function type and the
+      // body reduces to a single `Fn` expression (the common curried-function
+      // pattern `let f: (A) -> (B) -> C = (a) -> (b) -> body`), recursively
+      // fill the inner Fn so its placeholder params also get the expected
+      // types. Without this the checker sees the inner lambda's params as
+      // `Unit` (the placeholder sentinel) and raises a spurious "expected
+      // <ann ret param type>, actual Unit" mismatch.
+      let filled_body = descend_fn_ret_annotation_into_body(ann_ret, body)
       @core.Expr::Fn(
         type_params~,
         type_bounds~,
         params=filled_params,
         ret=filled_ret,
         effects=filled_effects,
-        body~,
+        body=filled_body,
         span~,
       )
     }
     _ => raw_expr
+  }
+}
+
+///|
+/// If `body` is a single-expression block `{ Fn(..) }` and `ann_ret` is a
+/// `Type::Func`, re-build the body with the inner Fn's placeholders filled
+/// from `ann_ret`. Returns the original body otherwise.
+fn descend_fn_ret_annotation_into_body(
+  ann_ret : @core.Type,
+  body : @core.Module,
+) -> @core.Module {
+  if body.stmts.length() != 1 {
+    return body
+  }
+  match body.stmts[0] {
+    @core.Stmt::Expr(expr~, span=stmt_span) =>
+      match (ann_ret, expr) {
+        (@core.Type::Func(_), @core.Expr::Fn(_)) => {
+          let new_expr = fill_fn_ret_from_annotation(ann_ret, expr)
+          @core.Module::{
+            stmts: [@core.Stmt::Expr(expr=new_expr, span=stmt_span)],
+          }
+        }
+        _ => body
+      }
+    _ => body
   }
 }
 


### PR DESCRIPTION
## Summary

Recursively fill nested Fn ret annotation for curried lets — `let f: (A) -> (B) -> C = (a) -> (b) -> body` was still triggering "expected \<B\>, actual Unit" on the inner lambda's `b` parameter because `fill_fn_ret_from_annotation` (from #317) only filled the outer Fn node's params/ret/effects.

### Root cause

The checker uses `Type::Unit` as the inference-placeholder sentinel for Fn params, and `type_fn_literal` has no mechanism to flow an outer lambda's annotated return type into a nested Fn body expression. So even after #317 filled the outer `(n) -> { body }` to `(n: Int) -> (Int) -> Int { body }`, the inner `(x) -> { x + n }` still had `x` as `Type::Unit` → `x + n` fails with "expected Int, actual Unit".

### Fix

Add `descend_fn_ret_annotation_into_body` which, when the annotation's return type is itself a `Type::Func` and the body reduces to a single `Expr::Fn` stmt (the curried-function pattern), recursively invokes `fill_fn_ret_from_annotation` on the inner Fn. Chains naturally through any depth of curried function types.

### Impact

`just test-vibe-package-suite` (227 files / 1,422 tests):

|  | Pass | Fail |
|---|---|---|
| Before (on main post #319) | 1,207 | 219 |
| After | **1,214** | **212** |

`examples/function_test.vibe` now 7/9 (was 0/9). The 2 remaining failures are separate issues:
- `"generic identity"` — `identity: [T](T) -> T` call-site monomorphisation binding (future work: category K)
- `"immediately invoked lambda"` — `((x) -> { x * x })(7)` with no annotation on the lambda; contextual type propagation from the call expected-arg type isn't wired up

### Test plan
- [x] `moon test src/parser src/checker` — 201/201
- [x] `moon test src/cmd/vibe` — 581/582 (pre-existing `mixed iterable fold` failure, confirmed unaffected)
- [x] `just test-vibe-package-suite` — 1,214/1,422 (+7)
- [ ] CI (ci-required)

https://claude.ai/code/session_01SDzQV8tiPCMwV56xEiP61b