### PR TITLE
tests: expand normalize / DCE / loader unit coverage (#298 follow-up)

### DIFF
--- a/src/core/normalize_export_wbtest.mbt
+++ b/src/core/normalize_export_wbtest.mbt
@@ -308,3 +308,266 @@ test "normalize_with_imports returns only the main module when resolver always f
   assert_eq(bundle.modules.length(), 1)
   assert_true(bundle.modules.contains(bundle.main_hash))
 }
+
+///|
+test "normalize_module renames LetMut binding" {
+  // `let mut x = 1; x` → `let mut $0 = 1; $0`
+  let mod_ast = Module::{
+    stmts: [
+      Stmt::LetMut(
+        name="x",
+        expr=int_expr_for_export_norm_test(1),
+        span=zero_span_for_export_norm_test,
+      ),
+      Stmt::Expr(
+        expr=Expr::Ident(name="x", span=zero_span_for_export_norm_test),
+        span=zero_span_for_export_norm_test,
+      ),
+    ],
+  }
+  let normalized = normalize_module(mod_ast)
+  assert_eq(normalized.stmts.length(), 2)
+  assert_true(
+    match normalized.stmts[0] {
+      Stmt::LetMut(name="$0", ..) => true
+      _ => false
+    },
+  )
+  assert_true(
+    match normalized.stmts[1] {
+      Stmt::Expr(expr=Expr::Ident(name="$0", ..), ..) => true
+      _ => false
+    },
+  )
+}
+
+///|
+test "normalize_module renames LetPat tuple bindings" {
+  // `let (a, b) = (1, 2); a` → `let ($0, $1) = (1, 2); $0`
+  let pat_a = Pat::Bind(name="a", span=zero_span_for_export_norm_test)
+  let pat_b = Pat::Bind(name="b", span=zero_span_for_export_norm_test)
+  let pat = Pat::Tuple(
+    items=[pat_a, pat_b],
+    span=zero_span_for_export_norm_test,
+  )
+  let tup = Expr::Tuple(
+    items=[
+      int_expr_for_export_norm_test(1),
+      int_expr_for_export_norm_test(2),
+    ],
+    span=zero_span_for_export_norm_test,
+  )
+  let mod_ast = Module::{
+    stmts: [
+      Stmt::LetPat(pat~, expr=tup, span=zero_span_for_export_norm_test),
+      Stmt::Expr(
+        expr=Expr::Ident(name="a", span=zero_span_for_export_norm_test),
+        span=zero_span_for_export_norm_test,
+      ),
+    ],
+  }
+  let normalized = normalize_module(mod_ast)
+  assert_eq(normalized.stmts.length(), 2)
+  assert_true(
+    match normalized.stmts[0] {
+      Stmt::LetPat(
+        pat=Pat::Tuple(
+          items=[Pat::Bind(name="$0", ..), Pat::Bind(name="$1", ..)],
+          ..,
+        ),
+        ..,
+      ) => true
+      _ => false
+    },
+  )
+  assert_true(
+    match normalized.stmts[1] {
+      Stmt::Expr(expr=Expr::Ident(name="$0", ..), ..) => true
+      _ => false
+    },
+  )
+}
+
+///|
+test "normalize_module LetPatElse else_body uses child scope so pat names don't leak" {
+  // `let Some(x) = e else { 0 }; x` — `x` from pat should NOT bind in
+  // outer scope, so the trailing `x` reference stays as the global ident
+  // rather than being renamed.
+  // Actually verify: pat in the let-pat-else IS visible after the let
+  // (the else-branch is the not-matched fallback). What matters is the
+  // ELSE body running in a child scope (its own bindings don't leak).
+  let pat = Pat::Ctor(
+    name="Some",
+    args=[Pat::Bind(name="x", span=zero_span_for_export_norm_test)],
+    span=zero_span_for_export_norm_test,
+  )
+  let else_body = Module::{
+    stmts: [
+      Stmt::Let(
+        rec=false,
+        name="fallback",
+        expr=int_expr_for_export_norm_test(0),
+        span=zero_span_for_export_norm_test,
+      ),
+      Stmt::Expr(
+        expr=Expr::Ident(
+          name="fallback",
+          span=zero_span_for_export_norm_test,
+        ),
+        span=zero_span_for_export_norm_test,
+      ),
+    ],
+  }
+  let mod_ast = Module::{
+    stmts: [
+      Stmt::LetPatElse(
+        pat~,
+        expr=Expr::Ident(name="e", span=zero_span_for_export_norm_test),
+        else_body~,
+        span=zero_span_for_export_norm_test,
+      ),
+    ],
+  }
+  let normalized = normalize_module(mod_ast)
+  // Verify the else-body's `fallback` got a fresh $0 in its child scope.
+  assert_true(
+    match normalized.stmts[0] {
+      Stmt::LetPatElse(
+        pat=Pat::Ctor(
+          name="Some",
+          args=[Pat::Bind(name="$0", ..)],
+          ..,
+        ),
+        else_body~,
+        ..,
+      ) =>
+        match else_body.stmts[0] {
+          // Block-child scope inherits counter from outer. The pat's $0
+          // is in the outer scope; else-body is its own child block, so
+          // `fallback` gets the next number ($1).
+          Stmt::Let(name="$1", ..) => true
+          _ => false
+        }
+      _ => false
+    },
+  )
+}
+
+///|
+test "normalize_module Match scrutinee + arm patterns are renamed" {
+  // `let v = 1; match v { x => x }` →
+  // `let $0 = 1; match $0 { $1 => $1 }`
+  let arm = MatchArm::{
+    pat: Pat::Bind(name="x", span=zero_span_for_export_norm_test),
+    cond: None,
+    expr: Expr::Ident(name="x", span=zero_span_for_export_norm_test),
+    span: zero_span_for_export_norm_test,
+  }
+  let match_expr = Expr::Match(
+    scrutinee=Expr::Ident(name="v", span=zero_span_for_export_norm_test),
+    arms=[arm],
+    span=zero_span_for_export_norm_test,
+  )
+  let mod_ast = Module::{
+    stmts: [
+      Stmt::Let(
+        rec=false,
+        name="v",
+        expr=int_expr_for_export_norm_test(1),
+        span=zero_span_for_export_norm_test,
+      ),
+      Stmt::Expr(expr=match_expr, span=zero_span_for_export_norm_test),
+    ],
+  }
+  let normalized = normalize_module(mod_ast)
+  let ok = match normalized.stmts[1] {
+    Stmt::Expr(
+      expr=Expr::Match(scrutinee=Expr::Ident(name="$0", ..), arms~, ..),
+      ..,
+    ) =>
+      if arms.length() == 1 {
+        let arm = arms[0]
+        let pat_ok = match arm.pat {
+          Pat::Bind(name="$1", ..) => true
+          _ => false
+        }
+        let expr_ok = match arm.expr {
+          Expr::Ident(name="$1", ..) => true
+          _ => false
+        }
+        pat_ok && expr_ok
+      } else {
+        false
+      }
+    _ => false
+  }
+  assert_true(ok)
+}
+
+///|
+test "normalize_module While renames cond and body identifiers" {
+  // `let mut i = 0; while i > 0 { i = i - 1 }` →
+  // `let mut $0 = 0; while $0 > 0 { $0 = $0 - 1 }`
+  let cond = Expr::Call(
+    name=">",
+    type_args=[],
+    args=[
+      CallArg::{
+        label: None,
+        expr: Expr::Ident(name="i", span=zero_span_for_export_norm_test),
+        span: zero_span_for_export_norm_test,
+      },
+      CallArg::{
+        label: None,
+        expr: int_expr_for_export_norm_test(0),
+        span: zero_span_for_export_norm_test,
+      },
+    ],
+    span=zero_span_for_export_norm_test,
+  )
+  let body = Module::{
+    stmts: [
+      Stmt::Assign(
+        name="i",
+        expr=int_expr_for_export_norm_test(99),
+        span=zero_span_for_export_norm_test,
+      ),
+    ],
+  }
+  let mod_ast = Module::{
+    stmts: [
+      Stmt::LetMut(
+        name="i",
+        expr=int_expr_for_export_norm_test(0),
+        span=zero_span_for_export_norm_test,
+      ),
+      Stmt::Expr(
+        expr=Expr::While(cond~, body~, span=zero_span_for_export_norm_test),
+        span=zero_span_for_export_norm_test,
+      ),
+    ],
+  }
+  let normalized = normalize_module(mod_ast)
+  assert_true(
+    match normalized.stmts[1] {
+      Stmt::Expr(
+        expr=Expr::While(
+          cond=Expr::Call(name=">", args~, ..),
+          body~,
+          ..,
+        ),
+        ..,
+      ) =>
+        args.length() == 2 &&
+        (match args[0].expr {
+          Expr::Ident(name="$0", ..) => true
+          _ => false
+        }) &&
+        (match body.stmts[0] {
+          Stmt::Assign(name="$0", ..) => true
+          _ => false
+        })
+      _ => false
+    },
+  )
+}

--- a/src/frontend/dce_wbtest.mbt
+++ b/src/frontend/dce_wbtest.mbt
@@ -584,3 +584,142 @@ test "dce drops ExternLet + its TypeAlias when nothing references them" {
   assert_false(has_type_alias_stmt(filtered.stmts, "Handle"))
   assert_false(has_extern_let_stmt(filtered.stmts, "fd"))
 }
+
+///|
+test "dce keeps InternalExportLet when reachable from a regular export" {
+  // InternalExportLet is filtered by `filter_reachable_stmts` only when it
+  // appears in the reachable set. Verify the path: reachable export calls
+  // the internal-export, so the internal-export must survive DCE.
+  let mod = @core.Module::{
+    stmts: [
+      @core.Stmt::InternalExportLet(
+        rec=false,
+        name="helper_internal",
+        expr=dce_test_int(1L),
+        span=dce_test_span(),
+      ),
+      @core.Stmt::InternalExportLet(
+        rec=false,
+        name="helper_unreachable",
+        expr=dce_test_int(99L),
+        span=dce_test_span(),
+      ),
+      @core.Stmt::ExportLet(
+        rec=false,
+        name="api",
+        expr=dce_test_call("helper_internal", []),
+        span=dce_test_span(),
+      ),
+    ],
+  }
+  let filtered = dce_module(mod)
+  let names = collect_stmt_names(filtered.stmts)
+  assert_true(names.contains("api"))
+  // Reachable internal export survives.
+  let mut kept_internal = false
+  let mut kept_unreachable = false
+  for stmt in filtered.stmts {
+    match stmt {
+      @core.Stmt::InternalExportLet(name="helper_internal", ..) =>
+        kept_internal = true
+      @core.Stmt::InternalExportLet(name="helper_unreachable", ..) =>
+        kept_unreachable = true
+      _ => ()
+    }
+  }
+  assert_true(kept_internal)
+  assert_false(kept_unreachable)
+}
+
+///|
+test "dce keeps InternalExportEnumDef when its constructor is referenced" {
+  // filter_reachable_stmts has a dedicated branch for InternalExportEnumDef
+  // that preserves the enum if any constructor (qualified or unqualified)
+  // is in the reachable set. Exercise it.
+  let ctor_a = dce_test_ctor("Active")
+  let ctor_b = dce_test_ctor("Idle")
+  let mod = @core.Module::{
+    stmts: [
+      @core.Stmt::InternalExportEnumDef(
+        name="State",
+        params=[],
+        ctors=[ctor_a, ctor_b],
+        span=dce_test_span(),
+      ),
+      @core.Stmt::ExportLet(
+        rec=false,
+        name="start",
+        expr=dce_test_call("Active", []),
+        span=dce_test_span(),
+      ),
+    ],
+  }
+  let filtered = dce_module(mod)
+  // The enum stays because Active is reachable.
+  assert_true(has_enum_stmt(filtered.stmts, "State"))
+}
+
+///|
+test "dce drops InternalExportEnumDef when no constructor is reached" {
+  let ctor = dce_test_ctor("Unused")
+  let mod = @core.Module::{
+    stmts: [
+      @core.Stmt::InternalExportEnumDef(
+        name="Dead",
+        params=[],
+        ctors=[ctor],
+        span=dce_test_span(),
+      ),
+      @core.Stmt::ExportLet(
+        rec=false,
+        name="api",
+        expr=dce_test_int(0L),
+        span=dce_test_span(),
+      ),
+    ],
+  }
+  let filtered = dce_module(mod)
+  assert_false(has_enum_stmt(filtered.stmts, "Dead"))
+}
+
+///|
+test "dce_module_with_entry_names handles missing entries gracefully" {
+  // Unknown entry names must not affect the kept-set; reachable analysis
+  // proceeds as if the unknown names contribute nothing.
+  let mod = @core.Module::{
+    stmts: [
+      @core.Stmt::ExportLet(
+        rec=false,
+        name="real_export",
+        expr=dce_test_int(1L),
+        span=dce_test_span(),
+      ),
+    ],
+  }
+  let filtered = dce_module_with_entry_names(
+    mod, ["does_not_exist", "another_phantom"],
+  )
+  let names = collect_stmt_names(filtered.stmts)
+  assert_true(names.contains("real_export"))
+  // Phantom entries don't show up because they were never defined.
+  assert_false(names.contains("does_not_exist"))
+}
+
+///|
+test "dce_module_with_entry_names accepts an empty entry list" {
+  // Smoke: empty extra_entries should not panic; ExportLet roots still
+  // anchor the reachable set so the export survives.
+  let mod = @core.Module::{
+    stmts: [
+      @core.Stmt::ExportLet(
+        rec=false,
+        name="kept",
+        expr=dce_test_int(1L),
+        span=dce_test_span(),
+      ),
+    ],
+  }
+  let filtered = dce_module_with_entry_names(mod, [])
+  let names = collect_stmt_names(filtered.stmts)
+  assert_true(names.contains("kept"))
+}

--- a/src/loader/loader_wbtest.mbt
+++ b/src/loader/loader_wbtest.mbt
@@ -1,0 +1,54 @@
+///| Whitebox tests for loader/lib.mbt internal helpers.
+
+///|
+test "extract_vibe_from_markdown extracts a single vibe block" {
+  let md = "# Title\n```vibe\nlet x = 1\n```\n"
+  let extracted = extract_vibe_from_markdown(md)
+  assert_eq(extracted, "let x = 1")
+}
+
+///|
+test "extract_vibe_from_markdown joins multiple vibe blocks with blank line" {
+  let md = "```vibe\nlet a = 1\n```\n\n```vibe\nlet b = 2\n```\n"
+  let extracted = extract_vibe_from_markdown(md)
+  assert_eq(extracted, "let a = 1\n\nlet b = 2")
+}
+
+///|
+test "extract_vibe_from_markdown skips non-vibe code fences" {
+  let md = "```js\nconst hidden = 1\n```\n\n```vibe\nlet visible = 2\n```\n"
+  let extracted = extract_vibe_from_markdown(md)
+  assert_eq(extracted, "let visible = 2")
+}
+
+///|
+test "extract_vibe_from_markdown returns empty for markdown without vibe blocks" {
+  let md = "# Just prose\n\nNo code here.\n"
+  let extracted = extract_vibe_from_markdown(md)
+  assert_eq(extracted, "")
+}
+
+///|
+test "extract_vibe_from_markdown drops an unterminated vibe block" {
+  // No closing ``` — the block content is buffered but never flushed.
+  // Current behaviour: the unterminated block is silently dropped.
+  let md = "```vibe\nlet x = 1\n"
+  let extracted = extract_vibe_from_markdown(md)
+  assert_eq(extracted, "")
+}
+
+///|
+test "extract_vibe_from_markdown ignores fence opens inside a non-vibe block" {
+  // Opening another fence while in a non-vibe block doesn't switch state;
+  // only `\`\`\`` (alone, after trim) closes the block.
+  let md = "```js\nconst x = 1\n```\n\n```vibe\nlet y = 2\n```\n"
+  let extracted = extract_vibe_from_markdown(md)
+  assert_eq(extracted, "let y = 2")
+}
+
+///|
+test "extract_vibe_from_markdown preserves blank lines inside a vibe block" {
+  let md = "```vibe\nlet a = 1\n\nlet b = 2\n```\n"
+  let extracted = extract_vibe_from_markdown(md)
+  assert_eq(extracted, "let a = 1\n\nlet b = 2")
+}


### PR DESCRIPTION
## Summary

Fills gaps in TODO.md's "normalize / DCE / loader テスト拡充 — #298 で一部着手、カバー範囲を埋める" item. Adds **17 targeted unit tests**; no production code changes.

`moon test --target js`: 1259 → **1276** (+17), 0 failures.

## Coverage added

**normalize** (`src/core/normalize_export_wbtest.mbt`, +5):
- `LetMut` binding rename
- `LetPat` tuple-pattern bindings rename
- `LetPatElse` else-body uses a child block scope
- `Match` scrutinee + arm pattern + arm body all renamed in lockstep
- `While` renames identifiers in cond and body

**DCE** (`src/frontend/dce_wbtest.mbt`, +5):
- `InternalExportLet` kept when reachable from a regular export
- `InternalExportLet` dropped when unreachable
- `InternalExportEnumDef` kept via constructor reachability
- `InternalExportEnumDef` dropped when no constructor reachable
- `dce_module_with_entry_names` handles unknown / empty entry names

**loader** (`src/loader/loader_wbtest.mbt`, **new file**, +7):
- `extract_vibe_from_markdown`: single block, multi-block joining, non-vibe fence skipped, no-block input, unterminated block dropped, fence-open inside non-vibe block is inert, blank lines preserved inside a block.

## Test plan

- [x] `moon test --target js`: 1276/1276 ✅
- [ ] CI green

https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e)_