### PR TITLE
chore(pkfire): pre-commit hook that moon-fmt's staged sources

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -132,6 +132,15 @@ if [ -x "$PKF_BIN" ]; then
       echo "[session-start] WARNING: pkl cache warm failed (run pkf with pkl --ca-certificates)" >&2
     fi
   fi
+
+  # Install the pkfire-managed git hooks (e.g. the `pre-commit` task that
+  # `moon fmt`s staged sources) so commits in this fresh clone land formatted.
+  # Idempotent and best-effort; `.git/hooks` is not version-controlled.
+  if [ -d "$PROJECT_DIR/.git" ] && [ -f "$PROJECT_DIR/Taskfile.pkl" ]; then
+    if (cd "$PROJECT_DIR" && "$PKF_BIN" hooks install >/dev/null 2>&1); then
+      echo "[session-start] pkf git hooks installed"
+    fi
+  fi
 fi
 
 echo "[session-start] toolchain init complete"

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -53,6 +53,15 @@ local fmt = new Task {
   cache = false
 }
 
+// git pre-commit hook target (wire with `pkf hooks install`): formats the
+// staged .mbt files with `moon fmt` and re-stages them.
+local preCommit = new Task {
+  name = "pre-commit"
+  description = "git pre-commit: moon fmt staged .mbt files + re-stage"
+  cmd = "bash scripts/pkfire/precommit_fmt.sh"
+  cache = false
+}
+
 local info = new Task {
   name = "info"
   cmd = "moon info"
@@ -1252,6 +1261,7 @@ local pkgTests: List<Task> = Packages.all.map((p) -> pkgTask(p))
 
 tasks {
   fmt
+  preCommit
   info
   check
   checkCodegenContract

--- a/docs/pkfire-pkspec.md
+++ b/docs/pkfire-pkspec.md
@@ -112,7 +112,22 @@ tracking (parser change → checker tests need rerun) is handled inside
 moon, not by pkfire. For the final pre-commit sweep, fall back to
 `just test` or `pkf run test`.
 
-## pkspec — `pkspec/VibeTest.pkl`
+## git hooks (`pkf hooks`)
+
+`pkf hooks install` writes `.git/hooks/*` shims that delegate to
+`pkf run <hook-name>` — pkfire binds a git hook to the task whose name
+matches the hook (e.g. the `pre-commit` task).
+
+This repo ships a **`pre-commit`** task that runs
+`scripts/pkfire/precommit_fmt.sh`: it `moon fmt`s the staged `.mbt` files and
+re-stages them, so every commit lands formatted. Hooks live under `.git/`
+(not version-controlled), so each clone must opt in once:
+
+```bash
+pkf hooks install      # wire .git/hooks → pkf run
+pkf hooks list         # show which hooks are installed / declared
+pkf hooks uninstall    # remove the shims
+```
 
 `pkspec/VibeTest.pkl` declares two tests that shell out to `moon test`
 (native and JS targets) so the run can be driven with pkspec's sharding,

--- a/scripts/pkfire/precommit_fmt.sh
+++ b/scripts/pkfire/precommit_fmt.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# pre-commit: format staged MoonBit sources with `moon fmt` and re-stage them,
+# so every commit lands already formatted. Only files staged for the commit are
+# touched — unrelated working-tree changes and moon.pkg import ordering are left
+# alone. Wired via `pkf hooks install` (delegates to `pkf run pre-commit`).
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+# Staged .mbt files (Added/Copied/Modified), NUL-safe for odd paths.
+mapfile -d '' -t staged < <(
+  git diff --cached --name-only --diff-filter=ACM -z -- '*.mbt'
+)
+if [ "${#staged[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+# Format just those files in place.
+moon fmt "${staged[@]}" >/dev/null
+
+# Re-stage the formatted versions. (A partially-staged file gets fully staged —
+# the usual formatter-hook caveat.)
+for f in "${staged[@]}"; do
+  [ -f "$f" ] && git add -- "$f"
+done

--- a/scripts/pkfire/precommit_fmt.sh
+++ b/scripts/pkfire/precommit_fmt.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # pre-commit: format staged MoonBit sources with `moon fmt` and re-stage them,
-# so every commit lands already formatted. Only files staged for the commit are
-# touched — unrelated working-tree changes and moon.pkg import ordering are left
-# alone. Wired via `pkf hooks install` (delegates to `pkf run pre-commit`).
+# so every commit lands already formatted. Wired via `pkf hooks install`
+# (delegates to `pkf run pre-commit`).
+#
+# A file that is *partially* staged (staged hunks + further unstaged edits in
+# the same file) is left untouched and reported: re-staging it would pull the
+# unstaged WIP hunks into the commit. Such files are formatted on a later
+# fully-staged commit. Only files whose staged content matches the worktree are
+# formatted + re-staged, so no unrelated working-tree change is ever committed.
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"
@@ -16,11 +21,33 @@ if [ "${#staged[@]}" -eq 0 ]; then
   exit 0
 fi
 
-# Format just those files in place.
-moon fmt "${staged[@]}" >/dev/null
+# .mbt files that also have unstaged worktree edits (→ partially staged).
+declare -A has_unstaged=()
+while IFS= read -r -d '' f; do
+  has_unstaged["$f"]=1
+done < <(git diff --name-only -z -- '*.mbt')
 
-# Re-stage the formatted versions. (A partially-staged file gets fully staged —
-# the usual formatter-hook caveat.)
+fmt=()
+skipped=()
 for f in "${staged[@]}"; do
-  [ -f "$f" ] && git add -- "$f"
+  if [ -n "${has_unstaged["$f"]:-}" ]; then
+    skipped+=("$f")
+  else
+    fmt+=("$f")
+  fi
 done
+
+if [ "${#fmt[@]}" -gt 0 ]; then
+  moon fmt "${fmt[@]}" >/dev/null
+  for f in "${fmt[@]}"; do
+    [ -f "$f" ] && git add -- "$f"
+  done
+fi
+
+if [ "${#skipped[@]}" -gt 0 ]; then
+  echo "pre-commit: skipped moon fmt for partially-staged files (commit them" \
+    "fully or run 'moon fmt' yourself):" >&2
+  for f in "${skipped[@]}"; do
+    echo "  - $f" >&2
+  done
+fi


### PR DESCRIPTION
## pkfire pre-commit hook: always `moon fmt` staged sources

Make commits land formatted (`moon fmt は常に採用`), wired through pkfire's
native git-hook support.

### Change
- **`scripts/pkfire/precommit_fmt.sh`** — runs `moon fmt` on the staged `.mbt`
  files and re-stages them. Only staged `.mbt` are touched; unrelated
  working-tree changes and `moon.pkg` import ordering are left alone.
- **`Taskfile.pkl`** — a `pre-commit` task (registered) that calls the script;
  pkfire binds a git hook to the like-named task.
- **`.claude/hooks/session-start.sh`** — runs `pkf hooks install` on session
  start (best-effort, idempotent) so each fresh clone / web session gets the
  hook without a manual step, since `.git/hooks` isn't version-controlled.
- **`docs/pkfire-pkspec.md`** — documents `pkf hooks install/list/uninstall`.

### Validation
- Staged a deliberately misformatted file (`pub fn  foo()->Int{ 42 }`) → the
  hook reformatted + re-staged it to canonical `moon fmt` output in the staged
  diff.
- The hook fires on real commits (no-op when no `.mbt` is staged).
- `pkf lint` clean; `bash -n` on the session-start hook passes.

### Notes
- Per-clone opt-in: `.git/hooks` is not version-controlled. The task/script are
  committed; the session-start step automates `pkf hooks install`. Contributors
  outside this environment run it once manually.
- Partial staging caveat: formatting a partially-staged file stages it fully
  (the usual formatter-hook limitation).

https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue)_