### PR TITLE
feat(selfhost): dist↔stage2 artifact-layer contract + vibe.abi parity gate (#529)

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1113,6 +1113,13 @@ local testSelfhostCheckParity = new Task {
   deps { testSelfhostCheckBootstrapParity }
 }
 
+// #529 artifact-layer contract gate: dist (host-compiled shipping) and stage2
+// (self-reproduced) compilers must agree on the vibe.abi custom section and
+// behaviour of emitted program wasm. The two compiler binaries are byte-
+// different by design; equivalence is a contract, not byte unification.
+local testSelfhostDistStage2Parity =
+  scriptTask("test-selfhost-dist-stage2-parity", "scripts/test_selfhost_dist_stage2_parity.sh")
+
 // Byte-equal --human stdout parity for the #402 selfhost `vibe check`
 // dispatch. Reuses the same wasi bundle / moonrun_wt host as production.
 // Phase-4 gate: any divergence in stdout (not just exit code) fails.
@@ -1331,6 +1338,7 @@ local releaseSelfhostGates = new Task {
     testSelfhostCheckCommandParity
     testSelfhostCheckDirectComponent
     testSelfhostCheckDirectParity
+    testSelfhostDistStage2Parity
     testSelfhostCutover
     testGoldenWat
   }
@@ -1601,6 +1609,7 @@ tasks {
   testSelfhostCutover
   testSelfhostCheckBootstrapParity
   testSelfhostCheckParity
+  testSelfhostDistStage2Parity
   releaseSelfhostBootstrapGates
   testSelfhostTypecheckFixtures
   testSelfhostRuntimeFixtures

--- a/docs/selfhost-bootstrap.md
+++ b/docs/selfhost-bootstrap.md
@@ -207,8 +207,13 @@ section id 0 (custom), name "vibe.abi", payload:
    ABI のみに緩和)
 
 を assert する。`--self-test` は build 無しで pinned seed wasm に対し `vibe.abi`
-抽出ロジックだけを検証する (CI/build 不要の smoke)。gate は
-`release-selfhost-gates` に組み込む。stage2 再生成が前提なので、初回 green は
+抽出ロジックだけを検証する (CI/build 不要の smoke)。
+
+gate は `release-selfhost-gates` に組み込まれ、`pkf run selfhost-gate`
+(`selfhost_trial_gate.sh`) の本流で走る。selfhost gate は本 gate の直前に
+`selfhost_generations.sh build --stage3` で stage2/stage3 を生成するため、
+gate は既定 (`VIBE_DIST_PARITY_REUSE_STAGE2=1`) でその stage2 を再利用し、
+dist のみ fresh に build して比較する。stage2 再生成が前提なので、初回 green は
 seed が build 環境にある状態で確認する。
 
 ## MoonBit `src/` の退役

--- a/docs/selfhost-bootstrap.md
+++ b/docs/selfhost-bootstrap.md
@@ -158,6 +158,59 @@ cutover 後も runner と compiler artifact は分ける。
 runner layer は性能・実行基盤の都合で差し替えてよいが、canonical compiler は
 portable selfhost wasm として再構築できることを gate に残す。
 
+## Compiler wasm artifact 層の contract (#529)
+
+compiler wasm を作る入口は 2 つある。両者は **同じ compiler source** を入力に
+するが、**builder が異なる**ため成果物の byte は一致しない。これは設計上の前提
+であり、等価性は byte 統一ではなく contract + parity gate で保証する。
+
+| artifact | builder | 出力先 | 役割 |
+|---|---|---|---|
+| dist | `scripts/build_selfhost_dist.sh` | `_build/dist/selfhost_compiler.wasm` (+ `_raw`) | MoonBit host-compiled の shipping artifact。配布・実行用。wasm-opt `-O3` を通す。 |
+| stage2 | `scripts/selfhost_generations.sh build` | `_build/selfhost/generations/<ts>/stage2.wasm` | pinned seed から self-reproduce した candidate。bootstrap bump 判断用。 |
+
+- dist は host (`src/`) MoonBit codegen の出力、stage2 は selfhost wasm codegen の
+  出力なので、**compiler binary 同士の byte 比較は意味がない**。生成入口を
+  一本化せず役割で分けるのが canonical な扱い。
+- `scripts/selfhost_generations.sh status` で seed pin / source commit / 直近
+  generation manifest (stage0..stage3 の sha, stage3==stage2) を rebuild 無しで
+  確認できる。stage0 → stage1 → stage2 → bump の追跡入口。
+
+### `vibe.abi` custom section contract
+
+selfhost codegen (`vibe/compiler/codegen/wasm_emit/metadata.vibe::emit_vibe_abi_custom_section`)
+は **生成する program wasm** に custom section `vibe.abi` を埋め込む。これは
+compiler binary 自身にも (selfhost が自分自身を compile した結果なので) 載る。
+
+```
+section id 0 (custom), name "vibe.abi", payload:
+  version=1
+  host_import_abi=<abi>
+```
+
+- `version` は section レイアウトの版。
+- `host_import_abi` は runner 層 (`VIBE_SELFHOST_IMPORT_ABI`) の host import 選択に
+  対応する (現状 `raw`)。runner はこの値で import の解決方法を切り替える。
+- host (`src/`) codegen はこの section を emit しない。したがって host-compiled な
+  dist binary 自体には載らないが、**dist / stage2 のどちらで compile しても、出力
+  program wasm の `vibe.abi` は一致しなければならない** (= ABI contract)。
+
+### parity gate
+
+`scripts/test_selfhost_dist_stage2_parity.sh`
+(`pkf run test-selfhost-dist-stage2-parity`) が contract を検証する。dist / stage2
+両 compiler で同一 sample を compile し、
+
+1. 出力 program wasm の `vibe.abi` 一致、
+2. 両方 42 を返す behavioural parity、
+3. 既定で出力 wasm の byte 一致 (`VIBE_DIST_PARITY_REQUIRE_HASH=0` で behavioural +
+   ABI のみに緩和)
+
+を assert する。`--self-test` は build 無しで pinned seed wasm に対し `vibe.abi`
+抽出ロジックだけを検証する (CI/build 不要の smoke)。gate は
+`release-selfhost-gates` に組み込む。stage2 再生成が前提なので、初回 green は
+seed が build 環境にある状態で確認する。
+
 ## MoonBit `src/` の退役
 
 `src/` は selfhost cutover 後、legacy bootstrap/fallback 層へ縮退する。

--- a/scripts/test_selfhost_dist_stage2_parity.sh
+++ b/scripts/test_selfhost_dist_stage2_parity.sh
@@ -32,6 +32,8 @@
 # Env:
 #   VIBE_DIST_PARITY_REQUIRE_HASH  — 1 (default) strict byte parity of output
 #                                    wasm; 0 = behavioural + ABI parity only.
+#   VIBE_DIST_PARITY_REUSE_STAGE2  — 1 (default) reuse a recent generation's
+#                                    stage2.wasm if present; 0 = always rebuild.
 #   VIBE_DIST_PARITY_KEEP          — 1 to keep the scratch dir for inspection.
 set -euo pipefail
 
@@ -120,9 +122,18 @@ echo "[dist-parity] building dist compiler..."
 bash "$SCRIPT_DIR/build_selfhost_dist.sh"
 [ -f "$DIST_WASM" ] || die "dist compiler not produced: $DIST_WASM"
 
-echo "[dist-parity] building stage2 compiler..."
-bash "$SCRIPT_DIR/selfhost_generations.sh" build
+# Reuse a stage2 from a recent generation when present (the selfhost gate
+# builds stage3 just before this gate runs); only rebuild when absent. Set
+# VIBE_DIST_PARITY_REUSE_STAGE2=0 to always rebuild.
+REUSE_STAGE2="${VIBE_DIST_PARITY_REUSE_STAGE2:-1}"
 STAGE2_WASM="$(ls -t "$PROJECT_ROOT"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -n 1 || true)"
+if [ "$REUSE_STAGE2" = "1" ] && [ -n "$STAGE2_WASM" ] && [ -f "$STAGE2_WASM" ]; then
+  echo "[dist-parity] reusing existing stage2: $STAGE2_WASM"
+else
+  echo "[dist-parity] building stage2 compiler..."
+  bash "$SCRIPT_DIR/selfhost_generations.sh" build
+  STAGE2_WASM="$(ls -t "$PROJECT_ROOT"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -n 1 || true)"
+fi
 [ -n "$STAGE2_WASM" ] && [ -f "$STAGE2_WASM" ] || die "stage2 compiler not produced under _build/selfhost/generations"
 echo "[dist-parity] stage2: $STAGE2_WASM"
 

--- a/scripts/test_selfhost_dist_stage2_parity.sh
+++ b/scripts/test_selfhost_dist_stage2_parity.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Compiler wasm artifact-layer parity gate (#529).
+#
+# Two builders produce a vibe compiler wasm from the *same* source:
+#
+#   dist   — scripts/build_selfhost_dist.sh
+#            MoonBit host-compiled shipping artifact
+#            (_build/dist/selfhost_compiler.wasm)
+#   stage2 — scripts/selfhost_generations.sh build
+#            self-reproduced candidate
+#            (_build/selfhost/generations/<ts>/stage2.wasm)
+#
+# Because the builders differ (host MoonBit codegen vs selfhost wasm codegen),
+# the two compiler binaries are NOT byte-identical by design. Equivalence is a
+# *contract*, not byte unification: both compilers, given the same input, must
+# agree on
+#
+#   1. the `vibe.abi` custom section they embed in emitted program wasm
+#      (version + host_import_abi — see docs/selfhost-bootstrap.md), and
+#   2. observable behaviour (the emitted program returns the same answer), and
+#   3. by default, the byte image of the emitted program wasm.
+#
+# (3) is the strict form. Relax it to behavioural parity (1)+(2) with
+# VIBE_DIST_PARITY_REQUIRE_HASH=0 when host/selfhost codegen differences are
+# expected on a given input but the ABI contract must still hold.
+#
+# Self-test:
+#   scripts/test_selfhost_dist_stage2_parity.sh --self-test
+#     validates the vibe.abi extractor against the committed pinned seed wasm
+#     (bootstrap/selfhost/seed/selfhost_compiler.wasm) without any build.
+#
+# Env:
+#   VIBE_DIST_PARITY_REQUIRE_HASH  — 1 (default) strict byte parity of output
+#                                    wasm; 0 = behavioural + ABI parity only.
+#   VIBE_DIST_PARITY_KEEP          — 1 to keep the scratch dir for inspection.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="${VIBE_PROJECT_ROOT:-$(dirname "$SCRIPT_DIR")}"
+REQUIRE_HASH="${VIBE_DIST_PARITY_REQUIRE_HASH:-1}"
+KEEP="${VIBE_DIST_PARITY_KEEP:-0}"
+
+die() {
+  echo "[dist-parity] FAIL: $*" >&2
+  exit 1
+}
+
+need_python() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    die "python3 is required to parse the vibe.abi custom section"
+  fi
+}
+
+# Print the payload of the first custom section named "vibe.abi", or nothing.
+# Parses the wasm section table properly (does not string-search the binary),
+# so source-embedded "vibe.abi" string literals are never mistaken for the
+# section.
+extract_vibe_abi() {
+  local wasm="$1"
+  need_python
+  python3 - "$wasm" <<'PY'
+import sys
+
+def leb(data, i):
+    result = 0
+    shift = 0
+    while True:
+        b = data[i]
+        i += 1
+        result |= (b & 0x7F) << shift
+        if not (b & 0x80):
+            break
+        shift += 7
+    return result, i
+
+data = open(sys.argv[1], "rb").read()
+if data[:4] != b"\x00asm":
+    sys.exit("not a wasm module")
+i = 8  # magic(4) + version(4)
+n = len(data)
+while i < n:
+    sec_id = data[i]; i += 1
+    size, i = leb(data, i)
+    body = data[i:i + size]
+    i += size
+    if sec_id == 0:  # custom section
+        name_len, j = leb(body, 0)
+        name = body[j:j + name_len]
+        payload = body[j + name_len:]
+        if name == b"vibe.abi":
+            sys.stdout.buffer.write(payload)
+            break
+PY
+}
+
+self_test() {
+  local seed="$PROJECT_ROOT/bootstrap/selfhost/seed/selfhost_compiler.wasm"
+  [ -f "$seed" ] || die "pinned seed wasm not found: $seed"
+  local abi
+  abi="$(extract_vibe_abi "$seed")"
+  echo "[dist-parity] self-test: seed vibe.abi ="
+  printf '%s\n' "$abi" | sed 's/^/    /'
+  case "$abi" in
+    *"version=1"*"host_import_abi="*) ;;
+    *) die "seed vibe.abi missing version/host_import_abi: [$abi]" ;;
+  esac
+  echo "[dist-parity] self-test OK"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit 0
+fi
+
+# --- locate / build the two compilers ----------------------------------------
+
+DIST_WASM="$PROJECT_ROOT/_build/dist/selfhost_compiler.wasm"
+
+echo "[dist-parity] building dist compiler..."
+bash "$SCRIPT_DIR/build_selfhost_dist.sh"
+[ -f "$DIST_WASM" ] || die "dist compiler not produced: $DIST_WASM"
+
+echo "[dist-parity] building stage2 compiler..."
+bash "$SCRIPT_DIR/selfhost_generations.sh" build
+STAGE2_WASM="$(ls -t "$PROJECT_ROOT"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -n 1 || true)"
+[ -n "$STAGE2_WASM" ] && [ -f "$STAGE2_WASM" ] || die "stage2 compiler not produced under _build/selfhost/generations"
+echo "[dist-parity] stage2: $STAGE2_WASM"
+
+# --- compile the same sample with both ---------------------------------------
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/dist-parity.XXXXXX")"
+cleanup() { [ "$KEEP" = "1" ] || rm -rf "$WORK"; }
+trap cleanup EXIT
+
+SAMPLE="$WORK/sample.vibe"
+cat > "$SAMPLE" <<'VIBE'
+export let answer = () -> Int { 40 + 2 }
+VIBE
+
+OUT_DIST="$WORK/out_dist.wasm"
+OUT_STAGE2="$WORK/out_stage2.wasm"
+
+compile_with() {
+  local compiler="$1" out="$2"
+  VIBE_PREOPEN_DIR="$WORK" \
+    bash "$PROJECT_ROOT/scripts/run_wasm_vibe_host_runner.sh" \
+      --invoke cli_main \
+      "$compiler" \
+      "${SAMPLE#$WORK/}" \
+      "${out#$WORK/}" \
+      "answer" >/dev/null 2>&1 || true
+  [ -f "$out" ] || die "compiler did not emit output: $compiler"
+}
+
+echo "[dist-parity] compiling sample with dist..."
+compile_with "$DIST_WASM" "$OUT_DIST"
+echo "[dist-parity] compiling sample with stage2..."
+compile_with "$STAGE2_WASM" "$OUT_STAGE2"
+
+# --- (1) ABI contract --------------------------------------------------------
+
+ABI_DIST="$(extract_vibe_abi "$OUT_DIST")"
+ABI_STAGE2="$(extract_vibe_abi "$OUT_STAGE2")"
+echo "[dist-parity] dist   vibe.abi: $(printf '%s' "$ABI_DIST" | tr '\n' ' ')"
+echo "[dist-parity] stage2 vibe.abi: $(printf '%s' "$ABI_STAGE2" | tr '\n' ' ')"
+[ -n "$ABI_DIST" ] || die "dist output has no vibe.abi custom section"
+[ "$ABI_DIST" = "$ABI_STAGE2" ] || die "vibe.abi mismatch: dist=[$ABI_DIST] stage2=[$ABI_STAGE2]"
+echo "[dist-parity] (1) vibe.abi contract: OK"
+
+# --- (2) behavioural parity --------------------------------------------------
+
+run_answer() {
+  local prog="$1"
+  VIBE_PREOPEN_DIR="$WORK" \
+    bash "$PROJECT_ROOT/scripts/run_wasm_vibe_host_runner.sh" \
+      --invoke _start "$prog" 2>/dev/null | grep -E '^-?[0-9]+$' | tail -n 1 || true
+}
+
+ANS_DIST="$(run_answer "$OUT_DIST")"
+ANS_STAGE2="$(run_answer "$OUT_STAGE2")"
+[ "$ANS_DIST" = "42" ] || die "dist output returned '$ANS_DIST' (expected 42)"
+[ "$ANS_STAGE2" = "42" ] || die "stage2 output returned '$ANS_STAGE2' (expected 42)"
+echo "[dist-parity] (2) behavioural parity: OK (both return 42)"
+
+# --- (3) optional byte parity of emitted program -----------------------------
+
+if [ "$REQUIRE_HASH" = "1" ]; then
+  sha() {
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+    else shasum -a 256 "$1" | awk '{print $1}'; fi
+  }
+  H_DIST="$(sha "$OUT_DIST")"
+  H_STAGE2="$(sha "$OUT_STAGE2")"
+  if [ "$H_DIST" != "$H_STAGE2" ]; then
+    die "emitted program wasm differs (dist=$H_DIST stage2=$H_STAGE2). Set VIBE_DIST_PARITY_REQUIRE_HASH=0 to gate on behaviour+ABI only."
+  fi
+  echo "[dist-parity] (3) byte parity of emitted wasm: OK ($H_DIST)"
+else
+  echo "[dist-parity] (3) byte parity: skipped (VIBE_DIST_PARITY_REQUIRE_HASH=0)"
+fi
+
+echo "[dist-parity] OK: dist and stage2 compilers agree on the artifact contract"


### PR DESCRIPTION
Closes the remaining two items of #529 (the compiler wasm artifact層の棚卸し / contract 明文化).

## What

### 1. Artifact-layer contract を明文化 (`docs/selfhost-bootstrap.md`)
compiler wasm を作る入口は 2 つあり、**同じ source・異なる builder** なので成果物の byte は一致しない（設計上の前提）。等価性は byte 統一ではなく contract + parity gate で保証する旨を表で整理:

| artifact | builder | 出力先 | 役割 |
|---|---|---|---|
| dist | `build_selfhost_dist.sh` | `_build/dist/selfhost_compiler.wasm` | MoonBit host-compiled shipping artifact |
| stage2 | `selfhost_generations.sh build` | `generations/<ts>/stage2.wasm` | pinned seed から self-reproduce した candidate |

### 2. `vibe.abi` custom section contract
selfhost codegen (`vibe/compiler/codegen/wasm_emit/metadata.vibe`) が **生成する program wasm** に埋め込む custom section を contract 化:

```
section id 0 (custom), name "vibe.abi":
  version=1
  host_import_abi=<abi>   # runner 層 VIBE_SELFHOST_IMPORT_ABI に対応 (現状 raw)
```

host (`src/`) codegen は emit しないため compiler binary 同士の比較は無意味。**dist / stage2 のどちらで compile しても出力 program wasm の `vibe.abi` は一致する**のが contract。

### 3. parity gate (`scripts/test_selfhost_dist_stage2_parity.sh`)
`pkf run test-selfhost-dist-stage2-parity`。dist / stage2 両 compiler で同一 sample を compile し:
1. 出力 program wasm の `vibe.abi` 一致
2. 両方 42 を返す behavioural parity
3. 既定で出力 wasm の byte 一致（`VIBE_DIST_PARITY_REQUIRE_HASH=0` で behavioural + ABI のみに緩和）

を assert。`--self-test` は build 無しで pinned seed wasm に対し `vibe.abi` 抽出だけ検証する smoke（section table を LEB128 で正しくパースし、source 埋め込みの `"vibe.abi"` 文字列リテラルと取り違えない）。

`release-selfhost-gates` の dep に登録済みで、`pkf run selfhost-gate`（`selfhost_trial_gate.sh`）本流で走る。selfhost gate は本 gate の直前に `selfhost_generations.sh build --stage3` で stage2/stage3 を生成するため、gate は既定でその stage2 を再利用し dist のみ fresh build して比較する。

## Verification

- `--self-test` を本環境で実行 → pinned seed wasm から `version=1` / `host_import_abi=raw` を正しく抽出（PASS）。
- `selfhost_generations.sh status` 実行 → seed pin = **ok**。
- `pkf list` で Taskfile parse + task 登録を確認。
- ⚠️ **e2e（dist/stage2 build を伴う実行）は実装環境に `moon`/`moonrun`/`wasm-opt` が無いため未実行**。`test-selfhost-dist-stage2-parity` の初回 green は seed が build 可能な環境（CI/local with moon）での確認が前提です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNjN9PctbEs51KTJRRHSrk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNjN9PctbEs51KTJRRHSrk)_