### PR TITLE
ci: corpus gate shard + selfbuild stage1 caching (#492)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,14 @@ jobs:
           chmod +x _build/native/debug/build/cmd/vibe/vibe.exe
           touch _build/native/debug/build/cmd/vibe/vibe.exe
           echo "VIBE_BIN=$(pwd)/_build/native/debug/build/cmd/vibe/vibe.exe" >> "$GITHUB_ENV"
+      - name: Cache selfhost wasi compiler wasm
+        uses: actions/cache@v5
+        with:
+          path: _build/wasm/debug/build/cmd/vibe_compile_wasi
+          # Exact-key only (no restore-keys): a partial restore could supply a
+          # stale wasm built from different src/*.mbt, which the gate's mtime
+          # staleness check would not catch. On a key miss the wasm is rebuilt.
+          key: selfhost-wasi-compiler-${{ runner.os }}-${{ hashFiles('src/**/*.mbt', '**/moon.pkg', '**/moon.pkg.json', 'moon.mod', 'moon.mod.json', '.moon-version') }}
       - name: Run selfhost bootstrap gate (${{ matrix.part }})
         # PRs use a sampled deterministic profile to keep feedback short.
         # Pushes keep the full deterministic mode coverage. Compiled
@@ -580,6 +588,21 @@ jobs:
           ripgrep: 'true'
           wasmtime: 'true'
           node-version: '24'
+      - name: Cache selfhost wasi compiler wasm
+        uses: actions/cache@v5
+        with:
+          path: _build/wasm/debug/build/cmd/vibe_compile_wasi
+          # Exact-key only (no restore-keys): a partial restore could supply a
+          # stale wasm built from different src/*.mbt, which the gate's mtime
+          # staleness check would not catch. On a key miss the wasm is rebuilt.
+          key: selfhost-wasi-compiler-${{ runner.os }}-${{ hashFiles('src/**/*.mbt', '**/moon.pkg', '**/moon.pkg.json', 'moon.mod', 'moon.mod.json', '.moon-version') }}
+      - name: Cache selfbuild stage1 wasm
+        uses: actions/cache@v5
+        with:
+          path: _build/bench/selfhost_wasi_selfbuild/stage1_cache
+          key: selfhost-stage1-${{ runner.os }}-${{ hashFiles('src/**/*.mbt', 'vibe/compiler/**/*.vibe') }}
+          restore-keys: |
+            selfhost-stage1-${{ runner.os }}-
       - name: Run selfbuild KPI
         run: bash scripts/pkfire/selfhost_gates_shard.sh selfbuild
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,7 +600,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: _build/bench/selfhost_wasi_selfbuild/stage1_cache
-          key: selfhost-stage1-${{ runner.os }}-${{ hashFiles('src/**/*.mbt', 'vibe/compiler/**/*.vibe') }}
+          key: selfhost-stage1-${{ runner.os }}-${{ hashFiles('src/**/*.mbt', 'vibe/**/*.vibe') }}
           restore-keys: |
             selfhost-stage1-${{ runner.os }}-
       - name: Run selfbuild KPI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,7 +592,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [cli, check]
+        shard: [cli, check, corpus]
     steps:
       - uses: actions/checkout@v5
       - name: Init wasmtime submodule

--- a/scripts/pkfire/selfhost_gates_shard.sh
+++ b/scripts/pkfire/selfhost_gates_shard.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Selfhost release gate shards — extracted from justfile `ci-selfhost-gates-shard`.
-# Usage: scripts/pkfire/selfhost_gates_shard.sh <bootstrap|bootstrap-core|selfbuild|cli|check|coverage>
+# Usage: scripts/pkfire/selfhost_gates_shard.sh <bootstrap|bootstrap-core|selfbuild|cli|check|coverage|corpus>
 set -euo pipefail
 
-shard="${1:?missing shard argument: bootstrap|bootstrap-core|selfbuild|cli|check|coverage}"
+shard="${1:?missing shard argument: bootstrap|bootstrap-core|selfbuild|cli|check|coverage|corpus}"
 
 case "$shard" in
   bootstrap-core)
@@ -56,8 +56,16 @@ case "$shard" in
     VIBE_SELFHOST_SUITE_MIN_BRANCH_RATE="${VIBE_SELFHOST_SUITE_MIN_BRANCH_RATE:-30}" \
     scripts/coverage_selfhost_suite.sh
     ;;
+  corpus)
+    # Full-corpus selfhost compile gate (#492): every corpus .vibe must
+    # compile through the self-hosted compiler with no REAL language/checker
+    # gaps. `--gate` exits non-zero only on REAL gaps (MODE/TRIAGE harness
+    # artifacts do not trip it). Tracks selfhost expressiveness regressions on
+    # the path to dropping the MoonBit implementation.
+    bash scripts/test_selfhost_corpus_gate.sh --gate
+    ;;
   *)
-    echo "unknown shard: $shard (expected: bootstrap|bootstrap-core|selfbuild|cli|check|coverage)" >&2
+    echo "unknown shard: $shard (expected: bootstrap|bootstrap-core|selfbuild|cli|check|coverage|corpus)" >&2
     exit 1
     ;;
 esac

--- a/scripts/test_selfhost_wasi_selfbuild.sh
+++ b/scripts/test_selfhost_wasi_selfbuild.sh
@@ -182,12 +182,16 @@ hash_file() {
 }
 
 stage1_fingerprint() {
-  # Determinant of stage1.wasm: the wasm compiler binary + every selfhost
-  # compiler source the entry transitively compiles + the entry path.
+  # Determinant of stage1.wasm: the wasm compiler binary + every Vibe source
+  # the entry transitively compiles + the entry path. index.vibe imports
+  # siblings outside vibe/compiler (../json, ../module, ../shell, and their
+  # transitive deps), so fingerprint the whole vibe/**/*.vibe tree — narrowing
+  # to vibe/compiler would let an out-of-tree dependency change reuse a stale
+  # stage1 wasm and validate a stale compiler against itself.
   {
     hash_file "$STAGE1_COMPILER_WASM"
     echo "$ENTRY_PATH"
-    find "$PROJECT_ROOT/vibe/compiler" -name '*.vibe' -type f 2>/dev/null \
+    find "$PROJECT_ROOT/vibe" -name '*.vibe' -type f 2>/dev/null \
       | LC_ALL=C sort \
       | while IFS= read -r f; do hash_file "$f"; done
   } | {

--- a/scripts/test_selfhost_wasi_selfbuild.sh
+++ b/scripts/test_selfhost_wasi_selfbuild.sh
@@ -160,8 +160,68 @@ if [ ! -f "$STAGE1_COMPILER_WASM" ]; then
   exit 1
 fi
 
-run_stage "stage0 (wasm compiler via moonrun) -> stage1 wasm compile" \
-  moonrun "$STAGE1_COMPILER_WASM" --wasm-mvp "$ENTRY_PATH" -o "$STAGE1_WASM"
+# --- stage1 wasm cache (#492) ---
+# stage0 (moonrun running the MoonBit-built wasm compiler) is the dominant
+# selfbuild cost (~27s, ~70% of the total). Its output, stage1.wasm, is a pure
+# function of the wasm compiler binary + the selfhost compiler sources, so
+# fingerprint those inputs and reuse a cached stage1.wasm when they are
+# unchanged. The true-recursive validation (stage2 = stage1 compiling itself)
+# still runs on the cached artifact; on any source change the fingerprint
+# misses and stage0 reruns. Opt out with VIBE_SELFHOST_SELFBUILD_STAGE1_CACHE=0.
+STAGE1_CACHE_ENABLED="${VIBE_SELFHOST_SELFBUILD_STAGE1_CACHE:-1}"
+STAGE1_CACHE_DIR="${VIBE_SELFHOST_SELFBUILD_STAGE1_CACHE_DIR:-$PROJECT_ROOT/_build/bench/selfhost_wasi_selfbuild/stage1_cache}"
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    cksum "$1" | cut -d' ' -f1
+  fi
+}
+
+stage1_fingerprint() {
+  # Determinant of stage1.wasm: the wasm compiler binary + every selfhost
+  # compiler source the entry transitively compiles + the entry path.
+  {
+    hash_file "$STAGE1_COMPILER_WASM"
+    echo "$ENTRY_PATH"
+    find "$PROJECT_ROOT/vibe/compiler" -name '*.vibe' -type f 2>/dev/null \
+      | LC_ALL=C sort \
+      | while IFS= read -r f; do hash_file "$f"; done
+  } | {
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum
+    elif command -v shasum >/dev/null 2>&1; then shasum -a 256
+    else cksum
+    fi
+  } | cut -d' ' -f1
+}
+
+STAGE1_CACHE_HIT=0
+if [ "$STAGE1_CACHE_ENABLED" = "1" ]; then
+  STAGE1_FP="$(stage1_fingerprint)"
+  STAGE1_CACHE_FILE="$STAGE1_CACHE_DIR/stage1_${STAGE1_FP}.wasm"
+  if [ -s "$STAGE1_CACHE_FILE" ]; then
+    echo "[selfbuild] stage0 cache hit (fp=${STAGE1_FP:0:12}) — reusing cached stage1 wasm, skipping moonrun compile"
+    cp "$STAGE1_CACHE_FILE" "$STAGE1_WASM"
+    STAGE1_CACHE_HIT=1
+    if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+      printf -- "- stage0 (cache hit, skipped): 0s\n" >> "$GITHUB_STEP_SUMMARY" || true
+    fi
+  fi
+fi
+
+if [ "$STAGE1_CACHE_HIT" -eq 0 ]; then
+  run_stage "stage0 (wasm compiler via moonrun) -> stage1 wasm compile" \
+    moonrun "$STAGE1_COMPILER_WASM" --wasm-mvp "$ENTRY_PATH" -o "$STAGE1_WASM"
+  if [ "$STAGE1_CACHE_ENABLED" = "1" ] && [ -s "$STAGE1_WASM" ]; then
+    mkdir -p "$STAGE1_CACHE_DIR"
+    # Keep only the current fingerprint's artifact to bound cache growth.
+    rm -f "$STAGE1_CACHE_DIR"/stage1_*.wasm 2>/dev/null || true
+    cp "$STAGE1_WASM" "$STAGE1_CACHE_FILE"
+  fi
+fi
 
 recursive_stage2_ok=0
 RECURSIVE_STAGE2_LOG="$OUT_DIR/stage2_recursive_compile.log"


### PR DESCRIPTION
## 概要

#494（REAL gaps 13→0）の follow-up（#492）。MoonBit 実装ドロップに向けた **退行検知の自動化** と **selfbuild の高速化**。

## 1. corpus gate を CI shard 化（`d204cad`）

全コーパス selfhost compile gate（`scripts/test_selfhost_corpus_gate.sh --gate`）を既存 `selfhost-gates` matrix の `corpus` shard として追加。

- informational（`continue-on-error` / push-only）、native CLI + node + wasmtime セットアップを再利用
- Rust/wac install は cli/check 限定なので corpus shard はスキップ
- `--gate` は **REAL な言語/checker ギャップでのみ** 失敗（MODE/TRIAGE の harness artifact は無視）→ selfhost 表現力の退行を継続検知
- main で 102 files / REAL 0 / exit 0 を確認済み

## 2. selfbuild 高速化（`be8dc44`）— プロファイル + キャッシュ

### プロファイル結果
per-stage 計測で **stage0（moonrun で MoonBit-wasm compiler を実行し stage1 を生成）が ~21-27s で総時間の ~70%** を占める支配的ボトルネックと判明。本来の目的 true-recursive stage2 は ~5s。

| 同一 index.vibe→wasm | 時間 |
|---|---|
| moonrun + MoonBit-wasm compiler（stage0） | ~24s |
| native compiler | ~15.7s |
| node + selfhost-generated wasm（stage2） | ~5s |

moonrun は node/V8 の ~5x 遅く、wasi compiler wasm は moonrun 専用 ABI（0 imports / WASI `_start` なし）で runtime 差し替え不可。release ビルドでも差なし。→ **stage0 の再実行を避ける** のが正解。

### Rec 1: stage1 wasm の fingerprint キャッシュ
stage1.wasm = （wasm compiler バイナリ + `vibe/compiler/**/*.vibe` + entry）の純粋関数。sha256 fingerprint で一致時は cached stage1 を再利用し **stage0 をスキップ**。stage2（true-recursive）は cached artifact 上で実行継続、ソース変更時は fingerprint ミスで stage0 再実行。`VIBE_SELFHOST_SELFBUILD_STAGE1_CACHE=0` でオプトアウト。

**実測**: cold = stage0 実行（~21s）/ warm = 「stage0 cache hit … skipping moonrun compile」で stage2-only（~4s）。fingerprint がソース編集で変化・revert で復元することも確認。**warm run で ~30s 削減**。

### Rec 3: CI キャッシュ
- **wasi compiler wasm** を `selfhost-selfbuild-kpi` / `selfhost-bootstrap-gate`（6 matrix jobs）でキャッシュ。**exact-key のみ（restore-keys なし）**で stale wasm 再利用を防止、ミス時は ~13s 再ビルド
- **stage1_cache dir** をキャッシュ → vibe/compiler 無変更なら CI run 跨ぎで stage0 スキップ。内部 fingerprint が正確性を守るので restore-keys も安全

## 検証
- selfbuild cold/warm 両 run とも EXIT 0、fingerprint 正確性確認
- corpus gate main で REAL 0
- ci.yml YAML 妥当性確認、shard script syntax OK

詳細は #492 を参照。

https://claude.ai/code/session_01JwQs1Srbi7oW9xom12Yy8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwQs1Srbi7oW9xom12Yy8S)_