### PR TITLE
test(incremental): prove stamp observation equivalence

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -142,6 +142,13 @@ or a control-character nonce, or has the wrong nonce. It records the result as
 `incremental_typecheck` telemetry. The feature is disabled by default and does
 not change compiler source loading, persistent formats, cache keys, or reuse.
 
+The opt-in persistent ingestion-stamp oracle similarly uses isolated gate-off
+and gate-on cache histories for a copied package. It proves only that unchanged
+and metadata-token-miss successful checks have equal observed invalidation
+traces (apart from the freshness nonce) and equal check output bytes/text. It
+retains malformed and content-token fallback checks. This does not remove the
+trusted stat-token limitation, and it does not prove artifact equivalence.
+
 ## Artifact boundaries
 
 A physical file is a useful ingestion/cache shard, but is not always an

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -69,10 +69,10 @@ VIBE_RC=0 node scripts/artifact_input_trace_oracle.mjs "$stage2_wasm"
 echo "[compiler-gate] 3aa/3 incremental invalidation observation oracle"
 VIBE_RC=0 node scripts/incremental_invalidation_oracle.mjs "$stage2_wasm"
 
-# 3ab. #1379 opt-in metadata-only ingestion stamp: a copied real index.vpkg
-# member proves cross-process exact-token reuse, malformed/token-change
-# fallback, and unchanged checker success under an isolated cache.
-echo "[compiler-gate] 3ab/3 persistent ingestion stamp oracle"
+# 3ab. #1379 opt-in metadata-only ingestion stamp: isolated equivalent cache
+# histories prove observed successful-check invalidation/output equivalence,
+# while retaining malformed/token-change fallback coverage.
+echo "[compiler-gate] 3ab/3 persistent ingestion stamp observed-check equivalence oracle"
 node scripts/ingestion_stamp_oracle.mjs "$stage2_wasm"
 
 # 3b. RC bootstrap gate (#556) -- CAVEAT: this reuses the manifest from the

--- a/scripts/incremental_invalidation_oracle.mjs
+++ b/scripts/incremental_invalidation_oracle.mjs
@@ -118,6 +118,45 @@ export function parseIncrementalInvalidationTrace(text, expectedNonce = undefine
   return trace;
 }
 
+/// Compare two successful, already-parsed observations while deliberately
+/// excluding the per-run freshness nonce. This is intentionally stricter than
+/// clean-snapshot parity: decisions and every versioned observation field are
+/// semantic evidence for the same check, so any drift is a failure.
+export function compareSuccessfulIncrementalInvalidationTraces(expected, actual) {
+  const mismatch = (context, expectedValue, actualValue) => {
+    fail(`semantic trace mismatch at ${context}: expected ${JSON.stringify(expectedValue)}, got ${JSON.stringify(actualValue)}`);
+  };
+  const compareField = (context, left, right) => {
+    if (left !== right) mismatch(context, left, right);
+  };
+  const compareArray = (context, left, right) => {
+    if (left.length !== right.length) mismatch(`${context}.length`, left.length, right.length);
+    for (let index = 0; index < left.length; index += 1) compareField(`${context}[${index}]`, left[index], right[index]);
+  };
+
+  compareField("schema", expected.schema, actual.schema);
+  compareField("fingerprint_note", expected.fingerprint_note, actual.fingerprint_note);
+  if (expected.modules.length !== actual.modules.length) mismatch("modules.length", expected.modules.length, actual.modules.length);
+  const moduleFields = [
+    "path", "source_fingerprint", "source_fingerprint_kind",
+    "implementation_fingerprint", "implementation_fingerprint_kind", "interface_fingerprint",
+    "interface_fingerprint_kind", "checked_env_fingerprint", "checked_env_fingerprint_kind", "decision",
+  ];
+  for (let index = 0; index < expected.modules.length; index += 1) {
+    const left = expected.modules[index];
+    const right = actual.modules[index];
+    // Compare positional paths first, so a module-order drift has stable,
+    // useful context rather than being misreported as a later field drift.
+    compareField(`modules[${index}].path`, left.path, right.path);
+    const context = `modules[${index}](${left.path})`;
+    compareArray(`${context}.direct_dependencies`, left.direct_dependencies, right.direct_dependencies);
+    for (const field of moduleFields.slice(1)) compareField(`${context}.${field}`, left[field], right[field]);
+  }
+  for (const key of ["schema", ...telemetryKeys]) {
+    compareField(`aggregate_telemetry.${key}`, expected.aggregate_telemetry[key], actual.aggregate_telemetry[key]);
+  }
+}
+
 function moduleByName(trace, name) {
   const module = trace.modules.find((row) => basename(row.path) === `${name}.vibe`);
   if (!module) fail(`missing ${name}.vibe module row`);

--- a/scripts/incremental_invalidation_oracle.test.mjs
+++ b/scripts/incremental_invalidation_oracle.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   compareObservedInvalidation,
+  compareSuccessfulIncrementalInvalidationTraces,
   parseIncrementalInvalidationTrace,
   planObservedTypingInvalidation,
 } from "./incremental_invalidation_oracle.mjs";
@@ -69,6 +70,76 @@ test("incremental invalidation trace rejects stale, missing, and dishonest ident
   const stale = structuredClone(validTrace);
   stale.modules[0].decision = "rechecked";
   assert.throws(() => parseIncrementalInvalidationTrace(JSON.stringify(stale)), /rechecked decision count mismatch/);
+});
+
+function parsedComparisonTrace(nonce) {
+  const trace = structuredClone(validTrace);
+  const row = (path, dependencies, suffix) => ({
+    ...structuredClone(validTrace.modules[0]),
+    path,
+    direct_dependencies: dependencies,
+    source_fingerprint: `source:${suffix}`,
+    implementation_fingerprint: `implementation:${suffix}`,
+    interface_fingerprint: `interface:${suffix}`,
+    checked_env_fingerprint: `checked-env:${suffix}`,
+  });
+  trace.run_nonce = nonce;
+  trace.modules = [
+    row("base.vibe", [], "base"),
+    row("library.vibe", ["base.vibe"], "library"),
+    row("app.vibe", ["base.vibe", "library.vibe"], "app"),
+  ];
+  trace.aggregate_telemetry = {
+    schema: 1,
+    modules_planned: 3,
+    modules_rechecked: 0,
+    modules_reused: 3,
+    parse_operations: 0,
+    modules_failed_or_blocked: 0,
+  };
+  return parseIncrementalInvalidationTrace(JSON.stringify(trace), nonce);
+}
+
+test("successful trace semantic comparison excludes only run_nonce", () => {
+  const expected = parsedComparisonTrace("comparison-expected");
+  const actual = parsedComparisonTrace("comparison-actual");
+  assert.doesNotThrow(() => compareSuccessfulIncrementalInvalidationTraces(expected, actual));
+
+  const fingerprintMismatch = structuredClone(actual);
+  fingerprintMismatch.modules[1].implementation_fingerprint = "implementation:changed";
+  assert.throws(
+    () => compareSuccessfulIncrementalInvalidationTraces(expected, fingerprintMismatch),
+    /modules\[1\]\(library\.vibe\)\.implementation_fingerprint/,
+  );
+
+  const dependencyOrderMismatch = structuredClone(actual);
+  dependencyOrderMismatch.modules[2].direct_dependencies.reverse();
+  assert.throws(
+    () => compareSuccessfulIncrementalInvalidationTraces(expected, dependencyOrderMismatch),
+    /modules\[2\]\(app\.vibe\)\.direct_dependencies\[0\]/,
+  );
+
+  // Keep this altered trace internally valid: the decision counts still
+  // partition planned modules, so rejection comes from semantic comparison.
+  const decisionMismatch = structuredClone(actual);
+  decisionMismatch.modules[0].decision = "rechecked";
+  decisionMismatch.aggregate_telemetry.modules_rechecked = 1;
+  decisionMismatch.aggregate_telemetry.modules_reused = 2;
+  const parsedDecisionMismatch = parseIncrementalInvalidationTrace(JSON.stringify(decisionMismatch), "comparison-actual");
+  assert.throws(
+    () => compareSuccessfulIncrementalInvalidationTraces(expected, parsedDecisionMismatch),
+    /modules\[0\]\(base\.vibe\)\.decision/,
+  );
+
+  // parse_operations is independent aggregate accounting, making this a
+  // valid successful trace with deliberately different observed telemetry.
+  const telemetryMismatch = structuredClone(actual);
+  telemetryMismatch.aggregate_telemetry.parse_operations = 1;
+  const parsedTelemetryMismatch = parseIncrementalInvalidationTrace(JSON.stringify(telemetryMismatch), "comparison-actual");
+  assert.throws(
+    () => compareSuccessfulIncrementalInvalidationTraces(expected, parsedTelemetryMismatch),
+    /aggregate_telemetry\.parse_operations/,
+  );
 });
 
 test("incremental invalidation trace rejects dependencies outside its complete module universe", () => {

--- a/scripts/ingestion_stamp_oracle.mjs
+++ b/scripts/ingestion_stamp_oracle.mjs
@@ -9,13 +9,17 @@
 // prefix validation path without changing normal compiler semantics.
 
 import assert from "node:assert/strict";
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parseIngestionFingerprintTelemetry } from "./edit_cycle_kpi.mjs";
+import {
+  compareSuccessfulIncrementalInvalidationTraces,
+  parseIncrementalInvalidationTrace,
+} from "./incremental_invalidation_oracle.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const runner = join(root, "scripts/run_wasm_vibe_host_runner.sh");
@@ -37,11 +41,14 @@ function main() {
   const work = mkdtempSync(join(tmpdir(), "vibe-ingestion-stamp-"));
   try {
     const pkg = join(work, "pkg");
-    const cache = join(work, "cache");
+    const gateOffCache = join(work, "gate-off-cache");
+    const gateOnCache = join(work, "gate-on-cache");
     mkdirSync(pkg);
-    mkdirSync(cache);
+    mkdirSync(gateOffCache);
+    mkdirSync(gateOnCache);
     // Real package files (not a hand-written synthetic contract) ensure this
-    // keeps following the production index.vpkg member path.
+    // keeps following the production index.vpkg member path. Everything below
+    // mutates only this temporary copy, never a tracked fixture.
     cpSync(join(root, "lib/@vibe/random/index.vpkg"), join(pkg, "index.vpkg"));
     cpSync(join(root, "lib/@vibe/random/random.vibe"), join(pkg, "random.vibe"));
     const input = join(pkg, "random.vibe");
@@ -56,7 +63,7 @@ function main() {
         env: {
           ...process.env,
           VIBE_PREOPEN_DIR: root,
-          VIBE_BUILD_CACHE_DIR: cache,
+          VIBE_BUILD_CACHE_DIR: gateOffCache,
           VIBE_INGESTION_TELEMETRY_OUT: sidecar,
           ...extraEnv,
         },
@@ -65,10 +72,16 @@ function main() {
       assert.ok(!existsSync(sidecar), `${name} request must remove stale sidecar before failing`);
     }
 
-    function check(name, stampEnabled) {
+    function check(name, { stampEnabled, cacheDir }) {
       const out = join(work, `${name}.out`);
-      const sidecar = join(work, `${name}.json`);
-      const nonce = `ingestion-stamp-${name}`;
+      const telemetryPath = join(work, `${name}.ingestion.json`);
+      const tracePath = join(work, `${name}.invalidation.json`);
+      const telemetryNonce = `ingestion-stamp-telemetry-${name}`;
+      const traceNonce = `ingestion-stamp-trace-${name}`;
+      // Both compiler-owned successful-only sidecars begin stale. Expected
+      // nonces make an accidental prior observation unable to satisfy this run.
+      writeFileSync(telemetryPath, "stale ingestion observation");
+      writeFileSync(tracePath, "stale invalidation observation");
       const result = spawnSync(runner, ["--invoke", "cli_main", stage2, input, out, ""], {
         cwd: root,
         encoding: "utf8",
@@ -76,17 +89,23 @@ function main() {
           ...process.env,
           VIBE_PREOPEN_DIR: root,
           VIBE_CHECK_ONLY: "1",
-          VIBE_BUILD_CACHE_DIR: cache,
-          VIBE_INGESTION_TELEMETRY_OUT: sidecar,
-          VIBE_INGESTION_TELEMETRY_NONCE: nonce,
+          VIBE_BUILD_CACHE_DIR: cacheDir,
+          VIBE_INGESTION_TELEMETRY_OUT: telemetryPath,
+          VIBE_INGESTION_TELEMETRY_NONCE: telemetryNonce,
+          VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT: tracePath,
+          VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE: traceNonce,
           VIBE_EXPERIMENTAL_PERSISTENT_INGESTION_STAMP: stampEnabled ? "1" : "",
         },
       });
       if (result.status !== 0) fail(`ingestion-stamp-oracle: ${name} check failed`, result);
-      if (!existsSync(out) || !existsSync(sidecar)) fail(`ingestion-stamp-oracle: ${name} omitted output or sidecar`, result);
+      if (!existsSync(out) || !existsSync(telemetryPath) || !existsSync(tracePath)) {
+        fail(`ingestion-stamp-oracle: ${name} omitted output or requested sidecar`, result);
+      }
       return {
-        output: readFileSync(out, "utf8"),
-        telemetry: parseIngestionFingerprintTelemetry(readFileSync(sidecar, "utf8"), nonce, `${name} telemetry`),
+        outputBytes: readFileSync(out),
+        outputText: readFileSync(out, "utf8"),
+        telemetry: parseIngestionFingerprintTelemetry(readFileSync(telemetryPath, "utf8"), telemetryNonce, `${name} telemetry`),
+        trace: parseIncrementalInvalidationTrace(readFileSync(tracePath, "utf8"), traceNonce),
       };
     }
 
@@ -100,34 +119,65 @@ function main() {
       VIBE_INGESTION_TELEMETRY_NONCE: "unsupported-mode",
     });
 
-    const baseline = check("baseline", false);
-    const prime = check("prime", true);
-    const warm = check("warm", true);
-    assert.equal(baseline.output, "ok\n", "baseline checker result");
-    assert.equal(prime.output, baseline.output, "stamp prime checker result");
-    assert.equal(warm.output, baseline.output, "stamp warm checker result");
-    assert.equal(baseline.telemetry.stamp_probes, 0, "gate-off baseline must not probe stamps");
-    assert.equal(baseline.telemetry.source_read_calls, 1, "fixture baseline must read once at the fingerprint boundary");
-    assert.equal(baseline.telemetry.hash_calls, 1, "fixture baseline must hash once at the fingerprint boundary");
-    assert.ok(prime.telemetry.stamp_publications > 0, "stamp prime must publish");
-    assert.ok(warm.telemetry.stamp_hits > 0, "unchanged fresh warm check must hit a stamp");
-    assert.equal(warm.telemetry.source_read_calls, 0, "warm stamp must eliminate fingerprint-boundary source reads");
-    assert.equal(warm.telemetry.hash_calls, 0, "warm stamp must eliminate fingerprint-boundary hashes");
+    // The two cache directories start from the same copied package and each
+    // sees exactly a prime followed by a warm check; only the opt-in differs.
+    const gateOffPrime = check("gate-off-prime", { stampEnabled: false, cacheDir: gateOffCache });
+    const gateOffWarm = check("gate-off-warm", { stampEnabled: false, cacheDir: gateOffCache });
+    const gateOnPrime = check("gate-on-prime", { stampEnabled: true, cacheDir: gateOnCache });
+    const gateOnWarm = check("gate-on-warm", { stampEnabled: true, cacheDir: gateOnCache });
+    assert.equal(gateOffPrime.outputText, "ok\n", "gate-off prime checker result");
+    assert.equal(gateOffWarm.outputText, gateOffPrime.outputText, "gate-off warm checker result");
+    assert.equal(gateOnPrime.outputText, gateOffPrime.outputText, "gate-on prime checker result");
+    assert.equal(gateOnWarm.outputText, gateOffPrime.outputText, "gate-on warm checker result");
+    assert.equal(gateOffWarm.telemetry.stamp_probes, 0, "gate-off warm must not probe stamps");
+    assert.equal(gateOffWarm.telemetry.source_read_calls, 1, "gate-off warm must read once at the fingerprint boundary");
+    assert.equal(gateOffWarm.telemetry.hash_calls, 1, "gate-off warm must hash once at the fingerprint boundary");
+    assert.ok(gateOnPrime.telemetry.stamp_publications > 0, "gate-on prime must publish");
+    assert.ok(gateOnWarm.telemetry.stamp_hits >= 1, "gate-on warm must hit a stamp");
+    assert.equal(gateOnWarm.telemetry.source_read_calls, 0, "gate-on warm must eliminate fingerprint-boundary source reads");
+    assert.equal(gateOnWarm.telemetry.hash_calls, 0, "gate-on warm must eliminate fingerprint-boundary hashes");
+    assert.deepEqual(gateOnWarm.outputBytes, gateOffWarm.outputBytes, "gate-off/on warm output bytes");
+    assert.equal(gateOnWarm.outputText, gateOffWarm.outputText, "gate-off/on warm output text");
+    compareSuccessfulIncrementalInvalidationTraces(gateOffWarm.trace, gateOnWarm.trace);
 
-    const stampName = readdirSync(cache).find((name) => name.startsWith("vibe_selfhost_ingestion_stamp_v1_"));
-    assert.ok(stampName, "prime must create the dedicated ingestion stamp namespace entry");
-    writeFileSync(join(cache, stampName), "v1\\t1\\t0not-a-fingerprint");
-    const malformed = check("malformed", true);
-    assert.ok(malformed.telemetry.stamp_malformed > 0, "malformed stamp must fail closed");
-    assert.ok(malformed.telemetry.source_read_calls > 0 && malformed.telemetry.stamp_publications > 0, "malformed stamp must re-read/hash and republish");
-
-    // A token change is also a miss even if the source edit is non-semantic.
+    // The package contract stays byte-for-byte identical, but its trusted stat
+    // token changes. A stamp miss must fall back to source/hash work without
+    // changing observed successful-check semantics from the prior warm run.
     const contract = join(pkg, "index.vpkg");
+    const contractBytes = readFileSync(contract);
+    const oldMtimeMs = statSync(contract).mtimeMs;
+    utimesSync(contract, 2_000_000_000, 2_000_000_000);
+    assert.deepEqual(readFileSync(contract), contractBytes, "metadata-only case must not change contract bytes");
+    assert.notEqual(statSync(contract).mtimeMs, oldMtimeMs, "metadata-only case must change the stat token");
+    const metadataChanged = check("metadata-changed", { stampEnabled: true, cacheDir: gateOnCache });
+    assert.ok(metadataChanged.telemetry.stamp_misses > 0, "metadata-only token change must miss the stamp");
+    assert.ok(metadataChanged.telemetry.source_read_calls > 0, "metadata-only token change must read source");
+    assert.ok(metadataChanged.telemetry.hash_calls > 0, "metadata-only token change must hash source");
+    assert.deepEqual(metadataChanged.outputBytes, gateOnWarm.outputBytes, "metadata-only output bytes");
+    assert.equal(metadataChanged.outputText, gateOnWarm.outputText, "metadata-only output text");
+    compareSuccessfulIncrementalInvalidationTraces(gateOnWarm.trace, metadataChanged.trace);
+
+    const stampName = readdirSync(gateOnCache).find((name) => name.startsWith("vibe_selfhost_ingestion_stamp_v1_"));
+    assert.ok(stampName, "gate-on prime must create the dedicated ingestion stamp namespace entry");
+    writeFileSync(join(gateOnCache, stampName), "v1\\t1\\t0not-a-fingerprint");
+    const malformed = check("malformed", { stampEnabled: true, cacheDir: gateOnCache });
+    assert.ok(malformed.telemetry.stamp_malformed > 0, "malformed stamp must fail closed");
+    assert.ok(malformed.telemetry.source_read_calls > 0 && malformed.telemetry.hash_calls > 0 && malformed.telemetry.stamp_publications > 0, "malformed stamp must re-read/hash and republish");
+
+    // A content token change is also a miss even if the source edit is non-semantic.
     writeFileSync(contract, `${readFileSync(contract, "utf8")}\n// token-change oracle\n`);
-    const tokenChanged = check("token-changed", true);
+    const tokenChanged = check("token-changed", { stampEnabled: true, cacheDir: gateOnCache });
     assert.ok(tokenChanged.telemetry.stamp_misses > 0 && tokenChanged.telemetry.stamp_hits === 0, "changed stat token must not reuse a stamp");
-    assert.ok(tokenChanged.telemetry.source_read_calls > 0, "changed token must read/hash source");
-    console.log(JSON.stringify({ baseline: baseline.telemetry, prime: prime.telemetry, warm: warm.telemetry, malformed: malformed.telemetry, token_changed: tokenChanged.telemetry }));
+    assert.ok(tokenChanged.telemetry.source_read_calls > 0 && tokenChanged.telemetry.hash_calls > 0, "changed token must read/hash source");
+    console.log(JSON.stringify({
+      gate_off_prime: gateOffPrime.telemetry,
+      gate_off_warm: gateOffWarm.telemetry,
+      gate_on_prime: gateOnPrime.telemetry,
+      gate_on_warm: gateOnWarm.telemetry,
+      metadata_changed: metadataChanged.telemetry,
+      malformed: malformed.telemetry,
+      token_changed: tokenChanged.telemetry,
+    }));
   } finally {
     if (process.env.VIBE_INGESTION_STAMP_KEEP_TMP === "1") {
       console.error(`ingestion-stamp-oracle: kept ${work}`);


### PR DESCRIPTION
## Summary

Issue #1379 Phase 2 の小さいtest-only sliceです。PR #1386 のopt-in metadata stampについて、`gate-off` と `gate-on` が同じsuccessful-check invalidation observationとcheck outputを生成することを、cross-process oracleで非vacuousに検証します。

## What changed

- schema-v4 incremental traceのstrict comparatorを追加
  - `run_nonce`だけを除外
  - module/order/path、dependency order、全fingerprint値+kind、decision、fingerprint note/schema、aggregate TypeDb telemetryを比較
  - mismatchはfield/path context付きでfail
- ingestion stamp oracleをequivalent isolated cache historiesへ拡張
  - gate-off prime → warm
  - gate-on prime → warm
  - copied real `@vibe/random/index.vpkg` memberを使用
- same-content metadata-only stat-token change caseを追加
- compiler gateとscope docsを更新

Compiler `.vibe` source、cache key/version/format、production reuse decisionは変更しません。

## Non-vacuous witness

| lane | warm fingerprint-boundary read/hash | stamp |
|---|---:|---:|
| gate-off | exactly 1 / 1 | probes 0 |
| gate-on | exactly 0 / 0 | hits >= 1 |

その上でwarm tracesとcheck output bytes/textが一致することをassertします。

Metadata-only caseはtemporary `index.vpkg`のbytesを維持したままmtime/stat tokenを変更し、stamp miss + read/hash fallbackを要求しつつ、直前warm runとtrace/outputが一致することをassertします。Malformed stampとcontent-token change fallbackも維持しています。

## Claim boundary

これはsuccessful `vibe check`で観測したinvalidation trace/output equivalenceだけを示します。trusted stat-token collision/restoreの制約は解消せず、artifact equivalenceも証明しません。

## Validation

- `node --test scripts/incremental_invalidation_oracle.test.mjs scripts/edit_cycle_kpi.test.mjs`
- `node scripts/ingestion_stamp_oracle.mjs <stage2.wasm>`
- `git diff --check`
- independent verifier: approved
- `pkf run release-check`
  - fresh stage2/stage3 fixpoint passed
  - enhanced `3ab` oracle passed

Part of #1379.
