### PR TITLE
Build moonrun_wt in byte parity gate

### DIFF
--- a/scripts/test_vibe_check_selfhost_byte_parity.sh
+++ b/scripts/test_vibe_check_selfhost_byte_parity.sh
@@ -39,8 +39,11 @@ if [ ! -f "$WASI_OPT" ] || \
 fi
 
 if [ ! -x "$MOONRUN_WT" ]; then
-  echo "[byte-parity] moonrun_wt not built at $MOONRUN_WT" >&2
-  echo "[byte-parity] build with 'cargo build --release --manifest-path tools/moonrun_wasmtime/Cargo.toml'" >&2
+  echo "[byte-parity] building moonrun_wt..." >&2
+  cargo build --release --manifest-path "$PROJECT_ROOT/tools/moonrun_wasmtime/Cargo.toml" >&2
+fi
+if [ ! -x "$MOONRUN_WT" ]; then
+  echo "[byte-parity] moonrun_wt build did not produce $MOONRUN_WT" >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary
- make the vibe check selfhost byte-parity gate build moonrun_wt when it is absent in a clean CI checkout
- keep the explicit failure if cargo build does not produce the expected binary

## Validation
- scripts/test_vibe_check_selfhost_byte_parity.sh
- attempted clean CARGO_TARGET_DIR build path; local Rust 1.92 is below moonrun_wt MSRV 1.93, while CI uses stable 1.95