### PR TITLE
syntax: 旧 braced effect row `with { A, B }` を削除する (#1429)

### DIFF
--- a/.claude/skills/selfhost-miscompile-bisect/SKILL.md
+++ b/.claude/skills/selfhost-miscompile-bisect/SKILL.md
@@ -54,7 +54,7 @@ flat bundle は namespace が平坦なので、末尾に 0 引数 entry を足�
 
 ```vibe
 // bundle コピーの末尾に追記(commit しない)
-export let probe_check: () -> Int with { Error } = () -> {
+export let probe_check: () -> Int with Error = () -> {
   let stmts = parse_program(lex("export let main = () -> Int { 40 + 2 }"))
   expand_interp_stmts(stmts)
   let _ = check_program(stmts)

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -152,11 +152,12 @@ fn fact(n: Int) -> Int {
 fn identity[T](x: T) -> T { x }                // generic
 fn show[T: Eq + Ord](x: T) -> T { x }          // trait bounds
 fn hello() -> Unit with Stdout { stdout_write("hi\n") }
-// #1429: the effect row has three accepted spellings while the migration runs.
-// They parse to the SAME row — nothing after the parser can tell them apart.
-//   with A + B      braceless, `+`-separated   (migrating TO this one)
+// #1429: the effect row has exactly one spelling, plus one for the empty row.
+//   with A + B      the row
 //   with ()         the explicitly empty row
-//   with { A, B }   braced, comma-separated    (migrating FROM)
+// The braced `with { A, B }` was accepted through the migration and is now a
+// named parse error. `vibe fmt` rewrites it for you (the formatter is a
+// token-level pass, so it converts source the compiler no longer accepts).
 // `+` rather than `,` because once the braces are gone a comma cannot be told
 // apart from an enclosing list's comma: in `fn g(cb: (Int) -> Int with A, x: Int)`
 // the `x` is either a second label or the next parameter. `+` starts neither a

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -585,16 +585,19 @@ Rules:
 - Function effects appear after return type: `-> T with Effect`.
 - Effect row variables such as `with e` are accepted in polymorphic
   higher-order signatures.
-- The effect row has three accepted spellings, and #1429 is migrating the
-  language from the third to the first. All three parse to the same row, so
-  nothing after the parser -- checker, codegen, printer, contract hash --
-  observes which was written:
+- The effect row has one spelling, plus one for the empty row:
 
   | spelling | |
   | --- | --- |
-  | `with A + B` | braceless, `+`-separated. The form being migrated **to** |
+  | `with A + B` | the row |
   | `with ()` | the explicitly empty row |
-  | `with { A, B }` | braced, comma-separated. The form being migrated **from** |
+
+  `with { A, B }` was the pre-#1429 spelling. It was accepted alongside the
+  new one while the tree was converted -- both parsed to the same row, so
+  nothing after the parser could tell them apart -- and is now rejected by
+  name. `vibe fmt` still rewrites it: the formatter normalizes rows at the
+  TOKEN level, so it converts source the compiler no longer accepts, which
+  makes it the migration path for code outside this repository.
 
   The separator is `+`, not `,`, because a comma cannot be told apart from an
   enclosing list's comma once the braces are gone: in `((Int) -> Int with A, B)`

--- a/eval/lang-bench/langs/vibe/README.md
+++ b/eval/lang-bench/langs/vibe/README.md
@@ -2,7 +2,7 @@
 
 ## Relevant API surface
 
-- argv: `Env::args_len` / `Env::args_get` (`with { Env::Read }` or the
+- argv: `Env::args_len` / `Env::args_get` (`with Env::Read` or the
   narrower `Env::args_len`/`Env::args_get` effectset — see
   `docs/effectset.md`).
 - file I/O: `lib/@vibe/fs` (`Fs::exists`, `Fs::read_file`,

--- a/eval/msr/tasks/intermediate/03_custom_effect_logger/task.md
+++ b/eval/msr/tasks/intermediate/03_custom_effect_logger/task.md
@@ -4,7 +4,7 @@
 `perform Logger::Log(...)` を Array に集めて、body の戻り値と集めた
 ログの Array のペアを返す (resume で継続すること)。
 
-`fn run_logged(body: () -> Int with { Logger }) -> (Int, Array[String])`
+`fn run_logged(body: () -> Int with Logger) -> (Int, Array[String])`
 のような形で、body 内で `perform Logger::Log("a")` を複数回行い、
 最終的な戻り値とログ配列を両方確認できるようにする。
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ pkf run run -- test examples/syntax.vibe
 
 ## Language Features
 
-- `effects.vibe`: `with { Error }` / `handle { ... } with Error { ... }`
+- `effects.vibe`: `with Error` / `handle { ... } with Error { ... }`
 - `async.vibe`: `await` and async effect combinations
 - `perform_handle.vibe`: `perform Effect::Op(...)` + `handle` による多層エフェクト/回復パターン
 - `effect_demo.vibe`: effect 宣言を名前で共有する複数関数パターン (#752)

--- a/formal/README.md
+++ b/formal/README.md
@@ -47,7 +47,7 @@ passing, and compiler-to-Wasm simulation are also out of scope for Phase 1.
   concrete undeclared `Fs` operation, preserving a negative witness.
 
 This is a policy model for #944, not yet the full Vibe type-and-effect calculus.
-ADR-0073 decides that explicit `with { Error }` is a semantic row element, but
+ADR-0073 decides that explicit `with Error` is a semantic row element, but
 the higher-order typing and subtyping proofs remain coupled to #939. The model
 also abstracts from payload types, divergence, traps, stack unwinding,
 finalizers, and backend exception representation.

--- a/lib/@vibe/compiler/fmt/vpkg_format_test.vibe
+++ b/lib/@vibe/compiler/fmt/vpkg_format_test.vibe
@@ -100,6 +100,24 @@ test "vpkg: formatting is idempotent" {
   assert(format_vpkg(once) == once)
 }
 
+test "#1429: normalize_effect_rows still converts the spelling the parser removed" {
+  // Lives here rather than in parser_test.vibe because it is a FORMATTER
+  // property and pulling @vibe/compiler/fmt into a parser test just to assert
+  // it would be the wrong dependency.
+  //
+  // #1429 removed `with { A, B }` from the grammar -- parse_effect_row throws
+  // on it by name. normalize_effect_rows is kept anyway, and that is the
+  // point: it is a TOKEN-level pass, so it rewrites source the compiler no
+  // longer accepts, which makes `vibe fmt` the migration path for code
+  // outside this repository. This assertion is what stops the next reader
+  // deleting it as dead code.
+  let converted = format_script("let f: (Int) -> Int with { Error, Fs } = (x) -> { x }\n")
+  assert(String::contains(converted, "with Error + Fs"))
+  assert(!String::contains(converted, "with {"))
+  let empty = format_script("let g: () -> Int with {} = () -> { 1 }\n")
+  assert(String::contains(empty, "with ()"))
+}
+
 test "format_source dispatches on the .vpkg extension" {
   let src = "name = @vibe/parser\nversion = 0.1.0\n\ngenerated_hash =\n\nfn f() -> Int\n"
   assert(format_source("lib/@vibe/parser/index.vpkg", src) == format_vpkg(src))

--- a/lib/@vibe/compiler/tests/parser_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_test.vibe
@@ -225,7 +225,7 @@ test "parse higher-order effect function type annotation" {
   // Regression: function types can appear as parenthesized parameter types
   // inside another function type, with an effect variable on both levels.
   let ok = handle {
-    let _ = parse_program(lex("let apply: [e]((Int) -> Int with { e }, Int) -> Int with { e } = (f, x) -> { f(x) }\n0"))
+    let _ = parse_program(lex("let apply: [e]((Int) -> Int with e, Int) -> Int with e = (f, x) -> { f(x) }\n0"))
     "ok"
   } with Error {
     Throw(_) => "threw"
@@ -234,7 +234,7 @@ test "parse higher-order effect function type annotation" {
 }
 
 test "parse higher-order effect function type annotation with trailing comma" {
-  let source = "let chain: [e](\n  (Int) -> Int with { e },\n  (Int) -> Int with { e },\n  Int,\n) -> Int with { e } = (f, g, x) -> { add(f(x), g(x)) }\n0"
+  let source = "let chain: [e](\n  (Int) -> Int with e,\n  (Int) -> Int with e,\n  Int,\n) -> Int with e = (f, g, x) -> { add(f(x), g(x)) }\n0"
   let ok = handle {
     let _ = parse_program(lex(source))
     "ok"
@@ -644,7 +644,7 @@ test "#1283: a guard else that only throws gets its own message" {
   // likely to be made first, since let-else did accept it. So it must not fall
   // into the generic message.
   let thrown = handle {
-    let _ = parse_program(lex("let f: (Option[Int]) -> Int with { Error } = (o) -> { guard o is Some(v) else { throw(\"none\") }\n  v }\nf(Some(1))"))
+    let _ = parse_program(lex("let f: (Option[Int]) -> Int with Error = (o) -> { guard o is Some(v) else { throw(\"none\") }\n  v }\nf(Some(1))"))
     "ok"
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
@@ -772,41 +772,47 @@ test "#819: `example` is a reserved word, escapable as r#example" {
 
 //# #1429: effect-row spellings
 
-test "#1429: all three row spellings normalize to the same row" {
-  // The braced and braceless forms are indistinguishable after parsing --
-  // that is the property that lets them coexist across the bootstrap bump.
-  // The printer emits the BRACELESS form for both (#1429 step 3), so a
-  // round-trip of either spelling produces byte-identical output.
+test "#1429: the braced row is rejected by name" {
+  // The braced form was accepted through the migration and is now gone. The
+  // rejection names the replacement AND `vibe fmt`, because a reader who hits
+  // "expected an effect name" has no way to learn that the syntax moved.
   let braced = handle {
     print_program(parse_program(lex("let f: (Int) -> Int with { Error, Fs } = (x) -> { x }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
+  assert(String::starts_with(braced, "ERROR: "))
+  assert(String::contains(braced, "removed in #1429"))
+  assert(String::contains(braced, "with A + B"))
+  assert(String::contains(braced, "vibe fmt"))
+}
+
+test "#1429: the braceless row parses and round-trips" {
   let braceless = handle {
     print_program(parse_program(lex("let f: (Int) -> Int with Error + Fs = (x) -> { x }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
-  assert(!String::starts_with(braced, "ERROR: "))
-  assert(braced == braceless)
-  assert(String::contains(braced, "with Error + Fs"))
-  assert(!String::contains(braced, "with {"))
+  assert(!String::starts_with(braceless, "ERROR: "))
+  assert(String::contains(braceless, "with Error + Fs"))
+  assert(!String::contains(braceless, "with {"))
 }
 
-test "#1429: `with ()` is the same row as the legacy `with {}`" {
+test "#1429: `with ()` is the empty row and `with {}` is rejected" {
   let parens = handle {
     print_program(parse_program(lex("let f: (Int) -> Int with () = (x) -> { x }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
+  assert(!String::starts_with(parens, "ERROR: "))
+  assert(String::contains(parens, "with ()"))
   let braces = handle {
     print_program(parse_program(lex("let f: (Int) -> Int with {} = (x) -> { x }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
-  assert(!String::starts_with(parens, "ERROR: "))
-  assert(parens == braces)
-  assert(String::contains(parens, "with ()"))
+  assert(String::starts_with(braces, "ERROR: "))
+  assert(String::contains(braces, "removed in #1429"))
 }
 
 test "#1429: a parenthesized non-empty row is rejected by name" {

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -926,26 +926,37 @@ fn collect_effect_names_plus(tokens: Array[Token], pos: Int, acc: String) -> (St
 }
 
 /// #1429: parse the effect row that follows `with`. `pos` is the token AFTER
-/// the `with` keyword. Three spellings are accepted:
+/// the `with` keyword. There is now exactly ONE spelling, plus a spelling for
+/// the empty row:
 ///
-///   with A + B      braceless, `+`-separated  (the spelling being migrated TO)
+///   with A + B      the row
 ///   with ()         the explicitly empty row
-///   with { A, B }   braced, comma-separated   (the spelling being migrated FROM)
 ///
-/// All three normalize to the same comma-joined internal string, so nothing
-/// downstream of the parser -- checker, codegen, printer, contract hash --
-/// observes which one was written. That is what lets the two spellings coexist
-/// across the bootstrap bump: the compiler source keeps the braced form (so the
-/// committed bundles and the seed stay byte-stable) while the new form becomes
-/// parseable, and only then can the tree be converted.
+/// The braced `with { A, B }` was accepted through the migration and is now
+/// REJECTED by name. Both were parsed into the same comma-joined internal
+/// string, so nothing downstream ever observed the difference -- which is what
+/// let them coexist while the tree was converted, and why removing one costs
+/// nothing but the error below.
+///
+/// The rejection is a named diagnostic rather than "expected an effect name",
+/// because the reader of that generic message has no way to know the syntax
+/// moved. It also names `vibe fmt` as the fix: the CST formatter still carries
+/// normalize_effect_rows, which rewrites the braced row at the TOKEN level, so
+/// it converts source this parser no longer accepts. That is deliberate -- the
+/// formatter is the migration path for code outside this repository.
 ///
 /// `()` is the empty row and NOTHING else: a parenthesised non-empty row is
 /// rejected rather than accepted as a second grouping syntax, because allowing
 /// it would put the brace-vs-no-brace choice straight back into the language
 /// under different punctuation.
+///
+/// NOTE: `effectset Name = { A, B }` still uses braces and still shares
+/// collect_effect_names' item grammar. Whether that brace should follow the row
+/// is deliberately UNDECIDED -- an `effectset` is a declaration of a set, not a
+/// row, so the two are not obviously the same question.
 fn parse_effect_row(tokens: Array[Token], pos: Int) -> (String, Int) with Error {
   match peek(tokens, pos) {
-    TLBrace => collect_effect_names(tokens, pos + 1, ""),
+    TLBrace => throw("the braced effect row `with { A, B }` was removed in #1429 -- write `with A + B` (and `with ()` for the empty row). `vibe fmt` rewrites the old spelling for you."),
     TLParen => match peek(tokens, pos + 1) {
       TRParen => ("", pos + 2),
       _ => throw("`with (` spells the EMPTY effect row `with ()` and nothing else -- a parenthesised non-empty row is not a spelling. Write `with A + B` (#1429)")
@@ -985,7 +996,7 @@ fn parse_type_impl(tokens: Array[Token], pos: Int, mode: Int) -> (TypeExpr, Int)
     }
   }
   // The optional effect row after a function type's return (#1429: `with
-  // A + B`, `with ()`, or the legacy `with { E1, E2 }`).
+  // A + B`, or `with ()` for the empty row).
   let parse_effect_suffix: (Array[Token], Int) -> (Option[String], Int) with Error = (tokens, rn) -> {
     match peek(tokens, rn) {
       TWith => {

--- a/lib/@vibe/prelude/README.md
+++ b/lib/@vibe/prelude/README.md
@@ -48,13 +48,13 @@ Boundary enforcement is active in:
 
 `vibe/prelude` は pure 層と effect 境界を意図的に分離し、関数シグネチャで副作用を可視化する。
 
-- pure modules (`pure-primitive`, `pure-data`) は `with {...}` を持たない。
+- pure modules (`pure-primitive`, `pure-data`) は `with` row を持たない。
 - runtime bridge (`effect-boundary`) は host builtin への薄い委譲に限定し、effect を明示する。
 - effect の種類は責務に合わせる:
-  - file/path: `with {Fs}` / `with {Env}`
-  - network: `with {Net}`
-  - stdio: `with {Stdin}` / `with {Stdout}`
-  - async runtime: `with {Async}`
+  - file/path: `with Fs` / `with Env`
+  - network: `with Net`
+  - stdio: `with Stdin` / `with Stdout`
+  - async runtime: `with Async`
 - 新規 API を追加する場合、pure 変換ロジックは pure module に置き、effect module には混在させない。
 - 実験 API は runtime wrapper 側へ隔離し、必要な unstable flag をドキュメントに明記する。
 

--- a/scripts/vibe_normalize_smoke.sh
+++ b/scripts/vibe_normalize_smoke.sh
@@ -5,12 +5,19 @@
 # and section layout. Also asserts idempotency and that --check distinguishes
 # normalized from un-normalized. (This script drives the COMMITTED SEED, so
 # stage2-only behavior — module-block rejection #728, fn rejection #727 —
-# is asserted in compiler_gate.sh step 6 instead. #1429: the fixtures below
-# deliberately keep the BRACED effect row. `vibe normalize` renders through
-# the AST printer, and the printer this script exercises is the SEED's --
-# still the pre-#1429 one. Convert these to `with Error` only in the same
-# change that adopts a seed built from the braceless printer, or this smoke
-# test starts failing against the very binary it is meant to pin. The old module-flatten
+# is asserted in compiler_gate.sh step 6 instead.
+#
+# #1429: the fixtures below deliberately keep the BRACED effect row, and that
+# is now load-bearing in BOTH directions:
+#   - the current compiler REJECTS `with { Error }` (the spelling was removed),
+#     so these fixtures are no longer valid input to it;
+#   - this script does not use the current compiler. `vibe normalize` runs
+#     through scripts/vibe_normalize.sh, which drives the COMMITTED SEED, and
+#     the seed still both accepts the braced row and prints it back.
+# So they must stay braced until the seed moves, and must be converted to
+# `with Error` IN THE SAME CHANGE that adopts a seed built from the current
+# source. Converting them earlier breaks this test against the very binary it
+# is meant to pin; converting them later leaves it broken after the bump. The old module-flatten
 # fixture 03 was retired with module blocks, #728.)
 set -euo pipefail
 


### PR DESCRIPTION
移行は #1444 で完了し、生きたコード位置に braced 綴りは残っていませんでした。`parse_effect_row` の `TLBrace` 分岐を**名前付きの拒否**に置き換えます。

```
line 1:1: the braced effect row `with { A, B }` was removed in #1429 --
write `with A + B` (and `with ()` for the empty row).
`vibe fmt` rewrites the old spelling for you.
```

「expected an effect name」では、**先週まで有効だった構文**を書いた人が「構文が動いた」ことを知る手段がありません。置換先と移行手段の両方を名指しします。

## 方針として決めた2点

### `normalize_effect_rows` は残す

削除後の方が価値が上がります。**トークンレベルのパス**なので、パーサが拒否するようになったソースを今も変換できる — つまり `vibe fmt` がリポジトリ外のコードにとっての**移行パス**になります。

これを保証するテストを fmt パッケージ側に追加したので、次の人が dead code として消せません。`parser_test.vibe` ではなく fmt 側に置いたのは、フォーマッタの性質を assert するために parser test から `@vibe/compiler/fmt` を引くのが依存の向きとして誤りだからです。

### `effectset Name = { A, B }` は一切触っていない

`collect_effect_names` の item grammar を共有しているので一緒に流せてしまいますが、**判断を保留**しています。`effectset` は集合の**宣言**であって row ではないので、同じ問いとは限りません。`parse_effect_row` の doc にその旨を残しました。

## ついでに直したもの

**`docs/` の外の markdown が、これまでの全掃引から漏れていました:**

- `.claude/skills/selfhost-miscompile-bisect/SKILL.md` — スキルが「これを貼れ」と指示するスニペット。今回の削除でそのまま貼るとコンパイルが通らない状態でした
- `lib/@vibe/prelude/README.md` / `examples/README.md` / `formal/README.md` / eval の2ファイル

残っていたパーサ入力のテストケース（row 変数 `with { e }`、guard の1件）も braceless へ。cheatsheet と `spec/syntax.md` の3綴り表は「移行中」の記述から**削除の記録**へ書き換えました。

## 残した罠に印をつけた

`scripts/vibe_normalize_smoke.sh` の fixture は **braced のまま**です。注記を両方向に書き直しました:

- 現在のコンパイラは `with { Error }` を**拒否する**ので、これはもう有効な入力ではない
- しかし**このスクリプトは現在のコンパイラを使っていない** — committed seed を駆動し、seed はまだ braced を受理して印字する

したがって「現ソースから作った seed を adopt するのと**同じ変更で**変換する」必要があります。早く変換すればこのテストが pin している当のバイナリに対して壊れ、遅ければ bump 後に壊れたままになります。

## 検証

- `ensure_generated` ok
- `check_vibe_fmt` 897ファイル clean
- `compiler_gate.sh` rc=0
- `unit_test_runner` 523/523 rc=0
- `vibe_fmt_smoke` / `vibe_normalize_smoke` / `vibe_run_smoke` すべて green
- doctest は削除前とバイト一致（150ブロック、88 pass / 12 fail / 50 skip — 既存の失敗のみ）

**stage2 でエンドツーエンド確認:**

| 入力 | 結果 |
|---|---|
| `with { Error }` | 上記メッセージで拒否 |
| `with Error` | 受理 |
| `vibe fmt` に前者を通す | 後者へ変換 |

> 上記は `af1e7fc2` 時点の tip で実施。その後 #1448 の上に rebase しています（追加されたのは新しい bench ファイル5点のみで、削除した綴りは使っていないことを確認済み）。rebase 後の再検証も走らせています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_