### PR TITLE
Fix #1595/#1591 effect migration sink, #1590 seed-lane diagnostics, #1553 FS heap marks

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -286,6 +286,31 @@ parse できることを確認した上で、bump なしで通している。**�
 > tree を直接解決させ (`VIBE_EMIT_MERGED_SOURCE`)、成果物の tracking もやめた
 > ので、この世代遅れも `drift detected` ゲートも今は存在しない。
 
+### seed lane と desugar-emitted builtins (#1590)
+
+seed が flat module source をコンパイルする lane (`generate_bundle.sh` の
+flatten-tool pass 3 / `validate_module_source_compiles`、`generations.sh` の
+stage1 hop — どれも `VIBE_FS_COMPILE=1` を付けない) では **checker が desugar
+の後に走る**。desugar はソースに存在しない builtin 呼び出しを合成する —
+String の `a < b` は `str_lex_diff(a, b) < 0` に、erased type parameter 上の
+`<`/`>`/`<=`/`>=` と `+` は `__generic_rel_diff` / `__generic_add` になる。
+この3つは builtin_registry で checker_visible=false だったため、この lane
+だけで `unknown name: <builtin>` で死んでいた (通常の `vibe` 呼び出しは
+`VIBE_FS_COMPILE=1` の checker-before-desugar lane なので無事)。
+
+live tree では f89b529 が3行とも checker_visible=true にして修正済み
+(`scripts/compiler_gate.sh` の section 97 が non-FS lane で3形をロックして
+いる)。ただし **pinned seed がこの fix より古い間は、compiler/cli source
+(cli_adapter.vibe から到達する全ファイル) は String `<`/`>`/`<=`/`>=` と
+erased-generic `<`/`+` を書けない** — bundle ビルド時に seed が上記の
+`unknown name` で拒否する。`generate_bundle.sh` はこの失敗を検出すると
+「どの演算子が原因か」を示す actionable な説明を付けて落ちる。
+
+この制約は **f89b529 以降の commit を seed にした次の bootstrap bump で消える**。
+bump したら: `lib/@vibe/compiler/core/sorted_index.vibe` の `str_lt` の
+char-by-char loop を `a < b` に戻し (doc comment がそう指示している)、lib/
+内の同型の手書き比較 loop も同様に畳んでよい。その後この節も削除する。
+
 ### bootstrap bump の手順 (更新版)
 
 `seed-release.yml` は **tag push ではなく `workflow_dispatch`** で手動起動する

--- a/fixtures/effect_effectset_expansion.vibe
+++ b/fixtures/effect_effectset_expansion.vibe
@@ -1,3 +1,7 @@
+import ../lib/@vibe/core {
+  inspect
+}
+
 // ADR-0071 step 3 (docs/effectset.md, #755): a VALID `effectset` (no
 // cycle, no operation-name collision) is now accepted and its members are
 // expanded into any `with EffectsetName` row item that references it,
@@ -21,7 +25,9 @@ effect Ask {
   Get -> Int
 }
 
-effectset AskAll = { Ask::Get }
+effectset AskAll = {
+  Ask::Get
+}
 
 let read_one = () -> Int with Ask::Get {
   perform Ask::Get
@@ -39,5 +45,18 @@ export let main = () -> Int with Ask + Ask::Get {
   }
 }
 
-__DATA__
-{"last": "42"}
+test "effectset row expansion authorizes the transitive operation requirement" {
+  // #1571: expectation lives beside the code (updatable via `vibe test
+  // --update`) instead of in a `__DATA__` tail. The wrapping handle is
+  // required because a test block's own row cannot authorize `Ask`, and
+  // `main`'s declared row still names it even though `main` discharges the
+  // effect itself -- so the outer arm can never actually fire (resume(0) is
+  // deliberately NOT the expected value: the inner handler must win). This
+  // exact shape -- calling a self-discharging fn from under another handle
+  // for the same effect -- was rejected before #1595.
+  handle {
+    inspect(main(), "42")
+  } with Ask {
+    Get => resume(0)
+  }
+}

--- a/fixtures/effect_effectset_param_expansion.vibe
+++ b/fixtures/effect_effectset_param_expansion.vibe
@@ -1,3 +1,7 @@
+import ../lib/@vibe/core {
+  inspect
+}
+
 // ADR-0071 step 3 (docs/effectset.md, #755): effectset row expansion also
 // covers a function PARAMETER's own function-typed row (the #885
 // callback-overlay case), not just a function's own top-level declared
@@ -17,7 +21,9 @@ effect Ask {
   Get -> Int
 }
 
-effectset AskAll = { Ask::Get }
+effectset AskAll = {
+  Ask::Get
+}
 
 let run_with = (f: () -> Int with AskAll) -> Int with AskAll {
   f()
@@ -35,5 +41,17 @@ export let main = () -> Int with Ask + Ask::Get {
   }
 }
 
-__DATA__
-{"last": "42"}
+test "effectset expansion covers a callback parameter's own row" {
+  // #1571: expectation lives beside the code (updatable via `vibe test
+  // --update`) instead of in a `__DATA__` tail. The wrapping handle is
+  // required because a test block's own row cannot authorize `Ask`;
+  // `main` discharges the effect itself, so the outer arm can never fire
+  // (resume(0) is deliberately NOT the expected value: the inner handler
+  // must win). Calling a self-discharging fn from under another handle for
+  // the same effect was rejected before #1595.
+  handle {
+    inspect(main(), "42")
+  } with Ask {
+    Get => resume(0)
+  }
+}

--- a/fixtures/effect_row_operation_item.vibe
+++ b/fixtures/effect_row_operation_item.vibe
@@ -1,3 +1,7 @@
+import ../lib/@vibe/core {
+  inspect
+}
+
 // ADR-0071 step 1 (docs/effectset.md): `with ...` row items may now name
 // a single qualified operation (`Effect::op`), not just a whole effect name.
 // This fixture is a parse/round-trip/compile/run smoke test for that new
@@ -21,5 +25,17 @@ export let main = () -> Int with Ask::Get {
   }
 }
 
-__DATA__
-{"last": "42"}
+test "an operation-qualified row item parses, checks, and runs" {
+  // #1571: expectation lives beside the code (updatable via `vibe test
+  // --update`) instead of in a `__DATA__` tail. The wrapping handle is
+  // required because a test block's own row cannot authorize `Ask::Get`;
+  // `main` discharges the effect itself, so the outer arm can never fire
+  // (resume(0) is deliberately NOT the expected value: the inner handler
+  // must win). Calling a self-discharging fn from under another handle for
+  // the same effect was rejected before #1595.
+  handle {
+    inspect(main(), "42")
+  } with Ask {
+    Get => resume(0)
+  }
+}

--- a/fixtures/effect_self_discharging_callee.vibe
+++ b/fixtures/effect_self_discharging_callee.vibe
@@ -1,0 +1,51 @@
+import ../lib/@vibe/core {
+  inspect
+}
+
+// #1595: a function that discharges its own effect but ALSO declares that
+// effect in its row (`selfd` -- the row is required so callers can name it,
+// and the checker separately requires a `handle ... with Effect`'s
+// enclosing declared row to authorize the whole effect name) must not sink
+// evidence-passing migration for the whole program when it is CALLED from
+// another row-carrying function. Two halves, both required:
+//   1. `selfd` is dropped from the effect's `needing` set
+//      (edp_drop_self_discharging_needing -- it provides the dict, never
+//      needs one), and
+//   2. calls TO `selfd` are inert (edp_append_self_discharging_row_fns) --
+//      without this the drop was self-defeating: removing `selfd` from
+//      `needing` removed the very membership that made `main`'s call to it
+//      safe in edp_has_unsafe_construct, so `main` went ineligible and the
+//      whole effect's migration failed hard.
+// The handler arm must stay perform-free for half 2 (an arm that
+// re-performs the effect escapes `selfd` -- see
+// fixtures/err_effect_self_discharge_arm_reperform.vibe for the rejection).
+effect Ask {
+  Get -> Int
+}
+
+fn read_one() -> Int with Ask::Get {
+  perform Ask::Get
+}
+
+fn selfd() -> Int with Ask + Ask::Get {
+  handle {
+    read_one()
+  } with Ask {
+    Get => resume(42)
+  }
+}
+
+fn main() -> Int with Ask + Ask::Get {
+  selfd()
+}
+
+test "calling a self-discharging fn from a row-carrying caller compiles and runs" {
+  // The wrapping handle discharges `main`'s declared row for the test
+  // block (a test's own row cannot authorize Ask); `selfd`'s inner handler
+  // must win, so resume(0) is deliberately NOT the expected value.
+  handle {
+    inspect(main(), "42")
+  } with Ask {
+    Get => resume(0)
+  }
+}

--- a/fixtures/err_effect_self_discharge_arm_reperform.vibe
+++ b/fixtures/err_effect_self_discharge_arm_reperform.vibe
@@ -1,0 +1,35 @@
+// #1595/#1591: the narrow boundary of self-discharging call-inertness. A
+// fn whose whole body is a bare same-effect handle is dropped from
+// `needing` (edp_drop_self_discharging_needing), but a handler ARM that
+// re-performs the effect escapes the fn (arms run outside their own
+// handle's coverage), so such a fn must NOT be call-inert
+// (edp_fn_is_self_discharging_inert rejects it) -- treating the call as
+// safe would migrate the outer handle while the arm's perform stays
+// invisible to it (silent-wrong, P0). The program is rejected, and the
+// diagnostic names the callee and the arm re-perform instead of reciting
+// the allowed-forms enumeration this program already satisfies (#1591:
+// the body really does only "call a named top-level `fn`").
+// needle: "hides a perform from it"
+effect Ask {
+  Get -> Int
+}
+
+fn read_one() -> Int with Ask::Get {
+  perform Ask::Get
+}
+
+fn selfd() -> Int with Ask + Ask::Get {
+  handle {
+    read_one()
+  } with Ask {
+    Get => resume(perform Ask::Get + 1)
+  }
+}
+
+fn main() -> Int with Ask + Ask::Get {
+  handle {
+    selfd()
+  } with Ask {
+    Get => resume(105)
+  }
+}

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -1038,6 +1038,16 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
         strip_executable_wasm_env(bytes, entry_name)
       }
       Fs::write_bytes(output_path, out_bytes)
+      // #1553: final named heap mark for the FS-compile measurement — captures
+      // the strip_executable_wasm_env + output-write tail, so the reported
+      // peak is not under-read when stripping allocates past the codegen_rc
+      // mark. No-op (empty env read) unless VIBE_PROFILE_MEMORY_MARKS=1.
+      if mark_memory {
+        let _ = Env::get("VIBE_PROFILE_MEMORY_MARK:write_output")
+        ()
+      } else {
+        ()
+      }
       // Best-effort `.funcmap` sidecar (entry-file top-level funcs -> line). A
       // failure to build/write it must NOT fail the compile (the wasm is already
       // written), so swallow any Exception::Throw here. The discarded result is bound

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -60,6 +60,7 @@ import @vibe/compiler/entry/compiler/file_compile {
   compile_file_fs_mode_cached_artifact_input_trace,
   compile_file_fs_mode_coverage,
   compile_file_fs_mode_rc,
+  compile_file_fs_mode_rc_heap_marked,
   compile_file_fs_mode_rc_shadow,
   compile_file_fs_mode_testmeta,
   compile_file_fs_mode_trace,
@@ -1001,7 +1002,14 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       } else if Env::get("VIBE_RC") != "0" {
         // ADR-0055 #493 cutover DEFAULT: RC reclaims memory each iteration; the
         // legacy bump path leaks until exit. Opt back into bump with VIBE_RC=0.
-        (compile_file_fs_mode_rc(input_path, entry_name), "")
+        // #1553: under VIBE_PROFILE_MEMORY_MARKS=1 take the heap-marked twin
+        // (same pipeline, named memory mark per phase); production runs keep
+        // the exact unmarked lane.
+        if mark_memory {
+          (compile_file_fs_mode_rc_heap_marked(input_path, entry_name), "")
+        } else {
+          (compile_file_fs_mode_rc(input_path, entry_name), "")
+        }
       } else {
         // Legacy bump path (VIBE_RC=0). #634 (ADR-0026): only when `vibe test`
         // requests the pure-test cache verdict (VIBE_TESTMETA_OUT set) do we

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -1175,23 +1175,59 @@ export fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[St
         } else {
           culprit_raw
         }
-        let head = String::concat(String::concat("handle of effect '", bad), "' cannot be compiled here. Every perform this handle covers has to be statically visible to it, so the handled body may only: perform directly, call a named top-level `fn`, or call a closure literal that carries an effect row annotation. A call through a local binding or a closure parameter hides the perform and is what this rejects")
-        let named = if String::length(culprit) > 0 {
-          String::concat(head, String::concat(" (here: the call to '", String::concat(culprit, "')")))
+        // #1591: when no opaque call exists -- the body really does only
+        // call named top-level `fn`s, the very form the enumeration below
+        // says is allowed -- check for the one named-callee shape that
+        // still breaks static visibility: a callee that discharges this
+        // same effect around its own whole body but RE-PERFORMS it from a
+        // handler arm (see edp_live_handle_dirty_selfdischarge's doc
+        // comment). Name it and say what about it is the problem, instead
+        // of emitting an enumeration this program already satisfies.
+        let (ds_raw, ds_off) = if String::length(culprit_raw) == 0 {
+          edp_live_handle_dirty_selfdischarge(stmts, keep, bad, li_fn_defs)
         } else {
-          head
+          ("", -1)
         }
-        let full = String::concat(named, " -- move the `handle` into the function that performs, or replace the indirect call with a direct one. (ADR-0076 evidence-passing migration; the replay engine that used to accept this shape was removed.)")
-        let marked = if culprit_off >= 0 {
-          if String::length(culprit) > 0 {
-            String::concat(full, String::concat(" [@off=", String::concat(__to_string(culprit_off), String::concat(":", String::concat(__to_string(culprit_off + String::length(culprit)), "]")))))
+        let ds_nm = if edp_renamed && !edp_str_array_contains(user_edpsh, ds_raw) {
+          edp_unmangle_shadow_name(ds_raw)
+        } else {
+          ds_raw
+        }
+        if String::length(ds_nm) > 0 {
+          let mut ds_head = String::concat(String::concat("handle of effect '", bad), "' cannot be compiled here: the handled body's call to '")
+          ds_head = String::concat(ds_head, ds_nm)
+          ds_head = String::concat(ds_head, "' hides a perform from it. '")
+          ds_head = String::concat(ds_head, ds_nm)
+          ds_head = String::concat(ds_head, String::concat("' handles ", bad))
+          ds_head = String::concat(ds_head, String::concat(" around its own body, but one of its handler arms performs ", bad))
+          ds_head = String::concat(ds_head, " again -- that re-perform escapes '")
+          ds_head = String::concat(ds_head, ds_nm)
+          ds_head = String::concat(ds_head, "' into this handle's body, where it is not statically visible. Move that perform out of the handler arm (compute the value before the `handle`), or wrap the arm's perform in its own `handle`. (ADR-0076 evidence-passing migration; the replay engine that used to accept this shape was removed.)")
+          let ds_marked = if ds_off >= 0 {
+            String::concat(ds_head, String::concat(" [@off=", String::concat(__to_string(ds_off), String::concat(":", String::concat(__to_string(ds_off + String::length(ds_nm)), "]")))))
           } else {
-            String::concat(full, String::concat(" [@off=", String::concat(__to_string(culprit_off), "]")))
+            ds_head
           }
+          Array::push(errs, ds_marked)
         } else {
-          full
+          let head = String::concat(String::concat("handle of effect '", bad), "' cannot be compiled here. Every perform this handle covers has to be statically visible to it, so the handled body may only: perform directly, call a named top-level `fn`, or call a closure literal that carries an effect row annotation. A call through a local binding or a closure parameter hides the perform and is what this rejects")
+          let named = if String::length(culprit) > 0 {
+            String::concat(head, String::concat(" (here: the call to '", String::concat(culprit, "')")))
+          } else {
+            head
+          }
+          let full = String::concat(named, " -- move the `handle` into the function that performs, or replace the indirect call with a direct one. (ADR-0076 evidence-passing migration; the replay engine that used to accept this shape was removed.)")
+          let marked = if culprit_off >= 0 {
+            if String::length(culprit) > 0 {
+              String::concat(full, String::concat(" [@off=", String::concat(__to_string(culprit_off), String::concat(":", String::concat(__to_string(culprit_off + String::length(culprit)), "]")))))
+            } else {
+              String::concat(full, String::concat(" [@off=", String::concat(__to_string(culprit_off), "]")))
+            }
+          } else {
+            full
+          }
+          Array::push(errs, marked)
         }
-        Array::push(errs, marked)
       }
     } else {
       ()
@@ -2757,6 +2793,148 @@ fn edp_unmangle_shadow_name(nm: String) -> String {
   }
 }
 
+/// #1591/#1595 follow-up culprit: the live handle's body only calls a named
+/// top-level `fn` -- a shape the ineligibility diagnostic's enumeration says
+/// is allowed -- but that callee's own body is a bare same-effect `handle`
+/// whose handler ARM re-performs the effect. Such a callee is dropped from
+/// `needing` (edp_drop_self_discharging_needing) yet NOT call-inert
+/// (edp_fn_is_self_discharging_inert rejects it for exactly this arm), so
+/// the caller's handle stays ineligible -- and without this scan the error
+/// carried no culprit at all (the call is resolvable, so
+/// edp_first_opaque_call_info finds nothing). Returns (callee name, source
+/// byte offset of the call) or ("", -1). Mirrors
+/// edp_live_handle_opaque_info's walk shape but only needs the first
+/// matching call in the first `ename` handle body.
+fn edp_dirty_selfdischarge_callee_expr(expr: Expr, ename: String, stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> (Bool, String, Int) {
+  match expr {
+    EHandle(body, arms) => if edp_handle_matches_effect(arms, ename) {
+      edp_dirty_selfdischarge_call_in(body, ename, stmts, fn_defs)
+    } else {
+      edp_dirty_selfdischarge_callee_exprs(expr_children(expr), ename, stmts, fn_defs)
+    },
+    _ => edp_dirty_selfdischarge_callee_exprs(expr_children(expr), ename, stmts, fn_defs)
+  }
+}
+
+fn edp_dirty_selfdischarge_callee_exprs(es: Array[Expr], ename: String, stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> (Bool, String, Int) {
+  let mut i = 0
+  let mut found = false
+  let mut nm = ""
+  let mut off = -1
+  while i < Array::length(es) && !found {
+    let (f, n, o) = edp_dirty_selfdischarge_callee_expr(Array::get(es, i), ename, stmts, fn_defs)
+    found = f
+    nm = n
+    off = o
+    i = i + 1
+  }
+  (found, nm, off)
+}
+
+/// Inside an `ename` handle's BODY: the first call to a top-level fn whose
+/// own body is a bare same-effect handle with an arm that re-performs.
+fn edp_dirty_selfdischarge_call_in(expr: Expr, ename: String, stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> (Bool, String, Int) {
+  match expr {
+    ECall(callee, args, off) => match callee {
+      EIdent(nm, ioff) => if edp_callee_is_dirty_selfdischarge(nm, ename, stmts, fn_defs) {
+        (true, nm, if ioff >= 0 {
+          ioff
+        } else {
+          off
+        })
+      } else {
+        edp_dirty_selfdischarge_call_in_exprs(args, ename, stmts, fn_defs)
+      },
+      _ => edp_dirty_selfdischarge_call_in_exprs(expr_children(expr), ename, stmts, fn_defs)
+    },
+    _ => edp_dirty_selfdischarge_call_in_exprs(expr_children(expr), ename, stmts, fn_defs)
+  }
+}
+
+fn edp_dirty_selfdischarge_call_in_exprs(es: Array[Expr], ename: String, stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> (Bool, String, Int) {
+  let mut i = 0
+  let mut found = false
+  let mut nm = ""
+  let mut off = -1
+  while i < Array::length(es) && !found {
+    let (f, n, o) = edp_dirty_selfdischarge_call_in(Array::get(es, i), ename, stmts, fn_defs)
+    found = f
+    nm = n
+    off = o
+    i = i + 1
+  }
+  (found, nm, off)
+}
+
+fn edp_callee_is_dirty_selfdischarge(nm: String, ename: String, stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> Bool {
+  match edp_find_fn_body(stmts, fn_defs, nm) {
+    Some(body) => match body {
+      EHandle(_, arms) => if edp_handle_matches_effect(arms, ename) {
+        let mut dirty = false
+        let mut ai = 0
+        while ai < Array::length(arms) {
+          let (_, ab) = Array::get(arms, ai)
+          if edp_performs_user_effect_expr(ab, ename) {
+            dirty = true
+          } else {
+            ()
+          }
+          ai = ai + 1
+        }
+        dirty
+      } else {
+        false
+      },
+      _ => false
+    },
+    None => false
+  }
+}
+
+/// Stmt-level driver for the dirty self-discharge culprit; same walk order
+/// and dead-`fn` exemption as edp_live_handle_opaque_info.
+fn edp_live_handle_dirty_selfdischarge(stmts: Array[Stmt], keep: Array[Bool], ename: String, fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> (String, Int) {
+  let mut i = 0
+  let mut found = false
+  let mut nm = ""
+  let mut off = -1
+  while i < Array::length(stmts) && !found {
+    let expr_opt = match Array::get(stmts, i) {
+      SLet(_, _, _, _, expr) => {
+        let dead_fn = match expr {
+          EFn(_, _, _, _, _, _) => if i < Array::length(keep) {
+            !Array::get(keep, i)
+          } else {
+            false
+          },
+          _ => false
+        }
+        if dead_fn {
+          None
+        } else {
+          Some(expr)
+        }
+      },
+      SLetMut(_, _, expr) => Some(expr),
+      SExpr(expr) => Some(expr),
+      STest(_, expr) => Some(expr),
+      SBench(_, expr) => Some(expr),
+      _ => None
+    }
+    match expr_opt {
+      Some(expr) => {
+        let (f, n, o) = edp_dirty_selfdischarge_callee_expr(expr, ename, stmts, fn_defs)
+        found = f
+        nm = n
+        off = o
+      },
+      None => ()
+    }
+    i = i + 1
+  }
+  (nm, off)
+}
+
 /// Drop any `needing` name whose OWN top-level definition `keep` (from
 /// `dce_keep_flags`, computed against the real entry point) marks
 /// unreachable -- a needing function that can never actually run at runtime
@@ -3064,6 +3242,15 @@ fn edp_drop_shadowed_needing(needing: Array[String], stmts: Array[Stmt]) -> Arra
 /// qualifies (no ESeq prefix, no wrapping ELet, etc.) -- anything else keeps
 /// the function in `needing` and falls back to the existing (already sound)
 /// conservative treatment, exactly as before this change existed.
+///
+/// #1595: this drop is only HALF of the treatment. Removing the fn from
+/// `needing` also removes the membership that made calls TO it safe in
+/// edp_has_unsafe_construct, so any row-carrying CALLER of a dropped fn
+/// went ineligible and sank the whole effect anyway. The other half is
+/// edp_append_self_discharging_row_fns (calls to such a fn are inert,
+/// appended into `pure_fns` at every safety-scan construction site) --
+/// with the extra arm condition documented on
+/// edp_fn_is_self_discharging_inert.
 fn edp_drop_self_discharging_needing(needing: Array[String], stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], ename: String) -> Array[String] {
   let out = array_empty()
   let mut ni = 0
@@ -3150,6 +3337,7 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
     // so both views classify these names identically.
     let pf_inert = edp_pure_fn_names(fn_defs)
     edp_append_free_host_inert_names(stmts, pf_inert)
+    edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pf_inert)
     edp_append_perform_free_row_fns(stmts, fn_defs, ename, pf_inert)
     let needing_full = array_empty()
     let mut pfi = 0
@@ -3301,6 +3489,7 @@ fn edp_try_plan_for_effect(stmts: Array[Stmt], ename: String, ops: Array[(String
 fn edp_any_handle_owner_cp(stmts: Array[Stmt], ename: String, needing: Array[String], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> Bool {
   let pure_fns = edp_pure_fn_names(fn_defs)
   edp_append_free_host_inert_names(stmts, pure_fns)
+  edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pure_fns)
   edp_append_perform_free_row_fns(stmts, fn_defs, ename, pure_fns)
   let es_names = array_empty()
   let es_members_list = array_empty()
@@ -4183,6 +4372,84 @@ fn edp_append_perform_free_row_fns(stmts: Array[Stmt], fn_defs: Array[(Int, Bool
   }
 }
 
+/// #1595: a row-E function whose ENTIRE body is a bare `handle {..} with
+/// ename {..}` that its own handler arms cannot leak `ename` out of is
+/// inert to CALL, exactly like a perform-free row fn (see
+/// edp_fn_is_perform_free above): every perform of `ename` reachable
+/// through the call is discharged inside the callee by its own handle
+/// (which edp_collect_handle_sites discovers and migrates independently),
+/// so nothing about the call needs this pass's attention -- no dict to
+/// forward (the callee was dropped from `needing` by
+/// edp_drop_self_discharging_needing for the same reason) and no perform
+/// that could escape into the caller's context. Without this second half,
+/// the drop was self-defeating for any self-discharging fn that had a
+/// CALLER carrying the same row: the drop removed the callee from
+/// `needing`, which removed the very membership that made calls to it safe
+/// in edp_has_unsafe_construct, so the caller went ineligible and sank the
+/// whole effect's migration -- #1595's repro (`main` with row
+/// `Ask + Ask::Get` calling self-discharging `selfd`) is exactly that.
+///
+/// The arm condition is what keeps this narrower than the drop itself: an
+/// arm CAN legally re-perform `ename` (arms run outside their own handle's
+/// coverage, so that perform escapes to the caller), and an arm making a
+/// call this pass cannot resolve could hide the same thing. Either
+/// disqualifies the fn from call-inertness (its callers then stay
+/// ineligible and fail loudly, same as before this change) while the drop
+/// still applies. `resume(...)` stays safe -- a resumed continuation
+/// re-enters the handled body, which the fn's own handle still covers.
+fn edp_fn_is_self_discharging_inert(stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], nm: String, ename: String, base_inert: Array[String]) -> Bool {
+  match edp_find_fn_body(stmts, fn_defs, nm) {
+    Some(body) => match body {
+      EHandle(_, arms) => if edp_handle_matches_effect(arms, ename) {
+        let mut ok = true
+        let mut ai = 0
+        while ai < Array::length(arms) {
+          let (_, ab) = Array::get(arms, ai)
+          if edp_performs_user_effect_expr(ab, ename) || edp_has_unsafe_construct(ab, empty_str_array(), ename, base_inert) {
+            ok = false
+          } else {
+            ()
+          }
+          ai = ai + 1
+        }
+        ok
+      } else {
+        false
+      },
+      _ => false
+    },
+    None => false
+  }
+}
+
+/// #1595: append every self-discharging call-inert row fn (see
+/// edp_fn_is_self_discharging_inert) into `pure_fns`, mirroring
+/// edp_append_perform_free_row_fns' shape -- called at the SAME
+/// construction sites, in the SAME position (after the host-inert append,
+/// before the perform-free append, so a caller whose only row-E reach is
+/// a call to a self-discharging fn is itself classified perform-free and
+/// kept out of `needing` too -- #1595's `main` needs exactly that to keep
+/// its entry arity). Single pass, same-order determinism argument as
+/// edp_fn_is_perform_free's doc comment.
+fn edp_append_self_discharging_row_fns(stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], ename: String, pure_fns: Array[String]) -> Unit {
+  let es_names = array_empty()
+  let es_members_list = array_empty()
+  edp_es_collect_into(stmts, es_names, es_members_list)
+  let candidates = edp_needing_names(fn_defs, ename, es_names, es_members_list)
+  let mut i = 0
+  while i < Array::length(candidates) {
+    let nm = Array::get(candidates, i)
+    if edp_str_array_contains(pure_fns, nm) {
+      ()
+    } else if edp_fn_is_self_discharging_inert(stmts, fn_defs, nm, ename, pure_fns) {
+      Array::push(pure_fns, nm)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}
+
 fn edp_append_free_host_inert_names(stmts: Array[Stmt], pure_fns: Array[String]) -> Unit {
   let top_names = empty_str_array()
   let mut ti = 0
@@ -4810,6 +5077,7 @@ fn edp_all_sites_eligible(stmts: Array[Stmt], ename: String, needing: Array[Stri
   } else {
     let pure_fns = edp_pure_fn_names(fn_defs)
     edp_append_free_host_inert_names(stmts, pure_fns)
+    edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pure_fns)
     edp_append_perform_free_row_fns(stmts, fn_defs, ename, pure_fns)
     let es_names = array_empty()
     let es_members_list = array_empty()
@@ -6847,6 +7115,7 @@ fn edp_apply_migration(stmts: Array[Stmt], ename: String, ops: Array[(String, Ar
   let dict_tyname = edp_dict_struct_name(ename)
   let pure_fns = edp_pure_fn_names(fn_defs)
   edp_append_free_host_inert_names(stmts, pure_fns)
+  edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pure_fns)
   edp_append_perform_free_row_fns(stmts, fn_defs, ename, pure_fns)
   let es_names = array_empty()
   let es_members_list = array_empty()

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -521,6 +521,48 @@ export fn compile_file_fs_mode_rc(entry_path: String, entry_name: String) -> Byt
   compile_wasi_module_rc(merged_stmts, entry_name)
 }
 
+/// #1553: emit a named heap mark for the FS-compile memory measurement. The
+/// node runner intercepts `Env::get` of "VIBE_PROFILE_MEMORY_MARK:<phase>"
+/// (scripts/wasm_vibe_host_runner.js maybeEmitEnvMemoryMark) and prints one
+/// `[profile-memory] ... name=<phase>` line with the current bump-heap
+/// pointer / linear-memory pages — but only under VIBE_PROFILE_MEMORY_MARKS=1;
+/// otherwise the env read returns "" and nothing is printed. The env var
+/// spelled here is never set, so the read is a pure observation signal.
+fn fs_heap_mark(phase: String) -> Unit with Env {
+  let _ = Env::get(String::concat("VIBE_PROFILE_MEMORY_MARK:", phase))
+  ()
+}
+
+/// #1553 heap-measurement variant of compile_file_fs_mode_rc: byte-identical
+/// pipeline with a named memory mark at each phase boundary. Selected by the
+/// CLI adapter ONLY under VIBE_PROFILE_MEMORY_MARKS=1 (the production lanes
+/// stay Env-free per the #634 layering note; this observation-only lane
+/// carries Env solely to reach the runner's mark hook). Phase names:
+///   start           — before any work (baseline heap)
+///   collect_sources — after collect_source_groups_fs (FS reads + module
+///                     header parsing + import-graph resolution)
+///   typecheck       — after db_typecheck_fs (type env build, persistent
+///                     type-env/dep-list TSV cache read/write)
+///   parse_merge     — after build_grouped_merged_stmts (parse all sources,
+///                     export-rename plan, alias rewriting, whole-program merge)
+///   codegen_rc      — after compile_wasi_module_rc (effect lowering /
+///                     evidence-passing migration, perceus RC insertion,
+///                     wasm emit) — this is also the run's heap peak, since
+///                     the bump allocator never frees.
+export fn compile_file_fs_mode_rc_heap_marked(entry_path: String, entry_name: String) -> Bytes with Exception + Fs + Env {
+  fs_heap_mark("start")
+  let source_groups = collect_source_groups_fs(entry_path)
+  fs_heap_mark("collect_sources")
+  let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
+  let _ = next_db
+  fs_heap_mark("typecheck")
+  let merged_stmts = build_grouped_merged_stmts(source_groups)
+  fs_heap_mark("parse_merge")
+  let bytes = compile_wasi_module_rc(merged_stmts, entry_name)
+  fs_heap_mark("codegen_rc")
+  bytes
+}
+
 /// #715/#768 debug variant (VIBE_RC=shadow): same load/merge as
 /// compile_file_fs_mode_rc but with shadow-liveness double-free traps, so an
 /// import-resolving test build's "moving target" free-list corruption becomes a

--- a/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
@@ -35,6 +35,9 @@ fn prepare_file_fs_cached(db: TypeDb, entry_path: String) -> TypeDb with Excepti
 fn check_file_fs_mode(entry_path: String) -> Int with Exception + Fs
 fn compile_file_fs_mode(entry_path: String, entry_name: String, mode: String) -> Bytes with Exception + Fs
 fn compile_file_fs_mode_rc(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
+// #1553 observation-only heap-mark lane (VIBE_PROFILE_MEMORY_MARKS=1); same
+// pipeline as compile_file_fs_mode_rc, Env only for the runner's mark hook.
+fn compile_file_fs_mode_rc_heap_marked(entry_path: String, entry_name: String) -> Bytes with Exception + Fs + Env
 fn compile_file_fs_mode_rc_shadow(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
 fn compile_file_fs_mode_testmeta(entry_path: String, entry_name: String, mode: String, meta_out: String) -> Bytes with Exception + Fs
 fn entry_cacheable_for_fs(entry_path: String, entry_name: String) -> Bool with Exception + Fs

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4246,24 +4246,80 @@ echo "[compiler-gate] wasm-gc backend dead needing function filtering ok (105)"
 #       shape; confirmed via direct testing that it failed under
 #       VIBE_BACKEND=gc with "only `with Error`..." before this change.
 echo "[compiler-gate] 40h4/40 wasm-gc backend: self-discharging needing function no longer blocks effect migration (ADR-0076 gc follow-up)"
+# #1571: fixture is an inspect() test-block suite now, compiled AS-IS (no
+# `sed` strip; its import resolves from fixtures/). Its test block wraps the
+# call to the self-discharging `main` in another `handle ... with Ask`,
+# which additionally locks #1595 on the gc lane: the CALL to a
+# self-discharging fn must be inert (edp_append_self_discharging_row_fns),
+# not just the fn itself dropped from `needing`.
 gcselfdir="_build/_gate_gc_self_discharge"
 rm -rf "$gcselfdir"; mkdir -p "$gcselfdir"
-sed '/^__DATA__$/,$d' fixtures/effect_effectset_expansion.vibe > "$gcselfdir/src.vibe"
-VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$gcselfdir/src.vibe" "$gcselfdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_effectset_expansion.vibe "$gcselfdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$gcselfdir/out.wasm" ]; then
-  echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe did not compile under VIBE_BACKEND=gc" >&2
+  echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe did not compile under VIBE_BACKEND=gc (self-discharging drop or #1595 call-inertness regressed)" >&2
   cat "$gcselfdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-gcself_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcselfdir/out.wasm" 2>&1 | tail -1)"
-if [ "$gcself_out" != "42" ]; then
-  echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe under gc got '$gcself_out' (want 42) -- self-discharging needing function filtering regressed" >&2
+if ! gcself_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcselfdir/out.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe under gc test failed (want inspect 42) -- self-discharging needing function filtering regressed" >&2
+  echo "$gcself_out" >&2
   exit 1
 fi
 rm -rf "$gcselfdir"
 echo "[compiler-gate] wasm-gc backend self-discharging needing function filtering ok (42)"
+
+# 40h4b. #1595: a self-discharging fn CALLED FROM another row-carrying fn.
+#        Dropping the callee from `needing` (40h4's fix) alone was
+#        self-defeating for this shape: the drop removed the very
+#        needing-membership that made the CALL to it safe in
+#        edp_has_unsafe_construct, so the caller went ineligible and the
+#        whole effect's migration failed hard ("cannot be compiled here").
+#        The second half (edp_append_self_discharging_row_fns) makes such
+#        calls inert -- mirroring the perform-free class's dual treatment.
+#        Positive: fixtures/effect_self_discharging_callee.vibe (inspect
+#        test block, both backends). Negative:
+#        fixtures/err_effect_self_discharge_arm_reperform.vibe -- a handler
+#        arm that RE-PERFORMS the effect escapes the callee, so that fn is
+#        NOT call-inert; the program must stay a hard error (never a
+#        silently-migrated outer handle blind to the arm's perform), and
+#        the diagnostic must name the callee + the arm re-perform (#1591:
+#        the old enumeration listed only forms this program satisfies).
+echo "[compiler-gate] 40h4b/40 self-discharging callee call-inertness (#1595) + dirty-arm rejection (#1591)"
+sdcdir="_build/_gate_self_discharge_callee"
+rm -rf "$sdcdir"; mkdir -p "$sdcdir"
+for sdc_backend in "" gc; do
+  rm -f "$sdcdir/out.wasm" "$sdcdir/out.wasm.diag"
+  env ${sdc_backend:+VIBE_BACKEND="$sdc_backend"} VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    fixtures/effect_self_discharging_callee.vibe "$sdcdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  if [ ! -s "$sdcdir/out.wasm" ]; then
+    echo "[compiler-gate] FAIL: effect_self_discharging_callee.vibe did not compile${sdc_backend:+ under VIBE_BACKEND=$sdc_backend} (#1595 call-inertness regressed)" >&2
+    cat "$sdcdir/out.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! sdc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$sdcdir/out.wasm" 2>&1)"; then
+    echo "[compiler-gate] FAIL: effect_self_discharging_callee.vibe test failed${sdc_backend:+ under VIBE_BACKEND=$sdc_backend} (want inspect 42 -- the callee's own handler must win)" >&2
+    echo "$sdc_out" >&2
+    exit 1
+  fi
+done
+rm -f "$sdcdir/rej.wasm" "$sdcdir/rej.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  fixtures/err_effect_self_discharge_arm_reperform.vibe "$sdcdir/rej.wasm" main >/dev/null 2>&1 || true
+if [ -s "$sdcdir/rej.wasm" ]; then
+  echo "[compiler-gate] FAIL: err_effect_self_discharge_arm_reperform.vibe compiled -- an arm re-perform escapes the callee, so call-inertness must NOT apply (P0 silent-wrong risk)" >&2
+  exit 1
+fi
+if ! grep -qF "hides a perform from it" "$sdcdir/rej.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: err_effect_self_discharge_arm_reperform.vibe rejection lacks the #1591 culprit diagnostic (want 'hides a perform from it')" >&2
+  cat "$sdcdir/rej.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$sdcdir"
+echo "[compiler-gate] self-discharging callee call-inertness ok (#1595/#1591)"
 
 # 40h5. ADR-0076 (#817) gc-backend follow-up: a local closure literal with
 #       NO explicit `with` annotation (its `eff` field is blank in the
@@ -4545,20 +4601,24 @@ echo "[compiler-gate] handle-replay side-effect corruption regression guard ok (
 #      perform of a DIFFERENT operation of the same effect when only one is
 #      named) is a separate, larger change (step 3), not covered here.
 echo "[compiler-gate] 40m/40 effect row operation-item grammar (ADR-0071 step 1/#755)"
+# #1571: the fixture carries its expectation as an inspect() test block now
+# (compiled AS-IS, no `sed` strip -- its `import ../lib/@vibe/core` resolves
+# from fixtures/); the test-block wrapper also locks #1595's shape (calling
+# the self-discharging `main` from under another `handle` for the same
+# effect).
 a71dir="_build/_gate_effectset_row_item"
 rm -rf "$a71dir"; mkdir -p "$a71dir"
-sed '/^__DATA__$/,$d' fixtures/effect_row_operation_item.vibe > "$a71dir/src.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$a71dir/src.vibe" "$a71dir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_row_operation_item.vibe "$a71dir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$a71dir/out.wasm" ]; then
-  echo "[compiler-gate] FAIL: effect_row_operation_item.vibe did not compile (with Effect::op row-item grammar regressed)" >&2
+  echo "[compiler-gate] FAIL: effect_row_operation_item.vibe did not compile (with Effect::op row-item grammar regressed, or #1595 self-discharging call-inertness regressed)" >&2
   cat "$a71dir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-a71_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$a71dir/out.wasm" 2>&1 | tail -1)"
-if [ "$a71_out" != "42" ]; then
-  echo "[compiler-gate] FAIL: effect_row_operation_item got '$a71_out' (want 42)" >&2
+if ! a71_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$a71dir/out.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: effect_row_operation_item test failed (want inspect 42)" >&2
+  echo "$a71_out" >&2
   exit 1
 fi
 rm -rf "$a71dir"
@@ -4579,20 +4639,21 @@ echo "[compiler-gate] effect row operation-item grammar ok"
 #      validity -- is superseded by this step; see gate 40o below for what
 #      STILL gets rejected.)
 echo "[compiler-gate] 40n/40 effectset row expansion authorizes a transitive call (ADR-0071 step 3/#755)"
+# #1571: fixture is an inspect() test-block suite now, compiled AS-IS (no
+# `sed` strip; its import resolves from fixtures/). See gate 40m's note.
 a71bdir="_build/_gate_effectset_expand"
 rm -rf "$a71bdir"; mkdir -p "$a71bdir"
-sed '/^__DATA__$/,$d' fixtures/effect_effectset_expansion.vibe > "$a71bdir/src.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$a71bdir/src.vibe" "$a71bdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_effectset_expansion.vibe "$a71bdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$a71bdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe did not compile -- effectset row expansion regressed" >&2
   cat "$a71bdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-a71b_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$a71bdir/out.wasm" 2>&1 | tail -1)"
-if [ "$a71b_out" != "42" ]; then
-  echo "[compiler-gate] FAIL: effect_effectset_expansion got '$a71b_out' (want 42)" >&2
+if ! a71b_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$a71bdir/out.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: effect_effectset_expansion test failed (want inspect 42)" >&2
+  echo "$a71b_out" >&2
   exit 1
 fi
 rm -rf "$a71bdir"
@@ -4654,20 +4715,21 @@ echo "[compiler-gate] effectset cycle + operation-collision detection ok"
 #      fixtures/effect_effectset_param_expansion.vibe, where a callback
 #      parameter's row is JUST an effectset name.
 echo "[compiler-gate] 40p/40 effectset parameter-type row expansion (ADR-0071 step 3/#755)"
+# #1571: fixture is an inspect() test-block suite now, compiled AS-IS (no
+# `sed` strip; its import resolves from fixtures/). See gate 40m's note.
 a71ddir="_build/_gate_effectset_param_expand"
 rm -rf "$a71ddir"; mkdir -p "$a71ddir"
-sed '/^__DATA__$/,$d' fixtures/effect_effectset_param_expansion.vibe > "$a71ddir/src.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$a71ddir/src.vibe" "$a71ddir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_effectset_param_expansion.vibe "$a71ddir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$a71ddir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_effectset_param_expansion.vibe did not compile -- parameter-type effectset expansion regressed" >&2
   cat "$a71ddir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-a71d_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$a71ddir/out.wasm" 2>&1 | tail -1)"
-if [ "$a71d_out" != "42" ]; then
-  echo "[compiler-gate] FAIL: effect_effectset_param_expansion got '$a71d_out' (want 42)" >&2
+if ! a71d_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$a71ddir/out.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: effect_effectset_param_expansion test failed (want inspect 42)" >&2
+  echo "$a71d_out" >&2
   exit 1
 fi
 rm -rf "$a71ddir"

--- a/scripts/generate_bundle.sh
+++ b/scripts/generate_bundle.sh
@@ -947,6 +947,47 @@ merge_flatten_tool_fingerprint() {
   bash "$helper" --print-fingerprint 2>/dev/null || true
 }
 
+# #1590: when the PINNED SEED compiles the flat module source (flatten-tool
+# pass 3 above, validate_module_source_compiles below, and the stage1 hop in
+# generations.sh), its checker runs AFTER desugar. Desugar synthesizes calls
+# to builtins that are not source-level names -- `a < b` on String becomes
+# `str_lex_diff(a, b) < 0`; `<`/`>`/`<=`/`>=` or `+` on an erased type
+# parameter become `__generic_rel_diff` / `__generic_add` -- so a seed whose
+# registry marks them checker-invisible dies with `unknown name: <builtin>`,
+# a message that never mentions the operator that caused it. The live tree
+# fixed the registry (checker_visible=true, #1590), but the failure keeps
+# this shape for as long as the pinned seed predates that fix, so translate
+# it back to the source-level construct the author actually wrote.
+explain_desugar_builtin_failure() {
+  local diag_file="$1"
+  [ -f "$diag_file" ] || return 0
+  local hit
+  hit="$(grep -oE 'unknown name: (str_lex_diff|__generic_rel_diff|__generic_add|__to_string)' \
+    "$diag_file" 2>/dev/null | head -1)" || true
+  [ -n "$hit" ] || return 0
+  local name="${hit#unknown name: }"
+  local construct
+  case "$name" in
+    str_lex_diff) construct='String `<` / `>` / `<=` / `>=`' ;;
+    __generic_rel_diff) construct='`<` / `>` / `<=` / `>=` on an erased type parameter ([T: Ord])' ;;
+    __generic_add) construct='`+` on an erased type parameter ([T: Add])' ;;
+    __to_string) construct='string interpolation / implicit to-string' ;;
+  esac
+  cat >&2 <<EOF
+
+generate_bundle: '$name' is not a name any source file spells -- the compiler
+itself introduces it when desugaring $construct.
+The pinned seed compiler rejects it in this lane (#1590): its checker runs
+after desugar here and its builtin registry predates the fix that made the
+name checker-visible. Until the next bootstrap bump, compiler/cli sources
+(everything reachable from lib/@vibe/compiler/cli_adapter.vibe) must not use
+$construct.
+For String order comparisons, call a char-by-char helper instead -- e.g.
+str_lt in lib/@vibe/compiler/core/sorted_index.vibe. See #1590 and
+docs/bootstrap.md ("seed lane と desugar-emitted builtins").
+EOF
+}
+
 bootstrap_merge_flatten_tool() {
   local flatten_wasm="$1"
   local seed_wasm="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
@@ -1007,6 +1048,7 @@ build_exact_adapter_merged_source() {
   if [ ! -s "$flatten_wasm" ]; then
     echo "generate_bundle: merge-flatten compiler build failed" >&2
     cat "$flatten_wasm.diag" >&2 2>/dev/null || true
+    explain_desugar_builtin_failure "$flatten_wasm.diag"
     echo "--- runner output ---" >&2
     tail -40 "$tool_log" >&2 2>/dev/null || true
     exit 1
@@ -1090,6 +1132,7 @@ validate_module_source_compiles() {
   if [ "$ok" != "1" ]; then
     echo "generate_bundle: candidate module source failed to compile (#979 sticky-failure guard) -- leaving any existing $ADAPTER_MODULE_SOURCE_OUT untouched" >&2
     cat "$check_wasm.diag" >&2 2>/dev/null || true
+    explain_desugar_builtin_failure "$check_wasm.diag"
     echo "--- runner output ---" >&2
     tail -40 "$check_log" >&2 2>/dev/null || true
   fi

--- a/scripts/measure_fs_heap.sh
+++ b/scripts/measure_fs_heap.sh
@@ -21,11 +21,15 @@
 #     After any prior compile of the same tree the type-env / dep-list TSVs
 #     hit, so the typecheck phase mostly deserializes cached envs
 #     (<2 GiB peak per #1553).
-#   --cold: first deletes _build/vibe_selfhost_type_env_v3_*.tsv and
-#     _build/vibe_selfhost_dep_list_*.tsv, so every module's type env is
-#     re-inferred AND re-serialized (the ~2.6 GiB peak of #1553). The cold
-#     run rebuilds those caches — expect it to take minutes and to leave the
-#     caches warm again afterwards.
+#   --cold: first deletes the type-env / dep-list TSVs
+#     (vibe_selfhost_type_env_v3_*.tsv + vibe_selfhost_dep_list_*.tsv), so
+#     every module's type env is re-inferred AND re-serialized (the ~2.6 GiB
+#     peak of #1553). The cold run rebuilds those caches — expect it to take
+#     minutes and to leave the caches warm again afterwards. The TSVs live
+#     under _build/ by default, but VIBE_BUILD_CACHE_DIR rebases them
+#     (cache_underlying.vibe rebase_cache_path: `_build/vibe_` ->
+#     `$VIBE_BUILD_CACHE_DIR/vibe_`), so the deletion follows the same rule —
+#     otherwise a warm run would be mislabeled cold.
 #
 # BASE COMPILER
 #   Must be built from the CURRENT tree (it has to contain the #1553 marks).
@@ -75,10 +79,17 @@ fi
 if [ "$MODE" = "cold" ]; then
   # Cold = the type-env cache TSVs from #1553 are gone; everything else
   # (artifact caches etc.) is left alone so the run still measures the
-  # compile itself, not unrelated cache rebuilds.
-  echo "[fs-heap] cold: deleting _build/vibe_selfhost_type_env_v3_*.tsv + _build/vibe_selfhost_dep_list_*.tsv" >&2
-  rm -f "$PROJECT_ROOT"/_build/vibe_selfhost_type_env_v3_*.tsv \
-    "$PROJECT_ROOT"/_build/vibe_selfhost_dep_list_*.tsv
+  # compile itself, not unrelated cache rebuilds. VIBE_BUILD_CACHE_DIR
+  # rebases the persistent caches (`_build/vibe_` -> `$override/vibe_`,
+  # cache_underlying.vibe), so mirror that rule or the "cold" run would
+  # silently read the surviving warm caches from the override root.
+  CACHE_PREFIX="$PROJECT_ROOT/_build/vibe_"
+  if [ -n "${VIBE_BUILD_CACHE_DIR:-}" ]; then
+    CACHE_PREFIX="${VIBE_BUILD_CACHE_DIR%/}/vibe_"
+  fi
+  echo "[fs-heap] cold: deleting ${CACHE_PREFIX}selfhost_type_env_v3_*.tsv + ${CACHE_PREFIX}selfhost_dep_list_*.tsv" >&2
+  rm -f "${CACHE_PREFIX}"selfhost_type_env_v3_*.tsv \
+    "${CACHE_PREFIX}"selfhost_dep_list_*.tsv
 fi
 
 ENTRY_REL="lib/@vibe/cli/main.vibex"
@@ -88,7 +99,10 @@ LOG="$OUT_DIR/run_${MODE}.log"
 echo "[fs-heap] mode=$MODE base=$BASE_COMPILER entry=$ENTRY_REL" >&2
 start_s=$(date +%s)
 set +e
-VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_PROFILE_MEMORY_MARKS=1 \
+# VIBE_RC=1 is forced: the heap-marked lane only exists on the RC path
+# (cli_adapter.vibe dispatch), so an ambient VIBE_RC=0/shadow would silently
+# measure the wrong pipeline while write_output still emits one mark.
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_RC=1 VIBE_PROFILE_MEMORY_MARKS=1 \
   bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" \
   --invoke cli_main \
   "$BASE_COMPILER" \
@@ -123,10 +137,20 @@ awk -v mode="$MODE" -v wall="$((end_s - start_s))" '
     prev = heap
     if (heap > peak) { peak = heap; peak_pages = pages }
     seen = 1
+    if (name == "codegen_rc") { seen_rc_lane = 1 }
   }
   END {
     if (!seen) {
       print "[fs-heap] ERROR: no named [profile-memory] marks in the log -- is the base compiler built from a tree that contains the #1553 marks?" > "/dev/stderr"
+      exit 1
+    }
+    # write_output is emitted unconditionally under the marks env, so a run
+    # that dodged the RC lane still produces one named mark; the per-phase
+    # marks live only in compile_file_fs_mode_rc_heap_marked. Require its
+    # codegen_rc mark so a wrong-lane run fails instead of reporting a
+    # plausible one-phase profile.
+    if (!seen_rc_lane) {
+      print "[fs-heap] ERROR: no codegen_rc mark -- the compile did not take the heap-marked RC lane (compile_file_fs_mode_rc_heap_marked)" > "/dev/stderr"
       exit 1
     }
     # wasm32 linear memory cap: 65536 pages = 4 GiB.

--- a/scripts/measure_fs_heap.sh
+++ b/scripts/measure_fs_heap.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# measure_fs_heap.sh — per-phase guest-heap measurement of the FS-mode
+# whole-CLI compile (#1553, first checkbox: continuous heap-peak measurement).
+#
+# WHAT IT MEASURES
+#   The stage1 step of scripts/build_cli_core.sh: an already-built base
+#   selfhost compiler wasm compiles lib/@vibe/cli/main.vibex under
+#   VIBE_FS_COMPILE=1. With VIBE_PROFILE_MEMORY_MARKS=1 the compiler takes the
+#   heap-marked RC lane (compile_file_fs_mode_rc_heap_marked,
+#   lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe) and the
+#   node runner prints one line per phase boundary:
+#     [profile-memory] mark=N pages=P bytes=B heap_ptr=H ... name=<phase>
+#   Phases: start / collect_sources / typecheck / parse_merge / codegen_rc.
+#   The guest bump allocator never frees, so heap_ptr is the cumulative
+#   allocation high-water mark: per-phase delta = that phase's allocation
+#   volume and the codegen_rc mark is the run's peak. `pages` is the actual
+#   linear-memory size (the wasm32 hard cap is 65536 pages = 4 GiB).
+#
+# WARM vs COLD
+#   warm (default): persistent caches under _build/vibe_* are left alone.
+#     After any prior compile of the same tree the type-env / dep-list TSVs
+#     hit, so the typecheck phase mostly deserializes cached envs
+#     (<2 GiB peak per #1553).
+#   --cold: first deletes _build/vibe_selfhost_type_env_v3_*.tsv and
+#     _build/vibe_selfhost_dep_list_*.tsv, so every module's type env is
+#     re-inferred AND re-serialized (the ~2.6 GiB peak of #1553). The cold
+#     run rebuilds those caches — expect it to take minutes and to leave the
+#     caches warm again afterwards.
+#
+# BASE COMPILER
+#   Must be built from the CURRENT tree (it has to contain the #1553 marks).
+#   Resolution order: --base <wasm> argument, else $VIBE_MEASURE_BASE_COMPILER,
+#   else a fresh scripts/build_cli_wasm.sh build into
+#   _build/measure_fs_heap/base_compiler.wasm (seed -> stage1 -> stage2,
+#   several minutes on a cold tree; cached by lib/ tree hash when clean).
+#
+# USAGE
+#   bash scripts/measure_fs_heap.sh                # warm run
+#   bash scripts/measure_fs_heap.sh --cold         # cold run (deletes TSVs)
+#   bash scripts/measure_fs_heap.sh --base X.wasm  # reuse a known-good base
+#
+# OUTPUT (stdout, grep-able; full runner stderr kept in
+# _build/measure_fs_heap/run_<mode>.log)
+#   [fs-heap] mode=<warm|cold> phase=<name> heap_mib=... delta_mib=... pages=... mem_mib=... rss_mib=...
+#   [fs-heap] mode=<warm|cold> peak heap_mib=... pages=... headroom_mib=... wall_s=...
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+MODE=warm
+BASE_COMPILER="${VIBE_MEASURE_BASE_COMPILER:-}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cold) MODE=cold; shift ;;
+    --base) BASE_COMPILER="$2"; shift 2 ;;
+    *) echo "measure_fs_heap: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+OUT_DIR="$PROJECT_ROOT/_build/measure_fs_heap"
+mkdir -p "$OUT_DIR"
+
+if [ -z "$BASE_COMPILER" ]; then
+  BASE_COMPILER="$OUT_DIR/base_compiler.wasm"
+  echo "[fs-heap] building base compiler from current tree -> $BASE_COMPILER" >&2
+  bash "$SCRIPT_DIR/build_cli_wasm.sh" "$BASE_COMPILER" >&2
+fi
+if [ ! -s "$BASE_COMPILER" ]; then
+  echo "measure_fs_heap: base compiler not found: $BASE_COMPILER" >&2
+  exit 1
+fi
+
+if [ "$MODE" = "cold" ]; then
+  # Cold = the type-env cache TSVs from #1553 are gone; everything else
+  # (artifact caches etc.) is left alone so the run still measures the
+  # compile itself, not unrelated cache rebuilds.
+  echo "[fs-heap] cold: deleting _build/vibe_selfhost_type_env_v3_*.tsv + _build/vibe_selfhost_dep_list_*.tsv" >&2
+  rm -f "$PROJECT_ROOT"/_build/vibe_selfhost_type_env_v3_*.tsv \
+    "$PROJECT_ROOT"/_build/vibe_selfhost_dep_list_*.tsv
+fi
+
+ENTRY_REL="lib/@vibe/cli/main.vibex"
+OUT_WASM="$OUT_DIR/cli_core_${MODE}.wasm"
+LOG="$OUT_DIR/run_${MODE}.log"
+
+echo "[fs-heap] mode=$MODE base=$BASE_COMPILER entry=$ENTRY_REL" >&2
+start_s=$(date +%s)
+set +e
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_PROFILE_MEMORY_MARKS=1 \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" \
+  --invoke cli_main \
+  "$BASE_COMPILER" \
+  "$ENTRY_REL" \
+  "_build/measure_fs_heap/cli_core_${MODE}.wasm" \
+  main 2>"$LOG" >/dev/null
+status=$?
+set -e
+end_s=$(date +%s)
+if [ "$status" -ne 0 ]; then
+  echo "measure_fs_heap: compile failed (exit $status); last stderr lines:" >&2
+  tail -20 "$LOG" >&2
+  exit "$status"
+fi
+if [ ! -s "$OUT_WASM" ]; then
+  echo "measure_fs_heap: no output wasm produced: $OUT_WASM" >&2
+  exit 1
+fi
+
+awk -v mode="$MODE" -v wall="$((end_s - start_s))" '
+  /^\[profile-memory\] / && / name=/ {
+    heap = 0; pages = 0; bytes = 0; rss = 0; name = ""
+    for (i = 1; i <= NF; i++) {
+      if ($i ~ /^heap_ptr=/) { heap = substr($i, 10) + 0 }
+      else if ($i ~ /^pages=/) { pages = substr($i, 7) + 0 }
+      else if ($i ~ /^bytes=/) { bytes = substr($i, 7) + 0 }
+      else if ($i ~ /^rss=/) { rss = substr($i, 5) + 0 }
+      else if ($i ~ /^name=/) { name = substr($i, 6) }
+    }
+    printf "[fs-heap] mode=%s phase=%s heap_mib=%.1f delta_mib=%.1f pages=%d mem_mib=%.1f rss_mib=%.1f\n",
+      mode, name, heap / 1048576, (heap - prev) / 1048576, pages, bytes / 1048576, rss / 1048576
+    prev = heap
+    if (heap > peak) { peak = heap; peak_pages = pages }
+    seen = 1
+  }
+  END {
+    if (!seen) {
+      print "[fs-heap] ERROR: no named [profile-memory] marks in the log -- is the base compiler built from a tree that contains the #1553 marks?" > "/dev/stderr"
+      exit 1
+    }
+    # wasm32 linear memory cap: 65536 pages = 4 GiB.
+    printf "[fs-heap] mode=%s peak heap_mib=%.1f pages=%d headroom_mib=%.1f wall_s=%d\n",
+      mode, peak / 1048576, peak_pages, (65536 - peak_pages) * 64 / 1024, wall
+  }
+' "$LOG"

--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -1620,7 +1620,11 @@ function writeTextFileEnsuringDir(filePath, content) {
 
 let profileMemoryMarkIndex = 0;
 
-function emitProfileMemoryMark() {
+// `label` (optional) is a phase name the guest attached to the mark (#1553);
+// when present the line ends with ` name=<label>` so per-phase heap numbers
+// can be grepped out of a compile's stderr. Unnamed marks (Profiler::now_us,
+// plain VIBE_PROFILE_MEMORY_MARK env reads) keep the exact pre-#1553 format.
+function emitProfileMemoryMark(label) {
   if (process.env.VIBE_PROFILE_MEMORY_MARKS !== "1" || !instanceRefGlobal) {
     return;
   }
@@ -1640,15 +1644,23 @@ function emitProfileMemoryMark() {
   const memoryPages = memoryBytes / 65536;
   const hostAllocPtr = hostAllocPtrGlobal === null ? 0 : hostAllocPtrGlobal;
   const rss = process.memoryUsage().rss;
+  const nameSuffix = label ? ` name=${label}` : "";
   console.error(
-    `[profile-memory] mark=${profileMemoryMarkIndex} pages=${memoryPages} bytes=${memoryBytes} heap_ptr=${heapPtr ?? "missing"} host_alloc_ptr=${hostAllocPtr} rss=${rss}`,
+    `[profile-memory] mark=${profileMemoryMarkIndex} pages=${memoryPages} bytes=${memoryBytes} heap_ptr=${heapPtr ?? "missing"} host_alloc_ptr=${hostAllocPtr} rss=${rss}${nameSuffix}`,
   );
   profileMemoryMarkIndex += 1;
 }
 
+const NAMED_MEMORY_MARK_ENV_PREFIX = "VIBE_PROFILE_MEMORY_MARK:";
+
 function maybeEmitEnvMemoryMark(name) {
   if (name === "VIBE_PROFILE_MEMORY_MARK") {
     emitProfileMemoryMark();
+  } else if (name.startsWith(NAMED_MEMORY_MARK_ENV_PREFIX)) {
+    // #1553: named mark. The guest spells a phase name into the env-get key
+    // (`Env::get("VIBE_PROFILE_MEMORY_MARK:<phase>")`); the env var itself is
+    // never set, so the guest observes "" and the read is a pure signal.
+    emitProfileMemoryMark(name.slice(NAMED_MEMORY_MARK_ENV_PREFIX.length));
   }
 }
 


### PR DESCRIPTION
Batch of P0/P1 fixes, continuing from #1599 (merged).

## #1595 (+#1591): calls to a self-discharging fn no longer sink effect migration

`edp_drop_self_discharging_needing` removed a self-discharging fn from `needing`, but that membership was also the only thing making calls **to** the fn safe in `edp_has_unsafe_construct` — so any row-carrying caller went ineligible and sank the whole effect's migration into the hard "cannot be compiled here" error.

Fix mirrors the perform-free class's dual treatment: `edp_append_self_discharging_row_fns` appends call-inert self-discharging fns into `pure_fns` at all four safety-scan construction sites. Call-inertness is deliberately narrower than the drop (P0 guard): handler arms must be perform-free for the effect — an arm that re-performs escapes the callee, and treating that call as inert would migrate an outer handle blind to the perform (silent-wrong). That shape stays a hard error, and per #1591 the diagnostic now names the callee and states that the arm re-perform breaks static visibility, instead of reciting an allowed-forms enumeration the program already satisfies.

#1571 payoff: `effect_effectset_expansion` / `effect_effectset_param_expansion` / `effect_row_operation_item` migrate from `__DATA__` tails to `inspect()` test blocks; gates 40m/40n/40p/40h4 compile them without the sed strip. New gate 40h4b locks the fix on both backends plus the dirty-arm rejection via two new fixtures.

## #1590: actionable diagnostics for desugar-emitted builtins in the seed lane

The core fix (f89b529, already on main) made `str_lex_diff` / `__generic_rel_diff` / `__generic_add` checker-visible in both lanes. But the pinned seed predates it, so compiler/cli sources still cannot spell String order comparisons or erased-generic `<`/`+` until the next bootstrap bump. `generate_bundle.sh` now detects the seed-lane `unknown name: <builtin>` failure and translates it back to the source-level construct the author actually wrote; `docs/bootstrap.md` records the constraint and its removal condition (fold `str_lt` back to `a < b` after the bump, then delete the section).

## #1553: FS-mode compile heap instrumentation

Named per-phase heap marks through the FS-mode compile pipeline plus a final `write_output` mark after strip+write, and `scripts/measure_fs_heap.sh` to run a compile and report per-phase heap deltas — the measurement baseline for the #1553 memory work.

## Verification

- `pkf run test` (operation gate, `scripts/compiler_gate.sh`) green on the integrated branch — includes self-compile fixpoint, unit_test_runner, doctests, and the new/extended gates 40h4b, 40m/40n/40p.

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_