### PR TITLE
chore(bootstrap): adopt seed with desugar-visible builtins

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "console-exception-rowvar-2026-08-06",
-    "tag": "seed/console-exception-rowvar-2026-08-06",
-    "source_commit": "88e26da3",
+    "name": "desugar-builtins-2026-08-09",
+    "tag": "seed/desugar-builtins-2026-08-09",
+    "source_commit": "236695d972e972de18105edda819ac4801904a3b",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "17c22701d35083cfea0763a3c123c66d60dc7ac068175155e2a2bd09a734683b"
+      "sha256": "24d68cf67a689a67ac567601c83cdeb322efe0496b8af6daed4dd6b7e92d8557"
     },
     "runtime": {
       "runner": "moonrun",


### PR DESCRIPTION
## Summary
- adopt deterministic stage2 built from source `236695d97` containing `f89b529`
- pin published prerelease `seed/desugar-builtins-2026-08-09`
- seed-only manifest change for #1590 phase 1

## Attestation
- stage0 == stage1 == stage2 == stage3 at SHA-256 `24d68cf67a689a67ac567601c83cdeb322efe0496b8af6daed4dd6b7e92d8557`
- release workflow succeeded: https://github.com/mizchi/vibe-lang/actions/runs/31303501638
- published immutable prerelease has five assets
- stacked branch CI passed before base merge; CI will rerun against main

Phase 2 cleanup is #1605.
