### PR TITLE
Perceus RC: nested-block reclamation + wasmtime e2e gate + selfhost analysis port

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -148,6 +148,13 @@ local testWasmGcMainlaneE2e = new Task {
   inputs { ...moonSources }
 }
 
+local testWasmRcE2e = new Task {
+  name = "test-wasm-rc-e2e"
+  cmd =
+    "VIBE_WASM_RC_E2E=1 moon test --target native src/tests/vibe_wasm_rc_e2e_test.mbt --warn-list '\(moonWarnList)'"
+  inputs { ...moonSources }
+}
+
 local testWasmGcValidate = scriptTask("test-wasm-gc-validate", "scripts/test_wasm_gc_validate.sh")
 local testVibePackageSuite =
   scriptTask("test-vibe-package-suite", "scripts/pkfire/test_vibe_package_suite.sh")
@@ -1277,6 +1284,7 @@ tasks {
   test
   testLocal
   testWasmGcMainlaneE2e
+  testWasmRcE2e
   testWasmGcValidate
   testVibePackageSuite
   testWasmHeavy

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -809,6 +809,15 @@ local testSelfhostCacheProbe = new Task {
   inputs { ...moonSources; ...scriptSources }
 }
 
+// Phase 2 of the selfhost Perceus RC port (docs/spec/selfhost-rc-port.md):
+// unit-test the ported analysis pass in isolation via the native vibe CLI.
+local testSelfhostPerceus = new Task {
+  name = "test-selfhost-perceus"
+  cmd =
+    "source scripts/ensure_native_cli.sh && _build/native/debug/build/cmd/vibe/vibe.exe test vibe/compiler/perceus_rc_test.vibe"
+  inputs { ...moonSources; ...scriptSources }
+}
+
 local testSelfhostWasiSelfbuild =
   scriptTask("test-selfhost-wasi-selfbuild", "scripts/test_selfhost_wasi_selfbuild.sh")
 
@@ -1401,6 +1410,7 @@ tasks {
   testHttpCompiledPolicy
   testSelfhostBootstrap
   testSelfhostCacheProbe
+  testSelfhostPerceus
   testSelfhostWasiSelfbuild
   testSelfhostWasiSelfbuildKpi
   testSelfhostCliAdapter

--- a/docs/spec/memory-contract.md
+++ b/docs/spec/memory-contract.md
@@ -59,9 +59,16 @@ RC as its first (default) reclamation strategy**, replacing the current
   expression results (e.g. a `for-in`'s ArrayBuilder and its frozen result
   array when the loop is used as a statement). Constant w.r.t. iteration
   count, but a real remaining leak.
-- **A-2 closure environment drop** — `emit_rc_drop_fields` has no
-  closure-specific branch; captured heap in closure envs needs
-  wasmtime-level verification.
+- **A-2 closure environment drop** — *done*. Closures that capture heap
+  leaked their env block and the captured values. Two fixes: (1) Perceus
+  treats a call as a *borrow* of the callee binding, so a closure stays
+  live across calls and is dropped at scope end (top-level fn names /
+  builtins resolve to no local binding, so this is a no-op for them);
+  (2) `rc_has_closure` is now derived from the authoritative funcs list
+  (any capturing closure) rather than a scan that used a mismatched span
+  key for parameterized closures, so the RC drop helper actually emits its
+  `obj_fn` capture-recursion branch. Verified balanced on the interpreter
+  and correct on wasmtime (`rc e2e: closure capturing heap value`).
 - **A-3 borrow inference scope** — only `__index` is recognized as a
   borrow; broaden to all borrowed parameters.
 - **A-4 cycles** — RC cannot reclaim cycles. Decide policy: accept and

--- a/docs/spec/memory-contract.md
+++ b/docs/spec/memory-contract.md
@@ -70,10 +70,17 @@ RC as its first (default) reclamation strategy**, replacing the current
 
 ### B. Verification gaps
 
-- **B-1** `enable_rc` is exercised only by the in-tree wasm interpreter
-  (`src/tests/vibe_wasm_eval_test.mbt`); there is no wasmtime-backed RC
-  e2e gate. Default-ing RC requires real-engine validation of
-  free / free-list reuse.
+- **B-1** *done*. A wasmtime-backed RC e2e gate now exists
+  (`src/tests/vibe_wasm_rc_e2e_test.mbt`, run via the `test-wasm-rc-e2e`
+  task on `--target native`). It compiles representative programs with
+  `enable_rc=true` and runs them on wasmtime, asserting correct results
+  (incl. a 1000-iteration loop-stress checksum that would corrupt under a
+  reuse-while-live bug). This immediately surfaced — and drove the fix
+  for — an invalid `block`/`br_if` ordering in the rc_dup/rc_drop emitters:
+  the tag-check condition was pushed *outside* the enclosing block, which
+  the lenient in-tree interpreter accepted but wasmtime rejects ("expected
+  i32 but nothing on stack"). RC had never produced spec-valid wasm before
+  this gate.
 - **B-2** `rc_debug` counters are interpreter-only.
 - **B-3** No parity/gate test pins the RC default.
 - **B-4** No differential test asserting that no-RC / RC / wasm-gc

--- a/docs/spec/memory-contract.md
+++ b/docs/spec/memory-contract.md
@@ -16,7 +16,7 @@ RC as its first (default) reclamation strategy**, replacing the current
 | reclamation | **none (leaks)** | Perceus dup/drop, free on `rc==0` | engine GC (tracing) |
 | object lifetime | n/a | deterministic, eager | non-deterministic, lazy |
 | cycles | n/a | **leak (RC limitation)** | collected |
-| known gaps | — | while-loop body drop, cycles, closure env drop (unverified), borrow inference scope | builtin parity (53 vs 169), coverage instrumentation, fixed-size arrays |
+| known gaps | — | temporary/discarded-value drops, cycles, closure env drop (unverified), borrow inference scope, no wasmtime e2e gate | builtin parity (53 vs 169), coverage instrumentation, fixed-size arrays |
 | intended status | legacy / opt-out | **future linear default** | primary target |
 
 ## Intended direction
@@ -46,10 +46,19 @@ RC as its first (default) reclamation strategy**, replacing the current
 
 ### A. Correctness blockers
 
-- **A-1 while-loop / for-in body drops** — per-iteration `let` bindings
-  are not dropped. Pinned as a known leak
-  (`src/tests/vibe_wasm_eval_test.mbt:4228`). Top-priority blocker:
-  loops are a hot path and must not leak for RC to replace bump.
+- **A-1 nested-block body drops** — *done*. Bindings that leave the scope
+  of a nested block were not dropped, leaking per loop iteration / branch.
+  Now wired for `while`, `for-in` (desugared before Perceus), `if`/`else`
+  arms, `match` arms, and bare block expressions. The codegen threads the
+  current statement site (`CodegenCtx.rc_stmt_site`) so each nested construct
+  derives its Perceus action prefix, and `p2_emit_block` keys loop/branch
+  scope-end drops to the last body statement. Regression tests assert
+  per-iteration / per-branch balance via the `rc_debug` counters.
+- **A-1b temporary / discarded-value drops** — *open*. Heap that is never
+  bound to a name still leaks: builtin intermediates and discarded
+  expression results (e.g. a `for-in`'s ArrayBuilder and its frozen result
+  array when the loop is used as a statement). Constant w.r.t. iteration
+  count, but a real remaining leak.
 - **A-2 closure environment drop** — `emit_rc_drop_fields` has no
   closure-specific branch; captured heap in closure envs needs
   wasmtime-level verification.

--- a/docs/spec/selfhost-rc-port.md
+++ b/docs/spec/selfhost-rc-port.md
@@ -79,17 +79,25 @@ is added.
   uses of the outer binding; the body is analysed separately as its own
   function). `EForIn` binds its element per iteration (structural scope-end
   drop). `EMatch` does branch-max counting across arms and drops arm-local
-  pattern bindings per arm.
+  pattern bindings per arm. `ELoop` treats its parameters as body-scoped
+  bindings. `ESeq` binds the discarded left value to a synthetic name so an
+  owned heap temporary is reclaimed at scope end (A-1b).
+- A binding with no owning uses (pure-borrow *or* entirely unused) keeps its
+  one owned reference and is dropped at scope end; the scalar check skips
+  known non-heap values.
 - Unit-tested in isolation via the native vibe CLI
-  (`vibe/compiler/perceus_rc_test.vibe`, task `test-selfhost-perceus`, 11/11):
+  (`vibe/compiler/perceus_rc_test.vibe`, task `test-selfhost-perceus`, 14/14):
   pure-borrow drop, moved-out (no drop), scalar (no drop), dup on double use,
   closure-call borrow + drop, nested borrow, branch-local drop, while-body
   per-iteration drop, for-in element drop, closure capture as owning use,
-  match arm pattern-binding drop.
-- **Remaining in Phase 2** (safe no-ops today — never emit a wrong drop):
-  `EHandle` / `ELoop`, cross-branch balancing of outer bindings consumed
-  unevenly across `EIf` / `EMatch` arms, and the discarded-statement-expr
-  reclamation (A-1b) which maps to `ESeq` here.
+  match arm pattern-binding drop, discarded sequenced heap value drop (A-1b),
+  discarded scalar (no drop), loop-parameter drop.
+- **Remaining in Phase 2**: `EHandle` (effect handlers) and cross-branch
+  balancing of outer bindings consumed unevenly across `EIf` / `EMatch` arms.
+  Cross-branch balancing needs each balancing drop placed in a specific branch,
+  which requires the action to carry placement (a site) — deferred to Phase 3,
+  where the codegen wiring assigns sites (as the `src/` backend already does).
+  Until then these are safe no-ops (never a wrong drop).
 
 ### Phase 3 — port the RC codegen
 

--- a/docs/spec/selfhost-rc-port.md
+++ b/docs/spec/selfhost-rc-port.md
@@ -1,0 +1,99 @@
+# Selfhost Perceus RC port — design & staged plan
+
+Status: planning (issue #493 direction C / item **D**). Tracks porting the
+Perceus reference-counting memory management from the authoritative MoonBit
+`src/` implementation into the vibe-written selfhost compiler
+(`vibe/compiler/`). `src/` stays authoritative; selfhost follows via the
+parity gates (per CLAUDE.md).
+
+## Why this is not a straight code port
+
+The `src/` linear backend and the selfhost linear backend use **different
+heap object layouts**, and RC's correctness depends on the `src/` layout.
+
+### `src/` linear layout (RC-ready)
+
+Every heap object carries a header, and RC prepends a refcount:
+
+```
+[alloc_size@-8][rc_count@-4][type_id@0][length@4][payload@8...]
+```
+
+`type_id` (tuple=3, array=5, record=4, map=6, enum=10, closure=7, view=11/12/14,
+string=1, bytes=13) lets the RC drop helper dispatch and **recursively drop the
+right fields**; `length` bounds the field loop. This is what
+`emit_rc_drop_fields` / `compile_rc_drop_function` rely on.
+
+### selfhost linear layout (no headers)
+
+The selfhost backend is a pure bump allocator with **no type-id / length
+headers**:
+
+- tuple: bare sequential `i64` slots (no header)
+- closure (`obj_fn`-equivalent): `[table_slot@0][num_captures@4][captures@8...]`
+- constructor: `[tag@0][pad@4][values...]`
+- string: `(offset << 32) | length` fat pointer (no heap header)
+- objects are tagged only by OR-ing the low bit; there is **no way at runtime
+  to tell a tuple from a record from an enum**, nor how many fields it has.
+
+Without a type-id + length header there is no way for a generic `drop` to know
+how to recurse, so the RC drop helper cannot be ported as-is.
+
+## Consequence: the prerequisite is a layout change
+
+The first real domino is **adding a uniform object header to every selfhost
+linear allocation** and updating every field-access offset accordingly. This
+is large and touches every allocation/access site, so it must land behind a
+flag and be proven output-equivalent by the parity gates before any RC code
+is added.
+
+## Staged plan
+
+### Phase 1 — uniform object header (prerequisite, no RC yet)
+
+- Introduce the `src/`-compatible header `[type_id@0][length@4][payload@8...]`
+  for tuple / array / record / enum / closure allocations in the selfhost
+  linear backend (`codegen/expr/compile_expr_tail2.vibe`, `compile_lambda.vibe`,
+  `compile_expr.vibe` ctor path, etc.).
+- Shift every field read/write by the header size; keep string/bytes fat
+  pointers as today (leaf objects).
+- No refcount field yet, no behavior change: the parity gates
+  (`scripts/test_selfhost_*`) must show identical compiled output / runtime
+  results. This phase is purely structural.
+- Risk: high (every offset moves). Mitigation: land incrementally per object
+  kind, each guarded by the parity gate.
+
+### Phase 2 — port the Perceus analysis pass
+
+- Port `src/frontend/perceus_poc.mbt::build_perceus_plan` to vibe against the
+  selfhost AST (`expr_tag` / `get_e*` accessors). It is pure
+  (AST → action list), independent of codegen, so it can be unit-tested in
+  isolation against expected action lists before any codegen wiring.
+- Mirror the analysis fixes already made in `src/`: loop/branch/match
+  scope-end drops keyed to the last body statement, call-callee treated as a
+  borrow, discarded statement-expr binding.
+
+### Phase 3 — port the RC codegen
+
+- Port `src/codegen/wasm_codegen_rc.mbt`: refcount header (`[rc@-4]` in front of
+  the Phase 1 header), `rc_dup` / `rc_drop` helpers (with the corrected
+  `block`-before-condition ordering found in B-1), recursive field drop keyed
+  by `type_id`, head-only free-list, and per-statement action injection in the
+  selfhost statement/expression compilers.
+- Gate behind a selfhost `enable_rc` flag, default off.
+
+### Phase 4 — verification & cutover
+
+- Add a wasmtime e2e gate for the selfhost RC backend, mirroring
+  `src/tests/vibe_wasm_rc_e2e_test.mbt` (the `test-wasm-rc-e2e` task).
+- Run the selfhost parity / cutover gates with RC on.
+- Only then consider making RC the selfhost linear default, in lockstep with
+  the `src/` default decision (issue #493 C/F).
+
+## Sequencing note
+
+Phases 2 and 3 can reuse the now-validated `src/` design directly (including
+the B-1 wasm-validity fix and the A-1/A-1b/A-2 analysis fixes). Phase 1 is the
+unavoidable, selfhost-specific prerequisite and is where most of the risk and
+effort sits. Until Phase 1 lands, the analysis pass (Phase 2) is the only part
+that can be built and tested without destabilizing the selfhost backend.

--- a/docs/spec/selfhost-rc-port.md
+++ b/docs/spec/selfhost-rc-port.md
@@ -75,16 +75,21 @@ is added.
 - Mirrors the validated `src/` semantics: call callee and field access
   (`EDot`, array `__index` arg0) are borrows; pure-borrow / unused non-scalar
   bindings get a scope-end drop; multiply-used owning references dup.
+- `EFn` captures are accounted (free vars via `collect_free_vars` are owning
+  uses of the outer binding; the body is analysed separately as its own
+  function). `EForIn` binds its element per iteration (structural scope-end
+  drop). `EMatch` does branch-max counting across arms and drops arm-local
+  pattern bindings per arm.
 - Unit-tested in isolation via the native vibe CLI
-  (`vibe/compiler/perceus_rc_test.vibe`, task `test-selfhost-perceus`, 8/8):
+  (`vibe/compiler/perceus_rc_test.vibe`, task `test-selfhost-perceus`, 11/11):
   pure-borrow drop, moved-out (no drop), scalar (no drop), dup on double use,
   closure-call borrow + drop, nested borrow, branch-local drop, while-body
-  per-iteration drop.
+  per-iteration drop, for-in element drop, closure capture as owning use,
+  match arm pattern-binding drop.
 - **Remaining in Phase 2** (safe no-ops today — never emit a wrong drop):
-  `EFn` capture accounting, `EMatch` / `EHandle` / `ELoop` / `EForIn`, and
-  cross-branch balancing of outer bindings consumed unevenly across `EIf`
-  arms. The discarded-statement-expr handling (A-1b) maps to `ESeq`/`ELet`
-  here and will be added with those.
+  `EHandle` / `ELoop`, cross-branch balancing of outer bindings consumed
+  unevenly across `EIf` / `EMatch` arms, and the discarded-statement-expr
+  reclamation (A-1b) which maps to `ESeq` here.
 
 ### Phase 3 — port the RC codegen
 

--- a/docs/spec/selfhost-rc-port.md
+++ b/docs/spec/selfhost-rc-port.md
@@ -63,15 +63,28 @@ is added.
 - Risk: high (every offset moves). Mitigation: land incrementally per object
   kind, each guarded by the parity gate.
 
-### Phase 2 — port the Perceus analysis pass
+### Phase 2 — port the Perceus analysis pass — *in progress*
 
-- Port `src/frontend/perceus_poc.mbt::build_perceus_plan` to vibe against the
-  selfhost AST (`expr_tag` / `get_e*` accessors). It is pure
-  (AST → action list), independent of codegen, so it can be unit-tested in
-  isolation against expected action lists before any codegen wiring.
-- Mirror the analysis fixes already made in `src/`: loop/branch/match
-  scope-end drops keyed to the last body statement, call-callee treated as a
-  borrow, discarded statement-expr binding.
+- Ported the analysis to `vibe/compiler/perceus/index.vibe`
+  (`build_perceus_plan : (Expr) -> Array[PerceusAction]`), pattern-matching the
+  selfhost `Expr` enum directly. Because the selfhost AST is
+  expression-oriented, scope is structural: an `ELet(x, val, body)` scopes `x`
+  to `body`, so per-iteration / per-branch bindings fall out of the tree shape
+  (no statement-index bookkeeping). Two passes (`pc_count` then `pc_emit`)
+  share binding ids assigned in tree order.
+- Mirrors the validated `src/` semantics: call callee and field access
+  (`EDot`, array `__index` arg0) are borrows; pure-borrow / unused non-scalar
+  bindings get a scope-end drop; multiply-used owning references dup.
+- Unit-tested in isolation via the native vibe CLI
+  (`vibe/compiler/perceus_rc_test.vibe`, task `test-selfhost-perceus`, 8/8):
+  pure-borrow drop, moved-out (no drop), scalar (no drop), dup on double use,
+  closure-call borrow + drop, nested borrow, branch-local drop, while-body
+  per-iteration drop.
+- **Remaining in Phase 2** (safe no-ops today — never emit a wrong drop):
+  `EFn` capture accounting, `EMatch` / `EHandle` / `ELoop` / `EForIn`, and
+  cross-branch balancing of outer bindings consumed unevenly across `EIf`
+  arms. The discarded-statement-expr handling (A-1b) maps to `ESeq`/`ELet`
+  here and will be added with those.
 
 ### Phase 3 — port the RC codegen
 

--- a/docs/spec/selfhost-rc-port.md
+++ b/docs/spec/selfhost-rc-port.md
@@ -63,7 +63,7 @@ is added.
 - Risk: high (every offset moves). Mitigation: land incrementally per object
   kind, each guarded by the parity gate.
 
-### Phase 2 — port the Perceus analysis pass — *in progress*
+### Phase 2 — port the Perceus analysis pass — *complete (bar branch balancing)*
 
 - Ported the analysis to `vibe/compiler/perceus/index.vibe`
   (`build_perceus_plan : (Expr) -> Array[PerceusAction]`), pattern-matching the
@@ -91,13 +91,18 @@ is added.
   closure-call borrow + drop, nested borrow, branch-local drop, while-body
   per-iteration drop, for-in element drop, closure capture as owning use,
   match arm pattern-binding drop, discarded sequenced heap value drop (A-1b),
-  discarded scalar (no drop), loop-parameter drop.
-- **Remaining in Phase 2**: `EHandle` (effect handlers) and cross-branch
-  balancing of outer bindings consumed unevenly across `EIf` / `EMatch` arms.
-  Cross-branch balancing needs each balancing drop placed in a specific branch,
-  which requires the action to carry placement (a site) — deferred to Phase 3,
-  where the codegen wiring assigns sites (as the `src/` backend already does).
-  Until then these are safe no-ops (never a wrong drop).
+  discarded scalar (no drop), loop-parameter drop, handle arm pattern-binding
+  drop.
+- `EHandle` is covered: the handled body is branch 0 and each handler arm is a
+  further branch (branch-max counting + arm-local pattern bindings) — a
+  conservative, safe approximation of effect control flow.
+- **Remaining in Phase 2**: only cross-branch *balancing* of outer bindings
+  consumed unevenly across `EIf` / `EMatch` / `EHandle` arms. Each balancing
+  drop must be placed in a specific branch, which requires the action to carry
+  placement (a site) — deferred to Phase 3, where the codegen wiring assigns
+  sites (as the `src/` backend already does). Until then this is a safe no-op
+  (never a wrong drop; at worst an outer binding consumed in only one arm is
+  reclaimed slightly late or left to its enclosing scope's drop).
 
 ### Phase 3 — port the RC codegen
 

--- a/src/codegen/wasm_codegen_control.mbt
+++ b/src/codegen/wasm_codegen_control.mbt
@@ -892,6 +892,13 @@ fn compile_guarded_arm_with_bindings(
     }
     ctx.local_kinds[name] = binding_kind
   }
+  // With RC enabled, the arm body sits at `<match_stmt_site>.expr.arm[index]`
+  // in Perceus. Point rc_stmt_site there while compiling the body so a nested
+  // block/while/if inside the arm derives the matching action prefix. The
+  // value is restored before the fall-through recursion so subsequent arms
+  // are not nested under this arm's site.
+  let saved_rc_site = ctx.rc_stmt_site
+  let arm_rc_site = "\{saved_rc_site}.expr.arm[\{index}]"
   match arm.cond {
     Some(c) => {
       compile_expr(ctx, buf, c)
@@ -903,7 +910,11 @@ fn compile_guarded_arm_with_bindings(
       buf.push((126).to_byte())
       adjust_loop_offsets(ctx, 1)
       emit_coverage(ctx, buf, WasmCoveragePointKind::BranchMatchArm, arm.span)
+      if ctx.enable_rc {
+        ctx.rc_stmt_site = arm_rc_site
+      }
       compile_expr(ctx, buf, arm.expr)
+      ctx.rc_stmt_site = saved_rc_site
       ctx.heap_synced = guard_heap_synced
       buf.push((5).to_byte())
       restore_locals(ctx, saved)
@@ -919,7 +930,11 @@ fn compile_guarded_arm_with_bindings(
     }
     None => {
       emit_coverage(ctx, buf, WasmCoveragePointKind::BranchMatchArm, arm.span)
+      if ctx.enable_rc {
+        ctx.rc_stmt_site = arm_rc_site
+      }
       compile_expr(ctx, buf, arm.expr)
+      ctx.rc_stmt_site = saved_rc_site
       restore_locals(ctx, saved)
       restore_local_kinds(ctx, saved_kinds)
       restore_named_fn_scope(ctx, saved_named_fn_scope)

--- a/src/codegen/wasm_codegen_expr.mbt
+++ b/src/codegen/wasm_codegen_expr.mbt
@@ -106,7 +106,22 @@ fn compile_expr(
     @core.Expr::Block(body~, span~) => {
       let _ = span
       ctx.is_tail_position = saved_tail // propagate to last expression
-      compile_block_expr(ctx, buf, body)
+      // With RC enabled, wire the nested block's statements into the action
+      // map so drops fire inside it (e.g. the while loop a for-in desugars
+      // to). A statement's expression sits at `<stmt_site>.expr` for both
+      // `let` RHS and bare expression statements, so the block body prefix is
+      // `<rc_stmt_site>.expr.body`, matching Perceus's `p2_emit_block` site.
+      if ctx.enable_rc {
+        compile_block_expr(
+          ctx,
+          buf,
+          body,
+          emit_rc_stmt_actions=true,
+          rc_prefix="\{ctx.rc_stmt_site}.expr.body",
+        )
+      } else {
+        compile_block_expr(ctx, buf, body)
+      }
     }
     @core.Expr::Match(scrutinee~, arms~, span~) => {
       let _ = span

--- a/src/codegen/wasm_codegen_expr_binding.mbt
+++ b/src/codegen/wasm_codegen_expr_binding.mbt
@@ -261,13 +261,39 @@ fn compile_expr_if(
   adjust_loop_offsets(ctx, 1)
   let saved_heap_synced = ctx.heap_synced
   emit_coverage(ctx, buf, WasmCoveragePointKind::BranchIfThen, span)
-  compile_block_expr(ctx, buf, then_body)
+  // With RC enabled, wire each branch's statements into the action map so
+  // branch-local bindings are dropped at the end of the branch (and only when
+  // that branch runs). The branch bodies sit at `<stmt_site>.expr.then` /
+  // `.else` in Perceus, matching `p2_emit_block`'s site for the If arms.
+  let rc_then_prefix = "\{ctx.rc_stmt_site}.expr.then"
+  let rc_else_prefix = "\{ctx.rc_stmt_site}.expr.else"
+  if ctx.enable_rc {
+    compile_block_expr(
+      ctx,
+      buf,
+      then_body,
+      emit_rc_stmt_actions=true,
+      rc_prefix=rc_then_prefix,
+    )
+  } else {
+    compile_block_expr(ctx, buf, then_body)
+  }
   // Restore heap_synced for the else branch so it doesn't inherit
   // the then-branch's sync state (they are mutually exclusive at runtime).
   ctx.heap_synced = saved_heap_synced
   buf.push((5).to_byte()) // else
   emit_coverage(ctx, buf, WasmCoveragePointKind::BranchIfElse, span)
-  compile_block_expr(ctx, buf, else_body)
+  if ctx.enable_rc {
+    compile_block_expr(
+      ctx,
+      buf,
+      else_body,
+      emit_rc_stmt_actions=true,
+      rc_prefix=rc_else_prefix,
+    )
+  } else {
+    compile_block_expr(ctx, buf, else_body)
+  }
   // After both branches, mark heap as unsynced since either branch
   // may have advanced the heap pointer.
   ctx.heap_synced = false

--- a/src/codegen/wasm_codegen_module.mbt
+++ b/src/codegen/wasm_codegen_module.mbt
@@ -3572,6 +3572,14 @@ fn emit_module_with_coverage(
     let f = funcs[i]
     ctx.fn_closure_indices[f.span_key] = i
     ctx.fn_closure_captures[f.span_key] = f.captures
+    // Any capturing closure means heap `obj_fn` env blocks exist, so the RC
+    // drop helper must emit its capture-recursion branch. Deriving this here
+    // (from the authoritative funcs list) avoids relying on the scan matching
+    // the closure's span key, which uses a different key form for closures
+    // that carry parameters.
+    if f.captures.length() > 0 {
+      ctx.rc_has_closure = true
+    }
     match f.name {
       Some(name) => ctx.fn_indices[name] = i
       None => ()

--- a/src/codegen/wasm_codegen_rc.mbt
+++ b/src/codegen/wasm_codegen_rc.mbt
@@ -297,14 +297,16 @@ fn emit_rc_bump_alloc(
 ///   i32.store offset=0   ; rc_count += 1
 ///   $skip:
 fn emit_rc_dup(buf : ByteBuf, val_local : Int, tmp_local : Int) -> Unit {
+  // if (not heap object) → skip. The `block` must open BEFORE the condition
+  // so the `br_if` operand is produced inside the block frame (wasmtime
+  // rejects a br_if whose condition was pushed outside the enclosing block).
+  emit_block(buf) // block void ($skip)
   // Check if value is a heap object (tag == tag_obj == 1)
   emit_local_get(buf, val_local)
   emit_i32_const_raw(buf, tag_mask)
   emit_i32_and(buf)
   emit_i32_const_raw(buf, tag_obj)
   emit_i32_ne(buf)
-  // if (not heap object) → skip
-  emit_block(buf) // block void
   emit_br_if(buf, 0) // br_if 0 → skip to end of block
   // obj_ptr = val & ~tag_mask (clear low 2 bits)
   emit_local_get(buf, val_local)
@@ -340,14 +342,15 @@ fn emit_rc_drop(
   new_rc_local : Int,
   recursive? : Bool = true,
 ) -> Unit {
+  // if (not heap object) → skip. The `block` must open BEFORE the condition
+  // so the `br_if` operand is produced inside the block frame.
+  emit_block(buf)
   // Check if value is a heap object
   emit_local_get(buf, val_local)
   emit_i32_const_raw(buf, tag_mask)
   emit_i32_and(buf)
   emit_i32_const_raw(buf, tag_obj)
   emit_i32_ne(buf)
-  // if (not heap object) → skip
-  emit_block(buf)
   emit_br_if(buf, 0)
   // obj_ptr = val & ~tag_mask
   emit_local_get(buf, val_local)
@@ -820,13 +823,15 @@ fn compile_rc_dup_function(heap_start? : Int = 0) -> WasmFunc {
   // Tag check in i64 space eliminates val32 local.
   let param = 0
   let rc_ptr = 1
-  // if (param & 3L) != 1L → skip (tag check in i64 space)
+  // if (param & 3L) != 1L → skip (tag check in i64 space). The `block` opens
+  // before the condition so the `br_if` operand stays inside the block frame
+  // (wasmtime rejects a condition pushed outside the enclosing block).
+  emit_block(body)
   emit_local_get(body, param)
   emit_i64_const_raw(body, tag_mask.to_int64())
   emit_i64_and(body)
   emit_i64_const_raw(body, tag_obj.to_int64())
   emit_i64_ne(body)
-  emit_block(body)
   emit_br_if(body, 0)
   // obj_ptr = i32.wrap(param) & ~3
   emit_local_get(body, param)
@@ -889,13 +894,15 @@ fn compile_rc_drop_function(
   let type_id = 3
   let len = 4
   let idx = 5
-  // if (param & 3L) != 1L → skip (tag check in i64 space)
+  // if (param & 3L) != 1L → skip (tag check in i64 space). The `block` opens
+  // before the condition so the `br_if` operand stays inside the block frame
+  // (wasmtime rejects a condition pushed outside the enclosing block).
+  emit_block(body)
   emit_local_get(body, param)
   emit_i64_const_raw(body, tag_mask.to_int64())
   emit_i64_and(body)
   emit_i64_const_raw(body, tag_obj.to_int64())
   emit_i64_ne(body)
-  emit_block(body)
   emit_br_if(body, 0)
   // obj_ptr = i32.wrap(param) & ~3
   emit_local_get(body, param)

--- a/src/frontend/desugar_discard.mbt
+++ b/src/frontend/desugar_discard.mbt
@@ -1,0 +1,187 @@
+///|
+/// Bind discarded statement-expression values to synthetic `let` bindings so
+/// Perceus RC can reclaim owned heap temporaries that are never named.
+///
+/// A non-final `Stmt::Expr(e)` in a block evaluates `e` and discards its
+/// value. When `e` produces a freshly owned heap object (e.g. a function call
+/// returning a tuple, or a for-in used as a statement whose result array is
+/// thrown away), nothing decrements its reference count and it leaks.
+///
+/// Rewriting `e` to `let __discardN = e` hands the value to a binding with
+/// zero uses, so Perceus's existing scope-end drop reclaims it. Delegating to
+/// Perceus's use counting keeps this correct for the borrow case too: a bare
+/// `Stmt::Expr(x)` becomes `let __discardN = x`, which Perceus accounts for as
+/// a move/borrow of `x` rather than a spurious extra drop.
+///
+/// Only the *non-final* statement of each block is rewritten; the final
+/// statement is the block's value and must stay an expression. Runs on the RC
+/// path only, before Perceus analysis (alongside the for-in / string-interp
+/// desugars).
+pub fn desugar_discarded_stmts(ast : @core.Module) -> @core.Module {
+  let counter : Ref[Int] = Ref(0)
+  dds_rewrite_module(ast, counter)
+}
+
+///|
+fn dds_rewrite_module(m : @core.Module, counter : Ref[Int]) -> @core.Module {
+  let n = m.stmts.length()
+  let next : Array[@core.Stmt] = []
+  for i = 0; i < n; i = i + 1 {
+    let rewritten = dds_rewrite_stmt(m.stmts[i], counter)
+    let is_last = i == n - 1
+    if !is_last {
+      match rewritten {
+        // Divergent expressions never produce a reclaimable value and must
+        // not be wrapped in a binding (it would put a `local.set` after the
+        // control-transfer / be semantically wrong).
+        @core.Stmt::Expr(expr=@core.Expr::Break(..), ..)
+        | @core.Stmt::Expr(expr=@core.Expr::Continue(..), ..)
+        | @core.Stmt::Expr(expr=@core.Expr::Return(..), ..)
+        | @core.Stmt::Expr(expr=@core.Expr::Perform(..), ..) =>
+          next.push(rewritten)
+        @core.Stmt::Expr(expr~, span~) => {
+          let name = "__discard" + counter.val.to_string()
+          counter.val = counter.val + 1
+          next.push(@core.Stmt::Let(rec=false, name~, expr~, span~))
+        }
+        _ => next.push(rewritten)
+      }
+    } else {
+      next.push(rewritten)
+    }
+  }
+  @core.Module::{ stmts: next }
+}
+
+///|
+fn dds_rewrite_stmt(stmt : @core.Stmt, counter : Ref[Int]) -> @core.Stmt {
+  match stmt {
+    @core.Stmt::Let(rec~, name~, expr~, span~) =>
+      @core.Stmt::Let(rec~, name~, expr=dds_rewrite_expr(expr, counter), span~)
+    @core.Stmt::ExportLet(rec~, name~, expr~, span~) =>
+      @core.Stmt::ExportLet(
+        rec~,
+        name~,
+        expr=dds_rewrite_expr(expr, counter),
+        span~,
+      )
+    @core.Stmt::InternalExportLet(rec~, name~, expr~, span~) =>
+      @core.Stmt::InternalExportLet(
+        rec~,
+        name~,
+        expr=dds_rewrite_expr(expr, counter),
+        span~,
+      )
+    @core.Stmt::LetMut(name~, expr~, span~) =>
+      @core.Stmt::LetMut(name~, expr=dds_rewrite_expr(expr, counter), span~)
+    @core.Stmt::Assign(name~, expr~, span~) =>
+      @core.Stmt::Assign(name~, expr=dds_rewrite_expr(expr, counter), span~)
+    @core.Stmt::Expr(expr~, span~) =>
+      @core.Stmt::Expr(expr=dds_rewrite_expr(expr, counter), span~)
+    @core.Stmt::Test(name~, body~, span~) =>
+      @core.Stmt::Test(name~, body=dds_rewrite_module(body, counter), span~)
+    @core.Stmt::Bench(name~, body~, span~) =>
+      @core.Stmt::Bench(name~, body=dds_rewrite_module(body, counter), span~)
+    _ => stmt
+  }
+}
+
+///|
+fn dds_rewrite_expr(expr : @core.Expr, counter : Ref[Int]) -> @core.Expr {
+  match expr {
+    @core.Expr::Call(name~, type_args~, args~, span~) => {
+      let next_args : Array[@core.CallArg] = []
+      for arg in args {
+        next_args.push(@core.CallArg::{
+          label: arg.label,
+          expr: dds_rewrite_expr(arg.expr, counter),
+          span: arg.span,
+        })
+      }
+      @core.Expr::Call(name~, type_args~, args=next_args, span~)
+    }
+    @core.Expr::If(cond~, then_body~, else_body~, span~) =>
+      @core.Expr::If(
+        cond=dds_rewrite_expr(cond, counter),
+        then_body=dds_rewrite_module(then_body, counter),
+        else_body=dds_rewrite_module(else_body, counter),
+        span~,
+      )
+    @core.Expr::Match(scrutinee~, arms~, span~) => {
+      let next_arms : Array[@core.MatchArm] = []
+      for arm in arms {
+        next_arms.push(@core.MatchArm::{
+          pat: arm.pat,
+          cond: match arm.cond {
+            Some(g) => Some(dds_rewrite_expr(g, counter))
+            None => None
+          },
+          expr: dds_rewrite_expr(arm.expr, counter),
+          span: arm.span,
+        })
+      }
+      @core.Expr::Match(
+        scrutinee=dds_rewrite_expr(scrutinee, counter),
+        arms=next_arms,
+        span~,
+      )
+    }
+    @core.Expr::Handle(body~, arms~, span~) => {
+      let next_arms : Array[@core.MatchArm] = []
+      for arm in arms {
+        next_arms.push(@core.MatchArm::{
+          pat: arm.pat,
+          cond: arm.cond,
+          expr: dds_rewrite_expr(arm.expr, counter),
+          span: arm.span,
+        })
+      }
+      @core.Expr::Handle(
+        body=dds_rewrite_module(body, counter),
+        arms=next_arms,
+        span~,
+      )
+    }
+    @core.Expr::Fn(
+      type_params~,
+      type_bounds~,
+      params~,
+      ret~,
+      effects~,
+      body~,
+      span~
+    ) =>
+      @core.Expr::Fn(
+        type_params~,
+        type_bounds~,
+        params~,
+        ret~,
+        effects~,
+        body=dds_rewrite_module(body, counter),
+        span~,
+      )
+    @core.Expr::Block(body~, span~) =>
+      @core.Expr::Block(body=dds_rewrite_module(body, counter), span~)
+    @core.Expr::While(cond~, body~, span~) =>
+      @core.Expr::While(
+        cond=dds_rewrite_expr(cond, counter),
+        body=dds_rewrite_module(body, counter),
+        span~,
+      )
+    @core.Expr::Tuple(items~, span~) => {
+      let next : Array[@core.Expr] = []
+      for e in items {
+        next.push(dds_rewrite_expr(e, counter))
+      }
+      @core.Expr::Tuple(items=next, span~)
+    }
+    @core.Expr::Array(items~, span~) => {
+      let next : Array[@core.Expr] = []
+      for e in items {
+        next.push(dds_rewrite_expr(e, counter))
+      }
+      @core.Expr::Array(items=next, span~)
+    }
+    _ => expr
+  }
+}

--- a/src/frontend/desugar_for_in.mbt
+++ b/src/frontend/desugar_for_in.mbt
@@ -1,0 +1,169 @@
+///|
+/// Desugar `ForIn` nodes into their `Block`/`While` form *before* Perceus RC
+/// analysis, so the analysis and the codegen observe the same lowered shape.
+///
+/// The linear codegen normally desugars `for-in` lazily at emit time
+/// (`compile_expr`'s `ForIn` case). On the RC path that is too late: Perceus
+/// runs on the original `ForIn` AST and emits drop sites under
+/// `...for_in.body...`, but codegen compiles the desugared `while`/`Block`,
+/// so the two site spaces never line up and the loop body's per-iteration
+/// drops are lost (the same class of leak fixed for plain `while` in A-1).
+///
+/// Running this pass up front makes `for-in` indistinguishable from a
+/// hand-written `while` for both passes, so the A-1 while-body drop wiring
+/// covers `for-in` too. This mirrors `desugar_string_interp`, which runs
+/// before Perceus for the same reason.
+///
+/// The String-vs-generic dispatch uses the same `is_string_for_in` registry
+/// the codegen consults, so the lowered form matches byte-for-byte.
+pub fn desugar_for_in_module(ast : @core.Module) -> @core.Module {
+  dfi_rewrite_module(ast)
+}
+
+///|
+fn dfi_rewrite_module(m : @core.Module) -> @core.Module {
+  let next : Array[@core.Stmt] = []
+  for stmt in m.stmts {
+    next.push(dfi_rewrite_stmt(stmt))
+  }
+  @core.Module::{ stmts: next }
+}
+
+///|
+fn dfi_rewrite_stmt(stmt : @core.Stmt) -> @core.Stmt {
+  match stmt {
+    @core.Stmt::Let(rec~, name~, expr~, span~) =>
+      @core.Stmt::Let(rec~, name~, expr=dfi_rewrite_expr(expr), span~)
+    @core.Stmt::ExportLet(rec~, name~, expr~, span~) =>
+      @core.Stmt::ExportLet(rec~, name~, expr=dfi_rewrite_expr(expr), span~)
+    @core.Stmt::InternalExportLet(rec~, name~, expr~, span~) =>
+      @core.Stmt::InternalExportLet(
+        rec~,
+        name~,
+        expr=dfi_rewrite_expr(expr),
+        span~,
+      )
+    @core.Stmt::LetMut(name~, expr~, span~) =>
+      @core.Stmt::LetMut(name~, expr=dfi_rewrite_expr(expr), span~)
+    @core.Stmt::Assign(name~, expr~, span~) =>
+      @core.Stmt::Assign(name~, expr=dfi_rewrite_expr(expr), span~)
+    @core.Stmt::Expr(expr~, span~) =>
+      @core.Stmt::Expr(expr=dfi_rewrite_expr(expr), span~)
+    @core.Stmt::Test(name~, body~, span~) =>
+      @core.Stmt::Test(name~, body=dfi_rewrite_module(body), span~)
+    @core.Stmt::Bench(name~, body~, span~) =>
+      @core.Stmt::Bench(name~, body=dfi_rewrite_module(body), span~)
+    _ => stmt
+  }
+}
+
+///|
+fn dfi_rewrite_expr(expr : @core.Expr) -> @core.Expr {
+  match expr {
+    @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
+      // Rewrite nested for-ins (and other constructs) inside the iterable and
+      // body first, then lower this for-in. The lowered body is a Module; we
+      // wrap it in a Block expression so it slots in as a single expr.
+      let iterable = dfi_rewrite_expr(iterable)
+      let body = dfi_rewrite_module(body)
+      let lowered = if @core.is_string_for_in(span.start) {
+        @core.desugar_for_in_string(
+          value_name, index_name, iterable, body, span,
+        )
+      } else {
+        @core.desugar_for_in(value_name, index_name, iterable, body, span)
+      }
+      @core.Expr::Block(body=lowered, span~)
+    }
+    @core.Expr::Call(name~, type_args~, args~, span~) => {
+      let next_args : Array[@core.CallArg] = []
+      for arg in args {
+        next_args.push(@core.CallArg::{
+          label: arg.label,
+          expr: dfi_rewrite_expr(arg.expr),
+          span: arg.span,
+        })
+      }
+      @core.Expr::Call(name~, type_args~, args=next_args, span~)
+    }
+    @core.Expr::If(cond~, then_body~, else_body~, span~) =>
+      @core.Expr::If(
+        cond=dfi_rewrite_expr(cond),
+        then_body=dfi_rewrite_module(then_body),
+        else_body=dfi_rewrite_module(else_body),
+        span~,
+      )
+    @core.Expr::Match(scrutinee~, arms~, span~) => {
+      let next_arms : Array[@core.MatchArm] = []
+      for arm in arms {
+        next_arms.push(@core.MatchArm::{
+          pat: arm.pat,
+          cond: match arm.cond {
+            Some(g) => Some(dfi_rewrite_expr(g))
+            None => None
+          },
+          expr: dfi_rewrite_expr(arm.expr),
+          span: arm.span,
+        })
+      }
+      @core.Expr::Match(
+        scrutinee=dfi_rewrite_expr(scrutinee),
+        arms=next_arms,
+        span~,
+      )
+    }
+    @core.Expr::Handle(body~, arms~, span~) => {
+      let next_arms : Array[@core.MatchArm] = []
+      for arm in arms {
+        next_arms.push(@core.MatchArm::{
+          pat: arm.pat,
+          cond: arm.cond,
+          expr: dfi_rewrite_expr(arm.expr),
+          span: arm.span,
+        })
+      }
+      @core.Expr::Handle(body=dfi_rewrite_module(body), arms=next_arms, span~)
+    }
+    @core.Expr::Fn(
+      type_params~,
+      type_bounds~,
+      params~,
+      ret~,
+      effects~,
+      body~,
+      span~
+    ) =>
+      @core.Expr::Fn(
+        type_params~,
+        type_bounds~,
+        params~,
+        ret~,
+        effects~,
+        body=dfi_rewrite_module(body),
+        span~,
+      )
+    @core.Expr::Block(body~, span~) =>
+      @core.Expr::Block(body=dfi_rewrite_module(body), span~)
+    @core.Expr::While(cond~, body~, span~) =>
+      @core.Expr::While(
+        cond=dfi_rewrite_expr(cond),
+        body=dfi_rewrite_module(body),
+        span~,
+      )
+    @core.Expr::Tuple(items~, span~) => {
+      let next : Array[@core.Expr] = []
+      for e in items {
+        next.push(dfi_rewrite_expr(e))
+      }
+      @core.Expr::Tuple(items=next, span~)
+    }
+    @core.Expr::Array(items~, span~) => {
+      let next : Array[@core.Expr] = []
+      for e in items {
+        next.push(dfi_rewrite_expr(e))
+      }
+      @core.Expr::Array(items=next, span~)
+    }
+    _ => expr
+  }
+}

--- a/src/frontend/perceus_poc.mbt
+++ b/src/frontend/perceus_poc.mbt
@@ -1329,7 +1329,11 @@ fn p2_count_expr(ctx : PerceusCountCtx2, expr : @core.Expr) -> Unit {
     | @core.Expr::Placeholder(..) => ()
     @core.Expr::Ident(name~, ..) => p2_count_use(ctx, name)
     @core.Expr::Call(name~, args~, ..) => {
-      p2_count_use(ctx, name)
+      // Calling a binding borrows it: a closure value stays live across the
+      // call (it may be called again) and is reclaimed at scope end, which
+      // recursively drops its captured heap. For top-level function names and
+      // builtins the lookup finds no local binding, so this is a no-op.
+      p2_count_borrow(ctx, name)
       // __index(obj, key) borrows the container — no ownership transfer
       // Applies to both record field access (string key) and array index (int key)
       if name == "__index" && args.length() == 2 {
@@ -1800,7 +1804,9 @@ fn p2_emit_expr(
     | @core.Expr::Placeholder(..) => ()
     @core.Expr::Ident(name~, ..) => p2_emit_use(ctx, name, site)
     @core.Expr::Call(name~, args~, ..) => {
-      p2_emit_use(ctx, name, site + ".callee")
+      // Borrow (not consume) the callee binding — see the count pass. A
+      // closure stays live across the call and is dropped at scope end.
+      p2_emit_borrow(ctx, name, site + ".callee")
       // __index(obj, key) borrows the container (record field or array index)
       if name == "__index" && args.length() == 2 {
         match args[0].expr {

--- a/src/frontend/perceus_poc.mbt
+++ b/src/frontend/perceus_poc.mbt
@@ -1839,10 +1839,10 @@ fn p2_emit_expr(
     @core.Expr::If(cond~, then_body~, else_body~, ..) => {
       p2_emit_expr(ctx, cond, site + ".cond")
       let pre = p2_emit_snapshot(ctx)
-      p2_emit_block(ctx, then_body, site + ".then")
+      p2_emit_block(ctx, then_body, site + ".then", scope_end_to_last=true)
       let then_snap = p2_emit_snapshot(ctx)
       p2_emit_restore(ctx, pre)
-      p2_emit_block(ctx, else_body, site + ".else")
+      p2_emit_block(ctx, else_body, site + ".else", scope_end_to_last=true)
       let else_snap = p2_emit_snapshot(ctx)
       p2_emit_merge_branches(ctx, pre, [
         (then_snap, site + ".then"),

--- a/src/frontend/perceus_poc.mbt
+++ b/src/frontend/perceus_poc.mbt
@@ -1850,7 +1850,10 @@ fn p2_emit_expr(
       ])
     }
     @core.Expr::Block(body~, ..) | @core.Expr::Handle(body~, ..) =>
-      p2_emit_block(ctx, body, site + ".body")
+      // Attach block-local scope-end drops to the last statement so codegen
+      // (which compiles a block expression statement-by-statement) emits them
+      // inside the block, e.g. a match-arm body `=> { let t = ...; ... }`.
+      p2_emit_block(ctx, body, site + ".body", scope_end_to_last=true)
     @core.Expr::Match(scrutinee~, arms~, ..) => {
       p2_emit_expr(ctx, scrutinee, site + ".scrutinee")
       if arms.length() == 0 {

--- a/src/frontend/pkg.generated.mbti
+++ b/src/frontend/pkg.generated.mbti
@@ -24,6 +24,8 @@ pub fn dce_module_gc(@core.Module) -> @core.Module
 
 pub fn dce_module_with_entry_names(@core.Module, Array[String]) -> @core.Module
 
+pub fn desugar_discarded_stmts(@core.Module) -> @core.Module
+
 pub fn desugar_for_in_module(@core.Module) -> @core.Module
 
 pub fn desugar_method_calls(@core.Module, Map[String, @core.Ref]) -> @core.Module

--- a/src/frontend/pkg.generated.mbti
+++ b/src/frontend/pkg.generated.mbti
@@ -24,6 +24,8 @@ pub fn dce_module_gc(@core.Module) -> @core.Module
 
 pub fn dce_module_with_entry_names(@core.Module, Array[String]) -> @core.Module
 
+pub fn desugar_for_in_module(@core.Module) -> @core.Module
+
 pub fn desugar_method_calls(@core.Module, Map[String, @core.Ref]) -> @core.Module
 
 pub fn desugar_string_interp(@core.Module) -> @core.Module

--- a/src/runtime_compile/compile.mbt
+++ b/src/runtime_compile/compile.mbt
@@ -2203,6 +2203,11 @@ fn wasm_emit_options_with_rc(
   // drops fire (the codegen would otherwise desugar for-in lazily, after RC
   // analysis, breaking the site mapping). See desugar_for_in_module.
   let desugared_ast = @frontend.desugar_for_in_module(desugared_ast)
+  // Bind discarded statement-expression values so owned heap temporaries that
+  // are never named (e.g. an ignored call result, or a for-in used purely for
+  // effect) are reclaimed at scope end instead of leaking. See
+  // desugar_discarded_stmts.
+  let desugared_ast = @frontend.desugar_discarded_stmts(desugared_ast)
   // Analyze top-level (non-function) statements
   let run_ast = extract_run_stmts(desugared_ast)
   let top_plan = @frontend.build_perceus_plan(run_ast)

--- a/src/runtime_compile/compile.mbt
+++ b/src/runtime_compile/compile.mbt
@@ -2198,6 +2198,11 @@ fn wasm_emit_options_with_rc(
   // Desugar StringInterp into let-binding chains before Perceus analysis
   // so that intermediate String::concat results are RC-tracked.
   let desugared_ast = @frontend.desugar_string_interp(ast)
+  // Desugar for-in into its while/Block form before Perceus, so the analysis
+  // and codegen share the same lowered shape and per-iteration loop-body
+  // drops fire (the codegen would otherwise desugar for-in lazily, after RC
+  // analysis, breaking the site mapping). See desugar_for_in_module.
+  let desugared_ast = @frontend.desugar_for_in_module(desugared_ast)
   // Analyze top-level (non-function) statements
   let run_ast = extract_run_stmts(desugared_ast)
   let top_plan = @frontend.build_perceus_plan(run_ast)

--- a/src/tests/moon.pkg
+++ b/src/tests/moon.pkg
@@ -21,5 +21,6 @@ options(
     "vibe_wasm_gc_e2e_support_test.mbt": [ "native" ],
     "vibe_wasm_gc_e2e_test.mbt": [ "native" ],
     "vibe_wasm_gc_mainlane_e2e_test.mbt": [ "native" ],
+    "vibe_wasm_rc_e2e_test.mbt": [ "native" ],
   },
 )

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -4382,6 +4382,35 @@ test "rc debug: match arm-local heap is dropped per arm" {
 }
 
 ///|
+test "rc debug: discarded statement-expr heap is dropped" {
+  // The first two `mk()` results are statement expressions whose values are
+  // discarded. They are bound to synthetic `let` bindings before Perceus so
+  // the owned tuples are reclaimed instead of leaking.
+  let script =
+    #|let mk = () -> (Int, Int) {
+    #|  (1, 2)
+    #|}
+    #|let f = () -> Int {
+    #|  mk()
+    #|  mk()
+    #|  let r = mk()
+    #|  r.0
+    #|}
+    #|f()
+  let res = try eval_run_rc_debug(script) catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    r => r
+  }
+  let (allocs, frees) = rc_debug_counts(res)
+  // Three tuples allocated (three mk() calls), all three reclaimed.
+  assert_true(allocs >= 3L)
+  assert_eq(allocs, frees)
+  // Correctness is preserved: r.0 == 1.
+  assert_eq(decode_int(res.value), 1L)
+}
+
+///|
 // ADR-0044 Phase 3: String now implements Iterable. The prelude provides
 // `String::iter_length` (= String::length) and `String::iter_get`
 // (= String::char_code_at), so generic Iterable combinators see each char

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -4411,6 +4411,51 @@ test "rc debug: discarded statement-expr heap is dropped" {
 }
 
 ///|
+test "rc debug: closure capturing heap is reclaimed (A-2)" {
+  // A closure that captures a heap value owns it via its env block. Calling the
+  // closure borrows it; at scope end the closure is dropped and its captured
+  // heap is recursively reclaimed. Verified both for a single closure and for
+  // per-iteration closures in a loop (no growth).
+  let single =
+    #|let f = () -> Int {
+    #|  let t = (1, 2)
+    #|  let g = (x: Int) -> Int { x + t.0 }
+    #|  g(10)
+    #|}
+    #|f()
+  let r1 = try eval_run_rc_debug(single) catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    r => r
+  }
+  let (a1, f1) = rc_debug_counts(r1)
+  assert_true(a1 >= 2L)
+  assert_eq(a1, f1)
+  assert_eq(decode_int(r1.value), 11L)
+  let loop_ =
+    #|let f = () -> Int {
+    #|  let mut s = 0
+    #|  let mut i = 0
+    #|  while i < 5 {
+    #|    let t = (i, i)
+    #|    let g = (x: Int) -> Int { x + t.0 }
+    #|    s = s + g(1)
+    #|    i = i + 1
+    #|  }
+    #|  s
+    #|}
+    #|f()
+  let r2 = try eval_run_rc_debug(loop_) catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    r => r
+  }
+  let (a2, f2) = rc_debug_counts(r2)
+  assert_true(a2 >= 10L)
+  assert_eq(a2, f2)
+}
+
+///|
 // ADR-0044 Phase 3: String now implements Iterable. The prelude provides
 // `String::iter_length` (= String::length) and `String::iter_get`
 // (= String::char_code_at), so generic Iterable combinators see each char

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -4319,6 +4319,38 @@ test "rc debug: for-in body has no per-iteration leak" {
 }
 
 ///|
+test "rc debug: if/else branch-local heap is dropped per branch" {
+  // A heap binding allocated inside a branch must be dropped at the end of
+  // that branch — and only when the branch actually runs (no spurious drop of
+  // an uninitialized local on the other path).
+  let prog = fn(arg : String) -> String {
+    "let f = (c: Bool) -> Int {\n" +
+    "  let mut s = 0\n" +
+    "  if c {\n    let t = (1, 2)\n    s = s + t.0\n  } else {\n    s = s + 5\n  }\n" +
+    "  s\n}\nf(" +
+    arg +
+    ")"
+  }
+  // then-branch taken: the tuple is allocated and must be freed.
+  let res_then = try eval_run_rc_debug(prog("true")) catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    r => r
+  }
+  let (allocs_then, frees_then) = rc_debug_counts(res_then)
+  assert_true(allocs_then >= 1L)
+  assert_eq(allocs_then, frees_then)
+  // else-branch taken: no allocation, and no drop of the uninitialized `t`.
+  let res_else = try eval_run_rc_debug(prog("false")) catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    r => r
+  }
+  let (allocs_else, frees_else) = rc_debug_counts(res_else)
+  assert_eq(allocs_else, frees_else)
+}
+
+///|
 // ADR-0044 Phase 3: String now implements Iterable. The prelude provides
 // `String::iter_length` (= String::length) and `String::iter_get`
 // (= String::char_code_at), so generic Iterable combinators see each char

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -4351,6 +4351,37 @@ test "rc debug: if/else branch-local heap is dropped per branch" {
 }
 
 ///|
+test "rc debug: match arm-local heap is dropped per arm" {
+  // A heap binding allocated inside a match arm body must be dropped at the
+  // end of that arm — and only when the arm is selected.
+  let prog = fn(arg : String) -> String {
+    "let f = (n: Int) -> Int {\n" +
+    "  let mut s = 0\n" +
+    "  match n {\n    0 => { let t = (1, 2); s = s + t.0 }\n    _ => { s = s + 9 }\n  }\n" +
+    "  s\n}\nf(" +
+    arg +
+    ")"
+  }
+  // matching arm allocates the tuple → must be freed.
+  let res0 = try eval_run_rc_debug(prog("0")) catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    r => r
+  }
+  let (allocs0, frees0) = rc_debug_counts(res0)
+  assert_true(allocs0 >= 1L)
+  assert_eq(allocs0, frees0)
+  // default arm allocates nothing, and emits no spurious drop.
+  let res1 = try eval_run_rc_debug(prog("1")) catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    r => r
+  }
+  let (allocs1, frees1) = rc_debug_counts(res1)
+  assert_eq(allocs1, frees1)
+}
+
+///|
 // ADR-0044 Phase 3: String now implements Iterable. The prelude provides
 // `String::iter_length` (= String::length) and `String::iter_get`
 // (= String::char_code_at), so generic Iterable combinators see each char

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -4284,6 +4284,41 @@ test "rc debug: while-loop body drops nested heap per-iteration (no leak)" {
 }
 
 ///|
+test "rc debug: for-in body has no per-iteration leak" {
+  // for-in is desugared to a while loop before Perceus analysis, so the
+  // per-iteration body binding `t` must be reclaimed each turn just like the
+  // hand-written while case. We assert the per-iteration property directly:
+  // the count of unreclaimed allocations must NOT grow with the iteration
+  // count. (A small constant remainder — the array builder / discarded result
+  // array — is tracked separately and is independent of iteration count.)
+  fn leak_for(elems : String) -> Int64 raise {
+    let script = "let f = () -> Int {\n" +
+      "  let xs = " +
+      elems +
+      "\n  let mut sum = 0\n" +
+      "  for x in xs {\n    let t = (x, x + 1)\n    sum = sum + t.0\n  }\n" +
+      "  sum\n}\nf()"
+    let res = eval_run_rc_debug(script)
+    let (allocs, frees) = rc_debug_counts(res)
+    allocs - frees
+  }
+
+  let leak_small = try leak_for("[10, 20, 30]") catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    v => v
+  }
+  let leak_large = try leak_for("[10, 20, 30, 40, 50, 60, 70]") catch {
+    e => fail("rc debug eval failed: " + e.to_string())
+  } noraise {
+    v => v
+  }
+  // No per-iteration leak: the unreclaimed count is the same for 3 and 7
+  // iterations (the per-iteration tuples are all dropped).
+  assert_eq(leak_small, leak_large)
+}
+
+///|
 // ADR-0044 Phase 3: String now implements Iterable. The prelude provides
 // `String::iter_length` (= String::length) and `String::iter_get`
 // (= String::char_code_at), so generic Iterable combinators see each char

--- a/src/tests/vibe_wasm_rc_e2e_test.mbt
+++ b/src/tests/vibe_wasm_rc_e2e_test.mbt
@@ -1,0 +1,218 @@
+///|
+/// End-to-end gate for the Perceus RC (linear-memory) backend on a real wasm
+/// engine (wasmtime). The in-tree interpreter in `vibe_wasm_eval_test.mbt` is
+/// lenient about wasm stack discipline; wasmtime enforces the spec, so this
+/// gate is what actually proves the RC-instrumented wasm is valid and produces
+/// correct results. (It already caught an invalid `block`/`br_if` ordering in
+/// the rc_dup/rc_drop emitters.)
+///
+/// Native-only: it shells out to `wasmtime` via libc `system`. Skipped unless
+/// `VIBE_WASM_RC_E2E=1` is set; run it with the `test-wasm-rc-e2e` task
+/// (`moon test --target native`).
+
+///|
+fn rc_e2e_should_skip(test_name : String) -> Bool {
+  if gc_e2e_env_truthy("VIBE_WASM_RC_E2E") {
+    false
+  } else {
+    println("[rc e2e] skipped \{test_name} (set VIBE_WASM_RC_E2E=1)")
+    true
+  }
+}
+
+///|
+/// Compile `source` with the linear backend + Perceus RC, run it on wasmtime
+/// via `--invoke _start`, and return (exit_code, trimmed_output).
+fn rc_e2e_compile_and_run(
+  source : String,
+  label : String,
+) -> (Int, String) raise {
+  let db = VibeDb::new()
+  db.set_source("main", source)
+  let wasm = try
+    @runtime_compile.compile_module_wasm(db, "main", enable_rc=true)
+  catch {
+    e => fail("[\{label}] compile error: \{e.to_string()}")
+  } noraise {
+    b => b
+  }
+  if wasm.length() < 8 {
+    fail("[\{label}] wasm too small: \{wasm.length()}")
+  }
+  let wasm_path = "/tmp/vibe_rc_e2e_\{label}.wasm"
+  let out_path = "/tmp/vibe_rc_e2e_\{label}.out"
+  @os_fs.write_bytes_to_file(wasm_path, wasm) catch {
+    e => fail("[\{label}] write wasm failed: \{e.to_string()}")
+  }
+  let exit_code = gc_e2e_system_cmd(
+    "wasmtime run --invoke _start " + wasm_path + " > " + out_path + " 2>&1",
+  )
+  let output = @os_fs.read_file_to_string(out_path) catch { _ => "" }
+  let _ = try? @os_fs.remove_file(wasm_path)
+  let _ = try? @os_fs.remove_file(out_path)
+  (exit_code, output.trim().to_owned())
+}
+
+///|
+fn assert_rc_e2e_int(
+  source : String,
+  label : String,
+  expected : Int,
+) -> Unit raise {
+  let (exit_code, output) = rc_e2e_compile_and_run(source, label)
+  if exit_code != 0 {
+    fail("[\{label}] exit code should be 0, got \{exit_code}: \{output}")
+  }
+  if !output.contains(expected.to_string()) {
+    fail("[\{label}] output should contain \{expected}, got: \{output}")
+  }
+}
+
+///|
+test "rc e2e: heap tuple field access" {
+  if rc_e2e_should_skip("heap tuple field access") {
+    return
+  }
+  assert_rc_e2e_int("let t = (3, 4)\nt.0 + t.1", "tuple", 7)
+}
+
+///|
+test "rc e2e: while loop allocating per iteration" {
+  if rc_e2e_should_skip("while loop") {
+    return
+  }
+  let src =
+    #|let f = () -> Int {
+    #|  let mut s = 0
+    #|  let mut i = 0
+    #|  while i < 5 {
+    #|    let t = (i, i + 1)
+    #|    s = s + t.0
+    #|    i = i + 1
+    #|  }
+    #|  s
+    #|}
+    #|f()
+  assert_rc_e2e_int(src, "while_loop", 10)
+}
+
+///|
+test "rc e2e: for-in loop over array" {
+  if rc_e2e_should_skip("for-in loop") {
+    return
+  }
+  let src =
+    #|let f = () -> Int {
+    #|  let xs = [10, 20, 30]
+    #|  let mut sum = 0
+    #|  for x in xs {
+    #|    let t = (x, x + 1)
+    #|    sum = sum + t.0
+    #|  }
+    #|  sum
+    #|}
+    #|f()
+  assert_rc_e2e_int(src, "for_in", 60)
+}
+
+///|
+test "rc e2e: if/else branch-local heap" {
+  if rc_e2e_should_skip("if/else branch") {
+    return
+  }
+  let src =
+    #|let f = (c: Bool) -> Int {
+    #|  let mut s = 0
+    #|  if c {
+    #|    let t = (1, 2)
+    #|    s = s + t.0
+    #|  } else {
+    #|    s = s + 5
+    #|  }
+    #|  s
+    #|}
+    #|f(true)
+  assert_rc_e2e_int(src, "if_else", 1)
+}
+
+///|
+test "rc e2e: match arm-local heap" {
+  if rc_e2e_should_skip("match arm") {
+    return
+  }
+  let src =
+    #|let f = (n: Int) -> Int {
+    #|  let mut s = 0
+    #|  match n {
+    #|    0 => { let t = (7, 8); s = s + t.0 }
+    #|    _ => { s = s + 9 }
+    #|  }
+    #|  s
+    #|}
+    #|f(0)
+  assert_rc_e2e_int(src, "match_arm", 7)
+}
+
+///|
+test "rc e2e: closure capturing heap" {
+  if rc_e2e_should_skip("closure") {
+    return
+  }
+  let src =
+    #|let make = (n: Int) -> (Int) -> Int {
+    #|  (x: Int) -> Int { x + n }
+    #|}
+    #|let add5 = make(5)
+    #|add5(3)
+  assert_rc_e2e_int(src, "closure", 8)
+}
+
+///|
+test "rc e2e: array allocation and index" {
+  if rc_e2e_should_skip("array") {
+    return
+  }
+  assert_rc_e2e_int("let a = [1, 2, 3]\nArray::get(a, 2)", "array", 3)
+}
+
+///|
+test "rc e2e: discarded statement-expr heap" {
+  if rc_e2e_should_skip("discarded stmt") {
+    return
+  }
+  let src =
+    #|let mk = () -> (Int, Int) {
+    #|  (1, 2)
+    #|}
+    #|let f = () -> Int {
+    #|  mk()
+    #|  mk()
+    #|  let r = mk()
+    #|  r.0
+    #|}
+    #|f()
+  assert_rc_e2e_int(src, "discard", 1)
+}
+
+///|
+test "rc e2e: loop stress reuses heap without corruption" {
+  if rc_e2e_should_skip("loop stress") {
+    return
+  }
+  // Many per-iteration allocations: with RC + free-list the heap is reused and
+  // the checksum stays correct. A reuse-while-live bug would corrupt the sum.
+  let src =
+    #|let f = () -> Int {
+    #|  let mut acc = 0
+    #|  let mut i = 0
+    #|  while i < 1000 {
+    #|    let t = (i, i * 2)
+    #|    acc = acc + t.1 - t.0
+    #|    i = i + 1
+    #|  }
+    #|  acc
+    #|}
+    #|f()
+  // sum_{i=0}^{999} (2i - i) = sum i = 999*1000/2 = 499500
+  assert_rc_e2e_int(src, "loop_stress", 499500)
+}

--- a/src/tests/vibe_wasm_rc_e2e_test.mbt
+++ b/src/tests/vibe_wasm_rc_e2e_test.mbt
@@ -168,6 +168,23 @@ test "rc e2e: closure capturing heap" {
 }
 
 ///|
+test "rc e2e: closure capturing heap value" {
+  if rc_e2e_should_skip("closure capturing heap") {
+    return
+  }
+  // The closure captures a heap tuple; its env (and the captured tuple) must be
+  // reclaimed without corrupting the computed result.
+  let src =
+    #|let f = () -> Int {
+    #|  let t = (3, 4)
+    #|  let g = (x: Int) -> Int { x + t.0 + t.1 }
+    #|  g(10)
+    #|}
+    #|f()
+  assert_rc_e2e_int(src, "closure_heap_capture", 17)
+}
+
+///|
 test "rc e2e: array allocation and index" {
   if rc_e2e_should_skip("array") {
     return

--- a/vibe/compiler/perceus/index.vibe
+++ b/vibe/compiler/perceus/index.vibe
@@ -8,6 +8,10 @@ import .. / codegen / common_analysis {
   collect_free_vars
 }
 
+import .. / core / polyfill.vibe {
+  __to_string
+}
+
 //# Types
 
 // Perceus RC analysis for the selfhost linear backend.
@@ -57,6 +61,7 @@ export struct PerceusAction {
 // re-advanced in lockstep so ids match.
 struct PCtx {
   mut next_id: Int;
+  mut seq_id: Int;
   names: Array[String];
   uses: Array[Int];
   borrows: Array[Int];
@@ -70,6 +75,7 @@ struct PCtx {
 let pctx_new: () -> PCtx = () -> {
   PCtx::{
     next_id: 0,
+    seq_id: 0,
     names: [],
     uses: [],
     borrows: [],
@@ -77,6 +83,14 @@ let pctx_new: () -> PCtx = () -> {
     remaining: [],
     actions: [],
   }
+}
+
+// A fresh, deterministic synthetic name for an `ESeq`-discarded value. Both
+// passes walk the tree identically, so the Nth `ESeq` gets the same name.
+let next_seq_name: (PCtx) -> String = (ctx) -> {
+  let nm = "__seq" + __to_string(ctx.seq_id)
+  ctx.seq_id = ctx.seq_id + 1
+  nm
 }
 
 export let pa_is_drop: (PerceusAction) -> Bool = (a) -> {
@@ -288,7 +302,11 @@ export let rec pc_count: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, ex
       pc_count(ctx, scope, body)
     },
     ESeq(a, b) => {
+      // `a`'s value is discarded; bind it so an owned heap temporary is
+      // reclaimed at scope end (A-1b). A scalar `a` needs no binding.
       pc_count(ctx, scope, a)
+      let nm = next_seq_name(ctx)
+      let _id = pc_declare(ctx, nm, is_scalar_expr(a))
       pc_count(ctx, scope, b)
     },
     EBinOp(_op, l, r) => {
@@ -392,6 +410,19 @@ export let rec pc_count: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, ex
       }
       pc_count(ctx, s3, fbody)
     },
+    ELoop(params, lbody) => {
+      // Loop parameters are bindings (re-bound on continue) scoped to the body.
+      let mut s = scope
+      let mut i = 0
+      while i < Array::length(params) {
+        let p = Array::get(params, i)
+        pc_count(ctx, scope, p.1)
+        let pid = pc_declare(ctx, p.0, is_scalar_expr(p.1))
+        s = Map::set(s, p.0, pid)
+        i = i + 1
+      }
+      pc_count(ctx, s, lbody)
+    },
     EMatch(scrut, arms) => {
       pc_count(ctx, scope, scrut)
       let snap_u = copy_ints(ctx.uses)
@@ -450,8 +481,12 @@ export let rec pc_count: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, ex
 let pe_declare: (PCtx, String) -> Int = (ctx, _name) -> {
   let id = ctx.next_id
   let owning = Array::get(ctx.uses, id)
-  let borrowed = Array::get(ctx.borrows, id)
-  let init = if owning == 0 && borrowed > 0 { 1 } else { owning }
+  // A binding holds one owned reference. If it is never used in an owning
+  // (consuming) position it still owns that reference at scope end and must be
+  // dropped there — this covers both pure-borrow bindings and entirely unused
+  // ones (e.g. a discarded sequenced value). The scalar check in pe_scope_end
+  // skips known non-heap values.
+  let init = if owning == 0 { 1 } else { owning }
   Array::push(ctx.remaining, init)
   ctx.next_id = id + 1
   id
@@ -556,7 +591,10 @@ export let rec pc_emit: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, exp
     },
     ESeq(a, b) => {
       pc_emit(ctx, scope, a)
+      let nm = next_seq_name(ctx)
+      let id = pe_declare(ctx, nm)
       pc_emit(ctx, scope, b)
+      pe_scope_end(ctx, id, nm)
     },
     EBinOp(_op, l, r) => {
       pc_emit(ctx, scope, l)
@@ -640,6 +678,28 @@ export let rec pc_emit: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, exp
       pc_emit(ctx, s3, fbody)
       pe_scope_end(ctx, idv, value_name)
     },
+    ELoop(params, lbody) => {
+      let mut s = scope
+      let pids: Array[Int] = []
+      let pnames: Array[String] = []
+      let mut i = 0
+      while i < Array::length(params) {
+        let p = Array::get(params, i)
+        pc_emit(ctx, scope, p.1)
+        let pid = pe_declare(ctx, p.0)
+        s = Map::set(s, p.0, pid)
+        Array::push(pids, pid)
+        Array::push(pnames, p.0)
+        i = i + 1
+      }
+      pc_emit(ctx, s, lbody)
+      let mut j = 0
+      while j < Array::length(pids) {
+        pe_scope_end(ctx, Array::get(pids, j), Array::get(pnames, j))
+        j = j + 1
+      }
+      0
+    },
     EMatch(scrut, arms) => {
       pc_emit(ctx, scope, scrut)
       let snap = copy_ints(ctx.remaining)
@@ -678,8 +738,10 @@ export let build_perceus_plan: (Expr) -> Array[PerceusAction] = (body) -> {
   let ctx = pctx_new()
   let empty: Map[String, Int] = map {}
   pc_count(ctx, empty, body)
-  // Reset id allocation; the emit pass re-declares in the same tree order.
+  // Reset id + synthetic-name allocation; the emit pass re-declares in the
+  // same tree order so ids and synthetic names line up.
   ctx.next_id = 0
+  ctx.seq_id = 0
   pc_emit(ctx, empty, body)
   ctx.actions
 }

--- a/vibe/compiler/perceus/index.vibe
+++ b/vibe/compiler/perceus/index.vibe
@@ -469,6 +469,68 @@ export let rec pc_count: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, ex
       }
       0
     },
+    EHandle(hbody, arms) => {
+      // Treat the handled body as branch 0 and each handler arm as a further
+      // branch (branch-max counting), with arm-local pattern bindings. This is
+      // a conservative approximation of effect control flow (safe: it never
+      // emits a wrong drop).
+      let snap_u = copy_ints(ctx.uses)
+      let snap_b = copy_ints(ctx.borrows)
+      let max_u = zeros(Array::length(snap_u))
+      let max_b = zeros(Array::length(snap_b))
+      pc_count(ctx, scope, hbody)
+      let mut id0 = 0
+      while id0 < Array::length(snap_u) {
+        let du = Array::get(ctx.uses, id0) - Array::get(snap_u, id0)
+        if du > Array::get(max_u, id0) {
+          Array::set(max_u, id0, du)
+        }
+        let db = Array::get(ctx.borrows, id0) - Array::get(snap_b, id0)
+        if db > Array::get(max_b, id0) {
+          Array::set(max_b, id0, db)
+        }
+        id0 = id0 + 1
+      }
+      let mut a = 0
+      while a < Array::length(arms) {
+        let arm = Array::get(arms, a)
+        restore_prefix(ctx.uses, snap_u)
+        restore_prefix(ctx.borrows, snap_b)
+        let pnames: Array[String] = []
+        pat_names(arm.0, pnames)
+        let mut s = scope
+        let mut k = 0
+        while k < Array::length(pnames) {
+          let nm = Array::get(pnames, k)
+          let pid = pc_declare(ctx, nm, false)
+          s = Map::set(s, nm, pid)
+          k = k + 1
+        }
+        pc_count(ctx, s, arm.1)
+        let mut id = 0
+        while id < Array::length(snap_u) {
+          let du = Array::get(ctx.uses, id) - Array::get(snap_u, id)
+          if du > Array::get(max_u, id) {
+            Array::set(max_u, id, du)
+          }
+          let db = Array::get(ctx.borrows, id) - Array::get(snap_b, id)
+          if db > Array::get(max_b, id) {
+            Array::set(max_b, id, db)
+          }
+          id = id + 1
+        }
+        a = a + 1
+      }
+      restore_prefix(ctx.uses, snap_u)
+      restore_prefix(ctx.borrows, snap_b)
+      let mut id2 = 0
+      while id2 < Array::length(snap_u) {
+        Array::set(ctx.uses, id2, Array::get(snap_u, id2) + Array::get(max_u, id2))
+        Array::set(ctx.borrows, id2, Array::get(snap_b, id2) + Array::get(max_b, id2))
+        id2 = id2 + 1
+      }
+      0
+    },
     _ => 0
   }
 }
@@ -703,6 +765,35 @@ export let rec pc_emit: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, exp
     EMatch(scrut, arms) => {
       pc_emit(ctx, scope, scrut)
       let snap = copy_ints(ctx.remaining)
+      let mut a = 0
+      while a < Array::length(arms) {
+        let arm = Array::get(arms, a)
+        restore_prefix(ctx.remaining, snap)
+        let pnames: Array[String] = []
+        pat_names(arm.0, pnames)
+        let mut s = scope
+        let pids: Array[Int] = []
+        let mut k = 0
+        while k < Array::length(pnames) {
+          let nm = Array::get(pnames, k)
+          let pid = pe_declare(ctx, nm)
+          s = Map::set(s, nm, pid)
+          Array::push(pids, pid)
+          k = k + 1
+        }
+        pc_emit(ctx, s, arm.1)
+        let mut j = 0
+        while j < Array::length(pids) {
+          pe_scope_end(ctx, Array::get(pids, j), Array::get(pnames, j))
+          j = j + 1
+        }
+        a = a + 1
+      }
+      0
+    },
+    EHandle(hbody, arms) => {
+      let snap = copy_ints(ctx.remaining)
+      pc_emit(ctx, scope, hbody)
       let mut a = 0
       while a < Array::length(arms) {
         let arm = Array::get(arms, a)

--- a/vibe/compiler/perceus/index.vibe
+++ b/vibe/compiler/perceus/index.vibe
@@ -1,0 +1,501 @@
+//# Imports
+
+import .. / core {
+  Expr, Pat, TypeExpr
+}
+
+//# Types
+
+// Perceus RC analysis for the selfhost linear backend.
+//
+// Phase 2 of docs/spec/selfhost-rc-port.md: a pure AST -> action-list pass,
+// independent of codegen, so it is unit-testable in isolation. It mirrors the
+// authoritative `src/frontend/perceus_poc.mbt` adapted to the selfhost's
+// expression-oriented AST: scope is structural (an `ELet(x, val, body)` scopes
+// `x` to `body`), so per-iteration / per-branch bindings fall out of the tree
+// shape rather than needing statement-index bookkeeping.
+//
+// Model (mirrors the validated src/ semantics):
+//   - An `EIdent` occurrence in a consuming position is an *owning* use.
+//   - A call callee and a field access (`EDot`, array `__index`) are *borrows*:
+//     the binding stays live and is reclaimed at scope end.
+//   - A binding is dropped at the end of its `ELet` body when it still owns a
+//     live reference (pure-borrow, or unused non-scalar). Used-more-than-once
+//     owning references emit a `dup` at all but the consuming use.
+//
+// Two passes share binding ids assigned in tree order (count then emit walk the
+// tree identically, so ids line up):
+//   pass 1 `pc_count` fills owning-use / borrow counts per binding;
+//   pass 2 `pc_emit` emits dup/drop actions using those counts.
+//
+// Covered: literals, EIdent, ECall (callee borrow + `__index` arg0 borrow),
+// EDot, ELet/ELetMut/ELetRec, EAssign/EAssignOp, ESeq, EBinOp/EUnaryOp, ETuple,
+// EArray, ERecord/EMap, EIf (branch-max counting), EWhile, EReturn/EThrow/
+// EBreak/ESpread/EStringInterp/ELabeledArg.
+//
+// Deferred (safe no-op for now — may leave heap unreclaimed but never emits a
+// wrong drop; tracked as follow-up within Phase 2): EFn captures, EMatch,
+// EHandle, ELoop, EForIn, and cross-branch balancing of outer bindings consumed
+// unevenly across `EIf` arms.
+
+export enum PerceusActionKind {
+  PaDup;
+  PaDrop
+}
+
+export struct PerceusAction {
+  kind: PerceusActionKind;
+  name: String
+}
+
+// Shared analysis context. Counters are indexed by binding id (assigned in
+// tree order). `next_id` is reset between the count and emit passes and
+// re-advanced in lockstep so ids match.
+struct PCtx {
+  mut next_id: Int;
+  names: Array[String];
+  uses: Array[Int];
+  borrows: Array[Int];
+  scalar: Array[Bool];
+  remaining: Array[Int];
+  actions: Array[PerceusAction]
+}
+
+//# Functions
+
+let pctx_new: () -> PCtx = () -> {
+  PCtx::{
+    next_id: 0,
+    names: [],
+    uses: [],
+    borrows: [],
+    scalar: [],
+    remaining: [],
+    actions: [],
+  }
+}
+
+export let pa_is_drop: (PerceusAction) -> Bool = (a) -> {
+  match a.kind {
+    PaDrop => true,
+    PaDup => false
+  }
+}
+
+export let pa_is_dup: (PerceusAction) -> Bool = (a) -> {
+  match a.kind {
+    PaDup => true,
+    PaDrop => false
+  }
+}
+
+// A value that is a known non-heap scalar literal needs no RC ops, so a binding
+// of one is never dropped.
+let is_scalar_expr: (Expr) -> Bool = (e) -> {
+  match e {
+    EInt(_) => true,
+    EBool(_) => true,
+    EFloat(_) => true,
+    EUnit => true,
+    _ => false
+  }
+}
+
+// --- count pass ---
+
+// Declare a binding during the count pass: allocate an id and zeroed counters.
+let pc_declare: (PCtx, String, Bool) -> Int = (ctx, name, scalar) -> {
+  let id = ctx.next_id
+  Array::push(ctx.names, name)
+  Array::push(ctx.uses, 0)
+  Array::push(ctx.borrows, 0)
+  Array::push(ctx.scalar, scalar)
+  ctx.next_id = id + 1
+  id
+}
+
+let pc_count_use: (PCtx, Map[String, Int], String) -> Int = (ctx, scope, name) -> {
+  if Map::has_key(scope, name) {
+    let id = Map::get(scope, name)
+    Array::set(ctx.uses, id, Array::get(ctx.uses, id) + 1)
+  }
+  0
+}
+
+let pc_count_borrow: (PCtx, Map[String, Int], String) -> Int = (ctx, scope, name) -> {
+  if Map::has_key(scope, name) {
+    let id = Map::get(scope, name)
+    Array::set(ctx.borrows, id, Array::get(ctx.borrows, id) + 1)
+  }
+  0
+}
+
+let copy_ints: (Array[Int]) -> Array[Int] = (src) -> {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(src) {
+    Array::push(out, Array::get(src, i))
+    i = i + 1
+  }
+  out
+}
+
+// Restore `dst[0..len(src)]` from `src` (ids created after the snapshot are
+// left untouched — they are branch-local and handled within their own scope).
+let restore_prefix: (Array[Int], Array[Int]) -> Int = (dst, src) -> {
+  let mut i = 0
+  while i < Array::length(src) {
+    Array::set(dst, i, Array::get(src, i))
+    i = i + 1
+  }
+  0
+}
+
+let int_max: (Int, Int) -> Int = (a, b) -> {
+  if a > b { a } else { b }
+}
+
+export let rec pc_count: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, expr) -> {
+  match expr {
+    EInt(_) => 0,
+    EFloat(_) => 0,
+    EString(_) => 0,
+    EBool(_) => 0,
+    EUnit => 0,
+    EStringInterp(_) => 0,
+    EIdent(x) => pc_count_use(ctx, scope, x),
+    ECall(callee, args) => {
+      // The callee binding is borrowed (a closure stays live across the call).
+      match callee {
+        EIdent(f) => {
+          // `__index(obj, idx)` borrows the container.
+          if f == "__index" {
+            0
+          } else {
+            pc_count_borrow(ctx, scope, f)
+          }
+        },
+        _ => pc_count(ctx, scope, callee)
+      }
+      let is_index = match callee {
+        EIdent(f) => f == "__index",
+        _ => false
+      }
+      let mut i = 0
+      while i < Array::length(args) {
+        let arg = Array::get(args, i)
+        if is_index && i == 0 {
+          match arg {
+            EIdent(obj) => pc_count_borrow(ctx, scope, obj),
+            _ => pc_count(ctx, scope, arg)
+          }
+        } else {
+          pc_count(ctx, scope, arg)
+        }
+        i = i + 1
+      }
+      0
+    },
+    EDot(obj, _field) => {
+      match obj {
+        EIdent(x) => pc_count_borrow(ctx, scope, x),
+        _ => pc_count(ctx, scope, obj)
+      }
+    },
+    ELet(name, value, body) => {
+      pc_count(ctx, scope, value)
+      let id = pc_declare(ctx, name, is_scalar_expr(value))
+      pc_count(ctx, Map::set(scope, name, id), body)
+    },
+    ELetMut(name, value, body) => {
+      pc_count(ctx, scope, value)
+      let id = pc_declare(ctx, name, is_scalar_expr(value))
+      pc_count(ctx, Map::set(scope, name, id), body)
+    },
+    ELetRec(name, value, body) => {
+      let id = pc_declare(ctx, name, false)
+      let s2 = Map::set(scope, name, id)
+      pc_count(ctx, s2, value)
+      pc_count(ctx, s2, body)
+    },
+    EAssign(_name, value, body) => {
+      pc_count(ctx, scope, value)
+      pc_count(ctx, scope, body)
+    },
+    EAssignOp(_op, _name, value, body) => {
+      pc_count(ctx, scope, value)
+      pc_count(ctx, scope, body)
+    },
+    ESeq(a, b) => {
+      pc_count(ctx, scope, a)
+      pc_count(ctx, scope, b)
+    },
+    EBinOp(_op, l, r) => {
+      pc_count(ctx, scope, l)
+      pc_count(ctx, scope, r)
+    },
+    EUnaryOp(_op, e) => pc_count(ctx, scope, e),
+    ETuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        pc_count(ctx, scope, Array::get(items, i))
+        i = i + 1
+      }
+      0
+    },
+    EArray(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        pc_count(ctx, scope, Array::get(items, i))
+        i = i + 1
+      }
+      0
+    },
+    ERecord(fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        pc_count(ctx, scope, (Array::get(fields, i)).1)
+        i = i + 1
+      }
+      0
+    },
+    EMap(fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        pc_count(ctx, scope, (Array::get(fields, i)).1)
+        i = i + 1
+      }
+      0
+    },
+    EIf(cond, then_e, else_e) => {
+      pc_count(ctx, scope, cond)
+      let snap_u = copy_ints(ctx.uses)
+      let snap_b = copy_ints(ctx.borrows)
+      pc_count(ctx, scope, then_e)
+      let then_u = copy_ints(ctx.uses)
+      let then_b = copy_ints(ctx.borrows)
+      restore_prefix(ctx.uses, snap_u)
+      restore_prefix(ctx.borrows, snap_b)
+      pc_count(ctx, scope, else_e)
+      // Merge outer bindings (ids < snapshot length) as branch-max.
+      let mut id = 0
+      while id < Array::length(snap_u) {
+        let base_u = Array::get(snap_u, id)
+        let dt = Array::get(then_u, id) - base_u
+        let de = Array::get(ctx.uses, id) - base_u
+        Array::set(ctx.uses, id, base_u + int_max(dt, de))
+        let base_b = Array::get(snap_b, id)
+        let dtb = Array::get(then_b, id) - base_b
+        let deb = Array::get(ctx.borrows, id) - base_b
+        Array::set(ctx.borrows, id, base_b + int_max(dtb, deb))
+        id = id + 1
+      }
+      0
+    },
+    EWhile(cond, body) => {
+      pc_count(ctx, scope, cond)
+      pc_count(ctx, scope, body)
+    },
+    EReturn(e) => pc_count(ctx, scope, e),
+    EThrow(e) => pc_count(ctx, scope, e),
+    ESpread(e) => pc_count(ctx, scope, e),
+    ELabeledArg(_l, _n, e) => pc_count(ctx, scope, e),
+    EBreak(opt) => {
+      match opt {
+        Some(e) => pc_count(ctx, scope, e),
+        None => 0
+      }
+    },
+    _ => 0
+  }
+}
+
+// --- emit pass ---
+
+// Declare in lockstep with the count pass and initialise the remaining-owning
+// count. A pure-borrow binding (0 owning uses, >=1 borrow) is given 1 remaining
+// so its scope-end drop fires.
+let pe_declare: (PCtx, String) -> Int = (ctx, _name) -> {
+  let id = ctx.next_id
+  let owning = Array::get(ctx.uses, id)
+  let borrowed = Array::get(ctx.borrows, id)
+  let init = if owning == 0 && borrowed > 0 { 1 } else { owning }
+  Array::push(ctx.remaining, init)
+  ctx.next_id = id + 1
+  id
+}
+
+let pe_push: (PCtx, PerceusActionKind, String) -> Int = (ctx, kind, name) -> {
+  Array::push(ctx.actions, PerceusAction::{ kind, name })
+  0
+}
+
+let pe_use: (PCtx, Map[String, Int], String) -> Int = (ctx, scope, name) -> {
+  if Map::has_key(scope, name) {
+    let id = Map::get(scope, name)
+    let rem = Array::get(ctx.remaining, id)
+    if rem > 1 && !Array::get(ctx.scalar, id) {
+      pe_push(ctx, PaDup, name)
+    } else {
+      0
+    }
+    if rem > 0 {
+      Array::set(ctx.remaining, id, rem - 1)
+    }
+  }
+  0
+}
+
+// Drop a binding leaving scope if it still owns a live reference.
+let pe_scope_end: (PCtx, Int, String) -> Int = (ctx, id, name) -> {
+  if Array::get(ctx.remaining, id) > 0 && !Array::get(ctx.scalar, id) {
+    pe_push(ctx, PaDrop, name)
+    Array::set(ctx.remaining, id, 0)
+  }
+  0
+}
+
+export let rec pc_emit: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, expr) -> {
+  match expr {
+    EInt(_) => 0,
+    EFloat(_) => 0,
+    EString(_) => 0,
+    EBool(_) => 0,
+    EUnit => 0,
+    EStringInterp(_) => 0,
+    EIdent(x) => pe_use(ctx, scope, x),
+    ECall(callee, args) => {
+      // Borrowed callee / `__index` arg0: no consuming use, no action.
+      let is_index = match callee {
+        EIdent(f) => f == "__index",
+        _ => false
+      }
+      match callee {
+        EIdent(_) => 0,
+        _ => pc_emit(ctx, scope, callee)
+      }
+      let mut i = 0
+      while i < Array::length(args) {
+        let arg = Array::get(args, i)
+        if is_index && i == 0 {
+          match arg {
+            EIdent(_) => 0,
+            _ => pc_emit(ctx, scope, arg)
+          }
+        } else {
+          pc_emit(ctx, scope, arg)
+        }
+        i = i + 1
+      }
+      0
+    },
+    EDot(obj, _field) => {
+      match obj {
+        EIdent(_) => 0,
+        _ => pc_emit(ctx, scope, obj)
+      }
+    },
+    ELet(name, value, body) => {
+      pc_emit(ctx, scope, value)
+      let id = pe_declare(ctx, name)
+      pc_emit(ctx, Map::set(scope, name, id), body)
+      pe_scope_end(ctx, id, name)
+    },
+    ELetMut(name, value, body) => {
+      pc_emit(ctx, scope, value)
+      let id = pe_declare(ctx, name)
+      pc_emit(ctx, Map::set(scope, name, id), body)
+      pe_scope_end(ctx, id, name)
+    },
+    ELetRec(name, value, body) => {
+      let id = pe_declare(ctx, name)
+      let s2 = Map::set(scope, name, id)
+      pc_emit(ctx, s2, value)
+      pc_emit(ctx, s2, body)
+      pe_scope_end(ctx, id, name)
+    },
+    EAssign(_name, value, body) => {
+      pc_emit(ctx, scope, value)
+      pc_emit(ctx, scope, body)
+    },
+    EAssignOp(_op, _name, value, body) => {
+      pc_emit(ctx, scope, value)
+      pc_emit(ctx, scope, body)
+    },
+    ESeq(a, b) => {
+      pc_emit(ctx, scope, a)
+      pc_emit(ctx, scope, b)
+    },
+    EBinOp(_op, l, r) => {
+      pc_emit(ctx, scope, l)
+      pc_emit(ctx, scope, r)
+    },
+    EUnaryOp(_op, e) => pc_emit(ctx, scope, e),
+    ETuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        pc_emit(ctx, scope, Array::get(items, i))
+        i = i + 1
+      }
+      0
+    },
+    EArray(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        pc_emit(ctx, scope, Array::get(items, i))
+        i = i + 1
+      }
+      0
+    },
+    ERecord(fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        pc_emit(ctx, scope, (Array::get(fields, i)).1)
+        i = i + 1
+      }
+      0
+    },
+    EMap(fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        pc_emit(ctx, scope, (Array::get(fields, i)).1)
+        i = i + 1
+      }
+      0
+    },
+    EIf(cond, then_e, else_e) => {
+      pc_emit(ctx, scope, cond)
+      let snap = copy_ints(ctx.remaining)
+      pc_emit(ctx, scope, then_e)
+      restore_prefix(ctx.remaining, snap)
+      pc_emit(ctx, scope, else_e)
+      0
+    },
+    EWhile(cond, body) => {
+      pc_emit(ctx, scope, cond)
+      pc_emit(ctx, scope, body)
+    },
+    EReturn(e) => pc_emit(ctx, scope, e),
+    EThrow(e) => pc_emit(ctx, scope, e),
+    ESpread(e) => pc_emit(ctx, scope, e),
+    ELabeledArg(_l, _n, e) => pc_emit(ctx, scope, e),
+    EBreak(opt) => {
+      match opt {
+        Some(e) => pc_emit(ctx, scope, e),
+        None => 0
+      }
+    },
+    _ => 0
+  }
+}
+
+// Build the dup/drop plan for a function body expression.
+export let build_perceus_plan: (Expr) -> Array[PerceusAction] = (body) -> {
+  let ctx = pctx_new()
+  let empty: Map[String, Int] = map {}
+  pc_count(ctx, empty, body)
+  // Reset id allocation; the emit pass re-declares in the same tree order.
+  ctx.next_id = 0
+  pc_emit(ctx, empty, body)
+  ctx.actions
+}

--- a/vibe/compiler/perceus/index.vibe
+++ b/vibe/compiler/perceus/index.vibe
@@ -4,6 +4,10 @@ import .. / core {
   Expr, Pat, TypeExpr
 }
 
+import .. / codegen / common_analysis {
+  collect_free_vars
+}
+
 //# Types
 
 // Perceus RC analysis for the selfhost linear backend.
@@ -101,6 +105,53 @@ let is_scalar_expr: (Expr) -> Bool = (e) -> {
   }
 }
 
+// Names bound by a pattern (for match arms).
+let rec pat_names: (Pat, Array[String]) -> Int = (pat, out) -> {
+  match pat {
+    PBind(name) => {
+      Array::push(out, name)
+      0
+    },
+    PCtor(_n, args) => {
+      let mut i = 0
+      while i < Array::length(args) {
+        pat_names(Array::get(args, i), out)
+        i = i + 1
+      }
+      0
+    },
+    PTuple(pats) => {
+      let mut i = 0
+      while i < Array::length(pats) {
+        pat_names(Array::get(pats, i), out)
+        i = i + 1
+      }
+      0
+    },
+    POr(l, _r) => pat_names(l, out),
+    PStruct(_n, fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        pat_names((Array::get(fields, i)).1, out)
+        i = i + 1
+      }
+      0
+    },
+    _ => 0
+  }
+}
+
+// Value parameter names of an EFn (the `params` array of (name, type?) pairs).
+let fn_param_names: (Array[(String, Option[TypeExpr])]) -> Array[String] = (params) -> {
+  let out: Array[String] = []
+  let mut i = 0
+  while i < Array::length(params) {
+    Array::push(out, (Array::get(params, i)).0)
+    i = i + 1
+  }
+  out
+}
+
 // --- count pass ---
 
 // Declare a binding during the count pass: allocate an id and zeroed counters.
@@ -153,6 +204,16 @@ let restore_prefix: (Array[Int], Array[Int]) -> Int = (dst, src) -> {
 
 let int_max: (Int, Int) -> Int = (a, b) -> {
   if a > b { a } else { b }
+}
+
+let zeros: (Int) -> Array[Int] = (n) -> {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < n {
+    Array::push(out, 0)
+    i = i + 1
+  }
+  out
 }
 
 export let rec pc_count: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, expr) -> {
@@ -305,6 +366,77 @@ export let rec pc_count: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, ex
         Some(e) => pc_count(ctx, scope, e),
         None => 0
       }
+    },
+    EFn(_tp, _tb, params, _ret, _eff, fbody) => {
+      // A closure captures its free variables: each is an owning use of the
+      // outer binding. The body is compiled as its own function (analysed
+      // separately), so we do not recurse into it with the outer scope.
+      let caps = collect_free_vars(fbody, fn_param_names(params), [])
+      let mut i = 0
+      while i < Array::length(caps) {
+        pc_count_use(ctx, scope, Array::get(caps, i))
+        i = i + 1
+      }
+      0
+    },
+    EForIn(value_name, index_opt, iterable, fbody) => {
+      pc_count(ctx, scope, iterable)
+      let idv = pc_declare(ctx, value_name, false)
+      let s2 = Map::set(scope, value_name, idv)
+      let s3 = match index_opt {
+        Some(idx) => {
+          let idi = pc_declare(ctx, idx, true)
+          Map::set(s2, idx, idi)
+        },
+        None => s2
+      }
+      pc_count(ctx, s3, fbody)
+    },
+    EMatch(scrut, arms) => {
+      pc_count(ctx, scope, scrut)
+      let snap_u = copy_ints(ctx.uses)
+      let snap_b = copy_ints(ctx.borrows)
+      let max_u = zeros(Array::length(snap_u))
+      let max_b = zeros(Array::length(snap_b))
+      let mut a = 0
+      while a < Array::length(arms) {
+        let arm = Array::get(arms, a)
+        restore_prefix(ctx.uses, snap_u)
+        restore_prefix(ctx.borrows, snap_b)
+        let pnames: Array[String] = []
+        pat_names(arm.0, pnames)
+        let mut s = scope
+        let mut k = 0
+        while k < Array::length(pnames) {
+          let nm = Array::get(pnames, k)
+          let pid = pc_declare(ctx, nm, false)
+          s = Map::set(s, nm, pid)
+          k = k + 1
+        }
+        pc_count(ctx, s, arm.1)
+        let mut id = 0
+        while id < Array::length(snap_u) {
+          let du = Array::get(ctx.uses, id) - Array::get(snap_u, id)
+          if du > Array::get(max_u, id) {
+            Array::set(max_u, id, du)
+          }
+          let db = Array::get(ctx.borrows, id) - Array::get(snap_b, id)
+          if db > Array::get(max_b, id) {
+            Array::set(max_b, id, db)
+          }
+          id = id + 1
+        }
+        a = a + 1
+      }
+      restore_prefix(ctx.uses, snap_u)
+      restore_prefix(ctx.borrows, snap_b)
+      let mut id2 = 0
+      while id2 < Array::length(snap_u) {
+        Array::set(ctx.uses, id2, Array::get(snap_u, id2) + Array::get(max_u, id2))
+        Array::set(ctx.borrows, id2, Array::get(snap_b, id2) + Array::get(max_b, id2))
+        id2 = id2 + 1
+      }
+      0
     },
     _ => 0
   }
@@ -484,6 +616,58 @@ export let rec pc_emit: (PCtx, Map[String, Int], Expr) -> Int = (ctx, scope, exp
         Some(e) => pc_emit(ctx, scope, e),
         None => 0
       }
+    },
+    EFn(_tp, _tb, params, _ret, _eff, fbody) => {
+      let caps = collect_free_vars(fbody, fn_param_names(params), [])
+      let mut i = 0
+      while i < Array::length(caps) {
+        pe_use(ctx, scope, Array::get(caps, i))
+        i = i + 1
+      }
+      0
+    },
+    EForIn(value_name, index_opt, iterable, fbody) => {
+      pc_emit(ctx, scope, iterable)
+      let idv = pe_declare(ctx, value_name)
+      let s2 = Map::set(scope, value_name, idv)
+      let s3 = match index_opt {
+        Some(idx) => {
+          let idi = pe_declare(ctx, idx)
+          Map::set(s2, idx, idi)
+        },
+        None => s2
+      }
+      pc_emit(ctx, s3, fbody)
+      pe_scope_end(ctx, idv, value_name)
+    },
+    EMatch(scrut, arms) => {
+      pc_emit(ctx, scope, scrut)
+      let snap = copy_ints(ctx.remaining)
+      let mut a = 0
+      while a < Array::length(arms) {
+        let arm = Array::get(arms, a)
+        restore_prefix(ctx.remaining, snap)
+        let pnames: Array[String] = []
+        pat_names(arm.0, pnames)
+        let mut s = scope
+        let pids: Array[Int] = []
+        let mut k = 0
+        while k < Array::length(pnames) {
+          let nm = Array::get(pnames, k)
+          let pid = pe_declare(ctx, nm)
+          s = Map::set(s, nm, pid)
+          Array::push(pids, pid)
+          k = k + 1
+        }
+        pc_emit(ctx, s, arm.1)
+        let mut j = 0
+        while j < Array::length(pids) {
+          pe_scope_end(ctx, Array::get(pids, j), Array::get(pnames, j))
+          j = j + 1
+        }
+        a = a + 1
+      }
+      0
     },
     _ => 0
   }

--- a/vibe/compiler/perceus_rc_test.vibe
+++ b/vibe/compiler/perceus_rc_test.vibe
@@ -199,3 +199,13 @@ test "perceus: match arm pattern binding is dropped" {
   let plan = build_perceus_plan(m)
   assert(count_drops(plan, "p") == 1)
 }
+
+// A handler arm-local pattern binding that is only borrowed is dropped.
+test "perceus: handle arm pattern binding is dropped" {
+  // handle comp { Op(v) => v.0 }
+  let arm1: (Pat, Expr) = (PCtor("Op", [PBind("v")]), EDot(EIdent("v"), "0"))
+  let arms: Array[(Pat, Expr)] = [arm1]
+  let h = EHandle(EIdent("comp"), arms)
+  let plan = build_perceus_plan(h)
+  assert(count_drops(plan, "v") == 1)
+}

--- a/vibe/compiler/perceus_rc_test.vibe
+++ b/vibe/compiler/perceus_rc_test.vibe
@@ -23,6 +23,18 @@ let count_drops: (Array[PerceusAction], String) -> Int = (plan, name) -> {
   n
 }
 
+let count_all_drops: (Array[PerceusAction]) -> Int = (plan) -> {
+  let mut n = 0
+  let mut i = 0
+  while i < Array::length(plan) {
+    if pa_is_drop(Array::get(plan, i)) {
+      n = n + 1
+    }
+    i = i + 1
+  }
+  n
+}
+
 let count_dups: (Array[PerceusAction], String) -> Int = (plan, name) -> {
   let mut n = 0
   let mut i = 0
@@ -148,6 +160,33 @@ test "perceus: closure capture counts as an owning use" {
   assert(count_drops(plan, "g") == 1)
   // t is moved into the closure env (its capture is the consuming use).
   assert(count_drops(plan, "t") == 0)
+}
+
+// A discarded sequenced heap value is reclaimed (A-1b): `mk(); r` where the
+// first call's owned result is thrown away.
+test "perceus: discarded sequenced heap value is dropped" {
+  // (1, 2) ; 7   -- the tuple value is discarded
+  let body = ESeq(ETuple([EInt(1), EInt(2)]), EInt(7))
+  let plan = build_perceus_plan(body)
+  // The discarded tuple is bound to a synthetic name and dropped.
+  assert(count_all_drops(plan) == 1)
+}
+
+// A discarded scalar needs no drop.
+test "perceus: discarded scalar is not dropped" {
+  // 5 ; 7
+  let body = ESeq(EInt(5), EInt(7))
+  let plan = build_perceus_plan(body)
+  assert(count_all_drops(plan) == 0)
+}
+
+// A loop parameter that owns heap and is only borrowed is dropped at scope end.
+test "perceus: loop parameter heap is dropped" {
+  // loop acc = (1, 2) { acc.0 }
+  let params: Array[(String, Expr)] = [("acc", ETuple([EInt(1), EInt(2)]))]
+  let lp = ELoop(params, EDot(EIdent("acc"), "0"))
+  let plan = build_perceus_plan(lp)
+  assert(count_drops(plan, "acc") == 1)
 }
 
 // A match arm-local pattern binding that is only borrowed is dropped per arm.

--- a/vibe/compiler/perceus_rc_test.vibe
+++ b/vibe/compiler/perceus_rc_test.vibe
@@ -1,0 +1,118 @@
+//# Imports
+
+import ./perceus/index.vibe {
+  PerceusAction, build_perceus_plan, pa_is_drop, pa_is_dup
+}
+
+import ./core {
+  Expr
+}
+
+//# Misc
+
+let count_drops: (Array[PerceusAction], String) -> Int = (plan, name) -> {
+  let mut n = 0
+  let mut i = 0
+  while i < Array::length(plan) {
+    let a = Array::get(plan, i)
+    if pa_is_drop(a) && a.name == name {
+      n = n + 1
+    }
+    i = i + 1
+  }
+  n
+}
+
+let count_dups: (Array[PerceusAction], String) -> Int = (plan, name) -> {
+  let mut n = 0
+  let mut i = 0
+  while i < Array::length(plan) {
+    let a = Array::get(plan, i)
+    if pa_is_dup(a) && a.name == name {
+      n = n + 1
+    }
+    i = i + 1
+  }
+  n
+}
+
+// A heap binding only borrowed (field access) is dropped once at scope end.
+test "perceus: pure-borrow binding is dropped once" {
+  // let t = (1, 2); t.0
+  let body = ELet("t", ETuple([EInt(1), EInt(2)]), EDot(EIdent("t"), "0"))
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "t") == 1)
+  assert(count_dups(plan, "t") == 0)
+}
+
+// A binding moved out as the body result is not dropped (ownership transfers).
+test "perceus: moved-out binding is not dropped" {
+  // let t = (1, 2); t
+  let body = ELet("t", ETuple([EInt(1), EInt(2)]), EIdent("t"))
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "t") == 0)
+  assert(count_dups(plan, "t") == 0)
+}
+
+// A scalar binding is never dropped.
+test "perceus: scalar binding is not dropped" {
+  // let n = 5; n + 1   (n borrowed? no — n is an owning use in EBinOp; scalar)
+  let body = ELet("n", EInt(5), EBinOp("+", EIdent("n"), EInt(1)))
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "n") == 0)
+}
+
+// A binding consumed twice (into a tuple) dups once and is not dropped.
+test "perceus: binding used twice owning emits one dup" {
+  // let t = (1, 2); (t, t)
+  let body = ELet(
+    "t",
+    ETuple([EInt(1), EInt(2)]),
+    ETuple([EIdent("t"), EIdent("t")])
+  )
+  let plan = build_perceus_plan(body)
+  assert(count_dups(plan, "t") == 1)
+  assert(count_drops(plan, "t") == 0)
+}
+
+// Calling a binding borrows it, so the closure value is dropped at scope end.
+test "perceus: called binding (closure) is borrowed and dropped" {
+  // let g = (x){ x }; g(1)   — represented with an EFn value
+  let lam = EFn([], [], [("x", None)], None, None, EIdent("x"))
+  let body = ELet("g", lam, ECall(EIdent("g"), [EInt(1)]))
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "g") == 1)
+}
+
+// Nested let where the inner borrows the outer: both dropped at their scopes.
+test "perceus: nested borrow drops both bindings" {
+  // let t = (1, 2); let u = (t.0, 3); u.0
+  let inner = ELet(
+    "u",
+    ETuple([EDot(EIdent("t"), "0"), EInt(3)]),
+    EDot(EIdent("u"), "0")
+  )
+  let body = ELet("t", ETuple([EInt(1), EInt(2)]), inner)
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "t") == 1)
+  assert(count_drops(plan, "u") == 1)
+}
+
+// An if/else with a branch-local heap binding drops it inside the branch scope.
+test "perceus: branch-local heap binding is dropped" {
+  // let s = 0; if true { let t = (1,2); t.0 } else { 5 } ; (body result is the if)
+  let then_e = ELet("t", ETuple([EInt(1), EInt(2)]), EDot(EIdent("t"), "0"))
+  let if_e = EIf(EBool(true), then_e, EInt(5))
+  let plan = build_perceus_plan(if_e)
+  assert(count_drops(plan, "t") == 1)
+}
+
+// A per-iteration heap binding inside a while body is dropped each iteration
+// (structurally, via its ELet scope).
+test "perceus: while-body binding is dropped in the loop" {
+  // while cond { let t = (1, 2); t.0 }
+  let loop_body = ELet("t", ETuple([EInt(1), EInt(2)]), EDot(EIdent("t"), "0"))
+  let while_e = EWhile(EBool(true), loop_body)
+  let plan = build_perceus_plan(while_e)
+  assert(count_drops(plan, "t") == 1)
+}

--- a/vibe/compiler/perceus_rc_test.vibe
+++ b/vibe/compiler/perceus_rc_test.vibe
@@ -5,7 +5,7 @@ import ./perceus/index.vibe {
 }
 
 import ./core {
-  Expr
+  Expr, Pat
 }
 
 //# Misc
@@ -115,4 +115,48 @@ test "perceus: while-body binding is dropped in the loop" {
   let while_e = EWhile(EBool(true), loop_body)
   let plan = build_perceus_plan(while_e)
   assert(count_drops(plan, "t") == 1)
+}
+
+// A for-in element binding only borrowed in the body is dropped per iteration.
+test "perceus: for-in element binding is dropped" {
+  // for x in xs { x.0 }
+  let body = EDot(EIdent("x"), "0")
+  let forin = EForIn("x", None, EIdent("xs"), body)
+  let plan = build_perceus_plan(forin)
+  assert(count_drops(plan, "x") == 1)
+}
+
+// A closure capturing an outer heap binding uses it; the outer binding, only
+// captured (not otherwise consumed), still owns its reference and the capture
+// is its consuming use, so no scope-end drop remains for the captured value.
+test "perceus: closure capture counts as an owning use" {
+  // let t = (1, 2); let g = (x){ t.0 + x }; g(1)
+  // t is captured by g (owning use via capture) -> consumed into the closure
+  // env, so t itself is not separately dropped; g is borrowed by the call and
+  // dropped at scope end.
+  let lam = EFn(
+    [],
+    [],
+    [("x", None)],
+    None,
+    None,
+    EBinOp("+", EDot(EIdent("t"), "0"), EIdent("x"))
+  )
+  let inner = ELet("g", lam, ECall(EIdent("g"), [EInt(1)]))
+  let body = ELet("t", ETuple([EInt(1), EInt(2)]), inner)
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "g") == 1)
+  // t is moved into the closure env (its capture is the consuming use).
+  assert(count_drops(plan, "t") == 0)
+}
+
+// A match arm-local pattern binding that is only borrowed is dropped per arm.
+test "perceus: match arm pattern binding is dropped" {
+  // match s { Some(p) => p.0, _ => 0 }
+  let arm1: (Pat, Expr) = (PCtor("Some", [PBind("p")]), EDot(EIdent("p"), "0"))
+  let arm2: (Pat, Expr) = (PWild, EInt(0))
+  let arms: Array[(Pat, Expr)] = [arm1, arm2]
+  let m = EMatch(EIdent("s"), arms)
+  let plan = build_perceus_plan(m)
+  assert(count_drops(plan, "p") == 1)
 }


### PR DESCRIPTION
## Summary

issue #493 の方向性(wasm-gc をメイン target に据えつつ、**wasm-gc が使えない環境では linear backend の reclamation を Perceus RC に切り替えて first にする**)に向け、Perceus RC を実用レベルへ引き上げる一連の作業。前 PR #496(while-loop の per-iteration leak 修正)の続き。

大きく4本柱:

### 1. nested-block の reclamation を網羅 (A-1 拡張)
`src/` の linear+RC で、nested block 内で確保した heap が drop されず leak していた問題を、構文を横断して解消:
- **for-in** ループ: Perceus 解析の前に for-in を while/Block へ desugar し、解析と codegen が同じ形を見るように(`desugar_for_in_module`)。`Expr::Block` の RC 配線も追加。
- **if/else** 分岐: branch-local heap を分岐内で drop(実行された分岐のみ、他方の未初期化 local を誤 drop しない)。
- **match** arm: arm-local heap を arm 内で drop(if-chain / br_table 両経路)。

各修正に `rc_debug` カウンタでの balance 回帰テストを追加。

### 2. 破棄値の reclamation (A-1b)
非末尾の `Stmt::Expr(e)` を `let __discardN = e` に desugar(`desugar_discarded_stmts`)し、名前に束縛されない所有 heap temporary(無視された呼び出し結果など)を scope-end で回収。借用ケースは use-counting に委譲、発散式(break/continue/return/perform)は除外。

### 3. closure capture の reclamation (A-2)
closure が捕捉した heap がリークしていた問題を2点修正:
- Perceus が call の callee を所有 use として消費していた → **borrow** に変更(closure は call をまたいで生存し scope-end で drop)。
- `rc_has_closure`(RC drop helper の obj_fn 再帰分岐を制御)が span key 不一致で取りこぼしていた → authoritative な funcs リストから導出。

### 4. wasmtime e2e gate + 既存 invalid wasm の修正 (B-1)
- **新 gate** `src/tests/vibe_wasm_rc_e2e_test.mbt`(native 限定、`test-wasm-rc-e2e` タスク): RC 出力を **wasmtime 実機**で実行・結果検証(tuple/while/for-in/if-else/match/closure/array/破棄文 + 1000反復 loop-stress checksum)。
- この gate が**既存の重大バグを発見**: `rc_dup`/`rc_drop` emitter が tag 判定の条件を skip `block` の**外**で計算しており、`br_if` のオペランドが block フレーム外。寛容な in-tree interpreter は許容するが wasmtime は拒否(`expected i32 but nothing on stack`)。**RC はこれまで一度も spec-valid な wasm を生成できていなかった**。4箇所修正。

### 5. selfhost への移植 (D, Phase 2)
- selfhost 調査で前提ブロッカーを発見・記録(`docs/spec/selfhost-rc-port.md`): selfhost linear heap オブジェクトには type-id/length ヘッダが無く、RC の recursive drop に必要なヘッダ追加(Phase 1)が前提。
- **Phase 2(解析パス)を完了**: `vibe/compiler/perceus/index.vibe` に `build_perceus_plan` を vibe で実装(式ベース AST に合わせスコープを構造的に処理)。isolated(source manifest 未登録)で既存ゲート無影響。`test-selfhost-perceus` で **15/15**。covered: literals/EIdent/ECall(callee borrow + `__index`)/EDot/ELet系/ESeq(A-1b)/EBinOp/ETuple/EArray/ERecord/EMap/EIf(branch-max)/EWhile/EFn(capture)/EForIn/EMatch/ELoop/EHandle。残りは cross-branch balancing(配置情報が必要なため Phase 3 へ)。

## 検証

`moon check --deny-warn` clean。
- rc 系 interpreter テスト、eval ファイル、codegen、frontend、runtime_compile すべて green。
- **wasmtime RC e2e gate 10/10**(実機検証)。
- selfhost 解析パス **15/15**(`test-selfhost-perceus`、native vibe CLI 経由)。

## ドキュメント
- `docs/spec/memory-contract.md`: linear/linear+RC/wasm-gc の contract table と gap 一覧を更新(A-1/A-1b/A-2/B-1 を done に)。
- `docs/spec/selfhost-rc-port.md`: selfhost 移植の段階計画(Phase 1 前提ブロッカー、Phase 2 完了、Phase 3/4 の道筋)。

## スコープ外 / follow-up
- selfhost Phase 1(統一ヘッダ、大規模・高リスク)、Phase 3(codegen 配線 + cross-branch balancing)、Phase 4(検証/cutover)。
- src 側の cross-branch balancing、cycle 方針(A-4)、builtin 内部 temporary、backend 自動選択(C/F)。

https://claude.ai/code/session_014bEGeBN27H1nKZe1qL2u6E

---
_Generated by [Claude Code](https://claude.ai/code/session_014bEGeBN27H1nKZe1qL2u6E)_