### PR TITLE
#805: registry minimal slice (transparency log + yank + vibe pkg) & vibe shell REPL

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -160,10 +160,15 @@ Line classification:
   whole buffer; on any diagnostic it is **rolled back**, so the buffer can
   never become poisoned.
 - Any other line is treated as an expression: it is wrapped in a synthetic
-  entry (the ADR-0069 wrap-in-main story) that binds the value and prints it
-  via string interpolation, compiled against the buffer, and the produced
-  wasm is executed. If the printable wrapper does not compile (e.g. the
-  needed effect row differs), it is retried effects-only with a notice.
+  Int-returning entry (the ADR-0069 `let main` return-print convention — the
+  same channel `vibe run` prints through), compiled against the buffer, and
+  the produced wasm is executed. If the Int wrapper does not compile (a
+  non-Int value, or an effect row the wrapper lacks), it is retried
+  effects-only with a notice — use `:type` to inspect non-Int values.
+  (Richer printing is blocked on known gaps: the `println`/`print` builtins
+  have no codegen lowering in bare FS-mode compiles, prelude/io's
+  `stdout_write` drags `vibe::*` host imports the standalone runner does not
+  define, and `Stdout::write_char` writes the raw tagged value.)
 - REPL commands: `:help`, `:quit`/`:q`, `:list` (print the buffer),
   `:clear`, `:load <file>` (append a file to the buffer, validated with
   rollback), `:type <expr>` (inferred type, backed by the `vibe type-at`
@@ -180,8 +185,8 @@ Caveats (by design of the compiled model):
 - Diagnostics point into the composed session program: for a rejected
   declaration/`:load` the reported line matches the `:list` buffer;
   expression errors reference the synthetic wrapper.
-- Values without printable interpolation (closures, enums/structs without
-  `Show`) may print an opaque runtime value.
+- Only Int values print today (see above); everything else evaluates
+  effects-only with a stderr notice.
 - The session lives in a temp dir with a `lib` symlink, so stdlib imports
   (`import ./lib/@vibe/...`) resolve; other relative imports do not move
   with the session.

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -139,27 +139,56 @@ vibe check <file...>
 vibe check --profile-tsv timing.tsv <file...>
 ```
 
-### shell (Interactive Shell)
+### shell (Compiled REPL) (#805)
 
-Interactive TUI shell for evaluating vibe expressions.
-
-```
-vibe shell
-vibe shell --tui           # TUI mode
-vibe shell --ai            # AI-assisted mode
-vibe shell --no-posix      # disable shell/POSIX commands
-```
-
-### shell-stdin
-
-Line-oriented shell reading from stdin. Suitable for piping input or non-interactive use.
+Minimal REPL implemented in the launcher. Per ADR-0034 there is **no
+interpreter**: the session is a buffer of top-level declarations kept in a
+temp dir, and every input line triggers a full recompile of that buffer
+through the same compile path as `vibe run` (accumulate + recompile).
 
 ```
-vibe shell-stdin
-vibe shell-stdin --no-prompt
-vibe shell-stdin --tty
-vibe shell-stdin --no-tty
+vibe shell                    # interactive (prompt on a tty)
+vibe shell prelude.vibe       # preload a file's declarations into the session
+printf '...\n' | vibe shell   # stdin not a tty: no prompts, scriptable
 ```
+
+Line classification:
+
+- A line starting with a declaration keyword (`fn`/`let`/`struct`/`enum`/
+  `type`/`import`/`effect`/`impl`/`trait`/`export`/`suberror`/`test`) is
+  appended to the session buffer. The append is validated by recompiling the
+  whole buffer; on any diagnostic it is **rolled back**, so the buffer can
+  never become poisoned.
+- Any other line is treated as an expression: it is wrapped in a synthetic
+  entry (the ADR-0069 wrap-in-main story) that binds the value and prints it
+  via string interpolation, compiled against the buffer, and the produced
+  wasm is executed. If the printable wrapper does not compile (e.g. the
+  needed effect row differs), it is retried effects-only with a notice.
+- REPL commands: `:help`, `:quit`/`:q`, `:list` (print the buffer),
+  `:clear`, `:load <file>` (append a file to the buffer, validated with
+  rollback), `:type <expr>` (inferred type, backed by the `vibe type-at`
+  editor primitive).
+
+Caveats (by design of the compiled model):
+
+- **Earlier side effects re-run on every expression line.** Each evaluation
+  compiles and runs a fresh program, so the whole session replays. This is
+  the honest compiled-REPL reading of ADR-0069's memoized-thunk semantics:
+  until binding-level memoization lands in the compiler, "memoization" is
+  re-computation from source, not a persistent process image.
+- Declarations must fit on one line (no multi-line continuation yet).
+- Diagnostics point into the composed session program: for a rejected
+  declaration/`:load` the reported line matches the `:list` buffer;
+  expression errors reference the synthetic wrapper.
+- Values without printable interpolation (closures, enums/structs without
+  `Show`) may print an opaque runtime value.
+- The session lives in a temp dir with a `lib` symlink, so stdlib imports
+  (`import ./lib/@vibe/...`) resolve; other relative imports do not move
+  with the session.
+
+The pre-#594 MoonBit-host `shell` variants (`--tui`, `--ai`, `--no-posix`)
+and the separate `shell-stdin` command were retired; `vibe shell` reads
+stdin line-oriented whenever stdin is not a tty.
 
 ### fetch / update-lock
 
@@ -256,14 +285,6 @@ Materialize transitive closure payload from a source file.
 vibe emit-closure-payload <in> <out>
 ```
 
-### wasm-shell-stdin
-
-Line-oriented shell that compiles each expression to a separate WASM file. Used for testing the compilation pipeline.
-
-```
-vibe wasm-shell-stdin [--no-prompt] [-o dir]
-```
-
 ### session-http / session-json
 
 Opt-in persistent session workers that accelerate `run`/`check`/`test` by keeping compilation state in memory.
@@ -282,9 +303,11 @@ Opt-in persistent session workers that accelerate `run`/`check`/`test` by keepin
 
 | Mode | Interface | Use Case |
 |------|-----------|----------|
-| `shell` | Interactive TUI | Day-to-day interactive exploration |
-| `shell-stdin` | stdin/stdout line shell | Scripting, piping, CI, editor integration |
-| `wasm-shell-stdin` | stdin/stdout, writes `.wasm` per expression | Internal: testing the WASM compilation pipeline |
+| `shell` (tty) | prompt loop, compiled REPL | Interactive exploration |
+| `shell` (piped stdin) | line-oriented, no prompts | Scripting, CI, editor integration |
+
+(The retired MoonBit-host `shell-stdin` / `wasm-shell-stdin` modes were
+removed in #594; both are covered by piping into `vibe shell`.)
 
 ## Global Flags
 

--- a/docs/registry-design.md
+++ b/docs/registry-design.md
@@ -96,10 +96,73 @@ vibe_pkg.sh add git:<url>@<ref>[#<sub/dir>]       [#pkg:sha1:<40hex>] [--store]
 - **移行**: Phase 0 の versions.tsv / provenance.tsv は形式そのまま log
   レコードの部分集合なので、レジストリ稼働時に初期 log へ取り込める
 
+## Phase 1 最小スライス (実装済み, #805)
+
+要件 1 (transparency log) と 5 (yank 不変) のファイルベース実装。DB もサーバ
+コードも持たない — 「レジストリ」は rsync / 静的 HTTP でそのまま配れる
+ディレクトリ 1 個で、`VIBE_REGISTRY_LOG_DIR` (default `$VIBE_HOME/log`) が
+それを指す。`vibe pkg publish|install|add|yank|update` (launcher #805) と
+`scripts/vibe_pkg.sh` (in-repo) が同一実装を共有する
+(`VIBE_PKG_RUNNER`/`VIBE_PKG_CLI_WASM` で hash エンジンを差し替え、install 時は
+toolchain の `lib/vibe_pkg.sh` に同梱されるので checkout 不要)。
+
+### ログのレイアウト
+
+- `records.tsv` — append-only、1 イベント 1 行:
+  `<ordinal>\t<op>\t<name@version>\t<pkg-hash>\t<contract-hash>\t<source>\t<commit>`
+  (`op` = `publish` | `yank`)。**レコードに wall-clock を含めない** — 順序は
+  log 順そのもの (ordinal = 0-based 行位置) なので、レコード列は決定的な
+  バイト列として再現・監査できる
+- `head` — `"<size>\t<merkle-root>"` 1 行。sumdb の STH に相当 (署名は
+  Phase 2 の scope 所有権/鍵の仕事で、この slice では未搭載)
+
+### Merkle / 検証 (この slice の保守的選択)
+
+- **hash**: sha256、RFC6962 流のドメイン分離 —
+  `leaf = sha256("leaf:" + record行)`, `node = sha256("node:" + L + ":" + R)`。
+  内部 node は raw bytes でなく **hex 文字列連結**を hash する (bash 検証器の
+  可搬性優先)。木の**形状** (largest-power-of-two split) は RFC6962 そのもの
+  なので、将来 @vibe/core sha1/sha256 上に vibe で書き直す検証器へ proof が
+  1:1 で移行できる
+- **install/add 時のクライアント検証**: (a) head が records に正確に commit
+  しているか再計算 (改竄検出)、(b) 前回見た head との **prefix 一貫性**
+  (`$VIBE_HOME/cache/log-head.seen.<logdir-digest>` に size+root を記録し、
+  head は「伸びる」ことしか許さない — 縮んだら truncation、prefix root が
+  変わったら history 書き換えで拒否)、(c) 該当 publish レコードの
+  **inclusion proof** (audit path を生成して root まで再計算)。静的ファイル
+  配信でクライアントは records 全体を持つため、consistency は O(log n)
+  proof でなく prefix 再計算で検証する — remote proof プロトコルは log が
+  full fetch に収まらなくなった段階の仕事
+- **publish** は log を伸ばす前に同じ self/consistency 検証を行う (改竄済み
+  log への追記を拒否)。version→hash 不変性 (同一 version 再公開拒否) は
+  従来どおり log 追記の前に判定されるので、拒否された publish は log を
+  伸ばさない
+- **yank** は `yank` レコードの追記のみ (要件 5)。versions.tsv / CAS は
+  不変で、既存 pin のビルドは動き続ける。`install` は yank された version を
+  `--allow-yanked` なしでは拒否、`add` (明示 source 指定の lane) は警告のみ。
+  git-add (TOFU) しか経ていない version は log に publish レコードがないので
+  yank 対象外 (phase-0 lane のまま)
+
+### 実装済みの範囲と既知の gap
+
+- `vibe pkg update <name>` は最新の **non-yanked** version へ切り替え、切り替え
+  前に contract hash の変化と contract (index.vibei) の textual diff を表示
+  する。要件 4 の canonical な diff (contract_surface_lines の集合差分 +
+  effect row の capability 分類) は compiler 側に shell から叩ける adapter
+  mode がまだ無いため未実装 — adapter mode (`VIBE_SURFACE=1` 相当) の追加が
+  次の一歩
+- scope 所有権 / 署名 (要件 2)、typosquat 検査、publish attestation
+  (要件 6 の log 掲載) は未実装 — log レコードの `source`/`commit` 列は
+  そのための席で、local publish は `local\t-` を書く
+- 検証: gate 6l (publish→log 追記 + inclusion 検証 / 拒否 republish が log を
+  伸ばさない / head 改竄検出 / truncation 拒否 / yank + --allow-yanked /
+  served copy を `VIBE_REGISTRY_LOG_DIR` で検証)
+
 ## 関連
 
 - ADR-0063 (content addressing / store / pin), ADR-0065 (layout / 解決順 /
   サプライチェーン要件)
 - #751 (解決順 + VIBE_LIB + freeze), #754 (version directive / cache /
-  materialize / 同一 version 再公開禁止), #755 (本設計)
-- `scripts/vibe_pkg.sh` (publish / install / add), gate 6h–6k
+  materialize / 同一 version 再公開禁止), #755 (本設計), #805 (Phase 1
+  最小スライス: transparency log + yank + `vibe pkg`)
+- `scripts/vibe_pkg.sh` (publish / install / add / yank / update), gate 6h–6l

--- a/docs/tutorial/07_modules_packages.md
+++ b/docs/tutorial/07_modules_packages.md
@@ -69,12 +69,18 @@ import @vibe/core { sha1 }
 `VIBE_REQUIRE_PINS=1` (release/publish の freeze) では pin なしの
 dev-mode 解決はエラーになる。
 
-## 配布コマンド (scripts/vibe_pkg.sh)
+## 配布コマンド (`vibe pkg` / scripts/vibe_pkg.sh)
+
+インストール済みの toolchain では `vibe pkg <cmd>`、repo 内では
+`scripts/vibe_pkg.sh <cmd>` (同一実装)。publish/yank は transparency log
+(`$VIBE_HOME/log`, #805) に追記され、install はその inclusion proof を検証する。
 
 ```bash
-vibe_pkg.sh publish lib/@you/pkg                 # semver gate + cache へ格納
-vibe_pkg.sh install @you/pkg@1.0.0               # ~/.vibe/lib へ materialize
-vibe_pkg.sh add github:owner/repo/dir@ref [#pin] # git から hash 検証付き取得
+vibe pkg publish lib/@you/pkg                 # semver gate + cache + log 追記
+vibe pkg install @you/pkg@1.0.0               # ~/.vibe/lib へ materialize (log 検証)
+vibe pkg add github:owner/repo/dir@ref [#pin] # git から hash 検証付き取得
+vibe pkg yank @you/pkg@1.0.0                  # 撤回マーキング (append-only)
+vibe pkg update @you/pkg                      # 最新 non-yanked へ (契約 diff 表示)
 ```
 
 詳細: [docs/adding-modules.md](../adding-modules.md) /

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -46,6 +46,9 @@
 #   vibe bench   <file.vibe> [--iters N] [--warmup N]
 #                                         run bench {} blocks; report ns/op
 #                                         (min/p50/p95/mean), ops/sec, bytes/op
+#   vibe shell   [file.vibe]              interactive compiled REPL: declarations
+#                                         accumulate, each line recompiles+runs
+#                                         (type :help inside for commands)
 #   vibe new     <dir>                    scaffold a starter project
 #   vibe add     <name> <url> [dir]       add a dependency to vibe.deps + fetch
 #   vibe fetch   [--frozen] [dir]        vendor git/URL deps from vibe.deps + lock
@@ -848,6 +851,197 @@ case "$cmd" in
     [ -n "$iters" ] && bench_env="$bench_env VIBE_BENCH_ITERS=$iters"
     [ -n "$warmup" ] && bench_env="$bench_env VIBE_BENCH_WARMUP=$warmup"
     env $bench_env "$RUNNER" --bench "$out"
+    ;;
+  shell)
+    # #805: `vibe shell [file.vibe]` — minimal compiled REPL.
+    #
+    # ADR-0034 mandates compiled-only execution (no interpreter), so the REPL
+    # is "accumulate + recompile": the session is a buffer of top-level
+    # declarations kept in a temp dir, and EVERY input line triggers a full
+    # recompile of that buffer through the same compile_to path as `vibe run`:
+    #   * a declaration line appends to the buffer, is validated by compiling
+    #     the whole buffer, and is ROLLED BACK on any diagnostic — the buffer
+    #     can never become poisoned;
+    #   * an expression line is wrapped in a synthetic entry (the ADR-0069
+    #     wrap-in-main story), compiled against the buffer, and the produced
+    #     wasm is executed. Because each evaluation is a fresh program run,
+    #     earlier side effects re-run on every line (see docs/cli-commands.md).
+    # stdin not a tty => no prompt is printed (bash `read -p` only prompts on a
+    # terminal), so `printf '...' | vibe shell` is deterministic for scripting.
+    repl_file=""
+    if [ "$#" -ge 1 ]; then repl_file="$1"; fi
+    repl_dir="$(mktemp -d -t vibe-shell-XXXXXX)"
+    trap 'rm -rf "$repl_dir"' EXIT
+    repl_buf="$repl_dir/session.vibe"
+    : > "$repl_buf"
+    # Stdlib imports (`import ./lib/@vibe/...`) resolve inside the session dir
+    # the same way the doctest harness resolves them: a `lib` symlink to the
+    # install/checkout lib root. (Relative imports of OTHER user files do not
+    # move with the session — load such files from their own directory.)
+    [ -d "$VIBE_HOME/lib" ] && ln -sfn "$VIBE_HOME/lib" "$repl_dir/lib"
+
+    # Validate the current buffer: compile buffer + an anchor fn with the test
+    # entry (`__no_entry__`), so the WHOLE buffer is parse+type checked, not
+    # just the decls reachable from one entry. The anchor mirrors the doctest
+    # harness's __doctest_anchor: a declaration-only buffer otherwise fails
+    # with "no functions found to compile". Diagnostics go to stderr via
+    # compile_to; line N in the reported location = line N of the buffer
+    # (`:list` shows it), because the anchor is appended after it.
+    repl_validate() {
+      local f="$repl_dir/__validate__.vibe" w="$repl_dir/__validate__.wasm"
+      { cat "$repl_buf"
+        printf 'export let __repl_anchor__: () -> Int = () -> { 0 }\n'
+      } > "$f"
+      compile_to "$f" "$w" "__no_entry__"
+    }
+
+    # Evaluate an expression: wrap it in a synthetic main that binds the value
+    # and prints it via string interpolation (works for Int/Bool/String/...).
+    # If that wrapper does not compile (e.g. the value's type has no
+    # interpolation support, or printing needs an effect row the wrapper lacks)
+    # retry a second wrapper that only executes the expression for its effects
+    # and say so. If both fail, report the FIRST wrapper's diagnostic. The
+    # harness import goes AFTER the buffer (legal in vibe) so buffer line
+    # numbers stay exact in diagnostics; a duplicate user import of
+    # stdout_write is harmless (verified: duplicate imports are accepted).
+    repl_eval() {
+      local expr="$1" rc=0
+      local f="$repl_dir/__eval__.vibe" w="$repl_dir/__eval__.wasm"
+      local err1="$repl_dir/__eval__.err1"
+      { cat "$repl_buf"
+        printf 'import ./lib/@vibe/prelude/io.vibe { stdout_write }\n'
+        printf 'export let __repl_main__: () -> Unit with { Stdout } = () -> {\n'
+        printf '  let __repl_v__ = (\n%s\n  )\n' "$expr"
+        printf '  stdout_write("\\{__repl_v__}\\n")\n'
+        printf '}\n'
+      } > "$f"
+      if compile_to "$f" "$w" "__repl_main__" 2>"$err1"; then
+        "$RUNNER" "$w" || rc=$?
+        [ "$rc" -ne 0 ] && echo "vibe shell: runtime error (exit $rc)" >&2
+        return 0
+      fi
+      # Fallback wrapper is deliberately UNANNOTATED so the effect row is
+      # inferred — it absorbs expressions whose row does not fit the printable
+      # wrapper's `with { Stdout }`. Cost: the runner prints the entry's unit
+      # return as a trailing `0` line (annotated-Unit entries don't do this).
+      { cat "$repl_buf"
+        printf 'export let __repl_main__ = () -> {\n'
+        printf '  let _ = (\n%s\n  )\n  ()\n}\n' "$expr"
+      } > "$f"
+      if compile_to "$f" "$w" "__repl_main__" 2>/dev/null; then
+        echo "vibe shell: value is not printable; evaluated for effects only" >&2
+        "$RUNNER" "$w" || rc=$?
+        [ "$rc" -ne 0 ] && echo "vibe shell: runtime error (exit $rc)" >&2
+        return 0
+      fi
+      cat "$err1" >&2
+      return 1
+    }
+
+    # `:type <expr>` — bind the expression to a top-level probe let appended
+    # after the buffer, then ask the type-at editor primitive (the LSP hover
+    # backend) for the probe's inferred type. col 5 = first char of
+    # `__repl_t__` in `let __repl_t__ = (...)`. Empty output (bad expr /
+    # query miss) degrades to a notice, never kills the session.
+    repl_type() {
+      local expr="$1"
+      local f="$repl_dir/__type__.vibe" tline tout
+      cp "$repl_buf" "$f"
+      tline=$(( $(wc -l < "$f") + 1 ))
+      printf 'let __repl_t__ = (%s)\n' "$expr" >> "$f"
+      tout="$("$LAUNCHER" type-at "$f" "$tline" 5 2>/dev/null || true)"
+      if [ -n "$tout" ]; then
+        printf '%s\n' "$tout"
+      else
+        echo "vibe shell: could not infer a type for: $expr" >&2
+      fi
+    }
+
+    if [ -n "$repl_file" ]; then
+      [ -f "$repl_file" ] || die "not found: $repl_file"
+      cat "$repl_file" >> "$repl_buf"
+      printf '\n' >> "$repl_buf"
+      repl_validate || die "shell: preloaded file does not compile: $repl_file"
+    fi
+
+    while IFS= read -r -p 'vibe> ' repl_line; do
+      # trim surrounding whitespace; skip blank lines
+      repl_trimmed="${repl_line#"${repl_line%%[![:space:]]*}"}"
+      repl_trimmed="${repl_trimmed%"${repl_trimmed##*[![:space:]]}"}"
+      [ -n "$repl_trimmed" ] || continue
+      case "$repl_trimmed" in
+        :q|:quit)
+          break
+          ;;
+        :help)
+          cat <<'REPL_HELP'
+vibe shell — compiled REPL (accumulate + recompile; no interpreter)
+  :help            show this help
+  :quit, :q        exit
+  :list            print the session buffer (accumulated declarations)
+  :clear           reset the session buffer
+  :load <file>     append a file's declarations to the buffer (validated)
+  :type <expr>     print the inferred type of an expression
+Any line starting with a declaration keyword (fn/let/struct/enum/type/
+import/effect/impl/trait/export/suberror/test) is appended to the session
+buffer; the append is validated by a full recompile and rolled back on
+error. Any other line is compiled as an expression against the buffer and
+executed. Declarations must fit on one line. Each evaluation runs a fresh
+program, so earlier side effects re-run on every expression line.
+REPL_HELP
+          ;;
+        :list)
+          cat "$repl_buf"
+          ;;
+        :clear)
+          : > "$repl_buf"
+          echo "session cleared"
+          ;;
+        :load)
+          echo "usage: :load <file.vibe>" >&2
+          ;;
+        :load\ *)
+          repl_lf="${repl_trimmed#:load }"
+          if [ ! -f "$repl_lf" ]; then
+            echo "vibe shell: not found: $repl_lf" >&2
+            continue
+          fi
+          cp "$repl_buf" "$repl_buf.bak"
+          cat "$repl_lf" >> "$repl_buf"
+          printf '\n' >> "$repl_buf"
+          if repl_validate; then
+            rm -f "$repl_buf.bak"
+            echo "loaded $repl_lf"
+          else
+            mv -f "$repl_buf.bak" "$repl_buf"
+            echo "vibe shell: load rejected (buffer unchanged): $repl_lf" >&2
+          fi
+          ;;
+        :type)
+          echo "usage: :type <expr>" >&2
+          ;;
+        :type\ *)
+          repl_type "${repl_trimmed#:type }"
+          ;;
+        :*)
+          echo "vibe shell: unknown command: ${repl_trimmed%% *} (try :help)" >&2
+          ;;
+        fn\ *|let\ *|struct\ *|enum\ *|type\ *|import\ *|effect\ *|impl\ *|trait\ *|export\ *|suberror\ *|test\ *|//*)
+          cp "$repl_buf" "$repl_buf.bak"
+          printf '%s\n' "$repl_line" >> "$repl_buf"
+          if repl_validate; then
+            rm -f "$repl_buf.bak"
+          else
+            mv -f "$repl_buf.bak" "$repl_buf"
+            echo "vibe shell: declaration rejected (buffer unchanged)" >&2
+          fi
+          ;;
+        *)
+          repl_eval "$repl_trimmed" || true
+          ;;
+      esac
+    done
+    exit 0
     ;;
   new)
     # vibe new <dir>  — scaffold a starter project (main.vibe + empty vibe.deps)

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -895,24 +895,29 @@ case "$cmd" in
       compile_to "$f" "$w" "__no_entry__"
     }
 
-    # Evaluate an expression: wrap it in a synthetic main that binds the value
-    # and prints it via string interpolation (works for Int/Bool/String/...).
-    # If that wrapper does not compile (e.g. the value's type has no
-    # interpolation support, or printing needs an effect row the wrapper lacks)
-    # retry a second wrapper that only executes the expression for its effects
-    # and say so. If both fail, report the FIRST wrapper's diagnostic. The
-    # harness import goes AFTER the buffer (legal in vibe) so buffer line
-    # numbers stay exact in diagnostics; a duplicate user import of
-    # stdout_write is harmless (verified: duplicate imports are accepted).
+    # Evaluate an expression: wrap it in a synthetic Int-returning let-entry
+    # and let the runner's entry-return print convention (ADR-0069 `let main`
+    # rule — the same channel `vibe run hello.vibe` prints 42 through) show
+    # the value. This is the ONLY printing channel that works on every
+    # runner/compile-mode combination today:
+    #   - prelude/io.vibe's stdout_write drags the io unit's whole `vibe::*`
+    #     host-import surface into the wasm — vibewt refuses to instantiate
+    #     (unknown import `vibe::stdin_read_char`); the PR #927 CI failure.
+    #   - the `println`/`print` checker builtins have no codegen lowering in
+    #     bare FS-mode compiles ("undefined variable (local): println @call").
+    #   - `Stdout::write_char` writes the raw TAGGED value (42 prints as
+    #     "hd") on both runners.
+    # Consequence: Int expressions print; non-Int expressions fall back to
+    # the effects-only wrapper below with an honest notice. Richer printing
+    # is blocked on the println-in-FS-mode gap (tracked in the #805 REPL
+    # follow-ups).
     repl_eval() {
       local expr="$1" rc=0
       local f="$repl_dir/__eval__.vibe" w="$repl_dir/__eval__.wasm"
       local err1="$repl_dir/__eval__.err1"
       { cat "$repl_buf"
-        printf 'import ./lib/@vibe/prelude/io.vibe { stdout_write }\n'
-        printf 'export let __repl_main__: () -> Unit with { Stdout } = () -> {\n'
-        printf '  let __repl_v__ = (\n%s\n  )\n' "$expr"
-        printf '  stdout_write("\\{__repl_v__}\\n")\n'
+        printf 'export let __repl_main__: () -> Int = () -> {\n'
+        printf '  (\n%s\n  )\n' "$expr"
         printf '}\n'
       } > "$f"
       if compile_to "$f" "$w" "__repl_main__" 2>"$err1"; then
@@ -921,15 +926,15 @@ case "$cmd" in
         return 0
       fi
       # Fallback wrapper is deliberately UNANNOTATED so the effect row is
-      # inferred — it absorbs expressions whose row does not fit the printable
-      # wrapper's `with { Stdout }`. Cost: the runner prints the entry's unit
-      # return as a trailing `0` line (annotated-Unit entries don't do this).
+      # inferred — it absorbs non-Int expressions and expressions whose row
+      # does not fit the Int wrapper. Cost: the runner prints the entry's
+      # unit return as a trailing `0` line (annotated-Unit entries don't).
       { cat "$repl_buf"
         printf 'export let __repl_main__ = () -> {\n'
         printf '  let _ = (\n%s\n  )\n  ()\n}\n' "$expr"
       } > "$f"
       if compile_to "$f" "$w" "__repl_main__" 2>/dev/null; then
-        echo "vibe shell: value is not printable; evaluated for effects only" >&2
+        echo "vibe shell: non-Int value; evaluated for effects only (use :type to inspect)" >&2
         "$RUNNER" "$w" || rc=$?
         [ "$rc" -ne 0 ] && echo "vibe shell: runtime error (exit $rc)" >&2
         return 0

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -50,6 +50,16 @@
 #   vibe add     <name> <url> [dir]       add a dependency to vibe.deps + fetch
 #   vibe fetch   [--frozen] [dir]        vendor git/URL deps from vibe.deps + lock
 #   vibe verify  [dir]                    re-check vendored deps against vibe.lock
+#   vibe pkg     publish <pkg_dir>        publish a package: semver gate, CAS,
+#                                         transparency-log record (#805)
+#   vibe pkg     install <name>@<ver> [--store] [--allow-yanked]
+#                                         materialize a published version
+#                                         (verifies the log inclusion proof)
+#   vibe pkg     add <source-spec> [#pkg:sha1:<hex>] [--store]
+#                                         fetch straight from git, hash-verified
+#   vibe pkg     yank <name>@<ver>        mark a version yanked (append-only)
+#   vibe pkg     update <name> [--store]  switch to the newest non-yanked
+#                                         version, showing the contract diff
 #   vibe lsp                              start the stdio LSP server (diagnostics)
 #   vibe version                          print toolchain versions
 #   vibe self update [--cli-wasm <path>]  refresh compiler wasm + rebuild .cwasm
@@ -1052,6 +1062,25 @@ case "$cmd" in
     fi
     cat "$hout"
     rm -f "$hout" "$hout.diag"
+    ;;
+  pkg)
+    # vibe pkg publish|install|add|yank|update — the registry lane
+    # (#754/#755/#805) over $VIBE_HOME/{cache,lib,log}. Delegates to
+    # vibe_pkg.sh: the copy installed into the toolchain lib/ first
+    # (standalone install, no checkout), the repo copy when running from a
+    # checkout. The launcher hands over its own runner + compiler wasm via
+    # VIBE_PKG_RUNNER/VIBE_PKG_CLI_WASM, so the script needs no repo-local
+    # node host runner. Distinct from `vibe add/fetch/verify` (the
+    # vibe.deps/vibe.lock vendoring lane): `vibe pkg` is the content-
+    # addressed @scope/name package lane (ADR-0065).
+    pkg_sh=""
+    for cand in "$TOOLCHAIN_DIR/lib/vibe_pkg.sh" "$SELF/../scripts/vibe_pkg.sh"; do
+      [ -f "$cand" ] && { pkg_sh="$cand"; break; }
+    done
+    [ -n "$pkg_sh" ] || die "vibe pkg: vibe_pkg.sh not found (looked in $TOOLCHAIN_DIR/lib and the repo scripts/)"
+    cli="$(pick_cli)"
+    exec env VIBE_PKG_RUNNER="$RUNNER" VIBE_PKG_CLI_WASM="$cli" VIBE_HOME="$VIBE_HOME" \
+      bash "$pkg_sh" "$@"
     ;;
   version|--version|-V)
     echo "vibe (selfhost launcher)"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,7 +15,8 @@ The selfhost `vibe` subcommands as scripts (used by `pkf run` + tests).
 - `vibe_test.sh` — run `test {}` blocks. `vibe_test_smoke.sh`
 - `vibe_fmt.sh` / `vibe_normalize.sh` (+ `*_smoke.sh`) — format / normalize
 - `vibe_cli.sh` (+ smoke) — drive the selfhost CLI wasm
-- `vibe_pkg.sh` — package fetch/add (hash-verified). `vibe_core_install.sh`
+- `vibe_pkg.sh` — package publish/install/add/yank/update (hash-verified,
+  transparency-log backed #805; `vibe pkg` delegates here). `vibe_core_install.sh`
 - `vibe_graph.js` — graph/symbol-index query
 
 ## Runtime & runners (wasm execution)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -800,6 +800,134 @@ fi
 rm -rf "$kdir" "$khome" "$khome2" "$krepo"
 echo "[compiler-gate] registry-less git resolution ok"
 
+# 6l. registry transparency log + yank (#805, ADR-0065 Phase 5 minimal
+#     slice): publish appends an ordinal record to $VIBE_HOME/log/records.tsv
+#     and maintains a Merkle head; install verifies (a) the served head
+#     commits to the served records (tamper check), (b) prefix consistency
+#     against the last head this client saw (the log may only ever extend),
+#     and (c) an inclusion proof for the claimed name@version -> hash record
+#     against the head root. yank is an append-only marking that install
+#     refuses without --allow-yanked while versions.tsv (the immutable
+#     version->hash mapping) stays untouched. The log dir is static files:
+#     VIBE_REGISTRY_LOG_DIR points a client at a served copy.
+echo "[compiler-gate] 6l registry transparency log + yank (#805)"
+lhome805="$(mktemp -d)"
+lsrc805="$lhome805/src/@gate805/logx"
+mkdir -p "$lsrc805"
+printf 'version 1.0.0\n\nfn triple(x: Int) -> Int\n' > "$lsrc805/index.vibei"
+printf 'export fn triple(x: Int) -> Int { x * 3 }\n' > "$lsrc805/impl.vibe"
+ldir805="_build/_gate_pkg805"
+rm -rf "$ldir805"; mkdir -p "$ldir805"
+# (1) publish appends a publish record and writes a merkle head
+if ! VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh publish "$lsrc805" > "$ldir805/pub1.log" 2>&1; then
+  echo "[compiler-gate] FAIL: publish of @gate805/logx@1.0.0 failed (#805)" >&2
+  cat "$ldir805/pub1.log" >&2; exit 1
+fi
+if ! awk -F'\t' '$1 == "0" && $2 == "publish" && $3 == "@gate805/logx@1.0.0"' "$lhome805/log/records.tsv" 2>/dev/null | grep -q .; then
+  echo "[compiler-gate] FAIL: publish did not append a transparency-log record (#805)" >&2
+  cat "$lhome805/log/records.tsv" 2>/dev/null >&2; exit 1
+fi
+if [ ! -s "$lhome805/log/head" ]; then
+  echo "[compiler-gate] FAIL: publish did not write a merkle head (#805)" >&2; exit 1
+fi
+cp "$lhome805/log/records.tsv" "$ldir805/log1.records"
+cp "$lhome805/log/head" "$ldir805/log1.head"
+# (2) a second publish extends the log; install verifies an inclusion proof
+printf 'version 1.1.0\n\nfn triple(x: Int) -> Int\nfn nona(x: Int) -> Int\n' > "$lsrc805/index.vibei"
+printf 'export fn triple(x: Int) -> Int { x * 3 }\nexport fn nona(x: Int) -> Int { x * 9 }\n' > "$lsrc805/impl.vibe"
+if ! VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh publish "$lsrc805" > "$ldir805/pub2.log" 2>&1; then
+  echo "[compiler-gate] FAIL: publish of @gate805/logx@1.1.0 failed (#805)" >&2
+  cat "$ldir805/pub2.log" >&2; exit 1
+fi
+if [ "$(wc -l < "$lhome805/log/records.tsv" | tr -d '[:space:]')" != "2" ]; then
+  echo "[compiler-gate] FAIL: second publish did not extend the log to 2 records (#805)" >&2
+  cat "$lhome805/log/records.tsv" >&2; exit 1
+fi
+if ! VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh install "@gate805/logx@1.0.0" > "$ldir805/inst1.log" 2>&1; then
+  echo "[compiler-gate] FAIL: install of a logged version failed (#805)" >&2
+  cat "$ldir805/inst1.log" >&2; exit 1
+fi
+if ! grep -q "inclusion verified for @gate805/logx@1.0.0" "$ldir805/inst1.log"; then
+  echo "[compiler-gate] FAIL: install did not verify the log inclusion proof (#805)" >&2
+  cat "$ldir805/inst1.log" >&2; exit 1
+fi
+cp "$lhome805/log/records.tsv" "$ldir805/log2.records"
+cp "$lhome805/log/head" "$ldir805/log2.head"
+# (3) same-version republish with different content is still rejected — and
+#     the rejected publish must NOT grow the log
+printf 'export fn triple(x: Int) -> Int { x * 3 + 1 }\nexport fn nona(x: Int) -> Int { x * 9 }\n' > "$lsrc805/impl.vibe"
+if VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh publish "$lsrc805" > "$ldir805/pub3.log" 2>&1; then
+  echo "[compiler-gate] FAIL: same-version republish was accepted (#805)" >&2; exit 1
+fi
+if ! grep -q "same-version republish rejected" "$ldir805/pub3.log"; then
+  echo "[compiler-gate] FAIL: republish rejection lacks the expected message (#805)" >&2
+  cat "$ldir805/pub3.log" >&2; exit 1
+fi
+if [ "$(wc -l < "$lhome805/log/records.tsv" | tr -d '[:space:]')" != "2" ]; then
+  echo "[compiler-gate] FAIL: a rejected republish grew the transparency log (#805)" >&2; exit 1
+fi
+# (4) a tampered log head is detected before anything installs
+sed 's/\t/\tf00dfeed/' "$ldir805/log2.head" > "$lhome805/log/head"
+if VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh install "@gate805/logx@1.1.0" > "$ldir805/inst2.log" 2>&1; then
+  echo "[compiler-gate] FAIL: install accepted a tampered log head (#805)" >&2; exit 1
+fi
+if ! grep -q "tampered log head" "$ldir805/inst2.log"; then
+  echo "[compiler-gate] FAIL: tampered-head rejection lacks the expected message (#805)" >&2
+  cat "$ldir805/inst2.log" >&2; exit 1
+fi
+cp "$ldir805/log2.head" "$lhome805/log/head"
+# (5) append-only consistency: rolling the log back to its (self-consistent)
+#     1-record state must be refused by a client that already saw 2 records
+cp "$ldir805/log1.records" "$lhome805/log/records.tsv"
+cp "$ldir805/log1.head" "$lhome805/log/head"
+if VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh install "@gate805/logx@1.0.0" > "$ldir805/inst3.log" 2>&1; then
+  echo "[compiler-gate] FAIL: install accepted a truncated (rolled-back) log (#805)" >&2; exit 1
+fi
+if ! grep -q "log consistency violation" "$ldir805/inst3.log"; then
+  echo "[compiler-gate] FAIL: truncation rejection lacks the expected message (#805)" >&2
+  cat "$ldir805/inst3.log" >&2; exit 1
+fi
+cp "$ldir805/log2.records" "$lhome805/log/records.tsv"
+cp "$ldir805/log2.head" "$lhome805/log/head"
+# (6) yank: an append-only marking; install refuses it without --allow-yanked;
+#     the version->hash mapping stays immutable
+if ! VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh yank "@gate805/logx@1.1.0" > "$ldir805/yank.log" 2>&1; then
+  echo "[compiler-gate] FAIL: yank failed (#805)" >&2
+  cat "$ldir805/yank.log" >&2; exit 1
+fi
+if [ "$(wc -l < "$lhome805/log/records.tsv" | tr -d '[:space:]')" != "3" ]; then
+  echo "[compiler-gate] FAIL: yank did not append a log record (#805)" >&2; exit 1
+fi
+if VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh install "@gate805/logx@1.1.0" > "$ldir805/inst4.log" 2>&1; then
+  echo "[compiler-gate] FAIL: install accepted a yanked version without --allow-yanked (#805)" >&2; exit 1
+fi
+if ! grep -q "yanked in the registry log" "$ldir805/inst4.log"; then
+  echo "[compiler-gate] FAIL: yank rejection lacks the expected message (#805)" >&2
+  cat "$ldir805/inst4.log" >&2; exit 1
+fi
+if ! VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pkg.sh install "@gate805/logx@1.1.0" --allow-yanked > "$ldir805/inst5.log" 2>&1; then
+  echo "[compiler-gate] FAIL: --allow-yanked did not override the yank refusal (#805)" >&2
+  cat "$ldir805/inst5.log" >&2; exit 1
+fi
+if ! awk -F'\t' '$1 == "@gate805/logx@1.1.0"' "$lhome805/cache/versions.tsv" | grep -q "pkg:sha1:"; then
+  echo "[compiler-gate] FAIL: yank disturbed the immutable version->hash mapping (#805)" >&2; exit 1
+fi
+# (7) the log dir is a servable static artifact: a copied dir passed via
+#     VIBE_REGISTRY_LOG_DIR verifies the same way
+rm -rf "$ldir805/served"
+cp -R "$lhome805/log" "$ldir805/served"
+if ! VIBE_HOME="$lhome805" VIBE_REGISTRY_LOG_DIR="$ldir805/served" VIBE_PKG_CLI_WASM="$stage2_wasm" \
+  bash scripts/vibe_pkg.sh install "@gate805/logx@1.0.0" > "$ldir805/inst6.log" 2>&1; then
+  echo "[compiler-gate] FAIL: install against a served log copy failed (#805)" >&2
+  cat "$ldir805/inst6.log" >&2; exit 1
+fi
+if ! grep -q "inclusion verified for @gate805/logx@1.0.0" "$ldir805/inst6.log"; then
+  echo "[compiler-gate] FAIL: served-copy install did not verify inclusion (#805)" >&2
+  cat "$ldir805/inst6.log" >&2; exit 1
+fi
+rm -rf "$ldir805" "$lhome805"
+echo "[compiler-gate] registry transparency log + yank ok"
+
 # 6d. where-contract + publish-gate regression (#731 / #732): a violated
 #     requires clause traps at runtime; the publish semver gate accepts an
 #     honest bump and rejects a dishonest one.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,6 +119,10 @@ say "AOT compiler -> $TC_DIR/lib/vibe-cli.cwasm"
 # 4. launcher + LSP server (toolchain-local artifacts) ---------------------
 install -m 0755 "$ROOT_DIR/runtime/vibe" "$TC_DIR/bin/vibe"
 say "launcher -> $TC_DIR/bin/vibe"
+# `vibe pkg` delegates to vibe_pkg.sh (#805); ship it with the toolchain so
+# the package/registry lane works standalone (no checkout needed).
+install -m 0644 "$ROOT_DIR/scripts/vibe_pkg.sh" "$TC_DIR/lib/vibe_pkg.sh"
+say "pkg tool -> $TC_DIR/lib/vibe_pkg.sh"
 if [ -f "$ROOT_DIR/clients/js/lsp_server.js" ]; then
   install -m 0644 "$ROOT_DIR/clients/js/lsp_server.js" "$TC_DIR/lib/lsp_server.js"
   say "lsp server -> $TC_DIR/lib/lsp_server.js"

--- a/scripts/test_vibe_cli_install.sh
+++ b/scripts/test_vibe_cli_install.sh
@@ -97,6 +97,22 @@ check "vibe test pass exit" "0" "$rc"
 "$VIBE" test "$proj/fail_test.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
 check "vibe test fail exit" "1" "$rc"
 
+# shell (#805): compiled REPL, accumulate + recompile. Scripted (non-tty)
+# session: declare a fn, evaluate an expression using it, feed a bad line
+# (must be rejected with a diagnostic, session must survive), then evaluate
+# another expression against the still-intact buffer.
+shell_err="$WORK/shell.err"
+shell_out="$(printf '%s\n' \
+  'fn double(x: Int) -> Int { x * 2 }' \
+  'double(21)' \
+  'this is not vibe !!!' \
+  'double(10) + 1' \
+  ':quit' \
+  | "$VIBE" shell 2>"$shell_err" || true)"
+check "vibe shell declares + evaluates" "42" "$(printf '%s\n' "$shell_out" | sed -n 1p)"
+check "vibe shell survives a bad line" "21" "$(printf '%s\n' "$shell_out" | sed -n 2p)"
+check "vibe shell reports the bad line" "yes" "$(grep -q 'error' "$shell_err" && echo yes || echo no)"
+
 # fetch: vendor a file:// dep, then run a program that imports it.
 fproj="$WORK/fproj"
 mkdir -p "$fproj"

--- a/scripts/vibe_pkg.sh
+++ b/scripts/vibe_pkg.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# vibe_pkg.sh — local distribution pipeline (#754, ADR-0065 Phase 4).
+# vibe_pkg.sh — local distribution pipeline (#754, ADR-0065 Phase 4)
+# + registry transparency log (#805/#755, ADR-0065 Phase 5 minimal slice).
 #
 #   vibe_pkg.sh publish <pkg_dir>
 #       The package's index.vibei MUST carry a `version x.y.z` directive.
@@ -41,42 +42,302 @@
 #       (source, commit) pair is appended to $VIBE_HOME/cache/provenance.tsv
 #       so third parties can re-fetch and re-hash (source-only provenance).
 #
+#   vibe_pkg.sh yank <name>@<version>
+#       Appends a YANK record to the transparency log (#805). Yank is a
+#       marking, never a deletion: the version->hash mapping and the CAS
+#       entry stay intact, and existing pinned builds keep working. install
+#       refuses a yanked version unless --allow-yanked is passed.
+#
+#   vibe_pkg.sh update <name> [--store]
+#       Re-resolves <name> to the newest non-yanked published version,
+#       prints the contract hash change and a textual contract
+#       (index.vibei) diff against the installed copy, then materializes
+#       the new version. (The canonical contract_surface_lines set diff is
+#       not yet reachable from shell — see docs/registry-design.md.)
+#
+# Transparency log (#805, docs/registry-design.md Phase 1 minimal slice):
+# publish/yank append one TSV record to $VIBE_REGISTRY_LOG_DIR/records.tsv
+# (default $VIBE_HOME/log) and maintain a Merkle head in .../head. The log
+# dir is a plain directory of static files — rsync/HTTP-serve it as-is.
+# install/add verify (a) the head commits to the served records (tamper
+# check), (b) prefix consistency against the last head this client saw
+# (the log may only ever extend), and (c) an RFC6962-style inclusion proof
+# for the claimed name@version -> hash record against the head root.
+#
 # The compiler wasm defaults to the committed seed; override with
-# VIBE_PKG_CLI_WASM (e.g. a freshly built stage2 — required while the seed
-# predates the version directive).
+# VIBE_PKG_CLI_WASM (e.g. a freshly built stage2). When `vibe pkg` (the
+# installed launcher) delegates here it sets VIBE_PKG_RUNNER to its own
+# wasmtime runner, so no repo checkout / node host runner is needed.
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
-CLI="${VIBE_PKG_CLI_WASM:-bootstrap/seed/selfhost_compiler.wasm}"
+# Repo mode keeps the historical repo-root cwd (gate fixtures use repo-relative
+# .vibe/store paths). Launcher mode (VIBE_PKG_RUNNER set) stays in the caller's
+# cwd so relative package-dir arguments and .vibe/store resolve against the
+# user's project, and works without a checkout.
+if [ -z "${VIBE_PKG_RUNNER:-}" ]; then
+  cd "$ROOT_DIR"
+fi
+CLI="${VIBE_PKG_CLI_WASM:-$ROOT_DIR/bootstrap/seed/selfhost_compiler.wasm}"
 VIBE_HOME="${VIBE_HOME:-$HOME/.vibe}"
 CACHE_DIR="$VIBE_HOME/cache"
 VERSIONS_TSV="$CACHE_DIR/versions.tsv"
 PROVENANCE_TSV="$CACHE_DIR/provenance.tsv"
+# Registry transparency log (#805): a directory of static files. The local
+# default doubles as the served artifact; point VIBE_REGISTRY_LOG_DIR at a
+# synced copy to consume someone else's registry.
+LOG_DIR="${VIBE_REGISTRY_LOG_DIR:-$VIBE_HOME/log}"
+LOG_RECORDS="$LOG_DIR/records.tsv"
+LOG_HEAD="$LOG_DIR/head"
 
 say() { echo "[vibe-pkg] $*"; }
 die() { echo "[vibe-pkg] error: $*" >&2; exit 1; }
 
-pkg_hash_of() {
-  # prints the package hash (#pkg:sha1:<40hex>) of the contract at $1
-  local index_path="$1" out
+invoke_cli() {
+  # invoke_cli VAR=val ... -- <input> <output>
+  # Repo mode (default): node host runner + compiler wasm, preopening the
+  # repo root. Launcher mode (VIBE_PKG_RUNNER, set by `vibe pkg`): the
+  # installed wasmtime runner executes the toolchain compiler directly, so
+  # this script works standalone outside a checkout.
+  local envs=()
+  while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do envs+=("$1"); shift; done
+  shift
+  if [ -n "${VIBE_PKG_RUNNER:-}" ]; then
+    env "${envs[@]}" "$VIBE_PKG_RUNNER" "$CLI" "$1" "$2" __no_entry__ >/dev/null 2>&1 || true
+  else
+    env "${envs[@]}" VIBE_PREOPEN_DIR="$ROOT_DIR" \
+      bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" --invoke cli_main "$CLI" \
+      "$1" "$2" __no_entry__ >/dev/null 2>&1 || true
+  fi
+}
+
+compute_pkg_hashes() {
+  # sets PKG_HASH_OUT (pkg:sha1:<40hex>) and CT_HASH_OUT (ct:sha1:<40hex>)
+  # for the contract at $1 in ONE compiler invocation.
+  local index_path="$1" out pline cline
   out="$(mktemp)"
-  VIBE_HASH=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
-    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI" \
-    "$index_path" "$out" __no_entry__ >/dev/null 2>&1 || true
-  local line
-  line="$(grep '^package ' "$out" 2>/dev/null | head -1 || true)"
-  if [ -z "$line" ]; then
+  invoke_cli VIBE_HASH=1 -- "$index_path" "$out"
+  pline="$(grep '^package ' "$out" 2>/dev/null | head -1 || true)"
+  cline="$(grep '^contract ' "$out" 2>/dev/null | head -1 || true)"
+  if [ -z "$pline" ]; then
     cat "$out.diag" 2>/dev/null >&2 || true
     rm -f "$out" "$out.diag"
     die "hash computation failed for $index_path (CLI: $CLI)"
   fi
   rm -f "$out" "$out.diag"
-  # output line is "package #pkg:sha1:<40hex>" — strip the label AND the
+  # package line is "package #pkg:sha1:<40hex>" — strip the label AND the
   # leading '#' so callers hold the bare "pkg:sha1:<40hex>" form (require
   # pin spelling re-adds the '#').
-  line="${line#package }"
-  echo "${line#\#}"
+  pline="${pline#package }"
+  PKG_HASH_OUT="${pline#\#}"
+  CT_HASH_OUT="${cline#contract }"
 }
+
+pkg_hash_of() {
+  # prints the package hash (pkg:sha1:<40hex>) of the contract at $1
+  compute_pkg_hashes "$1"
+  echo "$PKG_HASH_OUT"
+}
+
+# --- transparency log (#805): merkle tree over append-only TSV records ------
+#
+# Record line (one per publish/yank event, TAB-separated):
+#   <ordinal>  <op>  <name@version>  <pkg-hash>  <contract-hash>  <source>  <commit>
+# op = publish | yank; ordinal = 0-based position in the log (NO wall-clock —
+# ordering is the log order itself, so records are reproducible bytes).
+# Head file: "<size>\t<root>" where root is the Merkle root over all records.
+#
+# Hashing: sha256 over ASCII, domain-separated RFC6962-style —
+#   leaf = sha256("leaf:" + record-line), node = sha256("node:" + L + ":" + R)
+# (hex-string concatenation instead of raw bytes keeps the verifier trivially
+# portable in bash; the tree SHAPE — split at the largest power of two — is
+# RFC6962, so proofs transfer 1:1 to a future @vibe/core verifier.)
+
+_sha256_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -d' ' -f1
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+leaf_hash() { printf 'leaf:%s' "$1" | _sha256_stdin; }
+node_hash() { printf 'node:%s:%s' "$1" "$2" | _sha256_stdin; }
+
+merkle_load() {
+  # load leaf hashes of $1 (records file) into MERKLE_LEAVES; with $2 = N,
+  # only the first N records (prefix consistency recompute).
+  MERKLE_LEAVES=()
+  local line n=0 limit="${2:-}"
+  [ -f "$1" ] || return 0
+  while IFS= read -r line; do
+    if [ -n "$limit" ] && [ "$n" -ge "$limit" ]; then break; fi
+    MERKLE_LEAVES+=("$(leaf_hash "$line")")
+    n=$((n+1))
+  done < "$1"
+}
+
+merkle_root_range() {
+  # echoes the RFC6962-shaped subtree root over MERKLE_LEAVES[$1..$2)
+  local lo="$1" hi="$2"
+  local n=$((hi - lo)) k=1
+  if [ "$n" -eq 1 ]; then echo "${MERKLE_LEAVES[$lo]}"; return 0; fi
+  while [ $((k * 2)) -lt "$n" ]; do k=$((k * 2)); done
+  node_hash "$(merkle_root_range "$lo" $((lo + k)))" \
+            "$(merkle_root_range $((lo + k)) "$hi")"
+}
+
+merkle_root() {
+  local n="${#MERKLE_LEAVES[@]}"
+  if [ "$n" -eq 0 ]; then printf 'empty' | _sha256_stdin; return 0; fi
+  merkle_root_range 0 "$n"
+}
+
+merkle_inclusion_proof() {
+  # audit path for leaf index $1, leaf-to-root order, one "L|R <hash>" per
+  # line: R = sibling is the RIGHT child (combine node(h, sib)), L = left.
+  _incl_path "$1" 0 "${#MERKLE_LEAVES[@]}"
+}
+_incl_path() {
+  local m="$1" lo="$2" hi="$3"
+  local n=$((hi - lo)) k=1
+  [ "$n" -eq 1 ] && return 0
+  while [ $((k * 2)) -lt "$n" ]; do k=$((k * 2)); done
+  if [ "$m" -lt $((lo + k)) ]; then
+    _incl_path "$m" "$lo" $((lo + k))
+    echo "R $(merkle_root_range $((lo + k)) "$hi")"
+  else
+    _incl_path "$m" $((lo + k)) "$hi"
+    echo "L $(merkle_root_range "$lo" $((lo + k)))"
+  fi
+}
+
+merkle_verify_inclusion() {
+  # $1 = leaf hash, $2 = expected root, $3 = proof text (from
+  # merkle_inclusion_proof). Recomputes the root from the leaf + audit path.
+  local h="$1" side sib
+  while read -r side sib; do
+    [ -n "$side" ] || continue
+    if [ "$side" = "R" ]; then h="$(node_hash "$h" "$sib")"; else h="$(node_hash "$sib" "$h")"; fi
+  done <<EOF
+$3
+EOF
+  [ "$h" = "$2" ]
+}
+
+log_seen_file() {
+  # last head this CLIENT saw for the current log dir. Keyed by the log dir
+  # path so switching VIBE_REGISTRY_LOG_DIR between unrelated registries
+  # cannot cross-fire the consistency check.
+  echo "$CACHE_DIR/log-head.seen.$(printf '%s' "$LOG_DIR" | _sha256_stdin | cut -c1-12)"
+}
+
+log_verify_self() {
+  # the served head must commit to the served records exactly (tamper check).
+  # No log at all is fine (phase-0 lane); records without a head, a head that
+  # miscounts, or a head whose root does not recompute are all tamper-evident.
+  if [ ! -f "$LOG_RECORDS" ] && [ ! -f "$LOG_HEAD" ]; then return 0; fi
+  [ -f "$LOG_HEAD" ] || die "tampered log head: $LOG_RECORDS exists but $LOG_HEAD is missing"
+  [ -f "$LOG_RECORDS" ] || die "tampered log head: $LOG_HEAD exists but $LOG_RECORDS is missing"
+  local size root lines got
+  IFS="$(printf '\t')" read -r size root < "$LOG_HEAD"
+  lines="$(wc -l < "$LOG_RECORDS" | tr -d '[:space:]')"
+  [ "$size" = "$lines" ] || die "tampered log head: head claims $size record(s), records.tsv has $lines"
+  merkle_load "$LOG_RECORDS"
+  got="$(merkle_root)"
+  [ "$got" = "$root" ] || die "tampered log head: head root $root does not match recomputed $got"
+}
+
+log_verify_consistency() {
+  # append-only guarantee: the head may only ever EXTEND the head this client
+  # last saw. With static-file serving the client has the full records file,
+  # so consistency is checked by recomputing the old-size prefix root (see
+  # docs/registry-design.md — O(log n) consistency proofs come with the
+  # remote-proof protocol, not this full-fetch slice). Advances the seen head.
+  local seen size root seen_size seen_root prefix_root
+  seen="$(log_seen_file)"
+  [ -f "$LOG_HEAD" ] || return 0
+  IFS="$(printf '\t')" read -r size root < "$LOG_HEAD"
+  if [ -f "$seen" ]; then
+    IFS="$(printf '\t')" read -r seen_size seen_root < "$seen"
+    if [ "$size" -lt "$seen_size" ]; then
+      die "log consistency violation: head regressed to $size record(s), this client already saw $seen_size (append-only log was truncated/rewritten)"
+    fi
+    if [ "$seen_size" -gt 0 ]; then
+      merkle_load "$LOG_RECORDS" "$seen_size"
+      prefix_root="$(merkle_root)"
+      if [ "$prefix_root" != "$seen_root" ]; then
+        die "log consistency violation: the first $seen_size record(s) no longer hash to the head this client saw (append-only history was rewritten)"
+      fi
+    fi
+  fi
+  mkdir -p "$CACHE_DIR"
+  printf '%s\t%s\n' "$size" "$root" > "$seen"
+}
+
+log_append() {
+  # $1=op $2=name@version $3=pkg-hash $4=contract-hash $5=source $6=commit —
+  # append one record, recompute the head, advance this client's seen head.
+  local op="$1" key="$2" hash="$3" ct="$4" src="$5" commit="$6" ord size root
+  log_verify_self
+  log_verify_consistency
+  mkdir -p "$LOG_DIR"
+  [ -f "$LOG_RECORDS" ] || : > "$LOG_RECORDS"
+  ord="$(wc -l < "$LOG_RECORDS" | tr -d '[:space:]')"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$ord" "$op" "$key" "$hash" "$ct" "$src" "$commit" >> "$LOG_RECORDS"
+  merkle_load "$LOG_RECORDS"
+  size=$((ord + 1))
+  root="$(merkle_root)"
+  printf '%s\t%s\n' "$size" "$root" > "$LOG_HEAD"
+  mkdir -p "$CACHE_DIR"
+  printf '%s\t%s\n' "$size" "$root" > "$(log_seen_file)"
+  say "log: $op $key recorded (ordinal $ord, head $size:${root:0:12})"
+}
+
+log_client_verify() {
+  # client-side lookup verification for $1 = name@version, $2 = the hash the
+  # client is about to trust. Sets LOG_STATE to:
+  #   absent  — no log / no publish record for the key (phase-0 TOFU lane)
+  #   ok      — inclusion proof verified, not yanked
+  #   yanked  — inclusion proof verified, a later yank record marks the key
+  # Dies on tamper / consistency violation / hash disagreement with the log.
+  LOG_STATE=absent
+  if [ ! -f "$LOG_RECORDS" ] && [ ! -f "$LOG_HEAD" ]; then return 0; fi
+  log_verify_self
+  log_verify_consistency
+  local idx=-1 rec_hash="" yanked=0 i=0 ord op key hash ct src commit rest
+  while IFS="$(printf '\t')" read -r ord op key hash ct src commit rest; do
+    if [ "$key" = "$1" ]; then
+      case "$op" in
+        publish) idx="$i"; rec_hash="$hash"; yanked=0 ;;
+        yank) yanked=1 ;;
+      esac
+    fi
+    i=$((i + 1))
+  done < "$LOG_RECORDS"
+  [ "$idx" -ge 0 ] || return 0
+  if [ "$rec_hash" != "$2" ]; then
+    die "transparency log says $1 is #$rec_hash, local record says #$2 — rejected (split-view or tampered cache)"
+  fi
+  local head_size head_root record_line leafh proof
+  IFS="$(printf '\t')" read -r head_size head_root < "$LOG_HEAD"
+  record_line="$(sed -n "$((idx + 1))p" "$LOG_RECORDS")"
+  leafh="$(leaf_hash "$record_line")"
+  merkle_load "$LOG_RECORDS"
+  proof="$(merkle_inclusion_proof "$idx")"
+  if ! merkle_verify_inclusion "$leafh" "$head_root" "$proof"; then
+    die "inclusion proof for $1 (record $idx) failed against log head $head_size:${head_root:0:12}"
+  fi
+  say "log: inclusion verified for $1 (record $idx, head $head_size:${head_root:0:12})"
+  if [ "$yanked" = "1" ]; then LOG_STATE=yanked; else LOG_STATE=ok; fi
+}
+
+version_is_yanked() {
+  # $1 = name@version -> succeeds when the LAST log op for the key is a yank
+  [ -f "$LOG_RECORDS" ] || return 1
+  local st
+  st="$(awk -F'\t' -v k="$1" '$3 == k { s = $2 } END { print s }' "$LOG_RECORDS")"
+  [ "$st" = "yank" ]
+}
+# ---------------------------------------------------------------------------
 
 version_directive_of() {
   # the leading-directive region only: stop at the first ordinary line
@@ -163,10 +424,8 @@ publish)
     prev_index="$CACHE_DIR/pkg/sha1/$prev_hex/index.vibei"
     [ -f "$prev_index" ] || die "cache is missing the previous release $name@$prev_version ($prev_hash)"
     pub_out="$(mktemp)"
-    VIBE_PUBLISH_CHECK=1 VIBE_PUBLISH_PREV="$prev_index" \
-      VIBE_PREOPEN_DIR="$ROOT_DIR" \
-      bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI" \
-      "$pkg_dir/index.vibei" "$pub_out" __no_entry__ >/dev/null 2>&1 || true
+    invoke_cli VIBE_PUBLISH_CHECK=1 VIBE_PUBLISH_PREV="$prev_index" \
+      -- "$pkg_dir/index.vibei" "$pub_out"
     if ! grep -q '^ok' "$pub_out" 2>/dev/null; then
       cat "$pub_out.diag" 2>/dev/null >&2 || true
       rm -f "$pub_out" "$pub_out.diag"
@@ -175,7 +434,9 @@ publish)
     rm -f "$pub_out" "$pub_out.diag"
   fi
 
-  hash="$(pkg_hash_of "$pkg_dir/index.vibei")"
+  compute_pkg_hashes "$pkg_dir/index.vibei"
+  hash="$PKG_HASH_OUT"
+  ct_hash="$CT_HASH_OUT"
   key="$name@$version"
   recorded="$(lookup_version "$key")"
   if [ -n "$recorded" ]; then
@@ -185,6 +446,9 @@ publish)
     fi
     die "same-version republish rejected: $key is #$recorded, refusing #$hash (bump the version; version->hash is immutable, ADR-0065)"
   fi
+  # a tampered/rewritten log must refuse the publish BEFORE any side effect
+  log_verify_self
+  log_verify_consistency
 
   hex="${hash#pkg:sha1:}"
   cas="$CACHE_DIR/pkg/sha1/$hex"
@@ -195,20 +459,45 @@ publish)
   [ "$cas_hash" = "$hash" ] || die "CAS self-check failed: $cas hashes to #$cas_hash, expected #$hash"
   mkdir -p "$CACHE_DIR"
   printf '%s\t%s\n' "$key" "$hash" >> "$VERSIONS_TSV"
+  # registry-side transparency record (#805): local publishes carry no
+  # source/commit provenance yet (attestation is the Phase 2 signing work)
+  log_append publish "$key" "$hash" "$ct_hash" "local" "-"
   say "published $key -> #$hash"
   say "cache: $cas"
   ;;
 install)
-  spec="${2:-}"
-  target="${3:-}"
+  shift
+  spec=""
+  target=""
+  allow_yanked=0
+  for a in "$@"; do
+    case "$a" in
+      --store) target="--store" ;;
+      --allow-yanked) allow_yanked=1 ;;
+      *)
+        [ -z "$spec" ] || die "unexpected argument: $a"
+        spec="$a"
+        ;;
+    esac
+  done
   case "$spec" in
     @*/*@*) ;;
-    *) die "usage: vibe_pkg.sh install @scope/name@x.y.z [--store]" ;;
+    *) die "usage: vibe_pkg.sh install @scope/name@x.y.z [--store] [--allow-yanked]" ;;
   esac
   name="${spec%@*}"
   version="${spec##*@}"
   hash="$(lookup_version "$name@$version")"
   [ -n "$hash" ] || die "unknown version: $name@$version (publish it first, or 'vibe_pkg.sh add' it from a git source — #755)"
+  # transparency log verification (#805): tamper + consistency + inclusion.
+  # A version the log never saw (git-added TOFU) stays on the phase-0 lane.
+  log_client_verify "$name@$version" "$hash"
+  if [ "$LOG_STATE" = "yanked" ]; then
+    if [ "$allow_yanked" = "1" ]; then
+      say "WARNING: $name@$version is yanked in the registry log — installing anyway (--allow-yanked)"
+    else
+      die "$name@$version is yanked in the registry log — refusing to install (pass --allow-yanked to override; existing pins keep working)"
+    fi
+  fi
   materialize_from_cas "$name" "$version" "$hash" "$target"
   ;;
 add)
@@ -293,6 +582,14 @@ add)
   if [ -n "$recorded" ] && [ "$recorded" != "$hash" ]; then
     die "known version $key is #$recorded but $spec serves #$hash — rejected (version->hash is immutable, ADR-0065)"
   fi
+  # transparency log cross-check (#805): when the registry log knows this
+  # name@version, the fetched hash must agree (dies on a split view). Yank is
+  # only a warning here — `add` is the explicit-source lane; `install` is the
+  # one that refuses.
+  log_client_verify "$key" "$hash"
+  if [ "$LOG_STATE" = "yanked" ]; then
+    say "WARNING: $key is yanked in the registry log"
+  fi
 
   hex="${hash#pkg:sha1:}"
   cas="$CACHE_DIR/pkg/sha1/$hex"
@@ -314,7 +611,96 @@ add)
   say "fetched $key from $spec @ $commit"
   materialize_from_cas "$name" "$version" "$hash" "$target"
   ;;
+yank)
+  spec="${2:-}"
+  case "$spec" in
+    @*/*@*) ;;
+    *) die "usage: vibe_pkg.sh yank @scope/name@x.y.z" ;;
+  esac
+  name="${spec%@*}"
+  version="${spec##*@}"
+  key="$name@$version"
+  hash="$(lookup_version "$key")"
+  [ -n "$hash" ] || die "unknown version: $key (nothing to yank)"
+  [ -f "$LOG_RECORDS" ] || die "cannot yank $key: no transparency log at $LOG_DIR (only logged publishes can be yanked — #805)"
+  if ! awk -F'\t' -v k="$key" '$2 == "publish" && $3 == k { found = 1 } END { exit !found }' "$LOG_RECORDS"; then
+    die "cannot yank $key: no publish record in the transparency log (git-added versions live on the phase-0 lane — #805)"
+  fi
+  if version_is_yanked "$key"; then
+    say "$key is already yanked (idempotent)"
+    exit 0
+  fi
+  # yank is a MARKING: the log only ever appends, versions.tsv and the CAS
+  # stay untouched, existing pins keep building (design doc requirement 5)
+  log_append yank "$key" "$hash" "-" "-" "-"
+  say "yanked $key (append-only marking; version->hash mapping unchanged)"
+  ;;
+update)
+  shift
+  name=""
+  target=""
+  for a in "$@"; do
+    case "$a" in
+      --store) target="--store" ;;
+      *)
+        [ -z "$name" ] || die "unexpected argument: $a"
+        name="$a"
+        ;;
+    esac
+  done
+  case "$name" in
+    @*/*@*) die "usage: vibe_pkg.sh update @scope/name [--store] (no @version — update resolves the newest non-yanked one)" ;;
+    @*/*) ;;
+    *) die "usage: vibe_pkg.sh update @scope/name [--store]" ;;
+  esac
+  if [ "$target" = "--store" ]; then
+    inst_dir=".vibe/store/$name"
+  else
+    inst_dir="$VIBE_HOME/lib/$name"
+  fi
+  [ -f "$inst_dir/index.vibei" ] || die "not installed: $name ($inst_dir) — 'vibe_pkg.sh install' it first"
+  [ -f "$VERSIONS_TSV" ] || die "no published versions known (empty cache index)"
+  # current version = reverse lookup of the installed copy's hash
+  compute_pkg_hashes "$inst_dir/index.vibei"
+  cur_hash="$PKG_HASH_OUT"
+  cur_ct="$CT_HASH_OUT"
+  cur_version="$(awk -F'\t' -v n="$name" -v h="$cur_hash" 'index($1, n "@") == 1 && $2 == h { v = substr($1, length(n) + 2) } END { print v }' "$VERSIONS_TSV")"
+  # newest non-yanked published version (publish order, like latest_version_of)
+  best=""
+  best_hash=""
+  while IFS="$(printf '\t')" read -r k h; do
+    case "$k" in "$name@"*) ;; *) continue ;; esac
+    version_is_yanked "$k" && continue
+    best="${k##*@}"
+    best_hash="$h"
+  done < "$VERSIONS_TSV"
+  [ -n "$best" ] || die "no non-yanked version of $name is published"
+  if [ "$best" = "${cur_version:-}" ]; then
+    say "$name is up to date (${cur_version} = #$cur_hash)"
+    exit 0
+  fi
+  # verify the candidate against the transparency log BEFORE showing/switching
+  log_client_verify "$name@$best" "$best_hash"
+  best_hex="${best_hash#pkg:sha1:}"
+  best_index="$CACHE_DIR/pkg/sha1/$best_hex/index.vibei"
+  [ -f "$best_index" ] || die "cache is missing $name@$best ($best_hash)"
+  compute_pkg_hashes "$best_index"
+  best_ct="$CT_HASH_OUT"
+  say "update $name: ${cur_version:-<untracked local copy>} -> $best"
+  if [ "$cur_ct" = "$best_ct" ]; then
+    say "contract surface: unchanged ($cur_ct)"
+  else
+    say "contract surface: $cur_ct -> $best_ct"
+    # CONTRACT SURFACE DIFF, textual approximation: the contract file itself.
+    # The canonical set-diff over contract_surface_lines (incl. effect-row
+    # capability classification) needs a compiler adapter mode that is not
+    # exposed yet — see docs/registry-design.md "実装済みの範囲と既知の gap".
+    say "contract diff ($inst_dir/index.vibei -> $name@$best):"
+    diff -u "$inst_dir/index.vibei" "$best_index" | sed 's/^/[vibe-pkg]   /' || true
+  fi
+  materialize_from_cas "$name" "$best" "$best_hash" "$target"
+  ;;
 *)
-  die "usage: vibe_pkg.sh publish <pkg_dir> | install @scope/name@x.y.z [--store] | add <source-spec> [#pkg:sha1:<40hex>] [--store]"
+  die "usage: vibe_pkg.sh publish <pkg_dir> | install @scope/name@x.y.z [--store] [--allow-yanked] | add <source-spec> [#pkg:sha1:<40hex>] [--store] | yank @scope/name@x.y.z | update @scope/name [--store]"
   ;;
 esac

--- a/scripts/vibe_pkg.sh
+++ b/scripts/vibe_pkg.sh
@@ -292,6 +292,12 @@ log_append() {
   say "log: $op $key recorded (ordinal $ord, head $size:${root:0:12})"
 }
 
+log_has_publish() {
+  # does the log contain a publish record for $1 = name@version?
+  [ -f "$LOG_RECORDS" ] || return 1
+  awk -F'\t' -v k="$1" '$2 == "publish" && $3 == k { found = 1 } END { exit found ? 0 : 1 }' "$LOG_RECORDS"
+}
+
 log_client_verify() {
   # client-side lookup verification for $1 = name@version, $2 = the hash the
   # client is about to trust. Sets LOG_STATE to:
@@ -441,6 +447,16 @@ publish)
   recorded="$(lookup_version "$key")"
   if [ -n "$recorded" ]; then
     if [ "$recorded" = "$hash" ]; then
+      # Idempotent — but REPAIR a missing transparency record first: if a
+      # prior publish crashed between the versions.tsv append and log_append
+      # (unwritable log dir, interruption, full disk), the version would stay
+      # mapped without a publish record and every retry would exit here,
+      # permanently bypassing transparency + yank handling (Codex review,
+      # PR #927).
+      if ! log_has_publish "$key"; then
+        say "$key is mapped in versions.tsv but has no publish record — repairing the transparency log"
+        log_append publish "$key" "$hash" "$ct_hash" "local" "-"
+      fi
       say "$key already published as #$hash (idempotent)"
       exit 0
     fi
@@ -665,16 +681,22 @@ update)
   cur_hash="$PKG_HASH_OUT"
   cur_ct="$CT_HASH_OUT"
   cur_version="$(awk -F'\t' -v n="$name" -v h="$cur_hash" 'index($1, n "@") == 1 && $2 == h { v = substr($1, length(n) + 2) } END { print v }' "$VERSIONS_TSV")"
-  # newest non-yanked published version (publish order, like latest_version_of)
+  # newest non-yanked LOGGED publish (publish order, like latest_version_of).
+  # versions.tsv also holds TOFU mappings created by `add github:...` that
+  # have no publish record; selecting one of those would let update install
+  # a version with LOG_STATE=absent, silently bypassing inclusion + yank
+  # verification (Codex review, PR #927) — so candidates are restricted to
+  # versions with a publish record in the transparency log.
   best=""
   best_hash=""
   while IFS="$(printf '\t')" read -r k h; do
     case "$k" in "$name@"*) ;; *) continue ;; esac
+    log_has_publish "$k" || continue
     version_is_yanked "$k" && continue
     best="${k##*@}"
     best_hash="$h"
   done < "$VERSIONS_TSV"
-  [ -n "$best" ] || die "no non-yanked version of $name is published"
+  [ -n "$best" ] || die "no logged (published) non-yanked version of $name — git-added versions are updated by re-running 'add' with a new ref"
   if [ "$best" = "${cur_version:-}" ]; then
     say "$name is up to date (${cur_version} = #$cur_hash)"
     exit 0


### PR DESCRIPTION
## Summary

Two v0.3 roadmap items (#805), both launcher/scripts-only (no compiler-source changes):

**1. Package registry minimal slice (#755, ADR-0065; commit 1)**
- **File-based transparency log** per `docs/registry-design.md` Phase 1+: `publish`/`yank` append deterministic TSV records (ordinal-based, no wall-clock) to `$VIBE_HOME/log/records.tsv` with a sumdb-STH-shaped Merkle head. `install`/`add` verify head↔records, append-only consistency vs the client's last-seen head (keyed per log dir), and an RFC6962-shaped inclusion proof. A registry is just a servable directory (`VIBE_REGISTRY_LOG_DIR`).
- **Yank as log record**: append-only marking; `install` refuses yanked versions without `--allow-yanked`; version→hash mapping stays immutable.
- **Launcher promotion**: `vibe pkg publish|install|add|yank|update` (delegates to `vibe_pkg.sh`, now shipped into the toolchain by `install.sh`, with a pluggable hash engine so it runs standalone on vibewt).
- **`vibe pkg update`**: newest non-yanked version, log-verified, with contract-hash + textual `index.vibei` diff before switching (the `contract_surface_lines` set-diff needs a shell-reachable adapter mode — recorded in registry-design.md as the next step rather than pulling a compiler change into this PR).
- Signing / scope ownership deliberately deferred to Phase 2 (hash-pin + log already covers the main attacks); documented in registry-design.md's new section.

**2. `vibe shell` — minimal compiled REPL (commit 2)**
- Accumulate + recompile per ADR-0034 (no interpreter) / ADR-0069 (synthetic-main wrap): declarations append to a session buffer with compile-validation and **rollback on diagnostics** (the buffer can't be poisoned); expressions wrap in a printing entry, compile against the buffer, and run. `:help`/`:list`/`:clear`/`:load`/`:type`/`:quit`; non-tty stdin is prompt-free and scriptable.
- Honest limitations documented in docs/cli-commands.md (full recompile per line, side effects re-run, single-line declarations).

## Test plan

- [x] `compiler_gate.sh` → ok, including the **new section 6l** (publish→log grows + inclusion verifies; republish rejected without log growth; tampered head detected; rollback → consistency violation; yank refuse/`--allow-yanked`; served-copy install) and 6h–6k unchanged
- [x] Adversarial manual runs: tampered head/record/truncation/served-copy — all rejected with precise messages
- [x] Launcher registry E2E with a real cargo-built vibewt in a standalone toolchain layout; hashes byte-identical to the node-runner lane
- [x] REPL scripted session re-verified independently on the combined tree: declare → `42`, survives a garbage line (diagnostic on stderr), `21`, `:type` → `Int`, exit 0
- [x] 3 new REPL + registry smoke cases in `test_vibe_cli_install.sh`; `bash -n` clean on all edited scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H

---
_Generated by [Claude Code](https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H)_