### PR TITLE
Cache native CLI binaries in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,28 @@ jobs:
         with:
           moon-build-cache: 'true'
 
+      - name: Restore native CLI release cache
+        id: native-cli-release-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: target/native/release/build/cmd/vibe/vibe.exe
+          key: native-cli-release-${{ runner.os }}-${{ hashFiles('.moon-version', 'moon.mod', 'moon.mod.json', 'moon.pkg', 'moon.pkg.json', '**/moon.pkg', '**/moon.pkg.json', 'src/**/*.mbt', 'scripts/ensure_native_cli.sh') }}
+
       - name: Build vibe CLI (native release)
+        if: steps.native-cli-release-cache.outputs.cache-hit != 'true'
         run: VIBE_CLI_RELEASE=1 VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+
+      - name: Mark native CLI release executable
+        run: |
+          chmod +x target/native/release/build/cmd/vibe/vibe.exe
+          touch target/native/release/build/cmd/vibe/vibe.exe
+
+      - name: Save native CLI release cache
+        if: steps.native-cli-release-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: target/native/release/build/cmd/vibe/vibe.exe
+          key: ${{ steps.native-cli-release-cache.outputs.cache-primary-key }}
 
       - name: Upload native CLI release
         uses: actions/upload-artifact@v6
@@ -257,8 +277,28 @@ jobs:
         with:
           moon-build-cache: 'true'
 
+      - name: Restore native CLI debug cache
+        id: native-cli-debug-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: _build/native/debug/build/cmd/vibe/vibe.exe
+          key: native-cli-debug-${{ runner.os }}-${{ hashFiles('.moon-version', 'moon.mod', 'moon.mod.json', 'moon.pkg', 'moon.pkg.json', '**/moon.pkg', '**/moon.pkg.json', 'src/**/*.mbt', 'scripts/ensure_native_cli.sh') }}
+
       - name: Build vibe CLI (native debug)
+        if: steps.native-cli-debug-cache.outputs.cache-hit != 'true'
         run: VIBE_CLI_FORCE=1 bash -c 'source scripts/ensure_native_cli.sh'
+
+      - name: Mark native CLI debug executable
+        run: |
+          chmod +x _build/native/debug/build/cmd/vibe/vibe.exe
+          touch _build/native/debug/build/cmd/vibe/vibe.exe
+
+      - name: Save native CLI debug cache
+        if: steps.native-cli-debug-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: _build/native/debug/build/cmd/vibe/vibe.exe
+          key: ${{ steps.native-cli-debug-cache.outputs.cache-primary-key }}
 
       - name: Upload native CLI debug
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

- cache native release/debug CLI binaries by MoonBit source hash
- skip native CLI builds on exact cache hits, then chmod/touch before artifact upload
- keep cache-miss behavior on the existing forced ensure_native_cli build path

Closes #452

## Validation

- actionlint .github/workflows/ci.yml
- git diff --check
