### PR TITLE
checker: 宣言の重複を拒否する (#1464)

### DIFF
--- a/fixtures/typecheck/duplicate_discard_decl_ok.vibe
+++ b/fixtures/typecheck/duplicate_discard_decl_ok.vibe
@@ -1,0 +1,7 @@
+let _ = 1
+let _ = 2
+
+fn main {
+  let _ = 3
+  let _ = 4
+}

--- a/fixtures/typecheck/duplicate_fn_decl.vibe
+++ b/fixtures/typecheck/duplicate_fn_decl.vibe
@@ -1,0 +1,11 @@
+fn helper() -> Int {
+  1
+}
+
+fn helper() -> Int {
+  2
+}
+
+fn main {
+  let _ = helper()
+}

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -21,8 +21,10 @@
 # scripts/vibe_fmt_allowlist.txt uses. New fixtures must not be added as debt.
 #
 # name	status	needle
-duplicate_enum_ctor	debt-accepts	type: type definition: duplicate ctor: A
-duplicate_value_decl	debt-accepts	type: duplicate declaration: x
+duplicate_enum_ctor	reject	duplicate ctor: A
+duplicate_discard_decl_ok	ok	
+duplicate_fn_decl	reject	duplicate declaration: helper
+duplicate_value_decl	reject	duplicate declaration: x
 effect_explicit_scope_violation	reject	effect row mismatch for '_f': missing { B::OpB } (declared { A }, requires { A, B::OpB })
 effect_guard_missing_do_boundary_only	ok	
 effect_guard_missing_effect_and_do_boundary	reject	return type mismatch: expected (), got String
@@ -63,7 +65,7 @@ suberror_brace_ctor_arity_mismatch	reject	function arity mismatch for Io: expect
 suberror_brace_payload_type_mismatch	reject	argument type mismatch for Parse: expected Int, got String
 suberror_brace_raise_ok	ok	
 suberror_brace_zero_payload_raise_ok	ok	
-suberror_duplicate_ctor	reject	argument type mismatch for Io: expected Int, got String
+suberror_duplicate_ctor	reject	duplicate ctor: Io
 suberror_generic_error_bound_raise_ok	debt-rejects	no impl `Error` for `AppError`
 suberror_generic_try_catch_ok	ok	
 suberror_mixed_error_types_raise_ok	ok	

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -546,6 +546,43 @@ fn resource_decl_errors(stmts: Array[Stmt], from_idx: Int, errors: Array[String]
   }
 }
 
+/// #1464: reject a value name declared twice in one DECLARATION list (the
+/// top level of a file, or a `module { ... }` body). `fn` declarations are
+/// lowered to `SLet` before the checker, so this covers `fn f` twice,
+/// `let x` twice, and any mix of the two with `let mut` / `extern let`.
+///
+/// Deliberately NOT a shadowing check: this walk only ever sees declaration
+/// lists (check_stmts_with_binders' two callers are the program root and the
+/// SModule arm), never a function body, so the legal and widespread
+/// `let x = ...; let x = f(x)` inside a block is untouched. At the top level
+/// there is no sequencing to shadow -- declarations are hoisted (see the
+/// hoist_i pre-pass), so both `x`s are in scope for the whole file and every
+/// reference resolves to the last one, silently.
+///
+/// `_` is skipped: `let _ = ...` is a discard, not a name.
+fn duplicate_value_decl_errors(stmts: Array[Stmt], from_idx: Int, errors: Array[String]) -> Unit {
+  let seen = array_empty()
+  let mut i = from_idx
+  while i < Array::length(stmts) {
+    let dname = match Array::get(stmts, i) {
+      SLet(_, _, n, _, _) => n,
+      SLetMut(n, _, _) => n,
+      SExternLet(n, _) => n,
+      _ => "_"
+    }
+    if dname != "_" {
+      if es_string_array_contains(seen, dname) {
+        Array::push(errors, String::concat("duplicate declaration: ", dname))
+      } else {
+        Array::push(seen, dname)
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}
+
 /// ADR-0071 step 3 (#755) row expansion: recursively expand `name` into leaf
 /// labels (ordinary effect/operation names -- not further-expandable
 /// effectset names) via es_names/es_members_list, appending each freshly
@@ -830,6 +867,37 @@ fn derive_name_is_known(name: String) -> Bool {
   name == "Eq" || name == "Ord" || name == "Show" || name == "Hash" || name == "Default"
 }
 
+/// #1464: reject a constructor name declared twice by the SAME enum /
+/// suberror. #1078's `find_other_enum_declaring_variant` deliberately skips
+/// the declaration being registered (`other_name != enum_name`), so the
+/// within-one-declaration case fell between the two checks and nothing
+/// caught it.
+///
+/// It has to be an error rather than last-wins: `env_bind` is
+/// last-registered-wins, so `enum E { A(Int); A(String) }` silently binds
+/// only the second `A` and the first payload type becomes unreachable --
+/// `A(1)` then reports `argument type mismatch for A: expected String, got
+/// Int` pointing at a constructor the source really does declare with an
+/// `Int`. Codegen is worse: variant TAGS are assigned by position, so a
+/// `match` arm written against the first `A` gets the second one's tag.
+///
+/// `variants` is scanned rather than the registered `defs` entry because
+/// both callers push their TDEnum before binding, which would make every
+/// variant its own duplicate.
+fn duplicate_ctor_errors(kind: String, name: String, variants: Array[(String, Array[TypeExpr])], errors: Array[String]) -> Unit {
+  let seen = array_empty()
+  let mut i = 0
+  while i < Array::length(variants) {
+    let (vname, _) = Array::get(variants, i)
+    if es_string_array_contains(seen, vname) {
+      Array::push(errors, String::concat("type definition: duplicate ctor: ", String::concat(vname, String::concat(" is declared more than once by ", String::concat(kind, String::concat(" ", name))))))
+    } else {
+      Array::push(seen, vname)
+    }
+    i = i + 1
+  }
+}
+
 /// #1078: the name of a DIFFERENT enum (already registered in `defs`) that
 /// declares a variant named `vname`, or None. Used to reject bare-name
 /// constructor collisions at declaration time -- see the SEnum arm's
@@ -1002,6 +1070,8 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
   // (duplicate detection), so they run here rather than in the SResource arm
   // below -- which is why that arm has nothing left to do.
   resource_decl_errors(stmts, idx, errors)
+  // #1464: same shape -- duplicate value declarations need the WHOLE list.
+  duplicate_value_decl_errors(stmts, idx, errors)
   // #942 (Codex P2 on #969): if any top-level declaration in this statement
   // list binds the name `resume` (fn/let — fn decls are lowered to SLet
   // before the checker — let-pattern, extern let, or an import), codegen's
@@ -1274,6 +1344,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
       },
       SEnum(_, name, params, variants, enum_derives) => {
         validate_derives(enum_derives, errors)
+        duplicate_ctor_errors("enum", name, variants, errors)
         let param_len = Array::length(params)
         let param_var_ids = array_empty()
         let param_var_types = array_empty()
@@ -1407,6 +1478,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // a TDEnum def (so `match` + type resolution work) and bind each
         // constructor name as `CtFn(payload, CtEnum(name))`. `throw` accepts the
         // resulting value (its param is CtUnknown, see builtins_misc).
+        duplicate_ctor_errors("suberror", name, variants, errors)
         let ctor_result_type = CtEnum(name)
         let resolved_variants = array_empty()
         let mut vi = 0


### PR DESCRIPTION
#1464 の「効かなくなった検査」のうち、**規則の意思決定が要らない唯一のクラスタ = 宣言重複の2件**を直します。

## 1. 同一 enum / suberror 内の ctor 重複

```vibe
enum E { A; A }                       // 通っていた
suberror AppError { Io(String); Io(Int) }  // 通っていた
```

#1078 が入れた cross-enum の衝突検査は、登録中の宣言自身を意図的に除外します (`other_name != enum_name`)。そのため**同一宣言内**のケースが2つの検査の隙間に落ちていました。

last-wins で許す選択肢はありません:

- `env_bind` は last-registered-wins なので `enum E { A(Int); A(String) }` は2つ目の `A` しか束縛せず、`A(1)` は `expected String, got Int` を出します — **ソースが実際に `Int` で宣言している** ctor に対して。
- codegen はもっと悪く、variant tag は**位置で**振られるので、1つ目の `A` に対して書いた `match` arm が2つ目の tag を掴みます。

## 2. 宣言リスト内の値名の重複

```vibe
let x = 1
let x = 2      // 通っていた

fn helper() -> Int { 1 }
fn helper() -> Int { 2 }   // 同上 (fn は checker 到達前に SLet へ lower される)
```

**shadowing 検査ではありません**。`check_stmts_with_binders` の呼び出し元は program root と `SModule` arm だけで**関数本体には来ない**ので、ブロック内の `let x = ...; let x = f(x)` には触れません。トップレベルにはそもそも shadow する順序が無く、宣言は hoist される (`hoist_i` pre-pass) ので両方の `x` がファイル全体でスコープに入り、あらゆる参照が黙って後者に解決されます。

`let _` は discard なので対象外です。

## メッセージ

`CEDuplicateDecl` は `checker_error.vibe` に**元からあり**、レンダリングのユニットテストまであって、checker からは一度も構築されていませんでした。メッセージはそれに合わせてあります。

## expected.tsv

| row | before | after |
|---|---|---|
| `duplicate_enum_ctor` | debt-accepts | **reject** |
| `duplicate_value_decl` | debt-accepts | **reject** |
| `suberror_duplicate_ctor` | reject (`argument type mismatch for Io`) | reject (`duplicate ctor: Io`) |

`suberror_duplicate_ctor` は今まで**結果**(2つ目の宣言が勝ったせいの型不一致)で拒否されていたので、needle を原因に更新しました。

新しいピンを2つ追加:
- `duplicate_fn_decl` — 実際によく書かれる綴り
- `duplicate_discard_decl_ok` — `let _` の繰り返しが再宣言と誤検出されないこと (過剰拒否側のピン)

残り debt は 10 → 8 です。

## ここでは直していないもの

残る8件はいずれも規則の判断か新規実装を要します: `scoped_ref_param_*` は「`Ref[T]` を関数パラメータに許すか」という規則そのもの、`missing_label_call_argument` は #986/#1001 後のラベル引数呼び出し規約、`polymorphic_recursion_unsupported` は検出パスの新規実装、generic effect 2件は caller 側 row 規則、`suberror_raise_non_error_type` は「throw できる型か」の検査。

## 検証

`pkf run test` 緑。**fixpoint `stage2==stage3` (`3e5ff411c7c2`)** — これはそのまま「コンパイラ自身の約900ファイルに重複宣言が1つも無い」ことの証拠でもあります。typecheck fixtures 64件 / known debt 8。`vibe-fmt-check` 901ファイル clean。

---
_Generated by [Claude Code](https://claude.ai/code/session_01PENPDUZBtGEyxx27pMVtsa)_