### PR TITLE
warnings: round 2 — kill unused Show impls + delegated fixups (-23 warnings)

### DIFF
--- a/src/checker/builtin_table_decoder.mbt
+++ b/src/checker/builtin_table_decoder.mbt
@@ -17,11 +17,6 @@ struct BuiltinTableEntry {
 } derive(Eq, Debug)
 
 ///|
-impl Show for BuiltinTableEntry with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 /// Type identifier decoded from binary.
 enum BuiltinTypeId {
   BTUnit
@@ -47,11 +42,6 @@ enum BuiltinTypeId {
   BTTypeVar(Int) // 0=T, 1=U, 2=V
   BTUnknown
 } derive(Eq, Debug)
-
-///|
-impl Show for BuiltinTypeId with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
 
 ///|
 /// Read LEB128 unsigned integer from bytes at position.

--- a/src/checker/builtin_table_decoder_wbtest.mbt
+++ b/src/checker/builtin_table_decoder_wbtest.mbt
@@ -72,7 +72,7 @@ test "decode_builtin_table: single entry String::length" {
       assert_eq(entries.length(), 1)
       assert_eq(entries[0].name, "String::length")
       @debug.assert_eq(entries[0].params, [BuiltinTypeId::BTString])
-      assert_eq(entries[0].ret, BuiltinTypeId::BTInt)
+      @debug.assert_eq(entries[0].ret, BuiltinTypeId::BTInt)
       assert_eq(entries[0].flags, 0)
     }
     None => fail("expected Some")
@@ -92,12 +92,12 @@ test "decode_builtin_table: Array::get with container type" {
       assert_eq(entries.length(), 1)
       assert_eq(entries[0].name, "Array::get")
       assert_eq(entries[0].params.length(), 2)
-      assert_eq(
+      @debug.assert_eq(
         entries[0].params[0],
         BuiltinTypeId::BTArray(BuiltinTypeId::BTTypeVar(0)),
       )
-      assert_eq(entries[0].params[1], BuiltinTypeId::BTInt)
-      assert_eq(entries[0].ret, BuiltinTypeId::BTTypeVar(0))
+      @debug.assert_eq(entries[0].params[1], BuiltinTypeId::BTInt)
+      @debug.assert_eq(entries[0].ret, BuiltinTypeId::BTTypeVar(0))
     }
     None => fail("expected Some")
   }
@@ -116,15 +116,15 @@ test "decode_builtin_table: Map type" {
       assert_eq(entries.length(), 1)
       assert_eq(entries[0].name, "Map::get")
       assert_eq(entries[0].params.length(), 2)
-      assert_eq(
+      @debug.assert_eq(
         entries[0].params[0],
         BuiltinTypeId::BTMap(
           BuiltinTypeId::BTTypeVar(0),
           BuiltinTypeId::BTTypeVar(1),
         ),
       )
-      assert_eq(entries[0].params[1], BuiltinTypeId::BTTypeVar(0))
-      assert_eq(entries[0].ret, BuiltinTypeId::BTTypeVar(1))
+      @debug.assert_eq(entries[0].params[1], BuiltinTypeId::BTTypeVar(0))
+      @debug.assert_eq(entries[0].ret, BuiltinTypeId::BTTypeVar(1))
     }
     None => fail("expected Some")
   }
@@ -141,10 +141,10 @@ test "decode_builtin_table: multiple entries" {
       assert_eq(entries.length(), 2)
       assert_eq(entries[0].name, "Fs::getcwd")
       assert_eq(entries[0].params.length(), 0)
-      assert_eq(entries[0].ret, BuiltinTypeId::BTString)
+      @debug.assert_eq(entries[0].ret, BuiltinTypeId::BTString)
       assert_eq(entries[1].name, "Bytes::length")
       @debug.assert_eq(entries[1].params, [BuiltinTypeId::BTBytes])
-      assert_eq(entries[1].ret, BuiltinTypeId::BTInt)
+      @debug.assert_eq(entries[1].ret, BuiltinTypeId::BTInt)
     }
     None => fail("expected Some")
   }
@@ -177,7 +177,7 @@ test "decode_builtin_table: Set type" {
   match decode_builtin_table(data) {
     Some(entries) => {
       assert_eq(entries[0].params.length(), 1)
-      assert_eq(
+      @debug.assert_eq(
         entries[0].params[0],
         BuiltinTypeId::BTSet(BuiltinTypeId::BTTypeVar(0)),
       )
@@ -210,7 +210,7 @@ test "decode_builtin_table: Option type" {
   let data = ints_to_bytes(buf)
   match decode_builtin_table(data) {
     Some(entries) =>
-      assert_eq(entries[0].ret, BuiltinTypeId::BTOption(BuiltinTypeId::BTInt))
+      @debug.assert_eq(entries[0].ret, BuiltinTypeId::BTOption(BuiltinTypeId::BTInt))
     None => fail("expected Some")
   }
 }

--- a/src/checker/typecheck_unify.mbt
+++ b/src/checker/typecheck_unify.mbt
@@ -506,7 +506,7 @@ fn normalize_type_inner(
       }
     }
     @core.Type::Tuple(items) =>
-      if not(type_has_named_node(ty)) {
+      if !type_has_named_node(ty) {
         ty
       } else {
         let out : Array[@core.Type] = []
@@ -543,7 +543,7 @@ fn normalize_type_inner(
         )
       }
     @core.Type::Set(inner) =>
-      if not(type_has_named_node(inner)) {
+      if !type_has_named_node(inner) {
         ty
       } else {
         @core.Type::Set(normalize_type_inner(env, inner, visiting, expand_enum))

--- a/src/cmd/vibe/builtin_table_encoder.mbt
+++ b/src/cmd/vibe/builtin_table_encoder.mbt
@@ -106,11 +106,6 @@ struct BuiltinDecl {
 } derive(Eq, Debug)
 
 ///|
-impl Show for BuiltinDecl with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 /// Type tag for binary encoding. Supports nested container types.
 enum BuiltinTypeTag {
   Unit
@@ -136,11 +131,6 @@ enum BuiltinTypeTag {
   TypeVar(Int) // 0=T, 1=U, 2=V
   Unknown
 } derive(Eq, Debug)
-
-///|
-impl Show for BuiltinTypeTag with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
 
 ///|
 /// Write LEB128 unsigned integer to buffer.

--- a/src/cmd/vibe/builtin_table_encoder_wbtest.mbt
+++ b/src/cmd/vibe/builtin_table_encoder_wbtest.mbt
@@ -1,54 +1,54 @@
 ///|
 test "parse_type_tag: primitive types" {
-  assert_eq(parse_type_tag("Unit"), BuiltinTypeTag::Unit)
-  assert_eq(parse_type_tag("Int"), BuiltinTypeTag::Int_)
-  assert_eq(parse_type_tag("Bool"), BuiltinTypeTag::Bool_)
-  assert_eq(parse_type_tag("String"), BuiltinTypeTag::String_)
-  assert_eq(parse_type_tag("Double"), BuiltinTypeTag::Double_)
-  assert_eq(parse_type_tag("Float"), BuiltinTypeTag::Float_)
-  assert_eq(parse_type_tag("Bytes"), BuiltinTypeTag::Bytes_)
-  assert_eq(parse_type_tag("Char"), BuiltinTypeTag::Char_)
-  assert_eq(parse_type_tag("Path"), BuiltinTypeTag::Path_)
-  assert_eq(parse_type_tag("V128"), BuiltinTypeTag::V128_)
-  assert_eq(parse_type_tag("Json"), BuiltinTypeTag::Json_)
-  assert_eq(parse_type_tag("StringBuilder"), BuiltinTypeTag::StringBuilder_)
-  assert_eq(parse_type_tag("PromptText"), BuiltinTypeTag::PromptText_)
+  @debug.assert_eq(parse_type_tag("Unit"), BuiltinTypeTag::Unit)
+  @debug.assert_eq(parse_type_tag("Int"), BuiltinTypeTag::Int_)
+  @debug.assert_eq(parse_type_tag("Bool"), BuiltinTypeTag::Bool_)
+  @debug.assert_eq(parse_type_tag("String"), BuiltinTypeTag::String_)
+  @debug.assert_eq(parse_type_tag("Double"), BuiltinTypeTag::Double_)
+  @debug.assert_eq(parse_type_tag("Float"), BuiltinTypeTag::Float_)
+  @debug.assert_eq(parse_type_tag("Bytes"), BuiltinTypeTag::Bytes_)
+  @debug.assert_eq(parse_type_tag("Char"), BuiltinTypeTag::Char_)
+  @debug.assert_eq(parse_type_tag("Path"), BuiltinTypeTag::Path_)
+  @debug.assert_eq(parse_type_tag("V128"), BuiltinTypeTag::V128_)
+  @debug.assert_eq(parse_type_tag("Json"), BuiltinTypeTag::Json_)
+  @debug.assert_eq(parse_type_tag("StringBuilder"), BuiltinTypeTag::StringBuilder_)
+  @debug.assert_eq(parse_type_tag("PromptText"), BuiltinTypeTag::PromptText_)
 }
 
 ///|
 test "parse_type_tag: type variables" {
-  assert_eq(parse_type_tag("T"), BuiltinTypeTag::TypeVar(0))
-  assert_eq(parse_type_tag("U"), BuiltinTypeTag::TypeVar(1))
-  assert_eq(parse_type_tag("V"), BuiltinTypeTag::TypeVar(2))
+  @debug.assert_eq(parse_type_tag("T"), BuiltinTypeTag::TypeVar(0))
+  @debug.assert_eq(parse_type_tag("U"), BuiltinTypeTag::TypeVar(1))
+  @debug.assert_eq(parse_type_tag("V"), BuiltinTypeTag::TypeVar(2))
 }
 
 ///|
 test "parse_type_tag: container types" {
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("Array[Int]"),
     BuiltinTypeTag::Array_(BuiltinTypeTag::Int_),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("Map[String, Int]"),
     BuiltinTypeTag::Map_(BuiltinTypeTag::String_, BuiltinTypeTag::Int_),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("Set[T]"),
     BuiltinTypeTag::Set_(BuiltinTypeTag::TypeVar(0)),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("Option[Int]"),
     BuiltinTypeTag::Option_(BuiltinTypeTag::Int_),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("Array[T]"),
     BuiltinTypeTag::Array_(BuiltinTypeTag::TypeVar(0)),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("ArrayBuilder[T]"),
     BuiltinTypeTag::ArrayBuilder_(BuiltinTypeTag::TypeVar(0)),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("MapBuilder[T, U]"),
     BuiltinTypeTag::MapBuilder_(
       BuiltinTypeTag::TypeVar(0),
@@ -59,11 +59,11 @@ test "parse_type_tag: container types" {
 
 ///|
 test "parse_type_tag: nested containers" {
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("Array[Array[Int]]"),
     BuiltinTypeTag::Array_(BuiltinTypeTag::Array_(BuiltinTypeTag::Int_)),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("Array[String]"),
     BuiltinTypeTag::Array_(BuiltinTypeTag::String_),
   )
@@ -71,14 +71,14 @@ test "parse_type_tag: nested containers" {
 
 ///|
 test "parse_type_tag: function types" {
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("(T) -> U"),
     BuiltinTypeTag::Fn_(
       [BuiltinTypeTag::TypeVar(0)],
       BuiltinTypeTag::TypeVar(1),
     ),
   )
-  assert_eq(
+  @debug.assert_eq(
     parse_type_tag("(T) -> Bool"),
     BuiltinTypeTag::Fn_([BuiltinTypeTag::TypeVar(0)], BuiltinTypeTag::Bool_),
   )
@@ -90,7 +90,7 @@ test "parse_declare_line: simple builtin" {
     Some(d) => {
       assert_eq(d.name, "String::length")
       @debug.assert_eq(d.params, [BuiltinTypeTag::String_])
-      assert_eq(d.ret, BuiltinTypeTag::Int_)
+      @debug.assert_eq(d.ret, BuiltinTypeTag::Int_)
     }
     None => fail("expected Some")
   }
@@ -102,7 +102,7 @@ test "parse_declare_line: no params" {
     Some(d) => {
       assert_eq(d.name, "array_new")
       assert_eq(d.params.length(), 0)
-      assert_eq(d.ret, BuiltinTypeTag::Array_(BuiltinTypeTag::TypeVar(0)))
+      @debug.assert_eq(d.ret, BuiltinTypeTag::Array_(BuiltinTypeTag::TypeVar(0)))
     }
     None => fail("expected Some")
   }
@@ -114,10 +114,10 @@ test "parse_declare_line: multiple params" {
     Some(d) => {
       assert_eq(d.name, "Array::set")
       assert_eq(d.params.length(), 3)
-      assert_eq(d.params[0], BuiltinTypeTag::Array_(BuiltinTypeTag::TypeVar(0)))
-      assert_eq(d.params[1], BuiltinTypeTag::Int_)
-      assert_eq(d.params[2], BuiltinTypeTag::TypeVar(0))
-      assert_eq(d.ret, BuiltinTypeTag::Unit)
+      @debug.assert_eq(d.params[0], BuiltinTypeTag::Array_(BuiltinTypeTag::TypeVar(0)))
+      @debug.assert_eq(d.params[1], BuiltinTypeTag::Int_)
+      @debug.assert_eq(d.params[2], BuiltinTypeTag::TypeVar(0))
+      @debug.assert_eq(d.ret, BuiltinTypeTag::Unit)
     }
     None => fail("expected Some")
   }
@@ -239,20 +239,20 @@ test "parse_declarations: full declarations sample" {
   assert_eq(decls.length(), 4)
   assert_eq(decls[0].name, "Array::length")
   assert_eq(decls[0].params.length(), 1)
-  assert_eq(
+  @debug.assert_eq(
     decls[0].params[0],
     BuiltinTypeTag::Array_(BuiltinTypeTag::TypeVar(0)),
   )
-  assert_eq(decls[0].ret, BuiltinTypeTag::Int_)
+  @debug.assert_eq(decls[0].ret, BuiltinTypeTag::Int_)
   assert_eq(decls[1].name, "Map::get")
   assert_eq(decls[1].params.length(), 2)
-  assert_eq(
+  @debug.assert_eq(
     decls[1].params[0],
     BuiltinTypeTag::Map_(BuiltinTypeTag::TypeVar(0), BuiltinTypeTag::TypeVar(1)),
   )
   assert_eq(decls[2].name, "Set::new")
   assert_eq(decls[2].params.length(), 0)
-  assert_eq(decls[2].ret, BuiltinTypeTag::Set_(BuiltinTypeTag::TypeVar(0)))
+  @debug.assert_eq(decls[2].ret, BuiltinTypeTag::Set_(BuiltinTypeTag::TypeVar(0)))
   assert_eq(decls[3].name, "Int::parse")
-  assert_eq(decls[3].ret, BuiltinTypeTag::Option_(BuiltinTypeTag::Int_))
+  @debug.assert_eq(decls[3].ret, BuiltinTypeTag::Option_(BuiltinTypeTag::Int_))
 }

--- a/src/cmd/vibe/cli_bench.mbt
+++ b/src/cmd/vibe/cli_bench.mbt
@@ -4,11 +4,6 @@ enum BenchBackend {
 } derive(Debug, Eq)
 
 ///|
-impl Show for BenchBackend with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 struct BenchSourceCase {
   name : String?
   body_source : String

--- a/src/cmd/vibe/cli_check_cmd.mbt
+++ b/src/cmd/vibe/cli_check_cmd.mbt
@@ -151,11 +151,6 @@ enum CliSessionRequestKind {
 } derive(Eq, Debug)
 
 ///|
-impl Show for CliSessionRequestKind with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 struct CliSessionRequest {
   kind : CliSessionRequestKind
   path : String?

--- a/src/cmd/vibe/cli_e2e_wbtest.mbt
+++ b/src/cmd/vibe/cli_e2e_wbtest.mbt
@@ -116,7 +116,7 @@ test "shell meta command ignores non-meta input" {
     "",
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::NotMeta)
+  @debug.assert_eq(result, ReplMetaCommandResult::NotMeta)
   assert_eq(lines.length(), 0)
 }
 
@@ -130,7 +130,7 @@ test "shell meta view resolves current module symbol" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("inc : (x: Int) -> Int"))
 }
@@ -145,7 +145,7 @@ test "shell meta outline defaults to current module" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("outline: current"))
   assert_true(text.contains("\tbase\t"))
@@ -162,7 +162,7 @@ test "shell meta peek reports missing symbol" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   assert_eq(lines.length(), 1)
   assert_eq(lines[0], "symbol not found: __wb_missing_symbol_1")
 }
@@ -176,7 +176,7 @@ test "shell meta unknown command is handled" {
     "",
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   assert_eq(lines.length(), 1)
   assert_eq(lines[0], "unknown command: :unknown")
 }
@@ -258,7 +258,7 @@ test "shell vibe command prints readable help by default" {
     "",
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("vibe commands:"))
   assert_true(text.contains("symbols"))
@@ -279,7 +279,7 @@ test "shell vibe command supports --json for help output" {
     "",
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   assert_eq(lines.length(), 1)
   assert_true(lines[0].contains("\"command\":\"help\""))
   assert_true(lines[0].contains("\"ok\":true"))
@@ -300,7 +300,7 @@ test "shell vibe bare command prints symbols in readable format" {
     "let x = 1\n",
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("local scope (1)"))
   assert_true(text.contains("| kind | name | signature | address |"))
@@ -323,7 +323,7 @@ test "shell vibe symbols supports scope flags for builtin and shell" {
     "let x = 1\n",
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("builtin scope ("))
   assert_true(text.contains("shell commands ("))
@@ -346,7 +346,7 @@ test "shell vibe symbols supports --json output" {
     "let x = 1\n",
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   assert_eq(lines.length(), 1)
   assert_true(lines[0].contains("\"command\":\"symbols\""))
   assert_true(lines[0].contains("\"scopes\":[\"local\"]"))
@@ -370,7 +370,7 @@ test "shell vibe command supports pipeline transform over json payload" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(
     text.contains(
@@ -389,7 +389,7 @@ test "shell meta type prints symbol signature" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("inc : (x: Int) -> Int"))
 }
@@ -410,7 +410,7 @@ test "shell vibe type prints readable signature by default" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("inc : (x: Int) -> Int"))
 }
@@ -431,7 +431,7 @@ test "shell vibe type supports --json output" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   assert_eq(lines.length(), 1)
   assert_true(lines[0].contains("\"command\":\"type\""))
   assert_true(lines[0].contains("\"signature\":\"(x: Int) -> Int\""))
@@ -457,7 +457,7 @@ test "shell vibe normalize accepts entry symbols and drops pure expr stmt" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("normalize: scratch"))
   assert_true(text.contains("let f: (Int) -> Int = (v) -> { v * 2 }"))
@@ -483,7 +483,7 @@ test "shell vibe normalize dedups duplicate lets with last wins" {
     source,
     fn(s) { lines.push(s) },
   )
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_false(text.contains("let x: Int = 3"))
   assert_true(text.contains("let x: Int = 111"))
@@ -570,7 +570,7 @@ test "compiled repl line preserves let bindings across lines" {
     Ok(v) => v
     Err(err) => fail("first compiled repl line failed: " + err)
   }
-  assert_eq(first.value, WasmRunValue::Int(40L))
+  @debug.assert_eq(first.value, WasmRunValue::Int(40L))
   assert_true(@os_fs.path_exists(wasm0))
   let second = match
     run_compiled_repl_line_with_cache(
@@ -583,7 +583,7 @@ test "compiled repl line preserves let bindings across lines" {
     Ok(v) => v
     Err(err) => fail("second compiled repl line failed: " + err)
   }
-  assert_eq(second.value, WasmRunValue::Int(42L))
+  @debug.assert_eq(second.value, WasmRunValue::Int(42L))
   assert_true(@os_fs.path_exists(wasm1))
   assert_true(second.total_us > 0)
   wbtest_remove_if_exists(wasm0)
@@ -605,7 +605,7 @@ test "compiled repl line decodes bool result" {
     Ok(v) => v
     Err(err) => fail("compiled repl bool line failed: " + err)
   }
-  assert_eq(result.value, WasmRunValue::Bool(true))
+  @debug.assert_eq(result.value, WasmRunValue::Bool(true))
   assert_true(@os_fs.path_exists(wasm_path))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
@@ -638,7 +638,7 @@ test "compiled repl line preserves function bindings across lines" {
     Ok(v) => v
     Err(err) => fail("function binding line failed: " + err)
   }
-  assert_eq(fn_binding.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(fn_binding.value, WasmRunValue::Int(0L))
   @debug.assert_eq(fn_binding.display_override, Some("<fn add_x>"))
   let result = match
     run_compiled_repl_line_with_cache(
@@ -651,7 +651,7 @@ test "compiled repl line preserves function bindings across lines" {
     Ok(v) => v
     Err(err) => fail("function call line failed: " + err)
   }
-  assert_eq(result.value, WasmRunValue::Int(42L))
+  @debug.assert_eq(result.value, WasmRunValue::Int(42L))
   wbtest_remove_if_exists(wasm0)
   wbtest_remove_if_exists(wasm1)
   wbtest_remove_if_exists(wasm2)
@@ -691,7 +691,7 @@ test "compiled repl line preserves function alias bindings across lines" {
     Ok(v) => v
     Err(err) => fail("alias binding line failed: " + err)
   }
-  assert_eq(alias_binding.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(alias_binding.value, WasmRunValue::Int(0L))
   @debug.assert_eq(alias_binding.display_override, Some("<bound alias>"))
   let result = match
     run_compiled_repl_line_with_cache(
@@ -704,7 +704,7 @@ test "compiled repl line preserves function alias bindings across lines" {
     Ok(v) => v
     Err(err) => fail("alias call line failed: " + err)
   }
-  assert_eq(result.value, WasmRunValue::Int(42L))
+  @debug.assert_eq(result.value, WasmRunValue::Int(42L))
   wbtest_remove_if_exists(wasm0)
   wbtest_remove_if_exists(wasm1)
   wbtest_remove_if_exists(wasm2)
@@ -726,7 +726,7 @@ test "compiled repl line renders string literal" {
     Ok(v) => v
     Err(err) => fail("compiled repl string literal failed: " + err)
   }
-  assert_eq(result.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(result.value, WasmRunValue::Int(0L))
   @debug.assert_eq(result.display_override, Some("\"hi\""))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
@@ -747,7 +747,7 @@ test "compiled repl line renders string let binding and reuse" {
     Ok(v) => v
     Err(err) => fail("compiled repl string binding failed: " + err)
   }
-  assert_eq(bound.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(bound.value, WasmRunValue::Int(0L))
   @debug.assert_eq(bound.display_override, Some("\"hi\""))
   let reused = match
     run_compiled_repl_line_with_cache(
@@ -760,7 +760,7 @@ test "compiled repl line renders string let binding and reuse" {
     Ok(v) => v
     Err(err) => fail("compiled repl string reuse failed: " + err)
   }
-  assert_eq(reused.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(reused.value, WasmRunValue::Int(0L))
   @debug.assert_eq(reused.display_override, Some("\"hi\""))
   wbtest_remove_if_exists(wasm0)
   wbtest_remove_if_exists(wasm1)
@@ -1066,11 +1066,11 @@ test "cli normalize directory hoists non-index import into index" {
 ///|
 test "cli bench backend parse" {
   match parse_bench_backend("compiled") {
-    Some(backend) => assert_eq(backend, BenchBackend::Wasm)
+    Some(backend) => @debug.assert_eq(backend, BenchBackend::Wasm)
     None => fail("expected compiled backend")
   }
   match parse_bench_backend("wasm") {
-    Some(backend) => assert_eq(backend, BenchBackend::Wasm)
+    Some(backend) => @debug.assert_eq(backend, BenchBackend::Wasm)
     None => fail("expected wasm backend")
   }
   match parse_bench_backend("interpreter") {
@@ -1271,7 +1271,7 @@ test "cli bench parses json output options" {
       assert_eq(opts.runs, 5)
       assert_eq(opts.warmup, 1)
       @debug.assert_eq(opts.case_filters, ["beta"])
-      assert_eq(opts.backend, BenchBackend::Wasm)
+      @debug.assert_eq(opts.backend, BenchBackend::Wasm)
       @debug.assert_eq(opts.paths, ["examples/simple_bench.vibe"])
     }
     Err(err) => fail("parse bench args failed: " + err)

--- a/src/cmd/vibe/cli_repl.mbt
+++ b/src/cmd/vibe/cli_repl.mbt
@@ -66,11 +66,6 @@ enum ReplMetaCommandResult {
 } derive(Debug, Eq)
 
 ///|
-impl Show for ReplMetaCommandResult with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 struct ReplSymbolMatch {
   entry : @frontend.SymbolEntry
   source : String

--- a/src/cmd/vibe/cli_run_cmd.mbt
+++ b/src/cmd/vibe/cli_run_cmd.mbt
@@ -94,11 +94,6 @@ enum WasmRunValue {
 } derive(Debug, Eq)
 
 ///|
-impl Show for WasmRunValue with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 let cli_tagged_run_export_name = "_vibe_run_tagged"
 
 ///|

--- a/src/cmd/vibe/cli_session.mbt
+++ b/src/cmd/vibe/cli_session.mbt
@@ -279,11 +279,6 @@ enum SessionHttpPingState {
 } derive(Eq, Debug)
 
 ///|
-impl Show for SessionHttpPingState with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 fn parse_session_http_ping_state(json : Json) -> SessionHttpPingState {
   match json {
     Json::Object(obj) =>

--- a/src/cmd/vibe/cli_test_cmd.mbt
+++ b/src/cmd/vibe/cli_test_cmd.mbt
@@ -19,11 +19,6 @@ struct CliTestReport {
 } derive(Debug, Eq)
 
 ///|
-impl Show for CliTestReport with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 enum CompiledTestAttempt {
   Success(CliTestReport)
   Unsupported(String)

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -660,7 +660,7 @@ test "shell meta help uses shell terminology" {
   ) {
     lines.push(line)
   })
-  assert_eq(result, ReplMetaCommandResult::HandledContinue)
+  @debug.assert_eq(result, ReplMetaCommandResult::HandledContinue)
   let text = wbtest_join_lines(lines)
   assert_true(text.contains("Exit the shell"))
   assert_false(text.contains("REPL"))
@@ -2726,7 +2726,7 @@ test "compiled test wrapper executes top-level computed let bindings" {
     CompiledTestAttempt::Success(report) => {
       assert_eq(report.total, 1)
       if report.passed != 1 || report.failed != 0 {
-        fail("unexpected compiled report: " + report.to_string())
+        fail("unexpected compiled report: " + Debug::to_repr(report).to_string())
       }
     }
     CompiledTestAttempt::Unsupported(err) =>
@@ -2767,7 +2767,7 @@ test "compiled test wrapper executes closure-captured string condition" {
     CompiledTestAttempt::Success(report) => {
       assert_eq(report.total, 1)
       if report.passed != 1 || report.failed != 0 {
-        fail("unexpected compiled report: " + report.to_string())
+        fail("unexpected compiled report: " + Debug::to_repr(report).to_string())
       }
     }
     CompiledTestAttempt::Unsupported(err) =>
@@ -2804,7 +2804,7 @@ test "compiled test wrapper supports paren string interpolation syntax" {
     CompiledTestAttempt::Success(report) => {
       assert_eq(report.total, 1)
       if report.passed != 1 || report.failed != 0 {
-        fail("unexpected compiled report: " + report.to_string())
+        fail("unexpected compiled report: " + Debug::to_repr(report).to_string())
       }
     }
     CompiledTestAttempt::Unsupported(err) =>
@@ -3146,7 +3146,7 @@ test "compiled test wrapper keeps Map::keys results as strings" {
     CompiledTestAttempt::Success(report) => {
       assert_eq(report.total, 1)
       if report.passed != 1 || report.failed != 0 {
-        fail("unexpected compiled report: " + report.to_string())
+        fail("unexpected compiled report: " + Debug::to_repr(report).to_string())
       }
     }
     CompiledTestAttempt::Unsupported(err) =>
@@ -3861,7 +3861,7 @@ test "session http ping reports worker token" {
     "worker-token",
   )
   assert_false(should_shutdown)
-  assert_eq(
+  @debug.assert_eq(
     parse_session_http_ping_state(json),
     SessionHttpPingState::Alive(Some("worker-token")),
   )
@@ -3941,7 +3941,7 @@ test "cli session request parses check json" {
     Ok(v) => v
     Err(err) => fail("expected check request: " + err)
   }
-  assert_eq(req.kind, CliSessionRequestKind::Check)
+  @debug.assert_eq(req.kind, CliSessionRequestKind::Check)
   @debug.assert_eq(req.path, Some("/tmp/project/main.vibe"))
 }
 
@@ -3954,7 +3954,7 @@ test "cli session request parses run json" {
     Ok(v) => v
     Err(err) => fail("expected run request: " + err)
   }
-  assert_eq(req.kind, CliSessionRequestKind::Run)
+  @debug.assert_eq(req.kind, CliSessionRequestKind::Run)
   @debug.assert_eq(req.path, Some("/tmp/project/main.vibe"))
 }
 
@@ -3964,7 +3964,7 @@ test "cli session request parses shutdown json" {
     Ok(v) => v
     Err(err) => fail("expected shutdown request: " + err)
   }
-  assert_eq(req.kind, CliSessionRequestKind::Shutdown)
+  @debug.assert_eq(req.kind, CliSessionRequestKind::Shutdown)
   @debug.assert_eq(req.path, None)
 }
 
@@ -3974,7 +3974,7 @@ test "cli session request parses ping json" {
     Ok(v) => v
     Err(err) => fail("expected ping request: " + err)
   }
-  assert_eq(req.kind, CliSessionRequestKind::Ping)
+  @debug.assert_eq(req.kind, CliSessionRequestKind::Ping)
   @debug.assert_eq(req.path, None)
 }
 
@@ -4019,7 +4019,7 @@ test "cli session run json roundtrips" {
     Ok(v) => v
     Err(err) => fail("expected parsed int result: " + err)
   }
-  assert_eq(parsed_int, WasmRunValue::Int(42L))
+  @debug.assert_eq(parsed_int, WasmRunValue::Int(42L))
   let parsed_bool = match
     parse_cli_run_value_json(
       make_cli_session_run_result_json(
@@ -4030,7 +4030,7 @@ test "cli session run json roundtrips" {
     Ok(v) => v
     Err(err) => fail("expected parsed bool result: " + err)
   }
-  assert_eq(parsed_bool, WasmRunValue::Bool(true))
+  @debug.assert_eq(parsed_bool, WasmRunValue::Bool(true))
 }
 
 ///|
@@ -4151,7 +4151,7 @@ test "compiled exec keeps >= lowering away from imported or helpers" {
     Some(v) => v
     None => fail("unsupported tagged result: " + tagged.to_string())
   }
-  assert_eq(value, WasmRunValue::Int(1L))
+  @debug.assert_eq(value, WasmRunValue::Int(1L))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(entry_path)
   wbtest_remove_if_exists(helper_path)
@@ -4468,7 +4468,7 @@ test "compiled repl string fallback decodes _start export" {
     Ok(v) => v
     Err(err) => fail("compiled repl string literal failed: " + err)
   }
-  assert_eq(result.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(result.value, WasmRunValue::Int(0L))
   @debug.assert_eq(result.display_override, Some("\"hi\""))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
@@ -4488,7 +4488,7 @@ test "compiled repl array fallback renders duplicate strings" {
     Ok(v) => v
     Err(err) => fail("compiled repl array literal failed: " + err)
   }
-  assert_eq(result.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(result.value, WasmRunValue::Int(0L))
   @debug.assert_eq(result.display_override, Some("[\"hi\", \"hi\"]"))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
@@ -4509,7 +4509,7 @@ test "compiled repl array binding renders on reuse" {
     Ok(v) => v
     Err(err) => fail("compiled repl array binding failed: " + err)
   }
-  assert_eq(bound.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(bound.value, WasmRunValue::Int(0L))
   @debug.assert_eq(bound.display_override, Some("[1, 2]"))
   let reused = match
     run_compiled_repl_line_with_cache(
@@ -4522,7 +4522,7 @@ test "compiled repl array binding renders on reuse" {
     Ok(v) => v
     Err(err) => fail("compiled repl array reuse failed: " + err)
   }
-  assert_eq(reused.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(reused.value, WasmRunValue::Int(0L))
   @debug.assert_eq(reused.display_override, Some("[1, 2]"))
   wbtest_remove_if_exists(wasm0)
   wbtest_remove_if_exists(wasm1)
@@ -4543,7 +4543,7 @@ test "compiled repl map fallback renders entries" {
     Ok(v) => v
     Err(err) => fail("compiled repl map literal failed: " + err)
   }
-  assert_eq(result.value, WasmRunValue::Int(0L))
+  @debug.assert_eq(result.value, WasmRunValue::Int(0L))
   @debug.assert_eq(result.display_override, Some("{|\"a\": 1, \"b\": 2|}"))
   wbtest_remove_if_exists(wasm_path)
   wbtest_remove_if_exists(source_path)
@@ -4593,7 +4593,7 @@ test "compiled repl hoists import entered after prior binding" {
     Ok(v) => v
     Err(err) => fail("late import call failed: " + err)
   }
-  assert_eq(result.value, WasmRunValue::Int(42L))
+  @debug.assert_eq(result.value, WasmRunValue::Int(42L))
   wbtest_remove_if_exists(wasm0)
   wbtest_remove_if_exists(wasm1)
   wbtest_remove_if_exists(wasm2)

--- a/src/cmd/vibe/cli_write_file.mbt
+++ b/src/cmd/vibe/cli_write_file.mbt
@@ -421,7 +421,7 @@ fn load_scratch_write_file_candidates(
     Ok(v) => v
     Err(err) => return Err(err)
   }
-  if not(@os_fs.path_exists(scratch_db_path)) {
+  if !@os_fs.path_exists(scratch_db_path) {
     return Ok([])
   }
   let source = match load_scratch_db_source(scratch_db_path) {

--- a/src/cmd/vibe/normalize_render.mbt
+++ b/src/cmd/vibe/normalize_render.mbt
@@ -166,7 +166,7 @@ fn normalize_render_canonicalize_import_path(path : String) -> String {
   let had_dot_prefix = path.has_prefix("./")
   let parts : Array[String] = []
   for part_view in path.split("/") {
-    let part = part_view.to_string()
+    let part = part_view.to_owned()
     if part == "" || part == "." {
       continue
     }

--- a/src/cmd/vibe_wasm/main.mbt
+++ b/src/cmd/vibe_wasm/main.mbt
@@ -3,13 +3,13 @@ pub enum CommandKind {
   Run
   Compile
   Compare
-} derive(Eq, Show, Debug)
+} derive(Eq, Debug)
 
 ///|
 pub enum RunMode {
   CoreWasm
   Component
-} derive(Eq, Show, Debug)
+} derive(Eq, Debug)
 
 ///|
 pub struct CmdOptions {

--- a/src/cmd/vibe_wasm/main_wbtest.mbt
+++ b/src/cmd/vibe_wasm/main_wbtest.mbt
@@ -70,9 +70,9 @@ test "parse cmd args defaults to run core wasm" {
   let parsed = parse_cmd_args(["examples/hello.vibe"])
   match parsed {
     Ok(opts) => {
-      assert_eq(opts.command, CommandKind::Run)
-      assert_eq(opts.mode, RunMode::CoreWasm)
-      assert_eq(opts.entry_path, "examples/hello.vibe")
+      @debug.assert_eq(opts.command, CommandKind::Run)
+      @debug.assert_eq(opts.mode, RunMode::CoreWasm)
+      @debug.assert_eq(opts.entry_path, "examples/hello.vibe")
       assert_false(opts.keep_artifact)
     }
     Err(msg) => fail("unexpected err: " + msg)
@@ -86,8 +86,8 @@ test "parse cmd args compile component with out and wite" {
   ])
   match parsed {
     Ok(opts) => {
-      assert_eq(opts.command, CommandKind::Compile)
-      assert_eq(opts.mode, RunMode::Component)
+      @debug.assert_eq(opts.command, CommandKind::Compile)
+      @debug.assert_eq(opts.mode, RunMode::Component)
       @debug.assert_eq(opts.out_path, Some("dist/app.component.wasm"))
       @debug.assert_eq(opts.opt_level, Some("-Oz"))
     }
@@ -97,11 +97,11 @@ test "parse cmd args compile component with out and wite" {
 
 ///|
 test "default output path uses mode extension" {
-  assert_eq(
+  @debug.assert_eq(
     default_output_path("examples/hello.vibe", RunMode::CoreWasm),
     "dist/hello.wasm",
   )
-  assert_eq(
+  @debug.assert_eq(
     default_output_path("examples/hello.vibe", RunMode::Component),
     "dist/hello.component.wasm",
   )
@@ -168,7 +168,7 @@ test "snapshot restore rewinds file content" {
   let restored = @os_fs.read_file_to_string(file) catch {
     e => fail("read restored failed: " + e.to_string())
   }
-  assert_eq(restored, "before")
+  @debug.assert_eq(restored, "before")
   wbtest_remove_file_if_exists(file)
 }
 
@@ -253,6 +253,6 @@ test "vibe and vibe_wasm run outputs agree on normalized Int result" {
       )
   }
 
-  assert_eq(wasm_tagged >> 2, vibe_value)
-  assert_eq(component_tagged >> 2, vibe_value)
+  @debug.assert_eq(wasm_tagged >> 2, vibe_value)
+  @debug.assert_eq(component_tagged >> 2, vibe_value)
 }

--- a/src/codebase/codebase_test.mbt
+++ b/src/codebase/codebase_test.mbt
@@ -17,7 +17,7 @@ fn test_repo_root() -> String {
     return cwd
   }
   let gitdir = git_ref[prefix.length():].trim().to_owned()
-  let parts = gitdir.split("/.git/").map(StringView::to_string).collect()
+  let parts = gitdir.split("/.git/").map(StringView::to_owned).collect()
   if parts.length() == 0 || parts[0].length() == 0 {
     return cwd
   }

--- a/src/codebase/lib.mbt
+++ b/src/codebase/lib.mbt
@@ -3,7 +3,7 @@
 fn extract_vibe_from_markdown(markdown : String) -> String {
   let lines : Array[String] = markdown
     .split("\n")
-    .map(StringView::to_string)
+    .map(StringView::to_owned)
     .collect()
   let blocks : Array[String] = []
   let buf : Array[String] = []

--- a/src/codegen/wasm_codegen_expr_effect_wbtest.mbt
+++ b/src/codegen/wasm_codegen_expr_effect_wbtest.mbt
@@ -59,7 +59,7 @@ fn EffectTestCursor::read_bytes(self : EffectTestCursor, n : Int) -> Bytes {
   }
   let view = self.bytes[self.pos:self.pos + n]
   self.pos += n
-  view.to_bytes()
+  view.to_owned()
 }
 
 ///|

--- a/src/codegen/wasm_wat.mbt
+++ b/src/codegen/wasm_wat.mbt
@@ -45,7 +45,7 @@ fn Cursor::read_bytes(self : Cursor, n : Int) -> Bytes raise WasmWatError {
   }
   let view = self.bytes[self.pos:self.pos + n]
   self.pos += n
-  view.to_bytes()
+  view.to_owned()
 }
 
 ///|

--- a/src/loader/lib.mbt
+++ b/src/loader/lib.mbt
@@ -3,7 +3,7 @@
 fn extract_vibe_from_markdown(markdown : String) -> String {
   let lines : Array[String] = markdown
     .split("\n")
-    .map(StringView::to_string)
+    .map(StringView::to_owned)
     .collect()
   let blocks : Array[String] = []
   let buf : Array[String] = []

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -31,11 +31,6 @@ struct WasmEvalResult {
 } derive(Debug, Eq)
 
 ///|
-impl Show for WasmEvalResult with output(self, logger) {
-  logger.write_string(Debug::to_repr(self).to_string())
-}
-
-///|
 struct Cursor {
   bytes : Array[Byte]
   mut pos : Int

--- a/src/tests/vibe_wasm_gc_fixture_test.mbt
+++ b/src/tests/vibe_wasm_gc_fixture_test.mbt
@@ -153,7 +153,7 @@ fn CursorGc::read_bytes(self : CursorGc, n : Int) -> Bytes raise {
   }
   let view = self.bytes[self.pos:self.pos + n]
   self.pos += n
-  view.to_bytes()
+  view.to_owned()
 }
 
 ///|


### PR DESCRIPTION
## Summary

`moon check --target native --release`: **131 → 108 warnings**, 0 errors.

Round 2 of the warning cleanup, focused on the cluster `#392` left behind: 11 `impl Show for X with output(...)` blocks that were only there to silence the prelude `assert_eq` Show requirement. With every caller now on `@debug.assert_eq`, those Show impls themselves became "unused trait implementation" warnings.

## Changes

### `impl Show for X with output(...)` removed (11 sites)

```moonbit
- ///|
- impl Show for BuiltinTypeId with output(self, logger) {
-   logger.write_string(Debug::to_repr(self).to_string())
- }
```

Affected types: `BuiltinTableEntry`, `BuiltinTypeId`, `BuiltinDecl`, `BuiltinTypeTag`, `BenchBackend`, `CliCheckReport`, `CliSessionRequestKind`, `CliTestReport`, `WasmRunValue`, `ReplMetaCommandResult`, `WasmEvalResult`.

### Fallout — wbtest `assert_eq` → `@debug.assert_eq` (93 sites in 4 files)

Removing the Show impls broke prelude-`assert_eq` calls in the wbtests of those packages. Bulk-migrated to `@debug.assert_eq`, same shape as the cluster `#392` already did.

### Fallout — `report.to_string()` → `Debug::to_repr(report).to_string()` (4 sites)

`cli_wbtest.mbt` had `fail("…" + report.to_string())` which routed through the deleted Show. Replaced with the `Debug::to_repr(…)` path.

### `derive(Show)` → `derive(Debug)` only (2 sites)

`CommandKind` and `RunMode` in `cmd/vibe_wasm/main.mbt`. The only Show consumer (`assert_eq` in `main_wbtest.mbt`) is now on `@debug.assert_eq`, plus `derive(Show)` itself is deprecated. Same wbtest got the `assert_eq` migration.

### Bounded deprecations finished off

- `BytesView::to_bytes()` → `to_owned()` (3 sites)
- `StringView::to_string` → `to_owned` (4 sites) — tail of the migration started in #390
- Remaining `not(...)` (3 sites) — slipped through #390 because their spans had been recomputed since

## Verification

- `moon check --target native --release`: **131 → 108 warnings**, 0 errors.
- `mizchi/vibe/checker` 160/160
- `mizchi/vibe/codegen` 74/74
- `mizchi/vibe/cmd/vibe_wasm` 10/10
- `mizchi/vibe/cmd/vibe -f 'session*'` 10/10

## Remaining (108 warnings)

- **47** `Use Debug instead of Show` — `inspect(value, …)` / `value.to_string()` for types whose Show impl is the one deprecated. Needs per-site `derive(Debug)` adds + call-site rewrites.
- **9** false-positive `Unused package alias 'debug'` — wbtest-only usage that moon's unused-detector doesn't follow.
- **7** unused `raise Error` annotations.
- **~36** unused functions kept as scaffolding — needs owner judgement to delete or `#allow(unused)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7y6q8Df9KiLNTK77zR65T)_