### PR TITLE
#1256 review: mark the Task front-end bullets retired, drop the timeout coverage claim

### DIFF
--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -140,15 +140,25 @@ cancel point、failure propagation、handler task-affinity は ADR-0068 に従�
 #### 2.4/2.5 front-end（landed）
 
 M1a と同じ要領で、lexer/parser/core-Type を変えずに着地:
-- `Stream[T]` / `Task[T]` は `CtNamed("Stream"/"Task", _)` で構造表現（要素型は
-  gradual な `CtUnknown`）。`Future[Option[T]]` は `CtNamed("Future",
+
+**Stream 側（landed、現行）**
+- `Stream[T]` は `CtNamed("Stream", _)` で構造表現（要素型は gradual な
+  `CtUnknown`）。`Future[Option[T]]` は `CtNamed("Future",
   [CtOption(CtUnknown)])`。
-- builtin は `lib/@vibe/compiler/checker/builtins_async.vibe`（`lookup_stream` /
-  `lookup_concurrency`、`lookup_builtin` 経由）に登録。suspend / runtime 接触
-  操作（`*::next`/`fold`/`spawn`/`join`/`cancel`/`race`/`timeout`）は `Async`
-  effect を帯び、effect-escape チェックがそのまま機能する。
-- 検証: `checker_async_test.vibe` 13/13、`checker_effects_test.vibe` 19/19
-  （無回帰）。
+- builtin は `lib/@vibe/compiler/checker/builtins_async.vibe` の `lookup_stream`
+  （`lookup_builtin` 経由）に登録。suspend / runtime 接触操作
+  （`*::next`/`fold`）は `Async` effect を帯び、effect-escape チェックが
+  そのまま機能する。
+
+**Task 側（RETIRED in #1227、以下は当時の記録）**
+- ~~`Task[T]` は `CtNamed("Task", _)` で構造表現。~~
+- ~~builtin は同ファイルの `lookup_concurrency` に登録。`spawn`/`join`/`cancel`/
+  `race`/`timeout` は `Async` effect を帯びる。~~ 現在
+  `lookup_concurrency` は**無条件に `None` を返す**——これらの名前は
+  `unknown name` になる。
+- 検証: `checker_async_test.vibe` は「登録されている」ことを assert する4
+  テストを、「登録されていない」ことを pin する1テストに置き換えてある
+  （#1227）。`checker_effects_test.vibe` 19/19（無回帰）。
 - **`Task[T]` codegen（synchronous eager model, RETIRED in #1227）**: 単一スレッドの
   linear backend では「spawn = thunk を即時実行し、Task 値 = 解決済み結果」
   「join = identity」「cancel = drop して Unit」「race = 先行 task の値」という
@@ -158,9 +168,7 @@ M1a と同じ要領で、lexer/parser/core-Type を変えずに着地:
   wasmtime 45 上で実行可能だった。**#1227 でこの lowering ごと撤去し**、
   `test_async_component_gate.sh` の Task entry も外した（`option` entry の
   `Task::timeout` は `Stream::next(Stream::once(1))` に差し替え、合計 42 を維持）。
-  `checker_async_test.vibe` は「登録されている」ことを assert する4テストを、
-  「登録されていない」ことを pin する1テストに置き換えてある——この surface が
-  戻ってくればそこで落ちる。
+  checker 側の pin は上の「Task 側（RETIRED）」を参照。
   - **free-var capture 修正**（撤去前の記録）: inlined async builtin
     （`await`/`Future::ready`/`Task::spawn|join|cancel|race`）は func table に
     居ないため、nested lambda
@@ -186,7 +194,8 @@ M1a と同じ要領で、lexer/parser/core-Type を変えずに着地:
     deadline は評価して捨てた）。**#1227 で撤去**。gate の `option` entry は
     `Stream::next(Stream::once(1))` に差し替えて Some 経路の網羅を維持している。
   合成式経由なので `match { Some(x) => … None => … }` が正しく動く（gate の
-  Option entry が Some/None 両経路 + timeout を網羅 → 42）。
+  Option entry が `Stream::next` の Some/None 両経路を網羅 → 42。timeout 分は
+  #1227 の撤去で外した）。
 - **`String::to_bytes` codegen（ByteStream consume, landed）**: HTTP body を
   Stream 化する第一歩。`String::to_bytes(s) : Stream[Int]`（= `ByteStream`、
   WASI 0.3 `stream<u8>`）が文字列のバイト列を eager に Array へ展開し、handler


### PR DESCRIPTION
Two P2 findings on #1256, both correct. That PR merged before I could push the fixes, so this is a fresh PR on top of it.

My first pass marked only the codegen paragraph as retired and left the section above it — and a milestone coverage claim — still describing the deleted API as current.

## 1. The 2.4/2.5 front-end bullets still advertised the API

They said `Task[T]` is represented by the current front end, that `lookup_concurrency` registers spawn/join/cancel/race/timeout, and that their `Async` checks work. After #1227 `lookup_concurrency` returns `None` unconditionally, so all three sentences were false.

Split into two blocks. **Stream** keeps its "landed, 現行" description unchanged. **Task** gets its own RETIRED block, struck through, stating plainly that `lookup_concurrency` now returns `None` and the names resolve to `unknown name`.

Splitting rather than annotating in place matters here: the bullets covered both types in one breath, so there was no way to mark half a sentence retired.

## 2. The M2b gate-coverage sentence still said "+ timeout"

`test_async_component_gate.sh` now drives only the two `Stream::next` paths — the option fixture's timeout call became `Stream::next(Stream::once(1))` in #1255. Claiming timeout coverage made the milestone's stated coverage false.

## Also

The checker-test pin ("four tests asserting registered → one pinning not registered") ended up written twice, once in each block. Kept it in the Task RETIRED block, with a pointer from the codegen paragraph.

## Why the first pass missed these

I grepped for `Task::` **call sites**, which finds prose that names the operations but not prose that *describes* them — "`lookup_concurrency` に登録", "Option entry が … + timeout を網羅".

This time the sweep was `landed` / `done` / `登録` / `現行` intersected with Task, checking every hit. The one remaining hit is M2c-3's "subtask producer", which is the Component Model subtask — unrelated to the `Task::*` API.

## Test plan

- [x] `git diff origin/main` reviewed line by line: one file, +21/−12, exactly the two findings plus the dedup
- [x] sweep for Task-as-current claims comes back empty
- [x] `docs/spec/wasi-p3-async.md` is not a `.vibe.md` doctest, so nothing here compiles or runs

Docs only.

https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoHiTv1shjrM2aFUUd8xFm)_