### PR TITLE
Perceus RC: fix while-loop per-iteration leak (A-1) + memory contract docs

### DIFF
--- a/docs/spec/memory-contract.md
+++ b/docs/spec/memory-contract.md
@@ -1,0 +1,119 @@
+# Memory management contract (linear / wasm-gc / Perceus RC)
+
+Status: draft (tracks issue #493). This document pins the *current*
+behavior and records the intended direction: **wasm-gc stays the primary
+target; when wasm-gc is not available, the linear backend uses Perceus
+RC as its first (default) reclamation strategy**, replacing the current
+"bump allocator, never free" default.
+
+## Backend contract table
+
+| | linear (today) | linear + Perceus RC | wasm-gc |
+|---|---|---|---|
+| default entry points | `compile --wasm`, `build --release`, `test`, `bench` | opt-in `enable_rc` (not CLI-exposed) | `compile --wasm-gc`, env opt-in for test/bench |
+| value representation | tagged `i64` (2-bit tag) | same tagged `i64` | typed refs (struct / array), unboxed scalars |
+| allocation | bump allocator | bump + head-only exact-fit free-list | engine heap |
+| reclamation | **none (leaks)** | Perceus dup/drop, free on `rc==0` | engine GC (tracing) |
+| object lifetime | n/a | deterministic, eager | non-deterministic, lazy |
+| cycles | n/a | **leak (RC limitation)** | collected |
+| known gaps | — | while-loop body drop, cycles, closure env drop (unverified), borrow inference scope | builtin parity (53 vs 169), coverage instrumentation, fixed-size arrays |
+| intended status | legacy / opt-out | **future linear default** | primary target |
+
+## Intended direction
+
+1. wasm-gc remains the main backend (ADR-0036) for engines that support
+   the GC proposal.
+2. For engines without wasm-gc, the linear backend should default to
+   Perceus RC instead of the leaky bump allocator. This makes
+   "no-reclamation bump" the explicit legacy / opt-out path.
+3. A backend-selection step decides wasm-gc vs linear+RC; this selection
+   logic does not exist yet (see gaps below).
+
+## What already works (Perceus RC)
+
+- Branch-sensitive dup/drop analysis, scope-end drops, reuse tokens
+  (`src/frontend/perceus_poc.mbt`).
+- Recursive field-drop for tuple / array / record / map / enum / view
+  types (`src/codegen/wasm_codegen_rc.mbt:411-589`). Strings and bytes
+  are leaf objects freed directly by the outer `rc_drop`.
+- Borrow optimization for field-access-only bindings.
+- Head-only exact-fit free-list reclamation.
+- Binary-size optimization (ADR-0038, 1.95x → 1.49x) and code isolation
+  (ADR-0049): RC code is confined to two files; the wasm-gc backend does
+  not depend on it.
+
+## Gaps to make Perceus RC the linear default
+
+### A. Correctness blockers
+
+- **A-1 while-loop / for-in body drops** — per-iteration `let` bindings
+  are not dropped. Pinned as a known leak
+  (`src/tests/vibe_wasm_eval_test.mbt:4228`). Top-priority blocker:
+  loops are a hot path and must not leak for RC to replace bump.
+- **A-2 closure environment drop** — `emit_rc_drop_fields` has no
+  closure-specific branch; captured heap in closure envs needs
+  wasmtime-level verification.
+- **A-3 borrow inference scope** — only `__index` is recognized as a
+  borrow; broaden to all borrowed parameters.
+- **A-4 cycles** — RC cannot reclaim cycles. Decide policy: accept and
+  document the leak, or add weak refs / a cycle collector. This is a
+  permanent semantic difference from wasm-gc.
+
+### B. Verification gaps
+
+- **B-1** `enable_rc` is exercised only by the in-tree wasm interpreter
+  (`src/tests/vibe_wasm_eval_test.mbt`); there is no wasmtime-backed RC
+  e2e gate. Default-ing RC requires real-engine validation of
+  free / free-list reuse.
+- **B-2** `rc_debug` counters are interpreter-only.
+- **B-3** No parity/gate test pins the RC default.
+- **B-4** No differential test asserting that no-RC / RC / wasm-gc
+  produce identical observable results — this is the concrete way to
+  verify "linear+RC semantics match wasm-gc".
+
+### C. Productization / wiring
+
+- **C-1** `enable_rc` is not CLI-exposed and defaults false.
+- **C-2** `build --release` / `test` / `bench` backend selection does not
+  consider RC.
+- **C-3** Free-list is head-only / exact-fit
+  (`src/codegen/wasm_codegen_rc.mbt:204-245`): no coalescing, no
+  segregated lists; fragmentation grows under long runs.
+- **C-4** Stale doc comment: `wasm_codegen_rc.mbt:52-55` still says
+  "free is a no-op (bump allocator)" although a free-list is
+  implemented.
+- **C-5** 8-byte RC header + dup/drop instruction overhead; benchmark
+  before defaulting.
+
+### D. Selfhost
+
+- The selfhost compiler (`vibe/compiler/`) has **no** Perceus/RC. Its
+  linear backend is a pure bump allocator that never frees. Making
+  Perceus the selfhost default requires porting ~4100 LOC
+  (`perceus_poc.mbt` + `wasm_codegen_rc.mbt`) to vibe, following
+  src-first → parity gate → selfhost per CLAUDE.md.
+
+### E. Semantics alignment with wasm-gc
+
+- Memory model differs fundamentally (eager RC vs lazy GC) but, absent
+  finalizers, observable program results can be made identical — verify
+  via B-4.
+- `Array::push` semantics already differ across backends (linear:
+  in-place growable; wasm-gc: fixed-size, rebinds local). Orthogonal to
+  RC but must be reconciled or documented before unifying defaults.
+- Value representations differ (tagged i64 vs typed refs); RC does not
+  change this, so RC alone aligns only lifetime observation, not
+  representation. Remaining alignment is builtin parity, gated by
+  `src/tests/codegen_parity_test.mbt`.
+
+### F. Backend auto-selection
+
+- There is no logic to detect "is wasm-gc available?" at build/run time
+  and fall back to linear+RC. Without it, "wasm-gc else Perceus" cannot
+  be automatic and RC stays manual opt-in.
+
+## Relationship to issue #493
+
+This advances #493 Direction C from option 2 (expose a flag) toward
+option 2.5 (make RC the linear default). The contract table above is the
+memory-management table requested by #493's acceptance criteria.

--- a/src/codegen/wasm_codegen_ctx.mbt
+++ b/src/codegen/wasm_codegen_ctx.mbt
@@ -162,6 +162,10 @@ priv struct CodegenCtx {
   mut rc_pre_actions : Map[String, Map[Int, Array[RcStmtAction]]]
   mut rc_post_actions : Map[String, Map[Int, Array[RcStmtAction]]]
   mut rc_action_prefix : String
+  // Perceus RC: site of the statement currently being compiled within the
+  // enclosing block (e.g. "stmt[2]" or "outer.stmt[1]"). Nested constructs
+  // (while/loop bodies) extend this to derive their own action prefix.
+  mut rc_stmt_site : String
   // Per-function RC actions: func_name → raw action tuples
   mut rc_func_actions : Map[String, Array[(String, Bool, String)]]
   // RC free-list head global index (-1 if not allocated)
@@ -356,6 +360,7 @@ fn CodegenCtx::new(
     rc_pre_actions: {},
     rc_post_actions: {},
     rc_action_prefix: "",
+    rc_stmt_site: "",
     rc_func_actions: {},
     rc_free_list_global: -1,
     rc_tmp_local: -1,

--- a/src/codegen/wasm_codegen_expr_loop.mbt
+++ b/src/codegen/wasm_codegen_expr_loop.mbt
@@ -44,9 +44,33 @@ fn compile_expr_while(
   emit_br(buf, 2) // br $exit
   buf.push((11).to_byte()) // end if
 
-  // Execute body
+  // Execute body. With Perceus RC enabled, the body is its own scope: any
+  // bindings allocated per iteration must be dropped before looping back, or
+  // the heap leaks one object per iteration (the historical known leak). We
+  // mirror compile_block_expr's per-statement pre/post action emission, using
+  // the body's nested action prefix so the analysis-emitted scope-end drops
+  // fire inside the loop. The while statement appears as `Stmt::Expr` in the
+  // enclosing block, so its Perceus site is `<rc_stmt_site>.expr` and the body
+  // prefix is `<rc_stmt_site>.expr.body`.
+  let saved_rc_prefix = ctx.rc_action_prefix
+  let saved_rc_stmt_site = ctx.rc_stmt_site
+  let body_prefix = "\{ctx.rc_stmt_site}.expr.body"
+  if ctx.enable_rc {
+    ctx.rc_action_prefix = body_prefix
+  }
   for i in 0..<body.stmts.length() {
+    if ctx.enable_rc {
+      ctx.rc_stmt_site = rc_make_stmt_site(body_prefix, i)
+      emit_rc_actions(ctx, buf, ctx.rc_pre_actions, i)
+    }
     compile_stmt(ctx, buf, body.stmts[i], false)
+    if ctx.enable_rc {
+      emit_rc_actions(ctx, buf, ctx.rc_post_actions, i)
+    }
+  }
+  if ctx.enable_rc {
+    ctx.rc_action_prefix = saved_rc_prefix
+    ctx.rc_stmt_site = saved_rc_stmt_site
   }
   // Reset heap_synced before looping back: the condition check at the
   // top of the loop may call functions that need a fresh heap sync.

--- a/src/codegen/wasm_codegen_rc.mbt
+++ b/src/codegen/wasm_codegen_rc.mbt
@@ -642,6 +642,19 @@ fn emit_rc_drop_i64(ctx : CodegenCtx, buf : ByteBuf, local_idx : Int) -> Unit {
 
 ///|
 /// Emit all RC actions for a given stmt index (pre or post).
+/// Build the Perceus site string for statement `idx` inside a block whose
+/// action prefix is `prefix`. The top-level block uses an empty prefix and
+/// the bare `stmt[i]` form (matching `build_perceus_plan`); nested blocks
+/// prepend their dotted prefix.
+fn rc_make_stmt_site(prefix : String, idx : Int) -> String {
+  if prefix.length() == 0 {
+    "stmt[\{idx}]"
+  } else {
+    "\{prefix}.stmt[\{idx}]"
+  }
+}
+
+///|
 fn emit_rc_actions(
   ctx : CodegenCtx,
   buf : ByteBuf,

--- a/src/codegen/wasm_codegen_stmt.mbt
+++ b/src/codegen/wasm_codegen_stmt.mbt
@@ -1264,6 +1264,7 @@ fn compile_block_expr(
   let saved_named_fn_scope = snapshot_named_fn_scope(ctx)
   let saved_mut_captured = ctx.mut_captured_vars.copy()
   let saved_prefix = ctx.rc_action_prefix
+  let saved_stmt_site = ctx.rc_stmt_site
   ctx.mut_captured_vars = scoped_mut_captured_for_block(
     saved_mut_captured,
     body.stmts,
@@ -1279,6 +1280,7 @@ fn compile_block_expr(
     for i in 0..<len {
       let is_last = i == len - 1
       if emit_rc_stmt_actions {
+        ctx.rc_stmt_site = rc_make_stmt_site(ctx.rc_action_prefix, i)
         emit_rc_actions(ctx, buf, ctx.rc_pre_actions, i)
       }
       compile_stmt(ctx, buf, body.stmts[i], is_last)
@@ -1288,6 +1290,7 @@ fn compile_block_expr(
     }
   }
   ctx.rc_action_prefix = saved_prefix
+  ctx.rc_stmt_site = saved_stmt_site
   ctx.mut_captured_vars = saved_mut_captured
   restore_locals(ctx, saved)
   restore_local_kinds(ctx, saved_kinds)

--- a/src/frontend/perceus_poc.mbt
+++ b/src/frontend/perceus_poc.mbt
@@ -1932,7 +1932,7 @@ fn p2_emit_expr(
     @core.Expr::While(cond~, body~, ..) => {
       let pre = p2_emit_snapshot(ctx)
       p2_emit_expr(ctx, cond, site + ".cond")
-      p2_emit_block(ctx, body, site + ".body")
+      p2_emit_block(ctx, body, site + ".body", scope_end_to_last=true)
       let loop_snap = p2_emit_snapshot(ctx)
       p2_emit_merge_branches(ctx, pre, [
         (loop_snap, site + ".body"),
@@ -2110,12 +2110,22 @@ fn p2_emit_block(
   ctx : PerceusEmitCtx2,
   body : @core.Module,
   prefix : String,
+  scope_end_to_last? : Bool = false,
 ) -> Unit {
   p2_emit_push_scope(ctx)
   for i = 0; i < body.stmts.length(); i = i + 1 {
     p2_emit_stmt(ctx, body.stmts[i], prefix + ".stmt[\{i.to_string()}]")
   }
-  p2_emit_pop_scope(ctx, prefix)
+  // For loop bodies, attach scope-end drops to the last statement so the
+  // codegen emits them *inside* the loop (per iteration) rather than once at
+  // the enclosing statement. Without this, a binding allocated each iteration
+  // leaks all but the final allocation (the historical while-loop leak).
+  let pop_site = if scope_end_to_last && body.stmts.length() > 0 {
+    prefix + ".stmt[\{(body.stmts.length() - 1).to_string()}]"
+  } else {
+    prefix
+  }
+  p2_emit_pop_scope(ctx, pop_site)
 }
 
 ///|

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -4225,9 +4225,12 @@ test "rc debug: function with local tuple balanced" {
 }
 
 ///|
-test "rc debug: loop detects unbalanced allocs (known leak)" {
-  // While-loop bodies don't yet generate per-iteration drops for let bindings.
-  // This test verifies the debug counters correctly detect the leak.
+test "rc debug: while-loop body drops per-iteration allocs (no leak)" {
+  // While-loop bodies now generate per-iteration drops for bindings that
+  // leave the body scope. The per-iteration tuple is reclaimed each turn, so
+  // allocs and frees stay balanced. (Previously this leaked all but the final
+  // allocation; see the codegen wiring in compile_expr_while and the
+  // scope_end_to_last handling in perceus_poc.mbt::p2_emit_block.)
   let script =
     #|let f = () -> Int {
     #|  let mut i = 0
@@ -4248,8 +4251,36 @@ test "rc debug: loop detects unbalanced allocs (known leak)" {
   let (allocs, frees) = rc_debug_counts(res)
   // Alloc counter should track all 5 tuple allocations
   assert_true(allocs >= 5L)
-  // Free counter tracks actual frees — currently fewer than allocs (known leak)
-  assert_true(frees < allocs)
+  // Every per-iteration tuple is dropped — no leak.
+  assert_eq(allocs, frees)
+}
+
+///|
+test "rc debug: while-loop body drops nested heap per-iteration (no leak)" {
+  // A per-iteration binding whose value is a nested heap object (tuple of
+  // tuples) must be recursively dropped at the end of each iteration. Verifies
+  // that the loop-body scope-end drop reaches inner heap allocations too.
+  let script =
+    #|let f = () -> Int {
+    #|  let mut i = 0
+    #|  let mut sum = 0
+    #|  while i < 4 {
+    #|    let t = ((i, i + 1), (i + 2, i + 3))
+    #|    sum = sum + t.0.0 + t.1.1
+    #|    i = i + 1
+    #|  }
+    #|  sum
+    #|}
+    #|f()
+  let res = try eval_run_rc_debug(script) catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    r => r
+  }
+  let (allocs, frees) = rc_debug_counts(res)
+  // Each iteration allocates the outer tuple plus two inner tuples.
+  assert_true(allocs >= 12L)
+  assert_eq(allocs, frees)
 }
 
 ///|


### PR DESCRIPTION
## Summary

issue #493 の方向性整理(wasm-gc をメイン target に据えつつ、**wasm-gc が使えない環境では linear backend の reclamation を Perceus RC に切り替えて first にする**)に向けた最初の一歩。

1. **memory contract のドキュメント化** — `docs/spec/memory-contract.md` を新規追加。linear / linear+RC / wasm-gc の contract table と、Perceus RC を linear default にするための gap 一覧(A〜F)を記載。
2. **A-1: while-loop の per-iteration leak 修正** — 既知のリーク(`vibe_wasm_eval_test.mbt` に pin 済み)を解消。

詳しい gap 洗い出しは issue にもコメント済み: #493 (comment)

## 根本原因 (A-1)

while-loop body は RC stmt-action の配線を bypass していた:
- `compile_expr_while` が body 文を生 `compile_stmt` ループでコンパイルし、nested の action prefix を設定していなかった
- そのため Perceus が出した scope-end drop が**外側の statement に誤マップ**し、毎反復ではなくループ後に1回だけ free → ループ内で確保した binding は最後の1個を除き全部リーク

## 修正内容

- **`CodegenCtx.rc_stmt_site`** を追加。nested 構文が自身の action prefix を導出できるよう、現在コンパイル中の statement site を thread する(`compile_block_expr` で設定)。
- **`compile_expr_while`**: body に対して `compile_block_expr` と同様の per-statement pre/post RC action emission を行う。prefix は `<rc_stmt_site>.expr.body`。これで per-iteration drop がループ内で実行される。
- **Perceus `p2_emit_block`**: `scope_end_to_last` フラグを追加し、loop body の scope-end drop を最終 statement に紐付ける。これで `parse_site_path` が drop を body prefix 内に正しく key 化する。While body 用に `scope_end_to_last=true` を渡す。
- **テスト**: known-leak テストを「balanced(リークなし)」期待へ反転 + ネスト heap(tuple of tuples)を毎反復で再帰 drop するテストを追加。

## 検証

`moon check --deny-warn` 通過。テスト結果:

| suite | result |
|---|---|
| rc tests (`-f "rc *"`) | 43/43 |
| `vibe_wasm_eval_test.mbt` 全体 | 156/156 |
| perceus (`frontend`) | 32/32 |
| enable_rc whitebox (`runtime_compile`) | 10/10 |
| codegen package | 87/87 |

## スコープ外 / follow-up

- **for-in** は codegen 側で while に desugar されるため Perceus の site が一致せず、同じ修正は効かない(別 follow-up)。
- **if/else 分岐**内の RC action も未配線。
- 次の候補: B-1(wasmtime ベースの RC e2e gate)、for-in 対応、backend 自動選択(F)。

https://claude.ai/code/session_014bEGeBN27H1nKZe1qL2u6E

---
_Generated by [Claude Code](https://claude.ai/code/session_014bEGeBN27H1nKZe1qL2u6E)_