### PR TITLE
Speed up selfhost bundle self-test

### DIFF
--- a/scripts/generate_selfhost_bundle.sh
+++ b/scripts/generate_selfhost_bundle.sh
@@ -431,6 +431,29 @@ run_host_vibe_cmd() {
 
 build_adapter_module_source() {
   local merged_source_file="$1"
+  # Fast path for tiny shell self-tests; production generation uses
+  # emit-module-source through the host compiler below.
+  if [ "${VIBE_SELFHOST_ADAPTER_MODULE_SOURCE_FROM_MERGED:-0}" = "1" ]; then
+    local module_source_path
+    mkdir -p "$PROJECT_ROOT/_build"
+    module_source_path="$(mktemp "$PROJECT_ROOT/_build/selfhost_cli_adapter_module_source.XXXXXX")"
+    python3 - "$merged_source_file" "$module_source_path" <<'PY'
+import sys
+
+src, out = sys.argv[1:]
+with open(src, "r", encoding="utf-8") as f:
+    lines = f.readlines()
+
+with open(out, "w", encoding="utf-8") as f:
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("let ") and "->" not in stripped:
+            continue
+        f.write(line)
+PY
+    printf '%s\n' "$module_source_path"
+    return 0
+  fi
   local module_source_path
   mkdir -p "$PROJECT_ROOT/_build"
   module_source_path="$(mktemp "$PROJECT_ROOT/_build/selfhost_cli_adapter_module_source.XXXXXX")"

--- a/scripts/generate_selfhost_bundle_test.sh
+++ b/scripts/generate_selfhost_bundle_test.sh
@@ -45,6 +45,7 @@ VIBE_SELFHOST_SOURCE_MANIFEST="$TMP_ROOT/vibe/compiler/selfhost_sources_manifest
 VIBE_SELFHOST_BUNDLE_OUT="$TMP_ROOT/vibe/compiler/selfhost_sources_bundle.vibe" \
 VIBE_SELFHOST_ADAPTER_BUNDLE_OUT="$TMP_ROOT/vibe/compiler/selfhost_cli_adapter_bundle.vibe" \
 VIBE_SELFHOST_BUNDLE_EXTRA_ENTRIES="" \
+VIBE_SELFHOST_ADAPTER_MODULE_SOURCE_FROM_MERGED=1 \
 bash "$BUNDLE_SCRIPT" >/dev/null
 
 OUT="$TMP_ROOT/vibe/compiler/selfhost_sources_bundle.vibe"


### PR DESCRIPTION
## Summary

- add an explicit fast path for tiny selfhost bundle shell self-tests
- keep production bundle generation using host `emit-module-source` by default
- make `generate_selfhost_bundle_test.sh` avoid building the full native `vibe` CLI

## Validation

- `bash -n scripts/generate_selfhost_bundle.sh`
- `bash -n scripts/generate_selfhost_bundle_test.sh`
- `bash scripts/generate_selfhost_bundle_test.sh`
- `VIBE_CONTRACT_MOON_SKIP_MOON_CHECK=1 VIBE_CONTRACT_MOON_SKIP_JS_PACKAGE_TESTS=1 VIBE_MOON_WARN_LIST="-1-6-7-9-20-24-27-29" bash scripts/pkfire/contract_moon.sh`
- `bash scripts/check_selfhost_bundle_sync.sh`
- `pkf run release-check`

Closes #450
