### PR TITLE
refactor(string): remove pre-seed lexical comparison workarounds

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -286,31 +286,6 @@ parse できることを確認した上で、bump なしで通している。**�
 > tree を直接解決させ (`VIBE_EMIT_MERGED_SOURCE`)、成果物の tracking もやめた
 > ので、この世代遅れも `drift detected` ゲートも今は存在しない。
 
-### seed lane と desugar-emitted builtins (#1590)
-
-seed が flat module source をコンパイルする lane (`generate_bundle.sh` の
-flatten-tool pass 3 / `validate_module_source_compiles`、`generations.sh` の
-stage1 hop — どれも `VIBE_FS_COMPILE=1` を付けない) では **checker が desugar
-の後に走る**。desugar はソースに存在しない builtin 呼び出しを合成する —
-String の `a < b` は `str_lex_diff(a, b) < 0` に、erased type parameter 上の
-`<`/`>`/`<=`/`>=` と `+` は `__generic_rel_diff` / `__generic_add` になる。
-この3つは builtin_registry で checker_visible=false だったため、この lane
-だけで `unknown name: <builtin>` で死んでいた (通常の `vibe` 呼び出しは
-`VIBE_FS_COMPILE=1` の checker-before-desugar lane なので無事)。
-
-live tree では f89b529 が3行とも checker_visible=true にして修正済み
-(`scripts/compiler_gate.sh` の section 97 が non-FS lane で3形をロックして
-いる)。ただし **pinned seed がこの fix より古い間は、compiler/cli source
-(cli_adapter.vibe から到達する全ファイル) は String `<`/`>`/`<=`/`>=` と
-erased-generic `<`/`+` を書けない** — bundle ビルド時に seed が上記の
-`unknown name` で拒否する。`generate_bundle.sh` はこの失敗を検出すると
-「どの演算子が原因か」を示す actionable な説明を付けて落ちる。
-
-この制約は **f89b529 以降の commit を seed にした次の bootstrap bump で消える**。
-bump したら: `lib/@vibe/compiler/core/sorted_index.vibe` の `str_lt` の
-char-by-char loop を `a < b` に戻し (doc comment がそう指示している)、lib/
-内の同型の手書き比較 loop も同様に畳んでよい。その後この節も削除する。
-
 ### bootstrap bump の手順 (更新版)
 
 `seed-release.yml` は **tag push ではなく `workflow_dispatch`** で手動起動する

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1183,39 +1183,11 @@ fn labels_union(a: Array[String], b: Array[String]) -> Array[String] {
   out
 }
 
-/// #639: deterministic label ordering for effect-row diagnostics. Char-by-char
-/// lexicographic compare, shorter-prefix-first on a tie — written out by hand
-/// (see CLAUDE.md's length-first `String <` gotcha) so `{ Env, Fs }` always
-/// renders in the same order.
+/// #639: deterministic lexical label ordering for effect-row diagnostics.
+/// The typed helper keeps Array-sourced labels on String relational lowering
+/// (#1184).
 fn label_lt(a: String, b: String) -> Bool {
-  let la = String::length(a)
-  let lb = String::length(b)
-  let n = if la < lb {
-    la
-  } else {
-    lb
-  }
-  let mut i = 0
-  let mut decided = 0
-  while i < n && decided == 0 {
-    let ca = String::char_code_at(a, i)
-    let cb = String::char_code_at(b, i)
-    if ca < cb {
-      decided = 1
-    } else if ca > cb {
-      decided = 2
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  if decided == 1 {
-    true
-  } else if decided == 2 {
-    false
-  } else {
-    la < lb
-  }
+  a < b
 }
 
 /// Copying insertion sort (rows are tiny — a handful of labels at most).

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -971,6 +971,18 @@ export fn contract_facade_source(decls: Array[(String, String)], opaque_names: A
 // Format: `ct:sha1:<40hex>` / `pkg:sha1:<40hex>` (SHA1 per ADR-0004; the
 // scheme prefix leaves room for a stronger digest without ambiguity).
 
+/// Normalized lexical comparison behind typed String parameters. The helper
+/// boundary is required for Array::get-sourced operands (#1184).
+fn contract_str_compare(a: String, b: String) -> Int {
+  if a < b {
+    -1
+  } else if a > b {
+    1
+  } else {
+    0
+  }
+}
+
 fn sorted_strings(items: Array[String]) -> Array[String] {
   let out = array_empty()
   let mut i = 0
@@ -984,31 +996,9 @@ fn sorted_strings(items: Array[String]) -> Array[String] {
     let mut b = a + 1
     let mut min_i = a
     while b < n {
-      // char-by-char lexicographic compare (String < is length-first)
       let x = Array::get(out, b)
       let y = Array::get(out, min_i)
-      let xl = String::length(x)
-      let yl = String::length(y)
-      let mut ci = 0
-      let mut cmp = 0
-      while cmp == 0 && ci < xl && ci < yl {
-        let cx = String::char_code_at(x, ci)
-        let cy = String::char_code_at(y, ci)
-        if cx < cy {
-          cmp = 0 - 1
-        } else if cx > cy {
-          cmp = 1
-        } else ()
-        ci = ci + 1
-      }
-      if cmp == 0 {
-        if xl < yl {
-          cmp = 0 - 1
-        } else if xl > yl {
-          cmp = 1
-        } else ()
-      } else ()
-      if cmp < 0 {
+      if contract_str_compare(x, y) < 0 {
         min_i = b
       } else ()
       b = b + 1

--- a/lib/@vibe/compiler/core/sorted_index.vibe
+++ b/lib/@vibe/compiler/core/sorted_index.vibe
@@ -17,66 +17,12 @@ import @vibe/core {
 // duplicate keys (results are byte-identical to the linear scan they
 // replace).
 
-/// Lexicographic (char-code) string less-than. Written char-by-char instead of
-/// `a < b`, which costs one out-of-line `__rt_str_char_code_at` call PER BYTE
-/// on one of the compiler's hottest comparisons.
-///
-/// The reason is NOT the one this comment used to give ("the String `<`
-/// desugar, str_lex_diff #746, is newer than the pinned seed"). That is stale:
-/// the seed bump to console-exception-rowvar-2026-08-06 moved the seed past
-/// #746, and the committed seed compiles and correctly runs `a < b` on String
-/// today. Replacing this body with `a < b` was measured to be CORRECT --
-/// 81 pairs in the doubly-indirected call shape sort_perm_by_names actually
-/// uses, 0 disagreements with this loop, on both the seed and stage2.
-///
-/// What blocks it is #1590, and only until the next bootstrap bump. `a < b` on
-/// String desugars to `str_lex_diff(a, b) < 0`, and that builtin was
-/// checker_visible=false in builtin_registry.vibe -- correct only while the
-/// checker runs BEFORE desugar, which it does not in the lane that omits
-/// VIBE_FS_COMPILE=1. bootstrap_merge_flatten_tool pass 3 is exactly that
-/// lane, so the bundle build died with `unknown name: str_lex_diff`. The
-/// registry row is now checker_visible=true and a stage2 built from this tree
-/// compiles the merged module source fine -- but pass 3 runs the PINNED SEED,
-/// which predates the fix and still fails.
-///
-/// (An earlier revision of this comment blamed the merged-source emitter for
-/// printing post-desugar text it could not read back. That was wrong: the
-/// emitted text preserves `(a < b)` verbatim. The failure was always in
-/// compiling it, never in producing it.)
-///
-/// So: after the next seed bump, this body becomes `a < b` and the loop goes
-/// away. Two things to keep when it does. Keep it a FUNCTION with `String`
-/// parameters:
-/// inlining it as `Array::get(xs, i) < Array::get(xs, j)` is #1184, where `<`
-/// on two Array::get results degrades to a LENGTH-FIRST comparison (`"b" <
-/// "ab"` comes out true) and would silently reorder the sort. #1184 is marked
-/// closed but its own repro still prints the wrong answer on today's stage2;
-/// only adding a `: String` annotation rescues it.
+/// Lexicographic String less-than. Keep this typed helper boundary instead of
+/// inlining `Array::get(xs, i) < Array::get(xs, j)`: #1184 showed that an
+/// untyped aggregate-origin operand can miss String relational lowering and
+/// silently use the wrong representation order.
 export fn str_lt(a: String, b: String) -> Bool {
-  let la = String::length(a)
-  let lb = String::length(b)
-  let lim = if la < lb {
-    la
-  } else {
-    lb
-  }
-  let mut i = 0
-  let mut res = la < lb
-  let mut done = false
-  while i < lim && !done {
-    let ca = String::char_code_at(a, i)
-    let cb = String::char_code_at(b, i)
-    if ca < cb {
-      res = true
-      done = true
-    } else if ca > cb {
-      res = false
-      done = true
-    } else {
-      i = i + 1
-    }
-  }
-  res
+  a < b
 }
 
 /// Stable bottom-up merge sort. Returns the permutation `perm` such that

--- a/lib/@vibe/compiler/coverage_suite_lib.vibe
+++ b/lib/@vibe/compiler/coverage_suite_lib.vibe
@@ -144,24 +144,7 @@ fn bool_json(value: Bool) -> Json {
 }
 
 fn string_lt(a: String, b: String) -> Bool {
-  let len_a = String::length(a)
-  let len_b = String::length(b)
-  let rec go: (Int) -> Bool = (i) -> {
-    if i >= len_a || i >= len_b {
-      len_a < len_b
-    } else {
-      let ca = String::char_code_at(a, i)
-      let cb = String::char_code_at(b, i)
-      if ca < cb {
-        true
-      } else if ca > cb {
-        false
-      } else {
-        go(i + 1)
-      }
-    }
-  }
-  go(0)
+  a < b
 }
 
 fn double_json(value: Double) -> Json {

--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -2270,42 +2270,10 @@ fn item_key_text(item: Array[LTok]) -> String {
   key
 }
 
-/// Work around #1184 (String `<`/`>` degrade to a length-based comparison,
-/// not lexicographic, once an operand originates from Array::get): a
-/// char-by-char comparator confirmed correct against that issue's repro.
-/// Plain `<` is fine everywhere else in this file (only ever used on fresh
-/// literals/interpolated text); this is the one place that needs to compare
-/// two Array::get-sourced values.
+/// Typed helper for Array::get-sourced values. Keeping the operands behind
+/// String parameters preserves the #1184 relational-lowering boundary.
 fn str_lt(a: String, b: String) -> Bool {
-  let la = String::length(a)
-  let lb = String::length(b)
-  let n = if la < lb {
-    la
-  } else {
-    lb
-  }
-  let mut i = 0
-  let mut result = -1
-  while result < 0 && i < n {
-    let ca = String::char_code_at(a, i)
-    let cb = String::char_code_at(b, i)
-    if ca < cb {
-      result = 1
-    }
-    else if ca > cb {
-      result = 2
-    }
-    else {
-      i = i + 1
-    }
-  }
-  if result == 1 {
-    true
-  } else if result == 2 {
-    false
-  } else {
-    la < lb
-  }
+  a < b
 }
 
 /// Stable in-place insertion sort (import lists are small; O(n^2) is fine).
@@ -2826,9 +2794,8 @@ fn vp_header_end(src: String) -> Int {
   }
 }
 
-/// Sorts the parallel (name, version) deps arrays by package name. Uses
-/// str_lt, not `<`: plain String `<` is length-first, which would order
-/// `@a/zzz` before `@a/bbbb` (see str_lt's own note).
+/// Sorts the parallel (name, version) deps arrays by package name. Uses the
+/// typed str_lt helper because the operands originate from Array::get (#1184).
 fn vp_sort_deps(names: Array[String], vers: Array[String]) -> Unit {
   let n = Array::length(names)
   let mut i = 1

--- a/lib/@vibe/compiler/tests/canonical_checked_type_state_test.vibe
+++ b/lib/@vibe/compiler/tests/canonical_checked_type_state_test.vibe
@@ -10,7 +10,7 @@ import @vibe/compiler/checker {
 }
 
 import @vibe/compiler/core {
-  Expr, Stmt, Subst, Type, TypeDef, TypeEnv, TypeExpr
+  Expr, Stmt, Subst, Type, TypeDef, TypeEnv, TypeExpr, sort_perm_by_names, str_lt
 }
 
 import @vibe/core {
@@ -19,6 +19,24 @@ import @vibe/core {
 
 fn snapshot(env: TypeEnv, subst: Subst) -> String {
   canonical_effective_value_env_snapshot(env, subst)
+}
+
+test "typed String ordering is lexical for prefixes and Array values" {
+  assert(str_lt("a", "aa"))
+  assert(str_lt("ab", "b"))
+  assert(!str_lt("b", "ab"))
+  assert(!str_lt("same", "same"))
+  let names = [
+    "b",
+    "aa",
+    "a",
+    "ab"
+  ]
+  let perm = sort_perm_by_names(names)
+  assert(Array::get(perm, 0) == 2)
+  assert(Array::get(perm, 1) == 1)
+  assert(Array::get(perm, 2) == 3)
+  assert(Array::get(perm, 3) == 0)
 }
 
 fn typedef_observation(defs: Array[TypeDef], binders: Array[Array[Int]], subst: Subst) -> CheckedProgramTypeDefsObservation {

--- a/lib/@vibe/core/key.vibe
+++ b/lib/@vibe/core/key.vibe
@@ -49,29 +49,14 @@ export fn eq_string(a: String, b: String) -> Bool {
   a == b
 }
 
-/// Lexicographic (char-by-char, then length) String order. Deliberately NOT
-/// delegated to any host comparison: MoonBit's native `String <` was
-/// length-first, and this package must define proper dictionary order.
+/// Lexicographic String order with a normalized -1/0/1 result.
 export fn compare_string(a: String, b: String) -> Int {
-  let a_len = String::length(a)
-  let b_len = String::length(b)
-  let min_len = if a_len < b_len {
-    a_len
+  if a < b {
+    -1
+  } else if a > b {
+    1
   } else {
-    b_len
+    0
   }
-  let mut i = 0
-  while i < min_len {
-    let ac = String::char_code_at(a, i)
-    let bc = String::char_code_at(b, i)
-    if ac < bc {
-      return -1
-    }
-    if ac > bc {
-      return 1
-    }
-    i = i + 1
-  }
-  compare_int(a_len, b_len)
 }
 

--- a/lib/@vibe/core/sortedmap_test.vibe
+++ b/lib/@vibe/core/sortedmap_test.vibe
@@ -18,8 +18,7 @@ import ./sortedmap.vibe {
   SortedMap::values
 }
 import ./key.vibe {
-  compare_int,
-  compare_string
+  compare_int, compare_string
 }
 
 //# Helpers

--- a/lib/@vibe/core/sortedmap_test.vibe
+++ b/lib/@vibe/core/sortedmap_test.vibe
@@ -18,7 +18,8 @@ import ./sortedmap.vibe {
   SortedMap::values
 }
 import ./key.vibe {
-  compare_int
+  compare_int,
+  compare_string
 }
 
 //# Helpers
@@ -43,6 +44,14 @@ fn is_ascending_ints(xs: Array[Int]) -> Bool {
 }
 
 //# Misc
+
+test "String comparator is lexical and normalized" {
+  assert(compare_string("a", "aa") == -1)
+  assert(compare_string("aa", "a") == 1)
+  assert(compare_string("ab", "b") == -1)
+  assert(compare_string("b", "ab") == 1)
+  assert(compare_string("same", "same") == 0)
+}
 
 test "empty map" {
   let m: SortedMap[Int, String] = SortedMap::new_int()

--- a/lib/@vibe/graph/graph.vibe
+++ b/lib/@vibe/graph/graph.vibe
@@ -274,37 +274,10 @@ export fn ripple_record_eval(db: RippleDb, path: String, fingerprint: String, de
 
 //# Module order planning (#1239 step 4A / #906 step 4)
 
-/// Lexicographic (char-by-char) string ordering. Deliberately NOT a builtin
-/// `<`: canonical ordering must be true lexicographic, and a length-first
-/// comparison would make the plan's "canonical" order depend on path length
-/// (CLAUDE.md documents that exact footgun). Mirrors
-/// compiler/core/sorted_index.vibe's str_lt, duplicated rather than imported
-/// because @vibe/graph must not depend on the compiler package.
+/// Lexical module-name ordering. Keep the typed helper around Array-sourced
+/// paths so String relational lowering remains explicit (#1184).
 fn mo_str_lt(a: String, b: String) -> Bool {
-  let la = String::length(a)
-  let lb = String::length(b)
-  let lim = if la < lb {
-    la
-  } else {
-    lb
-  }
-  let mut i = 0
-  let mut res = la < lb
-  let mut done = false
-  while i < lim && !done {
-    let ca = String::char_code_at(a, i)
-    let cb = String::char_code_at(b, i)
-    if ca < cb {
-      res = true
-      done = true
-    } else if ca > cb {
-      res = false
-      done = true
-    } else {
-      i = i + 1
-    }
-  }
-  res
+  a < b
 }
 
 /// Index of `p` in `names`, or -1. Linear: this pass runs once per compile

--- a/lib/@vibe/prelude/cmp.vibe
+++ b/lib/@vibe/prelude/cmp.vibe
@@ -84,42 +84,11 @@ export fn minimum_by_key[T, K](a: T, b: T, key: (x: T) -> K, compare_key: (x: K,
   })
 }
 
-/// Byte-wise lexicographic compare with length tie-break. Deliberately does
-/// NOT use `a < b` on Strings: the selfhost linear lane lowers String
-/// relational operators to a raw i64 compare of the packed (ptr<<32)|len —
-/// a POINTER order, not content order. Short literals from the string table
-/// happen to sort by insertion order, which masked this until the >16-byte
-/// heap-concat cases in cmp_test's SIMD-chunk block flipped allocation order
-/// (#531 corpus scan).
+/// Byte-wise lexicographic comparison normalized to -1, 0, or 1.
 export fn string_compare(a: String, b: String) -> Int {
-  let la = String::length(a)
-  let lb = String::length(b)
-  let lim = if la < lb {
-    la
-  } else lb
-  let mut i = 0
-  let mut result = 0
-  let mut decided = false
-  while i < lim {
-    let ca = String::char_code_at(a, i)
-    let cb = String::char_code_at(b, i)
-    if ca < cb {
-      result = -1
-      decided = true
-      i = lim
-    } else if ca > cb {
-      result = 1
-      decided = true
-      i = lim
-    } else {
-      i = i + 1
-    }
-  }
-  if decided {
-    result
-  } else if la < lb {
+  if a < b {
     -1
-  } else if la > lb {
+  } else if a > b {
     1
   } else 0
 }

--- a/lib/@vibex/shell/pipeline.vibe
+++ b/lib/@vibex/shell/pipeline.vibe
@@ -531,40 +531,10 @@ export fn seq_step(first: Int, incr: Int, last: Int) -> Array[String] {
   }
 }
 
-/// #768: explicit lexicographic compare (true iff a < b, char-by-char with
-/// length tie-break). A bare `a < b` here relied on the #746 String-relational
-/// rewrite (desugar_trait_dict), but that rewrite needs an operand whose type
-/// is syntactically inferable -- `Array::get(arr, i)` is not, so the raw binop
-/// survived to codegen and compared the (ptr<<32)|len string values NUMERICALLY
-/// (pointer order): sort_str returned its input unsorted.
+/// #768/#1184: keep Array-sourced operands behind typed String parameters so
+/// the relational operator is lowered as a lexical String comparison.
 fn str_lex_lt(a: String, b: String) -> Bool {
-  let la = String::length(a)
-  let lb = String::length(b)
-  let n = if la < lb {
-    la
-  } else lb
-  let mut i = 0
-  let mut decided = 0
-  while i < n {
-    let ca = String::char_code_at(a, i)
-    let cb = String::char_code_at(b, i)
-    if ca < cb {
-      decided = 1
-      i = n
-    } else if ca > cb {
-      decided = 2
-      i = n
-    } else {
-      i = i + 1
-    }
-  }
-  if decided == 1 {
-    true
-  } else if decided == 2 {
-    false
-  } else {
-    la < lb
-  }
+  a < b
 }
 
 export fn sort_str(xs: Array[String]) -> Array[String] {

--- a/lib/@vibex/shell/pipeline_test.vibe
+++ b/lib/@vibex/shell/pipeline_test.vibe
@@ -222,16 +222,18 @@ test "extname extracts extension" {
   assert(extname(".hidden") == "")
 }
 
-test "sort_str sorts strings" {
+test "sort_str sorts strings lexicographically" {
   let xs = [
-    "c",
+    "b",
+    "aa",
     "a",
-    "b"
+    "ab"
   ]
   let result = sort_str(xs)
   assert(Array::get(result, 0) == "a")
-  assert(Array::get(result, 1) == "b")
-  assert(Array::get(result, 2) == "c")
+  assert(Array::get(result, 1) == "aa")
+  assert(Array::get(result, 2) == "ab")
+  assert(Array::get(result, 3) == "b")
 }
 
 test "uniq removes consecutive duplicates" {

--- a/scripts/generate_bundle.sh
+++ b/scripts/generate_bundle.sh
@@ -947,47 +947,6 @@ merge_flatten_tool_fingerprint() {
   bash "$helper" --print-fingerprint 2>/dev/null || true
 }
 
-# #1590: when the PINNED SEED compiles the flat module source (flatten-tool
-# pass 3 above, validate_module_source_compiles below, and the stage1 hop in
-# generations.sh), its checker runs AFTER desugar. Desugar synthesizes calls
-# to builtins that are not source-level names -- `a < b` on String becomes
-# `str_lex_diff(a, b) < 0`; `<`/`>`/`<=`/`>=` or `+` on an erased type
-# parameter become `__generic_rel_diff` / `__generic_add` -- so a seed whose
-# registry marks them checker-invisible dies with `unknown name: <builtin>`,
-# a message that never mentions the operator that caused it. The live tree
-# fixed the registry (checker_visible=true, #1590), but the failure keeps
-# this shape for as long as the pinned seed predates that fix, so translate
-# it back to the source-level construct the author actually wrote.
-explain_desugar_builtin_failure() {
-  local diag_file="$1"
-  [ -f "$diag_file" ] || return 0
-  local hit
-  hit="$(grep -oE 'unknown name: (str_lex_diff|__generic_rel_diff|__generic_add|__to_string)' \
-    "$diag_file" 2>/dev/null | head -1)" || true
-  [ -n "$hit" ] || return 0
-  local name="${hit#unknown name: }"
-  local construct
-  case "$name" in
-    str_lex_diff) construct='String `<` / `>` / `<=` / `>=`' ;;
-    __generic_rel_diff) construct='`<` / `>` / `<=` / `>=` on an erased type parameter ([T: Ord])' ;;
-    __generic_add) construct='`+` on an erased type parameter ([T: Add])' ;;
-    __to_string) construct='string interpolation / implicit to-string' ;;
-  esac
-  cat >&2 <<EOF
-
-generate_bundle: '$name' is not a name any source file spells -- the compiler
-itself introduces it when desugaring $construct.
-The pinned seed compiler rejects it in this lane (#1590): its checker runs
-after desugar here and its builtin registry predates the fix that made the
-name checker-visible. Until the next bootstrap bump, compiler/cli sources
-(everything reachable from lib/@vibe/compiler/cli_adapter.vibe) must not use
-$construct.
-For String order comparisons, call a char-by-char helper instead -- e.g.
-str_lt in lib/@vibe/compiler/core/sorted_index.vibe. See #1590 and
-docs/bootstrap.md ("seed lane と desugar-emitted builtins").
-EOF
-}
-
 bootstrap_merge_flatten_tool() {
   local flatten_wasm="$1"
   local seed_wasm="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
@@ -1048,7 +1007,6 @@ build_exact_adapter_merged_source() {
   if [ ! -s "$flatten_wasm" ]; then
     echo "generate_bundle: merge-flatten compiler build failed" >&2
     cat "$flatten_wasm.diag" >&2 2>/dev/null || true
-    explain_desugar_builtin_failure "$flatten_wasm.diag"
     echo "--- runner output ---" >&2
     tail -40 "$tool_log" >&2 2>/dev/null || true
     exit 1
@@ -1132,7 +1090,6 @@ validate_module_source_compiles() {
   if [ "$ok" != "1" ]; then
     echo "generate_bundle: candidate module source failed to compile (#979 sticky-failure guard) -- leaving any existing $ADAPTER_MODULE_SOURCE_OUT untouched" >&2
     cat "$check_wasm.diag" >&2 2>/dev/null || true
-    explain_desugar_builtin_failure "$check_wasm.diag"
     echo "--- runner output ---" >&2
     tail -40 "$check_log" >&2 2>/dev/null || true
   fi


### PR DESCRIPTION
## Summary
- replace the primary plus eight duplicated byte-at-a-time String comparators with typed lexical operators
- preserve typed helper boundaries required by #1184
- remove temporary #1590 bootstrap diagnostic/docs now that the new seed is published
- retain permanent non-FS builtin regression gate
- add lexical prefix/unequal-length and normalized comparator regressions

Depends on #1604 / seed `seed/desugar-builtins-2026-08-09`.

## Validation
- focused comparator/module/shell tests: 81 + 169 passing across worker/reviewer runs
- formatter: 917 files, zero violations
- generation gate stage2 == stage3 (`3d503964...`)
- known unrelated lazy iterator batch trap remains

Closes #1590 after both stacked PRs merge.
