### PR TITLE
ci: run contract-native subtests in parallel (51s → 21s locally)

### DIFF
--- a/justfile
+++ b/justfile
@@ -126,23 +126,40 @@ ci-contract-moon:
 # PR-oriented native/runtime contract checks
 ci-contract-native:
     #!/usr/bin/env bash
+    # Run contract-native subtests in parallel. Locally measured ~52s sequential
+    # vs ~20s parallel (CPU-bound subscripts overlap with I/O-bound ones, longest
+    # individual is parallel-cleanup at ~19s). Each script writes its own log
+    # under _build/contract-native-logs/ for post-run inspection; failures are
+    # collected after `wait` so partial failures don't abort the rest.
     set -uo pipefail
     source scripts/ensure_native_cli.sh
     cli="_build/native/debug/build/cmd/vibe/vibe.exe"
+    log_dir="_build/contract-native-logs"
+    rm -rf "$log_dir" && mkdir -p "$log_dir"
+    declare -A pids
+    run_in_bg() {
+      local name="$1"
+      shift
+      "$@" > "$log_dir/$name.log" 2>&1 &
+      pids[$name]=$!
+    }
+    run_in_bg watchdog        bash scripts/test_internal_parent_watchdog_e2e.sh "$cli"
+    run_in_bg fixtures        bash scripts/test_fixtures_isolation.sh
+    run_in_bg e2e-parity      bash scripts/test_e2e_parity.sh
+    run_in_bg repl-parity     bash scripts/test_repl_parity.sh
+    run_in_bg feature-parity  env VIBE_BIN="$cli" bash scripts/test_feature_parity.sh
+    run_in_bg parallel-cleanup bash scripts/test_parallel_cleanup_e2e.sh "$cli"
     failed=""
-    echo "=== contract-native: watchdog ==="
-    bash scripts/test_internal_parent_watchdog_e2e.sh "$cli" || failed="$failed watchdog"
-    echo "=== contract-native: fixtures ==="
-    scripts/test_fixtures_isolation.sh || failed="$failed fixtures"
-    echo "=== contract-native: e2e-parity ==="
-    bash scripts/test_e2e_parity.sh || failed="$failed e2e-parity"
-    echo "=== contract-native: repl-parity ==="
-    bash scripts/test_repl_parity.sh || failed="$failed repl-parity"
-    echo "=== contract-native: feature-parity ==="
-    VIBE_BIN="$cli" scripts/test_feature_parity.sh || failed="$failed feature-parity"
-    echo "=== contract-native: parallel-cleanup ==="
-    bash scripts/test_parallel_cleanup_e2e.sh "$cli" || failed="$failed parallel-cleanup"
+    for name in "${!pids[@]}"; do
+      if ! wait "${pids[$name]}"; then
+        failed="$failed $name"
+      fi
+    done
     echo "=== contract-native: done ==="
+    for name in watchdog fixtures e2e-parity repl-parity feature-parity parallel-cleanup; do
+      echo "--- $name ---"
+      cat "$log_dir/$name.log"
+    done
     if [ -n "$failed" ]; then
       echo "contract-native: FAILED tests:$failed (non-fatal, see individual test logs)"
     else

--- a/justfile
+++ b/justfile
@@ -127,18 +127,20 @@ ci-contract-moon:
 ci-contract-native:
     #!/usr/bin/env bash
     # Run contract-native subtests in parallel. Locally measured ~52s sequential
-    # vs ~20s parallel (CPU-bound subscripts overlap with I/O-bound ones, longest
-    # individual is parallel-cleanup at ~19s). Each script writes its own log
-    # under _build/contract-native-logs/ for post-run inspection; failures are
-    # collected after `wait` so partial failures don't abort the rest.
+    # vs ~20s parallel (longest individual is parallel-cleanup at ~19s). Each
+    # script writes its own log under _build/contract-native-logs/ for post-run
+    # inspection; failures are collected after `wait` so partial failures don't
+    # abort the rest.
     #
-    # CI workers (4 vCPU) cap: `test_fixtures_isolation.sh` and
-    # `test_e2e_parity.sh` default each to `nproc` workers via xargs -P. Running
-    # 6 subtests with that default would put 2*nproc on the CPU just from those
-    # two and can trip fixtures' 5s timeout. Cap each to 2 so aggregate
-    # concurrency stays ~10 on a 4-vCPU runner; other subtests spawn at most a
-    # handful of vibe.exe processes at a time and are I/O-bound (waiting on
-    # wasmtime), so they don't push the budget further.
+    # CI runner (4 vCPU) sizing: an earlier revision capped fixtures and
+    # e2e-parity to JOBS=2 to dodge fixtures' 5s per-fixture timeout under
+    # CPU contention, but on the actual 4-vCPU GitHub runner that cap regressed
+    # contract-native from ~1:41 (uncapped) to ~2:32 (capped) without changing
+    # the timeout count (1 in both runs, on the same `effect_higher_order_compose`
+    # fixture that times out locally too). Keep the inner JOBS at the script
+    # default (`nproc`) and instead double the per-fixture timeout to 10s so
+    # transient CPU contention can't trip a healthy fixture into a false
+    # timeout. Both can still be overridden from the env.
     set -uo pipefail
     source scripts/ensure_native_cli.sh
     cli="_build/native/debug/build/cmd/vibe/vibe.exe"
@@ -152,10 +154,9 @@ ci-contract-native:
       pids[$name]=$!
     }
     run_in_bg watchdog        bash scripts/test_internal_parent_watchdog_e2e.sh "$cli"
-    run_in_bg fixtures        env VIBE_FIXTURE_JOBS="${VIBE_FIXTURE_JOBS:-2}" \
+    run_in_bg fixtures        env VIBE_FIXTURE_TIMEOUT="${VIBE_FIXTURE_TIMEOUT:-10}" \
                                   bash scripts/test_fixtures_isolation.sh
-    run_in_bg e2e-parity      env VIBE_E2E_JOBS="${VIBE_E2E_JOBS:-2}" \
-                                  bash scripts/test_e2e_parity.sh
+    run_in_bg e2e-parity      bash scripts/test_e2e_parity.sh
     run_in_bg repl-parity     bash scripts/test_repl_parity.sh
     run_in_bg feature-parity  env VIBE_BIN="$cli" bash scripts/test_feature_parity.sh
     run_in_bg parallel-cleanup bash scripts/test_parallel_cleanup_e2e.sh "$cli"

--- a/justfile
+++ b/justfile
@@ -131,6 +131,14 @@ ci-contract-native:
     # individual is parallel-cleanup at ~19s). Each script writes its own log
     # under _build/contract-native-logs/ for post-run inspection; failures are
     # collected after `wait` so partial failures don't abort the rest.
+    #
+    # CI workers (4 vCPU) cap: `test_fixtures_isolation.sh` and
+    # `test_e2e_parity.sh` default each to `nproc` workers via xargs -P. Running
+    # 6 subtests with that default would put 2*nproc on the CPU just from those
+    # two and can trip fixtures' 5s timeout. Cap each to 2 so aggregate
+    # concurrency stays ~10 on a 4-vCPU runner; other subtests spawn at most a
+    # handful of vibe.exe processes at a time and are I/O-bound (waiting on
+    # wasmtime), so they don't push the budget further.
     set -uo pipefail
     source scripts/ensure_native_cli.sh
     cli="_build/native/debug/build/cmd/vibe/vibe.exe"
@@ -144,8 +152,10 @@ ci-contract-native:
       pids[$name]=$!
     }
     run_in_bg watchdog        bash scripts/test_internal_parent_watchdog_e2e.sh "$cli"
-    run_in_bg fixtures        bash scripts/test_fixtures_isolation.sh
-    run_in_bg e2e-parity      bash scripts/test_e2e_parity.sh
+    run_in_bg fixtures        env VIBE_FIXTURE_JOBS="${VIBE_FIXTURE_JOBS:-2}" \
+                                  bash scripts/test_fixtures_isolation.sh
+    run_in_bg e2e-parity      env VIBE_E2E_JOBS="${VIBE_E2E_JOBS:-2}" \
+                                  bash scripts/test_e2e_parity.sh
     run_in_bg repl-parity     bash scripts/test_repl_parity.sh
     run_in_bg feature-parity  env VIBE_BIN="$cli" bash scripts/test_feature_parity.sh
     run_in_bg parallel-cleanup bash scripts/test_parallel_cleanup_e2e.sh "$cli"


### PR DESCRIPTION
## Summary

`ci-contract-native` ran its 6 subtests sequentially under one `ensure_native_cli`-built binary even though they're independent processes. Run them in background + `wait`, with per-subtest logs captured under `_build/contract-native-logs/`.

## Local timing

| Subtest | Time |
|---|---|
| watchdog | 3.3s |
| fixtures | 11.3s |
| e2e-parity | 1.9s |
| repl-parity | 8.1s |
| feature-parity | 7.8s |
| parallel-cleanup | 19.4s |
| **sequential total** | **51.8s** |
| **parallel** | **20.4s** (= longest = parallel-cleanup) |

**-31s, -60% locally on a 16-vcpu host.** GitHub runners have 4 vCPU so the saving is smaller, but most subscript work is I/O-bound (spawn vibe.exe → wait on wasmtime) so 6-way overlap shouldn't saturate.

## CI critical path impact

Post-#337 the new critical path is contract-native (3:09 on PR #337 2nd run). Of that, ~52s was the sequential contract-native subscript chain. Trimming that to ~20s should pull total wall closer to ~2:30 on warm-cache runs.

## Behavior preserved

- Each subtest still runs against the same `_build/native/debug/build/cmd/vibe/vibe.exe`.
- Failures are collected into `failed=…` after `wait` and reported at the end with the historical "non-fatal" wording, same as before.
- Per-subtest stdout/stderr captured under `_build/contract-native-logs/<name>.log` and dumped after `wait` so CI logs still show the detail.
- Verified locally: same `FAILED tests: fixtures e2e-parity (non-fatal)` outcome as the sequential version.

## Test plan

- [x] `time just ci-contract-native` (sequential): 51.4s, FAILED tests: fixtures e2e-parity
- [x] `time just ci-contract-native` (parallel): 21.4s, FAILED tests: fixtures e2e-parity
- [ ] CI on this branch — wall reduction proportional to runner vCPU count

https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U)_