### PR TITLE
Perceus: elide dead-alias dup/drop; binary-size bench; almide survey (#1056)

### DIFF
--- a/docs/pl-survey-2026-07.md
+++ b/docs/pl-survey-2026-07.md
@@ -23,7 +23,11 @@
    キャッシュ、capability effect、where 契約 Phase 1) は世界的にも先行。
    差分価値が最大なのは **FBIP 系の未取り込み後半 (drop-guided reuse /
    TRMC)** と **Effekt の 2025 年成果 (one-shot 定数時間 resume /
-   dynamic-wind)**。
+   dynamic-wind)**。ただし Perceus 実装の**成熟度**では Rust 製の類似言語
+   almide (LLM 向け関数型言語、wasm+native dual target) が一歩先を行く
+   — alias 解析による rc チェック除去や翻訳検証・形式証明まで踏み込んで
+   おり (下記サーベイ表)、vibe の rc-port.md Phase 3 完了後の次の一手の
+   参考になる。
 4. 並行モデルは **nursery = Spawn capability handler**、typed channel、
    task-local heap/evidence を核にする。message は deep-copy snapshot を基準とし、
    Perceus の uniqueness は last-use と transitive arena ownership を証明できる場合の
@@ -54,6 +58,8 @@
 | Rust merged doctests / Unison | Rust 2024 edition | doctest は最初から統合コンパイル + content-addressed キャッシュで |
 | Koka FP² / TRMC | ICFP 2023, POPL 2023 | Perceus の先: drop-guided reuse、fip/fbip 保証、cons 再帰のループ化 |
 | Ante (ownership × effects) | antelang.org 2025-05 | 継続が捕捉した線形資源の所有権問題 — 継続導入時に踏む課題の整理 |
+| almide (LLM 向け関数型言語、Rust 実装) | github.com/almide/almide crates/ 2026-07 | Perceus 実装の一般化で先行: `almide-mir/src/alias_safety.rs` が関数ローカル fixpoint dataflow で証明可能 unaliased な値への `MakeUnique` (rc>1 COW チェック) を除去する最適化パスを持つ。vibe は dup/drop 挿入止まり (rc-port.md Phase 3) でこの段階に未到達。さらに `translation_validation.rs` / `certificate.rs` + 別ワークスペース `almide-perceus-belt` (RC 規律の Lean 形式証明) で正しさを担保しており、vibe の unit test (`perceus_rc_test.vibe` 14 件) より検証が重い |
+| almide ベンチマーク手法 | github.com/almide/almide docs/BENCHMARKS.md | Hello World / FizzBuzz / 再帰 Fibonacci / Closure+call_indirect / Variant(match+float) の5本を「as shipped」と `wasm-opt -Oz` 後の両方でサイズ計測し継続運用。vibe は ADR-0038 に一回限りの5ベンチ表 (int_literal 等) はあるが継続計測ドキュメントがない。almide の5本は closure+indirect call・pattern match+float という vibe が手薄なコード生成経路を突いており、バイナリサイズ回帰ベンチとして流用価値が高い。加えて `almide-dojo` の Modification Survival Rate (AI 改変後もコンパイル・テストが通り続ける率) は vibe の「エージェント向け構造化診断」施策 (下記 High priority #4) の効果測定指標として転用できる |
 
 ## 取り込み提案 (優先順)
 
@@ -84,12 +90,21 @@
    resource effect × 非局所脱出の資源解放規則。継続/cancel 導入の前提。
 7. **drop-guided reuse + TRMC** (Koka FP²) — Perceus backend の次の一手。
    コンパイラ自身のビルドが最大の受益者 (AST 再構築ホットパス)。
+8. **wasm バイナリサイズ回帰ベンチ** (almide `docs/BENCHMARKS.md` 方式) —
+   cost: small。Hello World / FizzBuzz / 再帰 Fibonacci / Closure+call_indirect
+   / Variant(match+float) の5本を `wasm-opt -Oz` 前後で継続計測する
+   `docs/BENCHMARKS.md` を新設。ADR-0038 の一回限り計測を定常運用に格上げし、
+   closure・pattern match 系の回帰を捕捉する。
+9. **rc チェック除去の fixpoint 最適化** (almide `alias_safety.rs` 方式) —
+   cost: medium、rc-port.md Phase 3 (drop codegen) 完了後の前提あり。
+   関数ローカルな dataflow で証明可能 unaliased な値への rc>1 (MakeUnique
+   相当) チェックを除去し、ホットループの不要な refcount 分岐を削る。
 
 ### Low priority
 
-8. **Flux 流 refinement (where 契約 Phase 3)** — 決定可能述語に制限した
-   二層 SMT。GA ブロッカーではない。vibe は述語純粋性を effect row で
-   機械判定できるため導入条件は既に揃っている。
+10. **Flux 流 refinement (where 契約 Phase 3)** — 決定可能述語に制限した
+    二層 SMT。GA ブロッカーではない。vibe は述語純粋性を effect row で
+    機械判定できるため導入条件は既に揃っている。
 
 ## 参照
 
@@ -99,3 +114,6 @@
 - [WebAssembly proposal registry](https://github.com/WebAssembly/proposals)
 - [WebKit: JSPI in Safari 27 beta](https://webkit.org/blog/17967/news-from-wwdc26-webkit-in-safari-27-beta/)
 - [Mozilla JSPI tracking bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1897981)
+- almide crates (Perceus RC 一般化・ベンチマーク手法の参照点、2026-07-22 調査):
+  [crates/almide-mir](https://github.com/almide/almide/tree/develop/crates/almide-mir)、
+  [docs/BENCHMARKS.md](https://github.com/almide/almide/blob/develop/docs/BENCHMARKS.md)


### PR DESCRIPTION
## Summary
- almide (github.com/almide/almide, `crates/`) を調査し、`docs/pl-survey-2026-07.md` に追記した（Perceus RC 実装比較・ベンチマーク手法比較）
- 追記から issue #1056 を起票し、その Phase B / Phase C を実装した:
  - **Phase B (rc-check elision)**: `lib/@vibe/compiler/perceus/perceus.vibe` の `build_perceus_plan` に、未使用エイリアス (`let a = t` で `a` が一度も参照されない) の dup+drop 相殺ペアを除去する occurrence-local な最適化を追加。alias の dup とそのエイリアス自身の無条件 scope-end drop は「同じメモリへの、間に読み取りのない inc→dec」で恒等的に no-op になることを、既存の per-binding-id ブックキーピング (`uses`/`remaining`) だけで証明できる範囲に絞って実装（almide `alias_safety.rs` の狭い occurrence-local な部分集合）。vibe の RC には almide の `MakeUnique`（COW ガード）相当がまだ無いため、フルの fixpoint 版は別途の下部構造が要る。
  - **Phase C (binary-size regression bench)**: `bench/binary_size/`（5 プログラム: hello_world / fizzbuzz / fib / closure_indirect / variant_float）+ `scripts/bench_binary_size.sh` + `docs/BENCHMARKS.md`。RC on/off の as-shipped サイズを継続計測（`wasm-opt -Oz` は利用可能な場合のみ、ベストエフォート）。
- issue #1056 クローズ後、続けて almide のもう一つの評価手法を導入 (別セッション):
  - **`eval/msr/`** — Modification Survival Rate ハーネス (almide-dojo 比較)。basic/intermediate/advanced 3レベル・8タスク (初期実装仕様 + 追加変更仕様のペア)、`run_msr.sh` で `scripts/vibe_test.sh` ベースに機械判定・MSR% 集計。モックの pass/fail ペアで動作検証済み。
  - **`eval/lang-bench/`** — 同一モデル・同一プロンプトでの多言語比較ベンチ (almide "minigit" 比較)。ハッシュ計算不要の縮小版 "mini-vcs" CLI 仕様 (`SPEC.md`) + 言語非依存の受け入れテストドライバ (`acceptance_test.sh`、12チェック) + vibe/rust/typescript のビルド手順 (gleam/moonbit はこのサンドボックスにツールチェインが無い旨を明記)。モック実装で12/12 pass 確認済み。
  - どちらもハーネスのみ (実ラウンド未実施、`scores/`/`results/` は空)。`docs/pl-survey-2026-07.md` に導入状況を追記。
- `docs/spec/rc-port.md`（Phase 3.5 として記録）を更新。

## Verification (Phase B)
コンパイラ自身の RC 挿入ロジックが変わるため、シードではなく変更込みの stage1/stage2 をビルドして検証した:
- `perceus_rc_test.vibe` 21/21（新規2件含む）、`codegen_heap_e2e_test.vibe` 130/130
- `scripts/generations.sh build --stage3`: stage2==stage3 fixpoint 維持
- `scripts/verify_rc.sh`: コンパイラ自身を RC でセルフコンパイルした結果が byte-identical
- `fixtures/rc_*_test.vibe` 全9ファイル20テスト、`rc_shadow_regression_test.vibe`（#715 shapes）、RC reclamation leak guard（heap_used=424B）— いずれも green

計測インパクトは現状のベンチ5本・コンパイラ自身のソースいずれにも対象パターンが無く 0（`docs/BENCHMARKS.md` に正直に記載）。将来の機械生成コード（derive 生成アクセサ等）向けの zero-cost セーフティネットとして残す判断。

副産物: almide の "variant + float" ベンチ相当のプログラムを書く過程で、`Double` payload の enum + match が bump backend で `memory access out of bounds` を起こす既存バグを発見し、#1062 として別途起票済み（この PR のスコープ外）。

## Test plan
- [x] `perceus_rc_test.vibe`（新規回帰テスト2件含む）
- [x] `codegen_heap_e2e_test.vibe`
- [x] selfhost stage2==stage3 fixpoint
- [x] `scripts/verify_rc.sh`（RC セルフコンパイル byte-identical）
- [x] `fixtures/rc_*_test.vibe` 全件 + shadow-liveness + reclaim-leak gate
- [x] `scripts/check_bundle_sync.sh` / `scripts/check_module_source_sync.sh`
- [x] `bash scripts/bench_binary_size.sh` で新規ベンチ5本の compile+run 確認
- [x] `eval/msr/run_msr.sh` をモックの pass/fail ペアで動作確認
- [x] `eval/lang-bench/acceptance_test.sh` をモック実装で12/12 pass確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BXLigdgi5CSrdUPqdaa39
