### PR TITLE
refactor(checker): move builtin registry to core

### DIFF
--- a/docs/host-runtime-contract.md
+++ b/docs/host-runtime-contract.md
@@ -59,7 +59,7 @@ Exists, Mkdir }` (`lib/@vibe/fs/fs_effect.vibe`) — that's wrong. That block
 is only a 4-op convenience subset for user-program `import Fs` usage. The
 actual boundary the checker enforces is a per-builtin string tag
 (`Some("Fs")` on each entry in
-`lib/@vibe/compiler/codegen/common_base/builtin_registry.vibe`, plus
+`lib/@vibe/compiler/core/builtin_registry.vibe`, plus
 `Fs::readdir` in `checker/builtins_fs.vibe`), and `cli_main`'s `with
 Fs` row admits any builtin carrying that tag. Round 1 added all 17
 tagged ops on that basis.

--- a/docs/resource-kind-parameters.md
+++ b/docs/resource-kind-parameters.md
@@ -26,7 +26,7 @@ effect を **resource kind パラメータの有無**で型レベルに区別す
    builtin 関数シグネチャ (`CtFn`) の第3スロット `Option[String]` **ただ1つ**
    である。`Fs` という effect の宣言はどこにも存在せず、
    `("Fs::read_file", CtFn(..., Some("Fs")), ...)`
-   (`codegen/common_base/builtin_registry.vibe`) と `builtins_*.vibe` の
+   (`core/builtin_registry.vibe`) と `builtins_*.vibe` の
    `if name == ...` チェーンに散らばった `Some("Fs")` リテラルがすべて。
 2. **`effect Fs[R: Fs::Root]` は現状パースできない**。
    `parse_type_params_list` (`parser/parser_base.vibe`) は**裸の識別子のみ**を

--- a/docs/wit/vibe-compiler-host.wit
+++ b/docs/wit/vibe-compiler-host.wit
@@ -27,7 +27,7 @@ package vibe:compiler-host;
 // (lib/@vibe/fs/fs_effect.vibe) -- that block is only a 4-op convenience
 // subset for user-program `import Fs` usage. The actual boundary the
 // checker enforces is a per-BUILTIN string tag (`Some("Fs")` on each entry
-// in lib/@vibe/compiler/codegen/common_base/builtin_registry.vibe, plus
+// in lib/@vibe/compiler/core/builtin_registry.vibe, plus
 // `Fs::readdir` in checker/builtins_fs.vibe), and `cli_main`'s declared
 // a `with` row containing `Fs` admits any builtin carrying that tag -- but
 // admitting an op and cli_main actually CALLING it are different things

--- a/lib/@vibe/compiler/builtins/declarations.vibe
+++ b/lib/@vibe/compiler/builtins/declarations.vibe
@@ -42,7 +42,7 @@ declare FixedArray::set(Array[T], Int, T) -> Unit
 declare FixedArray::unsafe_set(Array[T], Int, T) -> Unit
 declare FixedArray::blit(Array[T], Int, Array[T], Int, Int) -> Unit
 
-//# Int64Array (#835: alias onto Array[Int] — see codegen/builtin_registry.vibe)
+//# Int64Array (#835: alias onto Array[Int] — see core/builtin_registry.vibe)
 declare Int64Array::make(Int, Int) -> Array[Int]
 declare Int64Array::length(Array[Int]) -> Int
 declare Int64Array::get(Array[Int], Int) -> Int

--- a/lib/@vibe/compiler/checker/builtins.vibe
+++ b/lib/@vibe/compiler/checker/builtins.vibe
@@ -1,37 +1,10 @@
 //# Imports
 
-// #415 B-2: func-table builtin signatures live in the central registry; the
-// registry lookup is consulted FIRST below, so the per-namespace files no
-// longer carry (and must not re-add) arms for registry names.
-//
-// #847 Phase C exception UPDATE (#897): this used to deliberately leaf-import
-// codegen/builtin_registry.vibe directly rather than through the codegen
-// facade, because routing through the (then plain index.vibe) facade pulled
-// codegen's ENTIRE transitive graph into every program that imports
-// checker/builtins.vibe (nearly everything) and was found to trigger a
-// pre-existing whole-program-merge dedup bug (checker_pattern_test.vibe
-// regression, see old history for the exact wasm CompileError).
-//
-// Now that codegen/ is a real index.vpkg package boundary (#897), the leaf
-// form is no longer optional: `enforce_incoming_boundary_fs` (#729) rejects
-// this exact cross-package leaf import wherever a package's content hash is
-// computed for cache-key purposes -- which persistent test/build caching
-// does for every compiler-internal directory, not just require-pinned lib/
-// packages. Confirmed empirically: leaving this as a leaf import broke 86
-// unit-test-runner.sh files with "cannot import
-// lib/@vibe/compiler/codegen/builtin_registry.vibe across a package
-// boundary". Switched to the boundary-legal package import below; the
-// original #847 merge-dedup bug did not reproduce against the current
-// compiler (full verification chain incl. unit_test_runner.sh 458/458 green
-// with this form) -- whatever combination of fixes since #847 (export-rename
-// dedup, merge ordering, ...) resolved it, so the facade-routed form is safe
-// again.
-import @vibe/compiler/codegen {
-  lookup_registry_builtin
-}
-
+// #415 B-2: func-table builtin signatures live in core's central registry;
+// the registry lookup is consulted FIRST below, so the per-namespace files
+// no longer carry (and must not re-add) arms for registry names.
 import @vibe/compiler/core {
-  Type, canonical_builtin_name
+  Type, canonical_builtin_name, lookup_registry_builtin
 }
 
 import ./builtins_array.vibe {

--- a/lib/@vibe/compiler/checker/builtins_fs.vibe
+++ b/lib/@vibe/compiler/checker/builtins_fs.vibe
@@ -11,7 +11,7 @@ import @vibe/core {
 //# Functions
 
 // #415 B-2: every Fs func-table builtin signature moved to the central
-// registry (codegen/builtin_registry.vibe), which checker/builtins.vibe
+// registry (core/builtin_registry.vibe), which checker/builtins.vibe
 // consults FIRST -- do not re-add arms for those names here. This file only
 // keeps the Fs names that are NOT func-table entries: `Fs::readdir` is a
 // checker-level surface whose Array[String] result is lowered by

--- a/lib/@vibe/compiler/codegen/codegen.vibe
+++ b/lib/@vibe/compiler/codegen/codegen.vibe
@@ -24,17 +24,10 @@ import @vibe/compiler/codegen/wasi {
   compile_wasi_module_with_sources_impl
 }
 
-// #847 Phase C: facade re-export so external callers reach builtin_registry's
-// (and, as of #897's codegen/ top-level batch, inline_wat's) surface only
-// through codegen/index.vpkg (this file's contract), not an internal file
-// directly. #897 UPDATE: builtin_registry.vibe / inline_wat.vibe (and their
-// double_to_string_expr.vibe / int_parse_expr.vibe siblings, not re-exported
-// here) moved to codegen/common_base/ to break a codegen/index.vpkg <->
-// codegen/expr(gc,wasi)/index.vpkg import cycle -- see codegen/common_base/
-// index.vpkg's header for the full story. Cross-package SReExport form, same
-// as syntax/syntax.vibe's re-export of @vibe/parser.
+// #847 Phase C: facade re-export for inline_wat. The builtin registry is
+// owned by @vibe/compiler/core so checker and both codegen lanes consume the
+// same lower-level contract directly.
 export ./common_base {
-  builtin_registry,
   compile_inline_wat,
   compile_inline_wat_full,
   desugar_labeled_args,
@@ -43,9 +36,7 @@ export ./common_base {
   ensure_exn_kind_cell,
   exn_kind_read_expr,
   exn_msg_read_expr,
-  inject_trait_method_generics,
-  lookup_registry_builtin,
-  verify_lane_builtins
+  inject_trait_method_generics
 }
 
 //# Functions

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -45,35 +45,23 @@ generated_hash =
 // codegen/wasi/wasi.vibe. All three were switched to the bare form so every
 // consumer now reaches this package only through its index.vpkg.
 //
-// #897 codegen/ top-level batch UPDATE: this package gained 4 new sibling
-// files -- builtin_registry.vibe, double_to_string_expr.vibe,
-// int_parse_expr.vibe, inline_wat.vibe -- relocated here FROM codegen/'s own
-// top level while migrating codegen/'s own index.vibe to index.vpkg.
-// Reason: codegen/'s subpackages (expr/, gc/, wasi/ -- each already its own
-// index.vpkg from earlier #897 batches) need these 4 files directly
-// (builtin_registry for the func-table registry, double_to_string_expr /
-// int_parse_expr for synthesized-AST builtin lowering, inline_wat for
-// `= wasm "..."` bodies), while codegen/codegen.vibe (the top facade) ALSO
-// depends downward on expr/ and wasi/ to forward compile_module/
-// compile_wasi_module*. Leaving these 4 files owned by codegen/index.vpkg
-// itself therefore made codegen/index.vpkg <-> codegen/expr(gc,wasi)/
-// index.vpkg a genuine two-node import cycle the moment expr/gc/wasi's leaf
-// imports of them were switched to boundary-legal package imports
-// (confirmed empirically: `type_db: import cycle detected at
-// codegen/index.vpkg`, only surfaced by scripts/unit_test_runner.sh, not by
-// the build/gate steps that ran earlier in the same verification chain).
-// common_base already plays exactly this "shared substrate every codegen
-// backend and expr-compile module depends on, with no upward edges of its
-// own" role, so moving these 4 files here breaks the cycle cleanly: expr/
-// gc/wasi now reach them via an ordinary downward `import ../common_base`,
-// and codegen.vibe re-exports the externally-relevant subset
-// (lookup_registry_builtin, builtin_registry, verify_lane_builtins,
-// compile_inline_wat) via `export ./common_base { .. }` (cross-package
-// SReExport, same form as syntax/syntax.vibe's re-export of @vibe/parser) so
-// codegen/index.vpkg's own external facade surface is unchanged.
-// builtin_registry_typed, double_to_string_expr and int_parse_expr are NOT
-// re-exported by codegen.vibe (nothing outside codegen/expr and codegen/gc
-// consumes them), so they are declared here but not in codegen/index.vpkg.
+// #897 codegen/ top-level batch UPDATE: this package gained 3 new sibling
+// files -- double_to_string_expr.vibe, int_parse_expr.vibe, inline_wat.vibe --
+// relocated here FROM codegen/'s own top level while migrating codegen/'s
+// own index.vibe to index.vpkg. Reason: codegen/'s subpackages (expr/, gc/,
+// wasi/ -- each already its own index.vpkg from earlier #897 batches) need
+// these files directly for synthesized-AST builtin lowering and `= wasm
+// "..."` bodies, while codegen/codegen.vibe (the top facade) ALSO depends
+// downward on expr/ and wasi/ to forward compile_module/compile_wasi_module*.
+// Leaving these files owned by codegen/index.vpkg itself therefore made
+// codegen/index.vpkg <-> codegen/expr(gc,wasi)/index.vpkg a genuine two-node
+// import cycle the moment expr/gc/wasi's leaf imports of them were switched to
+// boundary-legal package imports. common_base already plays exactly this
+// "shared substrate every codegen backend and expr-compile module depends on,
+// with no upward edges of its own" role, so moving them here breaks the cycle
+// cleanly. codegen.vibe re-exports compile_inline_wat via `export
+// ./common_base { .. }` (cross-package SReExport) so codegen/index.vpkg's own
+// external facade surface is unchanged.
 
 // Func/string/lambda-table lookups threaded through CompileCtx/CompileCtxGc.
 type FuncTable
@@ -203,12 +191,6 @@ fn effect_name_to_tag(effect_names: Array[String], full: String) -> Int
 fn effect_op_declared_arity(keys: Array[String], arities: Array[Int], full: String) -> Int
 fn effect_op_index(keys: Array[String], full: String) -> Int
 fn emit_heap_grow_after_heap_set(buf: Bytes, ctx: CompileCtx) -> Unit
-
-// --- builtin_registry.vibe (relocated here, see #897 header note above)
-fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)]
-fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
-fn lookup_registry_builtin(name: String) -> Option[Type]
-fn verify_lane_builtins(lane: String, names: Array[String], param_counts: Array[Int], returns: Array[Int]) -> Unit with Error
 
 // --- double_to_string_expr.vibe (relocated here, see #897 header note above)
 fn double_to_string_expr(arg: Expr) -> Expr

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -622,7 +622,7 @@ fn cc_ft_first_idx(ft: FuncTable, name: String) -> Int {
 /// user function. A user/prelude shadow therefore classifies as 0 (unknown),
 /// exactly matching what the actual call emission dispatches to. Name sets
 /// mirror the checker's declared types (checker/checker.vibe
-/// direct_builtin_return / codegen/builtin_registry.vibe).
+/// direct_builtin_return / core/builtin_registry.vibe).
 export fn cc_builtin_call_ret_kind(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Int with Error {
   if expr_tag(e) == 8 {
     let bcallee = get_ecall_callee(e)

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -5,6 +5,7 @@ import @vibe/compiler/core {
   Pat,
   Stmt,
   TypeExpr,
+  builtin_registry,
   bytebuf_length,
   bytebuf_new,
   bytebuf_push,
@@ -14,7 +15,8 @@ import @vibe/compiler/core {
   bytebuf_to_bytes,
   leb128_encode_s64,
   leb128_encode_u32,
-  rewrite_top_level_fn_alias_refs
+  rewrite_top_level_fn_alias_refs,
+  verify_lane_builtins
 }
 
 import @vibe/core {
@@ -38,7 +40,6 @@ import @vibe/compiler/codegen/common_base {
   LambdaTable,
   StrTable,
   agg_info_of_type_expr,
-  builtin_registry,
   compute_agg_returning,
   ctor_sorted_index,
   emit_binop_op,
@@ -57,8 +58,7 @@ import @vibe/compiler/codegen/common_base {
   lookup_ctor,
   resolve_func,
   resolve_local,
-  rewrite_self_tail_calls,
-  verify_lane_builtins
+  rewrite_self_tail_calls
 }
 
 import @vibe/compiler/codegen/common_extractors {

--- a/lib/@vibe/compiler/codegen/index.vpkg
+++ b/lib/@vibe/compiler/codegen/index.vpkg
@@ -23,30 +23,21 @@ generated_hash =
 // naming note below) is the ENTIRE directory-owned surface. It is a thin
 // public facade, forwarding compile_module/compile_wasi_module* to the
 // expr/ and wasi/ subpackages, and re-exporting a subset of
-// codegen/common_base's surface (lookup_registry_builtin, builtin_registry,
-// verify_lane_builtins, compile_inline_wat) via the `export ./common_base
-// { names }` cross-package SReExport form (#847 Phase C; same shape as
-// syntax/syntax.vibe's re-export of @vibe/parser).
+// codegen/common_base's compile_inline_wat surface via the `export
+// ./common_base { names }` cross-package SReExport form (#847 Phase C; same
+// shape as syntax/syntax.vibe's re-export of @vibe/parser).
 //
 // Structural wrinkle (found only via the full verification chain, not by
-// static reading — scripts/unit_test_runner.sh, not the earlier build/gate
-// steps, is what caught it): builtin_registry.vibe, double_to_string_expr.
-// vibe, int_parse_expr.vibe and inline_wat.vibe used to live at this
-// directory's top level too (siblings of codegen.vibe). But codegen/'s own
-// subpackages (expr/, gc/, wasi/) need those 4 files directly, while
-// codegen.vibe (this package's facade) ALSO depends downward on expr/ and
-// wasi/ to forward compile_module/compile_wasi_module*. Owning those 4
-// files here therefore made codegen/index.vpkg <-> codegen/expr(gc,wasi)/
-// index.vpkg a genuine two-node import cycle the moment expr/gc/wasi's leaf
-// imports of them were switched from raw file paths (rejected by
-// enforce_incoming_boundary_fs, #729, once this directory became a package
-// boundary) to boundary-legal package imports (`type_db: import cycle
-// detected at codegen/index.vpkg`). Resolved by relocating all 4 files into
-// codegen/common_base/ — see that package's index.vpkg header for the full
-// story — which already plays the "shared substrate every codegen backend
-// and expr-compile module depends on, with no upward edges of its own"
-// role. This package therefore ends up back to a single file, same shape as
-// common_base/ was before this same batch added those 4 files to it.
+// static reading): double_to_string_expr.vibe, int_parse_expr.vibe and
+// inline_wat.vibe used to live at this directory's top level too (siblings
+// of codegen.vibe). But codegen/'s subpackages (expr/, gc/, wasi/) need
+// those 3 files directly, while codegen.vibe (this package's facade) ALSO
+// depends downward on expr/ and wasi/ to forward compile_module/
+// compile_wasi_module*. Owning the files here made codegen/index.vpkg <->
+// codegen/expr(gc,wasi)/index.vpkg a genuine two-node import cycle when their
+// leaf imports were switched to boundary-legal package imports. Moving them
+// to codegen/common_base/ breaks the cycle: that package remains shared
+// substrate with no upward codegen edges.
 //
 // Naming note: the established rename convention for this migration batch
 // is `git mv index.vibe <dirname>.vibe` (codegen/expr/expr.vibe,
@@ -57,10 +48,9 @@ generated_hash =
 //
 // Compiled into the compiler itself via compiler_sources_manifest.tsv
 // (group `codegen`): the old single `codegen/index.vibe` row becomes a dual
-// row (this contract + codegen.vibe); builtin_registry.vibe /
-// double_to_string_expr.vibe / int_parse_expr.vibe / inline_wat.vibe's rows
-// are repointed to their new codegen/common_base/ paths (see that
-// package's manifest rows) as part of this same batch.
+// row (this contract + codegen.vibe); double_to_string_expr.vibe /
+// int_parse_expr.vibe / inline_wat.vibe's rows are repointed to their new codegen/common_base/ paths (see that package's
+// manifest rows) as part of this same batch.
 
 // --- codegen.vibe
 fn compile_module(stmts: Array[Stmt]) -> Bytes with Error
@@ -75,14 +65,7 @@ fn compile_wasi_module_trace(stmts: Array[Stmt], entry_name: String) -> Bytes wi
 fn compile_wasi_module_break(stmts: Array[Stmt], entry_name: String, prov: DbgProv) -> Bytes with Error
 
 // --- re-exported from codegen/common_base (cross-package SReExport, see
-// header note above); NOT declared here: builtin_registry_typed,
-// double_to_string_expr, int_parse_expr, desugar_derives,
-// desugar_hoist_local_lambdas, desugar_array_spread, which codegen.vibe does
-// not re-export (nothing outside codegen/common_base itself consumes them) —
-// see codegen/common_base/index.vpkg for their declarations.
-fn lookup_registry_builtin(name: String) -> Option[Type]
-fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
-fn verify_lane_builtins(lane: String, names: Array[String], param_counts: Array[Int], returns: Array[Int]) -> Unit with Error
+// header note above).
 fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[String]) -> Bytes with Error
 fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Error
 

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -6,6 +6,7 @@ import @vibe/compiler/core {
   Stmt,
   TypeExpr,
   bsearch_leftmost,
+  builtin_registry,
   bytebuf_length,
   bytebuf_new,
   bytebuf_push,
@@ -18,7 +19,8 @@ import @vibe/compiler/core {
   leb128_encode_s64,
   leb128_encode_u32,
   rewrite_top_level_fn_alias_refs,
-  sorted_names_of
+  sorted_names_of,
+  verify_lane_builtins
 }
 
 import @vibe/core {
@@ -137,7 +139,6 @@ import @vibe/compiler/codegen/common_base {
   StrTable,
   agg_info_of_type_expr,
   await_poll_pass,
-  builtin_registry,
   codegen_body_cache_find,
   codegen_body_cache_merge,
   codegen_body_cache_new,
@@ -195,8 +196,7 @@ import @vibe/compiler/codegen/common_base {
   resolve_func,
   resolve_local,
   rewrite_self_tail_calls,
-  suspend_cps_pass,
-  verify_lane_builtins
+  suspend_cps_pass
 }
 
 import @vibe/compiler/codegen/common_extractors {

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -24,6 +24,7 @@ core	core/exception_effect.vibe
 core	core/builtin_name.vibe
 core	core/sorted_index.vibe
 core	core/import_alias_rewrite.vibe
+core	core/builtin_registry.vibe
 core	core/index.vpkg
 core	core/core.vibe
 core	bytebuf.vibe
@@ -111,7 +112,6 @@ codegen	codegen/expr/index.vpkg
 codegen	codegen/expr/expr.vibe
 codegen	codegen/expr/compile_match.vibe
 codegen	codegen/expr/compile_lambda.vibe
-codegen	codegen/common_base/builtin_registry.vibe
 codegen	codegen/common_base/double_to_string_expr.vibe
 codegen	codegen/common_base/int_parse_expr.vibe
 codegen	codegen/common_base/double_parse_expr.vibe

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -1,6 +1,6 @@
 //# Imports
 
-import @vibe/compiler/core {
+import ./types.vibe {
   Type
 }
 
@@ -407,7 +407,7 @@ export fn verify_lane_builtins(lane: String, names: Array[String], param_counts:
         if claimed {
           ()
         } else {
-          throw("builtin registry drift: '\{n}' is registered by the \{lane} lane but the registry says it is not in that lane's table (lib/@vibe/compiler/codegen/builtin_registry.vibe, #415)")
+          throw("builtin registry drift: '\{n}' is registered by the \{lane} lane but the registry says it is not in that lane's table (lib/@vibe/compiler/core/builtin_registry.vibe, #415)")
         }
         if rp == Array::get(param_counts, i) && rr == Array::get(returns, i) {
           ()
@@ -422,7 +422,7 @@ export fn verify_lane_builtins(lane: String, names: Array[String], param_counts:
     if found {
       ()
     } else {
-      throw("builtin registry drift: '\{n}' is registered by the \{lane} lane but has no row in lib/@vibe/compiler/codegen/builtin_registry.vibe (#415) — add one (and decide the other lane explicitly)")
+      throw("builtin registry drift: '\{n}' is registered by the \{lane} lane but has no row in lib/@vibe/compiler/core/builtin_registry.vibe (#415) — add one (and decide the other lane explicitly)")
     }
     i = i + 1
   }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -18,9 +18,10 @@ generated_hash =
 // already-migrated package), so this header documents the type-declaration
 // reasoning in more depth than usual.
 //
-// Directory-shared-scope package (8 impl files + the facade): ast.vibe
+// Directory-shared-scope package (9 impl files + the facade): ast.vibe
 // (cross-package re-export shim, see below), builtin_name.vibe (legacy
-// builtin-name canonicalization), bytebuf.vibe (wasm bytecode-buffer / leb128
+// builtin-name canonicalization), builtin_registry.vibe (central typed builtin
+// registry shared by checker and both codegen lanes), bytebuf.vibe (wasm bytecode-buffer / leb128
 // helpers), dce.vibe (dead-code elimination over Stmt), polyfill.vibe
 // (__to_string), sorted_index.vibe (sorted-name-table binary search helpers),
 // import_alias_rewrite.vibe (import-alias rewriting + the whole-program
@@ -117,6 +118,12 @@ fn expr_children(expr: Expr) -> Array[Expr]
 
 // --- builtin_name
 fn canonical_builtin_name(name: String) -> String
+
+// --- builtin_registry
+fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)]
+fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
+fn lookup_registry_builtin(name: String) -> Option[Type]
+fn verify_lane_builtins(lane: String, names: Array[String], param_counts: Array[Int], returns: Array[Int]) -> Unit with Error
 
 // --- exception_effect
 fn canonical_exception_effect_name(name: String) -> String

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -213,7 +213,7 @@ generated_hash =
 // Bodyless-declaration conventions used below (matching prior batches):
 // `fn` for every real function (whether written as `export fn` or
 // `export let name = (...) -> T { ... }`, an EFn-valued let — checker/checker.vibe,
-// common_base/index.vpkg's builtin_registry.vibe entries, etc. established
+// core/index.vpkg's builtin_registry.vibe entries, etc. established
 // this precedent); `let name: Type` (no `opaque`) for a real VALUE let,
 // fingerprinted as "val <type>" (version, the compiler_* aliases,
 // parse_line_list_export, the *_path/*_source string constants in

--- a/lib/@vibe/compiler/tests/builtin_registry_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_registry_test.vibe
@@ -1,6 +1,6 @@
 //# Imports
 
-import @vibe/compiler/codegen {
+import @vibe/compiler/core {
   builtin_registry, verify_lane_builtins
 }
 

--- a/lib/@vibe/compiler/tests/builtins_test.vibe
+++ b/lib/@vibe/compiler/tests/builtins_test.vibe
@@ -10,6 +10,20 @@ import @vibe/compiler/core {
 
 //# Misc
 
+test "lookup_builtin normalizes a legacy alias before registry lookup" {
+  match lookup_builtin("Fs::ReadFile") {
+    Some(_) => assert(true),
+    None => assert(false)
+  }
+}
+
+test "lookup_builtin hides codegen-internal registry rows" {
+  match lookup_builtin("vibe_sh_lines_raw") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
 test "lookup_builtin Array::length" {
   match lookup_builtin("Array::length") {
     Some(_) => assert(true),
@@ -68,7 +82,7 @@ test "lookup_builtin FixedArray::blit" {
 
 /// #835: Int64Array::make/length/get/set — cheatsheet-documented but
 /// previously "unknown name" in the checker (absent from every lookup
-/// table). See codegen/builtin_registry.vibe for the fix.
+/// table). See core/builtin_registry.vibe for the fix.
 test "lookup_builtin Int64Array::make" {
   match lookup_builtin("Int64Array::make") {
     Some(_) => assert(true),

--- a/lib/@vibe/http/high_level.vibe
+++ b/lib/@vibe/http/high_level.vibe
@@ -80,7 +80,7 @@ export fn status_is_success(status: Int) -> Bool {
 
 /// #774: `String::to_lower` is registered in the type checker's builtin table
 /// (checker/builtins_string2.vibe) but has no codegen builtin-registry entry
-/// (codegen/builtin_registry.vibe only carries `String::trim`/`to_upper`'s
+/// (core/builtin_registry.vibe only carries `String::trim`/`to_upper`'s
 /// siblings, not `to_lower`), so calling it traps at runtime with "undefined
 /// variable (local): String::to_lower @call" instead of failing to compile.
 /// Fixing that gap is a compiler codegen change out of scope for the HTTP

--- a/scripts/check_builtin_parity.sh
+++ b/scripts/check_builtin_parity.sh
@@ -2,7 +2,7 @@
 # #415 B-3: builtin parity gate (selfhost re-implementation of the retired
 # check_codegen_parity.sh idea).
 #
-# The registry (codegen/common_base/builtin_registry.vibe) already hard-verifies the two
+# The registry (core/builtin_registry.vibe) already hard-verifies the two
 # FUNC-TABLE lanes at compile time (verify_lane_builtins runs inside every
 # linear compile and every gc compile, incl. the gate's 40h gc smoke). What it
 # cannot see are the CALLSITE lowerings -- the `fname == "..."` dispatch arms
@@ -27,7 +27,7 @@ import re, sys
 
 LIN_CALLSITE = "lib/@vibe/compiler/codegen/expr/compile_call.vibe"
 GC_CALLSITE = "lib/@vibe/compiler/codegen/gc/backend_call.vibe"
-REGISTRY = "lib/@vibe/compiler/codegen/common_base/builtin_registry.vibe"
+REGISTRY = "lib/@vibe/compiler/core/builtin_registry.vibe"
 CLASSIFICATION = "scripts/builtin_parity_classification.tsv"
 
 def callsite_names(path):

--- a/scripts/check_inline_builtin_capture.sh
+++ b/scripts/check_inline_builtin_capture.sh
@@ -43,7 +43,7 @@ cd "$ROOT_DIR"
 
 CALL_SRC="lib/@vibe/compiler/codegen/expr/compile_call.vibe"
 ANALYSIS_SRC="lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe"
-REGISTRY_SRC="lib/@vibe/compiler/codegen/common_base/builtin_registry.vibe"
+REGISTRY_SRC="lib/@vibe/compiler/core/builtin_registry.vibe"
 ALLOWLIST="scripts/inline_builtin_capture_allowlist.txt"
 
 for f in "$CALL_SRC" "$ANALYSIS_SRC" "$REGISTRY_SRC"; do


### PR DESCRIPTION
## Summary

Continue #1440 phase 2 by moving the canonical typed builtin registry from `codegen/common_base` into existing compiler-internal `core`.

- relocate `builtin_registry_typed`, `builtin_registry`, `lookup_registry_builtin`, and `verify_lane_builtins` with semantic/allocation behavior preserved
- make checker lookup consume the core-owned registry directly
- make linear and GC lane registration/drift verification consume core directly
- remove obsolete common-base/codegen facade contracts and re-exports
- update active scripts and documentation references
- add focused integration assertions for legacy alias → canonical name → registry lookup and for hiding codegen-internal rows

This narrows the checker→codegen dependency to the three pre-check transforms imported by `checker_stmt.vibe`. It intentionally does **not** remove `checker/index.vpkg`'s codegen dependency yet or extract the coupled ~8k-line desugar implementation.

No new package/public API, production cache change, or manual generated-artifact edit is included.

## Semantic preservation

The moved registry is textually identical after accounting for:

- legal local `./types.vibe` import instead of cross-package core import
- two diagnostic source paths updated to the new owner

The module-level `registry_typed_rows` remains intact, preserving one-time initialization rather than rebuilding the typed table on each checker lookup.

## Boundary evidence

The merged baseline originally classified 68 codegen modules in the current-checker closure. After the builtin-name and registry ownership slices, the fresh current snapshot classifies 66 codegen modules while the closure remains 178 modules. That is ownership progress only; this PR does not claim engine extraction or size reduction.

The sole remaining checker source import of `@vibe/compiler/codegen` is now `checker/checker_stmt.vibe` for:

- `inject_trait_method_generics`
- `desugar_railway_binds`
- `desugar_labeled_args`

## Validation

- focused registry test: pass
- `builtins_test.vibe`: 81 tests pass
- builtin parity gate: pass
- inline builtin capture gate: pass
- Vibe formatter check: pass
- generated-artifact freshness check: pass
- fresh stage2 == stage3
- `pkf run release-check`: pass
- merged #1448 collector: all three required roots available with 2 samples
- independent hard review: no P0/P1; P2 test gap fixed
- `git diff --check`

The release gate skipped its optional async-stackful probe because local Wasmtime lacks that flag; the required gate completed successfully.

Progresses #1440.
