### PR TITLE
fix(incremental): project exact typecheck dependency environments

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -173,10 +173,16 @@ claim.
 narrow, default-off check-only experiment. TDRE4 aliases the exact logical
 `ModuleJob` checker input to a previously checked TypeEnv: canonical owner path,
 byte-exact owner source, `resolution_env_seed()`, and every `(path, canonical
-TypeEnv-v3 transport text)` row in the full `dep_envs` array in consumed order.
-It does not narrow that table to declared dependencies or replace exact transport
-text with a compact fingerprint. It validates and republishes the decoded
-environment under the ordinary conservative fingerprint. It does not use the
+TypeEnv-v3 transport text)` row in the exact ordered resolved direct-dependency
+projection. The coordinator retains the full accumulated environment cache only
+for graph coordination and upsert; it projects each `deps` occurrence in order,
+preserves duplicate paths and first-match cache lookup, and fails closed if any
+resolved row is missing. The same projected array is passed to `check_module`
+and to TDRE4 lookup/publication, so ambient non-direct cache mutations are
+semantically irrelevant and avoid quadratic canonical serialization. TDRE4 does
+not replace exact transport text with a compact fingerprint. It validates and
+republishes the decoded environment under the ordinary conservative fingerprint.
+It does not use the
 trace-only `vibe-module-interface:v2` observation as a production key, and
 malformed, missing, stale, torn, or cross-spliced aliases, witnesses, and targets
 fall back to a full check. The alias remains incompatible with the incremental
@@ -197,10 +203,13 @@ fingerprint, and exact canonical target text. Reuse reads the raw target,
 strictly decodes it, requires an exact canonical re-encode, and verifies the
 three-way alias/witness/target binding. Publication order is target, witness,
 alias; diagnosed or failed modules publish none of those rows. The production
-oracle covers hidden trait/impl and ambient non-direct `dep_envs` changes,
-valid-but-wrong targets, cross-splicing, missing/malformed/stale entries,
-diagnostic non-publication, and multi-level reuse. The public experimental flag
-and default-off behavior are unchanged.
+oracle covers natural dependency transport changes (public signatures,
+traits, and impls), sidecar-integrity corruption of dependency rows/order,
+ambient non-direct cache irrelevance, valid-but-wrong targets, cross-splicing,
+missing/malformed/stale entries, diagnostic non-publication, and multi-level
+reuse. Focused checker tests cover package/directory candidate selection,
+reexports, duplicate paths/order, first-match cache shadowing, and missing-row
+failure. The public experimental flag and default-off behavior are unchanged.
 
 ## Artifact boundaries
 

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -189,6 +189,9 @@ fn incremental_typecheck_telemetry_json() -> String
 fn incremental_invalidation_trace_json(entry_path: String, run_nonce: String) -> String with Exception + Fs
 // Test-only seam for malformed transparent STrait provenance.
 fn incremental_trait_generic_provenance_markers_for_test(header_params: Array[String], method_params: Array[String], generic_bounds: Array[(String, Array[String])], method_count: Int, method_gens: Array[(String, Array[String], Array[(String, Array[String])])]) -> String
+// Test-only semantic seam for the exact dependency projection used by
+// ModuleJob.dep_envs and TDRE4. Throws when a resolved dependency row is absent.
+fn projected_import_env_for_test(source: String, path: String, deps: Array[String], full_cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception
 // #906 Phase 1: the module job / outcome seam. `check_module` is the unit a
 // Phase 2 worker will receive; it takes no `Fs` row because every
 // dependency environment it needs is already a value inside the job, and
@@ -198,12 +201,10 @@ fn incremental_trait_generic_provenance_markers_for_test(header_params: Array[St
 // caller when they land in the same commit.
 // Defined transparently here rather than as an opaque handle (perceus/
 // PerceusAction precedent): the field layout IS the worker contract.
-// dep_envs is the driver's resolved environment table -- the doc's
-// contract is "ordered direct-dependency interfaces", and this is a
-// superset (the whole cache), because build_import_env resolves import
-// paths against it and narrowing changes which entry an import binds to.
-// Narrowing to the direct deps is a prerequisite for real worker
-// isolation, not for this seam.
+// dep_envs is exactly the driver's ordered resolved direct-dependency
+// projection. The coordinator keeps its full accumulated cache separately;
+// check_module and TDRE4 consume the same projected array so ambient rows
+// cannot affect either import resolution or the logical reuse key.
 // `fingerprint` is deliberately NOT a field here. An earlier cut had the
 // caller supply one, which check_module simply echoed back into `Checked`
 // without ever consulting it -- a purely decorative field that made every

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -264,6 +264,35 @@ fn ensure_env_cache_for_paths(rdb: RippleDb, env_cache: Array[(String, TypeEnv)]
   cache
 }
 
+/// Project the coordinator's accumulated environment cache onto exactly the
+/// resolved direct dependency sequence that the module header produced.
+///
+/// Order and duplicate paths are preserved verbatim. lookup_env_cache's
+/// first-match rule is intentional: it is the same rule build_import_env uses,
+/// so a duplicate cache path cannot select one interface while TDRE4 keys a
+/// different one. A missing row is an infrastructure error, never EnvEmpty:
+/// continuing would let an unreadable dependency silently weaken checking.
+fn project_exact_dependency_envs(deps: Array[String], full_cache: Array[(String, TypeEnv)]) -> Array[(String, TypeEnv)] with Exception {
+  let projected = array_empty()
+  let mut i = 0
+  while i < Array::length(deps) {
+    let dep_path = Array::get(deps, i)
+    match lookup_env_cache(full_cache, dep_path) {
+      Some(dep_env) => Array::push(projected, (dep_path, dep_env)),
+      None => throw(String::concat("type_db: missing resolved dependency environment: ", dep_path))
+    }
+    i = i + 1
+  }
+  projected
+}
+
+/// Test-only semantic seam: production projects with the same helper and then
+/// gives this exact table to build_import_env through ModuleJob.dep_envs.
+export fn projected_import_env_for_test(source: String, path: String, deps: Array[String], full_cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception {
+  let dep_envs = project_exact_dependency_envs(deps, full_cache)
+  build_import_env(parse_program_with_path(path, source), dir_of_path(path), dep_envs)
+}
+
 fn build_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
   let mut acc = compact_string_fingerprint(source)
   let mut i = 0
@@ -1621,10 +1650,11 @@ fn parse_typing_dependency_reuse_binding(text: String, tag: String) -> Option[(S
 }
 
 /// Exact logical input to check_module: canonical owner path, byte-exact owner
-/// source, resolution authority, and every entry of ModuleJob.dep_envs in its
-/// actual array order. dep_envs is intentionally not narrowed to declared deps:
-/// build_import_env consumes the whole table and first-match shadowing makes
-/// ambient entries and their order checker-visible.
+/// source, resolution authority, and every resolved direct dependency row of
+/// ModuleJob.dep_envs in its actual array order. finish_typecheck_fs_impl builds
+/// this table once with project_exact_dependency_envs and gives the same value
+/// to both check_module and TDRE4 lookup/publication, so ambient coordinator
+/// cache rows are neither checker-visible nor part of this canonical text.
 fn typing_dependency_transport_input_key(path: String, source: String, dep_envs: Array[(String, TypeEnv)]) -> String {
   let out = StringBuilder::new()
   StringBuilder::push(out, "vibe-typing-dependency-transport-env:v4")
@@ -2390,10 +2420,14 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
     let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
     (fingerprint, next_db, env_cache, dep_source_cache, parse_count)
   } else {
-    let import_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
+    // Keep the accumulated cache as coordinator state, but expose exactly the
+    // resolved dependency sequence to the checker and TDRE4. Construct this
+    // once: lookup, check, and publication must describe the same value.
+    let coordinated_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
+    let projected_dep_envs = project_exact_dependency_envs(deps, coordinated_env_cache)
     let reused_env = if experimental_typing_dependency_env_reuse_enabled() {
       if typing_dependency_env_reuse_is_eligible(dep_fps) {
-        let input_key = typing_dependency_transport_input_key(path, source, import_env_cache)
+        let input_key = typing_dependency_transport_input_key(path, source, projected_dep_envs)
         match load_typing_dependency_env_reuse_target(input_key) {
           Some((target_fingerprint, target_text, target_env)) => Some((input_key, target_fingerprint, target_text, target_env)),
           None => None
@@ -2412,7 +2446,7 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
         store_persistent_type_env(fingerprint, target_env)
         publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
         write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
-        let next_env_cache = upsert_env_cache(import_env_cache, path, target_env)
+        let next_env_cache = upsert_env_cache(coordinated_env_cache, path, target_env)
         let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
         (fingerprint, next_db, next_env_cache, dep_source_cache, parse_count)
       },
@@ -2422,10 +2456,10 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
           source: source,
           deps: deps,
           dep_fps: dep_fps,
-          dep_envs: import_env_cache
+          dep_envs: projected_dep_envs
         }
         let outcome = check_module(job)
-        commit_module_outcome(rdb, import_env_cache, dep_source_cache, parse_count + 1, job, outcome)
+        commit_module_outcome(rdb, coordinated_env_cache, dep_source_cache, parse_count + 1, job, outcome)
       }
     }
   }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -10,11 +10,11 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  env_lookup
+  TypeEnv, env_lookup
 }
 
 import @vibe/compiler/runtime {
-  set_collect_module_diagnostics, set_dep_order_seed
+  projected_import_env_for_test, set_collect_module_diagnostics, set_dep_order_seed
 }
 
 import @vibe/compiler/cache {
@@ -55,6 +55,15 @@ fn build_test_fingerprint(source: String, dep_fps: Array[(String, String)]) -> S
     i = i + 1
   }
   acc
+}
+
+fn checked_test_env(source: String) -> TypeEnv with Exception {
+  let path = "projection_fixture.vibe"
+  let checked = db_typecheck(db_set_source(db_new(), path, source), path)
+  match db_check_env(checked, path) {
+    Some(env) => env,
+    None => throw("projection fixture produced no checked environment")
+  }
 }
 
 fn remove_typecheck_fs_cache(path: String, source: String, fingerprint: String) -> Unit with Fs {
@@ -191,6 +200,73 @@ test "db_typecheck_fs: extensionless directory re-export imports enum constructo
     None => false
   }
   assert(has_ctor)
+}
+
+test "exact dep projection resolves the selected package and directory candidates" {
+  let store_env = checked_test_env("export let value = 1")
+  let workspace_env = checked_test_env("export let value = \"workspace\"")
+  let package_env = projected_import_env_for_test("import @scope/name { value }", "main.vibe", [
+    "lib/@scope/name/index.vpkg"
+  ], [
+    (".vibe/store/@scope/name/index.vpkg", store_env),
+    ("lib/@scope/name/index.vpkg", workspace_env)
+  ])
+  match env_lookup(package_env, "value") {
+    Some(CtString) => (),
+    _ => assert(false)
+  }
+  let plain_env = checked_test_env("export let value = 1")
+  let index_env = checked_test_env("export let value = \"index\"")
+  let directory_env = projected_import_env_for_test("export ./core { value }", "workspace/main.vibe", [
+    "workspace/core/index.vibe"
+  ], [
+    ("workspace/core.vibe", plain_env),
+    ("workspace/core/index.vibe", index_env)
+  ])
+  match env_lookup(directory_env, "value") {
+    Some(CtString) => (),
+    _ => assert(false)
+  }
+}
+
+test "exact dep projection preserves duplicate order and cache first-match semantics" {
+  let dep_path = "workspace/dep.vibe"
+  let int_env = checked_test_env("export let value = 1")
+  let string_env = checked_test_env("export let value = \"first\"")
+  let source = "import ./dep.vibe { value as imported }\nexport ./dep.vibe { value as reexported }"
+  let deps = [
+    dep_path,
+    dep_path
+  ]
+  let first_int = projected_import_env_for_test(source, "workspace/main.vibe", deps, [
+    (dep_path, int_env),
+    (dep_path, string_env)
+  ])
+  match (env_lookup(first_int, "imported"), env_lookup(first_int, "reexported")) {
+    (Some(CtInt), Some(CtInt)) => (),
+    _ => assert(false)
+  }
+  let first_string = projected_import_env_for_test(source, "workspace/main.vibe", deps, [
+    (dep_path, string_env),
+    (dep_path, int_env)
+  ])
+  match (env_lookup(first_string, "imported"), env_lookup(first_string, "reexported")) {
+    (Some(CtString), Some(CtString)) => (),
+    _ => assert(false)
+  }
+}
+
+test "exact dep projection fails closed when a resolved row is missing" {
+  let message = handle {
+    let _ = projected_import_env_for_test("import ./dep.vibe { value }", "workspace/main.vibe", [
+      "workspace/dep.vibe"
+    ], [
+    ])
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(String::contains(message, "type_db: missing resolved dependency environment: workspace/dep.vibe"))
 }
 
 test "db_typecheck_fs: source update bypasses current-run cache" {

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -428,9 +428,18 @@ function run(stage2) {
     makeAmbientProject(ambientProject);
     const ambientCold = check(stage2, ambientProject, ambientCache, true, "ambient-cold");
     expectCounts("ambient cold", ambientCold.telemetry, 3, 0, 3);
+    const ambientColdApp = appSidecar(ambientCache, readFileSync(join(ambientProject, "app.vibe"), "utf8"));
+    const ambientColdInput = parseLogicalInput(ambientColdApp.input);
+    if (ambientColdInput.rows.length !== 1 || basename(ambientColdInput.rows[0][0]) !== "middle.vibe") {
+      fail("TDRE4 app logical input was not the exact direct-dependency projection");
+    }
     ambientOnlyTransportEdit(ambientProject);
-    const ambientFallback = check(stage2, ambientProject, ambientCache, true, "ambient-change-fallback");
-    expectCounts("ambient non-direct dep_env change fallback", ambientFallback.telemetry, 3, 0, 3);
+    const ambientReuse = check(stage2, ambientProject, ambientCache, true, "ambient-change-reuse");
+    expectCounts("ambient non-direct cache change reuse", ambientReuse.telemetry, 2, 1, 3);
+    const ambientWarmApp = appSidecar(ambientCache, readFileSync(join(ambientProject, "app.vibe"), "utf8"));
+    if (ambientWarmApp.input !== ambientColdApp.input || ambientWarmApp.path !== ambientColdApp.path) {
+      fail("ambient non-direct cache mutation changed the app TDRE4 input key");
+    }
 
     const resolutionProject = join(work, "resolution-seed-project");
     const resolutionCache = join(work, "resolution-seed-cache");
@@ -441,6 +450,24 @@ function run(stage2) {
       VIBE_HOME: join(resolutionProject, ".other-home"),
     });
     expectCounts("resolution_env_seed change fallback", resolutionFallback.telemetry, 2, 0);
+
+    const rowProject = join(work, "dep-env-row-project");
+    const rowCache = join(work, "dep-env-row-cache");
+    makeProject(rowProject);
+    check(stage2, rowProject, rowCache, true, "row-cold");
+    const rowApp = appSidecar(rowCache, readFileSync(join(rowProject, "app.vibe"), "utf8"));
+    const parsedRowInput = parseLogicalInput(rowApp.input);
+    if (parsedRowInput.rows.length !== 1 || basename(parsedRowInput.rows[0][0]) !== "helper.vibe") {
+      fail("TDRE4 direct dependency row missing before row mutation");
+    }
+    const changedRowInput = logicalInputText({
+      ...parsedRowInput,
+      rows: [[`${parsedRowInput.rows[0][0]}.changed`, parsedRowInput.rows[0][1]]],
+    });
+    writeFileSync(rowApp.path, aliasText(changedRowInput, rowApp.target, rowApp.targetText));
+    privateEdit(rowProject);
+    const rowFallback = check(stage2, rowProject, rowCache, true, "row-change-fallback");
+    expectCounts("direct dep_env row fallback", rowFallback.telemetry, 2, 0);
 
     const orderProject = join(work, "dep-env-order-project");
     const orderCache = join(work, "dep-env-order-cache");
@@ -536,8 +563,9 @@ function run(stage2) {
         missing: missingWitnessFallback.telemetry,
         malformed: malformedWitnessFallback.telemetry,
       },
-      ambient_non_direct_dep_env_change_fallback: ambientFallback.telemetry,
+      ambient_non_direct_cache_change_reuse: ambientReuse.telemetry,
       resolution_env_seed_change_fallback: resolutionFallback.telemetry,
+      direct_dep_env_row_fallback: rowFallback.telemetry,
       dep_env_order_shadow_fallback: orderFallback.telemetry,
       diagnostics_publish_nothing: true,
       trait_graph: {


### PR DESCRIPTION
## Summary

Add the final correctness/performance prerequisite before considering default-on TDRE4: make the checker consume the same exact ordered resolved dependency projection that TDRE4 keys.

Previously the coordinator passed its full accumulated ambient environment cache into each `ModuleJob`; TDRE4 therefore had to serialize ambient rows and the logical checker input grew quadratically with graph size.

Now:

- coordinator retains the full cache only for graph lookup/upsert
- one fail-closed helper projects each exact resolved `deps` occurrence in order
- duplicate paths and first-match cache semantics are preserved
- missing resolved rows throw rather than weakening the environment
- the same projected array is passed to both `check_module` and TDRE4 lookup/publication
- ambient non-direct cache changes are no longer checker-visible or key-visible
- package/directory candidate selection, imports/reexports, duplicates/order, first-match shadowing, and missing rows have focused coverage

TDRE4 remains default-off and cache version remains `v16`. Interface-v2 and codegen/artifact reuse are unchanged.

## Validation

- focused projection tests: pass
- affected/test-local suite: pass
- TDRE4 oracle: pass
- fresh stage2 == stage3
- release-check: pass (with local BSD xargs buffer wrapper)
- KPI/default-off heap: pass
- independent hard review: no P0; documentation now distinguishes natural dependency transport changes from sidecar row/order integrity corruption

The exported `projected_import_env_for_test` function is a bounded pure test seam; it has no FS/cache effects and is documented test-only.

Progresses #1379.
