### PR TITLE
feat(incremental): enable TDRE4 reuse by default for check

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -167,10 +167,23 @@ trait definitions and method-generic rows, but remains a narrow environment
 transport, not a complete clean/warm typed artifact or lossless `CheckedProgram`
 claim.
 
-## Experimental dependency transport-environment typing reuse
+## Dependency transport-environment typing reuse
 
-`VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE=1` enables a deliberately
-narrow, default-off check-only experiment. TDRE4 aliases the exact logical
+TDRE4 TypeEnv reuse is enabled by default for the `vibe check` filesystem
+check-only lane. Build, codegen, LSP, and direct FS typecheck consumers remain
+conservative pending a compact exact-publication design: publishing the current
+exact TDRE4A/TDRE4W texts on a fresh selfcompile exceeds the signed 2 GiB guest
+heap boundary, while the conservative compile lane remains near 1.11 GB.
+`VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE=1` is the strict emergency opt-out for
+check-only reuse;
+any other nonempty value is rejected. The legacy
+`VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE` spelling accepts only empty or
+`1` and is otherwise a compatibility no-op. An ordinary incremental
+invalidation trace automatically forces reuse off so the trace stays
+observation-only. For compatibility, explicitly combining legacy `1` with an
+invalidation trace remains rejected.
+
+TDRE4 aliases the exact logical
 `ModuleJob` checker input to a previously checked TypeEnv: canonical owner path,
 byte-exact owner source, `resolution_env_seed()`, and every `(path, canonical
 TypeEnv-v3 transport text)` row in the exact ordered resolved direct-dependency
@@ -190,10 +203,11 @@ invalidation trace lane so the two identities cannot be confused.
 
 The v3 TypeEnv codec round-trips every current `TypeEnv` variant, including
 trait definitions, impls, generic impl bounds, trait-header parameters,
-positional method-generic binders/bounds, and method `TypeExpr` metadata. TDRE4
-keeps that TypeEnv-v3 envelope and production cache namespace v16 unchanged;
-only its experimental alias and eligibility-witness namespaces and `TDRE4A` /
-`TDRE4W` envelopes are new. A sidecar is still only an alias to a conservative
+positional method-generic binders/bounds, and method `TypeExpr` metadata. The
+production-default promotion bumps the global persistent cache namespace from
+v16 to v17 because reuse policy changed. It keeps the TypeEnv-v3 envelope,
+TDRE4 alias and eligibility-witness namespaces, and `TDRE4A` / `TDRE4W`
+envelopes unchanged. A sidecar is still only an alias to a conservative
 TypeEnv commit, not a `CheckedProgram` or lossless typed-IR transport.
 
 A witness is published only after that module's canonical TypeEnv-v3 target and
@@ -209,7 +223,10 @@ ambient non-direct cache irrelevance, valid-but-wrong targets, cross-splicing,
 missing/malformed/stale entries, diagnostic non-publication, and multi-level
 reuse. Focused checker tests cover package/directory candidate selection,
 reexports, duplicate paths/order, first-match cache shadowing, and missing-row
-failure. The public experimental flag and default-off behavior are unchanged.
+failure. The production oracle treats the default check environment as
+reuse-on and uses the explicit disable flag as its conservative control. It
+also covers trace forced-off behavior, strict environment diagnostics,
+conservative compile output parity, and isolation from v16 entries.
 
 ## Artifact boundaries
 
@@ -624,7 +641,7 @@ separate `changed`/`unchanged` observation rather than being treated as the
 exported interface. The current consumer decision must still be `rechecked` and
 is reported as `conservative_rechecked`; this is a record of current
 conservative behavior, not a new reuse rule. This classifier does not change
-trace schema 6, cache namespace v16, TypeEnv-v3/TDRE4 transport, production
+trace schema 6, cache namespace v17, TypeEnv-v3/TDRE4 transport, production
 artifact reuse, or default-gate wiring; it strengthens the existing observation gate's assertions.
 
 For this comparison, `source_fingerprint` is ingestion telemetry only;
@@ -699,7 +716,7 @@ context evidence is explicit trace-only extra filesystem work after the
 ordinary production compile. Because it is a post-compile recollection, the
 sidecar is not an atomic snapshot of the bytes used to produce the wasm; a
 concurrent filesystem or resolution-context change may describe a later
-snapshot. It never changes cache namespace `v16`, artifact
+snapshot. It never changes cache namespace `v17`, artifact
 fingerprints, artifact lookup/store/reuse decisions, interface-v2, TypeEnv-v3,
 TDRE4, or trace schema 6. A separately named shadow fingerprint uses a versioned,
 fixed-order, length-prefixed `vibe-artifact-input-observation:v2` preimage and

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -95,10 +95,13 @@ export ../../../../lib/@vibe/cache {
 ///    invalidates stale artifacts; no manual bump needed (#630). `vNN` is still a
 ///    manual knob for pure cache-FORMAT changes that don't change the source hash.
 fn persistent_cache_version_tag() -> String {
+  // v17: TDRE4 TypeEnv reuse is production-default for CLI check-only. The
+  // reuse-policy change gets a fresh global namespace so entries written while
+  // reuse was opt-in cannot influence the default-on lane. The TypeEnv v3
+  // envelope and TDRE4 alias/witness formats remain unchanged.
   // v16: persistent TypeEnv v3 retains trait method-generic provenance. The
   // version and TypeEnv namespace bump prevent v1/v2 transport artifacts from
-  // being reused. TDRE4 hardening remains isolated in its own sidecar/witness
-  // namespaces below and deliberately does not bump this production version.
+  // being reused.
   // v14 (#1326): artifact entries gained the "VART1" length-validated
   // envelope and atomic tmp+rename publish — a cache FORMAT change. Bumping
   // also orphans artifacts torn by the pre-#1326 isolation bypass (store/load
@@ -114,7 +117,7 @@ fn persistent_cache_version_tag() -> String {
   // (`.bin`, via Fs::write_bytes / Fs::read_bytes) — a cache FORMAT change, so
   // the manual `vNN` knob is bumped. Old `.hex` entries are now unreferenced
   // (different key + suffix) and reclaimable via `pkf run cache-clean` (#631).
-  String::concat("v16|cg-", codegen_fingerprint())
+  String::concat("v17|cg-", codegen_fingerprint())
 }
 
 /// Read-only trace evidence for the exact existing persistent cache identity.
@@ -143,9 +146,9 @@ export fn persistent_type_env_cache_path(fingerprint: String) -> String {
   cache_persistent_type_env_cache_path(persistent_cache_version_tag(), fingerprint)
 }
 
-/// Experimental TDRE4 typing-input aliases are deliberately separate from the
-/// TypeEnv-v3 artifact namespace and all earlier TDRE namespaces. The referenced
-/// TypeEnv remains in its conservative fingerprint-addressed cache entry.
+/// TDRE4 typing-input aliases are deliberately separate from the TypeEnv-v3
+/// artifact namespace and all earlier TDRE namespaces. The referenced TypeEnv
+/// remains in its conservative fingerprint-addressed cache entry.
 export fn persistent_typing_dependency_env_reuse_sidecar_path(typing_input_key: String) -> String {
   cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v4", typing_input_key)
 }

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -383,7 +383,30 @@ fn adapter_serve_component(input_path: String, output_path: String) -> Int with 
   }
 }
 
+fn configure_typing_dependency_env_reuse_policy() -> Unit with Exception + Env {
+  let disable = Env::get("VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE")
+  let legacy = Env::get("VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE")
+  let invalidation_trace_out = Env::get("VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT")
+  if disable != "" && disable != "1" {
+    throw("VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE must be exactly 1 when set")
+  } else if legacy != "" && legacy != "1" {
+    throw("VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE must be empty or exactly 1")
+  } else if legacy == "1" && invalidation_trace_out != "" {
+    // Preserve the experimental lane's strict rejection for callers that
+    // explicitly request that compatibility spelling. Without it, tracing
+    // remains observation-only by forcing production reuse off below.
+    throw("VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE does not support VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT")
+  } else {
+    set_experimental_typing_dependency_env_reuse_enabled(disable != "1" && invalidation_trace_out == "")
+  }
+}
+
 export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
+  // Reset the process-wide TDRE4 cell before every invocation. Only the
+  // check-only branch may enable it after strict policy validation below;
+  // build/codegen lanes stay conservative, and a prior check in a long-lived
+  // instance cannot leak its policy into a later invocation.
+  set_experimental_typing_dependency_env_reuse_enabled(false)
   // #944 (ADR-0073 stage B): checked-Error row discipline is ON by
   // default -- `Exception::Throw` propagates to the caller's row like any
   // other effect, dischargeable via `handle .. with Exception`.
@@ -759,27 +782,17 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   } else ()
   if Env::get("VIBE_CHECK_ONLY") == "1" {
     return handle {
-      // The sidecar is opt-in so ordinary `vibe check` remains output- and
-      // work-compatible. The counters cover only the db_typecheck_fs walk
+      // TDRE4 is production-default only for the proven check/edit-cycle lane.
+      // This call also resets policy on every check-only invocation, including
+      // strict opt-out and observation-only trace runs.
+      configure_typing_dependency_env_reuse_policy()
+      // Telemetry remains opt-in even though TDRE4 reuse is now the default
+      // for this check-only lane. The counters cover only the db_typecheck_fs walk
       // inside check_linked_file; the second linked inline-wasm validation is
       // intentionally outside this incremental-cache telemetry boundary.
       let telemetry_out = Env::get("VIBE_INCREMENTAL_TELEMETRY_OUT")
       let invalidation_trace_out = Env::get("VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT")
       let invalidation_trace_nonce = Env::get("VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE")
-      let experimental_typing_dependency_env_reuse = Env::get("VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE")
-      if experimental_typing_dependency_env_reuse != "" && experimental_typing_dependency_env_reuse != "1" {
-        throw("VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE must be exactly 1 when enabled")
-      } else {
-        ()
-      }
-      // The invalidation trace is deliberately observation-only and has its
-      // own interface identity. Keep this experimental production reuse lane
-      // separate so no trace schema/value becomes a cache key by accident.
-      if experimental_typing_dependency_env_reuse == "1" && invalidation_trace_out != "" {
-        throw("VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE does not support VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT")
-      } else {
-        ()
-      }
       if telemetry_out != "" {
         // Never leave a previous successful run looking like telemetry for a
         // failed check. The sidecar is published only after check_linked_file.
@@ -818,7 +831,6 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // This has no cache behavior: it only makes the successful walk carry
       // a canonical public-interface observation into the requested sidecar.
       set_incremental_interface_trace_enabled(invalidation_trace_out != "")
-      set_experimental_typing_dependency_env_reuse_enabled(experimental_typing_dependency_env_reuse == "1")
       let _ = check_linked_file(input_path)
       if telemetry_out != "" {
         Fs::write_file(telemetry_out, incremental_typecheck_telemetry_json())

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -181,7 +181,9 @@ fn set_collect_module_diagnostics(on: Bool) -> Unit
 // the row format and scripts/scheduler_trace_oracle.sh for the checks.
 fn set_scheduler_trace_path(path: String) -> Unit
 // Incremental typecheck work counters and successful-check observation sidecar.
-// Disabled by default; these do not change or persist production cache keys.
+// Telemetry/interface tracing remain default-off observations. TDRE4 TypeEnv
+// reuse is production-default only for CLI check-only; its setter resets
+// per-invocation policy and does not widen reuse beyond existing validation.
 fn set_incremental_typecheck_telemetry_enabled(enabled: Bool) -> Unit
 fn set_incremental_interface_trace_enabled(enabled: Bool) -> Unit
 fn set_experimental_typing_dependency_env_reuse_enabled(enabled: Bool) -> Unit

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -533,9 +533,12 @@ let incremental_checked_env_trace_observations: Array[(String, String)] = [
 let incremental_persistent_type_env_transport_trace_observations: Array[(String, String)] = [
 ]
 
-// This opt-in aliases only an exact v3 decoded TypeEnv when every direct
-// dependency transport environment is unchanged. It is not a CheckedProgram
-// or typed-IR transport; v3 retains the TypeEnv trait/impl chain only.
+// TDRE4 aliases only an exact v3 decoded TypeEnv when every direct dependency
+// transport environment is unchanged. It is not a CheckedProgram or typed-IR
+// transport; v3 retains the TypeEnv trait/impl chain only. The empty cell is
+// conservative for direct FS consumers. The CLI check-only lane explicitly
+// enables production reuse after validating its per-invocation policy; build,
+// codegen, and other FS consumers remain off pending compact publication.
 let experimental_typing_dependency_env_reuse_enabled_cell = array_empty()
 
 export fn set_experimental_typing_dependency_env_reuse_enabled(enabled: Bool) -> Unit {
@@ -1575,8 +1578,10 @@ let parse_memo_paths: Array[String] = [
     Array::push(parse_memo_stmts, parsed)
     Array::slice(parsed, 0, Array::length(parsed))
   }
-} fn store_persistent_type_env(fingerprint: String, env: TypeEnv) -> Unit with Exception + Fs {
-  Fs::write_file(persistent_type_env_cache_path(fingerprint), persistent_type_env_cache_text(env))
+} fn store_persistent_type_env(fingerprint: String, env: TypeEnv) -> String with Exception + Fs {
+  let text = persistent_type_env_cache_text(env)
+  Fs::write_file(persistent_type_env_cache_path(fingerprint), text)
+  text
 }
 
 // TDRE4 is deliberately independent from the TypeEnv v3 envelope and from
@@ -2154,14 +2159,16 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
       throw(String::concat(job.path, ": type error"))
     },
     Checked(path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity) => {
-      store_persistent_type_env(fingerprint, checked_env)
+      // Serialize the TypeEnv once. Production-default TDRE4 publication binds
+      // the exact same text as the conservative target; serializing it a second
+      // time materially inflates fresh selfcompile heap without adding evidence.
+      let target_text = store_persistent_type_env(fingerprint, checked_env)
       // Publish in commit order: canonical target first, bound witness second,
       // alias last. Diagnosed/thrown checks never enter this Checked arm. Keep
       // the extra canonical target text and input serialization wholly inside
       // the enabled, transitively eligible experimental lane.
       if experimental_typing_dependency_env_reuse_enabled() && typing_dependency_env_reuse_is_eligible(job.dep_fps) {
         let input_key = typing_dependency_transport_input_key(path, job.source, job.dep_envs)
-        let target_text = persistent_type_env_cache_text(checked_env)
         publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
         write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
       } else {
@@ -2443,7 +2450,7 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
         // Preserve the ordinary conservative fingerprint path for every later
         // consumer. Commit this target first, then its exact bound witness, and
         // only then the alias, so torn publication always fails closed.
-        store_persistent_type_env(fingerprint, target_env)
+        Fs::write_file(persistent_type_env_cache_path(fingerprint), target_text)
         publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
         write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
         let next_env_cache = upsert_env_cache(coordinated_env_cache, path, target_env)

--- a/scripts/artifact_input_trace_oracle.test.mjs
+++ b/scripts/artifact_input_trace_oracle.test.mjs
@@ -14,7 +14,7 @@ const validTrace = {
   source_groups_fingerprint_kind: "build_source_groups_fingerprint(source_groups)",
   production_artifact_input_fingerprint: "30:3:4",
   production_artifact_input_fingerprint_kind: "build_file_compile_wasi_artifact_fingerprint_from_group_fingerprint_for_entry_path(source_groups_fingerprint, entry_path, entry_name, mode)",
-  compiler_cache_version_tag: "v16|cg-example",
+  compiler_cache_version_tag: "v17|cg-example",
   compiler_cache_version_tag_kind: "persistent_cache_version_tag()",
   effective_config: { checked_error_row_mode: "checked", diagnostics_mode: "fail-fast", dep_order_seed: "0", target: "wasi", memory: "bump", dce_mode: "no-dce", strip_stage: "pre-strip", instrumentation: "uninstrumented" },
   dependency_plan: { fingerprint: "40:5:6", fingerprint_kind: "compact_string_fingerprint(vibe-artifact-input-dependency-plan:v1 length-prefixed planned order/ranks/dependency occurrences)", module_count: 2, edge_occurrence_count: 1 },

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-// Isolated production E2E oracle for the opt-in dependency transport-env
-// typing reuse slice. It intentionally reads telemetry only; trace-only
-// module-interface observations are rejected by the experiment and are never
-// used to establish a production reuse key here.
-import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+// Production E2E oracle for default-on check-only TDRE4 TypeEnv reuse. The
+// explicit disable flag is the conservative control. Trace-only observations
+// force reuse off and are never used to establish a production reuse key.
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve, isAbsolute } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -33,6 +32,10 @@ function privateEdit(project) {
 
 function publicEdit(project) {
   writeFileSync(join(project, "helper.vibe"), "export fn value() -> String { \"two\" }\n");
+}
+
+function privateStringEdit(project) {
+  writeFileSync(join(project, "helper.vibe"), "export fn value() -> String { let ignored = 1\n\"three\" }\n");
 }
 
 function makeChainProject(project) {
@@ -119,7 +122,8 @@ function check(stage2, project, cache, gate, name, allowFailure = false, extraEn
       // force a full check rather than exercise reuse.
       VIBE_HOME: join(project, ".home"),
       VIBE_PREOPEN_DIR: project,
-      ...(gate ? { VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "1" } : {}),
+      VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE: gate ? "" : "1",
+      VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "",
       ...extraEnv,
     },
   });
@@ -132,6 +136,27 @@ function check(stage2, project, cache, gate, name, allowFailure = false, extraEn
   } catch (error) {
     fail(`${name} omitted output or telemetry: ${error.message}`);
   }
+}
+
+function compile(stage2, project, cache, enabled, name) {
+  const out = `${name}.wasm`;
+  const result = spawnSync("bash", [join(root, "scripts/run_wasm_vibe_host_runner.sh"), "--invoke", "cli_main", stage2, "app.vibe", out, "main"], {
+    cwd: project,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      VIBE_BUILD_CACHE_DIR: cache,
+      VIBE_FS_COMPILE: "1",
+      VIBE_RC: "0",
+      VIBE_IMPORT_ABI: "raw",
+      VIBE_HOME: join(project, ".home"),
+      VIBE_PREOPEN_DIR: project,
+      VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE: enabled ? "" : "1",
+      VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "",
+    },
+  });
+  if (result.status !== 0) fail(`${name} failed: ${(result.stderr || result.stdout).trim()}`);
+  return readFileSync(join(project, out));
 }
 
 function expectCounts(name, actual, rechecked, reused, planned = 2) {
@@ -238,19 +263,30 @@ function compactFingerprint(source) {
   return `${source.length}:${h1}:${h2}`;
 }
 
-// Derive the exact referenced TypeEnv filename from the target conservative
-// fingerprint, mirroring @vibe/cache stable_cache_path. This avoids corrupting
-// another module's env and makes the malformed-target case non-vacuous.
-function referencedAppTargetEnv(stage2, cache, target) {
+function stageCodegenFingerprint(stage2) {
   // The stage compiler's bundled fingerprint can be one generation behind the
   // checkout's freshly regenerated source fingerprint, so read its adjacent
   // flattened module source rather than assuming the working-tree value.
   const stageSource = readFileSync(join(dirname(stage2), "cli_adapter_module_source.vibe"), "utf8");
   const codegen = stageSource.match(/codegen_fingerprint[\s\S]{0,200}?"([0-9a-f]{16})"/)?.[1];
   if (!codegen) fail("could not read stage compiler codegen fingerprint");
-  const version = `v16|cg-${codegen}`;
-  const token = compactFingerprint(`persistent-cache-${version}|${target}`).replaceAll(":", "_");
-  const path = join(cache, `vibe_selfhost_type_env_v3_${token}.tsv`);
+  return codegen;
+}
+
+function stableCachePath(cache, version, prefix, seed, suffix) {
+  const token = compactFingerprint(`persistent-cache-${version}|${seed}`).replaceAll(":", "_");
+  return join(cache, `vibe_${prefix}_${token}${suffix}`);
+}
+
+function typeEnvPath(stage2, cache, target, major = "v17") {
+  return stableCachePath(cache, `${major}|cg-${stageCodegenFingerprint(stage2)}`, "selfhost_type_env_v3", target, ".tsv");
+}
+
+// Derive the exact referenced TypeEnv filename from the target conservative
+// fingerprint, mirroring @vibe/cache stable_cache_path. This avoids corrupting
+// another module's env and makes the malformed-target case non-vacuous.
+function referencedAppTargetEnv(stage2, cache, target) {
+  const path = typeEnvPath(stage2, cache, target);
   try { readFileSync(path, "utf8"); }
   catch { fail("referenced app TypeEnv missing before corruption"); }
   return path;
@@ -266,6 +302,7 @@ function expectTraceLaneRejected(stage2, project, cache) {
       ...process.env,
       VIBE_BUILD_CACHE_DIR: cache,
       VIBE_CHECK_ONLY: "1",
+      VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE: "",
       VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "1",
       VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT: trace,
       VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE: "trace-lane-rejection",
@@ -274,9 +311,75 @@ function expectTraceLaneRejected(stage2, project, cache) {
       VIBE_PREOPEN_DIR: project,
     },
   });
-  if (result.status === 0) fail("trace lane unexpectedly accepted experimental reuse");
-  const diag = readFileSync(join(project, `${out}.diag`), "utf8");
-  if (!diag.includes("does not support VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT")) fail("trace lane rejection diagnostic changed");
+  if (result.status === 0) fail("trace lane unexpectedly accepted explicit legacy reuse");
+  const diagPath = join(project, `${out}.diag`);
+  const diagnostic = `${result.stderr || ""}\n${result.stdout || ""}\n${existsSync(diagPath) ? readFileSync(diagPath, "utf8") : ""}`;
+  if (!diagnostic.includes("does not support VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT")) fail("trace lane rejection diagnostic changed");
+}
+
+function traceForcedOff(stage2, project, cache) {
+  const beforeAliases = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v4").length;
+  const beforeWitnesses = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v4").length;
+  const result = check(stage2, project, cache, true, "trace-forced-off", false, {
+    VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT: "trace-forced-off.json",
+    VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE: "trace-forced-off",
+  });
+  expectCounts("ordinary trace forced off", result.telemetry, 2, 0);
+  if (!existsSync(join(project, "trace-forced-off.json"))) fail("ordinary trace omitted observation sidecar");
+  if (bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v4").length !== beforeAliases ||
+      bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v4").length !== beforeWitnesses) {
+    fail("observation-only trace published TDRE4 state");
+  }
+  return result.telemetry;
+}
+
+function expectInvalidEnvRejected(stage2, project, cache, variable, value) {
+  const out = `invalid-${variable}.out`;
+  const result = spawnSync("bash", [join(root, "scripts/run_wasm_vibe_host_runner.sh"), "--invoke", "cli_main", stage2, "app.vibe", out], {
+    cwd: project,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      VIBE_BUILD_CACHE_DIR: cache,
+      VIBE_CHECK_ONLY: "1",
+      VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE: "",
+      VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "",
+      VIBE_IMPORT_ABI: "raw",
+      VIBE_HOME: join(project, ".home-invalid-env"),
+      VIBE_PREOPEN_DIR: project,
+      [variable]: value,
+    },
+  });
+  if (result.status === 0) fail(`${variable}=${value} unexpectedly accepted`);
+  const diagPath = join(project, `${out}.diag`);
+  const diagnostic = `${result.stderr || ""}\n${result.stdout || ""}\n${existsSync(diagPath) ? readFileSync(diagPath, "utf8") : ""}`;
+  if (!diagnostic.includes(variable)) fail(`${variable} rejection omitted strict diagnostic`);
+}
+
+function expectV16Isolation(stage2, work) {
+  const project = join(work, "v16-isolation-project");
+  const currentCache = join(work, "v16-isolation-current-cache");
+  const oldCache = join(work, "v16-isolation-old-cache");
+  makeProject(project);
+  check(stage2, project, currentCache, true, "v16-source-cold");
+  mkdirSync(oldCache, { recursive: true });
+  const oldVersion = `v16|cg-${stageCodegenFingerprint(stage2)}`;
+  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_v4")) {
+    const text = readFileSync(path, "utf8");
+    const binding = parseBinding(text, "TDRE4A");
+    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_v4", binding.input, ".txt"), text);
+    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v16"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
+  }
+  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_eligibility_v4")) {
+    const text = readFileSync(path, "utf8");
+    const binding = parseBinding(text, "TDRE4W");
+    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_eligibility_v4", binding.target, ".txt"), text);
+    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v16"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
+  }
+  if (bindingFiles(oldCache, "selfhost_typing_dependency_env_reuse_v4").length === 0) fail("v16 isolation fixture omitted valid old aliases");
+  const isolated = check(stage2, project, oldCache, true, "v16-isolated-default");
+  expectCounts("v16 namespace isolation", isolated.telemetry, 2, 0);
+  return isolated.telemetry;
 }
 
 function run(stage2) {
@@ -296,7 +399,19 @@ function run(stage2) {
     if (coldOff.output !== coldOn.output) fail("cold gate-off/on output mismatch");
 
     const warmOn = check(stage2, onProject, onCache, true, "warm-on");
-    expectCounts("warm on", warmOn.telemetry, 0, 2);
+    expectCounts("warm default-on", warmOn.telemetry, 0, 2);
+    const legacyCompat = check(stage2, onProject, onCache, true, "legacy-compat", false, {
+      VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "1",
+    });
+    expectCounts("legacy 1 compatibility no-op", legacyCompat.telemetry, 0, 2);
+
+    const compileControlProject = join(work, "compile-control-project");
+    const compileDefaultProject = join(work, "compile-default-project");
+    makeProject(compileControlProject);
+    makeProject(compileDefaultProject);
+    const compileControl = compile(stage2, compileControlProject, join(work, "compile-control-cache"), false, "compile-control");
+    const compileDefault = compile(stage2, compileDefaultProject, join(work, "compile-default-cache"), true, "compile-default");
+    if (!compileControl.equals(compileDefault)) fail("FS compile default-on/explicit-disable output mismatch");
 
     privateEdit(offProject);
     privateEdit(onProject);
@@ -312,8 +427,15 @@ function run(stage2) {
     const publicOn = check(stage2, onProject, onCache, true, "public-on");
     expectCounts("public gate off", publicOff.telemetry, 2, 0);
     expectCounts("public gate on", publicOn.telemetry, 2, 0);
-    if (publicOff.output !== publicOn.output) fail("public edit gate-off/on output mismatch");
+    if (publicOff.output !== publicOn.output) fail("public edit control/default output mismatch");
+    privateStringEdit(onProject);
+    const traceForcedOffTelemetry = traceForcedOff(stage2, onProject, onCache);
+    const postTraceDefault = check(stage2, onProject, onCache, true, "post-trace-default");
+    expectCounts("normal check after trace resets default policy", postTraceDefault.telemetry, 0, 2);
     expectTraceLaneRejected(stage2, onProject, onCache);
+    expectInvalidEnvRejected(stage2, onProject, onCache, "VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE", "true");
+    expectInvalidEnvRejected(stage2, onProject, onCache, "VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE", "0");
+    const v16Isolation = expectV16Isolation(stage2, work);
 
     const malformedProject = join(work, "malformed-target-project");
     const malformedCache = join(work, "malformed-target-cache");
@@ -546,9 +668,20 @@ function run(stage2) {
 
     console.log(JSON.stringify({
       schema: 1,
-      scenario: "experimental-typing-dependency-transport-env-reuse",
-      private_body: { gate_off: privateOff.telemetry, gate_on: privateOn.telemetry },
-      public_interface: { gate_off: publicOff.telemetry, gate_on: publicOn.telemetry },
+      scenario: "production-typing-dependency-transport-env-reuse",
+      default_policy: {
+        cold: coldOn.telemetry,
+        warm: warmOn.telemetry,
+        legacy_compatibility: legacyCompat.telemetry,
+        explicit_disable_control: coldOff.telemetry,
+        trace_forced_off: traceForcedOffTelemetry,
+        post_trace_default: postTraceDefault.telemetry,
+        v16_namespace_isolation: v16Isolation,
+        conservative_compile_output_parity: true,
+        invalid_env_diagnostics: true,
+      },
+      private_body: { explicit_disable: privateOff.telemetry, default_on: privateOn.telemetry },
+      public_interface: { explicit_disable: publicOff.telemetry, default_on: publicOn.telemetry },
       malformed_target_fallback: malformedTargetFallback.telemetry,
       missing_target_fallback: missingTargetFallback.telemetry,
       stale_target_fallback: staleTargetFallback.telemetry,


### PR DESCRIPTION
## Summary

Enable hardened TDRE4 TypeEnv reuse by default for the proven `vibe check` / check-only edit-cycle lane.

- normal check enables exact TDRE4 reuse without an opt-in variable
- `VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE=1` is a strict emergency opt-out
- legacy `VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE=1` remains accepted as a compatibility no-op; other values fail
- ordinary schema-v6 invalidation trace runs force TDRE4 off and remain observation-only
- explicit legacy opt-in plus trace retains its prior rejection
- policy resets on every check-only invocation, preventing long-lived state leaks
- persistent cache generation bumps `v16` → `v17`; old cache/TDRE generations are unreachable

Scope is deliberately TypeEnv reuse only. Runtime unset fallback remains false, so build/codegen/LSP and other FS consumers stay conservative. An attempted all-FS default crossed the signed 2 GiB heap boundary due exact-text publication; it was rejected rather than shipping a size heuristic. Compact exact publication for those lanes remains future work.

Interface-v2 remains observation-only. No CheckedProgram, typed IR, diagnostic, codegen, or linked-artifact reuse is claimed.

## Production evidence

- warm no-op: **0 rechecked / 2 reused**
- private dependency body edit: **1 rechecked / 1 reused**
- four-module private leaf edit: **1 rechecked / 3 reused**
- public signature / trait / impl changes: required modules fully rechecked
- malformed, missing, stale, valid-wrong, and cross-spliced state: full-check fallback

Measured local edit cycle:

| scenario | wall |
|---|---:|
| cold | 1040 ms |
| no-op | 236 ms |
| private edit | 261 ms |

Selfcompile remains conservative and within KPI: 1429 ms, 1,110,437,680 heap bytes (gate 1,183,271,821).

## Validation

- default-on/explicit-disable TDRE4 oracle: pass
- output and diagnostics parity: pass
- traits/impls/multilevel/adversarial fallback: pass
- trace forced-off and state-reset cases: pass
- v16/old namespace isolation: pass
- generated fixpoint and release-check: pass
- independent hard production review: safe to merge, no P0/P1; stale comment corrected

Progresses #1379 and delivers production incremental typing for the check/edit-cycle lane.
