### PR TITLE
#1031: fix stale top-level destructure assertions in checker_parity_advanced_test

### DIFF
--- a/lib/@vibe/compiler/tests/checker_parity_advanced_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_parity_advanced_test.vibe
@@ -109,7 +109,11 @@ test "parity err: xor type mismatch" {
 }
 
 test "parity: let destructure tuple" {
-  assert(check_source_ok("let (a, b, c) = (1, 2, 3)\nlet _adr69 = () -> { a + b + c }"))
+  assert(check_source_ok("let _adr69 = () -> { let (a, b, c) = (1, 2, 3)\na + b + c }"))
+}
+
+test "parity err: top-level let destructure tuple rejected (#859)" {
+  assert(check_source_err("let (a, b, c) = (1, 2, 3)\nlet _adr69 = () -> { a + b + c }"))
 }
 
 test "parity: double arithmetic" {
@@ -133,7 +137,7 @@ test "parity: closure mut capture" {
 }
 
 test "parity: generic pair" {
-  assert(check_source_ok("let pair: [A, B](A, B) -> (A, B) = (a, b) -> { (a, b) }\nlet (x, y) = pair(1, \"hello\")\nlet _adr69 = () -> { x }"))
+  assert(check_source_ok("let pair: [A, B](A, B) -> (A, B) = (a, b) -> { (a, b) }\nlet _adr69 = () -> { let (x, y) = pair(1, \"hello\")\nx }"))
 }
 
 test "parity: nested handle" {
@@ -159,7 +163,7 @@ test "parity: string char_code_at" {
 // --- recently added features ---
 
 test "parity: struct destructuring let" {
-  assert(check_source_ok("struct Vec2 { x: Int; y: Int }\nlet p = Vec2::{ x: 3, y: 4 }\nlet Vec2::{ x, y } = p\nlet _adr69 = () -> { x + y }"))
+  assert(check_source_ok("struct Vec2 { x: Int; y: Int }\nlet p = Vec2::{ x: 3, y: 4 }\nlet _adr69 = () -> { let Vec2::{ x, y } = p\nx + y }"))
 }
 
 test "parity: derive(Eq) struct" {


### PR DESCRIPTION
## Summary

- `checker_parity_advanced_test.vibe`'s `"parity: let destructure tuple"`, `"parity: generic pair"`, and `"parity: struct destructuring let"` tests asserted that top-level tuple/struct-destructuring `let` type-checks successfully.
- That's no longer true (and hasn't been since #859/ADR-0069): `check_program` intentionally rejects top-level destructuring `let` with a clear diagnostic ("move it into a function body"), since only block-scoped destructuring is soundly supported. These three tests predate that restriction.
- Because `check_source_ok` swallows the thrown `Error` into a bare `false`, and the test then does `assert(false)`, the failure surfaced as an opaque `RuntimeError: unreachable` wasm trap rather than a normal assertion message — which is what #1031 reported as a "trap".
- Fix: rewrote each test to destructure inside a closure body (the form the language actually supports), preserving the original test intent (verifying destructure-pattern type inference), and added a dedicated test pinning the top-level-rejection behavior itself via `check_source_err`.

Verified with `bash scripts/vibe_test.sh lib/@vibe/compiler/tests/checker_parity_advanced_test.vibe` — all 53 tests pass (was failing before this fix, one test at a time, since `_start` traps and stops at the first failure — three separate stale tests were masking each other).

## Note on #1027

While investigating, confirmed #1027 ("collect_all_sources_fs undercounts vpkg-ified internal directories") was already fixed by #1033 (commit `b7f5c8e7`) — the manifest-header walker's version-directive gap. `module_loader_collect_sources_test.vibe` passes cleanly on current `main`. No code change needed there; closing the issue separately.

## Test plan

- [x] `bash scripts/vibe_test.sh lib/@vibe/compiler/tests/checker_parity_advanced_test.vibe` — 53/53 pass
- [x] `bash scripts/vibe_test.sh lib/@vibe/compiler/tests/module_loader_collect_sources_test.vibe` — 6/6 pass (confirms #1027 fix still holds)


---
_Generated by [Claude Code](https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H)_