### PR TITLE
runner: heap sampling over time (profiling tier 3)

### DIFF
--- a/docs/spec/profiling.md
+++ b/docs/spec/profiling.md
@@ -20,7 +20,7 @@ guest＋host を合わせた総ヒープ使用量を表す。
 |---|---|---|---|
 | **1** | 総ヒープ / ピーク（`__heap_ptr` 差分）| ゼロ | ✅ **実装済み**: `vibe run --mem` |
 | **2** | `memory.grow` イベント（成長タイムライン）| ホストのみ | ✅ **実装済み**: `--mem` の一部 |
-| 3 | アロケーション時系列サンプリング | `dbg_line` / epoch 流用 | 設計済み |
+| **3** | アロケーション時系列サンプリング | ホストのみ（epoch）| ✅ **実装済み**: `--mem-sample` |
 | 4 | サイト別 alloc 属性（massif/heaptrack 相当）| opt-in ビルド（`vibe::alloc_site`）| 設計済み |
 
 ## Tier 1: `vibe run --mem`（実装済み）
@@ -68,6 +68,25 @@ vibe:   growth 4.0 MiB -> 6.0 MiB across 32 event(s), 2.07 ms … 2.50 ms
 （`__heap_ptr` を `dbg_line`/epoch でサンプリング）。
 上の例は bump allocator が **1 ページ（64 KiB）ずつ** grow していることも示している
 （syscall を減らすなら成長チャンクを大きくする余地）。
+
+## Tier 3: 時系列サンプリング（実装済み）
+
+`vibe run --mem-sample[=MS]`（既定 1ms 間隔）。runner は wasmtime の **epoch interruption** を
+使い、バックグラウンドスレッドが MS ごとに engine epoch を increment、ゲストのチェックポイント
+（関数入口・ループ back-edge）で epoch-deadline コールバックが発火して `__heap_ptr` を読む。
+これで **初期メモリ（4 MiB）内**でも heap の推移が見える（tier 2 の grow イベントが拾えない領域）。
+ホスト側のみ・計装なし。epoch checks のコストは `--mem-sample` 時のみ（通常 / `vibe bench` は無影響）。
+
+```
+$ vibe run --mem-sample long.vibe
+vibe::memsample t_us=1235 heap=2459624
+vibe::memsample t_us=2314 heap=4571336
+…
+vibe: heap samples — 12 over 1.21 ms … 13.36 ms, 2.4 MiB -> 19.2 MiB (peak 19.2 MiB)
+```
+
+各 `vibe::memsample` 行は機械可読（`t_us`=経過、`heap`=`__heap_ptr` bytes）。サンプル数は
+実行時間と間隔に依存（プログラムが 1 間隔より速いと 0 サンプル）。
 
 ## `vibe bench`（実装済み）
 

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -311,6 +311,7 @@ case "$cmd" in
     trace=0
     brk=0
     mem=0
+    mem_sample=""
     break_spec=""
     args=()
     while [ "$#" -gt 0 ]; do
@@ -319,6 +320,8 @@ case "$cmd" in
         --break) brk=1; break_spec="$2"; shift 2 ;;
         --break=*) brk=1; break_spec="${1#--break=}"; shift ;;
         --mem) mem=1; shift ;;
+        --mem-sample) mem_sample=1; shift ;;
+        --mem-sample=*) mem_sample="${1#--mem-sample=}"; shift ;;
         *) args+=("$1"); shift ;;
       esac
     done
@@ -352,6 +355,8 @@ case "$cmd" in
     # runner reads `__heap_ptr` before/after `_start` and prints the delta.
     mem_env=""
     [ "$mem" = "1" ] && mem_env="VIBE_MEM=1"
+    # `--mem-sample[=MS]`: tier-3 heap sampling every MS ms (default 1).
+    [ -n "$mem_sample" ] && mem_env="$mem_env VIBE_MEM_SAMPLE_MS=$mem_sample"
     # span-arc step5: line-granularity breakpoints. A `--break <file>:<line>` (or
     # bare `<line>`) spec passes through VIBE_BREAK unchanged; the runner resolves
     # the entering function's source line via the `.funcmap` sidecar (name<TAB>

--- a/scripts/test_vibe_mem.sh
+++ b/scripts/test_vibe_mem.sh
@@ -107,5 +107,30 @@ printf '%s\n' "$grow_err" | grep -qE "vibe::memgrow t_us=[0-9]+ from=[0-9]+ to=[
   && ok "growth timeline emits machine-readable memgrow lines" \
   || bad "missing memgrow line (got: $(printf '%s\n' "$grow_err" | grep memgrow | head -1))"
 
+# 7. heap sampling (tier 3): --mem-sample produces a heap-over-time curve. Use a
+#    larger O(n^2) build so the run spans many sample intervals on any machine.
+cat > "$proj/long.vibe" <<'EOF'
+let build = (n: Int) -> Int {
+  let mut s = ""
+  let mut i = 0
+  while i < n { s = String::concat(s, "x"); i = i + 1 }
+  String::length(s)
+}
+let main = () -> Int { build(8000) }
+EOF
+sample_err="$("$VIBE" run --mem-sample "$proj/long.vibe" 2>&1 >/dev/null)"
+printf '%s\n' "$sample_err" | grep -qE "vibe: heap samples — " \
+  && ok "--mem-sample emits a heap-sampling summary" \
+  || bad "--mem-sample missing summary (got: $(printf '%s\n' "$sample_err" | tail -1))"
+scount="$(printf '%s\n' "$sample_err" | grep -cE "vibe::memsample t_us=[0-9]+ heap=[0-9]+")"
+if [ "$scount" -ge 1 ]; then
+  ok "--mem-sample records >=1 heap sample over time ($scount samples)"
+else
+  bad "--mem-sample recorded $scount samples (expected >=1 for a multi-ms run)"
+fi
+# plain run must not emit samples.
+"$VIBE" run "$proj/long.vibe" 2>&1 | grep -q "vibe::memsample" \
+  && bad "plain run leaked heap samples" || ok "plain run emits no heap samples"
+
 echo "[test_vibe_mem] $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/scripts/test_vibe_mem.sh
+++ b/scripts/test_vibe_mem.sh
@@ -107,30 +107,39 @@ printf '%s\n' "$grow_err" | grep -qE "vibe::memgrow t_us=[0-9]+ from=[0-9]+ to=[
   && ok "growth timeline emits machine-readable memgrow lines" \
   || bad "missing memgrow line (got: $(printf '%s\n' "$grow_err" | grep memgrow | head -1))"
 
-# 7. heap sampling (tier 3): --mem-sample produces a heap-over-time curve. Use a
-#    larger O(n^2) build so the run spans many sample intervals on any machine.
+# 7. heap sampling (tier 3): --mem-sample produces a heap-over-time curve. Sample
+#    capture is timing-based (epoch-driven), so use a long compute loop that spans
+#    many 1 ms intervals on any machine, retry a few times to absorb scheduler
+#    jitter, and guard `grep -c` (it exits non-zero on 0 matches, which would trip
+#    `set -e`).
 cat > "$proj/long.vibe" <<'EOF'
-let build = (n: Int) -> Int {
-  let mut s = ""
+let main = () -> Int {
+  let mut acc = 0
   let mut i = 0
-  while i < n { s = String::concat(s, "x"); i = i + 1 }
-  String::length(s)
+  while i < 60000000 { acc = acc + (i & 7); i = i + 1 }
+  acc
 }
-let main = () -> Int { build(8000) }
 EOF
-sample_err="$("$VIBE" run --mem-sample "$proj/long.vibe" 2>&1 >/dev/null)"
+sample_err=""; scount=0
+for _attempt in 1 2 3; do
+  sample_err="$("$VIBE" run --mem-sample "$proj/long.vibe" 2>&1 >/dev/null)"
+  scount="$(printf '%s\n' "$sample_err" | grep -cE 'vibe::memsample t_us=[0-9]+ heap=[0-9]+' || true)"
+  [ "${scount:-0}" -ge 1 ] && break
+done
 printf '%s\n' "$sample_err" | grep -qE "vibe: heap samples — " \
   && ok "--mem-sample emits a heap-sampling summary" \
   || bad "--mem-sample missing summary (got: $(printf '%s\n' "$sample_err" | tail -1))"
-scount="$(printf '%s\n' "$sample_err" | grep -cE "vibe::memsample t_us=[0-9]+ heap=[0-9]+")"
-if [ "$scount" -ge 1 ]; then
+if [ "${scount:-0}" -ge 1 ]; then
   ok "--mem-sample records >=1 heap sample over time ($scount samples)"
 else
-  bad "--mem-sample recorded $scount samples (expected >=1 for a multi-ms run)"
+  bad "--mem-sample recorded 0 samples across retries (expected >=1 for a long run)"
 fi
 # plain run must not emit samples.
-"$VIBE" run "$proj/long.vibe" 2>&1 | grep -q "vibe::memsample" \
-  && bad "plain run leaked heap samples" || ok "plain run emits no heap samples"
+if "$VIBE" run "$proj/long.vibe" 2>&1 | grep -q "vibe::memsample"; then
+  bad "plain run leaked heap samples"
+else
+  ok "plain run emits no heap samples"
+fi
 
 echo "[test_vibe_mem] $pass passed, $fail failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/tools/moonrun_wasmtime/src/main.rs
+++ b/tools/moonrun_wasmtime/src/main.rs
@@ -455,6 +455,17 @@ fn run(args: Vec<String>) -> Result<i32> {
         .ok()
         .and_then(|s| s.parse().ok())
         .filter(|n| *n > 0);
+    // A precompiled `.cwasm` was serialized with the plain engine config; flipping
+    // on epoch_interruption here would make deserialization fail (the config must
+    // match), and the AOT image has no epoch checkpoints to sample at anyway.
+    // Disable sampling for `.cwasm` (the `vibe run` path always passes a fresh
+    // `.wasm`, so this only guards direct `moonrun_wt <module.cwasm>` use).
+    let sample_ms = if sample_ms.is_some() && wasm_path.ends_with(".cwasm") {
+        eprintln!("vibe: --mem-sample needs a fresh .wasm (a precompiled .cwasm has no epoch checkpoints); sampling disabled");
+        None
+    } else {
+        sample_ms
+    };
     let mut cfg = engine_config();
     if sample_ms.is_some() {
         cfg.epoch_interruption(true);
@@ -554,10 +565,19 @@ fn run(args: Vec<String>) -> Result<i32> {
             let eng = engine.clone();
             let stop = stop_flag.clone();
             let interval = std::time::Duration::from_millis(ms);
+            // Sleep in small chunks (<=10ms) so the stop flag is observed promptly:
+            // a coarse `--mem-sample=1000` must not stall shutdown for a full
+            // second at join. Increment the epoch once per full `interval`.
+            let chunk = interval.min(std::time::Duration::from_millis(10));
             sampler_thread = Some(std::thread::spawn(move || {
+                let mut since_tick = std::time::Duration::ZERO;
                 while !stop.load(std::sync::atomic::Ordering::Relaxed) {
-                    std::thread::sleep(interval);
-                    eng.increment_epoch();
+                    std::thread::sleep(chunk);
+                    since_tick += chunk;
+                    if since_tick >= interval {
+                        eng.increment_epoch();
+                        since_tick = std::time::Duration::ZERO;
+                    }
                 }
             }));
         }

--- a/tools/moonrun_wasmtime/src/main.rs
+++ b/tools/moonrun_wasmtime/src/main.rs
@@ -136,6 +136,14 @@ struct HostState {
     capture_stdout: bool,
     captured_stdout: Vec<u8>,
     start_instant: Instant,
+    // Profiling tier 3 (heap sampling over time). When `__heap_ptr` sampling is
+    // on, the epoch-deadline callback reads this global on each epoch tick and
+    // appends (elapsed_ns, heap_ptr_bytes) — a fine-grained allocation curve that
+    // sees activity WITHIN the module's initial memory (where no memory.grow, and
+    // hence no tier-2 event, fires). `sample_start` anchors elapsed times.
+    sample_global: Option<wasmtime::Global>,
+    sample_start: Instant,
+    samples: Vec<(u128, u64)>,
     // debugger breakpoints (DAP P1): set of function names to pause at (from
     // VIBE_BREAK), and whether to auto-continue without reading stdin (not a
     // TTY, or VIBE_BREAK_AUTO=1). Empty set => the `vibe::dbg_break` hook is a
@@ -249,6 +257,9 @@ impl HostState {
             capture_stdout: false,
             captured_stdout: Vec::new(),
             start_instant: Instant::now(),
+            sample_global: None,
+            sample_start: Instant::now(),
+            samples: Vec::new(),
             break_set: Arc::new(break_set),
             break_auto,
             line_break_set: Arc::new(line_break_set),
@@ -437,7 +448,17 @@ fn run(args: Vec<String>) -> Result<i32> {
         .chain(args.iter().skip(1).cloned())
         .collect();
 
-    let cfg = engine_config();
+    // Profiling tier 3: sample `__heap_ptr` every VIBE_MEM_SAMPLE_MS ms via epoch
+    // interruption. Only enable epoch checks (a small per-checkpoint cost in the
+    // guest) when sampling is requested, so normal/bench runs are unaffected.
+    let sample_ms: Option<u64> = std::env::var("VIBE_MEM_SAMPLE_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|n| *n > 0);
+    let mut cfg = engine_config();
+    if sample_ms.is_some() {
+        cfg.epoch_interruption(true);
+    }
     let engine = Engine::new(&cfg)?;
     let module = load_module(&engine, wasm_path)?;
 
@@ -504,7 +525,51 @@ fn run(args: Vec<String>) -> Result<i32> {
         m.events.clear();
     }
 
+    // tier 3 sampler: arm the epoch-deadline callback to record (elapsed, heap)
+    // on each tick, and spawn a thread that bumps the engine epoch every `ms`.
+    let stop_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let mut sampler_thread = None;
+    if let Some(ms) = sample_ms {
+        if let Some(g) = instance.get_global(&mut store, "__heap_ptr") {
+            {
+                let d = store.data_mut();
+                d.sample_global = Some(g);
+                d.sample_start = Instant::now();
+                d.samples.clear();
+            }
+            store.set_epoch_deadline(1);
+            store.epoch_deadline_callback(|mut ctx| {
+                let gopt = ctx.data().sample_global;
+                if let Some(g) = gopt {
+                    let v = match g.get(&mut ctx) {
+                        Val::I32(x) => x as u32 as u64,
+                        Val::I64(x) => x as u64,
+                        _ => 0,
+                    };
+                    let t = ctx.data().sample_start.elapsed().as_nanos();
+                    ctx.data_mut().samples.push((t, v));
+                }
+                Ok(wasmtime::UpdateDeadline::Continue(1))
+            });
+            let eng = engine.clone();
+            let stop = stop_flag.clone();
+            let interval = std::time::Duration::from_millis(ms);
+            sampler_thread = Some(std::thread::spawn(move || {
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    std::thread::sleep(interval);
+                    eng.increment_epoch();
+                }
+            }));
+        }
+    }
+
     let result = start.call(&mut store, ());
+
+    // Stop the sampler thread before reading samples.
+    stop_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+    if let Some(h) = sampler_thread {
+        let _ = h.join();
+    }
 
     // Flush buffered prints if execution didn't end with a newline.
     {
@@ -534,6 +599,12 @@ fn run(args: Vec<String>) -> Result<i32> {
             .map(|m| m.data_size(&store) as u64);
         let events = std::mem::take(&mut store.data_mut().mem.events);
         report_memory(heap_base, heap_peak, committed, &events);
+    }
+
+    // tier 3 heap-sampling timeline.
+    if sample_ms.is_some() {
+        let samples = std::mem::take(&mut store.data_mut().samples);
+        report_samples(&samples);
     }
 
     match result {
@@ -1220,6 +1291,27 @@ fn report_memory(
             }
         }
         _ => eprintln!("vibe: memory — unavailable (module exports no `__heap_ptr` global)"),
+    }
+}
+
+// Print the tier-3 heap-sampling timeline: one machine-readable line per sample
+// (elapsed since run start + heap-pointer bytes) plus a human summary. Empty when
+// the program ran faster than one sample interval.
+fn report_samples(samples: &[(u128, u64)]) {
+    for (elapsed_ns, heap) in samples {
+        eprintln!("vibe::memsample t_us={} heap={heap}", elapsed_ns / 1_000);
+    }
+    match (samples.first(), samples.last()) {
+        (Some((t0, h0)), Some((t1, h1))) => eprintln!(
+            "vibe: heap samples — {} over {} … {}, {} -> {} (peak {})",
+            samples.len(),
+            fmt_ns(*t0),
+            fmt_ns(*t1),
+            human_bytes(*h0),
+            human_bytes(*h1),
+            human_bytes(samples.iter().map(|(_, h)| *h).max().unwrap_or(0)),
+        ),
+        _ => eprintln!("vibe: heap samples — 0 (program ran faster than one sample interval)"),
     }
 }
 


### PR DESCRIPTION
## 概要

残タスク 2 つ目。`vibe run --mem-sample[=MS]`（既定 1ms）で `__heap_ptr` を時系列サンプリングし、**細粒度のアロケーション曲線**を得る。tier 2 の grow イベントが拾えない **初期メモリ（4 MiB）内**の推移が見える。

## 仕組み

wasmtime の **epoch interruption** で実装（ホスト側のみ・計装なし）:
- バックグラウンドスレッドが MS ごとに engine epoch を increment
- store の epoch-deadline コールバックがゲストのチェックポイント（関数入口・ループ back-edge）で発火 → `__heap_ptr` を読み `(elapsed_ns, bytes)` を記録
- epoch checks は `--mem-sample` 時のみ有効 → 通常 run / `vibe bench` は無影響

```
$ vibe run --mem-sample long.vibe
vibe::memsample t_us=1235 heap=2459624
vibe::memsample t_us=2314 heap=4571336
…
vibe: heap samples — 12 over 1.21 ms … 13.36 ms, 2.4 MiB -> 19.2 MiB (peak 19.2 MiB)
```

各 `vibe::memsample` 行は機械可読。サンプル数は実行時間 / 間隔に依存（速いと 0）。stdout は汚さない。

## 変更点

- **runner**: `HostState` に `sample_global`/`samples`、`VIBE_MEM_SAMPLE_MS` で epoch_interruption をゲート、背景 epoch スレッド ＋ `epoch_deadline_callback`、`report_samples()`
- **launcher**: `vibe run --mem-sample[=MS]` → `VIBE_MEM_SAMPLE_MS`
- **docs/spec/profiling.md**: tier 3 を実装済みに
- **scripts/test_vibe_mem.sh**: +3 assertions（計 12、手元 12/12）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c)_