### PR TITLE
vibe runtime stubs: add missing effect annotations (Stdin/Stdout/Fs/Env/Async)

### DIFF
--- a/vibe/fs/fs.vibe
+++ b/vibe/fs/fs.vibe
@@ -1,21 +1,17 @@
 //# Functions
 
-// exists: (String) -> Bool with {Fs}
-export let exists = (path: String) -> Bool {
+export let exists = (path: String) -> Bool with { Fs } {
   perform Fs::Exists(path)
 }
 
-// read_file: (String) -> String with {Fs}
-export let read_file = (path: String) -> String {
+export let read_file = (path: String) -> String with { Fs } {
   perform Fs::ReadFile(path)
 }
 
-// stat_token: (String) -> Int with {Fs}
-export let stat_token = (path: String) -> Int {
+export let stat_token = (path: String) -> Int with { Fs } {
   Fs::stat_token(path)
 }
 
-// write_file: (String, String) -> Unit with {Fs}
-export let write_file = (path: String, content: String) -> Unit {
+export let write_file = (path: String, content: String) -> Unit with { Fs } {
   perform Fs::WriteFile(path, content)
 }

--- a/vibe/io/example_io.vibe
+++ b/vibe/io/example_io.vibe
@@ -6,7 +6,7 @@ import ./io.vibe {
 
 //# Functions
 
-let greet = (name: String) -> Unit {
+let greet = (name: String) -> Unit with { Stdout } {
   {
     print("Hello, ")
     println(name)
@@ -20,7 +20,7 @@ let echo_line = () -> Unit with { Stdin, Stdout } {
   }
 }
 
-let write_abc = () -> Unit {
+let write_abc = () -> Unit with { Stdout } {
   {
     write_char(65)
     write_char(66)

--- a/vibe/io/io.vibe
+++ b/vibe/io/io.vibe
@@ -1,30 +1,25 @@
 //# Functions
 
-// read: (Int) -> String with {Stdin}
-export let read = (max_bytes: Int) -> String {
+export let read = (max_bytes: Int) -> String with { Stdin } {
   perform Stdin::ReadStream(max_bytes)
 }
 
-// print: (String) -> Unit with {Stdout}
-export let print = (s: String) -> Unit {
+export let print = (s: String) -> Unit with { Stdout } {
   perform Stdout::WriteStream(s)
 }
 
-// println: (String) -> Unit with {Stdout}
-export let println = (s: String) -> Unit {
+export let println = (s: String) -> Unit with { Stdout } {
   {
     perform Stdout::WriteStream(s)
     perform Stdout::WriteChar(10)
   }
 }
 
-// read_char: () -> Int with {Stdin}
-export let read_char = () -> Int {
+export let read_char = () -> Int with { Stdin } {
   Stdin::read_char()
 }
 
-// read_line: () -> String with {Stdin}
-export let read_line = () -> String {
+export let read_line = () -> String with { Stdin } {
   {
     let mut acc = ""
     let mut done = false
@@ -40,7 +35,6 @@ export let read_line = () -> String {
   }
 }
 
-// write_char: (Int) -> Unit with {Stdout}
-export let write_char = (code: Int) -> Unit {
+export let write_char = (code: Int) -> Unit with { Stdout } {
   perform Stdout::WriteChar(code)
 }

--- a/vibe/io/io_test.vibe
+++ b/vibe/io/io_test.vibe
@@ -7,7 +7,7 @@ import ./io.vibe {
 //# Misc
 
 test "println and print run with Stdout effect" {
-  let run = () -> Unit {
+  let run = () -> Unit with { Stdout } {
     {
       print("hello")
       println(" world")
@@ -18,7 +18,7 @@ test "println and print run with Stdout effect" {
 }
 
 test "write_char runs with Stdout effect" {
-  let run = () -> Unit {
+  let run = () -> Unit with { Stdout } {
     write_char(65)
   }
   run()

--- a/vibe/path/runtime.vibe
+++ b/vibe/path/runtime.vibe
@@ -6,12 +6,12 @@ import ./ref.vibe {
 
 //# Functions
 
-export let resolve = (path: DynamicPath) -> PathRef {
+export let resolve = (path: DynamicPath) -> PathRef with { Env } {
   PathRef::{
     raw: Path::to_string(Path::resolve(path.raw))
   }
 }
 
-export let DynamicPath::resolve = (path: DynamicPath) -> PathRef {
+export let DynamicPath::resolve = (path: DynamicPath) -> PathRef with { Env } {
   resolve(path)
 }

--- a/vibe/prelude/io.vibe
+++ b/vibe/prelude/io.vibe
@@ -1,28 +1,28 @@
 //# Functions
 
-export let stdin_read = (max_bytes: Int) -> String {
+export let stdin_read = (max_bytes: Int) -> String with { Stdin } {
   perform Stdin::ReadStream(max_bytes)
 }
 
-export let ansi_escape = (suffix: String) -> Unit {
+export let ansi_escape = (suffix: String) -> Unit with { Stdout } {
   {
     perform Stdout::WriteChar(27)
     perform Stdout::WriteStream(suffix)
   }
 }
 
-export let stdout_write = (s: String) -> Unit {
+export let stdout_write = (s: String) -> Unit with { Stdout } {
   perform Stdout::WriteStream(s)
 }
 
-export let stdout_writeln = (s: String) -> Unit {
+export let stdout_writeln = (s: String) -> Unit with { Stdout } {
   {
     stdout_write(s)
     perform Stdout::WriteChar(10)
   }
 }
 
-export let stdin_read_line = () -> String {
+export let stdin_read_line = () -> String with { Stdin } {
   {
     let mut acc = ""
     let mut done = false
@@ -38,18 +38,18 @@ export let stdin_read_line = () -> String {
   }
 }
 
-export let tui_cursor_home = () -> Unit {
+export let tui_cursor_home = () -> Unit with { Stdout } {
   ansi_escape("[H")
 }
 
-export let tui_clear_screen = () -> Unit {
+export let tui_clear_screen = () -> Unit with { Stdout } {
   ansi_escape("[2J")
 }
 
-export let tui_enter_alt_screen = () -> Unit {
+export let tui_enter_alt_screen = () -> Unit with { Stdout } {
   ansi_escape("[?1049h")
 }
 
-export let tui_leave_alt_screen = () -> Unit {
+export let tui_leave_alt_screen = () -> Unit with { Stdout } {
   ansi_escape("[?1049l")
 }

--- a/vibe/prelude/io_test.vibe
+++ b/vibe/prelude/io_test.vibe
@@ -15,7 +15,7 @@ test "stdin_read_line eof is empty by default" {
 }
 
 test "stdout helpers run" {
-  let run_stdout = (s: String) -> Unit {
+  let run_stdout = (s: String) -> Unit with { Stdout } {
     {
       stdout_write(s)
       stdout_writeln(s)
@@ -37,7 +37,7 @@ test "stream helpers run" {
 }
 
 test "ansi escape helper runs" {
-  let run_ansi = (suffix: String) -> Unit {
+  let run_ansi = (suffix: String) -> Unit with { Stdout } {
     ansi_escape(suffix)
   }
   run_ansi("")
@@ -45,7 +45,7 @@ test "ansi escape helper runs" {
 }
 
 test "tui preset helpers run" {
-  let run_tui = () -> Unit {
+  let run_tui = () -> Unit with { Stdout } {
     {
       tui_enter_alt_screen()
       tui_clear_screen()

--- a/vibe/time/time.vibe
+++ b/vibe/time/time.vibe
@@ -1,7 +1,6 @@
 //# Functions
 
-// sleep_ms: (Int) -> Unit with {Async}
-export let sleep_ms = (ms: Int) -> Unit {
+export let sleep_ms = (ms: Int) -> Unit with { Async } {
   sleep(ms)
 }
 


### PR DESCRIPTION
## Summary

`vibe/io`, `vibe/prelude/io`, `vibe/fs`, `vibe/path/runtime`, and `vibe/time` wrap effectful builtins (`Stdin::read_char`, `Fs::*`, `Path::resolve`, `sleep`) but their wrapper lambdas were missing the matching `with { ... }` row, so the checker rejected each module with "effect requirements not satisfied" and every downstream test failed at compile time.

This PR adds the correct effect rows (`with { Stdin }` / `Stdout` / `Fs` / `Env` / `Async`) and updates the matching `_test.vibe` lambdas so the test bodies type-check.

The host-side WASI plumbing for these modules is still out of scope (per #324), so the wrapped tests continue to trap at runtime — but the upstream type-error cascade is cleared.

## Test plan

- [x] `vibe test examples` → 722/722 passing
- [x] `vibe test` over the full package suite: was failed=87 → failed=79; `vibe/path/*` tests now cleanly `skipped` (compile-unsupported) instead of compile-failing, `vibe/prelude/io_test` 0/6 → 1/6 (one pure test now runs).
- [x] `moon check --target js --deny-warn` clean

https://claude.ai/code/session_01GEaoKfFRwYm8YJco9NjG82

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEaoKfFRwYm8YJco9NjG82)_