### PR TITLE
checker: share subs in while/loop/for-in bodies so unification propagates (+2 tests)

### DIFF
--- a/src/checker/typecheck_env_lifecycle.mbt
+++ b/src/checker/typecheck_env_lifecycle.mbt
@@ -191,6 +191,73 @@ pub fn TypeEnv::fork_for_expr(self : TypeEnv) -> TypeEnv {
 }
 
 ///|
+/// Fork for inline block scopes whose type-inference state must
+/// propagate back to the caller (currently `while` / `loop` / `for-in`
+/// bodies). Bindings are scoped via `bindings.fork()`, but `subs` /
+/// `effect_subs` are shared by reference so unifications inside the
+/// body are visible to subsequent statements in the enclosing scope.
+/// Do NOT use for trial / speculative unification; prefer
+/// `fork_for_expr` / `fork_for_check` there to keep subs isolated.
+pub fn TypeEnv::fork_for_block(self : TypeEnv) -> TypeEnv {
+  {
+    bindings: self.bindings.fork(),
+    addr_types: self.addr_types,
+    enum_defs: self.enum_defs,
+    struct_defs: self.struct_defs,
+    type_aliases: self.type_aliases.copy(),
+    ctor_index: self.ctor_index,
+    effect_defs: self.effect_defs,
+    inferred_effects: {},
+    traits: self.traits,
+    trait_impls: self.trait_impls,
+    fn_versions: self.fn_versions,
+    purities: self.purities.fork(),
+    purity_tiers: self.purity_tiers.fork(),
+    expr_types: self.expr_types,
+    num_vars: self.num_vars.copy(),
+    var_trait_bounds: self.var_trait_bounds.copy(),
+    scoped_ref_contains_cache: self.scoped_ref_contains_cache,
+    scoped_ref_contains_cache_version: self.scoped_ref_contains_cache_version,
+    normalize_type_cache_expand: self.normalize_type_cache_expand,
+    normalize_type_cache_preserve: self.normalize_type_cache_preserve,
+    normalize_type_cache_subs_version: self.subs_version,
+    normalize_type_cache_expand_ground: self.normalize_type_cache_expand_ground,
+    normalize_type_cache_preserve_ground: self.normalize_type_cache_preserve_ground,
+    scoped_ref_checks_enabled: self.scoped_ref_checks_enabled,
+    has_scoped_ref_binding: self.has_scoped_ref_binding,
+    scoped_ref_binding_scan_stale: self.scoped_ref_binding_scan_stale,
+    scoped_ref_profile_enabled: self.scoped_ref_profile_enabled,
+    scoped_ref_contains_calls: self.scoped_ref_contains_calls,
+    scoped_ref_contains_cache_hits: self.scoped_ref_contains_cache_hits,
+    scoped_ref_contains_cache_misses: self.scoped_ref_contains_cache_misses,
+    scoped_ref_contains_time_us: self.scoped_ref_contains_time_us,
+    scoped_ref_capture_checks: self.scoped_ref_capture_checks,
+    scoped_ref_capture_time_us: self.scoped_ref_capture_time_us,
+    scoped_ref_call_arg_checks: self.scoped_ref_call_arg_checks,
+    scoped_ref_call_arg_time_us: self.scoped_ref_call_arg_time_us,
+    scoped_ref_return_checks: self.scoped_ref_return_checks,
+    scoped_ref_return_time_us: self.scoped_ref_return_time_us,
+    scoped_ref_toplevel_checks: self.scoped_ref_toplevel_checks,
+    scoped_ref_toplevel_time_us: self.scoped_ref_toplevel_time_us,
+    next_var: self.next_var,
+    next_effect_var: self.next_effect_var,
+    loop_depth: self.loop_depth,
+    loop_break_types: self.loop_break_types,
+    handle_arm_depth: self.handle_arm_depth,
+    handle_resume_types: self.handle_resume_types.copy(),
+    handle_resume_types_active: self.handle_resume_types_active,
+    handle_arm_effect_name: self.handle_arm_effect_name,
+    handle_arm_resume_expected: self.handle_arm_resume_expected,
+    active_rec_fn: self.active_rec_fn,
+    active_rec_fn_has_type_params: self.active_rec_fn_has_type_params,
+    subs_version: self.subs_version,
+    subs: self.subs,
+    effect_subs: self.effect_subs,
+    session_state: self.session_state,
+  }
+}
+
+///|
 pub fn TypeEnv::fork_for_check(self : TypeEnv) -> TypeEnv {
   {
     bindings: self.bindings.fork(),

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -1253,10 +1253,18 @@ fn type_match_block(
   if arms.is_empty() {
     raise TypeError::BadMatch(message="empty match", span~)
   }
-  let scrutinee_ty = normalize_type_expand_enum(
+  // Resolve aliases / type vars but do NOT expand `Named` enums into
+  // `Variant` for the binding-collection scrutinee. Pre-expanding would
+  // cause `match t { (a, b) => ... }` on a tuple of `Option[T]` to bind
+  // `a` to `Variant({...})`, which then fails to unify with subsequent
+  // `Some(_)` ctor calls (`Named`-typed). `Pat::Ctor` expands locally
+  // on demand. The exhaustiveness check below still needs the expanded
+  // view, so compute that separately.
+  let scrutinee_ty = normalize_type(
     env,
     type_expr_eff(env, scrutinee, aliases, effects, allow_effect),
   )
+  let scrutinee_ty_for_exhaust = normalize_type_expand_enum(env, scrutinee_ty)
   let mut result : @core.Type? = None
   let mut has_wildcard = false
   let mut has_ctor = false
@@ -1347,7 +1355,7 @@ fn type_match_block(
     }
   }
   if not(has_wildcard) {
-    match scrutinee_ty {
+    match scrutinee_ty_for_exhaust {
       @core.Type::Variant(types) => {
         let missing_names : Array[String] = []
         for name, _ in types {

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -932,7 +932,7 @@ fn type_expr_eff(
           // then iter_length/iter_get (which dispatch to the impl)
           @core.desugar_for_in(value_name, index_name, iterable, body, span)
       }
-      type_block(env, desugared, aliases, effects, true)
+      type_block(env, desugared, aliases, effects, true, share_subs=true)
     }
     @core.Expr::Fn(
       type_params~,
@@ -960,7 +960,7 @@ fn type_expr_eff(
       }
       env.loop_depth += 1
       let body_ty_result : Result[@core.Type, TypeError] = try? type_block(
-        env, body, aliases, effects, allow_effect,
+        env, body, aliases, effects, allow_effect, share_subs=true,
       )
       env.loop_depth -= 1
       match body_ty_result {
@@ -994,7 +994,7 @@ fn type_expr_eff(
       env.loop_break_types = []
       env.loop_depth += 1
       let body_ty_result : Result[@core.Type, TypeError] = try? type_block(
-        env, body, aliases, effects, allow_effect,
+        env, body, aliases, effects, allow_effect, share_subs=true,
       )
       env.loop_depth -= 1
       let break_types = env.loop_break_types
@@ -1686,8 +1686,20 @@ fn type_block(
   aliases : Map[String, @core.Ref],
   effects : EffectScope,
   allow_effect : Bool,
+  share_subs? : Bool,
 ) -> @core.Type raise TypeError {
-  let scope_env = clone_env(env)
+  // `share_subs` is for `while` / `loop` / `for-in` bodies whose
+  // unifications must be visible to the enclosing scope (e.g.
+  // `ArrayBuilder::push(b, () -> Int { 99 })` inside `while` setting
+  // the element type so a later `freeze(b)[0]()` knows it's a
+  // function). Default off so other blocks (if branches, lambda
+  // bodies, etc.) keep per-scope isolation.
+  let share_subs = share_subs.unwrap_or(false)
+  let scope_env = if share_subs {
+    env.fork_for_block()
+  } else {
+    clone_env(env)
+  }
   let mut last = @core.Type::Unit
   for stmt in body.stmts {
     match stmt {
@@ -1910,6 +1922,21 @@ fn type_block(
     }
     env.handle_resume_types = inferred_resume_types
     env.next_var = scope_env.next_var
+  }
+  if share_subs {
+    // `subs` / `effect_subs` are shared by reference (see
+    // `fork_for_block`), but the `next_var` / `next_effect_var`
+    // counters are still copied. Without writing them back, fresh
+    // vars allocated inside the block (e.g. by an inner closure)
+    // would leak into shared subs while the outer counter still
+    // points at a value that's already a key, producing collisions
+    // on the next outer allocation.
+    if scope_env.next_var > env.next_var {
+      env.next_var = scope_env.next_var
+    }
+    if scope_env.next_effect_var > env.next_effect_var {
+      env.next_effect_var = scope_env.next_effect_var
+    }
   }
   last
 }

--- a/src/checker/typecheck_pattern.mbt
+++ b/src/checker/typecheck_pattern.mbt
@@ -14,7 +14,13 @@ fn collect_pattern_bindings(
   scrutinee_ty : @core.Type,
 ) -> Map[String, @core.Type] raise TypeError {
   let out : Map[String, @core.Type] = {}
-  let normalized = normalize_type_expand_enum(env, scrutinee_ty)
+  // Resolve aliases / type vars but do NOT expand `Named` enums into
+  // `Variant`. Pre-expanding broke e.g. `let (a, b) = (Some(1), None)`:
+  // `a` got bound to `Variant({Some: Int, None: Unit})` while `Some(42)`
+  // continues to be typed as `Named("Option", [Int])`, so a later
+  // `a == Some(42)` failed to unify. Pat::Ctor still needs the Variant
+  // shape, so it expands locally.
+  let normalized = normalize_type(env, scrutinee_ty)
   collect_pattern_bindings_inner(env, out, pat, normalized)
   out
 }
@@ -52,7 +58,10 @@ fn collect_pattern_bindings_inner(
     @core.Pat::Ctor(name~, args~, span~) => {
       // Strip qualified prefix for variant lookup: Color::Red → Red
       let ctor_key = @core.strip_ctor_qualifier(name)
-      match scrutinee_ty {
+      // Pat::Ctor needs the expanded Variant view; the public entry no
+      // longer pre-expands so we do it here on demand.
+      let expanded = normalize_type_expand_enum(env, scrutinee_ty)
+      match expanded {
         @core.Type::Variant(types) =>
           match types.get(ctor_key) {
             Some(field_ty) =>


### PR DESCRIPTION
## Summary

`type_block` clones env via `fork_for_expr` which copies `subs`. Inside `while` / `loop` / `for-in` bodies this broke type-var propagation: unifications wrote to the inner copy of `subs` and were lost when the block returned.

```vibe
let b = ArrayBuilder::new()           // ArrayBuilder[α]
let mut i = 0
while i < n {
  ArrayBuilder::push(b, () -> Int { … })  // unifies α := () -> Int  (LOCAL ONLY)
  i += 1
}
let fns = ArrayBuilder::freeze(b)     // sees α still unbound
let f = fns[0]                        // f : Var(α)
assert(f() == 99)                     // type error: unknown function `f`
```

The `let f: () -> Int = fns[0]` workaround sidestepped it by constraining `f` from the caller.

## Fix

Add `TypeEnv::fork_for_block` next to `fork_for_expr`. Same semantics for bindings / aliases / etc., but `subs` and `effect_subs` are shared by reference. `type_block` gains an optional `share_subs?` parameter (default `false`). `Expr::While` / `Expr::Loop` / `Expr::ForIn` pass `share_subs=true` so their body unifications survive.

Trial / speculative unification (`fork_for_expr`, `fork_for_check`) is unchanged — those still need isolated subs to roll back failed attempts cleanly.

## Result

| | files | total | passed | failed |
|---|---:|---:|---:|---:|
| before | 72 | 720 | 716 | 4 |
| after  | 72 | 720 | **718** | **2** |

`closure_test` and `closure_advanced_test` newly green. The remaining 2 failures are the unrelated `perform+handle` host-runner-argv issues.

## Note

This PR is **stacked on #346** (the pattern-binding enum-expansion fix). Targets `claude/checker-pattern-bind-no-enum-expand` so the diff is clean — please merge #346 first then re-target this to `main`, or squash-merge both.

## Test plan

- [x] `moon test` (all packages): 1259/1259
- [x] `examples/closure_test.vibe`: 8/8
- [x] `examples/closure_advanced_test.vibe`: 14/14
- [x] Full `examples/` suite: zero regressions

https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U)_