### PR TITLE
Address Codex review on PR #1594: culprit marker whole-identifier check + unmangle gating

### DIFF
--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -156,11 +156,16 @@ fn append_non_import_stmts(dst: Array[Stmt], src: Array[Stmt]) -> Unit {
 /// call as `(here: the call to 'X') ... [@off=N:M]`, where N:M index the text
 /// of whichever MODULE the handle lives in. This lane resolves markers against
 /// the ENTRY file's text, which is only correct when the culprit is in the
-/// entry file itself. Verify the span actually spells `X` in `source` before
-/// letting locate_type_error resolve it; on mismatch (a dep-module offset)
-/// strip the marker so the message degrades to unlocated instead of naming a
+/// entry file itself. Verify the span actually spells `X` in `source` — as a
+/// whole identifier, not a slice of a longer one (a dep offset landing inside
+/// the entry's `run_all` must not pass for culprit `run`) — before letting
+/// locate_type_error resolve it; on mismatch (a dep-module offset) strip the
+/// marker so the message degrades to unlocated instead of naming a
 /// plausible-but-wrong entry-file line (worse than no position, per #1445).
-/// Messages without the culprit clause pass through untouched.
+/// Messages without the culprit clause pass through untouched. Residual
+/// (Codex review, PR #1594): a dep offset whose entry-text span coincidentally
+/// spells the same whole identifier still passes — closing that needs the
+/// marker to carry source identity, tracked as a follow-up issue.
 /// Parse a run of ASCII digits as a non-negative Int, or -1 when `s` is empty
 /// or contains any non-digit (local copy of typecheck_fs's parse_offset_digits,
 /// which is module-private there).
@@ -183,6 +188,12 @@ fn parse_marker_digits(s: String) -> Int {
   } else {
     -1
   }
+}
+
+/// True when char code `c` can appear in a vibe identifier (ASCII letter,
+/// digit, or underscore) — used for the whole-identifier boundary check.
+fn marker_ident_char(c: Int) -> Bool {
+  (c >= 97 && c <= 122) || (c >= 65 && c <= 90) || (c >= 48 && c <= 57) || c == 95
 }
 
 export fn verify_culprit_off_marker(source: String, msg: String) -> String {
@@ -208,7 +219,16 @@ export fn verify_culprit_off_marker(source: String, msg: String) -> String {
       } else {
         let n = parse_marker_digits(String::substring(inner, 0, colon))
         let m = parse_marker_digits(String::substring(inner, colon + 1, String::length(inner)))
-        n >= 0 && m > n && m <= String::length(source) && String::substring(source, n, m) == culprit
+        if n >= 0 && m > n && m <= String::length(source) && String::substring(source, n, m) == culprit {
+          // Whole-identifier boundary: the byte before N / at M must not
+          // extend the identifier, or the "match" is a slice of a longer
+          // name and the basis is not the entry file.
+          let left_ok = n == 0 || !marker_ident_char(String::char_code_at(source, n - 1))
+          let right_ok = m == String::length(source) || !marker_ident_char(String::char_code_at(source, m))
+          left_ok && right_ok
+        } else {
+          false
+        }
       }
       if span_ok {
         msg

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -1114,8 +1114,11 @@ export fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[St
   // name (fresh `__edpsh_N_<name>`), so edp_drop_shadowed_needing finds
   // nothing to drop and the shadowed-needing class migrates like any
   // other program instead of falling back to the (now removed) replay
-  // engine. See edp_alpha_rename_shadowed's doc comment.
-  edp_alpha_rename_shadowed(stmts, effect_defs, fn_defs)
+  // engine. See edp_alpha_rename_shadowed's doc comment. `user_edpsh` /
+  // `edp_renamed` feed the culprit diagnostic below: only names the walk
+  // actually generated may be un-mangled back to their original spelling.
+  let user_edpsh = empty_str_array()
+  let edp_renamed = edp_alpha_rename_shadowed(stmts, effect_defs, fn_defs, user_edpsh)
   let keep = dce_keep_flags(stmts, [
     entry_name
   ])
@@ -1163,7 +1166,15 @@ export fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[St
         let li_inert = edp_pure_fn_names(li_fn_defs)
         edp_append_free_host_inert_names(stmts, li_inert)
         let (culprit_raw, culprit_off) = edp_live_handle_opaque_info(stmts, keep, bad, li_inert, li_fn_names)
-        let culprit = edp_unmangle_shadow_name(culprit_raw)
+        // Un-mangle ONLY names the rename walk generated: a user-authored
+        // `__edpsh_0_helper` (in `user_edpsh`, or the walk never ran) must be
+        // reported verbatim -- stripping it would name a `helper` that does
+        // not exist in the source (Codex review, PR #1594).
+        let culprit = if edp_renamed && !edp_str_array_contains(user_edpsh, culprit_raw) {
+          edp_unmangle_shadow_name(culprit_raw)
+        } else {
+          culprit_raw
+        }
         let head = String::concat(String::concat("handle of effect '", bad), "' cannot be compiled here. Every perform this handle covers has to be statically visible to it, so the handled body may only: perform directly, call a named top-level `fn`, or call a closure literal that carries an effect row annotation. A call through a local binding or a closure parameter hides the perform and is what this rejects")
         let named = if String::length(culprit) > 0 {
           String::concat(head, String::concat(" (here: the call to '", String::concat(culprit, "')")))
@@ -2223,7 +2234,14 @@ fn edp_ar_expr(expr: Expr, seed: Array[String], env_names: Array[String], env_re
   }
 }
 
-fn edp_alpha_rename_shadowed(stmts: Array[Stmt], effect_defs: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> Unit {
+/// Returns true iff the rename walk actually ran (some needing name was
+/// shadowed), and in that case fills `user_prefixed` with every
+/// `__edpsh_`-prefixed name the program contained BEFORE renaming — i.e. the
+/// user-authored ones. edp_ar_fresh never re-issues a name from that census,
+/// so post-rename a prefixed name is compiler-generated iff the walk ran and
+/// the name is NOT in `user_prefixed` (Codex review, PR #1594: culprit
+/// diagnostics must not strip a prefix the user spelled themselves).
+fn edp_alpha_rename_shadowed(stmts: Array[Stmt], effect_defs: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], user_prefixed: Array[String]) -> Bool {
   let es_names = array_empty()
   let es_members_list = array_empty()
   edp_es_collect_into(stmts, es_names, es_members_list)
@@ -2270,14 +2288,15 @@ fn edp_alpha_rename_shadowed(stmts: Array[Stmt], effect_defs: Array[(String, Arr
     ei = ei + 1
   }
   if Array::length(seed) == 0 {
-    ()
+    false
   } else {
     let counter = [
       0
     ]
     // #1119 Codex review (P2): never generate a name the program already
-    // uses -- see edp_ar_fresh's doc comment.
-    let taken = empty_str_array()
+    // uses -- see edp_ar_fresh's doc comment. The same census doubles as
+    // the user-authored-name record for the culprit diagnostic (doc above).
+    let taken = user_prefixed
     edp_collect_prefixed_names(stmts, "__edpsh_", taken)
     let mut i = 0
     while i < Array::length(stmts) {
@@ -2317,6 +2336,7 @@ fn edp_alpha_rename_shadowed(stmts: Array[Stmt], effect_defs: Array[(String, Arr
       }
       i = i + 1
     }
+    true
   }
 }
 
@@ -2719,7 +2739,9 @@ fn edp_live_handle_opaque_info(stmts: Array[Stmt], keep: Array[Bool], ename: Str
 /// `__edpsh_<N>_` prefix that exists nowhere in the user's source; report the
 /// original spelling (the rename preserves the node's offset, and the binder's
 /// source text IS the original name, so the un-mangled spelling and its span
-/// both match the file).
+/// both match the file). The CALLER must gate on the rename census — a name
+/// the user spelled with this prefix themselves goes through verbatim (Codex
+/// review, PR #1594); this helper only does the string surgery.
 fn edp_unmangle_shadow_name(nm: String) -> String {
   let prefix = "__edpsh_"
   if String::index_of(nm, prefix) == 0 {

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ../cli_support.vibe {
-  compile_release_file_mode, check_linked_file
+  compile_release_file_mode, check_linked_file, verify_culprit_off_marker
 }
 
 import @vibe/core {
@@ -186,6 +186,63 @@ test "check_linked_file: dep-module culprit degrades to unlocated, no marker lea
     Throw(m) => m
   }
   assert(String::contains(msg, "here: the call to 'bump'"))
+  assert(!String::contains(msg, "[@off="))
+}
+
+/// Codex review on PR #1594: the spelling check must match a WHOLE
+/// identifier. A dep-module offset landing where the entry text spells the
+/// culprit as a prefix of a longer name (`run` inside `run_all`) is a basis
+/// mismatch and must degrade, not locate.
+test "verify_culprit_off_marker rejects a span inside a longer identifier (#1594 review)" {
+  let source = "let run_all = 1"
+  let msg = "handle of effect 'Ask' cannot be compiled here (here: the call to 'run') -- fix it. [@off=4:7]"
+  let out = verify_culprit_off_marker(source, msg)
+  assert(!String::contains(out, "[@off="))
+  assert(String::contains(out, "here: the call to 'run'"))
+}
+
+/// The accept counterpart: the same span as a whole identifier keeps the
+/// marker for locate_type_error to render.
+test "verify_culprit_off_marker keeps a whole-identifier span (#1594 review)" {
+  let source = "let run = 1"
+  let msg = "handle of effect 'Ask' cannot be compiled here (here: the call to 'run') -- fix it. [@off=4:7]"
+  let out = verify_culprit_off_marker(source, msg)
+  assert(String::contains(out, "[@off=4:7]"))
+}
+
+/// Codex review on PR #1594: a user-authored callee that happens to spell the
+/// `__edpsh_` mangling prefix must be reported VERBATIM — the alpha-rename
+/// walk never ran here, so stripping the prefix would name a 'bump' that does
+/// not exist in the source. The span verifies against the real spelling, so
+/// the diagnostic also keeps its `line:col`.
+test "check_linked_file: user-authored __edpsh_ culprit is reported verbatim (#1594 review)" {
+  let path = "/tmp/vibe_cli_support_check_edp_user_prefix.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Ask { Ask() -> Int }\nfn ask_once() -> Int with Ask { perform Ask::Ask() }\nexport fn main() -> Int {\n  let __edpsh_0_bump = (x: Int) -> Int { x + 1 }\n  handle { __edpsh_0_bump(ask_once()) } with Ask {\n    Ask() => resume(10)\n  }\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "here: the call to '__edpsh_0_bump'"))
+  assert(String::contains(msg, "line 5:12"))
+  assert(!String::contains(msg, "[@off="))
+}
+
+/// The generated counterpart: a local that SHADOWS a needing fn is renamed to
+/// `__edpsh_0_<name>` by the alpha walk, and the culprit diagnostic must
+/// still un-mangle THAT back to the user's spelling, located at the call.
+test "check_linked_file: generated __edpsh_ culprit still un-mangles (#1594 review)" {
+  let path = "/tmp/vibe_cli_support_check_edp_gen_prefix.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Ask { Ask() -> Int }\nfn ask_once() -> Int with Ask { perform Ask::Ask() }\nfn use_it() -> Int with Ask { ask_once() }\nexport fn main() -> Int {\n  let use_it = (x: Int) -> Int { x + 1 }\n  handle { use_it(ask_once()) } with Ask {\n    Ask() => resume(10)\n  }\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "here: the call to 'use_it'"))
+  assert(String::contains(msg, "line 6:12"))
   assert(!String::contains(msg, "[@off="))
 }
 


### PR DESCRIPTION
PR #1594 マージ時に未対応だった Codex レビュー 2 件 (P2) への対応。

## 1. `verify_culprit_off_marker`: whole-identifier 境界チェック ([discussion_r3740223826](https://github.com/mizchi/vibe-lang/pull/1594#discussion_r3740223826))

culprit 綴りを生の substring 一致で照合していたため、dep モジュール由来のオフセットが entry ファイルの**より長い識別子の内部**に一致すると (culprit `run` vs entry の `run_all`)、誤った entry 行を位置として報告できた。span の両側が識別子構成文字でないことを要求し、この誤受理クラスを排除。

残存ケース (同一トークンが同一オフセットに偶然完全一致 — dep と entry が共通のテキスト接頭辞を持つ場合に現実化) は marker 自体にソース識別を載せる必要があり、**#1596** として切り出した。緩和方針は従来どおり「誤位置より無位置」(#1445)。

## 2. `edp_unmangle_shadow_name`: 生成された名前だけを un-mangle ([discussion_r3740223827](https://github.com/mizchi/vibe-lang/pull/1594#discussion_r3740223827))

culprit 名から `__edpsh_` prefix を無条件に剥がしていたため、ユーザーが自分で `__edpsh_0_helper` と命名した callee (edp_ar_fresh の衝突回避が明示的にサポートするケース) が、ソースに存在しない `helper` として報告され、marker 照合も位置を落としていた。

`edp_alpha_rename_shadowed` が「rename walk が実行されたか」と rename **前**の `__edpsh_` census (= ユーザー命名分) を呼び出し側へ返すようにし、error path は **walk が実際に生成した名前のみ** un-mangle する。ユーザー命名はそのまま報告され、span が実綴りと一致するので `line:col` も正しく付く。

## テスト

`cli_support_test.vibe` に 4 件追加 (marker 境界の reject/accept 単体 2 件 + user-authored / generated culprit の e2e 2 件)。**修正前の実装に対して fail することを確認済み** (stash して実行 → 16 tests 中 fail、修正後は全 pass)。

operation gate (`bash scripts/compiler_gate.sh` 直接実行) はローカルで**通過** (stage2==stage3 fixpoint 含む)。※このコンテナでは `pkf run test` 経由だと pkf の nix wrapper が輸出する `LD_LIBRARY_PATH` で gate スクリプト内の `sort` が glibc 混在で落ちるため、直接実行で検証した (リポジトリ外の環境問題)。

refs #1514, #1596

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk