### PR TITLE
CI perf: cache build_cli_wasm.sh, drop wasmtime 45 leg, fix cargo mtime invalidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,46 +229,32 @@ jobs:
           if-no-files-found: ignore
 
   # WASI p3 guarantee (#821): vibe-built async components + the wasi:http p3
-  # serve pipeline must run on pinned wasmtime versions, with missing tools
-  # treated as FAILURES (no silent skip). Not yet folded into ci-required;
-  # promote once green for a week on the wasmtime 46 primary leg.
+  # serve pipeline must run on pinned wasmtime, with missing tools treated as
+  # FAILURES (no silent skip). Not yet folded into ci-required; promote once
+  # green for a week on the wasmtime 47 leg.
+  #
+  # Single leg, ratified WASI 0.3.0 (#821 cutover, done): the vendored WIT
+  # (lib/@vibe/wasi/wit/p3) was refreshed to wasi:http@0.3.0, matching what
+  # wasmtime 46+ serves by default (component-model-async on by default
+  # too). Both phases pass. A wasmtime 45.x compat leg (phase A / async only
+  # -- 45 only ever served the pre-cutover RC world, so it couldn't link
+  # phase B / http at all) was dropped once 47 had been the sole target
+  # everywhere else in this repo for a while; see git history if 45 compat
+  # ever needs re-checking.
   wasi-p3-gate:
-    name: wasi-p3-gate (wasmtime ${{ matrix.wasmtime }})
+    name: wasi-p3-gate (wasmtime v47.0.2)
     needs: [compiler-gate]
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Primary leg, ratified WASI 0.3.0 (#821 cutover, done): the
-          # vendored WIT (lib/@vibe/wasi/wit/p3) was refreshed to
-          # wasi:http@0.3.0, matching what wasmtime 46+ serves by default
-          # (component-model-async on by default too). Both phases pass.
-          - wasmtime: v47.0.2
-            phases: "async,http"
-          # Compat leg: wasmtime 45.x only ever served the RC world
-          # (wasi:http@0.3.0-rc-2026-03-15), which the repo no longer
-          # vendors post-cutover, so phase B (http) cannot link against it
-          # any more (mirrors the "resource implementation is missing"
-          # failure 46 used to hit against the RC world pre-cutover).
-          # Phase A (async component vertical) doesn't touch the wasi:http
-          # WIT at all, so it still passes unchanged with the wasmtime 45 RC
-          # flag set — kept as a smoke test that the async component path
-          # doesn't regress on the older runtime during the wasmtime 46
-          # rollout. Drop this leg once 46 has been the sole target for a
-          # while and 45 compat is no longer a concern.
-          - wasmtime: v45.0.2
-            phases: "async"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-      - name: Install wasmtime ${{ matrix.wasmtime }}
+      - name: Install wasmtime v47.0.2
         run: |
           set -euo pipefail
-          dir="wasmtime-${{ matrix.wasmtime }}-x86_64-linux"
-          curl -sSL "https://github.com/bytecodealliance/wasmtime/releases/download/${{ matrix.wasmtime }}/${dir}.tar.xz" | tar -xJ
+          dir="wasmtime-v47.0.2-x86_64-linux"
+          curl -sSL "https://github.com/bytecodealliance/wasmtime/releases/download/v47.0.2/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Install wasm-tools / wac
         # Prebuilt release binaries (validated versions; cargo install is the
@@ -306,7 +292,7 @@ jobs:
       - name: WASI p3 guarantee gate
         env:
           VIBE_P3_GATE_REQUIRE_TOOLS: "1"
-          VIBE_P3_GATE_PHASES: ${{ matrix.phases }}
+          VIBE_P3_GATE_PHASES: "async,http"
           VIBE_ASYNC_GATE_COMPILER: ${{ github.workspace }}/_build/ci-artifacts/stage2.wasm
           VIBE_SERVE_CLI_WASM: ${{ github.workspace }}/_build/ci-artifacts/stage2.wasm
         run: bash scripts/test_wasi_p3_guarantee_gate.sh

--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -141,16 +141,19 @@ jobs:
         with:
           node-version: "22"
 
+      # Swatinem/rust-cache, not a raw actions/cache path list: a plain
+      # actions/cache restore of runtime/vibewt/target keeps the archived
+      # mtimes from whenever the cache was saved, while actions/checkout
+      # (which runs before this step) resets every source file to the
+      # current checkout time -- cargo's fingerprinting sees "source newer
+      # than build output" and recompiles the entire dependency tree on
+      # every run regardless of cache hit/miss. rust-cache normalizes this
+      # (and dedupes registry/target caching by Cargo.lock hash) so a real
+      # cache hit is actually incremental.
       - name: Cache cargo + runner build
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            runtime/vibewt/target
-          key: cli-install-cargo-${{ matrix.os }}-${{ hashFiles('runtime/vibewt/Cargo.lock', 'runtime/vibewt/src/**') }}
-          restore-keys: |
-            cli-install-cargo-${{ matrix.os }}-
+          workspaces: runtime/vibewt
 
       - name: Cache seed artifact
         uses: actions/cache@v4

--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -158,6 +158,20 @@ jobs:
           path: bootstrap/seed/compiler.wasm
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
 
+      # scripts/build_cli_wasm.sh's own content-fingerprint cache (git tree
+      # hash of lib/ + the seed pin) lives under _build/cli_wasm_cache/ --
+      # persisting it here means every group in the smoke matrix below that
+      # calls build_cli_wasm.sh (directly or via install.sh) gets a cache hit
+      # instead of a full seed->stage1->stage2 rebuild whenever lib/ and the
+      # seed pin are unchanged since the last run on this branch. Within the
+      # `debug` group alone this used to mean 7 back-to-back full rebuilds
+      # for byte-identical output.
+      - name: Cache built CLI wasm
+        uses: actions/cache@v4
+        with:
+          path: _build/cli_wasm_cache
+          key: cli-wasm-${{ matrix.os }}-${{ hashFiles('lib/**', 'bootstrap/seed.json') }}
+
       - name: Ensure seed artifact
         # bootstrap/seed/compiler.wasm is a local build cache (gitignored,
         # not git-tracked) — the fresh-compiler build below needs it.

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -60,15 +60,15 @@ jobs:
         run: |
           VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
             bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      # See cli-install.yml's "Cache cargo + runner build" step for why this
+      # is Swatinem/rust-cache rather than a raw actions/cache path list: a
+      # plain restore keeps archived mtimes older than the fresh checkout's,
+      # so cargo re-fingerprints (and recompiles) the whole dependency tree
+      # even on a cache hit.
       - name: Cache vibewt build
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            runtime/vibewt/target
-          key: vibewt-v1-${{ hashFiles('runtime/vibewt/Cargo.lock', 'runtime/vibewt/Cargo.toml', 'runtime/vibewt/src/**') }}
-          restore-keys: vibewt-v1-
+          workspaces: runtime/vibewt
       - name: Build vibewt (micro-bench runtime)
         run: cargo build --release --manifest-path runtime/vibewt/Cargo.toml
       - name: Collect metrics

--- a/scripts/build_cli_wasm.sh
+++ b/scripts/build_cli_wasm.sh
@@ -5,6 +5,19 @@
 # AOT-compiles to a host-specific `.cwasm` (docs/release-roadmap.md テーマ1).
 #
 #   bash scripts/build_cli_wasm.sh [out.wasm]   # default: dist/cli/vibe-cli.wasm
+#
+# Content-fingerprint cache: stage0(seed)->stage1->stage2 is deterministic for
+# a fixed (seed, lib/@vibe/**) pair (docs/bootstrap.md), so a rebuild against
+# an unchanged tree just reproduces the same bytes. install.sh and every
+# scripts/test_vibe_*.sh debugger/profiler smoke test call this script fresh
+# per-invocation with no coordination between them -- in a single CI job that
+# runs several of those sequentially (e.g. the `debug` smoke group's 7
+# scripts), this used to mean 7 full seed->stage1->stage2 builds back to back
+# for byte-identical output. Cache the stage2 artifact keyed on the git tree
+# hash of `lib` + the seed pin; skip caching entirely (never a correctness
+# risk, just no speedup) when either has uncommitted changes, since `HEAD:`
+# tree hashing can't see working-tree edits. Opt out with
+# VIBE_BUILD_CLI_WASM_NO_CACHE=1.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -12,6 +25,39 @@ cd "$ROOT_DIR"
 
 out="${1:-$ROOT_DIR/dist/cli/vibe-cli.wasm}"
 mkdir -p "$(dirname "$out")"
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# Prints a cache key on stdout and exits 0, or exits 1 (no output) if the
+# tree is dirty / not a git checkout -- caller treats that as "don't cache".
+cache_key() {
+  [ "${VIBE_BUILD_CLI_WASM_NO_CACHE:-0}" != "1" ] || return 1
+  git rev-parse --git-dir >/dev/null 2>&1 || return 1
+  [ -z "$(git status --porcelain -- lib bootstrap/seed.json 2>/dev/null)" ] || return 1
+  local lib_tree seed_hash
+  lib_tree="$(git rev-parse HEAD:lib 2>/dev/null)" || return 1
+  seed_hash="$(sha256_file bootstrap/seed.json)" || return 1
+  printf '%s-%s\n' "$lib_tree" "$seed_hash"
+}
+
+cache_dir="${VIBE_BUILD_CLI_WASM_CACHE_DIR:-$ROOT_DIR/_build/cli_wasm_cache}"
+if key="$(cache_key)"; then
+  cached="$cache_dir/$key.wasm"
+  if [ -s "$cached" ]; then
+    cp "$cached" "$out"
+    echo "[build-cli-wasm] cache hit ($key): reused $cached -> $out ($(wc -c <"$out") bytes)" >&2
+    printf '%s\n' "$out"
+    exit 0
+  fi
+else
+  key=""
+fi
 
 echo "[build-cli-wasm] building selfhost compiler (seed -> stage1 -> stage2)…" >&2
 bash scripts/generations.sh build >/dev/null
@@ -23,5 +69,9 @@ gen="$(ls -dt _build/selfhost/generations/*/ 2>/dev/null | head -1 || true)"
 }
 
 cp "${gen}stage2.wasm" "$out"
+if [ -n "$key" ]; then
+  mkdir -p "$cache_dir"
+  cp "$out" "$cache_dir/$key.wasm"
+fi
 echo "[build-cli-wasm] wrote $out ($(wc -c <"$out") bytes)" >&2
 printf '%s\n' "$out"


### PR DESCRIPTION
## Summary

Three CI/build performance fixes, in two commits:

**1. `perf: cache build_cli_wasm.sh's seed->stage1->stage2 build by content fingerprint`**

`scripts/build_cli_wasm.sh` (a full `seed -> stage1 -> stage2` selfhost compiler build) had no caching and was called fresh, uncoordinated, by `install.sh` and 6 of the 7 `scripts/test_vibe_*.sh` debugger smoke tests. The `cli-install.yml` `debug` smoke group ran **7 back-to-back full builds producing byte-identical output**, taking ~8min against its ~3min siblings. Fixed by caching the stage2 artifact keyed on the git tree hash of `lib` + the seed pin (deterministic for a fixed (seed, source) pair per `docs/bootstrap.md`); falls back to always-rebuild when `lib/`/`bootstrap/seed.json` have uncommitted changes. Also added an `actions/cache` step so the cache persists across CI runs, not just within one job.

**2. `CI: drop the wasmtime 45 compat leg, fix cargo cache mtime invalidation`**

- `wasi-p3-gate`'s wasmtime 45.x compat leg was a temporary smoke test kept during the wasmtime 46 rollout. wasmtime 47.0.2 has been the sole target everywhere else in this repo since #1090, so the leg's own stated removal criterion is met — collapsed the matrix to the single primary leg. Doesn't change CI wall-clock (matrix legs ran in parallel, ~30s each), just trims a redundant job.
- `cli-install.yml`'s and `perf.yml`'s `cargo build --release` steps were fully recompiling the whole dependency tree (~2m40s) on **every** run despite their `actions/cache` step reporting a hit. Root cause: a raw `actions/cache` restore of `runtime/vibewt/target` keeps the mtimes from whenever the cache was saved, but `actions/checkout` (which runs first) resets every source file to the current checkout time — cargo's mtime-based fingerprinting sees "source newer than build output" and recompiles everything regardless of cache hit/miss. Swapped both to `Swatinem/rust-cache@v2`, purpose-built to avoid exactly this.

## Test plan

- [x] `build_cli_wasm.sh` twice against an unchanged tree: first call ~92s, second ~0.04s, byte-identical output
- [x] `scripts/test_vibe_trace.sh` (cold, ~82s) then `scripts/test_vibe_trace_calls.sh` (cache hit, ~1.5s) back to back — both passed
- [x] Confirmed via CI job logs that the cargo cache mtime issue is real: `Cache hit for: cli-install-cargo-ubuntu-latest-...` immediately followed by `Compiling proc-macro2 v1.0.106` ... `Compiling vibewt v0.1.0` ... `Finished release profile [optimized] target(s) in 2m 39s` — the full dependency tree, every run
- [x] Checked every other caller of `build_cli_wasm.sh` for reliance on it being uncached — none found
- [x] YAML syntax validated for all three edited workflow files
