### PR TITLE
docs/spec を doctest に載せ、bench の ADR-0069 違反を修正する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
           DOCTEST_REQUIRE_STAGE2=1 DOCTEST_STAGE2="${gen}stage2.wasm" \
-            bash scripts/doctest_extract_run.sh README.md docs/cheatsheet.md docs/vibe.md docs/language-tour/*.md
+            bash scripts/doctest_extract_run.sh README.md docs/cheatsheet.md docs/vibe.md docs/language-tour/*.md docs/spec/*.md
       - name: examples/ type-check ratchet
         # examples/ is the user-facing sample surface and had NOTHING checking
         # it, so it accumulated two independent classes of rot in silence: the

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -845,7 +845,7 @@ local doctest = new Task {
   name = "doctest"
   description = "compile-check ```vibe blocks in docs via the selfhost stage2 doctest harness"
   cmd =
-    "bash scripts/doctest_extract_run.sh README.md docs/cheatsheet.md docs/vibe.md docs/language-tour/*.md"
+    "bash scripts/doctest_extract_run.sh README.md docs/cheatsheet.md docs/vibe.md docs/language-tour/*.md docs/spec/*.md"
   // README.md is in the list because it was NOT, and its headline sample rotted
   // unnoticed: #1324 removed `Result` from the language and the sample kept
   // using bare `Ok`/`Err`, so the repo's most-read example failed to compile
@@ -873,7 +873,7 @@ local doctestGated = new Task {
   description =
     "doctest against a stage2 built for THIS checkout (release-check / CI form; refuses the seed)"
   cmd =
-    "DOCTEST_REQUIRE_STAGE2=1 bash scripts/doctest_extract_run.sh README.md docs/cheatsheet.md docs/vibe.md docs/language-tour/*.md"
+    "DOCTEST_REQUIRE_STAGE2=1 bash scripts/doctest_extract_run.sh README.md docs/cheatsheet.md docs/vibe.md docs/language-tour/*.md docs/spec/*.md"
   // Plain `doctest` resolves whatever stage2 happens to be lying in _build and
   // falls back to the committed seed. As a release-check dep that is unsound
   // twice over: pkfire runs sibling deps concurrently, so it could read a

--- a/bench/bench_base64_encode.vibe
+++ b/bench/bench_base64_encode.vibe
@@ -78,4 +78,6 @@ let rec bench_loop: (String, String, Int, Int) -> Int = (table, payload, n, acc)
 }
 
 let payload = repeat("abcdefghijklmnopqrstuvwxyz0123456789", 8)
-bench_loop(table, payload, 10, 0)
+let main = () -> Int {
+  bench_loop(table, payload, 10, 0)
+}

--- a/bench/bench_builder.vibe
+++ b/bench/bench_builder.vibe
@@ -14,4 +14,6 @@ let result = {
   let out = build(200, b)
   ArrayBuilder::freeze(out)
 }
-result
+let main = () -> Array[Int] {
+  result
+}

--- a/bench/bench_simple.vibe
+++ b/bench/bench_simple.vibe
@@ -1,4 +1,6 @@
 let a = add(1, 2)
 let b = add(a, 3)
 let c = sub(b, 1)
-c
+let main = () -> Int {
+  c
+}

--- a/bench/bench_string.vibe
+++ b/bench/bench_string.vibe
@@ -21,4 +21,6 @@ let t = String::substring(s, 5, sub(String::length(s), 5))
 let u = String::concat(t, s)
 let sum = sum_codes(u, 0, 0)
 let ok = String::equals(u, u)
-if ok { sum } else { 0 }
+let main = () -> Int {
+  if ok { sum } else { 0 }
+}

--- a/bench/bench_string_concat.vibe
+++ b/bench/bench_string_concat.vibe
@@ -16,4 +16,6 @@ let rec concat_loop: (String, Int) -> String = (s, i) -> {
 
 let base = repeat("abcdef", 40)
 let out = concat_loop(base, 200)
-String::length(out)
+let main = () -> Int {
+  String::length(out)
+}

--- a/bench/bench_string_equals.vibe
+++ b/bench/bench_string_equals.vibe
@@ -21,4 +21,6 @@ let same = String::concat(base, "z")
 let diff = String::concat(base, "y")
 let a = eq_loop(same, same, 200, 0)
 let b = eq_loop(same, diff, 200, 0)
-add(a, b)
+let main = () -> Int {
+  add(a, b)
+}

--- a/bench/bench_string_substring.vibe
+++ b/bench/bench_string_substring.vibe
@@ -19,4 +19,6 @@ let rec slice_loop: (String, Int, Int) -> Int = (s, i, acc) -> {
 }
 
 let base = repeat("abcdefghijklmnopqrstuvwxyz", 20)
-slice_loop(base, 200, 0)
+let main = () -> Int {
+  slice_loop(base, 200, 0)
+}

--- a/bench/bundle_size/consumer_double_core.vibe
+++ b/bench/bundle_size/consumer_double_core.vibe
@@ -4,4 +4,6 @@ let a = abs(-3.5)
 let b = max(2.0, 7.0)
 let c = lerp(0.0, 10.0, 0.25)
 
-if a == 3.5 && b == 7.0 && c == 2.5 { "ok" } else { "ng" }
+let main = () -> String {
+  if a == 3.5 && b == 7.0 && c == 2.5 { "ok" } else { "ng" }
+}

--- a/bench/bundle_size/consumer_double_rounding.vibe
+++ b/bench/bundle_size/consumer_double_rounding.vibe
@@ -6,4 +6,6 @@ let c = round(2.6)
 let d = trunc(-1.9)
 let e = fract(3.25)
 
-if a == 3.0 && b == -3.0 && c == 3.0 && d == -1.0 && e > 0.24 && e < 0.26 { "ok" } else { "ng" }
+let main = () -> String {
+  if a == 3.0 && b == -3.0 && c == 3.0 && d == -1.0 && e > 0.24 && e < 0.26 { "ok" } else { "ng" }
+}

--- a/bench/bundle_size/consumer_option_core.vibe
+++ b/bench/bundle_size/consumer_option_core.vibe
@@ -4,4 +4,6 @@ let a = is_some(Some(1))
 let b = unwrap_or(None, 7)
 let c = map_or(Some(5), 0, (x) -> x * 2)
 
-if a && eq(b, 7) && eq(c, 10) { "ok" } else { "ng" }
+let main = () -> String {
+  if a && eq(b, 7) && eq(c, 10) { "ok" } else { "ng" }
+}

--- a/bench/bundle_size/consumer_option_extra.vibe
+++ b/bench/bundle_size/consumer_option_extra.vibe
@@ -1,4 +1,6 @@
 import ./prelude/option.vibe { unwrap_or, zip_sum }
 
 let out = zip_sum(Some(2), Some(5))
-unwrap_or(out, 0)
+let main = () -> Int {
+  unwrap_or(out, 0)
+}

--- a/bench/bundle_size/prelude/double.vibe
+++ b/bench/bundle_size/prelude/double.vibe
@@ -1,6 +1,6 @@
 //# Functions
 
-let Double::abs: (Double) -> Double = (x) -> {
+export let Double::abs: (Double) -> Double = (x) -> {
   if x < 0.0 {
     0.0 - x
   } else x
@@ -8,7 +8,7 @@ let Double::abs: (Double) -> Double = (x) -> {
 
 export let abs: (Double) -> Double = Double::abs
 
-let Double::max: (Double, Double) -> Double = (a, b) -> {
+export let Double::max: (Double, Double) -> Double = (a, b) -> {
   if a > b {
     a
   } else b
@@ -16,7 +16,7 @@ let Double::max: (Double, Double) -> Double = (a, b) -> {
 
 export let max: (Double, Double) -> Double = Double::max
 
-let Double::min: (Double, Double) -> Double = (a, b) -> {
+export let Double::min: (Double, Double) -> Double = (a, b) -> {
   if a < b {
     a
   } else b
@@ -96,7 +96,7 @@ let double_to_int_saturating: (Double) -> Int = (x) -> {
   else Double::to_int(x)
 }
 
-let Double::ceil: (Double) -> Double = (x) -> {
+export let Double::ceil: (Double) -> Double = (x) -> {
   if x >= double_int_max_value {
     double_int_max_value
   } else {
@@ -110,7 +110,7 @@ let Double::ceil: (Double) -> Double = (x) -> {
 
 export let ceil: (Double) -> Double = Double::ceil
 
-let Double::floor: (Double) -> Double = (x) -> {
+export let Double::floor: (Double) -> Double = (x) -> {
   if x <= double_int_min_value {
     double_int_min_value
   } else {
@@ -144,22 +144,6 @@ let double_fract: (Double) -> Double = (x) -> {
 
 export let fract: (Double) -> Double = double_fract
 
-export let Double::abs: (Double) -> Double = (x) -> {
-  Double::abs(x)
-}
-
-export let Double::max: (Double, Double) -> Double = (a, b) -> {
-  Double::max(a, b)
-}
-
-export let Double::min: (Double, Double) -> Double = (a, b) -> {
-  Double::min(a, b)
-}
-
-export let Double::ceil: (Double) -> Double = (x) -> {
-  Double::ceil(x)
-}
-
 export let Double::cube: (Double) -> Double = (x) -> {
   double_cube(x)
 }
@@ -170,10 +154,6 @@ export let Double::lerp: (Double, Double, Double) -> Double = (a, b, t) -> {
 
 export let Double::clamp: (Double, Double, Double) -> Double = (x, min_val, max_val) -> {
   double_clamp(x, min_val, max_val)
-}
-
-export let Double::floor: (Double) -> Double = (x) -> {
-  Double::floor(x)
 }
 
 export let Double::fract: (Double) -> Double = (x) -> {

--- a/docs/spec/builtin-ssot-design.md
+++ b/docs/spec/builtin-ssot-design.md
@@ -38,7 +38,8 @@ declarations.vibe  (SSoT, 人間が編集)
 
 ### declarations.vibe 構文
 
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented
 // lib/@vibe/compiler/builtins/declarations.vibe
 
 //# Array
@@ -112,7 +113,8 @@ TypeTag (1 byte):
 
 ### デコーダー (vibe 実装, ~50行)
 
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented
 let decode_builtin_table = (bytes: Bytes) -> Array[BuiltinDecl] {
   let pos = [4]  // skip magic
   let version = Bytes::get(bytes, Array::get(pos, 0))
@@ -187,7 +189,8 @@ warning: builtin 'Set::from_array' declared but no codegen handler registered
 
 #### 実装
 
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented
 // checker 起動時
 let declared = decode_builtin_table(builtin_table_bytes)
 let registered = codegen_handler_names()  // codegen が提供する name set

--- a/docs/spec/show-trait-design.md
+++ b/docs/spec/show-trait-design.md
@@ -9,7 +9,8 @@ REPL/shell で値を表示するために各型に `to_string` を実装する�
 
 ### 1. to_string は通常の関数
 
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented
 // prelude/show.vibe
 let Int::to_string = (n: Int) -> String { ... }
 let Array::to_string = (arr: Array[T]) -> String { ... }
@@ -28,7 +29,8 @@ let Option::to_string = (opt: Option[T]) -> String { ... }
 
 ### 3. show_value ヘルパー
 
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented
 // コンパイラが自動生成する show_value 関数
 // REPL モードでのみバンドルに含まれる
 let show_value = (tagged: Int) -> String {

--- a/docs/spec/structured-shell-design.md
+++ b/docs/spec/structured-shell-design.md
@@ -84,7 +84,8 @@ cat data.csv |> from_csv |> where age > 30
 ```
 
 posix preprocessor が `ls . |> where is_dir` を以下に変換:
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented (preprocessor output sketch)
 Fs::readdir(".") |> where_entry(e -> e.is_dir)
 ```
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -84,7 +84,8 @@ literals only where the parser is expecting that literal head.
 
 ### Literals
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 42
 0xFF
 1.5f
@@ -178,7 +179,8 @@ Compatibility:
 
 ### Functions And Lambdas
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 (x) -> { x + 1 }
 (x, y) -> { x + y }
 x -> x * 2
@@ -188,7 +190,8 @@ _ + _
 
 Function types:
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 () -> Int
 (Int, String) -> Bool
 (Int) -> Int with Exception
@@ -324,7 +327,8 @@ programs.
 
 ## Imports And Exports
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program (the `./lib.vibe` it imports is illustrative)
 import ./lib.vibe { foo, bar as baz }
 import ./lib.vibe { type Pair, trait Show, foo }
 import ./lib.vibe { Int }
@@ -355,7 +359,8 @@ workflow — is not syntax and is specified once, in
 
 ### Blocks
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 {
   let x = 1
   let y = 2
@@ -365,7 +370,8 @@ workflow — is not syntax and is specified once, in
 
 ### Control Flow
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 if cond { a } else { b }
 
 match value {
@@ -418,7 +424,8 @@ Rules:
 
 ### Calls, Fields, Indexing
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 f(x)
 f(x=1, y=2)
 Array::map(xs, _ * 2)
@@ -439,7 +446,8 @@ a field must be invoked as `(obj.callback)(args)`.
 
 ### Collections
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 [1, 2, 3]
 (1, "two", true)
 record { x: 1, y: 2 }
@@ -454,7 +462,8 @@ literal reports a located parse error naming the replacement.
 
 ### Effects And Error Boundaries
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 throw("message")
 risky()?
 
@@ -492,7 +501,8 @@ Precedence is high to low.
 
 Assignments are statements, not expressions:
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 x = value
 x += 1
 x -= 1
@@ -503,7 +513,8 @@ x %= 2
 
 ## Pipe
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 x |> f
 x |> f(a, b)
 x |> f |> g
@@ -514,7 +525,8 @@ arr |> Array::length
 
 ## Patterns
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 _
 x
 42
@@ -529,7 +541,8 @@ A | B
 
 Match-arm guards:
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 match x {
   v if v > 0 => v,
   _ => 0,
@@ -538,7 +551,8 @@ match x {
 
 Destructuring:
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 let (a, b) = pair
 let record { x, y } = rec
 guard opt is Some(v) else { return -1 }
@@ -563,7 +577,8 @@ of the function.
 
 ## Types
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 Int
 Float
 Double
@@ -687,13 +702,10 @@ kind carries today.
 
 ## Tests, Examples And Benches
 
-```vibe
+```vibe skip
+// doctest-skip: form catalogue: bare surface forms, not a compilable program
 test "arithmetic" {
   assert_eq(1 + 1, 2)
-}
-
-test smoke_case {
-  assert(true)
 }
 
 example "adding two numbers" {
@@ -705,8 +717,11 @@ bench "hot path" {
 }
 ```
 
-Quoted and bare test names are accepted. Quoted names are preferred in public
-examples.
+The test name is a STRING literal. A bare identifier
+(`test smoke_case { .. }`) is rejected -- `expected test name string` -- so the
+name is always quoted. This section said both forms were accepted until it was
+measured against the compiler; nothing was checking it, because docs/spec/ was
+outside the doctest list.
 
 `example "name" { .. }` (#819) is a documentation example. It is compiled and
 RUN exactly like a test -- that is the point of the form: a doc sample that

--- a/docs/spec/test-example-capabilities.md
+++ b/docs/spec/test-example-capabilities.md
@@ -22,7 +22,8 @@ capability を宣言可能にする。Markdown fence の任意スクリプトを
 
 ## 構文
 
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented -- `test ".." with <row>` is rejected today
 test "test name" {
   // body
 }
@@ -55,7 +56,8 @@ capability を宣言しなければならない。
 `with` を書く場合、row は完全に明示する。`Exception` を省略することは
 エラーとする。
 
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented -- `test ".." with <row>` is rejected today
 // OK
 test "pure" with Exception { assert_eq(1, 1) }
 
@@ -80,7 +82,8 @@ capability である。
 開発用 fixture や integration test で capability をすべて個別列挙する負担を
 下げるため、`DevEnv` を定義済み development capability bundle とする。
 
-```vibe
+```vibe skip
+// doctest-skip: design sketch: the syntax below is not implemented -- `test ".." with <row>` is rejected today
 test "local integration" with Exception + DevEnv {
   // development fixture を使う
 }

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1279,7 +1279,8 @@ clock 下限 = park の実在)の両方を pin する。adapter 側の反映は 
 wrap され、viberun（`VIBE_ASYNC_STREAMS="body=10|15|17"`）上で **42** を
 返す:
 
-```vibe
+```vibe skip
+// doctest-skip: needs an Async-row entry + component adapter; not runnable standalone
 let run: () -> Int with Async = () -> {
   let s = host_stream_named("body")
   let mut sum = 0
@@ -1460,7 +1461,8 @@ surface は `host_stream_close: (Stream[Int]) -> Unit`。**`Async` は付かな�
 `stream.drop-readable` は block しない canon call なので park も予約帯も
 boundary settle arm も要らず、注入 fn `__hs_close` が adapter を直接呼ぶ。
 
-```vibe
+```vibe skip
+// doctest-skip: needs an Async-row entry + component adapter; not runnable standalone
 let run: () -> Int with Async = () -> {
   let s = host_stream_named("body")
   let a = host_stream_next(s)


### PR DESCRIPTION
#1504 の続き。あちらで `docs/` と `examples/` を CI で塞いだので、残していた `docs/spec/` と `bench/` を片付ける。

## docs/spec の仕分け (27 fail → 0 fail)

46 blocks 中 27 が落ちていた。中身を1つずつ見ると3種類だった。

### (a) form catalogue — そもそもプログラムではない (syntax.md 16件)

`docs/spec/syntax.md` は syntax 仕様なので、ブロックの多くは「受理される形の一覧」:

```
42 / 0xFF / "hello \{name}"        リテラルの一覧
(x) -> { x + 1 } / x -> x * 2      lambda の形の一覧
() -> Int / [T](T) -> T            関数型の一覧
x = value / x += 1 / x %= 2        代入演算子の一覧
Int / Float / Array[T] / Map[K, V] 型名の一覧
```

コンパイル可能にするには1つずつ program に包むしかなく、それは「素の形を見せる」という目的を壊す。ハーネスの ```vibe skip に**理由付きで**落とした (`// doctest-skip: form catalogue: ...`)。

### (b) design doc — 未実装の構文 (11件)

`builtin-ssot-design.md` (`declare` 構文)、`show-trait-design.md` (`...` 省略記法)、`structured-shell-design.md` (preprocessor 出力のスケッチ)、`test-example-capabilities.md` (Status: Proposal)、`wasi-p3-async.md` (Async-row entry + component adapter が要る)。同じく理由付き skip。

### (c) 仕様と実装の乖離 — 実在するバグ (1件)

`syntax.md` が `test smoke_case { .. }` (裸の識別子) を「受理される」と書いていたが、実際は:

```
expected test name string
```

この文書は冒頭で *"implemented surface syntax reference"* と名乗っているので事実誤り。当該の形を削り、拒否されることを明記した。

仕分け後 `docs/spec` は **15 pass / 0 fail / 31 skip** になったので、CI と Taskfile の doctest 対象に `docs/spec/*.md` を追加した。全体で **198 blocks / 116 pass / 0 fail / 82 skip**。

## bench の文法修正 (11件)

`bench_*.vibe` と `bundle_size/consumer_*.vibe` が ADR-0069 以前の script 形（末尾の裸の top-level 式が program の値）のまま残っていて、11ファイルが `top-level expressions are not allowed` で落ちていた。

同じ bench 群で**通っている** `bench/binary_size/fib.vibe` が既に `let main = () -> Int { .. }` の形なので、それに揃えた。**bench 本体は一切変えず**、末尾の式をそのまま包んだだけ。

併せて `bundle_size/prelude/double.vibe` の `duplicate declaration: Double::abs` を修正。ファイル末尾に

```vibe
export let Double::abs: (Double) -> Double = (x) -> {
  Double::abs(x)          // ← 自分自身を呼んでいる
}
```

という re-export のつもりの wrapper が5つあり、上部の private 実装と**同じ名前**を再宣言していた（re-export ではなく自己再帰）。wrapper を削り、実装側に `export` を付けた。これで隠れていた ADR-0069 違反が2件出たので同様に包んだ。

bench 49ファイル中 **44** が type-check を通る状態になった。

## 残り5件 — 文法ではないので手を付けていない

- **`checker_browser_baseline/*.vibe` 4件** — `vibe diagnostics` は clean で `vibe check` だけが無言で落ちる。package を import するファイルで起きる現象で (`lib/@vibe/parser/parser_smoke_test.vibe` も同じ)、ファイルの欠陥ではなく `vibe check` の適用範囲の問題
- **`http_bench.vibe`** — `Http::request` の arity が**コンパイラ内部で食い違っている** (#1505)。`lib/@vibe/compiler/builtins/declarations.vibe:316` は4引数、`checker/builtins_net.vibe:81` は2引数で、効くのは checker 側。4引数は `(method, url, headers, body)` を渡しているので単に削ると機能が落ちる。`tests/http_wasm_fallback_test.vibe` も同じ理由で落ちている

## 検証

```
doctest (docs/spec 込み, CI form)   198 blocks / 116 pass / 0 fail / 82 skip
check_examples_typecheck.sh        16 files, 1 known, 0 new
pkf format --check Taskfile.pkl    ok
```

Refs #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_