### PR TITLE
fix(lib): one-char String slice instead of s[i] in scan/args

### DIFF
--- a/vibe/x/args/parser.vibe
+++ b/vibe/x/args/parser.vibe
@@ -39,7 +39,7 @@ export let parse_args = (args: Array[String]) -> ParseResult {
     if j >= String::length(body) {
       tail
     } else {
-      ArgCons(Flag(body[j]), prepend_short_flags(body, j + 1, tail))
+      ArgCons(Flag(String::substring(body, j, j + 1)), prepend_short_flags(body, j + 1, tail))
     }
   }
   let rec r#loop = (i: Int, stop: Bool) -> ParseResult {

--- a/vibe/x/scan/scan.vibe
+++ b/vibe/x/scan/scan.vibe
@@ -15,7 +15,9 @@ export let new = (input: String) -> Scanner {
 }
 
 let char_at = (input: String, pos: Int) -> String {
-  input[pos]
+  // `input[pos]` yields the char CODE (Int, per #667 soundness hardening); a
+  // single-char String needs an explicit one-char slice.
+  String::substring(input, pos, pos + 1)
 }
 
 let clamp_pos = (input: String, pos: Int) -> Int {


### PR DESCRIPTION
## What

`s[i]` on a `String` yields the char **code** (`Int`). After **#667**'s type-system soundness hardening (`a1f24db`), the checker correctly rejects feeding that `Int` where a `String` is expected. Two library modules — **unchanged since #596** — therefore no longer typecheck on current `main`:

- `vibe/x/scan/scan.vibe` → `char_at` returns `input[pos]` annotated `-> String`
- `vibe/x/args/parser.vibe:42` → `Flag(body[j])` (the `Flag` ctor wants a `String`)

Both were also subtly wrong at runtime before (treating a code point as a string). Fix: replace the two `s[i]` sites with `String::substring(s, i, i + 1)`, which returns the intended single-char `String`.

## How this surfaced

The library `vibe test` CI coverage added in **#663** runs an allow-list of 11 `*_test.vibe`; on current `main` these two `*_import_test.vibe` failed to **compile**. Root-caused to the `#667` `s[i]`→`Int` refinement (not a regression — a correct soundness tightening exposing latent library bugs).

## Verification

- Reproduced the compile failures with a fresh CLI built from current `main`:
  - `vibe/x/scan/scan.vibe: return type mismatch: expected String, got Int`
  - `vibe/x/args/parser.vibe:42:15: argument type mismatch for Flag: expected String, got Int`
- With the fix, both `index_import_test.vibe` and `parser_import_test.vibe` **compile and pass** (`_start` exit 0).
- Only 2 single-index-on-String sites exist in these files; slices (`s[a:b]`, `__slice`, polymorphic) are unaffected.
- Compiler bytes are untouched (library-only change), so the selfhost fixpoint is unaffected.

After this merges, **#663**'s allow-list goes 11/11 green on a rebase — no allow-list change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUp6jZhxG1w1QBVuqKK9mf)_