### PR TITLE
compile 経路の診断に位置を付ける — effect row 不一致 (#1514 C)

### DIFF
--- a/eval/lang-review/repair/README.md
+++ b/eval/lang-review/repair/README.md
@@ -113,11 +113,34 @@ line:col に解決して文言からは剥がす)、対象の3つの throw が�
 
 mean = 33/10 = 3.3 → **repair_convergence = 4.3** (r4 3.6 → #1513 で 4.0 → 4.3)。
 
-**05 / 08 は据え置き** — こちらは「位置が一切付かない」C カテゴリで、原因が別。
-効果パス側のエラーは `EffectError` が offset を持たず、compile 経路の
-`emit_compile_diag` が `locate_type_error` を呼ばない。後者を配線するには
-offset がどのソース基準かを決める必要があり、merged 複数ファイルコンパイルでは
-一意でない。誤った位置は位置無しより悪いので、別スライスとして #1514 に残す。
+## 更新: #1514 の C カテゴリ (05 — 位置が一切付かなかった)
+
+当初「merged 複数ファイルでは offset の基準ソースが一意でない」と判断して降りたが、
+**実装を読んだらそうではなかった**。`compile_source_wasi_only(source, entry)` は
+ソース文字列そのものを受け取り、`check_program` はそれを lex した AST を見る —
+つまり offset の基準は呼び出し側が持っている `source` で確定している。
+
+塞いだのは2つ:
+
+1. `EEEffectRowMismatch` に**呼び出しサイトの offset** を持たせた。walker の
+   `ECall(callee, args, _)` arm がその場で offset を捨てていただけ
+2. `emit_compile_diag_located` を足し、compile 経路で ` [@off=N]` を解決する
+
+2 は**マーカーを持つメッセージだけ**に適用する。マーカーが無ければ
+`locate_type_error` の first-occurrence ヒューリスティックに落ちて、もっともらしい
+別の行を指しうる — 既存の全メッセージを黙って変える危険があるので、
+「自分がどこから来たか述べている診断」だけが位置を得る。
+
+| # | 位置 (before → after) | L | 計 |
+|---|---|---|---|
+| 05 | なし → **`line 2:3`** (effect を要求している呼び出しそのもの) | 0 → **1** | 3 → **4** |
+
+mean = 34/10 = 3.4 → **repair_convergence = 4.4**。
+
+**08 は据え置き** — こちらは codegen (`inline_direct_perform.vibe`) が投げる
+ADR-0076 のエラーで、位置の出どころが `EHandle(body, arms)`。この AST ノードは
+**offset フィールドを持たない**ので、付けるには EHandle を構築/分解している
+全箇所に触る必要がある。別スライスとして #1514 に残す。
 
 **ラチェットは位置の改善では落ちない** (`diag.grep` は文言だけを見る)。この表の
 更新は手動 — 位置は「文言が変わっていないのに質が上がる」唯一の軸なので、

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -60,7 +60,11 @@ export enum EffectError {
   // Fields (all pre-rendered ", "-joined label lists, deterministic order):
   // (enclosing fn name or "" when unnamed, missing labels (sorted),
   //  declared row (source order, "" when no row), required row (sorted union)).
-  EEEffectRowMismatch(String, String, String, String);
+  // #1514: the 5th field is the CALL SITE's source offset (-1 when unknown),
+  // carried to the renderer as the ` [@off=N]` marker locate_type_error decodes.
+  // Before this the row mismatch had no position at all -- measured as the worst
+  // tier in eval/lang-review/repair (05).
+  EEEffectRowMismatch(String, String, String, String, Int);
   EEAssignImmutable(String);
   // #1347: a `handle ... with E` whose arms are provably dead because the
   // body cannot reach a perform of E and only invokes an opaque value —
@@ -115,7 +119,7 @@ export fn effect_error_to_string(err: EffectError) -> String {
     // #639: expected-vs-actual effect rows as a set difference, then ONE
     // deterministic fix-it hint line targeting the enclosing declaration
     // (for a call-site leak that is the CALLER, not the callee).
-    EEEffectRowMismatch(fname, missing, declared, required) => {
+    EEEffectRowMismatch(fname, missing, declared, required, off) => {
       let head = if String::length(fname) > 0 {
         String::concat("effect row mismatch for '", String::concat(fname, "'"))
       } else {
@@ -133,7 +137,14 @@ export fn effect_error_to_string(err: EffectError) -> String {
       } else {
         String::concat("\nhint: add 'with ", String::concat(row_as_source(required), String::concat("' to '", String::concat(fname, "'"))))
       }
-      String::concat(head, String::concat(": missing { ", String::concat(missing, String::concat(" }", String::concat(detail, hint)))))
+      let body = String::concat(head, String::concat(": missing { ", String::concat(missing, String::concat(" }", String::concat(detail, hint)))))
+      // #1514: marker LAST so the hint line stays the visible tail; the decoder
+      // strips it before the user ever sees the string.
+      if off >= 0 {
+        String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
+      } else {
+        body
+      }
     },
     EEAssignImmutable(name) => String::concat("cannot assign to immutable binding `", String::concat(name, "` (declare it with `let mut`)")),
     EEHandleNeverFires(eff) => {
@@ -1242,10 +1253,10 @@ fn join_labels(xs: Array[String]) -> String {
 /// required effects are absent from the enclosing declaration's row. `missing`
 /// is the set difference (callee requires minus caller declares), rendered
 /// sorted; `required` is the sorted union the fix-it hint suggests declaring.
-fn make_row_mismatch(fn_name: String, declared: Array[String], missing: Array[String]) -> EffectError {
+fn make_row_mismatch(fn_name: String, declared: Array[String], missing: Array[String], off: Int) -> EffectError {
   let missing_sorted = sort_labels(labels_union(no_str_labels(), missing))
   let required = sort_labels(labels_union(declared, missing))
-  EEEffectRowMismatch(fn_name, join_labels(missing_sorted), join_labels(declared), join_labels(required))
+  EEEffectRowMismatch(fn_name, join_labels(missing_sorted), join_labels(declared), join_labels(required), off)
 }
 
 /// #626 criterion 2: a `handle ... with E` DISCHARGES E for its body — after
@@ -1760,7 +1771,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
     let (expr, declared, in_handle, ov_names, ov_effs, kinds) = Array::get(stack, n - 1)
     Array::truncate(stack, n - 1)
     match expr {
-      ECall(callee, args, _) => {
+      ECall(callee, args, call_off) => {
         match callee {
           EIdent(name, _) => {
             if name == "perform" && Array::length(args) == 1 {
@@ -1793,7 +1804,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                     if (!is_exception_effect_name(eff) || error_row_checked()) && !in_handle && !decl_authorizes_op(declared, required_op) {
                       Array::push(errors, make_row_mismatch(fn_name, declared, [
                         throw_report_label(op_name, required_op, declared)
-                      ]))
+                      ], call_off))
                     } else {
                       ()
                     }
@@ -1809,7 +1820,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                   if (!is_exception_effect_name(eff) || error_row_checked()) && !in_handle && !decl_authorizes_op(declared, op_name) {
                     Array::push(errors, make_row_mismatch(fn_name, declared, [
                       op_name
-                    ]))
+                    ], call_off))
                   } else {
                     ()
                   }
@@ -1834,7 +1845,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                     // perform path follows since Codex review on PR #1161).
                     Array::push(errors, make_row_mismatch(fn_name, declared, [
                       op_label
-                    ]))
+                    ], call_off))
                   } else {
                     ()
                   }
@@ -1911,7 +1922,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                   ti = ti + 1
                 }
                 if Array::length(missing) > 0 {
-                  Array::push(errors, make_row_mismatch(fn_name, declared, missing))
+                  Array::push(errors, make_row_mismatch(fn_name, declared, missing, call_off))
                 } else {
                   ()
                 }
@@ -1945,7 +1956,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                   pi = pi + 1
                 }
                 if Array::length(missing) > 0 {
-                  Array::push(errors, make_row_mismatch(fn_name, declared, missing))
+                  Array::push(errors, make_row_mismatch(fn_name, declared, missing, call_off))
                 } else {
                   ()
                 }

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -24,6 +24,7 @@ import @vibe/compiler/runtime {
   doc_at_source,
   incremental_invalidation_trace_json,
   incremental_typecheck_telemetry_json,
+  locate_type_error,
   module_plan_manifest_fs,
   run_module_job_dir,
   run_publish_env_cache_dir,
@@ -314,6 +315,30 @@ fn compile_source_for_rc_flag(source: String, entry_name: String, rc_flag: Strin
 fn emit_compile_diag(output_path: String, msg: String) -> Int with Fs {
   Fs::write_file(String::concat(output_path, ".diag"), msg)
   1
+}
+
+/// #1514: the same sidecar, but with the ` [@off=N]` marker resolved to a real
+/// `line:col` against the source the offsets are relative to.
+///
+/// The COMPILE path never located its diagnostics -- only the typecheck path
+/// calls `locate_type_error` -- so every checker diagnostic that reached a user
+/// through `vibe build` / `vibe run` arrived positionless. `source` here is
+/// exactly what `check_program` was run on (the single-source lane passes its
+/// post-`apply_cfg_env` text; the offsets in the marker index into it), so there
+/// is no ambiguity about the basis.
+///
+/// Marker-gated on purpose: with no marker this is byte-identical to
+/// `emit_compile_diag`. `locate_type_error` would otherwise fall through to its
+/// first-occurrence HEURISTIC, which can name a plausible-but-wrong line — worse
+/// than no position at all, and it would silently change every existing
+/// compile-path message. Only a diagnostic that states where it came from gets a
+/// position from this.
+fn emit_compile_diag_located(output_path: String, msg: String, source: String) -> Int with Fs {
+  if String::contains(msg, " [@off=") {
+    emit_compile_diag(output_path, locate_type_error(source, msg))
+  } else {
+    emit_compile_diag(output_path, msg)
+  }
 }
 
 /// debugger テーマ3 / M2: best-effort `.funcmap` sidecar beside the compiled wasm.
@@ -1124,10 +1149,11 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
     // ADR-0055 #493 cutover toggle: VIBE_RC=1 compiles on the Perceus RC codegen
     // path (Env::get returns "" when unset, so default stays the bump path). Lets
     // the selfbuild/bootstrap/e2e gates exercise the whole compiler under RC.
+    // #1514: bound OUTSIDE the handle so the `Throw` arm -- a sibling scope, not
+    // the handled body -- can name it when resolving a diagnostic's offset.
+    let source_cfg = apply_cfg_env(source, Env::get("VIBE_CFG"))
     handle {
       let rc_flag = Env::get("VIBE_RC")
-      // #cfg: activate compile-time flags from VIBE_CFG (see apply_cfg_env).
-      let source_cfg = apply_cfg_env(source, Env::get("VIBE_CFG"))
       // #cov: function-level coverage build (same source pipeline, instrumented
       // codegen). Running the produced wasm records which compiler functions ran.
       let bytes = if Env::get("VIBE_COVERAGE") == "1" {
@@ -1156,7 +1182,9 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       profile_memory_mark(mark_memory)
       0
     } with Exception {
-      Throw(msg) => emit_compile_diag(output_path, msg)
+      // #1514: `source_cfg` is the exact text `check_program` ran on, so a
+      // marker-carrying diagnostic can be resolved to line:col here.
+      Throw(msg) => emit_compile_diag_located(output_path, msg, source_cfg)
     }
   }
 }

--- a/lib/@vibe/compiler/tests/checker_effects_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_effects_test.vibe
@@ -35,7 +35,7 @@ test "undeclared-effect error formatting includes op, effect and fix hint" {
 }
 
 test "effect row mismatch formatting: declared row present" {
-  let e = EEEffectRowMismatch("f", "Fs", "Error", "Error, Fs")
+  let e = EEEffectRowMismatch("f", "Fs", "Error", "Error, Fs", 0 - 1)
   let s = effect_error_to_string(e)
   assert(String::contains(s, "effect row mismatch for 'f'"))
   assert(String::contains(s, "missing { Fs }"))
@@ -50,7 +50,7 @@ test "effect row mismatch formatting: declared row present" {
 }
 
 test "effect row mismatch formatting: no declared row" {
-  let e = EEEffectRowMismatch("g", "Error", "", "Error")
+  let e = EEEffectRowMismatch("g", "Error", "", "Error", 0 - 1)
   let s = effect_error_to_string(e)
   assert(String::contains(s, "effect row mismatch for 'g'"))
   assert(String::contains(s, "no 'with' clause"))

--- a/lib/@vibe/compiler/tests/checker_perform_effects_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_perform_effects_test.vibe
@@ -18,7 +18,7 @@ import @vibe/compiler/checker {
 /// EEEffectRowMismatch (set difference + fix-it hint).
 fn is_perform_err(e: EffectError) -> Bool {
   match e {
-    EEEffectRowMismatch(_, _, _, _) => true,
+    EEEffectRowMismatch(_, _, _, _, _) => true,
     _ => false
   }
 }


### PR DESCRIPTION
#1514 の C カテゴリ（位置が一切付かない）のうち 05（effect row 不一致）を塞ぐ。

## まず訂正: 前回の判断は誤りだった

PR #1517 で C カテゴリを見送ったとき、理由をこう書いた:

> 配線するには offset がどのソース基準かを決める必要があり、**merged 複数ファイルコンパイルでは一意でない**

**実装を読んだらそうではなかった。** `compile_source_wasi_only(source, entry_name)` は**ソース文字列そのもの**を受け取り、`check_program` はそれを lex した AST を見る。つまり offset の基準は呼び出し側が持っている `source` で確定していて、曖昧さは無い。

「呼び出し側が持っているのは `input_path` だけ」という前提が間違いで、実際には `source_cfg` がその場にあった。

## 2つ塞いだ

### 1. `EEEffectRowMismatch` に呼び出しサイトの offset を持たせた

walker の `ECall(callee, args, _)` arm がその場で offset を捨てていただけで、捕まえれば5つの生成サイトすべてに同じ値が届く。

### 2. `emit_compile_diag_located` — compile 経路で ` [@off=N]` を解決する

compile 経路はこれまで `locate_type_error` を一切呼んでおらず（呼ぶのは型検査経路だけ）、`vibe build` / `vibe run` でユーザーに届く checker 診断は全部位置無しだった。

**マーカーを持つメッセージだけ**に適用する。マーカーが無ければ `locate_type_error` の first-occurrence ヒューリスティックに落ちて、もっともらしい別の行を指しうる — 既存の全メッセージを黙って変える危険があるので、「自分がどこから来たか述べている診断」だけが位置を得る設計にした。マーカー無しの経路は byte-identical。

## 実測

```
before: effect row mismatch for 'helper': missing { Stdout::write_stream } (no 'with' clause, ...)
after:  line 2:3: effect row mismatch for 'helper': missing { Stdout::write_stream } (no 'with' clause, ...)
```

`2:3` は effect を要求している呼び出し（`Stdout::write_stream(..)`）そのもの。宣言ではなく呼び出しを指すのは、そこが row を要求している場所だから。

**生のマーカーが漏れないことも実測した** — FS_COMPILE 有無・`__no_entry__` の各レーンで確認済み。#1445 でマーカーだけ付けて `[@off=135]` を漏らした失敗の再発防止。

## 残す: 08（`handle` 適格性）

codegen (`inline_direct_perform.vibe`) が投げる ADR-0076 のエラーで、位置の出どころは `EHandle(body, arms)`。この AST ノードは **offset フィールドを持たない**ので、付けるには EHandle を構築/分解している全箇所に触る必要がある。別スライスとして #1514 に残す。

## repair 採点の推移

| ラウンド / 変更 | score |
|---|---|
| r4 実測 | 3.6 |
| #1513 host builtin の arity (PR #1516) | 4.0 |
| #1514 B カテゴリ (PR #1517) | 4.3 |
| **本 PR (#1514 C の 05)** | **4.4** |

## 実装メモ

`source_cfg` を `handle` の外へ出したのは、ハンドラのアームが handled body とは別スコープで、中の `let` が見えないため（`unknown name: source_cfg` で一度落ちて分かった）。

## 検証

```
compiler_gate.sh             RC=0 (typecheck fixtures 75件)
unit_test_runner.sh          533/533
doctest (CI form)            203 blocks / 116 pass / 0 fail
check_examples_typecheck.sh  16 files, 1 known, 0 new
check_playground_presets.sh  4 preset(s) ok
run_golden.sh / run_repair.sh 10/10 / 10/10
check_vibe_fmt.sh            911 file / 0 violation
```

Refs #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_