### PR TITLE
#1230 M1b-3c-1c: interleaving needs no ABI machinery -- disproves the §3.8 prediction

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -154,6 +154,8 @@ local testSpawnedFutureComponent =
   scriptTask("test-spawned-future-component", "scripts/test_spawned_future_component_gate.sh")
 local testConcurrentAwaitsComponent =
   scriptTask("test-concurrent-awaits-component", "scripts/test_concurrent_awaits_component_gate.sh")
+local testInterleavedTasksProbe =
+  scriptTask("test-interleaved-tasks-probe", "scripts/test_interleaved_tasks_probe_gate.sh")
 local testWasiHttpP3Full =
   scriptTask("test-wasi-http-p3-full", "scripts/test_wasi_http_p3_full_gate.sh")
 local testWasiP3Guarantee = scriptTask("test-wasi-p3", "scripts/test_wasi_p3_guarantee_gate.sh")
@@ -792,6 +794,7 @@ tasks {
   testSelfhostAsyncComponent
   testSpawnedFutureComponent
   testConcurrentAwaitsComponent
+  testInterleavedTasksProbe
   testWasiHttpP3Full
   testWasiP3Guarantee
   testSimdEmitWasmtime

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -642,6 +642,14 @@ handshake や観測可能な処理があると順序が変わるか deadlock す
 が既に抱えている制限と同じもので、今回それを超えてはいない。真の
 interleaving spawn は **M-conc-2 / M1b-3c-2 の未解決事項として残る**。
 
+> **追記（§3.11 で訂正）**: 上段の「並行な guest 計算には別 task か guest 側
+> poll executor のどちらかが要る」という推論は **誤りだった**。stackful 方式では
+> `waitable-set.wait` の payload[0](どの waitable が発火したか)による完了順
+> ディスパッチだけで interleaving が成立する——第2のスタックも
+> `context.get/set` も `waitable-set.poll` も要らない。Phase A が見ていた
+> `FuturesUnordered` + `context.get/set` は wit-bindgen の **callback 方式**の
+> 都合であって interleaving の要件ではなかった。実機反証は §3.11。
+
 ### 3.9 M1b-3c-2 landed — async component を production runtime が駆動できるようになった（#1230）
 
 §3.8 までの async component は、**プロジェクト内のどのツールでも動かせなかった**。
@@ -744,6 +752,60 @@ emitter 化した。**canon 集合は M1b-3c-1b から一切増えていない**
 
 **残る未解決は M1b-3c-1c のまま**: 親の処理と interleave する第2の *guest*
 計算は、本節の機構では作れない。
+
+### 3.11 M1b-3c-1c — interleaving は ABI 側の追加機構を要さなかった（§3.8 の予測を訂正、#1230）
+
+§3.8 は「真の interleaving spawn には**別 task か guest 側 poll executor の
+どちらかが要る**」と書き、根拠として Phase A の実測（`wit_bindgen::spawn_local`
+が `FuturesUnordered` executor 一式 + `context.get/set` + `waitable-set.poll`
+を引き込む）を挙げていた。**これは誤りだった** ——
+`tools/wasip3_component_probe/interleaved_tasks/` で実機反証した。
+
+Phase A が見ていたものは wit-bindgen の **callback 方式**（`[callback]` export
+経由で毎 wake event に再入する明示的 state machine）の都合であって、
+interleaving 自体の要件ではない。stackful 方式では
+`waitable-set.wait` が **payload[0] で「どの waitable が発火したか」を返す**
+——完了順ディスパッチに必要なものはそれだけである。
+
+#### probe の設計（偽装できない形にした）
+
+```
+  task A   await get-after(300) -> await get-after(300) -> log 1
+  task B   await get-after(100)                         -> log 2
+```
+
+どちらも「片方を待ち始める前に」発行する。結果は `log[0]*10 + log[1]`。
+
+| | 結果 | 実測時間 | 意味 |
+|---|---|---|---|
+| `component.wat` | **21** | **613ms** | B の継続が A の途中で走った。合計は **A 自身の 2×300ms** ——B は完全に重なった |
+| `serial_control.wat` | **12** | **713ms** | A を最後まで待ってから B。300+300+100 |
+
+タイムライン: t=0 で A の1st と B を発行 → **t=100 で B が解決し B の継続が走る**
+（A はまだ1st await 中）→ t=300 で A が state machine を1つ進めて 2nd await を発行
+→ t=600 で A の継続。
+
+負の対照（`serial_control.wat`）は同一の canon 集合・同一の値・同一の log
+エンコードで順序だけを変えたもので、**値と wall-clock の両方で反対の答えを出す**
+ことを gate が確認する（`scripts/test_interleaved_tasks_probe_gate.sh`）——
+これが無いと「21 を返す」という assertion が判別的である保証が無い。
+
+#### 確立したこと / 残ること
+
+**確立**: 2つの論理的な guest 計算が、**1本の stackful fiber 上で** await 点で
+interleave する。**第2のスタックも `context.get/set` も `waitable-set.poll` も
+不要**で、canon 集合は M1b-3c-1b から不変。
+
+**残る**: A が2つの await をまたいで持ち越す状態を、この probe は**メモリ上の
+スロットに手で置いた state machine** として書いた。任意の vibe ソースに対して
+この変換を行うのが **ADR-0076 の CPS/suspend lowering** そのものである。
+つまり M1b-3c-1c の残作業は **ABI 側ではなく codegen 側に局所化された**——
+「別 task か poll executor が要る」という §3.8 の前提が消えたぶん、当初の
+見積もりより小さい。
+
+emitter（固定シェイプの component 合成）は本節では作っていない——M1b-3c-1a と
+同じ「mechanics 実証のみ」フェーズ。実 `.vibe` ソースからこの形へ落とすには
+上記の state 表現が先に要る。
 
 ## 4. WASI 0.3 境界マッピング
 
@@ -868,7 +930,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 | **M1b-3b** | `await`/`Future::ready` の codegen（ready-future identity lowering）: `await(x)`/`Future::ready(x)` を引数の値へ lower。**await を使う async プログラムが初めてコンパイル&実行可能**。gate を `await(Future::ready(42))` body に更新し E2E で 42 | done |
 | **M1b-3c** | 真の blocking await: `future.read` + waitable-set 待機ループ（async source = host async import / subtask spawn が前提）。core codegen に future canon built-in の import + buffer + ループを emit | spike done（§3.7、mechanics 実機確認）/ codegen 未着手 |
 | **M1b-3c-1b** | blocking await（host async import）の component_codegen.vibe emitter。待機ループを別関数に括り出した形で、`future.*` canon 無しに動くことを実機検証（§3.8）。byte-exact 検証のみで実 `.vibe` ソースへの配線は対象外。**spawn 相当は「spawn と join の間に観測可能な処理が無い」退化ケースのみ**——真の interleaving spawn は未達（§3.8「実証範囲の限界」） | done（#1230、`comp_emit_component_wasm_async_spawned_future` + `scripts/test_spawned_future_component_gate.sh`） |
-| **M1b-3c-1c** | 真の interleaving spawn: 親の処理と並行して走る第2の guest 計算（guest 側 poll executor か別 task が要る）。M-conc-2 と実質同一の機構 | 未着手（#1240 review で M1b-3c-1b の範囲外と確定） |
+| **M1b-3c-1c** | 真の interleaving spawn: 親の処理と並行して走る第2の guest 計算。**§3.11 で ABI 側の問いは解決**——`waitable-set.wait` の完了順ディスパッチだけで interleave し、別 task も poll executor も `context.get/set` も不要（§3.8 の予測を実機反証、負の対照付き gate で固定）。残るのは **await をまたぐ task 状態の表現＝ADR-0076 の CPS/suspend lowering** のみで、codegen 側に局所化された | mechanics done（#1230、`tools/wasip3_component_probe/interleaved_tasks/` + `scripts/test_interleaved_tasks_probe_gate.sh`）/ emitter・実ソース配線は未着手 |
 | **M1b-3c-3** | **本物の並行 await**（§3.10）: guest の計算は1本のまま、**複数の host 操作を同時に in-flight** にして待つ。canon 集合は M1b-3c-1b から不変——並行性を生むのは「どちらも待ち始める前に両方発行する」という操作順序だけ。`comp_emit_component_wasm_async_concurrent_awaits` + probe + gate（値 84 と **両側の wall-clock** で検証、2×1000ms が 1015ms = 1× スケール）。M1b-3c-1c（guest の計算が2本 interleave）とは別問題で、そちらは未解決のまま | done（#1230） |
 | **M1b-3c-2** | async component を **production runtime が駆動**できるようにする（§3.9）: `runtime/viberun` の wasmtime を 45→47.0.2 bump（同期パスはソース無改修）、component ヘッダ判別 + `instantiate_async`/`run_concurrent`/`call_concurrent`、`get-async` を `func_wrap_concurrent` + 実 suspend する tokio timer で実装。gate が probe 専用 Rust host バイナリ依存を脱却。**副産物**: eager-completion 時に subtask が生成されないのに `subtask.drop` していた実バグを発見・修正（emitter + probe WAT 両方）、gate が blocked/eager 両パスを検証 | done（#1230） |
 | **M-conc-1** | `Task[T]` codegen（synchronous eager model）: `spawn`（thunk を即時実行・closure type 9 で `call_indirect`）/`join`（identity）/`cancel`（drop→Unit）/`race`（先行値）を `compile_call` で lower。inlined async builtin の free-var capture バグ（nested lambda 内で `Task::join` 等を closure として捕捉）を `collect_free_vars_expr` で修正。gate に Task entry 追加（spawn/join/cancel/race → 42、wasmtime 45） | done |

--- a/runtime/viberun/src/main.rs
+++ b/runtime/viberun/src/main.rs
@@ -650,6 +650,29 @@ fn run_async_component(path: &str) -> Result<i32> {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(ASYNC_COMPONENT_GET_DELAY_MS);
+    // Percentage applied to every suspend below. `get-after`'s delays come
+    // from the GUEST (baked into the probe components), so unlike
+    // VIBE_ASYNC_GET_DELAY_MS there is otherwise no way to scale them from
+    // outside -- and a gate that only needs to warm the JIT would sit through
+    // the probe's full timings for nothing. Scaling here keeps every ratio
+    // intact, so completion ORDER, and therefore what the probes assert, is
+    // unchanged. Raise it above 100 on a loaded machine to widen the margins.
+    let delay_scale_pct: u64 = std::env::var("VIBE_ASYNC_DELAY_SCALE_PCT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    // A nonzero request must stay nonzero: an async-lowered call that
+    // completes eagerly takes a different path through the guest (no subtask
+    // is created), which several probes deliberately reject with an
+    // `unreachable`. Scaling must not silently turn a blocking call into an
+    // eager one.
+    let scale = move |ms: u64| -> u64 {
+        if ms == 0 {
+            0
+        } else {
+            std::cmp::max(1, ms.saturating_mul(delay_scale_pct) / 100)
+        }
+    };
 
     let mut cfg = engine_config();
     cfg.wasm_component_model(true);
@@ -669,8 +692,9 @@ fn run_async_component(path: &str) -> Result<i32> {
             "get-async",
             move |_acc: &Accessor<StoreLimits>, _params: ()| {
                 Box::pin(async move {
-                    if delay_ms > 0 {
-                        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                    let ms = scale(delay_ms);
+                    if ms > 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
                     }
                     Ok((ASYNC_COMPONENT_GET_VALUE,))
                 })
@@ -691,8 +715,12 @@ fn run_async_component(path: &str) -> Result<i32> {
             "get-after",
             move |_acc: &Accessor<StoreLimits>, (ms,): (u32,)| {
                 Box::pin(async move {
-                    if ms > 0 {
-                        tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
+                    // The value echoed back is the guest's ORIGINAL request,
+                    // not the scaled sleep -- probes identify a completion by
+                    // it, so scaling must stay invisible to the guest.
+                    let slept = scale(ms as u64);
+                    if slept > 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(slept)).await;
                     }
                     Ok((ms,))
                 })

--- a/runtime/viberun/src/main.rs
+++ b/runtime/viberun/src/main.rs
@@ -677,6 +677,28 @@ fn run_async_component(path: &str) -> Result<i32> {
             },
         )
         .map_err(|e| format_err!("link get-async: {e}"))?;
+    // #1230 M1b-3c-1c: same thing with a caller-chosen delay, returned as the
+    // value. `get-async`'s single fixed delay makes every in-flight call
+    // resolve at the same moment, which is enough to show that calls OVERLAP
+    // (M1b-3c-3) but cannot show anything about the ORDER continuations run
+    // in -- completion order and start order coincide. A per-call delay makes
+    // them differ observably, which is what the interleaving probe needs.
+    // Echoing `ms` back also lets the guest identify a completion by value,
+    // independently of the waitable handle.
+    linker
+        .root()
+        .func_wrap_concurrent(
+            "get-after",
+            move |_acc: &Accessor<StoreLimits>, (ms,): (u32,)| {
+                Box::pin(async move {
+                    if ms > 0 {
+                        tokio::time::sleep(std::time::Duration::from_millis(ms as u64)).await;
+                    }
+                    Ok((ms,))
+                })
+            },
+        )
+        .map_err(|e| format_err!("link get-after: {e}"))?;
 
     // A current-thread runtime is enough (and keeps this off the thread pool):
     // the only await points are this timer and wasmtime's own event loop.

--- a/scripts/test_concurrent_awaits_component_gate.sh
+++ b/scripts/test_concurrent_awaits_component_gate.sh
@@ -136,6 +136,8 @@ wasm-tools validate --features all "$COMPONENT" \
   || { echo "selfhost concurrent-awaits component gate FAILED: generated component failed validation" >&2; exit 1; }
 
 # --- warmup (unmeasured): pay JIT compilation before the timed run ----------
+# Delay 0 keeps this cheap, and here it is also the eager path, which this
+# component must handle anyway (asserted for real further down).
 VIBE_ASYNC_GET_DELAY_MS=0 timeout 60 "$RUNNER" "$COMPONENT" >/dev/null 2>&1 \
   || { echo "selfhost concurrent-awaits component gate FAILED: warmup run did not exit 0" >&2; exit 1; }
 

--- a/scripts/test_interleaved_tasks_probe_gate.sh
+++ b/scripts/test_interleaved_tasks_probe_gate.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Interleaved-tasks probe gate (#1230 M1b-3c-1c).
+#
+# Locks in the M1b-3c-1c finding: two logical guest computations interleave
+# at their await points on ONE stackful fiber, dispatched by completion
+# order, using NO canon built-in beyond what M1b-3c-1b already proved -- no
+# second stack, no context.get/set, no waitable-set.poll.
+#
+# Unlike the spawned-future and concurrent-awaits gates, this one drives the
+# hand-authored probe WAT directly rather than a compiler-emitted component:
+# the finding is about what the ABI permits, and the emitter for this shape
+# is deliberately left to the follow-up (see docs/spec/wasi-p3-async.md
+# §3.11). What it therefore protects is (a) the ABI behavior itself against
+# a wasmtime bump, and (b) viberun's `get-after` host import, which nothing
+# else exercises.
+#
+# The probe:
+#     task A   await get-after(300) -> await get-after(300) -> log 1
+#     task B   await get-after(100)                         -> log 2
+# both started before either is waited on, result = log[0]*10 + log[1].
+#
+#     21 in ~600ms   B's continuation ran while A was still mid-sequence,
+#                    and the total is A's own two awaits -- B overlapped.
+#     12 in ~700ms   A ran to completion first: serial.
+#
+# serial_control.wat is the same component with A awaited to completion
+# before B starts. It is run too, and must produce exactly the OTHER answer
+# -- otherwise the assertions above are not discriminating and this gate is
+# decorative.
+#
+# Env:
+#   VIBE_INTERLEAVED_GATE_RUNNER    viberun binary override
+#   VIBE_P3_GATE_REQUIRE_TOOLS=1    missing tools = FAIL instead of skip
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/interleaved_tasks_probe}"
+mkdir -p "$OUT_DIR"
+
+PROBE_DIR="$PROJECT_ROOT/tools/wasip3_component_probe/interleaved_tasks"
+
+require_or_skip() {
+  local what="$1"
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "interleaved-tasks probe gate FAILED: $what (required mode)" >&2
+    exit 1
+  fi
+  echo "interleaved-tasks probe gate skipped: $what"
+  exit 0
+}
+
+command -v wasm-tools >/dev/null 2>&1 || require_or_skip "wasm-tools not installed"
+
+DEFAULT_RUNNER="$PROJECT_ROOT/runtime/viberun/target/release/viberun"
+RUNNER="${VIBE_INTERLEAVED_GATE_RUNNER:-$DEFAULT_RUNNER}"
+# Same rebuild-when-stale convention as the other component gates (Cargo.lock
+# included -- wasmtime/tokio ARE the behavior under test, so a stale binary
+# is a false pass rather than a crash).
+if [ "$RUNNER" = "$DEFAULT_RUNNER" ]; then
+  needs_build=0
+  if [ ! -x "$RUNNER" ]; then
+    needs_build=1
+  elif find "$PROJECT_ROOT/runtime/viberun/src" \
+        "$PROJECT_ROOT/runtime/viberun/Cargo.toml" \
+        "$PROJECT_ROOT/runtime/viberun/Cargo.lock" \
+        -newer "$RUNNER" -print -quit 2>/dev/null | grep -q .; then
+    needs_build=1
+    echo "[interleaved-tasks-gate] viberun is older than its build inputs; rebuilding..."
+  fi
+  if [ "$needs_build" = "1" ]; then
+    command -v cargo >/dev/null 2>&1 || require_or_skip "viberun needs a (re)build and cargo is not installed"
+    echo "[interleaved-tasks-gate] building viberun..."
+    if ! (cd "$PROJECT_ROOT/runtime/viberun" && cargo build --release >/dev/null 2>&1); then
+      require_or_skip "failed to build runtime/viberun"
+    fi
+  fi
+fi
+[ -x "$RUNNER" ] || require_or_skip "viberun not available: $RUNNER"
+echo "[interleaved-tasks-gate] runner: $RUNNER"
+
+# Runs $1.wat, echoes "<result> <elapsed_ms>".
+run_probe() {
+  local wat="$1" name="$2"
+  local wasm="$OUT_DIR/$name.wasm"
+  wasm-tools parse "$wat" -o "$wasm" \
+    || { echo "interleaved-tasks probe gate FAILED: $name did not assemble" >&2; exit 1; }
+  wasm-tools validate --features all "$wasm" \
+    || { echo "interleaved-tasks probe gate FAILED: $name did not validate" >&2; exit 1; }
+  # warmup: first execution pays wasmtime JIT (~200ms observed), which would
+  # blur the ~100ms gap between the interleaved and serial timings.
+  timeout 60 "$RUNNER" "$wasm" >/dev/null 2>&1 \
+    || { echo "interleaved-tasks probe gate FAILED: $name warmup did not exit 0" >&2; exit 1; }
+  local log="$OUT_DIR/$name.log" start_ns elapsed
+  start_ns=$(date +%s%N)
+  timeout 60 "$RUNNER" "$wasm" >"$log" 2>&1 \
+    || { echo "interleaved-tasks probe gate FAILED: $name did not exit 0" >&2; cat "$log" >&2; exit 1; }
+  elapsed=$(( ( $(date +%s%N) - start_ns ) / 1000000 ))
+  echo "$(cat "$log") $elapsed"
+}
+
+read -r INTER_RESULT INTER_MS <<<"$(run_probe "$PROBE_DIR/component.wat" interleaved)"
+read -r SERIAL_RESULT SERIAL_MS <<<"$(run_probe "$PROBE_DIR/serial_control.wat" serial_control)"
+
+if [ "$INTER_RESULT" != "21" ]; then
+  echo "interleaved-tasks probe gate FAILED: expected 21 (log = B then A, i.e. task B's continuation ran while task A was still mid-sequence), got $INTER_RESULT" >&2
+  exit 1
+fi
+if [ "$SERIAL_RESULT" != "12" ]; then
+  echo "interleaved-tasks probe gate FAILED: the serial control returned $SERIAL_RESULT, not 12 -- the log encoding no longer distinguishes the two orders, so the assertion above proves nothing" >&2
+  exit 1
+fi
+
+# Timing: interleaved must cost about A alone (2x300ms); serial must cost
+# A plus B (700ms). Assert the ORDER of the two measurements rather than
+# absolute bounds, so a uniformly slow machine cannot flake this -- what
+# matters is that overlapping is measurably cheaper than not.
+if [ "$INTER_MS" -ge "$SERIAL_MS" ]; then
+  echo "interleaved-tasks probe gate FAILED: interleaved took ${INTER_MS}ms but serial took ${SERIAL_MS}ms -- overlapping the two tasks saved nothing, so they did not actually overlap" >&2
+  exit 1
+fi
+# ...and the saving should be roughly task B's 100ms, not noise.
+SAVED=$(( SERIAL_MS - INTER_MS ))
+if [ "$SAVED" -lt 50 ]; then
+  echo "interleaved-tasks probe gate FAILED: interleaving saved only ${SAVED}ms (expected ~100ms, task B's whole duration) -- too close to call it overlap" >&2
+  exit 1
+fi
+
+echo "[interleaved-tasks-gate] interleaved: 21 in ${INTER_MS}ms (B's continuation ran mid-A)"
+echo "[interleaved-tasks-gate] serial control: 12 in ${SERIAL_MS}ms (assertions discriminate; overlap saved ${SAVED}ms)"
+echo "interleaved-tasks probe gate passed"

--- a/scripts/test_interleaved_tasks_probe_gate.sh
+++ b/scripts/test_interleaved_tasks_probe_gate.sh
@@ -28,6 +28,13 @@
 # -- otherwise the assertions above are not discriminating and this gate is
 # decorative.
 #
+# The probe's delays are baked into the committed WAT (they are part of the
+# artifact), so viberun exposes VIBE_ASYNC_DELAY_SCALE_PCT to scale every
+# host suspend by a percentage. Ratios are preserved, so completion order --
+# the thing being asserted -- is unaffected. Used below to make the warmups
+# nearly free; raise it above 100 if a loaded machine ever narrows the
+# margin between the two measurements.
+#
 # Env:
 #   VIBE_INTERLEAVED_GATE_RUNNER    viberun binary override
 #   VIBE_P3_GATE_REQUIRE_TOOLS=1    missing tools = FAIL instead of skip
@@ -88,9 +95,14 @@ run_probe() {
     || { echo "interleaved-tasks probe gate FAILED: $name did not assemble" >&2; exit 1; }
   wasm-tools validate --features all "$wasm" \
     || { echo "interleaved-tasks probe gate FAILED: $name did not validate" >&2; exit 1; }
-  # warmup: first execution pays wasmtime JIT (~200ms observed), which would
-  # blur the ~100ms gap between the interleaved and serial timings.
-  timeout 60 "$RUNNER" "$wasm" >/dev/null 2>&1 \
+  # Warmup: first execution pays wasmtime JIT (~200ms observed), which would
+  # blur the ~100ms gap between the interleaved and serial timings. Run it at
+  # 2% of the probe's delays -- the JIT work is identical, but the warmup
+  # stops costing as much as the measurement it exists to protect (it ran the
+  # full ~1.3s of sleeps before). Ratios are preserved, so the guest still
+  # takes exactly the same path; and the floor keeps every call blocking,
+  # which the probe's own `unreachable` guards require.
+  VIBE_ASYNC_DELAY_SCALE_PCT=2 timeout 60 "$RUNNER" "$wasm" >/dev/null 2>&1 \
     || { echo "interleaved-tasks probe gate FAILED: $name warmup did not exit 0" >&2; exit 1; }
   local log="$OUT_DIR/$name.log" start_ns elapsed
   start_ns=$(date +%s%N)

--- a/tools/wasip3_component_probe/README.md
+++ b/tools/wasip3_component_probe/README.md
@@ -481,3 +481,19 @@ table.
 Needs viberun's `get-after` host import (a per-call delay); `get-async`'s
 single fixed delay makes completion order and start order coincide, which
 is enough to show calls overlap but says nothing about dispatch order.
+
+Because these delays are baked into the committed WAT (they are part of the
+artifact), viberun also exposes `VIBE_ASYNC_DELAY_SCALE_PCT` to scale every
+host suspend by a percentage. Ratios are preserved, so completion order --
+the thing the probe asserts -- is unaffected; only the clock moves:
+
+| scale | interleaved | serial | saving |
+|---|---|---|---|
+| 2% | 21 in 23ms | 12 in 25ms | 2ms |
+| 100% | 21 in 612ms | 12 in 713ms | 101ms |
+| 200% | 21 in 1212ms | 12 in 1412ms | 200ms |
+
+The gate uses 2% for its warmups -- which otherwise ran the probe's full
+~1.3s of sleeps purely to warm the JIT, costing as much as the measurement
+they exist to protect -- and 100% for the measured runs, so the margin is
+untouched. Raise it above 100 if a loaded machine ever narrows that margin.

--- a/tools/wasip3_component_probe/README.md
+++ b/tools/wasip3_component_probe/README.md
@@ -426,3 +426,58 @@ Two 1000ms calls finish in the time of one. That 1x-not-2x scaling is the
 actual proof; the value check alone would pass on a serial implementation
 too. Ported to `comp_emit_component_wasm_async_concurrent_awaits` and gated
 by `scripts/test_concurrent_awaits_component_gate.sh`.
+
+## `interleaved_tasks/`: the M1b-3c-1c question, answered against the prediction (#1230)
+
+The "real interleaving spawn remains open" note above ended with a
+prediction: that concurrent guest work "requires either another task or a
+guest-side poll executor," citing Phase A's `spawn_local` dragging in a
+`FuturesUnordered` executor plus `context.get/set` and `waitable-set.poll`.
+
+**That prediction was wrong**, and this probe disproves it on real hardware.
+
+What Phase A was actually measuring is wit-bindgen's **callback** form —
+the explicit state machine that re-enters through a `[callback]` export on
+every wake event. Under the stackful form vibe emits, `waitable-set.wait`
+already reports **which** waitable fired (payload[0]), and completion-order
+dispatch is all interleaving needs.
+
+The probe is built so it cannot pass by accident:
+
+```
+  task A   await get-after(300) -> await get-after(300) -> log 1
+  task B   await get-after(100)                         -> log 2
+```
+
+both started before either is waited on; the result is `log[0]*10 + log[1]`.
+
+| | result | elapsed | reading |
+|---|---|---|---|
+| `component.wat` | **21** | **613ms** | B's continuation ran while A was still mid-sequence, and the total is A's *own* two awaits — B cost nothing |
+| `serial_control.wat` | **12** | **713ms** | A awaited to completion first: 300 + 300 + 100 |
+
+`serial_control.wat` is the same component — same canon set, same host
+import, same delays, same log encoding — with only the ordering changed. It
+is checked by the gate too, and must produce the **opposite** answer on
+both the value and the clock. Without it, "returns 21" would be an
+assertion with no evidence that it discriminates.
+
+Timeline: at t=0 both A's first await and B are issued; **at t=100 B
+resolves and B's continuation runs** while A is still waiting; at t=300 A
+advances its state machine and issues its second await; at t=600 A's
+continuation runs.
+
+**Established:** two logical guest computations interleave at their await
+points on ONE stackful fiber. No second stack, no `context.get/set`, no
+`waitable-set.poll`; the canon set is unchanged from `spawned_future/`.
+
+**Still open:** A's state across its two awaits is a hand-placed memory
+slot here — a hand-rolled state machine. Performing that transformation for
+arbitrary vibe source *is* ADR-0076's CPS/suspend lowering. So the
+remaining M1b-3c-1c work is localized to codegen, and is smaller than the
+old estimate now that "needs another task or a poll executor" is off the
+table.
+
+Needs viberun's `get-after` host import (a per-call delay); `get-async`'s
+single fixed delay makes completion order and start order coincide, which
+is enough to show calls overlap but says nothing about dispatch order.

--- a/tools/wasip3_component_probe/interleaved_tasks/component.wat
+++ b/tools/wasip3_component_probe/interleaved_tasks/component.wat
@@ -1,0 +1,200 @@
+;; M1b-3c-1c probe: does a SECOND GUEST COMPUTATION interleave with the
+;; first's await points, on one stackful fiber?
+;;
+;; §3.8 left this open and Phase A's evidence pointed the wrong way
+;; (wit_bindgen's spawn_local drags in a FuturesUnordered executor plus
+;; context.get/set and waitable-set.poll). This probe tests the narrower,
+;; concrete question the codegen actually has to answer:
+;;
+;;   Can the guest dispatch continuations BY COMPLETION ORDER, so that a
+;;   second task's code runs in the MIDDLE of the first task's sequence of
+;;   awaits -- with no second stack, no context.get/set, and no poll loop?
+;;
+;; The design makes interleaving impossible to fake:
+;;
+;;   task A   await get-after(300)  ->  await get-after(300)  ->  log 1
+;;   task B   await get-after(100)  ->  log 2
+;;
+;; Both are started before either is waited on. B resolves at ~100ms, i.e.
+;; strictly BETWEEN A's first await (~300ms) and its second (~600ms). So:
+;;
+;;   log = [2, 1]  ->  returns 21.  B's continuation ran while A was still
+;;                     mid-sequence. That is interleaving.
+;;   log = [1, 2]  ->  returns 12.  A ran to completion first: serial.
+;;
+;; and total elapsed must be ~600ms (A's two awaits), not ~700ms (A's two
+;; plus B's one), confirming B overlapped rather than followed.
+;;
+;; A's state across its two awaits lives in a memory slot ($A_STATE), not on
+;; a stack -- a hand-rolled state machine, which is exactly the shape a
+;; CPS/suspend lowering (ADR-0076) generates. That is the point: it shows
+;; the ABI side needs nothing new, and localizes the remaining work to the
+;; guest-side state representation.
+;;
+;; Canon set: UNCHANGED from M1b-3c-1b/3c-3. In particular NO
+;; waitable-set.poll and NO context.get/set -- `waitable-set.wait` already
+;; reports WHICH waitable fired (payload[0]), which is all a completion-order
+;; dispatcher needs.
+;;
+;; Memory layout (the shared memhost page):
+;;    0  result slot, task A       32  log[0]
+;;    4  result slot, task B       36  log[1]
+;;   16  wait payload[0] = handle  40  A's state: 0 = first await pending,
+;;   20  wait payload[1] = status         1 = second await pending
+(component
+  (type $get-after-type (func async (param "ms" u32) (result u32)))
+  (type $run-type (func async (result u32)))
+  (import "get-after" (func $host-get-after (type $get-after-type)))
+
+  (core module $guest
+    (import "$root" "[async-lower]get-after" (func $get_after (param i32 i32) (result i32)))
+    (import "$root" "[waitable-set-new]" (func $ws_new (result i32)))
+    (import "$root" "[waitable-join]" (func $waitable_join (param i32 i32)))
+    (import "$root" "[waitable-set-wait]" (func $ws_wait (param i32 i32) (result i32)))
+    (import "$root" "[waitable-set-drop]" (func $ws_drop (param i32)))
+    (import "$root" "[subtask-drop]" (func $subtask_drop (param i32)))
+    (import "[export]$root" "[task-return]run" (func $task_return (param i32)))
+    (import "env" "memory" (memory 1))
+
+    (func $sched (result i32)
+      (local $packed i32)
+      (local $code i32)
+      (local $sub_a i32)
+      (local $sub_b i32)
+      (local $ws i32)
+      (local $pending i32)
+      (local $event0 i32)
+      (local $handle i32)
+      (local $status i32)
+      (local $logn i32)
+
+      (local.set $ws (call $ws_new))
+      (i32.store (i32.const 40) (i32.const 0))   ;; A: first await pending
+      (local.set $logn (i32.const 0))
+
+      ;; --- start A's FIRST await (300ms), results -> addr 0 ----------------
+      (local.set $packed (call $get_after (i32.const 300) (i32.const 0)))
+      (local.set $code (i32.and (local.get $packed) (i32.const 0xf)))
+      (local.set $sub_a (i32.shr_u (local.get $packed) (i32.const 4)))
+      (if (i32.eq (local.get $code) (i32.const 2))
+        (then unreachable)   ;; a 300ms call must not complete eagerly
+      )
+      (call $waitable_join (local.get $sub_a) (local.get $ws))
+
+      ;; --- start B (100ms), results -> addr 4 ------------------------------
+      ;; Issued BEFORE waiting on A. This is what lets B resolve first.
+      (local.set $packed (call $get_after (i32.const 100) (i32.const 4)))
+      (local.set $code (i32.and (local.get $packed) (i32.const 0xf)))
+      (local.set $sub_b (i32.shr_u (local.get $packed) (i32.const 4)))
+      (if (i32.eq (local.get $code) (i32.const 2))
+        (then unreachable)
+      )
+      (call $waitable_join (local.get $sub_b) (local.get $ws))
+
+      (local.set $pending (i32.const 2))   ;; two logical TASKS outstanding
+
+      ;; --- completion-order dispatch loop ----------------------------------
+      (block $all_done
+        (loop $retry
+          (local.set $event0 (call $ws_wait (local.get $ws) (i32.const 16)))
+          (if (i32.eq (local.get $event0) (i32.const 1))
+            (then
+              (local.set $handle (i32.load (i32.const 16)))
+              (local.set $status (i32.load (i32.const 20)))
+              (if (i32.eq (local.get $status) (i32.const 2))
+                (then
+                  (call $subtask_drop (local.get $handle))
+                  (if (i32.eq (local.get $handle) (local.get $sub_b))
+                    (then
+                      ;; ---- task B's continuation ----
+                      (i32.store (i32.add (i32.const 32)
+                                          (i32.mul (local.get $logn) (i32.const 4)))
+                                 (i32.const 2))
+                      (local.set $logn (i32.add (local.get $logn) (i32.const 1)))
+                      (local.set $pending (i32.sub (local.get $pending) (i32.const 1)))
+                    )
+                    (else
+                      ;; ---- task A's continuation ----
+                      (if (i32.eqz (i32.load (i32.const 40)))
+                        (then
+                          ;; A was at its FIRST await: advance the state
+                          ;; machine and issue the SECOND one. A stays
+                          ;; outstanding -- $pending is untouched.
+                          (i32.store (i32.const 40) (i32.const 1))
+                          (local.set $packed
+                            (call $get_after (i32.const 300) (i32.const 0)))
+                          (local.set $sub_a
+                            (i32.shr_u (local.get $packed) (i32.const 4)))
+                          (if (i32.eq (i32.and (local.get $packed) (i32.const 0xf))
+                                      (i32.const 2))
+                            (then unreachable)
+                          )
+                          ;; join into the SAME set, mid-loop
+                          (call $waitable_join (local.get $sub_a) (local.get $ws))
+                        )
+                        (else
+                          ;; A was at its SECOND await: A is done
+                          (i32.store (i32.add (i32.const 32)
+                                              (i32.mul (local.get $logn) (i32.const 4)))
+                                     (i32.const 1))
+                          (local.set $logn (i32.add (local.get $logn) (i32.const 1)))
+                          (local.set $pending
+                            (i32.sub (local.get $pending) (i32.const 1)))
+                        )
+                      )
+                    )
+                  )
+                  (br_if $all_done (i32.eqz (local.get $pending)))
+                )
+              )
+            )
+          )
+          (br $retry)
+        )
+      )
+      (call $ws_drop (local.get $ws))
+
+      ;; log[0]*10 + log[1]: 21 = B then A (interleaved), 12 = A then B.
+      (i32.add (i32.mul (i32.load (i32.const 32)) (i32.const 10))
+               (i32.load (i32.const 36)))
+    )
+
+    (func (export "run")
+      (call $task_return (call $sched))
+    )
+  )
+
+  (core module $memhost
+    (memory (export "memory") 1)
+  )
+  (core instance $mem-inst (instantiate $memhost))
+
+  (core func $core-get-after (canon lower (func $host-get-after) async (memory $mem-inst "memory")))
+  (core func $core-task-return (canon task.return (result u32)))
+  (core func $core-ws-new (canon waitable-set.new))
+  (core func $core-waitable-join (canon waitable.join))
+  (core func $core-ws-wait (canon waitable-set.wait (memory $mem-inst "memory")))
+  (core func $core-ws-drop (canon waitable-set.drop))
+  (core func $core-subtask-drop (canon subtask.drop))
+
+  (core instance $guest-inst (instantiate $guest
+    (with "$root" (instance
+      (export "[async-lower]get-after" (func $core-get-after))
+      (export "[waitable-set-new]" (func $core-ws-new))
+      (export "[waitable-join]" (func $core-waitable-join))
+      (export "[waitable-set-wait]" (func $core-ws-wait))
+      (export "[waitable-set-drop]" (func $core-ws-drop))
+      (export "[subtask-drop]" (func $core-subtask-drop))
+    ))
+    (with "[export]$root" (instance
+      (export "[task-return]run" (func $core-task-return))
+    ))
+    (with "env" (instance
+      (export "memory" (memory $mem-inst "memory"))
+    ))
+  ))
+
+  (func (export "run") (type $run-type)
+    (canon lift (core func $guest-inst "run") async (memory $mem-inst "memory"))
+  )
+)

--- a/tools/wasip3_component_probe/interleaved_tasks/serial_control.wat
+++ b/tools/wasip3_component_probe/interleaved_tasks/serial_control.wat
@@ -1,0 +1,115 @@
+;; NEGATIVE CONTROL for component.wat (M1b-3c-1c, #1230).
+;;
+;; Identical component -- same canon set, same host import, same two logical
+;; tasks, same delays, same log encoding -- with ONE difference: task A is
+;; awaited to completion BEFORE task B is even started. So nothing overlaps.
+;;
+;; It exists to show the interleaving probe's assertions actually
+;; discriminate. Measured through runtime/viberun:
+;;
+;;   component.wat        21  in ~615ms   (B logged first; total = A's own
+;;                                        2x300ms, so B overlapped)
+;;   serial_control.wat   12  in ~714ms   (A logged first; total = 300+300+100)
+;;
+;; Both the value AND the wall-clock separate the two. A gate asserting only
+;; "returns 21" would still be meaningful, but a gate asserting only "both
+;; tasks completed" would pass on this file too.
+(component
+  (type $get-after-type (func async (param "ms" u32) (result u32)))
+  (type $run-type (func async (result u32)))
+  (import "get-after" (func $host-get-after (type $get-after-type)))
+
+  (core module $guest
+    (import "$root" "[async-lower]get-after" (func $get_after (param i32 i32) (result i32)))
+    (import "$root" "[waitable-set-new]" (func $ws_new (result i32)))
+    (import "$root" "[waitable-join]" (func $waitable_join (param i32 i32)))
+    (import "$root" "[waitable-set-wait]" (func $ws_wait (param i32 i32) (result i32)))
+    (import "$root" "[waitable-set-drop]" (func $ws_drop (param i32)))
+    (import "$root" "[subtask-drop]" (func $subtask_drop (param i32)))
+    (import "[export]$root" "[task-return]run" (func $task_return (param i32)))
+    (import "env" "memory" (memory 1))
+
+    (func $sched (result i32)
+      (local $packed i32)
+      (local $sub i32)
+      (local $ws i32)
+      (local $event0 i32)
+      (local $logn i32)
+      (local.set $ws (call $ws_new))
+      (local.set $logn (i32.const 0))
+      ;; A await 1
+      (local.set $packed (call $get_after (i32.const 300) (i32.const 0)))
+      (local.set $sub (i32.shr_u (local.get $packed) (i32.const 4)))
+      (call $waitable_join (local.get $sub) (local.get $ws))
+      (block $d1 (loop $r1
+        (local.set $event0 (call $ws_wait (local.get $ws) (i32.const 16)))
+        (br_if $d1 (i32.and (i32.eq (local.get $event0) (i32.const 1))
+                            (i32.eq (i32.load (i32.const 20)) (i32.const 2))))
+        (br $r1)))
+      (call $subtask_drop (local.get $sub))
+      ;; A await 2
+      (local.set $packed (call $get_after (i32.const 300) (i32.const 0)))
+      (local.set $sub (i32.shr_u (local.get $packed) (i32.const 4)))
+      (call $waitable_join (local.get $sub) (local.get $ws))
+      (block $d2 (loop $r2
+        (local.set $event0 (call $ws_wait (local.get $ws) (i32.const 16)))
+        (br_if $d2 (i32.and (i32.eq (local.get $event0) (i32.const 1))
+                            (i32.eq (i32.load (i32.const 20)) (i32.const 2))))
+        (br $r2)))
+      (call $subtask_drop (local.get $sub))
+      (i32.store (i32.const 32) (i32.const 1))
+      ;; B, only now
+      (local.set $packed (call $get_after (i32.const 100) (i32.const 4)))
+      (local.set $sub (i32.shr_u (local.get $packed) (i32.const 4)))
+      (call $waitable_join (local.get $sub) (local.get $ws))
+      (block $d3 (loop $r3
+        (local.set $event0 (call $ws_wait (local.get $ws) (i32.const 16)))
+        (br_if $d3 (i32.and (i32.eq (local.get $event0) (i32.const 1))
+                            (i32.eq (i32.load (i32.const 20)) (i32.const 2))))
+        (br $r3)))
+      (call $subtask_drop (local.get $sub))
+      (i32.store (i32.const 36) (i32.const 2))
+      (call $ws_drop (local.get $ws))
+      (i32.add (i32.mul (i32.load (i32.const 32)) (i32.const 10))
+               (i32.load (i32.const 36)))
+    )
+
+    (func (export "run")
+      (call $task_return (call $sched))
+    )
+  )
+
+  (core module $memhost
+    (memory (export "memory") 1)
+  )
+  (core instance $mem-inst (instantiate $memhost))
+
+  (core func $core-get-after (canon lower (func $host-get-after) async (memory $mem-inst "memory")))
+  (core func $core-task-return (canon task.return (result u32)))
+  (core func $core-ws-new (canon waitable-set.new))
+  (core func $core-waitable-join (canon waitable.join))
+  (core func $core-ws-wait (canon waitable-set.wait (memory $mem-inst "memory")))
+  (core func $core-ws-drop (canon waitable-set.drop))
+  (core func $core-subtask-drop (canon subtask.drop))
+
+  (core instance $guest-inst (instantiate $guest
+    (with "$root" (instance
+      (export "[async-lower]get-after" (func $core-get-after))
+      (export "[waitable-set-new]" (func $core-ws-new))
+      (export "[waitable-join]" (func $core-waitable-join))
+      (export "[waitable-set-wait]" (func $core-ws-wait))
+      (export "[waitable-set-drop]" (func $core-ws-drop))
+      (export "[subtask-drop]" (func $core-subtask-drop))
+    ))
+    (with "[export]$root" (instance
+      (export "[task-return]run" (func $core-task-return))
+    ))
+    (with "env" (instance
+      (export "memory" (memory $mem-inst "memory"))
+    ))
+  ))
+
+  (func (export "run") (type $run-type)
+    (canon lift (core func $guest-inst "run") async (memory $mem-inst "memory"))
+  )
+)


### PR DESCRIPTION
The last open item on #1230's roadmap. **The answer contradicts what the spec predicted**, which shrinks the remaining work rather than growing it.

## What §3.8 predicted, and why it was wrong

§3.8 concluded that concurrent guest work *"requires either another Component-Model task or a guest-side poll executor"*, citing Phase A's measurement that `wit_bindgen::spawn_local` drags in a `FuturesUnordered` executor plus `context.get/set` and `waitable-set.poll`.

Phase A was measuring wit-bindgen's **callback** form — the explicit state machine that re-enters through a `[callback]` export on every wake event. Under the **stackful** form vibe emits, `waitable-set.wait` already reports *which* waitable fired (payload[0]), and completion-order dispatch is all interleaving needs.

## The probe

Built so it cannot pass by accident:

```
  task A   await get-after(300) -> await get-after(300) -> log 1
  task B   await get-after(100)                         -> log 2
```

Both issued before either is waited on; result = `log[0]*10 + log[1]`.

| | result | elapsed | reading |
|---|---|---|---|
| `component.wat` | **21** | **613ms** | B's continuation ran while A was still mid-sequence, and the total is A's **own** two awaits — B cost nothing |
| `serial_control.wat` | **12** | **713ms** | A awaited to completion first: 300 + 300 + 100 |

**`serial_control.wat` is committed and run by the gate too.** It is the same component — same canon set, same host import, same delays, same log encoding — with only the ordering changed, and it must produce the *opposite* answer on both the value and the clock. Without it, "returns 21" would be an assertion with no evidence that it discriminates.

Timeline: at t=0 both A's first await and B are issued; **at t=100 B resolves and its continuation runs** while A is still waiting; at t=300 A advances its state machine and issues its second await; at t=600 A's continuation runs.

## Established / still open

**Established** — two logical guest computations interleave at their await points on **one** stackful fiber. No second stack, no `context.get/set`, no `waitable-set.poll`. The canon set is unchanged from M1b-3c-1b.

**Still open** — A's state across its two awaits is a hand-placed memory slot here, i.e. a hand-rolled state machine. Performing that transformation for arbitrary vibe source *is* ADR-0076's CPS/suspend lowering. So the remaining M1b-3c-1c work is **localized to codegen**, and is smaller than the old estimate now that "needs another task or a poll executor" is off the table.

No emitter in this PR — same mechanics-only phase as M1b-3c-1a. Lowering real `.vibe` source to this shape needs the state representation above first.

## Also

`viberun` gains `get-after: async func(u32) -> u32`. The existing `get-async` has one fixed delay, so every in-flight call resolves at the same instant — enough to show calls *overlap* (M1b-3c-3), but unable to say anything about the *order* continuations run in, since completion order and start order coincide. Nothing else exercises it, which is part of why the new gate is worth having.

## Test plan

- [x] `scripts/test_interleaved_tasks_probe_gate.sh` — interleaved 21/613ms, serial control 12/713ms, overlap saved 101ms
- [x] `scripts/compiler_gate.sh` — **70/70**
- [x] `scripts/test_spawned_future_component_gate.sh` — green against the changed viberun
- [x] `scripts/test_concurrent_awaits_component_gate.sh` — green against the changed viberun
- [x] `scripts/test_async_component_gate.sh` — **8/8**
- [x] Core-module path re-verified unaffected
- [x] No compiler `.vibe` source touched, so no bundle regeneration or unit-test impact

## Docs

`docs/spec/wasi-p3-async.md` gains §3.11, **and §3.8's superseded paragraph now carries an inline correction pointing at it** — the wrong prediction stays visible with the disproof attached rather than being quietly edited away. Milestone row updated to "mechanics done / emitter未着手". Probe README section added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_