### PR TITLE
feat(wasm_opt): remove dead `block` scopes (remove-unused-brs)

### DIFF
--- a/docs/wasm-opt-dogfood.md
+++ b/docs/wasm-opt-dogfood.md
@@ -167,6 +167,13 @@ byte-identical to a module that `wasm-opt` validates and `wasmtime` runs.
   table and element sections are dropped and the element-only functions collapse.
   Reaches parity on rume_gain.
 - section stripping, `local.tee`, `drop`/`br_if 0` elimination, local coalescing.
+- **local copy-propagation** (`propagate_local_copies`) — a conservative slice
+  of `simplify-locals`: deletes self-copy pairs (`local.get $x; local.set $x`)
+  and forwards `local.get $a; local.set $b` to the single later use of `$b` when
+  `$a` is not rewritten in between (then `$b` is dead for coalesce/DCE). This is
+  the safe, bytecode-level subset; the rest of `simplify-locals`' win is
+  AST-level expression sinking, which needs an expression IR we don't build.
+  Helps copy-heavy code (e.g. array loops: `arr` 816 → 781 B).
 
 A prerequisite fix landed here too: `decode_instr` now consumes the immediates
 of every `0xFC`-prefixed op (table/memory bulk ops). Previously `table.size`'s

--- a/docs/wasm-opt-dogfood.md
+++ b/docs/wasm-opt-dogfood.md
@@ -174,6 +174,18 @@ byte-identical to a module that `wasm-opt` validates and `wasmtime` runs.
   the safe, bytecode-level subset; the rest of `simplify-locals`' win is
   AST-level expression sinking, which needs an expression IR we don't build.
   Helps copy-heavy code (e.g. array loops: `arr` 816 → 781 B).
+- **dead `block` removal** (`remove_dead_blocks`) — binaryen's
+  `remove-unused-brs` analog. Runs right after `inline_calls`, where inlined
+  call bodies leave `block` scopes that nothing branches to. A `block` (`0x02`)
+  is unwrapped (header + matching `end` dropped) only in the fully safe case: no
+  `br`/`br_if`/`br_table` **or** `try_table` catch label targets it, and no
+  inner branch escapes it — so removal changes no branch's meaning and needs no
+  label renumbering. `loop`/`if`/`try_table` are never removed. Correct
+  `try_table` handling is load-bearing for effectful code: catch labels resolve
+  in the scope *enclosing* the try_table (its own label not counted, target at
+  `sp - 2 - label`), so a catch that targets or crosses a block pins it.
+  Validated on real effectful output (`perform_handle`, runs to 86) and shrinks
+  `selfhost_features` 834 → 824 B.
 
 A prerequisite fix landed here too: `decode_instr` now consumes the immediates
 of every `0xFC`-prefixed op (table/memory bulk ops). Previously `table.size`'s

--- a/vibe/wasm/wasm_opt/index.vibe
+++ b/vibe/wasm/wasm_opt/index.vibe
@@ -6,7 +6,7 @@ export ./wasm_opt.vibe {
   count_exports, count_functions, count_types,
   binary_size, section_sizes,
   optimize_code_section, build_call_graph, find_reachable,
-  dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, optimize,
+  dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, remove_dead_blocks, optimize,
   coalesce_locals, propagate_local_copies, remove_unused_types, remove_empty_sections, minify, minify_fast,
   minify_converge,
   directize, call_forwarding
@@ -24,7 +24,7 @@ export {
   count_exports, count_functions, count_types,
   binary_size, section_sizes, version,
   optimize_code_section, build_call_graph, find_reachable,
-  dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, optimize,
+  dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, remove_dead_blocks, optimize,
   coalesce_locals, propagate_local_copies, remove_unused_types, remove_empty_sections, minify, minify_fast,
   minify_converge,
   directize, call_forwarding

--- a/vibe/wasm/wasm_opt/index.vibe
+++ b/vibe/wasm/wasm_opt/index.vibe
@@ -7,7 +7,7 @@ export ./wasm_opt.vibe {
   binary_size, section_sizes,
   optimize_code_section, build_call_graph, find_reachable,
   dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, optimize,
-  coalesce_locals, remove_unused_types, remove_empty_sections, minify, minify_fast,
+  coalesce_locals, propagate_local_copies, remove_unused_types, remove_empty_sections, minify, minify_fast,
   minify_converge,
   directize, call_forwarding
 }
@@ -25,7 +25,7 @@ export {
   binary_size, section_sizes, version,
   optimize_code_section, build_call_graph, find_reachable,
   dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, optimize,
-  coalesce_locals, remove_unused_types, remove_empty_sections, minify, minify_fast,
+  coalesce_locals, propagate_local_copies, remove_unused_types, remove_empty_sections, minify, minify_fast,
   minify_converge,
   directize, call_forwarding
 }

--- a/vibe/wasm/wasm_opt/wasm_opt.vibe
+++ b/vibe/wasm/wasm_opt/wasm_opt.vibe
@@ -3129,6 +3129,222 @@ export let optimize_code_section = (bytes: Bytes) -> Bytes {
   }
 }
 
+// Unwrap `block` (0x02) scopes whose label no branch uses. vibe codegen
+// (especially around inlined call bodies) wraps regions in `block` scopes that
+// no `br` jumps to; binaryen's remove-unused-brs strips them. We remove a block
+// only when it is the fully safe case: no br/br_if/br_table (or try_table catch)
+// targets it AND no inner branch escapes it. Then dropping its header+end needs
+// no label renumbering, so removal cannot change any branch's meaning.
+// loop/if/try_table scopes are never removed.
+//
+// try_table catch clauses carry branch labels resolved in the scope *enclosing*
+// the try_table (its own label is not counted), so the catch target sits at
+// sp - 2 - label; a catch that targets or escapes a block marks it just like a
+// `br`. Getting this wrong would corrupt effectful programs (vibe effects
+// compile to wasm exception handling). A single forward pass suffices: every
+// branch inside a block is seen before the block's `end`.
+let remove_dead_blocks_body = (body: Bytes) -> Bytes {
+  let body_len = Bytes::length(body)
+  if body_len < 2 {
+    copy_bytes(body, 0, body_len)
+  }
+  else {
+    let mut pos = 0
+    let (local_count, lp) = read_uleb128(body, 0)
+    pos = lp
+    let mut lc = 0
+    while lc < local_count {
+      let (_, tp) = read_uleb128(body, pos)
+      pos = tp + 1
+      lc = lc + 1
+    }
+    let code_start = pos
+    let code_end = body_len - 1
+    if code_start >= code_end {
+      copy_bytes(body, 0, body_len)
+    } else {
+      let cap = code_end - code_start + 1
+      let frame_op = FixedArray::make(cap + 1, 0)
+      let frame_hdr_start = FixedArray::make(cap + 1, 0)
+      let frame_hdr_end = FixedArray::make(cap + 1, 0)
+      // frame_bad[sp] == 1: a branch/catch targets this frame, or an inner
+      // branch escapes it (both block removal here).
+      let frame_bad = FixedArray::make(cap + 1, 0)
+      let skip = FixedArray::make(cap + 1, 0)
+      let mut sp = 0
+      let mut p = code_start
+      let mut any = 0
+      while p < code_end {
+        let op = body[p]
+        let (_, _, next) = decode_instr(body, p)
+        if (op == 0x02) || (op == 0x03) || (op == 0x04) {
+          FixedArray::set(frame_op, sp, op)
+          FixedArray::set(frame_hdr_start, sp, p)
+          FixedArray::set(frame_hdr_end, sp, next)
+          FixedArray::set(frame_bad, sp, 0)
+          sp = sp + 1
+        }
+        else if op == 0x1F {
+          FixedArray::set(frame_op, sp, op)
+          FixedArray::set(frame_hdr_start, sp, p)
+          FixedArray::set(frame_hdr_end, sp, next)
+          FixedArray::set(frame_bad, sp, 0)
+          sp = sp + 1
+          let (_, q1) = read_sleb128(body, p + 1)
+          let (cnt, q2) = read_uleb128(body, q1)
+          let mut qq = q2
+          let mut ki = 0
+          while ki < cnt {
+            let kind = body[qq]
+            qq = qq + 1
+            let label = if (kind == 0) || (kind == 1) {
+              let (_, qa) = read_uleb128(body, qq)
+              let (lab, qb) = read_uleb128(body, qa)
+              qq = qb
+              lab
+            } else {
+              let (lab, qa) = read_uleb128(body, qq)
+              qq = qa
+              lab
+            }
+            // mark the catch target and every block it crosses (target at
+            // sp - 2 - label; the just-pushed try_table frame is not counted).
+            let ti = sp - 2 - label
+            let lo = if ti < 0 {
+              0
+            } else {
+              ti
+            }
+            let mut j = lo
+            while j < sp {
+              FixedArray::set(frame_bad, j, 1)
+              j = j + 1
+            }
+            ki = ki + 1
+          }
+        }
+        else if op == 0x0B {
+          if sp > 0 {
+            sp = sp - 1
+            if (FixedArray::get(frame_op, sp) == 0x02) && (FixedArray::get(frame_bad, sp) == 0) {
+              let hs = FixedArray::get(frame_hdr_start, sp)
+              let he = FixedArray::get(frame_hdr_end, sp)
+              let mut b = hs
+              while b < he {
+                FixedArray::set(skip, b - code_start, 1)
+                b = b + 1
+              }
+              FixedArray::set(skip, p - code_start, 1)
+              any = 1
+            }
+          }
+        }
+        else if (op == 0x0C) || (op == 0x0D) {
+          let (label, _) = read_uleb128(body, p + 1)
+          // mark the branch target and every block it escapes (target at
+          // sp - 1 - label)
+          let ti = sp - 1 - label
+          let lo = if ti < 0 {
+            0
+          } else {
+            ti
+          }
+          let mut j = lo
+          while j < sp {
+            FixedArray::set(frame_bad, j, 1)
+            j = j + 1
+          }
+        }
+        else if op == 0x0E {
+          let (cnt, q0) = read_uleb128(body, p + 1)
+          let mut q = q0
+          let mut bi = 0
+          while bi <= cnt {
+            let (label, qn) = read_uleb128(body, q)
+            q = qn
+            let ti = sp - 1 - label
+            let lo = if ti < 0 {
+              0
+            } else {
+              ti
+            }
+            let mut j = lo
+            while j < sp {
+              FixedArray::set(frame_bad, j, 1)
+              j = j + 1
+            }
+            bi = bi + 1
+          }
+        }
+        else {
+          ()
+        }
+        p = next
+      }
+      if any == 0 {
+        copy_bytes(body, 0, body_len)
+      } else {
+        let out = Bytes::new()
+        let mut hi = 0
+        while hi < code_start {
+          Bytes::push(out, body[hi])
+          hi = hi + 1
+        }
+        let mut ci = code_start
+        while ci < code_end {
+          if FixedArray::get(skip, ci - code_start) == 0 {
+            Bytes::push(out, body[ci])
+          }
+          ci = ci + 1
+        }
+        Bytes::push(out, body[code_end])
+        out
+      }
+    }
+  }
+}
+
+let remove_dead_blocks_code_section = (bytes: Bytes, offset: Int, size: Int) -> Bytes {
+  let raw_bodies = parse_code_bodies(bytes, offset, size)
+  let optimized = Array::slice([
+    (Bytes::new())
+  ], 0, 0)
+  let mut fi = 0
+  while fi < Array::length(raw_bodies) {
+    Array::push(optimized, remove_dead_blocks_body(Array::get(raw_bodies, fi)))
+    fi = fi + 1
+  }
+  rebuild_code_section(optimized)
+}
+
+export let remove_dead_blocks = (bytes: Bytes) -> Bytes {
+  let len = Bytes::length(bytes)
+  if len < 8 {
+    copy_bytes(bytes, 0, len)
+  }
+  else {
+    let out = Bytes::new()
+    let mut i = 0
+    while i < 8 {
+      Bytes::push(out, bytes[i]); i = i + 1
+    }
+    let sections = list_sections(bytes)
+    let mut s = 0
+    while s < Array::length(sections) {
+      let (sid, off, sz) = Array::get(sections, s)
+      if sid == 10 {
+        let new_content = remove_dead_blocks_code_section(bytes, off, sz)
+        emit_section(out, 10, new_content)
+      } else {
+        let content = copy_bytes(bytes, off, off + sz)
+        emit_section(out, sid, content)
+      }
+      s = s + 1
+    }
+    out
+  }
+}
+
 // Result-arity of a function type (mirror of get_type_param_count).
 let get_type_result_count = (bytes: Bytes, type_sec_off: Int, type_sec_sz: Int, type_idx: Int) -> Int {
   let end_pos = type_sec_off + type_sec_sz
@@ -4858,7 +5074,8 @@ export let minify = (bytes: Bytes) -> Bytes {
     let s4a = optimize_code_section(s3d)
     let s4b = inline_empty_calls(s4a)
     let s4c = inline_calls(s4b)
-    let s4 = drop_unused_tables(s4c)
+    let s4d = remove_dead_blocks(s4c)
+    let s4 = drop_unused_tables(s4d)
     let s5_removed = dce_remove(s4)
     let s5 = if binary_size(s5_removed) < binary_size(s4) {
       s5_removed

--- a/vibe/wasm/wasm_opt/wasm_opt.vibe
+++ b/vibe/wasm/wasm_opt/wasm_opt.vibe
@@ -4641,6 +4641,195 @@ export let drop_unused_globals = (bytes: Bytes) -> Bytes {
   }
 }
 
+// Per-body rewrite for propagate_local_copies: drop the `local.get; local.set`
+// pair at span indices (set_b_span - 1, set_b_span) and, when b_idx >= 0,
+// rewrite the single later `local.get $b_idx` to `local.get $a_idx`. Mirrors
+// the other rewrite_body_* helpers.
+let rewrite_body_locals = (body: Bytes, set_b_span: Int, a_idx: Int, b_idx: Int) -> Bytes {
+  let (_, code_start) = read_local_groups(body)
+  let code_end = Bytes::length(body) - 1
+  let spans = parse_body_spans(body, code_start, code_end)
+  let nb = Bytes::new()
+  let mut h = 0
+  while h < code_start {
+    Bytes::push(nb, body[h]); h = h + 1
+  }
+  let mut i = 0
+  while i < Array::length(spans) {
+    let (s_i, e_i, op_i) = Array::get(spans, i)
+    if (i == set_b_span - 1) || (i == set_b_span) {
+      i = i + 1
+    } else {
+      if (op_i == 0x20) && (span_read_uleb_imm(body, s_i) == b_idx) {
+        Bytes::push(nb, 0x20)
+        write_uleb128(nb, a_idx)
+      } else {
+        copy_span_bytes(nb, body, s_i, e_i)
+      }
+      i = i + 1
+    }
+  }
+  Bytes::push(nb, 0x0B)
+  nb
+}
+
+// Local copy-propagation (a conservative slice of wasm-opt's simplify-locals).
+// Handles two adjacent-pair shapes, one rewrite per call (converge repeats):
+//   (A) `local.get $x; local.set $x` — a pure no-op pair (push then pop into
+//       the same slot); both are deleted unconditionally.
+//   (B) `local.get $a; local.set $b` (a != b) where $b is written only here and
+//       read exactly once, that read comes after the set, and $a is not
+//       rewritten between the copy and the read. The pair is stack-neutral so
+//       both are deleted and the later `local.get $b` becomes `local.get $a`
+//       (value-equivalent since $a is unchanged). $b is then dead for
+//       coalesce/DCE.
+export let propagate_local_copies = (bytes: Bytes) -> Bytes {
+  let len = Bytes::length(bytes)
+  if len < 8 {
+    copy_bytes(bytes, 0, len)
+  }
+  else {
+    let sections = list_sections(bytes)
+    let mut code_off = -1
+    let mut code_sz = 0
+    let mut si = 0
+    while si < Array::length(sections) {
+      let (sid, off, sz) = Array::get(sections, si)
+      if sid == 10 {
+        code_off = off; code_sz = sz
+      }
+      si = si + 1
+    }
+    if code_off < 0 {
+      copy_bytes(bytes, 0, len)
+    }
+    else {
+      let bodies = parse_code_bodies(bytes, code_off, code_sz)
+      let mut target_fi = -1
+      let mut a_idx = -1
+      let mut b_idx = -1
+      let mut set_b_span = -1
+      let mut fi = 0
+      while (fi < Array::length(bodies)) && (target_fi < 0) {
+        let body = Array::get(bodies, fi)
+        let spans = parse_full_body_spans(body)
+        let mut maxidx = -1
+        let mut k = 0
+        while k < Array::length(spans) {
+          let (s_k, _, op_k) = Array::get(spans, k)
+          if (op_k == 0x20) || (op_k == 0x21) || (op_k == 0x22) {
+            let idx = span_read_uleb_imm(body, s_k)
+            if idx > maxidx {
+              maxidx = idx
+            }
+          }
+          k = k + 1
+        }
+        if maxidx >= 0 {
+          let reads = FixedArray::make(maxidx + 1, 0)
+          let writes = FixedArray::make(maxidx + 1, 0)
+          // read_pos[idx] = span index of a local.get of idx; for a local read
+          // exactly once (reads[idx] == 1) this is that single read's index.
+          let read_pos = FixedArray::make(maxidx + 1, -1)
+          let mut c = 0
+          while c < Array::length(spans) {
+            let (s_c, _, op_c) = Array::get(spans, c)
+            if op_c == 0x20 {
+              let idx = span_read_uleb_imm(body, s_c)
+              if (idx >= 0) && (idx <= maxidx) {
+                FixedArray::set(reads, idx, FixedArray::get(reads, idx) + 1)
+                FixedArray::set(read_pos, idx, c)
+              }
+            } else if (op_c == 0x21) || (op_c == 0x22) {
+              let idx = span_read_uleb_imm(body, s_c)
+              if (idx >= 0) && (idx <= maxidx) {
+                FixedArray::set(writes, idx, FixedArray::get(writes, idx) + 1)
+              }
+            }
+            c = c + 1
+          }
+          let mut p = 0
+          while (p + 1 < Array::length(spans)) && (target_fi < 0) {
+            let (s_p, _, op_p) = Array::get(spans, p)
+            let (s_q, _, op_q) = Array::get(spans, p + 1)
+            if (op_p == 0x20) && (op_q == 0x21) {
+              let a = span_read_uleb_imm(body, s_p)
+              let b = span_read_uleb_imm(body, s_q)
+              if (a == b) && (a >= 0) && (a <= maxidx) {
+                // self-copy `local.get $x; local.set $x`: a pure no-op pair.
+                target_fi = fi
+                a_idx = a
+                b_idx = -1
+                set_b_span = p + 1
+              } else if (a != b) && (a >= 0) && (a <= maxidx) && (b >= 0) && (b <= maxidx)
+                && (FixedArray::get(reads, b) == 1) && (FixedArray::get(writes, b) == 1) {
+                let gb = FixedArray::get(read_pos, b)
+                // Safe iff $b's single read comes after the set and $a is not
+                // rewritten between the copy and that read (so $a still holds
+                // the copied value at the use).
+                let mut a_clobbered = false
+                let mut w = p + 2
+                while w < gb {
+                  let (s_w, _, op_w) = Array::get(spans, w)
+                  if (op_w == 0x21) || (op_w == 0x22) {
+                    if span_read_uleb_imm(body, s_w) == a {
+                      a_clobbered = true
+                    }
+                  }
+                  w = w + 1
+                }
+                if (gb > (p + 1)) && (a_clobbered == false) {
+                  target_fi = fi
+                  a_idx = a
+                  b_idx = b
+                  set_b_span = p + 1
+                }
+              }
+            }
+            p = p + 1
+          }
+        }
+        fi = fi + 1
+      }
+      if target_fi < 0 {
+        copy_bytes(bytes, 0, len)
+      }
+      else {
+        let nb = rewrite_body_locals(Array::get(bodies, target_fi), set_b_span, a_idx, b_idx)
+        let newbodies = Array::slice([
+          (Bytes::new())
+        ], 0, 0)
+        let mut bj = 0
+        while bj < Array::length(bodies) {
+          if bj == target_fi {
+            Array::push(newbodies, nb)
+          } else {
+            Array::push(newbodies, Array::get(bodies, bj))
+          }
+          bj = bj + 1
+        }
+        let out = Bytes::new()
+        let mut hi = 0
+        while hi < 8 {
+          Bytes::push(out, bytes[hi]); hi = hi + 1
+        }
+        let mut s = 0
+        while s < Array::length(sections) {
+          let (sid, off, sz) = Array::get(sections, s)
+          if sid == 10 {
+            emit_section(out, 10, rebuild_code_section(newbodies))
+          } else {
+            let content = copy_bytes(bytes, off, off + sz)
+            emit_section(out, sid, content)
+          }
+          s = s + 1
+        }
+        out
+      }
+    }
+  }
+}
+
 export let minify = (bytes: Bytes) -> Bytes {
   let len = Bytes::length(bytes)
   if len < 8 {
@@ -4678,7 +4867,8 @@ export let minify = (bytes: Bytes) -> Bytes {
     }
     let s5g = drop_unused_globals(s5)
     let s5t = drop_unused_tags(s5g)
-    let s6 = coalesce_locals(s5t)
+    let s5p = propagate_local_copies(s5t)
+    let s6 = coalesce_locals(s5p)
     let s7 = remove_unused_types(s6)
     remove_empty_sections(s7)
   }

--- a/vibe/wasm/wasm_opt/wasm_opt.vibe
+++ b/vibe/wasm/wasm_opt/wasm_opt.vibe
@@ -4980,10 +4980,17 @@ export let propagate_local_copies = (bytes: Bytes) -> Bytes {
               } else if (a != b) && (a >= 0) && (a <= maxidx) && (b >= 0) && (b <= maxidx)
                 && (FixedArray::get(reads, b) == 1) && (FixedArray::get(writes, b) == 1) {
                 let gb = FixedArray::get(read_pos, b)
-                // Safe iff $b's single read comes after the set and $a is not
+                // Safe iff $b's single read comes after the set, $a is not
                 // rewritten between the copy and that read (so $a still holds
-                // the copied value at the use).
+                // the copied value at the use), and the set dominates the read.
+                // Dominance: the span between the set and the read must be
+                // straight-line (no control-flow ops) — otherwise the set may be
+                // conditional (e.g. inside an `if` arm) while the read runs
+                // unconditionally, and on the untaken path $b keeps its prior /
+                // zero-init value rather than $a's. A nested block/branch between
+                // the two is rejected conservatively.
                 let mut a_clobbered = false
+                let mut crosses_branch = false
                 let mut w = p + 2
                 while w < gb {
                   let (s_w, _, op_w) = Array::get(spans, w)
@@ -4992,9 +4999,15 @@ export let propagate_local_copies = (bytes: Bytes) -> Bytes {
                       a_clobbered = true
                     }
                   }
+                  if (op_w == 0x00) || (op_w == 0x02) || (op_w == 0x03) || (op_w == 0x04) ||
+                  (op_w == 0x05) || (op_w == 0x08) || (op_w == 0x0A) || (op_w == 0x0B) ||
+                  (op_w == 0x0C) || (op_w == 0x0D) || (op_w == 0x0E) || (op_w == 0x0F) ||
+                  (op_w == 0x1F) {
+                    crosses_branch = true
+                  }
                   w = w + 1
                 }
-                if (gb > (p + 1)) && (a_clobbered == false) {
+                if (gb > (p + 1)) && (a_clobbered == false) && (crosses_branch == false) {
                   target_fi = fi
                   a_idx = a
                   b_idx = b

--- a/vibe/wasm/wasm_opt/wasm_opt_test.vibe
+++ b/vibe/wasm/wasm_opt/wasm_opt_test.vibe
@@ -2540,6 +2540,21 @@ test "propagate_local_copies forwards local.get a; local.set b to the single use
   assert(bytes_eq(propagate_local_copies(m), expected))
 }
 
+test "propagate_local_copies keeps a copy that does not dominate the read" {
+  // () -> i32, 2 locals: const5; set0; const1; if { get0; set1 } end; get1; end
+  // The `get0; set1` copy is inside the `if` arm, so the `set1` does not
+  // dominate the later `get1`; forwarding it would change the untaken path.
+  // The pass must leave the module unchanged.
+  let m = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 5, 1, 96, 0, 1, 127,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 21, 1, 19, 1, 2, 127, 65, 5, 33, 0, 65, 1, 4, 64, 32, 0, 33, 1, 11, 32, 1, 11
+  ])
+  assert(bytes_eq(propagate_local_copies(m), m))
+}
+
 test "remove_dead_blocks unwraps a value-block with no branch target" {
   // () -> i64: block (result i64) { i64.const 5 } end -> i64.const 5 end
   let m = make_bytes([

--- a/vibe/wasm/wasm_opt/wasm_opt_test.vibe
+++ b/vibe/wasm/wasm_opt/wasm_opt_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./index.vibe {
-  binary_size, build_call_graph, coalesce_locals, count_exports, count_functions, count_types, dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, filter_exports, find_reachable, minify, minify_converge, minify_fast, optimize, optimize_code_section, remove_empty_sections, remove_unused_types, section_sizes, strip_custom_sections, strip_empty_data, strip_named_section
+  binary_size, build_call_graph, coalesce_locals, propagate_local_copies, count_exports, count_functions, count_types, dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, filter_exports, find_reachable, minify, minify_converge, minify_fast, optimize, optimize_code_section, remove_empty_sections, remove_unused_types, section_sizes, strip_custom_sections, strip_empty_data, strip_named_section
 }
 
 //# Functions
@@ -2499,4 +2499,43 @@ test "drop_unused_globals handles a const whose LEB byte is 0x0B" {
     10, 4, 1, 2, 0, 11
   ])
   assert(bytes_eq(drop_unused_globals(m), expected))
+}
+
+test "propagate_local_copies removes a self-copy local.get x; local.set x" {
+  // () -> i32 with 1 local: const 5; set0; (get0; set0 = no-op); get0; end
+  let m = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 5, 1, 96, 0, 1, 127,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 16, 1, 14, 1, 1, 127, 101, 5, 33, 0, 32, 0, 33, 0, 32, 0, 11
+  ])
+  let expected = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 5, 1, 96, 0, 1, 127,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 12, 1, 10, 1, 1, 127, 101, 5, 33, 0, 32, 0, 11
+  ])
+  assert(bytes_eq(propagate_local_copies(m), expected))
+}
+
+test "propagate_local_copies forwards local.get a; local.set b to the single use" {
+  // () -> i32, 2 locals: const 7; set0; get0; set1; get1; end
+  // -> const 7; set0; get0; end  (the get1 use becomes get0, $1 dead)
+  let m = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 5, 1, 96, 0, 1, 127,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 16, 1, 14, 1, 2, 127, 101, 7, 33, 0, 32, 0, 33, 1, 32, 1, 11
+  ])
+  let expected = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 5, 1, 96, 0, 1, 127,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 12, 1, 10, 1, 2, 127, 101, 7, 33, 0, 32, 0, 11
+  ])
+  assert(bytes_eq(propagate_local_copies(m), expected))
 }

--- a/vibe/wasm/wasm_opt/wasm_opt_test.vibe
+++ b/vibe/wasm/wasm_opt/wasm_opt_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./index.vibe {
-  binary_size, build_call_graph, coalesce_locals, propagate_local_copies, count_exports, count_functions, count_types, dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, filter_exports, find_reachable, minify, minify_converge, minify_fast, optimize, optimize_code_section, remove_empty_sections, remove_unused_types, section_sizes, strip_custom_sections, strip_empty_data, strip_named_section
+  binary_size, build_call_graph, coalesce_locals, propagate_local_copies, count_exports, count_functions, count_types, dce, dce_remove, inline_empty_calls, inline_calls, fold_table_size, drop_unused_tables, drop_unused_globals, drop_unused_tags, eliminate_dead_stores, remove_dead_blocks, filter_exports, find_reachable, minify, minify_converge, minify_fast, optimize, optimize_code_section, remove_empty_sections, remove_unused_types, section_sizes, strip_custom_sections, strip_empty_data, strip_named_section
 }
 
 //# Functions
@@ -2538,4 +2538,50 @@ test "propagate_local_copies forwards local.get a; local.set b to the single use
     10, 12, 1, 10, 1, 2, 127, 101, 7, 33, 0, 32, 0, 11
   ])
   assert(bytes_eq(propagate_local_copies(m), expected))
+}
+
+test "remove_dead_blocks unwraps a value-block with no branch target" {
+  // () -> i64: block (result i64) { i64.const 5 } end -> i64.const 5 end
+  let m = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 5, 1, 96, 0, 1, 126,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 9, 1, 7, 0, 2, 126, 66, 5, 11, 11
+  ])
+  let expected = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 5, 1, 96, 0, 1, 126,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 6, 1, 4, 0, 66, 5, 11
+  ])
+  assert(bytes_eq(remove_dead_blocks(m), expected))
+}
+
+test "remove_dead_blocks keeps a block that is a branch target" {
+  // () -> i64: block (result i64) { i64.const 5; br 0 } end -> unchanged
+  let m = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 5, 1, 96, 0, 1, 126,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 11, 1, 9, 0, 2, 126, 66, 5, 12, 0, 11, 11
+  ])
+  assert(bytes_eq(remove_dead_blocks(m), m))
+}
+
+test "remove_dead_blocks keeps an untargeted block that an inner br escapes" {
+  // () -> (): block $outer { block $inner { br 1 } } -> unchanged.
+  // $inner is untargeted but the inner `br 1` escapes it, so removing $inner
+  // would require relabeling the br; the safe subset keeps it. $outer is a
+  // branch target so it also stays.
+  let m = make_bytes([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    1, 4, 1, 96, 0, 0,
+    3, 2, 1, 0,
+    7, 8, 1, 4, 109, 97, 105, 110, 0, 0,
+    10, 12, 1, 10, 0, 2, 64, 2, 64, 12, 1, 11, 11, 11
+  ])
+  assert(bytes_eq(remove_dead_blocks(m), m))
 }


### PR DESCRIPTION
## Summary

Adds **`remove_dead_blocks`**, binaryen's `remove-unused-brs` analog, written in vibe and wired into the `minify` pipeline right after `inline_calls` — where inlined call bodies leave `block` scopes that nothing branches to. It unwraps a `block` (drops its header + matching `end`) only in the fully safe case: no `br`/`br_if`/`br_table` **or** `try_table` catch label targets it, and no inner branch escapes it. So removal changes no branch's meaning and needs no label renumbering. `loop`/`if`/`try_table` scopes are never removed.

## Exception-handling correctness

`try_table` handling is load-bearing for effectful code (vibe effects compile to wasm exception handling). Catch labels resolve in the scope *enclosing* the try_table — its own label is **not** counted, so the catch target sits at `sp - 2 - label` — and a catch that targets or crosses a block pins it. An earlier off-by-one here (`sp - 1 - label`) was caught by the real-code dogfood loop on `perform_handle` (wasm-opt rejected the output: *"catch kind generates 1 operand, target block expects 0"*) and fixed; unit fixtures without exception handling would not have surfaced it.

## Validation

Validated end-to-end against the selfhost compiler's own output — wasm-opt validates the result and wasmtime runs it to the same value as the baseline:

| program (selfhost-compiled) | before | after | valid | runs |
|---|--:|--:|--|--|
| `examples/selfhost_features` | 834 | **824** | ✅ | 0 = 0 |
| `examples/perform_handle` | 858 | 858 | ✅ | 86 = 86 |

`perform_handle` is unchanged because all its untargeted blocks turn out to be EH-entangled (crossed by try_table catch labels) and are conservatively pinned.

- **92/92** unit tests (added: value-block removal, keeping a self-targeted block, keeping a block an inner `br` escapes) + 9/9 inline fixtures.
- Confirmed the broad pre-existing `minify` invalidity on other examples (effects/async/base64/basics) is **not** caused by this pass — they are invalid with the pass disabled too, and the pass only ever shrinks them.

## Design note

A more capable variant that relabels escaping branches was prototyped and reverted: it produced **zero** extra removals on both baseline-valid programs, and with a thin validation surface a label-rewriting pass isn't worth the silent-corruption risk for no measured gain. The doc notes it as a future option once dataflow `simplify-locals` (the actual dominant remaining lever) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNjN9PctbEs51KTJRRHSrk)_