### PR TITLE
Speed up component E2E CLI startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,6 +638,20 @@ jobs:
           wasm-tools: 'true'
           node-version: '24'
 
+      - name: Restore native CLI release cache
+        id: e2e-native-cli-release-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: target/native/release/build/cmd/vibe/vibe.exe
+          key: native-cli-release-${{ runner.os }}-${{ hashFiles('.moon-version', 'moon.mod', 'moon.mod.json', 'moon.pkg', 'moon.pkg.json', '**/moon.pkg', '**/moon.pkg.json', 'src/**/*.mbt', 'scripts/ensure_native_cli.sh') }}
+
+      - name: Set VIBE_BIN from cached release binary
+        if: steps.e2e-native-cli-release-cache.outputs.cache-hit == 'true'
+        run: |
+          chmod +x target/native/release/build/cmd/vibe/vibe.exe
+          touch target/native/release/build/cmd/vibe/vibe.exe
+          echo "VIBE_BIN=$(pwd)/target/native/release/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
+
       - name: Run Component E2E tests
         run: ./scripts/test_component_e2e.sh
 

--- a/scripts/component_wkg_stdio.sh
+++ b/scripts/component_wkg_stdio.sh
@@ -39,7 +39,13 @@ EMBEDDED_WASM="${TMP_DIR}/${BASE}.embedded.wasm"
 WIT_PKG="${TMP_DIR}/${BASE}.wit.wasm"
 
 RELEASE_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
-if [ -x "$RELEASE_VIBE_EXE" ]; then
+if [ -n "${VIBE_BIN:-}" ]; then
+  if [ ! -x "$VIBE_BIN" ]; then
+    echo "VIBE_BIN is not executable: $VIBE_BIN" >&2
+    exit 1
+  fi
+  VIBE_CMD=("$VIBE_BIN" compile)
+elif [ -x "$RELEASE_VIBE_EXE" ]; then
   VIBE_CMD=("$RELEASE_VIBE_EXE" compile)
 else
   VIBE_CMD=(moon run --target native src/cmd/vibe -- compile)

--- a/scripts/test_component_e2e.sh
+++ b/scripts/test_component_e2e.sh
@@ -37,15 +37,25 @@ log_info() {
   echo -e "${YELLOW}INFO${NC}: $1"
 }
 
-# Build the CLI first
-log_info "Building vibe CLI..."
 cd "$PROJECT_ROOT"
-moon build src/cmd/vibe/main.mbt --target native -q 2>/dev/null || {
-  log_fail "Failed to build vibe CLI"
-  exit 1
-}
 
-VIBE="moon run src/cmd/vibe/main.mbt --target native --"
+if [ -n "${VIBE_BIN:-}" ]; then
+  log_info "Using VIBE_BIN: $VIBE_BIN"
+else
+  log_info "Building vibe CLI..."
+  moon build src/cmd/vibe/main.mbt --target native -q 2>/dev/null || {
+    log_fail "Failed to build vibe CLI"
+    exit 1
+  }
+  VIBE_BIN="$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe"
+fi
+
+if [ ! -x "$VIBE_BIN" ]; then
+  log_fail "vibe CLI is not executable: $VIBE_BIN"
+  exit 1
+fi
+
+VIBE_CMD=("$VIBE_BIN")
 WASMTIME_BIN=""
 WASMTIME_RUN="$PROJECT_ROOT/scripts/wasmtime_run.sh"
 HAS_WASMTIME=0
@@ -86,7 +96,7 @@ let sum_up = (n: Int) -> Int {
 sum_up(5)
 EOF
 
-  if ! $VIBE compile --wasm "$TMP_DIR/while_test.vibe" -o "$TMP_DIR/while_test.wasm" 2>/dev/null; then
+  if ! "${VIBE_CMD[@]}" compile --wasm "$TMP_DIR/while_test.vibe" -o "$TMP_DIR/while_test.wasm" 2>/dev/null; then
     log_fail "While loop WASM compilation failed"
     return
   fi
@@ -120,7 +130,7 @@ export let multiply = (a: Int, b: Int) -> Int {
 add(1, 2)
 EOF
 
-  if ! $VIBE compile --wit "$TMP_DIR/wit_test.vibe" -o "$TMP_DIR/wit_test.wit" 2>/dev/null; then
+  if ! "${VIBE_CMD[@]}" compile --wit "$TMP_DIR/wit_test.vibe" -o "$TMP_DIR/wit_test.wit" 2>/dev/null; then
     log_fail "WIT compilation failed"
     return
   fi
@@ -161,7 +171,7 @@ let square = (x: Int) -> Int {
 square(7)
 EOF
 
-  if ! $VIBE compile --component "$TMP_DIR/component_test.vibe" -o "$TMP_DIR/component_test.component.wasm" 2>/dev/null; then
+  if ! "${VIBE_CMD[@]}" compile --component "$TMP_DIR/component_test.vibe" -o "$TMP_DIR/component_test.component.wasm" 2>/dev/null; then
     log_fail "Component WASM compilation failed"
     return
   fi
@@ -218,7 +228,7 @@ let quot = a / b
 prod
 EOF
 
-  if ! $VIBE compile --wasm "$TMP_DIR/arith_test.vibe" -o "$TMP_DIR/arith_test.wasm" 2>/dev/null; then
+  if ! "${VIBE_CMD[@]}" compile --wasm "$TMP_DIR/arith_test.vibe" -o "$TMP_DIR/arith_test.wasm" 2>/dev/null; then
     log_fail "Arithmetic WASM compilation failed"
     return
   fi
@@ -243,7 +253,7 @@ EOF
 
   # Ensure dist/ exists and run from project root
   mkdir -p "$PROJECT_ROOT/dist"
-  if ! $VIBE compile --wasm "$TMP_DIR/default_out.vibe" 2>/dev/null; then
+  if ! "${VIBE_CMD[@]}" compile --wasm "$TMP_DIR/default_out.vibe" 2>/dev/null; then
     log_fail "Default output compilation failed"
     return
   fi
@@ -268,9 +278,9 @@ handle { parse("test", 5) } with Error { Throw(_) => ("err", 0) }
 EOF
 
   # Compile to WASM to verify parsing works; tuple return is not yet supported at runtime
-  if ! $VIBE compile --wasm "$TMP_DIR/tuple_effects.vibe" -o "$TMP_DIR/tuple_effects.wasm" 2>/dev/null; then
+  if ! "${VIBE_CMD[@]}" compile --wasm "$TMP_DIR/tuple_effects.vibe" -o "$TMP_DIR/tuple_effects.wasm" 2>/dev/null; then
     # Tuple return in WASM codegen is a known limitation, check WIT generation instead
-    if $VIBE compile --wit "$TMP_DIR/tuple_effects.vibe" -o "$TMP_DIR/tuple_effects.wit" 2>/dev/null; then
+    if "${VIBE_CMD[@]}" compile --wit "$TMP_DIR/tuple_effects.vibe" -o "$TMP_DIR/tuple_effects.wit" 2>/dev/null; then
       log_pass "Tuple with effects parses and generates WIT"
     else
       log_fail "Tuple with effects failed to parse"
@@ -291,7 +301,7 @@ export let identity = (x: Int) -> Int { x }
 1
 EOF
 
-  if ! $VIBE compile --wit "$TMP_DIR/wit_types.vibe" -o "$TMP_DIR/wit_types.wit" 2>/dev/null; then
+  if ! "${VIBE_CMD[@]}" compile --wit "$TMP_DIR/wit_types.vibe" -o "$TMP_DIR/wit_types.wit" 2>/dev/null; then
     log_fail "WIT types compilation failed"
     return
   fi


### PR DESCRIPTION
## Summary\n\n- let scripts/test_component_e2e.sh use VIBE_BIN when provided\n- call the built native CLI directly instead of repeatedly invoking moon run\n- let component_wkg_stdio.sh honor VIBE_BIN\n- restore the native-cli-release binary cache in e2e-component and pass VIBE_BIN only on cache hit\n\nCloses #458\n\n## Validation\n\n- bash -n scripts/test_component_e2e.sh scripts/component_wkg_stdio.sh\n- actionlint .github/workflows/ci.yml\n- shellcheck scripts/test_component_e2e.sh scripts/component_wkg_stdio.sh\n- git diff --check\n- time VIBE_BIN="/Users/mz/ghq/github.com/mizchi/vibe-lang/_build/native/debug/build/cmd/vibe/vibe.exe" scripts/test_component_e2e.sh (0.535s, 14 passed)\n- time scripts/test_component_e2e.sh (0.290s hot fallback, 14 passed)\n