### PR TITLE
feat(wasi-p3): M2c-3 read_all — whole-body reader on the host-stream bridge

### DIFF
--- a/scripts/test_host_stream_bridge.sh
+++ b/scripts/test_host_stream_bridge.sh
@@ -57,4 +57,21 @@ check "ABC" 198   # 65 + 66 + 67
 check "AA"  130   # 65 + 65
 check ""    0     # empty body -> EOF immediately
 
+# read_all round-trip: feed a body and assert echo_stdin returns it verbatim.
+check_echo() {
+  local feed="$1"
+  local out
+  out="$(VIBE_STDIN_BYTES="$feed" bash "$RUNNER" --invoke echo_stdin "$WASM" 0 2>/dev/null \
+    | head -n1 || true)"
+  if [ "$out" = "$feed" ]; then
+    echo "[host-stream-gate] PASS: echo '$feed'"
+  else
+    echo "[host-stream-gate] FAIL: echo '$feed' -> '$out'" >&2
+    exit 1
+  fi
+}
+
+check_echo "hello world"
+check_echo "vibe"
+
 echo "[host-stream-gate] done"

--- a/scripts/test_host_stream_bridge.sh
+++ b/scripts/test_host_stream_bridge.sh
@@ -57,16 +57,19 @@ check "ABC" 198   # 65 + 66 + 67
 check "AA"  130   # 65 + 65
 check ""    0     # empty body -> EOF immediately
 
-# read_all round-trip: feed a body and assert echo_stdin returns it verbatim.
+# read_all round-trip: feed a body and assert echo_stdin emits it verbatim.
+# echo_stdin uses `print` (no trailing newline), so stdout is byte-for-byte the
+# body; the runner then prints the function's Unit return ("0") right after it,
+# so the full captured output is "<body>0".
 check_echo() {
   local feed="$1"
   local out
   out="$(VIBE_STDIN_BYTES="$feed" bash "$RUNNER" --invoke echo_stdin "$WASM" 0 2>/dev/null \
-    | head -n1 || true)"
-  if [ "$out" = "$feed" ]; then
-    echo "[host-stream-gate] PASS: echo '$feed'"
+    | tr -d '\n' || true)"
+  if [ "$out" = "${feed}0" ]; then
+    echo "[host-stream-gate] PASS: echo '$feed' (verbatim)"
   else
-    echo "[host-stream-gate] FAIL: echo '$feed' -> '$out'" >&2
+    echo "[host-stream-gate] FAIL: echo '$feed' -> '$out' (expected '${feed}0')" >&2
     exit 1
   fi
 }

--- a/vibe/io/index.vibe
+++ b/vibe/io/index.vibe
@@ -1,8 +1,9 @@
 export let version = "0.0.1"
-export ./io.vibe { read, print, println, read_char, read_line, write_char }
+export ./io.vibe { read, read_all, print, println, read_char, read_line, write_char }
 
 // Canonical collision-safe aliases
 export let io_read = read
+export let io_read_all = read_all
 export let io_print = print
 export let io_println = println
 export let io_read_char = read_char

--- a/vibe/io/io.vibe
+++ b/vibe/io/io.vibe
@@ -39,18 +39,23 @@ export let read_line: () -> String with { Stdin } = () -> {
 // the "read the entire request body" primitive a WASI HTTP handler needs; on
 // the WASI 0.2 input-stream bridge (docs/spec/wasi-p3-async.md §3.3) the host
 // supplies the bytes and this consumes them via the read_char() loop.
+//
+// Accumulate into a StringBuilder and freeze once at EOF: real HTTP bodies are
+// large, so per-byte "\{acc}\{c}" concatenation (O(n^2) copies) is unacceptable.
 export let read_all: () -> String with { Stdin } = () -> {
   {
-    let mut acc = ""
+    let sb = StringBuilder::new()
     let mut done = false
     while not(done) {
       let c = Stdin::read_char()
       done = c < 0
-      acc = if c < 0 {
-        acc
-      } else "\{acc}\{String::from_char_code(c)}"
+      if c < 0 {
+        ()
+      } else {
+        StringBuilder::push(sb, String::from_char_code(c))
+      }
     }
-    acc
+    StringBuilder::freeze(sb)
   }
 }
 

--- a/vibe/io/io.vibe
+++ b/vibe/io/io.vibe
@@ -35,6 +35,25 @@ export let read_line: () -> String with { Stdin } = () -> {
   }
 }
 
+// Drain the input stream to EOF and return the whole body as a String. This is
+// the "read the entire request body" primitive a WASI HTTP handler needs; on
+// the WASI 0.2 input-stream bridge (docs/spec/wasi-p3-async.md §3.3) the host
+// supplies the bytes and this consumes them via the read_char() loop.
+export let read_all: () -> String with { Stdin } = () -> {
+  {
+    let mut acc = ""
+    let mut done = false
+    while not(done) {
+      let c = Stdin::read_char()
+      done = c < 0
+      acc = if c < 0 {
+        acc
+      } else "\{acc}\{String::from_char_code(c)}"
+    }
+    acc
+  }
+}
+
 export let write_char: (Int) -> Unit with { Stdout } = (code) -> {
   perform Stdout::WriteChar(code)
 }

--- a/vibe/io/stdin_stream_main.vibe
+++ b/vibe/io/stdin_stream_main.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./io.vibe {
-  println, read_all, read_char
+  print, println, read_all, read_char
 }
 
 //# Functions
@@ -25,8 +25,9 @@ export let print_stdin_sum: () -> Unit with { Stdin, Stdout } = () -> {
 }
 
 // Read the entire host-provided body and echo it back verbatim — the
-// "read the request body" round-trip. The gate feeds a known string and
-// asserts it comes back unchanged.
+// "read the request body" round-trip. Uses `print` (not `println`) so stdout is
+// byte-for-byte equal to the input. The gate feeds a known string and asserts
+// it comes back unchanged.
 export let echo_stdin: () -> Unit with { Stdin, Stdout } = () -> {
-  println(read_all())
+  print(read_all())
 }

--- a/vibe/io/stdin_stream_main.vibe
+++ b/vibe/io/stdin_stream_main.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./io.vibe {
-  read_char, println
+  println, read_all, read_char
 }
 
 //# Functions
@@ -22,4 +22,11 @@ export let print_stdin_sum: () -> Unit with { Stdin, Stdout } = () -> {
     }
   }
   println(Int::to_string(sum))
+}
+
+// Read the entire host-provided body and echo it back verbatim — the
+// "read the request body" round-trip. The gate feeds a known string and
+// asserts it comes back unchanged.
+export let echo_stdin: () -> Unit with { Stdin, Stdout } = () -> {
+  println(read_all())
 }

--- a/vibe/io/stdin_stream_test.vibe
+++ b/vibe/io/stdin_stream_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./io.vibe {
-  read_char
+  read_all, read_char
 }
 
 //# Functions
@@ -31,4 +31,10 @@ test "sum_stdin_bytes drains to EOF (empty stdin -> 0)" {
   // terminate at EOF with sum 0. The feed case (sum 198 for "ABC") is checked
   // end-to-end by scripts/test_host_stream_bridge.sh.
   assert(sum_stdin_bytes() == 0)
+}
+
+test "read_all drains to EOF (empty stdin -> \"\")" {
+  // Same EOF guarantee for the whole-body reader; the feed round-trip
+  // ("hello world" echoed back) is checked by the host-stream-bridge gate.
+  assert(read_all() == "")
 }


### PR DESCRIPTION
#575 で着地した WASI 0.2 input-stream ブリッジ上に、**「request body を丸ごと読む」プリミティブ `read_all`** を実装。WASI HTTP handler は body stream を EOF まで drain する必要があり、char 単位ではなく whole-body 読み出しが要る（docs/spec §3.3）。

## 実装

- **`vibe/io/io.vibe`**: `read_all : () -> String with { Stdin }` — input stream を read_char() ループで EOF まで drain して body 全体を String で返す。`vibe/io/index.vibe` から再 export（`io_read_all` canonical alias 付き）。
- **`vibe/io/stdin_stream_main.vibe`**: `echo_stdin` が body 全体を読んでそのまま echo（body round-trip）。
- **`scripts/test_host_stream_bridge.sh`**: 既知 body を feed し `echo_stdin` が変えずに返すことを検証（"hello world", "vibe"）。
- **`vibe/io/stdin_stream_test.vibe`**: CI-safe テスト — empty stdin で `read_all` が EOF→`""`（sum→0 と同じ保証）。

## 検証

- host-stream-bridge gate **全 PASS**: ABC→198 / AA→130 / ""→0（sum）+ echo round-trip（hello world, vibe）
- `stdin_stream_test` 2/2、`io_test` 5/5、`index_import_test` 1/1
- selfhost source 無変更（bundle sync ok）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHdX1R6gPNQym1o9FEy8Y6)_