### PR TITLE
#1225 follow-up: reject --entry-name in selfbuild invoke mode

### DIFF
--- a/scripts/generations.sh
+++ b/scripts/generations.sh
@@ -687,6 +687,13 @@ command_build() {
   fi
   select_generation_entry "$out_dir" "$requested_entry"
   entry="$GENERATION_ENTRY"
+  # Codex review on #1225: run_selfbuild_compile has no entry_name parameter
+  # (selfbuild_entry is a single fixed export) and would otherwise silently
+  # ignore --entry-name, succeeding with an artifact that doesn't use the
+  # requested entry. Reject rather than mis-build.
+  if [ -n "$entry_name" ] && [ "$GENERATION_INVOKE_MODE" != "cli" ]; then
+    die "--entry-name is only supported in cli invoke mode (got: $GENERATION_INVOKE_MODE)"
+  fi
   local stage0="$out_dir/stage0_seed.wasm"
   local stage1="$out_dir/stage1.wasm"
   local stage2="$out_dir/stage2.wasm"


### PR DESCRIPTION
## Summary

Follow-up to [Codex's review](https://github.com/mizchi/vibe-lang/pull/1225#discussion_r3681187240) on #1225 (merged before this fix landed).

`run_selfbuild_compile` has no `entry_name` parameter — `selfbuild_entry` is a single fixed export — so #1225's new `--entry-name NAME` override on `scripts/generations.sh build` silently vanished whenever `GENERATION_INVOKE_MODE` resolved to `selfbuild` instead of `cli`. The command would succeed while producing an artifact that ignores the requested entry.

- Rejects `--entry-name` outright when the resolved invoke mode isn't `cli`, instead of silently mis-building.
- Not reachable via any current default build path (`build_cli_wasm.sh --entry-name main` always resolves to `cli` mode), but a real footgun for future callers of the flag.

## Test plan

- [x] Default `scripts/generations.sh build` (no `--entry-name`) still succeeds.
- [x] `scripts/generations.sh build --entry-name main` (cli mode, the actual `build_cli_wasm.sh` usage) still succeeds.
- [x] `VIBE_GENERATION_CLI_INVOKE=0 VIBE_GENERATION_SELFBUILD_INVOKE=1 scripts/generations.sh build --entry-name main` (forced selfbuild mode) now fails loudly (`--entry-name is only supported in cli invoke mode`) instead of silently ignoring the override.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PENPDUZBtGEyxx27pMVtsa)_