### PR TITLE
fix(exec): capture full subprocess output without 1MB truncation (#412)

### DIFF
--- a/src/backend/exec_impl.mbt
+++ b/src/backend/exec_impl.mbt
@@ -4,41 +4,67 @@ pub fn exec_available() -> Bool {
 }
 
 ///|
-#borrow(cmd_ptr)
-#borrow(cmd_ptr, buf, out_len)
+/// Runs `cmd` and captures its full stdout into an internal growable buffer,
+/// writing the captured length to `out_len[0]`. Returns the subprocess exit
+/// code, or a negative value on spawn failure. Pair with `c_popen_drain`.
+#borrow(cmd_ptr, out_len)
 extern "c" fn c_popen_exec(
   cmd_ptr : Bytes,
   cmd_len : Int,
-  buf : Bytes,
-  buf_cap : Int,
   out_len : FixedArray[Int],
 ) -> Int = "vibe_popen_exec"
 
 ///|
-pub fn exec_command_lines(cmd : String) -> Result[Array[String], String] {
+/// Copies up to `cap` bytes of the most recent capture into `buf` and frees
+/// the internal buffer. Returns the number of bytes copied.
+#borrow(buf)
+extern "c" fn c_popen_drain(buf : Bytes, cap : Int) -> Int = "vibe_popen_drain"
+
+///|
+/// Runs `cmd` and returns its exit code together with the full captured
+/// stdout. There is no output-size cap: the C side reads into a growable
+/// buffer and reports the true length, so large outputs are never silently
+/// truncated. Returns `Err` only when the subprocess could not be spawned.
+fn run_command(cmd : String) -> Result[(Int, String), String] {
   let cmd_bytes = string_to_utf8(cmd)
   let cmd_len = cmd_bytes.length()
-  let buf_cap = 1024 * 1024 // 1 MB
-  let buf = Bytes::new(buf_cap)
   let out_len : FixedArray[Int] = [0]
-  let exit_code = c_popen_exec(cmd_bytes, cmd_len, buf, buf_cap, out_len)
+  let exit_code = c_popen_exec(cmd_bytes, cmd_len, out_len)
   if exit_code < 0 {
     return Err("popen failed: " + cmd)
   }
   let actual_len = out_len[0]
-  let text = utf8_to_string(buf, actual_len)
-  if exit_code != 0 {
-    return Err("command exited with code " + exit_code.to_string() + ": " + cmd)
-  }
+  let buf = Bytes::new(actual_len)
+  // Always drain, even for empty output, to release the internal buffer.
+  let _ = c_popen_drain(buf, actual_len)
+  Ok((exit_code, utf8_to_string(buf, actual_len)))
+}
+
+///|
+/// Splits captured text into lines, dropping the trailing empty line that a
+/// final newline produces.
+fn split_lines(text : String) -> Array[String] {
   let lines : Array[String] = []
   for part_view in text.split("\n") {
     lines.push(part_view.to_owned())
   }
-  // Remove trailing empty line from final newline
   if lines.length() > 0 && lines[lines.length() - 1] == "" {
     let _ = lines.pop()
   }
-  Ok(lines)
+  lines
+}
+
+///|
+pub fn exec_command_lines(cmd : String) -> Result[Array[String], String] {
+  match run_command(cmd) {
+    Err(e) => Err(e)
+    Ok((exit_code, text)) =>
+      if exit_code != 0 {
+        Err("command exited with code " + exit_code.to_string() + ": " + cmd)
+      } else {
+        Ok(split_lines(text))
+      }
+  }
 }
 
 ///|
@@ -50,23 +76,8 @@ pub fn exec_command_lines(cmd : String) -> Result[Array[String], String] {
 pub fn exec_command_capture(
   cmd : String,
 ) -> Result[(Int, Array[String]), String] {
-  let cmd_bytes = string_to_utf8(cmd)
-  let cmd_len = cmd_bytes.length()
-  let buf_cap = 1024 * 1024
-  let buf = Bytes::new(buf_cap)
-  let out_len : FixedArray[Int] = [0]
-  let exit_code = c_popen_exec(cmd_bytes, cmd_len, buf, buf_cap, out_len)
-  if exit_code < 0 {
-    return Err("popen failed: " + cmd)
+  match run_command(cmd) {
+    Err(e) => Err(e)
+    Ok((exit_code, text)) => Ok((exit_code, split_lines(text)))
   }
-  let actual_len = out_len[0]
-  let text = utf8_to_string(buf, actual_len)
-  let lines : Array[String] = []
-  for part_view in text.split("\n") {
-    lines.push(part_view.to_owned())
-  }
-  if lines.length() > 0 && lines[lines.length() - 1] == "" {
-    let _ = lines.pop()
-  }
-  Ok((exit_code, lines))
 }

--- a/src/backend/exec_popen.c
+++ b/src/backend/exec_popen.c
@@ -3,12 +3,33 @@
 #include <string.h>
 #include <sys/wait.h>
 
-// Synchronous shell execution via popen.
-// Returns stdout on success, or negative exit code on failure.
-// Caller provides buffer; actual length written to *out_len.
-int vibe_popen_exec(const char *cmd_ptr, int cmd_len,
-                    char *buf, int buf_cap, int *out_len) {
-    // Null-terminate the command
+// Synchronous shell execution via popen with an unbounded, growable capture
+// buffer. The full stdout of the subprocess is read into an internally-owned
+// buffer (no fixed 1 MB cap, so large `vibe check --human` output is never
+// silently truncated). The caller first invokes `vibe_popen_exec` to run the
+// command and learn the captured length, then `vibe_popen_drain` to copy the
+// bytes out and release the internal buffer.
+
+// Holds the most recent capture between `vibe_popen_exec` and
+// `vibe_popen_drain`. The exec CLI is single-threaded, so a static buffer is
+// sufficient and avoids passing raw pointers across the FFI boundary.
+static char *g_capture_buf = NULL;
+static int g_capture_len = 0;
+
+// Runs `cmd` and captures its entire stdout into the internal buffer.
+// Writes the captured byte count to *out_len and returns the subprocess exit
+// code, or -1 on spawn/allocation failure. Call `vibe_popen_drain` afterwards
+// (even for empty output) to copy the bytes out and free the internal buffer.
+int vibe_popen_exec(const char *cmd_ptr, int cmd_len, int *out_len) {
+    // Discard any buffer left over from a previous (undrained) call.
+    if (g_capture_buf) {
+        free(g_capture_buf);
+        g_capture_buf = NULL;
+        g_capture_len = 0;
+    }
+    *out_len = 0;
+
+    // Null-terminate the command.
     char *cmd = (char *)malloc(cmd_len + 1);
     if (!cmd) return -1;
     memcpy(cmd, cmd_ptr, cmd_len);
@@ -18,15 +39,52 @@ int vibe_popen_exec(const char *cmd_ptr, int cmd_len,
     free(cmd);
     if (!fp) return -1;
 
-    int length = 0;
+    size_t cap = 1 << 16; // 64 KB initial, doubled as needed
+    char *buf = (char *)malloc(cap);
+    if (!buf) {
+        pclose(fp);
+        return -1;
+    }
+
+    size_t length = 0;
+    char chunk[8192];
     size_t n;
-    while ((n = fread(buf + length, 1, buf_cap - length, fp)) > 0) {
-        length += (int)n;
-        if (length >= buf_cap) break;
+    while ((n = fread(chunk, 1, sizeof(chunk), fp)) > 0) {
+        if (length + n > cap) {
+            while (length + n > cap) cap *= 2;
+            char *nb = (char *)realloc(buf, cap);
+            if (!nb) {
+                free(buf);
+                pclose(fp);
+                return -1;
+            }
+            buf = nb;
+        }
+        memcpy(buf + length, chunk, n);
+        length += n;
     }
 
     int status = pclose(fp);
     int exit_code = WEXITSTATUS(status);
-    *out_len = length;
+
+    g_capture_buf = buf;
+    g_capture_len = (int)length;
+    *out_len = (int)length;
     return exit_code;
+}
+
+// Copies up to `cap` bytes of the most recent capture into `buf` and frees the
+// internal buffer. Returns the number of bytes copied. Safe to call once after
+// each `vibe_popen_exec`; a second call is a no-op.
+int vibe_popen_drain(char *buf, int cap) {
+    int n = g_capture_len < cap ? g_capture_len : cap;
+    if (g_capture_buf && n > 0) {
+        memcpy(buf, g_capture_buf, n);
+    }
+    if (g_capture_buf) {
+        free(g_capture_buf);
+        g_capture_buf = NULL;
+        g_capture_len = 0;
+    }
+    return n;
 }

--- a/src/backend/exec_wbtest.mbt
+++ b/src/backend/exec_wbtest.mbt
@@ -1,0 +1,28 @@
+///|
+/// Regression for #412: `exec_command_capture` must not silently truncate
+/// subprocess output that exceeds the old fixed 1 MB capture buffer.
+test "exec_command_capture captures output larger than 1 MB" {
+  // `seq 1 300000` emits 300000 lines (~2 MB), well past the old 1 MB cap.
+  match exec_command_capture("seq 1 300000") {
+    Ok((exit_code, lines)) => {
+      assert_eq(exit_code, 0)
+      assert_eq(lines.length(), 300000)
+      assert_eq(lines[0], "1")
+      assert_eq(lines[lines.length() - 1], "300000")
+    }
+    Err(e) => fail("expected capture to succeed, got: " + e)
+  }
+}
+
+///|
+test "exec_command_lines round-trips small output" {
+  match exec_command_lines("printf 'a\\nb\\nc\\n'") {
+    Ok(lines) => {
+      assert_eq(lines.length(), 3)
+      assert_eq(lines[0], "a")
+      assert_eq(lines[1], "b")
+      assert_eq(lines[2], "c")
+    }
+    Err(e) => fail("expected lines, got: " + e)
+  }
+}

--- a/src/backend/moon.pkg
+++ b/src/backend/moon.pkg
@@ -12,6 +12,7 @@ options(
   "native-stub": [ "exec_popen.c", "tcp_stub.c" ],
   targets: {
     "exec_impl.mbt": [ "native" ],
+    "exec_wbtest.mbt": [ "native" ],
     "exec_stub.mbt": [ "js", "wasm", "wasm-gc" ],
     "http_impl.mbt": [ "native" ],
     "http_stub.mbt": [ "js", "wasm", "wasm-gc" ],


### PR DESCRIPTION
## Summary

`exec_command_capture` / `exec_command_lines` previously passed a fixed 1MB buffer to `vibe_popen_exec`, which stopped reading once full and silently truncated larger output. After `VIBE_CHECK_SELFHOST` routes selfhost check stdout through `exec_command_capture`, a large project's `--human` output could exceed 1MB and disappear, unlike the native check.

- Rework `vibe_popen_exec` to read the entire stdout into a growable (doubling) internal buffer and report the true length, then copy it out via a new `vibe_popen_drain` call. No output-size cap remains, so no silent truncation.
- Factor shared run/split logic into `run_command` / `split_lines`. Public API unchanged (no `.mbti` change).
- Add native regression tests.

## Validation
- `moon build --target native src/cmd/vibe` — 0 errors.
- `moon test --target native -p mizchi/vibe/backend` — 3/3 pass, including a new regression that round-trips 300000 lines (~2MB) and verifies the full line count.

## Note
The original PR also bundled a `coverage-moon` ripgrep-skip change for #464, but that was independently fixed on `main` via #465 (`dc7e885`). Rebased onto latest `main` and dropped the now-redundant commit, so this PR is exec-only.

Closes #412

https://claude.ai/code/session_0128oJYgTN5FRRobjj7X8dJV