### PR TITLE
test(selfhost): restore + wire RC bootstrap gate; whole-compiler-under-RC is green (closes #556)

### DIFF
--- a/scripts/selfhost_only_gate.sh
+++ b/scripts/selfhost_only_gate.sh
@@ -41,6 +41,15 @@ if s2 != s3:
 print(f"[selfhost-only-gate] fixpoint ok: stage2==stage3 ({s2[:12]})")
 PY
 
+# 3b. RC bootstrap gate (#556). The stage build above IS the whole compiler
+# compiled as one unit under the canonical RC (Perceus, ADR-0055) backend — the
+# scenario where #556's `analyze_calls` deep recursion blew the wasm stack. Assert
+# it explicitly (reusing the build just produced), so the RC-bootstrap check is
+# named and guards the iterative `analyze_calls` fix (#681). The pre-cutover
+# RC-vs-default parity gate is obsolete (#594 removed the non-RC backend).
+VIBE_SELFHOST_RC_BOOTSTRAP_REUSE_GEN="${latest_gen}generation.json" \
+  bash scripts/test_selfhost_rc_bootstrap.sh
+
 # 4. multi-file compile regression (#594): the selfhost compiler must resolve
 #    imports from the filesystem. collect_import_path once built import paths via
 #    string interpolation, which a selfhost codegen bug rendered as garbage (only

--- a/scripts/test_selfhost_rc_bootstrap.sh
+++ b/scripts/test_selfhost_rc_bootstrap.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# RC bootstrap gate (#556).
+#
+# History / why this looks different from the issue:
+#   The original gate compared the whole-compiler self-compile under the RC
+#   (Perceus, ADR-0055) backend against the legacy non-RC "default" backend and
+#   required both to fail with the SAME signature (parity HOLDS). The RC path
+#   trapped in `analyze_calls` (deep recursive-descent exhausting the wasm stack)
+#   before reaching the default path's `EnvCached` ceiling, so the signatures
+#   diverged and the gate failed.
+#
+#   After the selfhost-only / RC-canonical cutover (#594) there is no separate
+#   non-RC backend, and the entire pre-cutover RC tooling (this script plus
+#   rc_cutover_readiness.sh / verify_selfhost_rc.sh) was removed. The
+#   RC-vs-default parity premise is therefore obsolete.
+#
+# What this modern replacement asserts:
+#   The whole compiler still compiles AS ONE MERGED UNIT under RC -- exactly the
+#   scenario where #556's `analyze_calls` recursion blew the stack -- and the
+#   result is a byte-exact self-build fixpoint (stage2 == stage3). The
+#   `analyze_calls` pass is now iterative over the let/seq spine (#681), so the
+#   deep-recursion trap can no longer occur; this gate guards that.
+#
+# Cheap mode: point VIBE_SELFHOST_RC_BOOTSTRAP_REUSE_GEN at an existing
+# generation.json (e.g. one the release gate just produced) to assert on it
+# without rebuilding.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+OUT_DIR="${VIBE_SELFHOST_RC_BOOTSTRAP_OUT_DIR:-_build/rc_bootstrap_gate}"
+reuse="${VIBE_SELFHOST_RC_BOOTSTRAP_REUSE_GEN:-}"
+
+if [ -n "$reuse" ] && [ -f "$reuse" ]; then
+  gen_json="$reuse"
+  echo "[rc-bootstrap] reusing existing generation manifest: $gen_json"
+else
+  gen_json="$OUT_DIR/generation.json"
+  echo "[rc-bootstrap] building whole compiler under RC (stage0 seed -> stage1 -> stage2 -> stage3)"
+  rm -f _build/vibe_selfhost_*.tsv
+  bash scripts/selfhost_generations.sh build --stage3 --out-dir "$OUT_DIR"
+fi
+
+[ -f "$gen_json" ] || {
+  echo "[rc-bootstrap] FAIL: no generation manifest at $gen_json (whole-compiler RC compile did not complete -- a deep-recursion / stack trap in this stage is the #556 failure mode)" >&2
+  exit 1
+}
+
+fixpoint="$(python3 - "$gen_json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+# Two manifest shapes are in use: an explicit result flag, and a stage sha pair.
+r = d.get("result", {}).get("stage3_equal_stage2")
+if r is None:
+    s = d.get("stages", {})
+    s2 = s.get("stage2", {}).get("sha256")
+    s3 = s.get("stage3", {}).get("sha256")
+    r = bool(s2) and bool(s3) and s2 == s3
+print("True" if r is True else ("True" if r == "True" else "False"))
+PY
+)"
+if [ "$fixpoint" != "True" ]; then
+  echo "[rc-bootstrap] FAIL: whole-compiler-under-RC did not reach a stage2==stage3 fixpoint (got: $fixpoint)" >&2
+  exit 1
+fi
+
+echo "[rc-bootstrap] OK: whole compiler compiles as one unit under RC; stage2==stage3 fixpoint holds"


### PR DESCRIPTION
Closes #556.

## Background
#556's RC bootstrap parity gate (`scripts/test_selfhost_rc_bootstrap.sh`) and the rest of the pre-cutover RC tooling were removed in the selfhost-only cutover (#594), leaving a dangling reference in `scripts/pkfire/selfhost_gates_shard.sh`. The original gate compared the whole-compiler self-compile under RC vs the legacy non-RC "default" backend and required signature parity; the RC path trapped in `analyze_calls` (deep recursion → wasm stack exhaustion) before reaching default's `EnvCached` ceiling.

## What changed
- **`analyze_calls` is now iterative** over the let/seq/assign spine (#681, already merged) — the deep-recursion trap class is gone, fixpoint-verified.
- **Restored a runnable RC bootstrap gate.** The RC-vs-default *parity* premise is obsolete post-#594 (there is no non-RC backend; RC is canonical), so the new gate asserts what actually mattered: the whole compiler compiles **as one merged unit under RC** — the #556 trap scenario — and reaches a byte-exact `stage2 == stage3` fixpoint. It can reuse an existing build (`VIBE_SELFHOST_RC_BOOTSTRAP_REUSE_GEN`) or build stage0→stage3 itself, and handles both `generation.json` shapes.
- **Wired into the live gate** (`selfhost_only_gate.sh` step 3b), reusing the stage build it already produces — so the RC-bootstrap check is named and runs in CI (the old shard did not), guarding #681.

## Result
The whole compiler now compiles under RC and fixpoints — no `analyze_calls` trap — and the live gate asserts it (`[rc-bootstrap] OK`). #556's underlying concern is resolved.

## Verification
- standalone full-build run: `[rc-bootstrap] OK`
- reuse-mode run: `[rc-bootstrap] OK`
- full `selfhost_only_gate` green with the new step; unit-test runner 67/67; stage2==stage3 fixpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUp6jZhxG1w1QBVuqKK9mf

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUp6jZhxG1w1QBVuqKK9mf)_