### PR TITLE
runner: vibe run --mem — bump-heap memory profiling (tier 1)

### DIFF
--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -25,6 +25,7 @@ on:
       - "scripts/test_vibe_binding_at.sh"
       - "scripts/test_vibe_symbols.sh"
       - "scripts/test_vibe_step.sh"
+      - "scripts/test_vibe_mem.sh"
       - "scripts/test_vibe_dap.js"
       - "js/vibe/dap_server.js"
       - "scripts/test_vibe_break_args.sh"
@@ -56,6 +57,7 @@ on:
       - "scripts/test_vibe_binding_at.sh"
       - "scripts/test_vibe_symbols.sh"
       - "scripts/test_vibe_step.sh"
+      - "scripts/test_vibe_mem.sh"
       - "scripts/test_vibe_dap.js"
       - "js/vibe/dap_server.js"
       - "scripts/test_vibe_break_args.sh"
@@ -160,6 +162,9 @@ jobs:
 
       - name: Step execution (vibe run --break s/n/o/c) regression test
         run: bash scripts/test_vibe_step.sh
+
+      - name: Memory profiling (vibe run --mem) regression test
+        run: bash scripts/test_vibe_mem.sh
 
       - name: Binding occurrences (vibe binding-at) regression test
         run: bash scripts/test_vibe_binding_at.sh

--- a/docs/spec/profiling.md
+++ b/docs/spec/profiling.md
@@ -1,0 +1,61 @@
+# vibe profiling — memory & benchmarking design
+
+vibe の計測基盤の設計と現状。メモリプロファイラはアロケーションモデルに直結している。
+
+## メモリモデル（前提）
+
+- **linear backend（既定 / `vibe build --release` / `moonrun_wt`）**: **bump allocator**。
+  `__heap_ptr`（export 済みの i32 mut global）が単調増加のヒープ先端。**free がない（arena）**。
+  → 1 回の実行内では **peak == total allocated**。プロファイル＝*アロケーション*プロファイル
+  （総量・レート・サイト別）であって live-set ではない。
+- **wasm-gc backend（opt-in）**: host GC を使うので live-set を測れるが、codegen ギャップあり
+  （HOF / Iterator 等、CLAUDE.md 参照）。
+
+ホスト側（`vibe_alloc_packed_str`）も同じ `__heap_ptr` に bump するので、`__heap_ptr` は
+guest＋host を合わせた総ヒープ使用量を表す。
+
+## 実装ティア（コスト順）
+
+| tier | 内容 | 計装 | 状態 |
+|---|---|---|---|
+| **1** | 総ヒープ / ピーク（`__heap_ptr` 差分）| ゼロ | ✅ **実装済み**: `vibe run --mem` |
+| 2 | `memory.grow` イベント（成長タイムライン）| ホストのみ | 設計済み（wasmtime `ResourceLimiter`）|
+| 3 | アロケーション時系列サンプリング | `dbg_line` / epoch 流用 | 設計済み |
+| 4 | サイト別 alloc 属性（massif/heaptrack 相当）| opt-in ビルド（`vibe::alloc_site`）| 設計済み |
+
+## Tier 1: `vibe run --mem`（実装済み）
+
+`__heap_ptr` を `_start` 実行の前後で読み、差分を「allocated」として出力する。無計装・ほぼゼロ
+オーバーヘッド。プログラム出力（stdout）は汚さず、レポートは stderr に出す。
+
+```
+$ vibe run --mem prog.vibe
+<program stdout>
+vibe::mem heap_base=131144 heap_peak=258152 allocated=127008 committed=4194304
+vibe: memory — allocated 124.0 KiB (127008 B), peak heap 252.1 KiB, committed 4.0 MiB
+```
+
+- `vibe::mem …` — 機械可読（ベンチ harness / CI が parse する用）
+- `vibe: memory — …` — 人間可読
+
+`allocated = heap_peak − heap_base`。linear では free がないので、これは実行全体で確保した総量。
+pure / 純計算プログラムは `allocated=0`。`committed` は wasm memory のページ総量。
+
+実装: runner は `VIBE_MEM=1`（`--mem` が設定）のとき `__heap_ptr`（`read_heap_ptr`）と
+`memory` サイズを読んで `report_memory` で出力（trap しても出る）。test: `scripts/test_vibe_mem.sh`。
+
+## ベンチマーカー設計（次段）
+
+`bench "name" { }` 構文と `vibe::profile-now-us`（µs clock）は既にある。harness を足す:
+
+- warmup → 反復自動スケール（合計 T µs まで / 安定まで）、µs 解像度対策に内側 batch（K 回回して割る）
+- 統計: min / median / mean / stddev / p95 / ops·sec、外れ値トリム
+- **メモリ併記**: 各 bench で `__heap_ptr` 差分（bytes/op）を時間と並べる（tier 1 を再利用）
+- 2 backend（linear / gc）を別レポート
+- 回帰検出: `(name, backend, source-hash)` で baseline 比較、% 退行を flag → CI ゲート
+
+## 注意点
+
+- `profile-now-us` は host 越しの wall-clock。micro は必ず batch。
+- bump allocator は断片化/解放の概念がなく peak=total（これが linear の意味論）。
+- 計測は本質的にブレる → 反復＋ロバスト統計で吸収。

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -23,6 +23,8 @@
 #                                           o/finish= finish current frame
 #                                           c/empty = continue
 #                                           q/quit  = abort the run
+#   vibe run --mem <file.vibe> [entry]    run + report bump-heap usage (peak /
+#                                         total allocated) to stderr after exit
 #   vibe compile <file.vibe> -o <out>     compile to a .wasm
 #   vibe build   <file.vibe> -o <out>     alias of compile
 #   vibe check   <file.vibe>              parse + typecheck (no output kept)
@@ -305,6 +307,7 @@ case "$cmd" in
     # annotated with its source location via the funcmap, like trap frames).
     trace=0
     brk=0
+    mem=0
     break_spec=""
     args=()
     while [ "$#" -gt 0 ]; do
@@ -312,11 +315,12 @@ case "$cmd" in
         --trace) trace=1; shift ;;
         --break) brk=1; break_spec="$2"; shift 2 ;;
         --break=*) brk=1; break_spec="${1#--break=}"; shift ;;
+        --mem) mem=1; shift ;;
         *) args+=("$1"); shift ;;
       esac
     done
     set -- "${args[@]}"
-    [ "$#" -ge 1 ] || die "usage: vibe run [--trace] [--break <fn>[,<fn>...]] <file.vibe> [entry]"
+    [ "$#" -ge 1 ] || die "usage: vibe run [--trace] [--break <fn>[,<fn>...]] [--mem] <file.vibe> [entry]"
     [ "$brk" = "1" ] && [ -z "$break_spec" ] && die "usage: vibe run --break <fn>[,<fn>...] <file.vibe> [entry]"
     src="$1"; entry="${2:-main}"
     [ -f "$src" ] || die "not found: $src"
@@ -341,6 +345,10 @@ case "$cmd" in
     # prefix (bash would treat it as a command).
     break_env=""
     [ "$brk" = "1" ] && break_env="VIBE_BREAK=$break_spec"
+    # `--mem`: report bump-allocator heap usage (peak/total) after the run. The
+    # runner reads `__heap_ptr` before/after `_start` and prints the delta.
+    mem_env=""
+    [ "$mem" = "1" ] && mem_env="VIBE_MEM=1"
     # span-arc step5: line-granularity breakpoints. A `--break <file>:<line>` (or
     # bare `<line>`) spec passes through VIBE_BREAK unchanged; the runner resolves
     # the entering function's source line via the `.funcmap` sidecar (name<TAB>
@@ -373,7 +381,7 @@ case "$cmd" in
     rerr_fifo="$(mktemp -u -t vibe-run-err-XXXXXX)"; mkfifo "$rerr_fifo"
     annotate_run_stream "$out.funcmap" "$(basename "$src")" < "$rerr_fifo" >&2 &
     annot_pid=$!
-    env $trace_env $break_env $funcmap_env $breakfile_env "$RUNNER" "$out" 2>"$rerr_fifo" || status=$?
+    env $trace_env $break_env $mem_env $funcmap_env $breakfile_env "$RUNNER" "$out" 2>"$rerr_fifo" || status=$?
     wait "$annot_pid" 2>/dev/null || true
     rm -f "$rerr_fifo"
     exit "$status"

--- a/scripts/test_vibe_mem.sh
+++ b/scripts/test_vibe_mem.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Integration test for `vibe run --mem` (memory profiling tier 1): the runner
+# reads the `__heap_ptr` bump-allocator pointer before/after `_start` and reports
+# peak / total allocated to stderr. A pure program allocates ~nothing; an
+# allocation-heavy program reports a real, larger figure. stdout stays clean.
+#
+# Installs a FRESH toolchain into a throwaway VIBE_HOME/VIBE_BIN_DIR (mirrors
+# scripts/test_vibe_step.sh) so it never touches a real install.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RT="$ROOT_DIR/tools/moonrun_wasmtime/target/release/moonrun_wt"
+if [ ! -x "$RT" ] || [ -n "$(find tools/moonrun_wasmtime/src -name "*.rs" -newer "$RT" 2>/dev/null | head -1)" ]; then
+  cargo build --release --manifest-path tools/moonrun_wasmtime/Cargo.toml >/dev/null
+fi
+
+cli="$(bash scripts/build_cli_wasm.sh)"
+[ -s "$cli" ] || { echo "FAIL: no CLI wasm built" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export VIBE_HOME="$WORK/home"
+export VIBE_BIN_DIR="$WORK/bin"
+unset RUST_BACKTRACE || true
+
+echo "[test] installing fresh CLI into $VIBE_HOME"
+bash scripts/install.sh --cli-wasm "$cli" >/dev/null 2>&1
+VIBE="$VIBE_BIN_DIR/vibe"
+[ -x "$VIBE" ] || { echo "FAIL: launcher not installed" >&2; exit 1; }
+
+pass=0; fail=0
+ok()  { echo "ok: $1"; pass=$((pass+1)); }
+bad() { echo "FAIL: $1" >&2; fail=$((fail+1)); }
+
+proj="$WORK/proj"; mkdir -p "$proj"
+cat > "$proj/pure.vibe" <<'EOF'
+let add = (a: Int, b: Int) -> Int { a + b }
+let main = () -> Int { add(2, 3) }
+EOF
+# Allocation-heavy: O(n^2) string build allocates a fresh string each iteration.
+cat > "$proj/alloc.vibe" <<'EOF'
+let build = (n: Int) -> String {
+  let mut s = ""
+  let mut i = 0
+  while i < n {
+    s = String::concat(s, "x")
+    i = i + 1
+  }
+  s
+}
+let main = () -> Int { String::length(build(500)) }
+EOF
+
+# 1. plain run emits NO memory report.
+plain_err="$("$VIBE" run "$proj/pure.vibe" 2>&1 >/dev/null)"
+if printf '%s' "$plain_err" | grep -q "vibe::mem"; then bad "plain run leaked a memory report"; else ok "plain run emits no memory report"; fi
+
+# 2. --mem emits the machine-readable line + keeps stdout clean.
+pure_out="$("$VIBE" run --mem "$proj/pure.vibe" 2>/dev/null)"
+pure_err="$("$VIBE" run --mem "$proj/pure.vibe" 2>&1 >/dev/null)"
+[ "$(printf '%s' "$pure_out" | tr -dc '0-9')" = "5" ] && ok "--mem: stdout is just the program output (5)" || bad "--mem: stdout polluted (got: $pure_out)"
+printf '%s\n' "$pure_err" | grep -qE "vibe::mem heap_base=[0-9]+ heap_peak=[0-9]+ allocated=[0-9]+ committed=[0-9]+" \
+  && ok "--mem: machine-readable line present" || bad "--mem: missing machine-readable line (got: $pure_err)"
+
+# 3. pure program allocates ~0 bytes.
+pure_alloc="$(printf '%s\n' "$pure_err" | grep -oE 'allocated=[0-9]+' | head -1 | cut -d= -f2)"
+[ "${pure_alloc:-x}" = "0" ] && ok "pure program allocates 0 bytes" || bad "pure program allocated=$pure_alloc (expected 0)"
+
+# 4. allocation-heavy program reports a substantial figure (> 10 KiB).
+alloc_err="$("$VIBE" run --mem "$proj/alloc.vibe" 2>&1 >/dev/null)"
+alloc_bytes="$(printf '%s\n' "$alloc_err" | grep -oE 'allocated=[0-9]+' | head -1 | cut -d= -f2)"
+if [ -n "$alloc_bytes" ] && [ "$alloc_bytes" -gt 10240 ]; then
+  ok "alloc-heavy program reports >10 KiB (allocated=$alloc_bytes)"
+else
+  bad "alloc-heavy program allocated=$alloc_bytes (expected >10240)"
+fi
+
+# 5. the human line is present too.
+printf '%s\n' "$alloc_err" | grep -qE "vibe: memory — allocated .* peak heap .* committed " \
+  && ok "--mem: human-readable summary present" || bad "--mem: missing human summary (got: $alloc_err)"
+
+echo "[test_vibe_mem] $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/tools/moonrun_wasmtime/src/main.rs
+++ b/tools/moonrun_wasmtime/src/main.rs
@@ -446,6 +446,14 @@ fn run(args: Vec<String>) -> Result<i32> {
 
     let instance = linker.instantiate(&mut store, &module)?;
     let start: TypedFunc<(), ()> = instance.get_typed_func(&mut store, "_start")?;
+    // Memory profiling (tier 1): `__heap_ptr` is the bump-allocator high-water
+    // mark. Read it right after instantiation (the static-data base, before any
+    // program allocation) and again after the run; the delta is everything the
+    // program — and host-produced strings — allocated. No instrumentation, ~zero
+    // overhead. Gated by VIBE_MEM=1 (set by `vibe run --mem`).
+    let mem_profile = std::env::var("VIBE_MEM").as_deref() == Ok("1");
+    let heap_base = if mem_profile { read_heap_ptr(&instance, &mut store) } else { None };
+
     let result = start.call(&mut store, ());
 
     // Flush buffered prints if execution didn't end with a newline.
@@ -465,6 +473,16 @@ fn run(args: Vec<String>) -> Result<i32> {
     // success OR trap, mirroring the coverage-bitmap read model.
     if std::env::var("VIBE_TRACE_OUT").as_deref() == Ok("1") {
         dump_trace(wasm_path, &instance, &mut store);
+    }
+
+    // Emit the memory report after the run (success OR trap), mirroring the trace
+    // dump model, so a program that traps still reports what it allocated.
+    if mem_profile {
+        let heap_peak = read_heap_ptr(&instance, &mut store);
+        let committed = instance
+            .get_memory(&mut store, "memory")
+            .map(|m| m.data_size(&store) as u64);
+        report_memory(heap_base, heap_peak, committed);
     }
 
     match result {
@@ -945,6 +963,53 @@ fn vibe_ensure_parent_dir(path: &str) {
         if !dir.as_os_str().is_empty() {
             let _ = fs::create_dir_all(dir);
         }
+    }
+}
+
+// Read the `__heap_ptr` bump-allocator pointer (an i32/i64 mut global) as bytes,
+// or None when the module doesn't export it. Used by the `--mem` memory report.
+fn read_heap_ptr(instance: &wasmtime::Instance, store: &mut Store<HostState>) -> Option<u64> {
+    let g = instance.get_global(&mut *store, "__heap_ptr")?;
+    match g.get(&mut *store) {
+        Val::I32(v) => Some(v as u32 as u64),
+        Val::I64(v) => Some(v as u64),
+        _ => None,
+    }
+}
+
+// Human-readable byte size (binary units).
+fn human_bytes(n: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut v = n as f64;
+    let mut i = 0;
+    while v >= 1024.0 && i < UNITS.len() - 1 {
+        v /= 1024.0;
+        i += 1;
+    }
+    if i == 0 {
+        format!("{n} B")
+    } else {
+        format!("{v:.1} {}", UNITS[i])
+    }
+}
+
+// Print the `--mem` report to stderr: a machine-readable line + a human line.
+// `allocated` = peak − base (everything the run bump-allocated; the linear
+// backend never frees, so peak == total). `committed` = wasm memory pages.
+fn report_memory(base: Option<u64>, peak: Option<u64>, committed: Option<u64>) {
+    match (base, peak) {
+        (Some(b), Some(p)) => {
+            let allocated = p.saturating_sub(b);
+            let c = committed.unwrap_or(0);
+            eprintln!("vibe::mem heap_base={b} heap_peak={p} allocated={allocated} committed={c}");
+            eprintln!(
+                "vibe: memory — allocated {} ({allocated} B), peak heap {}, committed {}",
+                human_bytes(allocated),
+                human_bytes(p),
+                human_bytes(c),
+            );
+        }
+        _ => eprintln!("vibe: memory — unavailable (module exports no `__heap_ptr` global)"),
     }
 }
 


### PR DESCRIPTION
## 概要

プロファイリング設計（`docs/spec/profiling.md`）の **tier 1** を実装。プログラムが**どれだけ確保したか**を、計装ゼロで報告する。

## 仕組み

linear backend は **bump allocator** — `__heap_ptr`（export 済み i32 mut global）が単調増加のヒープ先端で、**free がない（arena）**。よって 1 回の実行で **peak == total allocated**。`vibe run --mem` は runner が `_start` の**前**（static-data ベース、確保前）と**後**で `__heap_ptr` を読み、その差分を「allocated」として出す。

```
$ vibe run --mem prog.vibe
<program stdout>
vibe::mem heap_base=131144 heap_peak=258152 allocated=127008 committed=4194304
vibe: memory — allocated 124.0 KiB (127008 B), peak heap 252.1 KiB, committed 4.0 MiB
```

- `vibe::mem …` = 機械可読（bench harness / CI が parse）
- `vibe: memory — …` = 人間可読
- stdout は汚さず stderr に出力、**trap しても出る**

## 効果

- pure / 純計算: `allocated=0`
- `String::concat` ループで 500 文字を O(n²) 構築: **~124 KiB** → 非効率をそのまま可視化

## 変更点

- **runner**: `VIBE_MEM=1` ゲート ＋ `read_heap_ptr` / `report_memory` / `human_bytes`
- **launcher**: `vibe run --mem` → `VIBE_MEM=1`
- **docs/spec/profiling.md**: メモリモデル ＋ tier ロードマップ（grow イベント / 時系列サンプリング / サイト別属性）＋ これを再利用するベンチマーカー設計
- **scripts/test_vibe_mem.sh**（6 assertions）を cli-install に配線

## メモ

linear は free がないので tier 1 は *アロケーション* プロファイル（総量）で live-set ではない。live-set は wasm-gc backend（host GC）側。次段は bench harness への組み込み（bytes/op）と growth タイムライン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c)_