### PR TITLE
CI: selfcompile heap_ptr ゲート配線 (#987) + flaker の moon 残滓再配線 (#988)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,21 @@ jobs:
           echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Compiler gate
         run: bash scripts/compiler_gate.sh
+      - name: Selfcompile KPI heap gate (#987)
+        # One real compile through the gate's freshly-built stage2, gated on
+        # the linear backend's bump-allocator high-water (heap_ptr_bytes).
+        # Unlike wall time it is byte-deterministic for a fixed (stage2,
+        # input) pair — scripts/selfcompile_kpi.sh isolates the build cache —
+        # so it can block CI without flakes. Threshold = committed baseline
+        # + 10%; the baseline tracks the compiler itself, so rebaseline it
+        # alongside intentional allocation changes (procedure in
+        # bench/selfhost_perf/heap_baseline.txt).
+        run: |
+          gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
+          baseline="$(grep -vE '^\s*(#|$)' bench/selfhost_perf/heap_baseline.txt | head -1)"
+          export VIBE_KPI_MAX_HEAP_BYTES=$(( baseline * 110 / 100 ))
+          echo "baseline=$baseline gate_max=$VIBE_KPI_MAX_HEAP_BYTES (+10%)"
+          bash scripts/selfcompile_kpi.sh "${gen}stage2.wasm"
       - name: vibe normalize smoke test (#882)
         # compiler_gate.sh's "normalize compile+run regression" section
         # exercises the normalize ENGINE directly (VIBE_NORMALIZE=1 against

--- a/.github/workflows/flaker-ci.yml
+++ b/.github/workflows/flaker-ci.yml
@@ -1,12 +1,12 @@
 name: flaker-ci
 
 on:
-  # Disabled: this flaker sampling drove the MoonBit-host test suite, retired
-  # with src/ (#594). Manual-only until reworked on the selfhost test path.
+  # Manual-only: rewired from the retired MoonBit-host suite (#594) to the
+  # selfhost unit-test battery (#988 — flaker.toml custom runner via
+  # scripts/flaker_vibe_runner.mjs). Keep on workflow_dispatch until main
+  # accumulates a trusted baseline of selfhost runs, then wire into
+  # pull_request/push.
   workflow_dispatch:
-
-env:
-  VIBE_MOON_WARN_LIST: "-1-6-7-9-20-24-29"
 
 permissions:
   contents: read
@@ -19,16 +19,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Setup Vibe toolchain
-        uses: ./.github/actions/setup-vibe
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
+      - name: Install wasmtime
+        # Optional for the unit-test battery: allowlisted files that shell
+        # out to the wasmtime CLI are skipped when it is missing (#769).
+        # Install it so sampled runs cover them. Version pinned to ci.yml's.
+        env:
+          WASMTIME_VERSION: v46.0.1
+        run: |
+          set -euo pipefail
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
+
       - name: Install flaker
         run: npm install -g @mizchi/flaker
-
-      - name: Moon update
-        run: moon update
 
       - name: Restore flaker DB
         # SHA-version the main baseline so subsequent main pushes can
@@ -82,11 +91,11 @@ jobs:
             core.setOutput('count', String(files.length));
 
       - name: Sampled test run
-        # `continue-on-error`: flaker's moontest adapter occasionally
-        # exits non-zero on CI in ways we cannot reproduce locally (no
-        # log access for the runner). Keep the gate visible but
-        # non-blocking until main accumulates a baseline of real runs;
-        # flip to blocking once the signal is trusted.
+        # `continue-on-error`: keep the gate visible but non-blocking until
+        # main accumulates a baseline of real selfhost runs; flip to
+        # blocking once the signal is trusted. Note: without a prebuilt
+        # VIBE_STAGE2_WASM the first execute performs a fresh
+        # seed->stage1->stage2 selfbuild (scripts/unit_test_runner.sh).
         continue-on-error: true
         env:
           CHANGED_FILES: ${{ steps.changed.outputs.files }}

--- a/.github/workflows/flaker-scheduled.yml
+++ b/.github/workflows/flaker-scheduled.yml
@@ -1,12 +1,11 @@
 name: flaker-scheduled
 
 on:
-  # Disabled: drove the MoonBit-host test suite, retired with src/ (#594).
-  # Manual-only until reworked on the selfhost test path.
+  # Manual-only: rewired from the retired MoonBit-host suite (#594) to the
+  # selfhost unit-test battery (#988 — flaker.toml custom runner via
+  # scripts/flaker_vibe_runner.mjs). Re-enable a cron schedule once the
+  # selfhost runs are trusted.
   workflow_dispatch:
-
-env:
-  VIBE_MOON_WARN_LIST: "-1-6-7-9-20-24-29"
 
 jobs:
   full-run:
@@ -15,31 +14,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install MoonBit
-        run: bash scripts/install_moonbit.sh
-
-      - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
-
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
+      - name: Install wasmtime
+        # Optional for the unit-test battery: allowlisted files that shell
+        # out to the wasmtime CLI are skipped when it is missing (#769).
+        # Install it so the full run covers them. Version pinned to ci.yml's.
+        env:
+          WASMTIME_VERSION: v46.0.1
+        run: |
+          set -euo pipefail
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
+
       - name: Install flaker
         run: npm install -g @mizchi/flaker
-
-      - name: Moon update
-        run: moon update
-
-      - name: Cache MoonBit build
-        uses: actions/cache@v5
-        with:
-          path: |
-            _build
-            .mooncakes
-          key: moonbit-${{ runner.os }}-${{ hashFiles('.moon-version') }}-${{ hashFiles('moon.mod.json', 'src/**/*.mbt') }}
-          restore-keys: moonbit-${{ runner.os }}-${{ hashFiles('.moon-version') }}-
 
       - name: Restore flaker DB
         uses: actions/cache/restore@v4
@@ -49,6 +42,9 @@ jobs:
           restore-keys: flaker-db-
 
       - name: Full test run
+        # The custom runner's first execute builds a fresh
+        # seed->stage1->stage2 generation (scripts/unit_test_runner.sh),
+        # then runs the whole allowlist through it.
         run: flaker run --profile scheduled
 
       - name: Save flaker DB

--- a/bench/selfhost_perf/README.md
+++ b/bench/selfhost_perf/README.md
@@ -161,6 +161,36 @@ Both benches share `_build/wasm/opt/` and consult `.opt_level` so a
 runtime switch rebuilds the wasm-opt artifact rather than silently
 benching against the wrong level.
 
+## Selfcompile KPI heap gate (CI, #987)
+
+Driver: `scripts/selfcompile_kpi.sh <stage2.wasm> [input.vibe]`.
+
+One real compile through a selfhost stage2, reporting `wall_ms` and
+`heap_ptr_bytes` (linear backend bump-allocator high-water). With a cold
+isolated `VIBE_BUILD_CACHE_DIR` the heap number is **byte-deterministic**
+for a fixed (stage2, input) pair, so — unlike wall time — it gates CI
+without flakes.
+
+CI wiring (`.github/workflows/ci.yml`, step "Selfcompile KPI heap gate"):
+the compiler-gate job runs the script against its freshly-built stage2 and
+fails when `heap_ptr_bytes` exceeds the committed baseline in
+[`heap_baseline.txt`](heap_baseline.txt) by more than 10%
+(`VIBE_KPI_MAX_HEAP_BYTES = baseline * 110 / 100`).
+
+The baseline tracks the compiler itself: any change to
+`lib/@vibe/compiler/` (or the default input file) can move it. Rebaseline
+alongside intentional changes — in either direction; ratchet it down after
+an allocation win so the gate protects the win:
+
+```bash
+bash scripts/generations.sh build --out-dir /tmp/kpi_gen
+bash scripts/selfcompile_kpi.sh /tmp/kpi_gen/stage2.wasm
+# -> copy heap_ptr_bytes into bench/selfhost_perf/heap_baseline.txt
+```
+
+Commit the new number with the compiler change and note old -> new (and
+why) in the PR.
+
 ## Memory: peak RSS + wallclock
 
 Driver: `scripts/bench_selfhost_memory.sh` → `just bench-selfhost-memory`.

--- a/bench/selfhost_perf/heap_baseline.txt
+++ b/bench/selfhost_perf/heap_baseline.txt
@@ -1,0 +1,18 @@
+# Selfcompile KPI heap baseline — heap_ptr_bytes from scripts/selfcompile_kpi.sh
+# (bump-allocator high-water of one stage2 compile of the default input,
+# lib/@vibe/compiler/tests/codegen_lexer_test.vibe, with a cold isolated
+# VIBE_BUILD_CACHE_DIR). Byte-deterministic for a fixed (stage2, input) pair,
+# so CI (ci.yml "Selfcompile KPI heap gate") fails when the current commit's
+# stage2 exceeds this baseline by more than 10%.
+#
+# The number changes whenever the compiler itself changes. Rebaseline when an
+# intentional compiler change moves it (either direction — ratchet DOWN after
+# an allocation win so the gate protects it):
+#   bash scripts/generations.sh build --out-dir /tmp/kpi_gen
+#   bash scripts/selfcompile_kpi.sh /tmp/kpi_gen/stage2.wasm
+#   # -> copy the reported heap_ptr_bytes over the number below
+# and commit the new number together with the compiler change, noting the
+# old -> new value (and why) in the PR.
+#
+# Format: comments/blank lines ignored; first remaining line is the baseline.
+643835180

--- a/flaker.toml
+++ b/flaker.toml
@@ -5,16 +5,27 @@ name = "vibe-lang"
 [storage]
 path = ".flaker/data.duckdb"
 
+# Selfhost rewiring (#988): the previous moontest adapter / `moon test` runner
+# / moon resolver targeted the retired MoonBit host (#594) and made every
+# `flaker run` a silent 0/0 no-op. The custom runner bridges to the selfhost
+# unit-test battery (scripts/unit_test_runner.sh) via
+# scripts/flaker_vibe_runner.mjs; granularity is one *_test.vibe file per test.
+# Set VIBE_STAGE2_WASM to a prebuilt stage2 to skip the per-run selfbuild.
 [adapter]
-type = "moontest"
-artifact_name = "moontest-results"
+type = "custom"
+command = "node scripts/flaker_vibe_runner.mjs parse"
+artifact_name = "vibe-unit-test-results"
 
 [runner]
-type = "moontest"
-command = "moon test --target js -v"
+type = "custom"
+execute = "node scripts/flaker_vibe_runner.mjs execute"
+list = "node scripts/flaker_vibe_runner.mjs list"
 
 [affected]
-resolver = "moon"
+# Path/directory-based (git diff vs origin/main merge-base): a changed file
+# selects the *_test.vibe suites living in/under its directory. Coarse but
+# moon-free; an import-graph resolver is future work (#988).
+resolver = "simple"
 config = ""
 
 [quarantine]

--- a/scripts/flaker_vibe_runner.mjs
+++ b/scripts/flaker_vibe_runner.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// flaker <-> selfhost unit-test bridge (#988).
+//
+// flaker.toml's runner/adapter used to point at the retired MoonBit host
+// (`moon test --target js`, moontest adapter, moon resolver — #594), which
+// made `flaker run --profile local` a silent no-op: listTests failed, the
+// inventory was empty, and every run reported "Selected tests: 0 / 0" with
+// exit 0. This script rewires flaker's `custom` runner/adapter protocol onto
+// the selfhost unit-test battery (scripts/unit_test_runner.sh, #531/#535).
+//
+// Subcommands (see flaker's CustomRunner / CustomAdapter contracts):
+//   list     print the test inventory as JSON [{suite, testName}] — one entry
+//            per allowlisted *_test.vibe file (per-file granularity: the
+//            selfhost battery compiles+runs whole files, so a file is the
+//            selection unit).
+//   execute  read {tests, opts} JSON on stdin, run the selected files through
+//            unit_test_runner.sh (via a temp VIBE_UNIT_TEST_ALLOWLIST), print
+//            an ExecuteResult JSON {exitCode, results, durationMs, stdout,
+//            stderr} on stdout.
+//   parse    read unit_test_runner.sh output on stdin, print TestCaseResult[]
+//            JSON (flaker `import` / CI-artifact ingestion path).
+//
+// Stage2 selection: VIBE_STAGE2_WASM is passed through when set (CI reuses
+// the gate's stage2; locally, point it at a fresh generation to skip the
+// per-run seed->stage1->stage2 selfbuild that unit_test_runner.sh otherwise
+// performs). Without it, expect the first run to spend minutes selfbuilding.
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const ALLOWLIST =
+  process.env.VIBE_UNIT_TEST_ALLOWLIST ??
+  join(ROOT, "scripts", "unit_test_allowlist.txt");
+
+// A file is one test: suite = repo-relative path (what the path-based
+// affected resolver matches against), testName = fixed marker.
+const TEST_NAME = "file";
+
+function readAllowlist() {
+  return readFileSync(ALLOWLIST, "utf-8")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l !== "" && !l.startsWith("#"));
+}
+
+function readStdin() {
+  return readFileSync(0, "utf-8");
+}
+
+// Parse unit_test_runner.sh per-file lines:
+//   "ok:   <path>"                     -> passed
+//   "FAIL: <path> -- <diag>"           -> failed
+//   "skip: <path> (<reason>)"          -> skipped
+function parseRunnerOutput(text) {
+  const results = [];
+  for (const line of text.split("\n")) {
+    let m;
+    if ((m = line.match(/^ok:\s+(\S+)\s*$/))) {
+      results.push({
+        suite: m[1],
+        testName: TEST_NAME,
+        status: "passed",
+        durationMs: 0,
+        retryCount: 0,
+      });
+    } else if ((m = line.match(/^FAIL:\s+(\S+)(?:\s+--\s+(.*))?$/))) {
+      results.push({
+        suite: m[1],
+        testName: TEST_NAME,
+        status: "failed",
+        durationMs: 0,
+        retryCount: 0,
+        errorMessage: (m[2] ?? "").trim() || "unit_test_runner reported FAIL",
+      });
+    } else if ((m = line.match(/^skip:\s+(\S+)/))) {
+      results.push({
+        suite: m[1],
+        testName: TEST_NAME,
+        status: "skipped",
+        durationMs: 0,
+        retryCount: 0,
+      });
+    }
+  }
+  return results;
+}
+
+function cmdList() {
+  const tests = readAllowlist().map((suite) => ({ suite, testName: TEST_NAME }));
+  process.stdout.write(JSON.stringify(tests));
+}
+
+function cmdExecute() {
+  const started = Date.now();
+  let payload = {};
+  try {
+    payload = JSON.parse(readStdin() || "{}");
+  } catch {
+    payload = {};
+  }
+  const suites = [...new Set((payload.tests ?? []).map((t) => t.suite))];
+  if (suites.length === 0) {
+    process.stdout.write(
+      JSON.stringify({ exitCode: 0, results: [], durationMs: 0, stdout: "", stderr: "" }),
+    );
+    return;
+  }
+  const dir = mkdtempSync(join(tmpdir(), "flaker-vibe-"));
+  try {
+    const subset = join(dir, "allowlist.txt");
+    writeFileSync(subset, suites.join("\n") + "\n");
+    const proc = spawnSync("bash", [join(ROOT, "scripts", "unit_test_runner.sh")], {
+      cwd: ROOT,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+      env: { ...process.env, VIBE_UNIT_TEST_ALLOWLIST: subset },
+    });
+    const stdout = proc.stdout ?? "";
+    const stderr = proc.stderr ?? "";
+    // Per-file verdicts: ok/skip on stdout, FAIL on stderr.
+    const results = parseRunnerOutput(stdout + "\n" + stderr);
+    // Selected-but-unreported files (runner crashed before reaching them):
+    // surface them as failures instead of dropping them silently.
+    const seen = new Set(results.map((r) => r.suite));
+    for (const suite of suites) {
+      if (!seen.has(suite)) {
+        results.push({
+          suite,
+          testName: TEST_NAME,
+          status: "failed",
+          durationMs: 0,
+          retryCount: 0,
+          errorMessage: `no verdict from unit_test_runner.sh (exit ${proc.status ?? "?"})`,
+        });
+      }
+    }
+    process.stdout.write(
+      JSON.stringify({
+        exitCode: proc.status ?? 1,
+        results,
+        durationMs: Date.now() - started,
+        stdout,
+        stderr,
+      }),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function cmdParse() {
+  process.stdout.write(JSON.stringify(parseRunnerOutput(readStdin())));
+}
+
+const sub = process.argv[2];
+switch (sub) {
+  case "list":
+    cmdList();
+    break;
+  case "execute":
+    cmdExecute();
+    break;
+  case "parse":
+    cmdParse();
+    break;
+  default:
+    process.stderr.write(
+      "usage: node scripts/flaker_vibe_runner.mjs <list|execute|parse>\n",
+    );
+    process.exit(2);
+}


### PR DESCRIPTION
## Summary

ベンチ改善③ + issue #988 を 1 branch で (commit 分割)。

**A. selfcompile KPI heap ゲートを CI に配線** (`1940e676`, refs #987)
- baseline 実測: main `bf4d6677` の fresh stage2 で **heap_ptr_bytes=643835180** (2 回実行で byte 一致 — 決定性を再確認)
- ci.yml の Compiler gate 直後に KPI step 追加。`bench/selfhost_perf/heap_baseline.txt` の baseline × 110% をしきい値に fail。rebaseline 手順は baseline ファイルと README に記載
- ゲート動作をローカル実証: baseline+10% で rc=0、baseline−1 で rc=1

**B. #988: flaker の moon 残滓の再配線** (`7b47d2d8`)
- **Before 実測: `pkf run test-local` は無言の no-op だった** — moontest adapter の listTests が fail し flaker がエラーを握りつぶして「Selected tests: 0 / 0」rc=0。ずっと何も走らず green
- 新 bridge `scripts/flaker_vibe_runner.mjs` (flaker custom runner/adapter protocol → unit_test_runner.sh、file 単位 452 suites、temp allowlist で subset 実行)
- resolver は `moon` → 組み込み `simple` (git-diff パスベース)。After 実測: 452 suites 認識、cold-start 45/452 実行 green、`--changed lib/@vibe/json/index.vibe` で json 4 suites だけ選択・実行
- flaker workflows から MoonBit install / moon update / VIBE_MOON_WARN_LIST 等を掃除

妥協点: affected はディレクトリ一致で import graph 未対応 (#988 は followup として open 維持)、per-test duration 未計測、stage2 未指定時は execute ごとに selfbuild (~4 分、コメントで注記)。

## Test plan
- [x] KPI ゲート rc=0 / rc=1 の両方をローカル実証、YAML 3 本 parse ok
- [x] flaker before/after を実測 (上記)。compiler ソース非接触のため chain 不要

refs #987, refs #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H

---
_Generated by [Claude Code](https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H)_