### PR TITLE
fix(fmt): space the `|>` pipe operator + cheatsheet docs for pipeline ergonomics

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -113,13 +113,31 @@ Assignment: `=` `+=` `-=` `*=` `/=` `%=` (statement, not expr)
 
 ```vibe
 x |> f            // f(x)
-x |> f(a, b)      // f(x, a, b)
+x |> f(a, b)      // f(x, a, b)   — value is prepended
+x |> f(a, _)      // f(a, x)      — `_` marks where the value goes
+x |> g(a, _, b)   // g(a, x, b)
 x |> f |> g       // g(f(x))
 arr |> Array::length
 s |> String::trim |> String::length
 ```
 
+Without a `_`, the piped value becomes the **first** argument. A bare `_` in
+the call's arguments substitutes the value at that position instead (no
+prepend). A *compound* placeholder such as `_ * 2` is a section lambda
+(`(v) -> v * 2`), not a pipe slot — so `xs |> Array::map(_, _ * 2)` reads as
+`Array::map(xs, (v) -> v * 2)`.
+
 `.` is field access only. No method call sugar (`obj.method()` is error).
+
+### Function combinators (point-free)
+
+```vibe
+// vibe has no `>>` compose operator (`>>` is arithmetic shift) — use functions
+compose(f, g)            // (x) -> g(f(x))   apply f then g
+identity                 // (x) -> x         no-op stage / default
+flip(f)                  // (b, a) -> f(a, b)
+Array::map(xs, compose(parse, render))
+```
 
 ## Control Flow
 
@@ -261,6 +279,35 @@ let fetch_user: (String) -> Result[String, String] = (raw) -> {
   |> Result::and_then(validate_id)
   |> Result::and_then(load_user)
 }
+```
+
+### Railway bind (`let*`)
+
+`let* x = e` unwraps an `Ok` and binds `x`, or short-circuits the whole block
+with the `Err`. It desugars to `match e { Ok(x) => <rest>, Err(e) => Err(e) }`,
+so the enclosing function must return a `Result`. Handy when stages need
+names instead of point-free `and_then`:
+
+```vibe
+let fetch_user: (String) -> Result[String, String] = (raw) -> {
+  let* id   = parse_id(raw)        // returns Err early on failure
+  let* valid = validate_id(id)
+  load_user(valid)                 // last expr is the block's Result
+}
+```
+
+### Debugging a pipeline (`tap`)
+
+`tap` runs a side effect on the value and returns it unchanged — observe a
+stage without breaking the `|>` chain. Railway variants `tap_ok` / `tap_err` /
+`tap_some` observe only one track:
+
+```vibe
+x
+|> tap((v) -> stdout_write("step: \{Int::to_string(v)}\n"))
+|> next_stage
+
+result |> tap_ok((v) -> stdout_write("ok\n")) |> tap_err((e) -> stdout_write("err\n"))
 ```
 
 ### Error boundary (`throw` / `handle`)

--- a/src/parser/format.mbt
+++ b/src/parser/format.mbt
@@ -1054,7 +1054,8 @@ fn is_operator_kind(kind : @cst.SyntaxKind) -> Bool {
   kind == or_or() ||
   kind == arrow() ||
   kind == thin_arrow() ||
-  kind == pipe()
+  kind == pipe() ||
+  kind == pipe_gt()
 }
 
 ///|

--- a/src/parser/format_test.mbt
+++ b/src/parser/format_test.mbt
@@ -693,3 +693,31 @@ test "vibe format trait impl top-level spacing" {
     #|impl Eq for Int
   inspect(format_script(input), content=expected)
 }
+
+///|
+test "vibe format pipe operator spacing" {
+  // `|>` (pipe_gt) must be surrounded by spaces, and tight input normalizes.
+  let input =
+    #|let p: (Int) -> Int = (n) -> { n|>f|>g }
+    #|let q: (Int) -> Int = (n) -> { n |> slot(10, _) |> Result::and_then(h) }
+  let formatted = format_script(input)
+  if !formatted.contains("n |> f |> g") {
+    fail("[pipe spacing] expected `n |> f |> g`\n---\n\{formatted}")
+  }
+  if !formatted.contains("n |> slot(10, _) |> Result::and_then(h)") {
+    fail(
+      "[pipe spacing] expected spaced pipe with call/placeholder\n---\n\{formatted}",
+    )
+  }
+  // Idempotent.
+  let twice = format_script(formatted)
+  inspect(twice, content=formatted)
+  // Parse-equivalent before/after formatting.
+  let before = parse_ast(input) catch {
+    e => fail("[before-format] parse failed: \{e.to_string()}")
+  }
+  let after = parse_ast(formatted) catch {
+    e => fail("[after-format] parse failed: \{e.to_string()}")
+  }
+  assert_eq(@core.normalize_module(after), @core.normalize_module(before))
+}


### PR DESCRIPTION
Follow-up to #588 (function pipeline ergonomics). Two small, independent changes.

## `fix(fmt)`: space the `|>` pipe operator

`vibe fmt` rendered pipelines tight — `n|>f|>g` — instead of the documented
`n |> f |> g`.

**Root cause:** `|>` is a single `pipe_gt` token from the lexer, but the
formatter's `is_operator_kind` only listed the bit-or `pipe` token, so `|>`
got no surrounding spaces. One-line fix: classify `pipe_gt()` as an operator.

```
n|>f|>g                    =>  n |> f |> g
n |> slot(10, _) |> g(h)   =>  preserved, spaced
```

- Output is idempotent and parse-equivalent (new `format_test` case).
- Host-only formatter change (`src/parser/format.mbt`). Selfhost
  sources/bundles untouched; the `vibe-normalize` gate scope (`examples`,
  12 files) is unaffected; the selfhost bootstrap uses a separate AST
  printer, not this CST formatter.

> Note: this only fixes inline spacing. Auto-breaking *long* pipe chains
> across multiple lines (`n\n  |> f\n  |> g`) is a larger formatter feature
> and is intentionally left as a possible follow-up.

## `docs(cheatsheet)`: sync the reference with shipped features

Document the pipeline-ergonomics features from #588 that were missing from
the cheatsheet:

- **Pipe `_` placeholder** — bare `_` substitutes the piped value at that
  slot (`x |> f(a, _)` ⇒ `f(a, x)`); compound `_ * 2` stays a section lambda.
- **Function combinators** — `compose` / `identity` / `flip` (and why there's
  no `>>` operator: `>>` is arithmetic shift).
- **Railway bind `let*`** — Ok-unwrap / Err short-circuit desugar.
- **Pipeline debugging** — `tap` / `tap_ok` / `tap_err`.

All examples verified against the selfhost parser.

## Verification

- `moon test --target native src/parser` — 91/91.
- `moon check --target native src/parser` — 0 errors.
- `vibe_normalize_all.sh --check` — 12/12 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNjN9PctbEs51KTJRRHSrk)_