### PR TITLE
ci: skip ripgrep install for moon coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1100,7 +1100,6 @@ jobs:
       - name: Setup Vibe toolchain
         uses: ./.github/actions/setup-vibe
         with:
-          ripgrep: 'true'
           node-version: '24'
 
       - name: Run moon coverage with line-coverage gate


### PR DESCRIPTION
## Summary
- Remove ripgrep installation from the coverage-moon setup path
- Keep coverage_moon.sh relying on its existing grep fallback

Fixes #464

## Validation
- actionlint .github/workflows/ci.yml
- bash -n scripts/coverage_moon.sh
- git diff --check
- pkf format --check Taskfile.pkl