### PR TITLE
fix(parser): host parity for pipe `_` slot + runnable reference & cheatsheet prereqs

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -131,6 +131,9 @@ prepend). A *compound* placeholder such as `_ * 2` is a section lambda
 
 ### Function combinators (point-free)
 
+`compose` / `identity` / `flip` live in the prelude (`vibe/prelude/func.vibe`);
+import them before use (`import ./func.vibe { compose, identity, flip }`).
+
 ```vibe
 // vibe has no `>>` compose operator (`>>` is arithmetic shift) — use functions
 compose(f, g)            // (x) -> g(f(x))   apply f then g
@@ -138,6 +141,13 @@ identity                 // (x) -> x         no-op stage / default
 flip(f)                  // (b, a) -> f(a, b)
 Array::map(xs, compose(parse, render))
 ```
+
+> Runnable reference for the pipe `_` slot, combinators, `let*`, and `tap`:
+> [`vibe/prelude/pipeline_ergonomics_test.vibe`](../vibe/prelude/pipeline_ergonomics_test.vibe)
+> (`vibe test vibe/prelude/pipeline_ergonomics_test.vibe`). `Result`, `tap*`,
+> and the combinators are prelude exports, so a file must `import` them and sit
+> where it can reach the prelude — `import` paths may not escape the file's root
+> directory, so standalone `examples/` files cannot reach `vibe/prelude/`.
 
 ## Control Flow
 
@@ -300,7 +310,8 @@ let fetch_user: (String) -> Result[String, String] = (raw) -> {
 
 `tap` runs a side effect on the value and returns it unchanged — observe a
 stage without breaking the `|>` chain. Railway variants `tap_ok` / `tap_err` /
-`tap_some` observe only one track:
+`tap_some` observe only one track. They are prelude exports
+(`vibe/prelude/io.vibe`); import them and note they carry the `Stdout` effect:
 
 ```vibe
 x

--- a/examples/base64.vibe
+++ b/examples/base64.vibe
@@ -3,7 +3,7 @@
 let table: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
 let to_b64: (Int) -> String = (i) -> {
-  table|>String::substring(i, i + 1)
+  table |> String::substring(i, i + 1)
 }
 
 let encode_pair: (Int, Int) -> String = (a, b) -> {
@@ -12,13 +12,13 @@ let encode_pair: (Int, Int) -> String = (a, b) -> {
   let y1 = b / 16
   let c1 = to_b64(x1 + y1)
   let c2 = to_b64(b % 16 * 4)
-  c0|>String::concat(c1)|>String::concat(c2)|>String::concat("=")
+  c0 |> String::concat(c1) |> String::concat(c2) |> String::concat("=")
 }
 
 let encode_single: (Int) -> String = (a) -> {
   let c0 = to_b64(a / 4)
   let c1 = to_b64(a % 4 * 16)
-  c0|>String::concat(c1)|>String::concat("==")
+  c0 |> String::concat(c1) |> String::concat("==")
 }
 
 let encode_triplet: (Int, Int, Int) -> String = (a, b, c) -> {
@@ -30,7 +30,7 @@ let encode_triplet: (Int, Int, Int) -> String = (a, b, c) -> {
   let y2 = c / 64
   let c2 = to_b64(x2 + y2)
   let c3 = to_b64(c % 64)
-  c0|>String::concat(c1)|>String::concat(c2)|>String::concat(c3)
+  c0 |> String::concat(c1) |> String::concat(c2) |> String::concat(c3)
 }
 
 let rec enc_loop: (String, Int, String) -> String = (s, i, out) -> {

--- a/examples/basics.vibe
+++ b/examples/basics.vibe
@@ -107,7 +107,7 @@ test "string basics" {
   let name = "vibe"
   let msg = "hello \(name)"
   assert(msg == "hello vibe")
-  assert((msg|>String::length()) == 10)
+  assert((msg |> String::length()) == 10)
 }
 
 test "while and mut" {

--- a/examples/basics_test.vibe
+++ b/examples/basics_test.vibe
@@ -106,6 +106,6 @@ test "bitwise operators" {
 }
 
 test "pipe operator" {
-  let result = 1|>add(2)|>mul(3)
+  let result = 1 |> add(2) |> mul(3)
   assert(result == 9)
 }

--- a/examples/test.vibe
+++ b/examples/test.vibe
@@ -11,7 +11,7 @@ test "if" {
 }
 
 test "pipe" {
-  assert(eq(1|>add(2), 3))
+  assert(eq(1 |> add(2), 3))
 }
 
 test "string_eq" {

--- a/src/parser/parser_ast_expr.mbt
+++ b/src/parser/parser_ast_expr.mbt
@@ -490,7 +490,13 @@ fn pipe_apply(
       if has_hole {
         for arg in args {
           if arg.expr is @core.Expr::Placeholder(..) {
-            out.push(@core.CallArg::{ label: None, expr: left, span: left_span })
+            // Replace only the expr; keep the slot's label and span so a
+            // labeled hole (`x |> f(a=1, b=_)`) stays `f(a=1, b=x)`.
+            out.push(@core.CallArg::{
+              label: arg.label,
+              expr: left,
+              span: arg.span,
+            })
           } else {
             out.push(arg)
           }

--- a/src/parser/parser_ast_expr.mbt
+++ b/src/parser/parser_ast_expr.mbt
@@ -476,10 +476,30 @@ fn pipe_apply(
     @core.Expr::Call(name~, type_args~, args~, span~) => {
       let left_span = left.span()
       let call_span = @core.Span::merge(left_span, span)
-      let out : Array[@core.CallArg] = []
-      out.push(@core.CallArg::{ label: None, expr: left, span: left_span })
+      // Bare `_` placeholder slot: `x |> f(a, _)` substitutes the piped value
+      // at each `_` hole (`f(a, x)`) instead of prepending. Only direct args
+      // are checked; a compound `_ * 2` arg is a section lambda and still
+      // triggers the prepend path (matches selfhost `pipe_desugar`).
+      let mut has_hole = false
       for arg in args {
-        out.push(arg)
+        if arg.expr is @core.Expr::Placeholder(..) {
+          has_hole = true
+        }
+      }
+      let out : Array[@core.CallArg] = []
+      if has_hole {
+        for arg in args {
+          if arg.expr is @core.Expr::Placeholder(..) {
+            out.push(@core.CallArg::{ label: None, expr: left, span: left_span })
+          } else {
+            out.push(arg)
+          }
+        }
+      } else {
+        out.push(@core.CallArg::{ label: None, expr: left, span: left_span })
+        for arg in args {
+          out.push(arg)
+        }
       }
       @core.Expr::Call(name~, type_args~, args=out, span=call_span)
     }

--- a/src/parser/placeholder_sugar_wbtest.mbt
+++ b/src/parser/placeholder_sugar_wbtest.mbt
@@ -24,6 +24,50 @@ test "parse placeholder sugar does not wrap enclosing non-op call" {
 }
 
 ///|
+/// Pipe `_` slot: `x |> f(a, _)` substitutes the piped value at the hole
+/// (`f(a, x)`) instead of prepending. Host parity with selfhost `pipe_desugar`.
+test "parse pipe placeholder substitutes at hole" {
+  let ast = parse_ast("x |> f(a, _)")
+  match ast.stmts[0] {
+    @core.Stmt::Expr(expr~, ..) =>
+      match expr {
+        @core.Expr::Call(name="f", args~, ..) => {
+          assert_eq(args.length(), 2)
+          match (args[0].expr, args[1].expr) {
+            (@core.Expr::Ident(name="a", ..), @core.Expr::Ident(name="x", ..)) =>
+              ()
+            other => fail("expected args [a, x], got: \{other}")
+          }
+        }
+        other => fail("expected Call f, got: \{other}")
+      }
+    _ => fail("expected Expr stmt")
+  }
+}
+
+///|
+/// Pipe without a `_` hole still prepends the piped value as the first arg:
+/// `x |> f(a)` → `f(x, a)`.
+test "parse pipe without placeholder prepends" {
+  let ast = parse_ast("x |> f(a)")
+  match ast.stmts[0] {
+    @core.Stmt::Expr(expr~, ..) =>
+      match expr {
+        @core.Expr::Call(name="f", args~, ..) => {
+          assert_eq(args.length(), 2)
+          match (args[0].expr, args[1].expr) {
+            (@core.Expr::Ident(name="x", ..), @core.Expr::Ident(name="a", ..)) =>
+              ()
+            other => fail("expected args [x, a], got: \{other}")
+          }
+        }
+        other => fail("expected Call f, got: \{other}")
+      }
+    _ => fail("expected Expr stmt")
+  }
+}
+
+///|
 /// Operator-chain placeholders stay in the same lambda scope:
 /// `_ % 2 == 0` → `x -> x % 2 == 0` (one Fn, not nested).
 test "parse placeholder sugar spans operator chain" {

--- a/src/parser/placeholder_sugar_wbtest.mbt
+++ b/src/parser/placeholder_sugar_wbtest.mbt
@@ -46,6 +46,29 @@ test "parse pipe placeholder substitutes at hole" {
 }
 
 ///|
+/// A labeled hole keeps its label: `x |> f(a=1, b=_)` => `f(a=1, b=x)`,
+/// not a positional `f(a=1, x)` (the checker would reject that). Regression
+/// for the #590 Codex review.
+test "parse pipe placeholder preserves a labeled slot" {
+  let ast = parse_ast("x |> f(a=1, b=_)")
+  match ast.stmts[0] {
+    @core.Stmt::Expr(expr~, ..) =>
+      match expr {
+        @core.Expr::Call(name="f", args~, ..) => {
+          assert_eq(args.length(), 2)
+          assert_eq(args[1].label, Some("b"))
+          match args[1].expr {
+            @core.Expr::Ident(name="x", ..) => ()
+            other => fail("expected b slot filled with x, got: \{other}")
+          }
+        }
+        other => fail("expected Call f, got: \{other}")
+      }
+    _ => fail("expected Expr stmt")
+  }
+}
+
+///|
 /// Pipe without a `_` hole still prepends the piped value as the first arg:
 /// `x |> f(a)` → `f(x, a)`.
 test "parse pipe without placeholder prepends" {

--- a/vibe/prelude/pipeline_ergonomics_test.vibe
+++ b/vibe/prelude/pipeline_ergonomics_test.vibe
@@ -1,0 +1,85 @@
+//# Imports
+
+// Runnable reference for the pipeline-ergonomics features documented in
+// docs/cheatsheet.md ("Function combinators", "Railway bind", "Debugging a
+// pipeline"). Co-located with the prelude it imports so `vibe test` can run it.
+//
+//   vibe test vibe/prelude/pipeline_ergonomics_test.vibe
+
+import ./result.vibe {
+  Result
+}
+
+import ./func.vibe {
+  compose, flip, identity
+}
+
+import ./io.vibe {
+  tap, tap_err, tap_ok
+}
+
+//# Functions
+
+let double: (Int) -> Int = (x) -> x * 2
+
+let add1: (Int) -> Int = (x) -> x + 1
+
+let scale: (Int, Int) -> Int = (factor, x) -> x * factor
+
+// railway: each stage names its result; an Err short-circuits the block
+let checked: (Int) -> Result[Int, String] = (n) -> {
+  let* positive = if n > 0 { Ok(n) } else { Err("non-positive") }
+  let* small = if positive < 100 { Ok(positive) } else { Err("too big") }
+  Ok(small * 10)
+}
+
+//# Misc
+
+test "pipe `_` placeholder: substitute at a non-first slot" {
+  // 3 |> scale(10, _) == scale(10, 3); without `_` it would prepend.
+  assert((3 |> scale(10, _)) == 30)
+  assert((3 |> scale(10, _) |> scale(2, _)) == 60)
+  assert((3 |> scale(10)) == 30) // no hole -> prepend (scale(3, 10))
+}
+
+test "function combinators: compose / identity / flip" {
+  let inc_then_double = compose(add1, double) // double(add1(x))
+  assert(inc_then_double(3) == 8)
+  assert(identity(42) == 42)
+  let sub: (Int, Int) -> Int = (a, b) -> a - b
+  assert(flip(sub)(3, 10) == 7) // sub(10, 3)
+}
+
+test "railway bind: let* short-circuits on Err" {
+  match checked(5) {
+    Ok(v) => assert(v == 50)
+    Err(_) => assert(false)
+  }
+  match checked(0) {
+    Ok(_) => assert(false)
+    Err(e) => assert(e == "non-positive")
+  }
+  match checked(250) {
+    Ok(_) => assert(false)
+    Err(e) => assert(e == "too big")
+  }
+}
+
+test "tap: observe a stage without breaking the chain" {
+  // tap returns its input unchanged (side effect omitted here).
+  let result = 5 |> tap((_v) -> ()) |> double
+  assert(result == 10)
+}
+
+test "tap_ok / tap_err: observe one railway track" {
+  let good: Result[Int, String] = Ok(7)
+  let bad: Result[Int, String] = Err("boom")
+  match good |> tap_ok((_v) -> ()) |> tap_err((_e) -> ()) {
+    Ok(v) => assert(v == 7)
+    Err(_) => assert(false)
+  }
+  match bad |> tap_ok((_v) -> ()) |> tap_err((_e) -> ()) {
+    Ok(_) => assert(false)
+    Err(e) => assert(e == "boom")
+  }
+}


### PR DESCRIPTION
Follow-up to #588 / #589. The pipe `_` placeholder slot was documented and worked on the selfhost path, but failed on the native `vibe test` host path; this restores parity and adds a runnable reference + doc prerequisites.

## `fix(parser)`: host parity for the pipe `_` slot — break-glass `src/`

`x |> f(a, _)` failed with **"too many arguments"** in the native host runner (`vibe test`): host `pipe_apply` always prepended the piped value, so the bare `_` survived as an extra `Placeholder` arg through to typecheck. The slot was only implemented in the selfhost compiler (`vibe/compiler/syntax/parser_expr_core.vibe::pipe_desugar`), leaving the documented feature broken on the legacy path developers run locally.

Mirror the selfhost semantics in `pipe_apply`: if the piped call's **direct** args contain a bare `_`, substitute the piped value at each hole instead of prepending; with no hole, keep prepending. Compound placeholders (`_ * 2`) stay section lambdas and still take the prepend path. After substitution no `Placeholder` remains, so the later section-lambda desugar leaves the call alone.

> **BREAK-GLASS:** this edits `src/` (legacy host) to restore parity with the selfhost source of truth, against the usual "do not follow `src/` for parity" policy. Kept as a standalone commit. The selfhost compiler already had this behavior — no selfhost change needed.

## `docs(examples)`: runnable reference

`vibe/prelude/pipeline_ergonomics_test.vibe` — a tested showcase of the #588 features, co-located with the prelude it imports (`examples/` cannot reach the prelude: import paths may not escape the file's root). Covers all four features end to end, **5/5** via `vibe test`: pipe `_` slot, `compose`/`identity`/`flip`, railway `let*` with Err short-circuit, and `tap`/`tap_ok`/`tap_err`.

## `docs(cheatsheet)`: prelude prerequisites

Clarify that the helpers are **prelude exports, not globals** (import `Result`/`tap*`/combinators; `tap*` carry the `Stdout` effect; import paths can't escape the file root), and link the runnable reference. Note the `_` slot now works on both backends.

## Verification

- `src/parser` **93/93** (2 new parse regression cases), `src/checker` **171/171**, `moon check` 0 errors.
- `vibe test` on the new reference **5/5**; `examples/placeholder_lambda_test` 6/6, `examples/pipe_test` 10/10 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNjN9PctbEs51KTJRRHSrk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNjN9PctbEs51KTJRRHSrk)_