### PR TITLE
名前解決が「複数ありうるもの」を1件で決めていた2件を直す (#1512 trait / #1491 修飾 ctor / #1521 未解決 import)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -28,7 +28,7 @@ import @vibe/compiler/core {
   subst_add_bound,
   subst_apply,
   subst_bounds_for,
-  trait_method_sig_deep,
+  trait_method_sig_binders_deep,
   type_implements_trait,
   type_name_has_iterator_impl,
   type_to_string,
@@ -197,13 +197,17 @@ fn resolve_trait_method_ident(name: String, env: TypeEnv, defs: Array[TypeDef], 
             }
             if pending {
               let trait_name = Array::get(bounds, bi)
-              match trait_method_sig_deep(env, trait_name, method) {
+              match trait_method_sig_binders_deep(env, trait_name, method) {
                 Some(sig) => {
-                  let (params_te, ret_te) = sig
+                  // #1512: the trait header's params and the method's own
+                  // generics are binders, so they must shadow `defs` —
+                  // otherwise `import { Hue as T }` captures the `T` of
+                  // `trait Boxed[T] { unwrap(Self) -> T }`.
+                  let (params_te, ret_te, binders) = sig
                   let resolved_params = for pte in params_te {
-                    relax_unknown_named(subst_self_in_type(resolve_type_expr(pte, defs), self_ty), defs)
+                    relax_unknown_named(subst_self_in_type(resolve_type_expr_shadowed(pte, defs, binders), self_ty), defs)
                   }
-                  let resolved_ret = relax_unknown_named(subst_self_in_type(resolve_type_expr(ret_te, defs), self_ty), defs)
+                  let resolved_ret = relax_unknown_named(subst_self_in_type(resolve_type_expr_shadowed(ret_te, defs, binders), self_ty), defs)
                   result = Some(CtFn(resolved_params, resolved_ret, None))
                 },
                 None => ()

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -87,6 +87,8 @@ export ./types.vibe {
   trait_defined,
   trait_is_subtrait,
   trait_method_sig,
+  trait_method_sig_binders,
+  trait_method_sig_binders_deep,
   trait_method_sig_deep,
   trait_supers,
   type_implements_trait,

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -196,6 +196,8 @@ fn trait_method_sig(env: TypeEnv, trait_name: String, method_name: String) -> Op
 fn type_name_has_iterator_impl(env: TypeEnv, type_name: String) -> Bool
 fn type_name_has_async_iterator_impl(env: TypeEnv, type_name: String) -> Bool
 fn trait_method_sig_deep(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr)]
+fn trait_method_sig_binders(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr, Array[String])]
+fn trait_method_sig_binders_deep(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr, Array[String])]
 fn subst_bounds_for(s: Subst, id: Int) -> Array[String]
 fn subst_apply(s: Subst, ty: Type) -> Type
 fn trait_defined(env: TypeEnv, name: String) -> Bool

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -399,14 +399,49 @@ export fn trait_supers(env: TypeEnv, name: String) -> Array[String] {
   }
 }
 
+/// The type formals in scope for one trait method's declared signature: the
+/// trait header's own params (`trait Iter[T]`) followed by that method's own
+/// generics (`map[U](Self, (T) -> U)`). Anything in this list is a binder, not
+/// a lookup into the surrounding type definitions.
+fn trait_method_binder_names(tparams: Array[String], method_gens: Array[(String, Array[String], Array[(String, Array[String])])], method_name: String) -> Array[String] {
+  let out = ArrayBuilder::new()
+  let mut i = 0
+  while i < Array::length(tparams) {
+    ArrayBuilder::push(out, Array::get(tparams, i))
+    i = i + 1
+  }
+  let mut j = 0
+  while j < Array::length(method_gens) {
+    let (mname, gparams, _) = Array::get(method_gens, j)
+    if mname == method_name {
+      let mut k = 0
+      while k < Array::length(gparams) {
+        ArrayBuilder::push(out, Array::get(gparams, k))
+        k = k + 1
+      }
+    } else {
+      ()
+    }
+    j = j + 1
+  }
+  ArrayBuilder::freeze(out)
+}
+
 /// Look up a trait method's declared signature (param TypeExprs + return
-/// TypeExpr) by trait name + method name. `Self` appears verbatim as
+/// TypeExpr) by trait name + method name, together with the type formals that
+/// signature binds (`trait_method_binder_names`). `Self` appears verbatim as
 /// `TyName("Self")` in the stored signature; the caller substitutes it.
-export fn trait_method_sig(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr)] {
+///
+/// The binders are NOT decoration: a caller that resolves the signature
+/// against the module's type definitions must let them shadow it, or an
+/// import alias with the same name captures the formal (#1512). This is the
+/// single env walk — `trait_method_sig` is a projection of it, so the two can
+/// never disagree about which trait a method came from.
+export fn trait_method_sig_binders(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr, Array[String])] {
   match env {
     EnvEmpty => None,
-    EnvBind(_, _, rest) => trait_method_sig(rest, trait_name, method_name),
-    EnvTraitDef(tname, _, _, methods, rest, _, _) => if tname == trait_name {
+    EnvBind(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
+    EnvTraitDef(tname, _, _, methods, rest, tparams, method_gens) => if tname == trait_name {
       let mlen = Array::length(methods)
       let mut i = 0
       let mut found = None
@@ -420,14 +455,30 @@ export fn trait_method_sig(env: TypeEnv, trait_name: String, method_name: String
         }
       }
       match found {
-        Some(sig) => Some(sig),
-        None => trait_method_sig(rest, trait_name, method_name)
+        Some(sig) => {
+          let (params, ret) = sig
+          Some((params, ret, trait_method_binder_names(tparams, method_gens, method_name)))
+        },
+        None => trait_method_sig_binders(rest, trait_name, method_name)
       }
-    } else trait_method_sig(rest, trait_name, method_name),
-    EnvTraitImpl(_, _, rest) => trait_method_sig(rest, trait_name, method_name),
-    EnvTraitImplGen(_, _, _, _, rest) => trait_method_sig(rest, trait_name, method_name),
+    } else trait_method_sig_binders(rest, trait_name, method_name),
+    EnvTraitImpl(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
+    EnvTraitImplGen(_, _, _, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
     EnvFlat(_) => None,
-    EnvCached(_, _, rest) => trait_method_sig(rest, trait_name, method_name)
+    EnvCached(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name)
+  }
+}
+
+/// Look up a trait method's declared signature (param TypeExprs + return
+/// TypeExpr) by trait name + method name. `Self` appears verbatim as
+/// `TyName("Self")` in the stored signature; the caller substitutes it.
+export fn trait_method_sig(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr)] {
+  match trait_method_sig_binders(env, trait_name, method_name) {
+    Some(found) => {
+      let (params, ret, _) = found
+      Some((params, ret))
+    },
+    None => None
   }
 }
 
@@ -538,11 +589,11 @@ export fn type_name_has_async_iterator_impl(env: TypeEnv, type_name: String) -> 
   type_name_async_iterator_impl_scan(env, env, type_name)
 }
 
-/// Like `trait_method_sig` but follows supertraits transitively, so a method
-/// inherited from a supertrait (`trait B: A` calling an `A` method on `[T: B]`)
-/// resolves. Trait hierarchies are acyclic, so the recursion terminates.
-export fn trait_method_sig_deep(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr)] {
-  match trait_method_sig(env, trait_name, method_name) {
+/// Like `trait_method_sig_binders` but follows supertraits transitively. The
+/// binders come from whichever trait actually declared the method, so an
+/// inherited method carries the SUPERtrait's formals, not the subtrait's.
+export fn trait_method_sig_binders_deep(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr, Array[String])] {
+  match trait_method_sig_binders(env, trait_name, method_name) {
     Some(sig) => Some(sig),
     None => {
       let supers = trait_supers(env, trait_name)
@@ -554,7 +605,7 @@ export fn trait_method_sig_deep(env: TypeEnv, trait_name: String, method_name: S
           _ => false
         }
         if pending {
-          match trait_method_sig_deep(env, Array::get(supers, i), method_name) {
+          match trait_method_sig_binders_deep(env, Array::get(supers, i), method_name) {
             Some(sig) => {
               result = Some(sig)
             },
@@ -567,6 +618,19 @@ export fn trait_method_sig_deep(env: TypeEnv, trait_name: String, method_name: S
       }
       result
     }
+  }
+}
+
+/// Like `trait_method_sig` but follows supertraits transitively, so a method
+/// inherited from a supertrait (`trait B: A` calling an `A` method on `[T: B]`)
+/// resolves. Trait hierarchies are acyclic, so the recursion terminates.
+export fn trait_method_sig_deep(env: TypeEnv, trait_name: String, method_name: String) -> Option[(Array[TypeExpr], TypeExpr)] {
+  match trait_method_sig_binders_deep(env, trait_name, method_name) {
+    Some(found) => {
+      let (params, ret, _) = found
+      Some((params, ret))
+    },
+    None => None
   }
 }
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2638,6 +2638,42 @@ fn fn_type_return_head() -> String {
   "->"
 }
 
+/// Does the fn_returns table record `fname` with return head `want` ANYWHERE,
+/// not just at its leftmost entry?
+///
+/// #1491: `fn_return_type` answers "what does the FIRST `fname` entry return",
+/// which silently loses every later duplicate. Constructor names are not
+/// unique across enums -- two enums in one merged compile can both declare
+/// `Red` -- so asking "is `Red` a variant of `Color`" through the first-match
+/// helper answers about whichever enum happened to sort first (`Paint`), and
+/// `Color::Red` fails the `qual_ctor_member` gate. The table already holds
+/// BOTH entries; only the lookup was lossy. Duplicates are adjacent because
+/// the table is sorted by name, so the run scan below is O(#duplicates).
+fn fn_returns_has_type(fn_returns: Array[(String, String)], fname: String, want: String) -> Bool {
+  let start = fn_returns_find(fn_returns, fname)
+  if start < 0 {
+    false
+  } else {
+    let mut i = start
+    let mut found = false
+    let mut done = false
+    while !done && i < Array::length(fn_returns) {
+      let (n, rt) = Array::get(fn_returns, i)
+      if n == fname {
+        if rt == want {
+          found = true
+          done = true
+        } else {
+          i = i + 1
+        }
+      } else {
+        done = true
+      }
+    }
+    found
+  }
+}
+
 fn fn_return_type(fn_returns: Array[(String, String)], fname: String) -> Option[String] {
   let idx = fn_returns_find(fn_returns, fname)
   if idx < 0 {
@@ -3014,13 +3050,16 @@ fn qual_ctor_member(head: String, member: String, struct_sets: Array[(String, Ar
   // `undefined variable (ident): C::Red`. A non-alias head resolves to itself.
   let head = resolve_alias_head(fn_returns, head)
   if struct_set_has(struct_sets, head) {
-    match fn_return_type(fn_returns, member) {
-      Some(en) => if en == head {
-        Some(member)
-      } else {
-        None
-      },
-      None => None
+    // #1491: ask whether `member` is recorded as a constructor of THIS enum,
+    // not what `member`'s first table entry returns. Constructor names collide
+    // across enums (`enum Color { Red }` next to an imported `enum Paint
+    // { Red }`), and the first-match form answered about the wrong enum, left
+    // the name qualified, and handed codegen -- whose ctor table is keyed
+    // unqualified -- `undefined variable (ident): Color::Red`.
+    if fn_returns_has_type(fn_returns, member, head) {
+      Some(member)
+    } else {
+      None
     }
   } else {
     None

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -162,12 +162,33 @@ fn bind_enum_constructor_companions(acc: TypeEnv, dep_bindings: Array[(String, T
   out
 }
 
-fn bind_import_names_from_cache(acc: TypeEnv, resolved: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)]) -> TypeEnv {
+/// #1521: an import of a name the dependency does not export binds `CtUnknown`
+/// below, which unifies with anything, so every USE of that name typechecks
+/// and the program only fails in codegen with `undefined variable (ident): X`
+/// -- no file, no line. `unresolved` collects those names so the caller can
+/// turn them into a real diagnostic; pass a throwaway array to opt out.
+///
+/// The `dep_known` guard is load-bearing. A dependency whose environment is
+/// not in this cache -- a `@pkg` import, or an entry not computed yet --
+/// yields `EnvEmpty`, and then EVERY name looks missing. Reporting those is a
+/// false positive on correct code, and it is the failure mode that sank the
+/// two earlier attempts at this check (one keyed off the merged environment,
+/// one off a lane `vibe check` does not use).
+///
+/// Only names the dependency's VALUE environment can speak for are reported:
+/// `starts_with_upper` names may be a struct or a type alias, and those are
+/// not bindings at all -- they live in `defs`, which this cache does not
+/// carry -- so "absent here" does not mean "not exported" for them. Enums and
+/// their constructors DO appear, but there is no way at this point to tell an
+/// unexported `Foo` from a struct-only `Foo`, so the uppercase half of #1521
+/// stays open rather than risk rejecting valid code.
+fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> TypeEnv {
   let dep_env = match lookup_env_cache(cache, resolved) {
     Some(e) => e,
     None => EnvEmpty
   }
   let dep_bindings = env_flat_bindings(dep_env)
+  let dep_known = Array::length(dep_bindings) > 0
   let nlen = Array::length(names)
   let rec bind_names: (Int, TypeEnv) -> TypeEnv = (j, nacc) -> {
     if j >= nlen {
@@ -180,7 +201,14 @@ fn bind_import_names_from_cache(acc: TypeEnv, resolved: String, names: Array[(St
       }
       let ty = match env_lookup_flat(dep_bindings, name) {
         Some(t) => t,
-        None => CtUnknown
+        None => {
+          if dep_known && !starts_with_upper(name) {
+            Array::push(unresolved, String::concat(String::concat(String::concat("imported name '", name), "' is not exported by '"), String::concat(raw_path, "'")))
+          } else {
+            ()
+          }
+          CtUnknown
+        }
       }
       let with_name = env_bind(nacc, bound_name, ty)
       let with_companions = match ty {
@@ -198,6 +226,13 @@ fn bind_import_names_from_cache(acc: TypeEnv, resolved: String, names: Array[(St
 }
 
 fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv {
+  build_import_env_collecting(stmts, base_dir, cache, array_empty())
+}
+
+/// `build_import_env`, additionally collecting the imported names the
+/// dependency does not export (#1521 -- see
+/// `bind_import_names_from_cache_collecting`).
+fn build_import_env_collecting(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> TypeEnv {
   let len = Array::length(stmts)
   let rec go: (Int, TypeEnv) -> TypeEnv = (i, acc) -> {
     if i >= len {
@@ -206,11 +241,11 @@ fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, 
       let next = match Array::get(stmts, i) {
         SImport(raw_path, names) => {
           let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache(acc, resolved, names, cache)
+          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved)
         },
         SReExport(raw_path, names) => {
           let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache(acc, resolved, names, cache)
+          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved)
         },
         _ => acc
       }
@@ -2109,7 +2144,14 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
   // propagate verbatim, while type errors get located and path-prefixed.
   // Folding both into one handler would relabel every parse diagnostic.
   let stmts = parse_program_with_path(job.path, job.source)
-  let import_env = build_import_env(stmts, dir_of_path(job.path), job.dep_envs)
+  // #1521: importing a name the dependency does not export used to bind
+  // CtUnknown silently, so `vibe check` said ok and `vibe build` died in
+  // codegen with `undefined variable (ident): X` -- no file, no line. The
+  // names are collected during env construction and reported here, before
+  // the body is checked, so the diagnostic names the import rather than
+  // whatever the body happened to do with it.
+  let unresolved_imports = array_empty()
+  let import_env = build_import_env_collecting(stmts, dir_of_path(job.path), job.dep_envs, unresolved_imports)
   // The CANONICAL fingerprint, computed the same way the serial walk
   // computes it (build_fingerprint, same file) from the same inputs: this
   // module's own source and each dependency's fingerprint in declaration
@@ -2118,31 +2160,37 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
   // driver would never look up, which would make a parallel pre-check pass
   // silently do nothing.
   let fingerprint = build_fingerprint(job.source, job.dep_fps)
-  handle {
-    let checked_env = match import_env {
-      EnvEmpty => check_program(stmts),
-      _ => check_program_with_env(stmts, import_env)
+  if Array::length(unresolved_imports) > 0 {
+    Diagnosed(job.path, for msg in unresolved_imports {
+      String::concat(String::concat(job.path, ": "), msg)
+    })
+  } else {
+    handle {
+      let checked_env = match import_env {
+        EnvEmpty => check_program(stmts),
+        _ => check_program_with_env(stmts, import_env)
+      }
+      let interface_identity = if incremental_interface_trace_enabled() {
+        incremental_interface_identity(job.source, checked_env)
+      } else {
+        ""
+      }
+      let checked_env_identity = if incremental_interface_trace_enabled() {
+        incremental_checked_env_identity(checked_env)
+      } else {
+        ""
+      }
+      let persistent_type_env_transport_identity = if incremental_interface_trace_enabled() {
+        incremental_persistent_type_env_transport_identity(checked_env)
+      } else {
+        ""
+      }
+      Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity)
+    } with Exception {
+      Throw(msg) => Diagnosed(job.path, [
+        String::concat(String::concat(job.path, ": "), locate_type_error(job.source, msg))
+      ])
     }
-    let interface_identity = if incremental_interface_trace_enabled() {
-      incremental_interface_identity(job.source, checked_env)
-    } else {
-      ""
-    }
-    let checked_env_identity = if incremental_interface_trace_enabled() {
-      incremental_checked_env_identity(checked_env)
-    } else {
-      ""
-    }
-    let persistent_type_env_transport_identity = if incremental_interface_trace_enabled() {
-      incremental_persistent_type_env_transport_identity(checked_env)
-    } else {
-      ""
-    }
-    Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity)
-  } with Exception {
-    Throw(msg) => Diagnosed(job.path, [
-      String::concat(String::concat(job.path, ": "), locate_type_error(job.source, msg))
-    ])
   }
 }
 /// Coordinator-owned commit. Every filesystem and accumulator write for a

--- a/lib/@vibe/compiler/tests/qualified_ctor_collision_test.vibe
+++ b/lib/@vibe/compiler/tests/qualified_ctor_collision_test.vibe
@@ -1,0 +1,68 @@
+//# #1491: a LOCAL enum's qualified constructor still resolves when an IMPORTED
+// enum happens to declare a variant of the same name.
+//
+// `Tone::Crimson` below is unambiguous by construction -- the qualifier names
+// the enum. It still failed, and only at codegen:
+//
+//     undefined variable (ident): Tone::Crimson | locals=[__env,]
+//
+// The unqualify in `desugar_trait_dict.vibe` (codegen's constructor table is
+// keyed by the BARE variant name, so `E::V` has to become `V` before it gets
+// there) asked "what does `Crimson` return" through a first-match lookup over
+// a table that holds every top-level name in the merged compile. Constructor
+// names are not unique across enums, so with `Hue` imported the answer was
+// `Hue` -- not the `Tone` the qualifier asked about -- the gate failed, the
+// name stayed qualified, and codegen had no entry for it. Both entries were
+// already in the table; only the lookup was lossy.
+//
+// The type checker accepted all of this, so nothing surfaced until `vibe
+// build`, with a message naming no file and no line.
+//
+// NOT covered here (a separate, deliberate limitation): qualifying the
+// IMPORTED enum in this same file -- `Hue::Cerulean` -- is rejected by the
+// checker with `unknown name`. `seed_imported_enum_defs` drops an imported
+// enum from `defs` entirely when any of its variant names is also declared
+// locally, to preserve #1078's "no two enums in defs share a variant name"
+// invariant. That is a design decision #1455 step 5 has to revisit, not a
+// regression this file should lock.
+
+//# Imports
+
+import ./qualified_ctor_enum_support.vibe {
+  Cerulean, Crimson, Hue
+}
+
+//# Types
+
+/// `Crimson` collides with the imported `Hue`'s variant of the same name.
+enum Tone {
+  Crimson;
+  Muted
+}
+
+//# Functions
+
+fn tone_rank(t: Tone) -> Int {
+  match t {
+    Crimson => 0
+    Muted => 1
+  }
+}
+
+fn hue_rank(h: Hue) -> Int {
+  match h {
+    Crimson => 10
+    Cerulean => 11
+  }
+}
+
+//# Tests
+
+test "a local qualified ctor survives a colliding imported variant name" {
+  assert_eq(tone_rank(Tone::Crimson), 0)
+  assert_eq(tone_rank(Tone::Muted), 1)
+}
+
+test "the imported enum still works under its own bare constructors" {
+  assert_eq(hue_rank(Cerulean), 11)
+}

--- a/lib/@vibe/compiler/tests/type_formal_shadowing_test.vibe
+++ b/lib/@vibe/compiler/tests/type_formal_shadowing_test.vibe
@@ -33,6 +33,29 @@ import ./qualified_ctor_enum_support.vibe {
 
 //# Types
 
+/// A trait HEADER formal. The signature is stored raw and only resolved when a
+/// bounded call `B::unwrap(..)` is typed, so this one leaks through a different
+/// path than the four below (`resolve_trait_method_ident`, not the `SStmt`
+/// binders).
+trait Boxed[T] {
+  unwrap(Self) -> T
+}
+
+/// A METHOD-level formal on a trait with no header params of its own -- the
+/// binder comes from `method_gens`, not from the trait header.
+trait Applier {
+  apply[T](Self, T) -> T
+}
+
+/// `IntBox` is declared FIRST among this file's structs on purpose: a bounded
+/// call `B::unwrap(b)` miscompiles ("not enough arguments on the stack for
+/// call") whenever the impl's target is not the file's first struct (#1529 --
+/// a separate, pre-existing codegen bug, reproduced identically on a pre-#1512
+/// compiler). Move `Cell` above this and the file stops instantiating.
+struct IntBox {
+  v: Int
+}
+
 /// The reported case. `Box[Int]` must be `Int`, not `Hue`.
 type Box[T] = T
 
@@ -92,6 +115,27 @@ fn hue_name(h: T) -> String {
   }
 }
 
+impl Boxed for IntBox {
+  unwrap(self) -> Int {
+    self.v
+  }
+}
+
+impl Applier for IntBox {
+  apply(self, x: Int) -> Int {
+    self.v + x
+  }
+}
+
+/// `B::unwrap` resolves the trait's stored signature at THIS call site.
+fn unwrap_via_trait[B: Boxed](b: B) -> Int {
+  B::unwrap(b)
+}
+
+fn apply_via_trait[A: Applier](a: A, x: Int) -> Int {
+  A::apply(a, x)
+}
+
 //# Tests
 
 test "type alias formal shadows an import alias" {
@@ -127,6 +171,18 @@ test "struct formal shadows an import alias" {
     v: 7
   }
   assert_eq(c.v, 7)
+}
+
+test "trait header formal shadows an import alias" {
+  assert_eq(unwrap_via_trait(IntBox::{
+    v: 7
+  }), 7)
+}
+
+test "trait method formal shadows an import alias" {
+  assert_eq(apply_via_trait(IntBox::{
+    v: 7
+  }, 5), 12)
 }
 
 test "an unshadowed import alias is still the imported type" {

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9602,4 +9602,108 @@ fn main {
 rm -rf "$endir"
 echo "[compiler-gate] imported enum variant lists ok"
 
+echo "[compiler-gate] 94/94 importing a name the dependency does not export is a CHECK error (#1521)"
+# #1521: `bind_import_names_from_cache` bound CtUnknown for an imported name
+# the dependency does not export. CtUnknown unifies with anything, so every
+# USE of that name typechecked -- `vibe check` said ok -- and the program
+# died in codegen with `undefined variable (ident): X`, naming no file and
+# no line. Worse than having no diagnostic: the import SUPPRESSED the
+# `unknown name` the same code gets without it.
+#
+# The negatives are the point of this section, not padding. Two earlier
+# attempts at this check passed their positives while silently breaking
+# valid code (or while wired into a lane `vibe check` never runs), so every
+# shape that must stay clean is pinned right next to the shapes that must
+# fail.
+uidir="_build/_gate_unresolved_import"
+rm -rf "$uidir"; mkdir -p "$uidir"
+cat > "$uidir/dep.vibe" <<'UIDEP'
+export enum Hue {
+  Crimson;
+  Cerulean
+}
+
+export fn hue_rank(h: Hue) -> Int {
+  match h {
+    Crimson => 0
+    Cerulean => 1
+  }
+}
+UIDEP
+ui_case() {
+  # ui_case <name> <expect: ok|err> <source>
+  local uname="$1" uexpect="$2" usrc="$3"
+  printf '%s' "$usrc" > "$uidir/$uname.vibe"
+  rm -f "$uidir/$uname.wasm" "$uidir/$uname.wasm.diag"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$uidir/$uname.vibe" "$uidir/$uname.wasm" _start >/dev/null 2>&1 || true
+  if [ "$uexpect" = "ok" ]; then
+    if [ ! -s "$uidir/$uname.wasm" ]; then
+      echo "[compiler-gate] FAIL: unresolved-import case '$uname' should compile but did not (#1521)" >&2
+      cat "$uidir/$uname.wasm.diag" 2>/dev/null >&2 || true
+      exit 1
+    fi
+  else
+    if [ -s "$uidir/$uname.wasm" ]; then
+      echo "[compiler-gate] FAIL: unresolved-import case '$uname' compiled; the bogus import was not caught (#1521)" >&2
+      exit 1
+    fi
+    if ! grep -q "is not exported by" "$uidir/$uname.wasm.diag" 2>/dev/null; then
+      echo "[compiler-gate] FAIL: unresolved-import case '$uname' was rejected by something OTHER than the #1521 check" >&2
+      cat "$uidir/$uname.wasm.diag" 2>/dev/null >&2 || true
+      exit 1
+    fi
+  fi
+}
+# 1. The reported shape: a value import that does not exist, and is used.
+ui_case bogus_used err 'import ./dep.vibe { no_such_fn }
+
+export let _start = () -> Int { no_such_fn(1) }
+'
+# 2. Reported even when UNUSED. The pre-existing "never used" warning fires
+#    here too, but "unused" is not "no such name" -- the import is still wrong.
+ui_case bogus_unused err 'import ./dep.vibe { no_such_fn }
+
+export let _start = () -> Int { 1 }
+'
+# 3. An alias does not launder it: the ORIGINAL name is what must exist.
+ui_case bogus_aliased err 'import ./dep.vibe { no_such_fn as f }
+
+export let _start = () -> Int { f(1) }
+'
+# 4-6. Every valid shape stays clean: plain value + type + constructor,
+#      the same through aliases, and constructors imported on their own.
+ui_case good_plain ok 'import ./dep.vibe { hue_rank, Hue, Crimson }
+
+export let _start = () -> Int { hue_rank(Crimson) }
+'
+ui_case good_aliased ok 'import ./dep.vibe { hue_rank as r, Hue as T, Crimson }
+
+fn pick() -> T { T::Crimson }
+
+export let _start = () -> Int { r(pick()) }
+'
+ui_case good_ctors ok 'import ./dep.vibe { Hue, Crimson, Cerulean }
+
+export let _start = () -> Int {
+  match Cerulean {
+    Crimson => 0
+    Cerulean => 1
+  }
+}
+'
+# 7. The DELIBERATE gap, pinned so a later change to it is a visible decision
+#    rather than a surprise: an uppercase name is not reported. A struct or a
+#    type alias is not a value binding at all (it lives in `defs`, which the
+#    dependency-environment cache does not carry), so "absent" cannot be told
+#    apart from "not exported" for uppercase names. Closing this needs the
+#    dependency's type definitions, not a tweak here.
+ui_case bogus_uppercase_not_reported ok 'import ./dep.vibe { Hue, NoSuchType }
+
+export let _start = () -> Int { 1 }
+'
+rm -rf "$uidir"
+echo "[compiler-gate] unresolved import names ok"
+
 echo "[compiler-gate] ok"


### PR DESCRIPTION
3件。**どれも型検査を素通りして codegen の内部用語エラーになる**という同じ出口を持っています。

| | 症状 | 原因の形 |
|---|---|---|
| #1512 follow-up | `return type mismatch: expected Int, got Hue` | 型仮引数が binder として渡っていない |
| #1491 | `undefined variable (ident): Color::Red` | 複数ありうる答えを**先頭一致で1件**だけ引いていた |
| #1521 | `undefined variable (ident): no_such_fn` | 情報が無いことを**「問題なし」と解釈**していた |

---

## 1. #1512 follow-up: trait の型仮引数も import エイリアスを shadow する

PR #1524 の Codex レビュー(P2)の指摘です。**実在のバグでした** — #1524 本文の「仮引数を持つ binder 6箇所すべて」は誤りで、7箇所目がありました。

```vibe
import ./dep.vibe { Hue as T }

trait Boxed[T] {
  unwrap(Self) -> T
}
```

`resolve_trait_method_ident` (`checker.vibe:200`) が trait のシグネチャを `resolve_type_expr` で shadow なしに解決しており、trait header の `tparams` も method の `method_gens` も resolver に渡っていませんでした。

**修正**: `trait_method_sig_binders` / `_deep` を追加し、既存の `trait_method_sig` / `_deep` を**その射影**にしました。env の walk を1本に保つためで、supertrait から継承したメソッドで「どの trait 由来か」について binder と signature が食い違う余地を構造的に消しています。#1512 では同じ enum payload を38行離れた2箇所で独立に解決していて片方だけ直した状態でテストが落ち続けたので、その再発を設計で防いでいます。

検証: positive 1 + 対照2(import なし / 仮引数を `U` に改名)の A/B。回帰テストは trait header 形と method generic 形の2件。

---

## 2. #1491: 修飾 constructor を「その enum」に対して解決する

```vibe
import ./dep.vibe { Paint, Red, Blue }   // Paint { Red; Blue }

enum Color { Red; Green }

let c = Color::Red      // undefined variable (ident): Color::Red
```

`qual_ctor_member` は codegen 前に `E::V` を `V` へ unqualify します(codegen の ctor テーブルは bare 名キー)。その判定を「`member` は `head` を返すか」で行い、`fn_return_type` = **マージ後コンパイル全体の名前を持つテーブルへの leftmost 二分探索**で引いていました。constructor 名は enum を跨いで一意ではないので、`Red` の答えは修飾子が指す `Color` ではなく `Paint` になり、gate を通らず修飾が残り、codegen にエントリが無い、という流れです。

`Red → Paint` と `Red → Color` は**両方すでにテーブルに入っており、引き方だけが lossy** でした。`fn_returns_has_type` が等キーの run(名前でソート済みなので隣接)を走査し、gate が本来意味していた「`member` は**この** enum の constructor として登録されているか」に答えます。

検証: 親コミットからビルドした stage2 との A/B で、報告ケースのみ REJ→ok(1)、他5ケース(imported enum の修飾 / bare ctor の shadowing / `String::length` / 拒否され続けるべき negative 2件)は不変。

**ここで直していない点**(テストファイルにも明記): 同じファイルで**imported** enum を修飾する形 (`Hue::Cerulean`) は checker が今も拒否します。`seed_imported_enum_defs` が #1078 の「defs 内で variant 名は一意」不変条件を守るため、variant 名がローカルと衝突する imported enum を defs から**意図的に落としている**ためです。#1455 step 5 で見直すべき設計判断であって、リグレッションではありません。

---

## 3. #1521: 依存先が export していない名前の import を報告する

`import ./dep.vibe { no_such_fn }` が型検査を通っていました。`bind_import_names_from_cache` が `CtUnknown` を束縛し、それが何とでも unify するので**その名前の使用がすべて通り**、`vibe check` は ok を返し、codegen で

```
undefined variable (ident): no_such_fn | locals=[__env,,__fn_val,__slot,__env]
```

と、ファイル名も行番号もなく pass の内部状態だけを見せて落ちていました。単に診断が無いのではなく、**import が「その名前は無い」という既存の診断を握り潰していました**。

`check_module` が import 環境の構築中にそれらを集め、body を検査する前に `Diagnosed` として返します:

```
m.vibe: imported name 'no_such_fn' is not exported by './dep.vibe'
```

`ModuleOutcome::Diagnosed` が既にあったので、driver まで throw を通す配線は不要でした。

**ガード2つ、どちらも効いています**:

- 依存先の環境がキャッシュに無いとき(`@pkg` import、未計算エントリ)は報告しません。`EnvEmpty` になり**全名前が「無い」ように見える**ためです。これは過去2回の試行が沈んだ失敗モードそのもので、1回目はマージ後の env を照合相手にし、2回目は `vibe check` が通らない lane に配線して**positive が全部通ったまま何もしていませんでした**。
- 大文字始まりの名前は範囲外です。struct と型エイリアスはそもそも値の束縛ではなく `defs` 側にあり、依存先環境のキャッシュはそれを運びません。よって大文字名について「ここに無い」と「export されていない」は区別できません。#1521 の大文字側を閉じるには依存先の型定義が要り、この検査の調整では済みません。

**#1521 が求めていた「厳格化前の件数」**: コンパイラ自身のソースはクリーンにビルドできるので **0件** です。

---

## 検証

- `pkf run test` **94/94**、exit 0(main 取り込み後のツリーで実行)。fixpoint (stage2==stage3) 込み
- 新ゲート節 94 は **negative を positive の隣に置いています** — bogus import 3形(使用 / 未使用 / エイリアス)が落ち、valid 3形と**意図的な大文字の穴**が clean であることを同時にピン留め。過去2回の試行は positive しか見ずに valid なコードを壊していたため
- 回帰テスト: `type_formal_shadowing_test.vibe` (+2), `qualified_ctor_collision_test.vibe` (新規、pre-fix コンパイラで報告どおりのメッセージで落ちることを確認)

## 副産物

**#1529**(新規 issue): impl 対象の struct がファイル内で最初の struct でないと、bounded 呼び出し `B::method(x)` が wasm instantiate で `not enough arguments on the stack for call` になります。#1491 とは別物(witness dict のインデックス vs ctor テーブルの引き方)で、#1512 以前のコンパイラでも同一に再現します。`type_formal_shadowing_test.vibe` は現状この制約を踏まない宣言順にしてあり、理由をコメントで参照しています。

Closes #1491
Closes #1521

---
_Generated by [Claude Code](https://claude.ai/code/session_01PENPDUZBtGEyxx27pMVtsa)_