### PR TITLE
Reuse native CLI in selfhost scripts

### DIFF
--- a/scripts/build_selfhost_dist.sh
+++ b/scripts/build_selfhost_dist.sh
@@ -23,24 +23,43 @@ ENTRY_PATH="${VIBE_DIST_ENTRY_PATH:-$PROJECT_ROOT/vibe/compiler/selfhost_cli_sup
 OPT_LEVEL="${VIBE_DIST_OPT_LEVEL:--O3}"
 SKIP_OPT="${VIBE_DIST_SKIP_OPT:-0}"
 
-HOST_VIBE_EXE_RELEASE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
-HOST_VIBE_EXE_DEBUG="$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe"
+EXPLICIT_VIBE_BIN="${VIBE_BIN:-${VIBE_CLI:-}}"
 
 mkdir -p "$DIST_DIR"
 
 RAW_WASM="$DIST_DIR/selfhost_compiler_raw.wasm"
 DIST_WASM="$DIST_DIR/selfhost_compiler.wasm"
 
-# --- Step 1: Host compile ---
-if [ -x "$HOST_VIBE_EXE_RELEASE" ]; then
-  HOST_CMD=("$HOST_VIBE_EXE_RELEASE" compile --wasm --force-cabi-realloc)
-elif [ -x "$HOST_VIBE_EXE_DEBUG" ]; then
-  HOST_CMD=("$HOST_VIBE_EXE_DEBUG" compile --wasm --force-cabi-realloc)
-else
+resolve_host_cmd() {
+  if [ -n "$EXPLICIT_VIBE_BIN" ]; then
+    if [ ! -x "$EXPLICIT_VIBE_BIN" ]; then
+      echo "[dist] VIBE_BIN/VIBE_CLI is not executable: $EXPLICIT_VIBE_BIN" >&2
+      exit 1
+    fi
+    HOST_CMD=("$EXPLICIT_VIBE_BIN" compile --wasm --force-cabi-realloc)
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "$PROJECT_ROOT/target/native/release/build/cmd/vibe/vibe.exe" \
+    "$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe" \
+    "$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe" \
+    "$PROJECT_ROOT/target/native/debug/build/cmd/vibe/vibe.exe" \
+  ; do
+    if [ -x "$candidate" ]; then
+      HOST_CMD=("$candidate" compile --wasm --force-cabi-realloc)
+      return
+    fi
+  done
+
   echo "[dist] building host CLI..." >&2
-  (cd "$PROJECT_ROOT" && moon build --target native --release src/cmd/vibe --warn-list '-1-7-24-29' >/dev/null)
-  HOST_CMD=("$HOST_VIBE_EXE_RELEASE" compile --wasm --force-cabi-realloc)
-fi
+  VIBE_CLI_RELEASE=1 source "$SCRIPT_DIR/ensure_native_cli.sh"
+  HOST_CMD=("$VIBE_CLI_BIN" compile --wasm --force-cabi-realloc)
+}
+
+# --- Step 1: Host compile ---
+resolve_host_cmd
 
 echo "[dist] stage1: host compile $ENTRY_PATH"
 "${HOST_CMD[@]}" "$ENTRY_PATH" -o "$RAW_WASM"

--- a/scripts/test_selfhost_runtime_fixtures.sh
+++ b/scripts/test_selfhost_runtime_fixtures.sh
@@ -3,15 +3,40 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-VIBE_BIN="${VIBE_BIN:-$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe}"
+VIBE_BIN="${VIBE_BIN:-${VIBE_CLI:-}}"
 OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/selfhost_runtime_fixtures}"
 SNAPSHOT_FILE="${VIBE_SELFHOST_RUNTIME_FIXTURE_SNAPSHOT_FILE:-$PROJECT_ROOT/bench/golden/selfhost_runtime_fixture_snapshot.json}"
 SHARD_SIZE="${VIBE_SELFHOST_RUNTIME_FIXTURE_SHARD_SIZE:-10}"
 GENERATED_DIR="$PROJECT_ROOT/vibe/compiler/_generated_selfhost_runtime_fixtures"
 
-if [ ! -x "$VIBE_BIN" ]; then
-  moon build --target native src/cmd/vibe --warn-list '-29' >/dev/null
-fi
+resolve_vibe_bin() {
+  if [ -n "$VIBE_BIN" ]; then
+    if [ ! -x "$VIBE_BIN" ]; then
+      echo "selfhost runtime fixtures: VIBE_BIN/VIBE_CLI is not executable: $VIBE_BIN" >&2
+      exit 1
+    fi
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    "$PROJECT_ROOT/target/native/release/build/cmd/vibe/vibe.exe" \
+    "$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe" \
+    "$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe" \
+    "$PROJECT_ROOT/target/native/debug/build/cmd/vibe/vibe.exe" \
+  ; do
+    if [ -x "$candidate" ]; then
+      VIBE_BIN="$candidate"
+      return
+    fi
+  done
+
+  export VIBE_MOON_WARN_LIST="${VIBE_MOON_WARN_LIST:--29}"
+  source "$SCRIPT_DIR/ensure_native_cli.sh"
+  VIBE_BIN="$VIBE_CLI_BIN"
+}
+
+resolve_vibe_bin
 
 cd "$PROJECT_ROOT"
 mkdir -p "$OUT_DIR"

--- a/scripts/test_wasm_gc_validate.sh
+++ b/scripts/test_wasm_gc_validate.sh
@@ -25,12 +25,16 @@ log_fail() { echo -e "${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
 
 cd "$PROJECT_ROOT"
 
-VIBE="${VIBE_CLI:-}"
+VIBE="${VIBE_BIN:-${VIBE_CLI:-}}"
+if [ -n "$VIBE" ] && [ ! -x "$VIBE" ]; then
+  echo "ERROR: VIBE_BIN/VIBE_CLI is not executable: $VIBE" >&2
+  exit 1
+fi
 if [ -z "$VIBE" ]; then
-  # Try debug build first, then release
   for candidate in \
-    _build/native/debug/build/cmd/vibe/vibe.exe \
     target/native/release/build/cmd/vibe/vibe.exe \
+    _build/native/release/build/cmd/vibe/vibe.exe \
+    _build/native/debug/build/cmd/vibe/vibe.exe \
     target/native/debug/build/cmd/vibe/vibe.exe \
   ; do
     if [ -x "$candidate" ]; then
@@ -39,10 +43,10 @@ if [ -z "$VIBE" ]; then
     fi
   done
 fi
-if [ -z "$VIBE" ] || [ ! -x "$VIBE" ]; then
+if [ -z "$VIBE" ]; then
   echo "Building vibe CLI (debug)..."
-  moon build --target native src/cmd/vibe 2>/dev/null
-  VIBE="_build/native/debug/build/cmd/vibe/vibe.exe"
+  VIBE_MOON_WARN_LIST="${VIBE_MOON_WARN_LIST:--29}" source "$SCRIPT_DIR/ensure_native_cli.sh"
+  VIBE="$VIBE_CLI_BIN"
 fi
 if [ ! -x "$VIBE" ]; then
   echo "ERROR: vibe CLI not found and build failed" >&2


### PR DESCRIPTION
## Summary
- let `build_selfhost_dist.sh` honor explicit `VIBE_BIN` / `VIBE_CLI` and existing target/_build native CLI binaries before rebuilding
- make wasm-gc validation prefer existing release CLI and accept `VIBE_BIN`
- make selfhost runtime fixtures reuse an existing release/debug CLI instead of defaulting directly to debug build

This reduces redundant native CLI builds in the `selfhost-examples` CI job: after `build_selfhost_dist.sh` creates a release CLI, later validation scripts can reuse it instead of building a separate debug CLI.

## Validation
- `bash -n scripts/build_selfhost_dist.sh scripts/test_wasm_gc_validate.sh scripts/test_selfhost_runtime_fixtures.sh`
- `git diff --check`
- `VIBE_DIST_SKIP_OPT=1 bash scripts/build_selfhost_dist.sh` (4.042s wall)
- `bash scripts/pkfire/selfhost_examples_smoke.sh` (1.851s wall)
- `bash scripts/test_wasm_gc_validate.sh` (2.206s wall)
- `pkf run build-selfhost-dist-raw` (4.112s wall)
- `pkf run ci-selfhost-examples-smoke` (2.044s wall)
- `pkf run test-wasm-gc-validate` (2.265s wall)
- `pkf run release-check` (4m39.182s wall, 12m41.82s CPU)

## Notes
- Standalone `scripts/test_selfhost_runtime_fixtures.sh` currently fails before CLI resolution because the runtime fixture snapshot has drifted. Tracked separately in #442; CI keeps that step non-blocking today.