### PR TITLE
fix(diag): suspend/CPS 適格性エラーにも犯人の名指しと line:col を付ける (#1536/#1514)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1049,7 +1049,10 @@ let/seq/tail/分岐 tail に直接現れる必要がある。**concrete な row 
 「concrete row が対象 effect を含まない関数」。row 変数 (`with e`)
 付き callee・loop 内の perform は compile error。同じ継続の 2 回目の
 呼び出しは stderr 診断つきで trap する。post-processing は値経由
-(`let k = resume  let r = k(v)  r + 7`) で書く。
+(`let k = resume  let r = k(v)  r + 7`) で書く。see-through できない
+呼び出しで reject されるときの診断は、handle 適格性の診断と同じ形式で
+**どの呼び出しが不適格かを名指しし、その `line:col` を指す**
+(`(here: the call to 'pred')`, #1536/#1514)。
 
 **closure 値経由の suspend も可** (closure-CPS ABI, ADR-0076 追記31):
 `fn run_with(f: () -> Int with E) -> Int { handle { f() } with E

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -8981,6 +8981,199 @@ fn scps_fields_calls_ok(fields: Array[(String, Expr)], sctx: (String, Array[Stri
   ok
 }
 
+/// --- #1536 / #1514 parity: name the call scps_calls_ok rejected.
+///
+/// scps_calls_ok answers only Bool, so the suspend-lowering ineligibility
+/// errors could say WHAT kind of callee is rejected but not WHERE. This trio
+/// mirrors its decision structure in lockstep and returns the FIRST rejected
+/// call as (found, callee name, source char offset) -- the edit point. Name
+/// is the bare identifier (or the field name of a method-style callee, whose
+/// fdoff points at the spelled field); "" when the callee has no stable
+/// spelling in source (a computed callee expression, a nested handle).
+/// Offset is -1 when the node carries none (synthesized AST). Keep the
+/// traversal identical to scps_calls_ok: the culprit reported here must be
+/// exactly a call that made it return false, never a call it accepted.
+fn scps_first_bad_call_info(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> (Bool, String, Int) {
+  let (eff, _, needing, _, cps_locals) = sctx
+  match e {
+    ECall(callee, args, off) => match callee {
+      EIdent(nm, ioff) => if nm == "perform" && Array::length(args) == 1 {
+        match Array::get(args, 0) {
+          EIdent(_, _) => (false, "", -1),
+          ECall(opc, op_args, _) => match opc {
+            EIdent(_, _) => scps_first_bad_call_info_exprs(op_args, sctx, ctx),
+            _ => (true, nm, scps_pick_off(ioff, off))
+          },
+          _ => (true, nm, scps_pick_off(ioff, off))
+        }
+      } else if idp_is_pure_builtin_call(nm) || scps_is_safe_mut_builtin(nm) || scps_is_ctor_name(ctx, nm) || edp_str_array_contains(needing, nm) {
+        scps_first_bad_call_info_exprs(args, sctx, ctx)
+      } else if edp_str_array_contains(cps_locals, nm) || String::starts_with(nm, "__scps_") || String::starts_with(nm, "__Scps") {
+        scps_first_bad_call_info_exprs(args, sctx, ctx)
+      } else {
+        let (is_fn, row) = scps_fn_row_of(ctx, nm)
+        if is_fn && !scps_row_contains(ctx, row, eff) && !scps_row_has_var(row) {
+          scps_first_bad_call_info_exprs(args, sctx, ctx)
+        } else {
+          (true, nm, scps_pick_off(ioff, off))
+        }
+      },
+      EDot(_, field, _, fdoff) => (true, field, fdoff),
+      _ => (true, "", off)
+    },
+    ELet(_, v, b, _) => scps_first_bad_call_info_pair(v, b, sctx, ctx),
+    ELetMut(_, v, b, _) => scps_first_bad_call_info_pair(v, b, sctx, ctx),
+    ELetRec(_, v, b) => scps_first_bad_call_info_pair(v, b, sctx, ctx),
+    ESeq(a, b) => scps_first_bad_call_info_pair(a, b, sctx, ctx),
+    EIf(c, t, el) => {
+      let (f, n, o) = scps_first_bad_call_info_pair(c, t, sctx, ctx)
+      if f {
+        (f, n, o)
+      } else {
+        scps_first_bad_call_info(el, sctx, ctx)
+      }
+    },
+    EMatch(s, arms) => {
+      let mut found = false
+      let mut nm = ""
+      let mut off = -1
+      let (sf, sn, so) = scps_first_bad_call_info(s, sctx, ctx)
+      found = sf
+      nm = sn
+      off = so
+      let mut i = 0
+      while i < Array::length(arms) && !found {
+        let (_, ex) = Array::get(arms, i)
+        let (f, n, o) = scps_first_bad_call_info(ex, sctx, ctx)
+        found = f
+        nm = n
+        off = o
+        i = i + 1
+      }
+      (found, nm, off)
+    },
+    EHandle(_, _) => (true, "", -1),
+    EFn(_, _, _, _, _, b) => scps_first_bad_call_info(b, sctx, ctx),
+    EWhile(c, b) => scps_first_bad_call_info_pair(c, b, sctx, ctx),
+    EForIn(_, _, it, b) => scps_first_bad_call_info_pair(it, b, sctx, ctx),
+    ELoop(pairs, b) => {
+      let mut found = false
+      let mut nm = ""
+      let mut off = -1
+      let mut i = 0
+      while i < Array::length(pairs) && !found {
+        let (_, v) = Array::get(pairs, i)
+        let (f, n, o) = scps_first_bad_call_info(v, sctx, ctx)
+        found = f
+        nm = n
+        off = o
+        i = i + 1
+      }
+      if found {
+        (found, nm, off)
+      } else {
+        scps_first_bad_call_info(b, sctx, ctx)
+      }
+    },
+    EBinOp(_, l, r) => scps_first_bad_call_info_pair(l, r, sctx, ctx),
+    EUnaryOp(_, e2) => scps_first_bad_call_info(e2, sctx, ctx),
+    EAssign(_, v, c) => scps_first_bad_call_info_pair(v, c, sctx, ctx),
+    EAssignOp(_, _, v, c) => scps_first_bad_call_info_pair(v, c, sctx, ctx),
+    EReturn(e2) => scps_first_bad_call_info(e2, sctx, ctx),
+    EDot(o, _, _, _) => scps_first_bad_call_info(o, sctx, ctx),
+    ELabeledArg(_, _, v) => scps_first_bad_call_info(v, sctx, ctx),
+    EBreak(opt) => match opt {
+      Some(e2) => scps_first_bad_call_info(e2, sctx, ctx),
+      None => (false, "", -1)
+    },
+    EContinue(args) => scps_first_bad_call_info_exprs(args, sctx, ctx),
+    ETuple(elems) => scps_first_bad_call_info_exprs(elems, sctx, ctx),
+    EArray(elems) => scps_first_bad_call_info_exprs(elems, sctx, ctx),
+    ERecord(_, fields, _) => scps_first_bad_call_info_fields(fields, sctx, ctx),
+    EMap(fields) => scps_first_bad_call_info_fields(fields, sctx, ctx),
+    ESpread(e2) => scps_first_bad_call_info(e2, sctx, ctx),
+    _ => (false, "", -1)
+  }
+}
+
+fn scps_pick_off(ident_off: Int, call_off: Int) -> Int {
+  if ident_off >= 0 {
+    ident_off
+  } else {
+    call_off
+  }
+}
+
+fn scps_first_bad_call_info_pair(a: Expr, b: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> (Bool, String, Int) {
+  let (f, n, o) = scps_first_bad_call_info(a, sctx, ctx)
+  if f {
+    (f, n, o)
+  } else {
+    scps_first_bad_call_info(b, sctx, ctx)
+  }
+}
+
+fn scps_first_bad_call_info_exprs(es: Array[Expr], sctx: (String, Array[String], Array[String], Int, Array[String]), ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> (Bool, String, Int) {
+  let mut i = 0
+  let mut found = false
+  let mut nm = ""
+  let mut off = -1
+  while i < Array::length(es) && !found {
+    let (f, n, o) = scps_first_bad_call_info(Array::get(es, i), sctx, ctx)
+    found = f
+    nm = n
+    off = o
+    i = i + 1
+  }
+  (found, nm, off)
+}
+
+fn scps_first_bad_call_info_fields(fields: Array[(String, Expr)], sctx: (String, Array[String], Array[String], Int, Array[String]), ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> (Bool, String, Int) {
+  let mut i = 0
+  let mut found = false
+  let mut nm = ""
+  let mut off = -1
+  while i < Array::length(fields) && !found {
+    let (_, v) = Array::get(fields, i)
+    let (f, n, o) = scps_first_bad_call_info(v, sctx, ctx)
+    found = f
+    nm = n
+    off = o
+    i = i + 1
+  }
+  (found, nm, off)
+}
+
+/// Render the two culprit fragments for a suspend-lowering ineligibility
+/// error: the human clause ` (here: the call to 'X')` and the ` [@off=N:M]`
+/// transport marker (resolved to `line:col` by the lanes that know the source
+/// basis, ALWAYS stripped before a user sees it -- same contract as the
+/// handle-side #1514 C marker). Either half degrades to "" independently: an
+/// unnamed culprit (computed callee, nested handle) gets no clause, an
+/// offset-less culprit (synthesized AST) gets no marker.
+fn scps_culprit_parts(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> (String, String) {
+  let (found, nm, off) = scps_first_bad_call_info(e, sctx, ctx)
+  if !found {
+    ("", "")
+  } else {
+    let clause = if String::length(nm) > 0 {
+      String::concat(" (here: the call to '", String::concat(nm, "')"))
+    } else {
+      ""
+    }
+    let marker = if off >= 0 {
+      if String::length(nm) > 0 {
+        String::concat(" [@off=", String::concat(__to_string(off), String::concat(":", String::concat(__to_string(off + String::length(nm)), "]"))))
+      } else {
+        String::concat(" [@off=", String::concat(__to_string(off), "]"))
+      }
+    } else {
+      ""
+    }
+    (clause, marker)
+  }
+}
+
 // --- step constructors.
 
 fn scps_mk_yield(eff: String, opname: String, args: Array[Expr], bind_name: String, cont_body: Expr) -> Expr {
@@ -9766,7 +9959,15 @@ fn scps_transform_handle(body: Expr, arms: Array[(Pat, Expr)], ctx: (Array[Stmt]
     }
     let sctx = (eff, ops_qnames, needing, site, cps_seed)
     if !scps_calls_ok(body, sctx, ctx) {
-      Array::push(errs, "a handler arm captures `resume` as a value (suspend class, ADR-0076 Phase 3a/3b), but the handle body calls something this suspend lowering cannot see through (a local closure, a method-style callee, a nested handle, or a function whose declared row has a row variable) -- only `perform`, pure builtins, constructors, provably effect-free functions, and functions whose concrete row carries the handled effect may be called in the handled body (#817)")
+      // #1536 / #1514 parity: name the offending call and carry its offset
+      // as the ` [@off=N:M]` marker the located lanes resolve (and every
+      // lane strips), same contract as the handle-side culprit marker.
+      let (culprit_clause, culprit_marker) = scps_culprit_parts(body, sctx, ctx)
+      let mut scps_msg = "a handler arm captures `resume` as a value (suspend class, ADR-0076 Phase 3a/3b), but the handle body calls something this suspend lowering cannot see through (a local closure, a method-style callee, a nested handle, or a function whose declared row has a row variable)"
+      scps_msg = String::concat(scps_msg, culprit_clause)
+      scps_msg = String::concat(scps_msg, " -- only `perform`, pure builtins, constructors, provably effect-free functions, and functions whose concrete row carries the handled effect may be called in the handled body (#817)")
+      scps_msg = String::concat(scps_msg, culprit_marker)
+      Array::push(errs, scps_msg)
       None
     } else {
       let (split_ok, split_body) = scps_split_tail(body, sctx, ctx, st)
@@ -9898,7 +10099,16 @@ fn scps_emit_clone(eff: String, fname: String, ctx: (Array[Stmt], Array[(String,
         }
         let sctx = (eff, ops_qnames, needing, site, cps_seed)
         if !scps_calls_ok(fbody, sctx, ctx) {
-          Array::push(errs, String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, but its own body calls something the suspend lowering cannot see through (a local closure, a method-style callee, a nested handle, or a row-variable callee) (#817, ADR-0076 Phase 3b)"))
+          // #1536 / #1514 parity: name the offending call inside `fname`'s
+          // body. The offset indexes the module that defines `fname`, which
+          // may not be the entry file -- verify_culprit_off_marker degrades
+          // a basis mismatch to the unlocated message.
+          let (culprit_clause, culprit_marker) = scps_culprit_parts(fbody, sctx, ctx)
+          let mut scps_msg = String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, but its own body calls something the suspend lowering cannot see through (a local closure, a method-style callee, a nested handle, or a row-variable callee)")
+          scps_msg = String::concat(scps_msg, culprit_clause)
+          scps_msg = String::concat(scps_msg, " (#817, ADR-0076 Phase 3b)")
+          scps_msg = String::concat(scps_msg, culprit_marker)
+          Array::push(errs, scps_msg)
         } else {
           let (split_ok, split_body) = scps_split_tail(fbody, sctx, ctx, st)
           if !split_ok {
@@ -10537,7 +10747,13 @@ fn scps_split_literal(tps: Array[String], tbs: Array[(String, Array[String])], p
   }
   let sctx = (eff, ops_qnames, needing, site, cps_seed)
   if !scps_calls_ok(b, sctx, ctx) {
-    Array::push(errs, String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class, ADR-0076 追記31 Vertical B) calls something the suspend lowering cannot see through (a local closure, a method-style callee, a nested handle, or a row-variable callee) (#817)"))
+    // #1536 / #1514 parity: name the offending call in the literal's body.
+    let (culprit_clause, culprit_marker) = scps_culprit_parts(b, sctx, ctx)
+    let mut scps_msg = String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class, ADR-0076 追記31 Vertical B) calls something the suspend lowering cannot see through (a local closure, a method-style callee, a nested handle, or a row-variable callee)")
+    scps_msg = String::concat(scps_msg, culprit_clause)
+    scps_msg = String::concat(scps_msg, " (#817)")
+    scps_msg = String::concat(scps_msg, culprit_marker)
+    Array::push(errs, scps_msg)
     EFn(tps, tbs, params, None, None, b)
   } else {
     let (split_ok, split_body) = scps_split_tail(b, sctx, ctx, st)

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -280,3 +280,42 @@ test "check_linked_file: eligible suspend-class handle still checks clean (#1536
   let rc = check_linked_file(path)
   assert(rc == 0)
 }
+
+/// #1536 / #1514 parity: the suspend-side ineligibility error must NAME the
+/// call scps_calls_ok rejected and carry its `line:col`, same as the
+/// handle-side culprit diagnostic (the culprit `bump` sits at line 7 col 5 of
+/// the source below). The raw ` [@off=` transport marker must never survive
+/// to the reader.
+test "check_linked_file: ineligible suspend handle names the culprit call, located (#1536)" {
+  let path = "/tmp/vibe_cli_support_check_scps_culprit.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Sus { Suspend(Int) -> Int }\nlet conts: Array[(Int) -> Int] = []\nexport fn main() -> Int {\n  let bump = (x: Int) -> Int { x + 1 }\n  handle {\n    let a = perform Sus::Suspend(1)\n    bump(a)\n  } with Sus {\n    Suspend(t) => {\n      Array::push(conts, resume)\n      0 - t\n    }\n  }\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "suspend class"))
+  assert(String::contains(msg, "here: the call to 'bump'"))
+  assert(String::contains(msg, "line 7:5"))
+  assert(!String::contains(msg, "[@off="))
+}
+
+/// The Phase 3b clone site (#1536's original victim shape, async_iter_*): a
+/// row-carrying fn called from a suspend body whose OWN body calls its
+/// closure parameter. The error names the fn AND the closure-param call
+/// (`f(a)` at line 5 col 3), located.
+test "check_linked_file: needing-fn closure-param callee names the culprit, located (#1536)" {
+  let path = "/tmp/vibe_cli_support_check_scps_needing_culprit.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Sus { Suspend(Int) -> Int }\nlet conts: Array[(Int) -> Int] = []\nfn helper(f: (x: Int) -> Int) -> Int with Sus {\n  let a = perform Sus::Suspend(1)\n  f(a)\n}\nexport fn main() -> Int {\n  handle {\n    helper((x: Int) -> Int { x + 1 })\n  } with Sus {\n    Suspend(t) => {\n      Array::push(conts, resume)\n      0 - t\n    }\n  }\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "function `helper`"))
+  assert(String::contains(msg, "here: the call to 'f'"))
+  assert(String::contains(msg, "line 5:3"))
+  assert(!String::contains(msg, "[@off="))
+}


### PR DESCRIPTION
## 概要

handle 側の適格性診断が #1514 C で得た「犯人の呼び出しの名指し + `line:col`」を、**suspend/CPS split 側 (#1536) の 3 エラーサイトにも**付ける。

#1574 で ADR-0076 の適格性判定が `vibe check` 段で走るようになった ((c) スライス着地) 一方、suspend 側のエラー文は「a local closure, a method-style callee, a nested handle, or a row-variable callee のどれか」と可能性を列挙するだけで、**どの呼び出しが問題かも位置も言わなかった** — 呼び出しが複数ある body では二分探索が要る状態 (#1511 コメントで指摘されたのと同じ穴)。

## 実測 (before → after)

```
before: error: a handler arm captures `resume` as a value (suspend class, ...),
        but the handle body calls something this suspend lowering cannot see
        through (a local closure, a method-style callee, ...) ... (#817)

after:  error: line 11:5-9: a handler arm captures `resume` as a value (...),
        but the handle body calls something this suspend lowering cannot see
        through (a local closure, ...) (here: the call to 'bump') -- only
        `perform`, ... (#817)
```

Phase 3b (needing-fn clone) 側 — #1536 の本来の被害形 (`async_iter_*` の `pred(v)`) も同様:

```
after:  error: line 9:3-4: function `helper` (whose row carries Sus) is called
        from a suspend-class handle body, but its own body calls something the
        suspend lowering cannot see through (...) (here: the call to 'f')
        (#817, ADR-0076 Phase 3b)
```

## 実装

- `scps_first_bad_call_info` (+`_exprs`/`_fields`/`_pair`): `scps_calls_ok` の判定構造を **lockstep で**なぞり、最初に拒否された呼び出しを `(callee 名, offset)` で返す walker。判定と報告が食い違わないよう、traversal は scps_calls_ok と同一形 (accepted な呼び出しを名指しすることがない)
- method-style callee (`EDot`) はフィールド名と `fdoff` (フィールド名の offset) で名指し。nested handle / computed callee は綴りが無いので名指しなしに降格
- 3 サイト配線: handle body (Phase 3a/3b) / needing-fn clone (Phase 3b) / closure literal (追記31 Vertical B)
- 位置輸送は handle 側 #1514 C の ` [@off=N:M]` marker をそのまま再利用 — `verify_culprit_off_marker` (whole-identifier 検証、依存モジュール由来 offset は位置なしに降格) / `emit_compile_diag_*` / `strip_off_marker` が全レーンで既に効いており、生 marker は読者に届かない。`suspend_cps_pass` は `evidence_dict_pass` の alpha-rename (`__edpsh_`) より**前**に走るため unmangle は不要

## テスト

- `cli_support_test.vibe` に located assertion 2 本追加 (handle-body culprit `line 7:5` / needing-fn closure-param culprit `line 5:3`、いずれも `[@off=` 非漏洩を assert)。suite green
- `scripts/compiler_gate.sh` 直接実行で **97/97 全ステップ green** (exit 0)
- `bash scripts/vibe_fmt.sh --check` 両編集ファイル通過
- cheatsheet の suspend 制約節に診断形式の注記を追加 (prose のみ、doctest 対象コードブロックなし)

## 補足

- ローカルの `pkf run test` はこのコンテナの nix/system glibc 混在で `sort` が起動できず環境起因で fail するため (`GLIBC_ABI_DT_X86_64_PLT not found`)、ゲート本体 `scripts/compiler_gate.sh` を直接実行して検証した (同一内容)
- #1536 の残り本命 (a) — closure が row-free param へエスケープする形を evidence 機構で静的に追う — は本 PR の範囲外

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_