### PR TITLE
feat(wasi-p3): M2c-3 host-stream bridge — consume a host byte stream via input-stream

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1201,6 +1201,8 @@ local probeCmAsync = scriptTask("probe-cm-async", "src/x/cm_async/run_probe.sh")
 
 local probeCmStream = scriptTask("probe-cm-stream", "src/x/cm_async/run_stream_probe.sh")
 
+local hostStreamBridge = scriptTask("host-stream-bridge", "scripts/test_host_stream_bridge.sh")
+
 local wasmtimeSubmoduleInit = new Task {
   name = "wasmtime-submodule-init"
   cmd = "git submodule update --init deps/wasmtime"
@@ -1612,6 +1614,7 @@ tasks {
   showWasmtimeFlags
   probeCmAsync
   probeCmStream
+  hostStreamBridge
   wasmtimeSubmoduleInit
   wasmtimeSubmoduleUpdate
   buildWasmtimeSubmodule

--- a/scripts/test_host_stream_bridge.sh
+++ b/scripts/test_host_stream_bridge.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# M2c-3 host-stream bridge gate (docs/spec/wasi-p3-async.md §3.3).
+#
+# Proves a vibe handler can consume a HOST-provided byte stream incrementally:
+# the node runner feeds bytes through the WASI 0.2 input-stream
+# (input-stream.blocking-read) via VIBE_STDIN_BYTES, and vibe/io's
+# `print_stdin_sum` drains it with a read_char() loop and prints the byte sum.
+# This is the testable stand-in for the WASI 0.3 stream<u8> HTTP body (where
+# wasmtime is the producer); see §3.3 for why an intra-wasm producer can't
+# work.
+#
+# Skips cleanly when node is unavailable.
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="$PROJECT_ROOT/_build/bench/host_stream_bridge"
+SRC="$PROJECT_ROOT/vibe/io/stdin_stream_main.vibe"
+WASM="$OUT_DIR/stdin_main.wasm"
+RUNNER="$PROJECT_ROOT/scripts/run_wasm_vibe_host_runner.sh"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "[host-stream-gate] SKIP: node not found"; exit 0
+fi
+if [ ! -f "$RUNNER" ]; then
+  echo "[host-stream-gate] SKIP: wasm host runner not found"; exit 0
+fi
+
+mkdir -p "$OUT_DIR"
+
+HOST_VIBE_EXE="$PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
+if [ -x "$HOST_VIBE_EXE" ]; then
+  COMPILE=("$HOST_VIBE_EXE" compile --wasm)
+else
+  COMPILE=(moon run --target native src/cmd/vibe -- compile --wasm)
+fi
+
+echo "[host-stream-gate] compiling $SRC"
+"${COMPILE[@]}" "$SRC" -o "$WASM" >/dev/null
+
+# Feed "ABC" (65+66+67 = 198) and a second body to prove it is the feed, not a
+# constant, that drives the result.
+check() {
+  local feed="$1" expected="$2"
+  local out
+  out="$(VIBE_STDIN_BYTES="$feed" bash "$RUNNER" --invoke print_stdin_sum "$WASM" 0 2>/dev/null \
+    | grep -E '^[0-9]+$' | head -n1 || true)"
+  if [ "$out" = "$expected" ]; then
+    echo "[host-stream-gate] PASS: feed='$feed' -> sum $out"
+  else
+    echo "[host-stream-gate] FAIL: feed='$feed' -> '$out' (expected $expected)" >&2
+    exit 1
+  fi
+}
+
+check "ABC" 198   # 65 + 66 + 67
+check "AA"  130   # 65 + 65
+check ""    0     # empty body -> EOF immediately
+
+echo "[host-stream-gate] done"

--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -218,7 +218,10 @@ function ensureMemoryCapacity(instance, end) {
 
 function allocPreview2Buffer(instance, size, align = 4) {
   if (typeof instance.exports.cabi_realloc === "function") {
-    const ptr = instance.exports.cabi_realloc(0, 0, align, size) >>> 0;
+    // cabi_realloc returns a pointer that may be an i64 (BigInt) on the linear
+    // backend; normalize before the i32 coercion (`>>> 0` throws on BigInt).
+    const rawPtr = instance.exports.cabi_realloc(0, 0, align, size);
+    const ptr = (typeof rawPtr === "bigint" ? Number(rawPtr) : rawPtr) >>> 0;
     ensureMemoryCapacity(instance, ptr + size);
     return ptr;
   }
@@ -977,6 +980,17 @@ function createPreview2CliStreamsHost() {
   const STDERR_STREAM_HANDLE = 2;
   const STDIN_STREAM_HANDLE = 3;
 
+  // M2c-3 (0.2 input-stream bridge): when VIBE_STDIN_BYTES is set, feed its
+  // UTF-8 bytes to input-stream.blocking-read so a handler can consume a
+  // host-provided byte stream incrementally (the testable stand-in for the WASI
+  // 0.3 stream<u8> HTTP body; docs/spec/wasi-p3-async.md §3.3). Unset =>
+  // legacy EOF behaviour, so existing tests are unaffected.
+  const stdinFeed =
+    process.env.VIBE_STDIN_BYTES !== undefined
+      ? Buffer.from(process.env.VIBE_STDIN_BYTES, "utf8")
+      : null;
+  let stdinCursor = 0;
+
   function writeEmptyResultOk(retptr) {
     const mem = new Uint8Array(instanceRefGlobal.exports.memory.buffer);
     writeU8(mem, retptr, 0);
@@ -1022,18 +1036,41 @@ function createPreview2CliStreamsHost() {
         resolveWritableStream(handle).write(Buffer.from(bytes));
         writeEmptyResultOk(retptr);
       },
-      "[method]input-stream.blocking-read"(_handle, _maxLen, retptr) {
-        // Tests run without an interactive stdin; signal EOF (empty list) so
-        // callers like `Stdin::read_char` see `-1` and `read_line` returns "".
+      "[method]input-stream.blocking-read"(handle, maxLen, retptr) {
         const instance = instanceRefGlobal;
         if (!(instance?.exports?.memory instanceof WebAssembly.Memory)) {
           throw new Error("missing exported memory for input-stream read");
         }
+        // WIT signature is `blocking-read(len: u64)`, so `maxLen` arrives as a
+        // BigInt; `handle`/`retptr` may also be BigInt. Normalize to numbers.
+        const handleNum = Number(handle);
+        const maxLenNum = Number(maxLen);
+        const retptrNum = Number(retptr);
+        // With VIBE_STDIN_BYTES set, serve the feed buffer incrementally
+        // (respecting maxLen) so the guest's read loop drains a real
+        // host-provided byte stream; EOF (empty ok list) once exhausted.
+        if (
+          stdinFeed !== null &&
+          handleNum === STDIN_STREAM_HANDLE &&
+          stdinCursor < stdinFeed.length
+        ) {
+          const want = Math.min(maxLenNum, stdinFeed.length - stdinCursor);
+          const ptr = allocPreview2Buffer(instance, want, 1);
+          const mem = new Uint8Array(instance.exports.memory.buffer);
+          mem.set(stdinFeed.subarray(stdinCursor, stdinCursor + want), ptr);
+          stdinCursor += want;
+          // result<list<u8>, stream-error>: tag=0 (ok), then list { ptr, len }
+          writeU8(mem, retptrNum, 0);
+          writeU32LE(mem, retptrNum + 4, ptr);
+          writeU32LE(mem, retptrNum + 8, want);
+          return;
+        }
+        // Default / exhausted: signal EOF (empty list) so callers like
+        // `Stdin::read_char` see `-1` and `read_line` returns "".
         const mem = new Uint8Array(instance.exports.memory.buffer);
-        // result<list<u8>, stream-error>: tag=0 (ok), then list { ptr=0, len=0 }
-        writeU8(mem, retptr, 0);
-        writeU32LE(mem, retptr + 4, 0); // ptr
-        writeU32LE(mem, retptr + 8, 0); // len
+        writeU8(mem, retptrNum, 0);
+        writeU32LE(mem, retptrNum + 4, 0); // ptr
+        writeU32LE(mem, retptrNum + 8, 0); // len
       },
       "[resource-drop]output-stream"(_handle) {},
       "[resource-drop]input-stream"(_handle) {},

--- a/vibe/io/stdin_stream_main.vibe
+++ b/vibe/io/stdin_stream_main.vibe
@@ -1,0 +1,25 @@
+//# Imports
+
+import ./io.vibe {
+  read_char, println
+}
+
+//# Functions
+
+// M2c-3 (0.2 input-stream bridge, docs/spec/wasi-p3-async.md §3.3): drain the
+// host-provided stdin byte stream via read_char() until EOF and print the byte
+// sum. Driven end-to-end by scripts/test_host_stream_bridge.sh, which feeds
+// bytes through the node runner's wasi:io input-stream shim (VIBE_STDIN_BYTES).
+export let print_stdin_sum: () -> Unit with { Stdin, Stdout } = () -> {
+  let mut sum = 0
+  let mut done = false
+  while not(done) {
+    let c = read_char()
+    if c < 0 {
+      done = true
+    } else {
+      sum = sum + c
+    }
+  }
+  println(Int::to_string(sum))
+}

--- a/vibe/io/stdin_stream_test.vibe
+++ b/vibe/io/stdin_stream_test.vibe
@@ -1,0 +1,34 @@
+//# Imports
+
+import ./io.vibe {
+  read_char
+}
+
+//# Functions
+
+// Drain the host stdin byte stream via repeated read_char() until EOF (-1),
+// summing the byte values. This is the consume-loop shape M2c-3 uses to read a
+// host-provided byte stream (docs/spec/wasi-p3-async.md §3.3); with the WASI
+// 0.2 input-stream bridge the host (node runner) feeds the bytes.
+export let sum_stdin_bytes: () -> Int with { Stdin } = () -> {
+  let mut sum = 0
+  let mut done = false
+  while not(done) {
+    let c = read_char()
+    if c < 0 {
+      done = true
+    } else {
+      sum = sum + c
+    }
+  }
+  sum
+}
+
+//# Misc
+
+test "sum_stdin_bytes drains to EOF (empty stdin -> 0)" {
+  // Without VIBE_STDIN_BYTES the host stream is empty, so the loop must
+  // terminate at EOF with sum 0. The feed case (sum 198 for "ABC") is checked
+  // end-to-end by scripts/test_host_stream_bridge.sh.
+  assert(sum_stdin_bytes() == 0)
+}


### PR DESCRIPTION
M2c-3 で選んだ **WASI 0.2 input-stream ブリッジ**を実装。vibe handler が **host 供給のバイトストリームを逐次消費**する経路を e2e で実証した（§3.3 の「intra-wasm producer は不可、producer は host」を受けた、テスト可能な stand-in）。

## 実装

- **node host runner** (`scripts/wasm_vibe_host_runner.js`): `VIBE_STDIN_BYTES` が設定されていれば `input-stream.blocking-read` がそのバイトを逐次（read 長を尊重して）供給し、尽きたら EOF。未設定なら従来の EOF のままなので既存テストに影響なし。WIT の `len` は u64（BigInt）、handle/retptr も BigInt 可なので number に正規化。
- **`allocPreview2Buffer` のバグ修正**: linear backend では `cabi_realloc` が i64（BigInt）ポインタを返すため、`>>> 0`（BigInt で例外）前に正規化。これが read 結果のメモリ確保を失敗させていた。
- **`vibe/io/stdin_stream_test.vibe`**: CI-safe ユニットテスト（feed 無し→read_char ループが EOF で sum 0）。consume ループ + EOF を検証。
- **`vibe/io/stdin_stream_main.vibe`**: `print_stdin_sum` が read_char ループで stdin を drain し byte sum を print。
- **`scripts/test_host_stream_bridge.sh`** (`pkf run host-stream-bridge`): 既知の body を runner に feed し、handler の出力 sum を検証（**ABC→198, AA→130, ""→0**）。定数ではなく feed 駆動であることを確認。

`read_char` は `wasi:cli/stdin get-stdin` + `wasi:io/streams input-stream.blocking-read` に lower されるため、**実際の host-stream consume 経路**を通る。

## 検証

- host-stream-bridge gate **PASS**（ABC→198 / AA→130 / ""→0）
- `vibe/io/stdin_stream_test.vibe` 1/1、`io_test` 5/5、`prelude/io_test` 6/6（無回帰）
- selfhost source 無変更（bundle sync ok）

## 補足

実装中、stdin 経路で 2 つの BigInt 起因バグ（WIT u64 `len`、i64 `cabi_realloc` 戻り値）を踏んで修正。これらは host-stream を実際に流して初めて顕在化したもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHdX1R6gPNQym1o9FEy8Y6)_