### PR TITLE
perf: attribute and reduce RC codegen heap (#1553)

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -589,7 +589,7 @@ local selfcompileKpi = new Task {
 local measureFsHeap = new Task {
   name = "measure-fs-heap"
   description =
-    "#1553: isolated-cache full-CLI FS guest-memory measurement (--cold --gate is the 3.5 GiB page gate)"
+    "#1553: isolated-cache full-CLI FS guest-memory measurement (--compare requires explicit shared --base; --cold --gate is the 3.5 GiB page gate)"
   cmd = "bash scripts/measure_fs_heap.sh $@"
   acceptsArgs = true
   cache = false

--- a/fixtures/rc_shadow_regression_test.vibe
+++ b/fixtures/rc_shadow_regression_test.vibe
@@ -155,6 +155,13 @@ let shape7 = () -> {
   acc + String::length(Map::get(m, "a"))
 }
 
+// Shape 8 (#1553): the common one-arm residual match must retain pattern
+// scope accounting when its Perceus plan avoids the branch snapshot arrays.
+let shape8 = (n) -> {
+  let pair = (n, n + 1)
+  match pair { (a, b) => a + b }
+}
+
 let main = () -> Int {
   let names = ["a", "b", "c"]
   let effs = [[TInt], [TFn([TInt], TInt)], [TInt]]
@@ -180,6 +187,7 @@ let main = () -> Int {
     acc = acc + shape5(tys)
     acc = acc + shape6(k)
     acc = acc + shape7()
+    acc = acc + shape8(k)
     k = k + 1
   }
   acc

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -57,6 +57,7 @@ import @vibe/compiler/loader {
 import @vibe/compiler/entry/compiler/file_compile {
   compile_file_fs_mode,
   compile_file_fs_mode_break,
+  compile_file_fs_mode_bump_heap_marked,
   compile_file_fs_mode_cached_artifact_input_trace,
   compile_file_fs_mode_coverage,
   compile_file_fs_mode_rc,
@@ -1009,6 +1010,11 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
           compile_file_fs_mode_cached_artifact_input_trace(input_path, entry_name, "no-dce", artifact_input_trace_nonce, artifact_input_trace_checked_error_row_mode, artifact_input_trace_diagnostics_mode, artifact_input_trace_dep_order_seed)
         } else if testmeta_out != "" {
           (compile_file_fs_mode_testmeta(input_path, entry_name, "no-dce", testmeta_out), "")
+        } else if mark_memory {
+          // #1553: bump attribution twin. As with its RC sibling, this is
+          // selected only for explicit heap observation; ordinary VIBE_RC=0
+          // compiles retain the Env-free production helper above.
+          (compile_file_fs_mode_bump_heap_marked(input_path, entry_name), "")
         } else {
           (compile_file_fs_mode(input_path, entry_name, "no-dce"), "")
         }

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -564,6 +564,25 @@ export fn compile_file_fs_mode_rc_heap_marked(entry_path: String, entry_name: St
   bytes
 }
 
+/// #1553 observation-only bump counterpart of
+/// compile_file_fs_mode_rc_heap_marked. It deliberately mirrors the ordinary
+/// compile_file_fs_mode "no-dce" path, including its call boundaries, but is
+/// only selected when VIBE_RC=0 and VIBE_PROFILE_MEMORY_MARKS=1. Production
+/// bump compiles remain Env-free and continue to use compile_file_fs_mode.
+export fn compile_file_fs_mode_bump_heap_marked(entry_path: String, entry_name: String) -> Bytes with Exception + Fs + Env {
+  fs_heap_mark("start")
+  let source_groups = collect_source_groups_fs(entry_path)
+  fs_heap_mark("source_groups")
+  let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
+  let _ = next_db
+  fs_heap_mark("prepared_db")
+  let merged_stmts = build_grouped_merged_stmts(source_groups)
+  fs_heap_mark("merged_stmts")
+  let bytes = compile_wasi_module(merged_stmts, entry_name)
+  fs_heap_mark("codegen_bump")
+  bytes
+}
+
 /// #715/#768 debug variant (VIBE_RC=shadow): same load/merge as
 /// compile_file_fs_mode_rc but with shadow-liveness double-free traps, so an
 /// import-resolving test build's "moving target" free-list corruption becomes a

--- a/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
@@ -36,9 +36,11 @@ fn check_file_fs_mode(entry_path: String) -> Int with Exception + Fs
 fn check_file_fs_mode_from_source_groups(entry_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Int with Exception + Fs
 fn compile_file_fs_mode(entry_path: String, entry_name: String, mode: String) -> Bytes with Exception + Fs
 fn compile_file_fs_mode_rc(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
-// #1553 observation-only heap-mark lane (VIBE_PROFILE_MEMORY_MARKS=1); same
-// pipeline as compile_file_fs_mode_rc, Env only for the runner's mark hook.
+// #1553 observation-only heap-mark lanes (VIBE_PROFILE_MEMORY_MARKS=1); same
+// pipelines as the respective RC/bump FS helpers, Env only for the runner's
+// mark hook.
 fn compile_file_fs_mode_rc_heap_marked(entry_path: String, entry_name: String) -> Bytes with Exception + Fs + Env
+fn compile_file_fs_mode_bump_heap_marked(entry_path: String, entry_name: String) -> Bytes with Exception + Fs + Env
 fn compile_file_fs_mode_rc_shadow(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
 fn compile_file_fs_mode_testmeta(entry_path: String, entry_name: String, mode: String, meta_out: String) -> Bytes with Exception + Fs
 fn entry_cacheable_for_fs(entry_path: String, entry_name: String) -> Bool with Exception + Fs

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -1592,16 +1592,12 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         EIdent(_, _) => 0,
         _ => pc_emit(ctx, scope, scrut)
       }
-      let snap = copy_ints(ctx.remaining)
-      // #705: track the MIN remaining over all arms (see EIf). An arm that
-      // consumes an outer binding (e.g. a param re-stored into a ctor) leaves it
-      // at a lower remaining; leaving the LAST arm's (higher) value made the
-      // scope-end drop double-free that binding on the arm that consumed it.
-      let minrem = copy_ints(snap)
-      let mut a = 0
-      while a < Array::length(arms) {
-        let arm = Array::get(arms, a)
-        restore_prefix(ctx.remaining, snap)
+      // A single arm has no alternative control-flow state to merge. Count and
+      // emit it directly so the overwhelmingly common lowered residual match
+      // avoids the branch snapshot arrays. Empty and multi-arm matches retain
+      // the general path below.
+      if Array::length(arms) == 1 {
+        let arm = Array::get(arms, 0)
         let pnames: Array[String] = [
         ]
         pat_names(arm.0, pnames)
@@ -1622,19 +1618,52 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           pe_scope_end(ctx, Array::get(pids, j), Array::get(pnames, j))
           j = j + 1
         }
-        let mut mi = 0
-        while mi < Array::length(snap) {
-          if Array::get(ctx.remaining, mi) < Array::get(minrem, mi) {
-            Array::set(minrem, mi, Array::get(ctx.remaining, mi))
-          } else {
-            ()
+        0
+      } else {
+        let snap = copy_ints(ctx.remaining)
+        // #705: track the MIN remaining over all arms (see EIf). An arm that
+        // consumes an outer binding (e.g. a param re-stored into a ctor) leaves it
+        // at a lower remaining; leaving the LAST arm's (higher) value made the
+        // scope-end drop double-free that binding on the arm that consumed it.
+        let minrem = copy_ints(snap)
+        let mut a = 0
+        while a < Array::length(arms) {
+          let arm = Array::get(arms, a)
+          restore_prefix(ctx.remaining, snap)
+          let pnames: Array[String] = [
+          ]
+          pat_names(arm.0, pnames)
+          let mut s = scope
+          let pids: Array[Int] = [
+          ]
+          let mut k = 0
+          while k < Array::length(pnames) {
+            let nm = Array::get(pnames, k)
+            let pid = pe_declare(ctx, nm)
+            s = Map::set(s, nm, pid)
+            Array::push(pids, pid)
+            k = k + 1
           }
-          mi = mi + 1
+          pc_emit(ctx, s, arm.1)
+          let mut j = 0
+          while j < Array::length(pids) {
+            pe_scope_end(ctx, Array::get(pids, j), Array::get(pnames, j))
+            j = j + 1
+          }
+          let mut mi = 0
+          while mi < Array::length(snap) {
+            if Array::get(ctx.remaining, mi) < Array::get(minrem, mi) {
+              Array::set(minrem, mi, Array::get(ctx.remaining, mi))
+            } else {
+              ()
+            }
+            mi = mi + 1
+          }
+          a = a + 1
         }
-        a = a + 1
+        restore_prefix(ctx.remaining, minrem)
+        0
       }
-      restore_prefix(ctx.remaining, minrem)
-      0
     },
     EHandle(hbody, arms) => {
       let snap = copy_ints(ctx.remaining)
@@ -1879,15 +1908,11 @@ export fn pc_count(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         EIdent(sx, _) => pc_count_borrow(ctx, scope, sx),
         _ => pc_count(ctx, scope, scrut)
       }
-      let snap_u = copy_ints(ctx.uses)
-      let snap_b = copy_ints(ctx.borrows)
-      let max_u = zeros(Array::length(snap_u))
-      let max_b = zeros(Array::length(snap_b))
-      let mut a = 0
-      while a < Array::length(arms) {
-        let arm = Array::get(arms, a)
-        restore_prefix(ctx.uses, snap_u)
-        restore_prefix(ctx.borrows, snap_b)
+      // A single arm has no alternative counts to merge. Avoid the four
+      // branch snapshot arrays while preserving the general empty/multi-arm
+      // merge path below.
+      if Array::length(arms) == 1 {
+        let arm = Array::get(arms, 0)
         let pnames: Array[String] = [
         ]
         pat_names(arm.0, pnames)
@@ -1900,29 +1925,53 @@ export fn pc_count(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           k = k + 1
         }
         pc_count(ctx, s, arm.1)
-        let mut id = 0
-        while id < Array::length(snap_u) {
-          let du = Array::get(ctx.uses, id) - Array::get(snap_u, id)
-          if du > Array::get(max_u, id) {
-            Array::set(max_u, id, du)
+        0
+      } else {
+        let snap_u = copy_ints(ctx.uses)
+        let snap_b = copy_ints(ctx.borrows)
+        let max_u = zeros(Array::length(snap_u))
+        let max_b = zeros(Array::length(snap_b))
+        let mut a = 0
+        while a < Array::length(arms) {
+          let arm = Array::get(arms, a)
+          restore_prefix(ctx.uses, snap_u)
+          restore_prefix(ctx.borrows, snap_b)
+          let pnames: Array[String] = [
+          ]
+          pat_names(arm.0, pnames)
+          let mut s = scope
+          let mut k = 0
+          while k < Array::length(pnames) {
+            let nm = Array::get(pnames, k)
+            let pid = pc_declare(ctx, nm, false)
+            s = Map::set(s, nm, pid)
+            k = k + 1
           }
-          let db = Array::get(ctx.borrows, id) - Array::get(snap_b, id)
-          if db > Array::get(max_b, id) {
-            Array::set(max_b, id, db)
+          pc_count(ctx, s, arm.1)
+          let mut id = 0
+          while id < Array::length(snap_u) {
+            let du = Array::get(ctx.uses, id) - Array::get(snap_u, id)
+            if du > Array::get(max_u, id) {
+              Array::set(max_u, id, du)
+            }
+            let db = Array::get(ctx.borrows, id) - Array::get(snap_b, id)
+            if db > Array::get(max_b, id) {
+              Array::set(max_b, id, db)
+            }
+            id = id + 1
           }
-          id = id + 1
+          a = a + 1
         }
-        a = a + 1
+        restore_prefix(ctx.uses, snap_u)
+        restore_prefix(ctx.borrows, snap_b)
+        let mut id2 = 0
+        while id2 < Array::length(snap_u) {
+          Array::set(ctx.uses, id2, Array::get(snap_u, id2) + Array::get(max_u, id2))
+          Array::set(ctx.borrows, id2, Array::get(snap_b, id2) + Array::get(max_b, id2))
+          id2 = id2 + 1
+        }
+        0
       }
-      restore_prefix(ctx.uses, snap_u)
-      restore_prefix(ctx.borrows, snap_b)
-      let mut id2 = 0
-      while id2 < Array::length(snap_u) {
-        Array::set(ctx.uses, id2, Array::get(snap_u, id2) + Array::get(max_u, id2))
-        Array::set(ctx.borrows, id2, Array::get(snap_b, id2) + Array::get(max_b, id2))
-        id2 = id2 + 1
-      }
-      0
     },
     EHandle(hbody, arms) => {
       let snap_u = copy_ints(ctx.uses)

--- a/lib/@vibe/compiler/tests/codegen_heap_e2e_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_heap_e2e_test.vibe
@@ -202,6 +202,13 @@ test "heap e2e: tuple pattern match" {
   assert_result(src, "main", "tuple_match", "12")
 }
 
+/// #1553: a single-arm match runs through both bump and RC codegen; the RC
+/// planner skips branch snapshots but retains the payload bindings correctly.
+test "heap e2e: single-arm enum match" {
+  let src = "enum E { A((Int, Int)) }\nlet main: () -> Int = () -> {\n  let e = A((20, 22))\n  match e {\n    A((a, b)) => a + b\n  }\n}"
+  assert_result(src, "main", "single_arm_enum_match", "42")
+}
+
 test "heap e2e: nested tuple pattern match" {
   let src = "let main: () -> Int = () -> {\n  let t = ((1, 2), 3)\n  match t {\n    ((a, b), c) => a * 100 + b * 10 + c\n  }\n}"
   assert_result(src, "main", "nested_tuple_match", "123")

--- a/lib/@vibe/compiler/tests/perceus_rc_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_rc_test.vibe
@@ -250,6 +250,20 @@ test "perceus: match arm pattern binding is dropped" {
   assert(count_drops(plan, "p") == 1)
 }
 
+/// #1553: the single-arm path skips branch snapshots but must retain the same
+/// pattern scope-end drop as the general EMatch path.
+test "perceus: single-arm match pattern binding is dropped" {
+  // match s { Some(p) => p.0 }
+  let arm: (Pat, Expr) = (PCtor("Some", [
+    PBind("p")
+  ]), EDot(EIdent("p", -1), "0", -1, -1))
+  let m = EMatch(EIdent("s", -1), [
+    arm
+  ])
+  let plan = build_perceus_plan(m)
+  assert(count_drops(plan, "p") == 1)
+}
+
 /// A heap binding consumed only as a match scrutinee is borrowed (matching reads
 /// the tag/fields but frees nothing), so it keeps its owned reference and is
 /// dropped once at its scope end — this is what reclaims an enum/record/tuple

--- a/lib/@vibe/compiler/tests/perceus_rc_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_rc_test.vibe
@@ -264,6 +264,74 @@ test "perceus: single-arm match pattern binding is dropped" {
   assert(count_drops(plan, "p") == 1)
 }
 
+/// #1553: a one-arm body can consume an outer heap binding. Unlike a branch
+/// merge, the sole path transfers that binding's original reference, so its
+/// enclosing scope must not emit a second drop.
+test "perceus: single-arm match consumes outer heap binding" {
+  // let t = (1, 2); match 0 { _ => t }
+  let m = EMatch(EInt(0), [
+    (PWild, EIdent("t", -1))
+  ])
+  let body = ELet("t", ETuple([
+    EInt(1),
+    EInt(2)
+  ]), m, -1)
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "t") == 0)
+  assert(count_dups(plan, "t") == 0)
+}
+
+/// #1553: borrowing an outer heap binding before an owning tuple slot retains
+/// the original for the scope, so the slot takes one dup and that original is
+/// released exactly once at scope end.
+test "perceus: single-arm match borrows then owns outer heap binding" {
+  // let t = (1, 2); match 0 { _ => (t.0, t) }
+  let m = EMatch(EInt(0), [
+    (PWild, ETuple([
+      EDot(EIdent("t", -1), "0", -1, -1),
+      EIdent("t", -1)
+    ]))
+  ])
+  let body = ELet("t", ETuple([
+    EInt(1),
+    EInt(2)
+  ]), m, -1)
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "t") == 1)
+  assert(count_dups(plan, "t") == 1)
+}
+
+/// #1553: nested one-arm matches each create and close their own pattern
+/// scopes while preserving the borrowed outer payload binding.
+test "perceus: nested single-arm matches preserve pattern drops" {
+  // match s { p => match p { q => q.0 } }
+  let inner = EMatch(EIdent("p", -1), [
+    (PBind("q"), EDot(EIdent("q", -1), "0", -1, -1))
+  ])
+  let outer = EMatch(EIdent("s", -1), [
+    (PBind("p"), inner)
+  ])
+  let plan = build_perceus_plan(outer)
+  assert(count_drops(plan, "p") == 1)
+  assert(count_drops(plan, "q") == 1)
+}
+
+/// #1553: zero-arm matches stay on the general path. Their scrutinee remains a
+/// borrow, so an enclosing heap binding retains its ordinary scope-end drop.
+test "perceus: zero-arm match preserves outer heap drop" {
+  // let t = (1, 2); match t { }
+  let empty_arms: Array[(Pat, Expr)] = [
+  ]
+  let m = EMatch(EIdent("t", -1), empty_arms)
+  let body = ELet("t", ETuple([
+    EInt(1),
+    EInt(2)
+  ]), m, -1)
+  let plan = build_perceus_plan(body)
+  assert(count_drops(plan, "t") == 1)
+  assert(count_dups(plan, "t") == 0)
+}
+
 /// A heap binding consumed only as a match scrutinee is borrowed (matching reads
 /// the tag/fields but frees nothing), so it keeps its owned reference and is
 /// dropped once at its scope end — this is what reclaims an enum/record/tuple

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4099,12 +4099,12 @@ if [ ! -s "$shdir/shadow.wasm" ]; then
   exit 1
 fi
 sh_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$shdir/shadow.wasm" 2>&1 | tail -1)"
-if [ "$sh_out" != "232489" ]; then
-  echo "[compiler-gate] FAIL: rc_shadow_regression got '$sh_out' (want 232489). A trap here means an RC dup/drop accounting regression touched a freed block -- see fixtures/rc_shadow_regression_test.vibe for which shapes are covered and issue #715 for the debugging methodology." >&2
+if [ "$sh_out" != "25232489" ]; then
+  echo "[compiler-gate] FAIL: rc_shadow_regression got '$sh_out' (want 25232489). A trap here means an RC dup/drop accounting regression touched a freed block -- see fixtures/rc_shadow_regression_test.vibe for which shapes are covered and issue #715 for the debugging methodology." >&2
   exit 1
 fi
 rm -rf "$shdir"
-echo "[compiler-gate] RC shadow-liveness regression guard ok (232489)"
+echo "[compiler-gate] RC shadow-liveness regression guard ok (25232489)"
 
 # 40g. #cfg conditional-compilation guard: the flag-off build must strip the
 #      guarded statements entirely (compiles, dev symbols absent -> different

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -67,11 +67,43 @@ if s2 != s3:
 print(f"[compiler-gate] fixpoint ok: stage2==stage3 ({s2[:12]})")
 PY
 
+stage2_wasm="${latest_gen}stage2.wasm"
+# #1553: a real compiled-CLI smoke. The protocol test above validates the
+# measurement wrapper with a fake runner; this proves the freshly self-hosted
+# CLI actually selects both marked helpers and emits their required codegen
+# boundaries without changing the normal production lane.
+echo "[compiler-gate] 3a/3 FS heap mark lane smoke"
+heapmarkdir="_build/_gate_fs_heap_marks"
+rm -rf "$heapmarkdir"; mkdir -p "$heapmarkdir"
+printf 'export let _start: () -> Int = () -> { 42 }\n' > "$heapmarkdir/input.vibe"
+for heap_backend in rc bump; do
+  heap_rc=1
+  heap_boundary=codegen_rc
+  if [ "$heap_backend" = bump ]; then
+    heap_rc=0
+    heap_boundary=codegen_bump
+  fi
+  heap_log="$heapmarkdir/$heap_backend.log"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    VIBE_RC="$heap_rc" VIBE_PROFILE_MEMORY_MARKS=1 \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$heapmarkdir/input.vibe" "$heapmarkdir/$heap_backend.wasm" _start \
+    >/dev/null 2>"$heap_log"
+  if [ ! -s "$heapmarkdir/$heap_backend.wasm" ] \
+    || ! grep -q "name=start" "$heap_log" \
+    || ! grep -q "name=$heap_boundary" "$heap_log"; then
+    echo "[compiler-gate] FAIL: compiled CLI did not emit selected $heap_backend heap marks" >&2
+    cat "$heap_log" >&2 || true
+    exit 1
+  fi
+done
+rm -rf "$heapmarkdir"
+echo "[compiler-gate] FS heap mark lanes ok (rc + bump)"
+
 # 3a. Bounded artifact-input identity observation: use this just-built stage2
 # against an isolated cache. The trace wrapper is VIBE_RC=0-only and verifies a
 # cold miss/warm hit, dependency invalidation, and stale-sidecar fail-closed
 # behavior without changing any production cache key or format.
-stage2_wasm="${latest_gen}stage2.wasm"
 echo "[compiler-gate] 3a/3 artifact-input trace oracle"
 VIBE_RC=0 node scripts/artifact_input_trace_oracle.mjs "$stage2_wasm"
 

--- a/scripts/measure_fs_heap.sh
+++ b/scripts/measure_fs_heap.sh
@@ -33,15 +33,23 @@
 #   bash scripts/measure_fs_heap.sh --cold [--backend rc|bump] [--base stage2.wasm] [--gate]
 #   bash scripts/measure_fs_heap.sh --warm [--backend rc|bump] [--base stage2.wasm]
 #   bash scripts/measure_fs_heap.sh --cold --backend rc --verify-parity --base stage2.wasm
+#   bash scripts/measure_fs_heap.sh --cold --compare --base stage2.wasm
 #
 # --backend selects the marked RC (default) or bump codegen twin. --verify-parity
 # performs a second, independently cold unmarked compile in that same lane and
 # fails unless its wasm bytes exactly match the marked compile. It is also
 # opt-in because it doubles the already-expensive full-CLI work.
 #
+# A normal invocation measures exactly one lane and is explicitly unpaired: its
+# output MUST NOT be used as an RC-vs-bump comparison. --compare runs both lanes
+# against one caller-supplied --base, records base and compiler-input hashes, and
+# fails if either changes while the pair is collected. It never implicitly builds
+# a base compiler, so the pair has a stable shared compiler identity.
+#
 # Output is stdout-only and grep-able:
-#   [fs-heap] mode=cold backend=rc boundary=... heap_mib=... pages=... mem_mib=... rss_mib=...
-#   [fs-heap] mode=cold backend=rc peak_heap_mib=... peak_pages=... headroom_mib=... wall_s=...
+#   [fs-heap] comparison=unpaired mode=cold backend=rc boundary=... heap_mib=... pages=... mem_mib=... rss_mib=...
+#   [fs-heap] comparison=unpaired mode=cold backend=rc peak_heap_mib=... peak_pages=... headroom_mib=... wall_s=...
+#   [fs-heap] comparison=attested mode=cold backends=rc,bump base_sha256=... input_sha256=...
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -50,7 +58,10 @@ cd "$PROJECT_ROOT"
 
 MODE=warm
 BACKEND=rc
+BACKEND_EXPLICIT=0
 BASE_COMPILER="${VIBE_MEASURE_BASE_COMPILER:-}"
+BASE_EXPLICIT=0
+COMPARE=0
 VERIFY_PARITY=0
 GATE=0
 MAX_PAGES="${VIBE_FS_HEAP_MAX_PAGES:-}"
@@ -84,7 +95,7 @@ unset VIBE_WASM_PRE_GROW_PAGES VIBE_WASM_HOST_ALLOC_MODE \
   VIBE_FORCE_RUN_INIT
 
 usage() {
-  sed -n '1,45p' "$0" >&2
+  sed -n '1,52p' "$0" >&2
 }
 
 cleanup() {
@@ -122,10 +133,11 @@ while [ $# -gt 0 ]; do
     --warm) MODE=warm; shift ;;
     --backend)
       [ $# -ge 2 ] || { echo "measure_fs_heap: --backend requires rc or bump" >&2; exit 2; }
-      BACKEND="$2"; shift 2 ;;
+      BACKEND="$2"; BACKEND_EXPLICIT=1; shift 2 ;;
     --base)
       [ $# -ge 2 ] || { echo "measure_fs_heap: --base requires a wasm path" >&2; exit 2; }
-      BASE_COMPILER="$2"; shift 2 ;;
+      BASE_COMPILER="$2"; BASE_EXPLICIT=1; shift 2 ;;
+    --compare) COMPARE=1; shift ;;
     --gate) GATE=1; shift ;;
     --verify-parity) VERIFY_PARITY=1; shift ;;
     --help|-h) usage; exit 0 ;;
@@ -140,6 +152,71 @@ case "$BACKEND" in
     exit 2
     ;;
 esac
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+sha256_stream() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+# The full CLI entry is influenced by the checked-in compiler and CLI sources,
+# not only main.vibex. Hash the source set before and after a paired collection
+# so its attestation remains truthful if another writer touches the tree.
+compiler_input_hash() {
+  (
+    cd "$PROJECT_ROOT"
+    find lib/@vibe lib/@vibex -type f \
+      \( -name '*.vibe' -o -name '*.vibex' -o -name '*.vpkg' \) -print0 \
+      | LC_ALL=C sort -z \
+      | while IFS= read -r -d '' path; do
+          sha256_file "$path"
+        done
+  ) | sha256_stream
+}
+
+if [ "$COMPARE" = 1 ]; then
+  if [ "$BACKEND_EXPLICIT" = 1 ]; then
+    echo "measure_fs_heap: --compare selects both backends; do not pass --backend" >&2
+    exit 2
+  fi
+  if [ "$BASE_EXPLICIT" != 1 ]; then
+    echo "measure_fs_heap: --compare requires one explicit shared --base; separate runs are unpaired and must not be compared" >&2
+    exit 2
+  fi
+  if [ ! -s "$BASE_COMPILER" ]; then
+    echo "measure_fs_heap: base compiler not found: $BASE_COMPILER" >&2
+    exit 1
+  fi
+  base_hash_before="$(sha256_file "$BASE_COMPILER")"
+  input_hash_before="$(compiler_input_hash)"
+  pair_args=("--$MODE" --base "$BASE_COMPILER")
+  if [ "$GATE" = 1 ]; then pair_args+=(--gate); fi
+  if [ "$VERIFY_PARITY" = 1 ]; then pair_args+=(--verify-parity); fi
+  "$0" "${pair_args[@]}" --backend rc
+  "$0" "${pair_args[@]}" --backend bump
+  base_hash_after="$(sha256_file "$BASE_COMPILER")"
+  input_hash_after="$(compiler_input_hash)"
+  if [ "$base_hash_before" != "$base_hash_after" ]; then
+    echo "measure_fs_heap: comparison invalid: shared --base changed during collection" >&2
+    exit 1
+  fi
+  if [ "$input_hash_before" != "$input_hash_after" ]; then
+    echo "measure_fs_heap: comparison invalid: compiler input changed during collection" >&2
+    exit 1
+  fi
+  echo "[fs-heap] comparison=attested mode=$MODE backends=rc,bump base_sha256=$base_hash_before input_sha256=$input_hash_before"
+  exit 0
+fi
 
 if [ "$GATE" = 1 ] && [ -z "$MAX_PAGES" ]; then
   MAX_PAGES=57344
@@ -210,7 +287,7 @@ if [ "$BACKEND" = bump ]; then
   RC_VALUE=0
 fi
 
-echo "[fs-heap] mode=$MODE backend=$BACKEND base=$BASE_COMPILER entry=$ENTRY_REL run_dir=$RUN_DIR" >&2
+echo "[fs-heap] comparison=unpaired mode=$MODE backend=$BACKEND base=$BASE_COMPILER entry=$ENTRY_REL run_dir=$RUN_DIR" >&2
 
 run_compile() {
   local marks="$1"
@@ -318,7 +395,7 @@ awk -v mode="$MODE" -v backend="$BACKEND" -v codegen_boundary="$CODEGEN_BOUNDARY
       error("duplicate boundary mark: " name)
       next
     }
-    printf "[fs-heap] mode=%s backend=%s boundary=%s heap_mib=%.1f delta_mib=%.1f pages=%d mem_mib=%.1f rss_mib=%.1f\n", \
+    printf "[fs-heap] comparison=unpaired mode=%s backend=%s boundary=%s heap_mib=%.1f delta_mib=%.1f pages=%d mem_mib=%.1f rss_mib=%.1f\n", \
       mode, backend, name, heap / 1048576, (heap - prev_heap) / 1048576, pages, bytes / 1048576, rss / 1048576
     prev_heap = heap
     if (heap + 0 > peak_heap) { peak_heap = heap + 0 }
@@ -337,7 +414,7 @@ awk -v mode="$MODE" -v backend="$BACKEND" -v codegen_boundary="$CODEGEN_BOUNDARY
     }
     if (peak_pages == "") error("no valid named [profile-memory] marks in runner stderr")
     if (!failed) {
-      printf "[fs-heap] mode=%s backend=%s peak_heap_mib=%.1f peak_pages=%d headroom_mib=%.1f wall_s=%d\n", \
+      printf "[fs-heap] comparison=unpaired mode=%s backend=%s peak_heap_mib=%.1f peak_pages=%d headroom_mib=%.1f wall_s=%d\n", \
         mode, backend, peak_heap / 1048576, peak_pages, (65536 - peak_pages) * 64 / 1024, wall
       if (max_pages != "" && peak_pages > max_pages) {
         error("GATE FAIL: peak_pages " peak_pages " > limit " max_pages " (3.5 GiB default is 57344 pages)")
@@ -368,7 +445,7 @@ if [ "$VERIFY_PARITY" = 1 ]; then
     echo "measure_fs_heap: parity failure: marked and unmarked full-CLI wasm differ" >&2
     exit 1
   fi
-  echo "[fs-heap] parity=ok mode=$MODE backend=$BACKEND"
+  echo "[fs-heap] comparison=unpaired parity=ok mode=$MODE backend=$BACKEND"
 fi
 
 # Publish a warm cache only after every requested check passed. The run cache

--- a/scripts/measure_fs_heap.sh
+++ b/scripts/measure_fs_heap.sh
@@ -2,15 +2,15 @@
 # measure_fs_heap.sh — cold/warm guest-memory measurement of the FS-mode
 # whole-CLI compile (#1553).
 #
-# This compiles lib/@vibe/cli/main.vibex with a current-tree base compiler,
-# VIBE_FS_COMPILE=1, VIBE_RC=1, and VIBE_PROFILE_MEMORY_MARKS=1. The runner
+# This compiles lib/@vibe/cli/main.vibex with a pinned base compiler,
+# VIBE_FS_COMPILE=1, a selected VIBE_RC lane, and VIBE_PROFILE_MEMORY_MARKS=1. The runner
 # emits one `[profile-memory]` line for each explicit compiler boundary. The
 # deterministic measurements are `pages` (guest linear-memory pages) and
 # `heap_ptr` (guest bump-heap high-water); RSS is printed only as a host
 # diagnostic and must not be used as a gate.
 #
 # Boundary labels are deliberately call-boundary names, not inferred phases:
-#   start, source_groups, prepared_db, merged_stmts, codegen_rc,
+#   start, source_groups, prepared_db, merged_stmts, codegen_rc|codegen_bump,
 #   write_output, fs_compile_complete.
 # They do not claim separately unobservable normalize or link work.
 #
@@ -30,17 +30,18 @@
 #   always-on CI lane without recorded timing/cost data.
 #
 # USAGE
-#   bash scripts/measure_fs_heap.sh --cold [--base stage2.wasm] [--gate]
-#   bash scripts/measure_fs_heap.sh --warm [--base stage2.wasm]
-#   bash scripts/measure_fs_heap.sh --cold --verify-parity --base stage2.wasm
+#   bash scripts/measure_fs_heap.sh --cold [--backend rc|bump] [--base stage2.wasm] [--gate]
+#   bash scripts/measure_fs_heap.sh --warm [--backend rc|bump] [--base stage2.wasm]
+#   bash scripts/measure_fs_heap.sh --cold --backend rc --verify-parity --base stage2.wasm
 #
-# --verify-parity performs a second, independently cold unmarked RC compile
-# and fails unless its wasm bytes exactly match the marked compile. It is also
+# --backend selects the marked RC (default) or bump codegen twin. --verify-parity
+# performs a second, independently cold unmarked compile in that same lane and
+# fails unless its wasm bytes exactly match the marked compile. It is also
 # opt-in because it doubles the already-expensive full-CLI work.
 #
 # Output is stdout-only and grep-able:
-#   [fs-heap] mode=cold boundary=... heap_mib=... pages=... mem_mib=... rss_mib=...
-#   [fs-heap] mode=cold peak_heap_mib=... peak_pages=... headroom_mib=... wall_s=...
+#   [fs-heap] mode=cold backend=rc boundary=... heap_mib=... pages=... mem_mib=... rss_mib=...
+#   [fs-heap] mode=cold backend=rc peak_heap_mib=... peak_pages=... headroom_mib=... wall_s=...
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -48,6 +49,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
 MODE=warm
+BACKEND=rc
 BASE_COMPILER="${VIBE_MEASURE_BASE_COMPILER:-}"
 VERIFY_PARITY=0
 GATE=0
@@ -118,6 +120,9 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --cold) MODE=cold; shift ;;
     --warm) MODE=warm; shift ;;
+    --backend)
+      [ $# -ge 2 ] || { echo "measure_fs_heap: --backend requires rc or bump" >&2; exit 2; }
+      BACKEND="$2"; shift 2 ;;
     --base)
       [ $# -ge 2 ] || { echo "measure_fs_heap: --base requires a wasm path" >&2; exit 2; }
       BASE_COMPILER="$2"; shift 2 ;;
@@ -127,6 +132,14 @@ while [ $# -gt 0 ]; do
     *) echo "measure_fs_heap: unknown argument: $1" >&2; usage; exit 2 ;;
   esac
 done
+
+case "$BACKEND" in
+  rc|bump) ;;
+  *)
+    echo "measure_fs_heap: --backend must be rc or bump" >&2
+    exit 2
+    ;;
+esac
 
 if [ "$GATE" = 1 ] && [ -z "$MAX_PAGES" ]; then
   MAX_PAGES=57344
@@ -183,23 +196,28 @@ if [ ! -f "$ENTRY_REL" ]; then
   exit 1
 fi
 
-MARKED_CACHE="$RUN_DIR/cache_marked"
-if [ "$MODE" = warm ] && [ -d "$OUT_DIR/warm-cache" ]; then
-  cp -a "$OUT_DIR/warm-cache/." "$MARKED_CACHE"
+MARKED_CACHE="$RUN_DIR/cache_marked_$BACKEND"
+if [ "$MODE" = warm ] && [ -d "$OUT_DIR/warm-cache_$BACKEND" ]; then
+  cp -a "$OUT_DIR/warm-cache_$BACKEND/." "$MARKED_CACHE"
 else
   mkdir -p "$MARKED_CACHE"
 fi
-MARKED_OUT="$RUN_DIR/cli_core_marked.wasm"
-MARKED_LOG="$RUN_DIR/marked.log"
+MARKED_OUT="$RUN_DIR/cli_core_marked_$BACKEND.wasm"
+MARKED_LOG="$RUN_DIR/marked_$BACKEND.log"
+CODEGEN_BOUNDARY="codegen_$BACKEND"
+RC_VALUE=1
+if [ "$BACKEND" = bump ]; then
+  RC_VALUE=0
+fi
 
-echo "[fs-heap] mode=$MODE base=$BASE_COMPILER entry=$ENTRY_REL run_dir=$RUN_DIR" >&2
+echo "[fs-heap] mode=$MODE backend=$BACKEND base=$BASE_COMPILER entry=$ENTRY_REL run_dir=$RUN_DIR" >&2
 
 run_compile() {
   local marks="$1"
   local cache_dir="$2"
   local output="$3"
   local log="$4"
-  # Pin one FS RC lane. env -u prevents host-runner allocation controls,
+  # Pin one FS backend. env -u prevents host-runner allocation controls,
   # alternate compiler modes, sidecars, and observability from contaminating
   # the measured heap/pages or silently selecting a different compile path.
   exec env \
@@ -244,7 +262,7 @@ run_compile() {
     -u VIBE_EMIT_MERGED_SOURCE \
     -u VIBE_EMIT_MODULE_SOURCE \
     VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw \
-    VIBE_FS_COMPILE=1 VIBE_RC=1 VIBE_CHECK_ERROR_ROW=1 \
+    VIBE_FS_COMPILE=1 VIBE_RC="$RC_VALUE" VIBE_CHECK_ERROR_ROW=1 \
     VIBE_COVERAGE=0 VIBE_DEBUG_BREAK=0 VIBE_DEBUG=0 \
     VIBE_BUILD_CACHE_DIR="$cache_dir" VIBE_PROFILE_MEMORY_MARKS="$marks" \
     bash "$RUNNER" --invoke cli_main "$BASE_COMPILER" "$ENTRY_REL" "$output" main \
@@ -278,7 +296,7 @@ fi
 # Fail closed: a completed compile must expose every documented boundary and
 # every required guest metric. The awk program also applies the optional
 # page-limit gate to the maximum observed guest page count.
-awk -v mode="$MODE" -v wall="$((end_s - start_s))" -v max_pages="$MAX_PAGES" '
+awk -v mode="$MODE" -v backend="$BACKEND" -v codegen_boundary="$CODEGEN_BOUNDARY" -v wall="$((end_s - start_s))" -v max_pages="$MAX_PAGES" '
   function error(message) {
     print "[fs-heap] ERROR: " message > "/dev/stderr"
     failed = 1
@@ -300,8 +318,8 @@ awk -v mode="$MODE" -v wall="$((end_s - start_s))" -v max_pages="$MAX_PAGES" '
       error("duplicate boundary mark: " name)
       next
     }
-    printf "[fs-heap] mode=%s boundary=%s heap_mib=%.1f delta_mib=%.1f pages=%d mem_mib=%.1f rss_mib=%.1f\n", \
-      mode, name, heap / 1048576, (heap - prev_heap) / 1048576, pages, bytes / 1048576, rss / 1048576
+    printf "[fs-heap] mode=%s backend=%s boundary=%s heap_mib=%.1f delta_mib=%.1f pages=%d mem_mib=%.1f rss_mib=%.1f\n", \
+      mode, backend, name, heap / 1048576, (heap - prev_heap) / 1048576, pages, bytes / 1048576, rss / 1048576
     prev_heap = heap
     if (heap + 0 > peak_heap) { peak_heap = heap + 0 }
     if (pages + 0 > peak_pages) { peak_pages = pages + 0 }
@@ -311,7 +329,7 @@ awk -v mode="$MODE" -v wall="$((end_s - start_s))" -v max_pages="$MAX_PAGES" '
     required["source_groups"] = 1
     required["prepared_db"] = 1
     required["merged_stmts"] = 1
-    required["codegen_rc"] = 1
+    required[codegen_boundary] = 1
     required["write_output"] = 1
     required["fs_compile_complete"] = 1
     for (name in required) {
@@ -319,8 +337,8 @@ awk -v mode="$MODE" -v wall="$((end_s - start_s))" -v max_pages="$MAX_PAGES" '
     }
     if (peak_pages == "") error("no valid named [profile-memory] marks in runner stderr")
     if (!failed) {
-      printf "[fs-heap] mode=%s peak_heap_mib=%.1f peak_pages=%d headroom_mib=%.1f wall_s=%d\n", \
-        mode, peak_heap / 1048576, peak_pages, (65536 - peak_pages) * 64 / 1024, wall
+      printf "[fs-heap] mode=%s backend=%s peak_heap_mib=%.1f peak_pages=%d headroom_mib=%.1f wall_s=%d\n", \
+        mode, backend, peak_heap / 1048576, peak_pages, (65536 - peak_pages) * 64 / 1024, wall
       if (max_pages != "" && peak_pages > max_pages) {
         error("GATE FAIL: peak_pages " peak_pages " > limit " max_pages " (3.5 GiB default is 57344 pages)")
       }
@@ -330,9 +348,9 @@ awk -v mode="$MODE" -v wall="$((end_s - start_s))" -v max_pages="$MAX_PAGES" '
 ' "$MARKED_LOG"
 
 if [ "$VERIFY_PARITY" = 1 ]; then
-  UNMARKED_CACHE="$RUN_DIR/cache_unmarked"
-  UNMARKED_OUT="$RUN_DIR/cli_core_unmarked.wasm"
-  UNMARKED_LOG="$RUN_DIR/unmarked.log"
+  UNMARKED_CACHE="$RUN_DIR/cache_unmarked_$BACKEND"
+  UNMARKED_OUT="$RUN_DIR/cli_core_unmarked_$BACKEND.wasm"
+  UNMARKED_LOG="$RUN_DIR/unmarked_$BACKEND.log"
   mkdir -p "$UNMARKED_CACHE"
   set +e
   run_compile 0 "$UNMARKED_CACHE" "$UNMARKED_OUT" "$UNMARKED_LOG" &
@@ -350,17 +368,17 @@ if [ "$VERIFY_PARITY" = 1 ]; then
     echo "measure_fs_heap: parity failure: marked and unmarked full-CLI wasm differ" >&2
     exit 1
   fi
-  echo "[fs-heap] parity=ok mode=$MODE"
+  echo "[fs-heap] parity=ok mode=$MODE backend=$BACKEND"
 fi
 
 # Publish a warm cache only after every requested check passed. The run cache
 # itself is always unique; this snapshot is the sole shared warm state and is
 # covered by the warm-run lock above.
 if [ "$MODE" = warm ]; then
-  WARM_NEXT="$(mktemp -d "$OUT_DIR/.warm-cache.next.XXXXXX")"
+  WARM_NEXT="$(mktemp -d "$OUT_DIR/.warm-cache_$BACKEND.next.XXXXXX")"
   cp -a "$MARKED_CACHE/." "$WARM_NEXT"
-  rm -rf "$OUT_DIR/warm-cache"
-  mv "$WARM_NEXT" "$OUT_DIR/warm-cache"
+  rm -rf "$OUT_DIR/warm-cache_$BACKEND"
+  mv "$WARM_NEXT" "$OUT_DIR/warm-cache_$BACKEND"
   WARM_NEXT=""
 fi
 

--- a/scripts/measure_fs_heap.sh
+++ b/scripts/measure_fs_heap.sh
@@ -69,6 +69,7 @@ OUT_DIR="${VIBE_FS_HEAP_OUT_DIR:-$PROJECT_ROOT/_build/measure_fs_heap}"
 RUNNER="${VIBE_FS_HEAP_RUNNER:-$SCRIPT_DIR/run_wasm_vibe_host_runner.sh}"
 KEEP_RUN_DIR="${VIBE_FS_HEAP_KEEP_RUN_DIR:-0}"
 RUN_DIR=""
+PAIR_DIR=""
 WARM_NEXT=""
 LOCK_DIR=""
 LOCK_HELD=0
@@ -108,6 +109,9 @@ cleanup() {
   fi
   if [ -n "$RUN_DIR" ] && [ "$KEEP_RUN_DIR" != 1 ]; then
     rm -rf "$RUN_DIR"
+  fi
+  if [ -n "$PAIR_DIR" ]; then
+    rm -rf "$PAIR_DIR"
   fi
   exit "$status"
 }
@@ -197,24 +201,29 @@ if [ "$COMPARE" = 1 ]; then
     echo "measure_fs_heap: base compiler not found: $BASE_COMPILER" >&2
     exit 1
   fi
-  base_hash_before="$(sha256_file "$BASE_COMPILER")"
+  # Prepare deterministic ignored inputs before attesting the source snapshot.
+  # Child lanes repeat this as a no-op freshness check.
+  bash "$SCRIPT_DIR/ensure_generated.sh" >&2
   input_hash_before="$(compiler_input_hash)"
-  pair_args=("--$MODE" --base "$BASE_COMPILER")
+
+  # Both lanes consume one private snapshot, not the caller's mutable pathname.
+  # This prevents a concurrent replace/restore race from mixing base compilers
+  # while still producing matching before/after hashes.
+  PAIR_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe_fs_heap_pair.XXXXXX")"
+  cp "$BASE_COMPILER" "$PAIR_DIR/base.wasm"
+  chmod 0444 "$PAIR_DIR/base.wasm"
+  base_hash="$(sha256_file "$PAIR_DIR/base.wasm")"
+  pair_args=("--$MODE" --base "$PAIR_DIR/base.wasm")
   if [ "$GATE" = 1 ]; then pair_args+=(--gate); fi
   if [ "$VERIFY_PARITY" = 1 ]; then pair_args+=(--verify-parity); fi
   "$0" "${pair_args[@]}" --backend rc
   "$0" "${pair_args[@]}" --backend bump
-  base_hash_after="$(sha256_file "$BASE_COMPILER")"
   input_hash_after="$(compiler_input_hash)"
-  if [ "$base_hash_before" != "$base_hash_after" ]; then
-    echo "measure_fs_heap: comparison invalid: shared --base changed during collection" >&2
-    exit 1
-  fi
   if [ "$input_hash_before" != "$input_hash_after" ]; then
     echo "measure_fs_heap: comparison invalid: compiler input changed during collection" >&2
     exit 1
   fi
-  echo "[fs-heap] comparison=attested mode=$MODE backends=rc,bump base_sha256=$base_hash_before input_sha256=$input_hash_before"
+  echo "[fs-heap] comparison=attested mode=$MODE backends=rc,bump base_sha256=$base_hash input_sha256=$input_hash_before"
   exit 0
 fi
 

--- a/scripts/measure_fs_heap_test.sh
+++ b/scripts/measure_fs_heap_test.sh
@@ -79,8 +79,8 @@ VIBE_RC_HEAP_START=123456 \
 VIBE_EXPERIMENTAL_PERSISTENT_INGESTION_STAMP=1 \
   bash "$SCRIPT" --cold --base "$BASE" --verify-parity > "$TMP_DIR/ok.stdout"
 
-grep -q '^\[fs-heap\] parity=ok mode=cold backend=rc$' "$TMP_DIR/ok.stdout"
-grep -q '^\[fs-heap\] mode=cold backend=rc boundary=fs_compile_complete ' "$TMP_DIR/ok.stdout"
+grep -q '^\[fs-heap\] comparison=unpaired parity=ok mode=cold backend=rc$' "$TMP_DIR/ok.stdout"
+grep -q '^\[fs-heap\] comparison=unpaired mode=cold backend=rc boundary=fs_compile_complete ' "$TMP_DIR/ok.stdout"
 grep -Eq "^marks=1 rc=1 cache=$TMP_DIR/out/run\.[^/]*/cache_marked_rc pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
 grep -Eq "^marks=0 rc=1 cache=$TMP_DIR/out/run\.[^/]*/cache_unmarked_rc pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
 
@@ -90,8 +90,8 @@ FAKE_RUN_LOG="$RUN_LOG" \
 VIBE_FS_HEAP_RUNNER="$RUNNER" \
 VIBE_FS_HEAP_OUT_DIR="$TMP_DIR/bump" \
   bash "$SCRIPT" --cold --backend bump --base "$BASE" --verify-parity > "$TMP_DIR/bump.stdout"
-grep -q '^\[fs-heap\] parity=ok mode=cold backend=bump$' "$TMP_DIR/bump.stdout"
-grep -q '^\[fs-heap\] mode=cold backend=bump boundary=codegen_bump ' "$TMP_DIR/bump.stdout"
+grep -q '^\[fs-heap\] comparison=unpaired parity=ok mode=cold backend=bump$' "$TMP_DIR/bump.stdout"
+grep -q '^\[fs-heap\] comparison=unpaired mode=cold backend=bump boundary=codegen_bump ' "$TMP_DIR/bump.stdout"
 grep -Eq "^marks=1 rc=0 cache=$TMP_DIR/bump/run\.[^/]*/cache_marked_bump pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
 grep -Eq "^marks=0 rc=0 cache=$TMP_DIR/bump/run\.[^/]*/cache_unmarked_bump pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
 if grep -q 'ambient-cache-must-not-be-used' "$RUN_LOG"; then
@@ -102,6 +102,44 @@ if find "$TMP_DIR/out" -mindepth 1 -maxdepth 1 -type d -name 'run.*' | grep -q .
   echo "measure_fs_heap test: successful run directory was not cleaned" >&2
   exit 1
 fi
+
+# Separate lane runs remain deliberately unpaired even when a base happens to
+# be supplied. RC-vs-bump attribution must use --compare with one explicit
+# shared base; an environment default is intentionally insufficient.
+set +e
+FAKE_RUN_LOG="$RUN_LOG" \
+VIBE_MEASURE_BASE_COMPILER="$BASE" \
+VIBE_FS_HEAP_RUNNER="$RUNNER" \
+VIBE_FS_HEAP_OUT_DIR="$TMP_DIR/compare-no-base" \
+  bash "$SCRIPT" --cold --compare > "$TMP_DIR/compare-no-base.stdout" 2> "$TMP_DIR/compare-no-base.stderr"
+status=$?
+set -e
+if [ "$status" -eq 0 ]; then
+  echo "measure_fs_heap test: --compare accepted an implicit base" >&2
+  exit 1
+fi
+grep -q -- '--compare requires one explicit shared --base' "$TMP_DIR/compare-no-base.stderr"
+
+FAKE_RUN_LOG="$RUN_LOG" \
+VIBE_FS_HEAP_RUNNER="$RUNNER" \
+VIBE_FS_HEAP_OUT_DIR="$TMP_DIR/compare" \
+  bash "$SCRIPT" --cold --compare --base "$BASE" > "$TMP_DIR/compare.stdout"
+grep -Eq '^\[fs-heap\] comparison=attested mode=cold backends=rc,bump base_sha256=[0-9a-f]{64} input_sha256=[0-9a-f]{64}$' "$TMP_DIR/compare.stdout"
+grep -q '^\[fs-heap\] comparison=unpaired mode=cold backend=rc boundary=codegen_rc ' "$TMP_DIR/compare.stdout"
+grep -q '^\[fs-heap\] comparison=unpaired mode=cold backend=bump boundary=codegen_bump ' "$TMP_DIR/compare.stdout"
+
+set +e
+FAKE_RUN_LOG="$RUN_LOG" \
+VIBE_FS_HEAP_RUNNER="$RUNNER" \
+VIBE_FS_HEAP_OUT_DIR="$TMP_DIR/compare-backend" \
+  bash "$SCRIPT" --cold --compare --backend rc --base "$BASE" > "$TMP_DIR/compare-backend.stdout" 2> "$TMP_DIR/compare-backend.stderr"
+status=$?
+set -e
+if [ "$status" -eq 0 ]; then
+  echo "measure_fs_heap test: --compare accepted a single backend" >&2
+  exit 1
+fi
+grep -q -- '--compare selects both backends' "$TMP_DIR/compare-backend.stderr"
 
 # The default --gate limit is 57344 pages (3.5 GiB), and exceeding it must
 # fail rather than report a plausible measurement.

--- a/scripts/measure_fs_heap_test.sh
+++ b/scripts/measure_fs_heap_test.sh
@@ -23,6 +23,7 @@ out="$5"
 sleep_pid=""
 trap '[ -z "$sleep_pid" ] || kill "$sleep_pid" 2>/dev/null || true; [ -z "$sleep_pid" ] || wait "$sleep_pid" 2>/dev/null || true; printf "terminated\\n" >> "$FAKE_RUN_LOG"; exit 143' TERM
 printf 'runner_pid=%s\n' "$$" >> "$FAKE_RUN_LOG"
+printf 'base=%s\n' "$3" >> "$FAKE_RUN_LOG"
 printf 'marks=%s rc=%s cache=%s pre_grow=%s host_alloc=%s host_guard=%s entry_testmeta=%s testmeta=%s rc_heap_start=%s wasm_names=%s ingestion_stamp=%s import_abi=%s coverage=%s\n' \
   "${VIBE_PROFILE_MEMORY_MARKS:-unset}" \
   "${VIBE_RC:-unset}" \
@@ -127,6 +128,14 @@ VIBE_FS_HEAP_OUT_DIR="$TMP_DIR/compare" \
 grep -Eq '^\[fs-heap\] comparison=attested mode=cold backends=rc,bump base_sha256=[0-9a-f]{64} input_sha256=[0-9a-f]{64}$' "$TMP_DIR/compare.stdout"
 grep -q '^\[fs-heap\] comparison=unpaired mode=cold backend=rc boundary=codegen_rc ' "$TMP_DIR/compare.stdout"
 grep -q '^\[fs-heap\] comparison=unpaired mode=cold backend=bump boundary=codegen_bump ' "$TMP_DIR/compare.stdout"
+compare_base_paths="$(grep '^base=' "$RUN_LOG" | tail -n 2 | cut -d= -f2-)"
+[ "$(printf '%s\n' "$compare_base_paths" | sort -u | wc -l | tr -d ' ')" = 1 ]
+compare_base_path="$(printf '%s\n' "$compare_base_paths" | head -n 1)"
+[ "$compare_base_path" != "$BASE" ]
+case "$compare_base_path" in
+  */vibe_fs_heap_pair.*/base.wasm) ;;
+  *) echo "measure_fs_heap test: compare did not use one private base snapshot" >&2; exit 1 ;;
+esac
 
 set +e
 FAKE_RUN_LOG="$RUN_LOG" \

--- a/scripts/measure_fs_heap_test.sh
+++ b/scripts/measure_fs_heap_test.sh
@@ -23,8 +23,9 @@ out="$5"
 sleep_pid=""
 trap '[ -z "$sleep_pid" ] || kill "$sleep_pid" 2>/dev/null || true; [ -z "$sleep_pid" ] || wait "$sleep_pid" 2>/dev/null || true; printf "terminated\\n" >> "$FAKE_RUN_LOG"; exit 143' TERM
 printf 'runner_pid=%s\n' "$$" >> "$FAKE_RUN_LOG"
-printf 'marks=%s cache=%s pre_grow=%s host_alloc=%s host_guard=%s entry_testmeta=%s testmeta=%s rc_heap_start=%s wasm_names=%s ingestion_stamp=%s import_abi=%s coverage=%s\n' \
+printf 'marks=%s rc=%s cache=%s pre_grow=%s host_alloc=%s host_guard=%s entry_testmeta=%s testmeta=%s rc_heap_start=%s wasm_names=%s ingestion_stamp=%s import_abi=%s coverage=%s\n' \
   "${VIBE_PROFILE_MEMORY_MARKS:-unset}" \
+  "${VIBE_RC:-unset}" \
   "${VIBE_BUILD_CACHE_DIR:-unset}" \
   "${VIBE_WASM_PRE_GROW_PAGES:-unset}" \
   "${VIBE_WASM_HOST_ALLOC_MODE:-unset}" \
@@ -46,7 +47,11 @@ fi
 printf '\0asm\1\0\0\0' > "$out"
 if [ "${VIBE_PROFILE_MEMORY_MARKS:-}" = "1" ]; then
   pages="${FAKE_PAGES:-100}"
-  for name in start source_groups prepared_db merged_stmts codegen_rc write_output fs_compile_complete; do
+  codegen_boundary=codegen_rc
+  if [ "${VIBE_RC:-}" = "0" ]; then
+    codegen_boundary=codegen_bump
+  fi
+  for name in start source_groups prepared_db merged_stmts "$codegen_boundary" write_output fs_compile_complete; do
     if [ "${FAKE_MISSING_BOUNDARY:-}" = "$name" ]; then
       continue
     fi
@@ -74,10 +79,21 @@ VIBE_RC_HEAP_START=123456 \
 VIBE_EXPERIMENTAL_PERSISTENT_INGESTION_STAMP=1 \
   bash "$SCRIPT" --cold --base "$BASE" --verify-parity > "$TMP_DIR/ok.stdout"
 
-grep -q '^\[fs-heap\] parity=ok mode=cold$' "$TMP_DIR/ok.stdout"
-grep -q '^\[fs-heap\] mode=cold boundary=fs_compile_complete ' "$TMP_DIR/ok.stdout"
-grep -Eq "^marks=1 cache=$TMP_DIR/out/run\.[^/]*/cache_marked pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
-grep -Eq "^marks=0 cache=$TMP_DIR/out/run\.[^/]*/cache_unmarked pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
+grep -q '^\[fs-heap\] parity=ok mode=cold backend=rc$' "$TMP_DIR/ok.stdout"
+grep -q '^\[fs-heap\] mode=cold backend=rc boundary=fs_compile_complete ' "$TMP_DIR/ok.stdout"
+grep -Eq "^marks=1 rc=1 cache=$TMP_DIR/out/run\.[^/]*/cache_marked_rc pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
+grep -Eq "^marks=0 rc=1 cache=$TMP_DIR/out/run\.[^/]*/cache_unmarked_rc pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
+
+# The marked bump twin must pin VIBE_RC=0, require its distinct codegen mark,
+# and compare only against the independently cold unmarked bump lane.
+FAKE_RUN_LOG="$RUN_LOG" \
+VIBE_FS_HEAP_RUNNER="$RUNNER" \
+VIBE_FS_HEAP_OUT_DIR="$TMP_DIR/bump" \
+  bash "$SCRIPT" --cold --backend bump --base "$BASE" --verify-parity > "$TMP_DIR/bump.stdout"
+grep -q '^\[fs-heap\] parity=ok mode=cold backend=bump$' "$TMP_DIR/bump.stdout"
+grep -q '^\[fs-heap\] mode=cold backend=bump boundary=codegen_bump ' "$TMP_DIR/bump.stdout"
+grep -Eq "^marks=1 rc=0 cache=$TMP_DIR/bump/run\.[^/]*/cache_marked_bump pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
+grep -Eq "^marks=0 rc=0 cache=$TMP_DIR/bump/run\.[^/]*/cache_unmarked_bump pre_grow=unset host_alloc=unset host_guard=unset entry_testmeta=unset testmeta=unset rc_heap_start=unset wasm_names=unset ingestion_stamp=unset import_abi=raw coverage=0$" "$RUN_LOG"
 if grep -q 'ambient-cache-must-not-be-used' "$RUN_LOG"; then
   echo "measure_fs_heap test: ambient cache leaked into measurement" >&2
   exit 1


### PR DESCRIPTION
## Summary
- add marked bump-codegen attribution beside RC without changing production backend selection
- add attested paired `--compare` using one private immutable base snapshot and stable compiler-input hash
- optimize single-arm `EMatch` in `pc_count`/`pc_emit` by avoiding branch snapshot arrays
- add real RC/bump mark smoke and ownership/drop/nested semantic regressions

## Measurement
Pinned-base attribution showed RC-specific codegen delta 347.3 MiB (36.3%). The retained optimization reduced cold full-CLI peak 2216.2 → 2191.2 MiB: **25.0 MiB / 1.13%**. Guest heap/pages are acceptance values; RSS remains diagnostic only.

## Validation
- marked/unmarked parity passed independently for RC and bump
- protocol, Perceus/runtime/shadow tests, formatter, generation freshness passed
- independent reviews found the optimization semantically sound; paired-measurement blockers were fixed in `519b5c0e6` and re-reviewed safe
- full release gate remains for CI

Refs #1553