### PR TITLE
docs: fix stale AGENTS.md claims about doc comments and vibe fmt (#854)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,15 @@ pkf run test-local        # affected tests only (fast inner loop)
 pkf run full-gate         # complete operation gate
 pkf run run -- args       # run main with args
 # 単一ファイルの型検査 / 診断: vibe diagnostics <file.vibe>
-# `fmt` は現状 no-op placeholder (未移植)。moon 依存の
-# `check`/`info`/`test-update` や per-package `test:*` は dead-task
-# cleanup で Taskfile から削除済み。
+# selfhost の CST-token formatter (lib/@vibe/compiler/fmt/format.vibe,
+# scripts/vibe_fmt.sh, #854/#1138) は実装済みで `bash scripts/vibe_fmt.sh
+# [--check|--stdout] <file.vibe>` で直接使える。ただし `pkf run fmt` タスク
+# 自体はまだこれを呼ばない no-op placeholder のまま (Taskfile.pkl の
+# `fmt` task, cmd = "true") — 既存コードベースがこの formatter の
+# fixpoint になっている保証もまだない (サンプルで --check が落ちる
+# ファイルを確認済み)。全体への一括適用 + pkf 配線は別途スコープする。
+# moon 依存の `check`/`info`/`test-update` や per-package `test:*` は
+# dead-task cleanup で Taskfile から削除済み。
 ```
 
 ## Project Structure
@@ -80,8 +86,16 @@ CI shard では:
 
 ## Coding Convention
 
-- Each block is separated by `///|`
-- MoonBit code uses snake_case for variables/functions (lowercase only)
+- `///|` は MoonBit (`.mbt`) 時代の block separator 記法で、selfhost 移行後の
+  `.vibe` ソースでは使われていない (#854)。**vibe の doc comment は `///`**
+  (Rust 風、宣言の直前に置くとその宣言の doc として `vibe symbols`/hover/
+  `vibe doc-at` から拾われる。実装は `lib/@vibe/parser/lexer.vibe`
+  `collect_doc_comments`)。既存の `//#` (モジュール冒頭説明・セクション
+  見出しに広く使われている非公式記法) は `///` と意味が異なる (`//#` は
+  複数宣言にまたがる説明やセクション区切りにも使われており、`///` の
+  「直後の1宣言に対応する doc」という意味論とは食い違う) ため、
+  一括置換はしていない — 使い分けは書く場所ごとに判断すること。
+- variables/functions は snake_case (lowercase only)
 
 ## Code Navigation (IMPORTANT)
 
@@ -151,7 +165,13 @@ completion / signature help を提供する。詳細は
 - `pkf run release-check` — full gate (fmt + info + check + test + operation gates)。
 - `pkf run test-local` — 変更影響範囲のテストのみ (fast inner loop、flaker 経由)。
 - 単一ファイルの型検査 / 診断は `vibe diagnostics <file.vibe>`（空出力 = clean）。
-- `pkf run fmt` は現状 no-op placeholder（未移植、#594）。
+- selfhost の CST-token formatter は実装済み (`lib/@vibe/compiler/fmt/format.vibe`,
+  #854/#1138) — `bash scripts/vibe_fmt.sh [--check|--stdout] <file.vibe>` で
+  直接使える。ただし `pkf run fmt` タスク自体はまだこれを呼ばない no-op
+  のまま (Taskfile.pkl の `fmt` task, `cmd = "true"`)、既存コードベースが
+  fixpoint になっている保証もまだ無い (`--check` が落ちるファイルを確認
+  済み) — 全体への一括適用 + `pkf run fmt` 配線は別途大きめのタスクとして
+  スコープする。
 
 ### `vibe test` / `vibe bench` backend 切り替え
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,14 +86,18 @@ CI shard では:
 
 ## Coding Convention
 
-- `///|` は MoonBit (`.mbt`) 時代の block separator 記法で、selfhost 移行後の
-  `.vibe` ソースでは使われていない (#854)。**vibe の doc comment は `///`**
-  (Rust 風、宣言の直前に置くとその宣言の doc として `vibe symbols`/hover/
-  `vibe doc-at` から拾われる。実装は `lib/@vibe/parser/lexer.vibe`
-  `collect_doc_comments`)。既存の `//#` (モジュール冒頭説明・セクション
-  見出しに広く使われている非公式記法) は `///` と意味が異なる (`//#` は
-  複数宣言にまたがる説明やセクション区切りにも使われており、`///` の
-  「直後の1宣言に対応する doc」という意味論とは食い違う) ため、
+- `///|` は MoonBit (`.mbt`) 時代の block separator 記法。新規コードでは
+  使わないこと — ただし移植時の残骸が `lib/@vibe/compiler/core/types.vibe`
+  ほか数ファイルにまだ残っている(2026-07-28 時点で4ファイル)。見つけたら
+  削除して構わないが、一括削除はこの PR ではやっていない。**vibe の doc
+  comment は `///`** (Rust 風、宣言の直前に置くとその宣言の doc として
+  hover/`vibe doc-at` から拾われる。実装は `lib/@vibe/parser/lexer.vibe`
+  `collect_doc_comments`)。**`vibe symbols` はまだ doc comment を返さない**
+  (`runtime/symbol_spans.vibe` は `(name, kind, start, end)` のみ) —
+  拾えるのは hover と `doc-at` だけ。既存の `//#` (モジュール冒頭説明・
+  セクション見出しに広く使われている非公式記法) は `///` と意味が異なる
+  (`//#` は複数宣言にまたがる説明やセクション区切りにも使われており、
+  `///` の「直後の1宣言に対応する doc」という意味論とは食い違う) ため、
   一括置換はしていない — 使い分けは書く場所ごとに判断すること。
 - variables/functions は snake_case (lowercase only)
 


### PR DESCRIPTION
## Summary

Investigated #854 (formal doc comment convention). Found the actual proposal is already substantially implemented in #1138 — `///` Rust-style doc comments, LSP hover, `vibe doc-at`, and a real CST-token formatter (`lib/@vibe/compiler/fmt/format.vibe`) all exist. AGENTS.md (`CLAUDE.md`'s symlink target) was just stale, still describing these as unimplemented / MoonBit-era leftovers.

- Fixed the `///|` "block separator" claim in the Coding Convention section (a MoonBit-era leftover never true of `.vibe` source) — documents the real `///` doc comment convention instead, and explains why the existing `//#` convention (621 files) is deliberately **not** being bulk-converted: `//#` covers both whole-module descriptions and multi-declaration section headers, neither of which matches `///`'s "doc for exactly the one following declaration" semantics — confirmed by sampling `lib/@vibe/compiler/fmt/format.vibe` itself, which has both patterns in its own header.
- Fixed two "`fmt` is a no-op placeholder" claims — the real formatter exists and works via `scripts/vibe_fmt.sh`, but `pkf run fmt` itself is still `cmd = "true"` in `Taskfile.pkl`. Confirmed `lib/@vibe/parser/lexer.vibe` itself fails `--check`, so the codebase isn't yet a verified fixpoint under the formatter — wiring `pkf run fmt` for real needs a bulk reformat first, which is a separate, larger effort. Filed as #1176 rather than attempted here.

## Test plan

Docs-only change (`AGENTS.md`, symlinked from `CLAUDE.md`). No code paths touched.
- [x] Verified every claim against the actual source: `lib/@vibe/parser/lexer.vibe`'s `collect_doc_comments`, `lib/@vibe/compiler/cli_adapter.vibe`'s `vibe doc-at` wiring, `lib/@vibe/compiler/fmt/format.vibe`, `scripts/vibe_fmt.sh`, `Taskfile.pkl`'s `fmt` task.
- [x] Ran `bash scripts/vibe_fmt.sh --check lib/@vibe/parser/lexer.vibe` to confirm the fixpoint claim doesn't currently hold.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe)_