### PR TITLE
fix(codegen): run shadow uniquify in the bump lane too (silent clobber)

### DIFF
--- a/fixtures/shadow_scope_test.vibe
+++ b/fixtures/shadow_scope_test.vibe
@@ -1,0 +1,65 @@
+// Shadow-clobber regression (bump lane): the linear backend never restored
+// `local_names` when an inner binding scope closed mid-function, so a later
+// same-name reference resolved to the DEAD inner slot and silently read its
+// value. Fixed by running uniquify_shadowed_bindings (#712) in both lanes.
+// The RC lane already renamed shadows and always answered these correctly --
+// these tests pin the lanes to the same answers.
+
+//# Tests
+
+test "nested match rebinding the same tuple binders" {
+  match (1, 2) {
+    (a, b) => {
+      let inner = match (30, 40) {
+        (a, b) => a + b
+      }
+      // was: inner + 30 + 40 = 140 on the bump lane
+      assert(inner + a + b == 73)
+    }
+  }
+}
+
+test "block-valued let with an inner shadowing let" {
+  let a = 1
+  let blk = {
+    let a = 200
+    a + 1
+  }
+  // was: blk + 200 = 401 on the bump lane
+  assert(blk + a == 202)
+  assert(a == 1)
+}
+
+test "if-branch let shadow stays correct" {
+  let c = 5
+  let d = if true {
+    let c = 300
+    c + 1
+  } else {
+    0
+  }
+  assert(d + c == 306)
+}
+
+test "match arm let shadow does not leak into code after the match" {
+  let e = 7
+  let f = match 1 {
+    0 => {
+      let e = 400
+      e
+    },
+    _ => 9
+  }
+  assert(f + e == 16)
+}
+
+test "catch-all arm binder does not leak past the match" {
+  let x = 3
+  let y = match (10, 20) {
+    (x, _) => x
+  }
+  // was: the arm's x stayed resolvable after the match on the bump lane
+  assert(y == 10)
+  assert(x == 3)
+  assert(x + y == 13)
+}

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -5018,12 +5018,25 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   let mut pbi = 0
   while pbi < num_user_funcs {
     let pb_stmt = Array::get(stmts, Array::get(fn_stmt_indices, pbi))
+    // Shadow uniquify runs in BOTH lanes now. It was RC-only (#712,
+    // name-keyed RC bookkeeping), but the bump lane needs it for a harder
+    // reason: its codegen never restores `local_names` when an inner binding
+    // scope closes mid-function (a match catch-all arm's binders, a
+    // block-valued `let`'s inner lets), so a later same-name reference
+    // resolved to the DEAD inner slot and read its value — silently wrong,
+    // no diagnostic. Renaming every shadowing binding to a unique name
+    // removes the collision at the source, exactly as #712 did for RC's
+    // name-keyed maps (the pass's own doc already notes it is harmless on
+    // this lane). `lift_match_scrutinees` stays RC-only — it exists for
+    // Perceus drops.
     let pb_expr = if enable_rc {
       let pb_seen: Array[String] = [
       ]
       lift_match_scrutinees(uniquify_shadowed_bindings(get_slet_expr(pb_stmt), Map::new(), uq_shadow_counter, pb_seen), m_scrut_counter)
     } else {
-      get_slet_expr(pb_stmt)
+      let pb_seen: Array[String] = [
+      ]
+      uniquify_shadowed_bindings(get_slet_expr(pb_stmt), Map::new(), uq_shadow_counter, pb_seen)
     }
     Array::push(planned_bodies, pb_expr)
     Array::push(lambda_bases, lambda_base_acc)

--- a/lib/@vibe/compiler/normalize/normalize.vibe
+++ b/lib/@vibe/compiler/normalize/normalize.vibe
@@ -635,8 +635,14 @@ fn fold_expr(expr: Expr) -> Expr {
 /// (#708) -- same shared-counter-cell technique for uniqueness, same complete
 /// per-Expr-variant walk. Unshadowed bindings (the vast majority) are left with
 /// their original name (so debugging/argument-inspection output is unaffected
-/// outside the rare shadowing case). Pure rewrite; gated at the call site to
-/// keep the non-RC backend byte-identical.
+/// outside the rare shadowing case). Pure rewrite.
+///
+/// Runs in BOTH lanes since the shadow-clobber fix: the bump backend never
+/// restores `local_names` when an inner binding scope closes mid-function (a
+/// match catch-all arm's binders, a block-valued `let`'s inner lets), so its
+/// most-recent-first local resolution read a DEAD shadowing slot's value for
+/// a later same-name reference — silently wrong, no diagnostic. With every
+/// shadowing binding renamed, that stale entry can never capture a live name.
 fn fresh_shadow_name(counter: Array[Int], name: String) -> String {
   let n = Array::get(counter, 0)
   Array::set(counter, 0, n + 1)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -1515,7 +1515,8 @@ for fx in \
   fixtures/derive_enum_ord_show_test.vibe \
   fixtures/derive_default_test.vibe \
   fixtures/derive_hash_test.vibe \
-  fixtures/eq_array_option_fields.vibe; do
+  fixtures/eq_array_option_fields.vibe \
+  fixtures/shadow_scope_test.vibe; do
   fxout="_build/_gate_derive_ext_$(basename "${fx%.vibe}").wasm"
   rm -f "$fxout" "$fxout.diag"
   # ADR-0069: these are test-block suites with no `_start` of their own — the


### PR DESCRIPTION
perf lane (session `012z5xh8p4F1zinpczcSeVuS`) の成果物を coordinator が代理起票。P0 クラス (黙って誤る) の linear backend バグ修正。

linear (非 RC) backend は内側の binding スコープが閉じても `local_names` を復元しないため、後続の同名参照が most-recent-first で**死んだ内側 slot に解決**され、黙って誤答していた:

```vibe
match (1, 2) { (a, b) => {
  let inner = match (30, 40) { (a, b) => a + b }
  inner + a + b        // 140 (正: 73)
} }

let a = 1
let blk = { let a = 200; a + 1 }
blk + a                // 401 (正: 202)
```

RC lane は #712 の `uniquify_shadowed_bindings` (codegen 前の alpha-rename) で正答していた。この pass は自身の doc が bump lane でも無害と明記しているので、**ungate して両 lane が collision-free な名前を見る**ようにする — #712 が name-keyed consumer の全改修より alpha-rename を選んだのと同じ判断。`lift_match_scrutinees` は Perceus drop 用なので RC-only のまま。

Fixture: 入れ子 match binder / block-let shadow / if-branch let / arm-let leakage / catch-all binder leakage。linear / VIBE_RC=1 / VIBE_BACKEND=gc で検証済み。

関連: #1576 (`eq_for_typed` の tuple binder uid はこのバグの独立回避で、本 PR が根本修正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM)_