### PR TITLE
warnings: assert_eq → @debug.assert_eq + import hygiene (-123 warnings)

### DIFF
--- a/src/checker/builtin_table_decoder_wbtest.mbt
+++ b/src/checker/builtin_table_decoder_wbtest.mbt
@@ -71,7 +71,7 @@ test "decode_builtin_table: single entry String::length" {
     Some(entries) => {
       assert_eq(entries.length(), 1)
       assert_eq(entries[0].name, "String::length")
-      assert_eq(entries[0].params, [BuiltinTypeId::BTString])
+      @debug.assert_eq(entries[0].params, [BuiltinTypeId::BTString])
       assert_eq(entries[0].ret, BuiltinTypeId::BTInt)
       assert_eq(entries[0].flags, 0)
     }
@@ -143,7 +143,7 @@ test "decode_builtin_table: multiple entries" {
       assert_eq(entries[0].params.length(), 0)
       assert_eq(entries[0].ret, BuiltinTypeId::BTString)
       assert_eq(entries[1].name, "Bytes::length")
-      assert_eq(entries[1].params, [BuiltinTypeId::BTBytes])
+      @debug.assert_eq(entries[1].params, [BuiltinTypeId::BTBytes])
       assert_eq(entries[1].ret, BuiltinTypeId::BTInt)
     }
     None => fail("expected Some")

--- a/src/checker/moon.pkg
+++ b/src/checker/moon.pkg
@@ -4,6 +4,7 @@ import {
   "mizchi/vibe/parser" @parser,
   "mizchi/vibe/profiler" @profiler,
   "moonbitlang/core/ref" @ref,
+  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/fs" @os_fs,
   "mizchi/vibe/x/scoped_map" @scoped_map,
 }

--- a/src/checker/subtype_wbtest.mbt
+++ b/src/checker/subtype_wbtest.mbt
@@ -187,7 +187,7 @@ test "fn metadata version reflects generic parameter bound changes" {
     #|export let f = [T: Eq](x: T) -> Bool { x == x }
   let base_ast = parse_module(base_script)
   let env1 = type_check_with_env(env, base_ast, {})
-  assert_eq(
+  @debug.assert_eq(
     env1.get_fn_version("f"),
     Some(ApiSemver::{ major: 1, minor: 0, patch: 0 }),
   )
@@ -195,7 +195,7 @@ test "fn metadata version reflects generic parameter bound changes" {
     "export let f = [T: Eq + Show](x: T) -> Bool { x == x }",
   )
   let env2 = type_check_with_env(env1, tighten_ast, {})
-  assert_eq(
+  @debug.assert_eq(
     env2.get_fn_version("f"),
     Some(ApiSemver::{ major: 2, minor: 0, patch: 0 }),
   )
@@ -203,7 +203,7 @@ test "fn metadata version reflects generic parameter bound changes" {
     "export let f = [T: Eq](x: T) -> Bool { x == x }",
   )
   let env3 = type_check_with_env(env2, loosen_ast, {})
-  assert_eq(
+  @debug.assert_eq(
     env3.get_fn_version("f"),
     Some(ApiSemver::{ major: 2, minor: 1, patch: 0 }),
   )
@@ -216,19 +216,19 @@ test "fn metadata version auto bump" {
     #|export let f = (x: Int) -> Int { x }
   let base_ast = parse_module(base_script)
   let env1 = type_check_with_env(env, base_ast, {})
-  assert_eq(
+  @debug.assert_eq(
     env1.get_fn_version("f"),
     Some(ApiSemver::{ major: 1, minor: 0, patch: 0 }),
   )
   let patch_ast = parse_module("export let f = (x: Int) -> Int { x }")
   let env2 = type_check_with_env(env1, patch_ast, {})
-  assert_eq(
+  @debug.assert_eq(
     env2.get_fn_version("f"),
     Some(ApiSemver::{ major: 1, minor: 0, patch: 1 }),
   )
   let major_ast = parse_module("export let f = (x: Int) -> String { \"x\" }")
   let env3 = type_check_with_env(env2, major_ast, {})
-  assert_eq(
+  @debug.assert_eq(
     env3.get_fn_version("f"),
     Some(ApiSemver::{ major: 2, minor: 0, patch: 0 }),
   )
@@ -239,10 +239,10 @@ test "fn metadata version is not tracked for non-exported function" {
   let env = TypeEnv::new()
   let base_ast = parse_module("let f = (x: Int) -> Int { x }")
   let env1 = type_check_with_env(env, base_ast, {})
-  assert_eq(env1.get_fn_version("f"), None)
+  @debug.assert_eq(env1.get_fn_version("f"), None)
   let next_ast = parse_module("let f = (x: Int) -> String { \"x\" }")
   let env2 = type_check_with_env(env1, next_ast, {})
-  assert_eq(env2.get_fn_version("f"), None)
+  @debug.assert_eq(env2.get_fn_version("f"), None)
 }
 
 ///|

--- a/src/checker/trait_graph_wbtest.mbt
+++ b/src/checker/trait_graph_wbtest.mbt
@@ -60,7 +60,7 @@ test "TraitGraph::supertraits returns one-hop parents only" {
   env.set_trait_info("C", TraitDefInfo::defined_here(["B"], false))
   let g = TraitGraph::of(env)
   let parents = g.supertraits("C")
-  assert_eq(parents, ["B"])
+  @debug.assert_eq(parents, ["B"])
 }
 
 ///|
@@ -153,7 +153,7 @@ test "TraitGraph::import_def rolls back if it would close a cycle" {
   let installed = g.import_def("A", TraitDefInfo::defined_here([], true), ["B"])
   assert_false(installed)
   // After rollback, A should retain its empty supertrait list.
-  assert_eq(g.supertraits("A"), [])
+  @debug.assert_eq(g.supertraits("A"), [])
   assert_false(g.has_cycle("A"))
 }
 
@@ -186,7 +186,7 @@ test "TraitGraph::cycle_chain returns the offending trait sequence" {
   match g.cycle_chain("A") {
     Some(chain) =>
       // Walk order starts at A, hits B, closes back at A.
-      assert_eq(chain, ["A", "B", "A"])
+      @debug.assert_eq(chain, ["A", "B", "A"])
     None => fail("expected cycle_chain to detect A -> B -> A")
   }
 }

--- a/src/checker/typecheck_call_builtin_wbtest.mbt
+++ b/src/checker/typecheck_call_builtin_wbtest.mbt
@@ -331,7 +331,7 @@ test "type_call_builtin: Http::listen requires Net effect" {
     Ok(_) => fail("expected effect guard error")
     Err(TypeError::EffectGuardNotSatisfied(operation~, missing_effect~, ..)) => {
       assert_eq(operation, "Http::listen")
-      assert_eq(missing_effect, Some("Http"))
+      @debug.assert_eq(missing_effect, Some("Http"))
     }
     Err(other) => fail("unexpected error: \{other.to_string()}")
   }
@@ -405,7 +405,7 @@ test "type_call_builtin: Threads::spawn requires Threads effect" {
     Ok(_) => fail("expected effect guard error")
     Err(TypeError::EffectGuardNotSatisfied(operation~, missing_effect~, ..)) => {
       assert_eq(operation, "Threads::spawn")
-      assert_eq(missing_effect, Some("Threads"))
+      @debug.assert_eq(missing_effect, Some("Threads"))
     }
     Err(other) => fail("unexpected error: \{other.to_string()}")
   }

--- a/src/checker/typecheck_env_namespace_wbtest.mbt
+++ b/src/checker/typecheck_env_namespace_wbtest.mbt
@@ -1,9 +1,9 @@
 ///|
 test "TypeEnv::namespace_root resolves primitive and named roots" {
   let env = TypeEnv::new()
-  assert_eq(env.namespace_root(@core.Type::Int), Some("Int"))
-  assert_eq(env.namespace_root(@core.Type::String), Some("String"))
-  assert_eq(
+  @debug.assert_eq(env.namespace_root(@core.Type::Int), Some("Int"))
+  @debug.assert_eq(env.namespace_root(@core.Type::String), Some("String"))
+  @debug.assert_eq(
     env.namespace_root(@core.Type::Named(name="User", args=[])),
     Some("User"),
   )
@@ -13,9 +13,9 @@ test "TypeEnv::namespace_root resolves primitive and named roots" {
 test "TypeEnv::namespace_root returns None for unsupported shapes" {
   let env = TypeEnv::new()
   let unit_root = env.namespace_root(@core.Type::Unit)
-  assert_eq(unit_root, None)
+  @debug.assert_eq(unit_root, None)
   let variant_fields : Map[String, @core.Type] = {}
   variant_fields["Ctor"] = @core.Type::Int
   let variant_root = env.namespace_root(@core.Type::Variant(variant_fields))
-  assert_eq(variant_root, None)
+  @debug.assert_eq(variant_root, None)
 }

--- a/src/checker/typecheck_env_traits_wbtest.mbt
+++ b/src/checker/typecheck_env_traits_wbtest.mbt
@@ -2,17 +2,17 @@
 test "TraitDefInfo constructors preserve ownership and hierarchy" {
   let imported = TraitDefInfo::imported(["Eq", "Hash"], true)
   assert_true(imported.origin == TraitOrigin::Imported)
-  assert_eq(imported.supertraits, ["Eq", "Hash"])
+  @debug.assert_eq(imported.supertraits, ["Eq", "Hash"])
   assert_true(imported.open_impl)
 
   let defined_here = TraitDefInfo::defined_here(["Eq"], false)
   assert_true(defined_here.origin == TraitOrigin::DefinedHere)
-  assert_eq(defined_here.supertraits, ["Eq"])
+  @debug.assert_eq(defined_here.supertraits, ["Eq"])
   assert_false(defined_here.open_impl)
 
   let seeded = TraitDefInfo::prelude_seeded()
   assert_true(seeded.origin == TraitOrigin::PreludeSeed)
-  assert_eq(seeded.supertraits, [])
+  @debug.assert_eq(seeded.supertraits, [])
   assert_false(seeded.open_impl)
 }
 

--- a/src/cmd/vibe/builtin_table_encoder_wbtest.mbt
+++ b/src/cmd/vibe/builtin_table_encoder_wbtest.mbt
@@ -89,7 +89,7 @@ test "parse_declare_line: simple builtin" {
   match parse_declare_line("declare String::length(String) -> Int") {
     Some(d) => {
       assert_eq(d.name, "String::length")
-      assert_eq(d.params, [BuiltinTypeTag::String_])
+      @debug.assert_eq(d.params, [BuiltinTypeTag::String_])
       assert_eq(d.ret, BuiltinTypeTag::Int_)
     }
     None => fail("expected Some")

--- a/src/cmd/vibe/cli_closure_payload_wbtest.mbt
+++ b/src/cmd/vibe/cli_closure_payload_wbtest.mbt
@@ -95,7 +95,7 @@ test "build_closure_payload_with_fs serializes entry and imported sources" {
     Err(err) => fail(err)
   }
   let parts = split_payload_parts(payload)
-  assert_eq(parts, [
+  @debug.assert_eq(parts, [
     "/workspace/main.vibe", main_source, "/workspace/lib.vibe", lib_source,
   ])
 }
@@ -116,7 +116,7 @@ test "emit_closure_payload_file writes payload to output" {
     Err(err) => fail(err)
   }
   let parts = split_payload_parts(payload)
-  assert_eq(parts, ["/workspace/main.vibe", "let answer = () -> Int { 42 }\n"])
+  @debug.assert_eq(parts, ["/workspace/main.vibe", "let answer = () -> Int { 42 }\n"])
 }
 
 ///|

--- a/src/cmd/vibe/cli_e2e_wbtest.mbt
+++ b/src/cmd/vibe/cli_e2e_wbtest.mbt
@@ -186,7 +186,7 @@ test "shell vibe parser extracts subcommand args and pipeline" {
   match repl_parse_vibe_shell_invocation("vibe view inc |> Json::get(\"ok\")") {
     Some(invocation) => {
       assert_eq(invocation.subcommand, "view")
-      assert_eq(invocation.args, ["inc"])
+      @debug.assert_eq(invocation.args, ["inc"])
       match invocation.pipeline_tail {
         Some(tail) => assert_eq(tail, "Json::get(\"ok\")")
         None => fail("expected pipeline tail")
@@ -202,7 +202,7 @@ test "shell vibe parser accepts bare subcommand" {
     Some(invocation) => {
       assert_eq(invocation.subcommand, "symbols")
       assert_eq(invocation.args.length(), 0)
-      assert_eq(invocation.pipeline_tail, None)
+      @debug.assert_eq(invocation.pipeline_tail, None)
     }
     None => fail("expected bare vibe shell invocation")
   }
@@ -639,7 +639,7 @@ test "compiled repl line preserves function bindings across lines" {
     Err(err) => fail("function binding line failed: " + err)
   }
   assert_eq(fn_binding.value, WasmRunValue::Int(0L))
-  assert_eq(fn_binding.display_override, Some("<fn add_x>"))
+  @debug.assert_eq(fn_binding.display_override, Some("<fn add_x>"))
   let result = match
     run_compiled_repl_line_with_cache(
       cache,
@@ -692,7 +692,7 @@ test "compiled repl line preserves function alias bindings across lines" {
     Err(err) => fail("alias binding line failed: " + err)
   }
   assert_eq(alias_binding.value, WasmRunValue::Int(0L))
-  assert_eq(alias_binding.display_override, Some("<bound alias>"))
+  @debug.assert_eq(alias_binding.display_override, Some("<bound alias>"))
   let result = match
     run_compiled_repl_line_with_cache(
       cache,
@@ -727,7 +727,7 @@ test "compiled repl line renders string literal" {
     Err(err) => fail("compiled repl string literal failed: " + err)
   }
   assert_eq(result.value, WasmRunValue::Int(0L))
-  assert_eq(result.display_override, Some("\"hi\""))
+  @debug.assert_eq(result.display_override, Some("\"hi\""))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
   wbtest_remove_if_exists(root)
@@ -748,7 +748,7 @@ test "compiled repl line renders string let binding and reuse" {
     Err(err) => fail("compiled repl string binding failed: " + err)
   }
   assert_eq(bound.value, WasmRunValue::Int(0L))
-  assert_eq(bound.display_override, Some("\"hi\""))
+  @debug.assert_eq(bound.display_override, Some("\"hi\""))
   let reused = match
     run_compiled_repl_line_with_cache(
       cache,
@@ -761,7 +761,7 @@ test "compiled repl line renders string let binding and reuse" {
     Err(err) => fail("compiled repl string reuse failed: " + err)
   }
   assert_eq(reused.value, WasmRunValue::Int(0L))
-  assert_eq(reused.display_override, Some("\"hi\""))
+  @debug.assert_eq(reused.display_override, Some("\"hi\""))
   wbtest_remove_if_exists(wasm0)
   wbtest_remove_if_exists(wasm1)
   wbtest_remove_if_exists(source_path)
@@ -817,7 +817,7 @@ test "normalize options parse check single file" {
     Ok(opts) => {
       assert_true(opts.check)
       assert_false(opts.write)
-      assert_eq(opts.files, ["examples/main.vibe"])
+      @debug.assert_eq(opts.files, ["examples/main.vibe"])
     }
     Err(msg) => fail("unexpected err: " + msg)
   }
@@ -1187,7 +1187,7 @@ test "cli bench can filter cases by name" {
       assert_eq(report.passed, 1)
       assert_eq(report.failed, 0)
       assert_eq(report.results.length(), 1)
-      assert_eq(report.results[0].name, Some("beta"))
+      @debug.assert_eq(report.results[0].name, Some("beta"))
     }
     Err(err) => fail("bench run failed: " + err)
   }
@@ -1267,12 +1267,12 @@ test "cli bench parses json output options" {
     ]) {
     Ok(opts) => {
       assert_true(opts.output_json)
-      assert_eq(opts.json_out_path, Some("/tmp/vibe-bench.json"))
+      @debug.assert_eq(opts.json_out_path, Some("/tmp/vibe-bench.json"))
       assert_eq(opts.runs, 5)
       assert_eq(opts.warmup, 1)
-      assert_eq(opts.case_filters, ["beta"])
+      @debug.assert_eq(opts.case_filters, ["beta"])
       assert_eq(opts.backend, BenchBackend::Wasm)
-      assert_eq(opts.paths, ["examples/simple_bench.vibe"])
+      @debug.assert_eq(opts.paths, ["examples/simple_bench.vibe"])
     }
     Err(err) => fail("parse bench args failed: " + err)
   }

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -175,9 +175,9 @@ test "line shell options show help" {
 
 ///|
 test "check failure message returns exit text only for errors" {
-  assert_eq(check_failure_message(0), None)
-  assert_eq(check_failure_message(1), Some("check: 1 error(s) found"))
-  assert_eq(check_failure_message(3), Some("check: 3 error(s) found"))
+  @debug.assert_eq(check_failure_message(0), None)
+  @debug.assert_eq(check_failure_message(1), Some("check: 1 error(s) found"))
+  @debug.assert_eq(check_failure_message(3), Some("check: 3 error(s) found"))
 }
 
 ///|
@@ -418,7 +418,7 @@ test "fmt cmd options parse default write mode" {
   match parsed {
     Ok(opts) => {
       assert_false(opts.dry_run)
-      assert_eq(opts.files, ["a.vibe", "b.vibe"])
+      @debug.assert_eq(opts.files, ["a.vibe", "b.vibe"])
     }
     Err(msg) => fail("unexpected err: " + msg)
   }
@@ -430,7 +430,7 @@ test "fmt cmd options parse dry-run and legacy write flags" {
   match parsed {
     Ok(opts) => {
       assert_true(opts.dry_run)
-      assert_eq(opts.files, ["a.vibe"])
+      @debug.assert_eq(opts.files, ["a.vibe"])
     }
     Err(msg) => fail("unexpected err: " + msg)
   }
@@ -470,7 +470,7 @@ test "cli syntax mode parse default" {
   match parsed {
     Ok((mode, rest)) => {
       assert_eq(mode, @runtime.ParserMode::VibeMode)
-      assert_eq(rest, ["main.vibe"])
+      @debug.assert_eq(rest, ["main.vibe"])
     }
     Err(msg) => fail("unexpected err: " + msg)
   }
@@ -482,7 +482,7 @@ test "cli syntax mode parse explicit vibe" {
   match parsed {
     Ok((mode, rest)) => {
       assert_eq(mode, @runtime.ParserMode::VibeMode)
-      assert_eq(rest, ["main.vibe"])
+      @debug.assert_eq(rest, ["main.vibe"])
     }
     Err(msg) => fail("unexpected err: " + msg)
   }
@@ -530,7 +530,7 @@ test "cli runtime flags parse default" {
   match parsed {
     Ok(opts) => {
       assert_eq(opts.syntax_mode, @runtime.ParserMode::VibeMode)
-      assert_eq(opts.cmd_args, ["main.vibe"])
+      @debug.assert_eq(opts.cmd_args, ["main.vibe"])
       assert_false(opts.unstable_async)
       assert_false(opts.unstable_threads)
     }
@@ -547,7 +547,7 @@ test "cli runtime flags parse with unstable flags" {
   match parsed {
     Ok(opts) => {
       assert_eq(opts.syntax_mode, @runtime.ParserMode::VibeMode)
-      assert_eq(opts.cmd_args, ["main.vibe"])
+      @debug.assert_eq(opts.cmd_args, ["main.vibe"])
       assert_true(opts.unstable_async)
       assert_true(opts.unstable_threads)
     }
@@ -579,7 +579,7 @@ test "cli dispatch args parse leading unstable flags" {
     Ok(v) => {
       assert_eq(v.cmd, "run")
       assert_eq(v.syntax_mode, @runtime.ParserMode::VibeMode)
-      assert_eq(v.cmd_args, ["main.vibe"])
+      @debug.assert_eq(v.cmd_args, ["main.vibe"])
       assert_true(v.unstable_async)
       assert_true(v.unstable_threads)
     }
@@ -597,7 +597,7 @@ test "cli dispatch args merges leading and trailing unstable flags" {
     Ok(v) => {
       assert_eq(v.cmd, "run")
       assert_eq(v.syntax_mode, @runtime.ParserMode::VibeMode)
-      assert_eq(v.cmd_args, ["main.vibe"])
+      @debug.assert_eq(v.cmd_args, ["main.vibe"])
       assert_true(v.unstable_async)
       assert_true(v.unstable_threads)
     }
@@ -618,19 +618,19 @@ test "cli dispatch args rejects missing command" {
 
 ///|
 test "removed public commands stay blocked" {
-  assert_eq(
+  @debug.assert_eq(
     removed_command_message("eval"),
     Some(
       "eval: command was removed. Use 'vibe shell' or 'vibe shell-stdin' for interactive evaluation, and 'vibe finalize --db <path>' for persisted scratch-db workflows.",
     ),
   )
-  assert_eq(
+  @debug.assert_eq(
     removed_command_message("bundle"),
     Some(
       "bundle: command was removed. Use 'vibe compile' to compile modules, or 'vibe precompile' for precompilation.",
     ),
   )
-  assert_eq(removed_command_message("run"), None)
+  @debug.assert_eq(removed_command_message("run"), None)
 }
 
 ///|
@@ -672,7 +672,7 @@ test "cli dispatch args parse init command" {
   match parsed {
     Ok(v) => {
       assert_eq(v.cmd, "init")
-      assert_eq(v.cmd_args, ["my-lib"])
+      @debug.assert_eq(v.cmd_args, ["my-lib"])
     }
     Err(msg) => fail("unexpected err: " + msg)
   }
@@ -684,7 +684,7 @@ test "cli dispatch args parse new command" {
   match parsed {
     Ok(v) => {
       assert_eq(v.cmd, "new")
-      assert_eq(v.cmd_args, ["my-lib"])
+      @debug.assert_eq(v.cmd_args, ["my-lib"])
     }
     Err(msg) => fail("unexpected err: " + msg)
   }
@@ -696,7 +696,7 @@ test "cli dispatch args parse explain-import command" {
   match parsed {
     Ok(v) => {
       assert_eq(v.cmd, "explain-import")
-      assert_eq(v.cmd_args, ["main.vibe"])
+      @debug.assert_eq(v.cmd_args, ["main.vibe"])
     }
     Err(msg) => fail("unexpected err: " + msg)
   }
@@ -763,28 +763,28 @@ test "explain import report resolves lock-backed refs" {
   let path_item = wbtest_find_explain_import_item(report.imports, "./dep.vibe")
   assert_eq(path_item.ref_kind, "PathRef")
   assert_eq(path_item.lock_lookup_status, "hit")
-  assert_eq(path_item.resolved_hash, Some(dep_hash))
+  @debug.assert_eq(path_item.resolved_hash, Some(dep_hash))
   let version_item = wbtest_find_explain_import_item(
     report.imports,
     "version@main",
   )
   assert_eq(version_item.ref_kind, "VersionRef")
   assert_eq(version_item.lock_lookup_status, "hit")
-  assert_eq(version_item.resolved_hash, Some(version_hash))
+  @debug.assert_eq(version_item.resolved_hash, Some(version_hash))
   let symbol_item = wbtest_find_explain_import_item(
     report.imports,
     "symbol@main/sym",
   )
   assert_eq(symbol_item.ref_kind, "SymbolRef")
   assert_eq(symbol_item.lock_lookup_status, "hit")
-  assert_eq(symbol_item.resolved_hash, Some(symbol_hash))
+  @debug.assert_eq(symbol_item.resolved_hash, Some(symbol_hash))
   let hash_item = wbtest_find_explain_import_item(
     report.imports,
     "#" + direct_hash,
   )
   assert_eq(hash_item.ref_kind, "HashRef")
   assert_eq(hash_item.lock_lookup_status, "n/a")
-  assert_eq(hash_item.resolved_hash, Some(direct_hash))
+  @debug.assert_eq(hash_item.resolved_hash, Some(direct_hash))
   wbtest_remove_if_exists(root)
 }
 
@@ -2005,17 +2005,17 @@ test "ensure_parent_dir_for_file errors when parent path is file" {
 test "split test entry path batches caps workers and balances paths" {
   let capped = split_test_entry_path_batches(["a.vibe", "b.vibe", "c.vibe"], 10)
   assert_eq(capped.length(), 3)
-  assert_eq(capped[0], ["a.vibe"])
-  assert_eq(capped[1], ["b.vibe"])
-  assert_eq(capped[2], ["c.vibe"])
+  @debug.assert_eq(capped[0], ["a.vibe"])
+  @debug.assert_eq(capped[1], ["b.vibe"])
+  @debug.assert_eq(capped[2], ["c.vibe"])
 
   let balanced = split_test_entry_path_batches(
     ["a.vibe", "b.vibe", "c.vibe", "d.vibe", "e.vibe"],
     2,
   )
   assert_eq(balanced.length(), 2)
-  assert_eq(balanced[0], ["a.vibe", "b.vibe", "c.vibe"])
-  assert_eq(balanced[1], ["d.vibe", "e.vibe"])
+  @debug.assert_eq(balanced[0], ["a.vibe", "b.vibe", "c.vibe"])
+  @debug.assert_eq(balanced[1], ["d.vibe", "e.vibe"])
 }
 
 ///|
@@ -2234,13 +2234,13 @@ test "test entry batch env chunk size accepts positive int only" {
   let prev = @sys.get_env_var("VIBE_TEST_BATCH_CHUNK_SIZE")
   defer wbtest_restore_env_var("VIBE_TEST_BATCH_CHUNK_SIZE", prev)
   @sys.unset_env_var("VIBE_TEST_BATCH_CHUNK_SIZE")
-  assert_eq(test_entry_batch_env_chunk_size(), None)
+  @debug.assert_eq(test_entry_batch_env_chunk_size(), None)
   @sys.set_env_var("VIBE_TEST_BATCH_CHUNK_SIZE", "3")
-  assert_eq(test_entry_batch_env_chunk_size(), Some(3))
+  @debug.assert_eq(test_entry_batch_env_chunk_size(), Some(3))
   @sys.set_env_var("VIBE_TEST_BATCH_CHUNK_SIZE", "0")
-  assert_eq(test_entry_batch_env_chunk_size(), None)
+  @debug.assert_eq(test_entry_batch_env_chunk_size(), None)
   @sys.set_env_var("VIBE_TEST_BATCH_CHUNK_SIZE", "bad")
-  assert_eq(test_entry_batch_env_chunk_size(), None)
+  @debug.assert_eq(test_entry_batch_env_chunk_size(), None)
 }
 
 ///|
@@ -2511,22 +2511,22 @@ test "test worker parent pid parses env value safely" {
 
   @sys.unset_env_var("VIBE_INTERNAL_PARENT_PID")
   @sys.unset_env_var("VIBE_INTERNAL_TEST_PARENT_PID")
-  assert_eq(test_worker_parent_pid(), None)
+  @debug.assert_eq(test_worker_parent_pid(), None)
 
   @sys.set_env_var("VIBE_INTERNAL_PARENT_PID", "invalid")
-  assert_eq(test_worker_parent_pid(), None)
+  @debug.assert_eq(test_worker_parent_pid(), None)
 
   @sys.unset_env_var("VIBE_INTERNAL_PARENT_PID")
   @sys.set_env_var("VIBE_INTERNAL_TEST_PARENT_PID", "invalid")
-  assert_eq(test_worker_parent_pid(), None)
+  @debug.assert_eq(test_worker_parent_pid(), None)
 
   let pid = vibe_getpid()
   @sys.set_env_var("VIBE_INTERNAL_PARENT_PID", pid.to_string())
-  assert_eq(test_worker_parent_pid(), Some(pid))
+  @debug.assert_eq(test_worker_parent_pid(), Some(pid))
 
   @sys.unset_env_var("VIBE_INTERNAL_PARENT_PID")
   @sys.set_env_var("VIBE_INTERNAL_TEST_PARENT_PID", pid.to_string())
-  assert_eq(test_worker_parent_pid(), Some(pid))
+  @debug.assert_eq(test_worker_parent_pid(), Some(pid))
 }
 
 ///|
@@ -3690,8 +3690,8 @@ test "serialize source hash cache roundtrips" {
   hashes["/tmp/b.vibe"] = "bbb"
   let parsed = parse_source_hash_cache(serialize_source_hash_cache(hashes))
   assert_eq(parsed.length(), 2)
-  assert_eq(parsed.get("/tmp/a.vibe"), Some("aaa"))
-  assert_eq(parsed.get("/tmp/b.vibe"), Some("bbb"))
+  @debug.assert_eq(parsed.get("/tmp/a.vibe"), Some("aaa"))
+  @debug.assert_eq(parsed.get("/tmp/b.vibe"), Some("bbb"))
 }
 
 ///|
@@ -3942,7 +3942,7 @@ test "cli session request parses check json" {
     Err(err) => fail("expected check request: " + err)
   }
   assert_eq(req.kind, CliSessionRequestKind::Check)
-  assert_eq(req.path, Some("/tmp/project/main.vibe"))
+  @debug.assert_eq(req.path, Some("/tmp/project/main.vibe"))
 }
 
 ///|
@@ -3955,7 +3955,7 @@ test "cli session request parses run json" {
     Err(err) => fail("expected run request: " + err)
   }
   assert_eq(req.kind, CliSessionRequestKind::Run)
-  assert_eq(req.path, Some("/tmp/project/main.vibe"))
+  @debug.assert_eq(req.path, Some("/tmp/project/main.vibe"))
 }
 
 ///|
@@ -3965,7 +3965,7 @@ test "cli session request parses shutdown json" {
     Err(err) => fail("expected shutdown request: " + err)
   }
   assert_eq(req.kind, CliSessionRequestKind::Shutdown)
-  assert_eq(req.path, None)
+  @debug.assert_eq(req.path, None)
 }
 
 ///|
@@ -3975,7 +3975,7 @@ test "cli session request parses ping json" {
     Err(err) => fail("expected ping request: " + err)
   }
   assert_eq(req.kind, CliSessionRequestKind::Ping)
-  assert_eq(req.path, None)
+  @debug.assert_eq(req.path, None)
 }
 
 ///|
@@ -4003,7 +4003,7 @@ test "cli session test report json roundtrips" {
   assert_eq(parsed.passed, 1)
   assert_eq(parsed.failed, 1)
   assert_eq(parsed.failures.length(), 1)
-  assert_eq(parsed.failures[0].name, Some("demo"))
+  @debug.assert_eq(parsed.failures[0].name, Some("demo"))
   assert_eq(parsed.failures[0].error, "boom")
 }
 
@@ -4182,9 +4182,9 @@ test "compiled exec wasm embeds throw literal for handler parity" {
 
 ///|
 test "decode tagged wasm run value" {
-  assert_eq(decode_tagged_wasm_run_value(168L), Some(WasmRunValue::Int(42L)))
-  assert_eq(decode_tagged_wasm_run_value(7L), Some(WasmRunValue::Bool(true)))
-  assert_eq(decode_tagged_wasm_run_value(3L), Some(WasmRunValue::Bool(false)))
+  @debug.assert_eq(decode_tagged_wasm_run_value(168L), Some(WasmRunValue::Int(42L)))
+  @debug.assert_eq(decode_tagged_wasm_run_value(7L), Some(WasmRunValue::Bool(true)))
+  @debug.assert_eq(decode_tagged_wasm_run_value(3L), Some(WasmRunValue::Bool(false)))
 }
 
 ///|
@@ -4244,7 +4244,7 @@ test "graph ir semantic option parser keeps positional args" {
   assert_eq(parsed.0.length(), 2)
   assert_eq(parsed.0[0], "query")
   assert_eq(parsed.0[1], "entry.ts")
-  assert_eq(parsed.1, Some("rows.json"))
+  @debug.assert_eq(parsed.1, Some("rows.json"))
 }
 
 ///|
@@ -4357,7 +4357,7 @@ test "graph ir line helpers resolve line and snippet from start offset" {
     [],
     [],
   )
-  assert_eq(graph_ir_line_col(source, row), (2, 1))
+  @debug.assert_eq(graph_ir_line_col(source, row), (2, 1))
   assert_eq(graph_ir_line_text(source, row), "foo()")
 }
 
@@ -4469,7 +4469,7 @@ test "compiled repl string fallback decodes _start export" {
     Err(err) => fail("compiled repl string literal failed: " + err)
   }
   assert_eq(result.value, WasmRunValue::Int(0L))
-  assert_eq(result.display_override, Some("\"hi\""))
+  @debug.assert_eq(result.display_override, Some("\"hi\""))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
   wbtest_remove_if_exists(root)
@@ -4489,7 +4489,7 @@ test "compiled repl array fallback renders duplicate strings" {
     Err(err) => fail("compiled repl array literal failed: " + err)
   }
   assert_eq(result.value, WasmRunValue::Int(0L))
-  assert_eq(result.display_override, Some("[\"hi\", \"hi\"]"))
+  @debug.assert_eq(result.display_override, Some("[\"hi\", \"hi\"]"))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
   wbtest_remove_if_exists(root)
@@ -4510,7 +4510,7 @@ test "compiled repl array binding renders on reuse" {
     Err(err) => fail("compiled repl array binding failed: " + err)
   }
   assert_eq(bound.value, WasmRunValue::Int(0L))
-  assert_eq(bound.display_override, Some("[1, 2]"))
+  @debug.assert_eq(bound.display_override, Some("[1, 2]"))
   let reused = match
     run_compiled_repl_line_with_cache(
       cache,
@@ -4523,7 +4523,7 @@ test "compiled repl array binding renders on reuse" {
     Err(err) => fail("compiled repl array reuse failed: " + err)
   }
   assert_eq(reused.value, WasmRunValue::Int(0L))
-  assert_eq(reused.display_override, Some("[1, 2]"))
+  @debug.assert_eq(reused.display_override, Some("[1, 2]"))
   wbtest_remove_if_exists(wasm0)
   wbtest_remove_if_exists(wasm1)
   wbtest_remove_if_exists(source_path)
@@ -4544,7 +4544,7 @@ test "compiled repl map fallback renders entries" {
     Err(err) => fail("compiled repl map literal failed: " + err)
   }
   assert_eq(result.value, WasmRunValue::Int(0L))
-  assert_eq(result.display_override, Some("{|\"a\": 1, \"b\": 2|}"))
+  @debug.assert_eq(result.display_override, Some("{|\"a\": 1, \"b\": 2|}"))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
   wbtest_remove_if_exists(root)

--- a/src/cmd/vibe/moon.pkg
+++ b/src/cmd/vibe/moon.pkg
@@ -39,7 +39,8 @@ import {
   "moonbitlang/core/env" @env,
   "moonbitlang/core/json" @json,
   "moonbitlang/core/ref" @ref,
-  "moonbitlang/core/strconv" @strconv,
+  "moonbitlang/core/string",
+  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/fs" @os_fs,
   "moonbitlang/x/sys" @sys,
 }

--- a/src/cmd/vibe_wasm/main_wbtest.mbt
+++ b/src/cmd/vibe_wasm/main_wbtest.mbt
@@ -88,8 +88,8 @@ test "parse cmd args compile component with out and wite" {
     Ok(opts) => {
       assert_eq(opts.command, CommandKind::Compile)
       assert_eq(opts.mode, RunMode::Component)
-      assert_eq(opts.out_path, Some("dist/app.component.wasm"))
-      assert_eq(opts.opt_level, Some("-Oz"))
+      @debug.assert_eq(opts.out_path, Some("dist/app.component.wasm"))
+      @debug.assert_eq(opts.opt_level, Some("-Oz"))
     }
     Err(msg) => fail("unexpected err: " + msg)
   }

--- a/src/cmd/vibe_wasm/moon.pkg
+++ b/src/cmd/vibe_wasm/moon.pkg
@@ -7,7 +7,8 @@ import {
   "moonbitlang/core/bench" @bench,
   "moonbitlang/core/env" @env,
   "moonbitlang/core/encoding/utf8" @utf8,
-  "moonbitlang/core/strconv" @strconv,
+  "moonbitlang/core/string",
+  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/fs" @os_fs,
   "moonbitlang/x/sys" @sys,
 }

--- a/src/codegen/moon.pkg
+++ b/src/codegen/moon.pkg
@@ -2,4 +2,5 @@ import {
   "mizchi/vibe/core" @core,
   "mizchi/vibe/profiler" @profiler,
   "moonbitlang/core/encoding/utf8" @utf8,
+  "moonbitlang/core/debug" @debug,
 }

--- a/src/codegen/wasm_codegen_rc_wbtest.mbt
+++ b/src/codegen/wasm_codegen_rc_wbtest.mbt
@@ -295,20 +295,20 @@ test "RC codegen: emit_rc_dup generates correct byte sequence" {
 ///|
 test "RC codegen: parse_site_path extracts prefix and index" {
   // Top-level: no prefix
-  assert_eq(parse_site_path("stmt[0].after"), ("", 0))
-  assert_eq(parse_site_path("stmt[5].before"), ("", 5))
-  assert_eq(parse_site_path("stmt[12].old_value"), ("", 12))
-  assert_eq(parse_site_path("stmt[100].after"), ("", 100))
+  @debug.assert_eq(parse_site_path("stmt[0].after"), ("", 0))
+  @debug.assert_eq(parse_site_path("stmt[5].before"), ("", 5))
+  @debug.assert_eq(parse_site_path("stmt[12].old_value"), ("", 12))
+  @debug.assert_eq(parse_site_path("stmt[100].after"), ("", 100))
   // Nested: prefix extracted
-  assert_eq(
+  @debug.assert_eq(
     parse_site_path("stmt[2].expr.body.stmt[1].after"),
     ("stmt[2].expr.body", 1),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_site_path("stmt[3].else.stmt[0].old_value"),
     ("stmt[3].else", 0),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_site_path("stmt[0].body.stmt[2].expr.body.stmt[1].after"),
     ("stmt[0].body.stmt[2].expr.body", 1),
   )

--- a/src/core/moon.pkg
+++ b/src/core/moon.pkg
@@ -2,5 +2,6 @@ import {
   "mizchi/bit" @bit,
   "mizchi/vibe/x/fp" @fp,
   "moonbitlang/core/json" @json,
+  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/path" @path,
 }

--- a/src/core/normalize_dag_wbtest.mbt
+++ b/src/core/normalize_dag_wbtest.mbt
@@ -326,15 +326,15 @@ test "expand_module respects depth limit" {
 
   let depth0 = expand_module("main-hash", load_module, Some(0))
   assert_eq(depth0.modules.length(), 1)
-  assert_eq(depth0.order, ["main-hash"])
+  @debug.assert_eq(depth0.order, ["main-hash"])
 
   let depth1 = expand_module("main-hash", load_module, Some(1))
   assert_eq(depth1.modules.length(), 2)
-  assert_eq(depth1.order, ["dep-hash", "main-hash"])
+  @debug.assert_eq(depth1.order, ["dep-hash", "main-hash"])
 
   let depth_all = expand_module("main-hash", load_module, None)
   assert_eq(depth_all.modules.length(), 3)
-  assert_eq(depth_all.order, ["leaf-hash", "dep-hash", "main-hash"])
+  @debug.assert_eq(depth_all.order, ["leaf-hash", "dep-hash", "main-hash"])
 }
 
 ///|
@@ -354,7 +354,7 @@ test "expand_module skips missing dependency hashes" {
   }
   let expanded = expand_module("main-hash", load_module, None)
   assert_eq(expanded.modules.length(), 1)
-  assert_eq(expanded.order, ["main-hash"])
+  @debug.assert_eq(expanded.order, ["main-hash"])
 }
 
 ///|
@@ -382,5 +382,5 @@ test "expand_module handles cyclic hashes once" {
   }
   let expanded = expand_module("main-hash", load_module, None)
   assert_eq(expanded.modules.length(), 2)
-  assert_eq(expanded.order, ["dep-hash", "main-hash"])
+  @debug.assert_eq(expanded.order, ["dep-hash", "main-hash"])
 }

--- a/src/frontend/desugar_wbtest.mbt
+++ b/src/frontend/desugar_wbtest.mbt
@@ -209,7 +209,7 @@ test "desugar_vibe_commands: ls(l=true) → sh_lines with flag" {
         _ => abort("expected String arg")
       }
       // Second arg: labeled Bool l=true
-      assert_eq(args[1].label, Some("l"))
+      @debug.assert_eq(args[1].label, Some("l"))
       match args[1].expr {
         @core.Expr::Bool(value=true, ..) => ()
         _ => abort("expected Bool(true)")
@@ -232,8 +232,8 @@ test "desugar_vibe_commands: ls(l=true, a=true) preserves order" {
   match desugared.stmts[0] {
     @core.Stmt::Expr(expr=@core.Expr::Call(name="sh_lines", args~, ..), ..) => {
       // Labels preserve input order: l, a
-      assert_eq(args[1].label, Some("l"))
-      assert_eq(args[2].label, Some("a"))
+      @debug.assert_eq(args[1].label, Some("l"))
+      @debug.assert_eq(args[2].label, Some("a"))
     }
     _ => abort("expected sh_lines call")
   }
@@ -257,8 +257,8 @@ test "desugar_vibe_commands: ls -al → sh_lines with flags" {
         _ => abort("expected String")
       }
       // Flags sorted: a, l
-      assert_eq(args[1].label, Some("a"))
-      assert_eq(args[2].label, Some("l"))
+      @debug.assert_eq(args[1].label, Some("a"))
+      @debug.assert_eq(args[2].label, Some("l"))
     }
     _ => abort("expected sh_lines call")
   }

--- a/src/frontend/moon.pkg
+++ b/src/frontend/moon.pkg
@@ -2,4 +2,5 @@ import {
   "mizchi/vibe/core" @core,
   "mizchi/vibe/checker" @checker,
   "mizchi/vibe/parser" @parser,
+  "moonbitlang/core/debug" @debug,
 }

--- a/src/frontend/perceus_poc_wbtest.mbt
+++ b/src/frontend/perceus_poc_wbtest.mbt
@@ -53,7 +53,7 @@ test "perceus poc drops unused let binding" {
     ],
   }
   let lines = perceus_action_lines(build_perceus_plan_poc(mod))
-  assert_eq(lines, ["stmt[0].after drop x"])
+  @debug.assert_eq(lines, ["stmt[0].after drop x"])
 }
 
 ///|
@@ -77,7 +77,7 @@ test "perceus poc inserts dup before first sequential use" {
     ],
   }
   let lines = perceus_action_lines(build_perceus_plan_poc(mod))
-  assert_eq(lines, ["stmt[1].expr.arg[0].before dup x"])
+  @debug.assert_eq(lines, ["stmt[1].expr.arg[0].before dup x"])
 }
 
 ///|
@@ -124,7 +124,7 @@ test "perceus poc inserts dup at closure capture when outer value stays live" {
     ],
   }
   let lines = perceus_action_lines(build_perceus_plan_poc(mod))
-  assert_eq(lines, ["stmt[1].expr.capture[x].before dup x"])
+  @debug.assert_eq(lines, ["stmt[1].expr.capture[x].before dup x"])
 }
 
 ///|
@@ -146,7 +146,7 @@ test "perceus poc drops unused binding inside block expression" {
     stmts: [@core.Stmt::Expr(expr=block, span=perceus_test_span(34))],
   }
   let lines = perceus_action_lines(build_perceus_plan_poc(mod))
-  assert_eq(lines, ["stmt[0].expr.body.stmt[0].after drop y"])
+  @debug.assert_eq(lines, ["stmt[0].expr.body.stmt[0].after drop y"])
 }
 
 // ======================================================================

--- a/src/io/io_test.mbt
+++ b/src/io/io_test.mbt
@@ -94,7 +94,7 @@ test "io shell wrappers provide ls and cat behavior" {
     Ok(v) => v
     Err(err) => fail(err)
   }
-  assert_eq(lines, ["a", "b"])
+  @debug.assert_eq(lines, ["a", "b"])
   remove_if_exists(root)
 }
 

--- a/src/io/moon.pkg
+++ b/src/io/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "mizchi/vibe/backend" @backend,
   "moonbitlang/core/env" @env,
+  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/fs" @os_fs,
   "moonbitlang/x/sys" @sys,
 }

--- a/src/loader/loader_test.mbt
+++ b/src/loader/loader_test.mbt
@@ -502,7 +502,7 @@ test "loader resolve_entry_graph_head_with_fs returns None without graph_head" {
     Ok(_) => ()
     Err(err) => fail(err)
   }
-  assert_eq(resolve_entry_graph_head_with_fs(pkg, fs), None)
+  @debug.assert_eq(resolve_entry_graph_head_with_fs(pkg, fs), None)
 }
 
 ///|
@@ -1222,7 +1222,7 @@ test "loader resolve_entry_graph_head_with_fs returns None when cache.json is mi
     Ok(_) => ()
     Err(err) => fail(err)
   }
-  assert_eq(resolve_entry_graph_head_with_fs(pkg, fs), None)
+  @debug.assert_eq(resolve_entry_graph_head_with_fs(pkg, fs), None)
 }
 
 ///|
@@ -1246,7 +1246,7 @@ test "loader resolve_entry_graph_head_with_fs returns None for malformed cache.j
     Ok(_) => ()
     Err(err) => fail(err)
   }
-  assert_eq(resolve_entry_graph_head_with_fs(pkg, fs), None)
+  @debug.assert_eq(resolve_entry_graph_head_with_fs(pkg, fs), None)
 }
 
 ///|
@@ -1270,7 +1270,7 @@ test "loader resolve_entry_graph_head_with_fs returns None when graph_head is no
     Ok(_) => ()
     Err(err) => fail(err)
   }
-  assert_eq(resolve_entry_graph_head_with_fs(pkg, fs), None)
+  @debug.assert_eq(resolve_entry_graph_head_with_fs(pkg, fs), None)
 }
 
 ///|

--- a/src/loader/moon.pkg
+++ b/src/loader/moon.pkg
@@ -7,6 +7,7 @@ import {
   "mizchi/vibe/parser" @parser,
   "mizchi/vibe/runtime" @runtime,
   "moonbitlang/core/json" @json,
+  "moonbitlang/core/debug" @debug,
 }
 
 import {

--- a/src/lsp/lsp_wbtest.mbt
+++ b/src/lsp/lsp_wbtest.mbt
@@ -32,7 +32,7 @@ test "check_document/warning" {
   assert_true(ok)
   assert_eq(diagnostics.length(), 1)
   let diag = diagnostics[0]
-  assert_eq(diag.severity, Some(2))
+  @debug.assert_eq(diag.severity, Some(2))
   assert_true(diag.message.contains("unused variable: unused"))
 }
 
@@ -45,7 +45,7 @@ test "check_document/warning_unnecessary_mut" {
   let mut found = false
   for diag in diagnostics {
     if diag.message.contains("unnecessary `mut` binding: value") {
-      assert_eq(diag.severity, Some(2))
+      @debug.assert_eq(diag.severity, Some(2))
       found = true
     }
   }
@@ -56,7 +56,7 @@ test "check_document/warning_unnecessary_mut" {
 test "handle_initialize" {
   let resp = handle_initialize(Some(JsonRpcId::Num(1)))
   assert_eq(resp.jsonrpc, "2.0")
-  assert_eq(resp.id, Some(JsonRpcId::Num(1)))
+  @debug.assert_eq(resp.id, Some(JsonRpcId::Num(1)))
   assert_true(resp.result is Some(_))
   assert_true(resp.error is None)
   match resp.result {
@@ -82,7 +82,7 @@ test "handle_initialize" {
 test "handle_shutdown" {
   let resp = handle_shutdown(Some(JsonRpcId::Num(2)))
   assert_eq(resp.jsonrpc, "2.0")
-  assert_eq(resp.id, Some(JsonRpcId::Num(2)))
+  @debug.assert_eq(resp.id, Some(JsonRpcId::Num(2)))
   assert_true(resp.error is None)
 }
 
@@ -438,11 +438,11 @@ test "offset_to_position/middle" {
 test "DocumentManager/basic" {
   let dm = DocumentManager::new()
   dm.open("file://test.vibe", "let x = 1", 1)
-  assert_eq(dm.get("file://test.vibe"), Some("let x = 1"))
-  assert_eq(dm.get_version("file://test.vibe"), Some(1))
+  @debug.assert_eq(dm.get("file://test.vibe"), Some("let x = 1"))
+  @debug.assert_eq(dm.get_version("file://test.vibe"), Some(1))
   dm.update("file://test.vibe", "let x = 2", 2)
-  assert_eq(dm.get("file://test.vibe"), Some("let x = 2"))
-  assert_eq(dm.get_version("file://test.vibe"), Some(2))
+  @debug.assert_eq(dm.get("file://test.vibe"), Some("let x = 2"))
+  @debug.assert_eq(dm.get_version("file://test.vibe"), Some(2))
   dm.close("file://test.vibe")
   assert_true(dm.get("file://test.vibe") is None)
 }

--- a/src/lsp/moon.pkg
+++ b/src/lsp/moon.pkg
@@ -3,4 +3,5 @@ import {
   "mizchi/vibe/parser",
   "mizchi/vibe/checker",
   "mizchi/vibe/frontend",
+  "moonbitlang/core/debug" @debug,
 }

--- a/src/parser/moon.pkg
+++ b/src/parser/moon.pkg
@@ -3,4 +3,5 @@ import {
   "mizchi/vibe/core" @core,
   "moonbitlang/core/ref" @ref,
   "moonbitlang/core/string" @string,
+  "moonbitlang/core/debug" @debug,
 }

--- a/src/parser/parser_for_in_wbtest.mbt
+++ b/src/parser/parser_for_in_wbtest.mbt
@@ -10,7 +10,7 @@ test "for-in parses to ForIn AST node" {
       ..
     ) => {
       assert_eq(value_name, "x")
-      assert_eq(index_name, None)
+      @debug.assert_eq(index_name, None)
       // iterable is [1, 2, 3]
       match iterable {
         @core.Expr::Array(items~, ..) => assert_eq(items.length(), 3)
@@ -32,7 +32,7 @@ test "for-in with index binding parses correctly" {
   match ast.stmts[0] {
     @core.Stmt::Expr(expr=@core.Expr::ForIn(value_name~, index_name~, ..), ..) => {
       assert_eq(value_name, "x")
-      assert_eq(index_name, Some("i"))
+      @debug.assert_eq(index_name, Some("i"))
     }
     _ => abort("expected ForIn expression with index")
   }

--- a/src/runtime/moon.pkg
+++ b/src/runtime/moon.pkg
@@ -6,10 +6,10 @@ import {
   "mizchi/vibe/core" @core,
   "mizchi/vibe/io" @io,
   "mizchi/vibe/checker" @checker,
-  "moonbitlang/core/strconv" @strconv,
   "moonbitlang/x/path" @path,
   "moonbitlang/core/bench" @bench,
   "moonbitlang/core/ref" @ref,
+  "moonbitlang/core/string",
 }
 
 import {

--- a/src/runtime_compile/moon.pkg
+++ b/src/runtime_compile/moon.pkg
@@ -15,7 +15,6 @@ import {
 }
 
 import {
-  "mizchi/vibe/capability" @capability,
   "mizchi/vibe/loader" @loader,
   "moonbitlang/core/json" @json,
 } for "test"

--- a/src/tests/moon.pkg
+++ b/src/tests/moon.pkg
@@ -9,6 +9,7 @@ import {
   "mizchi/vibe/parser" @parser,
   "moonbitlang/core/encoding/utf8" @utf8,
   "moonbitlang/core/json" @json,
+  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/fs" @os_fs,
   "moonbitlang/x/path" @path,
   "moonbitlang/x/sys" @sys,

--- a/src/tests/vibe_db_integration_test.mbt
+++ b/src/tests/vibe_db_integration_test.mbt
@@ -98,7 +98,7 @@ test "vibe import parsing" {
   match imp.hash {
     Some(h) => {
       assert_eq(h, @core.git_blob_hash_string("export let y = 2"))
-      assert_eq(imp.module_ref, Some(@core.module_ref_from_hash(h)))
+      @debug.assert_eq(imp.module_ref, Some(@core.module_ref_from_hash(h)))
     }
     None => fail("missing hash")
   }
@@ -117,7 +117,7 @@ test "vibe hash import resolves by content hash" {
   match imp.hash {
     Some(h) => {
       assert_eq(h, lib_hash)
-      assert_eq(imp.module_ref, Some(@core.module_ref_from_hash(h)))
+      @debug.assert_eq(imp.module_ref, Some(@core.module_ref_from_hash(h)))
     }
     None => fail("missing hash for hash import")
   }
@@ -211,7 +211,7 @@ test "vibe path import lock accepts matching hash" {
   db.set_path_ref("./foo.vibe", lib_hash)
   let imports = db.imports("main")
   assert_eq(imports.length(), 1)
-  assert_eq(imports[0].hash, Some(lib_hash))
+  @debug.assert_eq(imports[0].hash, Some(lib_hash))
   let _ = db.types("main")
   let diags = db.diagnostics("main")
   assert_true(diags.is_empty())
@@ -257,8 +257,8 @@ test "vibe hash import keeps immutable snapshot after source update" {
   let imports = db.imports("main")
   assert_eq(imports.length(), 1)
   let imp = imports[0]
-  assert_eq(imp.hash, Some(hash_v1))
-  assert_eq(imp.source_hash, Some(hash_v1))
+  @debug.assert_eq(imp.hash, Some(hash_v1))
+  @debug.assert_eq(imp.source_hash, Some(hash_v1))
   match db.get_source(imp.path) {
     Some(snapshot) => assert_eq(snapshot, lib_v1)
     None => fail("missing immutable hash snapshot")
@@ -279,8 +279,8 @@ test "vibe version import resolves through lock ref" {
   let imports = db.imports("entry")
   assert_eq(imports.length(), 1)
   let imp = imports[0]
-  assert_eq(imp.source_version, Some("main"))
-  assert_eq(imp.hash, Some(lib_hash))
+  @debug.assert_eq(imp.source_version, Some("main"))
+  @debug.assert_eq(imp.hash, Some(lib_hash))
   let _ = db.types("entry")
   let diags = db.diagnostics("entry")
   assert_true(diags.is_empty())
@@ -297,8 +297,8 @@ test "vibe symbol import resolves through lock ref" {
   let imports = db.imports("entry")
   assert_eq(imports.length(), 1)
   let imp = imports[0]
-  assert_eq(imp.source_symbol, Some("std/math"))
-  assert_eq(imp.hash, Some(lib_hash))
+  @debug.assert_eq(imp.source_symbol, Some("std/math"))
+  @debug.assert_eq(imp.hash, Some(lib_hash))
   let _ = db.types("entry")
   let diags = db.diagnostics("entry")
   assert_true(diags.is_empty())

--- a/src/x/module_graph/lang_extractor_test.mbt
+++ b/src/x/module_graph/lang_extractor_test.mbt
@@ -1,16 +1,16 @@
 ///|
 test "detect_language_id" {
-  assert_eq(detect_language_id("foo.vibe"), Some("vibe"))
-  assert_eq(detect_language_id("bar.ts"), Some("typescript"))
-  assert_eq(detect_language_id("baz.tsx"), Some("typescript"))
-  assert_eq(detect_language_id("mod.mts"), Some("typescript"))
-  assert_eq(detect_language_id("mod.cts"), Some("typescript"))
-  assert_eq(detect_language_id("app.js"), Some("javascript"))
-  assert_eq(detect_language_id("app.mjs"), Some("javascript"))
-  assert_eq(detect_language_id("app.cjs"), Some("javascript"))
-  assert_eq(detect_language_id("main.py"), Some("python"))
-  assert_eq(detect_language_id("stub.pyi"), Some("python"))
-  assert_eq(detect_language_id("test.rs"), None)
+  @debug.assert_eq(detect_language_id("foo.vibe"), Some("vibe"))
+  @debug.assert_eq(detect_language_id("bar.ts"), Some("typescript"))
+  @debug.assert_eq(detect_language_id("baz.tsx"), Some("typescript"))
+  @debug.assert_eq(detect_language_id("mod.mts"), Some("typescript"))
+  @debug.assert_eq(detect_language_id("mod.cts"), Some("typescript"))
+  @debug.assert_eq(detect_language_id("app.js"), Some("javascript"))
+  @debug.assert_eq(detect_language_id("app.mjs"), Some("javascript"))
+  @debug.assert_eq(detect_language_id("app.cjs"), Some("javascript"))
+  @debug.assert_eq(detect_language_id("main.py"), Some("python"))
+  @debug.assert_eq(detect_language_id("stub.pyi"), Some("python"))
+  @debug.assert_eq(detect_language_id("test.rs"), None)
 }
 
 ///|
@@ -166,7 +166,7 @@ test "extract_graph_ir_rows_with_semantic_provider can refine baseline rows" {
     Ok(rows) => {
       assert_eq(rows.length(), 1)
       assert_eq(rows[0].signature, "function greet(name: string): string")
-      assert_eq(rows[0].type_terms, ["string"])
+      @debug.assert_eq(rows[0].type_terms, ["string"])
     }
     Err(e) => fail(e)
   }

--- a/src/x/module_graph/moon.pkg
+++ b/src/x/module_graph/moon.pkg
@@ -12,6 +12,7 @@ import {
   "mizchi/vibe/runtime_compile" @runtime_compile,
   "moonbitlang/core/encoding/utf8" @utf8,
   "moonbitlang/core/json" @json,
+  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/fs" @os_fs,
 }
 

--- a/src/x/scoped_map/moon.pkg
+++ b/src/x/scoped_map/moon.pkg
@@ -1,2 +1,3 @@
 import {
+  "moonbitlang/core/debug" @debug,
 }

--- a/src/x/scoped_map/scoped_map_test.mbt
+++ b/src/x/scoped_map/scoped_map_test.mbt
@@ -3,9 +3,9 @@ test "new and set/get" {
   let m : ScopedMap[Int] = ScopedMap::new()
   m["x"] = 1
   m["y"] = 2
-  assert_eq(m.get("x"), Some(1))
-  assert_eq(m.get("y"), Some(2))
-  assert_eq(m.get("z"), None)
+  @debug.assert_eq(m.get("x"), Some(1))
+  @debug.assert_eq(m.get("y"), Some(2))
+  @debug.assert_eq(m.get("z"), None)
 }
 
 ///|
@@ -13,11 +13,11 @@ test "fork inherits parent" {
   let parent : ScopedMap[Int] = ScopedMap::new()
   parent["a"] = 10
   let child = parent.fork()
-  assert_eq(child.get("a"), Some(10))
+  @debug.assert_eq(child.get("a"), Some(10))
   // child write doesn't affect parent
   child["a"] = 20
-  assert_eq(child.get("a"), Some(20))
-  assert_eq(parent.get("a"), Some(10))
+  @debug.assert_eq(child.get("a"), Some(20))
+  @debug.assert_eq(parent.get("a"), Some(10))
 }
 
 ///|
@@ -26,9 +26,9 @@ test "fork child adds own" {
   parent["a"] = 1
   let child = parent.fork()
   child["b"] = 2
-  assert_eq(child.get("a"), Some(1))
-  assert_eq(child.get("b"), Some(2))
-  assert_eq(parent.get("b"), None)
+  @debug.assert_eq(child.get("a"), Some(1))
+  @debug.assert_eq(child.get("b"), Some(2))
+  @debug.assert_eq(parent.get("b"), None)
 }
 
 ///|
@@ -49,7 +49,7 @@ test "remove only affects own" {
   let _ = c.get("x")
   c.remove("x")
   // still accessible from parent
-  assert_eq(c.get("x"), Some(1))
+  @debug.assert_eq(c.get("x"), Some(1))
 }
 
 ///|
@@ -59,8 +59,8 @@ test "copy flattens parent chain" {
   let c = p.fork()
   c["b"] = 2
   let flat = c.copy()
-  assert_eq(flat.get("a"), Some(1))
-  assert_eq(flat.get("b"), Some(2))
+  @debug.assert_eq(flat.get("a"), Some(1))
+  @debug.assert_eq(flat.get("b"), Some(2))
   assert_true(flat.parent is None)
 }
 
@@ -71,7 +71,7 @@ test "copy own overrides parent" {
   let c = p.fork()
   c["x"] = 2
   let flat = c.copy()
-  assert_eq(flat.get("x"), Some(2))
+  @debug.assert_eq(flat.get("x"), Some(2))
 }
 
 ///|
@@ -82,8 +82,8 @@ test "merge_up_or_self pushes to parent" {
   c["b"] = 2
   c["a"] = 10
   let merged = c.merge_up_or_self()
-  assert_eq(merged.get("a"), Some(10))
-  assert_eq(merged.get("b"), Some(2))
+  @debug.assert_eq(merged.get("a"), Some(10))
+  @debug.assert_eq(merged.get("b"), Some(2))
   assert_true(merged.parent is None)
 }
 
@@ -92,7 +92,7 @@ test "from_map" {
   let m : Map[String, Int] = {}
   m["k"] = 42
   let sm = ScopedMap::from_map(m)
-  assert_eq(sm.get("k"), Some(42))
+  @debug.assert_eq(sm.get("k"), Some(42))
 }
 
 ///|
@@ -101,7 +101,7 @@ test "lazy promotion caches in own" {
   p["x"] = 1
   let c = p.fork()
   // first get promotes to own
-  assert_eq(c.get("x"), Some(1))
+  @debug.assert_eq(c.get("x"), Some(1))
   assert_true(c.own.contains("x"))
 }
 
@@ -113,7 +113,7 @@ test "deep chain" {
   b["y"] = 2
   let c = b.fork()
   c["z"] = 3
-  assert_eq(c.get("x"), Some(1))
-  assert_eq(c.get("y"), Some(2))
-  assert_eq(c.get("z"), Some(3))
+  @debug.assert_eq(c.get("x"), Some(1))
+  @debug.assert_eq(c.get("y"), Some(2))
+  @debug.assert_eq(c.get("z"), Some(3))
 }


### PR DESCRIPTION
## Summary

`moon check --target native --release`: **254 → 131 warnings**, 0 errors.

## Three clusters

### `assert_eq(...)` → `@debug.assert_eq(...)` (~119 sites)

The prelude `assert_eq[T : Eq + Show]` is deprecated; the recommended form is `@debug.assert_eq[T : Eq + Debug]`. Each warning span flagged by `moon check --output-json` was rewritten to the qualified form. The warning cascades — replacing one site sometimes exposes another nested in a multi-arg call — so this iterates `check` → rewrite until stable.

### `moonbitlang/core/string` import hygiene (30 sites)

`@string.parse_int` / `parse_int64` / `parse_double` were already migrated in #389, but the matching `moonbitlang/core/string` import wasn't added — the toolchain now warns `core_package_not_imported` on every call site. Added to three `moon.pkg` files.

### Stale-import cleanup

- Dropped `moonbitlang/core/strconv` from three packages (only the deprecated `@strconv.parse_*` calls used it; #389 migrated them).
- Kept `mizchi/vibe/parser` in `frontend/moon.pkg` and `@debug` in 9 packages where they're only referenced by wbtest files — `moon`'s unused-package check doesn't follow wbtest references, so the resulting 9 + 1 `unused_package alias` warnings are unavoidable false positives (until the upstream check is fixed or the wbtest imports are split out).

## Remaining warnings (131)

The big bucket is `to_string()` / `inspect(value, …)` on values whose type implements `Show` but not `Debug` (~47 sites). Fixing those means either adding `derive(Debug)` to user types or switching the call to a format string — per-callsite type information needed, not safely sed-able. Deferred.

Also `Unused trait implementation` (11), `Unused error type` (7), `derive(Show) is deprecated` (2) — smaller clusters tracked for future passes.

## Verification

| target | result |
|---|---|
| `moon check --target native --release` | **254 → 131 warnings**, 0 errors |
| `mizchi/vibe/checker` | 160/160 |
| `mizchi/vibe/frontend` | 83/83 |
| `mizchi/vibe/cmd/vibe -f 'session*'` | 10/10 |
| `mizchi/vibe/tests` (target=js) | 257/257 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7y6q8Df9KiLNTK77zR65T)_