### PR TITLE
perf(compile): bundle prelude reachability-prune + #402 compile-ratio 本質診断

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,58 @@
 
 Spec-locked decisions are tracked in `docs/spec/decisions.md`.
 Completed items are archived in `docs/DONE.md`.
+タスクの一次管理は GitHub Issues (`gh issue` / MCP)。本ファイルはロードマップ概要。
 
-## 次の一手 (2026-05-05 時点)
+## 次の一手 (2026-05-31 時点)
+
+現況スナップショット。open issue は 4 件 (#402 #482 #418 #415)。優先順は下記。
+
+### 現状サマリ
+
+- **0.1.0 surface は通っている**。直近の主戦場は **selfhost cutover の perf gate (#402)**。
+- **#402 KPI (wasmtime-aot, RUNS=5 median, 2026-05-30〜31 再計測)**:
+  - **check ratio = 0.77× ✅** (gate ≤ 1.33× 通過)
+  - **compile ratio ≈ 3.4–3.9× ❌** (依然 blocker)。worst stage は **bundle ~4.7×**、次いで load 3.4–4× / compile_module 3.1–3.4× / type 3.3× / emit 2–3.3×。
+  - レポート: `docs/report/selfhost-cutover-kpi-2026-05-30.md`
+
+### 🔴 #402 compile ratio を動かす — 戦略の軌道修正 (重要)
+
+今セッションの A/B 計測で判明した、今後の方針を左右する事実:
+
+- **compile ratio ~3.4× は単一ホットスポットではなく、全 stage に乗る wasm↔native の constant-factor floor**(load/type/emit/bundle/compile_module がどれも ~3–5×)。
+- ⇒ **対称な algorithmic 改善は ratio を動かさない**。例: bundle の prelude reachability prune (commit `80098b6`, 51→2-6 def materialize) は bundle 絶対時間を host/selfhost 双方で ~2-3% 削るが、削減が対称なので selfhost÷host は不変(むしろ微増)。debug プロファイルが指した「prelude_add 1.3-1.6ms 固定費」は **debug ビルド固有**で release では数 %。
+- ⇒ ratio を動かすには次のいずれかが必要(優先順):
+  1. **selfhost compile の daemon 化** ← 最有力単一レバー。check が 0.77× を切れた主因は「check は daemon 化済 (#405) で `check.load` が 0.02–0.06×(host が毎回払う session-http/db setup を selfhost は skip)」という **load-stage の非対称**。compile は依然 one-shot で `compile.load` が 3.3–3.9×。compile も daemon 化すれば同じ非対称が効き、ratio を大きく押し下げる見込み。parity test (compile は output file 書き、state surface 広) の整備が必要。
+  2. **非対称な algorithmic 改善** ← selfhost wasm が native より桁で損する箇所(vibe runtime の `Map`/`Set` が線形走査、データ構造の差)。#366 accumulator / #483 selfhost ripple O(N) はこの系。vibe runtime に hash-backed Map が入れば §[accumulator 撲滅] でスキップした dedup 系 (~17 sites) も効くようになる。
+  3. **release ビルドでの bundle/emit sub-stage 再プロファイル** ← debug プロファイルは ratio 用途には誤誘導。release で bundle ~4.7× の真の支配項(deps collection / alias rewrite / dedup / DCE tree-walk のどれが wasm で重いか)を特定。
+- **未計測ゲート**: compile/check の **peak RSS ratio ≤ 2.0×** が wasmtime-aot 後に未計測(`/usr/bin/time -v` 環境要)。
+
+### 🟠 open issues (一次ソース)
+
+- [ ] **#402** selfhost cutover tracking — 上記。compile ratio が最後の gate。
+- [ ] **#482** host `mizchi/ripple` verifier の O(n²) memo scan — **upstream publish 待ちで bump のみ**。host typecheck hot path に効く(selfhost 側 ripple は #483 で O(N) 化済)。`moon.mod` の `mizchi/ripple` を修正版公開後に bump。
+- [ ] **#415** codegen builtin を 2 backend 共有 registry に refactor (Phase B) — linear↔wasm-gc の parity 117 件ずれ、新 builtin 追加時の silent regression 温床。3-6 週、namespace 単位の小 PR 5-7 本。wasm-gc default 化 (Phase D) の前提。
+- [ ] **#418** ADR-0052 Phase 2/3 — `mut` struct field の `state_local` effect 分類 + escape 検査。ADR-0017 `state_local` 実装が前提。大規模・既存コード影響大。
+
+### 🟡 機能 / 品質 (issue 化候補、TODO 内に詳細あり)
+
+- [ ] **CI branch coverage 70% gate** + normalize/DCE/loader テスト拡充 (§カバレッジ)
+- [ ] **SIMD codegen 本番化** — 0xFD prefix emit + `simd_skip_ws`/`simd_scan_alnum` builtin 化 (§vibe/wasm)
+- [ ] **#59 WASM-GC selfbuild ~350KB** — P4 残 3 ケース (simd_patterns / gc_only/index / selfhost_cli_gc_entry) + P5 DCE + wasm-opt
+- [ ] **WASI P3**: effect → WIT マッピング + `vibe serve`
+- [ ] selfhost accumulator 残 2 sites (`linked_helpers.vibe` の `contains_name` 線形走査) — vibe runtime の Map が hash table 化するまで保留 (ROI ≪、§accumulator 撲滅)
+
+### 🔵 リファクタ / 長期
+
+- [ ] `vibe/types/` `vibe/parser/` 分離、`vibe/compiler` 論理分割
+- [ ] MoonBit host CLI を bootstrap 専用へ縮退
+- [ ] MoonBit host 重複削減 (§similarity-mbt、残: `src/runtime/db.mbt` の `set_source`/`set_binary_source`)
+
+---
+
+## 次の一手 (2026-05-05 時点) — historical
+
+> 注: 以下は 2026-05-05 時点の整理。`just` は pkfire (`pkf`) に移行済み。最新の優先順は上の「2026-05-31 時点」を参照。各 §詳細は下に残置。
 
 優先順。各項目は該当セクションに詳細あり。
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,16 +16,20 @@ Completed items are archived in `docs/DONE.md`.
   - **compile ratio ≈ 3.4–3.9× ❌** (依然 blocker)。worst stage は **bundle ~4.7×**、次いで load 3.4–4× / compile_module 3.1–3.4× / type 3.3× / emit 2–3.3×。
   - レポート: `docs/report/selfhost-cutover-kpi-2026-05-30.md`
 
-### 🔴 #402 compile ratio を動かす — 戦略の軌道修正 (重要)
+### 🔴 #402 compile ratio — 本質診断で攻め方が確定 (重要・要 maintainer 判断)
 
-今セッションの A/B 計測で判明した、今後の方針を左右する事実:
+今セッションの per-frame profile (release/wasmtime, warm) で判明した、ロードマップを書き換える事実。詳細は #402 コメント (2026-05-31, `4586511284`)。
 
-- **compile ratio ~3.4× は単一ホットスポットではなく、全 stage に乗る wasm↔native の constant-factor floor**(load/type/emit/bundle/compile_module がどれも ~3–5×)。
-- ⇒ **対称な algorithmic 改善は ratio を動かさない**。例: bundle の prelude reachability prune (commit `80098b6`, 51→2-6 def materialize) は bundle 絶対時間を host/selfhost 双方で ~2-3% 削るが、削減が対称なので selfhost÷host は不変(むしろ微増)。debug プロファイルが指した「prelude_add 1.3-1.6ms 固定費」は **debug ビルド固有**で release では数 %。
-- ⇒ ratio を動かすには次のいずれかが必要(優先順):
-  1. **selfhost compile の daemon 化** ← 最有力単一レバー。check が 0.77× を切れた主因は「check は daemon 化済 (#405) で `check.load` が 0.02–0.06×(host が毎回払う session-http/db setup を selfhost は skip)」という **load-stage の非対称**。compile は依然 one-shot で `compile.load` が 3.3–3.9×。compile も daemon 化すれば同じ非対称が効き、ratio を大きく押し下げる見込み。parity test (compile は output file 書き、state surface 広) の整備が必要。
-  2. **非対称な algorithmic 改善** ← selfhost wasm が native より桁で損する箇所(vibe runtime の `Map`/`Set` が線形走査、データ構造の差)。#366 accumulator / #483 selfhost ripple O(N) はこの系。vibe runtime に hash-backed Map が入れば §[accumulator 撲滅] でスキップした dedup 系 (~17 sites) も効くようになる。
-  3. **release ビルドでの bundle/emit sub-stage 再プロファイル** ← debug プロファイルは ratio 用途には誤誘導。release で bundle ~4.7× の真の支配項(deps collection / alias rewrite / dedup / DCE tree-walk のどれが wasm で重いか)を特定。
+- **bench の "selfhost" は `src/cmd/vibe_compile_wasi` = src/ runtime_compile を `--target wasm` したもの**(vibe/compiler/ ではない)。host は同じ src/ を `--target native`。⇒ **両側は同一 MoonBit コード、アルゴリズム同一。**
+- ⇒ **src/ への algorithmic 改善は両側に等しく効く = 構造的に symmetric → compile ratio を原理的に動かさない**。prelude prune (`80098b6`) も過去の accumulator/ripple も「横ばい」だったのはこれが根本原因。**compile ratio 目的の src/ 最適化は ROI ゼロ**。
+- **ratio ~4.8× は wasmtime JIT vs native の runtime floor**(frame 別 2.5–13.6×: build_module 13.6× / prelude_add roots-walk 7.4× / cache_key 5.5× / parse_stmts 5.2×)。ばらつきは「wasmtime がその op mix で native よりどれだけ遅いか」を表すだけ。
+- **「compile daemon 化」レバーは棄却**: daemon は selfhost の cold-start を amortize するが host(one-shot native)も同じ cold cost を払うので、公平比較では両側 amortize → 残る per-compile work の ~4× は不変。**check が 0.77× なのは host が session-http (~7-9ms/invoke) を払う host-only の計測非対称**であって selfhost daemon の効果ではない(`CHECK_DAEMON_MODE` は default 0)。host check に `VIBE_USE_SESSION_HTTP=0` を与えれば check も ~4× に跳ねる。
+- **gate ≤ 1.33× は「wasmtime JIT が native の 1.33× 以内」を要求**。branchy な compiler workload で JIT が native の 1.3× 以内は一般に非現実的。**src/ 改善では到達不能。**
+
+⇒ 残る実レバー(いずれも maintainer 判断要):
+  1. **wasmtime runtime チューニング**(codegen flag / PGO 等。既に `-O3`+cwasm)。floor を 4.8→例えば 4.0 に削る程度、1.33× には届かない見込み。
+  2. **operation-mix 置換**(高非対称 frame: build_module の per-byte `ByteBuf::push` を bulk op 化 等)。同上、floor を少し削るのみ。
+  3. **cutover 基準の再定義** ← 本命。「native を常用 / wasm は portability・sandbox 用 optional artifact」とするか、gate を runtime 現実(~2-4×)へ緩める。check の "pass" も session-http 非対称依存で、apples-to-apples なら compile/check 共に ~4× が実態。
 - **未計測ゲート**: compile/check の **peak RSS ratio ≤ 2.0×** が wasmtime-aot 後に未計測(`/usr/bin/time -v` 環境要)。
 
 ### 🟠 open issues (一次ソース)

--- a/src/checker/pkg.generated.mbti
+++ b/src/checker/pkg.generated.mbti
@@ -48,6 +48,8 @@ pub fn prelude_core_value_stmts() -> Array[@core.Stmt]
 
 pub fn prelude_names() -> Array[String]
 
+pub fn prelude_reachable_value_stmts(Map[String, Bool], Map[String, Bool]) -> Array[@core.Stmt]
+
 pub fn purity_block(TypeEnv, @core.Module) -> Bool
 
 pub fn purity_expr(TypeEnv, @core.Expr) -> Bool

--- a/src/checker/prelude.mbt
+++ b/src/checker/prelude.mbt
@@ -547,6 +547,109 @@ pub fn prelude_builtin_value_stmts() -> Array[@core.Stmt] {
 }
 
 ///|
+/// #402: name -> prelude value stmt index, in canonical (core ++ builtin) order
+/// the bundler emits. Built once per process; only a cheap O(stmts) pass (no
+/// ref walk), so it costs far less than walking every prelude def.
+let cached_prelude_value_index : Ref[Map[String, @core.Stmt]?] = @ref.new(None)
+
+///|
+fn prelude_value_index() -> Map[String, @core.Stmt] {
+  match cached_prelude_value_index.val {
+    Some(idx) => idx
+    None => {
+      let idx : Map[String, @core.Stmt] = {}
+      for stmt in prelude_core_value_stmts() {
+        match prelude_stmt_value_name(stmt) {
+          Some(name) => idx[name] = stmt
+          None => ()
+        }
+      }
+      for stmt in prelude_builtin_value_stmts() {
+        match prelude_stmt_value_name(stmt) {
+          Some(name) => idx[name] = stmt
+          None => ()
+        }
+      }
+      cached_prelude_value_index.val = Some(idx)
+      idx
+    }
+  }
+}
+
+///|
+/// #402: prelude value defs transitively reachable from `roots` (the value names
+/// referenced by the bundled non-prelude code) via the prelude's internal value
+/// dependency graph, returned in canonical (core ++ builtin) order and skipping
+/// any name in `shadowed` (a non-prelude def of the same name takes precedence,
+/// mirroring the bundler's existing collision guard).
+///
+/// The closure is computed lazily: only prelude defs that are actually reached
+/// get their references walked, so a small program walks a handful of stdlib
+/// functions instead of the bundler materializing the entire prelude and the
+/// DCE then removing most of it. The result is a *superset* of the prelude defs
+/// the final DCE keeps (roots are a superset of DCE's prelude entry refs and the
+/// closure uses the same `walk_stmt_refs` ref semantics), so emitting only these
+/// and letting the authoritative DCE prune the remainder is bit-for-bit
+/// identical to adding the whole prelude up front.
+pub fn prelude_reachable_value_stmts(
+  roots : Map[String, Bool],
+  shadowed : Map[String, Bool],
+) -> Array[@core.Stmt] {
+  let index = prelude_value_index()
+  let reachable : Map[String, Bool] = {}
+  let queue : Array[String] = []
+  for r, _ in roots {
+    if index.contains(r) && !reachable.contains(r) {
+      reachable[r] = true
+      queue.push(r)
+    }
+  }
+  let mut i = 0
+  while i < queue.length() {
+    let name = queue[i]
+    i = i + 1
+    match index.get(name) {
+      Some(stmt) => {
+        let refs : Map[String, Bool] = {}
+        @core.walk_stmt_refs(
+          stmt,
+          @core.WalkerScope::new(),
+          refs,
+          prelude_add_unbound_ref,
+        )
+        for ref_name, _ in refs {
+          if index.contains(ref_name) && !reachable.contains(ref_name) {
+            reachable[ref_name] = true
+            queue.push(ref_name)
+          }
+        }
+      }
+      None => ()
+    }
+  }
+  let out : Array[@core.Stmt] = []
+  for stmt in prelude_core_value_stmts() {
+    match prelude_stmt_value_name(stmt) {
+      Some(name) =>
+        if reachable.contains(name) && !shadowed.contains(name) {
+          out.push(stmt)
+        }
+      None => ()
+    }
+  }
+  for stmt in prelude_builtin_value_stmts() {
+    match prelude_stmt_value_name(stmt) {
+      Some(name) =>
+        if reachable.contains(name) && !shadowed.contains(name) {
+          out.push(stmt)
+        }
+      None => ()
+    }
+  }
+  out
+}
+
+///|
 let cached_prelude_ast : Ref[@core.Module?] = @ref.new(None)
 
 ///|

--- a/src/runtime_compile/bundle.mbt
+++ b/src/runtime_compile/bundle.mbt
@@ -1845,9 +1845,16 @@ fn bundle_for_wasm_impl(
   // like array_map, array_filter, array_fold etc. are available in WASM.
   // These are defined as user-level .vibe code using primitive builtins
   // (array_builder, array_builder_push, etc.) that the WASM backend handles.
-  // DCE will remove any prelude definitions that aren't actually used.
-  // Snapshot non-prelude names before adding prelude stmts.
-  // Used for surgical prelude DCE in --no-dce mode.
+  //
+  // #402: instead of materializing the entire prelude here and letting DCE drop
+  // most of it (~1.3-1.6ms fixed bundle cost per compile), add only the prelude
+  // defs transitively reachable from the bundled program. The authoritative DCE
+  // below still prunes any over-approximation, so the output is bit-identical to
+  // adding the whole prelude up front, but a small program now walks a handful
+  // of stdlib functions rather than the full standard library.
+  //
+  // Snapshot non-prelude names for the surgical --no-dce path. Built from deps +
+  // main (re-export-expanded defs are intentionally excluded, as before).
   let non_prelude_names : Array[String] = []
   for stmt in bundled_stmts {
     match bundle_stmt_value_name(stmt) {
@@ -1859,25 +1866,10 @@ fn bundle_for_wasm_impl(
       None => ()
     }
   }
-  @profiler.profiler_enter("bundle/collect/prelude_add")
-  for
-    prelude_stmts in [
-      @checker.prelude_core_value_stmts(),
-      @checker.prelude_builtin_value_stmts(),
-    ] {
-    for stmt in prelude_stmts {
-      match bundle_stmt_value_name(stmt) {
-        Some(name) =>
-          if !existing_value_names.contains(name) {
-            bundled_stmts.push(stmt)
-            existing_value_names[name] = true
-          }
-        None => ()
-      }
-    }
-  }
-  @profiler.profiler_leave()
-  // Add main module statements (excluding imports and expanding re-exports)
+  // Expand re-exports and collect main module statements (excluding imports)
+  // into a tail appended after the prelude, preserving the original bundle order
+  // (deps ++ prelude ++ re-export-defs ++ sorted-main).
+  let tail_stmts : Array[@core.Stmt] = []
   let main_stmts : Array[@core.Stmt] = []
   for stmt in main_ast.stmts {
     match stmt {
@@ -1885,7 +1877,7 @@ fn bundle_for_wasm_impl(
       @core.Stmt::ReExport(spec~, source~, span=_) =>
         // Expand re-exports in main module
         collect_reexport_defs(
-          db, path, spec, source, bundled_stmts, visited, entry_value_names, entry_type_names,
+          db, path, spec, source, tail_stmts, visited, entry_value_names, entry_type_names,
         )
       _ => main_stmts.push(stmt)
     }
@@ -1929,6 +1921,37 @@ fn bundle_for_wasm_impl(
       Some(name) => non_prelude_names.push(name)
       None => ()
     }
+    tail_stmts.push(stmt)
+  }
+  // Roots = every name referenced by the bundled non-prelude code (deps +
+  // re-export-defs + main). A superset of DCE's prelude entry refs, so the
+  // reachable prelude closure is a superset of what DCE keeps.
+  @profiler.profiler_enter("bundle/collect/prelude_add")
+  let prelude_roots : Map[String, Bool] = {}
+  for stmt in bundled_stmts {
+    @core.walk_stmt_refs(
+      stmt,
+      @core.WalkerScope::new(),
+      prelude_roots,
+      bundle_add_unbound_ref,
+    )
+  }
+  for stmt in tail_stmts {
+    @core.walk_stmt_refs(
+      stmt,
+      @core.WalkerScope::new(),
+      prelude_roots,
+      bundle_add_unbound_ref,
+    )
+  }
+  for
+    stmt in @checker.prelude_reachable_value_stmts(
+      prelude_roots, existing_value_names,
+    ) {
+    bundled_stmts.push(stmt)
+  }
+  @profiler.profiler_leave()
+  for stmt in tail_stmts {
     bundled_stmts.push(stmt)
   }
   let bundled = @core.Module::{
@@ -1961,6 +1984,19 @@ fn bundle_stmt_value_name(stmt : @core.Stmt) -> String? {
     | @core.Stmt::InternalExportLet(name~, ..)
     | @core.Stmt::LetMut(name~, ..) => Some(name)
     _ => None
+  }
+}
+
+///|
+/// #402: `walk_stmt_refs` callback that records every unbound (free) name. Used
+/// to collect the prelude roots of a bundle.
+fn bundle_add_unbound_ref(
+  name : String,
+  bound : @core.WalkerScope,
+  refs : Map[String, Bool],
+) -> Unit {
+  if !bound.contains(name) {
+    refs[name] = true
   }
 }
 


### PR DESCRIPTION
## 概要

#402 (selfhost cutover) の compile ratio を動かす試みと、その過程で判明した**本質的な再診断**。コード変更1点 + ドキュメント整理。

## 1. code: bundle stage の prelude reachability-prune (`80098b6`)

bundle は毎 compile で**全 prelude/builtin value def(51 個)を materialize → DCE が未使用分を除去**する add-then-remove 方式だった。代わりに `prelude_reachable_value_stmts` が、bundled された非 prelude コードの roots から prelude 内部の value 依存グラフを**遅延 BFS** し、到達可能な prelude def だけを emit する。

- 最終 DCE は authoritative なまま残し、reachable set は「DCE が残す prelude def の superset」(roots ⊇ DCE の prelude entry refs、同じ `walk_stmt_refs` セマンティクス)なので**出力は bit-identical**。
- KPI ケースで materialize される prelude def: **51 → 2-6(88-96% 減)**。

### 検証
- 78 個の example/bench を `--wasm` で **byte-identical**(旧実装 vs 新、cmp 0 差分)
- runtime_compile 241 / checker 173 / e2e 262 / codegen 85 = **761 tests 全 pass**
- fmt + info + check 済み(0 errors)

## 2. docs: #402 の本質診断と roadmap 整理 (`05565e6`, `8cb0553`)

per-frame profile (release/wasmtime, warm) を取り直した結果、**これまでの「src/ の algorithmic 改善で compile ratio が動く」という前提が構造的に成り立たない**ことが判明:

- bench の "selfhost" は `src/cmd/vibe_compile_wasi`(= **src/ runtime_compile を `--target wasm`** したもの。vibe/compiler/ ではない)。host は同じ src/ を native ビルド。**両側は同一 MoonBit コード = アルゴリズム同一**。
- ⇒ **src/ への algorithmic 改善は両側に等しく効く = 構造的に symmetric → compile ratio を原理的に動かさない**。本 PR の prelude prune も、過去の accumulator/ripple 最適化も compile ratio に対して「横ばい」だった根本原因。
- ratio ~4.8× は **wasmtime JIT vs native の runtime floor**(frame 別 2.5–13.6×: build_module 13.6× / prelude_add 7.4× / cache_key 5.5× / parse_stmts 5.2×)。
- 「compile daemon 化」レバーも棄却(host も同じ cold cost を払う / check 0.77× は host session-http の計測非対称)。

詳細: #402 コメント `4586511284`。TODO.md の #402 セクションをこの確定理解で書き換え。

## 性質と位置づけ

本 PR の code 変更は **bit-identical + 小幅な絶対時間改善(release bundle host −2〜5%)+ debug ビルド/テスト反復の高速化**だが、**#402 の compile ratio gate は動かさない**(symmetric なため原理的に)。compile ratio を真に動かすには src/ 最適化ではなく **wasmtime runtime レイヤ or cutover 基準の再定義(maintainer 判断)**が必要、という負の結論を docs に記録している。

## コミット

- `80098b6` perf(compile): reachability-prune prelude inclusion in bundle stage (#402)
- `05565e6` docs(todo): refresh roadmap with 2026-05-31 状況
- `8cb0553` docs(todo): #402 本質診断で compile ratio の攻め方を確定

https://claude.ai/code/session_01MHMdWHvZnNg9CyVARkNLHL

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHMdWHvZnNg9CyVARkNLHL)_