### PR TITLE
parser: #import(&quot;...&quot;) directive on effect decls (ADR-0021 Phase 2 Step 1)

### DIFF
--- a/examples/effect_import_directive_test.vibe
+++ b/examples/effect_import_directive_test.vibe
@@ -15,6 +15,11 @@ effect Fs {
   Read(String) -> String
 }
 
+#import("wasi:cli/stdio@0.2.0")
+export effect Console {
+  Print(String) -> Unit
+}
+
 //# Misc
 
 test "import directive: handler still satisfies effect locally" {
@@ -29,4 +34,16 @@ test "import directive: handler still satisfies effect locally" {
     }
   }
   assert(String::equals(content, "stub-content"))
+}
+
+test "import directive: works on exported effect declarations too" {
+  // `#import(...) export effect ...` is the form needed when an
+  // external effect is part of a module's public API.
+  let mut last = ""
+  handle {
+    perform Console::Print("hello")
+  } with Console {
+    Print(msg) => { last = msg; resume(()) }
+  }
+  assert(String::equals(last, "hello"))
 }

--- a/examples/effect_import_directive_test.vibe
+++ b/examples/effect_import_directive_test.vibe
@@ -1,0 +1,32 @@
+// ADR-0021 Phase 2 Step 1: `#import("...")` directive parses on `effect`
+// declarations and is preserved on the AST node (Stmt::EffectDef.import_path).
+//
+// Phase 2 wiring (effect classification + WASM `import` section emission) is
+// not yet hooked up; this example just locks the parser surface so later
+// steps can rely on the directive being available on the AST.
+//
+// Until codegen consumes `import_path`, the effect must still be handled by
+// a tail-resumptive `with`-handler if `perform`-ed in the same module.
+
+//# Effects
+
+#import("wasi:filesystem/read@0.2.0")
+effect Fs {
+  Read(String) -> String
+}
+
+//# Misc
+
+test "import directive: handler still satisfies effect locally" {
+  // With no WASM import wiring yet, the directive is informational. The
+  // effect is still discharged by a local tail-resumptive handler.
+  let content = {
+    let mut canned = ""
+    handle {
+      perform Fs::Read("hello.txt")
+    } with Fs {
+      Read(_p) => { canned = "stub-content"; resume(canned) }
+    }
+  }
+  assert(String::equals(content, "stub-content"))
+}

--- a/src/cmd/vibe/normalize_render.mbt
+++ b/src/cmd/vibe/normalize_render.mbt
@@ -280,8 +280,17 @@ fn normalize_render_effect_stmt(
   name : String,
   params : Array[String],
   ops : Array[@vibe_core.EffectOp],
+  import_path : String?,
 ) -> String {
   let out = StringBuilder::new()
+  match import_path {
+    Some(p) => {
+      out.write_string("#import(\"")
+      out.write_string(p)
+      out.write_string("\")\n")
+    }
+    None => ()
+  }
   if exported {
     out.write_string("export ")
   }
@@ -386,10 +395,10 @@ fn normalize_render_stmt(
         source, true, rec, name, render_expr, rewritten_expr, annotation, env,
       )
     }
-    @vibe_core.Stmt::EffectDef(name~, params~, ops~, ..) =>
-      Some(normalize_render_effect_stmt(false, name, params, ops))
-    @vibe_core.Stmt::ExportEffectDef(name~, params~, ops~, ..) =>
-      Some(normalize_render_effect_stmt(true, name, params, ops))
+    @vibe_core.Stmt::EffectDef(name~, params~, ops~, import_path~, ..) =>
+      Some(normalize_render_effect_stmt(false, name, params, ops, import_path))
+    @vibe_core.Stmt::ExportEffectDef(name~, params~, ops~, import_path~, ..) =>
+      Some(normalize_render_effect_stmt(true, name, params, ops, import_path))
     _ => normalize_render_stmt_fallback(stmt)
   }
 }

--- a/src/cmd/vibe/normalize_render.mbt
+++ b/src/cmd/vibe/normalize_render.mbt
@@ -285,9 +285,9 @@ fn normalize_render_effect_stmt(
   let out = StringBuilder::new()
   match import_path {
     Some(p) => {
-      out.write_string("#import(\"")
-      out.write_string(p)
-      out.write_string("\")\n")
+      out.write_string("#import(")
+      out.write_string(normalize_quote_string(p))
+      out.write_string(")\n")
     }
     None => ()
   }

--- a/src/core/ast.mbt
+++ b/src/core/ast.mbt
@@ -279,12 +279,14 @@ pub(all) enum Stmt {
     name~ : String,
     params~ : Array[String],
     ops~ : Array[EffectOp],
+    import_path~ : String?,
     span~ : Span
   )
   ExportEffectDef(
     name~ : String,
     params~ : Array[String],
     ops~ : Array[EffectOp],
+    import_path~ : String?,
     span~ : Span
   )
 } derive(Debug, Eq)

--- a/src/core/normalize.mbt
+++ b/src/core/normalize.mbt
@@ -154,9 +154,11 @@ fn canonicalize_export_list_stmts(stmts : Array[Stmt]) -> Array[Stmt] {
         } else {
           out.push(stmt)
         }
-      Stmt::EffectDef(name~, params~, ops~, span~) =>
+      Stmt::EffectDef(name~, params~, ops~, import_path~, span~) =>
         if export_list_names.contains(name) {
-          out.push(Stmt::ExportEffectDef(name~, params~, ops~, span~))
+          out.push(
+            Stmt::ExportEffectDef(name~, params~, ops~, import_path~, span~),
+          )
         } else {
           out.push(stmt)
         }
@@ -414,18 +416,20 @@ fn normalize_stmt(stmt : Stmt, scope : NormScope) -> Stmt {
         fields=normalize_struct_fields(fields),
         span=zero_span,
       )
-    Stmt::EffectDef(name~, params~, ops~, ..) =>
+    Stmt::EffectDef(name~, params~, ops~, import_path~, ..) =>
       Stmt::EffectDef(
         name~,
         params~,
         ops=normalize_effect_ops(ops),
+        import_path~,
         span=zero_span,
       )
-    Stmt::ExportEffectDef(name~, params~, ops~, ..) =>
+    Stmt::ExportEffectDef(name~, params~, ops~, import_path~, ..) =>
       Stmt::ExportEffectDef(
         name~,
         params~,
         ops=normalize_effect_ops(ops),
+        import_path~,
         span=zero_span,
       )
   }

--- a/src/core/normalize_export_wbtest.mbt
+++ b/src/core/normalize_export_wbtest.mbt
@@ -190,6 +190,7 @@ test "normalize_module canonicalizes EffectDef export list into ExportEffectDef"
             span: zero_span_for_export_norm_test,
           },
         ],
+        import_path=None,
         span=zero_span_for_export_norm_test,
       ),
       Stmt::Export(names=["Net"], span=zero_span_for_export_norm_test),

--- a/src/core/serialize.mbt
+++ b/src/core/serialize.mbt
@@ -263,18 +263,32 @@ fn serialize_stmt_to(stmt : Stmt, buf : StringBuilder) -> Unit {
       serialize_strings_to(params, buf)
       buf.write_string("}}")
     }
-    Stmt::EffectDef(name~, params~, ops~, ..) => {
+    Stmt::EffectDef(name~, params~, ops~, import_path~, ..) => {
       buf.write_string("{\"EffectDef\":{\"name\":")
       serialize_string_to(name, buf)
+      match import_path {
+        Some(p) => {
+          buf.write_string(",\"import_path\":")
+          serialize_string_to(p, buf)
+        }
+        None => ()
+      }
       buf.write_string(",\"ops\":")
       serialize_effect_ops_to(ops, buf)
       buf.write_string(",\"params\":")
       serialize_strings_to(params, buf)
       buf.write_string("}}")
     }
-    Stmt::ExportEffectDef(name~, params~, ops~, ..) => {
+    Stmt::ExportEffectDef(name~, params~, ops~, import_path~, ..) => {
       buf.write_string("{\"ExportEffectDef\":{\"name\":")
       serialize_string_to(name, buf)
+      match import_path {
+        Some(p) => {
+          buf.write_string(",\"import_path\":")
+          serialize_string_to(p, buf)
+        }
+        None => ()
+      }
       buf.write_string(",\"ops\":")
       serialize_effect_ops_to(ops, buf)
       buf.write_string(",\"params\":")

--- a/src/core/structural_hash.mbt
+++ b/src/core/structural_hash.mbt
@@ -257,7 +257,7 @@ pub fn Stmt::structural_hash(self : Stmt) -> Int {
       }
       h
     }
-    Stmt::EffectDef(name~, params~, ops~, ..) => {
+    Stmt::EffectDef(name~, params~, ops~, import_path~, ..) => {
       let mut h = 0x45666644 // "EffD"
       h = combine_hash(h, name.hash())
       for p in params {
@@ -266,9 +266,13 @@ pub fn Stmt::structural_hash(self : Stmt) -> Int {
       for op in ops {
         h = combine_hash(h, op.structural_hash())
       }
+      match import_path {
+        Some(p) => h = combine_hash(h, p.hash())
+        None => ()
+      }
       h
     }
-    Stmt::ExportEffectDef(name~, params~, ops~, ..) => {
+    Stmt::ExportEffectDef(name~, params~, ops~, import_path~, ..) => {
       let mut h = 0x45784566 // "ExEf"
       h = combine_hash(h, name.hash())
       for p in params {
@@ -276,6 +280,10 @@ pub fn Stmt::structural_hash(self : Stmt) -> Int {
       }
       for op in ops {
         h = combine_hash(h, op.structural_hash())
+      }
+      match import_path {
+        Some(p) => h = combine_hash(h, p.hash())
+        None => ()
       }
       h
     }

--- a/src/frontend/dce.mbt
+++ b/src/frontend/dce.mbt
@@ -227,7 +227,7 @@ fn collect_stmt_info(
       }
       (Some(name), refs)
     }
-    @core.Stmt::EffectDef(name~, params~, ops~, span~) => {
+    @core.Stmt::EffectDef(name~, params~, ops~, span~, ..) => {
       let _ = params
       let _ = span
       for op in ops {
@@ -238,7 +238,7 @@ fn collect_stmt_info(
       }
       (Some(name), refs)
     }
-    @core.Stmt::ExportEffectDef(name~, params~, ops~, span~) => {
+    @core.Stmt::ExportEffectDef(name~, params~, ops~, span~, ..) => {
       let _ = params
       let _ = span
       for op in ops {

--- a/src/frontend/symbol_index.mbt
+++ b/src/frontend/symbol_index.mbt
@@ -611,8 +611,8 @@ pub fn build_symbol_index_for_module(
           )
         }
       }
-      @core.Stmt::EffectDef(name~, params~, ops~, span~)
-      | @core.Stmt::ExportEffectDef(name~, params~, ops~, span~) => {
+      @core.Stmt::EffectDef(name~, params~, ops~, span~, ..)
+      | @core.Stmt::ExportEffectDef(name~, params~, ops~, span~, ..) => {
         let op_parts : Array[String] = []
         for op in ops {
           let param_strs : Array[String] = []

--- a/src/parser/parser_ast_stmts.mbt
+++ b/src/parser/parser_ast_stmts.mbt
@@ -754,9 +754,12 @@ fn AstParser::parse_effect_stmt(
 /// ADR-0021 Phase 2 Step 1: binds the effect to a Component Model interface.
 ///   #import("wasi:filesystem/read@0.2.0")
 ///   effect Fs { read_file(String) -> String }
+///   #import("wasi:cli/stdio@0.2.0")
+///   export effect Console { print(String) -> Unit }
 fn AstParser::parse_import_directive_effect_stmt(
   self : AstParser,
 ) -> @core.Stmt raise ParseError {
+  let start = self.pos
   let _ = self.expect(hash_ref(), "#import")
   self.skip_trivia()
   let _ = self.expect(lparen(), "(")
@@ -766,6 +769,13 @@ fn AstParser::parse_import_directive_effect_stmt(
   self.skip_trivia()
   let _ = self.expect(rparen(), ")")
   self.skip_trivia()
+  let exported = if self.peek_kind() == export_kw() {
+    let _ = self.bump()
+    self.skip_trivia()
+    true
+  } else {
+    false
+  }
   if self.peek_kind() != name() || self.peek().text() != "effect" {
     raise ParseError::UnexpectedToken(
       expected="`effect` declaration after `#import(...)` directive",
@@ -773,7 +783,18 @@ fn AstParser::parse_import_directive_effect_stmt(
       span=self.token_span(),
     )
   }
-  self.parse_effect_stmt(false, import_path=Some(path))
+  let effect_stmt = self.parse_effect_stmt(exported, import_path=Some(path))
+  if exported {
+    match effect_stmt {
+      @core.Stmt::EffectDef(name~, params~, ops~, import_path~, ..) => {
+        let span = self.span_from(start)
+        @core.Stmt::ExportEffectDef(name~, params~, ops~, import_path~, span~)
+      }
+      other => other
+    }
+  } else {
+    effect_stmt
+  }
 }
 
 ///|

--- a/src/parser/parser_ast_stmts.mbt
+++ b/src/parser/parser_ast_stmts.mbt
@@ -2,6 +2,8 @@
 fn AstParser::parse_stmt(self : AstParser) -> @core.Stmt? raise ParseError {
   self.skip_trivia()
   match self.peek_kind() {
+    k if k == hash_ref() && self.peek().text() == "#import" =>
+      Some(self.parse_import_directive_effect_stmt())
     k if k == let_kw() => Some(self.parse_let_stmt())
     k if k == enum_kw() => Some(self.parse_enum_stmt())
     k if k == struct_kw() => Some(self.parse_struct_stmt())
@@ -715,6 +717,7 @@ fn AstParser::parse_suberror_stmt(
 fn AstParser::parse_effect_stmt(
   self : AstParser,
   _exported : Bool,
+  import_path? : String? = None,
 ) -> @core.Stmt raise ParseError {
   let start = self.pos
   let _ = self.expect(name(), "effect")
@@ -737,7 +740,40 @@ fn AstParser::parse_effect_stmt(
   }
   let _ = self.expect(rbrace(), "}")
   let span = self.span_from(start)
-  @core.Stmt::EffectDef(name=name_tok.text(), params~, ops~, span~)
+  @core.Stmt::EffectDef(
+    name=name_tok.text(),
+    params~,
+    ops~,
+    import_path~,
+    span~,
+  )
+}
+
+///|
+/// Parse `#import("<path>")` directive followed by an `effect` declaration.
+/// ADR-0021 Phase 2 Step 1: binds the effect to a Component Model interface.
+///   #import("wasi:filesystem/read@0.2.0")
+///   effect Fs { read_file(String) -> String }
+fn AstParser::parse_import_directive_effect_stmt(
+  self : AstParser,
+) -> @core.Stmt raise ParseError {
+  let _ = self.expect(hash_ref(), "#import")
+  self.skip_trivia()
+  let _ = self.expect(lparen(), "(")
+  self.skip_trivia()
+  let path_tok = self.expect(string_lit(), "import path string literal")
+  let path = path_tok.text()
+  self.skip_trivia()
+  let _ = self.expect(rparen(), ")")
+  self.skip_trivia()
+  if self.peek_kind() != name() || self.peek().text() != "effect" {
+    raise ParseError::UnexpectedToken(
+      expected="`effect` declaration after `#import(...)` directive",
+      got=self.peek().text(),
+      span=self.token_span(),
+    )
+  }
+  self.parse_effect_stmt(false, import_path=Some(path))
 }
 
 ///|
@@ -1234,10 +1270,10 @@ fn AstParser::parse_internal_export_stmt(
   } else if self.peek_kind() == name() && self.peek().text() == "effect" {
     let effect_stmt = self.parse_effect_stmt(false)
     match effect_stmt {
-      @core.Stmt::EffectDef(name~, params~, ops~, ..) => {
+      @core.Stmt::EffectDef(name~, params~, ops~, import_path~, ..) => {
         let span = self.span_from(start)
         // internal export effects are not yet supported; treat as non-exported
-        @core.Stmt::EffectDef(name~, params~, ops~, span~)
+        @core.Stmt::EffectDef(name~, params~, ops~, import_path~, span~)
       }
       _ => {
         let span = self.span_from(start)
@@ -2328,9 +2364,9 @@ fn AstParser::parse_export_stmt(
   } else if self.peek_kind() == name() && self.peek().text() == "effect" {
     let effect_stmt = self.parse_effect_stmt(false)
     match effect_stmt {
-      @core.Stmt::EffectDef(name~, params~, ops~, ..) => {
+      @core.Stmt::EffectDef(name~, params~, ops~, import_path~, ..) => {
         let span = self.span_from(start)
-        @core.Stmt::ExportEffectDef(name~, params~, ops~, span~)
+        @core.Stmt::ExportEffectDef(name~, params~, ops~, import_path~, span~)
       }
       _ => {
         let span = self.span_from(start)


### PR DESCRIPTION
## 経緯

ADR-0021 Phase 2 = エフェクト宣言を Component Model interface にバインドする。Step 1 は parser surface のロックインで、`#import("namespace:package/interface@version")` ディレクティブを `effect` 宣言の前に書けるようにし、AST ノードに `import_path : String?` を載せる。

codegen の wiring（外部エフェクト → WASM import section 生成）は次の slice。本 PR では directive は informational に留まり、`#import` 付きエフェクトを `perform` する場合は引き続きローカルの tail-resumptive handler で消化する必要がある。

## 変更

| 領域 | 変更 |
|---|---|
| AST (`src/core/ast.mbt`) | `Stmt::EffectDef` / `Stmt::ExportEffectDef` に `import_path~ : String?` 追加 |
| Parser (`src/parser/parser_ast_stmts.mbt`) | `parse_stmt` で `hash_ref("#import")` を dispatch、`parse_import_directive_effect_stmt` ヘルパ追加、`parse_effect_stmt` にオプショナル `import_path?` 引数 |
| Normalize / Serialize / Hash | `import_path` を round-trip させる (`normalize.mbt`, `serialize.mbt`, `structural_hash.mbt`) |
| AST printer (`src/cmd/vibe/normalize_render.mbt`) | path が Some のとき `#import("...")` 行を effect 宣言の前に emit |
| Destructure サイト | `dce.mbt`, `symbol_index.mbt`, `normalize_export_wbtest.mbt` の exhaustive destructure に `..` 追加 or `import_path~` 捕捉 |
| Example | `examples/effect_import_directive_test.vibe` — directive + ローカル handler のロックインテスト |

## 構文

```vibe
#import("wasi:filesystem/read@0.2.0")
effect Fs {
  Read(String) -> String
}
```

- directive は `effect` の直前にのみ出現可能
- 直後が `effect` キーワードでない場合は parse error
- 文字列リテラルの中身は将来 Component Model interface name resolution に使われる（本 PR では検証なし、生文字列としてそのまま AST に格納）

## 非対応 (Phase 2 の以降の Step)

- `#import` を持つエフェクトを WASM import section に変換 (Step 3)
- export 関数からの world 自動導出 (Step 4)
- テスト時のモックハンドラ差し替え (Step 5)
- snake_case ↔ kebab-case マッピング (Step 6)
- `export #import("...") effect ...` の組み合わせ（暫定で `export { Fs }` リストを使う）

## Test plan

- [ ] `just check`: AST 構築・destructure サイト全部が新フィールドを受け入れる
- [ ] `just test`: `examples/effect_import_directive_test.vibe` が pass、既存の effect 関連テストが regression なし
- [ ] `structural_hash` が `#import` の有無で別ハッシュを返す（再ビルドキャッシュが invalidate される）
- [ ] AST printer round-trip: `#import(...) effect Fs { ... }` が再パースして同じ AST

ローカルに `moon` / `just` がないため CI に依存。

ADR: docs/adr.md (ADR-0021), docs/mut-effect-plan.md Phase 2 Step 1

https://claude.ai/code/session_01PR1p4yesZZuTrCGMp9hhWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR1p4yesZZuTrCGMp9hhWR)_
