### PR TITLE
test(builtins): レジストリと lane 表の二重宣言を突き合わせる (#1520)

### DIFF
--- a/lib/@vibe/compiler/checker/builtins.vibe
+++ b/lib/@vibe/compiler/checker/builtins.vibe
@@ -69,36 +69,53 @@ export fn lookup_builtin(name: String) -> Option[Type] {
   let normalized = canonical_builtin_name(name)
   match lookup_registry_builtin(normalized) {
     Some(t) => Some(t),
-    None => match lookup_array(normalized) {
+    None => lookup_builtin_fallback(normalized)
+  }
+}
+
+/// The per-lane `lookup_*` chain, consulted only when the central registry
+/// (`core/builtin_registry.vibe`) has no checker-visible row for the name.
+///
+/// #1520: split out of `lookup_builtin` so a test can ask "which builtins are
+/// declared TWICE?" -- the registry short-circuits this chain, so a lane table
+/// that still carries an entry for a registry-backed name is a shadowed second
+/// declaration that nothing reads and nothing checks. That is exactly the
+/// state `eq` was in: `builtins_misc.vibe::lookup_eq` says `(Int, Int) -> Bool`
+/// while the registry (corrected in #1519) says `(?, ?) -> Bool`, and the
+/// disagreement was invisible because only the registry is ever consulted.
+///
+/// Takes an ALREADY-normalized name (`canonical_builtin_name`), like the lane
+/// lookups it delegates to.
+export fn lookup_builtin_fallback(normalized: String) -> Option[Type] {
+  match lookup_array(normalized) {
+    Some(t) => Some(t),
+    None => match lookup_fixed_array(normalized) {
       Some(t) => Some(t),
-      None => match lookup_fixed_array(normalized) {
+      None => match lookup_frozen_array(normalized) {
         Some(t) => Some(t),
-        None => match lookup_frozen_array(normalized) {
+        None => match lookup_array_builder(normalized) {
           Some(t) => Some(t),
-          None => match lookup_array_builder(normalized) {
+          None => match lookup_string1(normalized) {
             Some(t) => Some(t),
-            None => match lookup_string1(normalized) {
+            None => match lookup_string2(normalized) {
               Some(t) => Some(t),
-              None => match lookup_string2(normalized) {
+              None => match lookup_string_builder(normalized) {
                 Some(t) => Some(t),
-                None => match lookup_string_builder(normalized) {
+                None => match lookup_bytes(normalized) {
                   Some(t) => Some(t),
-                  None => match lookup_bytes(normalized) {
+                  None => match lookup_simd(normalized) {
                     Some(t) => Some(t),
-                    None => match lookup_simd(normalized) {
+                    None => match lookup_map(normalized) {
                       Some(t) => Some(t),
-                      None => match lookup_map(normalized) {
+                      None => match lookup_io(normalized) {
                         Some(t) => Some(t),
-                        None => match lookup_io(normalized) {
+                        None => match lookup_fs(normalized) {
                           Some(t) => Some(t),
-                          None => match lookup_fs(normalized) {
+                          None => match lookup_net(normalized) {
                             Some(t) => Some(t),
-                            None => match lookup_net(normalized) {
+                            None => match lookup_misc(normalized) {
                               Some(t) => Some(t),
-                              None => match lookup_misc(normalized) {
-                                Some(t) => Some(t),
-                                None => lookup_async(normalized)
-                              }
+                              None => lookup_async(normalized)
                             }
                           }
                         }

--- a/lib/@vibe/compiler/checker/builtins_misc.vibe
+++ b/lib/@vibe/compiler/checker/builtins_misc.vibe
@@ -41,9 +41,19 @@ fn misc_two_params(a: Type, b: Type) -> Array[Type] {
   arr
 }
 
+/// #1520: this is a SHADOWED declaration -- `eq` has a checker-visible registry
+/// row, and `lookup_builtin` consults the registry before this chain, so nothing
+/// reads it. It said `(Int, Int) -> Bool` while `eq` is the structural-equality
+/// builtin and is applied to enums / structs / strings; the registry carried the
+/// same untruth until #1519 made the checker read parameter types and
+/// `eq(Color::Red, c)` started being rejected. Kept in sync (rather than
+/// deleted) because 85 of the 154 registry rows are shadowed like this and
+/// deleting one of them would be an arbitrary partial cleanup -- the
+/// "registry and lane tables agree" test in tests/builtins_test.vibe is what
+/// makes the whole set self-checking.
 fn lookup_eq(name: String) -> Option[Type] {
   if name == "eq" {
-    Some(CtFn(misc_two_params(CtInt, CtInt), CtBool, None))
+    Some(CtFn(misc_two_params(CtUnknown, CtUnknown), CtBool, None))
   }
   else None
 }

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -83,6 +83,7 @@ generated_hash =
 
 // --- builtins.vibe
 fn lookup_builtin(name: String) -> Option[Type]
+fn lookup_builtin_fallback(normalized: String) -> Option[Type]
 
 // --- builtins_array.vibe
 fn lookup_array(name: String) -> Option[Type]

--- a/lib/@vibe/compiler/tests/builtins_test.vibe
+++ b/lib/@vibe/compiler/tests/builtins_test.vibe
@@ -1,11 +1,11 @@
 //# Imports
 
 import @vibe/compiler/checker {
-  lookup_builtin
+  lookup_builtin, lookup_builtin_fallback
 }
 
 import @vibe/compiler/core {
-  Type
+  Type, builtin_registry_typed, type_to_string
 }
 
 //# Misc
@@ -644,4 +644,47 @@ test "lookup_builtin println" {
     Some(_) => assert(true),
     None => assert(false)
   }
+}
+
+/// #1520: 85 of the 154 registry rows are ALSO declared in a per-lane
+/// `lookup_*` table. `lookup_builtin` consults the registry first, so those
+/// lane entries are shadowed -- nothing reads them, and nothing noticed when
+/// one drifted. That is the state `eq` was in: both sides claimed
+/// `(Int, Int) -> Bool` for the structural-equality builtin, and the untruth
+/// only surfaced when #1519 made the checker read the registry's parameter
+/// types and `eq(Color::Red, c)` started being rejected.
+///
+/// This locks the two declarations together. A row that resolves in BOTH
+/// places must render identically; fix the drift (or drop the shadowed lane
+/// entry) rather than relaxing this test. It does not require every registry
+/// row to have a lane twin -- only that the ones that do, agree.
+test "registry rows agree with their shadowed lane declarations" {
+  let rows = builtin_registry_typed()
+  let mut i = 0
+  let mut checked = 0
+  while i < Array::length(rows) {
+    let (name, ty, _, _, visible) = Array::get(rows, i)
+    if visible {
+      match lookup_builtin_fallback(name) {
+        Some(lane_ty) => {
+          let reg_s = type_to_string(ty)
+          let lane_s = type_to_string(lane_ty)
+          if reg_s == lane_s {
+            ()
+          } else {
+            println("registry/lane disagree for \{name}: registry \{reg_s} vs lane \{lane_s}")
+          }
+          assert(reg_s == lane_s)
+          checked = checked + 1
+        },
+        None => ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  // Guard against the test silently becoming vacuous (a refactor that makes
+  // the fallback chain unreachable would otherwise leave it green).
+  assert(checked > 50)
 }


### PR DESCRIPTION
#1520 の提案1。r5 の申し送り「診断の質を上げるより、**質が落ちたことに
気づく仕組み**が足りない」の最初のスライスでもある。

## 実測: 154 行中 85 行が二重宣言されている

レジストリ (`core/builtin_registry.vibe`) の 154 行のうち **85 行は
per-lane の `lookup_*` 表にも宣言がある**。`lookup_builtin` はレジストリを
先に引くので、その 85 件の lane 側 entry は**影に入っていて誰も読まない** —
片方がずれても誰も気づかない。

`eq` がまさにその状態だった。**両側が**構造的等価の builtin に対して
`(Int, Int) -> Bool` と主張しており、#1519 で checker がレジストリの
パラメータ型を読み始めて `eq(Color::Red, c)` が reject されるまで表に
出なかった。#1519 でレジストリ側だけ直したので、この PR の直前の main は
実際に**片側だけ正しい**状態だった。

## 変更

- `lookup_builtin` から fallback chain を `lookup_builtin_fallback` として
  切り出した。レジストリが hit しなかったときだけ引かれる経路そのもので、
  挙動は不変 (`lookup_builtin` = registry ?? fallback)
- `tests/builtins_test.vibe` に「**両方に解決する行は `type_to_string` が
  一致すること**」を検査するテストを追加。全レジストリ行に lane の双子を
  要求するのではなく、**あるものだけ**を縛る。テストが空回りしないよう
  検査件数 > 50 も assert した (fallback が到達不能になる refactor で
  黙って緑になるのを防ぐ)
- `builtins_misc.vibe::lookup_eq` を `(?, ?) -> Bool` に揃えた

`lookup_eq` は**削除ではなく同期**を選んだ。影の宣言が 85 件ある中で
1つだけ消すのは恣意的な部分整理で、テストが全体を self-checking にする方が
効く。85 件の二重宣言そのものは #1520 の債務として残す。

## ネガティブ確認

`lookup_eq` を `(Int, Int)` に戻すとテストが trap することを実測した
(assert 失敗 = trap)。テストが本当に今回のバグを捕まえることの確認。

## この PR が拾えないもの

#1520 で切り分けたとおり、これは**宣言どうしの食い違い**しか見ない。
`Char::to_int` のような **consumer 側の正規化漏れ**は宣言が正しいので
素通りする — そちらは #1520 の提案3 (ゴールデンな正例コーパス) の担当。

## 検証

- `scripts/compiler_gate.sh` RC=0 (93 sections / 75 typecheck fixtures)
- `scripts/unit_test_runner.sh` **533/533**
- doctest 203 blocks — 0 fail
- examples 16 + 既知1 + new 0、playground 4 presets
- `scripts/check_vibe_fmt.sh` 911 files / 0 violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxcnE3Vgrf2oc72eSmPC8K)_