### PR TITLE
Fix the unreachable seed fallback in six gate scripts; uncache the job-pool gate

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -156,7 +156,23 @@ local testConcurrentAwaitsComponent =
   scriptTask("test-concurrent-awaits-component", "scripts/test_concurrent_awaits_component_gate.sh")
 local testInterleavedTasksProbe =
   scriptTask("test-interleaved-tasks-probe", "scripts/test_interleaved_tasks_probe_gate.sh")
-local benchModuleJobPool = scriptTask("bench-module-job-pool", "scripts/bench_module_job_pool.sh")
+
+// Uncached (like kpi-selfcompile) because neither of the two things this
+// asserts is a function of the file inputs. The hard assertion is a race
+// detector -- outcome/fingerprint/env must stay byte-identical at -P 1/2/4/8 --
+// and re-running it on an unchanged tree is exactly the point. The speedup
+// floor depends on host cores and load, and the VIBE_JOBPOOL_BENCH_* overrides
+// are invisible to the input set, so a cache hit would report success for a
+// configuration it never measured.
+local benchModuleJobPool = new Task {
+  name = "bench-module-job-pool"
+  description =
+    "module-job process pool: determinism at -P 1/2/4/8 (gate) + parallel speedup (measured)"
+  cmd = "bash scripts/bench_module_job_pool.sh"
+  cache = false
+  inputs { ...moonSources; ...scriptSources }
+}
+
 local testWasiHttpP3Full =
   scriptTask("test-wasi-http-p3-full", "scripts/test_wasi_http_p3_full_gate.sh")
 local testWasiP3Guarantee = scriptTask("test-wasi-p3", "scripts/test_wasi_p3_guarantee_gate.sh")

--- a/scripts/bench_module_job_pool.sh
+++ b/scripts/bench_module_job_pool.sh
@@ -68,7 +68,10 @@ fi
 
 COMPILER="${VIBE_JOBPOOL_BENCH_COMPILER:-}"
 if [ -z "$COMPILER" ]; then
-  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1)stage2.wasm"
+  # `|| true`: with no generations dir the glob does not expand, ls exits
+  # nonzero, and pipefail would abort the script here -- making the seed
+  # fallback on the next line unreachable in a fresh checkout.
+  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
   [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
 fi
 [ -f "$COMPILER" ] || require_or_skip "no compiler wasm found"

--- a/scripts/emit_async_lift_fixture.sh
+++ b/scripts/emit_async_lift_fixture.sh
@@ -12,7 +12,9 @@
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
-STAGE2="$(ls -dt _build/selfhost/generations/*/ 2>/dev/null | head -1)stage2.wasm"
+# `|| true`: no generations dir => ls exits nonzero => pipefail would abort
+# here, skipping the explanatory message below.
+STAGE2="$(ls -dt _build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
 [ -s "$STAGE2" ] || { echo "no stage2 — run: bash scripts/generations.sh build" >&2; exit 1; }
 WORK="_build/_emit_async_fixture"; mkdir -p "$WORK"
 cat > "$WORK/emit.vibe" <<'EOF'

--- a/scripts/test_async_component_gate.sh
+++ b/scripts/test_async_component_gate.sh
@@ -50,7 +50,9 @@ echo "[async-component-gate] wasmtime: $("$WASMTIME_BIN" --version)"
 
 COMPILER="${VIBE_ASYNC_GATE_COMPILER:-}"
 if [ -z "$COMPILER" ]; then
-  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1)stage2.wasm"
+  # `|| true`: no generations dir => ls exits nonzero => pipefail would abort
+  # before the seed fallback below could run.
+  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
   [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
 fi
 echo "[async-component-gate] compiler: $COMPILER"

--- a/scripts/test_concurrent_awaits_component_gate.sh
+++ b/scripts/test_concurrent_awaits_component_gate.sh
@@ -96,7 +96,9 @@ fi
 
 COMPILER="${VIBE_CONCURRENT_AWAITS_GATE_COMPILER:-}"
 if [ -z "$COMPILER" ]; then
-  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1)stage2.wasm"
+  # `|| true`: no generations dir => ls exits nonzero => pipefail would abort
+  # before the seed fallback below could run.
+  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
   [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
 fi
 echo "[concurrent-awaits-gate] compiler: $COMPILER"

--- a/scripts/test_real_async_host.sh
+++ b/scripts/test_real_async_host.sh
@@ -33,7 +33,9 @@ fi
 
 # End-to-end for a real VIBE program: the selfhost compiles `sleep` to a
 # `vibe.sleep` host import; the async host suspends/resumes the guest fiber.
-STAGE2="$(ls -dt _build/selfhost/generations/*/ 2>/dev/null | head -1)stage2.wasm"
+# `|| true`: no generations dir => ls exits nonzero => pipefail would abort the
+# gate outright instead of taking the "no stage2, skip this section" branch.
+STAGE2="$(ls -dt _build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
 if [ -s "$STAGE2" ]; then
   echo "[real-async-host] vibe end-to-end: compiling examples/wasm/sleep_async.vibe"
   vdir="_build/_realasync_vibe"; mkdir -p "$vdir"

--- a/scripts/test_spawned_future_component_gate.sh
+++ b/scripts/test_spawned_future_component_gate.sh
@@ -105,7 +105,9 @@ fi
 
 COMPILER="${VIBE_SPAWNED_FUTURE_GATE_COMPILER:-}"
 if [ -z "$COMPILER" ]; then
-  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1)stage2.wasm"
+  # `|| true`: no generations dir => ls exits nonzero => pipefail would abort
+  # before the seed fallback below could run.
+  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
   [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
 fi
 echo "[spawned-future-component-gate] compiler: $COMPILER"


### PR DESCRIPTION
Two P2 review findings on #1248, both real. #1248 was already merged, so this follows the merged-PR convention: branch restarted from `main`, new PR.

## 1. The seed fallback was dead code

```bash
COMPILER="$(ls -td .../generations/*/ 2>/dev/null | head -1)stage2.wasm"
[ -f "$COMPILER" ] || COMPILER=".../bootstrap/seed/compiler.wasm"
```

With no generations directory the glob does not expand, `ls` exits 2, and under `set -euo pipefail` the assignment aborts the script — so line two, the fallback that exists precisely for that case, can never run. Verified in isolation: the snippet exits 2 before printing anything.

The consequence is that these scripts fail in **the repository's seed-only bootstrap state**, which is the one state the fallback was written for.

`|| true` is what the older scripts already do (`compiler_gate.sh`, `build_cli_wasm.sh`, `coverage_suite.sh`, `test_dist_stage2_parity.sh`, `test_gc_selfbuild.sh`). The review flagged `bench_module_job_pool.sh`; the same line had been copied into five more, so all six are fixed rather than leaving the newer ones broken:

| script | what the abort costs |
|---|---|
| `bench_module_job_pool.sh` | seed fallback unreachable |
| `test_async_component_gate.sh` | seed fallback unreachable |
| `test_concurrent_awaits_component_gate.sh` | seed fallback unreachable |
| `test_spawned_future_component_gate.sh` | seed fallback unreachable |
| `emit_async_lift_fixture.sh` | "no stage2 — run: …" message unreachable |
| `test_real_async_host.sh` | aborts the gate instead of taking its skip branch |

## 2. `bench-module-job-pool` must not be cached

It was registered through the plain `scriptTask` helper, which caches on file inputs. Neither thing this task asserts is a function of those inputs:

- The hard assertion is a **race detector** — `outcome`/`fingerprint`/`env` byte-identical at `-P 1/2/4/8`, which is #1239's own acceptance criterion. Re-running it on an unchanged tree is the entire point.
- The speedup floor depends on host cores and load.
- The `VIBE_JOBPOOL_BENCH_*` overrides are invisible to the input set, so a cache hit could report success for a configuration it never measured.

Now a full `Task` with `cache = false`, like `kpi-selfcompile`. The other bench tasks (`bench-http`, `bench-cmd-latency`, `bench-cache-probe`, `bench-loader-hotspots`) are deliberately left cached — they report numbers, they do not gate.

## Test plan

- [x] fallback selects `bootstrap/seed/compiler.wasm` with no generations dir (exit 0), and still selects the newest `stage2.wasm` when one exists
- [x] `scripts/bench_module_job_pool.sh` — passes; identical results at `-P 1/2/4/8`; 3.41x at `-P 4` on 4 cores
- [x] `scripts/test_async_component_gate.sh` — passes
- [x] `bash -n` on all six scripts

No compiler source touched, so no bundle regeneration and no unit-test impact.

https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_