### PR TITLE
CI selfhost gates and base64 speedups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,10 +166,54 @@ jobs:
       - name: Smoke test wasm/vibe with wasmtime
         run: ./scripts/test_wasm_vibe_wasmtime.sh wasm/vibe/vibe.wasm
 
+  native-cli-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Vibe toolchain
+        uses: ./.github/actions/setup-vibe
+        with:
+          moon-build-cache: 'true'
+
+      - name: Build vibe CLI (native release)
+        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+
+      - name: Upload native CLI release
+        uses: actions/upload-artifact@v6
+        with:
+          name: native-cli-release
+          path: target/native/release/build/cmd/vibe/vibe.exe
+          if-no-files-found: error
+          retention-days: 1
+
+  native-cli-debug:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Vibe toolchain
+        uses: ./.github/actions/setup-vibe
+        with:
+          moon-build-cache: 'true'
+
+      - name: Build vibe CLI (native debug)
+        run: VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+
+      - name: Upload native CLI debug
+        uses: actions/upload-artifact@v6
+        with:
+          name: native-cli-debug
+          path: _build/native/debug/build/cmd/vibe/vibe.exe
+          if-no-files-found: error
+          retention-days: 1
+
   wasm-codegen-quick:
     if: github.event_name == 'push'
     name: wasm-codegen-quick (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    needs: native-cli-debug
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -202,16 +246,23 @@ jobs:
           wasmtime: 'true'
           wasm-tools: 'true'
           node-version: '24'
-      - name: Build vibe CLI (native debug)
-        run: VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Download native CLI (debug)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-debug
+          path: _build/native/debug/build/cmd/vibe
       - name: Set VIBE_BIN for debug binary
-        run: echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
+        run: |
+          chmod +x _build/native/debug/build/cmd/vibe/vibe.exe
+          touch _build/native/debug/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
       - name: Run wasm quick shard (${{ matrix.shard }})
         run: bash scripts/pkfire/wasm_quick_shard.sh ${{ matrix.shard }}
 
   wasm-parity:
     name: wasm-parity (${{ matrix.name }})
     runs-on: ubuntu-latest
+    needs: native-cli-release
     strategy:
       fail-fast: false
       matrix:
@@ -234,10 +285,16 @@ jobs:
         uses: ./.github/actions/setup-vibe
         with:
           wasmtime: 'true'
-      - name: Build vibe CLI (native)
-        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Download native CLI (release)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-release
+          path: target/native/release/build/cmd/vibe
       - name: Set VIBE_BIN for release binary
-        run: echo "VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
+        run: |
+          chmod +x target/native/release/build/cmd/vibe/vibe.exe
+          touch target/native/release/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
       - name: Run wasm parity suite (${{ matrix.name }})
         id: wasm_parity_suite
         run: |
@@ -271,6 +328,7 @@ jobs:
 
   wasm-compile-e2e:
     runs-on: ubuntu-latest
+    needs: native-cli-release
     strategy:
       fail-fast: false
       matrix:
@@ -281,8 +339,16 @@ jobs:
         uses: ./.github/actions/setup-vibe
         with:
           wasmtime: 'true'
-      - name: Build vibe CLI (native)
-        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Download native CLI (release)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-release
+          path: target/native/release/build/cmd/vibe
+      - name: Set VIBE_BIN for release binary
+        run: |
+          chmod +x target/native/release/build/cmd/vibe/vibe.exe
+          touch target/native/release/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
       - name: WASM compile E2E (shard ${{ matrix.shard }}/4)
         id: wasm_compile_e2e
         env:
@@ -303,7 +369,79 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   selfhost-bootstrap-gate:
-    name: selfhost-bootstrap-gate
+    name: selfhost-bootstrap-gate (${{ matrix.part }})
+    runs-on: ubuntu-latest
+    needs: native-cli-debug
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - part: tests-0
+            run_tests: '1'
+            run_deterministic: '0'
+            test_shard_index: '0'
+            test_shard_total: '4'
+            needs_wasmtime_submodule: 'false'
+          - part: tests-1
+            run_tests: '1'
+            run_deterministic: '0'
+            test_shard_index: '1'
+            test_shard_total: '4'
+            needs_wasmtime_submodule: 'false'
+          - part: tests-2
+            run_tests: '1'
+            run_deterministic: '0'
+            test_shard_index: '2'
+            test_shard_total: '4'
+            needs_wasmtime_submodule: 'false'
+          - part: tests-3
+            run_tests: '1'
+            run_deterministic: '0'
+            test_shard_index: '3'
+            test_shard_total: '4'
+            needs_wasmtime_submodule: 'false'
+          - part: deterministic
+            run_tests: '0'
+            run_deterministic: '1'
+            test_shard_index: ''
+            test_shard_total: ''
+            needs_wasmtime_submodule: 'true'
+    steps:
+      - uses: actions/checkout@v5
+      - name: Init wasmtime submodule
+        if: matrix.needs_wasmtime_submodule == 'true'
+        run: git submodule update --init deps/wasmtime
+      - name: Setup Vibe toolchain
+        uses: ./.github/actions/setup-vibe
+        with:
+          ripgrep: 'true'
+          wasmtime: 'true'
+          wasm-tools: 'true'
+          node-version: '24'
+      - name: Download native CLI (debug)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-debug
+          path: _build/native/debug/build/cmd/vibe
+      - name: Set VIBE_BIN for debug binary
+        run: |
+          chmod +x _build/native/debug/build/cmd/vibe/vibe.exe
+          touch _build/native/debug/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
+      - name: Run selfhost bootstrap gate (${{ matrix.part }})
+        # PRs use a sampled deterministic profile to keep feedback short.
+        # Pushes keep the full deterministic mode coverage. Compiled
+        # selfhost tests are sharded across matrix jobs in both cases.
+        run: bash scripts/pkfire/selfhost_gates_shard.sh bootstrap-core
+        env:
+          VIBE_SELFHOST_BOOTSTRAP_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || 'full' }}
+          VIBE_SELFHOST_BOOTSTRAP_RUN_TESTS: ${{ matrix.run_tests }}
+          VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC: ${{ matrix.run_deterministic }}
+          VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_INDEX: ${{ matrix.test_shard_index }}
+          VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_TOTAL: ${{ matrix.test_shard_total }}
+
+  selfhost-selfbuild-kpi:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -315,23 +453,15 @@ jobs:
         with:
           ripgrep: 'true'
           wasmtime: 'true'
-          wasm-tools: 'true'
           node-version: '24'
-      - name: Build vibe CLI (native debug)
-        run: VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
-      - name: Set VIBE_BIN for debug binary
-        run: echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
-      - name: Run selfhost bootstrap + selfbuild KPI
-        # Lightweight (no Rust/wasm32/wac) selfhost gate: bootstrap probe +
-        # `test-selfhost-wasi-selfbuild-kpi` (300s wall-time budget).
-        # Runs on every PR for early selfhost-regression signal; the
-        # heavier `selfhost-gates` matrix (cli / check) stays push-only.
-        run: bash scripts/pkfire/selfhost_gates_shard.sh bootstrap
+      - name: Run selfbuild KPI
+        run: bash scripts/pkfire/selfhost_gates_shard.sh selfbuild
 
   selfhost-gates:
     if: github.event_name == 'push'
     name: selfhost-gates (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    needs: native-cli-debug
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -369,10 +499,16 @@ jobs:
           if ! command -v wac >/dev/null 2>&1; then
             cargo install wac-cli --version 0.9.0 --locked
           fi
-      - name: Build vibe CLI (native debug)
-        run: VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Download native CLI (debug)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-debug
+          path: _build/native/debug/build/cmd/vibe
       - name: Set VIBE_BIN for debug binary
-        run: echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
+        run: |
+          chmod +x _build/native/debug/build/cmd/vibe/vibe.exe
+          touch _build/native/debug/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
       - name: Run selfhost gate shard (${{ matrix.shard }})
         run: bash scripts/pkfire/selfhost_gates_shard.sh ${{ matrix.shard }}
 
@@ -554,6 +690,7 @@ jobs:
   # jobs let each gate's status be read directly.
   selfhost-perf-kpi:
     runs-on: ubuntu-latest
+    needs: native-cli-release
     steps:
       - uses: actions/checkout@v5
 
@@ -586,8 +723,17 @@ jobs:
           path: _build/wasm/opt/*.cwasm
           key: stage1-cwasm-${{ runner.os }}-wt:${{ hashFiles('tools/moonrun_wasmtime/Cargo.toml', 'tools/moonrun_wasmtime/src/**') }}-wasm:${{ hashFiles('.moon-version', 'moon.mod.json', '**/moon.pkg.json', 'src/**/*.mbt') }}
 
-      - name: Build vibe CLI (native)
-        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Download native CLI (release)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-release
+          path: target/native/release/build/cmd/vibe
+
+      - name: Set VIBE_BIN for release binary
+        run: |
+          chmod +x target/native/release/build/cmd/vibe/vibe.exe
+          touch target/native/release/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
 
       - name: Build moonrun_wt (wasmtime host)
         run: cargo build --release --manifest-path tools/moonrun_wasmtime/Cargo.toml
@@ -700,6 +846,7 @@ jobs:
   # cache (those belong to `selfhost-perf-kpi`).
   coverage-selfhost-suite:
     runs-on: ubuntu-latest
+    needs: native-cli-release
     steps:
       - uses: actions/checkout@v5
 
@@ -711,8 +858,17 @@ jobs:
           node-version: '24'
           wasmtime: 'true'
 
-      - name: Build vibe CLI (native)
-        run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+      - name: Download native CLI (release)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-release
+          path: target/native/release/build/cmd/vibe
+
+      - name: Set VIBE_BIN for release binary
+        run: |
+          chmod +x target/native/release/build/cmd/vibe/vibe.exe
+          touch target/native/release/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
 
       - name: Run selfhost suite coverage gate
         env:
@@ -850,6 +1006,7 @@ jobs:
       - contract-moon
       - contract-native
       - e2e-component
+      - native-cli-release
       - selfhost-examples
       - selfhost-runtime-parity
       - wasm-compile-e2e
@@ -868,6 +1025,7 @@ jobs:
             echo "  contract-moon: ${{ needs.contract-moon.result }}"
             echo "  contract-native: ${{ needs.contract-native.result }}"
             echo "  e2e-component: ${{ needs.e2e-component.result }}"
+            echo "  native-cli-release: ${{ needs.native-cli-release.result }}"
             echo "  selfhost-examples: ${{ needs.selfhost-examples.result }}"
             echo "  selfhost-runtime-parity: ${{ needs.selfhost-runtime-parity.result }}"
             echo "  wasm-compile-e2e: ${{ needs.wasm-compile-e2e.result }}"
@@ -884,8 +1042,10 @@ jobs:
       - bundle-size-product-gate
       - coverage-moon
       - coverage-selfhost-suite
+      - native-cli-debug
       - native-binary-parity
       - selfhost-bootstrap-gate
+      - selfhost-selfbuild-kpi
       - selfhost-gates
       - selfhost-perf-kpi
       - similarity-mbt-report
@@ -899,8 +1059,10 @@ jobs:
           echo "  bundle-size-product-gate: ${{ needs.bundle-size-product-gate.result }}"
           echo "  coverage-moon: ${{ needs.coverage-moon.result }}"
           echo "  coverage-selfhost-suite: ${{ needs.coverage-selfhost-suite.result }}"
+          echo "  native-cli-debug: ${{ needs.native-cli-debug.result }}"
           echo "  native-binary-parity: ${{ needs.native-binary-parity.result }}"
           echo "  selfhost-bootstrap-gate: ${{ needs.selfhost-bootstrap-gate.result }}"
+          echo "  selfhost-selfbuild-kpi: ${{ needs.selfhost-selfbuild-kpi.result }}"
           echo "  selfhost-gates: ${{ needs.selfhost-gates.result }}"
           echo "  selfhost-perf-kpi: ${{ needs.selfhost-perf-kpi.result }}"
           echo "  similarity-mbt-report: ${{ needs.similarity-mbt-report.result }}"

--- a/scripts/pkfire/selfhost_gates_shard.sh
+++ b/scripts/pkfire/selfhost_gates_shard.sh
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 # Selfhost release gate shards — extracted from justfile `ci-selfhost-gates-shard`.
-# Usage: scripts/pkfire/selfhost_gates_shard.sh <bootstrap|cli|check|coverage>
+# Usage: scripts/pkfire/selfhost_gates_shard.sh <bootstrap|bootstrap-core|selfbuild|cli|check|coverage>
 set -euo pipefail
 
-shard="${1:?missing shard argument: bootstrap|cli|check|coverage}"
+shard="${1:?missing shard argument: bootstrap|bootstrap-core|selfbuild|cli|check|coverage}"
 
 case "$shard" in
+  bootstrap-core)
+    bash scripts/check_selfhost_bundle_sync.sh
+    scripts/test_selfhost_bootstrap_gate.sh
+    ;;
+  selfbuild)
+    VIBE_SELFHOST_SELFBUILD_STRICT_RECURSIVE=1 \
+    VIBE_SELFHOST_SELFBUILD_REQUIRE_TRUE_RECURSIVE=1 \
+    VIBE_SELFHOST_SELFBUILD_MAX_TOTAL_SEC="${VIBE_SELFHOST_SELFBUILD_MAX_TOTAL_SEC:-300}" \
+    scripts/test_selfhost_wasi_selfbuild.sh
+    ;;
   bootstrap)
     bash scripts/check_selfhost_bundle_sync.sh
     scripts/test_selfhost_bootstrap_gate.sh
@@ -47,7 +57,7 @@ case "$shard" in
     scripts/coverage_selfhost_suite.sh
     ;;
   *)
-    echo "unknown shard: $shard (expected: bootstrap|cli|check|coverage)" >&2
+    echo "unknown shard: $shard (expected: bootstrap|bootstrap-core|selfbuild|cli|check|coverage)" >&2
     exit 1
     ;;
 esac

--- a/scripts/test_selfhost_bootstrap_gate.sh
+++ b/scripts/test_selfhost_bootstrap_gate.sh
@@ -12,6 +12,11 @@ PIPELINE_OPT_LEVEL="${VIBE_SELFHOST_PIPELINE_OPT_LEVEL:-}"
 SELFHOST_TEST_JOBS="${VIBE_SELFHOST_BOOTSTRAP_TEST_JOBS:-}"
 SELFHOST_BATCH_CHUNK_SIZE="${VIBE_SELFHOST_BOOTSTRAP_BATCH_CHUNK_SIZE:-1}"
 STAGE_TIMEOUT_SEC="${VIBE_SELFHOST_BOOTSTRAP_STAGE_TIMEOUT_SEC:-1800}"
+BOOTSTRAP_PROFILE="${VIBE_SELFHOST_BOOTSTRAP_PROFILE:-full}"
+RUN_TESTS="${VIBE_SELFHOST_BOOTSTRAP_RUN_TESTS:-1}"
+RUN_DETERMINISTIC="${VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC:-1}"
+TEST_SHARD_INDEX="${VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_INDEX:-}"
+TEST_SHARD_TOTAL="${VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_TOTAL:-}"
 BATCH_WEIGHT_CACHE_PATH="${VIBE_SELFHOST_BOOTSTRAP_BATCH_WEIGHT_CACHE:-$OUT_DIR/selfhost_test_batch_weights.json}"
 BATCH_WEIGHT_SEED_PATH="${VIBE_SELFHOST_BOOTSTRAP_BATCH_WEIGHT_SEED:-$PROJECT_ROOT/scripts/selfhost_test_batch_weights.seed.json}"
 # Cutover: use selfhost compiler (moonrun) instead of host CLI for wasm compilation.
@@ -116,6 +121,13 @@ is_positive_int() {
     return 1
   fi
   [ "$1" -gt 0 ]
+}
+
+is_bool_01() {
+  case "$1" in
+    0|1) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 detect_default_test_jobs() {
@@ -233,29 +245,67 @@ if [ "$needs_cli_rebuild" -eq 1 ]; then
     moon build --target native --release --target-dir target src/cmd/vibe --warn-list '-29'
 fi
 
-# Build selfhost compiler wasm if cutover is enabled and binary is missing/stale
-if [ "$SELFHOST_CUTOVER" = "1" ]; then
-  needs_selfhost_rebuild=0
-  if [ ! -f "$SELFHOST_COMPILER_WASM" ]; then
-    needs_selfhost_rebuild=1
-  elif find "$PROJECT_ROOT" -maxdepth 1 -type f \( -name 'moon.mod' -o -name 'moon.mod.json' \) -newer "$SELFHOST_COMPILER_WASM" -print -quit 2>/dev/null | grep -q .; then
-    needs_selfhost_rebuild=1
-  elif find "$PROJECT_ROOT/src" -type f \( -name '*.mbt' -o -name 'moon.pkg' \) -newer "$SELFHOST_COMPILER_WASM" -print -quit 2>/dev/null | grep -q .; then
-    needs_selfhost_rebuild=1
-  fi
-  if [ "$needs_selfhost_rebuild" -eq 1 ]; then
-    run_stage "building selfhost compiler (wasm)" \
-      moon build --target wasm src/cmd/vibe_compile_wasi
-  fi
-  if ! command -v moonrun >/dev/null 2>&1; then
-    echo "bootstrap gate failed: moonrun not found (required for VIBE_SELFHOST_CUTOVER=1)" >&2
+if ! is_bool_01 "$RUN_TESTS"; then
+  echo "bootstrap gate failed: VIBE_SELFHOST_BOOTSTRAP_RUN_TESTS must be 0 or 1" >&2
+  exit 1
+fi
+if ! is_bool_01 "$RUN_DETERMINISTIC"; then
+  echo "bootstrap gate failed: VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC must be 0 or 1" >&2
+  exit 1
+fi
+if [ "$RUN_TESTS" -eq 0 ] && [ "$RUN_DETERMINISTIC" -eq 0 ]; then
+  echo "bootstrap gate failed: at least one bootstrap section must run" >&2
+  exit 1
+fi
+case "$BOOTSTRAP_PROFILE" in
+  full|pr) ;;
+  *)
+    echo "bootstrap gate failed: VIBE_SELFHOST_BOOTSTRAP_PROFILE must be full or pr" >&2
+    exit 1
+    ;;
+esac
+if [ -n "$TEST_SHARD_INDEX" ] || [ -n "$TEST_SHARD_TOTAL" ]; then
+  if ! is_non_negative_int "$TEST_SHARD_INDEX"; then
+    echo "bootstrap gate failed: VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_INDEX must be non-negative integer" >&2
     exit 1
   fi
-  echo "[bootstrap] cutover: using selfhost compiler (moonrun)"
-  COMPILE_CMD_ARGS=(moonrun "$SELFHOST_COMPILER_WASM")
+  if ! is_positive_int "$TEST_SHARD_TOTAL"; then
+    echo "bootstrap gate failed: VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_TOTAL must be positive integer" >&2
+    exit 1
+  fi
+  if [ "$TEST_SHARD_INDEX" -ge "$TEST_SHARD_TOTAL" ]; then
+    echo "bootstrap gate failed: test shard index must be less than total" >&2
+    exit 1
+  fi
+fi
+
+if [ "$RUN_DETERMINISTIC" -eq 1 ]; then
+  # Build selfhost compiler wasm if cutover is enabled and binary is missing/stale.
+  if [ "$SELFHOST_CUTOVER" = "1" ]; then
+    needs_selfhost_rebuild=0
+    if [ ! -f "$SELFHOST_COMPILER_WASM" ]; then
+      needs_selfhost_rebuild=1
+    elif find "$PROJECT_ROOT" -maxdepth 1 -type f \( -name 'moon.mod' -o -name 'moon.mod.json' \) -newer "$SELFHOST_COMPILER_WASM" -print -quit 2>/dev/null | grep -q .; then
+      needs_selfhost_rebuild=1
+    elif find "$PROJECT_ROOT/src" -type f \( -name '*.mbt' -o -name 'moon.pkg' \) -newer "$SELFHOST_COMPILER_WASM" -print -quit 2>/dev/null | grep -q .; then
+      needs_selfhost_rebuild=1
+    fi
+    if [ "$needs_selfhost_rebuild" -eq 1 ]; then
+      run_stage "building selfhost compiler (wasm)" \
+        moon build --target wasm src/cmd/vibe_compile_wasi
+    fi
+    if ! command -v moonrun >/dev/null 2>&1; then
+      echo "bootstrap gate failed: moonrun not found (required for VIBE_SELFHOST_CUTOVER=1)" >&2
+      exit 1
+    fi
+    echo "[bootstrap] cutover: using selfhost compiler (moonrun)"
+    COMPILE_CMD_ARGS=(moonrun "$SELFHOST_COMPILER_WASM")
+  else
+    echo "[bootstrap] cutover: using host CLI"
+    COMPILE_CMD_ARGS=("$VIBE_BIN" compile)
+  fi
 else
-  echo "[bootstrap] cutover: using host CLI"
-  COMPILE_CMD_ARGS=("$VIBE_BIN" compile)
+  echo "[bootstrap] deterministic compile checks: skipped"
 fi
 
 mkdir -p "$OUT_DIR"
@@ -290,7 +340,15 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   printf -- "- %s: %s\n" "selfhost test jobs" "$SELFHOST_TEST_JOBS" >> "$GITHUB_STEP_SUMMARY" || true
   printf -- "- %s: %s\n" "selfhost batch chunk size" "$SELFHOST_BATCH_CHUNK_SIZE" >> "$GITHUB_STEP_SUMMARY" || true
   printf -- "- %s: %ss\n" "stage timeout" "$STAGE_TIMEOUT_SEC" >> "$GITHUB_STEP_SUMMARY" || true
-  printf -- "- %s: %s\n" "cutover" "$( [ "$SELFHOST_CUTOVER" = "1" ] && echo "selfhost (moonrun)" || echo "host CLI" )" >> "$GITHUB_STEP_SUMMARY" || true
+  printf -- "- %s: %s\n" "profile" "$BOOTSTRAP_PROFILE" >> "$GITHUB_STEP_SUMMARY" || true
+  printf -- "- %s: %s\n" "run tests" "$RUN_TESTS" >> "$GITHUB_STEP_SUMMARY" || true
+  printf -- "- %s: %s\n" "run deterministic" "$RUN_DETERMINISTIC" >> "$GITHUB_STEP_SUMMARY" || true
+  if [ -n "$TEST_SHARD_TOTAL" ]; then
+    printf -- "- %s: %s/%s\n" "test shard" "$TEST_SHARD_INDEX" "$TEST_SHARD_TOTAL" >> "$GITHUB_STEP_SUMMARY" || true
+  fi
+  if [ "$RUN_DETERMINISTIC" -eq 1 ]; then
+    printf -- "- %s: %s\n" "cutover" "$( [ "$SELFHOST_CUTOVER" = "1" ] && echo "selfhost (moonrun)" || echo "host CLI" )" >> "$GITHUB_STEP_SUMMARY" || true
+  fi
   printf -- "- %s: %s\n" "batch weight cache" "$BATCH_WEIGHT_CACHE_PATH" >> "$GITHUB_STEP_SUMMARY" || true
   printf -- "- %s: %s\n" "batch weight seed" "$BATCH_WEIGHT_SEED_PATH" >> "$GITHUB_STEP_SUMMARY" || true
 fi
@@ -344,122 +402,156 @@ run_compiled_selfhost_test_shard() {
   fi
 }
 
-SELFHOST_COMPILED_TEST_FILES_SHARD_0=()
-SELFHOST_COMPILED_TEST_FILES_SHARD_1=()
-SELFHOST_COMPILED_TEST_FILES_SHARD_2=()
-SELFHOST_COMPILED_TEST_FILES_SHARD_3=()
-shard_index=0
-for test_path in "${SELFHOST_COMPILED_TEST_FILES[@]}"; do
-  case "$shard_index" in
-    0)
-      SELFHOST_COMPILED_TEST_FILES_SHARD_0+=("$test_path")
-      ;;
-    1)
-      SELFHOST_COMPILED_TEST_FILES_SHARD_1+=("$test_path")
-      ;;
-    2)
-      SELFHOST_COMPILED_TEST_FILES_SHARD_2+=("$test_path")
-      ;;
-    *)
-      SELFHOST_COMPILED_TEST_FILES_SHARD_3+=("$test_path")
-      ;;
-  esac
-  shard_index=$(((shard_index + 1) % 4))
-done
+run_compiled_selfhost_test_shards() {
+  local shard_index selected_index selected_total shard_label
+  local -a selected_files
+  if [ -n "$TEST_SHARD_TOTAL" ]; then
+    selected_index="$TEST_SHARD_INDEX"
+    selected_total="$TEST_SHARD_TOTAL"
+    selected_files=()
+    shard_index=0
+    for test_path in "${SELFHOST_COMPILED_TEST_FILES[@]}"; do
+      if [ $((shard_index % selected_total)) -eq "$selected_index" ]; then
+        selected_files+=("$test_path")
+      fi
+      shard_index=$((shard_index + 1))
+    done
+    shard_label="$((selected_index + 1))/${selected_total}"
+    run_compiled_selfhost_test_shard "$shard_label" "${selected_files[@]}"
+    return
+  fi
 
-run_compiled_selfhost_test_shard "1/4" "${SELFHOST_COMPILED_TEST_FILES_SHARD_0[@]}"
-run_compiled_selfhost_test_shard "2/4" "${SELFHOST_COMPILED_TEST_FILES_SHARD_1[@]}"
-run_compiled_selfhost_test_shard "3/4" "${SELFHOST_COMPILED_TEST_FILES_SHARD_2[@]}"
-run_compiled_selfhost_test_shard "4/4" "${SELFHOST_COMPILED_TEST_FILES_SHARD_3[@]}"
+  local default_total=4
+  local default_index
+  for default_index in 0 1 2 3; do
+    selected_files=()
+    shard_index=0
+    for test_path in "${SELFHOST_COMPILED_TEST_FILES[@]}"; do
+      if [ $((shard_index % default_total)) -eq "$default_index" ]; then
+        selected_files+=("$test_path")
+      fi
+      shard_index=$((shard_index + 1))
+    done
+    run_compiled_selfhost_test_shard "$((default_index + 1))/${default_total}" "${selected_files[@]}"
+  done
+}
 
-run_stage "compiled selfhost cli cache test" \
-  env VIBE_TEST_BACKEND=compiled \
-  "$VIBE_BIN" test "$PROJECT_ROOT/vibe/compiler/cli_cache_test.vibe"
+should_run_unsharded_test() {
+  if [ -z "$TEST_SHARD_TOTAL" ]; then
+    return 0
+  fi
+  [ "$TEST_SHARD_INDEX" -eq 0 ]
+}
 
-run_stage "compiled selfhost cli adapter cache test" \
-  env VIBE_TEST_BACKEND=compiled \
-  "$VIBE_BIN" test "$PROJECT_ROOT/vibe/compiler/cli_adapter_cache_test.vibe"
+if [ "$RUN_TESTS" -eq 1 ]; then
+  run_compiled_selfhost_test_shards
 
-run_stage "compiled selfhost codegen enum import test" \
-  env VIBE_TEST_BACKEND=compiled \
-  "$VIBE_BIN" test "$PROJECT_ROOT/vibe/compiler/codegen_enum_import_test.vibe"
+  if should_run_unsharded_test; then
+    run_stage "compiled selfhost cli cache test" \
+      env VIBE_TEST_BACKEND=compiled \
+      "$VIBE_BIN" test "$PROJECT_ROOT/vibe/compiler/cli_cache_test.vibe"
 
-run_stage "compiled selfhost compiler cache test" \
-  env VIBE_TEST_BACKEND=compiled \
-  "$VIBE_BIN" test "$PROJECT_ROOT/vibe/compiler/compiler_cache_test.vibe"
+    run_stage "compiled selfhost cli adapter cache test" \
+      env VIBE_TEST_BACKEND=compiled \
+      "$VIBE_BIN" test "$PROJECT_ROOT/vibe/compiler/cli_adapter_cache_test.vibe"
 
-echo "[bootstrap] selfhost __to_string source path check"
-if rg -n "double_to_string_compiler" \
-  "$PROJECT_ROOT/vibe/compiler/token.vibe" \
-  "$PROJECT_ROOT/vibe/compiler/printer.vibe" >/dev/null; then
-  echo "bootstrap gate failed: selfhost compiler still depends on double_to_string_compiler" >&2
-  exit 1
-fi
+    run_stage "compiled selfhost codegen enum import test" \
+      env VIBE_TEST_BACKEND=compiled \
+      "$VIBE_BIN" test "$PROJECT_ROOT/vibe/compiler/codegen_enum_import_test.vibe"
 
-TOSTRING_PROBE="$OUT_DIR/selfhost_tostring_probe.vibe"
-cat >"$TOSTRING_PROBE" <<'EOF'
+    run_stage "compiled selfhost compiler cache test" \
+      env VIBE_TEST_BACKEND=compiled \
+      "$VIBE_BIN" test "$PROJECT_ROOT/vibe/compiler/compiler_cache_test.vibe"
+
+    echo "[bootstrap] selfhost __to_string source path check"
+    if rg -n "double_to_string_compiler" \
+      "$PROJECT_ROOT/vibe/compiler/token.vibe" \
+      "$PROJECT_ROOT/vibe/compiler/printer.vibe" >/dev/null; then
+      echo "bootstrap gate failed: selfhost compiler still depends on double_to_string_compiler" >&2
+      exit 1
+    fi
+
+    TOSTRING_PROBE="$OUT_DIR/selfhost_tostring_probe.vibe"
+    cat >"$TOSTRING_PROBE" <<'EOF'
 test "__to_string number parity" {
   assert(String::equals(__to_string(1.5), "1.5"))
   assert(String::equals(__to_string(2.0), "2"))
   assert(String::equals(__to_string(1.5f), "1.5"))
 }
 EOF
-run_stage "compiled __to_string(Double/Float) probe" \
-  env VIBE_TEST_BACKEND=compiled "$VIBE_BIN" test "$TOSTRING_PROBE"
+    run_stage "compiled __to_string(Double/Float) probe" \
+      env VIBE_TEST_BACKEND=compiled "$VIBE_BIN" test "$TOSTRING_PROBE"
+  else
+    echo "[bootstrap] unsharded compiled cache probes: skipped on shard ${TEST_SHARD_INDEX}/${TEST_SHARD_TOTAL}"
+  fi
+else
+  echo "[bootstrap] compiled selfhost tests: skipped"
+fi
 
 BASICS_FIXTURE="$PROJECT_ROOT/examples/basics.vibe"
 BASE64_FIXTURE="$PROJECT_ROOT/bench/compiler_size/cases/base64.vibe"
-if [ ! -f "$BASICS_FIXTURE" ]; then
-  echo "bootstrap gate failed: fixture not found: $BASICS_FIXTURE" >&2
-  exit 1
-fi
-if [ ! -f "$BASE64_FIXTURE" ]; then
-  echo "bootstrap gate failed: fixture not found: $BASE64_FIXTURE" >&2
-  exit 1
-fi
-
-verify_stage_pair_hash "index_mvp" "$ENTRY_PATH" "--wasm" --wasm
-STAGE1_WASM="$STAGE_PAIR_LAST_STAGE1"
-STAGE2_WASM="$STAGE_PAIR_LAST_STAGE2"
-HASH_STAGE1="$STAGE_PAIR_LAST_HASH"
-
-verify_stage_pair_hash "index_no_dce" "$ENTRY_PATH" "--wasm --no-dce" --wasm --no-dce
-verify_stage_pair_hash "index_debug_errors" "$ENTRY_PATH" "--wasm --debug-errors" --wasm --debug-errors
-verify_stage_pair_hash "basics_mvp" "$BASICS_FIXTURE" "--wasm" --wasm
-verify_stage_pair_hash "base64_mvp" "$BASE64_FIXTURE" "--wasm" --wasm
-
-PIPELINE_CHECK="$OUT_DIR/index_pipeline_check.log"
-PIPELINE_RAW_WASM="$OUT_DIR/index_pipeline_raw.wasm"
-PIPELINE_OPT_WASM="$OUT_DIR/index_pipeline_opt.wasm"
-run_stage_capture_stdout "pipeline parse+type check for $ENTRY_PATH" \
-  "$PIPELINE_CHECK" \
-  "$VIBE_BIN" check "$ENTRY_PATH"
-run_stage "pipeline codegen (--wasm --no-dce) for $ENTRY_PATH" \
-  "${COMPILE_CMD_ARGS[@]}" --wasm --no-dce "$ENTRY_PATH" -o "$PIPELINE_RAW_WASM"
-if [ -n "$PIPELINE_OPT_LEVEL" ]; then
-  run_stage "pipeline optimize/codegen (-O$PIPELINE_OPT_LEVEL) for $ENTRY_PATH" \
-    "${COMPILE_CMD_ARGS[@]}" --wasm "-O$PIPELINE_OPT_LEVEL" "$ENTRY_PATH" -o "$PIPELINE_OPT_WASM"
-else
-  echo "[bootstrap] pipeline optimize/codegen: skipped (set VIBE_SELFHOST_PIPELINE_OPT_LEVEL)"
-fi
-
-if command -v wasm-tools >/dev/null 2>&1; then
-  run_stage "validate pipeline raw wasm" wasm-tools validate --features all "$PIPELINE_RAW_WASM"
-  if [ -n "$PIPELINE_OPT_LEVEL" ]; then
-    run_stage "validate pipeline opt wasm" wasm-tools validate --features all "$PIPELINE_OPT_WASM"
+HASH_STAGE1="skipped"
+if [ "$RUN_DETERMINISTIC" -eq 1 ]; then
+  if [ ! -f "$BASICS_FIXTURE" ]; then
+    echo "bootstrap gate failed: fixture not found: $BASICS_FIXTURE" >&2
+    exit 1
   fi
-else
-  echo "warning: wasm-tools not found, skipping validate" >&2
-fi
+  if [ ! -f "$BASE64_FIXTURE" ]; then
+    echo "bootstrap gate failed: fixture not found: $BASE64_FIXTURE" >&2
+    exit 1
+  fi
 
-run_wasm_and_expect_zero \
-  "run stage1 wasm via wasmtime (--invoke _start)" \
-  "$STAGE1_WASM" \
-  "$OUT_DIR/stage1_run.out"
-run_wasm_and_expect_zero \
-  "run stage2 wasm via wasmtime (--invoke _start)" \
-  "$STAGE2_WASM" \
-  "$OUT_DIR/stage2_run.out"
+  verify_stage_pair_hash "index_mvp" "$ENTRY_PATH" "--wasm" --wasm
+  STAGE1_WASM="$STAGE_PAIR_LAST_STAGE1"
+  STAGE2_WASM="$STAGE_PAIR_LAST_STAGE2"
+  HASH_STAGE1="$STAGE_PAIR_LAST_HASH"
+
+  if [ "$BOOTSTRAP_PROFILE" = "full" ]; then
+    verify_stage_pair_hash "index_no_dce" "$ENTRY_PATH" "--wasm --no-dce" --wasm --no-dce
+    verify_stage_pair_hash "index_debug_errors" "$ENTRY_PATH" "--wasm --debug-errors" --wasm --debug-errors
+  else
+    echo "[bootstrap] full index mode pairs: skipped in pr profile"
+  fi
+  verify_stage_pair_hash "basics_mvp" "$BASICS_FIXTURE" "--wasm" --wasm
+  verify_stage_pair_hash "base64_mvp" "$BASE64_FIXTURE" "--wasm" --wasm
+
+  PIPELINE_CHECK="$OUT_DIR/index_pipeline_check.log"
+  PIPELINE_RAW_WASM="$OUT_DIR/index_pipeline_raw.wasm"
+  PIPELINE_OPT_WASM="$OUT_DIR/index_pipeline_opt.wasm"
+  run_stage_capture_stdout "pipeline parse+type check for $ENTRY_PATH" \
+    "$PIPELINE_CHECK" \
+    "$VIBE_BIN" check "$ENTRY_PATH"
+  if [ "$BOOTSTRAP_PROFILE" = "full" ]; then
+    run_stage "pipeline codegen (--wasm --no-dce) for $ENTRY_PATH" \
+      "${COMPILE_CMD_ARGS[@]}" --wasm --no-dce "$ENTRY_PATH" -o "$PIPELINE_RAW_WASM"
+    if [ -n "$PIPELINE_OPT_LEVEL" ]; then
+      run_stage "pipeline optimize/codegen (-O$PIPELINE_OPT_LEVEL) for $ENTRY_PATH" \
+        "${COMPILE_CMD_ARGS[@]}" --wasm "-O$PIPELINE_OPT_LEVEL" "$ENTRY_PATH" -o "$PIPELINE_OPT_WASM"
+    else
+      echo "[bootstrap] pipeline optimize/codegen: skipped (set VIBE_SELFHOST_PIPELINE_OPT_LEVEL)"
+    fi
+
+    if command -v wasm-tools >/dev/null 2>&1; then
+      run_stage "validate pipeline raw wasm" wasm-tools validate --features all "$PIPELINE_RAW_WASM"
+      if [ -n "$PIPELINE_OPT_LEVEL" ]; then
+        run_stage "validate pipeline opt wasm" wasm-tools validate --features all "$PIPELINE_OPT_WASM"
+      fi
+    else
+      echo "warning: wasm-tools not found, skipping validate" >&2
+    fi
+  else
+    echo "[bootstrap] pipeline codegen: skipped in pr profile"
+  fi
+
+  run_wasm_and_expect_zero \
+    "run stage1 wasm via wasmtime (--invoke _start)" \
+    "$STAGE1_WASM" \
+    "$OUT_DIR/stage1_run.out"
+  run_wasm_and_expect_zero \
+    "run stage2 wasm via wasmtime (--invoke _start)" \
+    "$STAGE2_WASM" \
+    "$OUT_DIR/stage2_run.out"
+fi
 
 bootstrap_total_end="$(date +%s)"
 bootstrap_total_elapsed="$((bootstrap_total_end - bootstrap_total_start))"

--- a/vibe/x/base64/base64.vibe
+++ b/vibe/x/base64/base64.vibe
@@ -25,7 +25,7 @@ let decode_char = (c: Int) -> Int {
 
 export let decode = (input: String) -> String {
   let len = String::length(input)
-  let mut result = ""
+  let result = StringBuilder::new()
   let mut i = 0
   while i < len {
     let c0 = if i < len {
@@ -49,27 +49,27 @@ export let decode = (input: String) -> String {
       -1
     }
     let b0 = ((c0&63)<<2)|((c1>>4)&3)
-    result = "\{result}\{String::from_char_code(b0)}"
+    StringBuilder::push(result, String::from_char_code(b0))
     if c2 >= 0 {
       let b1 = ((c1&15)<<4)|((c2>>2)&15)
-      result = "\{result}\{String::from_char_code(b1)}"
+      StringBuilder::push(result, String::from_char_code(b1))
     }
     if c3 >= 0 {
       let b2 = ((c2&3)<<6)|(c3&63)
-      result = "\{result}\{String::from_char_code(b2)}"
+      StringBuilder::push(result, String::from_char_code(b2))
     }
     i = i + 4
   }
-  result
+  StringBuilder::freeze(result)
 }
 
 let encode_char = (idx: Int) -> String {
-  alphabet[idx]
+  String::from_char_code(String::char_code_at(alphabet, idx))
 }
 
 export let encode = (input: String) -> String {
   let len = String::length(input)
-  let mut result = ""
+  let result = StringBuilder::new()
   let mut i = 0
   while i < len {
     let b0 = String::char_code_at(input, i)
@@ -84,43 +84,43 @@ export let encode = (input: String) -> String {
       0
     }
     let remaining = len - i
-    result = "\{result}\{encode_char((b0>>2)&63)}"
-    result = "\{result}\{encode_char(((b0&3)<<4)|((b1>>4)&15))}"
+    StringBuilder::push(result, encode_char((b0>>2)&63))
+    StringBuilder::push(result, encode_char(((b0&3)<<4)|((b1>>4)&15)))
     if remaining >= 2 {
-      result = "\{result}\{encode_char(((b1&15)<<2)|((b2>>6)&3))}"
+      StringBuilder::push(result, encode_char(((b1&15)<<2)|((b2>>6)&3)))
     } else {
-      result = "\{result}="
+      StringBuilder::push(result, "=")
     }
     if remaining >= 3 {
-      result = "\{result}\{encode_char(b2&63)}"
+      StringBuilder::push(result, encode_char(b2&63))
     } else {
-      result = "\{result}="
+      StringBuilder::push(result, "=")
     }
     i = i + 3
   }
-  result
+  StringBuilder::freeze(result)
 }
 
 export let encode_url_safe = (input: String) -> String {
   let base = encode(input)
   let len = String::length(base)
-  let mut result = ""
+  let result = StringBuilder::new()
   let mut i = 0
   while i < len {
     let c = base[i]
     if c == "+" {
-      result = "\{result}-"
+      StringBuilder::push(result, "-")
     }
     else if c == "/" {
-      result = "\{result}_"
+      StringBuilder::push(result, "_")
     }
     else if c == "=" {
       i = len
     }
     else {
-      result = "\{result}\{c}"
+      StringBuilder::push(result, String::from_char_code(String::char_code_at(base, i)))
     }
     i = i + 1
   }
-  result
+  StringBuilder::freeze(result)
 }


### PR DESCRIPTION
## Summary
- build native release/debug CLIs once in CI and reuse them via artifacts across wasm/selfhost jobs
- shard selfhost bootstrap compiled tests and split recursive selfbuild into an informational KPI job
- add a PR bootstrap deterministic profile that samples the expensive deterministic checks while preserving full mode on push
- replace base64 encode/decode/url-safe string concat accumulators with StringBuilder

## Validation
- `actionlint -color .github/workflows/ci.yml`
- `bash -n scripts/test_selfhost_bootstrap_gate.sh scripts/pkfire/selfhost_gates_shard.sh`
- `pkf run fmt`
- `pkf run check`
- `flaker run`
- `pkf run test`
- `_build/native/debug/build/cmd/vibe/vibe.exe test vibe/x/base64/base64_test.vibe`
- `VIBE_TEST_BACKEND=gc _build/native/debug/build/cmd/vibe/vibe.exe test vibe/x/base64/base64_test.vibe`
- `_build/native/debug/build/cmd/vibe/vibe.exe bench vibe/x/base64/bench.vibe`
- `_build/native/debug/build/cmd/vibe/vibe.exe test vibe/prelude/iterator_test.vibe`
- `_build/native/debug/build/cmd/vibe/vibe.exe bench vibe/prelude/iterator_bench.vibe`
- local selfhost bootstrap PR deterministic shard / compiled-test shards 0-1 / selfbuild shard

## Notes
- Closed #430 as stale after verifying Map Iterable direct lowering and the existing iterator bench.
