### PR TITLE
feat(wasi-p3): M2c-3 ByteStream — lazy host-body stream at the vibe level

### DIFF
--- a/scripts/test_host_stream_bridge.sh
+++ b/scripts/test_host_stream_bridge.sh
@@ -95,4 +95,40 @@ check_split() {
 check_split "hello" "hel" "lo"
 check_split "abcdefg" "abc" "defg"
 
+# ByteStream "for await" consume: stream_echo pulls the body in 4-byte chunks and
+# prints each verbatim; the concatenation equals the body (runner appends the
+# Unit return "0").
+check_stream_echo() {
+  local feed="$1"
+  local out
+  out="$(VIBE_STDIN_BYTES="$feed" bash "$RUNNER" --invoke stream_echo "$WASM" 0 2>/dev/null \
+    | tr -d '\n' || true)"
+  if [ "$out" = "${feed}0" ]; then
+    echo "[host-stream-gate] PASS: stream_echo '$feed' (chunked verbatim)"
+  else
+    echo "[host-stream-gate] FAIL: stream_echo '$feed' -> '$out' (expected '${feed}0')" >&2
+    exit 1
+  fi
+}
+
+# ByteStream fold: stream_total prints the total byte count of the body.
+check_stream_total() {
+  local feed="$1" expected="$2"
+  local out
+  out="$(VIBE_STDIN_BYTES="$feed" bash "$RUNNER" --invoke stream_total "$WASM" 0 2>/dev/null \
+    | grep -E '^[0-9]+$' | head -n1 || true)"
+  if [ "$out" = "$expected" ]; then
+    echo "[host-stream-gate] PASS: stream_total '$feed' -> $out"
+  else
+    echo "[host-stream-gate] FAIL: stream_total '$feed' -> '$out' (expected $expected)" >&2
+    exit 1
+  fi
+}
+
+check_stream_echo "streaming body"
+check_stream_echo "abcdefghij"
+check_stream_total "streaming body" 14
+check_stream_total "abcdefghij" 10
+check_stream_total "" 0
+
 echo "[host-stream-gate] done"

--- a/vibe/io/byte_stream.vibe
+++ b/vibe/io/byte_stream.vibe
@@ -30,30 +30,31 @@ export let stdin_stream: (Int) -> (() -> Option[String] with { Stdin }) = (chunk
   }
 }
 
-// Terminal left-fold: pull every chunk and fold it onto the accumulator. This is
-// the workhorse consumer (sum/length/reconstruct) for a ByteStream.
-export let stream_fold: [U](() -> Option[String] with { Stdin }, U, (U, String) -> U) -> U with { Stdin } = (next, init, f) -> {
+// Terminal byte length: pull every chunk and sum its length — the body size.
+// This is a concrete scalar consumer; see the NOTE below on why a fully generic
+// `stream_fold[U]` is intentionally not exported.
+export let stream_byte_length: (() -> Option[String] with { Stdin }) -> Int with { Stdin } = (next) -> {
   {
-    let mut acc = init
+    let mut total = 0
     let mut done = false
     while not(done) {
       match next() {
         Some(chunk) => {
-          acc = f(acc, chunk)
+          total = total + String::length(chunk)
         },
         None => {
           done = true
         }
       }
     }
-    acc
+    total
   }
 }
 
 // Terminal drain-to-String: concatenate every chunk into the full body. Uses a
-// local StringBuilder (O(n)) rather than threading one through `stream_fold` —
-// the generic fold accumulator is a scalar slot and mishandles a heap-object
-// (StringBuilder) accumulator, so reconstruction needs this monomorphic form.
+// local StringBuilder (O(n)). See the NOTE below: a generic fold cannot safely
+// thread a heap-object (StringBuilder) accumulator, so reconstruction is a
+// dedicated monomorphic consumer.
 export let stream_to_string: (() -> Option[String] with { Stdin }) -> String with { Stdin } = (next) -> {
   {
     let sb = StringBuilder::new()
@@ -72,12 +73,18 @@ export let stream_to_string: (() -> Option[String] with { Stdin }) -> String wit
   }
 }
 
-// NOTE: a `for await`-style `stream_for_each(next, action)` that runs an
-// effectful action per chunk is not shipped yet — passing an effectful closure
-// through a higher-order param currently (a) does not infer the action's effect
-// row from the param type and (b) panics host codegen in combination with other
-// functions. Until that is fixed, run side effects by reconstructing via
-// `stream_fold` (see stream_echo) or by consuming `stream_collect`.
+// NOTE: this module intentionally ships only concrete terminal consumers
+// (stream_byte_length / stream_to_string / stream_collect) rather than a fully
+// generic `stream_fold[U]`. Two host-codegen limitations make a generic
+// higher-order fold unsafe as a public API today:
+//   1. A generic fold accumulator is stored in a scalar slot, so a heap-object
+//      accumulator (e.g. StringBuilder/ArrayBuilder) traps at runtime — yet
+//      `[U]` is unconstrained, so such a call still type-checks (a footgun).
+//   2. Passing an effectful closure through a higher-order param neither infers
+//      the closure's effect row from the param type nor survives codegen in
+//      combination with other functions, so a `for await`-style
+//      `stream_for_each(next, action)` cannot run effectful actions yet.
+// Until those are fixed, reconstruct/consume via the concrete terminals above.
 
 // Terminal collect: drain the stream into an Array of chunks.
 export let stream_collect: (() -> Option[String] with { Stdin }) -> Array[String] with { Stdin } = (next) -> {

--- a/vibe/io/byte_stream.vibe
+++ b/vibe/io/byte_stream.vibe
@@ -1,0 +1,99 @@
+// A lazy byte stream over the host-provided input stream — the vibe-level
+// `ByteStream` (docs/spec/wasi-p3-async.md §2.4 / §3.3). It models the WASI 0.3
+// `stream<u8>` HTTP request body as a pull-based async iterator without touching
+// codegen: the source is a `() -> Option[String] with { Stdin }` closure that
+// pulls one bounded chunk per step via `read_n` (a single
+// input-stream.blocking-read), yielding `None` at EOF. This is the eventual
+// `for await chunk in request_body { ... }` desugar target, expressed today as
+// an effectful closure + terminal consumers.
+
+//# Imports
+
+import ./io.vibe {
+  read_n
+}
+
+//# Functions
+
+// Build a ByteStream over the host input stream, pulling up to `chunk_size`
+// bytes per step. Each pull is one bounded host read (short reads preserved);
+// the stream ends (`None`) at EOF. The stream cursor is shared host state, so a
+// stream is single-pass.
+export let stdin_stream: (Int) -> (() -> Option[String] with { Stdin }) = (chunk_size) -> {
+  () -> Option[String] with { Stdin } {
+    let chunk = read_n(chunk_size)
+    if String::length(chunk) == 0 {
+      None
+    } else {
+      Some(chunk)
+    }
+  }
+}
+
+// Terminal left-fold: pull every chunk and fold it onto the accumulator. This is
+// the workhorse consumer (sum/length/reconstruct) for a ByteStream.
+export let stream_fold: [U](() -> Option[String] with { Stdin }, U, (U, String) -> U) -> U with { Stdin } = (next, init, f) -> {
+  {
+    let mut acc = init
+    let mut done = false
+    while not(done) {
+      match next() {
+        Some(chunk) => {
+          acc = f(acc, chunk)
+        },
+        None => {
+          done = true
+        }
+      }
+    }
+    acc
+  }
+}
+
+// Terminal drain-to-String: concatenate every chunk into the full body. Uses a
+// local StringBuilder (O(n)) rather than threading one through `stream_fold` —
+// the generic fold accumulator is a scalar slot and mishandles a heap-object
+// (StringBuilder) accumulator, so reconstruction needs this monomorphic form.
+export let stream_to_string: (() -> Option[String] with { Stdin }) -> String with { Stdin } = (next) -> {
+  {
+    let sb = StringBuilder::new()
+    let mut done = false
+    while not(done) {
+      match next() {
+        Some(chunk) => {
+          StringBuilder::push(sb, chunk)
+        },
+        None => {
+          done = true
+        }
+      }
+    }
+    StringBuilder::freeze(sb)
+  }
+}
+
+// NOTE: a `for await`-style `stream_for_each(next, action)` that runs an
+// effectful action per chunk is not shipped yet — passing an effectful closure
+// through a higher-order param currently (a) does not infer the action's effect
+// row from the param type and (b) panics host codegen in combination with other
+// functions. Until that is fixed, run side effects by reconstructing via
+// `stream_fold` (see stream_echo) or by consuming `stream_collect`.
+
+// Terminal collect: drain the stream into an Array of chunks.
+export let stream_collect: (() -> Option[String] with { Stdin }) -> Array[String] with { Stdin } = (next) -> {
+  {
+    let b = ArrayBuilder::new()
+    let mut done = false
+    while not(done) {
+      match next() {
+        Some(chunk) => {
+          ArrayBuilder::push(b, chunk)
+        },
+        None => {
+          done = true
+        }
+      }
+    }
+    ArrayBuilder::freeze(b)
+  }
+}

--- a/vibe/io/index.vibe
+++ b/vibe/io/index.vibe
@@ -1,5 +1,6 @@
 export let version = "0.0.1"
 export ./io.vibe { read, read_all, read_n, print, println, read_char, read_line, write_char }
+export ./byte_stream.vibe { stdin_stream, stream_fold, stream_collect, stream_to_string }
 
 // Canonical collision-safe aliases
 export let io_read = read

--- a/vibe/io/index.vibe
+++ b/vibe/io/index.vibe
@@ -1,6 +1,6 @@
 export let version = "0.0.1"
 export ./io.vibe { read, read_all, read_n, print, println, read_char, read_line, write_char }
-export ./byte_stream.vibe { stdin_stream, stream_fold, stream_collect, stream_to_string }
+export ./byte_stream.vibe { stdin_stream, stream_byte_length, stream_collect, stream_to_string }
 
 // Canonical collision-safe aliases
 export let io_read = read

--- a/vibe/io/stdin_stream_main.vibe
+++ b/vibe/io/stdin_stream_main.vibe
@@ -4,7 +4,7 @@ import ./io.vibe {
   print, println, read_all, read_char, read_n
 }
 import ./byte_stream.vibe {
-  stdin_stream, stream_fold, stream_to_string
+  stdin_stream, stream_byte_length, stream_to_string
 }
 
 //# Functions
@@ -56,6 +56,5 @@ export let stream_echo: () -> Unit with { Stdin, Stdout } = () -> {
 // ByteStream fold: count the total bytes of the host body by summing each
 // chunk's length — the workhorse consumer over the stream.
 export let stream_total: () -> Unit with { Stdin, Stdout } = () -> {
-  let total = stream_fold(stdin_stream(4), 0, (acc, chunk) -> { acc + String::length(chunk) })
-  println(Int::to_string(total))
+  println(Int::to_string(stream_byte_length(stdin_stream(4))))
 }

--- a/vibe/io/stdin_stream_main.vibe
+++ b/vibe/io/stdin_stream_main.vibe
@@ -3,6 +3,9 @@
 import ./io.vibe {
   print, println, read_all, read_char, read_n
 }
+import ./byte_stream.vibe {
+  stdin_stream, stream_fold, stream_to_string
+}
 
 //# Functions
 
@@ -40,4 +43,19 @@ export let split_stdin: () -> Unit with { Stdin, Stdout } = () -> {
     println(read_n(3))
     println(read_all())
   }
+}
+
+// ByteStream consume: pull the host body in 4-byte chunks and reconstruct it by
+// folding the chunks into a StringBuilder, then print once. The output equals
+// the body, proving the lazy stream drains the host source in order across
+// multiple pulls.
+export let stream_echo: () -> Unit with { Stdin, Stdout } = () -> {
+  print(stream_to_string(stdin_stream(4)))
+}
+
+// ByteStream fold: count the total bytes of the host body by summing each
+// chunk's length — the workhorse consumer over the stream.
+export let stream_total: () -> Unit with { Stdin, Stdout } = () -> {
+  let total = stream_fold(stdin_stream(4), 0, (acc, chunk) -> { acc + String::length(chunk) })
+  println(Int::to_string(total))
 }

--- a/vibe/io/stdin_stream_test.vibe
+++ b/vibe/io/stdin_stream_test.vibe
@@ -4,7 +4,7 @@ import ./io.vibe {
   read_all, read_char, read_n
 }
 import ./byte_stream.vibe {
-  stdin_stream, stream_collect, stream_fold, stream_to_string
+  stdin_stream, stream_byte_length, stream_collect, stream_to_string
 }
 
 //# Functions
@@ -54,8 +54,7 @@ test "ByteStream over empty stdin yields nothing" {
   // An empty host stream produces no chunks: fold keeps init, collect is empty.
   // The fed case (stream_echo / stream_total over a real body) is checked
   // end-to-end by scripts/test_host_stream_bridge.sh.
-  let total = stream_fold(stdin_stream(4), 0, (acc, chunk) -> { acc + String::length(chunk) })
-  assert(total == 0)
+  assert(stream_byte_length(stdin_stream(4)) == 0)
   assert(Array::length(stream_collect(stdin_stream(4))) == 0)
   assert(stream_to_string(stdin_stream(4)) == "")
 }

--- a/vibe/io/stdin_stream_test.vibe
+++ b/vibe/io/stdin_stream_test.vibe
@@ -3,6 +3,9 @@
 import ./io.vibe {
   read_all, read_char, read_n
 }
+import ./byte_stream.vibe {
+  stdin_stream, stream_collect, stream_fold, stream_to_string
+}
 
 //# Functions
 
@@ -45,4 +48,14 @@ test "read_n stops at EOF / zero (empty stdin -> \"\")" {
   // end-to-end by scripts/test_host_stream_bridge.sh.
   assert(read_n(0) == "")
   assert(read_n(8) == "")
+}
+
+test "ByteStream over empty stdin yields nothing" {
+  // An empty host stream produces no chunks: fold keeps init, collect is empty.
+  // The fed case (stream_echo / stream_total over a real body) is checked
+  // end-to-end by scripts/test_host_stream_bridge.sh.
+  let total = stream_fold(stdin_stream(4), 0, (acc, chunk) -> { acc + String::length(chunk) })
+  assert(total == 0)
+  assert(Array::length(stream_collect(stdin_stream(4))) == 0)
+  assert(stream_to_string(stdin_stream(4)) == "")
 }


### PR DESCRIPTION
§3.3.1 step (b) を **codegen 非変更**で前進。`read_n` の上に、WASI 0.3 `stream<u8>` HTTP body を **pull ベース async iterator** として表現する vibe-level `ByteStream` を構築（docs/spec §2.4 / §3.3）。source は `() -> Option[String] with { Stdin }` クロージャで、1 step ごとに `read_n`（単一 input-stream.blocking-read）で bounded chunk を pull し EOF で `None`。これは将来の `for await chunk in body { ... }` の desugar 先を、今は effectful closure + terminal consumer として表現したもの。

## 実装

- **`vibe/io/byte_stream.vibe`**（新規）:
  - `stdin_stream(chunk_size)` — host input stream 上の ByteStream
  - `stream_fold(next, init, f)` — terminal left-fold（scalar accumulator）
  - `stream_collect(next)` — `Array[String]` に drain
  - `stream_to_string(next)` — body 全体の String に drain（monomorphic / local StringBuilder）
  - `index.vibe` から再 export
- **`stdin_stream_main.vibe`**: `stream_echo`（4-byte chunk で body 再構成）/ `stream_total`（fold で byte 数）gate demo
- **gate**: stream_echo verbatim + stream_total（streaming body→14, abcdefghij→10, ""→0）
- **CI-safe test**: empty stream で fold==0 / collect empty / to_string==""

## 発見した制約（follow-up、blocker ではない）

1. **effectful `stream_for_each(next, action)` は未出荷** — effectful closure を HOF param 経由で渡すと (a) action の effect row が param 型から推論されず、(b) 他関数との組合せで host codegen が panic。当面 side effect は `stream_to_string` 再構成 or `stream_collect` で対応。
2. **generic `stream_fold` の accumulator は scalar 限定** — heap-object（StringBuilder）を通すと trap。ゆえに再構成は monomorphic な `stream_to_string`。

いずれも host codegen の別バグで、本 PR は vibe-level API として動く範囲を出荷。

## 検証

gate 全 PASS、stdin tests 4/4、io_test 5/5、index_import_test 1/1、selfhost 無変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHdX1R6gPNQym1o9FEy8Y6)_