### PR TITLE
ci: bench regression gate (deterministic bytes/op)

### DIFF
--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -37,6 +37,8 @@ on:
       - "js/vibe/graph_query.js"
       - "scripts/test_graph_query.js"
       - "scripts/test_host_abi.js"
+      - "scripts/bench_regression.mjs"
+      - "bench/regression/**"
       - "bootstrap/selfhost/seed/**"
       - ".github/workflows/cli-install.yml"
   pull_request:
@@ -70,6 +72,8 @@ on:
       - "js/vibe/graph_query.js"
       - "scripts/test_graph_query.js"
       - "scripts/test_host_abi.js"
+      - "scripts/bench_regression.mjs"
+      - "bench/regression/**"
       - ".github/workflows/cli-install.yml"
   workflow_dispatch:
 
@@ -131,6 +135,8 @@ jobs:
           VIBE_BIN="$VIBE_BIN_DIR/vibe" node scripts/test_vibe_lsp.js
           # Host ABI contract snapshot (docs/spec/host-abi.md): reuse this install.
           VIBE_BIN="$VIBE_BIN_DIR/vibe" node scripts/test_host_abi.js
+          # Bench regression gate (deterministic bytes/op): reuse this install.
+          VIBE_BIN="$VIBE_BIN_DIR/vibe" node scripts/bench_regression.mjs
 
       - name: Name section (debugger P0) regression test
         run: bash scripts/test_name_section.sh

--- a/bench/regression/alloc_bench.vibe
+++ b/bench/regression/alloc_bench.vibe
@@ -1,0 +1,8 @@
+// Allocation-heavy but deterministic: same input -> same bump allocations.
+let build = (n: Int) -> Int {
+  let mut s = ""
+  let mut i = 0
+  while i < n { s = String::concat(s, "ab"); i = i + 1 }
+  String::length(s)
+}
+bench "build_100" { let _ = build(100) }

--- a/bench/regression/baseline.json
+++ b/bench/regression/baseline.json
@@ -1,0 +1,10 @@
+{
+  "pure_bench.vibe": {
+    "bytes_per_op": 0,
+    "ns_p50": 62
+  },
+  "alloc_bench.vibe": {
+    "bytes_per_op": 10400,
+    "ns_p50": 6687
+  }
+}

--- a/bench/regression/pure_bench.vibe
+++ b/bench/regression/pure_bench.vibe
@@ -1,0 +1,10 @@
+// Pure compute: must allocate nothing (deterministic 0 B/op).
+let add = (a: Int, b: Int) -> Int { a + b }
+let fib = (n: Int) -> Int {
+  let mut a = 0
+  let mut b = 1
+  let mut i = 0
+  while i < n { let t = a + b; a = b; b = t; i = i + 1 }
+  a
+}
+bench "fib30" { let _ = add(fib(30), 0) }

--- a/scripts/bench_regression.mjs
+++ b/scripts/bench_regression.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// Benchmark regression gate. Runs the fixtures in bench/regression/ via
+// `vibe bench` and compares against a committed baseline.
+//
+// The gate is on bytes/op, which is DETERMINISTIC on the linear backend (a bump
+// allocator allocates exactly the same bytes for the same input), so an
+// allocation regression is caught reliably with zero flakiness. Wall-time is
+// inherently noisy across machines/CI, so ns/op is reported as ADVISORY only and
+// never fails the gate.
+//
+// Usage:
+//   VIBE_BIN=<vibe> node scripts/bench_regression.mjs           # check
+//   VIBE_BIN=<vibe> node scripts/bench_regression.mjs --update   # rewrite baseline
+//
+// baseline.json shape: { "<file.vibe>": { "bytes_per_op": <int>, "ns_p50": <int> } }
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const DIR = join(ROOT, "bench", "regression");
+const BASELINE = join(DIR, "baseline.json");
+const VIBE = process.env.VIBE_BIN || "vibe";
+const ITERS = process.env.BENCH_ITERS || "300";
+const update = process.argv.includes("--update");
+
+// The fixture set the gate covers (must run cleanly on the linear backend).
+const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe"];
+
+function runBench(file) {
+  const r = spawnSync(VIBE, ["bench", join(DIR, file), "--iters", ITERS], { encoding: "utf8", timeout: 120000 });
+  const out = `${r.stdout || ""}\n${r.stderr || ""}`;
+  const m = /vibe::bench .*?bytes_per_op=(\d+)/.exec(out);
+  const t = /vibe::bench .*?ns_p50=(\d+)/.exec(out);
+  if (!m) throw new Error(`bench ${file} produced no parseable result:\n${out}`);
+  return { bytes_per_op: +m[1], ns_p50: t ? +t[1] : null };
+}
+
+const results = {};
+for (const f of FIXTURES) results[f] = runBench(f);
+
+if (update) {
+  writeFileSync(BASELINE, JSON.stringify(results, null, 2) + "\n");
+  console.log(`[bench-regression] wrote baseline for ${FIXTURES.length} fixtures -> ${BASELINE}`);
+  for (const f of FIXTURES) console.log(`  ${f}: ${results[f].bytes_per_op} B/op, p50 ${results[f].ns_p50} ns`);
+  process.exit(0);
+}
+
+if (!existsSync(BASELINE)) {
+  console.error(`[bench-regression] no baseline at ${BASELINE}; run with --update first`);
+  process.exit(2);
+}
+const baseline = JSON.parse(readFileSync(BASELINE, "utf8"));
+
+let failed = 0;
+console.log("[bench-regression] bytes/op gate (deterministic); time is advisory\n");
+for (const f of FIXTURES) {
+  const cur = results[f];
+  const base = baseline[f];
+  if (!base) {
+    console.log(`  ⚠️  ${f}: no baseline entry (run --update); current ${cur.bytes_per_op} B/op`);
+    continue;
+  }
+  const dB = cur.bytes_per_op - base.bytes_per_op;
+  // Advisory time delta.
+  const tNote =
+    base.ns_p50 && cur.ns_p50
+      ? ` | time p50 ${cur.ns_p50}ns (${dPct(cur.ns_p50, base.ns_p50)} vs ${base.ns_p50}ns, advisory)`
+      : "";
+  if (dB > 0) {
+    failed++;
+    console.log(`  ❌ ${f}: bytes/op REGRESSED ${base.bytes_per_op} -> ${cur.bytes_per_op} (+${dB})${tNote}`);
+  } else if (dB < 0) {
+    console.log(`  ✅ ${f}: bytes/op improved ${base.bytes_per_op} -> ${cur.bytes_per_op} (${dB}) — rerun --update to lock in${tNote}`);
+  } else {
+    console.log(`  ✅ ${f}: ${cur.bytes_per_op} B/op (unchanged)${tNote}`);
+  }
+}
+
+function dPct(cur, base) {
+  if (!base) return "n/a";
+  const p = ((cur - base) / base) * 100;
+  return `${p >= 0 ? "+" : ""}${p.toFixed(0)}%`;
+}
+
+console.log("");
+if (failed) {
+  console.error(`[bench-regression] FAIL: ${failed} allocation regression(s). If intentional, rerun with --update.`);
+  process.exit(1);
+}
+console.log(`[bench-regression] ok: ${FIXTURES.length} fixtures, no allocation regression.`);


### PR DESCRIPTION
## 概要

`vibe bench` の出力を使った**回帰ゲート**。残タスクの 1 つ目。

ゲートは **bytes/op** に対して張る。linear backend の bump allocator は同じ入力に対して**同じバイト数を確保する＝決定的**なので、アロケーション回帰を**ブレなく**検出できる。wall-time はマシン/CI でブレるので **advisory（参考表示のみ、ゲートしない）**。

## 構成

- `bench/regression/pure_bench.vibe`（0 B/op）＋ `alloc_bench.vibe`（10400 B/op）— 決定的なフィクスチャ
- `bench/regression/baseline.json` — コミット済み baseline
- `scripts/bench_regression.mjs` — 各フィクスチャを `vibe bench` で走らせ baseline と比較。`--update` で再生成
- cli-install に配線（既存 install を再利用）

## 動作確認

```
$ node scripts/bench_regression.mjs
  ✅ pure_bench.vibe: 0 B/op (unchanged) | time p50 63ns (+2%, advisory)
  ✅ alloc_bench.vibe: 10400 B/op (unchanged) | time p50 7041ns (+5%, advisory)
  ok: 2 fixtures, no allocation regression.
```

意図的に確保量を増やすと **exit 1** で落ちる（10400 → 40800, +30400 を検出）、戻すと pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c)_