### PR TITLE
失敗パターンを lint ルール化し、それが見つけた2件を直す (#1529 再診断 / #1491 の2箇所目)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -1846,9 +1846,26 @@ export fn resolve_local(names: Array[String], name: String, tag: String) -> Int 
     }
   }
   if result < 0 {
-    throw(String::concat(String::concat("undefined variable (local): ", name), String::concat(" @", tag)))
+    // A name reaching codegen unresolved is a CHECKER hole, not a user error:
+    // the checker either bound it or should have rejected it, and everything
+    // between accepted it. Every #1502 / #1510 / #1491 / #1521 / #1529 landed
+    // here, and the message said nothing a reader could act on -- no file, no
+    // line, and `locals=[__env,,__fn_val]` is pass state. Say whose bug it is.
+    throw(String::concat(String::concat(codegen_unresolved_name_prefix(), name), String::concat("` (local, @", String::concat(tag, codegen_unresolved_name_suffix()))))
   }
   result
+}
+
+/// Shared opening of the "a name survived type checking" internal error (see
+/// `resolve_local`). One spelling so the three codegen sites that can raise it
+/// -- linear locals, linear idents, and the gc backend -- cannot drift apart,
+/// and so a gate can pin the whole class by one string.
+export fn codegen_unresolved_name_prefix() -> String {
+  "internal compiler error: `"
+}
+
+export fn codegen_unresolved_name_suffix() -> String {
+  ") reached code generation unresolved. The type checker should have bound or rejected this name, so this is a bug in the compiler and not in your program -- please report the source that triggers it."
 }
 
 export fn emit_i64_store(buf: Bytes, align: Int, offset: Int) -> Unit {

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -175,6 +175,8 @@ fn get_slet_expr(stmt: Stmt) -> Expr with Exception
 fn get_slet_name(stmt: Stmt) -> String with Exception
 fn get_slet_type(stmt: Stmt) -> Option[TypeExpr]
 fn resolve_local(names: Array[String], name: String, tag: String) -> Int with Exception
+fn codegen_unresolved_name_prefix() -> String
+fn codegen_unresolved_name_suffix() -> String
 fn emit_i64_store(buf: Bytes, align: Int, offset: Int) -> Unit
 fn emit_box_float(buf: Bytes, ctx: CompileCtx, bits_local: Int, box_local: Int) -> Unit
 fn find_func_stmt(stmts: Array[Stmt], name: String) -> Stmt with Exception

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -33,6 +33,8 @@ import @vibe/compiler/codegen/common_base {
   agg_expr_of_ident,
   agg_info_of_ident,
   agg_log_reset_above2,
+  codegen_unresolved_name_prefix,
+  codegen_unresolved_name_suffix,
   cov_emit_branch,
   ctor_table_index_of,
   emit_binop_op,
@@ -899,7 +901,11 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
         } else {
           let __tf_result = func_table_index_of(ctx.func_table, name)
           if __tf_result < 0 {
-            let mut diag = String::concat("undefined variable (ident): ", name)
+            // See `resolve_local` in common_base: reaching here means the
+            // checker let an unresolved name through. Lead with whose bug it
+            // is; the locals dump stays for whoever debugs the compiler.
+            let mut diag = String::concat(codegen_unresolved_name_prefix(), name)
+            diag = String::concat(diag, String::concat("` (ident", codegen_unresolved_name_suffix()))
             diag = String::concat(diag, " | locals=[")
             let mut di = 0
             while di < len {

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -35,6 +35,8 @@ import @vibe/compiler/codegen/common_base {
   agg_log_reset_above,
   agg_ret_lookup,
   agg_slot_lookup,
+  codegen_unresolved_name_prefix,
+  codegen_unresolved_name_suffix,
   ctor_table_index_of,
   emit_binop_op,
   emit_i32_eq,
@@ -763,7 +765,9 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
             }
           }
           if fni < 0 {
-            throw(String::concat("undefined variable: ", name))
+            // See `resolve_local` in common_base: a checker hole, not a user
+            // error. Same wording as the two linear-backend sites.
+            throw(String::concat(String::concat(codegen_unresolved_name_prefix(), name), String::concat("` (gc ident", codegen_unresolved_name_suffix())))
           }
           let fidx = Array::get(ctx.func_table.indices, fni)
           let table_slot = fidx - ctx.func_offset

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -909,13 +909,18 @@ fn ctor_enum_of_name(fn_returns: Array[(String, String)], name: String) -> Optio
     None => match split_qualified(name) {
       Some(parts) => {
         let (head, member) = parts
-        match fn_return_type(fn_returns, member) {
-          Some(en) => if en == head {
-            Some(en)
-          } else {
-            None
-          },
-          None => None
+        // #1491 (second site): ask whether `member` is a constructor of THIS
+        // enum, not what `member`'s FIRST fn_returns entry returns.
+        // Constructor names collide across enums, so the first-match form
+        // answered about whichever enum sorted first and returned None for a
+        // perfectly good `Color::Green` -- leaving the binding untyped, which
+        // downstream means synth_dicts finds no witness and emits a call short
+        // its dictionary argument. Same defect as `qual_ctor_member`, same
+        // table, same fix.
+        if fn_returns_has_type(fn_returns, member, head) {
+          Some(head)
+        } else {
+          None
         }
       },
       None => None
@@ -1107,7 +1112,22 @@ fn infer_arg_type_name(arg: Expr, struct_sets: Array[(String, Array[String])], v
       },
       _ => None
     },
-    ERecord(_, fields, _) => {
+    // #1529: when the literal NAMES its struct (`IntBox::{ v: 7 }`), that name
+    // IS the answer. Re-deriving it from the field set picks the first struct
+    // with a matching shape, which is a DIFFERENT type as soon as two structs
+    // share a field set (`struct Plain { v: Int }` next to `struct IntBox
+    // { v: Int }`). The wrong name found no `impl` for the trait, synth_dicts
+    // silently produced nothing, and the call went out one argument short --
+    // surfacing only at instantiate as `not enough arguments on the stack for
+    // call`, naming neither the struct nor the call. Declaration order looked
+    // like the trigger because it decides which same-shaped struct is first.
+    //
+    // Shape matching stays for the ANONYMOUS form (`ERecord("", ..)`, #839
+    // top-level anonymous records and the witness records built by
+    // make_witness_record), where there is no written name to trust.
+    ERecord(rn, fields, _) => if String::length(rn) > 0 && struct_set_has(struct_sets, rn) {
+      Some(rn)
+    } else {
       let names = empty_str_array()
       let mut i = 0
       while i < Array::length(fields) {

--- a/scripts/architecture_debt_allowlist.txt
+++ b/scripts/architecture_debt_allowlist.txt
@@ -5,3 +5,13 @@
 #
 # Use * only for file-wide generated or transitional exceptions:
 # ARCH001	vibe/generated.vibe	*
+
+# scripts/ensure_generated.sh products. These embed compiler source as string
+# literals, so every rule matches its own subject text inside them. Permanent
+# file-wide exceptions, same as scripts/vibe_fmt_allowlist.txt carries.
+ARCH010	lib/@vibe/compiler/compiler_sources_bundle.vibe	*
+ARCH010	lib/@vibe/compiler/cli_adapter_bundle.vibe	*
+ARCH010	lib/@vibe/compiler/_cli_adapter_module_source.vibe	*
+ARCH011	lib/@vibe/compiler/compiler_sources_bundle.vibe	*
+ARCH011	lib/@vibe/compiler/cli_adapter_bundle.vibe	*
+ARCH011	lib/@vibe/compiler/_cli_adapter_module_source.vibe	*

--- a/scripts/architecture_debt_rules.tsv
+++ b/scripts/architecture_debt_rules.tsv
@@ -1,8 +1,20 @@
 # id	severity	scope	regex	message	issue
 #
-# Add project-specific stale-design rules here. Existing violations should be
-# recorded in scripts/architecture_debt_allowlist.txt first; after that, new
-# matches fail the lint task.
+# Project-specific stale-design rules, scanned by scripts/lint_architecture_debt.sh.
 #
-# Candidate examples:
-# ARCH001	error	vibe/**/*.vibe	String::concat\(acc,	avoid unbounded String::concat accumulators in hot loops	#428
+# severity:
+#   error  fails the run. Use once a rule's existing matches are all fixed or
+#          allowlisted, so any new match is a real regression.
+#   warn   reported, does not fail. Use while a shape still has known matches:
+#          the point is to keep them VISIBLE and countable, not to block work.
+#
+# Existing matches go in scripts/architecture_debt_allowlist.txt (exact line for
+# stable debt, `*` only for generated files). A `warn` rule does not need
+# allowlist entries -- that is the difference between the two severities.
+#
+# The two rules below are shapes that produced real, shipped defects. Neither
+# is wrong on its own; both are places where the code answers a DIFFERENT
+# question from the one it means to ask, so every match deserves a second look.
+
+ARCH010	warn	lib/@vibe/compiler/**/*.vibe	None => CtUnknown	absence of information treated as "anything goes": CtUnknown unifies with everything, so a name that could not be resolved typechecks and fails later in codegen. Confirm the fallback is a real "not our business" case, not a missing check	#1521
+ARCH011	warn	lib/@vibe/compiler/**/*.vibe	Some\([a-z_]+\) => if [a-z_]+ ==	single answer used to decide a membership question: a first-match lookup answers "what does the FIRST entry say", which is a different question from "does THIS one appear" whenever the table can hold the key twice (constructor names across enums, struct shapes, ctor->enum maps). Prefer a `has`/`contains` predicate over the run of equal keys	#1491

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9786,12 +9786,30 @@ for cg_site in \
   "lib/@vibe/compiler/codegen/expr/compile_expr.vibe" \
   "lib/@vibe/compiler/codegen/gc/backend_expr.vibe"
 do
+  # The load-bearing half: the OLD spelling must be gone. Asserting the new
+  # helper "appears in the file" does not do it -- common_base DEFINES the
+  # helper, so it matches whether or not `resolve_local` still calls it, and a
+  # revert there would sail through. (Codex review on PR #1562; the check was
+  # asking a different question from the one it meant, which is the very shape
+  # ARCH011 was added for.)
+  if grep -q '"undefined variable' "$ROOT_DIR/$cg_site"; then
+    echo "[compiler-gate] FAIL: $cg_site raises a bare \"undefined variable\" again" >&2
+    echo "[compiler-gate]       That message names no file, no line, and reads as the user's mistake." >&2
+    grep -n '"undefined variable' "$ROOT_DIR/$cg_site" >&2
+    exit 1
+  fi
   if ! grep -q "codegen_unresolved_name_prefix()" "$ROOT_DIR/$cg_site"; then
     echo "[compiler-gate] FAIL: $cg_site no longer routes its unresolved-name error through the shared wording" >&2
-    echo "[compiler-gate]       (a bare \"undefined variable\" throw is the unactionable form this replaced)" >&2
     exit 1
   fi
 done
+# ...and specifically INSIDE resolve_local, not merely somewhere in the file
+# that declares the helper.
+if ! awk '/^export fn resolve_local\(/,/^}/' "$ROOT_DIR/lib/@vibe/compiler/codegen/common_base/common_base.vibe" \
+  | grep -q "codegen_unresolved_name_prefix()"; then
+  echo "[compiler-gate] FAIL: resolve_local's own error no longer uses the shared wording" >&2
+  exit 1
+fi
 if ! grep -q 'internal compiler error' "$ROOT_DIR/lib/@vibe/compiler/codegen/common_base/common_base.vibe"; then
   echo "[compiler-gate] FAIL: the unresolved-name error no longer identifies itself as a compiler bug" >&2
   exit 1

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9766,4 +9766,50 @@ export let _start = () -> Int { public_fn(1) }
 rm -rf "$uidir"
 echo "[compiler-gate] unresolved import names ok"
 
+echo "[compiler-gate] 95/95 a name reaching codegen unresolved says it is a COMPILER bug (#1521/#1491/#1529)"
+# The shared exit of a whole family of defects. #1502, #1510, #1491, #1521,
+# #1529 and #1533 are unrelated in cause -- an alias qualifier, a first-match
+# lookup, a CtUnknown fallback, a struct shape collision -- and every one of
+# them surfaced the same way: the checker accepted the program, and codegen
+# died on a name it could not resolve, with a message naming no file, no line,
+# and `locals=[__env,,__fn_val]` (pass state).
+#
+# The three codegen sites that can raise it now say whose bug it is, in one
+# shared wording so they cannot drift. This section pins that wording, so the
+# next defect in this family arrives as "internal compiler error, report it"
+# rather than as something a user might read as their own mistake.
+#
+# It does NOT try to prove no program reaches those sites -- reaching them IS
+# the open-issue set. What it pins is that arriving there is legible.
+for cg_site in \
+  "lib/@vibe/compiler/codegen/common_base/common_base.vibe" \
+  "lib/@vibe/compiler/codegen/expr/compile_expr.vibe" \
+  "lib/@vibe/compiler/codegen/gc/backend_expr.vibe"
+do
+  if ! grep -q "codegen_unresolved_name_prefix()" "$ROOT_DIR/$cg_site"; then
+    echo "[compiler-gate] FAIL: $cg_site no longer routes its unresolved-name error through the shared wording" >&2
+    echo "[compiler-gate]       (a bare \"undefined variable\" throw is the unactionable form this replaced)" >&2
+    exit 1
+  fi
+done
+if ! grep -q 'internal compiler error' "$ROOT_DIR/lib/@vibe/compiler/codegen/common_base/common_base.vibe"; then
+  echo "[compiler-gate] FAIL: the unresolved-name error no longer identifies itself as a compiler bug" >&2
+  exit 1
+fi
+# And a normal program must NOT produce it -- the wording lock above is
+# worthless if the message fires on correct code.
+cgdir="_build/_gate_codegen_unresolved"
+rm -rf "$cgdir"; mkdir -p "$cgdir"
+printf 'enum Color {\n  Red;\n  Green\n}\n\nexport let _start = () -> Int {\n  match Color::Red {\n    Red => 1\n    Green => 2\n  }\n}\n' > "$cgdir/ok.vibe"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$cgdir/ok.vibe" "$cgdir/ok.wasm" _start >/dev/null 2>&1 || true
+if [ ! -s "$cgdir/ok.wasm" ]; then
+  echo "[compiler-gate] FAIL: a correct program hit the unresolved-name path" >&2
+  cat "$cgdir/ok.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$cgdir"
+echo "[compiler-gate] codegen unresolved-name error is legible ok"
+
 echo "[compiler-gate] ok"

--- a/scripts/lint_architecture_debt.sh
+++ b/scripts/lint_architecture_debt.sh
@@ -85,10 +85,32 @@ if [ ! -s "$findings" ]; then
   exit 0
 fi
 
-echo "architecture-debt lint: found new violations" >&2
+# `warn` is a standing REPORT of shapes worth a second look; only `error`
+# fails the run. Before this both severities exited 1, so `warn` was parsed
+# and validated but behaved identically to `error` -- a declaration nobody
+# read, which is the same class of defect several of these rules look for.
+#
+# The split is what makes a rule adoptable. A shape with dozens of existing
+# matches cannot start as `error` (the allowlist would need an entry per line
+# and would churn on every edit above one), and a fatal warn just gets the
+# whole lint switched off. A rule starts as `warn`, its matches get fixed or
+# justified, and it is promoted to `error` once the count reaches zero.
+error_count=0
+warn_count=0
 while IFS=$'\t' read -r severity rule_id rel_path line_no message issue text; do
   printf '%s:%s: %s %s: %s (%s)\n' \
     "$rel_path" "$line_no" "$severity" "$rule_id" "$message" "$issue" >&2
   printf '  %s\n' "$text" >&2
+  if [ "$severity" = "error" ]; then
+    error_count=$((error_count + 1))
+  else
+    warn_count=$((warn_count + 1))
+  fi
 done < "$findings"
-exit 1
+
+if [ "$error_count" -gt 0 ]; then
+  echo "architecture-debt lint: found new violations ($error_count error, $warn_count warn)" >&2
+  exit 1
+fi
+echo "architecture-debt lint: ok ($warn_count warn -- review, not a failure)"
+exit 0


### PR DESCRIPTION
今週の欠陥を分類して、機械的に抽出できる形を lint ルールにしました。**ルールを書いている最中にそのルールが2件の実バグを当てた**ので、あわせて直しています。

---

## 1. lint lane を使い始める

`scripts/architecture_debt_rules.tsv` は lint が書かれて以来**空**でした — コメント8行、ルール0件。`pkf run lint-architecture` は何も言ったことがありません。

### まず `warn` に意味を与える

スクリプトは `error|warn` を検証したうえで**どちらも exit 1** していました。2つの severity は区別不能で、**宣言はあるが誰も読んでいない** — ARCH010 が探しているのと同じ種類の欠陥です。`error` のみ失敗、`warn` は報告して 0 を返すようにしました。

この分離がルールの採用可能性を決めます。既存一致が多い形は `error` で始められません(allowlist が行番号キーなので、一致箇所より上を編集するたび churn する)し、失敗する warn はただの error です。ルールは `warn` で入り、一致が1つずつ解消され、0 になったら `error` に昇格します。

### 登録した2ルール

**ARCH010** `None => CtUnknown` — 情報の欠如を「何とでも unify する」に落とす形。未解決の名前が型検査を通り codegen で死にます。**#1521 そのもの**。9件。

**ARCH011** `Some(x) => if y == ..` — 先頭一致1件で membership を判定する形。「**最初の**エントリは何と言うか」と「**これ**が入っているか」は、テーブルが同じキーを2回持ちうるとき別の質問です — enum 跨ぎの constructor 名 (#1491)、struct の形 (#1529)、ctor→enum 表。7件。

どちらも `warn` です。形そのものが誤りではなく、目的は母集団を可視・可算に保つことであって作業を止めることではありません。

生成物3ファイル(`ensure_generated.sh` の産物)は自身の中にコンパイラソースを文字列として埋め込んでおり、あらゆるルールが自分の対象文字列に一致するので、`vibe_fmt_allowlist.txt` と同じく恒久的な file-wide 例外にしています。

現在の出力: **16 warn、exit 0**。

---

## 2. ARCH011 が見つけた2件

どちらも親コミットからビルドした stage2 との A/B で確定。

### #1529 — issue に書いた私の診断が間違っていました

「impl 対象の struct がファイル内で最初の struct でないと壊れる」と書きましたが、**宣言順は症状**です。`infer_arg_type_name` の `ERecord` 腕が**書かれた struct 名を捨てて**、field 集合を全 struct と突き合わせて先頭一致で引き直していました:

```vibe
struct Plain  { v: Int }     // 形 {v}
struct IntBox { v: Int }     // 形 {v}、impl を持つのはこちら
unwrap_via_trait(IntBox::{ v: 7 })
```

`IntBox::{ .. }` はノードに `IntBox` を持っています。腕は代わりに field 集合に尋ね、`Plain` を得て、`impl Boxed for Plain` が無いので synth_dicts が何も生成せず、dictionary 引数が1つ足りない呼び出しが出ます。instantiate 時に `not enough arguments on the stack for call (need 3, got 2)` として現れ、struct も呼び出しも名指ししません。宣言順は「同形の struct のどちらが先か」を決めていただけで、だから field 名を変えると「直った」のです。

| | pre | post |
|---|---|---|
| 同じ field 集合 `{v}` | **FAIL** | **PASS** |
| 名前違い `{w}` | PASS | PASS |
| 数違い `{v,u}` | PASS | PASS |

名前付きリテラルはその名前に解決します。形一致は無名形 (`ERecord("", ..)`) にのみ残しました — そこには信用すべき名前がありません。

issue #1529 は訂正済みです。

### #1491 の2箇所目

`ctor_enum_of_name` が `qual_ctor_member`(#1491 で修正済み)と同じ「1件引いてから比較」の形で残っていました。**1関数しか離れておらず、そのとき見落としました。** constructor 名は enum を跨いで衝突するので `Color::Green` は先にソートされた enum を経由して None になり、束縛が未型付けのまま残ります。`==` では隠れます(構造的 eq がフォールバックで、しかも結果は正しい)が、trait ディスパッチでは隠れません:

| | pre | post |
|---|---|---|
| 衝突する import + `let a = Color::Green; call_named(a)` | **FAIL** | **PASS** |
| 衝突なし | PASS | PASS |

---

## 3. 共通の出口に名前を付ける

#1502 / #1510 / #1491 / #1521 / #1529 / #1533 は原因が別々です(エイリアス修飾子、先頭一致、`CtUnknown` フォールバック、struct の形衝突)。**出口は全部同じ**で、checker がプログラムを受理し、codegen が解決できない名前で死に、メッセージはファイル名も行番号も無く `locals=[__env,,__fn_val]`(pass の内部状態)を見せます。

その3箇所が共有文言を使うようになりました:

```
internal compiler error: `X` (ident) reached code generation unresolved.
The type checker should have bound or rejected this name, so this is a bug in
the compiler and not in your program -- please report the source that triggers it.
```

ゲート95節が、3箇所すべてが共有文言を経由すること、文言が自身をコンパイラのバグと明示すること、そして**正しいプログラムではこの経路に入らないこと**(でなければ文言のロックは無意味)を固定します。

「どのプログラムもこの経路に到達しない」ことは証明しません — 到達することが未解決 issue の集合そのものです。固定するのは、到達したときに**読めること**です。

---

## 検証

- `pkf run test` **95/95**、exit 0(fixpoint 込み)、最新 main の上に rebase 済み
- lint 自己テスト通過(`error` の挙動は不変)、リポジトリ実行で 16 warn / exit 0
- 上記2件の A/B と、対照(衝突なし / 形違い)が不変であること

## 関連

- #1529(再診断して修正)、#1491(2箇所目)、#1521 / #1533(ARCH010 の由来)
- #1520(「誰も読んでいない宣言」の先例 — `warn` の扱いはその実例でした)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PENPDUZBtGEyxx27pMVtsa)_