### PR TITLE
Speed up bulk vibe fmt: batch + shard through a vibe CLI entry (30x)

### DIFF
--- a/lib/@vibe/cli/fmt.vibe
+++ b/lib/@vibe/cli/fmt.vibe
@@ -1,0 +1,285 @@
+//# `vibe fmt` batch entry: format many files in one process, optionally
+//# sharded across a handful of parallel subprocesses.
+//#
+//# Rationale (see lib/@vibe/compiler/fmt_bench.vibe / docs/perf notes): the
+//# per-file FIXED cost of scripts/vibe_fmt.sh -- node startup + wasm
+//# instantiate + host-runner protocol, one full process per file -- is
+//# ~200-250ms regardless of file size, while format_script() itself takes
+//# low single-digit ms for a typical file (scales ~linearly with source
+//# size). Looping over ~760 files by spawning one process each therefore
+//# spends >95% of wall time on fixed overhead, not formatting. This entry
+//# amortizes that cost by reading a whole file-list manifest and formatting
+//# every file in ONE wasm instantiation; `jobs > 1` additionally shards the
+//# manifest across a few backgrounded re-invocations of this SAME wasm
+//# module (via the Process effect's `sh_capture`, #865) to use more than
+//# one core -- vibe/wasm has no in-language thread/worker primitive, so
+//# OS-level subprocess fan-out is the only real parallelism available.
+//#
+//# Separately, the linear-memory backend's bump allocator never reclaims
+//# WITHIN a process, so cumulative allocation across many format_script()
+//# calls in one instance only grows -- confirmed by crashing (heap
+//# overflow past ~3GB linear memory) on a few hundred files in a single
+//# process. `main` therefore ALWAYS shards once the manifest exceeds a
+//# safety cap, regardless of `jobs`: `jobs` only controls how much of that
+//# sharding runs concurrently, it never disables the safety cap itself, so
+//# `jobs=1` on a huge manifest is slower but still correct, not a crash.
+//#
+//# argv[0] = mode ("check" | "write")
+//# argv[1] = manifest path: a file with one source path per line
+//# argv[2] = report path: written with one "STATUS\tpath" line per input
+//#           file (STATUS: OK = already a fixpoint / write no-op, DIFF =
+//#           check found drift / write rewrote it, ERROR = formatter or a
+//#           shard subprocess failed on this file -- message after a 2nd
+//#           tab). Order matches the manifest.
+//# argv[3] = jobs (optional; string int, default "1" = minimum
+//#           parallelism -- the safety cap above may still force sharding)
+//#
+//# Driven by scripts/vibe_fmt_apply.sh / scripts/check_vibe_fmt.sh, which
+//# own the git-ls-files listing and the allowlist policy; this entry only
+//# knows how to format a manifest and write a report.
+
+import ../compiler/fmt {
+  format_script
+}
+
+import ../process {
+  sh_capture
+}
+
+//# String / manifest helpers
+
+fn empty_strings() -> Array[String] {
+  Array::slice([
+    ""
+  ], 0, 0)
+}
+
+fn split_lines(text: String) -> Array[String] {
+  let len = String::length(text)
+  let mut lines = empty_strings()
+  let mut start = 0
+  let mut idx = 0
+  while idx < len {
+    if String::char_code_at(text, idx) == '\n' {
+      Array::push(lines, text[start: idx])
+      start = idx + 1
+    }
+    idx = idx + 1
+  }
+  if start < len {
+    Array::push(lines, text[start: len])
+  }
+  lines
+}
+
+fn join_lines(lines: Array[String]) -> String {
+  let n = Array::length(lines)
+  let mut acc = ""
+  let mut i = 0
+  while i < n {
+    let line = Array::get(lines, i)
+    acc = if i == 0 {
+      line
+    } else {
+      "\{acc}\n\{line}"
+    }
+    i = i + 1
+  }
+  acc
+}
+
+fn read_manifest(path: String) -> Array[String] with { Fs } {
+  let raw = split_lines(Fs::read_file(path))
+  let n = Array::length(raw)
+  let mut out = empty_strings()
+  let mut i = 0
+  while i < n {
+    let line = Array::get(raw, i)
+    if String::length(line) > 0 {
+      Array::push(out, line)
+    }
+    i = i + 1
+  }
+  out
+}
+
+//# Sequential formatting (always the actual work -- shards just call this
+//# recursively on a slice of the manifest).
+
+fn format_one_line(mode: String, rel_path: String) -> String with { Fs } {
+  let source = Fs::read_file(rel_path)
+  let formatted = format_script(source)
+  let is_fixpoint = formatted == source
+  if mode == "write" && !is_fixpoint {
+    Fs::write_file(rel_path, formatted)
+  }
+  let status = if is_fixpoint {
+    "OK"
+  } else {
+    "DIFF"
+  }
+  "\{status}\t\{rel_path}"
+}
+
+fn format_sequential(mode: String, files: Array[String]) -> Array[String] with { Fs } {
+  let n = Array::length(files)
+  let mut report = empty_strings()
+  let mut i = 0
+  while i < n {
+    Array::push(report, format_one_line(mode, Array::get(files, i)))
+    i = i + 1
+  }
+  report
+}
+
+//# Sharded formatting: write one manifest per shard (round-robin over the
+//# file list, so shard sizes are balanced even though real file sizes vary
+//# a lot), background-and-wait a re-invocation of this module per shard,
+//# then stitch the shard reports back together in manifest order.
+
+fn shard_dir() -> String {
+  "_build/vibe_fmt_batch"
+}
+
+fn shard_manifest_path(shard: Int) -> String {
+  "\{shard_dir()}/shard_\{Int::to_string(shard)}.manifest.txt"
+}
+
+fn shard_report_path(shard: Int) -> String {
+  "\{shard_dir()}/shard_\{Int::to_string(shard)}.report.txt"
+}
+
+fn shard_files(files: Array[String], jobs: Int, shard: Int) -> Array[String] {
+  let n = Array::length(files)
+  let mut out = empty_strings()
+  let mut i = 0
+  while i < n {
+    if i % jobs == shard {
+      Array::push(out, Array::get(files, i))
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn write_shard_manifests(files: Array[String], jobs: Int) -> Unit with { Fs } {
+  let mut shard = 0
+  while shard < jobs {
+    Fs::write_file(shard_manifest_path(shard), join_lines(shard_files(files, jobs, shard)))
+    shard = shard + 1
+  }
+}
+
+fn shard_command(mode: String, shard: Int) -> String {
+  "bash scripts/run_wasm_vibe_host_runner.sh --invoke main _build/vibe_fmt/fmt_batch.wasm \{mode} \{shard_manifest_path(shard)} \{shard_report_path(shard)} 1"
+}
+
+fn build_background_command(mode: String, jobs: Int) -> String {
+  let mut cmd = ""
+  let mut shard = 0
+  while shard < jobs {
+    let piece = "\{shard_command(mode, shard)} &"
+    cmd = if shard == 0 {
+      piece
+    } else {
+      "\{cmd} \{piece}"
+    }
+    shard = shard + 1
+  }
+  "\{cmd} wait"
+}
+
+// A crashed shard leaves its report short (or missing entirely) -- surface
+// every file it was responsible for as ERROR rather than silently dropping
+// lines from the final report (a truncated report file must never read as
+// "these files are fine").
+fn read_shard_report(mode: String, shard: Int, expected: Array[String]) -> Array[String] with { Fs } {
+  let expected_n = Array::length(expected)
+  if !Fs::exists(shard_report_path(shard)) {
+    fallback_error_report(expected, "shard \{Int::to_string(shard)} produced no report (crashed before writing output)")
+  } else {
+    let lines = split_lines(Fs::read_file(shard_report_path(shard)))
+    let filtered_n = Array::length(lines)
+    if filtered_n != expected_n {
+      fallback_error_report(expected, "shard \{Int::to_string(shard)} report has \{Int::to_string(filtered_n)} line(s), expected \{Int::to_string(expected_n)} (crashed partway through)")
+    } else {
+      lines
+    }
+  }
+}
+
+fn fallback_error_report(files: Array[String], message: String) -> Array[String] {
+  let n = Array::length(files)
+  let mut out = empty_strings()
+  let mut i = 0
+  while i < n {
+    Array::push(out, "ERROR\t\{Array::get(files, i)}\t\{message}")
+    i = i + 1
+  }
+  out
+}
+
+fn format_sharded(mode: String, files: Array[String], jobs: Int) -> Array[String] with { Fs, Process } {
+  write_shard_manifests(files, jobs)
+  let _ = sh_capture(build_background_command(mode, jobs))
+  let mut report = empty_strings()
+  let mut shard = 0
+  while shard < jobs {
+    let expected = shard_files(files, jobs, shard)
+    let shard_report = read_shard_report(mode, shard, expected)
+    let m = Array::length(shard_report)
+    let mut i = 0
+    while i < m {
+      Array::push(report, Array::get(shard_report, i))
+      i = i + 1
+    }
+    shard = shard + 1
+  }
+  report
+}
+
+export fn main() -> Int with { Fs, Env, Process } {
+  let mode = Env::args_get(0)
+  let manifest_path = Env::args_get(1)
+  let report_path = Env::args_get(2)
+  let jobs_arg = if Env::args_len() > 3 {
+    Env::args_get(3)
+  } else {
+    "1"
+  }
+  let requested_jobs = match Int::parse(jobs_arg) {
+    Some(n) => if n < 1 {
+      1
+    } else {
+      n
+    },
+    None => 1
+  }
+  let files = read_manifest(manifest_path)
+  let n = Array::length(files)
+  // The linear-memory backend's bump allocator never reclaims within a
+  // process, so cumulative allocation across many format_script() calls in
+  // one wasm instance only grows -- confirmed by crashing (heap pointer
+  // overflow past ~3GB linear memory) on ~300+ files in a single process,
+  // including this repo's largest generated file
+  // (lib/@vibe/compiler/cli_adapter_bundle.vibe, ~12MB source). A safety
+  // chunk cap, independent of the requested `jobs` (parallelism width),
+  // keeps every single wasm instance's workload bounded regardless of how
+  // few jobs were requested (VIBE_FMT_JOBS=1 must still be CORRECT, just
+  // slower) -- min_shards below forces sharding even at jobs=1 once the
+  // manifest is large enough that a single process would be unsafe.
+  let safety_chunk_cap = 60
+  let min_shards = (n + safety_chunk_cap - 1) / safety_chunk_cap
+  let jobs = if requested_jobs > min_shards {
+    requested_jobs
+  } else {
+    min_shards
+  }
+  let report = if jobs <= 1 || n <= safety_chunk_cap {
+    format_sequential(mode, files)
+  } else {
+    format_sharded(mode, files, jobs)
+  }
+  Fs::write_file(report_path, join_lines(report))
+  0
+}

--- a/lib/@vibe/compiler/fmt_bench.vibe
+++ b/lib/@vibe/compiler/fmt_bench.vibe
@@ -1,0 +1,58 @@
+//# Imports
+
+import @vibe/compiler/fmt {
+  format_script
+}
+
+//# Setup
+
+let small_source_box: Array[String] = [
+  ""
+]
+let medium_source_box: Array[String] = [
+  ""
+]
+let large_source_box: Array[String] = [
+  ""
+]
+
+fn ensure_source(box: Array[String], path: String) -> String with { Error, Fs } {
+  let current = box[0]
+  if String::length(current) == 0 {
+    let source = Fs::read_file(path)
+    box[0] = source
+    source
+  } else {
+    current
+  }
+}
+
+//# Benches
+
+// Small file: a handful of imports + a couple of small functions.
+bench "format_small_file" {
+  let _ = handle {
+    String::length(format_script(ensure_source(small_source_box, "lib/@vibe/path/index_import_test.vibe")))
+  } with Error {
+    Throw(_) => 0
+  }
+}
+
+// Medium file: format.vibe itself (~2.3k lines, the formatter's own source).
+bench "format_medium_file" {
+  let _ = handle {
+    String::length(format_script(ensure_source(medium_source_box, "lib/@vibe/compiler/fmt/format.vibe")))
+  } with Error {
+    Throw(_) => 0
+  }
+}
+
+// Large file: the biggest tracked .vibe file in lib/ (~9.4k lines), to see
+// whether format_tokens scales linearly or shows super-linear blowup.
+bench "format_large_file" {
+  let _ = handle {
+    String::length(format_script(ensure_source(large_source_box, "lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe")))
+  } with Error {
+    Throw(_) => 0
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,8 +14,15 @@ The selfhost `vibe` subcommands as scripts (used by `pkf run` + tests).
 - `vibe_run.sh` — compile+run a `.vibe` (seed → runner). `vibe_run_smoke.sh`
 - `vibe_test.sh` — run `test {}` blocks. `vibe_test_smoke.sh`
 - `vibe_fmt.sh` / `vibe_normalize.sh` (+ `*_smoke.sh`) — format / normalize
-  a single file (`--check`/`--stdout`/write). `vibe_fmt_apply.sh` (`pkf run
-  fmt`) is the tree-wide write-mode wrapper over `vibe_fmt.sh`.
+  a single file (`--check`/`--stdout`/write); `ensure_vibe_fmt_entry.sh`
+  compiles its wasm entry (`lib/@vibe/cli/fmt_entry.vibe`). `vibe_fmt_apply.sh`
+  (`pkf run fmt`) is the tree-wide write-mode counterpart, and
+  `check_vibe_fmt.sh` the read-only one -- both run through
+  `run_vibe_fmt_batch.sh` + `ensure_vibe_fmt_batch.sh`, which drive the
+  batched/sharded CLI entry `lib/@vibe/cli/fmt.vibe` (one wasm process for
+  the whole file list, sharded across cores via `Process::sh_capture`
+  background+wait) instead of spawning one process per file -- see that
+  file's header comment for why.
 - `vibe_cli.sh` (+ smoke) — drive the selfhost CLI wasm
 - `vibe_pkg.sh` — package publish/install/add/yank/update (hash-verified,
   transparency-log backed #805; `vibe pkg` delegates here). `vibe_core_install.sh`

--- a/scripts/check_vibe_fmt.sh
+++ b/scripts/check_vibe_fmt.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # vibe-fmt lint gate: every lib/**/*.vibe file must be a fixpoint of
-# the selfhost CST-token formatter (scripts/vibe_fmt.sh --check), UNLESS it's
-# listed in the allowlist below.
+# the selfhost CST-token formatter, UNLESS it's listed in the allowlist
+# below. Runs through scripts/run_vibe_fmt_batch.sh (one batched wasm
+# process for the whole file list, sharded across VIBE_FMT_JOBS
+# subprocesses) instead of one scripts/vibe_fmt.sh process per file --
+# see lib/@vibe/cli/fmt.vibe's header comment for why that matters at
+# ~750+ tracked files.
 #
 # `pkf run fmt` (scripts/vibe_fmt_apply.sh) applies the formatter across the
 # whole tree in write mode; the codebase was bulk-reformatted with it on
@@ -18,6 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="${VIBE_FMT_LINT_PROJECT_ROOT:-$(dirname "$SCRIPT_DIR")}"
 SCAN_ROOT="${VIBE_FMT_LINT_ROOT:-lib}"
 ALLOWLIST_FILE="${VIBE_FMT_LINT_ALLOWLIST:-$PROJECT_ROOT/scripts/vibe_fmt_allowlist.txt}"
+JOBS="${VIBE_FMT_JOBS:-$(nproc 2>/dev/null || echo 1)}"
 cd "$PROJECT_ROOT"
 
 if [ ! -d "$SCAN_ROOT" ]; then
@@ -44,24 +49,33 @@ fi
 
 new_violations=()
 stale_allowlist=()
+errors=()
 checked=0
 known_debt=0
 
-for rel_path in "${files[@]}"; do
+while IFS=$'\t' read -r status rel_path message; do
+  [ -n "$status" ] || continue
   checked=$((checked + 1))
-  if bash scripts/vibe_fmt.sh --check "$rel_path" >/dev/null 2>"/tmp/vibe_fmt_lint_err.$$"; then
+  if [ "$status" = "OK" ]; then
     if is_allowed "$rel_path"; then
       stale_allowlist+=("$rel_path")
     fi
-  else
-    if is_allowed "$rel_path"; then
-      known_debt=$((known_debt + 1))
-    else
-      new_violations+=("$rel_path")
-    fi
+    continue
   fi
-  rm -f "/tmp/vibe_fmt_lint_err.$$"
-done
+  if [ "$status" = "ERROR" ]; then
+    errors+=("$rel_path: $message")
+  fi
+  if is_allowed "$rel_path"; then
+    known_debt=$((known_debt + 1))
+  else
+    new_violations+=("$rel_path")
+  fi
+done < <(printf '%s\n' "${files[@]}" | bash scripts/run_vibe_fmt_batch.sh check "$JOBS")
+
+if [ "${#errors[@]}" -gt 0 ]; then
+  echo "vibe-fmt lint: ${#errors[@]} file(s) errored while checking (not merely unformatted):" >&2
+  printf '  %s\n' "${errors[@]}" >&2
+fi
 
 status=0
 

--- a/scripts/ensure_vibe_fmt_batch.sh
+++ b/scripts/ensure_vibe_fmt_batch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Compile lib/@vibe/cli/fmt.vibe (the multi-file/sharded `vibe fmt` batch
+# entry, #see lib/@vibe/cli/fmt.vibe header) to _build/vibe_fmt/fmt_batch.wasm
+# if it's missing or stale. Mirrors scripts/ensure_vibe_fmt_entry.sh; kept
+# separate because fmt.vibe pulls in @vibe/process (Process effect) which
+# the single-file fmt_entry.vibe does not need.
+#
+# Prints the repo-root-relative path to the compiled wasm on stdout.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+bash "$ROOT_DIR/scripts/ensure_seed.sh" >&2
+seed="$ROOT_DIR/bootstrap/seed/compiler.wasm"
+entry_src="lib/@vibe/cli/fmt.vibe"
+work="$ROOT_DIR/_build/vibe_fmt"
+mkdir -p "$work"
+batch_wasm_rel="_build/vibe_fmt/fmt_batch.wasm"
+
+if [ ! -s "$ROOT_DIR/$batch_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
+   || [ "lib/@vibe/process/process.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
+   || [ "lib/@vibe/process/index.vpkg" -nt "$ROOT_DIR/$batch_wasm_rel" ]; then
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
+    --invoke cli_main "$seed" "$entry_src" "$batch_wasm_rel" main >&2
+  [ -s "$ROOT_DIR/$batch_wasm_rel" ] || { echo "ensure_vibe_fmt_batch.sh: failed to compile fmt batch entry" >&2; exit 1; }
+fi
+
+echo "$batch_wasm_rel"

--- a/scripts/ensure_vibe_fmt_entry.sh
+++ b/scripts/ensure_vibe_fmt_entry.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Compile lib/@vibe/cli/fmt_entry.vibe (the `vibe fmt` entry point) to
+# _build/vibe_fmt/fmt_entry.wasm if it's missing or stale. Shared by
+# scripts/vibe_fmt.sh (single-file) and scripts/vibe_fmt_parallel.mjs
+# (multi-worker bulk apply/check) so both compile the exact same way and
+# reuse the exact same cached artifact.
+#
+# Prints the repo-root-relative path to the compiled wasm on stdout.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+bash "$ROOT_DIR/scripts/ensure_seed.sh" >&2
+seed="$ROOT_DIR/bootstrap/seed/compiler.wasm"
+entry_src="lib/@vibe/cli/fmt_entry.vibe"
+work="$ROOT_DIR/_build/vibe_fmt"
+mkdir -p "$work"
+entry_wasm_rel="_build/vibe_fmt/fmt_entry.wasm"
+
+if [ ! -s "$ROOT_DIR/$entry_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ]; then
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
+    --invoke cli_main "$seed" "$entry_src" "$entry_wasm_rel" main >&2
+  [ -s "$ROOT_DIR/$entry_wasm_rel" ] || { echo "ensure_vibe_fmt_entry.sh: failed to compile formatter" >&2; exit 1; }
+fi
+
+echo "$entry_wasm_rel"

--- a/scripts/run_vibe_fmt_batch.sh
+++ b/scripts/run_vibe_fmt_batch.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Format/check many files through ONE batched vibe process
+# (lib/@vibe/cli/fmt.vibe) instead of one scripts/vibe_fmt.sh process per
+# file. Per-file process spawn + wasm instantiate is a ~200-250ms fixed
+# cost regardless of file size (see lib/@vibe/compiler/fmt_bench.vibe) --
+# batching amortizes that across the whole file list, and `jobs > 1` shards
+# it across a few backgrounded subprocess re-invocations for real
+# wall-clock parallelism on top.
+#
+# Reads the file list on stdin (one repo-relative path per line, as
+# produced by `git ls-files`), writes one "STATUS\tpath[\tmessage]" report
+# line per input file to stdout (STATUS: OK | DIFF | ERROR). Callers
+# (scripts/vibe_fmt_apply.sh, scripts/check_vibe_fmt.sh) own listing files
+# and any allowlist policy.
+#
+#   printf '%s\n' "${files[@]}" | bash scripts/run_vibe_fmt_batch.sh <check|write> [jobs]
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+mode="${1:?usage: run_vibe_fmt_batch.sh <check|write> [jobs]}"
+jobs="${2:-$(nproc 2>/dev/null || echo 1)}"
+
+case "$mode" in
+  check | write) ;;
+  *) echo "run_vibe_fmt_batch.sh: mode must be check or write, got: $mode" >&2; exit 2 ;;
+esac
+
+batch_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_batch.sh")"
+
+work="$ROOT_DIR/_build/vibe_fmt_batch"
+mkdir -p "$work"
+manifest_rel="_build/vibe_fmt_batch/manifest.txt"
+report_rel="_build/vibe_fmt_batch/report.txt"
+rm -f "$ROOT_DIR/$report_rel"
+cat > "$ROOT_DIR/$manifest_rel"
+
+if [ ! -s "$ROOT_DIR/$manifest_rel" ]; then
+  exit 0
+fi
+
+VIBE_PREOPEN_DIR="$ROOT_DIR" \
+  bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
+  --invoke main "$batch_wasm_rel" "$mode" "$manifest_rel" "$report_rel" "$jobs" >/dev/null
+
+[ -f "$ROOT_DIR/$report_rel" ] || { echo "run_vibe_fmt_batch.sh: no report produced" >&2; exit 1; }
+# The report has no trailing newline (lib/@vibe/cli/fmt.vibe joins lines
+# without one) -- add one so a naive `while read` loop over this output
+# doesn't drop the final line.
+cat "$ROOT_DIR/$report_rel"
+echo

--- a/scripts/vibe_fmt.sh
+++ b/scripts/vibe_fmt.sh
@@ -33,22 +33,7 @@ case "$src" in
 esac
 [ -f "$ROOT_DIR/$src_rel" ] || { echo "vibe_fmt.sh: not found: $src_rel" >&2; exit 2; }
 
-bash "$ROOT_DIR/scripts/ensure_seed.sh"
-seed="$ROOT_DIR/bootstrap/seed/compiler.wasm"
-entry_src="lib/@vibe/cli/fmt_entry.vibe"
-work="$ROOT_DIR/_build/vibe_fmt"
-mkdir -p "$work"
-entry_wasm_rel="_build/vibe_fmt/fmt_entry.wasm"
-
-# Compile the formatter entry once (it FS-resolves the format module import).
-if [ ! -s "$ROOT_DIR/$entry_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ]; then
-  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
-    bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$seed" "$entry_src" "$entry_wasm_rel" main >/dev/null
-  [ -s "$ROOT_DIR/$entry_wasm_rel" ] || { echo "vibe_fmt.sh: failed to compile formatter" >&2; exit 1; }
-fi
+entry_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh")"
 
 out_rel="_build/vibe_fmt/out.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" \

--- a/scripts/vibe_fmt_apply.sh
+++ b/scripts/vibe_fmt_apply.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
-# vibe-fmt bulk apply: format every tracked lib/**/*.vibe file in place via
-# scripts/vibe_fmt.sh (write mode), except the small set of AUTO-GENERATED
-# files listed in scripts/vibe_fmt_allowlist.txt (bundle/module-source
-# artifacts scripts/generate_bundle.sh emits as compact/minified output --
-# those aren't meant to be hand-formatted). This is the counterpart to
+# vibe-fmt bulk apply: format every tracked lib/**/*.vibe file in place,
+# except the small set of AUTO-GENERATED files listed in
+# scripts/vibe_fmt_allowlist.txt (bundle/module-source artifacts
+# scripts/generate_bundle.sh emits as compact/minified output -- those
+# aren't meant to be hand-formatted). This is the counterpart to
 # scripts/check_vibe_fmt.sh (--check, CI-enforced) for actually paying down
 # the ratchet: `pkf run fmt` runs this.
+#
+# The actual formatting runs through scripts/run_vibe_fmt_batch.sh (the
+# selfhost CST-token formatter, lib/@vibe/compiler/fmt/format.vibe, driven
+# via the batched lib/@vibe/cli/fmt.vibe entry) -- one wasm process for the
+# WHOLE file list instead of one process per file, sharded across
+# VIBE_FMT_JOBS (default: nproc) subprocesses for real parallelism. See
+# lib/@vibe/cli/fmt.vibe's header comment for why: the old per-file
+# scripts/vibe_fmt.sh loop spent >95% of its wall time on fixed
+# process-spawn/wasm-instantiate overhead, not on formatting.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="${VIBE_FMT_LINT_PROJECT_ROOT:-$(dirname "$SCRIPT_DIR")}"
 SCAN_ROOT="${VIBE_FMT_LINT_ROOT:-lib}"
 ALLOWLIST_FILE="${VIBE_FMT_LINT_ALLOWLIST:-$PROJECT_ROOT/scripts/vibe_fmt_allowlist.txt}"
+JOBS="${VIBE_FMT_JOBS:-$(nproc 2>/dev/null || echo 1)}"
 cd "$PROJECT_ROOT"
 
 is_excluded() {
@@ -26,15 +36,34 @@ is_excluded() {
 
 mapfile -t files < <(git ls-files "$SCAN_ROOT/*.vibe" | sort)
 
-formatted=0
+to_format=()
 skipped=0
 for rel_path in "${files[@]}"; do
   if is_excluded "$rel_path"; then
     skipped=$((skipped + 1))
-    continue
+  else
+    to_format+=("$rel_path")
   fi
-  bash scripts/vibe_fmt.sh "$rel_path" >/dev/null
-  formatted=$((formatted + 1))
 done
 
-echo "vibe-fmt apply: formatted $formatted file(s) under $SCAN_ROOT ($skipped excluded as auto-generated)"
+formatted=0
+rewritten=0
+errors=()
+if [ "${#to_format[@]}" -gt 0 ]; then
+  while IFS=$'\t' read -r status rel_path message; do
+    [ -n "$status" ] || continue
+    formatted=$((formatted + 1))
+    case "$status" in
+      DIFF) rewritten=$((rewritten + 1)) ;;
+      ERROR) errors+=("$rel_path: $message") ;;
+    esac
+  done < <(printf '%s\n' "${to_format[@]}" | bash scripts/run_vibe_fmt_batch.sh write "$JOBS")
+fi
+
+if [ "${#errors[@]}" -gt 0 ]; then
+  echo "vibe-fmt apply: ${#errors[@]} file(s) errored:" >&2
+  printf '  %s\n' "${errors[@]}" >&2
+  exit 1
+fi
+
+echo "vibe-fmt apply: formatted $formatted file(s) under $SCAN_ROOT ($skipped excluded as auto-generated, $rewritten rewritten)"


### PR DESCRIPTION
## Summary

- `scripts/vibe_fmt_apply.sh` / `check_vibe_fmt.sh` looped `scripts/vibe_fmt.sh` once per file (~250ms fixed cost each — mostly node startup + wasm instantiate, per `lib/@vibe/compiler/fmt_bench.vibe` profiling via `vibe bench`, which shows `format_script()` itself only takes low single-digit ms and scales linearly with source size). A full 762-file sweep took ~3 minutes despite the actual formatting work being negligible.
- Add `lib/@vibe/cli/fmt.vibe`, a batched CLI entry that formats a whole file-list manifest in **one** wasm process, and shards across a few backgrounded subprocess re-invocations of itself (via `Process::sh_capture`) for real multi-core parallelism — vibe/wasm has no in-language thread/worker primitive, so OS-level subprocess fan-out is the only path to that.
- It also self-protects against the linear-memory backend's bump allocator (which never reclaims within a process): a naive single-process run crashed past ~300 files with a heap overflow (~3GB linear memory), so `main` now always shards once a manifest is large, independent of the requested job count — `jobs=1` is slower but never wrong.
- `scripts/run_vibe_fmt_batch.sh` (+ `scripts/ensure_vibe_fmt_batch.sh`) wires this into `vibe_fmt_apply.sh` / `check_vibe_fmt.sh`, replacing their per-file loops while keeping their `git ls-files` listing and allowlist policy unchanged.
- Full-tree `check_vibe_fmt.sh`: ~180s → ~5s.

## Test plan

- [x] `bash scripts/compiler_gate.sh` — full pass (`[compiler-gate] ok`, 67/67 checks)
- [x] `bash scripts/unit_test_runner.sh` — 460/460 allowlisted files passed
- [x] `bash scripts/vibe_fmt_smoke.sh` — all 9 regression cases pass
- [x] `bash scripts/check_vibe_fmt.sh` — 762 files checked, 0 new violations, 3 known (permanent) debt
- [x] `bash scripts/vibe_fmt_apply.sh` — 759 formatted, 0 rewritten (confirms no drift on the already-fixpoint tree)
- [x] Manually verified batched/sharded output is byte-identical to the single-file `scripts/vibe_fmt.sh` path (both check and write modes), including a deliberately mangled file round-tripped through the full pipeline
- [x] Verified the sharding-safety fix: `VIBE_FMT_JOBS=1` on the full 762-file corpus no longer crashes (previously overflowed the linear-memory heap) and still produces correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_