### PR TITLE
ci(selfhost): wire peak-RSS gate into selfhost-perf-kpi (#402)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1031,6 +1031,15 @@ jobs:
         # `MAX_CHECK_RATIO=8.5`.
         run: VIBE_SELFHOST_PERF_RUNS=3 VIBE_SELFHOST_PERF_MAX_COMPILE_RATIO=1.5 VIBE_SELFHOST_PERF_MAX_CHECK_RATIO=1.0 VIBE_SELFHOST_PERF_CASES_FILE=bench/selfhost_perf/kpi_cases.txt scripts/bench_selfhost_perf.sh
 
+      # Peak-RSS gate (#402). Reuses this job's release VIBE_BIN + MOONRUN_WT_BIN;
+      # AOT-precompiles the stage1 wasm and compares selfhost vs host peak RSS
+      # (getrusage) for compile/check on the KPI cases. Local: compile 1.01x /
+      # check 0.76x; cap 2.0x is generous (RSS is stable) to absorb CI variance.
+      - name: Run selfhost peak-RSS gate (wasmtime-AOT)
+        env:
+          VIBE_SELFHOST_RSS_MAX_RATIO: '2.0'
+        run: scripts/bench_selfhost_rss.sh --gate
+
       - name: Save stage1 cwasm cache
         if: always() && steps.cwasm-cache-kpi.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5

--- a/scripts/bench_selfhost_rss.sh
+++ b/scripts/bench_selfhost_rss.sh
@@ -47,8 +47,12 @@ mkdir -p "$OUT_DIR/tmp"
 command -v python3 >/dev/null 2>&1 || { echo "bench-selfhost-rss: python3 required" >&2; exit 2; }
 
 # --- ensure binaries ---
-VIBE_CLI_RELEASE=1 source "$PROJECT_ROOT/scripts/ensure_native_cli.sh"
-VIBE_BIN="${VIBE_BIN:-$VIBE_CLI_BIN}"
+# Reuse a caller-provided release CLI (e.g. CI's downloaded artifact) instead of
+# rebuilding it; only fall back to ensure_native_cli.sh when VIBE_BIN is unset.
+if [ -z "${VIBE_BIN:-}" ] || [ ! -x "${VIBE_BIN:-/nonexistent}" ]; then
+  VIBE_CLI_RELEASE=1 source "$PROJECT_ROOT/scripts/ensure_native_cli.sh"
+  VIBE_BIN="${VIBE_BIN:-$VIBE_CLI_BIN}"
+fi
 
 build_wasm() {
   local pkg="$1" out="$2"


### PR DESCRIPTION
Makes the selfhost peak-RSS measurement (#523) a standing CI gate.

## Change

- **`.github/workflows/ci.yml`**: adds a `Run selfhost peak-RSS gate (wasmtime-AOT)` step to the existing **`selfhost-perf-kpi`** job. That job already downloads the release CLI (`VIBE_BIN`) and `moonrun_wt` (`MOONRUN_WT_BIN`), so the step just runs `scripts/bench_selfhost_rss.sh --gate` (cap `VIBE_SELFHOST_RSS_MAX_RATIO=2.0`). Peak RSS now gates alongside the existing compile/check ratio gates.
- **`scripts/bench_selfhost_rss.sh`**: reuses a caller-provided `VIBE_BIN` instead of rebuilding the release CLI, so the CI step uses the downloaded artifact (no redundant build).

## Verification

- `ci.yml` parses (YAML lint).
- Local `bench_selfhost_rss.sh --gate`: compile **1.01×** / check **0.76×** (both ≤ 2.0× ✅), in both the build-CLI path and the preset-`VIBE_BIN` (CI-simulated) path.

The 2.0× cap matches #402's stated peak-RSS gate; it's generous on purpose (RSS is stable, but absorbs CI variance). With this, all four selfhost-cutover gates run in CI: TOTAL compile ≤2.5×, TOTAL check ≤1.33×, **peak RSS ≤2.0×**, corpus `check`-parity REAL=0.

Refs #402

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8JZgaLgD9oZ7WiLR6J57m)_