### PR TITLE
feat(checker): transport typedef declaration authority (#1549)

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_effective_effect_row_observation.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_effective_effect_row_observation.vibe
@@ -104,6 +104,9 @@ fn owner_env_lookup(env: TypeEnv, wanted: String) -> Option[Type] {
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
+      EnvTypeDefs(_, rest) => {
+        cur = rest
+      },
       EnvFlat(bindings) => {
         let mut i = 0
         while i < Array::length(bindings) && !done {

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -399,6 +399,9 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
+      EnvTypeDefs(_, rest) => {
+        cur = rest
+      },
       EnvFlat(bindings) => {
         let mut i = 0
         while i < Array::length(bindings) {
@@ -664,6 +667,9 @@ export fn canonical_retained_trait_impl_entries_snapshot(env: TypeEnv, s: Subst)
         Array::push(fields, entry)
         cur = rest
       },
+      EnvTypeDefs(_, rest) => {
+        cur = rest
+      },
       EnvFlat(_) => {
         done = true
       },
@@ -804,6 +810,9 @@ export fn canonical_retained_trait_method_gens_snapshot(env: TypeEnv) -> String 
         cur = rest
       },
       EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, rest) => {
         cur = rest
       },
       EnvFlat(_) => {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -623,6 +623,7 @@ fn collect_env_bindings(env: TypeEnv, acc: Array[(String, Type)]) -> Unit {
     EnvTraitDef(_, _, _, _, rest, _, _) => collect_env_bindings(rest, acc),
     EnvTraitImpl(_, _, rest) => collect_env_bindings(rest, acc),
     EnvTraitImplGen(_, _, _, _, rest) => collect_env_bindings(rest, acc),
+    EnvTypeDefs(_, rest) => collect_env_bindings(rest, acc),
     EnvFlat(bindings) => {
       let mut i = 0
       while i < Array::length(bindings) {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -244,17 +244,9 @@ fn resolve_trait_method_ident(name: String, env: TypeEnv, defs: Array[TypeDef], 
 /// the env but whose variant list only reaches this module through
 /// `enum_def_env_name`.
 ///
-/// A PARAMETERIZED enum is built from the `Enum::__variants__` carrier rather
-/// than from the `TDEnum`, because the `TDEnum`'s payloads carry the declaring
-/// compilation's `CtVar` ids and the `CtForAll` binders that quantify them live
-/// in `type_def_binders`, which this function cannot reach and which does not
-/// cross a module boundary anyway. The carrier stores the NAME-parameterized
-/// payloads, so the scheme can be rebuilt here from binder ids of our own:
-/// `c` is the caller's next-fresh counter, and the caller instantiates the
-/// result immediately, which renames every binder again (`instantiate` steps
-/// its own counter past any binder id it sees, so ids minted here cannot be
-/// captured). Falling back to `env_lookup(env, member)` when the carrier is
-/// missing keeps the pre-#1455 behaviour for anything this cannot reconstruct.
+/// A PARAMETERIZED enum validates ownership through `TDEnum` and then uses
+/// the imported bare constructor's checked `CtForAll` scheme. The historical
+/// `Enum::__variants__` carrier is deliberately not an authority source.
 fn resolve_qualified_ctor_ident(name: String, env: TypeEnv, defs: Array[TypeDef], c: Int) -> Option[Type] {
   let idx = String::index_of(name, "::")
   if idx < 0 {
@@ -285,7 +277,10 @@ fn resolve_qualified_ctor_ident(name: String, env: TypeEnv, defs: Array[TypeDef]
               Some(CtFn(payloads, CtEnum(ename), None))
             }
           } else {
-            resolve_qualified_parameterized_ctor(ename, params, member, env, c)
+            // The imported bare constructor is the checked `CtForAll` scheme.
+            // `Enum::__variants__` is legacy data only and is never consulted
+            // for authority, so a corrupt carrier cannot override EnvTypeDefs.
+            env_lookup(env, member)
           }
         } else {
           None
@@ -296,9 +291,8 @@ fn resolve_qualified_ctor_ident(name: String, env: TypeEnv, defs: Array[TypeDef]
   }
 }
 
-/// The parameterized half of `resolve_qualified_ctor_ident`: rebuild
-/// `Enum::Variant`'s `CtForAll` scheme from the carrier's name-parameterized
-/// payloads, binding the enum's formals to fresh ids starting at `c`.
+/// Legacy carrier decoder path retained for compatibility with its isolated
+/// codec tests. No checker/import path calls it; EnvTypeDefs is authoritative.
 fn resolve_qualified_parameterized_ctor(ename: String, params: Array[String], member: String, env: TypeEnv, c: Int) -> Option[Type] {
   match env_lookup(env, enum_def_env_name(ename)) {
     Some(carrier) => match decode_enum_def(carrier) {

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -919,6 +919,9 @@ fn set_throw_kind_table(env: TypeEnv) -> Unit {
         }
         cur = rest
       },
+      EnvTypeDefs(_, rest) => {
+        cur = rest
+      },
       EnvFlat(entries) => {
         let mut ei = 0
         while ei < Array::length(entries) {
@@ -2599,6 +2602,9 @@ fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[
         cur = rest
       },
       EnvCached(_, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, rest) => {
         cur = rest
       },
       EnvFlat(entries) => {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -983,8 +983,40 @@ fn collect_qualified_pattern_refs(stmts: Array[Stmt]) -> Array[(String, String)]
 /// the old `Enum::__variants__` value carrier is intentionally not consulted.
 /// Generic enum payloads are name-parameterized on the wire and rebound to
 /// this check's fresh ids here, exactly once.
-fn seed_imported_type_defs(initial_env: TypeEnv, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> (Int, Int) {
+fn local_type_def_names(stmts: Array[Stmt]) -> Array[String] {
+  let names = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SEnum(_, name, _, _, _) => Array::push(names, name),
+      SStruct(_, name, _, _, _, _) => Array::push(names, name),
+      STypeAlias(_, name, _, _) => Array::push(names, name),
+      _ => ()
+    }
+    i = i + 1
+  }
+  names
+}
+
+fn string_array_contains(items: Array[String], wanted: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) && !found {
+    if Array::get(items, i) == wanted {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn seed_imported_type_defs(stmts: Array[Stmt], initial_env: TypeEnv, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> (Int, Int) {
   let imported = env_type_defs(initial_env)
+  // `find_typedef` is first-match-wins. Local declarations are checked after
+  // this seed, so omit same-named imported authority up front; otherwise an
+  // imported typedef would permanently win over the lexical local declaration.
+  let local_names = local_type_def_names(stmts)
   let mut next_c = 0
   let mut i = 0
   while i < Array::length(imported) {
@@ -999,7 +1031,9 @@ fn seed_imported_type_defs(initial_env: TypeEnv, defs: Array[TypeDef], type_def_
     // first-match rule. A projected interface never contains effects here.
     match find_typedef(defs, name) {
       Some(_) => (),
-      None => match def {
+      None => if string_array_contains(local_names, name) {
+        ()
+      } else match def {
         TDEnum(enum_name, params, variants) => {
           let ids = array_empty()
           let vars = array_empty()
@@ -3032,7 +3066,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       // `seed_next_c` is the first type-variable id seeding did NOT consume;
       // checking has to start there or a parameterized imported enum's formals
       // would be handed out a second time.
-      let (local_defs_start, seed_next_c) = seed_imported_type_defs(initial_env, empty_defs, type_def_binders)
+      let (local_defs_start, seed_next_c) = seed_imported_type_defs(stmts, initial_env, empty_defs, type_def_binders)
       let cached_env = env_cache(initial_env)
       let seeded_raw_env = if trait_defined(cached_env, "Eq") {
         cached_env

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -31,6 +31,7 @@ import @vibe/compiler/core {
   env_cache,
   env_flat_bindings,
   env_lookup_flat,
+  env_type_defs,
   find_enum_typedef,
   find_typedef,
   generalize,
@@ -52,10 +53,6 @@ import ./checker.vibe {
   check_assignable,
   check_expr,
   check_expr_capture,
-  decode_enum_def,
-  encode_enum_def,
-  enum_def_env_name,
-  enum_def_env_target,
   fn_return_env_name,
   is_array_builder_ty,
   is_region_tagged_ty,
@@ -981,183 +978,68 @@ fn collect_qualified_pattern_refs(stmts: Array[Stmt]) -> Array[(String, String)]
   out
 }
 
-/// #1455: rebuild a `TDEnum` in this module's `defs` for every enum an
-/// imported module published under `enum_def_env_name`. Returns the index at
-/// which this module's OWN declarations start (which #1078's collision check
-/// needs -- see `find_other_enum_declaring_variant`) paired with the next free
-/// type-variable id.
-///
-/// The second half of that pair is what makes PARAMETERIZED imported enums
-/// work. The carrier stores name-parameterized payloads (`CtNamed("T", [])`),
-/// so seeding has to bind each formal to a `CtVar` of THIS compilation's
-/// counter before the payloads mean anything -- and those ids must not be
-/// handed out again, so checking has to resume from the counter seeding left
-/// off at rather than from zero.
-///
-/// Seeding happens once, before checking, rather than at each `SImport`, so an
-/// imported enum is visible from the first statement on, exactly like the
-/// constructor bindings it belongs to. A consequence is that
-/// `import ./m { E as F }` registers the enum under `E`: the alias is only
-/// known to `bind_stmt_imports`, and the dependency's constructors already
-/// arrive under their original names, so following them keeps the two
-/// consistent. Renaming the type is left out of this slice.
-///
-/// A candidate is DROPPED when any of its variant names is already declared
-/// locally, or by another candidate. Both `find_ctor_in_defs` and
-/// `find_typedef` are first-match-wins over one flat `defs`, so registering
-/// two enums that share a constructor name would silently decide which one a
-/// bare `Mk(..)` pattern means -- the exact hazard #1078 rejects WITHIN a
-/// unit. Across a module boundary the shadowing is legitimate (the local
-/// binding wins, and that code compiles today), so the conservative move is
-/// to leave the ambiguous enum unregistered and keep today's behaviour for
-/// it rather than to guess or to reject. This also keeps the invariant #1078
-/// relies on -- no two enums in `defs` share a variant name -- true of the
-/// seeded entries too.
-fn seed_imported_enum_defs(stmts: Array[Stmt], initial_env: TypeEnv, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> (Int, Int) {
-  let claimed_variants = array_empty()
-  let local_names = local_enum_names(stmts, claimed_variants)
-  let bindings = env_flat_bindings(initial_env)
-  // Pass 1: the candidates, deduped by enum name. `env_flat_bindings` lists
-  // the most recent binding first, so the first carrier seen for a name is
-  // the one whose constructors the env actually resolves to.
-  let cand_names = array_empty()
-  let cand_params = array_empty()
-  let cand_variants = array_empty()
-  let mut i = 0
-  while i < Array::length(bindings) {
-    let (bname, bty) = Array::get(bindings, i)
-    match enum_def_env_target(bname) {
-      Some(ename) => if es_string_array_contains(local_names, ename) || es_string_array_contains(cand_names, ename) {
-        ()
-      } else {
-        match decode_enum_def(bty) {
-          Some((params, variants)) => {
-            Array::push(cand_names, ename)
-            Array::push(cand_params, params)
-            Array::push(cand_variants, variants)
-          },
-          None => ()
-        }
-      },
-      None => ()
-    }
-    i = i + 1
-  }
-  // Pass 2: a variant name claimed more than once disqualifies every
-  // candidate that claims it, so the outcome does not depend on which
-  // candidate happened to be seen first.
-  let contested = array_empty()
-  let mut ci = 0
-  while ci < Array::length(cand_names) {
-    let variants = Array::get(cand_variants, ci)
-    let mut vi = 0
-    while vi < Array::length(variants) {
-      let (vname, _) = Array::get(variants, vi)
-      if es_string_array_contains(claimed_variants, vname) {
-        Array::push(contested, vname)
-      } else {
-        Array::push(claimed_variants, vname)
-      }
-      vi = vi + 1
-    }
-    ci = ci + 1
-  }
+/// Seed imported declaration authority before checking. The published
+/// `EnvTypeDefs` chain is the sole source for enum, struct, and alias defs;
+/// the old `Enum::__variants__` value carrier is intentionally not consulted.
+/// Generic enum payloads are name-parameterized on the wire and rebound to
+/// this check's fresh ids here, exactly once.
+fn seed_imported_type_defs(initial_env: TypeEnv, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> (Int, Int) {
+  let imported = env_type_defs(initial_env)
   let mut next_c = 0
-  let mut ri = 0
-  while ri < Array::length(cand_names) {
-    let ename = Array::get(cand_names, ri)
-    let params = Array::get(cand_params, ri)
-    let variants = Array::get(cand_variants, ri)
-    let mut ok = true
-    let mut vi2 = 0
-    while vi2 < Array::length(variants) {
-      let (vname, _) = Array::get(variants, vi2)
-      if es_string_array_contains(contested, vname) {
-        ok = false
-      } else {
-        ()
-      }
-      vi2 = vi2 + 1
-    }
-    if ok {
-      // Bind the formals to ids of this compilation's counter, then push the
-      // SAME shape a local `SEnum` would have: `CtVar`-substituted payloads in
-      // the `TDEnum`, the ids that quantify them in `type_def_binders`.
-      let param_var_ids = array_empty()
-      let param_var_types = array_empty()
-      let mut pi = 0
-      while pi < Array::length(params) {
-        Array::push(param_var_ids, next_c + pi)
-        Array::push(param_var_types, CtVar(next_c + pi))
-        pi = pi + 1
-      }
-      next_c = next_c + Array::length(params)
-      let resolved_variants = array_empty()
-      let mut si = 0
-      while si < Array::length(variants) {
-        let (vname, vtypes) = Array::get(variants, si)
-        let resolved_vtypes = for vt in vtypes {
-          subst_type_params(vt, params, param_var_types)
-        }
-        Array::push(resolved_variants, (vname, resolved_vtypes))
-        si = si + 1
-      }
-      Array::push(defs, TDEnum(ename, params, resolved_variants))
-      Array::push(type_def_binders, param_var_ids)
-    } else {
-      ()
-    }
-    ri = ri + 1
-  }
-  seed_import_alias_defs(stmts, defs, type_def_binders)
-  (Array::length(defs), next_c)
-}
-
-/// #1502: `import ./m { E as F }` registers `F` as a `TDAlias` of `E`, so the
-/// constructor qualifier can be spelled with the name this module actually
-/// bound (`F::Mk`). Before this the alias was known only to
-/// `bind_stmt_imports`, and `F::Mk` failed with `unknown name` while the
-/// unaliased `E::Mk` worked -- a surprise, since `F` is usable everywhere else
-/// (type annotations, and the bare constructors, which arrive under their
-/// ORIGINAL names and so need no renaming).
-///
-/// Runs after the enum seeding above so `orig` is resolvable whether it is a
-/// local enum or one that seeding just introduced. Registration is skipped
-/// when `alias` already names a type -- a genuine conflict belongs to whatever
-/// declared that name, not to this convenience.
-///
-/// `type_def_binders` is index-aligned with `defs`, so each alias pushes an
-/// empty binder row -- exactly what the `STypeAlias` arm does for a written
-/// `type` alias. Omitting it would misalign every typedef registered after
-/// this point.
-fn seed_import_alias_defs(stmts: Array[Stmt], defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> Unit {
   let mut i = 0
-  while i < Array::length(stmts) {
-    match Array::get(stmts, i) {
-      SImport(_, items) => {
-        let mut j = 0
-        while j < Array::length(items) {
-          let (orig, alias_opt) = Array::get(items, j)
-          match alias_opt {
-            Some(alias) => match find_enum_typedef(defs, orig) {
-              Some(_) => match find_typedef(defs, alias) {
-                Some(_) => (),
-                None => {
-                  Array::push(defs, TDAlias(alias, array_empty(), CtEnum(orig)))
-                  Array::push(type_def_binders, array_empty())
-                }
-              },
-              None => ()
-            },
-            None => ()
+  while i < Array::length(imported) {
+    let def = Array::get(imported, i)
+    let name = match def {
+      TDEnum(n, _, _) => n,
+      TDStruct(n, _, _, _) => n,
+      TDAlias(n, _, _) => n,
+      TDEffect(n, _, _) => n
+    }
+    // First declaration wins, matching find_typedef and the import cache's
+    // first-match rule. A projected interface never contains effects here.
+    match find_typedef(defs, name) {
+      Some(_) => (),
+      None => match def {
+        TDEnum(enum_name, params, variants) => {
+          let ids = array_empty()
+          let vars = array_empty()
+          let mut pi = 0
+          while pi < Array::length(params) {
+            Array::push(ids, next_c + pi)
+            Array::push(vars, CtVar(next_c + pi))
+            pi = pi + 1
           }
-          j = j + 1
-        }
-      },
-      _ => ()
+          next_c = next_c + Array::length(params)
+          let rebound = array_empty()
+          let mut vi = 0
+          while vi < Array::length(variants) {
+            let (variant, fields) = Array::get(variants, vi)
+            let rebound_fields = array_empty()
+            let mut fi = 0
+            while fi < Array::length(fields) {
+              Array::push(rebound_fields, subst_type_params(Array::get(fields, fi), params, vars))
+              fi = fi + 1
+            }
+            Array::push(rebound, (variant, rebound_fields))
+            vi = vi + 1
+          }
+          Array::push(defs, TDEnum(enum_name, params, rebound))
+          Array::push(type_def_binders, ids)
+        },
+        TDStruct(struct_name, fields, mut_fields, params) => {
+          Array::push(defs, TDStruct(struct_name, fields, mut_fields, params))
+          Array::push(type_def_binders, array_empty())
+        },
+        TDAlias(alias_name, params, target) => {
+          Array::push(defs, TDAlias(alias_name, params, target))
+          Array::push(type_def_binders, array_empty())
+        },
+        TDEffect(_, _, _) => ()
+      }
     }
     i = i + 1
   }
+  (Array::length(defs), next_c)
 }
 
 /// #1078: the name of a DIFFERENT enum (already registered in `defs`) that
@@ -1635,14 +1517,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }
         let ctor_bounds = array_empty()
         let resolved_variants = array_empty()
-        // #1455: the same variant list twice. `resolved_variants` binds the
-        // formals to THIS compilation's `CtVar` ids and is what the `TDEnum`
-        // stores; `exported_variants` keeps them as `CtNamed(paramName, [])`
-        // and is what rides the `Enum::__variants__` carrier, because an id
-        // means nothing without the binder list that quantifies it and that
-        // list does not cross a module boundary. For a monomorphic enum the
-        // two are the same value (the substitution has nothing to do).
-        let exported_variants = array_empty()
+        // The local TDEnum uses this check's ids; published authority retains
+        // the name-parameterized shape and rebinds it at each importer.
+        let published_variants = array_empty()
         let mut vi = 0
         while vi < Array::length(variants) {
           let (vname, vtypes) = Array::get(variants, vi)
@@ -1658,7 +1535,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             ti = ti + 1
           }
           Array::push(resolved_variants, (vname, resolved_vtypes))
-          Array::push(exported_variants, (vname, named_vtypes))
+          Array::push(published_variants, (vname, named_vtypes))
           vi = vi + 1
         }
         Array::push(defs, TDEnum(name, params, resolved_variants))
@@ -1716,12 +1593,6 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           }
           ci2 = ci2 + 1
         }
-        // #1455: publish this enum's variant list so a module that imports it
-        // can rebuild the TDEnum (see `enum_def_env_name`). Parameterized enums
-        // ride the same carrier now that it stores the name-parameterized
-        // payloads plus the formals; the importer re-substitutes ids of its own
-        // (`seed_imported_enum_defs`).
-        env1 = env_bind(env1, enum_def_env_name(name), encode_enum_def(params, exported_variants))
         // #672: pre-bind the generated structural `E::equals` (every enum gets
         // one) so `==` dispatch call sites resolve at check time.
         let env_eq = env_bind(env1, String::concat(name, "::equals"), CtFn([
@@ -1768,7 +1639,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         } else {
           env_hash
         }
-        (env_default, s, c + param_len)
+        (EnvTypeDefs([
+          TDEnum(name, params, published_variants)
+        ], env_default), s, c + param_len)
       },
       SSuberror(_, name, variants) => {
         // #786: a `suberror Name(payload...)` declaration is structurally a
@@ -1900,7 +1773,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         } else {
           env_hash
         }
-        (bind_fn_return(env5, name, CtStruct(name)), s, c)
+        (EnvTypeDefs([
+          TDStruct(name, resolved_fields, mut_fields, tparams)
+        ], bind_fn_return(env5, name, CtStruct(name))), s, c)
       },
       STypeAlias(_, name, params, te) => {
         // #1512: `params` shadow `defs` -- see resolve_type_expr_shadowed.
@@ -1909,7 +1784,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // `Name[Arg]` expands via subst in resolve_type_expr's TyApp case.
         Array::push(defs, TDAlias(name, params, t))
         Array::push(type_def_binders, array_empty())
-        (env_bind(env, name, t), s, c)
+        (EnvTypeDefs([
+          TDAlias(name, params, t)
+        ], env_bind(env, name, t)), s, c)
       },
       SExternLet(name, te) => {
         let t = resolve_type_expr(te, defs)
@@ -3155,7 +3032,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       // `seed_next_c` is the first type-variable id seeding did NOT consume;
       // checking has to start there or a parameterized imported enum's formals
       // would be handed out a second time.
-      let (local_defs_start, seed_next_c) = seed_imported_enum_defs(stmts, initial_env, empty_defs, type_def_binders)
+      let (local_defs_start, seed_next_c) = seed_imported_type_defs(initial_env, empty_defs, type_def_binders)
       let cached_env = env_cache(initial_env)
       let seeded_raw_env = if trait_defined(cached_env, "Eq") {
         cached_env

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -73,6 +73,7 @@ export ./types.vibe {
   env_flat_bindings,
   env_lookup,
   env_lookup_flat,
+  env_type_defs,
   find_typedef,
   fresh_var,
   generalize,

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -209,6 +209,7 @@ fn instantiate(ty: Type, c: Int) -> (Type, Int, Array[(Int, Array[String])])
 fn trait_is_subtrait(env: TypeEnv, sub: String, super_name: String) -> Bool
 fn collect_tvars(ty: Type) -> Array[Int]
 fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)]
+fn env_type_defs(env: TypeEnv) -> Array[TypeDef]
 fn types_equal(a: Type, b: Type) -> Bool
 fn unify(a: Type, b: Type, s: Subst) -> Option[Subst]
 fn types_compatible(expected: Type, actual: Type) -> Bool

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -63,6 +63,9 @@ export enum TypeEnv {
   EnvTraitDef(String, Array[String], Bool, Array[(String, Array[TypeExpr], TypeExpr)], TypeEnv, Array[String], Array[(String, Array[String], Array[(String, Array[String])])]);
   EnvTraitImpl(String, Type, TypeEnv);
   EnvTraitImplGen(String, Array[String], Array[(String, Array[String])], Type, TypeEnv);
+  // Published typedef authority. Unlike the retired enum value carrier this
+  // keeps enums, structs, and aliases in one lossless declaration channel.
+  EnvTypeDefs(Array[TypeDef], TypeEnv);
   EnvFlat(Array[(String, Type)]);
   // Sorted names/types pair (see core/sorted_index.vibe), instead of a
   // Map[String, Type]: this compiler's `Map` is a flat assoc list, so
@@ -105,6 +108,49 @@ export fn env_bind(env: TypeEnv, name: String, ty: Type) -> TypeEnv {
   }
 }
 
+/// Collect declaration authority in the chain's lookup order. Declaration
+/// nodes are semantic transport, not value bindings, so cached value indexes
+/// never participate in this walk.
+export fn env_type_defs(env: TypeEnv) -> Array[TypeDef] {
+  let out = array_empty()
+  let mut cur = env
+  let mut done = false
+  while !done {
+    match cur {
+      EnvEmpty => {
+        done = true
+      },
+      EnvBind(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitDef(_, _, _, _, rest, _, _) => {
+        cur = rest
+      },
+      EnvTraitImpl(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(defs, rest) => {
+        let mut i = 0
+        while i < Array::length(defs) {
+          Array::push(out, Array::get(defs, i))
+          i = i + 1
+        }
+        cur = rest
+      },
+      EnvFlat(_) => {
+        done = true
+      },
+      EnvCached(_, _, rest) => {
+        cur = rest
+      }
+    }
+  }
+  out
+}
+
 export fn env_cache(env: TypeEnv) -> TypeEnv {
   let is_empty = match env {
     EnvEmpty => true,
@@ -134,6 +180,9 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           cur = rest
         },
         EnvTraitImplGen(_, _, _, _, rest) => {
+          cur = rest
+        },
+        EnvTypeDefs(_, rest) => {
           cur = rest
         },
         EnvFlat(bindings) => {
@@ -233,6 +282,9 @@ export fn env_lookup(env: TypeEnv, name: String) -> Option[Type] {
         cur = rest
       },
       EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, rest) => {
         cur = rest
       },
       EnvFlat(bindings) => {
@@ -404,6 +456,7 @@ export fn trait_supers(env: TypeEnv, name: String) -> Array[String] {
     } else trait_supers(rest, name),
     EnvTraitImpl(_, _, rest) => trait_supers(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_supers(rest, name),
+    EnvTypeDefs(_, rest) => trait_supers(rest, name),
     EnvFlat(_) => empty,
     EnvCached(_, _, rest) => trait_supers(rest, name)
   }
@@ -474,6 +527,7 @@ export fn trait_method_sig_binders(env: TypeEnv, trait_name: String, method_name
     } else trait_method_sig_binders(rest, trait_name, method_name),
     EnvTraitImpl(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
+    EnvTypeDefs(_, rest) => trait_method_sig_binders(rest, trait_name, method_name),
     EnvFlat(_) => None,
     EnvCached(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name)
   }
@@ -520,6 +574,7 @@ fn type_name_iterator_impl_scan(scan: TypeEnv, full: TypeEnv, type_name: String)
       } else type_name_iterator_impl_scan(rest, full, type_name)
     },
     EnvTraitImplGen(_, _, _, _, rest) => type_name_iterator_impl_scan(rest, full, type_name),
+    EnvTypeDefs(_, rest) => type_name_iterator_impl_scan(rest, full, type_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_name_iterator_impl_scan(rest, full, type_name)
   }
@@ -584,6 +639,7 @@ fn type_name_async_iterator_impl_scan(scan: TypeEnv, full: TypeEnv, type_name: S
         true
       } else type_name_async_iterator_impl_scan(rest, full, type_name)
     },
+    EnvTypeDefs(_, rest) => type_name_async_iterator_impl_scan(rest, full, type_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_name_async_iterator_impl_scan(rest, full, type_name)
   }
@@ -873,6 +929,7 @@ export fn trait_defined(env: TypeEnv, name: String) -> Bool {
     } else trait_defined(rest, name),
     EnvTraitImpl(_, _, rest) => trait_defined(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_defined(rest, name),
+    EnvTypeDefs(_, rest) => trait_defined(rest, name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => trait_defined(rest, name)
   }
@@ -1372,6 +1429,9 @@ export fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)] {
             cur = rest
           },
           EnvTraitImplGen(_, _, _, _, rest) => {
+            cur = rest
+          },
+          EnvTypeDefs(_, rest) => {
             cur = rest
           },
           EnvFlat(bindings) => {
@@ -2107,6 +2167,7 @@ export fn impls_overlap_for(env: TypeEnv, trait_name: String, new_target: Type) 
       else impls_overlap_for(rest, trait_name, new_target)
     } else impls_overlap_for(rest, trait_name, new_target),
     EnvTraitImplGen(_, _, _, _, rest) => impls_overlap_for(rest, trait_name, new_target),
+    EnvTypeDefs(_, rest) => impls_overlap_for(rest, trait_name, new_target),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => impls_overlap_for(rest, trait_name, new_target)
   }
@@ -2171,6 +2232,7 @@ fn type_implements_check_env(e: TypeEnv, full: TypeEnv, trait_name: String, reso
       else type_implements_check_env(rest, full, trait_name, resolved)
     } else type_implements_check_env(rest, full, trait_name, resolved),
     EnvTraitImplGen(_, _, _, _, rest) => type_implements_check_env(rest, full, trait_name, resolved),
+    EnvTypeDefs(_, rest) => type_implements_check_env(rest, full, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_implements_check_env(rest, full, trait_name, resolved)
   }
@@ -2200,6 +2262,7 @@ export fn trait_impl_declared_for_ctor(e: TypeEnv, trait_name: String, resolved:
       } else {
         trait_impl_declared_for_ctor(rest, trait_name, resolved)
       },
+      EnvTypeDefs(_, rest) => trait_impl_declared_for_ctor(rest, trait_name, resolved),
       EnvFlat(_) => false,
       EnvCached(_, _, rest) => trait_impl_declared_for_ctor(rest, trait_name, resolved)
     }
@@ -2295,6 +2358,7 @@ fn type_implements_check_super(e2: TypeEnv, full_env: TypeEnv, s: Subst, trait_n
         type_implements_check_super(rest, full_env, s, trait_name, resolved)
       }
     },
+    EnvTypeDefs(_, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved)
   }
@@ -2332,6 +2396,7 @@ fn trait_is_method_bearing(env: TypeEnv, trait_name: String) -> Bool {
     } else trait_is_method_bearing(rest, trait_name),
     EnvTraitImpl(_, _, rest) => trait_is_method_bearing(rest, trait_name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_is_method_bearing(rest, trait_name),
+    EnvTypeDefs(_, rest) => trait_is_method_bearing(rest, trait_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => trait_is_method_bearing(rest, trait_name)
   }
@@ -2380,6 +2445,7 @@ fn generic_impl_satisfies(scan: TypeEnv, full: TypeEnv, s: Subst, trait_name: St
         true
       } else generic_impl_satisfies(rest, full, s, trait_name, resolved)
     },
+    EnvTypeDefs(_, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved)
   }

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -870,11 +870,11 @@ export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Except
   } else {
     let (payload, after_payload) = parse_segment(normalized, header_len)
     if after_payload + 1 != String::length(normalized) || String::char_code_at(normalized, after_payload) != '\n' {
-      throw("invalid persistent type env v3 envelope")
+      throw("invalid persistent type env v4 envelope")
     } else {
       let (env, end) = parse_persistent_type_env_payload(payload, 0)
       if end != String::length(payload) {
-        throw("invalid persistent type env v3 payload")
+        throw("invalid persistent type env v4 payload")
       } else {
         Some(env)
       }
@@ -882,12 +882,19 @@ export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Except
   }
 }
 
+/// Filesystem cache bytes are untrusted. A malformed or old envelope is a
+/// cache miss, never an exception that can turn a cold check into a failure or
+/// a partially decoded interface into authority.
 export fn load_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with Exception + Fs {
   let path = persistent_type_env_cache_path(fingerprint)
   if !(Fs::exists(path)) {
     None
   } else {
-    parse_persistent_type_env(Fs::read_file(path))
+    handle {
+      parse_persistent_type_env(Fs::read_file(path))
+    } with Exception {
+      Throw(_) => None
+    }
   }
 }
 

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -14,7 +14,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Type, TypeEnv, TypeExpr, env_cache
+  Type, TypeDef, TypeEnv, TypeExpr, env_cache
 }
 
 //# Functions
@@ -511,6 +511,113 @@ fn parse_trait_method_gens(text: String, pos: Int) -> (Array[(String, Array[Stri
   }
 }
 
+fn serialize_type_def(def: TypeDef) -> String {
+  match def {
+    TDEnum(name, params, variants) => {
+      let out = StringBuilder::new()
+      StringBuilder::push(out, "E")
+      StringBuilder::push(out, serialize_segment(name))
+      StringBuilder::push(out, serialize_string_array(params))
+      StringBuilder::push(out, __to_string(Array::length(variants)))
+      StringBuilder::push(out, "[")
+      let mut i = 0
+      while i < Array::length(variants) {
+        let (variant, fields) = Array::get(variants, i)
+        StringBuilder::push(out, serialize_segment(variant))
+        StringBuilder::push(out, serialize_type_array(fields))
+        i = i + 1
+      }
+      StringBuilder::push(out, "]")
+      StringBuilder::freeze(out)
+    },
+    TDStruct(name, fields, mut_fields, params) => String::concat("S", String::concat(serialize_segment(name), String::concat(serialize_bindings(fields), String::concat(serialize_string_array(mut_fields), serialize_string_array(params))))),
+    TDAlias(name, params, target) => String::concat("A", String::concat(serialize_segment(name), String::concat(serialize_string_array(params), serialize_type(target)))),
+    // Effects deliberately have no declaration transport in this slice.
+    // The decoder rejects this tag, so a future accidental insertion cannot
+    // turn an undeclared effect into the old permissive fallback.
+    TDEffect(_, _, _) => "!"
+  }
+}
+
+fn parse_type_def(text: String, pos: Int) -> (TypeDef, Int) with Exception {
+  if pos >= String::length(text) {
+    throw("invalid persistent type definition")
+  } else {
+    match String::char_code_at(text, pos) {
+      'E' => {
+        let (name, after_name) = parse_segment(text, pos + 1)
+        let (params, after_params) = parse_string_array(text, after_name)
+        let (count, start) = parse_count_header(text, after_params, '[')
+        let variants = array_empty()
+        let mut i = 0
+        let mut cursor = start
+        while i < count {
+          let (variant, after_variant) = parse_segment(text, cursor)
+          let (fields, next) = parse_type_array(text, after_variant)
+          Array::push(variants, (variant, fields))
+          cursor = next
+          i = i + 1
+        }
+        if cursor >= String::length(text) || String::char_code_at(text, cursor) != ']' {
+          throw("invalid persistent enum definition")
+        } else {
+          (TDEnum(name, params, variants), cursor + 1)
+        }
+      },
+      'S' => {
+        let (name, after_name) = parse_segment(text, pos + 1)
+        let (fields, after_fields) = parse_bindings(text, after_name)
+        let (mut_fields, after_mut_fields) = parse_string_array(text, after_fields)
+        let (params, next) = parse_string_array(text, after_mut_fields)
+        (TDStruct(name, fields, mut_fields, params), next)
+      },
+      'A' => {
+        let (name, after_name) = parse_segment(text, pos + 1)
+        let (params, after_params) = parse_string_array(text, after_name)
+        let (target, next) = parse_cached_type(text, after_params)
+        (TDAlias(name, params, target), next)
+      },
+      _ => throw("invalid persistent type definition tag")
+    }
+  }
+}
+
+fn serialize_type_defs(defs: Array[TypeDef]) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, __to_string(Array::length(defs)))
+  StringBuilder::push(out, "[")
+  let mut i = 0
+  while i < Array::length(defs) {
+    StringBuilder::push(out, serialize_segment(serialize_type_def(Array::get(defs, i))))
+    i = i + 1
+  }
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+fn parse_type_defs(text: String, pos: Int) -> (Array[TypeDef], Int) with Exception {
+  let (count, start) = parse_count_header(text, pos, '[')
+  let defs = array_empty()
+  let mut i = 0
+  let mut cursor = start
+  while i < count {
+    let (raw, after_raw) = parse_segment(text, cursor)
+    let (def, end) = parse_type_def(raw, 0)
+    if end != String::length(raw) {
+      throw("invalid persistent type definition payload")
+    } else {
+      Array::push(defs, def)
+      cursor = after_raw
+      i = i + 1
+    }
+  }
+  if cursor >= String::length(text) || String::char_code_at(text, cursor) != ']' {
+    throw("invalid persistent type definitions")
+  } else {
+    (defs, cursor + 1)
+  }
+}
+
 fn serialize_bindings(items: Array[(String, Type)]) -> String {
   let buf = StringBuilder::new()
   StringBuilder::push(buf, __to_string(Array::length(items)))
@@ -580,6 +687,11 @@ fn serialize_type_env_into(buf: StringBuilder, env: TypeEnv) -> Unit {
       StringBuilder::push(buf, serialize_string_array(params))
       StringBuilder::push(buf, serialize_string_bounds(bounds))
       StringBuilder::push(buf, serialize_type(target))
+      serialize_type_env_into(buf, rest)
+    },
+    EnvTypeDefs(defs, rest) => {
+      StringBuilder::push(buf, "P")
+      StringBuilder::push(buf, serialize_type_defs(defs))
       serialize_type_env_into(buf, rest)
     },
     EnvFlat(bindings) => {
@@ -655,6 +767,11 @@ fn parse_persistent_type_env_payload(text: String, pos: Int) -> (TypeEnv, Int) w
         let (target, after_target) = parse_cached_type(text, after_bounds)
         let (rest, next) = parse_persistent_type_env_payload(text, after_target)
         (EnvTraitImplGen(name, params, bounds, target, rest), next)
+      },
+      'P' => {
+        let (defs, after_defs) = parse_type_defs(text, pos + 1)
+        let (rest, next) = parse_persistent_type_env_payload(text, after_defs)
+        (EnvTypeDefs(defs, rest), next)
       },
       'L' => {
         let (bindings, next) = parse_bindings(text, pos + 1)
@@ -741,13 +858,12 @@ export fn load_persistent_dep_list(path: String, source: String) -> Option[Array
   }
 }
 
-/// Strict v3 TypeEnv wire format. It preserves the full persistent chain,
-/// including trait definitions' header and method-generic provenance, impl
-/// entries, and EnvCached lookup state; v1/v2 are rejected rather than silently
-/// reconstructed or partially reused.
+/// Strict v4 module-interface wire format. It preserves the full persistent
+/// chain plus enum/struct/alias declaration authority. Older bare TypeEnv-v3
+/// bytes are rejected rather than being misread as an interface with no defs.
 export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Exception {
   let normalized = normalize_persistent_cache_text(text)
-  let header = "version\t3\nenv\t"
+  let header = "version\t4\nenv\t"
   let header_len = String::length(header)
   if String::length(normalized) < header_len || normalized[0: header_len] != header {
     None
@@ -776,7 +892,7 @@ export fn load_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with 
 }
 
 export fn persistent_type_env_cache_text(env: TypeEnv) -> String {
-  String::concat("version\t3\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
+  String::concat("version\t4\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
 }
 
 export fn load_persistent_leaf_fingerprint(path: String, source: String) -> Option[String] with Exception + Fs {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -22,6 +22,7 @@ import @vibe/compiler/core {
   Expr,
   Stmt,
   Type,
+  TypeDef,
   TypeEnv,
   bsearch_leftmost,
   dir_of_path,
@@ -29,6 +30,7 @@ import @vibe/compiler/core {
   env_flat_bindings,
   env_lookup,
   env_lookup_flat,
+  env_type_defs,
   normalize_path,
   resolution_env_seed,
   resolve_import_path,
@@ -308,6 +310,7 @@ fn trait_projection_supers(env: TypeEnv, name: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => trait_projection_supers(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_projection_supers(rest, name),
+    EnvTypeDefs(_, rest) => trait_projection_supers(rest, name),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => trait_projection_supers(rest, name)
   }
@@ -341,6 +344,7 @@ fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: St
       }
       trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
     },
+    EnvTypeDefs(_, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
     EnvFlat(_) => (),
     EnvCached(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
   }
@@ -557,6 +561,152 @@ fn trait_projection_map_method_bound_rows(bounds: Array[(String, Array[String])]
   out
 }
 
+fn typedef_projection_name(def: TypeDef) -> String {
+  match def {
+    TDEnum(name, _, _) => name,
+    TDStruct(name, _, _, _) => name,
+    TDAlias(name, _, _) => name,
+    TDEffect(name, _, _) => name
+  }
+}
+
+fn typedef_projection_contains(defs: Array[TypeDef], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(defs) && !found {
+    if typedef_projection_name(Array::get(defs, i)) == name {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn typedef_projection_add_type_refs(ty: Type, dep_defs: Array[TypeDef], selected: Array[TypeDef]) -> Unit {
+  match ty {
+    CtEnum(name) => typedef_projection_add_named(name, dep_defs, selected),
+    CtStruct(name) => typedef_projection_add_named(name, dep_defs, selected),
+    CtNamed(name, args) => {
+      typedef_projection_add_named(name, dep_defs, selected)
+      let mut i = 0
+      while i < Array::length(args) {
+        typedef_projection_add_type_refs(Array::get(args, i), dep_defs, selected)
+        i = i + 1
+      }
+    },
+    CtFn(args, ret, _) => {
+      let mut i = 0
+      while i < Array::length(args) {
+        typedef_projection_add_type_refs(Array::get(args, i), dep_defs, selected)
+        i = i + 1
+      }
+      typedef_projection_add_type_refs(ret, dep_defs, selected)
+    },
+    CtTuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        typedef_projection_add_type_refs(Array::get(items, i), dep_defs, selected)
+        i = i + 1
+      }
+    },
+    CtArray(item) => typedef_projection_add_type_refs(item, dep_defs, selected),
+    CtOption(item) => typedef_projection_add_type_refs(item, dep_defs, selected),
+    CtForAll(_, _, body) => typedef_projection_add_type_refs(body, dep_defs, selected),
+    _ => ()
+  }
+}
+
+fn typedef_projection_add_named(name: String, dep_defs: Array[TypeDef], selected: Array[TypeDef]) -> Unit {
+  if typedef_projection_contains(selected, name) {
+    ()
+  } else {
+    let mut i = 0
+    let mut found = None
+    let mut done = false
+    while i < Array::length(dep_defs) && !done {
+      let def = Array::get(dep_defs, i)
+      if typedef_projection_name(def) == name {
+        found = Some(def)
+        done = true
+      } else {
+        i = i + 1
+      }
+    }
+    match found {
+      Some(def) => {
+        Array::push(selected, def)
+        match def {
+          TDEnum(_, _, variants) => {
+            let mut vi = 0
+            while vi < Array::length(variants) {
+              let (_, fields) = Array::get(variants, vi)
+              let mut fi = 0
+              while fi < Array::length(fields) {
+                typedef_projection_add_type_refs(Array::get(fields, fi), dep_defs, selected)
+                fi = fi + 1
+              }
+              vi = vi + 1
+            }
+          },
+          TDStruct(_, fields, _, _) => {
+            let mut fi = 0
+            while fi < Array::length(fields) {
+              let (_, ty) = Array::get(fields, fi)
+              typedef_projection_add_type_refs(ty, dep_defs, selected)
+              fi = fi + 1
+            }
+          },
+          TDAlias(_, _, target) => typedef_projection_add_type_refs(target, dep_defs, selected),
+          TDEffect(_, _, _) => ()
+        }
+      },
+      None => ()
+    }
+  }
+}
+
+fn dependency_typedef_projection(dep_env: TypeEnv, names: Array[(String, Option[String])]) -> Array[TypeDef] {
+  let dep_defs = env_type_defs(dep_env)
+  let selected = array_empty()
+  let mut i = 0
+  while i < Array::length(names) {
+    let (name, alias) = Array::get(names, i)
+    let before = Array::length(selected)
+    typedef_projection_add_named(name, dep_defs, selected)
+    if Array::length(selected) > before {
+      match alias {
+        Some(local_name) => if local_name != name && !typedef_projection_contains(selected, local_name) {
+          let source = Array::get(selected, before)
+          let alias_def = match source {
+            TDEnum(_, _, _) => TDAlias(local_name, array_empty(), CtEnum(name)),
+            TDStruct(_, _, _, _) => TDAlias(local_name, array_empty(), CtStruct(name)),
+            TDAlias(_, _, target) => TDAlias(local_name, array_empty(), target),
+            TDEffect(_, _, _) => TDAlias(local_name, array_empty(), CtUnknown)
+          }
+          Array::push(selected, alias_def)
+        } else {
+          ()
+        },
+        None => ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  selected
+}
+
+fn prepend_dependency_type_defs(dep_env: TypeEnv, names: Array[(String, Option[String])], tail: TypeEnv) -> TypeEnv {
+  let defs = dependency_typedef_projection(dep_env, names)
+  if Array::length(defs) == 0 {
+    tail
+  } else {
+    EnvTypeDefs(defs, tail)
+  }
+}
+
 fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, String)], tail: TypeEnv) -> TypeEnv {
   // Preserve every generic implementation in source order. Its parameters and
   // bounds are semantic payload, so deduplicating by erased target spelling
@@ -607,6 +757,9 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
           Some(local_name) => Array::push(retained, EnvTraitImplGen(local_name, params, trait_projection_map_method_bound_rows(bounds, mappings), trait_projection_map_type_bounds(target, mappings), EnvEmpty)),
           None => ()
         }
+        cur = rest
+      },
+      EnvTypeDefs(_, rest) => {
         cur = rest
       },
       EnvFlat(_) => {
@@ -685,7 +838,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       bind_names(j + 1, with_companions)
     }
   }
-  bind_names(0, prepend_dependency_trait_nodes(dep_env, trait_mappings, acc))
+  bind_names(0, prepend_dependency_trait_nodes(dep_env, trait_mappings, prepend_dependency_type_defs(dep_env, names, acc)))
 }
 
 /// Shared by the filesystem and in-memory TypeDb lanes. The latter accepts
@@ -1632,6 +1785,52 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
   interface_sorted_unique(names)
 }
 
+fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Array[String] {
+  let names = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SEnum(true, name, _, _, _) => Array::push(names, name),
+      SStruct(true, name, _, _, _, _) => Array::push(names, name),
+      STypeAlias(true, name, _, _) => Array::push(names, name),
+      SExport(items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          Array::push(names, Array::get(items, j))
+          j = j + 1
+        }
+      },
+      SReExport(_, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let (source, alias) = Array::get(items, j)
+          Array::push(names, match alias {
+            Some(local) => local,
+            None => source
+          })
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  let defs = env_type_defs(checked_env)
+  let selected = array_empty()
+  let mut ni = 0
+  while ni < Array::length(names) {
+    typedef_projection_add_named(Array::get(names, ni), defs, selected)
+    ni = ni + 1
+  }
+  let out = array_empty()
+  let mut si = 0
+  while si < Array::length(selected) {
+    Array::push(out, typedef_projection_name(Array::get(selected, si)))
+    si = si + 1
+  }
+  interface_sorted_unique(out)
+}
+
 /// #1533: the environment a module PUBLISHES to its importers is its export
 /// surface, not its full checked environment. The checked environment binds
 /// every top-level `let`/`fn` -- and, via the import env at its base, every
@@ -1654,11 +1853,11 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
 /// Trait definitions and implementations are published only for the selected
 /// trait surface. EnvCached wrappers are rebuilt from the restricted chain
 /// (their arrays are acceleration state, same rule as the serializer's).
-fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: Array[String], env: TypeEnv) -> TypeEnv {
+fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: Array[String], type_surface: Array[String], env: TypeEnv) -> TypeEnv {
   match env {
     EnvEmpty => EnvEmpty,
     EnvBind(name, ty, rest) => {
-      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       if starts_with_upper(name) || bsearch_leftmost(value_surface, name) >= 0 {
         EnvBind(name, ty, restricted)
       } else {
@@ -1666,7 +1865,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       }
     },
     EnvTraitDef(name, supers, is_auto, methods, rest, params, method_gens) => {
-      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       if bsearch_leftmost(trait_surface, name) >= 0 {
         EnvTraitDef(name, supers, is_auto, methods, restricted, params, method_gens)
       } else {
@@ -1674,7 +1873,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       }
     },
     EnvTraitImpl(name, target, rest) => {
-      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       if bsearch_leftmost(trait_surface, name) >= 0 {
         EnvTraitImpl(name, target, restricted)
       } else {
@@ -1682,11 +1881,30 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       }
     },
     EnvTraitImplGen(name, params, bounds, target, rest) => {
-      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       if bsearch_leftmost(trait_surface, name) >= 0 {
         EnvTraitImplGen(name, params, bounds, target, restricted)
       } else {
         restricted
+      }
+    },
+    EnvTypeDefs(defs, rest) => {
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
+      let kept = array_empty()
+      let mut i = 0
+      while i < Array::length(defs) {
+        let def = Array::get(defs, i)
+        if bsearch_leftmost(type_surface, typedef_projection_name(def)) >= 0 {
+          Array::push(kept, def)
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      if Array::length(kept) == 0 {
+        restricted
+      } else {
+        EnvTypeDefs(kept, restricted)
       }
     },
     EnvFlat(bindings) => {
@@ -1712,7 +1930,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
     // module lane resolves an import over a same-named local (the merge
     // lane shadows correctly), while an `as` alias broke the
     // collect_merged_stmts lane instead. Both are their own bugs.
-    EnvCached(_, _, rest) => restrict_env_to_export_surface(value_surface, trait_surface, rest)
+    EnvCached(_, _, rest) => restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
   }
 }
 
@@ -2816,7 +3034,8 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
       // environment never needs to outlive the check itself.
       let value_surface = interface_public_value_names(stmts)
       let trait_surface = interface_public_trait_names(stmts, full_checked_env)
-      let checked_env = restrict_env_to_export_surface(value_surface, trait_surface, full_checked_env)
+      let type_surface = interface_public_type_names(stmts, full_checked_env)
+      let checked_env = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, full_checked_env)
       let interface_identity = if incremental_interface_trace_enabled() {
         incremental_interface_identity(job.source, checked_env)
       } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -81,6 +81,22 @@ fn empty_dep_fps() -> Array[(String, String)] {
   array_empty()
 }
 
+/// Every acceptance of a persistent fingerprint must first decode its v4
+/// interface. Old/corrupt bytes are ordinary cold-cache misses.
+fn valid_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with Exception + Fs {
+  load_persistent_type_env(fingerprint)
+}
+
+fn valid_persistent_leaf_fingerprint(path: String, source: String) -> Option[String] with Exception + Fs {
+  match load_persistent_leaf_fingerprint(path, source) {
+    Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
+      Some(_) => Some(fingerprint),
+      None => None
+    },
+    None => None
+  }
+}
+
 fn lookup_env_cache(cache: Array[(String, TypeEnv)], path: String) -> Option[TypeEnv] {
   let len = Array::length(cache)
   let mut i = 0
@@ -140,6 +156,22 @@ fn type_returns_name(ty: Type, type_name: String) -> Bool {
     CtForAll(_, _, body) => type_returns_name(body, type_name),
     _ => false
   }
+}
+
+/// Constructors and generated `Type::member` values are value bindings, but
+/// their authority is the selected public typedef rather than capitalization.
+fn is_selected_type_companion(name: String, ty: Type, type_surface: Array[String]) -> Bool {
+  let mut i = 0
+  let mut selected = false
+  while i < Array::length(type_surface) && !selected {
+    let type_name = Array::get(type_surface, i)
+    if name == type_name || String::starts_with(name, String::concat(type_name, "::")) || type_returns_name(ty, type_name) {
+      selected = true
+    } else {
+      i = i + 1
+    }
+  }
+  selected
 }
 
 /// Companions bound alongside an imported type `T`: (a) constructors and
@@ -679,9 +711,15 @@ fn dependency_typedef_projection(dep_env: TypeEnv, names: Array[(String, Option[
         Some(local_name) => if local_name != name && !typedef_projection_contains(selected, local_name) {
           let source = Array::get(selected, before)
           let alias_def = match source {
-            TDEnum(_, _, _) => TDAlias(local_name, array_empty(), CtEnum(name)),
-            TDStruct(_, _, _, _) => TDAlias(local_name, array_empty(), CtStruct(name)),
-            TDAlias(_, _, target) => TDAlias(local_name, array_empty(), target),
+            TDEnum(_, params, _) => TDAlias(local_name, params, CtNamed(name, for param in params {
+              CtNamed(param, array_empty())
+            })),
+            TDStruct(_, _, _, params) => TDAlias(local_name, params, CtNamed(name, for param in params {
+              CtNamed(param, array_empty())
+            })),
+            TDAlias(_, params, target) => TDAlias(local_name, params, target),
+            // Effects have no declaration transport; this branch is
+            // unreachable for a selected import and must not fabricate one.
             TDEffect(_, _, _) => TDAlias(local_name, array_empty(), CtUnknown)
           }
           Array::push(selected, alias_def)
@@ -791,6 +829,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
     None => EnvEmpty
   }
   let dep_bindings = env_flat_bindings(dep_env)
+  let dep_type_defs = env_type_defs(dep_env)
   // Explicit trait aliases must be known before values are bound: a selected
   // value can mention the trait before its `trait X as Local` row appears.
   let trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, unresolved)
@@ -818,7 +857,12 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       let ty = match env_lookup_flat(dep_bindings, name) {
         Some(t) => trait_projection_map_type_bounds(t, trait_mappings),
         None => {
-          if dep_known && !starts_with_upper(name) {
+          // Declaration authority now travels explicitly in EnvTypeDefs, so
+          // uppercase is no longer evidence that an import is valid. This
+          // also rejects selected effects/effectsets until their own authority
+          // transport exists, instead of allowing a missing uppercase import
+          // to become CtUnknown and fail later in codegen.
+          if dep_known && !typedef_projection_contains(dep_type_defs, name) && !trait_defined(dep_env, name) {
             Array::push(unresolved, String::concat(String::concat(String::concat("imported name '", name), "' is not exported by '"), String::concat(raw_path, "'")))
           } else {
             ()
@@ -1198,9 +1242,9 @@ let incremental_checked_env_trace_observations: Array[(String, String)] = [
 let incremental_persistent_type_env_transport_trace_observations: Array[(String, String)] = [
 ]
 
-// TDRE4 aliases only an exact v3 decoded TypeEnv when every direct dependency
+// TDRE4 aliases only an exact v4 decoded TypeEnv when every direct dependency
 // transport environment is unchanged. It is not a CheckedProgram or typed-IR
-// transport; v3 retains the TypeEnv trait/impl chain only. The empty cell is
+// transport; v4 retains the TypeEnv declaration, trait, and impl chain. The empty cell is
 // conservative for direct FS consumers. The CLI check-only lane explicitly
 // enables production reuse after validating its per-invocation policy; build,
 // codegen, and other FS consumers remain off pending compact publication.
@@ -1841,14 +1885,9 @@ fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arra
 /// makes the existing membership check in
 /// bind_import_names_from_cache_collecting the export test itself.
 ///
-/// Only lowercase-initial bindings are dropped, and `surface` is
-/// interface_public_value_names -- exported `let`/`fn`, `export { .. }`
-/// lists, and re-export aliases -- which is exactly the set of importable
-/// lowercase names. Uppercase bindings (enum constructors, `T::` companions,
-/// qualified impl methods) are kept wholesale: the value environment cannot
-/// distinguish an unexported `Foo` from a struct-only `Foo`, so their half
-/// of #1521 stays open rather than risk rejecting valid code, and the
-/// companion-binding scan over dep_bindings keeps working unchanged.
+/// Value bindings are retained only when they are explicitly exported.
+/// Type/constructor authority travels separately through `EnvTypeDefs`; an
+/// uppercase spelling is never authority to import a private declaration.
 ///
 /// Trait definitions and implementations are published only for the selected
 /// trait surface. EnvCached wrappers are rebuilt from the restricted chain
@@ -1858,7 +1897,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
     EnvEmpty => EnvEmpty,
     EnvBind(name, ty, rest) => {
       let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
-      if starts_with_upper(name) || bsearch_leftmost(value_surface, name) >= 0 {
+      if bsearch_leftmost(value_surface, name) >= 0 || is_selected_type_companion(name, ty, type_surface) {
         EnvBind(name, ty, restricted)
       } else {
         restricted
@@ -1912,7 +1951,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       let mut i = 0
       while i < Array::length(bindings) {
         let (name, ty) = Array::get(bindings, i)
-        if starts_with_upper(name) || bsearch_leftmost(value_surface, name) >= 0 {
+        if bsearch_leftmost(value_surface, name) >= 0 || is_selected_type_companion(name, ty, type_surface) {
           Array::push(kept, (name, ty))
         } else {
           ()
@@ -2230,7 +2269,7 @@ fn incremental_checked_env_identity(env: TypeEnv) -> String with Exception {
   compact_string_fingerprint(StringBuilder::freeze(out))
 }
 
-/// A trace-only observation of the complete persistent TypeEnv v3 transport.
+/// A trace-only observation of the complete persistent TypeEnv v4 transport.
 /// The canonical cache-text bytes are the sole input. This is not a
 /// CheckedProgram, typed IR, exported interface, cache key, or reuse decision.
 fn incremental_persistent_type_env_transport_identity(env: TypeEnv) -> String {
@@ -2284,7 +2323,7 @@ fn incremental_trace_json_string(text: String) -> String {
 /// provisional canonical token-stream identity, not normalized typed IR.
 /// `checked_env_fingerprint` is a complete value-environment observation.
 /// `persistent_type_env_transport_fingerprint` observes only the complete
-/// persistent TypeEnv v3 transport, not a CheckedProgram, typed IR, exported
+/// persistent TypeEnv v4 transport, not a CheckedProgram, typed IR, exported
 /// interface, cache key, or reuse decision. `decision` records what this current TypeDb
 /// walk did (`rechecked` or `reused`), not a formal invalidation verdict.
 /// This function is called only after a successful check; a missing per-module
@@ -2349,7 +2388,7 @@ export fn incremental_invalidation_trace_json(entry_path: String, run_nonce: Str
       None => throw(String::concat("incremental invalidation trace: missing complete persistent TypeEnv transport observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(persistent_type_env_transport_fingerprint))
-    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v3 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
+    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v4 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
     StringBuilder::push(out, incremental_trace_json_string(decision))
     StringBuilder::push(out, "}")
     i = i + 1
@@ -2476,10 +2515,10 @@ let parse_memo_paths: Array[String] = [
   text
 }
 
-// TDRE4 is deliberately independent from the TypeEnv v3 envelope and from
+// TDRE4 is deliberately independent from the TypeEnv v4 envelope and from
 // every production artifact/cache identity. Both v4 envelopes use strict
 // decimal length-delimited fields and bind the logical checker input, target
-// conservative fingerprint, and exact canonical TypeEnv-v3 transport text.
+// conservative fingerprint, and exact canonical TypeEnv-v4 transport text.
 // The target text is intentionally not replaced by a compact fingerprint:
 // cache corruption must not turn a fingerprint collision into checker reuse.
 let typing_dependency_env_reuse_alias_v4_tag = "TDRE4A"
@@ -2570,7 +2609,7 @@ fn typing_dependency_transport_input_key(path: String, source: String, dep_envs:
 }
 
 /// Decode untrusted target bytes strictly and require the decoder's canonical
-/// v3 re-encoding to equal both the raw file and the binding's exact text.
+/// v4 re-encoding to equal both the raw file and the binding's exact text.
 /// parse_persistent_type_env accepts normalized line endings for ordinary cache
 /// compatibility; this additional equality makes the experimental lane strict.
 fn load_canonical_typing_dependency_env_reuse_target(target_fingerprint: String, expected_target_text: String) -> Option[TypeEnv] with Fs {
@@ -2624,7 +2663,7 @@ fn typing_dependency_env_reuse_eligibility_is_valid(fingerprint: String) -> Bool
   }
 }
 
-/// Eligibility is transitively witnessed by successful canonical TypeEnv-v3
+/// Eligibility is transitively witnessed by successful canonical TypeEnv-v4
 /// commits. Missing, malformed, stale, torn, or cross-spliced witnesses fail
 /// closed before the alias lookup.
 fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> Bool with Fs {
@@ -2988,7 +3027,7 @@ export fn locate_type_error(source: String, msg: String) -> String {
 /// resolve from impl units against the contract definition.
 export enum ModuleOutcome {
   // The final strings are trace-only interface, checked-value-env, and
-  // complete persistent TypeEnv v3 transport identities. They are computed
+  // complete persistent TypeEnv v4 transport identities. They are computed
   // from this successful check's typed environment, never used as cache
   // inputs, and are empty unless the invalidation trace is enabled.
   Checked(String, String, TypeEnv, String, String, String);
@@ -3316,7 +3355,17 @@ fn parse_publish_manifest_rows(text: String) -> Array[(String, String)] with Exc
   while i < len {
     let (fingerprint, env_file) = Array::get(rows, i)
     let env_text = Fs::read_file(job_dir_path(dir, env_file))
-    Fs::write_file(persistent_type_env_cache_path(fingerprint), env_text)
+    match parse_persistent_type_env(env_text) {
+      Some(env) => {
+        let canonical = persistent_type_env_cache_text(env)
+        if env_text == canonical {
+          Fs::write_file(persistent_type_env_cache_path(fingerprint), env_text)
+        } else {
+          throw(String::concat("publish manifest has non-canonical v4 environment: ", env_file))
+        }
+      },
+      None => throw(String::concat("publish manifest has unreadable v4 environment: ", env_file))
+    }
     i = i + 1
   }
 }
@@ -3329,58 +3378,58 @@ fn parse_publish_manifest_rows(text: String) -> Array[(String, String)] with Exc
 /// cross-check) that identical fingerprint itself, the same way a worker
 /// would -- one canonical computation, not a value trusted from the caller.
 fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String, source: String, deps: Array[String], dep_fps: Array[(String, String)], fingerprint: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
-  if Fs::exists(persistent_type_env_cache_path(fingerprint)) {
-    if incremental_interface_trace_enabled() {
-      match load_persistent_type_env(fingerprint) {
-        Some(cached_env) => incremental_trace_observe_checked_env(path, source, cached_env),
-        None => throw(String::concat("incremental trace observation: unreadable reused environment for ", path))
+  match valid_persistent_type_env(fingerprint) {
+    Some(cached_env) => {
+      if incremental_interface_trace_enabled() {
+        incremental_trace_observe_checked_env(path, source, cached_env)
+      } else {
+        ()
       }
-    } else {
-      ()
-    }
-    let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
-    (fingerprint, next_db, env_cache, dep_source_cache, parse_count)
-  } else {
-    // Keep the accumulated cache as coordinator state, but expose exactly the
-    // resolved dependency sequence to the checker and TDRE4. Construct this
-    // once: lookup, check, and publication must describe the same value.
-    let coordinated_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
-    let projected_dep_envs = project_exact_dependency_envs(deps, coordinated_env_cache)
-    let reused_env = if experimental_typing_dependency_env_reuse_enabled() {
-      if typing_dependency_env_reuse_is_eligible(dep_fps) {
-        let input_key = typing_dependency_transport_input_key(path, source, projected_dep_envs)
-        match load_typing_dependency_env_reuse_target(input_key) {
-          Some((target_fingerprint, target_text, target_env)) => Some((input_key, target_fingerprint, target_text, target_env)),
-          None => None
+      let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
+      (fingerprint, next_db, env_cache, dep_source_cache, parse_count)
+    },
+    None => {
+      // Keep the accumulated cache as coordinator state, but expose exactly the
+      // resolved dependency sequence to the checker and TDRE4. Construct this
+      // once: lookup, check, and publication must describe the same value.
+      let coordinated_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
+      let projected_dep_envs = project_exact_dependency_envs(deps, coordinated_env_cache)
+      let reused_env = if experimental_typing_dependency_env_reuse_enabled() {
+        if typing_dependency_env_reuse_is_eligible(dep_fps) {
+          let input_key = typing_dependency_transport_input_key(path, source, projected_dep_envs)
+          match load_typing_dependency_env_reuse_target(input_key) {
+            Some((target_fingerprint, target_text, target_env)) => Some((input_key, target_fingerprint, target_text, target_env)),
+            None => None
+          }
+        } else {
+          None
         }
       } else {
         None
       }
-    } else {
-      None
-    }
-    match reused_env {
-      Some((input_key, _target_fingerprint, target_text, target_env)) => {
-        // Preserve the ordinary conservative fingerprint path for every later
-        // consumer. Commit this target first, then its exact bound witness, and
-        // only then the alias, so torn publication always fails closed.
-        Fs::write_file(persistent_type_env_cache_path(fingerprint), target_text)
-        publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
-        write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
-        let next_env_cache = upsert_env_cache(coordinated_env_cache, path, target_env)
-        let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
-        (fingerprint, next_db, next_env_cache, dep_source_cache, parse_count)
-      },
-      None => {
-        let job = ModuleJob::{
-          path: path,
-          source: source,
-          deps: deps,
-          dep_fps: dep_fps,
-          dep_envs: projected_dep_envs
+      match reused_env {
+        Some((input_key, _target_fingerprint, target_text, target_env)) => {
+          // Preserve the ordinary conservative fingerprint path for every later
+          // consumer. Commit this target first, then its exact bound witness, and
+          // only then the alias, so torn publication always fails closed.
+          Fs::write_file(persistent_type_env_cache_path(fingerprint), target_text)
+          publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
+          write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
+          let next_env_cache = upsert_env_cache(coordinated_env_cache, path, target_env)
+          let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
+          (fingerprint, next_db, next_env_cache, dep_source_cache, parse_count)
+        },
+        None => {
+          let job = ModuleJob::{
+            path: path,
+            source: source,
+            deps: deps,
+            dep_fps: dep_fps,
+            dep_envs: projected_dep_envs
+          }
+          let outcome = check_module(job)
+          commit_module_outcome(rdb, coordinated_env_cache, dep_source_cache, parse_count + 1, job, outcome)
         }
-        let outcome = check_module(job)
-        commit_module_outcome(rdb, coordinated_env_cache, dep_source_cache, parse_count + 1, job, outcome)
       }
     }
   }
@@ -3475,7 +3524,10 @@ fn plan_import_graph_fs(rdb: RippleDb, dep_source_cache: Array[(String, String)]
       Some(source) => {
         let reusable = if dep_source_cache_is_current(dep_source_cache, path, source) {
           match ripple_get_fingerprint(rdb, path) {
-            Some(_) => true,
+            Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
+              Some(_) => true,
+              None => false
+            },
             None => false
           }
         } else {
@@ -3484,7 +3536,7 @@ fn plan_import_graph_fs(rdb: RippleDb, dep_source_cache: Array[(String, String)]
         if reusable {
           ()
         } else {
-          match load_persistent_leaf_fingerprint(path, source) {
+          match valid_persistent_leaf_fingerprint(path, source) {
             Some(leaf_fingerprint) => Array::push(leaf_fps, (path, leaf_fingerprint)),
             None => {
               // Codex review P2: resolving a module's imports PARSES it, so a
@@ -3566,18 +3618,22 @@ fn plan_deps_of(plan_edges: Array[(String, Array[String])], path: String) -> Opt
 /// The leaf-fingerprint arm: a module whose persistent leaf cache is valid is
 /// recorded with no deps at all and needs no checking.
 fn commit_leaf_fingerprint_fs(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String, source: String, leaf_fingerprint: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
-  if incremental_interface_trace_enabled() {
-    match load_persistent_type_env(leaf_fingerprint) {
-      Some(cached_env) => incremental_trace_observe_checked_env(path, source, cached_env),
-      None => throw(String::concat("incremental trace observation: unreadable reused leaf environment for ", path))
-    }
-  } else {
-    ()
+  // The plan read this cache earlier, but recheck at the accepting edge: a
+  // stale/malformed leaf pointer must cold-check rather than become authority.
+  match valid_persistent_type_env(leaf_fingerprint) {
+    Some(cached_env) => {
+      if incremental_interface_trace_enabled() {
+        incremental_trace_observe_checked_env(path, source, cached_env)
+      } else {
+        ()
+      }
+      write_persistent_dep_list_if_missing(path, source, empty_stack())
+      let next_dep_source_cache = upsert_string_pair(dep_source_cache, path, source)
+      let next_db = ripple_record_eval(rdb, path, leaf_fingerprint, empty_stack())
+      (leaf_fingerprint, next_db, env_cache, next_dep_source_cache, parse_count)
+    },
+    None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(source, empty_dep_fps()))
   }
-  write_persistent_dep_list_if_missing(path, source, empty_stack())
-  let next_dep_source_cache = upsert_string_pair(dep_source_cache, path, source)
-  let next_db = ripple_record_eval(rdb, path, leaf_fingerprint, empty_stack())
-  (leaf_fingerprint, next_db, env_cache, next_dep_source_cache, parse_count)
 }
 /// One module's step, once its dependency list is known and every dependency
 /// already has a fingerprint. Folds the dependency fingerprints in
@@ -3603,7 +3659,10 @@ fn commit_with_deps_fs(fps: Array[(String, String)], rdb: RippleDb, env_cache: A
   match ripple_get_fingerprint(rdb, path) {
     Some(cached_fp) =>
     if cached_fp == fingerprint {
-      (fingerprint, rdb, env_cache, dep_source_cache, parse_count)
+      match valid_persistent_type_env(fingerprint) {
+        Some(_) => (fingerprint, rdb, env_cache, dep_source_cache, parse_count),
+        None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, deps, dep_fps, fingerprint)
+      }
     } else {
       finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, deps, dep_fps, fingerprint)
     },
@@ -3636,7 +3695,13 @@ fn step_module_fs(plan_leaf_fps: Array[(String, String)], plan_edges: Array[(Str
     None => (String::concat("missing:", path), rdb, env_cache, dep_source_cache, parse_count),
     Some(source) => {
       let reusable = if dep_source_cache_is_current(dep_source_cache, path, source) {
-        ripple_get_fingerprint(rdb, path)
+        match ripple_get_fingerprint(rdb, path) {
+          Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
+            Some(_) => Some(fingerprint),
+            None => None
+          },
+          None => None
+        }
       } else {
         None
       }

--- a/lib/@vibe/compiler/tests/checker_program_result_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_program_result_test.vibe
@@ -76,6 +76,7 @@ fn trait_header_params(env: TypeEnv, wanted: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => trait_header_params(rest, wanted),
     EnvTraitImplGen(_, _, _, _, rest) => trait_header_params(rest, wanted),
+    EnvTypeDefs(_, rest) => trait_header_params(rest, wanted),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => trait_header_params(rest, wanted)
   }

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Type, TypeEnv, TypeExpr, env_lookup, trait_method_sig, trait_supers, types_equal
+  Type, TypeDef, TypeEnv, TypeExpr, env_lookup, env_type_defs, trait_method_sig, trait_supers, types_equal
 }
 
 import @vibe/compiler/runtime {
@@ -110,6 +110,7 @@ fn retained_trait_header_params(env: TypeEnv, name: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => retained_trait_header_params(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => retained_trait_header_params(rest, name),
+    EnvTypeDefs(_, rest) => retained_trait_header_params(rest, name),
     EnvFlat(_) => [
     ],
     EnvCached(_, _, rest) => retained_trait_header_params(rest, name)
@@ -127,6 +128,7 @@ fn retained_trait_method_gens(env: TypeEnv, name: String) -> Array[(String, Arra
     },
     EnvTraitImpl(_, _, rest) => retained_trait_method_gens(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => retained_trait_method_gens(rest, name),
+    EnvTypeDefs(_, rest) => retained_trait_method_gens(rest, name),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => retained_trait_method_gens(rest, name)
   }
@@ -144,6 +146,7 @@ fn retained_generic_impl_bounds(env: TypeEnv, name: String) -> Array[(String, Ar
     } else {
       retained_generic_impl_bounds(rest, name)
     },
+    EnvTypeDefs(_, rest) => retained_generic_impl_bounds(rest, name),
     EnvFlat(_) => [
     ],
     EnvCached(_, _, rest) => retained_generic_impl_bounds(rest, name)
@@ -163,10 +166,10 @@ fn malformed_rejected(text: String) -> Bool {
 
 //# Tests
 
-test "persistent TypeEnv v3 round-trips every variant and trait payload" {
+test "persistent module interface v4 round-trips every variant and trait payload" {
   let env = codec_fixture()
   let encoded = persistent_type_env_cache_text(env)
-  assert(String::starts_with(encoded, "version\t3\nenv\t"))
+  assert(String::starts_with(encoded, "version\t4\nenv\t"))
   // TDRE4 hardening binds this exact canonical text externally; it does not
   // change or wrap the production TypeEnv-v3 transport envelope itself.
   assert(String::index_of(encoded, "TDRE4") < 0)
@@ -221,7 +224,52 @@ test "persistent TypeEnv v3 round-trips every variant and trait payload" {
   }
 }
 
-test "persistent TypeEnv v3 rebuilds untrusted cached lookup indexes" {
+test "persistent module interface v4 round-trips enum struct and alias authority" {
+  let defs = [
+    TDEnum("Choice", [
+      "T"
+    ], [
+      ("Pick", [
+        CtNamed("T", [
+        ])
+      ])
+    ]),
+    TDStruct("Box", [
+      ("value", CtNamed("T", [
+      ]))
+    ], [
+    ], [
+      "T"
+    ]),
+    TDAlias("ChoiceBox", [
+    ], CtStruct("Box"))
+  ]
+  let env = EnvTypeDefs(defs, EnvBind("Choice", CtEnum("Choice"), EnvEmpty))
+  match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
+    Some(decoded) => {
+      let decoded_defs = env_type_defs(decoded)
+      assert(Array::length(decoded_defs) == 3)
+      match (Array::get(decoded_defs, 0), Array::get(decoded_defs, 1), Array::get(decoded_defs, 2)) {
+        (TDEnum(name, params, variants), TDStruct(struct_name, fields, _, struct_params), TDAlias(alias, _, CtStruct(target))) => {
+          assert(name == "Choice")
+          assert(Array::get(params, 0) == "T")
+          let (variant, payload) = Array::get(variants, 0)
+          assert(variant == "Pick")
+          assert(Array::length(payload) == 1)
+          assert(struct_name == "Box")
+          assert(Array::get(struct_params, 0) == "T")
+          assert(Array::get(fields, 0).0 == "value")
+          assert(alias == "ChoiceBox")
+          assert(target == "Box")
+        },
+        _ => assert(false)
+      }
+    },
+    None => assert(false)
+  }
+}
+
+test "persistent module interface v4 rebuilds untrusted cached lookup indexes" {
   let corrupt = EnvCached([
     "shadow",
     "shadow",
@@ -253,12 +301,14 @@ test "persistent TypeEnv v3 rebuilds untrusted cached lookup indexes" {
   }
 }
 
-test "persistent TypeEnv v3 rejects old, truncated, and malformed envelopes" {
+test "persistent module interface v4 rejects old, truncated, and malformed envelopes" {
   assert(malformed_rejected("version\t1\nbind\tvalue\tI\n"))
   assert(malformed_rejected("version\t2\nenv\t1:0\n"))
-  assert(malformed_rejected("version\t3\nenv\t"))
-  assert(malformed_rejected("version\t3\nenv\t1:Z\n"))
-  assert(malformed_rejected("version\t3\nenv\t2:00\n"))
-  assert(malformed_rejected("version\t3\nenv\t4:B0:0\n"))
-  assert(malformed_rejected("version\t3\nenv\t1:0\ntrailing"))
+  // Bare v3 was a value/trait-only TypeEnv, never an empty declaration interface.
+  assert(malformed_rejected("version\t3\nenv\t1:0\n"))
+  assert(malformed_rejected("version\t4\nenv\t"))
+  assert(malformed_rejected("version\t4\nenv\t1:Z\n"))
+  assert(malformed_rejected("version\t4\nenv\t2:00\n"))
+  assert(malformed_rejected("version\t4\nenv\t4:B0:0\n"))
+  assert(malformed_rejected("version\t4\nenv\t1:0\ntrailing"))
 }

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -269,6 +269,41 @@ test "persistent module interface v4 round-trips enum struct and alias authority
   }
 }
 
+test "legacy enum carrier bytes cannot alter v4 typedef authority" {
+  let declared = TDEnum("Choice", [
+  ], [
+    ("Pick", [
+      CtInt
+    ])
+  ])
+  // This was the retired `Choice::__variants__` value carrier. It is valid
+  // TypeEnv data but EnvTypeDefs must remain the only declaration authority.
+  let env = EnvTypeDefs([
+    declared
+  ], EnvBind("Choice::__variants__", CtNamed("__variants__", [
+    CtNamed("Corrupt", [
+      CtString
+    ])
+  ]), EnvEmpty))
+  match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
+    Some(decoded) => {
+      let defs = env_type_defs(decoded)
+      assert(Array::length(defs) == 1)
+      match Array::get(defs, 0) {
+        TDEnum(name, params, variants) => {
+          assert(name == "Choice")
+          assert(Array::length(params) == 0)
+          let (variant, fields) = Array::get(variants, 0)
+          assert(variant == "Pick")
+          assert(Array::get(fields, 0) == CtInt)
+        },
+        _ => assert(false)
+      }
+    },
+    None => assert(false)
+  }
+}
+
 test "persistent module interface v4 rebuilds untrusted cached lookup indexes" {
   let corrupt = EnvCached([
     "shadow",

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -178,7 +178,7 @@ test "db_typecheck_fs: re-exported enum type imports constructors" {
   let main_path = "/tmp/vibe_compiler_reexport_enum_ctor_fs_main.vibe"
   let ast_src = "export enum TypeExpr { TyName(String); TyTuple(Array[TypeExpr]) }"
   let index_src = "export ./vibe_compiler_reexport_enum_ctor_fs_ast.vibe { TypeExpr }"
-  let main_src = "import ./vibe_compiler_reexport_enum_ctor_fs_index.vibe { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
+  let main_src = "import ./vibe_compiler_reexport_enum_ctor_fs_index.vibe { TypeExpr }\nexport { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
   Fs::write_bytes(ast_path, string_to_bytes(ast_src))
   Fs::write_bytes(index_path, string_to_bytes(index_src))
   Fs::write_bytes(main_path, string_to_bytes(main_src))
@@ -213,7 +213,7 @@ test "db_typecheck_fs: extensionless directory re-export imports enum constructo
   let main_path = String::concat(base_dir, "/main.vibe")
   let ast_src = "export enum TypeExpr { TyName(String); TyTuple(Array[TypeExpr]) }"
   let index_src = "export ./ast.vibe { TypeExpr }"
-  let main_src = "import ./core { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
+  let main_src = "import ./core { TypeExpr }\nexport { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
   Fs::mkdir_p(core_dir)
   Fs::write_bytes(ast_path, string_to_bytes(ast_src))
   Fs::write_bytes(index_path, string_to_bytes(index_src))
@@ -660,6 +660,23 @@ fn export_surface_error(paths: Array[String], entry: String) -> String with Fs {
   }
 }
 
+fn typedef_surface_pair_error(dir: String, dep_src: String, main_src: String) -> String with Fs {
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ]))
+  export_surface_error([
+    dep_path,
+    main_path
+  ], main_path)
+}
+
 test "db_typecheck_fs: importing a private (non-export) name is reported (#1533)" {
   let dir = "/tmp/vibe_compiler_export_surface_private"
   let dep_path = String::concat(dir, "/dep.vibe")
@@ -785,4 +802,55 @@ test "db_typecheck_fs: a re-exported name IS on the middleman's surface (#1533 c
     main_path
   ], main_path)
   assert(err == "")
+}
+
+test "db_typecheck_fs: private struct enum and alias declarations are not importable" {
+  let struct_err = typedef_surface_pair_error("/tmp/vibe_private_struct_authority", "struct Secret { value: Int }\n", "import ./dep.vibe { Secret }\nexport let value = Secret(1)\n")
+  assert(String::contains(struct_err, "imported name 'Secret' is not exported by"))
+  let enum_err = typedef_surface_pair_error("/tmp/vibe_private_enum_authority", "enum Secret { Hidden(Int) }\n", "import ./dep.vibe { Secret }\nexport let value = Hidden(1)\n")
+  assert(String::contains(enum_err, "imported name 'Secret' is not exported by"))
+  let alias_err = typedef_surface_pair_error("/tmp/vibe_private_alias_authority", "type Secret = Int\n", "import ./dep.vibe { Secret }\nexport let value: Secret = 1\n")
+  assert(String::contains(alias_err, "imported name 'Secret' is not exported by"))
+}
+
+test "db_typecheck_fs: public struct enum and alias declarations remain importable" {
+  let err = typedef_surface_pair_error("/tmp/vibe_public_typedef_authority", "export struct PublicStruct { value: Int }\nexport enum PublicEnum { PublicCase(Int) }\nexport type PublicAlias = Int\n", "import ./dep.vibe { PublicStruct, PublicEnum, PublicAlias }\nexport let s = PublicStruct(1)\nexport let e = PublicCase(1)\nexport let a: PublicAlias = 1\n")
+  assert(err == "")
+}
+
+test "db_typecheck_fs: imported generic alias enum and struct aliases retain formals" {
+  let err = typedef_surface_pair_error("/tmp/vibe_generic_typedef_alias_authority", "export type Wrap[T] = Array[T]\nexport enum Choice[T] { Pick(T) }\nexport struct Box[T] { value: T }\n", "import ./dep.vibe { Wrap as LocalWrap, Choice as LocalChoice, Box as LocalBox }\nexport let xs: LocalWrap[Int] = [1]\nexport let picked: LocalChoice[Int] = Pick(1)\nexport fn unbox(value: LocalBox[String]) -> String { value.value }\n")
+  assert(err == "")
+}
+
+test "db_typecheck_fs: a local typedef shadows imported declaration authority" {
+  let err = typedef_surface_pair_error("/tmp/vibe_local_typedef_shadow", "export type Label = Int\n", "import ./dep.vibe { Label }\ntype Label = String\nexport fn use_label(value: Label) -> String { value }\n")
+  assert(err == "")
+}
+
+test "db_typecheck_fs: selected effects and effectsets reject until authority transport exists" {
+  let effect_err = typedef_surface_pair_error("/tmp/vibe_selected_effect_rejected", "export effect Audit { Emit(String) -> Unit }\n", "import ./dep.vibe { Audit }\nexport let value = 1\n")
+  assert(String::contains(effect_err, "imported name 'Audit' is not exported by"))
+  let set_err = typedef_surface_pair_error("/tmp/vibe_selected_effectset_rejected", "effect Audit { Emit(String) -> Unit }\nexport effectset Audits = { Audit }\n", "import ./dep.vibe { Audits }\nexport let value = 1\n")
+  assert(String::contains(set_err, "imported name 'Audits' is not exported by"))
+}
+
+test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck as v4" {
+  let dir = "/tmp/vibe_v4_cache_cold_recheck"
+  let path = String::concat(dir, "/main.vibe")
+  let source = "export let value = 1\n"
+  let fingerprint = build_test_fingerprint(source, array_empty())
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(path, string_to_bytes(source))
+  remove_typecheck_fs_cache(path, source, fingerprint)
+  let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
+  let env_path = persistent_type_env_cache_path(fingerprint)
+  let leaf_path = persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(source))
+  Fs::write_file(env_path, "version\t3\nenv\t1:0\n")
+  let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
+  assert(String::starts_with(Fs::read_file(env_path), "version\t4\nenv\t"))
+  Fs::write_file(env_path, "version\t4\nenv\t1:Z\n")
+  Fs::write_file(leaf_path, "version\t1\nnot-a-fingerprint\n")
+  let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
+  assert(String::starts_with(Fs::read_file(env_path), "version\t4\nenv\t"))
 }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -81,6 +81,7 @@ fn retained_trait_node_tags(env: TypeEnv) -> String {
     EnvTraitDef(name, _, _, _, rest, _, _) => String::concat(String::concat("def:", name), String::concat(";", retained_trait_node_tags(rest))),
     EnvTraitImpl(name, _, rest) => String::concat(String::concat("impl:", name), String::concat(";", retained_trait_node_tags(rest))),
     EnvTraitImplGen(name, _, _, _, rest) => String::concat(String::concat("gen:", name), String::concat(";", retained_trait_node_tags(rest))),
+    EnvTypeDefs(_, rest) => retained_trait_node_tags(rest),
     EnvFlat(_) => "",
     EnvCached(_, _, rest) => retained_trait_node_tags(rest)
   }


### PR DESCRIPTION
## Summary
- make exported typedef declarations part of the transported environment across FS, worker/persistent, TDRE, and in-memory TypeDb paths
- preserve generic typedef provenance, aliases/reexports, local shadow order, and strict first-match semantics
- validate v4 transport on every cache-hit path and cold-fallback old/malformed data
- reject selected effects/effectsets explicitly until their declaration authority lands
- retire the legacy enum carrier as an imported checker authority

## Validation
- focused codec and FS cross-module tests passed
- worker scheduler parity, persistent-cache suite, and TDRE oracle passed
- formatter, generated freshness, and `git diff --check` passed
- final independent review: safe to integrate, no blocker/major/minor findings

## Remaining #1549
Effect/effectset declaration transport and final authority unification remain follow-up scope.