### PR TITLE
perf(checker): AOT-parse disk cache for prelude/builtin (#427) + pkfire 0.10.0 alignment

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -11,7 +11,7 @@
 ///   pkf run test-local                        # affected local tests via flaker
 ///   pkf affected --since=origin/main 'test:*' # diff-aware package tests
 ///   pkf graph --format tree                   # visualize dependencies
-amends "package://pkg.pkl-lang.org/github.com/mizchi/pkfire/pkfire@0.9.0#/Taskfile.pkl"
+amends "package://pkg.pkl-lang.org/github.com/mizchi/pkfire/pkfire@0.10.0#/Taskfile.pkl"
 
 // Shared canonical package list — also consumed by pkspec/VibeTest.pkl
 // and pkspec/VibeSpec.pkl so per-package test definitions stay in sync.

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1261,6 +1261,7 @@ tasks {
   testLintArchitecture
   lintTrackedExperimentNames
   testLintTrackedExperimentNames
+  checkCodegenParity
   checkSelfhostBundleSync
   checkSelfhostPortableBoundary
   testSelfhostBundleSync

--- a/docs/report/selfhost-type-stage-aot-parse-2026-05-30.md
+++ b/docs/report/selfhost-type-stage-aot-parse-2026-05-30.md
@@ -61,7 +61,9 @@ the prelude parse is amortized elsewhere and typecheck dominates.
 `src/checker/ast_disk_cache.mbt` — `parse_ast_cached(source)` mirrors
 `@parser.parse_ast` but:
 
-1. key = `content_address_hash(source)` + `AST_BINARY_VERSION`;
+1. key = `content_address_hash(source)` + `AST_BINARY_VERSION` (serializer wire
+   format) + `AST_CACHE_PARSER_VERSION` (parser/desugar semantics, bumped when
+   the AST produced for unchanged source changes);
 2. read `.vibe/ast/<key>.vast`, `deserialize_module_binary` on hit;
 3. on miss/error/version-skew: parse, then best-effort
    `serialize_module_binary` + write.

--- a/docs/report/selfhost-type-stage-aot-parse-2026-05-30.md
+++ b/docs/report/selfhost-type-stage-aot-parse-2026-05-30.md
@@ -1,0 +1,135 @@
+# selfhost `type` stage: AOT-parse disk cache (#427)
+
+2026-05-30. Reducing the fixed startup cost of the selfhost compiler's
+`type` stage. Tracking: #427, rolls up into #402.
+
+## TL;DR
+
+- Re-decomposed the current-main `type` stage. **It is no longer dominated
+  by `type/builtin_modules`** (the 179ms / 65% bottleneck profiled in #400).
+  Since #400 landed session-level caching + `skip_fn_body_check`, the
+  `db.types` / `compile-lite` hot paths go through `type_check_with_env`,
+  which loads only the **prelude** (`ensure_prelude_functions`), not the full
+  builtin module set. `type/builtin/*` frames no longer appear in the profile
+  for the 5 KPI cases.
+- The new ceiling is **prelude parse + prelude typecheck**:
+  - compile path `type/prelude_functions` ≈ 10.5ms = parse **6.9ms (66%)** +
+    typecheck 3.5ms (33%).
+  - check path ≈ 3.5ms, dominated by typecheck (parse is amortized to a
+    different frame).
+- Landed the **AOT-parse lever** (Option C from #400): a best-effort on-disk
+  cache of the pre-parsed binary AST. Deserializing is ~10x faster than
+  re-parsing. Validated on host and on the real selfhost wasm; output is
+  bit-identical.
+- Remaining blocker for the `≤3ms` acceptance target: **prelude typecheck**
+  (~3.5ms wasmtime-aot) is untouched by parse-caching and needs typed-env
+  serialization (Option A/B). Documented below.
+
+## Decomposition (host, native debug, `--profile-callstack`, 5 KPI cases)
+
+`type/prelude_functions` total, split into parse vs typecheck (µs):
+
+| case | compile parse | compile TC | check TC |
+|---|---|---|---|
+| basics         | 7004 | 3551 | 4517 |
+| base64         | 6757 | 3476 | 3536 |
+| effects        | 6927 | 3501 | 3395 |
+| module_export  | 6973 | 3401 | 3478 |
+| module_import  | 6950 | 4259 | 3406 |
+
+Parse is ~66% of the compile-path type-stage fixed cost; on the check path
+the prelude parse is amortized elsewhere and typecheck dominates.
+
+## Lever comparison (microbench, native debug, parse vs deserialize)
+
+| source | parse µs | deserialize µs | speedup | binary bytes |
+|---|---|---|---|---|
+| prelude (9.8KB)        | 14,567 | 1,451 | **10.0×** | 15.4KB |
+| builtins (12 mods, 40.5KB) | 52,786 | 5,703 | **9.3×** | 62.2KB |
+
+- **AOT parse (Option C, landed)** — skip parse via cached binary AST. ~10x on
+  the parse portion. Serializer already existed
+  (`@core.serialize_module_binary` / `deserialize_module_binary`).
+- **typed-env snapshot (Option A/B, deferred)** — skip parse *and* typecheck
+  by serializing the typed builtins env. Bigger win (removes the ~3.5ms
+  typecheck floor) but needs new `TypeEnv` serialization infra.
+- **prelude env reuse** — already done within a process via the #400 session
+  cache; does not help a fresh selfhost invocation.
+
+## Implementation
+
+`src/checker/ast_disk_cache.mbt` — `parse_ast_cached(source)` mirrors
+`@parser.parse_ast` but:
+
+1. key = `content_address_hash(source)` + `AST_BINARY_VERSION`;
+2. read `.vibe/ast/<key>.vast`, `deserialize_module_binary` on hit;
+3. on miss/error/version-skew: parse, then best-effort
+   `serialize_module_binary` + write.
+
+Wired into the two parse sites: `prelude_ast()` (`src/checker/prelude.mbt`)
+and the builtin loop in `ensure_builtin_modules`
+(`src/checker/typecheck_prelude.mbt`).
+
+Design notes:
+- **Correctness-safe:** every step falls back to parsing on any failure, so
+  compiler output is unaffected. The 4-byte `vAST` magic + version guard +
+  length-prefixed encoding make a torn/partial write fail to deserialize
+  (→ fallback), never decode into a wrong-but-valid AST. The filename is the
+  source's SHA1, so distinct sources cannot collide.
+- **Portable:** cache dir is cwd-relative (`.vibe/ast`, gitignored) so it
+  resolves under the wasmtime/moonrun preopens that host the selfhost wasm
+  (which see cwd, not an absolute `~/.cache`). `@os_fs` is already imported by
+  the checker and links on `--target wasm` (`__moonbit_fs_unstable.*` imports
+  present in `vibe_check_wasi.wasm`).
+- **Toggle:** `set_ast_disk_cache_enabled(Bool)` / `set_ast_disk_cache_dir`
+  for tests/benches. Default on.
+
+## Validation
+
+- Cold vs warm `compile-lite --wasm` output **bit-identical** on basics /
+  base64 / effects / module_import.
+- `moon test -p mizchi/vibe/checker` 171/171, `-p mizchi/vibe/core` 88/88.
+
+### Host (compile-lite, base64, native debug), cold→warm
+
+| frame | cold | warm | Δ |
+|---|---|---|---|
+| type/prelude_parse     | 12,706 | 2,003 | **−84%** |
+| type/prelude_functions | 17,777 | 7,080 | **−60%** |
+| type (stage total)     | 22,219 | 12,064 | **−46%** |
+| type/prelude_typecheck | 5,059 | 5,064 | ~0 (expected) |
+
+### Selfhost wasm (`vibe_check_wasi.wasm` under moonrun), cold→warm
+
+moonrun is the v8 interpreter (~5× slower than the wasmtime-aot KPI runtime);
+the cold→warm **delta** is what validates the cache on the real selfhost path.
+
+| frame | cold (≈µs) | warm (≈µs) | Δ |
+|---|---|---|---|
+| prelude_parse         | ~36,000 | ~15,000 | **~−60%** |
+| prelude_functions     | ~72,000 | ~46,000 | **~−37%** |
+| prelude_typecheck     | ~35,000 | ~30,000 | ~−13% (variance) |
+
+The `.vibe/ast/<hash>.v1.vast` blob is created and reused by the wasm,
+confirming the disk cache works end-to-end under the selfhost runtime.
+
+## Status vs #427 acceptance criteria
+
+- [x] `type` stage re-decomposed into builtin / prelude / user typecheck with
+      `--profile-callstack`; finding that builtin_modules is no longer the
+      ceiling recorded.
+- [x] remaining fixed cost after `ensure_builtin_modules` identified =
+      prelude **parse** (cached now) + prelude **typecheck** (the floor).
+- [x] AOT-parse / typed-env-snapshot / prelude-reuse compared; AOT-parse
+      landed, typed-env-snapshot scoped as the next lever.
+- [~] `check.type` median to ≤3ms: parse eliminated, but the **typecheck
+      floor (~3.5ms wasmtime-aot) remains** → needs typed-env serialization.
+      Documented here per the "blocker documented with profile" criterion.
+
+## Next lever (deferred): typed-env snapshot (Option A/B)
+
+To reach the ≤3ms `check.type` target, serialize the typed builtins env
+(`cached_builtins_env`) so a fresh process deserializes a ready `TypeEnv`
+instead of re-running `ensure_prelude_functions` typecheck. Needs new
+`TypeEnv` serialization (the `store.mbt` types). Same disk-cache plumbing as
+here can host it. Estimated removal: the remaining ~3.5ms typecheck floor.

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "moonbit-overlay": {
       "inputs": {
         "nixpkgs": "nixpkgs",
@@ -69,11 +87,34 @@
         "type": "github"
       }
     },
+    "pkfire": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778686190,
+        "narHash": "sha256-cJg4q5erEp+ZZrvD7YTFnzpZGuQfjopLVnSWuX4t17E=",
+        "ref": "refs/tags/v0.10.0",
+        "rev": "74b22e14db6f166738a4a4f9b2962c94209a5603",
+        "revCount": 94,
+        "type": "git",
+        "url": "https://github.com/mizchi/pkfire"
+      },
+      "original": {
+        "ref": "refs/tags/v0.10.0",
+        "type": "git",
+        "url": "https://github.com/mizchi/pkfire"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "moonbit-overlay": "moonbit-overlay",
         "nixpkgs": "nixpkgs_2",
+        "pkfire": "pkfire",
         "rust-overlay": "rust-overlay"
       }
     },
@@ -98,6 +139,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,15 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     moonbit-overlay.url = "github:moonbit-community/moonbit-overlay";
+    # pkfire (pkf) — canonical task runner (Taskfile.pkl). Not in nixpkgs;
+    # pinned to the same tag CI and the session-start hook use (v0.10.0).
+    pkfire = {
+      url = "git+https://github.com/mizchi/pkfire?ref=refs/tags/v0.10.0";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, moonbit-overlay }:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, moonbit-overlay, pkfire }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -105,11 +111,13 @@
             similarity-mbt
 
             # Pkl CLI — required by pkfire (Taskfile.pkl) and by
-            # pkspec for evaluating local schemas. pkfire / pkspec binaries
-            # are not in nixpkgs; fetch them via `nix run github:mizchi/pkfire`
-            # or `go install github.com/mizchi/pkfire/cmd/pkf@latest`.
+            # pkspec for evaluating local schemas.
             # See docs/pkfire-pkspec.md for usage.
             pkgs.pkl
+
+            # pkfire (pkf) — canonical task runner, pinned to v0.10.0 via the
+            # `pkfire` flake input. Not in nixpkgs.
+            pkfire.packages.${system}.default
           ];
 
           shellHook = ''
@@ -121,9 +129,9 @@
               moon update 2>/dev/null || true
             fi
 
-            # pkf (pkfire) is the canonical task runner but is not in
-            # nixpkgs. Warn if it is missing so new contributors aren't
-            # blocked by `pkf: command not found` mid-task.
+            # pkf (pkfire) is provided by the `pkfire` flake input above. Keep
+            # a fallback hint in case the shell is entered without it on PATH
+            # (e.g. flake input fetch failed offline).
             if ! command -v pkf >/dev/null 2>&1; then
               echo ""
               echo "warn: pkf not on PATH — install pkfire to run tasks:"

--- a/src/checker/ast_disk_cache.mbt
+++ b/src/checker/ast_disk_cache.mbt
@@ -94,12 +94,27 @@ fn split_parent(path : String) -> String? {
 }
 
 ///|
+/// Parser/desugar semantics version, independent of the binary wire format
+/// (`AST_BINARY_VERSION`). `AST_BINARY_VERSION` only changes when the
+/// serializer's *encoding* changes; it does NOT change when `@parser.parse_ast`
+/// / desugar start producing a *different AST* for the same source. Without a
+/// separate knob, a parser-only fix would silently reuse a stale blob parsed by
+/// the old parser (the prelude/builtin source string is unchanged), until
+/// `.vibe/ast` is deleted by hand.
+///
+/// **Bump this whenever a parser/desugar change alters the AST produced for
+/// unchanged prelude/builtin source** so the cache key invalidates old blobs.
+const AST_CACHE_PARSER_VERSION : Int = 1
+
+///|
 fn ast_disk_cache_path(source : String) -> String {
   ast_disk_cache_dir.val +
   "/" +
   @core.content_address_hash_string(source) +
   ".v" +
   @core.AST_BINARY_VERSION.to_string() +
+  "-p" +
+  AST_CACHE_PARSER_VERSION.to_string() +
   ".vast"
 }
 

--- a/src/checker/ast_disk_cache.mbt
+++ b/src/checker/ast_disk_cache.mbt
@@ -1,0 +1,145 @@
+///|
+/// Issue #427: best-effort disk cache for pre-parsed prelude / builtin AST.
+///
+/// The prelude (`prelude_source`, ~542 lines) and the 12 builtin module
+/// sources (`builtin_module_sources`) are static strings embedded in the
+/// compiler binary. Parsing them is the dominant fixed cost of the `type`
+/// stage on a fresh process (~66% of the compile-path type-stage startup;
+/// measured ~67ms total parse in native debug across prelude + builtins).
+///
+/// Deserializing a binary AST written by `@core.serialize_module_binary` is
+/// ~10x faster than re-tokenizing + re-parsing the source (measured: prelude
+/// 14.6ms -> 1.5ms, builtins 52.8ms -> 5.7ms). This cache parses each source
+/// once, persists the serialized AST under `.vibe/ast/`, and deserializes it
+/// on subsequent processes.
+///
+/// The cache key is `content_hash(source) + AST_BINARY_VERSION`, so it
+/// auto-invalidates when either the embedded source or the binary serializer
+/// format changes. Every operation is best-effort: any miss, fs error,
+/// version skew, or corrupt blob falls back to parsing the source, so the
+/// cache never affects correctness or compiler output.
+
+///|
+/// Master switch. Defaults on; callers (tests / benches) may flip it via
+/// `set_ast_disk_cache_enabled` to measure with vs. without the cache. We do
+/// not read an env var here so the checker stays portable across the native
+/// CLI and the wasm (WASI) selfhost entrypoints.
+let ast_disk_cache_enabled : Ref[Bool] = @ref.new(true)
+
+///|
+pub fn set_ast_disk_cache_enabled(enabled : Bool) -> Unit {
+  ast_disk_cache_enabled.val = enabled
+}
+
+///|
+/// Directory holding the serialized AST blobs. Kept relative to the current
+/// working directory so it resolves under the wasmtime/moonrun preopens that
+/// host the selfhost wasm (which only see cwd, not an absolute `~/.cache`).
+let ast_disk_cache_dir : Ref[String] = @ref.new(".vibe/ast")
+
+///|
+pub fn set_ast_disk_cache_dir(dir : String) -> Unit {
+  ast_disk_cache_dir.val = dir
+}
+
+///|
+/// Tracks whether the cache directory has been ensured this process, so we
+/// only pay the path_exists / create_dir probes once.
+let ast_disk_cache_dir_ready : Ref[Bool] = @ref.new(false)
+
+///|
+fn ensure_ast_disk_cache_dir() -> Bool {
+  if ast_disk_cache_dir_ready.val {
+    return true
+  }
+  let dir = ast_disk_cache_dir.val
+  if @os_fs.path_exists(dir) {
+    ast_disk_cache_dir_ready.val = true
+    return true
+  }
+  // Create the parent (".vibe") first; `create_dir` is not guaranteed to be
+  // recursive. Both steps are best-effort.
+  match split_parent(dir) {
+    Some(parent) =>
+      if !@os_fs.path_exists(parent) {
+        @os_fs.create_dir(parent) catch {
+          _ => ()
+        }
+      }
+    None => ()
+  }
+  @os_fs.create_dir(dir) catch {
+    _ => ()
+  }
+  let ok = @os_fs.path_exists(dir)
+  ast_disk_cache_dir_ready.val = ok
+  ok
+}
+
+///|
+/// Return everything before the last '/' in `path`, or None if there is none.
+fn split_parent(path : String) -> String? {
+  let mut idx = -1
+  let chars = path.to_array()
+  for i in 0..<chars.length() {
+    if chars[i] == '/' {
+      idx = i
+    }
+  }
+  if idx <= 0 {
+    None
+  } else {
+    Some(path.substring(start=0, end=idx))
+  }
+}
+
+///|
+fn ast_disk_cache_path(source : String) -> String {
+  ast_disk_cache_dir.val +
+  "/" +
+  @core.content_address_hash_string(source) +
+  ".v" +
+  @core.AST_BINARY_VERSION.to_string() +
+  ".vast"
+}
+
+///|
+/// Read and deserialize a cached blob, or None on any fs / decode failure.
+fn load_cached_ast(path : String) -> @core.Module? {
+  if !@os_fs.path_exists(path) {
+    return None
+  }
+  let bytes = @os_fs.read_file_to_bytes(path) catch {
+    _ => return None
+  }
+  Some(@core.deserialize_module_binary(bytes)) catch {
+    _ => None
+  }
+}
+
+///|
+/// Parse `source` into a Module, using the on-disk AST cache when enabled.
+/// Mirrors `@parser.parse_ast`'s raising contract: a genuine parse error on a
+/// cache miss still propagates so call sites keep their existing handling.
+pub fn parse_ast_cached(
+  source : String,
+) -> @core.Module raise @parser.ParseError {
+  if !ast_disk_cache_enabled.val {
+    return @parser.parse_ast(source)
+  }
+  let path = ast_disk_cache_path(source)
+  match load_cached_ast(path) {
+    Some(m) => m
+    None => {
+      // Miss / corrupt / version skew: parse, then persist best-effort.
+      let m = @parser.parse_ast(source)
+      if ensure_ast_disk_cache_dir() {
+        let blob = @core.serialize_module_binary(m)
+        @os_fs.write_bytes_to_file(path, blob) catch {
+          _ => ()
+        }
+      }
+      m
+    }
+  }
+}

--- a/src/checker/pkg.generated.mbti
+++ b/src/checker/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "mizchi/vibe/checker"
 
 import {
   "mizchi/vibe/core",
+  "mizchi/vibe/parser",
   "mizchi/vibe/x/scoped_map",
   "moonbitlang/core/debug",
   "moonbitlang/core/ref",
@@ -35,6 +36,8 @@ pub fn is_prelude_builtin_trait(String) -> Bool
 
 pub fn is_type_subtype(TypeEnv, @core.Type, @core.Type) -> Bool
 
+pub fn parse_ast_cached(String) -> @core.Module raise @parser.ParseError
+
 pub fn prelude_ast() -> @core.Module
 
 pub fn prelude_builtin_value_stmts() -> Array[@core.Stmt]
@@ -48,6 +51,10 @@ pub fn purity_block(TypeEnv, @core.Module) -> Bool
 pub fn purity_expr(TypeEnv, @core.Expr) -> Bool
 
 pub fn purity_for_let(TypeEnv, Bool, String, @core.Expr) -> PurityInfo
+
+pub fn set_ast_disk_cache_dir(String) -> Unit
+
+pub fn set_ast_disk_cache_enabled(Bool) -> Unit
 
 pub fn type_check(@core.Module, allow_duplicate_decl? : Bool) -> TypeEnv raise TypeError
 

--- a/src/checker/prelude.mbt
+++ b/src/checker/prelude.mbt
@@ -522,7 +522,7 @@ pub fn prelude_ast() -> @core.Module {
   match cached_prelude_ast.val {
     Some(ast) => ast
     None => {
-      let ast = try! @parser.parse_ast(prelude_source)
+      let ast = try! parse_ast_cached(prelude_source)
       cached_prelude_ast.val = Some(ast)
       ast
     }

--- a/src/checker/typecheck_prelude.mbt
+++ b/src/checker/typecheck_prelude.mbt
@@ -199,7 +199,7 @@ pub fn ensure_builtin_modules(
       for pair in builtin_module_sources {
         let (mod_name, source) = pair
         @profiler.profiler_enter("type/builtin/" + mod_name)
-        let parsed = try? @parser.parse_ast(source)
+        let parsed = try? parse_ast_cached(source)
         match parsed {
           Ok(m) => {
             let exported_names = collect_exported_names(m.stmts)


### PR DESCRIPTION
## #427: selfhost `type` stage AOT-parse cache

Reduces the fixed startup cost of the `type` stage. Profiling found that since
#400's session caching landed, the `type` stage is **no longer dominated by
`type/builtin_modules`** (the old 179ms / 65% bottleneck) — those frames no
longer appear in the 5 KPI cases. The new ceiling is **prelude parse (~6.9ms,
66% of the compile-path type stage) + prelude typecheck (~3.5ms)**.

### Change
`src/checker/ast_disk_cache.mbt` — `parse_ast_cached(source)` mirrors
`@parser.parse_ast` but caches the pre-parsed binary AST under `.vibe/ast/`,
keyed by `content_hash(source) + AST_BINARY_VERSION`. Deserializing is ~10×
faster than re-parsing (the serializer already existed). Wired into
`prelude_ast()` and `ensure_builtin_modules`.

**Correctness-safe:** every step falls back to parsing on any fs error /
version skew / corrupt blob, so compiler output is unaffected. The `vAST`
magic + version + length-prefixed encoding make a torn write fail to
deserialize (→ fallback), never decode into a wrong-but-valid AST; the
filename is the source SHA1 so distinct sources can't collide.

### Validation
- cold vs warm `compile-lite --wasm` output **bit-identical** (basics /
  base64 / effects / module_import)
- tests: checker 171/171, core 88/88, loader 52/52, runtime_compile 241/241,
  parser 90/90
- **host** (compile-lite base64) cold→warm: `type/prelude_parse` −84%,
  `type` stage total −46%
- **selfhost wasm** (`vibe_check_wasi.wasm` under moonrun) cold→warm:
  `prelude_parse` ~−60%, `prelude_functions` ~−37%; `.vibe/ast/*.vast`
  generated + reused by the wasm

### Remaining (deferred)
The prelude **typecheck floor** (~3.5ms wasmtime-aot) is untouched by
parse-caching and needs typed-env serialization (Option A/B). Documented in
`docs/report/selfhost-type-stage-aot-parse-2026-05-30.md`; satisfies #427's
"blocker documented with profile" criterion. Recommend a follow-up issue.

## pkfire 0.10.0 alignment (bundled in)

While verifying the above, `pkf run` was failing locally. Three fixes bring
every pkfire reference to 0.10.0:

- **`Taskfile.pkl`**: register `check-codegen-parity` in the `tasks {}` block —
  it was in `release-check`'s deps but unregistered, so the graph failed with
  `unknown task "check-codegen-parity"`, breaking `pkf run release-check` /
  `test-local`.
- **`Taskfile.pkl`**: bump the schema `amends` from `pkfire@0.9.0` →
  `pkfire@0.10.0` (every other reference already pinned 0.10.0). Verified
  `pkf list` evaluates cleanly (251 tasks, exit 0).
- **`flake.nix` / `flake.lock`**: pin `pkfire` as a flake input at the v0.10.0
  tag and provide `pkf` in the devShell (was manual-install + warning only).
  Lock is additive; no existing input revisions change.

## Commits
- `perf(checker): disk-cache pre-parsed prelude/builtin AST (#427)`
- `docs(report): selfhost type-stage AOT-parse cache findings (#427)`
- `fix(pkfire): register check-codegen-parity in tasks block`
- `chore(pkfire): bump Taskfile schema amends to pkfire@0.10.0`
- `chore(nix): pin pkfire v0.10.0 as a flake input, provide pkf in devShell`

https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue)_