### PR TITLE
runtime/vibe: fix non-monotonic --minify round loop (same class as #1122)

### DIFF
--- a/runtime/vibe
+++ b/runtime/vibe
@@ -613,17 +613,26 @@ case "$cmd" in
       # flag as its input path, so fall back to one in-process converge there.
       if grep -aq -- "--single-round" "$opt_wasm" 2>/dev/null; then
         mtmp="$(mktemp -t vibe-minify-XXXXXX.wasm)"
+        mback="$(mktemp -t vibe-minify-backup-XXXXXX.wasm)"
         mprev=$(wc -c <"$out")
         mrounds=0
+        # #1122: back up before each round and restore on a non-shrinking
+        # round instead of committing it to $out first and only then
+        # checking — a round that doesn't shrink must not become the final
+        # output (mirrors the same fix in scripts/minify_wasm.sh).
         while [ "$mrounds" -lt "${VIBE_MINIFY_MAX_ROUNDS:-16}" ]; do
-          "$RUNNER" "$opt_wasm" --single-round "$out" "$mtmp" >/dev/null || { rm -f "$mtmp"; die "--minify failed for $out"; }
+          cp "$out" "$mback"
+          "$RUNNER" "$opt_wasm" --single-round "$out" "$mtmp" >/dev/null || { rm -f "$mtmp" "$mback"; die "--minify failed for $out"; }
           msize=$(wc -c <"$mtmp")
-          mv "$mtmp" "$out"
           mrounds=$((mrounds + 1))
-          [ "$msize" -lt "$mprev" ] || break
+          if [ "$msize" -ge "$mprev" ]; then
+            mv "$mback" "$out"
+            break
+          fi
+          mv "$mtmp" "$out"
           mprev="$msize"
         done
-        rm -f "$mtmp"
+        rm -f "$mtmp" "$mback"
       else
         "$RUNNER" "$opt_wasm" "$out" "$out" || die "--minify failed for $out"
       fi


### PR DESCRIPTION
#1122(Codex レビュー対応)で `scripts/minify_wasm.sh` の非単調収束を修正した際、`runtime/vibe` の `vibe build --minify` 自身が持つ同じ round ループ(#1109 の round-per-process converge、`--single-round` の grep で feature-detect)には同じクラスのバグが残っていることに気づいたので修正。

## バグ

`vibe build --minify` のラウンドループは、各ラウンドの出力を「縮小したかどうか」判定する前に `$out` へ確定させていた:

```sh
"$RUNNER" "$opt_wasm" --single-round "$out" "$mtmp" >/dev/null || ...
msize=$(wc -c <"$mtmp")
mv "$mtmp" "$out"          # ← 判定前に確定
mrounds=$((mrounds + 1))
[ "$msize" -lt "$mprev" ] || break
```

縮小しなかったラウンド(または成長したラウンド)がそのまま最終出力になり得る。`minify_wasm.sh` 側は #1122 で修正したが、これは launcher 自身が持つ独立した同ロジックのコピーで対象外だった。

## 修正

ラウンド実行前に `$out` をバックアップし、縮小しなかった場合は前ラウンドの結果へ巻き戻す。`minify_wasm.sh` の修正と同じパターン。

## 検証

- cargo で `runtime/vibewt`(Rust runner)を実ビルドし、`vibe build --minify` をエンドツーエンドで実行(`examples/compiler_features.vibe`: 7805B → 1487B、stdout/exit code が非 minify 版と一致)
- `scripts/minify_gate.sh` ALL OK(7 プログラム全て意味論保存を確認)
- `scripts/compiler_gate.sh` FAIL 0
- 実 corpus では成長ラウンドが発生しなかったため、fake `vibewt` で round 3 を強制的に成長させて巻き戻しロジック単体を直接検証(round2 の結果が正しく保持されることを確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_