### PR TITLE
feat(coverage): fs-cache + parse_stmt drivers to 81.45%

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -192,8 +192,8 @@ in-scope）を直接叩ける。型/trait/env に加え以下も edge-case 入�
 
 #### 80% 達成（no-DCE merged source + direct-call drivers）
 
-**分岐 5439/6694 (81.25%)**・関数 1037/1176 (88.18%) に到達（下限ガード 80% =
-5356 に対し +83 分岐のマージン）。
+**分岐 5452/6694 (81.45%)**・関数 1037/1176 (88.18%) に到達（下限ガード 80% =
+5356 に対し +96 分岐のマージン）。
 74% で頭打ちだった主因（コンパイラ自身の unit test 120/148 が builtins⇄checker
 の循環 re-export で FS-compile 不能）を、**循環 re-export を直さずに**回避した。
 
@@ -249,6 +249,12 @@ corpus acc.json に (fn_name, local_branch_index) キーで union する。分�
     (`pat_binds_name`/`wrap_placeholder_arg` は 0 dark まで到達) (+25)。注:
     whole-program compile を増やしても corpus が飽和済みで +0〜+1（実測で確認）—
     伸びるのは「特定 helper/walker を直接呼ぶ」driver に限る。
+  - `cov_fscache.vibe`: `load_source_if_cached_file_spec_matches`（unique な 8-arm
+    Fs validator: missing / stat-match / stat-miss+fp-match / +fp-miss / +fp-empty /
+    no-stat+fp-{match,miss,empty}）を、実 fixture `_build/covfs/f.vibe` の本物の
+    `Fs::stat_token` / `compact_string_fingerprint` 値と、わざと外した値で全 arm 踏破
+    （0 dark 到達）(+11)。注: その Bool twin `matches_cached_file_spec` は merged
+    source に重複定義があり 10 dark は dead copy（駆動不能）。
 - **manifest-header cache** (`coverage_selfhost_manifestcache.sh`): 非 special な
   manifest project を cold/warm/部分 invalidation で FS-compile し、
   `matches_cached_file_spec`/`try_collect_manifest_source_groups_fs`/

--- a/scripts/coverage/cov_fscache.vibe
+++ b/scripts/coverage/cov_fscache.vibe
@@ -1,0 +1,36 @@
+
+// #cov fs-cache driver: load_source_if_cached_file_spec_matches(path, stat_token,
+// fingerprint) is a unique 8-path Fs validator — missing / stat-match /
+// stat-miss+fp-match / stat-miss+fp-miss / stat-miss+fp-empty / no-stat+fp-match /
+// no-stat+fp-miss / no-stat+fp-empty. The corpus only hits the happy paths. Read a
+// real fixture's actual stat_token + fingerprint, then feed matching and
+// deliberately-wrong values to route through every arm. Needs _build/covfs/f.vibe.
+let cov_fc_one: (String, String, String) -> Int = (p, st, fp) -> {
+  handle {
+    match load_source_if_cached_file_spec_matches(p, st, fp) {
+      Some(_) => 1,
+      None => 0
+    }
+  } with Error {
+    Throw(_) => 0
+  }
+}
+
+export let cov_fscache_main: () -> Int = () -> {
+  let mut acc = 0
+  let path = "_build/covfs/f.vibe"
+  // missing file
+  acc = acc + cov_fc_one("_build/covfs/nope.vibe", "x", "y")
+  let real_stat = handle { __to_string(Fs::stat_token(path)) } with Error { Throw(_) => "" }
+  let real_fp = handle { compact_string_fingerprint(Fs::read_file(path)) } with Error { Throw(_) => "" }
+  // has stat-token: match / mismatch+fp-match / mismatch+fp-miss / mismatch+fp-empty
+  acc = acc + cov_fc_one(path, real_stat, "")
+  acc = acc + cov_fc_one(path, "wrong-stat-token", real_fp)
+  acc = acc + cov_fc_one(path, "wrong-stat-token", "wrong-fp")
+  acc = acc + cov_fc_one(path, "wrong-stat-token", "")
+  // no stat-token: fp-match / fp-miss / fp-empty
+  acc = acc + cov_fc_one(path, "", real_fp)
+  acc = acc + cov_fc_one(path, "", "wrong-fp")
+  acc = acc + cov_fc_one(path, "", "")
+  acc
+}

--- a/scripts/coverage/cov_syntax.vibe
+++ b/scripts/coverage/cov_syntax.vibe
@@ -45,6 +45,20 @@ export let cov_syntax_main: () -> Int = () -> {
   Array::push(progs, "trait Show { show: (Self) -> Int }\nstruct W { v: Int }\nimpl Show for W { show: (self) -> Int = self.v }\nexport let m: () -> Int = () -> { Show::show(W::{ v: 7 }) }")
   // string interpolation postfix
   Array::push(progs, "export let m: () -> String = () -> { let n = 3; \"n=${n}\" }")
+  // top-level statement-kind dispatch (parse_stmt): each only needs to START with
+  // the keyword to cover its dispatch arm, even if the sub-parser then errors.
+  Array::push(progs, "suberror MyErr { Bad; Worse(Int) }\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "type Alias = Int\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "type Pair[a] = (a, a)\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "test \"t\" { let _ = 1 + 1 }\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "bench \"b\" { let _ = 1 + 1 }\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "extern let host_fn: (Int) -> Int\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "effect Log { emit: (String) -> Unit }\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "module Inner { export let k: () -> Int = () -> { 1 } }\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "export module Pub { export let k: () -> Int = () -> { 1 } }\nexport let m: () -> Int = () -> { 0 }")
+  Array::push(progs, "use legacy\nexport let m: () -> Int = () -> { 0 }")  // 'use' is removed -> throw arm
+  // compound assignment ops (TPlusEq/TMinusEq/TStarEq/TSlashEq)
+  Array::push(progs, "export let m: () -> Int = () -> { let mut x = 8; x += 1; x -= 2; x *= 3; x /= 2; x }")
   let mut i = 0
   while i < Array::length(progs) { acc = acc + cov_sx_parse(Array::get(progs, i)); i = i + 1 }
   acc

--- a/scripts/coverage_selfhost_drivers.sh
+++ b/scripts/coverage_selfhost_drivers.sh
@@ -146,6 +146,9 @@ mkdir -p _build/covproj
 printf 'export let a_val: () -> Int = () -> { 41 }\n' > _build/covproj/a.vibe
 printf 'import ./a.vibe { a_val }\nexport let b_val: () -> Int = () -> { a_val() }\n' > _build/covproj/b.vibe
 printf 'export let c_val: () -> Int = () -> { 5 }\n' > _build/covproj/c.vibe
+# covfs/f.vibe is the real fixture cov_fscache reads its stat-token/fingerprint from.
+mkdir -p _build/covfs
+printf 'export let f: () -> Int = () -> { 123 }\n' > _build/covfs/f.vibe
 
 base=$(python3 -c "import json;print(sum(json.load(open('$ACC'))['br']))")
 run_driver cov_async_main      scripts/coverage/cov_async.vibe      async       # inlined async/stream builtins
@@ -160,6 +163,7 @@ run_driver cov_parse_main      scripts/coverage/cov_parse.vibe      parse       
 run_driver cov_helpers_main    scripts/coverage/cov_helpers.vibe    helpers     # unique pure helpers: valtype/int/io-dispatch/double/async-int
 run_driver cov_syntax_main     scripts/coverage/cov_syntax.vibe     syntax      # parser arms: slices/block-local let-rec-mut/enum-struct/impl/match-modes
 run_driver cov_exprwalk_main   scripts/coverage/cov_exprwalk.vibe   exprwalk    # Expr/Pat walkers: is_mut_captured_in/rewrite_import_alias_expr/wrap_placeholder_arg/pat_binds_name
+run_driver cov_fscache_main    scripts/coverage/cov_fscache.vibe    fscache     # Fs validator load_source_if_cached_file_spec_matches: every stat-token/fingerprint arm
 rm -f _build/vibe_selfhost_* 2>/dev/null || true
 
 now=$(python3 -c "import json;print(sum(json.load(open('$ACC'))['br']))")


### PR DESCRIPTION
## Summary

Follow-up to #615. Two more direct-call drivers raise selfhost-compiler **branch coverage 81.25% → 81.45%** (5452/6694, +96 over the 80% floor). Tooling only — no compiler or seed change.

## Drivers

- **`cov_fscache.vibe`** (+11): drives `load_source_if_cached_file_spec_matches` across all 8 stat-token/fingerprint arms (missing / stat-match / stat-miss+fp-{match,miss,empty} / no-stat+fp-{match,miss,empty}) by reading a real fixture's actual `Fs::stat_token` + `compact_string_fingerprint` and feeding matching and deliberately-wrong values. Reaches **0 dark**.
- **`cov_syntax.vibe`** (+2): adds top-level statement-kind dispatch (suberror / type-alias / test / bench / extern / effect / module / export-module / `use`-throw + compound-assign ops) so `parse_stmt`'s keyword arms light up.

Both wired into `coverage_selfhost_drivers.sh` (with the `_build/covfs/f.vibe` fixture) and documented.

## Dead-ends recorded in docs

- `types_equal`'s 7 residual are deep `CtFn`-label / `CtForAll`-bound arms (whole-Type pairs miss them, +0).
- `matches_cached_file_spec`'s 10 dark are a duplicate dead copy (same pattern as `strip_trailing_cr`) — not driveable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017puwmk6aLwNJRrKySkDRnS)_