### PR TITLE
#955: Subset-Equivalent congruence lemmas (Lean formalization)

### DIFF
--- a/formal/VibeFormal/Proofs/SubsetCorrect.lean
+++ b/formal/VibeFormal/Proofs/SubsetCorrect.lean
@@ -99,4 +99,26 @@ theorem Subset.antisymm {left right : Normalized}
   fun operation => ⟨fun membership => leftRight operation membership,
                      fun membership => rightLeft operation membership⟩
 
+/-
+`Subset` and `Equivalent` were each closed as their own relations (preorder,
+equivalence) by the lemmas above, but nothing connected them: substituting
+an equivalent row on either side of a `Subset` fact was not yet provable.
+This is exactly the operation a future row-subsumption proof needs when it
+normalizes/simplifies one side of a `Subset` obligation (e.g. via
+`ClosedRow.normalize_extensional` in `NormalizeCorrect.lean`) and must
+carry an existing `Subset` fact across that rewrite.
+-/
+
+/-- `Subset`'s left (required) side can be replaced by an equivalent row. -/
+theorem Subset.congr_left {left left' declared : Normalized}
+    (equiv : Equivalent left left') (subset : Subset left declared) :
+    Subset left' declared :=
+  fun operation membership => subset operation ((equiv operation).mpr membership)
+
+/-- `Subset`'s right (declared) side can be replaced by an equivalent row. -/
+theorem Subset.congr_right {required declared declared' : Normalized}
+    (equiv : Equivalent declared declared') (subset : Subset required declared) :
+    Subset required declared' :=
+  fun operation membership => (equiv operation).mp (subset operation membership)
+
 end VibeFormal.EffectRow


### PR DESCRIPTION
## Summary

Incremental formal-verification progress toward #955 (not a checklist item close — see #1165/#1166 for the same framing). Follow-up to #1165 (`Subset` preorder) and #1166 (`Equivalent` equivalence relation).

`Subset` and `Equivalent` were each closed as their own relations, but nothing connected them: substituting an equivalent row on either side of a `Subset` fact was not provable. Adds:
- `Subset.congr_left`: the required side of a `Subset` fact can be replaced by an equivalent row
- `Subset.congr_right`: the declared side of a `Subset` fact can be replaced by an equivalent row

This is exactly what a future row-subsumption proof needs when it normalizes/simplifies one side of a `Subset` obligation (e.g. via `NormalizeCorrect.lean`'s `ClosedRow.normalize_extensional`) and must carry an existing `Subset` fact across that rewrite.

No new modeling, no changes to the shared `Ty` type — purely completing the algebraic vocabulary #1165/#1166 already set up, using definitions already present in `Row.lean`.

## Test plan
- [x] `bash formal/check-oracle.sh` (== `pkf run formal-check`'s underlying command) → `lake build --wfail` clean (41 modules), `oracle/call-typing.tsv` diff clean, `selfhost-call-oracle-test.sh` passed
- [x] Both new lemmas prove without `sorry`


---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_