### PR TITLE
chore(toolchain): pkfire を MoonBit 版 v0.14.2 へ pin し、Go 版の再発を塞ぐ

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -93,25 +93,44 @@ fi
 
 # --- 4. pkfire (pkf) -----------------------------------------------------
 # pkf is the canonical task runner (Taskfile.pkl). It is not in nixpkgs, so we
-# install it from the upstream flake. Pinned to the same tag CI uses
-# (mizchi/pkfire@v0.10.0). The github: fetcher hits the rate-limited GitHub API,
-# so use the git+https fetcher which works unauthenticated.
+# install it from the upstream flake, pinned to the same tag CI uses
+# (.github/actions/setup-vibe + pkfire-pkspec.yml — keep the three in sync).
+# The github: fetcher hits the rate-limited GitHub API, so use the git+https
+# fetcher which works unauthenticated.
+#
+# pkfire was rewritten in MoonBit (the flake installs the prebuilt release
+# binary since v0.12); tags up to v0.10.0 built the RETIRED Go implementation.
+# Never pin below v0.12 — a stale pin silently hands every fresh container the
+# Go binary again.
 #
 # IMPORTANT: install into a DEDICATED profile, never the default one. The
 # nix-installer's default profile (~/.nix-profile) is classic-managed and holds
 # the `nix` binary itself; running `nix profile install` against it starts a
 # fresh manifest and would drop `nix` from PATH. A separate profile keeps both.
 NIX="$HOME/.nix-profile/bin/nix"
+PKF_VERSION="0.14.2"
 PKF_PROFILE="$HOME/.nix-profiles/pkfire"
 PKF_BIN="$PKF_PROFILE/bin/pkf"
+# Long-lived containers keep whatever the profile last held (the hook used to
+# skip install when the binary existed). Verify the version and wipe a stale
+# profile so the pin above is the single source of truth. The retired Go build
+# reports "dev", so it always mismatches and gets replaced.
+if [ -x "$PKF_BIN" ]; then
+  PKF_INSTALLED="$("$PKF_BIN" --version 2>/dev/null || true)"
+  if [ "$PKF_INSTALLED" != "$PKF_VERSION" ]; then
+    echo "[session-start] pkf ${PKF_INSTALLED:-unknown} != $PKF_VERSION; replacing stale install ..."
+    rm -f "$PKF_PROFILE"
+    rm -rf "$PKF_PROFILE"-*-link
+  fi
+fi
 if [ -x "$NIX" ] && ! [ -x "$PKF_BIN" ]; then
-  echo "[session-start] installing pkfire (pkf) via nix ..."
-  # nix builds Go modules without a sandbox here; an existing /homeless-shelter
+  echo "[session-start] installing pkfire (pkf) $PKF_VERSION via nix ..."
+  # nix evaluates/builds without a sandbox here; an existing /homeless-shelter
   # breaks the purity check, so clear it before building.
   rm -rf /homeless-shelter 2>/dev/null || true
   mkdir -p "$(dirname "$PKF_PROFILE")"
   "$NIX" profile install --profile "$PKF_PROFILE" \
-    'git+https://github.com/mizchi/pkfire?ref=refs/tags/v0.10.0' \
+    "git+https://github.com/mizchi/pkfire?ref=refs/tags/v$PKF_VERSION" \
     --extra-experimental-features 'nix-command flakes' || \
     echo "[session-start] WARNING: pkf install failed" >&2
 fi

--- a/.github/actions/setup-vibe/action.yml
+++ b/.github/actions/setup-vibe/action.yml
@@ -49,7 +49,9 @@ runs:
 
     - name: Install pkfire (pkl + pkf)
       if: inputs.pkfire == 'true'
-      uses: mizchi/pkfire@v0.10.0
+      # MoonBit build (>= v0.12; v0.10.0 and below = retired Go implementation).
+      # Keep in sync with pkfire-pkspec.yml and .claude/hooks/session-start.sh.
+      uses: mizchi/pkfire@v0.14.2
 
     # pkfire content-addressed CAS cache. Use restore+save semantics so
     # cache hits short-circuit task replay even when inputs hash drifts;

--- a/.github/workflows/pkfire-pkspec.yml
+++ b/.github/workflows/pkfire-pkspec.yml
@@ -38,9 +38,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pkfire (pkf)
-        uses: mizchi/pkfire@v0.10.0
-        with:
-          version: pkfire@0.10.0
+        # MoonBit build (>= v0.12). Tags up to v0.10.0 were the retired Go
+        # implementation — never pin below v0.12. Keep in sync with
+        # .github/actions/setup-vibe/action.yml and .claude/hooks/session-start.sh.
+        uses: mizchi/pkfire@v0.14.2
 
       - name: pkf format --check
         run: pkf format --check Taskfile.pkl

--- a/docs/pkfire-pkspec.md
+++ b/docs/pkfire-pkspec.md
@@ -34,7 +34,7 @@ nix run github:mizchi/pkfire -- list
 go install github.com/mizchi/pkfire/cmd/pkf@latest
 ```
 
-CI uses the `mizchi/pkfire@v0.10.0` composite action via
+CI uses the `mizchi/pkfire@v0.14.2` composite action via
 `.github/actions/setup-vibe` (set `pkfire: 'true'` on the caller). Pass
 `pkfire-cache: 'true'` to also hydrate `~/.cache/pkfire`.
 


### PR DESCRIPTION
エージェントが retired な Go 版 pkf を使っている事例の再発防止。

## 原因

pin の取り残し。pkfire は MoonBit で書き直され（v0.12 以降の flake は prebuilt MoonBit binary を配布）、**v0.10.0 以前の tag は Go 実装をビルドする**。この repo は 3 箇所で v0.10.0 を pin していた:

| 供給源 | 影響 |
|---|---|
| `.claude/hooks/session-start.sh` の nix install ref | **fresh container 全数**がここで Go 版を掴む |
| `.github/actions/setup-vibe/action.yml` | main CI |
| `.github/workflows/pkfire-pkspec.yml` | Pkl 検証 gate |

## 変更

1. **3 箇所を v0.14.2 へ**。相互参照コメントと「v0.12 未満に pin しない（Go 版に戻る）」を各所に明記。pkfire-pkspec.yml の `with: version:` 入力は削除（新 action は自身の ref から version を読むので二重管理だった）
2. **stale container の置換ガード** — hook は「binary があれば install スキップ」だったため、長寿命 container は古い pkf を持ち続けた。`pkf --version` が pin と不一致なら dedicated profile を破棄して再インストールする。Go 版は `dev` を返すので必ず置換される

## 実測

- v0.14.2 の nix インストール（git+https fetcher、proxy 経由）成功、`pkf --version` = `0.14.2`
- この repo の Taskfile.pkl で `pkf list` / `pkf hooks install` / pre-commit hook 動作確認
- ガード live 試験: Go 版 `dev` を持つ実 container で hook 実行 → 検出・置換・0.14.2 化。2 回目は no-op（冪等）
- `/homeless-shelter` 除去は prebuilt 化後も必要（wrapper drv のビルドが purity check に当たる）ため残置

## 残件（この PR の範囲外）

「apm」側の経路は、この container・repo・upstream pkfire のいずれにも見つからなかった（PATH 無し / `~/.apm` 無し / pkfire README は brew・install.sh・nix・GitHub Action のみ）。apm がどこで pkf を配っているか教えてもらえれば同様に pin を直します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM)_