### PR TITLE
perf: eliminate O(N²) String::concat accumulators in vibe/wasm (issue #366)

### DIFF
--- a/vibe/wasm/component_parser/component_parser.vibe
+++ b/vibe/wasm/component_parser/component_parser.vibe
@@ -53,13 +53,14 @@ let read_uleb128 = (buf: Bytes, offset: Int) -> (Int, Int) {
 
 let read_name = (bytes: Bytes, offset: Int) -> (String, Int) {
   let (name_len, pos) = read_uleb128(bytes, offset)
-  let mut s = ""
+  // O(N) build via StringBuilder; per-char String::concat was O(L²) (issue #366).
+  let s = StringBuilder::new()
   let mut i = 0
   while i < name_len {
-    s = String::concat(s, String::from_char_code(bytes[pos + i]))
+    StringBuilder::push(s, String::from_char_code(bytes[pos + i]))
     i = i + 1
   }
-  (s, pos + name_len)
+  (StringBuilder::freeze(s), pos + name_len)
 }
 
 export let parse_canon = (bytes: Bytes, offset: Int, size: Int) -> Array[(Int, Int, Int)] {

--- a/vibe/wasm/wasm_opt/wasm_opt.vibe
+++ b/vibe/wasm/wasm_opt/wasm_opt.vibe
@@ -100,13 +100,14 @@ let read_uleb128 = (buf: Bytes, offset: Int) -> (Int, Int) {
 
 let read_name = (bytes: Bytes, offset: Int) -> (String, Int) {
   let (name_len, pos) = read_uleb128(bytes, offset)
-  let mut s = ""
+  // O(N) build via StringBuilder; per-char String::concat was O(L²) (issue #366).
+  let s = StringBuilder::new()
   let mut i = 0
   while i < name_len {
-    s = String::concat(s, String::from_char_code(bytes[pos + i]))
+    StringBuilder::push(s, String::from_char_code(bytes[pos + i]))
     i = i + 1
   }
-  (s, pos + name_len)
+  (StringBuilder::freeze(s), pos + name_len)
 }
 
 export let minify_fast = (bytes: Bytes) -> Bytes {

--- a/vibe/wasm/wasm_parser/wasm_parser.vibe
+++ b/vibe/wasm/wasm_parser/wasm_parser.vibe
@@ -54,13 +54,14 @@ let read_uleb128 = (buf: Bytes, offset: Int) -> (Int, Int) {
 
 export let read_name = (bytes: Bytes, offset: Int) -> (String, Int) {
   let (name_len, pos) = read_uleb128(bytes, offset)
-  let mut s = ""
+  // O(N) build via StringBuilder; per-char String::concat was O(L²) (issue #366).
+  let s = StringBuilder::new()
   let mut i = 0
   while i < name_len {
-    s = String::concat(s, String::from_char_code(bytes[pos + i]))
+    StringBuilder::push(s, String::from_char_code(bytes[pos + i]))
     i = i + 1
   }
-  (s, pos + name_len)
+  (StringBuilder::freeze(s), pos + name_len)
 }
 
 export let parse_start = (bytes: Bytes, offset: Int, size: Int) -> Int {
@@ -373,18 +374,18 @@ export let valtype_name = (vt: Int) -> String {
 }
 
 let valtypes_str = (types: Array[Int]) -> String {
-  let mut s = ""
+  let s = StringBuilder::new()
   let mut i = 0
   while i < Array::length(types) {
     if i > 0 {
-      s = String::concat(s, " ")
+      StringBuilder::push(s, " ")
     } else {
       ()
     }
-    s = String::concat(s, valtype_name(Array::get(types, i)))
+    StringBuilder::push(s, valtype_name(Array::get(types, i)))
     i = i + 1
   }
-  s
+  StringBuilder::freeze(s)
 }
 
 let int_to_string = (n: Int) -> String {

--- a/vibe/wasm/wasm_runtime/wasm_runtime.vibe
+++ b/vibe/wasm/wasm_runtime/wasm_runtime.vibe
@@ -460,13 +460,14 @@ let read_uleb128 = (buf: Bytes, offset: Int) -> (Int, Int) {
 
 let read_name = (buf: Bytes, offset: Int) -> (String, Int) {
   let (name_len, np) = read_uleb128(buf, offset)
-  let mut s = ""
+  // O(N) build via StringBuilder; per-char String::concat was O(L²) (issue #366).
+  let s = StringBuilder::new()
   let mut i = 0
   while i < name_len {
-    s = String::concat(s, String::from_char_code(buf[np + i]))
+    StringBuilder::push(s, String::from_char_code(buf[np + i]))
     i = i + 1
   }
-  (s, np + name_len)
+  (StringBuilder::freeze(s), np + name_len)
 }
 
 let int_to_string = (n: Int) -> String {

--- a/vibe/wasm/wat_encoder/wat_encoder.vibe
+++ b/vibe/wasm/wat_encoder/wat_encoder.vibe
@@ -330,7 +330,8 @@ let decode_string = (s: String) -> String {
     ""
   }
   else {
-    let mut result = ""
+    // O(N) build via StringBuilder; per-char String::concat was O(L²) (issue #366).
+    let result = StringBuilder::new()
     let mut i = 1
     let end_pos = len - 1
     while i < end_pos {
@@ -340,27 +341,27 @@ let decode_string = (s: String) -> String {
         if i < end_pos {
           let c2 = String::char_code_at(s, i)
           if c2 == 110 {
-            result = String::concat(result, String::from_char_code(10)); i = i + 1
+            StringBuilder::push(result, String::from_char_code(10)); i = i + 1
           }
           else {
             if c2 == 116 {
-              result = String::concat(result, String::from_char_code(9)); i = i + 1
+              StringBuilder::push(result, String::from_char_code(9)); i = i + 1
             }
             else {
               if c2 == 92 {
-                result = String::concat(result, "\\"); i = i + 1
+                StringBuilder::push(result, "\\"); i = i + 1
               }
               else {
                 if c2 == 34 {
-                  result = String::concat(result, "\""); i = i + 1
+                  StringBuilder::push(result, "\""); i = i + 1
                 }
                 else {
                   if is_hex_digit(c2) && ((i + 1) < end_pos) && (is_hex_digit(String::char_code_at(s, i + 1))) {
                     let h = hex_val(c2) * 16 + hex_val(String::char_code_at(s, i + 1))
-                    result = String::concat(result, String::from_char_code(h))
+                    StringBuilder::push(result, String::from_char_code(h))
                     i = i + 2
                   } else {
-                    result = String::concat(result, String::from_char_code(c2))
+                    StringBuilder::push(result, String::from_char_code(c2))
                     i = i + 1
                   }
                 }
@@ -369,11 +370,11 @@ let decode_string = (s: String) -> String {
           }
         }
       } else {
-        result = String::concat(result, String::from_char_code(c))
+        StringBuilder::push(result, String::from_char_code(c))
         i = i + 1
       }
     }
-    result
+    StringBuilder::freeze(result)
   }
 }
 

--- a/vibe/wasm/wat_parser/wat_parser.vibe
+++ b/vibe/wasm/wat_parser/wat_parser.vibe
@@ -258,7 +258,8 @@ export let decode_string = (s: String) -> String {
     ""
   }
   else {
-    let mut result = ""
+    // O(N) build via StringBuilder; per-char String::concat was O(L²) (issue #366).
+    let result = StringBuilder::new()
     let mut i = 1
     let end_pos = len - 1
     while i < end_pos {
@@ -268,27 +269,27 @@ export let decode_string = (s: String) -> String {
         if i < end_pos {
           let c2 = String::char_code_at(s, i)
           if c2 == 110 {
-            result = String::concat(result, String::from_char_code(10)); i = i + 1
+            StringBuilder::push(result, String::from_char_code(10)); i = i + 1
           }
           else {
             if c2 == 116 {
-              result = String::concat(result, String::from_char_code(9)); i = i + 1
+              StringBuilder::push(result, String::from_char_code(9)); i = i + 1
             }
             else {
               if c2 == 92 {
-                result = String::concat(result, "\\"); i = i + 1
+                StringBuilder::push(result, "\\"); i = i + 1
               }
               else {
                 if c2 == 34 {
-                  result = String::concat(result, "\""); i = i + 1
+                  StringBuilder::push(result, "\""); i = i + 1
                 }
                 else {
                   if is_hex_digit(c2) && ((i + 1) < end_pos) && (is_hex_digit(String::char_code_at(s, i + 1))) {
                     let h = hex_val(c2) * 16 + hex_val(String::char_code_at(s, i + 1))
-                    result = String::concat(result, String::from_char_code(h))
+                    StringBuilder::push(result, String::from_char_code(h))
                     i = i + 2
                   } else {
-                    result = String::concat(result, String::from_char_code(c2))
+                    StringBuilder::push(result, String::from_char_code(c2))
                     i = i + 1
                   }
                 }
@@ -297,11 +298,11 @@ export let decode_string = (s: String) -> String {
           }
         }
       } else {
-        result = String::concat(result, String::from_char_code(c))
+        StringBuilder::push(result, String::from_char_code(c))
         i = i + 1
       }
     }
-    result
+    StringBuilder::freeze(result)
   }
 }
 


### PR DESCRIPTION
## 概要

#659 と同じプロファイリングの流れを `vibe/wasm/*` に適用。バイト列から文字列を **char ごとに `String::concat` で復元/エスケープ**する O(N²) を builder 化しました。

## 特定（`vibe run --mem`）

`read_name`（wasm モジュール内の全 import/export/name section で呼ばれる）を長い name でプロファイル:

| name 長 | OLD (`String::concat` O(L²)) | NEW (StringBuilder O(L)) |
|---|---|---|
| 100 | 6.3 KiB | **3.1 KiB** |
| 127 | 9.6 KiB | **3.3 KiB** |

OLD は超線形、NEW はほぼフラット（O(N)）。長い/多数の name ほど差が拡大。

## 修正

| ファイル | 関数 |
|---|---|
| `wasm_parser.vibe` | `read_name`, `valtypes_str` |
| `wasm_opt.vibe` | `read_name` |
| `component_parser.vibe` | `read_name` |
| `wasm_runtime.vibe` | `read_name` |
| `wat_parser.vibe` | `decode_string`（文字列エスケープ復元）|
| `wat_encoder.vibe` | `decode_string` |

## 検証

- **挙動保存**: `wat_parser` / `component_parser` のテスト ✅（`decode_string` / `read_name` を実行）。`StringBuilder::freeze == 連結`。
- `wat_encoder` / `wasm_opt` / `wasm_runtime` のテストは **selfhost CLI で pre-existing なコンパイル不可**（`Double::parse` / `FixedArray::make` / `int_to_string` 未対応）— pristine main でも同一失敗を確認済み、私の変更とは無関係。変換は検証済みの関数と同型。
- これらは selfhost 経路外のライブラリモジュールなので **bundle 再生成不要**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zrd5fCHcKUPYbrRrxJm6c)_