### PR TITLE
#882: wire `vibe normalize` as a launcher subcommand

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -181,12 +181,15 @@ vibe fmt --dry-run <file...>
 
 ### normalize
 
-Normalize declaration order and apply dead code elimination, then format.
+Canonicalize a source file via the in-compiler normalize engine (#882):
+parse -> module-flatten -> DCE from exported roots -> section layout
+(`//# Imports / Types / Functions / Tests`) re-rendered through the AST
+printer. The default rewrites the file in place.
 
 ```
-vibe normalize <file...>
-vibe normalize --write <file...>
-vibe normalize --check <file...>
+vibe normalize <file.vibe>            # rewrite in place
+vibe normalize --check <file.vibe>    # exit 1 if not normalized (no write)
+vibe normalize --stdout <file.vibe>   # print the result (no write)
 ```
 
 ### init / new

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -38,6 +38,10 @@
 #   vibe binding-at <file.vibe> <line> <col> print binding occurrence spans (START END per line)
 #   vibe symbols <file.vibe>              print declaration outline (NAME KIND START END per line)
 #   vibe diagnostics <file.vibe>          print all syntax/type diagnostics
+#   vibe normalize [--check|--stdout] <file.vibe>
+#                                         canonicalize a source file in place
+#                                         (--check: exit 1 if not normalized;
+#                                          --stdout: print, don't write)
 #   vibe test    <file_test.vibe>...      compile + run test {} blocks
 #   vibe bench   <file.vibe> [--iters N] [--warmup N]
 #                                         run bench {} blocks; report ns/op
@@ -692,6 +696,51 @@ case "$cmd" in
     # A clean file yields empty output; this subcommand always exits 0 (a report,
     # not a failure), so the LSP can treat empty as "no diagnostics".
     if [ -s "$out" ]; then cat "$out"; fi
+    ;;
+  normalize)
+    # vibe normalize [--check|--stdout] <file.vibe>  (#882)
+    # Canonicalize a source file via the in-compiler normalize engine
+    # (parse -> module-flatten -> DCE from exported roots -> section layout,
+    # lib/@vibe/compiler/normalize/index.vibe). Default rewrites in place;
+    # --check exits 1 without writing when the file is not normalized;
+    # --stdout prints the result without writing. Same engine
+    # scripts/vibe_normalize.sh drives in-repo.
+    nmode="write"
+    case "${1:-}" in
+      --check) nmode="check"; shift ;;
+      --stdout) nmode="stdout"; shift ;;
+      -*) die "vibe normalize: unknown flag: $1" ;;
+    esac
+    [ "$#" -ge 1 ] || die "usage: vibe normalize [--check|--stdout] <file.vibe>"
+    src="$1"
+    [ -f "$src" ] || die "not found: $src"
+    cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
+    out="$(mktemp -t vibe-normalize-XXXXXX.vibe)"
+    trap 'rm -f "$out" "$out.diag"' EXIT
+    # Clear inherited compile-mode envs so a leaked VIBE_FS_COMPILE (etc.)
+    # can't divert this into compiling wasm bytes as the "normalized source".
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_TYPE_AT \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_COVERAGE -u VIBE_DEBUG \
+        -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
+      VIBE_NORMALIZE=1 \
+      VIBE_IMPORT_ABI=raw \
+      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
+    if [ ! -s "$out" ]; then
+      [ -s "$out.diag" ] && cat "$out.diag" >&2
+      die "normalize failed: $src"
+    fi
+    case "$nmode" in
+      stdout) cat "$out" ;;
+      check)
+        if cmp -s "$src" "$out"; then
+          exit 0
+        else
+          echo "not normalized: $src" >&2
+          exit 1
+        fi
+        ;;
+      write) cp "$out" "$src" ;;
+    esac
     ;;
   test)
     # `vibe test [--no-cache] <file_test.vibe>...`

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -716,17 +716,26 @@ case "$cmd" in
     [ -f "$src" ] || die "not found: $src"
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
     out="$(mktemp -t vibe-normalize-XXXXXX.vibe)"
-    trap 'rm -f "$out" "$out.diag"' EXIT
-    # Clear inherited compile-mode envs so a leaked VIBE_FS_COMPILE (etc.)
-    # can't divert this into compiling wasm bytes as the "normalized source".
+    trap 'rm -f "$out" "$out.diag" "$out.err"' EXIT
+    # Clear inherited adapter-mode envs. Compile-mode leaks (VIBE_FS_COMPILE
+    # etc.) would divert this into compiling wasm bytes as the "normalized
+    # source"; worse, the adapter handles VIBE_HASH / VIBE_MISSING_VPKG_SCAN /
+    # VIBE_FILL_PINS / VIBE_PUBLISH_CHECK BEFORE VIBE_NORMALIZE, so a leaked
+    # selector would write a hash/report as $out and the default write mode
+    # would copy it OVER the user's source file.
     env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_TYPE_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_COVERAGE -u VIBE_DEBUG \
         -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
+        -u VIBE_HASH -u VIBE_MISSING_VPKG_SCAN -u VIBE_FILL_PINS \
+        -u VIBE_PUBLISH_CHECK \
       VIBE_NORMALIZE=1 \
       VIBE_IMPORT_ABI=raw \
-      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
+      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>"$out.err" || true
     if [ ! -s "$out" ]; then
+      # The normalize adapter branch has no .diag sidecar; the runner's stderr
+      # (parse error etc.) is the only detailed diagnostic — replay it.
       [ -s "$out.diag" ] && cat "$out.diag" >&2
+      [ -s "$out.err" ] && cat "$out.err" >&2
       die "normalize failed: $src"
     fi
     case "$nmode" in
@@ -1076,7 +1085,11 @@ case "$cmd" in
     esac
     ;;
   help|--help|-h)
-    sed -n '13,34p' "$LAUNCHER" | sed 's/^# \{0,1\}//'
+    # Content-anchored (not fixed line numbers): print the whole Subcommands
+    # block up to the `vibe help` line, so newly documented subcommands can't
+    # silently fall outside a stale hardcoded range (Codex review, PR #925 —
+    # the old '13,34p' already cut off everything after `vibe check`).
+    sed -n '/^# Subcommands:/,/^#   vibe help /p' "$LAUNCHER" | sed 's/^# \{0,1\}//'
     ;;
   *)
     die "unknown command: $cmd (try 'vibe help')"

--- a/scripts/test_vibe_cli_install.sh
+++ b/scripts/test_vibe_cli_install.sh
@@ -72,6 +72,15 @@ check "vibe check good exit" "0" "$rc"
 "$VIBE" check "$proj/bad.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
 check "vibe check bad exit" "1" "$rc"
 
+# normalize (#882): --check flags an unnormalized file, in-place write fixes it
+printf 'fn nrm_helper(x: Int) -> Int {\n  x + 1\n}\n\nexport fn nrm_entry(n: Int) -> Int {\n  nrm_helper(n)\n}\n' > "$proj/nrm.vibe"
+"$VIBE" normalize --check "$proj/nrm.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
+check "vibe normalize --check flags unnormalized" "1" "$rc"
+"$VIBE" normalize "$proj/nrm.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
+check "vibe normalize write exit" "0" "$rc"
+"$VIBE" normalize --check "$proj/nrm.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
+check "vibe normalize --check clean after write" "0" "$rc"
+
 # diagnostic: the seed predates the .diag sidecar, so only assert the launcher
 # reports failure cleanly. A freshly built compiler additionally yields a real
 # message; assert that when the sidecar feature is present.


### PR DESCRIPTION
## Summary

Closes #882 (残っていた「ユーザー向けサブコマンド化」部分). The normalize engine (`lib/@vibe/compiler/normalize`, driven by `VIBE_NORMALIZE=1` in the CLI adapter) was already implemented and CI-exercised via `scripts/vibe_normalize.sh`, but the `runtime/vibe` launcher had no `normalize` arm — `vibe normalize` died with "unknown command".

- Adds the `normalize)` launcher arm: in-place rewrite by default, `--check` (exit 1 when not normalized, no write), `--stdout` (print, no write) — same mode surface as the in-repo script. Clears inherited compile-mode env vars the same way the sibling `diagnostics`/`symbols` arms do.
- Updates `docs/cli-commands.md`'s normalize section (it described the retired MoonBit-host `--write <file...>` shape).
- Adds three install-smoke cases (`--check` flags unnormalized → write fixes → `--check` clean).

## Test plan

- [x] Verified end to end locally against the pinned seed (runner shimmed to the node host runner): `--stdout` prints the canonicalized source, `--check` returns 1 → in-place write → `--check` returns 0, write is idempotent (`--stdout` output equals the written file), unknown flag and missing file die cleanly with usage messages.
- [x] `bash -n` on both edited scripts.
- [x] No compiler-source changes — bundles/gates unaffected; the new smoke cases run in the `smoke (install)` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H

---
_Generated by [Claude Code](https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H)_