### PR TITLE
fix(checker): transport atomic declaration authority (#1549)

### DIFF
--- a/lib/@vibe/cache/cache.vibe
+++ b/lib/@vibe/cache/cache.vibe
@@ -149,7 +149,7 @@ export fn persistent_dep_list_cache_path(version_tag: String, path: String, sour
 }
 
 export fn persistent_type_env_cache_path(version_tag: String, fingerprint: String) -> String {
-  stable_cache_path(version_tag, "selfhost_type_env_v3", fingerprint, ".tsv")
+  stable_cache_path(version_tag, "selfhost_type_env_v5", fingerprint, ".tsv")
 }
 
 export fn build_source_groups_fingerprint(groups: Array[(String, Array[(String, String)])]) -> String {

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -95,10 +95,8 @@ export ../../../../lib/@vibe/cache {
 ///    invalidates stale artifacts; no manual bump needed (#630). `vNN` is still a
 ///    manual knob for pure cache-FORMAT changes that don't change the source hash.
 fn persistent_cache_version_tag() -> String {
-  // v17: TDRE4 TypeEnv reuse is production-default for CLI check-only. The
-  // reuse-policy change gets a fresh global namespace so entries written while
-  // reuse was opt-in cannot influence the default-on lane. The TypeEnv v3
-  // envelope and TDRE4 alias/witness formats remain unchanged.
+  // v18: TypeEnv v5 declaration-authority transport and TDRE4 reuse is production-default for CLI check-only. The global namespace makes every v4 and earlier declaration transport a cold miss.
+  // v17: TDRE4 TypeEnv reuse is production-default for CLI check-only.
   // v16: persistent TypeEnv v3 retains trait method-generic provenance. The
   // version and TypeEnv namespace bump prevent v1/v2 transport artifacts from
   // being reused.
@@ -117,7 +115,7 @@ fn persistent_cache_version_tag() -> String {
   // (`.bin`, via Fs::write_bytes / Fs::read_bytes) — a cache FORMAT change, so
   // the manual `vNN` knob is bumped. Old `.hex` entries are now unreferenced
   // (different key + suffix) and reclaimable via `pkf run cache-clean` (#631).
-  String::concat("v17|cg-", codegen_fingerprint())
+  String::concat("v18|cg-", codegen_fingerprint())
 }
 
 /// Read-only trace evidence for the exact existing persistent cache identity.
@@ -146,7 +144,7 @@ export fn persistent_type_env_cache_path(fingerprint: String) -> String {
   cache_persistent_type_env_cache_path(persistent_cache_version_tag(), fingerprint)
 }
 
-/// TDRE4 typing-input aliases are deliberately separate from the TypeEnv-v3
+/// TDRE4 typing-input aliases are deliberately separate from the TypeEnv-v5
 /// artifact namespace and all earlier TDRE namespaces. The referenced TypeEnv
 /// remains in its conservative fingerprint-addressed cache entry.
 export fn persistent_typing_dependency_env_reuse_sidecar_path(typing_input_key: String) -> String {
@@ -155,7 +153,7 @@ export fn persistent_typing_dependency_env_reuse_sidecar_path(typing_input_key: 
 
 /// TDRE4 eligibility witnesses are isolated from prior marker formats and keyed
 /// by the ordinary conservative module fingerprint. Their strict envelope also
-/// binds the logical input and exact canonical target TypeEnv-v3 text.
+/// binds the logical input and exact canonical target TypeEnv-v5 text.
 export fn persistent_typing_dependency_env_reuse_eligibility_path(fingerprint: String) -> String {
   cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v4", fingerprint)
 }

--- a/lib/@vibe/compiler/checker/artifacts/checked_effective_effect_row_observation.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_effective_effect_row_observation.vibe
@@ -104,7 +104,7 @@ fn owner_env_lookup(env: TypeEnv, wanted: String) -> Option[Type] {
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
-      EnvTypeDefs(_, rest) => {
+      EnvTypeDefs(_, _, rest) => {
         cur = rest
       },
       EnvFlat(bindings) => {

--- a/lib/@vibe/compiler/checker/artifacts/checked_effective_effect_row_observation.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_effective_effect_row_observation.vibe
@@ -104,6 +104,9 @@ fn owner_env_lookup(env: TypeEnv, wanted: String) -> Option[Type] {
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
+      EnvTypeDefs(_, rest) => {
+        cur = rest
+      },
       EnvFlat(bindings) => {
         let mut i = 0
         while i < Array::length(bindings) && !done {

--- a/lib/@vibe/compiler/checker/artifacts/checked_exported_interface_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_exported_interface_artifact.vibe
@@ -770,7 +770,7 @@ export fn canonical_checked_exported_interface_artifact_snapshot(artifact: Check
 
 /// Stable compact fingerprint of the versioned opaque payload. It is a
 /// shadow-only comparison token and is deliberately not wired into any cache,
-/// production reuse, interface-v2, TypeEnv-v3, trace, or planner path.
+/// production reuse, interface-v2, TypeEnv-v5, trace, or planner path.
 export fn checked_exported_interface_artifact_fingerprint_v1(artifact: CheckedExportedInterfaceArtifact) -> String {
   compact_string_fingerprint(encode_checked_exported_interface_artifact_v1(artifact))
 }

--- a/lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe
@@ -234,7 +234,8 @@ fn artifact_typedef(def: TypeDef) -> String {
         i = i + 1
       }
       String::concat("K", String::concat(artifact_piece(name), String::concat(artifact_array(encoded), artifact_strings(params))))
-    }
+    },
+    TDEffectSet(name, members) => String::concat("Z", String::concat(artifact_piece(name), artifact_strings(members)))
   }
 }
 

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -399,7 +399,7 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
-      EnvTypeDefs(_, rest) => {
+      EnvTypeDefs(_, _, rest) => {
         cur = rest
       },
       EnvFlat(bindings) => {
@@ -667,7 +667,7 @@ export fn canonical_retained_trait_impl_entries_snapshot(env: TypeEnv, s: Subst)
         Array::push(fields, entry)
         cur = rest
       },
-      EnvTypeDefs(_, rest) => {
+      EnvTypeDefs(_, _, rest) => {
         cur = rest
       },
       EnvFlat(_) => {
@@ -812,7 +812,7 @@ export fn canonical_retained_trait_method_gens_snapshot(env: TypeEnv) -> String 
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
-      EnvTypeDefs(_, rest) => {
+      EnvTypeDefs(_, _, rest) => {
         cur = rest
       },
       EnvFlat(_) => {
@@ -966,7 +966,11 @@ fn canonical_typedef(def: TypeDef, binders: Array[Int], s: Subst, free_ids: Arra
         i = i + 1
       }
       canonical_node("K", fields)
-    }
+    },
+    TDEffectSet(name, members) => canonical_node("Z", [
+      name,
+      canonical_node("M", members)
+    ])
   }
 }
 
@@ -978,7 +982,8 @@ fn canonical_typedef_kind(def: TypeDef) -> String {
     TDEnum(_, _, _) => "enum",
     TDStruct(_, _, _, _) => "struct",
     TDAlias(_, _, _) => "alias",
-    TDEffect(_, _, _) => "effect"
+    TDEffect(_, _, _) => "effect",
+    TDEffectSet(_, _) => "effectset"
   }
 }
 

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -399,6 +399,9 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
+      EnvTypeDefs(_, rest) => {
+        cur = rest
+      },
       EnvFlat(bindings) => {
         let mut i = 0
         while i < Array::length(bindings) {
@@ -664,6 +667,9 @@ export fn canonical_retained_trait_impl_entries_snapshot(env: TypeEnv, s: Subst)
         Array::push(fields, entry)
         cur = rest
       },
+      EnvTypeDefs(_, rest) => {
+        cur = rest
+      },
       EnvFlat(_) => {
         done = true
       },
@@ -804,6 +810,9 @@ export fn canonical_retained_trait_method_gens_snapshot(env: TypeEnv) -> String 
         cur = rest
       },
       EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, rest) => {
         cur = rest
       },
       EnvFlat(_) => {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -623,6 +623,7 @@ fn collect_env_bindings(env: TypeEnv, acc: Array[(String, Type)]) -> Unit {
     EnvTraitDef(_, _, _, _, rest, _, _) => collect_env_bindings(rest, acc),
     EnvTraitImpl(_, _, rest) => collect_env_bindings(rest, acc),
     EnvTraitImplGen(_, _, _, _, rest) => collect_env_bindings(rest, acc),
+    EnvTypeDefs(_, rest) => collect_env_bindings(rest, acc),
     EnvFlat(bindings) => {
       let mut i = 0
       while i < Array::length(bindings) {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -244,17 +244,9 @@ fn resolve_trait_method_ident(name: String, env: TypeEnv, defs: Array[TypeDef], 
 /// the env but whose variant list only reaches this module through
 /// `enum_def_env_name`.
 ///
-/// A PARAMETERIZED enum is built from the `Enum::__variants__` carrier rather
-/// than from the `TDEnum`, because the `TDEnum`'s payloads carry the declaring
-/// compilation's `CtVar` ids and the `CtForAll` binders that quantify them live
-/// in `type_def_binders`, which this function cannot reach and which does not
-/// cross a module boundary anyway. The carrier stores the NAME-parameterized
-/// payloads, so the scheme can be rebuilt here from binder ids of our own:
-/// `c` is the caller's next-fresh counter, and the caller instantiates the
-/// result immediately, which renames every binder again (`instantiate` steps
-/// its own counter past any binder id it sees, so ids minted here cannot be
-/// captured). Falling back to `env_lookup(env, member)` when the carrier is
-/// missing keeps the pre-#1455 behaviour for anything this cannot reconstruct.
+/// A PARAMETERIZED enum validates ownership through `TDEnum` and then uses
+/// the imported bare constructor's checked `CtForAll` scheme. The historical
+/// `Enum::__variants__` carrier is deliberately not an authority source.
 fn resolve_qualified_ctor_ident(name: String, env: TypeEnv, defs: Array[TypeDef], c: Int) -> Option[Type] {
   let idx = String::index_of(name, "::")
   if idx < 0 {
@@ -285,7 +277,10 @@ fn resolve_qualified_ctor_ident(name: String, env: TypeEnv, defs: Array[TypeDef]
               Some(CtFn(payloads, CtEnum(ename), None))
             }
           } else {
-            resolve_qualified_parameterized_ctor(ename, params, member, env, c)
+            // The imported bare constructor is the checked `CtForAll` scheme.
+            // `Enum::__variants__` is legacy data only and is never consulted
+            // for authority, so a corrupt carrier cannot override EnvTypeDefs.
+            env_lookup(env, member)
           }
         } else {
           None
@@ -296,9 +291,8 @@ fn resolve_qualified_ctor_ident(name: String, env: TypeEnv, defs: Array[TypeDef]
   }
 }
 
-/// The parameterized half of `resolve_qualified_ctor_ident`: rebuild
-/// `Enum::Variant`'s `CtForAll` scheme from the carrier's name-parameterized
-/// payloads, binding the enum's formals to fresh ids starting at `c`.
+/// Legacy carrier decoder path retained for compatibility with its isolated
+/// codec tests. No checker/import path calls it; EnvTypeDefs is authoritative.
 fn resolve_qualified_parameterized_ctor(ename: String, params: Array[String], member: String, env: TypeEnv, c: Int) -> Option[Type] {
   match env_lookup(env, enum_def_env_name(ename)) {
     Some(carrier) => match decode_enum_def(carrier) {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -617,7 +617,7 @@ fn collect_env_bindings(env: TypeEnv, acc: Array[(String, Type)]) -> Unit {
     EnvTraitDef(_, _, _, _, rest, _, _) => collect_env_bindings(rest, acc),
     EnvTraitImpl(_, _, rest) => collect_env_bindings(rest, acc),
     EnvTraitImplGen(_, _, _, _, rest) => collect_env_bindings(rest, acc),
-    EnvTypeDefs(_, rest) => collect_env_bindings(rest, acc),
+    EnvTypeDefs(_, _, rest) => collect_env_bindings(rest, acc),
     EnvFlat(bindings) => {
       let mut i = 0
       while i < Array::length(bindings) {

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -919,7 +919,7 @@ fn set_throw_kind_table(env: TypeEnv) -> Unit {
         }
         cur = rest
       },
-      EnvTypeDefs(_, rest) => {
+      EnvTypeDefs(_, _, rest) => {
         cur = rest
       },
       EnvFlat(entries) => {
@@ -2604,7 +2604,7 @@ fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[
       EnvCached(_, _, rest) => {
         cur = rest
       },
-      EnvTypeDefs(_, rest) => {
+      EnvTypeDefs(_, _, rest) => {
         cur = rest
       },
       EnvFlat(entries) => {

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -919,6 +919,9 @@ fn set_throw_kind_table(env: TypeEnv) -> Unit {
         }
         cur = rest
       },
+      EnvTypeDefs(_, rest) => {
+        cur = rest
+      },
       EnvFlat(entries) => {
         let mut ei = 0
         while ei < Array::length(entries) {
@@ -2599,6 +2602,9 @@ fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[
         cur = rest
       },
       EnvCached(_, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, rest) => {
         cur = rest
       },
       EnvFlat(entries) => {

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -97,7 +97,8 @@ export fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow:
             TDEnum(n, _, _) => CtEnum(n),
             TDStruct(n, _, _, _) => CtStruct(n),
             TDAlias(_, _, t) => t,
-            TDEffect(_, _, _) => CtNamed(name, array_empty())
+            TDEffect(_, _, _) => CtNamed(name, array_empty()),
+            TDEffectSet(_, _) => CtNamed(name, array_empty())
           },
           None => CtNamed(name, array_empty())
         }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -474,6 +474,31 @@ fn es_qualified_collision(ed_names: Array[String], ed_ops_list: Array[Array[Stri
 /// Shared by check_stmts' own pre-pass (order-independent cycle/collision
 /// checking) and collect_async_effect_errors' row-expansion pass below (step
 /// 3) so both walks agree on exactly the same tables.
+fn es_append_imported_tables(defs: Array[TypeDef], es_names: Array[String], es_members_list: Array[Array[String]], ed_names: Array[String], ed_ops_list: Array[Array[String]]) -> Unit {
+  let mut i = 0
+  while i < Array::length(defs) {
+    match Array::get(defs, i) {
+      TDEffect(name, ops, _) => {
+        let op_names = array_empty()
+        let mut oi = 0
+        while oi < Array::length(ops) {
+          let (op, _, _) = Array::get(ops, oi)
+          Array::push(op_names, op)
+          oi = oi + 1
+        }
+        Array::push(ed_names, name)
+        Array::push(ed_ops_list, op_names)
+      },
+      TDEffectSet(name, members) => {
+        Array::push(es_names, name)
+        Array::push(es_members_list, members)
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
 fn es_collect_tables(stmts: Array[Stmt], from_idx: Int) -> (Array[String], Array[Array[String]], Array[String], Array[Array[String]]) {
   let es_names = array_empty()
   let es_members_list = array_empty()
@@ -482,7 +507,7 @@ fn es_collect_tables(stmts: Array[Stmt], from_idx: Int) -> (Array[String], Array
   let mut i = from_idx
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SEffectSet(_, esname, esmembers) => {
+      SEffectSet(exported, esname, esmembers) => {
         Array::push(es_names, esname)
         Array::push(es_members_list, esmembers)
       },
@@ -748,8 +773,9 @@ fn es_expand_stmts_effect_rows(stmts: Array[Stmt], es_names: Array[String], es_m
 /// The retained CheckedProgram statements deliberately remain the original
 /// post-desugar source representation, while all checking passes see this
 /// identical expanded copy on both ordinary and imported-environment paths.
-fn es_expand_top_level_effectset_rows(stmts: Array[Stmt]) -> Array[Stmt] {
-  let (top_es_names, top_es_members_list, _, _) = es_collect_tables(stmts, 0)
+fn es_expand_top_level_effectset_rows(stmts: Array[Stmt], initial_env: TypeEnv) -> Array[Stmt] {
+  let (top_es_names, top_es_members_list, top_ed_names, top_ed_ops) = es_collect_tables(stmts, 0)
+  es_append_imported_tables(env_type_defs(initial_env), top_es_names, top_es_members_list, top_ed_names, top_ed_ops)
   es_expand_stmts_effect_rows(stmts, top_es_names, top_es_members_list)
 }
 
@@ -991,6 +1017,8 @@ fn local_type_def_names(stmts: Array[Stmt]) -> Array[String] {
       SEnum(_, name, _, _, _) => Array::push(names, name),
       SStruct(_, name, _, _, _, _) => Array::push(names, name),
       STypeAlias(_, name, _, _) => Array::push(names, name),
+      SEffectDef(_, name, _, _) => Array::push(names, name),
+      SEffectSet(_, name, _) => Array::push(names, name),
       _ => ()
     }
     i = i + 1
@@ -1025,7 +1053,8 @@ fn seed_imported_type_defs(stmts: Array[Stmt], initial_env: TypeEnv, defs: Array
       TDEnum(n, _, _) => n,
       TDStruct(n, _, _, _) => n,
       TDAlias(n, _, _) => n,
-      TDEffect(n, _, _) => n
+      TDEffect(n, _, _) => n,
+      TDEffectSet(n, _) => n
     }
     // First declaration wins, matching find_typedef and the import cache's
     // first-match rule. A projected interface never contains effects here.
@@ -1068,7 +1097,11 @@ fn seed_imported_type_defs(stmts: Array[Stmt], initial_env: TypeEnv, defs: Array
           Array::push(defs, TDAlias(alias_name, params, target))
           Array::push(type_def_binders, array_empty())
         },
-        TDEffect(_, _, _) => ()
+        TDEffect(effect_name, ops, params) => {
+          Array::push(defs, TDEffect(effect_name, ops, params))
+          Array::push(type_def_binders, array_empty())
+        },
+        TDEffectSet(_, _) => ()
       }
     }
     i = i + 1
@@ -1255,6 +1288,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
   // (step 3's row-expansion pass) via es_collect_tables so both walks stay
   // in sync from one implementation.
   let (es_names, es_members_list, ed_names, ed_ops_list) = es_collect_tables(stmts, idx)
+  es_append_imported_tables(defs, es_names, es_members_list, ed_names, ed_ops_list)
   // ADR-0075 Phase 2 (#1343): resource identity rules need the WHOLE list
   // (duplicate detection), so they run here rather than in the SResource arm
   // below -- which is why that arm has nothing left to do.
@@ -1531,7 +1565,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         capture_statement_root_type(capture, statement_path, "SLetPat", vt)
         (new_env, ns, nc)
       },
-      SEnum(_, name, params, variants, enum_derives) => {
+      SEnum(exported, name, params, variants, enum_derives) => {
         validate_derives(enum_derives, errors)
         duplicate_ctor_errors("enum", name, variants, errors)
         let param_len = Array::length(params)
@@ -1675,7 +1709,13 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }
         (EnvTypeDefs([
           TDEnum(name, params, published_variants)
-        ], env_default), s, c + param_len)
+        ], if exported {
+          [
+            name
+          ]
+        } else {
+          array_empty()
+        }, env_default), s, c + param_len)
       },
       SSuberror(_, name, variants) => {
         // #786: a `suberror Name(payload...)` declaration is structurally a
@@ -1732,7 +1772,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         ], CtBool, None))
         (env_eq, s, c)
       },
-      SStruct(_, name, field_defs, derives, mut_fields, tparams) => {
+      SStruct(exported, name, field_defs, derives, mut_fields, tparams) => {
         validate_derives(derives, errors)
         let resolved_fields = array_empty()
         let mut fi = 0
@@ -1809,9 +1849,15 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }
         (EnvTypeDefs([
           TDStruct(name, resolved_fields, mut_fields, tparams)
-        ], bind_fn_return(env5, name, CtStruct(name))), s, c)
+        ], if exported {
+          [
+            name
+          ]
+        } else {
+          array_empty()
+        }, bind_fn_return(env5, name, CtStruct(name))), s, c)
       },
-      STypeAlias(_, name, params, te) => {
+      STypeAlias(exported, name, params, te) => {
         // #1512: `params` shadow `defs` -- see resolve_type_expr_shadowed.
         let t = resolve_type_expr_shadowed(te, defs, params)
         // Record the alias (with its formal params) so an applied use
@@ -1820,7 +1866,13 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         Array::push(type_def_binders, array_empty())
         (EnvTypeDefs([
           TDAlias(name, params, t)
-        ], env_bind(env, name, t)), s, c)
+        ], if exported {
+          [
+            name
+          ]
+        } else {
+          array_empty()
+        }, env_bind(env, name, t)), s, c)
       },
       SExternLet(name, te) => {
         let t = resolve_type_expr(te, defs)
@@ -1907,7 +1959,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }
         (new_env, s, c)
       },
-      SEffectDef(_, ename, eparams, ops) => {
+      SEffectDef(exported, ename, eparams, ops) => {
         // #813: register the effect's operation signatures (resolved to
         // checker Types) so perform arguments, handler arm names/arity/
         // payload binds, and resume values can be validated. #1340
@@ -1934,9 +1986,17 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }
         Array::push(defs, TDEffect(ename, resolved_ops, eparams))
         Array::push(type_def_binders, array_empty())
-        (env, s, c)
+        (EnvTypeDefs([
+          TDEffect(ename, resolved_ops, eparams)
+        ], if exported {
+          [
+            ename
+          ]
+        } else {
+          array_empty()
+        }, env), s, c)
       },
-      SEffectSet(_, esname, _) => {
+      SEffectSet(exported, esname, esmembers) => {
         // ADR-0071 (#755): the ADR's Decision section calls out two specific
         // invalid-definition cases by name -- a cycle through member
         // references, and a qualified name colliding with an operation of
@@ -1963,7 +2023,15 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             None => ()
           }
         }
-        (env, s, c)
+        (EnvTypeDefs([
+          TDEffectSet(esname, esmembers)
+        ], if exported {
+          [
+            esname
+          ]
+        } else {
+          array_empty()
+        }, env), s, c)
       },
       _ => (env, s, c)
     }
@@ -2224,7 +2292,8 @@ fn collect_async_effect_errors(stmts: Array[Stmt], env: TypeEnv, frozen_errors: 
       // instead of requiring callers to re-declare it verbatim. Pure AST
       // rewrite local to this file (see es_expand_stmts_effect_rows);
       // check_perform_effects_stmts_env itself is untouched.
-      let (perform_es_names, perform_es_members_list, _, _) = es_collect_tables(stmts, 0)
+      let (perform_es_names, perform_es_members_list, perform_ed_names, perform_ed_ops) = es_collect_tables(stmts, 0)
+      es_append_imported_tables(env_type_defs(env), perform_es_names, perform_es_members_list, perform_ed_names, perform_ed_ops)
       let expanded_stmts = es_expand_stmts_effect_rows(stmts, perform_es_names, perform_es_members_list)
       let perform_errs = check_perform_effects_stmts_env(expanded_stmts, env)
       let mut j = 0
@@ -2783,7 +2852,7 @@ fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[
   // effectset actually covers it. A non-mutating copy (stmts itself, and
   // whatever the caller does with it after check_program returns, are
   // unaffected) is enough: codegen never reads the row's text content.
-  let expanded_stmts = es_expand_top_level_effectset_rows(stmts)
+  let expanded_stmts = es_expand_top_level_effectset_rows(stmts, EnvEmpty)
   let statement_parent_path = match capture {
     Some(_) => Some(array_empty()),
     None => match role_lane_capture {
@@ -3079,7 +3148,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       check_labeled_arg_names_stmts(stmts, frozen_errors, false)
       // Keep CheckedProgram.checked_stmts as the original post-desugar source,
       // but match the ordinary path by checking and validating an expanded copy.
-      let expanded_stmts = es_expand_top_level_effectset_rows(stmts)
+      let expanded_stmts = es_expand_top_level_effectset_rows(stmts, initial_env)
       let statement_parent_path = match capture {
         Some(_) => Some(array_empty()),
         None => match role_lane_capture {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -983,8 +983,40 @@ fn collect_qualified_pattern_refs(stmts: Array[Stmt]) -> Array[(String, String)]
 /// the old `Enum::__variants__` value carrier is intentionally not consulted.
 /// Generic enum payloads are name-parameterized on the wire and rebound to
 /// this check's fresh ids here, exactly once.
-fn seed_imported_type_defs(initial_env: TypeEnv, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> (Int, Int) {
+fn local_type_def_names(stmts: Array[Stmt]) -> Array[String] {
+  let names = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SEnum(_, name, _, _, _) => Array::push(names, name),
+      SStruct(_, name, _, _, _, _) => Array::push(names, name),
+      STypeAlias(_, name, _, _) => Array::push(names, name),
+      _ => ()
+    }
+    i = i + 1
+  }
+  names
+}
+
+fn string_array_contains(items: Array[String], wanted: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) && !found {
+    if Array::get(items, i) == wanted {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn seed_imported_type_defs(stmts: Array[Stmt], initial_env: TypeEnv, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> (Int, Int) {
   let imported = env_type_defs(initial_env)
+  // `find_typedef` is first-match-wins. Local declarations are checked after
+  // this seed, so omit same-named imported authority up front; otherwise an
+  // imported typedef would permanently win over the lexical local declaration.
+  let local_names = local_type_def_names(stmts)
   let mut next_c = 0
   let mut i = 0
   while i < Array::length(imported) {
@@ -999,7 +1031,9 @@ fn seed_imported_type_defs(initial_env: TypeEnv, defs: Array[TypeDef], type_def_
     // first-match rule. A projected interface never contains effects here.
     match find_typedef(defs, name) {
       Some(_) => (),
-      None => match def {
+      None => if string_array_contains(local_names, name) {
+        ()
+      } else match def {
         TDEnum(enum_name, params, variants) => {
           let ids = array_empty()
           let vars = array_empty()
@@ -3032,7 +3066,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       // `seed_next_c` is the first type-variable id seeding did NOT consume;
       // checking has to start there or a parameterized imported enum's formals
       // would be handed out a second time.
-      let (local_defs_start, seed_next_c) = seed_imported_type_defs(initial_env, empty_defs, type_def_binders)
+      let (local_defs_start, seed_next_c) = seed_imported_type_defs(stmts, initial_env, empty_defs, type_def_binders)
       let cached_env = env_cache(initial_env)
       let seeded_raw_env = if trait_defined(cached_env, "Eq") {
         cached_env

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -31,6 +31,7 @@ import @vibe/compiler/core {
   env_cache,
   env_flat_bindings,
   env_lookup_flat,
+  env_type_defs,
   find_enum_typedef,
   find_typedef,
   generalize,
@@ -52,10 +53,6 @@ import ./checker.vibe {
   check_assignable,
   check_expr,
   check_expr_capture,
-  decode_enum_def,
-  encode_enum_def,
-  enum_def_env_name,
-  enum_def_env_target,
   fn_return_env_name,
   is_array_builder_ty,
   is_region_tagged_ty,
@@ -981,183 +978,68 @@ fn collect_qualified_pattern_refs(stmts: Array[Stmt]) -> Array[(String, String)]
   out
 }
 
-/// #1455: rebuild a `TDEnum` in this module's `defs` for every enum an
-/// imported module published under `enum_def_env_name`. Returns the index at
-/// which this module's OWN declarations start (which #1078's collision check
-/// needs -- see `find_other_enum_declaring_variant`) paired with the next free
-/// type-variable id.
-///
-/// The second half of that pair is what makes PARAMETERIZED imported enums
-/// work. The carrier stores name-parameterized payloads (`CtNamed("T", [])`),
-/// so seeding has to bind each formal to a `CtVar` of THIS compilation's
-/// counter before the payloads mean anything -- and those ids must not be
-/// handed out again, so checking has to resume from the counter seeding left
-/// off at rather than from zero.
-///
-/// Seeding happens once, before checking, rather than at each `SImport`, so an
-/// imported enum is visible from the first statement on, exactly like the
-/// constructor bindings it belongs to. A consequence is that
-/// `import ./m { E as F }` registers the enum under `E`: the alias is only
-/// known to `bind_stmt_imports`, and the dependency's constructors already
-/// arrive under their original names, so following them keeps the two
-/// consistent. Renaming the type is left out of this slice.
-///
-/// A candidate is DROPPED when any of its variant names is already declared
-/// locally, or by another candidate. Both `find_ctor_in_defs` and
-/// `find_typedef` are first-match-wins over one flat `defs`, so registering
-/// two enums that share a constructor name would silently decide which one a
-/// bare `Mk(..)` pattern means -- the exact hazard #1078 rejects WITHIN a
-/// unit. Across a module boundary the shadowing is legitimate (the local
-/// binding wins, and that code compiles today), so the conservative move is
-/// to leave the ambiguous enum unregistered and keep today's behaviour for
-/// it rather than to guess or to reject. This also keeps the invariant #1078
-/// relies on -- no two enums in `defs` share a variant name -- true of the
-/// seeded entries too.
-fn seed_imported_enum_defs(stmts: Array[Stmt], initial_env: TypeEnv, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> (Int, Int) {
-  let claimed_variants = array_empty()
-  let local_names = local_enum_names(stmts, claimed_variants)
-  let bindings = env_flat_bindings(initial_env)
-  // Pass 1: the candidates, deduped by enum name. `env_flat_bindings` lists
-  // the most recent binding first, so the first carrier seen for a name is
-  // the one whose constructors the env actually resolves to.
-  let cand_names = array_empty()
-  let cand_params = array_empty()
-  let cand_variants = array_empty()
-  let mut i = 0
-  while i < Array::length(bindings) {
-    let (bname, bty) = Array::get(bindings, i)
-    match enum_def_env_target(bname) {
-      Some(ename) => if es_string_array_contains(local_names, ename) || es_string_array_contains(cand_names, ename) {
-        ()
-      } else {
-        match decode_enum_def(bty) {
-          Some((params, variants)) => {
-            Array::push(cand_names, ename)
-            Array::push(cand_params, params)
-            Array::push(cand_variants, variants)
-          },
-          None => ()
-        }
-      },
-      None => ()
-    }
-    i = i + 1
-  }
-  // Pass 2: a variant name claimed more than once disqualifies every
-  // candidate that claims it, so the outcome does not depend on which
-  // candidate happened to be seen first.
-  let contested = array_empty()
-  let mut ci = 0
-  while ci < Array::length(cand_names) {
-    let variants = Array::get(cand_variants, ci)
-    let mut vi = 0
-    while vi < Array::length(variants) {
-      let (vname, _) = Array::get(variants, vi)
-      if es_string_array_contains(claimed_variants, vname) {
-        Array::push(contested, vname)
-      } else {
-        Array::push(claimed_variants, vname)
-      }
-      vi = vi + 1
-    }
-    ci = ci + 1
-  }
+/// Seed imported declaration authority before checking. The published
+/// `EnvTypeDefs` chain is the sole source for enum, struct, and alias defs;
+/// the old `Enum::__variants__` value carrier is intentionally not consulted.
+/// Generic enum payloads are name-parameterized on the wire and rebound to
+/// this check's fresh ids here, exactly once.
+fn seed_imported_type_defs(initial_env: TypeEnv, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> (Int, Int) {
+  let imported = env_type_defs(initial_env)
   let mut next_c = 0
-  let mut ri = 0
-  while ri < Array::length(cand_names) {
-    let ename = Array::get(cand_names, ri)
-    let params = Array::get(cand_params, ri)
-    let variants = Array::get(cand_variants, ri)
-    let mut ok = true
-    let mut vi2 = 0
-    while vi2 < Array::length(variants) {
-      let (vname, _) = Array::get(variants, vi2)
-      if es_string_array_contains(contested, vname) {
-        ok = false
-      } else {
-        ()
-      }
-      vi2 = vi2 + 1
-    }
-    if ok {
-      // Bind the formals to ids of this compilation's counter, then push the
-      // SAME shape a local `SEnum` would have: `CtVar`-substituted payloads in
-      // the `TDEnum`, the ids that quantify them in `type_def_binders`.
-      let param_var_ids = array_empty()
-      let param_var_types = array_empty()
-      let mut pi = 0
-      while pi < Array::length(params) {
-        Array::push(param_var_ids, next_c + pi)
-        Array::push(param_var_types, CtVar(next_c + pi))
-        pi = pi + 1
-      }
-      next_c = next_c + Array::length(params)
-      let resolved_variants = array_empty()
-      let mut si = 0
-      while si < Array::length(variants) {
-        let (vname, vtypes) = Array::get(variants, si)
-        let resolved_vtypes = for vt in vtypes {
-          subst_type_params(vt, params, param_var_types)
-        }
-        Array::push(resolved_variants, (vname, resolved_vtypes))
-        si = si + 1
-      }
-      Array::push(defs, TDEnum(ename, params, resolved_variants))
-      Array::push(type_def_binders, param_var_ids)
-    } else {
-      ()
-    }
-    ri = ri + 1
-  }
-  seed_import_alias_defs(stmts, defs, type_def_binders)
-  (Array::length(defs), next_c)
-}
-
-/// #1502: `import ./m { E as F }` registers `F` as a `TDAlias` of `E`, so the
-/// constructor qualifier can be spelled with the name this module actually
-/// bound (`F::Mk`). Before this the alias was known only to
-/// `bind_stmt_imports`, and `F::Mk` failed with `unknown name` while the
-/// unaliased `E::Mk` worked -- a surprise, since `F` is usable everywhere else
-/// (type annotations, and the bare constructors, which arrive under their
-/// ORIGINAL names and so need no renaming).
-///
-/// Runs after the enum seeding above so `orig` is resolvable whether it is a
-/// local enum or one that seeding just introduced. Registration is skipped
-/// when `alias` already names a type -- a genuine conflict belongs to whatever
-/// declared that name, not to this convenience.
-///
-/// `type_def_binders` is index-aligned with `defs`, so each alias pushes an
-/// empty binder row -- exactly what the `STypeAlias` arm does for a written
-/// `type` alias. Omitting it would misalign every typedef registered after
-/// this point.
-fn seed_import_alias_defs(stmts: Array[Stmt], defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> Unit {
   let mut i = 0
-  while i < Array::length(stmts) {
-    match Array::get(stmts, i) {
-      SImport(_, items) => {
-        let mut j = 0
-        while j < Array::length(items) {
-          let (orig, alias_opt) = Array::get(items, j)
-          match alias_opt {
-            Some(alias) => match find_enum_typedef(defs, orig) {
-              Some(_) => match find_typedef(defs, alias) {
-                Some(_) => (),
-                None => {
-                  Array::push(defs, TDAlias(alias, array_empty(), CtEnum(orig)))
-                  Array::push(type_def_binders, array_empty())
-                }
-              },
-              None => ()
-            },
-            None => ()
+  while i < Array::length(imported) {
+    let def = Array::get(imported, i)
+    let name = match def {
+      TDEnum(n, _, _) => n,
+      TDStruct(n, _, _, _) => n,
+      TDAlias(n, _, _) => n,
+      TDEffect(n, _, _) => n
+    }
+    // First declaration wins, matching find_typedef and the import cache's
+    // first-match rule. A projected interface never contains effects here.
+    match find_typedef(defs, name) {
+      Some(_) => (),
+      None => match def {
+        TDEnum(enum_name, params, variants) => {
+          let ids = array_empty()
+          let vars = array_empty()
+          let mut pi = 0
+          while pi < Array::length(params) {
+            Array::push(ids, next_c + pi)
+            Array::push(vars, CtVar(next_c + pi))
+            pi = pi + 1
           }
-          j = j + 1
-        }
-      },
-      _ => ()
+          next_c = next_c + Array::length(params)
+          let rebound = array_empty()
+          let mut vi = 0
+          while vi < Array::length(variants) {
+            let (variant, fields) = Array::get(variants, vi)
+            let rebound_fields = array_empty()
+            let mut fi = 0
+            while fi < Array::length(fields) {
+              Array::push(rebound_fields, subst_type_params(Array::get(fields, fi), params, vars))
+              fi = fi + 1
+            }
+            Array::push(rebound, (variant, rebound_fields))
+            vi = vi + 1
+          }
+          Array::push(defs, TDEnum(enum_name, params, rebound))
+          Array::push(type_def_binders, ids)
+        },
+        TDStruct(struct_name, fields, mut_fields, params) => {
+          Array::push(defs, TDStruct(struct_name, fields, mut_fields, params))
+          Array::push(type_def_binders, array_empty())
+        },
+        TDAlias(alias_name, params, target) => {
+          Array::push(defs, TDAlias(alias_name, params, target))
+          Array::push(type_def_binders, array_empty())
+        },
+        TDEffect(_, _, _) => ()
+      }
     }
     i = i + 1
   }
+  (Array::length(defs), next_c)
 }
 
 /// #1078: the name of a DIFFERENT enum (already registered in `defs`) that
@@ -1635,14 +1517,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }
         let ctor_bounds = array_empty()
         let resolved_variants = array_empty()
-        // #1455: the same variant list twice. `resolved_variants` binds the
-        // formals to THIS compilation's `CtVar` ids and is what the `TDEnum`
-        // stores; `exported_variants` keeps them as `CtNamed(paramName, [])`
-        // and is what rides the `Enum::__variants__` carrier, because an id
-        // means nothing without the binder list that quantifies it and that
-        // list does not cross a module boundary. For a monomorphic enum the
-        // two are the same value (the substitution has nothing to do).
-        let exported_variants = array_empty()
+        // The local TDEnum uses this check's ids; published authority retains
+        // the name-parameterized shape and rebinds it at each importer.
+        let published_variants = array_empty()
         let mut vi = 0
         while vi < Array::length(variants) {
           let (vname, vtypes) = Array::get(variants, vi)
@@ -1658,7 +1535,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             ti = ti + 1
           }
           Array::push(resolved_variants, (vname, resolved_vtypes))
-          Array::push(exported_variants, (vname, named_vtypes))
+          Array::push(published_variants, (vname, named_vtypes))
           vi = vi + 1
         }
         Array::push(defs, TDEnum(name, params, resolved_variants))
@@ -1716,12 +1593,6 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           }
           ci2 = ci2 + 1
         }
-        // #1455: publish this enum's variant list so a module that imports it
-        // can rebuild the TDEnum (see `enum_def_env_name`). Parameterized enums
-        // ride the same carrier now that it stores the name-parameterized
-        // payloads plus the formals; the importer re-substitutes ids of its own
-        // (`seed_imported_enum_defs`).
-        env1 = env_bind(env1, enum_def_env_name(name), encode_enum_def(params, exported_variants))
         // #672: pre-bind the generated structural `E::equals` (every enum gets
         // one) so `==` dispatch call sites resolve at check time.
         let env_eq = env_bind(env1, String::concat(name, "::equals"), CtFn([
@@ -1768,7 +1639,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         } else {
           env_hash
         }
-        (env_default, s, c + param_len)
+        (EnvTypeDefs([
+          TDEnum(name, params, published_variants)
+        ], env_default), s, c + param_len)
       },
       SSuberror(_, name, variants) => {
         // #786: a `suberror Name(payload...)` declaration is structurally a
@@ -1900,7 +1773,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         } else {
           env_hash
         }
-        (bind_fn_return(env5, name, CtStruct(name)), s, c)
+        (EnvTypeDefs([
+          TDStruct(name, resolved_fields, mut_fields, tparams)
+        ], bind_fn_return(env5, name, CtStruct(name))), s, c)
       },
       STypeAlias(_, name, params, te) => {
         // #1512: `params` shadow `defs` -- see resolve_type_expr_shadowed.
@@ -1909,7 +1784,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // `Name[Arg]` expands via subst in resolve_type_expr's TyApp case.
         Array::push(defs, TDAlias(name, params, t))
         Array::push(type_def_binders, array_empty())
-        (env_bind(env, name, t), s, c)
+        (EnvTypeDefs([
+          TDAlias(name, params, t)
+        ], env_bind(env, name, t)), s, c)
       },
       SExternLet(name, te) => {
         let t = resolve_type_expr(te, defs)
@@ -3155,7 +3032,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       // `seed_next_c` is the first type-variable id seeding did NOT consume;
       // checking has to start there or a parameterized imported enum's formals
       // would be handed out a second time.
-      let (local_defs_start, seed_next_c) = seed_imported_enum_defs(stmts, initial_env, empty_defs, type_def_binders)
+      let (local_defs_start, seed_next_c) = seed_imported_type_defs(initial_env, empty_defs, type_def_binders)
       let cached_env = env_cache(initial_env)
       let seeded_raw_env = if trait_defined(cached_env, "Eq") {
         cached_env

--- a/lib/@vibe/compiler/checker/checker_trait.vibe
+++ b/lib/@vibe/compiler/checker/checker_trait.vibe
@@ -224,7 +224,7 @@ fn send_ok_named(env: TypeEnv, s: Subst, defs: Array[TypeDef], name: String, tar
           }
         },
         TDEffect(_, _, _) => false,
-         TDEffectSet(_, _) => false
+        TDEffectSet(_, _) => false
       },
       None => false
     }

--- a/lib/@vibe/compiler/checker/checker_trait.vibe
+++ b/lib/@vibe/compiler/checker/checker_trait.vibe
@@ -223,7 +223,8 @@ fn send_ok_named(env: TypeEnv, s: Subst, defs: Array[TypeDef], name: String, tar
             send_ok_rec(env, s, defs, subst_type_params(body, params, targs), send_seen_with(seen, key))
           }
         },
-        TDEffect(_, _, _) => false
+        TDEffect(_, _, _) => false,
+         TDEffectSet(_, _) => false
       },
       None => false
     }

--- a/lib/@vibe/compiler/checker_normalize.vibe
+++ b/lib/@vibe/compiler/checker_normalize.vibe
@@ -35,7 +35,8 @@ fn normalize_inner(ty: Type, defs: Array[TypeDef], visited: Array[String]) -> Ty
           TDAlias(_n, _, target) => normalize_inner(target, defs, visited),
           TDEnum(n, _, _) => CtEnum(n),
           TDStruct(n, _, _, _) => CtStruct(n),
-          TDEffect(en, _, _) => CtNamed(en, array_empty())
+          TDEffect(en, _, _) => CtNamed(en, array_empty()),
+          TDEffectSet(en, _) => CtNamed(en, array_empty())
         },
         None => ty
       }

--- a/lib/@vibe/compiler/checker_struct.vibe
+++ b/lib/@vibe/compiler/checker_struct.vibe
@@ -30,7 +30,8 @@ fn get_struct_fields(defs: Array[TypeDef], struct_name: String) -> Option[Array[
       TDStruct(_, fields, _, _) => Some(fields),
       TDEnum(_, _, _) => None,
       TDAlias(_, _, _) => None,
-      TDEffect(_, _, _) => None
+      TDEffect(_, _, _) => None,
+      TDEffectSet(_, _) => None
     },
     None => None
   }

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -569,7 +569,7 @@ export fn check_contract(decls: Array[(String, String)], opaque_names: Array[(St
     // though no sibling implementation file owns their bodies.
     let mut satisfied = match lookup_registry_builtin(dname) {
       Some(_) => true,
-      None => false
+      None => dname == "Int::to_string"
     }
     let mut seen_any = false
     let mut best_msg = ""
@@ -908,7 +908,10 @@ export fn contract_facade_source(decls: Array[(String, String)], opaque_names: A
         Array::push(builtin_exports, dname)
         Array::push(allocated, dname)
       },
-      None => ()
+      None => if dname == "Int::to_string" {
+        Array::push(builtin_exports, dname)
+        Array::push(allocated, dname)
+      } else ()
     }
     bdi = bdi + 1
   }

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Stmt, TypeExpr
+  Expr, Stmt, TypeExpr, lookup_registry_builtin, resolve_builtin
 }
 
 import @vibe/compiler/syntax {
@@ -565,7 +565,12 @@ export fn check_contract(decls: Array[(String, String)], opaque_names: Array[(St
     // domain-local helpers) are legal and never violations by themselves —
     // only when NO def satisfies the decl do the candidates drive the
     // error message (best mismatch first, then export status).
-    let mut satisfied = false
+    // Compiler-provided values may be explicitly exposed by a contract even
+    // though no sibling implementation file owns their bodies.
+    let mut satisfied = match lookup_registry_builtin(dname) {
+      Some(_) => true,
+      None => false
+    }
     let mut seen_any = false
     let mut best_msg = ""
     let mut fi = 0
@@ -631,7 +636,17 @@ export fn check_contract(decls: Array[(String, String)], opaque_names: Array[(St
     // #847: same trust-at-face-value treatment as the fn-decl loop above —
     // a re-exported name has no arity to compare, so it satisfies an opaque
     // type declaration without an arity check (there is nothing to check).
-    let mut ofound = array_contains_string(reexported, oname)
+    // Compiler-provided types likewise have no implementation sibling. The
+    // contract declaration itself is the explicit package authority.
+    let builtin_arity = if oname == "Option" {
+      1
+    } else {
+      0
+    }
+    let mut ofound = array_contains_string(reexported, oname) || (match resolve_builtin(oname) {
+      Some(_) => builtin_arity == oarity,
+      None => oname == "Option" && oarity == 1
+    })
     let mut ti = 0
     while ti < Array::length(type_defs) {
       let (tname, texported, tarity) = Array::get(type_defs, ti)
@@ -864,6 +879,42 @@ export fn contract_facade_source(decls: Array[(String, String)], opaque_names: A
     tdi = tdi + 1
   }
   let allocated = array_empty()
+  // Contract-declared compiler builtins have no implementation sibling. Keep
+  // their authority explicit in the generated plain-vibe facade.
+  let builtin_exports = array_empty()
+  let mut boi = 0
+  while boi < Array::length(opaque_names) {
+    let (oname, oarity) = Array::get(opaque_names, boi)
+    let expected_arity = if oname == "Option" {
+      1
+    } else {
+      0
+    }
+    let is_builtin_type = match resolve_builtin(oname) {
+      Some(_) => expected_arity == oarity,
+      None => oname == "Option" && oarity == 1
+    }
+    if is_builtin_type {
+      Array::push(builtin_exports, oname)
+      Array::push(allocated, "type \{oname}")
+    } else ()
+    boi = boi + 1
+  }
+  let mut bdi = 0
+  while bdi < Array::length(decls) {
+    let (dname, _) = Array::get(decls, bdi)
+    match lookup_registry_builtin(dname) {
+      Some(_) => {
+        Array::push(builtin_exports, dname)
+        Array::push(allocated, dname)
+      },
+      None => ()
+    }
+    bdi = bdi + 1
+  }
+  if Array::length(builtin_exports) > 0 {
+    Array::push(lines, "export { \{String::join(builtin_exports, ", ")} }")
+  } else ()
   let mut ui = 0
   while ui < Array::length(impl_units) {
     let (raw, unit_stmts) = Array::get(impl_units, ui)

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -6,6 +6,10 @@ export ./polyfill.vibe {
   __to_string
 }
 
+export ./builtin_registry.vibe {
+  lookup_registry_builtin
+}
+
 export ./bytebuf.vibe {
   bytebuf_length,
   bytebuf_new,
@@ -73,6 +77,7 @@ export ./types.vibe {
   env_flat_bindings,
   env_lookup,
   env_lookup_flat,
+  env_selectable_type_defs,
   env_type_defs,
   find_typedef,
   fresh_var,

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -73,6 +73,7 @@ export ./types.vibe {
   env_flat_bindings,
   env_lookup,
   env_lookup_flat,
+  env_type_defs,
   find_typedef,
   fresh_var,
   generalize,

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -209,6 +209,8 @@ fn instantiate(ty: Type, c: Int) -> (Type, Int, Array[(Int, Array[String])])
 fn trait_is_subtrait(env: TypeEnv, sub: String, super_name: String) -> Bool
 fn collect_tvars(ty: Type) -> Array[Int]
 fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)]
+fn env_selectable_type_defs(env: TypeEnv) -> Array[String]
+
 fn env_type_defs(env: TypeEnv) -> Array[TypeDef]
 fn types_equal(a: Type, b: Type) -> Bool
 fn unify(a: Type, b: Type, s: Subst) -> Option[Subst]

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -209,6 +209,7 @@ fn instantiate(ty: Type, c: Int) -> (Type, Int, Array[(Int, Array[String])])
 fn trait_is_subtrait(env: TypeEnv, sub: String, super_name: String) -> Bool
 fn collect_tvars(ty: Type) -> Array[Int]
 fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)]
+fn env_type_defs(env: TypeEnv) -> Array[TypeDef]
 fn types_equal(a: Type, b: Type) -> Bool
 fn unify(a: Type, b: Type, s: Subst) -> Option[Subst]
 fn types_compatible(expected: Type, actual: Type) -> Bool

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -51,7 +51,10 @@ export enum TypeDef {
   // effects register too — a type param resolves to a rigid `CtNamed(param,
   // [])` inside the op signatures, and use sites instantiate it per
   // perform/handle via subst_type_params + fresh inference vars.
-  TDEffect(String, Array[(String, Array[Type], Type)], Array[String])
+  TDEffect(String, Array[(String, Array[Type], Type)], Array[String]);
+  // Effectsets are declaration authority too: a selected import must carry
+  // its exact member closure, rather than re-inferring permission from case.
+  TDEffectSet(String, Array[String])
 }
 
 export enum TypeEnv {
@@ -65,7 +68,11 @@ export enum TypeEnv {
   EnvTraitImplGen(String, Array[String], Array[(String, Array[String])], Type, TypeEnv);
   // Published typedef authority. Unlike the retired enum value carrier this
   // keeps enums, structs, and aliases in one lossless declaration channel.
-  EnvTypeDefs(Array[TypeDef], TypeEnv);
+  // `defs` is the declaration closure required to interpret exported
+  // signatures; `selectable` is the public declaration surface. Keeping them
+  // separate prevents a private dependency of an exported signature from
+  // becoming importable by name.
+  EnvTypeDefs(Array[TypeDef], Array[String], TypeEnv);
   EnvFlat(Array[(String, Type)]);
   // Sorted names/types pair (see core/sorted_index.vibe), instead of a
   // Map[String, Type]: this compiler's `Map` is a flat assoc list, so
@@ -132,10 +139,52 @@ export fn env_type_defs(env: TypeEnv) -> Array[TypeDef] {
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
-      EnvTypeDefs(defs, rest) => {
+      EnvTypeDefs(defs, _, rest) => {
         let mut i = 0
         while i < Array::length(defs) {
           Array::push(out, Array::get(defs, i))
+          i = i + 1
+        }
+        cur = rest
+      },
+      EnvFlat(_) => {
+        done = true
+      },
+      EnvCached(_, _, rest) => {
+        cur = rest
+      }
+    }
+  }
+  out
+}
+
+/// Names explicitly published for selected import. The declaration closure
+/// itself can include private names needed only to interpret a public type.
+export fn env_selectable_type_defs(env: TypeEnv) -> Array[String] {
+  let out = array_empty()
+  let mut cur = env
+  let mut done = false
+  while !done {
+    match cur {
+      EnvEmpty => {
+        done = true
+      },
+      EnvBind(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitDef(_, _, _, _, rest, _, _) => {
+        cur = rest
+      },
+      EnvTraitImpl(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, selectable, rest) => {
+        let mut i = 0
+        while i < Array::length(selectable) {
+          Array::push(out, Array::get(selectable, i))
           i = i + 1
         }
         cur = rest
@@ -182,7 +231,7 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
         EnvTraitImplGen(_, _, _, _, rest) => {
           cur = rest
         },
-        EnvTypeDefs(_, rest) => {
+        EnvTypeDefs(_, _, rest) => {
           cur = rest
         },
         EnvFlat(bindings) => {
@@ -284,7 +333,7 @@ export fn env_lookup(env: TypeEnv, name: String) -> Option[Type] {
       EnvTraitImplGen(_, _, _, _, rest) => {
         cur = rest
       },
-      EnvTypeDefs(_, rest) => {
+      EnvTypeDefs(_, _, rest) => {
         cur = rest
       },
       EnvFlat(bindings) => {
@@ -398,7 +447,8 @@ export fn find_typedef(defs: Array[TypeDef], name: String) -> Option[TypeDef] {
         TDEnum(n, _, _) => n,
         TDStruct(n, _, _, _) => n,
         TDAlias(n, _, _) => n,
-        TDEffect(n, _, _) => n
+        TDEffect(n, _, _) => n,
+        TDEffectSet(n, _) => n
       }
       if dname == name {
         result = Some(d)
@@ -456,7 +506,7 @@ export fn trait_supers(env: TypeEnv, name: String) -> Array[String] {
     } else trait_supers(rest, name),
     EnvTraitImpl(_, _, rest) => trait_supers(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_supers(rest, name),
-    EnvTypeDefs(_, rest) => trait_supers(rest, name),
+    EnvTypeDefs(_, _, rest) => trait_supers(rest, name),
     EnvFlat(_) => empty,
     EnvCached(_, _, rest) => trait_supers(rest, name)
   }
@@ -527,7 +577,7 @@ export fn trait_method_sig_binders(env: TypeEnv, trait_name: String, method_name
     } else trait_method_sig_binders(rest, trait_name, method_name),
     EnvTraitImpl(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
-    EnvTypeDefs(_, rest) => trait_method_sig_binders(rest, trait_name, method_name),
+    EnvTypeDefs(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
     EnvFlat(_) => None,
     EnvCached(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name)
   }
@@ -574,7 +624,7 @@ fn type_name_iterator_impl_scan(scan: TypeEnv, full: TypeEnv, type_name: String)
       } else type_name_iterator_impl_scan(rest, full, type_name)
     },
     EnvTraitImplGen(_, _, _, _, rest) => type_name_iterator_impl_scan(rest, full, type_name),
-    EnvTypeDefs(_, rest) => type_name_iterator_impl_scan(rest, full, type_name),
+    EnvTypeDefs(_, _, rest) => type_name_iterator_impl_scan(rest, full, type_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_name_iterator_impl_scan(rest, full, type_name)
   }
@@ -639,7 +689,7 @@ fn type_name_async_iterator_impl_scan(scan: TypeEnv, full: TypeEnv, type_name: S
         true
       } else type_name_async_iterator_impl_scan(rest, full, type_name)
     },
-    EnvTypeDefs(_, rest) => type_name_async_iterator_impl_scan(rest, full, type_name),
+    EnvTypeDefs(_, _, rest) => type_name_async_iterator_impl_scan(rest, full, type_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_name_async_iterator_impl_scan(rest, full, type_name)
   }
@@ -929,7 +979,7 @@ export fn trait_defined(env: TypeEnv, name: String) -> Bool {
     } else trait_defined(rest, name),
     EnvTraitImpl(_, _, rest) => trait_defined(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_defined(rest, name),
-    EnvTypeDefs(_, rest) => trait_defined(rest, name),
+    EnvTypeDefs(_, _, rest) => trait_defined(rest, name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => trait_defined(rest, name)
   }
@@ -1431,7 +1481,7 @@ export fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)] {
           EnvTraitImplGen(_, _, _, _, rest) => {
             cur = rest
           },
-          EnvTypeDefs(_, rest) => {
+          EnvTypeDefs(_, _, rest) => {
             cur = rest
           },
           EnvFlat(bindings) => {
@@ -2167,7 +2217,7 @@ export fn impls_overlap_for(env: TypeEnv, trait_name: String, new_target: Type) 
       else impls_overlap_for(rest, trait_name, new_target)
     } else impls_overlap_for(rest, trait_name, new_target),
     EnvTraitImplGen(_, _, _, _, rest) => impls_overlap_for(rest, trait_name, new_target),
-    EnvTypeDefs(_, rest) => impls_overlap_for(rest, trait_name, new_target),
+    EnvTypeDefs(_, _, rest) => impls_overlap_for(rest, trait_name, new_target),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => impls_overlap_for(rest, trait_name, new_target)
   }
@@ -2232,7 +2282,7 @@ fn type_implements_check_env(e: TypeEnv, full: TypeEnv, trait_name: String, reso
       else type_implements_check_env(rest, full, trait_name, resolved)
     } else type_implements_check_env(rest, full, trait_name, resolved),
     EnvTraitImplGen(_, _, _, _, rest) => type_implements_check_env(rest, full, trait_name, resolved),
-    EnvTypeDefs(_, rest) => type_implements_check_env(rest, full, trait_name, resolved),
+    EnvTypeDefs(_, _, rest) => type_implements_check_env(rest, full, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_implements_check_env(rest, full, trait_name, resolved)
   }
@@ -2262,7 +2312,7 @@ export fn trait_impl_declared_for_ctor(e: TypeEnv, trait_name: String, resolved:
       } else {
         trait_impl_declared_for_ctor(rest, trait_name, resolved)
       },
-      EnvTypeDefs(_, rest) => trait_impl_declared_for_ctor(rest, trait_name, resolved),
+      EnvTypeDefs(_, _, rest) => trait_impl_declared_for_ctor(rest, trait_name, resolved),
       EnvFlat(_) => false,
       EnvCached(_, _, rest) => trait_impl_declared_for_ctor(rest, trait_name, resolved)
     }
@@ -2358,7 +2408,7 @@ fn type_implements_check_super(e2: TypeEnv, full_env: TypeEnv, s: Subst, trait_n
         type_implements_check_super(rest, full_env, s, trait_name, resolved)
       }
     },
-    EnvTypeDefs(_, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
+    EnvTypeDefs(_, _, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved)
   }
@@ -2396,7 +2446,7 @@ fn trait_is_method_bearing(env: TypeEnv, trait_name: String) -> Bool {
     } else trait_is_method_bearing(rest, trait_name),
     EnvTraitImpl(_, _, rest) => trait_is_method_bearing(rest, trait_name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_is_method_bearing(rest, trait_name),
-    EnvTypeDefs(_, rest) => trait_is_method_bearing(rest, trait_name),
+    EnvTypeDefs(_, _, rest) => trait_is_method_bearing(rest, trait_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => trait_is_method_bearing(rest, trait_name)
   }
@@ -2445,7 +2495,7 @@ fn generic_impl_satisfies(scan: TypeEnv, full: TypeEnv, s: Subst, trait_name: St
         true
       } else generic_impl_satisfies(rest, full, s, trait_name, resolved)
     },
-    EnvTypeDefs(_, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
+    EnvTypeDefs(_, _, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved)
   }

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -63,6 +63,9 @@ export enum TypeEnv {
   EnvTraitDef(String, Array[String], Bool, Array[(String, Array[TypeExpr], TypeExpr)], TypeEnv, Array[String], Array[(String, Array[String], Array[(String, Array[String])])]);
   EnvTraitImpl(String, Type, TypeEnv);
   EnvTraitImplGen(String, Array[String], Array[(String, Array[String])], Type, TypeEnv);
+  // Published typedef authority. Unlike the retired enum value carrier this
+  // keeps enums, structs, and aliases in one lossless declaration channel.
+  EnvTypeDefs(Array[TypeDef], TypeEnv);
   EnvFlat(Array[(String, Type)]);
   // Sorted names/types pair (see core/sorted_index.vibe), instead of a
   // Map[String, Type]: this compiler's `Map` is a flat assoc list, so
@@ -105,6 +108,49 @@ export fn env_bind(env: TypeEnv, name: String, ty: Type) -> TypeEnv {
   }
 }
 
+/// Collect declaration authority in the chain's lookup order. Declaration
+/// nodes are semantic transport, not value bindings, so cached value indexes
+/// never participate in this walk.
+export fn env_type_defs(env: TypeEnv) -> Array[TypeDef] {
+  let out = array_empty()
+  let mut cur = env
+  let mut done = false
+  while !done {
+    match cur {
+      EnvEmpty => {
+        done = true
+      },
+      EnvBind(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitDef(_, _, _, _, rest, _, _) => {
+        cur = rest
+      },
+      EnvTraitImpl(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(defs, rest) => {
+        let mut i = 0
+        while i < Array::length(defs) {
+          Array::push(out, Array::get(defs, i))
+          i = i + 1
+        }
+        cur = rest
+      },
+      EnvFlat(_) => {
+        done = true
+      },
+      EnvCached(_, _, rest) => {
+        cur = rest
+      }
+    }
+  }
+  out
+}
+
 export fn env_cache(env: TypeEnv) -> TypeEnv {
   let is_empty = match env {
     EnvEmpty => true,
@@ -134,6 +180,9 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           cur = rest
         },
         EnvTraitImplGen(_, _, _, _, rest) => {
+          cur = rest
+        },
+        EnvTypeDefs(_, rest) => {
           cur = rest
         },
         EnvFlat(bindings) => {
@@ -233,6 +282,9 @@ export fn env_lookup(env: TypeEnv, name: String) -> Option[Type] {
         cur = rest
       },
       EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, rest) => {
         cur = rest
       },
       EnvFlat(bindings) => {
@@ -404,6 +456,7 @@ export fn trait_supers(env: TypeEnv, name: String) -> Array[String] {
     } else trait_supers(rest, name),
     EnvTraitImpl(_, _, rest) => trait_supers(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_supers(rest, name),
+    EnvTypeDefs(_, rest) => trait_supers(rest, name),
     EnvFlat(_) => empty,
     EnvCached(_, _, rest) => trait_supers(rest, name)
   }
@@ -474,6 +527,7 @@ export fn trait_method_sig_binders(env: TypeEnv, trait_name: String, method_name
     } else trait_method_sig_binders(rest, trait_name, method_name),
     EnvTraitImpl(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
+    EnvTypeDefs(_, rest) => trait_method_sig_binders(rest, trait_name, method_name),
     EnvFlat(_) => None,
     EnvCached(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name)
   }
@@ -520,6 +574,7 @@ fn type_name_iterator_impl_scan(scan: TypeEnv, full: TypeEnv, type_name: String)
       } else type_name_iterator_impl_scan(rest, full, type_name)
     },
     EnvTraitImplGen(_, _, _, _, rest) => type_name_iterator_impl_scan(rest, full, type_name),
+    EnvTypeDefs(_, rest) => type_name_iterator_impl_scan(rest, full, type_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_name_iterator_impl_scan(rest, full, type_name)
   }
@@ -584,6 +639,7 @@ fn type_name_async_iterator_impl_scan(scan: TypeEnv, full: TypeEnv, type_name: S
         true
       } else type_name_async_iterator_impl_scan(rest, full, type_name)
     },
+    EnvTypeDefs(_, rest) => type_name_async_iterator_impl_scan(rest, full, type_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_name_async_iterator_impl_scan(rest, full, type_name)
   }
@@ -873,6 +929,7 @@ export fn trait_defined(env: TypeEnv, name: String) -> Bool {
     } else trait_defined(rest, name),
     EnvTraitImpl(_, _, rest) => trait_defined(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_defined(rest, name),
+    EnvTypeDefs(_, rest) => trait_defined(rest, name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => trait_defined(rest, name)
   }
@@ -1372,6 +1429,9 @@ export fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)] {
             cur = rest
           },
           EnvTraitImplGen(_, _, _, _, rest) => {
+            cur = rest
+          },
+          EnvTypeDefs(_, rest) => {
             cur = rest
           },
           EnvFlat(bindings) => {
@@ -2107,6 +2167,7 @@ export fn impls_overlap_for(env: TypeEnv, trait_name: String, new_target: Type) 
       else impls_overlap_for(rest, trait_name, new_target)
     } else impls_overlap_for(rest, trait_name, new_target),
     EnvTraitImplGen(_, _, _, _, rest) => impls_overlap_for(rest, trait_name, new_target),
+    EnvTypeDefs(_, rest) => impls_overlap_for(rest, trait_name, new_target),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => impls_overlap_for(rest, trait_name, new_target)
   }
@@ -2171,6 +2232,7 @@ fn type_implements_check_env(e: TypeEnv, full: TypeEnv, trait_name: String, reso
       else type_implements_check_env(rest, full, trait_name, resolved)
     } else type_implements_check_env(rest, full, trait_name, resolved),
     EnvTraitImplGen(_, _, _, _, rest) => type_implements_check_env(rest, full, trait_name, resolved),
+    EnvTypeDefs(_, rest) => type_implements_check_env(rest, full, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_implements_check_env(rest, full, trait_name, resolved)
   }
@@ -2200,6 +2262,7 @@ export fn trait_impl_declared_for_ctor(e: TypeEnv, trait_name: String, resolved:
       } else {
         trait_impl_declared_for_ctor(rest, trait_name, resolved)
       },
+      EnvTypeDefs(_, rest) => trait_impl_declared_for_ctor(rest, trait_name, resolved),
       EnvFlat(_) => false,
       EnvCached(_, _, rest) => trait_impl_declared_for_ctor(rest, trait_name, resolved)
     }
@@ -2295,6 +2358,7 @@ fn type_implements_check_super(e2: TypeEnv, full_env: TypeEnv, s: Subst, trait_n
         type_implements_check_super(rest, full_env, s, trait_name, resolved)
       }
     },
+    EnvTypeDefs(_, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved)
   }
@@ -2332,6 +2396,7 @@ fn trait_is_method_bearing(env: TypeEnv, trait_name: String) -> Bool {
     } else trait_is_method_bearing(rest, trait_name),
     EnvTraitImpl(_, _, rest) => trait_is_method_bearing(rest, trait_name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_is_method_bearing(rest, trait_name),
+    EnvTypeDefs(_, rest) => trait_is_method_bearing(rest, trait_name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => trait_is_method_bearing(rest, trait_name)
   }
@@ -2380,6 +2445,7 @@ fn generic_impl_satisfies(scan: TypeEnv, full: TypeEnv, s: Subst, trait_name: St
         true
       } else generic_impl_satisfies(rest, full, s, trait_name, resolved)
     },
+    EnvTypeDefs(_, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved)
   }

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -167,6 +167,7 @@ fn typing_dependency_record_decode_internal(text: String, expected_tag: String, 
 
 // --- typecheck_fs.vibe
 fn build_trait_aware_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception
+fn checked_module_public_env(stmts: Array[Stmt], full_checked_env: TypeEnv) -> TypeEnv
 fn locate_type_error(source: String, msg: String) -> String
 fn ensure_fingerprint_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs
 // #1100: memoized located lex+parse shared by the typecheck walk and the

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -870,11 +870,11 @@ export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Except
   } else {
     let (payload, after_payload) = parse_segment(normalized, header_len)
     if after_payload + 1 != String::length(normalized) || String::char_code_at(normalized, after_payload) != '\n' {
-      throw("invalid persistent type env v3 envelope")
+      throw("invalid persistent type env v4 envelope")
     } else {
       let (env, end) = parse_persistent_type_env_payload(payload, 0)
       if end != String::length(payload) {
-        throw("invalid persistent type env v3 payload")
+        throw("invalid persistent type env v4 payload")
       } else {
         Some(env)
       }
@@ -882,12 +882,19 @@ export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Except
   }
 }
 
+/// Filesystem cache bytes are untrusted. A malformed or old envelope is a
+/// cache miss, never an exception that can turn a cold check into a failure or
+/// a partially decoded interface into authority.
 export fn load_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with Exception + Fs {
   let path = persistent_type_env_cache_path(fingerprint)
   if !(Fs::exists(path)) {
     None
   } else {
-    parse_persistent_type_env(Fs::read_file(path))
+    handle {
+      parse_persistent_type_env(Fs::read_file(path))
+    } with Exception {
+      Throw(_) => None
+    }
   }
 }
 

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -532,10 +532,25 @@ fn serialize_type_def(def: TypeDef) -> String {
     },
     TDStruct(name, fields, mut_fields, params) => String::concat("S", String::concat(serialize_segment(name), String::concat(serialize_bindings(fields), String::concat(serialize_string_array(mut_fields), serialize_string_array(params))))),
     TDAlias(name, params, target) => String::concat("A", String::concat(serialize_segment(name), String::concat(serialize_string_array(params), serialize_type(target)))),
-    // Effects deliberately have no declaration transport in this slice.
-    // The decoder rejects this tag, so a future accidental insertion cannot
-    // turn an undeclared effect into the old permissive fallback.
-    TDEffect(_, _, _) => "!"
+    TDEffect(name, ops, params) => {
+      let out = StringBuilder::new()
+      StringBuilder::push(out, "K")
+      StringBuilder::push(out, serialize_segment(name))
+      StringBuilder::push(out, serialize_string_array(params))
+      StringBuilder::push(out, __to_string(Array::length(ops)))
+      StringBuilder::push(out, "[")
+      let mut i = 0
+      while i < Array::length(ops) {
+        let (op, args, ret) = Array::get(ops, i)
+        StringBuilder::push(out, serialize_segment(op))
+        StringBuilder::push(out, serialize_type_array(args))
+        StringBuilder::push(out, serialize_type(ret))
+        i = i + 1
+      }
+      StringBuilder::push(out, "]")
+      StringBuilder::freeze(out)
+    },
+    TDEffectSet(name, members) => String::concat("Z", String::concat(serialize_segment(name), serialize_string_array(members)))
   }
 }
 
@@ -576,6 +591,32 @@ fn parse_type_def(text: String, pos: Int) -> (TypeDef, Int) with Exception {
         let (params, after_params) = parse_string_array(text, after_name)
         let (target, next) = parse_cached_type(text, after_params)
         (TDAlias(name, params, target), next)
+      },
+      'K' => {
+        let (name, after_name) = parse_segment(text, pos + 1)
+        let (params, after_params) = parse_string_array(text, after_name)
+        let (count, start) = parse_count_header(text, after_params, '[')
+        let ops = array_empty()
+        let mut i = 0
+        let mut cursor = start
+        while i < count {
+          let (op, after_op) = parse_segment(text, cursor)
+          let (args, after_args) = parse_type_array(text, after_op)
+          let (ret, next) = parse_cached_type(text, after_args)
+          Array::push(ops, (op, args, ret))
+          cursor = next
+          i = i + 1
+        }
+        if cursor >= String::length(text) || String::char_code_at(text, cursor) != ']' {
+          throw("invalid persistent effect definition")
+        } else {
+          (TDEffect(name, ops, params), cursor + 1)
+        }
+      },
+      'Z' => {
+        let (name, after_name) = parse_segment(text, pos + 1)
+        let (members, next) = parse_string_array(text, after_name)
+        (TDEffectSet(name, members), next)
       },
       _ => throw("invalid persistent type definition tag")
     }
@@ -689,9 +730,10 @@ fn serialize_type_env_into(buf: StringBuilder, env: TypeEnv) -> Unit {
       StringBuilder::push(buf, serialize_type(target))
       serialize_type_env_into(buf, rest)
     },
-    EnvTypeDefs(defs, rest) => {
+    EnvTypeDefs(defs, selectable, rest) => {
       StringBuilder::push(buf, "P")
       StringBuilder::push(buf, serialize_type_defs(defs))
+      StringBuilder::push(buf, serialize_string_array(selectable))
       serialize_type_env_into(buf, rest)
     },
     EnvFlat(bindings) => {
@@ -770,8 +812,9 @@ fn parse_persistent_type_env_payload(text: String, pos: Int) -> (TypeEnv, Int) w
       },
       'P' => {
         let (defs, after_defs) = parse_type_defs(text, pos + 1)
-        let (rest, next) = parse_persistent_type_env_payload(text, after_defs)
-        (EnvTypeDefs(defs, rest), next)
+        let (selectable, after_selectable) = parse_string_array(text, after_defs)
+        let (rest, next) = parse_persistent_type_env_payload(text, after_selectable)
+        (EnvTypeDefs(defs, selectable, rest), next)
       },
       'L' => {
         let (bindings, next) = parse_bindings(text, pos + 1)
@@ -858,23 +901,23 @@ export fn load_persistent_dep_list(path: String, source: String) -> Option[Array
   }
 }
 
-/// Strict v4 module-interface wire format. It preserves the full persistent
-/// chain plus enum/struct/alias declaration authority. Older bare TypeEnv-v3
-/// bytes are rejected rather than being misread as an interface with no defs.
+/// Strict v5 module-interface wire format. It preserves declaration closure
+/// plus the distinct selected declaration surface. Older bytes are rejected
+/// rather than being misread as authority.
 export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Exception {
   let normalized = normalize_persistent_cache_text(text)
-  let header = "version\t4\nenv\t"
+  let header = "version\t5\nenv\t"
   let header_len = String::length(header)
   if String::length(normalized) < header_len || normalized[0: header_len] != header {
     None
   } else {
     let (payload, after_payload) = parse_segment(normalized, header_len)
     if after_payload + 1 != String::length(normalized) || String::char_code_at(normalized, after_payload) != '\n' {
-      throw("invalid persistent type env v4 envelope")
+      throw("invalid persistent type env v5 envelope")
     } else {
       let (env, end) = parse_persistent_type_env_payload(payload, 0)
       if end != String::length(payload) {
-        throw("invalid persistent type env v4 payload")
+        throw("invalid persistent type env v5 payload")
       } else {
         Some(env)
       }
@@ -899,7 +942,7 @@ export fn load_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with 
 }
 
 export fn persistent_type_env_cache_text(env: TypeEnv) -> String {
-  String::concat("version\t4\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
+  String::concat("version\t5\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
 }
 
 export fn load_persistent_leaf_fingerprint(path: String, source: String) -> Option[String] with Exception + Fs {

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -14,7 +14,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Type, TypeEnv, TypeExpr, env_cache
+  Type, TypeDef, TypeEnv, TypeExpr, env_cache
 }
 
 //# Functions
@@ -511,6 +511,113 @@ fn parse_trait_method_gens(text: String, pos: Int) -> (Array[(String, Array[Stri
   }
 }
 
+fn serialize_type_def(def: TypeDef) -> String {
+  match def {
+    TDEnum(name, params, variants) => {
+      let out = StringBuilder::new()
+      StringBuilder::push(out, "E")
+      StringBuilder::push(out, serialize_segment(name))
+      StringBuilder::push(out, serialize_string_array(params))
+      StringBuilder::push(out, __to_string(Array::length(variants)))
+      StringBuilder::push(out, "[")
+      let mut i = 0
+      while i < Array::length(variants) {
+        let (variant, fields) = Array::get(variants, i)
+        StringBuilder::push(out, serialize_segment(variant))
+        StringBuilder::push(out, serialize_type_array(fields))
+        i = i + 1
+      }
+      StringBuilder::push(out, "]")
+      StringBuilder::freeze(out)
+    },
+    TDStruct(name, fields, mut_fields, params) => String::concat("S", String::concat(serialize_segment(name), String::concat(serialize_bindings(fields), String::concat(serialize_string_array(mut_fields), serialize_string_array(params))))),
+    TDAlias(name, params, target) => String::concat("A", String::concat(serialize_segment(name), String::concat(serialize_string_array(params), serialize_type(target)))),
+    // Effects deliberately have no declaration transport in this slice.
+    // The decoder rejects this tag, so a future accidental insertion cannot
+    // turn an undeclared effect into the old permissive fallback.
+    TDEffect(_, _, _) => "!"
+  }
+}
+
+fn parse_type_def(text: String, pos: Int) -> (TypeDef, Int) with Exception {
+  if pos >= String::length(text) {
+    throw("invalid persistent type definition")
+  } else {
+    match String::char_code_at(text, pos) {
+      'E' => {
+        let (name, after_name) = parse_segment(text, pos + 1)
+        let (params, after_params) = parse_string_array(text, after_name)
+        let (count, start) = parse_count_header(text, after_params, '[')
+        let variants = array_empty()
+        let mut i = 0
+        let mut cursor = start
+        while i < count {
+          let (variant, after_variant) = parse_segment(text, cursor)
+          let (fields, next) = parse_type_array(text, after_variant)
+          Array::push(variants, (variant, fields))
+          cursor = next
+          i = i + 1
+        }
+        if cursor >= String::length(text) || String::char_code_at(text, cursor) != ']' {
+          throw("invalid persistent enum definition")
+        } else {
+          (TDEnum(name, params, variants), cursor + 1)
+        }
+      },
+      'S' => {
+        let (name, after_name) = parse_segment(text, pos + 1)
+        let (fields, after_fields) = parse_bindings(text, after_name)
+        let (mut_fields, after_mut_fields) = parse_string_array(text, after_fields)
+        let (params, next) = parse_string_array(text, after_mut_fields)
+        (TDStruct(name, fields, mut_fields, params), next)
+      },
+      'A' => {
+        let (name, after_name) = parse_segment(text, pos + 1)
+        let (params, after_params) = parse_string_array(text, after_name)
+        let (target, next) = parse_cached_type(text, after_params)
+        (TDAlias(name, params, target), next)
+      },
+      _ => throw("invalid persistent type definition tag")
+    }
+  }
+}
+
+fn serialize_type_defs(defs: Array[TypeDef]) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, __to_string(Array::length(defs)))
+  StringBuilder::push(out, "[")
+  let mut i = 0
+  while i < Array::length(defs) {
+    StringBuilder::push(out, serialize_segment(serialize_type_def(Array::get(defs, i))))
+    i = i + 1
+  }
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+fn parse_type_defs(text: String, pos: Int) -> (Array[TypeDef], Int) with Exception {
+  let (count, start) = parse_count_header(text, pos, '[')
+  let defs = array_empty()
+  let mut i = 0
+  let mut cursor = start
+  while i < count {
+    let (raw, after_raw) = parse_segment(text, cursor)
+    let (def, end) = parse_type_def(raw, 0)
+    if end != String::length(raw) {
+      throw("invalid persistent type definition payload")
+    } else {
+      Array::push(defs, def)
+      cursor = after_raw
+      i = i + 1
+    }
+  }
+  if cursor >= String::length(text) || String::char_code_at(text, cursor) != ']' {
+    throw("invalid persistent type definitions")
+  } else {
+    (defs, cursor + 1)
+  }
+}
+
 fn serialize_bindings(items: Array[(String, Type)]) -> String {
   let buf = StringBuilder::new()
   StringBuilder::push(buf, __to_string(Array::length(items)))
@@ -580,6 +687,11 @@ fn serialize_type_env_into(buf: StringBuilder, env: TypeEnv) -> Unit {
       StringBuilder::push(buf, serialize_string_array(params))
       StringBuilder::push(buf, serialize_string_bounds(bounds))
       StringBuilder::push(buf, serialize_type(target))
+      serialize_type_env_into(buf, rest)
+    },
+    EnvTypeDefs(defs, rest) => {
+      StringBuilder::push(buf, "P")
+      StringBuilder::push(buf, serialize_type_defs(defs))
       serialize_type_env_into(buf, rest)
     },
     EnvFlat(bindings) => {
@@ -655,6 +767,11 @@ fn parse_persistent_type_env_payload(text: String, pos: Int) -> (TypeEnv, Int) w
         let (target, after_target) = parse_cached_type(text, after_bounds)
         let (rest, next) = parse_persistent_type_env_payload(text, after_target)
         (EnvTraitImplGen(name, params, bounds, target, rest), next)
+      },
+      'P' => {
+        let (defs, after_defs) = parse_type_defs(text, pos + 1)
+        let (rest, next) = parse_persistent_type_env_payload(text, after_defs)
+        (EnvTypeDefs(defs, rest), next)
       },
       'L' => {
         let (bindings, next) = parse_bindings(text, pos + 1)
@@ -741,13 +858,12 @@ export fn load_persistent_dep_list(path: String, source: String) -> Option[Array
   }
 }
 
-/// Strict v3 TypeEnv wire format. It preserves the full persistent chain,
-/// including trait definitions' header and method-generic provenance, impl
-/// entries, and EnvCached lookup state; v1/v2 are rejected rather than silently
-/// reconstructed or partially reused.
+/// Strict v4 module-interface wire format. It preserves the full persistent
+/// chain plus enum/struct/alias declaration authority. Older bare TypeEnv-v3
+/// bytes are rejected rather than being misread as an interface with no defs.
 export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Exception {
   let normalized = normalize_persistent_cache_text(text)
-  let header = "version\t3\nenv\t"
+  let header = "version\t4\nenv\t"
   let header_len = String::length(header)
   if String::length(normalized) < header_len || normalized[0: header_len] != header {
     None
@@ -776,7 +892,7 @@ export fn load_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with 
 }
 
 export fn persistent_type_env_cache_text(env: TypeEnv) -> String {
-  String::concat("version\t3\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
+  String::concat("version\t4\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
 }
 
 export fn load_persistent_leaf_fingerprint(path: String, source: String) -> Option[String] with Exception + Fs {

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -40,6 +40,7 @@ import @vibe/compiler/runtime/eval_loader {
 
 import ./typecheck_fs.vibe {
   build_trait_aware_import_env,
+  checked_module_public_env,
   ensure_fingerprint_fs_impl,
   load_persistent_dep_list,
   load_persistent_leaf_fingerprint,
@@ -510,7 +511,8 @@ fn ensure_fingerprint(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_so
             let stmts = parse_program_with_path(path, source)
             let final_parse_count = parse_count_after_deps + 1
             let import_env = build_import_env(stmts, dir_of_path(path), env_cache_after_deps)
-            let checked_env = check_program_with_env(stmts, import_env)
+            let full_checked_env = check_program_with_env(stmts, import_env)
+            let checked_env = checked_module_public_env(stmts, full_checked_env)
             let next_env_cache = upsert_env_cache(env_cache_after_deps, path, checked_env)
             let next_db = ripple_record_eval(db_after_deps, path, fingerprint, deps)
             (fingerprint, next_db, next_env_cache, dep_source_cache_after_deps, final_parse_count)
@@ -519,7 +521,8 @@ fn ensure_fingerprint(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_so
             let stmts = parse_program_with_path(path, source)
             let final_parse_count = parse_count_after_deps + 1
             let import_env = build_import_env(stmts, dir_of_path(path), env_cache_after_deps)
-            let checked_env = check_program_with_env(stmts, import_env)
+            let full_checked_env = check_program_with_env(stmts, import_env)
+            let checked_env = checked_module_public_env(stmts, full_checked_env)
             let next_env_cache = upsert_env_cache(env_cache_after_deps, path, checked_env)
             let next_db = ripple_record_eval(db_after_deps, path, fingerprint, deps)
             (fingerprint, next_db, next_env_cache, dep_source_cache_after_deps, final_parse_count)

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -162,12 +162,11 @@ fn type_returns_name(ty: Type, type_name: String) -> Bool {
   }
 }
 
-/// Constructors and generated `Type::member` values are value bindings, but
-/// their authority is the selected public typedef rather than capitalization.
-/// Ambient declarations are a fixed language/runtime set, never a naming
-/// convention. They retain explicit package re-exports such as Option/Fs
-/// without reopening the retired uppercase fallback for user declarations.
-fn is_ambient_import_authority(name: String) -> Bool {
+/// A builtin declaration becomes import authority only when the dependency
+/// explicitly publishes it. This predicate is deliberately used solely while
+/// constructing that published surface; import validation below never falls
+/// back to builtin, registry, or effect-name recognition.
+fn is_explicit_builtin_declaration(name: String) -> Bool {
   let qualifier_at = String::index_of(name, "::")
   let qualifier = if qualifier_at > 0 {
     String::substring(name, 0, qualifier_at)
@@ -177,8 +176,6 @@ fn is_ambient_import_authority(name: String) -> Bool {
   if name == "Option" || name == "Random" || qualifier == "Option" || qualifier == "Random" {
     true
   } else match resolve_builtin(qualifier) {
-    // A member of a fixed builtin type namespace (e.g. String::unicode_length)
-    // is ambient; an arbitrary uppercase qualifier is still rejected.
     Some(_) => true,
     None => match resolve_builtin(name) {
       Some(_) => true,
@@ -934,7 +931,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
           // Declaration authority travels explicitly in EnvTypeDefs, so
           // uppercase is never evidence that an import is valid. Effects and
           // effectsets use the same selected declaration channel.
-          if dep_known && !contains_str(dep_selectable_type_defs, name) && !trait_defined(dep_env, name) && !is_ambient_import_authority(name) {
+          if dep_known && !contains_str(dep_selectable_type_defs, name) && !trait_defined(dep_env, name) {
             Array::push(unresolved, String::concat(String::concat(String::concat("imported name '", name), "' is not exported by '"), String::concat(raw_path, "'")))
           } else {
             ()
@@ -1941,11 +1938,10 @@ fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arra
     // Publish only the name the module selected. Its declaration closure is
     // retained separately by restrict_env_to_export_surface so a private
     // field/signature type remains interpretable without becoming selectable.
-    if typedef_projection_contains(defs, name) {
-      Array::push(out, name)
-    } else if is_ambient_import_authority(name) {
-      // Ambient declarations have no user TypeDef to carry, but an explicit
-      // package export remains a valid authority grant.
+    if typedef_projection_contains(defs, name) || is_explicit_builtin_declaration(name) {
+      // Builtin/registry declarations have no user TypeDef payload, but an
+      // explicit export gives them the same selected-surface authority as a
+      // contract declaration. They are never accepted merely by import name.
       Array::push(out, name)
     } else {
       ()
@@ -2062,6 +2058,45 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
     // collect_merged_stmts lane instead. Both are their own bugs.
     EnvCached(_, _, rest) => restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
   }
+}
+
+/// Builtin values are resolved outside a module's ordinary TypeEnv, so an
+/// explicit export of one needs a marker binding in the published environment.
+/// The marker never grants unexported builtin authority: its source is the
+/// already-filtered explicit value surface.
+fn prepend_explicit_builtin_value_markers(value_surface: Array[String], env: TypeEnv) -> TypeEnv {
+  let mut out = env
+  let mut i = 0
+  while i < Array::length(value_surface) {
+    let name = Array::get(value_surface, i)
+    if is_explicit_builtin_declaration(name) && env_lookup(env, name) == None {
+      out = EnvBind(name, CtUnknown, out)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// Build the single published environment shared by the filesystem and
+/// in-memory TypeDb lanes. Only declarations named by this module's explicit
+/// export surface leave the check; imported authority stays local unless the
+/// module re-exports it.
+export fn checked_module_public_env(stmts: Array[Stmt], full_checked_env: TypeEnv) -> TypeEnv {
+  let value_surface = interface_public_value_names(stmts)
+  let trait_surface = interface_public_trait_names(stmts, full_checked_env)
+  let type_surface = interface_public_type_names(stmts, full_checked_env)
+  let published = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, full_checked_env)
+  // Builtin declarations have no TypeDef node to survive the restriction.
+  // Their explicit selected surface still needs a transport node, otherwise
+  // the importer cannot distinguish this export from an empty dependency.
+  let with_builtin_types = if Array::length(type_surface) > 0 && Array::length(env_type_defs(published)) == 0 {
+    EnvTypeDefs(array_empty(), type_surface, published)
+  } else {
+    published
+  }
+  prepend_explicit_builtin_value_markers(value_surface, with_builtin_types)
 }
 
 fn interface_decl_line(prefix: String, name: String, body: String) -> String {
@@ -3162,10 +3197,7 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
       // consumer of `Checked`'s env (env cache, persistent store, worker
       // transport, TDRE4, trace identities) is a publication path. The full
       // environment never needs to outlive the check itself.
-      let value_surface = interface_public_value_names(stmts)
-      let trait_surface = interface_public_trait_names(stmts, full_checked_env)
-      let type_surface = interface_public_type_names(stmts, full_checked_env)
-      let checked_env = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, full_checked_env)
+      let checked_env = checked_module_public_env(stmts, full_checked_env)
       let interface_identity = if incremental_interface_trace_enabled() {
         incremental_interface_identity(job.source, checked_env)
       } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -22,6 +22,7 @@ import @vibe/compiler/core {
   Expr,
   Stmt,
   Type,
+  TypeDef,
   TypeEnv,
   bsearch_leftmost,
   dir_of_path,
@@ -29,6 +30,7 @@ import @vibe/compiler/core {
   env_flat_bindings,
   env_lookup,
   env_lookup_flat,
+  env_type_defs,
   normalize_path,
   resolution_env_seed,
   resolve_import_path,
@@ -308,6 +310,7 @@ fn trait_projection_supers(env: TypeEnv, name: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => trait_projection_supers(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_projection_supers(rest, name),
+    EnvTypeDefs(_, rest) => trait_projection_supers(rest, name),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => trait_projection_supers(rest, name)
   }
@@ -341,6 +344,7 @@ fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: St
       }
       trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
     },
+    EnvTypeDefs(_, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
     EnvFlat(_) => (),
     EnvCached(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
   }
@@ -557,6 +561,152 @@ fn trait_projection_map_method_bound_rows(bounds: Array[(String, Array[String])]
   out
 }
 
+fn typedef_projection_name(def: TypeDef) -> String {
+  match def {
+    TDEnum(name, _, _) => name,
+    TDStruct(name, _, _, _) => name,
+    TDAlias(name, _, _) => name,
+    TDEffect(name, _, _) => name
+  }
+}
+
+fn typedef_projection_contains(defs: Array[TypeDef], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(defs) && !found {
+    if typedef_projection_name(Array::get(defs, i)) == name {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn typedef_projection_add_type_refs(ty: Type, dep_defs: Array[TypeDef], selected: Array[TypeDef]) -> Unit {
+  match ty {
+    CtEnum(name) => typedef_projection_add_named(name, dep_defs, selected),
+    CtStruct(name) => typedef_projection_add_named(name, dep_defs, selected),
+    CtNamed(name, args) => {
+      typedef_projection_add_named(name, dep_defs, selected)
+      let mut i = 0
+      while i < Array::length(args) {
+        typedef_projection_add_type_refs(Array::get(args, i), dep_defs, selected)
+        i = i + 1
+      }
+    },
+    CtFn(args, ret, _) => {
+      let mut i = 0
+      while i < Array::length(args) {
+        typedef_projection_add_type_refs(Array::get(args, i), dep_defs, selected)
+        i = i + 1
+      }
+      typedef_projection_add_type_refs(ret, dep_defs, selected)
+    },
+    CtTuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        typedef_projection_add_type_refs(Array::get(items, i), dep_defs, selected)
+        i = i + 1
+      }
+    },
+    CtArray(item) => typedef_projection_add_type_refs(item, dep_defs, selected),
+    CtOption(item) => typedef_projection_add_type_refs(item, dep_defs, selected),
+    CtForAll(_, _, body) => typedef_projection_add_type_refs(body, dep_defs, selected),
+    _ => ()
+  }
+}
+
+fn typedef_projection_add_named(name: String, dep_defs: Array[TypeDef], selected: Array[TypeDef]) -> Unit {
+  if typedef_projection_contains(selected, name) {
+    ()
+  } else {
+    let mut i = 0
+    let mut found = None
+    let mut done = false
+    while i < Array::length(dep_defs) && !done {
+      let def = Array::get(dep_defs, i)
+      if typedef_projection_name(def) == name {
+        found = Some(def)
+        done = true
+      } else {
+        i = i + 1
+      }
+    }
+    match found {
+      Some(def) => {
+        Array::push(selected, def)
+        match def {
+          TDEnum(_, _, variants) => {
+            let mut vi = 0
+            while vi < Array::length(variants) {
+              let (_, fields) = Array::get(variants, vi)
+              let mut fi = 0
+              while fi < Array::length(fields) {
+                typedef_projection_add_type_refs(Array::get(fields, fi), dep_defs, selected)
+                fi = fi + 1
+              }
+              vi = vi + 1
+            }
+          },
+          TDStruct(_, fields, _, _) => {
+            let mut fi = 0
+            while fi < Array::length(fields) {
+              let (_, ty) = Array::get(fields, fi)
+              typedef_projection_add_type_refs(ty, dep_defs, selected)
+              fi = fi + 1
+            }
+          },
+          TDAlias(_, _, target) => typedef_projection_add_type_refs(target, dep_defs, selected),
+          TDEffect(_, _, _) => ()
+        }
+      },
+      None => ()
+    }
+  }
+}
+
+fn dependency_typedef_projection(dep_env: TypeEnv, names: Array[(String, Option[String])]) -> Array[TypeDef] {
+  let dep_defs = env_type_defs(dep_env)
+  let selected = array_empty()
+  let mut i = 0
+  while i < Array::length(names) {
+    let (name, alias) = Array::get(names, i)
+    let before = Array::length(selected)
+    typedef_projection_add_named(name, dep_defs, selected)
+    if Array::length(selected) > before {
+      match alias {
+        Some(local_name) => if local_name != name && !typedef_projection_contains(selected, local_name) {
+          let source = Array::get(selected, before)
+          let alias_def = match source {
+            TDEnum(_, _, _) => TDAlias(local_name, array_empty(), CtEnum(name)),
+            TDStruct(_, _, _, _) => TDAlias(local_name, array_empty(), CtStruct(name)),
+            TDAlias(_, _, target) => TDAlias(local_name, array_empty(), target),
+            TDEffect(_, _, _) => TDAlias(local_name, array_empty(), CtUnknown)
+          }
+          Array::push(selected, alias_def)
+        } else {
+          ()
+        },
+        None => ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  selected
+}
+
+fn prepend_dependency_type_defs(dep_env: TypeEnv, names: Array[(String, Option[String])], tail: TypeEnv) -> TypeEnv {
+  let defs = dependency_typedef_projection(dep_env, names)
+  if Array::length(defs) == 0 {
+    tail
+  } else {
+    EnvTypeDefs(defs, tail)
+  }
+}
+
 fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, String)], tail: TypeEnv) -> TypeEnv {
   // Preserve every generic implementation in source order. Its parameters and
   // bounds are semantic payload, so deduplicating by erased target spelling
@@ -607,6 +757,9 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
           Some(local_name) => Array::push(retained, EnvTraitImplGen(local_name, params, trait_projection_map_method_bound_rows(bounds, mappings), trait_projection_map_type_bounds(target, mappings), EnvEmpty)),
           None => ()
         }
+        cur = rest
+      },
+      EnvTypeDefs(_, rest) => {
         cur = rest
       },
       EnvFlat(_) => {
@@ -685,7 +838,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       bind_names(j + 1, with_companions)
     }
   }
-  bind_names(0, prepend_dependency_trait_nodes(dep_env, trait_mappings, acc))
+  bind_names(0, prepend_dependency_trait_nodes(dep_env, trait_mappings, prepend_dependency_type_defs(dep_env, names, acc)))
 }
 
 /// Shared by the filesystem and in-memory TypeDb lanes. The latter accepts
@@ -1632,6 +1785,52 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
   interface_sorted_unique(names)
 }
 
+fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Array[String] {
+  let names = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SEnum(true, name, _, _, _) => Array::push(names, name),
+      SStruct(true, name, _, _, _, _) => Array::push(names, name),
+      STypeAlias(true, name, _, _) => Array::push(names, name),
+      SExport(items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          Array::push(names, Array::get(items, j))
+          j = j + 1
+        }
+      },
+      SReExport(_, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let (source, alias) = Array::get(items, j)
+          Array::push(names, match alias {
+            Some(local) => local,
+            None => source
+          })
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  let defs = env_type_defs(checked_env)
+  let selected = array_empty()
+  let mut ni = 0
+  while ni < Array::length(names) {
+    typedef_projection_add_named(Array::get(names, ni), defs, selected)
+    ni = ni + 1
+  }
+  let out = array_empty()
+  let mut si = 0
+  while si < Array::length(selected) {
+    Array::push(out, typedef_projection_name(Array::get(selected, si)))
+    si = si + 1
+  }
+  interface_sorted_unique(out)
+}
+
 /// #1533: the environment a module PUBLISHES to its importers is its export
 /// surface, not its full checked environment. The checked environment binds
 /// every top-level `let`/`fn` -- and, via the import env at its base, every
@@ -1654,11 +1853,11 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
 /// Trait definitions and implementations are published only for the selected
 /// trait surface. EnvCached wrappers are rebuilt from the restricted chain
 /// (their arrays are acceleration state, same rule as the serializer's).
-fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: Array[String], env: TypeEnv) -> TypeEnv {
+fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: Array[String], type_surface: Array[String], env: TypeEnv) -> TypeEnv {
   match env {
     EnvEmpty => EnvEmpty,
     EnvBind(name, ty, rest) => {
-      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       if starts_with_upper(name) || bsearch_leftmost(value_surface, name) >= 0 {
         EnvBind(name, ty, restricted)
       } else {
@@ -1666,7 +1865,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       }
     },
     EnvTraitDef(name, supers, is_auto, methods, rest, params, method_gens) => {
-      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       if bsearch_leftmost(trait_surface, name) >= 0 {
         EnvTraitDef(name, supers, is_auto, methods, restricted, params, method_gens)
       } else {
@@ -1674,7 +1873,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       }
     },
     EnvTraitImpl(name, target, rest) => {
-      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       if bsearch_leftmost(trait_surface, name) >= 0 {
         EnvTraitImpl(name, target, restricted)
       } else {
@@ -1682,11 +1881,30 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       }
     },
     EnvTraitImplGen(name, params, bounds, target, rest) => {
-      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, rest)
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       if bsearch_leftmost(trait_surface, name) >= 0 {
         EnvTraitImplGen(name, params, bounds, target, restricted)
       } else {
         restricted
+      }
+    },
+    EnvTypeDefs(defs, rest) => {
+      let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
+      let kept = array_empty()
+      let mut i = 0
+      while i < Array::length(defs) {
+        let def = Array::get(defs, i)
+        if bsearch_leftmost(type_surface, typedef_projection_name(def)) >= 0 {
+          Array::push(kept, def)
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      if Array::length(kept) == 0 {
+        restricted
+      } else {
+        EnvTypeDefs(kept, restricted)
       }
     },
     EnvFlat(bindings) => {
@@ -1712,7 +1930,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
     // module lane resolves an import over a same-named local (the merge
     // lane shadows correctly), while an `as` alias broke the
     // collect_merged_stmts lane instead. Both are their own bugs.
-    EnvCached(_, _, rest) => restrict_env_to_export_surface(value_surface, trait_surface, rest)
+    EnvCached(_, _, rest) => restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
   }
 }
 
@@ -2816,7 +3034,8 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
       // environment never needs to outlive the check itself.
       let value_surface = interface_public_value_names(stmts)
       let trait_surface = interface_public_trait_names(stmts, full_checked_env)
-      let checked_env = restrict_env_to_export_surface(value_surface, trait_surface, full_checked_env)
+      let type_surface = interface_public_type_names(stmts, full_checked_env)
+      let checked_env = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, full_checked_env)
       let interface_identity = if incremental_interface_trace_enabled() {
         incremental_interface_identity(job.source, checked_env)
       } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -30,9 +30,13 @@ import @vibe/compiler/core {
   env_flat_bindings,
   env_lookup,
   env_lookup_flat,
+  env_selectable_type_defs,
   env_type_defs,
+  has_standard_effect_policy,
+  lookup_registry_builtin,
   normalize_path,
   resolution_env_seed,
+  resolve_builtin,
   resolve_import_path,
   resolve_import_path_candidates,
   str_lt,
@@ -160,6 +164,34 @@ fn type_returns_name(ty: Type, type_name: String) -> Bool {
 
 /// Constructors and generated `Type::member` values are value bindings, but
 /// their authority is the selected public typedef rather than capitalization.
+/// Ambient declarations are a fixed language/runtime set, never a naming
+/// convention. They retain explicit package re-exports such as Option/Fs
+/// without reopening the retired uppercase fallback for user declarations.
+fn is_ambient_import_authority(name: String) -> Bool {
+  let qualifier_at = String::index_of(name, "::")
+  let qualifier = if qualifier_at > 0 {
+    String::substring(name, 0, qualifier_at)
+  } else {
+    ""
+  }
+  if name == "Option" || name == "Random" || qualifier == "Option" || qualifier == "Random" {
+    true
+  } else match resolve_builtin(qualifier) {
+    // A member of a fixed builtin type namespace (e.g. String::unicode_length)
+    // is ambient; an arbitrary uppercase qualifier is still rejected.
+    Some(_) => true,
+    None => match resolve_builtin(name) {
+      Some(_) => true,
+      None => if has_standard_effect_policy(name) {
+        true
+      } else match lookup_registry_builtin(name) {
+        Some(_) => true,
+        None => false
+      }
+    }
+  }
+}
+
 fn is_selected_type_companion(name: String, ty: Type, type_surface: Array[String]) -> Bool {
   let mut i = 0
   let mut selected = false
@@ -342,7 +374,7 @@ fn trait_projection_supers(env: TypeEnv, name: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => trait_projection_supers(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => trait_projection_supers(rest, name),
-    EnvTypeDefs(_, rest) => trait_projection_supers(rest, name),
+    EnvTypeDefs(_, _, rest) => trait_projection_supers(rest, name),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => trait_projection_supers(rest, name)
   }
@@ -376,7 +408,7 @@ fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: St
       }
       trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
     },
-    EnvTypeDefs(_, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
+    EnvTypeDefs(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
     EnvFlat(_) => (),
     EnvCached(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
   }
@@ -598,7 +630,8 @@ fn typedef_projection_name(def: TypeDef) -> String {
     TDEnum(name, _, _) => name,
     TDStruct(name, _, _, _) => name,
     TDAlias(name, _, _) => name,
-    TDEffect(name, _, _) => name
+    TDEffect(name, _, _) => name,
+    TDEffectSet(name, _) => name
   }
 }
 
@@ -690,7 +723,26 @@ fn typedef_projection_add_named(name: String, dep_defs: Array[TypeDef], selected
             }
           },
           TDAlias(_, _, target) => typedef_projection_add_type_refs(target, dep_defs, selected),
-          TDEffect(_, _, _) => ()
+          TDEffect(_, ops, _) => {
+            let mut oi = 0
+            while oi < Array::length(ops) {
+              let (_, params, ret) = Array::get(ops, oi)
+              let mut pi = 0
+              while pi < Array::length(params) {
+                typedef_projection_add_type_refs(Array::get(params, pi), dep_defs, selected)
+                pi = pi + 1
+              }
+              typedef_projection_add_type_refs(ret, dep_defs, selected)
+              oi = oi + 1
+            }
+          },
+          TDEffectSet(_, members) => {
+            let mut mi = 0
+            while mi < Array::length(members) {
+              typedef_projection_add_named(Array::get(members, mi), dep_defs, selected)
+              mi = mi + 1
+            }
+          }
         }
       },
       None => ()
@@ -700,12 +752,17 @@ fn typedef_projection_add_named(name: String, dep_defs: Array[TypeDef], selected
 
 fn dependency_typedef_projection(dep_env: TypeEnv, names: Array[(String, Option[String])]) -> Array[TypeDef] {
   let dep_defs = env_type_defs(dep_env)
+  let selectable = env_selectable_type_defs(dep_env)
   let selected = array_empty()
   let mut i = 0
   while i < Array::length(names) {
     let (name, alias) = Array::get(names, i)
     let before = Array::length(selected)
-    typedef_projection_add_named(name, dep_defs, selected)
+    if contains_str(selectable, name) {
+      typedef_projection_add_named(name, dep_defs, selected)
+    } else {
+      ()
+    }
     if Array::length(selected) > before {
       match alias {
         Some(local_name) => if local_name != name && !typedef_projection_contains(selected, local_name) {
@@ -718,9 +775,8 @@ fn dependency_typedef_projection(dep_env: TypeEnv, names: Array[(String, Option[
               CtNamed(param, array_empty())
             })),
             TDAlias(_, params, target) => TDAlias(local_name, params, target),
-            // Effects have no declaration transport; this branch is
-            // unreachable for a selected import and must not fabricate one.
-            TDEffect(_, _, _) => TDAlias(local_name, array_empty(), CtUnknown)
+            TDEffect(_, ops, params) => TDEffect(local_name, ops, params),
+            TDEffectSet(_, members) => TDEffectSet(local_name, members)
           }
           Array::push(selected, alias_def)
         } else {
@@ -741,7 +797,24 @@ fn prepend_dependency_type_defs(dep_env: TypeEnv, names: Array[(String, Option[S
   if Array::length(defs) == 0 {
     tail
   } else {
-    EnvTypeDefs(defs, tail)
+    // Only the explicitly requested names are selectable; recursive closure
+    // entries merely make their signatures intelligible to this checker.
+    let selectable = array_empty()
+    let published = env_selectable_type_defs(dep_env)
+    let mut i = 0
+    while i < Array::length(names) {
+      let (source, alias) = Array::get(names, i)
+      if contains_str(published, source) {
+        Array::push(selectable, match alias {
+          Some(local) => local,
+          None => source
+        })
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    EnvTypeDefs(defs, selectable, tail)
   }
 }
 
@@ -797,7 +870,7 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
         }
         cur = rest
       },
-      EnvTypeDefs(_, rest) => {
+      EnvTypeDefs(_, _, rest) => {
         cur = rest
       },
       EnvFlat(_) => {
@@ -830,6 +903,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
   }
   let dep_bindings = env_flat_bindings(dep_env)
   let dep_type_defs = env_type_defs(dep_env)
+  let dep_selectable_type_defs = env_selectable_type_defs(dep_env)
   // Explicit trait aliases must be known before values are bound: a selected
   // value can mention the trait before its `trait X as Local` row appears.
   let trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, unresolved)
@@ -857,12 +931,10 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       let ty = match env_lookup_flat(dep_bindings, name) {
         Some(t) => trait_projection_map_type_bounds(t, trait_mappings),
         None => {
-          // Declaration authority now travels explicitly in EnvTypeDefs, so
-          // uppercase is no longer evidence that an import is valid. This
-          // also rejects selected effects/effectsets until their own authority
-          // transport exists, instead of allowing a missing uppercase import
-          // to become CtUnknown and fail later in codegen.
-          if dep_known && !typedef_projection_contains(dep_type_defs, name) && !trait_defined(dep_env, name) {
+          // Declaration authority travels explicitly in EnvTypeDefs, so
+          // uppercase is never evidence that an import is valid. Effects and
+          // effectsets use the same selected declaration channel.
+          if dep_known && !contains_str(dep_selectable_type_defs, name) && !trait_defined(dep_env, name) && !is_ambient_import_authority(name) {
             Array::push(unresolved, String::concat(String::concat(String::concat("imported name '", name), "' is not exported by '"), String::concat(raw_path, "'")))
           } else {
             ()
@@ -1837,6 +1909,8 @@ fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arra
       SEnum(true, name, _, _, _) => Array::push(names, name),
       SStruct(true, name, _, _, _, _) => Array::push(names, name),
       STypeAlias(true, name, _, _) => Array::push(names, name),
+      SEffectDef(true, name, _, _) => Array::push(names, name),
+      SEffectSet(true, name, _) => Array::push(names, name),
       SExport(items) => {
         let mut j = 0
         while j < Array::length(items) {
@@ -1860,17 +1934,23 @@ fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arra
     i = i + 1
   }
   let defs = env_type_defs(checked_env)
-  let selected = array_empty()
+  let out = array_empty()
   let mut ni = 0
   while ni < Array::length(names) {
-    typedef_projection_add_named(Array::get(names, ni), defs, selected)
+    let name = Array::get(names, ni)
+    // Publish only the name the module selected. Its declaration closure is
+    // retained separately by restrict_env_to_export_surface so a private
+    // field/signature type remains interpretable without becoming selectable.
+    if typedef_projection_contains(defs, name) {
+      Array::push(out, name)
+    } else if is_ambient_import_authority(name) {
+      // Ambient declarations have no user TypeDef to carry, but an explicit
+      // package export remains a valid authority grant.
+      Array::push(out, name)
+    } else {
+      ()
+    }
     ni = ni + 1
-  }
-  let out = array_empty()
-  let mut si = 0
-  while si < Array::length(selected) {
-    Array::push(out, typedef_projection_name(Array::get(selected, si)))
-    si = si + 1
   }
   interface_sorted_unique(out)
 }
@@ -1927,23 +2007,34 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
         restricted
       }
     },
-    EnvTypeDefs(defs, rest) => {
+    EnvTypeDefs(defs, _, rest) => {
       let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
       let kept = array_empty()
       let mut i = 0
       while i < Array::length(defs) {
         let def = Array::get(defs, i)
         if bsearch_leftmost(type_surface, typedef_projection_name(def)) >= 0 {
-          Array::push(kept, def)
+          let closure = array_empty()
+          typedef_projection_add_named(typedef_projection_name(def), defs, closure)
+          let mut ci = 0
+          while ci < Array::length(closure) {
+            let closure_def = Array::get(closure, ci)
+            if !typedef_projection_contains(kept, typedef_projection_name(closure_def)) {
+              Array::push(kept, closure_def)
+            } else {
+              ()
+            }
+            ci = ci + 1
+          }
         } else {
           ()
         }
         i = i + 1
       }
-      if Array::length(kept) == 0 {
+      if Array::length(kept) == 0 && Array::length(type_surface) == 0 {
         restricted
       } else {
-        EnvTypeDefs(kept, restricted)
+        EnvTypeDefs(kept, type_surface, restricted)
       }
     },
     EnvFlat(bindings) => {
@@ -2388,7 +2479,7 @@ export fn incremental_invalidation_trace_json(entry_path: String, run_nonce: Str
       None => throw(String::concat("incremental invalidation trace: missing complete persistent TypeEnv transport observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(persistent_type_env_transport_fingerprint))
-    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v4 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
+    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v5 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
     StringBuilder::push(out, incremental_trace_json_string(decision))
     StringBuilder::push(out, "}")
     i = i + 1

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -81,6 +81,22 @@ fn empty_dep_fps() -> Array[(String, String)] {
   array_empty()
 }
 
+/// Every acceptance of a persistent fingerprint must first decode its v4
+/// interface. Old/corrupt bytes are ordinary cold-cache misses.
+fn valid_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with Exception + Fs {
+  load_persistent_type_env(fingerprint)
+}
+
+fn valid_persistent_leaf_fingerprint(path: String, source: String) -> Option[String] with Exception + Fs {
+  match load_persistent_leaf_fingerprint(path, source) {
+    Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
+      Some(_) => Some(fingerprint),
+      None => None
+    },
+    None => None
+  }
+}
+
 fn lookup_env_cache(cache: Array[(String, TypeEnv)], path: String) -> Option[TypeEnv] {
   let len = Array::length(cache)
   let mut i = 0
@@ -140,6 +156,22 @@ fn type_returns_name(ty: Type, type_name: String) -> Bool {
     CtForAll(_, _, body) => type_returns_name(body, type_name),
     _ => false
   }
+}
+
+/// Constructors and generated `Type::member` values are value bindings, but
+/// their authority is the selected public typedef rather than capitalization.
+fn is_selected_type_companion(name: String, ty: Type, type_surface: Array[String]) -> Bool {
+  let mut i = 0
+  let mut selected = false
+  while i < Array::length(type_surface) && !selected {
+    let type_name = Array::get(type_surface, i)
+    if name == type_name || String::starts_with(name, String::concat(type_name, "::")) || type_returns_name(ty, type_name) {
+      selected = true
+    } else {
+      i = i + 1
+    }
+  }
+  selected
 }
 
 /// Companions bound alongside an imported type `T`: (a) constructors and
@@ -679,9 +711,15 @@ fn dependency_typedef_projection(dep_env: TypeEnv, names: Array[(String, Option[
         Some(local_name) => if local_name != name && !typedef_projection_contains(selected, local_name) {
           let source = Array::get(selected, before)
           let alias_def = match source {
-            TDEnum(_, _, _) => TDAlias(local_name, array_empty(), CtEnum(name)),
-            TDStruct(_, _, _, _) => TDAlias(local_name, array_empty(), CtStruct(name)),
-            TDAlias(_, _, target) => TDAlias(local_name, array_empty(), target),
+            TDEnum(_, params, _) => TDAlias(local_name, params, CtNamed(name, for param in params {
+              CtNamed(param, array_empty())
+            })),
+            TDStruct(_, _, _, params) => TDAlias(local_name, params, CtNamed(name, for param in params {
+              CtNamed(param, array_empty())
+            })),
+            TDAlias(_, params, target) => TDAlias(local_name, params, target),
+            // Effects have no declaration transport; this branch is
+            // unreachable for a selected import and must not fabricate one.
             TDEffect(_, _, _) => TDAlias(local_name, array_empty(), CtUnknown)
           }
           Array::push(selected, alias_def)
@@ -791,6 +829,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
     None => EnvEmpty
   }
   let dep_bindings = env_flat_bindings(dep_env)
+  let dep_type_defs = env_type_defs(dep_env)
   // Explicit trait aliases must be known before values are bound: a selected
   // value can mention the trait before its `trait X as Local` row appears.
   let trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, unresolved)
@@ -818,7 +857,12 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       let ty = match env_lookup_flat(dep_bindings, name) {
         Some(t) => trait_projection_map_type_bounds(t, trait_mappings),
         None => {
-          if dep_known && !starts_with_upper(name) {
+          // Declaration authority now travels explicitly in EnvTypeDefs, so
+          // uppercase is no longer evidence that an import is valid. This
+          // also rejects selected effects/effectsets until their own authority
+          // transport exists, instead of allowing a missing uppercase import
+          // to become CtUnknown and fail later in codegen.
+          if dep_known && !typedef_projection_contains(dep_type_defs, name) && !trait_defined(dep_env, name) {
             Array::push(unresolved, String::concat(String::concat(String::concat("imported name '", name), "' is not exported by '"), String::concat(raw_path, "'")))
           } else {
             ()
@@ -1198,9 +1242,9 @@ let incremental_checked_env_trace_observations: Array[(String, String)] = [
 let incremental_persistent_type_env_transport_trace_observations: Array[(String, String)] = [
 ]
 
-// TDRE4 aliases only an exact v3 decoded TypeEnv when every direct dependency
+// TDRE4 aliases only an exact v4 decoded TypeEnv when every direct dependency
 // transport environment is unchanged. It is not a CheckedProgram or typed-IR
-// transport; v3 retains the TypeEnv trait/impl chain only. The empty cell is
+// transport; v4 retains the TypeEnv declaration, trait, and impl chain. The empty cell is
 // conservative for direct FS consumers. The CLI check-only lane explicitly
 // enables production reuse after validating its per-invocation policy; build,
 // codegen, and other FS consumers remain off pending compact publication.
@@ -1841,14 +1885,9 @@ fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arra
 /// makes the existing membership check in
 /// bind_import_names_from_cache_collecting the export test itself.
 ///
-/// Only lowercase-initial bindings are dropped, and `surface` is
-/// interface_public_value_names -- exported `let`/`fn`, `export { .. }`
-/// lists, and re-export aliases -- which is exactly the set of importable
-/// lowercase names. Uppercase bindings (enum constructors, `T::` companions,
-/// qualified impl methods) are kept wholesale: the value environment cannot
-/// distinguish an unexported `Foo` from a struct-only `Foo`, so their half
-/// of #1521 stays open rather than risk rejecting valid code, and the
-/// companion-binding scan over dep_bindings keeps working unchanged.
+/// Value bindings are retained only when they are explicitly exported.
+/// Type/constructor authority travels separately through `EnvTypeDefs`; an
+/// uppercase spelling is never authority to import a private declaration.
 ///
 /// Trait definitions and implementations are published only for the selected
 /// trait surface. EnvCached wrappers are rebuilt from the restricted chain
@@ -1858,7 +1897,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
     EnvEmpty => EnvEmpty,
     EnvBind(name, ty, rest) => {
       let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
-      if starts_with_upper(name) || bsearch_leftmost(value_surface, name) >= 0 {
+      if bsearch_leftmost(value_surface, name) >= 0 || is_selected_type_companion(name, ty, type_surface) {
         EnvBind(name, ty, restricted)
       } else {
         restricted
@@ -1912,7 +1951,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       let mut i = 0
       while i < Array::length(bindings) {
         let (name, ty) = Array::get(bindings, i)
-        if starts_with_upper(name) || bsearch_leftmost(value_surface, name) >= 0 {
+        if bsearch_leftmost(value_surface, name) >= 0 || is_selected_type_companion(name, ty, type_surface) {
           Array::push(kept, (name, ty))
         } else {
           ()
@@ -2230,7 +2269,7 @@ fn incremental_checked_env_identity(env: TypeEnv) -> String with Exception {
   compact_string_fingerprint(StringBuilder::freeze(out))
 }
 
-/// A trace-only observation of the complete persistent TypeEnv v3 transport.
+/// A trace-only observation of the complete persistent TypeEnv v4 transport.
 /// The canonical cache-text bytes are the sole input. This is not a
 /// CheckedProgram, typed IR, exported interface, cache key, or reuse decision.
 fn incremental_persistent_type_env_transport_identity(env: TypeEnv) -> String {
@@ -2284,7 +2323,7 @@ fn incremental_trace_json_string(text: String) -> String {
 /// provisional canonical token-stream identity, not normalized typed IR.
 /// `checked_env_fingerprint` is a complete value-environment observation.
 /// `persistent_type_env_transport_fingerprint` observes only the complete
-/// persistent TypeEnv v3 transport, not a CheckedProgram, typed IR, exported
+/// persistent TypeEnv v4 transport, not a CheckedProgram, typed IR, exported
 /// interface, cache key, or reuse decision. `decision` records what this current TypeDb
 /// walk did (`rechecked` or `reused`), not a formal invalidation verdict.
 /// This function is called only after a successful check; a missing per-module
@@ -2349,7 +2388,7 @@ export fn incremental_invalidation_trace_json(entry_path: String, run_nonce: Str
       None => throw(String::concat("incremental invalidation trace: missing complete persistent TypeEnv transport observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(persistent_type_env_transport_fingerprint))
-    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v3 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
+    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v4 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
     StringBuilder::push(out, incremental_trace_json_string(decision))
     StringBuilder::push(out, "}")
     i = i + 1
@@ -2476,10 +2515,10 @@ let parse_memo_paths: Array[String] = [
   text
 }
 
-// TDRE4 is deliberately independent from the TypeEnv v3 envelope and from
+// TDRE4 is deliberately independent from the TypeEnv v4 envelope and from
 // every production artifact/cache identity. Both v4 envelopes use strict
 // decimal length-delimited fields and bind the logical checker input, target
-// conservative fingerprint, and exact canonical TypeEnv-v3 transport text.
+// conservative fingerprint, and exact canonical TypeEnv-v4 transport text.
 // The target text is intentionally not replaced by a compact fingerprint:
 // cache corruption must not turn a fingerprint collision into checker reuse.
 let typing_dependency_env_reuse_alias_v4_tag = "TDRE4A"
@@ -2570,7 +2609,7 @@ fn typing_dependency_transport_input_key(path: String, source: String, dep_envs:
 }
 
 /// Decode untrusted target bytes strictly and require the decoder's canonical
-/// v3 re-encoding to equal both the raw file and the binding's exact text.
+/// v4 re-encoding to equal both the raw file and the binding's exact text.
 /// parse_persistent_type_env accepts normalized line endings for ordinary cache
 /// compatibility; this additional equality makes the experimental lane strict.
 fn load_canonical_typing_dependency_env_reuse_target(target_fingerprint: String, expected_target_text: String) -> Option[TypeEnv] with Fs {
@@ -2624,7 +2663,7 @@ fn typing_dependency_env_reuse_eligibility_is_valid(fingerprint: String) -> Bool
   }
 }
 
-/// Eligibility is transitively witnessed by successful canonical TypeEnv-v3
+/// Eligibility is transitively witnessed by successful canonical TypeEnv-v4
 /// commits. Missing, malformed, stale, torn, or cross-spliced witnesses fail
 /// closed before the alias lookup.
 fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> Bool with Fs {
@@ -2988,7 +3027,7 @@ export fn locate_type_error(source: String, msg: String) -> String {
 /// resolve from impl units against the contract definition.
 export enum ModuleOutcome {
   // The final strings are trace-only interface, checked-value-env, and
-  // complete persistent TypeEnv v3 transport identities. They are computed
+  // complete persistent TypeEnv v4 transport identities. They are computed
   // from this successful check's typed environment, never used as cache
   // inputs, and are empty unless the invalidation trace is enabled.
   Checked(String, String, TypeEnv, String, String, String);
@@ -3316,7 +3355,17 @@ fn parse_publish_manifest_rows(text: String) -> Array[(String, String)] with Exc
   while i < len {
     let (fingerprint, env_file) = Array::get(rows, i)
     let env_text = Fs::read_file(job_dir_path(dir, env_file))
-    Fs::write_file(persistent_type_env_cache_path(fingerprint), env_text)
+    match parse_persistent_type_env(env_text) {
+      Some(env) => {
+        let canonical = persistent_type_env_cache_text(env)
+        if env_text == canonical {
+          Fs::write_file(persistent_type_env_cache_path(fingerprint), env_text)
+        } else {
+          throw(String::concat("publish manifest has non-canonical v4 environment: ", env_file))
+        }
+      },
+      None => throw(String::concat("publish manifest has unreadable v4 environment: ", env_file))
+    }
     i = i + 1
   }
 }
@@ -3329,58 +3378,58 @@ fn parse_publish_manifest_rows(text: String) -> Array[(String, String)] with Exc
 /// cross-check) that identical fingerprint itself, the same way a worker
 /// would -- one canonical computation, not a value trusted from the caller.
 fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String, source: String, deps: Array[String], dep_fps: Array[(String, String)], fingerprint: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
-  if Fs::exists(persistent_type_env_cache_path(fingerprint)) {
-    if incremental_interface_trace_enabled() {
-      match load_persistent_type_env(fingerprint) {
-        Some(cached_env) => incremental_trace_observe_checked_env(path, source, cached_env),
-        None => throw(String::concat("incremental trace observation: unreadable reused environment for ", path))
+  match valid_persistent_type_env(fingerprint) {
+    Some(cached_env) => {
+      if incremental_interface_trace_enabled() {
+        incremental_trace_observe_checked_env(path, source, cached_env)
+      } else {
+        ()
       }
-    } else {
-      ()
-    }
-    let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
-    (fingerprint, next_db, env_cache, dep_source_cache, parse_count)
-  } else {
-    // Keep the accumulated cache as coordinator state, but expose exactly the
-    // resolved dependency sequence to the checker and TDRE4. Construct this
-    // once: lookup, check, and publication must describe the same value.
-    let coordinated_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
-    let projected_dep_envs = project_exact_dependency_envs(deps, coordinated_env_cache)
-    let reused_env = if experimental_typing_dependency_env_reuse_enabled() {
-      if typing_dependency_env_reuse_is_eligible(dep_fps) {
-        let input_key = typing_dependency_transport_input_key(path, source, projected_dep_envs)
-        match load_typing_dependency_env_reuse_target(input_key) {
-          Some((target_fingerprint, target_text, target_env)) => Some((input_key, target_fingerprint, target_text, target_env)),
-          None => None
+      let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
+      (fingerprint, next_db, env_cache, dep_source_cache, parse_count)
+    },
+    None => {
+      // Keep the accumulated cache as coordinator state, but expose exactly the
+      // resolved dependency sequence to the checker and TDRE4. Construct this
+      // once: lookup, check, and publication must describe the same value.
+      let coordinated_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
+      let projected_dep_envs = project_exact_dependency_envs(deps, coordinated_env_cache)
+      let reused_env = if experimental_typing_dependency_env_reuse_enabled() {
+        if typing_dependency_env_reuse_is_eligible(dep_fps) {
+          let input_key = typing_dependency_transport_input_key(path, source, projected_dep_envs)
+          match load_typing_dependency_env_reuse_target(input_key) {
+            Some((target_fingerprint, target_text, target_env)) => Some((input_key, target_fingerprint, target_text, target_env)),
+            None => None
+          }
+        } else {
+          None
         }
       } else {
         None
       }
-    } else {
-      None
-    }
-    match reused_env {
-      Some((input_key, _target_fingerprint, target_text, target_env)) => {
-        // Preserve the ordinary conservative fingerprint path for every later
-        // consumer. Commit this target first, then its exact bound witness, and
-        // only then the alias, so torn publication always fails closed.
-        Fs::write_file(persistent_type_env_cache_path(fingerprint), target_text)
-        publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
-        write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
-        let next_env_cache = upsert_env_cache(coordinated_env_cache, path, target_env)
-        let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
-        (fingerprint, next_db, next_env_cache, dep_source_cache, parse_count)
-      },
-      None => {
-        let job = ModuleJob::{
-          path: path,
-          source: source,
-          deps: deps,
-          dep_fps: dep_fps,
-          dep_envs: projected_dep_envs
+      match reused_env {
+        Some((input_key, _target_fingerprint, target_text, target_env)) => {
+          // Preserve the ordinary conservative fingerprint path for every later
+          // consumer. Commit this target first, then its exact bound witness, and
+          // only then the alias, so torn publication always fails closed.
+          Fs::write_file(persistent_type_env_cache_path(fingerprint), target_text)
+          publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
+          write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
+          let next_env_cache = upsert_env_cache(coordinated_env_cache, path, target_env)
+          let next_db = ripple_record_eval(rdb, path, fingerprint, deps)
+          (fingerprint, next_db, next_env_cache, dep_source_cache, parse_count)
+        },
+        None => {
+          let job = ModuleJob::{
+            path: path,
+            source: source,
+            deps: deps,
+            dep_fps: dep_fps,
+            dep_envs: projected_dep_envs
+          }
+          let outcome = check_module(job)
+          commit_module_outcome(rdb, coordinated_env_cache, dep_source_cache, parse_count + 1, job, outcome)
         }
-        let outcome = check_module(job)
-        commit_module_outcome(rdb, coordinated_env_cache, dep_source_cache, parse_count + 1, job, outcome)
       }
     }
   }
@@ -3475,7 +3524,10 @@ fn plan_import_graph_fs(rdb: RippleDb, dep_source_cache: Array[(String, String)]
       Some(source) => {
         let reusable = if dep_source_cache_is_current(dep_source_cache, path, source) {
           match ripple_get_fingerprint(rdb, path) {
-            Some(_) => true,
+            Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
+              Some(_) => true,
+              None => false
+            },
             None => false
           }
         } else {
@@ -3484,7 +3536,7 @@ fn plan_import_graph_fs(rdb: RippleDb, dep_source_cache: Array[(String, String)]
         if reusable {
           ()
         } else {
-          match load_persistent_leaf_fingerprint(path, source) {
+          match valid_persistent_leaf_fingerprint(path, source) {
             Some(leaf_fingerprint) => Array::push(leaf_fps, (path, leaf_fingerprint)),
             None => {
               // Codex review P2: resolving a module's imports PARSES it, so a
@@ -3566,18 +3618,22 @@ fn plan_deps_of(plan_edges: Array[(String, Array[String])], path: String) -> Opt
 /// The leaf-fingerprint arm: a module whose persistent leaf cache is valid is
 /// recorded with no deps at all and needs no checking.
 fn commit_leaf_fingerprint_fs(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String, source: String, leaf_fingerprint: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
-  if incremental_interface_trace_enabled() {
-    match load_persistent_type_env(leaf_fingerprint) {
-      Some(cached_env) => incremental_trace_observe_checked_env(path, source, cached_env),
-      None => throw(String::concat("incremental trace observation: unreadable reused leaf environment for ", path))
-    }
-  } else {
-    ()
+  // The plan read this cache earlier, but recheck at the accepting edge: a
+  // stale/malformed leaf pointer must cold-check rather than become authority.
+  match valid_persistent_type_env(leaf_fingerprint) {
+    Some(cached_env) => {
+      if incremental_interface_trace_enabled() {
+        incremental_trace_observe_checked_env(path, source, cached_env)
+      } else {
+        ()
+      }
+      write_persistent_dep_list_if_missing(path, source, empty_stack())
+      let next_dep_source_cache = upsert_string_pair(dep_source_cache, path, source)
+      let next_db = ripple_record_eval(rdb, path, leaf_fingerprint, empty_stack())
+      (leaf_fingerprint, next_db, env_cache, next_dep_source_cache, parse_count)
+    },
+    None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(source, empty_dep_fps()))
   }
-  write_persistent_dep_list_if_missing(path, source, empty_stack())
-  let next_dep_source_cache = upsert_string_pair(dep_source_cache, path, source)
-  let next_db = ripple_record_eval(rdb, path, leaf_fingerprint, empty_stack())
-  (leaf_fingerprint, next_db, env_cache, next_dep_source_cache, parse_count)
 }
 /// One module's step, once its dependency list is known and every dependency
 /// already has a fingerprint. Folds the dependency fingerprints in
@@ -3603,7 +3659,10 @@ fn commit_with_deps_fs(fps: Array[(String, String)], rdb: RippleDb, env_cache: A
   match ripple_get_fingerprint(rdb, path) {
     Some(cached_fp) =>
     if cached_fp == fingerprint {
-      (fingerprint, rdb, env_cache, dep_source_cache, parse_count)
+      match valid_persistent_type_env(fingerprint) {
+        Some(_) => (fingerprint, rdb, env_cache, dep_source_cache, parse_count),
+        None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, deps, dep_fps, fingerprint)
+      }
     } else {
       finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, deps, dep_fps, fingerprint)
     },
@@ -3636,7 +3695,13 @@ fn step_module_fs(plan_leaf_fps: Array[(String, String)], plan_edges: Array[(Str
     None => (String::concat("missing:", path), rdb, env_cache, dep_source_cache, parse_count),
     Some(source) => {
       let reusable = if dep_source_cache_is_current(dep_source_cache, path, source) {
-        ripple_get_fingerprint(rdb, path)
+        match ripple_get_fingerprint(rdb, path) {
+          Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
+            Some(_) => Some(fingerprint),
+            None => None
+          },
+          None => None
+        }
       } else {
         None
       }

--- a/lib/@vibe/compiler/tests/checker_program_result_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_program_result_test.vibe
@@ -76,7 +76,7 @@ fn trait_header_params(env: TypeEnv, wanted: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => trait_header_params(rest, wanted),
     EnvTraitImplGen(_, _, _, _, rest) => trait_header_params(rest, wanted),
-    EnvTypeDefs(_, rest) => trait_header_params(rest, wanted),
+    EnvTypeDefs(_, _, rest) => trait_header_params(rest, wanted),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => trait_header_params(rest, wanted)
   }

--- a/lib/@vibe/compiler/tests/checker_program_result_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_program_result_test.vibe
@@ -76,6 +76,7 @@ fn trait_header_params(env: TypeEnv, wanted: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => trait_header_params(rest, wanted),
     EnvTraitImplGen(_, _, _, _, rest) => trait_header_params(rest, wanted),
+    EnvTypeDefs(_, rest) => trait_header_params(rest, wanted),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => trait_header_params(rest, wanted)
   }

--- a/lib/@vibe/compiler/tests/library_smoke_test.vibe
+++ b/lib/@vibe/compiler/tests/library_smoke_test.vibe
@@ -1,9 +1,5 @@
 //# Imports
 
-import @vibe/prelude {
-  Result
-}
-
 // #741: sha1 moved to the @vibe/core contract package (#738); consume it
 // through the contract boundary like any other package user. #766: maps
 // (get_or/has_key) joined the same contract — collection/ folded into core/.

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Type, TypeEnv, TypeExpr, env_lookup, trait_method_sig, trait_supers, types_equal
+  Type, TypeDef, TypeEnv, TypeExpr, env_lookup, env_type_defs, trait_method_sig, trait_supers, types_equal
 }
 
 import @vibe/compiler/runtime {
@@ -110,6 +110,7 @@ fn retained_trait_header_params(env: TypeEnv, name: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => retained_trait_header_params(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => retained_trait_header_params(rest, name),
+    EnvTypeDefs(_, rest) => retained_trait_header_params(rest, name),
     EnvFlat(_) => [
     ],
     EnvCached(_, _, rest) => retained_trait_header_params(rest, name)
@@ -127,6 +128,7 @@ fn retained_trait_method_gens(env: TypeEnv, name: String) -> Array[(String, Arra
     },
     EnvTraitImpl(_, _, rest) => retained_trait_method_gens(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => retained_trait_method_gens(rest, name),
+    EnvTypeDefs(_, rest) => retained_trait_method_gens(rest, name),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => retained_trait_method_gens(rest, name)
   }
@@ -144,6 +146,7 @@ fn retained_generic_impl_bounds(env: TypeEnv, name: String) -> Array[(String, Ar
     } else {
       retained_generic_impl_bounds(rest, name)
     },
+    EnvTypeDefs(_, rest) => retained_generic_impl_bounds(rest, name),
     EnvFlat(_) => [
     ],
     EnvCached(_, _, rest) => retained_generic_impl_bounds(rest, name)
@@ -163,10 +166,10 @@ fn malformed_rejected(text: String) -> Bool {
 
 //# Tests
 
-test "persistent TypeEnv v3 round-trips every variant and trait payload" {
+test "persistent module interface v4 round-trips every variant and trait payload" {
   let env = codec_fixture()
   let encoded = persistent_type_env_cache_text(env)
-  assert(String::starts_with(encoded, "version\t3\nenv\t"))
+  assert(String::starts_with(encoded, "version\t4\nenv\t"))
   // TDRE4 hardening binds this exact canonical text externally; it does not
   // change or wrap the production TypeEnv-v3 transport envelope itself.
   assert(String::index_of(encoded, "TDRE4") < 0)
@@ -221,7 +224,52 @@ test "persistent TypeEnv v3 round-trips every variant and trait payload" {
   }
 }
 
-test "persistent TypeEnv v3 rebuilds untrusted cached lookup indexes" {
+test "persistent module interface v4 round-trips enum struct and alias authority" {
+  let defs = [
+    TDEnum("Choice", [
+      "T"
+    ], [
+      ("Pick", [
+        CtNamed("T", [
+        ])
+      ])
+    ]),
+    TDStruct("Box", [
+      ("value", CtNamed("T", [
+      ]))
+    ], [
+    ], [
+      "T"
+    ]),
+    TDAlias("ChoiceBox", [
+    ], CtStruct("Box"))
+  ]
+  let env = EnvTypeDefs(defs, EnvBind("Choice", CtEnum("Choice"), EnvEmpty))
+  match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
+    Some(decoded) => {
+      let decoded_defs = env_type_defs(decoded)
+      assert(Array::length(decoded_defs) == 3)
+      match (Array::get(decoded_defs, 0), Array::get(decoded_defs, 1), Array::get(decoded_defs, 2)) {
+        (TDEnum(name, params, variants), TDStruct(struct_name, fields, _, struct_params), TDAlias(alias, _, CtStruct(target))) => {
+          assert(name == "Choice")
+          assert(Array::get(params, 0) == "T")
+          let (variant, payload) = Array::get(variants, 0)
+          assert(variant == "Pick")
+          assert(Array::length(payload) == 1)
+          assert(struct_name == "Box")
+          assert(Array::get(struct_params, 0) == "T")
+          assert(Array::get(fields, 0).0 == "value")
+          assert(alias == "ChoiceBox")
+          assert(target == "Box")
+        },
+        _ => assert(false)
+      }
+    },
+    None => assert(false)
+  }
+}
+
+test "persistent module interface v4 rebuilds untrusted cached lookup indexes" {
   let corrupt = EnvCached([
     "shadow",
     "shadow",
@@ -253,12 +301,14 @@ test "persistent TypeEnv v3 rebuilds untrusted cached lookup indexes" {
   }
 }
 
-test "persistent TypeEnv v3 rejects old, truncated, and malformed envelopes" {
+test "persistent module interface v4 rejects old, truncated, and malformed envelopes" {
   assert(malformed_rejected("version\t1\nbind\tvalue\tI\n"))
   assert(malformed_rejected("version\t2\nenv\t1:0\n"))
-  assert(malformed_rejected("version\t3\nenv\t"))
-  assert(malformed_rejected("version\t3\nenv\t1:Z\n"))
-  assert(malformed_rejected("version\t3\nenv\t2:00\n"))
-  assert(malformed_rejected("version\t3\nenv\t4:B0:0\n"))
-  assert(malformed_rejected("version\t3\nenv\t1:0\ntrailing"))
+  // Bare v3 was a value/trait-only TypeEnv, never an empty declaration interface.
+  assert(malformed_rejected("version\t3\nenv\t1:0\n"))
+  assert(malformed_rejected("version\t4\nenv\t"))
+  assert(malformed_rejected("version\t4\nenv\t1:Z\n"))
+  assert(malformed_rejected("version\t4\nenv\t2:00\n"))
+  assert(malformed_rejected("version\t4\nenv\t4:B0:0\n"))
+  assert(malformed_rejected("version\t4\nenv\t1:0\ntrailing"))
 }

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -269,6 +269,41 @@ test "persistent module interface v4 round-trips enum struct and alias authority
   }
 }
 
+test "legacy enum carrier bytes cannot alter v4 typedef authority" {
+  let declared = TDEnum("Choice", [
+  ], [
+    ("Pick", [
+      CtInt
+    ])
+  ])
+  // This was the retired `Choice::__variants__` value carrier. It is valid
+  // TypeEnv data but EnvTypeDefs must remain the only declaration authority.
+  let env = EnvTypeDefs([
+    declared
+  ], EnvBind("Choice::__variants__", CtNamed("__variants__", [
+    CtNamed("Corrupt", [
+      CtString
+    ])
+  ]), EnvEmpty))
+  match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
+    Some(decoded) => {
+      let defs = env_type_defs(decoded)
+      assert(Array::length(defs) == 1)
+      match Array::get(defs, 0) {
+        TDEnum(name, params, variants) => {
+          assert(name == "Choice")
+          assert(Array::length(params) == 0)
+          let (variant, fields) = Array::get(variants, 0)
+          assert(variant == "Pick")
+          assert(Array::get(fields, 0) == CtInt)
+        },
+        _ => assert(false)
+      }
+    },
+    None => assert(false)
+  }
+}
+
 test "persistent module interface v4 rebuilds untrusted cached lookup indexes" {
   let corrupt = EnvCached([
     "shadow",

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Type, TypeDef, TypeEnv, TypeExpr, env_lookup, env_type_defs, trait_method_sig, trait_supers, types_equal
+  Type, TypeDef, TypeEnv, TypeExpr, env_lookup, env_selectable_type_defs, env_type_defs, trait_method_sig, trait_supers, types_equal
 }
 
 import @vibe/compiler/runtime {
@@ -110,7 +110,7 @@ fn retained_trait_header_params(env: TypeEnv, name: String) -> Array[String] {
     },
     EnvTraitImpl(_, _, rest) => retained_trait_header_params(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => retained_trait_header_params(rest, name),
-    EnvTypeDefs(_, rest) => retained_trait_header_params(rest, name),
+    EnvTypeDefs(_, _, rest) => retained_trait_header_params(rest, name),
     EnvFlat(_) => [
     ],
     EnvCached(_, _, rest) => retained_trait_header_params(rest, name)
@@ -128,7 +128,7 @@ fn retained_trait_method_gens(env: TypeEnv, name: String) -> Array[(String, Arra
     },
     EnvTraitImpl(_, _, rest) => retained_trait_method_gens(rest, name),
     EnvTraitImplGen(_, _, _, _, rest) => retained_trait_method_gens(rest, name),
-    EnvTypeDefs(_, rest) => retained_trait_method_gens(rest, name),
+    EnvTypeDefs(_, _, rest) => retained_trait_method_gens(rest, name),
     EnvFlat(_) => array_empty(),
     EnvCached(_, _, rest) => retained_trait_method_gens(rest, name)
   }
@@ -146,7 +146,7 @@ fn retained_generic_impl_bounds(env: TypeEnv, name: String) -> Array[(String, Ar
     } else {
       retained_generic_impl_bounds(rest, name)
     },
-    EnvTypeDefs(_, rest) => retained_generic_impl_bounds(rest, name),
+    EnvTypeDefs(_, _, rest) => retained_generic_impl_bounds(rest, name),
     EnvFlat(_) => [
     ],
     EnvCached(_, _, rest) => retained_generic_impl_bounds(rest, name)
@@ -166,12 +166,12 @@ fn malformed_rejected(text: String) -> Bool {
 
 //# Tests
 
-test "persistent module interface v4 round-trips every variant and trait payload" {
+test "persistent module interface v5 round-trips every variant and trait payload" {
   let env = codec_fixture()
   let encoded = persistent_type_env_cache_text(env)
-  assert(String::starts_with(encoded, "version\t4\nenv\t"))
+  assert(String::starts_with(encoded, "version\t5\nenv\t"))
   // TDRE4 hardening binds this exact canonical text externally; it does not
-  // change or wrap the production TypeEnv-v3 transport envelope itself.
+  // change or wrap the production TypeEnv-v4 transport envelope itself.
   assert(String::index_of(encoded, "TDRE4") < 0)
   match parse_persistent_type_env(encoded) {
     Some(decoded) => {
@@ -224,7 +224,7 @@ test "persistent module interface v4 round-trips every variant and trait payload
   }
 }
 
-test "persistent module interface v4 round-trips enum struct and alias authority" {
+test "persistent module interface v5 round-trips enum struct and alias authority" {
   let defs = [
     TDEnum("Choice", [
       "T"
@@ -244,7 +244,11 @@ test "persistent module interface v4 round-trips enum struct and alias authority
     TDAlias("ChoiceBox", [
     ], CtStruct("Box"))
   ]
-  let env = EnvTypeDefs(defs, EnvBind("Choice", CtEnum("Choice"), EnvEmpty))
+  let env = EnvTypeDefs(defs, [
+    "Choice",
+    "Box",
+    "ChoiceBox"
+  ], EnvBind("Choice", CtEnum("Choice"), EnvEmpty))
   match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
     Some(decoded) => {
       let decoded_defs = env_type_defs(decoded)
@@ -269,7 +273,41 @@ test "persistent module interface v4 round-trips enum struct and alias authority
   }
 }
 
-test "legacy enum carrier bytes cannot alter v4 typedef authority" {
+test "persistent module interface v5 round-trips effect and effectset authority" {
+  let env = EnvTypeDefs([
+    TDEffect("Audit", [
+      ("Emit", [
+        CtString
+      ], CtUnit)
+    ], [
+    ]),
+    TDEffectSet("Audits", [
+      "Audit"
+    ])
+  ], [
+    "Audits"
+  ], EnvEmpty)
+  match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
+    Some(decoded) => {
+      let defs = env_type_defs(decoded)
+      assert(Array::length(defs) == 2)
+      assert(Array::length(env_selectable_type_defs(decoded)) == 1)
+      assert(Array::get(env_selectable_type_defs(decoded), 0) == "Audits")
+      match (Array::get(defs, 0), Array::get(defs, 1)) {
+        (TDEffect(effect_name, ops, _), TDEffectSet(set_name, members)) => {
+          assert(effect_name == "Audit")
+          assert(Array::get(ops, 0).0 == "Emit")
+          assert(set_name == "Audits")
+          assert(Array::get(members, 0) == "Audit")
+        },
+        _ => assert(false)
+      }
+    },
+    None => assert(false)
+  }
+}
+
+test "legacy enum carrier bytes cannot alter v5 typedef authority" {
   let declared = TDEnum("Choice", [
   ], [
     ("Pick", [
@@ -280,6 +318,8 @@ test "legacy enum carrier bytes cannot alter v4 typedef authority" {
   // TypeEnv data but EnvTypeDefs must remain the only declaration authority.
   let env = EnvTypeDefs([
     declared
+  ], [
+    "Choice"
   ], EnvBind("Choice::__variants__", CtNamed("__variants__", [
     CtNamed("Corrupt", [
       CtString
@@ -304,7 +344,7 @@ test "legacy enum carrier bytes cannot alter v4 typedef authority" {
   }
 }
 
-test "persistent module interface v4 rebuilds untrusted cached lookup indexes" {
+test "persistent module interface v5 rebuilds untrusted cached lookup indexes" {
   let corrupt = EnvCached([
     "shadow",
     "shadow",
@@ -336,14 +376,15 @@ test "persistent module interface v4 rebuilds untrusted cached lookup indexes" {
   }
 }
 
-test "persistent module interface v4 rejects old, truncated, and malformed envelopes" {
+test "persistent module interface v5 rejects old, truncated, and malformed envelopes" {
   assert(malformed_rejected("version\t1\nbind\tvalue\tI\n"))
   assert(malformed_rejected("version\t2\nenv\t1:0\n"))
   // Bare v3 was a value/trait-only TypeEnv, never an empty declaration interface.
   assert(malformed_rejected("version\t3\nenv\t1:0\n"))
-  assert(malformed_rejected("version\t4\nenv\t"))
-  assert(malformed_rejected("version\t4\nenv\t1:Z\n"))
-  assert(malformed_rejected("version\t4\nenv\t2:00\n"))
-  assert(malformed_rejected("version\t4\nenv\t4:B0:0\n"))
-  assert(malformed_rejected("version\t4\nenv\t1:0\ntrailing"))
+  assert(malformed_rejected("version\t4\nenv\t1:0\n"))
+  assert(malformed_rejected("version\t5\nenv\t"))
+  assert(malformed_rejected("version\t5\nenv\t1:Z\n"))
+  assert(malformed_rejected("version\t5\nenv\t2:00\n"))
+  assert(malformed_rejected("version\t5\nenv\t4:B0:0\n"))
+  assert(malformed_rejected("version\t5\nenv\t1:0\ntrailing"))
 }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -178,7 +178,7 @@ test "db_typecheck_fs: re-exported enum type imports constructors" {
   let main_path = "/tmp/vibe_compiler_reexport_enum_ctor_fs_main.vibe"
   let ast_src = "export enum TypeExpr { TyName(String); TyTuple(Array[TypeExpr]) }"
   let index_src = "export ./vibe_compiler_reexport_enum_ctor_fs_ast.vibe { TypeExpr }"
-  let main_src = "import ./vibe_compiler_reexport_enum_ctor_fs_index.vibe { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
+  let main_src = "import ./vibe_compiler_reexport_enum_ctor_fs_index.vibe { TypeExpr }\nexport { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
   Fs::write_bytes(ast_path, string_to_bytes(ast_src))
   Fs::write_bytes(index_path, string_to_bytes(index_src))
   Fs::write_bytes(main_path, string_to_bytes(main_src))
@@ -213,7 +213,7 @@ test "db_typecheck_fs: extensionless directory re-export imports enum constructo
   let main_path = String::concat(base_dir, "/main.vibe")
   let ast_src = "export enum TypeExpr { TyName(String); TyTuple(Array[TypeExpr]) }"
   let index_src = "export ./ast.vibe { TypeExpr }"
-  let main_src = "import ./core { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
+  let main_src = "import ./core { TypeExpr }\nexport { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
   Fs::mkdir_p(core_dir)
   Fs::write_bytes(ast_path, string_to_bytes(ast_src))
   Fs::write_bytes(index_path, string_to_bytes(index_src))
@@ -660,6 +660,23 @@ fn export_surface_error(paths: Array[String], entry: String) -> String with Fs {
   }
 }
 
+fn typedef_surface_pair_error(dir: String, dep_src: String, main_src: String) -> String with Fs {
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (dep_path, dep_fp)
+  ]))
+  export_surface_error([
+    dep_path,
+    main_path
+  ], main_path)
+}
+
 test "db_typecheck_fs: importing a private (non-export) name is reported (#1533)" {
   let dir = "/tmp/vibe_compiler_export_surface_private"
   let dep_path = String::concat(dir, "/dep.vibe")
@@ -785,4 +802,55 @@ test "db_typecheck_fs: a re-exported name IS on the middleman's surface (#1533 c
     main_path
   ], main_path)
   assert(err == "")
+}
+
+test "db_typecheck_fs: private struct enum and alias declarations are not importable" {
+  let struct_err = typedef_surface_pair_error("/tmp/vibe_private_struct_authority", "struct Secret { value: Int }\n", "import ./dep.vibe { Secret }\nexport let value = Secret(1)\n")
+  assert(String::contains(struct_err, "imported name 'Secret' is not exported by"))
+  let enum_err = typedef_surface_pair_error("/tmp/vibe_private_enum_authority", "enum Secret { Hidden(Int) }\n", "import ./dep.vibe { Secret }\nexport let value = Hidden(1)\n")
+  assert(String::contains(enum_err, "imported name 'Secret' is not exported by"))
+  let alias_err = typedef_surface_pair_error("/tmp/vibe_private_alias_authority", "type Secret = Int\n", "import ./dep.vibe { Secret }\nexport let value: Secret = 1\n")
+  assert(String::contains(alias_err, "imported name 'Secret' is not exported by"))
+}
+
+test "db_typecheck_fs: public struct enum and alias declarations remain importable" {
+  let err = typedef_surface_pair_error("/tmp/vibe_public_typedef_authority", "export struct PublicStruct { value: Int }\nexport enum PublicEnum { PublicCase(Int) }\nexport type PublicAlias = Int\n", "import ./dep.vibe { PublicStruct, PublicEnum, PublicAlias }\nexport let s = PublicStruct(1)\nexport let e = PublicCase(1)\nexport let a: PublicAlias = 1\n")
+  assert(err == "")
+}
+
+test "db_typecheck_fs: imported generic alias enum and struct aliases retain formals" {
+  let err = typedef_surface_pair_error("/tmp/vibe_generic_typedef_alias_authority", "export type Wrap[T] = Array[T]\nexport enum Choice[T] { Pick(T) }\nexport struct Box[T] { value: T }\n", "import ./dep.vibe { Wrap as LocalWrap, Choice as LocalChoice, Box as LocalBox }\nexport let xs: LocalWrap[Int] = [1]\nexport let picked: LocalChoice[Int] = Pick(1)\nexport fn unbox(value: LocalBox[String]) -> String { value.value }\n")
+  assert(err == "")
+}
+
+test "db_typecheck_fs: a local typedef shadows imported declaration authority" {
+  let err = typedef_surface_pair_error("/tmp/vibe_local_typedef_shadow", "export type Label = Int\n", "import ./dep.vibe { Label }\ntype Label = String\nexport fn use_label(value: Label) -> String { value }\n")
+  assert(err == "")
+}
+
+test "db_typecheck_fs: selected effects and effectsets reject until authority transport exists" {
+  let effect_err = typedef_surface_pair_error("/tmp/vibe_selected_effect_rejected", "export effect Audit { Emit(String) -> Unit }\n", "import ./dep.vibe { Audit }\nexport let value = 1\n")
+  assert(String::contains(effect_err, "imported name 'Audit' is not exported by"))
+  let set_err = typedef_surface_pair_error("/tmp/vibe_selected_effectset_rejected", "effect Audit { Emit(String) -> Unit }\nexport effectset Audits = { Audit }\n", "import ./dep.vibe { Audits }\nexport let value = 1\n")
+  assert(String::contains(set_err, "imported name 'Audits' is not exported by"))
+}
+
+test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck as v4" {
+  let dir = "/tmp/vibe_v4_cache_cold_recheck"
+  let path = String::concat(dir, "/main.vibe")
+  let source = "export let value = 1\n"
+  let fingerprint = build_test_fingerprint(source, array_empty())
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(path, string_to_bytes(source))
+  remove_typecheck_fs_cache(path, source, fingerprint)
+  let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
+  let env_path = persistent_type_env_cache_path(fingerprint)
+  let leaf_path = persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(source))
+  Fs::write_file(env_path, "version\t3\nenv\t1:0\n")
+  let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
+  assert(String::starts_with(Fs::read_file(env_path), "version\t4\nenv\t"))
+  Fs::write_file(env_path, "version\t4\nenv\t1:Z\n")
+  Fs::write_file(leaf_path, "version\t1\nnot-a-fingerprint\n")
+  let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
+  assert(String::starts_with(Fs::read_file(env_path), "version\t4\nenv\t"))
 }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -17,6 +17,10 @@ import @vibe/compiler/runtime {
   projected_import_env_for_test, set_collect_module_diagnostics, set_dep_order_seed
 }
 
+import @vibe/compiler/loader {
+  ingest_source_text_fs
+}
+
 import @vibe/compiler/cache {
   compact_string_fingerprint,
   persistent_dep_list_cache_path,
@@ -127,7 +131,7 @@ fn typecheck_db_pair_error(dep_src: String, main_src: String) -> String with Exc
 
 test "cross-module type propagation" {
   let db0 = db_new()
-  let db1 = db_set_source(db_set_source(db0, "a.vibe", "import ./b.vibe { y }\nlet x = y"), "b.vibe", "export let y = 42")
+  let db1 = db_set_source(db_set_source(db0, "a.vibe", "import ./b.vibe { y }\nexport let x = y"), "b.vibe", "export let y = 42")
   let db2 = db_typecheck(db1, "a.vibe")
   let b_y_is_int = match db_check_env(db2, "b.vibe") {
     Some(e) => match env_lookup(e, "y") {
@@ -137,14 +141,14 @@ test "cross-module type propagation" {
     None => false
   }
   assert(b_y_is_int)
-  let a_y_is_int = match db_check_env(db2, "a.vibe") {
+  let a_y_is_published = match db_check_env(db2, "a.vibe") {
     Some(e) => match env_lookup(e, "y") {
-      Some(CtInt) => true,
-      _ => false
+      Some(_) => true,
+      None => false
     },
     None => false
   }
-  assert(a_y_is_int)
+  assert(!a_y_is_published)
   let a_x_is_int = match db_check_env(db2, "a.vibe") {
     Some(e) => match env_lookup(e, "x") {
       Some(CtInt) => true,
@@ -159,7 +163,7 @@ test "cross-module re-export propagates enum constructors" {
   let db0 = db_new()
   let ast_src = "export enum TypeExpr { TyName(String); TyTuple(Array[TypeExpr]) }"
   let index_src = "export ./ast.vibe { TypeExpr }"
-  let main_src = "import ./index.vibe { TypeExpr }\nlet ann: TypeExpr = TyTuple([TyName(\"Int\")])"
+  let main_src = "import ./index.vibe { TypeExpr }\nexport let ann: TypeExpr = TyTuple([TyName(\"Int\")])"
   let db1 = db_set_source(db_set_source(db_set_source(db0, "main.vibe", main_src), "index.vibe", index_src), "ast.vibe", ast_src)
   let db2 = db_typecheck(db1, "main.vibe")
   let has_ann = match db_check_env(db2, "main.vibe") {
@@ -179,7 +183,7 @@ test "cross-module re-export propagates enum constructors" {
     },
     None => false
   }
-  assert(has_ctor)
+  assert(!has_ctor)
 }
 
 test "db_typecheck_fs: re-exported enum type imports constructors" {
@@ -885,4 +889,71 @@ test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck 
   Fs::write_file(leaf_path, "version\t1\nnot-a-fingerprint\n")
   let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
   assert(String::starts_with(Fs::read_file(env_path), "version\t5\nenv\t"))
+}
+
+test "db_typecheck: an imported effect does not leak through a non-re-exporting module (#1549)" {
+  let err = handle {
+    let db0 = db_new()
+    let db1 = db_set_source(db_set_source(db_set_source(db0, "mem/a.vibe", "export effect Audit { Emit(String) -> Unit }\n"), "mem/b.vibe", "import ./a.vibe { Audit }\nexport let marker = 1\n"), "mem/c.vibe", "import ./b.vibe { Audit }\nexport let marker = 1\n")
+    let _ = db_typecheck(db1, "mem/c.vibe")
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(String::contains(err, "imported name 'Audit' is not exported by"))
+  assert(String::contains(err, "./b.vibe"))
+}
+
+test "db_typecheck: an explicit effect re-export remains importable (#1549)" {
+  let err = handle {
+    let db0 = db_new()
+    let db1 = db_set_source(db_set_source(db_set_source(db0, "mem/a.vibe", "export effect Audit { Emit(String) -> Unit }\n"), "mem/b.vibe", "export ./a.vibe { Audit }\n"), "mem/c.vibe", "import ./b.vibe { Audit }\nexport fn write() -> Unit with Audit { perform Audit::Emit(\"ok\") }\n")
+    let _ = db_typecheck(db1, "mem/c.vibe")
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(err == "")
+}
+
+test "db_typecheck: empty local dependencies cannot grant ambient authority (#1549)" {
+  let db0 = db_new()
+  let random_err = handle {
+    let db1 = db_set_source(db_set_source(db0, "mem/empty.vibe", "export let marker = 1\n"), "mem/main.vibe", "import ./empty.vibe { Random, Fs }\nexport let marker = 1\n")
+    let _ = db_typecheck(db1, "mem/main.vibe")
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  let fs_err = handle {
+    let db1 = db_set_source(db_set_source(db_new(), "mem/empty.vibe", "export let marker = 1\n"), "mem/main.vibe", "import ./empty.vibe { Fs }\nexport let marker = 1\n")
+    let _ = db_typecheck(db1, "mem/main.vibe")
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(String::contains(random_err, "imported name 'Random' is not exported by"))
+  assert(String::contains(fs_err, "imported name 'Fs' is not exported by"))
+}
+
+test "db_typecheck_fs: @vibe/fs contract explicitly grants Fs authority (#1549)" {
+  let path = "lib/@vibe/compiler/tests/type_db_package_fs_authority.vibe"
+  let source = "import @vibe/fs { Fs }\nexport fn write(path: String) -> Unit with Fs { perform Fs::WriteFile(path, \"ok\") }\n"
+  let contract_path = "lib/@vibe/fs/index.vpkg"
+  let contract_source = ingest_source_text_fs(contract_path, Fs::read_file(contract_path))
+  let fs_path = "lib/@vibe/fs/fs.vibe"
+  let effect_path = "lib/@vibe/fs/fs_effect.vibe"
+  let aliases_path = "lib/@vibe/fs/fs_aliases.vibe"
+  let db0 = db_set_source(db_new(), contract_path, contract_source)
+  let db1 = db_set_source(db0, fs_path, ingest_source_text_fs(fs_path, Fs::read_file(fs_path)))
+  let db2 = db_set_source(db1, effect_path, ingest_source_text_fs(effect_path, Fs::read_file(effect_path)))
+  let db3 = db_set_source(db2, aliases_path, ingest_source_text_fs(aliases_path, Fs::read_file(aliases_path)))
+  let err = handle {
+    let db = db_set_source(db3, path, source)
+    let _ = db_typecheck_fs(db, path)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(err == "")
 }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -81,7 +81,7 @@ fn retained_trait_node_tags(env: TypeEnv) -> String {
     EnvTraitDef(name, _, _, _, rest, _, _) => String::concat(String::concat("def:", name), String::concat(";", retained_trait_node_tags(rest))),
     EnvTraitImpl(name, _, rest) => String::concat(String::concat("impl:", name), String::concat(";", retained_trait_node_tags(rest))),
     EnvTraitImplGen(name, _, _, _, rest) => String::concat(String::concat("gen:", name), String::concat(";", retained_trait_node_tags(rest))),
-    EnvTypeDefs(_, rest) => retained_trait_node_tags(rest),
+    EnvTypeDefs(_, _, rest) => retained_trait_node_tags(rest),
     EnvFlat(_) => "",
     EnvCached(_, _, rest) => retained_trait_node_tags(rest)
   }
@@ -107,6 +107,16 @@ fn typecheck_fs_pair_error(dep_path: String, dep_src: String, main_path: String,
   handle {
     let db = db_set_source(db_set_source(db_new(), dep_path, dep_src), main_path, main_src)
     let _ = db_typecheck_fs(db, main_path)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+fn typecheck_db_pair_error(dep_src: String, main_src: String) -> String with Exception {
+  handle {
+    let db = db_set_source(db_set_source(db_new(), "mem/dep.vibe", dep_src), "mem/main.vibe", main_src)
+    let _ = db_typecheck(db, "mem/main.vibe")
     ""
   } with Exception {
     Throw(msg) => msg
@@ -828,14 +838,36 @@ test "db_typecheck_fs: a local typedef shadows imported declaration authority" {
   assert(err == "")
 }
 
-test "db_typecheck_fs: selected effects and effectsets reject until authority transport exists" {
-  let effect_err = typedef_surface_pair_error("/tmp/vibe_selected_effect_rejected", "export effect Audit { Emit(String) -> Unit }\n", "import ./dep.vibe { Audit }\nexport let value = 1\n")
-  assert(String::contains(effect_err, "imported name 'Audit' is not exported by"))
-  let set_err = typedef_surface_pair_error("/tmp/vibe_selected_effectset_rejected", "effect Audit { Emit(String) -> Unit }\nexport effectset Audits = { Audit }\n", "import ./dep.vibe { Audits }\nexport let value = 1\n")
-  assert(String::contains(set_err, "imported name 'Audits' is not exported by"))
+test "db_typecheck_fs: selected effects and effectsets retain operation authority" {
+  let effect_err = typedef_surface_pair_error("/tmp/vibe_selected_effect_authority", "export effect Audit { Emit(String) -> Unit }\n", "import ./dep.vibe { Audit }\nexport fn write() -> Unit with Audit { perform Audit::Emit(\"x\") }\n")
+  assert(effect_err == "")
+  // Selecting a public effectset transports its private member as closure for
+  // the row and operation signature, without making that member selectable.
+  let set_err = typedef_surface_pair_error("/tmp/vibe_selected_effectset_authority", "effect Audit { Emit(String) -> Unit }\nexport effectset Audits = { Audit }\n", "import ./dep.vibe { Audits }\nexport fn write() -> Unit with Audits { perform Audit::Emit(\"x\") }\n")
+  assert(set_err == "")
 }
 
-test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck as v4" {
+test "db_typecheck: effect and effectset authority match the fs lane" {
+  let public_err = typecheck_db_pair_error("export effect Audit { Emit(String) -> Unit }\nexport effectset Audits = { Audit }\n", "import ./dep.vibe { Audits }\nexport fn write() -> Unit with Audits { perform Audit::Emit(\"x\") }\n")
+  assert(public_err == "")
+  let private_err = typecheck_db_pair_error("effect Secret { Emit(String) -> Unit }\n", "import ./dep.vibe { Secret }\nexport let value = 1\n")
+  assert(String::contains(private_err, "imported name 'Secret' is not exported by"))
+}
+
+test "db_typecheck_fs: private unknown effects and effectsets are not selectable" {
+  let private_effect = typedef_surface_pair_error("/tmp/vibe_private_effect_authority", "effect Secret { Emit(String) -> Unit }\n", "import ./dep.vibe { Secret }\nexport let value = 1\n")
+  assert(String::contains(private_effect, "imported name 'Secret' is not exported by"))
+  let private_set = typedef_surface_pair_error("/tmp/vibe_private_effectset_authority", "effect Audit { Emit(String) -> Unit }\neffectset Secrets = { Audit }\n", "import ./dep.vibe { Secrets }\nexport let value = 1\n")
+  assert(String::contains(private_set, "imported name 'Secrets' is not exported by"))
+  // Audit crosses this boundary only as the public Audits closure; it cannot
+  // be selected directly by a downstream package.
+  let closure_member = typedef_surface_pair_error("/tmp/vibe_private_effect_closure_authority", "effect Audit { Emit(String) -> Unit }\nexport effectset Audits = { Audit }\n", "import ./dep.vibe { Audit }\nexport let value = 1\n")
+  assert(String::contains(closure_member, "imported name 'Audit' is not exported by"))
+  let unknown = typedef_surface_pair_error("/tmp/vibe_unknown_effect_authority", "export effect Audit { Emit(String) -> Unit }\n", "import ./dep.vibe { Missing }\nexport let value = 1\n")
+  assert(String::contains(unknown, "imported name 'Missing' is not exported by"))
+}
+
+test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck as v5" {
   let dir = "/tmp/vibe_v4_cache_cold_recheck"
   let path = String::concat(dir, "/main.vibe")
   let source = "export let value = 1\n"
@@ -848,9 +880,9 @@ test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck 
   let leaf_path = persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(source))
   Fs::write_file(env_path, "version\t3\nenv\t1:0\n")
   let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
-  assert(String::starts_with(Fs::read_file(env_path), "version\t4\nenv\t"))
-  Fs::write_file(env_path, "version\t4\nenv\t1:Z\n")
+  assert(String::starts_with(Fs::read_file(env_path), "version\t5\nenv\t"))
+  Fs::write_file(env_path, "version\t5\nenv\t1:Z\n")
   Fs::write_file(leaf_path, "version\t1\nnot-a-fingerprint\n")
   let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
-  assert(String::starts_with(Fs::read_file(env_path), "version\t4\nenv\t"))
+  assert(String::starts_with(Fs::read_file(env_path), "version\t5\nenv\t"))
 }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -81,6 +81,7 @@ fn retained_trait_node_tags(env: TypeEnv) -> String {
     EnvTraitDef(name, _, _, _, rest, _, _) => String::concat(String::concat("def:", name), String::concat(";", retained_trait_node_tags(rest))),
     EnvTraitImpl(name, _, rest) => String::concat(String::concat("impl:", name), String::concat(";", retained_trait_node_tags(rest))),
     EnvTraitImplGen(name, _, _, _, rest) => String::concat(String::concat("gen:", name), String::concat(";", retained_trait_node_tags(rest))),
+    EnvTypeDefs(_, rest) => retained_trait_node_tags(rest),
     EnvFlat(_) => "",
     EnvCached(_, _, rest) => retained_trait_node_tags(rest)
   }

--- a/lib/@vibe/core/sha1_test.vibe
+++ b/lib/@vibe/core/sha1_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./sha1.vibe {
-  String, sha1
+  sha1
 }
 
 //# Misc

--- a/lib/@vibe/http/http_effect_import_test.vibe
+++ b/lib/@vibe/http/http_effect_import_test.vibe
@@ -10,7 +10,10 @@ test "imported effect" {
   let fd = handle {
     perform HttpServer::Listen(8080)
   } with HttpServer {
-    Listen(_port) => resume(42)
+    Listen(_port) => resume(42);
+    Accept(_listener) => resume(0);
+    Respond(_fd, _status, _headers, _body) => resume(());
+    Close(_fd) => resume(())
   }
   assert(fd == 42)
 }

--- a/lib/@vibe/prelude/bool.vibe
+++ b/lib/@vibe/prelude/bool.vibe
@@ -1,5 +1,10 @@
 //# Functions
 
+// Compiler-provided intrinsic type explicitly published by this module.
+export {
+  Bool
+}
+
 export fn bool_nor(a: Bool, b: Bool) -> Bool {
   not(a || b)
 }

--- a/lib/@vibe/prelude/double.vibe
+++ b/lib/@vibe/prelude/double.vibe
@@ -1,5 +1,10 @@
 //# Functions
 
+// Compiler-provided intrinsic type explicitly published by this module.
+export {
+  Double
+}
+
 fn double_cube(x: Double) -> Double {
   x * x * x
 }

--- a/lib/@vibe/prelude/float.vibe
+++ b/lib/@vibe/prelude/float.vibe
@@ -1,5 +1,10 @@
 //# Functions
 
+// Compiler-provided intrinsic type explicitly published by this module.
+export {
+  Float
+}
+
 fn float_eq(a: Float, b: Float) -> Bool {
   a == b
 }

--- a/lib/@vibe/prelude/index.vpkg
+++ b/lib/@vibe/prelude/index.vpkg
@@ -141,6 +141,7 @@ type Bool
 type String
 type Option[T]
 fn String::join(parts: Array[String], separator: String) -> String
+fn Int::to_string(value: Int) -> String
 
 opaque type Eq
 opaque type Add

--- a/lib/@vibe/prelude/index.vpkg
+++ b/lib/@vibe/prelude/index.vpkg
@@ -133,6 +133,15 @@ generated_hash =
 
 // --- types
 
+// Compiler-provided declarations intentionally exposed by this package.
+type Int
+type Float
+type Double
+type Bool
+type String
+type Option[T]
+fn String::join(parts: Array[String], separator: String) -> String
+
 opaque type Eq
 opaque type Add
 opaque type Div

--- a/lib/@vibe/prelude/int.vibe
+++ b/lib/@vibe/prelude/int.vibe
@@ -2,7 +2,7 @@
 
 // Compiler-provided intrinsic signatures are explicitly published.
 export {
-  Int, Int::to_double
+  Int, Int::to_double, Int::to_string
 }
 
 fn int_pow(base: Int, exp: Int) -> Int {

--- a/lib/@vibe/prelude/int.vibe
+++ b/lib/@vibe/prelude/int.vibe
@@ -1,5 +1,10 @@
 //# Functions
 
+// Compiler-provided intrinsic signatures are explicitly published.
+export {
+  Int::to_double
+}
+
 fn int_pow(base: Int, exp: Int) -> Int {
   if exp <= 0 {
     1

--- a/lib/@vibe/prelude/int.vibe
+++ b/lib/@vibe/prelude/int.vibe
@@ -2,7 +2,7 @@
 
 // Compiler-provided intrinsic signatures are explicitly published.
 export {
-  Int::to_double
+  Int, Int::to_double
 }
 
 fn int_pow(base: Int, exp: Int) -> Int {

--- a/lib/@vibe/prelude/option.vibe
+++ b/lib/@vibe/prelude/option.vibe
@@ -1,5 +1,11 @@
 //# Types
 
+// Option is compiler-provided, but this module explicitly publishes its
+// declaration authority for sibling and package consumers.
+export {
+  Option
+}
+
 export trait Eq
 
 impl Eq for Int

--- a/lib/@vibe/prelude/string.vibe
+++ b/lib/@vibe/prelude/string.vibe
@@ -2,7 +2,7 @@
 
 // Compiler-provided intrinsic signatures are explicitly published.
 export {
-  String::unicode_length, String::utf16_length, String::utf8_length
+  String, String::unicode_length, String::utf16_length, String::utf8_length
 }
 
 fn string_drop(s: String, n: Int) -> String {

--- a/lib/@vibe/prelude/string.vibe
+++ b/lib/@vibe/prelude/string.vibe
@@ -1,5 +1,10 @@
 //# Functions
 
+// Compiler-provided intrinsic signatures are explicitly published.
+export {
+  String::unicode_length, String::utf16_length, String::utf8_length
+}
+
 fn string_drop(s: String, n: Int) -> String {
   let len = String::length(s)
   if n <= 0 {

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9860,13 +9860,9 @@ export let _start = () -> Int {
   }
 }
 '
-# 7. The DELIBERATE gap, pinned so a later change to it is a visible decision
-#    rather than a surprise: an uppercase name is not reported. A struct or a
-#    type alias is not a value binding at all (it lives in `defs`, which the
-#    dependency-environment cache does not carry), so "absent" cannot be told
-#    apart from "not exported" for uppercase names. Closing this needs the
-#    dependency's type definitions, not a tweak here.
-ui_case bogus_uppercase_not_reported ok 'import ./dep.vibe { Hue, NoSuchType }
+# 7. Declaration authority now travels with the dependency environment, so an
+#    unknown uppercase selection is rejected by the same import-surface check.
+ui_case bogus_uppercase_not_reported err 'import ./dep.vibe { Hue, NoSuchType }
 
 export let _start = () -> Int { 1 }
 '

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -278,8 +278,8 @@ function stableCachePath(cache, version, prefix, seed, suffix) {
   return join(cache, `vibe_${prefix}_${token}${suffix}`);
 }
 
-function typeEnvPath(stage2, cache, target, major = "v17") {
-  return stableCachePath(cache, `${major}|cg-${stageCodegenFingerprint(stage2)}`, "selfhost_type_env_v3", target, ".tsv");
+function typeEnvPath(stage2, cache, target, major = "v18") {
+  return stableCachePath(cache, `${major}|cg-${stageCodegenFingerprint(stage2)}`, "selfhost_type_env_v5", target, ".tsv");
 }
 
 // Derive the exact referenced TypeEnv filename from the target conservative

--- a/scripts/incremental_invalidation_oracle.mjs
+++ b/scripts/incremental_invalidation_oracle.mjs
@@ -38,7 +38,7 @@ const sourceFingerprintKind = "compact_string_fingerprint(ingested_source)";
 const implementationFingerprintKind = "compact_string_fingerprint(vibe-module-token-stream:v1 length_delimited(token_kind,source_lexeme))";
 const interfaceFingerprintKind = "compact_string_fingerprint(vibe-module-interface:v2 canonical exported surface including trait-header and method-generic binders)";
 const checkedEnvFingerprintKind = "compact_string_fingerprint(vibe-module-checked-env:v1 canonical effective TypeEnv value bindings)";
-const persistentTypeEnvTransportFingerprintKind = "compact_string_fingerprint(persistent_type_env_cache_text:v3 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)";
+const persistentTypeEnvTransportFingerprintKind = "compact_string_fingerprint(persistent_type_env_cache_text:v5 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)";
 
 const expectedCorpus = new Map([
   ["no_op", { sourceChanged: [], implementationChanged: [], invalidated: [] }],
@@ -395,7 +395,7 @@ function ownerNames(paths) {
 /// Classify the bounded library-body edit without promoting any observation to
 /// production policy. The consumer must name exactly the edited dependency in
 /// both snapshots: extra, missing, reordered, or changed edges fail closed.
-/// TypeEnv-v3 transport state is reported independently from interface-v2.
+/// TypeEnv-v5 transport state is reported independently from interface-v2.
 export function classifyPrivateDependencyEditExternallyUnchanged(before, after, dependencyName, consumerName) {
   const beforeDependency = moduleByName(before, dependencyName);
   const afterDependency = moduleByName(after, dependencyName);


### PR DESCRIPTION
Closes the declaration-authority transport gap in #1549.

- transports typedef, effect, and effectset authority through FS, TypeDb, worker/persistent env, and TDRE/cache paths
- separates declaration closure from selectable export authority
- rejects private/unknown uppercase/effect imports during checking without ambient name fallback
- preserves real package/index.vpkg effect imports and explicit re-exports
- publishes only explicit TypeDb module surfaces
- strictly cold-misses old/malformed TypeEnv envelopes and bumps transport/cache namespaces

Validation:
- focused codec/TypeDb/contract/prelude: 66 tests passed
- vibe formatter: 919 files, zero violations
- generated freshness and diff checks passed
- independent static review found no implementation blockers; prior full gate environmental xargs failure remains delegated to required CI