### PR TITLE
codegen: Set::add tagged-int key compare uses i32.eq, not obj_string deref (+2 tests)

### DIFF
--- a/src/codegen/wasm_codegen_builtin_collection.mbt
+++ b/src/codegen/wasm_codegen_builtin_collection.mbt
@@ -942,7 +942,16 @@ fn compile_builtin_collection(
         emit_i32_add(buf)
         emit_i32_load(buf, 8)
         emit_local_set(buf, entry_key_local)
-        emit_non_js_string_ptr_equals_i32(ctx, buf, entry_key_local, key_local)
+        // Match Set::contains' i32.eq. The shared
+        // `emit_non_js_string_ptr_equals_i32` helper treats its operands as
+        // `obj_string` pointers (loading length at `(int<<2)+4`), so for
+        // tagged-int keys `Set::add(Set::add(Set::new(), 10), 20)` could
+        // false-positive 20 vs 10 against memory garbage and silently skip
+        // the append. Map ops keep the helper because their tests exercise
+        // String keys where structural compare is required.
+        emit_local_get(buf, entry_key_local)
+        emit_local_get(buf, key_local)
+        emit_i32_eq(buf)
         buf.push((4).to_byte()) // if
         buf.push((64).to_byte()) // void
         emit_i32_const_raw(buf, 1)


### PR DESCRIPTION
## Summary

`Set::add` chained twice silently dropped the second value. Continuation of #325 work after PR #333.

**+2 tests** in `examples/set_test.vibe`:
- `set contains` (was failing because chained add lost the second value)
- `set multiple adds`

`vibe test examples/*.vibe`: 599 → **601** passed.

## Root cause

`Set::add` reused `emit_non_js_string_ptr_equals_i32` to detect duplicates inside the search loop. That helper unconditionally strips the tag bits from both operands and dereferences them as `obj_string` pointers (loads length at `(int<<2)+4`, compares bytes). For tagged-int keys (`Set::add(s, 10)` stores `(10<<2)|0 = 40`), this read arbitrary low memory at offsets 44 and 84 — usually small static-data bytes that happened to match — so `found_local` came back true and the append branch was skipped.

`Set::contains` already used a plain `i32.eq`, so it would have matched the new key correctly if the append had happened. But the append never did, so containment returned false.

## Fix

Replace the helper call inside `Set::add` with raw `i32.eq`, matching `Set::contains`. For tagged-int keys this is exactly right. The same shallow-compare caveat that `Set::contains` already has for `tag_obj` String keys now applies to `Set::add` too — but the two are now symmetric.

Map / MapBuilder ops keep the helper because their tests exercise String keys where the byte-wise structural compare in the helper is needed.

## Test plan

- [x] `moon test --target native src/parser src/checker src/core src/codegen` — 360/360 pass
- [x] `vibe test examples/set_test.vibe` — 7/11 pass (was 5/11)
- [x] `vibe test examples/map_test.vibe` — 9/12 (unchanged — Map ops not touched)
- [x] `vibe test examples/*.vibe` — 601/683 (was 599, no regressions)
- [ ] CI

## Out of scope

- Set / Map with String keys — the helper's structural compare path itself appears buggy when called against non-String objects (Bytes, etc). Tracked as separate failing tests.
- Map int-keyed tests — Map's internal compare uses the same helper, but the failing Map tests use String keys where the helper is correct. No changes needed for Map's failing tests in this PR.

https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U)_