### PR TITLE
feat(wasi): vibe async HTTP handlers — request & response body

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -108,6 +108,8 @@ local testSelfhostAsyncComponent =
   scriptTask("test-selfhost-async-component", "scripts/test_selfhost_async_component_gate.sh")
 local testWasiHttpP3Body =
   scriptTask("test-wasi-http-p3-body", "scripts/test_wasi_http_p3_body_gate.sh")
+local testWasiHttpP3Reqbody =
+  scriptTask("test-wasi-http-p3-reqbody", "scripts/test_wasi_http_p3_reqbody_gate.sh")
 local testSimdEmitWasmtime =
   scriptTask("test-simd-emit-wasmtime", "scripts/test_simd_emit_wasmtime.sh")
 
@@ -1446,6 +1448,7 @@ tasks {
   testGenerateSelfhostBundle
   testSelfhostAsyncComponent
   testWasiHttpP3Body
+  testWasiHttpP3Reqbody
   testSimdEmitWasmtime
   testCoverageScripts
   refreshSelfhostBatchWeights

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -106,6 +106,8 @@ local testGenerateSelfhostBundle =
   scriptTask("test-generate-selfhost-bundle", "scripts/generate_selfhost_bundle_test.sh")
 local testSelfhostAsyncComponent =
   scriptTask("test-selfhost-async-component", "scripts/test_selfhost_async_component_gate.sh")
+local testWasiHttpP3Body =
+  scriptTask("test-wasi-http-p3-body", "scripts/test_wasi_http_p3_body_gate.sh")
 local testSimdEmitWasmtime =
   scriptTask("test-simd-emit-wasmtime", "scripts/test_simd_emit_wasmtime.sh")
 
@@ -1443,6 +1445,7 @@ tasks {
   testSelfhostBundleSync
   testGenerateSelfhostBundle
   testSelfhostAsyncComponent
+  testWasiHttpP3Body
   testSimdEmitWasmtime
   testCoverageScripts
   refreshSelfhostBatchWeights

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -398,6 +398,14 @@ wasmtime 45 で確認した。2 つの修正で **HTTP 200** が返るように�
 service-only adapter で compose → `wasmtime serve`（上記フラグ）→ curl で
 **HTTP 200**。**async HTTP serve は wasmtime 45 で動作する**。
 
+**handler が response body を返す（landed）**: `build_wasi_http_p3_body_adapter.sh`
+（`import handler: func(method, url) -> string;`、status 200 固定）を追加。vibe
+handler が**レスポンス body を制御**できる:
+`export let handler = (method, url) -> String { "..." }` → compose → serve →
+curl が **handler の返した body を HTTP 200 で返す**ことを実測。回帰 gate
+`scripts/test_wasi_http_p3_body_gate.sh`（pkf `test-wasi-http-p3-body`、CI cli
+shard、serve+curl で body 一致を検証、tooling 不在時 skip）。
+
 未解決（M3 の残り）:
 - **combined adapter（client/proxy 経路）は validate 不可**: `unknown type 1:
   type index out of bounds` — `wasi:http/client` import を含む合成で type-index

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -412,8 +412,14 @@ shard、serve+curl で body 一致を検証、tooling 不在時 skip）。
   バグ。host `--compose-p3`（`src/`、legacy）の current toolchain 非互換が疑い。
   service-only（直接レスポンス）経路は OK。
 - compose は host `--compose-p3`（`src/`）依存。selfhost 経路化は別途。
-- handler は現状 status code のみ（body/headers/method/url の本格 ABI、
-  `wasi:http/service` の async handler 化は後続）。
+- **request body（landed）**: `build_wasi_http_p3_reqbody_adapter.sh`
+  （`handler: func(method, url, body) -> string`）が p3 `Request::consume-body`
+  でリクエスト body を読み handler に渡す。`handler = (method, url, body) ->
+  String { concat("echo: ", body) }` に POST → **`echo: <body>` を HTTP 200** で
+  返すことを実測。gate `test_wasi_http_p3_reqbody_gate.sh`（pkf
+  `test-wasi-http-p3-reqbody`、CI cli shard）。
+- 残り: status+body 同時返却、response/request headers、trailers、`wasi:http
+  /service` async handler の本格 ABI。selfhost compose 経路化。
 
 ## 5. バージョン / WIT 整合（M0、本コミットで実施）
 

--- a/scripts/build_wasi_http_p3_body_adapter.sh
+++ b/scripts/build_wasi_http_p3_body_adapter.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a WASI P3 HTTP adapter whose vibe handler returns the response BODY.
+#
+# Unlike build_wasi_http_p3_adapter.sh (handler -> status code), here the vibe
+# handler controls the response body:
+#   export let handler = (method: String, url: String) -> String { "..." }
+# The adapter serves it with HTTP 200.
+#
+# Serve with (wasmtime 45):
+#   wasmtime serve -Sp3 -Shttp -W exceptions=y -W concurrency-support=y \
+#     -W component-model-async=y -W component-model-async-stackful=y <component.wasm>
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUT_PATH="${1:-$PROJECT_ROOT/_build/http_adapter/vibe_http_p3_body_adapter.component.wasm}"
+TMP_DIR="$(mktemp -d /tmp/vibe_http_p3_body_adapter.XXXXXX)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd cargo
+require_cmd wasm-tools
+
+if [ -x "$HOME/.cargo/bin/cargo" ]; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+mkdir -p "$TMP_DIR/src"
+mkdir -p "$(dirname "$OUT_PATH")"
+
+cat >"$TMP_DIR/Cargo.toml" <<'EOF'
+[package]
+name = "vibe_http_p3_body_adapter"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { version = "0.54.0", default-features = false, features = ["macros", "realloc", "bitflags", "async", "async-spawn"] }
+EOF
+
+cat >"$TMP_DIR/src/lib.rs" <<EOF
+wit_bindgen::generate!({
+    inline: r#"
+      package vibe:http-body-adapter;
+
+      world adapter {
+        /// vibe handler: (method, url) -> response body string.
+        import handler: func(method: string, url: string) -> string;
+        include wasi:http/service@0.3.0-rc-2026-03-15;
+      }
+    "#,
+    path: "$PROJECT_ROOT/deps/wasmtime/crates/wasi-http/src/p3/wit",
+    world: "vibe:http-body-adapter/adapter",
+    pub_export_macro: true,
+    generate_all,
+});
+
+use exports::wasi::http::handler::Guest;
+use wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+struct Component;
+
+impl Guest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let method = match request.get_method() {
+            wasi::http::types::Method::Get => "GET".to_string(),
+            wasi::http::types::Method::Post => "POST".to_string(),
+            wasi::http::types::Method::Put => "PUT".to_string(),
+            wasi::http::types::Method::Delete => "DELETE".to_string(),
+            wasi::http::types::Method::Head => "HEAD".to_string(),
+            wasi::http::types::Method::Options => "OPTIONS".to_string(),
+            wasi::http::types::Method::Patch => "PATCH".to_string(),
+            wasi::http::types::Method::Other(m) => m,
+            _ => "UNKNOWN".to_string(),
+        };
+        let url = request.get_path_with_query().unwrap_or_else(|| "/".to_string());
+
+        // The vibe handler produces the response body.
+        let body_text = handler(&method, &url);
+
+        let (mut body_tx, body_rx) = wit_stream::new();
+        let (body_result_tx, body_result_rx) = wit_future::new(|| Ok(None));
+        let (resp, _transmit) = Response::new(Fields::new(), Some(body_rx), body_result_rx);
+        resp.set_status_code(200)
+            .map_err(|_| ErrorCode::InternalError(None))?;
+        drop(body_result_tx);
+
+        wit_bindgen::spawn(async move {
+            let remaining = body_tx.write_all(body_text.into_bytes()).await;
+            assert!(remaining.is_empty());
+        });
+
+        Ok(resp)
+    }
+}
+
+export!(Component);
+EOF
+
+pushd "$TMP_DIR" >/dev/null
+cargo build --target wasm32-unknown-unknown --release
+wasm-tools component new \
+  target/wasm32-unknown-unknown/release/vibe_http_p3_body_adapter.wasm \
+  -o "$OUT_PATH"
+wasm-tools validate --features all "$OUT_PATH"
+popd >/dev/null
+
+echo "wrote $OUT_PATH"

--- a/scripts/build_wasi_http_p3_reqbody_adapter.sh
+++ b/scripts/build_wasi_http_p3_reqbody_adapter.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a WASI P3 HTTP adapter that passes the REQUEST body to the vibe handler.
+#
+# The vibe handler reads method, url AND the request body, and returns the
+# response body:
+#   export let handler = (method: String, url: String, body: String) -> String { ... }
+# Served with HTTP 200. Enables POST/PUT handlers that consume the request body.
+#
+# Serve with (wasmtime 45):
+#   wasmtime serve -Sp3 -Shttp -W exceptions=y -W concurrency-support=y \
+#     -W component-model-async=y -W component-model-async-stackful=y <component.wasm>
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUT_PATH="${1:-$PROJECT_ROOT/_build/http_adapter/vibe_http_p3_reqbody_adapter.component.wasm}"
+TMP_DIR="$(mktemp -d /tmp/vibe_http_p3_reqbody_adapter.XXXXXX)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd cargo
+require_cmd wasm-tools
+
+if [ -x "$HOME/.cargo/bin/cargo" ]; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+fi
+
+mkdir -p "$TMP_DIR/src"
+mkdir -p "$(dirname "$OUT_PATH")"
+
+cat >"$TMP_DIR/Cargo.toml" <<'EOF'
+[package]
+name = "vibe_http_p3_reqbody_adapter"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { version = "0.54.0", default-features = false, features = ["macros", "realloc", "bitflags", "async", "async-spawn"] }
+EOF
+
+cat >"$TMP_DIR/src/lib.rs" <<EOF
+wit_bindgen::generate!({
+    inline: r#"
+      package vibe:http-reqbody-adapter;
+
+      world adapter {
+        /// vibe handler: (method, url, request-body) -> response body string.
+        import handler: func(method: string, url: string, body: string) -> string;
+        include wasi:http/service@0.3.0-rc-2026-03-15;
+      }
+    "#,
+    path: "$PROJECT_ROOT/deps/wasmtime/crates/wasi-http/src/p3/wit",
+    world: "vibe:http-reqbody-adapter/adapter",
+    pub_export_macro: true,
+    generate_all,
+});
+
+use exports::wasi::http::handler::Guest;
+use wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+struct Component;
+
+impl Guest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        // Read method + url (borrowing) BEFORE consuming the request body.
+        let method = match request.get_method() {
+            wasi::http::types::Method::Get => "GET".to_string(),
+            wasi::http::types::Method::Post => "POST".to_string(),
+            wasi::http::types::Method::Put => "PUT".to_string(),
+            wasi::http::types::Method::Delete => "DELETE".to_string(),
+            wasi::http::types::Method::Head => "HEAD".to_string(),
+            wasi::http::types::Method::Options => "OPTIONS".to_string(),
+            wasi::http::types::Method::Patch => "PATCH".to_string(),
+            wasi::http::types::Method::Other(m) => m,
+            _ => "UNKNOWN".to_string(),
+        };
+        let url = request.get_path_with_query().unwrap_or_else(|| "/".to_string());
+
+        // Consume the request body stream into a String.
+        let (_, result_rx) = wit_future::new::<Result<(), ErrorCode>>(|| Ok(()));
+        let (req_body_rx, _trailers_rx) = Request::consume_body(request, result_rx);
+        let req_body_bytes = req_body_rx.collect().await;
+        let req_body = String::from_utf8_lossy(&req_body_bytes).into_owned();
+
+        // The vibe handler produces the response body from method/url/req-body.
+        let resp_text = handler(&method, &url, &req_body);
+
+        let (mut body_tx, body_rx) = wit_stream::new();
+        let (body_result_tx, body_result_rx) = wit_future::new(|| Ok(None));
+        let (resp, _transmit) = Response::new(Fields::new(), Some(body_rx), body_result_rx);
+        resp.set_status_code(200)
+            .map_err(|_| ErrorCode::InternalError(None))?;
+        drop(body_result_tx);
+
+        wit_bindgen::spawn(async move {
+            let remaining = body_tx.write_all(resp_text.into_bytes()).await;
+            assert!(remaining.is_empty());
+        });
+
+        Ok(resp)
+    }
+}
+
+export!(Component);
+EOF
+
+pushd "$TMP_DIR" >/dev/null
+cargo build --target wasm32-unknown-unknown --release
+wasm-tools component new \
+  target/wasm32-unknown-unknown/release/vibe_http_p3_reqbody_adapter.wasm \
+  -o "$OUT_PATH"
+wasm-tools validate --features all "$OUT_PATH"
+popd >/dev/null
+
+echo "wrote $OUT_PATH"

--- a/scripts/pkfire/selfhost_gates_shard.sh
+++ b/scripts/pkfire/selfhost_gates_shard.sh
@@ -35,6 +35,7 @@ case "$shard" in
     scripts/test_selfhost_cutover_gate.sh
     bash scripts/test_selfhost_rc_bootstrap.sh
     bash scripts/test_selfhost_async_component_gate.sh
+    bash scripts/test_wasi_http_p3_body_gate.sh
     ;;
   check)
     bash scripts/test_selfhost_check_preview2_package.sh

--- a/scripts/pkfire/selfhost_gates_shard.sh
+++ b/scripts/pkfire/selfhost_gates_shard.sh
@@ -36,6 +36,7 @@ case "$shard" in
     bash scripts/test_selfhost_rc_bootstrap.sh
     bash scripts/test_selfhost_async_component_gate.sh
     bash scripts/test_wasi_http_p3_body_gate.sh
+    bash scripts/test_wasi_http_p3_reqbody_gate.sh
     ;;
   check)
     bash scripts/test_selfhost_check_preview2_package.sh

--- a/scripts/test_wasi_http_p3_body_gate.sh
+++ b/scripts/test_wasi_http_p3_body_gate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WASI 0.3 async HTTP body gate (docs/spec/wasi-p3-async.md §4.1).
+#
+# Proves a vibe HTTP handler controls the response body end-to-end on wasmtime 45:
+#   build body adapter -> compose a String-returning handler -> wasmtime serve ->
+#   curl returns the handler's body with HTTP 200.
+#
+# Skips cleanly when cargo / wasm-tools / wasmtime / curl / node are unavailable.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUT_DIR="$PROJECT_ROOT/_build/bench/wasi_http_p3_body"
+ADAPTER="$OUT_DIR/body_adapter.component.wasm"
+HANDLER_SRC="$OUT_DIR/handler.vibe"
+COMPONENT="$OUT_DIR/handler.component.wasm"
+SERVE_LOG="$OUT_DIR/serve.log"
+ADDR="127.0.0.1:18981"
+EXPECT="hello from vibe gate"
+HOST_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+HOST_VIBE_EXE_DEBUG="$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe"
+
+WASM_FLAGS=(-Sp3 -Shttp -W exceptions=y -W concurrency-support=y -W component-model-async=y -W component-model-async-stackful=y)
+
+for c in cargo wasm-tools curl; do
+  command -v "$c" >/dev/null 2>&1 || { echo "[http-body-gate] SKIP: $c not found"; exit 0; }
+done
+WASMTIME_BIN="$("$PROJECT_ROOT/scripts/wasmtime_bin.sh" 2>/dev/null || command -v wasmtime || true)"
+if [ -z "${WASMTIME_BIN:-}" ] || ! "$WASMTIME_BIN" --version >/dev/null 2>&1; then
+  echo "[http-body-gate] SKIP: wasmtime not found"; exit 0
+fi
+if [ -x "$HOST_VIBE_EXE" ]; then VIBE="$HOST_VIBE_EXE"
+elif [ -x "$HOST_VIBE_EXE_DEBUG" ]; then VIBE="$HOST_VIBE_EXE_DEBUG"
+else echo "[http-body-gate] SKIP: host vibe.exe not built"; exit 0; fi
+
+mkdir -p "$OUT_DIR"
+echo "[http-body-gate] wasmtime: $($WASMTIME_BIN --version)"
+
+echo "[http-body-gate] build body adapter"
+bash "$SCRIPT_DIR/build_wasi_http_p3_body_adapter.sh" "$ADAPTER" >/dev/null
+
+printf 'export let handler = (method: String, url: String) -> String { "%s" }\n' "$EXPECT" > "$HANDLER_SRC"
+
+echo "[http-body-gate] compose"
+"$VIBE" compile --compose-p3 --adapter "$ADAPTER" "$HANDLER_SRC" -o "$COMPONENT" >/dev/null
+wasm-tools validate --features all "$COMPONENT" >/dev/null
+echo "[http-body-gate] composed component validates"
+
+SERVE_PID=""
+cleanup() { [ -n "$SERVE_PID" ] && kill "$SERVE_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+"$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$COMPONENT" >"$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+sleep 3
+
+body="$(curl -s --max-time 5 "http://$ADDR/gate" || true)"
+code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://$ADDR/gate" || true)"
+
+if [ "$code" != "200" ]; then
+  echo "[http-body-gate] FAIL: expected HTTP 200, got '$code'" >&2
+  echo "--- serve log ---" >&2; head -8 "$SERVE_LOG" >&2
+  exit 1
+fi
+case "$body" in
+  *"$EXPECT"*) ;;
+  *) echo "[http-body-gate] FAIL: body did not contain '$EXPECT' (got: '$body')" >&2; exit 1 ;;
+esac
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### WASI 0.3 Async HTTP Body Gate"
+    echo
+    echo "- a vibe \`handler : (String, String) -> String\` controlled the response body"
+    echo "- served via wasmtime, curl returned HTTP 200 with the handler's body"
+    echo
+  } >> "$GITHUB_STEP_SUMMARY" || true
+fi
+
+echo "[http-body-gate] PASS: vibe handler body served over HTTP (200, body matched)"

--- a/scripts/test_wasi_http_p3_reqbody_gate.sh
+++ b/scripts/test_wasi_http_p3_reqbody_gate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WASI 0.3 async HTTP request-body gate (docs/spec/wasi-p3-async.md §4.1).
+#
+# Proves a vibe HTTP handler can READ the request body and return a response body
+# end-to-end on wasmtime 45:
+#   build reqbody adapter -> compose a (method,url,body)->String handler ->
+#   wasmtime serve -> POST a body -> handler echoes it back with HTTP 200.
+#
+# Skips cleanly when cargo / wasm-tools / wasmtime / curl are unavailable.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUT_DIR="$PROJECT_ROOT/_build/bench/wasi_http_p3_reqbody"
+ADAPTER="$OUT_DIR/reqbody_adapter.component.wasm"
+HANDLER_SRC="$OUT_DIR/handler.vibe"
+COMPONENT="$OUT_DIR/handler.component.wasm"
+SERVE_LOG="$OUT_DIR/serve.log"
+ADDR="127.0.0.1:18982"
+POST_BODY="ping-12345"
+EXPECT="echo: $POST_BODY"
+HOST_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+HOST_VIBE_EXE_DEBUG="$PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe"
+
+WASM_FLAGS=(-Sp3 -Shttp -W exceptions=y -W concurrency-support=y -W component-model-async=y -W component-model-async-stackful=y)
+
+for c in cargo wasm-tools curl; do
+  command -v "$c" >/dev/null 2>&1 || { echo "[http-reqbody-gate] SKIP: $c not found"; exit 0; }
+done
+WASMTIME_BIN="$("$PROJECT_ROOT/scripts/wasmtime_bin.sh" 2>/dev/null || command -v wasmtime || true)"
+if [ -z "${WASMTIME_BIN:-}" ] || ! "$WASMTIME_BIN" --version >/dev/null 2>&1; then
+  echo "[http-reqbody-gate] SKIP: wasmtime not found"; exit 0
+fi
+if [ -x "$HOST_VIBE_EXE" ]; then VIBE="$HOST_VIBE_EXE"
+elif [ -x "$HOST_VIBE_EXE_DEBUG" ]; then VIBE="$HOST_VIBE_EXE_DEBUG"
+else echo "[http-reqbody-gate] SKIP: host vibe.exe not built"; exit 0; fi
+
+mkdir -p "$OUT_DIR"
+echo "[http-reqbody-gate] wasmtime: $($WASMTIME_BIN --version)"
+
+echo "[http-reqbody-gate] build reqbody adapter"
+bash "$SCRIPT_DIR/build_wasi_http_p3_reqbody_adapter.sh" "$ADAPTER" >/dev/null
+
+printf 'export let handler = (method: String, url: String, body: String) -> String { String::concat("echo: ", body) }\n' > "$HANDLER_SRC"
+
+echo "[http-reqbody-gate] compose"
+"$VIBE" compile --compose-p3 --adapter "$ADAPTER" "$HANDLER_SRC" -o "$COMPONENT" >/dev/null
+wasm-tools validate --features all "$COMPONENT" >/dev/null
+echo "[http-reqbody-gate] composed component validates"
+
+SERVE_PID=""
+cleanup() { [ -n "$SERVE_PID" ] && kill "$SERVE_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+"$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$COMPONENT" >"$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+sleep 3
+
+body="$(curl -s --max-time 5 -X POST --data-binary "$POST_BODY" "http://$ADDR/echo" || true)"
+code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 -X POST --data-binary "$POST_BODY" "http://$ADDR/echo" || true)"
+
+if [ "$code" != "200" ]; then
+  echo "[http-reqbody-gate] FAIL: expected HTTP 200, got '$code'" >&2
+  echo "--- serve log ---" >&2; head -8 "$SERVE_LOG" >&2
+  exit 1
+fi
+case "$body" in
+  *"$EXPECT"*) ;;
+  *) echo "[http-reqbody-gate] FAIL: body did not contain '$EXPECT' (got: '$body')" >&2; exit 1 ;;
+esac
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### WASI 0.3 Async HTTP Request-Body Gate"
+    echo
+    echo "- a vibe \`handler : (String, String, String) -> String\` read the POST request body"
+    echo "- served via wasmtime; POST -> handler echoed the body back with HTTP 200"
+    echo
+  } >> "$GITHUB_STEP_SUMMARY" || true
+fi
+
+echo "[http-reqbody-gate] PASS: vibe handler read request body and echoed it (200, body matched)"


### PR DESCRIPTION
## 概要

PR #561（async HTTP serve が wasmtime 45 で動く）の続き。vibe の async HTTP handler が **request body 入力 → response body 出力**できるようにする（M3）。両方とも wasmtime 45 で E2E 実測 + 回帰 gate 付き。

## 🎯 E2E（実機、wasmtime 45）

**response body**:
```vibe
export let handler = (method: String, url: String) -> String { "hello from vibe" }
```
→ compose → `wasmtime serve` → curl が `hello from vibe` を **HTTP 200** で受信。

**request body**（POST/PUT、Phase-1 ブロッカー解消）:
```vibe
export let handler = (method: String, url: String, body: String) -> String { String::concat("echo: ", body) }
```
→ compose → serve → `curl -X POST --data ping-12345` が **`echo: ping-12345`** を HTTP 200 で返す。

## 含まれるもの

### response body adapter
- `scripts/build_wasi_http_p3_body_adapter.sh`: `handler: func(method, url) -> string`。handler の返す文字列を HTTP 200 body として serve。

### request body adapter（POST/PUT）
- `scripts/build_wasi_http_p3_reqbody_adapter.sh`: `handler: func(method, url, body) -> string`。p3 `Request::consume-body` + `StreamReader::collect` でリクエスト body を読み handler に渡す（method/url は borrow で先に読む）。

### 回帰 gate（serve+curl、CI cli shard、tooling 不在時 skip）
- `scripts/test_wasi_http_p3_body_gate.sh`（pkf `test-wasi-http-p3-body`）
- `scripts/test_wasi_http_p3_reqbody_gate.sh`（pkf `test-wasi-http-p3-reqbody`）

## M3 残り（本 PR 対象外、spec §4.1）
status+body 同時返却、headers/trailers、`wasi:http/service` async handler の本格 ABI、selfhost compose 経路化、combined-adapter の validate バグ（`wasi:http/client` 合成の type-index）。

## 変更範囲
`scripts/`（adapter + gate）+ `Taskfile.pkl`（pkf task 2）+ `scripts/pkfire/selfhost_gates_shard.sh`（CI cli shard）+ `docs/spec/wasi-p3-async.md`（§4.1）。`src/`（legacy host）不変。

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHdX1R6gPNQym1o9FEy8Y6)_