### PR TITLE
#906: make vibewt's Fs::write_file/write_bytes atomic (temp+rename)

### DIFF
--- a/runtime/vibewt/src/main.rs
+++ b/runtime/vibewt/src/main.rs
@@ -1506,6 +1506,37 @@ fn vibe_ensure_parent_dir(path: &str) {
     }
 }
 
+// Guest Fs::write_file / Fs::write_bytes land here. Write via a same-dir temp
+// file + rename so a concurrent reader never sees a truncated file -- mirrors
+// scripts/wasm_vibe_host_runner.js's atomicWriteFileSync (same rationale: the
+// persistent caches under _build/vibe_* are content-keyed and shared across
+// concurrent compiler invocations -- parallel unit-test runs and #906's
+// --jobs pre-warm publish path both write these hot keys from more than one
+// process/worker -- and a plain fs::write opens with O_TRUNC, exposing a
+// partial-file window a racing reader can observe as a corrupt cache row).
+// rename() is atomic on POSIX; same-content racers simply last-write-win as
+// complete files, which is safe because a cache path already encodes its
+// content's own fingerprint (#906 acceptance criteria: partial cache writes
+// must never be published).
+static VIBE_TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn vibe_atomic_write(path: &str, data: &[u8]) -> Result<()> {
+    vibe_ensure_parent_dir(path);
+    let counter = VIBE_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = format!("{path}.tmp-{}-{counter}", std::process::id());
+    let write_result = fs::write(&tmp, data);
+    match write_result {
+        Ok(()) => fs::rename(&tmp, path).map_err(|e| {
+            let _ = fs::remove_file(&tmp);
+            format_err!("vibe atomic write rename '{tmp}' -> '{path}': {e}")
+        }),
+        Err(e) => {
+            let _ = fs::remove_file(&tmp);
+            Err(format_err!("vibe atomic write '{tmp}': {e}"))
+        }
+    }
+}
+
 // Read the `__heap_ptr` bump-allocator pointer (an i32/i64 mut global) as bytes,
 // or None when the module doesn't export it. Used by the `--mem` memory report.
 fn read_heap_ptr(instance: &wasmtime::Instance, store: &mut Store<HostState>) -> Option<u64> {
@@ -1779,10 +1810,7 @@ fn register_vibe_imports(linker: &mut Linker<HostState>) -> Result<()> {
         |mut caller: Caller<'_, HostState>, path: i64, content: i64| -> Result<()> {
             let path = vibe_read_packed_str(&mut caller, path)?;
             let content = vibe_read_packed_str(&mut caller, content)?;
-            vibe_ensure_parent_dir(&path);
-            fs::write(&path, content.as_bytes())
-                .map_err(|e| format_err!("vibe fs_write_file '{path}': {e}"))?;
-            Ok(())
+            vibe_atomic_write(&path, content.as_bytes())
         },
     )?;
     linker.func_wrap(
@@ -1791,10 +1819,7 @@ fn register_vibe_imports(linker: &mut Linker<HostState>) -> Result<()> {
         |mut caller: Caller<'_, HostState>, path: i64, bytes: i64| -> Result<()> {
             let path = vibe_read_packed_str(&mut caller, path)?;
             let data = vibe_read_packed_bytes(&mut caller, bytes)?;
-            vibe_ensure_parent_dir(&path);
-            fs::write(&path, &data)
-                .map_err(|e| format_err!("vibe fs_write_bytes '{path}': {e}"))?;
-            Ok(())
+            vibe_atomic_write(&path, &data)
         },
     )?;
     // #632: fs_read_bytes — binary-exact file read into a guest Bytes value (the


### PR DESCRIPTION
## Summary

Closes a gap directly named in #906's own acceptance criteria: "cache の部分書き込みが公開されない" (partial cache writes must never be published).

The Rust `vibewt` runner's `fs_write_file`/`fs_write_bytes` host imports (`runtime/vibewt/src/main.rs`) wrote directly via `fs::write` (open with `O_TRUNC`) — unlike the Node dev runner (`scripts/wasm_vibe_host_runner.js`'s `atomicWriteFileSync`), which already writes via a same-dir temp file + `rename()` for exactly this reason: the persistent caches under `_build/vibe_*` are content-keyed and shared across concurrent compiler invocations, and a plain truncating write exposes a partial-file window a racing reader can observe as a corrupt cache row.

`vibewt` is the **production** runner an installed toolchain actually uses (`runtime/vibe` defaults `VIBE_RUNNER` to `$TOOLCHAIN_DIR/bin/vibewt`), so this asymmetry mattered more there than in the dev-only Node runner that already had the fix. This was a documented open gap in `docs/compiler-parallelism.md`'s Phase 2 section ("the persistent-cache write itself is still a direct `Fs::write_file`... `--jobs` does not add a temp-file+rename step") — found while investigating the rest of the `--jobs` KPI work in #1169/#1170/#1171.

## Change

Adds `vibe_atomic_write()`: writes to `<path>.tmp-<pid>-<counter>` in the same directory (guaranteed same filesystem, required for atomic `rename()`), then renames over the destination — mirroring the Node runner's own rationale comment. `rename(2)` is atomic on POSIX; same-content racers simply last-write-win as complete files, which is safe because a cache path already encodes its content's own fingerprint (two writers racing on the same path are, by construction, writing identical bytes).

## Test plan

- [x] `cargo build --release` — clean.
- [x] `cargo clippy --release` — no new warnings (one pre-existing, unrelated warning at a different line).
- [x] `cargo fmt -- --check` — no diff in the changed region (pre-existing unrelated fmt diffs elsewhere in the file, out of scope).
- [x] Real cold + warm compile through the freshly-built `vibewt` binary against `scripts/fixtures/parallel_project_sample/main.vibe`: cache files written with real content, no leftover `.tmp-*` files after either run, cold and warm runs produce byte-identical output wasm that runs correctly (`main_value` → `28`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe)_