### PR TITLE
refactor(checker): isolate kind direct-return artifact

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_expression_kind_direct_return_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_expression_kind_direct_return_artifact.vibe
@@ -10,16 +10,11 @@ import @vibe/core {
   array_empty
 }
 
-import ./canonical_checked_type_state.vibe {
-  canonical_checked_occurrence_type_fields
-}
-
-import ./checked_expression_structure_core.vibe {
-  checked_expression_structure_kind_valid, checked_expression_structure_rows
-}
-
-import ./checker_stmt.vibe {
-  CheckedDirectExpressionReturnObservation
+import @vibe/compiler/checker {
+  CheckedDirectExpressionReturnObservation,
+  canonical_checked_occurrence_type_fields,
+  checked_expression_structure_kind_valid,
+  checked_expression_structure_rows
 }
 
 /// Opaque preorder transport of `(statement_path, expression_path, kind, ty)`.

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -129,6 +129,22 @@ fn checked_direct_expression_return_artifact_statement_path_at(artifact: Checked
 fn checked_direct_expression_return_artifact_expression_path_at(artifact: CheckedDirectExpressionReturnArtifact, row_index: Int) -> Option[Array[Int]]
 fn checked_direct_expression_return_artifact_type_at(artifact: CheckedDirectExpressionReturnArtifact, row_index: Int) -> Option[String]
 
+// --- checked_expression_kind_direct_return_artifact.vibe
+// Strict opaque v1 join of retained closed constructor kind and authoritative
+// direct checker-return type text. Decoded bytes prove neither checker success
+// nor canonical type semantics/full typed IR/provenance; no cache/reuse,
+// import/interface/trace, bindings/resolution, source identity, or diagnostics.
+opaque type CheckedExpressionKindDirectReturnArtifact
+fn checked_expression_kind_direct_return_artifact_from_observation(observation: CheckedDirectExpressionReturnObservation) -> Option[CheckedExpressionKindDirectReturnArtifact]
+fn encode_checked_expression_kind_direct_return_artifact_v1(artifact: CheckedExpressionKindDirectReturnArtifact) -> String
+fn decode_checked_expression_kind_direct_return_artifact_v1(text: String) -> Option[CheckedExpressionKindDirectReturnArtifact]
+fn canonical_checked_expression_kind_direct_return_artifact_snapshot(artifact: CheckedExpressionKindDirectReturnArtifact) -> String
+fn checked_expression_kind_direct_return_artifact_row_count(artifact: CheckedExpressionKindDirectReturnArtifact) -> Int
+fn checked_expression_kind_direct_return_artifact_statement_path_at(artifact: CheckedExpressionKindDirectReturnArtifact, row_index: Int) -> Option[Array[Int]]
+fn checked_expression_kind_direct_return_artifact_expression_path_at(artifact: CheckedExpressionKindDirectReturnArtifact, row_index: Int) -> Option[Array[Int]]
+fn checked_expression_kind_direct_return_artifact_kind_at(artifact: CheckedExpressionKindDirectReturnArtifact, row_index: Int) -> Option[String]
+fn checked_expression_kind_direct_return_artifact_type_at(artifact: CheckedExpressionKindDirectReturnArtifact, row_index: Int) -> Option[String]
+
 // --- checked_typed_occurrence_statement_observation.vibe
 // Checker-time statement-owner association for legacy typed-occurrence rows.
 // The opaque observation and producer APIs remain owned by

--- a/lib/@vibe/compiler/checker/checked_expression_kind_direct_return_artifact_internal_test.vibe
+++ b/lib/@vibe/compiler/checker/checked_expression_kind_direct_return_artifact_internal_test.vibe
@@ -8,7 +8,7 @@ import @vibe/core {
   array_empty
 }
 
-import ./checked_expression_kind_direct_return_artifact.vibe {
+import @vibe/compiler/checker/artifacts {
   checked_expression_kind_direct_return_artifact_from_observation
 }
 

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -176,22 +176,6 @@ fn checked_expression_structure_rows(stmts: Array[Stmt]) -> Option[Array[(Array[
 // Presentation APIs are owned by @vibe/compiler/checker/artifacts.
 opaque type CheckedDirectExpressionReturnObservation
 
-// --- checked_expression_kind_direct_return_artifact.vibe
-// Strict opaque v1 join of retained closed constructor kind and authoritative
-// direct checker-return type text. Decoded bytes prove neither checker success
-// nor canonical type semantics/full typed IR/provenance; no cache/reuse,
-// import/interface/trace, bindings/resolution, source identity, or diagnostics.
-opaque type CheckedExpressionKindDirectReturnArtifact
-fn checked_expression_kind_direct_return_artifact_from_observation(observation: CheckedDirectExpressionReturnObservation) -> Option[CheckedExpressionKindDirectReturnArtifact]
-fn encode_checked_expression_kind_direct_return_artifact_v1(artifact: CheckedExpressionKindDirectReturnArtifact) -> String
-fn decode_checked_expression_kind_direct_return_artifact_v1(text: String) -> Option[CheckedExpressionKindDirectReturnArtifact]
-fn canonical_checked_expression_kind_direct_return_artifact_snapshot(artifact: CheckedExpressionKindDirectReturnArtifact) -> String
-fn checked_expression_kind_direct_return_artifact_row_count(artifact: CheckedExpressionKindDirectReturnArtifact) -> Int
-fn checked_expression_kind_direct_return_artifact_statement_path_at(artifact: CheckedExpressionKindDirectReturnArtifact, row_index: Int) -> Option[Array[Int]]
-fn checked_expression_kind_direct_return_artifact_expression_path_at(artifact: CheckedExpressionKindDirectReturnArtifact, row_index: Int) -> Option[Array[Int]]
-fn checked_expression_kind_direct_return_artifact_kind_at(artifact: CheckedExpressionKindDirectReturnArtifact, row_index: Int) -> Option[String]
-fn checked_expression_kind_direct_return_artifact_type_at(artifact: CheckedExpressionKindDirectReturnArtifact, row_index: Int) -> Option[String]
-
 // --- checked_expression_leaf_payload_direct_return_artifact.vibe
 // Strict opaque v1 selected-leaf payload join. It exposes only five leaf tags,
 // exact retained payload text, and canonical direct-return type text; no raw

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -66,12 +66,12 @@ checker	checker/checker.vibe
 checker	checker/checked_expression_structure_core.vibe
 checker	checker/checker_stmt.vibe
 checker	checker/canonical_checked_type_state.vibe
-checker	checker/checked_expression_kind_direct_return_artifact.vibe
 checker	checker/checked_expression_leaf_payload_direct_return_artifact.vibe
 checker	checker/index.vpkg
 checker	checker/checker_facade.vibe
 checker	checker/artifacts/index.vpkg
 checker	checker/artifacts/checked_direct_expression_return_artifact.vibe
+checker	checker/artifacts/checked_expression_kind_direct_return_artifact.vibe
 checker	checker/artifacts/checked_type_defs_artifact.vibe
 checker	checker/artifacts/checked_direct_expression_return_observation.vibe
 checker	checker/artifacts/checked_typed_occurrence_expression_path_artifact.vibe

--- a/lib/@vibe/compiler/tests/checked_expression_kind_direct_return_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_expression_kind_direct_return_artifact_test.vibe
@@ -1,9 +1,11 @@
 //# Strict checked expression-kind direct-return artifact v1
 
 import @vibe/compiler/checker {
+  check_program_direct_expression_return_observation, check_program_with_env_direct_expression_return_observation
+}
+
+import @vibe/compiler/checker/artifacts {
   canonical_checked_expression_kind_direct_return_artifact_snapshot,
-  check_program_direct_expression_return_observation,
-  check_program_with_env_direct_expression_return_observation,
   checked_expression_kind_direct_return_artifact_expression_path_at,
   checked_expression_kind_direct_return_artifact_from_observation,
   checked_expression_kind_direct_return_artifact_kind_at,


### PR DESCRIPTION
## Summary

Move the kind+direct-return strict artifact into `@vibe/compiler/checker/artifacts`.

The parent retains the opaque observation, capture/producers, and structural authority. The leaf-payload sibling remains parent-owned in this bounded ratchet. Production implementation is byte-identical except for package imports.

The parent-local internal malformed-observation test remains in place and imports only the child converter. It continues to cover missing, extra, misaligned, and duplicate coordinate tables without exposing observation fields or widening the production ABI. There is no parent production reverse edge.

## Validation

- exact source parity except imports
- focused external/internal tests: pass
- affected suite: 222/222 pass
- formatter, generated freshness, fresh stage2 == stage3: pass
- package direction/manifest checks: pass
- independent review: no P0/P1/P2

Progresses #1440.
