### PR TITLE
checker: `with` / `allows` 句の分類検査 (#1345, ADR-0088 slice 2)

### DIFF
--- a/lib/@vibe/compiler/tests/parser_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_test.vibe
@@ -822,12 +822,12 @@ test "#1345: `allows` folds into the single row" {
   // row representation, so `with A allows C` and `with A + C` are the SAME
   // row and produce byte-identical output.
   let split = handle {
-    print_program(parse_program(lex("let f: (Int) -> Int with Log::Emit allows Cfg::Read = (x) -> { x }")))
+    print_program(parse_program(lex("let f: (Int) -> Int with Log::Emit allows Fs::read_file = (x) -> { x }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
   let flat = handle {
-    print_program(parse_program(lex("let f: (Int) -> Int with Log::Emit + Cfg::Read = (x) -> { x }")))
+    print_program(parse_program(lex("let f: (Int) -> Int with Log::Emit + Fs::read_file = (x) -> { x }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
@@ -841,24 +841,24 @@ test "#1345: `allows` folds into the single row" {
 
 test "#1345: `with () allows C` is the capability-only row" {
   let out = handle {
-    print_program(parse_program(lex("let f: (Int) -> Int with () allows Cfg::Read = (x) -> { x }")))
+    print_program(parse_program(lex("let f: (Int) -> Int with () allows Fs::read_file = (x) -> { x }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
   assert(!String::starts_with(out, "ERROR: "))
-  assert(String::contains(out, "with Cfg::Read"))
+  assert(String::contains(out, "with Fs::read_file"))
 }
 
 test "#1345: `allows` works in type position too" {
   // ADR-0088: the sugar is uniform across signature and type positions --
   // there is one row grammar, not a declaration-only spelling.
   let out = handle {
-    print_program(parse_program(lex("let g: ((Int) -> Int with Log::Emit allows Cfg::Read, Int) -> Int = (f, x) -> { f(x) }")))
+    print_program(parse_program(lex("let g: ((Int) -> Int with Log::Emit allows Fs::read_file, Int) -> Int = (f, x) -> { f(x) }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }
   assert(!String::starts_with(out, "ERROR: "))
-  assert(String::contains(out, "with Log::Emit + Cfg::Read"))
+  assert(String::contains(out, "with Log::Emit + Fs::read_file"))
 }
 
 test "#1345: `allows` is contextual, not reserved" {
@@ -873,13 +873,91 @@ test "#1345: `allows` is contextual, not reserved" {
   assert(String::contains(out, "let allows = 7"))
 }
 
+test "#1345: `allows` takes capability effects only" {
+  // ADR-0088 decision 1. The check runs at PARSE time because that is the
+  // only place the two clauses still exist -- they fold into one row
+  // immediately after, and nothing downstream can tell them apart again.
+  let ok = handle {
+    print_program(parse_program(lex("let f: () -> Int with Error allows Fs = () -> { 1 }")))
+  } with Error {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(!String::starts_with(ok, "ERROR: "))
+  // an algebraic effect in `allows`
+  let alg = handle {
+    print_program(parse_program(lex("let f: () -> Int with () allows Log = () -> { 1 }")))
+  } with Error {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(String::contains(alg, "not a capability effect"))
+  // a row variable in `allows` -- ADR-0088 rejects it because `allows`
+  // promises every item is a statically known capability
+  let rowvar = handle {
+    print_program(parse_program(lex("let f: [r]() -> Int with () allows r = () -> { 1 }")))
+  } with Error {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(String::contains(rowvar, "not a capability effect"))
+}
+
+test "#1345: a core ambient effect in `allows` names the right clause" {
+  // `Error`/`Exception[E]` get their own message rather than the generic
+  // "not a capability": the author wrote a real effect in the wrong clause,
+  // and the fix is to move it, not to reclassify it.
+  let out = handle {
+    print_program(parse_program(lex("let f: () -> Int with () allows Error = () -> { 1 }")))
+  } with Error {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(String::contains(out, "core ambient effect"))
+  assert(String::contains(out, "`with` clause"))
+}
+
+test "#1345: the SPLIT `with` clause rejects capabilities, the bare one does not" {
+  // ADR-0088: "通常関数の裸 with(混在可)は恒久的に合法" -- the restriction is
+  // opt-in and starts only once the author writes `allows`.
+  let bare = handle {
+    print_program(parse_program(lex("let f: () -> Int with Fs = () -> { 1 }")))
+  } with Error {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(!String::starts_with(bare, "ERROR: "))
+  let split = handle {
+    print_program(parse_program(lex("let f: () -> Int with Fs allows Http = () -> { 1 }")))
+  } with Error {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(String::contains(split, "must appear in the `allows` clause"))
+}
+
+test "#1345: classification uses the base effect name, and excludes Async" {
+  // A qualified operation classifies by its effect: `Fs::read_file` is a
+  // capability because `Fs` is.
+  let qualified = handle {
+    print_program(parse_program(lex("let f: () -> Int with () allows Fs::read_file = () -> { 1 }")))
+  } with Error {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(!String::starts_with(qualified, "ERROR: "))
+  // `Async` is builtin-tagged but is NOT a capability: it is ADR-0089's
+  // suspension effect, discharged by the runtime driver, with no resource
+  // kind to grant. Deriving the list from "is it builtin" would get this
+  // wrong, which is why it is written out.
+  let async_cap = handle {
+    print_program(parse_program(lex("let f: () -> Int with () allows Async = () -> { 1 }")))
+  } with Error {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(String::contains(async_cap, "not a capability effect"))
+}
+
 test "#1345: the `?` grade suffix does NOT parse yet" {
   // Deliberately absent: the checker compares row items as opaque labels, so
   // `Cfg::Read?` would be a different effect from `Cfg::Read` and a function
   // declaring the Optional form would be told to declare BOTH. `?` ships with
   // the slice that gives it meaning (strict grade matching / `perform?`).
   let out = handle {
-    print_program(parse_program(lex("let f: (Int) -> Int with () allows Cfg::Read? = (x) -> { x }")))
+    print_program(parse_program(lex("let f: (Int) -> Int with () allows Fs::read_file? = (x) -> { x }")))
   } with Error {
     Throw(e) => String::concat("ERROR: ", e)
   }

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -1002,15 +1002,109 @@ fn parse_effect_row_base(tokens: Array[Token], pos: Int) -> (String, Int) with E
 /// parse time, the printer renders `with A + C` and `vibe normalize` therefore
 /// ERASES an `allows` clause. For a clause whose whole purpose is to make the
 /// capability surface visible, that is wrong -- preserving it needs the split
-/// carried in the AST, which is a later slice. Classification (capability vs
-/// algebraic vs row variable, ADR-0088 decision 1) and grade matching are also
-/// not enforced yet: today `allows` parses anywhere a row may appear and
-/// anything may be written in it.
+/// carried in the AST, which is a later slice.
+///
+/// The classification check (ADR-0088 decision 1) DOES run -- see
+/// check_allows_clause_items / check_split_with_clause_items below. Still
+/// absent: grade matching, and the entry-point-only rule (`allows` is
+/// currently accepted anywhere a row may appear).
+
+/// #1345 / ADR-0088: the base effect NAME of a row item -- `Fs` for
+/// `Fs::read_file`, `Fs::Read[Cfg]` and plain `Fs`. Classification is a
+/// property of the effect, not of the operation or its resource kind.
+fn row_item_base_name(item: String) -> String {
+  let n = String::length(item)
+  let mut i = 0
+  let mut end = n
+  while i < n && end == n {
+    let c = String::char_code_at(item, i)
+    if c == ':' || c == '[' || c == '?' {
+      end = i
+    } else {
+      i = i + 1
+    }
+  }
+  String::substring(item, 0, end)
+}
+
+/// #1345 / ADR-0088: is this effect a CAPABILITY (resource kind, resolved by
+/// a host/provider) as opposed to an algebraic effect (discharged by an
+/// in-process handler) or a core ambient effect?
+///
+/// PROVISIONAL. ADR-0084's three-way classification is the real home for this
+/// (#1343) and is unimplemented; this list is derived from ADR-0088's own
+/// definition applied to the effects the builtin registry actually tags, so
+/// the checker has something principled to reject against in the meantime.
+///
+/// `Async` is deliberately EXCLUDED even though it is builtin-tagged: it is
+/// ADR-0089's suspension effect, discharged by the runtime driver, and it
+/// carries no resource kind to grant. Classifying it by "is it builtin" would
+/// get that wrong -- which is exactly why the list is written out rather than
+/// derived from the registry.
+fn is_capability_effect_name(name: String) -> Bool {
+  name == "Fs" || name == "Http" || name == "Socket" || name == "Env" ||
+  name == "Stdin" || name == "Stdout" || name == "Stderr" ||
+  name == "Process" || name == "Profiler"
+}
+
+/// ADR-0088: `Error` / `Exception[E]`. Spelled here rather than imported from
+/// the compiler's exception_effect.vibe because the parser package must not
+/// depend on the compiler.
+fn is_core_ambient_effect_name(name: String) -> Bool {
+  name == "Error" || name == "Exception"
+}
+
+/// ADR-0088 decision 1: `allows` takes capability effects ONLY.
+fn check_allows_clause_items(caps: String) -> Unit with Error {
+  let items = String::split(caps, ", ")
+  let mut i = 0
+  while i < Array::length(items) {
+    let item = Array::get(items, i)
+    if String::length(item) > 0 {
+      let base = row_item_base_name(item)
+      if !is_capability_effect_name(base) {
+        if is_core_ambient_effect_name(base) {
+          throw("`\{item}` is a core ambient effect and belongs in the `with` clause, not `allows` (ADR-0088)")
+        } else {
+          throw("`\{item}` is not a capability effect, so it cannot appear in `allows` -- `allows` promises every item is a statically known capability, which rules out algebraic effects and row variables. Write it in the `with` clause (ADR-0088, #1345)")
+        }
+      } else ()
+    } else ()
+    i = i + 1
+  }
+}
+
+/// ADR-0088 decision 1: the split `with` clause takes algebraic / core ambient
+/// / row variables ONLY. A bare `with` (no `allows`) stays permanently legal
+/// with anything in it -- the restriction is opt-in, and only applies once the
+/// author has chosen the split form.
+fn check_split_with_clause_items(row: String) -> Unit with Error {
+  let items = String::split(row, ", ")
+  let mut i = 0
+  while i < Array::length(items) {
+    let item = Array::get(items, i)
+    if String::length(item) > 0 && is_capability_effect_name(row_item_base_name(item)) {
+      throw("`\{item}` is a capability effect and must appear in the `allows` clause, not `with` (ADR-0088, #1345)")
+    } else ()
+    i = i + 1
+  }
+}
+
 fn parse_effect_row(tokens: Array[Token], pos: Int) -> (String, Int) with Error {
   let (row, after_row) = parse_effect_row_base(tokens, pos)
   match peek(tokens, after_row) {
     TIdent(kw) => if kw == "allows" {
       let (caps, after_caps) = collect_effect_names_plus(tokens, after_row + 1, "")
+      // ADR-0088 decision 1's classification check. It runs HERE, at parse
+      // time, because this is the only place the split still exists: the two
+      // clauses fold into one row on the next line and nothing downstream can
+      // tell them apart again. That is affordable only because the predicate
+      // is name-level (capability list / `Error` / everything else), so it
+      // needs no scope or declaration knowledge -- when ADR-0084's real
+      // classification lands (#1343) this check moves to the checker along
+      // with the split.
+      check_split_with_clause_items(row)
+      check_allows_clause_items(caps)
       let joined = if String::length(row) == 0 {
         caps
       } else if String::length(caps) == 0 {


### PR DESCRIPTION
ADR-0088 decision 1 の分割述語。**`allows` は capability effect のみ**、分割形を選んだ時点で **`with` 句はそれ以外のみ**。裸 `with` は何を書いても恒久的に合法のままです（ADR が明示している「オプトイン」）。

## 検査位置は「選んだ」のではなく「強制された」

`allows` は直後に単一 row へ畳まれる（decision 1: 分割は監査面であって第二の row 表現ではない）ので、**2つの句が存在する場所は1つだけ**です。それより先へ運ぶには新しい AST チャネルか、`EFn` 446 + `TyFn` 80 = **526 サイト**にわたる row 型の拡張が要ります。

パース時で済むのは、**述語が名前レベルだと判明したから**です（capability リスト / `Error` / それ以外）。スコープも宣言情報も要りません。ADR-0084 の本分類（#1343）が入ったら、分割の保持と一緒にチェッカへ移します。

> 当初は preserving-only ノード（SFnDecl の前例）で運ぶ想定でしたが、`parse_program` は `expand_top_level_pattern_lets(lower_fn_decl_stmts(parse_program_preserving(tokens)))` で **preserving の上に lowering が乗る**構造だと確認しました。preserving ノードはチェッカに届く前に畳まれるので、その経路では分類検査は実装できません。

## capability リストは暫定・かつ「導出せず書き下し」

自明な導出（builtin registry がタグ付けしている effect）は **`Async` を capability に誤分類**します。ADR-0089 の suspension effect で、ランタイムドライバが discharge し、grant する resource kind を持たないためです。

**書き下すことで、この除外が創発ではなくレビュー可能になります。** ADR-0088 自身の定義（resource kind を持ち host/provider が解決する）をタグ付き effect に適用した結果:

```
Fs  Http  Socket  Env  Stdin  Stdout  Stderr  Process  Profiler
除外: Async
```

## 診断の作り分け

- **core ambient を `allows` に書いた**場合は専用メッセージ。作者は実在のエフェクトを**間違った句**に書いたので、直し方は「移す」であって「分類し直す」ではありません
- **row 変数**は capability 規則から自動的に落ちます（ADR-0088 は `allows e` を「全要素が静的に既知」の約束違反として拒否）。メッセージにそう書いています
- 分類は**ベース effect 名**で行うので、`Fs::read_file` も `Fs::Read[Cfg]` も `Fs` と同じ扱いです。カテゴリは effect の性質であって、operation や resource kind の性質ではありません

## unit battery が拾った相互作用

slice 1 のテストが `allows Cfg::Read`（架空のエフェクト名）を使っており、新しい検査に**正しく拒否されました**。実在の capability へ差し替えています。

## 未実装

grade matching (`?`)、エントリポイント限定の規則（今は row が書ける場所ならどこでも `allows` が書ける）。

## 検証

`#1450`（builtin names を core へ移動）をマージしたベースで実施:

- `check_vibe_fmt` 898 clean
- `compiler_gate.sh` rc=0
- `unit_test_runner` 524/524 rc=0

このソースから作った stage2 で挙動を確認（committed seed は `allows` を parse できません）:

| ケース | 結果 |
|---|---|
| `with Error allows Fs` | OK |
| `with Fs allows Http`（分割 with に capability） | 拒否 |
| `allows Error`（core ambient） | 拒否・専用メッセージ |
| `allows Log`（algebraic） | 拒否 |
| `allows r`（row 変数） | 拒否 |
| `allows Async` | 拒否 |
| `with Fs`（裸） | **OK**（恒久的に合法） |
| `allows Fs::read_file`（qualified） | OK |

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_