### PR TITLE
feat(check): run the ADR-0076 effect-lowering eligibility passes at vibe check (#1536(c)/#1511(b))

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1245,8 +1245,11 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
 
 ### `handle` は型検査を通っても**コンパイルできない**ことがある
 
-`vibe check` は codegen まで行かないので、この失敗は**型検査では見えない**。
-`vibe build` / `vibe test` / doctest まで行って初めて出る:
+適格性は型システムの一部ではないので、この失敗は**型検査そのものでは見えない**。
+ただし **`vibe check` は #1511(b)/#1536(c) 以降、型検査の後に codegen と同じ
+効き方の適格性判定 (ADR-0076 の effect-lowering prelude) を走らせる**ため、
+`vibe check` / `vibe build` / `vibe test` / doctest のどれでも同じエラーが出る
+(`vibe diagnostics` は単一ファイル解析なので対象外):
 
 ```
 handle of effect 'Ask' cannot be compiled here. Every perform this handle

--- a/examples/perform_handle.vibe
+++ b/examples/perform_handle.vibe
@@ -10,6 +10,10 @@ effect Log {
 
 //# Functions
 
+fn add(a: Int, b: Int) -> Int {
+  a + b
+}
+
 // fail: () -> Int with Exception
 fn fail() -> Int with Exception {
   throw("division by zero")

--- a/lib/@vibe/compiler/_cli.vibe
+++ b/lib/@vibe/compiler/_cli.vibe
@@ -11,10 +11,17 @@ import ./type_db.vibe {
 //# Functions
 
 export fn main() -> Int with Exception + Fs + Process + Env + Stdout + Stdin {
-  let batch_tsv = perform Env::Get("VIBE_BATCH_TSV")
-  let input_path = perform Env::Get("VIBE_INPUT")
-  let output_path = perform Env::Get("VIBE_OUTPUT")
-  let entry = perform Env::Get("VIBE_ENTRY")
+  // #1536(c)/#1511(b): direct capability builtin calls, not `perform
+  // Env::Get`. The perform form made the whole merged program "user-performs
+  // Env", which kept the module-private label-pun `effect Env` handles
+  // (cache_underlying.vibe / module_graph_path.vibe) out of vacuous-handle
+  // erasure — and those handles cannot migrate, so this entry never actually
+  // compiled (latent: only the offbuild TYPECHECK gate ever looked at it,
+  // and check learned to run the eligibility prelude in this slice).
+  let batch_tsv = Env::get("VIBE_BATCH_TSV")
+  let input_path = Env::get("VIBE_INPUT")
+  let output_path = Env::get("VIBE_OUTPUT")
+  let entry = Env::get("VIBE_ENTRY")
   if not(batch_tsv == "") {
     let jobs = parse_batch_jobs_tsv(batch_tsv)
     let _ = compile_jobs_cached(db_new(), jobs)

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -166,6 +166,12 @@ export fn build_linked_debug_entry(input_path: String, entry_name: String) -> (B
 /// expressiveness gaps (parse errors, type errors, genuine unknown names)
 /// WITHOUT the codegen builtin-body-linking confounder that makes the `debug`
 /// mode emit spurious `undefined variable: Ns::method`. No wasm is produced.
+/// #1536(c)/#1511(b): "typecheck only" no longer means blind to effect-lowering
+/// eligibility — check_file_fs_mode below also runs the ADR-0076 prelude
+/// (suspend CPS split + evidence-passing migration, shared verbatim with the
+/// real compile) on the merged program, so a handle/suspend shape codegen
+/// would reject fails here instead of first failing at build/test/doctest.
+/// Still no wasm and no builtin-body linking.
 export fn check_linked_file(input_path: String) -> Int with Exception + Fs {
   // #946(3): parse the entry file OURSELVES first (located + recovering —
   // see the import comment above) so a parse error is reported with an exact

--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -47,6 +47,7 @@ fn compile_wasi_module_with_sources_coverage_impl(stmts: Array[Stmt], entry_name
 fn compile_wasi_module_with_sources_trace_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)]) -> Bytes with Exception
 fn compile_wasi_module_with_sources_break_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], prov: DbgProv) -> Bytes with Exception
 fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], linked_imports: Array[(String, String, Int, Int)], library_mode: Bool, enable_rc: Bool, coverage: Bool, debug_trace: Bool, debug_break: Bool, rc_shadow: Bool, prov: DbgProv, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, slice_lo: Int, slice_hi: Int) -> Bytes with Exception
+fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked_imports: Array[(String, String, Int, Int)], iw_names: Array[String], iw_wats: Array[String]) -> Array[String] with Exception
 fn compile_wasi_module_replayed_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_sliced_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -2877,102 +2877,124 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
   }
 }
 
-export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], linked_imports: Array[(String, String, Int, Int)], library_mode: Bool, enable_rc: Bool, coverage: Bool, debug_trace: Bool, debug_break: Bool, rc_shadow: Bool, prov: DbgProv, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, slice_lo: Int, slice_hi: Int) -> Bytes with Exception {
+/// #1536(c) / #1511(b): the ADR-0076 effect-lowering pass prefix of
+/// compile_wasi_module_linked_impl, split out so `vibe check` can run the
+/// EXACT eligibility judgement codegen applies (suspend CPS split +
+/// evidence-passing migration) without producing wasm — sharing the code is
+/// what guarantees check and codegen can never disagree on what is eligible.
+/// Returns the errors instead of throwing; an empty result means every pass
+/// accepted the program and `stmts` now holds the lowered form the rest of
+/// codegen consumes. All of these passes REWRITE `stmts` in place — a
+/// check-lane caller must pass a merged AST it is about to discard.
+/// `iw_names`/`iw_wats` receive the extracted inline-wasm texts (the compile
+/// path emits them later; check discards them).
+export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked_imports: Array[(String, String, Int, Int)], iw_names: Array[String], iw_wats: Array[String]) -> Array[String] with Exception {
+  let errs = lc_fresh_string_array()
   // ADR-0091 Phase 1: enforce `@zero_alloc` markers before any lowering
   // rewrites the marked bodies. No-op when no marker is present.
   let za_msg = zero_alloc_check(stmts)
   if za_msg != "" {
-    throw(za_msg)
+    Array::push(errs, za_msg)
   } else {
-    ()
+    // Method-bearing-trait dictionary passing (#641 PR-3). Universal codegen
+    // convergence point — runs here on the fully merged program before generic
+    // type params are stripped (just below). No-op unless a method-bearing trait
+    // is declared, and idempotent if an earlier pipeline stage already desugared.
+    desugar_trait_dicts(stmts)
+    // #1262: split eligible tuple-literal `let mut`s (what every `loop (s = ..)`
+    // lowers to) into scalar `let mut`s -- no per-iteration tuple box. Runs on
+    // both linear entries (compile_module has the same call); gc/interp lanes
+    // keep the boxed form, and the rewrite is semantics-preserving so the
+    // cross-lane differential gates still agree.
+    unbox_tuple_loop_params(stmts)
+    // Top-level `let f = g` function aliases: retarget references to the final
+    // EFn def so calls do not route through the 0-param thunk registration
+    // below (invalid wasm for any call arity). See import_alias_rewrite.vibe.
+    rewrite_top_level_fn_alias_refs(stmts)
+    // #805: inline-wasm fns — extract WAT texts + neutralize marker bodies
+    // BEFORE any analysis below (see lc_extract_inline_wasm's doc comment).
+    lc_extract_inline_wasm(stmts, iw_names, iw_wats)
+    // #tco: rewrite a top-level function's self-tail-recursive calls into the
+    // same ELetMut/EWhile/EBreak/EContinue shape `loop (...) { continue(...) }`
+    // already lowers to (see self_tail_call.vibe) -- zero wasm call-stack
+    // growth per recursive step instead of an unbounded `call`. No-op unless a
+    // function is directly self-tail-recursive; runs before the borrow/scalar-
+    // return analyses below so they see the rewritten (loop-shaped) body.
+    // #1230 (docs/spec/wasi-p3-async.md M1b-3c): expand `await(f)` into the
+    // suspend-and-retry loop a PENDING future needs. Runs right after
+    // desugar_trait_dicts (which is what produces the `await(..)` call of an
+    // async-iterator `for` loop) and BEFORE every effect pass below, so the
+    // `perform Async::Suspend(1)` it synthesizes is seen by them exactly like a
+    // hand-written one -- lowering `await` inside compile_call, where it used to
+    // live, is past the point where a perform can still be handled.
+    // waiter_hooks (ADR-0089 #1218): when @vibex/concurrent's direct-wake
+    // hooks are callable (linked imports or local defs), poll rounds route
+    // through __aw_wait so a Future::resolve can wake the awaiter directly.
+    await_poll_pass(stmts, lc_stmts_call_host_future(stmts), lc_waiter_hooks_available(stmts, linked_imports))
+    rewrite_self_tail_calls(stmts)
+    // #944 (ADR-0073 stage C): entry-boundary Error handler -- see
+    // lc_wrap_entry_error_boundary's doc comment. Runs BEFORE the effect
+    // passes below so the synthesized handle is visible to them like any
+    // hand-written one, and before collect_used_builtin_names so the
+    // diagnostic's Stderr host import is collected.
+    lc_wrap_entry_error_boundary(stmts, entry_name)
+    let async_sleep_boundary_err = lc_inject_async_sleep_boundary(stmts, entry_name)
+    if async_sleep_boundary_err != "" {
+      Array::push(errs, async_sleep_boundary_err)
+    } else {
+      // ADR-0076 (#817) Phase 2: inline `perform` calls that are structurally
+      // reachable-only-via-tail-resumptive-handler-arms directly into their
+      // handler arm body (single-shot fast path). Conservative: bails out
+      // per-handle whenever the handled body contains anything (nested
+      // `handle`, closures, or calls to named functions) that could hide a
+      // perform outside this direct scan, leaving those to evidence_dict_pass
+      // below (which, since 追記34 V2 removed the replay engine, hard-errors on
+      // any live non-Error handle it cannot migrate).
+      // ADR-0076 Phase 3a (#817, docs/effect-evidence-passing.md 追記27):
+      // depth-0 suspend CPS for handle sites whose arms capture `resume` as a
+      // first-class value (the suspend class -- ADR-0068's Async::suspend
+      // shape). Runs BEFORE the Phase 2 / evidence passes below so they only
+      // ever see the sites this pass left alone (a transformed site has no
+      // EHandle left at all). A triggered-but-ineligible site is a hard
+      // compile error -- a value-referencing arm cannot compile on the replay
+      // path, so silent fallback is not an option.
+      let scps_errs = suspend_cps_pass(stmts)
+      if Array::length(scps_errs) > 0 {
+        Array::push(errs, Array::get(scps_errs, 0))
+      } else {
+        inline_direct_performs(stmts)
+        // ADR-0076 (#817) Phase 3, first slice: evidence-dict threading for the
+        // narrow case Phase 2 above cannot reach on its own -- a handle body that
+        // calls a named top-level function which itself performs the handled
+        // effect (docs/effect-evidence-passing.md "追記 2", evidence_dict_pass's
+        // own doc comment in common_base/inline_direct_perform.vibe -- appended to
+        // that existing cross-file-registered file rather than a new one, to
+        // avoid the bootstrap flatten gotcha documented in docs/effectset.md).
+        // Runs after Phase 2 so it only sees the handles Phase 2 did
+        // not already fully inline; whole-program-conservative and strictly
+        // additive (per-effect all-or-nothing), so it never touches a handle or
+        // function Phase 2 already resolved or that this pass cannot prove safe.
+        let edp_errs = evidence_dict_pass(stmts, entry_name)
+        if Array::length(edp_errs) > 0 {
+          Array::push(errs, Array::get(edp_errs, 0))
+        } else {
+          ()
+        }
+      }
+    }
   }
-  // Method-bearing-trait dictionary passing (#641 PR-3). Universal codegen
-  // convergence point — runs here on the fully merged program before generic
-  // type params are stripped (just below). No-op unless a method-bearing trait
-  // is declared, and idempotent if an earlier pipeline stage already desugared.
-  desugar_trait_dicts(stmts)
-  // #1262: split eligible tuple-literal `let mut`s (what every `loop (s = ..)`
-  // lowers to) into scalar `let mut`s -- no per-iteration tuple box. Runs on
-  // both linear entries (compile_module has the same call); gc/interp lanes
-  // keep the boxed form, and the rewrite is semantics-preserving so the
-  // cross-lane differential gates still agree.
-  unbox_tuple_loop_params(stmts)
-  // Top-level `let f = g` function aliases: retarget references to the final
-  // EFn def so calls do not route through the 0-param thunk registration
-  // below (invalid wasm for any call arity). See import_alias_rewrite.vibe.
-  rewrite_top_level_fn_alias_refs(stmts)
-  // #805: inline-wasm fns — extract WAT texts + neutralize marker bodies
-  // BEFORE any analysis below (see lc_extract_inline_wasm's doc comment).
+  errs
+}
+
+export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], linked_imports: Array[(String, String, Int, Int)], library_mode: Bool, enable_rc: Bool, coverage: Bool, debug_trace: Bool, debug_break: Bool, rc_shadow: Bool, prov: DbgProv, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, slice_lo: Int, slice_hi: Int) -> Bytes with Exception {
+  // #1536(c)/#1511(b): the whole effect-lowering prefix lives in
+  // effect_lowering_prelude (shared verbatim with `vibe check`); a first
+  // error there is exactly the throw each pass used to raise inline here.
   let iw_names = lc_fresh_string_array()
   let iw_wats = lc_fresh_string_array()
-  lc_extract_inline_wasm(stmts, iw_names, iw_wats)
-  // #tco: rewrite a top-level function's self-tail-recursive calls into the
-  // same ELetMut/EWhile/EBreak/EContinue shape `loop (...) { continue(...) }`
-  // already lowers to (see self_tail_call.vibe) -- zero wasm call-stack
-  // growth per recursive step instead of an unbounded `call`. No-op unless a
-  // function is directly self-tail-recursive; runs before the borrow/scalar-
-  // return analyses below so they see the rewritten (loop-shaped) body.
-  // #1230 (docs/spec/wasi-p3-async.md M1b-3c): expand `await(f)` into the
-  // suspend-and-retry loop a PENDING future needs. Runs right after
-  // desugar_trait_dicts (which is what produces the `await(..)` call of an
-  // async-iterator `for` loop) and BEFORE every effect pass below, so the
-  // `perform Async::Suspend(1)` it synthesizes is seen by them exactly like a
-  // hand-written one -- lowering `await` inside compile_call, where it used to
-  // live, is past the point where a perform can still be handled.
-  // waiter_hooks (ADR-0089 #1218): when @vibex/concurrent's direct-wake
-  // hooks are callable (linked imports or local defs), poll rounds route
-  // through __aw_wait so a Future::resolve can wake the awaiter directly.
-  await_poll_pass(stmts, lc_stmts_call_host_future(stmts), lc_waiter_hooks_available(stmts, linked_imports))
-  rewrite_self_tail_calls(stmts)
-  // #944 (ADR-0073 stage C): entry-boundary Error handler -- see
-  // lc_wrap_entry_error_boundary's doc comment. Runs BEFORE the effect
-  // passes below so the synthesized handle is visible to them like any
-  // hand-written one, and before collect_used_builtin_names so the
-  // diagnostic's Stderr host import is collected.
-  lc_wrap_entry_error_boundary(stmts, entry_name)
-  let async_sleep_boundary_err = lc_inject_async_sleep_boundary(stmts, entry_name)
-  if async_sleep_boundary_err != "" {
-    throw(async_sleep_boundary_err)
-  } else {
-    ()
-  }
-  // ADR-0076 (#817) Phase 2: inline `perform` calls that are structurally
-  // reachable-only-via-tail-resumptive-handler-arms directly into their
-  // handler arm body (single-shot fast path). Conservative: bails out
-  // per-handle whenever the handled body contains anything (nested
-  // `handle`, closures, or calls to named functions) that could hide a
-  // perform outside this direct scan, leaving those to evidence_dict_pass
-  // below (which, since 追記34 V2 removed the replay engine, hard-errors on
-  // any live non-Error handle it cannot migrate).
-  // ADR-0076 Phase 3a (#817, docs/effect-evidence-passing.md 追記27):
-  // depth-0 suspend CPS for handle sites whose arms capture `resume` as a
-  // first-class value (the suspend class -- ADR-0068's Async::suspend
-  // shape). Runs BEFORE the Phase 2 / evidence passes below so they only
-  // ever see the sites this pass left alone (a transformed site has no
-  // EHandle left at all). A triggered-but-ineligible site is a hard
-  // compile error -- a value-referencing arm cannot compile on the replay
-  // path, so silent fallback is not an option.
-  let scps_errs = suspend_cps_pass(stmts)
-  if Array::length(scps_errs) > 0 {
-    throw(Array::get(scps_errs, 0))
-  } else {
-    ()
-  }
-  inline_direct_performs(stmts)
-  // ADR-0076 (#817) Phase 3, first slice: evidence-dict threading for the
-  // narrow case Phase 2 above cannot reach on its own -- a handle body that
-  // calls a named top-level function which itself performs the handled
-  // effect (docs/effect-evidence-passing.md "追記 2", evidence_dict_pass's
-  // own doc comment in common_base/inline_direct_perform.vibe -- appended to
-  // that existing cross-file-registered file rather than a new one, to
-  // avoid the bootstrap flatten gotcha documented in docs/effectset.md).
-  // Runs after Phase 2 so it only sees the handles Phase 2 did
-  // not already fully inline; whole-program-conservative and strictly
-  // additive (per-effect all-or-nothing), so it never touches a handle or
-  // function Phase 2 already resolved or that this pass cannot prove safe.
-  let edp_errs = evidence_dict_pass(stmts, entry_name)
-  if Array::length(edp_errs) > 0 {
-    throw(Array::get(edp_errs, 0))
+  let prelude_errs = effect_lowering_prelude(stmts, entry_name, linked_imports, iw_names, iw_wats)
+  if Array::length(prelude_errs) > 0 {
+    throw(Array::get(prelude_errs, 0))
   } else {
     ()
   }

--- a/lib/@vibe/compiler/codegen/wasi/wasi.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/wasi.vibe
@@ -21,7 +21,8 @@ export ./linked_compile.vibe {
   compile_wasi_module_with_sources_break_impl,
   compile_wasi_module_with_sources_coverage_impl,
   compile_wasi_module_with_sources_impl,
-  compile_wasi_module_with_sources_trace_impl
+  compile_wasi_module_with_sources_trace_impl,
+  effect_lowering_prelude
 }
 
 export fn compile_wasi_module_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception {

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -53,7 +53,7 @@ import @vibe/compiler/codegen/common_base {
 }
 
 import @vibe/compiler/codegen/wasi {
-  compile_wasi_module_impl
+  compile_wasi_module_impl, effect_lowering_prelude
 }
 
 import @vibe/compiler/loader {
@@ -469,7 +469,26 @@ export fn prepare_file_fs_cached(db: TypeDb, entry_path: String) -> TypeDb with 
 /// compile_file_fs_mode already relies on for a real compile's (working)
 /// typecheck pass -- and stop before build_grouped_merged_stmts/codegen.
 export fn check_file_fs_mode(entry_path: String) -> Int with Exception + Fs {
-  let _ = prepare_file_fs_cached(db_new(), entry_path)
+  let source_groups = collect_source_groups_fs(entry_path)
+  let _ = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
+  // #1536(c) / #1511(b): after the typecheck passes, run the ADR-0076
+  // effect-lowering eligibility passes (suspend CPS split + evidence-passing
+  // migration) on the SAME merged program a release compile lowers
+  // (build_grouped_merged_stmts over the same source_groups), via the same
+  // shared prelude compile_wasi_module_linked_impl runs — so a handle/suspend
+  // shape codegen would reject is reported here, at `vibe check`, instead of
+  // typechecking cleanly and first failing in codegen. The merged AST is
+  // discarded afterwards (the prelude rewrites it in place); no wasm is
+  // produced. Entry name "main" matches what `vibe build`/`vibe run` compile
+  // with; a program with no `main` simply has no entry-keyed boundary
+  // machinery installed, same as its real compile would.
+  let merged_stmts = build_grouped_merged_stmts(source_groups)
+  let lowering_errs = effect_lowering_prelude(merged_stmts, "main", array_empty(), array_empty(), array_empty())
+  if Array::length(lowering_errs) > 0 {
+    throw(Array::get(lowering_errs, 0))
+  } else {
+    ()
+  }
   0
 }
 

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -128,3 +128,56 @@ test "check_linked_file: wrong-typed call to an imported function throws (#946 P
   assert(String::contains(msg, "f"))
   assert(msg != "")
 }
+
+/// #1511(b) / #1536(c): a `handle` whose body calls a LOCAL CLOSURE hides the
+/// perform from evidence-passing migration (ADR-0076) — the exact shape the
+/// cheatsheet's 落とし穴 table records as NG. It typechecks, so before this
+/// slice `vibe check` said "ok" and the error first appeared at
+/// build/test/doctest time. check_linked_file now runs the same
+/// effect-lowering prelude codegen runs, so it must throw HERE.
+test "check_linked_file: handle body calling a local closure fails eligibility at check (#1511)" {
+  let path = "/tmp/vibe_cli_support_check_edp_ineligible.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Ask { Ask() -> Int }\nfn ask_once() -> Int with Ask { perform Ask::Ask() }\nexport fn main() -> Int {\n  let bump = (x: Int) -> Int { x + 1 }\n  handle { bump(ask_once()) } with Ask {\n    Ask() => resume(10)\n  }\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "cannot be compiled here"))
+}
+
+/// The eligible counterpart: the same handle with the perform statically
+/// visible (direct call to a named top-level fn) must keep checking clean —
+/// the new prelude run must not reject programs codegen accepts.
+test "check_linked_file: eligible handle still checks clean (#1511)" {
+  let path = "/tmp/vibe_cli_support_check_edp_eligible.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Ask { Ask() -> Int }\nfn ask_once() -> Int with Ask { perform Ask::Ask() }\nexport fn main() -> Int {\n  handle { ask_once() } with Ask {\n    Ask() => resume(10)\n  }\n}\n"))
+  let rc = check_linked_file(path)
+  assert(rc == 0)
+}
+
+/// #1536(c): the suspend class (an arm capturing `resume` as a value) with a
+/// perform OFF the eligible spine — inside a `for` form (docs/cheatsheet.md
+/// 制約: loop 内の perform は compile error). suspend_cps_pass rejects this at
+/// codegen; check_linked_file must now surface the same error.
+test "check_linked_file: suspend-class handle with perform in a for loop fails at check (#1536)" {
+  let path = "/tmp/vibe_cli_support_check_scps_ineligible.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Sus { Suspend(Int) -> Int }\nlet conts: Array[(Int) -> Int] = []\nexport fn main() -> Int {\n  handle {\n    let mut acc = 0\n    for j in [1, 2] {\n      acc = acc + (perform Sus::Suspend(j))\n    }\n    acc\n  } with Sus {\n    Suspend(t) => {\n      Array::push(conts, resume)\n      0 - t\n    }\n  }\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "suspend class"))
+}
+
+/// The suspend-class counterpart that IS eligible (perform on the let spine,
+/// resume captured as a value) — must keep checking clean.
+test "check_linked_file: eligible suspend-class handle still checks clean (#1536)" {
+  let path = "/tmp/vibe_cli_support_check_scps_eligible.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Sus { Suspend(Int) -> Int }\nlet conts: Array[(Int) -> Int] = []\nexport fn main() -> Int {\n  handle {\n    let a = perform Sus::Suspend(1)\n    a * 10\n  } with Sus {\n    Suspend(t) => {\n      Array::push(conts, resume)\n      0 - t\n    }\n  }\n}\n"))
+  let rc = check_linked_file(path)
+  assert(rc == 0)
+}


### PR DESCRIPTION
Closes #1511（(b) check レーン統合）。#1536 は (c) をここで実装、(a) の evidence 拡張が残るので open のまま。

> async/concurrency lane (session `01C6kJcn3gNTJwvjWYb52yr3`) の成果物。当該 session が GitHub API 遮断でPR を作れないため coordinator session が代理で起票。

## What

`vibe check` が release compile と**同じ** effect-lowering eligibility 判定を走らせるようにする。これまで handle/suspend の形が codegen で拒否されるファイルは typecheck を素通りして build/test/doctest で初めて落ちていた（P1「書けない」が check で見えない）。

- `compile_wasi_module_linked_impl` の pass 前段 (`zero_alloc_check` → `desugar_trait_dicts` → … → `suspend_cps_pass` → `inline_direct_performs` → `evidence_dict_pass`) を `effect_lowering_prelude` として抽出（throw ではなくエラー返却、compile 側は従来どおり最初のエラーを throw）
- `check_file_fs_mode` が release compile と同じ merged program (`build_grouped_merged_stmts`, entry `main`, 空 `linked_imports`) に同じ prelude を適用
- **コード共有そのものが check と codegen の判定不一致を構造的に不可能にする**（別実装の再現ではなく同一実装の再利用）

## 新検出が掘り出した潜在バグ 2 件（本 PR で修正）

1. `examples/perform_handle.vibe` — 未定義 `add` を呼んでいた（typecheck は通るが codegen body 無し、#1520/#1521 のクラス）。`vibe run` は今日でも落ちる状態だった
2. `lib/@vibe/compiler/_cli.vibe` — `perform Env::Get` により merged program が user-perform Env になり、label-pun `effect Env` の handle が vacuous-handle 消去から外れて**この off-manifest entry は実はコンパイル不能だった**。capability builtin (`Env::get`) 呼び出しへ移行

## Tests / Verification

- `check_linked_file` 回帰テスト 4 件: #1511 の local-closure callee NG 形 / #1536 の suspend-class for-loop NG 形 + それぞれの eligible 対
- compiler_gate 95/95 + fixpoint ok、offbuild 65/65、examples 0 fail、playground presets 4/4
- 4 fixture すべてで check ↔ compile の判定一致を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM)_