### PR TITLE
codegen: __perform(Ctor(args)) function-call form mirrors keyword for…

### DIFF
--- a/src/codegen/wasm_codegen_builtin_misc.mbt
+++ b/src/codegen/wasm_codegen_builtin_misc.mbt
@@ -85,13 +85,111 @@ fn compile_builtin_misc(
     }
     "__perform" => {
       let pos_args = extract_positional_exprs_with_arity(args, "__perform", 1)
-      if ctx.use_js_strings {
-        compile_expr(ctx, buf, pos_args[0])
-      } else {
-        compile_expr_i32(ctx, buf, pos_args[0])
+      // `perform(Ctor(args))` (function-call form) needs to behave like the
+      // keyword form `perform Effect::Op(args)` so the surrounding handle
+      // can dispatch on the ctor name as a string. Without this, the handler
+      // compares a thrown enum-object pointer to a literal ctor-name string
+      // and the dispatch never matches — the retry loop runs to OOB.
+      let inner = pos_args[0]
+      let ctor_payload : (String, Array[@core.Expr], @core.Span)? = match inner {
+        @core.Expr::Call(name~, args=ctor_args, span~, ..) =>
+          if @core.is_ctor_name(name) &&
+            ctx.need_effect_resume &&
+            ctx.effect_perform_arg_global >= 0 {
+            let exprs = extract_positional_exprs(ctor_args, name)
+            Some((name, exprs, span))
+          } else {
+            None
+          }
+        _ => None
       }
-      buf.push((8).to_byte()) // throw
-      write_u32_leb(buf, ctx.error_tag_index)
+      match ctor_payload {
+        Some((ctor_name, payload_exprs, ctor_span)) => {
+          // Look up the qualified key "Effect::Ctor" the surrounding handle
+          // expects. The scan pass populated `effect_handled_ops` with the
+          // qualified ctor names from in-scope handle arms; pick the entry
+          // ending in "::ctor_name". If no in-scope handle owns this op,
+          // fall back to the bare ctor name (the handler will not match
+          // and the throw will propagate, same as before).
+          let suffix = "::" + ctor_name
+          let mut qualified_key = ctor_name
+          for handled_key, _ in ctx.effect_handled_ops {
+            if handled_key.has_suffix(suffix) {
+              qualified_key = handled_key
+              break
+            }
+          }
+          // Mirror Expr::Perform's flow: on retry-iteration, read from the
+          // resume buffer instead of throwing. Without this branch the
+          // handle's retry loop would re-throw forever and overflow the
+          // 64-slot resume buffer — which surfaces as `memory access out
+          // of bounds` from the i64.store at the next slot.
+          if ctx.need_effect_resume && ctx.effect_resume_idx_global >= 0 {
+            // if (resume_idx < resume_count) { return resume_buf[idx++ * 8] }
+            emit_global_get(buf, ctx.effect_resume_idx_global)
+            emit_global_get(buf, ctx.effect_resume_count_global)
+            emit_i32_lt_s(buf)
+            buf.push((4).to_byte()) // if
+            buf.push((126).to_byte()) // result i64
+            emit_global_get(buf, ctx.effect_resume_buf_global)
+            emit_global_get(buf, ctx.effect_resume_idx_global)
+            emit_i32_const_raw(buf, 8)
+            emit_i32_mul(buf)
+            emit_i32_add(buf)
+            emit_i64_load(buf, 0)
+            emit_global_get(buf, ctx.effect_resume_idx_global)
+            emit_i32_const_raw(buf, 1)
+            emit_i32_add(buf)
+            emit_global_set(buf, ctx.effect_resume_idx_global)
+            buf.push((5).to_byte()) // else
+            // Store payload in effect_perform_arg_global, then throw key.
+            if payload_exprs.length() == 0 {
+              emit_i64_const_raw(buf, 0L)
+            } else if payload_exprs.length() == 1 {
+              compile_expr_i32(ctx, buf, payload_exprs[0])
+            } else {
+              let tuple_expr = @core.Expr::Tuple(
+                items=payload_exprs, span=ctor_span,
+              )
+              compile_expr_i32(ctx, buf, tuple_expr)
+            }
+            emit_global_set(buf, ctx.effect_perform_arg_global)
+            let tag_str = @core.Expr::String(
+              value=qualified_key, span=ctor_span,
+            )
+            compile_expr_raise(ctx, buf, tag_str)
+            buf.push((11).to_byte()) // end if
+          } else {
+            // No resume context: just store payload + throw.
+            if payload_exprs.length() == 0 {
+              emit_i64_const_raw(buf, 0L)
+            } else if payload_exprs.length() == 1 {
+              compile_expr_i32(ctx, buf, payload_exprs[0])
+            } else {
+              let tuple_expr = @core.Expr::Tuple(
+                items=payload_exprs, span=ctor_span,
+              )
+              compile_expr_i32(ctx, buf, tuple_expr)
+            }
+            emit_global_set(buf, ctx.effect_perform_arg_global)
+            let tag_str = @core.Expr::String(
+              value=qualified_key, span=ctor_span,
+            )
+            compile_expr_raise(ctx, buf, tag_str)
+          }
+        }
+        None => {
+          // Fallback: throw the value directly (legacy behavior for
+          // non-ctor payloads or when no resume-handler is in scope).
+          if ctx.use_js_strings {
+            compile_expr(ctx, buf, inner)
+          } else {
+            compile_expr_i32(ctx, buf, inner)
+          }
+          buf.push((8).to_byte()) // throw
+          write_u32_leb(buf, ctx.error_tag_index)
+        }
+      }
     }
     "__resume" => {
       let pos_args = extract_positional_exprs_with_arity(args, "__resume", 1)


### PR DESCRIPTION
…m (+1 test)

`perform(Ctor(args))` (the function-call form) was lowered as a plain `Call("__perform", [Ctor(args)])` whose codegen just compiled and threw the inner ctor object directly. The keyword form `perform Effect::Op(args)` instead stores the payload in `effect_perform_arg_global` and throws a string tag `"Effect::Op"` for the surrounding handle's catch to dispatch on.

Because the two paths disagreed, an inner `handle … with Ask` caught a tagged enum-object pointer while the catch-side dispatch compared against a string-literal pointer. They never matched, the handler retry loop ran to its 64-slot ceiling, and the `i64.store` to `resume_buf[count*8]` tripped a `memory access out of bounds` trap.

Symptoms in `examples/perform_handle.vibe`:

    test "perform+handle typed payload": failed (wasm OOB)
    test "perform+handle multi-layer":   failed (same root cause
                                                  + a separate
                                                  nested-handle
                                                  resume-state
                                                  issue, not fixed
                                                  here)

This patch makes the function-call form act like the keyword form when the inner expression is a ctor call AND a resume-handler is in scope:

1. Compile and store the ctor's payload (Unit / single arg / Tuple for arity ≥ 2) in `effect_perform_arg_global`.
2. Look up the qualified key `"Effect::Op"` from `ctx.effect_handled_ops` (populated during scan from in-scope handle arm patterns; ctor name is suffix-matched). Fall back to the bare ctor name when no enclosing handle owns the op.
3. Mirror `Expr::Perform`'s resume-read path: on retry iterations, read `resume_buf[idx++]` instead of throwing — without this the handler's outer retry loop would re-throw forever and overflow the 64-slot resume buffer (the original OOB trap).
4. Throw the qualified key so the catch-dispatch matches.

Result on examples/ suite:
  before: 720 total, 718 passed, 2 failed
  after:  720 total, 719 passed, 1 failed
  (`perform+handle typed payload` now passes; `multi-layer`
   still fails — that needs handler-local resume buffers or a resume-state stack, separate change)

Verified:
- moon test (all packages): 1259/1259
- examples/perform_handle.vibe: 2/3 (was 1/3)
- examples/effect*: all green (no regressions)
- Full examples/ suite: zero regressions

https://claude.ai/code/session_01CHCYdAQXmEBeDfDk9L2y1U