### PR TITLE
P1 batch: #1508 test/bench effect rows (Http codegen), #1595/#1591, #1590, #1553

### DIFF
--- a/bench/http_bench.vibe
+++ b/bench/http_bench.vibe
@@ -1,22 +1,25 @@
 
 // Requires: python3 tests/http_echo_server.py 18281
 // Uses builtins directly (Http::request etc.) since bench/ can't import vibe/http
+// #1508: each block declares the Http capability it performs -- `with Http`
+// widens the bench's ambient effect row (network is excluded from the default
+// row and must be explicit).
 
-bench "http_get_hello" {
+bench "http_get_hello" with Http {
   let h = Http::request("GET", "http://127.0.0.1:18281/hello", "", "")
   let _ = Http::response_status(h)
   let _ = Http::response_body(h)
   Http::close(h)
 }
 
-bench "http_post_echo_small" {
+bench "http_post_echo_small" with Http {
   let h = Http::request("POST", "http://127.0.0.1:18281/echo", "", "hello")
   let _ = Http::response_status(h)
   let _ = Http::response_body(h)
   Http::close(h)
 }
 
-bench "http_post_echo_1kb" {
+bench "http_post_echo_1kb" with Http {
   let payload = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
   let h = Http::request("POST", "http://127.0.0.1:18281/echo", "", payload)
   let _ = Http::response_status(h)
@@ -24,7 +27,7 @@ bench "http_post_echo_1kb" {
   Http::close(h)
 }
 
-bench "http_get_headers" {
+bench "http_get_headers" with Http {
   let h = Http::request("GET", "http://127.0.0.1:18281/headers", "X-Custom: test-value", "")
   let _ = Http::response_status(h)
   let _ = Http::response_body(h)

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1449,15 +1449,44 @@ let main = () -> Int { c }         // ok
 
 ```vibe skip
 // doctest-skip: every NG line here is a form the parser rejects on purpose
-test "name" { .. }        // ok  — 名前は文字列リテラル必須
-test name { .. }          // NG: expected test name string
-test "n" with Fs { .. }   // NG: expected { but got with — effect row は書けない
+test "name" { .. }             // ok  — 名前は文字列リテラル必須
+test name { .. }               // NG: expected test name string
+test "n" with { Fs } { .. }    // NG: braced row は #1429 で削除 — `with Fs` と書く
 ```
 
-row を書けない帰結として、**`Http` / `Socket` / `Llm` を実際に呼ぶ test / bench
-は書けない** (#1508)。これらは test/bench の ambient row に入っておらず、足す
-手段が無い。`handle { .. } with Http { _ => () }` は通るが、それは effect を
-**放電**する — 実際の呼び出しをハンドラで置換するので mock にしかならない。
+**名前付き `test` / `bench` は名前の後に effect row を書ける** (#1508)。宣言した
+row は ambient row (`{ Fs, Env, Stdin, Stdout, Stderr, Console, Process,
+Profiler, Error, Exception }`) を**置換ではなく拡張**する — `with Http` を
+書いても `assert` に必要な `Exception` などの既定は残る。無名 `test { .. }` /
+`bench { .. }` には row を書けない (row を対応付ける名前が無い)。
+
+```vibe
+// row は effect 名でも operation 粒度でも書ける
+test "declared row widens the ambient one" with Exception {
+  assert_eq(1 + 1, 2)
+}
+
+bench "http_get" with Http {
+  let h = Http::request("GET", "http://127.0.0.1:18281/hello", "", "")
+  let _ = Http::response_body(h)
+  Http::close(h)
+}
+
+test "op-granular row" with Http::request + Http::close {
+  let h = Http::request("GET", "http://127.0.0.1:18281/hello", "", "")
+  Http::close(h)
+  assert(true)
+}
+```
+
+これで **`Http` を実際に呼ぶ test / bench が書ける** — network は ambient row に
+入っておらず明示宣言が必須、という設計はそのまま。クライアント系 builtin
+(`Http::request` / `response_status` / `response_header` / `response_body` /
+`close`) は bare file の直接綴りでも host import に落ちる (#1508 第2障壁の解消。
+実行例: `bench/http_bench.vibe`、要 `python3 tests/http_echo_server.py 18281`)。
+server 系 (`Http::listen` / `accept` / `respond`) は今も handler が必要。
+`handle { .. } with Http { _ => () }` で row を放電する古い回避策は、実 HTTP の
+test/bench にはもう不要。
 
 ### 引数
 

--- a/docs/spec/test-example-capabilities.md
+++ b/docs/spec/test-example-capabilities.md
@@ -1,7 +1,19 @@
 # Test / Example capability と executable documentation 設計
 
-**Status:** Proposal  
-**Related:** #819 (merged doctest compile)
+**Status:** Proposal — 一部実装済み (#1508)  
+**Related:** #819 (merged doctest compile), #1508 (test/bench effect row)
+
+> **実装状況 (2026-08, #1508):** `test "name" with <row> { .. }` /
+> `bench "name" with <row> { .. }` は**実装済み**。ただし実装された意味論は
+> この文書の「明示時は row を完全に明示し `Exception` 必須」ではなく、
+> **宣言 row が ambient row (標準 effect policy の default 10 effect) を
+> 拡張する** — `with Http` が `Exception` や Stdout/Fs 系を黙って落とすと、
+> row を足すすべての test が既定値を全部書き直す羽目になるため
+> (決定の経緯は #1508 と 80f3088 のコミットメッセージ)。本文書の
+> 「省略時 `{ Exception }`」「明示時 `Exception` 必須」「`with ()` はエラー」は
+> **未実装の将来案**のまま。`example` / `for Symbol` / `DevEnv` bundle も未実装。
+> 無名 `test { .. }` / `bench { .. }` に row は書けない (row を対応付ける
+> 名前が無い)。
 
 ## 目的
 
@@ -23,7 +35,7 @@ capability を宣言可能にする。Markdown fence の任意スクリプトを
 ## 構文
 
 ```vibe skip
-// doctest-skip: design sketch: the syntax below is not implemented -- `test ".." with <row>` is rejected today
+// doctest-skip: design sketch: `test ".." with <row>` is implemented (#1508, widening semantics) but `example .. for Symbol` is not
 test "test name" {
   // body
 }
@@ -57,7 +69,7 @@ capability を宣言しなければならない。
 エラーとする。
 
 ```vibe skip
-// doctest-skip: design sketch: the syntax below is not implemented -- `test ".." with <row>` is rejected today
+// doctest-skip: design sketch: the strict explicit-row rules here (Exception mandatory, `with ()` rejected) are NOT implemented -- today a declared row widens the ambient default (#1508)
 // OK
 test "pure" with Exception { assert_eq(1, 1) }
 
@@ -83,7 +95,7 @@ capability である。
 下げるため、`DevEnv` を定義済み development capability bundle とする。
 
 ```vibe skip
-// doctest-skip: design sketch: the syntax below is not implemented -- `test ".." with <row>` is rejected today
+// doctest-skip: design sketch: the `DevEnv` bundle is not implemented (`test ".." with <row>` itself is, #1508)
 test "local integration" with Exception + DevEnv {
   // development fixture を使う
 }

--- a/fixtures/test_effect_row_exception_test.vibe
+++ b/fixtures/test_effect_row_exception_test.vibe
@@ -1,0 +1,23 @@
+// #1508: runnable positive case for `test "name" with <row> { .. }` -- the
+// declared row WIDENS the ambient one (docs/spec/test-example-capabilities.md,
+// implemented semantics recorded on #1508). `Exception` is already in the
+// ambient default, so this file exercises the syntax end to end (parse ->
+// effect check -> lowering -> a real run through unit_test_runner.sh) without
+// needing network or any capability the test sandbox does not have.
+
+fn boom() -> Int with Exception {
+  throw("boom")
+}
+
+test "declared Exception row parses and runs" with Exception {
+  let r = handle {
+    boom()
+  } with Exception {
+    Throw(_) => -1
+  }
+  assert_eq(r, -1)
+}
+
+test "declared row next to an undeclared test does not leak" {
+  assert_eq(1 + 1, 2)
+}

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -157,4 +157,5 @@ optional_param_omitted	ok
 optional_param_missing_required	reject	function arity mismatch for d: expected 3 args, got 1
 test_effect_row_widens	ok	
 test_effect_row_partial	reject	missing { Http::close }
+test_effect_row_brace_syntax	reject	write `with A + B`
 local_enum_rejected	reject	a block-local `enum` declaration is not supported

--- a/fixtures/typecheck/test_effect_row_brace_syntax.vibe
+++ b/fixtures/typecheck/test_effect_row_brace_syntax.vibe
@@ -1,0 +1,6 @@
+// #1508: the row on a `test`/`bench` block goes through the same row grammar
+// as fn rows, so the braced spelling removed in #1429 is rejected with the
+// same actionable guidance -- not accepted, not a bare "unexpected token".
+test "braced row" with { Http } {
+  assert(true)
+}

--- a/fixtures/typecheck/test_effect_row_widens.vibe
+++ b/fixtures/typecheck/test_effect_row_widens.vibe
@@ -6,9 +6,11 @@
 // test_effect_row_partial.vibe: its diagnostic shows `Http::request` present in
 // the declared set and `Http::close` still missing.
 //
-// This fixture does not PERFORM the Http call: `Http::*` does not lower in the
-// bare-file compile the fixture harness uses (`undefined variable (local):
-// Http::request @call`), which is a second, separate blocker tracked on #1508.
+// This fixture does not PERFORM the Http call -- the row acceptance is the
+// point here. The direct-spelling lowering (`Http::request` in a bare file)
+// is covered separately: codegen/expr/compile_call.vibe's
+// http_client_surface_to_raw (#1508 second barrier) and the runnable
+// bench/http_bench.vibe + fixtures/test_effect_row_exception_test.vibe.
 test "declared row is accepted and widens" with Http::request + Http::close {
   assert_eq(1, 1)
 }

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1140,9 +1140,36 @@ export fn compile_call(buf: Bytes, callee: Expr, args: Array[Expr], local_names:
   }
 }
 
+fn http_client_surface_to_raw(name: String) -> String {
+  match name {
+    "Http::request" => "vibe_http_request_raw",
+    "Http::response_status" => "vibe_http_response_status_raw",
+    "Http::response_header" => "vibe_http_response_header_raw",
+    "Http::response_body" => "vibe_http_response_body_raw",
+    "Http::close" => "vibe_http_close_raw",
+    _ => ""
+  }
+}
+
 fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, ce: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception {
   if is_eident(callee) {
-    let fname0 = canonical_builtin_name(get_eident_name(callee))
+    let fname00 = canonical_builtin_name(get_eident_name(callee))
+    // #1508 second barrier: the five CLIENT-side `Http::*` builtins are
+    // checker-legal as direct spellings (checker/builtins_net.vibe), but only
+    // the raw dunder names lib/@vibe/http calls internally (#794) had codegen
+    // wiring -- a bare file calling `Http::request(..)` died here with
+    // "reached code generation unresolved". Lower the direct spellings onto
+    // the very same host imports. Guarded on the name not resolving to
+    // anything real: a unit bundling lib/@vibe/http binds these names to its
+    // value aliases (`export let Http::request = request`, #795), and a bound
+    // name must keep winning. Server-side ops (listen/accept/respond/...)
+    // stay perform-based and are NOT aliased.
+    let http_raw = http_client_surface_to_raw(fname00)
+    let fname0 = if String::length(http_raw) > 0 && func_table_index_of(ctx.func_table, fname00) < 0 && !array_contains_str(local_names, fname00) {
+      http_raw
+    } else {
+      fname00
+    }
     // Stream[T] (docs/spec/wasi-p3-async.md §2.4) is backed by the eager Array
     // machinery on the linear backend: map/fold reuse the existing inline
     // Array::map / Array::fold lowering verbatim (same arg order, same value

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3702,11 +3702,15 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   // `Http::request` etc. -- cannot capture the ident, see #795). Each lowers
   // to a `vibe.http_*` host import, gated on use (fixpoint-safe: the compiler
   // itself uses none, so its bytes are unchanged).
-  let need_http_request_builtin = Map::has_key(used_builtin_names, "vibe_http_request_raw")
-  let need_http_response_status_builtin = Map::has_key(used_builtin_names, "vibe_http_response_status_raw")
-  let need_http_response_header_builtin = Map::has_key(used_builtin_names, "vibe_http_response_header_raw")
-  let need_http_response_body_builtin = Map::has_key(used_builtin_names, "vibe_http_response_body_raw")
-  let need_http_close_builtin = Map::has_key(used_builtin_names, "vibe_http_close_raw")
+  // #1508: the direct surface spellings (`Http::request` in a bare file that
+  // does not import lib/@vibe/http -- the shape a `test .. with Http::request`
+  // block uses) also reserve the import: compile_call lowers them onto the
+  // same raw names (http_client_surface_to_raw).
+  let need_http_request_builtin = Map::has_key(used_builtin_names, "vibe_http_request_raw") || Map::has_key(used_builtin_names, "Http::request")
+  let need_http_response_status_builtin = Map::has_key(used_builtin_names, "vibe_http_response_status_raw") || Map::has_key(used_builtin_names, "Http::response_status")
+  let need_http_response_header_builtin = Map::has_key(used_builtin_names, "vibe_http_response_header_raw") || Map::has_key(used_builtin_names, "Http::response_header")
+  let need_http_response_body_builtin = Map::has_key(used_builtin_names, "vibe_http_response_body_raw") || Map::has_key(used_builtin_names, "Http::response_body")
+  let need_http_close_builtin = Map::has_key(used_builtin_names, "vibe_http_close_raw") || Map::has_key(used_builtin_names, "Http::close")
   let mut next_import_idx = 1
   let env_get_import_idx = if need_env_get_builtin {
     let idx = next_import_idx

--- a/tests/http_wasm_fallback_test.vibe
+++ b/tests/http_wasm_fallback_test.vibe
@@ -2,8 +2,12 @@
 // This file is designed for --backend wasm execution.
 // On native/compiled host runners, HTTP builtins may succeed or fail
 // depending on host policy, so these tests only lock handle/error shape.
+//
+// #1508: each block declares the Http operation it performs at operation
+// granularity (`with Http::request`, ...) -- the declared row widens the
+// ambient one, which excludes network by default.
 
-test "Http::request handle compiles to wasm" {
+test "Http::request handle compiles to wasm" with Http::request {
   let result = handle {
     let h = Http::request("GET", "http://127.0.0.1:1/x", "", "")
     h
@@ -15,7 +19,7 @@ test "Http::request handle compiles to wasm" {
   assert(result == -1)
 }
 
-test "Http::response_status handle compiles to wasm" {
+test "Http::response_status handle compiles to wasm" with Http::response_status {
   let result = handle {
     Http::response_status(9999)
   } with Exception {
@@ -25,7 +29,7 @@ test "Http::response_status handle compiles to wasm" {
   assert(result == -1)
 }
 
-test "Http::close handle compiles to wasm" {
+test "Http::close handle compiles to wasm" with Http::close {
   let result = handle {
     Http::close(9999)
     1


### PR DESCRIPTION
P1 issue を並列 worktree で分担したバッチ。着地したストリームから順にコミットを積む。

## 着地済み

### #1508 — `Http` を実行する test / bench が書けない (第2障壁: codegen)

構文 (`test "n" with <row> { .. }`) と checker の ambient row 拡張は #80f3088 で既に merge 済みだったため、残っていた codegen 障壁を解消:

- **codegen**: 直接綴り `Http::request/response_status/response_header/response_body/close` が checker を通った後 codegen で ICE になっていたのを、raw dunder 名と同じ `vibe.http_*` host import へ lower するよう修正 (`compile_call.vibe` の `http_client_surface_to_raw`、実 binding — #795 の value alias — が常に優先される strictly-widening な変更)。`linked_compile.vibe` の import 予約ゲートも surface 綴りを受理
- **`bench/http_bench.vibe`** / **`tests/http_wasm_fallback_test.vibe`**: row を付けて type-check 回復。echo server 起動での実 HTTP 実行も smoke 済み (bench exit 0)
- **fixtures**: with-Exception の実行可能 fixture、row 構文エラーの負例 + `expected.tsv`
- **docs**: cheatsheet の test/bench 節を row 構文 + widening 意味論で書き直し (doctest 検証済み)、spec `test-example-capabilities.md` に実装状況バナー

検証: stage0→1→2 self-compile fixpoint 維持、unit_test_runner 542/542、doctest 54 blocks (28 pass / 0 fail / 26 skip)、typecheck fixtures 一致、vibe_fmt --check clean。

## 予定 (並列作業中)

- #1595 (+#1591): self-discharging 関数の row 宣言が effect migration を沈める件
- #1590: merged source round-trip が `str_lex_diff` を吐いて読み戻せない件
- #1553: FS コンパイル heap の memory mark 計測基盤

## Follow-ups (別 issue 候補)

- `tests/http_wasm_fallback_test.vibe` の runtime 前提 (host error を catchable `Exception::Throw` にする契約) は未提供 — 退役か契約追加かの判断が必要
- `scripts/bench_http.sh` stub の復活 (`vibe bench bench/http_bench.vibe` 経由で前提は解消済み)
- wasm-gc backend では `Http::*` は他の host import 同様未対応 (既知の制限)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_