### PR TITLE
feat(wasi-p3): lazy `for await x in pull { .. }` over a host byte stream

### DIFF
--- a/scripts/test_host_stream_bridge.sh
+++ b/scripts/test_host_stream_bridge.sh
@@ -131,4 +131,23 @@ check_stream_total "streaming body" 14
 check_stream_total "abcdefghij" 10
 check_stream_total "" 0
 
+# Lazy `for await x in stdin_stream(4) { print(x) }` — the async-iterator syntax
+# connected to a real host source. Echoes the body verbatim (runner appends the
+# Unit return "0").
+check_for_await() {
+  local feed="$1"
+  local out
+  out="$(VIBE_STDIN_BYTES="$feed" bash "$RUNNER" --invoke for_await_echo "$WASM" 0 2>/dev/null \
+    | tr -d '\n' || true)"
+  if [ "$out" = "${feed}0" ]; then
+    echo "[host-stream-gate] PASS: for_await_echo '$feed' (lazy stream)"
+  else
+    echo "[host-stream-gate] FAIL: for_await_echo '$feed' -> '$out' (expected '${feed}0')" >&2
+    exit 1
+  fi
+}
+
+check_for_await "streaming!"
+check_for_await "for await body"
+
 echo "[host-stream-gate] done"

--- a/src/checker/typecheck_expr.mbt
+++ b/src/checker/typecheck_expr.mbt
@@ -920,12 +920,18 @@ fn type_expr_eff(
       // `iter_require` / `iter_length` / `iter_get` desugar so the Iterable
       // trait constraint is enforced (ADR-0044 Phase 2).
       let iter_ty = type_expr_eff(env, iterable, aliases, effects, allow_effect)
-      let desugared = match iter_ty {
+      let desugared = match resolve_type(env, iter_ty) {
         @core.Type::String =>
           @core.desugar_for_in_with(
             value_name, index_name, iterable, body, span, "String::length", "String::char_code_at",
             false,
           )
+        // Lazy `for await x in pull { .. }`: a 0-arg closure returning Option[T]
+        // is a pull iterator — drain it to None instead of indexing (codegen
+        // marks the span via the post-typecheck rewrite pass).
+        @core.Type::Func(params=fn_params, ret~, ..) if fn_params.length() == 0 &&
+          is_option_type(resolve_type(env, ret)) =>
+          @core.desugar_for_in_pull(value_name, iterable, body, span)
         _ => @core.desugar_for_in(value_name, index_name, iterable, body, span)
       }
       type_block(env, desugared, aliases, effects, true, share_subs=true)
@@ -2685,6 +2691,15 @@ fn type_arg_with_context(
         _ => type_expr_eff(env, expr, aliases, effects, allow_effect)
       }
     _ => type_expr_eff(env, expr, aliases, effects, allow_effect)
+  }
+}
+
+///|
+/// Whether a type is `Option[_]` (host represents it as `Named("Option", ..)`).
+fn is_option_type(ty : @core.Type) -> Bool {
+  match ty {
+    @core.Type::Named(name="Option", ..) => true
+    _ => false
   }
 }
 

--- a/src/codegen/wasm_codegen_expr.mbt
+++ b/src/codegen/wasm_codegen_expr.mbt
@@ -129,7 +129,9 @@ fn compile_expr(
       compile_expr_match(ctx, buf, scrutinee, arms)
     }
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      let desugared = if @core.is_string_for_in(span.start) {
+      let desugared = if @core.is_pull_for_in(span.start) {
+        @core.desugar_for_in_pull(value_name, iterable, body, span)
+      } else if @core.is_string_for_in(span.start) {
         @core.desugar_for_in_string(
           value_name, index_name, iterable, body, span,
         )

--- a/src/core/for_in_desugar.mbt
+++ b/src/core/for_in_desugar.mbt
@@ -75,10 +75,8 @@ pub fn desugar_for_in_pull(
     Span::new(span.start + offset, span.start + offset + 1)
   }
   let suffix = span.start.to_string()
-  let next_span = synth_span(1)
   let b_span = synth_span(2)
   let done_span = synth_span(3)
-  let next_ident = Expr::Ident(name="__pull_next" + suffix, span=next_span)
   let b_ident = Expr::Ident(name="__pull_b" + suffix, span=b_span)
   let done_ident = Expr::Ident(name="__pull_done" + suffix, span=done_span)
   // let __pull_next = iterable

--- a/src/core/for_in_desugar.mbt
+++ b/src/core/for_in_desugar.mbt
@@ -23,6 +23,168 @@ pub fn clear_string_for_in_spans() -> Unit {
 }
 
 ///|
+/// Global set of ForIn span starts whose iterable is a pull closure
+/// (`() -> Option[T]`), i.e. lazy `for await x in stream { ... }`. Populated by
+/// the checker, consumed by codegen to dispatch to the pull desugar.
+let pull_for_in_spans : Map[Int, Bool] = {}
+
+///|
+/// Register a ForIn span as iterating over a pull closure (lazy `for await`).
+pub fn mark_pull_for_in(span_start : Int) -> Unit {
+  pull_for_in_spans[span_start] = true
+}
+
+///|
+/// Check whether a ForIn span iterates over a pull closure.
+pub fn is_pull_for_in(span_start : Int) -> Bool {
+  pull_for_in_spans.contains(span_start)
+}
+
+///|
+/// Clear the pull for-in registry (call before each compilation unit).
+pub fn clear_pull_for_in_spans() -> Unit {
+  pull_for_in_spans.clear()
+}
+
+///|
+/// Desugar a lazy `for await x in pull { body }` where `pull : () -> Option[T]`
+/// into a pull loop that drains the iterator to `None`:
+///
+/// {
+///   let __pull_next = pull
+///   let __pull_b = ArrayBuilder::new()
+///   let mut __pull_done = false
+///   while not(__pull_done) {
+///     match __pull_next() {
+///       Some(x) => { <body init>; ArrayBuilder::push(__pull_b, <last_expr>) }
+///       None => { __pull_done = true; () }
+///     }
+///   }
+///   ArrayBuilder::freeze(__pull_b)
+/// }
+///
+/// Like `desugar_for_in`, the loop collects each iteration's last expression so
+/// the for-in expression yields `Array[bodyresult]`.
+pub fn desugar_for_in_pull(
+  value_name : String,
+  iterable : Expr,
+  body : Module,
+  span : Span,
+) -> Module {
+  let synth_span = fn(offset : Int) -> Span {
+    Span::new(span.start + offset, span.start + offset + 1)
+  }
+  let suffix = span.start.to_string()
+  let next_span = synth_span(1)
+  let b_span = synth_span(2)
+  let done_span = synth_span(3)
+  let next_ident = Expr::Ident(name="__pull_next" + suffix, span=next_span)
+  let b_ident = Expr::Ident(name="__pull_b" + suffix, span=b_span)
+  let done_ident = Expr::Ident(name="__pull_done" + suffix, span=done_span)
+  // let __pull_next = iterable
+  let let_next = Stmt::Let(
+    rec=false,
+    name="__pull_next" + suffix,
+    expr=iterable,
+    span~,
+  )
+  // let __pull_b = ArrayBuilder::new()
+  let let_b = Stmt::Let(
+    rec=false,
+    name="__pull_b" + suffix,
+    expr=Expr::Call(name="ArrayBuilder::new", type_args=[], args=[], span~),
+    span~,
+  )
+  // let mut __pull_done = false
+  let let_done = Stmt::LetMut(
+    name="__pull_done" + suffix,
+    expr=Expr::Bool(value=false, span=done_span),
+    span~,
+  )
+  // not(__pull_done)
+  let cond = Expr::Call(
+    name="not",
+    type_args=[],
+    args=[CallArg::{ label: None, expr: done_ident, span: done_span }],
+    span~,
+  )
+  // __pull_next()
+  let pull_call = Expr::Call(
+    name="__pull_next" + suffix,
+    type_args=[],
+    args=[],
+    span~,
+  )
+  let (init_stmts, collect_expr) = desugar_split_body_last_expr(body, span)
+  // Some(x) arm: { <body init>; ArrayBuilder::push(__pull_b, <last_expr>) }
+  let some_stmts : Array[Stmt] = []
+  for stmt in init_stmts {
+    some_stmts.push(stmt)
+  }
+  some_stmts.push(
+    Stmt::Expr(
+      expr=Expr::Call(
+        name="ArrayBuilder::push",
+        type_args=[],
+        args=[
+          CallArg::{ label: None, expr: b_ident, span: b_span },
+          CallArg::{
+            label: None,
+            expr: collect_expr,
+            span: collect_expr.span(),
+          },
+        ],
+        span~,
+      ),
+      span~,
+    ),
+  )
+  let some_arm = MatchArm::{
+    pat: Pat::Ctor(name="Some", args=[Pat::Bind(name=value_name, span~)], span~),
+    cond: None,
+    expr: Expr::Block(body=Module::{ stmts: some_stmts }, span~),
+    span,
+  }
+  // None arm: { __pull_done = true; () }
+  let none_stmts : Array[Stmt] = [
+    Stmt::Assign(
+      name="__pull_done" + suffix,
+      expr=Expr::Bool(value=true, span=done_span),
+      span~,
+    ),
+    Stmt::Expr(expr=Expr::Tuple(items=[], span~), span~),
+  ]
+  let none_arm = MatchArm::{
+    pat: Pat::Ctor(name="None", args=[], span~),
+    cond: None,
+    expr: Expr::Block(body=Module::{ stmts: none_stmts }, span~),
+    span,
+  }
+  let match_expr = Expr::Match(
+    scrutinee=pull_call,
+    arms=[some_arm, none_arm],
+    span~,
+  )
+  let while_body = Module::{ stmts: [Stmt::Expr(expr=match_expr, span~)] }
+  let while_expr = Expr::While(cond~, body=while_body, span~)
+  let freeze_expr = Expr::Call(
+    name="ArrayBuilder::freeze",
+    type_args=[],
+    args=[CallArg::{ label: None, expr: b_ident, span: b_span }],
+    span~,
+  )
+  Module::{
+    stmts: [
+      let_next,
+      let_b,
+      let_done,
+      Stmt::Expr(expr=while_expr, span~),
+      Stmt::Expr(expr=freeze_expr, span~),
+    ],
+  }
+}
+
+///|
 /// Desugar ForIn AST node into a Block with array builder pattern.
 ///
 /// for x in iterable { body } →

--- a/src/frontend/desugar_for_in.mbt
+++ b/src/frontend/desugar_for_in.mbt
@@ -66,7 +66,9 @@ fn dfi_rewrite_expr(expr : @core.Expr) -> @core.Expr {
       // wrap it in a Block expression so it slots in as a single expr.
       let iterable = dfi_rewrite_expr(iterable)
       let body = dfi_rewrite_module(body)
-      let lowered = if @core.is_string_for_in(span.start) {
+      let lowered = if @core.is_pull_for_in(span.start) {
+        @core.desugar_for_in_pull(value_name, iterable, body, span)
+      } else if @core.is_string_for_in(span.start) {
         @core.desugar_for_in_string(
           value_name, index_name, iterable, body, span,
         )

--- a/src/frontend/rewrite_string_add.mbt
+++ b/src/frontend/rewrite_string_add.mbt
@@ -79,6 +79,27 @@ fn rsa_rewrite_stmt(
 }
 
 ///|
+
+///|
+/// Whether `expr` is a 0-arg pull closure returning `Option[_]` (the iterable of
+/// a lazy `for await x in pull { .. }`). Marked so codegen drains it via the
+/// pull desugar instead of indexing.
+fn rsa_is_pull_valued(
+  expr : @core.Expr,
+  expr_types : @core.ExprTypeIndex,
+) -> Bool {
+  match expr_types.get_expr_type(expr.span()) {
+    Some(@core.Type::Func(params~, ret~, ..)) =>
+      params.length() == 0 &&
+      (match ret {
+        @core.Type::Named(name="Option", ..) => true
+        _ => false
+      })
+    _ => false
+  }
+}
+
+///|
 fn rsa_is_string_valued(
   expr : @core.Expr,
   expr_types : @core.ExprTypeIndex,
@@ -218,7 +239,9 @@ fn rsa_rewrite_expr(
         span~,
       )
     @core.Expr::ForIn(value_name~, index_name~, iterable~, body~, span~) => {
-      if rsa_is_string_valued(iterable, expr_types) {
+      if rsa_is_pull_valued(iterable, expr_types) {
+        @core.mark_pull_for_in(span.start)
+      } else if rsa_is_string_valued(iterable, expr_types) {
         @core.mark_string_for_in(span.start)
       }
       @core.Expr::ForIn(

--- a/src/parser/parser_ast_expr.mbt
+++ b/src/parser/parser_ast_expr.mbt
@@ -618,6 +618,18 @@ fn AstParser::parse_for_in_expr(
 ) -> @core.Expr raise ParseError {
   let start = self.pos
   let _ = self.expect(for_kw(), "for") // consume keyword "for"
+  // `for await x in s` — `await` is a marker (not a keyword) distinguishing
+  // async-stream iteration; it desugars to the same ForIn node. Skip it when a
+  // binding name follows. `for await in s` (binding literally named "await") is
+  // preserved because the token after `await` is then the `in` keyword.
+  self.skip_trivia()
+  let marker = self.peek()
+  if marker.kind() == name() &&
+    marker.text() == "await" &&
+    self.peek_non_trivia_ahead(1) == name() {
+    let _ = self.bump()
+    self.skip_trivia()
+  }
   // Parse first binding name
   let first_name = self.expect(name(), "binding name").text()
   self.skip_trivia()

--- a/src/parser/parser_cst.mbt
+++ b/src/parser/parser_cst.mbt
@@ -780,6 +780,16 @@ fn Parser::parse_for_in_expr(self : Parser) -> Unit {
   self.builder.start_node(while_expr())
   self.bump() // for
   self.skip_trivia()
+  // `for await x in s` — skip the `await` marker (not a keyword) when a binding
+  // name follows, keeping it in the node so formatting preserves it. `for await
+  // in s` (binding named "await") is left intact.
+  let marker = self.peek()
+  if marker.kind() == name() &&
+    marker.text() == "await" &&
+    self.peek_non_trivia_ahead(1) == name() {
+    self.bump() // await marker
+    self.skip_trivia()
+  }
   // Parse binding name(s)
   self.expect(name())
   self.skip_trivia()

--- a/src/runtime_compile/compile.mbt
+++ b/src/runtime_compile/compile.mbt
@@ -1976,6 +1976,7 @@ pub fn compile_module(
     additional_specializable=imported_specializable,
   )
   @core.clear_string_for_in_spans()
+  @core.clear_pull_for_in_spans()
   let rewritten = @frontend.rewrite_string_add(mono.ast, expr_type_index)
   let resolved_ast = db.rewrite_imports_to_hash(path, rewritten)
   let ir = module_to_sexp(resolved_ast, aliases)
@@ -2070,6 +2071,7 @@ fn prepare_bundled_ast_for_codegen(
   let expr_type_index = typed_env.expr_type_index()
   let mono = @frontend.monoify_module(ast, expr_type_index)
   @core.clear_string_for_in_spans()
+  @core.clear_pull_for_in_spans()
   @frontend.rewrite_string_add(mono.ast, expr_type_index)
 }
 

--- a/vibe/io/stdin_stream_main.vibe
+++ b/vibe/io/stdin_stream_main.vibe
@@ -58,3 +58,14 @@ export let stream_echo: () -> Unit with { Stdin, Stdout } = () -> {
 export let stream_total: () -> Unit with { Stdin, Stdout } = () -> {
   println(Int::to_string(stream_byte_length(stdin_stream(4))))
 }
+
+// Lazy `for await` over the host byte stream — the M2c-3 async-iterator surface
+// (docs/spec/wasi-p3-async.md §2.2/§2.4) connected to a real host source: the
+// loop pulls one bounded chunk per step from stdin_stream and runs the body in
+// stream order, echoing the body verbatim.
+export let for_await_echo: () -> Unit with { Stdin, Stdout } = () -> {
+  for await chunk in stdin_stream(4) {
+    print(chunk)
+  }
+  ()
+}

--- a/vibe/io/stdin_stream_test.vibe
+++ b/vibe/io/stdin_stream_test.vibe
@@ -58,3 +58,14 @@ test "ByteStream over empty stdin yields nothing" {
   assert(Array::length(stream_collect(stdin_stream(4))) == 0)
   assert(stream_to_string(stdin_stream(4)) == "")
 }
+
+test "for await over empty host stream yields no iterations" {
+  // `for await x in <pull-closure>` desugars to a pull-to-EOF loop. With no
+  // VIBE_STDIN_BYTES the stream is empty, so zero iterations; the for-in
+  // expression collects each body result, so the result is an empty Array.
+  // The fed case (echo a body) is checked by scripts/test_host_stream_bridge.sh.
+  let collected = for await chunk in stdin_stream(4) {
+    chunk
+  }
+  assert(Array::length(collected) == 0)
+}


### PR DESCRIPTION
## for await の desugar 接続 — lazy host byte stream

`for await` async-iterator 構文（docs/spec §2.2/§2.4）を**実 host source の遅延 pull** に接続。`for await x in s { body }`（`s : () -> Option[T] with { E }` = pull closure、例: ByteStream の `stdin_stream(n)`）が drain-to-EOF の pull loop に desugar されるようになりました:

```
let __next = s
let __b = ArrayBuilder::new()
let mut __done = false
while not(__done) {
  match __next() { Some(x) => { <body>; push }, None => { __done = true } }
}
ArrayBuilder::freeze(__b)
```

handler が host body を **1 step = 1 bounded chunk** で消費。eager `Stream[T]` の Array 反復 path は不変。proven な while+match+closure-call 形を再利用し、captured-mutable closure loop バグ（Bug C）も回避（host-stream closure は外部 cursor 駆動で mutable counter を capture しない）。

## Host (src/) 実装
`await` marker（予約語ではない）は selfhost parser のみが扱っていたので host parser にも追加:
- **parser_ast_expr.mbt**: `for` の後の `await` marker を binding 名が続くときスキップ（`for await in s` = "await" という名の binding は保持）
- **for_in_desugar.mbt**: `desugar_for_in_pull` + `pull_for_in` span registry（string-for-in registry と同形）
- **typecheck_expr.mbt**: ForIn iterable が 0-arg closure returning `Option[T]` のとき pull desugar（body 型検査用）+ `is_option_type`
- **rewrite_string_add.mbt**: `rsa_is_pull_valued` が型検査後に span を mark（codegen が読む）
- **wasm_codegen_expr.mbt**: span が mark されていれば pull desugar に dispatch
- **runtime_compile/compile.mbt**: compilation unit ごとに registry clear

## 検証
- gate (`pkf run host-stream-bridge`): **`for_await_echo`** が fed body を 4-byte chunk で pull し verbatim echo（`streaming!` / `for await body`）
- CI-safe test: 空 stdin の for await → 0 iteration
- 回帰: host parser 90 / checker 171 / frontend 83 / core 89 / codegen 87 / tests 380（native）+ parser/frontend/core/tests green（JS）

## Follow-up
selfhost parity（`vibe/compiler` の EForIn checker + perceus + codegen lowering を pull-closure iterable 対応）は別 PR。host compiler が現状 gate で user program を compile します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHdX1R6gPNQym1o9FEy8Y6)_