### PR TITLE
checker: don't pre-expand enum types when collecting pattern bindings (+1 test)

### DIFF
--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -1253,10 +1253,18 @@ fn type_match_block(
   if arms.is_empty() {
     raise TypeError::BadMatch(message="empty match", span~)
   }
-  let scrutinee_ty = normalize_type_expand_enum(
+  // Resolve aliases / type vars but do NOT expand `Named` enums into
+  // `Variant` for the binding-collection scrutinee. Pre-expanding would
+  // cause `match t { (a, b) => ... }` on a tuple of `Option[T]` to bind
+  // `a` to `Variant({...})`, which then fails to unify with subsequent
+  // `Some(_)` ctor calls (`Named`-typed). `Pat::Ctor` expands locally
+  // on demand. The exhaustiveness check below still needs the expanded
+  // view, so compute that separately.
+  let scrutinee_ty = normalize_type(
     env,
     type_expr_eff(env, scrutinee, aliases, effects, allow_effect),
   )
+  let scrutinee_ty_for_exhaust = normalize_type_expand_enum(env, scrutinee_ty)
   let mut result : @core.Type? = None
   let mut has_wildcard = false
   let mut has_ctor = false
@@ -1347,7 +1355,7 @@ fn type_match_block(
     }
   }
   if not(has_wildcard) {
-    match scrutinee_ty {
+    match scrutinee_ty_for_exhaust {
       @core.Type::Variant(types) => {
         let missing_names : Array[String] = []
         for name, _ in types {

--- a/src/checker/typecheck_pattern.mbt
+++ b/src/checker/typecheck_pattern.mbt
@@ -14,7 +14,13 @@ fn collect_pattern_bindings(
   scrutinee_ty : @core.Type,
 ) -> Map[String, @core.Type] raise TypeError {
   let out : Map[String, @core.Type] = {}
-  let normalized = normalize_type_expand_enum(env, scrutinee_ty)
+  // Resolve aliases / type vars but do NOT expand `Named` enums into
+  // `Variant`. Pre-expanding broke e.g. `let (a, b) = (Some(1), None)`:
+  // `a` got bound to `Variant({Some: Int, None: Unit})` while `Some(42)`
+  // continues to be typed as `Named("Option", [Int])`, so a later
+  // `a == Some(42)` failed to unify. Pat::Ctor still needs the Variant
+  // shape, so it expands locally.
+  let normalized = normalize_type(env, scrutinee_ty)
   collect_pattern_bindings_inner(env, out, pat, normalized)
   out
 }
@@ -52,7 +58,10 @@ fn collect_pattern_bindings_inner(
     @core.Pat::Ctor(name~, args~, span~) => {
       // Strip qualified prefix for variant lookup: Color::Red → Red
       let ctor_key = @core.strip_ctor_qualifier(name)
-      match scrutinee_ty {
+      // Pat::Ctor needs the expanded Variant view; the public entry no
+      // longer pre-expands so we do it here on demand.
+      let expanded = normalize_type_expand_enum(env, scrutinee_ty)
+      match expanded {
         @core.Type::Variant(types) =>
           match types.get(ctor_key) {
             Some(field_ty) =>


### PR DESCRIPTION
## Summary

`collect_pattern_bindings` and `type_match_block` pre-normalized the scrutinee type with `normalize_type_expand_enum`, which converts `Named("Option", [Int])` into `Variant({"Some": Int, "None": Unit})`. That worked for ctor-pattern destructuring but broke straight `Bind` patterns of nested options.

```vibe
let (a, b) = (Some(42), Some("hi"))
assert(a == Some(42))   // type mismatch: expected Int, actual Variant
```

`a` got bound to the expanded `Variant` while later ctor calls like `Some(42)` continue to be typed as `Named("Option", ..)` (via `instantiate_ctor`), and the two don't unify in `__eq`. Plain `t.0` access worked because `TupleIndex` returns `items[i]` without expansion.

## Fix

Switch the public entry of `collect_pattern_bindings` and the top of `type_match_block` from `normalize_type_expand_enum` to `normalize_type` (resolves aliases / type vars, keeps enums as `Named`). `Pat::Ctor` still needs the `Variant` shape, so expand locally on demand.

## Result

| | files | total | passed | failed |
|---|---:|---:|---:|---:|
| before | 72 | 720 | 715 | 5 |
| after  | 72 | 720 | **716** | **4** |

## Test plan

- [x] `moon test checker`: 125/125
- [x] `examples/tuple_advanced_test.vibe`: 13/13 (was 12/13)
- [x] Full `examples/` suite: zero regressions

https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U)_