### PR TITLE
formal: Call Oracle の契約カバレッジを拡張

### DIFF
--- a/formal/README.md
+++ b/formal/README.md
@@ -60,8 +60,12 @@ variables, positional arguments, and fully-labeled arguments. It proves that:
   declared parameter contract;
 - after generic inference, every accepted actual argument equals its
   instantiated parameter type;
+- repeated occurrences of one type variable share a single substitution,
+  including when they occur below a nominal type constructor;
 - the reported return type is the unique instantiation of the signature return
   pattern;
+- call arity is exact, and a call uses either positional arguments or labels
+  consistently rather than mixing the two modes;
 - fully-labeled arguments resolve by ABI label rather than source order, while
   unknown and duplicate labels are rejected;
 - builtin signatures use the same call relation as user functions rather than
@@ -69,21 +73,25 @@ variables, positional arguments, and fully-labeled arguments. It proves that:
 - `Map::set` is a functional update returning `Map[K,V]`, and source aliases
   such as `Int64Array = Array[Int]` are normalized before core typing.
 
-The executable corpus in `formal/oracle/call-typing.tsv` locks positive and
-negative witnesses for #938, #981, #983, #985, and #986. Deliberately
+The 25-case executable corpus in `formal/oracle/call-typing.tsv` locks positive
+and negative witnesses for #938, #981, #983, #985, #986, and #1001. Deliberately
 broken head-only and unchecked-argument predicates demonstrate that the corpus
-detects type-argument erasure and argument-check bypass.
+detects type-argument erasure, inconsistent repeated-variable inference, and
+argument-resolution bypass.
 
 This slice begins after parsing, name resolution, signature collection, and
 generic-bound checking. It does not yet model function values, type-and-effect
-subtyping, optional parameters, mixed positional/labeled calls, implicit
-coercions, evaluation, or Wasm representation. The embedded Vibe sources are
+subtyping, optional parameters, implicit coercions, evaluation, or Wasm
+representation. The embedded Vibe sources are
 bridge fixtures. `examples/selfhost-call-oracle.sh` feeds them to the current
 selfhost checker and reports semantic drift, but passing the Lean corpus check
 alone does not prove implementation correspondence. In particular, the `?` /
 `let*` railway desugaring from #941 is outside this call-only slice; a plain
 `Result`/`Option` call mismatch is retained as a nominal-head witness without
 claiming to model that closed issue's desugaring path.
+Remaining checker correspondence gaps, including nominal mismatches and mixed
+argument modes, are tracked in #1001; report mode preserves them as explicit
+counterexamples until the implementation agrees with the Oracle.
 
 ## Verified compiler scheduler properties
 

--- a/formal/VibeFormal/Proofs/CallTypingExamples.lean
+++ b/formal/VibeFormal/Proofs/CallTypingExamples.lean
@@ -31,6 +31,28 @@ example : Oracle.mapValueAccepted.source =
 example : Oracle.boxArgumentMismatch.expected = .rejected .typeMismatch := by
   rfl
 
+example : Oracle.sameTypeVariableAccepted.expected =
+    .accepted .int [.int] := by
+  rfl
+
+example : Oracle.sameTypeVariableMismatch.expected = .rejected .typeMismatch := by
+  rfl
+
+example : Oracle.nestedTypeVariableCorrelation.expected = .rejected .typeMismatch := by
+  rfl
+
+example : Oracle.tooFewArguments.expected = .rejected .arityMismatch := by
+  rfl
+
+example : Oracle.tooManyArguments.expected = .rejected .arityMismatch := by
+  rfl
+
+example : Oracle.mixedArgumentModes.expected = .rejected .mixedArgumentModes := by
+  rfl
+
+example : Oracle.cases.length = 25 := by
+  rfl
+
 example : Oracle.brokenHeadOnlyAcceptsBoxMismatch = true := by
   native_decide
 
@@ -41,6 +63,12 @@ example : Oracle.brokenHeadOnlyAcceptsMapValueMismatch = true := by
   native_decide
 
 example : Oracle.brokenUncheckedAcceptsUnknownLabel = true := by
+  native_decide
+
+example : Oracle.brokenHeadOnlyAcceptsRepeatedVariableMismatch = true := by
+  native_decide
+
+example : Oracle.brokenUncheckedAcceptsMixedArgumentModes = true := by
   native_decide
 
 end VibeFormal.Typing.Examples

--- a/formal/VibeFormal/Typing/Oracle.lean
+++ b/formal/VibeFormal/Typing/Oracle.lean
@@ -21,6 +21,17 @@ private def option (element : Ty) : Ty := named "Option" [element]
 private def identitySignature : Signature :=
   ⟨"identity", 1, [parameter (.var 0)], .var 0⟩
 
+private def sameTypeVariableSignature : Signature :=
+  ⟨"same", 1, [parameter (.var 0), parameter (.var 0)], .var 0⟩
+
+private def correlatedArraysSignature : Signature :=
+  ⟨"first", 1,
+    [parameter (array (.var 0)), parameter (array (.var 0))],
+    array (.var 0)⟩
+
+private def addSignature : Signature :=
+  ⟨"add", 0, [parameter .int, parameter .int], .int⟩
+
 private def getIntSignature : Signature :=
   ⟨"get_int", 0, [parameter (box .int)], .int⟩
 
@@ -77,6 +88,51 @@ def genericIdentity : OracleCase := {
   expected := .accepted .int [.int]
 }
 
+def sameTypeVariableAccepted : OracleCase := {
+  name := "same-type-variable-accepted"
+  issue := "#990"
+  source := "fn same[T](x: T, y: T) -> T { x } fn good() -> Int { same(1, 2) }"
+  signature := sameTypeVariableSignature
+  arguments := [positional .int, positional .int]
+  expected := .accepted .int [.int]
+}
+
+def sameTypeVariableMismatch : OracleCase := {
+  name := "same-type-variable-mismatch"
+  issue := "#990"
+  source := "fn same[T](x: T, y: T) -> T { x } fn bad() -> Int { same(1, \"bad\") }"
+  signature := sameTypeVariableSignature
+  arguments := [positional .int, positional .string]
+  expected := .rejected .typeMismatch
+}
+
+def nestedTypeVariableCorrelation : OracleCase := {
+  name := "nested-type-variable-correlation"
+  issue := "#990"
+  source := "fn first[T](a: Array[T], b: Array[T]) -> Array[T] { a } fn bad(a: Array[Int], b: Array[String]) -> Array[Int] { first(a, b) }"
+  signature := correlatedArraysSignature
+  arguments := [positional (array .int), positional (array .string)]
+  expected := .rejected .typeMismatch
+}
+
+def tooFewArguments : OracleCase := {
+  name := "too-few-arguments"
+  issue := "#990"
+  source := "fn add(x: Int, y: Int) -> Int { x + y } fn bad() -> Int { add(1) }"
+  signature := addSignature
+  arguments := [positional .int]
+  expected := .rejected .arityMismatch
+}
+
+def tooManyArguments : OracleCase := {
+  name := "too-many-arguments"
+  issue := "#990"
+  source := "fn add(x: Int, y: Int) -> Int { x + y } fn bad() -> Int { add(1, 2, 3) }"
+  signature := addSignature
+  arguments := [positional .int, positional .int, positional .int]
+  expected := .rejected .arityMismatch
+}
+
 def labeledReordered : OracleCase := {
   name := "labeled-reordered"
   issue := "#986"
@@ -106,7 +162,7 @@ def builderElementMismatch : OracleCase := {
 
 def resultOptionCallMismatch : OracleCase := {
   name := "result-option-mismatch"
-  issue := "#990"
+  issue := "#1001"
   source := "fn use_result(x: Result[Int,String]) -> Int { 0 } fn bad(o: Option[Int]) -> Int { use_result(o) }"
   signature := resultOptionCallSignature
   arguments := [positional (option .int)]
@@ -142,7 +198,7 @@ def nestedGenericArgumentMismatch : OracleCase := {
 
 def nestedNominalHeadMismatch : OracleCase := {
   name := "nested-nominal-head-mismatch"
-  issue := "#981"
+  issue := "#1001"
   source := "fn use_options(x: Array[Option[Int]]) -> Int { 0 } fn bad(x: Array[Result[Int,String]]) -> Int { use_options(x) }"
   signature := useOptionsSignature
   arguments := [positional (array (result .int .string))]
@@ -239,8 +295,22 @@ def labeledMissing : OracleCase := {
   expected := .rejected .arityMismatch
 }
 
+def mixedArgumentModes : OracleCase := {
+  name := "mixed-argument-modes"
+  issue := "#1001"
+  source := "let f: (x~: Int, y~: String) -> Int = (x~, y~) -> { x } fn bad() -> Int { f(x=1, \"ok\") }"
+  signature := labeledSignature
+  arguments := [labeled "x" .int, positional .string]
+  expected := .rejected .mixedArgumentModes
+}
+
 def cases : List OracleCase := [
   genericIdentity,
+  sameTypeVariableAccepted,
+  sameTypeVariableMismatch,
+  nestedTypeVariableCorrelation,
+  tooFewArguments,
+  tooManyArguments,
   labeledReordered,
   labeledPositional,
   builderElementMismatch,
@@ -258,7 +328,8 @@ def cases : List OracleCase := [
   labeledTypeMismatch,
   labeledUnknown,
   labeledDuplicate,
-  labeledMissing
+  labeledMissing,
+  mixedArgumentModes
 ]
 
 def OracleCase.actual (testCase : OracleCase) : CallOutcome :=
@@ -280,6 +351,12 @@ def brokenHeadOnlyAcceptsMapValueMismatch : Bool :=
 
 def brokenUncheckedAcceptsUnknownLabel : Bool :=
   brokenUncheckedAccepts labeledUnknown.signature labeledUnknown.arguments
+
+def brokenHeadOnlyAcceptsRepeatedVariableMismatch : Bool :=
+  brokenHeadOnlyAccepts sameTypeVariableMismatch.signature sameTypeVariableMismatch.arguments
+
+def brokenUncheckedAcceptsMixedArgumentModes : Bool :=
+  brokenUncheckedAccepts mixedArgumentModes.signature mixedArgumentModes.arguments
 
 private def renderErrorKind : CallErrorKind → String
   | .arityMismatch => "arity-mismatch"

--- a/formal/oracle/call-typing.tsv
+++ b/formal/oracle/call-typing.tsv
@@ -1,14 +1,19 @@
 version	1
 name	issue	verdict	detail	source
 generic-identity	#990	accept	Int;types=[Int]	fn identity[T](x: T) -> T { x } fn main() -> Int { identity(1) }
+same-type-variable-accepted	#990	accept	Int;types=[Int]	fn same[T](x: T, y: T) -> T { x } fn good() -> Int { same(1, 2) }
+same-type-variable-mismatch	#990	reject	type-mismatch	fn same[T](x: T, y: T) -> T { x } fn bad() -> Int { same(1, "bad") }
+nested-type-variable-correlation	#990	reject	type-mismatch	fn first[T](a: Array[T], b: Array[T]) -> Array[T] { a } fn bad(a: Array[Int], b: Array[String]) -> Array[Int] { first(a, b) }
+too-few-arguments	#990	reject	arity-mismatch	fn add(x: Int, y: Int) -> Int { x + y } fn bad() -> Int { add(1) }
+too-many-arguments	#990	reject	arity-mismatch	fn add(x: Int, y: Int) -> Int { x + y } fn bad() -> Int { add(1, 2, 3) }
 labeled-reordered	#986	accept	Int;types=[]	let f: (x~: Int, y~: String) -> Int = (x~, y~) -> { x } fn main() -> Int { f(y="ok", x=1) }
 labeled-positional	#986	accept	Int;types=[]	let f: (x~: Int, y~: String) -> Int = (x~, y~) -> { x } fn main() -> Int { f(1, "ok") }
 array-builder-element-mismatch	#938	reject	type-mismatch	fn bad(b: ArrayBuilder[Int]) -> Unit { ArrayBuilder::push(b, "bad") }
-result-option-mismatch	#990	reject	type-mismatch	fn use_result(x: Result[Int,String]) -> Int { 0 } fn bad(o: Option[Int]) -> Int { use_result(o) }
+result-option-mismatch	#1001	reject	type-mismatch	fn use_result(x: Result[Int,String]) -> Int { 0 } fn bad(o: Option[Int]) -> Int { use_result(o) }
 box-type-argument-mismatch	#981	reject	type-mismatch	struct Box[T] { v: T } fn get_int(x: Box[Int]) -> Int { 0 } fn bad(x: Box[String]) -> Int { get_int(x) }
 generic-enum-type-argument-mismatch	#981	reject	type-mismatch	enum Box[T] { Wrap(T) } fn get_int(x: Box[Int]) -> Int { 0 } fn bad(x: Box[String]) -> Int { get_int(x) }
 nested-generic-type-argument-mismatch	#981	reject	type-mismatch	struct Box[T] { v: T } fn use_nested_ints(x: Box[Array[Int]]) -> Int { 0 } fn bad(x: Box[Array[String]]) -> Int { use_nested_ints(x) }
-nested-nominal-head-mismatch	#981	reject	type-mismatch	fn use_options(x: Array[Option[Int]]) -> Int { 0 } fn bad(x: Array[Result[Int,String]]) -> Int { use_options(x) }
+nested-nominal-head-mismatch	#1001	reject	type-mismatch	fn use_options(x: Array[Option[Int]]) -> Int { 0 } fn bad(x: Array[Result[Int,String]]) -> Int { use_options(x) }
 generic-method-receiver-mismatch	#981	reject	type-mismatch	struct Box[T] { v: T } fn Box::get_int(self: Box[Int]) -> Int { 0 } fn bad(x: Box[String]) -> Int { x.get_int() }
 map-value-mismatch	#983	reject	type-mismatch	fn bad(m: Map[String,Int]) -> Map[String,Int] { Map::set(m, "k", "bad") }
 map-value-accepted	#983	accept	Map[String,Int];types=[String,Int]	fn good(m: Map[String,Int]) -> Map[String,Int] { Map::set(m, "k", 1) }
@@ -19,3 +24,4 @@ labeled-type-mismatch	#986	reject	type-mismatch	let f: (x~: Int, y~: String) -> 
 labeled-unknown	#986	reject	unknown-label	let f: (x~: Int, y~: String) -> Int = (x~, y~) -> { x } fn bad() -> Int { f(z=1, y="ok") }
 labeled-duplicate	#986	reject	duplicate-label	let f: (x~: Int, y~: String) -> Int = (x~, y~) -> { x } fn bad() -> Int { f(x=1, x=2) }
 labeled-missing	#986	reject	arity-mismatch	let f: (x~: Int, y~: String) -> Int = (x~, y~) -> { x } fn bad() -> Int { f(x=1) }
+mixed-argument-modes	#1001	reject	mixed-argument-modes	let f: (x~: Int, y~: String) -> Int = (x~, y~) -> { x } fn bad() -> Int { f(x=1, "ok") }


### PR DESCRIPTION
## 概要

Lean Call Oracle の executable corpus を19件から25件へ拡張します。

- 同じ型変数が複数引数で単一の substitution を共有する正例・負例
- nominal type の内側にある型変数相関の負例
- 引数不足・過剰の arity mismatch
- positional / labeled argument mode の混在拒否
- head-only / arity-only の壊れた判定が新しい反例を誤受理する load-bearing witness

## 実装との接地

最新 selfhost checker との bridge は25件中22 match、3 mismatch、0 errorです。期待値を実装に合わせて弱めず、残る次の差分を #1001 で追跡します。

- Result / Option の nominal head mismatch
- nested nominal head mismatch
- mixed argument mode の check/compile parity

compiler実装はこのPRでは変更しません。

## 検証

- lake build --wfail
- pkf run formal-check
- pkf run formal-selfhost-oracle
- pkf affected formal/README.md formal/VibeFormal/Proofs/CallTypingExamples.lean formal/VibeFormal/Typing/Oracle.lean formal/oracle/call-typing.tsv
- pkf run release-check
- git diff --check
