### PR TITLE
refactor(checker): isolate statement root artifacts

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_statement_root_type_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_statement_root_type_artifact.vibe
@@ -9,12 +9,8 @@ import @vibe/core {
   array_empty
 }
 
-import ./canonical_checked_type_state.vibe {
-  canonical_checked_occurrence_type_fields
-}
-
-import ./checker_stmt.vibe {
-  CheckedStatementRootTypeObservation
+import @vibe/compiler/checker {
+  CheckedStatementRootTypeObservation, canonical_checked_occurrence_type_fields
 }
 
 /// Opaque capture-order rows of `(statement_path, kind, canonical_type_text)`.

--- a/lib/@vibe/compiler/checker/artifacts/checked_statement_root_type_observation.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_statement_root_type_observation.vibe
@@ -8,12 +8,8 @@ import @vibe/core {
   array_empty
 }
 
-import ./canonical_checked_type_state.vibe {
-  canonical_checked_occurrence_type_fields
-}
-
-import ./checker_stmt.vibe {
-  CheckedStatementRootTypeObservation
+import @vibe/compiler/checker {
+  CheckedStatementRootTypeObservation, canonical_checked_occurrence_type_fields
 }
 
 fn statement_root_snapshot_push_int(out: StringBuilder, value: Int) -> Unit {

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -71,3 +71,27 @@ fn checked_expression_structure_artifact_row_count(artifact: CheckedExpressionSt
 fn checked_expression_structure_artifact_statement_path_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[Array[Int]]
 fn checked_expression_structure_artifact_expression_path_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[Array[Int]]
 fn checked_expression_structure_artifact_kind_at(artifact: CheckedExpressionStructureArtifact, row_index: Int) -> Option[String]
+
+// --- checked_statement_root_type_observation.vibe
+// Successful direct checker-returned roots only. The opaque observation and
+// producer APIs remain owned by @vibe/compiler/checker; this package owns only
+// deterministic presentation of that parent-owned observation.
+fn canonical_checked_statement_root_type_snapshot(observation: CheckedStatementRootTypeObservation) -> String
+fn checked_statement_root_type_observation_row_count(observation: CheckedStatementRootTypeObservation) -> Int
+fn checked_statement_root_type_observation_statement_path_at(observation: CheckedStatementRootTypeObservation, row_index: Int) -> Option[Array[Int]]
+fn checked_statement_root_type_observation_kind_at(observation: CheckedStatementRootTypeObservation, row_index: Int) -> Option[String]
+fn checked_statement_root_type_observation_type_at(observation: CheckedStatementRootTypeObservation, row_index: Int) -> Option[String]
+
+// --- checked_statement_root_type_artifact.vibe
+// Strict opaque v1 transport of statement paths, closed root kinds, and
+// final-substitution canonical type text. It is not typed IR, checker
+// attestation, cache/reuse, an interface, trace, or import contract.
+opaque type CheckedStatementRootTypeArtifact
+fn checked_statement_root_type_artifact_from_observation(observation: CheckedStatementRootTypeObservation) -> Option[CheckedStatementRootTypeArtifact]
+fn encode_checked_statement_root_type_artifact_v1(artifact: CheckedStatementRootTypeArtifact) -> String
+fn decode_checked_statement_root_type_artifact_v1(text: String) -> Option[CheckedStatementRootTypeArtifact]
+fn canonical_checked_statement_root_type_artifact_snapshot(artifact: CheckedStatementRootTypeArtifact) -> String
+fn checked_statement_root_type_artifact_row_count(artifact: CheckedStatementRootTypeArtifact) -> Int
+fn checked_statement_root_type_artifact_statement_path_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[Array[Int]]
+fn checked_statement_root_type_artifact_kind_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[String]
+fn checked_statement_root_type_artifact_type_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[String]

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -53,26 +53,6 @@ export ./checked_typed_occurrence_statement_observation.vibe {
   canonical_checked_typed_occurrence_statement_snapshot
 }
 
-export ./checked_statement_root_type_observation.vibe {
-  canonical_checked_statement_root_type_snapshot,
-  checked_statement_root_type_observation_kind_at,
-  checked_statement_root_type_observation_row_count,
-  checked_statement_root_type_observation_statement_path_at,
-  checked_statement_root_type_observation_type_at
-}
-
-export ./checked_statement_root_type_artifact.vibe {
-  CheckedStatementRootTypeArtifact,
-  canonical_checked_statement_root_type_artifact_snapshot,
-  checked_statement_root_type_artifact_from_observation,
-  checked_statement_root_type_artifact_kind_at,
-  checked_statement_root_type_artifact_row_count,
-  checked_statement_root_type_artifact_statement_path_at,
-  checked_statement_root_type_artifact_type_at,
-  decode_checked_statement_root_type_artifact_v1,
-  encode_checked_statement_root_type_artifact_v1
-}
-
 export ./checked_typed_occurrence_role_lane_observation.vibe {
   canonical_checked_typed_occurrence_role_lane_snapshot
 }

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -247,27 +247,9 @@ fn checked_typed_occurrence_statement_observation_capture_ordinal_at(observation
 
 // --- checked_statement_root_type_observation.vibe
 // Successful direct checker-returned roots only. No typed IR, cache/reuse,
-// import contract, or persistent codec surface is exposed.
+// import contract, or persistent codec surface is exposed. Presentation and
+// artifact APIs are owned by @vibe/compiler/checker/artifacts.
 opaque type CheckedStatementRootTypeObservation
-fn canonical_checked_statement_root_type_snapshot(observation: CheckedStatementRootTypeObservation) -> String
-fn checked_statement_root_type_observation_row_count(observation: CheckedStatementRootTypeObservation) -> Int
-fn checked_statement_root_type_observation_statement_path_at(observation: CheckedStatementRootTypeObservation, row_index: Int) -> Option[Array[Int]]
-fn checked_statement_root_type_observation_kind_at(observation: CheckedStatementRootTypeObservation, row_index: Int) -> Option[String]
-fn checked_statement_root_type_observation_type_at(observation: CheckedStatementRootTypeObservation, row_index: Int) -> Option[String]
-
-// --- checked_statement_root_type_artifact.vibe
-// Strict opaque v1 transport of statement paths, closed root kinds, and
-// final-substitution canonical type text. It is not typed IR, checker
-// attestation, cache/reuse, an interface, trace, or import contract.
-opaque type CheckedStatementRootTypeArtifact
-fn checked_statement_root_type_artifact_from_observation(observation: CheckedStatementRootTypeObservation) -> Option[CheckedStatementRootTypeArtifact]
-fn encode_checked_statement_root_type_artifact_v1(artifact: CheckedStatementRootTypeArtifact) -> String
-fn decode_checked_statement_root_type_artifact_v1(text: String) -> Option[CheckedStatementRootTypeArtifact]
-fn canonical_checked_statement_root_type_artifact_snapshot(artifact: CheckedStatementRootTypeArtifact) -> String
-fn checked_statement_root_type_artifact_row_count(artifact: CheckedStatementRootTypeArtifact) -> Int
-fn checked_statement_root_type_artifact_statement_path_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[Array[Int]]
-fn checked_statement_root_type_artifact_kind_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[String]
-fn checked_statement_root_type_artifact_type_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[String]
 
 // --- checked_typed_occurrence_role_lane_observation.vibe
 // Successful append-aligned role/lane tags only. No offsets, types, paths, or

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -72,8 +72,6 @@ checker	checker/checked_expression_kind_direct_return_artifact.vibe
 checker	checker/checked_expression_leaf_payload_direct_return_artifact.vibe
 checker	checker/checked_typed_occurrence_expression_path_artifact.vibe
 checker	checker/checked_typed_occurrence_statement_observation.vibe
-checker	checker/checked_statement_root_type_observation.vibe
-checker	checker/checked_statement_root_type_artifact.vibe
 checker	checker/checked_typed_occurrence_role_lane_observation.vibe
 checker	checker/checked_typed_occurrence_expression_path_observation.vibe
 checker	checker/index.vpkg
@@ -85,6 +83,8 @@ checker	checker/artifacts/checked_effective_effect_row_observation.vibe
 checker	checker/artifacts/checked_effective_effect_row_artifact.vibe
 checker	checker/artifacts/checked_expression_structure_observation.vibe
 checker	checker/artifacts/checked_expression_structure_artifact.vibe
+checker	checker/artifacts/checked_statement_root_type_observation.vibe
+checker	checker/artifacts/checked_statement_root_type_artifact.vibe
 codegen	codegen/wasm_emit/index.vpkg
 codegen	codegen/wasm_emit/wasm_emit.vibe
 codegen	codegen/wasm_emit/sections.vibe

--- a/lib/@vibe/compiler/tests/checked_statement_root_type_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_statement_root_type_artifact_test.vibe
@@ -1,9 +1,12 @@
 //# Strict checked statement-root-type artifact v1
 
 import @vibe/compiler/checker {
+  check_program_statement_root_type_observation
+}
+
+import @vibe/compiler/checker/artifacts {
   canonical_checked_statement_root_type_artifact_snapshot,
   canonical_checked_statement_root_type_snapshot,
-  check_program_statement_root_type_observation,
   checked_statement_root_type_artifact_from_observation,
   checked_statement_root_type_artifact_kind_at,
   checked_statement_root_type_artifact_row_count,

--- a/lib/@vibe/compiler/tests/checked_statement_root_type_observation_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_statement_root_type_observation_test.vibe
@@ -5,10 +5,11 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/checker {
-  CheckedStatementRootTypeObservation,
+  CheckedStatementRootTypeObservation, check_program_statement_root_type_observation, check_program_with_env_statement_root_type_observation
+}
+
+import @vibe/compiler/checker/artifacts {
   canonical_checked_statement_root_type_snapshot,
-  check_program_statement_root_type_observation,
-  check_program_with_env_statement_root_type_observation,
   checked_statement_root_type_observation_kind_at,
   checked_statement_root_type_observation_row_count,
   checked_statement_root_type_observation_statement_path_at,


### PR DESCRIPTION
## Summary

Continue #1440's artifact-package ratchet with statement-root type presentation/transport.

- move statement-root observation presentation and strict v1 artifact codec into `@vibe/compiler/checker/artifacts`
- retain `CheckedStatementRootTypeObservation` and both checker producer APIs in the parent engine package
- consume the capture type and shared canonical type helper through the parent checker contract
- cut over only the two focused tests

This preserves the intended temporary boundary:

```text
artifacts presentation/codec -> checker capture/producer -> model/core
```

The moved implementations are byte-identical except for replacing sibling imports with legal parent-package imports. No parent compatibility re-export or reverse package edge is added.

`CheckedStatementRootTypeObservation` deliberately remains parent-owned because checker execution constructs it. This PR moves only optional presentation/transport, not checker-time capture allocation or semantics.

## Baseline evidence

Fresh matching-stage2 report:

| case | modules | source bytes | raw Wasm | codegen modules |
|---|---:|---:|---:|---:|
| parser-only | 16 | 374,155 | 234,390 | 0 |
| current checker | 105 | 2,082,769 | 1,054,582 | 0 |
| full compiler | 268 | 5,253,875 | 2,139,799 | 97 |

Current-checker closure drops 107 → 105 modules. Remaining parent-owned baseline categories are 5 artifact and 4 observation modules.

## Validation

- source parity except required package imports
- focused statement-root observation/artifact tests: pass
- corrected manifest old/new path ownership, then regenerated normally
- package direction / no reverse edge: pass
- formatter and generated freshness: pass
- fresh final stage2 == stage3
- final `pkf run release-check`: pass
- independent hard review after manifest correction: no P0/P1/P2
- deterministic matching-stage2 baseline
- `git diff --check`

No generated artifact is tracked or manually edited.

Progresses #1440.


## Incremental build maturity after this ratchet

Current approximate completion as of #1466:

| Area | Completion | Status |
|---|---:|---|
| KPI / trace / Lean oracle | 90–95% | schema-v6 strict validation and compiler conformance |
| ingestion fast path | 70–80% | persistent stamp implemented, still opt-in |
| persistent `TypeEnv` transport | 95% | strict v3 / cache v16 / TDRE3 |
| interface identity | 70–80% | `vibe-module-interface:v2`, observation-only |
| checked semantic artifact | 60–70% | multiple families extracted; not yet lossless |
| module-level typing reuse | 40–50% | private dependency body reuse demonstrated, default-off |
| production default-on semantic reuse | 20–30% | not connected to cache-key/reuse policy |
| declaration SCC / generic typed IR | 5–10% | future work |
| user-visible edit-cycle acceleration | 15–25% | still limited under normal defaults |
| overall roadmap | about 55–60% | correctness and observation infrastructure lead deployment |

The important distinction is that correctness infrastructure is close to production quality, while semantic reuse remains experimental. The remaining production path is to complete a sufficiently lossless checked artifact, promote semantic interface identity into a versioned production key, and enable fail-closed downstream typing/codegen reuse by default. Declaration-SCC and generic typed-IR reuse remain later phases.

#1466 itself improves ownership and checker closure rather than directly changing production cache decisions: current-checker closure is now 105 modules / 1,054,582 raw Wasm with zero codegen modules.
