### PR TITLE
fix(checker): transport selected trait authority (#1549)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1740,7 +1740,12 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           env_eq
         }
         let env_show = if struct_derives_has(enum_derives, "Show") || struct_derives_has(enum_derives, "Hash") {
-          env_bind(env_ord, String::concat(name, "::to_string"), CtFn([
+          let env_show_base = if struct_derives_has(enum_derives, "Show") {
+            EnvTraitImpl("Show", ctor_result_type, env_ord)
+          } else {
+            env_ord
+          }
+          env_bind(env_show_base, String::concat(name, "::to_string"), CtFn([
             ctor_result_type
           ], CtString, None))
         } else {
@@ -1859,7 +1864,12 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           env1
         }
         let env3 = if struct_derives_has(derives, "Show") || struct_derives_has(derives, "Hash") {
-          env_bind(env2, String::concat(name, "::to_string"), CtFn([
+          let env_show_base = if struct_derives_has(derives, "Show") {
+            EnvTraitImpl("Show", CtStruct(name), env2)
+          } else {
+            env2
+          }
+          env_bind(env_show_base, String::concat(name, "::to_string"), CtFn([
             CtStruct(name)
           ], CtString, None))
         } else {
@@ -2087,20 +2097,9 @@ fn unsatisfied_bound_hint(env: TypeEnv, trait_name: String, resolved: Type) -> S
 /// satisfy its bounds. Unresolved (still-polymorphic) vars are inherited by the
 /// caller, not violated, so they are skipped. One `no impl `Trait` for `Type``
 /// error per unsatisfied bound (matches fixtures/err_type_trait_*bound* messages).
+/// Import projection supplies the selected trait authority and implementations,
+/// so this is enforced identically for standalone and FS/import checking.
 fn check_program_bounds(env: TypeEnv, s: Subst, defs: Array[TypeDef], errors: Array[String]) -> Unit {
-  check_program_bounds_impl(env, s, defs, errors, false)
-}
-
-/// send_only: the FS/import path (check_program_with_env) checks ONLY the
-/// compiler-judged `Send` bound. User-trait bounds cannot be enforced there
-/// yet: imported files' `impl` declarations are not propagated into the
-/// entry file's TypeEnv, so a cross-module `impl Hash for String` would be
-/// invisible and every such bound would false-positive (found empirically:
-/// builtin_traits_test / iterator_test / to_string_bool_param_test).
-/// `Send` needs no user impls — its structural judgment plus the seeded
-/// primitive impls are complete in any env — so it is safe to enforce
-/// everywhere.
-fn check_program_bounds_impl(env: TypeEnv, s: Subst, defs: Array[TypeDef], errors: Array[String], send_only: Bool) -> Unit {
   let pairs = collect_subst_bounds_pairs(s)
   let n = Array::length(pairs)
   let mut i = 0
@@ -2115,14 +2114,12 @@ fn check_program_bounds_impl(env: TypeEnv, s: Subst, defs: Array[TypeDef], error
         let mut bi = 0
         while bi < bn {
           let b = Array::get(bounds, bi)
-          // ADR-0068: `Send` is judged structurally from the type
-          // definitions (type_send_ok), not from user impls.
           let sat = if b == "" {
             true
           } else if b == "Send" {
+            // ADR-0068: `Send` is judged structurally from the type
+            // definitions (type_send_ok), not from user impls.
             type_send_ok(env, s, defs, resolved)
-          } else if send_only {
-            true
           } else {
             type_implements_trait(env, s, resolved, b)
           }
@@ -3180,12 +3177,10 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
         }
       }
       let (env, final_s, _) = check_stmts_with_binders(expanded_stmts, 0, seeded_env, empty_defs, type_def_binders, local_defs_start, SubstEmpty, seed_next_c, frozen_errors, tytab, statement_parent_path, capture, role_lane_capture)
-      // #1090 review: the FS typecheck path (every file with imports) went
-      // through here and never enforced trait bounds, so `[T: Send]` on an
-      // imported generic fn was silently bypassed. Enforce the Send bound
-      // here (send_only — see check_program_bounds_impl for why user-trait
-      // bounds cannot be enforced on this path yet).
-      check_program_bounds_impl(env, final_s, empty_defs, frozen_errors, true)
+      // Selected import projection carries trait definitions and impls into
+      // this environment, so user-trait bounds are checked here with the same
+      // rule as the standalone path.
+      check_program_bounds(env, final_s, empty_defs, frozen_errors)
       collect_async_effect_errors(expanded_stmts, env, frozen_errors)
       // #1081 step 3 Phase B (Codex review, PR #1151): see check_program's
       // matching call for why this runs whole-program rather than per

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -166,6 +166,7 @@ fn typing_dependency_record_encode_internal(tag: String, fields: Array[String]) 
 fn typing_dependency_record_decode_internal(text: String, expected_tag: String, expected_fields: Int) -> Option[Array[String]]
 
 // --- typecheck_fs.vibe
+fn build_trait_aware_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception
 fn locate_type_error(source: String, msg: String) -> String
 fn ensure_fingerprint_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs
 // #1100: memoized located lex+parse shared by the typecheck walk and the

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -39,6 +39,7 @@ import @vibe/compiler/runtime/eval_loader {
 }
 
 import ./typecheck_fs.vibe {
+  build_trait_aware_import_env,
   ensure_fingerprint_fs_impl,
   load_persistent_dep_list,
   load_persistent_leaf_fingerprint,
@@ -298,121 +299,17 @@ fn lookup_env_cache(cache: Array[(String, TypeEnv)], path: String) -> Option[Typ
   go(0)
 }
 
-fn resolve_cached_import_path(base_dir: String, raw_path: String, cache: Array[(String, TypeEnv)]) -> String {
-  let candidates = resolve_import_path_candidates(base_dir, raw_path)
-  let mut selected = ""
-  let mut i = 0
-  while i < Array::length(candidates) && selected == "" {
-    let candidate = Array::get(candidates, i)
-    match lookup_env_cache(cache, candidate) {
-      Some(_) => {
-        selected = candidate
-      },
-      None => ()
-    }
-    i = i + 1
-  }
-  if selected == "" {
-    resolve_import_path(base_dir, raw_path)
-  } else {
-    selected
-  }
-}
-
 export fn db_check_env(db: TypeDb, path: String) -> Option[TypeEnv] {
   match unwrap_db(db) {
     TypeDbState(_, cache, _, _, _, _, _, _, _, _) => lookup_env_cache(cache, path)
   }
 }
 
-fn starts_with_upper(name: String) -> Bool {
-  if String::length(name) == 0 {
-    false
-  } else {
-    let c = String::char_code_at(name, 0)
-    c >= 65 && c <= 90
-  }
-}
-
-fn type_returns_name(ty: Type, type_name: String) -> Bool {
-  match ty {
-    CtEnum(name) => name == type_name,
-    CtNamed(name, _) => name == type_name,
-    CtFn(_, ret, _) => type_returns_name(ret, type_name),
-    CtForAll(_, _, body) => type_returns_name(body, type_name),
-    _ => false
-  }
-}
-
-fn bind_enum_constructor_companions(acc: TypeEnv, dep_bindings: Array[(String, Type)], enum_name: String) -> TypeEnv {
-  let mut out = acc
-  let mut i = 0
-  while i < Array::length(dep_bindings) {
-    let (candidate_name, candidate_ty) = Array::get(dep_bindings, i)
-    if candidate_name != enum_name && starts_with_upper(candidate_name) && type_returns_name(candidate_ty, enum_name) {
-      out = env_bind(out, candidate_name, candidate_ty)
-    }
-    i = i + 1
-  }
-  out
-}
-
-fn bind_import_names_from_cache(acc: TypeEnv, resolved: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)]) -> TypeEnv {
-  let dep_env = match lookup_env_cache(cache, resolved) {
-    Some(e) => e,
-    None => EnvEmpty
-  }
-  let dep_bindings = env_flat_bindings(dep_env)
-  let nlen = Array::length(names)
-  let rec bind_names: (Int, TypeEnv) -> TypeEnv = (j, nacc) -> {
-    if j >= nlen {
-      nacc
-    } else {
-      let (name, alias) = Array::get(names, j)
-      let bound_name = match alias {
-        Some(a) => a,
-        None => name
-      }
-      let ty = match env_lookup_flat(dep_bindings, name) {
-        Some(t) => t,
-        None => CtUnknown
-      }
-      let with_name = env_bind(nacc, bound_name, ty)
-      let with_companions = match ty {
-        CtEnum(enum_name) => bind_enum_constructor_companions(with_name, dep_bindings, enum_name),
-        _ => if starts_with_upper(name) {
-          bind_enum_constructor_companions(with_name, dep_bindings, name)
-        } else {
-          with_name
-        }
-      }
-      bind_names(j + 1, with_companions)
-    }
-  }
-  bind_names(0, acc)
-}
-
-fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv {
-  let len = Array::length(stmts)
-  let rec go: (Int, TypeEnv) -> TypeEnv = (i, acc) -> {
-    if i >= len {
-      acc
-    } else {
-      let next = match Array::get(stmts, i) {
-        SImport(raw_path, names) => {
-          let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache(acc, resolved, names, cache)
-        },
-        SReExport(raw_path, names) => {
-          let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache(acc, resolved, names, cache)
-        },
-        _ => acc
-      }
-      go(i + 1, next)
-    }
-  }
-  go(0, EnvEmpty)
+/// The in-memory TypeDb accepts caller-provided modules. Delegate its import
+/// assembly to the trait-aware FS implementation rather than silently dropping
+/// trait declarations and impls from those module environments.
+fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception {
+  build_trait_aware_import_env(stmts, base_dir, cache)
 }
 
 fn upsert_env_cache(cache: Array[(String, TypeEnv)], path: String, env: TypeEnv) -> Array[(String, TypeEnv)] {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -242,11 +242,11 @@ fn trait_projection_add_mapping(mappings: Array[(String, String)], canonical: St
 /// Keep these claims across every import in a module: otherwise two unrelated
 /// traits imported as the same local name would leave one definition and the
 /// other's impls/methods in the TypeEnv, depending on import order.
-fn trait_projection_claim_local(claims: Array[(String, String)], canonical: String) -> Option[String] {
+fn trait_projection_claim_local(claims: Array[(String, String, Bool)], canonical: String) -> Option[String] {
   let mut i = 0
   let mut found = None
   while i < Array::length(claims) && found == None {
-    let (candidate_canonical, local_name) = Array::get(claims, i)
+    let (candidate_canonical, local_name, _) = Array::get(claims, i)
     if candidate_canonical == canonical {
       found = Some(local_name)
     } else {
@@ -256,13 +256,13 @@ fn trait_projection_claim_local(claims: Array[(String, String)], canonical: Stri
   found
 }
 
-fn trait_projection_claim_owner(claims: Array[(String, String)], local_name: String) -> Option[String] {
+fn trait_projection_claim_owner(claims: Array[(String, String, Bool)], local_name: String) -> Option[(String, Bool)] {
   let mut i = 0
   let mut found = None
   while i < Array::length(claims) && found == None {
-    let (canonical, candidate_local) = Array::get(claims, i)
+    let (canonical, candidate_local, explicit_alias) = Array::get(claims, i)
     if candidate_local == local_name {
-      found = Some(canonical)
+      found = Some((canonical, explicit_alias))
     } else {
       i = i + 1
     }
@@ -270,23 +270,28 @@ fn trait_projection_claim_owner(claims: Array[(String, String)], local_name: Str
   found
 }
 
-fn trait_projection_claim_mappings(claims: Array[(String, String)], resolved: String, mappings: Array[(String, String)], unresolved: Array[String]) -> Unit {
+fn trait_projection_claim_mappings(claims: Array[(String, String, Bool)], resolved: String, mappings: Array[(String, String)], unresolved: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(mappings) {
     let (source_name, local_name) = Array::get(mappings, i)
     let canonical = String::concat(String::concat(resolved, "::"), source_name)
+    let explicit_alias = source_name != local_name
     match (trait_projection_claim_local(claims, canonical), trait_projection_claim_owner(claims, local_name)) {
       (Some(existing), _) => if existing != local_name {
         Array::push(unresolved, String::concat(String::concat(String::concat("ambiguous trait import '", canonical), "': aliases '"), String::concat(existing, String::concat("' and '", String::concat(local_name, "'")))))
       } else {
         ()
       },
-      (None, Some(owner)) => if owner != canonical {
+      (None, Some((owner, owner_explicit))) => if owner != canonical && (owner_explicit || explicit_alias) {
+        // Same-spelled, unaliased traits retain the language's historical
+        // name-based identity across re-export modules. An explicit alias is
+        // different: merging two canonical names through it would silently
+        // mix their impl and method authority.
         Array::push(unresolved, String::concat(String::concat(String::concat("ambiguous trait import alias '", local_name), "': used for '"), String::concat(owner, String::concat("' and '", String::concat(canonical, "'")))))
       } else {
-        Array::push(claims, (canonical, local_name))
+        Array::push(claims, (canonical, local_name, explicit_alias))
       },
-      (None, None) => Array::push(claims, (canonical, local_name))
+      (None, None) => Array::push(claims, (canonical, local_name, explicit_alias))
     }
     i = i + 1
   }
@@ -626,7 +631,7 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
   out
 }
 
-fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String)]) -> TypeEnv {
+fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String, Bool)]) -> TypeEnv {
   let cached = lookup_env_cache(cache, resolved)
   let dep_env = match cached {
     Some(e) => e,

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -238,6 +238,60 @@ fn trait_projection_add_mapping(mappings: Array[(String, String)], canonical: St
   }
 }
 
+/// A local trait spelling owns exactly one dependency-qualified authority.
+/// Keep these claims across every import in a module: otherwise two unrelated
+/// traits imported as the same local name would leave one definition and the
+/// other's impls/methods in the TypeEnv, depending on import order.
+fn trait_projection_claim_local(claims: Array[(String, String)], canonical: String) -> Option[String] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(claims) && found == None {
+    let (candidate_canonical, local_name) = Array::get(claims, i)
+    if candidate_canonical == canonical {
+      found = Some(local_name)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn trait_projection_claim_owner(claims: Array[(String, String)], local_name: String) -> Option[String] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(claims) && found == None {
+    let (canonical, candidate_local) = Array::get(claims, i)
+    if candidate_local == local_name {
+      found = Some(canonical)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn trait_projection_claim_mappings(claims: Array[(String, String)], resolved: String, mappings: Array[(String, String)], unresolved: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(mappings) {
+    let (source_name, local_name) = Array::get(mappings, i)
+    let canonical = String::concat(String::concat(resolved, "::"), source_name)
+    match (trait_projection_claim_local(claims, canonical), trait_projection_claim_owner(claims, local_name)) {
+      (Some(existing), _) => if existing != local_name {
+        Array::push(unresolved, String::concat(String::concat(String::concat("ambiguous trait import '", canonical), "': aliases '"), String::concat(existing, String::concat("' and '", String::concat(local_name, "'")))))
+      } else {
+        ()
+      },
+      (None, Some(owner)) => if owner != canonical {
+        Array::push(unresolved, String::concat(String::concat(String::concat("ambiguous trait import alias '", local_name), "': used for '"), String::concat(owner, String::concat("' and '", String::concat(canonical, "'")))))
+      } else {
+        Array::push(claims, (canonical, local_name))
+      },
+      (None, None) => Array::push(claims, (canonical, local_name))
+    }
+    i = i + 1
+  }
+}
+
 fn trait_projection_supers(env: TypeEnv, name: String) -> Array[String] {
   match env {
     EnvEmpty => array_empty(),
@@ -251,6 +305,39 @@ fn trait_projection_supers(env: TypeEnv, name: String) -> Array[String] {
     EnvTraitImplGen(_, _, _, _, rest) => trait_projection_supers(rest, name),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => trait_projection_supers(rest, name)
+  }
+}
+
+fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: String, mappings: Array[(String, String)]) -> Unit {
+  match dep_env {
+    EnvEmpty => (),
+    EnvBind(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
+    EnvTraitDef(_, _, _, _, rest, _, _) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
+    EnvTraitImpl(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
+    EnvTraitImplGen(candidate, _, bounds, _, rest) => {
+      if candidate == trait_name {
+        let mut i = 0
+        while i < Array::length(bounds) {
+          let (_, labels) = Array::get(bounds, i)
+          let mut j = 0
+          while j < Array::length(labels) {
+            let label = Array::get(labels, j)
+            if trait_defined(dep_env, label) {
+              trait_projection_add_mapping(mappings, label, label)
+            } else {
+              ()
+            }
+            j = j + 1
+          }
+          i = i + 1
+        }
+      } else {
+        ()
+      }
+      trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
+    },
+    EnvFlat(_) => (),
+    EnvCached(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
   }
 }
 
@@ -396,6 +483,7 @@ fn dependency_trait_projection_mappings(dep_env: TypeEnv, dep_bindings: Array[(S
   while cursor < Array::length(mappings) {
     let (canonical, _) = Array::get(mappings, cursor)
     let supers = trait_projection_supers(dep_env, canonical)
+    trait_projection_collect_generic_impl_bounds(dep_env, canonical, mappings)
     let mut j = 0
     while j < Array::length(supers) {
       let super_name = Array::get(supers, j)
@@ -538,7 +626,7 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
   out
 }
 
-fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> TypeEnv {
+fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String)]) -> TypeEnv {
   let cached = lookup_env_cache(cache, resolved)
   let dep_env = match cached {
     Some(e) => e,
@@ -548,6 +636,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
   // Explicit trait aliases must be known before values are bound: a selected
   // value can mention the trait before its `trait X as Local` row appears.
   let trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, unresolved)
+  trait_projection_claim_mappings(trait_claims, resolved, trait_mappings, unresolved)
   // Whether the dependency was CHECKED, not whether it happens to bind any
   // values. A module that exports only types or only traits is checked and
   // cached, and its flat value environment is legitimately empty -- deriving
@@ -594,14 +683,28 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
   bind_names(0, prepend_dependency_trait_nodes(dep_env, trait_mappings, acc))
 }
 
-fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv {
-  build_import_env_collecting(stmts, base_dir, cache, array_empty())
+/// Shared by the filesystem and in-memory TypeDb lanes. The latter accepts
+/// caller-provided source modules, so it must not fall back to value-only
+/// imports once global trait-bound enforcement is enabled.
+export fn build_trait_aware_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception {
+  let unresolved = array_empty()
+  let env = build_import_env_collecting(stmts, base_dir, cache, unresolved)
+  if Array::length(unresolved) == 0 {
+    env
+  } else {
+    throw(Array::get(unresolved, 0))
+  }
+}
+
+fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception {
+  build_trait_aware_import_env(stmts, base_dir, cache)
 }
 
 /// `build_import_env`, additionally collecting the imported names the
 /// dependency does not export (#1521 -- see
 /// `bind_import_names_from_cache_collecting`).
 fn build_import_env_collecting(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> TypeEnv {
+  let trait_claims = array_empty()
   let len = Array::length(stmts)
   let rec go: (Int, TypeEnv) -> TypeEnv = (i, acc) -> {
     if i >= len {
@@ -610,11 +713,11 @@ fn build_import_env_collecting(stmts: Array[Stmt], base_dir: String, cache: Arra
       let next = match Array::get(stmts, i) {
         SImport(raw_path, names) => {
           let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved)
+          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved, trait_claims)
         },
         SReExport(raw_path, names) => {
           let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved)
+          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved, trait_claims)
         },
         _ => acc
       }
@@ -1501,6 +1604,7 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
   while cursor < Array::length(mappings) {
     let (name, _) = Array::get(mappings, cursor)
     let supers = trait_projection_supers(checked_env, name)
+    trait_projection_collect_generic_impl_bounds(checked_env, name, mappings)
     let mut j = 0
     while j < Array::length(supers) {
       let super_name = Array::get(supers, j)

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -27,12 +27,14 @@ import @vibe/compiler/core {
   dir_of_path,
   env_bind,
   env_flat_bindings,
+  env_lookup,
   env_lookup_flat,
   normalize_path,
   resolution_env_seed,
   resolve_import_path,
   resolve_import_path_candidates,
-  str_lt
+  str_lt,
+  trait_defined
 }
 
 // #946(4): inline-wasm codegen validation (lane/align/etc. errors) runs as
@@ -149,14 +151,14 @@ fn type_returns_name(ty: Type, type_name: String) -> Bool {
 /// coincidence) but "unknown name: Json::string" for the other 8 of the
 /// 11 documented accessors. The bundle-merge lane resolves these by name
 /// against the merged unit and never had the gap; only this FS lane did.
-fn bind_enum_constructor_companions(acc: TypeEnv, dep_bindings: Array[(String, Type)], enum_name: String) -> TypeEnv {
+fn bind_enum_constructor_companions(acc: TypeEnv, dep_bindings: Array[(String, Type)], enum_name: String, trait_mappings: Array[(String, String)]) -> TypeEnv {
   let qual_prefix = String::concat(enum_name, "::")
   let mut out = acc
   let mut i = 0
   while i < Array::length(dep_bindings) {
     let (candidate_name, candidate_ty) = Array::get(dep_bindings, i)
     if candidate_name != enum_name && starts_with_upper(candidate_name) && (type_returns_name(candidate_ty, enum_name) || String::starts_with(candidate_name, qual_prefix)) {
-      out = env_bind(out, candidate_name, candidate_ty)
+      out = env_bind(out, candidate_name, trait_projection_map_type_bounds(candidate_ty, trait_mappings))
     }
     i = i + 1
   }
@@ -192,6 +194,350 @@ fn bind_enum_constructor_companions(acc: TypeEnv, dep_bindings: Array[(String, T
 /// therefore reported here, with the same message as a name that never
 /// existed: from the importer's side those are the same fact, "the
 /// dependency does not export this name".
+
+//# Trait-aware dependency projection (#1549)
+
+/// Trait declaration/implementation authority is not part of
+/// `env_flat_bindings`, so importing a bounded value used to drop the exact
+/// declarations needed to check that value at its consumer. This projection is
+/// intentionally limited to TypeEnv's trait nodes: typedef and effect
+/// declarations have different transport contracts.
+fn trait_projection_mapping(mappings: Array[(String, String)], canonical: String) -> Option[String] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(mappings) && found == None {
+    let (source_name, local_name) = Array::get(mappings, i)
+    if source_name == canonical {
+      found = Some(local_name)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn trait_projection_local_owner(mappings: Array[(String, String)], local_name: String) -> Option[String] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(mappings) && found == None {
+    let (source_name, candidate_local) = Array::get(mappings, i)
+    if candidate_local == local_name {
+      found = Some(source_name)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn trait_projection_add_mapping(mappings: Array[(String, String)], canonical: String, local_name: String) -> Unit {
+  if trait_projection_mapping(mappings, canonical) == None {
+    Array::push(mappings, (canonical, local_name))
+  } else {
+    ()
+  }
+}
+
+fn trait_projection_supers(env: TypeEnv, name: String) -> Array[String] {
+  match env {
+    EnvEmpty => array_empty(),
+    EnvBind(_, _, rest) => trait_projection_supers(rest, name),
+    EnvTraitDef(candidate, supers, _, _, rest, _, _) => if candidate == name {
+      supers
+    } else {
+      trait_projection_supers(rest, name)
+    },
+    EnvTraitImpl(_, _, rest) => trait_projection_supers(rest, name),
+    EnvTraitImplGen(_, _, _, _, rest) => trait_projection_supers(rest, name),
+    EnvFlat(_) => array_empty(),
+    EnvCached(_, _, rest) => trait_projection_supers(rest, name)
+  }
+}
+
+fn trait_projection_collect_type_bounds(ty: Type, mappings: Array[(String, String)], dep_env: TypeEnv) -> Unit {
+  match ty {
+    CtForAll(_, bounds, body) => {
+      let mut i = 0
+      while i < Array::length(bounds) {
+        let (_, labels) = Array::get(bounds, i)
+        let mut j = 0
+        while j < Array::length(labels) {
+          let label = Array::get(labels, j)
+          if trait_defined(dep_env, label) {
+            trait_projection_add_mapping(mappings, label, label)
+          } else {
+            ()
+          }
+          j = j + 1
+        }
+        i = i + 1
+      }
+      trait_projection_collect_type_bounds(body, mappings, dep_env)
+    },
+    CtFn(args, ret, _) => {
+      let mut i = 0
+      while i < Array::length(args) {
+        trait_projection_collect_type_bounds(Array::get(args, i), mappings, dep_env)
+        i = i + 1
+      }
+      trait_projection_collect_type_bounds(ret, mappings, dep_env)
+    },
+    CtTuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        trait_projection_collect_type_bounds(Array::get(items, i), mappings, dep_env)
+        i = i + 1
+      }
+    },
+    CtArray(item) => trait_projection_collect_type_bounds(item, mappings, dep_env),
+    CtOption(item) => trait_projection_collect_type_bounds(item, mappings, dep_env),
+    CtNamed(_, args) => {
+      let mut i = 0
+      while i < Array::length(args) {
+        trait_projection_collect_type_bounds(Array::get(args, i), mappings, dep_env)
+        i = i + 1
+      }
+    },
+    _ => ()
+  }
+}
+
+/// Rewrite every reachable Type that crosses the selected import boundary.
+/// In particular, a value's `CtForAll` labels must agree with the local alias
+/// of the projected trait authority; keeping the dependency spelling makes an
+/// otherwise valid alias fail closed as an unknown trait at use sites.
+fn trait_projection_map_type_bounds(ty: Type, mappings: Array[(String, String)]) -> Type {
+  match ty {
+    CtForAll(vars, bounds, body) => CtForAll(vars, trait_projection_map_bound_rows(bounds, mappings), trait_projection_map_type_bounds(body, mappings)),
+    CtFn(args, ret, effects) => {
+      let mapped_args = array_empty()
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(mapped_args, trait_projection_map_type_bounds(Array::get(args, i), mappings))
+        i = i + 1
+      }
+      CtFn(mapped_args, trait_projection_map_type_bounds(ret, mappings), effects)
+    },
+    CtTuple(items) => {
+      let mapped_items = array_empty()
+      let mut i = 0
+      while i < Array::length(items) {
+        Array::push(mapped_items, trait_projection_map_type_bounds(Array::get(items, i), mappings))
+        i = i + 1
+      }
+      CtTuple(mapped_items)
+    },
+    CtArray(item) => CtArray(trait_projection_map_type_bounds(item, mappings)),
+    CtOption(item) => CtOption(trait_projection_map_type_bounds(item, mappings)),
+    CtNamed(name, args) => {
+      let mapped_args = array_empty()
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(mapped_args, trait_projection_map_type_bounds(Array::get(args, i), mappings))
+        i = i + 1
+      }
+      CtNamed(name, mapped_args)
+    },
+    _ => ty
+  }
+}
+
+/// Explicit trait selections win regardless of their position among selected
+/// values. A second pass then imports only traits required by selected value
+/// schemes. Conflicting aliases fail closed instead of making import order an
+/// unobservable authority choice.
+fn dependency_trait_projection_mappings(dep_env: TypeEnv, dep_bindings: Array[(String, Type)], names: Array[(String, Option[String])], unresolved: Array[String]) -> Array[(String, String)] {
+  let mappings = array_empty()
+  let mut i = 0
+  // Pass one: reserve explicit trait aliases before inspecting value bounds.
+  while i < Array::length(names) {
+    let (name, alias) = Array::get(names, i)
+    if trait_defined(dep_env, name) {
+      let local_name = match alias {
+        Some(value) => value,
+        None => name
+      }
+      match (trait_projection_mapping(mappings, name), trait_projection_local_owner(mappings, local_name)) {
+        (Some(existing), _) => if existing != local_name {
+          Array::push(unresolved, String::concat(String::concat(String::concat("ambiguous trait import '", name), "': aliases '"), String::concat(existing, String::concat("' and '", String::concat(local_name, "'")))))
+        } else {
+          ()
+        },
+        (None, Some(owner)) => if owner != name {
+          Array::push(unresolved, String::concat(String::concat(String::concat("ambiguous trait import alias '", local_name), "': used for '"), String::concat(owner, String::concat("' and '", String::concat(name, "'")))))
+        } else {
+          trait_projection_add_mapping(mappings, name, local_name)
+        },
+        (None, None) => trait_projection_add_mapping(mappings, name, local_name)
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  // Pass two: values import only the trait labels their reachable Type schemes
+  // require. Explicit aliases above therefore always retain their spelling.
+  i = 0
+  while i < Array::length(names) {
+    let (name, _) = Array::get(names, i)
+    if !trait_defined(dep_env, name) {
+      match env_lookup_flat(dep_bindings, name) {
+        Some(ty) => trait_projection_collect_type_bounds(ty, mappings, dep_env),
+        None => ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  // Selected traits bring their supertrait closure. Unselected supers retain
+  // their canonical source spelling because they have no explicit local alias.
+  let mut cursor = 0
+  while cursor < Array::length(mappings) {
+    let (canonical, _) = Array::get(mappings, cursor)
+    let supers = trait_projection_supers(dep_env, canonical)
+    let mut j = 0
+    while j < Array::length(supers) {
+      let super_name = Array::get(supers, j)
+      if trait_defined(dep_env, super_name) {
+        trait_projection_add_mapping(mappings, super_name, super_name)
+      } else {
+        ()
+      }
+      j = j + 1
+    }
+    cursor = cursor + 1
+  }
+  mappings
+}
+
+fn trait_projection_map_bound_rows(bounds: Array[(Int, Array[String])], mappings: Array[(String, String)]) -> Array[(Int, Array[String])] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(bounds) {
+    let (param, labels) = Array::get(bounds, i)
+    let mapped_labels = array_empty()
+    let mut j = 0
+    while j < Array::length(labels) {
+      let label = Array::get(labels, j)
+      Array::push(mapped_labels, match trait_projection_mapping(mappings, label) {
+        Some(mapped) => mapped,
+        None => label
+      })
+      j = j + 1
+    }
+    Array::push(out, (param, mapped_labels))
+    i = i + 1
+  }
+  out
+}
+
+fn trait_projection_map_method_gens(method_gens: Array[(String, Array[String], Array[(String, Array[String])])], mappings: Array[(String, String)]) -> Array[(String, Array[String], Array[(String, Array[String])])] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(method_gens) {
+    let (name, params, bounds) = Array::get(method_gens, i)
+    Array::push(out, (name, params, trait_projection_map_method_bound_rows(bounds, mappings)))
+    i = i + 1
+  }
+  out
+}
+
+fn trait_projection_map_method_bound_rows(bounds: Array[(String, Array[String])], mappings: Array[(String, String)]) -> Array[(String, Array[String])] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(bounds) {
+    let (param, labels) = Array::get(bounds, i)
+    let mapped_labels = array_empty()
+    let mut j = 0
+    while j < Array::length(labels) {
+      let label = Array::get(labels, j)
+      Array::push(mapped_labels, match trait_projection_mapping(mappings, label) {
+        Some(mapped) => mapped,
+        None => label
+      })
+      j = j + 1
+    }
+    Array::push(out, (param, mapped_labels))
+    i = i + 1
+  }
+  out
+}
+
+fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, String)], tail: TypeEnv) -> TypeEnv {
+  // Preserve every generic implementation in source order. Its parameters and
+  // bounds are semantic payload, so deduplicating by erased target spelling
+  // could silently change obligation satisfaction.
+  let retained = array_empty()
+  let seen_defs = array_empty()
+  let mut cur = dep_env
+  let mut done = false
+  while !done {
+    match cur {
+      EnvEmpty => {
+        done = true
+      },
+      EnvBind(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitDef(name, supers, is_auto, methods, rest, params, method_gens) => {
+        match trait_projection_mapping(mappings, name) {
+          Some(local_name) => if !contains_str(seen_defs, local_name) {
+            let local_supers = array_empty()
+            let mut j = 0
+            while j < Array::length(supers) {
+              let super_name = Array::get(supers, j)
+              Array::push(local_supers, match trait_projection_mapping(mappings, super_name) {
+                Some(mapped) => mapped,
+                None => super_name
+              })
+              j = j + 1
+            }
+            Array::push(retained, EnvTraitDef(local_name, local_supers, is_auto, methods, EnvEmpty, params, trait_projection_map_method_gens(method_gens, mappings)))
+            Array::push(seen_defs, local_name)
+          } else {
+            ()
+          },
+          None => ()
+        }
+        cur = rest
+      },
+      EnvTraitImpl(name, target, rest) => {
+        match trait_projection_mapping(mappings, name) {
+          Some(local_name) => Array::push(retained, EnvTraitImpl(local_name, trait_projection_map_type_bounds(target, mappings), EnvEmpty)),
+          None => ()
+        }
+        cur = rest
+      },
+      EnvTraitImplGen(name, params, bounds, target, rest) => {
+        match trait_projection_mapping(mappings, name) {
+          Some(local_name) => Array::push(retained, EnvTraitImplGen(local_name, params, trait_projection_map_method_bound_rows(bounds, mappings), trait_projection_map_type_bounds(target, mappings), EnvEmpty)),
+          None => ()
+        }
+        cur = rest
+      },
+      EnvFlat(_) => {
+        done = true
+      },
+      EnvCached(_, _, rest) => {
+        cur = rest
+      }
+    }
+  }
+  let mut out = tail
+  let mut i = Array::length(retained) - 1
+  while i >= 0 {
+    out = match Array::get(retained, i) {
+      EnvTraitDef(name, supers, is_auto, methods, _, params, method_gens) => EnvTraitDef(name, supers, is_auto, methods, out, params, method_gens),
+      EnvTraitImpl(name, target, _) => EnvTraitImpl(name, target, out),
+      EnvTraitImplGen(name, params, bounds, target, _) => EnvTraitImplGen(name, params, bounds, target, out),
+      _ => out
+    }
+    i = i - 1
+  }
+  out
+}
+
 fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> TypeEnv {
   let cached = lookup_env_cache(cache, resolved)
   let dep_env = match cached {
@@ -199,6 +545,9 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
     None => EnvEmpty
   }
   let dep_bindings = env_flat_bindings(dep_env)
+  // Explicit trait aliases must be known before values are bound: a selected
+  // value can mention the trait before its `trait X as Local` row appears.
+  let trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, unresolved)
   // Whether the dependency was CHECKED, not whether it happens to bind any
   // values. A module that exports only types or only traits is checked and
   // cached, and its flat value environment is legitimately empty -- deriving
@@ -220,7 +569,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
         None => name
       }
       let ty = match env_lookup_flat(dep_bindings, name) {
-        Some(t) => t,
+        Some(t) => trait_projection_map_type_bounds(t, trait_mappings),
         None => {
           if dep_known && !starts_with_upper(name) {
             Array::push(unresolved, String::concat(String::concat(String::concat("imported name '", name), "' is not exported by '"), String::concat(raw_path, "'")))
@@ -232,9 +581,9 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       }
       let with_name = env_bind(nacc, bound_name, ty)
       let with_companions = match ty {
-        CtEnum(enum_name) => bind_enum_constructor_companions(with_name, dep_bindings, enum_name),
+        CtEnum(enum_name) => bind_enum_constructor_companions(with_name, dep_bindings, enum_name, trait_mappings),
         _ => if starts_with_upper(name) {
-          bind_enum_constructor_companions(with_name, dep_bindings, name)
+          bind_enum_constructor_companions(with_name, dep_bindings, name, trait_mappings)
         } else {
           with_name
         }
@@ -242,7 +591,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       bind_names(j + 1, with_companions)
     }
   }
-  bind_names(0, acc)
+  bind_names(0, prepend_dependency_trait_nodes(dep_env, trait_mappings, acc))
 }
 
 fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv {
@@ -1097,6 +1446,83 @@ fn interface_public_value_names(stmts: Array[Stmt]) -> Array[String] {
   interface_sorted_unique(names)
 }
 
+/// Trait and impl authority is published only for explicitly exported traits,
+/// plus traits required by exported value schemes and their supertrait closure.
+/// This mirrors selected import projection without widening the interface to
+/// typedef or effect transport.
+fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Array[String] {
+  let mappings = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      STrait(true, name, _, _, _, _) => trait_projection_add_mapping(mappings, name, name),
+      SExport(items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let name = Array::get(items, j)
+          if trait_defined(checked_env, name) {
+            trait_projection_add_mapping(mappings, name, name)
+          } else {
+            ()
+          }
+          j = j + 1
+        }
+      },
+      SReExport(_, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let (source_name, alias) = Array::get(items, j)
+          let local_name = match alias {
+            Some(value) => value,
+            None => source_name
+          }
+          if trait_defined(checked_env, local_name) {
+            trait_projection_add_mapping(mappings, local_name, local_name)
+          } else {
+            ()
+          }
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  let values = interface_public_value_names(stmts)
+  i = 0
+  while i < Array::length(values) {
+    match env_lookup(checked_env, Array::get(values, i)) {
+      Some(ty) => trait_projection_collect_type_bounds(ty, mappings, checked_env),
+      None => ()
+    }
+    i = i + 1
+  }
+  let mut cursor = 0
+  while cursor < Array::length(mappings) {
+    let (name, _) = Array::get(mappings, cursor)
+    let supers = trait_projection_supers(checked_env, name)
+    let mut j = 0
+    while j < Array::length(supers) {
+      let super_name = Array::get(supers, j)
+      if trait_defined(checked_env, super_name) {
+        trait_projection_add_mapping(mappings, super_name, super_name)
+      } else {
+        ()
+      }
+      j = j + 1
+    }
+    cursor = cursor + 1
+  }
+  let names = array_empty()
+  i = 0
+  while i < Array::length(mappings) {
+    let (name, _) = Array::get(mappings, i)
+    Array::push(names, name)
+    i = i + 1
+  }
+  interface_sorted_unique(names)
+}
+
 /// #1533: the environment a module PUBLISHES to its importers is its export
 /// surface, not its full checked environment. The checked environment binds
 /// every top-level `let`/`fn` -- and, via the import env at its base, every
@@ -1116,31 +1542,50 @@ fn interface_public_value_names(stmts: Array[Stmt]) -> Array[String] {
 /// of #1521 stays open rather than risk rejecting valid code, and the
 /// companion-binding scan over dep_bindings keeps working unchanged.
 ///
-/// Trait nodes ride through untouched; EnvCached wrappers are rebuilt from
-/// the restricted chain (their arrays are acceleration state, same rule as
-/// the serializer's). Persistent-cache staleness is not a concern: the cache
-/// version tag folds in codegen_fingerprint(), so envs published before this
-/// restriction live under different keys.
-fn restrict_env_to_export_surface(surface: Array[String], env: TypeEnv) -> TypeEnv {
+/// Trait definitions and implementations are published only for the selected
+/// trait surface. EnvCached wrappers are rebuilt from the restricted chain
+/// (their arrays are acceleration state, same rule as the serializer's).
+fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: Array[String], env: TypeEnv) -> TypeEnv {
   match env {
     EnvEmpty => EnvEmpty,
     EnvBind(name, ty, rest) => {
-      let restricted = restrict_env_to_export_surface(surface, rest)
-      if starts_with_upper(name) || bsearch_leftmost(surface, name) >= 0 {
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      if starts_with_upper(name) || bsearch_leftmost(value_surface, name) >= 0 {
         EnvBind(name, ty, restricted)
       } else {
         restricted
       }
     },
-    EnvTraitDef(name, supers, is_auto, methods, rest, params, method_gens) => EnvTraitDef(name, supers, is_auto, methods, restrict_env_to_export_surface(surface, rest), params, method_gens),
-    EnvTraitImpl(name, target, rest) => EnvTraitImpl(name, target, restrict_env_to_export_surface(surface, rest)),
-    EnvTraitImplGen(name, params, bounds, target, rest) => EnvTraitImplGen(name, params, bounds, target, restrict_env_to_export_surface(surface, rest)),
+    EnvTraitDef(name, supers, is_auto, methods, rest, params, method_gens) => {
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      if bsearch_leftmost(trait_surface, name) >= 0 {
+        EnvTraitDef(name, supers, is_auto, methods, restricted, params, method_gens)
+      } else {
+        restricted
+      }
+    },
+    EnvTraitImpl(name, target, rest) => {
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      if bsearch_leftmost(trait_surface, name) >= 0 {
+        EnvTraitImpl(name, target, restricted)
+      } else {
+        restricted
+      }
+    },
+    EnvTraitImplGen(name, params, bounds, target, rest) => {
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      if bsearch_leftmost(trait_surface, name) >= 0 {
+        EnvTraitImplGen(name, params, bounds, target, restricted)
+      } else {
+        restricted
+      }
+    },
     EnvFlat(bindings) => {
       let kept = array_empty()
       let mut i = 0
       while i < Array::length(bindings) {
         let (name, ty) = Array::get(bindings, i)
-        if starts_with_upper(name) || bsearch_leftmost(surface, name) >= 0 {
+        if starts_with_upper(name) || bsearch_leftmost(value_surface, name) >= 0 {
           Array::push(kept, (name, ty))
         } else {
           ()
@@ -1158,7 +1603,7 @@ fn restrict_env_to_export_surface(surface: Array[String], env: TypeEnv) -> TypeE
     // module lane resolves an import over a same-named local (the merge
     // lane shadows correctly), while an `as` alias broke the
     // collect_merged_stmts lane instead. Both are their own bugs.
-    EnvCached(_, _, rest) => restrict_env_to_export_surface(surface, rest)
+    EnvCached(_, _, rest) => restrict_env_to_export_surface(value_surface, trait_surface, rest)
   }
 }
 
@@ -2260,7 +2705,9 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
       // consumer of `Checked`'s env (env cache, persistent store, worker
       // transport, TDRE4, trace identities) is a publication path. The full
       // environment never needs to outlive the check itself.
-      let checked_env = restrict_env_to_export_surface(interface_public_value_names(stmts), full_checked_env)
+      let value_surface = interface_public_value_names(stmts)
+      let trait_surface = interface_public_trait_names(stmts, full_checked_env)
+      let checked_env = restrict_env_to_export_surface(value_surface, trait_surface, full_checked_env)
       let interface_identity = if incremental_interface_trace_enabled() {
         incremental_interface_identity(job.source, checked_env)
       } else {

--- a/lib/@vibe/compiler/tests/compiler_cache_prepare_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_cache_prepare_test.vibe
@@ -61,6 +61,17 @@ test "prepare_modules_cached: warm prepare reuses typecheck cache" {
   assert(eq(db_typecheck_count(db2), count1))
 }
 
+test "prepare_modules_cached: selected generic impl bounds retain dependency authority" {
+  let dep_source = "export trait Marker { mark(Self) -> Int }\ntrait Other\nimpl Other for Int\nimpl [T: Other] Marker for Array[T] { mark(self) -> Int { Array::length(self) } }\nexport fn accept[T: Marker](x: T) -> Int { let _ = x; 1 }"
+  let main_source = "import ./trait_dep.vibe { trait Marker, accept }\nlet result = accept([1])"
+  let sources = [
+    ("trait_dep.vibe", dep_source)
+  ]
+  let cold = prepare_modules_cached(db_new(), "trait_main.vibe", main_source, sources)
+  let warm = prepare_modules_cached(cold, "trait_main.vibe", main_source, sources)
+  assert(eq(db_typecheck_count(warm), db_typecheck_count(cold)))
+}
+
 test "prepare_modules_cached: warm prepare reuses parsed modules" {
   let helper_source = "export let add: (Int, Int) -> Int = (a, b) -> { a + b }"
   let main_source = "import ./helpers.vibe { add }\nlet main: () -> Int = () -> { add(1, 2) }"

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -365,6 +365,56 @@ test "db_typecheck_fs: missing imported trait impl fails cold and with a warm de
   assert(String::contains(warm_error, "no impl `Required` for `Int`"))
 }
 
+test "db_typecheck_fs: different dependency traits cannot share a local alias" {
+  let first_path = "/tmp/vibe_compiler_trait_authority_collision_first.vibe"
+  let second_path = "/tmp/vibe_compiler_trait_authority_collision_second.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_authority_collision_main.vibe"
+  let first_src = "export trait First { tag(Self) -> Int }\nimpl First for Int { tag(self) -> Int { 1 } }"
+  let second_src = "export trait Second { tag(Self) -> Int }\nimpl Second for String { tag(self) -> Int { 2 } }"
+  let main_src = "import ./vibe_compiler_trait_authority_collision_first.vibe { trait First as Local }\nimport ./vibe_compiler_trait_authority_collision_second.vibe { trait Second as Local }"
+  Fs::write_bytes(first_path, string_to_bytes(first_src))
+  Fs::write_bytes(second_path, string_to_bytes(second_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let first_fp = build_test_fingerprint(first_src, array_empty())
+  let second_fp = build_test_fingerprint(second_src, array_empty())
+  let main_fp = build_test_fingerprint(main_src, [
+    (first_path, first_fp),
+    (second_path, second_fp)
+  ])
+  remove_typecheck_fs_cache(first_path, first_src, first_fp)
+  remove_typecheck_fs_cache(second_path, second_src, second_fp)
+  remove_typecheck_fs_cache(main_path, main_src, main_fp)
+  let error = handle {
+    let db = db_set_source(db_set_source(db_set_source(db_new(), first_path, first_src), second_path, second_src), main_path, main_src)
+    let _ = db_typecheck_fs(db, main_path)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(String::contains(error, "ambiguous trait import alias 'Local'"))
+}
+
+test "db_typecheck_fs: selected generic impl bounds retain authority cold and warm" {
+  let dep_path = "/tmp/vibe_compiler_trait_authority_generic_dep.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_authority_generic_main.vibe"
+  let dep_src = "export trait Marker { mark(Self) -> Int }\ntrait Other\nimpl Other for Int\nimpl [T: Other] Marker for Array[T] { mark(self) -> Int { Array::length(self) } }\nexport fn accept[T: Marker](x: T) -> Int { let _ = x; 1 }"
+  let main_src = "import ./vibe_compiler_trait_authority_generic_dep.vibe { trait Marker, accept }\nexport let result = accept([1])"
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  let main_fp = build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ])
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, main_fp)
+  let cold = db_typecheck_fs(db_set_source(db_set_source(db_new(), dep_path, dep_src), main_path, main_src), main_path)
+  assert(db_check_env(cold, main_path) != None)
+  // Force import assembly while preserving the dependency's persistent env.
+  remove_typecheck_fs_cache(main_path, main_src, main_fp)
+  let warm = db_typecheck_fs(db_set_source(db_set_source(db_new(), dep_path, dep_src), main_path, main_src), main_path)
+  assert(db_check_env(warm, main_path) != None)
+}
+
 test "db_typecheck_fs: selected trait alias publishes only its projected authority" {
   let dep_path = "/tmp/vibe_compiler_trait_authority_selected_dep.vibe"
   let main_path = "/tmp/vibe_compiler_trait_authority_selected_main.vibe"

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -10,7 +10,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  TypeEnv, env_lookup
+  Type, TypeEnv, env_lookup, trait_defined
 }
 
 import @vibe/compiler/runtime {
@@ -72,6 +72,44 @@ fn remove_typecheck_fs_cache(path: String, source: String, fingerprint: String) 
   remove_file_if_exists(persistent_module_header_cache_path(path, source_fp))
   remove_file_if_exists(persistent_leaf_fingerprint_cache_path(path, source_fp))
   remove_file_if_exists(persistent_type_env_cache_path(fingerprint))
+}
+
+fn retained_trait_node_tags(env: TypeEnv) -> String {
+  match env {
+    EnvEmpty => "",
+    EnvBind(_, _, rest) => retained_trait_node_tags(rest),
+    EnvTraitDef(name, _, _, _, rest, _, _) => String::concat(String::concat("def:", name), String::concat(";", retained_trait_node_tags(rest))),
+    EnvTraitImpl(name, _, rest) => String::concat(String::concat("impl:", name), String::concat(";", retained_trait_node_tags(rest))),
+    EnvTraitImplGen(name, _, _, _, rest) => String::concat(String::concat("gen:", name), String::concat(";", retained_trait_node_tags(rest))),
+    EnvFlat(_) => "",
+    EnvCached(_, _, rest) => retained_trait_node_tags(rest)
+  }
+}
+
+fn imported_forall_bound_label(env: TypeEnv, name: String) -> String {
+  match env_lookup(env, name) {
+    Some(CtForAll(_, bounds, _)) => if Array::length(bounds) == 1 {
+      let (_, labels) = Array::get(bounds, 0)
+      if Array::length(labels) == 1 {
+        Array::get(labels, 0)
+      } else {
+        ""
+      }
+    } else {
+      ""
+    },
+    _ => ""
+  }
+}
+
+fn typecheck_fs_pair_error(dep_path: String, dep_src: String, main_path: String, main_src: String) -> String with Fs {
+  handle {
+    let db = db_set_source(db_set_source(db_new(), dep_path, dep_src), main_path, main_src)
+    let _ = db_typecheck_fs(db, main_path)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
 }
 
 //# Misc
@@ -267,6 +305,103 @@ test "exact dep projection fails closed when a resolved row is missing" {
     Throw(msg) => msg
   }
   assert(String::contains(message, "type_db: missing resolved dependency environment: workspace/dep.vibe"))
+}
+
+test "exact dep projection gives explicit trait aliases precedence over selected values" {
+  let dep_path = "workspace/dep.vibe"
+  let generic_value = CtForAll([
+    7
+  ], [
+    (7, [
+      "Marker"
+    ])
+  ], CtFn([
+    CtVar(7)
+  ], CtVar(7), None))
+  let dep_env = EnvTraitDef("Marker", [
+  ], false, [
+  ], EnvTraitImpl("Marker", CtInt, EnvBind("accept", generic_value, EnvEmpty)), [
+  ], [
+  ])
+  let value_first = projected_import_env_for_test("import ./dep.vibe { accept, trait Marker as Local }", "workspace/main.vibe", [
+    dep_path
+  ], [
+    (dep_path, dep_env)
+  ])
+  let trait_first = projected_import_env_for_test("import ./dep.vibe { trait Marker as Local, accept }", "workspace/main.vibe", [
+    dep_path
+  ], [
+    (dep_path, dep_env)
+  ])
+  assert(trait_defined(value_first, "Local"))
+  assert(trait_defined(trait_first, "Local"))
+  assert(!trait_defined(value_first, "Marker"))
+  assert(!trait_defined(trait_first, "Marker"))
+  assert(retained_trait_node_tags(value_first) == "def:Local;impl:Local;")
+  assert(retained_trait_node_tags(trait_first) == "def:Local;impl:Local;")
+  assert(imported_forall_bound_label(value_first, "accept") == "Local")
+  assert(imported_forall_bound_label(trait_first, "accept") == "Local")
+}
+
+test "db_typecheck_fs: missing imported trait impl fails cold and with a warm dependency interface" {
+  let dep_path = "/tmp/vibe_compiler_trait_authority_missing_impl_dep.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_authority_missing_impl_main.vibe"
+  let dep_src = "export trait Required\nexport fn accept[T: Required](x: T) -> Int { let _ = x; 1 }"
+  let main_src = "import ./vibe_compiler_trait_authority_missing_impl_dep.vibe { trait Required, accept }\nexport let result = accept(1)"
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  let main_fp = build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ])
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, main_fp)
+  let cold_error = typecheck_fs_pair_error(dep_path, dep_src, main_path, main_src)
+  assert(String::contains(cold_error, "no impl `Required` for `Int`"))
+  // Keep the dependency TypeEnv cache written by the cold run, but force the
+  // root through import assembly again.
+  remove_typecheck_fs_cache(main_path, main_src, main_fp)
+  let warm_error = typecheck_fs_pair_error(dep_path, dep_src, main_path, main_src)
+  assert(String::contains(warm_error, "no impl `Required` for `Int`"))
+}
+
+test "db_typecheck_fs: selected trait alias publishes only its projected authority" {
+  let dep_path = "/tmp/vibe_compiler_trait_authority_selected_dep.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_authority_selected_main.vibe"
+  let dep_src = "export trait Marker\nimpl Marker for Int\nexport fn accept[T: Marker](x: T) -> Int { let _ = x; 1 }"
+  let main_src = "import ./vibe_compiler_trait_authority_selected_dep.vibe { accept, trait Marker as Local }\nexport { Local }\nexport let result = accept(1)"
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  let main_fp = build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ])
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, main_fp)
+  let checked = db_typecheck_fs(db_set_source(db_set_source(db_new(), dep_path, dep_src), main_path, main_src), main_path)
+  match db_check_env(checked, main_path) {
+    Some(env) => {
+      assert(trait_defined(env, "Local"))
+      assert(!trait_defined(env, "Marker"))
+    },
+    None => assert(false)
+  }
+}
+
+test "db_typecheck_fs: duplicate trait aliases are rejected as ambiguous" {
+  let dep_path = "/tmp/vibe_compiler_trait_authority_ambiguous_dep.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_authority_ambiguous_main.vibe"
+  let dep_src = "export trait Marker\nimpl Marker for Int"
+  let main_src = "import ./vibe_compiler_trait_authority_ambiguous_dep.vibe { trait Marker as First, trait Marker as Second }"
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ]))
+  let error = typecheck_fs_pair_error(dep_path, dep_src, main_path, main_src)
+  assert(String::contains(error, "ambiguous trait import 'Marker'"))
 }
 
 test "db_typecheck_fs: source update bypasses current-run cache" {

--- a/lib/@vibe/prelude/builtin_traits.vibe
+++ b/lib/@vibe/prelude/builtin_traits.vibe
@@ -16,6 +16,22 @@ export trait Div
 
 export trait Signed
 
+// `to_string` carries this source-level bound; its runtime lowering remains
+// unchanged, but full import-path bound enforcement needs real witnesses.
+export trait Show
+
+impl Show for Int
+
+impl Show for Float
+
+impl Show for Double
+
+impl Show for Bool
+
+impl Show for Char
+
+impl Show for String
+
 impl Eq for Int
 
 impl Eq for Float

--- a/lib/@vibe/prelude/iterator_test.vibe
+++ b/lib/@vibe/prelude/iterator_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./iterator.vibe {
-  Iterator::all, Iterator::any, Iterator::filter, Iterator::find, Iterator::flatmap, Iterator::fold, Iterator::iter, Iterator::map
+  Iterable, Iterator::all, Iterator::any, Iterator::filter, Iterator::find, Iterator::flatmap, Iterator::fold, Iterator::iter, Iterator::map
 }
 /// A tiny local Iterable (prelude tests must not depend on lib packages;
 /// @vibe/core's List has its own tests in lib/@vibe/core).

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -100,8 +100,8 @@ function supertraitDependencyEdit(project) {
 }
 
 function traitDependencyEdit(project) {
-  // The app does not import the trait name. This independently proves that
-  // hidden method and concrete-impl changes invalidate the v3 transport key.
+  // The app imports neither this private trait nor a value bounded by it, so
+  // selected trait authority must not leak this method/impl edit into v3.
   writeFileSync(join(project, "helper.vibe"), "trait Base\ntrait OtherBase\ntrait Hidden: Base { changed(Self) -> Int }\nimpl Base for Int\nimpl OtherBase for Int\nimpl Hidden for String\nexport fn value() -> Int { 1 }\n");
 }
 
@@ -623,7 +623,7 @@ function run(stage2) {
     expectCounts("trait module private body reuse", traitPrivate.telemetry, 1, 1);
     supertraitDependencyEdit(traitProject);
     const supertraitFallback = check(stage2, traitProject, traitCache, true, "supertrait-dependency-fallback");
-    expectCounts("supertrait-only dependency change fallback", supertraitFallback.telemetry, 2, 0);
+    expectCounts("unselected supertrait dependency change reuses consumer", supertraitFallback.telemetry, 1, 1);
 
     const traitChangeProject = join(work, "trait-change-project");
     const traitChangeCache = join(work, "trait-change-cache");
@@ -631,7 +631,7 @@ function run(stage2) {
     check(stage2, traitChangeProject, traitChangeCache, true, "trait-change-cold");
     traitDependencyEdit(traitChangeProject);
     const traitFallback = check(stage2, traitChangeProject, traitChangeCache, true, "trait-dependency-fallback");
-    expectCounts("trait method/impl dependency change fallback", traitFallback.telemetry, 2, 0);
+    expectCounts("unselected trait method/impl dependency change reuses consumer", traitFallback.telemetry, 1, 1);
 
     const chainProject = join(work, "chain-project");
     const chainCache = join(work, "chain-cache");

--- a/scripts/incremental_invalidation_oracle.mjs
+++ b/scripts/incremental_invalidation_oracle.mjs
@@ -702,14 +702,14 @@ function run(stage2) {
     if (implementationOwnersChanged(implBoundEq, implBoundShow).join(",") !== "library") fail("impl generic bound edit did not change token-stream implementation identity");
     if (interfaceOwnersChanged(implBoundEq, implBoundShow).length !== 0) fail("impl-bound edit changed the exported interface identity even though impls have no export surface bit");
     if (checkedEnvOwnersChanged(implBoundEq, implBoundShow).length !== 0) fail("impl-bound edit changed the value-only checked environment identity");
-    if (persistentTypeEnvTransportOwnersChanged(implBoundEq, implBoundShow).join(",") !== "library") {
-      fail("impl-bound edit did not change the complete persistent TypeEnv transport identity")
+    if (persistentTypeEnvTransportOwnersChanged(implBoundEq, implBoundShow).length !== 0) {
+      fail("unselected Eq impl-bound edit changed the selected persistent TypeEnv transport identity")
     }
     writeFileSync(join(project, "library.vibe"), "import ./base.vibe { base_value }\nexport trait Identity { identity[U: Eq](U) -> U }\nimpl [T: Show] Eq for Array[T]\nexport let library_value = \"changed\"\nfn private_offset() -> Int { 2 }\n");
     const implTargetArray = check("impl_target_array");
     if (interfaceOwnersChanged(implBoundShow, implTargetArray).length !== 0) fail("impl-target edit changed the exported interface identity even though impls have no export surface bit");
-    if (persistentTypeEnvTransportOwnersChanged(implBoundShow, implTargetArray).join(",") !== "library") {
-      fail("impl-target edit did not change the complete persistent TypeEnv transport identity")
+    if (persistentTypeEnvTransportOwnersChanged(implBoundShow, implTargetArray).length !== 0) {
+      fail("unselected Eq impl-target edit changed the selected persistent TypeEnv transport identity")
     }
 
     writeFileSync(join(project, "app.vibe"), "import ./base.vibe { base_value }\nimport ./library.vibe { library_value }\nfn main() -> Int { let _ = library_value\nbase_value(0) }\n");


### PR DESCRIPTION
## Summary
- project selected/exported trait definitions and concrete/generic impl authority through FS and in-memory import assembly
- make explicit aliases order-independent, rewrite imported `CtForAll` bounds, and reject cross-dependency local-name collisions
- close authority over supertraits and generic-impl bounds
- remove the FS-only non-`Send` bound bypass and add cold/warm missing-impl controls

This is the trait slice of #1549. Typedef/effect transport remains follow-up, so this PR does not close the issue.

## Validation
- focused cross-module and prepare-cache tests passed before the current unrelated package-pin resolver failure
- both incremental oracles passed
- formatter, generation freshness, and `git diff --check` passed
- independent final review: safe to integrate; no code blocker

## Known environment issue
Full gate currently stops before affected test compilation with existing `no require pin for @vibe/core in lib/@vibe/compiler/core/sorted_index.vibe`; CI is the clean-environment rerun.