### PR TITLE
Reuse native debug CLI in contract-native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
 
   contract-native:
     runs-on: ubuntu-latest
+    needs: native-cli-debug
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -127,6 +128,19 @@ jobs:
           ripgrep: 'true'
           wasmtime: 'true'
           vibe-debug-cache: 'true'
+
+      - name: Download native CLI (debug)
+        uses: actions/download-artifact@v6
+        with:
+          name: native-cli-debug
+          path: _build/native/debug/build/cmd/vibe
+
+      - name: Set VIBE_BIN for debug binary
+        run: |
+          chmod +x _build/native/debug/build/cmd/vibe/vibe.exe
+          touch _build/native/debug/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
+          echo "VIBE_CLI_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
 
       - name: PR contract checks (native/runtime)
         run: bash scripts/pkfire/contract_native.sh


### PR DESCRIPTION
## Summary

- make contract-native consume the native-cli-debug artifact
- place the artifact at the path expected by ensure_native_cli.sh and touch it before running checks
- keep local contract_native.sh behavior unchanged

Closes #456

## Validation

- actionlint .github/workflows/ci.yml
- git diff --check
