### PR TITLE
fix(loader): top-level def shadows a same-named import alias in collect_merged_stmts + builtin golden-call corpus (#1584 follow-up, #1520)

### DIFF
--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -16,7 +16,7 @@ import @vibe/compiler/core {
   TypeDef,
   TypeEnv,
   TypeExpr,
-  append_import_alias_rewritten_non_import_stmts,
+  append_import_alias_rewritten_non_import_stmts_skipping,
   contains_path,
   dir_of_path,
   ensure_regular_source_fs,
@@ -2408,7 +2408,10 @@ export fn collect_source_groups_fs(entry_path: String) -> Array[(String, Array[(
 /// program only defines `x`, so a surviving `y` reference resolves to
 /// nothing and traps at runtime. append_import_alias_rewritten_* is the
 /// same shadow-aware rewrite the production FS merge applies; a file with
-/// no aliases takes its share-the-input fast path.
+/// no aliases takes its share-the-input fast path. A top-level `let`/`fn`
+/// whose name matches an alias shadows the import for the WHOLE file (the
+/// per-statement rewrite only suppresses the map inside the declaring
+/// statement), so those aliases are dropped from the map up front.
 export fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] with Exception {
   let merged = array_empty()
   let mut si = 0
@@ -2416,7 +2419,17 @@ export fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] 
     let (_, src) = Array::get(sources, si)
     // Use lex+parse_program directly (skip resolve_interp_stmt to reduce heap pressure)
     let stmts = parse_program(lex(src))
-    append_import_alias_rewritten_non_import_stmts(merged, stmts)
+    let top_level_value_names = array_empty()
+    let mut ti = 0
+    while ti < Array::length(stmts) {
+      match Array::get(stmts, ti) {
+        SLet(_, _, name, _, _) => Array::push(top_level_value_names, name),
+        SLetMut(name, _, _) => Array::push(top_level_value_names, name),
+        _ => ()
+      }
+      ti = ti + 1
+    }
+    append_import_alias_rewritten_non_import_stmts_skipping(merged, stmts, top_level_value_names)
     si = si + 1
   }
   merged

--- a/lib/@vibe/compiler/tests/builtin_registry_golden_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_registry_golden_test.vibe
@@ -1,0 +1,156 @@
+//# Imports
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/core {
+  Type, builtin_registry_typed
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+/// #1520 proposal 3: a literal source expression that inhabits `t`, or None
+/// when the type has no closed literal spelling (generic named types,
+/// function-typed parameters, ...). Rows whose parameters are all
+/// constructible get a golden call; the rest are skipped, and the coverage
+/// assert at the bottom keeps the skip set from silently swallowing the
+/// corpus.
+fn literal_for_type(t: Type) -> Option[String] {
+  match t {
+    CtInt => Some("1"),
+    CtDouble => Some("1.0"),
+    CtBool => Some("true"),
+    CtString => Some("\"s\""),
+    CtChar => Some("'a'"),
+    CtUnit => Some("()"),
+    CtBytes => Some("Bytes::new()"),
+    // A polymorphic/unchecked slot accepts anything; Int is the simplest.
+    CtUnknown => Some("1"),
+    CtArray(elem) => match literal_for_type(elem) {
+      Some(inner) => Some(String::concat("[", String::concat(inner, "]"))),
+      None => None
+    },
+    CtOption(elem) => match literal_for_type(elem) {
+      Some(inner) => Some(String::concat("Some(", String::concat(inner, ")"))),
+      None => None
+    },
+    CtTuple(items) => {
+      let mut acc = "("
+      let mut i = 0
+      let mut ok = true
+      while i < Array::length(items) && ok {
+        match literal_for_type(Array::get(items, i)) {
+          Some(inner) => {
+            acc = if i == 0 {
+              String::concat(acc, inner)
+            } else {
+              String::concat(acc, String::concat(", ", inner))
+            }
+          },
+          None => {
+            ok = false
+          }
+        }
+        i = i + 1
+      }
+      if ok && Array::length(items) > 1 {
+        Some(String::concat(acc, ")"))
+      } else {
+        None
+      }
+    },
+    _ => None
+  }
+}
+
+/// The golden call source for one registry row, or None when the row is not
+/// exercisable as a plain pure call: effectful rows need an ambient row this
+/// harness does not provide, and rows with non-literal parameter types have
+/// no closed argument spelling.
+fn golden_call_source(name: String, ty: Type) -> Option[String] {
+  match ty {
+    CtFn(params, _, effect) => match effect {
+      Some(_) => None,
+      None => {
+        let mut args = ""
+        let mut i = 0
+        let mut ok = true
+        while i < Array::length(params) && ok {
+          match literal_for_type(Array::get(params, i)) {
+            Some(lit) => {
+              args = if i == 0 {
+                lit
+              } else {
+                String::concat(args, String::concat(", ", lit))
+              }
+            },
+            None => {
+              ok = false
+            }
+          }
+          i = i + 1
+        }
+        if ok {
+          Some(String::concat("let golden_result = ", String::concat(name, String::concat("(", String::concat(args, ")")))))
+        } else {
+          None
+        }
+      }
+    },
+    _ => None
+  }
+}
+
+fn checks_cleanly(source: String) -> Bool {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    true
+  } with Exception {
+    Throw(_) => false
+  }
+}
+
+//# Misc
+
+test "every constructible registry builtin accepts its golden call (#1520)" {
+  // Proposal 3 of #1520: pin one ACCEPTED call per checker-visible registry
+  // row. A registry row nobody calls can be wrong without anyone noticing
+  // (that was `eq` before #1519, rejected only once a doctest happened to
+  // exercise it); this corpus makes the checker read every constructible row
+  // on every test run. Catches both over-restrictive declarations and
+  // consumer-side normalization gaps (the `Char::to_int` head-fold class),
+  // which the #1523 registry-vs-lane diff cannot see.
+  let rows = builtin_registry_typed()
+  let mut i = 0
+  let mut checked = 0
+  let mut failed = 0
+  while i < Array::length(rows) {
+    let (name, ty, _, _, visible) = Array::get(rows, i)
+    if visible {
+      match golden_call_source(name, ty) {
+        Some(source) => {
+          if checks_cleanly(source) {
+            ()
+          } else {
+            println("golden call rejected for \{name}: \{source}")
+            failed = failed + 1
+          }
+          checked = checked + 1
+        },
+        None => ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  assert(failed == 0)
+  // Guard against the corpus silently shrinking to nothing (e.g. a Type
+  // refactor that makes every parameter non-constructible).
+  assert(checked > 40)
+}

--- a/lib/@vibe/compiler/tests/module_loader_test.vibe
+++ b/lib/@vibe/compiler/tests/module_loader_test.vibe
@@ -151,3 +151,18 @@ test "collect_merged_stmts rewrites `as` aliases to the original name (#1584)" {
   assert(String::contains(text, "env_probe"))
   assert(!String::contains(text, "ep("))
 }
+
+test "collect_merged_stmts: a top-level def shadows a same-named import alias (#1584)" {
+  // `fn shade` is declared in the importing file itself; references to
+  // `shade` anywhere in that file must keep resolving to the local def,
+  // not get rewritten to the aliased import's original name.
+  let dep_src = "export fn tint(x: Int) -> Int {\n  x + 1\n}\n"
+  let main_src = "import ./dep.vibe { tint as shade }\n\nfn shade() -> Int {\n  5\n}\n\nexport let picked = shade()\n"
+  let merged = collect_merged_stmts([
+    ("dep.vibe", dep_src),
+    ("main.vibe", main_src)
+  ])
+  let text = print_program(merged)
+  assert(String::contains(text, "shade()"))
+  assert(!String::contains(text, "tint()"))
+}


### PR DESCRIPTION
#1588 の follow-up 2 件。

## 1. #1584 follow-up — Codex review (P1) 対応

#1588 の `collect_merged_stmts` alias rewrite には抜けがあった: per-statement の rewrite は**宣言している statement の中でしか** alias を抑制しないので、`import { tint as shade }` と top-level `fn shade` を両方持つファイルでは、**他の statement** の `shade` 参照が import 側の `tint` に書き換えられ、local def ではなく依存側を黙って選ぶ (#1588 以前の drop-imports 挙動ではこの形は正しく解決していたので、regression 芽)。

**修正**: rewrite の前に、ファイル自身の top-level `let`/`fn` 名で alias map をフィルタする (`append_import_alias_rewritten_non_import_stmts_skipping`)。「内側/ローカルの binding が import に勝つ」という #1583 と同じ規則に揃う。

**テスト**: `module_loader_test.vibe` に shadow 形を pin (`shade()` が残り `tint()` に書き換わらないこと)。

## 2. #1520 提案3 — builtin registry の golden 正例コーパス

`builtin_registry_golden_test.vibe`: checker-visible なレジストリ行のうち、pure かつリテラルから構築可能な signature を持つ **78 行** (pure 81 行中、visible 133 / 全 154 行) について「通るべき呼び出し」を生成して checker に食わせ、全行 accept を assert する。

- 過剰 reject な宣言 (#1519 以前の `eq` クラス) と consumer 側の正規化漏れ (`Char::to_int` の head-fold クラス) の**両方**を拾える — #1523 の registry↔lane 差分検査では見えない方
- effectful な行は ambient row をこのハーネスが提供しないため v1 では対象外 (skip)。カバレッジが黙って縮まないよう `checked > 40` も assert
- 失敗時は行名と生成した呼び出しを println してから assert で落ちる

## 検証

- `scripts/compiler_gate.sh` green end-to-end (stage2 == stage3 fixpoint)
- `scripts/unit_test_runner.sh` **541/541** (gate の stage2 再利用)
- `scripts/vibe_fmt.sh --check` clean (touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_