### PR TITLE
TODO: track selfhost checker parity gaps as #364, close wasm-heavy gap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 Spec-locked decisions are tracked in `docs/spec/decisions.md`.
 Completed items are archived in `docs/DONE.md`.
 
-## 次の一手 (2026-05-03 時点)
+## 次の一手 (2026-05-05 時点)
 
 優先順。各項目は該当セクションに詳細あり。
 
@@ -42,7 +42,8 @@ Completed items are archived in `docs/DONE.md`.
 
 ### 既知ギャップ（issue として追跡中）
 
-- `just test-wasm-heavy` の wasm_opt / wasm_runtime に 17 fail（13 + 4）が pre-existing（#356）。`test-vibe-package-suite` 対象外で 0.1.0 release ブロッカーではないが将来的には潰したい
+- ~~`just test-wasm-heavy` の wasm_opt / wasm_runtime に 17 fail~~（#356 → PR #357 + #358 で 129/129 ✅）
+- **selfhost checker parity 6 件（#364）** — `selfhost-bootstrap-gate`（PR #362）が surface した pre-existing failure。`vibe/compiler/checker_parity_advanced_test.vibe` で 37/43。host CLI では通る src を selfhost checker が reject (struct destructuring let / is expression / let else / trait impl / struct field type mismatch / derive unknown)。informational gate なので blocker ではないが、selfhost compiler の feature gap として要修正。
 - ~~derive(Eq) enum with payload の deep 比較~~（#341 で実装済）
 
 ## 0.2.0 roadmap: wasm-gc main backend gate (2026-03-27)


### PR DESCRIPTION
## Summary

Track the 6 selfhost-checker parity gaps surfaced by the new `selfhost-bootstrap-gate` (PR #362) as #364, and mark the now-resolved wasm-heavy gap (#356) as closed.

- **#364** — `vibe/compiler/checker_parity_advanced_test.vibe` 37/43 on the selfhost checker. Host CLI accepts the source but the wasm-compiled checker rejects (or, for negative tests, fails to flag): struct destructuring let, `is` expression, let-else, trait impl, struct field type mismatch, `derive(Unknown)`. Informational gate so non-blocking, but real selfhost feature gaps.
- **#356** — wasm-heavy 112/129 → 129/129 ✅ (PR #357 routed inline allocators, PR #358 added StringInterp to `needs_heap`). Move from "open gap" to ✅ marker.

## Test plan

- [ ] No code changes; doc-only update. CI should be a no-op pass.

https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXzgsAVDTSNSZDF11wy63e)_