### PR TITLE
checker+codegen: Map empty literal infers + Map::set stores untagged key (+4 tests)

### DIFF
--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -846,7 +846,12 @@ fn type_expr_eff(
     @core.Expr::Map(fields~, span~) => {
       let _ = span
       if fields.is_empty() {
-        @core.Type::Map(@core.Type::String, @core.Type::Unit)
+        // No element to infer from — use a fresh type variable so the value
+        // type can be unified later from context (e.g.
+        // `let m: Map[String, Int] = map {}`). Hard-coding `Unit` here forced
+        // a `Map(String, Unit)` mismatch even when the binding annotation
+        // resolved the value type concretely.
+        @core.Type::Map(@core.Type::String, fresh_type_var(env))
       } else {
         let first = type_expr_eff(
           env,

--- a/src/codegen/wasm_codegen_builtin_collection.mbt
+++ b/src/codegen/wasm_codegen_builtin_collection.mbt
@@ -1827,6 +1827,13 @@ fn compile_builtin_collection(
         let entry_key_local = alloc_temp_local(ctx)
         compile_expr_i32(ctx, buf, pos_args[1])
         emit_i32_wrap_i64(buf)
+        // Strip `tag_obj` to match the map literal's storage convention
+        // (`compile_map_expr` stores `ctx.strings.intern(key)` raw). `__index`
+        // compares the entry slot against the raw interned offset via
+        // `i32.eq`, so any tagged value stored here would silently fail the
+        // lookup (e.g. `Map::set(map { "a": 1 }, "b", 2)` then `m2["b"]`).
+        emit_i32_const_raw(buf, -4)
+        emit_i32_and(buf)
         emit_local_set(buf, key_local)
         buf.push((3).to_byte()) // loop
         buf.push((64).to_byte()) // void


### PR DESCRIPTION
## Summary

Two independent Map runtime bugs that surfaced together as the remaining `examples/map_test.vibe` failures. **+4 tests** on the examples sweep (601 → 605).

### 1. Empty `map {}` hard-coded to `Map(String, Unit)`

`let m: Map[String, Int] = map {}` was rejected by the checker — `expected: Map(String, Int), actual: Map(String, Unit)`. The `Expr::Map` arm with `fields.is_empty()` set the value type to `Type::Unit` (the same sentinel used for un-annotated lambda params before #332).

Fix: use `fresh_type_var(env)` so context-driven unification fills the value type from the binding annotation.

### 2. `Map::set` stored the key tagged

`Map::set(map { "a": 1 }, "b", 2)` then `m2["b"]` never found the new entry. The map literal codegen stores `ctx.strings.intern(key)` raw (no tag), but `Map::set` stored the wrapped i64-tagged value (`tag_obj` set in low bits). `__index(map, "name")` compares the entry slot against the raw interned offset via `i32.eq`, so any tagged value silently failed.

Fix: strip the `tag_obj` bits with `& -4` right after `i32_wrap_i64` so `Map::set` matches the literal's storage convention. Other Map ops (`Map::has`, `Map::get`, `Map::delete`) keep using the helper which untags both sides itself, so they continue to work for keys stored either way.

## Test plan

- [x] `moon test --target native src/parser src/checker src/core src/codegen` — 360/360 pass
- [x] `vibe test examples/map_test.vibe` — 12/12 pass (was 9/12)
- [x] `vibe test examples/*.vibe` — 605/683 (was 601, no regressions)
- [ ] CI

## Out of scope

- Map / Set with String keys via the helper still works because the helper does its own untag. Only `__index`'s direct compare needed the storage convention to be raw.
- Recursive enum deep compare, String concat in loop, `effect_advanced_test "user-defined effect with perform/resume"`, `perform_handle` typed-payload — separate codegen sub-targets of #325 / #329.

https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U)_