### PR TITLE
bootstrap bump: adopt seed/export-scope-paths-2026-07-23

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "map-from-pairs-2026-07-20",
-    "tag": "seed/map-from-pairs-2026-07-20",
-    "source_commit": "c2328238",
+    "name": "export-scope-paths-2026-07-23",
+    "tag": "seed/export-scope-paths-2026-07-23",
+    "source_commit": "fbad2d91",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "c3a32ce372770b5eb2db1d5d734269ab334d5c8bf91c3cf7d7e2d17dfe88a092"
+      "sha256": "5d2b48d47a8506319865546a56024b299093f24b63b756ea5fb6b00c7a920df2"
     },
     "runtime": {
       "runner": "moonrun",


### PR DESCRIPTION
## Summary

Adopts the stage2 candidate built from `main@6fc4495f` merged with `fbad2d91` (parser: accept `@scope/name` paths in export/re-export statements) as the new pinned bootstrap seed.

- `bootstrap/seed.json`: `map-from-pairs-2026-07-20` (`c2328238`) → `export-scope-paths-2026-07-23` (`fbad2d91`)
- stage2 == stage3 byte-identical: `5d2b48d47a8506319865546a56024b299093f24b63b756ea5fb6b00c7a920df2`
- `scripts/compiler_gate.sh` (`pkf run full-gate` / `release-gates`) green: builtin parity, bundle sync, module-source sync, seed→stage1→stage2→stage3 fixpoint, and the full 45-suite regression gate all pass.

This unblocks migrating the compiler's own boundary-crossing relative re-exports (`export ../pkg { ... }`) to the qualified `@scope/name` spelling and flipping `enforce_relative_import_package_boundary_fs` (`lib/@vibe/compiler/loader/header_cache.vibe`) to also cover `export`, per `docs/bootstrap.md`'s "新機能の入れ方" bootstrap discipline — the seed must understand a new grammar before compiler source can use it.

## Test plan

- [x] `scripts/generations.sh build --stage3` on `main` merged with `fbad2d91`: stage0→stage1→stage2→stage3, `stage2_distribution_candidate: true`, `stage3_equal_stage2: true`
- [x] `bash scripts/compiler_gate.sh` full green (`[compiler-gate] ok`)
- [ ] CI green on this PR

Note: `docs/bootstrap.md`'s older "Gate" section additionally lists perf-KPI-vs-host, RSS-vs-host, corpus-parity-vs-host, and dist/stage2-vs-MoonBit-host-build parity checks. Those compared against the MoonBit `src/` host build, which was fully retired in #594/#1000 — the scripts and comparison targets no longer exist in this selfhost-only tree (confirmed via `docs/operation-gate.md`, the newer authoritative doc, which explicitly states these were retired with their Taskfile tasks removed). The current live gate is `pkf run full-gate` / `release-gates` (`scripts/compiler_gate.sh`), run above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H

---
_Generated by [Claude Code](https://claude.ai/code/session_019tXS9Nb2wA5YErMjibod1H)_