### PR TITLE
#1485: 呼び出し地点で callee の row 変数を解決する — capability の漏れを塞ぐ

### DIFF
--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -65,15 +65,12 @@
 #     to restore.
 #
 #   generic_effect_{missing_caller_effect,matrix_fail_missing_effect_at_caller}
-#     are GENUINE lost checks, and worse than the fixtures suggest. The obvious
-#     hypothesis -- that the row leaks because `Error` is row-transparent -- was
-#     tested and is WRONG. Swapping `Error` for a capability or a user effect
-#     leaks identically (both measured, both compile):
-#       let apply = [T](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
-#       let boom  = (x: Int) -> Int with Fs { x }     // and with Ask
-#       let run   = (x: Int) -> Int { apply(boom, x) }   // no row required!
-#     So a function whose generic effect variable instantiates to a CAPABILITY
-#     claims a pure row. That is a permission leak, not just a bookkeeping gap.
+#     were the only GENUINE lost checks left, and worse than the fixtures
+#     suggested: the leak was not about `Error` being row-transparent (that
+#     hypothesis was tested and is wrong -- a capability or a user effect leaked
+#     identically), so a function whose generic effect variable instantiated to
+#     a CAPABILITY could claim a pure row. Fixed in #1485 by call-site
+#     effect-row unification; both rows are now `reject`.
 #
 # name	status	needle
 duplicate_enum_ctor	reject	duplicate ctor: A
@@ -89,13 +86,13 @@ effect_undeclared_op	reject	unknown operation `Debug` of effect Logger
 effect_unknown_op	reject	unknown operation `NoSuchOp` of effect Console
 effect_wrong_effect_name	reject	effect row mismatch for 'bad': missing { State::Get } (declared { Console }, requires { Console, State::Get })
 generic_effect_concrete_effect_mismatch	reject	effect row mismatch for 'chain': missing { Exception } (declared { Stdout }, requires { Exception, Stdout })
-generic_effect_matrix_fail_missing_effect_at_caller	debt-accepts	type: effect requirements not satisfied: `apply`
+generic_effect_matrix_fail_missing_effect_at_caller	reject	effect row mismatch for 'run': missing { Exception }
 generic_effect_matrix_fail_missing_wrapper_effect	reject	effect row mismatch for 'apply': missing { e } (no 'with' clause, requires { e })
 generic_effect_matrix_fail_trait_and_effect_mixed	reject	no impl `LocalEq` for `String`
 generic_effect_matrix_ok_passthrough_pure	ok	
 generic_effect_matrix_ok_trait_and_effect_bound	ok	
 generic_effect_matrix_ok_with_e_try_catch_localized	ok	
-generic_effect_missing_caller_effect	debt-accepts	type: effect requirements not satisfied: `apply`
+generic_effect_missing_caller_effect	reject	effect row mismatch for 'run': missing { Exception }
 generic_effect_trait_bound_violation	reject	no impl `LocalEq` for `String`
 generic_effect_try_catch_localizes_error	ok	
 generic_effect_wrapper_requires_effect_decl	reject	effect row mismatch for 'apply': missing { e } (no 'with' clause, requires { e })

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1331,6 +1331,169 @@ fn fn_binding_effects(ty: Option[TypeExpr], body: Expr) -> Array[String] {
   }
 }
 
+/// #1485: the effect labels a PARAMETER's own type declares. `(T) -> T with e`
+/// yields `["e"]`; a non-function parameter yields nothing.
+fn param_type_effect_labels(pty: TypeExpr) -> Array[String] {
+  match pty {
+    TyFn(_, _, peff) => effect_row_labels(effect_row_parse(peff)),
+    _ => no_str_labels()
+  }
+}
+
+/// #1485: per-PARAMETER effect labels for one top-level binding, positionally.
+/// `apply: [T](f: (T) -> T with e, x: T) -> T with e` yields `[["e"], []]`.
+///
+/// This is the data call-site row unification needs. To resolve what a callee's
+/// row VARIABLE binds to at ONE call site you have to know which of its
+/// parameters carry that variable, and then look at what was actually passed
+/// there -- the callee's own row alone cannot tell you, which is exactly why
+/// the transitive check used to exempt row variables outright.
+///
+/// Both spellings of a signature are read, because they put the parameter types
+/// in different places: a separate annotation (`let apply: [T](f: (T) -> T with
+/// e, ..) -> T = ..`) carries them on the `SLet`'s `TyFn`, while the inline
+/// generic literal (`let apply = [T](f: (x: T) -> T with e, ..) -> T with e
+/// { .. }`, the form both #1485 fixtures use) carries them on the `EFn`.
+fn fn_binding_param_effects(ty: Option[TypeExpr], body: Expr) -> Array[Array[String]] {
+  let out = array_empty()
+  match ty {
+    Some(TyFn(sig_params, _, _)) => {
+      let mut i = 0
+      while i < Array::length(sig_params) {
+        Array::push(out, param_type_effect_labels(Array::get(sig_params, i)))
+        i = i + 1
+      }
+    },
+    _ => match body {
+      EFn(_, _, params, _, _, _) => {
+        let mut i = 0
+        while i < Array::length(params) {
+          let (_, pty) = Array::get(params, i)
+          match pty {
+            Some(t) => Array::push(out, param_type_effect_labels(t)),
+            None => Array::push(out, no_str_labels())
+          }
+          i = i + 1
+        }
+      },
+      _ => ()
+    }
+  }
+  out
+}
+
+fn no_param_effs() -> Array[Array[Array[String]]] {
+  array_empty()
+}
+
+/// One callee's "no parameter rows known" entry.
+fn no_param_row() -> Array[Array[String]] {
+  array_empty()
+}
+
+/// Positional lookup companion to `lookup_fn_effs` -- same parallel-array
+/// discipline (see that function's note on why this is a linear scan).
+fn lookup_fn_param_effs(names: Array[String], param_effs: Array[Array[Array[String]]], name: String) -> Option[Array[Array[String]]] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(names) && i < Array::length(param_effs) {
+    match found {
+      None => if Array::get(names, i) == name {
+        found = Some(Array::get(param_effs, i))
+      } else {
+        ()
+      },
+      Some(_) => ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// #1485: what a callee's row VARIABLE is instantiated to at ONE call site.
+///
+/// `row_var` is a row-variable label from the callee's declared row (e.g. `"e"` of
+/// `apply: [T](f: (T) -> T with e, x: T) -> T with e`). For every parameter
+/// whose own type declares that same variable, the argument actually passed
+/// there is resolved to its declared row, and the union of those rows is what
+/// the variable binds to here.
+///
+/// Returns None when the instantiation cannot be determined, and the caller
+/// then keeps the pre-#1485 exemption. That happens when a contributing
+/// argument is anything other than a name this pass can look up -- a lambda
+/// literal, a call result, a field access. Bailing out there is what keeps the
+/// change one-directional: a call site either gains a requirement that is
+/// justified by a row we actually read, or is left exactly as it was. It never
+/// guesses, so it cannot produce the false positives that sank the naive fix
+/// (`generic_effect_matrix_ok_passthrough_pure`, where `apply(inc, 41)` passes
+/// a PURE function and must keep requiring nothing).
+fn resolve_row_var_instantiation(row_var: String, callee_param_effs: Array[Array[String]], args: Array[Expr], fn_names: Array[String], fn_effs: Array[Array[String]], ov_names: Array[String], ov_effs: Array[Array[String]]) -> Option[Array[String]] {
+  let out = no_str_labels()
+  let mut i = 0
+  let mut bailed = false
+  let mut saw_param = false
+  while i < Array::length(callee_param_effs) {
+    if effect_row_has_label(Some(Array::get(callee_param_effs, i)), row_var) {
+      saw_param = true
+      if i < Array::length(args) {
+        match Array::get(args, i) {
+          EIdent(argname, _) => {
+            // A named argument: its row is whatever the call-graph map or the
+            // in-scope callback overlay records for it. An argument naming
+            // nothing either table knows (an import this pass cannot see) is a
+            // bail-out, not an empty row -- treating "unknown" as "pure" would
+            // silently authorize the very leak this is closing.
+            match lookup_fn_effs(fn_names, fn_effs, argname) {
+              Some(argeffs) => {
+                let mut k = 0
+                while k < Array::length(argeffs) {
+                  let lbl = Array::get(argeffs, k)
+                  if effect_row_has_label(Some(out), lbl) {
+                    ()
+                  } else {
+                    Array::push(out, lbl)
+                  }
+                  k = k + 1
+                }
+              },
+              None => match lookup_fn_effs(ov_names, ov_effs, argname) {
+                Some(argeffs2) => {
+                  let mut k2 = 0
+                  while k2 < Array::length(argeffs2) {
+                    let lbl2 = Array::get(argeffs2, k2)
+                    if effect_row_has_label(Some(out), lbl2) {
+                      ()
+                    } else {
+                      Array::push(out, lbl2)
+                    }
+                    k2 = k2 + 1
+                  }
+                },
+                None => {
+                  bailed = true
+                }
+              }
+            }
+          },
+          _ => {
+            bailed = true
+          }
+        }
+      } else {
+        bailed = true
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  if bailed || !saw_param {
+    None
+  } else {
+    Some(out)
+  }
+}
+
 /// Look up a called function's declared effect row by linear scan over PARALLEL
 /// arrays (names[i] <-> effs[i]). A `Map` here allocates per lookup and, across
 /// the compiler's tens of thousands of call sites, exhausts the GC-less bump heap
@@ -1545,14 +1708,18 @@ fn merge_param_types_with_sig(ty: Option[TypeExpr], params: Array[(String, Optio
 /// program's top level and at any call site with no enclosing function-typed
 /// parameters in scope).
 export fn check_perform_effects_expr_tx(root: Expr, root_declared: Array[String], root_in_handle: Bool, fn_names: Array[String], fn_effs: Array[Array[String]], root_ov_names: Array[String], root_ov_effs: Array[Array[String]]) -> Array[EffectError] {
-  check_perform_effects_expr_tx_in("", root, root_declared, root_in_handle, fn_names, fn_effs, root_ov_names, root_ov_effs, no_kind_binds())
+  // #1485: the public entry keeps its 7-arg contract and supplies an EMPTY
+  // per-parameter table, which switches call-site row unification off and
+  // restores the pre-#1485 exemption. Callers of this entry are unit-test and
+  // non-stmts paths that have no call-graph parameter types to offer anyway.
+  check_perform_effects_expr_tx_in("", root, root_declared, root_in_handle, fn_names, fn_effs, no_param_effs(), root_ov_names, root_ov_effs, no_kind_binds())
 }
 
 /// #639: the same walk with the enclosing top-level binding's NAME threaded in
 /// so row-mismatch diagnostics can blame the caller's declaration in the fix-it
 /// hint. The name is constant per walk (lambdas are anonymous), so it rides as
 /// a plain parameter, not on the work stack.
-fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: Array[String], root_in_handle: Bool, fn_names: Array[String], fn_effs: Array[Array[String]], root_ov_names: Array[String], root_ov_effs: Array[Array[String]], root_kinds: Array[(String, String)]) -> Array[EffectError] {
+fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: Array[String], root_in_handle: Bool, fn_names: Array[String], fn_effs: Array[Array[String]], fn_param_effs: Array[Array[Array[String]]], root_ov_names: Array[String], root_ov_effs: Array[Array[String]], root_kinds: Array[(String, String)]) -> Array[EffectError] {
   let errors = array_empty()
   let stack = Array::slice([
     (root, root_declared, root_in_handle, root_ov_names, root_ov_effs, root_kinds)
@@ -1675,7 +1842,37 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                   // effect name first, then the exact operation, so both
                   // spellings of the caller's row work and nothing that
                   // authorized before stops authorizing.
-                  if String::length(teff) > 0 && (!is_exception_effect_name(teff) || error_row_checked()) && teff != "Async" && !label_is_effect_var(teff) && !in_handle && !decl_authorizes_op(declared, teff) {
+                  if label_is_effect_var(teff) {
+                    // #1485: a row VARIABLE used to be skipped outright. It is
+                    // now resolved AT THIS CALL SITE from the arguments
+                    // actually passed to the parameters that carry it, and the
+                    // labels it turns out to denote are required like any
+                    // other. Unresolvable instantiations still fall through to
+                    // the old exemption (see resolve_row_var_instantiation).
+                    let callee_param_effs = match lookup_fn_param_effs(fn_names, fn_param_effs, name) {
+                      Some(pe) => pe,
+                      None => no_param_row()
+                    }
+                    match resolve_row_var_instantiation(teff, callee_param_effs, args, fn_names, fn_effs, ov_names, ov_effs) {
+                      Some(inst) => {
+                        let mut ii = 0
+                        while ii < Array::length(inst) {
+                          let ieff = Array::get(inst, ii)
+                          // Same discipline the concrete branch below applies:
+                          // the exception row and `Async` are row-transparent,
+                          // and a variable resolving to another variable is
+                          // still unresolved.
+                          if String::length(ieff) > 0 && (!is_exception_effect_name(ieff) || error_row_checked()) && ieff != "Async" && !label_is_effect_var(ieff) && !in_handle && !decl_authorizes_op(declared, ieff) {
+                            Array::push(missing, ieff)
+                          } else {
+                            ()
+                          }
+                          ii = ii + 1
+                        }
+                      },
+                      None => ()
+                    }
+                  } else if String::length(teff) > 0 && (!is_exception_effect_name(teff) || error_row_checked()) && teff != "Async" && !in_handle && !decl_authorizes_op(declared, teff) {
                     Array::push(missing, teff)
                   } else {
                     ()
@@ -1982,7 +2179,7 @@ export fn check_perform_effects_expr(root: Expr, root_declared: Array[String], r
   check_perform_effects_expr_tx(root, root_declared, root_in_handle, no_str_labels(), no_ov_effs(), no_str_labels(), no_ov_effs())
 }
 
-fn check_perform_effects_binding_tx(fn_name: String, ty: Option[TypeExpr], body: Expr, fn_names: Array[String], fn_effs: Array[Array[String]]) -> Array[EffectError] {
+fn check_perform_effects_binding_tx(fn_name: String, ty: Option[TypeExpr], body: Expr, fn_names: Array[String], fn_effs: Array[Array[String]], fn_param_effs: Array[Array[Array[String]]]) -> Array[EffectError] {
   let sig_labels = sig_type_effect_labels(ty)
   match body {
     // #885: build the callback-parameter overlay for THIS binding's own
@@ -1997,9 +2194,9 @@ fn check_perform_effects_binding_tx(fn_name: String, ty: Option[TypeExpr], body:
       // parameters up on its own.
       let merged_params = merge_param_types_with_sig(ty, params)
       let (ov_names, ov_effs) = build_param_overlay(merged_params)
-      check_perform_effects_expr_tx_in(fn_name, fbody, labels_union(sig_labels, effect_row_labels(effect_row_parse(eff))), false, fn_names, fn_effs, ov_names, ov_effs, throw_kind_bind_params(no_kind_binds(), merged_params))
+      check_perform_effects_expr_tx_in(fn_name, fbody, labels_union(sig_labels, effect_row_labels(effect_row_parse(eff))), false, fn_names, fn_effs, fn_param_effs, ov_names, ov_effs, throw_kind_bind_params(no_kind_binds(), merged_params))
     },
-    _ => check_perform_effects_expr_tx_in(fn_name, body, sig_labels, false, fn_names, fn_effs, no_str_labels(), no_ov_effs(), no_kind_binds())
+    _ => check_perform_effects_expr_tx_in(fn_name, body, sig_labels, false, fn_names, fn_effs, fn_param_effs, no_str_labels(), no_ov_effs(), no_kind_binds())
   }
 }
 
@@ -2055,13 +2252,13 @@ fn error_row_checked() -> Bool {
 // 根拠 (Fs/Env の使用 operation 分布、Stdin の推移的要求、Process に退避先の
 // 綴りが無いこと) も表側のコメントへ移した。
 
-fn check_perform_effects_stmt_tx(stmt: Stmt, fn_names: Array[String], fn_effs: Array[Array[String]]) -> Array[EffectError] {
+fn check_perform_effects_stmt_tx(stmt: Stmt, fn_names: Array[String], fn_effs: Array[Array[String]], fn_param_effs: Array[Array[Array[String]]]) -> Array[EffectError] {
   match stmt {
-    SLet(_, _, name, ty, body) => check_perform_effects_binding_tx(name, ty, body, fn_names, fn_effs),
-    SLetMut(name, ty, body) => check_perform_effects_binding_tx(name, ty, body, fn_names, fn_effs),
-    STest(_, body) => check_perform_effects_expr_tx(body, test_bench_ambient_effects(), false, fn_names, fn_effs, no_str_labels(), no_ov_effs()),
-    SBench(_, body) => check_perform_effects_expr_tx(body, test_bench_ambient_effects(), false, fn_names, fn_effs, no_str_labels(), no_ov_effs()),
-    SExpr(e) => check_perform_effects_expr_tx(e, effect_row_labels(effect_row_parse(None)), false, fn_names, fn_effs, no_str_labels(), no_ov_effs())
+    SLet(_, _, name, ty, body) => check_perform_effects_binding_tx(name, ty, body, fn_names, fn_effs, fn_param_effs),
+    SLetMut(name, ty, body) => check_perform_effects_binding_tx(name, ty, body, fn_names, fn_effs, fn_param_effs),
+    STest(_, body) => check_perform_effects_expr_tx_in("", body, test_bench_ambient_effects(), false, fn_names, fn_effs, fn_param_effs, no_str_labels(), no_ov_effs(), no_kind_binds()),
+    SBench(_, body) => check_perform_effects_expr_tx_in("", body, test_bench_ambient_effects(), false, fn_names, fn_effs, fn_param_effs, no_str_labels(), no_ov_effs(), no_kind_binds()),
+    SExpr(e) => check_perform_effects_expr_tx_in("", e, effect_row_labels(effect_row_parse(None)), false, fn_names, fn_effs, fn_param_effs, no_str_labels(), no_ov_effs(), no_kind_binds())
     _ => array_empty()
   }
 }
@@ -2071,7 +2268,7 @@ export fn check_perform_effects_stmt(stmt: Stmt) -> Array[EffectError] {
   // No env to resolve payload kinds from: clear the table rather than let a
   // previous module's bindings decide this one's throw kinds (#1344).
   set_throw_kind_table(EnvEmpty)
-  check_perform_effects_stmt_tx(stmt, no_str_labels(), no_ov_effs())
+  check_perform_effects_stmt_tx(stmt, no_str_labels(), no_ov_effs(), no_param_effs())
 }
 
 /// #812: seed the transitive call-graph map with the checker ENV's bindings.
@@ -2083,7 +2280,7 @@ export fn check_perform_effects_stmt(stmt: Stmt) -> Array[EffectError] {
 /// AFTER the local rows (lookup_fn_effs is first-match, so a same-name local
 /// row still shadows the env row). Effect-free bindings are skipped — an
 /// absent row and an empty row enforce the same (nothing).
-fn push_env_fn_eff(name: String, ty: Type, fn_names: Array[String], fn_effs: Array[Array[String]]) -> Unit {
+fn push_env_fn_eff(name: String, ty: Type, fn_names: Array[String], fn_effs: Array[Array[String]], fn_param_effs: Array[Array[Array[String]]]) -> Unit {
   let fnty = match ty {
     CtForAll(_, _, body) => body,
     _ => ty
@@ -2094,6 +2291,12 @@ fn push_env_fn_eff(name: String, ty: Type, fn_names: Array[String], fn_effs: Arr
       if Array::length(labels) > 0 {
         Array::push(fn_names, name)
         Array::push(fn_effs, labels)
+        // #1485: an env-seeded (imported) binding carries a checked `Type`, not
+        // the `TypeExpr` the per-parameter table is built from, so it gets an
+        // empty entry and keeps the exemption. Pushing SOMETHING is required --
+        // the three arrays are index-aligned, and a skipped push would shift
+        // every later callee's parameter list onto the wrong name.
+        Array::push(fn_param_effs, no_param_row())
       } else {
         ()
       }
@@ -2102,13 +2305,13 @@ fn push_env_fn_eff(name: String, ty: Type, fn_names: Array[String], fn_effs: Arr
   }
 }
 
-fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[String]]) -> Unit {
+fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[String]], fn_param_effs: Array[Array[Array[String]]]) -> Unit {
   let mut cur = env
   let mut looping = true
   while looping {
     match cur {
       EnvBind(name, ty, rest) => {
-        push_env_fn_eff(name, ty, fn_names, fn_effs)
+        push_env_fn_eff(name, ty, fn_names, fn_effs, fn_param_effs)
         cur = rest
       },
       EnvTraitDef(_, _, _, _, rest, _, _) => {
@@ -2127,7 +2330,7 @@ fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[
         let mut ei = 0
         while ei < Array::length(entries) {
           let (ename, ety) = Array::get(entries, ei)
-          push_env_fn_eff(ename, ety, fn_names, fn_effs)
+          push_env_fn_eff(ename, ety, fn_names, fn_effs, fn_param_effs)
           ei = ei + 1
         }
         looping = false
@@ -2139,17 +2342,19 @@ fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[
   }
 }
 
-fn build_perform_fn_effs(stmts: Array[Stmt], fn_names: Array[String], fn_effs: Array[Array[String]]) -> Unit {
+fn build_perform_fn_effs(stmts: Array[Stmt], fn_names: Array[String], fn_effs: Array[Array[String]], fn_param_effs: Array[Array[Array[String]]]) -> Unit {
   let mut m = 0
   while m < Array::length(stmts) {
     match Array::get(stmts, m) {
       SLet(_, _, name, ty, body) => {
         Array::push(fn_names, name)
         Array::push(fn_effs, fn_binding_effects(ty, body))
+        Array::push(fn_param_effs, fn_binding_param_effects(ty, body))
       },
       SLetMut(name, ty, body) => {
         Array::push(fn_names, name)
         Array::push(fn_effs, fn_binding_effects(ty, body))
+        Array::push(fn_param_effs, fn_binding_param_effects(ty, body))
       },
       _ => ()
     }
@@ -2169,8 +2374,14 @@ export fn check_perform_effects_stmts_env(stmts: Array[Stmt], env: TypeEnv) -> A
   // functions it invokes.
   let fn_names = array_empty()
   let fn_effs = array_empty()
-  build_perform_fn_effs(stmts, fn_names, fn_effs)
-  seed_env_fn_effs(env, fn_names, fn_effs)
+  // #1485: the third parallel array is per-PARAMETER rows, used to resolve what
+  // a callee's row VARIABLE binds to at each call site. It stays index-aligned
+  // with the first two; entries seeded from the env get an empty list, which
+  // reads as "no parameter types available here" and leaves those callees on
+  // the pre-#1485 exemption.
+  let fn_param_effs = no_param_effs()
+  build_perform_fn_effs(stmts, fn_names, fn_effs, fn_param_effs)
+  seed_env_fn_effs(env, fn_names, fn_effs, fn_param_effs)
   // ADR-0085 Phase 3 (#1344): rebuild the `throw` payload-kind table from the
   // same checked env, so a typed `Exception[K]` row can be compared against
   // what each throw site actually throws.
@@ -2178,7 +2389,7 @@ export fn check_perform_effects_stmts_env(stmts: Array[Stmt], env: TypeEnv) -> A
   let errors = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
-    append_eff_errs(errors, check_perform_effects_stmt_tx(Array::get(stmts, i), fn_names, fn_effs))
+    append_eff_errs(errors, check_perform_effects_stmt_tx(Array::get(stmts, i), fn_names, fn_effs, fn_param_effs))
     i = i + 1
   }
   // #1347: only once the rows themselves check out — on a program with real


### PR DESCRIPTION
呼び出し側が callee の effect row **変数**を具体化しても、そのラベルを一切受け取っていなかった。main での実測:

```vibe
let apply = [T](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
let boom  = (x: Int) -> Int with Fs { x }
let run   = (x: Int) -> Int { apply(boom, x) }   // 通っていた。row 宣言なし
```

`run` は `Fs` に到達するのに何も宣言しない。**generic を経由しない同じプログラムは拒否される**ので、方針ではなく片方の経路の穴。

「`Error` (元々 row-transparent、fixture が使っている綴り) のときだけの話では」という仮説は**検証して外れた** — `Fs` でも user effect の `Ask` でも同じように漏れる。したがって権限の話で、ADR-0084 の entry row 検査も ADR-0088 の `allows` も**宣言された row が起点**なので、ラベルが載らない限り検査対象にならない。

## これまでの実装と、その理由

transitive pass は row 変数のラベルを丸ごと飛ばしていた。これは見落としではなく load-bearing で、row 変数の**トークンそのもの**を呼び出し側に要求すると `apply(inc, 41)`（`inc` は pure で変数は空に具体化される）が誤って落ちる。`generic_effect_matrix_ok_passthrough_pure` はそれを pin するために存在する。

コード自身が必要な修正を名指ししていた — 「call-site effect-row unification (matching the argument actually passed against the callee's parameter type)」 — そして #885 を指していたが、#885 は wrapper 側だけを対象に close 済みで、その close コメントがこの downstream 側を未解決として flag していた（追跡する issue は無かった → #1485）。

## この PR がやること

`fn_names`/`fn_effs` に3本目の parallel array を足す: 各 callee の**パラメータごとの宣言 row**。パラメータ型がどちらの綴りに載っていても読む（別注釈なら `SLet` の `TyFn`、インラインの generic literal なら `EFn`）。

callee の row が変数を含む呼び出し地点で:

1. その変数を持つパラメータを特定する
2. そこに実際に渡された引数を、それ自身の宣言 row へ解決する
3. その和が、**この地点で**その変数が意味するもの

得られたラベルを、具体的な row とまったく同じように要求する。

**解決できないときは旧来の免除へ落ちる** — 引数がこの pass で名前を引けないもの（ラムダリテラル、呼び出し結果、見えない import）のとき。**不明を pure と読むことはしない**（それこそが塞ごうとしている漏れを認可してしまう）。したがって変更は一方向で、呼び出し地点は「実際に読んだ row に裏付けられた要求を得る」か「まったく元のまま」かのどちらかにしかならない。

## 結果

| ケース | 変化 |
|---|---|
| `apply(boom, x)`, `boom: with Fs` | → `missing { Fs }` |
| `apply(boom, x)`, `boom: with Ask` | → `missing { Ask }` |
| `apply(inc, 41)`, `inc` pure | 変化なし（受理） |
| `matrix_ok_with_e_try_catch_localized` / `matrix_ok_trait_and_effect_bound` | 変化なし（受理） |

#1464 の債務2行が `reject` へ昇格。予想に反して**沈黙せず `Exception` で発火**した — checked-exception row が有効な状態では erased ラベルも他と同様に要求されるので、fixture は自分の綴りのまま拒否される。typecheck 債務: 5 → 3。

## 検証

```
BUILD RC=0   stage1 == stage2 fixpoint（コンパイラ自身のソースも新しい検査を通過）
FMT   RC=0   904 files, 0 new violations
GATE  RC=0   typecheck fixtures ok (64 fixtures, 3 known debt)
UNIT  RC=0   528/528
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_