### PR TITLE
fix(wasi): WASI 0.3 async HTTP serve works on wasmtime 45 (serve flags + adapter untag)

### DIFF
--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -377,6 +377,36 @@ blueprint→byte で進められるが、async 全体で最大の塊。
 
 worlds: 受信は `wasi:http/service`、proxy/中継は `wasi:http/middleware`。
 
+### 4.1 M3 spike — async HTTP serve 実機確認（wasmtime 45 で HTTP 200）
+
+既存 P3 adapter（Rust wit-bindgen async、M0 で WIT を rc-2026-03-15 に整合）を
+使い、vibe handler → host `--compose-p3` → `wasmtime serve` → curl の縦串を
+wasmtime 45 で確認した。2 つの修正で **HTTP 200** が返るようになった:
+
+1. **serve フラグ修正**: 全 P3 スクリプトが使っていた `-W
+   component-model-async-builtins=y` は **wasmtime 45 で無効**（reject）。正しい
+   セットは `-Sp3 -Shttp -W exceptions=y -W concurrency-support=y -W
+   component-model-async=y -W component-model-async-stackful=y`。6 スクリプトを
+   修正（compose/probe/e2e/serve/adapter hints）。
+2. **adapter untag 修正**: minimal adapter が handler 戻り値を `status >> 2` で
+   untag していたが、vibe `Int` は default 経路で **raw i64（untag 済み）** で
+   component 境界を渡るため `>> 2` は誤り（`200>>2=50` → 無効 status →
+   `InternalError` → HTTP 500）。`>> 2` を除去 → `set_status_code(200)` →
+   **HTTP 200**。
+
+実測: `export let handler = (method, url) -> Int { 200 }` →
+service-only adapter で compose → `wasmtime serve`（上記フラグ）→ curl で
+**HTTP 200**。**async HTTP serve は wasmtime 45 で動作する**。
+
+未解決（M3 の残り）:
+- **combined adapter（client/proxy 経路）は validate 不可**: `unknown type 1:
+  type index out of bounds` — `wasi:http/client` import を含む合成で type-index
+  バグ。host `--compose-p3`（`src/`、legacy）の current toolchain 非互換が疑い。
+  service-only（直接レスポンス）経路は OK。
+- compose は host `--compose-p3`（`src/`）依存。selfhost 経路化は別途。
+- handler は現状 status code のみ（body/headers/method/url の本格 ABI、
+  `wasi:http/service` の async handler 化は後続）。
+
 ## 5. バージョン / WIT 整合（M0、本コミットで実施）
 
 WASI 0.3 RC のバージョン文字列がリポジトリ内で 3 重にズレていた:

--- a/scripts/build_wasi_http_p3_adapter.sh
+++ b/scripts/build_wasi_http_p3_adapter.sh
@@ -79,9 +79,11 @@ impl Guest for Component {
         };
         let url = request.get_path_with_query().unwrap_or_else(|| "/".to_string());
 
-        // Call vibe handler with method and url (returns tagged status code)
+        // Call vibe handler with method and url (returns the status code).
+        // vibe Int crosses the component boundary as a plain s64 in the default
+        // compile path (raw i64, untagged), so no bit-untag is applied here.
         let status_tagged = handler(&method, &url);
-        let status_code = (status_tagged >> 2) as u16; // untag int
+        let status_code = status_tagged as u16; // status code (no tag in default path)
 
         // Build P3 response with body
         let body_text = format!("method={} url={} status={}", method, url, status_code);
@@ -114,4 +116,4 @@ popd >/dev/null
 
 echo "wrote $OUT_PATH"
 echo "note: wasmtime serve で async p3 component を起動するには少なくとも次が必要"
-echo "  wasmtime serve -Sp3 -W component-model-async=y -W component-model-async-builtins=y <component.wasm>"
+echo "  wasmtime serve -Sp3 -W component-model-async=y -W component-model-async-stackful=y -W exceptions=y -W concurrency-support=y <component.wasm>"

--- a/scripts/compose_http_p3_handler.sh
+++ b/scripts/compose_http_p3_handler.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 #   handler returns -2   → proxy POST to URL from ?target= query param
 #
 # Output: a WASI P3 component that can be served with:
-#   wasmtime serve -Sp3 -W component-model-async=y -W component-model-async-builtins=y output.wasm
+#   wasmtime serve -Sp3 -W component-model-async=y -W component-model-async-stackful=y -W exceptions=y -W concurrency-support=y output.wasm
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -69,4 +69,4 @@ $VIBE compile --compose-p3 --adapter "$ADAPTER" "$INPUT" -o "$OUTPUT"
 # Step 3: Validate
 wasm-tools validate --features all "$OUTPUT"
 echo "[compose] wrote $OUTPUT"
-echo "[compose] serve with: wasmtime serve -Sp3 -W component-model-async=y -W component-model-async-builtins=y $OUTPUT"
+echo "[compose] serve with: wasmtime serve -Sp3 -W component-model-async=y -W component-model-async-stackful=y -W exceptions=y -W concurrency-support=y $OUTPUT"

--- a/scripts/probe_wasi_http_p3_compose.sh
+++ b/scripts/probe_wasi_http_p3_compose.sh
@@ -63,7 +63,7 @@ echo "[probe] serve on $SERVE_ADDR"
 ( wasmtime serve \
     -Sp3 -Shttp \
     -W component-model-async=y \
-    -W component-model-async-builtins=y \
+    -W component-model-async-stackful=y -W exceptions=y -W concurrency-support=y \
     --addr "$SERVE_ADDR" \
     "$COMPOSED_COMPONENT" >"$SERVE_LOG" 2>&1 & echo $! > "$SERVE_PID_FILE" )
 sleep 2

--- a/scripts/probe_wasi_http_p3_service_only.sh
+++ b/scripts/probe_wasi_http_p3_service_only.sh
@@ -119,7 +119,7 @@ echo "[probe] serve smoke on $SERVE_ADDR"
 ( wasmtime serve \
     -Sp3 -Shttp \
     -W component-model-async=y \
-    -W component-model-async-builtins=y \
+    -W component-model-async-stackful=y -W exceptions=y -W concurrency-support=y \
     --addr "$SERVE_ADDR" \
     "$SERVICE_COMPONENT" >"$SERVE_LOG" 2>&1 & echo $! > "$SERVE_PID_FILE" )
 sleep 2

--- a/scripts/test_wasi_p3_e2e.sh
+++ b/scripts/test_wasi_p3_e2e.sh
@@ -122,7 +122,7 @@ VIBE
   ( "$WASMTIME" serve \
       -Sp3 -Shttp \
       -W component-model-async=y \
-      -W component-model-async-builtins=y \
+      -W component-model-async-stackful=y -W exceptions=y -W concurrency-support=y \
       --addr "$SERVE_ADDR" \
       "$component" >"$SERVE_LOG" 2>&1 & echo $! > "$SERVE_PID_FILE" )
   sleep 2

--- a/scripts/vibe_serve.sh
+++ b/scripts/vibe_serve.sh
@@ -168,6 +168,6 @@ echo ""
 exec "$WASMTIME_BIN" serve \
   -Sp3 \
   -W component-model-async=y \
-  -W component-model-async-builtins=y \
+  -W component-model-async-stackful=y -W exceptions=y -W concurrency-support=y \
   --addr "$LISTEN" \
   "$COMPONENT"


### PR DESCRIPTION
## 概要

WASI 0.3 async HTTP の serve 経路を **wasmtime 45 で動く状態に戻す**実バグ修正（M3 spike）。vibe handler → host `--compose-p3`（service-only adapter）→ `wasmtime serve` → curl で **HTTP 200** を確認。

## 🎯 E2E（実機）
```vibe
export let handler = (method: String, url: String) -> Int { 200 }
```
compose（service-only adapter）→ `wasmtime serve -Sp3 -Shttp -W exceptions=y -W concurrency-support=y -W component-model-async=y -W component-model-async-stackful=y` → curl で **HTTP 200**。

## 修正（どちらも実バグ）

1. **serve フラグ**: 全 P3 スクリプトが使う `-W component-model-async-builtins=y` は **wasmtime 45 で無効**（unknown flag として reject）。正しいセットに **6 スクリプト**を修正（`compose_http_p3_handler` / `probe_wasi_http_p3_compose` / `probe_wasi_http_p3_service_only` / `test_wasi_p3_e2e` / `vibe_serve` / `build_wasi_http_p3_adapter` の hint）。
2. **adapter untag**: minimal adapter が handler 戻り値を `status >> 2` で untag していたが、vibe `Int` は default 経路で **raw i64（untag 済み）** として component 境界を渡るため `200>>2=50` → 無効 status → `InternalError` → HTTP 500。`>> 2` 除去 → `set_status_code(200)` → **HTTP 200**。

## 未解決（M3 の残り、本 PR 対象外、spec §4.1）
- **combined adapter（client/proxy 経路）は validate 不可**: `unknown type 1: type index out of bounds`（`wasi:http/client` import 合成時）。host `--compose-p3`（`src/`、legacy）の current toolchain 非互換が疑い。service-only（直接レスポンス）経路は OK。
- compose は host `--compose-p3` 依存（selfhost 化は後続）。本格的な `wasi:http/service` async handler ABI（body/headers/method/url）も後続。

## 変更範囲
`scripts/`（P3 adapter/serve スクリプト）+ `docs/spec/wasi-p3-async.md`（§4.1 に M3 spike 記録）のみ。`src/`（legacy host）不変。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHdX1R6gPNQym1o9FEy8Y6)_