### PR TITLE
#1109 follow-up: fix stale hosted compile cache + non-monotonic per-pass minify rounds (#1118 Codex review)

### DIFF
--- a/lib/@vibe/compiler/cli_direct_component_entry.vibe
+++ b/lib/@vibe/compiler/cli_direct_component_entry.vibe
@@ -279,8 +279,21 @@ export fn compile_cli_request(source: String, request: String) -> String {
   }
 }
 
+// The vfs's `stat-token` import is a stable per-path content token (see
+// docs/vibec-component.md). compile_cli_request's cache key is naturally
+// content-addressed (the source text IS part of the key), but this file
+// variant's content lives on the host, so folding stat_token(input_path)
+// into the key here means a long-lived hosted component that recompiles the
+// same path after the host edits it (the common browser-IDE case) gets a
+// fresh compile instead of a stale cached result from before the edit.
+// This covers edits to the entry file itself; edits to files it imports are
+// not tracked (would need the module resolver to report every path it
+// touched, which this entry point does not do).
 fn ensure_compiled_file(input_path: String, entry_name: String, mode: String) -> Int with { Error, Fs } {
-  let cache_key = cache_key_for(String::concat("file:", input_path), entry_name, mode)
+  let content_token = Fs::stat_token(input_path)
+  let cache_key = cache_key_for(
+    String::concat("file:", String::concat(__to_string(content_token), String::concat(":", input_path))),
+    entry_name, mode)
   if cache_key_matches(cache_key) {
     Array::get(cached_compile_len, 0)
   } else {

--- a/scripts/minify_wasm.sh
+++ b/scripts/minify_wasm.sh
@@ -79,13 +79,28 @@ round=1
 run_round "${KEEP_ARGS[*]:-}"
 size=$(wc -c <"$work/cur.wasm")
 echo "[minify-wasm] round 1: $prev -> $size"
+prev="$size"
 
-while [ "$size" -lt "$prev" ] && [ "$round" -lt "$MAX_ROUNDS" ]; do
-  prev="$size"
+# Each subsequent round must strictly shrink to be kept. With --per-pass a
+# single pass is allowed to grow (dce_auto etc. compare whole rounds, not
+# passes), so a complete round can come out equal-or-larger than what went
+# in; run_round already overwrote cur.wasm by the time we can check, so back
+# up before running and restore on a non-shrinking round instead of letting
+# it become the final output.
+while [ "$round" -lt "$MAX_ROUNDS" ]; do
+  cp "$work/cur.wasm" "$work/prev_round.wasm"
   round=$((round + 1))
   run_round ""
   size=$(wc -c <"$work/cur.wasm")
   echo "[minify-wasm] round $round: $prev -> $size"
+  if [ "$size" -ge "$prev" ]; then
+    mv "$work/prev_round.wasm" "$work/cur.wasm"
+    size="$prev"
+    round=$((round - 1))
+    echo "[minify-wasm] did not shrink further; keeping round $round's result"
+    break
+  fi
+  prev="$size"
 done
 
 cp "$work/cur.wasm" "$OUT"


### PR DESCRIPTION
#1118(#1109-1/#1109-2)がマージされた後に届いた Codex レビューの 2 件の指摘に対応。

## P1: hosted compile cache が VFS の内容変更を検知できない (`cli_direct_component_entry.vibe`)

`ensure_compiled_file` のキャッシュキーは `"file:" + input_path` のみで、パスの中身自体は含んでいなかった。長期稼働の hosted component(ブラウザ IDE 想定)が同じパスをホスト側で編集した後に再コンパイルしても、キーが変わらないため前回セッションの古いコンパイル結果を返し続けてしまう。

vfs の `stat-token` import(パスごとの安定コンテンツトークン、`docs/vibec-component.md` 参照)を `Fs::stat_token(input_path)` で取得しキーに畳み込むことで修正。`compile_cli_request` 側のキャッシュキーはソーステキスト自体を含むため元々コンテンツアドレスだったが、file 変体はコンテンツがホスト側にあるため同じ性質を stat-token で近似する形。

- entry file 自体の編集は検知できる(主要ケース)
- entry が import する他ファイルの編集検知は対象外(モジュールリゾルバが読み取ったパス全体を報告する仕組みが無く、この PR の範囲を超える。コメントで明記)

## P2: `minify_wasm.sh --per-pass` の非単調な収束 (`scripts/minify_wasm.sh`)

`--per-pass` は 1 パスが一時的に成長することを許容する設計(`dce_auto` などはラウンド単位で比較する)。しかしラウンド単位のループには、ラウンド全体が縮小しなかった場合の巻き戻しガードが無く、`run_round` が既に `cur.wasm` を上書きした後で判定していたため、非単調な(縮小しなかった)ラウンドの結果がそのまま最終出力になり得た。

ラウンド実行前に `cur.wasm` をバックアップし、縮小しなかった場合は前ラウンドの結果へ巻き戻すよう修正。収束は常に単調減少になる。

## 検証

- stage2==stage3 fixpoint `01f4dfc54e69`(このブランチの base である最新 main `b0a5b94` 上)
- `scripts/compiler_gate.sh` FAIL 0
- unit-test battery 3 shard 全 green(156+157+156)
- `scripts/build_vibec.sh`(pure/vfs 両面)ビルド成功、サイズは main のみの baseline と同一(本 PR の diff によるサイズ変化なし)
- P2 は実 corpus では成長ラウンドが発生しなかったため、`$RUN` をモックして成長ラウンドを人工的に発生させ、巻き戻しロジック単体を直接検証(round3 で+50B成長 → round2 の結果に正しくロールバックすることを確認)
- vfs jco PoC(`vibec_hosted_poc_driver.mjs`)は本 PR と無関係な pre-existing 環境要因(`exceptions proposal not enabled`)でブロック中 — 修正前の baseline でも同一エラーが再現するため、本 PR 由来ではないと確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_