### PR TITLE
codegen: route 4 inline allocators through heap_local (#356, +13 tests)

### DIFF
--- a/src/codegen/wasm_codegen_builtin_collection.mbt
+++ b/src/codegen/wasm_codegen_builtin_collection.mbt
@@ -2568,12 +2568,13 @@ fn compile_builtin_collection(
       emit_i32_and(buf)
       let alloc_size_local = alloc_temp_local(ctx)
       emit_local_set(buf, alloc_size_local)
-      emit_global_get(buf, ctx.heap_global)
-      emit_local_tee(buf, obj_local)
-      emit_local_get(buf, alloc_size_local)
-      emit_i32_add(buf)
-      emit_global_set(buf, ctx.heap_global)
-      ctx.heap_synced = false
+      // Use the standard heap_local-based allocator. Bumping heap_global
+      // directly here desynchronizes ctx.heap_local — subsequent
+      // emit_heap_alloc / emit_heap_reserve calls then read a stale
+      // heap_local and allocate on top of the FixedArray. (Reproduced
+      // via `Array::push` to a literal `[]` allocated after
+      // `FixedArray::make`.)
+      emit_heap_alloc_local(ctx, buf, alloc_size_local, obj_local)
       emit_local_get(buf, obj_local)
       emit_i32_const_raw(buf, obj_array)
       emit_i32_store(buf, 0)

--- a/src/codegen/wasm_codegen_builtin_io.mbt
+++ b/src/codegen/wasm_codegen_builtin_io.mbt
@@ -862,12 +862,9 @@ fn compile_builtin_io(
       emit_i32_and(buf)
       let alloc_size_local = alloc_temp_local(ctx)
       emit_local_set(buf, alloc_size_local)
-      emit_global_get(buf, ctx.heap_global)
-      emit_local_tee(buf, obj_local)
-      emit_local_get(buf, alloc_size_local)
-      emit_i32_add(buf)
-      emit_global_set(buf, ctx.heap_global)
-      ctx.heap_synced = false
+      // Use heap_local; bumping heap_global directly desynchronizes
+      // ctx.heap_local and overlaps subsequent allocations.
+      emit_heap_alloc_local(ctx, buf, alloc_size_local, obj_local)
       // header: obj_string, len
       emit_local_get(buf, obj_local)
       emit_i32_const_raw(buf, obj_string)
@@ -1329,12 +1326,9 @@ fn compile_builtin_io(
       emit_i32_and(buf)
       let alloc_size_local = alloc_temp_local(ctx)
       emit_local_set(buf, alloc_size_local)
-      emit_global_get(buf, ctx.heap_global)
-      emit_local_tee(buf, dst_local)
-      emit_local_get(buf, alloc_size_local)
-      emit_i32_add(buf)
-      emit_global_set(buf, ctx.heap_global)
-      ctx.heap_synced = false
+      // See `Bytes::to_string` above — bumping heap_global directly
+      // leaves ctx.heap_local stale.
+      emit_heap_alloc_local(ctx, buf, alloc_size_local, dst_local)
       // header: obj_array (target Array), len
       emit_local_get(buf, dst_local)
       emit_i32_const_raw(buf, obj_array)

--- a/src/codegen/wasm_codegen_builtin_string.mbt
+++ b/src/codegen/wasm_codegen_builtin_string.mbt
@@ -2712,9 +2712,8 @@ fn compile_builtin_string(
       emit_i32_add(buf) // str_ptr = ptr + 8 (inline data start)
       emit_local_set(buf, str_ptr) // reuse as data ptr
       // Allocate array: header(8) + len*4
-      emit_global_get(buf, ctx.heap_global)
-      emit_local_set(buf, obj_local)
-      emit_local_get(buf, obj_local)
+      // Compute alloc_size = align4(8 + str_len*4)
+      let alloc_size_local = alloc_temp_local(ctx)
       emit_local_get(buf, str_len)
       emit_i32_const_raw(buf, 4)
       emit_i32_mul(buf)
@@ -2722,9 +2721,11 @@ fn compile_builtin_string(
       emit_i32_add(buf)
       emit_i32_const_raw(buf, -4)
       emit_i32_and(buf)
-      emit_i32_add(buf)
-      emit_global_set(buf, ctx.heap_global)
-      ctx.heap_synced = false
+      emit_local_set(buf, alloc_size_local)
+      // Use heap_local-based allocator; bumping heap_global directly
+      // here leaves ctx.heap_local stale and corrupts subsequent
+      // allocations sharing the same memory range.
+      emit_heap_alloc_local(ctx, buf, alloc_size_local, obj_local)
       // Set header
       emit_local_get(buf, obj_local)
       emit_i32_const_raw(buf, obj_array)


### PR DESCRIPTION
## Summary

Fixes a long-standing heap_local desynchronization bug in 4 builtins. The bug caused subsequent allocations to overlap with FixedArray/Bytes objects, corrupting them silently. Heavy wasm tests improve from **112/129 → 125/129 (+13)** with no regression on the package suite.

## Root cause

Four builtins (`FixedArray::make`, `Bytes::to_string`, the Bytes-to-Array conversion in `builtin_io`, and the per-byte string-to-Array path in `builtin_string`) bumped `heap_global` directly:

```moonbit
emit_global_get(buf, ctx.heap_global)
emit_local_tee(buf, obj_local)
emit_local_get(buf, alloc_size_local)
emit_i32_add(buf)
emit_global_set(buf, ctx.heap_global)
ctx.heap_synced = false
```

This left `ctx.heap_local` stale. When a subsequent allocation went through the standard `emit_heap_alloc` / `emit_heap_reserve` path (which reads `heap_local` directly without checking `heap_synced`), it allocated on top of the just-allocated object — silently corrupting it.

## Concrete repro

```vibe
test "fa get eq if push" {
  let fa = FixedArray::make(2, 0)
  FixedArray::set(fa, 0, 1)
  let xs : Array[Int] = []
  if FixedArray::get(fa, 0) == 1 {
    Array::push(xs, 42)
  }
  assert(Array::length(xs) == 1)  // failed: length was 0
}
```

The literal `[]` and the FixedArray shared the same heap address (local 1 in the wat — the cached heap_local that was set before `FixedArray::make`). After the push, the FixedArray's data slot overwrote `xs[0]`, but `xs.len` (also overlapping) was rewritten to a different value, so subsequent `Array::length` reported the wrong count and the if-branch's effect was effectively erased.

## Fix

Replace each of the four inline allocator-bump patterns with `emit_heap_alloc_local`, which uses `ctx.heap_local` consistently and calls `emit_heap_reserve` to grow memory if needed.

## Test results

| Test set | Before | After |
|---|---|---|
| package suite (`vibe test examples vibe/...`) | 1455/1455 | 1455/1455 ✓ |
| heavy wasm (`just test-wasm-heavy`) | 112/129 | **125/129 (+13)** |
| `moon test` codegen + checker | 199/199 | 199/199 ✓ |

The 13 new passes are wasm_opt's const-fold / identity / dce / coalesce / dead-drop tests, all of which depend on `optimize_code_section` producing a smaller binary via `Array::slice([X], 0, 0)` + `Array::push` — previously broken because each Array literal allocated on top of the slice's underlying buffer.

The 4 remaining heavy-wasm failures (`wasm_runtime` disassemble tests) involve a different bug and are tracked separately under #356 (string interpolation with `int_to_string` corrupting the `name` string in disassemble — root cause TBD).

## Test plan
- [x] Package suite: 1455/1455
- [x] Heavy wasm: +13 (125/129)
- [x] `moon test` codegen + checker: 199/199
- [x] Targeted repro of the heap-overlap pattern (works after fix)

https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e)_