### PR TITLE
incremental: shadow planner vs compiler decision diff を CI artifact 化 (#1548)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,18 @@ jobs:
           echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Compiler gate
         run: bash scripts/compiler_gate.sh
+      - name: Upload incremental shadow decision diff (#1548)
+        # compiler_gate.sh step 3aa writes the shadow planner vs current
+        # compiler decision diff (only after a successful oracle run).
+        # Uploading it keeps the conservative over-invalidation residual
+        # observable per run — "permitted but visible" (docs/incremental-
+        # build.md Roadmap invariants) — without promoting any observation
+        # into a production cache key or reuse decision.
+        uses: actions/upload-artifact@v4
+        with:
+          name: incremental-shadow-decision-diff
+          path: _build/ci-artifacts/incremental-shadow-decision-diff.json
+          if-no-files-found: error
       - name: Selfcompile KPI heap gate (#987)
         # One real compile through the gate's freshly-built stage2, gated on
         # the linear backend's bump-allocator high-water (heap_ptr_bytes).

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -676,6 +676,20 @@ plan with the relational model rows, requires every planned module to appear as
 `rechecked`, and reports additional rechecks as conservative over-invalidation.
 A missing required recheck fails the oracle.
 
+With `VIBE_SHADOW_DECISION_DIFF_OUT=<path>` the oracle additionally publishes
+that comparison as a versioned `incremental_shadow_decision_diff` v1 JSON
+artifact (#1548): per bounded edit case, each module's shadow decision
+(`recheck_required`/`typing_reusable`) against the current compiler decision
+(`rechecked`/`reused`), classified as agreement or
+`conservative_over_invalidation`. A requested stale artifact is deleted before
+the run and the new one is published atomically only after every case
+succeeded, so a failed run leaves nothing; a missing required recheck fails
+the oracle before publication and is never a published row. The gate writes it
+to `_build/ci-artifacts/incremental-shadow-decision-diff.json` and CI uploads
+it, making the over-invalidation residual visible per run. The artifact
+records current conservative behavior only — none of its fields is a
+production cache key or reuse decision.
+
 The existing private body case is also emitted under the explicit observation
 classification `private_dependency_edit_externally_unchanged`. That classifier
 fails closed unless `app` has exactly `library` as its sole direct dependency in

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -73,8 +73,14 @@ VIBE_RC=0 node scripts/artifact_input_trace_oracle.mjs "$stage2_wasm"
 # checks source/token-stream/interface/checked-env parity without incorporating
 # the new observation into a production cache key, cache format, or reuse
 # decision. Ordinary compiler-source fingerprint invalidation still applies.
+# #1548: the oracle also publishes the shadow planner vs current compiler
+# decision diff into _build/ci-artifacts/ (CI uploads it), keeping the
+# conservative over-invalidation residual visible per run instead of a log line.
 echo "[compiler-gate] 3aa/3 incremental invalidation observation oracle"
-VIBE_RC=0 node scripts/incremental_invalidation_oracle.mjs "$stage2_wasm"
+mkdir -p _build/ci-artifacts
+VIBE_RC=0 \
+  VIBE_SHADOW_DECISION_DIFF_OUT="$ROOT_DIR/_build/ci-artifacts/incremental-shadow-decision-diff.json" \
+  node scripts/incremental_invalidation_oracle.mjs "$stage2_wasm"
 
 # 3ab. #1379 opt-in metadata-only ingestion stamp: isolated equivalent cache
 # histories prove observed successful-check invalidation/output equivalence and

--- a/scripts/incremental_invalidation_oracle.mjs
+++ b/scripts/incremental_invalidation_oracle.mjs
@@ -11,9 +11,16 @@
 // exported-interface fingerprints; none is read by or incorporated into a
 // production cache key here. The normal compiler-source fingerprint still
 // invalidates compiler artifacts after any compiler source change.
+//
+// #1548: VIBE_SHADOW_DECISION_DIFF_OUT=<path> additionally publishes the
+// per-case shadow planner vs current compiler decision diff as a versioned
+// JSON artifact — only after every case succeeded (a failed run deletes the
+// requested path and publishes nothing). CI uploads it so the conservative
+// over-invalidation residual stays visible per run.
 
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -280,6 +287,107 @@ export function compareObservedInvalidation(before, after) {
   return { planned, observed, conservative_over_invalidation: observed.filter((path) => !plannedSet.has(path)) };
 }
 
+const shadowDecisionDiffSchema = "incremental_shadow_decision_diff";
+const shadowDecisionDiffScopeNote = "shadow planner decisions derive from observation-only fingerprints and are not production cache keys or reuse decisions; conservative over-invalidation is the permitted visible residual; a missing required recheck fails the oracle before this artifact is published, so no published row records one";
+
+/// Diff one bounded edit case: the shadow planner's decision against the
+/// current TypeDb decision, per module in trace order. A missing required
+/// recheck is a failure, never a published row (Roadmap invariants).
+export function buildShadowDecisionDiffCase(name, before, after) {
+  const planned = new Set(planObservedTypingInvalidation(before, after));
+  const modules = after.modules.map((module) => {
+    const shadow_decision = planned.has(module.path) ? "recheck_required" : "typing_reusable";
+    const compiler_decision = module.decision;
+    let classification;
+    if (shadow_decision === "recheck_required" && compiler_decision === "rechecked") classification = "agreement_recheck";
+    else if (shadow_decision === "typing_reusable" && compiler_decision === "reused") classification = "agreement_reuse";
+    else if (shadow_decision === "typing_reusable" && compiler_decision === "rechecked") classification = "conservative_over_invalidation";
+    else fail(`shadow decision diff for ${name} would publish a missing required recheck for ${module.path}`);
+    return { path: module.path, shadow_decision, compiler_decision, classification };
+  });
+  return {
+    case: name,
+    modules,
+    conservative_over_invalidation: modules
+      .filter((row) => row.classification === "conservative_over_invalidation")
+      .map((row) => row.path),
+  };
+}
+
+/// Aggregate the per-case diffs into the versioned CI artifact (#1548). The
+/// artifact records current conservative behavior; it is not a reuse rule.
+export function buildShadowDecisionDiffArtifact(cases, { scenario, stage2_sha256 }) {
+  const totals = { agreement_recheck: 0, agreement_reuse: 0, conservative_over_invalidation: 0 };
+  for (const diffCase of cases) {
+    for (const row of diffCase.modules) totals[row.classification] += 1;
+  }
+  return {
+    schema: shadowDecisionDiffSchema,
+    version: 1,
+    scenario,
+    stage2_sha256,
+    scope_note: shadowDecisionDiffScopeNote,
+    cases,
+    totals,
+  };
+}
+
+/// Strict parse of the published diff artifact. Consumers must reject rather
+/// than repair: unknown fields, inconsistent classifications, and total drift
+/// all fail so a torn or hand-edited artifact cannot pass as evidence.
+export function parseShadowDecisionDiffArtifact(text) {
+  let artifact;
+  try {
+    artifact = JSON.parse(text);
+  } catch (error) {
+    fail(`shadow decision diff: invalid JSON (${error.message})`);
+  }
+  if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) fail("shadow decision diff: expected object");
+  exactKeys(artifact, ["schema", "version", "scenario", "stage2_sha256", "scope_note", "cases", "totals"], "shadow decision diff");
+  if (artifact.schema !== shadowDecisionDiffSchema) fail(`shadow decision diff: unsupported schema ${JSON.stringify(artifact.schema)}`);
+  if (artifact.version !== 1) fail(`shadow decision diff: unsupported version ${JSON.stringify(artifact.version)}`);
+  if (typeof artifact.scenario !== "string" || artifact.scenario.length === 0) fail("shadow decision diff: missing scenario");
+  if (typeof artifact.stage2_sha256 !== "string" || !/^[0-9a-f]{64}$/.test(artifact.stage2_sha256)) fail("shadow decision diff: invalid stage2_sha256");
+  if (artifact.scope_note !== shadowDecisionDiffScopeNote) fail("shadow decision diff: dishonest scope_note");
+  if (!Array.isArray(artifact.cases) || artifact.cases.length === 0) fail("shadow decision diff: missing cases");
+  const totals = { agreement_recheck: 0, agreement_reuse: 0, conservative_over_invalidation: 0 };
+  const caseNames = new Set();
+  for (const diffCase of artifact.cases) {
+    if (!diffCase || typeof diffCase !== "object" || Array.isArray(diffCase)) fail("shadow decision diff: invalid case row");
+    exactKeys(diffCase, ["case", "modules", "conservative_over_invalidation"], "shadow decision diff case");
+    if (typeof diffCase.case !== "string" || diffCase.case.length === 0 || caseNames.has(diffCase.case)) fail("shadow decision diff: invalid or duplicate case name");
+    caseNames.add(diffCase.case);
+    if (!Array.isArray(diffCase.modules) || diffCase.modules.length === 0) fail(`shadow decision diff: missing modules for ${diffCase.case}`);
+    const paths = new Set();
+    const residual = [];
+    for (const row of diffCase.modules) {
+      if (!row || typeof row !== "object" || Array.isArray(row)) fail(`shadow decision diff: invalid module row in ${diffCase.case}`);
+      exactKeys(row, ["path", "shadow_decision", "compiler_decision", "classification"], "shadow decision diff module row");
+      if (typeof row.path !== "string" || row.path.length === 0 || paths.has(row.path)) fail(`shadow decision diff: invalid or duplicate module path in ${diffCase.case}`);
+      paths.add(row.path);
+      const expectedClassification =
+        row.shadow_decision === "recheck_required" && row.compiler_decision === "rechecked" ? "agreement_recheck"
+        : row.shadow_decision === "typing_reusable" && row.compiler_decision === "reused" ? "agreement_reuse"
+        : row.shadow_decision === "typing_reusable" && row.compiler_decision === "rechecked" ? "conservative_over_invalidation"
+        : undefined;
+      if (expectedClassification === undefined) fail(`shadow decision diff: published missing required recheck for ${row.path} in ${diffCase.case}`);
+      if (row.classification !== expectedClassification) fail(`shadow decision diff: classification inconsistent with decisions for ${row.path} in ${diffCase.case}`);
+      totals[row.classification] += 1;
+      if (row.classification === "conservative_over_invalidation") residual.push(row.path);
+    }
+    if (JSON.stringify(diffCase.conservative_over_invalidation) !== JSON.stringify(residual)) {
+      fail(`shadow decision diff: residual summary drift for ${diffCase.case}`);
+    }
+  }
+  const actualTotals = artifact.totals;
+  if (!actualTotals || typeof actualTotals !== "object" || Array.isArray(actualTotals)) fail("shadow decision diff: invalid totals");
+  exactKeys(actualTotals, Object.keys(totals), "shadow decision diff totals");
+  for (const [key, value] of Object.entries(totals)) {
+    if (actualTotals[key] !== value) fail(`shadow decision diff: totals drift for ${key}`);
+  }
+  return artifact;
+}
+
 function ownerNames(paths) {
   return paths.map((path) => basename(path).replace(/\.vibe$/, ""));
 }
@@ -394,6 +502,12 @@ function checkOracleCorpus(path) {
 function run(stage2) {
   const invoke = join(root, "scripts/run_wasm_vibe_host_runner.sh");
   if (![stage2, invoke].every(existsSync)) fail("missing stage2 compiler or node host runner");
+  // #1548: delete a previously requested diff artifact before doing any work,
+  // so a failed run can never leave an old diff to be mistaken for this run.
+  const diffOut = process.env.VIBE_SHADOW_DECISION_DIFF_OUT
+    ? resolve(process.cwd(), process.env.VIBE_SHADOW_DECISION_DIFF_OUT)
+    : "";
+  if (diffOut) rmSync(diffOut, { force: true });
   const work = mkdtempSync(join(tmpdir(), "vibe-incremental-invalidation-"));
   const project = join(work, "project");
   const cache = join(work, "cache");
@@ -441,6 +555,11 @@ function run(stage2) {
       return trace;
     };
     const plannerCases = {};
+    const shadowDiffCases = [];
+    const runPlannerCase = (name, before, after) => {
+      plannerCases[name] = checkPlannerCase(name, before, after);
+      shadowDiffCases.push(buildShadowDecisionDiffCase(name, before, after));
+    };
     const baseline = check("cold");
     if (baseline.aggregate_telemetry.modules_rechecked !== 3) fail("cold run did not recheck all modules");
     const noOp = check("no_op");
@@ -448,14 +567,14 @@ function run(stage2) {
     if (implementationOwnersChanged(baseline, noOp).length !== 0) fail("no-op changed an implementation identity");
     if (interfaceOwnersChanged(baseline, noOp).length !== 0) fail("no-op changed an interface identity");
     if (noOp.aggregate_telemetry.modules_rechecked !== 0) fail("no-op was not reused by the current cache");
-    plannerCases.no_op = checkPlannerCase("no_op", baseline, noOp);
+    runPlannerCase("no_op", baseline, noOp);
 
     writeFileSync(join(project, "library.vibe"), "// observation-only comment\nimport ./base.vibe { base_value }\nexport let library_value = base_value(40)\nfn private_offset() -> Int { 1 }\n");
     const commentEdit = check("comment_edit");
     if (sourceOwnersChanged(noOp, commentEdit).join(",") !== "library") fail("comment edit source delta drift");
     if (implementationOwnersChanged(noOp, commentEdit).length !== 0) fail("comment edit changed token-stream implementation identity");
     if (interfaceOwnersChanged(noOp, commentEdit).length !== 0) fail("comment edit changed an interface identity");
-    plannerCases.comment_only_edit = checkPlannerCase("comment_only_edit", noOp, commentEdit);
+    runPlannerCase("comment_only_edit", noOp, commentEdit);
 
     writeFileSync(join(project, "library.vibe"), "// observation-only comment\nimport ./base.vibe { base_value }\nexport let library_value = base_value(40)\nfn private_offset() -> Int { 2 }\n");
     const privateEdit = check("private_body_edit");
@@ -474,7 +593,7 @@ function run(stage2) {
       "library",
       "app",
     );
-    plannerCases.private_body_edit = checkPlannerCase("private_body_edit", commentEdit, privateEdit);
+    runPlannerCase("private_body_edit", commentEdit, privateEdit);
 
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
     const publicEdit = check("public_interface_edit");
@@ -484,7 +603,7 @@ function run(stage2) {
     if (JSON.stringify(decisionsByName(publicEdit)) !== JSON.stringify({ base: "reused", library: "rechecked", app: "rechecked" })) {
       fail("public edit current decision drift");
     }
-    plannerCases.public_interface_edit = checkPlannerCase("public_interface_edit", privateEdit, publicEdit);
+    runPlannerCase("public_interface_edit", privateEdit, publicEdit);
 
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport effect Logger { Info(String) -> Unit }\nexport effect Audit { Record(String) -> Unit }\nexport fn announce(message: String) -> Unit with Logger { let _ = message\n() }\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
     const publicFunctionLogger = check("public_function_logger");
@@ -602,7 +721,7 @@ function run(stage2) {
     }
     const appDependencies = moduleByName(planEdit, "app").direct_dependencies.map((path) => basename(path));
     if (appDependencies.join(",") !== "base.vibe,library.vibe") fail("dependency-plan trace did not record the added base import in declaration order");
-    plannerCases.dependency_plan_edit = checkPlannerCase("dependency_plan_edit", implTargetArray, planEdit);
+    runPlannerCase("dependency_plan_edit", implTargetArray, planEdit);
 
     // Integration regressions for the renderer: JSON requires every U+0000–
     // U+001F control character to be escaped, and POSIX paths may contain TAB.
@@ -616,6 +735,25 @@ function run(stage2) {
     // report (rather than fail on) the current implementation's additional
     // rechecks. This is the intended conservative-over-invalidation record.
     const currentPrivateRechecks = privateEdit.modules.filter((module) => module.decision === "rechecked").map((module) => module.path.replace(/\.vibe$/, ""));
+
+    // #1548: persist the shadow planner vs current compiler decision diff.
+    // Published only after every case above succeeded, atomically via rename,
+    // and strictly re-parsed first so a torn or malformed artifact cannot ship.
+    let shadowDecisionDiff;
+    if (diffOut) {
+      const artifact = buildShadowDecisionDiffArtifact(shadowDiffCases, {
+        scenario: "three-module-incremental-invalidation",
+        stage2_sha256: createHash("sha256").update(readFileSync(stage2)).digest("hex"),
+      });
+      const rendered = `${JSON.stringify(artifact, null, 2)}\n`;
+      parseShadowDecisionDiffArtifact(rendered);
+      mkdirSync(dirname(diffOut), { recursive: true });
+      const partial = `${diffOut}.partial-${process.pid}`;
+      writeFileSync(partial, rendered);
+      renameSync(partial, diffOut);
+      shadowDecisionDiff = { written_to: diffOut, totals: artifact.totals };
+    }
+
     console.log(JSON.stringify({
       schema: 6,
       scenario: "three-module-incremental-invalidation",
@@ -624,6 +762,7 @@ function run(stage2) {
       conservative_over_invalidation: currentPrivateRechecks.filter((name) => name !== "library"),
       private_dependency_classification: privateDependencyClassification,
       planner_cases: plannerCases,
+      ...(shadowDecisionDiff ? { shadow_decision_diff: shadowDecisionDiff } : {}),
       cases: [...traces.keys()],
     }));
   } finally {

--- a/scripts/incremental_invalidation_oracle.test.mjs
+++ b/scripts/incremental_invalidation_oracle.test.mjs
@@ -2,10 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildShadowDecisionDiffArtifact,
+  buildShadowDecisionDiffCase,
   classifyPrivateDependencyEditExternallyUnchanged,
   compareObservedInvalidation,
   compareSuccessfulIncrementalInvalidationTraces,
   parseIncrementalInvalidationTrace,
+  parseShadowDecisionDiffArtifact,
   planObservedTypingInvalidation,
 } from "./incremental_invalidation_oracle.mjs";
 
@@ -297,6 +300,79 @@ test("private dependency classifier is explicit, fail-closed, and reports TypeEn
       pattern,
       name,
     );
+  }
+});
+
+test("shadow decision diff records per-module decisions and the visible residual", () => {
+  const before = plannerTrace();
+  const privateAfter = plannerTrace({
+    source: { "/p/library.vibe": "source:library:private-edit" },
+    implementation: { "/p/library.vibe": "implementation:library:private-edit" },
+    rechecked: ["/p/library.vibe", "/p/app.vibe"],
+  });
+  assert.deepEqual(buildShadowDecisionDiffCase("private_body_edit", before, privateAfter), {
+    case: "private_body_edit",
+    modules: [
+      { path: "/p/base.vibe", shadow_decision: "typing_reusable", compiler_decision: "reused", classification: "agreement_reuse" },
+      { path: "/p/library.vibe", shadow_decision: "recheck_required", compiler_decision: "rechecked", classification: "agreement_recheck" },
+      { path: "/p/app.vibe", shadow_decision: "typing_reusable", compiler_decision: "rechecked", classification: "conservative_over_invalidation" },
+    ],
+    conservative_over_invalidation: ["/p/app.vibe"],
+  });
+
+  // A missing required recheck must fail before publication, never become a row.
+  const underInvalidated = plannerTrace({
+    implementation: { "/p/library.vibe": "implementation:library:public-edit" },
+    iface: { "/p/library.vibe": "interface:library:changed" },
+    rechecked: ["/p/library.vibe"],
+  });
+  assert.throws(
+    () => buildShadowDecisionDiffCase("public_interface_edit", before, underInvalidated),
+    /missing required recheck for \/p\/app\.vibe/,
+  );
+});
+
+test("shadow decision diff artifact aggregates totals and round-trips its strict parser", () => {
+  const before = plannerTrace();
+  const privateAfter = plannerTrace({
+    source: { "/p/library.vibe": "source:library:private-edit" },
+    implementation: { "/p/library.vibe": "implementation:library:private-edit" },
+    rechecked: ["/p/library.vibe", "/p/app.vibe"],
+  });
+  const noOpAfter = plannerTrace();
+  const artifact = buildShadowDecisionDiffArtifact(
+    [
+      buildShadowDecisionDiffCase("no_op", before, noOpAfter),
+      buildShadowDecisionDiffCase("private_body_edit", before, privateAfter),
+    ],
+    { scenario: "three-module-incremental-invalidation", stage2_sha256: "a".repeat(64) },
+  );
+  assert.deepEqual(artifact.totals, {
+    agreement_recheck: 1,
+    agreement_reuse: 4,
+    conservative_over_invalidation: 1,
+  });
+  assert.deepEqual(parseShadowDecisionDiffArtifact(JSON.stringify(artifact)), artifact);
+
+  const mutations = [
+    ["schema", (a) => { a.schema = "shadow_diff"; }, /unsupported schema/],
+    ["version", (a) => { a.version = 2; }, /unsupported version/],
+    ["sha", (a) => { a.stage2_sha256 = "not-a-sha"; }, /invalid stage2_sha256/],
+    ["scope note", (a) => { a.scope_note = "observation only"; }, /dishonest scope_note/],
+    ["extra key", (a) => { a.extra = true; }, /unexpected shadow decision diff keys/],
+    ["duplicate case", (a) => { a.cases.push(structuredClone(a.cases[0])); }, /duplicate case name/],
+    ["inconsistent classification", (a) => { a.cases[1].modules[2].classification = "agreement_recheck"; }, /classification inconsistent/],
+    ["published missing recheck", (a) => {
+      a.cases[1].modules[1].shadow_decision = "recheck_required";
+      a.cases[1].modules[1].compiler_decision = "reused";
+    }, /published missing required recheck/],
+    ["residual drift", (a) => { a.cases[1].conservative_over_invalidation = []; }, /residual summary drift/],
+    ["totals drift", (a) => { a.totals.agreement_reuse = 5; }, /totals drift for agreement_reuse/],
+  ];
+  for (const [name, mutate, pattern] of mutations) {
+    const mutated = structuredClone(artifact);
+    mutate(mutated);
+    assert.throws(() => parseShadowDecisionDiffArtifact(JSON.stringify(mutated)), pattern, name);
   }
 });
 


### PR DESCRIPTION
#1548 (incremental P0-1) の最初のスライス。スコープは issue の「shadow planner の decision と現 compiler の decision の差分を CI artifact として保存する」まで。production reuse decision / cache key / cache format / trace schema 6 / cache namespace v17 は一切変更しない。

> incremental lane (session `017jH32nTNMhNWN4f9fftW67`) の成果物。当該 session が GitHub API 遮断のため coordinator が PR-DRAFT commit の本文から代理起票。

## 何をしたか

- `scripts/incremental_invalidation_oracle.mjs`: `VIBE_SHADOW_DECISION_DIFF_OUT=<path>` opt-in で、bounded edit case ごとに各 module の shadow decision (`recheck_required`/`typing_reusable`) と compiler decision (`rechecked`/`reused`) の diff を versioned `incremental_shadow_decision_diff` v1 JSON として publish する。classification は agreement_recheck / agreement_reuse / conservative_over_invalidation の 3 値 + aggregate totals + stage2 sha256
- **fail-closed** (Roadmap invariants): 要求された stale artifact は実行前に削除、publish は全 case 成功後に rename で atomic、書く前に strict parser で re-parse。missing required recheck は従来どおり oracle 失敗であり、published row には決してならない
- `scripts/compiler_gate.sh` 3aa: `_build/ci-artifacts/incremental-shadow-decision-diff.json` へ書き出し
- `.github/workflows/ci.yml` compiler-gate job: upload-artifact (`incremental-shadow-decision-diff`) — over-invalidation residual が run ごとに「permitted but visible」になる
- strict parser/builder の unit tests 10 件 (node --test)、docs/incremental-build.md の observation bridge 節に追記

## 検証 (ローカル)

- `node --test scripts/incremental_invalidation_oracle.test.mjs`: 10 pass
- fresh stage2 (seed→stage1→stage2) で oracle full run pass、artifact 生成確認 (totals: agreement_recheck=4, agreement_reuse=8, conservative_over_invalidation=3 — comment_only_edit の library+app と private_body_edit の app が既知の conservative residual)
- fail path: 壊れた stage2 で oracle 失敗 → stale artifact 削除・publish なし
- `--check-oracle` corpus 検証 pass、`git diff --check` clean、YAML/bash/node 構文 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM)_