### PR TITLE
chore(bootstrap): adopt seed with desugar-visible builtins

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "console-exception-rowvar-2026-08-06",
-    "tag": "seed/console-exception-rowvar-2026-08-06",
-    "source_commit": "88e26da3",
+    "name": "desugar-builtins-2026-08-09",
+    "tag": "seed/desugar-builtins-2026-08-09",
+    "source_commit": "236695d972e972de18105edda819ac4801904a3b",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "17c22701d35083cfea0763a3c123c66d60dc7ac068175155e2a2bd09a734683b"
+      "sha256": "24d68cf67a689a67ac567601c83cdeb322efe0496b8af6daed4dd6b7e92d8557"
     },
     "runtime": {
       "runner": "moonrun",


### PR DESCRIPTION
## Summary
- adopt deterministic stage2 built from `236695d97` (contains `f89b529`)
- pin `seed/desugar-builtins-2026-08-09`
- seed-only manifest change for #1590 phase 1

## Attestation
- old seed built stage1/stage2/stage3
- stage2 == stage3 (`24d68cf67a689a67ac567601c83cdeb322efe0496b8af6daed4dd6b7e92d8557`)
- adopted seed stage0 == stage1 == stage2 == stage3
- release workflow run: https://github.com/mizchi/vibe-lang/actions/runs/31303501638
- published prerelease contains immutable assets

## Known baseline
Unit battery is 541/542; the only failure is the pre-existing `lazy_iter_combinators_test.vibe` trap also present on the parent. Formatter and generated freshness pass.

After this merges, a separate cleanup PR will replace the seven temporary String comparison loops and remove the #1590 seed-lane diagnostic/docs.
