### PR TITLE
feat(coverage): syntax + expr-walk drivers to 81.25%

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -192,8 +192,8 @@ in-scope）を直接叩ける。型/trait/env に加え以下も edge-case 入�
 
 #### 80% 達成（no-DCE merged source + direct-call drivers）
 
-**分岐 5406/6694 (80.76%)**・関数 1037/1176 (88.18%) に到達（下限ガード 80% =
-5356 に対し +50 分岐のマージン）。
+**分岐 5439/6694 (81.25%)**・関数 1037/1176 (88.18%) に到達（下限ガード 80% =
+5356 に対し +83 分岐のマージン）。
 74% で頭打ちだった主因（コンパイラ自身の unit test 120/148 が builtins⇄checker
 の循環 re-export で FS-compile 不能）を、**循環 re-export を直さずに**回避した。
 
@@ -238,6 +238,17 @@ corpus acc.json に (fn_name, local_branch_index) キーで union する。分�
     関数名で union するため、merged source 内に**重複定義**を持つ helper
     (`strip_trailing_cr`/`parse_struct_fields_rest` 等) は local-index がずれて
     点灯しない — driver は unique-named 関数に限定する。
+  - `cov_syntax.vibe`: parser を corpus が踏まない arm へ — slice 記法
+    (`a[:]`/`a[1:]`/`a[:2]`)、block-local `let rec`/`let mut`/enum/struct
+    (`parse_impl_block`)、if/else-if・is-pattern・match expression mode
+    (`parse_impl_dispatch`)。`load_and_parse` で parse のみ走らせ error は握り潰す。
+  - `cov_exprwalk.vibe`: unique な再帰 Expr/Pat walker を全 variant 構築で直接叩く
+    — `is_mut_captured_in`(`||` 短絡の else 側・`let n==name` shadowing arm)、
+    `rewrite_import_alias_expr`、`wrap_placeholder_arg`、`pat_binds_name`(全 Pat
+    variant)。Expr/Pat コンストラクタを手で組むため compile 不要で全 arm を踏む
+    (`pat_binds_name`/`wrap_placeholder_arg` は 0 dark まで到達) (+25)。注:
+    whole-program compile を増やしても corpus が飽和済みで +0〜+1（実測で確認）—
+    伸びるのは「特定 helper/walker を直接呼ぶ」driver に限る。
 - **manifest-header cache** (`coverage_selfhost_manifestcache.sh`): 非 special な
   manifest project を cold/warm/部分 invalidation で FS-compile し、
   `matches_cached_file_spec`/`try_collect_manifest_source_groups_fs`/

--- a/scripts/coverage/cov_exprwalk.vibe
+++ b/scripts/coverage/cov_exprwalk.vibe
@@ -1,0 +1,108 @@
+
+// #cov expr-walk driver: is_mut_captured_in / rewrite_import_alias_expr /
+// wrap_placeholder_arg are unique recursive Expr walkers whose per-variant arms
+// the corpus only partially exercises (real ASTs never hit every shape). Build one
+// Expr of each variant they branch on and feed it through all three directly.
+let cov_ew_mut: (Expr) -> Int = (e) -> { if is_mut_captured_in(e, "x") { 1 } else { 0 } }
+let cov_ew_rw: (Expr, Array[(String, String)]) -> Int = (e, al) -> {
+  match rewrite_import_alias_expr(e, al) { _ => 1 }
+}
+let cov_ew_wrap: (Expr) -> Int = (e) -> { match wrap_placeholder_arg(e) { _ => 1 } }
+
+let cov_ew_all: (Expr, Array[(String, String)]) -> Int = (e, al) -> {
+  cov_ew_mut(e) + cov_ew_rw(e, al) + cov_ew_wrap(e)
+}
+let cov_ew_proj: (Expr) -> Int = (e) -> { if expr_projects_or_matches("x", e) { 1 } else { 0 } }
+let cov_ew_pat: (Pat) -> Int = (p) -> { if pat_binds_name(p, "x") { 1 } else { 0 } }
+
+export let cov_exprwalk_main: () -> Int = () -> {
+  let mut acc = 0
+  let al = Array::slice([("x", "y")], 0, 1)        // alias map [("x","y")]
+  let noexpr = Array::slice([EUnit], 0, 0)          // empty Array[Expr]
+  let xid = EIdent("x")
+  let ph = EIdent("_")
+  let es = Array::slice([xid], 0, 0)                 // empty Array[Expr]
+  Array::push(es, xid)
+  // one Expr per branched variant (leaves + every recursive shape)
+  let progs = Array::slice([EUnit], 0, 0)
+  Array::push(progs, EInt(1))
+  Array::push(progs, EFloat(1.0))
+  Array::push(progs, EString("s"))
+  Array::push(progs, EBool(true))
+  Array::push(progs, EUnit)
+  Array::push(progs, xid)
+  Array::push(progs, ph)
+  Array::push(progs, ETuple(es))
+  Array::push(progs, EArray(es))
+  Array::push(progs, ERecord(Array::slice([("f", xid)], 0, 1)))
+  Array::push(progs, EMap(Array::slice([("k", xid)], 0, 1)))
+  Array::push(progs, EIf(xid, EInt(1), EInt(2)))
+  Array::push(progs, ELet("a", xid, EIdent("a")))
+  Array::push(progs, ELetRec("a", xid, EIdent("a")))
+  Array::push(progs, ELetMut("a", xid, EAssign("a", EInt(1), EUnit)))
+  Array::push(progs, EAssign("x", EInt(1), EUnit))
+  Array::push(progs, EAssignOp("+", "x", EInt(1), EUnit))
+  Array::push(progs, ESeq(xid, EUnit))
+  Array::push(progs, EWhile(xid, EUnit))
+  Array::push(progs, EForIn("i", None, xid, EUnit))
+  Array::push(progs, ECall(EIdent("f"), Array::slice([xid, ph], 0, 2)))
+  Array::push(progs, EBinOp("+", xid, ph))
+  Array::push(progs, EBinOp("+", EInt(1), EInt(2)))
+  Array::push(progs, EUnaryOp("-", xid))
+  Array::push(progs, EDot(ph, "field"))
+  Array::push(progs, EThrow(xid))
+  Array::push(progs, EReturn(xid))
+  Array::push(progs, EBreak(Some(xid)))
+  Array::push(progs, EBreak(None))
+  Array::push(progs, EContinue(Array::slice([xid], 0, 1)))
+  Array::push(progs, ESpread(xid))
+  Array::push(progs, EStringInterp(Array::slice(["a", "b"], 0, 2)))
+  // second-position / shadowing shapes: drive the `||` short-circuit's else side
+  // and the `let n == name` shadowing arms of is_mut_captured_in.
+  Array::push(progs, EBinOp("+", EInt(1), xid))          // x in rhs only
+  Array::push(progs, EIf(EInt(0), EInt(1), xid))         // x in else only
+  Array::push(progs, EIf(EInt(0), xid, EInt(1)))         // x in then only
+  Array::push(progs, ECall(EIdent("f"), Array::slice([EInt(1), xid], 0, 2)))  // x in later arg
+  Array::push(progs, ECall(xid, noexpr))                 // x in callee
+  Array::push(progs, ELet("x", EInt(1), EIdent("x")))    // shadowing: n == name
+  Array::push(progs, ELetRec("x", EInt(1), EIdent("x"))) // shadowing
+  Array::push(progs, ELetMut("x", EInt(1), EIdent("x"))) // shadowing
+  Array::push(progs, EForIn("i", None, EInt(0), xid))    // x in body only
+  Array::push(progs, EWhile(EInt(0), xid))               // x in body only
+  Array::push(progs, ESeq(EInt(0), xid))                 // x in second only
+  Array::push(progs, EAssign("y", xid, EUnit))           // x in assigned value
+  let mut i = 0
+  while i < Array::length(progs) { acc = acc + cov_ew_all(Array::get(progs, i), al); i = i + 1 }
+
+  // expr_projects_or_matches: EIdent / EDot / EMatch / EHandle (+ default)
+  let arms = Array::slice([(PWild, EUnit)], 0, 1)         // one arm [(PWild, EUnit)]
+  let pexprs = Array::slice([EUnit], 0, 0)
+  Array::push(pexprs, EIdent("x"))
+  Array::push(pexprs, EIdent("z"))
+  Array::push(pexprs, EDot(EIdent("x"), "f"))
+  Array::push(pexprs, EMatch(EIdent("x"), arms))
+  Array::push(pexprs, EHandle(EIdent("x"), arms))
+  Array::push(pexprs, EInt(1))
+  let mut j = 0
+  while j < Array::length(pexprs) { acc = acc + cov_ew_proj(Array::get(pexprs, j)); j = j + 1 }
+
+  // pat_binds_name: every Pat variant, with the bound name present and absent
+  let pats = Array::slice([PWild], 0, 0)
+  Array::push(pats, PWild)
+  Array::push(pats, PInt(1))
+  Array::push(pats, PString("s"))
+  Array::push(pats, PBool(true))
+  Array::push(pats, PBind("x"))
+  Array::push(pats, PBind("y"))
+  Array::push(pats, PCtor("C", Array::slice([PBind("x")], 0, 1)))
+  Array::push(pats, PCtor("C", Array::slice([PWild], 0, 1)))
+  Array::push(pats, PTuple(Array::slice([PBind("x")], 0, 1)))
+  Array::push(pats, PTuple(Array::slice([PWild], 0, 1)))
+  Array::push(pats, POr(PBind("x"), PWild))
+  Array::push(pats, POr(PWild, PBind("x")))
+  Array::push(pats, PStruct("S", Array::slice([("f", PBind("x"))], 0, 1)))
+  Array::push(pats, PStruct("S", Array::slice([("f", PWild)], 0, 1)))
+  let mut k = 0
+  while k < Array::length(pats) { acc = acc + cov_ew_pat(Array::get(pats, k)); k = k + 1 }
+  acc
+}

--- a/scripts/coverage/cov_syntax.vibe
+++ b/scripts/coverage/cov_syntax.vibe
@@ -1,0 +1,51 @@
+
+// #cov syntax-breadth driver: route the parser through arms the 728-file corpus
+// leaves dark — slice forms, postfix chains on unusual exprs, block-local
+// let rec / let mut / enum / struct (parse_impl_block), and the if/else-if /
+// is-pattern / match expression modes of parse_impl_dispatch. Parsing alone hits
+// these (load_and_parse runs the full parser); errors are swallowed so a partial
+// parse still lights the arms reached before any failure.
+let cov_sx_parse: (String) -> Int = (src) -> {
+  handle {
+    let stmts = load_and_parse(src)
+    Array::length(stmts)
+  } with Error {
+    Throw(_) => 0
+  }
+}
+
+export let cov_syntax_main: () -> Int = () -> {
+  let mut acc = 0
+  let progs = Array::slice([""], 0, 0)
+  // slice forms (parse_postfix index/slice arms)
+  Array::push(progs, "export let m: () -> Int = () -> { let a = [1, 2, 3]; let _ = a[:]; let _ = a[1:]; let _ = a[:2]; let _ = a[1:2]; 0 }")
+  // postfix chains: field, method, call, index in sequence
+  Array::push(progs, "export let m: () -> Int = () -> { let a = [[1]]; let _ = Array::length(a); let _ = a[0][0]; 0 }")
+  // call applied right after a parenthesised lambda
+  Array::push(progs, "export let m: () -> Int = () -> { let f = (x) -> { x + 1 }; f(2) }")
+  // block-local let rec
+  Array::push(progs, "export let m: () -> Int = () -> { let rec g: (Int) -> Int = (n) -> { if n <= 0 { 0 } else { g(n - 1) } }; g(3) }")
+  // block-local let mut + reassignment
+  Array::push(progs, "export let m: () -> Int = () -> { let mut s = 0; let mut i = 0; while i < 3 { s = s + i; i = i + 1 }; s }")
+  // block-local enum with zero-field + field variants, then match
+  Array::push(progs, "export let m: () -> Int = () -> { enum E { A; B(Int) }; let v = B(5); match v { A => 0, B(n) => n } }")
+  // block-local struct + field projection
+  Array::push(progs, "export let m: () -> Int = () -> { struct P { x: Int; y: Int }; let p = P::{ x: 1, y: 2 }; p.x + p.y }")
+  // if / else-if chain (parse_impl_dispatch mode 21)
+  Array::push(progs, "export let m: (Int) -> Int = (n) -> { if n == 0 { 10 } else if n == 1 { 11 } else if n == 2 { 12 } else { 13 } }")
+  // match with guard arm (parse_impl_dispatch mode 22, TIf guard)
+  Array::push(progs, "export let m: (Int) -> Int = (n) -> { match n { 0 => 100, x => if x > 0 { x } else { 0 - x } } }")
+  // nested match in else position
+  Array::push(progs, "export let m: (Int) -> Int = (n) -> { if n > 0 { 1 } else { match n { 0 => 0, _ => 0 - 1 } } }")
+  // loop with break value + for-in
+  Array::push(progs, "export let m: () -> Int = () -> { let mut t = 0; for x in [1, 2, 3] { t = t + x }; t }")
+  // tuple destructuring let + nested tuple pattern in match
+  Array::push(progs, "export let m: () -> Int = () -> { let (a, b) = (1, 2); match (a, b) { (0, _) => 0, (x, y) => x + y } }")
+  // trait + impl block
+  Array::push(progs, "trait Show { show: (Self) -> Int }\nstruct W { v: Int }\nimpl Show for W { show: (self) -> Int = self.v }\nexport let m: () -> Int = () -> { Show::show(W::{ v: 7 }) }")
+  // string interpolation postfix
+  Array::push(progs, "export let m: () -> String = () -> { let n = 3; \"n=${n}\" }")
+  let mut i = 0
+  while i < Array::length(progs) { acc = acc + cov_sx_parse(Array::get(progs, i)); i = i + 1 }
+  acc
+}

--- a/scripts/coverage_selfhost_drivers.sh
+++ b/scripts/coverage_selfhost_drivers.sh
@@ -158,6 +158,8 @@ run_driver cov_traitenv_main   scripts/coverage/cov_traitenv.vibe   traitenv    
 run_driver cov_link_main       scripts/coverage/cov_link.vibe       link        # compile_wasi_module_linked_impl arms
 run_driver cov_parse_main      scripts/coverage/cov_parse.vibe      parse       # parser arms (impl/postfix/pattern)
 run_driver cov_helpers_main    scripts/coverage/cov_helpers.vibe    helpers     # unique pure helpers: valtype/int/io-dispatch/double/async-int
+run_driver cov_syntax_main     scripts/coverage/cov_syntax.vibe     syntax      # parser arms: slices/block-local let-rec-mut/enum-struct/impl/match-modes
+run_driver cov_exprwalk_main   scripts/coverage/cov_exprwalk.vibe   exprwalk    # Expr/Pat walkers: is_mut_captured_in/rewrite_import_alias_expr/wrap_placeholder_arg/pat_binds_name
 rm -f _build/vibe_selfhost_* 2>/dev/null || true
 
 now=$(python3 -c "import json;print(sum(json.load(open('$ACC'))['br']))")


### PR DESCRIPTION
## Summary

Follow-up to #614. Two new direct-call coverage drivers raise selfhost-compiler **branch coverage from 80.76% to 81.25%** (5439/6694, +83 over the 80% floor). Tooling only — no compiler or seed change.

## Drivers

- **`cov_exprwalk.vibe`** (+25): constructs one `Expr`/`Pat` of every variant and drives the unique recursive walkers directly — `is_mut_captured_in` (the `||`-short-circuit else side + `let`-shadowing arms), `rewrite_import_alias_expr`, `wrap_placeholder_arg`, `expr_projects_or_matches`, and `pat_binds_name` over every `Pat` variant. `wrap_placeholder_arg` and `pat_binds_name` reach **0 dark**.
- **`cov_syntax.vibe`** (+8): parses the slice forms (`a[:]`/`a[1:]`/`a[:2]`), block-local `let rec`/`let mut`/enum/struct, and if-else-if/match-mode arms the example corpus leaves dark (`parse_impl_block`, `parse_impl_dispatch`, `parse_postfix`).

Both are wired into `coverage_selfhost_drivers.sh` and documented in `docs/coverage.md`.

## Note recorded in docs

- Whole-program compiles add ~+0–1 (the 728-file corpus saturates the full pipeline); only direct calls into specific uncovered helpers/walkers move the metric.
- Duplicate-named helpers (`strip_trailing_cr` ×3, `parse_struct_fields_rest`) look dark but are unreachable dead copies inflating the denominator — not driveable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017puwmk6aLwNJRrKySkDRnS)_