### PR TITLE
docs(cheatsheet): import stdout_write in the Quick Start example

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -5,6 +5,10 @@ WASM-targeting, pure-by-default language with algebraic effects. Compiled via Mo
 ## Quick Start
 
 ```vibe
+// `stdout_write` is a prelude helper, not a builtin — import it (otherwise the
+// checker reports `unknown function: String::stdout_write`).
+import ./vibe/prelude/io.vibe { stdout_write }
+
 let main: () -> Unit with { Stdout } = () -> {
   stdout_write("hello world\n")
 }


### PR DESCRIPTION
## Problem

The very first example in the cheat sheet (Quick Start) calls `stdout_write` but does not import it, so copying it verbatim fails to type-check:

```
$ vibe check hello.vibe
hello.vibe:2:3: type: unknown function: `String::stdout_write`
```

`stdout_write` is a **prelude export** (`vibe/prelude/io.vibe`), not a builtin, so it must be imported. The later "Debugging a pipeline (`tap`)" section already notes this for `tap`/`stdout_write`, but the headline example omits it — the worst place to have a broken snippet.

## Fix

Add the prelude import (and a one-line note explaining the error) to the Quick Start so the first thing a new user copies actually compiles.

```vibe
// `stdout_write` is a prelude helper, not a builtin — import it (otherwise the
// checker reports `unknown function: String::stdout_write`).
import ./vibe/prelude/io.vibe { stdout_write }

let main: () -> Unit with { Stdout } = () -> {
  stdout_write("hello world\n")
}
```

## Verification

- Before: `vibe check` → `unknown function: String::stdout_write` (error).
- After: `vibe check` → no errors (only the expected `unused variable: main` warning, since `vibe check` does not treat `main` as an entry point).

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNjN9PctbEs51KTJRRHSrk)_