### PR TITLE
docs(threads): deprecate wasi-threads (-S threads=y) ahead of Wasmtime 47 removal (#486)

### DIFF
--- a/docs/wasm_threads_requirements.md
+++ b/docs/wasm_threads_requirements.md
@@ -1,6 +1,6 @@
 # wasm + threads 要件メモ
 
-更新日: 2026-05-22
+更新日: 2026-06-21
 現在の repo 既定:
 
 - `wasmtime 45.0.0` (`deps/wasmtime` submodule / `scripts/install_wasmtime_release.sh`)
@@ -10,19 +10,62 @@
 - `wasmtime 41.0.3 (db1c043b5 2026-02-04)` (system)
 - `wasmtime 43.0.0 (57b4bf56c 2026-02-06)` (`deps/wasmtime` submodule)
 
-## TL;DR
+## ⚠️ deprecation: WASI Threads (`-S threads=y`) は通常経路で非推奨 (#486)
 
-WASI Threads を wasmtime 上で動かす最小要件は次の 3 点:
+`-S threads=y`（= `-Sthreads`、WASI Threads / `wasm32-wasip1-threads`）は
+**Wasmtime 47.0.0 (2026-07-20 予定) で hard error になり削除される**。
+Wasmtime 45/46 で `-S threads=y` を使うと次の警告が出る:
 
-1. ゲスト wasm が `wasi threads` ABI を満たすこと
-2. `-S threads=y` を有効化すること
-3. `-W shared-memory=y` と `-W threads=y` を有効化すること
+```text
+WARNING: the `-Sthreads` flag will be a hard error in Wasmtime 47.0.0 on 2026-07-20.
+```
 
-この条件で、実際に並列実行が進むことを確認済み（sleep 4 本で直列約2.03s -> 並列約0.51s）。
+参考:
 
-## 1. ゲスト側の要件
+- https://github.com/bytecodealliance/wasmtime/releases/tag/v45.0.0
+- https://docs.wasmtime.dev/stability-wasm-proposals.html
+- https://github.com/WebAssembly/shared-everything-threads
 
-Rust なら基本的に `wasm32-wasip1-threads` を使う。
+### 方針
+
+- **`-S threads=y`（wasi-threads）を通常経路の推奨から外す。** 本メモの WASI Threads
+  手順は historical reference として残し、新規開発では使わない。
+- **supported なスレッド面は core wasm の atomics + shared memory** に閉じる
+  (`-W threads=y` + `-W shared-memory=y`)。これは廃止対象ではない。下記 §1。
+- 将来のマルチスレッド基盤は **shared-everything-threads** に移行する。Wasmtime に
+  実装が入ってから再評価する。tracking: #488。
+- repo 内の active な gate (`scripts/test_selfhost_cli_*preview2*.sh` 等) は
+  `VIBE_WASMTIME_WASM_FLAGS=...threads=y`（= `-W threads=y`、wasm proposal）だけを
+  使い、廃止対象の `-S threads=y` は使っていない。これらは影響を受けない。
+
+## 1. supported: core wasm atomics + shared memory（非廃止）
+
+`-W threads=y` / `-W shared-memory=y` は wasm threads proposal（atomics + shared
+memory）であり、`-S threads`（wasi-threads）とは別物で deprecation の対象外。
+atomics / shared memory を使う core wasm の最小要件:
+
+最小 WAT（`memory shared` + `i32.atomic.store/load`）での実測:
+
+- デフォルト:
+  - `shared memory support is disabled for this engine -- see Config::shared_memory`
+- `-W shared-memory=y`:
+  - 成功
+- `-W shared-memory=y -W threads=n`:
+  - `threads must be enabled for shared memories`
+
+つまり atomics を使う core wasm は少なくとも `-W shared-memory=y` が必要で、
+`-W threads=y` も明示するのが安全。
+
+`vibe` の env 変数:
+
+- `VIBE_WASMTIME_WASM_FLAGS='threads=y shared-memory=y'`（→ `-W threads=y -W shared-memory=y`）
+
+## 2. historical: WASI Threads (`-S threads=y`) — 非推奨
+
+> ⚠️ 以下は Wasmtime 46 までで動く WASI Threads の手順だが、Wasmtime 47.0.0 で
+> `-S threads=y` が削除されるため新規利用は避けること。記録として残す。
+
+Rust なら `wasm32-wasip1-threads` を使う。
 
 ```bash
 rustup target add wasm32-wasip1-threads
@@ -37,60 +80,35 @@ WASI Threads モジュールとして必要な形:
 - export:
   - `wasi_thread_start`
 
-## 2. ホスト側（wasmtime）の要件
+ホスト側フラグ（Wasmtime 46 まで）:
 
-必須フラグ:
-
-- WASI: `-S threads=y`
+- WASI: `-S threads=y`  ← **47.0.0 で削除**
 - Wasm: `-W shared-memory=y`
-- Wasm: `-W threads=y`（shared memory 運用で実質必須）
+- Wasm: `-W threads=y`
 
-`vibe` の env 変数にすると:
+失敗パターン（実測）:
 
-- `VIBE_WASMTIME_WASI_FLAGS='threads=y'`
-- `VIBE_WASMTIME_WASM_FLAGS='threads=y shared-memory=y'`
+- `-S threads=y` なし: `unknown import: env::memory has not been defined`
+- `-W shared-memory=y` なし: `shared memory support is disabled for this engine`
+- `-W threads=n` で shared memory モジュールを読む: `threads must be enabled for shared memories`
 
-## 3. 失敗パターン（実測）
+## 3. concurrency-support との関係
 
-- `-S threads=y` なし:
-  - `unknown import: env::memory has not been defined`
-- `-W shared-memory=y` なし:
-  - `shared memory support is disabled for this engine`
-- `-W threads=n` で shared memory モジュールを読む:
-  - `threads must be enabled for shared memories`
-
-## 4. concurrency-support との関係
-
-- Core Wasm threads / WASI threads 実行には不要。
+- core wasm threads / WASI threads 実行には不要。
 - ただし Component Model の `component-model-async` / `component-model-threading` では別扱い。
   - 43 系の実測では `concurrency-support=y` が必要。
   - 41 系は `-W concurrency-support=...` 自体が未対応（unknown option）。
 
-## 5. vibe リポジトリ内での最小実行手順
+## 4. 移行先: shared-everything-threads
 
-追加済みプローブ:
+`-S threads`（wasi-threads）は core wasm の上に WASI 層で thread-spawn を載せる
+旧アプローチ。後継は WebAssembly の **shared-everything-threads** proposal
+（`thread.spawn-ref` / `thread.spawn-indirect` / `thread.available-parallelism`
+等）で、Wasmtime 側の実装が揃ってから vibe 側の probe を組み直す。
 
-- `src/x/threads/wasi_threads_probe.wat`
-- `src/x/threads/run_probe.sh`
-- `just experimental_wasi_threads_probe`
+- proposal: https://github.com/WebAssembly/shared-everything-threads
+- tracking issue: #488
 
-実行:
-
-```bash
-# system wasmtime を使う
-just experimental_wasi_threads_probe
-
-# submodule wasmtime を使う
-VIBE_USE_WASMTIME_SUBMODULE=1 just experimental_wasi_threads_probe
-
-# 直接実行
-VIBE_USE_WASMTIME_SUBMODULE=1 src/x/threads/run_probe.sh
-```
-
-## 6. 実装時チェックリスト
-
-- [ ] ゲスト wasm が threads ABI (`env::memory`, `wasi::thread-spawn`, `wasi_thread_start`) を持つ
-- [ ] `VIBE_WASMTIME_WASI_FLAGS` に `threads=y` が入っている
-- [ ] `VIBE_WASMTIME_WASM_FLAGS` に `threads=y shared-memory=y` が入っている
-- [ ] 実行環境の wasmtime バージョンを確認する
-- [ ] 必要なら並列実行の実測（時間短縮）で動作を裏取りする
+旧 probe (`src/x/threads/`, `just experimental_wasi_threads_probe`,
+`scripts/run_wasi_threads_probe.sh`) は既に repo から撤去済み。再導入する場合は
+wasi-threads ではなく shared-everything-threads を前提にする。

--- a/docs/wasmtime-v43.md
+++ b/docs/wasmtime-v43.md
@@ -285,6 +285,14 @@ just component-run script.vibe
 
 ## 12. wasi threads / atomics / concurrent 実測 (2026-02-09)
 
+> ⚠️ **deprecation (#486):** 本節の `-S threads=y`（WASI Threads /
+> `wasm32-wasip1-threads`）は **Wasmtime 47.0.0 (2026-07-20 予定) で hard error に
+> なり削除される**。以下は当時の実測記録（historical）。新規開発では `-S threads=y`
+> を使わず、core wasm の atomics + shared memory（`-W threads=y` /
+> `-W shared-memory=y`、非廃止）に閉じること。将来のマルチスレッドは
+> shared-everything-threads (#488) に移行する。詳細は
+> [docs/wasm_threads_requirements.md](./wasm_threads_requirements.md)。
+
 検証環境:
 
 - system: `wasmtime 41.0.3 (db1c043b5 2026-02-04)`
@@ -350,22 +358,15 @@ just component-run script.vibe
     は `concurrency support must be enabled ...` で失敗。
 - 41 では `-W concurrency-support=...` 自体が unknown option。
 
-### 12.5 vibe リポジトリ内の最小プローブ
+### 12.5 vibe リポジトリ内の最小プローブ（撤去済み）
 
-この検証を再実行できるように、以下を追加した:
+当時の検証用 probe (`src/x/threads/wasi_threads_probe.wat` /
+`src/x/threads/run_probe.sh` / `scripts/run_wasi_threads_probe.sh` /
+`just experimental_wasi_threads_probe`) は wasi-threads 非推奨化 (#486) に伴い
+**既に撤去済み**。再導入する場合は廃止予定の `-S threads=y` ではなく
+shared-everything-threads (#488) を前提にする。
 
-- `src/x/threads/wasi_threads_probe.wat`
-- `src/x/threads/run_probe.sh`
-- `scripts/run_wasi_threads_probe.sh`
-- `just experimental_wasi_threads_probe`
+なお当時の probe は未指定時に次を適用していた（historical）:
 
-実行例:
-
-```bash
-VIBE_USE_WASMTIME_SUBMODULE=1 just experimental_wasi_threads_probe
-```
-
-デフォルト（未指定時）では次のフラグを適用する:
-
-- `VIBE_WASMTIME_WASM_FLAGS='threads=y shared-memory=y'`
-- `VIBE_WASMTIME_WASI_FLAGS='threads=y'`
+- `VIBE_WASMTIME_WASM_FLAGS='threads=y shared-memory=y'`（→ `-W`、非廃止）
+- `VIBE_WASMTIME_WASI_FLAGS='threads=y'`（→ `-S threads=y`、**47.0.0 で削除**）

--- a/pkspec/Packages.pkl
+++ b/pkspec/Packages.pkl
@@ -41,7 +41,6 @@ all: List<String> =
     "x/fp",
     "x/module_graph",
     "x/scoped_map",
-    "x/threads",
   )
 
 /// Canonical task-name form (pkfire). `cmd/vibe` → `test:cmd-vibe`.


### PR DESCRIPTION
Closes #486.

Wasmtime makes `-Sthreads` (WASI Threads / `wasm32-wasip1-threads`) a hard error in 47.0.0 (2026-07-20). This audits and reframes the threads docs around that deprecation.

## Findings (inventory)

Most surfaces named in #486 no longer exist; only the docs (and one stale pkspec entry) referenced wasi-threads.

| #486 target | status |
|---|---|
| `src/x/threads/` probe | already removed |
| `vibe/prelude/threads` | does not exist |
| `recommended_wasi_flags()` / `recommended_wasi_env()` | do not exist |
| README `experimental_wasi_threads_probe` | no mention |
| `docs/wasm_threads_requirements.md` / `docs/wasmtime-v43.md` | recommend `-S threads=y` |
| selfhost CLI preview2/component gates (4 scripts) | use `-W threads=y` (wasm proposal, **not** deprecated) |

Key distinction: the deprecated flag is `-S threads=y` (WASI Threads). The active gates use `VIBE_WASMTIME_WASM_FLAGS=…threads=y` → `-W threads=y` (core wasm threads proposal: atomics/shared-memory), which stays supported in Wasmtime 47. No code emits `-S threads=y` on the normal path — only the docs recommended it.

## Changes

- **`docs/wasm_threads_requirements.md`**: deprecation banner; separate the supported, non-deprecated core-wasm surface (`-W threads=y` / `-W shared-memory=y`) from the now-historical WASI Threads path; point future multithreading at shared-everything-threads (#488); drop references to the already-removed probe.
- **`docs/wasmtime-v43.md`**: banner §12 as historical; mark §12.5 probe files as removed.
- **`pkspec/Packages.pkl`**: remove the dangling `"x/threads"` package entry — `src/x/threads` was removed with the wasi-threads experiment, so `pkf run test:x-threads` pointed at a non-existent package.

## Verification

Docs-centric. `pkf list` parses and `test:x-threads` is gone. README has no threads mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNjN9PctbEs51KTJRRHSrk)_