### PR TITLE
checker: allow Char in arithmetic (+1 test)

### DIFF
--- a/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
+++ b/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
@@ -791,7 +791,15 @@ fn type_call_builtin_handler_collection_numeric(
       if not(type_equal(env, resolved_a, @core.Type::String)) {
         ensure_num_operand(env, a, pos_args[0].span())
       }
-      if not(type_equal(env, b, a)) {
+      // Char + Int is allowed for char arithmetic (`'A' + 1 == 'B'`); both
+      // sides are 62-bit tagged at runtime so no conversion needed. The
+      // result type follows the first operand.
+      let resolved_b = resolve_type(env, b)
+      let char_int_mix = (type_equal(env, resolved_a, @core.Type::Char) &&
+        type_equal(env, resolved_b, @core.Type::Int)) ||
+        (type_equal(env, resolved_a, @core.Type::Int) &&
+        type_equal(env, resolved_b, @core.Type::Char))
+      if not(char_int_mix) && not(type_equal(env, b, a)) {
         raise TypeError::Mismatch(
           expected=a,
           actual=b,

--- a/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
+++ b/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
@@ -793,13 +793,22 @@ fn type_call_builtin_handler_collection_numeric(
       }
       // Char + Int is allowed for char arithmetic (`'A' + 1 == 'B'`); both
       // sides are 62-bit tagged at runtime so no conversion needed. The
-      // result type follows the first operand. Use a pure equality check
-      // (`type_equal` would unify and could bind an unresolved operand to
-      // Char, skipping the later same-type unification).
-      let resolved_b = resolve_type(env, b)
-      let char_int_mix = match (resolved_a, resolved_b) {
-        (@core.Type::Char, @core.Type::Int) => true
-        (@core.Type::Int, @core.Type::Char) => true
+      // result type follows the first operand. Keep this probe purely
+      // side-effect-free: only resolve `b` when `a` is already concretely
+      // Char or Int (otherwise the same-type `type_equal` below will handle
+      // unification), and match on resolved concrete variants instead of
+      // calling `type_equal` which unifies.
+      let char_int_mix = match resolved_a {
+        @core.Type::Char =>
+          match resolve_type(env, b) {
+            @core.Type::Int => true
+            _ => false
+          }
+        @core.Type::Int =>
+          match resolve_type(env, b) {
+            @core.Type::Char => true
+            _ => false
+          }
         _ => false
       }
       if not(char_int_mix) && not(type_equal(env, b, a)) {

--- a/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
+++ b/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
@@ -793,12 +793,15 @@ fn type_call_builtin_handler_collection_numeric(
       }
       // Char + Int is allowed for char arithmetic (`'A' + 1 == 'B'`); both
       // sides are 62-bit tagged at runtime so no conversion needed. The
-      // result type follows the first operand.
+      // result type follows the first operand. Use a pure equality check
+      // (`type_equal` would unify and could bind an unresolved operand to
+      // Char, skipping the later same-type unification).
       let resolved_b = resolve_type(env, b)
-      let char_int_mix = (type_equal(env, resolved_a, @core.Type::Char) &&
-        type_equal(env, resolved_b, @core.Type::Int)) ||
-        (type_equal(env, resolved_a, @core.Type::Int) &&
-        type_equal(env, resolved_b, @core.Type::Char))
+      let char_int_mix = match (resolved_a, resolved_b) {
+        (@core.Type::Char, @core.Type::Int) => true
+        (@core.Type::Int, @core.Type::Char) => true
+        _ => false
+      }
       if not(char_int_mix) && not(type_equal(env, b, a)) {
         raise TypeError::Mismatch(
           expected=a,

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -1902,7 +1902,7 @@ fn ensure_num_operand(
 ) -> Unit raise TypeError {
   let resolved = resolve_type(env, ty)
   match resolved {
-    @core.Type::Int | @core.Type::Float | @core.Type::Double => ()
+    @core.Type::Int | @core.Type::Float | @core.Type::Double | @core.Type::Char => ()
     @core.Type::Var(id) => mark_num_var(env, id)
     @core.Type::Named(..) =>
       if type_implements_trait(env, resolved, "Add") {


### PR DESCRIPTION
## Summary

Allow `Char` operands in arithmetic so `examples/char_test.vibe::"char arithmetic"` passes.

### Root cause

`examples/char_test.vibe` has:

```vibe
let c = 'A'
let next = c + 1
assert(next == 66)
assert(next == 'B')
```

Two checker issues blocked this:
1. `ensure_num_operand` rejected `Type::Char` (only accepted `Int`/`Float`/`Double`).
2. Even with Char allowed, the subsequent `type_equal(b, a)` check in `__add` required both operands to have the same type, rejecting the mixed `Char + Int` form.

### Fix

- Add `Type::Char` to `ensure_num_operand`'s numeric whitelist.
- In the `__add` handler, permit `Char + Int` or `Int + Char` as a documented mixed-operand case (both are 62-bit tagged at runtime so no conversion is needed). The result type follows the first operand.

### Impact

`just test-vibe-package-suite`:
- Before: 1,226 / 1,422
- After: **1,227 / 1,422** (+1)

`examples/char_test.vibe` now 12/12 (was 11/12).

### Test plan
- [x] `moon test src/parser src/checker`: 201/201
- [x] `just test-vibe-package-suite`: 1,227/1,422 (+1)
- [ ] CI (ci-required)

https://claude.ai/code/session_01SDzQV8tiPCMwV56xEiP61b