### PR TITLE
Parallelize bench_regression.mjs and fuzz/run_fuzz.sh with real OS processes

### DIFF
--- a/fuzz/run_fuzz.sh
+++ b/fuzz/run_fuzz.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 # Differential fuzzing harness for the selfhost vibe compiler.
 #
-#   bash fuzz/run_fuzz.sh [--seeds A..B] [--cli path/to/stage2.wasm]
+#   bash fuzz/run_fuzz.sh [--seeds A..B] [--cli path/to/stage2.wasm] [--jobs N]
 #   bash fuzz/run_fuzz.sh --mutate [--seeds A..B]   # parser-robustness mode
+#
+# Seeds run with up to --jobs concurrent OS processes (default: nproc, capped
+# at 8) via a bash job-slot pool -- real parallelism (each seed is its own
+# subshell/process tree), not vibe's own cooperative TaskGroup, which never
+# runs two task bodies at once (see docs/compiler-parallelism.md's
+# "Shared-everything migration note"). Safe because every seed already had
+# its own work dir ($WORK/s$seed) and finding dir ($FIND/seed_<n>_<class>);
+# the only genuinely shared file, failing_seeds.txt, is appended to via
+# `echo ... >>`, whose writes are atomic for lines under PIPE_BUF so
+# concurrent seeds interleave lines but never corrupt them. --jobs 1
+# reproduces the original strictly-sequential ordering exactly.
 #
 # Generative mode (default), per seed:
 #   1. fuzz/gen_program.py emits a well-typed, trap-free-by-construction
@@ -29,6 +40,7 @@ SEEDS="1..50"
 CLI=""
 MODE="gen"
 GENMODE=""   # "" = liveness-aware generation (default); "--classic" = opt out
+JOBS="${FUZZ_JOBS:-}"
 while [ $# -gt 0 ]; do
   case "$1" in
     --seeds) SEEDS="$2"; shift 2 ;;
@@ -36,10 +48,19 @@ while [ $# -gt 0 ]; do
     --mutate) MODE="mutate"; shift ;;
     --classic) GENMODE="--classic"; shift ;;
     --liveness-bias) GENMODE="--liveness-bias=$2"; shift 2 ;;
+    --jobs) JOBS="$2"; shift 2 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 A="${SEEDS%%..*}"; B="${SEEDS##*..}"
+if [ -z "$JOBS" ]; then
+  JOBS="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+  [ "$JOBS" -le 8 ] || JOBS=8
+fi
+case "$JOBS" in
+  ''|*[!0-9]*) echo "[fuzz] --jobs must be a positive integer, got: $JOBS" >&2; exit 2 ;;
+esac
+[ "$JOBS" -ge 1 ] || { echo "[fuzz] --jobs must be a positive integer, got: $JOBS" >&2; exit 2; }
 
 if [ -z "$CLI" ]; then
   CLI="$(ls -t _build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -1)"
@@ -48,7 +69,7 @@ if [ -z "$CLI" ] || [ ! -f "$CLI" ]; then
   echo "[fuzz] no stage2 CLI found; build one first (scripts/generations.sh build)" >&2
   exit 2
 fi
-echo "[fuzz] mode=$MODE gen=${GENMODE:-liveness} seeds=$A..$B cli=$CLI"
+echo "[fuzz] mode=$MODE gen=${GENMODE:-liveness} seeds=$A..$B cli=$CLI jobs=$JOBS"
 
 WORK=_build/fuzz/work
 FIND=_build/fuzz/findings
@@ -76,11 +97,9 @@ record() { # seed class dir note
   echo "[fuzz] seed $seed: $class ($note)"
 }
 
-fail=0
-total=0
-for seed in $(seq "$A" "$B"); do
-  total=$((total + 1))
-  dir="$WORK/s$seed"
+run_seed() { # seed -- runs entirely in its own background subshell/process
+  local seed="$1"
+  local dir="$WORK/s$seed"
   rm -rf "$dir"; mkdir -p "$dir"
   python3 fuzz/gen_program.py "$seed" "$dir" $GENMODE
 
@@ -103,9 +122,9 @@ EOF
     st=$(compile "$dir/mut.vibe" "$dir/mut.wasm" VIBE_RC=0)
     case "$st" in
       OK|COMPILE_DIAG) : ;;
-      *) record "$seed" "MUT_$st" "$dir" "mutated input: $st"; fail=$((fail+1)) ;;
+      *) record "$seed" "MUT_$st" "$dir" "mutated input: $st" ;;
     esac
-    continue
+    return
   fi
 
   # --- generative differential mode ---
@@ -114,10 +133,26 @@ EOF
   detail="${result#* }"
   if [ "$cls" != "OK" ]; then
     record "$seed" "$cls" "$dir" "$detail"
-    fail=$((fail + 1))
-    continue
+  fi
+}
+
+# Bounded job-slot pool: launch each seed as its own background process,
+# never more than $JOBS in flight at once. `fail`/`total` are NOT mutated
+# inside run_seed (background subshells can't write back to this shell's
+# variables) -- total is computed directly from the seed range, and fail is
+# the line count of failing_seeds.txt after every job has been waited on.
+total=$((B - A + 1))
+running=0
+for seed in $(seq "$A" "$B"); do
+  run_seed "$seed" &
+  running=$((running + 1))
+  if [ "$running" -ge "$JOBS" ]; then
+    wait -n
+    running=$((running - 1))
   fi
 done
+wait
 
+fail=$(wc -l < _build/fuzz/failing_seeds.txt | tr -d '[:space:]')
 echo "[fuzz] done: $total seeds, $fail findings"
 [ "$fail" -eq 0 ]

--- a/scripts/bench_regression.mjs
+++ b/scripts/bench_regression.mjs
@@ -12,9 +12,16 @@
 //   VIBE_BIN=<vibe> node scripts/bench_regression.mjs           # check
 //   VIBE_BIN=<vibe> node scripts/bench_regression.mjs --update   # rewrite baseline
 //
+// Fixtures run concurrently (real OS-process parallelism via child_process,
+// not vibe's own cooperative TaskGroup -- see docs/compiler-parallelism.md's
+// "Shared-everything migration note" for why the latter can't help here
+// today). Safe because each fixture is its own file with its own
+// content-addressed compile-cache key and its own mktemp'd output files --
+// no shared mutable state between concurrent `vibe bench` invocations.
+//
 // baseline.json shape: { "<file.vibe>": { "bytes_per_op": <int>, "ns_p50": <int> } }
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -29,16 +36,23 @@ const update = process.argv.includes("--update");
 const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe"];
 
 function runBench(file) {
-  const r = spawnSync(VIBE, ["bench", join(DIR, file), "--iters", ITERS], { encoding: "utf8", timeout: 120000 });
-  const out = `${r.stdout || ""}\n${r.stderr || ""}`;
-  const m = /vibe::bench .*?bytes_per_op=(\d+)/.exec(out);
-  const t = /vibe::bench .*?ns_p50=(\d+)/.exec(out);
-  if (!m) throw new Error(`bench ${file} produced no parseable result:\n${out}`);
-  return { bytes_per_op: +m[1], ns_p50: t ? +t[1] : null };
+  return new Promise((resolve, reject) => {
+    const child = spawn(VIBE, ["bench", join(DIR, file), "--iters", ITERS], { timeout: 120000 });
+    let out = "";
+    child.stdout.on("data", (d) => { out += d; });
+    child.stderr.on("data", (d) => { out += d; });
+    child.on("error", reject);
+    child.on("close", () => {
+      const m = /vibe::bench .*?bytes_per_op=(\d+)/.exec(out);
+      const t = /vibe::bench .*?ns_p50=(\d+)/.exec(out);
+      if (!m) { reject(new Error(`bench ${file} produced no parseable result:\n${out}`)); return; }
+      resolve({ bytes_per_op: +m[1], ns_p50: t ? +t[1] : null });
+    });
+  });
 }
 
-const results = {};
-for (const f of FIXTURES) results[f] = runBench(f);
+const resultList = await Promise.all(FIXTURES.map(runBench));
+const results = Object.fromEntries(FIXTURES.map((f, i) => [f, resultList[i]]));
 
 if (update) {
   writeFileSync(BASELINE, JSON.stringify(results, null, 2) + "\n");


### PR DESCRIPTION
## Summary

Both scripts ran embarrassingly-parallel work items fully sequentially. Switched to genuine host-level parallelism (separate OS processes), **not** vibe's own `TaskGroup` — confirmed by reading `lib/@vibex/concurrent/concurrent.vibe` that `TaskGroup` is a cooperative single-OS-thread scheduler (`drive_one` runs task bodies synchronously on the caller's own stack; no `thread.spawn`, shared memory, or atomics anywhere in the file), and Wasmtime 47.0.2 doesn't support real wasm threads yet either (shared-everything-threads is still an unimplemented stub upstream, per `docs/wasm_threads_requirements.md`). Real speedup today only comes from separate OS processes, which is what both scripts now use.

- **`scripts/bench_regression.mjs`**: `spawnSync` loop → async `spawn` + `Promise.all` over the two bench fixtures. Verified: `user` time (3.65s) exceeds `real` time (1.12s) on a run, confirming genuine parallel execution; `bytes/op` results identical to the serial baseline (the deterministic gate this script exists for is unaffected).
- **`fuzz/run_fuzz.sh`**: sequential per-seed `for` loop → bounded bash job-slot pool (new `--jobs N` flag, default `nproc` capped at 8; `--jobs 1` reproduces the exact original sequential order). Extracted the per-seed body into `run_seed()`; since background subshells can't mutate the parent's `fail`/`total` counters, `total` is now computed directly from the seed range and `fail` is the line count of `failing_seeds.txt` after `wait`.

## Investigated but not changed

Per the two other candidates raised in conversation:

- **`docs/compiler-parallelism.md`'s Phase 3** (split codegen's global discovery/index allocation from per-function body emission) — still the large, dedicated-design-session-sized item this session has repeatedly scoped out as too big to attempt casually. Not attempted here either.
- **`scripts/coverage_suite.sh`** — turns out to already be parallel. Its actual per-file work is delegated to `scripts/vibe_test.sh`, which already fans out over `VIBE_TEST_JOBS` via `xargs -P` (implemented in an earlier, unrelated session, #948-era code). Nothing to do here.

## Test plan

- [x] `node --check scripts/bench_regression.mjs` / `bash -n fuzz/run_fuzz.sh` — syntax clean.
- [x] Built a fresh stage2 and ran `bench_regression.mjs` end to end with a real `vibe` toolchain — correct `bytes_per_op` gate output, `user` time confirms real parallel execution.
- [x] `fuzz/run_fuzz.sh --seeds 1..8 --jobs 1` vs `--jobs 4`: identical result (8 seeds, 0 findings), 7.49s → 2.79s (2.7x).
- [x] `fuzz/run_fuzz.sh --mutate --seeds 1..8 --jobs 4`: clean run, no regressions in mutate mode.
- [x] Stress test: forced 10 simultaneous `COMPILE_CRASH` findings at `--jobs 8` (bad `--cli` path) — all 10 recorded correctly in `failing_seeds.txt` and `findings/` with no line corruption or lost records under real concurrent writes.
- Neither script is wired into `Taskfile.pkl`/CI gates directly (`bench_regression.mjs` is invoked ad hoc from `cli-install.yml` with no new required args, so it's a drop-in speedup there; `fuzz/run_fuzz.sh` is a manual local dev tool).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1JQxDgQzP5BW2qBW1iEoe)_