### PR TITLE
ci(flaker): feed changed files to hybrid sampled run (#468)

### DIFF
--- a/.github/workflows/flaker-ci.yml
+++ b/.github/workflows/flaker-ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   VIBE_MOON_WARN_LIST: "-1-6-7-9-20-24-29"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   sampled-run:
     runs-on: ubuntu-latest
@@ -39,15 +43,63 @@ jobs:
           key: flaker-db-main-${{ github.sha }}
           restore-keys: flaker-db-main-
 
+      - name: Compute changed files
+        # The `hybrid` strategy in `profile.ci` resolves changed files to
+        # affected suites; without a changed-file list flaker throws
+        # "hybrid mode requires resolver and changedFiles". `actions/checkout`
+        # fetches only the shallow PR merge ref, so flaker's own
+        # `origin/main` diff comes back empty. Source the list from the
+        # GitHub API instead (no extra git history fetch needed).
+        id: changed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let files = [];
+            if (context.eventName === 'pull_request') {
+              const it = github.paginate.iterator(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              });
+              for await (const { data } of it) {
+                files.push(...data.map((f) => f.filename));
+              }
+            } else if (context.eventName === 'push') {
+              const base = context.payload.before;
+              const head = context.payload.after;
+              // `before` is all-zeros for a brand-new branch push.
+              if (base && !/^0+$/.test(base) && head) {
+                const cmp = await github.rest.repos.compareCommitsWithBasehead({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  basehead: `${base}...${head}`,
+                });
+                files = (cmp.data.files || []).map((f) => f.filename);
+              }
+            }
+            core.info(`changed files: ${files.length}`);
+            core.setOutput('files', files.join(','));
+            core.setOutput('count', String(files.length));
+
       - name: Sampled test run
         # `continue-on-error`: flaker's moontest adapter occasionally
         # exits non-zero on CI in ways we cannot reproduce locally (no
-        # log access for the runner; locally `flaker run --profile ci`
-        # exits 0 with "0 / 0 selected" against an empty `.flaker/`).
-        # Keep the gate visible but non-blocking until the underlying
-        # flake is diagnosed.
+        # log access for the runner). Keep the gate visible but
+        # non-blocking until main accumulates a baseline of real runs;
+        # flip to blocking once the signal is trusted.
         continue-on-error: true
-        run: flaker run --profile ci
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
+          CHANGED_COUNT: ${{ steps.changed.outputs.count }}
+        run: |
+          if [ "${CHANGED_COUNT:-0}" -gt 0 ]; then
+            echo "Running hybrid sampling against $CHANGED_COUNT changed file(s)"
+            flaker run --profile ci --changed "$CHANGED_FILES"
+          else
+            echo "No changed files detected; falling back to weighted sampling"
+            flaker run --profile ci --strategy weighted
+          fi
 
       - name: Save flaker DB (main baseline)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/flaker.toml
+++ b/flaker.toml
@@ -40,6 +40,7 @@ strategy = "hybrid"
 sample_percentage = 30
 adaptive = true
 adaptive_min_percentage = 15
+fallback_strategy = "weighted"
 
 [profile.local]
 strategy = "affected"


### PR DESCRIPTION
## 背景 / Closes #468

`flaker-ci` の sampled-run は `profile.ci` の `hybrid` strategy を使う。hybrid は changed files を affected suites に解決するため changed-file list が必須だが、`actions/checkout@v5` は浅い PR merge ref しか取らないため flaker 自身の `origin/main` diff が空になり、`changedFiles` undefined で次の **ハードな throw** に落ちていた:

```
hybrid mode requires resolver and changedFiles
```

この throw は flaker の `plan.js` で fallback ロジックより手前にあるため捕捉されず、`continue-on-error: true` によって ~38s 後の失敗が pass 表示に偽装されていた。つまりこのゲートはこれまで一度も実テストを検証していない。

## 変更内容

- **`Compute changed files` ステップを追加** — git 履歴を追加 fetch せず GitHub API から changed files を取得する:
  - `pull_request`: `pulls.listFiles`（ページネーション対応）
  - `push` (main): `compareCommitsWithBasehead`（新規ブランチの all-zero `before` をガード）
- `flaker run --profile ci --changed "$CHANGED_FILES"` を実行。changed が空のときは `--strategy weighted` に**明示 fallback**。
- `flaker.toml` の `profile.ci` に `fallback_strategy = "weighted"` を追加（hybrid が解決しても 0 件選択になった場合の保険、`profile.local` と対称）。
- 読み取り専用 `permissions` ブロック（`contents: read` / `pull-requests: read`）を追加。filename は `${{ }}` を shell に直接展開せず env 経由で渡し、script injection を回避。

## 期待効果

- sampled-run の 38s 空振り失敗が、実際にサンプリングされたテストの実行に変わる。
- changed-file が無い/解決不能なケースでも weighted に倒れて明示ログを出すため、失敗理由が即時に分かる。

## `continue-on-error` の扱い

今回は **残した**。このゲートはこれまで実 signal を持たず（常に no-op pass）、main にベースライン run が貯まっていない段階で blocking 化すると adapter のまれな非ゼロ終了で全 PR を止めるリスクがある。コメントに「signal が信頼できたら blocking に倒す」方針を残した。

## 検証

- `actionlint .github/workflows/flaker-ci.yml` パス
- YAML パース OK
- `flaker run --profile ci --strategy weighted --dry-run` で新 `flaker.toml` が読めることを確認

https://claude.ai/code/session_01RXCiBSxqWUE28syjfZy1AD

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXCiBSxqWUE28syjfZy1AD)_