### PR TITLE
fix(diag): handle 適格性エラーに犯人の呼び出しと line:col を付ける (#1514 C 完結) + registry の reg_any/reg_opaque 綴り分け (#1520 提案2)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1356,11 +1356,18 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
 (`vibe diagnostics` は単一ファイル解析なので対象外):
 
 ```
-handle of effect 'Ask' cannot be compiled here. Every perform this handle
-covers has to be statically visible to it, so the handled body may only:
-perform directly, call a named top-level `fn`, or call a closure literal that
-carries an effect row annotation. ...
+line 5:12-16: handle of effect 'Ask' cannot be compiled here. Every perform
+this handle covers has to be statically visible to it, so the handled body may
+only: perform directly, call a named top-level `fn`, or call a closure literal
+that carries an effect row annotation. A call through a local binding or a
+closure parameter hides the perform and is what this rejects (here: the call
+to 'bump') ...
 ```
+
+診断は**どの呼び出しが不適格かを名指しし、その `line:col` を指す** (#1514)。
+`line:col` は handle ではなく犯人の呼び出し (上の例では `bump`) の位置。
+複数ファイルで犯人が依存側モジュールにあるときは位置なしに落ちる
+(entry ファイルの誤った行を指すより位置なしを選ぶ)。
 
 実測した境界は **handled body が呼ぶ callee の種類**。handle 自体が top-level
 `let` にあるか `fn` の中にあるかは**無関係**で、`ask_once` を `fn` で宣言したか

--- a/eval/lang-review/repair/08_handle_ineligible/diag.grep
+++ b/eval/lang-review/repair/08_handle_ineligible/diag.grep
@@ -1,3 +1,5 @@
 handle of effect 'Ask' cannot be compiled here
 perform directly, call a named top-level `fn`, or call a closure literal that carries an effect row annotation
 move the `handle` into the function that performs
+here: the call to 'bump'
+line 9:20-24

--- a/eval/lang-review/repair/README.md
+++ b/eval/lang-review/repair/README.md
@@ -271,3 +271,35 @@ r6 が直接比較できなくなる。
 足す場合は r6 の仕事として、**10ケース版と11ケース版の両方を報告する**こと。
 コーパスの「追加は可」規則はそのままだが、追加したラウンドは推移が
 二重になる、という運用上の注記。
+
+## 更新: #1514 C の残り — 08 が位置と名指しを得た (r5 内更新)
+
+「08 の残り2点は同じ1つの作業で取れる」(上の #1511 (c) 節) を実施した。
+`edp_body_has_opaque_call` (Bool) の隣に、同じ判定で**最初の不適格な呼び出し**を
+`(callee 名, source offset)` で返す walker を足し
+(`edp_first_opaque_call_info` / `edp_live_handle_opaque_info`,
+`inline_direct_perform.vibe`)、エラー文に `(here: the call to 'bump')` と
+` [@off=N:M]` marker を付けた。EHandle 自体は offset を持たないが、**編集位置と
+して正しいのは handle ではなく犯人の呼び出し**なので、AST に手を入れずに済む。
+
+位置の解決は「基準ソースを知っているレーンだけ」が行う:
+
+- **`vibe check`** (`check_linked_file`): entry ソースに対して解決。ただし
+  merged stmts には依存モジュール由来の offset も流れてくるので、
+  `verify_culprit_off_marker` (cli_support.vibe) が **span がその位置に犯人名を
+  実際に綴っているか**を検証してから解決する。不一致 (依存側の offset) は
+  marker を剥がして位置なしに降りる — もっともらしく間違った行を指すのは
+  位置なしより悪い (#1445 の教訓)
+- **FS-compile レーン** (`vibe build/run/test`, この repair ハーネス):
+  `emit_compile_diag_fs_located` (cli_adapter.vibe) が同じ検証付きで解決
+- **single-source レーン** (self-build 用): desugar 後の AST で offset が
+  失われるため名指しのみ・位置なし (marker は `emit_compile_diag` が常に
+  剥がすので生の `[@off=` は漏れない)
+
+| # | 位置 (before → after) | 名指し | L | C | 計 |
+|---|---|---|---|---|---|
+| 08 | なし → **`line 9:20-24`** (犯人の `bump` 呼び出しそのもの) | **`(here: the call to 'bump')`** | 0 → **1** | 1 → **2** | 2 → **4** |
+
+mean = 40/10 = 4.0 → **repair_convergence = 5.0**。コーパス10ケースの減点は
+これで無くなった。以降スコアを動かすには新しい種別の発見が必要 (上の
+「追加候補」節の運用に従う)。

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -83,7 +83,7 @@ import @vibe/compiler/syntax {
 }
 
 import ./cli_support.vibe {
-  check_deprecated_warnings, check_linked_file, strip_executable_wasm_env
+  check_deprecated_warnings, check_linked_file, strip_executable_wasm_env, verify_culprit_off_marker
 }
 
 import @vibe/lsp {
@@ -332,12 +332,35 @@ fn compile_source_for_rc_flag(source: String, entry_name: String, rc_flag: Strin
   }
 }
 
+/// Remove a ` [@off=...]` side-channel marker WITHOUT resolving it. The marker
+/// is internal transport for a source offset (#1514); a lane that does not know
+/// which source text the offset indexes (the FS-compile lane compiles MERGED
+/// module text) must degrade to the unlocated message -- never print the raw
+/// marker (#1445's leaked `[@off=135]` is the failure mode this guards against).
+fn strip_off_marker(msg: String) -> String {
+  let marker = " [@off="
+  let mi = String::index_of(msg, marker)
+  if mi < 0 {
+    msg
+  } else {
+    let inner_start = mi + String::length(marker)
+    let rest = String::substring(msg, inner_start, String::length(msg))
+    let rel = String::index_of(rest, "]")
+    if rel < 0 {
+      String::substring(msg, 0, mi)
+    } else {
+      String::concat(String::substring(msg, 0, mi), String::substring(msg, inner_start + rel + 1, String::length(msg)))
+    }
+  }
+}
+
 /// On a parse/type/codegen error the checker throws a formatted diagnostic
 /// String. Surface it to tooling by writing it to an `<output>.diag` sidecar so
 /// the `vibe` launcher can print a real message instead of an opaque wasm trap.
 /// Returns a non-zero exit code. (#594 usability / docs/release-roadmap.md.)
+/// Always strips an unresolved ` [@off=...]` marker -- see strip_off_marker.
 fn emit_compile_diag(output_path: String, msg: String) -> Int with Fs {
-  Fs::write_file(String::concat(output_path, ".diag"), msg)
+  Fs::write_file(String::concat(output_path, ".diag"), strip_off_marker(msg))
   1
 }
 
@@ -360,6 +383,30 @@ fn emit_compile_diag(output_path: String, msg: String) -> Int with Fs {
 fn emit_compile_diag_located(output_path: String, msg: String, source: String) -> Int with Fs {
   if String::contains(msg, " [@off=") {
     emit_compile_diag(output_path, locate_type_error(source, msg))
+  } else {
+    emit_compile_diag(output_path, msg)
+  }
+}
+
+/// #1514 (repair 08): the FS-compile lane's located variant. This lane
+/// compiles MERGED module text, so a marker's offsets index whichever module
+/// the diagnostic came from -- resolving blindly against the entry file could
+/// name a plausible-but-wrong line (#1445's leaked-marker lesson, one step
+/// worse). Only the evidence-passing culprit marker is resolvable here,
+/// because it carries its own proof: the message names the culprit callee and
+/// the span, so `verify_culprit_off_marker` can check the entry text actually
+/// spells that callee at that span before locate_type_error renders it. Any
+/// other (or failed-verify) marker degrades to the stripped, unlocated
+/// message via emit_compile_diag.
+fn emit_compile_diag_fs_located(output_path: String, msg: String, input_path: String) -> Int with Fs + Exception {
+  if String::contains(msg, " [@off=") && String::contains(msg, " (here: the call to '") {
+    let entry_source = Fs::read_file(input_path)
+    let verified = verify_culprit_off_marker(entry_source, msg)
+    if String::contains(verified, " [@off=") {
+      emit_compile_diag(output_path, locate_type_error(entry_source, verified))
+    } else {
+      emit_compile_diag(output_path, verified)
+    }
   } else {
     emit_compile_diag(output_path, msg)
   }
@@ -1023,7 +1070,12 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       }
       0
     } with Exception {
-      Throw(msg) => emit_compile_diag(output_path, msg)
+      // #1514: the evidence-passing culprit marker's offsets index whichever
+      // MODULE the offending handle lives in; resolve against the entry file
+      // only when the span provably spells the culprit there (see
+      // emit_compile_diag_fs_located). Everything else degrades to the
+      // stripped, unlocated message as before.
+      Throw(msg) => emit_compile_diag_fs_located(output_path, msg, input_path)
     }
   }
   // #594 `vibe normalize`: canonicalize a source file (module flatten + DCE +

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -152,6 +152,73 @@ fn append_non_import_stmts(dst: Array[Stmt], src: Array[Stmt]) -> Unit {
   }
 }
 
+/// #1514 C (repair 08): the evidence-passing hard error carries the culprit
+/// call as `(here: the call to 'X') ... [@off=N:M]`, where N:M index the text
+/// of whichever MODULE the handle lives in. This lane resolves markers against
+/// the ENTRY file's text, which is only correct when the culprit is in the
+/// entry file itself. Verify the span actually spells `X` in `source` before
+/// letting locate_type_error resolve it; on mismatch (a dep-module offset)
+/// strip the marker so the message degrades to unlocated instead of naming a
+/// plausible-but-wrong entry-file line (worse than no position, per #1445).
+/// Messages without the culprit clause pass through untouched.
+/// Parse a run of ASCII digits as a non-negative Int, or -1 when `s` is empty
+/// or contains any non-digit (local copy of typecheck_fs's parse_offset_digits,
+/// which is module-private there).
+fn parse_marker_digits(s: String) -> Int {
+  let n = String::length(s)
+  let mut i = 0
+  let mut acc = 0
+  let mut ok = n > 0
+  while i < n && ok {
+    let c = String::char_code_at(s, i)
+    if c >= 48 && c <= 57 {
+      acc = acc * 10 + (c - 48)
+    } else {
+      ok = false
+    }
+    i = i + 1
+  }
+  if ok {
+    acc
+  } else {
+    -1
+  }
+}
+
+export fn verify_culprit_off_marker(source: String, msg: String) -> String {
+  let clause = " (here: the call to '"
+  let ci = String::index_of(msg, clause)
+  let marker = " [@off="
+  let mi = String::index_of(msg, marker)
+  if ci < 0 || mi < 0 {
+    msg
+  } else {
+    let name_start = ci + String::length(clause)
+    let name_rel = String::index_of(String::substring(msg, name_start, String::length(msg)), "')")
+    let inner_start = mi + String::length(marker)
+    let close_rel = String::index_of(String::substring(msg, inner_start, String::length(msg)), "]")
+    if name_rel < 0 || close_rel < 0 {
+      msg
+    } else {
+      let culprit = String::substring(msg, name_start, name_start + name_rel)
+      let inner = String::substring(msg, inner_start, inner_start + close_rel)
+      let colon = String::index_of(inner, ":")
+      let span_ok = if colon < 0 {
+        false
+      } else {
+        let n = parse_marker_digits(String::substring(inner, 0, colon))
+        let m = parse_marker_digits(String::substring(inner, colon + 1, String::length(inner)))
+        n >= 0 && m > n && m <= String::length(source) && String::substring(source, n, m) == culprit
+      }
+      if span_ok {
+        msg
+      } else {
+        String::concat(String::substring(msg, 0, mi), String::substring(msg, inner_start + close_rel + 1, String::length(msg)))
+      }
+    }
+  }
+}
+
 export fn build_linked_debug_entry(input_path: String, entry_name: String) -> (Bytes, Array[(String, String)]) with Exception + Fs {
   let (entry_stmts, resolved_type_stmts, linked_imports, linked_dep_specs) = collect_linked_compile_inputs(input_path)
   let main_stmts = array_empty()
@@ -220,7 +287,10 @@ export fn check_linked_file(input_path: String) -> Int with Exception + Fs {
       None => ()
     }
   } with Exception {
-    Throw(msg) => throw(locate_type_error(entry_source, msg))
+    // #1514: verify_culprit_off_marker first — the evidence-passing culprit
+    // marker may index a DEP module's text; only a span that provably spells
+    // the culprit in the entry file is allowed to resolve against it.
+    Throw(msg) => throw(locate_type_error(entry_source, verify_culprit_off_marker(entry_source, msg)))
   }
   0
 }

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -1,7 +1,15 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, TypeExpr, dce_keep_flags, is_exception_effect_name, is_exception_throw_handler_name, is_exception_throw_operation
+  Expr,
+  Pat,
+  Stmt,
+  TypeExpr,
+  dce_keep_flags,
+  expr_children,
+  is_exception_effect_name,
+  is_exception_throw_handler_name,
+  is_exception_throw_operation
 }
 
 import @vibe/core {
@@ -1141,7 +1149,38 @@ export fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[St
         // reader had to get past two clauses of it to reach the only advice
         // that acts on their program. The ADR reference is kept, at the end,
         // for the reader who does want the design record.
-        Array::push(errs, String::concat(String::concat("handle of effect '", bad), "' cannot be compiled here. Every perform this handle covers has to be statically visible to it, so the handled body may only: perform directly, call a named top-level `fn`, or call a closure literal that carries an effect row annotation. A call through a local binding or a closure parameter hides the perform and is what this rejects -- move the `handle` into the function that performs, or replace the indirect call with a direct one. (ADR-0076 evidence-passing migration; the replay engine that used to accept this shape was removed.)"))
+        //
+        // #1514 C (repair 08): name WHICH call hides the perform and carry its
+        // source offset as the ` [@off=N:M]` marker (resolved to `line:col` by
+        // the lanes that know the source basis, ALWAYS stripped before a user
+        // sees it). EHandle itself has no offset field, but the offending
+        // CALL does -- and the call is the better edit point anyway. inert /
+        // fn_names are recomputed here (error path only): the erasure and
+        // migration passes above have mutated `stmts` since the vhe_* sets
+        // were built.
+        let li_fn_defs = edp_collect_fn_defs(stmts)
+        let li_fn_names = edp_all_fn_names(li_fn_defs)
+        let li_inert = edp_pure_fn_names(li_fn_defs)
+        edp_append_free_host_inert_names(stmts, li_inert)
+        let (culprit_raw, culprit_off) = edp_live_handle_opaque_info(stmts, keep, bad, li_inert, li_fn_names)
+        let culprit = edp_unmangle_shadow_name(culprit_raw)
+        let head = String::concat(String::concat("handle of effect '", bad), "' cannot be compiled here. Every perform this handle covers has to be statically visible to it, so the handled body may only: perform directly, call a named top-level `fn`, or call a closure literal that carries an effect row annotation. A call through a local binding or a closure parameter hides the perform and is what this rejects")
+        let named = if String::length(culprit) > 0 {
+          String::concat(head, String::concat(" (here: the call to '", String::concat(culprit, "')")))
+        } else {
+          head
+        }
+        let full = String::concat(named, " -- move the `handle` into the function that performs, or replace the indirect call with a direct one. (ADR-0076 evidence-passing migration; the replay engine that used to accept this shape was removed.)")
+        let marked = if culprit_off >= 0 {
+          if String::length(culprit) > 0 {
+            String::concat(full, String::concat(" [@off=", String::concat(__to_string(culprit_off), String::concat(":", String::concat(__to_string(culprit_off + String::length(culprit)), "]")))))
+          } else {
+            String::concat(full, String::concat(" [@off=", String::concat(__to_string(culprit_off), "]")))
+          }
+        } else {
+          full
+        }
+        Array::push(errs, marked)
       }
     } else {
       ()
@@ -2328,29 +2367,38 @@ fn edp_first_live_replay_handle(stmts: Array[Stmt], keep: Array[Bool]) -> String
   found
 }
 
+/// The effect desc a `handle`'s arm list claims: the first arm's effect name,
+/// `"<catch-all>"` for a wildcard/binder arm, `""` for an Error handle (or no
+/// arms). Shared by the live-handle check and the #1514 culprit-call locator so
+/// both agree on WHICH handle a given desc refers to.
+fn edp_handle_own_effect_desc(arms: Array[(Pat, Expr)]) -> String {
+  let mut own = ""
+  if Array::length(arms) > 0 {
+    let (p, _) = Array::get(arms, 0)
+    match p {
+      PCtor(qname, _) => if is_exception_throw_operation(qname) {
+        ()
+      } else {
+        own = edp_effect_name_of(qname)
+      },
+      PWild => {
+        own = "<catch-all>"
+      },
+      PBind(_) => {
+        own = "<catch-all>"
+      },
+      _ => ()
+    }
+  } else {
+    ()
+  }
+  own
+}
+
 fn edp_nonerror_handle_desc_expr(expr: Expr) -> String {
   match expr {
     EHandle(body, arms) => {
-      let mut own = ""
-      if Array::length(arms) > 0 {
-        let (p, _) = Array::get(arms, 0)
-        match p {
-          PCtor(qname, _) => if is_exception_throw_operation(qname) {
-            ()
-          } else {
-            own = edp_effect_name_of(qname)
-          },
-          PWild => {
-            own = "<catch-all>"
-          },
-          PBind(_) => {
-            own = "<catch-all>"
-          },
-          _ => ()
-        }
-      } else {
-        ()
-      }
+      let own = edp_handle_own_effect_desc(arms)
       if own == "" {
         let inner = edp_nonerror_handle_desc_expr(body)
         if inner == "" {
@@ -2533,6 +2581,158 @@ fn edp_nonerror_handle_desc_arms(arms: Array[(Pat, Expr)]) -> String {
     i = i + 1
   }
   out
+}
+
+/// --- #1514 C (repair 08): name the call that made a live handle ineligible.
+///
+/// `edp_body_has_opaque_call` answers only Bool, so the live-handle hard error
+/// could say WHAT is rejected (an indirect call) but not WHERE. This trio walks
+/// the same shapes and returns the first offending call as
+/// (found, callee name, source byte offset): the exact edit point. Callee name
+/// is "" when the callee is not a bare identifier (an arbitrary callee
+/// expression); offset is -1 when the node carries none (synthesized AST).
+
+fn edp_first_opaque_call_info(expr: Expr, inert: Array[String], fn_names: Array[String]) -> (Bool, String, Int) {
+  match expr {
+    ECall(callee, args, off) => match callee {
+      EIdent(nm, ioff) => if edp_callee_is_resolvable(nm, inert, fn_names) {
+        edp_first_opaque_call_info_exprs(args, inert, fn_names)
+      } else {
+        (true, nm, if ioff >= 0 {
+          ioff
+        } else {
+          off
+        })
+      },
+      _ => (true, "", off)
+    },
+    _ => edp_first_opaque_call_info_exprs(expr_children(expr), inert, fn_names)
+  }
+}
+
+fn edp_first_opaque_call_info_exprs(es: Array[Expr], inert: Array[String], fn_names: Array[String]) -> (Bool, String, Int) {
+  let mut i = 0
+  let mut found = false
+  let mut nm = ""
+  let mut off = -1
+  while i < Array::length(es) && !found {
+    let (f, n, o) = edp_first_opaque_call_info(Array::get(es, i), inert, fn_names)
+    found = f
+    nm = n
+    off = o
+    i = i + 1
+  }
+  (found, nm, off)
+}
+
+/// Find the first `handle` whose arm list claims effect `ename` (the desc
+/// edp_first_live_replay_handle just reported) and name the first opaque call
+/// in its BODY. Returns ("", -1) when the handle is found but its body has no
+/// opaque call (it survived for another reason), or when no such handle is in
+/// reachable code (should not happen when called with a live desc).
+fn edp_live_handle_opaque_info_expr(expr: Expr, ename: String, inert: Array[String], fn_names: Array[String]) -> (Bool, String, Int) {
+  match expr {
+    EHandle(body, arms) => if edp_handle_own_effect_desc(arms) == ename {
+      let (_, nm, off) = edp_first_opaque_call_info(body, inert, fn_names)
+      (true, nm, off)
+    } else {
+      edp_live_handle_opaque_info_exprs(expr_children(expr), ename, inert, fn_names)
+    },
+    _ => edp_live_handle_opaque_info_exprs(expr_children(expr), ename, inert, fn_names)
+  }
+}
+
+fn edp_live_handle_opaque_info_exprs(es: Array[Expr], ename: String, inert: Array[String], fn_names: Array[String]) -> (Bool, String, Int) {
+  let mut i = 0
+  let mut found = false
+  let mut nm = ""
+  let mut off = -1
+  while i < Array::length(es) && !found {
+    let (f, n, o) = edp_live_handle_opaque_info_expr(Array::get(es, i), ename, inert, fn_names)
+    found = f
+    nm = n
+    off = o
+    i = i + 1
+  }
+  (found, nm, off)
+}
+
+/// Stmt-level driver; mirrors edp_first_live_replay_handle's walk order and
+/// its dead-`fn` exemption so it lands on the same handle the desc came from.
+fn edp_live_handle_opaque_info(stmts: Array[Stmt], keep: Array[Bool], ename: String, inert: Array[String], fn_names: Array[String]) -> (String, Int) {
+  let mut i = 0
+  let mut found = false
+  let mut nm = ""
+  let mut off = -1
+  while i < Array::length(stmts) && !found {
+    match Array::get(stmts, i) {
+      SLet(_, _, _, _, expr) => {
+        let dead_fn = match expr {
+          EFn(_, _, _, _, _, _) => if i < Array::length(keep) {
+            !Array::get(keep, i)
+          } else {
+            false
+          },
+          _ => false
+        }
+        if dead_fn {
+          ()
+        } else {
+          let (f, n, o) = edp_live_handle_opaque_info_expr(expr, ename, inert, fn_names)
+          found = f
+          nm = n
+          off = o
+        }
+      },
+      SLetMut(_, _, expr) => {
+        let (f, n, o) = edp_live_handle_opaque_info_expr(expr, ename, inert, fn_names)
+        found = f
+        nm = n
+        off = o
+      },
+      SExpr(expr) => {
+        let (f, n, o) = edp_live_handle_opaque_info_expr(expr, ename, inert, fn_names)
+        found = f
+        nm = n
+        off = o
+      },
+      STest(_, expr) => {
+        let (f, n, o) = edp_live_handle_opaque_info_expr(expr, ename, inert, fn_names)
+        found = f
+        nm = n
+        off = o
+      },
+      SBench(_, expr) => {
+        let (f, n, o) = edp_live_handle_opaque_info_expr(expr, ename, inert, fn_names)
+        found = f
+        nm = n
+        off = o
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  (nm, off)
+}
+
+/// A culprit callee that went through edp_alpha_rename_shadowed carries a
+/// `__edpsh_<N>_` prefix that exists nowhere in the user's source; report the
+/// original spelling (the rename preserves the node's offset, and the binder's
+/// source text IS the original name, so the un-mangled spelling and its span
+/// both match the file).
+fn edp_unmangle_shadow_name(nm: String) -> String {
+  let prefix = "__edpsh_"
+  if String::index_of(nm, prefix) == 0 {
+    let rest = String::substring(nm, String::length(prefix), String::length(nm))
+    let us = String::index_of(rest, "_")
+    if us > 0 {
+      String::substring(rest, us + 1, String::length(rest))
+    } else {
+      nm
+    }
+  } else {
+    nm
+  }
 }
 
 /// Drop any `needing` name whose OWN top-level definition `keep` (from

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -49,6 +49,34 @@ import @vibe/core {
 // sees those names, and their synthesized types only feed the derived
 // param/returns view.
 
+// #1520 提案2: rows spell the unconstrained type by MEANING, not by the raw
+// constructor, so a reader can tell a deliberately-unchecked position from a
+// placeholder someone forgot to fill in:
+//
+//   - reg_any()     — deliberately POLYMORPHIC: any value type is legal at this
+//                     position and the checker's head-kind compare tolerates it
+//                     (`eq` / `assert_eq`, container element types).
+//   - reg_opaque(k) — an internal HANDLE with no checker-type representation
+//                     (builder objects, Map). `k` names the handle kind for the
+//                     reader; the value is ignored.
+//   - bare CtUnknown — not allowed in rows. It reads as "not written yet",
+//                     which is exactly how the #1519 `eq`-declared-as-CtInt
+//                     class of lie stayed invisible: nothing distinguished a
+//                     row nobody had thought about from a row deliberately
+//                     left open.
+//
+// All three produce the same runtime value (CtUnknown) — this is documentation
+// the type system cannot express, enforced by review + the golden positive
+// corpus (builtin_registry_golden_test.vibe), not by the checker.
+fn reg_any() -> Type {
+  CtUnknown
+}
+
+fn reg_opaque(kind: String) -> Type {
+  let _ = kind
+  CtUnknown
+}
+
 fn reg_p0() -> Array[Type] {
   array_empty()
 }
@@ -259,29 +287,29 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("String::length", CtFn(reg_p1(CtString), CtInt, None), true, true, true),
   ("String::equals", CtFn(reg_p2(CtString, CtString), CtBool, None), true, true, true),
   ("String::concat", CtFn(reg_p2(CtString, CtString), CtString, None), true, true, true),
-  ("array_new", CtFn(reg_p0(), CtArray(CtUnknown), None), true, true, true),
-  ("Array::length", CtFn(reg_p1(CtArray(CtUnknown)), CtInt, None), true, true, true),
-  ("Array::get", CtFn(reg_p2(CtArray(CtUnknown), CtInt), CtUnknown, None), true, true, true),
-  ("Array::push", CtFn(reg_p2(CtArray(CtUnknown), CtUnknown), CtUnit, None), true, true, true),
-  ("Array::push_all", CtFn(reg_p2(CtArray(CtUnknown), CtArray(CtUnknown)), CtUnit, None), true, true, true),
-  ("Array::set", CtFn(reg_p3(CtArray(CtUnknown), CtInt, CtUnknown), CtUnit, None), true, true, true),
+  ("array_new", CtFn(reg_p0(), CtArray(reg_any()), None), true, true, true),
+  ("Array::length", CtFn(reg_p1(CtArray(reg_any())), CtInt, None), true, true, true),
+  ("Array::get", CtFn(reg_p2(CtArray(reg_any()), CtInt), reg_any(), None), true, true, true),
+  ("Array::push", CtFn(reg_p2(CtArray(reg_any()), reg_any()), CtUnit, None), true, true, true),
+  ("Array::push_all", CtFn(reg_p2(CtArray(reg_any()), CtArray(reg_any())), CtUnit, None), true, true, true),
+  ("Array::set", CtFn(reg_p3(CtArray(reg_any()), CtInt, reg_any()), CtUnit, None), true, true, true),
   ("Double::to_int", CtFn(reg_p1(CtDouble), CtInt, None), true, true, true),
   ("Int::to_double", CtFn(reg_p1(CtInt), CtDouble, None), true, true, true),
   ("String::char_code_at", CtFn(reg_p2(CtString, CtInt), CtInt, None), true, true, true),
   ("String::from_char_code", CtFn(reg_p1(CtInt), CtString, None), true, true, true),
   ("String::substring", CtFn(reg_p3(CtString, CtInt, CtInt), CtString, None), true, true, true),
-  ("Array::truncate", CtFn(reg_p2(CtArray(CtUnknown), CtInt), CtUnit, None), true, true, true),
+  ("Array::truncate", CtFn(reg_p2(CtArray(reg_any()), CtInt), CtUnit, None), true, true, true),
   ("String::join", CtFn(reg_p2(CtArray(CtString), CtString), CtString, None), true, true, true),
   // #1513: POLYMORPHIC — `eq` is the structural equality builtin and is applied
   // to enums / structs / strings, not just Int. The `CtInt` placeholder here was
   // harmless while nothing read these parameter types; once the checker's
   // fast-path argument check started consulting the registry it turned into a
   // false rejection (measured: `eq(Color::Red, c)` in
-  // docs/language-tour/basics.vibe.md). `CtUnknown` is what the sibling
+  // docs/language-tour/basics.vibe.md). `reg_any()` is what the sibling
   // polymorphic row `assert_eq` already declares, and head_kind maps it to
   // "tolerate". Parameter COUNT and return type are unchanged, so the derived
   // `builtin_registry()` view the codegen lanes read is byte-identical.
-  ("eq", CtFn(reg_p2(CtUnknown, CtUnknown), CtBool, None), true, true, true),
+  ("eq", CtFn(reg_p2(reg_any(), reg_any()), CtBool, None), true, true, true),
   ("String::ends_with", CtFn(reg_p2(CtString, CtString), CtBool, None), true, true, true),
   ("String::last_index_of", CtFn(reg_p2(CtString, CtString), CtInt, None), true, true, true),
   ("String::index_of", CtFn(reg_p2(CtString, CtString), CtInt, None), true, true, true),
@@ -290,25 +318,25 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("String::split", CtFn(reg_p2(CtString, CtString), CtArray(CtString), None), true, true, true),
   ("String::trim", CtFn(reg_p1(CtString), CtString, None), true, true, true),
   ("compiler_sources", CtFn(reg_p0(), CtString, None), true, false, false),
-  ("ArrayBuilder::new", CtFn(reg_p0(), CtUnknown, None), true, true, true),
-  ("ArrayBuilder::push", CtFn(reg_p2(CtUnknown, CtUnknown), CtUnit, None), true, true, true),
-  ("ArrayBuilder::freeze", CtFn(reg_p1(CtUnknown), CtArray(CtUnknown), None), true, true, true),
+  ("ArrayBuilder::new", CtFn(reg_p0(), reg_opaque("ArrayBuilder"), None), true, true, true),
+  ("ArrayBuilder::push", CtFn(reg_p2(reg_opaque("ArrayBuilder"), reg_any()), CtUnit, None), true, true, true),
+  ("ArrayBuilder::freeze", CtFn(reg_p1(reg_opaque("ArrayBuilder")), CtArray(reg_any()), None), true, true, true),
   // #906: FrozenArray[T] -- a checker-only phantom-type wrapper over
   // Array[T]'s exact same runtime layout (same technique as ArrayBuilder
   // just above: from_array/to_array are pure identity casts, get/length
   // alias Array::get/Array::length's own bodies -- see
   // gc/backend_body.vibe and wasi/linked_compile.vibe). checker.vibe's
-  // FrozenArray::* ECall branches refine these CtUnknown-shaped rows with
+  // FrozenArray::* ECall branches refine these reg_any()-shaped rows with
   // the real per-call-site element type; these rows exist so both codegen
   // lanes' func-table registration (which is DRIVEN by this registry, #415
   // B-1) has a row to loop over and so a bare reference to the name (not a
   // direct call) still resolves to a sane function type.
-  ("FrozenArray::from_array", CtFn(reg_p1(CtArray(CtUnknown)), CtNamed("FrozenArray", reg_p1(CtUnknown)), None), true, true, true),
-  ("FrozenArray::get", CtFn(reg_p2(CtNamed("FrozenArray", reg_p1(CtUnknown)), CtInt), CtUnknown, None), true, true, true),
-  ("FrozenArray::length", CtFn(reg_p1(CtNamed("FrozenArray", reg_p1(CtUnknown))), CtInt, None), true, true, true),
-  ("FrozenArray::to_array", CtFn(reg_p1(CtNamed("FrozenArray", reg_p1(CtUnknown))), CtArray(CtUnknown), None), true, true, true),
-  ("Array::slice", CtFn(reg_p3(CtArray(CtUnknown), CtInt, CtInt), CtArray(CtUnknown), None), true, true, true),
-  ("Array::concat", CtFn(reg_p2(CtArray(CtUnknown), CtArray(CtUnknown)), CtArray(CtUnknown), None), true, true, true),
+  ("FrozenArray::from_array", CtFn(reg_p1(CtArray(reg_any())), CtNamed("FrozenArray", reg_p1(reg_any())), None), true, true, true),
+  ("FrozenArray::get", CtFn(reg_p2(CtNamed("FrozenArray", reg_p1(reg_any())), CtInt), reg_any(), None), true, true, true),
+  ("FrozenArray::length", CtFn(reg_p1(CtNamed("FrozenArray", reg_p1(reg_any()))), CtInt, None), true, true, true),
+  ("FrozenArray::to_array", CtFn(reg_p1(CtNamed("FrozenArray", reg_p1(reg_any()))), CtArray(reg_any()), None), true, true, true),
+  ("Array::slice", CtFn(reg_p3(CtArray(reg_any()), CtInt, CtInt), CtArray(reg_any()), None), true, true, true),
+  ("Array::concat", CtFn(reg_p2(CtArray(reg_any()), CtArray(reg_any())), CtArray(reg_any()), None), true, true, true),
   ("Bytes::new", CtFn(reg_p0(), CtBytes, None), true, true, true),
   ("Bytes::from_array", CtFn(reg_p1(CtArray(CtInt)), CtBytes, None), true, true, true),
   ("Bytes::to_array", CtFn(reg_p1(CtBytes), CtArray(CtInt), None), true, true, true),
@@ -319,10 +347,10 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("Bytes::append", CtFn(reg_p2(CtBytes, CtBytes), CtUnit, None), true, true, true),
   ("Bytes::concat", CtFn(reg_p2(CtBytes, CtBytes), CtBytes, None), true, true, true),
   ("Bytes::slice", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtBytes, None), true, true, true),
-  ("__to_string", CtFn(reg_p1(CtUnknown), CtString, None), true, true, true),
-  ("vibe_rc_drop", CtFn(reg_p1(CtUnknown), CtUnit, None), true, false, false),
+  ("__to_string", CtFn(reg_p1(reg_any()), CtString, None), true, true, true),
+  ("vibe_rc_drop", CtFn(reg_p1(reg_any()), CtUnit, None), true, false, false),
   ("vibe_rc_alloc", CtFn(reg_p1(CtInt), CtInt, None), true, false, false),
-  ("vibe_rc_dup", CtFn(reg_p1(CtUnknown), CtUnit, None), true, false, false),
+  ("vibe_rc_dup", CtFn(reg_p1(reg_any()), CtUnit, None), true, false, false),
   ("vibe_heap_grow_check", CtFn(reg_p0(), CtUnit, None), true, false, false),
   ("not", CtFn(reg_p1(CtBool), CtBool, None), false, true, true),
   ("Bytes::blit", CtFn(reg_p4(CtBytes, CtBytes, CtInt, CtInt), CtUnit, None), false, true, true),
@@ -333,12 +361,12 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("Char::to_int", CtFn(reg_p1(CtChar), CtInt, None), false, true, true),
   ("Char::from_int", CtFn(reg_p1(CtInt), CtChar, None), false, true, true),
   ("Int::to_float", CtFn(reg_p1(CtInt), CtDouble, None), false, true, true),
-  ("FixedArray::make", CtFn(reg_p2(CtInt, CtUnknown), CtArray(CtUnknown), None), false, true, true),
-  ("FixedArray::length", CtFn(reg_p1(CtArray(CtUnknown)), CtInt, None), false, true, true),
-  ("FixedArray::get", CtFn(reg_p2(CtArray(CtUnknown), CtInt), CtUnknown, None), false, true, true),
-  ("FixedArray::set", CtFn(reg_p3(CtArray(CtUnknown), CtInt, CtUnknown), CtUnit, None), false, true, true),
-  ("FixedArray::unsafe_set", CtFn(reg_p3(CtArray(CtUnknown), CtInt, CtUnknown), CtUnit, None), false, true, true),
-  ("FixedArray::blit", CtFn(reg_p5(CtArray(CtUnknown), CtInt, CtArray(CtUnknown), CtInt, CtInt), CtUnit, None), false, true, true),
+  ("FixedArray::make", CtFn(reg_p2(CtInt, reg_any()), CtArray(reg_any()), None), false, true, true),
+  ("FixedArray::length", CtFn(reg_p1(CtArray(reg_any())), CtInt, None), false, true, true),
+  ("FixedArray::get", CtFn(reg_p2(CtArray(reg_any()), CtInt), reg_any(), None), false, true, true),
+  ("FixedArray::set", CtFn(reg_p3(CtArray(reg_any()), CtInt, reg_any()), CtUnit, None), false, true, true),
+  ("FixedArray::unsafe_set", CtFn(reg_p3(CtArray(reg_any()), CtInt, reg_any()), CtUnit, None), false, true, true),
+  ("FixedArray::blit", CtFn(reg_p5(CtArray(reg_any()), CtInt, CtArray(reg_any()), CtInt, CtInt), CtUnit, None), false, true, true),
   // #835: Int64Array rides on the same linear-memory Array representation
   // as FixedArray (Array[Int] already stores the full 62-bit tagged Int
   // per cell, no i32-cell truncation in these backends — unlike the
@@ -350,28 +378,28 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("Int64Array::length", CtFn(reg_p1(CtArray(CtInt)), CtInt, None), false, true, true),
   ("Int64Array::get", CtFn(reg_p2(CtArray(CtInt), CtInt), CtInt, None), false, true, true),
   ("Int64Array::set", CtFn(reg_p3(CtArray(CtInt), CtInt, CtInt), CtUnit, None), false, true, true),
-  ("StringBuilder::new", CtFn(reg_p0(), CtUnknown, None), false, true, true),
-  ("StringBuilder::push", CtFn(reg_p2(CtUnknown, CtString), CtUnit, None), false, true, true),
-  ("StringBuilder::freeze", CtFn(reg_p1(CtUnknown), CtString, None), false, true, true),
-  ("Map::get", CtFn(reg_p2(CtUnknown, CtString), CtUnknown, None), false, true, true),
-  ("Map::keys", CtFn(reg_p1(CtUnknown), CtArray(CtString), None), false, true, true),
-  ("MapBuilder::new", CtFn(reg_p0(), CtUnknown, None), false, true, true),
-  ("MapBuilder::set", CtFn(reg_p3(CtUnknown, CtString, CtUnknown), CtUnit, None), false, true, true),
-  ("MapBuilder::freeze", CtFn(reg_p1(CtUnknown), CtUnknown, None), false, true, true),
+  ("StringBuilder::new", CtFn(reg_p0(), reg_opaque("StringBuilder"), None), false, true, true),
+  ("StringBuilder::push", CtFn(reg_p2(reg_opaque("StringBuilder"), CtString), CtUnit, None), false, true, true),
+  ("StringBuilder::freeze", CtFn(reg_p1(reg_opaque("StringBuilder")), CtString, None), false, true, true),
+  ("Map::get", CtFn(reg_p2(reg_opaque("Map"), CtString), reg_any(), None), false, true, true),
+  ("Map::keys", CtFn(reg_p1(reg_opaque("Map")), CtArray(CtString), None), false, true, true),
+  ("MapBuilder::new", CtFn(reg_p0(), reg_opaque("MapBuilder"), None), false, true, true),
+  ("MapBuilder::set", CtFn(reg_p3(reg_opaque("MapBuilder"), CtString, reg_any()), CtUnit, None), false, true, true),
+  ("MapBuilder::freeze", CtFn(reg_p1(reg_opaque("MapBuilder")), reg_opaque("Map"), None), false, true, true),
   // #1310: has_key/get read the builder without freezing (O(n) scan over
   // the same handle-indirect storage MapBuilder::set already walks -- see
   // its search loop in expr/compile_call.vibe / gc/backend_call.vibe).
   // `get` returns Option[V] (built via a synthesized Some/None `ce` call,
   // same technique as int_parse_expr / Array::find), not the "0 on miss"
   // raw-value convention Map::get uses.
-  ("MapBuilder::has_key", CtFn(reg_p2(CtUnknown, CtString), CtBool, None), false, true, true),
-  ("MapBuilder::get", CtFn(reg_p2(CtUnknown, CtString), CtOption(CtUnknown), None), false, true, true),
+  ("MapBuilder::has_key", CtFn(reg_p2(reg_opaque("MapBuilder"), CtString), CtBool, None), false, true, true),
+  ("MapBuilder::get", CtFn(reg_p2(reg_opaque("MapBuilder"), CtString), CtOption(reg_any()), None), false, true, true),
   ("assert", CtFn(reg_p1(CtBool), CtUnit, None), false, true, true),
   ("assert_true", CtFn(reg_p1(CtBool), CtUnit, None), false, true, true),
-  ("assert_eq", CtFn(reg_p2(CtUnknown, CtUnknown), CtUnit, None), false, true, true),
+  ("assert_eq", CtFn(reg_p2(reg_any(), reg_any()), CtUnit, None), false, true, true),
   ("println", CtFn(reg_p1(CtString), CtUnit, None), false, true, true),
   ("print", CtFn(reg_p1(CtString), CtUnit, None), false, true, true),
-  ("map_has", CtFn(reg_p2(CtUnknown, CtString), CtBool, None), false, true, true)
+  ("map_has", CtFn(reg_p2(reg_opaque("Map"), CtString), CtBool, None), false, true, true)
 ]
 
 export fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)] {

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -498,6 +498,9 @@ fn compile_release_file(input_path: String, entry_name: String) -> Bytes with Ex
 fn compile_debug_library(dep_path: String) -> Bytes with Exception + Fs
 fn build_linked_debug_entry(input_path: String, entry_name: String) -> (Bytes, Array[(String, String)]) with Exception + Fs
 fn check_linked_file(input_path: String) -> Int with Exception + Fs
+// #1514: culprit-call marker basis verification (see cli_support.vibe) --
+// exported for the FS-compile lane's located diag writer in cli_adapter.vibe.
+fn verify_culprit_off_marker(source: String, msg: String) -> String
 fn check_deprecated_warnings(input_path: String) -> Array[String] with Exception + Fs
 fn strip_executable_wasm(wasm: Bytes, entry_name: String, strip_names: Bool, filter_exports: Bool) -> Bytes
 fn strip_executable_wasm_env(wasm: Bytes, entry_name: String) -> Bytes with Env

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -147,6 +147,48 @@ test "check_linked_file: handle body calling a local closure fails eligibility a
   assert(String::contains(msg, "cannot be compiled here"))
 }
 
+/// #1514 C (repair 08): the same ineligibility error must now NAME the call
+/// that hides the perform and carry its `line:col` (the culprit `bump` sits at
+/// line 5 col 12 of the source below; the culprit-call marker verifies against
+/// the entry text, then locate_type_error renders the span). The raw ` [@off=`
+/// transport marker must never survive to the reader.
+test "check_linked_file: ineligible handle names the culprit call, located (#1514)" {
+  let path = "/tmp/vibe_cli_support_check_edp_culprit.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Ask { Ask() -> Int }\nfn ask_once() -> Int with Ask { perform Ask::Ask() }\nexport fn main() -> Int {\n  let bump = (x: Int) -> Int { x + 1 }\n  handle { bump(ask_once()) } with Ask {\n    Ask() => resume(10)\n  }\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "here: the call to 'bump'"))
+  assert(String::contains(msg, "line 5:12"))
+  assert(!String::contains(msg, "[@off="))
+}
+
+/// The culprit-call marker's offsets index the text of whichever MODULE the
+/// handle lives in. When that module is a DEPENDENCY, resolving them against
+/// the entry file would name a plausible-but-wrong entry line — worse than no
+/// position (#1445). verify_culprit_off_marker must detect the basis mismatch
+/// (the span does not spell the culprit in the entry text) and degrade to the
+/// unlocated message: culprit still named, no leaked marker.
+test "check_linked_file: dep-module culprit degrades to unlocated, no marker leak (#1514)" {
+  let base_dir = "/tmp/vibe_cli_support_check_edp_dep_culprit"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("effect Ask { Ask() -> Int }\nfn ask_once() -> Int with Ask { perform Ask::Ask() }\nexport fn run() -> Int {\n  let bump = (x: Int) -> Int { x + 1 }\n  handle { bump(ask_once()) } with Ask {\n    Ask() => resume(10)\n  }\n}\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./dep.vibe { run }\nexport fn main() -> Int { run() }\n"))
+  let msg = handle {
+    let _ = check_linked_file(main_path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "here: the call to 'bump'"))
+  assert(!String::contains(msg, "[@off="))
+}
+
 /// The eligible counterpart: the same handle with the perform statically
 /// visible (direct call to a named top-level fn) must keep checking clean —
 /// the new prelude run must not reject programs codegen accepts.


### PR DESCRIPTION
2 スライス。#1514 と #1520 の残作業をそれぞれ完了させる。

Closes #1514
Closes #1520 (残債の lane 表縮退は #1593 に切り出し済み)

## 1. #1514 C — repair 08 (`handle` 適格性) に位置と名指しが付いた

C カテゴリ最後の 1 件。出どころの `EHandle` が offset を持たない問題は、**編集位置として正しいのは handle ではなく犯人の呼び出し**だという観察で回避した — `edp_body_has_opaque_call` (Bool) と同じ判定で「最初の不適格な呼び出し」を `(callee 名, offset)` で返す walker を追加し (`edp_first_opaque_call_info` / `edp_live_handle_opaque_info`)、エラー文に `(here: the call to 'bump')` と ` [@off=N:M]` marker を付ける。AST は無変更。

```
before: handle of effect 'Ask' cannot be compiled here. ...
after:  line 9:20-24: handle of effect 'Ask' cannot be compiled here. ... (here: the call to 'bump') ...
```

**位置の解決は基準ソースを知っているレーンだけが行う** (merged 複数モジュールの offset 基準問題):

- `vibe check`: entry ソースで解決。ただし `verify_culprit_off_marker` が **span がその位置に犯人名を実際に綴っているか**を検証してから解決し、不一致 (依存モジュール由来の offset) は位置なしへ降りる — もっともらしく間違った行を指すのは位置なしより悪い (#1445 の教訓)。dep 側に犯人がある形はテストで pin
- FS-compile レーン (`vibe build/run/test`): `emit_compile_diag_fs_located` が同じ検証付きで解決
- single-source レーン: desugar 後で offset が失われるため名指しのみ。`emit_compile_diag` が marker を常に剥がすので、生の `[@off=` はどのレーンにも漏れない (#1445 再発防止)

alpha-rename (`__edpsh_N_`) された callee は元の綴りで報告。repair 採点は 08 が L=0→1, C=1→2 で **10 ケースの減点が消滅** (repair_convergence 4.8 → **5.0**)。ラチェット `diag.grep` に名指しと `line 9:20-24` を pin し、cheatsheet の落とし穴節も更新。

## 2. #1520 提案2 — registry の多相行を意味で綴り分け

`CtUnknown` が「多相ゆえに検査しない」「型表現の無い内部ハンドル」「まだ書いていない」のどれなのか読み手にしか分からず、#1519 の `eq` (多相なのに `CtInt`) の嘘が見えなかった。行の綴りを分ける:

- `reg_any()` — 意図的に多相 (`eq` / `assert_eq`、コンテナ要素型)
- `reg_opaque(k)` — 型表現の無いハンドル (builder 各種, `Map`)。`k` がハンドル種を読み手に名指しする
- 裸の `CtUnknown` — **行では禁止** (「まだ書いていない」と読む)。規約はファイル冒頭に明文化

3 つとも実行時値は同じなので checker / codegen lane の派生ビューは不変。#1523 の差分検査・#1589 の golden コーパスも無変更で通る。

## 検証

- `scripts/compiler_gate.sh` **全緑** (stage2 == stage3 fixpoint、最終ツリーで実行)
- `scripts/unit_test_runner.sh` **541/541** (check レーンの located / dep-degrade を pin する新テスト 2 件を含む)
- `eval/lang-review/run_repair.sh` **10/10** (強化した 08 ラチェット込み)
- `scripts/vibe_fmt.sh --check` clean (touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_