### PR TITLE
runner: vibe bench — ns/op + bytes/op benchmark harness

### DIFF
--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -26,6 +26,7 @@ on:
       - "scripts/test_vibe_symbols.sh"
       - "scripts/test_vibe_step.sh"
       - "scripts/test_vibe_mem.sh"
+      - "scripts/test_vibe_bench.sh"
       - "scripts/test_vibe_dap.js"
       - "js/vibe/dap_server.js"
       - "scripts/test_vibe_break_args.sh"
@@ -58,6 +59,7 @@ on:
       - "scripts/test_vibe_symbols.sh"
       - "scripts/test_vibe_step.sh"
       - "scripts/test_vibe_mem.sh"
+      - "scripts/test_vibe_bench.sh"
       - "scripts/test_vibe_dap.js"
       - "js/vibe/dap_server.js"
       - "scripts/test_vibe_break_args.sh"
@@ -165,6 +167,9 @@ jobs:
 
       - name: Memory profiling (vibe run --mem) regression test
         run: bash scripts/test_vibe_mem.sh
+
+      - name: Benchmark harness (vibe bench) regression test
+        run: bash scripts/test_vibe_bench.sh
 
       - name: Binding occurrences (vibe binding-at) regression test
         run: bash scripts/test_vibe_binding_at.sh

--- a/docs/spec/profiling.md
+++ b/docs/spec/profiling.md
@@ -44,15 +44,32 @@ pure / 純計算プログラムは `allocated=0`。`committed` は wasm memory �
 実装: runner は `VIBE_MEM=1`（`--mem` が設定）のとき `__heap_ptr`（`read_heap_ptr`）と
 `memory` サイズを読んで `report_memory` で出力（trap しても出る）。test: `scripts/test_vibe_mem.sh`。
 
-## ベンチマーカー設計（次段）
+## `vibe bench`（実装済み）
 
-`bench "name" { }` 構文と `vibe::profile-now-us`（µs clock）は既にある。harness を足す:
+`bench "name" { }` 構文と `vibe::profile-now-us` はあったが計測ハーネスが無かった。`vibe bench`
+を追加した。実装は runner 側（`moonrun_wt --bench`）で、**codegen 変更なし**:
 
-- warmup → 反復自動スケール（合計 T µs まで / 安定まで）、µs 解像度対策に内側 batch（K 回回して割る）
-- 統計: min / median / mean / stddev / p95 / ops·sec、外れ値トリム
-- **メモリ併記**: 各 bench で `__heap_ptr` 差分（bytes/op）を時間と並べる（tier 1 を再利用）
-- 2 backend（linear / gc）を別レポート
-- 回帰検出: `(name, backend, source-hash)` で baseline 比較、% 退行を flag → CI ゲート
+- 再実行可能な test entry（`__no_entry__` が `bench{}`/`test{}` body を走らせる `_start`）を、
+  **同一の warm インスタンス上で N 回呼ぶ**。warmup → 計測。
+- 各呼び出しを `Instant` で計時し、`__heap_ptr` をバッチ前後で読んで **bytes/op**（tier 1 を再利用）。
+- 統計: **min / p50 / p95 / mean / ops·sec** ＋ **bytes/op**。
+
+```
+$ vibe bench examples/simple_bench.vibe
+vibe::bench label=simple_bench.vibe iters=1000 ns_min=47 ns_p50=49 ns_p95=51 ns_mean=49 ops_per_sec=20408163 bytes_per_op=0
+bench simple_bench.vibe: 1000 iters — 49 ns/op (min 47 ns, p50 49 ns, p95 51 ns), 20.4M ops/s, 0 B/op
+```
+
+`vibe bench <file> [--iters N] [--warmup N]`。`vibe::bench …` は機械可読（CI/比較が parse）。
+env: `VIBE_BENCH_ITERS` / `VIBE_BENCH_WARMUP` / `VIBE_BENCH_LABEL`。test: `scripts/test_vibe_bench.sh`。
+
+**現状の粒度と限界**: `__bench_*` は未 export なので **ファイル単位**（その file の bench/test body の和）
+で測る。`*_bench.vibe` に bench を 1 つ置く運用なら実質ピンポイント。次段で精度を上げるなら:
+
+- `__bench_<name>` を export → runner が **bench ブロック個別**に計時（codegen 変更が要る）
+- µs 級でなく ns 級を狙うなら内側 batch（K 回回して割る）で per-call overhead を相殺
+- 2 backend（linear / gc）の別レポート
+- 回帰検出: `(label, backend, source-hash)` で baseline 比較、% 退行を flag → CI ゲート
 
 ## 注意点
 

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -33,6 +33,9 @@
 #   vibe symbols <file.vibe>              print declaration outline (NAME KIND START END per line)
 #   vibe diagnostics <file.vibe>          print all syntax/type diagnostics
 #   vibe test    <file_test.vibe>...      compile + run test {} blocks
+#   vibe bench   <file.vibe> [--iters N] [--warmup N]
+#                                         run bench {} blocks; report ns/op
+#                                         (min/p50/p95/mean), ops/sec, bytes/op
 #   vibe new     <dir>                    scaffold a starter project
 #   vibe add     <name> <url> [dir]       add a dependency to vibe.deps + fetch
 #   vibe fetch   [--frozen] [dir]        vendor git/URL deps from vibe.deps + lock
@@ -538,6 +541,31 @@ case "$cmd" in
       rm -f "$out"
     done
     exit "$failed"
+    ;;
+  bench)
+    # `vibe bench <file.vibe> [--iters N] [--warmup N]` — compile the file's
+    # `bench {}` blocks (via the `__no_entry__` test entry) then run the warm
+    # instance N times, reporting ns/op (min/p50/p95/mean), ops/sec, and bytes/op
+    # (bump-heap delta / iters). The harness lives in the runner (`--bench`).
+    iters=""; warmup=""; bsrc=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --iters) iters="$2"; shift 2 ;;
+        --iters=*) iters="${1#--iters=}"; shift ;;
+        --warmup) warmup="$2"; shift 2 ;;
+        --warmup=*) warmup="${1#--warmup=}"; shift ;;
+        *) bsrc="$1"; shift ;;
+      esac
+    done
+    [ -n "$bsrc" ] || die "usage: vibe bench <file.vibe> [--iters N] [--warmup N]"
+    [ -f "$bsrc" ] || die "not found: $bsrc"
+    out="$(mktemp -t vibe-bench-XXXXXX.wasm)"
+    trap 'rm -f "$out"' EXIT
+    compile_to "$bsrc" "$out" "__no_entry__" || die "compilation failed: $bsrc"
+    bench_env="VIBE_BENCH_LABEL=$(basename "$bsrc")"
+    [ -n "$iters" ] && bench_env="$bench_env VIBE_BENCH_ITERS=$iters"
+    [ -n "$warmup" ] && bench_env="$bench_env VIBE_BENCH_WARMUP=$warmup"
+    env $bench_env "$RUNNER" --bench "$out"
     ;;
   new)
     # vibe new <dir>  — scaffold a starter project (main.vibe + empty vibe.deps)

--- a/scripts/test_vibe_bench.sh
+++ b/scripts/test_vibe_bench.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Integration test for `vibe bench`: compile a file's `bench {}` blocks and run
+# the warm instance N times, reporting ns/op (min/p50/p95/mean), ops/sec, and
+# bytes/op (bump-heap delta / iters — reuses the --mem tier-1 foundation). A pure
+# bench allocates 0 B/op; an allocation-heavy bench reports a real figure.
+#
+# Fresh throwaway install (mirrors scripts/test_vibe_mem.sh).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RT="$ROOT_DIR/tools/moonrun_wasmtime/target/release/moonrun_wt"
+if [ ! -x "$RT" ] || [ -n "$(find tools/moonrun_wasmtime/src -name "*.rs" -newer "$RT" 2>/dev/null | head -1)" ]; then
+  cargo build --release --manifest-path tools/moonrun_wasmtime/Cargo.toml >/dev/null
+fi
+
+cli="$(bash scripts/build_cli_wasm.sh)"
+[ -s "$cli" ] || { echo "FAIL: no CLI wasm built" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+export VIBE_HOME="$WORK/home"
+export VIBE_BIN_DIR="$WORK/bin"
+unset RUST_BACKTRACE || true
+
+echo "[test] installing fresh CLI into $VIBE_HOME"
+bash scripts/install.sh --cli-wasm "$cli" >/dev/null 2>&1
+VIBE="$VIBE_BIN_DIR/vibe"
+[ -x "$VIBE" ] || { echo "FAIL: launcher not installed" >&2; exit 1; }
+
+pass=0; fail=0
+ok()  { echo "ok: $1"; pass=$((pass+1)); }
+bad() { echo "FAIL: $1" >&2; fail=$((fail+1)); }
+field() { printf '%s\n' "$1" | grep -oE "$2=[0-9]+" | head -1 | cut -d= -f2; }
+
+proj="$WORK/proj"; mkdir -p "$proj"
+cat > "$proj/pure_bench.vibe" <<'EOF'
+let add = (a: Int, b: Int) -> Int { a + b }
+bench "pure_add" { let _ = add(2, 3) }
+EOF
+cat > "$proj/alloc_bench.vibe" <<'EOF'
+let build = (n: Int) -> String {
+  let mut s = ""
+  let mut i = 0
+  while i < n { s = String::concat(s, "x"); i = i + 1 }
+  s
+}
+bench "build" { let _ = String::length(build(50)) }
+EOF
+
+# 1. pure bench: machine-readable line, bytes_per_op = 0, ops_per_sec present.
+pure_out="$("$VIBE" bench "$proj/pure_bench.vibe" --iters 200 --warmup 10 2>&1)"
+printf '%s\n' "$pure_out" | grep -qE "vibe::bench label=.* iters=200 .* ops_per_sec=[0-9]+ bytes_per_op=[0-9]+" \
+  && ok "pure: machine-readable bench line present" || bad "pure: missing/garbled bench line (got: $pure_out)"
+[ "$(field "$pure_out" iters)" = "200" ] && ok "--iters respected (200)" || bad "--iters not respected (got: $(field "$pure_out" iters))"
+[ "$(field "$pure_out" bytes_per_op)" = "0" ] && ok "pure bench: 0 bytes/op" || bad "pure bench bytes_per_op=$(field "$pure_out" bytes_per_op) (expected 0)"
+pops="$(field "$pure_out" ops_per_sec)"
+[ -n "$pops" ] && [ "$pops" -gt 0 ] && ok "ops_per_sec reported (> 0)" || bad "ops_per_sec not > 0 (got: $pops)"
+
+# 2. alloc bench: bytes_per_op > 0.
+alloc_out="$("$VIBE" bench "$proj/alloc_bench.vibe" --iters 200 2>&1)"
+abytes="$(field "$alloc_out" bytes_per_op)"
+if [ -n "$abytes" ] && [ "$abytes" -gt 0 ]; then
+  ok "alloc bench reports bytes/op > 0 (bytes_per_op=$abytes)"
+else
+  bad "alloc bench bytes_per_op=$abytes (expected > 0)"
+fi
+
+# 3. percentile fields present + ordered (min <= p50 <= p95 not required strictly,
+#    but all three must be present and numeric).
+for f in ns_min ns_p50 ns_p95 ns_mean; do
+  v="$(field "$alloc_out" "$f")"
+  [ -n "$v" ] && ok "$f present ($v)" || bad "$f missing"
+done
+
+# 4. human summary line present.
+printf '%s\n' "$alloc_out" | grep -qE "bench .*: 200 iters — .*/op .*ops/s" \
+  && ok "human summary line present" || bad "missing human summary (got: $alloc_out)"
+
+echo "[test_vibe_bench] $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/tools/moonrun_wasmtime/src/main.rs
+++ b/tools/moonrun_wasmtime/src/main.rs
@@ -514,6 +514,135 @@ fn run(args: Vec<String>) -> Result<i32> {
     }
 }
 
+// Format a nanosecond duration with an adaptive unit.
+fn fmt_ns(ns: u128) -> String {
+    if ns < 1_000 {
+        format!("{ns} ns")
+    } else if ns < 1_000_000 {
+        format!("{:.2} µs", ns as f64 / 1_000.0)
+    } else if ns < 1_000_000_000 {
+        format!("{:.2} ms", ns as f64 / 1_000_000.0)
+    } else {
+        format!("{:.2} s", ns as f64 / 1_000_000_000.0)
+    }
+}
+
+// Format an ops/second figure with a k/M suffix.
+fn fmt_ops(ops: f64) -> String {
+    if ops >= 1_000_000.0 {
+        format!("{:.1}M", ops / 1_000_000.0)
+    } else if ops >= 1_000.0 {
+        format!("{:.0}k", ops / 1_000.0)
+    } else {
+        format!("{ops:.0}")
+    }
+}
+
+// Benchmark mode. Instantiate ONCE, then call `_start` (which the test entry
+// builds to run the file's `bench {}`/`test {}` bodies) repeatedly on the WARM
+// instance, timing each call and reading `__heap_ptr` before/after the batch for
+// bytes/op. Reuses the re-runnable entry, so NO codegen change is needed; the
+// granularity is the whole file's bench blocks. Reports ns/op (min/p50/p95/mean),
+// ops/sec, and bytes/op (bump-heap delta / iters — the linear backend never frees
+// so this is the average allocation per iteration).
+//
+//   moonrun_wt --bench <wasm|cwasm>
+// Env: VIBE_BENCH_ITERS (default 1000), VIBE_BENCH_WARMUP (default 50),
+//      VIBE_BENCH_LABEL (report label; default the wasm path).
+fn bench(args: Vec<String>) -> Result<i32> {
+    if args.is_empty() {
+        bail!("--bench: missing <wasm|cwasm> argument");
+    }
+    let wasm_path = &args[0];
+    let iters: u64 = std::env::var("VIBE_BENCH_ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(1000);
+    let warmup: u64 = std::env::var("VIBE_BENCH_WARMUP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(50);
+    let label = std::env::var("VIBE_BENCH_LABEL").unwrap_or_else(|_| wasm_path.clone());
+
+    let cfg = engine_config();
+    let engine = Engine::new(&cfg)?;
+    let module = load_module(&engine, wasm_path)?;
+    let memory_mb: usize = std::env::var("MOONRUN_WT_MEMORY_MB")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8192);
+    let limits = StoreLimitsBuilder::new()
+        .memory_size(memory_mb * 1024 * 1024)
+        .build();
+    let mut state = HostState::new(vec!["moonrun_wt".to_string()], limits);
+    state.capture_stdout = true; // suppress per-iteration program output
+    let mut store = Store::new(&engine, state);
+    store.limiter(|s| &mut s.limits);
+    let mut linker = Linker::new(&engine);
+    register_imports(&mut linker)?;
+    let instance = linker.instantiate(&mut store, &module)?;
+    let start: TypedFunc<(), ()> = instance.get_typed_func(&mut store, "_start")?;
+
+    let run_once = |store: &mut Store<HostState>, phase: &str| -> Result<()> {
+        store.data_mut().captured_stdout.clear();
+        match start.call(&mut *store, ()) {
+            Ok(()) => Ok(()),
+            // A clean `proc_exit(0)` is fine; any other trap aborts the bench.
+            Err(e) => match e.downcast_ref::<ExitTrap>() {
+                Some(ExitTrap(0)) => Ok(()),
+                Some(ExitTrap(code)) => bail!("bench `{label}`: exit({code}) during {phase}"),
+                None => bail!("bench `{label}`: trap during {phase}: {e}"),
+            },
+        }
+    };
+
+    // Warmup also pays one-time lazy init so it doesn't skew the first sample.
+    for _ in 0..warmup {
+        run_once(&mut store, "warmup")?;
+    }
+
+    let heap_before = read_heap_ptr(&instance, &mut store);
+    let mut samples: Vec<u128> = Vec::with_capacity(iters as usize);
+    for _ in 0..iters {
+        let t0 = Instant::now();
+        run_once(&mut store, "measurement")?;
+        samples.push(t0.elapsed().as_nanos());
+    }
+    let heap_after = read_heap_ptr(&instance, &mut store);
+
+    samples.sort_unstable();
+    let n = samples.len();
+    let sum: u128 = samples.iter().sum();
+    let mean = sum / n as u128;
+    let min = samples[0];
+    let p50 = samples[(n / 2).min(n - 1)];
+    let p95 = samples[(n * 95 / 100).min(n - 1)];
+    let ops_per_sec = if mean > 0 { 1_000_000_000f64 / mean as f64 } else { 0.0 };
+    let bytes_per_op = match (heap_before, heap_after) {
+        (Some(b), Some(a)) => Some(a.saturating_sub(b) / iters),
+        _ => None,
+    };
+
+    // Machine-readable line (tools/CI parse this) + a human summary, both stdout.
+    println!(
+        "vibe::bench label={label} iters={iters} ns_min={min} ns_p50={p50} ns_p95={p95} ns_mean={mean} ops_per_sec={ops_per_sec:.0} bytes_per_op={}",
+        bytes_per_op.map(|b| b.to_string()).unwrap_or_else(|| "na".into()),
+    );
+    println!(
+        "bench {label}: {iters} iters — {}/op (min {}, p50 {}, p95 {}), {} ops/s, {}",
+        fmt_ns(mean),
+        fmt_ns(min),
+        fmt_ns(p50),
+        fmt_ns(p95),
+        fmt_ops(ops_per_sec),
+        bytes_per_op
+            .map(|b| format!("{}/op", human_bytes(b)))
+            .unwrap_or_else(|| "mem n/a".into()),
+    );
+    Ok(0)
+}
+
 // Long-running daemon: instantiate the wasm module ONCE and reuse the
 // store/instance across many requests. moonbit module-level state
 // (top-level let-bindings, e.g. `default_typecheck_session` which holds
@@ -2114,6 +2243,16 @@ fn main() {
             Ok(code) => std::process::exit(code),
             Err(e) => {
                 eprintln!("moonrun_wt: daemon failed: {e:?}");
+                std::process::exit(1);
+            }
+        }
+    }
+    if args.first().map(|s| s.as_str()) == Some("--bench") {
+        let bench_args: Vec<String> = args.iter().skip(1).cloned().collect();
+        match bench(bench_args) {
+            Ok(code) => std::process::exit(code),
+            Err(e) => {
+                eprintln!("moonrun_wt: {e}");
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
## 概要

メモリ計測（bytes/op）を **`vibe bench` に組み込んだ**。`bench "name" {}` 構文はあったが計測ハーネスが無く、テストとして 1 回走るだけだった。runner 側にハーネスを足す（**codegen 変更なし**）。

## 仕組み

`moonrun_wt --bench <wasm>` は 1 回 instantiate し、再実行可能な test entry（`__no_entry__` が `bench{}`/`test{}` body を走らせる `_start`）を**同じ warm インスタンス上で N 回**呼ぶ:

1. warmup → 計測（各呼び出しを `Instant` で計時）
2. `__heap_ptr` をバッチ前後で読み **bytes/op**（#652 の `--mem` tier-1 を再利用）
3. 統計: **min / p50 / p95 / mean / ops·sec ＋ bytes/op**

```
$ vibe bench examples/simple_bench.vibe
vibe::bench label=simple_bench.vibe iters=1000 ns_min=47 ns_p50=49 ns_p95=51 ns_mean=49 ops_per_sec=20408163 bytes_per_op=0
bench simple_bench.vibe: 1000 iters — 49 ns/op (min 47 ns, p50 49 ns, p95 51 ns), 20.4M ops/s, 0 B/op
```

- 純計算 bench → **0 B/op**
- `String::concat` ループ bench → **~1.4 KiB/op**（時間と確保量を並記）
- `vibe::bench …` 行は機械可読（CI / 比較用）

## 変更点

- **runner**: `--bench` モード ＋ `bench()` / `fmt_ns` / `fmt_ops`（env: `VIBE_BENCH_ITERS` / `WARMUP` / `LABEL`）
- **launcher**: `vibe bench <file> [--iters N] [--warmup N]`
- **docs/spec/profiling.md**: ベンチマーカーを「実装済み」に更新、限界と次段を明記
- **scripts/test_vibe_bench.sh**（10 assertions）を cli-install に配線

## 限界（明記）

`__bench_*` は未 export なので粒度は**ファイル単位**（その file の bench/test body の和）。`*_bench.vibe` に bench を 1 つ置く運用なら実質ピンポイント。per-block にするには `__bench_<name>` を export する codegen 変更が要る（次段）。`_start` の warm 再実行可能性は実測で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c)_