### PR TITLE
#1458: effect 分類に `runtime` を追加し、operation の二トラック命名則を明文化する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,18 @@ CI shard では:
   `///` の「直後の1宣言に対応する doc」という意味論とは食い違う) ため、
   一括置換はしていない — 使い分けは書く場所ごとに判断すること。
 - variables/functions は snake_case (lowercase only)
+- **effect 名と代数 effect の operation は CamelCase** (#1458)。operation が
+  snake_case でないのは、effect が**代数レコードを発行している**からで、
+  `Log::Emit` は関数ではなく constructor に当たる。一方 capability builtin
+  (`Fs::read_file` / `Env::get` / `Console::write_stream`) は本当に関数なので
+  `Effect::snake_case`。この二トラックは揺れではなく用途の違いで、
+  `perform` が要るかどうかで見分けられる。分類の表と使い分けは
+  [docs/cheatsheet.md](docs/cheatsheet.md) の "Effect classes and how
+  operations are spelled" と ADR-0084
+  ([docs/effect-taxonomy-entry-policy.md](docs/effect-taxonomy-entry-policy.md))。
+- **言語ポリシー: コアロジック以外は、できるだけ「色のない関数」で書けるように
+  する** — 権限は row が運び、呼び出し側の式は素の関数呼び出しのままにする
+  (capability builtin がその形)。
 
 ## Code Navigation (IMPORTANT)
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -582,6 +582,55 @@ syntax — which is why they survived #1429 while the `hint:` line, being
 something you paste into your code, moved to the braceless spelling with
 everything else.
 
+### Effect classes and how operations are spelled (#1458)
+
+Effects fall into four classes (ADR-0084 + #1458; the table lives in
+`lib/@vibe/compiler/core/effect_taxonomy.vibe`, which is the single definition
+the checker and `wit_gen` both read):
+
+| class | who discharges it | varies with grants | members |
+|---|---|---|---|
+| capability | host / provider, outside the wasm boundary | yes | `Fs` `Http` `Socket` `Env` `Console` `Stdin` `Stdout` `Stderr` `Process` `Profiler` `Llm` |
+| algebraic | a `handle` inside your program | n/a | `Log` `State` `Ask` … — anything not in the table |
+| core ambient | nobody; the entry boundary turns it into a diagnosed failure | n/a | `Exception[E]` (`Error` is a migration alias) |
+| runtime | the runtime itself | n/a | `Async` |
+
+**Naming.** Effect NAMES are CamelCase, without exception. Operations come in
+two spellings, and which one you see tells you which track you are on:
+
+```vibe
+// Track A -- capability builtin: `Effect::snake_case`, called as a plain
+// function. No `perform`. The row carries the effect label.
+fn read_config() -> String with Fs {
+  Fs::read_file("config.toml")
+}
+
+// Track B -- algebraic effect operation: CamelCase, performed and handled.
+effect Log {
+  Emit(String) -> Unit
+}
+
+fn greet() -> Unit with Log {
+  perform Log::Emit("hi")
+}
+```
+
+Operations are CamelCase because an effect performs an **algebraic record**:
+`Log::Emit` is a constructor, not a function, so it follows the constructor
+convention rather than the `snake_case` rule that governs variables and
+functions. Capability builtins are the other way round — they really are
+functions (that is the point: outside your core logic, code should read as
+**colourless functions** and let the row carry the colour), so they are
+`snake_case`.
+
+`Fs`, `Env` and `Profiler` currently carry BOTH tracks — `perform Fs::ReadFile(p)`
+against `lib/@vibe/fs/fs_effect.vibe`, and `Fs::read_file(p)` against the
+builtin registry — under the same row label `Fs`. That coexistence is
+deliberate and stays: use the builtin when you just want the operation done,
+and the declared effect when you want to intercept it with a `handle`.
+Collapsing the two into one spelling is possible but has not been decided
+(#1458 item 3).
+
 ### Failure-carrying pipeline
 
 > **推奨は `throw` + `Exception[E]` row** (ADR-0085 / #1324)。失敗は返り値では

--- a/docs/effect-taxonomy-entry-policy.md
+++ b/docs/effect-taxonomy-entry-policy.md
@@ -21,7 +21,14 @@ contract は満たせない。反対に `Fs` のような capability を `main` 
 
 ## Decision
 
-effect operation を、次の三分類で扱う。
+effect operation を、次の四分類で扱う（`runtime effect` は #1458 の追加）。
+
+| 分類 | 誰が discharge するか | 許諾で揺れるか | メンバー |
+|---|---|---|---|
+| **capability effect** | host / provider (wasm 境界の外) | 揺れる | Fs, Http, Socket, Env, Console, Stdin, Stdout, Stderr, Process, Profiler, Llm |
+| **algebraic effect** | プログラム内の `handle` | 無関係 | Log, State, Ask, ParseRecur, … (表に無い名前はすべてここ) |
+| **core ambient effect** | 誰も discharge しない (entry が abortive に処理する) | 無関係 | Exception[E] / Error |
+| **runtime effect** | runtime そのもの | 無関係 | Async |
 
 1. **capability effect** は resource kind parameter を持つ effect である。
    host/provider が binding を解決し、residual WIT contract に投影する。例えば
@@ -30,13 +37,28 @@ effect operation を、次の三分類で扱う。
    である。これは in-process の handler/DI 用であり、`.vibex` の `main` に
    到達する前に `handle` で discharge しなければならない。
 3. **core ambient effect** は言語予約の少数の effect である。ADR-0085 の
-   typed `Exception[E]`（移行中は checked `Error`）が該当する。これは entry
+   typed `Exception[E]`（`Error` は移行中の alias）が該当する。これは entry
    boundary の runtime handler が diagnosed failure へ変換するため、`main` の
    row に残ることを許可する。
+4. **runtime effect** (#1458) は runtime が駆動する effect である。今日の
+   唯一のメンバーは `Async` で、ADR-0089 Decision 5 のとおり **backend の
+   選択であって権限ではない**。`main` の row に残ることを許可する。
 
-`.vibex` の `main` の残余 row は capability effect と core ambient effect
-だけを含めてよい。row に algebraic effect が残るプログラムは、WIT 生成や
-host preflight の前に型エラーとする。これは通常の関数の row を制限しない。
+   core ambient と分けたのは分類の正確さのためだけではない。両者は「row を
+   素通りする」点では同じだが、**理由が逆**である — core ambient は誰も
+   discharge しないから残ってよく、runtime は runtime が discharge するから
+   残ってよい。`Async` を core ambient に混ぜていた間、checker と wit_gen の
+   両方に「`Error` と `Async` は同じ理由でここに居る」と読めるコメントが
+   書かれていた。
+
+   実装上、「権限として数えない」ことだけを見たい呼び出し側 (checker の
+   `builtin_call_effect`、wit_gen の world import 収集) は、二クラスの和を
+   取る `is_row_transparent_effect` を使う。
+
+`.vibex` の `main` の残余 row は capability effect・core ambient effect・
+runtime effect を含めてよい。row に algebraic effect が残るプログラムは、
+WIT 生成や host preflight の前に型エラーとする。これは通常の関数の row を
+制限しない。
 
 既存 builtin の source compatibility は保つ。Phase 1 では、既存の
 `with Fs` と `Fs::read_file(...)` を暗黙 singleton resource
@@ -53,7 +75,7 @@ Phase 2 以降の追加であり、この ADR では構文を決めない。
   既存ソースの一括変更や bootstrap bump は不要である。
 - `Fs` / `Env` / `Process` / `Stdout` / `HttpServer` の resource-kind
   retrofit が完了するまでは、この entry row 検査を有効化しない。現在の
-  string-label checker だけでは三分類を表現できないためである。
+  string-label checker だけでは分類を表現できないためである。
 
 ## Non-goals
 

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -16,10 +16,10 @@ import @vibe/compiler/core {
   exception_label_kind,
   exception_throw_label_for_kind,
   expr_children,
-  is_core_ambient_effect,
   is_exception_effect_name,
   is_exception_label,
   is_exception_throw_operation,
+  is_row_transparent_effect,
   test_bench_ambient_effects,
   type_name_has_async_iterator_impl
 }
@@ -1134,7 +1134,7 @@ fn builtin_call_effect(name: String) -> Option[String] {
         // ADR-0084 の core ambient — この二項判定は
         // core/effect_taxonomy.vibe の `is_core_ambient_effect` が唯一の
         // 定義になった。
-        CtFn(_, _, Some(eff)) => if is_core_ambient_effect(eff) {
+        CtFn(_, _, Some(eff)) => if is_row_transparent_effect(eff) {
           None
         } else {
           Some(eff)

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -53,10 +53,13 @@ export ./effect_taxonomy.vibe {
   effect_class_algebraic,
   effect_class_capability,
   effect_class_core_ambient,
+  effect_class_runtime,
   effect_default_resource_kind,
   entry_cache_safe_effects,
   is_capability_effect,
   is_core_ambient_effect,
+  is_row_transparent_effect,
+  is_runtime_effect,
   taxonomy_effect_names,
   test_bench_ambient_effects
 }

--- a/lib/@vibe/compiler/core/effect_taxonomy.vibe
+++ b/lib/@vibe/compiler/core/effect_taxonomy.vibe
@@ -71,9 +71,22 @@ export fn effect_class_algebraic() -> String {
   "algebraic"
 }
 
-/// 言語予約。main の row を素通りできる (`Error` / `Exception[E]` / `Async`)。
+/// 言語予約。main の row を素通りできる (`Error` / `Exception[E]`)。
 export fn effect_class_core_ambient() -> String {
   "core_ambient"
+}
+
+/// #1458: runtime が駆動する effect。放電不要で grant でも揺れない点は
+/// core ambient と同じだが、**理由が違う** — core ambient は「entry が
+/// abortive に処理するので誰も discharge しない」、runtime は「runtime
+/// そのものが discharge する」。今日の唯一のメンバーは `Async`
+/// (ADR-0089 Decision 5: backend の選択であって権限ではない)。
+///
+/// 分けたのは分類の正確さのためだけではない。`Async` を core ambient に
+/// 混ぜていた間、checker と wit_gen の両方に「`Error` と `Async` は同じ
+/// 理由でここに居る」と読めるコメントが書かれていた。実際の理由は違う。
+export fn effect_class_runtime() -> String {
+  "runtime"
 }
 
 //# The table
@@ -164,9 +177,13 @@ let effect_taxonomy_rows: Array[(String, String, String, Bool, Bool)] = [
   // (契約適合検査は row を逐語比較する)。両方の綴りを載せておけば
   // canonical がどちらであっても問いが消える — 費用は配列 1 要素。
   ("Exception", "core_ambient", "", true, true),
+  // --- runtime (#1458) ---
+  //
   // ADR-0089: `Async` は backend 選択であって権限ではない。合成であり
-  // host 非決定性の源そのものではないので cache-safe。
-  ("Async", "core_ambient", "", false, true)
+  // host 非決定性の源そのものではないので cache-safe。#1458 で core ambient
+  // から分離した — row を素通りする点は同じだが、`Error` が「誰も
+  // discharge しない」のに対し `Async` は「runtime が discharge する」。
+  ("Async", "runtime", "", false, true)
 ]
 
 //# Lookups
@@ -229,13 +246,33 @@ export fn effect_class(label: String) -> String {
   }
 }
 
-/// `Error` / `Exception[K]` / `Async` — main の row を素通りでき、
-/// 権限としては数えない effect。
+/// `Error` / `Exception[K]` — entry が abortive に処理するので誰も
+/// discharge しない effect。
 ///
-/// 吸収前は `is_exception_effect_name(x) || x == "Async"` という二項判定が
-/// checker_effects.vibe と wit_gen.vibe に別々に書かれていた。
+/// #1458 で `Async` はここから外れて `runtime` になった。両方をまとめて
+/// 見たい呼び出し側は `is_row_transparent_effect` を使うこと。
 export fn is_core_ambient_effect(label: String) -> Bool {
   effect_class(label) == "core_ambient"
+}
+
+/// `Async` — runtime が discharge する effect (#1458)。
+export fn is_runtime_effect(label: String) -> Bool {
+  effect_class(label) == "runtime"
+}
+
+/// row を素通りする二クラス (core ambient + runtime) のどちらかか。
+///
+/// **これが実際の呼び出し側が欲しい述語**。checker_effects.vibe の
+/// `builtin_call_effect` (要求 row に載せない) と wit_gen.vibe (world import
+/// にしない) は、どちらも「権限として数えない」ことだけを見ており、
+/// discharge するのが誰かは問うていない。吸収前は
+/// `is_exception_effect_name(x) || x == "Async"` という二項判定が両方に
+/// 別々に書かれていて、#1343 でいったん `is_core_ambient_effect` に寄せた
+/// もの — #1458 でクラスが二つに割れたので、**述語のほうを二クラスの和に
+/// する**。呼び出し側の挙動は不変。
+export fn is_row_transparent_effect(label: String) -> Bool {
+  let class = effect_class(label)
+  class == "core_ambient" || class == "runtime"
 }
 
 /// host provider が実装する権限 effect か。

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -144,7 +144,10 @@ fn effect_class(label: String) -> String
 fn effect_class_capability() -> String
 fn effect_class_algebraic() -> String
 fn effect_class_core_ambient() -> String
+fn effect_class_runtime() -> String
 fn is_core_ambient_effect(label: String) -> Bool
+fn is_runtime_effect(label: String) -> Bool
+fn is_row_transparent_effect(label: String) -> Bool
 fn is_capability_effect(label: String) -> Bool
 fn effect_default_resource_kind(label: String) -> String
 fn process_root_resource_kind() -> String

--- a/lib/@vibe/compiler/tests/effect_taxonomy_test.vibe
+++ b/lib/@vibe/compiler/tests/effect_taxonomy_test.vibe
@@ -1,6 +1,7 @@
 //# Imports
 
-// #1343 / ADR-0094 実装順 1: ADR-0084 の三分類 metadata
+// #1343 / ADR-0094 実装順 1: ADR-0084 の分類 metadata (#1458 で
+// `runtime` が加わり四分類)
 // (lib/@vibe/compiler/core/effect_taxonomy.vibe) と、そこから派生する二つの
 // リストのロック。
 //
@@ -14,10 +15,13 @@ import @vibe/compiler/core {
   effect_class_algebraic,
   effect_class_capability,
   effect_class_core_ambient,
+  effect_class_runtime,
   effect_default_resource_kind,
   entry_cache_safe_effects,
   is_capability_effect,
   is_core_ambient_effect,
+  is_row_transparent_effect,
+  is_runtime_effect,
   is_singleton_resource_kind,
   predeclared_resources,
   process_root_resource_kind,
@@ -57,9 +61,36 @@ test "effect_class: core ambient" {
   assert_eq(effect_class("Exception[IoError]"), "core_ambient")
   assert_eq(effect_class("Error::Throw"), "core_ambient")
   assert_eq(effect_class("Exception[IoError]::Throw"), "core_ambient")
-  assert_eq(effect_class("Async"), "core_ambient")
-  assert(is_core_ambient_effect("Async"))
   assert(not(is_core_ambient_effect("Fs")))
+  // #1458: `Async` は第四カテゴリへ移った。core ambient ではない。
+  assert(not(is_core_ambient_effect("Async")))
+}
+
+test "effect_class: runtime (#1458)" {
+  // 第四カテゴリ。row を素通りする点は core ambient と同じだが、
+  // discharge するのは runtime であって「誰も discharge しない」ではない。
+  // 今日の唯一のメンバー。
+  assert_eq(effect_class("Async"), "runtime")
+  assert_eq(effect_class_runtime(), effect_class("Async"))
+  assert(is_runtime_effect("Async"))
+  assert(not(is_runtime_effect("Error")))
+  assert(not(is_runtime_effect("Fs")))
+  assert(not(is_runtime_effect("Ask")))
+}
+
+test "#1458: row-transparent is the union the call sites actually want" {
+  // checker_effects の builtin_call_effect と wit_gen は「権限として数えない
+  // か」だけを見ており、discharge するのが誰かは問うていない。#1458 で
+  // クラスが二つに割れたので、その二つの和がこの述語。両方の呼び出し側の
+  // 挙動が不変であることは、この和が分割前の core_ambient と一致すること
+  // で担保される。
+  assert(is_row_transparent_effect("Error"))
+  assert(is_row_transparent_effect("Exception"))
+  assert(is_row_transparent_effect("Exception[IoError]"))
+  assert(is_row_transparent_effect("Async"))
+  assert(not(is_row_transparent_effect("Fs")))
+  assert(not(is_row_transparent_effect("Console")))
+  assert(not(is_row_transparent_effect("Ask")))
 }
 
 test "effect_class: unknown labels are algebraic" {
@@ -84,7 +115,8 @@ test "effect_class: operation and instantiation labels reduce to the effect" {
 
 test "class name accessors match effect_class output" {
   assert_eq(effect_class_capability(), effect_class("Fs"))
-  assert_eq(effect_class_core_ambient(), effect_class("Async"))
+  assert_eq(effect_class_core_ambient(), effect_class("Error"))
+  assert_eq(effect_class_runtime(), effect_class("Async"))
   assert_eq(effect_class_algebraic(), effect_class("Ask"))
 }
 
@@ -123,13 +155,14 @@ test "only the tty capability is cache-safe" {
     if is_capability_effect(name) {
       assert(name == "Stdout" || name == "Console")
     } else {
-      assert(is_core_ambient_effect(name))
+      // #1458: 非 capability 側は core ambient と runtime (`Async`) の二つ。
+      assert(is_row_transparent_effect(name))
     }
     i = i + 1
   }
 }
 
-test "capabilities carry a default resource kind, core ambient does not" {
+test "capabilities carry a default resource kind, the others do not" {
   // ADR-0094 Decision 5 の受け皿。`resource` 宣言 (ADR-0075 Phase 2) が
   // 未実装なので `Process::Root` はまだ検査には使われていないが、列が
   // 空になっていないことは pin しておく。

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Stmt, TypeExpr, is_core_ambient_effect, is_exception_effect_name
+  Expr, Stmt, TypeExpr, is_exception_effect_name, is_row_transparent_effect
 }
 
 import @vibe/core {
@@ -568,24 +568,26 @@ export fn wit_from_program(export_stmts: Array[Stmt], effect_stmts: Array[Stmt],
         let mut ri = 0
         while ri < Array::length(resolved) {
           let rname = Array::get(resolved, ri)
-          // ADR-0084's CORE AMBIENT class never becomes a world import:
-          // `Error`/`Exception[K]` are vibe-internal control flow (an
-          // escaping throw is a component trap, not a capability), and
-          // `Async` is THE builtin suspension effect (ADR-0089 Decision 5,
-          // #1218) -- it surfaces as the export's `async func` lifting mode
-          // (even when the program carries a transparent local `effect Async
-          // { .. }` declaration, #752).
+          // Neither ROW-TRANSPARENT class becomes a world import, for two
+          // different reasons: `Error`/`Exception[K]` (core ambient) are
+          // vibe-internal control flow -- an escaping throw is a component
+          // trap, not a capability -- while `Async` (runtime, #1458) is THE
+          // builtin suspension effect (ADR-0089 Decision 5, #1218), which
+          // surfaces as the export's `async func` lifting mode rather than as
+          // an import (even when the program carries a transparent local
+          // `effect Async { .. }` declaration, #752).
           //
           // #1343 (ADR-0094 実装順 1): この `rname == "Async" ||
           // is_exception_effect_name(rname)` の二項判定は
-          // core/effect_taxonomy.vibe の `is_core_ambient_effect` に寄せた
-          // (checker 側の builtin_call_effect と同じ規則の重複だった)。
+          // core/effect_taxonomy.vibe へ寄せた (checker 側の
+          // builtin_call_effect と同じ規則の重複だった)。#1458 で
+          // `is_row_transparent_effect` に名前が付いた。
           // **wit_gen の分類の反転 -- 下の `def_idx < 0` が「`effect X {..}`
           // 宣言があれば interface、無ければ host capability」という
           // ADR-0084 と逆の規則になっている件 (#1143 のねじれ) -- は
           // ADR-0094 実装順 4 で直す。挙動変更を分離するため、ここでは
           // 触っていない。**
-          if is_core_ambient_effect(rname) {
+          if is_row_transparent_effect(rname) {
             ()
           } else if !wit_array_contains(used_effects, rname) {
             Array::push(used_effects, rname)


### PR DESCRIPTION
#1458 の決定事項を実装する。分類の追加は挙動不変で、残りは文書。

## 1. 4分類目 `runtime`

`Async` は `core_ambient` に `Error`/`Exception[E]` と同居していた。どちらも `main` の row を素通りするが、**理由が逆**:

- **core ambient** — 誰も discharge しないから残ってよい (entry boundary が escaping throw を diagnosed failure に変える)
- **runtime** — runtime が discharge するから残ってよい (ADR-0089 Decision 5: `Async` は backend の選択であって権限ではない)

混ぜていたのは不正確なだけでなく、**すでにコードを誤解させていた**: `checker_effects.vibe` と `wit_gen.vibe` の両方に「`Error` と `Async` は同じ理由でここに居る」と読めるコメントが書かれていた。

述語を3本に分ける:

| 述語 | メンバー | 意味 |
|---|---|---|
| `is_core_ambient_effect` | `Exception[E]` / `Error` | 誰も discharge しない |
| `is_runtime_effect` | `Async` | runtime が discharge する |
| `is_row_transparent_effect` | 上記の和 | **呼び出し側が実際に欲しいもの** |

呼び出し側は2箇所しかなく、どちらも「権限として数えるか」だけを見ていて「誰が discharge するか」は問うていない:

- `checker_effects.vibe` の `builtin_call_effect` — 要求 row に載せない
- `wit_gen.vibe` の world import 収集 — import にしない

両方を和の述語へ移した。**挙動は不変**で、テストが「和が分割前の `core_ambient` 集合と一致する」ことを pin している。

## 2. 二トラックの命名則

綴りは割れていたのではなく、**明文化されていない二トラックが並存**していた:

| | 綴り | 呼び出し | 規模 |
|---|---|---|---|
| Track A: capability builtin | `Effect::snake_case` | ただの関数呼び出し (`perform` なし) | registry 47 エントリ |
| Track B: 代数 effect の operation | CamelCase | `perform E::Op` + `handle` | 21 宣言 / 102 operation、CamelCase 例外ゼロ |

operation が CamelCase なのは、effect を perform することが**代数レコードの発行**だから — `Log::Emit` は関数ではなく constructor なので、variables/functions の snake_case ではなく constructor の規約に従う。capability builtin は本当に関数なので snake_case であり、これがそのまま言語ポリシーの形になる: **コアロジック以外は色のない関数で書き、色は row に運ばせる**。

### `Fs` / `Env` / `Profiler` の二重トラック (issue item 3)

同じ row ラベルの下に両方が存在する状態は**意図的な並存として文書化**し、使い分けの規則を書いた (「実行したいだけなら builtin、`handle` で横取りしたいなら宣言された effect」)。

**item 3 の (b)「片方を正とする」は取っていない** — 移行の決定を含むため。cheatsheet 側に未決として明記してある。

## 文書

- ADR-0084 (`docs/effect-taxonomy-entry-policy.md`) — 4分類の表を追加
- `docs/cheatsheet.md` — 分類表 + 命名則 + 二重トラックの使い分け
- `CLAUDE.md` — 命名規約とポリシー

## 検証

```
BUILD RC=0   (stage1 == stage2 fixpoint)
FMT   RC=0   904 files, 0 new violations
GATE  RC=0
UNIT  RC=0   528/528
```

cheatsheet の新しい ```vibe ブロックは doctest harness で pass する (既存の失敗4件は無関係な pre-existing — `lib/@vibe/prelude/io.vibe` の package boundary import 3件と `version = x.y.z` プレースホルダ1件)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_