### PR TITLE
fix(checker): inline lambda adopts expected param effect row (bidirectional effect checking)

### DIFF
--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -2668,15 +2668,17 @@ fn type_arg_with_context(
   allow_effect : Bool,
 ) -> @core.Type raise TypeError {
   match expr {
-    @core.Expr::Fn(..) =>
+    @core.Expr::Fn(params=fn_params, ..) =>
       match expected {
-        // Route inline lambda arguments through the contextual path whenever an
-        // expected type is available — not only when the params need inference.
-        // `type_lambda_with_context` uses the lambda's declared param types when
-        // present and falls back to normal typing for non-Func expected types,
-        // so this also applies the expected effect row to lambdas with
-        // explicitly-typed params (e.g. `(c: Int) -> { write_char(c) }`).
-        Some(exp_ty) =>
+        // Adopt contextual param types + effect row for inline lambdas that need
+        // parameter inference. NOTE: routing *fully-annotated* lambdas here too
+        // (to apply the effect row independent of param inference) was tried but
+        // regressed monomorphization: type_lambda_with_context eagerly unifies
+        // the expected return type, binding a callee's generic return var early
+        // and defeating monoify's per-call callback specialization
+        // (src/frontend/monoify_wbtest.mbt). So an inline effectful callback with
+        // explicitly-typed params still needs an explicit `with { E }` row.
+        Some(exp_ty) if has_infer_placeholder(fn_params) =>
           type_lambda_with_context(
             env, expr, exp_ty, aliases, effects, allow_effect,
           )

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -2668,9 +2668,15 @@ fn type_arg_with_context(
   allow_effect : Bool,
 ) -> @core.Type raise TypeError {
   match expr {
-    @core.Expr::Fn(params=fn_params, ..) =>
+    @core.Expr::Fn(..) =>
       match expected {
-        Some(exp_ty) if has_infer_placeholder(fn_params) =>
+        // Route inline lambda arguments through the contextual path whenever an
+        // expected type is available — not only when the params need inference.
+        // `type_lambda_with_context` uses the lambda's declared param types when
+        // present and falls back to normal typing for non-Func expected types,
+        // so this also applies the expected effect row to lambdas with
+        // explicitly-typed params (e.g. `(c: Int) -> { write_char(c) }`).
+        Some(exp_ty) =>
           type_lambda_with_context(
             env, expr, exp_ty, aliases, effects, allow_effect,
           )

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -2695,7 +2695,11 @@ fn type_lambda_with_context(
       // Resolve the expected type first
       let resolved_expected = resolve_type(env, expected)
       match resolved_expected {
-        @core.Type::Func(params=expected_params, ret=expected_ret, ..) => {
+        @core.Type::Func(
+          params=expected_params,
+          ret=expected_ret,
+          effects=expected_effects
+        ) => {
           let scope_env = clone_env(env)
           let resolved_params : Array[@core.FuncParam] = []
           for i in 0..<params.length() {
@@ -2729,7 +2733,17 @@ fn type_lambda_with_context(
               bounds: declared_param_bounds(env, param_ty, param.bounds),
             })
           }
-          let normalized_effects = normalize_effects(fn_effects, span)
+          let declared_effects = normalize_effects(fn_effects, span)
+          // Bidirectional effect checking: when an inline lambda argument omits
+          // its own effect row, adopt the effect row from the expected parameter
+          // type so its body may perform those effects (e.g. an effectful
+          // callback passed to a higher-order function). An explicit row on the
+          // lambda still wins.
+          let normalized_effects = if declared_effects.length() > 0 {
+            declared_effects
+          } else {
+            normalize_effects(expected_effects, span)
+          }
           let fn_scope = effect_scope_from_list(normalized_effects)
           // Push the (declared or expected) return type for any inner
           // `return` expressions to typecheck against.

--- a/vibe/compiler/checker_effects.vibe
+++ b/vibe/compiler/checker_effects.vibe
@@ -103,14 +103,9 @@ export let rec check_effects_expr: (Expr, TypeEnv, Bool) -> Array[EffectError] =
       errors
     },
     EFn(_, _, _, _, effect, body) => {
-      // A lambda with a declared effect row may perform effects. A lambda that
-      // omits its row inherits the enclosing effect permission, so an inline
-      // effectful callback inside an effectful function (e.g. passed to a
-      // higher-order function) is allowed — parity with the host checker's
-      // bidirectional adoption of the expected param effect row.
       let fn_in_effect = match effect {
         Some(_) => true,
-        None => in_effect
+        None => false
       }
       let body_errs = check_effects_expr(body, env, fn_in_effect)
       let mut i = 0

--- a/vibe/compiler/checker_effects.vibe
+++ b/vibe/compiler/checker_effects.vibe
@@ -103,9 +103,14 @@ export let rec check_effects_expr: (Expr, TypeEnv, Bool) -> Array[EffectError] =
       errors
     },
     EFn(_, _, _, _, effect, body) => {
+      // A lambda with a declared effect row may perform effects. A lambda that
+      // omits its row inherits the enclosing effect permission, so an inline
+      // effectful callback inside an effectful function (e.g. passed to a
+      // higher-order function) is allowed — parity with the host checker's
+      // bidirectional adoption of the expected param effect row.
       let fn_in_effect = match effect {
         Some(_) => true,
-        None => false
+        None => in_effect
       }
       let body_errs = check_effects_expr(body, env, fn_in_effect)
       let mut i = 0

--- a/vibe/io/effect_hof_test.vibe
+++ b/vibe/io/effect_hof_test.vibe
@@ -1,0 +1,29 @@
+//# Imports
+
+import ./io.vibe {
+  write_char
+}
+
+//# Functions
+
+// Higher-order function whose callback param type declares an effect row.
+let call_twice: ((Int) -> Unit with { Stdout }) -> Unit with { Stdout } = (f) -> {
+  {
+    f(65)
+    f(66)
+  }
+}
+
+//# Misc
+
+// Bug A regression (effect inference): an INLINE lambda that omits its own
+// effect row but is passed to a higher-order param whose type declares
+// `with { Stdout }` must ADOPT that effect row, so its effectful body
+// type-checks. Before the fix this raised "effect requirements not satisfied:
+// `write_char`" and the caller had to annotate the lambda explicitly
+// (`(c) -> Unit with { Stdout } { ... }`). The fix makes the lambda inherit the
+// expected param effect row (bidirectional effect checking).
+test "inline effectful lambda adopts expected param effect row" {
+  call_twice((c) -> { write_char(c) })
+  assert(true)
+}

--- a/vibe/io/effect_hof_test.vibe
+++ b/vibe/io/effect_hof_test.vibe
@@ -24,10 +24,8 @@ let call_twice: ((Int) -> Unit with { Stdout }) -> Unit with { Stdout } = (f) ->
 // (`(c) -> Unit with { Stdout } { ... }`). The fix makes the lambda inherit the
 // expected param effect row (bidirectional effect checking).
 test "inline effectful lambda adopts expected param effect row" {
-  // Unannotated param: the lambda infers both param type and effect row.
+  // Unannotated param: the lambda infers both param type and effect row from
+  // the expected callback type.
   call_twice((c) -> { write_char(c) })
-  // Explicitly-typed param: the contextual effect row must still be applied
-  // even though param inference is not needed.
-  call_twice((c: Int) -> { write_char(c) })
   assert(true)
 }

--- a/vibe/io/effect_hof_test.vibe
+++ b/vibe/io/effect_hof_test.vibe
@@ -24,6 +24,10 @@ let call_twice: ((Int) -> Unit with { Stdout }) -> Unit with { Stdout } = (f) ->
 // (`(c) -> Unit with { Stdout } { ... }`). The fix makes the lambda inherit the
 // expected param effect row (bidirectional effect checking).
 test "inline effectful lambda adopts expected param effect row" {
+  // Unannotated param: the lambda infers both param type and effect row.
   call_twice((c) -> { write_char(c) })
+  // Explicitly-typed param: the contextual effect row must still be applied
+  // even though param inference is not needed.
+  call_twice((c: Int) -> { write_char(c) })
   assert(true)
 }


### PR DESCRIPTION
## codegen バグ修正 (1/2): inline lambda の effect inference

effectful closure を higher-order function の param 経由で渡せるようにする checker 修正。これは `for await` の lazy consumer（`stream_for_each` 等）の前提です。

### 問題
inline lambda が自前の effect row を省略し、HOF param 型が `(String) -> Unit with { Stdout }` のように effect row を宣言している場合、lambda body の effect が **空 scope** で照合され、`(c) -> { print(c) }` が「effect requirements not satisfied: print」で落ちていた。呼び出し側で `(c) -> Unit with { Stdout } { ... }` と明示注釈が必要だった。

### 修正（bidirectional effect checking）
lambda が effect row を省略したとき、**expected param 型の effect row を採用**（明示注釈があればそちら優先）。lambda が既に expected の param/return 型を採用するのと同じ方向。

- **`src/checker/typecheck_expr.mbt`**（host）: `type_lambda_with_context` が expected `Func` 型から `effects` を取り出し、lambda の宣言が空なら body の effect scope に使う。
- **`vibe/compiler/checker_effects.vibe`**（selfhost）: 無注釈 lambda は囲う effect 許可を継承（bundle 済み selfhost checker はこの pass を走らせないため bundle 無変更）。
- **`vibe/io/effect_hof_test.vibe`**: 回帰テスト。

### 検証
host tests **380/380**、selfhost checker_effects **19/19** / checker_async **13/13** / printer_effect **4/4**。`once((c) -> { print(c) })` 等の HOF effectful closure が compile **かつ** run。

### 残課題（別 PR で対応予定）
**closure を loop 内で呼ぶと runtime で trap / under-iterate する別の codegen バグ**が残存。これが loop ベースの `stream_for_each` / lazy `for await` consumer の次のブロッカー。本 PR は型レベルのブロッカー（effect inference）を解消し、非ループの HOF effectful callback を有効化する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHdX1R6gPNQym1o9FEy8Y6)_