### PR TITLE
fix(ci): use wasm feature wrapper for selfcompile KPI

### DIFF
--- a/scripts/selfcompile_kpi.sh
+++ b/scripts/selfcompile_kpi.sh
@@ -49,7 +49,7 @@ mkdir -p "$CACHE_DIR"
 start_ns=$(date +%s%N)
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   VIBE_WASM_MEMORY_STATS=1 VIBE_BUILD_CACHE_DIR="$CACHE_DIR" \
-  node scripts/wasm_vibe_host_runner.js --invoke cli_main "$STAGE2" \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" \
   "$INPUT" "$OUT_WASM" __no_entry__ 2>"$STATS_FILE"
 end_ns=$(date +%s%N)
 wall_ms=$(( (end_ns - start_ns) / 1000000 ))


### PR DESCRIPTION
## Summary

Route `selfcompile_kpi.sh` through the existing `run_wasm_vibe_host_runner.sh` feature-probing wrapper instead of invoking Node directly.

After #1472 canonicalized `Exception`, freshly built stage2 uses Wasm exnref. The direct Node invocation fails before KPI output with `Invalid opcode 0x1f`; the wrapper already probes and supplies `--experimental-wasm-exnref` on runtimes that require it and omits graduated/unsupported flags.

This also restores `bench_metrics.sh`, which consumes the selfcompile KPI.

## Validation

- reproduced failure on current main stage2 with direct Node
- wrapper-backed KPI passes: `heap_ptr_bytes=1109835200`, under the existing +10% gate
- no compiler/runtime behavior change