### PR TITLE
runner: memory growth timeline (profiling tier 2)

### DIFF
--- a/docs/spec/profiling.md
+++ b/docs/spec/profiling.md
@@ -19,7 +19,7 @@ guest＋host を合わせた総ヒープ使用量を表す。
 | tier | 内容 | 計装 | 状態 |
 |---|---|---|---|
 | **1** | 総ヒープ / ピーク（`__heap_ptr` 差分）| ゼロ | ✅ **実装済み**: `vibe run --mem` |
-| 2 | `memory.grow` イベント（成長タイムライン）| ホストのみ | 設計済み（wasmtime `ResourceLimiter`）|
+| **2** | `memory.grow` イベント（成長タイムライン）| ホストのみ | ✅ **実装済み**: `--mem` の一部 |
 | 3 | アロケーション時系列サンプリング | `dbg_line` / epoch 流用 | 設計済み |
 | 4 | サイト別 alloc 属性（massif/heaptrack 相当）| opt-in ビルド（`vibe::alloc_site`）| 設計済み |
 
@@ -43,6 +43,31 @@ pure / 純計算プログラムは `allocated=0`。`committed` は wasm memory �
 
 実装: runner は `VIBE_MEM=1`（`--mem` が設定）のとき `__heap_ptr`（`read_heap_ptr`）と
 `memory` サイズを読んで `report_memory` で出力（trap しても出る）。test: `scripts/test_vibe_mem.sh`。
+
+## Tier 2: 成長タイムライン（実装済み）
+
+`--mem` 実行時、runner は wasmtime の `ResourceLimiter`（`MemLimiter`）で `memory.grow` を
+すべて記録する。guest の `memory.grow` も host の `Memory::grow`（bump 文字列確保）も
+wasmtime はこの limiter を通すので、タイムラインは完全。計装ゼロ・ホスト側のみ。
+
+```
+$ vibe run --mem grow.vibe          # >4 MiB を確保するプログラム
+vibe::mem heap_base=131144 heap_peak=6270152 allocated=6139008 committed=6291456 grow_events=32
+vibe: memory — allocated 5.9 MiB …, committed 6.0 MiB, 32 growth event(s)
+vibe::memgrow t_us=2066 from=4194304 to=4259840 pages=+1
+vibe::memgrow t_us=2107 from=4259840 to=4325376 pages=+1
+…
+vibe:   growth 4.0 MiB -> 6.0 MiB across 32 event(s), 2.07 ms … 2.50 ms
+```
+
+各 `vibe::memgrow` 行は機械可読（`t_us` = run 開始からの経過、`from`/`to` = bytes、`pages` = 追加ページ）。
+
+**限界**: 生成 wasm の初期メモリは **64 ページ（4 MiB, `default_wasi_memory_min_pages`）** なので、
+4 MiB 未満で収まるプログラムは grow が発生せず `grow_events=0`。つまりこれは**ページコミットの
+粗いタイムライン**（4 MiB 超のときに有効）。細粒度のアロケーション曲線が要るなら tier 3
+（`__heap_ptr` を `dbg_line`/epoch でサンプリング）。
+上の例は bump allocator が **1 ページ（64 KiB）ずつ** grow していることも示している
+（syscall を減らすなら成長チャンクを大きくする余地）。
 
 ## `vibe bench`（実装済み）
 

--- a/scripts/test_vibe_mem.sh
+++ b/scripts/test_vibe_mem.sh
@@ -81,5 +81,31 @@ fi
 printf '%s\n' "$alloc_err" | grep -qE "vibe: memory — allocated .* peak heap .* committed " \
   && ok "--mem: human-readable summary present" || bad "--mem: missing human summary (got: $alloc_err)"
 
+# 6. growth timeline (tier 2): small program stays within the 4 MiB initial
+#    memory -> 0 grow events; a >4 MiB allocator -> grow events + memgrow lines.
+printf '%s\n' "$alloc_err" | grep -qE "grow_events=0\b" \
+  && ok "small program: 0 growth events (stays within initial memory)" \
+  || bad "small program: expected grow_events=0 (got: $(printf '%s' "$alloc_err" | grep -oE 'grow_events=[0-9]+'))"
+
+cat > "$proj/grow.vibe" <<'EOF'
+let build = (n: Int) -> Int {
+  let mut s = ""
+  let mut i = 0
+  while i < n { s = String::concat(s, "x"); i = i + 1 }
+  String::length(s)
+}
+let main = () -> Int { build(3500) }
+EOF
+grow_err="$("$VIBE" run --mem "$proj/grow.vibe" 2>&1 >/dev/null)"
+gcount="$(printf '%s\n' "$grow_err" | grep -oE 'grow_events=[0-9]+' | head -1 | cut -d= -f2)"
+if [ -n "$gcount" ] && [ "$gcount" -gt 0 ]; then
+  ok ">4 MiB program records growth events (grow_events=$gcount)"
+else
+  bad ">4 MiB program expected grow_events>0 (got: $gcount)"
+fi
+printf '%s\n' "$grow_err" | grep -qE "vibe::memgrow t_us=[0-9]+ from=[0-9]+ to=[0-9]+ pages=\+[0-9]+" \
+  && ok "growth timeline emits machine-readable memgrow lines" \
+  || bad "missing memgrow line (got: $(printf '%s\n' "$grow_err" | grep memgrow | head -1))"
+
 echo "[test_vibe_mem] $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/tools/moonrun_wasmtime/src/main.rs
+++ b/tools/moonrun_wasmtime/src/main.rs
@@ -21,8 +21,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use wasmtime::{
-    bail, format_err, Caller, Config, Engine, ExternRef, ExternType, Linker, Module, Result,
-    Rooted, Store, StoreLimits, StoreLimitsBuilder, Strategy, TypedFunc, Val, ValType,
+    bail, format_err, Caller, Config, Engine, ExternRef, ExternType, Linker, Module, ResourceLimiter,
+    Result, Rooted, Store, StoreLimits, StoreLimitsBuilder, Strategy, TypedFunc, Val, ValType,
 };
 
 const FFI_END_OF_STRING_ARRAY: &str = "ffi_end_of_/string_array";
@@ -80,13 +80,55 @@ struct StringArrayReader {
     pos: usize,
 }
 
+// Memory ResourceLimiter that delegates the size cap to an inner StoreLimits but
+// also records every accepted `memory.grow` as a growth-timeline event (tier 2
+// of docs/spec/profiling.md). Recording is gated (`record`) so non-profiling runs
+// pay nothing. wasmtime routes BOTH guest `memory.grow` and host `Memory::grow`
+// (the bump-string allocator) through this, so the timeline is complete.
+struct MemLimiter {
+    inner: StoreLimits,
+    record: bool,
+    start: Instant,
+    // (elapsed_ns, from_bytes, to_bytes) per accepted growth.
+    events: Vec<(u128, u64, u64)>,
+}
+
+impl MemLimiter {
+    fn new(inner: StoreLimits) -> Self {
+        MemLimiter { inner, record: false, start: Instant::now(), events: Vec::new() }
+    }
+}
+
+impl ResourceLimiter for MemLimiter {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> Result<bool> {
+        let allowed = self.inner.memory_growing(current, desired, maximum)?;
+        if self.record && allowed && desired > current {
+            self.events.push((self.start.elapsed().as_nanos(), current as u64, desired as u64));
+        }
+        Ok(allowed)
+    }
+    fn table_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> Result<bool> {
+        self.inner.table_growing(current, desired, maximum)
+    }
+}
+
 struct HostState {
     last_error: Option<String>,
     args: Arc<Vec<String>>,
     print_buf: Vec<u16>,
     pending_bytes: Option<Arc<Vec<u8>>>,
     pending_strings: Option<Arc<Vec<String>>>,
-    limits: StoreLimits,
+    mem: MemLimiter,
     // Daemon mode: when set, print_char's flushed lines go into
     // captured_stdout instead of host stdout. The daemon loop emits
     // them as part of the per-request JSON response envelope so they
@@ -160,7 +202,7 @@ enum StepMode {
 }
 
 impl HostState {
-    fn new(args: Vec<String>, limits: StoreLimits) -> Self {
+    fn new(args: Vec<String>, mem: MemLimiter) -> Self {
         // VIBE_BREAK is a comma-separated list mixing function-name specs and
         // line specs. A line spec is either `<file>:<line>` or a bare `<line>`
         // (all-digit). Everything else is a function name. Split them so both
@@ -203,7 +245,7 @@ impl HostState {
             print_buf: Vec::new(),
             pending_bytes: None,
             pending_strings: None,
-            limits,
+            mem,
             capture_stdout: false,
             captured_stdout: Vec::new(),
             start_instant: Instant::now(),
@@ -407,8 +449,8 @@ fn run(args: Vec<String>) -> Result<i32> {
         .memory_size(memory_mb * 1024 * 1024)
         .build();
 
-    let mut store = Store::new(&engine, HostState::new(prog_args, limits));
-    store.limiter(|s| &mut s.limits);
+    let mut store = Store::new(&engine, HostState::new(prog_args, MemLimiter::new(limits)));
+    store.limiter(|s| &mut s.mem);
 
     // DAP P2: if the module is a break build it carries a `vibe.dbgargs` custom
     // section publishing the two addresses of the spilled-argument region. Parse
@@ -453,6 +495,14 @@ fn run(args: Vec<String>) -> Result<i32> {
     // overhead. Gated by VIBE_MEM=1 (set by `vibe run --mem`).
     let mem_profile = std::env::var("VIBE_MEM").as_deref() == Ok("1");
     let heap_base = if mem_profile { read_heap_ptr(&instance, &mut store) } else { None };
+    if mem_profile {
+        // Start recording memory.grow events (tier 2 timeline) relative to the
+        // run, from this point — before `_start`, after instantiation.
+        let m = &mut store.data_mut().mem;
+        m.record = true;
+        m.start = Instant::now();
+        m.events.clear();
+    }
 
     let result = start.call(&mut store, ());
 
@@ -482,7 +532,8 @@ fn run(args: Vec<String>) -> Result<i32> {
         let committed = instance
             .get_memory(&mut store, "memory")
             .map(|m| m.data_size(&store) as u64);
-        report_memory(heap_base, heap_peak, committed);
+        let events = std::mem::take(&mut store.data_mut().mem.events);
+        report_memory(heap_base, heap_peak, committed, &events);
     }
 
     match result {
@@ -575,10 +626,10 @@ fn bench(args: Vec<String>) -> Result<i32> {
     let limits = StoreLimitsBuilder::new()
         .memory_size(memory_mb * 1024 * 1024)
         .build();
-    let mut state = HostState::new(vec!["moonrun_wt".to_string()], limits);
+    let mut state = HostState::new(vec!["moonrun_wt".to_string()], MemLimiter::new(limits));
     state.capture_stdout = true; // suppress per-iteration program output
     let mut store = Store::new(&engine, state);
-    store.limiter(|s| &mut s.limits);
+    store.limiter(|s| &mut s.mem);
     let mut linker = Linker::new(&engine);
     register_imports(&mut linker)?;
     let instance = linker.instantiate(&mut store, &module)?;
@@ -679,10 +730,10 @@ fn daemon(args: Vec<String>) -> Result<i32> {
     // Empty initial args; daemon will populate per-request before each
     // `_start` call. capture_stdout is set true so per-request output
     // accumulates in HostState.captured_stdout for the JSON envelope.
-    let mut state = HostState::new(vec!["moonrun_wt".to_string()], limits);
+    let mut state = HostState::new(vec!["moonrun_wt".to_string()], MemLimiter::new(limits));
     state.capture_stdout = true;
     let mut store = Store::new(&engine, state);
-    store.limiter(|s| &mut s.limits);
+    store.limiter(|s| &mut s.mem);
 
     let mut linker = Linker::new(&engine);
     register_imports(&mut linker)?;
@@ -1125,18 +1176,48 @@ fn human_bytes(n: u64) -> String {
 // Print the `--mem` report to stderr: a machine-readable line + a human line.
 // `allocated` = peak − base (everything the run bump-allocated; the linear
 // backend never frees, so peak == total). `committed` = wasm memory pages.
-fn report_memory(base: Option<u64>, peak: Option<u64>, committed: Option<u64>) {
+fn report_memory(
+    base: Option<u64>,
+    peak: Option<u64>,
+    committed: Option<u64>,
+    grow_events: &[(u128, u64, u64)],
+) {
     match (base, peak) {
         (Some(b), Some(p)) => {
             let allocated = p.saturating_sub(b);
             let c = committed.unwrap_or(0);
-            eprintln!("vibe::mem heap_base={b} heap_peak={p} allocated={allocated} committed={c}");
+            eprintln!("vibe::mem heap_base={b} heap_peak={p} allocated={allocated} committed={c} grow_events={}", grow_events.len());
             eprintln!(
-                "vibe: memory — allocated {} ({allocated} B), peak heap {}, committed {}",
+                "vibe: memory — allocated {} ({allocated} B), peak heap {}, committed {}, {} growth event(s)",
                 human_bytes(allocated),
                 human_bytes(p),
                 human_bytes(c),
+                grow_events.len(),
             );
+            // Growth timeline (tier 2): one machine-readable line per
+            // `memory.grow`, with the time since run start and the page-commitment
+            // jump. Empty for programs that stay within the module's initial
+            // memory. A trailing human summary of the first/last event bounds the
+            // timeline without flooding for allocation-heavy runs.
+            for (elapsed_ns, from, to) in grow_events {
+                let pages = to.saturating_sub(*from) / 65536;
+                eprintln!(
+                    "vibe::memgrow t_us={} from={from} to={to} pages=+{pages}",
+                    elapsed_ns / 1_000
+                );
+            }
+            if let (Some((t0, f0, _)), Some((t1, _, l1))) =
+                (grow_events.first(), grow_events.last())
+            {
+                eprintln!(
+                    "vibe:   growth {} -> {} across {} event(s), {} … {}",
+                    human_bytes(*f0),
+                    human_bytes(*l1),
+                    grow_events.len(),
+                    fmt_ns(*t0),
+                    fmt_ns(*t1),
+                );
+            }
         }
         _ => eprintln!("vibe: memory — unavailable (module exports no `__heap_ptr` global)"),
     }


### PR DESCRIPTION
## 概要

プロファイリング設計の **tier 2**（成長タイムライン）を実装。`--mem` 実行中の `memory.grow` を
すべてイベントとして記録する。

## 仕組み

wasmtime の `ResourceLimiter` を実装した `MemLimiter` を導入。既存の `StoreLimits`（メモリ上限）を
ラップしつつ、受理された grow ごとに `(elapsed_ns, from_bytes, to_bytes)` を記録する。guest の
`memory.grow` も host の `Memory::grow`（bump 文字列確保）も wasmtime はこの limiter を通すので、
タイムラインは完全。記録は `--mem` 時のみ（他の実行はコストゼロ）。

```
$ vibe run --mem grow.vibe          # >4 MiB を確保
vibe::mem … committed=6291456 grow_events=32
vibe: memory — allocated 5.9 MiB …, committed 6.0 MiB, 32 growth event(s)
vibe::memgrow t_us=2066 from=4194304 to=4259840 pages=+1
vibe::memgrow t_us=2107 from=4259840 to=4325376 pages=+1
…
vibe:   growth 4.0 MiB -> 6.0 MiB across 32 event(s), 2.07 ms … 2.50 ms
```

各 `vibe::memgrow` 行は機械可読（`t_us`=run 開始からの経過、`from`/`to`=bytes、`pages`=追加ページ）。

## 限界（明記）

生成 wasm の初期メモリは **64 ページ（4 MiB, `default_wasi_memory_min_pages`）** なので、
4 MiB 未満のプログラムは grow せず `grow_events=0`。つまり**ページコミットの粗いタイムライン**で、
4 MiB 超のとき有効。細粒度のアロケーション曲線は tier 3（`__heap_ptr` サンプリング）。
副産物として、bump allocator が **1 ページ（64 KiB）ずつ** grow していることも可視化される。

## 変更点

- **runner**: `MemLimiter`（`ResourceLimiter`）が素の `StoreLimits` フィールドを置換。`_start` 直前に
  記録を有効化＋ゼロ初期化、イベントを `report_memory` に渡しタイムライン出力（success/trap 両方）
- **docs/spec/profiling.md**: tier 2 を実装済みに更新、限界を明記
- **scripts/test_vibe_mem.sh**: +3 assertions（小プログラムは 0 events、>4 MiB は events ＋ memgrow 行）→ 計 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c)_