### PR TITLE
refactor(checker): isolate type definition artifact

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe
@@ -6,16 +6,16 @@
 // CheckedProgram, TypeEnv, typed IR, cache artifact, trace schema, interface,
 // import contract, or production reuse input.
 
+import @vibe/compiler/checker {
+  CheckedProgram, CheckedProgramTypeDefsObservation, canonical_checked_type_defs_snapshot
+}
+
 import @vibe/compiler/core {
   Subst, Type, TypeDef, TypeEnv
 }
 
 import @vibe/core {
   array_empty
-}
-
-import ./canonical_checked_type_state.vibe {
-  canonical_checked_type_defs_snapshot
 }
 
 /// Narrow checked semantic fragment. Binder rows align positionally with

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -11,9 +11,18 @@ deps = {
 generated_hash =
 
 // @vibe/compiler/checker/artifacts — narrow checked-program artifact APIs.
-// This nested compiler-internal boundary owns checked effect-set declarations,
-// effective-effect-row, and checked expression-structure observation/artifact
-// transport.
+// This nested compiler-internal boundary owns narrow retained-type-definition,
+// checked effect-set declaration, effective-effect-row, and checked
+// expression-structure observation/artifact transport.
+
+// --- checked_type_defs_artifact.vibe
+// Narrow retained-TypeDef semantic fragment only. It deliberately excludes
+// TypeEnv/full CheckedProgram transport, cache/reuse, trace, and interfaces.
+opaque type CheckedTypeDefsArtifact
+fn checked_type_defs_artifact_from_observation(observation: CheckedProgramTypeDefsObservation) -> Option[CheckedTypeDefsArtifact]
+fn encode_checked_type_defs_artifact_v1(artifact: CheckedTypeDefsArtifact) -> Option[String]
+fn decode_checked_type_defs_artifact_v1(text: String) -> Option[CheckedTypeDefsArtifact]
+fn canonical_checked_type_defs_artifact_snapshot(artifact: CheckedTypeDefsArtifact) -> Option[String]
 
 opaque type CheckedEffectSetDeclarationsObservation
 opaque type CheckedEffectSetDeclarationsArtifact

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -21,14 +21,6 @@ export ./checker_resolve.vibe {
   resolve_type_expr
 }
 
-export ./checked_type_defs_artifact.vibe {
-  CheckedTypeDefsArtifact,
-  canonical_checked_type_defs_artifact_snapshot,
-  checked_type_defs_artifact_from_observation,
-  decode_checked_type_defs_artifact_v1,
-  encode_checked_type_defs_artifact_v1
-}
-
 export ./checked_direct_expression_return_observation.vibe {
   canonical_checked_direct_expression_return_snapshot,
   checked_direct_expression_return_observation_expression_path_at,

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -159,15 +159,6 @@ fn resolve_type_expr(te: TypeExpr, defs: Array[TypeDef]) -> Type
 fn check_spawnable_captures(env: TypeEnv, s: Subst, defs: Array[TypeDef], f_expr: Expr, r_here: Type) -> Array[String]
 fn check_spawnable_mut_captures_stmts(stmts: Array[Stmt]) -> Array[String]
 
-// --- checked_type_defs_artifact.vibe
-// Narrow retained-TypeDef semantic fragment only. It deliberately excludes
-// TypeEnv/full CheckedProgram transport, cache/reuse, trace, and interfaces.
-opaque type CheckedTypeDefsArtifact
-fn checked_type_defs_artifact_from_observation(observation: CheckedProgramTypeDefsObservation) -> Option[CheckedTypeDefsArtifact]
-fn encode_checked_type_defs_artifact_v1(artifact: CheckedTypeDefsArtifact) -> Option[String]
-fn decode_checked_type_defs_artifact_v1(text: String) -> Option[CheckedTypeDefsArtifact]
-fn canonical_checked_type_defs_artifact_snapshot(artifact: CheckedTypeDefsArtifact) -> Option[String]
-
 // --- checked_expression_structure_core.vibe
 // Internal bounded retained-coordinate walker shared by observations.
 fn checked_expression_structure_max_rows() -> Int

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -66,7 +66,6 @@ checker	checker/checker.vibe
 checker	checker/checked_expression_structure_core.vibe
 checker	checker/checker_stmt.vibe
 checker	checker/canonical_checked_type_state.vibe
-checker	checker/checked_type_defs_artifact.vibe
 checker	checker/checked_direct_expression_return_observation.vibe
 checker	checker/checked_direct_expression_return_artifact.vibe
 checker	checker/checked_expression_kind_direct_return_artifact.vibe
@@ -78,6 +77,7 @@ checker	checker/checked_typed_occurrence_expression_path_observation.vibe
 checker	checker/index.vpkg
 checker	checker/checker_facade.vibe
 checker	checker/artifacts/index.vpkg
+checker	checker/artifacts/checked_type_defs_artifact.vibe
 checker	checker/artifacts/checked_effect_set_observation.vibe
 checker	checker/artifacts/checked_effect_set_artifact.vibe
 checker	checker/artifacts/checked_effective_effect_row_observation.vibe

--- a/lib/@vibe/compiler/tests/checked_type_defs_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_type_defs_artifact_test.vibe
@@ -1,11 +1,11 @@
 //# #1379 narrow checked TypeDef artifact v1 codec tests.
 
 import @vibe/compiler/checker {
-  CheckedProgram,
-  CheckedProgramTypeDefsObservation,
+  CheckedProgram, CheckedProgramTypeDefsObservation, canonical_checked_type_defs_snapshot, check_program_type_defs_observation
+}
+
+import @vibe/compiler/checker/artifacts {
   canonical_checked_type_defs_artifact_snapshot,
-  canonical_checked_type_defs_snapshot,
-  check_program_type_defs_observation,
   checked_type_defs_artifact_from_observation,
   decode_checked_type_defs_artifact_v1,
   encode_checked_type_defs_artifact_v1


### PR DESCRIPTION
## Summary

Continue #1440's one-family checker artifact ratchet.

- move `checked_type_defs_artifact.vibe` into `@vibe/compiler/checker/artifacts`
- retain `CheckedProgram`, `CheckedProgramTypeDefsObservation`, its producer, and canonical checked typedef snapshot in the parent checker engine
- move only the opaque artifact and strict codec/presentation APIs into the child contract
- remove the parent compatibility export to preserve `artifacts -> checker`
- cut over the focused typedef artifact test and manifest path

Implementation bytes are unchanged except for legal package imports. Production cache/reuse, codec bytes, artifact semantics, schema, and capture allocation are unchanged.

## Validation

- exact implementation parity except imports
- focused 6-test suite: pass
- package/API/import ownership checks: pass
- formatter and generated freshness: pass
- fresh stage2 == stage3: pass
- `pkf run release-check`: pass
- independent review: no P0/P1/P2
- generated artifacts absent from diff

This is the first of three independent worktree implementations. Merge this PR first; the other overlapping manifest/contract ratchets will be rebased afterward.

Progresses #1440.
