### PR TITLE
#1000: drop the redundant "moon-free" qualifier from active docs/scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
   pull_request:
 
 # vibe is selfhost-only (the MoonBit host src/ was retired in #594). CI runs the
-# moon-free selfhost-only gate: bundle/module-source sync + seed->stage1->stage2
+# selfhost-only gate: bundle/module-source sync + seed->stage1->stage2
 # ->stage3 selfbuild with the stage2==stage3 fixpoint and per-stage compile/run
 # validation. No MoonBit toolchain is installed or used.
 jobs:
   compiler-gate:
-    name: compiler-gate (moon-free)
+    name: compiler-gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 > implementation (`src/`, `moon.mod`) was retired. The compiler is built,
 > checked, and run entirely from the committed seed (`bootstrap/seed/`)
 > + selfhost source (`lib/@vibe/compiler/`, `lib/@vibe/cli/`) via the Rust/node wasm runner
-> — **no MoonBit toolchain (`moon`) is required**. The default gate is the
-> moon-free `pkf run release-check` → `scripts/compiler_gate.sh`.
+> — **no MoonBit toolchain (`moon`) is required**. The default gate is
+> `pkf run release-check` → `scripts/compiler_gate.sh`.
 >
 > Sections below that reference `moon` (`moon fmt/test/check/info`) or `src/`
 > describe the **retired** host flow and are kept only for historical context;
@@ -27,7 +27,7 @@ vibe 言語の構文・機能を把握するには、最初に [docs/cheatsheet.
 
 ```bash
 pkf list                  # show all tasks
-pkf run                   # default: release-check (moon-free selfhost sign-off)
+pkf run                   # default: release-check (selfhost sign-off)
 pkf run test              # selfhost operation gate (commit 前の主チェック)
 pkf run test-local        # affected tests only (fast inner loop)
 pkf run full-gate         # complete selfhost operation gate

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -619,8 +619,7 @@ local adr = new Task {
 
 local doctest = new Task {
   name = "doctest"
-  description =
-    "compile-check ```vibe blocks in docs via the selfhost stage2 doctest harness"
+  description = "compile-check ```vibe blocks in docs via the selfhost stage2 doctest harness"
   cmd =
     "bash scripts/doctest_extract_run.sh docs/cheatsheet.md docs/vibe.md docs/language-tour/*.md"
   // stage2 resolution depends on _build/selfhost state (falls back to the

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -137,7 +137,7 @@ local testSelfhostCliSeam = scriptTask("test-cli-seam", "scripts/vibe_cli_smoke.
 local test = new Task {
   name = "test"
   // selfhost-only (#594): the MoonBit-host test suite (scripts/pkfire/test_suite.sh)
-  // was retired with src/. Run the moon-free selfhost-only gate as the test
+  // was retired with src/. Run the selfhost-only gate as the test
   // entry until selfhost unit-test running is ported (#594).
   cmd = "bash scripts/compiler_gate.sh"
   cache = false
@@ -620,7 +620,7 @@ local adr = new Task {
 local doctest = new Task {
   name = "doctest"
   description =
-    "compile-check ```vibe blocks in docs via the selfhost stage2 (moon-free doctest harness)"
+    "compile-check ```vibe blocks in docs via the selfhost stage2 doctest harness"
   cmd =
     "bash scripts/doctest_extract_run.sh docs/cheatsheet.md docs/vibe.md docs/language-tour/*.md"
   // stage2 resolution depends on _build/selfhost state (falls back to the
@@ -630,9 +630,9 @@ local doctest = new Task {
 
 local releaseSelfhostGates = new Task {
   name = "release-gates"
-  description = "pre-release selfhost sign-off (moon-free)"
+  description = "pre-release selfhost sign-off"
   // selfhost-only (#594): the component/preview2/parity/cutover gates compared
-  // against the MoonBit host (retired with src/). The canonical moon-free gate
+  // against the MoonBit host (retired with src/). The canonical gate
   // is scripts/compiler_gate.sh.
   cmd = "bash scripts/compiler_gate.sh"
   cache = false
@@ -649,7 +649,7 @@ local selfhostOnlyGate = scriptTask("compiler-gate", "scripts/compiler_gate.sh")
 local releaseCheck = new Task {
   name = "release-check"
   description =
-    "selfhost-only moon-free sign-off: bundle/module-source sync + seed->stage1->stage2->stage3 fixpoint + compile/run validation"
+    "selfhost-only sign-off: bundle/module-source sync + seed->stage1->stage2->stage3 fixpoint + compile/run validation"
   deps {
     selfhostOnlyGate
     // NOTE: `doctest` (docs ```vibe compile check) is intentionally NOT yet a

--- a/docs/operation-gate.md
+++ b/docs/operation-gate.md
@@ -70,7 +70,7 @@ pkf run full-gate
 
 - `generation-gate`: fixed seed -> stage1 -> stage2 -> stage3
 - `post-generation-gate` (`scripts/gate.sh --post-generation` -> `trial_gate.sh`):
-  moon-free selfhost sign-off一式
+  selfhost sign-off一式
 
 旧 host 比較系 (`test-selfhost-corpus-gate` / `perf-kpi` / `rss-kpi` /
 component parity) は MoonBit host 退役 (#594) でスクリプトごと退役済み。
@@ -83,7 +83,7 @@ stage generation は gate の先頭で固定している。post-generation 系�
 短い調査ループでは、必要な部分だけを単独で走らせてよい。
 
 ```bash
-pkf run release-gates   # = scripts/compiler_gate.sh (moon-free)
+pkf run release-gates   # = scripts/compiler_gate.sh
 pkf run generation-gate
 ```
 

--- a/docs/pkfire-pkspec.md
+++ b/docs/pkfire-pkspec.md
@@ -52,7 +52,7 @@ Highlights (post-#594 selfhost-only):
 | `test`         | `bash scripts/compiler_gate.sh`| selfhost operation gate — commit 前の主チェック |
 | `test-local`   | affected tests via `flaker`        | fast inner loop                      |
 | `run`          | `bash scripts/vibe_run.sh $@`      | `acceptsArgs` — pass via `--`        |
-| `release-check`| `deps { compiler-gate }`           | moon-free sign-off: bundle/module-source sync + seed→stage1→stage2→stage3 fixpoint + compile/run validation |
+| `release-check`| `deps { compiler-gate }`           | sign-off: bundle/module-source sync + seed→stage1→stage2→stage3 fixpoint + compile/run validation |
 | `info` / `check` / `test-update` | legacy `moon …`  | MoonBit host 依存で #594 以降は無効。検証は `test` / `release-check` / `vibe diagnostics` を使う |
 
 Two helper factories keep the file readable:

--- a/flaker.toml
+++ b/flaker.toml
@@ -24,7 +24,7 @@ list = "node scripts/flaker_vibe_runner.mjs list"
 [affected]
 # Path/directory-based (git diff vs origin/main merge-base): a changed file
 # selects the *_test.vibe suites living in/under its directory. Coarse but
-# moon-free; an import-graph resolver is future work (#988).
+# simple; an import-graph resolver is future work (#988).
 resolver = "simple"
 config = ""
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,7 +29,7 @@ The selfhost `vibe` subcommands as scripts (used by `pkf run` + tests).
 - `run_check_*_component.sh` / `run_cli_preview2_component.sh`
 
 ## Selfhost build / bootstrap
-- `compiler_gate.sh` — **moon-free sign-off** (seed→stage1→stage2→stage3
+- `compiler_gate.sh` — **sign-off** (seed→stage1→stage2→stage3
   fixpoint + compile/run validation); `pkf run test` / `release-check`
 - `gate.sh` / `trial_gate.sh` — operation gates
 - `generations.sh` (+ `_test`) — stage build driver

--- a/scripts/build_cli_wasm.sh
+++ b/scripts/build_cli_wasm.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Build a fresh selfhost CLI compiler wasm from the current committed source,
-# moon-free (seed -> stage1 -> stage2 via the Rust/node runner). The resulting
+# Build a fresh selfhost CLI compiler wasm from the current committed source
+# (seed -> stage1 -> stage2 via the Rust/node runner). The resulting
 # stage2 wasm is the portable `vibe-cli.wasm` the installer ships and the runner
 # AOT-compiles to a host-specific `.cwasm` (docs/release-roadmap.md テーマ1).
 #

--- a/scripts/build_selfhost_cli_core.sh
+++ b/scripts/build_selfhost_cli_core.sh
@@ -8,8 +8,8 @@
 # Historically this script used an already-built *host* `vibe` compiler
 # (MoonBit `moon run ... src/cmd/vibe -- compile ...`, or a native `VIBE_BIN`)
 # to compile an entry `.vibe` file into the selfhost CLI's "core" wasm. With
-# src/ gone there is no host compiler left; the moon-free equivalent is to use
-# an already-built *selfhost* compiler wasm (produced moon-free via the
+# src/ gone there is no host compiler left; the equivalent is to use
+# an already-built *selfhost* compiler wasm (produced via the
 # bootstrap seed -> stage1 -> stage2 pipeline, scripts/generations.sh --
 # the same machinery scripts/build_cli_wasm.sh uses for dist/cli/vibe-cli.wasm)
 # to compile the entry file instead.
@@ -125,7 +125,7 @@ fi
 
 mkdir -p "$(dirname "$STAGE1_CORE_WASM")"
 
-# Base compiler: an already-built moon-free selfhost compiler wasm, used to
+# Base compiler: an already-built selfhost compiler wasm, used to
 # compile ENTRY_PATH. HOST_MODE is accepted (and validated) for interface
 # compatibility with the retired moon-host script, but there is no separate
 # debug/release selfhost compiler build to pick between -- both modes build

--- a/scripts/check_module_source_sync.sh
+++ b/scripts/check_module_source_sync.sh
@@ -3,7 +3,7 @@
 # current compiler source (#594 Stage 1, moonbit-retirement).
 #
 # emit-module-source is a deterministic function of the committed compiler
-# source. The default (moon-free) build consumes the committed prebuilt
+# source. The default build consumes the committed prebuilt
 # lib/@vibe/compiler/cli_adapter_module_source.vibe instead of calling
 # the MoonBit host. This gate regenerates it through the host compiler
 # (VIBE_REGEN_MODULE_SOURCE=1) and fails on drift, so a stale
@@ -24,7 +24,7 @@ if [ ! -f "$EXPECTED" ]; then
   exit 1
 fi
 
-# Prefer the selfhost seed compiler (moon-free) to regenerate; the seed carries
+# Prefer the selfhost seed compiler to regenerate; the seed carries
 # emit-module-source. Fall back to the MoonBit host only if the seed is absent.
 # If neither is available, the freshness check cannot run and is skipped.
 have_emit=0

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4,7 +4,7 @@
 # committed selfhost compiler source/bundles. Verifies:
 #   1. committed bundles are in sync with the compiler source,
 #   2. the committed flat module source is in sync (regenerated via the seed),
-#   3. the selfhost compiler self-reproduces moon-free (seed -> stage1 -> stage2
+#   3. the selfhost compiler self-reproduces (seed -> stage1 -> stage2
 #      -> stage3) with stage2 == stage3 (fixpoint) and each stage validates a
 #      compiled sample (compile -> run smoke).
 set -euo pipefail
@@ -23,7 +23,7 @@ bash scripts/check_bundle_sync.sh
 echo "[compiler-gate] 2/3 module-source sync (via seed)"
 bash scripts/check_module_source_sync.sh
 
-echo "[compiler-gate] 3/3 moon-free selfbuild seed->stage1->stage2->stage3"
+echo "[compiler-gate] 3/3 selfbuild seed->stage1->stage2->stage3"
 bash scripts/generations.sh build --stage3
 
 # Assert the stage2==stage3 fixpoint from the freshest generation manifest.
@@ -1921,7 +1921,7 @@ echo "[compiler-gate] cross-import trait-iterator element-type regression ok"
 #     Covers the sync `lazy_iter` and async `async_iter` combinator libraries
 #     (take / drop / take_while / enumerate / zip / flat_map / find / any / all,
 #     and the async `for await`-driven terminals) — these prelude tests are not
-#     otherwise exercised by the moon-free gate.
+#     otherwise exercised by the gate.
 echo "[compiler-gate] 21/21 prelude iterator combinator suites"
 for suite in lib/@vibe/prelude/lazy_iter_test.vibe lib/@vibe/prelude/async_iter_test.vibe; do
   out="_build/_gate_prelude_iter_$(basename "${suite%.vibe}").wasm"
@@ -2050,7 +2050,7 @@ echo "[compiler-gate] generic trait impl (Increment B, dict-of-dict) ok"
 # 24. async-lifted component EXECUTION on wasmtime (docs/spec/wasi-p3-async.md
 #     §3.1). The async-lift codegen (`comp_emit_component_wasm_async*` — task.return
 #     canon + async functype + async lift) is byte-tested on node, but the emitted
-#     component had no moon-free EXECUTION check (the only runner was the retired
+#     component had no EXECUTION check (the only runner was the retired
 #     host `vibe.exe`). `fixtures/async_lift_run42.component.wasm` is a committed
 #     async component (its `run()` returns 42) emitted by the selfhost codegen;
 #     here wasmtime runs it with the async-stackful flags and we assert 42 — so

--- a/scripts/doctest_extract_run.sh
+++ b/scripts/doctest_extract_run.sh
@@ -2,7 +2,7 @@
 # doctest_extract_run.sh — executable-docs harness (0.3.0 roadmap: doctest / *.vibe.md).
 #
 # Extracts ```vibe fenced code blocks from one or more markdown files and
-# compiles each one with the selfhost stage2 compiler (moon-free). Reports a
+# compiles each one with the selfhost stage2 compiler. Reports a
 # per-block PASS/FAIL/SKIP line and exits 1 if any block fails, so docs code
 # examples cannot silently rot.
 #

--- a/scripts/generate_bundle.sh
+++ b/scripts/generate_bundle.sh
@@ -500,7 +500,7 @@ run_host_vibe_cmd() {
   local release_vibe="$SCRIPT_PROJECT_ROOT/_build/native/release/build/cmd/vibe/vibe.exe"
   local debug_vibe="$SCRIPT_PROJECT_ROOT/_build/native/debug/build/cmd/vibe/vibe.exe"
   if [ "$cmd" = "emit-module-source" ]; then
-    # #594 Stage 1b/seed-bump: prefer the selfhost seed compiler (moon-free).
+    # #594 Stage 1b/seed-bump: prefer the selfhost seed compiler.
     # The seed carries emit-module-source (VIBE_EMIT_MODULE_SOURCE mode), so the
     # flat module source needs no MoonBit host. Args are (input, output, entry),
     # rewritten to repo-root-relative for the wasm preopen. Force the legacy host

--- a/scripts/pkfire/gates_shard.sh
+++ b/scripts/pkfire/gates_shard.sh
@@ -27,7 +27,7 @@ case "$shard" in
     bash scripts/check_bundle_sync.sh
     bash scripts/check_module_source_sync.sh
     # Live replacement for the retired MoonBit-host bootstrap/selfbuild gates:
-    # the moon-free seed->stage1->stage2(->stage3 fixpoint) build is exactly
+    # the seed->stage1->stage2(->stage3 fixpoint) build is exactly
     # what those gates existed to protect.
     bash scripts/compiler_gate.sh
     ;;

--- a/scripts/trial_gate.sh
+++ b/scripts/trial_gate.sh
@@ -3,7 +3,7 @@
 # and perf/RSS-vs-host benches (test_selfhost_corpus_gate.sh,
 # bench_selfhost_perf.sh, bench_selfhost_rss.sh) plus the preview2/component
 # release gates — all comparisons against the MoonBit host, retired with src/.
-# The canonical moon-free gate is now scripts/compiler_gate.sh
+# The canonical gate is now scripts/compiler_gate.sh
 # (bundle/module-source sync + seed->stage1->stage2->stage3 fixpoint +
 # compile/run validation). Redirect here so existing entry points
 # (gate.sh, the `full-gate` task) keep working. The old `selfhost-trial-gate`

--- a/scripts/unit_test_runner.sh
+++ b/scripts/unit_test_runner.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Selfhost unit-test runner (#531 / #535).
 #
-# Compiles + runs every allowlisted `*_test.vibe` through the moon-free selfhost
+# Compiles + runs every allowlisted `*_test.vibe` through the selfhost
 # compiler. A file PASSES when it compiles (the compiler emits a `_start` that
 # runs the file's `test {}` blocks, selected via the `__no_entry__` entry) AND
 # that `_start` runs to completion (a failing `assert` traps the module).

--- a/scripts/vibe_cli.sh
+++ b/scripts/vibe_cli.sh
@@ -17,7 +17,7 @@
 # Absolute paths under the repo root are rewritten to repo-relative.
 #
 # The CLI wasm path can be supplied with VIBE_CLI_WASM (e.g. a
-# moon-free generation build); otherwise it is built by build_selfhost_cli_core.sh.
+# prebuilt generation build); otherwise it is built by build_selfhost_cli_core.sh.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary

First batch of #1000 ("命名債務の解消: moon-free / selfhost 用語の除去"), following the issue's own recommendation to start with the smallest, most contained slice: the CI gate names / log wording ("影響範囲が閉じている").

- Removed the now-redundant `moon-free` qualifier from CI (`.github/workflows/ci.yml`), `Taskfile.pkl` task descriptions/comments, `scripts/*.sh` comments and `echo` log lines, and operator-facing docs (`docs/operation-gate.md`, `docs/pkfire-pkspec.md`, `scripts/README.md`, `AGENTS.md`/`CLAUDE.md`).
- selfhost-only has been the default build/gate mode since #594; calling it out as "moon-free" on top of that no longer conveys information — it was meaningful only during the MoonBit-retirement transition.
- Left dated/archival records untouched since they describe the historical migration itself, not current terminology: `docs/archive/moonbit-retirement.md`, `docs/archive/report/profile-selfhost-compile-memory-2026-07-12.md`, `docs/doctest-report-2026-07-12.md`.
- Text-only change (comments, log strings, doc prose) — no compiler source or script logic touched.

Remaining `#1000` scope (not attempted here, tracked on the issue): the much larger `selfhost` naming cleanup (170 non-`.vibe` files + 106 `.vibe` files), `bench/selfhost_*` directory renames, and the seed-binary → GitHub Release Artifacts migration.

## Test plan
- [x] `bash -n` syntax check on all modified `.sh` files
- [x] Full `bash scripts/compiler_gate.sh` run — 44/44 checks passed, exit 0
- [x] Confirmed no remaining `moon-free` occurrences outside the 3 intentionally-untouched archival/dated docs


---
_Generated by [Claude Code](https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H)_