### PR TITLE
#1239 step 4(D): make --jobs use the process pool, and gate the determinism

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -157,6 +157,18 @@ local testConcurrentAwaitsComponent =
 local testInterleavedTasksProbe =
   scriptTask("test-interleaved-tasks-probe", "scripts/test_interleaved_tasks_probe_gate.sh")
 
+// Uncached for the same reason as bench-module-job-pool below: the assertion
+// is that what the warm-pool coordinator publishes does not depend on how much
+// of it ran at once, and re-running that on an unchanged tree is the point.
+local testParallelWarmPool = new Task {
+  name = "test-warm-pool"
+  description =
+    "warm-pool coordinator: plan_module_order ranks + byte-identical publish at -P 1/2/4/8"
+  cmd = "bash scripts/test_parallel_warm_pool_gate.sh"
+  cache = false
+  inputs { ...moonSources; ...scriptSources }
+}
+
 // Uncached (like kpi-selfcompile) because neither of the two things this
 // asserts is a function of the file inputs. The hard assertion is a race
 // detector -- outcome/fingerprint/env must stay byte-identical at -P 1/2/4/8 --
@@ -812,6 +824,7 @@ tasks {
   testSpawnedFutureComponent
   testConcurrentAwaitsComponent
   testInterleavedTasksProbe
+  testParallelWarmPool
   benchModuleJobPool
   testWasiHttpP3Full
   testWasiP3Guarantee

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -333,6 +333,42 @@ compile_to() {
 maybe_warm_frontend_cache() {
   local jobs="$1" src="$2"
   [ "$jobs" -gt 1 ] || return 0
+  # Preferred path (#1239 step 4(D)): the process-pool coordinator. It needs
+  # only bash and the runner this launcher already uses, so unlike the node
+  # driver below it works in an installed toolchain -- install.sh puts it in
+  # lib/ next to vibe_pkg.sh, and a dev checkout finds it under scripts/.
+  #
+  # It also gets to use pick_cli's choice, which the node driver cannot: a
+  # .cwasm is a wasmtime AOT image that only viberun can load, and that is the
+  # difference between ~8ms and ~485ms of startup per module job (#1248). Every
+  # worker here is a fresh process, so that cost is paid once per job.
+  local pool=""
+  local cand
+  for cand in "$TOOLCHAIN_DIR/lib/parallel_warm_pool.sh" \
+              "$TOOLCHAIN_DIR/scripts/parallel_warm_pool.sh"; do
+    [ -f "$cand" ] && { pool="$cand"; break; }
+  done
+  if [ -n "$pool" ]; then
+    local pool_log; pool_log="$(mktemp -t vibe-jobs-pool-XXXXXX)"
+    local pool_status=0
+    # `$src` verbatim, and the same guarded-timeout dispatch as below.
+    if command -v timeout >/dev/null 2>&1; then
+      timeout 600 bash "$pool" "$(pick_cli)" "$src" "$jobs" "$RUNNER" >"$pool_log" 2>&1 || pool_status=$?
+    elif command -v gtimeout >/dev/null 2>&1; then
+      gtimeout 600 bash "$pool" "$(pick_cli)" "$src" "$jobs" "$RUNNER" >"$pool_log" 2>&1 || pool_status=$?
+    else
+      bash "$pool" "$(pick_cli)" "$src" "$jobs" "$RUNNER" >"$pool_log" 2>&1 || pool_status=$?
+    fi
+    if [ "$pool_status" -eq 0 ]; then
+      rm -f "$pool_log"
+      return 0
+    fi
+    # Same advisory contract as the node driver: report and fall through. The
+    # node path below is tried next, and failing that the serial compile that
+    # runs after every call site produces the identical result anyway.
+    echo "vibe: --jobs=$jobs process-pool pre-warm failed, trying the node driver: $(tail -1 "$pool_log")" >&2
+    rm -f "$pool_log"
+  fi
   local driver="$TOOLCHAIN_DIR/scripts/parallel_frontend_warm.mjs"
   local node_runner="$TOOLCHAIN_DIR/scripts/run_wasm_vibe_host_runner.sh"
   if [ ! -f "$driver" ] || [ ! -f "$node_runner" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,6 +130,11 @@ say "launcher -> $TC_DIR/bin/vibe"
 # `vibe pkg` delegates to vibe_pkg.sh (#805); ship it with the toolchain so
 # the package/registry lane works standalone (no checkout needed).
 install -m 0644 "$ROOT_DIR/scripts/vibe_pkg.sh" "$TC_DIR/lib/vibe_pkg.sh"
+# #1239 step 4(D): the `--jobs=N` process-pool pre-warm. Shipping it is what
+# makes `--jobs` more than a no-op in an installed toolchain -- the older node
+# driver lives in the dev-repo scripts/ tree only, so `vibe` there printed a
+# note and compiled serially. Needs nothing but bash and the installed runner.
+install -m 0644 "$ROOT_DIR/scripts/parallel_warm_pool.sh" "$TC_DIR/lib/parallel_warm_pool.sh"
 say "pkg tool -> $TC_DIR/lib/vibe_pkg.sh"
 if [ -f "$ROOT_DIR/clients/js/lsp_server.js" ]; then
   install -m 0644 "$ROOT_DIR/clients/js/lsp_server.js" "$TC_DIR/lib/lsp_server.js"

--- a/scripts/test_parallel_warm_pool_gate.sh
+++ b/scripts/test_parallel_warm_pool_gate.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Warm-pool coordinator gate (#1239 step 4(D)).
+#
+# The coordinator (scripts/parallel_warm_pool.sh) dispatches module jobs a
+# whole plan_module_order rank at a time. This pins the property that makes
+# such a schedule safe to turn on, which is #1239's own acceptance criterion:
+#
+#   what it publishes must not depend on how much of it ran at once.
+#
+# Asserted on BYTES, not just key names. A coordinator that raced could
+# plausibly publish the same set of fingerprints with one module's env built
+# from a half-written dependency -- identical key list, different content --
+# so comparing the manifest alone would miss exactly the bug this exists for.
+#
+# Also asserted: the plan mode itself (ranks, cycle rejection), since the
+# coordinator's correctness rests on it and a wrong rank shows up here as a
+# schedule that happens to work on a small graph rather than as a failure.
+#
+# Env:
+#   VIBE_WARM_POOL_GATE_COMPILER  compiler wasm/cwasm override
+#   VIBE_WARM_POOL_GATE_RUNNER    runner override
+#   VIBE_P3_GATE_REQUIRE_TOOLS=1  missing tools = FAIL instead of skip
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/test/warm_pool_gate}"
+SAMPLE="$PROJECT_ROOT/scripts/fixtures/parallel_project_sample"
+
+require_or_skip() {
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "warm-pool gate FAILED: $1 (required mode)" >&2
+    exit 1
+  fi
+  echo "warm-pool gate skipped: $1"
+  exit 0
+}
+
+RUNNER="${VIBE_WARM_POOL_GATE_RUNNER:-$PROJECT_ROOT/runtime/viberun/target/release/viberun}"
+if [ ! -x "$RUNNER" ]; then
+  command -v cargo >/dev/null 2>&1 || require_or_skip "viberun not built and cargo not installed"
+  echo "[warm-pool-gate] building viberun..."
+  (cd "$PROJECT_ROOT/runtime/viberun" && cargo build --release >/dev/null 2>&1) \
+    || require_or_skip "failed to build runtime/viberun"
+fi
+
+COMPILER="${VIBE_WARM_POOL_GATE_COMPILER:-}"
+if [ -z "$COMPILER" ]; then
+  # `|| true`: no generations dir => ls exits nonzero => pipefail would abort
+  # before the seed fallback below could run.
+  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
+  [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
+fi
+[ -f "$COMPILER" ] || require_or_skip "no compiler wasm found"
+COMPILER="$(cd "$(dirname "$COMPILER")" && pwd)/$(basename "$COMPILER")"
+[ -d "$SAMPLE" ] || require_or_skip "sample project missing: $SAMPLE"
+
+echo "[warm-pool-gate] compiler: $COMPILER"
+rm -rf "$OUT_DIR"; mkdir -p "$OUT_DIR"
+
+fail=0
+die() { echo "warm-pool gate FAILED: $*" >&2; fail=1; }
+
+# --- 1. the plan mode: ranks, tie-breaking, cycle rejection ------------------
+#
+# A diamond is the discriminating shape: root depends on a and b, both of
+# which depend on c. Nothing may schedule c after a or b, and a/b must land
+# in the SAME rank -- a plan that serialized them would still "work" but
+# would give the coordinator no parallelism at all, silently.
+# Sets PLAN and PLAN_DIAG. Deliberately NOT a function that echoes its result:
+# `X="$(plan_of ...)"` runs the body in a subshell, so any variable it set
+# there would be lost -- both outputs travel through files instead.
+run_plan() {  # run_plan <edges-file>
+  local edges="$1" out="$OUT_DIR/plan.out"
+  rm -f "$out" "$out.diag"
+  env VIBE_PLAN_MODULE_ORDER=1 timeout 300 "$RUNNER" "$COMPILER" "$edges" "$out" __no_entry__ \
+    >/dev/null 2>&1 || true
+  PLAN="$(cat "$out" 2>/dev/null || true)"
+  PLAN_DIAG="$(cat "$out.diag" 2>/dev/null || true)"
+}
+PLAN=""
+PLAN_DIAG=""
+
+printf 'root.vibe\ta.vibe\tb.vibe\na.vibe\tc.vibe\nb.vibe\tc.vibe\nc.vibe\n' > "$OUT_DIR/diamond.tsv"
+run_plan "$OUT_DIR/diamond.tsv"
+DIAMOND="$PLAN"
+EXPECTED="$(printf '0\tc.vibe\n1\ta.vibe\n1\tb.vibe\n2\troot.vibe')"
+if [ "$DIAMOND" != "$EXPECTED" ]; then
+  die "diamond plan is not the canonical order (rank asc, then path asc)"
+  printf 'expected:\n%s\ngot:\n%s\n' "$EXPECTED" "$DIAMOND" >&2
+else
+  echo "[warm-pool-gate] diamond plan ok (c=0, {a,b}=1 share a rank, root=2)"
+fi
+
+printf 'x.vibe\ty.vibe\ny.vibe\tx.vibe\n' > "$OUT_DIR/cycle.tsv"
+run_plan "$OUT_DIR/cycle.tsv"
+CYC="$PLAN"
+# The wording must match ensure_fingerprint_fs_go's inline check: moving the
+# rejection upfront must not change what a user sees.
+case "$PLAN_DIAG" in
+  *"import cycle detected"*) echo "[warm-pool-gate] cycle rejected: $PLAN_DIAG" ;;
+  *) die "a cyclic graph produced no cycle diagnostic (plan=[$CYC] diag=[$PLAN_DIAG])" ;;
+esac
+[ -z "$CYC" ] || die "a cyclic graph still produced a plan: [$CYC]"
+
+: > "$OUT_DIR/empty.tsv"
+run_plan "$OUT_DIR/empty.tsv"
+EMPTY="$PLAN"
+if [ -n "$EMPTY" ] || [ -n "$PLAN_DIAG" ]; then
+  die "empty graph should yield an empty plan and no diagnostic (plan=[$EMPTY] diag=[$PLAN_DIAG])"
+else
+  echo "[warm-pool-gate] empty graph ok (empty plan, no diagnostic)"
+fi
+
+# --- 2. the coordinator: identical published bytes at every parallelism ------
+snapshot_cache() {  # snapshot_cache <cachedir> -> "<relpath> <sha256>" per line
+  ( cd "$1" && find . -type f | sort | while IFS= read -r f; do
+      printf '%s %s\n' "$f" "$(sha256sum <"$f" | cut -d' ' -f1)"
+    done )
+}
+
+BASE=""
+for P in 1 2 4 8; do
+  CACHE="$OUT_DIR/cache.$P"
+  rm -rf "$CACHE"; mkdir -p "$CACHE"
+  if ! ( cd "$SAMPLE" && VIBE_BUILD_CACHE_DIR="$CACHE" timeout 900 \
+           bash "$PROJECT_ROOT/scripts/parallel_warm_pool.sh" "$COMPILER" main.vibe "$P" "$RUNNER" \
+           > "$OUT_DIR/warm.$P.log" 2>&1 ); then
+    die "coordinator exited nonzero at -P $P: $(tail -1 "$OUT_DIR/warm.$P.log")"
+    continue
+  fi
+  snapshot_cache "$CACHE" > "$OUT_DIR/snap.$P"
+  ENTRIES="$(wc -l < "$OUT_DIR/snap.$P" | tr -d ' ')"
+  # A run that published nothing would compare equal to every other empty run,
+  # so the whole determinism assertion below would pass vacuously.
+  if [ "$ENTRIES" -eq 0 ]; then
+    die "-P $P published no cache entries at all -- the comparison below would be vacuous"
+    continue
+  fi
+  if [ -z "$BASE" ]; then
+    BASE="$P"
+    echo "[warm-pool-gate] -P $P: $ENTRIES cache entries ($(tail -1 "$OUT_DIR/warm.$P.log"))"
+  elif diff -q "$OUT_DIR/snap.$BASE" "$OUT_DIR/snap.$P" >/dev/null; then
+    echo "[warm-pool-gate] -P $P: $ENTRIES entries, byte-identical to -P $BASE"
+  else
+    die "-P $P published different bytes than -P $BASE -- what the warm publishes depends on scheduling"
+    diff "$OUT_DIR/snap.$BASE" "$OUT_DIR/snap.$P" | head -10 >&2
+  fi
+done
+
+[ "$fail" = "0" ] || exit 1
+echo "warm-pool gate passed"


### PR DESCRIPTION
Closes out 4(D). The coordinator landed in #1250 but nothing called it and nothing checked it. Both now.

## `--jobs` actually does something in an installed toolchain

`maybe_warm_frontend_cache` tries the process pool first and keeps the node driver as a fallback. Two things change:

- **It needs only bash and the runner the launcher already uses**, so it works where the node driver never could. That driver lives in the dev-repo `scripts/` tree, so an installed `vibe --jobs=4` printed *"needs the dev-repo parallel driver scripts"* and compiled serially. `install.sh` now ships the pool into `lib/` next to `vibe_pkg.sh`.
- **It gets `pick_cli`'s choice.** A `.cwasm` is a wasmtime AOT image only viberun can load — the node driver's own comment called that out as the reason it always used the portable `.wasm`. That is ~8ms vs ~485ms of startup per module job (#1248), paid once per job because every worker is a fresh process.

The advisory contract is unchanged: a pool failure reports and falls through to the node driver, and failing that to the serial compile that runs after every call site regardless.

## The gate

`scripts/test_parallel_warm_pool_gate.sh` asserts what makes the schedule safe to turn on — #1239's own acceptance criterion:

> what the warm publishes must not depend on how much of it ran at once

On **bytes**, not the manifest. A coordinator that raced could publish the same fingerprint set with one env built from a half-written dependency: same key list, different content. Comparing keys alone would miss the exact bug this exists for. A run that publishes nothing is failed explicitly, so the comparison cannot pass vacuously.

It also covers the plan mode the coordinator rests on: diamond ranks (`c=0`, `{a,b}=1` sharing a rank, `root=2`), cycle rejection with the serial walk's own wording, empty graph. A plan that serialized `a` and `b` would still "work" while giving the coordinator no parallelism at all, silently — hence asserting the exact canonical order rather than just "it ran".

Uncached in `Taskfile.pkl`, same reasoning as `bench-module-job-pool`.

## Test plan

- [x] warm-pool gate passes: ranks ok, cycle rejected, 6 cache entries byte-identical at `-P 1/2/4/8`
- [x] **mutation test** — dispatching all ranks at once instead of rank-by-rank makes the gate fail at `-P 2` with the intended message. It still passes at `-P 1`, which is why the parallel comparison is the assertion and not a sanity check
- [x] `vibe build --jobs=1` and `--jobs=4` produce byte-identical wasm (796 B)
- [x] **the pool path is really taken** — proven by replacing the script with a marker that exits 3: the marker surfaces, the node fallback engages, the build still succeeds. Output equality alone could not distinguish "pool ran" from "silently fell back to node"
- [x] `install.sh` smoke: pool lands in `toolchains/main/lib/`, and the installed `vibe build --jobs=4` succeeds with no warning on stderr
- [x] full `compiler_gate.sh`: 70/70, no FAIL, no drift

No compiler source touched, so no bundle regeneration.

## What remains in #1239

Step 5 (canonical diagnostic ordering, `--jobs=1/2/4` identical) now has something to verify. `ensure_fingerprint_fs_go` is still the sequential path for the reasons given in #1250 — its recursion threads state through dependencies in sequence, which is a separate blocker from the one #1248 disproved.

https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_