### PR TITLE
perf(codegen): extend named-fn scope undo-log to the sparse pre-registered maps

### DIFF
--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -1896,44 +1896,6 @@ fn restore_local_kinds(
 }
 
 ///|
-fn restore_string_int_map(
-  target : Map[String, Int],
-  saved : Map[String, Int],
-) -> Unit {
-  let to_remove : Array[String] = []
-  for name, _ in target {
-    if !saved.contains(name) {
-      to_remove.push(name)
-    }
-  }
-  for name in to_remove {
-    target.remove(name)
-  }
-  for name, value in saved {
-    target[name] = value
-  }
-}
-
-///|
-fn restore_string_array_value_kind_map(
-  target : Map[String, Array[ValueKind]],
-  saved : Map[String, Array[ValueKind]],
-) -> Unit {
-  let to_remove : Array[String] = []
-  for name, _ in target {
-    if !saved.contains(name) {
-      to_remove.push(name)
-    }
-  }
-  for name in to_remove {
-    target.remove(name)
-  }
-  for name, value in saved {
-    target[name] = value
-  }
-}
-
-///|
 fn restore_string_func_sig_map(
   target : Map[String, FuncSig],
   saved : Map[String, FuncSig],
@@ -1974,25 +1936,24 @@ fn restore_string_string_map(
 ///|
 /// Scope snapshot for the named-function maps.
 ///
-/// `fn_indices` / `fn_params` / `fn_param_names` / `fn_returns` are
-/// pre-registered to the size of the whole module (every top-level function),
-/// so copying them by value on every block snapshot was O(module_size) per
-/// block — O(N^2) over a compile (this dominated codegen on large modules).
-/// They are now scoped via the `ctx.scope_undo` log instead: in-region writes
+/// `fn_indices` / `fn_params` / `fn_param_names` / `fn_returns`,
+/// `fn_return_sigs`, `fn_multivalue_results` and the three `linked_fn_*` maps
+/// are all pre-registered before the compile loop (the big four for every
+/// top-level function, the others for every fn-returning / tuple-returning /
+/// linked-import function). Copying them by value on every block snapshot was
+/// O(module_size) per block — O(N^2) over a compile, which dominated codegen
+/// on large modules (and left a smaller residual quadratic on match/loop-heavy
+/// code). They are now scoped via the `ctx.scope_undo` log: in-region writes
 /// go through `scoped_named_map_set`, which records a revert closure, and the
-/// snapshot only remembers the log length (`big_map_undo_marker`).
+/// snapshot only remembers the log length (`scope_undo_marker`).
 ///
-/// The remaining maps are sparse (only special functions populate them) or
-/// per-function and small, so copying them stays cheap.
+/// `fn_local_sigs` (reset per function, small) and `forward_fn_keys` (not
+/// pre-registered, small) are not pre-registered to module size, so they keep
+/// the cheap value copy.
 priv struct NamedFnScopeSnapshot {
-  big_map_undo_marker : Int
-  fn_multivalue_results : Map[String, Array[ValueKind]]
-  fn_return_sigs : Map[String, FuncSig]
+  scope_undo_marker : Int
   fn_local_sigs : Map[String, FuncSig]
   forward_fn_keys : Map[String, String]
-  linked_fn_imports : Map[String, Int]
-  linked_fn_param_counts : Map[String, Int]
-  linked_fn_return_counts : Map[String, Int]
 }
 
 ///|
@@ -2015,14 +1976,9 @@ fn[V] scoped_named_map_set(
 ///|
 fn snapshot_named_fn_scope(ctx : CodegenCtx) -> NamedFnScopeSnapshot {
   NamedFnScopeSnapshot::{
-    big_map_undo_marker: ctx.scope_undo.length(),
-    fn_multivalue_results: ctx.fn_multivalue_results.copy(),
-    fn_return_sigs: ctx.fn_return_sigs.copy(),
+    scope_undo_marker: ctx.scope_undo.length(),
     fn_local_sigs: ctx.fn_local_sigs.copy(),
     forward_fn_keys: ctx.forward_fn_keys.copy(),
-    linked_fn_imports: ctx.linked_fn_imports.copy(),
-    linked_fn_param_counts: ctx.linked_fn_param_counts.copy(),
-    linked_fn_return_counts: ctx.linked_fn_return_counts.copy(),
   }
 }
 
@@ -2031,31 +1987,18 @@ fn restore_named_fn_scope(
   ctx : CodegenCtx,
   saved : NamedFnScopeSnapshot,
 ) -> Unit {
-  // Revert in-region writes to the pre-registered big maps (fn_indices,
-  // fn_params, fn_param_names, fn_returns) by replaying the undo log back to
-  // the snapshot marker, newest first.
-  while ctx.scope_undo.length() > saved.big_map_undo_marker {
+  // Revert in-region writes to the pre-registered maps (fn_indices, fn_params,
+  // fn_param_names, fn_returns, fn_return_sigs, fn_multivalue_results,
+  // linked_fn_*) by replaying the undo log back to the snapshot marker,
+  // newest first.
+  while ctx.scope_undo.length() > saved.scope_undo_marker {
     match ctx.scope_undo.pop() {
       Some(revert) => revert()
       None => break
     }
   }
-  restore_string_array_value_kind_map(
-    ctx.fn_multivalue_results,
-    saved.fn_multivalue_results,
-  )
-  restore_string_func_sig_map(ctx.fn_return_sigs, saved.fn_return_sigs)
   restore_string_func_sig_map(ctx.fn_local_sigs, saved.fn_local_sigs)
   restore_string_string_map(ctx.forward_fn_keys, saved.forward_fn_keys)
-  restore_string_int_map(ctx.linked_fn_imports, saved.linked_fn_imports)
-  restore_string_int_map(
-    ctx.linked_fn_param_counts,
-    saved.linked_fn_param_counts,
-  )
-  restore_string_int_map(
-    ctx.linked_fn_return_counts,
-    saved.linked_fn_return_counts,
-  )
 }
 
 ///|

--- a/src/codegen/wasm_codegen_stmt.mbt
+++ b/src/codegen/wasm_codegen_stmt.mbt
@@ -137,13 +137,15 @@ fn compile_stmt(
             match fn_ret {
               Some(r) =>
                 match func_sig_from_type(ctx, r) {
-                  Some(sig) => ctx.fn_return_sigs[name] = sig
+                  Some(sig) =>
+                    scoped_named_map_set(ctx, ctx.fn_return_sigs, name, sig)
                   None => ()
                 }
               None =>
                 // Try to infer from body's last expression
                 match infer_body_return_sig(ctx, fn_body) {
-                  Some(sig) => ctx.fn_return_sigs[name] = sig
+                  Some(sig) =>
+                    scoped_named_map_set(ctx, ctx.fn_return_sigs, name, sig)
                   None => ()
                 }
             }
@@ -290,7 +292,8 @@ fn compile_stmt(
                     None => ()
                   }
                   match ctx.fn_return_sigs.get(source_name) {
-                    Some(sig) => ctx.fn_return_sigs[name] = sig
+                    Some(sig) =>
+                      scoped_named_map_set(ctx, ctx.fn_return_sigs, name, sig)
                     None => ()
                   }
                   // Skip only when: not is_last, not captured, and
@@ -312,19 +315,34 @@ fn compile_stmt(
                   // Check linked imports (library functions from --preload)
                   match ctx.linked_fn_imports.get(source_name) {
                     Some(import_idx) => {
-                      ctx.linked_fn_imports[name] = import_idx
+                      scoped_named_map_set(
+                        ctx,
+                        ctx.linked_fn_imports,
+                        name,
+                        import_idx,
+                      )
                       let param_count = match
                         ctx.linked_fn_param_counts.get(source_name) {
                         Some(pc) => pc
                         None => 0
                       }
-                      ctx.linked_fn_param_counts[name] = param_count
+                      scoped_named_map_set(
+                        ctx,
+                        ctx.linked_fn_param_counts,
+                        name,
+                        param_count,
+                      )
                       let return_count = match
                         ctx.linked_fn_return_counts.get(source_name) {
                         Some(rc) => rc
                         None => 1
                       }
-                      ctx.linked_fn_return_counts[name] = return_count
+                      scoped_named_map_set(
+                        ctx,
+                        ctx.linked_fn_return_counts,
+                        name,
+                        return_count,
+                      )
                       let param_kinds : Array[ValueKind] = []
                       for _ in 0..<param_count {
                         param_kinds.push(ValueKind::I64)
@@ -337,7 +355,12 @@ fn compile_stmt(
                         ctx.fn_local_sigs[name] = func_sig_with_env_multi(
                           param_kinds, result_kinds,
                         )
-                        ctx.fn_multivalue_results[name] = result_kinds
+                        scoped_named_map_set(
+                          ctx,
+                          ctx.fn_multivalue_results,
+                          name,
+                          result_kinds,
+                        )
                       } else {
                         ctx.fn_local_sigs[name] = func_sig_with_env(
                           param_kinds,
@@ -418,7 +441,13 @@ fn compile_stmt(
                         None => ()
                       }
                       match ctx.fn_return_sigs.get(target_name) {
-                        Some(sig) => ctx.fn_return_sigs[name] = sig
+                        Some(sig) =>
+                          scoped_named_map_set(
+                            ctx,
+                            ctx.fn_return_sigs,
+                            name,
+                            sig,
+                          )
                         None => ()
                       }
                       let needs_env = fn_index_needs_env(ctx, func_idx)


### PR DESCRIPTION
## Summary

Follow-up to #484. That PR scoped the four dense named-function maps (`fn_indices` / `fn_params` / `fn_param_names` / `fn_returns`) via the `ctx.scope_undo` log but still deep-copied the remaining maps on every block snapshot.

Three of those — `fn_return_sigs`, `fn_multivalue_results`, and the three `linked_fn_*` maps — are **also pre-registered before the compile loop** (for fn-returning, tuple-returning, and linked-import functions). So they grow to ~O(module size), and copying them on every block / match-arm / loop snapshot left a **residual O(N²)** on higher-order-, tuple-, or preload-heavy code with many nested scopes.

This routes their in-region writes through `scoped_named_map_set` too. The snapshot now copies only `fn_local_sigs` (reset per function) and `forward_fn_keys` (not pre-registered) — both genuinely small. The self-balancing `fn_multivalue_results` toggle in `compile_expr_multivalue` and all pre-loop / `build_module` writes stay direct.

## Measurement

N higher-order functions, each returning a function inside a 4-arm match (`compile-lite --wasm-linear`, codegen stage):

| N | no-fix | this PR |
|---|---|---|
| 200 | 0.85 s | 0.106 s |
| 400 | 3.43 s | 0.26 s |
| 800 | 14.86 s | **0.81 s** (~18×) |

The snapshot O(N²) is now entirely gone from the CPU profile (no `snapshot_named_fn_scope` / `Map::iter`).

## Known remaining (separate follow-up)

A distinct, pre-existing O(N²) remains for lambda-heavy code: `format_lambda_position_linear` → `line_info` rescans the source for newlines **per lambda** to build the `line:col` label for the wasm name section → O(lambdas × source). Unrelated to scope snapshotting; best fixed by caching a newline-offset index. Not addressed here.

## Validation

- Full test suite green (0 failures).
- `moon check --deny-warn --warn-list … --target js` (CI gate) clean.
- Nested-function scoping incl. sibling local-name collisions still resolves correctly (undo log reverts in LIFO order; the toggle remains self-balancing).

---
_Generated by [Claude Code](https://claude.ai/code/session_013Xj7ofC4BNSdE2DboKD7Ue)_