### PR TITLE
fix(checker): host builtin の引数型を中央レジストリで検査する (#1513 後半)

### DIFF
--- a/eval/lang-review/repair/10_silent_builtin_argtype/diag.grep
+++ b/eval/lang-review/repair/10_silent_builtin_argtype/diag.grep
@@ -1,0 +1,2 @@
+argument type mismatch for Stdout::write_stream
+receiver type Int

--- a/eval/lang-review/repair/README.md
+++ b/eval/lang-review/repair/README.md
@@ -146,6 +146,36 @@ ADR-0076 のエラーで、位置の出どころが `EHandle(body, arms)`。こ�
 更新は手動 — 位置は「文言が変わっていないのに質が上がる」唯一の軸なので、
 自動検出の対象外にしてある。
 
+## 更新: #1513 の後半 (10 が silent → 診断あり)
+
+arity に続いて**引数の型**も塞いだ。`builtin_first_arg_head` /
+`builtin_arg_head_rest` という手書きの表 (Array / String / Bytes / FixedArray
+しかカバーしていない) を、中央レジストリのパラメータ型へフォールバックさせた。
+手書きの表は entry がある位置で勝つので、既に検査されていたものは verdict が
+変わらない。
+
+| # | ケース | 診断 | L | A | C | 計 |
+|---|---|---|---|---|---|---|
+| 10 | `Stdout::write_stream(42)` | `line 2:3-23: argument type mismatch for Stdout::write_stream: receiver type Int` | **1** | **1** | **2** | **4** (was 0) |
+
+mean = 38/10 = 3.8 → **repair_convergence = 4.8**。
+
+レジストリの型を head-kind 比較に落とすとき、`CtChar` は `CtInt` に畳む。
+`Char` はこの言語では `Int` の別名 (lexer が char リテラルを `TInt` で出すので
+`'A' == 65`、`core/types.vibe` の `char_int_compatible` が両方向に unify を許す)
+であり、head 比較が `unify` の作らない区別を作ってはいけない。畳まないと
+レジストリで `CtChar` と書かれた `Char::to_int` が `Char::to_int('A')` を弾き、
+逆に `CtChar` の値 (`Char::from_int(65)`) が `CtInt` と書かれた
+`Stdout::write_char` に渡せなくなる (実際に prelude の `char.vibe` が落ちた)。
+
+**コーパスから silent ケースが無くなった。** 09/10 は「診断が出ないこと」を測る
+ために置いた2件で、どちらも塞がった。今後 silent 種別が見つかったら**新しい
+ケースとして追加する**(既存の変更は不可) — この2件は「かつて診断が無かった」
+記録として、診断ありのケースのまま残る。
+
+`type_soundness` を 4.0 → 3.0 に下げた理由 (rubric 4 の定義そのままの silent
+miscompile) はこれで解消したので、次ラウンドの見直し対象。
+
 ### 09/10 の範囲 (実測) — #1513
 
 `direct_call_return` の fast path (`checker.vibe`、#626 の seed ヒープ制約で

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -23,6 +23,7 @@ import @vibe/compiler/core {
   is_exception_throw_handler_name,
   is_exception_throw_operation,
   registry_builtin_arity,
+  registry_builtin_param_type,
   resolve_builtin,
   subst_add_bound,
   subst_apply,
@@ -2136,6 +2137,53 @@ fn builtin_fixed_arity(name: String) -> Int {
     // name, so anything this pass genuinely cannot see stays tolerated exactly
     // as before.
     registry_builtin_arity(name)
+  }
+}
+
+/// #1513: the expected head kind of builtin `name`'s argument `i`, hand table
+/// FIRST and the central registry as the fallback.
+///
+/// The two hand tables above (`builtin_first_arg_head` /
+/// `builtin_arg_head_rest`) predate the registry and cover Array / String /
+/// Bytes / FixedArray only, so every HOST builtin's arguments were unchecked:
+/// `Stdout::write_stream(42)` compiled AND RAN, printing the pointer as a
+/// decimal. Same shape as the arity gap this issue's first half closed —
+/// "which builtins get checked" was the maintenance state of a list, not a rule.
+///
+/// The hand table wins where it has an entry so nothing already checked can
+/// change verdict (it encodes receiver-position knowledge the registry's
+/// per-parameter types do not, e.g. HOF callbacks deliberately left at 0).
+/// A registry parameter typed `CtUnknown` maps to head 0 = tolerate, which is
+/// how `assert_eq` and friends stay unchecked.
+fn builtin_param_head(name: String, i: Int) -> Int {
+  let hand = if i == 0 {
+    builtin_first_arg_head(name)
+  } else {
+    builtin_arg_head_rest(name, i)
+  }
+  if hand != 0 {
+    hand
+  } else {
+    match registry_builtin_param_type(name, i) {
+      Some(t) => head_fold_char(head_kind(t)),
+      None => 0
+    }
+  }
+}
+
+/// `Char` is an `Int` alias in this language: the lexer emits `TInt` for a char
+/// literal, so `'A' == 65` and `char_int_compatible` (core/types.vibe) lets the
+/// two unify freely in both directions. The head-kind check must not invent a
+/// distinction `unify` does not make, so fold `CtChar`'s head into `CtInt`'s on
+/// both sides of the comparison. Without this the registry's `Char::to_int`
+/// row (declared `CtChar`) rejects `Char::to_int('A')`, and a `CtChar`-typed
+/// value (e.g. `Char::from_int(65)`) is rejected by every builtin whose
+/// registry row spells the slot `CtInt` (`Stdout::write_char`, ...).
+fn head_fold_char(k: Int) -> Int {
+  if k == 5 {
+    1
+  } else {
+    k
   }
 }
 
@@ -5089,7 +5137,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           match direct_call_return(env, name) {
             Some(ret_ty) => {
               let alen = Array::length(args)
-              let want_head = builtin_first_arg_head(name)
+              let want_head = builtin_param_head(name, 0)
               // Argument-count check (see `builtin_fixed_arity`). `Bytes::new`
               // is special-cased: 0 args = empty growable buffer, 1 arg =
               // length-n zero-filled (MoonBit semantics, linear backend synth).
@@ -5117,7 +5165,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                 // passes an Int where an Array is required). A non-concrete head
                 // (var / generic / unknown) is tolerated.
                 if ai == 0 && want_head != 0 {
-                  let got_head = head_kind(subst_apply(s2, at))
+                  let got_head = head_fold_char(head_kind(subst_apply(s2, at)))
                   if got_head != 0 && got_head != want_head {
                     Array::push(errors, String::concat(String::concat("argument type mismatch for ", String::concat(name, ": receiver type ")), String::concat(type_to_string(subst_apply(s2, at)), off_marker_len(callee_off, String::length(name)))))
                   } else if want_head == 9 && is_stream_named_type(subst_apply(s2, at)) {
@@ -5131,9 +5179,9 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                 } else if ai >= 1 {
                   // Non-receiver argument head check for fixed-signature builtins
                   // (`String::concat("a", 1)`, `String::substring(s, "x", 2)`).
-                  let want_rest = builtin_arg_head_rest(name, ai)
+                  let want_rest = builtin_param_head(name, ai)
                   if want_rest != 0 {
-                    let got_head = head_kind(subst_apply(s2, at))
+                    let got_head = head_fold_char(head_kind(subst_apply(s2, at)))
                     if got_head != 0 && got_head != want_rest {
                       Array::push(errors, String::concat(String::concat("argument type mismatch for ", String::concat(name, String::concat(" (arg ", String::concat(__to_string(ai), "): ")))), String::concat(type_to_string(subst_apply(s2, at)), off_marker_len(callee_off, String::length(name)))))
                     } else {

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -272,7 +272,16 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("String::substring", CtFn(reg_p3(CtString, CtInt, CtInt), CtString, None), true, true, true),
   ("Array::truncate", CtFn(reg_p2(CtArray(CtUnknown), CtInt), CtUnit, None), true, true, true),
   ("String::join", CtFn(reg_p2(CtArray(CtString), CtString), CtString, None), true, true, true),
-  ("eq", CtFn(reg_p2(CtInt, CtInt), CtBool, None), true, true, true),
+  // #1513: POLYMORPHIC — `eq` is the structural equality builtin and is applied
+  // to enums / structs / strings, not just Int. The `CtInt` placeholder here was
+  // harmless while nothing read these parameter types; once the checker's
+  // fast-path argument check started consulting the registry it turned into a
+  // false rejection (measured: `eq(Color::Red, c)` in
+  // docs/language-tour/basics.vibe.md). `CtUnknown` is what the sibling
+  // polymorphic row `assert_eq` already declares, and head_kind maps it to
+  // "tolerate". Parameter COUNT and return type are unchanged, so the derived
+  // `builtin_registry()` view the codegen lanes read is byte-identical.
+  ("eq", CtFn(reg_p2(CtUnknown, CtUnknown), CtBool, None), true, true, true),
   ("String::ends_with", CtFn(reg_p2(CtString, CtString), CtBool, None), true, true, true),
   ("String::last_index_of", CtFn(reg_p2(CtString, CtString), CtInt, None), true, true, true),
   ("String::index_of", CtFn(reg_p2(CtString, CtString), CtInt, None), true, true, true),
@@ -422,6 +431,40 @@ export fn registry_builtin_arity(name: String) -> Int {
       i = Array::length(rows)
     } else {
       i = i + 1
+    }
+  }
+  found
+}
+
+/// #1513: the declared type of a checker-visible registry row's parameter `i`,
+/// or None when the name is not a registry row / has no such parameter.
+///
+/// Companion to `registry_builtin_arity`, for the same reason and with the same
+/// cost profile: the checker's direct-call fast path avoids `lookup_builtin`
+/// because #626's seed-heap constraint was about BUILDING nested `CtFn`/`Array`
+/// values per call, and this reads the already-built row.
+///
+/// Returning the TYPE rather than a head kind keeps `head_kind` (and its
+/// tolerate-on-unknown rule) in the checker, which is the only place that knows
+/// what an "unchecked" head means.
+export fn registry_builtin_param_type(name: String, i: Int) -> Option[Type] {
+  let rows = builtin_registry_typed()
+  let mut ri = 0
+  let mut found = None
+  while ri < Array::length(rows) {
+    let (rname, ty, _, _, visible) = Array::get(rows, ri)
+    if rname == name && visible {
+      found = match ty {
+        CtFn(params, _, _) => if i >= 0 && i < Array::length(params) {
+          Some(Array::get(params, i))
+        } else {
+          None
+        },
+        _ => None
+      }
+      ri = Array::length(rows)
+    } else {
+      ri = ri + 1
     }
   }
   found

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -124,6 +124,7 @@ fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)]
 fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
 fn lookup_registry_builtin(name: String) -> Option[Type]
 fn registry_builtin_arity(name: String) -> Int
+fn registry_builtin_param_type(name: String, i: Int) -> Option[Type]
 fn verify_lane_builtins(lane: String, names: Array[String], param_counts: Array[Int], returns: Array[Int]) -> Unit with Exception
 fn verify_standard_effect_policy_coverage() -> Unit with Exception
 


### PR DESCRIPTION
`direct_call_return` の fast path に載る builtin は、引数の型が
`builtin_first_arg_head` / `builtin_arg_head_rest` という**手書きの表**に
載っているものだけ検査されていた。表は Array / String / Bytes / FixedArray しか
カバーしておらず、それ以外は compile も実行も通って garbage を出す
silent miscompile だった。

前段の arity 修正 (#1518) と同じ場所・同じ手口で、表を中央レジストリ
(`core/builtin_registry.vibe`) のパラメータ型へフォールバックさせる。

## 実測 (before → after)

| 形 | before | after |
|---|---|---|
| `Stdout::write_stream(42)` | compile も実行も通り garbage | `line 2:3-23: argument type mismatch for Stdout::write_stream: receiver type Int` |
| `Fs::read_file(7)` | 同上 | reject |
| `Env::args_get("x")` | 同上 | `line 2:11-24: ... receiver type String` |
| `Fs::write_file("a.txt", 3)` | 同上 | `line 2:3-17: ... (arg 1): Int` |
| `Char::to_int("a")` | 同上 | `line 2:11-23: ... receiver type String` |
| 正しい型の呼び出し / `Stdout::write_char(Char::from_int(65))` | ok | ok |

## 変更点

- `registry_builtin_param_type(name, i) -> Option[Type]` を追加。
  `registry_builtin_arity` と同じ理由・同じコスト特性 — #626 の seed ヒープ
  制約は「呼び出しごとに nested `CtFn`/`Array` を**構築する**」ことが問題で、
  構築済みの行を**読む**のは対象外
- checker 側は `builtin_param_head(name, i)` に集約。**手書きの表 → 無ければ
  レジストリ**の順なので、既に検査されていた呼び出しの verdict は変わらない
- head 比較で `CtChar` は `CtInt` に畳む (`head_fold_char`)。`Char` はこの言語では
  `Int` の別名 (lexer が char リテラルを `TInt` で出すので `'A' == 65`、
  `core/types.vibe` の `char_int_compatible` が両方向に unify を許す) であり、
  head 比較が `unify` の作らない区別を作ってはいけない。畳まないと
  レジストリで `CtChar` と書かれた `Char::to_int` が `Char::to_int('A')` を弾き、
  逆に `CtChar` の値が `CtInt` と書かれた `Stdout::write_char` に渡せなくなる
  (実際に prelude の `char.vibe` が落ちた)
- レジストリの `eq` 行を `reg_p2(CtInt, CtInt)` → `reg_p2(CtUnknown, CtUnknown)` に
  訂正。`eq` は構造的等価の builtin で多相 (兄弟の `assert_eq` は既に
  `CtUnknown`)。何もパラメータ型を読んでいなかった間は無害だったが、
  fast path が読み始めた瞬間に過剰 reject になった (`eq(Color::Red, c)` が
  `docs/language-tour/basics.vibe.md` で落ちた)。パラメータ数と戻り値は不変なので
  codegen 側が読む `builtin_registry()` ビューはバイト同一

## eval への影響

repair コーパスのケース 10 が silent → 診断ありに変わり、ラチェットが設計どおり
FAIL して採点し直しを要求した。`repair_convergence` **4.4 → 4.8**。
**コーパスから silent ケースが無くなった** (09/10 は「診断が出ないこと」を測る
ために置いた2件で、どちらも塞がった)。`type_soundness` を 4.0 → 3.0 に下げた理由
(rubric 4 の定義そのままの silent miscompile) も解消したので、次ラウンドの
見直し対象。

## 検証

- `scripts/compiler_gate.sh` RC=0 (93 sections / 75 typecheck fixtures / golden 10 / repair 10)
- `scripts/unit_test_runner.sh` **533/533**
- doctest 203 blocks — 0 fail
- examples 16 + 既知1 + new 0、playground 4 presets
- `scripts/check_vibe_fmt.sh` 911 files / 0 violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_