### PR TITLE
deprecation: Ref::new → Ref, Option::or → unwrap_or (-20 warnings)

### DIFF
--- a/src/checker/typecheck_call.mbt
+++ b/src/checker/typecheck_call.mbt
@@ -1,5 +1,5 @@
 ///|
-let resolve_member_depth : Ref[Int] = Ref::new(0)
+let resolve_member_depth : Ref[Int] = Ref(0)
 
 ///|
 /// Map a resolved type to its builtin namespace root for UFCS dispatch.

--- a/src/cmd/vibe/cli_repl.mbt
+++ b/src/cmd/vibe/cli_repl.mbt
@@ -1799,19 +1799,19 @@ fn repl_tui_cmd(
   let (app, cleanup) = @tui.init_vnode_terminal(
     initial_cols, initial_rows, @tui.print_raw,
   )
-  let width = Ref::new(initial_cols)
-  let height = Ref::new(initial_rows)
+  let width = Ref(initial_cols)
+  let height = Ref(initial_rows)
   let outputs : Array[String] = []
   let history : Array[String] = []
   load_history(history)
   let vibe_names : Array[String] = @checker.prelude_names()
-  let history_idx = Ref::new(-1)
-  let history_draft = Ref::new("")
+  let history_idx = Ref(-1)
+  let history_draft = Ref("")
   let completion_session = @editor.CompletionSession::new()
-  let completion_request_id : Ref[Int] = Ref::new(0)
-  let last_popup_rect : Ref[OverlayRect?] = Ref::new(None)
-  let completion_anchor : Ref[CompletionAnchor?] = Ref::new(None)
-  let cleaned = Ref::new(false)
+  let completion_request_id : Ref[Int] = Ref(0)
+  let last_popup_rect : Ref[OverlayRect?] = Ref(None)
+  let completion_anchor : Ref[CompletionAnchor?] = Ref(None)
+  let cleaned = Ref(false)
   fn cleanup_once() -> Unit {
     if cleaned.val {
       return
@@ -1820,13 +1820,13 @@ fn repl_tui_cmd(
     cleanup()
   }
 
-  let input_rows = Ref::new(repl_input_rows_for_height(initial_rows))
+  let input_rows = Ref(repl_input_rows_for_height(initial_rows))
   let input_editor = @editor.EditorState::new_with_kind(
     "",
     input_rows.val,
     @editor.HighlightKind::Plain,
   )
-  let scratch_source_ref = Ref::new(restored_source)
+  let scratch_source_ref = Ref(restored_source)
   fn set_input_text(text : String) -> Unit {
     input_editor.set_text("")
     if text.length() > 0 {
@@ -3590,13 +3590,13 @@ fn repl_interactive_raw_loop_compiled(
   let wasm_path = compiled_repl_temp_wasm_path()
   defer remove_file_if_exists(source_path)
   defer remove_file_if_exists(wasm_path)
-  let scratch_source_ref = Ref::new(initial_source)
+  let scratch_source_ref = Ref(initial_source)
   let line_buf = StringBuilder::new()
-  let cursor_pos = Ref::new(0)
+  let cursor_pos = Ref(0)
   let history : Array[String] = []
   load_history(history)
-  let history_idx = Ref::new(-1)
-  let history_draft = Ref::new("")
+  let history_idx = Ref(-1)
+  let history_draft = Ref("")
 
   fn get_prompt() -> String {
     @vibe_fs.basename(@io.current_dir_or_root()) + "> "
@@ -3771,7 +3771,7 @@ fn repl_interactive_raw_loop_compiled(
     redraw_line()
   }
 
-  let done = Ref::new(false)
+  let done = Ref(false)
 
   fn submit_line() {
     let text = line_buf_to_string().trim().to_string()

--- a/src/frontend/desugar_string_interp.mbt
+++ b/src/frontend/desugar_string_interp.mbt
@@ -8,7 +8,7 @@
 ///     let __si_2 = String::concat(__si_1, __to_string(b))
 ///     __si_2 }
 pub fn desugar_string_interp(ast : @core.Module) -> @core.Module {
-  let counter : Ref[Int] = Ref::new(0)
+  let counter : Ref[Int] = Ref(0)
   dsi_rewrite_module(ast, counter)
 }
 

--- a/src/frontend/rewrite_effect_handle.mbt
+++ b/src/frontend/rewrite_effect_handle.mbt
@@ -1003,7 +1003,7 @@ fn reh_cps_stmts(
 
 ///|
 /// Global counter for generating unique spans in CPS expansion
-let cps_counter : Ref[Int] = Ref::new(0)
+let cps_counter : Ref[Int] = Ref(0)
 
 ///|
 /// Generate a unique span offset for CPS expansion

--- a/src/runtime/db_query.mbt
+++ b/src/runtime/db_query.mbt
@@ -41,7 +41,7 @@ pub fn VibeDb::new() -> VibeDb {
                   Some(d) => diags.push(rt, d)
                   None => ()
                 }
-                HashedModule::new(parsed.or({ stmts: [] }))
+                HashedModule::new(parsed.unwrap_or({ stmts: [] }))
               }
             }
           _ => {
@@ -50,7 +50,7 @@ pub fn VibeDb::new() -> VibeDb {
               Some(d) => diags.push(rt, d)
               None => ()
             }
-            HashedModule::new(parsed.or({ stmts: [] }))
+            HashedModule::new(parsed.unwrap_or({ stmts: [] }))
           }
         }
       }


### PR DESCRIPTION
## Summary

Two small clusters of stale stdlib idioms that the toolchain has been warning about on every check. Plain renames, no semantic changes.

## Changes

### `Ref::new(v)` → `Ref(v)` (18 sites)

The stdlib has `Ref::new` as `#alias(new, deprecated)` of `Ref::Ref`. Warning text says:

> Warning (deprecated): \`new\` is deprecated, use \`Ref\` instead

Affected:
- `src/checker/typecheck_call.mbt` (1)
- `src/frontend/desugar_string_interp.mbt` (1)
- `src/frontend/rewrite_effect_handle.mbt` (1)
- `src/cmd/vibe/cli_repl.mbt` (15)

### `Option::or(default)` → `Option::unwrap_or(default)` (2 sites)

> Warning (deprecated): \`or\` is deprecated, use \`unwrap_or\` instead

Both in `src/runtime/db_query.mbt`: `parsed.or({ stmts: [] })`.

## Verification

```
moon check --target native --release   # 1431 → 1411 warnings, 0 errors
moon test -p mizchi/vibe/checker        # 160/160
moon test -p mizchi/vibe/frontend       # 83/83
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7y6q8Df9KiLNTK77zR65T)_