### PR TITLE
Continuous perf tracking: per-PR sticky report + main history (bench-data branch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,10 @@ jobs:
           VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
             bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
       - name: Selfhost suite coverage gate (#535)
+        # Relative path: coverage_suite.sh historically rebased $cli onto the
+        # repo root (it now tolerates absolute paths too, but stay canonical).
         run: |
-          VIBE_SUITE_CLI_WASM="$PWD/_build/_ci_shard_gen/stage2.wasm" \
+          VIBE_SUITE_CLI_WASM="_build/_ci_shard_gen/stage2.wasm" \
             bash scripts/coverage_suite.sh
       - name: Upload compiler suite coverage report
         if: always()

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,134 @@
+name: perf
+
+# Continuous performance tracking (bench/perf/README.md "Continuous perf
+# tracking" section):
+#   - every PR gets a sticky "📊 Perf report" comment comparing its metrics
+#     against the latest main baseline (updated in place on new pushes),
+#   - every main push appends a snapshot to the `bench-data` branch
+#     (data/main.jsonl + latest.json), which is what PRs baseline against.
+#
+# Metrics come from scripts/bench_metrics.sh: deterministic allocation/size
+# numbers (selfcompile heap, stage2/bundle/sample-wasm sizes, bytes/op of the
+# tracked `bench {}` series) plus advisory wall times. This workflow never
+# blocks merges — the blocking allocation gate stays in ci.yml (KPI heap step).
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  perf-metrics:
+    name: perf-metrics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Cache stage2 (keyed on seed + flat module source)
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v1-${{ hashFiles('bootstrap/seed.json', 'lib/@vibe/compiler/_cli_adapter_module_source.vibe', 'scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Build stage2 from committed flat module source
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
+            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Cache vibewt build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            runtime/vibewt/target
+          key: vibewt-v1-${{ hashFiles('runtime/vibewt/Cargo.lock', 'runtime/vibewt/Cargo.toml', 'runtime/vibewt/src/**') }}
+          restore-keys: vibewt-v1-
+      - name: Build vibewt (micro-bench runtime)
+        run: cargo build --release --manifest-path runtime/vibewt/Cargo.toml
+      - name: Collect metrics
+        run: |
+          bash scripts/bench_metrics.sh _build/_ci_shard_gen/stage2.wasm _build/bench_metrics.json
+          cat _build/bench_metrics.json
+      - name: Fetch baseline from bench-data branch
+        run: |
+          if git fetch --depth 1 origin bench-data 2>/dev/null; then
+            git show FETCH_HEAD:latest.json > _build/bench_baseline.json 2>/dev/null || true
+          fi
+          ls -la _build/bench_baseline.json 2>/dev/null || echo "no baseline yet"
+      - name: Render report
+        run: |
+          node scripts/bench_report.mjs _build/bench_metrics.json _build/bench_baseline.json \
+            > _build/bench_report.md
+          cat _build/bench_report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upsert PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('_build/bench_report.md', 'utf8');
+            const marker = '<!-- vibe-perf-report -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 });
+            const mine = comments.find(c => c.body && c.body.includes(marker));
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+      - name: Append snapshot to bench-data branch (main only)
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Retry loop: concurrent main pushes race on the data branch; the
+          # payload is append-only so refetch + reapply + push is always safe.
+          for attempt in 1 2 3; do
+            rm -rf _build/bench-data
+            if git fetch --depth 1 origin bench-data 2>/dev/null; then
+              git worktree add _build/bench-data FETCH_HEAD
+            else
+              git worktree add --detach _build/bench-data
+              (cd _build/bench-data && git checkout --orphan bench-data && git rm -rf --quiet . || true)
+            fi
+            mkdir -p _build/bench-data/data
+            cat _build/bench_metrics.json | tr -d '\n' >> _build/bench-data/data/main.jsonl
+            echo >> _build/bench-data/data/main.jsonl
+            cp _build/bench_metrics.json _build/bench-data/latest.json
+            (
+              cd _build/bench-data
+              git add -A
+              git commit -m "perf: snapshot ${GITHUB_SHA::9}"
+            )
+            if git -C _build/bench-data push origin HEAD:refs/heads/bench-data; then
+              break
+            fi
+            git worktree remove --force _build/bench-data || true
+            [ "$attempt" -lt 3 ] || { echo "::error::failed to push bench-data after 3 attempts"; exit 1; }
+            sleep $((attempt * 3))
+          done
+          git worktree remove --force _build/bench-data || true
+      - name: Upload metrics artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-metrics
+          path: |
+            _build/bench_metrics.json
+            _build/bench_report.md

--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -33,6 +33,45 @@ bash scripts/selfcompile_kpi.sh /tmp/kpi_gen/stage2.wasm
 Commit the new number with the compiler change and note old -> new (and
 why) in the PR.
 
+## Continuous perf tracking (per-PR report + main history)
+
+`.github/workflows/perf.yml` runs on every PR and every main push
+(non-blocking — the blocking allocation gate stays in ci.yml's KPI step):
+
+- `scripts/bench_metrics.sh <stage2.wasm> [out.json]` collects one snapshot:
+  - **deterministic**: selfcompile `heap_ptr_bytes` (cold cache), stage2 /
+    committed-bundle / flat-module-source byte sizes, compiled wasm size of
+    every `bench/binary_size/` sample, and `bytes_per_op` of every `bench {}`
+    block listed in [`tracked_benches.txt`](tracked_benches.txt),
+  - **advisory** (wall time, noisy on shared runners): selfcompile `wall_ms`
+    (median of 3) and `ns_p50` per tracked bench.
+- `scripts/bench_report.mjs current.json [baseline.json]` renders the
+  markdown comparison — deterministic rows flag at ±2%, advisory rows only
+  at ±15%.
+- **Per-PR**: the workflow upserts a sticky "📊 Perf report" comment on the
+  PR (marker `<!-- vibe-perf-report -->`), comparing against the latest
+  main snapshot. Pushing new commits updates the same comment.
+- **History**: every main push appends the snapshot to the `bench-data`
+  branch (`data/main.jsonl`, one JSON object per line, plus `latest.json` =
+  the PR baseline). Plot or diff over time straight from that branch:
+
+  ```bash
+  git fetch origin bench-data
+  git show origin/bench-data:data/main.jsonl | tail -20 \
+    | node -e 'process.stdin.on("data",()=>{}); ...'   # or jq
+  ```
+
+To track a new micro bench, add its file to `tracked_benches.txt` (keep the
+whole list fast — it runs on every PR). To track a new size sample, drop a
+standalone `main`-entry program into `bench/binary_size/`. Run locally:
+
+```bash
+bash scripts/generations.sh build --out-dir /tmp/gen
+cargo build --release --manifest-path runtime/vibewt/Cargo.toml  # micro benches
+bash scripts/bench_metrics.sh /tmp/gen/stage2.wasm /tmp/m.json
+node scripts/bench_report.mjs /tmp/m.json            # vs no baseline
+```
+
 ## Micro: vibe bench probes
 
 Files:

--- a/bench/perf/tracked_benches.txt
+++ b/bench/perf/tracked_benches.txt
@@ -1,0 +1,10 @@
+# Micro benches tracked by the continuous perf pipeline
+# (scripts/bench_metrics.sh -> .github/workflows/perf.yml).
+# One path per line; every `bench {}` block in each file becomes a tracked
+# series keyed "<basename>::<label>". bytes_per_op is deterministic (linear
+# backend bump allocator) and flagged tightly; ns_p50 is advisory (CI runner
+# wall time is noisy).
+# Keep this list SMALL and fast (< ~30s total) — it runs on every PR.
+bench/regression/pure_bench.vibe
+bench/regression/alloc_bench.vibe
+lib/@vibe/compiler/parser_bench.vibe

--- a/scripts/bench_metrics.sh
+++ b/scripts/bench_metrics.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Collect the per-commit performance metrics snapshot the continuous perf
+# pipeline tracks (.github/workflows/perf.yml, bench/perf/README.md).
+#
+#   scripts/bench_metrics.sh <stage2.wasm> [out.json]
+#
+# Metric classes:
+#   DETERMINISTIC (byte-stable for a fixed commit -> tight regression flags):
+#     - selfcompile heap_ptr_bytes (scripts/selfcompile_kpi.sh, cold cache)
+#     - stage2.wasm size + committed bundle/module-source sizes
+#     - compiled wasm size of each bench/binary_size sample
+#     - bytes_per_op of every tracked `bench {}` block (bump-alloc delta)
+#   ADVISORY (wall time; machine/load dependent -> loose flags, never gate):
+#     - selfcompile wall_ms (median of VIBE_BENCH_KPI_RUNS, default 3)
+#     - ns_p50 of every tracked bench block
+#
+# Micro benches need the vibewt runtime; they are skipped (with a note in the
+# JSON) unless VIBE_RUNNER points at a vibewt binary or
+# runtime/vibewt/target/release/vibewt exists.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+STAGE2="${1:-}"
+OUT_JSON="${2:-_build/bench_metrics.json}"
+[ -n "$STAGE2" ] && [ -s "$STAGE2" ] || { echo "usage: scripts/bench_metrics.sh <stage2.wasm> [out.json]" >&2; exit 2; }
+mkdir -p "$(dirname "$OUT_JSON")"
+
+KPI_RUNS="${VIBE_BENCH_KPI_RUNS:-3}"
+BENCH_ITERS="${VIBE_BENCH_ITERS:-100}"
+TRACKED="${VIBE_TRACKED_BENCHES:-bench/perf/tracked_benches.txt}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# --- selfcompile KPI: heap (deterministic) + wall (median of N) ---------------
+heap=""
+walls=()
+for i in $(seq 1 "$KPI_RUNS"); do
+  line="$(bash scripts/selfcompile_kpi.sh "$STAGE2" | grep '\[selfcompile-kpi\]' | tail -1)"
+  h="$(sed -n 's/.*heap_ptr_bytes=\([0-9][0-9]*\).*/\1/p' <<<"$line")"
+  w="$(sed -n 's/.*wall_ms=\([0-9][0-9]*\).*/\1/p' <<<"$line")"
+  [ -n "$h" ] && [ -n "$w" ] || { echo "[bench-metrics] KPI run $i produced no metrics" >&2; exit 1; }
+  if [ -n "$heap" ] && [ "$heap" != "$h" ]; then
+    echo "[bench-metrics] WARN: heap_ptr_bytes not stable across runs ($heap vs $h)" >&2
+  fi
+  heap="$h"
+  walls+=("$w")
+done
+wall_median="$(printf '%s\n' "${walls[@]}" | sort -n | awk '{a[NR]=$1} END {print a[int((NR+1)/2)]}')"
+echo "[bench-metrics] selfcompile heap_ptr_bytes=$heap wall_ms_median=$wall_median (runs: ${walls[*]})"
+
+# --- sizes (deterministic) ----------------------------------------------------
+stage2_bytes="$(wc -c < "$STAGE2")"
+adapter_bundle_bytes="$(wc -c < lib/@vibe/compiler/cli_adapter_bundle.vibe)"
+sources_bundle_bytes="$(wc -c < lib/@vibe/compiler/compiler_sources_bundle.vibe)"
+module_source_bytes="$(wc -c < lib/@vibe/compiler/_cli_adapter_module_source.vibe)"
+
+# compiled wasm size of each binary_size sample (release-shape compile)
+samples_tsv="$work/samples.tsv"; : > "$samples_tsv"
+for src in bench/binary_size/*.vibe; do
+  name="$(basename "$src" .vibe)"
+  out="$work/$name.wasm"
+  rm -f "$out" "$out.diag"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" \
+    "$src" "$out" main >/dev/null 2>&1 || true
+  if [ -s "$out" ]; then
+    printf '%s\t%s\n' "$name" "$(wc -c < "$out")" >> "$samples_tsv"
+  else
+    echo "[bench-metrics] WARN: binary_size sample failed to compile: $src" >&2
+  fi
+done
+
+# --- micro benches (bytes_per_op deterministic, ns_p50 advisory) --------------
+bench_tsv="$work/bench.tsv"; : > "$bench_tsv"
+micro_status="skipped (no vibewt runtime)"
+RUNNER_BIN="${VIBE_RUNNER:-$ROOT_DIR/runtime/vibewt/target/release/vibewt}"
+if [ -x "$RUNNER_BIN" ] && [ -f "$TRACKED" ]; then
+  micro_status="ok"
+  while IFS= read -r bf; do
+    case "$bf" in ''|\#*) continue ;; esac
+    if [ ! -f "$bf" ]; then
+      echo "[bench-metrics] WARN: tracked bench missing: $bf" >&2
+      micro_status="partial"
+      continue
+    fi
+    if ! VIBE_RUNNER="$RUNNER_BIN" VIBE_CLI_WASM="$(cd "$(dirname "$STAGE2")" && pwd)/$(basename "$STAGE2")" \
+      timeout 300 ./runtime/vibe bench "$bf" --iters "$BENCH_ITERS" 2>/dev/null \
+      | grep '^vibe::bench ' \
+      | sed -n 's/^vibe::bench label=\([^ ]*\) .* ns_p50=\([0-9]*\) .* bytes_per_op=\([0-9]*\).*/\1\t\2\t\3/p' \
+      >> "$bench_tsv"; then
+      echo "[bench-metrics] WARN: bench run failed: $bf" >&2
+      micro_status="partial"
+    fi
+  done < "$TRACKED"
+  echo "[bench-metrics] micro benches: $(wc -l < "$bench_tsv") series ($micro_status)"
+else
+  echo "[bench-metrics] micro benches skipped (runtime: $RUNNER_BIN)"
+fi
+
+# --- assemble JSON ------------------------------------------------------------
+BM_HEAP="$heap" BM_WALL_MEDIAN="$wall_median" BM_WALL_RUNS="${walls[*]}" \
+BM_STAGE2="$stage2_bytes" BM_ADAPTER="$adapter_bundle_bytes" \
+BM_SOURCES="$sources_bundle_bytes" BM_MODSRC="$module_source_bytes" \
+BM_MICRO_STATUS="$micro_status" \
+node - "$OUT_JSON" "$samples_tsv" "$bench_tsv" <<'NODE'
+const fs = require("fs");
+const [out, samplesTsv, benchTsv] = process.argv.slice(2);
+const tsv = (p) => fs.existsSync(p)
+  ? fs.readFileSync(p, "utf8").split("\n").filter(Boolean).map(l => l.split("\t"))
+  : [];
+const samples = {}; for (const [k, v] of tsv(samplesTsv)) samples[k] = +v;
+const benches = {}; for (const [k, ns, b] of tsv(benchTsv)) benches[k] = { ns_p50: +ns, bytes_per_op: +b };
+const sh = (c) => require("child_process").execSync(c, { encoding: "utf8" }).trim();
+let commit = process.env.GITHUB_SHA || "";
+try { if (!commit) commit = sh("git rev-parse HEAD"); } catch {}
+const doc = {
+  schema: 1,
+  commit,
+  date: new Date().toISOString(),
+  selfcompile: {
+    heap_ptr_bytes: +process.env.BM_HEAP,
+    wall_ms_median: +process.env.BM_WALL_MEDIAN,
+    wall_ms_runs: process.env.BM_WALL_RUNS.split(/\s+/).filter(Boolean).map(Number),
+  },
+  sizes: {
+    stage2_wasm: +process.env.BM_STAGE2,
+    cli_adapter_bundle: +process.env.BM_ADAPTER,
+    compiler_sources_bundle: +process.env.BM_SOURCES,
+    module_source: +process.env.BM_MODSRC,
+    samples,
+  },
+  benches,
+  micro_status: process.env.BM_MICRO_STATUS,
+};
+fs.writeFileSync(out, JSON.stringify(doc, null, 2) + "\n");
+console.log("[bench-metrics] wrote " + out);
+NODE

--- a/scripts/bench_report.mjs
+++ b/scripts/bench_report.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Render the perf-tracking markdown report from bench_metrics.sh snapshots.
+//
+//   node scripts/bench_report.mjs current.json [baseline.json]
+//
+// DETERMINISTIC metrics (heap, sizes, bytes/op) get a tight flag threshold
+// (any change is real; >±2% gets a warning emoji). ADVISORY wall-time
+// metrics (wall_ms, ns_p50) flag only past ±15% — CI runners are noisy.
+// Never exits non-zero on regressions: this is a report, the blocking gate
+// for allocation is ci.yml's KPI heap step.
+import { readFileSync, existsSync } from "node:fs";
+
+const [curPath, basePath] = process.argv.slice(2);
+if (!curPath) {
+  console.error("usage: bench_report.mjs current.json [baseline.json]");
+  process.exit(2);
+}
+const cur = JSON.parse(readFileSync(curPath, "utf8"));
+const base = basePath && existsSync(basePath) ? JSON.parse(readFileSync(basePath, "utf8")) : null;
+
+const fmt = (n) => n == null ? "–" : n.toLocaleString("en-US");
+function delta(curV, baseV, loosePct) {
+  if (baseV == null || curV == null) return " | –";
+  if (baseV === curV) return " | ±0";
+  const pct = baseV === 0 ? 100 : ((curV - baseV) / baseV) * 100;
+  const sign = pct > 0 ? "+" : "";
+  const flagAt = loosePct ? 15 : 2;
+  const flag = Math.abs(pct) >= flagAt ? (pct > 0 ? " ⚠️" : " 🎉") : "";
+  return ` | ${sign}${pct.toFixed(2)}%${flag}`;
+}
+
+const lines = [];
+lines.push("<!-- vibe-perf-report -->");
+lines.push(`### 📊 Perf report`);
+lines.push("");
+lines.push(`current: \`${(cur.commit || "?").slice(0, 9)}\`` +
+  (base ? ` / baseline (main): \`${(base.commit || "?").slice(0, 9)}\` (${(base.date || "").slice(0, 10)})` : " / baseline: _none yet_"));
+lines.push("");
+
+lines.push("#### Deterministic (allocation & size — any drift is real)");
+lines.push("");
+lines.push("| metric | current | baseline | Δ |");
+lines.push("|---|---:|---:|---|");
+const detRows = [
+  ["selfcompile heap_ptr_bytes", cur.selfcompile?.heap_ptr_bytes, base?.selfcompile?.heap_ptr_bytes],
+  ["stage2.wasm bytes", cur.sizes?.stage2_wasm, base?.sizes?.stage2_wasm],
+  ["cli_adapter_bundle bytes", cur.sizes?.cli_adapter_bundle, base?.sizes?.cli_adapter_bundle],
+  ["compiler_sources_bundle bytes", cur.sizes?.compiler_sources_bundle, base?.sizes?.compiler_sources_bundle],
+  ["flat module source bytes", cur.sizes?.module_source, base?.sizes?.module_source],
+];
+for (const [name, c, b] of detRows) lines.push(`| ${name} | ${fmt(c)} | ${fmt(b)}${delta(c, b, false)} |`);
+for (const [name, c] of Object.entries(cur.sizes?.samples || {})) {
+  const b = base?.sizes?.samples?.[name];
+  lines.push(`| sample wasm: ${name} | ${fmt(c)} | ${fmt(b)}${delta(c, b, false)} |`);
+}
+for (const [label, v] of Object.entries(cur.benches || {})) {
+  const b = base?.benches?.[label]?.bytes_per_op;
+  lines.push(`| B/op: ${label} | ${fmt(v.bytes_per_op)} | ${fmt(b)}${delta(v.bytes_per_op, b, false)} |`);
+}
+lines.push("");
+
+lines.push("#### Advisory (wall time — CI noise ±10-15% is normal)");
+lines.push("");
+lines.push("| metric | current | baseline | Δ |");
+lines.push("|---|---:|---:|---|");
+lines.push(`| selfcompile wall_ms (median) | ${fmt(cur.selfcompile?.wall_ms_median)} | ${fmt(base?.selfcompile?.wall_ms_median)}${delta(cur.selfcompile?.wall_ms_median, base?.selfcompile?.wall_ms_median, true)} |`);
+for (const [label, v] of Object.entries(cur.benches || {})) {
+  const b = base?.benches?.[label]?.ns_p50;
+  lines.push(`| ns/op p50: ${label} | ${fmt(v.ns_p50)} | ${fmt(b)}${delta(v.ns_p50, b, true)} |`);
+}
+lines.push("");
+if (cur.micro_status && cur.micro_status !== "ok") {
+  lines.push(`> micro benches: ${cur.micro_status}`);
+  lines.push("");
+}
+lines.push(`<sub>tracked series: bench/perf/tracked_benches.txt · history: \`bench-data\` branch · docs: bench/perf/README.md</sub>`);
+
+console.log(lines.join("\n"));

--- a/scripts/coverage_suite.sh
+++ b/scripts/coverage_suite.sh
@@ -177,7 +177,15 @@ mkdir -p "$OUT_DIR"
 run_log="$OUT_DIR/vibe_test.log"
 # vibe_test.sh exits non-zero when any entry fails; the pass-rate threshold
 # below decides gate success, so tolerate the exit code here.
-VIBE_TEST_CLI_WASM="$ROOT/$cli" bash scripts/vibe_test.sh --coverage "${entries[@]}" \
+# $cli may be absolute (CI passes VIBE_SUITE_CLI_WASM that way) — only
+# rebase relative paths onto $ROOT. Blindly prefixing doubled the path
+# ("$ROOT//home/runner/…") and instantly failed all 467 compiles on the
+# first standalone coverage-suite run (2026-07-25).
+case "$cli" in
+  /*) cli_abs="$cli" ;;
+  *) cli_abs="$ROOT/$cli" ;;
+esac
+VIBE_TEST_CLI_WASM="$cli_abs" bash scripts/vibe_test.sh --coverage "${entries[@]}" \
   | tee "$run_log" || true
 
 python3 - "$run_log" "$COV_DIR" "$REPORT" "$MIN_POINT" "$MIN_LINE" "$MIN_BRANCH" "$MIN_FN_HIT" "$MIN_BRANCH_HIT" <<'PY'


### PR DESCRIPTION
bench / パフォーマンスを継続監視し、PR 単位で追える仕組みを追加します。非ブロッキング(マージを止めない)で、ブロッキングなアロケーションゲートは従来通り ci.yml の KPI heap ステップが担当。

## 仕組み

**収集** — `scripts/bench_metrics.sh <stage2.wasm> [out.json]`(1 コミット = 1 スナップショット JSON):

| クラス | メトリクス | 閾値フラグ |
|---|---|---|
| 決定的(バイト安定) | selfcompile `heap_ptr_bytes`(KPI スクリプト、cold cache)/ stage2・bundle・flat source サイズ / `bench/binary_size/*` の生成 wasm サイズ / tracked bench 全系列の `bytes_per_op` | ±2% で ⚠️/🎉 |
| advisory(壁時間) | selfcompile `wall_ms`(median of 3)/ 各 bench の `ns_p50` | ±15% のみフラグ |

**追跡系列** — `bench/perf/tracked_benches.txt`: regression fixtures(pure/alloc)+ compiler `parser_bench` 13 系列(計 ~30s、PR 毎に走らせても軽い)。ファイルを追記すれば系列が増えます。

**PR 単位の追跡** — `.github/workflows/perf.yml` が PR ごとに sticky コメント「📊 Perf report」を upsert(マーカー `<!-- vibe-perf-report -->`、push のたび同一コメントを更新)。baseline は main の最新スナップショット。

**継続監視(履歴)** — main への push ごとに `bench-data` ブランチへ追記(`data/main.jsonl` 1 行 1 JSON + `latest.json` = PR baseline)。初回は orphan ブランチを自動作成、並行 push は fetch→再適用のリトライで append-only に安全。履歴は `git show origin/bench-data:data/main.jsonl` で直接読めます。

## 実測(ローカル検証)

- metrics 収集 ~50s(KPI×3 + サンプル 5 個 + micro 15 系列)。stage2 は ci.yml と同じ actions/cache キーを共有、vibewt は Cargo キャッシュ付きビルド
- report 描画: baseline なし/ありの両モード確認(決定的行 ±2% フラグ、advisory ±15%)
- `vibe bench` headless 実行(VIBE_CLI_WASM + VIBE_RUNNER)確認済み。bytes_per_op は iters を変えても安定(決定的)

## メモ

- 初回マージ直後は baseline が無いので PR コメントは「baseline: none yet」になり、main への最初の push で `bench-data` が生えてから差分が出ます
- binary_size サンプルのエントリは `main`(`_start` ではない)— bench_binary_size.sh と同じ流儀
- ドキュメント: bench/perf/README.md「Continuous perf tracking」節(系列の追加方法・ローカル実行手順)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_