### PR TITLE
feat(scps): row-free closure param の実引数フロー証明で see-through を広げる (#1536 (a) v1)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1046,7 +1046,12 @@ let/seq/tail/分岐 tail に直接現れる必要がある。**concrete な row 
 対象 effect を含む top-level 関数の呼び出しは可** (3b yield bubbling —
 再帰も可; callee には CPS clone が合成され、元の関数は他の呼び出し元
 向けに無変更)。それ以外に呼べるのは perform / pure builtin / ctor /
-「concrete row が対象 effect を含まない関数」。row 変数 (`with e`)
+「concrete row が対象 effect を含まない関数」、そして **row-free な
+closure param 経由の呼び出しのうち、その関数の全 by-name call site が
+perform を含まない closure literal (または委譲元の同様に証明済みの
+param) を渡すと静的に証明できるもの** (#1536 (a) — `async_iter_find`
+の `pred(v)` がこの形。1 site でも perform する literal を渡すと従来
+どおり reject)。row 変数 (`with e`)
 付き callee・loop 内の perform は compile error。同じ継続の 2 回目の
 呼び出しは stderr 診断つきで trap する。post-processing は値経由
 (`let k = resume  let r = k(v)  r + 7`) で書く。see-through できない

--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2694,6 +2694,45 @@ fixtures: `effect_iife_needing_call.vibe` (素の IIFE、want 142)、
 `effect_trivial_wrapper_needing_call.vibe` (#1070 経由で IIFE になる形、
 want 142)。どちらも修正前の compiler では上記 hard error になることを確認済み。
 
+### 追記40 (2026-08-08): row-free closure param の実引数フロー証明 (#1536 (a) v1)
+
+suspend CPS split が「closure パラメータの呼び出し」を無条件拒否していた件の
+第一スライス。`pred: (x: T) -> Bool` のような **row-free** な関数型 param は
+#761 の字句帰属ゆえに「row が空 ⇒ perform しない」を型からは保証できないが、
+**CPS clone `__scps_cps_E_f` に到達する呼び出しは `f` の by-name call site
+だけ** (値経由の呼び出しは untouched な original を走る) という事実が使える:
+全 by-name site が当該 slot に suspend-inert な値を渡すと証明できれば、clone
+内の `pred(v)` は plain call として健全に受理できる。
+
+- **suspend-inert の判定** (`scps_inert_taint`): perform を 1 つでも含む
+  literal は taint (alias 綴りがあるため effect 単位の照合はせず全 perform を
+  対象にする — 意図的な過剰拒否)。needing 名の参照 (call でも値でも)、
+  `__scps_`/`__Scps` 名前空間への参照 (phase 2 prepass が step 化した機械が
+  引数内にある = suspend する)、不透明 callee、nested handle も taint。
+- **委譲** (`async_iter_any` → `async_iter_find` 転送形): site の実引数が
+  囲む top-level fn 自身の row-free param なら、その slot を再帰的に証明する
+  (`scps_param_slot_inert`、循環は coinductive に inert 扱い)。fn 本体の
+  どこかで同名が再束縛されていたら保守的に降りる。
+- **phase 順序**: この証明は phase 4 (clone 排出) で走るが、phase 3 が
+  suspend 文脈の call site を clone 綴りに書き換え済みなので、site 走査は
+  `f` と `__scps_cps_E_f` の**両方の綴り**を対象にする (片方だけだと taint
+  した引数を見逃す)。
+- **機構**: `sctx` は広げない。証明済み param を clone 内だけ
+  `__scps_inert_<site>_<name>` へ shadow-aware に α-rename する
+  (`scps_rename_ident`) — 両 eligibility walker は `__scps_` prefix を既に
+  受理し、split は needing でも cps-local でもない呼び出しを bubble しない
+  ので、rename だけで plain call 意味論が得られる。未証明 param は従来の
+  `cannot see through` 拒否のまま。
+- **範囲外**: literal param (spawn_suspend closure 自身の param — call site を
+  名前で列挙できない)、row 変数 callee (追記34 の据え置きどおり)、builtin
+  `Stream::next` の retarget (#1536 残件)。
+
+fixtures: `effect_closure_param_inert.vibe` (want 5)、
+`effect_closure_param_inert_transitive.vibe` (委譲形、want 5)、
+`err_effect_closure_param_taint.vibe` (1 site が perform する literal を渡す
+→ 拒否維持)。これで `async_iter_find` / `_any` / `_all` が suspend body から
+呼べる。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -165,17 +165,28 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
 
 - **適格**: let / seq / tail / branch-tail の spine、`while` + `let mut`
   (#1230 で widening 済み。`let mut x = v` → 1 要素セル、`while` → `let rec`
-  ローカル closure への末尾再帰)
+  ローカル closure への末尾再帰)、**row-free closure パラメータの呼び出しの
+  うち、全 by-name call site の実引数が suspend-inert と証明できるもの**
+  (#1536 (a)。下記)
 - **不適格**: ループ内 `break`/`continue`/`return`、`for`/`loop` 形、
-  sequence の HEAD が perform を内側に抱えた複合式、**closure パラメータの
-  呼び出し** (`pred(v)` — `scps_calls_ok` が local closure callee を
-  see-through できない)
+  sequence の HEAD が perform を内側に抱えた複合式、実引数証明が成立しない
+  closure パラメータの呼び出し、row 変数 callee (`with e`)
 
-最後のものが `lib/@vibe/prelude/async_iter.vibe` の `async_iter_find` /
-`_all` が今も ineligible な理由で、`await(Stream::next(s))` が書けない直接の
-原因でもある。closure param を無条件に許すのは**不健全** — closure literal
-内の `perform` は「リテラルが置かれた関数の row」に字句的に計上されるので、
-「宣言 row が空 ⇒ perform しない」が成り立たない。
+closure param を**無条件に**許すのは不健全 — closure literal 内の `perform`
+は「リテラルが置かれた関数の row」に字句的に計上されるので (#761)、「宣言
+row が空 ⇒ perform しない」が成り立たない。#1536 (a) の受理はそのため
+**実引数フローの証明**に基づく: CPS clone `__scps_cps_E_f` に到達するのは
+`f` の by-name call site だけ (値経由の呼び出しは untouched な original を
+走る) なので、全 by-name site が当該 slot に suspend-inert な値 — perform を
+一切含まず・needing 名を参照せず・不透明 callee を呼ばない closure literal、
+または委譲元 fn 自身の同様に証明済みの row-free param (`async_iter_any` →
+`async_iter_find` の転送形) — を渡すと証明できた slot に限り、clone 内の
+`pred(v)` を plain call として受理する。1 site でも perform する literal を
+渡せば slot 全体が taint し、従来どおり `cannot see through` で拒否される
+(fixtures/err_effect_closure_param_taint.vibe)。これで `async_iter_find` /
+`_any` / `_all` は suspend body から呼べる。`await(Stream::next(s))` は
+別問題 (builtin `Stream::next` が top-level fn ではなく needing 集合に
+乗らない) で、まだ書けない。
 
 ### 2.3 同期 effect との関係
 

--- a/fixtures/effect_closure_param_inert.vibe
+++ b/fixtures/effect_closure_param_inert.vibe
@@ -1,0 +1,54 @@
+// #1536 (a): a suspend-class handle body may call a needing fn through a
+// ROW-FREE closure param -- when every by-name call site of that fn
+// provably passes a suspend-inert closure in the slot. #761 charges a
+// literal's performs to the ENCLOSING row, so "row-free param => cannot
+// perform" is not free; the proof is argument flow: the CPS clone is only
+// reachable from by-name sites, every site here passes a perform-free
+// literal, so `pred(bumped)` compiles as a plain call inside the clone
+// (no bubble). The pred literal is pure; the suspends all come from
+// `pick` itself, driven synchronously through the resume-value arm.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let pick = (xs: Array[Int], pred: (x: Int) -> Bool) -> Int with Ask {
+  let mut i = 0
+  let mut out = 0 - 1
+  let mut go = true
+  while go {
+    if i >= Array::length(xs) {
+      go = false
+    } else {
+      let v = Array::get(xs, i)
+      let bumped = perform Ask::Get(v)
+      if pred(bumped) {
+        out = bumped
+        go = false
+      } else {
+        i = i + 1
+      }
+    }
+  }
+  out
+}
+
+let _start = () -> Int {
+  handle {
+    pick([
+      1,
+      3,
+      4
+    ], (x: Int) -> Bool {
+      x % 5 == 0
+    })
+  } with Ask {
+    Get(t) => {
+      let k = resume
+      k(t + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{"last":"5"}

--- a/fixtures/effect_closure_param_inert_transitive.vibe
+++ b/fixtures/effect_closure_param_inert_transitive.vibe
@@ -1,0 +1,54 @@
+// #1536 (a), delegation: `pick_any` forwards its own row-free `pred`
+// param into `pick`'s slot (the `async_iter_any` -> `async_iter_find`
+// shape). The inert proof follows the forwarded param to pick_any's own
+// call sites -- which all pass a perform-free literal -- so both clones
+// treat the call through `pred` as a plain call.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let pick = (xs: Array[Int], pred: (x: Int) -> Bool) -> Int with Ask {
+  let mut i = 0
+  let mut out = 0 - 1
+  let mut go = true
+  while go {
+    if i >= Array::length(xs) {
+      go = false
+    } else {
+      let v = Array::get(xs, i)
+      let bumped = perform Ask::Get(v)
+      if pred(bumped) {
+        out = bumped
+        go = false
+      } else {
+        i = i + 1
+      }
+    }
+  }
+  out
+}
+
+let pick_any = (xs: Array[Int], pred: (x: Int) -> Bool) -> Int with Ask {
+  pick(xs, pred)
+}
+
+let _start = () -> Int {
+  handle {
+    pick_any([
+      1,
+      3,
+      4
+    ], (x: Int) -> Bool {
+      x % 5 == 0
+    })
+  } with Ask {
+    Get(t) => {
+      let k = resume
+      k(t + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{"last":"5"}

--- a/fixtures/err_effect_closure_param_capture_launder.vibe
+++ b/fixtures/err_effect_closure_param_capture_launder.vibe
@@ -1,0 +1,59 @@
+// #1536 (a) negative lock (Codex review on #1602): a candidate literal
+// that CAPTURES a performing closure and launders it into an accepted
+// eff-free helper (`apply1(g, x)` -- g performs, apply1's row is empty)
+// must taint the slot. A captured bare identifier has unknown provenance
+// (here it aliases a closure the prepass step-compiled), so treating the
+// call chain as plain calls would bypass suspension dispatch; only names
+// bound WITHIN the literal are trusted by the inert scan.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn apply1(f: (y: Int) -> Int, x: Int) -> Int {
+  f(x)
+}
+
+let pick = (xs: Array[Int], pred: (x: Int) -> Bool) -> Int with Ask {
+  let mut i = 0
+  let mut out = 0 - 1
+  let mut go = true
+  while go {
+    if i >= Array::length(xs) {
+      go = false
+    } else {
+      let v = Array::get(xs, i)
+      let bumped = perform Ask::Get(v)
+      if pred(bumped) {
+        out = bumped
+        go = false
+      } else {
+        i = i + 1
+      }
+    }
+  }
+  out
+}
+
+let _start = () -> Int {
+  handle {
+    let g = (y: Int) -> Int {
+      perform Ask::Get(y)
+    }
+    pick([
+      1,
+      3,
+      4
+    ], (x: Int) -> Bool {
+      apply1(g, x) > 0
+    })
+  } with Ask {
+    Get(t) => {
+      let k = resume
+      k(t + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{"error_contains": "cannot see through"}

--- a/fixtures/err_effect_closure_param_taint.vibe
+++ b/fixtures/err_effect_closure_param_taint.vibe
@@ -1,0 +1,52 @@
+// #1536 (a), negative lock: ONE call site passing a literal that
+// performs the split effect through the row-free slot taints the whole
+// slot (the argument-flow proof cannot hold), so the see-through
+// rejection stays -- never a silent plain-call miscompile of a closure
+// that actually suspends. The literal's perform typechecks because #761
+// charges it to the enclosing (handled) context, which is exactly why
+// the row-free param type proves nothing by itself.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let pick = (xs: Array[Int], pred: (x: Int) -> Bool) -> Int with Ask {
+  let mut i = 0
+  let mut out = 0 - 1
+  let mut go = true
+  while go {
+    if i >= Array::length(xs) {
+      go = false
+    } else {
+      let v = Array::get(xs, i)
+      let bumped = perform Ask::Get(v)
+      if pred(bumped) {
+        out = bumped
+        go = false
+      } else {
+        i = i + 1
+      }
+    }
+  }
+  out
+}
+
+let _start = () -> Int {
+  handle {
+    pick([
+      1,
+      3,
+      4
+    ], (x: Int) -> Bool {
+      perform Ask::Get(x) > 0
+    })
+  } with Ask {
+    Get(t) => {
+      let k = resume
+      k(t + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{"error_contains": "cannot see through"}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -10046,6 +10046,676 @@ fn scps_transform_handle(body: Expr, arms: Array[(Pat, Expr)], ctx: (Array[Stmt]
   }
 }
 
+// --- #1536 (a): inert closure-param see-through.
+//
+// A ROW-FREE function-typed parameter (`pred: (x: T) -> Bool`) is not
+// automatically safe to call from a CPS clone: #761 charges a closure
+// literal's performs to the ENCLOSING function's row, so "declared row is
+// empty => cannot perform" does not hold for values arriving through a
+// parameter (docs/spec/wasi-p3-async.md §2.2). What IS sound is an
+// argument-flow proof: the clone `__scps_cps_E_f` is only ever invoked
+// from BY-NAME call sites of `f` (a call through a binding that aliases
+// `f` runs the untouched original), so if every by-name site of `f`
+// passes a provably suspend-inert value in that slot -- a closure literal
+// whose body cannot reach a perform of E (no perform at all, no needing
+// name, no opaque callee), or the enclosing top-level fn's own row-free
+// param whose slot is proven the same way (delegation, e.g.
+// `async_iter_any` forwarding `pred` to `async_iter_find`) -- then a call
+// through that parameter inside the clone cannot suspend and compiles as
+// a plain call.
+//
+// Mechanically the proof does NOT widen `sctx`: a proven param is
+// alpha-renamed into the reserved `__scps_inert_<site>_<name>` namespace
+// inside the clone only (shadow-aware, scps_rename_ident), and both
+// scps_calls_ok and scps_first_bad_call_info already accept the
+// `__scps_` prefix, while scps_split_tail treats the call as an ordinary
+// spine element (it is neither a needing call nor a cps-local call), so
+// no bubble is emitted -- exactly the plain-call semantics the proof
+// grants. An unproven param is left alone and keeps today's rejection.
+//
+// Conservative by construction: ANY perform inside a candidate literal
+// taints it (even of an unrelated tail-resumptive effect -- alias
+// spellings make per-effect matching unreliable here), as does any
+// reference to a needing name (call or value), any opaque/method/row-var
+// callee, any nested handle, a labeled/spread argument at a site, a
+// value reference to `f` itself anywhere, or a rebind of the forwarded
+// param name anywhere in the delegating fn's body.
+
+/// Shadow-aware alpha-rename of local name `x` to `nx` in `e` -- reads,
+/// writes and compound-assign targets, stopping at any binder that
+/// shadows `x`. Traversal mirrors scps_cellify.
+fn scps_rename_ident(e: Expr, x: String, nx: String) -> Expr {
+  match e {
+    EIdent(nm, off) => if nm == x {
+      EIdent(nx, off)
+    } else {
+      e
+    },
+    EAssign(nm, v, b) => if nm == x {
+      EAssign(nx, scps_rename_ident(v, x, nx), scps_rename_ident(b, x, nx))
+    } else {
+      EAssign(nm, scps_rename_ident(v, x, nx), scps_rename_ident(b, x, nx))
+    },
+    EAssignOp(op, nm, v, b) => if nm == x {
+      EAssignOp(op, nx, scps_rename_ident(v, x, nx), scps_rename_ident(b, x, nx))
+    } else {
+      EAssignOp(op, nm, scps_rename_ident(v, x, nx), scps_rename_ident(b, x, nx))
+    },
+    ELet(nm, v, b, off) => ELet(nm, scps_rename_ident(v, x, nx), if nm == x {
+      b
+    } else {
+      scps_rename_ident(b, x, nx)
+    }, off),
+    ELetMut(nm, v, b, off) => ELetMut(nm, scps_rename_ident(v, x, nx), if nm == x {
+      b
+    } else {
+      scps_rename_ident(b, x, nx)
+    }, off),
+    ELetRec(nm, v, b) => if nm == x {
+      e
+    } else {
+      ELetRec(nm, scps_rename_ident(v, x, nx), scps_rename_ident(b, x, nx))
+    },
+    ESeq(a, b) => ESeq(scps_rename_ident(a, x, nx), scps_rename_ident(b, x, nx)),
+    EIf(c, t, el) => EIf(scps_rename_ident(c, x, nx), scps_rename_ident(t, x, nx), scps_rename_ident(el, x, nx)),
+    EMatch(s, arms) => EMatch(scps_rename_ident(s, x, nx), scps_rename_ident_arms(arms, x, nx)),
+    EHandle(b, arms) => EHandle(scps_rename_ident(b, x, nx), scps_rename_ident_arms(arms, x, nx)),
+    EFn(tps, tbs, params, rt, ef, b) => if scps_params_bind_name(params, x) {
+      e
+    } else {
+      EFn(tps, tbs, params, rt, ef, scps_rename_ident(b, x, nx))
+    },
+    EWhile(c, b) => EWhile(scps_rename_ident(c, x, nx), scps_rename_ident(b, x, nx)),
+    EForIn(nm, idx, it, b) => {
+      let shadowed = nm == x || match idx {
+        Some(inm) => inm == x,
+        None => false
+      }
+      EForIn(nm, idx, scps_rename_ident(it, x, nx), if shadowed {
+        b
+      } else {
+        scps_rename_ident(b, x, nx)
+      })
+    },
+    ELoop(pairs, b) => {
+      let mut shadowed = false
+      let out = scps_empty_pairs()
+      let mut i = 0
+      while i < Array::length(pairs) {
+        let (nm, v) = Array::get(pairs, i)
+        if nm == x {
+          shadowed = true
+        } else {
+          ()
+        }
+        Array::push(out, (nm, scps_rename_ident(v, x, nx)))
+        i = i + 1
+      }
+      ELoop(out, if shadowed {
+        b
+      } else {
+        scps_rename_ident(b, x, nx)
+      })
+    },
+    ECall(callee, args, off) => ECall(scps_rename_ident(callee, x, nx), scps_rename_ident_exprs(args, x, nx), off),
+    EBinOp(op, l, r) => EBinOp(op, scps_rename_ident(l, x, nx), scps_rename_ident(r, x, nx)),
+    EUnaryOp(op, a) => EUnaryOp(op, scps_rename_ident(a, x, nx)),
+    EReturn(a) => EReturn(scps_rename_ident(a, x, nx)),
+    EDot(o, f, off, foff) => EDot(scps_rename_ident(o, x, nx), f, off, foff),
+    ELabeledArg(l, m, v) => ELabeledArg(l, m, scps_rename_ident(v, x, nx)),
+    EBreak(opt) => match opt {
+      Some(a) => EBreak(Some(scps_rename_ident(a, x, nx))),
+      None => e
+    },
+    EContinue(args) => EContinue(scps_rename_ident_exprs(args, x, nx)),
+    ETuple(items) => ETuple(scps_rename_ident_exprs(items, x, nx)),
+    EArray(items) => EArray(scps_rename_ident_exprs(items, x, nx)),
+    ERecord(rn, fields, targs) => ERecord(rn, scps_rename_ident_pairs(fields, x, nx), targs),
+    EMap(fields) => EMap(scps_rename_ident_pairs(fields, x, nx)),
+    ESpread(a) => ESpread(scps_rename_ident(a, x, nx)),
+    _ => e
+  }
+}
+
+fn scps_rename_ident_exprs(es: Array[Expr], x: String, nx: String) -> Array[Expr] {
+  let out = array_empty_expr()
+  let mut i = 0
+  while i < Array::length(es) {
+    Array::push(out, scps_rename_ident(Array::get(es, i), x, nx))
+    i = i + 1
+  }
+  out
+}
+
+fn scps_rename_ident_pairs(pairs: Array[(String, Expr)], x: String, nx: String) -> Array[(String, Expr)] {
+  let out = scps_empty_pairs()
+  let mut i = 0
+  while i < Array::length(pairs) {
+    let (nm, v) = Array::get(pairs, i)
+    Array::push(out, (nm, scps_rename_ident(v, x, nx)))
+    i = i + 1
+  }
+  out
+}
+
+fn scps_rename_ident_arms(arms: Array[(Pat, Expr)], x: String, nx: String) -> Array[(Pat, Expr)] {
+  let out = scps_empty_arms()
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (p, ex) = Array::get(arms, i)
+    Array::push(out, (p, if scps_pat_binds_name(p, x) {
+      ex
+    } else {
+      scps_rename_ident(ex, x, nx)
+    }))
+    i = i + 1
+  }
+  out
+}
+
+/// True if ANY binder anywhere in `e` (let / let mut / let rec / closure
+/// param / for / loop / match / handle arm pattern) binds `x`. Used as the
+/// conservative shadow check before trusting a forwarded param name at a
+/// delegating call site.
+fn scps_binds_name(e: Expr, x: String) -> Bool {
+  match e {
+    ELet(nm, v, b, _) => nm == x || scps_binds_name(v, x) || scps_binds_name(b, x),
+    ELetMut(nm, v, b, _) => nm == x || scps_binds_name(v, x) || scps_binds_name(b, x),
+    ELetRec(nm, v, b) => nm == x || scps_binds_name(v, x) || scps_binds_name(b, x),
+    EFn(_, _, params, _, _, b) => scps_params_bind_name(params, x) || scps_binds_name(b, x),
+    EForIn(nm, idx, it, b) => nm == x || match idx {
+      Some(inm) => inm == x,
+      None => false
+    } || scps_binds_name(it, x) || scps_binds_name(b, x),
+    ELoop(pairs, b) => {
+      let mut hit = scps_binds_name(b, x)
+      let mut i = 0
+      while i < Array::length(pairs) {
+        let (nm, v) = Array::get(pairs, i)
+        if nm == x || scps_binds_name(v, x) {
+          hit = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      hit
+    },
+    EMatch(s, arms) => scps_binds_name(s, x) || scps_binds_name_arms(arms, x),
+    EHandle(b, arms) => scps_binds_name(b, x) || scps_binds_name_arms(arms, x),
+    ESeq(a, b) => scps_binds_name(a, x) || scps_binds_name(b, x),
+    EIf(c, t, el) => scps_binds_name(c, x) || scps_binds_name(t, x) || scps_binds_name(el, x),
+    ECall(callee, args, _) => scps_binds_name(callee, x) || scps_binds_name_exprs(args, x),
+    EBinOp(_, l, r) => scps_binds_name(l, x) || scps_binds_name(r, x),
+    EUnaryOp(_, a) => scps_binds_name(a, x),
+    EAssign(_, v, b) => scps_binds_name(v, x) || scps_binds_name(b, x),
+    EAssignOp(_, _, v, b) => scps_binds_name(v, x) || scps_binds_name(b, x),
+    EReturn(a) => scps_binds_name(a, x),
+    EDot(o, _, _, _) => scps_binds_name(o, x),
+    ELabeledArg(_, _, v) => scps_binds_name(v, x),
+    EBreak(opt) => match opt {
+      Some(a) => scps_binds_name(a, x),
+      None => false
+    },
+    EContinue(args) => scps_binds_name_exprs(args, x),
+    ETuple(items) => scps_binds_name_exprs(items, x),
+    EArray(items) => scps_binds_name_exprs(items, x),
+    ERecord(_, fields, _) => scps_binds_name_pairs(fields, x),
+    EMap(fields) => scps_binds_name_pairs(fields, x),
+    ESpread(a) => scps_binds_name(a, x),
+    _ => false
+  }
+}
+
+fn scps_binds_name_exprs(es: Array[Expr], x: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(es) {
+    if scps_binds_name(Array::get(es, i), x) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn scps_binds_name_pairs(pairs: Array[(String, Expr)], x: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(pairs) {
+    let (_, v) = Array::get(pairs, i)
+    if scps_binds_name(v, x) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn scps_binds_name_arms(arms: Array[(Pat, Expr)], x: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(arms) {
+    let (p, ex) = Array::get(arms, i)
+    if scps_pat_binds_name(p, x) || scps_binds_name(ex, x) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+/// True if `e` could reach a suspend of the effect under proof: ANY
+/// perform (per-effect matching is unreliable under alias spellings, so
+/// every perform taints), any reference to a needing name (call OR value
+/// -- a value escape could smuggle a performer), any callee that is not a
+/// pure/safe-mut builtin, a ctor, reserved `__scps_`/`__Scps` machinery,
+/// or a named top-level fn with a concrete eff-free row, or any nested
+/// handle. Nested closure literals are recursed (their row annotation
+/// carrying `eff` also taints -- convention mixing).
+fn scps_inert_taint(e: Expr, eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
+  match e {
+    // A needing name (call or value) can suspend; anything in the
+    // reserved __scps_/__Scps namespace means the phase-2 prepass already
+    // step-compiled machinery into this argument (a raw-performing
+    // literal is rewritten BEFORE this proof runs, so the step spelling
+    // is how its suspension is visible here) -- both taint.
+    EIdent(nm, _) => edp_str_array_contains(needing, nm) || String::starts_with(nm, "__scps_") || String::starts_with(nm, "__Scps"),
+    ECall(callee, args, _) => match callee {
+      EIdent(nm, _) => if nm == "perform" {
+        true
+      } else if edp_str_array_contains(needing, nm) || String::starts_with(nm, "__scps_") || String::starts_with(nm, "__Scps") {
+        true
+      } else if idp_is_pure_builtin_call(nm) || scps_is_safe_mut_builtin(nm) || scps_is_ctor_name(ctx, nm) {
+        scps_inert_taint_exprs(args, eff, needing, ctx)
+      } else {
+        let (is_fn, row) = scps_fn_row_of(ctx, nm)
+        if is_fn && !scps_row_contains(ctx, row, eff) && !scps_row_has_var(row) {
+          scps_inert_taint_exprs(args, eff, needing, ctx)
+        } else {
+          true
+        }
+      },
+      _ => true
+    },
+    EHandle(_, _) => true,
+    EFn(_, _, _, _, ef, b) => match ef {
+      Some(row) => scps_row_contains(ctx, row, eff) || scps_row_has_var(row) || scps_inert_taint(b, eff, needing, ctx),
+      None => scps_inert_taint(b, eff, needing, ctx)
+    },
+    ELet(_, v, b, _) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    ELetMut(_, v, b, _) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    ELetRec(_, v, b) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    ESeq(a, b) => scps_inert_taint(a, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    EIf(c, t, el) => scps_inert_taint(c, eff, needing, ctx) || scps_inert_taint(t, eff, needing, ctx) || scps_inert_taint(el, eff, needing, ctx),
+    EMatch(s, arms) => scps_inert_taint(s, eff, needing, ctx) || scps_inert_taint_arms(arms, eff, needing, ctx),
+    EWhile(c, b) => scps_inert_taint(c, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    EForIn(_, _, it, b) => scps_inert_taint(it, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    ELoop(pairs, b) => scps_inert_taint_pairs(pairs, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    EBinOp(_, l, r) => scps_inert_taint(l, eff, needing, ctx) || scps_inert_taint(r, eff, needing, ctx),
+    EUnaryOp(_, a) => scps_inert_taint(a, eff, needing, ctx),
+    EAssign(_, v, b) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    EAssignOp(_, _, v, b) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
+    EReturn(a) => scps_inert_taint(a, eff, needing, ctx),
+    EDot(o, _, _, _) => scps_inert_taint(o, eff, needing, ctx),
+    ELabeledArg(_, _, v) => scps_inert_taint(v, eff, needing, ctx),
+    EBreak(opt) => match opt {
+      Some(a) => scps_inert_taint(a, eff, needing, ctx),
+      None => false
+    },
+    EContinue(args) => scps_inert_taint_exprs(args, eff, needing, ctx),
+    ETuple(items) => scps_inert_taint_exprs(items, eff, needing, ctx),
+    EArray(items) => scps_inert_taint_exprs(items, eff, needing, ctx),
+    ERecord(_, fields, _) => scps_inert_taint_pairs(fields, eff, needing, ctx),
+    EMap(fields) => scps_inert_taint_pairs(fields, eff, needing, ctx),
+    ESpread(a) => scps_inert_taint(a, eff, needing, ctx),
+    _ => false
+  }
+}
+
+fn scps_inert_taint_exprs(es: Array[Expr], eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(es) {
+    if scps_inert_taint(Array::get(es, i), eff, needing, ctx) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn scps_inert_taint_pairs(pairs: Array[(String, Expr)], eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(pairs) {
+    let (_, v) = Array::get(pairs, i)
+    if scps_inert_taint(v, eff, needing, ctx) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn scps_inert_taint_arms(arms: Array[(Pat, Expr)], eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(arms) {
+    let (_, ex) = Array::get(arms, i)
+    if scps_inert_taint(ex, eff, needing, ctx) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+/// Is argument `a` (found in a proven-slot position at a by-name call
+/// site) suspend-inert? A closure literal must have a taint-free body and
+/// must not itself declare a row carrying `eff`; a bare identifier is
+/// accepted only as the enclosing top-level fn's own function-typed param
+/// whose slot is (recursively) proven and never rebound anywhere in that
+/// fn's body. Everything else is not provable.
+fn scps_arg_is_inert(a: Expr, has_encl: Bool, encl_params: Array[(String, Option[TypeExpr])], encl_body: Expr, eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), encl_name: String, visiting: Array[String]) -> Bool {
+  match a {
+    EFn(_, _, _, _, ef, b) => {
+      let row_ok = match ef {
+        Some(row) => !scps_row_contains(ctx, row, eff) && !scps_row_has_var(row),
+        None => true
+      }
+      row_ok && !scps_inert_taint(b, eff, needing, ctx)
+    },
+    EIdent(an, _) => if has_encl {
+      let mut slot = -1
+      let mut i = 0
+      while i < Array::length(encl_params) {
+        let (pnm, _) = Array::get(encl_params, i)
+        if pnm == an && slot < 0 {
+          slot = i
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      if slot < 0 {
+        false
+      } else if scps_binds_name(encl_body, an) {
+        false
+      } else {
+        scps_param_slot_inert(encl_name, slot, eff, needing, ctx, visiting)
+      }
+    } else {
+      false
+    },
+    _ => false
+  }
+}
+
+/// True when every occurrence of `fname` in `e` is a by-name call whose
+/// argument in `slot` is suspend-inert -- and `fname` never escapes as a
+/// bare value. Binders shadowing `fname` stop the scan (calls below them
+/// are not calls to the top-level fn).
+fn scps_slot_sites_ok(e: Expr, fname: String, slot: Int, has_encl: Bool, encl_params: Array[(String, Option[TypeExpr])], encl_body: Expr, eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), encl_name: String, visiting: Array[String]) -> Bool {
+  // Phase 3 has already rewritten suspend-context call sites of `fname`
+  // to its CPS-clone spelling (args preserved) by the time phase 4 runs
+  // this proof, so a site counts under EITHER name -- missing the
+  // rewritten spelling would let a tainted argument through unseen.
+  let cname = scps_clone_name(eff, fname)
+  match e {
+    EIdent(nm, _) => nm != fname && nm != cname,
+    ECall(callee, args, _) => {
+      let head_ok = match callee {
+        EIdent(nm, _) => if nm == fname || nm == cname {
+          let mut shape_ok = slot < Array::length(args)
+          let mut ai = 0
+          while ai < Array::length(args) {
+            match Array::get(args, ai) {
+              ELabeledArg(_, _, _) => {
+                shape_ok = false
+              },
+              ESpread(_) => {
+                shape_ok = false
+              },
+              _ => ()
+            }
+            ai = ai + 1
+          }
+          shape_ok && scps_arg_is_inert(Array::get(args, slot), has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting)
+        } else {
+          true
+        },
+        _ => scps_slot_sites_ok(callee, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting)
+      }
+      let mut ok = head_ok
+      let mut i = 0
+      while i < Array::length(args) {
+        // Bare-ident args recurse like everything else: EIdent(fname) in
+        // ANY argument position (including a self-call's own slot) is a
+        // value escape and must fail via the EIdent arm.
+        if !scps_slot_sites_ok(Array::get(args, i), fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) {
+          ok = false
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      ok
+    },
+    EFn(_, _, params, _, _, b) => if scps_params_bind_name(params, fname) {
+      true
+    } else {
+      scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting)
+    },
+    ELet(nm, v, b, _) => scps_slot_sites_ok(v, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && (nm == fname || scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting)),
+    ELetMut(nm, v, b, _) => scps_slot_sites_ok(v, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && (nm == fname || scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting)),
+    ELetRec(nm, v, b) => if nm == fname {
+      true
+    } else {
+      scps_slot_sites_ok(v, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting)
+    },
+    ESeq(a, b) => scps_slot_sites_ok(a, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EIf(c, t, el) => scps_slot_sites_ok(c, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && scps_slot_sites_ok(t, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && scps_slot_sites_ok(el, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EMatch(s, arms) => {
+      let mut ok = scps_slot_sites_ok(s, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting)
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (p, ex) = Array::get(arms, i)
+        if scps_pat_binds_name(p, fname) {
+          ()
+        } else if !scps_slot_sites_ok(ex, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) {
+          ok = false
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      ok
+    },
+    EHandle(b, arms) => {
+      let mut ok = scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting)
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (p, ex) = Array::get(arms, i)
+        if scps_pat_binds_name(p, fname) {
+          ()
+        } else if !scps_slot_sites_ok(ex, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) {
+          ok = false
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      ok
+    },
+    EWhile(c, b) => scps_slot_sites_ok(c, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EForIn(nm, idx, it, b) => {
+      let shadowed = nm == fname || match idx {
+        Some(inm) => inm == fname,
+        None => false
+      }
+      scps_slot_sites_ok(it, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && (shadowed || scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting))
+    },
+    ELoop(pairs, b) => {
+      let mut shadowed = false
+      let mut ok = true
+      let mut i = 0
+      while i < Array::length(pairs) {
+        let (nm, v) = Array::get(pairs, i)
+        if nm == fname {
+          shadowed = true
+        } else {
+          ()
+        }
+        if !scps_slot_sites_ok(v, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) {
+          ok = false
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      ok && (shadowed || scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting))
+    },
+    EBinOp(_, l, r) => scps_slot_sites_ok(l, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && scps_slot_sites_ok(r, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EUnaryOp(_, a) => scps_slot_sites_ok(a, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EAssign(_, v, b) => scps_slot_sites_ok(v, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EAssignOp(_, _, v, b) => scps_slot_sites_ok(v, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) && scps_slot_sites_ok(b, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EReturn(a) => scps_slot_sites_ok(a, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EDot(o, _, _, _) => scps_slot_sites_ok(o, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    ELabeledArg(_, _, v) => scps_slot_sites_ok(v, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EBreak(opt) => match opt {
+      Some(a) => scps_slot_sites_ok(a, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+      None => true
+    },
+    EContinue(args) => scps_slot_sites_ok_exprs(args, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    ETuple(items) => scps_slot_sites_ok_exprs(items, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EArray(items) => scps_slot_sites_ok_exprs(items, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    ERecord(_, fields, _) => scps_slot_sites_ok_pairs(fields, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    EMap(fields) => scps_slot_sites_ok_pairs(fields, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    ESpread(a) => scps_slot_sites_ok(a, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting),
+    _ => true
+  }
+}
+
+fn scps_slot_sites_ok_exprs(es: Array[Expr], fname: String, slot: Int, has_encl: Bool, encl_params: Array[(String, Option[TypeExpr])], encl_body: Expr, eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), encl_name: String, visiting: Array[String]) -> Bool {
+  let mut i = 0
+  let mut ok = true
+  while i < Array::length(es) {
+    if !scps_slot_sites_ok(Array::get(es, i), fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) {
+      ok = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  ok
+}
+
+fn scps_slot_sites_ok_pairs(pairs: Array[(String, Expr)], fname: String, slot: Int, has_encl: Bool, encl_params: Array[(String, Option[TypeExpr])], encl_body: Expr, eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), encl_name: String, visiting: Array[String]) -> Bool {
+  let mut i = 0
+  let mut ok = true
+  while i < Array::length(pairs) {
+    let (_, v) = Array::get(pairs, i)
+    if !scps_slot_sites_ok(v, fname, slot, has_encl, encl_params, encl_body, eff, needing, ctx, encl_name, visiting) {
+      ok = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  ok
+}
+
+/// Prove param slot `slot` of top-level fn `fname` suspend-inert for
+/// `eff`: the slot's declared type must be function-typed with a row that
+/// is absent, or concrete and eff-free; and every by-name occurrence of
+/// `fname` program-wide must be a call passing an inert value in that
+/// slot. Delegation cycles are handled coinductively: a slot already on
+/// the `visiting` stack contributes no new taint evidence and is treated
+/// as inert within its own proof.
+fn scps_param_slot_inert(fname: String, slot: Int, eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), visiting: Array[String]) -> Bool {
+  let key = String::concat(String::concat(fname, "||"), Int::to_string(slot))
+  if edp_str_array_contains(visiting, key) {
+    true
+  } else {
+    let (stmts, _, fn_defs, _, _, _) = ctx
+    let slot_ok = match edp_params_of_fn(stmts, fn_defs, fname) {
+      Some(params) => if slot < Array::length(params) {
+        let (_, pty) = Array::get(params, slot)
+        let prow = scps_ty_row(pty)
+        match pty {
+          Some(TyFn(_, _, _)) => !scps_row_contains(ctx, prow, eff) && !scps_row_has_var(prow),
+          _ => false
+        }
+      } else {
+        false
+      },
+      None => false
+    }
+    if !slot_ok {
+      false
+    } else {
+      let visiting2 = Array::slice(visiting, 0, Array::length(visiting))
+      Array::push(visiting2, key)
+      let mut ok = true
+      let mut i = 0
+      while i < Array::length(stmts) {
+        match Array::get(stmts, i) {
+          SLet(_, _, dnm, _, dexpr) => match dexpr {
+            EFn(_, _, dparams, _, _, dbody) => {
+              if !scps_slot_sites_ok(dbody, fname, slot, true, dparams, dbody, eff, needing, ctx, dnm, visiting2) {
+                ok = false
+              } else {
+                ()
+              }
+            },
+            _ => if !scps_slot_sites_ok(dexpr, fname, slot, false, scps_empty_params(), EUnit, eff, needing, ctx, "", visiting2) {
+              ok = false
+            } else {
+              ()
+            }
+          },
+          SLetMut(_, _, mexpr) => if !scps_slot_sites_ok(mexpr, fname, slot, false, scps_empty_params(), EUnit, eff, needing, ctx, "", visiting2) {
+            ok = false
+          } else {
+            ()
+          },
+          SExpr(sexpr) => if !scps_slot_sites_ok(sexpr, fname, slot, false, scps_empty_params(), EUnit, eff, needing, ctx, "", visiting2) {
+            ok = false
+          } else {
+            ()
+          },
+          STest(_, texpr) => if !scps_slot_sites_ok(texpr, fname, slot, false, scps_empty_params(), EUnit, eff, needing, ctx, "", visiting2) {
+            ok = false
+          } else {
+            ()
+          },
+          SBench(_, bexpr) => if !scps_slot_sites_ok(bexpr, fname, slot, false, scps_empty_params(), EUnit, eff, needing, ctx, "", visiting2) {
+            ok = false
+          } else {
+            ()
+          },
+          _ => ()
+        }
+        i = i + 1
+      }
+      ok
+    }
+  }
+}
+
 // --- CPS clone emission (3b). The clone's EFn deliberately carries
 // ret=None and eff=None: the return type is now __ScpsStep_E (an
 // annotation would lie, and codegen ignores it post-check), and the row
@@ -10097,24 +10767,51 @@ fn scps_emit_clone(eff: String, fname: String, ctx: (Array[Stmt], Array[(String,
           }
           cpi = cpi + 1
         }
+        // #1536 (a): a row-free (or concrete eff-free row) function-typed
+        // param whose every by-name call site provably receives a
+        // suspend-inert value is renamed into the reserved __scps_inert_
+        // namespace inside this clone, which both eligibility walkers
+        // already accept and the split leaves as a plain call (see the
+        // inert see-through block above). An unproven param stays as-is
+        // and keeps the existing rejection.
+        let cparams = scps_empty_params()
+        let mut fbody2 = fbody
+        let mut ipi = 0
+        while ipi < Array::length(params) {
+          let (pnm, pty) = Array::get(params, ipi)
+          let prow = scps_ty_row(pty)
+          let in_seed = edp_str_array_contains(cps_seed, pnm)
+          let candidate = match pty {
+            Some(TyFn(_, _, _)) => !in_seed && !scps_row_contains(ctx, prow, eff) && !scps_row_has_var(prow),
+            _ => false
+          }
+          if candidate && scps_param_slot_inert(fname, ipi, eff, needing, ctx, array_empty_str()) {
+            let inm = String::concat(String::concat(scps_local("__scps_inert_", site), "_"), pnm)
+            Array::push(cparams, (inm, pty))
+            fbody2 = scps_rename_ident(fbody2, pnm, inm)
+          } else {
+            Array::push(cparams, (pnm, pty))
+          }
+          ipi = ipi + 1
+        }
         let sctx = (eff, ops_qnames, needing, site, cps_seed)
-        if !scps_calls_ok(fbody, sctx, ctx) {
+        if !scps_calls_ok(fbody2, sctx, ctx) {
           // #1536 / #1514 parity: name the offending call inside `fname`'s
           // body. The offset indexes the module that defines `fname`, which
           // may not be the entry file -- verify_culprit_off_marker degrades
           // a basis mismatch to the unlocated message.
-          let (culprit_clause, culprit_marker) = scps_culprit_parts(fbody, sctx, ctx)
+          let (culprit_clause, culprit_marker) = scps_culprit_parts(fbody2, sctx, ctx)
           let mut scps_msg = String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, but its own body calls something the suspend lowering cannot see through (a local closure, a method-style callee, a nested handle, or a row-variable callee)")
           scps_msg = String::concat(scps_msg, culprit_clause)
           scps_msg = String::concat(scps_msg, " (#817, ADR-0076 Phase 3b)")
           scps_msg = String::concat(scps_msg, culprit_marker)
           Array::push(errs, scps_msg)
         } else {
-          let (split_ok, split_body) = scps_split_tail(fbody, sctx, ctx, st)
+          let (split_ok, split_body) = scps_split_tail(fbody2, sctx, ctx, st)
           if !split_ok {
             Array::push(errs, String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, but a perform of that effect (or a call to a function that performs it) is not directly on its body's let/seq/tail/branch-tail spine (a `while` loop carrying `break`/`continue`/`return`, a `for`/`loop` form, nested closures/handles, and nested expression positions are not eligible; a plain `while` + `let mut` spine is, #1230) (#817, ADR-0076 Phase 3b)"))
           } else {
-            Array::push(scps_st_inj(st), SLet(false, true, scps_clone_name(eff, fname), None, EFn(tps, tbs, params, None, None, split_body)))
+            Array::push(scps_st_inj(st), SLet(false, true, scps_clone_name(eff, fname), None, EFn(tps, tbs, cparams, None, None, split_body)))
           }
         }
       },

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -10315,29 +10315,34 @@ fn scps_binds_name_arms(arms: Array[(Pat, Expr)], x: String) -> Bool {
 /// perform (per-effect matching is unreliable under alias spellings, so
 /// every perform taints), any reference to a needing name (call OR value
 /// -- a value escape could smuggle a performer), any callee that is not a
-/// pure/safe-mut builtin, a ctor, reserved `__scps_`/`__Scps` machinery,
-/// or a named top-level fn with a concrete eff-free row, or any nested
-/// handle. Nested closure literals are recursed (their row annotation
-/// carrying `eff` also taints -- convention mixing).
-fn scps_inert_taint(e: Expr, eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
+/// pure/safe-mut builtin, a ctor, or a named top-level fn with a concrete
+/// eff-free row, any reference into the reserved `__scps_`/`__Scps`
+/// namespace, or any nested handle. Nested closure literals are recursed
+/// (their row annotation carrying `eff` also taints -- convention
+/// mixing).
+///
+/// `locals` carries the names BOUND WITHIN the candidate literal (its
+/// params plus let/letrec/for/loop/match binders on the path): a bare
+/// identifier outside that set is a CAPTURED value of unknown provenance
+/// -- it may alias a closure the phase-2 prepass step-compiled (a
+/// captured performing literal is spelled through its binding, not
+/// inline) -- so passing one into an accepted callee would launder a
+/// suspending closure through the plain-call convention. Everything not
+/// locally bound taints, except ctor references (Codex review on #1602).
+fn scps_inert_taint(e: Expr, eff: String, needing: Array[String], locals: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
   match e {
-    // A needing name (call or value) can suspend; anything in the
-    // reserved __scps_/__Scps namespace means the phase-2 prepass already
-    // step-compiled machinery into this argument (a raw-performing
-    // literal is rewritten BEFORE this proof runs, so the step spelling
-    // is how its suspension is visible here) -- both taint.
-    EIdent(nm, _) => edp_str_array_contains(needing, nm) || String::starts_with(nm, "__scps_") || String::starts_with(nm, "__Scps"),
+    EIdent(nm, _) => !edp_str_array_contains(locals, nm) && !scps_is_ctor_name(ctx, nm),
     ECall(callee, args, _) => match callee {
       EIdent(nm, _) => if nm == "perform" {
         true
       } else if edp_str_array_contains(needing, nm) || String::starts_with(nm, "__scps_") || String::starts_with(nm, "__Scps") {
         true
       } else if idp_is_pure_builtin_call(nm) || scps_is_safe_mut_builtin(nm) || scps_is_ctor_name(ctx, nm) {
-        scps_inert_taint_exprs(args, eff, needing, ctx)
+        scps_inert_taint_exprs(args, eff, needing, locals, ctx)
       } else {
         let (is_fn, row) = scps_fn_row_of(ctx, nm)
         if is_fn && !scps_row_contains(ctx, row, eff) && !scps_row_has_var(row) {
-          scps_inert_taint_exprs(args, eff, needing, ctx)
+          scps_inert_taint_exprs(args, eff, needing, locals, ctx)
         } else {
           true
         }
@@ -10345,45 +10350,116 @@ fn scps_inert_taint(e: Expr, eff: String, needing: Array[String], ctx: (Array[St
       _ => true
     },
     EHandle(_, _) => true,
-    EFn(_, _, _, _, ef, b) => match ef {
-      Some(row) => scps_row_contains(ctx, row, eff) || scps_row_has_var(row) || scps_inert_taint(b, eff, needing, ctx),
-      None => scps_inert_taint(b, eff, needing, ctx)
+    EFn(_, _, fparams, _, ef, b) => match ef {
+      Some(row) => scps_row_contains(ctx, row, eff) || scps_row_has_var(row) || scps_inert_taint(b, eff, needing, scps_locals_with_params(locals, fparams), ctx),
+      None => scps_inert_taint(b, eff, needing, scps_locals_with_params(locals, fparams), ctx)
     },
-    ELet(_, v, b, _) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    ELetMut(_, v, b, _) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    ELetRec(_, v, b) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    ESeq(a, b) => scps_inert_taint(a, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    EIf(c, t, el) => scps_inert_taint(c, eff, needing, ctx) || scps_inert_taint(t, eff, needing, ctx) || scps_inert_taint(el, eff, needing, ctx),
-    EMatch(s, arms) => scps_inert_taint(s, eff, needing, ctx) || scps_inert_taint_arms(arms, eff, needing, ctx),
-    EWhile(c, b) => scps_inert_taint(c, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    EForIn(_, _, it, b) => scps_inert_taint(it, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    ELoop(pairs, b) => scps_inert_taint_pairs(pairs, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    EBinOp(_, l, r) => scps_inert_taint(l, eff, needing, ctx) || scps_inert_taint(r, eff, needing, ctx),
-    EUnaryOp(_, a) => scps_inert_taint(a, eff, needing, ctx),
-    EAssign(_, v, b) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    EAssignOp(_, _, v, b) => scps_inert_taint(v, eff, needing, ctx) || scps_inert_taint(b, eff, needing, ctx),
-    EReturn(a) => scps_inert_taint(a, eff, needing, ctx),
-    EDot(o, _, _, _) => scps_inert_taint(o, eff, needing, ctx),
-    ELabeledArg(_, _, v) => scps_inert_taint(v, eff, needing, ctx),
+    ELet(nm, v, b, _) => scps_inert_taint(v, eff, needing, locals, ctx) || scps_inert_taint(b, eff, needing, scps_locals_with(locals, nm), ctx),
+    ELetMut(nm, v, b, _) => scps_inert_taint(v, eff, needing, locals, ctx) || scps_inert_taint(b, eff, needing, scps_locals_with(locals, nm), ctx),
+    ELetRec(nm, v, b) => {
+      let ext = scps_locals_with(locals, nm)
+      scps_inert_taint(v, eff, needing, ext, ctx) || scps_inert_taint(b, eff, needing, ext, ctx)
+    },
+    ESeq(a, b) => scps_inert_taint(a, eff, needing, locals, ctx) || scps_inert_taint(b, eff, needing, locals, ctx),
+    EIf(c, t, el) => scps_inert_taint(c, eff, needing, locals, ctx) || scps_inert_taint(t, eff, needing, locals, ctx) || scps_inert_taint(el, eff, needing, locals, ctx),
+    EMatch(s, arms) => scps_inert_taint(s, eff, needing, locals, ctx) || scps_inert_taint_arms(arms, eff, needing, locals, ctx),
+    EWhile(c, b) => scps_inert_taint(c, eff, needing, locals, ctx) || scps_inert_taint(b, eff, needing, locals, ctx),
+    EForIn(nm, idx, it, b) => {
+      let ext = scps_locals_with(locals, nm)
+      let ext2 = match idx {
+        Some(inm) => scps_locals_with(ext, inm),
+        None => ext
+      }
+      scps_inert_taint(it, eff, needing, locals, ctx) || scps_inert_taint(b, eff, needing, ext2, ctx)
+    },
+    ELoop(pairs, b) => {
+      let mut ext = locals
+      let mut hit = false
+      let mut i = 0
+      while i < Array::length(pairs) {
+        let (nm, v) = Array::get(pairs, i)
+        if scps_inert_taint(v, eff, needing, locals, ctx) {
+          hit = true
+        } else {
+          ()
+        }
+        ext = scps_locals_with(ext, nm)
+        i = i + 1
+      }
+      hit || scps_inert_taint(b, eff, needing, ext, ctx)
+    },
+    EBinOp(_, l, r) => scps_inert_taint(l, eff, needing, locals, ctx) || scps_inert_taint(r, eff, needing, locals, ctx),
+    EUnaryOp(_, a) => scps_inert_taint(a, eff, needing, locals, ctx),
+    EAssign(_, v, b) => scps_inert_taint(v, eff, needing, locals, ctx) || scps_inert_taint(b, eff, needing, locals, ctx),
+    EAssignOp(_, _, v, b) => scps_inert_taint(v, eff, needing, locals, ctx) || scps_inert_taint(b, eff, needing, locals, ctx),
+    EReturn(a) => scps_inert_taint(a, eff, needing, locals, ctx),
+    EDot(o, _, _, _) => scps_inert_taint(o, eff, needing, locals, ctx),
+    ELabeledArg(_, _, v) => scps_inert_taint(v, eff, needing, locals, ctx),
     EBreak(opt) => match opt {
-      Some(a) => scps_inert_taint(a, eff, needing, ctx),
+      Some(a) => scps_inert_taint(a, eff, needing, locals, ctx),
       None => false
     },
-    EContinue(args) => scps_inert_taint_exprs(args, eff, needing, ctx),
-    ETuple(items) => scps_inert_taint_exprs(items, eff, needing, ctx),
-    EArray(items) => scps_inert_taint_exprs(items, eff, needing, ctx),
-    ERecord(_, fields, _) => scps_inert_taint_pairs(fields, eff, needing, ctx),
-    EMap(fields) => scps_inert_taint_pairs(fields, eff, needing, ctx),
-    ESpread(a) => scps_inert_taint(a, eff, needing, ctx),
+    EContinue(args) => scps_inert_taint_exprs(args, eff, needing, locals, ctx),
+    ETuple(items) => scps_inert_taint_exprs(items, eff, needing, locals, ctx),
+    EArray(items) => scps_inert_taint_exprs(items, eff, needing, locals, ctx),
+    ERecord(_, fields, _) => scps_inert_taint_pairs(fields, eff, needing, locals, ctx),
+    EMap(fields) => scps_inert_taint_pairs(fields, eff, needing, locals, ctx),
+    ESpread(a) => scps_inert_taint(a, eff, needing, locals, ctx),
     _ => false
   }
 }
 
-fn scps_inert_taint_exprs(es: Array[Expr], eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
+fn scps_locals_with(locals: Array[String], nm: String) -> Array[String] {
+  let out = Array::slice(locals, 0, Array::length(locals))
+  Array::push(out, nm)
+  out
+}
+
+fn scps_locals_with_params(locals: Array[String], params: Array[(String, Option[TypeExpr])]) -> Array[String] {
+  let out = Array::slice(locals, 0, Array::length(locals))
+  let mut i = 0
+  while i < Array::length(params) {
+    let (pnm, _) = Array::get(params, i)
+    Array::push(out, pnm)
+    i = i + 1
+  }
+  out
+}
+
+fn scps_pat_collect_binds(p: Pat, acc: Array[String]) -> Unit {
+  match p {
+    PBind(n) => Array::push(acc, n),
+    PCtor(_, ps) => scps_pats_collect_binds(ps, acc),
+    PTuple(ps) => scps_pats_collect_binds(ps, acc),
+    POr(a, b) => {
+      scps_pat_collect_binds(a, acc)
+      scps_pat_collect_binds(b, acc)
+    },
+    PStruct(_, fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (_, fp) = Array::get(fields, i)
+        scps_pat_collect_binds(fp, acc)
+        i = i + 1
+      }
+    },
+    _ => ()
+  }
+}
+
+fn scps_pats_collect_binds(ps: Array[Pat], acc: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(ps) {
+    scps_pat_collect_binds(Array::get(ps, i), acc)
+    i = i + 1
+  }
+}
+
+fn scps_inert_taint_exprs(es: Array[Expr], eff: String, needing: Array[String], locals: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
   let mut i = 0
   let mut hit = false
   while i < Array::length(es) {
-    if scps_inert_taint(Array::get(es, i), eff, needing, ctx) {
+    if scps_inert_taint(Array::get(es, i), eff, needing, locals, ctx) {
       hit = true
     } else {
       ()
@@ -10393,12 +10469,12 @@ fn scps_inert_taint_exprs(es: Array[Expr], eff: String, needing: Array[String], 
   hit
 }
 
-fn scps_inert_taint_pairs(pairs: Array[(String, Expr)], eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
+fn scps_inert_taint_pairs(pairs: Array[(String, Expr)], eff: String, needing: Array[String], locals: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
   let mut i = 0
   let mut hit = false
   while i < Array::length(pairs) {
     let (_, v) = Array::get(pairs, i)
-    if scps_inert_taint(v, eff, needing, ctx) {
+    if scps_inert_taint(v, eff, needing, locals, ctx) {
       hit = true
     } else {
       ()
@@ -10408,12 +10484,14 @@ fn scps_inert_taint_pairs(pairs: Array[(String, Expr)], eff: String, needing: Ar
   hit
 }
 
-fn scps_inert_taint_arms(arms: Array[(Pat, Expr)], eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
+fn scps_inert_taint_arms(arms: Array[(Pat, Expr)], eff: String, needing: Array[String], locals: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Bool {
   let mut i = 0
   let mut hit = false
   while i < Array::length(arms) {
-    let (_, ex) = Array::get(arms, i)
-    if scps_inert_taint(ex, eff, needing, ctx) {
+    let (p, ex) = Array::get(arms, i)
+    let ext = Array::slice(locals, 0, Array::length(locals))
+    scps_pat_collect_binds(p, ext)
+    if scps_inert_taint(ex, eff, needing, ext, ctx) {
       hit = true
     } else {
       ()
@@ -10431,12 +10509,16 @@ fn scps_inert_taint_arms(arms: Array[(Pat, Expr)], eff: String, needing: Array[S
 /// fn's body. Everything else is not provable.
 fn scps_arg_is_inert(a: Expr, has_encl: Bool, encl_params: Array[(String, Option[TypeExpr])], encl_body: Expr, eff: String, needing: Array[String], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), encl_name: String, visiting: Array[String]) -> Bool {
   match a {
-    EFn(_, _, _, _, ef, b) => {
+    EFn(_, _, aparams, _, ef, b) => {
       let row_ok = match ef {
         Some(row) => !scps_row_contains(ctx, row, eff) && !scps_row_has_var(row),
         None => true
       }
-      row_ok && !scps_inert_taint(b, eff, needing, ctx)
+      // The taint scan starts with ONLY the literal's own params as
+      // locally-bound names: any other bare identifier in the body is a
+      // captured value of unknown provenance and taints (it may alias a
+      // step-compiled closure -- Codex review on #1602).
+      row_ok && !scps_inert_taint(b, eff, needing, scps_locals_with_params(array_empty_str(), aparams), ctx)
     },
     EIdent(an, _) => if has_encl {
       let mut slot = -1

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -305,9 +305,13 @@ test "check_linked_file: ineligible suspend handle names the culprit call, locat
 /// row-carrying fn called from a suspend body whose OWN body calls its
 /// closure parameter. The error names the fn AND the closure-param call
 /// (`f(a)` at line 5 col 3), located.
-test "check_linked_file: needing-fn closure-param callee names the culprit, located (#1536)" {
+test "check_linked_file: tainted closure-param callee names the culprit, located (#1536)" {
+  // #1536 (a): a PURE literal in the slot is now accepted (argument-flow
+  // proof), so the rejection coverage needs a tainted site -- the literal
+  // here performs the split effect, which taints the slot and keeps the
+  // see-through error with the same culprit naming and location.
   let path = "/tmp/vibe_cli_support_check_scps_needing_culprit.vibe"
-  Fs::write_bytes(path, string_to_bytes("effect Sus { Suspend(Int) -> Int }\nlet conts: Array[(Int) -> Int] = []\nfn helper(f: (x: Int) -> Int) -> Int with Sus {\n  let a = perform Sus::Suspend(1)\n  f(a)\n}\nexport fn main() -> Int {\n  handle {\n    helper((x: Int) -> Int { x + 1 })\n  } with Sus {\n    Suspend(t) => {\n      Array::push(conts, resume)\n      0 - t\n    }\n  }\n}\n"))
+  Fs::write_bytes(path, string_to_bytes("effect Sus { Suspend(Int) -> Int }\nlet conts: Array[(Int) -> Int] = []\nfn helper(f: (x: Int) -> Int) -> Int with Sus {\n  let a = perform Sus::Suspend(1)\n  f(a)\n}\nexport fn main() -> Int {\n  handle {\n    helper((x: Int) -> Int { perform Sus::Suspend(x) })\n  } with Sus {\n    Suspend(t) => {\n      Array::push(conts, resume)\n      0 - t\n    }\n  }\n}\n"))
   let msg = handle {
     let _ = check_linked_file(path)
     ""
@@ -319,3 +323,11 @@ test "check_linked_file: needing-fn closure-param callee names the culprit, loca
   assert(String::contains(msg, "line 5:3"))
   assert(!String::contains(msg, "[@off="))
 }
+
+// The ACCEPT side of #1536 (a) (perform-free literal at every site =>
+// clean compile) is deliberately NOT pinned here: the accept path runs
+// the full suspend split + codegen inside the in-harness compiler, which
+// exceeds the unit-test wasm's heap (the reject path above stops at
+// eligibility). Coverage lives in the gate instead --
+// fixtures/effect_closure_param_inert.vibe (+ _transitive) compile AND
+// execute through stage2 in compiler_gate lane 50.

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6680,8 +6680,16 @@ scps_check_reject() {
     exit 1
   fi
 }
+# #1536 (a): a row-free closure param whose every by-name call site
+# passes a provably suspend-inert literal is see-through (plain call in
+# the clone; want 5), including the delegation shape (pick_any forwards
+# its own param into pick's slot; want 5). One site passing a PERFORMING
+# literal taints the slot and the rejection stays.
+scps_run_expect "effect_closure_param_inert.vibe" "5" "inertparam"
+scps_run_expect "effect_closure_param_inert_transitive.vibe" "5" "inertdeleg"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"
 scps_check_reject "err_effect_resume_store_ineligible.vibe" "cannot see through" "inelig"
+scps_check_reject "err_effect_closure_param_taint.vibe" "cannot see through" "inerttaint"
 scps_check_reject "err_effect_resume_store_loop.vibe" "let/seq/tail/branch-tail spine" "loopbreak"
 # #1261: an unannotated performing closure is row-backfilled by
 # dlh_hoist_expr and so gets the evidence dict prepended; handing that value

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6690,6 +6690,10 @@ scps_run_expect "effect_closure_param_inert_transitive.vibe" "5" "inertdeleg"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"
 scps_check_reject "err_effect_resume_store_ineligible.vibe" "cannot see through" "inelig"
 scps_check_reject "err_effect_closure_param_taint.vibe" "cannot see through" "inerttaint"
+# Codex review on #1602: a candidate literal that CAPTURES a performing
+# closure and launders it into an eff-free helper must stay rejected --
+# only names bound within the literal are trusted by the inert scan.
+scps_check_reject "err_effect_closure_param_capture_launder.vibe" "cannot see through" "inertlaunder"
 scps_check_reject "err_effect_resume_store_loop.vibe" "let/seq/tail/branch-tail spine" "loopbreak"
 # #1261: an unannotated performing closure is row-backfilled by
 # dlh_hoist_expr and so gets the evidence dict prepended; handing that value


### PR DESCRIPTION
## 概要

#1536 (a) の第一スライス。suspend CPS split が「closure パラメータの呼び出し」(`pred(v)`) を無条件拒否していたのを、**実引数フローの静的証明**に基づいて受理できるようにする。これで `async_iter_find` / `_any` / `_all` が suspend body から呼べる (#1536 が名指しした直接被害)。

## 健全性の根拠

`pred: (x: T) -> Bool` のような row-free param は #761 の字句帰属ゆえに「row が空 ⇒ perform しない」を型からは保証できない (docs/spec/wasi-p3-async.md §2.2)。使えるのは: **CPS clone `__scps_cps_E_f` に到達する呼び出しは `f` の by-name call site だけ** (値経由の呼び出しは untouched な original を走る)。よって全 by-name site が当該 slot に suspend-inert な値を渡すと証明できれば、clone 内の `pred(v)` は plain call として健全。

- **suspend-inert 判定** (`scps_inert_taint`): perform を 1 つでも含む literal は taint (alias 綴りがあるため effect 単位照合はしない — 意図的過剰拒否)。needing 名参照 (call/値とも)、`__scps_`/`__Scps` 参照 (prepass が step 化した機械 = suspend する)、不透明 callee、nested handle も taint
- **委譲** (`async_iter_any` → `find` の param 転送): slot 単位の再帰証明 (`scps_param_slot_inert`)、循環は coinductive、fn 本体での同名再束縛は保守的に降りる
- **phase 順序**: phase 3 が suspend 文脈の site を clone 綴りに書き換えた後に証明が走るため、site 走査は元名と clone 名の**両綴り**を対象 (片方だけだと taint した引数を見逃す)

## 機構

`sctx` は広げない。証明済み param を clone 内だけ `__scps_inert_<site>_<名>` へ shadow-aware に α-rename (`scps_rename_ident`) — 両 eligibility walker (`scps_calls_ok` / `scps_first_bad_call_info`) の `__scps_` prefix 受理に乗り、split は needing でも cps-local でもない呼び出しを bubble しないので、rename だけで plain call 意味論が得られる。未証明 param は従来の `cannot see through` 拒否のまま (位置 + 名指し付き)。

## 範囲外 (次スライス)

- literal param (spawn_suspend closure 自身の param — call site を名前で列挙できない)
- row 変数 callee (`Sender::send` の `with e` — 追記34 の据え置きどおり)
- builtin `Stream::next` の retarget (`await(Stream::next(s))` の残件)

## 検証

- `scripts/compiler_gate.sh` 直接実行 **97/97 green**。新 fixture 3 本を lane 50 に配線: `effect_closure_param_inert.vibe` (want 5) / `_transitive.vibe` (委譲形、want 5) / `err_effect_closure_param_taint.vibe` (1 site が perform する literal → 拒否維持)
- unit suite: 変更込みで 541/542 → 唯一の regress は #1601 の「closure-param 拒否」テストが**受理側に反転したため** (この変更の目的どおり)。perform する literal を渡す taint 形に書き換えて診断カバレッジを維持し、単体 green。accept 側の in-harness pin は unit harness の heap を超えるため gate fixture に委ねる (コメントで明記)
- **実物 end-to-end**: `async_iter_find` を `TaskGroup::spawn_suspend` body から呼ぶ .vibex が `vibe run` で正しく `4` を返す (旧: `cannot see through` 拒否)
- seed 互換: `ensure_generated.sh` ok。途中で seed パーサの罠を実測 — **match arm 本体の裸の代入 (`X => flag = false`) は現行 parser は通すが seed が parse できない** — brace で回避 (bisect で特定)
- fmt: 全編集ファイル `--check` 通過。cheatsheet doctest はベースライン同値 (prose のみ)

## docs

spec §2.2 適格性表 / ADR-0076 **追記40** / cheatsheet の suspend 制約節を更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_