### PR TITLE
codegen + host runner: Array view writethrough, fs_readdir, string lex compare (#325, +22 tests)

### DIFF
--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -286,6 +286,33 @@ function encodeTaggedString(instance, jsStr) {
   return BigInt(ptr) | TAG_OBJ;
 }
 
+// Allocate an Array[String] in WASM linear memory matching codegen layout:
+//   base+0  capacity (i32)
+//   base+4  type tag (i32 = OBJ_ARRAY = 5)
+//   base+8  length (i32)
+//   base+12 elements (each i32 = tagged String pointer)
+// Returned tagged i64 = (base+4) | TAG_OBJ.
+function encodeTaggedStringArray(instance, jsStrings) {
+  const stringPtrs = jsStrings.map((s) => {
+    const tagged = encodeTaggedString(instance, s);
+    // Element slots are 4 bytes; tagged String fits in 32 bits since the
+    // pointer is below 4GiB.
+    return Number(tagged & 0xffffffffn);
+  });
+  const len = stringPtrs.length;
+  const totalSize = 4 + 8 + len * 4; // cap + header + elements
+  const alignedSize = (totalSize + 7) & ~7;
+  const base = allocHostBuffer(instance, alignedSize, 8);
+  const mem = new Uint8Array(instance.exports.memory.buffer);
+  writeU32LE(mem, base, len); // capacity = len
+  writeU32LE(mem, base + 4, OBJ_ARRAY);
+  writeU32LE(mem, base + 8, len);
+  for (let i = 0; i < len; i += 1) {
+    writeU32LE(mem, base + 12 + i * 4, stringPtrs[i]);
+  }
+  return BigInt(base + 4) | TAG_OBJ;
+}
+
 function encodeSelfhostString(instance, jsStr) {
   const encoded = new TextEncoder().encode(jsStr);
   const alignedSize = (encoded.length + 7) & ~7;
@@ -964,19 +991,9 @@ async function main() {
         const dirPath = decodeStringArg(instanceRef, pathTagged);
         try {
           const entries = fs.readdirSync(dirPath);
-          // Return as newline-separated string with type info
-          const lines = entries.map((name) => {
-            const fullPath = path.join(dirPath, name);
-            try {
-              const stat = fs.statSync(fullPath);
-              return (stat.isDirectory() ? "d " : "- ") + name;
-            } catch {
-              return "? " + name;
-            }
-          });
-          return encodeTaggedString(instanceRef, lines.join("\n"));
+          return encodeTaggedStringArray(instanceRef, entries);
         } catch (e) {
-          return encodeTaggedString(instanceRef, "");
+          return encodeTaggedStringArray(instanceRef, []);
         }
       },
       fs_getcwd() {
@@ -1544,7 +1561,12 @@ main().catch((err) => {
       }
     } catch (_) {}
   }
-  usage();
+  // usage() is only relevant for argument-parsing errors. Runtime errors
+  // (wasm traps, exceptions, etc.) drop straight to the stack trace so the
+  // failing test output points at the real cause.
+  if (instanceRefGlobal === null) {
+    usage();
+  }
   console.error(err && err.stack ? err.stack : String(err));
   process.exit(1);
 });

--- a/src/codegen/wasm_codegen_builtin_collection.mbt
+++ b/src/codegen/wasm_codegen_builtin_collection.mbt
@@ -2465,6 +2465,8 @@ fn compile_builtin_collection(
     }
     "Array::set" => {
       // array_set(arr, idx, value) -> arr[idx] = value
+      // Supports both obj_array (length at offset 4) and obj_array_view
+      // (writes through to source[start+idx]).
       let pos_args = extract_positional_exprs_with_arity(args, "Array::set", 3)
       let ptr_local = alloc_temp_local(ctx)
       let idx_local = alloc_temp_local(ctx)
@@ -2479,6 +2481,42 @@ fn compile_builtin_collection(
       compile_expr_i32(ctx, buf, pos_args[2])
       emit_i32_wrap_i64(buf)
       emit_local_set(buf, val_local)
+      // Dispatch on obj_array_view vs obj_array
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 0) // obj_type
+      emit_i32_const_raw(buf, obj_array_view)
+      emit_i32_eq(buf)
+      buf.push((4).to_byte()) // if (array_view)
+      buf.push((64).to_byte()) // void
+      // ArrayView: bounds check using length = end - start
+      emit_local_get(buf, idx_local)
+      emit_i32_const_raw(buf, 0)
+      emit_i32_lt_s(buf)
+      emit_local_get(buf, idx_local)
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 12) // end
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 8) // start
+      emit_i32_sub(buf) // end - start
+      emit_i32_ge_s(buf)
+      emit_i32_or(buf)
+      buf.push((4).to_byte()) // if (OOB)
+      buf.push((64).to_byte()) // void
+      buf.push((0).to_byte()) // unreachable
+      buf.push((11).to_byte()) // end if
+      // Compute addr = source_ptr + (start + idx) * 4 + 8
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 4) // source_ptr
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 8) // start
+      emit_local_get(buf, idx_local)
+      emit_i32_add(buf) // start + idx
+      emit_i32_const_raw(buf, 4)
+      emit_i32_mul(buf)
+      emit_i32_add(buf) // source_ptr + (start + idx) * 4
+      emit_local_get(buf, val_local)
+      emit_i32_store(buf, 8) // store with +8 offset
+      buf.push((5).to_byte()) // else (regular array)
       // bounds check: trap if idx < 0 || idx >= length
       emit_local_get(buf, idx_local)
       emit_i32_const_raw(buf, 0)
@@ -2500,6 +2538,7 @@ fn compile_builtin_collection(
       emit_i32_add(buf)
       emit_local_get(buf, val_local)
       emit_i32_store(buf, 8)
+      buf.push((11).to_byte()) // end if
       emit_i64_const_tagged(buf, 0L) // return Unit
     }
     "FixedArray::make" => {
@@ -3043,7 +3082,44 @@ fn compile_builtin_collection(
       emit_i64_shr_u(buf) // untag byte value
       emit_i32_wrap_i64(buf)
       emit_i32_store8(buf, 0)
-      buf.push((5).to_byte()) // else (array)
+      buf.push((5).to_byte()) // else (array or array_view)
+      // Dispatch on obj_array_view vs obj_array
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 0) // obj_type
+      emit_i32_const_raw(buf, obj_array_view)
+      emit_i32_eq(buf)
+      buf.push((4).to_byte()) // if (array_view)
+      buf.push((64).to_byte()) // void
+      // ArrayView: bounds check using length = end - start
+      emit_local_get(buf, idx_local)
+      emit_i32_const_raw(buf, 0)
+      emit_i32_lt_s(buf)
+      emit_local_get(buf, idx_local)
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 12) // end
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 8) // start
+      emit_i32_sub(buf) // end - start
+      emit_i32_ge_s(buf)
+      emit_i32_or(buf)
+      buf.push((4).to_byte()) // if (OOB)
+      buf.push((64).to_byte()) // void
+      buf.push((0).to_byte()) // unreachable
+      buf.push((11).to_byte()) // end if
+      // Compute addr = source_ptr + (start + idx) * 4 + 8
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 4) // source_ptr
+      emit_local_get(buf, ptr_local)
+      emit_i32_load(buf, 8) // start
+      emit_local_get(buf, idx_local)
+      emit_i32_add(buf) // start + idx
+      emit_i32_const_raw(buf, 4)
+      emit_i32_mul(buf)
+      emit_i32_add(buf)
+      emit_local_get(buf, value_local)
+      emit_i32_wrap_i64(buf)
+      emit_i32_store(buf, 8) // store with +8 offset
+      buf.push((5).to_byte()) // else (regular array)
       // bounds check: trap if idx < 0 || idx >= length
       emit_local_get(buf, idx_local)
       emit_i32_const_raw(buf, 0)
@@ -3066,7 +3142,8 @@ fn compile_builtin_collection(
       emit_local_get(buf, value_local)
       emit_i32_wrap_i64(buf)
       emit_i32_store(buf, 8)
-      buf.push((11).to_byte()) // end if
+      buf.push((11).to_byte()) // end if (view vs array)
+      buf.push((11).to_byte()) // end if (bytes vs non-bytes)
       emit_local_get(buf, value_local)
     }
     "Map::get" => {

--- a/src/codegen/wasm_codegen_builtin_numeric.mbt
+++ b/src/codegen/wasm_codegen_builtin_numeric.mbt
@@ -75,24 +75,14 @@ fn compile_builtin_numeric(
       compile_binary_cmp_op(
         ctx, buf, "eq", args, emit_i64_eq, emit_f32_eq, emit_f64_eq,
       )
-    "lt" if not(is_user_fn) => {
-      let pos_args = extract_positional_exprs_with_arity(args, "lt", 2)
-      let resolved_kind = resolve_numeric_kind(ctx, pos_args[0], pos_args[1])
-      match resolved_kind {
-        ValueKind::I32 | ValueKind::I64 =>
-          compile_i32_cmp_tagged(
-            ctx,
-            buf,
-            pos_args[0],
-            pos_args[1],
-            emit_i64_lt_s,
-          )
-        _ =>
-          compile_binary_cmp_op(
-            ctx, buf, "lt", args, emit_i64_lt_s, emit_f32_lt, emit_f64_lt,
-          )
-      }
-    }
+    "lt" if not(is_user_fn) =>
+      // Route through compile_binary_cmp_op so the runtime obj_string
+      // branch handles lexicographic comparison; for tagged ints the
+      // fallback there is a plain i64 lt_s on the tagged values, which
+      // preserves order since (a<<2) < (b<<2) iff a < b.
+      compile_binary_cmp_op(
+        ctx, buf, "lt", args, emit_i64_lt_s, emit_f32_lt, emit_f64_lt,
+      )
     "assert" | "assert_true" | "__assert" if not(is_user_fn) => {
       let builtin_name = name
       let pos_args = extract_positional_exprs_with_arity(args, builtin_name, 1)
@@ -244,24 +234,13 @@ fn compile_builtin_numeric(
       compile_binary_cmp_op(
         ctx, buf, "__eq", args, emit_i64_eq, emit_f32_eq, emit_f64_eq,
       )
-    "__lt" => {
-      let pos_args = extract_positional_exprs_with_arity(args, "__lt", 2)
-      let resolved_kind = resolve_numeric_kind(ctx, pos_args[0], pos_args[1])
-      match resolved_kind {
-        ValueKind::I32 | ValueKind::I64 =>
-          compile_i32_cmp_tagged(
-            ctx,
-            buf,
-            pos_args[0],
-            pos_args[1],
-            emit_i64_lt_s,
-          )
-        _ =>
-          compile_binary_cmp_op(
-            ctx, buf, "__lt", args, emit_i64_lt_s, emit_f32_lt, emit_f64_lt,
-          )
-      }
-    }
+    "__lt" =>
+      // See `lt`: always route through compile_binary_cmp_op so strings
+      // get lex compare and tagged ints fall back to i64 lt_s (correct
+      // because tagging preserves ordering).
+      compile_binary_cmp_op(
+        ctx, buf, "__lt", args, emit_i64_lt_s, emit_f32_lt, emit_f64_lt,
+      )
     "i32_eqz" if not(is_user_fn) => {
       let pos_args = extract_positional_exprs_with_arity(args, "i32_eqz", 1)
       compile_expr_i32(ctx, buf, pos_args[0])

--- a/src/codegen/wasm_codegen_call.mbt
+++ b/src/codegen/wasm_codegen_call.mbt
@@ -372,6 +372,90 @@ fn compile_binary_arith_op(
 }
 
 ///|
+/// Lexicographic byte-wise compare of two `obj_string` values, then test the
+/// resulting signed difference against 0 with the operator selected by `name`.
+/// Leaves an i32 boolean (1 or 0) on the stack.
+fn emit_string_lex_cmp_to_bool(
+  buf : ByteBuf,
+  name : String,
+  left_ptr_local : Int,
+  right_ptr_local : Int,
+  left_len_local : Int,
+  right_len_local : Int,
+  loop_i_local : Int,
+  diff_local : Int,
+) -> Unit {
+  // Load lengths from each obj_string header (offset 4).
+  emit_local_get(buf, left_ptr_local)
+  emit_i32_load(buf, 4)
+  emit_local_set(buf, left_len_local)
+  emit_local_get(buf, right_ptr_local)
+  emit_i32_load(buf, 4)
+  emit_local_set(buf, right_len_local)
+  // diff_local accumulates the eventual signed lex difference; default to
+  // length difference so an empty common prefix decides on length alone.
+  emit_local_get(buf, left_len_local)
+  emit_local_get(buf, right_len_local)
+  emit_i32_sub(buf)
+  emit_local_set(buf, diff_local)
+  // Iterate min(left_len, right_len) bytes, breaking on the first mismatch.
+  emit_i32_const_raw(buf, 0)
+  emit_local_set(buf, loop_i_local)
+  emit_block(buf)
+  emit_loop(buf)
+  // if loop_i >= left_len: break
+  emit_local_get(buf, loop_i_local)
+  emit_local_get(buf, left_len_local)
+  emit_i32_ge_s(buf)
+  emit_br_if(buf, 1)
+  // if loop_i >= right_len: break
+  emit_local_get(buf, loop_i_local)
+  emit_local_get(buf, right_len_local)
+  emit_i32_ge_s(buf)
+  emit_br_if(buf, 1)
+  // byte_diff = left[loop_i] - right[loop_i]; both unsigned 0..255.
+  emit_local_get(buf, left_ptr_local)
+  emit_local_get(buf, loop_i_local)
+  emit_i32_add(buf)
+  emit_i32_load8_u(buf, 8)
+  emit_local_get(buf, right_ptr_local)
+  emit_local_get(buf, loop_i_local)
+  emit_i32_add(buf)
+  emit_i32_load8_u(buf, 8)
+  emit_i32_sub(buf)
+  emit_local_tee(buf, diff_local)
+  emit_i32_eqz(buf)
+  emit_i32_eqz(buf) // if byte_diff != 0
+  buf.push((4).to_byte())
+  buf.push((64).to_byte())
+  emit_br(buf, 2) // break out of loop+block; diff_local already set
+  buf.push((11).to_byte())
+  // loop_i++
+  emit_local_get(buf, loop_i_local)
+  emit_i32_const_raw(buf, 1)
+  emit_i32_add(buf)
+  emit_local_set(buf, loop_i_local)
+  emit_br(buf, 0)
+  emit_end(buf) // end loop
+  emit_end(buf) // end block
+  // Compare diff against 0 with the requested op.
+  emit_local_get(buf, diff_local)
+  emit_i32_const_raw(buf, 0)
+  if name == "lt" || name == "__lt" {
+    emit_i32_lt_s(buf)
+  } else if name == "le" || name == "__le" {
+    emit_i32_le_s(buf)
+  } else if name == "gt" || name == "__gt" {
+    emit_i32_gt_s(buf)
+  } else if name == "ge" || name == "__ge" {
+    emit_i32_ge_s(buf)
+  } else {
+    // Fallback for unexpected names: treat as equality.
+    emit_i32_eq(buf)
+  }
+}
+
+///|
 fn compile_binary_cmp_op(
   ctx : CodegenCtx,
   buf : ByteBuf,
@@ -862,12 +946,38 @@ fn compile_binary_cmp_op(
         emit_f64_load(buf, 4)
         emit_f64(buf)
         buf.push((5).to_byte()) // else
+        // Both strings: byte-wise lexicographic order. Compute a signed
+        // i32 lex difference, then compare against 0 with the requested
+        // op. Without this branch, `__lt`/`__le`/`__gt`/`__ge` on strings
+        // fall through to a tagged-i64 pointer comparison and return
+        // arbitrary results.
+        emit_local_get(buf, left_type_local)
+        emit_i32_const_raw(buf, obj_string)
+        emit_i32_eq(buf)
+        emit_local_get(buf, right_type_local)
+        emit_i32_const_raw(buf, obj_string)
+        emit_i32_eq(buf)
+        emit_i32_and(buf)
+        buf.push((4).to_byte()) // if both strings
+        buf.push((127).to_byte()) // result i32
+        emit_string_lex_cmp_to_bool(
+          buf,
+          name,
+          left_ptr_local,
+          right_ptr_local,
+          left_len_local,
+          right_len_local,
+          loop_i_local,
+          eq_local,
+        )
+        buf.push((5).to_byte()) // else (not both strings)
         // Compare tagged i64 values directly
         emit_local_get(buf, left_local)
         emit_local_get(buf, right_local)
         emit_i64_cmp(buf)
-        buf.push((11).to_byte()) // end if
-        buf.push((11).to_byte()) // end if
+        buf.push((11).to_byte()) // end if (string)
+        buf.push((11).to_byte()) // end if (double)
+        buf.push((11).to_byte()) // end if (float)
       }
       buf.push((5).to_byte()) // else
       // Compare tagged i64 values directly


### PR DESCRIPTION
## Summary

Closes the remaining `vibe/shell/*` failures from #325. Package suite goes from **1433/1455 → 1455/1455 (100%)**, +22 tests.

## Bugs fixed

### 1. `Array::set` / `__set_index` ignored `obj_array_view`
`__slice` allocates a zero-copy view (`obj_array_view`), but the set paths only knew the regular `obj_array` layout. Writes to a sliced array trampled the view's `start`/`end` fields and the next 4 bytes past the 16-byte view object, producing OOB traps later.

Fix: dispatch on `obj_type == obj_array_view` first; in the view case, write through to `source[start + idx]`. The regular array path is unchanged.

### 2. `fs_readdir` host import returned a tagged String
`Fs::ReadDir(String) -> Array[String]` per `typecheck_env.mbt`, but the JS host returned a newline-joined String. Consumers calling `Array::length(perform Fs::ReadDir(...))` walked a String header as if it were an Array header and trapped on OOB memory access.

Fix: added `encodeTaggedStringArray` and made `fs_readdir` build an actual `obj_array` of tagged String pointers, matching the codegen layout (`base+0` cap, `base+4` tag, `base+8` len, `base+12` elements; returned tagged ptr = `(base+4) | TAG_OBJ`).

### 3. `__lt` / `lt` on strings did pointer comparison
The `__lt` handler short-circuited tagged-i64 operands (which include strings) to `compile_i32_cmp_tagged`, bypassing `compile_binary_cmp_op`'s runtime obj_string dispatch. So `__lt("c", "a")` returned whatever `i64.lt_s` produced on heap addresses.

Fix: `__lt`/`lt` always go through `compile_binary_cmp_op`. For tagged ints the fallback there is still a single `i64.lt_s` on tagged values, correct because `(a<<2) < (b<<2) iff a < b`. Added a new `obj_string` branch with `emit_string_lex_cmp_to_bool` — byte-wise lex compare to a signed difference, then test against 0 with the operator selected by `name` (lt/le/gt/ge).

### 4. Host runner masked runtime errors with `usage()`
`main.catch` always prepended the argv usage string before the stack trace. For wasm traps and exceptions this is misleading — those have nothing to do with command-line parsing — and it was the leading line in every test failure detail. Now `usage()` only fires when no module instance was created (i.e. arg parsing actually failed).

## Test results

```
package suite (vibe test examples vibe/...): 1433/1455 → 1455/1455 (100%)
moon test codegen + checker: 199/199
```

## Test plan
- [x] `vibe test` over the full package suite
- [x] `moon test -p mizchi/vibe/codegen -p mizchi/vibe/checker`
- [x] Manual repro of each of the four bugs

https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e)_