### PR TITLE
warnings: round 3 — Debug migration + test-import hygiene (-64 warnings)

### DIFF
--- a/src/checker/moon.pkg
+++ b/src/checker/moon.pkg
@@ -4,7 +4,10 @@ import {
   "mizchi/vibe/parser" @parser,
   "mizchi/vibe/profiler" @profiler,
   "moonbitlang/core/ref" @ref,
-  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/fs" @os_fs,
   "mizchi/vibe/x/scoped_map" @scoped_map,
 }
+
+import {
+  "moonbitlang/core/debug" @debug,
+} for "wbtest"

--- a/src/checker/obligation_solver.mbt
+++ b/src/checker/obligation_solver.mbt
@@ -92,7 +92,7 @@ pub fn TraitWitness::message(self : TraitWitness) -> String {
         "type variable has no trait bounds; expected `" + trait_name + "`"
       } else {
         "type variable bounds " +
-        available.to_string() +
+        Debug::to_repr(available).to_string() +
         " do not include `" +
         trait_name +
         "`"

--- a/src/checker/typecheck_call.mbt
+++ b/src/checker/typecheck_call.mbt
@@ -34,7 +34,7 @@ fn resolve_type_member_call_name(
   effects : EffectScope,
   allow_effect : Bool,
   call_span : @core.Span,
-) -> String? raise TypeError {
+) -> String? {
   if name.contains("::") || name.contains(".") {
     return None
   }

--- a/src/cmd/vibe/cli_tools_cmd.mbt
+++ b/src/cmd/vibe/cli_tools_cmd.mbt
@@ -625,7 +625,7 @@ fn init_cmd(args : Array[String]) -> Unit {
   }
   let root = resolve_project_root_path(target)
   let created = scaffold_project_root(root, false)
-  println("initialized: " + root + " created=" + created.to_string())
+  println("initialized: " + root + " created=" + Debug::to_repr(created).to_string())
 }
 
 ///|
@@ -638,7 +638,7 @@ fn new_cmd(args : Array[String]) -> Unit {
     abort("new: target already exists: " + root)
   }
   let created = scaffold_project_root(root, true)
-  println("created: " + root + " files=" + created.to_string())
+  println("created: " + root + " files=" + Debug::to_repr(created).to_string())
 }
 
 ///|

--- a/src/cmd/vibe/cli_wbtest.mbt
+++ b/src/cmd/vibe/cli_wbtest.mbt
@@ -1909,7 +1909,7 @@ test "normalize fixtures has no stale output files" {
   wbtest_sort_strings(stale_outputs)
   if stale_outputs.length() > 0 {
     fail(
-      "[\{fixture_dir}] stale .out.vibe fixtures found: \{stale_outputs.to_string()}",
+      "[\{fixture_dir}] stale .out.vibe fixtures found: \{Debug::to_repr(stale_outputs).to_string()}",
     )
   }
 }

--- a/src/cmd/vibe/normalize_engine_pass_wbtest.mbt
+++ b/src/cmd/vibe/normalize_engine_pass_wbtest.mbt
@@ -55,7 +55,7 @@ test "pass_select_and_dedup: no entry names keeps all stmts" {
   }
   let result = pass_select_and_dedup(ast, [])
   let expected = ["let:a", "let:b", "let:c"]
-  inspect(wbtest_stmt_summary(result), content=expected.to_string())
+  @debug.debug_inspect(wbtest_stmt_summary(result), content=Debug::to_repr(expected).to_string())
 }
 
 ///|
@@ -104,9 +104,9 @@ test "pass_select_and_dedup: duplicate names dedup last wins" {
       }
     })
     .count()
-  inspect(x_count, content="1")
+  @debug.debug_inspect(x_count, content="1")
   let expected = ["let:x", "let:y"]
-  inspect(wbtest_stmt_summary(result), content=expected.to_string())
+  @debug.debug_inspect(wbtest_stmt_summary(result), content=Debug::to_repr(expected).to_string())
 }
 
 ///|
@@ -205,7 +205,7 @@ test "pass_validate: valid render passes" {
   }
   let rendered = "let x: Int = 1\n"
   let result = pass_validate(source, rendered, ast.stmts)
-  inspect(result, content="Ok(())")
+  @debug.debug_inspect(result, content="Ok(())")
 }
 
 ///|
@@ -291,17 +291,11 @@ test "pass pipeline: full chain produces same result as normalize_source_text" {
     }
   }
   let actual : Result[String, String] = Ok(rendered)
-  inspect(
+  @debug.debug_inspect(
     actual,
     content=(
-      #|Ok(//# Functions
-      #|
-      #|let a: () -> Int = () -> { 42 }
-      #|
-      #|let b: () -> Int = () -> { a() }
-      #|
-      #|let z: () -> Int = () -> { b() }
-      #|)
+      #|Ok("//# Functions\n\nlet a: () -> Int = () -> { 42 }\n\nlet b: () -> Int = () -> { a() }\n\nlet z: () -> Int = () -> { b() }\n")
+
     ),
   )
 }

--- a/src/cmd/vibe/normalize_engine_wbtest.mbt
+++ b/src/cmd/vibe/normalize_engine_wbtest.mbt
@@ -24,13 +24,11 @@ fn ne_substring_index(haystack : String, needle : String) -> Int {
 test "normalize_engine: format basic let binding" {
   let source = "let   x  =  1"
   let result = normalize_source_text(source)
-  inspect(
+  @debug.debug_inspect(
     result,
     content=(
-      #|Ok(//# Functions
-      #|
-      #|let x: Int = 1
-      #|)
+      #|Ok("//# Functions\n\nlet x: Int = 1\n")
+
     ),
   )
 }
@@ -41,15 +39,11 @@ test "normalize_engine: format multiple let bindings with spacing" {
     #|let a  = 1
     #|let b  = 2
   let result = normalize_source_text(source)
-  inspect(
+  @debug.debug_inspect(
     result,
     content=(
-      #|Ok(//# Functions
-      #|
-      #|let a: Int = 1
-      #|
-      #|let b: Int = 2
-      #|)
+      #|Ok("//# Functions\n\nlet a: Int = 1\n\nlet b: Int = 2\n")
+
     ),
   )
 }
@@ -59,13 +53,11 @@ test "normalize_engine: constant folding for addition" {
   let source =
     #|let value = 1 + 2
   let result = normalize_source_text(source)
-  inspect(
+  @debug.debug_inspect(
     result,
     content=(
-      #|Ok(//# Functions
-      #|
-      #|let value: Int = 3
-      #|)
+      #|Ok("//# Functions\n\nlet value: Int = 3\n")
+
     ),
   )
 }
@@ -75,13 +67,11 @@ test "normalize_engine: constant folding for multiplication" {
   let source =
     #|let value = 3 * 4
   let result = normalize_source_text(source)
-  inspect(
+  @debug.debug_inspect(
     result,
     content=(
-      #|Ok(//# Functions
-      #|
-      #|let value: Int = 12
-      #|)
+      #|Ok("//# Functions\n\nlet value: Int = 12\n")
+
     ),
   )
 }
@@ -185,13 +175,11 @@ test "normalize_engine: inferred annotation on non-fn let" {
   let source =
     #|let answer = 40 + 2
   let result = normalize_source_text(source)
-  inspect(
+  @debug.debug_inspect(
     result,
     content=(
-      #|Ok(//# Functions
-      #|
-      #|let answer: Int = 42
-      #|)
+      #|Ok("//# Functions\n\nlet answer: Int = 42\n")
+
     ),
   )
 }
@@ -460,10 +448,11 @@ test "normalize_engine: empty source returns empty string" {
   let result = normalize_source_text(source)
   let expected =
     #|Ok("")
-  inspect(
+  @debug.debug_inspect(
     result,
     content=(
-      #|Ok()
+      #|Ok("")
+
     ),
   )
 }
@@ -473,13 +462,11 @@ test "normalize_engine: constant folding subtraction" {
   let source =
     #|let value = 10 - 3
   let result = normalize_source_text(source)
-  inspect(
+  @debug.debug_inspect(
     result,
     content=(
-      #|Ok(//# Functions
-      #|
-      #|let value: Int = 7
-      #|)
+      #|Ok("//# Functions\n\nlet value: Int = 7\n")
+
     ),
   )
 }

--- a/src/codegen/moon.pkg
+++ b/src/codegen/moon.pkg
@@ -2,5 +2,8 @@ import {
   "mizchi/vibe/core" @core,
   "mizchi/vibe/profiler" @profiler,
   "moonbitlang/core/encoding/utf8" @utf8,
-  "moonbitlang/core/debug" @debug,
 }
+
+import {
+  "moonbitlang/core/debug" @debug,
+} for "wbtest"

--- a/src/codegen/wasm_codegen_rc_wbtest.mbt
+++ b/src/codegen/wasm_codegen_rc_wbtest.mbt
@@ -29,11 +29,11 @@ test "RC codegen: build_rc_action_maps parses site strings" {
   let pre_top = pre.get("").unwrap_or({})
   let post_top = post.get("").unwrap_or({})
   // stmt[1].old_value → pre[""][1]
-  inspect(pre_top.get(1).map(fn(a) { a.length() }), content="Some(1)")
+  @debug.debug_inspect(pre_top.get(1).map(fn(a) { a.length() }), content="Some(1)")
   // stmt[0].after → post[""][0]
-  inspect(post_top.get(0).map(fn(a) { a.length() }), content="Some(1)")
+  @debug.debug_inspect(post_top.get(0).map(fn(a) { a.length() }), content="Some(1)")
   // stmt[2].before → post[""][2] (not old_value, so it's post)
-  inspect(post_top.get(2).map(fn(a) { a.length() }), content="Some(1)")
+  @debug.debug_inspect(post_top.get(2).map(fn(a) { a.length() }), content="Some(1)")
 }
 
 ///|
@@ -91,10 +91,11 @@ test "RC codegen: perceus plan actions emit dup/drop at stmt boundaries" {
   inspect(pre.length(), content="0")
   inspect(post.length(), content="1")
   let post_top = post.get("").unwrap_or({})
-  inspect(
+  @debug.debug_inspect(
     post_top.get(1).map(fn(a) { a[0].name }),
     content=(
-      #|Some(x)
+      #|Some("x")
+
     ),
   )
   // Compile with RC + actions
@@ -330,13 +331,13 @@ test "RC codegen: build_rc_action_maps separates old_value into pre-actions" {
   let pre_top = pre.get("").unwrap_or({})
   let post_top = post.get("").unwrap_or({})
   // old_value → pre-action
-  inspect(pre_top.get(0).map(fn(a) { a.length() }), content="Some(1)")
-  inspect(pre_top.get(0).map(fn(a) { a[0].kind }), content="Some(Drop)")
+  @debug.debug_inspect(pre_top.get(0).map(fn(a) { a.length() }), content="Some(1)")
+  @debug.debug_inspect(pre_top.get(0).map(fn(a) { a[0].kind }), content="Some(Drop)")
   // after → post-action
-  inspect(post_top.get(0).map(fn(a) { a.length() }), content="Some(1)")
+  @debug.debug_inspect(post_top.get(0).map(fn(a) { a.length() }), content="Some(1)")
   // before (dup) → post-action
-  inspect(post_top.get(1).map(fn(a) { a.length() }), content="Some(1)")
-  inspect(post_top.get(1).map(fn(a) { a[0].kind }), content="Some(Dup)")
+  @debug.debug_inspect(post_top.get(1).map(fn(a) { a.length() }), content="Some(1)")
+  @debug.debug_inspect(post_top.get(1).map(fn(a) { a[0].kind }), content="Some(Dup)")
 }
 
 ///|
@@ -393,13 +394,14 @@ test "RC codegen: build_rc_action_maps groups multiple actions on same stmt" {
   let post_top = post.get("").unwrap_or({})
   let pre_top = pre.get("").unwrap_or({})
   // Two post actions on stmt 2 (drop x, dup y)
-  inspect(post_top.get(2).map(fn(a) { a.length() }), content="Some(2)")
+  @debug.debug_inspect(post_top.get(2).map(fn(a) { a.length() }), content="Some(2)")
   // One pre action on stmt 2 (old_value drop z)
-  inspect(pre_top.get(2).map(fn(a) { a.length() }), content="Some(1)")
-  inspect(
+  @debug.debug_inspect(pre_top.get(2).map(fn(a) { a.length() }), content="Some(1)")
+  @debug.debug_inspect(
     pre_top.get(2).map(fn(a) { a[0].name }),
     content=(
-      #|Some(z)
+      #|Some("z")
+
     ),
   )
 }
@@ -415,10 +417,11 @@ test "RC codegen: build_rc_action_maps skips invalid site strings" {
   assert_eq(pre.length(), 0)
   assert_eq(post.length(), 1)
   let post_top = post.get("").unwrap_or({})
-  inspect(
+  @debug.debug_inspect(
     post_top.get(0).map(fn(a) { a[0].name }),
     content=(
-      #|Some(y)
+      #|Some("y")
+
     ),
   )
 }
@@ -434,34 +437,38 @@ test "RC codegen: build_rc_action_maps handles nested site paths" {
   let (pre, post) = build_rc_action_maps(actions)
   // Top-level action
   let post_top = post.get("").unwrap_or({})
-  inspect(
+  @debug.debug_inspect(
     post_top.get(0).map(fn(a) { a[0].name }),
     content=(
-      #|Some(x)
+      #|Some("x")
+
     ),
   )
   // Nested body action
   let post_body = post.get("stmt[2].expr.body").unwrap_or({})
-  inspect(
+  @debug.debug_inspect(
     post_body.get(0).map(fn(a) { a[0].name }),
     content=(
-      #|Some(y)
+      #|Some("y")
+
     ),
   )
   // Nested old_value → pre
   let pre_body = pre.get("stmt[2].expr.body").unwrap_or({})
-  inspect(
+  @debug.debug_inspect(
     pre_body.get(1).map(fn(a) { a[0].name }),
     content=(
-      #|Some(z)
+      #|Some("z")
+
     ),
   )
   // Nested else action
   let post_else = post.get("stmt[3].else").unwrap_or({})
-  inspect(
+  @debug.debug_inspect(
     post_else.get(0).map(fn(a) { a[0].name }),
     content=(
-      #|Some(w)
+      #|Some("w")
+
     ),
   )
 }

--- a/src/codegen/wasm_gc_codegen.mbt
+++ b/src/codegen/wasm_gc_codegen.mbt
@@ -327,7 +327,7 @@ fn emit_coerce_top_gc(
   buf : GcByteBuf,
   actual_kind : GcValKind,
   expected_kind : GcValKind,
-) -> Unit raise WasmGenError {
+) -> Unit {
   if actual_kind == expected_kind {
     return
   }

--- a/src/core/ast_walker_wbtest.mbt
+++ b/src/core/ast_walker_wbtest.mbt
@@ -24,10 +24,11 @@ test "walk_expr_refs collects free variable from Ident" {
     refs,
     add_all_refs,
   )
-  inspect(
+  @debug.debug_inspect(
     refs.keys().collect(),
     content=(
-      #|[x]
+      #|["x"]
+
     ),
   )
 }
@@ -43,7 +44,7 @@ test "walk_expr_refs skips bound variable" {
     refs,
     add_all_refs,
   )
-  inspect(refs.keys().collect(), content="[]")
+  @debug.debug_inspect(refs.keys().collect(), content="[]")
 }
 
 ///|
@@ -68,10 +69,11 @@ test "walk_expr_refs collects call name and arg refs" {
   )
   let keys = refs.keys().collect()
   keys.sort()
-  inspect(
+  @debug.debug_inspect(
     keys,
     content=(
-      #|[a, f]
+      #|["a", "f"]
+
     ),
   )
 }
@@ -107,7 +109,7 @@ test "walk_expr_refs fn params bind correctly" {
     refs,
     add_all_refs,
   )
-  inspect(refs.keys().collect(), content="[]")
+  @debug.debug_inspect(refs.keys().collect(), content="[]")
 }
 
 ///|
@@ -144,10 +146,11 @@ test "walk_expr_refs match arm binds pattern names" {
   let keys = refs.keys().collect()
   keys.sort()
   // "val" (scrutinee) and "f" (call), but "x" is bound by pattern
-  inspect(
+  @debug.debug_inspect(
     keys,
     content=(
-      #|[f, val]
+      #|["f", "val"]
+
     ),
   )
 }
@@ -175,10 +178,11 @@ test "walk_block_refs let binding scopes correctly" {
     add_all_refs,
   )
   // "a" is free, "x" is bound by the let
-  inspect(
+  @debug.debug_inspect(
     refs.keys().collect(),
     content=(
-      #|[a]
+      #|["a"]
+
     ),
   )
 }
@@ -198,10 +202,11 @@ test "bind_pattern_names_walker binds nested patterns" {
   )
   let keys = bound.keys().collect()
   keys.sort()
-  inspect(
+  @debug.debug_inspect(
     keys,
     content=(
-      #|[a, b]
+      #|["a", "b"]
+
     ),
   )
 }

--- a/src/core/deserialize.mbt
+++ b/src/core/deserialize.mbt
@@ -980,7 +980,7 @@ fn parse_import_kind(kind : String?) -> ImportKind raise DeserializeError {
 fn expect_object(json : Json) -> Map[String, Json] raise DeserializeError {
   match json {
     Json::Object(obj) => obj
-    _ => raise DeserializeError("Expected object, got: " + json.to_string())
+    _ => raise DeserializeError("Expected object, got: " + Debug::to_repr(json).to_string())
   }
 }
 

--- a/src/core/moon.pkg
+++ b/src/core/moon.pkg
@@ -2,6 +2,9 @@ import {
   "mizchi/bit" @bit,
   "mizchi/vibe/x/fp" @fp,
   "moonbitlang/core/json" @json,
-  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/path" @path,
 }
+
+import {
+  "moonbitlang/core/debug" @debug,
+} for "wbtest"

--- a/src/frontend/moon.pkg
+++ b/src/frontend/moon.pkg
@@ -1,6 +1,9 @@
 import {
   "mizchi/vibe/core" @core,
   "mizchi/vibe/checker" @checker,
+}
+
+import {
   "mizchi/vibe/parser" @parser,
   "moonbitlang/core/debug" @debug,
-}
+} for "wbtest"

--- a/src/frontend/perceus_poc_wbtest.mbt
+++ b/src/frontend/perceus_poc_wbtest.mbt
@@ -181,10 +181,11 @@ test "perceus plan: unused let binding gets drop" {
     ],
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[0].after drop x]
+      #|["stmt[0].after drop x"]
+
     ),
   )
 }
@@ -207,7 +208,7 @@ test "perceus plan: single use, no dup needed" {
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // Single use → no dup, no drop
-  inspect(lines, content="[]")
+  @debug.debug_inspect(lines, content="[]")
 }
 
 ///|
@@ -231,10 +232,11 @@ test "perceus plan: two sequential uses, first gets dup" {
     ],
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[1].expr.arg[0].before dup x]
+      #|["stmt[1].expr.arg[0].before dup x"]
+
     ),
   )
 }
@@ -269,10 +271,11 @@ test "perceus plan: if/else branch-sensitive drop" {
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // x is used in then but not in else → drop in else branch
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[1].expr.else.end drop x]
+      #|["stmt[1].expr.else.end drop x"]
+
     ),
   )
 }
@@ -318,10 +321,14 @@ test "perceus plan: if/else both use x, then also uses after → dup" {
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // x used in both branches (1 each) + 1 after = 2 total uses
   // First use in then branch dups, first use in else branch dups
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[1].expr.then.stmt[0].expr.arg[0].before dup x, stmt[1].expr.else.stmt[0].expr.arg[0].before dup x]
+      #|[
+      #|  "stmt[1].expr.then.stmt[0].expr.arg[0].before dup x",
+      #|  "stmt[1].expr.else.stmt[0].expr.arg[0].before dup x",
+      #|]
+
     ),
   )
 }
@@ -364,10 +371,15 @@ test "perceus plan: match with two arms, only one uses x" {
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // x used in arm[0] but not arm[1] → drop in arm[1]
   // a and b are unused pattern bindings → drop at scope end
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[1].expr.arm[0].pat_bind drop a, stmt[1].expr.arm[1].pat_bind drop b, stmt[1].expr.arm[1].end drop x]
+      #|[
+      #|  "stmt[1].expr.arm[0].pat_bind drop a",
+      #|  "stmt[1].expr.arm[1].pat_bind drop b",
+      #|  "stmt[1].expr.arm[1].end drop x",
+      #|]
+
     ),
   )
 }
@@ -397,10 +409,11 @@ test "perceus plan: scope-end drop in block" {
     ],
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[0].expr.body.stmt[0].after drop z]
+      #|["stmt[0].expr.body.stmt[0].after drop z"]
+
     ),
   )
 }
@@ -424,10 +437,11 @@ test "perceus plan: mutable reassignment drops old value" {
     ],
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[0].after drop x, stmt[1].old_value drop x]
+      #|["stmt[0].after drop x", "stmt[1].old_value drop x"]
+
     ),
   )
 }
@@ -458,10 +472,14 @@ test "perceus plan: three uses need two dups" {
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // 3 uses → dup before 1st and 2nd, last use is a move
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[1].expr.arg[0].before dup x, stmt[2].expr.arg[0].before dup x]
+      #|[
+      #|  "stmt[1].expr.arg[0].before dup x",
+      #|  "stmt[2].expr.arg[0].before dup x",
+      #|]
+
     ),
   )
 }
@@ -618,7 +636,7 @@ test "perceus plan: for-in loop drops iterable when unused after" {
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // xs is consumed by the for-in, x is consumed inside body → no dup/drop needed
-  inspect(lines, content="[]")
+  @debug.debug_inspect(lines, content="[]")
 }
 
 ///|
@@ -690,10 +708,11 @@ test "perceus plan: multiple variables, only unused ones get drops" {
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // Only y gets dropped (unused), x is consumed exactly once
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[1].after drop y]
+      #|["stmt[1].after drop y"]
+
     ),
   )
 }
@@ -748,7 +767,7 @@ test "perceus plan: nested if/else with inner variable" {
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // x used exactly once in each path → no dup needed
-  inspect(lines, content="[]")
+  @debug.debug_inspect(lines, content="[]")
 }
 
 ///|
@@ -1020,10 +1039,11 @@ test "perceus plan: tuple field access borrows — no dup for t.0 + t.1" {
   }
   let lines = perceus_action_lines(build_perceus_plan(mod))
   // No dup should be emitted — both uses are borrows
-  inspect(
+  @debug.debug_inspect(
     lines,
     content=(
-      #|[stmt[1].scope_end drop t]
+      #|["stmt[1].scope_end drop t"]
+
     ),
   )
 }

--- a/src/io/moon.pkg
+++ b/src/io/moon.pkg
@@ -1,7 +1,10 @@
 import {
   "mizchi/vibe/backend" @backend,
   "moonbitlang/core/env" @env,
-  "moonbitlang/core/debug" @debug,
   "moonbitlang/x/fs" @os_fs,
   "moonbitlang/x/sys" @sys,
 }
+
+import {
+  "moonbitlang/core/debug" @debug,
+} for "test"

--- a/src/loader/moon.pkg
+++ b/src/loader/moon.pkg
@@ -7,10 +7,10 @@ import {
   "mizchi/vibe/parser" @parser,
   "mizchi/vibe/runtime" @runtime,
   "moonbitlang/core/json" @json,
-  "moonbitlang/core/debug" @debug,
 }
 
 import {
   "mizchi/vibe/runtime_compile" @runtime_compile,
   "moonbitlang/x/fs" @os_fs,
+  "moonbitlang/core/debug" @debug,
 } for "test"

--- a/src/lsp/moon.pkg
+++ b/src/lsp/moon.pkg
@@ -3,5 +3,8 @@ import {
   "mizchi/vibe/parser",
   "mizchi/vibe/checker",
   "mizchi/vibe/frontend",
-  "moonbitlang/core/debug" @debug,
 }
+
+import {
+  "moonbitlang/core/debug" @debug,
+} for "wbtest"

--- a/src/parser/moon.pkg
+++ b/src/parser/moon.pkg
@@ -3,5 +3,8 @@ import {
   "mizchi/vibe/core" @core,
   "moonbitlang/core/ref" @ref,
   "moonbitlang/core/string" @string,
-  "moonbitlang/core/debug" @debug,
 }
+
+import {
+  "moonbitlang/core/debug" @debug,
+} for "wbtest"

--- a/src/runtime/compiler_hooks.mbt
+++ b/src/runtime/compiler_hooks.mbt
@@ -93,7 +93,7 @@ pub fn desugar_method_calls(
 let parse_ast_hook : Ref[
   (String) -> (@core.Module, @core.Diagnostic?) raise Error,
 ] = {
-  val: fn(_source) -> (@core.Module, @core.Diagnostic?) raise Error {
+  val: fn(_source) -> (@core.Module, @core.Diagnostic?) {
     ({ stmts: [] }, None)
   },
 }
@@ -240,7 +240,7 @@ pub fn hook_get_prelude_env() -> @checker.TypeEnv {
 let type_check_with_env_hook : Ref[
   (@checker.TypeEnv, @core.Module, Map[String, @core.Ref]) -> @checker.TypeEnv raise @checker.TypeError,
 ] = {
-  val: fn(env, _ast, _aliases) -> @checker.TypeEnv raise @checker.TypeError {
+  val: fn(env, _ast, _aliases) -> @checker.TypeEnv {
     env
   },
 }

--- a/src/runtime/test_hooks_wbtest.mbt
+++ b/src/runtime/test_hooks_wbtest.mbt
@@ -9,7 +9,7 @@ fn init {
   // Parser hooks
   parse_ast_hook.val = fn(
     source,
-  ) -> (@core.Module, @core.Diagnostic?) raise Error {
+  ) -> (@core.Module, @core.Diagnostic?) {
     let ast = @parser.parse_ast(source) catch {
       e => return ({ stmts: [] }, Some(e.diagnostic()))
     }

--- a/src/runtime_compile/hooks.mbt
+++ b/src/runtime_compile/hooks.mbt
@@ -18,7 +18,7 @@ pub fn init_hooks() -> Unit {
   // Parser
   @runtime.set_parse_ast_hook(fn(
     source,
-  ) -> (@core.Module, @core.Diagnostic?) raise Error {
+  ) -> (@core.Module, @core.Diagnostic?) {
     let ast = @parser.parse_ast(source) catch {
       e => return ({ stmts: [] }, Some(e.diagnostic()))
     }

--- a/src/tests/fixture_test.mbt
+++ b/src/tests/fixture_test.mbt
@@ -473,6 +473,6 @@ test "fixtures has no stale todo files" {
   }
   sort_strings(stale)
   if stale.length() > 0 {
-    fail("[fixtures] stale todo fixtures found: \{stale.to_string()}")
+    fail("[fixtures] stale todo fixtures found: \{Debug::to_repr(stale).to_string()}")
   }
 }

--- a/src/x/scoped_map/moon.pkg
+++ b/src/x/scoped_map/moon.pkg
@@ -1,3 +1,6 @@
 import {
-  "moonbitlang/core/debug" @debug,
 }
+
+import {
+  "moonbitlang/core/debug" @debug,
+} for "test"


### PR DESCRIPTION
## Summary

`moon check --target native --release`: **108 → 44 warnings**, 0 errors.

Round 3 of the warning cleanup, finishing off:
- The remaining `Use Debug instead of Show` cluster (47 sites)
- The 9 false-positive `Unused package alias 'debug'` (now via `for "wbtest"` / `for "test"` import blocks)
- 6 of 7 `unused_error_type` annotations
- Various tails from earlier rounds

## Changes

### `inspect(...)` → `@debug.debug_inspect(...)` (44 sites)

The prelude `inspect[T : Show]` is deprecated for debugging output. Iterated `moon check --output-json` → rewrite at the exact warning span → repeat until converged.

### `.to_string()` → `Debug::to_repr(x).to_string()` (8 sites)

Log / error strings that concat values via `Show::to_string` — routed through Debug.

### `raise <ErrorType>` removed where unused (6 sites)

`checker/typecheck_call`, `codegen/wasm_gc_codegen`, three closure literals in `runtime/compiler_hooks` and `runtime/test_hooks_wbtest` and `runtime_compile/hooks`. Kept `runtime_compile/compile::CompileError` because callers catch + re-raise.

### `@debug` import → `for "wbtest"` / `for "test"` blocks

The 9 `Unused package alias 'debug'` warnings were a false positive — `@debug.assert_eq` is only called from `_wbtest.mbt` / `_test.mbt` files, but moon's unused-detector reads only main-file `.mbt` sources. Per-flavour import blocks fix this cleanly:
- `for "wbtest"`: checker, codegen, core, frontend, lsp, parser
- `for "test"`: io, loader (merged into existing test block), x/scoped_map

Same false positive for `@parser` in `frontend/moon.pkg` (only used in wbtest); also moved.

### Tail fixes from earlier rounds

- 3 `BytesView::to_bytes()` → `to_owned()`
- 4 `StringView::to_string` → `to_owned`
- 3 leftover `not(...)` rewrites (spans had moved since #390)
- 2 `derive(Show)` → `derive(Debug)` (`CommandKind`, `RunMode` in vibe_wasm)
- 11 `impl Show for X` Show-collateral fixups (e.g. `report.to_string()`, `assert_eq(opts.command, …)`) from #393

## Test snapshots regenerated

`@debug.debug_inspect` formats `Array[String]` as `["x", "y"]` where prelude `inspect` produced `[x, y]`. Ran `moon test --update` on affected packages — 10 snapshot regens in `perceus_poc_wbtest.mbt`, 11 in `wasm_codegen_rc_wbtest.mbt`. New snapshots match the Debug-flavoured output downstream tooling actually consumes.

## Verification

| target | result |
|---|---|
| `moon check --release` | **108 → 44 warnings**, 0 errors |
| `mizchi/vibe/checker` | 160/160 |
| `mizchi/vibe/frontend` | 83/83 |
| `mizchi/vibe/codegen` | 74/74 |
| `mizchi/vibe/loader` | 52/52 |
| `mizchi/vibe/io` | 4/4 |
| `mizchi/vibe/cmd/vibe -f 'session*'` | 10/10 |
| `mizchi/vibe/tests` (target=js) | 257/257 |

## Remaining (44 warnings)

- 37 `unused_value` — mostly intentionally-kept scaffolding (codegen `emit_*` helpers, runtime/store `threads_*`, etc.)
- 3 `unused_field`
- 1 each: `unused_try`, `unused_error_type`, `unused_attribute`, `deprecated`

Owner judgement needed to delete vs `pub` vs `#allow(unused)`; outside this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7y6q8Df9KiLNTK77zR65T)_