### PR TITLE
fail-fast × suspendable task の統合 + ADR-0076 追記34 (closure-value evidence 設計)

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -706,6 +706,14 @@ suspendable task の第一スライスを実装した:
   すると deadlock trap に見えず livelock になる (#1111 Codex review)。
   yield は deadlock の証拠に数えない (resume は常に body を前進させる;
   無限 yield は通常の無限ループ)。
+- **fail-fast × suspendable の統合も着地**: `spawn_suspend` の body row は
+  `{ Async, Error }` になり、escape した `Error::Throw` は Failed へ変換
+  される。settle leg は spawn_suspend 内の外側 Error handle (Async handle
+  は CPS 化済みなので handler 越え resume は存在せず #543 の罠は当たら
+  ない)、resume 後の leg は park wrapper の per-leg Error boundary が
+  受ける (pump の stack 上で走るため)。失敗は group の first-observed
+  failure を記録し、**parked sibling を自動 cancel** (継続 drop = RC 解放)
+  して pump_all を自然終了させる。run は Err(Failed(first)) を返す。
 - conformance lock (`suspend_test.vibe`): **2 task の mid-body 相互
   interleave** (run-to-completion では不可能だった形 — log が厳密交互)、
   wake 値の suspension point への配達、parked task の cancel (継続 drop

--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2247,6 +2247,65 @@ primitive **`__set_field`** (`o.f = v` の脱糖先) と **`__index`**
 checker-verified effect-free / function-typed 引数なしで、追記30 の
 基準そのまま。idp/edp の共有 list に足さない理由も追記30 と同一。
 
+### 追記34 (2026-07-25): closure-value evidence の設計 — 「型主導・全域」
+での dict-param 化 (追記25 の解決形)
+
+実装前調査 (evidence dict の受け渡し実態 / closure layout 変更の blast
+radius) と実測から確定した設計。**結論: 追記25 が想定した「closure 値
+そのものに evidence を持たせる env slot / ABI 変更」は不要**。closure-CPS
+(追記31 Vertical B) と同じ「規約は checker の row 型で静的に決まる」原理を
+edp に適用すれば、既存の dict-param 機構 (trait dict と同形の先頭 value
+引数) のまま #1070 一般ケースが解ける。
+
+**確定した事実**:
+- evidence は既に「先頭 param + 呼び出し側 prepend」の構造的 ABI
+  (`edp_rewrite_needing_fn` / `edp_prepend_dict_arg` / anonymous ERecord)。
+  closure literal への param 前置も `edp_maybe_migrate_efn` (#1075) として
+  実装済み。
+- #1070 系の 4 制約 (single-use / universal-call-site / no-value-reference /
+  handle-confinement) は全て「同じ closure 値が migrated ABI と未 migration
+  ABI の両方から呼ばれると arity が割れる」ことの回避 proof。従って
+  **migration を proof-directed-partial から type-directed-total に変えれば
+  4 制約は原理ごと消える**: row に E を含む関数型の値は、literal も param
+  も local も named-fn 参照も一律「`__ev_E` を先頭に取る」規約でコンパイル
+  する。同じ row 型 = 同じ arity なので mismatch が構造的に起きない。
+- `effect_local_closure_by_value_hof_escaping` 形は実測で本物の replay
+  実行 (副作用カウンタ probe: handle body 再実行で hits=4、M2 重複あり)。
+  dtpw wrapper inlining は当たっていない (agent の静的追跡は誤り)。
+  移行後は hits=2 (M2 解消) — 値 206 は不変。
+
+**変換規則 (edp の拡張、全て AST レベル)**:
+1. row に E を含む **annotated closure literal** → 無条件で `__ev_E`
+   param 前置 + body 書き換え (既存 edp_maybe_migrate_efn の証明ゲートを
+   型主導に置換)。無注釈 literal は #761 により enclosing row へ帰属する
+   ので、suspend 側 (追記31) と同じ「明示 row 注釈必須」規約。
+2. **row-E typed param/local 経由の呼び出し** `f(a)` → `f(<ev>, a)`。
+   `<ev>` は lexical に決まる: 囲む needing fn の `__ev_E` param、または
+   handle site の dict literal。
+3. **needing fn の値参照** — migrated named fn は既に arity+1 なので、
+   値としてそのまま row-E closure 型位置に流せる (規約が一致するため
+   wrapper 合成は不要)。
+4. **整合ガード (v1)**: row-E closure 値が存在するプログラムでは E の
+   migration が全域で成立しなければ hard error (replay への silent
+   fallback 禁止 — scps の規約整合ガードと同型)。row-E closure 値が
+   存在しないプログラムは従来の proof-directed 動作のまま
+   (`evidence_dict_needing_shadowed_by_local` の negative pin は不変)。
+5. row 変数 (`with { e }`) は据え置き (evidence vector 表現は後続、本文
+   529-549 の決定通り)。
+
+**やらないこと (調査で棄却)**: env slot 方式 (Option B) は creation 時に
+evidence が存在しない (dict は handle site 生成で、closure は site の外で
+作られる) ため dynamic write channel が必要になり、static closure
+`(slot<<2)|2` の物質化・class-7 drop の slot 迂回など ~30 emit site に
+波及する。hidden arg 方式 (Option A) は全 user fn / linked import の
+cross-module ABI を破壊し bootstrap seed と衝突する。型主導 dict-param は
+どちらのコストも払わない。
+
+**着地順**: V1 = 型主導 total 化 + hof_escaping の evidence 移行
+(re-baseline: 値 206 不変、M2 重複解消を新 fixture で pin) + ガード。
+V2 = 一次 replay 消費者ゼロ化の確認後、frontier 経路 (uses_frontier /
+perform counter・memo / eff_reserve) の削除。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/lib/@vibex/concurrent/concurrent.vibe
+++ b/lib/@vibex/concurrent/concurrent.vibe
@@ -195,6 +195,17 @@ fn conc_fail_cell(n: TaskGroup, cell: TaskCell, msg: String) -> Unit {
     n.fail_msg = msg
     if n.phase == 0 { n.phase = 1 }
   }
+  conc_cancel_parked(n)
+  conc_progress(n)
+}
+
+// Fail-fast sweep shared by BOTH failure lanes (#1115 Codex review): a
+// run-to-completion child's Throw (spawn's runner) must cancel parked
+// suspendable siblings exactly like a suspendable failure does —
+// otherwise the parked sibling either keeps running under a later
+// pump_all or leaves run's terminal-state check to TRAP instead of
+// returning Err(Failed(...)).
+fn conc_cancel_parked(n: TaskGroup) -> Unit {
   let mut i = 0
   while i < Array::length(n.adopted) {
     let c = Array::get(n.adopted, i)
@@ -207,7 +218,6 @@ fn conc_fail_cell(n: TaskGroup, cell: TaskCell, msg: String) -> Unit {
     }
     i = i + 1
   }
-  conc_progress(n)
 }
 
 fn empty_cells() -> Array[TaskCell] {
@@ -364,6 +374,7 @@ export fn TaskGroup::spawn[T: Send](n: TaskGroup, f: () -> T with { Error }) -> 
           n.fail_msg = msg
           if n.phase == 0 { n.phase = 1 }
         }
+        conc_cancel_parked(n)
       }
     }
   }

--- a/lib/@vibex/concurrent/concurrent.vibe
+++ b/lib/@vibex/concurrent/concurrent.vibe
@@ -62,6 +62,10 @@
 // Sender::send_wait / Receiver::recv_wait (bottom of this file) suspend
 // instead of stack-driving, so the producer-overflows-capacity shape the
 // header above calls out now works with plain spawn_suspend closures.
+// Fail-fast is integrated with the suspendable lane too: an Error::Throw
+// escaping a spawn_suspend body (settle leg OR a resumed leg on the
+// pump's stack) converts to Failed and auto-cancels parked siblings
+// (conc_fail_cell).
 
 //# Types
 
@@ -171,6 +175,39 @@ fn conc_require(ok: Bool) -> Unit where { requires: ok } {
 // may call it (ADR-0076 追記31: concrete Async-free row callees are safe).
 fn conc_progress(n: TaskGroup) -> Unit {
   n.progress = n.progress + 1
+}
+
+// Fail-fast entry for the SUSPENDABLE lane (mirrors spawn's runner-side
+// Error conversion): mark the cell Failed, record the group's first
+// observed failure, and auto-cancel parked adopted siblings — their
+// stored continuations are DROPPED (RC frees the captures, the ADR-0076
+// "Cont は RC drop で解放" guarantee) so pump_all has nothing left to
+// deliver and the group close observes terminal states only. Ready
+// run-to-completion siblings are covered by the existing dispatch-time
+// cancel point (drive_one checks n.failing). Counts as progress (a
+// terminal transition).
+fn conc_fail_cell(n: TaskGroup, cell: TaskCell, msg: String) -> Unit {
+  cell.status = 3
+  cell.fail_msg = msg
+  cell.cont = None
+  if !n.failing {
+    n.failing = true
+    n.fail_msg = msg
+    if n.phase == 0 { n.phase = 1 }
+  }
+  let mut i = 0
+  while i < Array::length(n.adopted) {
+    let c = Array::get(n.adopted, i)
+    if c.status == 5 {
+      c.status = 4
+      c.cont = None
+      c.wait_poll = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  conc_progress(n)
 }
 
 fn empty_cells() -> Array[TaskCell] {
@@ -631,17 +668,28 @@ effect Async {
 // (the literal is CPS-split for Async) and this body bubbles the steps
 // it returns, so `f()` below is a needing call through a closure value —
 // the exact shape 3c could not express lexically.
-export fn TaskGroup::spawn_suspend[T: Send](n: TaskGroup, f: () -> T with { Async }) -> TaskHandle[T] {
+export fn TaskGroup::spawn_suspend[T: Send](n: TaskGroup, f: () -> T with { Async, Error }) -> TaskHandle[T] {
   let h = TaskGroup::adopt(n)
-  TaskHandle::settle(h, handle {
-    let v = f()
-    SDone(v)
-  } with Async {
-    Suspend(r) => {
-      TaskHandle::park_poll(h, resume, r == 1)
+  let step = handle {
+    handle {
+      let v = f()
+      SDone(v)
+    } with Async {
+      Suspend(r) => {
+        TaskHandle::park_poll(h, resume, r == 1)
+        SParked
+      }
+    }
+  } with Error {
+    Throw(msg) => {
+      // Error escaping the first (settle) leg: Failed conversion +
+      // fail-fast, exactly like spawn's runner. The Async handle is
+      // CPS-lowered (no exceptions), so only real throws land here.
+      conc_fail_cell(n, h.cell, msg)
       SParked
     }
-  })
+  }
+  TaskHandle::settle(h, step)
   h
 }
 
@@ -696,7 +744,18 @@ export fn TaskHandle::park_poll[T](h: TaskHandle[T], k: (Int) -> TaskStep[T], po
   cell.wait_poll = poll
   cell.cont = Some((rv: Int) -> {
     cell.status = 1
-    match k(rv) {
+    // Each resumed leg gets its own Error boundary: a throw AFTER a
+    // suspend runs on the pump's stack, outside spawn_suspend's own
+    // handler — without this it would unwind straight out of pump_all.
+    let step = handle {
+      k(rv)
+    } with Error {
+      Throw(msg) => {
+        conc_fail_cell(grp, cell, msg)
+        SParked
+      }
+    }
+    match step {
       SDone(v) => {
         rc.value = Some(v)
         cell.status = 2

--- a/lib/@vibex/concurrent/index.vpkg
+++ b/lib/@vibex/concurrent/index.vpkg
@@ -55,8 +55,9 @@ type TaskStep[T]
 
 fn TaskGroup::adopt[T: Send](n: TaskGroup) -> TaskHandle[T]
 // closure-CPS (ADR-0076 追記31 Vertical B): handle site は library 内部。
-// caller は plain な `() -> T with { Async }` body を渡すだけ。
-fn TaskGroup::spawn_suspend[T: Send](n: TaskGroup, f: () -> T with { Async }) -> TaskHandle[T]
+// caller は plain な closure body を渡すだけ。escaping Error::Throw は
+// Failed へ変換され fail-fast (parked sibling の自動 cancel) を起こす。
+fn TaskGroup::spawn_suspend[T: Send](n: TaskGroup, f: () -> T with { Async, Error }) -> TaskHandle[T]
 fn TaskGroup::pump(n: TaskGroup) -> Bool
 fn TaskGroup::pump_all(n: TaskGroup) -> Unit
 // blocking channel ops for suspendable tasks (suspend+retry; the

--- a/lib/@vibex/concurrent/suspend_test.vibe
+++ b/lib/@vibex/concurrent/suspend_test.vibe
@@ -281,6 +281,94 @@ test "a lone spawn_suspend task may yield three times without tripping the deadl
   })
 }
 
+// Fail-fast × suspendable (ADR-0068 次スライス): a spawn_suspend body
+// whose Error::Throw escapes converts to Failed, records the group's
+// first observed failure, and AUTO-CANCELS parked siblings (their stored
+// continuations are dropped). Case 1: the throw happens on the settle
+// leg (before any suspend) — the sibling parked first and never wakes.
+test "spawn_suspend Error on the settle leg fails fast and cancels the parked sibling" {
+  let out = TaskGroup::run((g) -> {
+    let ha = TaskGroup::spawn_suspend(g, () -> Int with { Async } {
+      let _w = perform Async::Suspend(0)
+      100
+    })
+    let hb = TaskGroup::spawn_suspend(g, () -> Int with { Async, Error } {
+      throw("boom")
+    })
+    TaskGroup::pump_all(g)
+    let a_cancelled = match TaskHandle::join(ha) {
+      Ok(_) => false,
+      Err(e) => match e {
+        Cancelled => true,
+        Failed(_) => false
+      }
+    }
+    let b_failed = match TaskHandle::join(hb) {
+      Ok(_) => false,
+      Err(e) => match e {
+        Cancelled => false,
+        Failed(m) => m == "boom"
+      }
+    }
+    if a_cancelled && b_failed {
+      1
+    } else {
+      0
+    }
+  })
+  assert(match out {
+    Ok(_) => false,
+    Err(e) => match e {
+      Failed(m) => m == "boom",
+      Cancelled => false
+    }
+  })
+}
+
+// Case 2: the throw happens on a RESUMED leg (after a suspend) — it runs
+// on the pump's stack, caught by the park wrapper's per-leg Error
+// boundary. The parked sibling is cancelled by the fail-fast sweep.
+test "spawn_suspend Error after a resume fails fast from the pump stack" {
+  let out = TaskGroup::run((g) -> {
+    let ha = TaskGroup::spawn_suspend(g, () -> Int with { Async, Error } {
+      let _w = perform Async::Suspend(0)
+      throw("later")
+    })
+    let hb = TaskGroup::spawn_suspend(g, () -> Int with { Async } {
+      let _w1 = perform Async::Suspend(0)
+      let _w2 = perform Async::Suspend(0)
+      200
+    })
+    TaskGroup::pump_all(g)
+    let a_failed = match TaskHandle::join(ha) {
+      Ok(_) => false,
+      Err(e) => match e {
+        Cancelled => false,
+        Failed(m) => m == "later"
+      }
+    }
+    let b_cancelled = match TaskHandle::join(hb) {
+      Ok(_) => false,
+      Err(e) => match e {
+        Cancelled => true,
+        Failed(_) => false
+      }
+    }
+    if a_failed && b_cancelled {
+      1
+    } else {
+      0
+    }
+  })
+  assert(match out {
+    Ok(_) => false,
+    Err(e) => match e {
+      Failed(m) => m == "later",
+      Cancelled => false
+    }
+  })
+}
+
 // Channel blocking (ADR-0076 追記31 の続きスライス): the shape the module
 // header called out as impossible under run-to-completion — a producer
 // overflowing a capacity-1 channel while the consumer drains — now works

--- a/lib/@vibex/concurrent/suspend_test.vibe
+++ b/lib/@vibex/concurrent/suspend_test.vibe
@@ -4,7 +4,7 @@ import ./concurrent.vibe {
   type TaskGroup, type TaskHandle, type TaskError, type TaskStep,
   type Channel, type Sender, type Receiver, type SendError, type ChannelConfigError,
   TaskGroup::run, TaskGroup::adopt, TaskGroup::pump, TaskGroup::pump_all,
-  TaskGroup::spawn_suspend,
+  TaskGroup::spawn, TaskGroup::spawn_suspend,
   TaskHandle::settle, TaskHandle::park, TaskHandle::park_poll, TaskHandle::wake,
   TaskHandle::join, TaskHandle::cancel,
   Channel::bounded, Sender::send, Sender::send_wait, Sender::release, Receiver::recv_wait
@@ -364,6 +364,31 @@ test "spawn_suspend Error after a resume fails fast from the pump stack" {
     Ok(_) => false,
     Err(e) => match e {
       Failed(m) => m == "later",
+      Cancelled => false
+    }
+  })
+}
+
+// #1115 Codex review: BOTH failure lanes must run the fail-fast sweep.
+// A run-to-completion spawn child throwing (dispatched by run's close
+// drive) cancels the parked suspendable sibling — without the shared
+// sweep the close-time terminal check would TRAP on the still-parked
+// cell instead of returning Err(Failed(...)).
+test "a spawn-lane failure cancels a parked spawn_suspend sibling" {
+  let out = TaskGroup::run((g) -> {
+    let ha = TaskGroup::spawn_suspend(g, () -> Int with { Async } {
+      let _w = perform Async::Suspend(0)
+      100
+    })
+    let _hb = TaskGroup::spawn(g, () -> Int with { Error } {
+      throw("spawn-lane")
+    })
+    7
+  })
+  assert(match out {
+    Ok(_) => false,
+    Err(e) => match e {
+      Failed(m) => m == "spawn-lane",
       Cancelled => false
     }
   })


### PR DESCRIPTION
## 概要

2 つの独立スライス。lib/@vibex + docs のみ (compiler 本体は不変)。

## 1. fail-fast × suspendable task の統合 (ADR-0068 次スライス)

`spawn_suspend` の body row を `{ Async, Error }` に拡張し、escape した `Error::Throw` を run-to-completion lane と同じ契約で処理する:

- **settle leg** (最初の suspend 前の throw): spawn_suspend 内の外側 Error handle が受ける。内側の Async handle は CPS 化済みで handler 越え resume が存在しないため、#543 の「resume が無関係な handler を跨ぐと miscompile」の罠は構造的に当たらない
- **resumed leg** (suspend 後の throw): pump の stack 上で走るため spawn_suspend 自身の handler では受からない — park wrapper に per-leg の Error boundary を追加
- **`conc_fail_cell`**: cell の Failed 化 + group の first-observed failure 記録 + **parked sibling の自動 cancel** (継続 drop = RC 解放) + progress 計上。pump_all は自然終了し、run は `Err(Failed(first))` を返す

テスト 2 件 (settle leg / resumed leg、sibling の Cancelled 変換と run の Err(Failed) を pin)。

## 2. ADR-0076 追記34: closure-value evidence の設計 (実装は次 PR)

調査 2 本 (evidence dict 受け渡しの実態 / closure layout 変更の blast radius) + 実測 (hof_escaping が本物の replay 実行であることを副作用 probe で確認 — handle body 再実行で M2 重複 hits=4) から設計を確定:

- **追記25 想定の env slot / hidden arg の ABI 変更は不要**。#1070 系 4 制約 (single-use / universal-call-site / no-value-ref / handle-confinement) は「同じ closure 値に 2 つの arity を与えられない」ことの回避 proof にすぎず、closure-CPS (追記31) と同じ**型主導・全域化** — row-E 関数型の値は literal / param / local / named-fn 参照とも一律 `__ev_E` 先頭引数 — で原理ごと消える
- env slot 方式は「dict は handle site 生成、closure は site の外で作られる」ため creation 時に evidence が存在せず棄却。hidden arg 方式は全 user fn / linked import の cross-module ABI を破壊し bootstrap seed と衝突するため棄却
- V1 = 型主導 total 化 + hof_escaping の evidence 移行 (値 206 不変、M2 重複解消を新 fixture で pin)、V2 = frontier 経路 (uses_frontier / counter・memo / eff_reserve) の物理削除

## 検証

#1112 (Binary size) の上に rebase 後、bundle regen → stage2 == stage3 fixpoint → unit battery 468/468 全通過 (regen 差分なし = compiler 不変の確認込み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe)_