### PR TITLE
Fix #1104: point parser bench corpus at the real lexer/parser sources

### DIFF
--- a/lib/@vibe/compiler/parser_bench.vibe
+++ b/lib/@vibe/compiler/parser_bench.vibe
@@ -78,7 +78,7 @@ bench "parse_parser_vibe" {
 
 bench "parse_only_lexer_vibe" {
   let _ = handle {
-    probe_parse_tokens_count(ensure_file_tokens(lexer_vibe_tokens, "lib/@vibe/compiler/syntax/lexer.vibe"))
+    probe_parse_tokens_count(ensure_file_tokens(lexer_vibe_tokens, "lib/@vibe/parser/lexer.vibe"))
   } with Error {
     Throw(_) => 0
   }
@@ -94,7 +94,7 @@ bench "parse_only_checker_vibe" {
 
 bench "parse_only_parser_vibe" {
   let _ = handle {
-    probe_parse_tokens_count(ensure_file_tokens(parser_vibe_tokens, "lib/@vibe/compiler/syntax/parser.vibe"))
+    probe_parse_tokens_count(ensure_file_tokens(parser_vibe_tokens, "lib/@vibe/parser/parser.vibe"))
   } with Error {
     Throw(_) => 0
   }

--- a/lib/@vibe/compiler/parser_hotspot_probe.vibe
+++ b/lib/@vibe/compiler/parser_hotspot_probe.vibe
@@ -62,7 +62,14 @@ export fn probe_parse_expr_tokens_repeat_count(tokens: Array[Token], repeats: In
 }
 
 export fn probe_parse_lexer_vibe() -> Int with { Error, Fs } {
-  parse_program_count(lex(Fs::read_file("lib/@vibe/compiler/syntax/lexer.vibe")))
+  // #1104: the corpus must be the REAL implementation files. The old
+  // lib/@vibe/compiler/syntax/{lexer,parser}.vibe paths became 8-line
+  // re-export shims in #753, silently turning these file-level benches
+  // into ~2µs micro-measurements whose ns/op amplified runner noise into
+  // headline regressions (a +50% report that was ±0 B/op and layout/JIT
+  // noise). checker.vibe was never moved, which is why the checker rows
+  // stayed meaningful throughout.
+  parse_program_count(lex(Fs::read_file("lib/@vibe/parser/lexer.vibe")))
 }
 
 export fn probe_parse_checker_vibe() -> Int with { Error, Fs } {
@@ -70,7 +77,7 @@ export fn probe_parse_checker_vibe() -> Int with { Error, Fs } {
 }
 
 export fn probe_parse_parser_vibe() -> Int with { Error, Fs } {
-  parse_program_count(lex(Fs::read_file("lib/@vibe/compiler/syntax/parser.vibe")))
+  parse_program_count(lex(Fs::read_file("lib/@vibe/parser/parser.vibe")))
 }
 
 export fn probe_parse_deep_binop_chain() -> Int with { Error } {


### PR DESCRIPTION
#1102 の perf report で `parse_only_parser_vibe` が +49.79% と表示された件(#1104)の根治。

## 問題

`parse_lexer_vibe` / `parse_parser_vibe` / `parse_only_lexer_vibe` / `parse_only_parser_vibe` の corpus だった `lib/@vibe/compiler/syntax/{lexer,parser}.vibe` は **#753 のパッケージ移動以降 8 行の re-export shim** で、この 4 行は ~2〜17µs の shim parse を測っていた。そのスケールでは ns/op p50 が runner スケジューリングとコードレイアウトを見出しの Δ に増幅する(#1102 の +49.79% は B/op ±0・実行されない関数 1 個の +72 bytes が唯一のコード差、という「実体ゼロ」の行だった — 追跡の全記録は #1104)。checker.vibe は移動していないので checker 行はずっと有意だった。

## 修正

corpus を実体の `lib/@vibe/parser/lexer.vibe`(1083 行)/ `lib/@vibe/parser/parser.vibe`(1051 行)へ差し替え(bench 2 ファイルのみ、compiler sources bundle 対象外なので regen なし)。差し替え後の実測(node runner, 20 iters):

| bench | before | after |
|---|---:|---:|
| parse_lexer_vibe | ~15µs | **~3.96ms** |
| parse_parser_vibe | ~17µs | **~5.90ms** |
| parse_only_lexer_vibe | ~2µs | **~3.81ms** |
| parse_only_parser_vibe | ~2.4µs | **~2.00ms** |

すべて advisory ±10-15% ノイズ方針が意味を持つ ms 帯に入った。

## 注意

- この PR の perf report ではこの 4 行の Δ が巨大に出るが、**それが正常**(空測定 → 実測定への切り替え)。tracked series の履歴はこの commit でリセット。
- bench 名は不変なので `tracked_benches.txt` の変更なし。

Refs #1104 #1102 #753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe)_