### PR TITLE
refactor: split standard effect policy owners

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -597,12 +597,14 @@ everything else.
 
 ### Standard provider and entry-execution policy (#1496)
 
-The compiler keeps a small policy table at
-`lib/@vibe/compiler/core/standard_effect_policy.vibe`. It records only the
-standard host providers and entry/runtime handling that the current runner
-needs; it does **not** assign a source-language effect class. An ordinary user
-effect such as `Log`, `State`, or `Ask` has no standard policy record and is
-handled solely by its declarations and `handle` expressions.
+The compiler keeps independent private policy owners at
+`lib/@vibe/compiler/core/standard_effect_policy.vibe`: host-provider resource
+defaults, ordered test/bench defaults, ordered entry-cache-safe labels, and
+predicates for entry-boundary exceptions and runtime-scheduled `Async`. They
+record only the standard execution behavior the current runner needs; they do
+**not** assign a source-language effect class. An ordinary user effect such as
+`Log`, `State`, or `Ask` has no standard policy record and is handled solely by
+its declarations and `handle` expressions.
 
 | policy | execution owner | current standard labels |
 |---|---|---|
@@ -610,8 +612,8 @@ handled solely by its declarations and `handle` expressions.
 | entry-boundary exception policy | entry boundary diagnoses an escaping exception | `Exception[E]` (`Error` is a migration alias) |
 | runtime scheduling policy | runtime itself | `Async` |
 
-The same table supplies test/bench defaults and entry-cache safety in their
-existing order. Checker row filtering and WIT import filtering use only the
+The ordered default and cache-safe owners preserve their existing output.
+Checker row filtering and WIT import filtering use only the predicate-based
 entry/runtime policy; WIT mapping and handler behavior are unchanged.
 
 **Naming.** Effect names are CamelCase. A standard provider builtin is a plain

--- a/docs/effect-taxonomy-review.md
+++ b/docs/effect-taxonomy-review.md
@@ -483,13 +483,13 @@ DCE)→ apply(BindingLock)→ instantiate(preflight prompt)の最も早い
 ための段階計画。
 
 - **Phase -1(着地済み、#1496)**: standard provider / entry-execution
-  policy metadata. `lib/@vibe/compiler/core/standard_effect_policy.vibe` holds
-  `(label, provider default resource kind, test/bench default, entry cache
-  safe)` rows. Its narrow predicates describe standard host providers,
-  entry-boundary exceptions, and runtime scheduling; ordinary user effects
-  have no policy record. The existing test/bench defaults, doctest cache-safe
-  row, and entry/runtime filtering remain byte-for-byte behaviorally unchanged.
-  This implementation policy is not the prospective taxonomy/admission model.
+  policy metadata. `lib/@vibe/compiler/core/standard_effect_policy.vibe` owns
+  provider resource defaults, test/bench defaults, and entry-cache-safe labels
+  independently; `Exception` entry-boundary and `Async` runtime handling are
+  narrow predicates. Ordinary user effects have no policy record. The existing
+  test/bench defaults, doctest cache-safe row, and entry/runtime filtering
+  remain byte-for-byte behaviorally unchanged. This implementation policy is
+  not the prospective taxonomy/admission model.
 - **Phase 0(着地済み、#1343 実装順 2)**: ADR-0075 Phase 2 の
   `resource Name : Owner::Kind` 宣言を AST (`SResource`) / parser /
   printer / checker に入れ、`Process::Root` を singleton resource kind

--- a/docs/resource-kind-parameters.md
+++ b/docs/resource-kind-parameters.md
@@ -217,11 +217,12 @@ Phase 0 の前提である ADR-0075 Phase 2 (`resource` 宣言) が当初**未�
    **provider ラベルではなく `Http::*` operation 上の effectset** へ寄せる
    (provider 軸は `Http` に統一)。
 1. **(着地済み、#1496)** standard provider / entry-execution policy。
-   `lib/@vibe/compiler/core/standard_effect_policy.vibe` has
-   `(label, provider default resource kind, test/bench default, entry cache
-   safe)` rows and narrow behavior predicates. It retains the existing
-   test/bench default order, entry-cache-safe order, and entry/runtime
-   filtering without assigning ordinary effects a string class.
+   `lib/@vibe/compiler/core/standard_effect_policy.vibe` has independent
+   private owners for `(label, provider default resource kind)`, ordered
+   test/bench defaults, and ordered entry-cache-safe labels, plus narrow
+   predicates for `Exception` and `Async` entry/runtime behavior. They retain
+   the existing output/order and entry/runtime filtering without assigning
+   ordinary effects a string class.
 
    Registry rows are **operation** keyed, so provider policy remains in this
    label-keyed table rather than being copied to every operation. The

--- a/lib/@vibe/compiler/core/standard_effect_policy.vibe
+++ b/lib/@vibe/compiler/core/standard_effect_policy.vibe
@@ -1,13 +1,13 @@
-//# Standard effect policy — standard host-provider and entry-execution metadata (#1496)
+//# Standard effect policy — independent standard execution owners (#1496)
 //
-// This table records execution policy for the standard labels the compiler
-// recognizes. It does not classify source-language effects: ordinary user
-// effects simply have no standard policy record.
+// The compiler recognizes a small set of standard host providers plus
+// entry-boundary exception and runtime scheduling behavior. These owners do
+// not classify source-language effects: ordinary user effects simply have no
+// standard policy metadata.
 //
-// The checker and WIT generator share the entry/runtime-managed predicate,
-// while test/bench defaults and entry-cache safety are derived in table order.
-// WIT declaration-versus-provider behavior, resource lowering, and handler
-// semantics intentionally remain unchanged in this behavior-preserving slice.
+// Each private owner below records one concern only. WIT declaration-versus-
+// provider behavior, resource lowering, and handler semantics intentionally
+// remain unchanged in this behavior-preserving slice.
 
 import ./exception_effect.vibe {
   is_exception_label
@@ -17,36 +17,45 @@ import @vibe/core {
   array_empty
 }
 
-//# Standard policy table
+//# Independent standard execution owners
 
-/// `(label, provider default resource kind, test/bench default, entry cache
-/// safe)`. The order preserves all existing derived-row output.
-///
-/// A nonempty resource kind records that the standard host provider uses the
-/// process-root default. `Error`, `Exception`, and `Async` instead record
-/// entry-boundary or runtime execution policy and therefore have no provider
-/// resource kind.
-let standard_effect_policy_rows: Array[(String, String, Bool, Bool)] = [
-  // Standard host-provider labels. Test and bench run with the first eight
-  // providers below; network and external-service providers remain explicit.
-  ("Fs", "Process::Root", true, false),
-  ("Env", "Process::Root", true, false),
-  ("Stdin", "Process::Root", true, false),
-  // Stdout and Console are entry output, not hidden nondeterministic input.
-  ("Stdout", "Process::Root", true, true),
-  ("Stderr", "Process::Root", true, false),
-  ("Console", "Process::Root", true, true),
-  ("Process", "Process::Root", true, false),
-  ("Profiler", "Process::Root", true, false),
-  ("Http", "Process::Root", false, false),
-  ("Socket", "Process::Root", false, false),
-  ("Llm", "Process::Root", false, false),
-  // Entry-boundary exception policy. Exception[K] is recognized dynamically
-  // below, while this erased row preserves existing derived-row spelling.
-  ("Error", "", true, true),
-  ("Exception", "", true, true),
-  // Runtime scheduling policy. Async is not a host-provider label.
-  ("Async", "", false, true)
+/// `(label, default resource kind)` for standard host providers, in the
+/// established provider order. Every current provider uses the process root.
+let standard_host_provider_resource_defaults: Array[(String, String)] = [
+  ("Fs", "Process::Root"),
+  ("Env", "Process::Root"),
+  ("Stdin", "Process::Root"),
+  ("Stdout", "Process::Root"),
+  ("Stderr", "Process::Root"),
+  ("Console", "Process::Root"),
+  ("Process", "Process::Root"),
+  ("Profiler", "Process::Root"),
+  ("Http", "Process::Root"),
+  ("Socket", "Process::Root"),
+  ("Llm", "Process::Root")
+]
+
+/// Effects supplied by test and bench execution, in established order.
+let test_bench_default_effect_labels: Array[String] = [
+  "Fs",
+  "Env",
+  "Stdin",
+  "Stdout",
+  "Stderr",
+  "Console",
+  "Process",
+  "Profiler",
+  "Error",
+  "Exception"
+]
+
+/// Effects allowed in the entry execution cache, in established order.
+let entry_cache_safe_effect_labels: Array[String] = [
+  "Stdout",
+  "Console",
+  "Error",
+  "Exception",
+  "Async"
 ]
 
 //# Lookups
@@ -68,14 +77,14 @@ fn standard_policy_effect_name(label: String) -> String {
   }
 }
 
-fn standard_effect_policy_row_index(name: String) -> Int {
+fn standard_host_provider_index(name: String) -> Int {
   let mut i = 0
   let mut found = 0 - 1
-  while i < Array::length(standard_effect_policy_rows) {
-    let (rname, _, _, _) = Array::get(standard_effect_policy_rows, i)
-    if rname == name {
+  while i < Array::length(standard_host_provider_resource_defaults) {
+    let (provider_name, _) = Array::get(standard_host_provider_resource_defaults, i)
+    if provider_name == name {
       found = i
-      i = Array::length(standard_effect_policy_rows)
+      i = Array::length(standard_host_provider_resource_defaults)
     } else {
       i = i + 1
     }
@@ -86,31 +95,26 @@ fn standard_effect_policy_row_index(name: String) -> Int {
 /// True when a label has standard provider or entry-execution metadata.
 /// `Exception[K]` is covered by the standard entry-boundary exception policy.
 export fn has_standard_effect_policy(label: String) -> Bool {
-  if is_exception_label(label) {
-    true
-  } else {
-    standard_effect_policy_row_index(standard_policy_effect_name(label)) >= 0
-  }
+  has_standard_host_provider(label)
+  || is_entry_runtime_managed_effect(label)
+  // Retains the old arbitrary-string normalization of erased aliases,
+  // including malformed generic stems such as `Exception[`.
+  || standard_policy_effect_name(label) == "Error"
+  || standard_policy_effect_name(label) == "Exception"
 }
 
 /// True only for labels supplied by a standard host provider.
 export fn has_standard_host_provider(label: String) -> Bool {
-  let idx = standard_effect_policy_row_index(standard_policy_effect_name(label))
-  if idx < 0 {
-    false
-  } else {
-    let (_, resource_kind, _, _) = Array::get(standard_effect_policy_rows, idx)
-    resource_kind != ""
-  }
+  standard_host_provider_index(standard_policy_effect_name(label)) >= 0
 }
 
 /// The standard host provider's default resource kind, or `""` when none.
 export fn standard_provider_default_resource_kind(label: String) -> String {
-  let idx = standard_effect_policy_row_index(standard_policy_effect_name(label))
+  let idx = standard_host_provider_index(standard_policy_effect_name(label))
   if idx < 0 {
     ""
   } else {
-    let (_, resource_kind, _, _) = Array::get(standard_effect_policy_rows, idx)
+    let (_, resource_kind) = Array::get(standard_host_provider_resource_defaults, idx)
     resource_kind
   }
 }
@@ -152,48 +156,41 @@ export fn predeclared_resources() -> Array[(String, String)] {
   out
 }
 
-/// All labels with standard policy metadata, in table order.
+/// All labels with standard policy metadata, in the established order.
 export fn standard_effect_policy_names() -> Array[String] {
   let out = array_empty()
   let mut i = 0
-  while i < Array::length(standard_effect_policy_rows) {
-    let (name, _, _, _) = Array::get(standard_effect_policy_rows, i)
+  while i < Array::length(standard_host_provider_resource_defaults) {
+    let (name, _) = Array::get(standard_host_provider_resource_defaults, i)
     Array::push(out, name)
     i = i + 1
   }
+  // Exception and Async policy is predicate-based; these erased spellings
+  // retain this exported API's established output.
+  Array::push(out, "Error")
+  Array::push(out, "Exception")
+  Array::push(out, "Async")
   out
 }
 
 //# Derived entry policy
 
-/// Effects test and bench execution supplies by default, in existing order.
-export fn test_bench_default_effects() -> Array[String] {
+fn copied_labels(labels: Array[String]) -> Array[String] {
   let out = array_empty()
   let mut i = 0
-  while i < Array::length(standard_effect_policy_rows) {
-    let (name, _, default_for_test_bench, _) = Array::get(standard_effect_policy_rows, i)
-    if default_for_test_bench {
-      Array::push(out, name)
-    } else {
-      ()
-    }
+  while i < Array::length(labels) {
+    Array::push(out, Array::get(labels, i))
     i = i + 1
   }
   out
 }
 
+/// Effects test and bench execution supplies by default, in existing order.
+export fn test_bench_default_effects() -> Array[String] {
+  copied_labels(test_bench_default_effect_labels)
+}
+
 /// Effects allowed in the entry execution cache, in existing order.
 export fn entry_cache_safe_effects() -> Array[String] {
-  let out = array_empty()
-  let mut i = 0
-  while i < Array::length(standard_effect_policy_rows) {
-    let (name, _, _, cache_safe) = Array::get(standard_effect_policy_rows, i)
-    if cache_safe {
-      Array::push(out, name)
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  out
+  copied_labels(entry_cache_safe_effect_labels)
 }

--- a/lib/@vibe/compiler/tests/standard_effect_policy_test.vibe
+++ b/lib/@vibe/compiler/tests/standard_effect_policy_test.vibe
@@ -1,7 +1,7 @@
 //# Standard host-provider and entry-execution policy regression coverage (#1496)
 //
-// The policy table preserves current decisions and derived-row order without
-// assigning ordinary source effects an inherent string class.
+// Independent policy owners preserve current decisions and derived-row order
+// without assigning ordinary source effects an inherent string class.
 import @vibe/compiler/core {
   entry_cache_safe_effects,
   has_standard_effect_policy,
@@ -77,8 +77,17 @@ test "operations and instantiations resolve through standard policy" {
   assert(has_standard_host_provider("Fs::read_file"))
   assert(has_standard_host_provider("Http::request"))
   assert(is_entry_boundary_exception("Exception[IoError]::Throw"))
+  assert(has_standard_effect_policy("Error[Int]"))
+  // Preserve the arbitrary-string compatibility view even though malformed
+  // labels are not valid entry-boundary exceptions.
+  assert(has_standard_effect_policy("Exception["))
+  assert(not(is_entry_boundary_exception("Exception[")))
   assert(not(has_standard_effect_policy("State[Int]")))
   assert(not(has_standard_effect_policy("Ask::Get")))
+}
+
+test "standard policy names preserve full established order" {
+  assert_eq(join_row(standard_effect_policy_names()), "Fs,Env,Stdin,Stdout,Stderr,Console,Process,Profiler,Http,Socket,Llm,Error,Exception,Async")
 }
 
 test "test and bench default row order is unchanged" {
@@ -111,19 +120,22 @@ test "only standard output providers are entry cache-safe" {
   }
 }
 
-test "standard provider resource defaults are unchanged" {
-  let names = standard_effect_policy_names()
-  let mut i = 0
-  while i < Array::length(names) {
-    let name = Array::get(names, i)
-    if has_standard_host_provider(name) {
-      assert_eq(standard_provider_default_resource_kind(name), "Process::Root")
-    } else {
-      assert_eq(standard_provider_default_resource_kind(name), "")
-    }
-    i = i + 1
-  }
+test "standard provider resource defaults preserve every provider" {
+  assert_eq(standard_provider_default_resource_kind("Fs"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Env"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Stdin"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Stdout"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Stderr"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Console"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Process"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Profiler"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Http"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Socket"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Llm"), "Process::Root")
   assert_eq(standard_provider_default_resource_kind("Fs::read_file"), "Process::Root")
+  assert_eq(standard_provider_default_resource_kind("Error"), "")
+  assert_eq(standard_provider_default_resource_kind("Exception"), "")
+  assert_eq(standard_provider_default_resource_kind("Async"), "")
   assert_eq(standard_provider_default_resource_kind("Ask"), "")
 }
 
@@ -153,10 +165,21 @@ test "Process::Root remains the singleton provider default" {
   assert(not(is_singleton_resource_kind("S3::Bucket")))
 }
 
-test "the predeclared resource remains Process::Root of its own kind" {
+test "returned policy arrays are fresh and mutation-isolated" {
+  let names = standard_effect_policy_names()
+  Array::set(names, 0, "changed")
+  assert_eq(join_row(standard_effect_policy_names()), "Fs,Env,Stdin,Stdout,Stderr,Console,Process,Profiler,Http,Socket,Llm,Error,Exception,Async")
+  let defaults = test_bench_default_effects()
+  Array::set(defaults, 0, "changed")
+  assert_eq(join_row(test_bench_default_effects()), "Fs,Env,Stdin,Stdout,Stderr,Console,Process,Profiler,Error,Exception")
+  let cache_safe = entry_cache_safe_effects()
+  Array::set(cache_safe, 0, "changed")
+  assert_eq(join_row(entry_cache_safe_effects()), "Stdout,Console,Error,Exception,Async")
   let pre = predeclared_resources()
-  assert_eq(Array::length(pre), 1)
-  let (rname, rkind) = Array::get(pre, 0)
+  Array::set(pre, 0, ("changed", "changed"))
+  let fresh_pre = predeclared_resources()
+  assert_eq(Array::length(fresh_pre), 1)
+  let (rname, rkind) = Array::get(fresh_pre, 0)
   assert_eq(rname, process_root_resource_kind())
   assert_eq(rkind, process_root_resource_kind())
 }


### PR DESCRIPTION
## Summary
- split the mixed standard-effect-policy tuple into independent owners
- keep host-provider defaults, test/bench defaults, entry-cache policy, exception handling, and Async scheduling separate
- preserve all exported APIs, exact ordering, lookup outcomes, and fresh-array behavior
- document that this does not alter WIT mapping, handlers, or direct builtin/`perform` semantics

## Validation
- `VIBE_TEST_JOBS=1 bash scripts/vibe_test.sh lib/@vibe/compiler/tests/standard_effect_policy_test.vibe` — 15 tests passed
- changed Vibe formatter checks — passed
- `bash scripts/ensure_generated.sh && bash scripts/ensure_generated.sh --check` — passed
- `pkf run test-local` — passed (worker run)
- `git diff --check main...HEAD` — passed

## Review
Independent review found one P1 compatibility regression for malformed arbitrary-string input `Exception[`. Restored the old normalized compatibility result and added a regression assertion distinguishing it from a valid entry-boundary exception.

Refs #1496
