### PR TITLE
codegen: per-effect resume globals for nested handle multi-layer (+2 …

### DIFF
--- a/examples/perform_handle.vibe
+++ b/examples/perform_handle.vibe
@@ -62,3 +62,20 @@ test "perform+handle multi-layer" {
 test "throw is still handled by Error" {
   assert(recover(7) == 7)
 }
+
+test "perform+handle multi-layer different effects nested twice" {
+  // Re-running the multi_layer body re-enters the inner Log handle, which
+  // re-initializes Log's resume globals. Without per-effect globals, the
+  // outer Ask handle's resume buffer would be clobbered on every retry.
+  assert(multi_layer() == 43)
+  assert(multi_layer() == 43)
+}
+
+test "perform+handle save-restore across function call" {
+  // ask_plus_one establishes its own Ask handle; calling it twice from main
+  // exercises the save/restore on entry/exit of the same effect's globals
+  // so the second call sees a fresh frame, not stale state from the first.
+  assert(ask_plus_one() == 43)
+  assert(ask_plus_one() == 43)
+  assert(ask_plus_one() + ask_plus_one() == 86)
+}

--- a/src/codegen/wasm_codegen_builtin_misc.mbt
+++ b/src/codegen/wasm_codegen_builtin_misc.mbt
@@ -85,13 +85,115 @@ fn compile_builtin_misc(
     }
     "__perform" => {
       let pos_args = extract_positional_exprs_with_arity(args, "__perform", 1)
-      if ctx.use_js_strings {
-        compile_expr(ctx, buf, pos_args[0])
-      } else {
-        compile_expr_i32(ctx, buf, pos_args[0])
+      // `perform(Ctor(args))` (function-call form) needs to behave like the
+      // keyword form `perform Effect::Op(args)` so the surrounding handle
+      // can dispatch on the qualified op key as a string. Without this, the
+      // handler compares a thrown enum-object pointer to a literal ctor-name
+      // string and the dispatch never matches — the retry loop runs to OOB.
+      let inner = pos_args[0]
+      let ctor_payload : (String, Array[@core.Expr], @core.Span)? = match
+        inner {
+        @core.Expr::Call(name~, args=ctor_args, span~, ..) =>
+          if @core.is_ctor_name(name) && ctx.need_effect_resume {
+            let exprs = extract_positional_exprs(ctor_args, name)
+            Some((name, exprs, span))
+          } else {
+            None
+          }
+        _ => None
       }
-      buf.push((8).to_byte()) // throw
-      write_u32_leb(buf, ctx.error_tag_index)
+      match ctor_payload {
+        Some((ctor_name, payload_exprs, ctor_span)) => {
+          // Look up the qualified key the surrounding handle expects. Scan
+          // populated `effect_handled_ops` with qualified keys ("Eff::Op");
+          // pick the entry ending in "::ctor_name". Fallback is the bare ctor
+          // name (handler won't match → throw propagates, same as before).
+          let suffix = "::" + ctor_name
+          let mut qualified_key = ctor_name
+          for handled_key, _ in ctx.effect_handled_ops {
+            if handled_key.has_suffix(suffix) {
+              qualified_key = handled_key
+              break
+            }
+          }
+          let effect_name = extract_effect_name_from_key(qualified_key)
+          let (idx_g, count_g, buf_g) = get_effect_resume_globals(
+            ctx, effect_name,
+          )
+          // Mirror Expr::Perform: on retry-iteration, read from the resume
+          // buffer instead of throwing. Without this branch the handle's
+          // retry loop would re-throw forever and overflow the 64-slot
+          // buffer (memory access OOB on i64.store at the next slot).
+          if ctx.need_effect_resume && idx_g >= 0 {
+            // if (resume_idx < resume_count) { return resume_buf[idx++ * 8] }
+            emit_global_get(buf, idx_g)
+            emit_global_get(buf, count_g)
+            emit_i32_lt_s(buf)
+            buf.push((4).to_byte()) // if
+            buf.push((126).to_byte()) // result i64
+            emit_global_get(buf, buf_g)
+            emit_global_get(buf, idx_g)
+            emit_i32_const_raw(buf, 8)
+            emit_i32_mul(buf)
+            emit_i32_add(buf)
+            emit_i64_load(buf, 0)
+            emit_global_get(buf, idx_g)
+            emit_i32_const_raw(buf, 1)
+            emit_i32_add(buf)
+            emit_global_set(buf, idx_g)
+            buf.push((5).to_byte()) // else
+            // Store payload in effect_perform_arg_global, then throw key.
+            if payload_exprs.length() == 0 {
+              emit_i64_const_raw(buf, 0L)
+            } else if payload_exprs.length() == 1 {
+              compile_expr_i32(ctx, buf, payload_exprs[0])
+            } else {
+              let tuple_expr = @core.Expr::Tuple(
+                items=payload_exprs,
+                span=ctor_span,
+              )
+              compile_expr_i32(ctx, buf, tuple_expr)
+            }
+            emit_global_set(buf, ctx.effect_perform_arg_global)
+            let tag_str = @core.Expr::String(
+              value=qualified_key,
+              span=ctor_span,
+            )
+            compile_expr_raise(ctx, buf, tag_str)
+            buf.push((11).to_byte()) // end if
+          } else {
+            // No resume context: just store payload + throw.
+            if payload_exprs.length() == 0 {
+              emit_i64_const_raw(buf, 0L)
+            } else if payload_exprs.length() == 1 {
+              compile_expr_i32(ctx, buf, payload_exprs[0])
+            } else {
+              let tuple_expr = @core.Expr::Tuple(
+                items=payload_exprs,
+                span=ctor_span,
+              )
+              compile_expr_i32(ctx, buf, tuple_expr)
+            }
+            emit_global_set(buf, ctx.effect_perform_arg_global)
+            let tag_str = @core.Expr::String(
+              value=qualified_key,
+              span=ctor_span,
+            )
+            compile_expr_raise(ctx, buf, tag_str)
+          }
+        }
+        None => {
+          // Fallback: throw the value directly (legacy behavior for
+          // non-ctor payloads or when no resume-handler is in scope).
+          if ctx.use_js_strings {
+            compile_expr(ctx, buf, inner)
+          } else {
+            compile_expr_i32(ctx, buf, inner)
+          }
+          buf.push((8).to_byte()) // throw
+          write_u32_leb(buf, ctx.error_tag_index)
+        }
+      }
     }
     "__resume" => {
       let pos_args = extract_positional_exprs_with_arity(args, "__resume", 1)

--- a/src/codegen/wasm_codegen_ctx.mbt
+++ b/src/codegen/wasm_codegen_ctx.mbt
@@ -60,9 +60,11 @@ priv struct CodegenCtx {
   // Effect resume globals for cross-function perform dispatch
   effect_handled_ops : Map[String, Bool]
   mut need_effect_resume : Bool
-  mut effect_resume_idx_global : Int // i32: current read position
-  mut effect_resume_count_global : Int // i32: number of stored resume values
-  mut effect_resume_buf_global : Int // i32: pointer to resume value buffer
+  // Per-effect resume globals: effect_name -> (idx, count, buf) global indices.
+  // Each handled effect gets its own (idx, count, buf) triple so nested
+  // handles for *different* effects don't clobber each other's resume state.
+  // Same-effect nesting is handled via save/restore in handle codegen.
+  effect_resume_globals : Map[String, (Int, Int, Int)]
   mut effect_perform_arg_global : Int // i64: perform argument value for cross-function dispatch
   // Stack switching for async
   mut need_stack_switching : Bool
@@ -260,9 +262,7 @@ fn CodegenCtx::new(
     current_env_idx: -1,
     effect_handled_ops: {},
     need_effect_resume: false,
-    effect_resume_idx_global: -1,
-    effect_resume_count_global: -1,
-    effect_resume_buf_global: -1,
+    effect_resume_globals: {},
     effect_perform_arg_global: -1,
     need_exceptions: false,
     error_tag_type_index: -1,

--- a/src/codegen/wasm_codegen_expr.mbt
+++ b/src/codegen/wasm_codegen_expr.mbt
@@ -149,27 +149,33 @@ fn compile_expr(
           buf.push((0).to_byte())
           emit_call(buf, idx)
         }
-        _ =>
-          // User-defined effect: check resume globals first, then throw.
-          if ctx.need_effect_resume && ctx.effect_resume_idx_global >= 0 {
+        _ => {
+          // User-defined effect: pick this effect's per-effect resume globals.
+          // Different nested effects (e.g. Log inside an Ask handle) read/write
+          // independent (idx, count, buf) triples so they don't clobber each
+          // other on retry.
+          let (idx_g, count_g, buf_g) = get_effect_resume_globals(
+            ctx, effect_name,
+          )
+          if ctx.need_effect_resume && idx_g >= 0 {
             // if (resume_idx < resume_count) { return resume_buf[resume_idx++ * 8] }
-            emit_global_get(buf, ctx.effect_resume_idx_global)
-            emit_global_get(buf, ctx.effect_resume_count_global)
+            emit_global_get(buf, idx_g)
+            emit_global_get(buf, count_g)
             emit_i32_lt_s(buf)
             buf.push((4).to_byte()) // if
             buf.push((126).to_byte()) // result i64
             // Read resume value: buf_ptr + idx * 8
-            emit_global_get(buf, ctx.effect_resume_buf_global)
-            emit_global_get(buf, ctx.effect_resume_idx_global)
+            emit_global_get(buf, buf_g)
+            emit_global_get(buf, idx_g)
             emit_i32_const_raw(buf, 8)
             emit_i32_mul(buf)
             emit_i32_add(buf)
             emit_i64_load(buf, 0)
             // Increment idx
-            emit_global_get(buf, ctx.effect_resume_idx_global)
+            emit_global_get(buf, idx_g)
             emit_i32_const_raw(buf, 1)
             emit_i32_add(buf)
-            emit_global_set(buf, ctx.effect_resume_idx_global)
+            emit_global_set(buf, idx_g)
             buf.push((5).to_byte()) // else
             // Store perform arg in global before throwing
             if args.length() > 0 {
@@ -193,6 +199,7 @@ fn compile_expr(
             let tag_str = @core.Expr::String(value=key, span~)
             compile_expr_raise(ctx, buf, tag_str)
           }
+        }
       }
     }
     @core.Expr::Handle(body~, arms~, span~) =>

--- a/src/codegen/wasm_codegen_expr_effect.mbt
+++ b/src/codegen/wasm_codegen_expr_effect.mbt
@@ -4,6 +4,31 @@ fn is_builtin_error_handler_name(name : String) -> Bool {
 }
 
 ///|
+/// Extract the effect name (prefix before "::") from a qualified op key.
+/// "Logger::Log" -> "Logger"; "Bare" -> "Bare" (used for enum-as-effect).
+fn extract_effect_name_from_key(qualified : String) -> String {
+  for i = 0; i + 1 < qualified.length(); i = i + 1 {
+    if qualified[i] == ':' && qualified[i + 1] == ':' {
+      return qualified[0:i].to_string()
+    }
+  }
+  qualified
+}
+
+///|
+/// Look up the per-effect resume globals for a given effect name.
+/// Returns (-1, -1, -1) when no handle in scope handles this effect.
+fn get_effect_resume_globals(
+  ctx : CodegenCtx,
+  effect_name : String,
+) -> (Int, Int, Int) {
+  match ctx.effect_resume_globals.get(effect_name) {
+    Some(t) => t
+    None => (-1, -1, -1)
+  }
+}
+
+///|
 fn is_resume_effect_pat(pat : @core.Pat) -> Bool {
   match pat {
     @core.Pat::Ctor(name~, ..) =>
@@ -215,16 +240,40 @@ fn compile_expr_handle_with_resume(
 ) -> Unit raise WasmGenError {
   let error_kind = handle_error_kind(ctx)
   require_heap(ctx)
+  // Determine which effect this handle handles. One `with E { ... }` block
+  // covers exactly one effect; pull the prefix off the first effect arm's
+  // qualified key (e.g. "Logger::Log" -> "Logger"), and pick that effect's
+  // (idx, count, buf) global triple.
+  let handled_effect_name = match effect_arms[0].pat {
+    @core.Pat::Ctor(name~, ..) => extract_effect_name_from_key(name)
+    _ => ""
+  }
+  let (idx_g, count_g, buf_g) = get_effect_resume_globals(
+    ctx, handled_effect_name,
+  )
+  // Save outer state for THIS effect to locals so a nested same-effect handle
+  // (or a re-entry of a function that contains a handle) can re-read the
+  // outer's resume buffer when this frame finishes. Without save/restore,
+  // an outer handle's `count` would be permanently clobbered by inner init.
+  let save_idx_local = alloc_temp_local(ctx)
+  let save_count_local = alloc_temp_local(ctx)
+  let save_buf_local = alloc_temp_local(ctx)
+  emit_global_get(buf, idx_g)
+  emit_local_set(buf, save_idx_local)
+  emit_global_get(buf, count_g)
+  emit_local_set(buf, save_count_local)
+  emit_global_get(buf, buf_g)
+  emit_local_set(buf, save_buf_local)
   // Allocate resume buffer on heap (max 64 slots = 512 bytes)
   let resume_buf_local = alloc_temp_local(ctx)
   emit_heap_alloc(ctx, buf, 512, resume_buf_local)
   // Initialize resume globals: idx=0, count=0, buf=allocated
   emit_i32_const_raw(buf, 0)
-  emit_global_set(buf, ctx.effect_resume_idx_global)
+  emit_global_set(buf, idx_g)
   emit_i32_const_raw(buf, 0)
-  emit_global_set(buf, ctx.effect_resume_count_global)
+  emit_global_set(buf, count_g)
   emit_local_get(buf, resume_buf_local)
-  emit_global_set(buf, ctx.effect_resume_buf_global)
+  emit_global_set(buf, buf_g)
   // Structure:
   // block $exit (result i64)                    ; depth 0
   //   loop $retry                               ; depth 1
@@ -250,7 +299,7 @@ fn compile_expr_handle_with_resume(
   buf.push((64).to_byte()) // void
   // Reset resume idx at start of each retry
   emit_i32_const_raw(buf, 0)
-  emit_global_set(buf, ctx.effect_resume_idx_global)
+  emit_global_set(buf, idx_g)
   // block $catch_target (result error_kind)
   buf.push((2).to_byte()) // block
   buf.push(valtype_byte(error_kind)) // result error_kind
@@ -360,18 +409,18 @@ fn compile_expr_handle_with_resume(
       adjust_loop_offsets(ctx, -1)
     }
     // Store resume value: buf[count * 8] = value
-    emit_global_get(buf, ctx.effect_resume_buf_global)
-    emit_global_get(buf, ctx.effect_resume_count_global)
+    emit_global_get(buf, buf_g)
+    emit_global_get(buf, count_g)
     emit_i32_const_raw(buf, 8)
     emit_i32_mul(buf)
     emit_i32_add(buf)
     emit_local_get(buf, resume_val_local)
     emit_i64_store(buf, 0)
     // Increment count
-    emit_global_get(buf, ctx.effect_resume_count_global)
+    emit_global_get(buf, count_g)
     emit_i32_const_raw(buf, 1)
     emit_i32_add(buf)
-    emit_global_set(buf, ctx.effect_resume_count_global)
+    emit_global_set(buf, count_g)
   }
   // br $retry (loop back — depth 0 from handler position = loop)
   buf.push((12).to_byte()) // br
@@ -383,6 +432,18 @@ fn compile_expr_handle_with_resume(
   // end block $exit
   buf.push((11).to_byte())
   adjust_loop_offsets(ctx, -4)
+  // Restore outer state for THIS effect from save_*. Result of handle is
+  // already on the stack from $exit; restoring afterwards keeps it intact.
+  // NOTE: this only fires on the success path (body→br $exit). When a perform
+  // for a *different* effect throws past us, restoration of *that* effect's
+  // globals is the responsibility of the outer handle that owns it; this
+  // handle only manages its own.
+  emit_local_get(buf, save_idx_local)
+  emit_global_set(buf, idx_g)
+  emit_local_get(buf, save_count_local)
+  emit_global_set(buf, count_g)
+  emit_local_get(buf, save_buf_local)
+  emit_global_set(buf, buf_g)
 }
 
 ///|

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -108,6 +108,24 @@ fn resolve_exported_fn_aliases(ctx : CodegenCtx) -> Unit {
 }
 
 ///|
+/// Collect distinct effect names from `ctx.effect_handled_ops` keys.
+/// "Logger::Log" / "Logger::Warn" -> "Logger" (deduped). "Bare" -> "Bare"
+/// (enum-as-effect ctor used as-is). Order is stable so global indices
+/// match between pre-compute and emit passes.
+fn collect_effect_names(ctx : CodegenCtx) -> Array[String] {
+  let seen : Map[String, Bool] = {}
+  let names : Array[String] = []
+  for key, _ in ctx.effect_handled_ops {
+    let eff_name = extract_effect_name_from_key(key)
+    if not(seen.contains(eff_name)) {
+      seen[eff_name] = true
+      names.push(eff_name)
+    }
+  }
+  names
+}
+
+///|
 fn collect_emittable_user_exports(ctx : CodegenCtx) -> Array[String] {
   let names : Array[String] = []
   for name, _ in ctx.exported_fns {
@@ -1206,11 +1224,16 @@ fn build_module(
     exported_env_global_count > 0
   // In linked mode, __heap_ptr is imported (not defined in global section)
   let heap_global_in_section = ctx.use_heap_global && not(has_linked_imports)
+  let effect_resume_global_count = if ctx.need_effect_resume {
+    collect_effect_names(ctx).length() * 3 + 1
+  } else {
+    0
+  }
   if need_globals {
     let global_sec = ByteBuf::new()
     let global_count = (if heap_global_in_section { 1 } else { 0 }) +
       (if ctx.need_stack_switching { 1 } else { 0 }) +
-      (if ctx.need_effect_resume { 4 } else { 0 }) +
+      effect_resume_global_count +
       (if ctx.coverage_enabled { 2 } else { 0 }) +
       (if need_fs_global { 1 } else { 0 }) +
       (if ctx.need_socket { 1 } else { 0 }) +
@@ -1235,21 +1258,25 @@ fn build_module(
       emit_i64_const_raw(global_sec, 0L) // initial value = 0
       global_sec.push((11).to_byte()) // end
     }
-    // Effect resume globals: idx, count, buf_ptr, perform_arg
+    // Effect resume globals: per-effect (idx, count, buf) + 1 shared perform_arg.
+    // Indices were assigned in pre-compute (collect_effect_names order). Emit
+    // 3 i32 globals per effect, then 1 i64 perform_arg global.
     if ctx.need_effect_resume {
       let base_idx = (if ctx.use_heap_global { 1 } else { 0 }) +
         (if ctx.need_stack_switching { 1 } else { 0 })
-      ctx.effect_resume_idx_global = base_idx
-      ctx.effect_resume_count_global = base_idx + 1
-      ctx.effect_resume_buf_global = base_idx + 2
-      ctx.effect_perform_arg_global = base_idx + 3
-      for i in 0..<3 {
-        let _ = i
-        global_sec.push((127).to_byte()) // i32
-        global_sec.push((1).to_byte()) // mutable
-        emit_i32_const_raw(global_sec, 0)
-        global_sec.push((11).to_byte()) // end
+      let eff_names = collect_effect_names(ctx)
+      let mut idx = base_idx
+      for eff_name in eff_names {
+        ctx.effect_resume_globals[eff_name] = (idx, idx + 1, idx + 2)
+        idx = idx + 3
+        for _i in 0..<3 {
+          global_sec.push((127).to_byte()) // i32
+          global_sec.push((1).to_byte()) // mutable
+          emit_i32_const_raw(global_sec, 0)
+          global_sec.push((11).to_byte()) // end
+        }
       }
+      ctx.effect_perform_arg_global = idx
       // perform_arg global (i64)
       global_sec.push((126).to_byte()) // i64
       global_sec.push((1).to_byte()) // mutable
@@ -1259,7 +1286,7 @@ fn build_module(
     if ctx.coverage_enabled {
       ctx.coverage_base_global_index = (if ctx.use_heap_global { 1 } else { 0 }) +
         (if ctx.need_stack_switching { 1 } else { 0 }) +
-        (if ctx.need_effect_resume { 4 } else { 0 })
+        effect_resume_global_count
       ctx.coverage_count_global_index = ctx.coverage_base_global_index + 1
       // Coverage counter base offset (immutable)
       global_sec.push((127).to_byte()) // i32
@@ -3793,14 +3820,20 @@ fn emit_module_with_coverage(
       ctx.effect_op_imports[key] = base + eidx
     }
   }
-  // Pre-compute effect resume global indices before compile loop
+  // Pre-compute effect resume global indices before compile loop.
+  // Each handled effect gets its own (idx, count, buf) triple, plus a single
+  // shared perform_arg global. Effect names are extracted from the qualified
+  // op keys recorded by scan in `effect_handled_ops` ("Eff::Op" -> "Eff").
   if ctx.need_effect_resume {
     let base = (if ctx.use_heap_global { 1 } else { 0 }) +
       (if ctx.need_stack_switching { 1 } else { 0 })
-    ctx.effect_resume_idx_global = base
-    ctx.effect_resume_count_global = base + 1
-    ctx.effect_resume_buf_global = base + 2
-    ctx.effect_perform_arg_global = base + 3
+    let eff_names = collect_effect_names(ctx)
+    let mut idx = base
+    for eff_name in eff_names {
+      ctx.effect_resume_globals[eff_name] = (idx, idx + 1, idx + 2)
+      idx = idx + 3
+    }
+    ctx.effect_perform_arg_global = idx
   }
   // Pre-compute RC helper function indices before compile loop.
   // Helpers are appended right after user functions in compiled_funcs.


### PR DESCRIPTION
…tests)

Multi-layer `handle { handle { ... } with Log { ... } } with Ask { ... }` ran into an OOB on i64.store: the inner handle re-initialized the singleton (idx, count, buf) globals every retry, clobbering the outer Ask handle's resume buffer. The outer's resume value got stored at inner_buf[0] (because buf_global pointed at inner_buf at dispatch time) and the retry loop never converged.

Two fixes here:

1. Per-effect resume globals. `effect_resume_idx_global` / `_count_global` / `_buf_global` were a single triple shared by every handle. Replace with `effect_resume_globals: Map[String, (Int, Int, Int)]` keyed by effect name (extracted from `effect_handled_ops` qualified keys via `extract_effect_name_from_key`). The module-emit and pre-compute passes both walk `collect_effect_names(ctx)` in the same order so global indices stay aligned. `Expr::Perform` and the `__perform` function-call builtin now look up globals by the effect's name, so a `perform Log(...)` inside an Ask handle reads/writes Log's triple — outer Ask's state is untouched.

2. Save/restore around the handle frame. Each handle saves the current (idx, count, buf) for ITS effect to locals on entry, allocates a fresh buffer, runs body+arm dispatch, then restores from the saved locals after `end $exit`. This covers cross-call reuse (a function with a handle called twice from main) and same-effect nesting. Restore only fires on the success path; other-effect throws that escape this frame are owned by an outer handle that manages its own globals.

3. `__perform(Ctor(args))` typed-payload fix. Reapplied from earlier work: when the inner is a ctor call and an in-scope handle handles it, resolve the qualified key by suffix-matching `effect_handled_ops` and throw the key string (mirroring `Expr::Perform`) instead of throwing the raw enum object pointer. Without this, single-layer `perform(Ask(N))` tests also infinite-looped because the catch dispatch compared an enum-object ptr to the literal "Ask::Ask" string.

Tests added in `examples/perform_handle.vibe`:
- `multi-layer different effects nested twice` — re-entering inner Log on outer Ask retry must not clobber outer.
- `save-restore across function call` — `ask_plus_one()` called multiple times exercises the save/restore on entry/exit.

examples/ now passes 722/722. moon test passes 1259/1259.