### PR TITLE
interp: generic 文脈の Show を witness 経由でディスパッチする (#1445)

### DIFF
--- a/fixtures/interp_show_binding_test.vibe
+++ b/fixtures/interp_show_binding_test.vibe
@@ -15,17 +15,28 @@
 // rather than only `Some`/`Ok`/`Err`, which is what gives a USER enum's
 // pattern binder a type.
 //
-// STILL OPEN: a value reached through a generic parameter (`fn f[T: Show](x:
-// T) -> String { "\{x}" }`). That one is not a missing shape record -- there
-// is no shape, because `T` is whatever the caller instantiated. It needs the
-// Show dictionary to carry a renderer, i.e. method-bearing traits
-// (docs/method-bearing-traits-plan.md), not another sentinel here.
+// The generic-parameter case (`fn f[T: Show](x: T) -> String { "\{x}" }`) is
+// closed too, and NOT by another sentinel here -- there is no shape to record,
+// because `T` is whatever the caller instantiated. It goes through the Show
+// dictionary (docs/method-bearing-traits-plan.md components 3+4), with the
+// trait injected only into the desugar pass so the checker never starts
+// enforcing `impl Show` -- see synthetic_show_sigs in
+// lib/@vibe/compiler/normalize/desugar_trait_dict.vibe. The witness is total:
+// a type with no `C::to_string` still renders through the ADR-0058 heuristic,
+// which is what the Int/String blocks below pin.
 //
 // This is a separate file rather than more digits on interp_show_derive.vibe
 // because that fixture's weight is already 1e16 and vibe's Int literal ceiling
 // is 2^61-1 (~2.3e18) -- two more digits and the encoding overflows. Per-block
 // `test { }` attribution (#819) names the failing case directly anyway, which
 // is what the digit scheme was emulating.
+
+// `to_string` is bare-exported by the prelude but not ambient here, and the
+// generic block below pins that the spelled-out call renders like `"\{v}"`
+// does (#1443's symmetry) rather than only the interpolation form.
+import @vibe/prelude {
+  to_string
+}
 
 struct P {
   x: Int
@@ -59,6 +70,50 @@ fn nested_tuple_param(t: (Int, (Int, P))) -> String {
 
 fn array_param(a: Array[P]) -> String {
   "\{a}"
+}
+
+fn generic_interp[T: Show](v: T) -> String {
+  "\{v}"
+}
+
+fn generic_to_string[T: Show](v: T) -> String {
+  to_string(v)
+}
+
+/// A Show-bounded generic that forwards to ANOTHER one. The witness must be
+/// forwarded, not re-synthesized -- inside `generic_forward` the receiver's
+/// type is still the variable `T`, so there is nothing to synthesize from.
+fn generic_forward[T: Show](v: T) -> String {
+  generic_interp(v)
+}
+
+test "#1445: a value reached through a generic parameter renders structurally" {
+  let p = P::{
+    x: 1
+  }
+  assert_eq(generic_interp(p), "P { x: 1 }")
+  assert_eq(generic_to_string(p), "P { x: 1 }")
+  assert_eq(generic_interp(E2::B(3)), "B(3)")
+}
+
+test "#1445: the generic witness is forwarded through a second generic" {
+  let p = P::{
+    x: 2
+  }
+  assert_eq(generic_forward(p), "P { x: 2 }")
+}
+
+test "#1445: a type with no renderer keeps the ADR-0058 heuristic" {
+  // The synthetic Show witness is TOTAL -- this is the fallback member, and
+  // it must stay byte-identical to what the same value prints outside a
+  // generic, or activating the dictionary would be a regression for every
+  // type that does not derive(Show).
+  assert_eq(generic_interp(5), "5")
+  assert_eq(generic_interp("hi"), "hi")
+  // No `Bool` case: `[T: Show]` instantiated at `Bool` is rejected outright
+  // with `no impl 'Show' for 'Bool'` -- measured on the SEED compiler too, so
+  // it predates the witness and is a gap in which primitives
+  // register_builtin_traits gives a `Show` impl, not something this pass sees.
 }
 
 test "#1445: a tuple through a variable renders structurally" {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -117,6 +117,98 @@ fn collect_method_traits(stmts: Array[Stmt]) -> Array[(String, Array[(String, Ar
   out
 }
 
+/// #1445 原因2 (#1392 slice 3): the SYNTHETIC `Show` witness trait.
+///
+/// `Show` is a marker trait in source. `lib/@vibe/prelude/builtin_traits.vibe`
+/// spells `to_string[T: Show](x: T)`, but no `trait Show { .. }` declaration
+/// exists anywhere and `register_builtin_traits` (checker_trait.vibe) does not
+/// register one, so the bound is vacuous. That has to STAY vacuous: the moment
+/// a trait carries a method the checker enforces its impls, and `to_string` is
+/// a universal function -- a real `trait Show { to_string(Self) -> String }`
+/// turns `to_string(5)` into a hard `no impl 'Show' for 'Int'` (measured).
+///
+/// So the trait is injected HERE and nowhere else. This pass collects traits
+/// from the STATEMENT LIST (`collect_method_traits`); the checker enforces
+/// impls from its OWN env. Injecting into the former and not the latter buys
+/// the dictionary threading with none of the enforcement.
+///
+/// The witness is total by construction -- `build_concrete_dict` falls back to
+/// the ADR-0058 `__to_string` heuristic for a type with no `C::to_string` --
+/// so nothing that compiles today stops compiling, and a value whose type this
+/// pass cannot resolve renders exactly as it does now.
+fn synthetic_show_sigs() -> Array[(String, Array[TypeExpr], TypeExpr)] {
+  [
+    ("to_string", [
+      TyName("Self")
+    ], TyName("String"))
+  ]
+}
+
+fn bounds_mention_show(bounds: Array[(String, Array[String])]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(bounds) {
+    let (_, trait_list) = Array::get(bounds, i)
+    if str_array_contains(trait_list, "Show") {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// Whether this program has a `[T: Show]` bound worth threading a witness for.
+///
+/// The `__to_string` pass-through shims are excluded (`collect_show_shims` must
+/// have run first): they never render THROUGH the witness -- their whole body
+/// is the heuristic -- and threading them would put a hidden dict parameter on
+/// `to_string` itself, i.e. on every one of its call sites in the program.
+/// Without that exclusion the prelude alone would activate this for every
+/// compilation unit.
+fn program_wants_show_dict(stmts: Array[Stmt]) -> Bool {
+  let mut i = 0
+  let mut want = false
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, fname, _, body) => match body {
+        EFn(_, bounds, _, _, _, _) => if bounds_mention_show(bounds) && !str_array_contains(dtd_show_shims, fname) {
+          want = true
+        } else {
+          ()
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  want
+}
+
+/// `collect_method_traits` plus the synthetic `Show` entry when this program
+/// wants it. A program that declares its own method-bearing `trait Show` keeps
+/// that one verbatim -- the injection must never shadow a real declaration.
+fn collect_method_traits_with_show(stmts: Array[Stmt]) -> Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])] {
+  let declared = collect_method_traits(stmts)
+  match lookup_trait_sigs(declared, "Show") {
+    Some(_) => declared,
+    None => if program_wants_show_dict(stmts) {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(declared) {
+        Array::push(out, Array::get(declared, i))
+        i = i + 1
+      }
+      Array::push(out, ("Show", synthetic_show_sigs()))
+      out
+    } else {
+      declared
+    }
+  }
+}
+
 // ---- rank-1 method generics (#684) ----
 //
 // A trait method may declare its own type parameters, `m: [X: Show](Self, X) ->
@@ -1509,6 +1601,17 @@ fn find_dict_for_trait(dict_binds: Array[(String, String, String, Array[String])
   result
 }
 
+/// #1445: `(__w) -> String { __to_string(__w) }` -- the total fallback member
+/// of a synthetic `Show` witness (see synthetic_show_sigs). Same closure shape
+/// build_concrete_dict already synthesizes for a bounded generic-impl method.
+fn show_fallback_closure() -> Expr {
+  EFn(empty_str_array(), array_empty(), Array::slice([
+    ("__w", None)
+  ], 0, 1), None, None, ECall(EIdent("__to_string", -1), [
+    EIdent("__w", -1)
+  ], -1))
+}
+
 /// The first element of an array-literal receiver (for a bounded generic impl
 /// `impl [T: Bound] Trait for Array`, the element determines T's witness).
 fn first_array_elem(e: Expr) -> Option[Expr] {
@@ -1545,11 +1648,21 @@ fn build_concrete_dict(cname: String, trait_name: String, traits: Array[(String,
         let m = Array::get(mnames, mi)
         let qm = String::concat(cname, String::concat("::", m))
         if not(fn_exists(fn_returns, qm)) {
-          // No `cname::m` free function exists — `cname` does not actually
-          // implement `trait_name`. Refuse to fabricate a witness (which would
-          // otherwise silently dispatch to a same-shaped function), so the call
-          // is left unrewritten and fails loudly instead of miscompiling.
-          failed = true
+          // #1445: the SYNTHETIC `Show` witness is total. A type with no
+          // `C::to_string` renders through the ADR-0058 heuristic -- exactly
+          // what it does outside a generic today -- so threading a witness
+          // never turns a compiling program into a failing one. This is the
+          // one trait allowed a fabricated member, and only because its
+          // fallback is the status quo rather than a guess at an impl.
+          if trait_name == "Show" && m == "to_string" {
+            Array::push(recfields, (m, show_fallback_closure()))
+          } else {
+            // No `cname::m` free function exists — `cname` does not actually
+            // implement `trait_name`. Refuse to fabricate a witness (which would
+            // otherwise silently dispatch to a same-shaped function), so the call
+            // is left unrewritten and fails loudly instead of miscompiling.
+            failed = true
+          }
         } else {
           match lookup_gen(gens, qm) {
             Some(threaded) => {
@@ -3689,6 +3802,24 @@ fn interp_expand(arg: Expr, derived_only: Bool, gens: Array[(String, Array[(Stri
     Some(h) => h,
     None => ""
   }
+  // #1445 原因2: inside `f[T: Show](v: T)`, `head` is the TYPE PARAMETER `T`,
+  // not a concrete type -- every resolver below is looking for a type this
+  // pass can name, and a type variable is exactly the case where there is
+  // none. But the caller knows: `find_dict_for_method` hits when this function
+  // was threaded a `Show` witness, and the witness carries the renderer the
+  // concrete instantiation chose. Emitting the dict call here rather than
+  // `T::to_string(v)` is deliberate -- this runs INSIDE rewrite_expr, so a
+  // qualified call spelled now would not be revisited by the rewrite that
+  // lowers it.
+  match find_dict_for_method(dict_binds, head, "to_string") {
+    Some(dict_pname) => Some(ECall(EDot(EIdent(dict_pname, -1), "to_string", -1, -1), [
+      arg
+    ], -1)),
+    None => interp_expand_local(arg, head, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+  }
+}
+
+fn interp_expand_local(arg: Expr, head: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Error {
   match arg {
     ETuple(items) => Some(interp_join(items, "(", ", ", ")", derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),
     EArray(items) => Some(interp_join(items, "[", ", ", "]", derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),
@@ -8629,7 +8760,12 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Error {
   // rewrites are all no-ops (`gens` empty, sync-`for` classification gated off),
   // and the rewrite pass only classifies the ASYNC for-loop shapes — so it must
   // still run unconditionally (those shapes need no trait machinery, #1350).
-  let traits_raw = collect_method_traits(stmts)
+  // #1392: the `Show`-bounded `__to_string` pass-throughs in THIS program, so a
+  // spelled-out `to_string(v)` renders like `"\{v}"` does. See dtd_show_shims.
+  // #1445: must run BEFORE collect_method_traits_with_show, whose gate excludes
+  // the shims -- see program_wants_show_dict.
+  collect_show_shims(stmts)
+  let traits_raw = collect_method_traits_with_show(stmts)
   let supers_map = collect_trait_supers(stmts)
   let traits = flatten_traits(traits_raw, supers_map)
   // Rank-1 method generics (#684): re-attach each trait method's `[X: Bound]`
@@ -8643,9 +8779,6 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Error {
   let struct_sets = collect_struct_field_sets(stmts)
   let fn_returns = collect_fn_returns(stmts)
   let gimpl_types = collect_generic_impl_types(stmts)
-  // #1392: the `Show`-bounded `__to_string` pass-throughs in THIS program, so a
-  // spelled-out `to_string(v)` renders like `"\{v}"` does. See dtd_show_shims.
-  collect_show_shims(stmts)
   let gens = build_gens(stmts, traits, gimpl_types)
   // #839: see `collect_toplevel_anon_records` / the `rewrite_stmt` doc comment.
   let toplevel_vars = collect_toplevel_anon_records(stmts, struct_sets)


### PR DESCRIPTION
#1445 の原因2（最後の残件）。`fn f[T: Show](v: T) -> String { "\{v}" }` が生ポインタの10進数を出していた問題を閉じます。

```
                     before   after
generic to_string      196    P { x: 1 }
generic 補間           196    P { x: 1 }
user enum 越し         196    B(3)
```

## これは sentinel の追加ではない

#1445 の他のケース（変数越しのタプル/配列、pattern binder、ネスト）は束縛サイトで**形を記録**することで直りましたが、generic だけは違います。**記録すべき形が存在しない** — `T` は呼び出し側が instantiate したものだからです。witness が renderer を運ぶ必要があり、それは method-bearing traits（[docs/method-bearing-traits-plan.md](../blob/main/docs/method-bearing-traits-plan.md) の component 3+4）が**既に landed で動いている**機構です。実測でも、手書きの `trait Show2 { to_string2(Self) -> String }` + `impl Show2 for P` は今日そのまま正しくディスパッチします。

## なぜ `Show` をそのまま method-bearing にできないか

bound は method-bearing になった瞬間に**強制されます**（実測）:

```vibe
trait Show2 { to_string2(Self) -> String }
fn passthru[T: Show2](v: T) -> T { v }    // prelude の to_string[T: Show] と同じ形
fn main with Console { let n = passthru(5) }
```
```
no impl `Show2` for `Int`
```

`lib/@vibe/prelude/builtin_traits.vibe` の `to_string[T: Show](x: T) -> String { __to_string(x) }` は**万能関数**なので、素直に `trait Show { .. }` を宣言すると `to_string(5)` がハードエラーになります。`Show` が `register_builtin_traits` に登録すらされていない（bound が事実上 vacuous）のはそのためです。

## 分離点を使う

trait の収集と impl の強制は**別の場所**にあります:

| | どこから読むか |
|---|---|
| `desugar_trait_dicts` | ソースの**文リスト** (`collect_method_traits`) |
| checker | **自分の env** (`register_builtin_traits` / `SImpl`) |

なので `Show` を**前者にだけ**注入します（`collect_method_traits_with_show`）。checker は `trait Show { .. }` 宣言を一切見ないので impl 強制は発生せず、threading・呼び出し側の witness 合成・generic→generic の forwarding は**すべて既存の機構がそのまま担当**します。自前で `trait Show` を宣言したプログラムはそちらが優先されます（注入が実宣言を隠さない）。

## 今日通るものが通らなくならない2つの仕掛け

1. **witness が total**。`C::to_string` を持たない型には `(__w) -> String { __to_string(__w) }`（ADR-0058 のヒューリスティック）を渡します — generic の外で同じ値が出す表示と byte 単位で同一です。他の trait は今までどおり member の捏造を拒否します（偽の witness で黙って誤ディスパッチするより loud に落とす、という既存の判断は維持）。
2. **`__to_string` pass-through shim を gate から除外**。これが無いと prelude の `to_string[T: Show]` 自身に hidden dict パラメータが付き、プログラム中の全 `to_string` 呼び出しサイトに波及します。`collect_show_shims` が既にその shim を特定しているので、実行順を `collect_method_traits_with_show` の前に移して使っています。

## #1392 slice 4 との関係

「型が本当に分からない値をどう出すか」は、この設計では **2 のフォールバック経路の表示**そのものになりました。今回は「今日と同じ」を選んでいるので挙動の変化はゼロで、明示マーカーや checker 警告にしたくなったらそこ1箇所を差し替える形になります。

## 検証

- `pkf run test` 緑、**fixpoint `stage2 == stage3` (`2a13926c255a`)**
- `fixtures/interp_show_binding_test.vibe` 25/25 ブロック（generic 3ブロック追加: 直接・forwarding・フォールバック）
- typecheck fixtures 64件 / known debt 5
- `vibe fmt --check` clean

## 付随して分かったこと（この PR では直していない）

`[T: Show]` を `Bool` で instantiate すると `no impl 'Show' for 'Bool'` で落ちます。**seed コンパイラでも同じ**なので本 PR とは無関係で、`register_builtin_traits` がどのプリミティブに `Show` impl を与えているかの穴です。fixture のコメントに明記して、Bool のケースは入れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PENPDUZBtGEyxx27pMVtsa

---
_Generated by [Claude Code](https://claude.ai/code/session_01PENPDUZBtGEyxx27pMVtsa)_