### PR TITLE
spec: finalize the generated-wasm host ABI contract (+ CI snapshot)

### DIFF
--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -34,6 +34,7 @@ on:
       - "scripts/test_vibe_lsp_workspace.js"
       - "js/vibe/graph_query.js"
       - "scripts/test_graph_query.js"
+      - "scripts/test_host_abi.js"
       - "bootstrap/selfhost/seed/**"
       - ".github/workflows/cli-install.yml"
   pull_request:
@@ -64,6 +65,7 @@ on:
       - "scripts/test_vibe_lsp_workspace.js"
       - "js/vibe/graph_query.js"
       - "scripts/test_graph_query.js"
+      - "scripts/test_host_abi.js"
       - ".github/workflows/cli-install.yml"
   workflow_dispatch:
 
@@ -123,6 +125,8 @@ jobs:
           # LSP server relies on for messages.
           bash scripts/install.sh >/dev/null
           VIBE_BIN="$VIBE_BIN_DIR/vibe" node scripts/test_vibe_lsp.js
+          # Host ABI contract snapshot (docs/spec/host-abi.md): reuse this install.
+          VIBE_BIN="$VIBE_BIN_DIR/vibe" node scripts/test_host_abi.js
 
       - name: Name section (debugger P0) regression test
         run: bash scripts/test_name_section.sh

--- a/docs/spec/host-abi.md
+++ b/docs/spec/host-abi.md
@@ -1,0 +1,106 @@
+# vibe 生成物のホスト ABI 契約 (host-abi)
+
+> 目的: `vibe build` が出力する `.wasm` を「どんなホストが・何を満たせば実行できるか」
+> を確定させる。実測（素の `wasmtime` + import セクションのダンプ）で裏取りした内容。
+
+## TL;DR（確定事項）
+
+- 生成物は **core wasm（linear memory）**。**exception-handling proposal が必須**。
+- ホストが満たすべき import 面 =
+  **`wasi_snapshot_preview1::fd_write`（常時）＋ プログラムが使ったエフェクトに対応する `vibe::*`**。
+- **pure / compute なプログラムは、任意の WASI Preview1 ホスト（＋exceptions）で動く** —
+  実測: 素の `wasmtime run -W exceptions=y pure.wasm` が `5` を出力。
+- **エフェクトを使う生成物は `vibe::*` host ABI を実装したホストが必要**（現状は `moonrun_wt`）。
+  標準 WASI だけのホストでは `unknown import: vibe::fs_read_file` で instantiate に失敗する（実測）。
+- したがって **「IO は wasip3 前提」はデフォルトの linear path には当てはまらない**。
+  デフォルトは *Preview1 fd_write ＋ 独自 `vibe::*`*。wasip3 は別系統（component path）の到達目標。
+
+## 1. 生成物の形（artifact shape）
+
+| 項目 | 値 |
+|---|---|
+| module 種別 | core wasm、linear memory（component ではない）|
+| 必須 proposal | **exception-handling**（tag section ＋ try/throw）|
+| exports | `_start`（WASI command entry）, `main`, `memory`, `__heap_ptr`(global i32 mut), `error`(exception **tag**) |
+
+`_start` は結果を `fd_write` で stdout に出すため、**出力の有無に関わらず全プログラムが `fd_write` を import する**。
+
+## 2. import 契約（ホストが提供すべき面）
+
+### 2.1 常時必要
+
+- `wasi_snapshot_preview1::fd_write` — stdout/stderr（結果出力・panic）。標準 WASI Preview1。
+
+### 2.2 エフェクト別 `vibe::*`（独自 host module）
+
+値表現は **vibe tagged i64**。packed string / bytes は引数 i64 が linear memory 上の領域を指し、
+ホストは export された `memory` 経由で読み書きする（エンコードは runtime / `vibe_read_packed_str` 参照）。
+
+| effect | import | signature | 意味 |
+|---|---|---|---|
+| `Fs` | `vibe::fs_read_file` | `(path: i64) -> i64` | ファイル読込（戻り値は packed string）|
+| `Fs` | `vibe::fs_write_file` | `(path: i64, content: i64) -> ()` | テキスト書込 |
+| `Fs` | `vibe::fs_write_bytes` | `(path: i64, bytes: i64) -> ()` | バイト書込 |
+| `Fs` | `vibe::fs_exists` | `(path: i64) -> i64` | 真偽（tagged）|
+| `Fs` | `vibe::fs_stat_token` | `(path: i64) -> i64` | stat トークン |
+| debug | `vibe::dbg_line` | `(file_id: i32, line: i32) -> ()` | `--break` ビルドのみ |
+| debug | `vibe::dbg_break` | `() -> ()` | `--break` ビルドのみ |
+
+注:
+- **Process / Shell / Http エフェクトは現行 runner の `vibe::*` には未実装**。これらを使う
+  プログラムを動かすには ABI 拡張（`vibe::proc_*` 等）か component path が要る。
+- `__moonbit_fs_unstable::*` / `__moonbit_sys_unstable::*` / `spectest::*` は
+  **コンパイラ wasm（`vibe-cli.wasm`）専用**の externref ベース runtime であり、
+  **ユーザ生成物の import には現れない**。混同しないこと。
+
+## 3. 移植性ティア（いずれも実測済み）
+
+- **Tier 0 — pure / compute**: import は `fd_write` のみ。
+  任意の WASI Preview1 ＋ exceptions ホストで動く（wasmtime / wasmer / Node `node:wasi` /
+  ブラウザの WASI shim 等）。
+  実測: `wasmtime run -W exceptions=y pure.wasm` → `5`（`add(2,3)`）。
+- **Tier 1 — effectful**: 上記に加え `vibe::*` が必要。vibe ABI を実装したホストに限る。
+  実測: 素の wasmtime で `unknown import: vibe::fs_read_file`。
+
+つまり **claim「生成物は任意の環境で動く .wasm」は Tier 0 では真**、
+**Tier 1 では「vibe host ABI を満たすホスト」という条件付きで真**。
+
+## 4. wasip3 との関係（前提の整理）
+
+- **デフォルト linear path**（`vibe build` / `moonrun_wt`）: Preview1 `fd_write` ＋ 独自 `vibe::*`。
+  **wasip3 ではない**。
+- **component path**（`vibe/compiler/component_codegen.vibe`）: canonical ABI（`cabi_realloc`）＋
+  preview1 adapter で WASI component 化。標準 I/O を `wasi:io`（preview2）→ p3 async に寄せるのが
+  到達目標（[wasi-p3-async.md](./wasi-p3-async.md), [decisions.md](./decisions.md)）。
+- よって「IO を wasip3 前提にする」のは **component path の方針**であり、
+  core path のエフェクトを wasip3 に載せ替えるには `vibe::fs_*` →
+  `wasi:filesystem`/`wasi:cli` へのマッピング adapter が別途必要。
+
+## 5. 任意ホストで動かす実装ガイド
+
+エフェクト付き生成物を任意環境（JS / Rust / Go / …）で動かす最小手順:
+
+1. wasm 実行時に **exceptions proposal を有効化**する。
+2. `wasi_snapshot_preview1::fd_write` を提供（最低限 stdout を書ければよい）。
+3. プログラムが使う **`vibe::*`（§2.2）だけ**を実装する。
+   値は tagged-i64 ＋ export された `memory` から packed string/bytes を読む。
+4. `_start` を呼ぶ（または `main` を直接 invoke）。
+
+この 4 点が「契約」。これを満たすホストは moonrun_wt と等価に生成物を実行できる。
+
+## 付録: 契約の再現手順
+
+```bash
+vibe build pure.vibe -o pure.wasm        # Tier 0
+vibe build fs_prog.vibe -o fs.wasm       # Tier 1 (Fs effect)
+
+# import 面の確認（module::field を列挙する任意のツールで）
+wasm-tools print pure.wasm | grep '(import'   # => wasi_snapshot_preview1 "fd_write"
+wasm-tools print fs.wasm   | grep '(import'   # => + vibe "fs_read_file" 等
+
+# Tier 0 は素の wasmtime で動く
+wasmtime run -W exceptions=y pure.wasm        # => 5
+
+# Tier 1 は vibe host ABI が無いと落ちる
+wasmtime run -W exceptions=y fs.wasm          # => unknown import: vibe::fs_read_file
+```

--- a/docs/spec/host-abi.md
+++ b/docs/spec/host-abi.md
@@ -88,6 +88,13 @@
 
 この 4 点が「契約」。これを満たすホストは moonrun_wt と等価に生成物を実行できる。
 
+## CI enforcement
+
+この契約は `scripts/test_host_abi.js`（cli-install ワークフロー）が **スナップショットとして固定**する:
+pure 生成物の import が `wasi_snapshot_preview1::fd_write` のみであること、exceptions タグを
+export すること、Fs エフェクトが `vibe::fs_*` に落ちること（`wasi:*` / `__moonbit_*` でないこと）を
+ビルドして検証する。ホストに要求する面が変わるとここで落ちる。
+
 ## 付録: 契約の再現手順
 
 ```bash

--- a/scripts/test_host_abi.js
+++ b/scripts/test_host_abi.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Host ABI contract snapshot test (docs/spec/host-abi.md).
+//
+// Compiles a pure program and an Fs-effect program with the real `vibe` launcher
+// and asserts the import/export surface matches the documented host contract, so
+// a change to what a host must provide can't land unnoticed:
+//
+//   - every artifact imports exactly `wasi_snapshot_preview1::fd_write` (+ the
+//     `vibe::*` for the effects it uses) and nothing else,
+//   - the artifact requires the exception-handling proposal (exports an `error`
+//     tag),
+//   - the Fs effect lowers to the `vibe::fs_*` host module (not wasip3, not
+//     `__moonbit_*_unstable`).
+//
+// Needs a working launcher: VIBE_BIN=<path to vibe> node scripts/test_host_abi.js
+"use strict";
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const VIBE = process.env.VIBE_BIN || "vibe";
+const REPO = path.resolve(__dirname, "..");
+
+let pass = 0, fail = 0;
+const ok = (n, c, d) => { c ? (pass++, console.log(`ok: ${n}`)) : (fail++, console.error(`FAIL: ${n}${d ? " — " + d : ""}`)); };
+
+// ---- minimal wasm section reader (imports + exports) ----------------------
+function leb(b, p) { let r = 0, s = 0, x; do { x = b[p++]; r |= (x & 0x7f) << s; s += 7; } while (x & 0x80); return [r >>> 0, p]; }
+function sections(file) {
+  const b = fs.readFileSync(file);
+  if (b.length < 8 || b.readUInt32LE(0) !== 0x6d736100) throw new Error("not a wasm module: " + file);
+  const imports = [], exports = [];
+  let p = 8;
+  while (p < b.length) {
+    const id = b[p++]; let n; [n, p] = leb(b, p); const end = p + n;
+    if (id === 2) { // imports
+      let c; [c, p] = leb(b, p);
+      for (let i = 0; i < c; i++) {
+        let l; [l, p] = leb(b, p); const mod = b.slice(p, p + l).toString(); p += l;
+        [l, p] = leb(b, p); const fld = b.slice(p, p + l).toString(); p += l;
+        const k = b[p++];
+        if (k === 0) { [, p] = leb(b, p); }
+        else if (k === 1) { p += 1; const f = b[p++]; if (f) [, p] = leb(b, p); [, p] = leb(b, p); }
+        else if (k === 2) { const f = b[p++]; [, p] = leb(b, p); if (f) [, p] = leb(b, p); }
+        else if (k === 3) { p += 2; }
+        else if (k === 4) { p += 1; [, p] = leb(b, p); } // tag
+        imports.push(`${mod}::${fld}`);
+      }
+    } else if (id === 7) { // exports
+      let c; [c, p] = leb(b, p);
+      for (let i = 0; i < c; i++) {
+        let l; [l, p] = leb(b, p); const nm = b.slice(p, p + l).toString(); p += l;
+        const k = b[p++]; let idx; [idx, p] = leb(b, p);
+        exports.push({ name: nm, kind: k }); // kind 4 = tag (exceptions)
+      }
+    }
+    p = end;
+  }
+  return { imports, exports };
+}
+
+function build(name, src) {
+  const out = path.join(work, name + ".wasm");
+  const file = path.join(work, name + ".vibe");
+  fs.writeFileSync(file, src);
+  const r = spawnSync(VIBE, ["build", file, "-o", out], { encoding: "utf8", timeout: 60000 });
+  if (!fs.existsSync(out)) throw new Error(`build ${name} failed: ${r.stderr || r.stdout}`);
+  return sections(out);
+}
+
+const work = fs.mkdtempSync(path.join(os.tmpdir(), "vibe-abi-"));
+process.on("exit", () => { try { fs.rmSync(work, { recursive: true, force: true }); } catch {} });
+
+try {
+  // --- Tier 0: pure / compute -------------------------------------------
+  const pure = build("pure", "let add = (a: Int, b: Int) -> Int { a + b }\nlet main = () -> Int { add(2, 3) }\n");
+  ok("pure: imports exactly { wasi_snapshot_preview1::fd_write }",
+    JSON.stringify([...pure.imports].sort()) === JSON.stringify(["wasi_snapshot_preview1::fd_write"]),
+    JSON.stringify(pure.imports));
+  ok("pure: no vibe::* host imports (Tier 0 runs on any WASI p1 host)",
+    !pure.imports.some((i) => i.startsWith("vibe::")));
+  ok("pure: requires exceptions proposal (exports an `error` tag)",
+    pure.exports.some((e) => e.name === "error" && e.kind === 4),
+    JSON.stringify(pure.exports.map((e) => `${e.name}:${e.kind}`)));
+  ok("pure: exports the WASI command entry `_start` + `memory`",
+    pure.exports.some((e) => e.name === "_start") && pure.exports.some((e) => e.name === "memory"));
+
+  // --- Tier 1: Fs effect -------------------------------------------------
+  const fsAbs = path.join(REPO, "vibe", "fs", "fs.vibe");
+  const fsw = build("fsprog",
+    `import ${fsAbs} { read_file }\nlet main = () -> Unit { let _ = read_file("/tmp/x"); () }\n`);
+  ok("fs: still imports wasi_snapshot_preview1::fd_write", fsw.imports.includes("wasi_snapshot_preview1::fd_write"));
+  ok("fs: Fs effect lowers to the vibe::fs_* host module", fsw.imports.includes("vibe::fs_read_file"),
+    JSON.stringify(fsw.imports));
+  ok("fs: no wasip3 / wasi:* component imports on the linear path",
+    !fsw.imports.some((i) => i.startsWith("wasi:")), JSON.stringify(fsw.imports));
+  ok("fs: no __moonbit_*_unstable imports (those are compiler-only)",
+    !fsw.imports.some((i) => i.startsWith("__moonbit_")), JSON.stringify(fsw.imports));
+  console.log("  [host-abi] fs imports:", JSON.stringify(fsw.imports));
+} catch (e) {
+  fail++; console.error("FAIL: " + e.message);
+}
+
+console.log(`\n[test_host_abi] ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## 概要

`vibe build` の生成物を「どんなホストが・何を満たせば実行できるか」という**契約を確定**する。
import セクションのダンプと素の `wasmtime` での実行で裏取りした内容を `docs/spec/host-abi.md` に明文化し、
`scripts/test_host_abi.js`（cli-install）で**スナップショットとして固定**する。

## 確定した契約

| | 内容 |
|---|---|
| 生成物 | core wasm（linear memory）、**exception-handling proposal 必須**（`error` タグを export）|
| 常時 import | `wasi_snapshot_preview1::fd_write` |
| エフェクト別 | `vibe::*` 独自 module（`Fs`: `fs_read_file/write_file/write_bytes/exists/stat_token`、debug: `dbg_line/dbg_break`）。値は tagged-i64 ＋ export された `memory` |

## 実測で確認した移植性ティア

- **Tier 0（pure/compute）**: import は `fd_write` のみ → 任意の WASI Preview1 ＋ exceptions ホストで動く。
  `wasmtime run -W exceptions=y pure.wasm` が `5` を出力。
- **Tier 1（エフェクトあり）**: ＋ `vibe::*` が必要 → vibe ABI 実装ホスト限定。
  素の wasmtime では `unknown import: vibe::fs_read_file` で失敗。

## 前提の整理（重要）

- **デフォルトの linear path は wasip3 ではない** — Preview1 `fd_write` ＋ 独自 `vibe::*`。
  `wasip3` は別系統（`component_codegen.vibe` の component path）の到達目標。
- `__moonbit_*_unstable` は**コンパイラ wasm 専用**で、ユーザ生成物には現れない。
- **Process/Shell/Http エフェクトは現行 runner の `vibe::*` に未実装**（ABI 拡張の余地）。

## CI enforcement

`scripts/test_host_abi.js`（8 assertions, 手元で 8/8）が pure/fs を実ビルドして import/export 面を検証:
pure は `fd_write` のみ・`vibe::*` を持たない・exceptions タグを export、Fs は `vibe::fs_*` に落ちる
（`wasi:*` でも `__moonbit_*` でもない）。ホストに要求する面が変わると落ちる。

これで契約は「確定」。任意ホスト（JS/Rust/Go…）は §5 の 4 点を満たせば moonrun_wt 等価に実行できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c)_