### PR TITLE
feat: add canonical TDRE5 record codec

### DIFF
--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -188,6 +188,7 @@ runtime	runtime/eval_loader/index.vpkg
 runtime	runtime/eval_loader/eval_loader.vibe
 vibe_graph	../../../lib/@vibe/graph/index.vpkg
 vibe_graph	../../../lib/@vibe/graph/graph.vibe
+runtime	runtime/typing_dependency_record_codec.vibe
 runtime	runtime/typecheck_fs.vibe
 runtime	runtime/type_at.vibe
 runtime	runtime/binding_at.vibe

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -148,6 +148,12 @@ fn doc_at_source(source: String, line: Int, col: Int) -> String
 // --- symbol_spans.vibe
 fn symbol_spans(source: String) -> Array[(String, Int, Int, Int)] with Exception
 
+// --- typing_dependency_record_codec.vibe
+// Compiler-internal generic framing only; TDRE5 semantic field schemas remain
+// private to typecheck_fs and are not frozen in this contract.
+fn typing_dependency_record_encode_internal(tag: String, fields: Array[String]) -> String
+fn typing_dependency_record_decode_internal(text: String, expected_tag: String, expected_fields: Int) -> Option[Array[String]]
+
 // --- typecheck_fs.vibe
 fn locate_type_error(source: String, msg: String) -> String
 fn ensure_fingerprint_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs

--- a/lib/@vibe/compiler/runtime/typing_dependency_record_codec.vibe
+++ b/lib/@vibe/compiler/runtime/typing_dependency_record_codec.vibe
@@ -1,0 +1,131 @@
+//# Canonical framing for compiler-internal TDRE5 typing-dependency records.
+
+fn tdre5_record_tag_is_valid(tag: String) -> Bool {
+  tag == "TDEO5" || tag == "TDI5" || tag == "TDRA5" || tag == "TDC5" || tag == "TDREW5"
+}
+
+/// Compiler-internal generic framing primitive for the five exact TDRE5 tags.
+/// Field schemas stay private to typecheck_fs and are deliberately not
+/// represented by public semantic types. An unknown tag cannot be encoded.
+export fn typing_dependency_record_encode_internal(tag: String, fields: Array[String]) -> String {
+  if not(tdre5_record_tag_is_valid(tag)) {
+    ""
+  } else {
+    let out = StringBuilder::new()
+    StringBuilder::push(out, tag)
+    StringBuilder::push(out, __to_string(Array::length(fields)))
+    StringBuilder::push(out, "[")
+    let mut i = 0
+    while i < Array::length(fields) {
+      let field = Array::get(fields, i)
+      StringBuilder::push(out, __to_string(String::length(field)))
+      StringBuilder::push(out, ":")
+      StringBuilder::push(out, field)
+      i = i + 1
+    }
+    StringBuilder::push(out, "]")
+    StringBuilder::freeze(out)
+  }
+}
+
+/// Parses one canonical nonnegative decimal followed by `terminator`.
+/// Values larger than the complete input cannot describe either a field count
+/// or a field length, so bounding by `total` also prevents multiply-add
+/// overflow before any allocation or slice.
+fn tdre5_parse_decimal(text: String, pos: Int, terminator: Int) -> Option[(Int, Int)] {
+  let total = String::length(text)
+  if pos < 0 || pos >= total {
+    None
+  } else {
+    let first = String::char_code_at(text, pos)
+    if first < '0' || first > '9' {
+      None
+    } else if first == '0' {
+      let next = pos + 1
+      if next < total && String::char_code_at(text, next) == terminator {
+        Some((0, next + 1))
+      } else {
+        // Literal 0 is canonical; every longer zero-prefixed decimal is not.
+        None
+      }
+    } else {
+      let mut cursor = pos
+      let mut value = 0
+      let mut valid = true
+      while valid && cursor < total && String::char_code_at(text, cursor) != terminator {
+        let code = String::char_code_at(text, cursor)
+        let digit = code - '0'
+        if code < '0' || code > '9' || value > (total - digit) / 10 {
+          valid = false
+        } else {
+          value = value * 10 + digit
+          cursor = cursor + 1
+        }
+      }
+      if valid && cursor < total && String::char_code_at(text, cursor) == terminator {
+        Some((value, cursor + 1))
+      } else {
+        None
+      }
+    }
+  }
+}
+
+fn tdre5_parse_segment(text: String, pos: Int) -> Option[(String, Int)] {
+  match tdre5_parse_decimal(text, pos, ':') {
+    Some((field_len, start)) => {
+      let remaining = String::length(text) - start
+      if field_len > remaining {
+        None
+      } else {
+        let end = start + field_len
+        Some((String::substring(text, start, end), end))
+      }
+    },
+    None => None
+  }
+}
+
+/// Compiler-internal strict decoder for an exact tag and fixed field arity.
+/// Malformed, noncanonical, cross-tag, and trailing input always returns None.
+export fn typing_dependency_record_decode_internal(text: String, expected_tag: String, expected_fields: Int) -> Option[Array[String]] {
+  let tag_len = String::length(expected_tag)
+  if expected_fields < 0 || not(tdre5_record_tag_is_valid(expected_tag)) || not(String::starts_with(text, expected_tag)) {
+    None
+  } else {
+    match tdre5_parse_decimal(text, tag_len, '[') {
+      Some((field_count, after_count)) => if field_count != expected_fields {
+        None
+      } else {
+        let fields = Array::slice([
+          ""
+        ], 0, 0)
+        let mut cursor = after_count
+        let mut i = 0
+        let mut valid = true
+        while valid && i < field_count {
+          match tdre5_parse_segment(text, cursor) {
+            Some((field, next)) => {
+              Array::push(fields, field)
+              cursor = next
+              i = i + 1
+            },
+            None => {
+              valid = false
+            }
+          }
+        }
+        if not(valid) || cursor >= String::length(text) || String::char_code_at(text, cursor) != ']' || cursor + 1 != String::length(text) {
+          None
+        } else if typing_dependency_record_encode_internal(expected_tag, fields) != text {
+          // Keep this final equality even though the parser is strict: future
+          // parser changes must not silently widen the canonical wire grammar.
+          None
+        } else {
+          Some(fields)
+        }
+      },
+      None => None
+    }
+  }
+}

--- a/lib/@vibe/compiler/tests/typing_dependency_record_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/typing_dependency_record_codec_test.vibe
@@ -1,0 +1,117 @@
+//# Focused pure tests for compiler-internal TDRE5 canonical record framing.
+
+import @vibe/compiler/runtime {
+  typing_dependency_record_decode_internal, typing_dependency_record_encode_internal
+}
+
+fn tdre5_fields_equal(actual: Array[String], expected: Array[String]) -> Bool {
+  if Array::length(actual) != Array::length(expected) {
+    false
+  } else {
+    let mut equal = true
+    let mut i = 0
+    while equal && i < Array::length(expected) {
+      equal = Array::get(actual, i) == Array::get(expected, i)
+      i = i + 1
+    }
+    equal
+  }
+}
+
+fn tdre5_assert_decoded(decoded: Option[Array[String]], expected: Array[String], encoded: String, tag: String) -> Unit {
+  match decoded {
+    Some(fields) => {
+      assert(tdre5_fields_equal(fields, expected))
+      assert(typing_dependency_record_encode_internal(tag, fields) == encoded)
+    },
+    None => assert(false)
+  }
+}
+
+fn tdre5_assert_rejected(text: String, expected_tag: String, expected_fields: Int) -> Unit {
+  match typing_dependency_record_decode_internal(text, expected_tag, expected_fields) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
+test "TDRE5 canonical records round-trip empty and opaque special fields across every tag" {
+  let empty: Array[String] = [
+  ]
+  let empty_tags = [
+    "TDEO5",
+    "TDI5",
+    "TDRA5",
+    "TDC5",
+    "TDREW5"
+  ]
+  let mut empty_i = 0
+  while empty_i < Array::length(empty_tags) {
+    let tag = Array::get(empty_tags, empty_i)
+    let encoded = typing_dependency_record_encode_internal(tag, empty)
+    tdre5_assert_decoded(typing_dependency_record_decode_internal(encoded, tag, 0), empty, encoded, tag)
+    empty_i = empty_i + 1
+  }
+  let fields = [
+    "",
+    ":left[right]",
+    "line one\nline two\r\n",
+    "日本語🙂",
+    "TDEO5/TDI5/TDRA5/TDC5/TDREW5"
+  ]
+  let tags = [
+    "TDEO5",
+    "TDI5",
+    "TDRA5",
+    "TDC5",
+    "TDREW5"
+  ]
+  let mut i = 0
+  while i < Array::length(tags) {
+    let tag = Array::get(tags, i)
+    let encoded = typing_dependency_record_encode_internal(tag, fields)
+    tdre5_assert_decoded(typing_dependency_record_decode_internal(encoded, tag, 5), fields, encoded, tag)
+    i = i + 1
+  }
+}
+
+test "TDRE5 decoder rejects wrong tags arity counts and noncanonical decimals" {
+  assert(typing_dependency_record_encode_internal("TDRE5", [
+  ]) == "")
+  tdre5_assert_rejected("TDRE50[]", "TDRE5", 0)
+  tdre5_assert_rejected("0[]", "", 0)
+  let tdeo = typing_dependency_record_encode_internal("TDEO5", [
+    "x"
+  ])
+  tdre5_assert_rejected(tdeo, "TDI5", 1)
+  tdre5_assert_rejected(tdeo, "TDEO5", 0)
+  tdre5_assert_rejected("TDEO50[]", "TDREW5", 0)
+  tdre5_assert_rejected("TDEO500[]", "TDEO5", 0)
+  tdre5_assert_rejected("TDEO5-1[]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO5+1[0:]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO5 1[0:]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO5[]", "TDEO5", 0)
+  tdre5_assert_rejected("TDEO51[01:x]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO51[00:]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO51[-1:x]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO51[+1:x]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO51[ 1:x]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO51[:x]", "TDEO5", 1)
+  tdre5_assert_rejected("TDEO52[0:]", "TDEO5", 2)
+  tdre5_assert_rejected("TDEO51[0:0:x]", "TDEO5", 1)
+}
+
+test "TDRE5 decoder rejects overflow truncation missing delimiters brackets and trailing data" {
+  tdre5_assert_rejected("", "TDC5", 0)
+  tdre5_assert_rejected("TDC", "TDC5", 0)
+  tdre5_assert_rejected("TDC52305843009213693951[]", "TDC5", 0)
+  tdre5_assert_rejected("TDC51[2305843009213693951:x]", "TDC5", 1)
+  tdre5_assert_rejected("TDC51[3:ab]", "TDC5", 1)
+  tdre5_assert_rejected("TDC51[0:", "TDC5", 1)
+  tdre5_assert_rejected("TDC51[1x]", "TDC5", 1)
+  tdre5_assert_rejected("TDC51{1:x}", "TDC5", 1)
+  tdre5_assert_rejected("TDC51[1:x", "TDC5", 1)
+  tdre5_assert_rejected("TDC51[1:x}", "TDC5", 1)
+  tdre5_assert_rejected("TDC51[1:x]trailing", "TDC5", 1)
+  tdre5_assert_rejected("TDC50[]\n", "TDC5", 0)
+}


### PR DESCRIPTION
## Summary
- add a pure compiler-internal canonical framing codec for the five TDRE5 record tags
- reject unknown/cross tags, noncanonical decimal counts/lengths, malformed bounds, truncation, and trailing data
- require exact decode/re-encode equality
- add focused positive and fail-closed tests without changing cache policy or defaults

## Validation
- `VIBE_TEST_JOBS=1 bash scripts/vibe_test.sh lib/@vibe/compiler/tests/typing_dependency_record_codec_test.vibe`
- `bash scripts/vibe_fmt.sh --check lib/@vibe/compiler/runtime/typing_dependency_record_codec.vibe`
- `bash scripts/vibe_fmt.sh --check lib/@vibe/compiler/tests/typing_dependency_record_codec_test.vibe`
- `bash scripts/ensure_generated.sh --check`
- `git diff --check origin/main...HEAD`
- worker also ran `pkf run test-local` successfully
- local release-check reached fixture fanout but hit the known environment-specific `xargs: command line cannot be assembled, too long` limitation

## Scope
No cache behavior, reuse policy, or production default changes. Semantic TDRE5 record schemas remain private.
