### PR TITLE
#1461 最終段: `Error` を effect の綴りとして退役させる

### DIFF
--- a/fixtures/boundary_test.vibe
+++ b/fixtures/boundary_test.vibe
@@ -163,12 +163,12 @@ test "record_destructure" {
 }
 
 test "throw_handle" {
-  let fail_fn: () -> Int with Error = () -> {
+  let fail_fn: () -> Int with Exception = () -> {
     throw("error")
   }
   let r = handle {
     fail_fn()
-  } with Error {
+  } with Exception {
     Throw(_) => 42
   }
   assert(r == 42)

--- a/fixtures/cheatsheet_effects_test.vibe
+++ b/fixtures/cheatsheet_effects_test.vibe
@@ -1,38 +1,38 @@
-// Test 1: Function that throws an error with `with Error`
-fn risky(x: Int) -> Int with Error {
+// Test 1: Function that throws an error with `with Exception`
+fn risky(x: Int) -> Int with Exception {
   if x == 0 { throw("division by zero") }
   100 / x
 }
 
-test "1 - throw with Error effect" {
-  let result = handle { risky(0) } with Error { Throw(_) => -1 }
+test "1 - throw with Exception effect" {
+  let result = handle { risky(0) } with Exception { Throw(_) => -1 }
   assert(result == -1)
 }
 
-// Test 2: Handling error with handle { } with Error { Throw(msg) => ... }
+// Test 2: Handling error with handle { } with Exception { Throw(msg) => ... }
 test "2 - handle catches error" {
-  let result = handle { risky(5) } with Error { Throw(_) => -1 }
+  let result = handle { risky(5) } with Exception { Throw(_) => -1 }
   assert(result == 20)
 }
 
 test "2b - handle catches thrown error" {
-  let result = handle { risky(0) } with Error { Throw(_) => 42 }
+  let result = handle { risky(0) } with Exception { Throw(_) => 42 }
   assert(result == 42)
 }
 
 // Test 3: Nested error handling
 test "3 - nested error handling" {
-  let inner: () -> Int with Error = () -> {
+  let inner: () -> Int with Exception = () -> {
     throw("inner error")
     0
   }
   let result = handle {
     handle {
       inner()
-    } with Error {
+    } with Exception {
       Throw(_) => 42
     }
-  } with Error {
+  } with Exception {
     Throw(_) => 0
   }
   assert(result == 42)
@@ -47,4 +47,4 @@ test "3 - nested error handling" {
 //   5. effect Logger { Log(String) -> Unit } — user-defined effects
 //   6. perform Logger::Log(msg) + resume(()) — algebraic effect pattern
 //   7. [T](f: (T) -> T with e, x: T) -> T with e — effect polymorphism
-//   8. with Error + Counter — multiple effect composition
+//   8. with Exception + Counter — multiple effect composition

--- a/fixtures/cheatsheet_eval_test.vibe
+++ b/fixtures/cheatsheet_eval_test.vibe
@@ -138,13 +138,13 @@ test "loop with break and continue" {
 
 // --- 11. Error effects: throw + handle ---
 test "error effects" {
-  let risky: (Int) -> Int with Error = (x) -> {
+  let risky: (Int) -> Int with Exception = (x) -> {
     if x == 0 { throw("division by zero") }
     100 / x
   }
-  let safe = handle { risky(0) } with Error { Throw(_msg) => -1 }
+  let safe = handle { risky(0) } with Exception { Throw(_msg) => -1 }
   assert(safe == -1)
-  let ok = handle { risky(10) } with Error { Throw(_msg) => -1 }
+  let ok = handle { risky(10) } with Exception { Throw(_msg) => -1 }
   assert(ok == 10)
 }
 

--- a/fixtures/contract_conformance_test.vibe
+++ b/fixtures/contract_conformance_test.vibe
@@ -202,12 +202,12 @@ test "malformed require lines are rejected (#730 D-2)" {
   let bad1 = handle {
     let _ = extract_require_pins("require @a/b 1.2 = #pkg:sha1:dfd1c758bb64203416db0b64b5854882a43abc11\n")
     false
-  } with Error { Throw(_) => true }
+  } with Exception { Throw(_) => true }
   assert(bad1)
   let bad2 = handle {
     let _ = extract_require_pins("require @a/b 1.2.3 = #bad\n")
     false
-  } with Error { Throw(_) => true }
+  } with Exception { Throw(_) => true }
   assert(bad2)
 }
 
@@ -252,7 +252,7 @@ test "contract declaration with a body is rejected (#729)" {
   let failed = handle {
     let _ = parse_contract_program(lex("fn bad(x: Int) -> Int { x }"))
     false
-  } with Error {
+  } with Exception {
     Throw(_) => true
   }
   assert(failed)
@@ -300,7 +300,7 @@ test "contract value declaration with a definition is rejected (#752)" {
   let outcome = handle {
     let (_, _, _) = parse_contract_program(lex("let pi: Double = 3.14"))
     "no-throw"
-  } with Error {
+  } with Exception {
     Throw(msg) => if String::contains(msg, "must not have a definition") {
       "rejected"
     } else {
@@ -385,14 +385,14 @@ test "version directive: malformed forms are rejected (#754)" {
   let bad = handle {
     let (_, _) = extract_require_pins("version ^1.2.3\nfn f(x: Int) -> Int")
     ""
-  } with Error {
+  } with Exception {
     Throw(msg) => msg
   }
   assert(String::contains(bad, "exact semver"))
   let dup = handle {
     let (_, _) = extract_require_pins("version 1.0.0\nversion 1.0.1\nfn f(x: Int) -> Int")
     ""
-  } with Error {
+  } with Exception {
     Throw(msg) => msg
   }
   assert(String::contains(dup, "duplicate version directive"))

--- a/fixtures/effect_advanced_test.vibe
+++ b/fixtures/effect_advanced_test.vibe
@@ -28,11 +28,11 @@ test "user-defined effect with perform/resume" {
 }
 
 test "error effect rethrow with ?" {
-  let risky: (Int) -> Int with Error = (x) -> {
+  let risky: (Int) -> Int with Exception = (x) -> {
     if x == 0 { throw("zero") }
     x * 2
   }
-  let caller: () -> Int with Error = () -> {
+  let caller: () -> Int with Exception = () -> {
     // `?` unwraps Result/Option — `risky` returns a plain Int and signals
     // failure via the Error effect's `throw`, which already propagates
     // through the call chain on its own, so a plain call is correct here.
@@ -40,52 +40,52 @@ test "error effect rethrow with ?" {
     let b = risky(3)
     a + b
   }
-  let result = handle { caller() } with Error { Throw(_) => -1 }
+  let result = handle { caller() } with Exception { Throw(_) => -1 }
   assert(result == 16)
 }
 
 test "error rethrow short-circuits on first error" {
-  let risky: (Int) -> Int with Error = (x) -> {
+  let risky: (Int) -> Int with Exception = (x) -> {
     if x == 0 { throw("zero") }
     x
   }
-  let caller: () -> Int with Error = () -> {
+  let caller: () -> Int with Exception = () -> {
     let a = risky(0)
     let b = risky(5)
     a + b
   }
-  let result = handle { caller() } with Error { Throw(_) => -1 }
+  let result = handle { caller() } with Exception { Throw(_) => -1 }
   assert(result == -1)
 }
 
 suberror NotFound(String)
 
 test "suberror throw and catch" {
-  let find: (String) -> Int with Error = (key) -> {
+  let find: (String) -> Int with Exception = (key) -> {
     if key == "" { throw(NotFound("empty")) }
     42
   }
-  let result = handle { find("") } with Error { Throw(_) => -1 }
+  let result = handle { find("") } with Exception { Throw(_) => -1 }
   assert(result == -1)
 }
 
 test "suberror with valid input" {
-  let find: (String) -> Int with Error = (key) -> {
+  let find: (String) -> Int with Exception = (key) -> {
     if key == "" { throw(NotFound("empty")) }
     42
   }
-  let result = handle { find("ok") } with Error { Throw(_) => -1 }
+  let result = handle { find("ok") } with Exception { Throw(_) => -1 }
   assert(result == 42)
 }
 
 test "nested handle" {
-  let risky: (Int) -> Int with Error = (x) -> {
+  let risky: (Int) -> Int with Exception = (x) -> {
     if x < 0 { throw("negative") }
     x
   }
   let outer = handle {
-    let inner = handle { risky(-1) } with Error { Throw(_) => 0 }
+    let inner = handle { risky(-1) } with Exception { Throw(_) => 0 }
     inner + risky(10)
-  } with Error { Throw(_) => -1 }
+  } with Exception { Throw(_) => -1 }
   assert(outer == 10)
 }

--- a/fixtures/effect_error_as_perform.vibe
+++ b/fixtures/effect_error_as_perform.vibe
@@ -1,15 +1,15 @@
 // Error as explicit perform: perform Error::Throw("msg")
 // Equivalent to throw("msg") (#640): both emit the same wasm throw (tag 2),
-// so the `with Error` handler catches either spelling.
+// so the `with Exception` handler catches either spelling.
 
-let safe = () -> Int with Error {
+let safe = () -> Int with Exception {
   perform Error::Throw("fail")
   0
 }
 
 let result = handle {
   safe()
-} with Error {
+} with Exception {
   Throw(msg) => String::length(msg)
 }
 // "fail" → length 4 (same as the throw("fail") spelling)

--- a/fixtures/effect_error_recovery.vibe
+++ b/fixtures/effect_error_recovery.vibe
@@ -9,7 +9,7 @@ let happy = handle {
   } with Validate {
     Check(_s) => resume(true)
   }
-} with Error {
+} with Exception {
   Throw(_msg) => -1
 }
 
@@ -21,7 +21,7 @@ let err = handle {
   } with Validate {
     Check(_s) => resume(false)
   }
-} with Error {
+} with Exception {
   Throw(_msg) => -1
 }
 

--- a/fixtures/effect_error_unified.vibe
+++ b/fixtures/effect_error_unified.vibe
@@ -1,7 +1,7 @@
 // Error as effect: throw is sugar for perform Error::Throw
 // This test verifies backward compatibility
 
-let safe_div = (a: Int, b: Int) -> Int with Error {
+let safe_div = (a: Int, b: Int) -> Int with Exception {
   if b == 0 {
     throw("division by zero")
   }
@@ -10,7 +10,7 @@ let safe_div = (a: Int, b: Int) -> Int with Error {
 
 let result = handle {
   safe_div(10, 0)
-} with Error {
+} with Exception {
   Throw(msg) => String::length(msg)
 }
 // "division by zero" → length 16

--- a/fixtures/effect_exception_alias_test.vibe
+++ b/fixtures/effect_exception_alias_test.vibe
@@ -9,7 +9,7 @@ fn divide(x: Int) -> Int with Exception {
   100 / x
 }
 
-fn legacy_fail() -> Int with Error {
+fn legacy_fail() -> Int with Exception {
   throw("legacy failure")
 }
 
@@ -31,7 +31,7 @@ test "Exception Throw is abortive and handled on its own alias" {
 test "Error and Exception handler spellings share the abortive tag" {
   let caught_by_error = handle {
     divide(0)
-  } with Error {
+  } with Exception {
     Throw(_) => 10
   }
   let caught_by_exception = handle {

--- a/fixtures/effect_handle_call_evidence_error_mix.vibe
+++ b/fixtures/effect_handle_call_evidence_error_mix.vibe
@@ -2,7 +2,7 @@
 // row exactly `{ Ask }`) whose body performs `Error::Throw` -- legal per
 // #640 Stage 2, which exempts `Error` from row declaration entirely, so
 // a function can freely mix a declared effect's operations with `Error`
-// without declaring `with Error` -- used to hit a COMPILE-TIME error
+// without declaring `with Exception` -- used to hit a COMPILE-TIME error
 // ("unknown struct field: Error::Throw") instead of compiling at all.
 // edp_rewrite_perform_via_dict rewrote EVERY `perform` inside a needing
 // function's body through the evidence dict unconditionally, regardless
@@ -29,7 +29,7 @@ effect Ask {
   Get -> Int
 }
 
-let only_throws = () -> Int with Ask + Error {
+let only_throws = () -> Int with Ask + Exception {
   perform Error::Throw("never called")
 }
 

--- a/fixtures/effect_handle_error_and_effect.vibe
+++ b/fixtures/effect_handle_error_and_effect.vibe
@@ -16,7 +16,7 @@ let validate = handle {
   } with Validator {
     IsValid(_s) => resume(true)
   }
-} with Error {
+} with Exception {
   Throw(_msg) => -1
 }
 validate

--- a/fixtures/effect_handle_error_nontail.vibe
+++ b/fixtures/effect_handle_error_nontail.vibe
@@ -1,5 +1,5 @@
 // #1087: a `throw` in NON-tail position directly inside a
-// `handle .. with Error` body (here: inside an if-branch with trailing
+// `handle .. with Exception` body (here: inside an if-branch with trailing
 // body code) must abort the body and make the arm's value the handle's
 // result. The ADR-0076 Phase 2 direct-perform inliner used to splice the
 // arm body in place of the perform (resumptive semantics) -- the arm ran
@@ -14,7 +14,7 @@ export let main = () -> Int {
       throw("boom")
     }
     x
-  } with Error {
+  } with Exception {
     Throw(_) => 1
   }
 }

--- a/fixtures/effect_handler_test.vibe
+++ b/fixtures/effect_handler_test.vibe
@@ -72,28 +72,28 @@ test "effect with loop" {
 }
 
 test "error with suberror types" {
-  let lookup: (String) -> Int with Error = (key) -> {
+  let lookup: (String) -> Int with Exception = (key) -> {
     if key == "" { throw(KeyInvalid("empty key")) }
     if key == "missing" { throw(KeyNotFound(key)) }
     42
   }
 
-  let r1 = handle { lookup("ok") } with Error { Throw(_) => -1 }
+  let r1 = handle { lookup("ok") } with Exception { Throw(_) => -1 }
   assert(r1 == 42)
 
-  let r2 = handle { lookup("") } with Error { Throw(_) => -1 }
+  let r2 = handle { lookup("") } with Exception { Throw(_) => -1 }
   assert(r2 == -1)
 
-  let r3 = handle { lookup("missing") } with Error { Throw(_) => -1 }
+  let r3 = handle { lookup("missing") } with Exception { Throw(_) => -1 }
   assert(r3 == -1)
 }
 
 test "error ? propagation chain" {
-  let step1: (Int) -> Int with Error = (x) -> {
+  let step1: (Int) -> Int with Exception = (x) -> {
     if x < 0 { throw("negative") }
     x + 10
   }
-  let step2: (Int) -> Int with Error = (x) -> {
+  let step2: (Int) -> Int with Exception = (x) -> {
     // `?` unwraps Result/Option — `step1` returns a plain Int and signals
     // failure via the Error effect's `throw`, which already propagates
     // through the call chain on its own, so a plain call is correct here.
@@ -101,51 +101,51 @@ test "error ? propagation chain" {
     let b = step1(a)
     a + b
   }
-  let ok = handle { step2(5) } with Error { Throw(_) => -1 }
+  let ok = handle { step2(5) } with Exception { Throw(_) => -1 }
   assert(ok == 40)
-  let err = handle { step2(-1) } with Error { Throw(_) => -1 }
+  let err = handle { step2(-1) } with Exception { Throw(_) => -1 }
   assert(err == -1)
 }
 
 test "handle returns value on success" {
-  let f: () -> Int with Error = () -> { 42 }
-  let result = handle { f() } with Error { Throw(_) => 0 }
+  let f: () -> Int with Exception = () -> { 42 }
+  let result = handle { f() } with Exception { Throw(_) => 0 }
   assert(result == 42)
 }
 
 test "nested handle error" {
-  let risky: (Int) -> Int with Error = (x) -> {
+  let risky: (Int) -> Int with Exception = (x) -> {
     if x < 0 { throw("negative") }
     x
   }
   let outer = handle {
-    let inner = handle { risky(-1) } with Error { Throw(_) => 0 }
+    let inner = handle { risky(-1) } with Exception { Throw(_) => 0 }
     inner + risky(10)
-  } with Error { Throw(_) => -1 }
+  } with Exception { Throw(_) => -1 }
   assert(outer == 10)
 }
 
 test "error in match arm" {
-  let process: (Option[Int]) -> Int with Error = (opt) -> {
+  let process: (Option[Int]) -> Int with Exception = (opt) -> {
     match opt {
       Some(x) if x > 0 => x * 2,
       Some(_) => throw("non-positive"),
       None => throw("missing")
     }
   }
-  let r1 = handle { process(Some(5)) } with Error { Throw(_) => -1 }
+  let r1 = handle { process(Some(5)) } with Exception { Throw(_) => -1 }
   assert(r1 == 10)
-  let r2 = handle { process(Some(-1)) } with Error { Throw(_) => -1 }
+  let r2 = handle { process(Some(-1)) } with Exception { Throw(_) => -1 }
   assert(r2 == -1)
-  let r3 = handle { process(None) } with Error { Throw(_) => -1 }
+  let r3 = handle { process(None) } with Exception { Throw(_) => -1 }
   assert(r3 == -1)
 }
 
 test "multiple error handlers in sequence" {
-  let fail1: () -> Int with Error = () -> { throw("a"); 0 }
-  let fail2: () -> Int with Error = () -> { throw("b"); 0 }
-  let a = handle { fail1() } with Error { Throw(_) => 10 }
-  let b = handle { fail2() } with Error { Throw(_) => 20 }
+  let fail1: () -> Int with Exception = () -> { throw("a"); 0 }
+  let fail2: () -> Int with Exception = () -> { throw("b"); 0 }
+  let a = handle { fail1() } with Exception { Throw(_) => 10 }
+  let b = handle { fail2() } with Exception { Throw(_) => 20 }
   assert(a == 10)
   assert(b == 20)
 }
@@ -158,7 +158,7 @@ test "error handler with block body" {
       throw("too big")
     }
     x + y
-  } with Error { Throw(_) => -1 }
+  } with Exception { Throw(_) => -1 }
   assert(result == 30)
 }
 

--- a/fixtures/effect_koka_exception_state.vibe
+++ b/fixtures/effect_koka_exception_state.vibe
@@ -16,7 +16,7 @@ let result = handle {
     } else {
       c
     }
-  } with Error {
+  } with Exception {
     Throw(_msg) => -1
   }
 } with Counter {

--- a/fixtures/effect_koka_handler_ordering.vibe
+++ b/fixtures/effect_koka_handler_ordering.vibe
@@ -1,4 +1,4 @@
-// Handler ordering semantics — nested handle with Error + effect
+// Handler ordering semantics — nested handle with Exception + effect
 // Ported from koka/test/algeff/effs2.kk
 // Counter outside Error: effect handled, then error caught
 effect Counter {
@@ -16,7 +16,7 @@ let result = handle {
     } else {
       c
     }
-  } with Error {
+  } with Exception {
     Throw(_msg) => -1
   }
 } with Counter {

--- a/fixtures/effect_koka_multi_effect_compose.vibe
+++ b/fixtures/effect_koka_multi_effect_compose.vibe
@@ -1,4 +1,4 @@
-// Multiple effects composed — Logger + Config + Error
+// Multiple effects composed — Logger + Config + Exception
 // Demonstrates 3-effect composition in single handle
 effect Logger {
   Log(String) -> Unit;
@@ -27,7 +27,7 @@ let result = handle {
     GetHost => resume("localhost");
     GetPort => resume(8080)
   }
-} with Error {
+} with Exception {
   Throw(_msg) => -1
 }
 // host = "localhost" (9), port = 8080, Log → resume(0), 9 + 8080 = 8089

--- a/fixtures/effect_polysemy_error_catch.vibe
+++ b/fixtures/effect_polysemy_error_catch.vibe
@@ -1,6 +1,6 @@
 // Polysemy-style Error effect with catch via handle
 // Ported from polysemy test/ErrorSpec.hs
-// throw/catch using handle { } with Error { Throw(_) => ... }
+// throw/catch using handle { } with Exception { Throw(_) => ... }
 
 let result = handle {
   let x = 10 / 2
@@ -9,7 +9,7 @@ let result = handle {
   } else {
     x
   }
-} with Error {
+} with Exception {
   Throw(_msg) => -1
 }
 // x = 5, 5 > 3, throws "overflow", caught → -1

--- a/fixtures/effect_polysemy_state_error_interaction.vibe
+++ b/fixtures/effect_polysemy_state_error_interaction.vibe
@@ -1,4 +1,4 @@
-// State + Error interaction — handler ordering determines semantics
+// State + Exception interaction — handler ordering determines semantics
 // Ported from polysemy test/FinalSpec.hs
 // Effect outside Error: effect handler processes even after error
 effect Vault {
@@ -11,7 +11,7 @@ let result = handle {
     perform Vault::Deposit(100)
     throw("bank error")
     perform Vault::Balance
-  } with Error {
+  } with Exception {
     Throw(_msg) => -1
   }
 } with Vault {

--- a/fixtures/effect_row_spellings_test.vibe
+++ b/fixtures/effect_row_spellings_test.vibe
@@ -9,21 +9,21 @@
 //   with ()         the explicitly empty row
 //   with A + B   braced, comma-separated   (migrating FROM)
 
-fn braceless_one(a: Int) -> Int with Error {
+fn braceless_one(a: Int) -> Int with Exception {
   if a < 0 {
     throw("negative")
   }
   a
 }
 
-fn braceless_plus(a: Int) -> Int with Error + Stdout {
+fn braceless_plus(a: Int) -> Int with Exception + Stdout {
   if a < 0 {
     throw("negative")
   }
   a
 }
 
-fn braced_legacy(a: Int) -> Int with Error {
+fn braced_legacy(a: Int) -> Int with Exception {
   if a < 0 {
     throw("negative")
   }
@@ -39,29 +39,29 @@ fn explicitly_pure(a: Int, b: Int) -> Int with () {
 
 // The row in a nested function TYPE, inside a parameter list, followed by a
 // comma and another parameter. This is the shape the separator was chosen for:
-// with a comma separator, `(Int) -> Int with Error, b: Int` cannot be told
+// with a comma separator, `(Int) -> Int with Exception, b: Int` cannot be told
 // apart from a two-label row, so the row's end would need lookahead. `+` can
 // start neither a type nor a parameter name, so the end is unambiguous.
-fn takes_effectful_callback(f: (Int) -> Int with Error, b: Int) -> Int with Error {
+fn takes_effectful_callback(f: (Int) -> Int with Exception, b: Int) -> Int with Exception {
   f(b)
 }
 
 test "braceless single-label row" {
   let got = handle {
     braceless_one(0 - 1)
-  } with Error {
+  } with Exception {
     Throw(_) => 0 - 99
   }
   assert_eq(got, 0 - 99)
-  assert_eq(handle { braceless_one(7) } with Error { Throw(_) => 0 }, 7)
+  assert_eq(handle { braceless_one(7) } with Exception { Throw(_) => 0 }, 7)
 }
 
 test "braceless `+`-separated row" {
-  assert_eq(handle { braceless_plus(7) } with Error { Throw(_) => 0 }, 7)
+  assert_eq(handle { braceless_plus(7) } with Exception { Throw(_) => 0 }, 7)
 }
 
 test "the braced spelling still parses to the same row" {
-  assert_eq(handle { braced_legacy(7) } with Error { Throw(_) => 0 }, 7)
+  assert_eq(handle { braced_legacy(7) } with Exception { Throw(_) => 0 }, 7)
 }
 
 test "`with ()` is the empty row" {
@@ -71,7 +71,7 @@ test "`with ()` is the empty row" {
 test "a row inside a parameter's function type ends at the comma" {
   assert_eq(handle {
     takes_effectful_callback(braceless_one, 5)
-  } with Error {
+  } with Exception {
     Throw(_) => 0
   }, 5)
 }

--- a/fixtures/effect_subtype_pure_to_effectful.vibe
+++ b/fixtures/effect_subtype_pure_to_effectful.vibe
@@ -1,4 +1,4 @@
-let apply_err = (f: () -> Int with Error) -> Int with Error { f() }
+let apply_err = (f: () -> Int with Exception) -> Int with Exception { f() }
 let pure = () -> Int { 42 }
 
 apply_err(pure)

--- a/fixtures/effect_talk_exception_test.vibe
+++ b/fixtures/effect_talk_exception_test.vibe
@@ -23,7 +23,7 @@ effect Abort {
 
 //# Tests
 
-fn safe_copy(exists: Bool) -> Int with Error {
+fn safe_copy(exists: Bool) -> Int with Exception {
   if exists { throw("FileAlreadyExists") }
   42
 }
@@ -35,7 +35,7 @@ test "talk p23-32: Error handler discards the continuation (global escape)" {
     let v = safe_copy(true)
     Array::push(log, 2)
     v
-  } with Error {
+  } with Exception {
     Throw(_) => 0 - 1
   }
   assert(r == 0 - 1)
@@ -44,7 +44,7 @@ test "talk p23-32: Error handler discards the continuation (global escape)" {
 }
 
 test "talk p24: no throw means the handler arm never fires" {
-  let r = handle { safe_copy(false) } with Error { Throw(_) => 0 - 1 }
+  let r = handle { safe_copy(false) } with Exception { Throw(_) => 0 - 1 }
   assert(r == 42)
 }
 

--- a/fixtures/effect_test.vibe
+++ b/fixtures/effect_test.vibe
@@ -1,7 +1,7 @@
 //# Functions
 
-// might_fail: (Int) -> Int with Error
-fn might_fail(x: Int) -> Int with Error {
+// might_fail: (Int) -> Int with Exception
+fn might_fail(x: Int) -> Int with Exception {
   if x == 0 {
     throw("zero error")
   } else x
@@ -12,7 +12,7 @@ fn might_fail(x: Int) -> Int with Error {
 test "handle error recovery" {
   let result = handle {
     might_fail(0)
-  } with Error {
+  } with Exception {
     Throw(_) => 99
   }
   assert(result == 99)
@@ -21,7 +21,7 @@ test "handle error recovery" {
 test "handle success passthrough" {
   let result = handle {
     might_fail(42)
-  } with Error {
+  } with Exception {
     Throw(_) => 0
   }
   assert(result == 42)
@@ -34,7 +34,7 @@ test "throw and handle" {
         throw("div by zero")
         0
       } else a / b
-    } with Error {
+    } with Exception {
       Throw(_) => -1
     }
   }
@@ -43,30 +43,30 @@ test "throw and handle" {
 }
 
 test "nested handle" {
-  let inner: () -> Int with Error = () -> {
+  let inner: () -> Int with Exception = () -> {
     throw("inner")
     0
   }
   let outer = handle {
     handle {
       inner()
-    } with Error {
+    } with Exception {
       Throw(_) => 42
     }
-  } with Error {
+  } with Exception {
     Throw(_) => 0
   }
   assert(outer == 42)
 }
 
 test "error does not propagate past handle" {
-  let f: () -> Int with Error = () -> {
+  let f: () -> Int with Exception = () -> {
     throw("oops")
     0
   }
   let result = handle {
     f() + 10
-  } with Error {
+  } with Exception {
     Throw(_) => 100
   }
   assert(result == 100)

--- a/fixtures/effect_throw_in_handle_arm.vibe
+++ b/fixtures/effect_throw_in_handle_arm.vibe
@@ -13,7 +13,7 @@ let result = handle {
       resume("x")
     }
   }
-} with Error {
+} with Exception {
   Throw(msg) => String::length(msg)
 }
 // "handler failure" → length 15

--- a/fixtures/effect_throw_perform_one_form.vibe
+++ b/fixtures/effect_throw_perform_one_form.vibe
@@ -3,9 +3,9 @@
 // EIdent("Error::Throw"), [x])])) — one internal form through the checker,
 // normalize, and both codegen backends; the printer re-sugars that form back
 // to `throw(x)`. This pins that the desugar does NOT tighten effect rows:
-// `helper` declares NO `with Error` row (throw's Error row is pervasive
+// `helper` declares NO `with Exception` row (throw's Error row is pervasive
 // and exempt from the #626 perform discipline, exactly as before Stage 2),
-// and both spellings are caught by the same `with Error` handler with the
+// and both spellings are caught by the same `with Exception` handler with the
 // payload preserved.
 
 let helper = (n: Int) -> Int {
@@ -17,14 +17,14 @@ let helper = (n: Int) -> Int {
 
 let via_throw = handle {
   helper(-1)
-} with Error {
+} with Exception {
   Throw(msg) => String::length(msg)
 }
 
 let via_perform = handle {
   perform Error::Throw("negative")
   0
-} with Error {
+} with Exception {
   Throw(msg) => String::length(msg)
 }
 

--- a/fixtures/entry_error_boundary.vibe
+++ b/fixtures/entry_error_boundary.vibe
@@ -1,10 +1,10 @@
 // #944 (ADR-0073 stage C, "entry boundary A"): an ENTRY function may carry
-// `with Error` under checked-Error, and an Error::Throw escaping the
+// `with Exception` under checked-Error, and an Error::Throw escaping the
 // entry must become a DIAGNOSED, unsuccessful process outcome -- stderr
 // gets "vibe: uncaught error: <msg>" and the entry evaluates to 1 --
 // instead of a raw WebAssembly.Exception leaking past the entry into the
 // host runtime. lc_wrap_entry_error_boundary (codegen/wasi/
-// linked_compile.vibe) wraps the entry body in `handle .. with Error`
+// linked_compile.vibe) wraps the entry body in `handle .. with Exception`
 // post-check, so the checker still sees the honest row and inner handles
 // still win (an Error discharged INSIDE the entry never reaches the
 // boundary handler).
@@ -16,7 +16,7 @@
 // separately by fixtures/effect_handle_error_nontail.vibe now that Error
 // arms are excluded from that pass.
 //   main throws "boom" -> boundary handler -> stderr diag, entry value 1
-export let main = () -> Int with Error {
+export let main = () -> Int with Exception {
   throw("boom")
 }
 

--- a/fixtures/err_async_boundary_mixed_convention.vibe
+++ b/fixtures/err_async_boundary_mixed_convention.vibe
@@ -11,10 +11,10 @@ import @vibex/concurrent {
   TaskGroup, TaskHandle
 }
 
-fn main() -> Int with Async + Error {
+fn main() -> Int with Async + Exception {
   sleep(1)
   TaskGroup::run((g) -> {
-    let h = TaskGroup::spawn_suspend(g, () -> Int with Async + Error {
+    let h = TaskGroup::spawn_suspend(g, () -> Int with Async + Exception {
       let _ = perform Async::Suspend(0)
       21
     })

--- a/fixtures/err_effect_call_effectful_from_pure.vibe
+++ b/fixtures/err_effect_call_effectful_from_pure.vibe
@@ -1,4 +1,4 @@
-let risky = () -> Int with Error {
+let risky = () -> Int with Exception {
   throw("fail")
   0
 }

--- a/fixtures/err_effect_handle_arm_mismatch.vibe
+++ b/fixtures/err_effect_handle_arm_mismatch.vibe
@@ -1,7 +1,7 @@
 let result: Int = handle {
   throw("err")
   42
-} with Error {
+} with Exception {
   Throw(_) => true
 }
 

--- a/fixtures/err_effect_handler_type_mismatch.vibe
+++ b/fixtures/err_effect_handler_type_mismatch.vibe
@@ -1,6 +1,6 @@
 let result = handle {
   42
-} with Error {
+} with Exception {
   Throw(_) => "wrong type"
 }
 

--- a/fixtures/err_effect_nested_escape.vibe
+++ b/fixtures/err_effect_nested_escape.vibe
@@ -1,5 +1,5 @@
 let outer = () -> Int {
-  let inner = () -> Int with Error {
+  let inner = () -> Int with Exception {
     throw("fail")
     0
   }

--- a/fixtures/err_effect_throw_non_string.vibe
+++ b/fixtures/err_effect_throw_non_string.vibe
@@ -1,4 +1,4 @@
-let f = () -> Int with Error {
+let f = () -> Int with Exception {
   throw(42)
   0
 }

--- a/fixtures/err_effect_wrong_effect_name.vibe
+++ b/fixtures/err_effect_wrong_effect_name.vibe
@@ -7,7 +7,7 @@ let read = () -> Int with IoError {
   0
 }
 
-let bad = () -> Int with Error {
+let bad = () -> Int with Exception {
   read()
 }
 

--- a/fixtures/err_entry_boundary_string_payload.vibe
+++ b/fixtures/err_entry_boundary_string_payload.vibe
@@ -11,6 +11,6 @@
 // discrimination is the identity on a real string.
 //
 // Pinned behaviour: exit 1, `vibe: uncaught error: plain boom` on stderr.
-fn main() -> Int with Error {
+fn main() -> Int with Exception {
   throw("plain boom")
 }

--- a/fixtures/err_entry_boundary_typed_payload.vibe
+++ b/fixtures/err_entry_boundary_typed_payload.vibe
@@ -26,6 +26,6 @@ enum Boom {
   Bang(Int)
 }
 
-fn main() -> Int with Error {
+fn main() -> Int with Exception {
   throw(Bang(7))
 }

--- a/fixtures/err_exception_kind_mismatch.vibe
+++ b/fixtures/err_exception_kind_mismatch.vibe
@@ -16,7 +16,7 @@ let boom = () -> Int with Exception[ParseError] {
 let main = () -> Int {
   handle {
     boom()
-  } with Error {
+  } with Exception {
     Throw(_e) => 42
   }
 }

--- a/fixtures/err_exception_local_binder_kind.vibe
+++ b/fixtures/err_exception_local_binder_kind.vibe
@@ -20,7 +20,7 @@ let boom = () -> Int with Exception[ParseError] {
 let main = () -> Int {
   handle {
     boom()
-  } with Error {
+  } with Exception {
     Throw(_e) => 42
   }
 }

--- a/fixtures/err_region_escape_return.vibe
+++ b/fixtures/err_region_escape_return.vibe
@@ -4,7 +4,7 @@
 // not merely a runtime concern.
 import @vibex/concurrent { TaskGroup }
 
-fn main() -> Unit with Error {
+fn main() -> Unit with Exception {
   let _r = TaskGroup::run((n) -> {
     TaskGroup::spawn(n, () -> { 1 })
   })

--- a/fixtures/err_resume_in_error_arm.vibe
+++ b/fixtures/err_resume_in_error_arm.vibe
@@ -1,8 +1,8 @@
 // #640: Error is non-resumable — throw / perform Error::Throw unwind for
-// good, so a resume(...) inside a `with Error` arm never resumed anything.
+// good, so a resume(...) inside a `with Exception` arm never resumed anything.
 // The checker rejects it: the arm's value IS the handle result.
 
-let risky = () -> Int with Error {
+let risky = () -> Int with Exception {
   throw("boom")
   0
 }
@@ -10,7 +10,7 @@ let risky = () -> Int with Error {
 let main = () -> Int {
   handle {
     risky()
-  } with Error {
+  } with Exception {
     Throw(_msg) => resume(0)
   }
 }

--- a/fixtures/err_spawnable_capture_array.vibe
+++ b/fixtures/err_spawnable_capture_array.vibe
@@ -5,7 +5,7 @@
 // discipline the type system can check now, not merely today's runtime.
 import @vibex/concurrent { TaskGroup }
 
-fn main() -> Unit with Error {
+fn main() -> Unit with Exception {
   let seen = [0]
   let _r = TaskGroup::run((n) -> {
     TaskGroup::spawn(n, () -> {

--- a/fixtures/err_spawnable_capture_cross_region.vibe
+++ b/fixtures/err_spawnable_capture_cross_region.vibe
@@ -4,7 +4,7 @@
 // spawn call's own region, per docs/concurrency.md.
 import @vibex/concurrent { TaskGroup, Channel, Sender }
 
-fn main() -> Unit with Error {
+fn main() -> Unit with Exception {
   let _r = TaskGroup::run((outer) -> {
     let (tx, rx) = Channel::bounded(outer, 1)
     TaskGroup::run((inner) -> {

--- a/fixtures/err_spawnable_capture_letmut.vibe
+++ b/fixtures/err_spawnable_capture_letmut.vibe
@@ -8,7 +8,7 @@
 // judgment (`check_spawnable_mut_captures`, purely AST-based).
 import @vibex/concurrent { TaskGroup }
 
-fn main() -> Unit with Error {
+fn main() -> Unit with Exception {
   let _r = TaskGroup::run((n) -> {
     let mut counter = 0
     let _t = TaskGroup::spawn(n, () -> {

--- a/fixtures/err_spawnable_capture_letmut_outer_scope.vibe
+++ b/fixtures/err_spawnable_capture_letmut_outer_scope.vibe
@@ -9,7 +9,7 @@
 // `TaskGroup::run` call (see check_spawnable_mut_captures_stmts).
 import @vibex/concurrent { TaskGroup }
 
-fn main() -> Unit with Error {
+fn main() -> Unit with Exception {
   let mut counter = 0
   let _r = TaskGroup::run((n) -> {
     let _t = TaskGroup::spawn(n, () -> {

--- a/fixtures/err_taskgroup_sugar_region_escape.vibe
+++ b/fixtures/err_taskgroup_sugar_region_escape.vibe
@@ -5,7 +5,7 @@
 // a `TaskHandle` obtained inside the sugar body still cannot escape it.
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-fn main() -> Unit with Error {
+fn main() -> Unit with Exception {
   let leaked = taskgroup { g => {
     let h = TaskGroup::spawn(g, () -> { 1 })
     h

--- a/fixtures/exception_typed_row.vibe
+++ b/fixtures/exception_typed_row.vibe
@@ -32,7 +32,7 @@ let load = (which: Bool) -> Int with ConfigExceptions {
 }
 
 // The erased alias still covers a kinded callee.
-let anything = () -> Int with Error {
+let anything = () -> Int with Exception {
   load(true)
 }
 
@@ -58,7 +58,7 @@ export let main = () -> Int {
   // Erased handler over a union of kinds.
   let b = handle {
     load(false)
-  } with Error {
+  } with Exception {
     Throw(_e) => 20
   }
   let c = handle {

--- a/fixtures/exn_kind_side_channel_test.vibe
+++ b/fixtures/exn_kind_side_channel_test.vibe
@@ -3,7 +3,7 @@
 // ADR-0085 lowers every exception spelling to ONE abortive Wasm tag with no
 // kind discriminator, and the erased `Error` spelling is deliberately
 // compatible with every kind (that is what kept #1344 additive over #786's
-// suberror throws). So an erased `handle { .. } with Error { Throw(m) => .. }`
+// suberror throws). So an erased `handle { .. } with Exception { Throw(m) => .. }`
 // arm also catches a typed `Exception[E]` throw, and `m`'s static type there is
 // `CtUnknown` -- using it as a String type-checks and then reads an enum
 // pointer as a packed `(ptr<<32)|len` string. Measured on the #1372 review: a
@@ -31,7 +31,7 @@ test "an erased arm sees the typed kind of an enum payload" {
   let k = handle {
     throw(Bang(7))
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(k, "Boom")
@@ -41,7 +41,7 @@ test "a String payload reports String, so the sinks keep printing it verbatim" {
   let k = handle {
     throw("boom")
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(k, "String")
@@ -51,7 +51,7 @@ test "an Int payload reports Int" {
   let k = handle {
     throw(42)
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(k, "Int")
@@ -63,7 +63,7 @@ test "a struct-literal payload reports its struct name" {
       n: 1
     })
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(k, "Wrapped")
@@ -81,13 +81,13 @@ test "a nested throw does not leak its kind to the outer arm" {
     let inner = handle {
       throw(Bang(1))
       ""
-    } with Error {
+    } with Exception {
       Throw(_) => __exn_kind()
     }
     assert_eq(inner, "Boom")
     throw("outer")
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(k, "String")
@@ -97,13 +97,13 @@ test "two throws in sequence each report their own kind" {
   let first = handle {
     throw(Second("x"))
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   let second = handle {
     throw(Bang(2))
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(first, "Other")
@@ -122,7 +122,7 @@ test "an unresolvable payload reports the empty kind, never a guess" {
   let k = handle {
     throw(f(1))
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(k, "")
@@ -134,7 +134,7 @@ test "an unresolved throw clears the previous throw's kind" {
   let first = handle {
     throw(Bang(3))
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(first, "Boom")
@@ -144,7 +144,7 @@ test "an unresolved throw clears the previous throw's kind" {
   let second = handle {
     throw(g(1))
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(second, "")
@@ -166,7 +166,7 @@ fn exn_kind_recovering_payload() -> String {
   handle {
     throw(Bang(1))
     "unreachable"
-  } with Error {
+  } with Exception {
     Throw(_) => "outer"
   }
 }
@@ -175,7 +175,7 @@ test "a payload that internally handles a throw does not lose its own kind" {
   let k = handle {
     throw(exn_kind_recovering_payload())
     ""
-  } with Error {
+  } with Exception {
     Throw(_) => __exn_kind()
   }
   assert_eq(k, "String")
@@ -190,7 +190,7 @@ test "the outer payload survives an inner handled throw" {
   let m = handle {
     throw(exn_kind_recovering_payload())
     ""
-  } with Error {
+  } with Exception {
     Throw(msg) => msg
   }
   assert_eq(m, "outer")

--- a/fixtures/fn_syntax_test.vibe
+++ b/fixtures/fn_syntax_test.vibe
@@ -16,7 +16,7 @@ fn ident_gen[T](x: T) -> T { x }
 
 fn labeled(x~: Int, y~: Int) -> Int { x - y }
 
-fn risky(x: Int) -> Int with Error {
+fn risky(x: Int) -> Int with Exception {
   if x == 0 { throw("zero") }
   100 / x
 }
@@ -39,7 +39,7 @@ test "fn sugar basics (#727)" {
 }
 
 test "fn effect row and where clause (#727)" {
-  let v = handle { risky(0) } with Error { Throw(_) => 0 - 1 }
+  let v = handle { risky(0) } with Exception { Throw(_) => 0 - 1 }
   assert_eq(v, 0 - 1)
   assert_eq(risky(4), 25)
   assert_eq(clamp(99, 0, 10), 10)

--- a/fixtures/gc_backend_effect_evidence_dict.vibe
+++ b/fixtures/gc_backend_effect_evidence_dict.vibe
@@ -1,5 +1,5 @@
 // ADR-0076 (#817), 段階導入計画 step 6: the wasm-gc backend used to support
-// ONLY `with Error { Throw(..) => .. }` for `EHandle`/`perform` -- any other
+// ONLY `with Exception { Throw(..) => .. }` for `EHandle`/`perform` -- any other
 // effect hit backend_call.vibe's "unsupported perform (no builtin mapping)"
 // hard compile error (backend_expr.vibe's EHandle case rejected any handler
 // arm 0 pattern besides `Error::Throw`/`Throw` outright). Fixed by wiring

--- a/fixtures/gc_backend_smoke_test.vibe
+++ b/fixtures/gc_backend_smoke_test.vibe
@@ -102,7 +102,7 @@ let rec tree_sum: (Tree) -> Int = (t) -> {
   }
 }
 
-let risky: (Int) -> Int with Error = (x) -> {
+let risky: (Int) -> Int with Exception = (x) -> {
   if x == 0 {
     throw("zero")
   }
@@ -139,7 +139,7 @@ let batch2: () -> Int = () -> {
   // Error handle via try_table (42)
   let handled = handle {
     risky(0)
-  } with Error {
+  } with Exception {
     Throw(_) => 42
   }
   nested + acc + map_v + sops + sblen + handled

--- a/fixtures/gc_backend_suberror_ctor.vibe
+++ b/fixtures/gc_backend_suberror_ctor.vibe
@@ -21,14 +21,14 @@ suberror KeyNotFound(String)
 suberror KeyInvalid(String)
 
 export let main = () -> Int {
-  let lookup: (String) -> Int with Error = (key) -> {
+  let lookup: (String) -> Int with Exception = (key) -> {
     if key == "" { throw(KeyInvalid("empty key")) }
     if key == "missing" { throw(KeyNotFound(key)) }
     42
   }
-  let r1 = handle { lookup("ok") } with Error { Throw(_) => -1 }
-  let r2 = handle { lookup("") } with Error { Throw(_) => -1 }
-  let r3 = handle { lookup("missing") } with Error { Throw(_) => -1 }
+  let r1 = handle { lookup("ok") } with Exception { Throw(_) => -1 }
+  let r2 = handle { lookup("") } with Exception { Throw(_) => -1 }
+  let r3 = handle { lookup("missing") } with Exception { Throw(_) => -1 }
   r1 * 100 + (r2 + 1) * 10 + (r3 + 1)
 }
 

--- a/fixtures/handle_basic.vibe
+++ b/fixtures/handle_basic.vibe
@@ -1,6 +1,6 @@
 let result = handle {
   42
-} with Error {
+} with Exception {
   Throw(_) => -1
 }
 result

--- a/fixtures/handle_multiple_catch.vibe
+++ b/fixtures/handle_multiple_catch.vibe
@@ -1,12 +1,12 @@
-let risky = (n: Int) -> Int with Error {
+let risky = (n: Int) -> Int with Exception {
   if n < 0 { throw("negative") }
   if n == 0 { throw("zero") }
   n * 2
 }
 
-let a = handle { risky(5) } with Error { Throw(_) => -1 }
-let b = handle { risky(0) } with Error { Throw(_) => -1 }
-let c = handle { risky(-1) } with Error { Throw(_) => -1 }
+let a = handle { risky(5) } with Exception { Throw(_) => -1 }
+let b = handle { risky(0) } with Exception { Throw(_) => -1 }
+let c = handle { risky(-1) } with Exception { Throw(_) => -1 }
 a + b + c
 
 __DATA__

--- a/fixtures/handle_mutable_in_handler.vibe
+++ b/fixtures/handle_mutable_in_handler.vibe
@@ -4,7 +4,7 @@ let _start = () -> {
     count = count + 1
     throw("err")
     0
-  } with Error {
+  } with Exception {
     Throw(_) => count
   }
   result

--- a/fixtures/handle_nested.vibe
+++ b/fixtures/handle_nested.vibe
@@ -2,11 +2,11 @@ let outer = handle {
   let inner = handle {
     throw("inner")
     0
-  } with Error {
+  } with Exception {
     Throw(msg) => String::length(msg)
   }
   inner + 100
-} with Error {
+} with Exception {
   Throw(_) => -1
 }
 outer

--- a/fixtures/handle_nested_rethrow.vibe
+++ b/fixtures/handle_nested_rethrow.vibe
@@ -1,17 +1,17 @@
-let inner = () -> Int with Error {
+let inner = () -> Int with Exception {
   throw("inner error")
 }
-let outer = () -> String with Error {
+let outer = () -> String with Exception {
   let _ = handle {
     inner()
-  } with Error {
+  } with Exception {
     Throw(msg) => throw(String::concat("wrapped: ", msg))
   }
   "unreachable"
 }
 let result = handle {
   outer()
-} with Error {
+} with Exception {
   Throw(msg) => msg
 }
 result

--- a/fixtures/handle_propagate.vibe
+++ b/fixtures/handle_propagate.vibe
@@ -1,15 +1,15 @@
-let inner = () -> Int with Error {
+let inner = () -> Int with Exception {
   throw("propagated")
   0
 }
 
-let middle = () -> Int with Error {
+let middle = () -> Int with Exception {
   inner() + 1
 }
 
 let result = handle {
   middle()
-} with Error {
+} with Exception {
   Throw(msg) => String::length(msg)
 }
 result

--- a/fixtures/handle_rethrow.vibe
+++ b/fixtures/handle_rethrow.vibe
@@ -1,12 +1,12 @@
-let fail = () -> Int with Error {
+let fail = () -> Int with Exception {
   throw("original")
   0
 }
 
-let wrap = () -> Int with Error {
+let wrap = () -> Int with Exception {
   let x = handle {
     fail()
-  } with Error {
+  } with Exception {
     Throw(msg) => throw(String::concat("wrapped: ", msg))
   }
   x
@@ -14,7 +14,7 @@ let wrap = () -> Int with Error {
 
 let result = handle {
   wrap()
-} with Error {
+} with Exception {
   Throw(msg) => String::length(msg)
 }
 result

--- a/fixtures/handle_throw_catch.vibe
+++ b/fixtures/handle_throw_catch.vibe
@@ -1,7 +1,7 @@
 let result = handle {
   throw("oops")
   0
-} with Error {
+} with Exception {
   Throw(msg) => String::length(msg)
 }
 result

--- a/fixtures/handle_value_passthrough.vibe
+++ b/fixtures/handle_value_passthrough.vibe
@@ -1,10 +1,10 @@
-let compute = () -> Int with Error {
+let compute = () -> Int with Exception {
   40 + 2
 }
 
 let result = handle {
   compute()
-} with Error {
+} with Exception {
   Throw(_) => -1
 }
 result

--- a/fixtures/handle_with_effect_annotation.vibe
+++ b/fixtures/handle_with_effect_annotation.vibe
@@ -1,4 +1,4 @@
-let risky = () -> Int with Error {
+let risky = () -> Int with Exception {
   throw("fail")
   0
 }
@@ -6,7 +6,7 @@ let risky = () -> Int with Error {
 let safe = () -> Int {
   handle {
     risky()
-  } with Error {
+  } with Exception {
     Throw(_) => 99
   }
 }

--- a/fixtures/let_type_annotation_effect.vibe
+++ b/fixtures/let_type_annotation_effect.vibe
@@ -1,7 +1,7 @@
-let safe_div: (Int, Int) -> Int with Error = (a, b) -> Int with Error {
+let safe_div: (Int, Int) -> Int with Exception = (a, b) -> Int with Exception {
   if b == 0 { throw("div0") } else { a / b }
 }
-handle { safe_div(10, 2) } with Error { Throw(_e) => -1 }
+handle { safe_div(10, 2) } with Exception { Throw(_e) => -1 }
 
 __DATA__
 {"last": "5"}

--- a/fixtures/region_ok_basic.vibe
+++ b/fixtures/region_ok_basic.vibe
@@ -4,7 +4,7 @@
 // fixtures (err_region_escape_return.vibe, err_region_escape_outer_mut.vibe).
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-let _start = () -> Int with Error {
+let _start = () -> Int with Exception {
   TaskGroup::run((n) -> {
     let h = TaskGroup::spawn(n, () -> { 40 })
     let v = TaskHandle::join(h)

--- a/fixtures/region_ok_frozen_array_taskgroup_capture.vibe
+++ b/fixtures/region_ok_frozen_array_taskgroup_capture.vibe
@@ -11,7 +11,7 @@
 // TaskGroup::spawn boundary.
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-let _start = () -> Int with Error {
+let _start = () -> Int with Exception {
   let data = [10, 10, 20]
   let fa = FrozenArray::from_array(data)
   TaskGroup::run((n) -> {

--- a/fixtures/region_ok_spawnable_capture.vibe
+++ b/fixtures/region_ok_spawnable_capture.vibe
@@ -6,7 +6,7 @@
 // err_spawnable_capture_cross_region.vibe).
 import @vibex/concurrent { TaskGroup, TaskHandle, Channel, Sender, Receiver }
 
-let _start = () -> Int with Error {
+let _start = () -> Int with Exception {
   TaskGroup::run((n) -> {
     let (tx, rx) = Channel::bounded(n, 1)
     let t = TaskGroup::spawn(n, () -> {

--- a/fixtures/region_ok_spawnable_capture_shadowed_letmut.vibe
+++ b/fixtures/region_ok_spawnable_capture_shadowed_letmut.vibe
@@ -11,7 +11,7 @@
 // err_spawnable_capture_letmut.vibe/err_spawnable_capture_letmut_outer_scope.vibe.
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-let _start = () -> Int with Error {
+let _start = () -> Int with Exception {
   let x = 40
   let result = TaskGroup::run((n) -> {
     let h = TaskGroup::spawn(n, () -> { x + 1 })

--- a/fixtures/region_ok_taskgroup_sugar.vibe
+++ b/fixtures/region_ok_taskgroup_sugar.vibe
@@ -6,7 +6,7 @@
 // the same result a hand-written call would.
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-let _start = () -> Int with Error {
+let _start = () -> Int with Exception {
   taskgroup { g => {
     let h = TaskGroup::spawn(g, () -> { 40 })
     let v = TaskHandle::join(h)

--- a/fixtures/suberror_basic.vibe
+++ b/fixtures/suberror_basic.vibe
@@ -3,7 +3,7 @@ suberror AppError {
   InvalidInput(String)
 }
 
-let validate = (n: Int) -> Int with Error {
+let validate = (n: Int) -> Int with Exception {
   if n < 0 {
     throw(InvalidInput("negative"))
   }
@@ -12,7 +12,7 @@ let validate = (n: Int) -> Int with Error {
 
 let result = handle {
   validate(5)
-} with Error {
+} with Exception {
   Throw(_) => -1
 }
 result

--- a/fixtures/suberror_catch.vibe
+++ b/fixtures/suberror_catch.vibe
@@ -2,14 +2,14 @@ suberror MathError {
   DivByZero
 }
 
-let safe_div = (a: Int, b: Int) -> Int with Error {
+let safe_div = (a: Int, b: Int) -> Int with Exception {
   if b == 0 { throw(DivByZero) }
   a / b
 }
 
 let result = handle {
   safe_div(10, 0)
-} with Error {
+} with Exception {
   Throw(_) => -1
 }
 result

--- a/fixtures/suberror_chain.vibe
+++ b/fixtures/suberror_chain.vibe
@@ -1,4 +1,4 @@
-let parse_int = (s: String) -> Int with Error {
+let parse_int = (s: String) -> Int with Exception {
   if s == "42" { 42 }
   else if s == "0" { 0 }
   else { throw(String::concat("not a number: ", s)) }
@@ -7,7 +7,7 @@ let parse_int = (s: String) -> Int with Error {
 let safe_parse = (s: String) -> Int {
   handle {
     parse_int(s)
-  } with Error {
+  } with Exception {
     Throw(_) => -1
   }
 }

--- a/fixtures/suberror_propagate.vibe
+++ b/fixtures/suberror_propagate.vibe
@@ -3,18 +3,18 @@ suberror AppError {
   BadInput(String)
 }
 
-let inner = () -> Int with Error {
+let inner = () -> Int with Exception {
   throw(BadInput("oops"))
   0
 }
 
-let outer = () -> Int with Error {
+let outer = () -> Int with Exception {
   inner() + 1
 }
 
 let result = handle {
   outer()
-} with Error {
+} with Exception {
   Throw(_) => 99
 }
 result

--- a/fixtures/throw_string_catch.vibe
+++ b/fixtures/throw_string_catch.vibe
@@ -1,12 +1,12 @@
 // throw string → catch → verify string is preserved
-let safe = () -> String with Error {
+let safe = () -> String with Exception {
   throw("hello_error")
   "unreachable"
 }
 
 let result = handle {
   safe()
-} with Error {
+} with Exception {
   Throw(msg) => msg
 }
 

--- a/fixtures/try_question_mark.vibe
+++ b/fixtures/try_question_mark.vibe
@@ -1,15 +1,15 @@
 // ? operator: propagate Error effect
-let safe_div = (a: Int, b: Int) -> Int with Error {
+let safe_div = (a: Int, b: Int) -> Int with Exception {
   if b == 0 { throw("division by zero") }
   a / b
 }
 
-let compute = (x: Int) -> Int with Error {
+let compute = (x: Int) -> Int with Exception {
   let a = safe_div(x, 2)?
   a + 1
 }
 
-let result = handle { compute(10) } with Error { Throw(_) => -1 }
+let result = handle { compute(10) } with Exception { Throw(_) => -1 }
 result
 
 __DATA__

--- a/fixtures/typecheck/generic_effect_concrete_effect_mismatch.vibe
+++ b/fixtures/typecheck/generic_effect_concrete_effect_mismatch.vibe
@@ -1,12 +1,12 @@
 let chain = [T](
   f: (x: T) -> T with Stdout,
-  g: (x: T) -> T with Error,
+  g: (x: T) -> T with Exception,
   x: T,
 ) -> T with Stdout {
   g(f(x))
 }
 let f = (x: Int) -> Int with Stdout { x }
-let g = (x: Int) -> Int with Error { x }
+let g = (x: Int) -> Int with Exception { x }
 
 fn main {
   let _ = chain(f, g, 1)

--- a/fixtures/typecheck/generic_effect_matrix_fail_missing_effect_at_caller.vibe
+++ b/fixtures/typecheck/generic_effect_matrix_fail_missing_effect_at_caller.vibe
@@ -1,5 +1,5 @@
 let apply = [T](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
-let risky = (x: Int) -> Int with Error { x }
+let risky = (x: Int) -> Int with Exception { x }
 let run = () -> Int { apply(risky, 1) }
 
 fn main {

--- a/fixtures/typecheck/generic_effect_matrix_fail_trait_and_effect_mixed.vibe
+++ b/fixtures/typecheck/generic_effect_matrix_fail_trait_and_effect_mixed.vibe
@@ -1,7 +1,7 @@
 trait LocalEq
 impl LocalEq for Int
 let apply = [T: LocalEq](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
-let bad = (x: String) -> String with Error { x }
+let bad = (x: String) -> String with Exception { x }
 let run = () -> String { apply(bad, "s") }
 
 fn main {

--- a/fixtures/typecheck/generic_effect_matrix_ok_trait_and_effect_bound.vibe
+++ b/fixtures/typecheck/generic_effect_matrix_ok_trait_and_effect_bound.vibe
@@ -1,9 +1,9 @@
 trait LocalEq
 impl LocalEq for Int
 let apply = [T: LocalEq](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
-let id_err = (x: Int) -> Int with Error { x }
+let id_err = (x: Int) -> Int with Exception { x }
 let run = () -> Int {
-  handle { apply(id_err, 1) } with Error { Throw(_) => 0 }
+  handle { apply(id_err, 1) } with Exception { Throw(_) => 0 }
 }
 
 fn main {

--- a/fixtures/typecheck/generic_effect_matrix_ok_with_e_try_catch_localized.vibe
+++ b/fixtures/typecheck/generic_effect_matrix_ok_with_e_try_catch_localized.vibe
@@ -1,7 +1,7 @@
 let apply = [T](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
-let risky = (x: Int) -> Int with Error { throw("boom")}
+let risky = (x: Int) -> Int with Exception { throw("boom")}
 let run = () -> Int {
-  handle { apply(risky, 1) } with Error { Throw(_) => 0 }
+  handle { apply(risky, 1) } with Exception { Throw(_) => 0 }
 }
 
 fn main {

--- a/fixtures/typecheck/generic_effect_missing_caller_effect.vibe
+++ b/fixtures/typecheck/generic_effect_missing_caller_effect.vibe
@@ -1,5 +1,5 @@
 let apply = [T](f: (x: T) -> T with e, x: T) -> T with e { f(x) }
-let boom = (x: Int) -> Int with Error { x }
+let boom = (x: Int) -> Int with Exception { x }
 let run = (x: Int) -> Int { apply(boom, x) }
 
 fn main {

--- a/fixtures/typecheck/generic_effect_trait_bound_violation.vibe
+++ b/fixtures/typecheck/generic_effect_trait_bound_violation.vibe
@@ -1,9 +1,9 @@
 trait LocalEq
 impl LocalEq for Int
-let run = [T: LocalEq](x: T, f: (x: T) -> T with Error) -> T {
-  handle { f(x) } with Error { Throw(_) => x }
+let run = [T: LocalEq](x: T, f: (x: T) -> T with Exception) -> T {
+  handle { f(x) } with Exception { Throw(_) => x }
 }
-let bad = (x: String) -> String with Error { x }
+let bad = (x: String) -> String with Exception { x }
 
 fn main {
   let _ = run("s", bad)

--- a/fixtures/typecheck/generic_effect_try_catch_localizes_error.vibe
+++ b/fixtures/typecheck/generic_effect_try_catch_localizes_error.vibe
@@ -1,7 +1,7 @@
-let apply = [T](f: (x: T) -> T with Error, x: T) -> T {
-  handle { f(x) } with Error { Throw(_) => x }
+let apply = [T](f: (x: T) -> T with Exception, x: T) -> T {
+  handle { f(x) } with Exception { Throw(_) => x }
 }
-let boom = (x: Int) -> Int with Error { x }
+let boom = (x: Int) -> Int with Exception { x }
 
 fn main {
   let _ = apply(boom, 1)

--- a/fixtures/typecheck/suberror_brace_ctor_arity_mismatch.vibe
+++ b/fixtures/typecheck/suberror_brace_ctor_arity_mismatch.vibe
@@ -2,6 +2,6 @@ suberror AppError {
   Io(String);
 }
 
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   throw(Io())
 }

--- a/fixtures/typecheck/suberror_brace_payload_type_mismatch.vibe
+++ b/fixtures/typecheck/suberror_brace_payload_type_mismatch.vibe
@@ -2,6 +2,6 @@ suberror AppError {
   Parse(Int);
 }
 
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   throw(Parse("oops"))
 }

--- a/fixtures/typecheck/suberror_brace_raise_ok.vibe
+++ b/fixtures/typecheck/suberror_brace_raise_ok.vibe
@@ -3,7 +3,7 @@ suberror AppError {
   Parse(Int);
 }
 
-let fail = (x: Int) -> Unit with Error {
+let fail = (x: Int) -> Unit with Exception {
   if x == 0 {
     throw(Io("io"))
   } else {

--- a/fixtures/typecheck/suberror_brace_zero_payload_raise_ok.vibe
+++ b/fixtures/typecheck/suberror_brace_zero_payload_raise_ok.vibe
@@ -2,6 +2,6 @@ suberror AppError {
   Cancelled;
 }
 
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   throw(Cancelled)
 }

--- a/fixtures/typecheck/suberror_generic_error_bound_raise_ok.vibe
+++ b/fixtures/typecheck/suberror_generic_error_bound_raise_ok.vibe
@@ -1,9 +1,9 @@
 suberror AppError(String);
 
-let rethrow = [E: Error](e: E) -> Unit with Error {
+let rethrow = [E: Error](e: E) -> Unit with Exception {
   throw(e)
 }
 
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   rethrow(AppError("boom"))
 }

--- a/fixtures/typecheck/suberror_generic_try_catch_ok.vibe
+++ b/fixtures/typecheck/suberror_generic_try_catch_ok.vibe
@@ -1,10 +1,10 @@
 suberror AppError(String);
 
-let apply_safe = [T](f: (x: T) -> T with Error, x: T) -> T {
-  handle { f(x) } with Error { Throw(_) => x }
+let apply_safe = [T](f: (x: T) -> T with Exception, x: T) -> T {
+  handle { f(x) } with Exception { Throw(_) => x }
 }
 
-let boom = (x: Int) -> Int with Error {
+let boom = (x: Int) -> Int with Exception {
   throw(AppError("boom"))
 }
 

--- a/fixtures/typecheck/suberror_mixed_error_types_raise_ok.vibe
+++ b/fixtures/typecheck/suberror_mixed_error_types_raise_ok.vibe
@@ -3,7 +3,7 @@ suberror ParseError {
   Parse(Int);
 }
 
-let fail = (x: Int) -> Unit with Error {
+let fail = (x: Int) -> Unit with Exception {
   if x == 0 {
     throw(AppError("boom"))
   } else {

--- a/fixtures/typecheck/suberror_raise_ctor_arity_mismatch.vibe
+++ b/fixtures/typecheck/suberror_raise_ctor_arity_mismatch.vibe
@@ -1,5 +1,5 @@
 suberror AppError(String);
 
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   throw(AppError("boom", 1))
 }

--- a/fixtures/typecheck/suberror_raise_non_error_type.vibe
+++ b/fixtures/typecheck/suberror_raise_non_error_type.vibe
@@ -2,6 +2,6 @@ enum NotError {
   NotError(String);
 }
 
-let bad = () -> Unit with Error {
+let bad = () -> Unit with Exception {
   throw(NotError("boom"))
 }

--- a/fixtures/typecheck/suberror_raise_payload_type_mismatch.vibe
+++ b/fixtures/typecheck/suberror_raise_payload_type_mismatch.vibe
@@ -1,5 +1,5 @@
 suberror AppError(String);
 
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   throw(AppError(1))
 }

--- a/fixtures/typecheck/suberror_raise_string_ok.vibe
+++ b/fixtures/typecheck/suberror_raise_string_ok.vibe
@@ -1,3 +1,3 @@
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   throw("boom")
 }

--- a/fixtures/typecheck/suberror_raise_unknown_ctor.vibe
+++ b/fixtures/typecheck/suberror_raise_unknown_ctor.vibe
@@ -1,5 +1,5 @@
 suberror AppError(String);
 
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   throw(Parse(1))
 }

--- a/fixtures/typecheck/suberror_try_catch_localizes_error_ok.vibe
+++ b/fixtures/typecheck/suberror_try_catch_localizes_error_ok.vibe
@@ -1,6 +1,6 @@
 suberror AppError(String);
 
-let boom = (x: Int) -> Int with Error {
+let boom = (x: Int) -> Int with Exception {
   if x == 0 {
     throw(AppError("boom"))
   } else {
@@ -9,7 +9,7 @@ let boom = (x: Int) -> Int with Error {
 }
 
 let safe = (x: Int) -> Int {
-  handle { boom(x) } with Error { Throw(_) => 0 }
+  handle { boom(x) } with Exception { Throw(_) => 0 }
 }
 
 fn main {

--- a/fixtures/typecheck/suberror_tuple_raise_ok.vibe
+++ b/fixtures/typecheck/suberror_tuple_raise_ok.vibe
@@ -1,5 +1,5 @@
 suberror MyError(String);
 
-let fail = () -> Unit with Error {
+let fail = () -> Unit with Exception {
   throw(MyError("boom"))
 }

--- a/fixtures/typecheck/throw_payload_call_type_error.vibe
+++ b/fixtures/typecheck/throw_payload_call_type_error.vibe
@@ -6,6 +6,6 @@ fn f(a: String) -> Int {
   1
 }
 
-let g = () -> Unit with Error {
+let g = () -> Unit with Exception {
   throw(f(f("x", 1)))
 }

--- a/fixtures/typecheck/top_level_handle_closes_effect.vibe
+++ b/fixtures/typecheck/top_level_handle_closes_effect.vibe
@@ -1,8 +1,8 @@
-let f = () -> Int with Error {
+let f = () -> Int with Exception {
   throw("fail")
   0
 }
 
 fn main {
-  let _ = handle { f() } with Error { Throw(_) => -1 }
+  let _ = handle { f() } with Exception { Throw(_) => -1 }
 }

--- a/fixtures/typecheck/top_level_unhandled_effect_throw.vibe
+++ b/fixtures/typecheck/top_level_unhandled_effect_throw.vibe
@@ -1,4 +1,4 @@
-let f = () -> Int with Error {
+let f = () -> Int with Exception {
   throw("fail")
   0
 }

--- a/fixtures/wit_gen_http.vibe
+++ b/fixtures/wit_gen_http.vibe
@@ -1,6 +1,6 @@
 // #537 effect->WIT golden fixture (gate step: selfhost_only_gate.sh).
 // Exercises every branch of the WIT world mapping:
-//   - `route` carries `with HttpReq + Error`: the declared HttpReq effect
+//   - `route` carries `with HttpReq + Exception`: the declared HttpReq effect
 //     becomes an inline interface import (Error never surfaces).
 //   - `stats` carries `with Fs`: an undeclared host-capability effect
 //     renders as a comment marker.
@@ -15,14 +15,14 @@ effect HttpReq {
   Header(String) -> String
 }
 
-export let route: (String) -> String with HttpReq + Error = (prefix) -> {
+export let route: (String) -> String with HttpReq + Exception = (prefix) -> {
   let m = perform HttpReq::Method
   let u = perform HttpReq::Url
   "\{prefix}:\{m} \{u}"
 }
 
 export let handler = (method: String, url: String, headers: String, body: String) -> String {
-  // #944 (checked-Error): route's `with HttpReq + Error` row now
+  // #944 (checked-Error): route's `with HttpReq + Exception` row now
   // propagates, so the serve handler discharges Error here (keeping its
   // own signature row-less -- the serve contract shape and the generated
   // WIT are unchanged).
@@ -34,7 +34,7 @@ export let handler = (method: String, url: String, headers: String, body: String
       Url => resume(url);
       Header(_) => resume(headers)
     }
-  } with Error {
+  } with Exception {
     Throw(msg) => msg
   }
 }

--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -2409,8 +2409,57 @@ fn normalize_effect_rows(toks: Array[LTok]) -> Array[LTok] {
   out
 }
 
+/// #1461: rewrite the retired effect label `Error` to `Exception` inside effect
+/// ROWS, at the token level.
+///
+/// This is the fix-it the parser's retirement message points at, and it exists
+/// for the same reason `normalize_effect_rows` above does: the parser rejects
+/// the old spelling, so only a pass that never parses can convert source
+/// written against an older vibe.
+///
+/// Runs AFTER `normalize_effect_rows` so it also catches labels freed from a
+/// braced row in the same format: `with { Error, Fs }` has already become
+/// `with Error + Fs` by the time this sees it.
+///
+/// Row position is recognized structurally rather than by tracking the row
+/// grammar: a label is renamed only where a row ITEM can begin -- directly
+/// after `with`, after the contextual `allows`, or after a `+` -- skipping
+/// trivia. That is deliberately narrower than the real grammar and it is what
+/// keeps the pass safe. `Error` is still a live TYPE name (the throwable trait,
+/// `impl Error for ..`), and none of its uses sit in any of those three
+/// positions; a textual rewrite, or one that renamed every `Error` token,
+/// would have corrupted all of them.
+fn normalize_retired_effect_labels(toks: Array[LTok]) -> Array[LTok] {
+  let out = Array::slice([
+    LTok::{
+      kind: k_none, text: ""
+    }
+  ], 0, 0)
+  let n = Array::length(toks)
+  let mut i = 0
+  let mut item_start = false
+  while i < n {
+    let t = Array::get(toks, i)
+    if item_start && t.kind == k_name && t.text == "Error" {
+      Array::push(out, LTok::{
+        kind: k_name, text: "Exception"
+      })
+    } else {
+      Array::push(out, t)
+    }
+    if t.kind == k_ws || t.kind == k_newline || t.kind == k_comment {
+      // Trivia does not end an item position -- `with\n  Error` is still a row.
+      ()
+    } else {
+      item_start = t.kind == k_with || t.kind == k_plus || (t.kind == k_name && t.text == "allows")
+    }
+    i = i + 1
+  }
+  out
+}
+
 export fn format_script(src: String) -> String {
-  format_tokens(normalize_effect_rows(reorder_import_lists(lex_lossless(src))), 2)
+  format_tokens(normalize_retired_effect_labels(normalize_effect_rows(reorder_import_lists(lex_lossless(src)))), 2)
 }
 
 //# ======================================================================

--- a/lib/@vibe/compiler/fmt/vpkg_format_test.vibe
+++ b/lib/@vibe/compiler/fmt/vpkg_format_test.vibe
@@ -48,7 +48,7 @@ test "vpkg: the declaration region still goes through format_script" {
   // effect is a checker-level canonicalization, and the formatter must not
   // reach into it, or `vibe fmt` would start rewriting identifiers.
   let src = "name = @vibe/x\nversion = 0.0.1\n\ngenerated_hash =\n\nfn f() -> Int with { Error }\n"
-  let want = "name = @vibe/x\nversion = 0.0.1\n\ngenerated_hash =\n\nfn f() -> Int with Error\n"
+  let want = "name = @vibe/x\nversion = 0.0.1\n\ngenerated_hash =\n\nfn f() -> Int with Exception\n"
   assert(format_vpkg(src) == want)
 }
 
@@ -117,7 +117,7 @@ test "#1429: normalize_effect_rows still converts the spelling the parser remove
   // deleting it as dead code.
   let converted = format_script("let f: (Int) -> Int with { Error, Fs } = (x) -> { x }\n")
   // The label is untouched (#1461): this pass debraces, it does not rename.
-  assert(String::contains(converted, "with Error + Fs"))
+  assert(String::contains(converted, "with Exception + Fs"))
   assert(!String::contains(converted, "with {"))
   let empty = format_script("let g: () -> Int with {} = () -> { 1 }\n")
   assert(String::contains(empty, "with ()"))

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -3819,7 +3819,7 @@ fn interp_expand(arg: Expr, derived_only: Bool, gens: Array[(String, Array[(Stri
   }
 }
 
-fn interp_expand_local(arg: Expr, head: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Error {
+fn interp_expand_local(arg: Expr, head: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Exception {
   match arg {
     ETuple(items) => Some(interp_join(items, "(", ", ", ")", derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),
     EArray(items) => Some(interp_join(items, "[", ", ", "]", derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),

--- a/lib/@vibe/compiler/tests/checker_exception_kind_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_exception_kind_test.vibe
@@ -137,7 +137,7 @@ test "the erased Error row still authorizes a suberror throw (#786 unchanged)" {
   // is the end-to-end proof that the alias is still a working row label --
   // parsed, matched against the canonical `Exception` requirement, and
   // discharged -- which nothing else in lib/ demonstrates any more.
-  let src = "enum IoError {\n  NotFound(String)\n}\n\nlet boom = () -> Int with Error {\n  throw(NotFound(\"x\"))\n}\n\nlet main = () -> Int {\n  handle {\n    boom()\n  } with Error {\n    Throw(_e) => 42\n  }\n}\n"
+  let src = "enum IoError {\n  NotFound(String)\n}\n\nlet boom = () -> Int with Exception {\n  throw(NotFound(\"x\"))\n}\n\nlet main = () -> Int {\n  handle {\n    boom()\n  } with Exception {\n    Throw(_e) => 42\n  }\n}\n"
   assert(eq(Array::length(checked_diags(src)), 0))
 }
 

--- a/lib/@vibe/compiler/tests/fixture_roundtrip_test.vibe
+++ b/lib/@vibe/compiler/tests/fixture_roundtrip_test.vibe
@@ -82,11 +82,11 @@ test "fixture_fn_where_keeps_fn_form" {
   // the alias still parses and survives a format cycle -- the rest of lib/ was
   // converted to `Exception`, which would otherwise leave nothing in the tree
   // exercising the alias at all before the seed bump that removes it.
-  let src = "fn checked_add(x: Int, y: Int) -> Int with Error where { requires: x >= 0, ensures: result >= x } { x + y }\nexport { checked_add }"
+  let src = "fn checked_add(x: Int, y: Int) -> Int with Exception where { requires: x >= 0, ensures: result >= x } { x + y }\nexport { checked_add }"
   let printed = pp_preserving(src)
   assert(String::contains(printed, "fn checked_add"))
   assert(String::contains(printed, "where { requires:"))
   assert(String::contains(printed, "ensures:"))
-  assert(String::contains(printed, "with Error"))
+  assert(String::contains(printed, "with Exception"))
   assert(not(String::contains(printed, "let rec checked_add")))
 }

--- a/lib/@vibe/compiler/tests/parser_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_test.vibe
@@ -901,11 +901,17 @@ test "#1345: `allows` takes capability effects only" {
 }
 
 test "#1345: a core ambient effect in `allows` names the right clause" {
-  // `Error`/`Exception[E]` get their own message rather than the generic
+  // `Exception`/`Exception[E]` get their own message rather than the generic
   // "not a capability": the author wrote a real effect in the wrong clause,
   // and the fix is to move it, not to reclassify it.
+  //
+  // #1461: spelled `Exception`, not the `Error` this case used to carry. The
+  // two named the SAME core ambient effect, but `Error` is no longer a
+  // spelling at all -- it now fails in parse_effect_item before the clause
+  // classification ever runs, which would silently retarget this case at the
+  // retirement message and leave ADR-0088's check untested.
   let out = handle {
-    print_program(parse_program(lex("let f: () -> Int with () allows Error = () -> { 1 }")))
+    print_program(parse_program(lex("let f: () -> Int with () allows Exception = () -> { 1 }")))
   } with Exception {
     Throw(e) => String::concat("ERROR: ", e)
   }

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -891,16 +891,47 @@ fn collect_effect_names(tokens: Array[Token], pos: Int, acc: String) -> (String,
 /// #1429: one effect-row item -- `Name`, `Name::Op`, or `Name[T, ..]`. Split
 /// out of collect_effect_names so the braced and braceless spellings read the
 /// same item grammar rather than drifting apart.
+/// #1461 final stage: `Error` is no longer a spelling. It was the original name
+/// of the core ambient exception effect and rode along as an accepted alias
+/// through the migration; ADR-0085 made `Exception` the one name, and every row
+/// in this tree was converted. Rejecting it here retires the alias at the only
+/// place a SOURCE row label is produced.
+///
+/// This is a SURFACE rejection and nothing more. `is_exception_effect_name`
+/// still answers true for the label internally, the taxonomy table still
+/// carries its row, and `printer.vibe` still re-sugars both spellings -- a
+/// pinned seed from before the bump prints `Error`, and re-sugar must keep
+/// reading it. What changes is only what a `.vibe` file may say.
+///
+/// Named, like #1429's braced-row rejection, for the same reason: a reader who
+/// gets "expected an effect name" has no way to learn that the name moved. It
+/// points at `vibe fmt` for the same reason too -- the CST formatter rewrites
+/// the label at the token level, so it converts source this parser no longer
+/// accepts, which is the migration path for code outside this repository.
+fn reject_retired_effect_label(name: String) -> Unit with Exception {
+  if name == "Error" {
+    throw("`Error` was retired as an effect spelling in #1461 -- write `Exception` (or `Exception[Kind]` for a typed row). `vibe fmt` rewrites the old spelling for you.")
+  } else {
+    ()
+  }
+}
+
 fn parse_effect_item(tokens: Array[Token], pos: Int) -> (String, Int) with Exception {
   match peek(tokens, pos) {
-    TIdent(name) => match peek(tokens, pos + 1) {
-      TDoubleColon => match peek(tokens, pos + 2) {
-        TIdent(member) =>
-        (String::concat(name, String::concat("::", member)), pos + 3),
-        _ => throw("expected qualified operation name after '::' in effect row")
-      },
-      TLBracket => collect_row_item_targs(tokens, pos + 2, 1, String::concat(name, "[")),
-      _ => (name, pos + 1)
+    TIdent(name) => {
+      // Covers every shape the label can take: bare (`Error`), qualified
+      // (`Error::Throw`), and applied (`Error[IoError]`) -- the check is on the
+      // HEAD, which all three share.
+      reject_retired_effect_label(name)
+      match peek(tokens, pos + 1) {
+        TDoubleColon => match peek(tokens, pos + 2) {
+          TIdent(member) =>
+          (String::concat(name, String::concat("::", member)), pos + 3),
+          _ => throw("expected qualified operation name after '::' in effect row")
+        },
+        TLBracket => collect_row_item_targs(tokens, pos + 2, 1, String::concat(name, "[")),
+        _ => (name, pos + 1)
+      }
     },
     _ => throw("expected an effect name in the effect row after 'with'")
   }

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -2303,7 +2303,7 @@ cat > "$pfdir/bad_row_single.vibe" <<'EOF'
 let leaf: (String) -> String with Fs = (p) -> {
   Fs::read_file(p)
 }
-let mid: (String) -> String with Error = (p) -> {
+let mid: (String) -> String with Exception = (p) -> {
   leaf(p)
 }
 export let _start: () -> Int = () -> { 42 }
@@ -2314,9 +2314,12 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 if [ -s "$pfdir/bad_row_single.wasm" ]; then
   echo "[compiler-gate] FAIL: partially-declared transitive effect call compiled (#639)" >&2; exit 1
 fi
-# #1461: the fixture still DECLARES `with Error`; the diagnostic reports the
-# canonical `Exception`. That asymmetry is the point of the flip and is what
-# this assertion pins -- the alias keeps parsing, it just stops being printed.
+# #1461: the fixture used to DECLARE `with Error` while the diagnostic reported
+# the canonical `Exception` -- an asymmetry that was the point of Step 1's flip,
+# and what this assertion pinned. The final stage retired the alias as a
+# spelling, so the fixture now declares `Exception` too and the asymmetry is
+# gone. The assertion text is unchanged: it always read `declared { Exception }`,
+# because the canonical name is what gets printed either way.
 if ! grep -qF "effect row mismatch for 'mid': missing { Fs } (declared { Exception }, requires { Exception, Fs })" "$pfdir/bad_row_single.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: partial-row reject lacks the declared-vs-required diff (#639)" >&2
   cat "$pfdir/bad_row_single.wasm.diag" 2>/dev/null >&2; exit 1
@@ -2363,7 +2366,7 @@ fi
 # local callee was rejected. The env-seeded row closes the module boundary.
 mkdir -p "$pfdir/sub"
 cat > "$pfdir/sub/helper.vibe" <<'EOF'
-export let read_it: (String) -> String with Error + Fs = (p) -> {
+export let read_it: (String) -> String with Exception + Fs = (p) -> {
   Fs::read_file(p)
 }
 EOF
@@ -2379,7 +2382,7 @@ EOF
 cat > "$pfdir/good_import_transitive.vibe" <<'EOF'
 import ./sub/helper.vibe { read_it }
 
-let g: (String) -> String with Error + Fs = (p) -> {
+let g: (String) -> String with Exception + Fs = (p) -> {
   read_it(p)
 }
 export let _start: () -> Int = () -> { 42 }
@@ -2736,42 +2739,42 @@ echo "[compiler-gate] 27e/27 Error-as-perform equivalence + non-resumability (#6
 edir="_build/_gate_error_perform"
 rm -rf "$edir"; mkdir -p "$edir"
 cat > "$edir/via_perform.vibe" <<'EOF'
-let safe = () -> Int with Error {
+let safe = () -> Int with Exception {
   perform Error::Throw("fail")
   0
 }
 export let _start: () -> Int = () -> {
-  handle { safe() } with Error { Throw(msg) => String::length(msg) }
+  handle { safe() } with Exception { Throw(msg) => String::length(msg) }
 }
 EOF
 cat > "$edir/via_throw.vibe" <<'EOF'
-let safe = () -> Int with Error {
+let safe = () -> Int with Exception {
   throw("fail")
   0
 }
 export let _start: () -> Int = () -> {
-  handle { safe() } with Error { Throw(msg) => String::length(msg) }
+  handle { safe() } with Exception { Throw(msg) => String::length(msg) }
 }
 EOF
 cat > "$edir/bad_resume_arm.vibe" <<'EOF'
-let risky = () -> Int with Error {
+let risky = () -> Int with Exception {
   throw("boom")
   0
 }
 export let _start: () -> Int = () -> {
-  handle { risky() } with Error { Throw(_m) => resume(0) }
+  handle { risky() } with Exception { Throw(_m) => resume(0) }
 }
 EOF
 # Codex P2 on #933: the rejection walk's catch-all used to end at EBreak /
 # ELoop (and EMap/ESpread/ELabeledArg/EContinue/ERecord), so a resume tucked
 # into `loop { break resume(0) }` reached codegen's meaningless tag-1 path.
 cat > "$edir/bad_resume_loop.vibe" <<'EOF'
-let risky = () -> Int with Error {
+let risky = () -> Int with Exception {
   throw("boom")
   0
 }
 export let _start: () -> Int = () -> {
-  handle { risky() } with Error { Throw(_m) => loop { break resume(0) } }
+  handle { risky() } with Exception { Throw(_m) => loop { break resume(0) } }
 }
 EOF
 for v in via_perform via_throw; do
@@ -6014,7 +6017,7 @@ echo "[compiler-gate] 44b/44 checked-Error row discipline default-on (#944 stage
 g944dir="_build/_gate_944"
 rm -rf "$g944dir"; mkdir -p "$g944dir"
 cat > "$g944dir/leak.vibe" <<'EOF'
-fn boom(x: Int) -> Int with Error {
+fn boom(x: Int) -> Int with Exception {
   if x == 0 {
     throw("zero")
   }
@@ -6030,7 +6033,7 @@ export let main = () -> Int {
 }
 EOF
 cat > "$g944dir/discharged.vibe" <<'EOF'
-fn boom(x: Int) -> Int with Error {
+fn boom(x: Int) -> Int with Exception {
   if x == 0 {
     throw("zero")
   }
@@ -6040,7 +6043,7 @@ fn boom(x: Int) -> Int with Error {
 export let main = () -> Int {
   handle {
     boom(1)
-  } with Error {
+  } with Exception {
     Throw(_) => 0
   }
 }
@@ -8782,7 +8785,7 @@ let boom = () -> Int with Exception[IoError] + Exception[ParseError] {
 let main = () -> Int {
   handle {
     boom()
-  } with Error {
+  } with Exception {
     Throw(_e) => 42
   }
 }
@@ -8880,12 +8883,12 @@ enum AppError {
   Cancelled
 } derive (Show)
 
-let _start = () -> Int with Error {
+let _start = () -> Int with Exception {
   throw(Failed("io"))
 }
 VIBEEOF
 cat > "$exnmsgdir/plain.vibe" <<'VIBEEOF'
-let _start = () -> Int with Error {
+let _start = () -> Int with Exception {
   throw("plain message")
 }
 VIBEEOF
@@ -8894,7 +8897,7 @@ enum NoShow {
   Bang(Int)
 }
 
-let _start = () -> Int with Error {
+let _start = () -> Int with Exception {
   throw(Bang(5))
 }
 VIBEEOF
@@ -8942,7 +8945,7 @@ let _start = () -> Int {
   println("interp=\{Bang(1)}")
   handle {
     throw(Bang(1))
-  } with Error {
+  } with Exception {
     Throw(_m) => 7
   }
 }

--- a/scripts/coverage/cov_async.vibe
+++ b/scripts/coverage/cov_async.vibe
@@ -4,7 +4,7 @@
 // example/fixture program uses them, so the bulk corpus leaves every one dark.
 // Compile programs exercising each builtin so its compile_call branch runs.
 let cov_async_one: (String) -> Int = (src) -> {
-  handle { Bytes::length(compile_source_wasi_only(src, "main")) } with Error { Throw(_) => 0 }
+  handle { Bytes::length(compile_source_wasi_only(src, "main")) } with Exception { Throw(_) => 0 }
 }
 
 export let cov_async_main: () -> Int = () -> {

--- a/scripts/coverage/cov_block.vibe
+++ b/scripts/coverage/cov_block.vibe
@@ -4,7 +4,7 @@
 // struct arms plus its error throws (eof-in-block, "expected identifier after
 // 'let rec'/'let mut'", "did not advance") with well-formed and malformed bodies.
 let blk: (String) -> Int = (s) -> {
-  handle { let r = parse_impl_block(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_impl_block(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 
 let blk_ok: () -> Int = () -> {

--- a/scripts/coverage/cov_builtins.vibe
+++ b/scripts/coverage/cov_builtins.vibe
@@ -5,7 +5,7 @@
 // handful (get/length/push/map/concat), leaving the rest dark. Compile a program
 // per builtin so each dispatch + codegen arm runs.
 let cov_bi_one: (String) -> Int = (src) -> {
-  handle { Bytes::length(compile_source_wasi_only(src, "main")) } with Error { Throw(_) => 0 }
+  handle { Bytes::length(compile_source_wasi_only(src, "main")) } with Exception { Throw(_) => 0 }
 }
 
 export let cov_builtins_main: () -> Int = () -> {

--- a/scripts/coverage/cov_cache2.vibe
+++ b/scripts/coverage/cov_cache2.vibe
@@ -5,10 +5,10 @@
 // parse_persistent_manifest_header_cache (version / manifest / entry / CR / empty).
 let c2_np: (String) -> Int = (p) -> { String::length(normalize_path(p)) }
 let c2_rows: (String) -> Int = (s) -> {
-  handle { Array::length(parse_source_manifest_rows(s)) } with Error { Throw(_) => 0 }
+  handle { Array::length(parse_source_manifest_rows(s)) } with Exception { Throw(_) => 0 }
 }
 let c2_hdr: (String) -> Int = (s) -> {
-  handle { let r = parse_persistent_manifest_header_cache(s); r.0 } with Error { Throw(_) => 0 }
+  handle { let r = parse_persistent_manifest_header_cache(s); r.0 } with Exception { Throw(_) => 0 }
 }
 
 export let cov_cache2_main: () -> Int = () -> {

--- a/scripts/coverage/cov_cachetext.vibe
+++ b/scripts/coverage/cov_cachetext.vibe
@@ -9,13 +9,13 @@ let cov_ct_group: (String) -> Int = (raw) -> {
   handle {
     let (v, _, rows) = parse_persistent_source_group_cache(raw)
     v + Array::length(rows)
-  } with Error { Throw(_) => 0 }
+  } with Exception { Throw(_) => 0 }
 }
 let cov_ct_list: (String) -> Int = (raw) -> {
   handle {
     let (v, _, srcs) = parse_persistent_source_list_cache(raw)
     v + Array::length(srcs)
-  } with Error { Throw(_) => 0 }
+  } with Exception { Throw(_) => 0 }
 }
 
 export let cov_cachetext_main: () -> Int = () -> {

--- a/scripts/coverage/cov_driver.vibe
+++ b/scripts/coverage/cov_driver.vibe
@@ -257,9 +257,9 @@ let cov_cache_text: () -> Int = () -> {
   let mut i = 0
   while i < Array::length(txts) {
     let t = Array::get(txts, i)
-    let r1 = handle { let (v, _, rows) = parse_persistent_manifest_header_cache(t); v + Array::length(rows) } with Error { Throw(_) => 0 }
-    let r2 = handle { let (v, _, rows) = parse_persistent_source_list_cache(t); v + Array::length(rows) } with Error { Throw(_) => 0 }
-    let r3 = handle { let (v, _, rows) = parse_persistent_source_group_cache(t); v + Array::length(rows) } with Error { Throw(_) => 0 }
+    let r1 = handle { let (v, _, rows) = parse_persistent_manifest_header_cache(t); v + Array::length(rows) } with Exception { Throw(_) => 0 }
+    let r2 = handle { let (v, _, rows) = parse_persistent_source_list_cache(t); v + Array::length(rows) } with Exception { Throw(_) => 0 }
+    let r3 = handle { let (v, _, rows) = parse_persistent_source_group_cache(t); v + Array::length(rows) } with Exception { Throw(_) => 0 }
     let r4 = Array::length(split_header_values(t))
     acc = acc + r1 + r2 + r3 + r4
     i = i + 1
@@ -285,7 +285,7 @@ let cov_parse: () -> Int = () -> {
   let mut acc = 0
   let mut i = 0
   while i < Array::length(srcs) {
-    let r = handle { Array::length(parse_program(lex(Array::get(srcs, i)))) } with Error { Throw(_) => 0 }
+    let r = handle { Array::length(parse_program(lex(Array::get(srcs, i)))) } with Exception { Throw(_) => 0 }
     acc = acc + r
     i = i + 1
   }
@@ -299,7 +299,7 @@ let cov_ast: () -> Int = () -> {
   let mut acc = 0
   let mut i = 0
   while i < Array::length(srcs) {
-    let stmts = handle { parse_program(lex(Array::get(srcs, i))) } with Error { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
+    let stmts = handle { parse_program(lex(Array::get(srcs, i))) } with Exception { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
     let ns1 = namespace_private_value_stmts("mod_a.vibe", stmts)
     let ns2 = namespace_private_value_stmts("dir/mod_b.vibe", stmts)
     acc = acc + Array::length(ns1) + Array::length(ns2)
@@ -418,7 +418,7 @@ let cov_check: () -> Int = () -> {
     let r = handle {
       let (_, _, _) = check_expr(Array::get(es, i), env, defs, SubstEmpty, 100, errors)
       1
-    } with Error { Throw(_) => 0 }
+    } with Exception { Throw(_) => 0 }
     let rw = rewrite_private_type_ctor_expr(Array::get(es, i), Array::slice([("Foo", "Foo_x")], 0, 1), Array::slice([("A", "A_x")], 0, 1))
     let _ = rw
     acc = acc + r
@@ -458,9 +458,9 @@ let cov_stmts: () -> Int = () -> {
   let mut acc = 0
   let mut i = 0
   while i < Array::length(srcs) {
-    let stmts = handle { parse_program(lex(Array::get(srcs, i))) } with Error { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
-    let deps = handle { collect_import_deps_from_stmts(stmts, "base/dir") } with Error { Throw(_) => Array::slice([""], 0, 0) }
-    let cs = handle { let (_, _, _) = check_stmts(stmts, 0, env, defs, SubstEmpty, 200, errors); 1 } with Error { Throw(_) => 0 }
+    let stmts = handle { parse_program(lex(Array::get(srcs, i))) } with Exception { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
+    let deps = handle { collect_import_deps_from_stmts(stmts, "base/dir") } with Exception { Throw(_) => Array::slice([""], 0, 0) }
+    let cs = handle { let (_, _, _) = check_stmts(stmts, 0, env, defs, SubstEmpty, 200, errors); 1 } with Exception { Throw(_) => 0 }
     acc = acc + Array::length(deps) + cs
     i = i + 1
   }

--- a/scripts/coverage/cov_final.vibe
+++ b/scripts/coverage/cov_final.vibe
@@ -32,7 +32,7 @@ let fin_import: () -> Int = () -> {
   Array::push(srcs, "./x"); Array::push(srcs, "@scope/pkg/mod"); Array::push(srcs, "single")
   let mut i = 0
   while i < Array::length(srcs) {
-    acc = acc + (handle { let r = collect_import_path(lex(Array::get(srcs, i)), 0, "base"); String::length(r.0) } with Error { Throw(_) => 0 })
+    acc = acc + (handle { let r = collect_import_path(lex(Array::get(srcs, i)), 0, "base"); String::length(r.0) } with Exception { Throw(_) => 0 })
     i = i + 1
   }
   acc
@@ -51,7 +51,7 @@ let fin_groups: () -> Int = () -> {
   Array::push(body, SExport(Array::slice(["k"], 0, 1)))
   acc = acc + module_value_aliases(body, "M", Array::slice([("k", "M_k"), ("p", "M_p")], 0, 2))
   acc = acc + module_value_aliases(body, "M", Array::slice([("", "")], 0, 0))
-  handle { acc = acc + Array::length(collect_source_groups_fs("_build/covwarm/main.vibe")) } with Error { Throw(_) => () }
+  handle { acc = acc + Array::length(collect_source_groups_fs("_build/covwarm/main.vibe")) } with Exception { Throw(_) => () }
   acc
 }
 

--- a/scripts/coverage/cov_final2.vibe
+++ b/scripts/coverage/cov_final2.vibe
@@ -51,8 +51,8 @@ let f2_rewrite: () -> Int = () -> {
   acc = acc + f2_rw(EDot(x, "f"))
   acc = acc + f2_rw(EWhile(x, x))
   acc = acc + f2_rw(EForIn("i", None, x, x))
-  acc = acc + (handle { let r = scan_header_import_dep(lex("@pkg/m { y }"), 0, "b", MapBuilder::freeze(MapBuilder::new())); String::length(r.0) } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = scan_header_import_dep(lex("./a.vibe as A { x }"), 0, "b", MapBuilder::freeze(MapBuilder::new())); String::length(r.0) } with Error { Throw(_) => 0 })
+  acc = acc + (handle { let r = scan_header_import_dep(lex("@pkg/m { y }"), 0, "b", MapBuilder::freeze(MapBuilder::new())); String::length(r.0) } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = scan_header_import_dep(lex("./a.vibe as A { x }"), 0, "b", MapBuilder::freeze(MapBuilder::new())); String::length(r.0) } with Exception { Throw(_) => 0 })
   acc
 }
 

--- a/scripts/coverage/cov_fs2.vibe
+++ b/scripts/coverage/cov_fs2.vibe
@@ -6,19 +6,19 @@
 // against a real manifest project + missing cache (the None / cold arms). Needs
 // _build/covfs2/{main.vibe,compiler_sources_manifest.tsv}.
 let f_bms: (String) -> Int = (src) -> {
-  handle { String::length(build_module_source_from_source(src, "m")) } with Error { Throw(_) => 0 }
+  handle { String::length(build_module_source_from_source(src, "m")) } with Exception { Throw(_) => 0 }
 }
 let f_all: (String) -> Int = (p) -> {
-  handle { Array::length(collect_all_sources_fs(p)) } with Error { Throw(_) => 0 }
+  handle { Array::length(collect_all_sources_fs(p)) } with Exception { Throw(_) => 0 }
 }
 let f_grp: (String) -> Int = (p) -> {
-  handle { Array::length(collect_source_groups_fs(p)) } with Error { Throw(_) => 0 }
+  handle { Array::length(collect_source_groups_fs(p)) } with Exception { Throw(_) => 0 }
 }
 let f_dep: (String, String) -> Int = (a, b) -> {
-  handle { match load_persistent_dep_list(a, b) { Some(_) => 1, None => 0 } } with Error { Throw(_) => 0 }
+  handle { match load_persistent_dep_list(a, b) { Some(_) => 1, None => 0 } } with Exception { Throw(_) => 0 }
 }
 let f_env: (String) -> Int = (p) -> {
-  handle { match load_persistent_type_env(p) { Some(_) => 1, None => 0 } } with Error { Throw(_) => 0 }
+  handle { match load_persistent_type_env(p) { Some(_) => 1, None => 0 } } with Exception { Throw(_) => 0 }
 }
 
 export let cov_fs2_main: () -> Int = () -> {

--- a/scripts/coverage/cov_fscache.vibe
+++ b/scripts/coverage/cov_fscache.vibe
@@ -11,7 +11,7 @@ let cov_fc_one: (String, String, String) -> Int = (p, st, fp) -> {
       Some(_) => 1,
       None => 0
     }
-  } with Error {
+  } with Exception {
     Throw(_) => 0
   }
 }
@@ -21,8 +21,8 @@ export let cov_fscache_main: () -> Int = () -> {
   let path = "_build/covfs/f.vibe"
   // missing file
   acc = acc + cov_fc_one("_build/covfs/nope.vibe", "x", "y")
-  let real_stat = handle { __to_string(Fs::stat_token(path)) } with Error { Throw(_) => "" }
-  let real_fp = handle { compact_string_fingerprint(Fs::read_file(path)) } with Error { Throw(_) => "" }
+  let real_stat = handle { __to_string(Fs::stat_token(path)) } with Exception { Throw(_) => "" }
+  let real_fp = handle { compact_string_fingerprint(Fs::read_file(path)) } with Exception { Throw(_) => "" }
   // has stat-token: match / mismatch+fp-match / mismatch+fp-miss / mismatch+fp-empty
   acc = acc + cov_fc_one(path, real_stat, "")
   acc = acc + cov_fc_one(path, "wrong-stat-token", real_fp)

--- a/scripts/coverage/cov_grab.vibe
+++ b/scripts/coverage/cov_grab.vibe
@@ -42,7 +42,7 @@ let grab_binop: () -> Int = () -> {
   Array::push(ops, "+"); Array::push(ops, "-"); Array::push(ops, "*"); Array::push(ops, "=="); Array::push(ops, "<"); Array::push(ops, "&&")
   let mut i = 0
   while i < Array::length(ops) {
-    acc = acc + (handle { let (t, _) = infer_binop_type(Array::get(ops, i), CtInt, CtInt, env, SubstEmpty, Array::slice([""], 0, 0)); match t { _ => 1 } } with Error { Throw(_) => 0 })
+    acc = acc + (handle { let (t, _) = infer_binop_type(Array::get(ops, i), CtInt, CtInt, env, SubstEmpty, Array::slice([""], 0, 0)); match t { _ => 1 } } with Exception { Throw(_) => 0 })
     i = i + 1
   }
   acc
@@ -93,10 +93,10 @@ let grab_ast: () -> Int = () -> {
 }
 let grab_tok: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + (handle { skip_derive(lex("derive(Eq, Show) struct S { x: Int }"), 0) } with Error { Throw(_) => 0 })
-  acc = acc + (handle { skip_derive(lex("struct S { x: Int }"), 0) } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let t = lex("a + b"); if has_non_pipe_infix_top(t, 0, Array::length(t)) { 1 } else { 0 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = collect_import_path(lex("import ./x/y.vibe { z }"), 1, "b"); String::length(r.0) } with Error { Throw(_) => 0 })
+  acc = acc + (handle { skip_derive(lex("derive(Eq, Show) struct S { x: Int }"), 0) } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { skip_derive(lex("struct S { x: Int }"), 0) } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let t = lex("a + b"); if has_non_pipe_infix_top(t, 0, Array::length(t)) { 1 } else { 0 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = collect_import_path(lex("import ./x/y.vibe { z }"), 1, "b"); String::length(r.0) } with Exception { Throw(_) => 0 })
   acc
 }
 

--- a/scripts/coverage/cov_grind.vibe
+++ b/scripts/coverage/cov_grind.vibe
@@ -31,8 +31,8 @@ export let cov_grind_main: () -> Int = () -> {
   let rows = Array::slice([g_rows4("e.vibe", "d.vibe")], 0, 1)
   Array::push(rows, g_rows4("e.vibe", "d2.vibe"))
   let idx = Map::set(empty_path_index(), "e.vibe", true)
-  acc = acc + (handle { Array::length(collect_needed_paths_from_manifest_headers("e.vibe", idx, rows)) } with Error { Throw(_) => 0 })
+  acc = acc + (handle { Array::length(collect_needed_paths_from_manifest_headers("e.vibe", idx, rows)) } with Exception { Throw(_) => 0 })
   // empty rows -> None lookup -> Fs path (covers the None arm; Fs may fail, swallowed)
-  acc = acc + (handle { Array::length(collect_needed_paths_from_manifest_headers("_build/covwarm/main.vibe", empty_path_index(), Array::slice([g_rows4("x", "y")], 0, 0))) } with Error { Throw(_) => 0 })
+  acc = acc + (handle { Array::length(collect_needed_paths_from_manifest_headers("_build/covwarm/main.vibe", empty_path_index(), Array::slice([g_rows4("x", "y")], 0, 0))) } with Exception { Throw(_) => 0 })
   acc
 }

--- a/scripts/coverage/cov_grind2.vibe
+++ b/scripts/coverage/cov_grind2.vibe
@@ -27,13 +27,13 @@ let gr2_ns: () -> Int = () -> {
 }
 let gr2_perform: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + (handle { let r = parse_perform_primary(lex("perform St::get()"), 1, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_perform_primary(lex("perform Eff::put(1, 2)"), 1, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a, b](x: a, y: b) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a](x: a) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("lbl: 5"), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("...rest"), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("plain"), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_perform_primary(lex("perform St::get()"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_perform_primary(lex("perform Eff::put(1, 2)"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a, b](x: a, y: b) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a](x: a) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_call_arg(lex("lbl: 5"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_call_arg(lex("...rest"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_call_arg(lex("plain"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
   acc
 }
 

--- a/scripts/coverage/cov_link.vibe
+++ b/scripts/coverage/cov_link.vibe
@@ -15,7 +15,7 @@ let cov_link_linked: () -> Array[(String, String, Int, Int)] = () -> {
   xs
 }
 
-let cov_link_compile_one: (String, String, Bool, Bool, Bool) -> Int with Error = (src, entry, library_mode, enable_rc, coverage) -> {
+let cov_link_compile_one: (String, String, Bool, Bool, Bool) -> Int with Exception = (src, entry, library_mode, enable_rc, coverage) -> {
   let stmts = load_and_parse(src)
   let bytes = compile_wasi_module_linked_impl(
     stmts, entry, cov_link_empty_pairs(), cov_link_linked(),
@@ -27,7 +27,7 @@ let cov_link_compile_one: (String, String, Bool, Bool, Bool) -> Int with Error =
 let cov_link_safe: (String, String, Bool, Bool, Bool) -> Int = (src, entry, library_mode, enable_rc, coverage) -> {
   handle {
     cov_link_compile_one(src, entry, library_mode, enable_rc, coverage)
-  } with Error {
+  } with Exception {
     Throw(_) => 0
   }
 }

--- a/scripts/coverage/cov_margin.vibe
+++ b/scripts/coverage/cov_margin.vibe
@@ -4,13 +4,13 @@
 // / name?= / name~ / name? / plain / non-ident), parse_generic_fn_primary (bracket
 // depth + after-params dispatch). Called directly with parse_impl as parse_recur.
 let m_perf: (String) -> Int = (s) -> {
-  handle { let r = parse_perform_primary(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_perform_primary(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let m_arg: (String) -> Int = (s) -> {
-  handle { let r = parse_call_arg(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_call_arg(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let m_gen: (String) -> Int = (s) -> {
-  handle { let r = parse_generic_fn_primary(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_generic_fn_primary(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 
 let m_performs: () -> Int = () -> {

--- a/scripts/coverage/cov_misc.vibe
+++ b/scripts/coverage/cov_misc.vibe
@@ -9,11 +9,11 @@ let m_infix: (String) -> Int = (src) -> {
   handle {
     let toks = lex(src)
     if has_non_pipe_infix_top(toks, 0, Array::length(toks)) { 1 } else { 0 }
-  } with Error { Throw(_) => 0 }
+  } with Exception { Throw(_) => 0 }
 }
 let m_cp: (Pat, Type) -> Int = (pp, ty) -> {
   handle { match check_pattern(pp, ty, EnvEmpty, Array::slice([TDAlias("T", Array::slice([""], 0, 0), CtInt)], 0, 0)) { _ => 1 } }
-  with Error { Throw(_) => 0 }
+  with Exception { Throw(_) => 0 }
 }
 
 export let cov_misc_main: () -> Int = () -> {

--- a/scripts/coverage/cov_parse.vibe
+++ b/scripts/coverage/cov_parse.vibe
@@ -5,7 +5,7 @@
 // typecheck/codegen — so syntactically-diverse sources cover them even when they
 // would not compile. load_and_parse each, swallowing errors.
 let cov_parse_one: (String) -> Int = (src) -> {
-  handle { Array::length(load_and_parse(src)) } with Error { Throw(_) => 0 }
+  handle { Array::length(load_and_parse(src)) } with Exception { Throw(_) => 0 }
 }
 
 export let cov_parse_main: () -> Int = () -> {

--- a/scripts/coverage/cov_parser2.vibe
+++ b/scripts/coverage/cov_parser2.vibe
@@ -5,7 +5,7 @@
 // fires; exotic-valid input takes the rare constructs the corpus never writes.
 // Per-snippet errors are swallowed so one bad parse still banks every arm it reached.
 let p: (String) -> Int = (src) -> {
-  handle { Array::length(load_and_parse(src)) } with Error { Throw(_) => 0 }
+  handle { Array::length(load_and_parse(src)) } with Exception { Throw(_) => 0 }
 }
 
 export let cov_parser2_main: () -> Int = () -> {

--- a/scripts/coverage/cov_parser3.vibe
+++ b/scripts/coverage/cov_parser3.vibe
@@ -5,13 +5,13 @@
 // immediately followed by '(' is NOT a call) — shapes normal parsing never yields —
 // plus parse_impl across its mode dispatch and parse_impl_block on block bodies.
 let pp: (Expr) -> Int = (e) -> {
-  handle { let r = parse_postfix(lex("(a)"), 0, e, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_postfix(lex("(a)"), 0, e, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let pm: (Int) -> Int = (mode) -> {
-  handle { let r = parse_impl(lex("a + b"), 0, mode); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_impl(lex("a + b"), 0, mode); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let pblk: (String) -> Int = (src) -> {
-  handle { let r = parse_impl_block(lex(src), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_impl_block(lex(src), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 
 let pp_stopcases: () -> Int = () -> {

--- a/scripts/coverage/cov_parser4.vibe
+++ b/scripts/coverage/cov_parser4.vibe
@@ -3,16 +3,16 @@
 // with lexed token sequences (and parse_impl as the parse_recur callback) to reach
 // pattern/type/stmt/primary/decl arms the black-box parser leaves dark.
 let p4_pat: (String) -> Int = (s) -> {
-  handle { let r = parse_pattern(lex(s), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_pattern(lex(s), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let p4_ty: (String, Int) -> Int = (s, m) -> {
-  handle { let r = parse_type_impl(lex(s), 0, m); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_type_impl(lex(s), 0, m); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let p4_stmt: (String) -> Int = (s) -> {
-  handle { let r = parse_stmt(lex(s), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_stmt(lex(s), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let p4_disp: (String, Int) -> Int = (s, m) -> {
-  handle { let r = parse_impl_dispatch(lex(s), 0, m, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_impl_dispatch(lex(s), 0, m, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 
 let p4_patterns: () -> Int = () -> {
@@ -44,24 +44,24 @@ let p4_stmts: () -> Int = () -> {
 }
 let p4_primaries: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + (handle { let r = parse_perform_primary(lex("perform St::get()"), 1, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a](x: a) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("label: 1"), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("42"), 0, parse_impl); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_perform_primary(lex("perform St::get()"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a](x: a) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_call_arg(lex("label: 1"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_call_arg(lex("42"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
   let mut m = 20
   while m < 28 { acc = acc + p4_disp("if a { 1 } else { 2 }", m); m = m + 1 }
   acc
 }
 let p4_decls: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + (handle { let r = parse_enum_stmt(lex("E { A; B(Int); C(Int, Bool) }"), 0, false); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_enum_stmt(lex("E { A }"), 0, true); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_export_stmt(lex("export { a, b as c }"), 1); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_one_param(lex("x: Int"), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_one_param(lex("y"), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_impl_type_params(lex("[a, b]"), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_export_name(lex("foo as bar"), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_export_name(lex("baz"), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_enum_stmt(lex("E { A; B(Int); C(Int, Bool) }"), 0, false); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_enum_stmt(lex("E { A }"), 0, true); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_export_stmt(lex("export { a, b as c }"), 1); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_one_param(lex("x: Int"), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_one_param(lex("y"), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_impl_type_params(lex("[a, b]"), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_export_name(lex("foo as bar"), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { let r = parse_export_name(lex("baz"), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
   acc
 }
 

--- a/scripts/coverage/cov_parser5.vibe
+++ b/scripts/coverage/cov_parser5.vibe
@@ -3,16 +3,16 @@
 // exotic forms, parse_export_stmt export forms, parse_one_param labeled/optional/
 // typed params. All called directly with lexed tokens.
 let p5_ty: (String, Int) -> Int = (s, m) -> {
-  handle { let r = parse_type_impl(lex(s), 0, m); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_type_impl(lex(s), 0, m); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let p5_pat: (String) -> Int = (s) -> {
-  handle { let r = parse_pattern(lex(s), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_pattern(lex(s), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let p5_exp: (String) -> Int = (s) -> {
-  handle { let r = parse_export_stmt(lex(s), 1); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_export_stmt(lex(s), 1); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let p5_param: (String) -> Int = (s) -> {
-  handle { let r = parse_one_param(lex(s), 0); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_one_param(lex(s), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 
 let p5_types: () -> Int = () -> {

--- a/scripts/coverage/cov_push85.vibe
+++ b/scripts/coverage/cov_push85.vibe
@@ -5,14 +5,14 @@
 //  - collect_import_path / scan_header_import_dep: dotted/aliased import headers.
 //  - namespace_private_value_stmts: an SImpl-bearing private body.
 let h_inf: (String) -> Int = (s) -> {
-  handle { let t = lex(s); if has_non_pipe_infix_top(t, 0, Array::length(t)) { 1 } else { 0 } } with Error { Throw(_) => 0 }
+  handle { let t = lex(s); if has_non_pipe_infix_top(t, 0, Array::length(t)) { 1 } else { 0 } } with Exception { Throw(_) => 0 }
 }
 let h_cip: (String) -> Int = (s) -> {
-  handle { let r = collect_import_path(lex(s), 0, "base"); String::length(r.0) } with Error { Throw(_) => 0 }
+  handle { let r = collect_import_path(lex(s), 0, "base"); String::length(r.0) } with Exception { Throw(_) => 0 }
 }
 let h_empty_map: () -> Map[String, Bool] = () -> { MapBuilder::freeze(MapBuilder::new()) }
 let h_shd: (String, Int) -> Int = (s, p) -> {
-  handle { let r = scan_header_import_dep(lex(s), p, "base", h_empty_map()); String::length(r.0) } with Error { Throw(_) => 0 }
+  handle { let r = scan_header_import_dep(lex(s), p, "base", h_empty_map()); String::length(r.0) } with Exception { Throw(_) => 0 }
 }
 
 let push_infix: () -> Int = () -> {

--- a/scripts/coverage/cov_remainder.vibe
+++ b/scripts/coverage/cov_remainder.vibe
@@ -5,14 +5,14 @@
 // exported_value_names, entry_declares_async_int.
 let r_lit: (Expr) -> Int = (e) -> { match literal_type(e) { Some(_) => 1, None => 0 } }
 let r_skip: (String) -> Int = (src) -> {
-  handle { skip_brace_list(lex(src), 0) } with Error { Throw(_) => 0 }
+  handle { skip_brace_list(lex(src), 0) } with Exception { Throw(_) => 0 }
 }
 let r_imp: (String) -> Int = (src) -> {
-  handle { let r = collect_import_path(lex(src), 1, "base"); String::length(r.0) } with Error { Throw(_) => 0 }
+  handle { let r = collect_import_path(lex(src), 1, "base"); String::length(r.0) } with Exception { Throw(_) => 0 }
 }
 let r_infix: (String, Int) -> Int = (src, st) -> {
   handle { let t = lex(src); if has_non_pipe_infix_top(t, st, Array::length(t)) { 1 } else { 0 } }
-  with Error { Throw(_) => 0 }
+  with Exception { Throw(_) => 0 }
 }
 
 export let cov_remainder_main: () -> Int = () -> {

--- a/scripts/coverage/cov_round.vibe
+++ b/scripts/coverage/cov_round.vibe
@@ -3,14 +3,14 @@
 // (plain / aliased), print_stmt remaining Stmt variants (SImpl/SModule/SReExport/
 // SAliasDecl/SLetPat/STest/SBench/SEffectDef), has_non_pipe_infix_top more ranges.
 let r_enum: (String, Bool) -> Int = (s, e) -> {
-  handle { let r = parse_enum_stmt(lex(s), 0, e); match r.0 { _ => 1 } } with Error { Throw(_) => 0 }
+  handle { let r = parse_enum_stmt(lex(s), 0, e); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
 let r_expname: (String) -> Int = (s) -> {
-  handle { let r = parse_export_name(lex(s), 0); String::length(r.0) } with Error { Throw(_) => 0 }
+  handle { let r = parse_export_name(lex(s), 0); String::length(r.0) } with Exception { Throw(_) => 0 }
 }
 let r_ps: (Stmt) -> Int = (st) -> { String::length(print_stmt(st)) }
 let r_inf: (String, Int, Int) -> Int = (s, a, b) -> {
-  handle { if has_non_pipe_infix_top(lex(s), a, b) { 1 } else { 0 } } with Error { Throw(_) => 0 }
+  handle { if has_non_pipe_infix_top(lex(s), a, b) { 1 } else { 0 } } with Exception { Throw(_) => 0 }
 }
 
 let r_enums: () -> Int = () -> {

--- a/scripts/coverage/cov_serialize.vibe
+++ b/scripts/coverage/cov_serialize.vibe
@@ -6,7 +6,7 @@
 // collect_private_type_renames over a private-decl Stmt body.
 let s_rt: (Type) -> Int = (ty) -> {
   let enc = serialize_type(ty)
-  handle { match parse_cached_type(enc, 0) { _ => String::length(enc) } } with Error { Throw(_) => String::length(enc) }
+  handle { match parse_cached_type(enc, 0) { _ => String::length(enc) } } with Exception { Throw(_) => String::length(enc) }
 }
 
 export let cov_serialize_main: () -> Int = () -> {
@@ -29,9 +29,9 @@ export let cov_serialize_main: () -> Int = () -> {
   let mut i = 0
   while i < Array::length(tys) { acc = acc + s_rt(Array::get(tys, i)); i = i + 1 }
   // parse_cached_type error arms: truncated / unknown tag / trailing junk
-  acc = acc + (handle { match parse_cached_type("", 0) { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { match parse_cached_type("Z", 0) { _ => 1 } } with Error { Throw(_) => 0 })
-  acc = acc + (handle { match parse_cached_type("A", 0) { _ => 1 } } with Error { Throw(_) => 0 })  // array, no elem
+  acc = acc + (handle { match parse_cached_type("", 0) { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { match parse_cached_type("Z", 0) { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle { match parse_cached_type("A", 0) { _ => 1 } } with Exception { Throw(_) => 0 })  // array, no elem
   // grouped-source accumulators: new bucket, then existing bucket
   let groups = Array::slice([("", Array::slice([("", "")], 0, 0))], 0, 0)
   push_grouped_source(groups, "g1", "a.vibe", "src_a")

--- a/scripts/coverage/cov_syntax.vibe
+++ b/scripts/coverage/cov_syntax.vibe
@@ -9,7 +9,7 @@ let cov_sx_parse: (String) -> Int = (src) -> {
   handle {
     let stmts = load_and_parse(src)
     Array::length(stmts)
-  } with Error {
+  } with Exception {
     Throw(_) => 0
   }
 }

--- a/scripts/coverage/cov_units.vibe
+++ b/scripts/coverage/cov_units.vibe
@@ -5,13 +5,13 @@
 // collect_import_deps_from_stmts, pat_binds_name. These never see edge inputs in a
 // normal compile of the examples/fixtures corpus.
 let cov_u_assignop: (String) -> Int = (op) -> {
-  handle { let buf = bytebuf_new(); emit_assignop_op(buf, op); Bytes::length(buf) } with Error { Throw(_) => 0 }
+  handle { let buf = bytebuf_new(); emit_assignop_op(buf, op); Bytes::length(buf) } with Exception { Throw(_) => 0 }
 }
 let cov_u_iter: (String) -> Int = (name) -> {
   match lookup_iter_intrinsic(name) { Some(_) => 1, None => 0 }
 }
 let cov_u_parse: (String) -> Array[Stmt] = (src) -> {
-  handle { load_and_parse(src) } with Error { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
+  handle { load_and_parse(src) } with Exception { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
 }
 
 export let cov_units_main: () -> Int = () -> {
@@ -45,10 +45,10 @@ export let cov_units_main: () -> Int = () -> {
   let stmts = cov_u_parse("let used: () -> Int = () -> { 5 }\nlet unused: () -> Int = () -> { 9 }\nlet helper: () -> Int = () -> { used() }\nexport let main: () -> Int = () -> { helper() }")
   let entries = Array::slice([""], 0, 0)
   Array::push(entries, "main")
-  acc = acc + handle { Array::length(dce_reachable_names(stmts, entries)) } with Error { Throw(_) => 0 }
+  acc = acc + handle { Array::length(dce_reachable_names(stmts, entries)) } with Exception { Throw(_) => 0 }
   // collect_import_deps_from_stmts: program with relative imports
   let istmts = cov_u_parse("import ./a.vibe { foo }\nimport ./sub/b.vibe { bar }\nexport let main: () -> Int = () -> { 0 }")
-  acc = acc + handle { Array::length(collect_import_deps_from_stmts(istmts, ".")) } with Error { Throw(_) => 0 }
+  acc = acc + handle { Array::length(collect_import_deps_from_stmts(istmts, ".")) } with Exception { Throw(_) => 0 }
   // pat_binds_name: parse a match, walk arm patterns checking name binding
   let pstmts = cov_u_parse("let f: (E) -> Int = (e) -> { match e { Som((a, b)) => a + b, None => 0 } }")
   acc = acc + Array::length(pstmts)

--- a/scripts/coverage/cov_units2.vibe
+++ b/scripts/coverage/cov_units2.vibe
@@ -5,24 +5,24 @@
 // parse_struct_fields_rest, has_non_pipe_infix_top. Requires _build/covproj/a.vibe
 // to exist (the harness recreates it before running).
 let cov_u2_spec: (String, String, String) -> Int = (path, stat, fp) -> {
-  handle { if matches_cached_file_spec(path, stat, fp) { 1 } else { 0 } } with Error { Throw(_) => 0 }
+  handle { if matches_cached_file_spec(path, stat, fp) { 1 } else { 0 } } with Exception { Throw(_) => 0 }
 }
 let cov_u2_parse: (String) -> Array[Stmt] = (src) -> {
-  handle { load_and_parse(src) } with Error { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
+  handle { load_and_parse(src) } with Exception { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
 }
 let cov_u2_infix: (String) -> Int = (src) -> {
   handle {
     let toks = lex(src)
     if has_non_pipe_infix_top(toks, 0, Array::length(toks)) { 1 } else { 0 }
-  } with Error { Throw(_) => 0 }
+  } with Exception { Throw(_) => 0 }
 }
 
-export let cov_units2_main: () -> Int with Error + Fs = () -> {
+export let cov_units2_main: () -> Int with Exception + Fs = () -> {
   let mut acc = 0
   let p = "_build/covproj/a.vibe"
   // real fingerprint + stat token for the existing file
-  let fp = handle { compact_string_fingerprint(Fs::read_file(p)) } with Error { Throw(_) => "" }
-  let stat = handle { __to_string(Fs::stat_token(p)) } with Error { Throw(_) => "" }
+  let fp = handle { compact_string_fingerprint(Fs::read_file(p)) } with Exception { Throw(_) => "" }
+  let stat = handle { __to_string(Fs::stat_token(p)) } with Exception { Throw(_) => "" }
   // 1. non-existent file -> false arm
   acc = acc + cov_u2_spec("_build/covproj/__no_such__.vibe", stat, fp)
   // 2. exists + matching stat token -> true arm
@@ -41,7 +41,7 @@ export let cov_units2_main: () -> Int with Error + Fs = () -> {
   acc = acc + cov_u2_spec(p, "", "")
   // collect_import_deps_from_stmts on real imports under covproj
   let istmts = cov_u2_parse("import ./b.vibe { b_val }\nimport ./c.vibe { c_val }\nexport let main: () -> Int = () -> { 0 }")
-  acc = acc + handle { Array::length(collect_import_deps_from_stmts(istmts, "_build/covproj")) } with Error { Throw(_) => 0 }
+  acc = acc + handle { Array::length(collect_import_deps_from_stmts(istmts, "_build/covproj")) } with Exception { Throw(_) => 0 }
   // parse_struct_fields_rest: varied struct declarations (multi-field, derive, nested types)
   acc = acc + Array::length(cov_u2_parse("struct A { x: Int }"))
   acc = acc + Array::length(cov_u2_parse("struct B { a: Int; b: String; c: Array[Int] } derive(Eq)"))

--- a/scripts/coverage/cov_walker2.vibe
+++ b/scripts/coverage/cov_walker2.vibe
@@ -9,7 +9,7 @@ let w_pe: (Expr) -> Int = (e) -> { String::length(print_expr(e)) }
 let w_proj: (Expr) -> Int = (e) -> { String::length(scope_tail_proj_root(e)) }
 let w_desugar: (Expr) -> Int = (e) -> { match desugar_loop_body(e, Array::slice([""], 0, 0)) { _ => 1 } }
 let w_reassign: (Expr) -> Int = (e) -> {
-  handle { if reassign_self_reusable(e, "x") { 1 } else { 0 } } with Error { Throw(_) => 0 }
+  handle { if reassign_self_reusable(e, "x") { 1 } else { 0 } } with Exception { Throw(_) => 0 }
 }
 let w_ps: (Stmt) -> Int = (s) -> { String::length(print_stmt(s)) }
 let w_struct: (Stmt) -> Int = (s) -> { if is_type_or_structural(s) { 1 } else { 0 } }

--- a/scripts/coverage_features.sh
+++ b/scripts/coverage_features.sh
@@ -117,12 +117,12 @@ let greet: (String) -> Int with Logger = (name) -> {
   String::length(name)
 }
 suberror MyErr(Int)
-let risky: (Int) -> Int with Error = (x) -> {
+let risky: (Int) -> Int with Exception = (x) -> {
   if x < 0 { throw(MyErr(x)) } else { x * 2 }
 }
 export let main: () -> Int = () -> {
   let n = handle { greet("world") } with Logger { Log(_, k) => k(()) }
-  let v = handle { risky(-1) } with Error { Throw(_) => 99 }
+  let v = handle { risky(-1) } with Exception { Throw(_) => 99 }
   n + v
 }
 EOF

--- a/scripts/coverage_gen_errcorpus.sh
+++ b/scripts/coverage_gen_errcorpus.sh
@@ -233,7 +233,7 @@ export let main: () -> Int = () -> { wide() + tall() }'
 #      labeled args, pipes, early return) the type-error corpus never reaches. ----
 emit f_suberror 'suberror PBad(String)
 let pfail: (Int) -> Int = (n) -> {
-  handle { if n < 0 { throw(PBad("neg")) } else { n } } with Error { Throw(_) => 0 } }
+  handle { if n < 0 { throw(PBad("neg")) } else { n } } with Exception { Throw(_) => 0 } }
 export let main: () -> Int = () -> { pfail(-1) + pfail(7) }'
 emit f_generic 'let id: [T](T) -> T = (x) -> { x }
 let pair: [A, B](A, B) -> (A, B) = (a, b) -> { (a, b) }

--- a/scripts/coverage_unittests.vibex
+++ b/scripts/coverage_unittests.vibex
@@ -358,11 +358,11 @@ fn extract_and_replace_tests(body_src: String, start_n: Int) -> (String, Array[S
       n = n + 1
       StringBuilder::push(
         out,
-        "let cov_ut_" + Int::to_string(n) + ": () -> Int with Error = () -> {\n" + tbody + "\n  0\n}\n"
+        "let cov_ut_" + Int::to_string(n) + ": () -> Int with Exception = () -> {\n" + tbody + "\n  0\n}\n"
       )
       ArrayBuilder::push(
         calls,
-        "  let _ = handle { cov_ut_" + Int::to_string(n) + "() } with Error { Throw(_) => 0 }"
+        "  let _ = handle { cov_ut_" + Int::to_string(n) + "() } with Exception { Throw(_) => 0 }"
       )
       last = close_end
       i = close_end
@@ -377,9 +377,9 @@ fn extract_and_replace_tests(body_src: String, start_n: Int) -> (String, Array[S
 fn compiler_dir() -> String { "lib/@vibe/compiler/" }
 
 fn assert_helpers() -> String {
-  "\nlet assert: (Bool) -> Int with Error = (b) -> { if b { 1 } else { throw(\"assert failed\") } }\n" +
-  "let assert_eq: [T: Eq](T, T) -> Int with Error = (a, b) -> { if eq(a, b) { 1 } else { throw(\"assert_eq failed\") } }\n" +
-  "let assert_neq: [T: Eq](T, T) -> Int with Error = (a, b) -> { if eq(a, b) { throw(\"assert_neq failed\") } else { 1 } }\n"
+  "\nlet assert: (Bool) -> Int with Exception = (b) -> { if b { 1 } else { throw(\"assert failed\") } }\n" +
+  "let assert_eq: [T: Eq](T, T) -> Int with Exception = (a, b) -> { if eq(a, b) { 1 } else { throw(\"assert_eq failed\") } }\n" +
+  "let assert_neq: [T: Eq](T, T) -> Int with Exception = (a, b) -> { if eq(a, b) { throw(\"assert_neq failed\") } else { 1 } }\n"
 }
 
 fn split_csv(s: String) -> Array[String] {

--- a/scripts/coverage_wasm_source.test.mjs
+++ b/scripts/coverage_wasm_source.test.mjs
@@ -56,7 +56,7 @@ test("isCoverageNoiseLine: handle bridge line is excluded", () => {
   const sourceLines = [
     "let ok = handle {",
     "  run()",
-    "} with Error {",
+    "} with Exception {",
     "  Throw(_) => false;",
     "}",
   ];

--- a/scripts/test_concurrent_awaits_component_gate.sh
+++ b/scripts/test_concurrent_awaits_component_gate.sh
@@ -113,7 +113,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_async_concurrent_awaits
 }
 
-fn main() -> Unit with Error + Fs {
+fn main() -> Unit with Exception + Fs {
   let bytes = comp_emit_component_wasm_async_concurrent_awaits("run", 121)
   Fs::write_bytes("_build/bench/selfhost_concurrent_awaits_component/generated.component.wasm", bytes)
 }

--- a/scripts/test_future_value_component_gate.sh
+++ b/scripts/test_future_value_component_gate.sh
@@ -74,7 +74,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_future_value
 }
 
-fn main() -> Unit with Error + Fs {
+fn main() -> Unit with Exception + Fs {
   let bytes = comp_emit_component_wasm_future_value("run", 121)
   Fs::write_bytes("_build/bench/selfhost_future_value_component/generated.component.wasm", bytes)
 }

--- a/scripts/test_gc_selfbuild.sh
+++ b/scripts/test_gc_selfbuild.sh
@@ -147,7 +147,7 @@ export let main = () -> Int {
 EOF
 
 write_probe effect_throw_handle <<'EOF'
-let risky: (Int) -> Int with Error = (x) -> {
+let risky: (Int) -> Int with Exception = (x) -> {
   if x == 0 {
     throw("zero")
   }
@@ -156,7 +156,7 @@ let risky: (Int) -> Int with Error = (x) -> {
 export let main = () -> Int {
   handle {
     risky(0)
-  } with Error {
+  } with Exception {
     Throw(_) => 42
   }
 }

--- a/scripts/test_host_future_value_component_gate.sh
+++ b/scripts/test_host_future_value_component_gate.sh
@@ -107,7 +107,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_host_future_value
 }
 
-fn main() -> Unit with Error + Fs {
+fn main() -> Unit with Exception + Fs {
   let bytes = comp_emit_component_wasm_host_future_value("run", 121)
   Fs::write_bytes("_build/bench/selfhost_host_future_value_component/generated.component.wasm", bytes)
 }

--- a/scripts/test_spawned_future_component_gate.sh
+++ b/scripts/test_spawned_future_component_gate.sh
@@ -124,7 +124,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_async_spawned_future
 }
 
-fn main() -> Unit with Error + Fs {
+fn main() -> Unit with Exception + Fs {
   let bytes = comp_emit_component_wasm_async_spawned_future("run", 121)
   Fs::write_bytes("_build/bench/selfhost_spawned_future_component/generated.component.wasm", bytes)
 }

--- a/scripts/test_stream_value_component_gate.sh
+++ b/scripts/test_stream_value_component_gate.sh
@@ -75,7 +75,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_stream_value
 }
 
-fn main() -> Unit with Error + Fs {
+fn main() -> Unit with Exception + Fs {
   let bytes = comp_emit_component_wasm_stream_value("run", 121)
   Fs::write_bytes("_build/bench/selfhost_stream_value_component/generated.component.wasm", bytes)
 }

--- a/scripts/vibe_fmt_smoke.sh
+++ b/scripts/vibe_fmt_smoke.sh
@@ -252,10 +252,10 @@ fi
 # into an unrelated far-later "unexpected token: with" parse error (the
 # merge-flatten compile step of scripts/generate_bundle.sh).
 cat > "$WORK/return_handle.in.vibe" <<'EOF'
-fn foo() -> Int with Error {
+fn foo() -> Int with Exception {
   return handle {
     1
-  } with Error {
+  } with Exception {
     Throw(msg) => 0
   }
 }

--- a/scripts/vibe_md.vibex
+++ b/scripts/vibe_md.vibex
@@ -232,7 +232,7 @@ fn array_empty[T]() -> Array[T] {
 // An unterminated fence uses the built-in `Error` effect (`throw`) rather
 // than a custom effect -- distinct from a block that compiled/ran and
 // failed verification, but no new effect vocabulary is needed for it.
-fn parse_blocks(text: String) -> Array[Token] with Error {
+fn parse_blocks(text: String) -> Array[Token] with Exception {
   let lines = splitlines_like(text)
   let n = Array::length(lines)
   let tokens = ArrayBuilder::new()
@@ -1015,7 +1015,7 @@ fn basename_no_ext(path: String) -> String {
   }
 }
 
-fn process_file(md_path: String, cwd: String, compiler: String, mode: String) -> FileOutcome with Fs + Process + Error + Env {
+fn process_file(md_path: String, cwd: String, compiler: String, mode: String) -> FileOutcome with Fs + Process + Exception + Env {
   let text = Fs::read_file(md_path)
   let tokens = parse_blocks(text)
   link_run_output_pairs(tokens)
@@ -1104,7 +1104,7 @@ fn process_file(md_path: String, cwd: String, compiler: String, mode: String) ->
 // fmt/fmt-check counterpart of process_file: no compiler wasm, no
 // execution, no ```output pairing -- just every vibe-source block
 // (check/run/skip) through run_fmt_block.
-fn process_file_fmt(md_path: String, mode: String) -> FileOutcome with Fs + Process + Error + Env {
+fn process_file_fmt(md_path: String, mode: String) -> FileOutcome with Fs + Process + Exception + Env {
   let text = Fs::read_file(md_path)
   let tokens = parse_blocks(text)
   let md_dir = dirname(md_path)
@@ -1267,7 +1267,7 @@ fn run_mode_fmt(mode: String, files: Array[String]) -> Int with Fs + Env + Proce
           ()
         }
         push_all(all_results, outcome.results)
-      } with Error {
+      } with Exception {
         Throw(msg) => {
           Stderr::write_stream("vibe_md: \{md_path}: \{msg}\n")
           hard_fail = 2
@@ -1313,7 +1313,7 @@ fn run_mode(mode: String, files: Array[String]) -> Int with Fs + Env + Process +
             ()
           }
           push_all(all_results, outcome.results)
-        } with Error {
+        } with Exception {
           Throw(msg) => {
             Stderr::write_stream("vibe_md: \{md_path}: \{msg}\n")
             hard_fail = 2

--- a/scripts/vibec_componentize.vibex
+++ b/scripts/vibec_componentize.vibex
@@ -60,7 +60,7 @@ fn main with Fs + Env + Stdout + Stderr + Process {
         Fs::write_bytes(out_path, component)
         Stdout::write_stream("vibec: \{core_path} \{Bytes::length(core)}B -> \{out_path} \{Bytes::length(component)}B\n")
         0
-      } with Error {
+      } with Exception {
         Throw(msg) => {
           Stderr::write_stream("vibec-componentize: \{msg}\n")
           1


### PR DESCRIPTION
ADR-0085 は core ambient exception effect の名前を `Exception` 一つに決めた。`Error` は元の名前で、移行中は accepted alias として乗り続けていた。Step 1 (#1472) が canonical を反転し、Step 2 がツリー全体を変換し、seed bump (#1492, `console-exception-rowvar-2026-08-06`) が「拒否した後もコンパイラが自分をビルドできる」状態を作った。これがその最終段。

## 拒否の位置

`parse_effect_item` — source の row ラベルが生成される唯一の場所。bare (`Error`)、qualified (`Error::Throw`)、applied (`Error[IoError]`) の3形はすべて HEAD を共有するので、そこ1箇所で足りる。

**これは surface だけの拒否**。`is_exception_effect_name` は内部では今も true を返し、taxonomy 表も行を保ち、`printer.vibe` は両綴りを re-sugar する（bump 前の seed は `Error` を印字するので、re-sugar は読めなければならない）。変わるのは `.vibe` ファイルが何を書けるかだけ。

診断は #1429 の braced-row 拒否と同じく named にした。「expected an effect name」を受け取った読み手には、名前が動いたことを知る術がない。

## formatter が fix-it

エラーメッセージが `vibe fmt` を名指しするので、実体が要る。`normalize_retired_effect_labels` を `normalize_effect_rows` の後段に足した（braced row から解放されたラベルも同じ format で拾える）。

row 位置は文法を追わず**構造的に**判定する — `with` / 文脈キーワード `allows` / `+` の直後（trivia は読み飛ばす）だけを改名する。実際の文法より狭いが、それが安全性の要。`Error` は今も生きた**型名**（throwable trait、`impl Error for ..`）で、その用法はどれもこの3位置に現れない。全 `Error` トークンを改名する実装なら全部壊していた。

## 変換した範囲

| | |
|---|---|
| `fixtures/` | 97 ファイル 248 ラベル。裸の `Error` 68件 (trait / 型名) は無傷 |
| `scripts/` | gate の inline fixture と coverage ツールが生成する source、計 142 ラベル。**コメント行は未変更**（歴史的記述として残す） |
| compiler source | 実 row 1件 (`desugar_trait_dict.vibe`) |

## alias が生きていることを検査していたテストの扱い

#1461 のコメントに「一括変換の対象にしないこと」として列挙してあったもの。個別に判断した:

- **`fixture_roundtrip_test` / `checker_exception_kind_test`** — source を parse するので `Exception` へ変換
- **`vpkg_format_test`** — formatter が改名するようになったので期待値を更新
- **`parser_test` の `allows` ケース** — ADR-0088 の「core ambient を誤った節に書いた」検査。私の拒否が先に出て検査が素通りになるので、**同じ core ambient の生きた綴り** `Exception` へ向け直して意図を保った
- **`parser_test` の braced / 括弧付き row** — `#1429` の拒否が先に出るので影響なし。そのまま
- **`checker_effects_test` の hint** — row をリテラル配列で渡すので parse を経ない。renderer が綴りに依存しないことの記録として残す
- **`compiler_gate.sh` の #639 fixture** — Step 1 の「alias は parse され続けるが印字されない」非対称性を pin していた。その前提が消えたので fixture を `Exception` にし、コメントを書き換えた。assertion 本文は不変（`declared { Exception }` — canonical はどちらでも印字される側）

## 検証

```
with Error                            -> REJECTED  `Error` was retired as an
                                                   effect spelling in #1461
with Exception                        -> ACCEPTED
trait Error / impl Error for IoError  -> ACCEPTED  (型名は無傷)
vibe fmt: with Error                  -> with Exception

BUILD RC=0   stage1 == stage2（拒否を入れたコンパイラが自分をビルドできる）
FMT   RC=0   906 files, 0 violations
GATE  RC=0
UNIT  RC=0   529/529
```

これで #1461 は完了。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_