### PR TITLE
fix: pump_all の deadlock 検出から cooperative yield を除外 (#1110 Codex review follow-up)

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -699,6 +699,13 @@ suspendable task の第一スライスを実装した:
   livelock ではなく deadlock trap になる (drive_one の規則と同型)。
   stack-driving の `Sender::send` / `Receiver::recv` は無変更で、両者は
   同じ linearization (buf/pend/pend_seq/pend_consumed) を共有する。
+  **Suspend payload 規約**: `0` = cooperative yield / `1` = poll wait。
+  adoption-site の arm は理由を伝播する
+  `TaskHandle::park_poll(h, resume, r == 1)` を canonical とする —
+  plain `park` は yield 扱いなので、channel 待ちを plain park で park
+  すると deadlock trap に見えず livelock になる (#1111 Codex review)。
+  yield は deadlock の証拠に数えない (resume は常に body を前進させる;
+  無限 yield は通常の無限ループ)。
 - conformance lock (`suspend_test.vibe`): **2 task の mid-body 相互
   interleave** (run-to-completion では不可能だった形 — log が厳密交互)、
   wake 値の suspension point への配達、parked task の cancel (継続 drop

--- a/lib/@vibex/concurrent/concurrent.vibe
+++ b/lib/@vibex/concurrent/concurrent.vibe
@@ -78,7 +78,14 @@ export struct TaskCell {
   // to its next suspend (or completion). Uniform (Int) -> Unit so the
   // group can hold heterogeneous tasks; the T-aware settle logic lives in
   // the wrapper closure TaskHandle::park builds.
-  mut cont: Option[(Int) -> Unit]
+  mut cont: Option[(Int) -> Unit];
+  // Parked as a POLLER (Suspend(1) — waiting on an external condition it
+  // re-checks on every wake, e.g. send_wait/recv_wait) rather than a
+  // productive cooperative yield (Suspend(0)). pump_all's deadlock trap
+  // only fires when EVERY parked task is a poller: resuming a yielder
+  // always advances its body, so yielders are never deadlock evidence
+  // (Codex review on #1110 — a lone task yielding 3+ times must not trap).
+  mut wait_poll: Bool
 }
 
 // Task-group phase codes: 0 open, 1 cancelling (fail-fast in progress),
@@ -305,7 +312,7 @@ export fn TaskGroup::run[T](body: (TaskGroup) -> T with { e }) -> Result[T, Task
 export fn TaskGroup::spawn[T: Send](n: TaskGroup, f: () -> T with { Error }) -> TaskHandle[T] {
   conc_require(n.phase == 0)
   let rc = ResCell::{ value: None }
-  let cell = TaskCell::{ status: 0, cancel_requested: false, fail_msg: "", cont: None }
+  let cell = TaskCell::{ status: 0, cancel_requested: false, fail_msg: "", cont: None, wait_poll: false }
   let runner: () -> Unit = () -> {
     handle {
       let v = f()
@@ -624,7 +631,7 @@ export fn TaskGroup::spawn_suspend[T: Send](n: TaskGroup, f: () -> T with { Asyn
     SDone(v)
   } with Async {
     Suspend(r) => {
-      TaskHandle::park(h, resume)
+      TaskHandle::park_poll(h, resume, r == 1)
       SParked
     }
   })
@@ -637,7 +644,7 @@ export fn TaskGroup::spawn_suspend[T: Send](n: TaskGroup, f: () -> T with { Asyn
 export fn TaskGroup::adopt[T: Send](n: TaskGroup) -> TaskHandle[T] {
   conc_require(n.phase == 0)
   let rc = ResCell::{ value: None }
-  let cell = TaskCell::{ status: 1, cancel_requested: false, fail_msg: "", cont: None }
+  let cell = TaskCell::{ status: 1, cancel_requested: false, fail_msg: "", cont: None, wait_poll: false }
   Array::push(n.adopted, cell)
   TaskHandle::{ group: n, cell: cell, result: rc }
 }
@@ -664,10 +671,19 @@ export fn TaskHandle::settle[T](h: TaskHandle[T], step: TaskStep[T]) -> Unit {
 // settles the result, and if it suspends again the arm has already
 // re-parked (this same function) before the wrapper observes SParked.
 export fn TaskHandle::park[T](h: TaskHandle[T], k: (Int) -> TaskStep[T]) -> Unit {
+  TaskHandle::park_poll(h, k, false)
+}
+
+// Park with an explicit wait kind: `poll = true` marks the task as
+// waiting on an external condition (deadlock-trap eligible, see
+// TaskCell.wait_poll). spawn_suspend derives it from the Suspend payload
+// (1 = poll wait — the convention the blocking channel ops use).
+export fn TaskHandle::park_poll[T](h: TaskHandle[T], k: (Int) -> TaskStep[T], poll: Bool) -> Unit {
   let cell = h.cell
   let rc = h.result
   let grp = h.group
   cell.status = 5
+  cell.wait_poll = poll
   cell.cont = Some((rv: Int) -> {
     cell.status = 1
     match k(rv) {
@@ -717,6 +733,7 @@ export fn TaskGroup::pump(n: TaskGroup) -> Bool {
       match c.cont {
         Some(k) => {
           c.cont = None
+          c.wait_poll = false
           k(0)
           ()
         },
@@ -738,21 +755,49 @@ export fn TaskGroup::pump_all(n: TaskGroup) -> Unit {
     let before = n.progress
     go = TaskGroup::pump(n)
     if go {
-      if n.progress == before {
+      if n.progress == before && conc_all_parked_polling(n) {
         stall = stall + 1
       } else {
         stall = 0
       }
-      // A full round-robin sweep of every adopted slot with zero progress
-      // can only repeat itself (the scheduler is deterministic and no wake
-      // can originate outside this loop) — blocked-forever channel waits
-      // land here. Trap like every other deadlock (drive_one's rule)
-      // instead of livelocking.
+      // A full round-robin sweep in which every parked task is a POLLER
+      // (Suspend(1) — waiting on an external condition) and zero progress
+      // was made can only repeat itself: the scheduler is deterministic
+      // and no wake can originate outside this loop — blocked-forever
+      // channel waits land here. Trap like every other deadlock
+      // (drive_one's rule) instead of livelocking. Cooperative YIELDS
+      // (Suspend(0)) never count: resuming one always advances its body,
+      // so a lone task yielding any number of times completes normally
+      // (an infinitely-yielding body is an ordinary infinite loop, not a
+      // deadlock).
       conc_require(stall <= Array::length(n.adopted))
     } else {
       ()
     }
   }
+}
+
+// Every currently-parked adopted task is a poller (wait_poll). False when
+// nothing is parked (vacuous sweeps must not accumulate stall).
+fn conc_all_parked_polling(n: TaskGroup) -> Bool {
+  let mut any = false
+  let mut all = true
+  let mut i = 0
+  while i < Array::length(n.adopted) {
+    let c = Array::get(n.adopted, i)
+    if c.status == 5 {
+      any = true
+      if c.wait_poll {
+        ()
+      } else {
+        all = false
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  any && all
 }
 
 //# Blocking channel ops (suspend-based)
@@ -796,7 +841,7 @@ fn conc_send_wait_consumed[T](c: Channel[T], myseq: Int) -> Result[Unit, SendErr
   } else if chan_closed(c) {
     Err(Closed)
   } else {
-    let _w = perform Async::Suspend(0)
+    let _w = perform Async::Suspend(1)
     conc_send_wait_consumed(c, myseq)
   }
 }
@@ -828,7 +873,7 @@ export fn Receiver::recv_wait[T](r: Receiver[T]) -> Option[T] with { Async } {
   } else if chan_closed(c) {
     None
   } else {
-    let _w = perform Async::Suspend(0)
+    let _w = perform Async::Suspend(1)
     Receiver::recv_wait(r)
   }
 }

--- a/lib/@vibex/concurrent/concurrent.vibe
+++ b/lib/@vibex/concurrent/concurrent.vibe
@@ -593,6 +593,13 @@ export fn Receiver::recv[T](r: Receiver[T]) -> Option[T] {
 //     }
 //   })
 //
+// Arms should PROPAGATE the suspend reason: `TaskHandle::park_poll(h,
+// resume, r == 1)` (payload convention: 0 = cooperative yield, 1 = poll
+// wait). Plain `TaskHandle::park` records a YIELD — safe for pure
+// yielding bodies, but a body that blocks in send_wait/recv_wait under a
+// plain-park arm is invisible to pump_all's deadlock trap (it livelocks
+// instead of trapping; Codex review on #1111).
+//
 // The body is subject to the suspend lowering's eligibility rules
 // (docs/effect-evidence-passing.md 追記27-29): performs and calls to
 // row-carrying functions on the let/seq/tail/branch-tail spine; other
@@ -670,6 +677,9 @@ export fn TaskHandle::settle[T](h: TaskHandle[T], step: TaskStep[T]) -> Unit {
 // body with the wake value; if the body runs to completion the wrapper
 // settles the result, and if it suspends again the arm has already
 // re-parked (this same function) before the wrapper observes SParked.
+// Compatibility form: records a cooperative YIELD (wait_poll = false).
+// Use park_poll with the arm's suspend payload when the body may block
+// on a channel, or the deadlock trap cannot see the wait.
 export fn TaskHandle::park[T](h: TaskHandle[T], k: (Int) -> TaskStep[T]) -> Unit {
   TaskHandle::park_poll(h, k, false)
 }

--- a/lib/@vibex/concurrent/index.vpkg
+++ b/lib/@vibex/concurrent/index.vpkg
@@ -65,4 +65,8 @@ fn Sender::send_wait[T](s: Sender[T], v: T) -> Result[Unit, SendError] with { As
 fn Receiver::recv_wait[T](r: Receiver[T]) -> Option[T] with { Async }
 fn TaskHandle::settle[T](h: TaskHandle[T], step: TaskStep[T]) -> Unit
 fn TaskHandle::park[T](h: TaskHandle[T], k: (Int) -> TaskStep[T]) -> Unit
+// park with an explicit wait kind: poll=true marks an external-condition
+// wait (deadlock-trap eligible). Suspend payload convention: 0 = yield,
+// 1 = poll wait (the blocking channel ops use 1).
+fn TaskHandle::park_poll[T](h: TaskHandle[T], k: (Int) -> TaskStep[T], poll: Bool) -> Unit
 fn TaskHandle::wake[T](h: TaskHandle[T], v: Int) -> Bool

--- a/lib/@vibex/concurrent/suspend_test.vibe
+++ b/lib/@vibex/concurrent/suspend_test.vibe
@@ -214,6 +214,31 @@ test "spawn_suspend with a pure body settles synchronously" {
   })
 }
 
+// Codex review regression (#1110): a LONE task that yields (Suspend(0))
+// three or more times must complete normally — cooperative yields carry
+// no progress bump, and the first deadlock-detector counted them as
+// stalls (traps at the 3rd consecutive yield of a single task). Yields
+// are never deadlock evidence; only pollers (Suspend(1)) are.
+test "a lone spawn_suspend task may yield three times without tripping the deadlock trap" {
+  let out = TaskGroup::run((g) -> {
+    let h = TaskGroup::spawn_suspend(g, () -> Int with { Async } {
+      let _y1 = perform Async::Suspend(0)
+      let _y2 = perform Async::Suspend(0)
+      let _y3 = perform Async::Suspend(0)
+      21
+    })
+    TaskGroup::pump_all(g)
+    match TaskHandle::join(h) {
+      Ok(v) => v * 2,
+      Err(_) => 0 - 1
+    }
+  })
+  assert(match out {
+    Ok(v) => v == 42,
+    Err(_) => false
+  })
+}
+
 // Channel blocking (ADR-0076 追記31 の続きスライス): the shape the module
 // header called out as impossible under run-to-completion — a producer
 // overflowing a capacity-1 channel while the consumer drains — now works

--- a/lib/@vibex/concurrent/suspend_test.vibe
+++ b/lib/@vibex/concurrent/suspend_test.vibe
@@ -5,9 +5,9 @@ import ./concurrent.vibe {
   type Channel, type Sender, type Receiver, type SendError, type ChannelConfigError,
   TaskGroup::run, TaskGroup::adopt, TaskGroup::pump, TaskGroup::pump_all,
   TaskGroup::spawn_suspend,
-  TaskHandle::settle, TaskHandle::park, TaskHandle::wake,
+  TaskHandle::settle, TaskHandle::park, TaskHandle::park_poll, TaskHandle::wake,
   TaskHandle::join, TaskHandle::cancel,
-  Channel::bounded, Sender::send_wait, Sender::release, Receiver::recv_wait
+  Channel::bounded, Sender::send, Sender::send_wait, Sender::release, Receiver::recv_wait
 }
 
 //# Types
@@ -41,7 +41,7 @@ test "adopted tasks interleave mid-body via Async::Suspend" {
       SDone(100)
     } with Async {
       Suspend(r) => {
-        TaskHandle::park(ha, resume)
+        TaskHandle::park_poll(ha, resume, r == 1)
         SParked
       }
     })
@@ -55,7 +55,7 @@ test "adopted tasks interleave mid-body via Async::Suspend" {
       SDone(200)
     } with Async {
       Suspend(r) => {
-        TaskHandle::park(hb, resume)
+        TaskHandle::park_poll(hb, resume, r == 1)
         SParked
       }
     })
@@ -206,6 +206,48 @@ test "spawn_suspend with a pure body settles synchronously" {
     match TaskHandle::join(h) {
       Ok(v) => v,
       Err(_) => -1
+    }
+  })
+  assert(match out {
+    Ok(v) => v == 42,
+    Err(_) => false
+  })
+}
+
+// Codex review (#1111): the ADOPTION-lane canonical arm must propagate
+// the suspend reason (park_poll(h, resume, r == 1)); a channel wait
+// parked through it is poller-classified, so a deliverable message
+// resumes it and an undeliverable one would TRAP (not livelock). Here:
+// an adopted consumer blocks in recv_wait, the run body then supplies
+// the message through the stack-driving send, and pump_all delivers.
+test "adoption-lane recv_wait parks as a poller and resumes on delivery" {
+  let out = TaskGroup::run((g) -> {
+    match Channel::bounded(g, 1) {
+      Ok(pair) => {
+        let (tx, rx) = pair
+        let h = TaskGroup::adopt(g)
+        TaskHandle::settle(h, handle {
+          let r1 = Receiver::recv_wait(rx)
+          let a = match r1 {
+            Some(v) => v,
+            None => 0 - 1
+          }
+          SDone(a * 3)
+        } with Async {
+          Suspend(r) => {
+            TaskHandle::park_poll(h, resume, r == 1)
+            SParked
+          }
+        })
+        let _s = Sender::send(tx, 14)
+        Sender::release(tx)
+        TaskGroup::pump_all(g)
+        match TaskHandle::join(h) {
+          Ok(v) => v,
+          Err(_) => 0 - 1
+        }
+      },
+      Err(_) => 0 - 999
     }
   })
   assert(match out {


### PR DESCRIPTION
## 概要

#1110 の Codex review (P1) が指摘した実バグの修正。**単一の adopted task が 3 回以上 cooperative yield すると `pump_all` が誤って deadlock trap していた** — yield は progress を刻まないため stall 計数に入り、`stall > adopted 長` で `conc_require` が落ちる (#1110 のテスト群は 2 task × 2 yield で閾値ちょうどに収まり偶然通過していた)。

resuming a yielder は常に body を前進させるので、yield は deadlock の証拠にならない — deadlock と呼べるのは「外部条件をポーリングして再 park する待ち」だけ、という区別を入れた。

## 変更

- **Suspend payload 規約**: `0` = cooperative yield / `1` = poll wait (外部条件待ち)。channel の `send_wait` / `recv_wait` / 内部の consumed 待ちは `Suspend(1)` を perform する。
- **`TaskCell.wait_poll`**: park 時に種別を記録。`TaskHandle::park_poll(h, k, poll)` を追加 (`park` は従来シグネチャのまま yield 扱い)。`spawn_suspend` の arm は payload から `r == 1` で導出。pump が resume する際にクリア (再 park 時に再設定)。
- **`pump_all` の stall 計数**: 「無進捗 **かつ parked 全員が poller**」の周のみカウント。yielder が 1 つでも居れば stall は 0 のまま — yielder はいずれ settle して progress を刻む (無限 yield は通常の無限ループであって deadlock ではない)。channel 詰まり (全員 poller で全周無進捗) は従来どおり trap。

## 回帰テスト

`suspend_test.vibe` に Codex シナリオを追加: 単一 spawn_suspend task が 3 連続 yield して正常完了することを pin (修正前はこのテストが trap で fail する)。

## 検証

lib のみの変更 (compiler 不変)。suspend_test (channel blocking 2 テスト含む) + unit battery 468/468 全通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe)_