### PR TITLE
bench(checker): measure engine artifact boundary

### DIFF
--- a/bench/checker_browser_baseline/README.md
+++ b/bench/checker_browser_baseline/README.md
@@ -1,18 +1,31 @@
 # Checker browser baseline
 
-This is an **opt-in observation baseline** for Issue #1440. It has two fixed,
-ownerless Vibe roots and no `index.vpkg`, package extraction, public API, or
-checker ABI:
+This is an **opt-in observation baseline** for Issue #1440. It uses four fixed,
+ownerless Vibe roots and deliberately has no local `index.vpkg`, package
+extraction, public API, or checker ABI:
 
 - `parser_only.vibe` lexes and parses a fixed small program.
-- `current_checker.vibe` lexes, parses, and invokes the current checker on the
-  same fixed program.
+- `current_checker.vibe` lexes, parses, and invokes the current checker.
+- `checker_engine_only.vibe` exercises that parser + parent-checker engine
+  boundary under a strict closure policy that excludes the optional artifacts
+  child and backend/runtime ownership.
+- `checker_engine_plus_artifacts.vibe` executes the existing checked effect-set
+  observation -> artifact -> v1 encode pipeline through
+  `@vibe/compiler/checker/artifacts`.
 
-The accompanying `full_compiler` case is intentionally rooted at the existing
-`lib/@vibe/compiler/cli_adapter.vibe` / `cli_main` self-host compiler root.
-That is the buildable whole-compiler root verified by the repository's
-self-build flow. A root that merely imports `@vibe/compiler` was investigated
-and is not used because it is not buildable as a standalone baseline input.
+`current_checker` and `checker_engine_only` intentionally execute equivalent
+current checker-engine workload today, so their generated Wasm may be identical.
+`checker_engine_only` does not claim a separate engine API or a behavioral
+implementation difference. Its independent value is the strict artifact-free
+closure policy and its fixed root identity; the collector and serialized-report
+validator require that declared root to occur exactly once in the attested
+module plan.
+
+The `full_compiler` case is rooted at the existing
+`lib/@vibe/compiler/cli_adapter.vibe` / `cli_main` self-host compiler root. That
+is the buildable whole-compiler root verified by the repository's self-build
+flow. A root that merely imports `@vibe/compiler` is not used because it is not
+buildable as a standalone baseline input.
 
 ## Run
 
@@ -28,49 +41,65 @@ The default report is ignored at
 
 ## Report schema and authority
 
-Schema version 1 has fixed ordered cases:
+Schema version 2 has six fixed ordered cases:
 
-1. `parser_only`, `current_checker`, and `full_compiler` when they build;
-2. explicit unavailable rows for `checker_engine_only`,
-   `checker_engine_plus_artifacts`, and `full_compiler_check`.
+1. available `parser_only`;
+2. available `current_checker`;
+3. available `checker_engine_only`;
+4. available `checker_engine_plus_artifacts`;
+5. available `full_compiler`;
+6. explicitly unavailable `full_compiler_check` because no supported direct
+   check invocation ABI exists.
 
 Every available source closure comes only from a fresh
 `VIBE_MODULE_PLAN=1` version-1 sidecar and its numbered ingested `.src`
 companions. The collector does **not** derive a closure from import text or
 `compiler_sources_manifest.tsv`. It records canonical plan order, declared
 dependency occurrences (including duplicates), ingested source byte counts and
-SHA-256 digests, categories, and a manifest annotation. Compiler-relative
-manifest paths are resolved under `lib/@vibe/compiler/`; the annotation is only
-an exact-path label, not closure authority. Categories separately expose
-`codegen`, `checker_core_and_model`, `checker_artifact`, and
-`checker_observation` source contribution, but none of those path-based groups
-claims that an extracted checker engine already exists. `current_checker` has
-an additional strict closure invariant: no module categorized as `codegen`
-(including `codegen/` and `perceus/` sources) is allowed. The collector rejects
-such a plan before building, and report validation rejects a contaminated
-`current_checker` report. This invariant deliberately does not apply to the
-`full_compiler` case, whose whole-compiler closure necessarily contains codegen.
+SHA-256 digests, path-derived categories, and a manifest annotation.
+Compiler-relative manifest paths are resolved under `lib/@vibe/compiler/`; the
+annotation is only an exact-path label, not closure authority.
 
-Each build has its own temporary `VIBE_BUILD_CACHE_DIR` and disables the
-persistent artifact cache. The supplied compiler is used for both plan and
-builds. The caller is responsible for supplying a matching stage2; its path
-and SHA-256 are recorded so a report is attributable. The three supported
-roots are required to build, and repeated output must be byte-identical;
-either failure aborts the collector rather than being relabeled unavailable.
+The extracted child is classified before the broader checker path:
+
+- `checker_artifacts_contract` for its exact `index.vpkg`;
+- `checker_artifacts_artifact` for child `*_artifact.vibe` sources;
+- `checker_artifacts_observation` for child `*_observation.vibe` sources;
+- `checker_artifacts_support` for any remaining child source.
+
+These categories report source ownership and do not infer per-symbol
+reachability. Parent-checker artifact/observation names remain separate from
+those child categories.
+
+Case-specific closure policies are applied both to the live compiler sidecar
+before a build and by the strict serialized-report parser. `current_checker`
+remains codegen/perceus-free. `checker_engine_only` rejects every artifacts
+child source and all compiler `codegen`, `perceus`, `runtime`, `cache`, and
+`loader` sources. `checker_engine_plus_artifacts` rejects the same five backend
+or host-facing ownership groups and requires exact plan evidence for the child
+`index.vpkg` plus the invoked `checked_effect_set_observation.vibe` and
+`checked_effect_set_artifact.vibe` sources. `full_compiler` intentionally does
+not use those exclusions.
+
+Each plan and build receives a fresh temporary `VIBE_BUILD_CACHE_DIR`, inherited
+`VIBE_*` variables are removed, and the persistent artifact cache is disabled.
+The supplied compiler is used for both planning and every build. The caller is
+responsible for supplying a matching stage2; its path and SHA-256 are recorded.
+All five supported roots must build, and repeated output must be byte-identical;
+either failure aborts rather than being relabeled unavailable.
 
 ## Metrics
 
-For available core Wasm outputs, the report records raw/gzip-9/brotli-11
-bytes, SHA-256, canonically sorted exact imports, per-build SHA-256 values, and
-exact byte-for-byte repeated-artifact equality. Source closure digests and
-equal repeated artifacts are deterministic evidence for a matching
-compiler/source/compression implementation.
+For available core Wasm outputs, the report records raw, gzip level 9, and
+Brotli quality 11 bytes, SHA-256, canonically sorted exact imports, per-build
+SHA-256 values, and exact `Buffer.equals` repeated-artifact evidence. Source
+closure digests and equal repeated artifacts are deterministic evidence for a
+matching compiler/source/compression implementation.
 
 Build wall time, Node `WebAssembly.compile`, instantiation, and direct export
 invocation are raw sample arrays and are environment-sensitive. The report
 records Node/V8/OS/CPU metadata rather than presenting them as stable scores.
-Instantiation and direct invocation run only when the core module has no
-imports and its named entry is actually exported. The collector never invents
-host imports, calls a component through `WebAssembly.Module`, or guesses a CLI
-ABI. Unsupported timing paths carry a reason; unavailable is never encoded as
-zero.
+Instantiation and direct invocation run only when the core module has no imports
+and its named entry is actually exported. The collector never invents host
+imports, calls a component through `WebAssembly.Module`, or guesses a CLI ABI.
+Unsupported timing paths carry a reason; unavailable is never encoded as zero.

--- a/bench/checker_browser_baseline/checker_engine_only.vibe
+++ b/bench/checker_browser_baseline/checker_engine_only.vibe
@@ -1,0 +1,22 @@
+//# Browser checker baseline: extracted checker-engine ownerless root.
+//
+// This is a fixed build input, not a package boundary or public API. Its
+// measured closure must exclude the optional checker/artifacts child package.
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/parser {
+  lex, parse_program
+}
+
+export fn main() -> Int {
+  handle {
+    let program = parse_program(lex("let answer: Int = 42"))
+    let _ = check_program(program)
+    0
+  } with Error {
+    Throw(_) => -1
+  }
+}

--- a/bench/checker_browser_baseline/checker_engine_plus_artifacts.vibe
+++ b/bench/checker_browser_baseline/checker_engine_plus_artifacts.vibe
@@ -1,0 +1,31 @@
+//# Browser checker baseline: checker engine plus optional artifacts ownerless root.
+//
+// This is a fixed build input, not a package boundary or public API. It runs
+// the existing effect-set observation -> artifact -> v1 encoding pipeline.
+
+import @vibe/compiler/checker {
+  check_program_result
+}
+
+import @vibe/compiler/checker/artifacts {
+  checked_effect_set_declarations_artifact_from_observation,
+  checked_effect_set_declarations_observation,
+  encode_checked_effect_set_declarations_artifact_v1
+}
+
+import @vibe/parser {
+  lex, parse_program
+}
+
+export fn main() -> Int {
+  handle {
+    let program = parse_program(lex("let answer: Int = 42"))
+    let checked = check_program_result(program)
+    let observation = checked_effect_set_declarations_observation(checked)
+    let artifact = checked_effect_set_declarations_artifact_from_observation(observation)
+    let encoded = encode_checked_effect_set_declarations_artifact_v1(artifact)
+    String::length(encoded)
+  } with Error {
+    Throw(_) => -1
+  }
+}

--- a/scripts/measure_checker_browser_baseline.mjs
+++ b/scripts/measure_checker_browser_baseline.mjs
@@ -13,18 +13,24 @@ import { performance } from "node:perf_hooks";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const runner = join(root, "scripts/run_wasm_vibe_host_runner.sh");
-const schema = 1;
+const schema = 2;
 const caseDefinitions = [
   { id: "parser_only", root: "bench/checker_browser_baseline/parser_only.vibe", entry: "main" },
   { id: "current_checker", root: "bench/checker_browser_baseline/current_checker.vibe", entry: "main" },
+  { id: "checker_engine_only", root: "bench/checker_browser_baseline/checker_engine_only.vibe", entry: "main" },
+  { id: "checker_engine_plus_artifacts", root: "bench/checker_browser_baseline/checker_engine_plus_artifacts.vibe", entry: "main" },
   // This is the compiler's actual self-host CLI root. The failed facade-only
   // experiment is intentionally not a benchmark root: it is not buildable.
   { id: "full_compiler", root: "lib/@vibe/compiler/cli_adapter.vibe", entry: "cli_main" },
 ];
 const unavailableDefinitions = [
-  ["checker_engine_only", "No supported isolated checker-engine root or ABI exists; this baseline does not extract one."],
-  ["checker_engine_plus_artifacts", "No supported isolated checker-engine-plus-artifacts entry exists; this baseline does not infer one from imports."],
   ["full_compiler_check", "The full compiler CLI exposes no supported isolated direct check invocation ABI; host imports and CLI argument ABI are not fabricated."],
+];
+const checkerArtifactsPrefix = "lib/@vibe/compiler/checker/artifacts/";
+const checkerArtifactsContract = `${checkerArtifactsPrefix}index.vpkg`;
+const invokedArtifactSources = [
+  `${checkerArtifactsPrefix}checked_effect_set_artifact.vibe`,
+  `${checkerArtifactsPrefix}checked_effect_set_observation.vibe`,
 ];
 
 function fail(message) {
@@ -149,22 +155,63 @@ function sourceManifestAnnotations() {
 
 function category(path) {
   if (path.startsWith("bench/checker_browser_baseline/")) return "benchmark_root";
+  // Classify the extracted child before the broader checker prefix. These
+  // categories describe path ownership, not inferred symbol reachability.
+  if (path === checkerArtifactsContract) return "checker_artifacts_contract";
+  if (path.startsWith(checkerArtifactsPrefix)) {
+    if (path.endsWith("_artifact.vibe")) return "checker_artifacts_artifact";
+    if (path.endsWith("_observation.vibe")) return "checker_artifacts_observation";
+    return "checker_artifacts_support";
+  }
   if (path.startsWith("lib/@vibe/compiler/checker/")) {
     if (path.endsWith("_artifact.vibe")) return "checker_artifact";
     if (path.endsWith("_observation.vibe")) return "checker_observation";
     return "checker_core_and_model";
   }
   if (path.startsWith("lib/@vibe/compiler/codegen/") || path.startsWith("lib/@vibe/compiler/perceus/")) return "codegen";
+  if (path.startsWith("lib/@vibe/compiler/runtime/")) return "runtime";
+  if (path.startsWith("lib/@vibe/compiler/cache/")) return "cache";
+  if (path.startsWith("lib/@vibe/compiler/loader/")) return "loader";
   if (path.startsWith("lib/@vibe/parser/")) return "parser";
   if (path.startsWith("lib/@vibe/compiler/")) return "compiler_other";
   if (path.startsWith("lib/@vibe/")) return "stdlib_other";
   return "other";
 }
 
-function assertCurrentCheckerNoCodegenClosure(caseId, modules) {
-  if (caseId !== "current_checker") return;
-  const codegenModule = modules.find((module) => category(module.path) === "codegen");
-  if (codegenModule) fail(`current_checker closure includes codegen source: ${codegenModule.path}`);
+function forbiddenEngineOwnership(path) {
+  for (const ownership of ["codegen", "perceus", "runtime", "cache", "loader"]) {
+    if (path.startsWith(`lib/@vibe/compiler/${ownership}/`)) return ownership;
+  }
+  return undefined;
+}
+
+function validateDeclaredRoot(rootPath, modules, label) {
+  const occurrences = modules.filter((module) => module.path === rootPath).length;
+  if (occurrences !== 1) fail(`${label} must contain declared root exactly once: ${rootPath}`);
+}
+
+/** Enforce case-specific ownership policies on live and serialized closures. */
+export function validateCaseClosure(caseId, modules) {
+  if (caseId === "current_checker") {
+    const codegenModule = modules.find((module) => category(module.path) === "codegen");
+    if (codegenModule) fail(`current_checker closure includes codegen source: ${codegenModule.path}`);
+    return;
+  }
+  if (caseId !== "checker_engine_only" && caseId !== "checker_engine_plus_artifacts") return;
+  for (const module of modules) {
+    const forbidden = forbiddenEngineOwnership(module.path);
+    if (forbidden) fail(`${caseId} closure includes forbidden ${forbidden} source: ${module.path}`);
+    if (caseId === "checker_engine_only" && module.path.startsWith(checkerArtifactsPrefix)) {
+      fail(`checker_engine_only closure includes checker artifacts child source: ${module.path}`);
+    }
+  }
+  if (caseId === "checker_engine_plus_artifacts") {
+    const paths = new Set(modules.map((module) => module.path));
+    if (!paths.has(checkerArtifactsContract)) fail(`checker_engine_plus_artifacts closure is missing child contract: ${checkerArtifactsContract}`);
+    for (const source of invokedArtifactSources) {
+      if (!paths.has(source)) fail(`checker_engine_plus_artifacts closure is missing invoked artifact source: ${source}`);
+    }
+  }
 }
 
 function digestClosure(plan, planPath) {
@@ -255,7 +302,8 @@ function planCase(stage2, definition, workdir) {
     throw new Error(`VIBE_MODULE_PLAN failed (${result.status ?? "signal"}): ${detail || "no sidecar"}`);
   }
   const closure = digestClosure(parseModulePlan(readFileSync(planPath, "utf8")), planPath);
-  assertCurrentCheckerNoCodegenClosure(definition.id, closure.modules);
+  validateDeclaredRoot(definition.root, closure.modules, `${definition.id} module plan`);
+  validateCaseClosure(definition.id, closure.modules);
   return { planPath, closure };
 }
 
@@ -419,7 +467,8 @@ export function parseCheckerBrowserBaselineReport(text) {
         computedCategories[module.category].bytes += module.bytes;
       }
       validateCanonicalPlan(item.module_plan.modules, `report module plan ${item.id}`);
-      assertCurrentCheckerNoCodegenClosure(item.id, item.module_plan.modules);
+      validateDeclaredRoot(item.root.path, item.module_plan.modules, `report module plan ${item.id}`);
+      validateCaseClosure(item.id, item.module_plan.modules);
       if (computedBytes !== item.module_plan.total_bytes) fail(`source byte total mismatch for ${item.id}`);
       const closureIdentity = item.module_plan.modules.map((module) => `${module.index}\t${module.rank}\t${module.path}\t${module.bytes}\t${module.sha256}\t${module.dependencies.join("\u0000")}`).join("\n");
       if (sha256(closureIdentity) !== item.module_plan.sha256) fail(`closure digest mismatch for ${item.id}`);

--- a/scripts/measure_checker_browser_baseline.test.mjs
+++ b/scripts/measure_checker_browser_baseline.test.mjs
@@ -2,24 +2,52 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
 
-import { isolatedCompilerEnvironment, parseCheckerBrowserBaselineReport, parseModulePlan } from "./measure_checker_browser_baseline.mjs";
+import {
+  isolatedCompilerEnvironment,
+  parseCheckerBrowserBaselineReport,
+  parseModulePlan,
+  validateCaseClosure,
+} from "./measure_checker_browser_baseline.mjs";
 
 const plan = "version\t1\nmodule\t0\t0\tdep.vibe\nmodule\t1\t1\tmain.vibe\ndep\t1\tdep.vibe\n";
-
 const sourceHash = "a".repeat(64);
 const artifactHash = "b".repeat(64);
+const artifactPrefix = "lib/@vibe/compiler/checker/artifacts/";
+
 function closureDigest(modules) {
   return createHash("sha256").update(modules.map((module) => `${module.index}\t${module.rank}\t${module.path}\t${module.bytes}\t${module.sha256}\t${module.dependencies.join("\u0000")}`).join("\n")).digest("hex");
 }
 
-const closureHash = closureDigest([{ index: 0, rank: 0, path: "root.vibe", dependencies: [], bytes: 1, sha256: sourceHash }]);
+function sourceModule(index, path, category) {
+  return { index, rank: 0, path, dependencies: [], bytes: 1, sha256: sourceHash, category, manifest_annotation: "not-listed" };
+}
 
 function available(id) {
   const roots = {
     parser_only: { path: "bench/checker_browser_baseline/parser_only.vibe", entry: "main" },
     current_checker: { path: "bench/checker_browser_baseline/current_checker.vibe", entry: "main" },
+    checker_engine_only: { path: "bench/checker_browser_baseline/checker_engine_only.vibe", entry: "main" },
+    checker_engine_plus_artifacts: { path: "bench/checker_browser_baseline/checker_engine_plus_artifacts.vibe", entry: "main" },
     full_compiler: { path: "lib/@vibe/compiler/cli_adapter.vibe", entry: "cli_main" },
   };
+  let modules;
+  if (id === "checker_engine_plus_artifacts") {
+    modules = [
+      sourceModule(0, roots[id].path, "benchmark_root"),
+      sourceModule(1, `${artifactPrefix}checked_effect_set_artifact.vibe`, "checker_artifacts_artifact"),
+      sourceModule(2, `${artifactPrefix}checked_effect_set_observation.vibe`, "checker_artifacts_observation"),
+      sourceModule(3, `${artifactPrefix}index.vpkg`, "checker_artifacts_contract"),
+    ];
+  } else {
+    const path = roots[id].path;
+    modules = [sourceModule(0, path, path.startsWith("bench/") ? "benchmark_root" : "compiler_other")];
+  }
+  const category_breakdown = {};
+  for (const module of modules) {
+    if (!category_breakdown[module.category]) category_breakdown[module.category] = { modules: 0, bytes: 0 };
+    category_breakdown[module.category].modules += 1;
+    category_breakdown[module.category].bytes += module.bytes;
+  }
   return {
     id,
     status: "available",
@@ -27,11 +55,11 @@ function available(id) {
     module_plan: {
       authority: "VIBE_MODULE_PLAN=1 version 1 sidecar; ingested .src files",
       dependency_order: "canonical compiler plan order (index ascending)",
-      module_count: 1,
-      total_bytes: 1,
-      sha256: closureHash,
-      modules: [{ index: 0, rank: 0, path: "root.vibe", dependencies: [], bytes: 1, sha256: sourceHash, category: "other", manifest_annotation: "not-listed" }],
-      category_breakdown: { other: { modules: 1, bytes: 1 } },
+      module_count: modules.length,
+      total_bytes: modules.length,
+      sha256: closureDigest(modules),
+      modules,
+      category_breakdown,
     },
     artifacts: { raw_bytes: 1, gzip_bytes: 1, brotli_bytes: 1, sha256: artifactHash, imports: [], repeated_sha256: [artifactHash, artifactHash], repeated_artifacts_equal: true },
     timings: { build_ms: [1, 2], wasm_compile_ms: [1, 2], wasm_instantiate_ms: [1, 2], direct_entry_ms: [1, 2], unsupported: {} },
@@ -40,19 +68,33 @@ function available(id) {
 
 function report() {
   return {
-    schema: 1,
+    schema: 2,
     methodology: { opt_in: true, cache_policy: "isolated", source_authority: "VIBE_MODULE_PLAN=1", unavailable_policy: "explicit", timing_policy: "raw samples", samples: 2 },
     environment: { node: "v", v8: "v", platform: "p", release: "r", arch: "a", cpu_model: "c", cpu_count: 1, cwd: "root", isolated_workdir_parent: "_build" },
     compiler: { path: "stage2.wasm", sha256: "c".repeat(64), matching_contract: "caller supplied" },
     cases: [
       available("parser_only"),
       available("current_checker"),
+      available("checker_engine_only"),
+      available("checker_engine_plus_artifacts"),
       available("full_compiler"),
-      { id: "checker_engine_only", status: "unavailable", unavailable_reason: "no entry" },
-      { id: "checker_engine_plus_artifacts", status: "unavailable", unavailable_reason: "no entry" },
       { id: "full_compiler_check", status: "unavailable", unavailable_reason: "no ABI" },
     ],
   };
+}
+
+function replaceClosure(item, modules) {
+  item.module_plan.modules = modules;
+  item.module_plan.module_count = modules.length;
+  item.module_plan.total_bytes = modules.reduce((total, module) => total + module.bytes, 0);
+  item.module_plan.sha256 = closureDigest(modules);
+  item.module_plan.category_breakdown = {};
+  for (const module of modules) {
+    const breakdown = item.module_plan.category_breakdown;
+    if (!breakdown[module.category]) breakdown[module.category] = { modules: 0, bytes: 0 };
+    breakdown[module.category].modules += 1;
+    breakdown[module.category].bytes += module.bytes;
+  }
 }
 
 test("compiler subprocess environment rejects inherited adapter modes", () => {
@@ -81,18 +123,54 @@ test("module plan rejects malformed, non-contiguous, and guessed dependencies", 
   assert.throws(() => parseModulePlan("version\t1\nmodule\t0\t0\tmain.vibe\ndep\t0\tmissing.vibe\n"), /absent from closure/);
 });
 
-test("report parser accepts exact baseline schema with explicit unavailable cases", () => {
+test("schema 2 accepts five fixed measured cases and only honest full-check unavailability", () => {
   const value = report();
   assert.deepEqual(parseCheckerBrowserBaselineReport(JSON.stringify(value)), value);
 });
 
-test("report parser rejects widened reports and unavailable zero metrics", () => {
+test("live engine closure policies reject forbidden ownership and require invoked artifact evidence", () => {
+  assert.doesNotThrow(() => validateCaseClosure("checker_engine_only", [{ path: "lib/@vibe/compiler/checker/checker.vibe" }]));
+  assert.throws(() => validateCaseClosure("checker_engine_only", [{ path: `${artifactPrefix}index.vpkg` }]), /checker artifacts child/);
+  for (const ownership of ["codegen", "perceus", "runtime", "cache", "loader"]) {
+    assert.throws(() => validateCaseClosure("checker_engine_only", [{ path: `lib/@vibe/compiler/${ownership}/bad.vibe` }]), new RegExp(`forbidden ${ownership}`));
+    assert.throws(() => validateCaseClosure("checker_engine_plus_artifacts", [{ path: `lib/@vibe/compiler/${ownership}/bad.vibe` }]), new RegExp(`forbidden ${ownership}`));
+  }
+  const exactEvidence = [
+    { path: `${artifactPrefix}index.vpkg` },
+    { path: `${artifactPrefix}checked_effect_set_artifact.vibe` },
+    { path: `${artifactPrefix}checked_effect_set_observation.vibe` },
+  ];
+  assert.doesNotThrow(() => validateCaseClosure("checker_engine_plus_artifacts", exactEvidence));
+  assert.throws(() => validateCaseClosure("checker_engine_plus_artifacts", exactEvidence.slice(1)), /missing child contract/);
+  assert.throws(() => validateCaseClosure("checker_engine_plus_artifacts", exactEvidence.slice(0, 2)), /missing invoked artifact source/);
+});
+
+test("report parser rejects widened reports, reordered availability, and unavailable zero metrics", () => {
   const widened = report();
   widened.extra = true;
   assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(widened)), /unexpected or missing fields/);
   const dishonest = report();
-  dishonest.cases[3].timings = { build_ms: [0] };
+  dishonest.cases[5].timings = { build_ms: [0] };
   assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(dishonest)), /unexpected or missing fields/);
+  const reordered = report();
+  [reordered.cases[1], reordered.cases[2]] = [reordered.cases[2], reordered.cases[1]];
+  assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(reordered)), /case order or IDs changed/);
+  const unavailableEngine = report();
+  unavailableEngine.cases[2] = { id: "checker_engine_only", status: "unavailable", unavailable_reason: "pretend" };
+  assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(unavailableEngine)), /required measured case is unavailable/);
+});
+
+test("serialized report requires every declared root exactly once in its module plan", () => {
+  const missingRoot = report();
+  replaceClosure(missingRoot.cases[3], [
+    sourceModule(0, `${artifactPrefix}checked_effect_set_artifact.vibe`, "checker_artifacts_artifact"),
+    sourceModule(1, `${artifactPrefix}checked_effect_set_observation.vibe`, "checker_artifacts_observation"),
+    sourceModule(2, `${artifactPrefix}index.vpkg`, "checker_artifacts_contract"),
+  ]);
+  assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(missingRoot)), /must contain declared root exactly once/);
+});
+
+test("report parser rejects false authority, root, closure, digest, import, and category evidence", () => {
   const wrongAuthority = report();
   wrongAuthority.cases[0].module_plan.authority = "imports guessed from text";
   assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(wrongAuthority)), /dishonest module-plan authority/);
@@ -115,21 +193,45 @@ test("report parser rejects widened reports and unavailable zero metrics", () =>
   ];
   assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(unsortedImports)), /noncanonical Wasm import order/);
   const mislabeledCategory = report();
-  mislabeledCategory.cases[0].module_plan.modules[0].category = "codegen";
-  mislabeledCategory.cases[0].module_plan.category_breakdown = { codegen: { modules: 1, bytes: 1 } };
+  mislabeledCategory.cases[3].module_plan.modules[0].category = "checker_artifact";
+  mislabeledCategory.cases[3].module_plan.category_breakdown = { checker_artifact: { modules: 1, bytes: 1 } };
   assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(mislabeledCategory)), /module category mismatch/);
-  const contaminatedChecker = report();
-  const checkerClosure = contaminatedChecker.cases[1].module_plan;
-  checkerClosure.modules[0].path = "lib/@vibe/compiler/codegen/contamination.vibe";
-  checkerClosure.modules[0].category = "codegen";
-  checkerClosure.category_breakdown = { codegen: { modules: 1, bytes: 1 } };
-  checkerClosure.sha256 = closureDigest(checkerClosure.modules);
-  assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(contaminatedChecker)), /current_checker closure includes codegen source/);
+});
+
+test("serialized closure policies reject engine contamination and missing exact artifact sources", () => {
+  const contaminatedCurrent = report();
+  replaceClosure(contaminatedCurrent.cases[1], [
+    sourceModule(0, contaminatedCurrent.cases[1].root.path, "benchmark_root"),
+    sourceModule(1, "lib/@vibe/compiler/codegen/contamination.vibe", "codegen"),
+  ]);
+  assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(contaminatedCurrent)), /current_checker closure includes codegen source/);
+
+  const contaminatedEngine = report();
+  replaceClosure(contaminatedEngine.cases[2], [
+    sourceModule(0, contaminatedEngine.cases[2].root.path, "benchmark_root"),
+    sourceModule(1, "lib/@vibe/compiler/runtime/contamination.vibe", "runtime"),
+  ]);
+  assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(contaminatedEngine)), /checker_engine_only closure includes forbidden runtime source/);
+
+  const childInEngine = report();
+  replaceClosure(childInEngine.cases[2], [
+    sourceModule(0, childInEngine.cases[2].root.path, "benchmark_root"),
+    sourceModule(1, `${artifactPrefix}index.vpkg`, "checker_artifacts_contract"),
+  ]);
+  assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(childInEngine)), /checker artifacts child/);
+
+  const missingArtifact = report();
+  replaceClosure(missingArtifact.cases[3], [
+    sourceModule(0, missingArtifact.cases[3].root.path, "benchmark_root"),
+    sourceModule(1, `${artifactPrefix}checked_effect_set_observation.vibe`, "checker_artifacts_observation"),
+    sourceModule(2, `${artifactPrefix}index.vpkg`, "checker_artifacts_contract"),
+  ]);
+  assert.throws(() => parseCheckerBrowserBaselineReport(JSON.stringify(missingArtifact)), /missing invoked artifact source/);
+
   const fullCompilerCodegen = report();
-  const fullCompilerClosure = fullCompilerCodegen.cases[2].module_plan;
-  fullCompilerClosure.modules[0].path = "lib/@vibe/compiler/codegen/allowed.vibe";
-  fullCompilerClosure.modules[0].category = "codegen";
-  fullCompilerClosure.category_breakdown = { codegen: { modules: 1, bytes: 1 } };
-  fullCompilerClosure.sha256 = closureDigest(fullCompilerClosure.modules);
+  replaceClosure(fullCompilerCodegen.cases[4], [
+    sourceModule(0, fullCompilerCodegen.cases[4].root.path, "compiler_other"),
+    sourceModule(1, "lib/@vibe/compiler/codegen/allowed.vibe", "codegen"),
+  ]);
   assert.deepEqual(parseCheckerBrowserBaselineReport(JSON.stringify(fullCompilerCodegen)), fullCompilerCodegen);
 });


### PR DESCRIPTION
## Summary

Complete the post-extraction Issue #1440 closure measurement boundary.

- add ownerless `checker_engine_only` and `checker_engine_plus_artifacts` benchmark roots (no `index.vpkg`)
- promote both to available cases in strict report schema 2
- retain only `full_compiler_check` as honestly unavailable
- derive child artifact contract/artifact/observation/support categories from actual module paths
- enforce live and serialized closure policies:
  - engine-only rejects child artifacts, codegen, perceus, runtime, cache, and loader
  - plus-artifacts rejects codegen/perceus/runtime/cache/loader and requires the exact child contract + invoked effect-set artifact source
- attest every available declared root appears exactly once in its measured closure
- preserve environment isolation, module-plan sidecar authority, byte equality, gzip-9/Brotli-11, and unavailable timing/import honesty

`current_checker` and `checker_engine_only` intentionally exercise the equivalent current engine workload today and can emit identical Wasm. Their distinction is explicit: the former is the historical baseline; the latter is the strict artifact-free closure contract with separately attested root identity.

## Fresh matching-stage2 metrics

| case | modules | source bytes | raw Wasm | gzip-9 | brotli-11 |
|---|---:|---:|---:|---:|---:|
| parser_only | 16 | 377,690 | 236,168 | 61,432 | 43,876 |
| current_checker | 97 | 2,017,911 | 1,001,272 | 251,302 | 163,585 |
| checker_engine_only | 97 | 2,018,003 | 1,001,272 | 251,302 | 163,585 |
| checker_engine_plus_artifacts | 115 | 2,204,751 | 1,107,012 | 265,720 | 171,867 |
| full_compiler | 260 | 5,190,244 | 2,086,429 | 546,444 | 344,872 |

## Validation

- Node syntax check and strict schema tests: 9/9 pass
- both roots compile twice with matching fresh stage2
- repeated collector runs: matching closure/artifact hashes
- fresh stage2 == stage3
- formatter and generated freshness: pass
- independent hard review + follow-up: no P0/P1/P2
- local release-check reached final fixture gate, then hit host `xargs: command line cannot be assembled, too long`; CI is authoritative for the full gate

No compiler ABI, package boundary, manifest entry, cache/reuse policy, or generated source is changed.

Closes the benchmark-boundary portion of #1440.
