### PR TITLE
ci: add moon line-coverage gate (informational, threshold 50%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,54 @@ jobs:
             _build/coverage/selfhost-suite/selfhost_suite.report.json
           if-no-files-found: ignore
 
+  coverage-moon:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Vibe toolchain
+        uses: ./.github/actions/setup-vibe
+        with:
+          ripgrep: 'true'
+          node-version: '24'
+
+      - name: Run moon coverage with line-coverage gate
+        # Initial gate at 50%: current baseline measures ~54.3% on
+        # `--target js`, so this leaves ~4% of slack against minor
+        # regressions while still catching meaningful drops. Raise the
+        # threshold (`VIBE_MOON_COVERAGE_MIN_LINE`) as coverage improves
+        # toward the TODO.md aspirational target of 70%.
+        env:
+          VIBE_MOON_COVERAGE_TARGET: js
+          VIBE_MOON_COVERAGE_MIN_LINE: '50'
+        run: bash scripts/coverage_moon.sh
+
+      - name: Coverage summary
+        if: always()
+        run: |
+          {
+            echo "### Moon Coverage (target=js)"
+            if [ -f _build/coverage/moon/summary.txt ]; then
+              echo '```'
+              grep '^Total:' _build/coverage/moon/summary.txt || echo "(no Total line)"
+              echo '```'
+            else
+              echo "- No summary produced"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: moon-coverage-report
+          path: |
+            _build/coverage/moon/summary.txt
+            _build/coverage/moon/moonbit-cobertura.xml
+            _build/coverage/moon/html
+          if-no-files-found: ignore
+
   similarity-mbt-report:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -543,6 +591,7 @@ jobs:
     needs:
       - bundle-size-compiler
       - bundle-size-product-gate
+      - coverage-moon
       - coverage-selfhost-suite
       - native-binary-parity
       - selfhost-gates
@@ -555,6 +604,7 @@ jobs:
           echo "Informational job results (non-blocking):"
           echo "  bundle-size-compiler: ${{ needs.bundle-size-compiler.result }}"
           echo "  bundle-size-product-gate: ${{ needs.bundle-size-product-gate.result }}"
+          echo "  coverage-moon: ${{ needs.coverage-moon.result }}"
           echo "  coverage-selfhost-suite: ${{ needs.coverage-selfhost-suite.result }}"
           echo "  native-binary-parity: ${{ needs.native-binary-parity.result }}"
           echo "  selfhost-gates: ${{ needs.selfhost-gates.result }}"


### PR DESCRIPTION
## Summary

TODO.md tier-🟠 follow-up: "**CI カバレッジ gate** — branch coverage 70% target". Stand up the **measurement infrastructure** first; the 70% target is aspirational and well above current baseline.

## Baseline

Measured locally via `bash scripts/coverage_moon.sh` (target=js):

```
Total: 41910/77155 = 54.32% line coverage
```

## What this PR adds

A new `coverage-moon` job in `ci.yml`:

- **target**: `js` (faster than native; same test set, 1276 tests)
- **threshold**: `VIBE_MOON_COVERAGE_MIN_LINE=50` — trips the gate on a >4% drop from baseline but doesn't fail on routine churn
- **non-blocking**: `continue-on-error: true` + member of `ci-informational` (not `ci-required`) while we ratchet the threshold up
- **artifact**: uploads `summary.txt`, cobertura XML, and HTML report for drill-down

## Why a 50% gate, not 70%

Setting 70% on day one would fail every PR (current baseline is 54.32%). A 50% gate detects regressions immediately while staying achievable. Raise `VIBE_MOON_COVERAGE_MIN_LINE` over time as targeted test additions land — the gate is the mechanism, the 70% target stays in TODO.md as the destination.

## Notes

- The script (`scripts/coverage_moon.sh`) was already in place; this PR only wires it into CI.
- Branch coverage isn't natively reported by `moon coverage` (only line). If/when moon adds branch coverage support, the gate can switch.
- Locally: `VIBE_MOON_COVERAGE_TARGET=js bash scripts/coverage_moon.sh` reproduces the CI measurement; opens a `_build/coverage/moon/html/index.html` drill-down view.

## Test plan

- [ ] CI green on this PR (the new job runs and the threshold is met since baseline > 50%)
- [ ] `coverage-moon` artifact downloadable from the run

https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e)_