### PR TITLE
codegen: structural string comparison for `match` literal patterns (closes #521)

### DIFF
--- a/src/codegen/wasm_codegen_control.mbt
+++ b/src/codegen/wasm_codegen_control.mbt
@@ -41,6 +41,92 @@ fn compile_pat_cont(
 }
 
 ///|
+// Structural equality of a string scrutinee (tagged, in `value_idx`) against a
+// string-literal pattern. Leaves i32 (0/1) on the stack. Fixes #521: the
+// previous `emit_i64_eq` compared tagged POINTERS, so a computed scrutinee
+// (e.g. from String::concat) never matched the interned literal. Mirrors the
+// scalar string compare of compile_string_equals_linear (obj_string: len@4,
+// data@8).
+fn emit_pat_string_eq(
+  ctx : CodegenCtx,
+  buf : ByteBuf,
+  value_idx : Int,
+  pat : @core.Pat,
+) -> Unit raise WasmGenError {
+  let a_ptr = alloc_temp_local(ctx)
+  let b_ptr = alloc_temp_local(ctx)
+  let a_len = alloc_temp_local(ctx)
+  let i_local = alloc_temp_local(ctx)
+  let eq_local = alloc_temp_local(ctx)
+  // scrutinee -> untagged ptr
+  emit_local_get(buf, value_idx)
+  emit_untag_ptr_i32(buf)
+  emit_local_set(buf, a_ptr)
+  // pattern literal -> untagged ptr
+  emit_pat_literal(ctx, buf, pat)
+  emit_untag_ptr_i32(buf)
+  emit_local_set(buf, b_ptr)
+  // identical pointers -> equal
+  emit_local_get(buf, a_ptr)
+  emit_local_get(buf, b_ptr)
+  emit_i32_eq(buf)
+  buf.push((4).to_byte()) // if
+  buf.push((127).to_byte()) // result i32
+  emit_i32_const_raw(buf, 1)
+  buf.push((5).to_byte()) // else
+  emit_local_get(buf, a_ptr)
+  emit_i32_load(buf, 4)
+  emit_local_set(buf, a_len)
+  emit_local_get(buf, a_len)
+  emit_local_get(buf, b_ptr)
+  emit_i32_load(buf, 4)
+  emit_i32_eq(buf)
+  buf.push((4).to_byte()) // if (lengths equal)
+  buf.push((127).to_byte()) // result i32
+  emit_i32_const_raw(buf, 1)
+  emit_local_set(buf, eq_local)
+  emit_i32_const_raw(buf, 0)
+  emit_local_set(buf, i_local)
+  emit_block(buf)
+  emit_loop(buf)
+  emit_local_get(buf, i_local)
+  emit_local_get(buf, a_len)
+  emit_i32_lt_s(buf)
+  emit_i32_eqz(buf)
+  emit_br_if(buf, 1)
+  emit_local_get(buf, a_ptr)
+  emit_local_get(buf, i_local)
+  emit_i32_add(buf)
+  emit_i32_load8_u(buf, 8)
+  emit_local_get(buf, b_ptr)
+  emit_local_get(buf, i_local)
+  emit_i32_add(buf)
+  emit_i32_load8_u(buf, 8)
+  emit_i32_eq(buf)
+  emit_i32_eqz(buf)
+  buf.push((4).to_byte()) // if (byte mismatch)
+  buf.push((64).to_byte()) // void
+  emit_i32_const_raw(buf, 0)
+  emit_local_set(buf, eq_local)
+  emit_local_get(buf, a_len)
+  emit_local_set(buf, i_local)
+  buf.push((5).to_byte()) // else
+  emit_local_get(buf, i_local)
+  emit_i32_const_raw(buf, 1)
+  emit_i32_add(buf)
+  emit_local_set(buf, i_local)
+  buf.push((11).to_byte()) // end if (byte)
+  emit_br(buf, 0)
+  emit_end(buf) // loop
+  emit_end(buf) // block
+  emit_local_get(buf, eq_local)
+  buf.push((5).to_byte()) // else (lengths differ)
+  emit_i32_const_raw(buf, 0)
+  buf.push((11).to_byte()) // end if (lengths)
+  buf.push((11).to_byte()) // end if (pointers)
+}
+
+///|
 fn compile_pat_match(
   ctx : CodegenCtx,
   buf : ByteBuf,
@@ -203,10 +289,10 @@ fn compile_pat_match(
         buf.push((11).to_byte())
         adjust_loop_offsets(ctx, -1)
       } else {
-        // Non-js-string mode: compare tagged pointers
-        emit_local_get(buf, value_idx)
-        emit_pat_literal(ctx, buf, pat)
-        emit_i64_eq(buf)
+        // Non-js-string mode: structural string comparison (#521). Comparing
+        // tagged pointers (emit_i64_eq) only matched interned-literal
+        // scrutinees, not computed strings.
+        emit_pat_string_eq(ctx, buf, value_idx, pat)
         buf.push((4).to_byte())
         buf.push((126).to_byte())
         adjust_loop_offsets(ctx, 1)

--- a/src/tests/vibe_wasm_eval_test.mbt
+++ b/src/tests/vibe_wasm_eval_test.mbt
@@ -1951,6 +1951,23 @@ test "vibe wasm eval returns value" {
 }
 
 ///|
+// Regression for #521: `match s { "lit" => ... }` must compare by content, not
+// by tagged pointer, so a COMPUTED scrutinee (here from String::concat) matches
+// the interned literal pattern.
+test "vibe wasm eval: match on computed string compares by content (#521)" {
+  let src =
+    #|let classify = (s: String) -> Int { match s { "ab" => 1, _ => 0 } }
+    #|let computed = String::concat("a", "b")
+    #|classify(computed)
+  let res = try eval_run(src) catch {
+    e => fail(e.to_string())
+  } noraise {
+    r => r
+  }
+  assert_eq(decode_int(res.value), 1L)
+}
+
+///|
 test "vibe wasm export _start returns raw int" {
   let db = VibeDb::new()
   db.set_source("main", "42")


### PR DESCRIPTION
Fixes #521.

## Bug

In the linear-memory backend, `match s { "lit" => ... }` compiled the arm test as `emit_i64_eq` on the two **tagged string pointers**. That only matches when the scrutinee is the *same interned literal* constant; a **computed** string (from `String::concat`, parsing, or returned across calls) has a different heap pointer with identical content, so it never matched and fell through to the wildcard arm. (The js-string backend already used `js_equals` correctly.)

Minimal repro (was failing):
```vibe
let classify = (s: String) -> Int { match s { "ab" => 1, _ => 0 } }
let computed = String::concat("a", "b")
classify(computed)   // returned 0, should be 1
```

## Fix

`src/codegen/wasm_codegen_control.mbt`: replace the pointer compare in the `Pat::String` arm (non-js mode) with a **structural byte-wise comparison** (`emit_pat_string_eq`), mirroring the scalar path of `compile_string_equals_linear` (`obj_string`: len@4, data@8). The identical-pointer fast path is retained.

## Impact

This was the root cause behind the selfhost `lookup_io` builtin tables silently resolving to `None` (PR #520 worked around it with `if name == ...` chains). With this fix, `match name { "Ns::method" => ... }` and `canonical_builtin_name` work correctly again — the workaround is no longer required (left in place; no churn).

## Tests

- New wasm-eval regression test (`match` on a `String::concat` result) in `src/tests/vibe_wasm_eval_test.mbt`.
- `moon test`: **1373/1373**.
- selfhost bootstrap: deterministic (346s) — host recompiles the selfhost with the new codegen.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8JZgaLgD9oZ7WiLR6J57m)_