### PR TITLE
test(incremental): classify private dependency edits

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -590,6 +590,20 @@ plan with the relational model rows, requires every planned module to appear as
 `rechecked`, and reports additional rechecks as conservative over-invalidation.
 A missing required recheck fails the oracle.
 
+The existing private body case is also emitted under the explicit observation
+classification `private_dependency_edit_externally_unchanged`. That classifier
+fails closed unless `app` has exactly `library` as its sole direct dependency in
+both snapshots, the dependency's source and provisional token-stream
+implementation identities change, its interface-v2 identity does not change,
+and all of the consumer's own observed identities stay unchanged. The
+persistent TypeEnv-v3 transport result for the dependency is reported as a
+separate `changed`/`unchanged` observation rather than being treated as the
+exported interface. The current consumer decision must still be `rechecked` and
+is reported as `conservative_rechecked`; this is a record of current
+conservative behavior, not a new reuse rule. This classifier does not change
+trace schema 6, cache namespace v16, TypeEnv-v3/TDRE3 transport, production
+reuse, or default-gate wiring; it strengthens the existing observation gate's assertions.
+
 For this comparison, `source_fingerprint` is ingestion telemetry only;
 `implementation_fingerprint` is the provisional owner-change trigger. It is
 not normalized typed IR. The shadow planner is independently implemented bridge

--- a/scripts/incremental_invalidation_oracle.mjs
+++ b/scripts/incremental_invalidation_oracle.mjs
@@ -163,9 +163,10 @@ export function compareSuccessfulIncrementalInvalidationTraces(expected, actual)
 }
 
 function moduleByName(trace, name) {
-  const module = trace.modules.find((row) => basename(row.path) === `${name}.vibe`);
-  if (!module) fail(`missing ${name}.vibe module row`);
-  return module;
+  const modules = trace.modules.filter((row) => basename(row.path) === `${name}.vibe`);
+  if (modules.length === 0) fail(`missing ${name}.vibe module row`);
+  if (modules.length !== 1) fail(`ambiguous ${name}.vibe module row`);
+  return modules[0];
 }
 
 function decisionsByName(trace) {
@@ -283,6 +284,81 @@ function ownerNames(paths) {
   return paths.map((path) => basename(path).replace(/\.vibe$/, ""));
 }
 
+/// Classify the bounded library-body edit without promoting any observation to
+/// production policy. The consumer must name exactly the edited dependency in
+/// both snapshots: extra, missing, reordered, or changed edges fail closed.
+/// TypeEnv-v3 transport state is reported independently from interface-v2.
+export function classifyPrivateDependencyEditExternallyUnchanged(before, after, dependencyName, consumerName) {
+  const beforeDependency = moduleByName(before, dependencyName);
+  const afterDependency = moduleByName(after, dependencyName);
+  const beforeConsumer = moduleByName(before, consumerName);
+  const afterConsumer = moduleByName(after, consumerName);
+  if (beforeDependency.path !== afterDependency.path) fail("private dependency path changed across observations");
+  if (beforeConsumer.path !== afterConsumer.path) fail("private dependency consumer path changed across observations");
+
+  const expectedDependencies = [beforeDependency.path];
+  for (const [snapshot, consumer] of [["before", beforeConsumer], ["after", afterConsumer]]) {
+    if (JSON.stringify(consumer.direct_dependencies) !== JSON.stringify(expectedDependencies)) {
+      fail(`private dependency ${snapshot} direct relation was not exactly ${consumerName} -> ${dependencyName}`);
+    }
+  }
+  const requireIdentity = (snapshot, module, field) => {
+    if (typeof module[field] !== "string" || module[field].length === 0) {
+      fail(`private dependency classification missing ${snapshot} ${field}`);
+    }
+  };
+  for (const [snapshot, dependency] of [["before dependency", beforeDependency], ["after dependency", afterDependency]]) {
+    for (const field of ["source_fingerprint", "implementation_fingerprint", "interface_fingerprint", "persistent_type_env_transport_fingerprint"]) {
+      requireIdentity(snapshot, dependency, field);
+    }
+  }
+  if (beforeDependency.source_fingerprint === afterDependency.source_fingerprint) {
+    fail("private dependency edit did not change dependency source identity");
+  }
+  if (beforeDependency.implementation_fingerprint === afterDependency.implementation_fingerprint) {
+    fail("private dependency edit did not change dependency implementation identity");
+  }
+  if (beforeDependency.interface_fingerprint !== afterDependency.interface_fingerprint) {
+    fail("private dependency edit changed dependency interface-v2 identity");
+  }
+
+  const consumerIdentityFields = [
+    "source_fingerprint",
+    "implementation_fingerprint",
+    "interface_fingerprint",
+    "checked_env_fingerprint",
+    "persistent_type_env_transport_fingerprint",
+  ];
+  for (const field of consumerIdentityFields) {
+    requireIdentity("before consumer", beforeConsumer, field);
+    requireIdentity("after consumer", afterConsumer, field);
+    if (beforeConsumer[field] !== afterConsumer[field]) fail(`private dependency edit changed consumer own ${field}`);
+  }
+  if (afterConsumer.decision !== "rechecked") {
+    fail("private dependency edit consumer is no longer conservatively rechecked");
+  }
+
+  return {
+    classification: "private_dependency_edit_externally_unchanged",
+    dependency: dependencyName,
+    consumer: consumerName,
+    direct_dependency_relation: {
+      before: [`${consumerName}->${dependencyName}`],
+      after: [`${consumerName}->${dependencyName}`],
+    },
+    dependency_identity: {
+      source: "changed",
+      implementation_token_stream_v1: "changed",
+      interface_v2: "unchanged",
+    },
+    dependency_type_env_transport_v3: beforeDependency.persistent_type_env_transport_fingerprint === afterDependency.persistent_type_env_transport_fingerprint
+      ? "unchanged"
+      : "changed",
+    consumer_own_identities: Object.fromEntries(consumerIdentityFields.map((field) => [field, "unchanged"])),
+    current_consumer_decision: "conservative_rechecked",
+  };
+}
+
 function checkPlannerCase(name, before, after) {
   const expected = expectedCorpus.get(name);
   if (!expected) fail(`missing formal corpus case ${name}`);
@@ -392,6 +468,12 @@ function run(stage2) {
     if (JSON.stringify(decisionsByName(privateEdit)) !== JSON.stringify({ base: "reused", library: "rechecked", app: "rechecked" })) {
       fail("private edit current decision drift");
     }
+    const privateDependencyClassification = classifyPrivateDependencyEditExternallyUnchanged(
+      commentEdit,
+      privateEdit,
+      "library",
+      "app",
+    );
     plannerCases.private_body_edit = checkPlannerCase("private_body_edit", commentEdit, privateEdit);
 
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
@@ -540,6 +622,7 @@ function run(stage2) {
       model_private_body_typing_invalidated: ["library"],
       current_private_body_rechecked: currentPrivateRechecks,
       conservative_over_invalidation: currentPrivateRechecks.filter((name) => name !== "library"),
+      private_dependency_classification: privateDependencyClassification,
       planner_cases: plannerCases,
       cases: [...traces.keys()],
     }));

--- a/scripts/incremental_invalidation_oracle.test.mjs
+++ b/scripts/incremental_invalidation_oracle.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  classifyPrivateDependencyEditExternallyUnchanged,
   compareObservedInvalidation,
   compareSuccessfulIncrementalInvalidationTraces,
   parseIncrementalInvalidationTrace,
@@ -170,7 +171,7 @@ test("incremental invalidation trace rejects dependencies outside its complete m
   );
 });
 
-function plannerTrace({ source = {}, implementation = {}, iface = {}, deps = {}, rechecked = [] } = {}) {
+function plannerTrace({ source = {}, implementation = {}, iface = {}, checkedEnv = {}, transport = {}, deps = {}, rechecked = [] } = {}) {
   const paths = ["/p/base.vibe", "/p/library.vibe", "/p/app.vibe"];
   const defaultDeps = {
     "/p/base.vibe": [],
@@ -184,6 +185,8 @@ function plannerTrace({ source = {}, implementation = {}, iface = {}, deps = {},
       source_fingerprint: source[path] ?? `source:${path}`,
       implementation_fingerprint: implementation[path] ?? `implementation:${path}`,
       interface_fingerprint: iface[path] ?? `interface:${path}`,
+      checked_env_fingerprint: checkedEnv[path] ?? `checked-env:${path}`,
+      persistent_type_env_transport_fingerprint: transport[path] ?? `persistent-type-env-transport:${path}`,
       decision: rechecked.includes(path) ? "rechecked" : "reused",
     })),
   };
@@ -235,6 +238,66 @@ test("shadow planner keeps implementation edits local and propagates interface e
     rechecked: ["/p/base.vibe", "/p/library.vibe", "/p/app.vibe"],
   });
   assert.deepEqual(planObservedTypingInvalidation(before, removedEdgeAfter), ["/p/base.vibe", "/p/library.vibe", "/p/app.vibe"]);
+});
+
+test("private dependency classifier is explicit, fail-closed, and reports TypeEnv-v3 separately", () => {
+  const before = plannerTrace();
+  const after = plannerTrace({
+    source: { "/p/library.vibe": "source:library:private-edit" },
+    implementation: { "/p/library.vibe": "implementation:library:private-edit" },
+    rechecked: ["/p/library.vibe", "/p/app.vibe"],
+  });
+  assert.deepEqual(classifyPrivateDependencyEditExternallyUnchanged(before, after, "library", "app"), {
+    classification: "private_dependency_edit_externally_unchanged",
+    dependency: "library",
+    consumer: "app",
+    direct_dependency_relation: {
+      before: ["app->library"],
+      after: ["app->library"],
+    },
+    dependency_identity: {
+      source: "changed",
+      implementation_token_stream_v1: "changed",
+      interface_v2: "unchanged",
+    },
+    dependency_type_env_transport_v3: "unchanged",
+    consumer_own_identities: {
+      source_fingerprint: "unchanged",
+      implementation_fingerprint: "unchanged",
+      interface_fingerprint: "unchanged",
+      checked_env_fingerprint: "unchanged",
+      persistent_type_env_transport_fingerprint: "unchanged",
+    },
+    current_consumer_decision: "conservative_rechecked",
+  });
+
+  const transportChanged = structuredClone(after);
+  transportChanged.modules[1].persistent_type_env_transport_fingerprint = "persistent-type-env-transport:library:changed";
+  assert.equal(
+    classifyPrivateDependencyEditExternallyUnchanged(before, transportChanged, "library", "app").dependency_type_env_transport_v3,
+    "changed",
+  );
+
+  const cases = [
+    ["before relation", (left) => { left.modules[2].direct_dependencies = ["/p/base.vibe", "/p/library.vibe"]; }, /before direct relation/],
+    ["after relation", (_, right) => { right.modules[2].direct_dependencies = []; }, /after direct relation/],
+    ["source", (_, right) => { right.modules[1].source_fingerprint = before.modules[1].source_fingerprint; }, /did not change dependency source/],
+    ["implementation", (_, right) => { right.modules[1].implementation_fingerprint = before.modules[1].implementation_fingerprint; }, /did not change dependency implementation/],
+    ["interface", (_, right) => { right.modules[1].interface_fingerprint = "interface:library:changed"; }, /changed dependency interface-v2/],
+    ["consumer identity", (_, right) => { right.modules[2].source_fingerprint = "source:app:changed"; }, /changed consumer own source_fingerprint/],
+    ["missing transport", (_, right) => { delete right.modules[1].persistent_type_env_transport_fingerprint; }, /missing after dependency persistent_type_env_transport_fingerprint/],
+    ["consumer decision", (_, right) => { right.modules[2].decision = "reused"; }, /no longer conservatively rechecked/],
+  ];
+  for (const [name, mutate, pattern] of cases) {
+    const left = structuredClone(before);
+    const right = structuredClone(after);
+    mutate(left, right);
+    assert.throws(
+      () => classifyPrivateDependencyEditExternallyUnchanged(left, right, "library", "app"),
+      pattern,
+      name,
+    );
+  }
 });
 
 test("shadow planner retains dependency-plan owner semantics and rejects under-invalidation", () => {


### PR DESCRIPTION
## Summary

Add an explicit observation-only classifier for a private dependency edit whose exported interface remains unchanged.

The real three-module oracle now fails closed unless it proves:

- the consumer has the exact edited direct dependency before and after
- dependency source and implementation identities changed
- dependency `vibe-module-interface:v2` identity stayed unchanged
- TypeEnv-v3 transport behavior is reported separately rather than conflated with interface identity
- consumer own identities stayed unchanged
- current production behavior remains conservative and rechecks the consumer

This names and locks the proof needed before any later interface-based reuse promotion. It does not alter schema 6, cache v16, TDRE3, cache keys, reuse decisions, or default-gate wiring; it strengthens assertions in the existing observation gate.

## Validation

- focused Node tests: 8/8 pass
- formal corpus check: pass
- fresh stage2 and real three-module oracle: pass
- new assertion executes under existing compiler gate
- independent review: no P0/P1; documentation P2 corrected
- local release-check later hit unrelated macOS `xargs` fixture-fanout limit; CI is authoritative

Progresses #1379.
