### PR TITLE
host builtin の arity をレジストリから検査する (#1513)

### DIFF
--- a/eval/lang-review/repair/09_silent_builtin_arity/diag.grep
+++ b/eval/lang-review/repair/09_silent_builtin_arity/diag.grep
@@ -1,0 +1,2 @@
+function arity mismatch for Stdout::write_stream
+expected 1 args, got 0

--- a/eval/lang-review/repair/README.md
+++ b/eval/lang-review/repair/README.md
@@ -78,6 +78,26 @@ mean = 26/10 = 2.6 → **repair_convergence = 3.6**
   (`expected 1 elements on the stack for fallthru`) がソース位置なしで出る。
   10 は**成功して間違った出力を出す** (silent miscompile)。→ 全項目 0
 
+## 更新: #1513 を塞いだ (09 が silent → 診断あり)
+
+ラチェットが設計どおりこの改善を検出して FAIL し、採点し直しを要求した。上の r4
+表は**そのラウンドの記録として残す**。現行の値は:
+
+| # | ケース | 診断 | L | A | C | 計 |
+|---|---|---|---|---|---|---|
+| 09 | `Stdout::write_stream()` (0引数) | `line 2:3-23: function arity mismatch for Stdout::write_stream: expected 1 args, got 0` | **1** | **1** | **2** | **4** (was 0) |
+
+`line:col-col` のスパン付きで出るので、06/07 と同じ最良の段。
+
+mean = 30/10 = 3.0 → **repair_convergence = 4.0** (r4 の 3.6 から)。
+`type_soundness` の 3.0 も、silent miscompile が1種類消えたので次ラウンドで
+見直す対象になる (スコアの更新はラウンドの仕事なので `scores/` は触っていない)。
+
+**ケース 10 は silent のまま据え置き** — 直したのは arity であって引数の型では
+ない。`Stdout::write_stream(42)` は今も compile も実行も通り garbage を出す。
+ディレクトリ名 `09_silent_builtin_arity` は当初この2つが同じ穴だった経緯の記録
+なので、名前は変えていない。
+
 ### 09/10 の範囲 (実測) — #1513
 
 `direct_call_return` の fast path (`checker.vibe`、#626 の seed ヒープ制約で

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -21,6 +21,7 @@ import @vibe/compiler/core {
   is_exception_label,
   is_exception_throw_handler_name,
   is_exception_throw_operation,
+  registry_builtin_arity,
   resolve_builtin,
   subst_add_bound,
   subst_apply,
@@ -2124,7 +2125,16 @@ fn builtin_fixed_arity(name: String) -> Int {
   } else if name == "FixedArray::blit" {
     5
   } else {
-    0 - 1
+    // #1513: fall back to the central registry rather than growing this list.
+    // The chain above predates the registry and covers the pure container /
+    // string builtins; every HOST builtin (`Stdout::*`, `Env::*`, `Stdin::*`,
+    // `Fs::*`, `sh`, `sleep`, ...) declares its parameters there and was
+    // therefore arity-UNCHECKED here -- `Stdout::write_stream()` compiled and
+    // emitted a module the host rejected at load time, and
+    // `Fs::read_file("a", "b")` did the same. Returns -1 for a non-registry
+    // name, so anything this pass genuinely cannot see stays tolerated exactly
+    // as before.
+    registry_builtin_arity(name)
   }
 }
 

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -395,6 +395,38 @@ export fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)] {
   out
 }
 
+/// #1513: the parameter COUNT of a checker-visible registry row, or -1 when the
+/// name is not one. Split out from `lookup_registry_builtin` because the
+/// checker's direct-call FAST PATH (`checker.vibe::builtin_fixed_arity`)
+/// deliberately avoids `lookup_builtin` -- #626's seed-heap constraint was about
+/// BUILDING nested `CtFn`/`Array` values per call, and this reads the
+/// already-built row without constructing anything.
+///
+/// Before this, that fast path checked arity against a hand-maintained list in
+/// checker.vibe, so `Stdout::write_stream()` / `Fs::read_file("a", "b")` /
+/// `Env::get("A", "B")` were silently unchecked and emitted an invalid module
+/// (measured: the host rejected it at load with `expected 1 elements on the
+/// stack for fallthru`, no source position). Which builtins got checked was the
+/// maintenance state of that list, not a rule of the language.
+export fn registry_builtin_arity(name: String) -> Int {
+  let rows = builtin_registry_typed()
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < Array::length(rows) {
+    let (rname, ty, _, _, visible) = Array::get(rows, i)
+    if rname == name && visible {
+      found = match ty {
+        CtFn(params, _, _) => Array::length(params),
+        _ => 0 - 1
+      }
+      i = Array::length(rows)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
 /// B-2: the checker-facing lookup, consulted FIRST by
 /// checker/builtins.vibe::lookup_builtin. Only checker_visible rows resolve;
 /// codegen-internal names stay invisible to user code.

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -123,6 +123,7 @@ fn canonical_builtin_name(name: String) -> String
 fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)]
 fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
 fn lookup_registry_builtin(name: String) -> Option[Type]
+fn registry_builtin_arity(name: String) -> Int
 fn verify_lane_builtins(lane: String, names: Array[String], param_counts: Array[Int], returns: Array[Int]) -> Unit with Exception
 fn verify_standard_effect_policy_coverage() -> Unit with Exception
 


### PR DESCRIPTION
#1513 の silent miscompile を塞ぐ。lang-review r4 の所見が「次にやると効くこと」の1番に挙げていたもの。

## 症状

```vibe
fn main with Stdout {
  Stdout::write_stream()          // 診断なしで compile が通る
}
```

生成された wasm を host が load 時に拒否する:

```
CompileError: ... expected 1 elements on the stack for fallthru
```

ソース位置なし、vibe の語彙ですらない。`Fs::read_file("a", "b")` / `Env::get("A", "B")` / `Stdin::read_char(1)` も同じ。

## 原因は「表の保守状況」だった

checker の direct-call fast path は `builtin_fixed_arity` という**手書きの if チェーン**で arity を見ている。これは container / string 系 builtin を書いた当時のもので、`Stdout::*` / `Env::*` / `Stdin::*` / `Fs::*` / `sh` / `sleep` は載っていない → arity 検査が丸ごと素通りしていた。

つまり**「検査される builtin の集合」は言語の規則ではなく、その表がどこまで更新されているか**だった。#1505（`Http::request` の arity が checker 側だけ2引数）と同じ根。

なお当初は「capability builtin だから検査されない」という仮説を立てたが、**外れ**だった（`Profiler::now_us` は capability だが検査される）。分かれ目は fast path の表に載っているかどうか。

## 表を増やさずレジストリを引く

`core/builtin_registry.vibe` が既に**中央レジストリ**として全 host builtin の signature を持っている（`reg_p0` / `reg_p1` / … で arity を綴る形。今回の対象は**全て**レジストリ行だった）。

そこに `registry_builtin_arity(name)` を足し、`builtin_fixed_arity` の末尾をそのフォールバックにした。**手書きの表に名前を追加していくと同じ問題を再生産する**ので、そうしていない。

`#626` の seed ヒープ制約は「呼び出しごとに `CtFn` / `Array` を**構築**する」コストの話（`registry_typed_rows` の doc comment が明記している）。この関数は構築済みの行を**読むだけ**なので該当しない。根拠はコード註釈にも残した。

## 実測

| 形 | before | after |
|---|---|---|
| `Stdout::write_stream()` | 診断なし → 不正な wasm | `line 1:23-43: function arity mismatch for Stdout::write_stream: expected 1 args, got 0` |
| `Stdout::write_stream("a", "b")` | 同上 | `expected 1 args, got 2` |
| `Fs::read_file("a", "b")` | 同上 | `expected 1 args, got 2` |
| `Env::get("A", "B")` | 同上 | `expected 1 args, got 2` |
| `Stdin::read_char(1)` | 同上 | `expected 0 args, got 1` |
| 正しい arity の呼び出し | ok | **ok** |

`line:col-col` のスパン付きで出るので、repair 採点では最良の段（L=1 / A=1 / C=2）。

## repair コーパスの追随

**ラチェットが設計どおりこの改善を検出して FAIL した**:

```
FAIL 09_silent_builtin_arity: silent ケースに診断が付いた (改善)。
     silent を消して diag.grep を書き、scores を付け直してから通すこと
```

指示どおり `silent` を消して `diag.grep` を書き、採点し直した（0点 → 4点）。**repair_convergence は 3.6 → 4.0**。r4 の表は当該ラウンドの記録として残し、更新は別節にしている。スコアの更新はラウンドの仕事なので `scores/` は触っていない。

**ケース10（引数の型）は silent のまま据え置き** — 直したのは arity であって型ではない。`Stdout::write_stream(42)` は今も compile も実行も通り garbage を出す。#1513 はそこが残るので open のままにしてある。

## 検証

```
compiler_gate.sh             RC=0
unit_test_runner.sh          531/531
doctest (CI form)            203 blocks / 116 pass / 0 fail
check_examples_typecheck.sh  16 files, 1 known, 0 new
check_playground_presets.sh  4 preset(s) ok
run_golden.sh / run_repair.sh 10/10 / 10/10
check_vibe_fmt.sh            909 file / 0 violation
```

Refs #1513 #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_