### PR TITLE
fix(checker): a dependency publishes its export surface, not its checked env (#1533)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,8 +213,12 @@ vibe escapes file.vibe
 > のあるファイルは、正しくても `unknown name: T::Crimson` を返す。空出力が意味
 > するのは「**単体ファイルとして** clean」であって「コンパイルが通る」ではない。
 > **import があるファイルの可否は `vibe check`** で見る (diagnostics はエディタの
-> バッファ単位フィードバック用で、そこでは正しい道具)。逆向きの穴 — export されて
-> いない名前の import — は**両方とも見逃し**、codegen まで落ちない (#1521)。
+> バッファ単位フィードバック用で、そこでは正しい道具)。逆向き — export されて
+> いない名前の import — は `vibe check` が検査時に報告する (#1521/#1533。
+> 依存が publish する環境は export surface に制限されるので、private も
+> 単なる import 素通しも「is not exported by」になる)。`vibe diagnostics` は
+> 単一ファイル解析なのでこちらは今も見えない。大文字名 (struct / type alias)
+> だけは値環境が判定できず、未検出のまま (#1521 の残り半分)。
 
 ### `vibe lsp` - Language Server
 

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -23,6 +23,7 @@ import @vibe/compiler/core {
   Stmt,
   Type,
   TypeEnv,
+  bsearch_leftmost,
   dir_of_path,
   env_bind,
   env_flat_bindings,
@@ -183,13 +184,14 @@ fn bind_enum_constructor_companions(acc: TypeEnv, dep_bindings: Array[(String, T
 /// unexported `Foo` from a struct-only `Foo`, so the uppercase half of #1521
 /// stays open rather than risk rejecting valid code.
 ///
-/// The other half still open (#1533): this tests membership in the
-/// dependency's CHECKED environment, which binds every top-level `let`/`fn`
-/// whether or not it is exported. `import ./dep.vibe { private_fn }` therefore
-/// passes here and still dies in codegen. Closing it needs the dependency's
-/// export SURFACE -- `interface_public_value_names` computes exactly that from
-/// the dependency's stmts, but only its environment reaches this point, so the
-/// surface has to be published alongside the environment first.
+/// #1533 (closed): this membership test IS the export test for lowercase
+/// names, because the environment a dependency publishes is no longer its
+/// full checked environment -- check_module restricts it to the module's
+/// export surface before it reaches any cache (see
+/// restrict_env_to_export_surface). `import ./dep.vibe { private_fn }` is
+/// therefore reported here, with the same message as a name that never
+/// existed: from the importer's side those are the same fact, "the
+/// dependency does not export this name".
 fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> TypeEnv {
   let cached = lookup_env_cache(cache, resolved)
   let dep_env = match cached {
@@ -1093,6 +1095,71 @@ fn interface_public_value_names(stmts: Array[Stmt]) -> Array[String] {
     i = i + 1
   }
   interface_sorted_unique(names)
+}
+
+/// #1533: the environment a module PUBLISHES to its importers is its export
+/// surface, not its full checked environment. The checked environment binds
+/// every top-level `let`/`fn` -- and, via the import env at its base, every
+/// name the module itself imported -- so testing an import against it let
+/// `import ./dep.vibe { private_fn }` through to die in codegen. Dropping
+/// the non-exported bindings here, at the single point every publication
+/// path flows through (persistent store, env cache, worker env.out, TDRE4),
+/// makes the existing membership check in
+/// bind_import_names_from_cache_collecting the export test itself.
+///
+/// Only lowercase-initial bindings are dropped, and `surface` is
+/// interface_public_value_names -- exported `let`/`fn`, `export { .. }`
+/// lists, and re-export aliases -- which is exactly the set of importable
+/// lowercase names. Uppercase bindings (enum constructors, `T::` companions,
+/// qualified impl methods) are kept wholesale: the value environment cannot
+/// distinguish an unexported `Foo` from a struct-only `Foo`, so their half
+/// of #1521 stays open rather than risk rejecting valid code, and the
+/// companion-binding scan over dep_bindings keeps working unchanged.
+///
+/// Trait nodes ride through untouched; EnvCached wrappers are rebuilt from
+/// the restricted chain (their arrays are acceleration state, same rule as
+/// the serializer's). Persistent-cache staleness is not a concern: the cache
+/// version tag folds in codegen_fingerprint(), so envs published before this
+/// restriction live under different keys.
+fn restrict_env_to_export_surface(surface: Array[String], env: TypeEnv) -> TypeEnv {
+  match env {
+    EnvEmpty => EnvEmpty,
+    EnvBind(name, ty, rest) => {
+      let restricted = restrict_env_to_export_surface(surface, rest)
+      if starts_with_upper(name) || bsearch_leftmost(surface, name) >= 0 {
+        EnvBind(name, ty, restricted)
+      } else {
+        restricted
+      }
+    },
+    EnvTraitDef(name, supers, is_auto, methods, rest, params, method_gens) => EnvTraitDef(name, supers, is_auto, methods, restrict_env_to_export_surface(surface, rest), params, method_gens),
+    EnvTraitImpl(name, target, rest) => EnvTraitImpl(name, target, restrict_env_to_export_surface(surface, rest)),
+    EnvTraitImplGen(name, params, bounds, target, rest) => EnvTraitImplGen(name, params, bounds, target, restrict_env_to_export_surface(surface, rest)),
+    EnvFlat(bindings) => {
+      let kept = array_empty()
+      let mut i = 0
+      while i < Array::length(bindings) {
+        let (name, ty) = Array::get(bindings, i)
+        if starts_with_upper(name) || bsearch_leftmost(surface, name) >= 0 {
+          Array::push(kept, (name, ty))
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      EnvFlat(kept)
+    },
+    // The wrapper is DROPPED, not rebuilt. Its arrays are acceleration
+    // state (the codec re-derives them via env_cache on both serialize and
+    // parse), and every consumer of a published env either flat-walks the
+    // chain or serializes it, so nothing loses correctness. Rebuilding here
+    // would need core's `env_cache` -- a name this file cannot import: it
+    // collides with the ubiquitous `env_cache` PARAMETERS, and the FS
+    // module lane resolves an import over a same-named local (the merge
+    // lane shadows correctly), while an `as` alias broke the
+    // collect_merged_stmts lane instead. Both are their own bugs.
+    EnvCached(_, _, rest) => restrict_env_to_export_surface(surface, rest)
+  }
 }
 
 fn interface_decl_line(prefix: String, name: String, body: String) -> String {
@@ -2184,10 +2251,16 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
     })
   } else {
     handle {
-      let checked_env = match import_env {
+      let full_checked_env = match import_env {
         EnvEmpty => check_program(stmts),
         _ => check_program_with_env(stmts, import_env)
       }
+      // #1533: what leaves this function is the module's PUBLISHED
+      // environment -- restricted to its export surface -- because every
+      // consumer of `Checked`'s env (env cache, persistent store, worker
+      // transport, TDRE4, trace identities) is a publication path. The full
+      // environment never needs to outlive the check itself.
+      let checked_env = restrict_env_to_export_surface(interface_public_value_names(stmts), full_checked_env)
       let interface_identity = if incremental_interface_trace_enabled() {
         incremental_interface_identity(job.source, checked_env)
       } else {

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -451,3 +451,126 @@ test "cross-module delta recomputation" {
   let db4 = db_typecheck(db3, "a.vibe")
   assert(eq(db_typecheck_count(db4), 5))
 }
+
+/// #1533: the environment a dependency publishes through the FS lane is its
+/// EXPORT SURFACE, not its full checked environment (check_module's
+/// restrict_env_to_export_surface). These four pin both directions: private
+/// and merely-imported names are reported by the #1521 membership check
+/// (same message as a name that never existed), while exported and
+/// re-exported names keep importing cleanly.
+fn export_surface_error(paths: Array[String], entry: String) -> String with Fs {
+  handle {
+    let mut db = db_new()
+    let mut i = 0
+    while i < Array::length(paths) {
+      let p = Array::get(paths, i)
+      db = db_set_source(db, p, Fs::read_file(p))
+      i = i + 1
+    }
+    let _db = db_typecheck_fs(db, entry)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+test "db_typecheck_fs: importing a private (non-export) name is reported (#1533)" {
+  let dir = "/tmp/vibe_compiler_export_surface_private"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  let dep_src = "fn private_fn(x: Int) -> Int {\n  x + 1\n}\n\nexport fn public_fn(x: Int) -> Int {\n  private_fn(x)\n}\n"
+  let main_src = "import ./dep.vibe { private_fn }\nexport let m = private_fn(1)\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ]))
+  let err = export_surface_error([
+    dep_path,
+    main_path
+  ], main_path)
+  assert(String::contains(err, "imported name 'private_fn' is not exported by"))
+}
+
+test "db_typecheck_fs: the exported name from the same module imports cleanly (#1533 control)" {
+  let dir = "/tmp/vibe_compiler_export_surface_public"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  let dep_src = "fn private_fn(x: Int) -> Int {\n  x + 1\n}\n\nexport fn public_fn(x: Int) -> Int {\n  private_fn(x)\n}\n"
+  let main_src = "import ./dep.vibe { public_fn }\nexport let m = public_fn(1)\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ]))
+  let err = export_surface_error([
+    dep_path,
+    main_path
+  ], main_path)
+  assert(err == "")
+}
+
+test "db_typecheck_fs: a pass-through import is not on the middleman's surface (#1533)" {
+  let dir = "/tmp/vibe_compiler_export_surface_passthrough"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let mid_path = String::concat(dir, "/mid.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  let dep_src = "export fn public_fn(x: Int) -> Int {\n  x + 1\n}\n"
+  let mid_src = "import ./dep.vibe { public_fn }\n\nexport fn mid_fn(x: Int) -> Int {\n  public_fn(x)\n}\n"
+  let main_src = "import ./mid.vibe { public_fn }\nexport let m = public_fn(1)\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(mid_path, string_to_bytes(mid_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  let mid_fp = build_test_fingerprint(mid_src, [
+    (dep_path, dep_fp)
+  ])
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(mid_path, mid_src, mid_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (mid_path, mid_fp)
+  ]))
+  let err = export_surface_error([
+    dep_path,
+    mid_path,
+    main_path
+  ], main_path)
+  assert(String::contains(err, "imported name 'public_fn' is not exported by"))
+  assert(String::contains(err, "mid.vibe"))
+}
+
+test "db_typecheck_fs: a re-exported name IS on the middleman's surface (#1533 control)" {
+  let dir = "/tmp/vibe_compiler_export_surface_reexport"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let mid_path = String::concat(dir, "/mid.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  let dep_src = "export fn public_fn(x: Int) -> Int {\n  x + 1\n}\n"
+  let mid_src = "export ./dep.vibe { public_fn }\n"
+  let main_src = "import ./mid.vibe { public_fn }\nexport let m = public_fn(1)\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(mid_path, string_to_bytes(mid_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  let mid_fp = build_test_fingerprint(mid_src, [
+    (dep_path, dep_fp)
+  ])
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(mid_path, mid_src, mid_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (mid_path, mid_fp)
+  ]))
+  let err = export_surface_error([
+    dep_path,
+    mid_path,
+    main_path
+  ], main_path)
+  assert(err == "")
+}

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9634,13 +9634,14 @@ export fn hue_rank(h: Hue) -> Int {
 }
 UIDEP
 ui_case() {
-  # ui_case <name> <expect: ok|err|gap> <source>
+  # ui_case <name> <expect: ok|err> <source>
   #   ok  -- compiles
   #   err -- rejected BY THE #1521 CHECK (diag names the unexported import)
-  #   gap -- rejected, but LATER than the check: a shape #1521 is supposed to
-  #          cover and does not yet. Pinning the phase is the point; `ok` would
-  #          be wrong (no wasm is produced) and `err` would be wrong (the diag
-  #          is codegen's, not the check's), so neither expresses it.
+  # (A third expectation, `gap`, used to pin the #1533 shape: a private
+  # import that failed in CODEGEN instead of the check. #1533 is fixed --
+  # published dependency environments are restricted to the export surface,
+  # see runtime/typecheck_fs.vibe restrict_env_to_export_surface -- so that
+  # shape is an ordinary `err` now and the expectation is gone.)
   local uname="$1" uexpect="$2" usrc="$3"
   printf '%s' "$usrc" > "$uidir/$uname.vibe"
   rm -f "$uidir/$uname.wasm" "$uidir/$uname.wasm.diag"
@@ -9651,16 +9652,6 @@ ui_case() {
     if [ ! -s "$uidir/$uname.wasm" ]; then
       echo "[compiler-gate] FAIL: unresolved-import case '$uname' should compile but did not (#1521)" >&2
       cat "$uidir/$uname.wasm.diag" 2>/dev/null >&2 || true
-      exit 1
-    fi
-  elif [ "$uexpect" = "gap" ]; then
-    if [ -s "$uidir/$uname.wasm" ]; then
-      echo "[compiler-gate] FAIL: known-gap case '$uname' compiled cleanly; it is supposed to still fail somewhere (#1533)" >&2
-      exit 1
-    fi
-    if grep -q "is not exported by" "$uidir/$uname.wasm.diag" 2>/dev/null; then
-      echo "[compiler-gate] FAIL: known-gap case '$uname' is now caught by the #1521 check -- #1533 is fixed." >&2
-      echo "[compiler-gate]       Move this case from 'gap' to 'err' and close #1533." >&2
       exit 1
     fi
   else
@@ -9736,14 +9727,11 @@ ui_case bogus_from_traitonly err 'import ./traitonly.vibe { no_such_fn }
 
 export let _start = () -> Int { no_such_fn(1) }
 '
-# 9. The OTHER known gap (#1533): membership is tested against the dependency's
-#    checked environment, which binds every top-level fn whether exported or
-#    not, so importing a PRIVATE name is not reported by the check. It still
-#    fails -- but in CODEGEN, which is exactly the failure mode #1521 exists to
-#    remove, so the phase is what has to be pinned. `ok` would be wrong (no
-#    wasm) and `err` would be wrong (the diag is codegen's), hence `gap`: it
-#    asserts the compile fails AND that the #1521 check was not what rejected
-#    it. Fixing #1533 turns this red with an instruction to flip it to `err`.
+# 9. #1533, fixed (was pinned here as a `gap` case): a PRIVATE name is not in
+#    the environment the dependency publishes -- check_module restricts it to
+#    the export surface -- so the membership check reports it exactly like a
+#    name that never existed. From the importer's side those are the same
+#    fact: the dependency does not export it.
 cat > "$uidir/privates.vibe" <<'UIPRIV'
 fn private_fn(x: Int) -> Int {
   x + 1
@@ -9753,15 +9741,38 @@ export fn public_fn(x: Int) -> Int {
   private_fn(x)
 }
 UIPRIV
-ui_case private_import_gap gap 'import ./privates.vibe { private_fn }
+ui_case private_import_reported err 'import ./privates.vibe { private_fn }
 
 export let _start = () -> Int { private_fn(1) }
 '
 # 10. ...and the public name from that same module still imports cleanly, so
-#     the gap case above is not passing because the module is broken.
+#     case 9 is not passing because the module is broken.
 ui_case public_from_mixed_module ok 'import ./privates.vibe { public_fn }
 
 export let _start = () -> Int { public_fn(1) }
+'
+# 11-12. The same rule for PASS-THROUGH names (#1533's other face): a name the
+#     dependency merely imported sits in its checked environment (the import
+#     env is the base of the chain) but is NOT part of its export surface --
+#     importing it from the middleman is an error unless the middleman
+#     re-exports it, which puts the name on the surface for real.
+cat > "$uidir/middleman.vibe" <<'UIMID'
+import ./dep.vibe { hue_rank, Hue, Crimson }
+
+export fn middleman_rank() -> Int {
+  hue_rank(Crimson)
+}
+UIMID
+ui_case passthrough_import_reported err 'import ./middleman.vibe { hue_rank }
+
+export let _start = () -> Int { hue_rank(1) }
+'
+cat > "$uidir/reexporter.vibe" <<'UIREX'
+export ./dep.vibe { hue_rank, Hue, Crimson }
+UIREX
+ui_case reexported_name_ok ok 'import ./reexporter.vibe { hue_rank, Hue, Crimson }
+
+export let _start = () -> Int { hue_rank(Crimson) }
 '
 rm -rf "$uidir"
 echo "[compiler-gate] unresolved import names ok"


### PR DESCRIPTION
Closes #1533。ergonomics lane (session `017u2j3Ze1YvvuSsxhfXqGuv`) の成果物を coordinator が代理起票。

#1521 の membership check は依存側の **CHECKED environment** に対して import を検査していた — そこには export の有無を問わず全 top-level let/fn が、さらに import env 経由で依存自身が import した名前まで bind されている。そのため `import ./dep.vibe { private_fn }` が `vibe check` を通過し、codegen で位置情報の無い `undefined variable` で死んでいた。

`check_module` が返す環境 (env cache / persistent store / worker env.out / TDRE4 の全 publication path が消費する唯一の値) を **module の export surface に制限**する: lowercase 始まりの値 binding は `interface_public_value_names` にあるもの (exported let/fn、`export { .. }`、re-export alias) だけ生存。uppercase binding は丸ごと維持 (値 env では未 export の Foo と struct-only の Foo を区別できない — #1521 の未解決 uppercase 半分。enum constructor / `T::` companion binding は不変)。これで既存の membership check がそのまま export 検査になり、private / pass-through 名は存在しない名前と同じ報告になる。stale persistent cache は非問題 (cache version tag が `codegen_fingerprint()` を織り込む)。

Gate: c88b62e の `gap` pin は red-instruction どおり `err` に反転して gap expectation を退役、pass-through の両面 (middleman import 拒否 / re-export 受理) を追加。type_db_cross_module_test.vibe に FS-lane テスト 4 件。

**道中で 2 つの別バグを踏んだ** (この PR では EnvCached wrapper を drop して回避、issue は coordinator が起票予定):
1. FS module lane が import を同名 local parameter より優先して解決してしまう
2. package-import の `as` alias が collect_merged_stmts lane を壊す (s5_entry_test / s5_wasm_test trap)

検証: compiler_gate.sh green end-to-end (stage2==stage3 fixpoint)、unit_test_runner.sh 537/537、check_vibe_fmt.sh clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUM9P268iMqZuBQFogx9qM)_