### PR TITLE
#934: http echo server のポートを worktree ごとに導出 (バグ潰しバッチ)

### DIFF
--- a/lib/@vibe/http/http_e2e_test.vibe
+++ b/lib/@vibe/http/http_e2e_test.vibe
@@ -11,23 +11,32 @@ import ./http.vibe {
 // discharge the Http row for the checker — the client ops compile to direct
 // host-import calls (#794), so the arm is never invoked and the requests hit
 // the real test server.
+//
+// The echo-server port is overridable via VIBE_HTTP_ECHO_PORT (#934: a fixed
+// port collides when concurrent worktree batteries each start their own
+// server); default stays 18280 for standalone runs.
 
-fn do_get() -> Bool with { Http } {
-  let h = request("GET", "http://127.0.0.1:18280/hello", "", "")
+fn base_from(port: String) -> String {
+  let p = if String::length(port) > 0 { port } else { "18280" }
+  String::concat("http://127.0.0.1:", p)
+}
+
+fn do_get(base: String) -> Bool with { Http } {
+  let h = request("GET", String::concat(base, "/hello"), "", "")
   let ok = response_status(h) == 200 && response_body(h) == "hello"
   close(h)
   ok
 }
 
-fn do_post_echo() -> Bool with { Http } {
-  let h = request("POST", "http://127.0.0.1:18280/echo", "", "ping from vibe")
+fn do_post_echo(base: String) -> Bool with { Http } {
+  let h = request("POST", String::concat(base, "/echo"), "", "ping from vibe")
   let ok = response_status(h) == 200 && response_body(h) == "ping from vibe"
   close(h)
   ok
 }
 
-fn do_404() -> Bool with { Http } {
-  let h = request("GET", "http://127.0.0.1:18280/nonexistent", "", "")
+fn do_404(base: String) -> Bool with { Http } {
+  let h = request("GET", String::concat(base, "/nonexistent"), "", "")
   let ok = response_status(h) == 404
   close(h)
   ok
@@ -36,8 +45,9 @@ fn do_404() -> Bool with { Http } {
 //# Misc
 
 test "http GET request" {
+  let base = base_from(Env::get("VIBE_HTTP_ECHO_PORT"))
   let ok = handle {
-    do_get()
+    do_get(base)
   } with Http {
     Listen(_p) => resume(0)
   }
@@ -45,8 +55,9 @@ test "http GET request" {
 }
 
 test "http POST echo" {
+  let base = base_from(Env::get("VIBE_HTTP_ECHO_PORT"))
   let ok = handle {
-    do_post_echo()
+    do_post_echo(base)
   } with Http {
     Listen(_p) => resume(0)
   }
@@ -54,8 +65,9 @@ test "http POST echo" {
 }
 
 test "http 404 response" {
+  let base = base_from(Env::get("VIBE_HTTP_ECHO_PORT"))
   let ok = handle {
-    do_404()
+    do_404(base)
   } with Http {
     Listen(_p) => resume(0)
   }

--- a/scripts/coverage_suite.sh
+++ b/scripts/coverage_suite.sh
@@ -101,21 +101,30 @@ fi
 # #794: mirror the unit-test runner's echo-server start -- entries that drive
 # real HTTP mention the local echo endpoint; start tests/http_echo_server.py
 # for the run when any does (content-based, like the wasmtime gate below).
+# #934: port derived per worktree and exported as VIBE_HTTP_ECHO_PORT, same
+# as unit_test_runner.sh (the test reads the env var, default 18280).
 http_echo_pid=""
+http_echo_port="${VIBE_HTTP_ECHO_PORT:-$((18280 + $(printf '%s' "$ROOT" | cksum | cut -d' ' -f1) % 1000))}"
+export VIBE_HTTP_ECHO_PORT="$http_echo_port"
 start_http_echo_server_if_needed() {
   local need=0 f
   while IFS= read -r f; do
     case "$f" in ''|\#*) continue ;; esac
-    if [ -f "$f" ] && grep -q "127.0.0.1:18280" "$f"; then need=1; break; fi
+    if [ -f "$f" ] && grep -q "VIBE_HTTP_ECHO_PORT\|127.0.0.1:18280" "$f"; then need=1; break; fi
   done < "$ALLOWLIST"
   [ "$need" -eq 1 ] || return 0
   command -v python3 >/dev/null 2>&1 || return 0
   [ -f "$ROOT/tests/http_echo_server.py" ] || return 0
-  python3 "$ROOT/tests/http_echo_server.py" 18280 >/dev/null 2>&1 &
+  python3 "$ROOT/tests/http_echo_server.py" "$http_echo_port" >/dev/null 2>&1 &
   http_echo_pid=$!
   trap 'if [ -n "$http_echo_pid" ]; then kill "$http_echo_pid" 2>/dev/null || true; fi' EXIT
-  echo "[coverage-suite] started http echo server (pid $http_echo_pid, 127.0.0.1:18280)"
   sleep 1
+  if ! kill -0 "$http_echo_pid" 2>/dev/null; then
+    echo "[coverage-suite] WARN: http echo server failed to start on 127.0.0.1:$http_echo_port" >&2
+    http_echo_pid=""
+    return 0
+  fi
+  echo "[coverage-suite] started http echo server (pid $http_echo_pid, 127.0.0.1:$http_echo_port)"
 }
 start_http_echo_server_if_needed
 

--- a/scripts/unit_test_allowlist.txt
+++ b/scripts/unit_test_allowlist.txt
@@ -11,8 +11,9 @@
 # response_body/close) now lower to real `vibe.http_*` host imports
 # (fetch-backed in scripts/wasm_vibe_host_runner.js) instead of an unhandled
 # `perform ... -> throw`. The unit-test runner auto-starts
-# tests/http_echo_server.py (127.0.0.1:18280) when an allowlisted test
-# mentions that endpoint. The surface builtins use `__http_*_raw` dunder
+# tests/http_echo_server.py (port derived per worktree, exported as
+# VIBE_HTTP_ECHO_PORT, #934) when an allowlisted test mentions that
+# endpoint. The surface builtins use `__http_*_raw` dunder
 # names because index.vibe's alias exports (`export let Http::request = ...`)
 # would otherwise capture the ident and recurse forever (#795 -- the same
 # latent bug ships in lib/@vibe/fs's Fs::stat_token today).

--- a/scripts/unit_test_runner.sh
+++ b/scripts/unit_test_runner.sh
@@ -62,26 +62,40 @@ fi
 
 # --- local HTTP echo server (#794) --------------------------------------------
 # lib/@vibe/http/http_e2e_test.vibe drives real HTTP against
-# tests/http_echo_server.py on 127.0.0.1:18280. Detection is content-based
-# (the endpoint string in the test source), like the wasmtime gate below. If
-# python3 is unavailable the server is not started and the affected tests
+# tests/http_echo_server.py. Detection is content-based (the env-override
+# marker / endpoint string in the test source), like the wasmtime gate below.
+# If python3 is unavailable the server is not started and the affected tests
 # fail with a connection error -- an honest signal, not a silent skip.
+#
+# #934: the port is derived from the repo path (18280 + hash % 1000) so
+# concurrent batteries in different worktrees each own a private server
+# instead of colliding on a fixed 18280 (where the first battery to finish
+# killed the shared server out from under the other). The test reads the
+# port from VIBE_HTTP_ECHO_PORT, exported below for the compiled test runs.
 http_echo_pid=""
+http_echo_port="${VIBE_HTTP_ECHO_PORT:-$((18280 + $(printf '%s' "$ROOT_DIR" | cksum | cut -d' ' -f1) % 1000))}"
+export VIBE_HTTP_ECHO_PORT="$http_echo_port"
 start_http_echo_server_if_needed() {
   local list_file="$1"
   local need=0 f
   while IFS= read -r f; do
     case "$f" in ''|\#*) continue ;; esac
-    if [ -f "$f" ] && grep -q "127.0.0.1:18280" "$f"; then need=1; break; fi
+    if [ -f "$f" ] && grep -q "VIBE_HTTP_ECHO_PORT\|127.0.0.1:18280" "$f"; then need=1; break; fi
   done < "$list_file"
   [ "$need" -eq 1 ] || return 0
   command -v python3 >/dev/null 2>&1 || return 0
   [ -f "$ROOT_DIR/tests/http_echo_server.py" ] || return 0
-  python3 "$ROOT_DIR/tests/http_echo_server.py" 18280 >/dev/null 2>&1 &
+  python3 "$ROOT_DIR/tests/http_echo_server.py" "$http_echo_port" >/dev/null 2>&1 &
   http_echo_pid=$!
   trap 'if [ -n "$http_echo_pid" ]; then kill "$http_echo_pid" 2>/dev/null || true; fi' EXIT
-  echo "[unit-test-runner] started http echo server (pid $http_echo_pid, 127.0.0.1:18280)"
   sleep 1
+  if ! kill -0 "$http_echo_pid" 2>/dev/null; then
+    echo "[unit-test-runner] WARN: http echo server failed to start on 127.0.0.1:$http_echo_port" >&2
+    echo "[unit-test-runner] WARN: (port in use? another battery in the SAME worktree would collide)" >&2
+    http_echo_pid=""
+    return 0
+  fi
+  echo "[unit-test-runner] started http echo server (pid $http_echo_pid, 127.0.0.1:$http_echo_port)"
 }
 
 # --- compile + run one test file; 0 = pass, 1 = fail --------------------------

--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -2563,8 +2563,14 @@ async function main() {
       throw err;
     }
   };
-  const resultToExitCode = (result) => {
+  const resultToExitCode = (result, isSelfhost) => {
     if (typeof result === "bigint") {
+      // Selfhost-compiled modules return untagged i64 values (same split as
+      // emitResult). Treating them as tagged shifted any multiple-of-4 exit
+      // code right by 2 (main returning 20 exited 5).
+      if (isSelfhost) {
+        return Number(result) | 0;
+      }
       return decodeTaggedOrRawInt(result);
     }
     if (typeof result === "number") {
@@ -2725,9 +2731,9 @@ async function main() {
       try {
         const req = JSON.parse(row);
         const args = Array.isArray(req.args) ? req.args.map(String) : [];
-        const { result, elapsedUs } = runInvokes(args);
+        const { result, isSelfhost, elapsedUs } = runInvokes(args);
         response = {
-          exit_code: resultToExitCode(result),
+          exit_code: resultToExitCode(result, isSelfhost),
           elapsed_us: Math.max(1, Math.round(elapsedUs)),
           stdout: capturedStdout,
         };
@@ -2780,7 +2786,7 @@ async function main() {
   const invoke = invokes[invokes.length - 1];
   emitResult(invoke, result, isSelfhost);
   if (invoke === "cli_main" || process.env.VIBE_RUNNER_EXIT_WITH_RESULT === "1") {
-    process.exitCode = resultToExitCode(result);
+    process.exitCode = resultToExitCode(result, isSelfhost);
   }
 }
 


### PR DESCRIPTION
## Summary

バグ潰しバッチ第1弾: **#934** (unit_test_runner の http echo server ポート衝突) を修正。

- `scripts/unit_test_runner.sh`: echo server のポートを repo パスから導出 (`18280 + cksum(ROOT_DIR) % 1000`) し、worktree ごとに専用サーバを持つように。`VIBE_HTTP_ECHO_PORT` としてテスト実行に export。bind 失敗時は黙って続行せず WARN を出す
- `lib/@vibe/http/http_e2e_test.vibe`: test ブロック内で `Env::get("VIBE_HTTP_ECHO_PORT")` を読み (fn 本体は base URL を引数で受ける — 素の fn だと Env row が必要になるため)、未設定時は従来どおり 18280 にフォールバック

これで「先に終わった battery の EXIT trap が共有サーバを kill し、まだ走っている側の http_e2e_test が connection error で trap する」誤検出が構造的に消えます。

並列バグハント (4 agent) の検証済み findings があれば、このブランチに追加コミットで積みます。

## Test plan

- [x] runner 経由 (導出ポート 18769): `1/1 passed`
- [x] standalone `vibe_test.sh` + 手動起動サーバ (18280、env 未設定): pass — 後方互換維持
- [x] パスごとにポートが異なることを確認 (3 パスで 18769/18328/18404)
- [x] `check_bundle_sync.sh` / `check_module_source_sync.sh` ok (http は compiler manifest 外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H

---
_Generated by [Claude Code](https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H)_