### PR TITLE
warnings: moon fmt + bounded deprecation migrations (-29 warnings)

### DIFF
--- a/src/benches/parser_bench.mbt
+++ b/src/benches/parser_bench.mbt
@@ -81,7 +81,11 @@ test "load pipeline scaling probe" {
     //    walks every entry and synthesises def-ids / symbol & type maps.
     let t_idx = @bench.monotonic_clock_start()
     let idx = @x_exp.build_advanced_graph_index(
-      db, paths, base_commit="", created_at="", skip_types=true,
+      db,
+      paths,
+      base_commit="",
+      created_at="",
+      skip_types=true,
     )
     let graph_index_us = @bench.monotonic_clock_end(t_idx)
 

--- a/src/checker/impl_index_wbtest.mbt
+++ b/src/checker/impl_index_wbtest.mbt
@@ -81,7 +81,11 @@ test "ImplIndex::register_impl rejects unknown trait" {
   let env = TypeEnv::new()
   let span = @core.Span::empty(0)
   let result : Result[Unit, TypeError] = try? ImplIndex::of(env).register_impl(
-    [], {}, "DoesNotExist", @core.Type::Int, span,
+    [],
+    {},
+    "DoesNotExist",
+    @core.Type::Int,
+    span,
   )
   match result {
     Err(_) => ()
@@ -99,7 +103,11 @@ test "ImplIndex::register_impl rejects overlap with existing impl" {
     err => fail("first register_impl unexpectedly failed: \{err.to_string()}")
   }
   let second : Result[Unit, TypeError] = try? index.register_impl(
-    [], {}, "Eq", @core.Type::Int, span,
+    [],
+    {},
+    "Eq",
+    @core.Type::Int,
+    span,
   )
   match second {
     Err(_) => ()

--- a/src/checker/obligation_solver.mbt
+++ b/src/checker/obligation_solver.mbt
@@ -74,7 +74,7 @@ pub fn TraitWitness::message(self : TraitWitness) -> String {
       impl_target~,
       param_name~,
       required_bound~,
-      actual_ty~,
+      actual_ty~
     ) =>
       "impl `" +
       trait_name +
@@ -126,10 +126,7 @@ pub fn ObligationSolver::witness(
           if self.bound_satisfied(bounds, trait_name) {
             TraitWitness::Satisfied
           } else {
-            TraitWitness::VarLacksBound(
-              trait_name~,
-              available=bounds.copy(),
-            )
+            TraitWitness::VarLacksBound(trait_name~, available=bounds.copy())
           }
         None => TraitWitness::VarLacksBound(trait_name~, available=[])
       }
@@ -158,7 +155,8 @@ pub fn ObligationSolver::witness(
       // beyond the default fallback below, so recording it would cause
       // a later subtrait-fallback ImplBoundFailed to be dropped.
       let mut near_miss : TraitWitness? = None
-      match obligation_solver_witness_match_any(
+      match
+        obligation_solver_witness_match_any(
           self,
           resolved,
           trait_name,
@@ -180,7 +178,8 @@ pub fn ObligationSolver::witness(
         if not(self.graph.is_subtrait(impl_trait_name, trait_name)) {
           continue
         }
-        match obligation_solver_witness_match_any(
+        match
+          obligation_solver_witness_match_any(
             self,
             resolved,
             // The user-visible failure is still about `trait_name`
@@ -235,9 +234,7 @@ fn obligation_solver_witness_match_any(
   let mut bound_failure : TraitWitness? = None
   for impl_def in impls {
     let mapping : Map[String, @core.Type] = {}
-    if type_matches_impl_target(
-        solver.env, impl_def.target, resolved, mapping,
-      ) {
+    if type_matches_impl_target(solver.env, impl_def.target, resolved, mapping) {
       let mut ok = true
       let mut first_failure : TraitWitness? = None
       for param in impl_def.type_params {

--- a/src/checker/obligation_solver_wbtest.mbt
+++ b/src/checker/obligation_solver_wbtest.mbt
@@ -49,12 +49,8 @@ test "ObligationSolver::satisfies falls back to subtrait impls" {
     target: @core.Type::Named(name="MyKey", args=[]),
   })
   let solver = ObligationSolver::of(env)
-  assert_true(
-    solver.satisfies(@core.Type::Named(name="MyKey", args=[]), "Ord"),
-  )
-  assert_true(
-    solver.satisfies(@core.Type::Named(name="MyKey", args=[]), "Eq"),
-  )
+  assert_true(solver.satisfies(@core.Type::Named(name="MyKey", args=[]), "Ord"))
+  assert_true(solver.satisfies(@core.Type::Named(name="MyKey", args=[]), "Eq"))
 }
 
 ///|
@@ -74,7 +70,10 @@ test "ObligationSolver::satisfies covers Option[T]: Eq when T: Eq" {
   let env = TypeEnv::new()
   let solver = ObligationSolver::of(env)
   assert_true(
-    solver.satisfies(@core.Type::Named(name="Option", args=[@core.Type::Int]), "Eq"),
+    solver.satisfies(
+      @core.Type::Named(name="Option", args=[@core.Type::Int]),
+      "Eq",
+    ),
   )
 }
 
@@ -108,12 +107,7 @@ test "ObligationSolver::witness reports ImplBoundFailed when bounds fail" {
   let w = ObligationSolver::of(env).witness(target, "Show")
   assert_false(w.is_satisfied())
   match w {
-    TraitWitness::ImplBoundFailed(
-      trait_name~,
-      param_name~,
-      required_bound~,
-      ..
-    ) => {
+    TraitWitness::ImplBoundFailed(trait_name~, param_name~, required_bound~, ..) => {
       assert_eq(trait_name, "Show")
       assert_eq(param_name, "T")
       assert_eq(required_bound, "Hash")
@@ -142,12 +136,7 @@ test "ObligationSolver::witness prefers ImplBoundFailed from subtrait fallback" 
   let target = @core.Type::Array(@core.Type::Int)
   let w = ObligationSolver::of(env).witness(target, "Eq")
   match w {
-    TraitWitness::ImplBoundFailed(
-      trait_name~,
-      param_name~,
-      required_bound~,
-      ..
-    ) => {
+    TraitWitness::ImplBoundFailed(trait_name~, param_name~, required_bound~, ..) => {
       assert_eq(trait_name, "Eq")
       assert_eq(param_name, "T")
       assert_eq(required_bound, "Hash")

--- a/src/checker/prelude.mbt
+++ b/src/checker/prelude.mbt
@@ -534,8 +534,7 @@ pub fn prelude_names() -> Array[String] {
   [
     "add", "sub", "mul", "div", "eq", "lt", "not", "and", "or", "__not", "__or",
     "assert", "assert_true", "to_string", "iter_require", "iter_length", "iter_get",
-    "String::iter_length", "String::iter_get",
-    "Map::iter_length", "Map::iter_get",
+    "String::iter_length", "String::iter_get", "Map::iter_length", "Map::iter_get",
     "Array::map", "Array::fold", "Array::filter", "Array::foreach", "Array::concat",
     "Array::reverse", "Array::any", "Array::all", "Array::find", "assert_eq", "Array::sort",
     "Array::contains", "Array::join", "Map::get_or", "Map::map", "Map::filter", "where",

--- a/src/checker/trait_graph.mbt
+++ b/src/checker/trait_graph.mbt
@@ -32,7 +32,10 @@ pub fn TraitGraph::info(self : TraitGraph, name : String) -> TraitDefInfo? {
 
 ///|
 /// Direct (one-hop) supertraits of `name`.
-pub fn TraitGraph::supertraits(self : TraitGraph, name : String) -> Array[String] {
+pub fn TraitGraph::supertraits(
+  self : TraitGraph,
+  name : String,
+) -> Array[String] {
   match self.env.get_trait_info(name) {
     Some(info) => info.supertraits_copy()
     None => []
@@ -128,7 +131,9 @@ fn trait_graph_is_subtrait_inner(
         if parent == super_trait {
           return true
         }
-        if trait_graph_is_subtrait_inner(env, parent, super_trait, next_visiting) {
+        if trait_graph_is_subtrait_inner(
+            env, parent, super_trait, next_visiting,
+          ) {
           return true
         }
       }

--- a/src/checker/trait_graph_wbtest.mbt
+++ b/src/checker/trait_graph_wbtest.mbt
@@ -80,7 +80,11 @@ test "TraitGraph::register_def rejects self-referential supertrait" {
   let g = TraitGraph::of(env)
   let span = @core.Span::empty(0)
   let result : Result[Unit, TypeError] = try? g.register_def(
-    "Bad", ["Bad"], false, true, span,
+    "Bad",
+    ["Bad"],
+    false,
+    true,
+    span,
   )
   match result {
     Err(_) => ()
@@ -94,7 +98,11 @@ test "TraitGraph::register_def rejects unknown supertrait" {
   let g = TraitGraph::of(env)
   let span = @core.Span::empty(0)
   let result : Result[Unit, TypeError] = try? g.register_def(
-    "Ord", ["Eq"], false, true, span,
+    "Ord",
+    ["Eq"],
+    false,
+    true,
+    span,
   )
   match result {
     Err(_) => ()
@@ -108,7 +116,11 @@ test "TraitGraph::register_def rejects open trait without export" {
   let g = TraitGraph::of(env)
   let span = @core.Span::empty(0)
   let result : Result[Unit, TypeError] = try? g.register_def(
-    "Custom", [], true, false, span,
+    "Custom",
+    [],
+    true,
+    false,
+    span,
   )
   match result {
     Err(_) => ()
@@ -122,7 +134,9 @@ test "TraitGraph::import_def installs an external trait cleanly" {
   env.set_trait_info("Eq", TraitDefInfo::defined_here([], false))
   let g = TraitGraph::of(env)
   let installed = g.import_def(
-    "Ord", TraitDefInfo::defined_here(["Eq"], true), ["Eq"],
+    "Ord",
+    TraitDefInfo::defined_here(["Eq"], true),
+    ["Eq"],
   )
   assert_true(installed)
   assert_true(g.is_subtrait("Ord", "Eq"))
@@ -136,9 +150,7 @@ test "TraitGraph::import_def rolls back if it would close a cycle" {
   env.set_trait_info("A", TraitDefInfo::defined_here([], false))
   env.set_trait_info("B", TraitDefInfo::defined_here(["A"], false))
   let g = TraitGraph::of(env)
-  let installed = g.import_def(
-    "A", TraitDefInfo::defined_here([], true), ["B"],
-  )
+  let installed = g.import_def("A", TraitDefInfo::defined_here([], true), ["B"])
   assert_false(installed)
   // After rollback, A should retain its empty supertrait list.
   assert_eq(g.supertraits("A"), [])
@@ -172,10 +184,9 @@ test "TraitGraph::cycle_chain returns the offending trait sequence" {
   env.set_trait_info("A", TraitDefInfo::imported(["B"], true))
   let g = TraitGraph::of(env)
   match g.cycle_chain("A") {
-    Some(chain) => {
+    Some(chain) =>
       // Walk order starts at A, hits B, closes back at A.
       assert_eq(chain, ["A", "B", "A"])
-    }
     None => fail("expected cycle_chain to detect A -> B -> A")
   }
 }

--- a/src/checker/typecheck_errors.mbt
+++ b/src/checker/typecheck_errors.mbt
@@ -320,7 +320,7 @@ pub fn TypeError::diagnostic(self : TypeError) -> @core.Diagnostic {
       trait_name~,
       existing_target~,
       incoming_target~,
-      span~,
+      span~
     ) =>
       @core.Diagnostic::{
         stage: "type",
@@ -499,7 +499,7 @@ fn TypeError::resolve_vars(self : TypeError, env : TypeEnv) -> TypeError {
       trait_name~,
       existing_target~,
       incoming_target~,
-      span~,
+      span~
     ) =>
       TypeError::TraitImplOverlap(
         trait_name~,

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -2012,11 +2012,7 @@ fn ensure_eq_operand(
       let w = ObligationSolver::of(env).witness(resolved, "Eq")
       if not(w.is_satisfied()) {
         let extra = w.message()
-        let ctx = if extra == "" {
-          "argument"
-        } else {
-          "argument: " + extra
-        }
+        let ctx = if extra == "" { "argument" } else { "argument: " + extra }
         raise TypeError::Mismatch(
           expected=@core.Type::Named(name="Eq", args=[]),
           actual=resolved,
@@ -2865,9 +2861,7 @@ fn check_call_args(
                 expected=argument_mismatch_expected_type(env, param_ty, arg.ty),
                 actual=resolve_type(env, arg.ty),
                 span=arg.span,
-                context=Some(
-                  argument_mismatch_context(env, param_ty, arg.ty),
-                ),
+                context=Some(argument_mismatch_context(env, param_ty, arg.ty)),
               )
             }
           None =>
@@ -2907,9 +2901,7 @@ fn check_call_args(
                 expected=argument_mismatch_expected_type(env, param.ty, arg.ty),
                 actual=resolve_type(env, arg.ty),
                 span=arg.span,
-                context=Some(
-                  argument_mismatch_context(env, param.ty, arg.ty),
-                ),
+                context=Some(argument_mismatch_context(env, param.ty, arg.ty)),
               )
             }
           }

--- a/src/cmd/vibe/cli_bench.mbt
+++ b/src/cmd/vibe/cli_bench.mbt
@@ -196,7 +196,7 @@ fn parse_bench_cmd_args(
         if i + 1 >= args.length() {
           return Err("bench: missing value for --runs")
         }
-        runs = @strconv.parse_int(args[i + 1]) catch {
+        runs = @string.parse_int(args[i + 1]) catch {
           e => return Err("bench: invalid --runs: " + e.to_string())
         }
         i += 2
@@ -206,7 +206,7 @@ fn parse_bench_cmd_args(
           return Err("bench: missing value for --n")
         }
         legacy_n = Some(
-          @strconv.parse_int(args[i + 1]) catch {
+          @string.parse_int(args[i + 1]) catch {
             e => return Err("bench: invalid --n: " + e.to_string())
           },
         )
@@ -216,7 +216,7 @@ fn parse_bench_cmd_args(
         if i + 1 >= args.length() {
           return Err("bench: missing value for --warmup")
         }
-        warmup = @strconv.parse_int(args[i + 1]) catch {
+        warmup = @string.parse_int(args[i + 1]) catch {
           e => return Err("bench: invalid --warmup: " + e.to_string())
         }
         i += 2
@@ -1025,7 +1025,7 @@ fn build_http_host_bench_command(
 ///|
 fn parse_http_host_bench_elapsed_us(stdout : String) -> Result[Double, String] {
   let text = stdout.trim().to_string()
-  let parsed : Result[Double, @strconv.StrConvError] = try? @strconv.parse_double(
+  let parsed : Result[Double, Error] = try? @string.parse_double(
     text,
   )
   match parsed {
@@ -1093,18 +1093,16 @@ fn resolve_wasm_opt_bin_for_bench() -> String? {
   // Probe PATH `wasm-opt`. Run `wasm-opt --version` and require >= 118.
   // exec_command_lines returns a Result (does not raise) — pattern-match
   // instead of using catch.
-  let probe = match @backend.exec_command_lines(
-    "command -v wasm-opt 2>/dev/null",
-  ) {
+  let probe = match
+    @backend.exec_command_lines("command -v wasm-opt 2>/dev/null") {
     Ok(lines) => lines
     Err(_) => return None
   }
   if probe.length() == 0 || probe[0].trim().to_string() == "" {
     return None
   }
-  let version_lines = match @backend.exec_command_lines(
-    "wasm-opt --version 2>&1 | head -n 1",
-  ) {
+  let version_lines = match
+    @backend.exec_command_lines("wasm-opt --version 2>&1 | head -n 1") {
     Ok(lines) => lines
     Err(_) => return None
   }
@@ -1127,9 +1125,7 @@ fn resolve_wasm_opt_bin_for_bench() -> String? {
   if digits.length() == 0 {
     return None
   }
-  let version = @strconv.parse_int(digits) catch {
-    _ => return None
-  }
+  let version = @string.parse_int(digits) catch { _ => return None }
   if version < 118 {
     return None
   }
@@ -1156,8 +1152,7 @@ fn try_wasm_opt_shell_out(
   }
   // Same feature flag set as scripts/build_selfhost_wasi_opt.sh — these
   // are the moonbit wasm features the binary can use.
-  let cmd =
-    bin +
+  let cmd = bin +
     " " +
     opt_level +
     " --enable-gc --enable-reference-types --enable-bulk-memory" +
@@ -1172,9 +1167,7 @@ fn try_wasm_opt_shell_out(
     Ok(_) => ()
     Err(_) => return None
   }
-  let out_bytes = @os_fs.read_file_to_bytes(tmp_out) catch {
-    _ => return None
-  }
+  let out_bytes = @os_fs.read_file_to_bytes(tmp_out) catch { _ => return None }
   // Best-effort cleanup; ignore failures.
   ignore(@os_fs.remove_file(tmp_in) catch { _ => () })
   ignore(@os_fs.remove_file(tmp_out) catch { _ => () })
@@ -1318,7 +1311,7 @@ fn compile_bench_script_to_wasm_with_runner(
     Some(level) =>
       match try_wasm_opt_shell_out(raw_bytes, level, wasm_path) {
         Some(opt) => opt
-        None => {
+        None =>
           // Shell-out unavailable / failed — try in-process @wite as a
           // last resort. This may still be pathological on very large
           // selfhost-import wasm, but it is the historical path.
@@ -1344,7 +1337,6 @@ fn compile_bench_script_to_wasm_with_runner(
               _ => raw_bytes
             }
           }
-        }
       }
   }
   @os_fs.write_bytes_to_file(wasm_path, wasm_bytes) catch {
@@ -2194,7 +2186,7 @@ fn bench_file_cmd(
         if i + 1 >= args.length() {
           abort("bench-file: missing value for --n")
         }
-        count = @strconv.parse_int(args[i + 1]) catch {
+        count = @string.parse_int(args[i + 1]) catch {
           e => abort("bench-file: invalid --n: " + e.to_string())
         }
         i += 2
@@ -2203,7 +2195,7 @@ fn bench_file_cmd(
         if i + 1 >= args.length() {
           abort("bench-file: missing value for --warmup")
         }
-        warmup = @strconv.parse_int(args[i + 1]) catch {
+        warmup = @string.parse_int(args[i + 1]) catch {
           e => abort("bench-file: invalid --warmup: " + e.to_string())
         }
         i += 2

--- a/src/cmd/vibe/cli_cache.mbt
+++ b/src/cmd/vibe/cli_cache.mbt
@@ -255,8 +255,8 @@ fn parse_linked_imports_cache(
       parts.push(part_view.to_string())
     }
     if parts.length() >= 4 {
-      let pc : Result[Int, _] = try? @strconv.parse_int(parts[2])
-      let rc : Result[Int, _] = try? @strconv.parse_int(parts[3])
+      let pc : Result[Int, _] = try? @string.parse_int(parts[2])
+      let rc : Result[Int, _] = try? @string.parse_int(parts[3])
       match (pc, rc) {
         (Ok(param_count), Ok(return_count)) =>
           out.push(@runtime_compile.LinkedImport::{
@@ -368,7 +368,7 @@ fn pure_test_cache_lookup(
     return None
   }
   let saved_hash = parts[0]
-  let saved_count : Result[Int, _] = try? @strconv.parse_int(parts[1])
+  let saved_count : Result[Int, _] = try? @string.parse_int(parts[1])
   let expected_count = match saved_count {
     Ok(n) => n
     Err(_) => return None

--- a/src/cmd/vibe/cli_check_cmd.mbt
+++ b/src/cmd/vibe/cli_check_cmd.mbt
@@ -403,7 +403,7 @@ fn split_check_cmd_args(
       }
       profile_tsv = Some(args[i])
     } else if arg.has_prefix("--builtin-contract=") {
-      let value = arg.substring(start="--builtin-contract=".length())
+      let value = arg["--builtin-contract=".length():].to_owned()
       if value == "warn" || value == "error" || value == "ignore" {
         builtin_contract = value
       } else {

--- a/src/cmd/vibe/cli_ide.mbt
+++ b/src/cmd/vibe/cli_ide.mbt
@@ -1357,7 +1357,7 @@ async fn lsp_main_loop() -> Unit {
         // Parse content length
         let len_part = header_str[15:].to_string()
         let len_str = trim_whitespace(len_part)
-        let content_length = @strconv.parse_int(len_str) catch { _ => continue }
+        let content_length = @string.parse_int(len_str) catch { _ => continue }
 
         // Skip empty line after headers
         let _ = stdin.read_until("\n")

--- a/src/cmd/vibe/cli_repl.mbt
+++ b/src/cmd/vibe/cli_repl.mbt
@@ -4032,7 +4032,7 @@ fn extract_let_binding_name(line : String) -> String? {
   if end == prefix_len {
     return None
   }
-  let name = line.substring(start=prefix_len, end~)
+  let name = line[prefix_len:end].to_owned()
   Some(name)
 }
 
@@ -4042,7 +4042,7 @@ fn extract_vibe_display_line(stdout : String) -> String? {
   for line_view in stdout.split("\n") {
     let line = line_view.to_string()
     if line.has_prefix("VIBE_DISPLAY:") {
-      return Some(line.substring(start=13))
+      return Some(line[13:].to_owned())
     }
   }
   None

--- a/src/cmd/vibe/cli_run_cmd.mbt
+++ b/src/cmd/vibe/cli_run_cmd.mbt
@@ -56,7 +56,7 @@ fn parse_numeric_line_int64(line : String) -> Int64? {
   if not(has_digit) {
     return None
   }
-  let value = @strconv.parse_int(trimmed) catch { _ => return None }
+  let value = @string.parse_int(trimmed) catch { _ => return None }
   Some(value.to_int64())
 }
 
@@ -1077,7 +1077,7 @@ fn extract_vibe_display_line_run(stdout : String) -> String? {
   for line_view in stdout.split("\n") {
     let line = line_view.to_string()
     if line.has_prefix("VIBE_DISPLAY:") {
-      return Some(line.substring(start=13))
+      return Some(line[13:].to_owned())
     }
   }
   None

--- a/src/cmd/vibe/cli_session.mbt
+++ b/src/cmd/vibe/cli_session.mbt
@@ -410,9 +410,7 @@ fn build_session_http_spawn_command(
   // through unescaped. Wrapping the whole payload in `'…'` would split
   // mid-path on those. Splice each embedded `'` as `'\''` so the outer
   // single-quoted region survives.
-  "nohup sh -c " +
-  pose_single_quote(payload) +
-  " >/dev/null 2>&1 &"
+  "nohup sh -c " + pose_single_quote(payload) + " >/dev/null 2>&1 &"
 }
 
 ///|
@@ -448,7 +446,7 @@ fn session_http_effective_parent_pid() -> Int {
 /// back-to-back `vibe test` invocations reuse the same worker.
 fn session_http_idle_seconds() -> Int {
   match @sys.get_env_var("VIBE_SESSION_IDLE_SECONDS") {
-    Some(raw) => @strconv.parse_int(raw) catch { _ => 60 }
+    Some(raw) => @string.parse_int(raw) catch { _ => 60 }
     None => 60
   }
 }
@@ -460,7 +458,7 @@ fn session_http_idle_seconds() -> Int {
 fn session_http_cache_capacity() -> Int {
   match @sys.get_env_var("VIBE_SESSION_CACHE_MAX") {
     Some(raw) => {
-      let n = @strconv.parse_int(raw) catch { _ => 16 }
+      let n = @string.parse_int(raw) catch { _ => 16 }
       if n <= 0 {
         16
       } else {
@@ -589,7 +587,7 @@ fn parse_cli_run_value_json(json : Json) -> Result[WasmRunValue, String] {
         "int" =>
           match obj.get("value") {
             Some(Json::String(value)) => {
-              let parsed = @strconv.parse_int(value) catch {
+              let parsed = @string.parse_int(value) catch {
                 _ => return Err("session-http: invalid run int result")
               }
               Ok(WasmRunValue::Int(parsed.to_int64()))
@@ -985,7 +983,7 @@ fn split_session_http_cmd_args(args : Array[String]) -> Result[Int, String] {
       if i >= args.length() {
         return Err("session-http: missing value after --port")
       }
-      let parsed = @strconv.parse_int(args[i]) catch {
+      let parsed = @string.parse_int(args[i]) catch {
         e => return Err("session-http: invalid --port: " + e.to_string())
       }
       port = Some(parsed)
@@ -1078,7 +1076,7 @@ fn parse_report_json_int(json : Json, key : String) -> Int {
 fn parse_internal_parent_pid_env(env_name : String) -> Int? {
   match @sys.get_env_var(env_name) {
     Some(raw) => {
-      let pid = @strconv.parse_int(raw) catch { _ => 0 }
+      let pid = @string.parse_int(raw) catch { _ => 0 }
       if pid > 1 {
         Some(pid)
       } else {

--- a/src/cmd/vibe/cli_test_cmd.mbt
+++ b/src/cmd/vibe/cli_test_cmd.mbt
@@ -72,7 +72,7 @@ fn compiled_test_stmt_module_prefix(stmt : @vibe_core.Stmt) -> String? {
   let idx = name.find("::")
   match idx {
     Some(i) => {
-      let prefix = name.substring(start=0, end=i)
+      let prefix = name[0:i].to_owned()
       if prefix.length() == 0 || prefix.contains("::") {
         None
       } else {
@@ -717,7 +717,7 @@ fn run_test_file_compiled_with_cache(
     let stdout = run_out.stdout.trim().to_string()
     if stdout.has_prefix("last: ") {
       let num_str = stdout.unsafe_substring(start=6, end=stdout.length())
-      let parsed : Result[Int, _] = try? @strconv.parse_int(num_str)
+      let parsed : Result[Int, _] = try? @string.parse_int(num_str)
       match parsed {
         Ok(n) => n
         Err(_) => cases.length()
@@ -881,7 +881,7 @@ fn test_cmd(
     if arg == "--jobs" {
       i += 1
       if i < args.length() {
-        jobs = @strconv.parse_int(args[i]) catch { _ => 0 }
+        jobs = @string.parse_int(args[i]) catch { _ => 0 }
       }
     } else if arg == "--report-json" {
       report_json = true
@@ -929,7 +929,7 @@ fn default_test_jobs() -> Int {
   // Safe default with env override for local tuning.
   match @sys.get_env_var("VIBE_TEST_JOBS") {
     Some(raw) => {
-      let parsed = @strconv.parse_int(raw) catch { _ => 0 }
+      let parsed = @string.parse_int(raw) catch { _ => 0 }
       if parsed > 0 {
         parsed
       } else {
@@ -1346,7 +1346,7 @@ let test_entry_batch_max_chunk_size = 4
 fn test_entry_batch_env_chunk_size() -> Int? {
   match @sys.get_env_var("VIBE_TEST_BATCH_CHUNK_SIZE") {
     Some(raw) => {
-      let parsed = @strconv.parse_int(raw.trim().to_string()) catch { _ => 0 }
+      let parsed = @string.parse_int(raw.trim().to_string()) catch { _ => 0 }
       if parsed > 0 {
         Some(parsed)
       } else {

--- a/src/cmd/vibe/cli_tools_cmd.mbt
+++ b/src/cmd/vibe/cli_tools_cmd.mbt
@@ -892,7 +892,7 @@ fn expand_cmd(args : Array[String]) -> Unit {
     if arg == "--depth" || arg == "-d" {
       i += 1
       if i < args.length() {
-        depth = Some(@strconv.parse_int(args[i]) catch { _ => 0 })
+        depth = Some(@string.parse_int(args[i]) catch { _ => 0 })
       }
     } else if arg == "--json" {
       output_json = true

--- a/src/cmd/vibe/function_tracking.mbt
+++ b/src/cmd/vibe/function_tracking.mbt
@@ -67,9 +67,9 @@ fn function_tracking_parse_semver(text : String) -> FunctionTrackingSemver? {
   if parts.length() != 3 {
     return None
   }
-  let major = @strconv.parse_int(parts[0].trim()) catch { _ => return None }
-  let minor = @strconv.parse_int(parts[1].trim()) catch { _ => return None }
-  let patch = @strconv.parse_int(parts[2].trim()) catch { _ => return None }
+  let major = @string.parse_int(parts[0].trim()) catch { _ => return None }
+  let minor = @string.parse_int(parts[1].trim()) catch { _ => return None }
+  let patch = @string.parse_int(parts[2].trim()) catch { _ => return None }
   Some({ major, minor, patch })
 }
 

--- a/src/cmd/vibe/normalize_engine_pass_wbtest.mbt
+++ b/src/cmd/vibe/normalize_engine_pass_wbtest.mbt
@@ -302,7 +302,6 @@ test "pass pipeline: full chain produces same result as normalize_source_text" {
       #|
       #|let z: () -> Int = () -> { b() }
       #|)
-
     ),
   )
 }

--- a/src/cmd/vibe/normalize_engine_wbtest.mbt
+++ b/src/cmd/vibe/normalize_engine_wbtest.mbt
@@ -31,7 +31,6 @@ test "normalize_engine: format basic let binding" {
       #|
       #|let x: Int = 1
       #|)
-
     ),
   )
 }
@@ -51,7 +50,6 @@ test "normalize_engine: format multiple let bindings with spacing" {
       #|
       #|let b: Int = 2
       #|)
-
     ),
   )
 }
@@ -68,7 +66,6 @@ test "normalize_engine: constant folding for addition" {
       #|
       #|let value: Int = 3
       #|)
-
     ),
   )
 }
@@ -85,7 +82,6 @@ test "normalize_engine: constant folding for multiplication" {
       #|
       #|let value: Int = 12
       #|)
-
     ),
   )
 }
@@ -196,7 +192,6 @@ test "normalize_engine: inferred annotation on non-fn let" {
       #|
       #|let answer: Int = 42
       #|)
-
     ),
   )
 }
@@ -465,9 +460,12 @@ test "normalize_engine: empty source returns empty string" {
   let result = normalize_source_text(source)
   let expected =
     #|Ok("")
-  inspect(result, content=(
-    #|Ok()
-  ))
+  inspect(
+    result,
+    content=(
+      #|Ok()
+    ),
+  )
 }
 
 ///|
@@ -482,7 +480,6 @@ test "normalize_engine: constant folding subtraction" {
       #|
       #|let value: Int = 7
       #|)
-
     ),
   )
 }

--- a/src/cmd/vibe_wasm/main_wbtest.mbt
+++ b/src/cmd/vibe_wasm/main_wbtest.mbt
@@ -21,7 +21,7 @@ fn wbtest_remove_file_if_exists(path : String) -> Unit {
 
 ///|
 fn wbtest_parse_int(text : String) -> Int? {
-  let value = @strconv.parse_int(text[:]) catch { _ => return None }
+  let value = @string.parse_int(text[:]) catch { _ => return None }
   Some(value)
 }
 

--- a/src/codegen/wasm_codegen_rc_wbtest.mbt
+++ b/src/codegen/wasm_codegen_rc_wbtest.mbt
@@ -91,9 +91,12 @@ test "RC codegen: perceus plan actions emit dup/drop at stmt boundaries" {
   inspect(pre.length(), content="0")
   inspect(post.length(), content="1")
   let post_top = post.get("").unwrap_or({})
-  inspect(post_top.get(1).map(fn(a) { a[0].name }), content=(
-    #|Some(x)
-  ))
+  inspect(
+    post_top.get(1).map(fn(a) { a[0].name }),
+    content=(
+      #|Some(x)
+    ),
+  )
   // Compile with RC + actions
   let options_rc = wasm_emit_options(enable_rc=true, rc_actions~)
   let wasm_rc = emit_module_wasm_with_options(ast, options_rc)
@@ -393,9 +396,12 @@ test "RC codegen: build_rc_action_maps groups multiple actions on same stmt" {
   inspect(post_top.get(2).map(fn(a) { a.length() }), content="Some(2)")
   // One pre action on stmt 2 (old_value drop z)
   inspect(pre_top.get(2).map(fn(a) { a.length() }), content="Some(1)")
-  inspect(pre_top.get(2).map(fn(a) { a[0].name }), content=(
-    #|Some(z)
-  ))
+  inspect(
+    pre_top.get(2).map(fn(a) { a[0].name }),
+    content=(
+      #|Some(z)
+    ),
+  )
 }
 
 ///|
@@ -409,9 +415,12 @@ test "RC codegen: build_rc_action_maps skips invalid site strings" {
   assert_eq(pre.length(), 0)
   assert_eq(post.length(), 1)
   let post_top = post.get("").unwrap_or({})
-  inspect(post_top.get(0).map(fn(a) { a[0].name }), content=(
-    #|Some(y)
-  ))
+  inspect(
+    post_top.get(0).map(fn(a) { a[0].name }),
+    content=(
+      #|Some(y)
+    ),
+  )
 }
 
 ///|
@@ -425,24 +434,36 @@ test "RC codegen: build_rc_action_maps handles nested site paths" {
   let (pre, post) = build_rc_action_maps(actions)
   // Top-level action
   let post_top = post.get("").unwrap_or({})
-  inspect(post_top.get(0).map(fn(a) { a[0].name }), content=(
-    #|Some(x)
-  ))
+  inspect(
+    post_top.get(0).map(fn(a) { a[0].name }),
+    content=(
+      #|Some(x)
+    ),
+  )
   // Nested body action
   let post_body = post.get("stmt[2].expr.body").unwrap_or({})
-  inspect(post_body.get(0).map(fn(a) { a[0].name }), content=(
-    #|Some(y)
-  ))
+  inspect(
+    post_body.get(0).map(fn(a) { a[0].name }),
+    content=(
+      #|Some(y)
+    ),
+  )
   // Nested old_value → pre
   let pre_body = pre.get("stmt[2].expr.body").unwrap_or({})
-  inspect(pre_body.get(1).map(fn(a) { a[0].name }), content=(
-    #|Some(z)
-  ))
+  inspect(
+    pre_body.get(1).map(fn(a) { a[0].name }),
+    content=(
+      #|Some(z)
+    ),
+  )
   // Nested else action
   let post_else = post.get("stmt[3].else").unwrap_or({})
-  inspect(post_else.get(0).map(fn(a) { a[0].name }), content=(
-    #|Some(w)
-  ))
+  inspect(
+    post_else.get(0).map(fn(a) { a[0].name }),
+    content=(
+      #|Some(w)
+    ),
+  )
 }
 
 ///|

--- a/src/core/ast_walker_wbtest.mbt
+++ b/src/core/ast_walker_wbtest.mbt
@@ -24,9 +24,12 @@ test "walk_expr_refs collects free variable from Ident" {
     refs,
     add_all_refs,
   )
-  inspect(refs.keys().collect(), content=(
-    #|[x]
-  ))
+  inspect(
+    refs.keys().collect(),
+    content=(
+      #|[x]
+    ),
+  )
 }
 
 ///|
@@ -65,9 +68,12 @@ test "walk_expr_refs collects call name and arg refs" {
   )
   let keys = refs.keys().collect()
   keys.sort()
-  inspect(keys, content=(
-    #|[a, f]
-  ))
+  inspect(
+    keys,
+    content=(
+      #|[a, f]
+    ),
+  )
 }
 
 ///|
@@ -138,9 +144,12 @@ test "walk_expr_refs match arm binds pattern names" {
   let keys = refs.keys().collect()
   keys.sort()
   // "val" (scrutinee) and "f" (call), but "x" is bound by pattern
-  inspect(keys, content=(
-    #|[f, val]
-  ))
+  inspect(
+    keys,
+    content=(
+      #|[f, val]
+    ),
+  )
 }
 
 ///|
@@ -166,9 +175,12 @@ test "walk_block_refs let binding scopes correctly" {
     add_all_refs,
   )
   // "a" is free, "x" is bound by the let
-  inspect(refs.keys().collect(), content=(
-    #|[a]
-  ))
+  inspect(
+    refs.keys().collect(),
+    content=(
+      #|[a]
+    ),
+  )
 }
 
 ///|
@@ -186,9 +198,12 @@ test "bind_pattern_names_walker binds nested patterns" {
   )
   let keys = bound.keys().collect()
   keys.sort()
-  inspect(keys, content=(
-    #|[a, b]
-  ))
+  inspect(
+    keys,
+    content=(
+      #|[a, b]
+    ),
+  )
 }
 
 ///|

--- a/src/frontend/perceus_poc_wbtest.mbt
+++ b/src/frontend/perceus_poc_wbtest.mbt
@@ -185,7 +185,6 @@ test "perceus plan: unused let binding gets drop" {
     lines,
     content=(
       #|[stmt[0].after drop x]
-
     ),
   )
 }
@@ -236,7 +235,6 @@ test "perceus plan: two sequential uses, first gets dup" {
     lines,
     content=(
       #|[stmt[1].expr.arg[0].before dup x]
-
     ),
   )
 }
@@ -271,9 +269,12 @@ test "perceus plan: if/else branch-sensitive drop" {
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // x is used in then but not in else → drop in else branch
-  inspect(lines, content=(
-    #|[stmt[1].expr.else.end drop x]
-  ))
+  inspect(
+    lines,
+    content=(
+      #|[stmt[1].expr.else.end drop x]
+    ),
+  )
 }
 
 ///|
@@ -321,7 +322,6 @@ test "perceus plan: if/else both use x, then also uses after → dup" {
     lines,
     content=(
       #|[stmt[1].expr.then.stmt[0].expr.arg[0].before dup x, stmt[1].expr.else.stmt[0].expr.arg[0].before dup x]
-
     ),
   )
 }
@@ -368,7 +368,6 @@ test "perceus plan: match with two arms, only one uses x" {
     lines,
     content=(
       #|[stmt[1].expr.arm[0].pat_bind drop a, stmt[1].expr.arm[1].pat_bind drop b, stmt[1].expr.arm[1].end drop x]
-
     ),
   )
 }
@@ -402,7 +401,6 @@ test "perceus plan: scope-end drop in block" {
     lines,
     content=(
       #|[stmt[0].expr.body.stmt[0].after drop z]
-
     ),
   )
 }
@@ -430,7 +428,6 @@ test "perceus plan: mutable reassignment drops old value" {
     lines,
     content=(
       #|[stmt[0].after drop x, stmt[1].old_value drop x]
-
     ),
   )
 }
@@ -465,7 +462,6 @@ test "perceus plan: three uses need two dups" {
     lines,
     content=(
       #|[stmt[1].expr.arg[0].before dup x, stmt[2].expr.arg[0].before dup x]
-
     ),
   )
 }
@@ -698,7 +694,6 @@ test "perceus plan: multiple variables, only unused ones get drops" {
     lines,
     content=(
       #|[stmt[1].after drop y]
-
     ),
   )
 }
@@ -1029,7 +1024,6 @@ test "perceus plan: tuple field access borrows — no dup for t.0 + t.1" {
     lines,
     content=(
       #|[stmt[1].scope_end drop t]
-
     ),
   )
 }

--- a/src/parser/parser_ast_patterns.mbt
+++ b/src/parser/parser_ast_patterns.mbt
@@ -25,7 +25,7 @@ fn AstParser::parse_type_with_params(
       let mut q_suffix_count = 0
       let mut core_name = raw_name
       while core_name.length() > 0 && core_name[core_name.length() - 1] == '?' {
-        core_name = core_name.substring(start=0, end=core_name.length() - 1)
+        core_name = core_name[0:core_name.length() - 1].to_owned()
         q_suffix_count = q_suffix_count + 1
       }
       let args = self.parse_type_args(params)

--- a/src/runtime/cache.mbt
+++ b/src/runtime/cache.mbt
@@ -157,7 +157,7 @@ fn encode_value(value : @core.Value) -> String {
 fn decode_value(encoded : String) -> @core.Value? {
   if encoded.has_prefix("i:") {
     let rest = slice_from(encoded, 2)
-    let parsed : Result[Int64, @strconv.StrConvError] = try? @strconv.parse_int64(
+    let parsed : Result[Int64, Error] = try? @string.parse_int64(
       rest,
     )
     match parsed {
@@ -166,7 +166,7 @@ fn decode_value(encoded : String) -> @core.Value? {
     }
   } else if encoded.has_prefix("f32:") {
     let rest = slice_from(encoded, 4)
-    let parsed : Result[Double, @strconv.StrConvError] = try? @strconv.parse_double(
+    let parsed : Result[Double, Error] = try? @string.parse_double(
       rest,
     )
     match parsed {
@@ -175,7 +175,7 @@ fn decode_value(encoded : String) -> @core.Value? {
     }
   } else if encoded.has_prefix("f64:") {
     let rest = slice_from(encoded, 4)
-    let parsed : Result[Double, @strconv.StrConvError] = try? @strconv.parse_double(
+    let parsed : Result[Double, Error] = try? @string.parse_double(
       rest,
     )
     match parsed {
@@ -196,7 +196,7 @@ fn decode_value(encoded : String) -> @core.Value? {
     }
   } else if encoded.has_prefix("c:") {
     let rest = slice_from(encoded, 2)
-    let parsed : Result[Int, @strconv.StrConvError] = try? @strconv.parse_int(
+    let parsed : Result[Int, Error] = try? @string.parse_int(
       rest,
     )
     match parsed {

--- a/src/runtime/db_query.mbt
+++ b/src/runtime/db_query.mbt
@@ -1055,9 +1055,7 @@ pub fn VibeDb::new() -> VibeDb {
                               )
                               let import_index = @checker.ImplIndex::of(env)
                               for impl_def in impls {
-                                import_index.import_impl(
-                                  target_name, impl_def,
-                                )
+                                import_index.import_impl(target_name, impl_def)
                               }
                             }
                           }
@@ -1128,7 +1126,9 @@ pub fn VibeDb::new() -> VibeDb {
                             )
                           }
                           if trait_present {
-                            let impls = imported_env.trait_impls_for(source_name)
+                            let impls = imported_env.trait_impls_for(
+                              source_name,
+                            )
                             let import_index = @checker.ImplIndex::of(env)
                             for impl_def in impls {
                               import_index.import_impl(target_name, impl_def)

--- a/src/x/module_graph/advanced_graph_poc.mbt
+++ b/src/x/module_graph/advanced_graph_poc.mbt
@@ -158,7 +158,6 @@ fn index_map_finalize(index_map : Map[String, Array[String]]) -> Unit {
   }
 }
 
-
 ///|
 fn remove_index_id(
   index_map : Map[String, Array[String]],


### PR DESCRIPTION
## Summary

`moon check --target native --release`: **1431 → 1402 warnings**, errors still 0. No production-code semantic changes.

Bundled into one PR because the changes are mechanical and the file overlap with `moon fmt` would otherwise cause churn across two PRs.

## What's in here

### 1. `moon fmt`

Pure whitespace / line-wrap normalisation across the tree.

### 2. `@strconv.parse_*` → `@string.parse_*`

The stdlib has deprecated `@strconv.parse_int`, `parse_int64`, and `parse_double` in favour of the equivalents in `@string`. The signatures match (`StringView` in, `T raise Error` out), so it's a plain rename. Also rewrites explicit `Result[T, @strconv.StrConvError]` annotations to `Result[T, Error]` since the new functions raise the generic `Error`.

Sites: `runtime/cache.mbt`, `cmd/vibe/cli_session.mbt`, `cmd/vibe/cli_bench.mbt`, `cmd/vibe_wasm/main_wbtest.mbt`.

### 3. `String::substring(start, end)` → `str[N:M].to_owned()`

The `substring` method is deprecated in favour of slicing. All 6 sites consumed the result as `String`, so the StringView slice gets materialised with `.to_owned()` — not `.to_string()`, which would itself fire the new "Use `to_owned` to allocate an owned String from a StringView" deprecation.

Sites: `parser_ast_patterns.mbt`, `cli_check_cmd.mbt`, `cli_test_cmd.mbt`, `cli_run_cmd.mbt`, `cli_repl.mbt` (×2).

## Verification

- `moon test --release -p mizchi/vibe/cmd/vibe -f 'session*'` → 10/10
- `moon test --release -p mizchi/vibe/runtime` → 49/49
- `moon check --release` → **0 errors, 1402 warnings** (was 1431).

## Untouched (deferred)

- `Use !expr instead` (~844): mechanical `not(...)` → `!...` rewrite needs AST-aware multi-line handling; an earlier sed attempt this session broke multi-line cases at `runtime_compile/compile.mbt`.
- `Use Debug instead of Show` (146): `assert_eq` migrations across snapshot tests; partially overlaps with the renderer drift that #386 just stabilised.
- `Use to_owned ... StringView` (~317): needs per-callsite type-awareness to distinguish `String.to_string()` (fine) from `StringView.to_string()` (deprecated); not safely sed-able.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7y6q8Df9KiLNTK77zR65T)_