### PR TITLE
#955: EffectRow.Equivalent equivalence-relation lemmas (Lean formalization)

### DIFF
--- a/formal/VibeFormal/Proofs/SubsetCorrect.lean
+++ b/formal/VibeFormal/Proofs/SubsetCorrect.lean
@@ -61,4 +61,42 @@ theorem Subset.union_left_iff {left right declared : Normalized} :
     · exact subsetLeft operation inLeft
     · exact subsetRight operation inRight
 
+/-
+`Equivalent` (Row.lean) is used by `NormalizeCorrect.lean` to state that
+`normalize` preserves meaning, but had no algebraic lemmas of its own --
+this closes the same preorder-to-partial-order gap the `Subset` lemmas
+above set up but didn't finish: `Subset.antisymm` is the standard
+"mutual Subset implies Equivalent" fact, and needs `Equivalent` to
+actually be an equivalence relation to be useful downstream.
+-/
+
+/-- `Equivalent` is reflexive: a row always denotes the same operations as itself. -/
+theorem Equivalent.refl (row : Normalized) : Equivalent row row :=
+  fun _ => Iff.rfl
+
+/-- `Equivalent` is symmetric. -/
+theorem Equivalent.symm {left right : Normalized} (h : Equivalent left right) :
+    Equivalent right left :=
+  fun operation => (h operation).symm
+
+/-- `Equivalent` is transitive. -/
+theorem Equivalent.trans {left middle right : Normalized}
+    (leftMiddle : Equivalent left middle) (middleRight : Equivalent middle right) :
+    Equivalent left right :=
+  fun operation => (leftMiddle operation).trans (middleRight operation)
+
+/--
+`Subset` is antisymmetric up to `Equivalent`: two rows that each authorize
+the other denote the same operation set. This is the standard closing
+lemma that promotes the `Subset` preorder (`refl`/`trans` above) to a
+partial order, and is exactly what a future row-subsumption proof needs
+to conclude two effect rows are interchangeable rather than merely
+mutually-authorizing.
+-/
+theorem Subset.antisymm {left right : Normalized}
+    (leftRight : Subset left right) (rightLeft : Subset right left) :
+    Equivalent left right :=
+  fun operation => ⟨fun membership => leftRight operation membership,
+                     fun membership => rightLeft operation membership⟩
+
 end VibeFormal.EffectRow


### PR DESCRIPTION
## Summary

Incremental formal-verification progress toward #955 (not a checklist item close — see #1165 for the same framing). Follow-up to #1165's `EffectRow.Subset` preorder lemmas.

`Equivalent` (`formal/VibeFormal/Effect/Row.lean`) is already used by `NormalizeCorrect.lean` to state that `normalize` preserves meaning, but had no algebraic lemmas of its own. This adds:
- `Equivalent.refl` / `Equivalent.symm` / `Equivalent.trans` — it's genuinely an equivalence relation, not just a definition, and nothing had proven that.
- `Subset.antisymm` — the standard "mutual `Subset` implies `Equivalent`" fact, promoting the `Subset` preorder #1165 introduced (`refl`/`trans`) into a partial order.

This is exactly what a future row-subsumption proof (#939's function-type-effect-row lifting) would need to conclude two effect rows are *interchangeable*, not merely mutually-authorizing — the same building-block framing #1165 used for its own lemmas.

No new modeling, no changes to the shared `Ty` type — purely completing the algebraic vocabulary #1165 already set up, using definitions already present in `Row.lean`.

## Test plan
- [x] `bash formal/check-oracle.sh` (== `pkf run formal-check`'s underlying command) → `lake build --wfail` clean (41 modules), `oracle/call-typing.tsv` diff clean, `selfhost-call-oracle-test.sh` passed
- [x] All 4 new lemmas prove without `sorry`


---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_