### PR TITLE
Allow shadowing of builtin Json functions with user definitions

### DIFF
--- a/src/codegen/wasm_codegen_builtin_io.mbt
+++ b/src/codegen/wasm_codegen_builtin_io.mbt
@@ -2102,26 +2102,28 @@ fn compile_builtin_io(
       emit_call(buf, import_index_fs_host_close_write(ctx))
       emit_heap_post_call_sync(ctx, buf)
     }
-    // Json host imports (vibe module, available when fs_host_imports is set)
-    "Json::parse" if ctx.fs_host_imports => {
+    // Json host imports (vibe module, available when fs_host_imports is set).
+    // Skip when the user has shadowed the builtin with a same-named definition,
+    // matching the convention used by other builtins (e.g. `Env::get`).
+    "Json::parse" if ctx.fs_host_imports && not(is_user_fn) => {
       let pos_args = extract_positional_exprs_with_arity(args, "Json::parse", 1)
       compile_expr(ctx, buf, pos_args[0])
       emit_call(buf, import_index_json_host_parse(ctx))
     }
-    "Json::stringify" if ctx.fs_host_imports => {
+    "Json::stringify" if ctx.fs_host_imports && not(is_user_fn) => {
       let pos_args = extract_positional_exprs_with_arity(
         args, "Json::stringify", 1,
       )
       compile_expr(ctx, buf, pos_args[0])
       emit_call(buf, import_index_json_host_stringify(ctx))
     }
-    "Json::get" if ctx.fs_host_imports => {
+    "Json::get" if ctx.fs_host_imports && not(is_user_fn) => {
       let pos_args = extract_positional_exprs_with_arity(args, "Json::get", 2)
       compile_expr(ctx, buf, pos_args[0])
       compile_expr(ctx, buf, pos_args[1])
       emit_call(buf, import_index_json_host_get(ctx))
     }
-    "Json::string" if ctx.fs_host_imports => {
+    "Json::string" if ctx.fs_host_imports && not(is_user_fn) => {
       let pos_args = extract_positional_exprs_with_arity(
         args, "Json::string", 1,
       )


### PR DESCRIPTION
## Summary
This change allows users to shadow the builtin `Json::parse`, `Json::stringify`, `Json::get`, and `Json::string` functions with their own custom implementations, matching the convention already used by other builtins like `Env::get`.

## Key Changes
- Added `is_user_fn` condition to all four Json host import function calls in the builtin IO codegen
- Updated the guard conditions from `ctx.fs_host_imports` to `ctx.fs_host_imports && not(is_user_fn)` for:
  - `Json::parse`
  - `Json::stringify`
  - `Json::get`
  - `Json::string`
- Added clarifying comment explaining that user-defined functions with the same name will take precedence, consistent with other builtins

## Implementation Details
The change ensures that when a user defines their own function with the same name as a builtin Json function, the user's definition is used instead of the host import. This is accomplished by checking the `is_user_fn` flag before emitting the host import call, allowing the normal function resolution to handle user-defined functions first.

https://claude.ai/code/session_01LYkVXmAiAJqxAdcyvYJQfn