### PR TITLE
perf(compile): disk-snapshot prelude value-stmt partition (#402)

### DIFF
--- a/src/checker/prelude.mbt
+++ b/src/checker/prelude.mbt
@@ -518,7 +518,18 @@ fn prelude_partitioned_value_stmts() -> (Array[@core.Stmt], Array[@core.Stmt]) {
   match cached_prelude_partition.val {
     Some(p) => p
     None => {
-      let p = prelude_partition_value_stmts(prelude_ast())
+      let ast = prelude_ast()
+      // #402: load the partition name-set from disk (skip graph+fixpoint) on a
+      // fresh process; on a miss compute it and persist the name-set. Both paths
+      // produce the identical (core, builtin) split.
+      let p = match try_load_prelude_partition(ast) {
+        Some(loaded) => loaded
+        None => {
+          let computed = prelude_partition_value_stmts(ast)
+          save_prelude_partition(computed.1)
+          computed
+        }
+      }
       cached_prelude_partition.val = Some(p)
       p
     }

--- a/src/checker/prelude_partition_snapshot.mbt
+++ b/src/checker/prelude_partition_snapshot.mbt
@@ -1,0 +1,125 @@
+///|
+/// Issue #402: disk snapshot of the prelude value-stmt partition.
+///
+/// `prelude_partition_value_stmts` builds a dependency graph + runs a fixpoint
+/// over the prelude value defs to split them into "core" vs "builtin-dependent"
+/// (~0.8ms native / ~2-4ms selfhost-wasm). #479 memoized it per-process, but a
+/// fresh selfhost process (one compile per invocation) re-pays it every time.
+///
+/// The split is fully determined by which value names are builtin-dependent, so
+/// we snapshot just that name set to disk (reusing the #427/#476 `.vibe/ast`
+/// plumbing). A fresh process loads the names and re-splits `prelude_ast()` by
+/// name — an O(stmts) pass with no graph/fixpoint. Bit-for-bit equivalent to
+/// the computed partition (same value-stmt order, same classification).
+///
+/// All best-effort: any disabled cache / miss / fs error / version skew falls
+/// back to computing the partition. Bump `PARTITION_SNAPSHOT_VERSION` if the
+/// partition *logic* changes so stale name sets invalidate.
+
+///|
+const PARTITION_SNAPSHOT_VERSION : Int = 1
+
+///|
+fn partition_snapshot_path() -> String {
+  ast_disk_cache_dir.val +
+  "/prelude-partition." +
+  @core.content_address_hash_string(prelude_source) +
+  ".v" +
+  PARTITION_SNAPSHOT_VERSION.to_string() +
+  ".names"
+}
+
+///|
+/// Encode the builtin-dependent name set as a length-prefixed string list.
+fn encode_partition_names(names : Array[String]) -> Bytes {
+  let w = @core.TypeBinWriter::new()
+  w.uint(names.length())
+  for n in names {
+    w.str(n)
+  }
+  w.to_bytes()
+}
+
+///|
+fn decode_partition_names(
+  bytes : Bytes,
+) -> Array[String] raise @core.BinaryDeserializeError {
+  let r = @core.TypeBinReader::new(bytes)
+  let n = r.uint()
+  let names : Array[String] = []
+  for _i in 0..<n {
+    names.push(r.str())
+  }
+  names
+}
+
+///|
+/// Re-split the prelude value stmts by a known builtin-dependent name set,
+/// reproducing `prelude_partition_value_stmts`'s output without the graph.
+fn split_prelude_value_stmts(
+  ast : @core.Module,
+  builtin_names : Map[String, Bool],
+) -> (Array[@core.Stmt], Array[@core.Stmt]) {
+  let core_stmts : Array[@core.Stmt] = []
+  let builtin_stmts : Array[@core.Stmt] = []
+  for stmt in ast.stmts {
+    match prelude_stmt_value_name(stmt) {
+      Some(name) =>
+        if builtin_names.contains(name) {
+          builtin_stmts.push(stmt)
+        } else {
+          core_stmts.push(stmt)
+        }
+      None => ()
+    }
+  }
+  (core_stmts, builtin_stmts)
+}
+
+///|
+fn builtin_names_of(builtin_stmts : Array[@core.Stmt]) -> Array[String] {
+  let names : Array[String] = []
+  for stmt in builtin_stmts {
+    match prelude_stmt_value_name(stmt) {
+      Some(name) => names.push(name)
+      None => ()
+    }
+  }
+  names
+}
+
+///|
+/// Try to load the partition from disk and re-split. None on
+/// disabled/miss/fs-error/version-skew/corrupt.
+fn try_load_prelude_partition(
+  ast : @core.Module,
+) -> (Array[@core.Stmt], Array[@core.Stmt])? {
+  if !ast_disk_cache_enabled.val {
+    return None
+  }
+  let path = partition_snapshot_path()
+  if !@os_fs.path_exists(path) {
+    return None
+  }
+  let bytes = @os_fs.read_file_to_bytes(path) catch { _ => return None }
+  let names = decode_partition_names(bytes) catch { _ => return None }
+  let set : Map[String, Bool] = {}
+  for n in names {
+    set[n] = true
+  }
+  Some(split_prelude_value_stmts(ast, set))
+}
+
+///|
+fn save_prelude_partition(builtin_stmts : Array[@core.Stmt]) -> Unit {
+  if !ast_disk_cache_enabled.val {
+    return
+  }
+  if !ensure_ast_disk_cache_dir() {
+    return
+  }
+  let bytes = encode_partition_names(builtin_names_of(builtin_stmts))
+  @os_fs.write_bytes_to_file(partition_snapshot_path(), bytes) catch {
+    _ => ()
+  }
+}

--- a/src/checker/prelude_partition_snapshot.mbt
+++ b/src/checker/prelude_partition_snapshot.mbt
@@ -21,11 +21,18 @@ const PARTITION_SNAPSHOT_VERSION : Int = 1
 
 ///|
 fn partition_snapshot_path() -> String {
+  // The classification is computed over the *parsed/desugared* prelude AST, so
+  // fold in AST_CACHE_PARSER_VERSION (as the #427/#476 caches do): a
+  // parser/desugar change that alters refs for unchanged prelude source must
+  // invalidate the cached name set, since the warm path trusts it without
+  // re-running walk_stmt_refs.
   ast_disk_cache_dir.val +
   "/prelude-partition." +
   @core.content_address_hash_string(prelude_source) +
   ".v" +
   PARTITION_SNAPSHOT_VERSION.to_string() +
+  "-p" +
+  AST_CACHE_PARSER_VERSION.to_string() +
   ".names"
 }
 

--- a/src/checker/prelude_partition_snapshot_wbtest.mbt
+++ b/src/checker/prelude_partition_snapshot_wbtest.mbt
@@ -1,0 +1,30 @@
+///|
+/// #402: re-splitting prelude value stmts by the snapshotted builtin-name set
+/// must reproduce the computed partition exactly (same core/builtin split).
+test "prelude partition snapshot reconstruction matches computed" {
+  let ast = prelude_ast()
+  let (core, builtin) = prelude_partition_value_stmts(ast)
+  // Encode the builtin names, decode, re-split.
+  let bytes = encode_partition_names(builtin_names_of(builtin))
+  let names = (try? decode_partition_names(bytes)).unwrap_or([])
+  let set : Map[String, Bool] = {}
+  for n in names {
+    set[n] = true
+  }
+  let (core2, builtin2) = split_prelude_value_stmts(ast, set)
+  assert_eq(core2.length(), core.length())
+  assert_eq(builtin2.length(), builtin.length())
+  // Names must match in order.
+  let names_of = fn(stmts : Array[@core.Stmt]) -> Array[String] {
+    let r : Array[String] = []
+    for s in stmts {
+      match prelude_stmt_value_name(s) {
+        Some(n) => r.push(n)
+        None => ()
+      }
+    }
+    r
+  }
+  assert_eq(names_of(core2), names_of(core))
+  assert_eq(names_of(builtin2), names_of(builtin))
+}


### PR DESCRIPTION
## Disk-snapshot the prelude value-stmt partition (#402)

Follow-up to the compile-stage profiling. The bundle stage's prelude partition
(`prelude_partition_value_stmts` — a dependency graph + fixpoint splitting the
prelude value defs into core vs builtin-dependent) costs ~0.8ms native /
~2–4ms selfhost-wasm. #479 memoized it per-process, but a fresh selfhost
process (one compile per invocation) re-pays it every time.

### Change
Snapshot just the **builtin-dependent name set** to `.vibe/ast` (reusing the
#427/#476 disk-cache plumbing). A fresh process loads the names and re-splits
`prelude_ast()` by name in an O(stmts) pass — no graph/fixpoint:

- `src/checker/prelude_partition_snapshot.mbt` — encode/decode the name set
  (length-prefixed via the `@core` binary facade), best-effort disk load/save,
  and `split_prelude_value_stmts` reconstruction.
- `prelude_partitioned_value_stmts` tries the snapshot before computing.
- Versioned key (`PARTITION_SNAPSHOT_VERSION` + `content_hash(prelude_source)`);
  best-effort fallback to computing on any miss / fs error / version skew.

### Correctness
- Reconstruction reproduces the computed partition **exactly** (same value-stmt
  order + core/builtin classification) — unit test asserts equal lengths +
  names in order.
- cold (compute + save) vs warm (load + split) compile output **bit-identical**
  on basics / base64 / effects / module_export / module_import.
- checker 173/173, runtime_compile 241/241.

### Scope note
Per the corrected moon-pprof profile (#480), a fresh compile is dominated by
typecheck + parse; this partition snapshot is a focused **fixed-cost** removal
for fresh selfhost processes, not the dominant compile lever.

https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue)_