### PR TITLE
lsp: incremental workspace symbol + call-hierarchy index (+ macro-graph export)

### DIFF
--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -29,6 +29,9 @@ on:
       - "js/vibe/dap_server.js"
       - "scripts/test_vibe_break_args.sh"
       - "js/vibe/lsp_server.js"
+      - "js/vibe/symbol_index.js"
+      - "scripts/test_symbol_index.js"
+      - "scripts/test_vibe_lsp_workspace.js"
       - "bootstrap/selfhost/seed/**"
       - ".github/workflows/cli-install.yml"
   pull_request:
@@ -54,6 +57,9 @@ on:
       - "js/vibe/dap_server.js"
       - "scripts/test_vibe_break_args.sh"
       - "js/vibe/lsp_server.js"
+      - "js/vibe/symbol_index.js"
+      - "scripts/test_symbol_index.js"
+      - "scripts/test_vibe_lsp_workspace.js"
       - ".github/workflows/cli-install.yml"
   workflow_dispatch:
 
@@ -155,3 +161,9 @@ jobs:
 
       - name: DAP adapter pure-logic unit test
         run: node scripts/test_vibe_dap.js
+
+      - name: Workspace symbol / call-graph index unit test
+        run: node scripts/test_symbol_index.js
+
+      - name: LSP workspace/symbol + callHierarchy e2e test
+        run: node scripts/test_vibe_lsp_workspace.js

--- a/js/vibe/lsp_server.js
+++ b/js/vibe/lsp_server.js
@@ -67,9 +67,84 @@ function notify(method, params) {
 const docs = new Map(); // uri -> { text, version }
 const pending = new Map(); // uri -> timeout (debounce)
 
+// ---- workspace symbol / call-hierarchy index ---------------------------
+// In-process incremental index (js/vibe/symbol_index.js) backing workspace/
+// symbol and callHierarchy. Avoids a `vibe` subprocess per file (~0.5s) for
+// these workspace-wide ops; a cold scan is sub-second, edits re-index in ms.
+const { SymbolIndex } = require("./symbol_index.js");
+const wsIndex = new SymbolIndex();
+let wsRoot = null; // absolute workspace root path (from initialize)
+let wsScanned = false;
+
+function pathToUri(p) {
+  return "file://" + p.split("/").map((seg, i) => (i === 0 ? seg : encodeURIComponent(seg))).join("/");
+}
+
+// Walk wsRoot once for *.vibe and index them; cheap and lazy (first workspace/
+// symbol or callHierarchy request triggers it). Open documents override on-disk
+// content via their in-memory text on each edit.
+function ensureWorkspaceScanned() {
+  if (wsScanned || !wsRoot) return;
+  wsScanned = true;
+  const stack = [wsRoot];
+  while (stack.length) {
+    const dir = stack.pop();
+    let ents;
+    try { ents = fs.readdirSync(dir, { withFileTypes: true }); } catch { continue; }
+    for (const e of ents) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) { if (e.name !== "node_modules" && e.name !== ".git" && e.name !== "target") stack.push(p); }
+      else if (e.isFile() && p.endsWith(".vibe")) {
+        try { wsIndex.update(p, fs.readFileSync(p, "utf8")); } catch {}
+      }
+    }
+  }
+  // Open docs reflect unsaved edits — layer them on top.
+  for (const [uri, doc] of docs) {
+    try { wsIndex.update(uriToPath(uri), doc.text); } catch {}
+  }
+}
+
+// Cache of file text for offset->position conversion of index results (closed
+// files aren't in `docs`). Keyed by path; invalidated by mtime.
+const fileTextCache = new Map(); // path -> { mtimeMs, text }
+function fileText(p) {
+  const doc = docs.get(pathToUri(p));
+  if (doc) return doc.text;
+  try {
+    const st = fs.statSync(p);
+    const c = fileTextCache.get(p);
+    if (c && c.mtimeMs === st.mtimeMs) return c.text;
+    const text = fs.readFileSync(p, "utf8");
+    fileTextCache.set(p, { mtimeMs: st.mtimeMs, text });
+    return text;
+  } catch { return null; }
+}
+
+// Build an LSP Range from a file path + [startOff, endOff] char offsets.
+function rangeFromOffsets(p, startOff, endOff) {
+  const text = fileText(p) || "";
+  return { start: offsetToPosition(text, startOff), end: offsetToPosition(text, endOff) };
+}
+
+// A CallHierarchyItem for a symbol name, located at its workspace definition.
+function callHierarchyItem(name) {
+  const defs = wsIndex.definitions(name);
+  if (!defs.length) return null;
+  const { path: p, symbol } = defs[0];
+  const range = rangeFromOffsets(p, symbol.bodyStart >= 0 ? symbol.declStart : symbol.nameStart, symbol.bodyEnd);
+  const selectionRange = rangeFromOffsets(p, symbol.nameStart, symbol.nameEnd);
+  return { name, kind: symbol.kind, uri: pathToUri(p), range, selectionRange, data: { name } };
+}
+
 function handle(msg) {
   switch (msg.method) {
-    case "initialize":
+    case "initialize": {
+      // Capture the workspace root for the symbol/call-hierarchy index.
+      const p = msg.params || {};
+      if (p.workspaceFolders && p.workspaceFolders[0]) wsRoot = uriToPath(p.workspaceFolders[0].uri);
+      else if (p.rootUri) wsRoot = uriToPath(p.rootUri);
+      else if (p.rootPath) wsRoot = p.rootPath;
       reply(msg.id, {
         capabilities: {
           textDocumentSync: 1, // full
@@ -81,10 +156,58 @@ function handle(msg) {
           documentHighlightProvider: true,
           completionProvider: { triggerCharacters: ["."] },
           signatureHelpProvider: { triggerCharacters: ["(", ","] },
+          workspaceSymbolProvider: true,
+          callHierarchyProvider: true,
         },
         serverInfo: { name: "vibe-lsp", version: "0.1.0" },
       });
       break;
+    }
+    case "workspace/symbol": {
+      ensureWorkspaceScanned();
+      const query = (msg.params && msg.params.query) || "";
+      const results = wsIndex.workspaceSymbols(query, 200).map((s) => ({
+        name: s.name,
+        kind: s.kind,
+        location: { uri: pathToUri(s.path), range: rangeFromOffsets(s.path, s.nameStart, s.nameEnd) },
+      }));
+      reply(msg.id, results);
+      break;
+    }
+    case "textDocument/prepareCallHierarchy": {
+      ensureWorkspaceScanned();
+      const doc = docs.get(msg.params.textDocument.uri);
+      if (!doc) { reply(msg.id, null); break; }
+      const word = wordAt(doc.text, msg.params.position);
+      const item = word ? callHierarchyItem(word) : null;
+      reply(msg.id, item ? [item] : null);
+      break;
+    }
+    case "callHierarchy/incomingCalls": {
+      ensureWorkspaceScanned();
+      const name = msg.params.item && msg.params.item.data && msg.params.item.data.name;
+      if (!name) { reply(msg.id, []); break; }
+      const out = [];
+      for (const c of wsIndex.incomingCalls(name)) {
+        const from = callHierarchyItem(c.caller);
+        if (from) out.push({ from, fromRanges: [from.selectionRange] });
+      }
+      reply(msg.id, out);
+      break;
+    }
+    case "callHierarchy/outgoingCalls": {
+      ensureWorkspaceScanned();
+      const name = msg.params.item && msg.params.item.data && msg.params.item.data.name;
+      if (!name) { reply(msg.id, []); break; }
+      const out = [];
+      for (const c of wsIndex.outgoingCalls(name)) {
+        if (!c.defined) continue; // only edges to workspace-defined symbols
+        const to = callHierarchyItem(c.callee);
+        if (to) out.push({ to, fromRanges: [to.selectionRange] });
+      }
+      reply(msg.id, out);
+      break;
+    }
     case "textDocument/rename": {
       const uri = msg.params.textDocument.uri;
       const doc = docs.get(uri);
@@ -209,6 +332,7 @@ function handle(msg) {
     case "textDocument/didOpen": {
       const { uri, text } = msg.params.textDocument;
       docs.set(uri, { text, version: msg.params.textDocument.version });
+      if (wsScanned) wsIndex.update(uriToPath(uri), text); // keep index fresh
       scheduleCheck(uri);
       break;
     }
@@ -217,7 +341,9 @@ function handle(msg) {
       const changes = msg.params.contentChanges;
       if (changes && changes.length) {
         // full sync: last change holds the whole document
-        docs.set(uri, { text: changes[changes.length - 1].text, version: msg.params.textDocument.version });
+        const text = changes[changes.length - 1].text;
+        docs.set(uri, { text, version: msg.params.textDocument.version });
+        if (wsScanned) wsIndex.update(uriToPath(uri), text); // incremental re-index
       }
       scheduleCheck(uri);
       break;

--- a/js/vibe/lsp_server.js
+++ b/js/vibe/lsp_server.js
@@ -137,6 +137,12 @@ function callHierarchyItem(name) {
   return { name, kind: symbol.kind, uri: pathToUri(p), range, selectionRange, data: { name } };
 }
 
+// Convert index call-sites ({ path, off, end }) to LSP Ranges at the call
+// expressions — the `fromRanges` for incoming/outgoing call hierarchy.
+function callSiteRanges(sites) {
+  return (sites || []).map((s) => rangeFromOffsets(s.path, s.off, s.end));
+}
+
 function handle(msg) {
   switch (msg.method) {
     case "initialize": {
@@ -190,7 +196,8 @@ function handle(msg) {
       const out = [];
       for (const c of wsIndex.incomingCalls(name)) {
         const from = callHierarchyItem(c.caller);
-        if (from) out.push({ from, fromRanges: [from.selectionRange] });
+        // fromRanges: where the call to `name` appears inside the caller's body.
+        if (from) out.push({ from, fromRanges: callSiteRanges(c.sites) });
       }
       reply(msg.id, out);
       break;
@@ -203,7 +210,8 @@ function handle(msg) {
       for (const c of wsIndex.outgoingCalls(name)) {
         if (!c.defined) continue; // only edges to workspace-defined symbols
         const to = callHierarchyItem(c.callee);
-        if (to) out.push({ to, fromRanges: [to.selectionRange] });
+        // fromRanges: where `name` invokes the callee, inside `name`'s body.
+        if (to) out.push({ to, fromRanges: callSiteRanges(c.sites) });
       }
       reply(msg.id, out);
       break;

--- a/js/vibe/symbol_index.js
+++ b/js/vibe/symbol_index.js
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+// Incremental workspace symbol + call-graph index for vibe.
+//
+// Motivation (LSP perf): the LSP server answers per-file queries by spawning a
+// `vibe` subprocess (each loads the wasm compiler, ~0.5s). That is fine for a
+// single hover but catastrophic for WORKSPACE-WIDE operations — `workspace/
+// symbol` and `callHierarchy` would need one spawn per file (~420s for this
+// repo's 754 files). This module builds an in-process, content-hash-keyed,
+// INCREMENTAL index directly from source text (no subprocess), so a cold
+// workspace scan is sub-second and a single-file edit re-indexes in microseconds.
+//
+// It is also the foundation for macro-level visualization (à la mizchi/
+// sprawlens): `graph()` exports nodes (files / modules / symbols, sized by source
+// span) and edges (calls / imports) as plain JSON a renderer can lay out.
+//
+// Extraction is a lightweight, comment/string-aware scan — NOT a full parse. It
+// is AST-approximate by design (fast, dependency-free); the LSP can still refine
+// a focused file with the AST-accurate `vibe symbols` when exactness matters.
+"use strict";
+
+// ---------------------------------------------------------------------------
+// LSP SymbolKind numbers we emit.
+// ---------------------------------------------------------------------------
+const KIND = {
+  Function: 12,
+  Variable: 13,
+  Struct: 23,
+  Enum: 10,
+  Interface: 11, // trait
+  Module: 2,
+  Class: 5, // type alias
+};
+
+// vibe keywords that can appear immediately before `(` but are NOT calls.
+const NON_CALL = new Set([
+  "if", "else", "match", "while", "for", "return", "with", "handle", "in", "as",
+  "let", "mut", "export", "import", "enum", "struct", "trait", "module", "type",
+  "test", "bench", "true", "false", "throw", "and", "or", "not", "fn",
+]);
+
+// FNV-1a 32-bit content hash (fast, stable across runs) for incremental skip.
+function hashText(s) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i) & 0xff;
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h >>> 0;
+}
+
+// Produce a "code mask": a copy of `text` where every byte that is inside a line
+// comment (`// ...`) or a string literal ("...") is replaced by a space, but all
+// offsets/newlines are preserved. Scanning the mask for declarations and calls
+// then never false-matches words in comments/strings. vibe has no block comments.
+function codeMask(text) {
+  const n = text.length;
+  const out = Buffer.alloc(n);
+  let i = 0;
+  let state = 0; // 0 = code, 1 = line comment, 2 = string
+  while (i < n) {
+    const c = text.charCodeAt(i);
+    const ch = text[i];
+    if (state === 0) {
+      if (ch === "/" && text[i + 1] === "/") {
+        out[i] = 32; out[i + 1] = 32; i += 2; state = 1; continue;
+      }
+      if (ch === '"') { out[i] = 32; i++; state = 2; continue; }
+      out[i] = c < 128 ? c : 32;
+      i++;
+    } else if (state === 1) {
+      if (ch === "\n") { out[i] = 10; i++; state = 0; continue; }
+      out[i] = 32; i++;
+    } else {
+      // inside string
+      if (ch === "\\") { out[i] = 32; if (i + 1 < n) out[i + 1] = 32; i += 2; continue; }
+      if (ch === '"') { out[i] = 32; i++; state = 0; continue; }
+      out[i] = ch === "\n" ? 10 : 32;
+      i++;
+    }
+  }
+  return out.toString("latin1");
+}
+
+// Match-brace from the open-brace at `open` to its closing `}` in `mask` (already
+// comment/string-free). Returns the index of the matching `}` or text length.
+function matchBrace(mask, open) {
+  let depth = 0;
+  for (let i = open; i < mask.length; i++) {
+    const c = mask[i];
+    if (c === "{") depth++;
+    else if (c === "}") { depth--; if (depth === 0) return i; }
+  }
+  return mask.length;
+}
+
+// Top-level (and one level of `module { ... }`-nested) declarations.
+// Recognizes: let / struct / enum / trait / module / type, with optional
+// `export` and (for let) `mut`. For a let bound to a lambda we record Function,
+// else Variable, and capture the body span (`{ ... }`) for call attribution.
+// NOTE: this matches at ANY brace depth; the caller filters to depth 0 (top
+// level) and depth 1 inside a `module` body, so locals inside function bodies
+// (`let x = ...` in a lambda) are not mistaken for workspace symbols.
+const DECL_RE =
+  /(^|\n)[ \t]*(export[ \t]+)?(let|struct|enum|trait|module|type)[ \t]+(mut[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)/g;
+
+function declKind(keyword, mask, nameEnd) {
+  switch (keyword) {
+    case "struct": return KIND.Struct;
+    case "enum": return KIND.Enum;
+    case "trait": return KIND.Interface;
+    case "module": return KIND.Module;
+    case "type": return KIND.Class;
+    case "let": {
+      // Function iff the RHS is a lambda: `= ( ... ) ->` (optionally a leading
+      // `[T]` type-param list). Scan forward from the name over `=` to a `(`.
+      let i = nameEnd;
+      const n = mask.length;
+      while (i < n && mask[i] !== "=" && mask[i] !== "\n") i++;
+      if (mask[i] !== "=") return KIND.Variable;
+      i++;
+      while (i < n && /\s/.test(mask[i])) i++;
+      if (mask[i] === "[") { let d = 0; while (i < n) { if (mask[i] === "[") d++; else if (mask[i] === "]") { d--; if (!d) { i++; break; } } i++; } while (i < n && /\s/.test(mask[i])) i++; }
+      return mask[i] === "(" ? KIND.Function : KIND.Variable;
+    }
+    default: return KIND.Variable;
+  }
+}
+
+// Extract symbols, imports, and call edges from one file's source text.
+function extractFile(text) {
+  const mask = codeMask(text);
+
+  // --- candidate declarations (any depth) with body spans ---
+  const cands = [];
+  DECL_RE.lastIndex = 0;
+  let m;
+  while ((m = DECL_RE.exec(mask)) !== null) {
+    const lead = m[1] ? m[1].length : 0;
+    const declStart = m.index + lead;
+    const keyword = m[3];
+    const name = m[5];
+    const nameStart = m.index + m[0].length - name.length;
+    const nameEnd = nameStart + name.length;
+    const kind = declKind(keyword, mask, nameEnd);
+    // Body span: the first `{` on/after the name, brace-matched. struct/enum/
+    // trait/module aggregates and lambda function bodies all use `{ ... }`. A
+    // value let (`let x = 5`) has no body brace before the next decl/EOF.
+    const braceAt = mask.indexOf("{", nameEnd);
+    let bodyStart = -1, bodyEnd = nameEnd;
+    if (braceAt >= 0) {
+      // For a value let with no lambda, the next `{` may belong to a LATER decl;
+      // only claim it as a body when nothing structural separates them. We accept
+      // it if no newline-starting decl keyword appears between nameEnd and braceAt.
+      const between = mask.slice(nameEnd, braceAt);
+      if (kind === KIND.Function || keyword !== "let" || !/\n[ \t]*(export[ \t]+)?(let|struct|enum|trait|module|type)[ \t]/.test(between)) {
+        bodyStart = braceAt;
+        bodyEnd = matchBrace(mask, braceAt);
+      }
+    }
+    cands.push({ name, kind, keyword, nameStart, nameEnd, declStart, bodyStart, bodyEnd, depth: 0 });
+  }
+
+  // --- brace depth at each candidate's declStart (single pass) ---
+  {
+    let ci = 0, depth = 0;
+    for (let i = 0; i < mask.length && ci < cands.length; i++) {
+      while (ci < cands.length && cands[ci].declStart === i) { cands[ci].depth = depth; ci++; }
+      const c = mask[i];
+      if (c === "{") depth++;
+      else if (c === "}") depth--;
+    }
+  }
+
+  // --- keep top-level (depth 0) + one level of module-nested (depth 1 inside a
+  //     top-level `module` body). Locals inside function/struct bodies (depth>=1,
+  //     not in a module) are dropped — they are not workspace symbols. ---
+  const topLevel = cands.filter((c) => c.depth === 0);
+  const moduleBodies = topLevel.filter((c) => c.keyword === "module" && c.bodyStart >= 0);
+  const symbols = [];
+  for (const c of topLevel) symbols.push({ name: c.name, kind: c.kind, keyword: c.keyword, container: null, nameStart: c.nameStart, nameEnd: c.nameEnd, declStart: c.declStart, bodyStart: c.bodyStart, bodyEnd: c.bodyEnd });
+  for (const c of cands) {
+    if (c.depth !== 1) continue;
+    const mod = moduleBodies.find((mb) => mb.bodyStart < c.declStart && c.declStart < mb.bodyEnd);
+    if (mod) symbols.push({ name: c.name, kind: c.kind, keyword: c.keyword, container: mod.name, nameStart: c.nameStart, nameEnd: c.nameEnd, declStart: c.declStart, bodyStart: c.bodyStart, bodyEnd: c.bodyEnd });
+  }
+
+  const imports = [];
+  // --- imports: `import <path> { A, B, ... }` (path may be ./x.vibe or ../m) ---
+  const IMP_RE = /(^|\n)[ \t]*(export[ \t]+)?import[ \t]+([^\n{]+?)[ \t]*\{([^}]*)\}/g;
+  let im;
+  while ((im = IMP_RE.exec(mask)) !== null) {
+    const rawPath = im[3].replace(/\s+/g, "");
+    const names = im[4].split(",").map((s) => s.trim()).filter(Boolean);
+    imports.push({ path: rawPath, names, start: im.index + (im[1] ? im[1].length : 0) });
+  }
+
+  // --- call edges: identifier (optionally Qual::method) immediately before `(`,
+  //     attributed to the innermost enclosing symbol body. ---
+  // Sort symbols with a body by start for a quick enclosing lookup.
+  const bodied = symbols.filter((s) => s.bodyStart >= 0).sort((a, b) => a.bodyStart - b.bodyStart);
+  const enclosing = (off) => {
+    // innermost body covering off
+    let best = null;
+    for (const s of bodied) {
+      if (s.bodyStart <= off && off <= s.bodyEnd) {
+        if (!best || s.bodyStart > best.bodyStart) best = s;
+      }
+    }
+    return best ? best.name : null;
+  };
+
+  const calls = [];
+  const CALL_RE = /([A-Za-z_][A-Za-z0-9_]*)(?:::([A-Za-z_][A-Za-z0-9_]*))?[ \t]*\(/g;
+  let cm;
+  while ((cm = CALL_RE.exec(mask)) !== null) {
+    const qualifier = cm[2] ? cm[1] : null;
+    const callee = cm[2] || cm[1];
+    if (NON_CALL.has(callee) || (!qualifier && NON_CALL.has(cm[1]))) continue;
+    // The token must not itself be a declaration name (e.g. `let f = (` — the
+    // `(` there is the lambda param list, not a call of `f`). Skip if the char
+    // run immediately before is `= ` following a decl — cheap heuristic: if the
+    // identifier start is a decl nameStart, skip.
+    const off = cm.index;
+    calls.push({ caller: enclosing(off), callee, qualifier, off });
+  }
+
+  return { symbols, imports, calls };
+}
+
+// ---------------------------------------------------------------------------
+// The incremental index.
+// ---------------------------------------------------------------------------
+class SymbolIndex {
+  constructor() {
+    // path -> { hash, symbols, imports, calls }
+    this.files = new Map();
+    this._stats = { extracts: 0, skips: 0 };
+  }
+
+  // Add or update a file. Returns true if the index changed (content differed),
+  // false if the file was unchanged (incremental skip — the hot path on edits
+  // that don't alter a given file, and on re-scans).
+  update(filePath, text) {
+    const h = hashText(text);
+    const prev = this.files.get(filePath);
+    if (prev && prev.hash === h) { this._stats.skips++; return false; }
+    const ex = extractFile(text);
+    this.files.set(filePath, { hash: h, symbols: ex.symbols, imports: ex.imports, calls: ex.calls });
+    this._stats.extracts++;
+    return true;
+  }
+
+  remove(filePath) { return this.files.delete(filePath); }
+
+  get fileCount() { return this.files.size; }
+  get symbolCount() { let n = 0; for (const f of this.files.values()) n += f.symbols.length; return n; }
+  stats() { return Object.assign({}, this._stats); }
+
+  // workspace/symbol: fuzzy subsequence match on the symbol name, ranked by
+  // match quality (prefix > word-boundary > contiguous > scattered, shorter
+  // names first). Empty query returns all (capped by `limit`).
+  workspaceSymbols(query, limit = 200) {
+    const q = (query || "").toLowerCase();
+    const out = [];
+    for (const [path, f] of this.files) {
+      for (const s of f.symbols) {
+        const score = q ? fuzzyScore(s.name.toLowerCase(), q) : 0;
+        if (q && score < 0) continue;
+        out.push({ name: s.name, kind: s.kind, path, nameStart: s.nameStart, nameEnd: s.nameEnd, score });
+      }
+    }
+    out.sort((a, b) => a.score - b.score || a.name.length - b.name.length || (a.name < b.name ? -1 : 1));
+    return out.slice(0, limit);
+  }
+
+  // Resolve a name to its defining symbol(s) across the workspace.
+  definitions(name) {
+    const defs = [];
+    for (const [path, f] of this.files) {
+      for (const s of f.symbols) if (s.name === name) defs.push({ path, symbol: s });
+    }
+    return defs;
+  }
+
+  // callHierarchy: outgoing calls FROM `name` (callees it invokes in its body).
+  outgoingCalls(name) {
+    const seen = new Map(); // callee -> count
+    for (const f of this.files.values()) {
+      for (const c of f.calls) {
+        if (c.caller === name) seen.set(c.callee, (seen.get(c.callee) || 0) + 1);
+      }
+    }
+    return [...seen.entries()].map(([callee, count]) => ({ callee, count, defined: this.definitions(callee).length > 0 }))
+      .sort((a, b) => b.count - a.count || (a.callee < b.callee ? -1 : 1));
+  }
+
+  // callHierarchy: incoming calls TO `name` (callers that invoke it).
+  incomingCalls(name) {
+    const seen = new Map(); // caller -> {count, path}
+    for (const [path, f] of this.files) {
+      for (const c of f.calls) {
+        if (c.callee === name && c.caller) {
+          const key = c.caller;
+          const e = seen.get(key) || { caller: c.caller, count: 0, path };
+          e.count++; seen.set(key, e);
+        }
+      }
+    }
+    return [...seen.values()].sort((a, b) => b.count - a.count || (a.caller < b.caller ? -1 : 1));
+  }
+
+  // Macro-visualization export: a directed graph of symbols (nodes sized by their
+  // source span) and call edges (resolved to defined symbols), grouped by file
+  // and module (top directory under the workspace root). Sprawlens-shaped: nodes
+  // carry {id, name, kind, file, module, size}; edges carry {from, to, weight}.
+  graph(opts = {}) {
+    const root = opts.root || "";
+    const rel = (p) => (root && p.startsWith(root) ? p.slice(root.length).replace(/^\/+/, "") : p);
+    const moduleOf = (p) => { const r = rel(p); const i = r.indexOf("/"); return i < 0 ? r : r.slice(0, r.indexOf("/", i + 1) > 0 ? r.indexOf("/", i + 1) : i); };
+
+    const nodes = [];
+    const nodeId = new Map(); // name -> id (first definition wins; calls resolve by name)
+    for (const [path, f] of this.files) {
+      const file = rel(path);
+      for (const s of f.symbols) {
+        const id = `${file}#${s.name}`;
+        nodes.push({
+          id, name: s.name, kind: s.kind, file, module: moduleOf(path),
+          size: s.bodyStart >= 0 ? Math.max(1, s.bodyEnd - s.bodyStart) : 1,
+        });
+        if (!nodeId.has(s.name)) nodeId.set(s.name, id);
+      }
+    }
+    const edgeKey = new Map(); // "from to" -> weight
+    for (const [path, f] of this.files) {
+      const file = rel(path);
+      for (const c of f.calls) {
+        if (!c.caller) continue;
+        const from = `${file}#${c.caller}`;
+        const to = nodeId.get(c.callee);
+        if (!to || to === from) continue; // only edges to defined symbols; drop self
+        const k = `${from} ${to}`;
+        edgeKey.set(k, (edgeKey.get(k) || 0) + 1);
+      }
+    }
+    const edges = [...edgeKey.entries()].map(([k, weight]) => { const [from, to] = k.split(" "); return { from, to, weight }; });
+    return { nodes, edges, root: rel(root) || root };
+  }
+}
+
+// Fuzzy subsequence score: lower is better; -1 = no match. Rewards prefix and
+// word-boundary (after _ or a case bump) matches; penalizes gaps.
+function fuzzyScore(hay, needle) {
+  if (!needle) return 0;
+  let hi = 0, score = 0, prevMatch = -2;
+  for (let ni = 0; ni < needle.length; ni++) {
+    const c = needle[ni];
+    let found = -1;
+    for (let k = hi; k < hay.length; k++) { if (hay[k] === c) { found = k; break; } }
+    if (found < 0) return -1;
+    const boundary = found === 0 || hay[found - 1] === "_";
+    if (found === prevMatch + 1) score += 1; // contiguous
+    else score += 5 + (found - hi); // gap penalty
+    if (boundary) score -= 2;
+    if (found === ni) score -= 1; // prefix-aligned
+    prevMatch = found; hi = found + 1;
+  }
+  return score;
+}
+
+module.exports = { SymbolIndex, extractFile, codeMask, hashText, fuzzyScore, KIND };

--- a/js/vibe/symbol_index.js
+++ b/js/vibe/symbol_index.js
@@ -95,15 +95,36 @@ function matchBrace(mask, open) {
 
 // Top-level (and one level of `module { ... }`-nested) declarations.
 // Recognizes: let / struct / enum / trait / module / type, with optional
-// `export` and (for let) `mut`. For a let bound to a lambda we record Function,
-// else Variable, and capture the body span (`{ ... }`) for call attribution.
+// `export` and (for let) a `mut` or `rec` modifier (`let rec f = ...` is the
+// common recursive-function form — without consuming it the name would parse as
+// "rec"). For a let bound to a lambda we record Function, else Variable, and
+// capture the body span (`{ ... }`) for call attribution.
 // NOTE: this matches at ANY brace depth; the caller filters to depth 0 (top
 // level) and depth 1 inside a `module` body, so locals inside function bodies
 // (`let x = ...` in a lambda) are not mistaken for workspace symbols.
 const DECL_RE =
-  /(^|\n)[ \t]*(export[ \t]+)?(let|struct|enum|trait|module|type)[ \t]+(mut[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)/g;
+  /(^|\n)[ \t]*(export[ \t]+)?(let|struct|enum|trait|module|type)[ \t]+(?:(?:mut|rec)[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)/g;
 
-function declKind(keyword, mask, nameEnd) {
+// The first top-level `=` at/after `from` that binds a `let` (skipping any inside
+// (), [], {} — e.g. a `(...) -> T with { E }` signature — and the compound
+// operators ==, =>, <=, >=, !=, :=). Returns its index, or -1 if none before the
+// next top-level declaration. This separates a let's TYPE annotation from its
+// VALUE, so the body brace is searched in the value, not in a `with { E }` set.
+function findBindingEq(mask, from) {
+  let depth = 0;
+  for (let i = from; i < mask.length; i++) {
+    const c = mask[i];
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") { if (depth === 0) return -1; depth--; }
+    else if (depth === 0) {
+      if (c === "\n" && /^[ \t]*(export[ \t]+)?(let|struct|enum|trait|module|type)[ \t]/.test(mask.slice(i + 1, i + 48))) return -1;
+      if (c === "=" && mask[i + 1] !== "=" && mask[i + 1] !== ">" && mask[i - 1] !== "<" && mask[i - 1] !== ">" && mask[i - 1] !== "!" && mask[i - 1] !== ":" && mask[i - 1] !== "=") return i;
+    }
+  }
+  return -1;
+}
+
+function declKind(keyword, mask, eqPos) {
   switch (keyword) {
     case "struct": return KIND.Struct;
     case "enum": return KIND.Enum;
@@ -111,13 +132,13 @@ function declKind(keyword, mask, nameEnd) {
     case "module": return KIND.Module;
     case "type": return KIND.Class;
     case "let": {
-      // Function iff the RHS is a lambda: `= ( ... ) ->` (optionally a leading
-      // `[T]` type-param list). Scan forward from the name over `=` to a `(`.
-      let i = nameEnd;
+      // Function iff the VALUE (after the binding `=`) is a lambda `( ... ) ->`,
+      // optionally with a leading `[T]` type-param list. eqPos isolates the value
+      // from the type annotation, so a `(...) -> T with { E } = ...` signature
+      // doesn't fool the scan.
+      if (eqPos < 0) return KIND.Variable;
+      let i = eqPos + 1;
       const n = mask.length;
-      while (i < n && mask[i] !== "=" && mask[i] !== "\n") i++;
-      if (mask[i] !== "=") return KIND.Variable;
-      i++;
       while (i < n && /\s/.test(mask[i])) i++;
       if (mask[i] === "[") { let d = 0; while (i < n) { if (mask[i] === "[") d++; else if (mask[i] === "]") { d--; if (!d) { i++; break; } } i++; } while (i < n && /\s/.test(mask[i])) i++; }
       return mask[i] === "(" ? KIND.Function : KIND.Variable;
@@ -138,20 +159,21 @@ function extractFile(text) {
     const lead = m[1] ? m[1].length : 0;
     const declStart = m.index + lead;
     const keyword = m[3];
-    const name = m[5];
+    const name = m[4];
     const nameStart = m.index + m[0].length - name.length;
     const nameEnd = nameStart + name.length;
-    const kind = declKind(keyword, mask, nameEnd);
-    // Body span: the first `{` on/after the name, brace-matched. struct/enum/
-    // trait/module aggregates and lambda function bodies all use `{ ... }`. A
-    // value let (`let x = 5`) has no body brace before the next decl/EOF.
-    const braceAt = mask.indexOf("{", nameEnd);
+    // For a let, find the binding `=` so the body brace is searched in the VALUE,
+    // not in a type-annotation `... with { E }` set. Other decls have no `=`.
+    const eqPos = keyword === "let" ? findBindingEq(mask, nameEnd) : -1;
+    const kind = declKind(keyword, mask, eqPos);
+    // Body span: the first `{` on/after the value (let) or the name (aggregate),
+    // brace-matched. A value let (`let x = 5`) has no body brace before the next
+    // decl/EOF; the crossesDecl guard prevents claiming a LATER decl's brace.
+    const bodyFrom = keyword === "let" ? (eqPos >= 0 ? eqPos + 1 : nameEnd) : nameEnd;
+    const braceAt = mask.indexOf("{", bodyFrom);
     let bodyStart = -1, bodyEnd = nameEnd;
     if (braceAt >= 0) {
-      // For a value let with no lambda, the next `{` may belong to a LATER decl;
-      // only claim it as a body when nothing structural separates them. We accept
-      // it if no newline-starting decl keyword appears between nameEnd and braceAt.
-      const between = mask.slice(nameEnd, braceAt);
+      const between = mask.slice(bodyFrom, braceAt);
       if (kind === KIND.Function || keyword !== "let" || !/\n[ \t]*(export[ \t]+)?(let|struct|enum|trait|module|type)[ \t]/.test(between)) {
         bodyStart = braceAt;
         bodyEnd = matchBrace(mask, braceAt);
@@ -216,12 +238,11 @@ function extractFile(text) {
     const qualifier = cm[2] ? cm[1] : null;
     const callee = cm[2] || cm[1];
     if (NON_CALL.has(callee) || (!qualifier && NON_CALL.has(cm[1]))) continue;
-    // The token must not itself be a declaration name (e.g. `let f = (` — the
-    // `(` there is the lambda param list, not a call of `f`). Skip if the char
-    // run immediately before is `= ` following a decl — cheap heuristic: if the
-    // identifier start is a decl nameStart, skip.
     const off = cm.index;
-    calls.push({ caller: enclosing(off), callee, qualifier, off });
+    // Span of the called name token (qualifier::callee), excluding trailing
+    // spaces and the `(`, for precise call-site ranges in call hierarchy.
+    const end = off + (qualifier ? qualifier.length + 2 + callee.length : callee.length);
+    calls.push({ caller: enclosing(off), callee, qualifier, off, end });
   }
 
   return { symbols, imports, calls };
@@ -283,26 +304,34 @@ class SymbolIndex {
   }
 
   // callHierarchy: outgoing calls FROM `name` (callees it invokes in its body).
+  // Each entry carries the call SITES — { path, off, end } of each invocation
+  // inside `name`'s body — so the LSP can report fromRanges at the call
+  // expressions (per spec), not at the callee's definition.
   outgoingCalls(name) {
-    const seen = new Map(); // callee -> count
-    for (const f of this.files.values()) {
+    const seen = new Map(); // callee -> { callee, count, sites: [...] }
+    for (const [path, f] of this.files) {
       for (const c of f.calls) {
-        if (c.caller === name) seen.set(c.callee, (seen.get(c.callee) || 0) + 1);
+        if (c.caller !== name) continue;
+        const e = seen.get(c.callee) || { callee: c.callee, count: 0, sites: [] };
+        e.count++; e.sites.push({ path, off: c.off, end: c.end });
+        seen.set(c.callee, e);
       }
     }
-    return [...seen.entries()].map(([callee, count]) => ({ callee, count, defined: this.definitions(callee).length > 0 }))
+    return [...seen.values()].map((e) => Object.assign(e, { defined: this.definitions(e.callee).length > 0 }))
       .sort((a, b) => b.count - a.count || (a.callee < b.callee ? -1 : 1));
   }
 
-  // callHierarchy: incoming calls TO `name` (callers that invoke it).
+  // callHierarchy: incoming calls TO `name` (callers that invoke it). Each entry
+  // carries the call SITES inside the caller's body for accurate fromRanges.
   incomingCalls(name) {
-    const seen = new Map(); // caller -> {count, path}
+    const seen = new Map(); // caller -> {caller, count, path, sites}
     for (const [path, f] of this.files) {
       for (const c of f.calls) {
         if (c.callee === name && c.caller) {
           const key = c.caller;
-          const e = seen.get(key) || { caller: c.caller, count: 0, path };
-          e.count++; seen.set(key, e);
+          const e = seen.get(key) || { caller: c.caller, count: 0, path, sites: [] };
+          e.count++; e.sites.push({ path, off: c.off, end: c.end });
+          seen.set(key, e);
         }
       }
     }

--- a/scripts/bench_vibe_lsp.js
+++ b/scripts/bench_vibe_lsp.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Benchmark for the vibe LSP workspace symbol / call-hierarchy index
+// (js/vibe/symbol_index.js).
+//
+// Establishes the perf case for the in-process index: the LSP server answers
+// queries by spawning a `vibe` subprocess (each loads the wasm compiler), which
+// is fine for one hover but ~0.5s PER FILE — so a naive `workspace/symbol` or
+// `callHierarchy` that needs every file's symbols would take minutes. The index
+// extracts the same information directly from source in-process.
+//
+// Measures, over the repo's .vibe corpus:
+//   1. cold index build (extract all files)
+//   2. no-op re-scan (every file unchanged -> incremental hash skip)
+//   3. single-file edit re-index (the steady-state editor hot path)
+//   4. workspace/symbol query latency
+//   5. call-hierarchy (incoming/outgoing) query latency
+//   6. baseline: `vibe symbols` subprocess cost on a sample, extrapolated
+//
+// Usage: node scripts/bench_vibe_lsp.js [rootDir] [--baseline]
+"use strict";
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+const { SymbolIndex } = require(path.join(__dirname, "..", "js", "vibe", "symbol_index.js"));
+
+const ROOT = path.resolve(process.argv[2] && !process.argv[2].startsWith("--") ? process.argv[2] : path.join(__dirname, "..", "vibe"));
+const WANT_BASELINE = process.argv.includes("--baseline");
+
+function walk(dir, out) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) { if (e.name !== "node_modules" && e.name !== ".git") walk(p, out); }
+    else if (e.isFile() && p.endsWith(".vibe")) out.push(p);
+  }
+  return out;
+}
+
+function ms(t) { return `${t.toFixed(1)} ms`; }
+function now() { return Number(process.hrtime.bigint()) / 1e6; }
+
+function main() {
+  console.log(`== vibe LSP index benchmark ==`);
+  console.log(`root: ${ROOT}`);
+  const files = walk(ROOT, []);
+  const texts = new Map();
+  let bytes = 0;
+  for (const f of files) { const t = fs.readFileSync(f, "utf8"); texts.set(f, t); bytes += t.length; }
+  console.log(`corpus: ${files.length} files, ${(bytes / 1e6).toFixed(2)} MB\n`);
+
+  // 1. cold build
+  let t0 = now();
+  const idx = new SymbolIndex();
+  for (const f of files) idx.update(f, texts.get(f));
+  const buildMs = now() - t0;
+  console.log(`1. cold index build      : ${ms(buildMs)}  (${(files.length / (buildMs / 1000)).toFixed(0)} files/s, ${(bytes / 1e6 / (buildMs / 1000)).toFixed(1)} MB/s)`);
+  console.log(`   indexed               : ${idx.symbolCount} symbols across ${idx.fileCount} files`);
+
+  // 2. no-op re-scan (all unchanged -> hash skip)
+  t0 = now();
+  let changed = 0;
+  for (const f of files) if (idx.update(f, texts.get(f))) changed++;
+  const rescanMs = now() - t0;
+  console.log(`2. no-op re-scan          : ${ms(rescanMs)}  (${changed} re-extracted, ${idx.stats().skips} hash-skipped)`);
+
+  // 3. single-file edit re-index (median over the 20 largest files)
+  const bySize = [...files].sort((a, b) => texts.get(b).length - texts.get(a).length).slice(0, 20);
+  const editTimes = [];
+  for (const f of bySize) {
+    const orig = texts.get(f);
+    const edited = orig + "\nlet __bench_marker = () -> Int { 0 }\n";
+    let s = now(); idx.update(f, edited); editTimes.push(now() - s);
+    idx.update(f, orig); // restore
+  }
+  editTimes.sort((a, b) => a - b);
+  console.log(`3. single-file edit       : ${ms(editTimes[editTimes.length >> 1])} median, ${ms(editTimes[editTimes.length - 1])} max  (20 largest files)`);
+
+  // 4. workspace/symbol latency
+  const queries = ["check", "parse", "type", "compile", "emit", "Index", "resolve", "x"];
+  let qt = 0, qn = 0, hits = 0;
+  for (let r = 0; r < 50; r++) for (const q of queries) {
+    const s = now(); const res = idx.workspaceSymbols(q, 100); qt += now() - s; qn++; hits += res.length;
+  }
+  console.log(`4. workspace/symbol query : ${ms(qt / qn)} avg over ${qn} queries  (${(hits / qn).toFixed(0)} results avg)`);
+
+  // 5. call hierarchy latency — pick a frequently-defined name
+  const sample = idx.workspaceSymbols("", 1)[0];
+  const probes = ["check_program", "extractFile", "update", sample ? sample.name : "main"];
+  let ht = 0, hn = 0;
+  for (let r = 0; r < 50; r++) for (const name of probes) {
+    let s = now(); idx.incomingCalls(name); idx.outgoingCalls(name); ht += now() - s; hn++;
+  }
+  console.log(`5. call-hierarchy query   : ${ms(ht / hn)} avg (incoming+outgoing) over ${hn} probes`);
+
+  // graph export size
+  const s = now(); const g = idx.graph({ root: path.join(__dirname, "..") }); const gms = now() - s;
+  console.log(`   graph() export         : ${ms(gms)}  (${g.nodes.length} nodes, ${g.edges.length} edges)`);
+
+  // 6. baseline subprocess comparison
+  if (WANT_BASELINE) {
+    const VIBE = process.env.VIBE_BIN || "vibe";
+    // Sample EVENLY across the size distribution (small + medium + large) so the
+    // mean per-file cost is representative, not skewed by the giant adapter.
+    const sorted = [...files].sort((a, b) => texts.get(a).length - texts.get(b).length);
+    const sample = [];
+    const N = 12;
+    for (let i = 0; i < N; i++) sample.push(sorted[Math.floor((i + 0.5) * sorted.length / N)]);
+    let st = now();
+    for (const f of sample) spawnSync(VIBE, ["symbols", f], { encoding: "utf8", timeout: 30000 });
+    const perFile = (now() - st) / sample.length;
+    console.log(`\n6. baseline \`vibe symbols\` : ${ms(perFile)}/file mean (subprocess), ${sample.length} files spread across sizes`);
+    console.log(`   extrapolated workspace : ${(perFile * files.length / 1000).toFixed(1)} s for ${files.length} files (one spawn each)`);
+    console.log(`   index speedup          : ${(perFile * files.length / buildMs).toFixed(0)}x faster (cold build) for full-workspace symbols`);
+  } else {
+    console.log(`\n(pass --baseline to measure the \`vibe symbols\` subprocess cost for comparison)`);
+  }
+}
+
+main();

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,6 +87,13 @@ say "launcher -> $VIBE_HOME/bin/vibe"
 if [ -f "$ROOT_DIR/js/vibe/lsp_server.js" ]; then
   install -m 0644 "$ROOT_DIR/js/vibe/lsp_server.js" "$VIBE_HOME/lib/lsp_server.js"
   say "lsp server -> $VIBE_HOME/lib/lsp_server.js"
+  # The LSP server requires the workspace symbol/call-hierarchy index alongside
+  # it (workspace/symbol + callHierarchy). Install it next to lsp_server.js so
+  # `require("./symbol_index.js")` resolves in the installed layout.
+  if [ -f "$ROOT_DIR/js/vibe/symbol_index.js" ]; then
+    install -m 0644 "$ROOT_DIR/js/vibe/symbol_index.js" "$VIBE_HOME/lib/symbol_index.js"
+    say "lsp symbol index -> $VIBE_HOME/lib/symbol_index.js"
+  fi
 fi
 
 if [ "$DO_LINK" = "1" ]; then

--- a/scripts/test_symbol_index.js
+++ b/scripts/test_symbol_index.js
@@ -49,6 +49,36 @@ function eq(a, b, name) { ok(JSON.stringify(a) === JSON.stringify(b), name, `${J
   ok(!ex.calls.some((c) => c.caller === null && c.callee === "twice"), "no spurious top-level call of twice");
 }
 
+// --- `let rec` / `let mut` modifiers: the NAME, not the modifier ------------
+{
+  const ex = extractFile("export let rec walk = (n: Int) -> Int { walk(n) }\nlet mut counter = 0\nlet rec a = () -> Int { b() }\nlet b = () -> Int { 0 }\n");
+  const names = ex.symbols.map((s) => s.name).sort();
+  eq(names, ["a", "b", "counter", "walk"], "`let rec`/`let mut` capture the real name, not 'rec'/'mut'");
+  ok(!ex.symbols.some((s) => s.name === "rec" || s.name === "mut"), "no fake 'rec'/'mut' symbol");
+  ok(ex.symbols.find((s) => s.name === "walk").kind === KIND.Function, "let rec fn is Function kind");
+  ok(ex.calls.some((c) => c.caller === "walk" && c.callee === "walk"), "recursive call attributed to the rec fn");
+}
+
+// --- effect-annotated signatures: body is the lambda, not `with { E }` -------
+{
+  const ex = extractFile(
+    "export let run: (String) -> Unit with { Process } = (cmd) -> {\n  exec(cmd)\n  log(cmd)\n}\nlet exec = (c: String) -> Unit with { Process } => 0\n");
+  const run = ex.symbols.find((s) => s.name === "run");
+  ok(run && run.kind === KIND.Function, "effectful let is a Function");
+  const runCalls = ex.calls.filter((c) => c.caller === "run").map((c) => c.callee).sort();
+  ok(runCalls.includes("exec") && runCalls.includes("log"), "calls in the real lambda body attribute to the fn (not lost to the effect set)", JSON.stringify(runCalls));
+  ok(!ex.calls.some((c) => c.caller === null && (c.callee === "exec" || c.callee === "log")), "effectful-fn body calls are not orphaned to caller:null");
+}
+
+// --- call sites carry precise offsets ---------------------------------------
+{
+  const src = "let a = () -> Int { foo(1) }\nlet foo = (x: Int) -> Int { x }\n";
+  const ex = extractFile(src);
+  const call = ex.calls.find((c) => c.callee === "foo" && c.caller === "a");
+  ok(call && typeof call.off === "number" && call.end === call.off + 3, "call records off..end spanning the callee token");
+  ok(src.slice(call.off, call.end) === "foo", "call off..end slices to the callee name", src.slice(call.off, call.end));
+}
+
 // --- module-nested symbols --------------------------------------------------
 {
   const src = "module M {\n  let inner = (x: Int) -> Int { x }\n}\nlet outer = () -> Int { 0 }\n";
@@ -88,10 +118,14 @@ function eq(a, b, name) { ok(JSON.stringify(a) === JSON.stringify(b), name, `${J
   ok(tw[0] && tw[0].name === "twice" && tw[0].path === "/util.vibe", "fuzzy query ranks exact name first with its path");
 
   // incoming calls to twice: combo (util) and run (main) — cross file
-  eq(idx.incomingCalls("twice").map((c) => c.caller).sort(), ["combo", "run"], "incomingCalls(twice) spans files");
+  const inc = idx.incomingCalls("twice");
+  eq(inc.map((c) => c.caller).sort(), ["combo", "run"], "incomingCalls(twice) spans files");
+  ok(inc.every((c) => c.sites.length >= 1 && c.sites[0].path && typeof c.sites[0].off === "number"), "incoming entries carry call-site offsets");
   // outgoing from combo: inc, twice
-  eq(idx.outgoingCalls("combo").map((c) => c.callee).sort(), ["inc", "twice"], "outgoingCalls(combo)");
-  ok(idx.outgoingCalls("combo").every((c) => c.defined), "outgoing callees resolve to workspace symbols");
+  const og = idx.outgoingCalls("combo");
+  eq(og.map((c) => c.callee).sort(), ["inc", "twice"], "outgoingCalls(combo)");
+  ok(og.every((c) => c.defined), "outgoing callees resolve to workspace symbols");
+  ok(og.every((c) => c.sites.length >= 1 && c.sites[0].path === "/util.vibe"), "outgoing call-sites are in the caller's file");
 
   // remove a file drops its symbols and edges
   idx.remove("/main.vibe");

--- a/scripts/test_symbol_index.js
+++ b/scripts/test_symbol_index.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// Unit tests for the workspace symbol / call-graph index (js/vibe/symbol_index.js).
+// Pure JS, no compiler/runner required — runs anywhere node does.
+"use strict";
+const path = require("path");
+const { SymbolIndex, extractFile, codeMask, hashText, fuzzyScore, KIND } =
+  require(path.join(__dirname, "..", "js", "vibe", "symbol_index.js"));
+
+let pass = 0, fail = 0;
+function ok(cond, name, detail) {
+  if (cond) { pass++; console.log(`ok: ${name}`); }
+  else { fail++; console.error(`FAIL: ${name}${detail ? " — " + detail : ""}`); }
+}
+function eq(a, b, name) { ok(JSON.stringify(a) === JSON.stringify(b), name, `${JSON.stringify(a)} !== ${JSON.stringify(b)}`); }
+
+// --- codeMask: comments and strings are blanked, offsets preserved ----------
+{
+  const src = 'let x = "he(llo" // call me( here\nlet y = 1\n';
+  const mask = codeMask(src);
+  ok(mask.length === src.length, "codeMask preserves length");
+  ok(!/call/.test(mask), "codeMask blanks line comments");
+  ok(!mask.includes("he(llo"), "codeMask blanks string contents");
+  ok(mask.includes("let y = 1"), "codeMask keeps code");
+}
+
+// --- extractFile: top-level symbols only, kinds, body spans -----------------
+{
+  const src = [
+    "export let twice = (x: Int) -> Int { x * 2 }",
+    "let combo = (x: Int) -> Int {",
+    "  let local = twice(x)        // local must NOT be a symbol",
+    "  combo(local)                // self-recursion",
+    "}",
+    "struct Point { x: Int, y: Int }",
+    "enum Color { Red, Green }",
+    "let value = 42",
+  ].join("\n");
+  const ex = extractFile(src);
+  const names = ex.symbols.map((s) => s.name).sort();
+  eq(names, ["Color", "Point", "combo", "twice", "value"], "extractFile keeps only top-level decls (locals excluded)");
+  const byName = Object.fromEntries(ex.symbols.map((s) => [s.name, s]));
+  ok(byName.twice.kind === KIND.Function, "let-lambda is Function kind");
+  ok(byName.value.kind === KIND.Variable, "let-value is Variable kind");
+  ok(byName.Point.kind === KIND.Struct, "struct is Struct kind");
+  ok(byName.Color.kind === KIND.Enum, "enum is Enum kind");
+  // call attribution
+  const callsFromCombo = ex.calls.filter((c) => c.caller === "combo").map((c) => c.callee).sort();
+  ok(callsFromCombo.includes("twice") && callsFromCombo.includes("combo"), "calls inside combo attributed to combo", JSON.stringify(callsFromCombo));
+  ok(!ex.calls.some((c) => c.caller === null && c.callee === "twice"), "no spurious top-level call of twice");
+}
+
+// --- module-nested symbols --------------------------------------------------
+{
+  const src = "module M {\n  let inner = (x: Int) -> Int { x }\n}\nlet outer = () -> Int { 0 }\n";
+  const ex = extractFile(src);
+  const inner = ex.symbols.find((s) => s.name === "inner");
+  ok(inner && inner.container === "M", "module-nested symbol records its container");
+  ok(ex.symbols.some((s) => s.name === "outer" && s.container === null), "top-level symbol after a module still captured");
+}
+
+// --- keywords are not calls -------------------------------------------------
+{
+  const ex = extractFile("let f = (x: Int) -> Int {\n  if (x) { g(x) } else { 0 }\n}\nlet g = (x: Int) -> Int { x }\n");
+  ok(!ex.calls.some((c) => c.callee === "if"), "`if (` is not a call");
+  ok(ex.calls.some((c) => c.callee === "g"), "real call g() captured");
+}
+
+// --- incremental update: hash skip ------------------------------------------
+{
+  const idx = new SymbolIndex();
+  const a = "let f = () -> Int { g() }\nlet g = () -> Int { 0 }\n";
+  ok(idx.update("/a.vibe", a) === true, "first update extracts");
+  ok(idx.update("/a.vibe", a) === false, "identical re-update is a hash skip");
+  ok(idx.update("/a.vibe", a + "let h = () -> Int { 1 }\n") === true, "changed content re-extracts");
+  ok(idx.stats().skips === 1, "exactly one hash skip recorded");
+}
+
+// --- workspace symbols, definitions, call hierarchy across files ------------
+{
+  const idx = new SymbolIndex();
+  idx.update("/util.vibe", "let twice = (x: Int) -> Int { x * 2 }\nlet inc = (x: Int) -> Int { x + 1 }\nlet combo = (x: Int) -> Int { twice(inc(x)) }\n");
+  idx.update("/main.vibe", "let run = () -> Int {\n  let a = combo(10)\n  twice(a)\n}\n");
+
+  const all = idx.workspaceSymbols("");
+  eq(all.map((s) => s.name).sort(), ["combo", "inc", "run", "twice"], "workspaceSymbols('') returns all 4");
+
+  const tw = idx.workspaceSymbols("twice");
+  ok(tw[0] && tw[0].name === "twice" && tw[0].path === "/util.vibe", "fuzzy query ranks exact name first with its path");
+
+  // incoming calls to twice: combo (util) and run (main) — cross file
+  eq(idx.incomingCalls("twice").map((c) => c.caller).sort(), ["combo", "run"], "incomingCalls(twice) spans files");
+  // outgoing from combo: inc, twice
+  eq(idx.outgoingCalls("combo").map((c) => c.callee).sort(), ["inc", "twice"], "outgoingCalls(combo)");
+  ok(idx.outgoingCalls("combo").every((c) => c.defined), "outgoing callees resolve to workspace symbols");
+
+  // remove a file drops its symbols and edges
+  idx.remove("/main.vibe");
+  eq(idx.incomingCalls("twice").map((c) => c.caller).sort(), ["combo"], "remove() drops a file's call edges");
+}
+
+// --- graph export -----------------------------------------------------------
+{
+  const idx = new SymbolIndex();
+  idx.update("/proj/a.vibe", "let f = () -> Int { g() }\nlet g = () -> Int { 0 }\n");
+  const g = idx.graph({ root: "/proj" });
+  ok(g.nodes.length === 2, "graph has a node per symbol");
+  ok(g.nodes.every((n) => n.file === "a.vibe"), "graph node files are root-relative");
+  const e = g.edges.find((x) => x.from.endsWith("#f") && x.to.endsWith("#g"));
+  ok(e && e.weight === 1, "graph edge f->g with weight", JSON.stringify(g.edges));
+}
+
+// --- fuzzy score ordering ---------------------------------------------------
+{
+  ok(fuzzyScore("check_program", "checkp") >= 0, "subsequence matches");
+  ok(fuzzyScore("xyz", "checkp") < 0, "non-subsequence rejected");
+  ok(fuzzyScore("check", "check") < fuzzyScore("recheck", "check"), "prefix beats mid-word");
+}
+
+// --- hashText is stable & sensitive -----------------------------------------
+ok(hashText("abc") === hashText("abc"), "hashText stable");
+ok(hashText("abc") !== hashText("abd"), "hashText sensitive");
+
+console.log(`\n[test_symbol_index] ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/scripts/test_vibe_lsp_workspace.js
+++ b/scripts/test_vibe_lsp_workspace.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// End-to-end test for the LSP server's workspace/symbol + callHierarchy support
+// (index-backed; js/vibe/symbol_index.js). Drives the real stdio JSON-RPC server
+// over a tiny two-file workspace. Spawns `node js/vibe/lsp_server.js` directly —
+// these features are pure-JS (no compiler subprocess), so no vibe build needed.
+"use strict";
+const { spawn } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const SERVER = path.join(__dirname, "..", "js", "vibe", "lsp_server.js");
+
+// --- scratch workspace ------------------------------------------------------
+const ws = fs.mkdtempSync(path.join(os.tmpdir(), "vibe-lsp-ws-"));
+fs.writeFileSync(path.join(ws, "util.vibe"),
+  "let twice = (x: Int) -> Int { x * 2 }\n" +
+  "let inc = (x: Int) -> Int { x + 1 }\n" +
+  "let combo = (x: Int) -> Int { twice(inc(x)) }\n");
+fs.writeFileSync(path.join(ws, "main.vibe"),
+  "let run = () -> Int {\n  let a = combo(10)\n  twice(a)\n}\n");
+
+const uri = (p) => "file://" + p;
+const srv = spawn(process.execPath, [SERVER], { stdio: ["pipe", "pipe", "inherit"] });
+
+let buf = Buffer.alloc(0);
+const pending = new Map();
+let idc = 0;
+function send(method, params, notify) {
+  const id = notify ? undefined : ++idc;
+  const m = { jsonrpc: "2.0", method, params };
+  if (!notify) m.id = id;
+  const b = Buffer.from(JSON.stringify(m), "utf8");
+  srv.stdin.write(`Content-Length: ${b.length}\r\n\r\n`);
+  srv.stdin.write(b);
+  if (notify) return Promise.resolve();
+  return new Promise((r) => pending.set(id, r));
+}
+srv.stdout.on("data", (c) => {
+  buf = Buffer.concat([buf, c]);
+  for (;;) {
+    const he = buf.indexOf("\r\n\r\n");
+    if (he < 0) return;
+    const mm = /Content-Length:\s*(\d+)/i.exec(buf.slice(0, he).toString("ascii"));
+    if (!mm) { buf = buf.slice(he + 4); continue; }
+    const len = +mm[1], st = he + 4;
+    if (buf.length < st + len) return;
+    const msg = JSON.parse(buf.slice(st, st + len).toString("utf8"));
+    buf = buf.slice(st + len);
+    if (msg.id !== undefined && pending.has(msg.id)) { pending.get(msg.id)(msg.result); pending.delete(msg.id); }
+  }
+});
+
+let pass = 0, fail = 0;
+const ok = (n, c, d) => { c ? (pass++, console.log(`ok: ${n}`)) : (fail++, console.error(`FAIL: ${n}${d ? " — " + d : ""}`)); };
+const eqset = (a, b) => JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+
+(async () => {
+  const init = await send("initialize", { processId: process.pid, rootUri: uri(ws), capabilities: {} });
+  ok("advertises workspaceSymbolProvider", init.capabilities.workspaceSymbolProvider === true);
+  ok("advertises callHierarchyProvider", init.capabilities.callHierarchyProvider === true);
+  await send("initialized", {}, true);
+
+  // workspace/symbol
+  const all = await send("workspace/symbol", { query: "" });
+  ok("workspace/symbol '' returns all 4 top-level symbols", all.length === 4, `got ${all.length}: ${all.map((s) => s.name).join(",")}`);
+  const tw = await send("workspace/symbol", { query: "twice" });
+  ok("workspace/symbol 'twice' finds it", tw.some((s) => s.name === "twice"), JSON.stringify(tw.map((s) => s.name)));
+  const twHit = tw.find((s) => s.name === "twice");
+  ok("result carries cross-file location in util.vibe", twHit && /util\.vibe$/.test(twHit.location.uri.replace(/#.*/, "")), JSON.stringify(twHit && twHit.location.uri));
+
+  // callHierarchy: open main.vibe, prepare on a `twice` usage
+  const mainPath = path.join(ws, "main.vibe");
+  const mainText = fs.readFileSync(mainPath, "utf8");
+  await send("textDocument/didOpen", { textDocument: { uri: uri(mainPath), languageId: "vibe", version: 1, text: mainText } }, true);
+  const lines = mainText.split("\n");
+  const li = lines.findIndex((l) => l.includes("twice"));
+  const ch = lines[li].indexOf("twice") + 1;
+  const prep = await send("textDocument/prepareCallHierarchy", { textDocument: { uri: uri(mainPath) }, position: { line: li, character: ch } });
+  ok("prepareCallHierarchy returns item for 'twice'", prep && prep[0] && prep[0].name === "twice", JSON.stringify(prep));
+
+  if (prep && prep[0]) {
+    const inc = await send("callHierarchy/incomingCalls", { item: prep[0] });
+    ok("incomingCalls(twice) = {combo, run} (cross-file)", eqset(inc.map((c) => c.from.name), ["combo", "run"]), JSON.stringify(inc.map((c) => c.from.name)));
+  }
+  // outgoing of combo (build item via prepare on its def in util.vibe)
+  const utilPath = path.join(ws, "util.vibe");
+  const utilText = fs.readFileSync(utilPath, "utf8");
+  await send("textDocument/didOpen", { textDocument: { uri: uri(utilPath), languageId: "vibe", version: 1, text: utilText } }, true);
+  const ulines = utilText.split("\n");
+  const uli = ulines.findIndex((l) => l.startsWith("let combo"));
+  const uch = ulines[uli].indexOf("combo") + 1;
+  const comboPrep = await send("textDocument/prepareCallHierarchy", { textDocument: { uri: uri(utilPath) }, position: { line: uli, character: uch } });
+  ok("prepareCallHierarchy returns item for 'combo'", comboPrep && comboPrep[0] && comboPrep[0].name === "combo");
+  if (comboPrep && comboPrep[0]) {
+    const outg = await send("callHierarchy/outgoingCalls", { item: comboPrep[0] });
+    ok("outgoingCalls(combo) = {inc, twice}", eqset(outg.map((c) => c.to.name), ["inc", "twice"]), JSON.stringify(outg.map((c) => c.to.name)));
+  }
+
+  await send("shutdown", {});
+  await send("exit", {}, true);
+  setTimeout(() => {
+    try { fs.rmSync(ws, { recursive: true, force: true }); } catch {}
+    console.log(`\n[test_vibe_lsp_workspace] ${pass} passed, ${fail} failed`);
+    srv.kill();
+    process.exit(fail ? 1 : 0);
+  }, 150);
+})().catch((e) => { console.error(e); srv.kill(); process.exit(2); });

--- a/scripts/test_vibe_lsp_workspace.js
+++ b/scripts/test_vibe_lsp_workspace.js
@@ -82,6 +82,11 @@ const eqset = (a, b) => JSON.stringify([...a].sort()) === JSON.stringify([...b].
   if (prep && prep[0]) {
     const inc = await send("callHierarchy/incomingCalls", { item: prep[0] });
     ok("incomingCalls(twice) = {combo, run} (cross-file)", eqset(inc.map((c) => c.from.name), ["combo", "run"]), JSON.stringify(inc.map((c) => c.from.name)));
+    // fromRanges must point at the call site inside the caller (run), not at the
+    // callee's definition. In main.vibe `twice(a)` is on the same line as the cursor.
+    const runCall = inc.find((c) => c.from.name === "run");
+    const fr = runCall && runCall.fromRanges && runCall.fromRanges[0];
+    ok("incoming fromRanges point at the call site in the caller", fr && fr.start.line === li, `fromRange=${JSON.stringify(fr)} callLine=${li}`);
   }
   // outgoing of combo (build item via prepare on its def in util.vibe)
   const utilPath = path.join(ws, "util.vibe");

--- a/scripts/vibe_graph.js
+++ b/scripts/vibe_graph.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Export a vibe workspace's symbol + call graph as JSON for macro-level
+// visualization (à la mizchi/sprawlens). Builds the in-process incremental
+// index (js/vibe/symbol_index.js) over a directory tree and emits:
+//
+//   {
+//     root,
+//     nodes: [{ id, name, kind, file, module, size }],   // symbols, sized by span
+//     edges: [{ from, to, weight }],                      // call edges (resolved)
+//     modules: [{ name, symbols, files }],                // rollups for zoom-out
+//     stats: { files, symbols, edges, ms }
+//   }
+//
+// `kind` is the LSP SymbolKind. A renderer can lay nodes out by module, size
+// area by `size`, and bundle `edges` as the call graph; `modules` gives the
+// zoomed-out plane. Import edges are available per file via the index but are
+// emitted here only as intra-call edges to keep the default output call-focused.
+//
+// Usage:
+//   node scripts/vibe_graph.js [rootDir] [--out file.json] [--functions-only]
+"use strict";
+const fs = require("fs");
+const path = require("path");
+const { SymbolIndex, KIND } = require(path.join(__dirname, "..", "js", "vibe", "symbol_index.js"));
+
+const args = process.argv.slice(2);
+let root = null, out = null, functionsOnly = false;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--out") out = args[++i];
+  else if (args[i] === "--functions-only") functionsOnly = true;
+  else if (!args[i].startsWith("--")) root = args[i];
+}
+root = path.resolve(root || process.cwd());
+
+function walk(dir, acc) {
+  let ents;
+  try { ents = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const e of ents) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) { if (e.name !== "node_modules" && e.name !== ".git" && e.name !== "target") walk(p, acc); }
+    else if (e.isFile() && p.endsWith(".vibe")) acc.push(p);
+  }
+  return acc;
+}
+
+const t0 = Number(process.hrtime.bigint()) / 1e6;
+const idx = new SymbolIndex();
+const files = walk(root, []);
+for (const f of files) { try { idx.update(f, fs.readFileSync(f, "utf8")); } catch {} }
+
+let g = idx.graph({ root });
+if (functionsOnly) {
+  const fnIds = new Set(g.nodes.filter((n) => n.kind === KIND.Function).map((n) => n.id));
+  g.nodes = g.nodes.filter((n) => fnIds.has(n.id));
+  g.edges = g.edges.filter((e) => fnIds.has(e.from) && fnIds.has(e.to));
+}
+
+// Module rollups (zoom-out plane): symbol + file counts per module.
+const modMap = new Map();
+for (const n of g.nodes) {
+  const m = modMap.get(n.module) || { name: n.module, symbols: 0, files: new Set() };
+  m.symbols++; m.files.add(n.file); modMap.set(n.module, m);
+}
+const modules = [...modMap.values()].map((m) => ({ name: m.name, symbols: m.symbols, files: m.files.size }))
+  .sort((a, b) => b.symbols - a.symbols);
+
+const result = {
+  root: g.root,
+  nodes: g.nodes,
+  edges: g.edges,
+  modules,
+  stats: { files: idx.fileCount, symbols: g.nodes.length, edges: g.edges.length, ms: +(Number(process.hrtime.bigint()) / 1e6 - t0).toFixed(1) },
+};
+
+const json = JSON.stringify(result, null, out ? 0 : 2);
+if (out) {
+  fs.writeFileSync(out, json);
+  process.stderr.write(`vibe graph -> ${out}: ${result.stats.symbols} nodes, ${result.stats.edges} edges, ${result.stats.files} files in ${result.stats.ms} ms\n`);
+} else {
+  process.stdout.write(json + "\n");
+}


### PR DESCRIPTION
## 概要

LSP の `workspace/symbol` と `callHierarchy` を高速化し、シンボルをインクリメンタルに収集して**マクロ可視化**（[mizchi/sprawlens](https://github.com/mizchi/sprawlens) 想定）するための基盤を追加する。

中核は、ソースから直接トップレベルシンボル・import・呼び出しエッジを抽出する**インプロセスのインクリメンタル索引** (`js/vibe/symbol_index.js`)。`vibe` サブプロセスを使わない。

## 動機 — なぜ索引が要るか

現状の LSP サーバはクエリごとに `vibe` サブプロセスを spawn する（毎回 wasm コンパイラをロード、~0.3〜0.5s/file）。単発の hover なら問題ないが、ワークスペース全体の操作では致命的 — 素朴な `workspace/symbol` / `callHierarchy` はファイル数だけ spawn が要り、本リポジトリ 754 ファイルでは **~220 秒**。索引はコールド全走査が ~0.5s、1ファイル編集の再索引は ~2ms。

## ベンチマーク

`node scripts/bench_vibe_lsp.js --baseline`（754 files / 13.8 MB）:

| 項目 | 計測 |
|---|---|
| コールド索引構築 | **~0.5 s**（6165 symbols） |
| no-op 再走査（全 hash-skip） | ~35 ms |
| 単一ファイル編集の再索引 | **~2 ms** median |
| workspace/symbol クエリ | ~1 ms avg |
| call-hierarchy クエリ | ~1 ms avg |
| baseline `vibe symbols`（subprocess） | ~288 ms/file → 全体 ~220 s |
| **索引の高速化** | **~433× faster**（フルワークスペース構築） |

## LSP サーバ (`js/vibe/lsp_server.js`)

- **`workspace/symbol`** — fuzzy ランキング、クロスファイル
- **`callHierarchy`** — prepare / incomingCalls / outgoingCalls（クロスファイル）
- 索引は最初のワークスペースクエリ時に遅延構築、`didOpen`/`didChange` でインクリメンタル更新

## マクロ可視化基盤 (`scripts/vibe_graph.js`)

`{nodes, edges, modules}` の JSON を出力 — シンボルはソーススパンでサイズ付け、呼び出しエッジは頻度で重み付け、モジュール rollup でズームアウト面を提供。sprawlens 風レンダラのデータ基盤。

```
node scripts/vibe_graph.js vibe/compiler/runtime --functions-only --out graph.json
# 170 nodes, 103 edges, 9 files in ~29 ms
```

## 抽出方式

コメント/文字列を除去した軽量スキャン（フルパースではない）。トップレベル（+ `module {}` 1段ネスト）の宣言のみを採り、関数本体内のローカル `let` は除外。呼び出しは囲っているトップレベル関数に帰属。AST 厳密ではないが高速・依存ゼロで、マクロ視点には十分。厳密さが要る局面では LSP が従来の `vibe symbols` でフォーカスファイルを補完できる。

## テスト

- `scripts/test_symbol_index.js` — 33 件のユニット（純 JS、抽出/インクリメンタル/workspace symbol/call hierarchy/graph/fuzzy）
- `scripts/test_vibe_lsp_workspace.js` — 9 件の e2e（実サーバ越しに workspace/symbol + callHierarchy をクロスファイル検証）
- 両方を cli-install ワークフローに追加
- `install.sh` は `symbol_index.js` を `lsp_server.js` の隣に同梱

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c)_