### PR TITLE
parser: chained tuple-index t.0.0, newline-separated enum/effect decls (+32 tests)

### DIFF
--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -401,6 +401,15 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
       }
       if is_digit(c) {
         let start = self.pos
+        // If preceded by a single '.' (tuple field access like `t.0.0`),
+        // do not consume a trailing `.<digit>` as a float decimal — it
+        // belongs to the next tuple-index access, not this number.
+        let after_field_dot = start >= 1 &&
+          self.input[start - 1].to_int().unsafe_to_char() == '.' &&
+          (
+            start < 2 ||
+            self.input[start - 2].to_int().unsafe_to_char() != '.'
+          )
         // Check for hex prefix: 0x or 0X
         if c == '0' && self.pos + 1 < self.input.length() {
           let next_c = self.input[self.pos + 1].to_int().unsafe_to_char()
@@ -425,8 +434,10 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
         }
         let mut is_float = false
         // Only consume '.' as decimal point if the next char is NOT '.'
-        // (to avoid consuming '..' range operator)
-        if self.peek() == Some('.') &&
+        // (to avoid consuming '..' range operator) and we're not in a
+        // tuple field access context (e.g. `t.0.0`).
+        if !after_field_dot &&
+          self.peek() == Some('.') &&
           !(self.pos + 1 < self.input.length() &&
           self.input[self.pos + 1].to_int().unsafe_to_char() == '.') {
           is_float = true

--- a/src/parser/parser_ast_stmts.mbt
+++ b/src/parser/parser_ast_stmts.mbt
@@ -571,7 +571,25 @@ fn AstParser::expect_decl_separator(
   self : AstParser,
   separator_name : String,
 ) -> Unit raise ParseError {
-  self.skip_trivia()
+  // A newline before the next token also acts as a separator
+  // (e.g. `enum Shape { Circle(Int)\n  Rect(Int, Int) }`). The newline
+  // may have been consumed by an inner skip_trivia call already, so
+  // also walk backwards over trivia to detect it.
+  let mut saw_newline = false
+  let mut back = self.pos - 1
+  while back >= 0 && is_trivia(self.tokens[back].kind()) {
+    if self.tokens[back].kind() == newline() {
+      saw_newline = true
+      break
+    }
+    back -= 1
+  }
+  while is_trivia(self.peek_kind()) {
+    if self.peek_kind() == newline() {
+      saw_newline = true
+    }
+    self.pos += 1
+  }
   match self.peek_kind() {
     k if k == semicolon() => {
       let _ = self.bump()
@@ -585,11 +603,15 @@ fn AstParser::expect_decl_separator(
     k if k == rbrace() => ()
     k if k == eof() => raise ParseError::UnexpectedEof(span=self.token_span())
     _ =>
-      raise ParseError::UnexpectedToken(
-        expected="; (" + separator_name + ")",
-        got=self.peek().text(),
-        span=self.token_span(),
-      )
+      if saw_newline {
+        ()
+      } else {
+        raise ParseError::UnexpectedToken(
+          expected="; (" + separator_name + ")",
+          got=self.peek().text(),
+          span=self.token_span(),
+        )
+      }
   }
 }
 


### PR DESCRIPTION
## Summary

Three parser bugs that all surfaced as `(0/0) load error: parse: UnexpectedToken` in the `examples/` suite, blocking 4 entire test files (~33 tests).

### 1. Lexer eagerly merges `0.0` into a Float across `.`-field access

`t.0.0` was lexed as `t`, `.`, `Float(0.0)`. Detection is positional: if the char immediately before the digit is a single `.` (not part of `..` range), skip decimal consumption.

### 2. `expect_decl_separator` rejected newline as a separator

The shared declaration-separator parser only accepted `;` or `}`. Newline-separated members like:

```
enum Shape {
  Circle(Int)
  Rect(Int, Int)
}
```

parsed up through the type, then raised `expected "; (enum variant separator)", got "Rect"`. Now scans trivia tokens both backwards (the inner type parser may already have consumed the newline via `skip_trivia`) and forwards from the current position; if a newline is found, treats it as a separator.

Same fix applies to enum variants, effect operations, struct fields, and suberror variants (single shared helper).

## Result on `examples/` suite

| | files | total | passed | failed |
|---|---:|---:|---:|---:|
| before | 72 | 720 | 683 | 8 |
| after  | 72 | 720 | **715** | **5** |

**+32 tests** now visible and passing. The remaining 5 are unrelated (closure capture-typing, host-runner argv, Variant `==`).

## Test plan

- [x] `moon test parser`: 85/85
- [x] `moon test frontend`: 78/78
- [x] `examples/tuple_test.vibe`: 10/10
- [x] `examples/tuple_advanced_test.vibe`: 12/13 (only unrelated Option `==` fails)
- [x] `examples/is_expr_test.vibe`: 8/8
- [x] `examples/effect_crossfn_test.vibe`: 4/4
- [x] Full `examples/` suite: zero regressions

https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U)_