### PR TITLE
feat(incremental): trace host filesystem work

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -108,6 +108,40 @@ and is not yet a per-cache-class hit count. The next implementation target is
 therefore interface/implementation fingerprint separation, preceded by an
 invalidation model/oracle rather than more wall-time tuning.
 
+### Host filesystem ingestion telemetry
+
+The edit-cycle KPI also requests a separate runner-owned sidecar for actual
+host filesystem import work. It opts in only when both variables are supplied:
+
+```text
+VIBE_HOST_FS_SCOPE_OUT=<sidecar.json>
+VIBE_HOST_FS_SCOPE_NONCE=<unique-non-empty-run-id-without-control-characters>
+```
+
+`viberun` deletes an old requested sidecar before it executes the core guest,
+counts calls at the exact `vibe` host-import boundaries (`fs_read_file`,
+`fs_read_bytes`, `fs_stat_token`, and `fs_exists`), and publishes the sidecar
+atomically only after a successful guest completion (including explicit
+`exit(0)`). The host's post-completion write is not a guest import and does not
+contaminate these counters. Failed guests, missing nonces, invalid nonces, and
+sidecar publication failures produce no successful observation.
+
+The strict version-1 JSON object has `schema: "host_fs_scope"`, `version: 1`,
+the caller nonce, and non-negative integer fields `read_file_calls`,
+`read_file_returned_bytes`, `read_bytes_calls`,
+`read_bytes_returned_bytes`, `stat_token_calls`, and `exists_calls`.
+`read_*_returned_bytes` count bytes returned through that import (after
+`fs_read_file`'s existing lossy UTF-8 conversion). This schema describes host
+filesystem-import scope only: it does **not** claim compiler source hashes,
+cache keys, cache hits, reuse decisions, or a compiler ingestion identity.
+
+`scripts/edit_cycle_kpi.mjs` generates a fresh nonce and fails closed if this
+sidecar is missing, malformed, has unexpected fields, contains invalid counts
+or a control-character nonce, or has the wrong nonce. It records the result as
+`host_fs_scope` alongside—not inside—the compiler-owned
+`incremental_typecheck` telemetry. The feature is disabled by default and does
+not change compiler source loading, persistent formats, cache keys, or reuse.
+
 ## Artifact boundaries
 
 A physical file is a useful ingestion/cache shard, but is not always an

--- a/runtime/viberun/src/main.rs
+++ b/runtime/viberun/src/main.rs
@@ -136,6 +136,25 @@ impl ResourceLimiter for MemLimiter {
     }
 }
 
+#[derive(Default)]
+struct HostFsScopeCounters {
+    read_file_calls: u64,
+    read_file_returned_bytes: u64,
+    read_bytes_calls: u64,
+    read_bytes_returned_bytes: u64,
+    stat_token_calls: u64,
+    exists_calls: u64,
+}
+
+// Opt-in, runner-owned observation of the core `vibe` filesystem imports.
+// This deliberately reports host import calls, not compiler source hashes or
+// cache decisions.
+struct HostFsScope {
+    output: PathBuf,
+    nonce: String,
+    counters: HostFsScopeCounters,
+}
+
 struct HostState {
     last_error: Option<String>,
     args: Arc<Vec<String>>,
@@ -255,6 +274,7 @@ struct HostState {
     // See stdin_read_stream's own comment for why this matters for the
     // self-hosted LSP's JSON-RPC framing.
     stdin_pending: Vec<u8>,
+    host_fs_scope: Option<HostFsScope>,
 }
 
 // #901: {exit_code, stdout, stderr} parked behind a handle by `sh_capture`,
@@ -364,12 +384,17 @@ impl HostState {
             http_responses: std::collections::HashMap::new(),
             next_http_handle: 1,
             stdin_pending: Vec::new(),
+            host_fs_scope: None,
         }
     }
 
     fn record_err<E: std::fmt::Display>(&mut self, e: E) -> i32 {
         self.last_error = Some(format!("{e}"));
         -1
+    }
+
+    fn host_fs_scope_mut(&mut self) -> Option<&mut HostFsScopeCounters> {
+        self.host_fs_scope.as_mut().map(|scope| &mut scope.counters)
     }
 }
 
@@ -1054,7 +1079,13 @@ fn run(args: Vec<String>) -> Result<i32> {
         bail!("missing wasm/cwasm argument");
     }
     let wasm_path = &args[0];
+    let host_fs_scope = prepare_host_fs_scope()?;
     if is_component_file(wasm_path) {
+        if host_fs_scope.is_some() {
+            bail!(
+                "host_fs_scope: unsupported for component guests (no core vibe filesystem imports)"
+            );
+        }
         return run_async_component(wasm_path);
     }
     let prog_args: Vec<String> = std::iter::once("viberun".to_string())
@@ -1088,7 +1119,9 @@ fn run(args: Vec<String>) -> Result<i32> {
 
     let limits = store_mem_limits();
 
-    let mut store = Store::new(&engine, HostState::new(prog_args, MemLimiter::new(limits)));
+    let mut state = HostState::new(prog_args, MemLimiter::new(limits));
+    state.host_fs_scope = host_fs_scope;
+    let mut store = Store::new(&engine, state);
     store.limiter(|s| &mut s.mem);
 
     // DAP P2: if the module is a break build it carries a `vibe.dbgargs` custom
@@ -1269,11 +1302,21 @@ fn run(args: Vec<String>) -> Result<i32> {
     }
 
     match result {
-        Ok(()) => Ok(0),
+        Ok(()) => {
+            if let Some(scope) = store.data().host_fs_scope.as_ref() {
+                publish_host_fs_scope(scope)?;
+            }
+            Ok(0)
+        }
         Err(e) => {
             // `__moonbit_sys_unstable::exit(code)` traps via `ExitTrap(code)`.
             // Recover the code and propagate as our exit status.
             if let Some(ExitTrap(code)) = e.downcast_ref::<ExitTrap>() {
+                if *code == 0 {
+                    if let Some(scope) = store.data().host_fs_scope.as_ref() {
+                        publish_host_fs_scope(scope)?;
+                    }
+                }
                 return Ok(*code);
             }
             // `vibe::dbg_break` user abort (`q` at an interactive breakpoint).
@@ -2064,8 +2107,8 @@ fn vibe_alloc_packed_bytes(caller: &mut Caller<'_, HostState>, data: &[u8]) -> R
     Ok(aligned as i64)
 }
 
-fn vibe_ensure_parent_dir(path: &str) {
-    if let Some(dir) = std::path::Path::new(path).parent() {
+fn vibe_ensure_parent_dir(path: &std::path::Path) {
+    if let Some(dir) = path.parent() {
         if !dir.as_os_str().is_empty() {
             let _ = fs::create_dir_all(dir);
         }
@@ -2087,7 +2130,7 @@ fn vibe_ensure_parent_dir(path: &str) {
 static VIBE_TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 fn vibe_atomic_write(path: &str, data: &[u8]) -> Result<()> {
-    vibe_ensure_parent_dir(path);
+    vibe_ensure_parent_dir(std::path::Path::new(path));
     let counter = VIBE_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let tmp = format!("{path}.tmp-{}-{counter}", std::process::id());
     let write_result = fs::write(&tmp, data);
@@ -2099,6 +2142,76 @@ fn vibe_atomic_write(path: &str, data: &[u8]) -> Result<()> {
         Err(e) => {
             let _ = fs::remove_file(&tmp);
             Err(format_err!("vibe atomic write '{tmp}': {e}"))
+        }
+    }
+}
+
+// Prepare the opt-in telemetry sidecar before the guest can run. A stale file
+// is removed even when the nonce is invalid, so callers cannot accidentally
+// accept an old observation after this invocation fails closed.
+fn prepare_host_fs_scope() -> Result<Option<HostFsScope>> {
+    let Some(output) = std::env::var_os("VIBE_HOST_FS_SCOPE_OUT") else {
+        return Ok(None);
+    };
+    if output.is_empty() {
+        return Ok(None);
+    }
+    let output = PathBuf::from(output);
+    match fs::remove_file(&output) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => bail!("host_fs_scope: remove stale '{}': {e}", output.display()),
+    }
+    let nonce = std::env::var("VIBE_HOST_FS_SCOPE_NONCE")
+        .map_err(|_| format_err!("host_fs_scope: VIBE_HOST_FS_SCOPE_NONCE is required"))?;
+    if nonce.is_empty() || nonce.chars().any(char::is_control) {
+        bail!("host_fs_scope: VIBE_HOST_FS_SCOPE_NONCE must be non-empty and contain no control characters");
+    }
+    Ok(Some(HostFsScope {
+        output,
+        nonce,
+        counters: HostFsScopeCounters::default(),
+    }))
+}
+
+fn host_fs_scope_json(scope: &HostFsScope) -> Result<Vec<u8>> {
+    serde_json::to_vec(&serde_json::json!({
+        "schema": "host_fs_scope",
+        "version": 1,
+        "nonce": scope.nonce,
+        "read_file_calls": scope.counters.read_file_calls,
+        "read_file_returned_bytes": scope.counters.read_file_returned_bytes,
+        "read_bytes_calls": scope.counters.read_bytes_calls,
+        "read_bytes_returned_bytes": scope.counters.read_bytes_returned_bytes,
+        "stat_token_calls": scope.counters.stat_token_calls,
+        "exists_calls": scope.counters.exists_calls,
+    }))
+    .map_err(|e| format_err!("host_fs_scope: serialize sidecar: {e}"))
+}
+
+// This is intentionally a host-side write after `_start` returns successfully,
+// so it cannot itself show up as a guest filesystem-import counter.
+fn publish_host_fs_scope(scope: &HostFsScope) -> Result<()> {
+    let json = host_fs_scope_json(scope)?;
+    // `vibe_atomic_write` takes a UTF-8 guest ABI path. The host-side output
+    // path may be a native non-UTF-8 path, so use the same atomic protocol
+    // directly without lossy path conversion.
+    vibe_ensure_parent_dir(&scope.output);
+    let counter = VIBE_TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let mut tmp_name = scope.output.file_name().unwrap_or_default().to_os_string();
+    tmp_name.push(format!(".tmp-{}-{counter}", std::process::id()));
+    let tmp = scope.output.with_file_name(tmp_name);
+    match fs::write(&tmp, &json) {
+        Ok(()) => fs::rename(&tmp, &scope.output).map_err(|e| {
+            let _ = fs::remove_file(&tmp);
+            format_err!("host_fs_scope: publish '{}': {e}", scope.output.display())
+        }),
+        Err(e) => {
+            let _ = fs::remove_file(&tmp);
+            Err(format_err!(
+                "host_fs_scope: publish '{}': {e}",
+                scope.output.display()
+            ))
         }
     }
 }
@@ -2319,9 +2432,15 @@ fn register_vibe_imports(linker: &mut Linker<HostState>) -> Result<()> {
         "fs_read_file",
         |mut caller: Caller<'_, HostState>, path: i64| -> Result<i64> {
             let path = vibe_read_packed_str(&mut caller, path)?;
+            if let Some(counters) = caller.data_mut().host_fs_scope_mut() {
+                counters.read_file_calls += 1;
+            }
             let content =
                 fs::read(&path).map_err(|e| format_err!("vibe fs_read_file '{path}': {e}"))?;
             let s = String::from_utf8_lossy(&content).into_owned();
+            if let Some(counters) = caller.data_mut().host_fs_scope_mut() {
+                counters.read_file_returned_bytes += s.len() as u64;
+            }
             vibe_alloc_packed_str(&mut caller, &s)
         },
     )?;
@@ -2330,6 +2449,9 @@ fn register_vibe_imports(linker: &mut Linker<HostState>) -> Result<()> {
         "fs_exists",
         |mut caller: Caller<'_, HostState>, path: i64| -> Result<i64> {
             let path = vibe_read_packed_str(&mut caller, path)?;
+            if let Some(counters) = caller.data_mut().host_fs_scope_mut() {
+                counters.exists_calls += 1;
+            }
             Ok(i64::from(std::path::Path::new(&path).exists()))
         },
     )?;
@@ -2338,6 +2460,9 @@ fn register_vibe_imports(linker: &mut Linker<HostState>) -> Result<()> {
         "fs_stat_token",
         |mut caller: Caller<'_, HostState>, path: i64| -> Result<i64> {
             let path = vibe_read_packed_str(&mut caller, path)?;
+            if let Some(counters) = caller.data_mut().host_fs_scope_mut() {
+                counters.stat_token_calls += 1;
+            }
             Ok(vibe_stat_token(&path))
         },
     )?;
@@ -2481,8 +2606,14 @@ fn register_vibe_imports(linker: &mut Linker<HostState>) -> Result<()> {
         "fs_read_bytes",
         |mut caller: Caller<'_, HostState>, path: i64| -> Result<i64> {
             let path = vibe_read_packed_str(&mut caller, path)?;
+            if let Some(counters) = caller.data_mut().host_fs_scope_mut() {
+                counters.read_bytes_calls += 1;
+            }
             let data =
                 fs::read(&path).map_err(|e| format_err!("vibe fs_read_bytes '{path}': {e}"))?;
+            if let Some(counters) = caller.data_mut().host_fs_scope_mut() {
+                counters.read_bytes_returned_bytes += data.len() as u64;
+            }
             vibe_alloc_packed_bytes(&mut caller, &data)
         },
     )?;
@@ -4160,6 +4291,39 @@ fn main() {
     match handle.join() {
         Ok(()) => {}
         Err(_) => std::process::exit(1),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_fs_scope_sidecar_is_versioned_and_has_only_host_import_counters() {
+        let scope = HostFsScope {
+            output: PathBuf::from("unused.json"),
+            nonce: "run-1".to_string(),
+            counters: HostFsScopeCounters {
+                read_file_calls: 2,
+                read_file_returned_bytes: 7,
+                read_bytes_calls: 3,
+                read_bytes_returned_bytes: 11,
+                stat_token_calls: 5,
+                exists_calls: 13,
+            },
+        };
+        let value: serde_json::Value =
+            serde_json::from_slice(&host_fs_scope_json(&scope).unwrap()).unwrap();
+        assert_eq!(value["schema"], "host_fs_scope");
+        assert_eq!(value["version"], 1);
+        assert_eq!(value["nonce"], "run-1");
+        assert_eq!(value["read_file_calls"], 2);
+        assert_eq!(value["read_file_returned_bytes"], 7);
+        assert_eq!(value["read_bytes_calls"], 3);
+        assert_eq!(value["read_bytes_returned_bytes"], 11);
+        assert_eq!(value["stat_token_calls"], 5);
+        assert_eq!(value["exists_calls"], 13);
+        assert_eq!(value.as_object().unwrap().len(), 9);
     }
 }
 

--- a/scripts/edit_cycle_kpi.mjs
+++ b/scripts/edit_cycle_kpi.mjs
@@ -8,7 +8,7 @@
 // sources or generated compiler bundles. It measures the current one-shot
 // `vibe check` behavior and records its opt-in db_typecheck_fs work counters.
 
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   cpSync,
   existsSync,
@@ -31,6 +31,18 @@ const telemetryKeys = [
   "parse_operations",
   "modules_failed_or_blocked",
 ];
+const hostFsScopeKeys = [
+  "schema",
+  "version",
+  "nonce",
+  "read_file_calls",
+  "read_file_returned_bytes",
+  "read_bytes_calls",
+  "read_bytes_returned_bytes",
+  "stat_token_calls",
+  "exists_calls",
+];
+const hostFsScopeCounterKeys = hostFsScopeKeys.slice(3);
 
 /// Parse and validate the compiler-owned incremental typecheck sidecar.
 /// Kept exported so the structural contract has a focused Node regression test
@@ -62,6 +74,45 @@ export function parseIncrementalTelemetry(text, source = "incremental telemetry"
     throw new Error(
       `${source}: modules_rechecked + modules_reused + modules_failed_or_blocked must equal modules_planned`,
     );
+  }
+  return telemetry;
+}
+
+/// Parse the runner-owned host filesystem import sidecar. This is intentionally
+/// separate from compiler-owned incremental typecheck telemetry: its schema is
+/// `host_fs_scope`, and its counters are import boundaries, not source hashes.
+export function parseHostFsScopeTelemetry(text, expectedNonce, source = "host filesystem telemetry") {
+  let telemetry;
+  try {
+    telemetry = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${source}: invalid JSON (${error.message})`);
+  }
+  if (telemetry === null || typeof telemetry !== "object" || Array.isArray(telemetry)) {
+    throw new Error(`${source}: expected a JSON object`);
+  }
+  const actualKeys = Object.keys(telemetry).sort();
+  const expectedKeys = [...hostFsScopeKeys].sort();
+  if (actualKeys.length !== expectedKeys.length || actualKeys.some((key, index) => key !== expectedKeys[index])) {
+    throw new Error(`${source}: expected exactly the host_fs_scope v1 fields`);
+  }
+  if (telemetry.schema !== "host_fs_scope" || telemetry.version !== 1) {
+    throw new Error(`${source}: unsupported host_fs_scope schema/version`);
+  }
+  if (
+    typeof telemetry.nonce !== "string"
+    || telemetry.nonce.length === 0
+    || /\p{Cc}/u.test(telemetry.nonce)
+  ) {
+    throw new Error(`${source}: nonce must be non-empty and contain no control characters`);
+  }
+  if (telemetry.nonce !== expectedNonce) {
+    throw new Error(`${source}: nonce mismatch`);
+  }
+  for (const key of hostFsScopeCounterKeys) {
+    if (!Number.isSafeInteger(telemetry[key]) || telemetry[key] < 0) {
+      throw new Error(`${source}: ${key} must be a non-negative safe integer`);
+    }
   }
   return telemetry;
 }
@@ -104,7 +155,12 @@ function main() {
 
   function check(project, cache, run, caseName, editKind, cacheState) {
     const telemetryPath = join(project, ".vibe-incremental-telemetry.json");
+    const hostFsScopePath = join(project, ".vibe-host-fs-scope.json");
+    const hostFsScopeNonce = randomUUID();
     rmSync(telemetryPath, { force: true });
+    // The runner also removes this before guest execution; do it here too so
+    // a runner regression cannot turn a stale sidecar into a benchmark result.
+    rmSync(hostFsScopePath, { force: true });
     const start = process.hrtime.bigint();
     const result = spawnSync(launcher, ["check", "entry.vibe"], {
       cwd: project,
@@ -116,6 +172,8 @@ function main() {
         VIBE_CLI_WASM: stage2,
         VIBE_HOME: join(work, "home"),
         VIBE_INCREMENTAL_TELEMETRY_OUT: telemetryPath,
+        VIBE_HOST_FS_SCOPE_OUT: hostFsScopePath,
+        VIBE_HOST_FS_SCOPE_NONCE: hostFsScopeNonce,
         VIBE_PREOPEN_DIR: project,
         VIBE_RUNNER: runner,
       },
@@ -137,8 +195,16 @@ function main() {
     if (telemetry.modules_planned < 1) {
       throw new Error(`edit-cycle-kpi: ${caseName} telemetry planned no modules`);
     }
+    if (!existsSync(hostFsScopePath)) {
+      throw new Error(`edit-cycle-kpi: ${caseName} omitted host filesystem telemetry sidecar`);
+    }
+    const hostFsScope = parseHostFsScopeTelemetry(
+      readFileSync(hostFsScopePath, "utf8"),
+      hostFsScopeNonce,
+      `edit-cycle-kpi: ${caseName} host filesystem telemetry`,
+    );
     records.push({
-      schema: 2,
+      schema: 3,
       benchmark: "user-edit-cycle-check",
       compiler_sha256: compilerSha,
       compiler_file: basename(stage2),
@@ -151,6 +217,7 @@ function main() {
       process_mode: "one-shot",
       endpoint: "check-command-complete",
       incremental_typecheck: telemetry,
+      host_fs_scope: hostFsScope,
       wall_ms: Number(wallMs.toFixed(3)),
       success: true,
     });

--- a/scripts/edit_cycle_kpi.test.mjs
+++ b/scripts/edit_cycle_kpi.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parseIncrementalTelemetry } from "./edit_cycle_kpi.mjs";
+import { parseHostFsScopeTelemetry, parseIncrementalTelemetry } from "./edit_cycle_kpi.mjs";
 
 const validSidecar = JSON.stringify({
   schema: 1,
@@ -11,6 +11,18 @@ const validSidecar = JSON.stringify({
   parse_operations: 3,
   modules_failed_or_blocked: 0,
 });
+
+const validHostFsScope = {
+  schema: "host_fs_scope",
+  version: 1,
+  nonce: "run-123",
+  read_file_calls: 2,
+  read_file_returned_bytes: 7,
+  read_bytes_calls: 3,
+  read_bytes_returned_bytes: 11,
+  stat_token_calls: 5,
+  exists_calls: 13,
+};
 
 test("edit-cycle KPI accepts a complete incremental typecheck sidecar", () => {
   assert.deepEqual(parseIncrementalTelemetry(validSidecar), JSON.parse(validSidecar));
@@ -31,5 +43,35 @@ test("edit-cycle KPI rejects malformed or internally inconsistent telemetry", ()
       modules_failed_or_blocked: 0,
     })),
     /must equal modules_planned/,
+  );
+});
+
+test("edit-cycle KPI accepts a complete host_fs_scope sidecar", () => {
+  assert.deepEqual(
+    parseHostFsScopeTelemetry(JSON.stringify(validHostFsScope), "run-123"),
+    validHostFsScope,
+  );
+});
+
+test("edit-cycle KPI fails closed on invalid host_fs_scope sidecars", () => {
+  assert.throws(
+    () => parseHostFsScopeTelemetry("not json", "run-123"),
+    /invalid JSON/,
+  );
+  assert.throws(
+    () => parseHostFsScopeTelemetry(JSON.stringify({ ...validHostFsScope, nonce: "other" }), "run-123"),
+    /nonce mismatch/,
+  );
+  assert.throws(
+    () => parseHostFsScopeTelemetry(JSON.stringify({ ...validHostFsScope, nonce: "bad\u0000nonce" }), "bad\u0000nonce"),
+    /control characters/,
+  );
+  assert.throws(
+    () => parseHostFsScopeTelemetry(JSON.stringify({ ...validHostFsScope, exists_calls: -1 }), "run-123"),
+    /non-negative safe integer/,
+  );
+  assert.throws(
+    () => parseHostFsScopeTelemetry(JSON.stringify({ ...validHostFsScope, extra: 1 }), "run-123"),
+    /exactly the host_fs_scope v1 fields/,
   );
 });


### PR DESCRIPTION
## Summary

First bounded implementation slice of #1379 Phase 0.

- add opt-in runner-owned `host_fs_scope` telemetry at Rust `viberun`'s core guest FS import boundaries
- record read-file/read-bytes calls and returned bytes, stat-token calls, and exists calls
- require a nonce, remove stale output before execution, and publish atomically only after successful guest completion
- integrate the strict sidecar into the isolated-cache edit-cycle KPI as a separate observation from compiler typecheck telemetry

This deliberately does **not** add the proposed persistent raw-source stamp yet: reading a cached raw-source payload would read equivalent bytes and does not by itself demonstrate an edit-cycle improvement. The new counters establish the before/after evidence needed to choose the mtime/Git fast-path boundary.

## Safety and scope

- disabled by default
- mandatory non-empty control-character-free nonce
- stale sidecar removed before guest execution
- no publication on traps or nonzero exit
- publication failure turns an otherwise successful invocation into failure
- host-side atomic publication does not contaminate guest import counters
- schema is explicitly aggregate host-FS-import scope, not source hashes, cache identity, or reuse semantics
- no compiler cache key, persistent format, source-loading path, or reuse decision changes

## Validation

- `node --test scripts/edit_cycle_kpi.test.mjs`
- `cargo test --manifest-path runtime/viberun/Cargo.toml`
- `cargo build --release --manifest-path runtime/viberun/Cargo.toml`
- fresh stage2/stage3 selfbuild
- one-run isolated-cache edit-cycle KPI
- `git diff --check`
- independent review: approved

Fresh one-run baseline for the two-module fixture:

| case | wall ms | read_file calls/bytes | stat | exists | rechecked/reused | parses |
|---|---:|---:|---:|---:|---:|---:|
| cold | 675.787 | 6 / 336 | 10 | 63 | 2 / 0 | 2 |
| exact no-op | 238.869 | 8 / 642 | 4 | 28 | 0 / 2 | 0 |
| comment edit | 237.881 | 13 / 1140 | 19 | 100 | 2 / 0 | 2 |
| private body edit | 222.268 | 13 / 1143 | 19 | 100 | 2 / 0 | 2 |
| public interface edit | 226.760 | 13 / 1068 | 19 | 100 | 2 / 0 | 2 |

Wall time is advisory; host-import counts are the deterministic KPI added by this PR.

`cargo fmt --check` still reports pre-existing unrelated drift in `runtime/viberun/src/main.rs`; no reported formatter hunk overlaps this diff.
