### PR TITLE
Cache selfhost adapter builds

### DIFF
--- a/scripts/build_selfhost_check_command_component.sh
+++ b/scripts/build_selfhost_check_command_component.sh
@@ -7,8 +7,16 @@ OUT_COMPONENT="${1:-$PROJECT_ROOT/dist/selfhost_check_command.component.wasm}"
 OUT_WIT="${2:-${OUT_COMPONENT%.wasm}.wit}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_check_component_entry.vibe}"
 TMP_DIR="$(mktemp -d /tmp/vibe_selfhost_check_command_component.XXXXXX)"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${VIBE_SELFHOST_CHECK_COMMAND_CARGO_TARGET_DIR:-$PROJECT_ROOT/_build/cargo-target/selfhost_component_adapters}}"
+ADAPTER_LOCK_FILE="${VIBE_SELFHOST_CHECK_COMMAND_CARGO_LOCK:-$PROJECT_ROOT/_build/cargo-locks/selfhost_check_command_adapter.Cargo.lock}"
+ADAPTER_BUILD_LOCK_DIR="${VIBE_SELFHOST_CHECK_COMMAND_BUILD_LOCK:-$PROJECT_ROOT/_build/locks/selfhost_check_command_adapter.lock}"
+ADAPTER_BUILD_LOCK_HELD=0
+export CARGO_TARGET_DIR
 
 cleanup() {
+  if [ "$ADAPTER_BUILD_LOCK_HELD" = "1" ]; then
+    rmdir "$ADAPTER_BUILD_LOCK_DIR" 2>/dev/null || true
+  fi
   if [ "${VIBE_KEEP_TMP:-0}" = "1" ]; then
     echo "keeping tmp dir: $TMP_DIR" >&2
     return
@@ -22,6 +30,21 @@ require_cmd() {
     echo "missing required command: $1" >&2
     exit 1
   fi
+}
+
+acquire_adapter_build_lock() {
+  mkdir -p "$(dirname "$ADAPTER_BUILD_LOCK_DIR")"
+  local attempts=0
+  local max_attempts=1500
+  while ! mkdir "$ADAPTER_BUILD_LOCK_DIR" 2>/dev/null; do
+    sleep 0.2
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge "$max_attempts" ]; then
+      echo "timed out waiting for adapter build lock: $ADAPTER_BUILD_LOCK_DIR" >&2
+      exit 1
+    fi
+  done
+  ADAPTER_BUILD_LOCK_HELD=1
 }
 
 if [ -x "$HOME/.cargo/bin/cargo" ]; then
@@ -41,9 +64,16 @@ ADAPTER_WIT_DIR="$TMP_DIR/wit"
 ADAPTER_WIT_DEPS_DIR="$ADAPTER_WIT_DIR/deps"
 mkdir -p "$ADAPTER_WIT_DEPS_DIR"
 
-RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
-if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+if [ -n "${VIBE_BIN:-}" ]; then
+  RELEASE_VIBE_EXE="$VIBE_BIN"
+  if [ ! -x "$RELEASE_VIBE_EXE" ]; then
+    echo "VIBE_BIN is not executable: $RELEASE_VIBE_EXE" >&2
+    exit 1
+  fi
+else
+  export VIBE_MOON_WARN_LIST="${VIBE_MOON_WARN_LIST:--29-55-67-23-24-7-1}"
+  source "$SCRIPT_DIR/ensure_native_cli.sh"
+  RELEASE_VIBE_EXE="$VIBE_CLI_BIN"
 fi
 
 "$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$PLUG_COMPONENT"
@@ -139,10 +169,20 @@ cp \
   "$PROJECT_ROOT/deps/wasmtime/crates/wasi/src/p2/wit/deps/sockets.wit" \
   "$ADAPTER_WIT_DEPS_DIR/"
 
+acquire_adapter_build_lock
+mkdir -p "$(dirname "$ADAPTER_LOCK_FILE")"
 pushd "$TMP_DIR" >/dev/null
-PATH="$HOME/.cargo/bin:$PATH" cargo build --target wasm32-unknown-unknown --release >/dev/null
+cargo_build_args=(--target wasm32-unknown-unknown --release)
+if [ -f "$ADAPTER_LOCK_FILE" ]; then
+  cp "$ADAPTER_LOCK_FILE" Cargo.lock
+  cargo_build_args+=(--locked)
+fi
+PATH="$HOME/.cargo/bin:$PATH" cargo build "${cargo_build_args[@]}" >/dev/null
+if [ ! -f "$ADAPTER_LOCK_FILE" ] && [ -f Cargo.lock ]; then
+  cp Cargo.lock "$ADAPTER_LOCK_FILE"
+fi
 wasm-tools component embed "$ADAPTER_WIT_DIR" \
-  target/wasm32-unknown-unknown/release/vibe_selfhost_check_command_adapter.wasm \
+  "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/vibe_selfhost_check_command_adapter.wasm" \
   --world adapter \
   -o "$ADAPTER_EMBEDDED_WASM"
 wasm-tools component new "$ADAPTER_EMBEDDED_WASM" -o "$ADAPTER_COMPONENT"

--- a/scripts/build_selfhost_check_direct_component.sh
+++ b/scripts/build_selfhost_check_direct_component.sh
@@ -6,10 +6,17 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_COMPONENT="${1:-$PROJECT_ROOT/dist/selfhost_check_direct.component.wasm}"
 OUT_WIT="${2:-${OUT_COMPONENT%.wasm}.wit}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_check_component_entry.vibe}"
-RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 TMP_DIR="$(mktemp -d /tmp/vibe_selfhost_check_direct_component.XXXXXX)"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${VIBE_SELFHOST_CHECK_DIRECT_CARGO_TARGET_DIR:-$PROJECT_ROOT/_build/cargo-target/selfhost_component_adapters}}"
+ADAPTER_LOCK_FILE="${VIBE_SELFHOST_CHECK_DIRECT_CARGO_LOCK:-$PROJECT_ROOT/_build/cargo-locks/selfhost_check_direct_adapter.Cargo.lock}"
+ADAPTER_BUILD_LOCK_DIR="${VIBE_SELFHOST_CHECK_DIRECT_BUILD_LOCK:-$PROJECT_ROOT/_build/locks/selfhost_check_direct_adapter.lock}"
+ADAPTER_BUILD_LOCK_HELD=0
+export CARGO_TARGET_DIR
 
 cleanup() {
+  if [ "$ADAPTER_BUILD_LOCK_HELD" = "1" ]; then
+    rmdir "$ADAPTER_BUILD_LOCK_DIR" 2>/dev/null || true
+  fi
   if [ "${VIBE_KEEP_TMP:-0}" = "1" ]; then
     echo "keeping tmp dir: $TMP_DIR" >&2
     return
@@ -23,6 +30,21 @@ require_cmd() {
     echo "missing required command: $1" >&2
     exit 1
   fi
+}
+
+acquire_adapter_build_lock() {
+  mkdir -p "$(dirname "$ADAPTER_BUILD_LOCK_DIR")"
+  local attempts=0
+  local max_attempts=1500
+  while ! mkdir "$ADAPTER_BUILD_LOCK_DIR" 2>/dev/null; do
+    sleep 0.2
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge "$max_attempts" ]; then
+      echo "timed out waiting for adapter build lock: $ADAPTER_BUILD_LOCK_DIR" >&2
+      exit 1
+    fi
+  done
+  ADAPTER_BUILD_LOCK_HELD=1
 }
 
 if [ -x "$HOME/.cargo/bin/cargo" ]; then
@@ -42,8 +64,16 @@ ADAPTER_WIT_DIR="$TMP_DIR/wit"
 ADAPTER_WIT_DEPS_DIR="$ADAPTER_WIT_DIR/deps"
 mkdir -p "$ADAPTER_WIT_DEPS_DIR"
 
-if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+if [ -n "${VIBE_BIN:-}" ]; then
+  RELEASE_VIBE_EXE="$VIBE_BIN"
+  if [ ! -x "$RELEASE_VIBE_EXE" ]; then
+    echo "VIBE_BIN is not executable: $RELEASE_VIBE_EXE" >&2
+    exit 1
+  fi
+else
+  export VIBE_MOON_WARN_LIST="${VIBE_MOON_WARN_LIST:--29-55-67-23-24-7-1}"
+  source "$SCRIPT_DIR/ensure_native_cli.sh"
+  RELEASE_VIBE_EXE="$VIBE_CLI_BIN"
 fi
 
 "$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$PLUG_COMPONENT"
@@ -176,10 +206,20 @@ cp \
   "$PROJECT_ROOT/deps/wasmtime/crates/wasi/src/p2/wit/deps/sockets.wit" \
   "$ADAPTER_WIT_DEPS_DIR/"
 
+acquire_adapter_build_lock
+mkdir -p "$(dirname "$ADAPTER_LOCK_FILE")"
 pushd "$TMP_DIR" >/dev/null
-PATH="$HOME/.cargo/bin:$PATH" cargo build --target wasm32-unknown-unknown --release >/dev/null
+cargo_build_args=(--target wasm32-unknown-unknown --release)
+if [ -f "$ADAPTER_LOCK_FILE" ]; then
+  cp "$ADAPTER_LOCK_FILE" Cargo.lock
+  cargo_build_args+=(--locked)
+fi
+PATH="$HOME/.cargo/bin:$PATH" cargo build "${cargo_build_args[@]}" >/dev/null
+if [ ! -f "$ADAPTER_LOCK_FILE" ] && [ -f Cargo.lock ]; then
+  cp Cargo.lock "$ADAPTER_LOCK_FILE"
+fi
 wasm-tools component embed "$ADAPTER_WIT_DIR" \
-  target/wasm32-unknown-unknown/release/vibe_selfhost_check_direct_adapter.wasm \
+  "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/vibe_selfhost_check_direct_adapter.wasm" \
   --world adapter \
   -o "$ADAPTER_EMBEDDED_WASM"
 wasm-tools component new "$ADAPTER_EMBEDDED_WASM" -o "$ADAPTER_COMPONENT"

--- a/scripts/build_selfhost_cli_command_component.sh
+++ b/scripts/build_selfhost_cli_command_component.sh
@@ -7,8 +7,16 @@ OUT_COMPONENT="${1:-$PROJECT_ROOT/dist/selfhost_cli_command.component.wasm}"
 OUT_WIT="${2:-${OUT_COMPONENT%.wasm}.wit}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_cli_command_entry.vibe}"
 TMP_DIR="$(mktemp -d /tmp/vibe_selfhost_cli_command_component.XXXXXX)"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${VIBE_SELFHOST_CLI_COMMAND_CARGO_TARGET_DIR:-$PROJECT_ROOT/_build/cargo-target/selfhost_component_adapters}}"
+ADAPTER_LOCK_FILE="${VIBE_SELFHOST_CLI_COMMAND_CARGO_LOCK:-$PROJECT_ROOT/_build/cargo-locks/selfhost_cli_command_adapter.Cargo.lock}"
+ADAPTER_BUILD_LOCK_DIR="${VIBE_SELFHOST_CLI_COMMAND_BUILD_LOCK:-$PROJECT_ROOT/_build/locks/selfhost_cli_command_adapter.lock}"
+ADAPTER_BUILD_LOCK_HELD=0
+export CARGO_TARGET_DIR
 
 cleanup() {
+  if [ "$ADAPTER_BUILD_LOCK_HELD" = "1" ]; then
+    rmdir "$ADAPTER_BUILD_LOCK_DIR" 2>/dev/null || true
+  fi
   if [ "${VIBE_KEEP_TMP:-0}" = "1" ]; then
     echo "keeping tmp dir: $TMP_DIR" >&2
     return
@@ -22,6 +30,21 @@ require_cmd() {
     echo "missing required command: $1" >&2
     exit 1
   fi
+}
+
+acquire_adapter_build_lock() {
+  mkdir -p "$(dirname "$ADAPTER_BUILD_LOCK_DIR")"
+  local attempts=0
+  local max_attempts=1500
+  while ! mkdir "$ADAPTER_BUILD_LOCK_DIR" 2>/dev/null; do
+    sleep 0.2
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge "$max_attempts" ]; then
+      echo "timed out waiting for adapter build lock: $ADAPTER_BUILD_LOCK_DIR" >&2
+      exit 1
+    fi
+  done
+  ADAPTER_BUILD_LOCK_HELD=1
 }
 
 if [ -x "$HOME/.cargo/bin/cargo" ]; then
@@ -41,9 +64,16 @@ ADAPTER_WIT_DIR="$TMP_DIR/wit"
 ADAPTER_WIT_DEPS_DIR="$ADAPTER_WIT_DIR/deps"
 mkdir -p "$ADAPTER_WIT_DEPS_DIR"
 
-RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
-if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+if [ -n "${VIBE_BIN:-}" ]; then
+  RELEASE_VIBE_EXE="$VIBE_BIN"
+  if [ ! -x "$RELEASE_VIBE_EXE" ]; then
+    echo "VIBE_BIN is not executable: $RELEASE_VIBE_EXE" >&2
+    exit 1
+  fi
+else
+  export VIBE_MOON_WARN_LIST="${VIBE_MOON_WARN_LIST:--29-55-67-23-24-7-1}"
+  source "$SCRIPT_DIR/ensure_native_cli.sh"
+  RELEASE_VIBE_EXE="$VIBE_CLI_BIN"
 fi
 
 "$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$PLUG_COMPONENT"
@@ -197,10 +227,20 @@ cp \
   "$PROJECT_ROOT/deps/wasmtime/crates/wasi/src/p2/wit/deps/sockets.wit" \
   "$ADAPTER_WIT_DEPS_DIR/"
 
+acquire_adapter_build_lock
+mkdir -p "$(dirname "$ADAPTER_LOCK_FILE")"
 pushd "$TMP_DIR" >/dev/null
-PATH="$HOME/.cargo/bin:$PATH" cargo build --target wasm32-unknown-unknown --release >/dev/null
+cargo_build_args=(--target wasm32-unknown-unknown --release)
+if [ -f "$ADAPTER_LOCK_FILE" ]; then
+  cp "$ADAPTER_LOCK_FILE" Cargo.lock
+  cargo_build_args+=(--locked)
+fi
+PATH="$HOME/.cargo/bin:$PATH" cargo build "${cargo_build_args[@]}" >/dev/null
+if [ ! -f "$ADAPTER_LOCK_FILE" ] && [ -f Cargo.lock ]; then
+  cp Cargo.lock "$ADAPTER_LOCK_FILE"
+fi
 wasm-tools component embed "$ADAPTER_WIT_DIR" \
-  target/wasm32-unknown-unknown/release/vibe_selfhost_cli_command_adapter.wasm \
+  "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/vibe_selfhost_cli_command_adapter.wasm" \
   --world adapter \
   -o "$ADAPTER_EMBEDDED_WASM"
 wasm-tools component new "$ADAPTER_EMBEDDED_WASM" -o "$ADAPTER_COMPONENT"

--- a/scripts/build_selfhost_cli_direct_component.sh
+++ b/scripts/build_selfhost_cli_direct_component.sh
@@ -6,10 +6,17 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_COMPONENT="${1:-$PROJECT_ROOT/dist/selfhost_cli_direct.component.wasm}"
 OUT_WIT="${2:-${OUT_COMPONENT%.wasm}.wit}"
 ENTRY_PATH="${ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_cli_direct_component_entry.vibe}"
-RELEASE_VIBE_EXE="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 TMP_DIR="$(mktemp -d /tmp/vibe_selfhost_cli_direct_component.XXXXXX)"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${VIBE_SELFHOST_CLI_DIRECT_CARGO_TARGET_DIR:-$PROJECT_ROOT/_build/cargo-target/selfhost_component_adapters}}"
+ADAPTER_LOCK_FILE="${VIBE_SELFHOST_CLI_DIRECT_CARGO_LOCK:-$PROJECT_ROOT/_build/cargo-locks/selfhost_cli_direct_adapter.Cargo.lock}"
+ADAPTER_BUILD_LOCK_DIR="${VIBE_SELFHOST_CLI_DIRECT_BUILD_LOCK:-$PROJECT_ROOT/_build/locks/selfhost_cli_direct_adapter.lock}"
+ADAPTER_BUILD_LOCK_HELD=0
+export CARGO_TARGET_DIR
 
 cleanup() {
+  if [ "$ADAPTER_BUILD_LOCK_HELD" = "1" ]; then
+    rmdir "$ADAPTER_BUILD_LOCK_DIR" 2>/dev/null || true
+  fi
   if [ "${VIBE_KEEP_TMP:-0}" = "1" ]; then
     echo "keeping tmp dir: $TMP_DIR" >&2
     return
@@ -23,6 +30,21 @@ require_cmd() {
     echo "missing required command: $1" >&2
     exit 1
   fi
+}
+
+acquire_adapter_build_lock() {
+  mkdir -p "$(dirname "$ADAPTER_BUILD_LOCK_DIR")"
+  local attempts=0
+  local max_attempts=1500
+  while ! mkdir "$ADAPTER_BUILD_LOCK_DIR" 2>/dev/null; do
+    sleep 0.2
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge "$max_attempts" ]; then
+      echo "timed out waiting for adapter build lock: $ADAPTER_BUILD_LOCK_DIR" >&2
+      exit 1
+    fi
+  done
+  ADAPTER_BUILD_LOCK_HELD=1
 }
 
 if [ -x "$HOME/.cargo/bin/cargo" ]; then
@@ -42,8 +64,16 @@ ADAPTER_WIT_DIR="$TMP_DIR/wit"
 ADAPTER_WIT_DEPS_DIR="$ADAPTER_WIT_DIR/deps"
 mkdir -p "$ADAPTER_WIT_DEPS_DIR"
 
-if [ ! -x "$RELEASE_VIBE_EXE" ]; then
-  moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+if [ -n "${VIBE_BIN:-}" ]; then
+  RELEASE_VIBE_EXE="$VIBE_BIN"
+  if [ ! -x "$RELEASE_VIBE_EXE" ]; then
+    echo "VIBE_BIN is not executable: $RELEASE_VIBE_EXE" >&2
+    exit 1
+  fi
+else
+  export VIBE_MOON_WARN_LIST="${VIBE_MOON_WARN_LIST:--29-55-67-23-24-7-1}"
+  source "$SCRIPT_DIR/ensure_native_cli.sh"
+  RELEASE_VIBE_EXE="$VIBE_CLI_BIN"
 fi
 
 "$RELEASE_VIBE_EXE" compile --component-string-lift "$ENTRY_PATH" -o "$PLUG_COMPONENT"
@@ -234,10 +264,20 @@ cp \
   "$PROJECT_ROOT/deps/wasmtime/crates/wasi/src/p2/wit/deps/sockets.wit" \
   "$ADAPTER_WIT_DEPS_DIR/"
 
+acquire_adapter_build_lock
+mkdir -p "$(dirname "$ADAPTER_LOCK_FILE")"
 pushd "$TMP_DIR" >/dev/null
-PATH="$HOME/.cargo/bin:$PATH" cargo build --target wasm32-unknown-unknown --release >/dev/null
+cargo_build_args=(--target wasm32-unknown-unknown --release)
+if [ -f "$ADAPTER_LOCK_FILE" ]; then
+  cp "$ADAPTER_LOCK_FILE" Cargo.lock
+  cargo_build_args+=(--locked)
+fi
+PATH="$HOME/.cargo/bin:$PATH" cargo build "${cargo_build_args[@]}" >/dev/null
+if [ ! -f "$ADAPTER_LOCK_FILE" ] && [ -f Cargo.lock ]; then
+  cp Cargo.lock "$ADAPTER_LOCK_FILE"
+fi
 wasm-tools component embed "$ADAPTER_WIT_DIR" \
-  target/wasm32-unknown-unknown/release/vibe_selfhost_cli_direct_adapter.wasm \
+  "$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/vibe_selfhost_cli_direct_adapter.wasm" \
   --world adapter \
   -o "$ADAPTER_EMBEDDED_WASM"
 wasm-tools component new "$ADAPTER_EMBEDDED_WASM" -o "$ADAPTER_COMPONENT"

--- a/scripts/run_selfhost_cli_direct_component.sh
+++ b/scripts/run_selfhost_cli_direct_component.sh
@@ -14,7 +14,8 @@ OUTPUT_PATH="$3"
 ENTRY_NAME="$4"
 COMPILE_MODE="${5:-mvp}"
 WASMTIME_RUN="$SCRIPT_DIR/wasmtime_run.sh"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
+USER_VIBE_BIN="${VIBE_BIN:-}"
+VIBE_BIN="${USER_VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
 WASMTIME_WASM_FLAGS="${VIBE_WASMTIME_WASM_FLAGS:-exceptions=y}"
 WASMTIME_WASI_FLAGS="${VIBE_WASMTIME_WASI_FLAGS:-cli=y}"
 
@@ -42,13 +43,16 @@ OUTPUT_NAME="output.wasm"
 cp -R "$INPUT_DIR"/. "$TMP_DIR/"
 
 ensure_host_vibe_bin() {
-  if [ ! -x "$VIBE_BIN" ]; then
-    moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
+  if [ -n "$USER_VIBE_BIN" ]; then
+    if [ ! -x "$VIBE_BIN" ]; then
+      echo "VIBE_BIN is not executable: $VIBE_BIN" >&2
+      exit 1
+    fi
     return
   fi
-  if ! "$VIBE_BIN" 2>&1 | grep -q 'emit-closure-payload'; then
-    moon build --target native --warn-list '-29-55-67-23-24-7-1' src/cmd/vibe >/dev/null
-  fi
+  export VIBE_MOON_WARN_LIST="${VIBE_MOON_WARN_LIST:--29-55-67-23-24-7-1}"
+  source "$SCRIPT_DIR/ensure_native_cli.sh"
+  VIBE_BIN="$VIBE_CLI_BIN"
 }
 
 ensure_host_vibe_bin

--- a/scripts/test_selfhost_cli_direct_parity.sh
+++ b/scripts/test_selfhost_cli_direct_parity.sh
@@ -17,7 +17,7 @@ if [ ! -x "$VIBE_BIN" ]; then
   moon build --target native --release src/cmd/vibe --warn-list '-29'
 fi
 
-bash "$SCRIPT_DIR/build_selfhost_cli_direct_component.sh" "$COMPONENT_PATH" "$WIT_PATH"
+VIBE_BIN="$VIBE_BIN" bash "$SCRIPT_DIR/build_selfhost_cli_direct_component.sh" "$COMPONENT_PATH" "$WIT_PATH"
 
 run_case() {
   local case_name="$1"
@@ -46,7 +46,7 @@ run_case() {
       ;;
   esac
   "$VIBE_BIN" compile-lite "${mode_flags[@]}" "$input_path" -o "$host_out"
-  bash "$SCRIPT_DIR/run_selfhost_cli_direct_component.sh" "$COMPONENT_PATH" "$input_path" "$selfhost_out" "$entry_name" "$mode"
+  VIBE_BIN="$VIBE_BIN" bash "$SCRIPT_DIR/run_selfhost_cli_direct_component.sh" "$COMPONENT_PATH" "$input_path" "$selfhost_out" "$entry_name" "$mode"
 
   wasm-tools validate "$host_out" >/dev/null
   wasm-tools validate "$selfhost_out" >/dev/null
@@ -105,7 +105,7 @@ selfhost_import_out="$import_case_dir/selfhost.wasm"
 host_import_log="$import_case_dir/host.run.log"
 selfhost_import_log="$import_case_dir/selfhost.run.log"
 "$VIBE_BIN" compile-lite --wasm-linear "$import_case_dir/main.vibe" -o "$host_import_out"
-bash "$SCRIPT_DIR/run_selfhost_cli_direct_component.sh" "$COMPONENT_PATH" "$import_case_dir/main.vibe" "$selfhost_import_out" "answer" "mvp"
+VIBE_BIN="$VIBE_BIN" bash "$SCRIPT_DIR/run_selfhost_cli_direct_component.sh" "$COMPONENT_PATH" "$import_case_dir/main.vibe" "$selfhost_import_out" "answer" "mvp"
 wasm-tools validate "$host_import_out" >/dev/null
 wasm-tools validate "$selfhost_import_out" >/dev/null
 env VIBE_WASMTIME_WASM_FLAGS="$WASMTIME_WASM_FLAGS" \


### PR DESCRIPTION
Refs #439

## Summary
- reuse a shared Cargo target dir for the selfhost component adapter temp crates
- persist generated adapter Cargo.lock files under `_build/cargo-locks` and build with `--locked` once warm
- stop probing hidden CLI commands in the direct component runner, and use `ensure_native_cli.sh` unless `VIBE_BIN` is explicit
- pass the release `VIBE_BIN` through direct parity build/run steps

## Validation
- `bash -n` on modified selfhost adapter scripts
- `git diff --check`
- focused `pkf run test-selfhost-*component` and parity gates
- `pkf run release-selfhost-gates`
- `pkf run release-check` (5m50.551s wall, 16m6.898s CPU)