### PR TITLE
installer: macOS bash 3.2 対応 — 実行文字列から非 ASCII を排除

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# vibe installer — toolchain worker (docs/release-roadmap.md テーマ1, #755).
+# vibe installer -- toolchain worker (docs/release-roadmap.md テーマ1, #755).
 #
 # Installs the selfhost vibe toolchain from THIS checkout into a
 # rustup-style layout under $VIBE_HOME (default ~/.vibe):
@@ -8,14 +8,14 @@
 #                                             entry; picks a toolchain)
 #   $VIBE_HOME/toolchain                      default toolchain name
 #   $VIBE_HOME/toolchains/<name>/bin/{vibe,moonrun_wt}
-#   $VIBE_HOME/toolchains/<name>/lib/{vibe-cli.wasm,vibe-cli.cwasm,lsp…}
+#   $VIBE_HOME/toolchains/<name>/lib/{vibe-cli.wasm,vibe-cli.cwasm,lsp...}
 #   $VIBE_HOME/lib/@vibe/{core,ast,parser}    stdlib packages, hash-verified
 #                                             (the default VIBE_LIB root #751
-#                                             — SHARED across toolchains)
-#   $VIBE_HOME/cache/…                        fetch cache (#754 — shared)
+#                                             -- SHARED across toolchains)
+#   $VIBE_HOME/cache/...                        fetch cache (#754 -- shared)
 #
 # A future `vibe toolchain` selector only has to rewrite $VIBE_HOME/toolchain
-# (or set $VIBE_TOOLCHAIN) — the layout already isolates artifacts per
+# (or set $VIBE_TOOLCHAIN) -- the layout already isolates artifacts per
 # toolchain while packages stay content-addressed and shared.
 #
 # Steps:
@@ -27,7 +27,7 @@
 #   4. install the launcher into the toolchain + the dispatcher onto PATH,
 #   5. materialize the stdlib packages into $VIBE_HOME/lib (hash-verified).
 #
-# PATH policy: `$VIBE_HOME/bin` (the dispatcher) IS the PATH entry — the
+# PATH policy: `$VIBE_HOME/bin` (the dispatcher) IS the PATH entry -- the
 # installer writes `$VIBE_HOME/env` (rustup's ~/.cargo/env pattern) and, for
 # a default-prefix install, appends `. "$HOME/.vibe/env"` to the shell rc
 # files (skip with --no-modify-path; custom --prefix installs never touch rc
@@ -84,7 +84,7 @@ if [ -z "$RUNNER_SRC" ]; then
     say "using already-built runner: $RUNNER_SRC"
   else
     command -v cargo >/dev/null 2>&1 || die "cargo not found; pass a prebuilt runner with --runner"
-    say "building runner (cargo build --release)…"
+    say "building runner (cargo build --release)..."
     ( cd "$ROOT_DIR/tools/moonrun_wasmtime" && cargo build --release >/dev/null )
     RUNNER_SRC="$prebuilt"
   fi
@@ -111,7 +111,7 @@ install -m 0644 "$CLI_WASM_SRC" "$TC_DIR/lib/vibe-cli.wasm"
 say "compiler wasm -> $TC_DIR/lib/vibe-cli.wasm"
 
 # 3. install-time AOT (.cwasm) --------------------------------------------
-say "AOT-compiling host-specific .cwasm…"
+say "AOT-compiling host-specific .cwasm..."
 "$TC_DIR/bin/moonrun_wt" --precompile "$TC_DIR/lib/vibe-cli.wasm" \
   -o "$TC_DIR/lib/vibe-cli.cwasm"
 say "AOT compiler -> $TC_DIR/lib/vibe-cli.cwasm"
@@ -183,7 +183,7 @@ if [ "$SET_DEFAULT" = "1" ] || [ ! -f "$VIBE_HOME/toolchain" ]; then
 fi
 
 # 6. stdlib packages (shared, hash-verified) --------------------------------
-# The runtime-relevant standard library is materialized into $VIBE_HOME/lib —
+# The runtime-relevant standard library is materialized into $VIBE_HOME/lib --
 # the default VIBE_LIB resolution root (#751). Verification: the hash of the
 # materialized copy must equal the hash of the source package, computed by
 # the JUST-INSTALLED toolchain (`vibe hash`, ADR-0063 §5).
@@ -215,8 +215,8 @@ fi
 
 # 7. PATH setup --------------------------------------------------------------
 # $VIBE_HOME/bin (the dispatcher) is THE PATH entry. Write the sourceable env
-# file (rustup's ~/.cargo/env pattern) and — for a default-prefix install
-# only — wire it into the shell rc files. A custom --prefix (tests, throwaway
+# file (rustup's ~/.cargo/env pattern) and -- for a default-prefix install
+# only -- wire it into the shell rc files. A custom --prefix (tests, throwaway
 # installs) never touches the user's rc files.
 cat > "$VIBE_HOME/env" <<ENVEOF
 #!/bin/sh

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# vibe curl installer (#755) — the `curl | bash` entry point.
+# vibe curl installer (#755) -- the `curl | bash` entry point.
 #
 #   curl -fsSL https://raw.githubusercontent.com/mizchi/vibe-lang/main/scripts/installer.sh | bash
 #
@@ -7,12 +7,12 @@
 # running inside a checkout) and delegates to scripts/install.sh, which lays
 # down the rustup-style toolchain layout under ~/.vibe:
 #
-#   ~/.vibe/bin/vibe                    dispatcher (put this dir — or the
-#                                       --bin-dir symlink — on PATH)
-#   ~/.vibe/toolchains/<name>/…         compiler wasm + runner + launcher
+#   ~/.vibe/bin/vibe                    dispatcher (put this dir -- or the
+#                                       --bin-dir symlink -- on PATH)
+#   ~/.vibe/toolchains/<name>/...         compiler wasm + runner + launcher
 #   ~/.vibe/lib/@vibe/{core,ast,parser} stdlib packages (hash-verified;
 #                                       the default VIBE_LIB root)
-#   ~/.vibe/cache/…                     package fetch cache
+#   ~/.vibe/cache/...                     package fetch cache
 #
 # The toolchain name defaults to the installed ref, so a future rustup-like
 # selector can install several refs side by side and flip
@@ -29,7 +29,7 @@
 #
 # Requirements: git, bash; cargo (to build the wasmtime runner from source)
 # unless a prebuilt runner is passed through; node is optional (used to
-# freshly self-build the compiler — without it the committed seed compiler
+# freshly self-build the compiler -- without it the committed seed compiler
 # wasm is installed, which is always functional).
 set -euo pipefail
 
@@ -53,7 +53,7 @@ done
 command -v git >/dev/null 2>&1 || die "git is required"
 
 # When already inside a vibe-lang checkout (developer flow), install from it
-# directly. The pipe flow (`curl | bash`) has no checkout — clone one.
+# directly. The pipe flow (`curl | bash`) has no checkout -- clone one.
 SRC_DIR=""
 if [ -f "scripts/install.sh" ] && [ -f "bootstrap/selfhost/seed/selfhost_compiler.wasm" ]; then
   SRC_DIR="$(pwd)"
@@ -61,7 +61,7 @@ if [ -f "scripts/install.sh" ] && [ -f "bootstrap/selfhost/seed/selfhost_compile
 else
   work="$(mktemp -d "${TMPDIR:-/tmp}/vibe-install-XXXXXX")"
   trap 'rm -rf "$work"' EXIT
-  say "cloning $REPO @ $REF…"
+  say "cloning $REPO @ $REF..."
   git clone -q --depth 1 --branch "$REF" "$REPO" "$work/src" \
     || die "clone failed: $REPO @ $REF"
   SRC_DIR="$work/src"
@@ -71,5 +71,5 @@ fi
 # coexist under ~/.vibe/toolchains and a selector can flip between them.
 TOOLCHAIN="$(printf '%s' "$REF" | tr '/' '-')"
 
-say "installing toolchain '$TOOLCHAIN'…"
+say "installing toolchain '$TOOLCHAIN'..."
 bash "$SRC_DIR/scripts/install.sh" --toolchain "$TOOLCHAIN" ${passthrough[@]+"${passthrough[@]}"}


### PR DESCRIPTION
macOS の `/bin/bash` (3.2) は `say "cloning $REPO @ $REF…"` の U+2026 (ellipsis) を変数名の一部として parse し、`set -u` で `REF…: unbound variable` になって curl インストールが即死する (実機報告)。

installer.sh / install.sh の文字列とコメントの ellipsis / em-dash を ASCII に置換し、curl 配布される入口スクリプトを全 ASCII に保つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wo3ZjDzboj8Ps41rv2Qa9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo3ZjDzboj8Ps41rv2Qa9K)_