### PR TITLE
perf(codegen): O(N) named-fn scope via undo-log (was O(N²) per-block map copy)

### DIFF
--- a/src/codegen/wasm_codegen_ctx.mbt
+++ b/src/codegen/wasm_codegen_ctx.mbt
@@ -115,6 +115,13 @@ priv struct CodegenCtx {
   mut loop_continue_offset : Int
   // For parameterized loop: local indices for loop params
   mut loop_param_locals : Array[Int]
+  // Undo log for scoped named-function maps (fn_indices, fn_params,
+  // fn_param_names, fn_returns). These maps are pre-registered to the size
+  // of the whole module, so snapshotting them by value on every block was
+  // O(module_size) per block = O(N^2) over a compile. Instead, in-region
+  // writes push a revert closure here; snapshot records the log length and
+  // restore pops back to it. O(writes-in-block) per block.
+  scope_undo : Array[() -> Unit]
   // Forward-declared function tracking for mutual recursion back-patch
   // Maps function name -> span_key for forward-declarable functions
   forward_fn_keys : Map[String, String]
@@ -322,6 +329,7 @@ fn CodegenCtx::new(
     loop_break_offset: -1,
     loop_continue_offset: -1,
     loop_param_locals: [],
+    scope_undo: [],
     // Forward function tracking
     forward_fn_keys: {},
     // Mutable capture ref cell tracking

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -1934,44 +1934,6 @@ fn restore_string_array_value_kind_map(
 }
 
 ///|
-fn restore_string_array_string_map(
-  target : Map[String, Array[String]],
-  saved : Map[String, Array[String]],
-) -> Unit {
-  let to_remove : Array[String] = []
-  for name, _ in target {
-    if !saved.contains(name) {
-      to_remove.push(name)
-    }
-  }
-  for name in to_remove {
-    target.remove(name)
-  }
-  for name, value in saved {
-    target[name] = value
-  }
-}
-
-///|
-fn restore_string_value_kind_map(
-  target : Map[String, ValueKind],
-  saved : Map[String, ValueKind],
-) -> Unit {
-  let to_remove : Array[String] = []
-  for name, _ in target {
-    if !saved.contains(name) {
-      to_remove.push(name)
-    }
-  }
-  for name in to_remove {
-    target.remove(name)
-  }
-  for name, value in saved {
-    target[name] = value
-  }
-}
-
-///|
 fn restore_string_func_sig_map(
   target : Map[String, FuncSig],
   saved : Map[String, FuncSig],
@@ -2010,11 +1972,20 @@ fn restore_string_string_map(
 }
 
 ///|
+/// Scope snapshot for the named-function maps.
+///
+/// `fn_indices` / `fn_params` / `fn_param_names` / `fn_returns` are
+/// pre-registered to the size of the whole module (every top-level function),
+/// so copying them by value on every block snapshot was O(module_size) per
+/// block — O(N^2) over a compile (this dominated codegen on large modules).
+/// They are now scoped via the `ctx.scope_undo` log instead: in-region writes
+/// go through `scoped_named_map_set`, which records a revert closure, and the
+/// snapshot only remembers the log length (`big_map_undo_marker`).
+///
+/// The remaining maps are sparse (only special functions populate them) or
+/// per-function and small, so copying them stays cheap.
 priv struct NamedFnScopeSnapshot {
-  fn_indices : Map[String, Int]
-  fn_params : Map[String, Array[ValueKind]]
-  fn_param_names : Map[String, Array[String]]
-  fn_returns : Map[String, ValueKind]
+  big_map_undo_marker : Int
   fn_multivalue_results : Map[String, Array[ValueKind]]
   fn_return_sigs : Map[String, FuncSig]
   fn_local_sigs : Map[String, FuncSig]
@@ -2025,12 +1996,26 @@ priv struct NamedFnScopeSnapshot {
 }
 
 ///|
+/// Write `key=value` into one of the pre-registered named-function maps while
+/// recording how to revert it, so `restore_named_fn_scope` can undo exactly
+/// the in-region writes without copying the whole (module-sized) map.
+fn[V] scoped_named_map_set(
+  ctx : CodegenCtx,
+  m : Map[String, V],
+  key : String,
+  value : V,
+) -> Unit {
+  match m.get(key) {
+    Some(old) => ctx.scope_undo.push(fn() { m[key] = old })
+    None => ctx.scope_undo.push(fn() { m.remove(key) })
+  }
+  m[key] = value
+}
+
+///|
 fn snapshot_named_fn_scope(ctx : CodegenCtx) -> NamedFnScopeSnapshot {
   NamedFnScopeSnapshot::{
-    fn_indices: ctx.fn_indices.copy(),
-    fn_params: ctx.fn_params.copy(),
-    fn_param_names: ctx.fn_param_names.copy(),
-    fn_returns: ctx.fn_returns.copy(),
+    big_map_undo_marker: ctx.scope_undo.length(),
     fn_multivalue_results: ctx.fn_multivalue_results.copy(),
     fn_return_sigs: ctx.fn_return_sigs.copy(),
     fn_local_sigs: ctx.fn_local_sigs.copy(),
@@ -2046,10 +2031,15 @@ fn restore_named_fn_scope(
   ctx : CodegenCtx,
   saved : NamedFnScopeSnapshot,
 ) -> Unit {
-  restore_string_int_map(ctx.fn_indices, saved.fn_indices)
-  restore_string_array_value_kind_map(ctx.fn_params, saved.fn_params)
-  restore_string_array_string_map(ctx.fn_param_names, saved.fn_param_names)
-  restore_string_value_kind_map(ctx.fn_returns, saved.fn_returns)
+  // Revert in-region writes to the pre-registered big maps (fn_indices,
+  // fn_params, fn_param_names, fn_returns) by replaying the undo log back to
+  // the snapshot marker, newest first.
+  while ctx.scope_undo.length() > saved.big_map_undo_marker {
+    match ctx.scope_undo.pop() {
+      Some(revert) => revert()
+      None => break
+    }
+  }
   restore_string_array_value_kind_map(
     ctx.fn_multivalue_results,
     saved.fn_multivalue_results,
@@ -2083,14 +2073,14 @@ fn compile_function_with_scoped_names(
   let saved_named_fn_scope = snapshot_named_fn_scope(ctx)
   match f.name {
     Some(name) => {
-      ctx.fn_indices[name] = func_idx
-      ctx.fn_params[name] = param_kinds
+      scoped_named_map_set(ctx, ctx.fn_indices, name, func_idx)
+      scoped_named_map_set(ctx, ctx.fn_params, name, param_kinds)
       let param_names : Array[String] = []
       for p in f.params {
         param_names.push(p.name)
       }
-      ctx.fn_param_names[name] = param_names
-      ctx.fn_returns[name] = result_kind
+      scoped_named_map_set(ctx, ctx.fn_param_names, name, param_names)
+      scoped_named_map_set(ctx, ctx.fn_returns, name, result_kind)
     }
     None => ()
   }

--- a/src/codegen/wasm_codegen_stmt.mbt
+++ b/src/codegen/wasm_codegen_stmt.mbt
@@ -124,15 +124,15 @@ fn compile_stmt(
           }
           if func_idx >= 0 {
             // Register as callable function (direct call)
-            ctx.fn_indices[name] = func_idx
-            ctx.fn_params[name] = kinds
+            scoped_named_map_set(ctx, ctx.fn_indices, name, func_idx)
+            scoped_named_map_set(ctx, ctx.fn_params, name, kinds)
             // Save parameter names for labeled args resolution
             let names : Array[String] = []
             for p in fn_params {
               names.push(p.name)
             }
-            ctx.fn_param_names[name] = names
-            ctx.fn_returns[name] = ret_kind
+            scoped_named_map_set(ctx, ctx.fn_param_names, name, names)
+            scoped_named_map_set(ctx, ctx.fn_returns, name, ret_kind)
             // Infer return signature if function returns a function type
             match fn_ret {
               Some(r) =>
@@ -269,21 +269,24 @@ fn compile_stmt(
               match ctx.fn_indices.get(source_name) {
                 Some(func_idx) => {
                   let _ = span
-                  ctx.fn_indices[name] = func_idx
+                  scoped_named_map_set(ctx, ctx.fn_indices, name, func_idx)
                   match ctx.fn_local_sigs.get(source_name) {
                     Some(sig) => ctx.fn_local_sigs[name] = sig
                     None => ()
                   }
                   match ctx.fn_params.get(source_name) {
-                    Some(kinds) => ctx.fn_params[name] = kinds
+                    Some(kinds) =>
+                      scoped_named_map_set(ctx, ctx.fn_params, name, kinds)
                     None => ()
                   }
                   match ctx.fn_param_names.get(source_name) {
-                    Some(names) => ctx.fn_param_names[name] = names
+                    Some(names) =>
+                      scoped_named_map_set(ctx, ctx.fn_param_names, name, names)
                     None => ()
                   }
                   match ctx.fn_returns.get(source_name) {
-                    Some(ret_kind) => ctx.fn_returns[name] = ret_kind
+                    Some(ret_kind) =>
+                      scoped_named_map_set(ctx, ctx.fn_returns, name, ret_kind)
                     None => ()
                   }
                   match ctx.fn_return_sigs.get(source_name) {
@@ -340,7 +343,12 @@ fn compile_stmt(
                           param_kinds,
                           ValueKind::I64,
                         )
-                        ctx.fn_returns[name] = ValueKind::I64
+                        scoped_named_map_set(
+                          ctx,
+                          ctx.fn_returns,
+                          name,
+                          ValueKind::I64,
+                        )
                       }
                       let mut is_captured = false
                       for _key, captures in ctx.fn_closure_captures {
@@ -379,21 +387,34 @@ fn compile_stmt(
                 Some(target_name) =>
                   match ctx.fn_indices.get(target_name) {
                     Some(func_idx) => {
-                      ctx.fn_indices[name] = func_idx
+                      scoped_named_map_set(ctx, ctx.fn_indices, name, func_idx)
                       match ctx.fn_local_sigs.get(target_name) {
                         Some(sig) => ctx.fn_local_sigs[name] = sig
                         None => ()
                       }
                       match ctx.fn_params.get(target_name) {
-                        Some(kinds) => ctx.fn_params[name] = kinds
+                        Some(kinds) =>
+                          scoped_named_map_set(ctx, ctx.fn_params, name, kinds)
                         None => ()
                       }
                       match ctx.fn_param_names.get(target_name) {
-                        Some(names) => ctx.fn_param_names[name] = names
+                        Some(names) =>
+                          scoped_named_map_set(
+                            ctx,
+                            ctx.fn_param_names,
+                            name,
+                            names,
+                          )
                         None => ()
                       }
                       match ctx.fn_returns.get(target_name) {
-                        Some(ret_kind) => ctx.fn_returns[name] = ret_kind
+                        Some(ret_kind) =>
+                          scoped_named_map_set(
+                            ctx,
+                            ctx.fn_returns,
+                            name,
+                            ret_kind,
+                          )
                         None => ()
                       }
                       match ctx.fn_return_sigs.get(target_name) {


### PR DESCRIPTION
## Summary

The codegen ("compile") stage was **O(N²)** in the number of functions in a module. Root cause: `snapshot_named_fn_scope` deep-`.copy()`s four named-function maps (`fn_indices` / `fn_params` / `fn_param_names` / `fn_returns`) that are **pre-registered to the whole module size**, and a snapshot is taken for **every block scope** — function bodies, each if/match/loop branch. So threading a compile through a module was O(blocks × module_size).

This replaces the per-block copy of those four maps with an **undo log**: in-region writes go through `scoped_named_map_set`, which records a revert closure on `ctx.scope_undo`; a snapshot just remembers the log length and restore replays the log back to that marker (newest first). The remaining scope maps are sparse or per-function and small, so they keep the cheap value copy.

## Measurement

Synthetic module of N single-expression functions (`compile-lite --wasm-linear`, codegen stage):

| N | before | after |
|---|---|---|
| 400 | 0.53 s | 0.086 s |
| 800 | 2.15 s | 0.19 s |
| 1600 | **9.29 s** | **0.49 s** |

~19× at N=1600; quadratic → linear.

## How it was found

`vibe bench`'s phase micro-benches turned out to be dominated by a fixed per-iteration wasm-instantiation floor (≈280k ns, driven by `Fs` host-import linking), so they couldn't resolve phase cost. The bottleneck was instead isolated with `compile-lite --profile-tsv` scaling sweeps + a callstack profile, which pinned it to `codegen/compile_functions` → `snapshot_named_fn_scope`.

## Validation

- Full test suite green (0 failures).
- `moon check --deny-warn --warn-list … --target js` (CI gate) clean.
- Nested-function scoping — including sibling local-name collisions — verified to still resolve to the correct definition (undo log reverts in LIFO order).
- The selfhost codegen (`vibe/compiler/`) has no equivalent pattern, so the change is self-contained to the MoonBit host.

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue)_