### PR TITLE
De-duplicate CI contract setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,13 @@ jobs:
           ripgrep: 'true'
 
       - name: Run moon test (verbose, for flaker)
+        id: moon_test_flaker
         run: |
-          moon test --target js -v 2>&1 | tee .flaker-test-output.txt || true
+          set +e
+          moon test --target js -v 2>&1 | tee .flaker-test-output.txt
+          status=${PIPESTATUS[0]}
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: Upload test results for flaker
         if: always()
@@ -44,7 +49,7 @@ jobs:
 
       - name: PR contract checks (MoonBit/js)
         id: contract_moon
-        run: bash scripts/pkfire/contract_moon.sh 2>&1 | tee /tmp/contract_moon.log
+        run: VIBE_CONTRACT_MOON_SKIP_JS_PACKAGE_TESTS=1 bash scripts/pkfire/contract_moon.sh 2>&1 | tee /tmp/contract_moon.log
         continue-on-error: true
 
       - name: Surface contract-moon failure in annotations
@@ -53,6 +58,15 @@ jobs:
           echo "::error::contract-moon failed; tail of log follows:"
           tail -80 /tmp/contract_moon.log | while IFS= read -r line; do
             echo "::error::cm: $line"
+          done
+          exit 1
+
+      - name: Surface moon test failure in annotations
+        if: steps.moon_test_flaker.outputs.exit_code != '0'
+        run: |
+          echo "::error::moon test --target js failed; tail of log follows:"
+          tail -80 .flaker-test-output.txt | while IFS= read -r line; do
+            echo "::error::moon-test: $line"
           done
           exit 1
 
@@ -530,6 +544,7 @@ jobs:
 
   selfhost-examples:
     runs-on: ubuntu-latest
+    needs: native-cli-release
     steps:
       - uses: actions/checkout@v5
 
@@ -538,6 +553,18 @@ jobs:
         with:
           wasmtime: 'true'
           node-version: '24'
+
+      - name: Download native CLI (release)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-release
+          path: target/native/release/build/cmd/vibe
+
+      - name: Set VIBE_BIN for release binary
+        run: |
+          chmod +x target/native/release/build/cmd/vibe/vibe.exe
+          touch target/native/release/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
 
       - name: Build selfhost compiler
         run: VIBE_DIST_SKIP_OPT=1 bash scripts/build_selfhost_dist.sh

--- a/scripts/generate_selfhost_bundle_test.sh
+++ b/scripts/generate_selfhost_bundle_test.sh
@@ -130,20 +130,20 @@ if ! rg -q '^export let selfhost_cli_adapter_module_source' "$OUT_ADAPTER"; then
   exit 1
 fi
 
-if ! rg -Fq 'push_grouped_source_pair(groups, "core", source_0)' "$OUT"; then
+if ! rg -Fq 'push_grouped_source_pair(groups, "core", selfhost_source_0)' "$OUT"; then
   echo "generate-selfhost-bundle self-test: missing core group mapping" >&2
   cat "$OUT" >&2
   exit 1
 fi
 
-if ! rg -Fq 'push_grouped_source_pair(groups, "syntax", source_1)' "$OUT"; then
+if ! rg -Fq 'push_grouped_source_pair(groups, "syntax", selfhost_source_1)' "$OUT"; then
   echo "generate-selfhost-bundle self-test: missing syntax group mapping" >&2
   cat "$OUT" >&2
   exit 1
 fi
 
 # source_2 is selfhost_cli_adapter.vibe (entry group)
-if ! rg -Fq 'push_grouped_source_pair(groups, "entry", source_2)' "$OUT"; then
+if ! rg -Fq 'push_grouped_source_pair(groups, "entry", selfhost_source_2)' "$OUT"; then
   echo "generate-selfhost-bundle self-test: missing entry group mapping" >&2
   cat "$OUT" >&2
   exit 1
@@ -155,13 +155,13 @@ adapter_module_block="$(sed -n '/export let selfhost_cli_adapter_module_source/,
 adapter_merged_value_block="$(sed -n '/let selfhost_cli_adapter_merged_source_value =/,/export let selfhost_cli_adapter_merged_source/p' "$OUT_ADAPTER")"
 adapter_module_value_block="$(sed -n '/let selfhost_cli_adapter_module_source_value =/,/export let selfhost_cli_adapter_module_source/p' "$OUT_ADAPTER")"
 
-if ! printf '%s\n' "$adapter_sources_block" | rg -Fq 'Array::push(sources, source_1)'; then
+if ! printf '%s\n' "$adapter_sources_block" | rg -Fq 'Array::push(sources, cli_adapter_source_1)'; then
   echo "generate-selfhost-bundle self-test: adapter closure missing token source" >&2
   cat "$OUT_ADAPTER" >&2
   exit 1
 fi
 
-if ! printf '%s\n' "$adapter_sources_block" | rg -Fq 'Array::push(sources, source_2)'; then
+if ! printf '%s\n' "$adapter_sources_block" | rg -Fq 'Array::push(sources, cli_adapter_source_2)'; then
   echo "generate-selfhost-bundle self-test: adapter closure missing adapter source" >&2
   cat "$OUT_ADAPTER" >&2
   exit 1

--- a/scripts/pkfire/contract_moon.sh
+++ b/scripts/pkfire/contract_moon.sh
@@ -3,11 +3,12 @@
 set -euo pipefail
 
 moon_warn_list="${VIBE_MOON_WARN_LIST:--1-6-7-9-20-24-29}"
+skip_js_package_tests="${VIBE_CONTRACT_MOON_SKIP_JS_PACKAGE_TESTS:-0}"
 
 scripts/check_lock_clean.sh
 scripts/check_lock_clean_test.sh
 bash scripts/generate_selfhost_bundle_test.sh
 node --test scripts/coverage_selfhost_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs
 moon check --deny-warn --warn-list "$moon_warn_list" --target js
-bash scripts/test_codegen_contract.sh
-VIBE_MOON_WARN_LIST="$moon_warn_list" bash scripts/test_contract_moon.sh
+VIBE_CODEGEN_CONTRACT_SKIP_MOON_CHECK=1 bash scripts/test_codegen_contract.sh
+VIBE_CONTRACT_MOON_SKIP_JS_PACKAGE_TESTS="$skip_js_package_tests" VIBE_MOON_WARN_LIST="$moon_warn_list" bash scripts/test_contract_moon.sh

--- a/scripts/test_codegen_contract.sh
+++ b/scripts/test_codegen_contract.sh
@@ -8,4 +8,6 @@ if rg -n '@checker|mizchi/vibe/checker' src/codegen/moon.pkg src/codegen >/dev/n
   exit 1
 fi
 
-moon check --target js --deny-warn --warn-list "${warn_list}" src/codegen
+if [ "${VIBE_CODEGEN_CONTRACT_SKIP_MOON_CHECK:-0}" != "1" ]; then
+  moon check --target js --deny-warn --warn-list "${warn_list}" src/codegen
+fi

--- a/scripts/test_contract_moon.sh
+++ b/scripts/test_contract_moon.sh
@@ -8,13 +8,16 @@ contract_js_packages=(
   src/runtime_compile
 )
 
-for pkg_dir in "${contract_js_packages[@]}"; do
-  NODE_OPTIONS=--max-old-space-size=8192 moon test --target js --warn-list "$warn_list" "$pkg_dir"
-done
+if [ "${VIBE_CONTRACT_MOON_SKIP_JS_PACKAGE_TESTS:-0}" != "1" ]; then
+  NODE_OPTIONS=--max-old-space-size=8192 moon test --target js --warn-list "$warn_list" "${contract_js_packages[@]}"
+fi
 
 moon build src/cmd/warning_fixture/main.mbt --target js --warn-list "$warn_list"
-moon build src/cmd/typecheck_fixture/main.mbt --target native --warn-list "$warn_list"
-moon build src/cmd/parser_contract/main.mbt --target native --warn-list "$warn_list"
+moon build \
+  src/cmd/typecheck_fixture/main.mbt \
+  src/cmd/parser_contract/main.mbt \
+  --target native \
+  --warn-list "$warn_list"
 
 warning_fixture_js="_build/js/debug/build/cmd/warning_fixture/warning_fixture.js"
 typecheck_fixture_native="_build/native/debug/build/cmd/typecheck_fixture/typecheck_fixture.exe"


### PR DESCRIPTION
## Summary
- make the contract-moon flaker moon test authoritative, then skip duplicated JS package subset tests in the CI contract path
- skip duplicated codegen moon check after the full contract-moon moon check
- have selfhost-examples reuse the native-cli-release artifact instead of rebuilding the release CLI
- refresh stale generate_selfhost_bundle self-test expectations for current generated variable names

Closes #444

## Validation
- actionlint .github/workflows/ci.yml
- bash -n scripts/generate_selfhost_bundle_test.sh scripts/test_codegen_contract.sh scripts/test_contract_moon.sh scripts/pkfire/contract_moon.sh
- bash scripts/generate_selfhost_bundle_test.sh
- VIBE_CODEGEN_CONTRACT_SKIP_MOON_CHECK=1 bash scripts/test_codegen_contract.sh
- VIBE_CONTRACT_MOON_SKIP_JS_PACKAGE_TESTS=1 bash scripts/test_contract_moon.sh
- bash scripts/test_contract_moon.sh
- VIBE_CONTRACT_MOON_SKIP_JS_PACKAGE_TESTS=1 bash scripts/pkfire/contract_moon.sh
- moon test --target js -v
- bash scripts/pkfire/contract_moon.sh
- VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe VIBE_DIST_SKIP_OPT=1 bash scripts/build_selfhost_dist.sh
- VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe bash scripts/pkfire/selfhost_examples_smoke.sh
- VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe bash scripts/test_wasm_gc_validate.sh
- pkf run release-check