### PR TITLE
perf(compile): cutover KPI refresh + bundle-stage profiling + prelude partition memoize (#402)

### DIFF
--- a/docs/report/selfhost-cutover-kpi-2026-05-30.md
+++ b/docs/report/selfhost-cutover-kpi-2026-05-30.md
@@ -1,0 +1,68 @@
+# selfhost cutover KPI — re-measure after #427 + #476 (2026-05-30)
+
+Refreshes the stale (2026-05-17, moonrun) numbers in #402 after the
+wasmtime-AOT runtime became the default and #427 (AST parse cache) + #476
+(typed-env snapshot) removed the prelude `type`-stage startup.
+
+- Driver: `VIBE_SELFHOST_PERF_RUNS=5 bash scripts/bench_selfhost_perf.sh`
+- Runtime: **wasmtime-aot** (`tools/moonrun_wasmtime`, `.cwasm` precompiled)
+- Caches **active**: `.vibe/ast/prelude-env.*.venv` (#476) + `*.vast` (#427)
+  written + reused by the selfhost wasm during the run (median-of-5 reflects
+  warm runs).
+- 5 KPI cases (basics, base64, effects, module_export, module_import).
+
+## Totals (selfhost ÷ host wallclock, gate ≤ 1.33×)
+
+| phase | per-case ratios | **median** | vs #402 (2026-05-17, moonrun) |
+|---|---|---|---|
+| **check**   | 0.43 / 0.71 / 0.74 / 0.77 / 1.25 | **0.77×** ✅ | 2.23× |
+| **compile** | 3.29 / 3.34 / 3.37 / 3.47 / 3.55 | **3.37×** ❌ | 3.97× |
+
+**check now passes the 1.33× gate** (median 0.77×); **compile is ~3.4×**, still
+the focus.
+
+## Stage breakdown (ratio ranges across cases)
+
+### compile (~3.37× total)
+
+| stage | ratio | note |
+|---|---|---|
+| bundle | **3.7–4.1×** | worst stage — lowering / linking |
+| load   | 3.3–3.7×    | apply_lock + parse |
+| compile (module) | 3.4–3.7× | |
+| type   | 3.0–3.2×    | prelude parse/typecheck removed by #427/#476; residual is user-module typecheck + wasmtime constant overhead |
+| emit   | 2.0–3.1×    | codegen |
+| write  | 1.6–9.8×    | moonrun/wasi fs shim, algorithmically fixed (tiny absolute) |
+
+### check (~0.77× total)
+
+| stage | ratio | note |
+|---|---|---|
+| load   | **0.02–0.06×** | selfhost far faster — host pays per-invocation session-http / db setup the selfhost check skips; dominant reason check total < 1× |
+| type   | 1.9–3.9×    | snapshot active; residual is user-module typecheck + deserialize + constant overhead |
+
+## Interpretation
+
+- The headline check win is two-fold: (1) #427/#476 keep `check.type` bounded
+  (no prelude parse/typecheck per process), and (2) the host check pays a
+  session-http/db setup cost per invocation that the selfhost path doesn't —
+  so `check.load` is ~20–50× cheaper on selfhost, pulling the total under 1×.
+  The apples-to-apples `check.type` stage is still ~2–4× selfhost-slower; the
+  total passing the gate is partly a load-stage asymmetry, not pure
+  type-stage parity.
+- **compile is the remaining gate blocker (~3.4×)**, dominated by **bundle
+  (~4×)** and the `compile`/`load` stages. Type stage is no longer the
+  ceiling there either.
+
+## Next levers (compile)
+
+1. **bundle stage (~4×)** — biggest single compile ratio; profile
+   lowering/linking hot functions (`compile/bundle` callstack).
+2. **emit / codegen** — `codegen/compile_functions` was 33% of compile in the
+   old profile; re-profile under the current build.
+3. **load** — apply_lock + parse; #427 AST cache helps parse, apply_lock
+   fast-path (#401) helps lock.
+
+Per #402's strategic note, wasmtime-AOT (now default) was the big multiplier;
+with check under gate, the focused work is compile-stage constant-factor
+(bundle/emit) reduction.

--- a/docs/report/selfhost-cutover-kpi-2026-05-30.md
+++ b/docs/report/selfhost-cutover-kpi-2026-05-30.md
@@ -66,3 +66,37 @@ the focus.
 Per #402's strategic note, wasmtime-AOT (now default) was the big multiplier;
 with check under gate, the focused work is compile-stage constant-factor
 (bundle/emit) reduction.
+
+## compile bundle/emit profiling (host, native debug, warm)
+
+Added finer `--profile-callstack` instrumentation to the bundle path
+(`compile/bundle/{collect,dce,cache_key}` and, inside the collector,
+`bundle/collect/{deps,prelude_add,dce}`) — the bundle stage was previously a
+single opaque self-time leaf.
+
+`compile/bundle` totals (µs), basics / base64:
+
+| sub-stage | basics | base64 | nature |
+|---|---|---|---|
+| bundle/collect/**prelude_add** | ~1300–1600 | ~1300–1600 | **fixed** — merges every prelude+builtin value def into each bundle |
+| bundle/collect/dce | ~450 | ~490 | fixed — surgical prelude DCE reachability walk (`dce_module_with_entry_names`) |
+| bundle/cache_key | ~7 | ~680 | program-proportional — content hash of bundled module |
+| bundle/collect/deps | ~1 | ~1 | negligible for these cases |
+
+`compile/emit` = `codegen/compile_functions` + `codegen/build_module`, both
+program-proportional (tiny for small programs); not a fixed floor.
+
+**Finding:** like the prelude parse (#427) and typecheck (#476) floors, the
+bundle stage carries a **~1.3–1.6ms fixed cost from re-processing the entire
+prelude/builtin value set on every compile** (`prelude_add` merge loop +
+surgical prelude DCE). This dominates the worst compile stage.
+
+Landed here: memoized `prelude_partition_value_stmts` (the dependency-graph +
+fixpoint partition was recomputed twice per compile; now once per process).
+Modest on single-file compile (~300µs) but removes a full recompute per module
+on multi-module / warm-process compiles.
+
+**Follow-up (next lever):** cache the *bundled* prelude/builtin stmt set (or
+disk-snapshot it, analogous to #476) so each compile doesn't re-merge +
+re-DCE the full standard library. Estimated ~1.7ms off the compile `type`/
+`bundle` fixed cost — the largest remaining compile-stage constant factor.

--- a/src/checker/prelude.mbt
+++ b/src/checker/prelude.mbt
@@ -503,15 +503,36 @@ fn prelude_partition_value_stmts(
 }
 
 ///|
+/// Memoized partition of the prelude AST into (core, builtin) value stmts.
+/// `prelude_partition_value_stmts` builds a dependency graph + runs a fixpoint
+/// over every prelude value def (~0.8ms); it depends only on the (cached,
+/// static) prelude AST, so compute it once per process. Bundling called this
+/// twice on every compile (`prelude_core_value_stmts` +
+/// `prelude_builtin_value_stmts`), making it ~1.6ms of fixed bundle-stage cost.
+let cached_prelude_partition : Ref[(Array[@core.Stmt], Array[@core.Stmt])?] = @ref.new(
+  None,
+)
+
+///|
+fn prelude_partitioned_value_stmts() -> (Array[@core.Stmt], Array[@core.Stmt]) {
+  match cached_prelude_partition.val {
+    Some(p) => p
+    None => {
+      let p = prelude_partition_value_stmts(prelude_ast())
+      cached_prelude_partition.val = Some(p)
+      p
+    }
+  }
+}
+
+///|
 pub fn prelude_core_value_stmts() -> Array[@core.Stmt] {
-  let (core_stmts, _) = prelude_partition_value_stmts(prelude_ast())
-  core_stmts
+  prelude_partitioned_value_stmts().0
 }
 
 ///|
 pub fn prelude_builtin_value_stmts() -> Array[@core.Stmt] {
-  let (_, builtin_stmts) = prelude_partition_value_stmts(prelude_ast())
-  builtin_stmts
+  prelude_partitioned_value_stmts().1
 }
 
 ///|

--- a/src/runtime_compile/bundle.mbt
+++ b/src/runtime_compile/bundle.mbt
@@ -1815,9 +1815,11 @@ fn bundle_for_wasm_impl(
   let entry_value_names = bundle_module_all_value_binder_names(main_ast)
   let entry_type_names = bundle_module_type_names(main_ast)
   // Collect all dependency definitions in topological order
+  @profiler.profiler_enter("bundle/collect/deps")
   collect_dependency_defs_with_protected_names(
     db, path, collected_dep_stmts, visited, entry_value_names, entry_type_names,
   )
+  @profiler.profiler_leave()
   let dep_stmts = bundle_drop_colliding_value_defs(
     collected_dep_stmts,
     bundle_collision_original_names(import_alias_collisions),
@@ -1857,6 +1859,7 @@ fn bundle_for_wasm_impl(
       None => ()
     }
   }
+  @profiler.profiler_enter("bundle/collect/prelude_add")
   for
     prelude_stmts in [
       @checker.prelude_core_value_stmts(),
@@ -1873,6 +1876,7 @@ fn bundle_for_wasm_impl(
       }
     }
   }
+  @profiler.profiler_leave()
   // Add main module statements (excluding imports and expanding re-exports)
   let main_stmts : Array[@core.Stmt] = []
   for stmt in main_ast.stmts {
@@ -1930,6 +1934,7 @@ fn bundle_for_wasm_impl(
   let bundled = @core.Module::{
     stmts: dedupe_bundle_structural_defs(bundled_stmts),
   }
+  @profiler.profiler_enter("bundle/collect/dce")
   let after_dce = if apply_dce {
     if include_test_entries {
       @pipeline.dce_module_for_tests(bundled)
@@ -1944,6 +1949,7 @@ fn bundle_for_wasm_impl(
     // All user/dependency names are kept as roots so only prelude is affected.
     @pipeline.dce_module_with_entry_names(bundled, non_prelude_names)
   }
+  @profiler.profiler_leave()
   demote_unused_let_mut(after_dce)
 }
 

--- a/src/runtime_compile/compile.mbt
+++ b/src/runtime_compile/compile.mbt
@@ -2080,13 +2080,18 @@ fn bundle_for_codegen(
   ast : @core.Module,
   bundle_kind : String,
 ) -> @core.Module raise CompileError {
+  @profiler.profiler_enter("compile/bundle/collect")
   let raw = bundle_for_wasm_no_dce(db, path, ast)
-  match bundle_kind {
+  @profiler.profiler_leave()
+  @profiler.profiler_enter("compile/bundle/dce")
+  let result = match bundle_kind {
     "default" => @pipeline.dce_module(raw)
     "gc" => @pipeline.dce_module_gc(raw)
     "tests" => @pipeline.dce_module_for_tests(raw)
     _ => raw
   }
+  @profiler.profiler_leave()
+  result
 }
 
 ///|
@@ -2362,12 +2367,14 @@ fn compile_module_wasm_profiled_with(
   let bundled = bundle_for_codegen(db, path, compiled.ast, bundle_kind) catch {
     e => raise WasmCompileError::Compile(e)
   }
+  @profiler.profiler_enter("compile/bundle/cache_key")
   let cache_key = wasm_artifact_cache_key(
     bundled,
     compiled.aliases,
     cache_namespace,
     opt_level,
   )
+  @profiler.profiler_leave()
   let bundle_us = elapsed_us_from(start_bundle)
   @profiler.profiler_leave()
   match wasm_artifact_cache.val.get(cache_key) {


### PR DESCRIPTION
## selfhost cutover KPI refresh + compile bundle profiling (#402)

### 1. KPI re-measure (wasmtime-aot, post #427/#476)
`docs/report/selfhost-cutover-kpi-2026-05-30.md` refreshes #402's stale
(2026-05-17, moonrun) numbers:

| phase | median ratio | gate ≤1.33× | was |
|---|---|---|---|
| **check**   | **0.77×** | ✅ pass | 2.23× |
| **compile** | **3.37×** | ❌ | 3.97× |

check now passes the gate (driven by #427/#476 bounding `check.type` + the host
paying a per-invocation session-http/db setup the selfhost skips). compile is
the remaining blocker, worst stage `bundle` (~4×).

### 2. compile bundle/emit profiling
Added finer `--profile-callstack` frames (`compile/bundle/{collect,dce,
cache_key}`, `bundle/collect/{deps,prelude_add,dce}`) — bundle was a single
opaque self-time leaf. Localizes the bundle fixed cost to re-processing the
whole prelude/builtin value set on every compile: `prelude_add` merge
(~1.3–1.6ms) + surgical prelude DCE (~0.45ms). Like #427/#476, a
builtin-reprocessing floor. emit (`compile_functions`/`build_module`) is
program-proportional, not a fixed floor.

### 3. small win: memoize prelude partition
`prelude_partition_value_stmts` (dependency-graph + fixpoint) was recomputed
twice per compile → now once per process.

### Validation
- compile output bit-identical on basics / base64 / effects / module_export /
  module_import.
- checker 172/172, runtime_compile 241/241.

### Next (follow-up issue)
Cache/disk-snapshot the *bundled* prelude/builtin stmt set (analogous to #476)
to remove the remaining ~1.7ms re-merge + re-DCE compile floor.

https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue)_