### PR TITLE
#1464: 残り5行の読み直し — 2行は再分類、generic effect の2行は権限リークだった

### DIFF
--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -42,6 +42,39 @@
 #     ADR-0094's 実測 5: a row label is not checked to name a real effect
 #     either). Do not "restore" a Ref escape check to close these.
 #
+#   polymorphic_recursion_unsupported  was debt-accepts; reclassified `ok`. The
+#     retired host could not do polymorphic recursion; the selfhost compiler
+#     can. Verified by RUNNING it, not just compiling it:
+#       let rec depth = [T](x: T, n: Int) -> Int {
+#         if n == 0 { 0 } else { 1 + depth([x], n - 1) }
+#       }
+#       depth(7, 3)   ==> 3
+#     "Restoring" this rejection would remove a capability the compiler has.
+#
+#   suberror_generic_error_bound_raise_ok  was debt-rejects ("should compile");
+#     reclassified `reject`. There is NO `Error` trait in the selfhost compiler
+#     -- `[E: Error]` names an undefined trait, and rejecting it is right.
+#     ADR-0085 replaced the trait-bound design: the exception kind rides the
+#     ROW (`Exception[E]`), not a bound on the payload type. (The diagnostic
+#     could be clearer -- "no impl `Error` for `AppError`" reads as a missing
+#     impl rather than an unknown trait -- but that is separate work.)
+#
+#   suberror_raise_non_error_type  still debt-accepts, same root cause: with no
+#     `Error` trait there is nothing to bound a throw's payload with. Whether
+#     throws are bounded AT ALL is an open ADR-0085 question, not a lost check
+#     to restore.
+#
+#   generic_effect_{missing_caller_effect,matrix_fail_missing_effect_at_caller}
+#     are GENUINE lost checks, and worse than the fixtures suggest. The obvious
+#     hypothesis -- that the row leaks because `Error` is row-transparent -- was
+#     tested and is WRONG. Swapping `Error` for a capability or a user effect
+#     leaks identically (both measured, both compile):
+#       let apply = [T](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
+#       let boom  = (x: Int) -> Int with Fs { x }     // and with Ask
+#       let run   = (x: Int) -> Int { apply(boom, x) }   // no row required!
+#     So a function whose generic effect variable instantiates to a CAPABILITY
+#     claims a pure row. That is a permission leak, not just a bookkeeping gap.
+#
 # name	status	needle
 duplicate_enum_ctor	reject	duplicate ctor: A
 duplicate_discard_decl_ok	ok	
@@ -79,7 +112,7 @@ parse_import_trailing_comma	ok
 parse_int_min_literal_boundary	reject	IntLiteralOverflow: integer literal exceeds Int::max_value (2305843009213693951)
 parse_let_annotation_colon	ok	
 parse_loop_expr	ok	
-polymorphic_recursion_unsupported	debt-accepts	type: polymorphic recursion is unsupported
+polymorphic_recursion_unsupported	ok	
 property_access_ambiguous_function_vs_field	ok	
 scoped_ref_param_decl_forbidden	debt-accepts	type: scoped Ref[T] cannot escape: function parameter
 scoped_ref_param_nested_decl_forbidden	debt-accepts	type: scoped Ref[T] cannot escape: function parameter
@@ -88,7 +121,7 @@ suberror_brace_payload_type_mismatch	reject	argument type mismatch for Parse: ex
 suberror_brace_raise_ok	ok	
 suberror_brace_zero_payload_raise_ok	ok	
 suberror_duplicate_ctor	reject	duplicate ctor: Io
-suberror_generic_error_bound_raise_ok	debt-rejects	no impl `Error` for `AppError`
+suberror_generic_error_bound_raise_ok	reject	no impl `Error` for `AppError`
 suberror_generic_try_catch_ok	ok	
 suberror_mixed_error_types_raise_ok	ok	
 suberror_raise_ctor_arity_mismatch	reject	function arity mismatch for AppError: expected 1 args, got 2


### PR DESCRIPTION
PR #1482 の続き。#1464 の債務台帳の読み直しを完了する。

## 1. `polymorphic_recursion_unsupported` → `ok`

退役した host は多相再帰ができなかったが、**selfhost コンパイラはできる**。「コンパイルが通る」だけでは silent miscompile を排除できないので、**実際に走らせて**確認した:

```vibe
let rec depth = [T](x: T, n: Int) -> Int {
  if n == 0 { 0 } else { 1 + depth([x], n - 1) }
}
depth(7, 3)   // ==> 3
```

拒否を「復活」させると、コンパイラが持っている能力を削ることになる。

## 2. `suberror_generic_error_bound_raise_ok` → `reject`

`debt-rejects` = 「通るべき」と記録されていたが、通るべきではない。**selfhost コンパイラに `Error` trait は存在しない**ので、`[E: Error]` は未定義の trait を指しており、拒否が正しい。

ADR-0085 が trait bound の設計を置き換えている — 例外の kind は **row** (`Exception[E]`) が運ぶのであって、payload 型の bound ではない。

（診断が「no impl \`Error\` for \`AppError\`」なのは、未定義の trait ではなく impl 漏れに読めるので改善余地がある。別作業。）

## 3. `suberror_raise_non_error_type` — 債務のまま、同じ根

`Error` trait が無い以上、throw の payload を縛るものが無い。**そもそも throw に bound を課すか**は ADR-0085 の未決事項であって、復活させるべき失われた検査ではない。

## 4. `generic_effect_*` 2行 — 本物、しかも記録より悪い

最初に立てた仮説は「`Error` が row-transparent だから漏れる」だった。**検証して、外れた。** capability でも user effect でも同じように漏れる（どちらも実測、どちらも通る）:

```vibe
let apply = [T](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
let boom  = (x: Int) -> Int with Fs { x }        // Ask でも同じ
let run   = (x: Int) -> Int { apply(boom, x) }   // row を宣言しない
```

つまり **generic effect 変数が capability に具体化された関数が、pure な row を名乗れる**。帳簿の穴ではなく**権限リーク**で、台帳の他の行より優先度が高い。

## 検証

```
GATE RC=0
[compiler-gate] typecheck fixtures ok (64 fixtures, 5 known debt)
```

読み直し前は 8 → PR #1482 で 7 → この PR で 5。コンパイラのソースは変更していない。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_