### PR TITLE
ci: use setup-vibe for flaker sampled run

### DIFF
--- a/.github/workflows/flaker-ci.yml
+++ b/.github/workflows/flaker-ci.yml
@@ -16,14 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install MoonBit
-        run: bash scripts/install_moonbit.sh
-
-      - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Vibe toolchain
+        uses: ./.github/actions/setup-vibe
         with:
           node-version: '24'
 
@@ -33,22 +27,13 @@ jobs:
       - name: Moon update
         run: moon update
 
-      - name: Cache MoonBit build
-        uses: actions/cache@v5
-        with:
-          path: |
-            _build
-            .mooncakes
-          key: moonbit-${{ runner.os }}-${{ hashFiles('.moon-version') }}-${{ hashFiles('moon.mod.json', 'src/**/*.mbt') }}
-          restore-keys: moonbit-${{ runner.os }}-${{ hashFiles('.moon-version') }}-
-
       - name: Restore flaker DB
         # SHA-version the main baseline so subsequent main pushes can
         # update it (`actions/cache` save is immutable per-key). Restore
         # via the `flaker-db-main-` prefix only — never fall back to
         # PR-saved caches, which historically polluted the gate with
         # stale test names from older branches.
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .flaker/
           key: flaker-db-main-${{ github.sha }}
@@ -66,14 +51,14 @@ jobs:
 
       - name: Save flaker DB (main baseline)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .flaker/
           key: flaker-db-main-${{ github.sha }}
 
       - name: Save flaker DB (PR run)
         if: github.event_name == 'pull_request'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .flaker/
           key: flaker-db-pr-${{ github.event.pull_request.number }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- Replace direct MoonBit install, ripgrep apt install, setup-node v4, and duplicate MoonBit build cache in flaker-ci with setup-vibe
- Upgrade flaker DB cache restore/save actions from v4 to v5

Fixes #466

## Validation
- actionlint .github/workflows/flaker-ci.yml
- git diff --check
- pkf format --check Taskfile.pkl