### PR TITLE
test(incremental): strengthen interface identity oracle

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -444,6 +444,21 @@ the source `STrait` to canonicalize trait methods. The provenance is now also
 retained in `EnvTraitDef` and the TypeEnv v3 transport, but no full checked
 artifact exists yet. The transport remains TypeEnv-only—not a `CheckedProgram`,
 typed IR, exported interface, cache key, or reuse decision.
+
+These observation identities have intentionally different authorities.
+`vibe-module-interface:v2` covers only the exported API surface. In particular,
+`SImpl` has no exported/public bit, so impl declarations are excluded from that
+interface identity rather than being silently treated as public declarations.
+Impl bounds and targets are module-visible trait-resolution state and are
+observed by the complete persistent TypeEnv v3 transport identity instead.
+Neither identity establishes final linked-artifact freshness: the current
+runnable-artifact lane continues to use its whole resolved source-group input
+identity and compile configuration. Consequently an impl-only edit is expected
+to preserve `interface_fingerprint`, change
+`persistent_type_env_transport_fingerprint`, and invalidate linked artifacts
+through their existing source-group identity. This distinction does not promote
+either observation into a production key or reuse decision.
+
 The token-stream, interface, checked-environment, and transport reconstructions
 are not charged to the existing TypeDb `parse_operations` counter, so the `rechecked`/`reused`
 report remains the current conservative cache-path observation rather than a
@@ -560,10 +575,12 @@ attest checker success or provenance. The artifact remains payload- and
 type-free, post-desugar/artifact-local rather than source- or edit-stable, and
 is not connected to full checked bodies, typed IR, imports, interfaces, traces,
 caches, or reuse policy.
-A trait/impl regression proves an impl-bound edit changes the
+Trait/impl regressions prove impl-bound and impl-target edits change the
 complete persistent TypeEnv v3 transport observation while leaving the
-value-only checked-env observation unchanged; it makes no exported-interface
-stability assertion.
+exported-interface observation unchanged; the bound case also leaves the
+value-only checked-env observation unchanged. Exported type derives,
+trait-supertrait edges, effect operation signatures, and effectset members are
+separately covered by clean/warm interface-v2 parity and sensitivity checks.
 An external
 executable shadow planner treats source changes as ingestion telemetry, derives
 owner typing invalidation from canonical token-stream implementation changes

--- a/scripts/incremental_invalidation_oracle.mjs
+++ b/scripts/incremental_invalidation_oracle.mjs
@@ -404,12 +404,30 @@ function run(stage2) {
     }
     plannerCases.public_interface_edit = checkPlannerCase("public_interface_edit", privateEdit, publicEdit);
 
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport effect Logger { Info(String) -> Unit }\nexport effect Audit { Record(String) -> Unit }\nexport fn announce(message: String) -> Unit with Logger { let _ = message\n() }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const publicFunctionLogger = check("public_function_logger");
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport effect Logger { Info(String) -> Unit }\nexport effect Audit { Record(String) -> Unit }\nexport fn announce(message: String) -> Unit with Audit { let _ = message\n() }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const publicFunctionAudit = check("public_function_audit");
+    if (interfaceOwnersChanged(publicFunctionLogger, publicFunctionAudit).join(",") !== "library") fail("exported function effect edit did not change the interface identity");
+
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport type PublicAlias = Int\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const publicAliasInt = check("public_alias_int");
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport type PublicAlias = String\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const publicAliasString = check("public_alias_string");
+    if (interfaceOwnersChanged(publicAliasInt, publicAliasString).join(",") !== "library") fail("exported type alias edit did not change the interface identity");
+
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport struct PublicShape { value: Int }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
     const publicTypeAdd = check("public_type_add");
     if (interfaceOwnersChanged(publicEdit, publicTypeAdd).join(",") !== "library") fail("exported type addition did not change the interface identity");
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport struct PublicShape { value: String }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
     const publicTypeLayout = check("public_type_layout_edit");
     if (interfaceOwnersChanged(publicTypeAdd, publicTypeLayout).join(",") !== "library") fail("exported type layout edit did not change the interface identity");
+
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport struct DerivedShape { value: Int } derive(Eq)\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const publicDeriveEq = check("public_derive_eq");
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport struct DerivedShape { value: Int } derive(Eq, Show)\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const publicDeriveShow = check("public_derive_show");
+    if (interfaceOwnersChanged(publicDeriveEq, publicDeriveShow).join(",") !== "library") fail("exported type derive edit did not change the interface identity");
 
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport fn generic_identity[T](value: T) -> T { value }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
     const genericValueT = check("generic_value_t");
@@ -457,27 +475,52 @@ function run(stage2) {
     const traitFreeName = check("trait_free_name");
     if (interfaceOwnersChanged(traitScopedSignature, traitFreeName).join(",") !== "library") fail("free nominal type name did not remain distinct in trait interface identity");
 
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport trait ParentA { parent_a(Int) -> Int }\nexport trait ParentB { parent_b(Int) -> Int }\nexport trait Child: ParentA { child(Int) -> Int }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const traitSuperA = check("trait_super_a");
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport trait ParentA { parent_a(Int) -> Int }\nexport trait ParentB { parent_b(Int) -> Int }\nexport trait Child: ParentB { child(Int) -> Int }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const traitSuperB = check("trait_super_b");
+    if (interfaceOwnersChanged(traitSuperA, traitSuperB).join(",") !== "library") fail("exported trait supertrait edit did not change interface identity");
+
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport effect Logger { Info(String) -> Unit }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const effectString = check("effect_operation_string");
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport effect Logger { Info(Int) -> Unit }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const effectInt = check("effect_operation_int");
+    if (interfaceOwnersChanged(effectString, effectInt).join(",") !== "library") fail("exported effect operation signature edit did not change interface identity");
+
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport effect Ask { Get -> Int; Put(Int) -> Unit }\nexport effectset AskAll = { Ask::Get }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const effectsetGet = check("effectset_get");
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport effect Ask { Get -> Int; Put(Int) -> Unit }\nexport effectset AskAll = { Ask::Get, Ask::Put }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const effectsetGetPut = check("effectset_get_put");
+    if (interfaceOwnersChanged(effectsetGet, effectsetGetPut).join(",") !== "library") fail("exported effectset member edit did not change interface identity");
+
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport trait Identity { identity[U: Eq](U) -> U }\nimpl [T: Eq] Eq for Option[T]\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
     const implBoundEq = check("impl_bound_eq");
     if (implementationOwnersChanged(traitBoundEq, implBoundEq).join(",") !== "library") fail("impl generic bound addition did not change token-stream implementation identity");
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport trait Identity { identity[U: Eq](U) -> U }\nimpl [T: Show] Eq for Option[T]\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
     const implBoundShow = check("impl_bound_show");
     if (implementationOwnersChanged(implBoundEq, implBoundShow).join(",") !== "library") fail("impl generic bound edit did not change token-stream implementation identity");
+    if (interfaceOwnersChanged(implBoundEq, implBoundShow).length !== 0) fail("impl-bound edit changed the exported interface identity even though impls have no export surface bit");
     if (checkedEnvOwnersChanged(implBoundEq, implBoundShow).length !== 0) fail("impl-bound edit changed the value-only checked environment identity");
     if (persistentTypeEnvTransportOwnersChanged(implBoundEq, implBoundShow).join(",") !== "library") {
       fail("impl-bound edit did not change the complete persistent TypeEnv transport identity")
     }
+    writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport trait Identity { identity[U: Eq](U) -> U }\nimpl [T: Show] Eq for Array[T]\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
+    const implTargetArray = check("impl_target_array");
+    if (interfaceOwnersChanged(implBoundShow, implTargetArray).length !== 0) fail("impl-target edit changed the exported interface identity even though impls have no export surface bit");
+    if (persistentTypeEnvTransportOwnersChanged(implBoundShow, implTargetArray).join(",") !== "library") {
+      fail("impl-target edit did not change the complete persistent TypeEnv transport identity")
+    }
 
     writeFileSync(join(project, "app.vibe"), "import ./base.vibe { base_value }\nimport ./library.vibe { library_value }\nfn main() -> Int { let _ = library_value\nbase_value(0) }\n");
     const planEdit = check("dependency_plan_edit");
-    if (sourceOwnersChanged(implBoundShow, planEdit).join(",") !== "app") fail("dependency-plan edit source delta drift");
-    if (implementationOwnersChanged(implBoundShow, planEdit).join(",") !== "app") fail("dependency-plan edit implementation delta drift");
+    if (sourceOwnersChanged(implTargetArray, planEdit).join(",") !== "app") fail("dependency-plan edit source delta drift");
+    if (implementationOwnersChanged(implTargetArray, planEdit).join(",") !== "app") fail("dependency-plan edit implementation delta drift");
     if (JSON.stringify(decisionsByName(planEdit)) !== JSON.stringify({ base: "reused", library: "reused", app: "rechecked" })) {
       fail("dependency-plan edit current decision drift");
     }
     const appDependencies = moduleByName(planEdit, "app").direct_dependencies.map((path) => basename(path));
     if (appDependencies.join(",") !== "base.vibe,library.vibe") fail("dependency-plan trace did not record the added base import in declaration order");
-    plannerCases.dependency_plan_edit = checkPlannerCase("dependency_plan_edit", implBoundShow, planEdit);
+    plannerCases.dependency_plan_edit = checkPlannerCase("dependency_plan_edit", implTargetArray, planEdit);
 
     // Integration regressions for the renderer: JSON requires every U+0000–
     // U+001F control character to be escaped, and POSIX paths may contain TAB.


### PR DESCRIPTION
## Summary

Strengthen the existing schema-6 observation oracle around the semantic boundary of `vibe-module-interface:v2` without changing compiler behavior, trace schema, cache keys, persistent formats, or reuse decisions.

New clean/warm parity and sensitivity pairs cover:

- exported function effect row with an otherwise identical body
- exported type alias target
- exported struct layout and derive list
- exported trait supertrait
- exported effect operation signature
- exported effectset membership
- impl generic bound and target

The impl cases explicitly establish the current boundary:

- impl-only changes preserve `interface_fingerprint` because `SImpl` has no exported/public bit
- impl-bound/target changes alter the complete persistent TypeEnv-v3 transport identity
- linked artifact freshness remains governed by the existing resolved source-group input identity

Documentation now states these three authorities separately and keeps every observation disconnected from production reuse.

## Scope

- no compiler source changes
- no generated artifacts
- no schema bump
- no production cache/reuse change
- no TypeEnv/TDRE3 change
- no full checked artifact or typed-IR claim

## Validation

- `node --test scripts/incremental_invalidation_oracle.test.mjs`
- fresh stage2 `node scripts/incremental_invalidation_oracle.mjs ...`
- `git diff --check`
- `pkf run release-check`
- independent review: no P0/P1; one P2 fixed by keeping the exported function body identical across the effect-row pair

Follow-up for #1379.
