### PR TITLE
refactor(checker): isolate direct return presentation

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_direct_expression_return_observation.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_direct_expression_return_observation.vibe
@@ -8,12 +8,8 @@ import @vibe/core {
   array_empty
 }
 
-import ./canonical_checked_type_state.vibe {
-  canonical_checked_occurrence_type_fields
-}
-
-import ./checker_stmt.vibe {
-  CheckedDirectExpressionReturnObservation
+import @vibe/compiler/checker {
+  CheckedDirectExpressionReturnObservation, canonical_checked_occurrence_type_fields
 }
 
 fn checked_direct_return_push_int(out: StringBuilder, value: Int) -> Unit {

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -104,3 +104,13 @@ fn checked_statement_root_type_artifact_row_count(artifact: CheckedStatementRoot
 fn checked_statement_root_type_artifact_statement_path_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[Array[Int]]
 fn checked_statement_root_type_artifact_kind_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[String]
 fn checked_statement_root_type_artifact_type_at(artifact: CheckedStatementRootTypeArtifact, row_index: Int) -> Option[String]
+
+// --- checked_direct_expression_return_observation.vibe
+// Complete-or-none direct primary checker-return observation. The opaque
+// observation, capture machinery, and producer APIs remain owned by
+// @vibe/compiler/checker; this package owns only deterministic presentation.
+fn canonical_checked_direct_expression_return_snapshot(observation: CheckedDirectExpressionReturnObservation) -> String
+fn checked_direct_expression_return_observation_row_count(observation: CheckedDirectExpressionReturnObservation) -> Int
+fn checked_direct_expression_return_observation_statement_path_at(observation: CheckedDirectExpressionReturnObservation, row_index: Int) -> Option[Array[Int]]
+fn checked_direct_expression_return_observation_expression_path_at(observation: CheckedDirectExpressionReturnObservation, row_index: Int) -> Option[Array[Int]]
+fn checked_direct_expression_return_observation_type_at(observation: CheckedDirectExpressionReturnObservation, row_index: Int) -> Option[String]

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -21,14 +21,6 @@ export ./checker_resolve.vibe {
   resolve_type_expr
 }
 
-export ./checked_direct_expression_return_observation.vibe {
-  canonical_checked_direct_expression_return_snapshot,
-  checked_direct_expression_return_observation_expression_path_at,
-  checked_direct_expression_return_observation_row_count,
-  checked_direct_expression_return_observation_statement_path_at,
-  checked_direct_expression_return_observation_type_at
-}
-
 export ./checked_direct_expression_return_artifact.vibe {
   CheckedDirectExpressionReturnArtifact,
   canonical_checked_direct_expression_return_artifact_snapshot,

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -173,12 +173,8 @@ fn checked_expression_structure_rows(stmts: Array[Stmt]) -> Option[Array[(Array[
 // --- checked_direct_expression_return_observation.vibe
 // Complete-or-none direct primary checker-return observation. It is neither
 // typed IR nor a codec/artifact/cache/reuse/import/interface/trace surface.
+// Presentation APIs are owned by @vibe/compiler/checker/artifacts.
 opaque type CheckedDirectExpressionReturnObservation
-fn canonical_checked_direct_expression_return_snapshot(observation: CheckedDirectExpressionReturnObservation) -> String
-fn checked_direct_expression_return_observation_row_count(observation: CheckedDirectExpressionReturnObservation) -> Int
-fn checked_direct_expression_return_observation_statement_path_at(observation: CheckedDirectExpressionReturnObservation, row_index: Int) -> Option[Array[Int]]
-fn checked_direct_expression_return_observation_expression_path_at(observation: CheckedDirectExpressionReturnObservation, row_index: Int) -> Option[Array[Int]]
-fn checked_direct_expression_return_observation_type_at(observation: CheckedDirectExpressionReturnObservation, row_index: Int) -> Option[String]
 
 // --- checked_direct_expression_return_artifact.vibe
 // Strict opaque v1 transport of retained direct-return preorder coordinates

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -66,7 +66,6 @@ checker	checker/checker.vibe
 checker	checker/checked_expression_structure_core.vibe
 checker	checker/checker_stmt.vibe
 checker	checker/canonical_checked_type_state.vibe
-checker	checker/checked_direct_expression_return_observation.vibe
 checker	checker/checked_direct_expression_return_artifact.vibe
 checker	checker/checked_expression_kind_direct_return_artifact.vibe
 checker	checker/checked_expression_leaf_payload_direct_return_artifact.vibe
@@ -78,6 +77,7 @@ checker	checker/index.vpkg
 checker	checker/checker_facade.vibe
 checker	checker/artifacts/index.vpkg
 checker	checker/artifacts/checked_type_defs_artifact.vibe
+checker	checker/artifacts/checked_direct_expression_return_observation.vibe
 checker	checker/artifacts/checked_effect_set_observation.vibe
 checker	checker/artifacts/checked_effect_set_artifact.vibe
 checker	checker/artifacts/checked_effective_effect_row_observation.vibe

--- a/lib/@vibe/compiler/tests/checked_direct_expression_return_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_direct_expression_return_artifact_test.vibe
@@ -3,7 +3,6 @@
 import @vibe/compiler/checker {
   CheckedDirectExpressionReturnObservation,
   canonical_checked_direct_expression_return_artifact_snapshot,
-  canonical_checked_direct_expression_return_snapshot,
   check_program_direct_expression_return_observation,
   check_program_with_env_direct_expression_return_observation,
   checked_direct_expression_return_artifact_expression_path_at,
@@ -13,6 +12,10 @@ import @vibe/compiler/checker {
   checked_direct_expression_return_artifact_type_at,
   decode_checked_direct_expression_return_artifact_v1,
   encode_checked_direct_expression_return_artifact_v1
+}
+
+import @vibe/compiler/checker/artifacts {
+  canonical_checked_direct_expression_return_snapshot
 }
 
 import @vibe/compiler/core {

--- a/lib/@vibe/compiler/tests/checked_direct_expression_return_observation_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_direct_expression_return_observation_test.vibe
@@ -6,9 +6,12 @@ import @vibe/compiler/core {
 
 import @vibe/compiler/checker {
   CheckedDirectExpressionReturnObservation,
-  canonical_checked_direct_expression_return_snapshot,
   check_program_direct_expression_return_observation,
-  check_program_with_env_direct_expression_return_observation,
+  check_program_with_env_direct_expression_return_observation
+}
+
+import @vibe/compiler/checker/artifacts {
+  canonical_checked_direct_expression_return_snapshot,
   checked_direct_expression_return_observation_expression_path_at,
   checked_direct_expression_return_observation_row_count,
   checked_direct_expression_return_observation_statement_path_at,


### PR DESCRIPTION
## Summary

Move only direct-expression-return observation presentation into `@vibe/compiler/checker/artifacts`.

Parent checker retains the opaque `CheckedDirectExpressionReturnObservation`, capture/reconciliation machinery, structural core, and ordinary/with-env producers. The three direct-return artifact codecs deliberately remain parent-owned in this bounded step. Child owns only the five deterministic snapshot/accessor APIs.

Implementation bytes are unchanged except for legal parent-package imports. No reverse edge, codec/schema/cache change, or generated artifact is introduced.

## Validation

- source parity except imports
- focused tests: 14 pass
- formatter, manifest generation, and generated freshness: pass
- fresh stage2 == stage3: pass
- worker `release-check`: pass
- independent review: no P0/P1/P2
- unrelated pre-existing `test-local` heap assertion was observed; affected suites pass

Implemented independently in a worktree from #1466's merge base. This PR overlaps the child contract/manifest with the typedef ratchet and should be rebased after that PR merges.

Progresses #1440.
