### PR TITLE
feat(scps): distribute sequence-head if and match continuations (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2801,6 +2801,24 @@ rename を外すと捕獲で黙って誤る、その P0 側を pin)、
 実験では 1015 に化ける)。実害側は
 `async_iter_test.vibe` の suspend-class handle 内 terminals テスト。
 
+### 追記43 (2026-08-10): sequence HEAD の EIf / EMatch へ継続を分配する (#1536 (a) v4)
+
+`scps_split_tail` は sequence HEAD が suspending `EIf` なら
+`EIf(c, ESeq(t, b), ESeq(el, b))` へ、suspending `EMatch` なら各 arm body に
+`ESeq(body, b)` を置く形へ分配する。condition / scrutinee は transform の外に
+残るので一回だけ評価され、選ばれなかった branch / arm の tail は実行されない。
+
+match の pattern binder は tail の元の外側参照を捕獲し得るため、arm ごとに
+`__scps_match<site>_<arm>_<name>` を基底とする fresh name へ alpha-rename してから
+分配する。freshness は pattern・arm body・shared tail の全出現を probe する。
+`effect_seq_head_if_suspend.vibe` (want 41100) は condition 一回評価と branch-local
+shadow を、`effect_seq_head_match_suspend.vibe` (want 3200) は scrutinee 一回評価と
+pattern capture を pin する。suspend が condition / scrutinee 自身にある形は選択前の
+継続を要するためこの slice の範囲外で、negative fixture で拒否を固定する。
+
+**残る不適格**: EForIn(array)/ELoop HEAD、代入 RHS 直書きの perform、row 変数
+callee、literal param flow。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/fixtures/effect_seq_head_if_suspend.vibe
+++ b/fixtures/effect_seq_head_if_suspend.vibe
@@ -1,0 +1,41 @@
+// #1536 (a) v4: a suspending if expression in SEQUENCE HEAD position is
+// distributed over its continuation. `once` proves the condition evaluates
+// once; the branch-local `outer` must not capture the tail's outer binding.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let visits = [
+  0
+]
+
+fn once() -> Bool {
+  Array::set(visits, 0, Array::get(visits, 0) + 1)
+  Array::get(visits, 0) == 1
+}
+
+let _start = () -> Int {
+  handle {
+    let outer = 100
+    let mut got = 0
+    if once() {
+      let outer = perform Ask::Get(3)
+      got = outer
+    } else {
+      let outer = perform Ask::Get(99)
+      got = outer
+    }
+    got * 10000 + Array::get(visits, 0) * 1000 + outer
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "last": "41100"
+}

--- a/fixtures/effect_seq_head_match_suspend.vibe
+++ b/fixtures/effect_seq_head_match_suspend.vibe
@@ -1,0 +1,43 @@
+// #1536 (a) v4: a suspending match expression in SEQUENCE HEAD position is
+// distributed over its continuation. The pattern binds `outer`, while the
+// sequence tail refers to the outer `outer`; alpha-renaming the pattern is
+// required to prevent that tail reference from being captured. `next_key`
+// also proves the scrutinee is evaluated once.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let visits = [
+  0
+]
+let calls = [
+  0
+]
+
+fn next_key() -> Option[Int] {
+  Array::set(visits, 0, Array::get(visits, 0) + 1)
+  Some(1)
+}
+
+let _start = () -> Int {
+  handle {
+    let outer = 100
+    match next_key() {
+      Some(outer) => perform Ask::Get(outer + 2),
+      _ => perform Ask::Get(99)
+    }
+    Array::get(calls, 0) * 1000 + Array::get(visits, 0) * 100 + outer
+  } with Ask {
+    Get(n) => {
+      Array::set(calls, 0, n)
+      let k = resume
+      k(n + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "last": "3200"
+}

--- a/fixtures/err_effect_seq_head_if_condition_suspend.vibe
+++ b/fixtures/err_effect_seq_head_if_condition_suspend.vibe
@@ -1,0 +1,28 @@
+// #1536 (a) v4 boundary: only a branch-local suspend can receive the
+// distributed sequence continuation. A suspend in the condition precedes
+// branch selection and remains unsupported by this slice.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    if perform Ask::Get(1) > 0 {
+      10
+    } else {
+      20
+    }
+    0
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "let/seq/tail/branch-tail spine"
+}

--- a/fixtures/err_effect_seq_head_match_scrutinee_suspend.vibe
+++ b/fixtures/err_effect_seq_head_match_scrutinee_suspend.vibe
@@ -1,0 +1,26 @@
+// #1536 (a) v4 boundary: a suspend in the match scrutinee precedes pattern
+// selection, so it cannot use the branch-continuation distribution here.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    match perform Ask::Get(1) {
+      1 => 10,
+      _ => 20
+    }
+    0
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "let/seq/tail/branch-tail spine"
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9432,6 +9432,35 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
             let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
             (bok, ESeq(a, bexpr))
           },
+          // #1536 (a) v4: distribute the sequence continuation through a
+          // suspending conditional. The condition remains outside the
+          // branches, so it is evaluated exactly once before exactly one
+          // branch and its continuation. Branch-local lets remain lexical
+          // to their branch because `b` is an ESeq sibling, not their body.
+          EIf(c, t, el) => if scps_contains_susp(a, sctx) {
+            if scps_contains_susp(c, sctx) {
+              (false, e)
+            } else {
+              scps_split_tail(EIf(c, ESeq(t, b), ESeq(el, b)), sctx, ctx, st)
+            }
+          } else {
+            let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
+            (bok, ESeq(a, bexpr))
+          },
+          // #1536 (a) v4: likewise distribute through match after first
+          // alpha-renaming every pattern binder. The tail was outside the
+          // match originally; without the rename, a pattern binding could
+          // capture an outer reference in the duplicated tail.
+          EMatch(s, arms) => if scps_contains_susp(a, sctx) {
+            if scps_contains_susp(s, sctx) {
+              (false, e)
+            } else {
+              scps_split_tail(EMatch(s, scps_seq_float_match_arms(arms, b, site)), sctx, ctx, st)
+            }
+          } else {
+            let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
+            (bok, ESeq(a, bexpr))
+          },
           // Reassociate a suspending nested sequence head so its own head
           // surfaces for the arms above: ESeq(ESeq(a1, a2), b) ==>
           // ESeq(a1, ESeq(a2, b)). Strictly decreases head size, so the
@@ -10469,6 +10498,96 @@ fn scps_seq_float_fresh(x: String, k: Expr, b: Expr, site: Int) -> String {
     nx = String::concat(String::concat(base, "_"), Int::to_string(i))
   }
   nx
+}
+
+/// Append the original sequence tail to every match arm without letting a
+/// pattern binder capture a name in that tail. Each arm gets fresh binders
+/// and a correspondingly alpha-renamed body before `b` is placed under the
+/// arm scope. The scrutinee remains outside this helper and is evaluated once.
+fn scps_seq_float_match_arms(arms: Array[(Pat, Expr)], b: Expr, site: Int) -> Array[(Pat, Expr)] {
+  let out = scps_empty_arms()
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (p, body) = Array::get(arms, i)
+    let names = array_empty()
+    scps_pat_collect_binds(p, names)
+    let mut p2 = p
+    let mut body2 = body
+    let mut ni = 0
+    while ni < Array::length(names) {
+      let nm = Array::get(names, ni)
+      let mut seen = false
+      let mut prev = 0
+      while prev < ni {
+        if Array::get(names, prev) == nm {
+          seen = true
+        } else {
+          ()
+        }
+        prev = prev + 1
+      }
+      if seen {
+        ()
+      } else {
+        let nx = scps_seq_float_match_fresh(nm, p2, body2, b, site, i)
+        p2 = scps_rename_pat_ident(p2, nm, nx)
+        body2 = scps_rename_ident(body2, nm, nx)
+      }
+      ni = ni + 1
+    }
+    Array::push(out, (p2, ESeq(body2, b)))
+    i = i + 1
+  }
+  out
+}
+
+/// Fresh name for one distributed match arm. Besides the arm body and shared
+/// tail, probe the pattern itself: a target already bound by a sibling field
+/// or an or-pattern would change its binding relation.
+fn scps_seq_float_match_fresh(x: String, p: Pat, body: Expr, b: Expr, site: Int, arm: Int) -> String {
+  let arm_base = String::concat(String::concat(scps_local("__scps_match", site), "_"), Int::to_string(arm))
+  let base = String::concat(String::concat(arm_base, "_"), x)
+  let mut nx = base
+  let mut i = 0
+  while scps_pat_binds_name(p, nx) || scps_mentions_name(body, nx) || scps_mentions_name(b, nx) {
+    i = i + 1
+    nx = String::concat(String::concat(base, "_"), Int::to_string(i))
+  }
+  nx
+}
+
+fn scps_rename_pat_ident(p: Pat, x: String, nx: String) -> Pat {
+  match p {
+    PBind(nm) => if nm == x {
+      PBind(nx)
+    } else {
+      p
+    },
+    PCtor(nm, ps) => PCtor(nm, scps_rename_pat_idents(ps, x, nx)),
+    PTuple(ps) => PTuple(scps_rename_pat_idents(ps, x, nx)),
+    POr(a, b) => POr(scps_rename_pat_ident(a, x, nx), scps_rename_pat_ident(b, x, nx)),
+    PStruct(nm, fields) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (fname, fp) = Array::get(fields, i)
+        Array::push(out, (fname, scps_rename_pat_ident(fp, x, nx)))
+        i = i + 1
+      }
+      PStruct(nm, out)
+    },
+    _ => p
+  }
+}
+
+fn scps_rename_pat_idents(ps: Array[Pat], x: String, nx: String) -> Array[Pat] {
+  let out = scps_empty_pats()
+  let mut i = 0
+  while i < Array::length(ps) {
+    Array::push(out, scps_rename_pat_ident(Array::get(ps, i), x, nx))
+    i = i + 1
+  }
+  out
 }
 
 /// True if `e` could reach a suspend of the effect under proof: ANY

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6747,6 +6747,15 @@ scps_run_expect "effect_seq_head_block_suspend.vibe" "1105" "seqheadshadow"
 # probe bumps past any occurrence in the floated continuation or the
 # tail. Control-measured: with the probe disabled this prints 1015.
 scps_run_expect "effect_seq_head_reserved_name_collision.vibe" "3011" "seqheadfresh"
+# #1536 (a) v4: suspendable if/match heads distribute the original sequence
+# tail into each selected branch. The runtime pins one evaluation of the
+# condition/scrutinee and capture-safe branch/pattern bindings.
+scps_run_expect "effect_seq_head_if_suspend.vibe" "41100" "seqheadif"
+scps_run_expect "effect_seq_head_match_suspend.vibe" "3200" "seqheadmatch"
+# This continuation distribution deliberately starts AFTER selection; a
+# suspendable if condition or match scrutinee remains an ineligible head.
+scps_check_reject "err_effect_seq_head_if_condition_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadifcond"
+scps_check_reject "err_effect_seq_head_match_scrutinee_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadmatchscrut"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"
 scps_check_reject "err_effect_resume_store_ineligible.vibe" "cannot see through" "inelig"
 scps_check_reject "err_effect_closure_param_taint.vibe" "cannot see through" "inerttaint"


### PR DESCRIPTION
## Summary
- distribute non-tail sequence continuations into `if` branches when the condition is suspend-inert
- distribute into `match` arms after hygienically alpha-renaming pattern binders
- keep suspending conditions/scrutinees fail-closed
- add positive runtime and negative eligibility regressions

## Validation
- focused Phase-3a compiler-gate section passed
- formatter and generated freshness passed
- `git diff --check` passed
- full compiler gate later hit the pre-existing host `xargs: command line cannot be assembled, too long` at gate 92
- independent review: safe to integrate, no blocker/major/minor findings

## Remaining #1536 scope
Row-variable callees, residual literal-param flows, suspendable condition/scrutinee, loop/for-in heads, and assignment RHS remain fail-closed.