### PR TITLE
feat(scps): sequence HEAD の let 連鎖を継続 spine へ float する (#1536 (a) v3)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1043,7 +1043,11 @@ let r = handle {
 
 制約 (linear backend のみ): resume を値参照する handle の body では、
 対象 effect の perform (と、row にその effect を持つ関数の呼び出し) は
-let/seq/tail/分岐 tail に直接現れる必要がある。**concrete な row に
+let/seq/tail/分岐 tail に直接現れる必要がある。**let 連鎖 (brace block
+文や文位置の async-iterator `for` の脱糖出力) が文の途中 (sequence HEAD)
+に立つ形は、split が継続 spine へ float して受理する** (#1536 (a) v3,
+ADR-0076 追記42 — `async_iter_collect` / `_fold` / `_count` が suspend
+body から呼べるのはこれ)。**concrete な row に
 対象 effect を含む top-level 関数の呼び出しは可** (3b yield bubbling —
 再帰も可; callee には CPS clone が合成され、元の関数は他の呼び出し元
 向けに無変更)。それ以外に呼べるのは perform / pure builtin / ctor /

--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2755,6 +2755,44 @@ fixtures: `effect_stream_next_suspend_retarget.vibe` (want 42; `Some(41)` と
 argument の一回評価を pin)、`effect_stream_next_retarget_hygiene.vibe`
 (`__sn_next` collision、shadowed `Future::ready`、empty layout を pin)。
 
+### 追記42 (2026-08-09): sequence HEAD の let 連鎖を継続 spine へ float する (#1536 (a) v3)
+
+「sequence の HEAD が perform を内側に抱えた複合式」は追記27 以来の不適格形
+だったが、**async-iterator `for` の脱糖出力 (`build_await_iter_for`) が
+構造的に必ずこの形になる** — `for` は自己完結の
+`ELet(__iter_src, .., ELetMut(.., ELetMut(.., EWhile)))` 1 式に落ち、文位置の
+`for` ではそれが `ESeq(<for 機械>, rest)` の HEAD に置かれる。手書きの
+while+let-mut spine (適格) と脱糖出力の差はこの木の左右バランスだけで、
+`async_iter_collect` / `_fold` / `_count` (と suspend body 内のあらゆる非末尾
+`for`、brace block 文) が実質これだけで塞がっていた (#1536 の残りの名指し被害)。
+
+`scps_split_tail` の ESeq arm に let-floating を足した:
+
+- `ESeq(ELet(x, v, k), b)` → `ELet(nx, v, ESeq(k[x:=nx], b))`
+  (ELetMut も同形、`ESeq(ESeq(a1, a2), b)` は右結合へ再結合)。
+  float 後は既存の ELet/ELetMut/while arm がそのまま split する。
+- **binder は無条件に site-suffix の fresh 名 `__scps_seq<site>_<x>` へ
+  α-rename する** (`scps_rename_ident`、shadow-aware で代入先も追う)。
+  scope を `b` の上へ広げるので、`b` 内の自由な `x` (外側 binding への参照)
+  を捕獲しないことが正しさの条件 — rename で構造的に排除する。同名 float の
+  `nx` 衝突は「内側 literal binder が外側を shadow する」surface scoping が
+  そのまま成り立つので無害。
+- 判定と変換が同じ関数なので、`vibe check` の #1574 ミラー
+  (`effect_lowering_prelude` 経由) と codegen は自動で lockstep。
+- suspend しない HEAD は従来どおり素通し (while arm と同じ理由 — 不要な
+  再構成をしない)。
+
+**残る不適格 (このスライスの範囲外)**: EIf/EMatch/EForIn(array)/ELoop が
+suspend を抱えて HEAD に立つ形、代入 RHS 直書きの perform
+(`acc = perform ..` — cellify 後に call-arg 位置へ落ちる)、row 変数 callee、
+literal param。
+
+fixtures: `effect_for_await_suspend.vibe` (want 20; 逐次 2 loop で同名
+`__iter_*` の反復 float を pin)、`effect_seq_head_block_suspend.vibe`
+(want 1105; inner binder が outer 名を shadow し tail が outer を参照する形 —
+rename を外すと捕獲で黙って誤る、その P0 側を pin)。実害側は
+`async_iter_test.vibe` の suspend-class handle 内 terminals テスト。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2771,12 +2771,17 @@ while+let-mut spine (適格) と脱糖出力の差はこの木の左右バラン
 - `ESeq(ELet(x, v, k), b)` → `ELet(nx, v, ESeq(k[x:=nx], b))`
   (ELetMut も同形、`ESeq(ESeq(a1, a2), b)` は右結合へ再結合)。
   float 後は既存の ELet/ELetMut/while arm がそのまま split する。
-- **binder は無条件に site-suffix の fresh 名 `__scps_seq<site>_<x>` へ
-  α-rename する** (`scps_rename_ident`、shadow-aware で代入先も追う)。
-  scope を `b` の上へ広げるので、`b` 内の自由な `x` (外側 binding への参照)
-  を捕獲しないことが正しさの条件 — rename で構造的に排除する。同名 float の
-  `nx` 衝突は「内側 literal binder が外側を shadow する」surface scoping が
-  そのまま成り立つので無害。
+- **binder は無条件に fresh 名へ α-rename する** (`scps_rename_ident`、
+  shadow-aware で代入先も追う)。scope を `b` の上へ広げるので、`b` 内の
+  自由な `x` (外側 binding への参照) を捕獲しないことが正しさの条件 —
+  rename で構造的に排除する。fresh 名は `__scps_seq<site>_<x>` を基底に、
+  **その綴りが `k`・`b` のどこにも出現しなくなるまで数値 suffix を bump
+  して mint する** (`scps_seq_float_fresh` — Codex P1 on #1607: user code が
+  生成綴りを文字どおり書いていると、tail の外側参照の捕獲か、`k` 内の同綴り
+  binder による rename 済み出現の捕獲が起き、どちらも黙って誤る。probe は
+  scope-blind な出現検査 `scps_mentions_name` = binder + 参照 + 代入先)。
+  同名 float どうしの `nx` 衝突は「内側 literal binder が外側を shadow する」
+  surface scoping がそのまま成り立つので無害。
 - 判定と変換が同じ関数なので、`vibe check` の #1574 ミラー
   (`effect_lowering_prelude` 経由) と codegen は自動で lockstep。
 - suspend しない HEAD は従来どおり素通し (while arm と同じ理由 — 不要な
@@ -2790,7 +2795,10 @@ literal param。
 fixtures: `effect_for_await_suspend.vibe` (want 20; 逐次 2 loop で同名
 `__iter_*` の反復 float を pin)、`effect_seq_head_block_suspend.vibe`
 (want 1105; inner binder が outer 名を shadow し tail が outer を参照する形 —
-rename を外すと捕獲で黙って誤る、その P0 側を pin)。実害側は
+rename を外すと捕獲で黙って誤る、その P0 側を pin)、
+`effect_seq_head_reserved_name_collision.vibe` (want 3011; user code が
+生成綴り `__scps_seq0_x` を文字どおり束縛/参照する形 — probe を外した対照
+実験では 1015 に化ける)。実害側は
 `async_iter_test.vibe` の suspend-class handle 内 terminals テスト。
 
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -165,11 +165,14 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
 
 - **適格**: let / seq / tail / branch-tail の spine、`while` + `let mut`
   (#1230 で widening 済み。`let mut x = v` → 1 要素セル、`while` → `let rec`
-  ローカル closure への末尾再帰)、**row-free closure パラメータの呼び出しの
-  うち、全 by-name call site の実引数が suspend-inert と証明できるもの**
-  (#1536 (a)。下記)
-- **不適格**: ループ内 `break`/`continue`/`return`、`for`/`loop` 形、
-  sequence の HEAD が perform を内側に抱えた複合式、実引数証明が成立しない
+  ローカル closure への末尾再帰)、**sequence HEAD に立つ let 連鎖複合式**
+  (brace block 文・文位置の async-iterator `for` の脱糖出力 — #1536 (a) v3
+  の let-floating が継続 spine へ再バランスする、ADR-0076 追記42)、
+  **row-free closure パラメータの呼び出しのうち、全 by-name call site の
+  実引数が suspend-inert と証明できるもの** (#1536 (a)。下記)
+- **不適格**: ループ内 `break`/`continue`/`return`、配列 `for` / `loop` 形、
+  sequence HEAD に立つ perform 抱えの `if`/`match` 複合式、代入 RHS 直書きの
+  perform (`acc = perform ..`)、実引数証明が成立しない
   closure パラメータの呼び出し、row 変数 callee (`with e`)
 
 closure param を**無条件に**許すのは不健全 — closure literal 内の `perform`
@@ -185,8 +188,9 @@ row が空 ⇒ perform しない」が成り立たない。#1536 (a) の受理�
 渡せば slot 全体が taint し、従来どおり `cannot see through` で拒否される
 (fixtures/err_effect_closure_param_taint.vibe)。これで `async_iter_find` /
 `_any` / `_all` は suspend body から呼べる。`await(Stream::next(s))` は
-別問題 (builtin `Stream::next` が top-level fn ではなく needing 集合に
-乗らない) で、まだ書けない。
+synthetic retarget (#1536 (a) v2, ADR-0076 追記41) で書けるようになり、
+`for` 駆動の terminal (`async_iter_collect` / `_fold` / `_count`) は
+let-floating (#1536 (a) v3, 追記42) で書けるようになった。
 
 ### 2.3 同期 effect との関係
 
@@ -1627,7 +1631,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 
 | 項目 | 内容 | 依存 |
 |---|---|---|
-| **suspend lowering の適格性** (#1536) | row-variable callee と literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow と eager `await(Stream::next(s))` retarget は済み (§2.2 末尾) | — (ADR-0076 本体) |
+| **suspend lowering の適格性** (#1536) | row-variable callee と literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow、eager `await(Stream::next(s))` retarget、sequence-HEAD let 連鎖の float (`for` 駆動 terminal) は済み (§2.2 末尾) | — (ADR-0076 本体) |
 | **AsyncIter への一本化** (#1538) | eager `Stream[T]` combinator の退役 / AsyncIter 上への再実装。`Stream::next` protocol と host stream read の接続 | 上の適格性 |
 | **`ByteStream` の p3 接続** (#1539) | `lib/@vibe/console/byte_stream.vibe` の Stdin closure 版を `stream.read` へ。ADR-0089 は「pull closure の host shim を差し替えるだけ」と設計済み | — |
 | **実 provider = `wasi:http` incoming-body** (#1540) | serve composition と host-stream composition の統合が要る (§3.19 に構造的な理由と 3 点の分解) | — |

--- a/fixtures/effect_for_await_suspend.vibe
+++ b/fixtures/effect_for_await_suspend.vibe
@@ -1,0 +1,61 @@
+// #1536 (a) v3, let-floating: an async-iterator `for` in STATEMENT position
+// desugars (build_await_iter_for) to a self-contained let-chain terminating
+// in the eligible while spine -- but the chain lands in SEQUENCE HEAD
+// position (`ESeq(<for machine>, rest)`), which the suspend split used to
+// reject wholesale ("sequence HEAD carrying a perform"). scps_split_tail now
+// floats the chain onto the continuation spine it already handles
+// (`ESeq(ELet(x, v, k), b)` => `ELet(nx, v, ESeq(k[x:=nx], b))`, binder
+// alpha-renamed so `b`'s own references can never be captured), so the
+// desugared `for` splits exactly like the hand-written while+let-mut spine.
+// Two sequential loops on purpose: both desugar to the same `__iter_*`
+// spellings, so this also pins that repeated floats of the same original
+// name stay independent.
+trait AIter[T] {
+  next(Self) -> Future[Option[(T, Self)]]
+}
+
+struct Countdown {
+  n: Int
+}
+
+impl AIter for Countdown {
+  next(self) -> Future[Option[(Int, Countdown)]] {
+    Future::ready(if self.n > 0 {
+      Some((self.n, Countdown::{
+        n: self.n - 1
+      }))
+    } else {
+      None
+    })
+  }
+}
+
+fn total() -> Int with Async {
+  let mut acc = 0
+  for x in Countdown::{
+    n: 4
+  } {
+    acc = acc + x
+  }
+  for y in Countdown::{
+    n: 4
+  } {
+    acc = acc + y
+  }
+  acc
+}
+
+let _start = () -> Int {
+  handle {
+    total()
+  } with Async {
+    Suspend(t) => {
+      let k = resume
+      k(t)
+    }
+  }
+}
+_start()
+
+__DATA__
+{"last":"20"}

--- a/fixtures/effect_seq_head_block_suspend.vibe
+++ b/fixtures/effect_seq_head_block_suspend.vibe
@@ -1,0 +1,41 @@
+// #1536 (a) v3, let-floating shadow pin: a brace block in SEQUENCE HEAD
+// position whose inner `let x` SHADOWS an outer `x` that the sequence TAIL
+// still references. Floating the block's binder over the tail without the
+// alpha-rename would capture the tail's `x` (104 would silently become 8 --
+// the P0 failure mode this fixture locks out). Covers both split lanes: the
+// handle BODY's own spine (`res`) and a needing fn's clone (`f`).
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn f() -> Int with Ask {
+  let x = 100
+  let mut acc = 0
+  {
+    let x = perform Ask::Get(3)
+    acc = x
+  }
+  acc + x
+}
+
+let _start = () -> Int {
+  handle {
+    let y = 1000
+    let mut got = 0
+    {
+      let base = f()
+      let y = perform Ask::Get(base)
+      got = y
+    }
+    got + y
+  } with Ask {
+    Get(t) => {
+      let k = resume
+      k(t + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{"last":"1105"}

--- a/fixtures/effect_seq_head_reserved_name_collision.vibe
+++ b/fixtures/effect_seq_head_reserved_name_collision.vibe
@@ -1,0 +1,40 @@
+// Codex P1 on #1607: nothing stops user code from literally spelling the
+// seq-float's generated alpha-rename target (`__scps_seq<site>_<x>`). A
+// collision is silent-wrong in both roles: the sequence TAIL's reference
+// to its own outer binding would be captured by the floated binder, and an
+// inner binder of that spelling inside the floated continuation would
+// capture the renamed occurrences. scps_seq_float_fresh probes the
+// continuation AND the tail (scope-blind: any occurrence of the candidate
+// spelling disqualifies it) and bumps a numeric suffix until genuinely
+// fresh. Both roles are laid here under a few site spellings; capture in
+// any of them shifts the total away from 3011.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn f() -> Int with Ask {
+  let __scps_seq0_x = 1000
+  let __scps_seq1_x = 2000
+  let mut acc = 0
+  {
+    let x = perform Ask::Get(3)
+    let __scps_seq0_x = 7
+    acc = x + __scps_seq0_x
+  }
+  acc + __scps_seq0_x + __scps_seq1_x
+}
+
+let _start = () -> Int {
+  handle {
+    f()
+  } with Ask {
+    Get(t) => {
+      let k = resume
+      k(t + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{"last":"3011"}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9402,6 +9402,46 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
             let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
             (bok, ESeq(a, bexpr))
           },
+          // #1536 (a) v3, let-floating: a suspending let-chain compound in
+          // SEQUENCE HEAD position (what an async-iterator `for` in statement
+          // position desugars to -- `ELet(__iter_src, ..)` terminating in the
+          // loop, with the rest of the body as the seq tail) is rebalanced
+          // onto the continuation spine this split already handles:
+          //   ESeq(ELet(x, v, k), b)  ==>  ELet(nx, v, ESeq(k[x:=nx], b))
+          // Widening the binder's scope over `b` is only sound if `b` cannot
+          // capture it, so the binder is ALWAYS alpha-renamed to a
+          // site-suffixed fresh spelling first (shadow-aware, assignment
+          // targets included -- scps_rename_ident): any `x` free in `b`
+          // refers to an OUTER binding and must keep doing so. Two floated
+          // binders collide in `nx` only if they share the original name, and
+          // then surface block scoping already guarantees the inner one
+          // shadows every use the rename could reach. Non-suspending heads
+          // keep the ordinary statement path below (same reasoning as the
+          // `while` arm above: no gratuitous restructuring).
+          ELet(x, v, k, off) => if scps_contains_susp(a, sctx) {
+            let nx = String::concat(String::concat(scps_local("__scps_seq", site), "_"), x)
+            scps_split_tail(ELet(nx, v, ESeq(scps_rename_ident(k, x, nx), b), off), sctx, ctx, st)
+          } else {
+            let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
+            (bok, ESeq(a, bexpr))
+          },
+          ELetMut(x, v, k, off) => if scps_contains_susp(a, sctx) {
+            let nx = String::concat(String::concat(scps_local("__scps_seq", site), "_"), x)
+            scps_split_tail(ELetMut(nx, v, ESeq(scps_rename_ident(k, x, nx), b), off), sctx, ctx, st)
+          } else {
+            let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
+            (bok, ESeq(a, bexpr))
+          },
+          // Reassociate a suspending nested sequence head so its own head
+          // surfaces for the arms above: ESeq(ESeq(a1, a2), b) ==>
+          // ESeq(a1, ESeq(a2, b)). Strictly decreases head size, so the
+          // rewrite loop terminates.
+          ESeq(a1, a2) => if scps_contains_susp(a, sctx) {
+            scps_split_tail(ESeq(a1, ESeq(a2, b)), sctx, ctx, st)
+          } else {
+            let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
+            (bok, ESeq(a, bexpr))
+          },
           _ => {
             let ap = scps_as_target_perform(a, ops)
             let an = scps_as_needing_call(a, sctx)

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9419,14 +9419,14 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           // keep the ordinary statement path below (same reasoning as the
           // `while` arm above: no gratuitous restructuring).
           ELet(x, v, k, off) => if scps_contains_susp(a, sctx) {
-            let nx = String::concat(String::concat(scps_local("__scps_seq", site), "_"), x)
+            let nx = scps_seq_float_fresh(x, k, b, site)
             scps_split_tail(ELet(nx, v, ESeq(scps_rename_ident(k, x, nx), b), off), sctx, ctx, st)
           } else {
             let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
             (bok, ESeq(a, bexpr))
           },
           ELetMut(x, v, k, off) => if scps_contains_susp(a, sctx) {
-            let nx = String::concat(String::concat(scps_local("__scps_seq", site), "_"), x)
+            let nx = scps_seq_float_fresh(x, k, b, site)
             scps_split_tail(ELetMut(nx, v, ESeq(scps_rename_ident(k, x, nx), b), off), sctx, ctx, st)
           } else {
             let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
@@ -10349,6 +10349,126 @@ fn scps_binds_name_arms(arms: Array[(Pat, Expr)], x: String) -> Bool {
     i = i + 1
   }
   hit
+}
+
+/// True if `x` occurs ANYWHERE in `e` as an identifier reference or an
+/// assignment target (scope-blind on purpose: this feeds the seq-float's
+/// freshness probe, where any occurrence at all -- bound or free -- means
+/// the candidate spelling is not safe to mint). Binder occurrences are
+/// scps_binds_name's job; scps_mentions_name below ORs the two.
+fn scps_refs_name(e: Expr, x: String) -> Bool {
+  match e {
+    EIdent(nm, _) => nm == x,
+    EAssign(nm, v, b) => nm == x || scps_refs_name(v, x) || scps_refs_name(b, x),
+    EAssignOp(_, nm, v, b) => nm == x || scps_refs_name(v, x) || scps_refs_name(b, x),
+    ELet(_, v, b, _) => scps_refs_name(v, x) || scps_refs_name(b, x),
+    ELetMut(_, v, b, _) => scps_refs_name(v, x) || scps_refs_name(b, x),
+    ELetRec(_, v, b) => scps_refs_name(v, x) || scps_refs_name(b, x),
+    EFn(_, _, _, _, _, b) => scps_refs_name(b, x),
+    EForIn(_, _, it, b) => scps_refs_name(it, x) || scps_refs_name(b, x),
+    ELoop(pairs, b) => {
+      let mut hit = scps_refs_name(b, x)
+      let mut i = 0
+      while i < Array::length(pairs) {
+        let (_, v) = Array::get(pairs, i)
+        if scps_refs_name(v, x) {
+          hit = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      hit
+    },
+    EMatch(s, arms) => scps_refs_name(s, x) || scps_refs_name_arms(arms, x),
+    EHandle(b, arms) => scps_refs_name(b, x) || scps_refs_name_arms(arms, x),
+    ESeq(a, b) => scps_refs_name(a, x) || scps_refs_name(b, x),
+    EIf(c, t, el) => scps_refs_name(c, x) || scps_refs_name(t, x) || scps_refs_name(el, x),
+    ECall(callee, args, _) => scps_refs_name(callee, x) || scps_refs_name_exprs(args, x),
+    EBinOp(_, l, r) => scps_refs_name(l, x) || scps_refs_name(r, x),
+    EUnaryOp(_, a) => scps_refs_name(a, x),
+    EReturn(a) => scps_refs_name(a, x),
+    EDot(o, _, _, _) => scps_refs_name(o, x),
+    ELabeledArg(_, _, v) => scps_refs_name(v, x),
+    EBreak(opt) => match opt {
+      Some(a) => scps_refs_name(a, x),
+      None => false
+    },
+    EContinue(args) => scps_refs_name_exprs(args, x),
+    ETuple(items) => scps_refs_name_exprs(items, x),
+    EArray(items) => scps_refs_name_exprs(items, x),
+    ERecord(_, fields, _) => scps_refs_name_pairs(fields, x),
+    EMap(fields) => scps_refs_name_pairs(fields, x),
+    ESpread(a) => scps_refs_name(a, x),
+    _ => false
+  }
+}
+
+fn scps_refs_name_exprs(es: Array[Expr], x: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(es) {
+    if scps_refs_name(Array::get(es, i), x) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn scps_refs_name_pairs(pairs: Array[(String, Expr)], x: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(pairs) {
+    let (_, v) = Array::get(pairs, i)
+    if scps_refs_name(v, x) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn scps_refs_name_arms(arms: Array[(Pat, Expr)], x: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(arms) {
+    let (_, ex) = Array::get(arms, i)
+    if scps_refs_name(ex, x) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn scps_mentions_name(e: Expr, x: String) -> Bool {
+  scps_binds_name(e, x) || scps_refs_name(e, x)
+}
+
+/// Mint the seq-float's alpha-renaming target: `__scps_seq<site>_<x>`,
+/// bumped with a numeric suffix until the spelling occurs NOWHERE in the
+/// floated continuation `k` or the sequence tail `b` (Codex P1 on #1607:
+/// nothing stops a user binding or referencing the generated spelling
+/// literally, and a collision either captures the tail's outer reference
+/// or lets an inner binder capture the renamed occurrences -- both
+/// silent-wrong). The probe is scope-blind (any occurrence disqualifies),
+/// so the minted name is fresh for both roles by construction.
+fn scps_seq_float_fresh(x: String, k: Expr, b: Expr, site: Int) -> String {
+  let base = String::concat(String::concat(scps_local("__scps_seq", site), "_"), x)
+  let mut nx = base
+  let mut i = 0
+  while scps_mentions_name(k, nx) || scps_mentions_name(b, nx) {
+    i = i + 1
+    nx = String::concat(String::concat(base, "_"), Int::to_string(i))
+  }
+  nx
 }
 
 /// True if `e` could reach a suspend of the effect under proof: ANY

--- a/lib/@vibe/prelude/async_iter_test.vibe
+++ b/lib/@vibe/prelude/async_iter_test.vibe
@@ -201,3 +201,45 @@ test "async_iter: lazy combinators chain into an async terminal" {
   })
   assert(total == 36)
 }
+
+test "async_iter: terminals run inside a suspend-class handle body (#1536)" {
+  // The `for`-driven terminals (collect / fold / count) desugar to a
+  // let-chain-in-sequence-head shape; the suspend split's let-floating
+  // (ADR-0076 追記42) is what makes them eligible here. find is the
+  // hand-written while spine, pinned alongside as the baseline.
+  let out = handle {
+    let folded = async_iter_fold(async_iter_arr([
+      1,
+      2,
+      3
+    ]), 0, (acc: Int, x: Int) -> Int {
+      acc + x
+    })
+    let collected = async_iter_collect(async_iter_arr([
+      10,
+      20
+    ]))
+    let counted = async_iter_count(async_iter_arr([
+      7,
+      7,
+      7
+    ]))
+    let found_opt = async_iter_find(async_iter_arr([
+      4,
+      5
+    ]), (x: Int) -> Bool {
+      x % 5 == 0
+    })
+    let found = match found_opt {
+      Some(v) => v,
+      None => 0 - 1
+    }
+    folded + Array::length(collected) + counted + found
+  } with Async {
+    Suspend(t) => {
+      let k = resume
+      k(t)
+    }
+  }
+  assert_eq(out, 16)
+}

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6701,6 +6701,15 @@ scps_run_expect "effect_stream_next_suspend_retarget.vibe" "42" "streamnext"
 # `__sn_next` must not capture the retarget and shadowed Future::ready must
 # not change empty-stream layout (None fallback = 7).
 scps_run_expect "effect_stream_next_retarget_hygiene.vibe" "7" "streamnexthygiene"
+# #1536 (a) v3 (let-floating): an async-iterator `for` in statement position
+# desugars to a let-chain in SEQUENCE HEAD position; scps_split_tail floats
+# it onto the continuation spine. Two sequential loops pin repeated floats
+# of the same __iter_* spellings.
+scps_run_expect "effect_for_await_suspend.vibe" "20" "forawaitsusp"
+# Shadow pin for the float's alpha-rename: an inner block binder shadows an
+# outer name the sequence TAIL references -- capture would print 8/wrong,
+# not 1105. Covers both the handle-body spine and a needing fn's clone.
+scps_run_expect "effect_seq_head_block_suspend.vibe" "1105" "seqheadshadow"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"
 scps_check_reject "err_effect_resume_store_ineligible.vibe" "cannot see through" "inelig"
 scps_check_reject "err_effect_closure_param_taint.vibe" "cannot see through" "inerttaint"

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6710,6 +6710,11 @@ scps_run_expect "effect_for_await_suspend.vibe" "20" "forawaitsusp"
 # outer name the sequence TAIL references -- capture would print 8/wrong,
 # not 1105. Covers both the handle-body spine and a needing fn's clone.
 scps_run_expect "effect_seq_head_block_suspend.vibe" "1105" "seqheadshadow"
+# Codex P1 on #1607: user code literally spelling the generated
+# `__scps_seq<site>_<x>` target must not be captured -- the freshness
+# probe bumps past any occurrence in the floated continuation or the
+# tail. Control-measured: with the probe disabled this prints 1015.
+scps_run_expect "effect_seq_head_reserved_name_collision.vibe" "3011" "seqheadfresh"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"
 scps_check_reject "err_effect_resume_store_ineligible.vibe" "cannot see through" "inelig"
 scps_check_reject "err_effect_closure_param_taint.vibe" "cannot see through" "inerttaint"


### PR DESCRIPTION
## 概要

#1536 (a) の第三スライス。suspend CPS split が「sequence の HEAD が perform を内側に抱えた複合式」を一律拒否していた壁を、**let-floating** で外します。

## 実測で特定した真因

`async_iter_collect` / `_fold` / `_count` が suspend body から呼べない理由は closure param (v1 で解決) でも builtin retarget (v2/#1603 で解決) でもなく、**for-await の脱糖出力の木の形**でした:

- `build_await_iter_for` は文位置の `for x in src` を自己完結の `ELet(__iter_src, .., ELetMut(.., ELetMut(.., EWhile)))` 1 式に落とし、それが `ESeq(<for機械>, rest)` の **HEAD** に置かれる
- 手書きの while+let-mut spine (#1230 で適格) との差はこの左右バランスだけ — **同一内容の手書き展開は受理・`for` 版は拒否**を切り分けで確認
- brace block 文 (`{ let got = perform ..; acc = got }` を文中に置く形) も同じ壁

## 修正

`scps_split_tail` の ESeq arm に let-floating を追加 (判定と変換が同じ関数なので `vibe check` の #1574 ミラーと codegen は自動で lockstep):

```
ESeq(ELet(x, v, k), b)  ==>  ELet(nx, v, ESeq(k[x:=nx], b))
```

- ELetMut も同形、`ESeq(ESeq(a1,a2), b)` は右結合へ再結合。float 後は既存の arm がそのまま split
- **binder は無条件に fresh 名 `__scps_seq<site>_<x>` へ α-rename** (shadow-aware、代入先も追う)。scope を `b` の上へ広げるため、`b` 内の自由な `x` (外側 binding への参照) の捕獲を構造的に排除 — 捕獲すると**黙って誤る** (P0 側) ので fixture で値を pin
- suspend しない HEAD は従来どおり素通し (不要な再構成をしない — while arm と同じ理由)

## 効果

- `for` 駆動の async_iter terminal (`collect` / `fold` / `count`) が suspend-class handle body から呼べる (prelude テストに実物を追加、`find` を baseline 併置、値 16 で pin)
- suspend body 内の brace block 文・非末尾 `for` が書ける

**範囲外のまま**: EIf/EMatch/配列 EForIn/ELoop が suspend を抱えて HEAD に立つ形、代入 RHS 直書き perform (`acc = perform ..`)、row 変数 callee、literal param。

## fixtures / 検証

| fixture | want | pin する内容 |
|---|---|---|
| `effect_for_await_suspend.vibe` | 20 | 逐次 2 loop で同名 `__iter_*` の反復 float |
| `effect_seq_head_block_suspend.vibe` | 1105 | shadow + 外側参照の捕獲回避 (rename を外すと値が変わる)、handle-body spine と needing-fn clone の両レーン |

- `scripts/compiler_gate.sh` **exit 0** (新レーン `forawaitsusp` / `seqheadshadow` 含む、seed flatten / stage2→stage3 検証込み)
- unit suite **542/542**
- 既存の負の pin (`for j in [1,2]` 内 perform の拒否、#1536(c) unit test) は配列 EForIn なので従来どおり拒否のまま

> 環境メモ: `pkf run test` はこのコンテナで nix/system glibc 不整合 (`sort: GLIBC_ABI_DT_X86_64_PLT not found`) のため直接 `bash scripts/compiler_gate.sh` で検証。

## docs

- ADR-0076 **追記42** (docs/effect-evidence-passing.md): 設計・健全性議論・残件
- docs/cheatsheet.md: suspend 制約の段落に float の受理形を追記
- docs/spec/wasi-p3-async.md §2.2: 適格性境界の表を更新 (§6.2 の現在地も)

Refs #1536, #1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_