### PR TITLE
Balance selfhost bootstrap test shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,30 +492,42 @@ jobs:
         include:
           - part: tests-0
             run_tests: '1'
+            run_probes: '0'
             run_deterministic: '0'
             test_shard_index: '0'
             test_shard_total: '4'
             needs_wasmtime_submodule: 'false'
           - part: tests-1
             run_tests: '1'
+            run_probes: '0'
             run_deterministic: '0'
             test_shard_index: '1'
             test_shard_total: '4'
             needs_wasmtime_submodule: 'false'
           - part: tests-2
             run_tests: '1'
+            run_probes: '0'
             run_deterministic: '0'
             test_shard_index: '2'
             test_shard_total: '4'
             needs_wasmtime_submodule: 'false'
           - part: tests-3
             run_tests: '1'
+            run_probes: '0'
             run_deterministic: '0'
             test_shard_index: '3'
             test_shard_total: '4'
             needs_wasmtime_submodule: 'false'
+          - part: probes
+            run_tests: '0'
+            run_probes: '1'
+            run_deterministic: '0'
+            test_shard_index: ''
+            test_shard_total: ''
+            needs_wasmtime_submodule: 'false'
           - part: deterministic
             run_tests: '0'
+            run_probes: '0'
             run_deterministic: '1'
             test_shard_index: ''
             test_shard_total: ''
@@ -550,6 +562,7 @@ jobs:
         env:
           VIBE_SELFHOST_BOOTSTRAP_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || 'full' }}
           VIBE_SELFHOST_BOOTSTRAP_RUN_TESTS: ${{ matrix.run_tests }}
+          VIBE_SELFHOST_BOOTSTRAP_RUN_PROBES: ${{ matrix.run_probes }}
           VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC: ${{ matrix.run_deterministic }}
           VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_INDEX: ${{ matrix.test_shard_index }}
           VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_TOTAL: ${{ matrix.test_shard_total }}

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -99,7 +99,7 @@ local testGenerateSelfhostBundle =
 local testCoverageScripts = new Task {
   name = "test-coverage-scripts"
   cmd =
-    "node --test scripts/coverage_selfhost_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs"
+    "node --test scripts/coverage_selfhost_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/selfhost_select_test_shard.test.mjs"
   inputs { "scripts/**/*.mjs" }
 }
 

--- a/scripts/pkfire/contract_moon.sh
+++ b/scripts/pkfire/contract_moon.sh
@@ -9,7 +9,7 @@ skip_js_package_tests="${VIBE_CONTRACT_MOON_SKIP_JS_PACKAGE_TESTS:-0}"
 scripts/check_lock_clean.sh
 scripts/check_lock_clean_test.sh
 bash scripts/generate_selfhost_bundle_test.sh
-node --test scripts/coverage_selfhost_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs
+node --test scripts/coverage_selfhost_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/selfhost_select_test_shard.test.mjs
 if [ "$skip_moon_check" != "1" ]; then
   moon check --deny-warn --warn-list "$moon_warn_list" --target js
 fi

--- a/scripts/pkfire/test_suite.sh
+++ b/scripts/pkfire/test_suite.sh
@@ -10,7 +10,7 @@ node_options="${VIBE_TEST_NODE_OPTIONS:---max-old-space-size=16384}"
 scripts/check_lock_clean.sh
 scripts/check_lock_clean_test.sh
 bash scripts/generate_selfhost_bundle_test.sh
-node --test scripts/coverage_selfhost_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs
+node --test scripts/coverage_selfhost_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/selfhost_select_test_shard.test.mjs
 env NODE_OPTIONS="$node_options" moon test --target "$target" --warn-list "$moon_warn_list"
 bash scripts/test_typecheck_fixtures.sh
 bash scripts/test_warning_fixtures.sh

--- a/scripts/selfhost_select_test_shard.mjs
+++ b/scripts/selfhost_select_test_shard.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_WEIGHT = 1000;
+
+export function normalizeRepoPath(file, root) {
+  const rel = path.isAbsolute(file) ? path.relative(root, file) : file;
+  return rel.split(path.sep).join("/");
+}
+
+export function loadWeights(weightsPath) {
+  if (!weightsPath || !fs.existsSync(weightsPath)) {
+    return {};
+  }
+  const parsed = JSON.parse(fs.readFileSync(weightsPath, "utf8"));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`weights file must be a JSON object: ${weightsPath}`);
+  }
+  const weights = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    const weight = Number(value);
+    if (Number.isFinite(weight) && weight >= 0) {
+      weights[key.replaceAll("\\", "/")] = weight;
+    }
+  }
+  return weights;
+}
+
+export function selectWeightedShard(files, options) {
+  const index = Number(options.index);
+  const total = Number(options.total);
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(`invalid shard index: ${options.index}`);
+  }
+  if (!Number.isInteger(total) || total <= 0) {
+    throw new Error(`invalid shard total: ${options.total}`);
+  }
+  if (index >= total) {
+    throw new Error(`shard index must be less than total: ${index}/${total}`);
+  }
+
+  const root = options.root || process.cwd();
+  const weights = options.weights || {};
+  const items = files.map((file, originalIndex) => {
+    const key = normalizeRepoPath(file, root);
+    const weight = Number(weights[key] ?? weights[file] ?? DEFAULT_WEIGHT);
+    return {
+      file,
+      key,
+      originalIndex,
+      weight: Number.isFinite(weight) && weight >= 0 ? weight : DEFAULT_WEIGHT,
+    };
+  });
+
+  const bins = Array.from({ length: total }, (_, shardIndex) => ({
+    shardIndex,
+    weight: 0,
+    items: [],
+  }));
+
+  for (const item of [...items].sort(
+    (a, b) => b.weight - a.weight || a.key.localeCompare(b.key) || a.originalIndex - b.originalIndex,
+  )) {
+    let target = bins[0];
+    for (const bin of bins.slice(1)) {
+      if (bin.weight < target.weight || (bin.weight === target.weight && bin.shardIndex < target.shardIndex)) {
+        target = bin;
+      }
+    }
+    target.weight += item.weight;
+    target.items.push(item);
+  }
+
+  return bins[index].items
+    .sort((a, b) => a.originalIndex - b.originalIndex)
+    .map((item) => item.file);
+}
+
+export function parseArgs(argv) {
+  const options = {
+    index: null,
+    total: null,
+    root: process.cwd(),
+    weightsPath: "",
+    files: [],
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--") {
+      options.files = argv.slice(i + 1);
+      break;
+    }
+    if (arg === "--index") {
+      options.index = argv[++i];
+    } else if (arg === "--total") {
+      options.total = argv[++i];
+    } else if (arg === "--root") {
+      options.root = argv[++i];
+    } else if (arg === "--weights") {
+      options.weightsPath = argv[++i];
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (options.index === null) {
+    throw new Error("missing --index");
+  }
+  if (options.total === null) {
+    throw new Error("missing --total");
+  }
+  return options;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const selected = selectWeightedShard(options.files, {
+    index: options.index,
+    total: options.total,
+    root: options.root,
+    weights: loadWeights(options.weightsPath),
+  });
+  process.stdout.write(selected.join("\n"));
+  if (selected.length > 0) {
+    process.stdout.write("\n");
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/selfhost_select_test_shard.test.mjs
+++ b/scripts/selfhost_select_test_shard.test.mjs
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  loadWeights,
+  normalizeRepoPath,
+  parseArgs,
+  selectWeightedShard,
+} from "./selfhost_select_test_shard.mjs";
+
+test("normalizeRepoPath converts absolute paths to repo-relative slash paths", () => {
+  const root = path.join(os.tmpdir(), "repo");
+  assert.equal(
+    normalizeRepoPath(path.join(root, "vibe", "compiler", "a_test.vibe"), root),
+    "vibe/compiler/a_test.vibe",
+  );
+});
+
+test("selectWeightedShard balances heavy files and preserves original order within a shard", () => {
+  const files = ["a_test.vibe", "b_test.vibe", "c_test.vibe", "d_test.vibe", "e_test.vibe"];
+  const weights = {
+    "a_test.vibe": 1,
+    "b_test.vibe": 10,
+    "c_test.vibe": 9,
+    "d_test.vibe": 1,
+    "e_test.vibe": 1,
+  };
+
+  assert.deepEqual(selectWeightedShard(files, { index: 0, total: 2, weights }), [
+    "b_test.vibe",
+    "d_test.vibe",
+  ]);
+  assert.deepEqual(selectWeightedShard(files, { index: 1, total: 2, weights }), [
+    "a_test.vibe",
+    "c_test.vibe",
+    "e_test.vibe",
+  ]);
+});
+
+test("loadWeights accepts missing files as empty weights", () => {
+  assert.deepEqual(loadWeights(path.join(os.tmpdir(), "missing-selfhost-weights.json")), {});
+});
+
+test("loadWeights ignores non-finite or negative weights", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "selfhost-shard-"));
+  const weightsPath = path.join(dir, "weights.json");
+  fs.writeFileSync(
+    weightsPath,
+    JSON.stringify({
+      keep: 3,
+      "nested\\path": 2,
+      negative: -1,
+      stringy: "4",
+      bad: "nan",
+    }),
+  );
+  assert.deepEqual(loadWeights(weightsPath), { keep: 3, "nested/path": 2, stringy: 4 });
+});
+
+test("parseArgs separates selector options from file list", () => {
+  assert.deepEqual(
+    parseArgs(["--index", "1", "--total", "4", "--root", "/repo", "--weights", "weights.json", "--", "a", "b"]),
+    {
+      index: "1",
+      total: "4",
+      root: "/repo",
+      weightsPath: "weights.json",
+      files: ["a", "b"],
+    },
+  );
+});

--- a/scripts/selfhost_test_batch_weights.seed.json
+++ b/scripts/selfhost_test_batch_weights.seed.json
@@ -18,6 +18,7 @@
   "vibe/compiler/printer_operator_test.vibe": 9264,
   "vibe/compiler/printer_loop_test.vibe": 9228,
   "vibe/compiler/cst_lower_stmt_test.vibe": 9030,
+  "vibe/compiler/persistent_fs_compile_cache_test.vibe": 9000,
   "vibe/compiler/type_db_cross_module_test.vibe": 8968,
   "vibe/compiler/printer_expr_literal_test.vibe": 8563,
   "vibe/compiler/cst_lower_pattern_test.vibe": 8250,

--- a/scripts/test_selfhost_bootstrap_gate.sh
+++ b/scripts/test_selfhost_bootstrap_gate.sh
@@ -15,10 +15,12 @@ STAGE_TIMEOUT_SEC="${VIBE_SELFHOST_BOOTSTRAP_STAGE_TIMEOUT_SEC:-1800}"
 BOOTSTRAP_PROFILE="${VIBE_SELFHOST_BOOTSTRAP_PROFILE:-full}"
 RUN_TESTS="${VIBE_SELFHOST_BOOTSTRAP_RUN_TESTS:-1}"
 RUN_DETERMINISTIC="${VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC:-1}"
+RUN_PROBES="${VIBE_SELFHOST_BOOTSTRAP_RUN_PROBES:-$RUN_TESTS}"
 TEST_SHARD_INDEX="${VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_INDEX:-}"
 TEST_SHARD_TOTAL="${VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_TOTAL:-}"
 BATCH_WEIGHT_CACHE_PATH="${VIBE_SELFHOST_BOOTSTRAP_BATCH_WEIGHT_CACHE:-$OUT_DIR/selfhost_test_batch_weights.json}"
 BATCH_WEIGHT_SEED_PATH="${VIBE_SELFHOST_BOOTSTRAP_BATCH_WEIGHT_SEED:-$PROJECT_ROOT/scripts/selfhost_test_batch_weights.seed.json}"
+SHARD_SELECTOR="${VIBE_SELFHOST_BOOTSTRAP_SHARD_SELECTOR:-$PROJECT_ROOT/scripts/selfhost_select_test_shard.mjs}"
 # Cutover: use selfhost compiler (moonrun) instead of host CLI for wasm compilation.
 # Set VIBE_SELFHOST_CUTOVER=0 to fall back to host CLI (emergency rollback).
 SELFHOST_CUTOVER="${VIBE_SELFHOST_CUTOVER:-1}"
@@ -216,10 +218,10 @@ verify_stage_pair_hash() {
     exit 1
   fi
 
-  echo "[bootstrap] deterministic hash ok: mode=${mode_label} source=${source_path#$PROJECT_ROOT/} hash=$pair_hash1"
+  echo "[bootstrap] deterministic hash ok: mode=${mode_label} source=${source_path#"$PROJECT_ROOT"/} hash=$pair_hash1"
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     printf -- "- deterministic hash: mode=%s source=%s hash=%s\n" \
-      "$mode_label" "${source_path#$PROJECT_ROOT/}" "$pair_hash1" >> "$GITHUB_STEP_SUMMARY" || true
+      "$mode_label" "${source_path#"$PROJECT_ROOT"/}" "$pair_hash1" >> "$GITHUB_STEP_SUMMARY" || true
   fi
 
   STAGE_PAIR_LAST_STAGE1="$pair_stage1"
@@ -253,7 +255,11 @@ if ! is_bool_01 "$RUN_DETERMINISTIC"; then
   echo "bootstrap gate failed: VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC must be 0 or 1" >&2
   exit 1
 fi
-if [ "$RUN_TESTS" -eq 0 ] && [ "$RUN_DETERMINISTIC" -eq 0 ]; then
+if ! is_bool_01 "$RUN_PROBES"; then
+  echo "bootstrap gate failed: VIBE_SELFHOST_BOOTSTRAP_RUN_PROBES must be 0 or 1" >&2
+  exit 1
+fi
+if [ "$RUN_TESTS" -eq 0 ] && [ "$RUN_DETERMINISTIC" -eq 0 ] && [ "$RUN_PROBES" -eq 0 ]; then
   echo "bootstrap gate failed: at least one bootstrap section must run" >&2
   exit 1
 fi
@@ -342,6 +348,7 @@ if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   printf -- "- %s: %ss\n" "stage timeout" "$STAGE_TIMEOUT_SEC" >> "$GITHUB_STEP_SUMMARY" || true
   printf -- "- %s: %s\n" "profile" "$BOOTSTRAP_PROFILE" >> "$GITHUB_STEP_SUMMARY" || true
   printf -- "- %s: %s\n" "run tests" "$RUN_TESTS" >> "$GITHUB_STEP_SUMMARY" || true
+  printf -- "- %s: %s\n" "run probes" "$RUN_PROBES" >> "$GITHUB_STEP_SUMMARY" || true
   printf -- "- %s: %s\n" "run deterministic" "$RUN_DETERMINISTIC" >> "$GITHUB_STEP_SUMMARY" || true
   if [ -n "$TEST_SHARD_TOTAL" ]; then
     printf -- "- %s: %s/%s\n" "test shard" "$TEST_SHARD_INDEX" "$TEST_SHARD_TOTAL" >> "$GITHUB_STEP_SUMMARY" || true
@@ -402,20 +409,58 @@ run_compiled_selfhost_test_shard() {
   fi
 }
 
+select_compiled_selfhost_test_shard_file() {
+  local selected_index="$1"
+  local selected_total="$2"
+  local output_path="$3"
+  local shard_index test_path count
+
+  if command -v node >/dev/null 2>&1 && [ -f "$SHARD_SELECTOR" ]; then
+    if node "$SHARD_SELECTOR" \
+      --index "$selected_index" \
+      --total "$selected_total" \
+      --root "$PROJECT_ROOT" \
+      --weights "$BATCH_WEIGHT_CACHE_PATH" \
+      -- "${SELFHOST_COMPILED_TEST_FILES[@]}" >"$output_path"; then
+      count="$(wc -l <"$output_path" | tr -d ' ')"
+      echo "[bootstrap] weighted compiled selfhost shard $((selected_index + 1))/${selected_total}: ${count} files"
+      return 0
+    fi
+    echo "[bootstrap] weighted shard selection failed; falling back to round-robin" >&2
+  fi
+
+  : >"$output_path"
+  shard_index=0
+  for test_path in "${SELFHOST_COMPILED_TEST_FILES[@]}"; do
+    if [ $((shard_index % selected_total)) -eq "$selected_index" ]; then
+      printf '%s\n' "$test_path" >>"$output_path"
+    fi
+    shard_index=$((shard_index + 1))
+  done
+  count="$(wc -l <"$output_path" | tr -d ' ')"
+  echo "[bootstrap] round-robin compiled selfhost shard $((selected_index + 1))/${selected_total}: ${count} files"
+}
+
+read_selected_selfhost_test_files() {
+  local input_path="$1"
+  local test_path
+  selected_files=()
+  while IFS= read -r test_path; do
+    selected_files+=("$test_path")
+  done <"$input_path"
+}
+
 run_compiled_selfhost_test_shards() {
-  local shard_index selected_index selected_total shard_label
+  local selected_index selected_total shard_label
   local -a selected_files
   if [ -n "$TEST_SHARD_TOTAL" ]; then
     selected_index="$TEST_SHARD_INDEX"
     selected_total="$TEST_SHARD_TOTAL"
-    selected_files=()
-    shard_index=0
-    for test_path in "${SELFHOST_COMPILED_TEST_FILES[@]}"; do
-      if [ $((shard_index % selected_total)) -eq "$selected_index" ]; then
-        selected_files+=("$test_path")
-      fi
-      shard_index=$((shard_index + 1))
-    done
+    select_compiled_selfhost_test_shard_file \
+      "$selected_index" \
+      "$selected_total" \
+      "$OUT_DIR/compiled_selfhost_shard_${selected_index}_of_${selected_total}.txt"
+    read_selected_selfhost_test_files "$OUT_DIR/compiled_selfhost_shard_${selected_index}_of_${selected_total}.txt"
     shard_label="$((selected_index + 1))/${selected_total}"
     run_compiled_selfhost_test_shard "$shard_label" "${selected_files[@]}"
     return
@@ -424,14 +469,11 @@ run_compiled_selfhost_test_shards() {
   local default_total=4
   local default_index
   for default_index in 0 1 2 3; do
-    selected_files=()
-    shard_index=0
-    for test_path in "${SELFHOST_COMPILED_TEST_FILES[@]}"; do
-      if [ $((shard_index % default_total)) -eq "$default_index" ]; then
-        selected_files+=("$test_path")
-      fi
-      shard_index=$((shard_index + 1))
-    done
+    select_compiled_selfhost_test_shard_file \
+      "$default_index" \
+      "$default_total" \
+      "$OUT_DIR/compiled_selfhost_shard_${default_index}_of_${default_total}.txt"
+    read_selected_selfhost_test_files "$OUT_DIR/compiled_selfhost_shard_${default_index}_of_${default_total}.txt"
     run_compiled_selfhost_test_shard "$((default_index + 1))/${default_total}" "${selected_files[@]}"
   done
 }
@@ -445,7 +487,11 @@ should_run_unsharded_test() {
 
 if [ "$RUN_TESTS" -eq 1 ]; then
   run_compiled_selfhost_test_shards
+else
+  echo "[bootstrap] compiled selfhost tests: skipped"
+fi
 
+if [ "$RUN_PROBES" -eq 1 ]; then
   if should_run_unsharded_test; then
     run_stage "compiled selfhost cli cache test" \
       env VIBE_TEST_BACKEND=compiled \
@@ -485,7 +531,7 @@ EOF
     echo "[bootstrap] unsharded compiled cache probes: skipped on shard ${TEST_SHARD_INDEX}/${TEST_SHARD_TOTAL}"
   fi
 else
-  echo "[bootstrap] compiled selfhost tests: skipped"
+  echo "[bootstrap] unsharded compiled cache probes: skipped"
 fi
 
 BASICS_FIXTURE="$PROJECT_ROOT/examples/basics.vibe"


### PR DESCRIPTION
## Summary\n\n- add a tested weighted shard selector for compiled selfhost test files\n- use the selector from test_selfhost_bootstrap_gate.sh with round-robin fallback\n- split unsharded compiled cache probes into their own CI matrix part so tests-0 no longer carries them\n- add persistent_fs_compile_cache_test to the batch weight seed so it no longer rides with cli_test\n- include the selector test in pkfire/script test entry points\n\nCloses #460\n\n## Validation\n\n- node --test scripts/coverage_selfhost_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/selfhost_select_test_shard.test.mjs\n- pkf run test-coverage-scripts\n- pkf format --check Taskfile.pkl\n- actionlint .github/workflows/ci.yml\n- bash -n scripts/test_selfhost_bootstrap_gate.sh scripts/pkfire/test_suite.sh scripts/pkfire/contract_moon.sh\n- shellcheck scripts/test_selfhost_bootstrap_gate.sh\n- git diff --check\n- VIBE_BIN=... VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC=0 VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_INDEX=2 VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_TOTAL=4 OUT_DIR=... scripts/test_selfhost_bootstrap_gate.sh (weighted shard 3/4, 319 tests passed, 4s)\n- VIBE_BIN=... VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC=0 VIBE_SELFHOST_BOOTSTRAP_RUN_TESTS=0 VIBE_SELFHOST_BOOTSTRAP_RUN_PROBES=1 OUT_DIR=... scripts/test_selfhost_bootstrap_gate.sh (probe-only, 13s)\n- VIBE_BIN=... VIBE_SELFHOST_BOOTSTRAP_RUN_DETERMINISTIC=0 VIBE_SELFHOST_BOOTSTRAP_RUN_PROBES=0 VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_INDEX=0 VIBE_SELFHOST_BOOTSTRAP_TEST_SHARD_TOTAL=4 OUT_DIR=... scripts/test_selfhost_bootstrap_gate.sh (weighted shard 1/4 without probes, 225 tests passed, 3s)\n