### PR TITLE
pkspec: migrate VibeTest.pkl to v0.3.0 Test.body schema

### DIFF
--- a/.github/workflows/pkfire-pkspec.yml
+++ b/.github/workflows/pkfire-pkspec.yml
@@ -37,7 +37,13 @@ jobs:
         uses: mizchi/pkfire@v0.10.0
 
       - name: Install pkspec
-        uses: mizchi/pkspec@v0.2.0
+        # Pinned to v0.3.0: the v0.3.0 binary introduced the typed
+        # `Test.body: TestBody?` schema replacing flat `Test.cmd`.
+        # `mizchi/pkspec@v0.2.0` was floating to install v0.3.0 anyway
+        # (its `normalize()` falls through `latest()` for unknown
+        # ref patterns), so this pin just makes the workflow match
+        # reality. VibeTest.pkl uses the v0.3.0 schema.
+        uses: mizchi/pkspec@v0.3.0
         with:
           init-schema-dir: pkspec
 

--- a/pkspec/VibeTest.pkl
+++ b/pkspec/VibeTest.pkl
@@ -31,7 +31,7 @@ local function pkgTest(pkg: String) = new Test {
   specRef { "VIBE-TEST-PKG-\(pkg.replaceAll("/", "-").toUpperCase())" }
   retries = 0
   timeoutSec = 600
-  cmd = "moon test --target native -p mizchi/vibe/\(pkg)"
+  body = new CmdTest { cmd = "moon test --target native -p mizchi/vibe/\(pkg)" }
 }
 
 tests {
@@ -41,7 +41,7 @@ tests {
     specRef { "VIBE-TEST-NATIVE" }
     retries = 0
     timeoutSec = 1800
-    cmd = "moon test --target native"
+    body = new CmdTest { cmd = "moon test --target native" }
   }
 
   // Whole-suite JS-target run — matches the flaker runner command.
@@ -51,7 +51,7 @@ tests {
     retries = 1
     flakyAcceptable = false
     timeoutSec = 1800
-    cmd = "moon test --target js -v"
+    body = new CmdTest { cmd = "moon test --target js -v" }
   }
 
   for (p in Packages.all) {


### PR DESCRIPTION
Unblocks the `pkfire / pkspec validation` workflow for every PR that touches Taskfile.pkl (which is most selfhost / bench infra work).

## Problem

`mizchi/pkspec@v0.2.0` (the GitHub Action pin) floats: its `normalize()` ref resolver doesn't recognize `v0.2.0` as a binary tag and falls through to `latest()`, which installs **pkspec v0.3.0** of the underlying Go binary. pkspec v0.3.0 broke the flat `Test.cmd` slot in favor of a typed `Test.body: TestBody?` (one of `CmdTest` / `SequentialTest` / `ParallelTest`).

Result: `pkspec check pkspec/VibeSpec.pkl pkspec/VibeTest.pkl` fails on every PR that touches Taskfile.pkl with:
```
Cannot find property `body` in object of type `pkspec.Test#Test`
```
(Available properties under v0.3.0 schema; the file uses v0.2.0 `cmd` syntax.)

PRs #403, #404, and #405 all merged through this broken state because the workflow isn't in `ci-required` — but the red X on every relevant PR is noise.

## Fix

1. **`pkspec/VibeTest.pkl`** — migrate three `Test` entries from `cmd = "..."` to `body = new CmdTest { cmd = "..." }`. Mechanical edit, no semantic change.
2. **`.github/workflows/pkfire-pkspec.yml`** — bump action pin `@v0.2.0` → `@v0.3.0` to match the binary version that's actually installed.

## Compatibility

**Forward-only.** v0.2.0 has flat `cmd`; v0.3.0 has typed `body`. Confirmed locally — feeding the migrated `VibeTest.pkl` into pkspec v0.2.0 now reports `Cannot find property body`, matching the symmetric error the other direction.

Anyone with a stale v0.2.0 install needs `go install github.com/mizchi/pkspec/cmd/pkspec@v0.3.0`. The Action change in this PR forces CI onto v0.3.0 explicitly.

## Verified locally (pkspec v0.3.0)

- `pkspec check pkspec/VibeSpec.pkl pkspec/VibeTest.pkl` → `all 34 declared spec(s) have an implementation`
- `pkspec coverage` → `34 / 34 specs implemented (100%)`
- `pkf format --check Taskfile.pkl pkspec/VibeTest.pkl pkspec/VibeSpec.pkl` → exit 0

## Test plan

- [x] Local: pkspec v0.3.0 check + coverage green
- [x] Local: pkf format --check on touched files clean
- [x] Cross-check: pkspec v0.2.0 produces the expected forward-only error
- [ ] CI: `validate Pkl configs` step green (this is the gate the PR exists to fix)

https://claude.ai/code/session_01HPXnQJ1WF1LEAdeUqRtLv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPXnQJ1WF1LEAdeUqRtLv8)_