### PR TITLE
checker + codegen: lambda + Unit equality + empty map (#326, #327)

### DIFF
--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -1461,7 +1461,15 @@ fn type_fn_literal(
       None => effective_ty
     }
     let param_ty = substitute_type_params(param_ty_with_num, type_param_vars)
-    let resolved = normalize_type(env, param_ty)
+    let normalized = normalize_type(env, param_ty)
+    // Un-annotated lambda param (`(x) -> ...`) arrives with Type::Unit as the
+    // infer sentinel. When no contextual expected type is available (let RHS,
+    // IIFE), allocate a fresh type var so the body check can unify normally.
+    let resolved = if normalized.is_infer_placeholder() {
+      fresh_type_var(env)
+    } else {
+      normalized
+    }
     ensure_no_scoped_ref_param_decl(env, resolved, span)
     let _ = ensure_type_satisfies_bounds(
       env,

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -1993,8 +1993,8 @@ fn ensure_eq_operand(
     | @core.Type::Double
     | @core.Type::Bool
     | @core.Type::Char
-    | @core.Type::String => ()
-    @core.Type::Unit => ()
+    | @core.Type::String
+    | @core.Type::Unit => ()
     @core.Type::Var(_) => ()
     @core.Type::Tuple(items) =>
       // Recurse — tuple eq is element-wise, so every element must itself be Eq.

--- a/src/codegen/wasm_codegen_data.mbt
+++ b/src/codegen/wasm_codegen_data.mbt
@@ -372,6 +372,13 @@ fn compile_tuple_expr(
   buf : ByteBuf,
   items : Array[@core.Expr],
 ) -> Unit raise WasmGenError {
+  // Empty tuple `()` is the Unit singleton — emit tagged 0 to match the
+  // sentinel used elsewhere and to make `() == ()` return true (two
+  // distinct heap allocations would compare as inequal pointers).
+  if items.length() == 0 {
+    emit_i64_const_tagged(buf, 0L)
+    return
+  }
   require_heap(ctx)
   let len = items.length()
   let size = align4(8 + len * 4)


### PR DESCRIPTION
## Summary

Three small, independent checker/codegen wins batched into one PR. Each commit stands alone.

### 1. Un-annotated lambda params (#326, partial) — commit `df40374`

`(x) -> x + 1` had `x` arrive at `type_fn_literal` as `Type::Unit` — the infer-placeholder sentinel. When no contextual expected type flowed in (let-RHS binding, IIFE), the param stayed `Unit` and `x + 1` raised `expected: Int, actual: Unit`.

`type_lambda_with_context` already swaps the placeholder with `expected_param[i].ty` when a call-site context is available, but let-RHS and direct-invocation positions never reach that path.

**Fix:** In `type_fn_literal`, after `normalize_type`, swap any remaining infer-placeholder for a fresh type var so the body check can unify operators normally. Non-placeholder annotations stay verbatim.

### 2. Unit equality (#327, Unit part) — commit `3a8a578`

`() == ()` and `let u = (); u == ()` both failed:
- checker rejected `Type::Unit` at `ensure_eq_operand`
- even after type-check passed, codegen emitted each `()` as a fresh heap-allocated empty-tuple object, so two such values compared as distinct pointers

**Fix (two prongs):**
- `ensure_eq_operand`: add `Type::Unit` to the whitelist
- `compile_tuple_expr`: short-circuit `items.length() == 0` to emit the tagged-0 Unit sentinel instead of heap-allocating. Matches the `"return Unit (tagged 0)"` convention used elsewhere in codegen.

### 3. Empty map literal value type (#327 adj) — commit `ed0fa61`

`let m: Map[String, Int] = map {}` failed with `expected Map(String, Int), actual Map(String, Unit)` — the empty map typed its value as `Type::Unit` (placeholder), which then refused to unify with the annotated `Int`.

**Fix:** emit a fresh type var instead of Unit so a surrounding annotation can drive the value type via unification.

## Remaining work (out of scope for this PR)

Multi-element tuple equality remains unsupported — runtime tag dispatch for `__eq` doesn't recurse into tuple fields. Tracked in #327.

Un-annotated lambda in `_ > N` form failing inside `Array::any`/`all` — suggests the `_` placeholder desugar has a bug specific to comparison operators. Needs its own investigation.

## Test plan

- [x] `moon test src/checker src/parser src/codegen` → 275/275
- [x] `moon test src/cmd/vibe` → 381/382 (pre-existing #330)
- [x] `examples/` package suite → 584 → 587 (+3 tests: `function_test` IIFE, `edge_case_test` unit value, `map_test` map empty)
- [x] `vibe/*` suites unchanged (505/517)
