### PR TITLE
refactor(checker): isolate expression structure artifacts

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_expression_structure_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_expression_structure_artifact.vibe
@@ -9,7 +9,7 @@ import @vibe/core {
   array_empty
 }
 
-import ./checked_expression_structure_core.vibe {
+import @vibe/compiler/checker {
   checked_expression_structure_kind_valid
 }
 

--- a/lib/@vibe/compiler/checker/artifacts/checked_expression_structure_observation.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_expression_structure_observation.vibe
@@ -10,12 +10,8 @@
 // offsets, inferred types, bindings, typed IR, cache identity, or edit-stable
 // identity.
 
-import ./checked_expression_structure_core.vibe {
-  checked_expression_structure_copy_path, checked_expression_structure_rows
-}
-
-import ./checker_stmt.vibe {
-  CheckedProgram
+import @vibe/compiler/checker {
+  CheckedProgram, checked_expression_structure_copy_path, checked_expression_structure_rows
 }
 
 /// Opaque complete structural coordinate table for retained checked

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -11,8 +11,8 @@ deps = {
 generated_hash =
 
 // @vibe/compiler/checker/artifacts — narrow checked-program artifact APIs.
-// This nested compiler-internal boundary owns only checked effect-set
-// declaration observation and its strict v1 artifact transport.
+// This nested compiler-internal boundary owns checked effect-set declarations
+// and checked expression-structure observation/artifact transport.
 
 opaque type CheckedEffectSetDeclarationsObservation
 opaque type CheckedEffectSetDeclarationsArtifact
@@ -23,3 +23,32 @@ fn checked_effect_set_declarations_artifact_from_observation(observation: Checke
 fn encode_checked_effect_set_declarations_artifact_v1(artifact: CheckedEffectSetDeclarationsArtifact) -> String
 fn decode_checked_effect_set_declarations_artifact_v1(text: String) -> Option[CheckedEffectSetDeclarationsArtifact]
 fn canonical_checked_effect_set_declarations_artifact_snapshot(artifact: CheckedEffectSetDeclarationsArtifact) -> String
+
+// --- checked_expression_structure_observation.vibe
+// Structural coordinate skeleton over supplied CheckedProgram.checked_stmts.
+// Production inputs are retained/post-desugar, but this API does not attest
+// checker success or provenance. Rows are in statement order and expression
+// preorder using core::expr_children. Payloads, offsets, inferred types,
+// bindings, typed IR, cache/reuse, and edit-stable identity are deliberately
+// absent. Unlowered SFnDecl and bounded size/depth exhaustion fail closed.
+opaque type CheckedExpressionStructureObservation
+fn checked_expression_structure_observation(checked: CheckedProgram) -> Option[CheckedExpressionStructureObservation]
+fn canonical_checked_expression_structure_snapshot(observation: CheckedExpressionStructureObservation) -> String
+fn checked_expression_structure_observation_row_count(observation: CheckedExpressionStructureObservation) -> Int
+fn checked_expression_structure_observation_statement_path_at(observation: CheckedExpressionStructureObservation, row_index: Int) -> Option[Array[Int]]
+fn checked_expression_structure_observation_expression_path_at(observation: CheckedExpressionStructureObservation, row_index: Int) -> Option[Array[Int]]
+fn checked_expression_structure_observation_kind_at(observation: CheckedExpressionStructureObservation, row_index: Int) -> Option[String]
+
+// --- checked_expression_structure_artifact.vibe
+// Strict opaque v1 transport of the structure-only preorder observation.
+// It excludes payloads, types, bindings, checker attestation, full typed IR,
+// cache/reuse/import identity, source identity, and edit-stable identity.
+opaque type CheckedExpressionStructureArtifact
+fn checked_expression_structure_artifact_from_observation(observation: CheckedExpressionStructureObservation) -> Option[CheckedExpressionStructureArtifact]
+fn encode_checked_expression_structure_artifact_v1(artifact: CheckedExpressionStructureArtifact) -> String
+fn decode_checked_expression_structure_artifact_v1(text: String) -> Option[CheckedExpressionStructureArtifact]
+fn canonical_checked_expression_structure_artifact_snapshot(artifact: CheckedExpressionStructureArtifact) -> String
+fn checked_expression_structure_artifact_row_count(artifact: CheckedExpressionStructureArtifact) -> Int
+fn checked_expression_structure_artifact_statement_path_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[Array[Int]]
+fn checked_expression_structure_artifact_expression_path_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[Array[Int]]
+fn checked_expression_structure_artifact_kind_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[String]

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -41,16 +41,6 @@ export ./checked_effective_effect_row_artifact.vibe {
   encode_checked_effective_effect_row_artifact_v1
 }
 
-export ./checked_expression_structure_observation.vibe {
-  CheckedExpressionStructureObservation,
-  canonical_checked_expression_structure_snapshot,
-  checked_expression_structure_observation,
-  checked_expression_structure_observation_expression_path_at,
-  checked_expression_structure_observation_kind_at,
-  checked_expression_structure_observation_row_count,
-  checked_expression_structure_observation_statement_path_at
-}
-
 export ./checked_direct_expression_return_observation.vibe {
   canonical_checked_direct_expression_return_snapshot,
   checked_direct_expression_return_observation_expression_path_at,
@@ -69,18 +59,6 @@ export ./checked_direct_expression_return_artifact.vibe {
   checked_direct_expression_return_artifact_type_at,
   decode_checked_direct_expression_return_artifact_v1,
   encode_checked_direct_expression_return_artifact_v1
-}
-
-export ./checked_expression_structure_artifact.vibe {
-  CheckedExpressionStructureArtifact,
-  canonical_checked_expression_structure_artifact_snapshot,
-  checked_expression_structure_artifact_expression_path_at,
-  checked_expression_structure_artifact_from_observation,
-  checked_expression_structure_artifact_kind_at,
-  checked_expression_structure_artifact_row_count,
-  checked_expression_structure_artifact_statement_path_at,
-  decode_checked_expression_structure_artifact_v1,
-  encode_checked_expression_structure_artifact_v1
 }
 
 export ./checked_typed_occurrence_statement_observation.vibe {

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -197,21 +197,6 @@ fn checked_expression_structure_leaf_rows(stmts: Array[Stmt]) -> Option[Array[(A
 fn checked_expression_structure_kind(expr: Expr) -> String
 fn checked_expression_structure_rows(stmts: Array[Stmt]) -> Option[Array[(Array[Int], Array[Int], String)]]
 
-// --- checked_expression_structure_observation.vibe
-// Structural coordinate skeleton over supplied CheckedProgram.checked_stmts.
-// Production inputs are retained/post-desugar, but this API does not attest
-// checker success or provenance. Rows are in statement order and expression
-// preorder using core::expr_children. Payloads, offsets, inferred types,
-// bindings, typed IR, cache/reuse, and edit-stable identity are deliberately
-// absent. Unlowered SFnDecl and bounded size/depth exhaustion fail closed.
-opaque type CheckedExpressionStructureObservation
-fn checked_expression_structure_observation(checked: CheckedProgram) -> Option[CheckedExpressionStructureObservation]
-fn canonical_checked_expression_structure_snapshot(observation: CheckedExpressionStructureObservation) -> String
-fn checked_expression_structure_observation_row_count(observation: CheckedExpressionStructureObservation) -> Int
-fn checked_expression_structure_observation_statement_path_at(observation: CheckedExpressionStructureObservation, row_index: Int) -> Option[Array[Int]]
-fn checked_expression_structure_observation_expression_path_at(observation: CheckedExpressionStructureObservation, row_index: Int) -> Option[Array[Int]]
-fn checked_expression_structure_observation_kind_at(observation: CheckedExpressionStructureObservation, row_index: Int) -> Option[String]
-
 // --- checked_direct_expression_return_observation.vibe
 // Complete-or-none direct primary checker-return observation. It is neither
 // typed IR nor a codec/artifact/cache/reuse/import/interface/trace surface.
@@ -268,20 +253,6 @@ fn checked_expression_leaf_payload_direct_return_artifact_expression_path_at(art
 fn checked_expression_leaf_payload_direct_return_artifact_kind_at(artifact: CheckedExpressionLeafPayloadDirectReturnArtifact, row_index: Int) -> Option[String]
 fn checked_expression_leaf_payload_direct_return_artifact_payload_at(artifact: CheckedExpressionLeafPayloadDirectReturnArtifact, row_index: Int) -> Option[String]
 fn checked_expression_leaf_payload_direct_return_artifact_type_at(artifact: CheckedExpressionLeafPayloadDirectReturnArtifact, row_index: Int) -> Option[String]
-
-// --- checked_expression_structure_artifact.vibe
-// Strict opaque v1 transport of the structure-only preorder observation.
-// It excludes payloads, types, bindings, checker attestation, full typed IR,
-// cache/reuse/import identity, source identity, and edit-stable identity.
-opaque type CheckedExpressionStructureArtifact
-fn checked_expression_structure_artifact_from_observation(observation: CheckedExpressionStructureObservation) -> Option[CheckedExpressionStructureArtifact]
-fn encode_checked_expression_structure_artifact_v1(artifact: CheckedExpressionStructureArtifact) -> String
-fn decode_checked_expression_structure_artifact_v1(text: String) -> Option[CheckedExpressionStructureArtifact]
-fn canonical_checked_expression_structure_artifact_snapshot(artifact: CheckedExpressionStructureArtifact) -> String
-fn checked_expression_structure_artifact_row_count(artifact: CheckedExpressionStructureArtifact) -> Int
-fn checked_expression_structure_artifact_statement_path_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[Array[Int]]
-fn checked_expression_structure_artifact_expression_path_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[Array[Int]]
-fn checked_expression_structure_artifact_kind_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[String]
 
 // --- checked_typed_occurrence_statement_observation.vibe
 // Checker-time statement-owner association for legacy typed-occurrence rows.

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -72,8 +72,6 @@ checker	checker/checked_direct_expression_return_observation.vibe
 checker	checker/checked_direct_expression_return_artifact.vibe
 checker	checker/checked_expression_kind_direct_return_artifact.vibe
 checker	checker/checked_expression_leaf_payload_direct_return_artifact.vibe
-checker	checker/checked_expression_structure_observation.vibe
-checker	checker/checked_expression_structure_artifact.vibe
 checker	checker/checked_typed_occurrence_expression_path_artifact.vibe
 checker	checker/checked_typed_occurrence_statement_observation.vibe
 checker	checker/checked_statement_root_type_observation.vibe
@@ -85,6 +83,8 @@ checker	checker/checker_facade.vibe
 checker	checker/artifacts/index.vpkg
 checker	checker/artifacts/checked_effect_set_observation.vibe
 checker	checker/artifacts/checked_effect_set_artifact.vibe
+checker	checker/artifacts/checked_expression_structure_observation.vibe
+checker	checker/artifacts/checked_expression_structure_artifact.vibe
 codegen	codegen/wasm_emit/index.vpkg
 codegen	codegen/wasm_emit/wasm_emit.vibe
 codegen	codegen/wasm_emit/sections.vibe

--- a/lib/@vibe/compiler/tests/checked_expression_structure_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_expression_structure_artifact_test.vibe
@@ -1,7 +1,10 @@
 //# Strict checked expression-structure artifact v1
 
 import @vibe/compiler/checker {
-  CheckedProgram,
+  CheckedProgram
+}
+
+import @vibe/compiler/checker/artifacts {
   canonical_checked_expression_structure_artifact_snapshot,
   canonical_checked_expression_structure_snapshot,
   checked_expression_structure_artifact_expression_path_at,

--- a/lib/@vibe/compiler/tests/checked_expression_structure_observation_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_expression_structure_observation_test.vibe
@@ -1,18 +1,21 @@
 import @vibe/compiler/checker {
-  CheckedExpressionStructureObservation,
   CheckedProgram,
   CheckedTypedOccurrenceExpressionPathObservation,
-  canonical_checked_expression_structure_snapshot,
   check_program_result,
   check_program_typed_occurrence_expression_path_observation,
+  checked_typed_occurrence_expression_path_observation_expression_path_at,
+  checked_typed_occurrence_expression_path_observation_row_count,
+  checked_typed_occurrence_expression_path_observation_statement_path_at
+}
+
+import @vibe/compiler/checker/artifacts {
+  CheckedExpressionStructureObservation,
+  canonical_checked_expression_structure_snapshot,
   checked_expression_structure_observation,
   checked_expression_structure_observation_expression_path_at,
   checked_expression_structure_observation_kind_at,
   checked_expression_structure_observation_row_count,
-  checked_expression_structure_observation_statement_path_at,
-  checked_typed_occurrence_expression_path_observation_expression_path_at,
-  checked_typed_occurrence_expression_path_observation_row_count,
-  checked_typed_occurrence_expression_path_observation_statement_path_at
+  checked_expression_structure_observation_statement_path_at
 }
 
 import @vibe/compiler/core {


### PR DESCRIPTION
## Summary

Continue #1440's one-family-at-a-time internal artifact package ratchet.

- move the complete checked expression-structure observation + strict v1 artifact codec into `@vibe/compiler/checker/artifacts`
- consume the retained expression walker through the parent checker contract
- remove only this family's API from the parent checker contract/facade
- cut over only the two focused tests

The implementation is byte-identical except for replacing sibling imports with legal package-boundary imports. No parent compatibility re-export is added, preserving the one-way dependency:

```text
checker/artifacts -> checker -> normalize/core
```

`checked_expression_structure_core.vibe` deliberately remains in the parent: checker capture and the remaining direct-return artifacts still use its bounded retained-coordinate walker. This PR does not move those families, split model from engine, or create a stable checker ABI.

## Baseline evidence

Fresh matching-stage2 report:

| case | modules | source bytes | raw Wasm | codegen modules |
|---|---:|---:|---:|---:|
| parser-only | 16 | 374,155 | 234,390 | 0 |
| current checker | 109 | 2,125,536 | 1,078,370 | 0 |
| full compiler | 272 | 5,296,642 | 2,163,593 | 97 |

The historical current-checker closure drops 111 → 109 modules because it does not import the child artifact package. Remaining parent-owned counts are 7 artifact and 6 observation modules. Engine-only/plus-artifacts roots remain deferred until those families have been extracted honestly.

## Validation

- source parity except required import rewrites
- focused structure observation tests: pass
- focused strict structure artifact/decoder tests: pass
- package boundary / no reverse edge checks: pass
- Vibe formatter checks: pass
- generated-artifact freshness: pass
- fresh stage2 == stage3
- `pkf run release-check`: pass
- independent hard review: no P0/P1/P2
- fresh deterministic baseline collection
- `git diff --check`

No generated artifact is tracked or manually edited.

Progresses #1440.
