### PR TITLE
refactor(checker): isolate direct return artifact

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_direct_expression_return_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_direct_expression_return_artifact.vibe
@@ -9,16 +9,8 @@ import @vibe/core {
   array_empty
 }
 
-import ./canonical_checked_type_state.vibe {
-  canonical_checked_occurrence_type_fields
-}
-
-import ./checked_expression_structure_core.vibe {
-  checked_expression_structure_rows
-}
-
-import ./checker_stmt.vibe {
-  CheckedDirectExpressionReturnObservation
+import @vibe/compiler/checker {
+  CheckedDirectExpressionReturnObservation, canonical_checked_occurrence_type_fields, checked_expression_structure_rows
 }
 
 /// Opaque preorder transport of `(statement_path, expression_path, ty)`.

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -115,6 +115,20 @@ fn checked_direct_expression_return_observation_statement_path_at(observation: C
 fn checked_direct_expression_return_observation_expression_path_at(observation: CheckedDirectExpressionReturnObservation, row_index: Int) -> Option[Array[Int]]
 fn checked_direct_expression_return_observation_type_at(observation: CheckedDirectExpressionReturnObservation, row_index: Int) -> Option[String]
 
+// --- checked_direct_expression_return_artifact.vibe
+// Strict opaque v1 transport of retained direct-return preorder coordinates
+// and canonical type text. Decoded bytes attest no checker, canonical-type,
+// or full typed-IR semantics; cache/reuse/import/interface/trace are absent.
+opaque type CheckedDirectExpressionReturnArtifact
+fn checked_direct_expression_return_artifact_from_observation(observation: CheckedDirectExpressionReturnObservation) -> Option[CheckedDirectExpressionReturnArtifact]
+fn encode_checked_direct_expression_return_artifact_v1(artifact: CheckedDirectExpressionReturnArtifact) -> String
+fn decode_checked_direct_expression_return_artifact_v1(text: String) -> Option[CheckedDirectExpressionReturnArtifact]
+fn canonical_checked_direct_expression_return_artifact_snapshot(artifact: CheckedDirectExpressionReturnArtifact) -> String
+fn checked_direct_expression_return_artifact_row_count(artifact: CheckedDirectExpressionReturnArtifact) -> Int
+fn checked_direct_expression_return_artifact_statement_path_at(artifact: CheckedDirectExpressionReturnArtifact, row_index: Int) -> Option[Array[Int]]
+fn checked_direct_expression_return_artifact_expression_path_at(artifact: CheckedDirectExpressionReturnArtifact, row_index: Int) -> Option[Array[Int]]
+fn checked_direct_expression_return_artifact_type_at(artifact: CheckedDirectExpressionReturnArtifact, row_index: Int) -> Option[String]
+
 // --- checked_typed_occurrence_statement_observation.vibe
 // Checker-time statement-owner association for legacy typed-occurrence rows.
 // The opaque observation and producer APIs remain owned by

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -21,18 +21,6 @@ export ./checker_resolve.vibe {
   resolve_type_expr
 }
 
-export ./checked_direct_expression_return_artifact.vibe {
-  CheckedDirectExpressionReturnArtifact,
-  canonical_checked_direct_expression_return_artifact_snapshot,
-  checked_direct_expression_return_artifact_expression_path_at,
-  checked_direct_expression_return_artifact_from_observation,
-  checked_direct_expression_return_artifact_row_count,
-  checked_direct_expression_return_artifact_statement_path_at,
-  checked_direct_expression_return_artifact_type_at,
-  decode_checked_direct_expression_return_artifact_v1,
-  encode_checked_direct_expression_return_artifact_v1
-}
-
 export ./canonical_checked_type_state.vibe {
   canonical_checked_effect_row_snapshot,
   canonical_checked_type_defs_snapshot,

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -176,20 +176,6 @@ fn checked_expression_structure_rows(stmts: Array[Stmt]) -> Option[Array[(Array[
 // Presentation APIs are owned by @vibe/compiler/checker/artifacts.
 opaque type CheckedDirectExpressionReturnObservation
 
-// --- checked_direct_expression_return_artifact.vibe
-// Strict opaque v1 transport of retained direct-return preorder coordinates
-// and canonical type text. Decoded bytes attest no checker, canonical-type,
-// or full typed-IR semantics; cache/reuse/import/interface/trace are absent.
-opaque type CheckedDirectExpressionReturnArtifact
-fn checked_direct_expression_return_artifact_from_observation(observation: CheckedDirectExpressionReturnObservation) -> Option[CheckedDirectExpressionReturnArtifact]
-fn encode_checked_direct_expression_return_artifact_v1(artifact: CheckedDirectExpressionReturnArtifact) -> String
-fn decode_checked_direct_expression_return_artifact_v1(text: String) -> Option[CheckedDirectExpressionReturnArtifact]
-fn canonical_checked_direct_expression_return_artifact_snapshot(artifact: CheckedDirectExpressionReturnArtifact) -> String
-fn checked_direct_expression_return_artifact_row_count(artifact: CheckedDirectExpressionReturnArtifact) -> Int
-fn checked_direct_expression_return_artifact_statement_path_at(artifact: CheckedDirectExpressionReturnArtifact, row_index: Int) -> Option[Array[Int]]
-fn checked_direct_expression_return_artifact_expression_path_at(artifact: CheckedDirectExpressionReturnArtifact, row_index: Int) -> Option[Array[Int]]
-fn checked_direct_expression_return_artifact_type_at(artifact: CheckedDirectExpressionReturnArtifact, row_index: Int) -> Option[String]
-
 // --- checked_expression_kind_direct_return_artifact.vibe
 // Strict opaque v1 join of retained closed constructor kind and authoritative
 // direct checker-return type text. Decoded bytes prove neither checker success

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -66,12 +66,12 @@ checker	checker/checker.vibe
 checker	checker/checked_expression_structure_core.vibe
 checker	checker/checker_stmt.vibe
 checker	checker/canonical_checked_type_state.vibe
-checker	checker/checked_direct_expression_return_artifact.vibe
 checker	checker/checked_expression_kind_direct_return_artifact.vibe
 checker	checker/checked_expression_leaf_payload_direct_return_artifact.vibe
 checker	checker/index.vpkg
 checker	checker/checker_facade.vibe
 checker	checker/artifacts/index.vpkg
+checker	checker/artifacts/checked_direct_expression_return_artifact.vibe
 checker	checker/artifacts/checked_type_defs_artifact.vibe
 checker	checker/artifacts/checked_direct_expression_return_observation.vibe
 checker	checker/artifacts/checked_typed_occurrence_expression_path_artifact.vibe

--- a/lib/@vibe/compiler/tests/checked_direct_expression_return_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_direct_expression_return_artifact_test.vibe
@@ -1,10 +1,12 @@
 //# Strict checked direct-expression-return artifact v1
 
 import @vibe/compiler/checker {
-  CheckedDirectExpressionReturnObservation,
+  check_program_direct_expression_return_observation, check_program_with_env_direct_expression_return_observation
+}
+
+import @vibe/compiler/checker/artifacts {
   canonical_checked_direct_expression_return_artifact_snapshot,
-  check_program_direct_expression_return_observation,
-  check_program_with_env_direct_expression_return_observation,
+  canonical_checked_direct_expression_return_snapshot,
   checked_direct_expression_return_artifact_expression_path_at,
   checked_direct_expression_return_artifact_from_observation,
   checked_direct_expression_return_artifact_row_count,
@@ -12,10 +14,6 @@ import @vibe/compiler/checker {
   checked_direct_expression_return_artifact_type_at,
   decode_checked_direct_expression_return_artifact_v1,
   encode_checked_direct_expression_return_artifact_v1
-}
-
-import @vibe/compiler/checker/artifacts {
-  canonical_checked_direct_expression_return_snapshot
 }
 
 import @vibe/compiler/core {


### PR DESCRIPTION
## Summary

Continue #1440's one-family ratchet by moving only the base direct-expression-return strict artifact into `@vibe/compiler/checker/artifacts`.

- parent retains the opaque observation, checker capture/reconciliation, producers, canonical type support, and structural authority
- child owns the opaque base artifact, converter, strict v1 codec, snapshot, and accessors
- kind and leaf-payload direct-return artifacts remain parent-owned for later bounded ratchets
- no parent compatibility re-export or reverse dependency

Implementation bytes are unchanged except for legal imports through `@vibe/compiler/checker`. Codec bytes, validation, capture behavior, cache/reuse, and trace schemas are unchanged.

## Validation

- exact implementation parity except imports
- focused artifact tests: pass
- formatter and generated freshness: pass
- fresh stage2 == stage3: pass
- package direction and manifest ordering: pass
- independent review after rebasing onto #1469: no P0/P1/P2
- generated artifacts absent from diff

Progresses #1440.
