### PR TITLE
warnings: not(x) → !x + StringView.to_string() → .to_owned() (-1148 warnings, 144 files)

### DIFF
--- a/src/backend/exec_impl.mbt
+++ b/src/backend/exec_impl.mbt
@@ -32,7 +32,7 @@ pub fn exec_command_lines(cmd : String) -> Result[Array[String], String] {
   }
   let lines : Array[String] = []
   for part_view in text.split("\n") {
-    lines.push(part_view.to_string())
+    lines.push(part_view.to_owned())
   }
   // Remove trailing empty line from final newline
   if lines.length() > 0 && lines[lines.length() - 1] == "" {

--- a/src/backend/http_impl.mbt
+++ b/src/backend/http_impl.mbt
@@ -62,7 +62,7 @@ fn parse_headers_to_map(s : String) -> Map[String, String] {
       val_buf.clear()
       in_value = false
       skip_space = false
-    } else if not(in_value) && ch == ':' {
+    } else if !in_value && ch == ':' {
       in_value = true
       skip_space = true
     } else if skip_space && ch == ' ' {

--- a/src/benches/checker_bench.mbt
+++ b/src/benches/checker_bench.mbt
@@ -234,7 +234,7 @@ test "bench: checker.db_types.cross_module.delta" (b : @bench.T) {
   let mut toggle = false
   b.bench(fn() {
     db.set_source("./dep0.vibe", if toggle { src_a } else { src_b })
-    toggle = not(toggle)
+    toggle = !toggle
     b.keep(db.types("main").get_scheme("result"))
   })
 }

--- a/src/checker/impl_index.mbt
+++ b/src/checker/impl_index.mbt
@@ -107,10 +107,10 @@ pub fn ImplIndex::register_impl(
   target : @core.Type,
   span : @core.Span,
 ) -> Unit raise TypeError {
-  if not(self.env.has_trait(trait_name)) {
+  if !self.env.has_trait(trait_name) {
     raise TypeError::BadTypeDef(message="unknown trait: " + trait_name, span~)
   }
-  if not(self.env.trait_accepts_impl_here(trait_name)) {
+  if !self.env.trait_accepts_impl_here(trait_name) {
     raise TypeError::TraitSealed(trait_name~, span~)
   }
   ensure_unique_params(type_params, span)

--- a/src/checker/obligation_solver.mbt
+++ b/src/checker/obligation_solver.mbt
@@ -175,7 +175,7 @@ pub fn ObligationSolver::witness(
         if impl_trait_name == trait_name {
           continue
         }
-        if not(self.graph.is_subtrait(impl_trait_name, trait_name)) {
+        if !self.graph.is_subtrait(impl_trait_name, trait_name) {
           continue
         }
         match
@@ -243,7 +243,7 @@ fn obligation_solver_witness_match_any(
             match impl_def.type_bounds.get(param) {
               Some(bounds) =>
                 for bound in bounds {
-                  if not(solver.satisfies(actual_ty, bound)) {
+                  if !solver.satisfies(actual_ty, bound) {
                     ok = false
                     if first_failure is None {
                       first_failure = Some(
@@ -263,7 +263,7 @@ fn obligation_solver_witness_match_any(
             }
           None => ()
         }
-        if not(ok) {
+        if !ok {
           break
         }
       }

--- a/src/checker/prelude.mbt
+++ b/src/checker/prelude.mbt
@@ -362,7 +362,7 @@ fn prelude_add_unbound_ref(
   bound : @core.WalkerScope,
   refs : Map[String, Bool],
 ) -> Unit {
-  if not(bound.contains(name)) {
+  if !bound.contains(name) {
     refs[name] = true
   }
 }

--- a/src/checker/purity.mbt
+++ b/src/checker/purity.mbt
@@ -99,7 +99,7 @@ fn env_purity_tier(env : TypeEnv, name : String) -> TopLevelPurityTier? {
 
 ///|
 fn PurityAnalysis::is_pure(self : PurityAnalysis) -> Bool {
-  not(self.has_state_local) && not(self.has_impure)
+  !self.has_state_local && !self.has_impure
 }
 
 ///|

--- a/src/checker/trait_graph.mbt
+++ b/src/checker/trait_graph.mbt
@@ -249,7 +249,7 @@ pub fn TraitGraph::register_def(
   exported : Bool,
   span : @core.Span,
 ) -> Unit raise TypeError {
-  if open_impl && not(exported) {
+  if open_impl && !exported {
     raise TypeError::BadTypeDef(
       message="`open trait` is only allowed with export",
       span~,
@@ -262,7 +262,7 @@ pub fn TraitGraph::register_def(
     // Allow re-defining a prelude builtin trait (e.g. Eq, Hash, Ord).
     // The prelude seed soft-registers these so derive(Eq) works, but
     // user modules may redefine them via `export trait Eq`.
-    if not(is_prelude_builtin_trait(name)) {
+    if !is_prelude_builtin_trait(name) {
       raise TypeError::BadTypeDef(message="duplicate trait: " + name, span~)
     }
   }

--- a/src/checker/typecheck_call.mbt
+++ b/src/checker/typecheck_call.mbt
@@ -128,7 +128,7 @@ fn type_call(
                     effects,
                     allow_effect,
                   )
-                  if not(type_equal(env, arg_ty, items[i])) {
+                  if !type_equal(env, arg_ty, items[i]) {
                     raise TypeError::Mismatch(
                       expected=items[i],
                       actual=arg_ty,
@@ -149,7 +149,7 @@ fn type_call(
                   effects,
                   allow_effect,
                 )
-                if not(type_equal(env, arg_ty, inst.payload)) {
+                if !type_equal(env, arg_ty, inst.payload) {
                   raise TypeError::Mismatch(
                     expected=inst.payload,
                     actual=arg_ty,

--- a/src/checker/typecheck_call_builtin.mbt
+++ b/src/checker/typecheck_call_builtin.mbt
@@ -22,7 +22,7 @@ fn ensure_type(
   span : @core.Span,
   context : String,
 ) -> Unit raise TypeError {
-  if not(type_equal(env, actual, expected)) {
+  if !type_equal(env, actual, expected) {
     raise TypeError::Mismatch(expected~, actual~, span~, context=Some(context))
   }
 }
@@ -52,10 +52,8 @@ fn check_arg_string_or_prompt_text(
   allow_effect : Bool,
 ) -> @core.Type raise TypeError {
   let actual = type_expr_eff(env, expr, aliases, effects, allow_effect)
-  if not(
-      type_equal(env, actual, @core.Type::String) ||
-      type_equal(env, actual, @core.Type::PromptText),
-    ) {
+  if !(type_equal(env, actual, @core.Type::String) ||
+      type_equal(env, actual, @core.Type::PromptText)) {
     raise TypeError::Mismatch(
       expected=@core.Type::String,
       actual~,
@@ -144,7 +142,7 @@ fn ensure_map_key_hashable(
     | @core.Type::Char
     | @core.Type::String => () // primitive types are always hashable
     _ =>
-      if not(type_implements_trait(env, resolved, "Hash")) {
+      if !type_implements_trait(env, resolved, "Hash") {
         raise TypeError::Mismatch(
           expected=@core.Type::Named(name="Hash", args=[]),
           actual=resolved,
@@ -277,7 +275,7 @@ fn type_call_builtin(
     TypeError::BadCall(message=msg, span=err_span) =>
       // Only attempt UFCS when the error is "unknown function" (message == name).
       // Concrete errors like "select: unknown field: X" must propagate as-is.
-      if msg == name && not(name.contains("::")) {
+      if msg == name && !name.contains("::") {
         let ufcs_name = match @core.first_positional_expr(args) {
           None => None
           Some(expr) =>

--- a/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
+++ b/src/checker/typecheck_call_builtin_handler_collection_numeric.mbt
@@ -800,7 +800,7 @@ fn type_call_builtin_handler_collection_numeric(
         (_, @core.Type::String) => true
         _ => false
       }
-      if not(is_string) {
+      if !is_string {
         ensure_num_operand(env, a, pos_args[0].span())
       }
       // Char + Int is allowed for char arithmetic (`'A' + 1 == 'B'`); both
@@ -812,7 +812,7 @@ fn type_call_builtin_handler_collection_numeric(
         (@core.Type::Int, @core.Type::Char) => true
         _ => false
       }
-      if not(char_int_mix) && not(type_equal(env, b, a)) {
+      if !char_int_mix && !type_equal(env, b, a) {
         raise TypeError::Mismatch(
           expected=a,
           actual=b,
@@ -849,7 +849,7 @@ fn type_call_builtin_handler_collection_numeric(
           }
         _ => false
       }
-      if not(char_int_mix) && not(type_equal(env, b, a)) {
+      if !char_int_mix && !type_equal(env, b, a) {
         raise TypeError::Mismatch(
           expected=a,
           actual=b,
@@ -881,7 +881,7 @@ fn type_call_builtin_handler_collection_numeric(
           }
         _ => false
       }
-      if not(char_int_mix) && not(type_equal(env, b, a)) {
+      if !char_int_mix && !type_equal(env, b, a) {
         raise TypeError::Mismatch(
           expected=a,
           actual=b,
@@ -913,7 +913,7 @@ fn type_call_builtin_handler_collection_numeric(
           }
         _ => false
       }
-      if not(char_int_mix) && not(type_equal(env, b, a)) {
+      if !char_int_mix && !type_equal(env, b, a) {
         raise TypeError::Mismatch(
           expected=a,
           actual=b,
@@ -930,7 +930,7 @@ fn type_call_builtin_handler_collection_numeric(
       }
       let a = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
       let b = type_expr_eff(env, pos_args[1], aliases, effects, allow_effect)
-      if not(type_equal(env, a, @core.Type::Int)) {
+      if !type_equal(env, a, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=a,
@@ -938,7 +938,7 @@ fn type_call_builtin_handler_collection_numeric(
           context=Some("bit operation"),
         )
       }
-      if not(type_equal(env, b, @core.Type::Int)) {
+      if !type_equal(env, b, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=b,
@@ -955,7 +955,7 @@ fn type_call_builtin_handler_collection_numeric(
       }
       let a = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
       let b = type_expr_eff(env, pos_args[1], aliases, effects, allow_effect)
-      if not(type_equal(env, a, @core.Type::Bool)) {
+      if !type_equal(env, a, @core.Type::Bool) {
         raise TypeError::Mismatch(
           expected=@core.Type::Bool,
           actual=a,
@@ -963,7 +963,7 @@ fn type_call_builtin_handler_collection_numeric(
           context=Some("boolean operation"),
         )
       }
-      if not(type_equal(env, b, @core.Type::Bool)) {
+      if !type_equal(env, b, @core.Type::Bool) {
         raise TypeError::Mismatch(
           expected=@core.Type::Bool,
           actual=b,
@@ -979,7 +979,7 @@ fn type_call_builtin_handler_collection_numeric(
         raise TypeError::BadCall(message="__not", span=call_span)
       }
       let a = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
-      if not(type_equal(env, a, @core.Type::Bool)) {
+      if !type_equal(env, a, @core.Type::Bool) {
         raise TypeError::Mismatch(
           expected=@core.Type::Bool,
           actual=a,
@@ -1087,7 +1087,7 @@ fn type_call_builtin_handler_collection_numeric(
       let resolved_container = resolve_type(env, container_ty)
       match resolved_container {
         @core.Type::Array(_) => {
-          if not(type_equal(env, index_ty, @core.Type::Int)) {
+          if !type_equal(env, index_ty, @core.Type::Int) {
             raise TypeError::Mismatch(
               expected=@core.Type::Int,
               actual=index_ty,
@@ -1095,9 +1095,7 @@ fn type_call_builtin_handler_collection_numeric(
               context=Some("index"),
             )
           }
-          if not(
-              type_equal(env, resolved_container, @core.Type::Array(elem_ty)),
-            ) {
+          if !type_equal(env, resolved_container, @core.Type::Array(elem_ty)) {
             raise TypeError::Mismatch(
               expected=@core.Type::Array(elem_ty),
               actual=resolved_container,
@@ -1110,13 +1108,11 @@ fn type_call_builtin_handler_collection_numeric(
         @core.Type::Map(key_ty, _) => {
           ensure_type(env, index_ty, key_ty, pos_args[1].span(), "index")
           ensure_map_key_hashable(env, index_ty, pos_args[1].span())
-          if not(
-              type_equal(
+          if !type_equal(
                 env,
                 resolved_container,
                 @core.Type::Map(key_ty, elem_ty),
-              ),
-            ) {
+              ) {
             raise TypeError::Mismatch(
               expected=@core.Type::Map(key_ty, elem_ty),
               actual=resolved_container,
@@ -1127,7 +1123,7 @@ fn type_call_builtin_handler_collection_numeric(
           elem_ty
         }
         @core.Type::Record(fields) => {
-          if not(type_equal(env, index_ty, @core.Type::String)) {
+          if !type_equal(env, index_ty, @core.Type::String) {
             raise TypeError::Mismatch(
               expected=@core.Type::String,
               actual=index_ty,
@@ -1155,7 +1151,7 @@ fn type_call_builtin_handler_collection_numeric(
         @core.Type::Named(name~, args=type_args) =>
           match env.get_struct(name) {
             Some(struct_def) => {
-              if not(type_equal(env, index_ty, @core.Type::String)) {
+              if !type_equal(env, index_ty, @core.Type::String) {
                 raise TypeError::Mismatch(
                   expected=@core.Type::String,
                   actual=index_ty,
@@ -1195,7 +1191,7 @@ fn type_call_builtin_handler_collection_numeric(
               )
           }
         @core.Type::String => {
-          if not(type_equal(env, index_ty, @core.Type::Int)) {
+          if !type_equal(env, index_ty, @core.Type::Int) {
             raise TypeError::Mismatch(
               expected=@core.Type::Int,
               actual=index_ty,
@@ -1206,7 +1202,7 @@ fn type_call_builtin_handler_collection_numeric(
           @core.Type::String
         }
         @core.Type::Bytes => {
-          if not(type_equal(env, index_ty, @core.Type::Int)) {
+          if !type_equal(env, index_ty, @core.Type::Int) {
             raise TypeError::Mismatch(
               expected=@core.Type::Int,
               actual=index_ty,
@@ -1296,7 +1292,7 @@ fn type_call_builtin_handler_collection_numeric(
       let a = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
       let b = type_expr_eff(env, pos_args[1], aliases, effects, allow_effect)
       // Unify types first so type variables resolve before Eq check
-      if not(type_equal(env, b, a)) && not(int_char_comparable_pair(env, a, b)) {
+      if !type_equal(env, b, a) && !int_char_comparable_pair(env, a, b) {
         raise TypeError::Mismatch(
           expected=a,
           actual=b,
@@ -1316,7 +1312,7 @@ fn type_call_builtin_handler_collection_numeric(
       }
       let a = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
       let b = type_expr_eff(env, pos_args[1], aliases, effects, allow_effect)
-      if not(type_equal(env, b, a)) && not(int_char_comparable_pair(env, a, b)) {
+      if !type_equal(env, b, a) && !int_char_comparable_pair(env, a, b) {
         raise TypeError::Mismatch(
           expected=a,
           actual=b,
@@ -1334,7 +1330,7 @@ fn type_call_builtin_handler_collection_numeric(
       let a = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
       let b = type_expr_eff(env, pos_args[1], aliases, effects, allow_effect)
       // Unify types first so type variables resolve before Ord check
-      if not(type_equal(env, b, a)) && not(int_char_comparable_pair(env, a, b)) {
+      if !type_equal(env, b, a) && !int_char_comparable_pair(env, a, b) {
         raise TypeError::Mismatch(
           expected=a,
           actual=b,

--- a/src/checker/typecheck_call_builtin_handler_core_io.mbt
+++ b/src/checker/typecheck_call_builtin_handler_core_io.mbt
@@ -104,7 +104,7 @@ fn type_call_builtin_handler_core_io(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, arg_ty, @core.Type::String)) {
+      if !type_equal(env, arg_ty, @core.Type::String) {
         raise TypeError::Mismatch(
           expected=@core.Type::String,
           actual=arg_ty,
@@ -115,7 +115,7 @@ fn type_call_builtin_handler_core_io(
       // Validate labeled args are all Bool
       for larg in label_args {
         let lty = type_expr_eff(env, larg.expr, aliases, effects, allow_effect)
-        if not(type_equal(env, lty, @core.Type::Bool)) {
+        if !type_equal(env, lty, @core.Type::Bool) {
           raise TypeError::Mismatch(
             expected=@core.Type::Bool,
             actual=lty,
@@ -147,7 +147,7 @@ fn type_call_builtin_handler_core_io(
           effects,
           allow_effect,
         )
-        if not(type_equal(env, arg_ty, @core.Type::String)) {
+        if !type_equal(env, arg_ty, @core.Type::String) {
           raise TypeError::Mismatch(
             expected=@core.Type::String,
             actual=arg_ty,
@@ -264,7 +264,7 @@ fn type_call_builtin_handler_core_io(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, name_ty, @core.Type::String)) {
+      if !type_equal(env, name_ty, @core.Type::String) {
         raise TypeError::Mismatch(
           expected=@core.Type::String,
           actual=name_ty,
@@ -279,7 +279,7 @@ fn type_call_builtin_handler_core_io(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, mailbox_ty, @core.Type::Int)) {
+      if !type_equal(env, mailbox_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=mailbox_ty,

--- a/src/checker/typecheck_call_builtin_handler_runtime_memory.mbt
+++ b/src/checker/typecheck_call_builtin_handler_runtime_memory.mbt
@@ -16,7 +16,7 @@ fn type_call_builtin_handler_runtime_memory(
         raise TypeError::BadCall(message="__assert", span=call_span)
       }
       let a = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
-      if not(type_equal(env, a, @core.Type::Bool)) {
+      if !type_equal(env, a, @core.Type::Bool) {
         raise TypeError::Mismatch(
           expected=@core.Type::Bool,
           actual=a,
@@ -42,7 +42,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, field_ty, @core.Type::String)) {
+      if !type_equal(env, field_ty, @core.Type::String) {
         raise TypeError::Mismatch(
           expected=@core.Type::String,
           actual=field_ty,
@@ -63,7 +63,7 @@ fn type_call_builtin_handler_runtime_memory(
             @core.Expr::String(value=name, span~) =>
               match fields.get(name) {
                 Some(expect) =>
-                  if not(type_equal(env, expect, value_ty)) {
+                  if !type_equal(env, expect, value_ty) {
                     raise TypeError::Mismatch(
                       expected=expect,
                       actual=value_ty,
@@ -197,7 +197,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, start_ty, @core.Type::Int)) {
+      if !type_equal(env, start_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=start_ty,
@@ -212,7 +212,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, end_ty, @core.Type::Int)) {
+      if !type_equal(env, end_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=end_ty,
@@ -373,7 +373,7 @@ fn type_call_builtin_handler_runtime_memory(
       }
       let a = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
       let b = type_expr_eff(env, pos_args[1], aliases, effects, allow_effect)
-      if not(type_equal(env, a, @core.Type::Int)) {
+      if !type_equal(env, a, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=a,
@@ -381,7 +381,7 @@ fn type_call_builtin_handler_runtime_memory(
           context=Some("bit operation"),
         )
       }
-      if not(type_equal(env, b, @core.Type::Int)) {
+      if !type_equal(env, b, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=b,
@@ -439,7 +439,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, base_ty, @core.Type::Int)) {
+      if !type_equal(env, base_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=base_ty,
@@ -454,7 +454,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, offset_ty, @core.Type::Int)) {
+      if !type_equal(env, offset_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=offset_ty,
@@ -476,7 +476,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, base_ty, @core.Type::Int)) {
+      if !type_equal(env, base_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=base_ty,
@@ -491,7 +491,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, offset_ty, @core.Type::Int)) {
+      if !type_equal(env, offset_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=offset_ty,
@@ -506,7 +506,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, value_ty, @core.Type::Int)) {
+      if !type_equal(env, value_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=value_ty,
@@ -528,7 +528,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, base_ty, @core.Type::Int)) {
+      if !type_equal(env, base_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=base_ty,
@@ -543,7 +543,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, offset_ty, @core.Type::Int)) {
+      if !type_equal(env, offset_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=offset_ty,
@@ -565,7 +565,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, base_ty, @core.Type::Int)) {
+      if !type_equal(env, base_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=base_ty,
@@ -580,7 +580,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, offset_ty, @core.Type::Int)) {
+      if !type_equal(env, offset_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=offset_ty,
@@ -602,7 +602,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, base_ty, @core.Type::Int)) {
+      if !type_equal(env, base_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=base_ty,
@@ -617,7 +617,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, offset_ty, @core.Type::Int)) {
+      if !type_equal(env, offset_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=offset_ty,
@@ -632,7 +632,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, value_ty, @core.Type::Float)) {
+      if !type_equal(env, value_ty, @core.Type::Float) {
         raise TypeError::Mismatch(
           expected=@core.Type::Float,
           actual=value_ty,
@@ -654,7 +654,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, base_ty, @core.Type::Int)) {
+      if !type_equal(env, base_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=base_ty,
@@ -669,7 +669,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, offset_ty, @core.Type::Int)) {
+      if !type_equal(env, offset_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=offset_ty,
@@ -684,7 +684,7 @@ fn type_call_builtin_handler_runtime_memory(
         effects,
         allow_effect,
       )
-      if not(type_equal(env, value_ty, @core.Type::Double)) {
+      if !type_equal(env, value_ty, @core.Type::Double) {
         raise TypeError::Mismatch(
           expected=@core.Type::Double,
           actual=value_ty,

--- a/src/checker/typecheck_effects_set.mbt
+++ b/src/checker/typecheck_effects_set.mbt
@@ -56,7 +56,7 @@ fn normalize_effects(
   for effect in effects {
     match effect {
       @core.EffectAtom::Const(name) =>
-        if not(seen.contains(name)) {
+        if !seen.contains(name) {
           seen[name] = true
           out.push(effect)
         }
@@ -174,7 +174,7 @@ fn effect_consts_subset(
   large : Map[String, Bool],
 ) -> Bool {
   for name, _ in small {
-    if not(large.contains(name)) {
+    if !large.contains(name) {
       return false
     }
   }
@@ -196,7 +196,7 @@ fn effect_consts_minus(
 ) -> Map[String, Bool] {
   let out : Map[String, Bool] = {}
   for name, _ in left {
-    if not(right.contains(name)) {
+    if !right.contains(name) {
       out[name] = true
     }
   }

--- a/src/checker/typecheck_env_bindings.mbt
+++ b/src/checker/typecheck_env_bindings.mbt
@@ -157,7 +157,7 @@ fn update_scoped_ref_binding_flag(
   name : String,
   scheme : TypeScheme,
 ) -> Unit {
-  if not(env.scoped_ref_checks_enabled) {
+  if !env.scoped_ref_checks_enabled {
     return
   }
   if env.has_scoped_ref_binding {
@@ -168,7 +168,7 @@ fn update_scoped_ref_binding_flag(
     @core.has_qualified_name(name) {
     return
   }
-  if not(type_may_contain_scoped_ref_hint(scheme.ty)) {
+  if !type_may_contain_scoped_ref_hint(scheme.ty) {
     return
   }
   env.scoped_ref_binding_scan_stale = true
@@ -176,12 +176,12 @@ fn update_scoped_ref_binding_flag(
 
 ///|
 fn refresh_scoped_ref_binding_flag(env : TypeEnv) -> Unit {
-  if not(env.scoped_ref_checks_enabled) {
+  if !env.scoped_ref_checks_enabled {
     env.has_scoped_ref_binding = false
     env.scoped_ref_binding_scan_stale = false
     return
   }
-  if env.has_scoped_ref_binding || not(env.scoped_ref_binding_scan_stale) {
+  if env.has_scoped_ref_binding || !env.scoped_ref_binding_scan_stale {
     return
   }
   let mut found = false
@@ -205,7 +205,7 @@ fn refresh_scoped_ref_binding_flag(env : TypeEnv) -> Unit {
 
 ///|
 pub fn TypeEnv::has_scoped_ref_binding_for_capture(self : TypeEnv) -> Bool {
-  if not(self.scoped_ref_checks_enabled) {
+  if !self.scoped_ref_checks_enabled {
     return false
   }
   refresh_scoped_ref_binding_flag(self)

--- a/src/checker/typecheck_env_generalize.mbt
+++ b/src/checker/typecheck_env_generalize.mbt
@@ -15,10 +15,10 @@ fn generalize(env : TypeEnv, ty : @core.Type) -> TypeScheme raise TypeError {
     }
   }
   let vars : Array[Int] = []
-  if not(free_ty.is_empty()) {
+  if !free_ty.is_empty() {
     let free_env = free_vars_in_env(env)
     for id, _ in free_ty {
-      if not(free_env.contains(id)) {
+      if !free_env.contains(id) {
         vars.push(id)
       }
     }
@@ -30,10 +30,10 @@ fn generalize(env : TypeEnv, ty : @core.Type) -> TypeScheme raise TypeError {
     }
   }
   let effect_vars : Array[String] = []
-  if not(free_effects.is_empty()) {
+  if !free_effects.is_empty() {
     let free_effect_env = free_effect_vars_in_env(env)
     for name, _ in free_effects {
-      if not(free_effect_env.contains(name)) {
+      if !free_effect_env.contains(name) {
         effect_vars.push(name)
       }
     }

--- a/src/checker/typecheck_env_namespace.mbt
+++ b/src/checker/typecheck_env_namespace.mbt
@@ -12,7 +12,7 @@ pub fn TypeEnv::variant_namespace_root(
         }
         let mut all_match = true
         for ctor in enum_def.ctors {
-          if not(fields.contains(ctor.name)) {
+          if !fields.contains(ctor.name) {
             all_match = false
             break
           }

--- a/src/checker/typecheck_env_substitution.mbt
+++ b/src/checker/typecheck_env_substitution.mbt
@@ -11,7 +11,7 @@ fn instantiate_scheme(env : TypeEnv, scheme : TypeScheme) -> @core.Type {
       mapping[id] = fresh_type_var(env)
     }
   }
-  if not(scheme.trait_bounds.is_empty()) {
+  if !scheme.trait_bounds.is_empty() {
     for id in scheme.vars {
       match mapping.get(id) {
         Some(@core.Type::Var(new_id)) =>
@@ -152,7 +152,7 @@ fn transform_type_structure(
       let out : Array[@core.Type] = []
       let mut changed = false
       for item in items {
-        if not(changed) && not(has_target(item)) {
+        if !changed && !has_target(item) {
           out.push(item)
         } else {
           out.push(walk(item))
@@ -271,7 +271,7 @@ fn transform_type_structure(
       let out : Array[@core.Type] = []
       let mut changed = false
       for arg in args {
-        if not(changed) && not(has_target(arg)) {
+        if !changed && !has_target(arg) {
           out.push(arg)
         } else {
           out.push(walk(arg))
@@ -323,7 +323,7 @@ fn resolve_type(env : TypeEnv, ty : @core.Type) -> @core.Type {
   if env.subs.is_empty() {
     return ty
   }
-  if not(type_has_substitutable_var(env, ty)) {
+  if !type_has_substitutable_var(env, ty) {
     return ty
   }
   resolve_type_walk(env, ty)
@@ -353,7 +353,7 @@ fn substitute_type_vars(
   ty : @core.Type,
   subs : Map[Int, @core.Type],
 ) -> @core.Type {
-  if subs.is_empty() || not(type_has_var_in_map(ty, subs)) {
+  if subs.is_empty() || !type_has_var_in_map(ty, subs) {
     return ty
   }
   substitute_type_vars_walk(ty, subs)
@@ -384,7 +384,7 @@ fn substitute_effect_vars(
   ty : @core.Type,
   subs : Map[String, String],
 ) -> @core.Type {
-  if subs.is_empty() || not(type_has_effect_var_in_map(ty, subs)) {
+  if subs.is_empty() || !type_has_effect_var_in_map(ty, subs) {
     return ty
   }
   substitute_effect_vars_walk(ty, subs)
@@ -457,7 +457,7 @@ fn substitute_type(
   ty : @core.Type,
   subs : Map[String, @core.Type],
 ) -> @core.Type {
-  if subs.is_empty() || not(type_has_param_in_map(ty, subs)) {
+  if subs.is_empty() || !type_has_param_in_map(ty, subs) {
     return ty
   }
   substitute_type_walk(ty, subs)

--- a/src/checker/typecheck_env_typevars.mbt
+++ b/src/checker/typecheck_env_typevars.mbt
@@ -40,7 +40,7 @@ fn dedup_trait_bounds(bounds : Array[String]) -> Array[String] {
   let seen : Map[String, Bool] = {}
   let out : Array[String] = []
   for bound in bounds {
-    if not(seen.contains(bound)) {
+    if !seen.contains(bound) {
       seen[bound] = true
       out.push(bound)
     }

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -105,7 +105,7 @@ fn collect_perform_ops_expr(expr : @core.Expr, ops : Array[String]) -> Unit {
 fn extract_effect_name(qualified : String) -> String {
   for i = 0; i + 1 < qualified.length(); i = i + 1 {
     if qualified[i] == ':' && qualified[i + 1] == ':' {
-      return qualified[0:i].to_string()
+      return qualified[0:i].to_owned()
     }
   }
   qualified
@@ -128,8 +128,8 @@ fn reh_resolve_effect_op_params(
   if sep < 0 {
     return None
   }
-  let effect_name = qualified_name[0:sep].to_string()
-  let op_name = qualified_name[sep + 2:qualified_name.length()].to_string()
+  let effect_name = qualified_name[0:sep].to_owned()
+  let op_name = qualified_name[sep + 2:qualified_name.length()].to_owned()
   match env.effect_defs.get(effect_name) {
     Some(effect_def) =>
       match effect_def.ops.get(op_name) {
@@ -248,10 +248,10 @@ fn ensure_no_scoped_ref_capture_in_fn(
   body : @core.Module,
   span : @core.Span,
 ) -> Unit raise TypeError {
-  if not(env.scoped_ref_checks_enabled) {
+  if !env.scoped_ref_checks_enabled {
     return
   }
-  if not(env.has_scoped_ref_binding_for_capture()) {
+  if !env.has_scoped_ref_binding_for_capture() {
     return
   }
   let bound = @core.WalkerScope::new()
@@ -287,7 +287,7 @@ fn ensure_no_scoped_ref_param_decl(
   param_ty : @core.Type,
   span : @core.Span,
 ) -> Unit raise TypeError {
-  if not(env.scoped_ref_checks_enabled) {
+  if !env.scoped_ref_checks_enabled {
     return
   }
   if type_contains_scoped_ref(env, param_ty) {
@@ -355,7 +355,7 @@ fn type_struct_lit(
               field_def.ty,
               type_map,
             )
-            if not(type_equal(env, expected, field_ty)) {
+            if !type_equal(env, expected, field_ty) {
               raise TypeError::Mismatch(
                 expected~,
                 actual=field_ty,
@@ -373,7 +373,7 @@ fn type_struct_lit(
       }
       // Check all required fields are provided
       for field_def in struct_def.fields {
-        if not(provided.contains(field_def.name)) {
+        if !provided.contains(field_def.name) {
           raise TypeError::BadTypeDef(
             message="missing field: " + field_def.name,
             span~,
@@ -403,7 +403,7 @@ fn infer_type_params_from_field(
 ) -> Unit {
   match expected {
     @core.Type::Param(param_name) =>
-      if not(type_map.contains(param_name)) {
+      if !type_map.contains(param_name) {
         type_map[param_name] = actual
       }
     @core.Type::Array(inner) =>
@@ -575,7 +575,7 @@ fn type_perform_expr(
   if env.handle_resume_types_active {
     match env.handle_resume_types.get(effect_name) {
       Some(expected_ty) =>
-        if not(type_equal(env, expected_ty, ret_ty)) {
+        if !type_equal(env, expected_ty, ret_ty) {
           raise TypeError::Mismatch(
             expected=expected_ty,
             actual=ret_ty,
@@ -606,7 +606,7 @@ fn type_resume_expr(
     raise TypeError::BadCall(message="resume used outside handle arm", span~)
   }
   let arg_ty = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
-  if not(env.handle_resume_types_active) {
+  if !env.handle_resume_types_active {
     raise TypeError::BadCall(
       message="resume used outside resumable handle",
       span~,
@@ -620,8 +620,8 @@ fn type_resume_expr(
   match env.handle_arm_resume_expected {
     Some(expected_ty) =>
       // Allow Int → Unit coercion (resume(0) for Unit-returning ops)
-      if not(type_equal(env, expected_ty, arg_ty)) &&
-        not(expected_ty is @core.Type::Unit) {
+      if !type_equal(env, expected_ty, arg_ty) &&
+        !(expected_ty is @core.Type::Unit) {
         raise TypeError::Mismatch(
           expected=expected_ty,
           actual=arg_ty,
@@ -633,8 +633,8 @@ fn type_resume_expr(
   }
   match env.handle_resume_types.get(effect_name) {
     Some(expected_ty) =>
-      if not(type_equal(env, expected_ty, arg_ty)) &&
-        not(expected_ty is @core.Type::Unit) {
+      if !type_equal(env, expected_ty, arg_ty) &&
+        !(expected_ty is @core.Type::Unit) {
         raise TypeError::Mismatch(
           expected=expected_ty,
           actual=arg_ty,
@@ -657,7 +657,7 @@ fn type_handle_arm_expr(
 ) -> @core.Type raise TypeError {
   if arm.cond is Some(c) {
     let g_ty = type_expr_eff(env, c, aliases, effects, allow_effect)
-    if not(type_equal(env, g_ty, @core.Type::Bool)) {
+    if !type_equal(env, g_ty, @core.Type::Bool) {
       raise TypeError::Mismatch(
         expected=@core.Type::Bool,
         actual=g_ty,
@@ -831,7 +831,7 @@ fn type_expr_eff(
             }
             _ => type_expr_eff(env, items[i], aliases, effects, allow_effect)
           }
-          if not(type_equal(env, elem_ty, item_ty)) {
+          if !type_equal(env, elem_ty, item_ty) {
             raise TypeError::Mismatch(
               expected=elem_ty,
               actual=item_ty,
@@ -869,7 +869,7 @@ fn type_expr_eff(
             effects,
             allow_effect,
           )
-          if not(type_equal(env, val_ty, item_ty)) {
+          if !type_equal(env, val_ty, item_ty) {
             raise TypeError::Mismatch(
               expected=val_ty,
               actual=item_ty,
@@ -883,7 +883,7 @@ fn type_expr_eff(
     }
     @core.Expr::If(cond~, then_body~, else_body~, span~) => {
       let cond_ty = type_expr_eff(env, cond, aliases, effects, allow_effect)
-      if not(type_equal(env, cond_ty, @core.Type::Bool)) {
+      if !type_equal(env, cond_ty, @core.Type::Bool) {
         raise TypeError::Mismatch(
           expected=@core.Type::Bool,
           actual=cond_ty,
@@ -893,7 +893,7 @@ fn type_expr_eff(
       }
       let then_ty = type_block(env, then_body, aliases, effects, allow_effect)
       let else_ty = type_block(env, else_body, aliases, effects, allow_effect)
-      if not(type_equal(env, then_ty, else_ty)) {
+      if !type_equal(env, then_ty, else_ty) {
         raise TypeError::Mismatch(
           expected=then_ty,
           actual=else_ty,
@@ -946,7 +946,7 @@ fn type_expr_eff(
     @core.Expr::While(cond~, body~, span~) => {
       let _ = span
       let cond_ty = type_expr_eff(env, cond, aliases, effects, allow_effect)
-      if not(type_equal(env, cond_ty, @core.Type::Bool)) {
+      if !type_equal(env, cond_ty, @core.Type::Bool) {
         raise TypeError::Mismatch(
           expected=@core.Type::Bool,
           actual=cond_ty,
@@ -1158,7 +1158,7 @@ fn type_handle_block(
   }
   for op_name in body_performs {
     let eff = extract_effect_name(op_name)
-    if handled_effect_set.contains(eff) && not(handled_ops.contains(op_name)) {
+    if handled_effect_set.contains(eff) && !handled_ops.contains(op_name) {
       raise TypeError::BadTypeDef(
         message="handle is missing handler for `" +
           op_name +
@@ -1173,7 +1173,7 @@ fn type_handle_block(
   let inferred_resume_types = body_resume_types.copy()
   let escaping_resume_types : Map[String, @core.Type] = {}
   for effect_name, resume_ty in body_resume_types {
-    if not(handled_effect_names.contains(effect_name)) {
+    if !handled_effect_names.contains(effect_name) {
       escaping_resume_types[effect_name] = resume_ty
     }
   }
@@ -1207,7 +1207,7 @@ fn type_handle_block(
       }
       match escaping_resume_types.get(effect_name) {
         Some(existing) =>
-          if not(type_equal(arm_env, existing, resume_ty)) {
+          if !type_equal(arm_env, existing, resume_ty) {
             raise TypeError::Mismatch(
               expected=existing,
               actual=resume_ty,
@@ -1218,7 +1218,7 @@ fn type_handle_block(
         None => escaping_resume_types[effect_name] = resume_ty
       }
     }
-    if not(type_equal(arm_env, body_ty, arm_ty)) {
+    if !type_equal(arm_env, body_ty, arm_ty) {
       raise TypeError::Mismatch(
         expected=body_ty,
         actual=arm_ty,
@@ -1231,7 +1231,7 @@ fn type_handle_block(
     for effect_name, resume_ty in escaping_resume_types {
       match env.handle_resume_types.get(effect_name) {
         Some(existing) =>
-          if not(type_equal(env, existing, resume_ty)) {
+          if !type_equal(env, existing, resume_ty) {
             raise TypeError::Mismatch(
               expected=existing,
               actual=resume_ty,
@@ -1329,7 +1329,7 @@ fn type_match_block(
     match arm.cond {
       Some(c) => {
         let g_ty = type_expr_eff(arm_env, c, aliases, effects, allow_effect)
-        if not(type_equal(env, g_ty, @core.Type::Bool)) {
+        if !type_equal(env, g_ty, @core.Type::Bool) {
           raise TypeError::Mismatch(
             expected=@core.Type::Bool,
             actual=g_ty,
@@ -1349,7 +1349,7 @@ fn type_match_block(
     )
     match result {
       Some(t) =>
-        if not(type_equal(env, t, arm_ty)) {
+        if !type_equal(env, t, arm_ty) {
           raise TypeError::Mismatch(
             expected=t,
             actual=arm_ty,
@@ -1360,12 +1360,12 @@ fn type_match_block(
       None => result = Some(arm_ty)
     }
   }
-  if not(has_wildcard) {
+  if !has_wildcard {
     match scrutinee_ty_for_exhaust {
       @core.Type::Variant(types) => {
         let missing_names : Array[String] = []
         for name, _ in types {
-          if not(covered.contains(name)) {
+          if !covered.contains(name) {
             missing_names.push(name)
           }
         }
@@ -1375,18 +1375,18 @@ fn type_match_block(
       }
       @core.Type::Bool => {
         let missing_names : Array[String] = []
-        if not(covered_true) {
+        if !covered_true {
           missing_names.push("true")
         }
-        if not(covered_false) {
+        if !covered_false {
           missing_names.push("false")
         }
-        if not(has_bool_pat && covered_true && covered_false) {
+        if !(has_bool_pat && covered_true && covered_false) {
           raise TypeError::NonExhaustiveMatch(missing=missing_names, span~)
         }
       }
       _ =>
-        if not(has_ctor) {
+        if !has_ctor {
           raise TypeError::NonExhaustiveMatch(missing=[], span~)
         }
     }
@@ -1434,7 +1434,7 @@ fn type_fn_literal(
       break
     }
   }
-  if not(uses_num) {
+  if !uses_num {
     match ret {
       Some(r) => uses_num = has_num_type(r)
       None => ()
@@ -1535,7 +1535,7 @@ fn type_fn_literal(
         }
         let ret_ty = substitute_type_params(ret_ty_with_num, type_param_vars)
         let resolved = normalize_type(env, ret_ty)
-        if not(type_equal(env, resolved, body_ty)) {
+        if !type_equal(env, resolved, body_ty) {
           raise TypeError::Mismatch(
             expected=resolved,
             actual=body_ty,
@@ -1561,7 +1561,7 @@ fn type_fn_literal(
             _ => ()
           }
         }
-        if not(already) {
+        if !already {
           merged.push(@core.EffectAtom::Const(name))
         }
       }
@@ -1588,7 +1588,7 @@ fn type_perform_effect(
   effects : EffectScope,
   allow_effect : Bool,
 ) -> @core.Type raise TypeError {
-  if not(effect_scope_allows(effects, effect_name)) {
+  if !effect_scope_allows(effects, effect_name) {
     if allow_effect {
       raise TypeError::EffectGuardNotSatisfied(
         operation="perform " + effect_name + "::" + op_name,
@@ -1633,7 +1633,7 @@ fn type_perform_effect(
                 effects,
                 allow_effect,
               )
-              if not(unify_types(env, arg_ty, inst_params[i])) {
+              if !unify_types(env, arg_ty, inst_params[i]) {
                 raise TypeError::Mismatch(
                   expected=inst_params[i],
                   actual=arg_ty,
@@ -1882,7 +1882,7 @@ fn type_block(
         match scope_env.get_scheme(name) {
           Some(scheme) => {
             let expected = instantiate_scheme(scope_env, scheme)
-            if not(type_equal(scope_env, expected, ty)) {
+            if !type_equal(scope_env, expected, ty) {
               raise TypeError::Mismatch(
                 expected~,
                 actual=ty,
@@ -2010,7 +2010,7 @@ fn ensure_eq_operand(
       // ADR-0045: surface the TraitWitness reason so a missing `derive(Eq)`
       // hints at the actual fix instead of just "expected Eq, actual Vec2".
       let w = ObligationSolver::of(env).witness(resolved, "Eq")
-      if not(w.is_satisfied()) {
+      if !w.is_satisfied() {
         let extra = w.message()
         let ctx = if extra == "" { "argument" } else { "argument: " + extra }
         raise TypeError::Mismatch(
@@ -2050,7 +2050,7 @@ fn ensure_ord_operand(
       } else {
         match env.var_trait_bounds.get(id) {
           Some(bounds) =>
-            if not(trait_bound_satisfied(env, bounds, "Ord")) {
+            if !trait_bound_satisfied(env, bounds, "Ord") {
               raise TypeError::Mismatch(
                 expected=@core.Type::Named(name="Ord", args=[]),
                 actual=resolved,
@@ -2102,12 +2102,12 @@ fn int_char_comparable_pair(
 
 ///|
 fn parse_type_member_decl(name : String) -> (String, String)? {
-  if not(name.contains("::")) {
+  if !name.contains("::") {
     return None
   }
   let parts : Array[String] = []
   for part_view in name.split("::") {
-    parts.push(part_view.to_string())
+    parts.push(part_view.to_owned())
   }
   if parts.length() != 2 {
     return None
@@ -2146,7 +2146,7 @@ fn ensure_type_member_decl_receiver_contract(
     None => ()
     Some((type_name, member_name)) => {
       let _ = member_name
-      if not(should_enforce_type_member_decl_contract(env, type_name)) {
+      if !should_enforce_type_member_decl_contract(env, type_name) {
         return
       }
       let resolved = normalize_type(env, ty)
@@ -2219,7 +2219,7 @@ fn type_check_unary_convert(
     raise TypeError::BadCall(message=name, span=call_span)
   }
   let arg_ty = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
-  if not(type_equal(env, arg_ty, from_ty)) {
+  if !type_equal(env, arg_ty, from_ty) {
     raise TypeError::Mismatch(
       expected=from_ty,
       actual=arg_ty,
@@ -2248,7 +2248,7 @@ fn type_check_binary_exact(
     raise TypeError::BadCall(message=name, span=call_span)
   }
   let left_ty = type_expr_eff(env, pos_args[0], aliases, effects, allow_effect)
-  if not(type_equal(env, left_ty, left_expect)) {
+  if !type_equal(env, left_ty, left_expect) {
     raise TypeError::Mismatch(
       expected=left_expect,
       actual=left_ty,
@@ -2257,7 +2257,7 @@ fn type_check_binary_exact(
     )
   }
   let right_ty = type_expr_eff(env, pos_args[1], aliases, effects, allow_effect)
-  if not(type_equal(env, right_ty, right_expect)) {
+  if !type_equal(env, right_ty, right_expect) {
     raise TypeError::Mismatch(
       expected=right_expect,
       actual=right_ty,
@@ -2283,13 +2283,13 @@ fn is_non_expansive_expr(
     @core.Expr::String(..) => true
     @core.Expr::Ident(name~, span~) => {
       let _ = span
-      not(has_alias_prefix(name, aliases))
+      !has_alias_prefix(name, aliases)
     }
     @core.Expr::Tuple(items~, span~) => {
       let _ = span
       let mut ok = true
       for item in items {
-        if not(is_non_expansive_expr(env, item, aliases)) {
+        if !is_non_expansive_expr(env, item, aliases) {
           ok = false
           break
         }
@@ -2302,7 +2302,7 @@ fn is_non_expansive_expr(
       let _ = span
       let mut ok = true
       for field in fields {
-        if not(is_non_expansive_expr(env, field.expr, aliases)) {
+        if !is_non_expansive_expr(env, field.expr, aliases) {
           ok = false
           break
         }
@@ -2313,7 +2313,7 @@ fn is_non_expansive_expr(
       let _ = span
       let mut ok = true
       for item in items {
-        if not(is_non_expansive_expr(env, item, aliases)) {
+        if !is_non_expansive_expr(env, item, aliases) {
           ok = false
           break
         }
@@ -2324,7 +2324,7 @@ fn is_non_expansive_expr(
       let _ = span
       let mut ok = true
       for field in fields {
-        if not(is_non_expansive_expr(env, field.expr, aliases)) {
+        if !is_non_expansive_expr(env, field.expr, aliases) {
           ok = false
           break
         }
@@ -2339,7 +2339,7 @@ fn is_non_expansive_expr(
       } else if @core.is_ctor_name(name) {
         let mut ok = true
         for arg in args {
-          if not(is_non_expansive_expr(env, arg.expr, aliases)) {
+          if !is_non_expansive_expr(env, arg.expr, aliases) {
             ok = false
             break
           }
@@ -2408,7 +2408,7 @@ fn type_let_expr(
                 break
               }
             }
-            if not(uses_num) {
+            if !uses_num {
               uses_num = has_num_type(r)
             }
             let num_var = if uses_num { Some(fresh_num_var(env)) } else { None }
@@ -2476,11 +2476,11 @@ fn type_let_expr(
             let fn_scope = effect_scope_from_list(normalized_effects)
             let fn_allow_effect = allow_effect ||
               normalized_effects.length() > 0
-            if not(env.session_state.skip_fn_body_check) {
+            if !env.session_state.skip_fn_body_check {
               let body_ty = type_block(
                 scope_env, body, aliases, fn_scope, fn_allow_effect,
               )
-              if not(type_equal(scope_env, resolved_ret, body_ty)) {
+              if !type_equal(scope_env, resolved_ret, body_ty) {
                 raise TypeError::Mismatch(
                   expected=resolved_ret,
                   actual=body_ty,
@@ -2655,7 +2655,7 @@ fn type_lambda_with_context(
           let final_ret = match ret {
             Some(r) => {
               let resolved = normalize_type(env, r)
-              if not(type_equal(env, resolved, body_ty)) {
+              if !type_equal(env, resolved, body_ty) {
                 raise TypeError::Mismatch(
                   expected=resolved,
                   actual=body_ty,
@@ -2730,7 +2730,7 @@ fn ensure_no_scoped_ref_call_argument(
   arg_ty : @core.Type,
   span : @core.Span,
 ) -> Unit raise TypeError {
-  if not(env.scoped_ref_checks_enabled) {
+  if !env.scoped_ref_checks_enabled {
     return
   }
   if type_contains_scoped_ref(env, arg_ty) {
@@ -2753,7 +2753,7 @@ fn check_call_args(
   let positional : Array[@core.FuncParam] = []
   let mut variadic_param : @core.FuncParam? = None
   for param in params {
-    if not(@core.ParamLabel::is_positional(param.label)) {
+    if !@core.ParamLabel::is_positional(param.label) {
       continue
     }
     match param.label {
@@ -2815,7 +2815,7 @@ fn check_call_args(
         // Labeled argument - find expected type
         let mut expected_ty : @core.Type? = None
         for param in params {
-          if not(@core.ParamLabel::is_positional(param.label)) &&
+          if !@core.ParamLabel::is_positional(param.label) &&
             param.name == label {
             expected_ty = Some(param.ty)
             break
@@ -2849,8 +2849,8 @@ fn check_call_args(
         }
         match expected_ty {
           Some(param_ty) =>
-            if not(type_equal(env, param_ty, arg.ty)) &&
-              not(is_type_subtype(env, arg.ty, param_ty)) {
+            if !type_equal(env, param_ty, arg.ty) &&
+              !is_type_subtype(env, arg.ty, param_ty) {
               if is_active_polymorphic_recursive_call(env, callee_name) {
                 raise TypeError::BadRec(
                   message="polymorphic recursion is unsupported",
@@ -2880,7 +2880,7 @@ fn check_call_args(
         }
         let mut found : @core.FuncParam? = None
         for param in params {
-          if not(@core.ParamLabel::is_positional(param.label)) &&
+          if !@core.ParamLabel::is_positional(param.label) &&
             param.name == label {
             found = Some(param)
             break
@@ -2889,8 +2889,8 @@ fn check_call_args(
         match found {
           Some(param) => {
             used_labels[label] = true
-            if not(type_equal(env, param.ty, arg.ty)) &&
-              not(is_type_subtype(env, arg.ty, param.ty)) {
+            if !type_equal(env, param.ty, arg.ty) &&
+              !is_type_subtype(env, arg.ty, param.ty) {
               if is_active_polymorphic_recursive_call(env, callee_name) {
                 raise TypeError::BadRec(
                   message="polymorphic recursion is unsupported",
@@ -2919,7 +2919,7 @@ fn check_call_args(
   }
   for param in params {
     if param.label == @core.ParamLabel::Required &&
-      not(used_labels.contains(param.name)) {
+      !used_labels.contains(param.name) {
       raise TypeError::BadCall(
         message="missing label: " + param.name,
         span=call_span,
@@ -2942,7 +2942,7 @@ fn argument_mismatch_expected_type(
         Some(bounds) => {
           let deduped = dedup_trait_bounds(bounds)
           for bound in deduped {
-            if not(type_implements_trait(env, resolved_actual, bound)) {
+            if !type_implements_trait(env, resolved_actual, bound) {
               return @core.Type::Named(name=bound, args=[])
             }
           }
@@ -2977,7 +2977,7 @@ fn argument_mismatch_context(
           let solver = ObligationSolver::of(env)
           for bound in deduped {
             let w = solver.witness(resolved_actual, bound)
-            if not(w.is_satisfied()) {
+            if !w.is_satisfied() {
               return base + ": " + w.message()
             }
           }

--- a/src/checker/typecheck_fixture.mbt
+++ b/src/checker/typecheck_fixture.mbt
@@ -35,7 +35,7 @@ fn sort_strings_typecheck_fixture(arr : Array[String]) -> Unit {
 ///|
 fn diag_path_for_fixture(path : String) -> String {
   if path.has_suffix(".vibe") {
-    let stem = path[:path.length() - 5].to_string()
+    let stem = path[:path.length() - 5].to_owned()
     stem + ".diag"
   } else {
     path + ".diag"
@@ -48,7 +48,7 @@ fn trim_trailing_newlines(text : String) -> String {
     return text
   }
   if text.has_suffix("\n") || text.has_suffix("\r") {
-    let next = text[:text.length() - 1].to_string()
+    let next = text[:text.length() - 1].to_owned()
     trim_trailing_newlines(next)
   } else {
     text

--- a/src/checker/typecheck_pattern.mbt
+++ b/src/checker/typecheck_pattern.mbt
@@ -150,7 +150,7 @@ fn collect_pattern_bindings_inner(
     }
     @core.Pat::Int(value~, span~) => {
       let _ = value
-      if not(type_equal(env, scrutinee_ty, @core.Type::Int)) {
+      if !type_equal(env, scrutinee_ty, @core.Type::Int) {
         raise TypeError::Mismatch(
           expected=@core.Type::Int,
           actual=scrutinee_ty,
@@ -161,7 +161,7 @@ fn collect_pattern_bindings_inner(
     }
     @core.Pat::Float(value~, span~) => {
       let _ = value
-      if not(type_equal(env, scrutinee_ty, @core.Type::Float)) {
+      if !type_equal(env, scrutinee_ty, @core.Type::Float) {
         raise TypeError::Mismatch(
           expected=@core.Type::Float,
           actual=scrutinee_ty,
@@ -172,7 +172,7 @@ fn collect_pattern_bindings_inner(
     }
     @core.Pat::Double(value~, span~) => {
       let _ = value
-      if not(type_equal(env, scrutinee_ty, @core.Type::Double)) {
+      if !type_equal(env, scrutinee_ty, @core.Type::Double) {
         raise TypeError::Mismatch(
           expected=@core.Type::Double,
           actual=scrutinee_ty,
@@ -183,7 +183,7 @@ fn collect_pattern_bindings_inner(
     }
     @core.Pat::Bool(value~, span~) => {
       let _ = value
-      if not(type_equal(env, scrutinee_ty, @core.Type::Bool)) {
+      if !type_equal(env, scrutinee_ty, @core.Type::Bool) {
         raise TypeError::Mismatch(
           expected=@core.Type::Bool,
           actual=scrutinee_ty,
@@ -194,7 +194,7 @@ fn collect_pattern_bindings_inner(
     }
     @core.Pat::Char(value~, span~) => {
       let _ = value
-      if not(type_equal(env, scrutinee_ty, @core.Type::Char)) {
+      if !type_equal(env, scrutinee_ty, @core.Type::Char) {
         raise TypeError::Mismatch(
           expected=@core.Type::Char,
           actual=scrutinee_ty,
@@ -205,7 +205,7 @@ fn collect_pattern_bindings_inner(
     }
     @core.Pat::String(value~, span~) => {
       let _ = value
-      if not(type_equal(env, scrutinee_ty, @core.Type::String)) {
+      if !type_equal(env, scrutinee_ty, @core.Type::String) {
         raise TypeError::Mismatch(
           expected=@core.Type::String,
           actual=scrutinee_ty,

--- a/src/checker/typecheck_prelude.mbt
+++ b/src/checker/typecheck_prelude.mbt
@@ -139,10 +139,10 @@ pub fn ensure_prelude_option(env : TypeEnv) -> Unit raise TypeError {
 ///|
 fn ensure_prelude_error_trait(env : TypeEnv) -> Unit raise TypeError {
   let span = @core.Span::empty(0)
-  if not(env.has_trait("Error")) {
+  if !env.has_trait("Error") {
     register_trait_def(env, "Error", [], true, true, span)
   }
-  if not(type_implements_trait(env, @core.Type::String, "Error")) {
+  if !type_implements_trait(env, @core.Type::String, "Error") {
     register_trait_impl(env, [], {}, "Error", @core.Type::String, span)
   }
 }
@@ -237,7 +237,7 @@ pub fn ensure_prelude_builtin_traits(env : TypeEnv) -> Unit {
     "Eq", "Hash", "Ord", "Add", "Sub", "Mul", "Div", "Signed",
   ]
   for name in builtin_trait_names {
-    if not(env.has_trait(name)) {
+    if !env.has_trait(name) {
       env.set_trait_info(name, TraitDefInfo::prelude_seeded())
     }
   }

--- a/src/checker/typecheck_stmts.mbt
+++ b/src/checker/typecheck_stmts.mbt
@@ -369,7 +369,7 @@ fn type_check_stmts(
 ) -> TypeEnv raise TypeError {
   let is_top_level = is_top_level.unwrap_or(false)
   let declared_in_scope : Map[String, Bool] = {}
-  let has_exports = not(exported_names.is_empty())
+  let has_exports = !exported_names.is_empty()
   let ensure_fresh_value_binding = fn(
     name : String,
     span : @core.Span,
@@ -424,19 +424,19 @@ fn type_check_stmts(
   for stmt in stmts {
     let fn_info : (String, @core.Expr)? = match stmt {
       @core.Stmt::Let(rec~, name~, expr~, ..) =>
-        if not(rec) && name != "_" {
+        if !rec && name != "_" {
           Some((name, expr))
         } else {
           None
         }
       @core.Stmt::ExportLet(rec~, name~, expr~, ..) =>
-        if not(rec) && name != "_" {
+        if !rec && name != "_" {
           Some((name, expr))
         } else {
           None
         }
       @core.Stmt::InternalExportLet(rec~, name~, expr~, ..) =>
-        if not(rec) && name != "_" {
+        if !rec && name != "_" {
           Some((name, expr))
         } else {
           None
@@ -485,12 +485,12 @@ fn type_check_stmts(
               // when all parameters have explicit type annotations and
               // the body does not self-reference (self-recursion needs
               // explicit `let rec` with return type annotation).
-              let all_annotated = not(has_infer_placeholder(params))
+              let all_annotated = !has_infer_placeholder(params)
               let self_refs = if all_annotated {
                 let refs : Map[String, Bool] = {}
                 let bound = @core.WalkerScope::new()
                 @core.walk_expr_refs(expr, bound, refs, fn(n, b, r) {
-                  if not(b.contains(n)) {
+                  if !b.contains(n) {
                     r[n] = true
                   }
                 })
@@ -498,7 +498,7 @@ fn type_check_stmts(
               } else {
                 false
               }
-              if all_annotated && not(self_refs) {
+              if all_annotated && !self_refs {
                 let inferred_ret = fresh_type_var(env)
                 let result : Result[TypeScheme, TypeError] = try? build_forward_fn_scheme(
                   env, type_params, type_bounds, params, inferred_ret, fn_effects,
@@ -811,7 +811,7 @@ fn type_check_stmts(
         match env.get_scheme(name) {
           Some(scheme) => {
             let expected = instantiate_scheme(env, scheme)
-            if not(type_equal(env, expected, ty)) {
+            if !type_equal(env, expected, ty) {
               raise TypeError::Mismatch(
                 expected~,
                 actual=ty,
@@ -871,7 +871,7 @@ fn collect_exported_names(stmts : Array[@core.Stmt]) -> Map[String, Bool] {
       _ => ()
     }
   }
-  if not(has_late_exports) {
+  if !has_late_exports {
     return exports
   }
   let defined : Map[String, Bool] = {}
@@ -978,7 +978,7 @@ fn ensure_traits_defined(
 ) -> Unit raise TypeError {
   let deduped = dedup_trait_bounds(bounds)
   for bound in deduped {
-    if not(env.has_trait(bound)) {
+    if !env.has_trait(bound) {
       raise TypeError::BadTypeDef(message="unknown trait: " + bound, span~)
     }
   }
@@ -1024,7 +1024,7 @@ fn type_matches_impl_target(
           } else {
             let mut ok = true
             for i in 0..<pa.length() {
-              if not(type_matches_impl_target(env, pa[i], aa[i], mapping)) {
+              if !type_matches_impl_target(env, pa[i], aa[i], mapping) {
                 ok = false
                 break
               }
@@ -1063,9 +1063,7 @@ fn type_matches_impl_target(
           } else {
             let mut ok = true
             for i in 0..<ps.length() {
-              if not(
-                  type_matches_impl_target(env, ps[i], actual_items[i], mapping),
-                ) {
+              if !type_matches_impl_target(env, ps[i], actual_items[i], mapping) {
                 ok = false
                 break
               }
@@ -1084,7 +1082,7 @@ fn type_matches_impl_target(
             for name, p_ty in pf {
               match af.get(name) {
                 Some(a_ty) =>
-                  if not(type_matches_impl_target(env, p_ty, a_ty, mapping)) {
+                  if !type_matches_impl_target(env, p_ty, a_ty, mapping) {
                     ok = false
                     break
                   }
@@ -1140,7 +1138,7 @@ fn type_matches_impl_target(
             for name, p_ty in pf {
               match af.get(name) {
                 Some(a_ty) =>
-                  if not(type_matches_impl_target(env, p_ty, a_ty, mapping)) {
+                  if !type_matches_impl_target(env, p_ty, a_ty, mapping) {
                     ok = false
                     break
                   }
@@ -1163,8 +1161,8 @@ fn type_matches_impl_target(
             let mut ok = true
             for i in 0..<pp.length() {
               if pp[i].label != ap[i].label ||
-                (not(pp[i].label.is_positional()) && pp[i].name != ap[i].name) ||
-                not(type_matches_impl_target(env, pp[i].ty, ap[i].ty, mapping)) {
+                (!pp[i].label.is_positional() && pp[i].name != ap[i].name) ||
+                !type_matches_impl_target(env, pp[i].ty, ap[i].ty, mapping) {
                 ok = false
                 break
               }
@@ -1249,7 +1247,7 @@ fn ensure_type_satisfies_bounds(
       let solver = ObligationSolver::of(env)
       for bound in deduped {
         let witness = solver.witness(resolved, bound)
-        if not(witness.is_satisfied()) {
+        if !witness.is_satisfied() {
           let extra = witness.message()
           let enriched_context = if extra == "" {
             context
@@ -1316,7 +1314,7 @@ fn trait_impl_targets_may_overlap_many(
   }
   let mut i = 0
   while i < left.length() {
-    if not(trait_impl_targets_may_overlap(left[i], right[i])) {
+    if !trait_impl_targets_may_overlap(left[i], right[i]) {
       return false
     }
     i += 1
@@ -1479,17 +1477,15 @@ fn trait_impl_targets_may_overlap_concrete(
           while i < left_params.length() {
             if left_params[i].label != right_params[i].label ||
               (
-                not(left_params[i].label.is_positional()) &&
+                !left_params[i].label.is_positional() &&
                 left_params[i].name != right_params[i].name
               ) {
               return false
             }
-            if not(
-                trait_impl_targets_may_overlap(
+            if !trait_impl_targets_may_overlap(
                   left_params[i].ty,
                   right_params[i].ty,
-                ),
-              ) {
+                ) {
               return false
             }
             i += 1
@@ -1518,7 +1514,7 @@ fn trait_impls_overlap(
   left : TraitImplDef,
   right : TraitImplDef,
 ) -> Bool {
-  if not(trait_impl_targets_may_overlap(left.target, right.target)) {
+  if !trait_impl_targets_may_overlap(left.target, right.target) {
     return false
   }
   let overlap_env = clone_env(env)
@@ -1662,7 +1658,7 @@ fn build_forward_fn_scheme(
       break
     }
   }
-  if not(uses_num) {
+  if !uses_num {
     uses_num = has_num_type(ret)
   }
   let num_var = if uses_num { Some(fresh_num_var(env)) } else { None }

--- a/src/checker/typecheck_unify.mbt
+++ b/src/checker/typecheck_unify.mbt
@@ -75,7 +75,7 @@ fn normalize_type_cache_store_to(
   normalized : @core.Type,
 ) -> Unit {
   let key = normalize_type_cache_key(source)
-  if cache.length() >= 8192 && not(cache.contains(key)) {
+  if cache.length() >= 8192 && !cache.contains(key) {
     return
   }
   let entry = (source, normalized)
@@ -91,7 +91,7 @@ fn normalize_type_cache_lookup(
   ty : @core.Type,
   expand_enum : Bool,
 ) -> @core.Type? {
-  if not(normalize_type_cacheable(ty)) {
+  if !normalize_type_cacheable(ty) {
     return None
   }
   // Fast path: ground cache for 0-arg Named types.
@@ -126,8 +126,8 @@ fn normalize_type_cache_store(
   normalized : @core.Type,
   expand_enum : Bool,
 ) -> Unit {
-  if not(normalize_type_cacheable(source)) ||
-    not(normalize_type_cacheable(normalized)) {
+  if !normalize_type_cacheable(source) ||
+    !normalize_type_cacheable(normalized) {
     return
   }
   // Store in ground cache for 0-arg Named types (survives subs_version changes).
@@ -457,7 +457,7 @@ fn normalize_type_inner(
                 for i in 0..<def.params.length() {
                   mapping[def.params[i]] = normalized_args[i]
                 }
-                if not(expand_enum) {
+                if !expand_enum {
                   return @core.Type::Named(name~, args=normalized_args)
                 }
                 let ctor_map : Map[String, @core.Type] = {}
@@ -516,7 +516,7 @@ fn normalize_type_inner(
         @core.Type::Tuple(out)
       }
     @core.Type::Record(fields) =>
-      if not(type_has_named_node(ty)) {
+      if !type_has_named_node(ty) {
         ty
       } else {
         let out : Map[String, @core.Type] = {}
@@ -526,7 +526,7 @@ fn normalize_type_inner(
         @core.Type::Record(out)
       }
     @core.Type::Array(inner) =>
-      if not(type_has_named_node(inner)) {
+      if !type_has_named_node(inner) {
         ty
       } else {
         @core.Type::Array(
@@ -534,7 +534,7 @@ fn normalize_type_inner(
         )
       }
     @core.Type::Map(key, inner) =>
-      if not(type_has_named_node(key)) && not(type_has_named_node(inner)) {
+      if !type_has_named_node(key) && !type_has_named_node(inner) {
         ty
       } else {
         @core.Type::Map(
@@ -549,7 +549,7 @@ fn normalize_type_inner(
         @core.Type::Set(normalize_type_inner(env, inner, visiting, expand_enum))
       }
     @core.Type::ArrayBuilder(inner) =>
-      if not(type_has_named_node(inner)) {
+      if !type_has_named_node(inner) {
         ty
       } else {
         @core.Type::ArrayBuilder(
@@ -557,7 +557,7 @@ fn normalize_type_inner(
         )
       }
     @core.Type::MapBuilder(key, inner) =>
-      if not(type_has_named_node(key)) && not(type_has_named_node(inner)) {
+      if !type_has_named_node(key) && !type_has_named_node(inner) {
         ty
       } else {
         @core.Type::MapBuilder(
@@ -566,7 +566,7 @@ fn normalize_type_inner(
         )
       }
     @core.Type::Variant(fields) =>
-      if not(type_has_named_node(ty)) {
+      if !type_has_named_node(ty) {
         ty
       } else {
         let out : Map[String, @core.Type] = {}
@@ -578,7 +578,7 @@ fn normalize_type_inner(
     @core.Type::Param(_) => ty
     @core.Type::Var(_) => ty
     @core.Type::Func(params~, ret~, effects~) =>
-      if not(type_has_named_node(ty)) {
+      if !type_has_named_node(ty) {
         ty
       } else {
         let out : Array[@core.FuncParam] = []
@@ -682,7 +682,7 @@ fn scoped_ref_cache_store(env : TypeEnv, ty : @core.Type, value : Bool) -> Unit 
   let key : String = scoped_ref_cache_key(env, ty)
   let next = ScopedRefContainsCacheEntry::{ ty, has_scoped_ref: value }
   if env.scoped_ref_contains_cache.length() >= 4096 &&
-    not(env.scoped_ref_contains_cache.contains(key)) {
+    !env.scoped_ref_contains_cache.contains(key) {
     return
   }
   match env.scoped_ref_contains_cache.get(key) {
@@ -706,7 +706,7 @@ fn type_contains_scoped_ref(
   env : TypeEnv,
   ty : @core.Type,
 ) -> Bool raise TypeError {
-  if not(env.scoped_ref_checks_enabled) {
+  if !env.scoped_ref_checks_enabled {
     return false
   }
   let profile_start = if env.scoped_ref_profile_enabled {
@@ -724,7 +724,7 @@ fn type_contains_scoped_ref(
     result
   }
   let resolved = resolve_type(env, ty)
-  if not(type_may_contain_scoped_ref_hint(resolved)) {
+  if !type_may_contain_scoped_ref_hint(resolved) {
     return finish(false)
   }
   match scoped_ref_cache_lookup(env, resolved) {
@@ -932,7 +932,7 @@ fn ensure_no_scoped_ref_return_escape(
   ret_ty : @core.Type,
   span : @core.Span,
 ) -> Unit raise TypeError {
-  if not(env.scoped_ref_checks_enabled) {
+  if !env.scoped_ref_checks_enabled {
     return
   }
   let profile_start = if env.scoped_ref_profile_enabled {
@@ -961,7 +961,7 @@ fn ensure_no_toplevel_scoped_ref_escape(
   ty : @core.Type,
   span : @core.Span,
 ) -> Unit raise TypeError {
-  if not(env.scoped_ref_checks_enabled) {
+  if !env.scoped_ref_checks_enabled {
     return
   }
   let profile_start = if env.scoped_ref_profile_enabled {
@@ -1056,7 +1056,7 @@ fn effects_subset(
     large_keys[effect_atom_key(effect)] = true
   }
   for effect in small {
-    if not(large_keys.contains(effect_atom_key(effect))) {
+    if !large_keys.contains(effect_atom_key(effect)) {
       return false
     }
   }
@@ -1072,7 +1072,7 @@ fn trait_bounds_subset(
   let required = dedup_trait_bounds(small)
   let available = dedup_trait_bounds(large)
   for bound in required {
-    if not(trait_bound_satisfied(env, available, bound)) {
+    if !trait_bound_satisfied(env, available, bound) {
       return false
     }
   }
@@ -1109,7 +1109,7 @@ pub fn is_type_subtype(
       } else {
         let mut ok = true
         for i in 0..<sub_items.length() {
-          if not(is_type_subtype(env, sub_items[i], sup_items[i])) {
+          if !is_type_subtype(env, sub_items[i], sup_items[i]) {
             ok = false
             break
           }
@@ -1121,7 +1121,7 @@ pub fn is_type_subtype(
       for name, sup_ty in sup_fields {
         match sub_fields.get(name) {
           Some(sub_ty) =>
-            if not(is_type_subtype(env, sub_ty, sup_ty)) {
+            if !is_type_subtype(env, sub_ty, sup_ty) {
               ok = false
               break
             }
@@ -1154,7 +1154,7 @@ pub fn is_type_subtype(
     ) =>
       if sub_params.length() != sup_params.length() {
         false
-      } else if not(effects_subset(sub_effects, sup_effects)) {
+      } else if !effects_subset(sub_effects, sup_effects) {
         false
       } else {
         let mut ok = true
@@ -1165,18 +1165,18 @@ pub fn is_type_subtype(
             ok = false
             break
           }
-          if not(@core.ParamLabel::is_positional(sub_param.label)) &&
+          if !@core.ParamLabel::is_positional(sub_param.label) &&
             sub_param.name != sup_param.name {
             ok = false
             break
           }
-          if not(trait_bounds_subset(env, sub_param.bounds, sup_param.bounds)) {
+          if !trait_bounds_subset(env, sub_param.bounds, sup_param.bounds) {
             ok = false
             break
           }
           // Function parameter types are contravariant:
           // new <: old requires old_param <: new_param
-          if not(is_type_subtype(env, sup_param.ty, sub_param.ty)) {
+          if !is_type_subtype(env, sup_param.ty, sub_param.ty) {
             ok = false
             break
           }
@@ -1314,7 +1314,7 @@ fn unify_types_inner(
         } else {
           let mut ok = true
           for i in 0..<aa.length() {
-            if not(unify_types_inner(env, aa[i], bb[i], cache)) {
+            if !unify_types_inner(env, aa[i], bb[i], cache) {
               ok = false
               break
             }
@@ -1367,7 +1367,7 @@ fn unify_types_inner(
       } else {
         let mut ok = true
         for i in 0..<xs.length() {
-          if not(unify_types_inner(env, xs[i], ys[i], cache)) {
+          if !unify_types_inner(env, xs[i], ys[i], cache) {
             ok = false
             break
           }
@@ -1382,7 +1382,7 @@ fn unify_types_inner(
         for name, ty in ax {
           match bx.get(name) {
             Some(other) =>
-              if not(unify_types_inner(env, ty, other, cache)) {
+              if !unify_types_inner(env, ty, other, cache) {
                 ok = false
                 break
               }
@@ -1417,7 +1417,7 @@ fn unify_types_inner(
         for name, ty in ax {
           match bx.get(name) {
             Some(other) =>
-              if not(unify_types_inner(env, ty, other, cache)) {
+              if !unify_types_inner(env, ty, other, cache) {
                 ok = false
                 break
               }
@@ -1435,14 +1435,14 @@ fn unify_types_inner(
     ) =>
       if pa.length() != pb.length() {
         false
-      } else if not(unify_effects(env, ea, eb)) {
+      } else if !unify_effects(env, ea, eb) {
         false
-      } else if not(unify_types_inner(env, ra, rb, cache)) {
+      } else if !unify_types_inner(env, ra, rb, cache) {
         false
       } else {
         let mut ok = true
         for i in 0..<pa.length() {
-          if not(param_unify(env, pa[i], pb[i], cache)) {
+          if !param_unify(env, pa[i], pb[i], cache) {
             ok = false
             break
           }
@@ -1475,13 +1475,11 @@ fn param_unify(
   if a.label != b.label {
     return false
   }
-  if not(@core.ParamLabel::is_positional(a.label)) && a.name != b.name {
+  if !@core.ParamLabel::is_positional(a.label) && a.name != b.name {
     return false
   }
-  if not(
-      trait_bounds_subset(env, a.bounds, b.bounds) &&
-      trait_bounds_subset(env, b.bounds, a.bounds),
-    ) {
+  if !(trait_bounds_subset(env, a.bounds, b.bounds) &&
+      trait_bounds_subset(env, b.bounds, a.bounds)) {
     return false
   }
   unify_types_inner(env, a.ty, b.ty, cache)
@@ -1510,7 +1508,7 @@ fn bind_var(env : TypeEnv, id : Int, ty : @core.Type) -> Bool {
         }
       @core.Type::Int | @core.Type::Float | @core.Type::Double => {
         for bound in required_bounds {
-          if not(type_implements_trait(env, resolved, bound)) {
+          if !type_implements_trait(env, resolved, bound) {
             return false
           }
         }
@@ -1538,7 +1536,7 @@ fn bind_var(env : TypeEnv, id : Int, ty : @core.Type) -> Bool {
           false
         } else {
           for bound in required_bounds {
-            if not(type_implements_trait(env, resolved, bound)) {
+            if !type_implements_trait(env, resolved, bound) {
               return false
             }
           }

--- a/src/checker/warning.mbt
+++ b/src/checker/warning.mbt
@@ -666,7 +666,7 @@ fn walk_expr(
         }
         walk_expr(arm.expr, scopes, out)
         warning_scope_pop(scopes, out)
-        if not(catchall_seen) && arm.cond is None {
+        if !catchall_seen && arm.cond is None {
           match arm.pat {
             @core.Pat::Wildcard(..) | @core.Pat::Bind(..) =>
               catchall_seen = true

--- a/src/checker/warning_fixture.mbt
+++ b/src/checker/warning_fixture.mbt
@@ -11,7 +11,7 @@ fn trim_trailing_newlines_warning(text : String) -> String {
     return text
   }
   if text.has_suffix("\n") || text.has_suffix("\r") {
-    let next = text[:text.length() - 1].to_string()
+    let next = text[:text.length() - 1].to_owned()
     trim_trailing_newlines_warning(next)
   } else {
     text

--- a/src/cmd/fbgen/main.mbt
+++ b/src/cmd/fbgen/main.mbt
@@ -2,7 +2,7 @@
 fn postprocess_generated(src : String) -> String {
   let lines : Array[String] = []
   for line_view in src.split("\n") {
-    lines.push(line_view.to_string())
+    lines.push(line_view.to_owned())
   }
   let out = StringBuilder::new()
   for i in 0..<lines.length() {

--- a/src/cmd/vibe/bench_options.mbt
+++ b/src/cmd/vibe/bench_options.mbt
@@ -13,16 +13,14 @@ fn is_valid_bench_case_name(name : String) -> Bool {
   for _, c in name {
     if first {
       first = false
-      if not(Char::is_ascii_alphabetic(c) || c == '_') {
+      if !(Char::is_ascii_alphabetic(c) || c == '_') {
         return false
       }
       continue
     }
-    if not(
-        (Char::is_ascii_alphabetic(c) || Char::is_ascii_digit(c)) ||
+    if !((Char::is_ascii_alphabetic(c) || Char::is_ascii_digit(c)) ||
         c == '_' ||
-        c == '-',
-      ) {
+        c == '-') {
       return false
     }
   }
@@ -34,7 +32,7 @@ pub fn parse_bench_case_arg(
   raw : String,
   case_index : Int,
 ) -> Result[BenchCase, String] {
-  let trimmed = raw.trim().to_string()
+  let trimmed = raw.trim().to_owned()
   if trimmed.length() == 0 {
     return Err("empty case expression")
   }
@@ -50,14 +48,14 @@ pub fn parse_bench_case_arg(
       if pos <= 0 || pos + 1 >= trimmed.length() {
         return Ok({ name: "case" + case_index.to_string(), expr: trimmed })
       }
-      let left = trimmed.unsafe_substring(start=0, end=pos).trim().to_string()
+      let left = trimmed.unsafe_substring(start=0, end=pos).trim().to_owned()
       let right = trimmed
         .unsafe_substring(start=pos + 1, end=trimmed.length())
         .trim()
-        .to_string()
+        .to_owned()
       if right.length() == 0 ||
         right.has_prefix("=") ||
-        not(is_valid_bench_case_name(left)) {
+        !is_valid_bench_case_name(left) {
         return Ok({ name: "case" + case_index.to_string(), expr: trimmed })
       }
       Ok({ name: left, expr: right })
@@ -76,7 +74,7 @@ pub fn parse_bench_case_source(
   let mut line_no = 0
   for line_view in source.split("\n") {
     line_no += 1
-    let line = line_view.to_string().trim().to_string()
+    let line = line_view.to_owned().trim().to_owned()
     if line.length() == 0 || line.has_prefix("#") {
       continue
     }

--- a/src/cmd/vibe/builtin_table_encoder.mbt
+++ b/src/cmd/vibe/builtin_table_encoder.mbt
@@ -266,18 +266,18 @@ fn split_top_level_comma(s : String) -> Array[String] {
     } else if c == cc_close_bracket || c == cc_close_paren {
       depth = depth - 1
     } else if c == cc_comma && depth == 0 {
-      result.push(s[start:i].trim().to_string())
+      result.push(s[start:i].trim().to_owned())
       start = i + 1
     }
   }
-  result.push(s[start:s.length()].trim().to_string())
+  result.push(s[start:s.length()].trim().to_owned())
   result
 }
 
 ///|
 /// Parse a type string (e.g. "Array[T]", "Int", "Map[String, Int]") into BuiltinTypeTag.
 fn parse_type_tag(s : String) -> BuiltinTypeTag {
-  let trimmed = s.trim().to_string()
+  let trimmed = s.trim().to_owned()
   if trimmed == "Unit" {
     return Unit
   }
@@ -329,8 +329,8 @@ fn parse_type_tag(s : String) -> BuiltinTypeTag {
   // Check for container types with brackets
   let bracket_start = find_charcode(trimmed, cc_open_bracket)
   if bracket_start >= 0 {
-    let container_name = trimmed[0:bracket_start].to_string()
-    let inner = trimmed[bracket_start + 1:trimmed.length() - 1].to_string()
+    let container_name = trimmed[0:bracket_start].to_owned()
+    let inner = trimmed[bracket_start + 1:trimmed.length() - 1].to_owned()
     if container_name == "Array" {
       return Array_(parse_type_tag(inner))
     }
@@ -361,8 +361,8 @@ fn parse_type_tag(s : String) -> BuiltinTypeTag {
     let arrow_pos = find_arrow(trimmed)
     if arrow_pos >= 0 {
       let close_paren = find_matching_paren(trimmed, 0)
-      let params_inner = trimmed[1:close_paren].trim().to_string()
-      let ret_str = trimmed[arrow_pos + 2:trimmed.length()].trim().to_string()
+      let params_inner = trimmed[1:close_paren].trim().to_owned()
+      let ret_str = trimmed[arrow_pos + 2:trimmed.length()].trim().to_owned()
       let params = if params_inner.length() == 0 {
         []
       } else {
@@ -383,24 +383,24 @@ fn parse_type_tag(s : String) -> BuiltinTypeTag {
 /// Parse a single `declare` line into a BuiltinDecl.
 /// Format: `declare Name::method(Type1, Type2) -> RetType`
 fn parse_declare_line(line : String) -> BuiltinDecl? {
-  let trimmed = line.trim().to_string()
-  if not(trimmed.has_prefix("declare ")) {
+  let trimmed = line.trim().to_owned()
+  if !trimmed.has_prefix("declare ") {
     return None
   }
-  let rest = trimmed[8:trimmed.length()].to_string()
+  let rest = trimmed[8:trimmed.length()].to_owned()
   // Find the opening paren
   let paren_pos = find_charcode(rest, cc_open_paren)
   if paren_pos < 0 {
     return None
   }
-  let name = rest[0:paren_pos].trim().to_string()
+  let name = rest[0:paren_pos].trim().to_owned()
   // Find matching close paren
   let close_paren = find_matching_paren(rest, paren_pos)
   if close_paren < 0 {
     return None
   }
   // Parse params
-  let params_str = rest[paren_pos + 1:close_paren].trim().to_string()
+  let params_str = rest[paren_pos + 1:close_paren].trim().to_owned()
   let params : Array[BuiltinTypeTag] = if params_str.length() == 0 {
     []
   } else {
@@ -412,9 +412,9 @@ fn parse_declare_line(line : String) -> BuiltinDecl? {
     result
   }
   // Find "->" for return type
-  let arrow_str = rest[close_paren + 1:rest.length()].trim().to_string()
+  let arrow_str = rest[close_paren + 1:rest.length()].trim().to_owned()
   let ret = if arrow_str.has_prefix("->") {
-    parse_type_tag(arrow_str[2:arrow_str.length()].to_string())
+    parse_type_tag(arrow_str[2:arrow_str.length()].to_owned())
   } else {
     BuiltinTypeTag::Unit
   }
@@ -426,7 +426,7 @@ fn parse_declare_line(line : String) -> BuiltinDecl? {
 fn parse_declarations(source : String) -> Array[BuiltinDecl] {
   let result : Array[BuiltinDecl] = []
   for line in source.split("\n") {
-    match parse_declare_line(line.to_string()) {
+    match parse_declare_line(line.to_owned()) {
       Some(decl) => result.push(decl)
       None => ()
     }

--- a/src/cmd/vibe/cli.mbt
+++ b/src/cmd/vibe/cli.mbt
@@ -365,7 +365,7 @@ fn short_hash(hash : String) -> String {
   if hash.length() <= 7 {
     hash
   } else {
-    hash[0:7].to_string()
+    hash[0:7].to_owned()
   }
 }
 
@@ -458,16 +458,16 @@ fn sanitize_wit_ident(raw : String) -> String {
       out.write_char(ch)
       last_dash = ch == '-'
     } else if ch == '_' || ch == '.' || ch == ' ' {
-      if not(last_dash) {
+      if !last_dash {
         out.write_char('-')
         last_dash = true
       }
-    } else if not(last_dash) {
+    } else if !last_dash {
       out.write_char('-')
       last_dash = true
     }
   }
-  let normalized = out.to_string().trim().to_string()
+  let normalized = out.to_string().trim().to_owned()
   let candidate = if normalized.length() == 0 { "main" } else { normalized }
   let mut first = 'a'
   for _, c in candidate {
@@ -484,7 +484,7 @@ fn sanitize_wit_ident(raw : String) -> String {
 ///|
 /// Ensure dist directory exists
 fn ensure_dist_dir_with(fs : &@io.FileSystemAdapter) -> Unit {
-  if not(@io.path_exists_with(fs, "dist")) {
+  if !@io.path_exists_with(fs, "dist") {
     match @io.create_dir_with(fs, "dist") {
       Ok(_) => ()
       Err(err) => abort("compile: failed to create dist/: " + err)
@@ -575,7 +575,7 @@ fn write_wasm_coverage_sidecar_with(
 
 ///|
 fn parse_bool_flag(value : String) -> Bool {
-  let normalized = value.trim().to_string().to_lower()
+  let normalized = value.trim().to_owned().to_lower()
   match normalized {
     "1" | "true" | "yes" | "on" => true
     "0" | "false" | "no" | "off" => false
@@ -609,7 +609,7 @@ fn ensure_compile_coverage_allowed(
   coverage : Bool,
   test_mode_enabled : Bool,
 ) -> Result[Unit, String] {
-  if not(coverage) || test_mode_enabled {
+  if !coverage || test_mode_enabled {
     Ok(())
   } else {
     Err("compile: --coverage is test-only (set VIBE_TEST_COVERAGE=1)")
@@ -652,7 +652,7 @@ fn sync_wac_dependencies_if_configured(
   fs : &@io.FileSystemAdapter,
 ) -> Result[UInt, String] {
   let config_path = default_wac_config_path(wac_path)
-  if not(@io.path_exists_with(fs, config_path)) {
+  if !@io.path_exists_with(fs, config_path) {
     return Ok(0U)
   }
   @wite_deps.materialize_wac_dependencies_from_config(
@@ -690,7 +690,7 @@ fn compile_lite_validate_opts(
   if opts.adapter_path is Some(_) {
     return Err("compile-lite: --adapter is not supported")
   }
-  if not(in_memory) && opts.out_path is None {
+  if !in_memory && opts.out_path is None {
     return Err("compile-lite: -o/--out is required")
   }
   Ok(())
@@ -731,7 +731,7 @@ fn split_compile_lite_args(
 
 ///|
 fn remove_file_if_exists(path : String) -> Unit {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return
   }
   let is_file = @os_fs.is_file(path) catch { _ => false }

--- a/src/cmd/vibe/cli_bench.mbt
+++ b/src/cmd/vibe/cli_bench.mbt
@@ -86,7 +86,7 @@ fn is_wasm_unsupported_compile_error(message : String) -> Bool {
 
 ///|
 fn parse_bench_backend(value : String) -> BenchBackend? {
-  match value.trim().to_string().to_lower() {
+  match value.trim().to_owned().to_lower() {
     "wasm" | "compiled" => Some(BenchBackend::Wasm)
     _ => None
   }
@@ -166,14 +166,14 @@ fn bench_uses_expr_mode(args : Array[String]) -> Bool {
           i += 1
         }
       _ => {
-        if not(arg.has_prefix("-")) {
+        if !arg.has_prefix("-") {
           saw_path = true
         }
         i += 1
       }
     }
   }
-  not(saw_path)
+  !saw_path
 }
 
 ///|
@@ -408,7 +408,7 @@ fn bench_blocks_cmd(args : Array[String]) -> Unit {
       total,
       passed,
       failed_count,
-      not(failed),
+      !failed,
       file_reports,
     )
     let json_text = root_json.stringify()
@@ -489,7 +489,7 @@ fn module_source_from_stmt_spans(
       continue
     }
     out.write_string(snippet)
-    if not(snippet.has_suffix("\n")) {
+    if !snippet.has_suffix("\n") {
       out.write_char('\n')
     }
   }
@@ -631,7 +631,7 @@ fn build_bench_case_loop_script(
   out.write_string(" {\n")
   if body_source.length() > 0 {
     out.write_string(body_source)
-    if not(body_source.has_suffix("\n")) {
+    if !body_source.has_suffix("\n") {
       out.write_char('\n')
     }
   }
@@ -720,7 +720,7 @@ fn bench_script_cache_paths(
 
 ///|
 fn is_existing_file(path : String) -> Bool {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return false
   }
   @os_fs.is_file(path) catch {
@@ -732,7 +732,7 @@ fn is_existing_file(path : String) -> Bool {
 fn split_env_flags(raw : String) -> Array[String] {
   let out : Array[String] = []
   for part_view in raw.split(" ") {
-    let token = part_view.trim().to_string()
+    let token = part_view.trim().to_owned()
     if token.length() > 0 {
       out.push(token)
     }
@@ -744,7 +744,7 @@ fn split_env_flags(raw : String) -> Array[String] {
 fn has_wasm_feature_flag(flags : Array[String], feature : String) -> Bool {
   let prefix = feature.to_lower() + "="
   for flag in flags {
-    let token = flag.trim().to_string().to_lower()
+    let token = flag.trim().to_owned().to_lower()
     if token == feature || token.has_prefix(prefix) {
       return true
     }
@@ -756,7 +756,7 @@ fn has_wasm_feature_flag(flags : Array[String], feature : String) -> Bool {
 fn with_default_bench_wasm_flags(flags : Array[String]) -> Array[String] {
   let out = flags.copy()
   // vibe-generated core wasm currently uses exception tags; enable by default.
-  if not(has_wasm_feature_flag(out, "exceptions")) {
+  if !has_wasm_feature_flag(out, "exceptions") {
     out.push("exceptions=y")
   }
   out
@@ -768,7 +768,7 @@ fn find_command_in_path(name : String) -> String? {
     None => None
     Some(path_value) => {
       for dir_view in path_value.split(":") {
-        let dir = dir_view.trim().to_string()
+        let dir = dir_view.trim().to_owned()
         if dir.length() == 0 {
           continue
         }
@@ -806,7 +806,7 @@ fn resolve_wasmtime_bin_for_bench(
 ) -> Result[String, String] {
   match @sys.get_env_var("WASMTIME_BIN") {
     Some(value) => {
-      let trimmed = value.trim().to_string()
+      let trimmed = value.trim().to_owned()
       if trimmed.length() > 0 {
         return Ok(trimmed)
       }
@@ -816,7 +816,7 @@ fn resolve_wasmtime_bin_for_bench(
   let local_release = project_root + "/deps/wasmtime/target/release/wasmtime"
   let local_debug = project_root + "/deps/wasmtime/target/debug/wasmtime"
   let use_submodule = match @sys.get_env_var("VIBE_USE_WASMTIME_SUBMODULE") {
-    Some(value) => value.trim().to_string() == "1"
+    Some(value) => value.trim().to_owned() == "1"
     None => false
   }
   if use_submodule {
@@ -1024,7 +1024,7 @@ fn build_http_host_bench_command(
 
 ///|
 fn parse_http_host_bench_elapsed_us(stdout : String) -> Result[Double, String] {
-  let text = stdout.trim().to_string()
+  let text = stdout.trim().to_owned()
   let parsed : Result[Double, Error] = try? @string.parse_double(
     text,
   )
@@ -1098,7 +1098,7 @@ fn resolve_wasm_opt_bin_for_bench() -> String? {
     Ok(lines) => lines
     Err(_) => return None
   }
-  if probe.length() == 0 || probe[0].trim().to_string() == "" {
+  if probe.length() == 0 || probe[0].trim().to_owned() == "" {
     return None
   }
   let version_lines = match
@@ -1221,7 +1221,7 @@ fn compile_bench_script_to_wasm_with_runner(
     let saved_mode = @os_fs.read_file_to_string(cached_mode_path) catch {
       _ => ""
     }
-    saved_mode.trim().to_string() == current_mode
+    saved_mode.trim().to_owned() == current_mode
   } else {
     false
   }
@@ -1250,7 +1250,7 @@ fn compile_bench_script_to_wasm_with_runner(
   // imports (entire selfhost compiler tree) compile in reasonable
   // time. See `bench/selfhost_perf/README.md` postmortem.
   let bench_no_dce = match @sys.get_env_var("VIBE_BENCH_NO_DCE") {
-    Some(v) => not(v == "0" || v.to_lower() == "false" || v.to_lower() == "off")
+    Some(v) => !(v == "0" || v.to_lower() == "false" || v.to_lower() == "off")
     None => true
   }
   // debug_errors=true keeps throw string literals in the output, but the
@@ -1261,7 +1261,7 @@ fn compile_bench_script_to_wasm_with_runner(
   // opts out for selfhost benches at the cost of less helpful failure
   // messages from `throw` inside the bench body.
   let bench_debug_errors = match @sys.get_env_var("VIBE_BENCH_DEBUG_ERRORS") {
-    Some(v) => not(v == "0" || v.to_lower() == "false" || v.to_lower() == "off")
+    Some(v) => !(v == "0" || v.to_lower() == "false" || v.to_lower() == "off")
     None => true
   }
   // `vibe compile -Oz` runs the in-process `@wite.optimize_binary_for_size`
@@ -1696,7 +1696,7 @@ fn run_bench_blocks_wasm_statistical_entry_with_cases(
         }
         trial = trial * 2
       }
-      if not(calibration_ok) {
+      if !calibration_ok {
         continue
       }
       let run_source = build_bench_case_loop_script(
@@ -1768,7 +1768,7 @@ fn run_bench_blocks_wasm_statistical_entry_with_cases(
         }
         trial = trial * 2
       }
-      if not(calibration_ok) {
+      if !calibration_ok {
         continue
       }
       let mut sample_ok = true
@@ -1795,7 +1795,7 @@ fn run_bench_blocks_wasm_statistical_entry_with_cases(
         }
         samples.push(elapsed_us / batch_size.to_double())
       }
-      if not(sample_ok) {
+      if !sample_ok {
         continue
       }
     } else {
@@ -1814,7 +1814,7 @@ fn run_bench_blocks_wasm_statistical_entry_with_cases(
           }
         }
       }
-      if not(warmup_ok) {
+      if !warmup_ok {
         continue
       }
       let mut sample_ok = true
@@ -1835,7 +1835,7 @@ fn run_bench_blocks_wasm_statistical_entry_with_cases(
         let elapsed_us = @bench.monotonic_clock_end(start)
         samples.push(elapsed_us / batch_size.to_double())
       }
-      if not(sample_ok) {
+      if !sample_ok {
         continue
       }
     }

--- a/src/cmd/vibe/cli_cache.mbt
+++ b/src/cmd/vibe/cli_cache.mbt
@@ -132,7 +132,7 @@ fn collect_source_hash_cache(
     }
     let imports = db.imports(path)
     for imp in imports {
-      if not(visited.contains(imp.path)) {
+      if !visited.contains(imp.path) {
         pending.push(imp.path)
       }
     }
@@ -166,13 +166,13 @@ fn serialize_source_hash_cache(hashes : Map[String, String]) -> String {
 fn parse_source_hash_cache(text : String) -> Map[String, String] {
   let out : Map[String, String] = {}
   for line_view in text.split("\n") {
-    let line = line_view.to_string().trim().to_string()
+    let line = line_view.to_owned().trim().to_owned()
     if line.length() == 0 {
       continue
     }
     let parts : Array[String] = []
     for part_view in line.split("\t") {
-      parts.push(part_view.to_string())
+      parts.push(part_view.to_owned())
     }
     if parts.length() >= 2 {
       out[parts[0]] = parts[1]
@@ -246,13 +246,13 @@ fn parse_linked_imports_cache(
 ) -> Array[@runtime_compile.LinkedImport] {
   let out : Array[@runtime_compile.LinkedImport] = []
   for line_view in text.split("\n") {
-    let line = line_view.to_string().trim().to_string()
+    let line = line_view.to_owned().trim().to_owned()
     if line.length() == 0 {
       continue
     }
     let parts : Array[String] = []
     for part_view in line.split("\t") {
-      parts.push(part_view.to_string())
+      parts.push(part_view.to_owned())
     }
     if parts.length() >= 4 {
       let pc : Result[Int, _] = try? @string.parse_int(parts[2])
@@ -282,7 +282,7 @@ fn all_test_blocks_pure(
 ) -> Bool {
   let env = db.types(entry)
   for case in cases {
-    if not(@checker.purity_block(env, case.body)) {
+    if !@checker.purity_block(env, case.body) {
       return false
     }
   }
@@ -339,11 +339,11 @@ fn pure_test_cache_lookup(
     Some(v) if v.length() > 0 => return None
     _ => ()
   }
-  if not(all_test_blocks_pure(db, entry, cases)) {
+  if !all_test_blocks_pure(db, entry, cases) {
     return None
   }
   let (_cache_dir, result_path) = pure_test_result_cache_paths(entry)
-  if not(@os_fs.path_exists(result_path)) {
+  if !@os_fs.path_exists(result_path) {
     return None
   }
   let saved_text = @os_fs.read_file_to_string(result_path) catch {
@@ -352,7 +352,7 @@ fn pure_test_cache_lookup(
   // Format: "hash\tcount\n" where hash is the combined source hash
   let lines : Array[String] = []
   for line_view in saved_text.split("\n") {
-    let line = line_view.to_string().trim().to_string()
+    let line = line_view.to_owned().trim().to_owned()
     if line.length() > 0 {
       lines.push(line)
     }
@@ -362,7 +362,7 @@ fn pure_test_cache_lookup(
   }
   let parts : Array[String] = []
   for part_view in lines[0].split("\t") {
-    parts.push(part_view.to_string())
+    parts.push(part_view.to_owned())
   }
   if parts.length() < 2 {
     return None
@@ -398,7 +398,7 @@ fn pure_test_cache_save(
   current_hashes : Map[String, String],
 ) -> Unit {
   let _ = ast
-  if not(all_test_blocks_pure(db, entry, cases)) {
+  if !all_test_blocks_pure(db, entry, cases) {
     return
   }
   let (cache_dir, result_path) = pure_test_result_cache_paths(entry)

--- a/src/cmd/vibe/cli_check_cmd.mbt
+++ b/src/cmd/vibe/cli_check_cmd.mbt
@@ -564,25 +564,25 @@ fn finalize_render_source(
     match finalize_render_stmt_fallback(stmt) {
       Some(rendered) => {
         out.write_string(rendered)
-        if not(rendered.has_suffix("\n")) {
+        if !rendered.has_suffix("\n") {
           out.write_char('\n')
         }
       }
       None => {
         let span = stmt.span()
         let snippet = source_slice_by_span(source, span.start, span.end)
-        if snippet.trim().to_string().length() == 0 {
+        if snippet.trim().to_owned().length() == 0 {
           continue
         }
         out.write_string(snippet)
-        if not(snippet.has_suffix("\n")) {
+        if !snippet.has_suffix("\n") {
           out.write_char('\n')
         }
       }
     }
   }
   let result = out.to_string()
-  if result.trim().to_string().length() == 0 {
+  if result.trim().to_owned().length() == 0 {
     Err("finalize: no statements kept")
   } else {
     let _ = @parser.parse_ast(result) catch {
@@ -645,7 +645,7 @@ fn finalize_cmd(args : Array[String]) -> Unit {
     Ok(v) => v
     Err(err) => abort("finalize: " + err)
   }
-  if source.trim().to_string().length() == 0 {
+  if source.trim().to_owned().length() == 0 {
     abort("finalize: source is empty: " + db_path)
   }
   let ast = @parser.parse_ast(source) catch {
@@ -663,7 +663,7 @@ fn finalize_cmd(args : Array[String]) -> Unit {
   if options.print_source {
     println(finalized_source)
   }
-  if not(options.dry_run) {
+  if !options.dry_run {
     match write_scratch_db_source(db_path, finalized_source) {
       Ok(_) => ()
       Err(err) => abort("finalize: " + err)

--- a/src/cmd/vibe/cli_closure_payload.mbt
+++ b/src/cmd/vibe/cli_closure_payload.mbt
@@ -111,7 +111,7 @@ fn append_closure_payload_part(
   first : Bool,
   part : String,
 ) -> Unit {
-  if not(first) {
+  if !first {
     buf.write_string(closure_payload_separator)
   }
   buf.write_string(part)
@@ -152,7 +152,7 @@ pub fn build_closure_payload_with_fs(
 fn split_closure_payload_parts(payload : String) -> Array[String] {
   let parts : Array[String] = []
   for part in payload.split(closure_payload_separator) {
-    parts.push(part.to_string())
+    parts.push(part.to_owned())
   }
   parts
 }
@@ -190,7 +190,7 @@ fn closure_payload_dirname(path : String) -> String {
   if last_slash <= 0 {
     "/"
   } else {
-    path[:last_slash].to_string()
+    path[:last_slash].to_owned()
   }
 }
 

--- a/src/cmd/vibe/cli_closure_payload_wbtest.mbt
+++ b/src/cmd/vibe/cli_closure_payload_wbtest.mbt
@@ -156,7 +156,7 @@ test "compile_closure_payload_file compiles import closure payload" {
 fn split_payload_parts(payload : String) -> Array[String] {
   let parts : Array[String] = []
   for part in payload.split("\u{0}") {
-    parts.push(part.to_string())
+    parts.push(part.to_owned())
   }
   parts
 }

--- a/src/cmd/vibe/cli_compile_cmd.mbt
+++ b/src/cmd/vibe/cli_compile_cmd.mbt
@@ -59,7 +59,7 @@ fn compile_lite_cmd(args : Array[String]) -> Unit {
         }
       }
       let mut write_us = 0
-      if not(in_memory) {
+      if !in_memory {
         @profiler.profiler_enter("write")
         let start_write = @bench.monotonic_clock_start()
         match @io.write_bytes_with(fs, out_path, wasm_bytes) {
@@ -518,10 +518,10 @@ fn build_cmd_debug(entry : String, out_path : String?) -> Unit {
     let mut all_valid = cached.length() > 0
     // Check library .wasm files exist
     for li in cached {
-      if not(module_names.contains(li.module_name)) {
+      if !module_names.contains(li.module_name) {
         module_names[li.module_name] = true
         let lib_path = cache_dir + "/" + li.module_name + ".wasm"
-        if not(@os_fs.path_exists(lib_path)) {
+        if !@os_fs.path_exists(lib_path) {
           all_valid = false
         }
       }
@@ -626,7 +626,7 @@ fn build_cmd_debug(entry : String, out_path : String?) -> Unit {
       e => abort("build --debug: " + e.user_message())
     }
     // Save linked imports cache
-    if not(@os_fs.path_exists(cache_dir)) {
+    if !@os_fs.path_exists(cache_dir) {
       let _ = c_system(
         system_command_bytes("mkdir -p " + shell_quote_command_arg(cache_dir)),
       )
@@ -648,7 +648,7 @@ fn build_cmd_debug(entry : String, out_path : String?) -> Unit {
   let preload_parts : Array[String] = []
   let module_names : Map[String, Bool] = {}
   for li in linked_imports {
-    if not(module_names.contains(li.module_name)) {
+    if !module_names.contains(li.module_name) {
       module_names[li.module_name] = true
       let lib_path = cache_dir + "/" + li.module_name + ".wasm"
       preload_parts.push("--preload " + li.module_name + "=" + lib_path)
@@ -715,7 +715,7 @@ fn save_library_modules(
   let db_imports = db.imports(entry)
   for imp in db_imports {
     let mod_name = @runtime_compile.linked_module_name(imp.path)
-    if not(module_names.contains(mod_name)) {
+    if !module_names.contains(mod_name) {
       continue
     }
     let lib_wasm_path = cache_dir + "/" + mod_name + ".wasm"
@@ -815,19 +815,19 @@ fn collect_reexport_types_recursive(
   for stmt in source_ast.stmts {
     match stmt {
       @vibe_core.Stmt::ExportEnumDef(name~, params~, ctors~, span~) =>
-        if wanted.contains(name) && not(found.contains(name)) {
+        if wanted.contains(name) && !found.contains(name) {
           found[name] = true
           result.push(@vibe_core.Stmt::EnumDef(name~, params~, ctors~, span~))
         }
       @vibe_core.Stmt::ExportTypeAlias(name~, params~, target~, span~) =>
-        if wanted.contains(name) && not(found.contains(name)) {
+        if wanted.contains(name) && !found.contains(name) {
           found[name] = true
           result.push(
             @vibe_core.Stmt::TypeAlias(name~, params~, target~, span~),
           )
         }
       @vibe_core.Stmt::ExportStructDef(name~, params~, fields~, span~) =>
-        if wanted.contains(name) && not(found.contains(name)) {
+        if wanted.contains(name) && !found.contains(name) {
           found[name] = true
           result.push(
             @vibe_core.Stmt::StructDef(name~, params~, fields~, span~),
@@ -836,7 +836,7 @@ fn collect_reexport_types_recursive(
       @vibe_core.Stmt::ReExport(spec=inner_spec, source=inner_source, ..) => {
         let inner_wanted : Map[String, Bool] = {}
         for item in inner_spec.items {
-          if wanted.contains(item.name) && not(found.contains(item.name)) {
+          if wanted.contains(item.name) && !found.contains(item.name) {
             inner_wanted[item.name] = true
           }
         }

--- a/src/cmd/vibe/cli_e2e_wbtest.mbt
+++ b/src/cmd/vibe/cli_e2e_wbtest.mbt
@@ -2100,7 +2100,7 @@ fn read_function_tracking_record(
   }
   let renamed_from = match record.get("renamed_from") {
     Some(Json::String(value)) =>
-      if value.trim().to_string().length() == 0 {
+      if value.trim().to_owned().length() == 0 {
         None
       } else {
         Some(value)
@@ -2161,9 +2161,9 @@ test "selfhost compiler source files roundtrip format" {
       fail(
         file +
         " roundtrip unstable:\n--- fmt1 (first 200) ---\n" +
-        fmt1[:200].to_string() +
+        fmt1[:200].to_owned() +
         "\n--- fmt2 (first 200) ---\n" +
-        fmt2[:200].to_string(),
+        fmt2[:200].to_owned(),
       )
     }
   }

--- a/src/cmd/vibe/cli_ide.mbt
+++ b/src/cmd/vibe/cli_ide.mbt
@@ -21,7 +21,7 @@ fn symbol_line_col(source : String, span : @vibe_core.Span) -> (Int, Int) {
 ///|
 fn symbol_line_text(source : String, span : @vibe_core.Span) -> String {
   let (_, line_start, line_end) = @vibe_core.line_info(source, span.start)
-  source[line_start:line_end].to_string()
+  source[line_start:line_end].to_owned()
 }
 
 ///|
@@ -33,7 +33,7 @@ fn graph_ir_line_col(source : String, row : @x_exp.GraphIrRow) -> (Int, Int) {
 ///|
 fn graph_ir_line_text(source : String, row : @x_exp.GraphIrRow) -> String {
   let (_, line_start, line_end) = @vibe_core.line_info(source, row.start)
-  source[line_start:line_end].to_string()
+  source[line_start:line_end].to_owned()
 }
 
 ///|
@@ -1351,11 +1351,11 @@ async fn lsp_main_loop() -> Unit {
       None => break
       Some(header_line) => {
         let header_str = header_line.to_string()
-        if not(header_str.has_prefix("Content-Length:")) {
+        if !header_str.has_prefix("Content-Length:") {
           continue
         }
         // Parse content length
-        let len_part = header_str[15:].to_string()
+        let len_part = header_str[15:].to_owned()
         let len_str = trim_whitespace(len_part)
         let content_length = @string.parse_int(len_str) catch { _ => continue }
 

--- a/src/cmd/vibe/cli_module_source.mbt
+++ b/src/cmd/vibe/cli_module_source.mbt
@@ -21,7 +21,7 @@ fn module_source_slice_by_span(
   if stop <= s {
     return ""
   }
-  source[s:stop].to_string()
+  source[s:stop].to_owned()
 }
 
 ///|
@@ -68,7 +68,7 @@ fn module_source_from_selected_stmt_spans(
       continue
     }
     out.write_string(snippet)
-    if not(snippet.has_suffix("\n")) {
+    if !snippet.has_suffix("\n") {
       out.write_char('\n')
     }
   }

--- a/src/cmd/vibe/cli_module_source_wbtest.mbt
+++ b/src/cmd/vibe/cli_module_source_wbtest.mbt
@@ -37,7 +37,7 @@ test "build_module_source_from_source keeps required type defs" {
 ///|
 test "build_module_source_from_source keeps parse errors" {
   let result = build_module_source_from_source("let =", "main")
-  if not(result is Err(_)) {
+  if !(result is Err(_)) {
     fail("expected parse error")
   }
 }

--- a/src/cmd/vibe/cli_normalize_cmd.mbt
+++ b/src/cmd/vibe/cli_normalize_cmd.mbt
@@ -78,7 +78,7 @@ fn normalize_collect_top_level_decls(
 fn normalize_is_simple_semver(text : String) -> Bool {
   let parts : Array[String] = []
   for part in text.split(".") {
-    let normalized = part.to_string()
+    let normalized = part.to_owned()
     if normalized.length() == 0 {
       return false
     }
@@ -111,7 +111,7 @@ fn normalize_parse_digits(text : String) -> Int? {
 fn normalize_parse_semver(text : String) -> (Int, Int, Int)? {
   let parts : Array[String] = []
   for part in text.split(".") {
-    parts.push(part.to_string())
+    parts.push(part.to_owned())
   }
   if parts.length() != 3 {
     return None
@@ -190,7 +190,7 @@ fn normalize_resolve_latest_scope_version(
   let mut best_version : String? = None
   let mut best_semver : (Int, Int, Int)? = None
   for entry in entries {
-    if not(entry.has_prefix(prefix)) || not(entry.has_suffix(suffix)) {
+    if !entry.has_prefix(prefix) || !entry.has_suffix(suffix) {
       continue
     }
     let ver_start = prefix.length()
@@ -269,7 +269,7 @@ fn normalize_is_unversioned_scope_import_target(scope : String) -> Bool {
     scope.has_suffix(".vibe") ||
     scope.has_suffix(".xm") ||
     scope.has_suffix(".wasm") ||
-    not(scope.contains("/")) {
+    !scope.contains("/") {
     false
   } else {
     true
@@ -281,7 +281,7 @@ fn normalize_resolve_index_import_line(
   line : String,
   lib_root : String,
 ) -> Result[String, String] {
-  let trimmed = line.trim().to_string()
+  let trimmed = line.trim().to_owned()
   let head = if trimmed.has_prefix("import ") {
     "import "
   } else {
@@ -304,7 +304,7 @@ fn normalize_resolve_index_import_line(
       let scope_head = rest
         .unsafe_substring(start=0, end=brace_pos)
         .trim()
-        .to_string()
+        .to_owned()
       let scope_tokens = normalize_split_ws_tokens(scope_head)
       let scope_buf = StringBuilder::new()
       for token in scope_tokens {
@@ -312,7 +312,7 @@ fn normalize_resolve_index_import_line(
       }
       let scope = scope_buf.to_string()
       if scope.length() == 0 ||
-        not(normalize_is_unversioned_scope_import_target(scope)) {
+        !normalize_is_unversioned_scope_import_target(scope) {
         return Ok(line)
       }
       let version = match
@@ -329,7 +329,7 @@ fn normalize_resolve_index_import_line(
       let suffix = rest
         .unsafe_substring(start=brace_pos, end=rest.length())
         .trim()
-        .to_string()
+        .to_owned()
       let out = StringBuilder::new()
       out.write_string(prefix)
       out.write_string(head)
@@ -343,13 +343,13 @@ fn normalize_resolve_index_import_line(
     None => ()
   }
   // Resolve legacy bare `import <scope>` declarations.
-  let mut rest_trimmed = rest.trim().to_string()
+  let mut rest_trimmed = rest.trim().to_owned()
   let has_semicolon = rest_trimmed.has_suffix(";")
   if has_semicolon && rest_trimmed.length() > 0 {
     rest_trimmed = rest_trimmed
       .unsafe_substring(start=0, end=rest_trimmed.length() - 1)
       .trim()
-      .to_string()
+      .to_owned()
   }
   let tokens = normalize_split_ws_tokens(rest_trimmed)
   if tokens.length() == 0 {
@@ -373,7 +373,7 @@ fn normalize_resolve_index_import_line(
   if scope.length() == 0 {
     return Ok(line)
   }
-  if not(normalize_is_unversioned_scope_import_target(scope)) {
+  if !normalize_is_unversioned_scope_import_target(scope) {
     return Ok(line)
   }
   let version = match normalize_resolve_latest_scope_version(lib_root, scope) {
@@ -412,7 +412,7 @@ fn normalize_resolve_index_import_versions(
 ) -> Result[String, String] {
   let lines : Array[String] = []
   for part in source.split("\n") {
-    lines.push(part.to_string())
+    lines.push(part.to_owned())
   }
   let out = StringBuilder::new()
   for i, line in lines {
@@ -457,7 +457,7 @@ fn normalize_ensure_index_version_export(
       _ => ()
     }
   }
-  if source.trim().to_string().length() == 0 {
+  if source.trim().to_owned().length() == 0 {
     Ok("export let version = \"0.1.0\"\n")
   } else {
     Ok("export let version = \"0.1.0\"\n\n" + source)
@@ -479,7 +479,7 @@ fn normalize_directory_vibe_files(
     if name == "." || name == ".." {
       continue
     }
-    if not(name.has_suffix(".vibe")) {
+    if !name.has_suffix(".vibe") {
       continue
     }
     let path = @vibe_fs.normalize_path(dir + "/" + name)
@@ -773,7 +773,7 @@ fn parse_normalize_cmd_options(
   if files.length() == 0 {
     return Err("normalize: expected <file...>")
   }
-  if output_path is Some(_) && not(merge) {
+  if output_path is Some(_) && !merge {
     return Err("normalize: -o is only valid with --merge")
   }
   if check && write {
@@ -785,7 +785,7 @@ fn parse_normalize_cmd_options(
   if check && merge {
     return Err("normalize: --check cannot be combined with --merge")
   }
-  if not(write) && not(check) && files.length() > 1 && not(merge) {
+  if !write && !check && files.length() > 1 && !merge {
     return Err("normalize: use --write or --check for multiple files")
   }
   Ok({ write, check, skip_unchanged, merge, library_mode, output_path, files })

--- a/src/cmd/vibe/cli_precompile.mbt
+++ b/src/cmd/vibe/cli_precompile.mbt
@@ -92,7 +92,7 @@ fn precompile_cmd(args : Array[String]) -> Unit {
     }
     ensure_dir_recursive(file_out_dir)
     for entry in entries {
-      if not(entry.has_suffix(".vibe")) {
+      if !entry.has_suffix(".vibe") {
         continue
       }
       // Skip entries that are too short to be valid filenames (e.g. ".vibe" artifacts)

--- a/src/cmd/vibe/cli_repl.mbt
+++ b/src/cmd/vibe/cli_repl.mbt
@@ -139,7 +139,7 @@ fn repl_split_words(line : String) -> Array[String] {
 fn repl_split_first_pipeline(line : String) -> (String, String?) {
   let parts : Array[String] = []
   for part_view in line.split("|>") {
-    parts.push(part_view.to_string())
+    parts.push(part_view.to_owned())
   }
   if parts.length() <= 1 {
     return (line, None)
@@ -151,7 +151,7 @@ fn repl_split_first_pipeline(line : String) -> (String, String?) {
     }
     tail.write_string(parts[i])
   }
-  let pipe_tail = tail.to_string().trim().to_string()
+  let pipe_tail = tail.to_string().trim().to_owned()
   let maybe_tail = if pipe_tail.length() == 0 { None } else { Some(pipe_tail) }
   (parts[0], maybe_tail)
 }
@@ -223,7 +223,7 @@ fn repl_symbols_parse_scope_value(
   let mut next_shell = include_shell
   let mut consumed = false
   for part_view in value.split(",") {
-    let part = part_view.to_string().trim().to_string()
+    let part = part_view.to_owned().trim().to_owned()
     if part.length() == 0 {
       continue
     }
@@ -242,7 +242,7 @@ fn repl_symbols_parse_scope_value(
         )
     }
   }
-  if not(consumed) {
+  if !consumed {
     return Err("symbols: missing value for --scope")
   }
   Ok((next_local, next_builtin, next_shell))
@@ -306,7 +306,7 @@ fn repl_parse_symbols_options(
       _ => return Err("symbols: unknown option " + arg)
     }
   }
-  if not(explicit) {
+  if !explicit {
     return Ok(repl_symbols_default_options())
   }
   Ok({ include_local, include_builtin, include_shell })
@@ -335,7 +335,7 @@ fn repl_collect_path_shell_commands() -> Array[String] {
     None => ()
     Some(path) =>
       for dir_view in path.split(":") {
-        let dir = dir_view.to_string()
+        let dir = dir_view.to_owned()
         let entries = @os_fs.read_dir(dir) catch { _ => [] }
         for name in entries {
           if seen.contains(name) {
@@ -534,7 +534,7 @@ fn repl_collect_current_symbol_matches(
   scratch_source : String,
   symbol : String?,
 ) -> Array[ReplSymbolMatch] {
-  if scratch_source.trim().to_string().length() == 0 {
+  if scratch_source.trim().to_owned().length() == 0 {
     return []
   }
   let db = @runtime.VibeDb::new()
@@ -563,7 +563,7 @@ fn repl_load_workspace_symbol_matches(
   symbol : String?,
 ) -> Result[Array[ReplSymbolMatch], String] {
   let workspace_entry = repl_workspace_entry_path()
-  if not(@os_fs.path_exists(workspace_entry)) {
+  if !@os_fs.path_exists(workspace_entry) {
     return Ok([])
   }
   match @loader.load_db_with_paths(workspace_entry) {
@@ -670,7 +670,7 @@ fn repl_symbol_match_to_json(
   obj["location"] = Json::string(repl_symbol_match_location(item))
   if include_snippet {
     obj["snippet"] = Json::string(
-      symbol_line_text(item.source, entry.span).trim().to_string(),
+      symbol_line_text(item.source, entry.span).trim().to_owned(),
     )
   }
   Json::object(obj)
@@ -699,12 +699,12 @@ fn repl_vibe_error_json(command : String, message : String) -> Json {
 
 ///|
 fn repl_parse_vibe_shell_invocation(line : String) -> VibeShellInvocation? {
-  let trimmed = line.trim().to_string()
+  let trimmed = line.trim().to_owned()
   if trimmed.length() == 0 {
     return None
   }
   let (head, pipeline_tail) = repl_split_first_pipeline(trimmed)
-  let tokens = repl_split_words(head.trim().to_string())
+  let tokens = repl_split_words(head.trim().to_owned())
   if tokens.length() == 0 {
     return None
   }
@@ -714,7 +714,7 @@ fn repl_parse_vibe_shell_invocation(line : String) -> VibeShellInvocation? {
     }
     (tokens[1], 2)
   } else {
-    if not(repl_is_vibe_shell_subcommand(tokens[0])) {
+    if !repl_is_vibe_shell_subcommand(tokens[0]) {
       return None
     }
     (tokens[0], 1)
@@ -949,7 +949,7 @@ fn repl_vibe_normalize_json(
   let selected_entries : Array[String] = []
   let seen_entries : Map[String, Bool] = {}
   for name in entry_names {
-    let trimmed = name.trim().to_string()
+    let trimmed = name.trim().to_owned()
     if trimmed.length() == 0 || seen_entries.contains(trimmed) {
       continue
     }
@@ -963,10 +963,10 @@ fn repl_vibe_normalize_json(
   }
   if target != "scratch" &&
     args.length() == 1 &&
-    source.trim().to_string().length() == 0 {
+    source.trim().to_owned().length() == 0 {
     return repl_vibe_error_json("normalize", "source is empty")
   }
-  if source.trim().to_string().length() == 0 {
+  if source.trim().to_owned().length() == 0 {
     return repl_vibe_error_json("normalize", "source is empty")
   }
   let normalized_result = if selected_entries.length() == 0 {
@@ -1232,7 +1232,7 @@ fn repl_print_multiline_text(
   print_line : (String) -> Unit,
 ) -> Unit {
   for part in text.split("\n") {
-    print_line(part.to_string())
+    print_line(part.to_owned())
   }
 }
 
@@ -1269,7 +1269,7 @@ fn repl_print_vibe_payload_human(
     Json::Object(obj) => {
       let command = repl_json_string_or(obj, "command", "vibe")
       let ok = repl_json_bool_or(obj, "ok", true)
-      if not(ok) {
+      if !ok {
         let err = repl_json_string_or(obj, "error", "unknown error")
         if err == "multiple matches" {
           let query = repl_json_string_or(obj, "query", "?")
@@ -1503,7 +1503,7 @@ fn repl_handle_peek_meta_command(
     entry.signature,
   )
   print_line("at " + repl_symbol_match_location(item))
-  let snippet = symbol_line_text(item.source, entry.span).trim().to_string()
+  let snippet = symbol_line_text(item.source, entry.span).trim().to_owned()
   if snippet.length() > 0 {
     print_line(snippet)
   }
@@ -1581,7 +1581,7 @@ fn handle_repl_meta_command(
   scratch_source : String,
   print_line : (String) -> Unit,
 ) -> ReplMetaCommandResult {
-  let trimmed = line.trim().to_string()
+  let trimmed = line.trim().to_owned()
   if trimmed.length() == 0 {
     return ReplMetaCommandResult::NotMeta
   }
@@ -1590,7 +1590,7 @@ fn handle_repl_meta_command(
       return ReplMetaCommandResult::HandledExit
     _ => ()
   }
-  if not(trimmed.has_prefix(":")) {
+  if !trimmed.has_prefix(":") {
     return ReplMetaCommandResult::NotMeta
   }
   let parts = repl_split_words(trimmed)
@@ -1622,7 +1622,7 @@ fn handle_repl_meta_command(
         return ReplMetaCommandResult::HandledContinue
       }
       let path = cmd_args[0]
-      if scratch_source.trim().to_string().length() == 0 {
+      if scratch_source.trim().to_owned().length() == 0 {
         print_line("nothing to save (empty session)")
         return ReplMetaCommandResult::HandledContinue
       }
@@ -1636,7 +1636,7 @@ fn handle_repl_meta_command(
       }
       let mut binding_count = 0
       for line_view in deduped.split("\n") {
-        let l = line_view.to_string().trim().to_string()
+        let l = line_view.to_owned().trim().to_owned()
         if l.has_prefix("let ") || l.has_prefix("export let ") {
           binding_count += 1
         }
@@ -1672,7 +1672,7 @@ fn handle_repl_meta_command(
       ReplMetaCommandResult::HandledLoadSource("")
     }
     ":source" => {
-      if scratch_source.trim().to_string().length() == 0 {
+      if scratch_source.trim().to_owned().length() == 0 {
         print_line("(empty session)")
       } else {
         print_line(scratch_source)
@@ -1714,7 +1714,7 @@ fn get_history_file_path() -> String {
 ///|
 fn load_history(target : Array[String]) -> Unit {
   let path = get_history_file_path()
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return
   }
   let content = @os_fs.read_file_to_string(path) catch { _ => return }
@@ -1723,7 +1723,7 @@ fn load_history(target : Array[String]) -> Unit {
   }
   let lines = content.split("\n")
   for line in lines {
-    let trimmed = line.to_string()
+    let trimmed = line.to_owned()
     if trimmed.length() > 0 {
       target.push(trimmed)
     }
@@ -1738,7 +1738,7 @@ fn append_history(line : String) -> Unit {
   let lines : Array[String] = []
   if existing.length() > 0 {
     for part in existing.split("\n") {
-      let s = part.to_string()
+      let s = part.to_owned()
       if s.length() > 0 {
         lines.push(s)
       }
@@ -1849,7 +1849,7 @@ fn repl_tui_cmd(
       None => ()
       Some(path) =>
         for dir_view in path.split(":") {
-          let dir = dir_view.to_string()
+          let dir = dir_view.to_owned()
           let entries = @os_fs.read_dir(dir) catch { _ => [] }
           for name in entries {
             let full_path = dir + "/" + name
@@ -1910,7 +1910,7 @@ fn repl_tui_cmd(
   fn completion_overlay(
     view : ReplViewState,
   ) -> (String?, OverlayRect?, CompletionAnchor?) {
-    if not(completion_visible()) {
+    if !completion_visible() {
       return (None, None, None)
     }
     let items = completion_session.get_items()
@@ -2060,7 +2060,7 @@ fn repl_tui_cmd(
     let mut need_clear = false
     match (last_popup_rect.val, next_rect) {
       (Some(prev), Some(next)) =>
-        if not(prev.eq(next)) {
+        if !prev.eq(next) {
           clear_rect(prev)
           need_clear = true
         }
@@ -2089,12 +2089,12 @@ fn repl_tui_cmd(
   fn push_output_line(line : String) -> Unit {
     // Split multi-line strings into separate output entries
     for part in line.split("\n") {
-      outputs.push(part.to_string())
+      outputs.push(part.to_owned())
     }
   }
 
   fn run_command(cmd : String) -> Bool {
-    let trimmed = cmd.trim().to_string()
+    let trimmed = cmd.trim().to_owned()
     if trimmed.length() == 0 {
       return true
     }
@@ -2201,7 +2201,7 @@ fn repl_tui_cmd(
     }
 
     let method_like = method_info is Some(_) || pipe_info is Some(_)
-    if prefix.length() == 0 && not(method_like) {
+    if prefix.length() == 0 && !method_like {
       completion_session.clear()
       return
     }
@@ -2235,7 +2235,7 @@ fn repl_tui_cmd(
           }
         }
       CompletionContext::VibeLetExpr | CompletionContext::VibeExpr => {
-        if not(method_like) {
+        if !method_like {
           for item in vibe_keywords {
             if item.has_prefix(prefix) {
               push_unique(items, item)
@@ -2412,7 +2412,7 @@ fn repl_tui_cmd(
               cleanup_once()
               return
             }
-            let input_value = input_editor.get_text().trim().to_string()
+            let input_value = input_editor.get_text().trim().to_owned()
             if input_value.length() > 0 {
               history.push(input_value)
               append_history(input_value)
@@ -2529,7 +2529,7 @@ fn repl_raw_output_text(text : String) -> String {
   let mut wrote = false
   for part in text.split("\n") {
     out.write_string("\r\n")
-    out.write_string(part.to_string())
+    out.write_string(part.to_owned())
     wrote = true
   }
   if wrote {
@@ -2551,7 +2551,7 @@ fn repl_print_wasm_run_value(
 
 ///|
 fn repl_compiled_zero_result_line(line : String) -> Bool {
-  let trimmed = line.trim().to_string()
+  let trimmed = line.trim().to_owned()
   trimmed.has_prefix("fn ") ||
   trimmed.has_prefix("enum ") ||
   trimmed.has_prefix("struct ") ||
@@ -2579,7 +2579,7 @@ fn repl_compiled_binding_rhs(line : String) -> String? {
   while i < chars.length() {
     if chars[i] == '=' {
       return Some(
-        line.unsafe_substring(start=i + 1, end=line.length()).trim().to_string(),
+        line.unsafe_substring(start=i + 1, end=line.length()).trim().to_owned(),
       )
     }
     i += 1
@@ -2917,7 +2917,7 @@ fn repl_try_compiled_display(wasm_path : String) -> String? {
     return None
   }
   let stdout = @os_fs.read_file_to_string(out_path) catch { _ => "" }
-  let display = stdout.trim().to_string()
+  let display = stdout.trim().to_owned()
   if display.length() == 0 {
     None
   } else {
@@ -2930,7 +2930,7 @@ fn repl_build_compiled_source(scratch_source : String, line : String) -> String 
   let buf = StringBuilder::new()
   let base = append_scratch_db_source(scratch_source, line)
   buf.write_string(base)
-  if not(base.has_suffix("\n")) {
+  if !base.has_suffix("\n") {
     buf.write_string("\n")
   }
   let result_expr = repl_compiled_result_expr(line)
@@ -3099,7 +3099,7 @@ fn run_compiled_shell_line(
   // Handle sh_lines directly in REPL (bypass WASM compilation)
   if effective_line.has_prefix("sh_lines(\"") &&
     effective_line.has_suffix("\")") {
-    let cmd = effective_line[10:effective_line.length() - 2].to_string()
+    let cmd = effective_line[10:effective_line.length() - 2].to_owned()
     let cmd_unescaped = cmd
       .replace(old="\\\\", new="\\")
       .replace(old="\\\"", new="\"")
@@ -3116,9 +3116,9 @@ fn run_compiled_shell_line(
     remove_file_if_exists(out_path)
     remove_file_if_exists(err_path)
     if status != 0 && stderr.length() > 0 {
-      print_line("error: " + stderr.trim().to_string())
-    } else if stdout.trim().to_string().length() > 0 {
-      print_line(stdout.trim().to_string())
+      print_line("error: " + stderr.trim().to_owned())
+    } else if stdout.trim().to_owned().length() > 0 {
+      print_line(stdout.trim().to_owned())
     }
     return scratch_source
   }
@@ -3203,8 +3203,8 @@ fn run_compiled_line_repl_with_prompt(
         }
         continue
       }
-      let line_str = trimmed.to_string()
-      if not(handle_cd_builtin(rt, line_str, fn(s) { println(s) })) {
+      let line_str = trimmed.to_owned()
+      if !handle_cd_builtin(rt, line_str, fn(s) { println(s) }) {
         scratch_source = run_compiled_shell_line(
           cache, rt, syntax_mode, scratch_db_path, source_path, wasm_path, scratch_source,
           line_str,
@@ -3248,7 +3248,7 @@ fn wasm_repl_stdin_cmd(args : Array[String]) -> Unit {
     }
   }
   // Ensure output directory exists
-  if not(@os_fs.path_exists(out_dir)) {
+  if !@os_fs.path_exists(out_dir) {
     @os_fs.create_dir(out_dir) catch {
       e =>
         abort("wasm-shell-stdin: failed to create output dir: " + e.to_string())
@@ -3275,7 +3275,7 @@ fn wasm_repl_stdin_cmd(args : Array[String]) -> Unit {
         }
         continue
       }
-      let line_str = trimmed.to_string()
+      let line_str = trimmed.to_owned()
       match line_str {
         ":q" | ":quit" | ":exit" | "exit" => break
         _ => {
@@ -3415,7 +3415,7 @@ fn repl_ai_cmd(
         }
         continue
       }
-      let line_str = trimmed.to_string()
+      let line_str = trimmed.to_owned()
       match
         handle_repl_meta_command(line_str, scratch_db_path, scratch_source, fn(
           s,
@@ -3557,11 +3557,11 @@ fn repl_interactive_plain_loop_compiled(
         }
         continue
       }
-      let line_str = trimmed.to_string()
+      let line_str = trimmed.to_owned()
       match line_str {
         ":q" | ":quit" | ":exit" | "exit" => break
         _ =>
-          if not(handle_cd_builtin(rt, line_str, fn(s) { println(s) })) {
+          if !handle_cd_builtin(rt, line_str, fn(s) { println(s) }) {
             scratch_source = run_compiled_shell_line(
               cache, rt, syntax_mode, scratch_db_path, source_path, wasm_path, scratch_source,
               line_str,
@@ -3615,7 +3615,7 @@ fn repl_interactive_raw_loop_compiled(
   }
 
   fn redraw_line() {
-    if not(prompt_enabled) {
+    if !prompt_enabled {
       return
     }
     let prompt = get_prompt()
@@ -3774,7 +3774,7 @@ fn repl_interactive_raw_loop_compiled(
   let done = Ref(false)
 
   fn submit_line() {
-    let text = line_buf_to_string().trim().to_string()
+    let text = line_buf_to_string().trim().to_owned()
     @tui.print_raw("\r\n")
     line_buf.reset()
     cursor_pos.val = 0
@@ -3797,7 +3797,7 @@ fn repl_interactive_raw_loop_compiled(
       history.push(text)
       append_history(text)
     }
-    if not(handle_cd_builtin(rt, text, raw_println)) {
+    if !handle_cd_builtin(rt, text, raw_println) {
       scratch_source_ref.val = run_compiled_shell_line(
         cache,
         rt,
@@ -3945,8 +3945,8 @@ fn repl_deduplicate_bindings(source : String) -> String {
   let buf = StringBuilder::new()
   let mut in_block = 0
   for line_view in source.split("\n") {
-    let line = line_view.to_string()
-    let trimmed = line.trim().to_string()
+    let line = line_view.to_owned()
+    let trimmed = line.trim().to_owned()
     // Track brace depth for multi-line blocks
     for ch in trimmed {
       if ch == '{' {
@@ -3961,7 +3961,7 @@ fn repl_deduplicate_bindings(source : String) -> String {
       in_block = 0
       let stmt = buf.to_string()
       buf.reset()
-      let name = extract_let_binding_name(stmt.trim().to_string())
+      let name = extract_let_binding_name(stmt.trim().to_owned())
       stmts.push((stmt, name))
     }
   }
@@ -3992,9 +3992,9 @@ fn repl_deduplicate_bindings(source : String) -> String {
     }
     if keep {
       let stmt_text = stmts[i].0
-      if stmt_text.trim().to_string().length() > 0 {
+      if stmt_text.trim().to_owned().length() > 0 {
         out.write_string(stmt_text)
-        if not(stmt_text.has_suffix("\n")) {
+        if !stmt_text.has_suffix("\n") {
           out.write_char('\n')
         }
       }
@@ -4016,7 +4016,7 @@ fn extract_let_binding_name(line : String) -> String? {
       break
     }
   }
-  if not(found) {
+  if !found {
     return None
   }
   // Extract name until = or : or space
@@ -4040,7 +4040,7 @@ fn extract_let_binding_name(line : String) -> String? {
 /// Extract VIBE_DISPLAY: line from Node runner output.
 fn extract_vibe_display_line(stdout : String) -> String? {
   for line_view in stdout.split("\n") {
-    let line = line_view.to_string()
+    let line = line_view.to_owned()
     if line.has_prefix("VIBE_DISPLAY:") {
       return Some(line[13:].to_owned())
     }
@@ -4055,7 +4055,7 @@ fn handle_cd_builtin(
   line : String,
   print_line : (String) -> Unit,
 ) -> Bool {
-  if not(line == "cd" || line.has_prefix("cd ")) {
+  if !(line == "cd" || line.has_prefix("cd ")) {
     return false
   }
   let arg = if line == "cd" {
@@ -4069,7 +4069,7 @@ fn handle_cd_builtin(
     for i in 3..<chars.length() {
       rest.write_char(chars[i])
     }
-    rest.to_string().trim().to_string()
+    rest.to_string().trim().to_owned()
   }
   // Resolve relative paths against current cwd
   let target = if arg.has_prefix("/") {

--- a/src/cmd/vibe/cli_run_cmd.mbt
+++ b/src/cmd/vibe/cli_run_cmd.mbt
@@ -17,7 +17,7 @@ fn cli_use_session_http() -> Bool {
 ///|
 fn first_non_empty_line(text : String) -> String {
   for line_view in text.split("\n") {
-    let line = line_view.trim().to_string()
+    let line = line_view.trim().to_owned()
     if line.length() > 0 {
       return line
     }
@@ -29,7 +29,7 @@ fn first_non_empty_line(text : String) -> String {
 fn last_non_empty_line(text : String) -> String {
   let mut out = ""
   for line_view in text.split("\n") {
-    let line = line_view.trim().to_string()
+    let line = line_view.trim().to_owned()
     if line.length() > 0 {
       out = line
     }
@@ -39,7 +39,7 @@ fn last_non_empty_line(text : String) -> String {
 
 ///|
 fn parse_numeric_line_int64(line : String) -> Int64? {
-  let trimmed = line.trim().to_string()
+  let trimmed = line.trim().to_owned()
   if trimmed.length() == 0 {
     return None
   }
@@ -53,7 +53,7 @@ fn parse_numeric_line_int64(line : String) -> Int64? {
     }
     has_digit = true
   }
-  if not(has_digit) {
+  if !has_digit {
     return None
   }
   let value = @string.parse_int(trimmed) catch { _ => return None }
@@ -64,7 +64,7 @@ fn parse_numeric_line_int64(line : String) -> Int64? {
 fn parse_last_numeric_line_int64(text : String) -> Int64? {
   let mut out : Int64? = None
   for line_view in text.split("\n") {
-    let line = line_view.to_string()
+    let line = line_view.to_owned()
     match parse_numeric_line_int64(line) {
       Some(value) => out = Some(value)
       None => ()
@@ -140,7 +140,7 @@ fn resolve_http_host_runner(
 ) -> Result[HttpHostRunner, String] {
   let node_bin = match @sys.get_env_var("NODE_BIN") {
     Some(raw) => {
-      let value = raw.trim().to_string()
+      let value = raw.trim().to_owned()
       if value.length() > 0 {
         value
       } else {
@@ -202,8 +202,8 @@ fn resolve_http_host_runner(
 ///|
 fn split_command_flag_words(raw : String) -> Array[String] {
   let out : Array[String] = []
-  for part in raw.trim().to_string().split(" ") {
-    let token = part.trim().to_string()
+  for part in raw.trim().to_owned().split(" ") {
+    let token = part.trim().to_owned()
     if token.length() > 0 {
       out.push(token)
     }
@@ -816,10 +816,10 @@ fn run_cmd_wasm_linked(
   // Verify all library .wasm exist
   let module_names : Map[String, Bool] = {}
   for li in cached_imports {
-    if not(module_names.contains(li.module_name)) {
+    if !module_names.contains(li.module_name) {
       module_names[li.module_name] = true
       let lib_path = cache_dir + "/" + li.module_name + ".wasm"
-      if not(@os_fs.path_exists(lib_path)) {
+      if !@os_fs.path_exists(lib_path) {
         return Err("missing library")
       }
     }
@@ -866,7 +866,7 @@ fn run_cmd_wasm_linked(
   )
   let seen : Map[String, Bool] = {}
   for li in cached_imports {
-    if not(seen.contains(li.module_name)) {
+    if !seen.contains(li.module_name) {
       seen[li.module_name] = true
       let lib_path = cache_dir + "/" + li.module_name + ".wasm"
       cmd = shell_quote_command_arg(runner.wasmtime_bin)
@@ -925,7 +925,7 @@ fn run_cmd_wasm_backend_with_cache(
     Some("release") | Some("monolithic") => true
     _ => false
   }
-  if not(force_release) {
+  if !force_release {
     let resolved = @loader.resolve_entry_path(entry_path)
     let parent = @vibe_fs.parent_path(resolved)
     let (vibe_root, cache_key) = find_vibe_cache_root(resolved)
@@ -985,7 +985,7 @@ fn run_cmd_wasm_backend_with_cache(
   } else {
     parent + "/.vibe_run_wasm_" + stamp + ".wasm"
   }
-  if not(use_cached_wasm) {
+  if !use_cached_wasm {
     let wasm_bytes = compile_module_wasm_for_exec(
       db,
       entry,
@@ -1013,7 +1013,7 @@ fn run_cmd_wasm_backend_with_cache(
       Err(_) => ()
     }
   }
-  defer (if not(use_cached_wasm) { remove_file_if_exists(wasm_path) })
+  defer (if !use_cached_wasm { remove_file_if_exists(wasm_path) })
   let exec_out = match http_runner {
     Some(host_runner) =>
       run_http_host_invoke_run_capture(
@@ -1075,7 +1075,7 @@ fn run_cmd_wasm_backend_with_cache(
 ///|
 fn extract_vibe_display_line_run(stdout : String) -> String? {
   for line_view in stdout.split("\n") {
-    let line = line_view.to_string()
+    let line = line_view.to_owned()
     if line.has_prefix("VIBE_DISPLAY:") {
       return Some(line[13:].to_owned())
     }

--- a/src/cmd/vibe/cli_scratch_helpers.mbt
+++ b/src/cmd/vibe/cli_scratch_helpers.mbt
@@ -1,10 +1,10 @@
 ///|
 fn load_scratch_db_source(path : String) -> Result[String, String] {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return Ok("")
   }
   let is_file = @os_fs.is_file(path) catch { _ => false }
-  if not(is_file) {
+  if !is_file {
     return Err("scratch-db path is not a file: " + path)
   }
   let source = @os_fs.read_file_to_string(path) catch {
@@ -44,7 +44,7 @@ fn collect_scratch_scope_symbols(
   path : String,
   source : String,
 ) -> Array[ScratchScopeSymbol] {
-  if source.trim().to_string().length() == 0 {
+  if source.trim().to_owned().length() == 0 {
     return []
   }
   let db = @runtime.VibeDb::new()
@@ -105,7 +105,7 @@ fn vibe_cache_json_path(index_root : String) -> String {
 fn load_vibe_cache_object(index_root : String) -> Map[String, Json] {
   let path = vibe_cache_json_path(index_root)
   let obj : Map[String, Json] = {}
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return obj
   }
   let source = @os_fs.read_file_to_string(path) catch { _ => return obj }
@@ -128,7 +128,7 @@ fn write_vibe_cache_object(
 ) -> Result[Unit, String] {
   let path = vibe_cache_json_path(index_root)
   let dir = @vibe_fs.parent_path(path)
-  if not(@os_fs.path_exists(dir)) {
+  if !@os_fs.path_exists(dir) {
     @os_fs.create_dir(dir) catch {
       e => return Err("mkdir .vibe: " + e.to_string())
     }
@@ -143,8 +143,8 @@ fn write_vibe_cache_object(
 fn resolve_active_ns_name_from_cache(cache : Map[String, Json]) -> String {
   match cache.get("active_namespace") {
     Some(Json::String(name)) =>
-      if name.trim().to_string().length() > 0 {
-        name.trim().to_string()
+      if name.trim().to_owned().length() > 0 {
+        name.trim().to_owned()
       } else {
         default_scratch_ns_name()
       }
@@ -163,8 +163,8 @@ fn resolve_ns_db_rel_path_from_cache(
         Some(Json::Object(ns_obj)) =>
           match ns_obj.get("db_path") {
             Some(Json::String(path)) =>
-              if path.trim().to_string().length() > 0 {
-                path.trim().to_string()
+              if path.trim().to_owned().length() > 0 {
+                path.trim().to_owned()
               } else {
                 default_ns_db_rel_path(ns_name)
               }
@@ -191,7 +191,7 @@ fn resolve_scratch_db_path_for_index_root(
 ) -> Result[(String, String), String] {
   match @sys.get_env_var("VIBE_SCRATCH_DB_PATH") {
     Some(path) =>
-      if path.trim().to_string().length() == 0 {
+      if path.trim().to_owned().length() == 0 {
         Err("VIBE_SCRATCH_DB_PATH must not be empty")
       } else {
         Ok((default_scratch_ns_name(), @loader.resolve_entry_path(path)))
@@ -232,12 +232,12 @@ fn resolve_scratch_db_path_for_index_root(
 
 ///|
 fn scratch_source_is_import_stmt(source : String) -> Bool {
-  source.trim().to_string().has_prefix("import ")
+  source.trim().to_owned().has_prefix("import ")
 }
 
 ///|
 fn scratch_source_is_import_prefix_line(line : String) -> Bool {
-  let trimmed = line.trim().to_string()
+  let trimmed = line.trim().to_owned()
   trimmed.length() == 0 ||
   trimmed.has_prefix("//") ||
   trimmed.has_prefix("/*") ||
@@ -282,9 +282,9 @@ fn scratch_source_contains_import_stmt(
     }
     None => ()
   }
-  let target = import_stmt.trim().to_string()
+  let target = import_stmt.trim().to_owned()
   for line_view in base_source.split("\n") {
-    if line_view.to_string().trim().to_string() == target {
+    if line_view.to_owned().trim().to_owned() == target {
       return true
     }
   }
@@ -318,7 +318,7 @@ fn append_scratch_db_source_hoist_import(
   let mut inserted = false
   let mut import_block_depth = 0
   for line_view in base_source.split("\n") {
-    let line = line_view.to_string()
+    let line = line_view.to_owned()
     if import_block_depth > 0 {
       head.write_string(line)
       head.write_char('\n')
@@ -331,7 +331,7 @@ fn append_scratch_db_source_hoist_import(
     if in_prefix && scratch_source_is_import_prefix_line(line) {
       head.write_string(line)
       head.write_char('\n')
-      if line.trim().to_string().has_prefix("import ") {
+      if line.trim().to_owned().has_prefix("import ") {
         import_block_depth = scratch_source_import_block_delta(line)
         if import_block_depth < 0 {
           import_block_depth = 0
@@ -348,7 +348,7 @@ fn append_scratch_db_source_hoist_import(
     tail.write_string(line)
     tail.write_char('\n')
   }
-  if not(inserted) {
+  if !inserted {
     head.write_string(import_stmt)
     head.write_char('\n')
   }
@@ -358,7 +358,7 @@ fn append_scratch_db_source_hoist_import(
 
 ///|
 fn append_scratch_db_source(base_source : String, expr : String) -> String {
-  let trimmed = expr.trim().to_string()
+  let trimmed = expr.trim().to_owned()
   if trimmed.length() == 0 {
     return base_source
   }
@@ -372,12 +372,12 @@ fn append_scratch_db_source(base_source : String, expr : String) -> String {
     let out = StringBuilder::new()
     if base_source.length() > 0 {
       out.write_string(base_source)
-      if not(base_source.has_suffix("\n")) {
+      if !base_source.has_suffix("\n") {
         out.write_char('\n')
       }
     }
     out.write_string(trimmed)
-    if not(trimmed.has_suffix("\n")) {
+    if !trimmed.has_suffix("\n") {
       out.write_char('\n')
     }
     out.to_string()

--- a/src/cmd/vibe/cli_session.mbt
+++ b/src/cmd/vibe/cli_session.mbt
@@ -177,7 +177,7 @@ fn session_http_port_for_entry_with_features(
 ///|
 fn current_cli_binary_path() -> String? {
   let resolve_bin = fn(raw : String) -> String {
-    if raw.has_prefix("/") || not(raw.contains("/")) {
+    if raw.has_prefix("/") || !raw.contains("/") {
       raw
     } else {
       @io.current_dir_or_root() + "/" + raw
@@ -487,7 +487,7 @@ fn ensure_session_http_worker(
   }
   if ping_state is SessionHttpPingState::Alive(_) {
     ignore(session_http_shutdown(port))
-    if not(session_http_wait_until_unreachable(port)) {
+    if !session_http_wait_until_unreachable(port) {
       return Err("session-http: stale worker did not shut down")
     }
   }
@@ -767,7 +767,7 @@ fn parse_cli_session_request(
   match json {
     Json::Object(obj) => {
       let cmd = match obj.get("cmd") {
-        Some(Json::String(value)) => value.trim().to_string().to_lower()
+        Some(Json::String(value)) => value.trim().to_owned().to_lower()
         _ => return Err("session-json: missing cmd")
       }
       match cmd {
@@ -779,7 +779,7 @@ fn parse_cli_session_request(
         "run" =>
           match obj.get("path") {
             Some(Json::String(value)) => {
-              let path = value.trim().to_string()
+              let path = value.trim().to_owned()
               if path.length() == 0 {
                 Err("session-json: missing path")
               } else {
@@ -794,7 +794,7 @@ fn parse_cli_session_request(
         "check" =>
           match obj.get("path") {
             Some(Json::String(value)) => {
-              let path = value.trim().to_string()
+              let path = value.trim().to_owned()
               if path.length() == 0 {
                 Err("session-json: missing path")
               } else {
@@ -809,7 +809,7 @@ fn parse_cli_session_request(
         "test" =>
           match obj.get("path") {
             Some(Json::String(value)) => {
-              let path = value.trim().to_string()
+              let path = value.trim().to_owned()
               if path.length() == 0 {
                 Err("session-json: missing path")
               } else {
@@ -945,7 +945,7 @@ fn session_json_cmd(
     let input = @stdio.stdin
     let cache = CliEntryDbCache::new()
     while input.read_until("\n") is Some(line) {
-      let trimmed = line.trim().to_string()
+      let trimmed = line.trim().to_owned()
       if trimmed.length() == 0 {
         continue
       }
@@ -1125,7 +1125,7 @@ fn find_json_lines(text : String) -> Array[String] {
   let lines = text.split("\n")
   let out : Array[String] = []
   for line in lines {
-    let trimmed = line.to_string().trim().to_string()
+    let trimmed = line.to_owned().trim().to_owned()
     if trimmed.length() > 0 && trimmed.has_prefix("{") {
       out.push(trimmed)
     }

--- a/src/cmd/vibe/cli_test_cmd.mbt
+++ b/src/cmd/vibe/cli_test_cmd.mbt
@@ -145,13 +145,13 @@ fn render_stmt_snippets(
             inner_span.start,
             inner_span.end,
           )
-          if snippet.trim().to_string().length() == 0 {
+          if snippet.trim().to_owned().length() == 0 {
             j = j + 1
             continue
           }
           out.write_string("  ")
           out.write_string(snippet)
-          if not(snippet.has_suffix("\n")) {
+          if !snippet.has_suffix("\n") {
             out.write_char('\n')
           }
           j = j + 1
@@ -162,12 +162,12 @@ fn render_stmt_snippets(
       None => {
         seen_spans[span_key] = true
         let snippet = source_slice_by_span(source, span.start, span.end)
-        if snippet.trim().to_string().length() == 0 {
+        if snippet.trim().to_owned().length() == 0 {
           i = i + 1
           continue
         }
         out.write_string(snippet)
-        if not(snippet.has_suffix("\n")) {
+        if !snippet.has_suffix("\n") {
           out.write_char('\n')
         }
         i = i + 1
@@ -249,7 +249,7 @@ fn compiled_test_prelude_collect_ref_name(
   scope : @vibe_core.WalkerScope,
   refs : Map[String, Bool],
 ) -> Unit {
-  if not(scope.contains(name)) {
+  if !scope.contains(name) {
     refs[name] = true
   }
 }
@@ -296,7 +296,7 @@ fn partition_compiled_test_prelude_stmts(
 ) -> (Array[@vibe_core.Stmt], Array[@vibe_core.Stmt]) {
   let required_names : Map[String, Bool] = {}
   for stmt in stmts {
-    if not(compiled_test_prelude_stmt_runs_in_wrapper(stmt)) {
+    if !compiled_test_prelude_stmt_runs_in_wrapper(stmt) {
       compiled_test_prelude_absorb_stmt_refs(stmt, required_names)
     }
   }
@@ -312,7 +312,7 @@ fn partition_compiled_test_prelude_stmts(
   let wrapper_prelude_stmts : Array[@vibe_core.Stmt] = []
   for stmt in stmts {
     if compiled_test_prelude_stmt_runs_in_wrapper(stmt) &&
-      not(compiled_test_prelude_stmt_must_stay_top_level(stmt, required_names)) {
+      !compiled_test_prelude_stmt_must_stay_top_level(stmt, required_names) {
       wrapper_prelude_stmts.push(stmt)
     } else {
       top_level_stmts.push(stmt)
@@ -328,24 +328,24 @@ fn build_compiled_test_case_source(
   body_source : String,
 ) -> String {
   let out = StringBuilder::new()
-  if top_level_source.trim().to_string().length() > 0 {
+  if top_level_source.trim().to_owned().length() > 0 {
     out.write_string(top_level_source)
-    if not(top_level_source.has_suffix("\n")) {
+    if !top_level_source.has_suffix("\n") {
       out.write_char('\n')
     }
   }
   out.write_string(
     "let __vibe_compiled_test_case = () -> Int with { Error, Fs, Process, Env, Stdout, Stdin, Net, Async, Threads, Llm } {\n",
   )
-  if wrapper_prelude_source.trim().to_string().length() > 0 {
+  if wrapper_prelude_source.trim().to_owned().length() > 0 {
     out.write_string(wrapper_prelude_source)
-    if not(wrapper_prelude_source.has_suffix("\n")) {
+    if !wrapper_prelude_source.has_suffix("\n") {
       out.write_char('\n')
     }
   }
-  if body_source.trim().to_string().length() > 0 {
+  if body_source.trim().to_owned().length() > 0 {
     out.write_string(body_source)
-    if not(body_source.has_suffix("\n")) {
+    if !body_source.has_suffix("\n") {
       out.write_char('\n')
     }
   }
@@ -372,9 +372,9 @@ fn build_compiled_test_batch_source(
   body_sources : Array[String],
 ) -> String {
   let out = StringBuilder::new()
-  if top_level_source.trim().to_string().length() > 0 {
+  if top_level_source.trim().to_owned().length() > 0 {
     out.write_string(top_level_source)
-    if not(top_level_source.has_suffix("\n")) {
+    if !top_level_source.has_suffix("\n") {
       out.write_char('\n')
     }
   }
@@ -385,15 +385,15 @@ fn build_compiled_test_batch_source(
       i.to_string() +
       " = () -> Int with { Error, Fs, Process, Env, Stdout, Stdin, Net, Async, Threads, Llm } {\n",
     )
-    if wrapper_prelude_source.trim().to_string().length() > 0 {
+    if wrapper_prelude_source.trim().to_owned().length() > 0 {
       out.write_string(wrapper_prelude_source)
-      if not(wrapper_prelude_source.has_suffix("\n")) {
+      if !wrapper_prelude_source.has_suffix("\n") {
         out.write_char('\n')
       }
     }
-    if body_source.trim().to_string().length() > 0 {
+    if body_source.trim().to_owned().length() > 0 {
       out.write_string(body_source)
-      if not(body_source.has_suffix("\n")) {
+      if !body_source.has_suffix("\n") {
         out.write_char('\n')
       }
     }
@@ -613,7 +613,7 @@ fn run_test_file_compiled_with_cache(
     match stmt {
       @vibe_core.Stmt::Test(..) | @vibe_core.Stmt::Bench(..) => ()
       _ =>
-        if not(should_omit_compiled_test_prelude_stmt(stmt)) {
+        if !should_omit_compiled_test_prelude_stmt(stmt) {
           prelude_stmts.push(stmt)
         }
     }
@@ -632,7 +632,7 @@ fn run_test_file_compiled_with_cache(
   } else {
     parent + "/.vibe_test_batch_" + stamp + ".wasm"
   }
-  if not(use_cached_batch_wasm) {
+  if !use_cached_batch_wasm {
     // Build batched source: all tests compiled + run in a single WASM
     let body_sources : Array[String] = []
     for case in cases {
@@ -714,7 +714,7 @@ fn run_test_file_compiled_with_cache(
   // stdout contains "last: N" where N is the failure count
   let fail_count = if run_out.status != 0 {
     // Parse failure count from stdout "last: N"
-    let stdout = run_out.stdout.trim().to_string()
+    let stdout = run_out.stdout.trim().to_owned()
     if stdout.has_prefix("last: ") {
       let num_str = stdout.unsafe_substring(start=6, end=stdout.length())
       let parsed : Result[Int, _] = try? @string.parse_int(num_str)
@@ -1000,7 +1000,7 @@ fn test_cmd_sequential(
 fn test_batch_weight_cache_path() -> String? {
   match @sys.get_env_var("VIBE_TEST_BATCH_WEIGHT_CACHE") {
     Some(raw) => {
-      let trimmed = raw.trim().to_string()
+      let trimmed = raw.trim().to_owned()
       if trimmed.length() == 0 {
         None
       } else {
@@ -1030,11 +1030,11 @@ fn strip_leading_slashes(path : String) -> String {
 
 ///|
 fn test_batch_weight_cache_key(path : String) -> String {
-  if not(path.has_prefix("/")) {
+  if !path.has_prefix("/") {
     return strip_leading_slashes(@vibe_fs.normalize_path(path))
   }
   let normalized = @vibe_fs.normalize_path(path)
-  if not(normalized.has_prefix("/")) {
+  if !normalized.has_prefix("/") {
     return normalized
   }
   let cwd = @vibe_fs.normalize_path(@io.current_dir_or_root())
@@ -1051,7 +1051,7 @@ fn test_batch_weight_cache_key(path : String) -> String {
 
 ///|
 fn load_test_batch_weight_cache(cache_path : String) -> Map[String, Int] {
-  if not(@os_fs.path_exists(cache_path)) {
+  if !@os_fs.path_exists(cache_path) {
     return {}
   }
   let text = @os_fs.read_file_to_string(cache_path) catch { _ => return {} }
@@ -1307,7 +1307,7 @@ fn test_entry_batch_has_unassigned_other_root_after(
           already_assigned = true
         }
       }
-      if not(already_assigned) {
+      if !already_assigned {
         return true
       }
     }
@@ -1346,7 +1346,7 @@ let test_entry_batch_max_chunk_size = 4
 fn test_entry_batch_env_chunk_size() -> Int? {
   match @sys.get_env_var("VIBE_TEST_BATCH_CHUNK_SIZE") {
     Some(raw) => {
-      let parsed = @string.parse_int(raw.trim().to_string()) catch { _ => 0 }
+      let parsed = @string.parse_int(raw.trim().to_owned()) catch { _ => 0 }
       if parsed > 0 {
         Some(parsed)
       } else {
@@ -1776,11 +1776,11 @@ fn test_cmd_parallel(
           if code != 0 {
             println("  process exited with code \{code}")
           }
-          if stdout_text.trim().to_string().length() > 0 {
-            println("  stdout: \{stdout_text.trim().to_string()}")
+          if stdout_text.trim().to_owned().length() > 0 {
+            println("  stdout: \{stdout_text.trim().to_owned()}")
           }
-          if stderr_text.trim().to_string().length() > 0 {
-            println("  stderr: \{stderr_text.trim().to_string()}")
+          if stderr_text.trim().to_owned().length() > 0 {
+            println("  stderr: \{stderr_text.trim().to_owned()}")
           }
           any_failed = true
           failed_count += 1
@@ -1839,8 +1839,8 @@ fn test_cmd_parallel(
             println("\{path}: fail (missing JSON report)")
             if code != 0 {
               println("  process exited with code \{code}")
-              if stderr_text.trim().to_string().length() > 0 {
-                println("  stderr: \{stderr_text.trim().to_string()}")
+              if stderr_text.trim().to_owned().length() > 0 {
+                println("  stderr: \{stderr_text.trim().to_owned()}")
               }
             }
             any_failed = true
@@ -1860,12 +1860,12 @@ fn test_cmd_parallel(
             None => has_failure_in_batch = true
           }
         }
-        if not(has_failure_in_batch) {
+        if !has_failure_in_batch {
           for path in batch_paths {
             println("\{path}: fail (process exited with code \{code})")
           }
-          if stderr_text.trim().to_string().length() > 0 {
-            println("  stderr: \{stderr_text.trim().to_string()}")
+          if stderr_text.trim().to_owned().length() > 0 {
+            println("  stderr: \{stderr_text.trim().to_owned()}")
           }
           any_failed = true
           failed_count += batch_paths.length()

--- a/src/cmd/vibe/cli_tools_cmd.mbt
+++ b/src/cmd/vibe/cli_tools_cmd.mbt
@@ -309,7 +309,7 @@ fn collect_symbols_rows(
         if candidate.def.name != def.name {
           continue
         }
-        if not(symbols_defs_equivalent(def, candidate.def)) {
+        if !symbols_defs_equivalent(def, candidate.def) {
           has_conflicting_scratch = true
           break
         }
@@ -421,17 +421,17 @@ fn is_scaffold_seed_vibe_root(vibe_root : String) -> Bool {
   let json_mod = @vibe_fs.normalize_path(json_dir + "/json.vibe")
   let base64_mod = @vibe_fs.normalize_path(base64_dir + "/base64.vibe")
   let sha1_mod = @vibe_fs.normalize_path(sha1_dir + "/sha1.vibe")
-  if not(has_prelude) {
+  if !has_prelude {
     return false
   }
   let prelude_is_dir = @os_fs.is_dir(prelude_dir) catch { _ => false }
-  if not(prelude_is_dir) {
+  if !prelude_is_dir {
     return false
   }
   let json_is_dir = @os_fs.is_dir(json_dir) catch { _ => false }
   let base64_is_dir = @os_fs.is_dir(base64_dir) catch { _ => false }
   let sha1_is_dir = @os_fs.is_dir(sha1_dir) catch { _ => false }
-  if not(json_is_dir) || not(base64_is_dir) || not(sha1_is_dir) {
+  if !json_is_dir || !base64_is_dir || !sha1_is_dir {
     return false
   }
   @os_fs.path_exists(string_mod) &&
@@ -466,7 +466,7 @@ fn resolve_scaffold_seed_vibe_root() -> String? {
 fn ensure_dir_recursive(path : String) -> Unit {
   if @os_fs.path_exists(path) {
     let is_dir = @os_fs.is_dir(path) catch { _ => false }
-    if not(is_dir) {
+    if !is_dir {
       abort("init: path exists and is not directory: " + path)
     }
     return
@@ -477,7 +477,7 @@ fn ensure_dir_recursive(path : String) -> Unit {
   }
   @os_fs.create_dir(path) catch {
     e =>
-      if not(@os_fs.path_exists(path)) {
+      if !@os_fs.path_exists(path) {
         abort("init: mkdir failed: " + path + " (" + e.to_string() + ")")
       }
   }
@@ -501,17 +501,17 @@ fn copy_seed_tree_if_missing(src_dir : String, dest_dir : String) -> Bool {
   if src_norm == dest_norm {
     return false
   }
-  if not(@os_fs.path_exists(src_norm)) {
+  if !@os_fs.path_exists(src_norm) {
     return false
   }
   let src_is_dir = @os_fs.is_dir(src_norm) catch { _ => false }
-  if not(src_is_dir) {
+  if !src_is_dir {
     return false
   }
   let mut changed = false
   if @os_fs.path_exists(dest_norm) {
     let dest_is_dir = @os_fs.is_dir(dest_norm) catch { _ => false }
-    if not(dest_is_dir) {
+    if !dest_is_dir {
       abort("init: seed target exists and is not directory: " + dest_norm)
     }
   } else {
@@ -533,7 +533,7 @@ fn copy_seed_tree_if_missing(src_dir : String, dest_dir : String) -> Bool {
       if copy_seed_tree_if_missing(src_path, dest_path) {
         changed = true
       }
-    } else if not(@os_fs.path_exists(dest_path)) {
+    } else if !@os_fs.path_exists(dest_path) {
       let content = match @io.read_string(src_path) {
         Ok(v) => v
         Err(err) => abort("init: read failed: " + src_path + " (" + err + ")")
@@ -565,7 +565,7 @@ fn scaffold_project_root_with_seed(
     created.push("index.lock")
   }
   let vibe_dir = root + "/.vibe"
-  if not(@os_fs.path_exists(vibe_dir)) {
+  if !@os_fs.path_exists(vibe_dir) {
     ensure_dir_recursive(vibe_dir)
     created.push(".vibe/")
   }
@@ -728,7 +728,7 @@ fn source_slice_by_span(source : String, start : Int, end : Int) -> String {
   if stop <= s {
     return ""
   }
-  source[s:stop].to_string()
+  source[s:stop].to_owned()
 }
 
 ///|
@@ -796,7 +796,7 @@ fn save_cmd(args : Array[String]) -> Unit {
     saved_count += 1
   }
   // Update paths.json for the main module
-  if not(use_git) {
+  if !use_git {
     let base_dir = find_vibe_dir(path)
     let codebase = @codebase.Codebase::new(base_dir)
     let _ = codebase.upsert_path_mapping(file_arg, bundle.main_hash) catch {
@@ -907,7 +907,7 @@ fn expand_cmd(args : Array[String]) -> Unit {
     abort("expand: no target specified")
   }
   // Default to source output if nothing specified
-  if not(output_json) && not(output_source) {
+  if !output_json && !output_source {
     output_source = true
   }
   // Find .vibe directory from target path
@@ -1010,7 +1010,7 @@ fn is_hash_like(s : String) -> Bool {
     return false
   }
   for c in s {
-    if not((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+    if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
       return false
     }
   }

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -1859,7 +1859,7 @@ test "normalize fixtures input output pairs" {
   }
   for input_path in input_files {
     let output_path = wbtest_replace_suffix(input_path, ".in.vibe", ".out.vibe")
-    if not(@os_fs.path_exists(output_path)) {
+    if !@os_fs.path_exists(output_path) {
       fail("[\{input_path}] missing expected output fixture: \{output_path}")
     }
     let source = @os_fs.read_file_to_string(input_path) catch {
@@ -1898,11 +1898,11 @@ test "normalize fixtures has no stale output files" {
     let is_file = @os_fs.is_file(path) catch {
       e => fail("[\{fixture_dir}] stat failed: \{e.to_string()}")
     }
-    if not(is_file) || not(path.has_suffix(".out.vibe")) {
+    if !is_file || !path.has_suffix(".out.vibe") {
       continue
     }
     let input_path = wbtest_replace_suffix(path, ".out.vibe", ".in.vibe")
-    if not(@os_fs.path_exists(input_path)) {
+    if !@os_fs.path_exists(input_path) {
       stale_outputs.push(path)
     }
   }
@@ -2667,7 +2667,7 @@ test "compiled test case source omits example main binding" {
     match stmt {
       @vibe_core.Stmt::Test(..) | @vibe_core.Stmt::Bench(..) => ()
       _ =>
-        if not(should_omit_compiled_test_prelude_stmt(stmt)) {
+        if !should_omit_compiled_test_prelude_stmt(stmt) {
           if compiled_test_prelude_stmt_runs_in_wrapper(stmt) {
             wrapper_prelude_stmts.push(stmt)
           } else {
@@ -3378,7 +3378,7 @@ fn wbtest_make_temp_dir(prefix : String) -> String {
   let base = "/tmp/cmd_vibe_wbtest_" + prefix + "_" + @env.now().to_string()
   for i in 0..<1000 {
     let path = if i == 0 { base } else { base + "_" + i.to_string() }
-    if not(@os_fs.path_exists(path)) {
+    if !@os_fs.path_exists(path) {
       @os_fs.create_dir(path) catch {
         e => abort("create temp dir failed: " + e.to_string())
       }
@@ -3429,7 +3429,7 @@ fn wbtest_substring_index(haystack : String, needle : String) -> Int {
     let slice = try haystack[i:i + n_len] catch {
       _ => ""
     } noraise {
-      value => value.to_string()
+      value => value.to_owned()
     }
     if slice == needle {
       return i
@@ -3458,9 +3458,9 @@ fn wbtest_join_lines(lines : Array[String]) -> String {
 fn wbtest_normalize_fixture_text(text : String) -> String {
   let lines : Array[String] = []
   for line_view in text.split("\n") {
-    lines.push(line_view.trim_end().to_string())
+    lines.push(line_view.trim_end().to_owned())
   }
-  while lines.length() > 0 && lines[lines.length() - 1].trim().to_string() == "" {
+  while lines.length() > 0 && lines[lines.length() - 1].trim().to_owned() == "" {
     ignore(lines.pop())
   }
   wbtest_join_lines(lines)
@@ -3494,7 +3494,7 @@ fn wbtest_replace_suffix(
   new_suffix : String,
 ) -> String {
   match path.strip_suffix(suffix) {
-    Some(view) => view.to_string() + new_suffix
+    Some(view) => view.to_owned() + new_suffix
     None => path
   }
 }
@@ -3538,7 +3538,7 @@ fn wbtest_collect_vibe_files_recursive_impl(
 
 ///|
 fn wbtest_remove_if_exists(path : String) -> Unit {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return
   }
   let is_file = @os_fs.is_file(path) catch { _ => false }

--- a/src/cmd/vibe/cli_write_file.mbt
+++ b/src/cmd/vibe/cli_write_file.mbt
@@ -45,7 +45,7 @@ fn first_char_index(text : String, target : Char) -> Int? {
 
 ///|
 fn parse_write_file_selector(raw : String) -> Result[WriteFileSelector, String] {
-  let trimmed = raw.trim().to_string()
+  let trimmed = raw.trim().to_owned()
   if trimmed.length() == 0 {
     return Err("write_file: selector must not be empty")
   }
@@ -53,7 +53,7 @@ fn parse_write_file_selector(raw : String) -> Result[WriteFileSelector, String] 
     let hash = trimmed
       .unsafe_substring(start=1, end=trimmed.length())
       .trim()
-      .to_string()
+      .to_owned()
     if hash.length() == 0 {
       return Err("write_file: selector hash must not be empty")
     }
@@ -61,11 +61,11 @@ fn parse_write_file_selector(raw : String) -> Result[WriteFileSelector, String] 
   }
   match first_char_index(trimmed, '#') {
     Some(idx) => {
-      let name = trimmed.unsafe_substring(start=0, end=idx).trim().to_string()
+      let name = trimmed.unsafe_substring(start=0, end=idx).trim().to_owned()
       let hash = trimmed
         .unsafe_substring(start=idx + 1, end=trimmed.length())
         .trim()
-        .to_string()
+        .to_owned()
       if name.length() == 0 {
         return Err("write_file: selector name must not be empty")
       }
@@ -101,7 +101,7 @@ fn parse_write_file_cmd_args(
     }
     if arg.has_prefix("--entry=") {
       let path = arg.unsafe_substring(start=8, end=arg.length())
-      if path.trim().to_string().length() == 0 {
+      if path.trim().to_owned().length() == 0 {
         return Err("write_file: --entry path must not be empty")
       }
       entry_path = Some(path)
@@ -277,7 +277,7 @@ fn write_file_filter_hash(
 ) -> Array[WriteFileCandidate] {
   let out : Array[WriteFileCandidate] = []
   for candidate in candidates {
-    if not(candidate.def.def_id.has_prefix(hash_prefix)) {
+    if !candidate.def.def_id.has_prefix(hash_prefix) {
       continue
     }
     if name.length() > 0 && candidate.def.name != name {
@@ -371,7 +371,7 @@ fn write_file_resolve_candidate(
 fn graph_head_from_cache(cache : Map[String, Json]) -> String? {
   match cache.get("graph_head") {
     Some(Json::String(hash)) => {
-      let normalized = hash.trim().to_string()
+      let normalized = hash.trim().to_owned()
       if normalized.length() == 0 {
         None
       } else {
@@ -428,7 +428,7 @@ fn load_scratch_write_file_candidates(
     Ok(v) => v
     Err(err) => return Err(err)
   }
-  if source.trim().to_string().length() == 0 {
+  if source.trim().to_owned().length() == 0 {
     return Ok([])
   }
   let _ = @parser.parse_ast(source) catch {
@@ -448,11 +448,11 @@ fn load_scratch_write_file_candidates(
 ///|
 fn read_write_file_source(path : String) -> Result[String, String] {
   let resolved = @loader.resolve_entry_path(path)
-  if not(@os_fs.path_exists(resolved)) {
+  if !@os_fs.path_exists(resolved) {
     return Err("write_file: source path not found: " + resolved)
   }
   let is_file = @os_fs.is_file(resolved) catch { _ => false }
-  if not(is_file) {
+  if !is_file {
     return Err("write_file: source path is not a file: " + resolved)
   }
   let source = @os_fs.read_file_to_string(resolved) catch {
@@ -519,7 +519,7 @@ fn ensure_write_file_export(source : String, name : String) -> String {
   }
   let buf = StringBuilder::new()
   buf.write_string(source)
-  if source.length() > 0 && not(source.has_suffix("\n")) {
+  if source.length() > 0 && !source.has_suffix("\n") {
     buf.write_char('\n')
   }
   buf.write_string("export { " + name + " }\n")
@@ -532,11 +532,11 @@ fn materialize_write_file_source(
   def : WriteFileDef,
   no_deps : Bool,
 ) -> Result[String, String] {
-  if not(no_deps) {
+  if !no_deps {
     return Ok(source)
   }
   let snippet = source_slice_by_span(source, def.start, def.end)
-  if snippet.trim().to_string().length() == 0 {
+  if snippet.trim().to_owned().length() == 0 {
     return Err(
       "write_file: empty selector span for " + def.path + "#" + def.name,
     )

--- a/src/cmd/vibe/compile_options.mbt
+++ b/src/cmd/vibe/compile_options.mbt
@@ -217,30 +217,30 @@ pub fn parse_compile_cmd_args(
   match entry_path {
     None => Err("compile: missing <file>")
     Some(path) => {
-      if no_dce && not(compile_mode_supports_no_dce(mode)) {
+      if no_dce && !compile_mode_supports_no_dce(mode) {
         return Err(
           "compile: --no-dce is only supported with --wasm, --wasm-js-string, or --wasm-gc",
         )
       }
-      if opt_level is Some(_) && not(compile_mode_supports_wite_opt(mode)) {
+      if opt_level is Some(_) && !compile_mode_supports_wite_opt(mode) {
         return Err(
           "compile: --wite/-O* is only supported with --wasm, --wasm-js-string, --wasm-gc, --component, or --wac",
         )
       }
-      if coverage && not(compile_mode_supports_coverage(mode)) {
+      if coverage && !compile_mode_supports_coverage(mode) {
         return Err(
           "compile: --coverage is only supported with --wasm or --wasm-js-string",
         )
       }
-      if coverage_run_tests && not(coverage) {
+      if coverage_run_tests && !coverage {
         return Err("compile: --coverage-run-tests requires --coverage")
       }
-      if debug_errors && not(compile_mode_supports_debug_errors(mode)) {
+      if debug_errors && !compile_mode_supports_debug_errors(mode) {
         return Err(
           "compile: --debug-errors is only supported with --wasm or --wasm-js-string",
         )
       }
-      if http_host_imports && not(compile_mode_supports_http_host_imports(mode)) {
+      if http_host_imports && !compile_mode_supports_http_host_imports(mode) {
         return Err(
           "compile: --http-host-imports is only supported with --wasm or --component",
         )

--- a/src/cmd/vibe/explain_import.mbt
+++ b/src/cmd/vibe/explain_import.mbt
@@ -95,7 +95,7 @@ fn explain_import_path_item(
         Some(h) => Some(explain_import_normalize_hash(h))
         None => None
       }
-      if not(@io.path_exists(resolved)) {
+      if !@io.path_exists(resolved) {
         {
           module_path: source_path,
           line,
@@ -421,7 +421,7 @@ fn explain_import_collect_module(
                 base, raw_path, root, registry_modules,
               ) {
               Ok(next) =>
-                if @io.path_exists(next) && not(next.has_suffix(".wasm")) {
+                if @io.path_exists(next) && !next.has_suffix(".wasm") {
                   match
                     explain_import_collect_module(
                       next, root, registry_modules, lock, codebase, visited, out,

--- a/src/cmd/vibe/finalize_options.mbt
+++ b/src/cmd/vibe/finalize_options.mbt
@@ -44,7 +44,7 @@ pub fn parse_finalize_cmd_args(
     }
     if arg.has_prefix("--db=") {
       let path = arg.unsafe_substring(start=5, end=arg.length())
-      if path.trim().to_string().length() == 0 {
+      if path.trim().to_owned().length() == 0 {
         return Err("finalize: --db path must not be empty")
       }
       db_path = Some(path)
@@ -61,7 +61,7 @@ pub fn parse_finalize_cmd_args(
     }
     if arg.has_prefix("--export=") {
       let path = arg.unsafe_substring(start=9, end=arg.length())
-      if path.trim().to_string().length() == 0 {
+      if path.trim().to_owned().length() == 0 {
         return Err("finalize: --export path must not be empty")
       }
       export_path = Some(path)

--- a/src/cmd/vibe/fmt_options.mbt
+++ b/src/cmd/vibe/fmt_options.mbt
@@ -38,7 +38,7 @@ fn source_to_diff_lines(source : String) -> Array[String] {
     return lines
   }
   for line_view in source.split("\n") {
-    lines.push(line_view.to_string())
+    lines.push(line_view.to_owned())
   }
   if source.has_suffix("\n") && lines.length() > 0 {
     let _ = lines.pop()

--- a/src/cmd/vibe/function_tracking.mbt
+++ b/src/cmd/vibe/function_tracking.mbt
@@ -62,7 +62,7 @@ fn function_tracking_semver_to_string(
 fn function_tracking_parse_semver(text : String) -> FunctionTrackingSemver? {
   let parts : Array[String] = []
   for piece in text.split(".") {
-    parts.push(piece.to_string())
+    parts.push(piece.to_owned())
   }
   if parts.length() != 3 {
     return None
@@ -535,7 +535,7 @@ fn function_tracking_record_from_json(
   }
   let renamed_from = match obj.get("renamed_from") {
     Some(Json::String(value)) =>
-      if value.trim().to_string().length() == 0 {
+      if value.trim().to_owned().length() == 0 {
         None
       } else {
         Some(value)
@@ -786,7 +786,7 @@ fn function_tracking_build_next_records(
 
   let unmatched_prev : Map[String, FunctionTrackingRecordState] = {}
   for key, record in previous {
-    if not(snapshot_map.contains(key)) {
+    if !snapshot_map.contains(key) {
       unmatched_prev[key] = record
     }
   }

--- a/src/cmd/vibe/normalize_annotate.mbt
+++ b/src/cmd/vibe/normalize_annotate.mbt
@@ -19,7 +19,7 @@ fn normalize_collect_inferred_annotations(
           Some(v) => v
           None => continue
         }
-        if not(normalize_type_annotation_allowed(ty)) {
+        if !normalize_type_annotation_allowed(ty) {
           continue
         }
         let rendered = normalize_render_type_annotation(ty)
@@ -60,7 +60,7 @@ fn normalize_unwrap_local_type_assert(
           ..
         ) =>
           if rec ||
-            not(name.contains("__vibe_local_type_assert_")) ||
+            !name.contains("__vibe_local_type_assert_") ||
             params.length() != 1 ||
             helper_body.stmts.length() != 1 {
             return None
@@ -86,11 +86,9 @@ fn normalize_unwrap_local_type_assert(
       match call_stmt {
         @vibe_core.Stmt::Expr(expr=@vibe_core.Expr::Call(name~, args~, ..), ..) =>
           if args.length() != 1 ||
-            not(
-              name == helper_name ||
+            !(name == helper_name ||
               helper_name.has_suffix("::" + name) ||
-              name.has_suffix("::" + helper_name),
-            ) {
+              name.has_suffix("::" + helper_name)) {
             None
           } else {
             Some((helper_ty, args[0].expr))
@@ -140,7 +138,7 @@ fn normalize_strip_decl_assign_fn_param_types_stmt(
 ) -> @vibe_core.Stmt {
   match stmt {
     @vibe_core.Stmt::ExportLet(rec~, name~, expr~, span~) =>
-      if not(decl_assign_names.contains(name)) {
+      if !decl_assign_names.contains(name) {
         stmt
       } else {
         @vibe_core.Stmt::ExportLet(
@@ -187,7 +185,7 @@ fn normalize_strip_decl_assign_fn_param_types_expr(
           bounds: param.bounds,
         })
       }
-      if not(changed) {
+      if !changed {
         expr
       } else {
         @vibe_core.Expr::Fn(
@@ -221,7 +219,7 @@ fn normalize_type_annotation_allowed(ty : @vibe_core.Type) -> Bool {
     @vibe_core.Type::Infer => false
     @vibe_core.Type::Tuple(items) => {
       for item in items {
-        if not(normalize_type_annotation_allowed(item)) {
+        if !normalize_type_annotation_allowed(item) {
           return false
         }
       }
@@ -238,7 +236,7 @@ fn normalize_type_annotation_allowed(ty : @vibe_core.Type) -> Bool {
     | @vibe_core.Type::V128 => true
     @vibe_core.Type::Named(args~, ..) => {
       for arg in args {
-        if not(normalize_type_annotation_allowed(arg)) {
+        if !normalize_type_annotation_allowed(arg) {
           return false
         }
       }
@@ -246,11 +244,11 @@ fn normalize_type_annotation_allowed(ty : @vibe_core.Type) -> Bool {
     }
     @vibe_core.Type::Func(params~, ret~, effects~) => {
       for param in params {
-        if not(normalize_type_annotation_allowed(param.ty)) {
+        if !normalize_type_annotation_allowed(param.ty) {
           return false
         }
       }
-      if not(normalize_type_annotation_allowed(ret)) {
+      if !normalize_type_annotation_allowed(ret) {
         return false
       }
       for effect in effects {

--- a/src/cmd/vibe/normalize_engine.mbt
+++ b/src/cmd/vibe/normalize_engine.mbt
@@ -158,7 +158,7 @@ fn normalize_source_text_with_modules(
       Err(err) => return Err(err)
     }
     out.write_string(normalized_stmt)
-    if not(normalized_stmt.has_suffix("\n")) {
+    if !normalized_stmt.has_suffix("\n") {
       out.write_char('\n')
     }
     cursor = range.end
@@ -178,14 +178,14 @@ fn normalize_module_stmt_source(stmt_source : String) -> Result[String, String] 
   }
   let head = normalize_source_slice_by_span(stmt_source, 0, open_index)
     .trim()
-    .to_string()
+    .to_owned()
   let body_source = normalize_source_slice_by_span(
     stmt_source,
     open_index + 1,
     close_index,
   )
   let normalized_body = match normalize_source_text_flat(body_source) {
-    Ok(v) => v.trim().to_string()
+    Ok(v) => v.trim().to_owned()
     Err(err) => return Err(err)
   }
   let out = StringBuilder::new()
@@ -305,12 +305,12 @@ fn normalize_indent_block(source : String, indent_spaces : Int) -> String {
   let out = StringBuilder::new()
   let mut first = true
   for line_view in source.split("\n") {
-    if not(first) {
+    if !first {
       out.write_char('\n')
     }
     first = false
-    let line = line_view.to_string()
-    if line.trim().to_string().length() == 0 {
+    let line = line_view.to_owned()
+    if line.trim().to_owned().length() == 0 {
       continue
     }
     for _ in 0..<indent_spaces {
@@ -383,7 +383,7 @@ fn normalize_filter_top_level_expr_stmts(
       @vibe_core.Stmt::Expr(expr~, ..) =>
         if @checker.purity_expr(env, expr) {
           ()
-        } else if not(drop_effectful_expr_stmts) {
+        } else if !drop_effectful_expr_stmts {
           out.push(stmt)
         }
       _ => out.push(stmt)
@@ -480,8 +480,8 @@ fn normalize_is_synthetic_trait_impl(
     @vibe_core.Stmt::TraitImpl(span~, ..) => {
       let snippet = normalize_source_slice_by_span(source, span.start, span.end)
         .trim()
-        .to_string()
-      not(snippet.has_prefix("impl "))
+        .to_owned()
+      !snippet.has_prefix("impl ")
     }
     _ => false
   }
@@ -494,7 +494,7 @@ fn normalize_filter_synthetic_trait_impls(
 ) -> Array[@vibe_core.Stmt] {
   let out : Array[@vibe_core.Stmt] = []
   for stmt in stmts {
-    if not(normalize_is_synthetic_trait_impl(source, stmt)) {
+    if !normalize_is_synthetic_trait_impl(source, stmt) {
       out.push(stmt)
     }
   }
@@ -893,7 +893,7 @@ fn normalize_disambiguate_import_items(
   let used : Map[String, Int] = {}
   let out : Array[@vibe_core.ImportItem] = []
   for item in items {
-    if not(normalize_import_item_accepts_value(item)) {
+    if !normalize_import_item_accepts_value(item) {
       out.push(item)
       continue
     }
@@ -929,14 +929,14 @@ fn normalize_canonicalize_import_path(path : String) -> String {
   let had_dot_prefix = path.has_prefix("./")
   let parts : Array[String] = []
   for part_view in path.split("/") {
-    let part = part_view.to_string()
+    let part = part_view.to_owned()
     if part == "" || part == "." {
       continue
     }
     if part == ".." {
       if parts.length() > 0 && parts[parts.length() - 1] != ".." {
         let _ = parts.pop()
-      } else if not(is_abs) {
+      } else if !is_abs {
         parts.push(part)
       }
     } else {
@@ -954,9 +954,9 @@ fn normalize_canonicalize_import_path(path : String) -> String {
     normalized
   }
   if had_dot_prefix &&
-    not(without_index.has_prefix("./")) &&
-    not(without_index.has_prefix("../")) &&
-    not(without_index.has_prefix("/")) {
+    !without_index.has_prefix("./") &&
+    !without_index.has_prefix("../") &&
+    !without_index.has_prefix("/") {
     "./" + without_index
   } else {
     without_index
@@ -1002,7 +1002,7 @@ fn merge_dedup_stmts(stmts : Array[@vibe_core.Stmt]) -> Array[@vibe_core.Stmt] {
     let stmt = stmts[i]
     match merge_stmt_def_name(stmt) {
       Some(name) =>
-        if not(seen.contains(name)) {
+        if !seen.contains(name) {
           seen[name] = ()
           keep[i] = true
         }
@@ -1076,7 +1076,7 @@ fn merge_prefilter_stmts(
       | @vibe_core.Stmt::IndexAssign(..)
       | @vibe_core.Stmt::LetPat(..)
       | @vibe_core.Stmt::LetPatElse(..) =>
-        if not(library_mode) {
+        if !library_mode {
           out.push(stmt)
         }
       _ => out.push(stmt)
@@ -1095,7 +1095,7 @@ fn merge_render_deduped(
     match merge_render_stmt_fallback(stmt) {
       Some(rendered) => {
         out.write_string(rendered)
-        if not(rendered.has_suffix("\n")) {
+        if !rendered.has_suffix("\n") {
           out.write_char('\n')
         }
       }
@@ -1106,11 +1106,11 @@ fn merge_render_deduped(
           span.start,
           span.end,
         )
-        if snippet.trim().to_string().length() == 0 {
+        if snippet.trim().to_owned().length() == 0 {
           continue
         }
         out.write_string(snippet)
-        if not(snippet.has_suffix("\n")) {
+        if !snippet.has_suffix("\n") {
           out.write_char('\n')
         }
       }
@@ -1143,7 +1143,7 @@ pub fn normalize_merge_sources(
   let filtered = merge_prefilter_stmts(deduped, library_mode)
   // [5] Render from source spans
   let rendered = merge_render_deduped(combined, filtered)
-  if rendered.trim().to_string().length() == 0 {
+  if rendered.trim().to_owned().length() == 0 {
     return Err("merge: no statements kept after dedup")
   }
   // [6] Normalize

--- a/src/cmd/vibe/normalize_engine_wbtest.mbt
+++ b/src/cmd/vibe/normalize_engine_wbtest.mbt
@@ -11,7 +11,7 @@ fn ne_substring_index(haystack : String, needle : String) -> Int {
   let mut i = 0
   let limit = h_len - n_len
   while i <= limit {
-    let slice = haystack[i:i + n_len].to_string()
+    let slice = haystack[i:i + n_len].to_owned()
     if slice == needle {
       return i
     }

--- a/src/cmd/vibe/normalize_format.mbt
+++ b/src/cmd/vibe/normalize_format.mbt
@@ -13,10 +13,10 @@ fn std_layer_name(layer : StdModuleLayer) -> String {
 fn std_layer_for_path(path : String) -> StdModuleLayer? {
   let normalized = @vibe_fs.normalize_path(path)
   if (
-      not(normalized.contains("/vibe/prelude/")) &&
-      not(normalized.contains("/vibe/path/"))
+      !normalized.contains("/vibe/prelude/") &&
+      !normalized.contains("/vibe/path/")
     ) ||
-    not(normalized.has_suffix(".vibe")) ||
+    !normalized.has_suffix(".vibe") ||
     normalized.has_suffix("_test.vibe") ||
     normalized.has_suffix("_type_import_test.vibe") ||
     normalized.has_suffix("/test_import.vibe") {
@@ -126,7 +126,7 @@ pub fn std_layering_violations_for_source(
   for import_path in imports {
     match std_layer_for_path(import_path) {
       Some(imported_layer) =>
-        if not(std_layer_allows_import(source_layer, imported_layer)) {
+        if !std_layer_allows_import(source_layer, imported_layer) {
           violations.push(
             "std layering violation: " +
             std_layer_name(source_layer) +
@@ -345,8 +345,8 @@ fn split_data_section(source : String) -> (String, String) {
   let marker = "\n__DATA__\n"
   match source.split_once(marker) {
     Some((before, after)) => {
-      let code = before.to_string()
-      let data = "\n__DATA__\n" + after.to_string()
+      let code = before.to_owned()
+      let data = "\n__DATA__\n" + after.to_owned()
       (code, data)
     }
     None => (source, "")
@@ -360,7 +360,7 @@ fn normalize_next_non_trivia_token_index(
 ) -> Int? {
   let mut i = start
   while i < tokens.length() {
-    if not(@parser.is_trivia(tokens[i].kind())) {
+    if !@parser.is_trivia(tokens[i].kind()) {
       return Some(i)
     }
     i += 1
@@ -495,7 +495,7 @@ fn normalize_apply_grammar_quickfixes(source : String) -> String {
         let _ = call_paren_stack.pop()
       }
     }
-    if not(@parser.is_trivia(kind)) {
+    if !@parser.is_trivia(kind) {
       prev_non_trivia_kind = Some(kind)
     }
     cursor = end

--- a/src/cmd/vibe/normalize_optimize.mbt
+++ b/src/cmd/vibe/normalize_optimize.mbt
@@ -30,7 +30,7 @@ fn normalize_inline_single_use(
   for i, stmt in ast.stmts {
     match normalize_stmt_inline_candidate(stmt) {
       Some((name, body_expr)) =>
-        if not(exported_names.contains(name)) {
+        if !exported_names.contains(name) {
           candidates[name] = { stmt_index: i, name, body_expr }
         }
       None => ()
@@ -102,7 +102,7 @@ fn normalize_inline_single_use(
             }
           None => ()
         }
-        if not(drop_stmt) {
+        if !drop_stmt {
           out_stmts.push(stmt)
         }
       }
@@ -197,7 +197,7 @@ fn normalize_count_candidate_refs_module(
       @vibe_core.WalkerScope::new(),
       candidate_names,
       fn(name, bound, cands) {
-        if bound.contains(name) || not(cands.contains(name)) {
+        if bound.contains(name) || !cands.contains(name) {
           return
         }
         match counts.get(name) {
@@ -424,7 +424,7 @@ fn normalize_fold_builtin_call(
     "not" =>
       if args.length() == 1 {
         match normalize_expr_as_bool(args[0]) {
-          Some(value) => Some(@vibe_core.Expr::Bool(value=not(value), span~))
+          Some(value) => Some(@vibe_core.Expr::Bool(value=!value, span~))
           None => None
         }
       } else {

--- a/src/cmd/vibe/normalize_render.mbt
+++ b/src/cmd/vibe/normalize_render.mbt
@@ -8,7 +8,7 @@ fn normalize_collect_normalize_entry_names(
     names[name] = true
   }
   for name in extra_entry_names {
-    if name.trim().to_string().length() > 0 {
+    if name.trim().to_owned().length() > 0 {
       names[name] = true
     }
   }
@@ -127,7 +127,7 @@ fn normalize_all_names_already_exported(
     }
   }
   for name in entry_names {
-    if not(exported.contains(name)) {
+    if !exported.contains(name) {
       return false
     }
   }
@@ -173,7 +173,7 @@ fn normalize_render_canonicalize_import_path(path : String) -> String {
     if part == ".." {
       if parts.length() > 0 && parts[parts.length() - 1] != ".." {
         let _ = parts.pop()
-      } else if not(is_abs) {
+      } else if !is_abs {
         parts.push(part)
       }
     } else {
@@ -191,9 +191,9 @@ fn normalize_render_canonicalize_import_path(path : String) -> String {
     normalized
   }
   if had_dot_prefix &&
-    not(without_index.has_prefix("./")) &&
-    not(without_index.has_prefix("../")) &&
-    not(without_index.has_prefix("/")) {
+    !without_index.has_prefix("./") &&
+    !without_index.has_prefix("../") &&
+    !without_index.has_prefix("/") {
     "./" + without_index
   } else {
     without_index
@@ -354,12 +354,12 @@ fn normalize_render_stmt(
     @vibe_core.Stmt::Let(rec~, name~, expr~, span~) => {
       let should_preserve_raw = rewritten_expr is None &&
         annotation is None &&
-        not(normalize_let_stmt_prefers_rendered_expr(expr, env.get(name)))
+        !normalize_let_stmt_prefers_rendered_expr(expr, env.get(name))
       if should_preserve_raw {
         let snippet = normalize_strip_trailing_comments(
           normalize_source_slice_by_span(source, span.start, span.end)
           .trim()
-          .to_string(),
+          .to_owned(),
         )
         if normalize_render_stmt_accept_raw_snippet(snippet) {
           return Some(snippet)
@@ -377,14 +377,12 @@ fn normalize_render_stmt(
       }
       let should_preserve_raw = rewritten_expr is None &&
         annotation is None &&
-        not(
-          normalize_let_stmt_prefers_rendered_expr(render_expr, env.get(name)),
-        )
+        !normalize_let_stmt_prefers_rendered_expr(render_expr, env.get(name))
       if should_preserve_raw {
         let snippet = normalize_strip_trailing_comments(
           normalize_source_slice_by_span(source, span.start, span.end)
           .trim()
-          .to_string(),
+          .to_owned(),
         )
         if snippet.has_prefix("export ") &&
           normalize_render_stmt_accept_raw_snippet(snippet) {
@@ -678,7 +676,7 @@ fn normalize_render_fn_separated(
   }
   let snippet = normalize_source_slice_by_span(source, span.start, span.end)
     .trim()
-    .to_string()
+    .to_owned()
   if snippet.length() == 0 {
     return None
   }
@@ -761,7 +759,7 @@ fn normalize_render_stmt_expr_text(
             original_expr.span().end,
           )
           .trim()
-          .to_string()
+          .to_owned()
       }
   }
   if expr_text.length() == 0 {
@@ -831,7 +829,7 @@ fn normalize_render_expr_for_stmt(
       let span = expr.span()
       let snippet = normalize_source_slice_by_span(source, span.start, span.end)
         .trim()
-        .to_string()
+        .to_owned()
       if snippet.length() == 0 {
         None
       } else {
@@ -1038,11 +1036,11 @@ fn normalize_stmt_group_section_name(group : NormalizeStmtGroup) -> String {
 fn normalize_strip_trailing_comments(text : String) -> String {
   let lines : Array[String] = []
   for part in text.split("\n") {
-    lines.push(part.to_string())
+    lines.push(part.to_owned())
   }
   let mut end = lines.length()
   while end > 0 {
-    let line = lines[end - 1].trim().to_string()
+    let line = lines[end - 1].trim().to_owned()
     if line.length() == 0 || line.has_prefix("//") {
       end -= 1
     } else {
@@ -1084,12 +1082,12 @@ fn normalize_trim_rendered_block(text : String) -> String {
 fn normalize_strip_comment_only_lines(text : String) -> String {
   let lines : Array[String] = []
   for part in text.split("\n") {
-    lines.push(part.to_string())
+    lines.push(part.to_owned())
   }
   let buf = StringBuilder::new()
   let mut wrote = false
   for line in lines {
-    if not(line.trim().to_string().has_prefix("//")) {
+    if !line.trim().to_owned().has_prefix("//") {
       if wrote {
         buf.write_char('\n')
       }
@@ -1103,7 +1101,7 @@ fn normalize_strip_comment_only_lines(text : String) -> String {
 ///|
 fn normalize_has_standalone_comment_line(text : String) -> Bool {
   for part in text.split("\n") {
-    if part.trim().to_string().has_prefix("//") {
+    if part.trim().to_owned().has_prefix("//") {
       return true
     }
   }
@@ -1125,7 +1123,7 @@ fn normalize_render_signature_comment(
 ) -> String? {
   match env.get(name) {
     Some(ty) => {
-      if not(normalize_type_has_effects(ty)) {
+      if !normalize_type_has_effects(ty) {
         return None
       }
       let ty_text = normalize_render_type_annotation(ty)
@@ -1146,13 +1144,13 @@ fn normalize_inject_signature_comments(
 ) -> String {
   let lines : Array[String] = []
   for part in rendered.split("\n") {
-    lines.push(part.to_string())
+    lines.push(part.to_owned())
   }
   let out = StringBuilder::new()
   let mut i = 0
   while i < lines.length() {
     let line = lines[i]
-    let trimmed = line.trim().to_string()
+    let trimmed = line.trim().to_owned()
     let name : String? = if trimmed.has_prefix("export let ") {
       normalize_extract_let_name(trimmed, 11)
     } else if trimmed.has_prefix("let rec ") {
@@ -1171,7 +1169,7 @@ fn normalize_inject_signature_comments(
               let mut k = i - 1
               let mut found = false
               while k >= 0 {
-                let prev = lines[k].trim().to_string()
+                let prev = lines[k].trim().to_owned()
                 if prev.length() == 0 {
                   k -= 1
                   continue
@@ -1183,7 +1181,7 @@ fn normalize_inject_signature_comments(
               }
               found
             }
-            if not(prev_is_sig) {
+            if !prev_is_sig {
               out.write_string(c)
               out.write_char('\n')
             }
@@ -1208,7 +1206,7 @@ fn normalize_extract_let_name(line : String, start : Int) -> String? {
     return None
   }
   let rest = line.unsafe_substring(start~, end=line.length())
-  let trimmed = rest.trim().to_string()
+  let trimmed = rest.trim().to_owned()
   if trimmed.length() == 0 {
     return None
   }
@@ -1243,7 +1241,7 @@ fn normalize_render_source(
   let rendered : Array[NormalizeRenderedBlock] = []
   let push_rendered = fn(group : NormalizeStmtGroup, raw_text : String) {
     let text = normalize_trim_rendered_block(raw_text)
-    if text.trim().to_string().length() == 0 {
+    if text.trim().to_owned().length() == 0 {
       return
     }
     rendered.push({ group, text })
@@ -1333,7 +1331,7 @@ fn normalize_source_slice_by_span(
   if stop <= s {
     return ""
   }
-  source[s:stop].to_string()
+  source[s:stop].to_owned()
 }
 
 ///|

--- a/src/cmd/vibe/repl_completion.mbt
+++ b/src/cmd/vibe/repl_completion.mbt
@@ -107,11 +107,11 @@ fn is_in_fn_param_context(line : String, col : Int) -> Bool {
   let mut last_fn = -1
   for i in 0..<(limit - 1) {
     if chars[i] == 'f' && chars[i + 1] == 'n' {
-      let prev_ok = if i == 0 { true } else { not(is_ident_char(chars[i - 1])) }
+      let prev_ok = if i == 0 { true } else { !is_ident_char(chars[i - 1]) }
       let next_ok = if i + 2 >= chars.length() {
         true
       } else {
-        not(is_ident_char(chars[i + 2]))
+        !is_ident_char(chars[i + 2])
       }
       if prev_ok && next_ok {
         last_fn = i
@@ -256,8 +256,8 @@ fn detect_pipe_completion(line : String, col : Int) -> PipeCompletion? {
 
 ///|
 fn extract_let_name(line : String) -> String? {
-  let trimmed = line.trim().to_string()
-  if trimmed.length() < 4 || not(trimmed.has_prefix("let")) {
+  let trimmed = line.trim().to_owned()
+  if trimmed.length() < 4 || !trimmed.has_prefix("let") {
     return None
   }
   let chars = trimmed.to_array()
@@ -265,7 +265,7 @@ fn extract_let_name(line : String) -> String? {
     return None
   }
   let mut i = 3
-  if i >= chars.length() || not(is_space_char(chars[i])) {
+  if i >= chars.length() || !is_space_char(chars[i]) {
     return None
   }
   while i < chars.length() && is_space_char(chars[i]) {

--- a/src/cmd/vibe/repl_line.mbt
+++ b/src/cmd/vibe/repl_line.mbt
@@ -58,12 +58,12 @@ pub fn parse_line_repl_options(
 ///|
 pub fn extract_let_name_line(line : String) -> String? {
   let t = line.trim()
-  if not(t.has_prefix("let ")) {
+  if !t.has_prefix("let ") {
     return None
   }
-  let mut rest = t[4:].trim().to_string()
+  let mut rest = t[4:].trim().to_owned()
   if rest.has_prefix("rec ") {
-    rest = rest[4:].trim().to_string()
+    rest = rest[4:].trim().to_owned()
   }
   let out = StringBuilder::new()
   for _, c in rest {
@@ -72,7 +72,7 @@ pub fn extract_let_name_line(line : String) -> String? {
     }
     out.write_char(c)
   }
-  let name = out.to_string().trim().to_string()
+  let name = out.to_string().trim().to_owned()
   if name.length() == 0 {
     None
   } else {

--- a/src/cmd/vibe/syntax_mode.mbt
+++ b/src/cmd/vibe/syntax_mode.mbt
@@ -122,7 +122,7 @@ fn split_comma_values(value : String) -> Array[String] {
   let buf = StringBuilder::new()
   for ch in value {
     if ch == ',' {
-      let s = buf.to_string().trim().to_string()
+      let s = buf.to_string().trim().to_owned()
       if s.length() > 0 {
         result.push(s)
       }
@@ -131,7 +131,7 @@ fn split_comma_values(value : String) -> Array[String] {
       buf.write_char(ch)
     }
   }
-  let s = buf.to_string().trim().to_string()
+  let s = buf.to_string().trim().to_owned()
   if s.length() > 0 {
     result.push(s)
   }
@@ -141,7 +141,7 @@ fn split_comma_values(value : String) -> Array[String] {
 ///|
 fn extract_flag_value(arg : String, prefix : String) -> String? {
   if arg.has_prefix(prefix) {
-    let value = arg[prefix.length():].to_string()
+    let value = arg[prefix.length():].to_owned()
     if value.length() > 0 {
       Some(value)
     } else {

--- a/src/cmd/vibe/test_paths.mbt
+++ b/src/cmd/vibe/test_paths.mbt
@@ -100,7 +100,7 @@ fn extract_entry_basename(entry_name : String) -> String {
   let normalized = entry_name.replace(old="\\", new="/")
   let mut last = normalized
   for segment in normalized.split("/") {
-    let part = segment.to_string()
+    let part = segment.to_owned()
     if part.length() > 0 {
       last = part
     }

--- a/src/cmd/vibe_wasm/main.mbt
+++ b/src/cmd/vibe_wasm/main.mbt
@@ -73,7 +73,7 @@ fn elapsed_us_to_ms_int(elapsed_us : Double) -> Int {
 
 ///|
 fn remove_file_if_exists(path : String) -> Unit {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return
   }
   let is_file = @os_fs.is_file(path) catch { _ => false }
@@ -84,10 +84,10 @@ fn remove_file_if_exists(path : String) -> Unit {
 
 ///|
 fn snapshot_file(path : String) -> FileSnapshot {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return { exists: false, content: "" }
   }
-  if not(@os_fs.is_file(path) catch { _ => false }) {
+  if !(@os_fs.is_file(path) catch { _ => false }) {
     return { exists: false, content: "" }
   }
   let content = @os_fs.read_file_to_string(path) catch { _ => "" }
@@ -107,7 +107,7 @@ fn restore_file_snapshot(path : String, snapshot : FileSnapshot) -> Unit {
 
 ///|
 fn is_existing_file(path : String) -> Bool {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return false
   }
   @os_fs.is_file(path) catch {
@@ -119,7 +119,7 @@ fn is_existing_file(path : String) -> Bool {
 fn split_env_flags(raw : String) -> Array[String] {
   let out : Array[String] = []
   for part_view in raw.split(" ") {
-    let token = part_view.trim().to_string()
+    let token = part_view.trim().to_owned()
     if token.length() > 0 {
       out.push(token)
     }
@@ -131,7 +131,7 @@ fn split_env_flags(raw : String) -> Array[String] {
 fn has_wasm_feature_flag(flags : Array[String], feature : String) -> Bool {
   let prefix = feature.to_lower() + "="
   for flag in flags {
-    let token = flag.trim().to_string().to_lower()
+    let token = flag.trim().to_owned().to_lower()
     if token == feature || token.has_prefix(prefix) {
       return true
     }
@@ -142,7 +142,7 @@ fn has_wasm_feature_flag(flags : Array[String], feature : String) -> Bool {
 ///|
 fn with_default_core_wasm_flags(flags : Array[String]) -> Array[String] {
   let out = flags.copy()
-  if not(has_wasm_feature_flag(out, "exceptions")) {
+  if !has_wasm_feature_flag(out, "exceptions") {
     out.push("exceptions=y")
   }
   out
@@ -150,7 +150,7 @@ fn with_default_core_wasm_flags(flags : Array[String]) -> Array[String] {
 
 ///|
 fn is_component_incompatible_wasm_flag(flag : String) -> Bool {
-  let token = flag.trim().to_string().to_lower()
+  let token = flag.trim().to_owned().to_lower()
   token == "unknown-imports-default" ||
   token.has_prefix("unknown-imports-default=")
 }
@@ -173,7 +173,7 @@ fn find_command_in_path(name : String) -> String? {
     None => None
     Some(path_value) => {
       for dir_view in path_value.split(":") {
-        let dir = dir_view.trim().to_string()
+        let dir = dir_view.trim().to_owned()
         if dir.length() == 0 {
           continue
         }
@@ -218,7 +218,7 @@ fn absolute_path_from_cwd(path : String) -> String {
 fn resolve_wasmtime_bin(project_root : String) -> Result[String, String] {
   match @sys.get_env_var("WASMTIME_BIN") {
     Some(value) => {
-      let trimmed = value.trim().to_string()
+      let trimmed = value.trim().to_owned()
       if trimmed.length() > 0 {
         return Ok(trimmed)
       }
@@ -228,7 +228,7 @@ fn resolve_wasmtime_bin(project_root : String) -> Result[String, String] {
   let local_release = project_root + "/deps/wasmtime/target/release/wasmtime"
   let local_debug = project_root + "/deps/wasmtime/target/debug/wasmtime"
   let use_submodule = match @sys.get_env_var("VIBE_USE_WASMTIME_SUBMODULE") {
-    Some(value) => value.trim().to_string() == "1"
+    Some(value) => value.trim().to_owned() == "1"
     None => false
   }
   if use_submodule {
@@ -286,7 +286,7 @@ fn resolve_wasmtime_runner(
 fn resolve_vibe_bin(project_root : String) -> Result[String, String] {
   match @sys.get_env_var("VIBE_BIN") {
     Some(value) => {
-      let trimmed = value.trim().to_string()
+      let trimmed = value.trim().to_owned()
       if trimmed.length() > 0 {
         return Ok(trimmed)
       }
@@ -338,7 +338,7 @@ fn system_command_bytes(cmd : String) -> Bytes {
 ///|
 fn first_non_empty_line(text : String) -> String {
   for line_view in text.split("\n") {
-    let line = line_view.trim().to_string()
+    let line = line_view.trim().to_owned()
     if line.length() > 0 {
       return line
     }
@@ -704,7 +704,7 @@ fn run_mode_capture(
     resolve_wasmtime_runner(absolute_path_from_cwd(entry_path), mode) {
     Ok(v) => v
     Err(err) => {
-      if out_path is None && not(keep_artifact) {
+      if out_path is None && !keep_artifact {
         remove_file_if_exists(artifact_path)
       }
       return Err(err)
@@ -714,7 +714,7 @@ fn run_mode_capture(
   let tmp_prefix = artifact_path + ".exec"
   let (status, stdout, stderr) = run_shell_capture(cmd, tmp_prefix)
   let elapsed_ms = elapsed_us_to_ms_int(@bench.monotonic_clock_end(total_start))
-  if out_path is None && not(keep_artifact) {
+  if out_path is None && !keep_artifact {
     remove_file_if_exists(artifact_path)
   }
   Ok((artifact_path, { status, elapsed_ms, stdout, stderr }))

--- a/src/cmd/vibe_wasm/main_wbtest.mbt
+++ b/src/cmd/vibe_wasm/main_wbtest.mbt
@@ -10,7 +10,7 @@ fn wbtest_temp_dir(name : String) -> String {
 ///|
 fn wbtest_remove_file_if_exists(path : String) -> Unit {
   let exists = @os_fs.path_exists(path)
-  if not(exists) {
+  if !exists {
     return
   }
   let is_file = @os_fs.is_file(path) catch { _ => false }
@@ -28,7 +28,7 @@ fn wbtest_parse_int(text : String) -> Int? {
 ///|
 fn wbtest_extract_first_int_line(stdout : String) -> Int? {
   for line_view in stdout.split("\n") {
-    let line = line_view.trim().to_string()
+    let line = line_view.trim().to_owned()
     if line.length() == 0 {
       continue
     }
@@ -43,9 +43,9 @@ fn wbtest_extract_first_int_line(stdout : String) -> Int? {
 ///|
 fn wbtest_extract_vibe_last_value(stdout : String) -> Int? {
   for line_view in stdout.split("\n") {
-    let line = line_view.trim().to_string()
+    let line = line_view.trim().to_owned()
     if line.has_prefix("last:") {
-      let raw = line.replace(old="last:", new="").trim().to_string()
+      let raw = line.replace(old="last:", new="").trim().to_owned()
       match wbtest_parse_int(raw) {
         Some(value) => return Some(value)
         None => ()

--- a/src/codebase/codebase_test.mbt
+++ b/src/codebase/codebase_test.mbt
@@ -16,7 +16,7 @@ fn test_repo_root() -> String {
   if !git_ref.has_prefix(prefix) {
     return cwd
   }
-  let gitdir = git_ref[prefix.length():].trim().to_string()
+  let gitdir = git_ref[prefix.length():].trim().to_owned()
   let parts = gitdir.split("/.git/").map(StringView::to_string).collect()
   if parts.length() == 0 || parts[0].length() == 0 {
     return cwd
@@ -27,7 +27,7 @@ fn test_repo_root() -> String {
 ///|
 fn make_temp_dir(prefix : String) -> String {
   let tmp_root = test_repo_root() + "/_build/vibe_codebase_test"
-  if not(@os_fs.path_exists(tmp_root)) {
+  if !@os_fs.path_exists(tmp_root) {
     @os_fs.create_dir(tmp_root) catch {
       e => abort("create temp root failed: " + e.to_string())
     }
@@ -35,7 +35,7 @@ fn make_temp_dir(prefix : String) -> String {
   let base = tmp_root + "/vibe_codebase_test_" + prefix
   for i in 0..<1000 {
     let path = if i == 0 { base } else { base + "_" + i.to_string() }
-    if not(@os_fs.path_exists(path)) {
+    if !@os_fs.path_exists(path) {
       @os_fs.create_dir(path) catch {
         e => abort("create temp dir failed: " + e.to_string())
       }
@@ -48,7 +48,7 @@ fn make_temp_dir(prefix : String) -> String {
 
 ///|
 fn remove_if_exists(path : String) -> Unit {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return
   }
   let is_file = @os_fs.is_file(path) catch { _ => false }

--- a/src/codebase/lib.mbt
+++ b/src/codebase/lib.mbt
@@ -11,14 +11,14 @@ fn extract_vibe_from_markdown(markdown : String) -> String {
   let mut in_other_block = false
   for i = 0; i < lines.length(); i = i + 1 {
     let line = lines[i]
-    if not(in_vibe_block) && not(in_other_block) {
+    if !in_vibe_block && !in_other_block {
       if line.has_prefix("```vibe") {
         in_vibe_block = true
       } else if line.has_prefix("```") {
         in_other_block = true
       }
     } else if in_vibe_block {
-      if line.trim().to_string() == "```" {
+      if line.trim().to_owned() == "```" {
         let sb = StringBuilder::new()
         for j, s in buf {
           if j > 0 {
@@ -33,7 +33,7 @@ fn extract_vibe_from_markdown(markdown : String) -> String {
         buf.push(line)
       }
     } else if in_other_block {
-      if line.trim().to_string() == "```" {
+      if line.trim().to_owned() == "```" {
         in_other_block = false
       }
     }
@@ -110,7 +110,7 @@ pub fn Codebase::write_object(
   ensure_dir(objects_dir)
   ensure_dir(self.object_dir(hash))
   let path = self.object_path(hash)
-  if not(@io.path_exists(path)) {
+  if !@io.path_exists(path) {
     match @io.write_string(path, content) {
       Ok(_) => ()
       Err(err) => raise CodebaseError::Io("write object: " + err)
@@ -123,7 +123,7 @@ pub fn Codebase::load_path_mappings(
   self : Codebase,
 ) -> Array[@core.PathMapping] {
   let path = self.root + "/paths.json"
-  if not(@io.path_exists(path)) {
+  if !@io.path_exists(path) {
     return []
   }
   let json = match @io.read_string(path) {
@@ -163,7 +163,7 @@ pub fn Codebase::upsert_path_mapping(
       break
     }
   }
-  if not(found) {
+  if !found {
     mappings.push(@core.PathMapping::{ path, hash })
   }
   self.save_path_mappings(mappings)
@@ -437,7 +437,7 @@ fn unwrap_local_type_assert_expr(expr : @core.Expr) -> @core.Expr {
           ..
         ) =>
           if rec ||
-            not(name.has_prefix("__vibe_local_type_assert_")) ||
+            !name.has_prefix("__vibe_local_type_assert_") ||
             params.length() != 1 ||
             helper_body.stmts.length() != 1 {
             return expr
@@ -526,13 +526,13 @@ fn is_ascii_digits(text : String) -> Bool {
 fn is_simple_semver(version : String) -> Bool {
   let parts : Array[String] = []
   for part in version.split(".") {
-    parts.push(part.to_string())
+    parts.push(part.to_owned())
   }
   if parts.length() != 3 {
     return false
   }
   for part in parts {
-    if not(is_ascii_digits(part)) {
+    if !is_ascii_digits(part) {
       return false
     }
   }
@@ -578,7 +578,7 @@ fn normalize_registry_modules(
     } else {
       @vibe_fs.normalize_path(root + "/" + raw_path)
     }
-    if not(is_within_root(root, resolved)) {
+    if !is_within_root(root, resolved) {
       return Err(
         "index.vibe registry path outside root: " + ns + " -> " + resolved,
       )
@@ -595,7 +595,7 @@ pub fn load_registry_modules_with_fs(
 ) -> Result[Map[String, String], String] {
   let root_norm = @vibe_fs.normalize_path(root)
   let index_path = @vibe_fs.normalize_path(root_norm + "/index.vibe")
-  if not(@io.path_exists_with(fs, index_path)) {
+  if !@io.path_exists_with(fs, index_path) {
     return Ok(default_registry_modules(root_norm))
   }
   let content = match @io.read_string_with(fs, index_path) {
@@ -630,7 +630,7 @@ pub fn load_registry_root_version_with_fs(
 ) -> Result[String, String] {
   let root_norm = @vibe_fs.normalize_path(root)
   let index_path = @vibe_fs.normalize_path(root_norm + "/index.vibe")
-  if not(@io.path_exists_with(fs, index_path)) {
+  if !@io.path_exists_with(fs, index_path) {
     return Ok("0.0.0")
   }
   let content = match @io.read_string_with(fs, index_path) {
@@ -682,7 +682,7 @@ pub fn resolve_import_path_with_registry(
   }
   let resolved = resolve_import_module_entry(resolved_raw)
   // Registry-resolved paths are trusted (they point to well-known module locations)
-  if not(from_registry) && not(is_within_root(root, resolved)) {
+  if !from_registry && !is_within_root(root, resolved) {
     return Err(
       "import path outside root: " + resolved + " (root: " + root + ")",
     )
@@ -747,7 +747,7 @@ fn module_ref_relative_path(base : String, target : String) -> String? {
 
 ///|
 fn module_ref_root_version(version : String) -> String {
-  let normalized = version.trim().to_string()
+  let normalized = version.trim().to_owned()
   if normalized.length() == 0 {
     "0.0.0"
   } else {
@@ -773,7 +773,7 @@ pub fn lock_module_ref_canonical_symbol_with_context(
     let ns_root_path = module_ref_symbol_path(ns_root)
     match module_ref_relative_path(ns_root_path, module_path) {
       Some(rel) =>
-        if not(has_match) ||
+        if !has_match ||
           ns_root_path.length() > matched_root.length() ||
           (
             ns_root_path.length() == matched_root.length() &&
@@ -1086,7 +1086,7 @@ fn line_leading_indent(line : String) -> String {
 fn render_comment_block(note : String, indent : String) -> String {
   let buf = StringBuilder::new()
   for part in note.split("\n") {
-    let line = part.to_string()
+    let line = part.to_owned()
     buf.write_string(indent)
     buf.write_string("//")
     if line.length() > 0 {
@@ -1152,7 +1152,7 @@ pub fn apply_annotations_to_source(
       None => ()
     }
     let line_idx = line_index_for_offset(line_starts, source.length(), anchor)
-    if not(line_notes.contains(line_idx)) {
+    if !line_notes.contains(line_idx) {
       line_notes[line_idx] = note
     }
   }
@@ -1192,7 +1192,7 @@ fn collect_path_refs_impl(
   fs : &@io.FileSystemAdapter,
 ) -> Result[Unit, String] {
   let norm = @vibe_fs.normalize_path(path)
-  if not(is_within_root(root, norm)) {
+  if !is_within_root(root, norm) {
     return Err("import path outside root: " + norm + " (root: " + root + ")")
   }
   for i, p in stack {
@@ -1460,7 +1460,7 @@ fn parse_lock_data(
   content : String,
   base_dir : String,
 ) -> Result[LockData, String] {
-  if content.trim().to_string().length() == 0 {
+  if content.trim().to_owned().length() == 0 {
     return Ok(empty_lock_data())
   }
   let json : Json = @json.parse(content) catch {
@@ -1525,7 +1525,7 @@ fn write_json_string_literal(text : String, buf : StringBuilder) -> Unit {
 fn split_path_parts(path : String) -> Array[String] {
   let parts : Array[String] = []
   for part in path.split("/") {
-    let s = part.to_string()
+    let s = part.to_owned()
     if s.length() > 0 {
       parts.push(s)
     }
@@ -1537,7 +1537,7 @@ fn split_path_parts(path : String) -> Array[String] {
 fn relativize_lock_path(base_dir : String, target_path : String) -> String {
   let base = @vibe_fs.normalize_path(base_dir)
   let target = @vibe_fs.normalize_path(target_path)
-  if not(base.has_prefix("/")) || not(target.has_prefix("/")) {
+  if !base.has_prefix("/") || !target.has_prefix("/") {
     return target
   }
   let base_parts = split_path_parts(base)
@@ -1682,7 +1682,7 @@ pub fn load_lock_data_with_fs(
 ) -> Result[LockData, String] {
   let base_dir = @vibe_fs.parent_path(lock_path)
   let mut target = lock_path
-  if not(@io.path_exists_with(fs, target)) {
+  if !@io.path_exists_with(fs, target) {
     let legacy_path = base_dir + "/vibe.lock"
     if @io.path_exists_with(fs, legacy_path) {
       target = legacy_path
@@ -1824,7 +1824,7 @@ pub fn update_lock_path_refs(entry : String) -> Result[LockData, String] {
 
 ///|
 fn ensure_dir(path : String) -> Unit raise CodebaseError {
-  if not(@io.path_exists(path)) {
+  if !@io.path_exists(path) {
     match @io.create_dir(path) {
       Ok(_) => ()
       Err(err) => raise CodebaseError::Io("mkdir: " + err)

--- a/src/codegen/capture_env_wbtest.mbt
+++ b/src/codegen/capture_env_wbtest.mbt
@@ -239,7 +239,7 @@ test "nested lambda without return annotation keeps boxed int wasm result" {
   let ast = @core.Module::{ stmts: [wb_let("run", run_fn)] }
   let wat = wasm_to_wat(emit_module_wasm(ast))
   assert_true(wat.contains("(param i64 i32) (result i64)"))
-  assert_true(not(wat.contains("(param i64 i32) (result i32)")))
+  assert_true(!wat.contains("(param i64 i32) (result i32)"))
 }
 
 ///|

--- a/src/codegen/component_codegen.mbt
+++ b/src/codegen/component_codegen.mbt
@@ -896,13 +896,13 @@ pub fn collect_exports(ast : @core.Module) -> Array[ExportInfo] {
   for stmt in ast.stmts {
     match stmt {
       @core.Stmt::ExportLet(name~, expr~, ..) =>
-        if not(seen.contains(name)) {
+        if !seen.contains(name) {
           exports.push(ExportInfo::{ name, ty: infer_export_type(expr) })
           seen[name] = true
         }
       @core.Stmt::Export(names~, ..) =>
         for name in names {
-          if not(seen.contains(name)) {
+          if !seen.contains(name) {
             match find_let_expr(ast, name) {
               Some(expr) => {
                 exports.push(ExportInfo::{ name, ty: infer_export_type(expr) })
@@ -1286,7 +1286,7 @@ pub fn generate_component_wit(
     wit = wit + "  import wasi:sockets/tcp-create-socket@0.2.0;\n"
     wit = wit + "  import wasi:sockets/tcp@0.2.0;\n"
     wit = wit + "  import wasi:io/poll@0.2.0;\n"
-    if not(imports.need_stdout_write_char) && not(imports.need_stdin_read_char) {
+    if !imports.need_stdout_write_char && !imports.need_stdin_read_char {
       wit = wit + "  import wasi:io/streams@0.2.0;\n"
     }
   }
@@ -1777,7 +1777,7 @@ pub fn emit_component_wasm_with_string_lift(
   let has_env_param = needs_target_env
   if needs_target_env {
     let env_global_name = exported_env_global_export_name(target_func_name)
-    if not(core_has_named_export(core_wasm, env_global_name, 3)) {
+    if !core_has_named_export(core_wasm, env_global_name, 3) {
       needs_target_env = false
     }
   }

--- a/src/codegen/wasm_codegen_builtin_collection.mbt
+++ b/src/codegen/wasm_codegen_builtin_collection.mbt
@@ -2272,7 +2272,7 @@ fn compile_builtin_collection(
       emit_i32_shl(buf)
       emit_i32_add(buf)
       emit_i32_load(buf, 8)
-      if not(ctx.use_js_strings) {
+      if !ctx.use_js_strings {
         emit_i64_extend_i32_u(buf)
         emit_i64_const_raw(buf, tag_obj.to_int64())
         emit_i64_or(buf)
@@ -2387,14 +2387,14 @@ fn compile_builtin_collection(
       emit_i64_shl(buf)
       buf.push((11).to_byte()) // end if
     }
-    "iter_require" if not(is_user_fn) => {
+    "iter_require" if !is_user_fn => {
       // iter_require(xs) -> identity (prelude fallback for Array iteration)
       let pos_args = extract_positional_exprs_with_arity(
         args, "iter_require", 1,
       )
       compile_expr(ctx, buf, pos_args[0])
     }
-    "iter_length" if not(is_user_fn) => {
+    "iter_length" if !is_user_fn => {
       // iter_length(xs) -> Array::length(xs) semantics.
       // Mirrors Array::length so for-in over an ArrayView (Array slice)
       // works through the unified Iterable desugar (ADR-0044 Phase 2).
@@ -2426,7 +2426,7 @@ fn compile_builtin_collection(
       emit_i64_shl(buf)
       buf.push((11).to_byte()) // end if
     }
-    "iter_get" if not(is_user_fn) => {
+    "iter_get" if !is_user_fn => {
       // iter_get(xs, idx) -> Array::get(xs, idx) semantics.
       // Mirrors Array::get so for-in over an ArrayView (Array slice)
       // works through the unified Iterable desugar (ADR-0044 Phase 2).

--- a/src/codegen/wasm_codegen_builtin_http.mbt
+++ b/src/codegen/wasm_codegen_builtin_http.mbt
@@ -145,7 +145,7 @@ fn compile_builtin_http(
         // WASI P3 HTTP is draft; emit raise with error message instead of
         // unreachable trap so the error is catchable by try/catch.
         let msg = name + " is not available on wasm target"
-        if not(ctx.use_js_strings) && not(ctx.embed_error_strings) {
+        if !ctx.use_js_strings && !ctx.embed_error_strings {
           emit_i64_const_tagged(buf, intern_error_code(ctx, msg).to_int64())
         } else if ctx.use_js_strings {
           emit_string_const(ctx, buf, msg)

--- a/src/codegen/wasm_codegen_builtin_io.mbt
+++ b/src/codegen/wasm_codegen_builtin_io.mbt
@@ -25,7 +25,7 @@ fn compile_builtin_io(
       emit_call(buf, import_index_path(ctx))
       emit_heap_post_call_sync(ctx, buf)
     }
-    "Env::get" if not(is_user_fn) => {
+    "Env::get" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(args, "Env::get", 1)
       compile_expr_i32(ctx, buf, pos_args[0])
       emit_untag_ptr_i32(buf)
@@ -33,13 +33,13 @@ fn compile_builtin_io(
       emit_call(buf, import_index_env_get(ctx))
       emit_heap_post_call_sync(ctx, buf)
     }
-    "Env::args_len" if not(is_user_fn) => {
+    "Env::args_len" if !is_user_fn => {
       let _ = extract_positional_exprs_with_arity(args, "Env::args_len", 0)
       emit_heap_pre_call_sync(ctx, buf)
       emit_call(buf, import_index_env_args_len(ctx))
       emit_heap_post_call_sync(ctx, buf)
     }
-    "Env::args_get" if not(is_user_fn) => {
+    "Env::args_get" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(
         args, "Env::args_get", 1,
       )
@@ -2099,25 +2099,25 @@ fn compile_builtin_io(
     // Json host imports (vibe module, available when fs_host_imports is set).
     // Skip when the user has shadowed the builtin with a same-named definition,
     // matching the convention used by other builtins (e.g. `Env::get`).
-    "Json::parse" if ctx.fs_host_imports && not(is_user_fn) => {
+    "Json::parse" if ctx.fs_host_imports && !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(args, "Json::parse", 1)
       compile_expr(ctx, buf, pos_args[0])
       emit_call(buf, import_index_json_host_parse(ctx))
     }
-    "Json::stringify" if ctx.fs_host_imports && not(is_user_fn) => {
+    "Json::stringify" if ctx.fs_host_imports && !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(
         args, "Json::stringify", 1,
       )
       compile_expr(ctx, buf, pos_args[0])
       emit_call(buf, import_index_json_host_stringify(ctx))
     }
-    "Json::get" if ctx.fs_host_imports && not(is_user_fn) => {
+    "Json::get" if ctx.fs_host_imports && !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(args, "Json::get", 2)
       compile_expr(ctx, buf, pos_args[0])
       compile_expr(ctx, buf, pos_args[1])
       emit_call(buf, import_index_json_host_get(ctx))
     }
-    "Json::string" if ctx.fs_host_imports && not(is_user_fn) => {
+    "Json::string" if ctx.fs_host_imports && !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(
         args, "Json::string", 1,
       )

--- a/src/codegen/wasm_codegen_builtin_numeric.mbt
+++ b/src/codegen/wasm_codegen_builtin_numeric.mbt
@@ -7,7 +7,7 @@ fn compile_builtin_numeric(
   is_user_fn : Bool,
 ) -> Unit raise WasmGenError {
   match name {
-    "add" if not(is_user_fn) || args.length() == 2 => {
+    "add" if !is_user_fn || args.length() == 2 => {
       let pos_args = extract_positional_exprs_with_arity(args, "add", 2)
       let resolved_kind = resolve_numeric_kind(ctx, pos_args[0], pos_args[1])
       match resolved_kind {
@@ -23,7 +23,7 @@ fn compile_builtin_numeric(
           )
       }
     }
-    "sub" if not(is_user_fn) || args.length() == 2 => {
+    "sub" if !is_user_fn || args.length() == 2 => {
       let pos_args = extract_positional_exprs_with_arity(args, "sub", 2)
       let resolved_kind = resolve_numeric_kind(ctx, pos_args[0], pos_args[1])
       match resolved_kind {
@@ -39,7 +39,7 @@ fn compile_builtin_numeric(
           )
       }
     }
-    "mul" if not(is_user_fn) || args.length() == 2 => {
+    "mul" if !is_user_fn || args.length() == 2 => {
       let pos_args = extract_positional_exprs_with_arity(args, "mul", 2)
       let resolved_kind = resolve_numeric_kind(ctx, pos_args[0], pos_args[1])
       match resolved_kind {
@@ -55,7 +55,7 @@ fn compile_builtin_numeric(
           )
       }
     }
-    "div" if not(is_user_fn) || args.length() == 2 => {
+    "div" if !is_user_fn || args.length() == 2 => {
       let pos_args = extract_positional_exprs_with_arity(args, "div", 2)
       let resolved_kind = resolve_numeric_kind(ctx, pos_args[0], pos_args[1])
       match resolved_kind {
@@ -71,11 +71,11 @@ fn compile_builtin_numeric(
           )
       }
     }
-    "eq" if not(is_user_fn) =>
+    "eq" if !is_user_fn =>
       compile_binary_cmp_op(
         ctx, buf, "eq", args, emit_i64_eq, emit_f32_eq, emit_f64_eq,
       )
-    "lt" if not(is_user_fn) =>
+    "lt" if !is_user_fn =>
       // Route through compile_binary_cmp_op so the runtime obj_string
       // branch handles lexicographic comparison; for tagged ints the
       // fallback there is a plain i64 lt_s on the tagged values, which
@@ -83,7 +83,7 @@ fn compile_builtin_numeric(
       compile_binary_cmp_op(
         ctx, buf, "lt", args, emit_i64_lt_s, emit_f32_lt, emit_f64_lt,
       )
-    "assert" | "assert_true" | "__assert" if not(is_user_fn) => {
+    "assert" | "assert_true" | "__assert" if !is_user_fn => {
       let builtin_name = name
       let pos_args = extract_positional_exprs_with_arity(args, builtin_name, 1)
       compile_expr_i32(ctx, buf, pos_args[0])
@@ -96,7 +96,7 @@ fn compile_builtin_numeric(
       buf.push((11).to_byte()) // end if
       emit_i64_const_tagged(buf, 0L)
     }
-    "assert_eq" | "__assert_eq" if not(is_user_fn) => {
+    "assert_eq" | "__assert_eq" if !is_user_fn => {
       // assert_eq(a, b): compile __eq(a, b), then assert the result
       compile_binary_cmp_op(
         ctx, buf, "__eq", args, emit_i64_eq, emit_f32_eq, emit_f64_eq,
@@ -241,48 +241,48 @@ fn compile_builtin_numeric(
       compile_binary_cmp_op(
         ctx, buf, "__lt", args, emit_i64_lt_s, emit_f32_lt, emit_f64_lt,
       )
-    "i32_eqz" if not(is_user_fn) => {
+    "i32_eqz" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(args, "i32_eqz", 1)
       compile_expr_i32(ctx, buf, pos_args[0])
       emit_untag_int_i32(buf)
       emit_i32_eqz(buf)
       emit_i32_result_as_tagged_int(buf)
     }
-    "i32_eq" if not(is_user_fn) =>
+    "i32_eq" if !is_user_fn =>
       compile_i32_cmp_to_tagged_int(ctx, buf, "i32_eq", args, emit_i32_eq)
-    "i32_ne" if not(is_user_fn) =>
+    "i32_ne" if !is_user_fn =>
       compile_i32_cmp_to_tagged_int(ctx, buf, "i32_ne", args, emit_i32_ne)
-    "i32_lt_s" if not(is_user_fn) =>
+    "i32_lt_s" if !is_user_fn =>
       compile_i32_cmp_to_tagged_int(ctx, buf, "i32_lt_s", args, emit_i32_lt_s)
-    "i32_gt_s" if not(is_user_fn) =>
+    "i32_gt_s" if !is_user_fn =>
       compile_i32_cmp_to_tagged_int(ctx, buf, "i32_gt_s", args, emit_i32_gt_s)
-    "i32_le_s" if not(is_user_fn) =>
+    "i32_le_s" if !is_user_fn =>
       compile_i32_cmp_to_tagged_int(ctx, buf, "i32_le_s", args, emit_i32_le_s)
-    "i32_ge_s" if not(is_user_fn) =>
+    "i32_ge_s" if !is_user_fn =>
       compile_i32_cmp_to_tagged_int(ctx, buf, "i32_ge_s", args, emit_i32_ge_s)
-    "f32_eq" if not(is_user_fn) =>
+    "f32_eq" if !is_user_fn =>
       compile_f32_cmp_to_tagged_int(ctx, buf, "f32_eq", args, emit_f32_eq)
-    "f32_ne" if not(is_user_fn) =>
+    "f32_ne" if !is_user_fn =>
       compile_f32_cmp_to_tagged_int(ctx, buf, "f32_ne", args, emit_f32_ne)
-    "f32_lt" if not(is_user_fn) =>
+    "f32_lt" if !is_user_fn =>
       compile_f32_cmp_to_tagged_int(ctx, buf, "f32_lt", args, emit_f32_lt)
-    "f32_gt" if not(is_user_fn) =>
+    "f32_gt" if !is_user_fn =>
       compile_f32_cmp_to_tagged_int(ctx, buf, "f32_gt", args, emit_f32_gt)
-    "f32_le" if not(is_user_fn) =>
+    "f32_le" if !is_user_fn =>
       compile_f32_cmp_to_tagged_int(ctx, buf, "f32_le", args, emit_f32_le)
-    "f32_ge" if not(is_user_fn) =>
+    "f32_ge" if !is_user_fn =>
       compile_f32_cmp_to_tagged_int(ctx, buf, "f32_ge", args, emit_f32_ge)
-    "f64_eq" if not(is_user_fn) =>
+    "f64_eq" if !is_user_fn =>
       compile_f64_cmp_to_tagged_int(ctx, buf, "f64_eq", args, emit_f64_eq)
-    "f64_ne" if not(is_user_fn) =>
+    "f64_ne" if !is_user_fn =>
       compile_f64_cmp_to_tagged_int(ctx, buf, "f64_ne", args, emit_f64_ne)
-    "f64_lt" if not(is_user_fn) =>
+    "f64_lt" if !is_user_fn =>
       compile_f64_cmp_to_tagged_int(ctx, buf, "f64_lt", args, emit_f64_lt)
-    "f64_gt" if not(is_user_fn) =>
+    "f64_gt" if !is_user_fn =>
       compile_f64_cmp_to_tagged_int(ctx, buf, "f64_gt", args, emit_f64_gt)
-    "f64_le" if not(is_user_fn) =>
+    "f64_le" if !is_user_fn =>
       compile_f64_cmp_to_tagged_int(ctx, buf, "f64_le", args, emit_f64_le)
-    "f64_ge" if not(is_user_fn) =>
+    "f64_ge" if !is_user_fn =>
       compile_f64_cmp_to_tagged_int(ctx, buf, "f64_ge", args, emit_f64_ge)
     "__neg" => {
       let pos_args = extract_positional_exprs_with_arity(args, "__neg", 1)
@@ -399,7 +399,7 @@ fn compile_builtin_numeric(
       })
     }
     // ========== Integer math builtins ==========
-    "Int::abs" if not(is_user_fn) => {
+    "Int::abs" if !is_user_fn => {
       // int_abs(x): if x < 0 then -x else x (operates on tagged i64 directly)
       let pos_args = extract_positional_exprs_with_arity(args, "Int::abs", 1)
       let tmp = alloc_temp_local_with_kind(ctx, ValueKind::I64)
@@ -415,7 +415,7 @@ fn compile_builtin_numeric(
       emit_end(buf) // end if
       emit_local_get(buf, tmp)
     }
-    "Int::max" if not(is_user_fn) => {
+    "Int::max" if !is_user_fn => {
       // int_max(a, b): works directly on tagged i64 values
       let pos_args = extract_positional_exprs_with_arity(args, "Int::max", 2)
       let a_local = alloc_temp_local_with_kind(ctx, ValueKind::I64)
@@ -432,7 +432,7 @@ fn compile_builtin_numeric(
       emit_i64_gt_s(buf) // a > b → 1:i32
       emit_select(buf) // select(a, b, a>b) → a if a>b else b
     }
-    "Int::min" if not(is_user_fn) => {
+    "Int::min" if !is_user_fn => {
       // int_min(a, b): works directly on tagged i64 values
       let pos_args = extract_positional_exprs_with_arity(args, "Int::min", 2)
       let a_local = alloc_temp_local_with_kind(ctx, ValueKind::I64)
@@ -448,7 +448,7 @@ fn compile_builtin_numeric(
       emit_i64_lt_s(buf) // a < b → 1:i32
       emit_select(buf) // select(a, b, a<b) → a if a<b else b
     }
-    "Int::clamp" if not(is_user_fn) => {
+    "Int::clamp" if !is_user_fn => {
       // int_clamp(x, lo, hi): max(lo, min(x, hi))
       let pos_args = extract_positional_exprs_with_arity(args, "Int::clamp", 3)
       let x_local = alloc_temp_local_with_kind(ctx, ValueKind::I64)
@@ -476,7 +476,7 @@ fn compile_builtin_numeric(
       emit_i64_gt_s(buf)
       emit_select(buf) // max(lo, min(x, hi))
     }
-    "Int::signum" if not(is_user_fn) => {
+    "Int::signum" if !is_user_fn => {
       // int_signum(x): -1 if x<0, 0 if x==0, 1 if x>0
       let pos_args = extract_positional_exprs_with_arity(args, "Int::signum", 1)
       let tmp = alloc_temp_local_with_kind(ctx, ValueKind::I64)
@@ -508,7 +508,7 @@ fn compile_builtin_numeric(
       emit_end(buf) // end outer if
       emit_local_get(buf, tmp)
     }
-    "Int::is_even" if not(is_user_fn) => {
+    "Int::is_even" if !is_user_fn => {
       // int_is_even(x): ((x >> 2) & 1) == 0 → tagged bool
       let pos_args = extract_positional_exprs_with_arity(
         args, "Int::is_even", 1,
@@ -525,7 +525,7 @@ fn compile_builtin_numeric(
       emit_i64_const_raw(buf, tag_bool.to_int64())
       emit_i64_or(buf) // tag as bool
     }
-    "Int::is_odd" if not(is_user_fn) => {
+    "Int::is_odd" if !is_user_fn => {
       // int_is_odd(x): ((x >> 2) & 1) == 1 → tagged bool
       let pos_args = extract_positional_exprs_with_arity(args, "Int::is_odd", 1)
       compile_expr_i32(ctx, buf, pos_args[0])
@@ -789,19 +789,19 @@ fn compile_builtin_numeric(
       emit_i64_const_raw(buf, 2L)
       emit_i64_shl(buf)
     }
-    "not" | "__not" if not(is_user_fn) => {
+    "not" | "__not" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(args, "not", 1)
       compile_expr_i32(ctx, buf, pos_args[0])
       emit_i64_const_raw(buf, 4L)
       emit_i64_xor(buf)
     }
-    "and" if not(is_user_fn) => {
+    "and" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(args, "and", 2)
       compile_expr_i32(ctx, buf, pos_args[0])
       compile_expr_i32(ctx, buf, pos_args[1])
       emit_i64_and(buf)
     }
-    "or" | "__or" if not(is_user_fn) => {
+    "or" | "__or" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(args, "or", 2)
       compile_expr_i32(ctx, buf, pos_args[0])
       compile_expr_i32(ctx, buf, pos_args[1])

--- a/src/codegen/wasm_codegen_builtin_string.mbt
+++ b/src/codegen/wasm_codegen_builtin_string.mbt
@@ -1405,7 +1405,7 @@ fn compile_builtin_string(
         // tag_int = 0, i64.or is a no-op
       }
     }
-    "String::contains" if not(is_user_fn) => {
+    "String::contains" if !is_user_fn => {
       // string_contains(str, sub) -> Bool
       // Reuses the same substring search as string_index_of but returns bool.
       let pos_args = extract_positional_exprs_with_arity(
@@ -1521,7 +1521,7 @@ fn compile_builtin_string(
         emit_tag_bool_from_i32(buf)
       }
     }
-    "String::starts_with" if not(is_user_fn) => {
+    "String::starts_with" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::starts_with", 2,
       )
@@ -1597,7 +1597,7 @@ fn compile_builtin_string(
         emit_tag_bool_from_i32(buf)
       }
     }
-    "String::ends_with" if not(is_user_fn) => {
+    "String::ends_with" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::ends_with", 2,
       )
@@ -1680,7 +1680,7 @@ fn compile_builtin_string(
         emit_tag_bool_from_i32(buf)
       }
     }
-    "String::last_index_of" if not(is_user_fn) => {
+    "String::last_index_of" if !is_user_fn => {
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::last_index_of", 2,
       )
@@ -1795,7 +1795,7 @@ fn compile_builtin_string(
         // tag_int = 0, i64.or is a no-op
       }
     }
-    "String::count" if not(is_user_fn) => {
+    "String::count" if !is_user_fn => {
       // string_count(str, sub) -> Int (non-overlapping count)
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::count", 2,
@@ -1925,7 +1925,7 @@ fn compile_builtin_string(
         // tag_int = 0, i64.or is a no-op
       }
     }
-    "String::trim" if not(is_user_fn) => {
+    "String::trim" if !is_user_fn => {
       // string_trim(str) -> String (trim ASCII whitespace from both ends)
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::trim", 1,
@@ -2061,7 +2061,7 @@ fn compile_builtin_string(
         emit_i64_or(buf)
       }
     }
-    "String::trim_start" if not(is_user_fn) => {
+    "String::trim_start" if !is_user_fn => {
       // string_trim_start(str) -> String (trim leading whitespace)
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::trim_start", 1,
@@ -2166,7 +2166,7 @@ fn compile_builtin_string(
         emit_i64_or(buf)
       }
     }
-    "String::trim_end" if not(is_user_fn) => {
+    "String::trim_end" if !is_user_fn => {
       // string_trim_end(str) -> String (trim trailing whitespace)
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::trim_end", 1,
@@ -2265,7 +2265,7 @@ fn compile_builtin_string(
         emit_i64_or(buf)
       }
     }
-    "String::to_upper" if not(is_user_fn) => {
+    "String::to_upper" if !is_user_fn => {
       // string_to_upper(str) -> String (convert ASCII lowercase to uppercase)
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::to_upper", 1,
@@ -2360,7 +2360,7 @@ fn compile_builtin_string(
         emit_i64_or(buf)
       }
     }
-    "String::to_lower" if not(is_user_fn) => {
+    "String::to_lower" if !is_user_fn => {
       // string_to_lower(str) -> String (convert ASCII uppercase to lowercase)
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::to_lower", 1,
@@ -2455,7 +2455,7 @@ fn compile_builtin_string(
         emit_i64_or(buf)
       }
     }
-    "String::replace" if not(is_user_fn) => {
+    "String::replace" if !is_user_fn => {
       // string_replace(str, pattern, replacement) -> String (replace first occurrence)
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::replace", 3,
@@ -2469,7 +2469,7 @@ fn compile_builtin_string(
         emit_string_replace_impl(ctx, buf, pos_args, replace_all=false)
       }
     }
-    "String::replace_all" if not(is_user_fn) => {
+    "String::replace_all" if !is_user_fn => {
       // string_replace_all(str, pattern, replacement) -> String (replace all occurrences)
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::replace_all", 3,
@@ -2483,7 +2483,7 @@ fn compile_builtin_string(
         emit_string_replace_impl(ctx, buf, pos_args, replace_all=true)
       }
     }
-    "String::split" if not(is_user_fn) => {
+    "String::split" if !is_user_fn => {
       // string_split(str, delimiter) -> Array[String]
       let pos_args = extract_positional_exprs_with_arity(
         args, "String::split", 2,
@@ -2916,7 +2916,7 @@ fn emit_string_replace_impl(
   emit_i32_const_raw(buf, 1)
   emit_i32_add(buf)
   emit_local_set(buf, match_count)
-  if not(replace_all) {
+  if !replace_all {
     emit_br(buf, 2) // break $count_break
   } else {
     // Advance by pat_len to avoid overlapping
@@ -3064,7 +3064,7 @@ fn emit_string_replace_impl(
   emit_local_get(buf, pat_len)
   emit_i32_add(buf)
   emit_local_set(buf, src_i)
-  if not(replace_all) {
+  if !replace_all {
     // Copy remaining bytes directly, then break
     emit_block(buf) // block $rest_done
     emit_loop(buf) // loop $rest_loop

--- a/src/codegen/wasm_codegen_call.mbt
+++ b/src/codegen/wasm_codegen_call.mbt
@@ -1108,7 +1108,7 @@ fn resolve_args_with_labels(
     }
   }
   // If no labeled args, just return positional
-  if not(has_labeled) {
+  if !has_labeled {
     let out : Array[@core.Expr] = []
     for arg in args {
       out.push(arg.expr)
@@ -1204,9 +1204,9 @@ fn compile_call_user_fn(
   // Direct call needs the callee's closure env when the function has captures.
   // Do not fall back to current function env; it may belong to another closure.
   // Skip closure env check for functions known to not need env at compile time.
-  let known_no_env = not(fn_index_needs_env(ctx, fn_idx))
+  let known_no_env = !fn_index_needs_env(ctx, fn_idx)
   match ctx.locals.get(name) {
-    Some(local_idx) if ctx.fn_local_sigs.contains(name) && not(known_no_env) => {
+    Some(local_idx) if ctx.fn_local_sigs.contains(name) && !known_no_env => {
       let env_local = alloc_temp_local(ctx)
       emit_local_get(buf, local_idx)
       emit_i64_const_raw(buf, tag_mask.to_int64())
@@ -1251,7 +1251,7 @@ fn compile_call_user_fn(
     Some(_) => true
     None => false
   }
-  if ctx.is_tail_position && not(has_multivalue) {
+  if ctx.is_tail_position && !has_multivalue {
     emit_return_call(buf, idx)
   } else {
     emit_call(buf, idx)

--- a/src/codegen/wasm_codegen_call_builtin_pre_user.mbt
+++ b/src/codegen/wasm_codegen_call_builtin_pre_user.mbt
@@ -1253,7 +1253,7 @@ fn compile_call_builtin_pre_user_inner(
     }
   }
   // No handler matched — check runtime fallback or raise unhandled
-  if not(is_user_fn) && is_wasm_runtime_fallback_builtin(name) {
+  if !is_user_fn && is_wasm_runtime_fallback_builtin(name) {
     emit_wasm_runtime_fallback_throw(ctx, buf, name)
   } else {
     raise WasmGenError::Unsupported(pre_user_builtin_unhandled_marker)

--- a/src/codegen/wasm_codegen_call_dispatch_tail.mbt
+++ b/src/codegen/wasm_codegen_call_dispatch_tail.mbt
@@ -5,7 +5,7 @@ fn compile_call_enum_ctor_by_name(
   name : String,
   args : Array[@core.CallArg],
 ) -> Bool raise WasmGenError {
-  if not(ctx.enum_ctor_tags.contains(name)) {
+  if !ctx.enum_ctor_tags.contains(name) {
     return false
   }
   // Enum constructor call
@@ -97,7 +97,7 @@ fn compile_call_record_field_fallback_by_name(
     return false
   }
   let pos_args = extract_positional_exprs(args, name)
-  if not(pos_args.length() == 1 && ctx.known_record_fields.contains(name)) {
+  if !(pos_args.length() == 1 && ctx.known_record_fields.contains(name)) {
     return false
   }
   // Fallback for method-style record field access desugared as `field(record)`.

--- a/src/codegen/wasm_codegen_ctx.mbt
+++ b/src/codegen/wasm_codegen_ctx.mbt
@@ -454,7 +454,7 @@ fn push_capture(
   captures : Array[String],
   seen : Map[String, Bool],
 ) -> Unit {
-  if not(seen.contains(name)) {
+  if !seen.contains(name) {
     seen[name] = true
     captures.push(name)
   }
@@ -610,7 +610,7 @@ fn collect_captures_block(
       }
       @core.Stmt::Assign(name~, expr~, span~) => {
         let _ = span
-        if not(scope.contains(name)) && outer_bound.contains(name) {
+        if !scope.contains(name) && outer_bound.contains(name) {
           push_capture(name, captures, seen)
         }
         collect_captures_expr(expr, scope, outer_bound, captures, seen)
@@ -637,13 +637,13 @@ fn collect_captures_expr(
   match expr {
     @core.Expr::Ident(name~, span~) => {
       let _ = span
-      if not(bound.contains(name)) && outer_bound.contains(name) {
+      if !bound.contains(name) && outer_bound.contains(name) {
         push_capture(name, captures, seen)
       }
     }
     @core.Expr::Call(name~, args~, span~, ..) => {
       let _ = span
-      if not(bound.contains(name)) && outer_bound.contains(name) {
+      if !bound.contains(name) && outer_bound.contains(name) {
         push_capture(name, captures, seen)
       }
       for arg in args {
@@ -749,7 +749,7 @@ fn collect_captures_expr(
         body, nested_bound, nested_outer, nested_caps, nested_seen,
       )
       for name in nested_caps {
-        if not(bound.contains(name)) && outer_bound.contains(name) {
+        if !bound.contains(name) && outer_bound.contains(name) {
           push_capture(name, captures, seen)
         }
       }
@@ -794,7 +794,7 @@ fn collect_nested_funcs_block(
               fn_bound[param.name] = true
             }
             collect_captures_block(body, fn_bound, scope, captures, seen)
-            if not(skip_top_level) {
+            if !skip_top_level {
               funcs.push(FuncDef::{
                 name: Some(name),
                 params,
@@ -876,7 +876,7 @@ fn collect_nested_funcs_block(
               fn_bound[param.name] = true
             }
             collect_captures_block(body, fn_bound, scope, captures, seen)
-            if not(skip_top_level) {
+            if !skip_top_level {
               funcs.push(FuncDef::{
                 name: Some(name),
                 params,
@@ -1166,7 +1166,7 @@ fn collect_func_defs(ast : @core.Module) -> Array[FuncDef] {
     match f.name {
       Some(name) if top_level_fn_names.contains(name) =>
         for cap in f.captures {
-          if not(top_level_fn_names.contains(cap)) {
+          if !top_level_fn_names.contains(cap) {
             top_level_needs_env[name] = true
             break
           }
@@ -1180,7 +1180,7 @@ fn collect_func_defs(ast : @core.Module) -> Array[FuncDef] {
     for f in funcs {
       match f.name {
         Some(name) if top_level_fn_names.contains(name) =>
-          if not(top_level_needs_env.contains(name)) {
+          if !top_level_needs_env.contains(name) {
             let mut needs = false
             for cap in f.captures {
               if top_level_fn_names.contains(cap) &&
@@ -1204,7 +1204,7 @@ fn collect_func_defs(ast : @core.Module) -> Array[FuncDef] {
       Some(name) if top_level_fn_names.contains(name) => {
         let filtered_captures : Array[String] = []
         for cap in f.captures {
-          if not(top_level_fn_names.contains(cap)) ||
+          if !top_level_fn_names.contains(cap) ||
             top_level_needs_env.contains(cap) {
             filtered_captures.push(cap)
           }
@@ -1264,7 +1264,7 @@ fn compute_mut_captured_for_block(
       break
     }
   }
-  if not(has_any_mut) {
+  if !has_any_mut {
     return {}
   }
   // Step 2: Collect all Fn span_keys defined in this scope

--- a/src/codegen/wasm_codegen_data.mbt
+++ b/src/codegen/wasm_codegen_data.mbt
@@ -124,7 +124,7 @@ fn require_heap(ctx : CodegenCtx) -> Unit {
     ctx.local_types.push(ValueKind::I32)
     ctx.heap_synced = false
     // Also ensure heap_global is set (build_module needs it for global section)
-    if not(ctx.use_heap_global) {
+    if !ctx.use_heap_global {
       ctx.use_heap_global = true
       // In linked mode, __heap_ptr is imported global index 0.
       // Otherwise, it'll be global index 0 in the defined globals section.

--- a/src/codegen/wasm_codegen_emit.mbt
+++ b/src/codegen/wasm_codegen_emit.mbt
@@ -163,7 +163,7 @@ fn write_i32_leb_unchecked(buf : ByteBuf, value : Int, depth : Int) -> Unit {
   let byte_val = value & 0x7f
   let rest = value >> 7
   let sign_bit_set = (byte_val & 0x40) != 0
-  let done = (rest == 0 && not(sign_bit_set)) || (rest == -1 && sign_bit_set)
+  let done = (rest == 0 && !sign_bit_set) || (rest == -1 && sign_bit_set)
   if done {
     buf.data.unsafe_set(buf.len, byte_val.to_byte())
     buf.len += 1
@@ -566,7 +566,7 @@ fn register_coverage_point(
   kind : WasmCoveragePointKind,
   span : @core.Span,
 ) -> Int {
-  if not(ctx.coverage_enabled) {
+  if !ctx.coverage_enabled {
     return -1
   }
   let id = ctx.coverage_points.length()
@@ -595,7 +595,7 @@ fn emit_coverage(
   kind : WasmCoveragePointKind,
   span : @core.Span,
 ) -> Unit {
-  if not(ctx.coverage_enabled) {
+  if !ctx.coverage_enabled {
     return
   }
   let point_id = register_coverage_point(ctx, kind, span)
@@ -906,7 +906,7 @@ fn write_i64_leb_unchecked_inner(
   let byte_val = (value & 0x7fL).to_int()
   let rest = value >> 7
   let sign_bit_set = (byte_val & 0x40) != 0
-  let done = (rest == 0L && not(sign_bit_set)) || (rest == -1L && sign_bit_set)
+  let done = (rest == 0L && !sign_bit_set) || (rest == -1L && sign_bit_set)
   if done {
     buf.data.unsafe_set(buf.len, byte_val.to_byte())
     buf.len += 1

--- a/src/codegen/wasm_codegen_expr_binding.mbt
+++ b/src/codegen/wasm_codegen_expr_binding.mbt
@@ -250,7 +250,7 @@ fn compile_expr_if(
   }
   // Optimization: if cond is an integer comparison, emit comparison directly
   // without going through tagged bool (tag → untag cancels out)
-  if not(try_compile_cond_i32(ctx, buf, cond)) {
+  if !try_compile_cond_i32(ctx, buf, cond) {
     compile_expr_i32(ctx, buf, cond)
     emit_i64_const_raw(buf, 2L)
     emit_i64_shr_u(buf)

--- a/src/codegen/wasm_codegen_expr_call.mbt
+++ b/src/codegen/wasm_codegen_expr_call.mbt
@@ -14,7 +14,7 @@ fn compile_expr_call(
   // Respect lexical locals first. Named local functions also live in fn_indices,
   // but env-backed captures may only be safely direct-called when the local
   // function metadata is still in scope.
-  if ctx.locals.contains(name) && not(ctx.enum_ctor_tags.contains(name)) {
+  if ctx.locals.contains(name) && !ctx.enum_ctor_tags.contains(name) {
     let direct_arity_match = match ctx.fn_params.get(name) {
       Some(params) => args.length() == params.length()
       None => false
@@ -128,7 +128,7 @@ fn compile_expr_call(
   } else {
     // Optimization: if name refers to a known non-local function with matching
     // arity, use direct `call` instead of `call_indirect`.
-    if ctx.fn_indices.contains(name) && not(ctx.enum_ctor_tags.contains(name)) {
+    if ctx.fn_indices.contains(name) && !ctx.enum_ctor_tags.contains(name) {
       let direct_arity_match = match ctx.fn_params.get(name) {
         Some(params) => args.length() == params.length()
         None => false

--- a/src/codegen/wasm_codegen_expr_effect.mbt
+++ b/src/codegen/wasm_codegen_expr_effect.mbt
@@ -9,7 +9,7 @@ fn is_builtin_error_handler_name(name : String) -> Bool {
 fn extract_effect_name_from_key(qualified : String) -> String {
   for i = 0; i + 1 < qualified.length(); i = i + 1 {
     if qualified[i] == ':' && qualified[i + 1] == ':' {
-      return qualified[0:i].to_string()
+      return qualified[0:i].to_owned()
     }
   }
   qualified
@@ -32,7 +32,7 @@ fn get_effect_resume_globals(
 fn is_resume_effect_pat(pat : @core.Pat) -> Bool {
   match pat {
     @core.Pat::Ctor(name~, ..) =>
-      name.contains("::") && not(is_builtin_error_handler_name(name))
+      name.contains("::") && !is_builtin_error_handler_name(name)
     _ => false
   }
 }

--- a/src/codegen/wasm_codegen_expr_loop.mbt
+++ b/src/codegen/wasm_codegen_expr_loop.mbt
@@ -26,7 +26,7 @@ fn compile_expr_while(
   ctx.loop_param_locals = []
 
   // Evaluate condition
-  if not(try_compile_cond_i32(ctx, buf, cond)) {
+  if !try_compile_cond_i32(ctx, buf, cond) {
     compile_expr_i32(ctx, buf, cond)
     // Extract bool value: (tagged >> 2) & 1
     emit_i64_const_raw(buf, 2L)

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -20,7 +20,7 @@ fn http_host_import_binding(
   ctx : CodegenCtx,
   builtin_name : String,
 ) -> (String, String) {
-  if not(ctx.http_component_wasi_shim) {
+  if !ctx.http_component_wasi_shim {
     return ("vibe:http", builtin_name)
   }
   match builtin_name {
@@ -67,7 +67,7 @@ fn write_fs_host_import(
 fn fs_host_import_func_name(builtin_name : String) -> String {
   // "Fs::read_file" -> "fs_read_file"
   // "Fs::getcwd" -> "fs_getcwd"
-  "fs_" + builtin_name[4:].to_string()
+  "fs_" + builtin_name[4:].to_owned()
 }
 
 ///|
@@ -117,7 +117,7 @@ fn collect_effect_names(ctx : CodegenCtx) -> Array[String] {
   let names : Array[String] = []
   for key, _ in ctx.effect_handled_ops {
     let eff_name = extract_effect_name_from_key(key)
-    if not(seen.contains(eff_name)) {
+    if !seen.contains(eff_name) {
       seen[eff_name] = true
       names.push(eff_name)
     }
@@ -242,7 +242,7 @@ fn build_module(
     stdin_read_char_type = type_count
     type_count += 1
   }
-  if ctx.need_fs && not(ctx.fs_host_imports) {
+  if ctx.need_fs && !ctx.fs_host_imports {
     // fs_get_dirs_type: (i32) -> () — shared by get-directories and resource-drop
     fs_get_dirs_type = type_count
     type_count += 1
@@ -456,7 +456,7 @@ fn build_module(
     type_sec.push((127).to_byte())
     write_u32_leb(type_sec, 0)
   }
-  if ctx.need_fs && not(ctx.fs_host_imports) {
+  if ctx.need_fs && !ctx.fs_host_imports {
     // fs_get_dirs_type: (func (param i32) -> ()) — get-directories & resource-drop
     type_sec.push((96).to_byte())
     write_u32_leb(type_sec, 1)
@@ -650,7 +650,7 @@ fn build_module(
   // Exclude user-defined effects that are handled by throw/catch (not imports)
   let effect_op_keys : Array[String] = []
   for key, _ in ctx.effect_op_imports {
-    if not(ctx.effect_handled_ops.contains(key)) {
+    if !ctx.effect_handled_ops.contains(key) {
       effect_op_keys.push(key)
     }
   }
@@ -735,7 +735,7 @@ fn build_module(
   if ctx.need_stdin_read_char {
     func_import_count += 2
   }
-  if ctx.need_fs && not(ctx.fs_host_imports) {
+  if ctx.need_fs && !ctx.fs_host_imports {
     func_import_count += 7
   }
   if ctx.need_fs && ctx.fs_host_imports {
@@ -876,7 +876,7 @@ fn build_module(
       import_sec.push((0).to_byte())
       write_u32_leb(import_sec, stdin_read_char_type)
     }
-    if ctx.need_fs && not(ctx.fs_host_imports) {
+    if ctx.need_fs && !ctx.fs_host_imports {
       // 1. get-directories
       write_name(import_sec, "wasi:filesystem/preopens@0.2.6")
       write_name(import_sec, "get-directories")
@@ -1080,8 +1080,8 @@ fn build_module(
         }
       }
       if found {
-        let mod_name = key[0:sep].to_string()
-        let fn_name = key[sep + 2:key.length()].to_string()
+        let mod_name = key[0:sep].to_owned()
+        let fn_name = key[sep + 2:key.length()].to_owned()
         write_name(import_sec, mod_name)
         write_name(import_sec, fn_name)
         import_sec.push((0).to_byte()) // func import
@@ -1151,7 +1151,7 @@ fn build_module(
     ctx.need_funcref_table
   // TODO: In linked mode with closures, import funcref table from library
   let import_funcref_table = false // not yet implemented
-  let table_count = (if has_funcref_table && not(import_funcref_table) {
+  let table_count = (if has_funcref_table && !import_funcref_table {
       1
     } else {
       0
@@ -1176,7 +1176,7 @@ fn build_module(
   }
 
   // memory section (skip when importing memory from linked library)
-  if not(has_linked_imports) {
+  if !has_linked_imports {
     let mem_sec = ByteBuf::new()
     write_u32_leb(mem_sec, 1)
     mem_sec.push((0).to_byte())
@@ -1212,7 +1212,7 @@ fn build_module(
   let coverage_count = ctx.coverage_points.length()
   let coverage_bytes = coverage_count * 4
   let exported_env_global_count = ctx.exported_fn_env_globals.length()
-  let need_fs_global = ctx.need_fs && not(ctx.fs_host_imports)
+  let need_fs_global = ctx.need_fs && !ctx.fs_host_imports
   let need_globals = ctx.use_heap_global ||
     ctx.need_stack_switching ||
     ctx.need_effect_resume ||
@@ -1223,7 +1223,7 @@ fn build_module(
     ctx.rc_debug ||
     exported_env_global_count > 0
   // In linked mode, __heap_ptr is imported (not defined in global section)
-  let heap_global_in_section = ctx.use_heap_global && not(has_linked_imports)
+  let heap_global_in_section = ctx.use_heap_global && !has_linked_imports
   let effect_resume_global_count = if ctx.need_effect_resume {
     collect_effect_names(ctx).length() * 3 + 1
   } else {
@@ -1361,7 +1361,7 @@ fn build_module(
     need_fs_global ||
     ctx.force_cabi_realloc
   let need_http_host_string_new_export = ctx.need_http && ctx.http_host_imports
-  let emit_start = not(ctx.library_mode)
+  let emit_start = !ctx.library_mode
   // Library mode: export funcref table for linked builds
   let export_funcref_table = ctx.library_mode && has_funcref_table
   let export_count = (if emit_start { 3 } else { 1 }) + // _start + _vibe_run_tagged + memory, or just memory
@@ -1618,7 +1618,7 @@ fn build_module(
       caps.push("Async")
     }
     for key, _ in ctx.effect_op_imports {
-      if not(ctx.effect_handled_ops.contains(key)) {
+      if !ctx.effect_handled_ops.contains(key) {
         caps.push(key)
       }
     }
@@ -1672,7 +1672,7 @@ fn build_error_map_custom_content(ctx : CodegenCtx) -> Array[Byte] {
 fn restore_locals(ctx : CodegenCtx, saved : Map[String, Int]) -> Unit {
   let to_remove : Array[String] = []
   for name, _ in ctx.locals {
-    if not(saved.contains(name)) {
+    if !saved.contains(name) {
       to_remove.push(name)
     }
   }
@@ -1691,7 +1691,7 @@ fn restore_local_kinds(
 ) -> Unit {
   let to_remove : Array[String] = []
   for name, _ in ctx.local_kinds {
-    if not(saved.contains(name)) {
+    if !saved.contains(name) {
       to_remove.push(name)
     }
   }
@@ -1710,7 +1710,7 @@ fn restore_string_int_map(
 ) -> Unit {
   let to_remove : Array[String] = []
   for name, _ in target {
-    if not(saved.contains(name)) {
+    if !saved.contains(name) {
       to_remove.push(name)
     }
   }
@@ -1729,7 +1729,7 @@ fn restore_string_array_value_kind_map(
 ) -> Unit {
   let to_remove : Array[String] = []
   for name, _ in target {
-    if not(saved.contains(name)) {
+    if !saved.contains(name) {
       to_remove.push(name)
     }
   }
@@ -1748,7 +1748,7 @@ fn restore_string_array_string_map(
 ) -> Unit {
   let to_remove : Array[String] = []
   for name, _ in target {
-    if not(saved.contains(name)) {
+    if !saved.contains(name) {
       to_remove.push(name)
     }
   }
@@ -1767,7 +1767,7 @@ fn restore_string_value_kind_map(
 ) -> Unit {
   let to_remove : Array[String] = []
   for name, _ in target {
-    if not(saved.contains(name)) {
+    if !saved.contains(name) {
       to_remove.push(name)
     }
   }
@@ -1786,7 +1786,7 @@ fn restore_string_func_sig_map(
 ) -> Unit {
   let to_remove : Array[String] = []
   for name, _ in target {
-    if not(saved.contains(name)) {
+    if !saved.contains(name) {
       to_remove.push(name)
     }
   }
@@ -1805,7 +1805,7 @@ fn restore_string_string_map(
 ) -> Unit {
   let to_remove : Array[String] = []
   for name, _ in target {
-    if not(saved.contains(name)) {
+    if !saved.contains(name) {
       to_remove.push(name)
     }
   }
@@ -2200,7 +2200,7 @@ fn static_fold_value_eq(
       } else {
         let mut ok = true
         for i in 0..<left_items.length() {
-          if not(static_fold_value_eq(left_items[i], right_items[i])) {
+          if !static_fold_value_eq(left_items[i], right_items[i]) {
             ok = false
           }
         }
@@ -2215,7 +2215,7 @@ fn static_fold_value_eq(
       } else {
         let mut ok = true
         for i in 0..<left_args.length() {
-          if not(static_fold_value_eq(left_args[i], right_args[i])) {
+          if !static_fold_value_eq(left_args[i], right_args[i]) {
             ok = false
           }
         }
@@ -2235,9 +2235,7 @@ fn static_fold_value_eq(
         let mut ok = true
         for i in 0..<left_fields.length() {
           if left_fields[i].name != right_fields[i].name ||
-            not(
-              static_fold_value_eq(left_fields[i].value, right_fields[i].value),
-            ) {
+            !static_fold_value_eq(left_fields[i].value, right_fields[i].value) {
             ok = false
           }
         }
@@ -2455,7 +2453,7 @@ fn static_fold_builtin_call(
       if args.length() == 1 {
         match args[0] {
           StaticFoldValue::Bool(value~) =>
-            Some(StaticFoldValue::Bool(value=not(value)))
+            Some(StaticFoldValue::Bool(value=!value))
           _ => None
         }
       } else {
@@ -2500,7 +2498,7 @@ fn static_fold_match_pat(
           } else {
             let mut ok = true
             for i in 0..<items.length() {
-              if not(static_fold_match_pat(items[i], value_items[i], bindings)) {
+              if !static_fold_match_pat(items[i], value_items[i], bindings) {
                 ok = false
               }
             }
@@ -2517,7 +2515,7 @@ fn static_fold_match_pat(
           } else {
             let mut ok = true
             for i in 0..<args.length() {
-              if not(static_fold_match_pat(args[i], value_args[i], bindings)) {
+              if !static_fold_match_pat(args[i], value_args[i], bindings) {
                 ok = false
               }
             }
@@ -2549,7 +2547,7 @@ fn static_fold_match_pat(
           for pf in fields {
             match value_map.get(pf.name) {
               Some(vv) =>
-                if not(static_fold_match_pat(pf.pat, vv, bindings)) {
+                if !static_fold_match_pat(pf.pat, vv, bindings) {
                   ok = false
                 }
               None => ok = false
@@ -2813,7 +2811,7 @@ fn static_fold_count_ref_name(
   counts : Map[String, Int],
   bound : Map[String, Bool],
 ) -> Unit {
-  if bound.contains(name) || not(candidates.contains(name)) {
+  if bound.contains(name) || !candidates.contains(name) {
     return
   }
   match counts.get(name) {
@@ -2833,7 +2831,7 @@ fn static_fold_count_refs_expr(
     @core.Expr::Ident(name~, ..) =>
       static_fold_count_ref_name(name, candidates, counts, bound)
     @core.Expr::Call(name~, args~, ..) => {
-      if not(@core.is_ctor_name(name)) {
+      if !@core.is_ctor_name(name) {
         static_fold_count_ref_name(name, candidates, counts, bound)
       }
       for arg in args {
@@ -3034,7 +3032,7 @@ fn strip_unused_top_level_static_bindings(
         @core.Stmt::Let(name~, ..) =>
           if name != "_start" &&
             candidates.contains(name) &&
-            not(counts.contains(name)) {
+            !counts.contains(name) {
             changed = true
           } else {
             stmts.push(stmt)
@@ -3376,7 +3374,7 @@ fn emit_module_with_coverage(
         @core.Stmt::Let(name~, expr~, ..) =>
           match expr {
             @core.Expr::Fn(..) =>
-              if not(ctx.exported_fns.contains(name)) {
+              if !ctx.exported_fns.contains(name) {
                 ctx.exported_fns[name] = true
               }
             _ => ()
@@ -3470,7 +3468,7 @@ fn emit_module_with_coverage(
     if ctx.need_stdin_read_char {
       pre_import_count += 2
     }
-    if ctx.need_fs && not(ctx.fs_host_imports) {
+    if ctx.need_fs && !ctx.fs_host_imports {
       pre_import_count += 7
     }
     if ctx.need_fs && ctx.fs_host_imports {
@@ -3597,7 +3595,7 @@ fn emit_module_with_coverage(
         let f = funcs[i]
         match f.name {
           Some(name) =>
-            if not(ctx.fn_multivalue_results.contains(name)) {
+            if !ctx.fn_multivalue_results.contains(name) {
               match tuple_return_kinds(ctx, f.ret) {
                 Some(kinds) =>
                   if body_always_returns_tuple(
@@ -3681,7 +3679,7 @@ fn emit_module_with_coverage(
   for _pass = 0; _pass < 10; _pass = _pass + 1 {
     let mut changed = false
     for i in 0..<funcs.length() {
-      if not(func_needs_heap[i]) {
+      if !func_needs_heap[i] {
         if needs_heap_block(ctx, funcs[i].body) {
           func_needs_heap[i] = true
           any_user_heap = true
@@ -3693,7 +3691,7 @@ fn emit_module_with_coverage(
         }
       }
     }
-    if not(changed) {
+    if !changed {
       break
     }
   }
@@ -3710,7 +3708,7 @@ fn emit_module_with_coverage(
   // Linked library modules share their memory with dependents.
   // Even when they only expose static string data, the consumer needs
   // a stable heap_ptr export to reserve space after the library's segments.
-  let require_library_heap_global = ctx.library_mode && not(ctx.use_js_strings)
+  let require_library_heap_global = ctx.library_mode && !ctx.use_js_strings
   // In linked mode, always enable heap_global (library provides memory/heap_ptr)
   if require_library_heap_global ||
     any_user_heap ||
@@ -3789,7 +3787,7 @@ fn emit_module_with_coverage(
       (if ctx.need_stack_switching { 1 } else { 0 }) +
       (if ctx.need_effect_resume { 4 } else { 0 }) +
       (if ctx.coverage_enabled { 2 } else { 0 }) +
-      (if ctx.need_fs && not(ctx.fs_host_imports) { 1 } else { 0 }) +
+      (if ctx.need_fs && !ctx.fs_host_imports { 1 } else { 0 }) +
       (if ctx.need_socket { 1 } else { 0 }) +
       (if ctx.rc_free_list_global >= 0 { 1 } else { 0 }) +
       (if ctx.rc_debug { 2 } else { 0 })
@@ -3808,7 +3806,7 @@ fn emit_module_with_coverage(
   {
     let effect_op_keys : Array[String] = []
     for key, _ in ctx.effect_op_imports {
-      if not(ctx.effect_handled_ops.contains(key)) {
+      if !ctx.effect_handled_ops.contains(key) {
         effect_op_keys.push(key)
       }
     }
@@ -3861,7 +3859,7 @@ fn emit_module_with_coverage(
         (if ctx.need_stack_switching { 1 } else { 0 }) +
         (if ctx.need_effect_resume { 4 } else { 0 }) +
         (if ctx.coverage_enabled { 2 } else { 0 }) +
-        (if ctx.need_fs && not(ctx.fs_host_imports) { 1 } else { 0 }) +
+        (if ctx.need_fs && !ctx.fs_host_imports { 1 } else { 0 }) +
         (if ctx.need_socket { 1 } else { 0 })
     } else {
       ctx.rc_header_size = 4 // [rc_count@-4] only
@@ -3876,7 +3874,7 @@ fn emit_module_with_coverage(
         (if ctx.need_stack_switching { 1 } else { 0 }) +
         (if ctx.need_effect_resume { 4 } else { 0 }) +
         (if ctx.coverage_enabled { 2 } else { 0 }) +
-        (if ctx.need_fs && not(ctx.fs_host_imports) { 1 } else { 0 }) +
+        (if ctx.need_fs && !ctx.fs_host_imports { 1 } else { 0 }) +
         (if ctx.need_socket { 1 } else { 0 })
       }
       ctx.rc_debug_alloc_global = debug_base
@@ -4024,7 +4022,7 @@ fn emit_module_with_coverage(
   if ctx.need_stdin_read_char ||
     ctx.need_socket ||
     ctx.need_http ||
-    (ctx.need_fs && not(ctx.fs_host_imports)) ||
+    (ctx.need_fs && !ctx.fs_host_imports) ||
     ctx.force_cabi_realloc {
     let cabi_realloc_sig = FuncSig::{
       params: [ValueKind::I32, ValueKind::I32, ValueKind::I32, ValueKind::I32],
@@ -4073,7 +4071,7 @@ fn emit_module_with_coverage(
   )
   let run_func_index = func_import_count(ctx) + run_func_array_index
   let mut start_export_index = None
-  if not(ctx.library_mode) {
+  if !ctx.library_mode {
     let start_idx = func_import_count(ctx) + compiled_funcs.length()
     compiled_funcs.push(compile_public_start_wrapper(run_func_index))
     start_export_index = Some(start_idx)

--- a/src/codegen/wasm_codegen_rc.mbt
+++ b/src/codegen/wasm_codegen_rc.mbt
@@ -754,7 +754,7 @@ fn parse_site_path(site : String) -> (String, Int) {
     ""
   } else {
     // Remove trailing '.' from prefix
-    site[:last_stmt_pos - 1].to_string()
+    site[:last_stmt_pos - 1].to_owned()
   }
   // Extract index from "stmt[N]..."
   let mut i = last_stmt_pos + 5 // skip "stmt["
@@ -773,7 +773,7 @@ fn parse_site_path(site : String) -> (String, Int) {
     }
     i += 1
   }
-  if not(found_digit) {
+  if !found_digit {
     return (prefix, -1)
   }
   (prefix, result)

--- a/src/codegen/wasm_codegen_scan.mbt
+++ b/src/codegen/wasm_codegen_scan.mbt
@@ -149,7 +149,7 @@ fn scan_needs_expr(ctx : CodegenCtx, expr : @core.Expr) -> Unit {
         | "Float::to_string"
         | "Double::to_string"
         | "Bool::to_string" =>
-          if not(ctx.use_js_strings) {
+          if !ctx.use_js_strings {
             ctx.need_heap = true
           }
         _ =>
@@ -299,8 +299,8 @@ fn scan_needs_expr(ctx : CodegenCtx, expr : @core.Expr) -> Unit {
     @core.Expr::Perform(effect_name~, op_name~, args~, ..) => {
       let key = effect_name + "::" + op_name
       // Only register as import if not a user-defined effect (handled by throw/catch)
-      if not(ctx.effect_op_imports.contains(key)) &&
-        not(ctx.effect_handled_ops.contains(key)) {
+      if !ctx.effect_op_imports.contains(key) &&
+        !ctx.effect_handled_ops.contains(key) {
         ctx.effect_op_imports[key] = -1
         ctx.effect_op_param_counts[key] = args.length()
       }
@@ -334,7 +334,7 @@ fn scan_needs_stmt(ctx : CodegenCtx, stmt : @core.Stmt) -> Unit {
       let _ = span
       for i in 0..<ctors.length() {
         let ctor = ctors[i]
-        if not(ctx.enum_ctor_tags.contains(ctor.name)) {
+        if !ctx.enum_ctor_tags.contains(ctor.name) {
           ctx.enum_ctor_tags[ctor.name] = ctx.next_ctor_tag
           ctx.next_ctor_tag += 1
         }
@@ -346,7 +346,7 @@ fn scan_needs_stmt(ctx : CodegenCtx, stmt : @core.Stmt) -> Unit {
         ctx.enum_ctor_arg_kinds[ctor.name] = arg_kinds
         // Register qualified form: EnumName::CtorName
         let qualified_ctor = enum_name + "::" + ctor.name
-        if not(ctx.enum_ctor_tags.contains(qualified_ctor)) {
+        if !ctx.enum_ctor_tags.contains(qualified_ctor) {
           ctx.enum_ctor_tags[qualified_ctor] = ctx.enum_ctor_tags[ctor.name]
           ctx.enum_ctor_arities[qualified_ctor] = ctor.args.length()
           ctx.enum_ctor_arg_kinds[qualified_ctor] = arg_kinds
@@ -614,7 +614,7 @@ fn scan_strings_expr(ctx : CodegenCtx, expr : @core.Expr) -> Unit {
     }
     @core.Expr::Perform(effect_name="Error", op_name="Throw", args~, ..) => {
       let value = if args.length() >= 1 { args[0].expr } else { return }
-      if not(ctx.use_js_strings) {
+      if !ctx.use_js_strings {
         match value {
           @core.Expr::String(value=message, span~) => {
             let _ = span
@@ -660,7 +660,7 @@ fn scan_strings_pat(ctx : CodegenCtx, pat : @core.Pat) -> Unit {
   match pat {
     @core.Pat::String(value=s, span~) => {
       let _ = span
-      if not(ctx.use_js_strings) {
+      if !ctx.use_js_strings {
         let _ = ctx.strings.intern(s)
       }
     }

--- a/src/codegen/wasm_codegen_sig.mbt
+++ b/src/codegen/wasm_codegen_sig.mbt
@@ -244,7 +244,7 @@ fn builtin_type_count(ctx : CodegenCtx) -> Int {
   if ctx.need_stdin_read_char {
     count += 1
   }
-  if ctx.need_fs && not(ctx.fs_host_imports) {
+  if ctx.need_fs && !ctx.fs_host_imports {
     // Keep in sync with wasm_codegen_module.mbt type section:
     // get-directories/resource-drop, open-at, read, write, metadata-hash-at, stat-at
     count += 5
@@ -327,7 +327,7 @@ fn func_import_count(ctx : CodegenCtx) -> Int {
   if ctx.need_stdin_read_char {
     count += 2
   }
-  if ctx.need_fs && not(ctx.fs_host_imports) {
+  if ctx.need_fs && !ctx.fs_host_imports {
     count += 7
   }
   if ctx.need_fs && ctx.fs_host_imports {
@@ -351,7 +351,7 @@ fn func_import_count(ctx : CodegenCtx) -> Int {
 
 ///|
 fn json_host_import_count(ctx : CodegenCtx) -> Int {
-  if not(ctx.need_fs && ctx.fs_host_imports) {
+  if !(ctx.need_fs && ctx.fs_host_imports) {
     return 0
   }
   let mut count = 0
@@ -972,7 +972,7 @@ fn filter_top_level_funcs(ctx : CodegenCtx, ast : @core.Module) -> @core.Module 
         }
       _ => false
     }
-    if not(skip) {
+    if !skip {
       out.push(stmt)
     }
   }
@@ -1479,7 +1479,7 @@ fn js_import_count(ctx : CodegenCtx) -> Int {
 
 ///|
 fn import_index_path(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_path) {
+  if !ctx.need_path {
     raise WasmGenError::BackendLimit(backend="wasm", feature="path import")
   }
   js_import_count(ctx)
@@ -1489,7 +1489,7 @@ fn import_index_path(ctx : CodegenCtx) -> Int raise WasmGenError {
 fn import_index_dynamic_path_resolve(
   ctx : CodegenCtx,
 ) -> Int raise WasmGenError {
-  if not(ctx.need_dynamic_path_resolve) {
+  if !ctx.need_dynamic_path_resolve {
     raise WasmGenError::BackendLimit(
       backend="wasm",
       feature="Path::resolve import",
@@ -1504,7 +1504,7 @@ fn import_index_dynamic_path_resolve(
 
 ///|
 fn import_index_sh(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_sh) {
+  if !ctx.need_sh {
     raise WasmGenError::BackendLimit(backend="wasm", feature="sh import")
   }
   let mut idx = js_import_count(ctx)
@@ -1519,7 +1519,7 @@ fn import_index_sh(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_env_get(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_env_get) {
+  if !ctx.need_env_get {
     raise WasmGenError::BackendLimit(backend="wasm", feature="Env::get import")
   }
   let mut idx = js_import_count(ctx)
@@ -1537,7 +1537,7 @@ fn import_index_env_get(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_env_args_len(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_env_args_len) {
+  if !ctx.need_env_args_len {
     raise WasmGenError::BackendLimit(
       backend="wasm",
       feature="Env::args_len import",
@@ -1561,7 +1561,7 @@ fn import_index_env_args_len(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_env_args_get(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_env_args_get) {
+  if !ctx.need_env_args_get {
     raise WasmGenError::BackendLimit(
       backend="wasm",
       feature="Env::args_get import",
@@ -1588,7 +1588,7 @@ fn import_index_env_args_get(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_js_length(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_js_length) {
+  if !ctx.need_js_length {
     raise WasmGenError::BackendLimit(
       backend="wasm-js-string",
       feature="length import",
@@ -1599,7 +1599,7 @@ fn import_index_js_length(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_js_char_code_at(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_js_char_code_at) {
+  if !ctx.need_js_char_code_at {
     raise WasmGenError::BackendLimit(
       backend="wasm-js-string",
       feature="charCodeAt import",
@@ -1614,7 +1614,7 @@ fn import_index_js_char_code_at(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_js_substring(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_js_substring) {
+  if !ctx.need_js_substring {
     raise WasmGenError::BackendLimit(
       backend="wasm-js-string",
       feature="substring import",
@@ -1632,7 +1632,7 @@ fn import_index_js_substring(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_js_concat(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_js_concat) {
+  if !ctx.need_js_concat {
     raise WasmGenError::BackendLimit(
       backend="wasm-js-string",
       feature="concat import",
@@ -1653,7 +1653,7 @@ fn import_index_js_concat(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_js_equals(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_js_equals) {
+  if !ctx.need_js_equals {
     raise WasmGenError::BackendLimit(
       backend="wasm-js-string",
       feature="equals import",
@@ -1704,7 +1704,7 @@ fn import_index_after_sleep(ctx : CodegenCtx) -> Int {
 
 ///|
 fn import_index_stdout_get_stream(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_stdout_write_char) {
+  if !ctx.need_stdout_write_char {
     raise WasmGenError::BackendLimit(
       backend="wasm",
       feature="stdout stream import",
@@ -1715,7 +1715,7 @@ fn import_index_stdout_get_stream(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_stdout_write_stream(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_stdout_write_char) {
+  if !ctx.need_stdout_write_char {
     raise WasmGenError::BackendLimit(
       backend="wasm",
       feature="stdout stream import",
@@ -1726,7 +1726,7 @@ fn import_index_stdout_write_stream(ctx : CodegenCtx) -> Int raise WasmGenError 
 
 ///|
 fn import_index_stdin_get_stream(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_stdin_read_char) {
+  if !ctx.need_stdin_read_char {
     raise WasmGenError::BackendLimit(
       backend="wasm",
       feature="stdin stream import",
@@ -1741,7 +1741,7 @@ fn import_index_stdin_get_stream(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_stdin_read_stream(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_stdin_read_char) {
+  if !ctx.need_stdin_read_char {
     raise WasmGenError::BackendLimit(
       backend="wasm",
       feature="stdin stream import",
@@ -1764,7 +1764,7 @@ fn import_index_after_stdin(ctx : CodegenCtx) -> Int {
 
 ///|
 fn import_index_fs_get_directories(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_fs) || ctx.fs_host_imports {
+  if !ctx.need_fs || ctx.fs_host_imports {
     raise WasmGenError::BackendLimit(backend="wasm", feature="fs WASI import")
   }
   import_index_after_stdin(ctx)
@@ -1810,7 +1810,7 @@ fn fs_root_descriptor_global_index(ctx : CodegenCtx) -> Int {
 
 ///|
 fn import_index_fs_host_read_file(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_fs && ctx.fs_host_imports) {
+  if !(ctx.need_fs && ctx.fs_host_imports) {
     raise WasmGenError::BackendLimit(backend="wasm", feature="fs host import")
   }
   import_index_after_stdin(ctx)
@@ -1909,7 +1909,7 @@ fn import_index_fs_host_close_write(ctx : CodegenCtx) -> Int raise WasmGenError 
 ///|
 fn import_index_after_fs(ctx : CodegenCtx) -> Int {
   let mut idx = import_index_after_stdin(ctx)
-  if ctx.need_fs && not(ctx.fs_host_imports) {
+  if ctx.need_fs && !ctx.fs_host_imports {
     idx += 7
   }
   if ctx.need_fs && ctx.fs_host_imports {
@@ -1921,7 +1921,7 @@ fn import_index_after_fs(ctx : CodegenCtx) -> Int {
 
 ///|
 fn import_index_json_host_parse(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_fs && ctx.fs_host_imports && ctx.need_json_host_parse) {
+  if !(ctx.need_fs && ctx.fs_host_imports && ctx.need_json_host_parse) {
     raise WasmGenError::BackendLimit(backend="wasm", feature="json host import")
   }
   let mut idx = import_index_after_stdin(ctx)
@@ -1933,7 +1933,7 @@ fn import_index_json_host_parse(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_json_host_stringify(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_fs && ctx.fs_host_imports && ctx.need_json_host_stringify) {
+  if !(ctx.need_fs && ctx.fs_host_imports && ctx.need_json_host_stringify) {
     raise WasmGenError::BackendLimit(backend="wasm", feature="json host import")
   }
   let mut idx = import_index_after_stdin(ctx)
@@ -1948,7 +1948,7 @@ fn import_index_json_host_stringify(ctx : CodegenCtx) -> Int raise WasmGenError 
 
 ///|
 fn import_index_json_host_get(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_fs && ctx.fs_host_imports && ctx.need_json_host_get) {
+  if !(ctx.need_fs && ctx.fs_host_imports && ctx.need_json_host_get) {
     raise WasmGenError::BackendLimit(backend="wasm", feature="json host import")
   }
   let mut idx = import_index_after_stdin(ctx)
@@ -1966,7 +1966,7 @@ fn import_index_json_host_get(ctx : CodegenCtx) -> Int raise WasmGenError {
 
 ///|
 fn import_index_json_host_string(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_fs && ctx.fs_host_imports && ctx.need_json_host_string) {
+  if !(ctx.need_fs && ctx.fs_host_imports && ctx.need_json_host_string) {
     raise WasmGenError::BackendLimit(backend="wasm", feature="json host import")
   }
   let mut idx = import_index_after_stdin(ctx)
@@ -1989,7 +1989,7 @@ fn import_index_json_host_string(ctx : CodegenCtx) -> Int raise WasmGenError {
 fn import_index_socket_instance_network(
   ctx : CodegenCtx,
 ) -> Int raise WasmGenError {
-  if not(ctx.need_socket) {
+  if !ctx.need_socket {
     raise WasmGenError::BackendLimit(
       backend="wasm",
       feature="socket WASI import",
@@ -2075,7 +2075,7 @@ fn import_index_after_socket(ctx : CodegenCtx) -> Int {
 
 ///|
 fn import_index_http_request(ctx : CodegenCtx) -> Int raise WasmGenError {
-  if not(ctx.need_http && ctx.http_host_imports) {
+  if !(ctx.need_http && ctx.http_host_imports) {
     raise WasmGenError::BackendLimit(backend="wasm", feature="http host import")
   }
   import_index_after_socket(ctx)
@@ -2146,7 +2146,7 @@ fn socket_table_global_index(ctx : CodegenCtx) -> Int {
   (if ctx.need_stack_switching { 1 } else { 0 }) +
   (if ctx.need_effect_resume { 4 } else { 0 }) +
   (if ctx.coverage_enabled { 2 } else { 0 }) +
-  (if ctx.need_fs && not(ctx.fs_host_imports) { 1 } else { 0 })
+  (if ctx.need_fs && !ctx.fs_host_imports { 1 } else { 0 })
 }
 
 ///|
@@ -2223,9 +2223,7 @@ fn expr_always_returns_tuple(
         return false
       }
       for arm in arms {
-        if not(
-            expr_always_returns_tuple(arm.expr, arity, self_name, eligible_fns~),
-          ) {
+        if !expr_always_returns_tuple(arm.expr, arity, self_name, eligible_fns~) {
           return false
         }
       }
@@ -2248,13 +2246,11 @@ fn expr_always_returns_tuple(
         self_name,
         eligible_fns~,
       )
-      if not(body_ok) {
+      if !body_ok {
         return false
       }
       for arm in arms {
-        if not(
-            expr_always_returns_tuple(arm.expr, arity, self_name, eligible_fns~),
-          ) {
+        if !expr_always_returns_tuple(arm.expr, arity, self_name, eligible_fns~) {
           return false
         }
       }

--- a/src/codegen/wasm_codegen_stmt.mbt
+++ b/src/codegen/wasm_codegen_stmt.mbt
@@ -55,7 +55,7 @@ fn unwrap_type_assert_block(expr : @core.Expr) -> @core.Expr {
           ) => {
             // Check: call target matches the local type-assert function
             if assert_name != call_name ||
-              not(assert_name.has_prefix("__vibe_local_type_assert_")) {
+              !assert_name.has_prefix("__vibe_local_type_assert_") {
               return expr
             }
             // Check: the function is a single-param identity (body = param)
@@ -68,7 +68,7 @@ fn unwrap_type_assert_block(expr : @core.Expr) -> @core.Expr {
                 ret_name == param_name
               _ => false
             }
-            if not(is_identity) {
+            if !is_identity {
               return expr
             }
             // Check: exactly one argument
@@ -301,7 +301,7 @@ fn compile_stmt(
                       break
                     }
                   }
-                  if not(is_last) && not(is_captured) && not(needs_env) {
+                  if !is_last && !is_captured && !needs_env {
                     return
                   }
                 }
@@ -349,7 +349,7 @@ fn compile_stmt(
                           break
                         }
                       }
-                      if not(is_last) && not(is_captured) {
+                      if !is_last && !is_captured {
                         return
                       }
                       let idx = ctx.local_count
@@ -408,7 +408,7 @@ fn compile_stmt(
                           break
                         }
                       }
-                      if not(is_last) && not(is_captured) && not(needs_env) {
+                      if !is_last && !is_captured && !needs_env {
                         return
                       }
                     }
@@ -424,7 +424,7 @@ fn compile_stmt(
           // directly instead of local.get.
           // When captured by a closure, still register (for inline in closure body)
           // but don't skip local allocation (closure construction needs the local).
-          if not(rec) {
+          if !rec {
             let const_tagged : Int64? = match effective_expr {
               @core.Expr::Int(value=int_val, ..) =>
                 Some(tag_int_value64(int_val))
@@ -442,7 +442,7 @@ fn compile_stmt(
                     break
                   }
                 }
-                if not(is_captured) {
+                if !is_captured {
                   if is_last {
                     emit_i64_const_raw(buf, tagged)
                   }
@@ -518,12 +518,12 @@ fn compile_stmt(
       let _ = span
       for i in 0..<ctors.length() {
         let ctor = ctors[i]
-        if not(ctx.enum_ctor_tags.contains(ctor.name)) {
+        if !ctx.enum_ctor_tags.contains(ctor.name) {
           ctx.enum_ctor_tags[ctor.name] = ctx.next_ctor_tag
           ctx.next_ctor_tag += 1
         }
         ctx.enum_ctor_arities[ctor.name] = ctor.args.length()
-        if not(ctx.enum_ctor_arg_kinds.contains(ctor.name)) {
+        if !ctx.enum_ctor_arg_kinds.contains(ctor.name) {
           let arg_kinds : Array[ValueKind] = []
           for arg in ctor.args {
             arg_kinds.push(value_kind_from_type(ctx, arg))
@@ -532,7 +532,7 @@ fn compile_stmt(
         }
         // Also register qualified form: EnumName::CtorName
         let qualified_ctor = enum_name + "::" + ctor.name
-        if not(ctx.enum_ctor_tags.contains(qualified_ctor)) {
+        if !ctx.enum_ctor_tags.contains(qualified_ctor) {
           ctx.enum_ctor_tags[qualified_ctor] = ctx.enum_ctor_tags[ctor.name]
           ctx.enum_ctor_arities[qualified_ctor] = ctor.args.length()
           if ctx.enum_ctor_arg_kinds.contains(ctor.name) {
@@ -541,7 +541,7 @@ fn compile_stmt(
         }
         // Register singleton for 0-arg enum constructors
         if ctor.args.length() == 0 &&
-          not(ctx.enum_ctor_singletons.contains(ctor.name)) {
+          !ctx.enum_ctor_singletons.contains(ctor.name) {
           let offset = ctx.strings.intern_enum_singleton(
             ctor.name,
             ctx.enum_ctor_tags[ctor.name],
@@ -568,7 +568,7 @@ fn compile_stmt(
       // Tail position propagates only for the last expression in a block
       // compile_expr will save/reset is_tail_position itself
       compile_expr(ctx, buf, expr)
-      if not(is_last) {
+      if !is_last {
         emit_drop(buf)
       }
     }
@@ -760,7 +760,7 @@ fn compile_stmt(
         span~,
       )
       compile_expr(ctx, buf, call_expr)
-      if not(is_last) {
+      if !is_last {
         emit_drop(buf)
       }
     }
@@ -1105,7 +1105,7 @@ fn pat_is_irrefutable(pat : @core.Pat) -> Bool {
     @core.Pat::Bind(..) | @core.Pat::Wildcard(..) => true
     @core.Pat::Tuple(items~, ..) => {
       for item in items {
-        if not(pat_is_irrefutable(item)) {
+        if !pat_is_irrefutable(item) {
           return false
         }
       }
@@ -1113,7 +1113,7 @@ fn pat_is_irrefutable(pat : @core.Pat) -> Bool {
     }
     @core.Pat::Record(fields~, ..) => {
       for field in fields {
-        if not(pat_is_irrefutable(field.pat)) {
+        if !pat_is_irrefutable(field.pat) {
           return false
         }
       }
@@ -1121,7 +1121,7 @@ fn pat_is_irrefutable(pat : @core.Pat) -> Bool {
     }
     @core.Pat::Struct(fields~, ..) => {
       for field in fields {
-        if not(pat_is_irrefutable(field.pat)) {
+        if !pat_is_irrefutable(field.pat) {
           return false
         }
       }
@@ -1432,7 +1432,7 @@ fn detect_multivalue_call(
     @core.Expr::Call(name~, ..) => {
       let lowered = @core.lower_wasm_intrinsic_name(name)
       let is_direct = ctx.fn_indices.contains(lowered) &&
-        not(ctx.fn_local_sigs.contains(lowered) && ctx.locals.contains(lowered))
+        !(ctx.fn_local_sigs.contains(lowered) && ctx.locals.contains(lowered))
       let indirect_mv = match ctx.fn_local_sigs.get(lowered) {
         Some(sig) => sig.results.length() > 1 && ctx.locals.contains(lowered)
         None => false

--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -2651,7 +2651,7 @@ fn infer_expr_kind_gc(
     @core.Expr::Break(..) | @core.Expr::Continue(..) => GcValKind::I32
     other =>
       raise WasmGenError::Unsupported(
-        "expr: " + other.to_string()[:40].to_string(),
+        "expr: " + other.to_string()[:40].to_owned(),
       )
   }
 }
@@ -8651,7 +8651,7 @@ fn compile_expr_gc(
       emit_br_gc(buf, 0)
     other =>
       raise WasmGenError::Unsupported(
-        "expr: " + other.to_string()[:40].to_string(),
+        "expr: " + other.to_string()[:40].to_owned(),
       )
   }
 }

--- a/src/core/diagnostic_render.mbt
+++ b/src/core/diagnostic_render.mbt
@@ -135,7 +135,7 @@ pub fn render_snippet(source : String, span : Span) -> String {
 /// `vibe check` on files with thousands of warnings).
 pub fn render_snippet_with_index(index : LineIndex, span : Span) -> String {
   let (pos, line_start, line_end) = index.line_info(span.start)
-  let line_text = index.source[line_start:line_end].to_string()
+  let line_text = index.source[line_start:line_end].to_owned()
   if line_text.length() == 0 {
     return ""
   }

--- a/src/core/module_store.mbt
+++ b/src/core/module_store.mbt
@@ -30,7 +30,7 @@ pub fn hash_from_object_path(path : String) -> String? {
   // Find last two path components
   let parts : Array[String] = []
   for p in path.split("/") {
-    parts.push(p.to_string())
+    parts.push(p.to_owned())
   }
   if parts.length() < 2 {
     return None

--- a/src/core/normalize.mbt
+++ b/src/core/normalize.mbt
@@ -43,7 +43,7 @@ fn NormScope::bind(self : NormScope, name : String) -> String {
   // Also bind unqualified name for module-prefixed identifiers (e.g. "math::helper" -> bind "helper" too)
   match name.rev_find("::") {
     Some(idx) => {
-      let unqualified = name[idx + 2:].to_string()
+      let unqualified = name[idx + 2:].to_owned()
       if unqualified.length() > 0 && !self.bindings.contains(unqualified) {
         self.bindings[unqualified] = normalized
       }

--- a/src/core/resolve.mbt
+++ b/src/core/resolve.mbt
@@ -19,7 +19,7 @@ pub fn import_alias_name(path : String) -> String {
   }
   let base = buf.to_string()
   if base.has_suffix(".vibe") && base.length() > 5 {
-    base[0:base.length() - 5].to_string()
+    base[0:base.length() - 5].to_owned()
   } else {
     base
   }

--- a/src/frontend/dce.mbt
+++ b/src/frontend/dce.mbt
@@ -67,7 +67,7 @@ fn dce_module_impl(
       return
     }
     // Only filter builtin names that are NOT shadowed by user definitions
-    if @core.is_builtin_name(name) && not(user_defs.contains(name)) {
+    if @core.is_builtin_name(name) && !user_defs.contains(name) {
       return
     }
     refs[name] = true
@@ -432,7 +432,7 @@ fn compute_reachable(
   let queue : Array[String] = []
   // Initialize with entry points
   for name, _ in entries {
-    if not(reachable.contains(name)) {
+    if !reachable.contains(name) {
       reachable[name] = true
       queue.push(name)
     }
@@ -445,7 +445,7 @@ fn compute_reachable(
         match graph.get(name) {
           Some(deps) =>
             for dep, _ in deps {
-              if not(reachable.contains(dep)) {
+              if !reachable.contains(dep) {
                 reachable[dep] = true
                 queue.push(dep)
               }
@@ -485,7 +485,7 @@ fn filter_reachable_stmts(
         // Keep if type name is reachable OR any constructor is reachable
         // (including qualified form: EnumName::CtorName)
         let mut keep = reachable.contains(name)
-        if not(keep) {
+        if !keep {
           for ctor in ctors {
             if reachable.contains(ctor.name) ||
               reachable.contains(name + "::" + ctor.name) {
@@ -502,7 +502,7 @@ fn filter_reachable_stmts(
         let _ = params
         let _ = span
         let mut keep = reachable.contains(name)
-        if not(keep) {
+        if !keep {
           for ctor in ctors {
             if reachable.contains(ctor.name) ||
               reachable.contains(name + "::" + ctor.name) {
@@ -519,7 +519,7 @@ fn filter_reachable_stmts(
         let _ = params
         let _ = span
         let mut keep = reachable.contains(name)
-        if not(keep) {
+        if !keep {
           for ctor in ctors {
             if reachable.contains(ctor.name) ||
               reachable.contains(name + "::" + ctor.name) {
@@ -741,7 +741,7 @@ fn collect_for_in_helper_refs_stmt(
         scope.bindings[name] = true
       }
       collect_for_in_helper_refs_expr(expr, scope, refs, on_name)
-      if not(rec) {
+      if !rec {
         scope.bindings[name] = true
       }
     }

--- a/src/frontend/desugar.mbt
+++ b/src/frontend/desugar.mbt
@@ -82,8 +82,8 @@ fn is_vibe_command_candidate(
   scope : DesugarScope,
   known_non_cmd : Map[String, Bool],
 ) -> Bool {
-  not(scope.contains(name)) &&
-  not(known_non_cmd.contains(name)) &&
+  !scope.contains(name) &&
+  !known_non_cmd.contains(name) &&
   is_command_like_name(name)
 }
 
@@ -770,7 +770,7 @@ fn desugar_expr(
       if next_args.length() >= 1 {
         match next_args[0].expr {
           @core.Expr::Ident(name=recv, ..) =>
-            if aliases.contains(recv) && not(scope.contains(recv)) {
+            if aliases.contains(recv) && !scope.contains(recv) {
               let qualified = recv + "." + name
               if next_args.length() == 1 {
                 // foo.bar → Ident("foo.bar")
@@ -794,7 +794,7 @@ fn desugar_expr(
       }
       match split_method_call_name(name) {
         Some((recv, method_name)) =>
-          if scope.contains(recv) && not(aliases.contains(recv)) {
+          if scope.contains(recv) && !aliases.contains(recv) {
             let merged : Array[@core.CallArg] = []
             let recv_expr = @core.Expr::Ident(name=recv, span~)
             merged.push(@core.CallArg::{ label: None, expr: recv_expr, span })
@@ -1032,9 +1032,9 @@ fn split_method_call_name(name : String) -> (String, String)? {
   if dot <= 0 || dot >= chars.length() - 1 {
     return None
   }
-  let left = name[0:dot].to_string()
-  let right = name[dot + 1:chars.length()].to_string()
-  if not(is_simple_ident(left)) || not(is_simple_ident(right)) {
+  let left = name[0:dot].to_owned()
+  let right = name[dot + 1:chars.length()].to_owned()
+  if !is_simple_ident(left) || !is_simple_ident(right) {
     return None
   }
   Some((left, right))
@@ -1052,7 +1052,7 @@ fn is_simple_ident(name : String) -> Bool {
       (code >= 65 && code <= 90) ||
       (code >= 97 && code <= 122) ||
       code == 95
-    if not(ok) {
+    if !ok {
       return false
     }
   }

--- a/src/frontend/monoify.mbt
+++ b/src/frontend/monoify.mbt
@@ -30,7 +30,7 @@ pub fn monoify_module(
   // another file but the receiver's concrete root type is only known here.
   // The user's own defs win on name collision (rare in practice).
   for name, expr in additional_specializable {
-    if not(specializable.contains(name)) {
+    if !specializable.contains(name) {
       specializable[name] = expr
     }
   }
@@ -146,7 +146,7 @@ fn collect_transitive_instantiations(ctx : MonoifyContext) -> Unit {
       let tags = ctx.tags_for_name(name)
       for tag in tags {
         let key = inst_key(name, tag)
-        if not(visited.contains(key)) {
+        if !visited.contains(key) {
           visited[key] = true
           has_pending = true
           let specialized = specialize_fn_expr(expr, name, tag, ctx)
@@ -209,7 +209,7 @@ fn collect_instantiations_expr(
   match expr {
     @core.Expr::Call(name~, args~, span~, ..) => {
       let _ = span
-      if ctx.specializable.contains(name) && not(scope.contains(name)) {
+      if ctx.specializable.contains(name) && !scope.contains(name) {
         match ctx.tag_for_call(name, args, {}, {}) {
           Some(inst) => ctx.add_instantiation(name, inst)
           None => ()
@@ -591,7 +591,7 @@ fn monoify_expr(
           @core.Expr::Call(name=mapped, type_args~, args=next_args, span~)
         None =>
           if ctx.specializable.contains(rewritten_name) &&
-            not(scope.contains(rewritten_name)) {
+            !scope.contains(rewritten_name) {
             match
               ctx.tag_for_call(
                 rewritten_name, args, local_types, scope_type_subst,
@@ -1056,7 +1056,7 @@ fn maybe_specialize_ident_arg(
 ) -> @core.Expr {
   match expr {
     @core.Expr::Ident(name~, span~) =>
-      if ctx.specializable.contains(name) && not(scope.contains(name)) {
+      if ctx.specializable.contains(name) && !scope.contains(name) {
         if ctx.instantiations.contains(inst_key(name, tag)) {
           @core.Expr::Ident(name=specialized_name(name, tag), span~)
         } else {
@@ -1763,12 +1763,12 @@ fn fn_has_root_specializable_param(
 
 ///|
 fn explicit_root_tag_from_name(name : String) -> String? {
-  if not(name.contains("::")) {
+  if !name.contains("::") {
     return None
   }
   let parts : Array[String] = []
   for part_view in name.split("::") {
-    parts.push(part_view.to_string())
+    parts.push(part_view.to_owned())
   }
   if parts.length() != 2 || parts[0] == "" || parts[1] == "" {
     None
@@ -2092,7 +2092,7 @@ fn monoify_collect_iter_dispatch_param_names_expr(
         for arg in pos_args {
           match arg.expr {
             @core.Expr::Ident(name=recv, ..) =>
-              if not(seen.contains(recv)) {
+              if !seen.contains(recv) {
                 seen[recv] = true
                 out.push(recv)
               }
@@ -2147,7 +2147,7 @@ fn rewrite_iter_dispatch_call_name(
   args : Array[@core.CallArg],
   iterable_spec : Map[String, String],
 ) -> String {
-  if not(is_iter_dispatch_call_name(name)) {
+  if !is_iter_dispatch_call_name(name) {
     return name
   }
   let pos_args = positional_args(args)

--- a/src/frontend/perceus_poc.mbt
+++ b/src/frontend/perceus_poc.mbt
@@ -2192,7 +2192,7 @@ fn perceus_block_prefix(site : String) -> String {
     i = i + 1
   }
   if last_dot_stmt > 0 {
-    return site[0:last_dot_stmt].to_string()
+    return site[0:last_dot_stmt].to_owned()
   }
   // No nested stmt — find last '.' for terminal suffixes
   let mut last_dot = -1
@@ -2204,7 +2204,7 @@ fn perceus_block_prefix(site : String) -> String {
     j = j + 1
   }
   if last_dot > 0 {
-    return site[0:last_dot].to_string()
+    return site[0:last_dot].to_owned()
   }
   site
 }

--- a/src/frontend/rewrite_effect_handle.mbt
+++ b/src/frontend/rewrite_effect_handle.mbt
@@ -332,7 +332,7 @@ fn reh_parse_effect_arm(arm : @core.MatchArm) -> EffectHandler? {
   // Pattern must be Ctor("Effect::Op", params)
   let (key, param_names) = match arm.pat {
     @core.Pat::Ctor(name~, args~, ..) =>
-      if name.contains("::") && not(reh_is_builtin_error_handler_name(name)) {
+      if name.contains("::") && !reh_is_builtin_error_handler_name(name) {
         let names : Array[String] = []
         for arg in args {
           match arg {
@@ -832,10 +832,10 @@ fn reh_try_defunctionalize(
   }
   // Verify all handlers are accumulate: raw_expr is BinOp("+", v, Call(k, [arg]))
   for _key, handler in handlers {
-    if not(handler.has_continuation) {
+    if !handler.has_continuation {
       return None
     }
-    if not(reh_is_accumulate_pattern(handler)) {
+    if !reh_is_accumulate_pattern(handler) {
       return None
     }
   }

--- a/src/frontend/symbol_index.mbt
+++ b/src/frontend/symbol_index.mbt
@@ -403,15 +403,15 @@ fn si_collect_plus_bound_fragments(
       continue
     }
     if tokens[i + 1] != "+" ||
-      not(si_is_bound_atom(tokens[i])) ||
-      not(si_is_bound_atom(tokens[i + 2])) {
+      !si_is_bound_atom(tokens[i]) ||
+      !si_is_bound_atom(tokens[i + 2]) {
       i += 1
       continue
     }
     let atoms : Array[String] = [tokens[i]]
     let mut j = i
     while j + 2 < tokens.length() {
-      if tokens[j + 1] != "+" || not(si_is_bound_atom(tokens[j + 2])) {
+      if tokens[j + 1] != "+" || !si_is_bound_atom(tokens[j + 2]) {
         break
       }
       atoms.push(tokens[j + 2])
@@ -435,7 +435,7 @@ fn si_collect_plus_bound_fragments(
 fn si_collect_effect_fragments(signature : String, out : Array[String]) -> Unit {
   let chunks : Array[String] = []
   for part_view in signature.split("with {") {
-    chunks.push(part_view.to_string())
+    chunks.push(part_view.to_owned())
   }
   if chunks.length() <= 1 {
     return
@@ -445,13 +445,13 @@ fn si_collect_effect_fragments(signature : String, out : Array[String]) -> Unit 
     match tail.find("}") {
       Some(end_pos) => {
         let inner_raw = tail.unsafe_substring(start=0, end=end_pos)
-        let inner = inner_raw.trim().to_string()
+        let inner = inner_raw.trim().to_owned()
         if inner.length() == 0 {
           continue
         }
         out.push("with {" + inner + "}")
         for effect_view in inner.split(",") {
-          let effect = effect_view.to_string().trim().to_string()
+          let effect = effect_view.to_owned().trim().to_owned()
           if effect.length() > 0 {
             out.push("with {" + effect + "}")
           }
@@ -511,7 +511,7 @@ fn si_build_vibe_query_index(
   let out : Map[String, Array[Int]] = {}
   for i in 0..<entries.length() {
     let signature = entries[i].signature
-    if not(signature.contains(" + ") || signature.contains("with {")) {
+    if !(signature.contains(" + ") || signature.contains("with {")) {
       continue
     }
     for key in si_collect_vibe_query_fragments(signature) {

--- a/src/frontend/symbol_index_lsif.mbt
+++ b/src/frontend/symbol_index_lsif.mbt
@@ -168,7 +168,7 @@ fn sorted_index_paths(index : SymbolIndex) -> Array[String] {
   let seen : Map[String, Bool] = {}
   let paths : Array[String] = []
   for entry in index.entries {
-    if not(seen.contains(entry.path)) {
+    if !seen.contains(entry.path) {
       seen[entry.path] = true
       paths.push(entry.path)
     }

--- a/src/fs/backend.mbt
+++ b/src/fs/backend.mbt
@@ -40,7 +40,7 @@ pub fn normalize_path(path : String) -> String {
   // Simple normalization: remove trailing slash, handle . and ..
   let parts : Array[String] = []
   for part in path.split("/") {
-    let s = part.to_string()
+    let s = part.to_owned()
     match s {
       "" | "." => continue
       ".." => if parts.length() > 0 { let _ = parts.pop() }

--- a/src/fs/memfs.mbt
+++ b/src/fs/memfs.mbt
@@ -66,7 +66,7 @@ fn MemFs::resolve(self : MemFs, path : String) -> Int? {
     ""
   }
   for part in path_without_slash.split("/") {
-    let part_str = part.to_string()
+    let part_str = part.to_owned()
     if part_str.is_empty() {
       continue
     }
@@ -287,7 +287,7 @@ pub impl FileSystemBackend for MemFs with mkdir_p(self, path) {
   }
   let parts : Array[String] = []
   for part in path_without_slash.split("/") {
-    parts.push(part.to_string())
+    parts.push(part.to_owned())
   }
   let mut current_path = ""
   for part in parts {

--- a/src/io/lib.mbt
+++ b/src/io/lib.mbt
@@ -232,7 +232,7 @@ pub fn get_env_var(name : String) -> String? {
 fn split_output_lines(text : String) -> Array[String] {
   let out : Array[String] = []
   for part in text.split("\n") {
-    out.push(part.to_string())
+    out.push(part.to_owned())
   }
   if out.length() > 0 && out[out.length() - 1] == "" {
     ignore(out.pop())

--- a/src/loader/lib.mbt
+++ b/src/loader/lib.mbt
@@ -11,14 +11,14 @@ fn extract_vibe_from_markdown(markdown : String) -> String {
   let mut in_other_block = false
   for i = 0; i < lines.length(); i = i + 1 {
     let line = lines[i]
-    if not(in_vibe_block) && not(in_other_block) {
+    if !in_vibe_block && !in_other_block {
       if line.has_prefix("```vibe") {
         in_vibe_block = true
       } else if line.has_prefix("```") {
         in_other_block = true
       }
     } else if in_vibe_block {
-      if line.trim().to_string() == "```" {
+      if line.trim().to_owned() == "```" {
         let sb = StringBuilder::new()
         for j, s in buf {
           if j > 0 {
@@ -33,7 +33,7 @@ fn extract_vibe_from_markdown(markdown : String) -> String {
         buf.push(line)
       }
     } else if in_other_block {
-      if line.trim().to_string() == "```" {
+      if line.trim().to_owned() == "```" {
         in_other_block = false
       }
     }
@@ -114,7 +114,7 @@ fn resolve_alias_to_source(
   fs : &@io.FileSystemAdapter,
 ) -> Result[@vibe_core.ModuleRef, String] {
   let index_path = dir + "/index.vibe"
-  if not(@io.path_exists_with(fs, index_path)) {
+  if !@io.path_exists_with(fs, index_path) {
     return Err("alias @" + alias_name + ": no index.vibe found in " + dir)
   }
   let source = match @io.read_string_with(fs, index_path) {
@@ -214,7 +214,7 @@ fn load_sources_recursive_impl(
               }
             }
             if resolved.has_suffix(".wasm") {
-              if not(visited.contains(resolved)) {
+              if !visited.contains(resolved) {
                 visited.set(resolved, true)
                 let wasm_bytes = match @io.read_bytes_with(fs, resolved) {
                   Ok(v) => v
@@ -241,7 +241,7 @@ fn load_sources_recursive_impl(
           @vibe_core.ModuleRef::Alias(name~) => {
             // Ensure index.vibe is loaded into db for alias resolution in db_query
             let index_path = @vibe_fs.normalize_path(base + "/index.vibe")
-            if not(visited.contains(index_path)) {
+            if !visited.contains(index_path) {
               match @io.read_string_with(fs, index_path) {
                 Ok(index_src) => db.set_source(index_path, index_src)
                 Err(_) => ()
@@ -301,7 +301,7 @@ fn load_sources_recursive_impl(
               }
             }
             if resolved.has_suffix(".wasm") {
-              if not(visited.contains(resolved)) {
+              if !visited.contains(resolved) {
                 visited.set(resolved, true)
                 let wasm_bytes = match @io.read_bytes_with(fs, resolved) {
                   Ok(v) => v

--- a/src/loader/loader_test.mbt
+++ b/src/loader/loader_test.mbt
@@ -1,7 +1,7 @@
 ///|
 fn make_temp_dir(prefix : String) -> String {
   let tmp_root = @vibe_fs.normalize_path(@io.current_dir_or_root() + "/.tmp")
-  if not(@os_fs.path_exists(tmp_root)) {
+  if !@os_fs.path_exists(tmp_root) {
     @os_fs.create_dir(tmp_root) catch {
       e => abort("create temp root failed: " + e.to_string())
     }
@@ -9,7 +9,7 @@ fn make_temp_dir(prefix : String) -> String {
   let base = tmp_root + "/vibe_loader_test_" + prefix
   for i in 0..<1000 {
     let path = if i == 0 { base } else { base + "_" + i.to_string() }
-    if not(@os_fs.path_exists(path)) {
+    if !@os_fs.path_exists(path) {
       @os_fs.create_dir(path) catch {
         e => abort("create temp dir failed: " + e.to_string())
       }
@@ -22,7 +22,7 @@ fn make_temp_dir(prefix : String) -> String {
 
 ///|
 fn remove_if_exists(path : String) -> Unit {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return
   }
   let is_file = @os_fs.is_file(path) catch { _ => false }
@@ -179,7 +179,7 @@ test "loader load_db_with_paths_with_fs resolves alias imports declared in index
   }
   let env = db.types(resolved)
   let diags = db.diagnostics(resolved)
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -303,7 +303,7 @@ test "loader load_db_with_paths_with_fs extracts vibe blocks from markdown entry
     None => fail("expected markdown source to be extracted")
   }
   let diags = db.import_diagnostics(resolved)
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -353,7 +353,7 @@ test "loader load_db_with_paths_with_fs loads wasm binary imports" {
   assert_true(imports[0].hash is Some(_))
   let _ = db.types(resolved)
   let diags = db.diagnostics(resolved)
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -411,7 +411,7 @@ test "loader load_db_with_paths keeps transitive import diagnostics clean" {
   }
   let (db, resolved, _) = loaded
   let entry_diags = db.import_diagnostics(resolved)
-  if not(entry_diags.is_empty()) {
+  if !entry_diags.is_empty() {
     let lines : Array[String] = []
     for diag in entry_diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -419,7 +419,7 @@ test "loader load_db_with_paths keeps transitive import diagnostics clean" {
     fail("unexpected entry import diagnostics: " + lines.join(","))
   }
   let lib_diags = db.import_diagnostics(@vibe_fs.normalize_path(lib))
-  if not(lib_diags.is_empty()) {
+  if !lib_diags.is_empty() {
     let lines : Array[String] = []
     for diag in lib_diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -946,7 +946,7 @@ test "loader load_db_with_paths: repo process index_import_test has callable run
   let env = db.types(resolved)
   let diags = db.diagnostics(resolved)
   let type_diags = diags.filter(fn(diag) { diag.stage == "type" })
-  if not(type_diags.is_empty()) {
+  if !type_diags.is_empty() {
     let lines : Array[String] = []
     for diag in type_diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -1011,7 +1011,7 @@ test "loader load_db_with_paths: repo url_test cross-directory import" {
   let import_errors = diags.filter(fn(diag) {
     diag.stage == "import" && diag.message.contains("missing:")
   })
-  if not(import_errors.is_empty()) {
+  if !import_errors.is_empty() {
     let lines : Array[String] = []
     for diag in import_errors {
       lines.push(diag.message)
@@ -1037,7 +1037,7 @@ test "loader load_db_with_paths: repo url/url_test cross-directory import" {
   let import_errors = diags.filter(fn(diag) {
     diag.stage == "import" && diag.message.contains("missing:")
   })
-  if not(import_errors.is_empty()) {
+  if !import_errors.is_empty() {
     let lines : Array[String] = []
     for diag in import_errors {
       lines.push(diag.message)
@@ -1064,7 +1064,7 @@ test "loader load_db_with_paths: repo scan_root_import_test cross-directory" {
   let import_errors = diags.filter(fn(diag) {
     diag.stage == "import" && diag.message.contains("missing:")
   })
-  if not(import_errors.is_empty()) {
+  if !import_errors.is_empty() {
     let lines : Array[String] = []
     for diag in import_errors {
       lines.push(diag.message)
@@ -1165,7 +1165,7 @@ test "loader cross-root import via transitive dependency" {
       assert_true(contains_path(paths, "/project/x/regexp/regexp.vibe"))
       // Verify import resolution is clean
       let diags = db.import_diagnostics(resolved)
-      if not(diags.is_empty()) {
+      if !diags.is_empty() {
         let lines : Array[String] = []
         for diag in diags {
           lines.push(diag.stage + ":" + diag.message)

--- a/src/lsp/handlers.mbt
+++ b/src/lsp/handlers.mbt
@@ -144,7 +144,7 @@ fn source_ident_at(source : String, offset : Int) -> String? {
   if anchor >= chars.length() {
     anchor = chars.length() - 1
   }
-  if not(is_ident_char(chars[anchor])) {
+  if !is_ident_char(chars[anchor]) {
     if anchor > 0 && is_ident_char(chars[anchor - 1]) {
       anchor -= 1
     } else {
@@ -208,7 +208,7 @@ pub fn completion_items_json(
   match symbol_index_for_source(uri, source) {
     Some(index) =>
       for entry in index.entries {
-        if prefix.length() > 0 && not(entry.name.has_prefix(prefix)) {
+        if prefix.length() > 0 && !entry.name.has_prefix(prefix) {
           continue
         }
         if seen.contains(entry.name) {
@@ -294,12 +294,12 @@ fn leading_ident(s : String) -> String? {
 ///|
 fn extract_unknown_trait_name(message : String) -> String? {
   let marker = "unknown trait: "
-  if not(message.contains(marker)) {
+  if !message.contains(marker) {
     return None
   }
   let mut tail = ""
   for part in message.split(marker) {
-    tail = part.to_string()
+    tail = part.to_owned()
   }
   leading_ident(tail)
 }
@@ -342,7 +342,7 @@ fn is_trait_imported(
         for item in spec.items {
           let trait_compatible = item.kind == @core.ImportKind::Value ||
             item.kind == @core.ImportKind::Trait
-          if not(trait_compatible) {
+          if !trait_compatible {
             continue
           }
           let local_name = match item.rename {
@@ -375,7 +375,7 @@ fn import_insert_line(source : String) -> Int {
   let mut has_import = false
   let mut line_index = 0
   for line_view in source.split("\n") {
-    let line = line_view.to_string().trim().to_string()
+    let line = line_view.to_owned().trim().to_owned()
     if line.has_prefix("import ") {
       has_import = true
       insert_line = line_index + 1

--- a/src/parser/lexer.mbt
+++ b/src/parser/lexer.mbt
@@ -328,7 +328,7 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
               }) {
           let _ = self.advance()
         }
-        let text = self.input[start:self.pos].to_string()
+        let text = self.input[start:self.pos].to_owned()
         return Token::new(whitespace(), text)
       }
       if c == '\n' {
@@ -419,7 +419,7 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
                   }) {
               let _ = self.advance()
             }
-            let text = self.input[start:self.pos].to_string()
+            let text = self.input[start:self.pos].to_owned()
             return Token::new(int_lit(), text)
           }
         }
@@ -470,7 +470,7 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
           }
           _ => ()
         }
-        let text = self.input[start:self.pos].to_string()
+        let text = self.input[start:self.pos].to_owned()
         if is_float {
           return Token::new(float_lit(), text)
         }
@@ -533,7 +533,7 @@ pub fn Lexer::next_token(self : Lexer) -> Token {
                     }) {
                 let _ = self.advance()
               }
-              let text = self.input[start:self.pos].to_string()
+              let text = self.input[start:self.pos].to_owned()
               Token::new(comment(), text)
             }
             _ => Token::new(slash(), "/")
@@ -771,7 +771,7 @@ fn Lexer::lex_ident(self : Lexer) -> String {
       None => break
     }
   }
-  self.input[start:self.pos].to_string()
+  self.input[start:self.pos].to_owned()
 }
 
 ///|

--- a/src/parser/parser_ast_expr.mbt
+++ b/src/parser/parser_ast_expr.mbt
@@ -2114,7 +2114,7 @@ fn AstParser::parse_call_or_primary(
         let span = self.span_from(start)
         @core.Expr::Ident(name=qualified_name, span~)
       }
-    } else if self.peek_kind() == lparen() && not(name_followed_by_newline) {
+    } else if self.peek_kind() == lparen() && !name_followed_by_newline {
       let _ = self.bump()
       let args = self.parse_args()
       let _ = self.expect(rparen(), ")")
@@ -2506,7 +2506,7 @@ fn AstParser::parse_primary(self : AstParser) -> @core.Expr raise ParseError {
         let last = text[len - 1]
         if last == 'f' || last == 'F' {
           is_float = true
-          raw = text[0:len - 1].to_string()
+          raw = text[0:len - 1].to_owned()
         }
       }
       let v = @string.parse_double(raw) catch {

--- a/src/parser/parser_ast_patterns.mbt
+++ b/src/parser/parser_ast_patterns.mbt
@@ -74,7 +74,7 @@ fn AstParser::parse_type_post_suffixes(
 ) -> @core.Type raise ParseError {
   let mut out = base_ty
   let mut done = false
-  while not(done) {
+  while !done {
     self.skip_trivia()
     let k = self.peek_kind()
     if k == lbracket() && self.peek_non_trivia_ahead(1) == rbracket() {
@@ -303,7 +303,7 @@ fn AstParser::parse_pattern(self : AstParser) -> @core.Pat raise ParseError {
         let last = text[len - 1]
         if last == 'f' || last == 'F' {
           is_float = true
-          raw = text[0:len - 1].to_string()
+          raw = text[0:len - 1].to_owned()
         }
       }
       let v = @string.parse_double(raw) catch {

--- a/src/parser/parser_ast_stmts.mbt
+++ b/src/parser/parser_ast_stmts.mbt
@@ -276,7 +276,7 @@ fn collect_type_param_names(
 ) -> Unit {
   match ty {
     @core.Type::Param(name) =>
-      if not(seen.contains(name)) {
+      if !seen.contains(name) {
         seen[name] = true
         out.push(name)
       }

--- a/src/parser/parser_cst.mbt
+++ b/src/parser/parser_cst.mbt
@@ -69,7 +69,7 @@ fn parse_error_unexpected_token_hint(
   expected : String,
   got : String,
 ) -> String? {
-  let got_trimmed = got.trim().to_string()
+  let got_trimmed = got.trim().to_owned()
   if got_trimmed == "," {
     match parse_error_separator_name(expected) {
       Some(separator_name) => {
@@ -112,7 +112,7 @@ pub fn ParseError::diagnostic(self : ParseError) -> @core.Diagnostic {
       let got_display = if got.is_empty() {
         "<eof>"
       } else {
-        let trimmed = got.trim().to_string()
+        let trimmed = got.trim().to_owned()
         if trimmed.is_empty() {
           "<whitespace>"
         } else {

--- a/src/profiler/profiler_test.mbt
+++ b/src/profiler/profiler_test.mbt
@@ -62,7 +62,7 @@ test "tsv format" {
   let report = @profiler.profiler_report_tsv()
   let lines : Array[String] = report
     .split("\n")
-    .map(fn(sv) { sv.to_string() })
+    .map(fn(sv) { sv.to_owned() })
     .collect()
   // header + outer + inner + trailing empty
   assert_true(lines.length() >= 3)

--- a/src/runtime/cache.mbt
+++ b/src/runtime/cache.mbt
@@ -61,7 +61,7 @@ pub fn PureCache::snapshot(self : PureCache) -> String {
 /// Load snapshot entries into the cache (invalid lines are ignored).
 pub fn PureCache::load(self : PureCache, snapshot : String) -> Unit {
   for line in snapshot.split("\n") {
-    let line_str = line.to_string()
+    let line_str = line.to_owned()
     if line_str.is_empty() {
       continue
     }
@@ -374,7 +374,7 @@ fn read_number(chars : Array[Char], start : Int) -> (Int, Int)? {
     saw = true
     i += 1
   }
-  if not(saw) {
+  if !saw {
     return None
   }
   Some((value, i))

--- a/src/runtime/compiler_hooks.mbt
+++ b/src/runtime/compiler_hooks.mbt
@@ -23,7 +23,7 @@ pub fn mark_compiler_hooks_initialized() -> Unit {
 
 ///|
 fn assert_hooks_initialized(caller : String) -> Unit {
-  if not(compiler_hooks_initialized.val) {
+  if !compiler_hooks_initialized.val {
     abort(
       caller +
       ": compiler hooks not initialized. Call runtime_compile.init_hooks() first.",

--- a/src/runtime/db.mbt
+++ b/src/runtime/db.mbt
@@ -104,7 +104,7 @@ fn collect_pat_bind_names(
 ) -> Unit {
   match pat {
     @core.Pat::Bind(name~, span~) =>
-      if name != "_" && not(out.contains(name)) {
+      if name != "_" && !out.contains(name) {
         out[name] = span
       }
     @core.Pat::Ctor(args~, ..) =>
@@ -137,7 +137,7 @@ fn collect_local_value_decl_spans(
 ) -> Map[String, @core.Span] {
   let out : Map[String, @core.Span] = {}
   let collect_name = fn(name : String, span : @core.Span) {
-    if name != "_" && not(out.contains(name)) {
+    if name != "_" && !out.contains(name) {
       out[name] = span
     }
   }

--- a/src/runtime/db_graph.mbt
+++ b/src/runtime/db_graph.mbt
@@ -65,7 +65,7 @@ fn render_import_cycle(cycle : Array[String]) -> String {
 
 ///|
 fn is_module_facade_path(path : String) -> Bool {
-  let basename = @path.Path(path).basename().to_string()
+  let basename = @path.Path(path).basename().to_owned()
   basename == "index.vibe" || basename == "index.xm"
 }
 
@@ -249,7 +249,7 @@ fn detect_module_cycle(
                         arr
                       }
                     }
-                    if not(array_has_string(edges, next_dir)) {
+                    if !array_has_string(edges, next_dir) {
                       edges.push(next_dir)
                     }
                   }

--- a/src/runtime/db_import.mbt
+++ b/src/runtime/db_import.mbt
@@ -31,9 +31,9 @@ fn normalize_lock_path(path : String) -> String {
 ///|
 fn strip_module_ext(path : String) -> String {
   if path.has_suffix(".vibe") && path.length() > 5 {
-    path[0:path.length() - 5].to_string()
+    path[0:path.length() - 5].to_owned()
   } else if path.has_suffix(".xm") && path.length() > 3 {
-    path[0:path.length() - 3].to_string()
+    path[0:path.length() - 3].to_owned()
   } else {
     path
   }
@@ -137,7 +137,7 @@ fn fallback_import_root_from_vibe_segment(base_dir : String) -> String? {
     if parent == dir {
       break
     }
-    let name = @path.Path(dir).basename().to_string()
+    let name = @path.Path(dir).basename().to_owned()
     if name == "vibe" {
       return Some(parent)
     }

--- a/src/runtime/db_query.mbt
+++ b/src/runtime/db_query.mbt
@@ -123,7 +123,7 @@ pub fn VibeDb::new() -> VibeDb {
               let alias_name = @core.import_alias_name(path)
               let candidates : Array[String] = []
               let push_candidate = fn(candidate : String) {
-                if not(array_has_string(candidates, candidate)) {
+                if !array_has_string(candidates, candidate) {
                   candidates.push(candidate)
                 }
               }
@@ -132,25 +132,25 @@ pub fn VibeDb::new() -> VibeDb {
                 Some(candidate) => push_candidate(candidate)
                 None => ()
               }
-              if not(path_obj.normalized.has_suffix(".vibe")) {
+              if !path_obj.normalized.has_suffix(".vibe") {
                 push_candidate(path_obj.normalized + ".vibe")
               }
-              if not(path_obj.normalized.has_suffix(".xm")) {
+              if !path_obj.normalized.has_suffix(".xm") {
                 push_candidate(path_obj.normalized + ".xm")
               }
               push_candidate(path)
-              if not(path.has_suffix(".vibe")) &&
-                not(path.has_suffix(".xm")) &&
-                not(path.has_suffix(".wasm")) &&
-                not(path.has_suffix(".db")) &&
-                not(path.has_suffix(".lock")) &&
-                not(path.has_suffix("/index.vibe")) {
+              if !path.has_suffix(".vibe") &&
+                !path.has_suffix(".xm") &&
+                !path.has_suffix(".wasm") &&
+                !path.has_suffix(".db") &&
+                !path.has_suffix(".lock") &&
+                !path.has_suffix("/index.vibe") {
                 push_candidate(path + "/index.vibe")
               }
-              if not(path.has_suffix(".vibe")) {
+              if !path.has_suffix(".vibe") {
                 push_candidate(path + ".vibe")
               }
-              if not(path.has_suffix(".xm")) {
+              if !path.has_suffix(".xm") {
                 push_candidate(path + ".xm")
               }
               let mut final_path = path_obj.normalized
@@ -178,7 +178,7 @@ pub fn VibeDb::new() -> VibeDb {
                 base_dir, path, final_path,
               )
               if is_reexport {
-                if not(path.has_prefix("./")) {
+                if !path.has_prefix("./") {
                   diags.push(rt, @core.Diagnostic::{
                     stage: "import",
                     message: "cross-package re-export is forbidden: " +
@@ -199,7 +199,7 @@ pub fn VibeDb::new() -> VibeDb {
               // index.vibe itself is exempt (it's the module facade)
               let importer_basename = @path.Path(file_path)
                 .basename()
-                .to_string()
+                .to_owned()
               if importer_basename != "index.vibe" &&
                 importer_basename != "index.xm" {
                 let importer_dir = @path.Path(file_path).dirname().to_string()
@@ -211,7 +211,7 @@ pub fn VibeDb::new() -> VibeDb {
                       resolved_path_obj.normalized,
                     )
                     .basename()
-                    .to_string()
+                    .to_owned()
                   if imported_basename != "index.vibe" &&
                     imported_basename != "index.xm" {
                     diags.push(rt, @core.Diagnostic::{
@@ -589,7 +589,7 @@ pub fn VibeDb::new() -> VibeDb {
                   let alias_name_str = "@" + name
                   let candidates : Array[String] = []
                   let push_candidate = fn(candidate : String) {
-                    if not(array_has_string(candidates, candidate)) {
+                    if !array_has_string(candidates, candidate) {
                       candidates.push(candidate)
                     }
                   }
@@ -598,24 +598,24 @@ pub fn VibeDb::new() -> VibeDb {
                     Some(candidate) => push_candidate(candidate)
                     None => ()
                   }
-                  if not(path_obj.normalized.has_suffix(".vibe")) {
+                  if !path_obj.normalized.has_suffix(".vibe") {
                     push_candidate(path_obj.normalized + ".vibe")
                   }
-                  if not(path_obj.normalized.has_suffix(".xm")) {
+                  if !path_obj.normalized.has_suffix(".xm") {
                     push_candidate(path_obj.normalized + ".xm")
                   }
                   push_candidate(path)
-                  if not(path.has_suffix(".vibe")) &&
-                    not(path.has_suffix(".xm")) &&
-                    not(path.has_suffix(".wasm")) &&
-                    not(path.has_suffix(".db")) &&
-                    not(path.has_suffix(".lock")) &&
-                    not(path.has_suffix(".vbundle")) &&
-                    not(path.has_suffix("/index.vibe")) {
+                  if !path.has_suffix(".vibe") &&
+                    !path.has_suffix(".xm") &&
+                    !path.has_suffix(".wasm") &&
+                    !path.has_suffix(".db") &&
+                    !path.has_suffix(".lock") &&
+                    !path.has_suffix(".vbundle") &&
+                    !path.has_suffix("/index.vibe") {
                     push_candidate(path + "/index.vibe")
                     push_candidate(path_obj.normalized + "/index.vibe")
                   }
-                  if not(path.has_suffix(".vibe")) {
+                  if !path.has_suffix(".vibe") {
                     push_candidate(path + ".vibe")
                   }
                   let mut final_path = path_obj.normalized
@@ -810,7 +810,7 @@ pub fn VibeDb::new() -> VibeDb {
     match sources.get(rt, path) {
       None => hook_new_type_env()
       Some(content) =>
-        if not(content.contains("import")) && not(content.contains("use")) {
+        if !content.contains("import") && !content.contains("use") {
           let hash = @core.content_address_hash_string(content)
           match no_import_type_query.fetch(rt, hash) {
             Some(env) => env
@@ -1311,7 +1311,7 @@ pub fn VibeDb::new() -> VibeDb {
                           continue
                         }
                         imported_any = true
-                        if not(import_symbol(item, exported_name, target_name)) {
+                        if !import_symbol(item, exported_name, target_name) {
                           report_kind_mismatch(item, exported_name)
                         }
                       }
@@ -1328,7 +1328,7 @@ pub fn VibeDb::new() -> VibeDb {
                         continue
                       }
                       let target_name = target_prefix + exported_name
-                      if not(import_item_accepts_value(item, target_name)) {
+                      if !import_item_accepts_value(item, target_name) {
                         continue
                       }
                       if explicit_targets.contains(target_name) {
@@ -1379,7 +1379,7 @@ pub fn VibeDb::new() -> VibeDb {
                   for item in spec.items {
                     let name = item.name
                     if item.kind == @core.ImportKind::Module {
-                      if not(supports_module_namespace_import(imp.path)) {
+                      if !supports_module_namespace_import(imp.path) {
                         diags.push(rt, @core.Diagnostic::{
                           stage: "import",
                           message: "module import is only supported for .xm source: " +
@@ -1409,14 +1409,12 @@ pub fn VibeDb::new() -> VibeDb {
                           )
                           let target_name = target_prefix + suffix
                           imported_any = true
-                          if not(
-                              import_symbol(item, exported_name, target_name),
-                            ) {
+                          if !import_symbol(item, exported_name, target_name) {
                             report_kind_mismatch(item, exported_name)
                           }
                         }
                       }
-                      if not(imported_any) {
+                      if !imported_any {
                         report_kind_mismatch(item, name)
                       }
                       continue
@@ -1426,7 +1424,7 @@ pub fn VibeDb::new() -> VibeDb {
                       None => name
                     }
                     if visible_names.contains(name) {
-                      if not(import_symbol(item, name, local_name)) {
+                      if !import_symbol(item, name, local_name) {
                         // Name is declared as exported in the dependency AST
                         // but absent from its type env — the dependency has
                         // type errors that made the export unavailable.
@@ -1458,7 +1456,7 @@ pub fn VibeDb::new() -> VibeDb {
                       let imported_any = import_namespace_members(
                         item, name, name,
                       )
-                      if not(imported_any) {
+                      if !imported_any {
                         if import_item_accepts_trait(item) &&
                           trait_names.contains(name) {
                           report_non_exported_trait(name)

--- a/src/runtime/db_type_import.mbt
+++ b/src/runtime/db_type_import.mbt
@@ -36,11 +36,11 @@ fn resolve_imported_trait_supertraits(
       Some(alias_name) => alias_name
       None => supertrait
     }
-    if not(array_has_string(out, local_super)) {
+    if !array_has_string(out, local_super) {
       out.push(local_super)
     }
   }
-  if local_name != source_name && not(array_has_string(out, source_name)) {
+  if local_name != source_name && !array_has_string(out, source_name) {
     // Preserve canonical source relation so renamed traits still satisfy
     // built-in canonical bounds like Eq/Ord.
     out.push(source_name)
@@ -98,7 +98,7 @@ fn collect_scheme_trait_bounds(scheme : @checker.TypeScheme) -> Array[String] {
   let out : Array[String] = []
   for _, bounds in scheme.trait_bounds {
     for bound in bounds {
-      if not(array_has_string(out, bound)) {
+      if !array_has_string(out, bound) {
         out.push(bound)
       }
     }
@@ -119,10 +119,10 @@ fn import_trait_dependency_for_scheme(
     return
   }
   visiting[source_trait_name] = true
-  if not(imported_env.has_trait(source_trait_name)) {
+  if !imported_env.has_trait(source_trait_name) {
     return
   }
-  if not(exported_names.contains(source_trait_name)) {
+  if !exported_names.contains(source_trait_name) {
     return
   }
   let local_trait_name = match trait_aliases.get(source_trait_name) {
@@ -400,7 +400,7 @@ fn collect_exported_names(ast : @core.Module) -> Map[String, Bool] {
       _ => ()
     }
   }
-  if not(has_late_exports) {
+  if !has_late_exports {
     return exports
   }
   // Second pass: handle export and re-export statements

--- a/src/runtime/db_wasm_introspection.mbt
+++ b/src/runtime/db_wasm_introspection.mbt
@@ -262,7 +262,7 @@ fn parse_wasm_exported_function_types(
               None => return Err("invalid wasm function import type")
             }
             imported_func_type_indices.push(type_idx)
-          } else if not(wasm_skip_import_desc(kind, section)) {
+          } else if !wasm_skip_import_desc(kind, section) {
             return Err("invalid wasm import descriptor")
           }
         }

--- a/src/runtime/db_wbtest.mbt
+++ b/src/runtime/db_wbtest.mbt
@@ -37,7 +37,7 @@ test "type query resolves extensionless directory import to index.vibe" {
   db.set_source("main", "import ./dep { value }\n" + "let x = value\n" + "x\n")
   let env = db.types("main")
   let diags = db.diagnostics("main")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -76,7 +76,7 @@ test "type query resolves cross-directory transitive dependency through sibling 
   )
   let env = db.types("/project/x/url_test.vibe")
   let diags = db.diagnostics("/project/x/url_test.vibe")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -127,7 +127,7 @@ test "type query keeps re-exported value return type through directory index" {
   )
   let index_env = db.types("/project/scan/index.vibe")
   let index_diags = db.diagnostics("/project/scan/index.vibe")
-  if not(index_diags.is_empty()) {
+  if !index_diags.is_empty() {
     let lines : Array[String] = []
     for diag in index_diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -144,7 +144,7 @@ test "type query keeps re-exported value return type through directory index" {
   }
   let env = db.types("/project/main.vibe")
   let diags = db.diagnostics("/project/main.vibe")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -263,7 +263,7 @@ test "type query root import exposes constructor-like helpers under namespace" {
   )
   let env = db.types("/project/main.vibe")
   let diags = db.diagnostics("/project/main.vibe")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -305,7 +305,7 @@ test "type query resolves nested relative re-export from dot-prefixed keys" {
   )
   let env = db.types("main")
   let diags = db.diagnostics("main")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -342,7 +342,7 @@ test "type query keeps no-import dependency exports for alias call" {
   )
   let env = db.types("main")
   let diags = db.diagnostics("main")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -373,7 +373,7 @@ test "type query resolves Bytes parameter in imported function" {
   )
   let env = db.types("main")
   let diags = db.diagnostics("main")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -409,7 +409,7 @@ test "type query imports transitive type deps from imported value schemes" {
   )
   let env = db.types("main")
   let diags = db.diagnostics("main")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -442,7 +442,7 @@ test "type query re-exported enum type imports constructors" {
   )
   let env = db.types("main")
   let diags = db.diagnostics("main")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -489,7 +489,7 @@ test "type query imports re-exported Process functions through index" {
   )
   let env = db.types("main")
   let diags = db.diagnostics("main")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -538,7 +538,7 @@ test "type query keeps exported schemes for thread runtime-style wrappers" {
   )
   let env = db.types("main")
   let diags = db.diagnostics("main")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)
@@ -631,7 +631,7 @@ test "internal export is importable from same directory" {
   )
   let env = db.types("/project/lib/main.vibe")
   let diags = db.diagnostics("/project/lib/main.vibe")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)

--- a/src/runtime/preprocess_posix.mbt
+++ b/src/runtime/preprocess_posix.mbt
@@ -6,11 +6,11 @@ pub fn preprocess_posix_source(script : String) -> String {
   let buf = StringBuilder::new()
   let mut first = true
   for line_view in script.split("\n") {
-    if not(first) {
+    if !first {
       buf.write_char('\n')
     }
     first = false
-    buf.write_string(preprocess_posix_line(line_view.to_string()))
+    buf.write_string(preprocess_posix_line(line_view.to_owned()))
   }
   buf.to_string()
 }
@@ -61,11 +61,9 @@ fn preprocess_posix_line_with_compat_note(line : String) -> (String, String?) {
     return (line, None)
   }
   let first_char = chars[ws_end]
-  if not(
-      (first_char >= 'a' && first_char <= 'z') ||
+  if !((first_char >= 'a' && first_char <= 'z') ||
       (first_char >= 'A' && first_char <= 'Z') ||
-      first_char == '_',
-    ) {
+      first_char == '_') {
     return (line, None)
   }
   // Extract first word
@@ -102,7 +100,7 @@ fn preprocess_posix_line_with_compat_note(line : String) -> (String, String?) {
     return (line, None)
   }
   // Check if first_word is a known vibe/shell command
-  let rest = chars_slice(chars, rest_start, len).trim().to_string()
+  let rest = chars_slice(chars, rest_start, len).trim().to_owned()
   let leading = chars_slice(chars, 0, ws_end)
   match convert_shell_builtin_command(first_word, rest) {
     Some(rewritten) =>
@@ -268,7 +266,7 @@ fn split_first_arg(s : String) -> (String, String)? {
     if i >= len {
       return None
     }
-    let second = chars_slice(chars, i, len).trim().to_string()
+    let second = chars_slice(chars, i, len).trim().to_owned()
     return Some((first, second))
   }
   // Unquoted first arg
@@ -285,7 +283,7 @@ fn split_first_arg(s : String) -> (String, String)? {
   if i >= len {
     return None
   }
-  let second = chars_slice(chars, i, len).trim().to_string()
+  let second = chars_slice(chars, i, len).trim().to_owned()
   Some((first, second))
 }
 
@@ -331,7 +329,7 @@ fn scan_brace_interp(chars : Array[Char], i : Int, len : Int) -> (String, Int)? 
   if depth != 0 {
     return None
   }
-  let expr = chars_slice(chars, start, j).trim().to_string()
+  let expr = chars_slice(chars, start, j).trim().to_owned()
   Some(("\\{" + expr + "}", j + 2))
 }
 
@@ -357,7 +355,7 @@ fn scan_cmd_subst(chars : Array[Char], i : Int, len : Int) -> (String, Int)? {
   if depth != 0 {
     return None
   }
-  let cmd = chars_slice(chars, start, j).trim().to_string()
+  let cmd = chars_slice(chars, start, j).trim().to_owned()
   let escaped = escape_posix_for_vibe_string(cmd)
   let s = "\\{{ match sh_lines(\"" +
     escaped +

--- a/src/runtime/store.mbt
+++ b/src/runtime/store.mbt
@@ -173,7 +173,7 @@ fn ThreadRuntime::spawn(
   mailbox : Int,
 ) -> Int? {
   let channel_key = thread_runtime_key(mailbox)
-  if not(self.channels.contains(channel_key)) {
+  if !self.channels.contains(channel_key) {
     None
   } else {
     let id = self.next_task_id
@@ -429,7 +429,7 @@ pub fn Runtime::gc(self : Runtime) -> Unit {
   }
   let to_delete : Array[String] = []
   for hash, _ in self.store.values {
-    if not(live.contains(hash)) {
+    if !live.contains(hash) {
       to_delete.push(hash)
     }
   }

--- a/src/runtime_compile/builtin_contract.mbt
+++ b/src/runtime_compile/builtin_contract.mbt
@@ -32,14 +32,14 @@ pub fn verify_builtin_contract(
   // Find declared but not covered
   let missing_handlers : Array[String] = []
   for name in checker_declared {
-    if not(covered.contains(name)) {
+    if !covered.contains(name) {
       missing_handlers.push(name)
     }
   }
   // Find covered but not declared (codegen only, not fallback)
   let undeclared_handlers : Array[String] = []
   for name in codegen_names {
-    if not(declared.contains(name)) {
+    if !declared.contains(name) {
       undeclared_handlers.push(name)
     }
   }

--- a/src/runtime_compile/bundle.mbt
+++ b/src/runtime_compile/bundle.mbt
@@ -145,7 +145,7 @@ fn append_prelude_core_linked_imports(
   for stmt in prelude_core_library_stmts() {
     match prelude_core_linked_import(stmt) {
       Some(li) =>
-        if not(existing_value_names.contains(li.func_name)) {
+        if !existing_value_names.contains(li.func_name) {
           existing_value_names[li.func_name] = true
           linked_imports.push(li)
         }
@@ -162,7 +162,7 @@ fn append_prelude_inline_stmts_for_linked_build(
   for stmt in prelude_linked_build_inline_stmts() {
     match bundle_stmt_value_name(stmt) {
       Some(name) =>
-        if not(existing_value_names.contains(name)) {
+        if !existing_value_names.contains(name) {
           bundled_stmts.push(stmt)
           existing_value_names[name] = true
         }
@@ -188,7 +188,7 @@ fn push_linked_import(
   existing_value_names : Map[String, Bool],
   li : LinkedImport,
 ) -> Unit {
-  if not(existing_value_names.contains(li.func_name)) {
+  if !existing_value_names.contains(li.func_name) {
     existing_value_names[li.func_name] = true
     linked_imports.push(li)
   }
@@ -233,7 +233,7 @@ fn collect_dependency_defs_selected(
   for imp in imports {
     collect_dependency_defs(db, imp.path, out, visited)
   }
-  if not(is_entry) {
+  if !is_entry {
     let dep_ast = db.ast_with_hash_imports(path)
     for stmt in dep_ast.stmts {
       match stmt {
@@ -242,23 +242,23 @@ fn collect_dependency_defs_selected(
             out.push(@core.Stmt::Let(rec~, name~, expr~, span~))
           }
         @core.Stmt::ExportEnumDef(name~, params~, ctors~, span~) =>
-          if not(emitted_types.contains(name)) {
+          if !emitted_types.contains(name) {
             out.push(@core.Stmt::EnumDef(name~, params~, ctors~, span~))
             emitted_types[name] = true
           }
         @core.Stmt::ExportTypeAlias(name~, params~, target~, span~) =>
-          if not(emitted_types.contains(name)) {
+          if !emitted_types.contains(name) {
             out.push(@core.Stmt::TypeAlias(name~, params~, target~, span~))
             emitted_types[name] = true
           }
         @core.Stmt::Let(..) => out.push(stmt)
         @core.Stmt::EnumDef(name~, ..) =>
-          if not(emitted_types.contains(name)) {
+          if !emitted_types.contains(name) {
             out.push(stmt)
             emitted_types[name] = true
           }
         @core.Stmt::TypeAlias(name~, ..) =>
-          if not(emitted_types.contains(name)) {
+          if !emitted_types.contains(name) {
             out.push(stmt)
             emitted_types[name] = true
           }
@@ -1074,7 +1074,7 @@ fn bundle_for_wasm_impl(
     for stmt in prelude_stmts {
       match bundle_stmt_value_name(stmt) {
         Some(name) =>
-          if not(existing_value_names.contains(name)) {
+          if !existing_value_names.contains(name) {
             bundled_stmts.push(stmt)
             existing_value_names[name] = true
           }
@@ -1193,7 +1193,7 @@ fn collect_dependency_defs(
   }
   // Then add definitions from this module (if it's an imported module)
   // Skip the entry module itself (it will be added separately)
-  if not(is_entry) {
+  if !is_entry {
     let dep_ast = db.ast_with_hash_imports(path)
     for stmt in dep_ast.stmts {
       match stmt {
@@ -1201,24 +1201,24 @@ fn collect_dependency_defs(
         @core.Stmt::ExportLet(rec~, name~, expr~, span~) =>
           out.push(@core.Stmt::Let(rec~, name~, expr~, span~))
         @core.Stmt::ExportEnumDef(name~, params~, ctors~, span~) =>
-          if not(emitted_types.contains(name)) {
+          if !emitted_types.contains(name) {
             out.push(@core.Stmt::EnumDef(name~, params~, ctors~, span~))
             emitted_types[name] = true
           }
         @core.Stmt::ExportTypeAlias(name~, params~, target~, span~) =>
-          if not(emitted_types.contains(name)) {
+          if !emitted_types.contains(name) {
             out.push(@core.Stmt::TypeAlias(name~, params~, target~, span~))
             emitted_types[name] = true
           }
         // Also include non-exported definitions that exported ones might depend on
         @core.Stmt::Let(..) => out.push(stmt)
         @core.Stmt::EnumDef(name~, ..) =>
-          if not(emitted_types.contains(name)) {
+          if !emitted_types.contains(name) {
             out.push(stmt)
             emitted_types[name] = true
           }
         @core.Stmt::TypeAlias(name~, ..) =>
-          if not(emitted_types.contains(name)) {
+          if !emitted_types.contains(name) {
             out.push(stmt)
             emitted_types[name] = true
           }
@@ -1264,7 +1264,7 @@ fn dedupe_bundle_structural_defs(
   for stmt in stmts {
     match bundle_stmt_type_name(stmt) {
       Some(name) =>
-        if not(seen_type_names.contains(name)) {
+        if !seen_type_names.contains(name) {
           out.push(stmt)
           seen_type_names[name] = true
         }
@@ -1391,12 +1391,12 @@ fn collect_reexport_defs(
           append_value_aliases(name, span)
         }
       @core.Stmt::ExportEnumDef(name~, params~, ctors~, span~) =>
-        if requested_items.contains(name) && not(emitted_types.contains(name)) {
+        if requested_items.contains(name) && !emitted_types.contains(name) {
           out.push(@core.Stmt::EnumDef(name~, params~, ctors~, span~))
           emitted_types[name] = true
         }
       @core.Stmt::ExportTypeAlias(name~, params~, target~, span~) =>
-        if requested_items.contains(name) && not(emitted_types.contains(name)) {
+        if requested_items.contains(name) && !emitted_types.contains(name) {
           out.push(@core.Stmt::TypeAlias(name~, params~, target~, span~))
           emitted_types[name] = true
         }
@@ -1406,22 +1406,22 @@ fn collect_reexport_defs(
           append_value_aliases(name, span)
         }
       @core.Stmt::EnumDef(name~, params~, ctors~, span~) =>
-        if requested_items.contains(name) && not(emitted_types.contains(name)) {
+        if requested_items.contains(name) && !emitted_types.contains(name) {
           out.push(@core.Stmt::EnumDef(name~, params~, ctors~, span~))
           emitted_types[name] = true
         }
       @core.Stmt::TypeAlias(name~, params~, target~, span~) =>
-        if requested_items.contains(name) && not(emitted_types.contains(name)) {
+        if requested_items.contains(name) && !emitted_types.contains(name) {
           out.push(@core.Stmt::TypeAlias(name~, params~, target~, span~))
           emitted_types[name] = true
         }
       @core.Stmt::ExportStructDef(name~, params~, fields~, span~) =>
-        if requested_items.contains(name) && not(emitted_types.contains(name)) {
+        if requested_items.contains(name) && !emitted_types.contains(name) {
           out.push(@core.Stmt::StructDef(name~, params~, fields~, span~))
           emitted_types[name] = true
         }
       @core.Stmt::StructDef(name~, params~, fields~, span~) =>
-        if requested_items.contains(name) && not(emitted_types.contains(name)) {
+        if requested_items.contains(name) && !emitted_types.contains(name) {
           out.push(@core.Stmt::StructDef(name~, params~, fields~, span~))
           emitted_types[name] = true
         }
@@ -1461,7 +1461,7 @@ fn demote_unused_let_mut(mod_ : @core.Module) -> @core.Module {
   for stmt in mod_.stmts {
     match stmt {
       @core.Stmt::LetMut(name~, expr~, span~) =>
-        if not(assigned.contains(name)) {
+        if !assigned.contains(name) {
           new_stmts.push(@core.Stmt::Let(rec=false, name~, expr~, span~))
           changed = true
         } else {

--- a/src/runtime_compile/compile.mbt
+++ b/src/runtime_compile/compile.mbt
@@ -1692,7 +1692,7 @@ fn scan_server_builtins_expr(
   match expr {
     @core.Expr::Call(name~, args~, ..) => {
       for n in names {
-        if name == n && not(found.contains(n)) {
+        if name == n && !found.contains(n) {
           found.push(n)
         }
       }

--- a/src/runtime_compile/hooks.mbt
+++ b/src/runtime_compile/hooks.mbt
@@ -50,7 +50,7 @@ pub fn init_hooks() -> Unit {
 ///|
 /// Ensure hooks are initialized. Called automatically by key entry points.
 fn ensure_hooks() -> Unit {
-  if not(hooks_initialized.val) {
+  if !hooks_initialized.val {
     init_hooks()
   }
 }

--- a/src/tests/fixture_test.mbt
+++ b/src/tests/fixture_test.mbt
@@ -51,8 +51,8 @@ fn split_fixture(source : String, path : String) -> (String, String) raise {
   let data_lines : Array[String] = []
   let mut in_data = false
   for line_view in source.split("\n") {
-    let line = line_view.to_string()
-    if line.trim().to_string() == "__DATA__" {
+    let line = line_view.to_owned()
+    if line.trim().to_owned() == "__DATA__" {
       in_data = true
       continue
     }
@@ -223,8 +223,8 @@ fn preload_module_sources(
   if normalized_path != module_path {
     db.set_source(normalized_path, source)
   }
-  if not(normalized_path.has_prefix("/")) &&
-    not(normalized_path.has_prefix("./")) {
+  if !normalized_path.has_prefix("/") &&
+    !normalized_path.has_prefix("./") {
     let dotted_path = "./" + normalized_path
     if dotted_path != module_path {
       db.set_source(dotted_path, source)
@@ -400,7 +400,7 @@ fn run_fixture(path : String) -> Unit raise {
     Err(err) =>
       match spec.error_contains {
         Some(expect) =>
-          if not(contains_ci(err.to_string(), expect)) {
+          if !contains_ci(err.to_string(), expect) {
             fail(
               "[\{path}] error mismatch: expected '\{expect}', got '\{err.to_string()}'",
             )

--- a/src/tests/vibe_db_integration_test.mbt
+++ b/src/tests/vibe_db_integration_test.mbt
@@ -393,7 +393,7 @@ test "vibe db path std module has no type diagnostics" {
   db.set_source("runtime.vibe", runtime_source)
   let env = db.types("path")
   let diags = db.diagnostics("path")
-  if not(diags.is_empty()) {
+  if !diags.is_empty() {
     let lines : Array[String] = []
     for diag in diags {
       lines.push(diag.stage + ":" + diag.message)

--- a/src/tests/vibe_wasm_gc_e2e_support_test.mbt
+++ b/src/tests/vibe_wasm_gc_e2e_support_test.mbt
@@ -50,7 +50,7 @@ pub fn gc_e2e_compile_and_run(
   let output = @os_fs.read_file_to_string(out_path) catch { _ => "" }
   let _ = try? @os_fs.remove_file(wasm_path)
   let _ = try? @os_fs.remove_file(out_path)
-  (exit_code, output.trim().to_string())
+  (exit_code, output.trim().to_owned())
 }
 
 ///|

--- a/src/tests/vibe_wasm_gc_fixture_test.mbt
+++ b/src/tests/vibe_wasm_gc_fixture_test.mbt
@@ -47,8 +47,8 @@ fn split_fixture_gc(source : String, path : String) -> (String, String) raise {
   let data_lines : Array[String] = []
   let mut in_data = false
   for line_view in source.split("\n") {
-    let line = line_view.to_string()
-    if line.trim().to_string() == "__DATA__" {
+    let line = line_view.to_owned()
+    if line.trim().to_owned() == "__DATA__" {
       in_data = true
       continue
     }

--- a/src/tests/vibe_wat_fixture_test.mbt
+++ b/src/tests/vibe_wat_fixture_test.mbt
@@ -17,9 +17,9 @@ fn join_lines_wat(lines : Array[String]) -> String {
 fn normalize_wat(text : String) -> String {
   let lines : Array[String] = []
   for line_view in text.split("\n") {
-    lines.push(line_view.trim_end().to_string())
+    lines.push(line_view.trim_end().to_owned())
   }
-  while lines.length() > 0 && lines[lines.length() - 1].trim().to_string() == "" {
+  while lines.length() > 0 && lines[lines.length() - 1].trim().to_owned() == "" {
     ignore(lines.pop())
   }
   join_lines_wat(lines)
@@ -53,7 +53,7 @@ fn replace_suffix(
   new_suffix : String,
 ) -> String {
   match path.strip_suffix(suffix) {
-    Some(view) => view.to_string() + new_suffix
+    Some(view) => view.to_owned() + new_suffix
     None => path
   }
 }
@@ -63,7 +63,7 @@ test "wasm wat fixtures" {
   let fixture_dir = "fixtures/wasm"
   let update_mode = match @sys.get_env_var("VIBE_WAT_FIXTURE_UPDATE") {
     Some(v) => {
-      let lowered = v.trim().to_string().to_lower()
+      let lowered = v.trim().to_owned().to_lower()
       lowered == "1" || lowered == "true" || lowered == "yes"
     }
     None => false

--- a/src/x/module_graph/advanced_graph_flatbuffers_codec.mbt
+++ b/src/x/module_graph/advanced_graph_flatbuffers_codec.mbt
@@ -340,7 +340,7 @@ fn fb_sorted_defs_for_delta(
         break
       }
     }
-    if not(inserted) {
+    if !inserted {
       out.push(def)
     }
   }
@@ -455,7 +455,7 @@ fn advanced_graph_index_from_flatbuffer_bytes(
   payload : Bytes,
 ) -> Result[AdvancedGraphIndex, String] {
   let bb = @flatbuffers.ByteBuffer::from_bytes(payload)
-  if not(bb.verify()) {
+  if !bb.verify() {
     return Err("index flatbuffer: invalid byte buffer")
   }
   let root = FbIndex::from_buffer(bb)
@@ -828,7 +828,7 @@ fn advanced_graph_delta_from_flatbuffer_bytes(
   payload : Bytes,
 ) -> Result[AdvancedGraphDelta, String] {
   let bb = @flatbuffers.ByteBuffer::from_bytes(payload)
-  if not(bb.verify()) {
+  if !bb.verify() {
     return Err("delta flatbuffer: invalid byte buffer")
   }
   let root = FbDelta::from_buffer(bb)

--- a/src/x/module_graph/advanced_graph_git_ref_native.mbt
+++ b/src/x/module_graph/advanced_graph_git_ref_native.mbt
@@ -42,13 +42,13 @@ fn ensure_dir_recursive(path : String) -> Result[Unit, String] {
 
 ///|
 fn normalize_ref_scope(scope : String) -> Result[String, String] {
-  let trimmed = scope.trim().to_string()
+  let trimmed = scope.trim().to_owned()
   if trimmed.length() == 0 {
     return Err("ref scope must not be empty")
   }
   let parts : Array[String] = []
   for part in trimmed.split("/") {
-    let text = part.to_string()
+    let text = part.to_owned()
     if text.length() == 0 || text == "." {
       continue
     }
@@ -111,7 +111,7 @@ fn read_ref_hash(path : String) -> Result[String, String] {
   let content = @os_fs.read_file_to_string(path) catch {
     e => return Err("read ref `" + path + "`: " + e.to_string())
   }
-  let hash = content.trim().to_string()
+  let hash = content.trim().to_owned()
   if hash.length() == 0 {
     return Err("ref `" + path + "` is empty")
   }
@@ -145,7 +145,7 @@ fn load_git_blob_bytes(
   hash : String,
 ) -> Result[Bytes, String] {
   let objects_dir = git_dir + "/objects"
-  if not(@os_fs.path_exists(objects_dir)) {
+  if !@os_fs.path_exists(objects_dir) {
     return Err("git objects dir not found: " + objects_dir)
   }
   let fs = @osfs.OsFs::new()
@@ -242,7 +242,7 @@ pub fn write_advanced_graph_delta_to_git_ref(
 
 ///|
 fn try_read_ref_hash(path : String) -> Result[String?, String] {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return Ok(None)
   }
   match read_ref_hash(path) {
@@ -253,7 +253,7 @@ fn try_read_ref_hash(path : String) -> Result[String?, String] {
 
 ///|
 fn validate_hex_hash(hash : String, field : String) -> Result[String, String] {
-  let normalized = hash.trim().to_string()
+  let normalized = hash.trim().to_owned()
   if normalized.length() == 0 {
     return Err(field + " must not be empty")
   }

--- a/src/x/module_graph/advanced_graph_git_ref_native_test.mbt
+++ b/src/x/module_graph/advanced_graph_git_ref_native_test.mbt
@@ -15,14 +15,14 @@ fn build_git_ref_test_graph_index(
 
 ///|
 fn ensure_dir_if_missing(path : String) -> Unit {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     let _ = @os_fs.create_dir(path) catch { _ => () }
   }
 }
 
 ///|
 fn remove_if_exists(path : String) -> Unit {
-  if not(@os_fs.path_exists(path)) {
+  if !@os_fs.path_exists(path) {
     return
   }
   let is_file = @os_fs.is_file(path) catch { _ => false }

--- a/src/x/module_graph/advanced_graph_poc.mbt
+++ b/src/x/module_graph/advanced_graph_poc.mbt
@@ -506,7 +506,7 @@ pub fn AdvancedGraphIndex::query_symbol(
     if name == key {
       continue
     }
-    if lang_prefix.length() > 0 && not(name.has_prefix(lang_prefix)) {
+    if lang_prefix.length() > 0 && !name.has_prefix(lang_prefix) {
       continue
     }
     if name.contains(query) {
@@ -545,7 +545,7 @@ pub fn AdvancedGraphIndex::query_type(
     if sig == key {
       continue
     }
-    if lang_prefix.length() > 0 && not(sig.has_prefix(lang_prefix)) {
+    if lang_prefix.length() > 0 && !sig.has_prefix(lang_prefix) {
       continue
     }
     if sig.contains(query) {
@@ -561,14 +561,14 @@ pub fn AdvancedGraphIndex::verify(self : AdvancedGraphIndex) -> Array[String] {
   let issues : Array[String] = []
   for symbol, ids in self.symbol_index {
     for def_id in ids {
-      if not(self.defs.contains(def_id)) {
+      if !self.defs.contains(def_id) {
         issues.push("symbol index missing def: " + symbol + " -> " + def_id)
       }
     }
   }
   for sig, ids in self.type_index {
     for def_id in ids {
-      if not(self.defs.contains(def_id)) {
+      if !self.defs.contains(def_id) {
         issues.push("type index missing def: " + sig + " -> " + def_id)
       }
     }
@@ -586,7 +586,7 @@ pub fn AdvancedGraphIndex::verify(self : AdvancedGraphIndex) -> Array[String] {
         }
       None => ()
     }
-    if not(has_symbol_link) {
+    if !has_symbol_link {
       issues.push(
         "def missing symbol link: " + def_id + " (" + symbol_key + ")",
       )
@@ -603,7 +603,7 @@ pub fn AdvancedGraphIndex::verify(self : AdvancedGraphIndex) -> Array[String] {
         }
       None => ()
     }
-    if not(has_type_link) {
+    if !has_type_link {
       issues.push("def missing type link: " + def_id + " (" + type_key + ")")
     }
   }
@@ -657,7 +657,7 @@ fn remote_query_from_hits(
   let requested_module_hashes = sorted_unique_strings(requested_hashes)
   let missing_module_hashes : Array[String] = []
   for hash in requested_module_hashes {
-    if not(local_hashes.contains(hash)) {
+    if !local_hashes.contains(hash) {
       missing_module_hashes.push(hash)
     }
   }
@@ -753,7 +753,7 @@ pub fn advanced_graph_diff(
   let removed_def_ids : Array[String] = []
   let upsert_defs : Array[AdvancedGraphDef] = []
   for def_id, _ in base.defs {
-    if not(target.defs.contains(def_id)) {
+    if !target.defs.contains(def_id) {
       removed_def_ids.push(def_id)
     }
   }
@@ -782,7 +782,7 @@ pub fn advanced_graph_diff(
     }
   }
   for key, _ in base.symbol_index {
-    if not(target.symbol_index.contains(key)) {
+    if !target.symbol_index.contains(key) {
       symbol_removes.push(key)
     }
   }
@@ -802,7 +802,7 @@ pub fn advanced_graph_diff(
     }
   }
   for key, _ in base.type_index {
-    if not(target.type_index.contains(key)) {
+    if !target.type_index.contains(key) {
       type_removes.push(key)
     }
   }
@@ -847,7 +847,7 @@ pub fn apply_advanced_graph_delta(
     type_index[key] = ids
   }
   let mut next_manifest = delta.target_manifest
-  if not(advanced_graph_manifest_equal(delta.base_manifest, base.manifest)) {
+  if !advanced_graph_manifest_equal(delta.base_manifest, base.manifest) {
     next_manifest = AdvancedGraphManifest::{
       schema_version: base.manifest.schema_version,
       base_commit: base.manifest.base_commit,
@@ -1524,7 +1524,7 @@ fn parse_advanced_graph_wal_record(
     Json::Object(obj) => obj
     _ => return Err(context + ": record must be object")
   }
-  if not(root.contains("record_kind")) {
+  if !root.contains("record_kind") {
     return match advanced_graph_delta_from_json(record) {
       Ok(delta) => Ok(delta)
       Err(err) => Err(context + ": " + err)
@@ -1560,7 +1560,7 @@ fn parse_advanced_graph_wal_record(
 
 ///|
 fn read_advanced_graph_wal_content(wal_path : String) -> Result[String, String] {
-  if not(@os_fs.path_exists(wal_path)) {
+  if !@os_fs.path_exists(wal_path) {
     return Ok("")
   }
   let content = @os_fs.read_file_to_string(wal_path) catch {
@@ -1577,7 +1577,7 @@ fn parse_advanced_graph_wal_records(
   let mut line_no = 0
   for line_view in content.split("\n") {
     line_no += 1
-    let line = line_view.to_string().trim().to_string()
+    let line = line_view.to_owned().trim().to_owned()
     if line.length() == 0 {
       continue
     }
@@ -1611,7 +1611,7 @@ pub fn append_advanced_graph_deltas_jsonl(
   let buf = StringBuilder::new()
   if content.length() > 0 {
     buf.write_string(content)
-    if not(content.has_suffix("\n")) {
+    if !content.has_suffix("\n") {
       buf.write_char('\n')
     }
   }
@@ -1665,7 +1665,7 @@ pub fn advanced_graph_wal_stats(
   }
   let mut count = 0
   for line_view in content.split("\n") {
-    let line = line_view.to_string().trim().to_string()
+    let line = line_view.to_owned().trim().to_owned()
     if line.length() > 0 {
       count += 1
     }
@@ -1691,12 +1691,10 @@ pub fn replay_advanced_graph_delta_jsonl(
   }
   let mut state = base
   for record in records {
-    if not(
-        advanced_graph_manifest_equal(
+    if !advanced_graph_manifest_equal(
           record.delta.base_manifest,
           state.manifest,
-        ),
-      ) {
+        ) {
       return Err(
         "wal line " + record.line_no.to_string() + ": base manifest mismatch",
       )

--- a/src/x/module_graph/extractor_python.mbt
+++ b/src/x/module_graph/extractor_python.mbt
@@ -10,16 +10,16 @@ pub fn extract_python_graph_ir_rows(
   let lines = source.split("\n")
   let mut offset = 0
   for line_view in lines {
-    let line = line_view.to_string()
+    let line = line_view.to_owned()
     let line_start = offset
     let line_end = offset + line.length()
     // Only process lines at indent level 0 (no leading whitespace)
-    if line.length() > 0 && not(py_is_whitespace_char(line, 0)) {
+    if line.length() > 0 && !py_is_whitespace_char(line, 0) {
       let trimmed = line
       // Skip comments, blank, imports
-      if not(trimmed.has_prefix("#")) &&
-        not(trimmed.has_prefix("import ")) &&
-        not(trimmed.has_prefix("from ")) {
+      if !trimmed.has_prefix("#") &&
+        !trimmed.has_prefix("import ") &&
+        !trimmed.has_prefix("from ") {
         match py_try_extract_declaration(trimmed) {
           Some((kind, name, signature)) =>
             rows.push(GraphIrRow::{

--- a/src/x/module_graph/extractor_typescript.mbt
+++ b/src/x/module_graph/extractor_typescript.mbt
@@ -16,16 +16,16 @@ pub fn extract_typescript_graph_ir_rows(
   let lines = source.split("\n")
   let mut offset = 0
   for line_view in lines {
-    let line = line_view.to_string()
+    let line = line_view.to_owned()
     let trimmed = ts_trim_start(line)
     let line_start = offset
     let line_end = offset + line.length()
     // Skip empty lines, comments, imports
     if trimmed.length() > 0 &&
-      not(trimmed.has_prefix("//")) &&
-      not(trimmed.has_prefix("/*")) &&
-      not(trimmed.has_prefix("*")) &&
-      not(trimmed.has_prefix("import ")) {
+      !trimmed.has_prefix("//") &&
+      !trimmed.has_prefix("/*") &&
+      !trimmed.has_prefix("*") &&
+      !trimmed.has_prefix("import ") {
       // Strip leading export/declare/async/default keywords
       let stripped = ts_strip_modifiers(trimmed)
       match ts_try_extract_declaration(stripped) {

--- a/src/x/module_graph/multilang_symbol_index.mbt
+++ b/src/x/module_graph/multilang_symbol_index.mbt
@@ -161,7 +161,7 @@ fn ml_extract_type_terms_from_signature(signature : String) -> Array[String] {
   let normalized = ml_replace_all_delimiters(signature)
   let terms : Array[String] = []
   for part_view in normalized.split(" ") {
-    let token = part_view.to_string()
+    let token = part_view.to_owned()
     if token.length() == 0 {
       continue
     }
@@ -489,7 +489,7 @@ pub fn MultiLangSymbolIndex::query_symbol(
       Some(def) =>
         if (language_id.length() == 0 || def.language_id == language_id) &&
           def.name.contains(query) {
-          if not(seen.contains(def_id)) {
+          if !seen.contains(def_id) {
             seen[def_id] = true
             out.push(def)
           }
@@ -537,7 +537,7 @@ pub fn MultiLangSymbolIndex::query_type(
       Some(def) =>
         if language_id.length() == 0 || def.language_id == language_id {
           if def.signature.contains(query) {
-            if not(seen.contains(def_id)) {
+            if !seen.contains(def_id) {
               seen[def_id] = true
               out.push(def)
               continue
@@ -545,7 +545,7 @@ pub fn MultiLangSymbolIndex::query_type(
           }
           for term in def.type_terms {
             if term.contains(query) {
-              if not(seen.contains(def_id)) {
+              if !seen.contains(def_id) {
                 seen[def_id] = true
                 out.push(def)
               }
@@ -566,14 +566,14 @@ pub fn MultiLangSymbolIndex::verify(
   let issues : Array[String] = []
   for key, ids in self.symbol_index {
     for def_id in ids {
-      if not(self.defs.contains(def_id)) {
+      if !self.defs.contains(def_id) {
         issues.push("symbol index missing def: " + key + " -> " + def_id)
       }
     }
   }
   for key, ids in self.type_index {
     for def_id in ids {
-      if not(self.defs.contains(def_id)) {
+      if !self.defs.contains(def_id) {
         issues.push("type index missing def: " + key + " -> " + def_id)
       }
     }


### PR DESCRIPTION
## Summary

Mechanical migration off two long-standing stdlib deprecations, driven off `moon check --output-json` so each rewrite uses the exact source span the toolchain flagged rather than a regex guess.

**`moon check --target native --release`: 1402 → 254 warnings (-1148), 0 errors.**

## Two patterns

### `not(...)` → `!...` (844 sites)

- bare `!ident` / `!foo.bar()` / `!Mod::call(args)` when the inner has no top-level binary operator or `is`/`as`/`in`/`catch` keyword.
- `!(...)` otherwise, to preserve grouping. Concrete examples in this PR that needed the wrapped form:
  - `!(x catch { _ => false })`
  - `!(a && b)`
  - `!(opt is Some(_))`
- Multi-line `not(\n  expr,\n)` arglists get the trailing comma stripped and collapse to one line.

### `view.to_string()` → `view.to_owned()` (308 sites)

The `StringView::to_string` deprecation explicitly recommends `.to_owned()` for "allocate an owned String". `.to_string()` stays reserved for `Show` rendering. 3 sites skipped because the warning span text wasn't `to_string` (probably already migrated).

## How

`scripts`-free Python one-shot (not committed) parses `--output-json` diagnostic lines, groups by file, sorts rewrites bottom-to-top so positions don't drift, then walks balanced parens (including across lines, inside strings, and around nested method chains) for each `not(...)` rewrite.

The earlier sed-based attempt this session broke multi-line cases at `runtime_compile/compile.mbt` and was reverted; this rewrite handles those cleanly. Cases that an unaware sed would mangle and that all parse here:

- `if !@os_fs.is_file(path) catch { _ => false } { ... }` → wrapped
- `if not(\n    type_equal(env, resolved, …),\n) {` → trailing comma dropped, collapsed

## Verification

| target | result |
|---|---|
| `moon check --target native --release` | **1402 → 254 warnings**, 0 errors |
| `mizchi/vibe/checker` | 160/160 |
| `mizchi/vibe/frontend` | 83/83 |
| `mizchi/vibe/runtime` | 49/49 |
| `mizchi/vibe/codegen` | 74/74 |
| `mizchi/vibe/cmd/vibe -f 'session*'` | 10/10 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7y6q8Df9KiLNTK77zR65T)_