### PR TITLE
fix(checker/loader): inner bindings shadow cached imports; merge lane rewrites import aliases (#1583, #1584)

### DIFF
--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -90,7 +90,17 @@ export enum Subst {
 
 export fn env_bind(env: TypeEnv, name: String, ty: Type) -> TypeEnv {
   match env {
-    EnvCached(names_sorted, types_sorted, rest) => EnvCached(names_sorted, types_sorted, EnvBind(name, ty, rest)),
+    // Keeping the cache at the head is only sound while the new binding's
+    // name is NOT in the cached index: env_lookup consults the index first,
+    // so a same-named binding tucked under it would be permanently shadowed
+    // by the older cached entry (#1583 -- an import env is cached before a
+    // function body is checked, and a parameter named like an import then
+    // resolved to the import). Bind shadowing names IN FRONT of the cache.
+    EnvCached(names_sorted, types_sorted, rest) => if bsearch_leftmost(names_sorted, name) >= 0 {
+      EnvBind(name, ty, env)
+    } else {
+      EnvCached(names_sorted, types_sorted, EnvBind(name, ty, rest))
+    },
     _ => EnvBind(name, ty, env)
   }
 }

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -16,6 +16,7 @@ import @vibe/compiler/core {
   TypeDef,
   TypeEnv,
   TypeExpr,
+  append_import_alias_rewritten_non_import_stmts,
   contains_path,
   dir_of_path,
   ensure_regular_source_fs,
@@ -2402,6 +2403,12 @@ export fn collect_source_groups_fs(entry_path: String) -> Array[(String, Array[(
 
 /// Given all sources (in dependency order), parse and merge their statements.
 /// Skips SImport, SReExport (already resolved). Keeps all definitions.
+/// #1584: an `import { x as y }` alias must be rewritten back to the
+/// original name before the import statement is dropped — the merged flat
+/// program only defines `x`, so a surviving `y` reference resolves to
+/// nothing and traps at runtime. append_import_alias_rewritten_* is the
+/// same shadow-aware rewrite the production FS merge applies; a file with
+/// no aliases takes its share-the-input fast path.
 export fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] with Exception {
   let merged = array_empty()
   let mut si = 0
@@ -2409,17 +2416,7 @@ export fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] 
     let (_, src) = Array::get(sources, si)
     // Use lex+parse_program directly (skip resolve_interp_stmt to reduce heap pressure)
     let stmts = parse_program(lex(src))
-    let mut j = 0
-    while j < Array::length(stmts) {
-      let stmt = Array::get(stmts, j)
-      match stmt {
-        SImport(_, _) => (),
-        SReExport(_, _) => (),
-        SAliasDecl(_, _) => (),
-        _ => Array::push(merged, stmt)
-      }
-      j = j + 1
-    }
+    append_import_alias_rewritten_non_import_stmts(merged, stmts)
     si = si + 1
   }
   merged

--- a/lib/@vibe/compiler/tests/module_loader_test.vibe
+++ b/lib/@vibe/compiler/tests/module_loader_test.vibe
@@ -1,7 +1,11 @@
 //# Imports
 
 import @vibe/compiler/loader {
-  check_module
+  check_module, collect_merged_stmts
+}
+
+import @vibe/compiler/syntax {
+  print_program
 }
 
 import @vibe/core {
@@ -131,4 +135,19 @@ test "check_module: non-exported name not imported" {
     None => assert(true),
     _ => assert(true)
   }
+}
+
+test "collect_merged_stmts rewrites `as` aliases to the original name (#1584)" {
+  // The merged flat program only defines `env_probe`; before #1584 the
+  // alias reference `ep(1)` survived the import-dropping merge untouched
+  // and resolved to nothing at runtime (s5_entry_test / s5_wasm_test trap).
+  let dep_src = "export fn env_probe(x: Int) -> Int {\n  x + 1\n}\n"
+  let main_src = "import ./dep.vibe { env_probe as ep }\n\nexport fn use_alias() -> Int {\n  ep(1)\n}\n"
+  let merged = collect_merged_stmts([
+    ("dep.vibe", dep_src),
+    ("main.vibe", main_src)
+  ])
+  let text = print_program(merged)
+  assert(String::contains(text, "env_probe"))
+  assert(!String::contains(text, "ep("))
 }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -546,6 +546,32 @@ test "db_typecheck_fs: a pass-through import is not on the middleman's surface (
   assert(String::contains(err, "mid.vibe"))
 }
 
+test "db_typecheck_fs: a local parameter shadows a same-named import (#1583)" {
+  // The import env is cached (env_cache) before bodies are checked; a
+  // parameter named like an imported value must still shadow it. Before
+  // #1583 the cached import won and `helper + 1` failed with "type
+  // mismatch in '+'" (and the same shape could type-check yet silently
+  // resolve to the import when the types happened to agree).
+  let dir = "/tmp/vibe_compiler_import_param_shadow"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  let dep_src = "export fn helper(env: Int) -> Int {\n  env + 100\n}\n"
+  let main_src = "import ./dep.vibe { helper }\n\nfn use_it(helper: Int) -> Int {\n  helper + 1\n}\n\nexport let m = use_it(5) + helper(1)\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ]))
+  let err = export_surface_error([
+    dep_path,
+    main_path
+  ], main_path)
+  assert(err == "")
+}
+
 test "db_typecheck_fs: a re-exported name IS on the middleman's surface (#1533 control)" {
   let dir = "/tmp/vibe_compiler_export_surface_reexport"
   let dep_path = String::concat(dir, "/dep.vibe")

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -134,6 +134,24 @@ test "env_bind keeps cached env lookup path" {
   }
 }
 
+test "env_bind shadowing a cached name wins env_lookup (#1583)" {
+  // The cached index holds "x" -> CtInt; a NEWER inner binding of the same
+  // name (a parameter, a let) must shadow it. Before #1583 env_bind tucked
+  // the new binding under the cache head and env_lookup answered from the
+  // index first, so the older cached entry won silently.
+  let base = env_cache(env_bind(EnvEmpty, "x", CtInt))
+  let env = env_bind(base, "x", CtString)
+  match env_lookup(env, "x") {
+    Some(t) => assert(types_equal(t, CtString)),
+    None => assert(false)
+  }
+  // The cached fallback still answers for non-shadowed names.
+  match env_lookup(env_bind(base, "y", CtBool), "x") {
+    Some(t) => assert(types_equal(t, CtInt)),
+    None => assert(false)
+  }
+}
+
 test "env_bind over cached env remains visible to flat lookup" {
   let base = env_cache(env_bind(EnvEmpty, "x", CtInt))
   let env = env_bind(base, "x", CtString)


### PR DESCRIPTION
Closes #1583 (P0, silent-wrong), closes #1584 (P1)。P0/P1 消化レーン。

## #1583: FS module lane が import を同名 local parameter より優先して解決する

**機構**: `env_bind` (core/types.vibe) は head が `EnvCached` の env に対して新しい binding を **cache ノードの下**に押し込む一方、`env_lookup` は **cached index を最初に**引く。FS module lane は import env を `env_cache` してから body を検査する (`check_program_with_env_type_defs_observation_impl` の `env_cache(initial_env)`) ので、import と同名の parameter / let は**永遠に cache に負ける** — 型が食い違えば型エラー、一致すれば黙って import の値に解決 (P0 = silent-wrong)。単一ファイル lane は cached な値 binding を持たない seed env で始まるため踏まない — #1579 で FS lane だけが壊れた理由。

**再現** (修正前の stage2 で確認):

```vibe
// dep.vibe
export fn helper(env: Int) -> Int { env + 100 }
// main.vibe
import ./dep.vibe { helper }
fn use_it(helper: Int) -> Int { helper + 1 }
```

FS lane: `type mismatch in '+'` (helper が import の fn 型に解決)。修正後は clean。

**修正**: cached index に既にある名前だけ **cache の前に** `EnvBind` する。無い名前は従来どおり cache head を保つ (perf fast path 不変)。lookup/serializer/restrict は generic な chain walk なので EnvBind-over-EnvCached の形をそのまま扱える。

## #1584: package-import の `as` alias が collect_merged_stmts lane を壊す

**機構**: loader の `collect_merged_stmts` (s5_entry_test / s5_wasm_test / selfbuild bundle lane) は SImport を**捨てるだけ**で alias rewrite を適用しない。`import { x as y }` の `y` 参照が merged flat program に残り、`y` の定義は存在しないので runtime trap。

**修正**: per-file の append を `append_import_alias_rewritten_non_import_stmts` (production FS merge と同じ shadow-aware rewrite) に差し替え。alias の無いファイルは share-the-input fast path のまま。

## テスト

- `types_test.vibe`: cached 名を shadow する `env_bind` が `env_lookup` で勝つことを pin (+ 非 shadow 名の cached fallback)
- `type_db_cross_module_test.vibe`: FS lane (db_typecheck_fs) で parameter が同名 import を shadow する #1583 形
- `module_loader_test.vibe`: `collect_merged_stmts` が alias を original へ書き戻すことを pin

## 検証

- `scripts/compiler_gate.sh` green end-to-end (96/96、stage2 == stage3 fixpoint)
- `scripts/unit_test_runner.sh` **540/540** (gate の stage2 再利用)
- `scripts/vibe_fmt.sh --check` clean (touched files)

補足: この環境では `pkf run test` が `check_inline_builtin_capture.sh` の `sort` 呼び出しで glibc 不整合 (nix/system 混在) により落ちるため、実体の `scripts/compiler_gate.sh` を直接実行して検証した。コンテナ環境の問題で本 diff とは無関係 (同スクリプト単体実行は ok)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_