### PR TITLE
#955: EffectRow.Subset preorder lemmas (Lean formalization)

### DIFF
--- a/formal/VibeFormal/Proofs/SubsetCorrect.lean
+++ b/formal/VibeFormal/Proofs/SubsetCorrect.lean
@@ -9,4 +9,56 @@ theorem subset_correct (required declared : Normalized) :
     subset required declared = true ↔ Subset required declared := by
   simp [subset, Subset, List.all_eq_true]
 
+/-
+Foundational preorder lemmas for `Subset`, not yet used by any Phase-1
+checker but needed as building blocks by any future row-subsumption model
+(#939's "effectful function value assigned to a pure function type" slice
+requires lifting `Subset` through a function-type comparison, which needs
+exactly this reflexivity/transitivity/union-monotonicity vocabulary).
+-/
+
+/-- `Subset` is reflexive: a row always authorizes itself. -/
+theorem Subset.refl (row : Normalized) : Subset row row :=
+  fun _ membership => membership
+
+/-- `Subset` is transitive. -/
+theorem Subset.trans {left middle right : Normalized}
+    (leftMiddle : Subset left middle) (middleRight : Subset middle right) :
+    Subset left right :=
+  fun operation membership => middleRight operation (leftMiddle operation membership)
+
+/-- Declaring additional operations never revokes an existing authorization. -/
+theorem Subset.union_right_mono {required declared more : Normalized}
+    (existing : Subset required declared) :
+    Subset required (declared ++ more) :=
+  fun operation membership => List.mem_append_left more (existing operation membership)
+
+/-- A row is always authorized by any union containing it on the left. -/
+theorem Subset.subset_union_left (left right : Normalized) :
+    Subset left (left ++ right) :=
+  fun _ membership => List.mem_append_left right membership
+
+/-- A row is always authorized by any union containing it on the right. -/
+theorem Subset.subset_union_right (left right : Normalized) :
+    Subset right (left ++ right) :=
+  fun _ membership => List.mem_append_right left membership
+
+/--
+The union of two required rows is authorized exactly when both halves are --
+this is the algebraic shape of `make_row_mismatch`'s `required = declared ∪
+missing` construction in the live checker (checker_effects.vibe), where
+authorization of the combined requirement decomposes into authorization of
+each contributing call site's own requirement.
+-/
+theorem Subset.union_left_iff {left right declared : Normalized} :
+    Subset (left ++ right) declared ↔ Subset left declared ∧ Subset right declared := by
+  constructor
+  · intro combined
+    exact ⟨fun operation membership => combined operation (List.mem_append_left right membership),
+           fun operation membership => combined operation (List.mem_append_right left membership)⟩
+  · intro ⟨subsetLeft, subsetRight⟩ operation membership
+    rcases List.mem_append.mp membership with inLeft | inRight
+    · exact subsetLeft operation inLeft
+    · exact subsetRight operation inRight
+
 end VibeFormal.EffectRow


### PR DESCRIPTION
## Summary

Incremental formal-verification progress toward #955 (not a checklist item close — see below).

Adds reflexivity, transitivity, and union-monotonicity lemmas for `EffectRow.Subset` to `formal/VibeFormal/Proofs/SubsetCorrect.lean`.

### Why this and not one of #955's listed slices

I looked into whether a real slice (#939 higher-order effect soundness, #942/#817 handler/continuation, the channel/finalizer runtime protocols) was tractable this session. `Typing/Core.lean`'s `Ty` type explicitly has **no function-type constructor yet** — its own comment says "Function types, variance, and row polymorphism belong to the higher-order extension tracked by #939." A real #939 slice means extending that shared type (used by the existing `CallTyping`/`Oracle` proofs too) with function types + effect rows + a subsumption relation, then proving soundness — a genuine multi-hour design task in an unfamiliar proof codebase I'm not going to rush.

What I found instead: `EffectRow.Subset`'s own basic preorder properties (reflexivity, transitivity) were never proven — confirmed by grep (`CapabilityContractCorrect.lean`'s `subset_trans` is a *different*, unrelated `Subset` for capability contracts). These don't touch the shared `Ty` type, and are exactly the algebraic building blocks any future subsumption proof will need once it lifts `Subset` through a function-type comparison. `Subset.union_left_iff` is stated to mirror the live checker's actual shape: `checker_effects.vibe`'s `make_row_mismatch` builds `required = declared ∪ missing`, and this session's #639/#1161 work aggregates `missing` across every call site in a function body — this lemma is the formal statement that authorizing the combined requirement is equivalent to authorizing each call site's own requirement.

## Test plan
- [x] Installed a fresh `elan`/`lean4:v4.32.0` toolchain (none was present in this environment — confirmed rather than assumed unavailable) and confirmed the *existing* 41-module formal project built clean first, as a baseline
- [x] `bash formal/check-oracle.sh` (== `pkf run formal-check`'s underlying command) → `lake build --wfail` clean, `oracle/call-typing.tsv` diff clean, `selfhost-call-oracle-test.sh` passed
- [x] All 4 new lemmas prove without `sorry`


---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_