### PR TITLE
bootstrap bump: seed を exception-typed-rows-2026-08-04 へ更新 (#1324)

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "vpkg-structured-header-2026-07-27",
-    "tag": "seed/vpkg-structured-header-2026-07-27",
-    "source_commit": "08c4c58",
+    "name": "exception-typed-rows-2026-08-04",
+    "tag": "seed/exception-typed-rows-2026-08-04",
+    "source_commit": "34a294d9",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "a59e8da8bf7a2ef1c5f01d9f5a384dccc98d06fee45019be1fd9b29e92aecbda"
+      "sha256": "ff613a950e81be06f4e7daa5e8c0c45d1564a6e0984e128a231383bfb96fc6c1"
     },
     "runtime": {
       "runner": "moonrun",


### PR DESCRIPTION
`bootstrap/seed.json` の**4行のみ**。コード変更なし、生成物の変更なし。

```
name          vpkg-structured-header-2026-07-27 -> exception-typed-rows-2026-08-04
tag           seed/vpkg-structured-header-2026-07-27 -> seed/exception-typed-rows-2026-08-04
source_commit 08c4c58                           -> 34a294d9
sha256        a59e8da8...aecbda                  -> ff613a95...fc6c1
```

対応する release は公開済みです — [seed/exception-typed-rows-2026-08-04](https://github.com/mizchi/vibe-lang/releases/tag/seed/exception-typed-rows-2026-08-04)。

## なぜ要るか

`Exception[String]` の typed row (ADR-0085 / #1344) を **compiler source 自身で**使えるようにするためです。旧 seed はこの構文を解釈できず、#1324 の残りスライスが全部そこで止まっていました。

seed **だけ**を入れ替えた A/B で確認しています: 同一の probe source を固定したまま stage0 を差し替えると、旧 seed では失敗し、新 seed では成功して `42` を返します。

これは #1407 が無効化した形の比較ではありません。あちらの教訓は「seed と source を**同時に**動かした比較は帰属の根拠にならない」で、この A/B は source を固定した単一変数です。

## 検証

この PR の tree（= main `8c4c81f4` + 本 bump）に対して実行しました。**34a294d9 時点での検証結果を流用していません** — main はその後 #1406 / #1408 でコンパイラ source が動いており、その組み合わせは未検証だったため取り直しています。

- `scripts/ensure_seed.sh` が release から fetch して sha256 一致を確認 (`ff613a95…fc6c1`)。公開 asset の digest とも一致
- **`pkf run full-gate` green**、compiler-gate **87/87**
- **stage1 == stage2 == stage3 が byte 一致** — いずれも `bb67b617075214d2239e53b908dfe9144af86f016026a79aeb3719f55fef9961`

fixpoint の hash が seed 自身の sha と違うのは、main が #1406 / #1408 を取り込んでいて 34a294d9 時点の source ではなくなっているためです。不変条件は `stage1 == stage2 == stage3` の方で、それは成立しています。

生成物 (`compiler_sources_bundle.vibe` 等5ファイル) は変わりません。seed の入れ替えはコンパイラの**入力**ではなく **stage0 の選択**なので、source から決まる成果物は同一です。

## #1262 との関係

この bump は #1262 の all-RC blocker を**直しも壊しもしません**。#1407 が示したとおりあれは (コンパイラ, source 形状) の交互作用で、bump では消えません。self-build gate は性能理由で `VIBE_RC=0` に pin されている (`docs/perceus-reuse.md:21`) ので、all-RC は required gate ではなく、full-gate が green なのもそれと整合します。

## 次

これがマージされると #1324 の残り — `@vibe/json` の row を `Exception[String]` へ締め直す作業 — が着手可能になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_