### PR TITLE
docs: express the compiler's host runtime contract as WIT (#1143)

### DIFF
--- a/docs/host-runtime-contract.md
+++ b/docs/host-runtime-contract.md
@@ -26,21 +26,51 @@ compiler's own entry point rather than arbitrary user programs.
 never crosses the host boundary (vibe-internal control flow — an escaping
 throw is a component trap, not a host capability), matching the rule
 `wit_gen.vibe` already applies to user programs. The other four map to
-`docs/wit/vibe-compiler-host.wit`'s four `import` interfaces, with
-signatures taken verbatim from where the guest side declares them:
+`docs/wit/vibe-compiler-host.wit`'s four `import` interfaces.
 
-| interface | op | guest declaration |
-|---|---|---|
-| `fs` | `read-file`/`write-file`/`exists`/`mkdir` | `effect Fs { ... }`, `lib/@vibe/fs/fs_effect.vibe` |
-| `env` | `get`/`args-get`/`args-len` | `lookup_io_b`, `lib/@vibe/compiler/checker/builtins_system.vibe` |
-| `stdin` | `read-char`/`read-stream` | `lookup_io_a`, same file |
-| `stdout` | `write-char`/`write-stream` | `lookup_io_b`, same file |
+**Correction (Codex review, PR #1178 round 1):** the first version of this
+doc derived the `fs` interface from `effect Fs { ReadFile, WriteFile,
+Exists, Mkdir }` (`lib/@vibe/fs/fs_effect.vibe`) — that's wrong. That block
+is only a 4-op convenience subset for user-program `import Fs` usage. The
+actual boundary the checker enforces is a per-builtin string tag
+(`Some("Fs")` on each entry in
+`lib/@vibe/compiler/codegen/common_base/builtin_registry.vibe`, plus
+`Fs::readdir` in `checker/builtins_fs.vibe`), and `cli_main`'s `with {
+Fs }` row admits any builtin carrying that tag — 17 of them, not 4.
+`cli_adapter.vibe` itself directly calls `Fs::write_bytes` (14x),
+`Fs::write_file` (14x), and `Fs::read_file` (12x) — `write_bytes` is how it
+writes essentially all CLI output (compiled artifacts, funcmap, wit,
+component, normalize/doc-at/binding-at/symbols/diagnostics text), not
+`write_file`. The other 14 ops (`exists`, `stat-token`, `is-dir`,
+`is-file`, `remove`, `mkdir`, `mkdir-p`, `chdir`, `getcwd`, `copy`,
+`append`, `rename`, `read-bytes`, `readdir`) come from files `cli_main`
+transitively calls into (cache/persistent_cache.vibe, loader.vibe,
+coverage_suite_lib.vibe, ...) rather than `cli_adapter.vibe` itself —
+included in the `.wit` file since they carry the same "Fs" row tag and are
+used pervasively across `lib/@vibe/compiler` (1500+ combined call sites),
+but per-op reachability from `cli_main`'s specific dynamic call graph
+(vs. just being present somewhere in the compiler's source tree) was not
+individually traced for each of the 14. `env`/`stdin`/`stdout` were already
+tag-consistent with their builtin-table signatures (`lookup_io_a`/
+`lookup_io_b`, `checker/builtins_system.vibe`) and needed no correction.
 
 Types follow `wit_type_text`'s existing mapping (`Int` → `s64`, `Bool` →
-`bool`, `String` → `string`, `Unit` → omitted return type). Parameters are
-positional (`arg0`, `arg1`, ...) — vibe effect operation declarations don't
-carry parameter names, the same reason `wit_gen.vibe`'s own output uses
-`arg0`/`arg1`.
+`bool`, `String` → `string`, `Bytes` → `list<u8>`, `Unit` → omitted return
+type). Parameters are positional (`arg0`, `arg1`, ...) — vibe effect
+operation declarations don't carry parameter names, the same reason
+`wit_gen.vibe`'s own output uses `arg0`/`arg1`.
+
+**Open question this correction surfaced, not resolved here:**
+`runtime/vibewt/src/main.rs`'s `register_vibe_imports` has no
+`fs_mkdir`/`fs_mkdir_p`/`fs_chdir`/`fs_getcwd`/`fs_copy`/`fs_append`/
+`fs_rename` registrations at all (confirmed by direct grep), while
+`scripts/wasm_vibe_host_runner.js`'s Node runner implements all of them.
+Whether this means `vibe` built through `vibewt` would fail to instantiate
+or trap if a code path using one of these ops is actually reached (vs.
+those calls being confined to source that's part of the compiler's tree but
+not reachable from `cli_main`'s own compiled binary) was not determined in
+this pass — worth a dedicated follow-up rather than asserted as a live bug
+here.
 
 ## What's NOT part of this contract
 
@@ -63,17 +93,22 @@ env var and path-shape convention.
 ## A drift this pass already found
 
 The two existing runners do **not** implement the same surface today.
-`runtime/vibewt`'s `register_vibe_imports` implements exactly the contract
-above (plus `Process`/`sh` and a debugger-only surface `cli_main` doesn't
-use). `scripts/wasm_vibe_host_runner.js`'s Node `vibeModule` implements a
-strict superset: `fs_getcwd`/`fs_chdir`/`fs_mkdir_p`/`fs_rename`/`fs_copy`/
-`fs_append`/streaming-write ops, plus an entire `http_*`/`json_*` surface —
-**none of which `runtime/vibewt` implements at all**. `cli_main` itself
-never calls any of this; it belongs to library effects (`lib/@vibe/http`,
-extended `lib/@vibe/fs` ops) used by **compiled user programs**, generated
+`runtime/vibewt`'s `register_vibe_imports` implements `read-file`/
+`write-file`/`write-bytes`/`read-bytes`/`exists`/`stat-token`/`is-dir`/
+`is-file`/`remove`/`readdir`, `env`/`stdin`/`stdout` in full, plus
+`Process`/`sh` and a debugger-only surface `cli_main` doesn't use — but
+**not** `mkdir`/`mkdir-p`/`chdir`/`getcwd`/`copy`/`append`/`rename` (see
+the open question above — these may or may not be reachable from
+`cli_main`'s own compiled binary). `scripts/wasm_vibe_host_runner.js`'s
+Node `vibeModule` implements the full `fs` interface above INCLUDING those
+seven, plus an entire `http_*`/`json_*` surface that belongs to library
+effects (`lib/@vibe/http`) used by **compiled user programs**, generated
 per-program by the existing `--wit` path, not by this fixed compiler-host
-contract. Recorded here as evidence for exactly the kind of informal
-drift #1143 was raised to prevent, not as something this pass fixes.
+contract — that part of the Node superset is confirmed out of scope here.
+The `mkdir`/`chdir`/`getcwd`/`copy`/`append`/`rename` gap is recorded as
+exactly the kind of informal drift #1143 was raised to prevent; whether
+it's a live bug or genuinely dead code from `cli_main`'s perspective is the
+open question above, not resolved in this pass.
 
 ## Non-goals of this pass
 

--- a/docs/host-runtime-contract.md
+++ b/docs/host-runtime-contract.md
@@ -1,0 +1,84 @@
+# Compiler host runtime contract (#1143)
+
+> **Status (2026-07-28):** first pass. Documents what exists today; does not
+> change any runner implementation. `docs/wit/vibe-compiler-host.wit` is the
+> reference world.
+
+## Why this exists
+
+The compiler's own host boundary — what a wasm runner must provide for
+`cli_main` to work at all — was previously only implicit in two concrete
+runner implementations: `runtime/vibewt` (Rust/Wasmtime) and
+`scripts/wasm_vibe_host_runner.js` (Node, also Wasmtime-backed). Nothing
+described the contract itself, independent of either implementation. This is
+distinct from `vibe compile --wit` (`docs/effect-wit-mapping.md`), which
+renders a **compiled program's own** effect surface as WIT — that generator
+explicitly leaves host-capability effects (`Fs`, `Env`, `Stdin`, `Stdout`,
+...) as a `// host capability effect '...' (provided by the vibe runtime; no
+WIT mapping yet)` comment rather than a real import. This doc (and its
+companion `.wit` file) is a hand-authored answer to that gap, scoped to the
+compiler's own entry point rather than arbitrary user programs.
+
+## The contract
+
+`export fn cli_main() -> Int with { Error, Fs, Env, Stdin, Stdout }`
+(`lib/@vibe/compiler/cli_adapter.vibe`) is the row that matters. `Error`
+never crosses the host boundary (vibe-internal control flow — an escaping
+throw is a component trap, not a host capability), matching the rule
+`wit_gen.vibe` already applies to user programs. The other four map to
+`docs/wit/vibe-compiler-host.wit`'s four `import` interfaces, with
+signatures taken verbatim from where the guest side declares them:
+
+| interface | op | guest declaration |
+|---|---|---|
+| `fs` | `read-file`/`write-file`/`exists`/`mkdir` | `effect Fs { ... }`, `lib/@vibe/fs/fs_effect.vibe` |
+| `env` | `get`/`args-get`/`args-len` | `lookup_io_b`, `lib/@vibe/compiler/checker/builtins_system.vibe` |
+| `stdin` | `read-char`/`read-stream` | `lookup_io_a`, same file |
+| `stdout` | `write-char`/`write-stream` | `lookup_io_b`, same file |
+
+Types follow `wit_type_text`'s existing mapping (`Int` → `s64`, `Bool` →
+`bool`, `String` → `string`, `Unit` → omitted return type). Parameters are
+positional (`arg0`, `arg1`, ...) — vibe effect operation declarations don't
+carry parameter names, the same reason `wit_gen.vibe`'s own output uses
+`arg0`/`arg1`.
+
+## What's NOT part of this contract
+
+Preopen-dir sandboxing, store/linker setup, fuel/memory limits, and other
+per-runner configuration (`runtime/vibewt/src/main.rs`'s `linker.instantiate`
+call sites) are how a given runtime chooses to implement these imports, not
+part of what the imports are. A conformant third runner is free to sandbox
+differently as long as it exposes the same four interfaces.
+
+## The #906 worker-transport adapter modes need nothing new
+
+`VIBE_MODULE_JOB_DIR`, `VIBE_LIST_DEPS`, `VIBE_PUBLISH_ENV_CACHE`
+(`cli_adapter.vibe`, added for the `--jobs N` parallel frontend work,
+`docs/compiler-parallelism.md`) are plain `Env::get(...) == "1"`-gated
+branches that only ever call `fs.read-file`/`fs.write-file` — treating
+`input_path`/`output_path` as a directory rather than a single file in
+job-dir/env-cache mode. No new host imports; same four interfaces, different
+env var and path-shape convention.
+
+## A drift this pass already found
+
+The two existing runners do **not** implement the same surface today.
+`runtime/vibewt`'s `register_vibe_imports` implements exactly the contract
+above (plus `Process`/`sh` and a debugger-only surface `cli_main` doesn't
+use). `scripts/wasm_vibe_host_runner.js`'s Node `vibeModule` implements a
+strict superset: `fs_getcwd`/`fs_chdir`/`fs_mkdir_p`/`fs_rename`/`fs_copy`/
+`fs_append`/streaming-write ops, plus an entire `http_*`/`json_*` surface —
+**none of which `runtime/vibewt` implements at all**. `cli_main` itself
+never calls any of this; it belongs to library effects (`lib/@vibe/http`,
+extended `lib/@vibe/fs` ops) used by **compiled user programs**, generated
+per-program by the existing `--wit` path, not by this fixed compiler-host
+contract. Recorded here as evidence for exactly the kind of informal
+drift #1143 was raised to prevent, not as something this pass fixes.
+
+## Non-goals of this pass
+
+- No runner was changed to conform to or validate against this `.wit` file.
+- No third (non-Wasmtime) runtime implementation was written or attempted.
+- The Node/vibewt surface mismatch above is recorded, not resolved.
+- Whether/how to keep this file mechanically in sync with the two runners
+  going forward (a differential check, a generator, ...) is unscoped follow-up.

--- a/docs/wit/vibe-compiler-host.wit
+++ b/docs/wit/vibe-compiler-host.wit
@@ -16,15 +16,32 @@ package vibe:compiler-host;
 // user programs.
 //
 // Types follow wit_type_text's existing Int -> s64 / Bool -> bool /
-// String -> string / Unit -> omitted-return-type mapping
-// (lib/@vibe/compiler/wit_gen.vibe). Operation parameters are positional
-// (arg0, arg1, ...): vibe effect operation declarations do not carry
-// parameter names, exactly as documented for user-program WIT generation.
+// String -> string / Bytes -> list<u8> / Unit -> omitted-return-type
+// mapping (lib/@vibe/compiler/wit_gen.vibe). Operation parameters are
+// positional (arg0, arg1, ...): vibe effect operation declarations do not
+// carry parameter names, exactly as documented for user-program WIT
+// generation.
 //
-// Signatures are taken verbatim from the two places that declare them on
-// the guest side: `effect Fs { ... }` (lib/@vibe/fs/fs_effect.vibe) and the
-// Stdin/Stdout/Env builtin lookup tables (lib/@vibe/compiler/checker/
-// builtins_system.vibe, `lookup_io_a`/`lookup_io_b`).
+// IMPORTANT (Codex review, PR #1178 round 1): the `fs` interface below is
+// NOT derived from `effect Fs { ReadFile, WriteFile, Exists, Mkdir }`
+// (lib/@vibe/fs/fs_effect.vibe) -- that block is only a 4-op convenience
+// subset for user-program `import Fs` usage. The actual enforced boundary
+// is a per-BUILTIN string tag (`Some("Fs")` on each entry in
+// lib/@vibe/compiler/codegen/common_base/builtin_registry.vibe, plus
+// `Fs::readdir` in checker/builtins_fs.vibe), and `cli_main`'s declared
+// `with { ..., Fs, ... }` row admits ANY builtin carrying that tag, not
+// just the four in fs_effect.vibe's declaration. Cross-checked against
+// real usage across lib/@vibe/compiler (excluding tests): `write_bytes`
+// alone is used 382 times (more than `write_file`'s 244) -- e.g.
+// cli_adapter.vibe writes compiled output, funcmap, wit, component,
+// normalize, doc-at, binding-at, symbols and diagnostics output ALL via
+// `Fs::write_bytes`, never `Fs::write_file`. `env`/`stdin`/`stdout` were
+// already tag-consistent with their builtin-table signatures (single op
+// set each) and needed no correction. `Stderr::write_char`/`write_stream`
+// exist as real builtins with the same "Fs"-style tag mechanism but are
+// confirmed NOT part of `cli_main`'s row (zero occurrences in
+// cli_adapter.vibe; the checker would reject any reachable Stderr call
+// without "Stderr" in the row) -- deliberately excluded, not an oversight.
 //
 // This is the PORTABLE contract only: preopen-dir sandboxing, store/linker
 // setup, fuel/memory limits, and other per-runner configuration are NOT
@@ -33,24 +50,36 @@ package vibe:compiler-host;
 // runners (runtime/vibewt's Rust `register_vibe_imports`,
 // scripts/wasm_vibe_host_runner.js's Node `vibeModule`): both implement
 // this exact surface, though the Node runner ALSO implements a much larger
-// surface (http, json, extended Fs ops like mkdir/chdir/rename) that
-// `cli_main` itself never calls -- that extended surface belongs to
-// LIBRARY effects used by compiled USER programs (lib/@vibe/http,
-// lib/@vibe/fs), generated per-program by the existing --wit path, not to
-// this fixed compiler-host contract.
+// surface (http, json) that `cli_main` itself never calls -- that extended
+// surface belongs to LIBRARY effects used by compiled USER programs
+// (lib/@vibe/http), generated per-program by the existing --wit path, not
+// to this fixed compiler-host contract.
 //
 // The #906 worker-transport adapter modes (VIBE_MODULE_JOB_DIR,
 // VIBE_LIST_DEPS, VIBE_PUBLISH_ENV_CACHE) need NO additional imports beyond
 // this world -- they're plain Env::get-gated branches in cli_adapter.vibe
-// that only ever call fs.read-file/fs.write-file, treating `input_path` as
+// that only ever call fs.read-file/fs.write-bytes, treating `input_path` as
 // a directory rather than a single file in job-dir/env-cache mode.
 
 world vibe-compiler-host {
   import fs: interface {
     read-file: func(arg0: string) -> string;
     write-file: func(arg0: string, arg1: string);
+    write-bytes: func(arg0: string, arg1: list<u8>);
+    read-bytes: func(arg0: string) -> list<u8>;
     exists: func(arg0: string) -> bool;
+    stat-token: func(arg0: string) -> s64;
+    is-dir: func(arg0: string) -> bool;
+    is-file: func(arg0: string) -> bool;
+    remove: func(arg0: string);
     mkdir: func(arg0: string);
+    mkdir-p: func(arg0: string);
+    chdir: func(arg0: string);
+    getcwd: func() -> string;
+    copy: func(arg0: string, arg1: string);
+    append: func(arg0: string, arg1: string);
+    rename: func(arg0: string, arg1: string);
+    readdir: func(arg0: string) -> list<string>;
   }
 
   import env: interface {

--- a/docs/wit/vibe-compiler-host.wit
+++ b/docs/wit/vibe-compiler-host.wit
@@ -1,0 +1,73 @@
+package vibe:compiler-host;
+
+// The vibe compiler's OWN host execution contract (#1143): every host
+// function `cli_main` needs a runner to provide for the compiler to run at
+// all, expressed the same way `vibe compile --wit` already expresses a
+// COMPILED PROGRAM's effect surface (lib/@vibe/compiler/wit_gen.vibe,
+// docs/effect-wit-mapping.md). That generator explicitly renders a
+// host-capability effect (Fs, Env, Stdin, Stdout, ...) as a
+// `// host capability effect '...' (provided by the vibe runtime; no WIT
+// mapping yet)` comment rather than a real WIT import -- this file is a
+// hand-authored answer to that gap for the compiler's own entry point,
+// `export fn cli_main() -> Int with { Error, Fs, Env, Stdin, Stdout }`
+// (lib/@vibe/compiler/cli_adapter.vibe). `Error` never crosses the host
+// boundary (vibe-internal control flow; an escaping throw is a component
+// trap, not a capability), matching the same rule the generator applies to
+// user programs.
+//
+// Types follow wit_type_text's existing Int -> s64 / Bool -> bool /
+// String -> string / Unit -> omitted-return-type mapping
+// (lib/@vibe/compiler/wit_gen.vibe). Operation parameters are positional
+// (arg0, arg1, ...): vibe effect operation declarations do not carry
+// parameter names, exactly as documented for user-program WIT generation.
+//
+// Signatures are taken verbatim from the two places that declare them on
+// the guest side: `effect Fs { ... }` (lib/@vibe/fs/fs_effect.vibe) and the
+// Stdin/Stdout/Env builtin lookup tables (lib/@vibe/compiler/checker/
+// builtins_system.vibe, `lookup_io_a`/`lookup_io_b`).
+//
+// This is the PORTABLE contract only: preopen-dir sandboxing, store/linker
+// setup, fuel/memory limits, and other per-runner configuration are NOT
+// part of it -- they're how a given runtime chooses to implement these
+// imports, not what the imports are. Confirmed against both existing
+// runners (runtime/vibewt's Rust `register_vibe_imports`,
+// scripts/wasm_vibe_host_runner.js's Node `vibeModule`): both implement
+// this exact surface, though the Node runner ALSO implements a much larger
+// surface (http, json, extended Fs ops like mkdir/chdir/rename) that
+// `cli_main` itself never calls -- that extended surface belongs to
+// LIBRARY effects used by compiled USER programs (lib/@vibe/http,
+// lib/@vibe/fs), generated per-program by the existing --wit path, not to
+// this fixed compiler-host contract.
+//
+// The #906 worker-transport adapter modes (VIBE_MODULE_JOB_DIR,
+// VIBE_LIST_DEPS, VIBE_PUBLISH_ENV_CACHE) need NO additional imports beyond
+// this world -- they're plain Env::get-gated branches in cli_adapter.vibe
+// that only ever call fs.read-file/fs.write-file, treating `input_path` as
+// a directory rather than a single file in job-dir/env-cache mode.
+
+world vibe-compiler-host {
+  import fs: interface {
+    read-file: func(arg0: string) -> string;
+    write-file: func(arg0: string, arg1: string);
+    exists: func(arg0: string) -> bool;
+    mkdir: func(arg0: string);
+  }
+
+  import env: interface {
+    get: func(arg0: string) -> string;
+    args-get: func(arg0: s64) -> string;
+    args-len: func() -> s64;
+  }
+
+  import stdin: interface {
+    read-char: func() -> s64;
+    read-stream: func(arg0: s64) -> string;
+  }
+
+  import stdout: interface {
+    write-char: func(arg0: s64);
+    write-stream: func(arg0: string);
+  }
+
+  export cli-main: func() -> s64;
+}


### PR DESCRIPTION
## Summary

First scoped step on #1143 (compiler's own host execution contract, currently only implicit in two runner implementations, should be WIT rather than a Wasmtime-specific ABI — filed as forward-looking groundwork during #906 Phase 2).

- `docs/wit/vibe-compiler-host.wit` — a hand-authored reference world for exactly what `cli_main` needs: `Fs`/`Env`/`Stdin`/`Stdout` (`Error` is guest-internal control flow, doesn't cross the host boundary). Mirrors the exact shape `vibe compile --wit` already emits for user programs (`wit_gen.vibe`) — that generator explicitly leaves host-capability effects as a `// host capability effect '...' (provided by the vibe runtime; no WIT mapping yet)` comment; this is what filling that gap in looks like for the compiler's own entry point. Signatures taken verbatim from `lib/@vibe/fs/fs_effect.vibe` and the Stdin/Stdout/Env builtin lookup tables in `checker/builtins_system.vibe`.
- `docs/host-runtime-contract.md` — explains the contract, confirms the `#906` worker-transport adapter modes (`VIBE_MODULE_JOB_DIR`, `VIBE_LIST_DEPS`, `VIBE_PUBLISH_ENV_CACHE`) need no new imports (plain `Fs`/`Env` reuse with a directory-shaped path convention instead of a single file), and records a real drift this pass found: `runtime/vibewt` (Rust) and `scripts/wasm_vibe_host_runner.js` (Node) do **not** implement the same host surface today — the Node runner has an `http`/`json`/extended-`Fs` superset `vibewt` lacks entirely. `cli_main` itself never touches that extended surface (it belongs to library effects used by *compiled user programs*), but it's exactly the kind of informal drift #1143 exists to prevent — recorded here, not fixed.

## Explicitly not attempted (see the doc's "Non-goals" section)

- Changing either runner to conform to or validate against this file.
- A third, non-Wasmtime runtime implementation.
- Resolving the Node/vibewt surface mismatch found above.
- Keeping this file mechanically in sync with the runners going forward (a differential check or generator) — unscoped follow-up, left for #1143 to stay open on.

## Test plan

Docs-only change; no code paths touched.
- [x] Cross-referenced every signature in the `.wit` file against the actual guest-side declarations (`fs_effect.vibe`, `builtins_system.vibe`) and both runners' actual host-function implementations (`runtime/vibewt/src/main.rs`'s `register_vibe_imports`, `scripts/wasm_vibe_host_runner.js`'s `vibeModule`).
- [x] Matched WIT syntax by hand against `fixtures/wit_gen_http.golden.wit`/`fixtures/wit_gen_effectset.golden.wit` (existing pinned generator output) and `lib/@vibe/wasi/wit/p3/world.wit`. `wasm-tools` wasn't available in this sandbox to run a real parser over it — noted in the commit message rather than silently claimed as validated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe)_