### PR TITLE
#1168: parallelize --jobs discovery loop (was fully serial)

### DIFF
--- a/docs/compiler-parallelism.md
+++ b/docs/compiler-parallelism.md
@@ -562,8 +562,21 @@ It requires Node (the coordinator uses `worker_threads`) even when the
 installed toolchain's own runner is the Rust `vibewt`, so it is scoped to a
 dev checkout of this repo — see the "Shared-everything migration note" below
 and #1143 for the broader runtime-portability question this leaves open.
-Discovery still pays one `vibe` subprocess launch per file
-(`VIBE_LIST_DEPS`); the persistent-cache write itself is still a direct
+Discovery still pays one `vibe` subprocess launch per file (`VIBE_LIST_DEPS`),
+but as of #1168 that discovery walk itself runs with up to `jobs` files in
+flight at once (`mapWithConcurrency` in `scripts/parallel_frontend_warm.mjs`,
+one BFS level/frontier at a time) rather than fully serially. Measured
+against the compiler's own manifest (~209 modules, 4-core sandbox,
+2026-07-28): parallelizing discovery alone cuts `--jobs 4` cold wall time
+from 21601ms to 10977ms (-49%), and `--jobs 2` from 21072ms to 15627ms
+(-26%); crucially, wall time now actually scales down as `jobs` increases
+(10977ms at 4 workers vs 15627ms at 2), which the fully-serial discovery
+loop never did (it cost the same regardless of `jobs`). It is still slower
+than the plain serial baseline (~5.5s) at this project size — discovery-loop
+parallelism narrows the gap, it does not close it — so this alone does not
+change the "default worker count stays at 1" decision; see the KPI note
+below for the fuller picture including the persistent-cache benefit. The
+persistent-cache write itself is still a direct
 `Fs::write_file`; `--jobs` does not add a temp-file+rename step, so two
 concurrent `vibe build --jobs` invocations racing on the same fingerprint is
 the same pre-existing hazard the Cache publication section above already

--- a/scripts/parallel_frontend_warm.mjs
+++ b/scripts/parallel_frontend_warm.mjs
@@ -74,32 +74,69 @@ async function listDeps(runnerPath, compilerWasm, cacheDir, projectRoot, filePat
   return text.split("\n").map((line) => line.trim()).filter(Boolean);
 }
 
-// BFS from a single entry file, deduping by resolved path across the whole
-// walk (a diamond dependency must not be scheduled twice) -- mirrors
-// parallel_project_driver.mjs's discoverProject, parameterized by
-// projectRoot/runnerPath instead of this repo's own fixed layout.
-async function discoverProject(runnerPath, compilerWasm, projectRoot, entryPaths, cacheDir) {
+// Run `fn` over every item in `items`, at most `concurrency` in flight at
+// once, preserving no particular completion order (callers only need the
+// full result set, not ordering). A plain worker-pool loop rather than a
+// library dependency, since this script has none today.
+async function mapWithConcurrency(items, concurrency, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.max(1, Math.min(concurrency, items.length)) }, worker),
+  );
+  return results;
+}
+
+// Level-order BFS from a single entry file, deduping by resolved path
+// across the whole walk (a diamond dependency must not be scheduled twice)
+// -- mirrors parallel_project_driver.mjs's discoverProject, parameterized
+// by projectRoot/runnerPath instead of this repo's own fixed layout.
+//
+// Each BFS level (frontier) is discovered with up to `concurrency` files
+// in flight at once, instead of one `vibe --invoke cli_main` subprocess
+// spawn awaited fully before the next starts. On a project the size of
+// the compiler's own manifest (~209 modules) the fully-serial version
+// measured ~4x the plain serial-compile wall time, dominated entirely by
+// this discovery loop and independent of the later parallel-check phase's
+// own `jobs` count (#1168). Concurrency here reuses that same `jobs`
+// value: at `jobs=1` this reduces to the original one-at-a-time walk
+// (`Math.max(1, ...)` above), so a `jobs=1` run's discovery cost is
+// unchanged.
+async function discoverProject(runnerPath, compilerWasm, projectRoot, entryPaths, cacheDir, concurrency) {
   const modules = new Map();
   const seen = new Set(entryPaths);
-  const queue = [...entryPaths];
-  while (queue.length > 0) {
-    const path = queue.shift();
-    const [deps, source] = await Promise.all([
-      listDeps(runnerPath, compilerWasm, cacheDir, projectRoot, path),
-      readFile(path, "utf8"),
-    ]);
-    modules.set(path, {
-      id: path,
-      dependencies: [...new Set(deps)],
-      dependencyOccurrences: deps,
-      source,
+  let frontier = [...entryPaths];
+  while (frontier.length > 0) {
+    const discovered = await mapWithConcurrency(frontier, concurrency, async (path) => {
+      const [deps, source] = await Promise.all([
+        listDeps(runnerPath, compilerWasm, cacheDir, projectRoot, path),
+        readFile(path, "utf8"),
+      ]);
+      return { path, deps, source };
     });
-    for (const dep of deps) {
-      if (!seen.has(dep)) {
-        seen.add(dep);
-        queue.push(dep);
+    const nextFrontier = [];
+    for (const { path, deps, source } of discovered) {
+      modules.set(path, {
+        id: path,
+        dependencies: [...new Set(deps)],
+        dependencyOccurrences: deps,
+        source,
+      });
+      for (const dep of deps) {
+        if (!seen.has(dep)) {
+          seen.add(dep);
+          nextFrontier.push(dep);
+        }
       }
     }
+    frontier = nextFrontier;
   }
   return [...modules.values()];
 }
@@ -156,7 +193,7 @@ async function main() {
   const cacheDir = await mkdtemp(join(tmpdir(), "vibe-list-deps-"));
   let modules;
   try {
-    modules = await discoverProject(runnerPath, compilerWasm, projectRoot, [entryFile], cacheDir);
+    modules = await discoverProject(runnerPath, compilerWasm, projectRoot, [entryFile], cacheDir, jobs);
   } finally {
     await rm(cacheDir, { recursive: true, force: true });
   }

--- a/scripts/parallel_frontend_warm.mjs
+++ b/scripts/parallel_frontend_warm.mjs
@@ -54,8 +54,18 @@ async function readIfPresent(path) {
   }
 }
 
-async function listDeps(runnerPath, compilerWasm, cacheDir, projectRoot, filePath) {
-  const outAbs = join(cacheDir, `${filePath.replace(/[^a-zA-Z0-9]/g, "_")}.deps.out`);
+// `uniqueId` disambiguates the on-disk .deps.out/.diag path: the sanitized
+// filePath alone can collide (e.g. this repo's own checker_builtins.vibe
+// vs checker/builtins.vibe both sanitize to checker_builtins_vibe) --
+// harmless when listDeps calls were strictly sequential, but with
+// discoverProject now running several concurrently (#1168), two colliding
+// in-flight calls would race on the same temp file and let one module
+// silently consume another's dependency list or diagnostic (Codex review,
+// PR #1170). The caller passes a per-call monotonic counter so every
+// listDeps invocation in a given cacheDir gets a distinct path regardless
+// of filename collisions.
+async function listDeps(runnerPath, compilerWasm, cacheDir, projectRoot, filePath, uniqueId) {
+  const outAbs = join(cacheDir, `${uniqueId}_${filePath.replace(/[^a-zA-Z0-9]/g, "_")}.deps.out`);
   await rm(outAbs, { force: true });
   await rm(`${outAbs}.diag`, { force: true });
   const exitCode = await runVibe(
@@ -78,6 +88,17 @@ async function listDeps(runnerPath, compilerWasm, cacheDir, projectRoot, filePat
 // once, preserving no particular completion order (callers only need the
 // full result set, not ordering). A plain worker-pool loop rather than a
 // library dependency, since this script has none today.
+//
+// Uses allSettled, not Promise.all: a worker whose `fn` throws stops
+// pulling new items, but other workers keep draining the shared queue via
+// `next`, and every already-spawned subprocess (runVibe's child_process)
+// is awaited to completion inside its own worker's loop either way. If we
+// instead let one rejection short-circuit via Promise.all, main()'s catch
+// would call process.exit(1) while other workers' in-flight `runVibe`
+// subprocesses are still running -- Node does not kill spawned children on
+// process.exit, so they'd become orphans still writing into a cacheDir the
+// caller is about to rm -rf (Codex review, PR #1170). Waiting for every
+// worker to settle first means no subprocess is ever abandoned mid-flight.
 async function mapWithConcurrency(items, concurrency, fn) {
   const results = new Array(items.length);
   let next = 0;
@@ -88,9 +109,11 @@ async function mapWithConcurrency(items, concurrency, fn) {
       results[i] = await fn(items[i], i);
     }
   }
-  await Promise.all(
+  const settled = await Promise.allSettled(
     Array.from({ length: Math.max(1, Math.min(concurrency, items.length)) }, worker),
   );
+  const failure = settled.find((r) => r.status === "rejected");
+  if (failure) throw failure.reason;
   return results;
 }
 
@@ -113,10 +136,12 @@ async function discoverProject(runnerPath, compilerWasm, projectRoot, entryPaths
   const modules = new Map();
   const seen = new Set(entryPaths);
   let frontier = [...entryPaths];
+  let nextUniqueId = 0;
   while (frontier.length > 0) {
     const discovered = await mapWithConcurrency(frontier, concurrency, async (path) => {
+      const uniqueId = nextUniqueId++;
       const [deps, source] = await Promise.all([
-        listDeps(runnerPath, compilerWasm, cacheDir, projectRoot, path),
+        listDeps(runnerPath, compilerWasm, cacheDir, projectRoot, path, uniqueId),
         readFile(path, "utf8"),
       ]);
       return { path, deps, source };


### PR DESCRIPTION
## Summary

Fixes the first of two root causes filed in #1168 (itself found while measuring `--jobs N` KPI in #1169): `discoverProject()` in `scripts/parallel_frontend_warm.mjs` walked the import DAG with a **strictly serial** BFS loop — one `vibe` subprocess spawn (bash + node + wasmtime startup) per file, fully sequential and independent of the `jobs` value, before any parallel checking even started. On the compiler's own manifest (~209 modules) this dominated wall time and made `--jobs 2/4` ~4x slower than plain serial compile.

- Adds `mapWithConcurrency()`, a small worker-pool helper (no new dependency).
- Rewrites `discoverProject()` as level-order BFS: each frontier is discovered with up to `jobs` files in flight, instead of one at a time. `jobs=1` still reduces to the original one-at-a-time walk, so the serial baseline's discovery cost is unchanged.

## Measured impact

Same compiler-manifest input as #1169's KPI table (`lib/@vibe/compiler/cli_support.vibe`, ~209 modules, 4-core sandbox):

| jobs | cold wall_ms before | cold wall_ms after | Δ |
|---|---:|---:|---|
| 2 | 21072 | 15627 | -26% |
| 4 | 21601 | 10977 | -49% |

Wall time now scales down as `jobs` increases (10977ms @ 4 workers vs 15627ms @ 2) — before this fix, `jobs=2` and `jobs=4` cost the same, which was the tell that discovery (not the checking phase) was the bottleneck.

**Still slower than the ~5.5s serial baseline at this project size** — this narrows the gap, it doesn't close it. The default worker count decision recorded in `docs/compiler-parallelism.md` (stay at 1) is unchanged; the doc is updated with these numbers and that framing.

The second item from #1168 — ~84% of the compiler's own modules coming back `diagnosed` rather than `checked` under the job-dir sandbox at this scale — is **not** addressed here and remains open on that issue.

## Test plan

- [x] `bash scripts/test_parallel_frontend_warm.sh` — byte-identical Wasm + diagnostic-equality oracle for `--jobs`, unmodified and still green.
- [x] `scripts/jobs_kpi.sh` against `lib/@vibe/compiler/cli_support.vibe` at `jobs={1,2,4}`, before/after this change, to produce the table above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe)_