### PR TITLE
selfhost: release-asset から MoonBit host build なしで bootstrap 可能にする

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -223,6 +223,15 @@ local releaseTagPreflight = new Task {
   inputs { ...moonSources; ...scriptSources }
 }
 
+local fetchSelfhostCompiler = new Task {
+  name = "fetch-selfhost-compiler"
+  description = "download + verify the selfhost compiler release asset (no MoonBit host build needed)"
+  cmd = "bash scripts/fetch_selfhost_compiler.sh $@"
+  acceptsArgs = true
+  cache = false
+  inputs { "scripts/fetch_selfhost_compiler.sh" }
+}
+
 local buildSelfhostDist = new Task {
   name = "build-selfhost-dist"
   cmd = "bash scripts/build_selfhost_dist.sh"
@@ -1455,6 +1464,7 @@ tasks {
   buildWasmVibe
   buildReleaseAssets
   releaseTagPreflight
+  fetchSelfhostCompiler
   buildSelfhostDist
   buildSelfhostDistRaw
   buildSelfhostDistGc

--- a/bench/selfhost_perf/README.md
+++ b/bench/selfhost_perf/README.md
@@ -498,3 +498,67 @@ selfhost compiler:
    remains `wasm-opt -O3` (already wired) and the moonrun → wasmtime
    AOT switch (blocked on WASI binding reshape), not algorithmic
    improvements.
+
+## Linked-build `contains_name` / `contains_path` scans (#533)
+
+`#533` re-opened the question of the linear `contains_name`
+(`vibe/compiler/entry/source_compile/wasi_only/linked_helpers.vibe`,
+3 sites) and `contains_path`
+(`.../linked_artifacts.vibe`, 2 sites) scans that the linked-build
+path uses to filter re-exported names and to dedup direct dependency
+paths. Both delegate to helpers in `vibe/compiler/module_graph_path.vibe`.
+
+**Re-classification (matches the #366 survey verdict).**
+
+- `contains_name`: bounded by one re-export selection (`wanted_names`,
+  ≈1–5 names) scanned once per pub statement of one source file —
+  per-module, not whole-program. #366 measured ≈5–150 ops.
+- `contains_path`: bounded by one entry file's unique imports
+  (D ≈ 5–30), so the dedup is `O(D²)` with small D (≤ ~900 ops in
+  #366's survey).
+
+Both are dominated by the surrounding `Fs::ReadFile` + `lex` + `parse`
+of the very same files, so the string-equality scans are not the
+linked-build hotspot.
+
+**Why we do not change the algorithm.**
+
+1. **`Map[String, Bool]` is a no-op.** The selfhost runtime emits
+   `Map::has_key`/`Map::get` as linear searches
+   (`wasm_codegen_builtin_collection.mbt`); the dedicated runtime
+   upgrade issue (#395) was closed *not-planned*. See the
+   "String-keyed lookup" postmortem above.
+2. **Sorted index + binary search does not help** — per-comparison
+   cost is still a string-equality walk and D/W are small enough that
+   constant factors dominate (same conclusion as the `resolve_func`
+   postmortem above).
+3. **A custom hash-bucket (`StrIntIndex`) does not pay rent.** The
+   reverted experiment above showed a real 4–5× microbench win that
+   did not translate to measurable selfhost wallclock at any workload
+   size we can exercise.
+4. **Sort + merge dedup of `dep_paths` is unsafe, not merely low-ROI.**
+   The dedup must preserve first-occurrence order: `dep_paths` order
+   flows into `linked_imports`, which `compile_wasi_module_linked_impl`
+   (`vibe/compiler/codegen/wasi/linked_compile.vibe`) turns into wasm
+   import-section indices and emission order. Reordering would change
+   the emitted binary and break selfhost reproducibility/parity. This
+   rules out the "input order normalization / sort + merge" option from
+   the #533 scope on correctness grounds.
+
+**Decision: keep the linear scans, order-preserving, as-is.** The
+sites are now annotated with these bounds and the reorder hazard in
+`module_graph_path.vibe` and `linked_artifacts.vibe` so a future
+contributor does not re-attempt the unsafe sort+merge. The only path
+that would help every string-keyed scan at once is upgrading the
+runtime `Map` to a hash table (#395, not-planned); until then there is
+no bounded improvement to make here without regressing the binary or
+the build.
+
+**Verification used:** static re-read of the call sites and the
+`linked_imports` → wasm import-index data flow. The selfhost gates
+(`scripts/bench_selfhost_perf.sh --gate`,
+`scripts/bench_selfhost_compile_hotspots.sh bundle`,
+`pkf run selfhost-gate`) require the MoonBit toolchain to build the
+stage compiler and were not re-run in this doc-only/comment-only
+change; the change is behavior-preserving (comments + markdown), so
+the compile/check KPI cannot regress.

--- a/docs/selfhost-bootstrap.md
+++ b/docs/selfhost-bootstrap.md
@@ -99,6 +99,48 @@ bootstrap bump は最低限、以下を満たす。
 つまり「新機能を実装する commit」と「compiler source が新機能を使い始める
 commit」は分ける。これにより、常に固定 seed から HEAD を復元できる。
 
+## Release asset からの bootstrap (MoonBit host build なし)
+
+selfhost を「保証」するには、stage0 -> stage1 -> stage2 を **MoonBit host を
+ビルドせずに** 回せる必要がある。完全な registry (mooncakes) と native build が
+無い環境 (web/remote container 等) では `moon build src/cmd/vibe` が通らず、
+従来は flatten 工程 (`emit-module-source`) が host `vibe.exe` に依存していた。
+
+これを解消するため、selfhost に必要な 2 つの prebuilt artifact を
+**GitHub Release asset** として配布し、pull して使えるようにする。
+
+- `vibe-selfhost-<tag>.wasm` — stage0 seed compiler wasm。stock wasmtime で
+  instantiate でき、`moonrun` 上で `cli_main` として動く。中身は
+  `bootstrap/selfhost/seed/selfhost_compiler.wasm` (seed.json で sha256 pin)。
+- `vibe-selfhost-module-source-<tag>.vibe` — flatten 済みの flat module source。
+  `emit-module-source` の出力 (= committed compiler source からの決定的関数) を
+  pin したもの。これがあれば flatten で host `vibe.exe` を呼ばない。
+- `vibe-selfhost-seed-<tag>.json` / `release-manifest.json` / `SHA256SUMS.txt` —
+  provenance と整合性メタデータ。manifest の `selfhost` block に各 asset の
+  sha256 と `source_commit` が入る。
+
+publish は `scripts/build_release_assets.sh`、取得は
+`scripts/fetch_selfhost_compiler.sh` (`pkf run fetch-selfhost-compiler`)。
+
+```bash
+# release から pull + sha256 検証し、prebuilt module source の env を出す
+eval "$(pkf run fetch-selfhost-compiler -- <tag> --print-env)"
+# MoonBit host build を一切せず stage0 -> stage1 -> stage2 を回す
+bash scripts/selfhost_generations.sh build
+```
+
+`scripts/selfhost_generations.sh` の `prepare_flat_cli_source` は
+`VIBE_SELFHOST_PREBUILT_MODULE_SOURCE`(+ optional `..._SHA256`)が指定されると
+regeneration を skip して pull 済み flat source を使う。未指定時の挙動
+(host `vibe.exe` で regenerate) は不変。
+
+freshness 契約: prebuilt flat source は **対応する source commit / tag 専用**。
+HEAD 開発で compiler source を変えた場合は stale になるため、その場合は
+従来どおり host `vibe.exe` で regenerate する。stale な artifact を使うと
+flat source が現在の source と食い違い、stage1/stage2 parity 失敗として
+顕在化する (fetch 側は manifest の `source_commit` を、`--adopt-seed` 時は
+`seed.json` の sha256 を突き合わせて誤用を弾く)。
+
 ## Layer split
 
 cutover 後も runner と compiler artifact は分ける。

--- a/scripts/build_release_assets.sh
+++ b/scripts/build_release_assets.sh
@@ -4,6 +4,23 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "release-assets: sha256sum or shasum is required" >&2
+    exit 1
+  fi
+}
+
+json_string_field() {
+  # naive extractor: first "<field>": "<value>" occurrence in file $1
+  grep -o "\"$2\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$1" | head -1 \
+    | sed -E "s/.*:[[:space:]]*\"([^\"]*)\".*/\1/"
+}
+
 usage() {
   echo "usage: $0 <tag|version>" >&2
   echo "example: $0 v0.0.1" >&2
@@ -56,6 +73,61 @@ echo "[release-assets] smoke testing wasm/vibe/vibe.wasm"
 cp "$PROJECT_ROOT/wasm/vibe/vibe.wasm" "$OUT_DIR/$WASM_NAME"
 cp "$PROJECT_ROOT/wasm/vibe/README.md" "$OUT_DIR/$README_NAME"
 
+# --- selfhost compiler artifacts ---------------------------------------
+# Unlike vibe-<tag>.wasm (the MoonBit-host lib, which needs moonbit fs
+# host imports), these run the *selfhost* compiler and let a consumer
+# bootstrap the stage0 -> stage1 -> stage2 build WITHOUT building the
+# MoonBit host from the mooncakes registry. See
+# scripts/fetch_selfhost_compiler.sh and docs/selfhost-bootstrap.md.
+#   - vibe-selfhost-<tag>.wasm           : stage0 seed compiler wasm
+#                                          (instantiates under stock
+#                                           wasmtime, runs under moonrun)
+#   - vibe-selfhost-module-source-<tag>.vibe : prebuilt flat module
+#                                          source (emit-module-source
+#                                          output for the seed entry),
+#                                          so the flatten step needs no
+#                                          host vibe.exe
+#   - vibe-selfhost-seed-<tag>.json      : seed provenance manifest
+SELFHOST_WASM_NAME="vibe-selfhost-$TAG.wasm"
+SELFHOST_MODSRC_NAME="vibe-selfhost-module-source-$TAG.vibe"
+SELFHOST_SEED_JSON_NAME="vibe-selfhost-seed-$TAG.json"
+
+seed_src="$PROJECT_ROOT/bootstrap/selfhost/seed/selfhost_compiler.wasm"
+seed_json="$PROJECT_ROOT/bootstrap/selfhost/seed.json"
+[ -f "$seed_src" ] || { echo "release-assets: selfhost seed wasm missing: $seed_src" >&2; exit 1; }
+[ -f "$seed_json" ] || { echo "release-assets: selfhost seed.json missing: $seed_json" >&2; exit 1; }
+
+# Guard: the committed seed wasm must match its pinned manifest sha256.
+pinned_seed_sha="$(json_string_field "$seed_json" sha256)"
+actual_seed_sha="$(sha256_file "$seed_src")"
+if [ -n "$pinned_seed_sha" ] && [ "$pinned_seed_sha" != "$actual_seed_sha" ]; then
+  echo "release-assets: selfhost seed sha256 mismatch (manifest=$pinned_seed_sha actual=$actual_seed_sha)" >&2
+  exit 1
+fi
+seed_source_commit="$(json_string_field "$seed_json" source_commit)"
+seed_entry="$(json_string_field "$seed_json" entry)"
+seed_entry_name="$(json_string_field "$seed_json" entry_name)"
+
+echo "[release-assets] generating prebuilt flat selfhost module source"
+sh_tmp="$(mktemp -d)"
+if ! VIBE_SELFHOST_BUNDLE_OUT="$sh_tmp/selfhost_sources_bundle.vibe" \
+  VIBE_SELFHOST_ADAPTER_BUNDLE_OUT="$sh_tmp/selfhost_cli_adapter_bundle.vibe" \
+  VIBE_SELFHOST_RUNTIME_ENTRY_BUNDLE_OUT="$sh_tmp/selfbuild_runtime_entry_bundle.vibe" \
+  VIBE_SELFHOST_ADAPTER_MODULE_SOURCE_OUT="$OUT_DIR/$SELFHOST_MODSRC_NAME" \
+  bash "$PROJECT_ROOT/scripts/generate_selfhost_bundle.sh" >"$sh_tmp/gen.log" 2>&1; then
+  cat "$sh_tmp/gen.log" >&2
+  echo "release-assets: selfhost module source generation failed" >&2
+  exit 1
+fi
+[ -s "$OUT_DIR/$SELFHOST_MODSRC_NAME" ] || {
+  echo "release-assets: selfhost module source not produced" >&2; exit 1; }
+
+cp "$seed_src" "$OUT_DIR/$SELFHOST_WASM_NAME"
+cp "$seed_json" "$OUT_DIR/$SELFHOST_SEED_JSON_NAME"
+
+selfhost_wasm_sha="$(sha256_file "$OUT_DIR/$SELFHOST_WASM_NAME")"
+selfhost_modsrc_sha="$(sha256_file "$OUT_DIR/$SELFHOST_MODSRC_NAME")"
+
 commit_sha="$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || true)"
 cat > "$OUT_DIR/$MANIFEST_NAME" <<EOF
 {
@@ -64,17 +136,38 @@ cat > "$OUT_DIR/$MANIFEST_NAME" <<EOF
   "commit": "$commit_sha",
   "artifacts": [
     "$WASM_NAME",
-    "$README_NAME"
-  ]
+    "$README_NAME",
+    "$SELFHOST_WASM_NAME",
+    "$SELFHOST_MODSRC_NAME",
+    "$SELFHOST_SEED_JSON_NAME"
+  ],
+  "selfhost": {
+    "compiler_wasm": "$SELFHOST_WASM_NAME",
+    "compiler_wasm_sha256": "$selfhost_wasm_sha",
+    "module_source": "$SELFHOST_MODSRC_NAME",
+    "module_source_sha256": "$selfhost_modsrc_sha",
+    "seed_manifest": "$SELFHOST_SEED_JSON_NAME",
+    "source_commit": "$seed_source_commit",
+    "entry": "$seed_entry",
+    "entry_name": "$seed_entry_name",
+    "runtime": {
+      "runner": "moonrun",
+      "wasmtime_flags": "unknown-imports-default=y exceptions=y"
+    }
+  }
 }
 EOF
 
 (
   cd "$OUT_DIR"
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$WASM_NAME" "$README_NAME" "$MANIFEST_NAME" > "$CHECKSUM_NAME"
+    sha256sum "$WASM_NAME" "$README_NAME" "$SELFHOST_WASM_NAME" \
+      "$SELFHOST_MODSRC_NAME" "$SELFHOST_SEED_JSON_NAME" "$MANIFEST_NAME" \
+      > "$CHECKSUM_NAME"
   else
-    shasum -a 256 "$WASM_NAME" "$README_NAME" "$MANIFEST_NAME" > "$CHECKSUM_NAME"
+    shasum -a 256 "$WASM_NAME" "$README_NAME" "$SELFHOST_WASM_NAME" \
+      "$SELFHOST_MODSRC_NAME" "$SELFHOST_SEED_JSON_NAME" "$MANIFEST_NAME" \
+      > "$CHECKSUM_NAME"
   fi
 )
 
@@ -82,5 +175,8 @@ echo "[release-assets] staged assets:"
 printf '  %s\n' \
   "$OUT_DIR/$WASM_NAME" \
   "$OUT_DIR/$README_NAME" \
+  "$OUT_DIR/$SELFHOST_WASM_NAME" \
+  "$OUT_DIR/$SELFHOST_MODSRC_NAME" \
+  "$OUT_DIR/$SELFHOST_SEED_JSON_NAME" \
   "$OUT_DIR/$MANIFEST_NAME" \
   "$OUT_DIR/$CHECKSUM_NAME"

--- a/scripts/fetch_selfhost_compiler.sh
+++ b/scripts/fetch_selfhost_compiler.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch the selfhost compiler artifacts published as GitHub release assets
+# and verify them by sha256. This lets a constrained environment bootstrap
+# the selfhost stage0 -> stage1 -> stage2 build WITHOUT building the
+# MoonBit host compiler from the mooncakes registry.
+#
+# Published by scripts/build_release_assets.sh (release.yml on tag push):
+#   - vibe-selfhost-<tag>.wasm                : stage0 seed compiler wasm
+#   - vibe-selfhost-module-source-<tag>.vibe  : prebuilt flat module source
+#   - vibe-selfhost-seed-<tag>.json           : seed provenance manifest
+#   - release-manifest.json / SHA256SUMS.txt  : integrity metadata
+#
+# Usage:
+#   scripts/fetch_selfhost_compiler.sh <tag> [options]
+#
+# Options:
+#   --out-dir DIR        Place artifacts here
+#                        (default: _build/selfhost/release/<tag>)
+#   --adopt-seed         Also copy the compiler wasm to the in-repo seed
+#                        path (bootstrap/selfhost/seed/selfhost_compiler.wasm)
+#                        after verifying it matches bootstrap/selfhost/seed.json
+#   --no-module-source   Skip the prebuilt flat module source
+#   --base-url URL       Override the release download base URL
+#                        (default: https://github.com/mizchi/vibe-lang/releases/download/<tag>)
+#   --from-dir DIR       Read assets from a local staged directory instead
+#                        of downloading (for testing / air-gapped mirrors)
+#   --print-env          Print shell exports wiring the prebuilt module
+#                        source into scripts/selfhost_generations.sh
+#
+# After a successful fetch with --print-env, the generation can run with
+# no MoonBit host build:
+#   eval "$(scripts/fetch_selfhost_compiler.sh <tag> --print-env)"
+#   bash scripts/selfhost_generations.sh build
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="${VIBE_PROJECT_ROOT:-$(dirname "$SCRIPT_DIR")}"
+
+die() { echo "fetch-selfhost-compiler: $*" >&2; exit 1; }
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    die "sha256sum or shasum is required"
+  fi
+}
+
+TAG=""
+OUT_DIR=""
+ADOPT_SEED=0
+WANT_MODULE_SOURCE=1
+BASE_URL=""
+FROM_DIR=""
+PRINT_ENV=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out-dir) OUT_DIR="$2"; shift 2 ;;
+    --adopt-seed) ADOPT_SEED=1; shift ;;
+    --no-module-source) WANT_MODULE_SOURCE=0; shift ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --from-dir) FROM_DIR="$2"; shift 2 ;;
+    --print-env) PRINT_ENV=1; shift ;;
+    -h|--help) sed -n '3,46p' "$0"; exit 0 ;;
+    -*) die "unknown option: $1" ;;
+    *)
+      if [ -z "$TAG" ]; then TAG="$1"; else die "unexpected argument: $1"; fi
+      shift ;;
+  esac
+done
+
+[ -n "$TAG" ] || die "missing <tag> (e.g. v0.0.1)"
+case "$TAG" in v*) : ;; *) TAG="v$TAG" ;; esac
+
+[ -n "$OUT_DIR" ] || OUT_DIR="$PROJECT_ROOT/_build/selfhost/release/$TAG"
+[ -n "$BASE_URL" ] || BASE_URL="https://github.com/mizchi/vibe-lang/releases/download/$TAG"
+mkdir -p "$OUT_DIR"
+
+# Fetch one asset into $OUT_DIR (download or local copy).
+fetch_asset() {
+  local name="$1"
+  local dest="$OUT_DIR/$name"
+  if [ -n "$FROM_DIR" ]; then
+    [ -f "$FROM_DIR/$name" ] || die "asset not found in --from-dir: $FROM_DIR/$name"
+    cp "$FROM_DIR/$name" "$dest"
+  else
+    local url="$BASE_URL/$name"
+    echo "[fetch] $url" >&2
+    local attempt=0 delay=2
+    until curl -fsSL --max-time 120 -o "$dest" "$url"; do
+      attempt=$((attempt + 1))
+      [ "$attempt" -ge 4 ] && die "download failed after retries: $url"
+      sleep "$delay"; delay=$((delay * 2))
+    done
+  fi
+  printf '%s\n' "$dest"
+}
+
+manifest="$(fetch_asset release-manifest.json)"
+
+# Parse the selfhost block with python3 (present in CI and dev shells).
+read_manifest() {
+  python3 - "$manifest" "$1" <<'PY'
+import json, sys
+path, key = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+node = data.get("selfhost") or {}
+cur = node
+for part in key.split("."):
+    if isinstance(cur, dict) and part in cur:
+        cur = cur[part]
+    else:
+        cur = ""
+        break
+print(cur if isinstance(cur, str) else json.dumps(cur))
+PY
+}
+
+compiler_wasm_name="$(read_manifest compiler_wasm)"
+compiler_wasm_sha="$(read_manifest compiler_wasm_sha256)"
+module_source_name="$(read_manifest module_source)"
+module_source_sha="$(read_manifest module_source_sha256)"
+seed_manifest_name="$(read_manifest seed_manifest)"
+source_commit="$(read_manifest source_commit)"
+
+[ -n "$compiler_wasm_name" ] || die "release $TAG has no selfhost assets in release-manifest.json. \
+The release must be built with the updated scripts/build_release_assets.sh."
+
+verify_sha() {
+  local file="$1" want="$2"
+  [ -n "$want" ] || { echo "[fetch] (no pinned sha for $(basename "$file"), skipping verify)" >&2; return 0; }
+  local got; got="$(sha256_file "$file")"
+  [ "$got" = "$want" ] || die "sha256 mismatch for $(basename "$file"): got=$got want=$want"
+  echo "[fetch] verified $(basename "$file") sha256=$got" >&2
+}
+
+compiler_wasm="$(fetch_asset "$compiler_wasm_name")"
+verify_sha "$compiler_wasm" "$compiler_wasm_sha"
+
+module_source=""
+if [ "$WANT_MODULE_SOURCE" = "1" ] && [ -n "$module_source_name" ]; then
+  module_source="$(fetch_asset "$module_source_name")"
+  verify_sha "$module_source" "$module_source_sha"
+fi
+
+if [ -n "$seed_manifest_name" ]; then
+  fetch_asset "$seed_manifest_name" >/dev/null || true
+fi
+
+if [ "$ADOPT_SEED" = "1" ]; then
+  seed_json="$PROJECT_ROOT/bootstrap/selfhost/seed.json"
+  seed_path="$PROJECT_ROOT/bootstrap/selfhost/seed/selfhost_compiler.wasm"
+  if [ -f "$seed_json" ]; then
+    pinned="$(grep -o '"sha256"[[:space:]]*:[[:space:]]*"[0-9a-f]*"' "$seed_json" | head -1 \
+      | sed -E 's/.*"([0-9a-f]+)".*/\1/')"
+    got="$(sha256_file "$compiler_wasm")"
+    [ -z "$pinned" ] || [ "$pinned" = "$got" ] || \
+      die "--adopt-seed refused: fetched wasm sha256=$got does not match bootstrap/selfhost/seed.json pinned=$pinned (tag/source mismatch)"
+  fi
+  mkdir -p "$(dirname "$seed_path")"
+  cp "$compiler_wasm" "$seed_path"
+  echo "[fetch] adopted seed -> $seed_path" >&2
+fi
+
+echo "[fetch] selfhost compiler artifacts ready in $OUT_DIR (source_commit=$source_commit)" >&2
+
+if [ "$PRINT_ENV" = "1" ]; then
+  if [ -n "$module_source" ]; then
+    printf 'export VIBE_SELFHOST_PREBUILT_MODULE_SOURCE=%q\n' "$module_source"
+    printf 'export VIBE_SELFHOST_PREBUILT_MODULE_SOURCE_SHA256=%q\n' "$module_source_sha"
+  else
+    echo "# (no module source fetched; flatten will fall back to host vibe.exe)" >&2
+  fi
+fi

--- a/scripts/selfhost_generations.sh
+++ b/scripts/selfhost_generations.sh
@@ -305,6 +305,37 @@ use_flat_cli_source() {
 prepare_flat_cli_source() {
   local out_dir="$1"
   local out="$out_dir/selfhost_cli_adapter_module_source.vibe"
+  # Decoupling hook (#533 follow-up / selfhost release-asset bootstrap):
+  # the flat module source is a deterministic function of the committed
+  # compiler source. Regenerating it requires the MoonBit-built host
+  # `vibe.exe` (via emit-module-source), which in turn needs the full
+  # mooncakes registry. In a constrained environment that prebuilt flat
+  # source can instead be PULLED from a release asset (see
+  # scripts/fetch_selfhost_compiler.sh) and supplied here, so the seed ->
+  # stage1 -> stage2 build needs no MoonBit host build at all.
+  #
+  #   VIBE_SELFHOST_PREBUILT_MODULE_SOURCE         path to prebuilt source
+  #   VIBE_SELFHOST_PREBUILT_MODULE_SOURCE_SHA256  optional integrity check
+  #
+  # The caller is responsible for matching the prebuilt source to the
+  # configured seed's source commit; a mismatch is a stale-artifact error,
+  # surfaced as a stage1/stage2 parity failure downstream.
+  local prebuilt="${VIBE_SELFHOST_PREBUILT_MODULE_SOURCE:-}"
+  if [ -n "$prebuilt" ]; then
+    [ -s "$prebuilt" ] || die "prebuilt module source not found or empty: $prebuilt"
+    local want_sha="${VIBE_SELFHOST_PREBUILT_MODULE_SOURCE_SHA256:-}"
+    if [ -n "$want_sha" ]; then
+      local got_sha
+      got_sha="$(sha256_file "$prebuilt")"
+      [ "$got_sha" = "$want_sha" ] || \
+        die "prebuilt module source sha256 mismatch: got=$got_sha want=$want_sha"
+    fi
+    mkdir -p "$out_dir"
+    cp "$prebuilt" "$out"
+    echo "[selfhost-gen] use prebuilt flat selfhost compiler source: $prebuilt" >&2
+    printf '%s\n' "$out"
+    return 0
+  fi
   local generator="$PROJECT_ROOT/scripts/generate_selfhost_bundle.sh"
   [ -f "$generator" ] || die "selfhost bundle generator not found: $generator"
   local bundle_tmp="$out_dir/.selfhost_bundle"

--- a/vibe/compiler/entry/source_compile/wasi_only/linked_artifacts.vibe
+++ b/vibe/compiler/entry/source_compile/wasi_only/linked_artifacts.vibe
@@ -58,6 +58,11 @@ let append_stmt_array: (Array[Stmt], Array[Stmt]) -> Unit = (dst, src) -> {
   }
 }
 
+// Dedup is via `contains_path` (linear, see module_graph_path.vibe). The
+// dedup MUST preserve first-occurrence order: `dep_paths` order flows
+// into `linked_imports` and then into wasm import-section indices, so a
+// sort/reorder here would change the emitted binary. D (a single entry's
+// unique imports) is small, so the O(D^2) scan is bounded (#533, #366).
 let collect_direct_dep_paths: (Array[Stmt], String) -> Array[String] = (entry_stmts, entry_dir) -> {
   let dep_paths = Array::slice([
     ""

--- a/vibe/compiler/module_graph_path.vibe
+++ b/vibe/compiler/module_graph_path.vibe
@@ -11,6 +11,15 @@ export let dir_of_path: (String) -> String = (file_path) -> {
   }
 }
 
+// Linear membership scan used by `resolve_reexport_chain` to filter
+// re-exported names. Bounded per-module, not whole-program: `items`
+// (`wanted_names`) is a single re-export selection (typically 1-5 names)
+// and it is scanned once per pub statement of one source file. The
+// original O(N^2)-accumulator survey (#366) classified this as "small N,
+// refactor pointless" and #533 re-confirms it. A `Map[String, Bool]`
+// would NOT help: the selfhost runtime emits `Map::has_key` as a linear
+// search (#395, closed not-planned). See
+// bench/selfhost_perf/README.md ("String-keyed lookup" postmortem).
 export let contains_name: (Array[String], String) -> Bool = (items, name) -> {
   let mut i = 0
   let mut found = false
@@ -24,6 +33,18 @@ export let contains_name: (Array[String], String) -> Bool = (items, name) -> {
   found
 }
 
+// Linear membership scan used by `collect_direct_dep_paths` to dedup the
+// direct dependency paths of one entry file. Bounded by that file's
+// unique imports (≈5-30), so the dedup is O(D^2) with small D (≤ ~900
+// ops, per #366's survey). Kept linear deliberately (#533):
+//   - `Map[String, Bool]` is a no-op — the selfhost runtime emits
+//     `Map::has_key`/`Map::get` as linear searches (#395 not-planned).
+//   - A sort+merge dedup is UNSAFE: the resulting `dep_paths` order is
+//     preserved into `linked_imports`, which the linked codegen turns
+//     into wasm import-section indices (see
+//     vibe/compiler/codegen/wasi/linked_compile.vibe). Reordering would
+//     change the emitted binary, breaking reproducibility/parity.
+// First-occurrence insertion order must therefore be preserved.
 export let contains_path: (Array[String], String) -> Bool = (visited, path) -> {
   let mut i = 0
   let mut found = false


### PR DESCRIPTION
## 概要

selfhost を「保証」するには stage0 → stage1 → stage2 を **MoonBit host を一切ビルドせず**に回せる必要がある。完全な mooncakes registry / native build が無い環境(web/remote container 等)では `moon build src/cmd/vibe` が通らず、従来は flatten 工程(`emit-module-source`)が host `vibe.exe` に依存していた。

このPRは、selfhost に必要な prebuilt artifact を **GitHub Release asset** として配布し、pull + sha256 検証して使えるようにする。あわせて selfhost generation が pull 済みの flat module source を消費できるようにし、bootstrap から MoonBit host build 依存を外す。

## 背景で判明したギャップ

- release が publish していた `vibe-vX.Y.Z.wasm` は **MoonBit host(`src/lib`)** ビルドで `__moonbit_fs_unstable` 依存 → stock wasmtime では動かない。
- 真の selfhost compiler(`bootstrap/selfhost/seed/selfhost_compiler.wasm`、stock wasmtime で instantiate 可)は **release 未公開**で in-repo のみ。
- flatten 工程 `emit-module-source`(parse → DCE → reachable span emit)が host `vibe.exe` 依存。selfhost 側 AST には span が無く純粋移植は大掛かりなので、**flatten 出力(committed source の決定的関数)を prebuilt asset として pin/pull する**方式を採用。

## 変更

- **`scripts/build_release_assets.sh`**: 既存 host wasm に加えて以下を stage/publish。
  - `vibe-selfhost-<tag>.wasm` — stage0 seed compiler wasm(`seed.json` の sha256 と突き合わせて検証）
  - `vibe-selfhost-module-source-<tag>.vibe` — flatten 済み flat module source(`emit-module-source` 出力)
  - `vibe-selfhost-seed-<tag>.json` — seed provenance
  - `release-manifest.json` の `selfhost` block と `SHA256SUMS.txt` に sha256 / `source_commit` を記録
  - `release.yml` は `dist/release/<tag>/*` を glob 済みなので workflow 変更は不要
- **`scripts/fetch_selfhost_compiler.sh`(新規 / `pkf run fetch-selfhost-compiler`)**: release から download + sha256 検証。`--adopt-seed`・`--print-env`・`--from-dir`(ローカル/エアギャップ用)対応。改ざん/不一致 artifact は reject。
- **`scripts/selfhost_generations.sh`**: `prepare_flat_cli_source` が `VIBE_SELFHOST_PREBUILT_MODULE_SOURCE`(+ optional `_SHA256`)指定時に regeneration を skip して pull 済み flat source を使用。**未指定時の挙動(host `vibe.exe` で regenerate)は不変**。
- **`docs/selfhost-bootstrap.md`**: MoonBit-host-free bootstrap 手順と prebuilt-source の freshness 契約を追記。
- **`Taskfile.pkl`**: `fetch-selfhost-compiler` task を追加。

使い方:

```bash
eval "$(pkf run fetch-selfhost-compiler -- <tag> --print-env)"
bash scripts/selfhost_generations.sh build   # MoonBit host build なし
```

## 検証(ローカル実機)

`vibe.exe` を退避(= MoonBit host build 不可の状態)→ fetch → `selfhost_generations.sh build`:

- `[selfhost-gen] use prebuilt flat selfhost compiler source` 経路を通過
- stage0 seed → stage1 → stage2 を `moonrun` 上で完走
- **stage1 == stage2 == `4e00f02…`** で from-source ビルドと **byte 一致**
- `build_release_assets.sh v0.0.1` で 7 asset を stage、selfhost wasm sha が `seed.json` pin と一致、module-source sha が検証値と一致
- fetch の sha256 改ざん検出が正しく reject

> 注: この環境では結局 registry も到達可能で full build もできたため、この経路は registry/host build が使えない環境向けの「保証」として効く。`wasm/vibe/vibe.wasm` はテストビルドで一旦書き換わったが commit 前に復元済み(差分は scripts/docs/Taskfile の5ファイルのみ)。

## 同梱の別コミット

`docs(selfhost-perf): record #533 decision for linked-build contains_* scans` — issue #533 の調査結果(linear scan を bounded として維持する判断 + reorder hazard 注記)。doc/comment のみ。

## Notes / follow-up

- prebuilt flat source は対応 source commit/tag 専用(freshness 契約は docs に記載)。HEAD で compiler source を変えた場合は従来どおり host `vibe.exe` で regenerate。
- 次タグの実 release に対する `fetch_selfhost_compiler.sh <tag>`(`--from-dir` なし)の疎通は未実施。

https://claude.ai/code/session_01HcJ24wBXbRWZHE2RZjPtJi

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcJ24wBXbRWZHE2RZjPtJi)_