### PR TITLE
fix(incremental): harden experimental TDRE4 reuse

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -170,30 +170,37 @@ claim.
 ## Experimental dependency transport-environment typing reuse
 
 `VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE=1` enables a deliberately
-narrow check-only experiment. It aliases a source plus ordered direct-dependency
-**v3 TypeEnv transport** identities to a previously checked TypeEnv, then
-validates and republishes that decoded environment under the
-ordinary conservative fingerprint. It does not use the trace-only
-`vibe-module-interface:v2` observation as a production key, and malformed,
-missing, or stale aliases—including a malformed, truncated, or absent referenced
-TypeEnv—fall back to a full check. The alias is incompatible with the
-incremental invalidation trace lane so the two identities cannot be confused.
+narrow, default-off check-only experiment. TDRE4 aliases the exact logical
+`ModuleJob` checker input to a previously checked TypeEnv: canonical owner path,
+byte-exact owner source, `resolution_env_seed()`, and every `(path, canonical
+TypeEnv-v3 transport text)` row in the full `dep_envs` array in consumed order.
+It does not narrow that table to declared dependencies or replace exact transport
+text with a compact fingerprint. It validates and republishes the decoded
+environment under the ordinary conservative fingerprint. It does not use the
+trace-only `vibe-module-interface:v2` observation as a production key, and
+malformed, missing, stale, torn, or cross-spliced aliases, witnesses, and targets
+fall back to a full check. The alias remains incompatible with the incremental
+invalidation trace lane so the two identities cannot be confused.
 
 The v3 TypeEnv codec round-trips every current `TypeEnv` variant, including
 trait definitions, impls, generic impl bounds, trait-header parameters,
-positional method-generic binders/bounds, and method `TypeExpr` metadata. Its
-TypeEnv cache namespace, `TDRE3` alias envelope, and eligibility-marker
-namespace are all version-bumped, so v1/v2 artifacts cannot be reused. The sidecar is still only an alias to a conservative TypeEnv
-commit, not a `CheckedProgram` or lossless typed-IR transport.
+positional method-generic binders/bounds, and method `TypeExpr` metadata. TDRE4
+keeps that TypeEnv-v3 envelope and production cache namespace v16 unchanged;
+only its experimental alias and eligibility-witness namespaces and `TDRE4A` /
+`TDRE4W` envelopes are new. A sidecar is still only an alias to a conservative
+TypeEnv commit, not a `CheckedProgram` or lossless typed-IR transport.
 
-A marker is published only after that module's v3 TypeEnv commit and when every
-direct dependency already has a validated marker for its conservative
-fingerprint. The transport-input key fingerprints the complete ordered v3
-dependency environments, so a trait or impl dependency edit changes the key and
-fails closed to a full check. The production oracle covers that hidden
-trait/impl-dependency invalidation. Alias publication and reuse require the
-witness chain; absent or malformed markers, sidecars, targets, and envelopes
-fall back to full checking. The gate remains disabled by default.
+A witness is published only after that module's canonical TypeEnv-v3 target and
+when every direct dependency already has a validated witness for its conservative
+fingerprint. Alias and witness both bind the logical input, target conservative
+fingerprint, and exact canonical target text. Reuse reads the raw target,
+strictly decodes it, requires an exact canonical re-encode, and verifies the
+three-way alias/witness/target binding. Publication order is target, witness,
+alias; diagnosed or failed modules publish none of those rows. The production
+oracle covers hidden trait/impl and ambient non-direct `dep_envs` changes,
+valid-but-wrong targets, cross-splicing, missing/malformed/stale entries,
+diagnostic non-publication, and multi-level reuse. The public experimental flag
+and default-off behavior are unchanged.
 
 ## Artifact boundaries
 
@@ -608,8 +615,8 @@ separate `changed`/`unchanged` observation rather than being treated as the
 exported interface. The current consumer decision must still be `rechecked` and
 is reported as `conservative_rechecked`; this is a record of current
 conservative behavior, not a new reuse rule. This classifier does not change
-trace schema 6, cache namespace v16, TypeEnv-v3/TDRE3 transport, production
-reuse, or default-gate wiring; it strengthens the existing observation gate's assertions.
+trace schema 6, cache namespace v16, TypeEnv-v3/TDRE4 transport, production
+artifact reuse, or default-gate wiring; it strengthens the existing observation gate's assertions.
 
 For this comparison, `source_fingerprint` is ingestion telemetry only;
 `implementation_fingerprint` is the provisional owner-change trigger. It is
@@ -684,8 +691,8 @@ ordinary production compile. Because it is a post-compile recollection, the
 sidecar is not an atomic snapshot of the bytes used to produce the wasm; a
 concurrent filesystem or resolution-context change may describe a later
 snapshot. It never changes cache namespace `v16`, artifact
-fingerprints, lookup/store/reuse decisions, interface-v2, TypeEnv-v3, TDRE3,
-or trace schema 6. A separately named shadow fingerprint uses a versioned,
+fingerprints, artifact lookup/store/reuse decisions, interface-v2, TypeEnv-v3,
+TDRE4, or trace schema 6. A separately named shadow fingerprint uses a versioned,
 fixed-order, length-prefixed `vibe-artifact-input-observation:v2` preimage and
 existing compact fingerprint. It is observation-only and is never passed to a
 load/store/database reuse API. This remains neither a normalized implementation

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -96,8 +96,9 @@ export ../../../../lib/@vibe/cache {
 ///    manual knob for pure cache-FORMAT changes that don't change the source hash.
 fn persistent_cache_version_tag() -> String {
   // v16: persistent TypeEnv v3 retains trait method-generic provenance. The
-  // version and TypeEnv namespace bump prevent v1/v2 transport artifacts and
-  // their experimental dependency aliases from being reused.
+  // version and TypeEnv namespace bump prevent v1/v2 transport artifacts from
+  // being reused. TDRE4 hardening remains isolated in its own sidecar/witness
+  // namespaces below and deliberately does not bump this production version.
   // v14 (#1326): artifact entries gained the "VART1" length-validated
   // envelope and atomic tmp+rename publish — a cache FORMAT change. Bumping
   // also orphans artifacts torn by the pre-#1326 isolation bypass (store/load
@@ -142,20 +143,18 @@ export fn persistent_type_env_cache_path(fingerprint: String) -> String {
   cache_persistent_type_env_cache_path(persistent_cache_version_tag(), fingerprint)
 }
 
-/// Experimental typing-input sidecars are deliberately separate from the
-/// TypeEnv artifact namespace. Their key is a versioned v3 dependency transport
-/// environment identity; the referenced TypeEnv remains in its conservative
-/// fingerprint-addressed cache entry.
+/// Experimental TDRE4 typing-input aliases are deliberately separate from the
+/// TypeEnv-v3 artifact namespace and all earlier TDRE namespaces. The referenced
+/// TypeEnv remains in its conservative fingerprint-addressed cache entry.
 export fn persistent_typing_dependency_env_reuse_sidecar_path(typing_input_key: String) -> String {
-  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v3", typing_input_key)
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v4", typing_input_key)
 }
 
-/// A versioned, conservative eligibility witness for the experimental typing
-/// alias lane. It is keyed by the ordinary full module fingerprint. The v2
-/// TypeEnv codec transports trait/impl state, but the marker remains a separate
-/// fail-closed publication witness rather than decoded-cache evidence.
+/// TDRE4 eligibility witnesses are isolated from prior marker formats and keyed
+/// by the ordinary conservative module fingerprint. Their strict envelope also
+/// binds the logical input and exact canonical target TypeEnv-v3 text.
 export fn persistent_typing_dependency_env_reuse_eligibility_path(fingerprint: String) -> String {
-  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v3", fingerprint)
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v4", fingerprint)
 }
 
 export fn persistent_source_list_cache_path(entry_path: String) -> String {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -27,6 +27,8 @@ import @vibe/compiler/core {
   env_bind,
   env_flat_bindings,
   env_lookup_flat,
+  normalize_path,
+  resolution_env_seed,
   resolve_import_path,
   resolve_import_path_candidates,
   str_lt
@@ -1548,48 +1550,14 @@ let parse_memo_paths: Array[String] = [
   Fs::write_file(persistent_type_env_cache_path(fingerprint), persistent_type_env_cache_text(env))
 }
 
-// The sidecar wire format is intentionally independent from the TypeEnv v3
-// envelope: `TDRE3` followed by two strict decimal length-delimited strings
-// (typing-input key, target conservative fingerprint). It is an alias to an
-// existing artifact, never a CheckedProgram or typed-IR transport.
-//
-// TDRE eligibility is a separate, versioned witness keyed by the ordinary
-// conservative module fingerprint. The v3 transport is complete for TypeEnv
-// variants, including trait/impl state, so source exclusion is no longer
-// necessary; publication still requires an already validated witness chain.
-let typing_dependency_env_reuse_eligibility_v3_text = "TDRE-ELIGIBILITY-3"
-
-fn typing_dependency_env_reuse_eligibility_is_valid(fingerprint: String) -> Bool with Fs {
-  let marker_path = persistent_typing_dependency_env_reuse_eligibility_path(fingerprint)
-  if Fs::exists(marker_path) {
-    Fs::read_file(marker_path) == typing_dependency_env_reuse_eligibility_v3_text
-  } else {
-    false
-  }
-}
-
-/// Eligibility is transitively witnessed by successful v3 TypeEnv commits.
-/// The input key below fingerprints those complete direct dependency transports,
-/// including trait definitions and impls; an absent/malformed witness fails
-/// closed before any alias lookup.
-fn typing_dependency_env_reuse_is_eligible(_path: String, _source: String, dep_fps: Array[(String, String)]) -> Bool with Exception + Fs {
-  let mut i = 0
-  let mut deps_eligible = true
-  while deps_eligible && i < Array::length(dep_fps) {
-    let (_dep_path, dep_fingerprint) = Array::get(dep_fps, i)
-    if typing_dependency_env_reuse_eligibility_is_valid(dep_fingerprint) {
-      ()
-    } else {
-      deps_eligible = false
-    }
-    i = i + 1
-  }
-  deps_eligible
-}
-
-fn publish_typing_dependency_env_reuse_eligibility(fingerprint: String) -> Unit with Fs {
-  Fs::write_file(persistent_typing_dependency_env_reuse_eligibility_path(fingerprint), typing_dependency_env_reuse_eligibility_v3_text)
-}
+// TDRE4 is deliberately independent from the TypeEnv v3 envelope and from
+// every production artifact/cache identity. Both v4 envelopes use strict
+// decimal length-delimited fields and bind the logical checker input, target
+// conservative fingerprint, and exact canonical TypeEnv-v3 transport text.
+// The target text is intentionally not replaced by a compact fingerprint:
+// cache corruption must not turn a fingerprint collision into checker reuse.
+let typing_dependency_env_reuse_alias_v4_tag = "TDRE4A"
+let typing_dependency_env_reuse_witness_v4_tag = "TDRE4W"
 
 fn typing_reuse_segment(text: String) -> String {
   String::concat(__to_string(String::length(text)), String::concat(":", text))
@@ -1624,52 +1592,26 @@ fn parse_typing_reuse_segment(text: String, pos: Int) -> Option[(String, Int)] {
   }
 }
 
-fn typing_dependency_transport_input_key(source: String, deps: Array[String], env_cache: Array[(String, TypeEnv)]) -> Option[String] {
-  let out = StringBuilder::new()
-  StringBuilder::push(out, "vibe-typing-dependency-transport-env:v3")
-  StringBuilder::push(out, typing_reuse_segment(source))
-  StringBuilder::push(out, typing_reuse_segment(__to_string(Array::length(deps))))
-  let mut i = 0
-  let mut complete = true
-  while complete && i < Array::length(deps) {
-    let dep_path = Array::get(deps, i)
-    match lookup_env_cache(env_cache, dep_path) {
-      Some(dep_env) => {
-        // This is the exact complete TypeEnv v3 text transported through
-        // persistent_env_codec, not the trace-only module-interface:v2 value.
-        let transport_env_fingerprint = compact_string_fingerprint(persistent_type_env_cache_text(dep_env))
-        StringBuilder::push(out, typing_reuse_segment(dep_path))
-        StringBuilder::push(out, typing_reuse_segment(transport_env_fingerprint))
-      },
-      None => {
-        complete = false
-      }
-    }
-    i = i + 1
-  }
-  if complete {
-    Some(StringBuilder::freeze(out))
-  } else {
-    None
-  }
+fn typing_dependency_reuse_binding_text(tag: String, input_key: String, target_fingerprint: String, target_text: String) -> String {
+  String::concat(tag, String::concat(typing_reuse_segment(input_key), String::concat(typing_reuse_segment(target_fingerprint), typing_reuse_segment(target_text))))
 }
 
-fn typing_dependency_env_reuse_sidecar_text(input_key: String, target_fingerprint: String) -> String {
-  String::concat("TDRE3", String::concat(typing_reuse_segment(input_key), typing_reuse_segment(target_fingerprint)))
-}
-
-fn parse_typing_dependency_env_reuse_sidecar(text: String, expected_input_key: String) -> Option[String] {
-  if !String::starts_with(text, "TDRE3") {
+fn parse_typing_dependency_reuse_binding(text: String, tag: String) -> Option[(String, String, String)] {
+  if !String::starts_with(text, tag) {
     None
   } else {
-    match parse_typing_reuse_segment(text, 5) {
+    match parse_typing_reuse_segment(text, String::length(tag)) {
       Some((input_key, after_input)) =>
       match parse_typing_reuse_segment(text, after_input) {
-        Some((target_fingerprint, end)) =>
-        if input_key == expected_input_key && end == String::length(text) && String::length(target_fingerprint) > 0 {
-          Some(target_fingerprint)
-        } else {
-          None
+        Some((target_fingerprint, after_target)) =>
+        match parse_typing_reuse_segment(text, after_target) {
+          Some((target_text, end)) =>
+          if end == String::length(text) && String::length(input_key) > 0 && String::length(target_fingerprint) > 0 && String::length(target_text) > 0 {
+            Some((input_key, target_fingerprint, target_text))
+          } else {
+            None
+          },
+          None => None
         },
         None => None
       },
@@ -1678,41 +1620,140 @@ fn parse_typing_dependency_env_reuse_sidecar(text: String, expected_input_key: S
   }
 }
 
-fn load_typing_dependency_env_reuse_target(input_key: String) -> Option[(String, TypeEnv)] with Exception + Fs {
-  let sidecar_path = persistent_typing_dependency_env_reuse_sidecar_path(input_key)
-  if !Fs::exists(sidecar_path) {
+/// Exact logical input to check_module: canonical owner path, byte-exact owner
+/// source, resolution authority, and every entry of ModuleJob.dep_envs in its
+/// actual array order. dep_envs is intentionally not narrowed to declared deps:
+/// build_import_env consumes the whole table and first-match shadowing makes
+/// ambient entries and their order checker-visible.
+fn typing_dependency_transport_input_key(path: String, source: String, dep_envs: Array[(String, TypeEnv)]) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, "vibe-typing-dependency-transport-env:v4")
+  StringBuilder::push(out, typing_reuse_segment(normalize_path(path)))
+  StringBuilder::push(out, typing_reuse_segment(source))
+  StringBuilder::push(out, typing_reuse_segment(resolution_env_seed()))
+  StringBuilder::push(out, typing_reuse_segment(__to_string(Array::length(dep_envs))))
+  let mut i = 0
+  while i < Array::length(dep_envs) {
+    let (dep_path, dep_env) = Array::get(dep_envs, i)
+    StringBuilder::push(out, typing_reuse_segment(dep_path))
+    StringBuilder::push(out, typing_reuse_segment(persistent_type_env_cache_text(dep_env)))
+    i = i + 1
+  }
+  StringBuilder::freeze(out)
+}
+
+/// Decode untrusted target bytes strictly and require the decoder's canonical
+/// v3 re-encoding to equal both the raw file and the binding's exact text.
+/// parse_persistent_type_env accepts normalized line endings for ordinary cache
+/// compatibility; this additional equality makes the experimental lane strict.
+fn load_canonical_typing_dependency_env_reuse_target(target_fingerprint: String, expected_target_text: String) -> Option[TypeEnv] with Fs {
+  let target_path = persistent_type_env_cache_path(target_fingerprint)
+  if !Fs::exists(target_path) {
     None
   } else {
-    match parse_typing_dependency_env_reuse_sidecar(Fs::read_file(sidecar_path), input_key) {
-      Some(target_fingerprint) =>
-      if typing_dependency_env_reuse_eligibility_is_valid(target_fingerprint) {
-        // A referenced target is untrusted cache text. Its decoder may throw
-        // for a truncated/malformed row; an alias miss must instead take the
-        // ordinary full-check path.
-        let loaded = handle {
-          load_persistent_type_env(target_fingerprint)
-        } with Exception {
-          Throw(_) => None
-        }
-        match loaded {
-          Some(target_env) => Some((target_fingerprint, target_env)),
+    handle {
+      let raw_target_text = Fs::read_file(target_path)
+      match parse_persistent_type_env(raw_target_text) {
+        Some(target_env) => {
+          let canonical_target_text = persistent_type_env_cache_text(target_env)
+          if raw_target_text == canonical_target_text && raw_target_text == expected_target_text {
+            Some(target_env)
+          } else {
+            None
+          }
+        },
+        None => None
+      }
+    } with Exception {
+      Throw(_) => None
+    }
+  }
+}
+
+fn typing_dependency_env_reuse_witness_binding(fingerprint: String) -> Option[(String, String)] with Fs {
+  let witness_path = persistent_typing_dependency_env_reuse_eligibility_path(fingerprint)
+  if !Fs::exists(witness_path) {
+    None
+  } else {
+    match parse_typing_dependency_reuse_binding(Fs::read_file(witness_path), typing_dependency_env_reuse_witness_v4_tag) {
+      Some((input_key, target_fingerprint, target_text)) =>
+      if target_fingerprint != fingerprint {
+        None
+      } else {
+        match load_canonical_typing_dependency_env_reuse_target(target_fingerprint, target_text) {
+          Some(_) => Some((input_key, target_text)),
           None => None
         }
-      } else {
-        None
       },
       None => None
     }
   }
 }
 
-fn write_typing_dependency_env_reuse_sidecar(source: String, deps: Array[String], env_cache: Array[(String, TypeEnv)], target_fingerprint: String) -> Unit with Fs {
-  match typing_dependency_transport_input_key(source, deps, env_cache) {
-    Some(input_key) => Fs::write_file(persistent_typing_dependency_env_reuse_sidecar_path(input_key), typing_dependency_env_reuse_sidecar_text(input_key, target_fingerprint)),
-    // A missing direct-dependency transport environment is never a partial
-    // key: simply omit the experimental alias and retain conservative reuse.
-    None => ()
+fn typing_dependency_env_reuse_eligibility_is_valid(fingerprint: String) -> Bool with Fs {
+  match typing_dependency_env_reuse_witness_binding(fingerprint) {
+    Some(_) => true,
+    None => false
   }
+}
+
+/// Eligibility is transitively witnessed by successful canonical TypeEnv-v3
+/// commits. Missing, malformed, stale, torn, or cross-spliced witnesses fail
+/// closed before the alias lookup.
+fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> Bool with Fs {
+  let mut i = 0
+  let mut deps_eligible = true
+  while deps_eligible && i < Array::length(dep_fps) {
+    let (_dep_path, dep_fingerprint) = Array::get(dep_fps, i)
+    if typing_dependency_env_reuse_eligibility_is_valid(dep_fingerprint) {
+      ()
+    } else {
+      deps_eligible = false
+    }
+    i = i + 1
+  }
+  deps_eligible
+}
+
+fn publish_typing_dependency_env_reuse_eligibility(input_key: String, fingerprint: String, target_text: String) -> Unit with Fs {
+  let witness_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_witness_v4_tag, input_key, fingerprint, target_text)
+  Fs::write_file(persistent_typing_dependency_env_reuse_eligibility_path(fingerprint), witness_text)
+}
+
+fn load_typing_dependency_env_reuse_target(input_key: String) -> Option[(String, String, TypeEnv)] with Fs {
+  let sidecar_path = persistent_typing_dependency_env_reuse_sidecar_path(input_key)
+  if !Fs::exists(sidecar_path) {
+    None
+  } else {
+    match parse_typing_dependency_reuse_binding(Fs::read_file(sidecar_path), typing_dependency_env_reuse_alias_v4_tag) {
+      Some((alias_input_key, target_fingerprint, target_text)) =>
+      if alias_input_key != input_key {
+        None
+      } else {
+        // Validate the raw target before consulting the separately published
+        // witness. Only an exact three-way alias/witness/target binding reuses.
+        match load_canonical_typing_dependency_env_reuse_target(target_fingerprint, target_text) {
+          Some(target_env) =>
+          match typing_dependency_env_reuse_witness_binding(target_fingerprint) {
+            Some((witness_input_key, witness_target_text)) =>
+            if witness_input_key == input_key && witness_target_text == target_text {
+              Some((target_fingerprint, target_text, target_env))
+            } else {
+              None
+            },
+            None => None
+          },
+          None => None
+        }
+      },
+      None => None
+    }
+  }
+}
+
+fn write_typing_dependency_env_reuse_sidecar(input_key: String, target_fingerprint: String, target_text: String) -> Unit with Fs {
+  let alias_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_alias_v4_tag, input_key, target_fingerprint, target_text)
+  Fs::write_file(persistent_typing_dependency_env_reuse_sidecar_path(input_key), alias_text)
 }
 
 fn write_persistent_dep_list_if_missing(path: String, source: String, deps: Array[String]) -> Unit with Fs {
@@ -2084,13 +2125,15 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
     },
     Checked(path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity) => {
       store_persistent_type_env(fingerprint, checked_env)
-      // The TypeEnv commit comes first. Every direct conservative dependency
-      // marker must already be validated before this module may publish its
-      // witness and alias; each dependency witness was itself published under
-      // that rule, establishing the transitive v3 TypeEnv commit chain.
-      if experimental_typing_dependency_env_reuse_enabled() && typing_dependency_env_reuse_is_eligible(path, job.source, job.dep_fps) {
-        publish_typing_dependency_env_reuse_eligibility(fingerprint)
-        write_typing_dependency_env_reuse_sidecar(job.source, job.deps, job.dep_envs, fingerprint)
+      // Publish in commit order: canonical target first, bound witness second,
+      // alias last. Diagnosed/thrown checks never enter this Checked arm. Keep
+      // the extra canonical target text and input serialization wholly inside
+      // the enabled, transitively eligible experimental lane.
+      if experimental_typing_dependency_env_reuse_enabled() && typing_dependency_env_reuse_is_eligible(job.dep_fps) {
+        let input_key = typing_dependency_transport_input_key(path, job.source, job.dep_envs)
+        let target_text = persistent_type_env_cache_text(checked_env)
+        publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
+        write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
       } else {
         ()
       }
@@ -2348,25 +2391,27 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
     (fingerprint, next_db, env_cache, dep_source_cache, parse_count)
   } else {
     let import_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
-    let reused_env = if experimental_typing_dependency_env_reuse_enabled() && typing_dependency_env_reuse_is_eligible(path, source, dep_fps) {
-      match typing_dependency_transport_input_key(source, deps, import_env_cache) {
-        Some(input_key) => load_typing_dependency_env_reuse_target(input_key),
-        None => None
+    let reused_env = if experimental_typing_dependency_env_reuse_enabled() {
+      if typing_dependency_env_reuse_is_eligible(dep_fps) {
+        let input_key = typing_dependency_transport_input_key(path, source, import_env_cache)
+        match load_typing_dependency_env_reuse_target(input_key) {
+          Some((target_fingerprint, target_text, target_env)) => Some((input_key, target_fingerprint, target_text, target_env)),
+          None => None
+        }
+      } else {
+        None
       }
     } else {
       None
     }
     match reused_env {
-      Some((_target_fingerprint, target_env)) => {
+      Some((input_key, _target_fingerprint, target_text, target_env)) => {
         // Preserve the ordinary conservative fingerprint path for every later
-        // consumer; this only avoids recomputing an already validated typing
-        // result whose dependency transport inputs are identical. The alias is
-        // itself a successful TypeEnv commit, so publish this conservative
-        // fingerprint's transitive eligibility witness afterwards as well;
-        // otherwise a multi-level consumer would correctly fail closed.
+        // consumer. Commit this target first, then its exact bound witness, and
+        // only then the alias, so torn publication always fails closed.
         store_persistent_type_env(fingerprint, target_env)
-        publish_typing_dependency_env_reuse_eligibility(fingerprint)
-        write_typing_dependency_env_reuse_sidecar(source, deps, import_env_cache, fingerprint)
+        publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
+        write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
         let next_env_cache = upsert_env_cache(import_env_cache, path, target_env)
         let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
         (fingerprint, next_db, next_env_cache, dep_source_cache, parse_count)

--- a/lib/@vibe/compiler/tests/persistent_cache_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_cache_test.vibe
@@ -13,7 +13,9 @@ import @vibe/compiler/cache {
   persistent_module_header_cache_path,
   persistent_source_group_cache_path,
   persistent_source_list_cache_path,
-  persistent_type_env_cache_path
+  persistent_type_env_cache_path,
+  persistent_typing_dependency_env_reuse_eligibility_path,
+  persistent_typing_dependency_env_reuse_sidecar_path
 }
 
 import @vibe/core {
@@ -33,6 +35,16 @@ import ../type_db.vibe {
 }
 
 //# Functions
+
+test "TDRE4 cache paths use isolated alias and witness namespaces" {
+  let alias_path = persistent_typing_dependency_env_reuse_sidecar_path("logical-input")
+  let witness_path = persistent_typing_dependency_env_reuse_eligibility_path("conservative-target")
+  assert(String::index_of(alias_path, "selfhost_typing_dependency_env_reuse_v4") >= 0)
+  assert(String::index_of(witness_path, "selfhost_typing_dependency_env_reuse_eligibility_v4") >= 0)
+  assert(alias_path != witness_path)
+  assert(String::index_of(alias_path, "reuse_v3") < 0)
+  assert(String::index_of(witness_path, "eligibility_v3") < 0)
+}
 
 test "source-group compact fingerprint preserves paths and equals full fingerprint" {
   let groups = [

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -167,6 +167,9 @@ test "persistent TypeEnv v3 round-trips every variant and trait payload" {
   let env = codec_fixture()
   let encoded = persistent_type_env_cache_text(env)
   assert(String::starts_with(encoded, "version\t3\nenv\t"))
+  // TDRE4 hardening binds this exact canonical text externally; it does not
+  // change or wrap the production TypeEnv-v3 transport envelope itself.
+  assert(String::index_of(encoded, "TDRE4") < 0)
   match parse_persistent_type_env(encoded) {
     Some(decoded) => {
       assert(persistent_type_env_cache_text(decoded) == encoded)

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -53,6 +53,33 @@ function publicChainEdit(project) {
   writeFileSync(join(project, "leaf.vibe"), "export fn value() -> Int { let ignored = 1\n2 }\nexport fn public_value() -> String { \"seven\" }\n");
 }
 
+function makeAmbientProject(project) {
+  mkdirSync(project, { recursive: true });
+  writeFileSync(join(project, "leaf.vibe"), "export fn used() -> Int { 1 }\nexport fn ambient() -> Int { 2 }\n");
+  writeFileSync(join(project, "middle.vibe"), "import ./leaf.vibe { used }\nexport fn middle() -> Int { used() }\n");
+  writeFileSync(join(project, "app.vibe"), "import ./middle.vibe { middle }\nfn main() -> Int { middle() }\n");
+}
+
+function ambientOnlyTransportEdit(project) {
+  // middle does not import ambient, so its own TypeEnv remains byte-identical;
+  // app nevertheless receives leaf's changed TypeEnv as an ambient dep_env row.
+  writeFileSync(join(project, "leaf.vibe"), "export fn used() -> Int { 1 }\nexport fn ambient() -> String { \"two\" }\n");
+}
+
+function makeOrderProject(project) {
+  mkdirSync(project, { recursive: true });
+  writeFileSync(join(project, "a.vibe"), "export fn value() -> Int { 1 }\n");
+  writeFileSync(join(project, "b.vibe"), "export fn value() -> Int { 2 }\n");
+  // Equal exported spellings are deliberately renamed at import. This keeps
+  // the checker result unambiguous while exercising the ordered environment
+  // table whose first-match semantics protect future shadowing cases.
+  writeFileSync(join(project, "app.vibe"), "import ./a.vibe { value as a_value }\nimport ./b.vibe { value as b_value }\nfn main() -> Int { a_value() + b_value() }\n");
+}
+
+function privateOrderEdit(project) {
+  writeFileSync(join(project, "a.vibe"), "export fn value() -> Int { let ignored = 1\n1 }\n");
+}
+
 function makeTraitProject(project) {
   mkdirSync(project, { recursive: true });
   writeFileSync(join(project, "helper.vibe"), "trait Base\ntrait OtherBase\ntrait Hidden: Base { hidden(Self) -> Int }\nimpl Base for Int\nimpl OtherBase for Int\nimpl Hidden for Int\nexport fn value() -> Int { 1 }\n");
@@ -75,7 +102,7 @@ function traitDependencyEdit(project) {
   writeFileSync(join(project, "helper.vibe"), "trait Base\ntrait OtherBase\ntrait Hidden: Base { changed(Self) -> Int }\nimpl Base for Int\nimpl OtherBase for Int\nimpl Hidden for String\nexport fn value() -> Int { 1 }\n");
 }
 
-function check(stage2, project, cache, gate, name, allowFailure = false) {
+function check(stage2, project, cache, gate, name, allowFailure = false, extraEnv = {}) {
   const out = `${name}.out`;
   const telemetryOut = `${name}.telemetry.json`;
   const result = spawnSync("bash", [join(root, "scripts/run_wasm_vibe_host_runner.sh"), "--invoke", "cli_main", stage2, "app.vibe", out], {
@@ -87,9 +114,13 @@ function check(stage2, project, cache, gate, name, allowFailure = false) {
       VIBE_CHECK_ONLY: "1",
       VIBE_INCREMENTAL_TELEMETRY_OUT: telemetryOut,
       VIBE_IMPORT_ABI: "raw",
-      VIBE_HOME: join(project, `.home-${name}`),
+      // Resolution authority is part of the TDRE4 logical input. Keep it
+      // stable within each scenario; varying it per invocation would correctly
+      // force a full check rather than exercise reuse.
+      VIBE_HOME: join(project, ".home"),
       VIBE_PREOPEN_DIR: project,
       ...(gate ? { VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "1" } : {}),
+      ...extraEnv,
     },
   });
   if (result.status !== 0 && !allowFailure) fail(`${name} failed: ${(result.stderr || result.stdout).trim()}`);
@@ -118,20 +149,80 @@ function parseSegment(text, start) {
   return [text.slice(colon + 1, end), end];
 }
 
-function appSidecar(cache, appSource) {
-  const candidates = readdirSync(cache)
-    .filter((name) => name.startsWith("vibe_selfhost_typing_dependency_env_reuse_v3_"))
+function parseBinding(text, tag) {
+  if (!text.startsWith(tag)) fail(`invalid ${tag} binding marker`);
+  const [input, afterInput] = parseSegment(text, tag.length);
+  const [target, afterTarget] = parseSegment(text, afterInput);
+  const [targetText, end] = parseSegment(text, afterTarget);
+  if (end !== text.length || !input || !target || !targetText) fail(`${tag} binding has trailing or empty data`);
+  return { input, target, targetText };
+}
+
+function bindingFiles(cache, namespace) {
+  return readdirSync(cache)
+    .filter((name) => name.startsWith(`vibe_${namespace}_`))
     .map((name) => join(cache, name));
+}
+
+function appSidecar(cache, appSource) {
+  const candidates = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v4");
   const path = candidates.find((candidate) => {
     const text = readFileSync(candidate, "utf8");
-    return text.startsWith("TDRE3") && text.includes(appSource);
+    return text.startsWith("TDRE4A") && text.includes(appSource);
   });
-  if (!path) fail(`non-vacuous app sidecar missing in ${basename(cache)}`);
-  const text = readFileSync(path, "utf8");
-  const [input, afterInput] = parseSegment(text, 5);
-  const [target, end] = parseSegment(text, afterInput);
-  if (end !== text.length) fail("TDRE sidecar has trailing data");
-  return { path, input, target };
+  if (!path) fail(`non-vacuous TDRE4 app sidecar missing in ${basename(cache)}`);
+  return { path, ...parseBinding(readFileSync(path, "utf8"), "TDRE4A") };
+}
+
+function otherSidecar(cache, target) {
+  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v4")) {
+    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE4A");
+    if (binding.target !== target) return { path, ...binding };
+  }
+  fail("second valid TDRE4 target missing");
+}
+
+function targetWitness(cache, target) {
+  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v4")) {
+    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE4W");
+    if (binding.target === target) return { path, ...binding };
+  }
+  fail(`bound TDRE4 witness missing for ${target}`);
+}
+
+function aliasText(input, target, targetText) {
+  return `TDRE4A${segment(input)}${segment(target)}${segment(targetText)}`;
+}
+
+function witnessText(input, target, targetText) {
+  return `TDRE4W${segment(input)}${segment(target)}${segment(targetText)}`;
+}
+
+const logicalInputTag = "vibe-typing-dependency-transport-env:v4";
+function parseLogicalInput(input) {
+  if (!input.startsWith(logicalInputTag)) fail("TDRE4 logical input tag changed");
+  let cursor = logicalInputTag.length;
+  const fields = [];
+  for (let i = 0; i < 4; i += 1) {
+    const [field, next] = parseSegment(input, cursor);
+    fields.push(field);
+    cursor = next;
+  }
+  const count = Number(fields[3]);
+  if (!Number.isInteger(count) || count < 0) fail("invalid TDRE4 dep_env count");
+  const rows = [];
+  for (let i = 0; i < count; i += 1) {
+    const [path, afterPath] = parseSegment(input, cursor);
+    const [text, afterText] = parseSegment(input, afterPath);
+    rows.push([path, text]);
+    cursor = afterText;
+  }
+  if (cursor !== input.length) fail("TDRE4 logical input has trailing data");
+  return { owner: fields[0], source: fields[1], resolutionSeed: fields[2], rows };
+}
+
+function logicalInputText({ owner, source, resolutionSeed, rows }) {
+  return `${logicalInputTag}${segment(owner)}${segment(source)}${segment(resolutionSeed)}${segment(String(rows.length))}${rows.map(([path, text]) => `${segment(path)}${segment(text)}`).join("")}`;
 }
 
 function compactFingerprint(source) {
@@ -249,7 +340,7 @@ function run(stage2) {
     makeProject(staleProject);
     check(stage2, staleProject, staleCache, true, "stale-target-cold");
     const staleSidecar = appSidecar(staleCache, readFileSync(join(staleProject, "app.vibe"), "utf8"));
-    writeFileSync(staleSidecar.path, `TDRE3${segment(staleSidecar.input)}${segment("stale-conservative-target")}`);
+    writeFileSync(staleSidecar.path, aliasText(staleSidecar.input, "stale-conservative-target", staleSidecar.targetText));
     privateEdit(staleProject);
     const staleTargetFallback = check(stage2, staleProject, staleCache, true, "stale-target-fallback");
     expectCounts("stale referenced target fallback", staleTargetFallback.telemetry, 2, 0);
@@ -263,6 +354,116 @@ function run(stage2) {
     privateEdit(malformedSidecarProject);
     const malformedSidecarFallback = check(stage2, malformedSidecarProject, malformedSidecarCache, true, "malformed-sidecar-fallback");
     expectCounts("malformed sidecar fallback", malformedSidecarFallback.telemetry, 2, 0);
+
+    const validWrongProject = join(work, "valid-wrong-target-project");
+    const validWrongCache = join(work, "valid-wrong-target-cache");
+    makeProject(validWrongProject);
+    check(stage2, validWrongProject, validWrongCache, true, "valid-wrong-target-cold");
+    const validWrongApp = appSidecar(validWrongCache, readFileSync(join(validWrongProject, "app.vibe"), "utf8"));
+    const validWrongOther = otherSidecar(validWrongCache, validWrongApp.target);
+    // All target bytes are independently valid, but the other target's witness
+    // is bound to another logical input. A target-only eligibility marker would
+    // incorrectly accept this coherent-looking wrong-target alias.
+    writeFileSync(validWrongApp.path, aliasText(validWrongApp.input, validWrongOther.target, validWrongOther.targetText));
+    privateEdit(validWrongProject);
+    const validWrongFallback = check(stage2, validWrongProject, validWrongCache, true, "valid-wrong-target-fallback");
+    expectCounts("valid wrong target fallback", validWrongFallback.telemetry, 2, 0);
+
+    const sidecarSpliceProject = join(work, "sidecar-splice-project");
+    const sidecarSpliceCache = join(work, "sidecar-splice-cache");
+    makeProject(sidecarSpliceProject);
+    check(stage2, sidecarSpliceProject, sidecarSpliceCache, true, "sidecar-splice-cold");
+    const sidecarSpliceApp = appSidecar(sidecarSpliceCache, readFileSync(join(sidecarSpliceProject, "app.vibe"), "utf8"));
+    const sidecarSpliceOther = otherSidecar(sidecarSpliceCache, sidecarSpliceApp.target);
+    writeFileSync(sidecarSpliceApp.path, readFileSync(sidecarSpliceOther.path, "utf8"));
+    privateEdit(sidecarSpliceProject);
+    const sidecarSpliceFallback = check(stage2, sidecarSpliceProject, sidecarSpliceCache, true, "sidecar-splice-fallback");
+    expectCounts("cross-spliced sidecar fallback", sidecarSpliceFallback.telemetry, 2, 0);
+
+    const witnessSpliceProject = join(work, "witness-splice-project");
+    const witnessSpliceCache = join(work, "witness-splice-cache");
+    makeProject(witnessSpliceProject);
+    check(stage2, witnessSpliceProject, witnessSpliceCache, true, "witness-splice-cold");
+    const witnessSpliceApp = appSidecar(witnessSpliceCache, readFileSync(join(witnessSpliceProject, "app.vibe"), "utf8"));
+    const witnessSpliceOther = otherSidecar(witnessSpliceCache, witnessSpliceApp.target);
+    const witnessSpliceWitness = targetWitness(witnessSpliceCache, witnessSpliceApp.target);
+    writeFileSync(witnessSpliceWitness.path, witnessText(witnessSpliceApp.input, witnessSpliceApp.target, witnessSpliceOther.targetText));
+    privateEdit(witnessSpliceProject);
+    const witnessSpliceFallback = check(stage2, witnessSpliceProject, witnessSpliceCache, true, "witness-splice-fallback");
+    expectCounts("cross-spliced witness fallback", witnessSpliceFallback.telemetry, 2, 0);
+
+    const targetSpliceProject = join(work, "target-splice-project");
+    const targetSpliceCache = join(work, "target-splice-cache");
+    makeProject(targetSpliceProject);
+    check(stage2, targetSpliceProject, targetSpliceCache, true, "target-splice-cold");
+    const targetSpliceApp = appSidecar(targetSpliceCache, readFileSync(join(targetSpliceProject, "app.vibe"), "utf8"));
+    const targetSpliceOther = otherSidecar(targetSpliceCache, targetSpliceApp.target);
+    writeFileSync(referencedAppTargetEnv(stage2, targetSpliceCache, targetSpliceApp.target), targetSpliceOther.targetText);
+    privateEdit(targetSpliceProject);
+    const targetSpliceFallback = check(stage2, targetSpliceProject, targetSpliceCache, true, "target-splice-fallback");
+    expectCounts("cross-spliced target fallback", targetSpliceFallback.telemetry, 2, 0);
+
+    const missingWitnessProject = join(work, "missing-witness-project");
+    const missingWitnessCache = join(work, "missing-witness-cache");
+    makeProject(missingWitnessProject);
+    check(stage2, missingWitnessProject, missingWitnessCache, true, "missing-witness-cold");
+    const missingWitnessApp = appSidecar(missingWitnessCache, readFileSync(join(missingWitnessProject, "app.vibe"), "utf8"));
+    rmSync(targetWitness(missingWitnessCache, missingWitnessApp.target).path);
+    privateEdit(missingWitnessProject);
+    const missingWitnessFallback = check(stage2, missingWitnessProject, missingWitnessCache, true, "missing-witness-fallback");
+    expectCounts("missing witness fallback", missingWitnessFallback.telemetry, 2, 0);
+
+    const malformedWitnessProject = join(work, "malformed-witness-project");
+    const malformedWitnessCache = join(work, "malformed-witness-cache");
+    makeProject(malformedWitnessProject);
+    check(stage2, malformedWitnessProject, malformedWitnessCache, true, "malformed-witness-cold");
+    const malformedWitnessApp = appSidecar(malformedWitnessCache, readFileSync(join(malformedWitnessProject, "app.vibe"), "utf8"));
+    writeFileSync(targetWitness(malformedWitnessCache, malformedWitnessApp.target).path, "TDRE4W1:x");
+    privateEdit(malformedWitnessProject);
+    const malformedWitnessFallback = check(stage2, malformedWitnessProject, malformedWitnessCache, true, "malformed-witness-fallback");
+    expectCounts("malformed witness fallback", malformedWitnessFallback.telemetry, 2, 0);
+
+    const ambientProject = join(work, "ambient-dep-env-project");
+    const ambientCache = join(work, "ambient-dep-env-cache");
+    makeAmbientProject(ambientProject);
+    const ambientCold = check(stage2, ambientProject, ambientCache, true, "ambient-cold");
+    expectCounts("ambient cold", ambientCold.telemetry, 3, 0, 3);
+    ambientOnlyTransportEdit(ambientProject);
+    const ambientFallback = check(stage2, ambientProject, ambientCache, true, "ambient-change-fallback");
+    expectCounts("ambient non-direct dep_env change fallback", ambientFallback.telemetry, 3, 0, 3);
+
+    const resolutionProject = join(work, "resolution-seed-project");
+    const resolutionCache = join(work, "resolution-seed-cache");
+    makeProject(resolutionProject);
+    check(stage2, resolutionProject, resolutionCache, true, "resolution-cold");
+    privateEdit(resolutionProject);
+    const resolutionFallback = check(stage2, resolutionProject, resolutionCache, true, "resolution-change-fallback", false, {
+      VIBE_HOME: join(resolutionProject, ".other-home"),
+    });
+    expectCounts("resolution_env_seed change fallback", resolutionFallback.telemetry, 2, 0);
+
+    const orderProject = join(work, "dep-env-order-project");
+    const orderCache = join(work, "dep-env-order-cache");
+    makeOrderProject(orderProject);
+    const orderCold = check(stage2, orderProject, orderCache, true, "order-cold");
+    expectCounts("dep_env order cold", orderCold.telemetry, 3, 0, 3);
+    const orderApp = appSidecar(orderCache, readFileSync(join(orderProject, "app.vibe"), "utf8"));
+    const parsedOrderInput = parseLogicalInput(orderApp.input);
+    const orderPaths = parsedOrderInput.rows.map(([path]) => basename(path)).sort();
+    if (parsedOrderInput.rows.length !== 2 || orderPaths[0] !== "a.vibe" || orderPaths[1] !== "b.vibe") {
+      fail("TDRE4 app logical input omitted exact dep_env rows");
+    }
+    const swappedOrderInput = logicalInputText({
+      ...parsedOrderInput,
+      rows: [parsedOrderInput.rows[1], parsedOrderInput.rows[0]],
+    });
+    // Keep the sidecar at the correct key path but cross-splice a binding whose
+    // two valid same-spelling dependency rows are reversed. Order-blind parsing
+    // would accept the wrong witness/alias relationship.
+    writeFileSync(orderApp.path, aliasText(swappedOrderInput, orderApp.target, orderApp.targetText));
+    privateOrderEdit(orderProject);
+    const orderFallback = check(stage2, orderProject, orderCache, true, "order-change-fallback");
+    expectCounts("dep_env order/shadow fallback", orderFallback.telemetry, 2, 1, 3);
 
     const traitProject = join(work, "trait-project");
     const traitCache = join(work, "trait-cache");
@@ -304,6 +505,18 @@ function run(stage2) {
     if (diagnosticOff.status === 0 || diagnosticOn.status === 0) fail("diagnostic scenario unexpectedly succeeded");
     if (diagnosticOff.output !== diagnosticOn.output) fail("diagnostic gate-off/on output mismatch");
 
+    const noPublishProject = join(work, "diagnostic-no-publish-project");
+    const noPublishCache = join(work, "diagnostic-no-publish-cache");
+    makeProject(noPublishProject);
+    const failingSource = "import ./helper.vibe { value }\nfn main() -> Int { missing_name }\n";
+    writeFileSync(join(noPublishProject, "app.vibe"), failingSource);
+    const noPublish = check(stage2, noPublishProject, noPublishCache, true, "diagnostic-no-publish", true);
+    if (noPublish.status === 0) fail("diagnostic no-publish scenario unexpectedly succeeded");
+    const noPublishAliases = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_v4");
+    const noPublishWitnesses = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_eligibility_v4");
+    if (noPublishAliases.length !== 1 || noPublishWitnesses.length !== 1) fail("diagnosed module published TDRE4 alias or witness");
+    if (noPublishAliases.some((path) => readFileSync(path, "utf8").includes(failingSource))) fail("diagnosed owner source appeared in TDRE4 alias");
+
     console.log(JSON.stringify({
       schema: 1,
       scenario: "experimental-typing-dependency-transport-env-reuse",
@@ -313,6 +526,20 @@ function run(stage2) {
       missing_target_fallback: missingTargetFallback.telemetry,
       stale_target_fallback: staleTargetFallback.telemetry,
       malformed_sidecar_fallback: malformedSidecarFallback.telemetry,
+      valid_wrong_target_fallback: validWrongFallback.telemetry,
+      cross_splice_fallbacks: {
+        sidecar: sidecarSpliceFallback.telemetry,
+        witness: witnessSpliceFallback.telemetry,
+        target: targetSpliceFallback.telemetry,
+      },
+      witness_fallbacks: {
+        missing: missingWitnessFallback.telemetry,
+        malformed: malformedWitnessFallback.telemetry,
+      },
+      ambient_non_direct_dep_env_change_fallback: ambientFallback.telemetry,
+      resolution_env_seed_change_fallback: resolutionFallback.telemetry,
+      dep_env_order_shadow_fallback: orderFallback.telemetry,
+      diagnostics_publish_nothing: true,
       trait_graph: {
         private_body_reuse: traitPrivate.telemetry,
         supertrait_change_fallback: supertraitFallback.telemetry,


### PR DESCRIPTION
## Summary

Harden the existing default-off typing dependency environment reuse experiment as TDRE4 before any production-default decision.

TDRE4 now:

- stays opt-in and leaves global persistent cache version at `v16`
- uses isolated v4 alias/witness namespaces and markers
- keys the exact checker input: canonical owner path, exact owner source, resolution seed, and every actual `ModuleJob.dep_envs` `(path, canonical TypeEnv-v3 text)` row in order
- binds alias and eligibility witness to both the conservative target fingerprint and exact canonical target TypeEnv-v3 text
- loads raw target text, requires strict decode plus exact canonical re-encode equality, and verifies sidecar/witness/target binding
- publishes target → witness → alias; diagnosed/failed modules publish nothing
- fails closed to full checking on malformed, stale, torn, valid-but-wrong, ambient-input-changed, or cross-spliced state
- remains incompatible with the schema-v6 observation trace lane

This reuses only an exact `TypeEnv`; it does not claim `CheckedProgram`, typed IR, diagnostics, codegen, or linked-artifact reuse. Interface-v2 remains observation-only.

## Validation

- hardened TDRE4 real oracle: pass
- valid-wrong-target and ambient non-direct input adversaries: pass/fallback
- 526/526 unit files: pass
- generated freshness and fresh stage2 == stage3: pass
- independent hard correctness review: no P0/P1/P2
- local release-check reached final fixture gate, then hit host macOS `xargs` command-length failure; CI is authoritative

No default flip or cache-v17 migration is included. A later independent PR may consider default-on only after this format has passed CI and production-path equivalence evidence.

Progresses #1379.
