### PR TITLE
test(wasi): probe ratified P3 stdin ABI availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,9 +515,10 @@ jobs:
           if-no-files-found: ignore
 
   # WASI p3 guarantee (#821): vibe-built async components + the wasi:http p3
-  # serve pipeline must run on pinned wasmtime, with missing tools treated as
-  # FAILURES (no silent skip). Not yet folded into ci-required; promote once
-  # green for a week on the wasmtime 47 leg.
+  # serve pipeline, plus the optional ratified wasi:cli/stdin availability
+  # probe. Missing tools are FAILURES (no silent skip). This job is not folded
+  # into ci-required; the stdin probe records explicit host unavailability
+  # without turning that expected result into a required CI failure.
   #
   # Single leg, ratified WASI 0.3.0 (#821 cutover, done): the vendored WIT
   # (lib/@vibe/wasi/wit/p3) was refreshed to wasi:http@0.3.0, matching what
@@ -578,7 +579,7 @@ jobs:
       - name: WASI p3 guarantee gate
         env:
           VIBE_P3_GATE_REQUIRE_TOOLS: "1"
-          VIBE_P3_GATE_PHASES: "async,http"
+          VIBE_P3_GATE_PHASES: "async,http,stdin"
           VIBE_ASYNC_GATE_COMPILER: ${{ github.workspace }}/_build/ci-artifacts/stage2.wasm
           VIBE_SERVE_CLI_WASM: ${{ github.workspace }}/_build/ci-artifacts/stage2.wasm
         run: bash scripts/test_wasi_p3_guarantee_gate.sh

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1466,45 +1466,22 @@ gate lane = `test_named_hoststreams_component_gate.sh` の close lane
 かつ drain-only component に close import が無いこと + closing component に
 guest import と adapter export が両方あることを .wat で確認）。
 
-### 3.18.2 #1539 — `wasi:cli/stdin@0.3.0` の ABI/lifecycle 前提（availability のみ実測）
+### 3.18.2 #1539 — `wasi:cli/stdin@0.3.0` ABI availability probe
 
-#1539 の production stdin 接続は、`read-via-stream` が返す **readable
-`stream<u8>` と completion `future<result<_, error-code>>` の両方**を正しく
-所有・終了処理できることが前提である。ここでは lifecycle を推測で埋めないため、
-まず ratified import 名と returned stream/future shape を手書き component
-probe (`tools/wasip3_component_probe/stdin_read_via_stream/component.wat`) に固定した。
-WIT の署名は `wasi:cli/stdin@0.3.0` の
-`read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>`
-である（`error-code` は nominal enum: `io` / `illegal-byte-sequence` / `pipe`）。
-現行 `wasm-tools 1.245.1` は hand-authored imported-instance type 内の nominal
-error enum を reject するため、probe は validate 可能な one-byte error payload
-で **availability だけ**を検査する。full nominal result compatibility も未測定で
-あり、production ABI として扱わない。
+`tools/wasip3_component_probe/stdin_read_via_stream/component.wat` declares
+`wasi:cli/stdin@0.3.0` and its `read-via-stream` result type:
+`tuple<stream<u8>, future<result<_, error-code>>>`. The component imports
+`wasi:cli/types@0.3.0` and aliases its nominal `error-code` into the stdin
+instance, so the declaration does not substitute a representation-compatible
+payload for the WIT type.
 
-**測定結果（2026-08-10, この tree の pinned wasmtime source + local CLI）**:
-
-- pinned `deps/wasmtime` は 45.0.0 (`377cd917a`) で、vendored p3 WIT は
-  `wasi:cli@0.3.0-rc-2026-03-15` だけを定義している。ratified `@0.3.0` ではない。
-- local `wasmtime 42.0.1` にこの ratified-import component を
-  `run -Sp3 -Wcomponent-model-async=y` で渡すと、stdin instance を link できず
-  nonzero で終了した（`matching implementation was not found` / missing function
-  implementation）。`wasm-tools 1.245.1` の parse と `validate --features all` は
-  通るので、これは component text の不正ではなく実行 host availability の失敗である。
-
-従って **normal EOF、readable end の早期 drop、completion future を await/drop
-すべき時点、host 読み取り失敗時の `error-code` はいずれも未測定**である。特に
-completion future を「EOF で自動的に成功」「drop してよい」とは扱わない。host
-failure も再現していないため、error-code mapping や recovery は実装しない。
-
-`bash scripts/test_wasi_cli_stdin_p3_probe_gate.sh` はこの availability 結果を
-reproduce する。将来の host が `@0.3.0` を link した時点で gate は意図的に失敗し、
-normal-EOF と early-readable-drop の executable lifecycle lanes（completion result
-を明示的に await する lane を含む）を追加するまで green にしない。
-
-**#1539 constraint**: compiler / Console / runtime の stdin API を p3 stream に
-接続してはならない。再開条件は、ratified `wasi:cli/stdin@0.3.0` を実際に link
-できる wasmtime host と、上の二 lifecycle lane の実測である。RC ABI や
-`host_stream_named` の `body` probe を代用してこの条件を満たしたとは扱わない。
+`bash scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates that
+component, then accepts only wasmtime's explicit diagnostic that the ratified
+stdin instance has no matching linker implementation. Generic ABI/type
+mismatch diagnostics are failures. A successful link also fails this
+availability-only gate for review rather than being reported as a passing
+behavioral result. The optional `test-wasi-p3` aggregate includes this probe;
+its CI job remains outside `ci-required`.
 
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1476,12 +1476,15 @@ instance, so the declaration does not substitute a representation-compatible
 payload for the WIT type.
 
 `bash scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates that
-component, then accepts only wasmtime's explicit diagnostic that the ratified
-stdin instance has no matching linker implementation. Generic ABI/type
-mismatch diagnostics are failures. A successful link also fails this
-availability-only gate for review rather than being reported as a passing
-behavioral result. The optional `test-wasi-p3` aggregate includes this probe;
-its CI job remains outside `ci-required`.
+component. Its minimal `wasi:cli/run@0.2.12` command export makes wasmtime 47
+instantiate the component before it resolves the retained stdin function
+import, rather than rejecting it for lacking a command export. The gate then
+accepts only wasmtime's explicit diagnostic that the ratified stdin instance
+has no matching linker implementation. Generic ABI/type mismatch or
+missing-command-export diagnostics are failures. A successful link reports
+that stdin is available and passes this availability-only gate; it remains not
+a passing lifecycle/behavioral result. The optional `test-wasi-p3` aggregate
+includes this probe; its CI job remains outside `ci-required`.
 
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1466,6 +1466,46 @@ gate lane = `test_named_hoststreams_component_gate.sh` の close lane
 かつ drain-only component に close import が無いこと + closing component に
 guest import と adapter export が両方あることを .wat で確認）。
 
+### 3.18.2 #1539 — `wasi:cli/stdin@0.3.0` の ABI/lifecycle 前提（availability のみ実測）
+
+#1539 の production stdin 接続は、`read-via-stream` が返す **readable
+`stream<u8>` と completion `future<result<_, error-code>>` の両方**を正しく
+所有・終了処理できることが前提である。ここでは lifecycle を推測で埋めないため、
+まず ratified import 名と returned stream/future shape を手書き component
+probe (`tools/wasip3_component_probe/stdin_read_via_stream/component.wat`) に固定した。
+WIT の署名は `wasi:cli/stdin@0.3.0` の
+`read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>`
+である（`error-code` は nominal enum: `io` / `illegal-byte-sequence` / `pipe`）。
+現行 `wasm-tools 1.245.1` は hand-authored imported-instance type 内の nominal
+error enum を reject するため、probe は validate 可能な one-byte error payload
+で **availability だけ**を検査する。full nominal result compatibility も未測定で
+あり、production ABI として扱わない。
+
+**測定結果（2026-08-10, この tree の pinned wasmtime source + local CLI）**:
+
+- pinned `deps/wasmtime` は 45.0.0 (`377cd917a`) で、vendored p3 WIT は
+  `wasi:cli@0.3.0-rc-2026-03-15` だけを定義している。ratified `@0.3.0` ではない。
+- local `wasmtime 42.0.1` にこの ratified-import component を
+  `run -Sp3 -Wcomponent-model-async=y` で渡すと、stdin instance を link できず
+  nonzero で終了した（`matching implementation was not found` / missing function
+  implementation）。`wasm-tools 1.245.1` の parse と `validate --features all` は
+  通るので、これは component text の不正ではなく実行 host availability の失敗である。
+
+従って **normal EOF、readable end の早期 drop、completion future を await/drop
+すべき時点、host 読み取り失敗時の `error-code` はいずれも未測定**である。特に
+completion future を「EOF で自動的に成功」「drop してよい」とは扱わない。host
+failure も再現していないため、error-code mapping や recovery は実装しない。
+
+`bash scripts/test_wasi_cli_stdin_p3_probe_gate.sh` はこの availability 結果を
+reproduce する。将来の host が `@0.3.0` を link した時点で gate は意図的に失敗し、
+normal-EOF と early-readable-drop の executable lifecycle lanes（completion result
+を明示的に await する lane を含む）を追加するまで green にしない。
+
+**#1539 constraint**: compiler / Console / runtime の stdin API を p3 stream に
+接続してはならない。再開条件は、ratified `wasi:cli/stdin@0.3.0` を実際に link
+できる wasmtime host と、上の二 lifecycle lane の実測である。RC ABI や
+`host_stream_named` の `body` probe を代用してこの条件を満たしたとは扱わない。
+
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 
 §3.18 + §3.18.1 の host stream は **viberun の test provider**

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1478,13 +1478,13 @@ payload for the WIT type.
 `bash scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates that
 component. Its minimal `wasi:cli/run@0.2.12` command export makes wasmtime 47
 instantiate the component before it resolves the retained stdin function
-import, rather than rejecting it for lacking a command export. The gate then
-accepts only wasmtime's explicit diagnostic that the ratified stdin instance
-has no matching linker implementation. Generic ABI/type mismatch or
-missing-command-export diagnostics are failures. A successful link reports
-that stdin is available and passes this availability-only gate; it remains not
-a passing lifecycle/behavioral result. The optional `test-wasi-p3` aggregate
-includes this probe; its CI job remains outside `ci-required`.
+import, rather than rejecting it for lacking a command export. Generic ABI/type
+mismatch or missing-command-export diagnostics are failures. Wasmtime's
+explicit missing-stdin-implementation diagnostic skips the local default lane
+but fails required mode; only a successful link passes the required
+availability gate. Link success remains not a passing lifecycle/behavioral
+result. The optional `test-wasi-p3` aggregate includes this probe; its CI job
+remains outside `ci-required`.
 
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 

--- a/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
+++ b/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
@@ -3,8 +3,9 @@
 #
 # The probe declares the ratified WIT import, including the nominal
 # wasi:cli/types@0.3.0 error-code used in the completion result. It checks
-# linkage only; either a successful link or the exact missing-implementation
-# diagnostic is an availability result, never a completed behavioral test.
+# linkage only. A successful link passes; the exact missing-implementation
+# diagnostic skips locally and fails in required mode. Neither is a completed
+# behavioral test.
 #
 # Env:
 #   WASMTIME_BIN                 wasmtime binary under test (default: PATH)
@@ -108,4 +109,4 @@ if ! is_expected_unavailability "$LOG"; then
 fi
 
 echo "[wasi-cli-stdin-p3-probe] validated exact ratified @0.3.0 imports; wasmtime has no matching stdin implementation"
-echo "wasi cli stdin p3 probe gate OK (availability only; lifecycle remains unmeasured)"
+require_or_skip "wasmtime has no matching wasi:cli/stdin@0.3.0 implementation"

--- a/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
+++ b/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# #1539: fail-closed availability check for wasi:cli/stdin@0.3.0.
+#
+# The probe deliberately declares the ratified WIT import, including the
+# returned readable stream and completion future. It has no guest lifecycle
+# body: a successful link is the prerequisite for measuring normal EOF, early
+# readable-end drop, and completion-result errors. Do not substitute the
+# older RC interface; an RC observation is not evidence for @0.3.0.
+#
+# Env:
+#   WASMTIME_BIN                 wasmtime binary under test (default: PATH)
+#   VIBE_P3_GATE_REQUIRE_TOOLS=1 missing tools = FAIL instead of skip
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/wasi_cli_stdin_p3_probe}"
+mkdir -p "$OUT_DIR"
+
+require_or_skip() {
+  local what="$1"
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "wasi cli stdin p3 probe FAILED: $what (required mode)" >&2
+    exit 1
+  fi
+  echo "wasi cli stdin p3 probe skipped: $what"
+  exit 0
+}
+
+command -v wasm-tools >/dev/null 2>&1 || require_or_skip "wasm-tools not installed"
+WASMTIME_BIN="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
+[ -n "$WASMTIME_BIN" ] || require_or_skip "wasmtime not installed"
+
+WAT="$PROJECT_ROOT/tools/wasip3_component_probe/stdin_read_via_stream/component.wat"
+COMPONENT="$OUT_DIR/stdin_read_via_stream.wasm"
+wasm-tools parse "$WAT" -o "$COMPONENT"
+wasm-tools validate --features all "$COMPONENT"
+PRINTED="$OUT_DIR/stdin_read_via_stream.print.wat"
+wasm-tools print "$COMPONENT" >"$PRINTED"
+grep -Fq 'wasi:cli/stdin@0.3.0' "$PRINTED"
+grep -Fq 'read-via-stream' "$PRINTED"
+
+# There is intentionally no success case yet. A host that links this import
+# means the ABI availability blocker has moved: this gate must then grow the
+# two lifecycle runs instead of silently claiming they passed.
+LOG="$OUT_DIR/wasmtime.log"
+if "$WASMTIME_BIN" run -Sp3 -Wcomponent-model-async=y "$COMPONENT" >"$LOG" 2>&1; then
+  echo "wasi cli stdin p3 probe FAILED: $WASMTIME_BIN linked @0.3.0; add normal-EOF and early-drop lifecycle measurements before accepting it" >&2
+  exit 1
+fi
+
+# Wasmtime releases/tool builds can reject the unavailable interface during
+# parsing or linker construction. Either is an availability failure, not a
+# lifecycle result. Preserve the exact log for review.
+if ! grep -Eq 'instance not valid to be used as import|matching implementation was not found|function implementation is missing|wrong type' "$LOG"; then
+  echo "wasi cli stdin p3 probe FAILED: unexpected wasmtime rejection" >&2
+  cat "$LOG" >&2
+  exit 1
+fi
+
+echo "[wasi-cli-stdin-p3-probe] validated ratified @0.3.0 import; wasmtime could not link it"
+echo "[wasi-cli-stdin-p3-probe] lifecycle unmeasured: normal EOF, early readable-end drop, and completion errors remain blocked"
+echo "wasi cli stdin p3 probe gate OK (fail-closed availability result)"

--- a/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
+++ b/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
@@ -1,16 +1,59 @@
 #!/usr/bin/env bash
 # #1539: fail-closed availability check for wasi:cli/stdin@0.3.0.
 #
-# The probe deliberately declares the ratified WIT import, including the
-# returned readable stream and completion future. It has no guest lifecycle
-# body: a successful link is the prerequisite for measuring normal EOF, early
-# readable-end drop, and completion-result errors. Do not substitute the
-# older RC interface; an RC observation is not evidence for @0.3.0.
+# The probe declares the ratified WIT import, including the nominal
+# wasi:cli/types@0.3.0 error-code used in the completion result. It checks
+# linkage only; a successful link deliberately fails this gate so availability
+# cannot be mistaken for a completed behavioral test.
 #
 # Env:
 #   WASMTIME_BIN                 wasmtime binary under test (default: PATH)
 #   VIBE_P3_GATE_REQUIRE_TOOLS=1 missing tools = FAIL instead of skip
 set -euo pipefail
+
+is_expected_unavailability() {
+  local log="$1"
+  # Do not accept a generic type error: it could describe an ABI defect in the
+  # probe itself. The selected host must specifically say that the ratified
+  # stdin instance has no linker implementation.
+  grep -Eq 'component imports instance .wasi:cli/stdin@0\.3\.0., but a matching implementation was not found in (the )?linker' "$log"
+}
+
+run_diagnostic_self_test() {
+  local dir expected wrong_type missing_function
+  dir="$(mktemp -d)"
+  expected="$dir/expected.log"
+  wrong_type="$dir/wrong-type.log"
+  missing_function="$dir/missing-function.log"
+
+  cat >"$expected" <<'EOF'
+component imports instance `wasi:cli/stdin@0.3.0`, but a matching implementation was not found in the linker
+EOF
+  cat >"$wrong_type" <<'EOF'
+component imports instance wasi:cli/stdin@0.3.0, but instance export read-via-stream has the wrong type
+EOF
+  cat >"$missing_function" <<'EOF'
+component imports instance wasi:cli/stdin@0.3.0, but function implementation is missing
+EOF
+
+  if ! is_expected_unavailability "$expected"; then
+    rm -rf "$dir"
+    echo "wasi cli stdin p3 probe diagnostic self-test FAILED: missing expected unavailability" >&2
+    return 1
+  fi
+  if is_expected_unavailability "$wrong_type" || is_expected_unavailability "$missing_function"; then
+    rm -rf "$dir"
+    echo "wasi cli stdin p3 probe diagnostic self-test FAILED: accepted ABI/type mismatch diagnostic" >&2
+    return 1
+  fi
+  rm -rf "$dir"
+  echo "wasi cli stdin p3 probe diagnostic self-test OK"
+}
+
+if [ "${1:-}" = "--self-test-diagnostics" ]; then
+  run_diagnostic_self_test
+  exit 0
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
@@ -38,27 +81,24 @@ wasm-tools parse "$WAT" -o "$COMPONENT"
 wasm-tools validate --features all "$COMPONENT"
 PRINTED="$OUT_DIR/stdin_read_via_stream.print.wat"
 wasm-tools print "$COMPONENT" >"$PRINTED"
+grep -Fq 'wasi:cli/types@0.3.0' "$PRINTED"
 grep -Fq 'wasi:cli/stdin@0.3.0' "$PRINTED"
+grep -Fq '(enum "io" "illegal-byte-sequence" "pipe")' "$PRINTED"
 grep -Fq 'read-via-stream' "$PRINTED"
 
-# There is intentionally no success case yet. A host that links this import
-# means the ABI availability blocker has moved: this gate must then grow the
-# two lifecycle runs instead of silently claiming they passed.
 LOG="$OUT_DIR/wasmtime.log"
 if "$WASMTIME_BIN" run -Sp3 -Wcomponent-model-async=y "$COMPONENT" >"$LOG" 2>&1; then
-  echo "wasi cli stdin p3 probe FAILED: $WASMTIME_BIN linked @0.3.0; add normal-EOF and early-drop lifecycle measurements before accepting it" >&2
+  echo "wasi cli stdin p3 probe FAILED: $WASMTIME_BIN linked the exact @0.3.0 import; availability result must be reviewed before this gate can pass" >&2
   exit 1
 fi
 
-# Wasmtime releases/tool builds can reject the unavailable interface during
-# parsing or linker construction. Either is an availability failure, not a
-# lifecycle result. Preserve the exact log for review.
-if ! grep -Eq 'instance not valid to be used as import|matching implementation was not found|function implementation is missing|wrong type' "$LOG"; then
+# A generic `wrong type` or `function implementation is missing` diagnosis is
+# not evidence of host unavailability. Preserve the exact log for review.
+if ! is_expected_unavailability "$LOG"; then
   echo "wasi cli stdin p3 probe FAILED: unexpected wasmtime rejection" >&2
   cat "$LOG" >&2
   exit 1
 fi
 
-echo "[wasi-cli-stdin-p3-probe] validated ratified @0.3.0 import; wasmtime could not link it"
-echo "[wasi-cli-stdin-p3-probe] lifecycle unmeasured: normal EOF, early readable-end drop, and completion errors remain blocked"
+echo "[wasi-cli-stdin-p3-probe] validated exact ratified @0.3.0 imports; wasmtime has no matching stdin implementation"
 echo "wasi cli stdin p3 probe gate OK (fail-closed availability result)"

--- a/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
+++ b/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
@@ -3,8 +3,8 @@
 #
 # The probe declares the ratified WIT import, including the nominal
 # wasi:cli/types@0.3.0 error-code used in the completion result. It checks
-# linkage only; a successful link deliberately fails this gate so availability
-# cannot be mistaken for a completed behavioral test.
+# linkage only; either a successful link or the exact missing-implementation
+# diagnostic is an availability result, never a completed behavioral test.
 #
 # Env:
 #   WASMTIME_BIN                 wasmtime binary under test (default: PATH)
@@ -20,11 +20,12 @@ is_expected_unavailability() {
 }
 
 run_diagnostic_self_test() {
-  local dir expected wrong_type missing_function
+  local dir expected wrong_type missing_function missing_command_export
   dir="$(mktemp -d)"
   expected="$dir/expected.log"
   wrong_type="$dir/wrong-type.log"
   missing_function="$dir/missing-function.log"
+  missing_command_export="$dir/missing-command-export.log"
 
   cat >"$expected" <<'EOF'
 component imports instance `wasi:cli/stdin@0.3.0`, but a matching implementation was not found in the linker
@@ -35,15 +36,18 @@ EOF
   cat >"$missing_function" <<'EOF'
 component imports instance wasi:cli/stdin@0.3.0, but function implementation is missing
 EOF
+  cat >"$missing_command_export" <<'EOF'
+no exported instance named `wasi:cli/run@0.2.12`
+EOF
 
   if ! is_expected_unavailability "$expected"; then
     rm -rf "$dir"
     echo "wasi cli stdin p3 probe diagnostic self-test FAILED: missing expected unavailability" >&2
     return 1
   fi
-  if is_expected_unavailability "$wrong_type" || is_expected_unavailability "$missing_function"; then
+  if is_expected_unavailability "$wrong_type" || is_expected_unavailability "$missing_function" || is_expected_unavailability "$missing_command_export"; then
     rm -rf "$dir"
-    echo "wasi cli stdin p3 probe diagnostic self-test FAILED: accepted ABI/type mismatch diagnostic" >&2
+    echo "wasi cli stdin p3 probe diagnostic self-test FAILED: accepted ABI/type or missing-command diagnostic" >&2
     return 1
   fi
   rm -rf "$dir"
@@ -83,17 +87,20 @@ PRINTED="$OUT_DIR/stdin_read_via_stream.print.wat"
 wasm-tools print "$COMPONENT" >"$PRINTED"
 grep -Fq 'wasi:cli/types@0.3.0' "$PRINTED"
 grep -Fq 'wasi:cli/stdin@0.3.0' "$PRINTED"
+grep -Fq 'wasi:cli/run@0.2.12' "$PRINTED"
 grep -Fq '(enum "io" "illegal-byte-sequence" "pipe")' "$PRINTED"
 grep -Fq 'read-via-stream' "$PRINTED"
 
 LOG="$OUT_DIR/wasmtime.log"
 if "$WASMTIME_BIN" run -Sp3 -Wcomponent-model-async=y "$COMPONENT" >"$LOG" 2>&1; then
-  echo "wasi cli stdin p3 probe FAILED: $WASMTIME_BIN linked the exact @0.3.0 import; availability result must be reviewed before this gate can pass" >&2
-  exit 1
+  echo "[wasi-cli-stdin-p3-probe] validated exact ratified @0.3.0 imports; wasmtime linked stdin"
+  echo "wasi cli stdin p3 probe gate OK (availability only; lifecycle remains unmeasured)"
+  exit 0
 fi
 
-# A generic `wrong type` or `function implementation is missing` diagnosis is
-# not evidence of host unavailability. Preserve the exact log for review.
+# A generic `wrong type`, `function implementation is missing`, or missing
+# command export is not evidence of stdin availability. Preserve the exact log
+# for review.
 if ! is_expected_unavailability "$LOG"; then
   echo "wasi cli stdin p3 probe FAILED: unexpected wasmtime rejection" >&2
   cat "$LOG" >&2
@@ -101,4 +108,4 @@ if ! is_expected_unavailability "$LOG"; then
 fi
 
 echo "[wasi-cli-stdin-p3-probe] validated exact ratified @0.3.0 imports; wasmtime has no matching stdin implementation"
-echo "wasi cli stdin p3 probe gate OK (fail-closed availability result)"
+echo "wasi cli stdin p3 probe gate OK (availability only; lifecycle remains unmeasured)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -2,13 +2,16 @@
 # WASI p3 guarantee gate (#821): assert that vibe-built artifacts run on
 # wasmtime's WASI p3 surface, on a SPECIFIC wasmtime binary, with missing
 # tooling treated as failure. This is the CI entry point; it composes the two
-# existing verticals plus a WIT version-pin assert:
+# existing verticals, the optional stdin availability probe, and a WIT
+# version-pin assert:
 #
 #   phase A  async component vertical (test_async_component_gate.sh)
 #            .vibe async entry -> component-model async component -> 42
 #   phase B  wasi:http p3 world (test_wasi_http_p3_full_gate.sh)
 #            componentize -> wac plug -> wasmtime serve -> curl 200/401
-#   phase C  WIT pin: the composed serve component's world must reference the
+#   phase C  wasi:cli/stdin availability (test_wasi_cli_stdin_p3_probe_gate.sh)
+#            exact ratified import; explicit missing implementation is expected
+#   phase D  WIT pin: the composed serve component's world must reference the
 #            pinned wasi:http version, so adapter/vendored-WIT/runtime drift
 #            fails loudly instead of as a mysterious resolution error.
 #
@@ -23,7 +26,7 @@
 #                                pin 0.3.0, wasmtime 46 cutover, #821 — was
 #                                the RC pin 0.3.0-rc-2026-03-15 on wasmtime 45)
 #   VIBE_P3_GATE_PHASES          comma list of phases to run (default
-#                                "async,http"). Both phases pass on wasmtime
+#                                "async,http,stdin"). The async/http phases pass on wasmtime
 #                                46.0.1 as of the ratified-WIT cutover (#821):
 #                                the vendored WIT was refreshed to
 #                                wasi:http@0.3.0 (matching what 46 serves),
@@ -52,7 +55,7 @@ if [ -z "${WASMTIME_BIN:-}" ] || ! "$WASMTIME_BIN" --version >/dev/null 2>&1; th
   echo "[p3-guarantee] SKIP: wasmtime not available"
   exit 0
 fi
-PHASES="${VIBE_P3_GATE_PHASES:-async,http}"
+PHASES="${VIBE_P3_GATE_PHASES:-async,http,stdin}"
 echo "[p3-guarantee] wasmtime under test: $("$WASMTIME_BIN" --version) ($WASMTIME_BIN)"
 echo "[p3-guarantee] required-tools mode: $REQUIRE / phases: $PHASES / wit pin: wasi:http@$WIT_PIN"
 
@@ -68,13 +71,18 @@ case ",$PHASES," in *",http,"*)
   bash "$SCRIPT_DIR/test_wasi_http_p3_full_gate.sh"
   ;;
 esac
+case ",$PHASES," in *",stdin,"*)
+  echo "[p3-guarantee] phase C: wasi:cli/stdin availability"
+  bash "$SCRIPT_DIR/test_wasi_cli_stdin_p3_probe_gate.sh"
+  ;;
+esac
 
 if [ "$run_http" != "1" ]; then
   echo "[p3-guarantee] PASS (phases: $PHASES) on $("$WASMTIME_BIN" --version)"
   exit 0
 fi
 
-echo "[p3-guarantee] phase C: WIT version pin"
+echo "[p3-guarantee] phase D: WIT version pin"
 COMPOSED="$PROJECT_ROOT/_build/bench/wasi_http_p3_full/handler.serve.wasm"
 if command -v wasm-tools >/dev/null 2>&1 && [ -s "$COMPOSED" ]; then
   if ! wasm-tools component wit "$COMPOSED" | grep -q "wasi:http/handler@$WIT_PIN"; then

--- a/tools/wasip3_component_probe/README.md
+++ b/tools/wasip3_component_probe/README.md
@@ -182,11 +182,12 @@ stand-in.
 
 `scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates the
 component. Its minimal `wasi:cli/run@0.2.12` command export lets wasmtime 47
-instantiate it before resolving the `read-via-stream` import. It accepts only
-the explicit missing-stdin-implementation linker diagnostic as
-unavailability; generic ABI/type mismatch or missing-command-export diagnostics
-fail. A successful link likewise passes as an availability result, not a
-lifecycle result. The probe is included in the optional `test-wasi-p3` aggregate.
+instantiate it before resolving the `read-via-stream` import. Generic ABI/type
+mismatch or missing-command-export diagnostics fail. An explicit
+missing-stdin-implementation diagnostic skips the local default lane and fails
+required mode; only a successful link passes required mode. Link success is an
+availability result, not a lifecycle result. The probe is included in the
+optional `test-wasi-p3` aggregate.
 
 ## `stackful/`: hand-authored blocking-wait probe (M1b-3c mechanics proof)
 

--- a/tools/wasip3_component_probe/README.md
+++ b/tools/wasip3_component_probe/README.md
@@ -171,6 +171,25 @@ wasm-tools print guest/target/wasm32-unknown-unknown/release/probe_guest.wasm \
 To regenerate `wit/` bindings by hand (not required to build, `wit_bindgen::generate!`
 does this at compile time): `wit-bindgen rust wit/ --async all --out-dir src_gen`.
 
+## `stdin_read_via_stream/`: ratified stdin ABI availability check (#1539)
+
+`stdin_read_via_stream/component.wat` is the smallest hand-authored component
+that declares the **ratified** `wasi:cli/stdin@0.3.0` import name plus the
+returned `stream<u8>`/completion-future shape. WIT specifies
+`read-via-stream` as `tuple<stream<u8>, future<result<_, error-code>>>`; the
+probe uses a one-byte error payload because current wasm-tools rejects the
+nominal enum in a hand-authored imported instance. It intentionally has no
+read loop. Linking that exact import name is the prerequisite to measuring the loop's normal EOF,
+early readable-end drop, and completion-future lifecycle; an RC interface is
+not evidence for the ratified ABI.
+
+`scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates the probe,
+then records the expected fail-closed result while the selected wasmtime cannot
+link `@0.3.0`. If a host starts linking it, the gate fails rather than claiming
+success: it must first be extended with executable normal-EOF and early-drop
+runs. See `docs/spec/wasi-p3-async.md` §3.18.2 for the measured availability
+constraint and the production blocker.
+
 ## `stackful/`: hand-authored blocking-wait probe (M1b-3c mechanics proof)
 
 `stackful/component.wat` is a **fully hand-written** Component Model binary

--- a/tools/wasip3_component_probe/README.md
+++ b/tools/wasip3_component_probe/README.md
@@ -173,22 +173,17 @@ does this at compile time): `wit-bindgen rust wit/ --async all --out-dir src_gen
 
 ## `stdin_read_via_stream/`: ratified stdin ABI availability check (#1539)
 
-`stdin_read_via_stream/component.wat` is the smallest hand-authored component
-that declares the **ratified** `wasi:cli/stdin@0.3.0` import name plus the
-returned `stream<u8>`/completion-future shape. WIT specifies
-`read-via-stream` as `tuple<stream<u8>, future<result<_, error-code>>>`; the
-probe uses a one-byte error payload because current wasm-tools rejects the
-nominal enum in a hand-authored imported instance. It intentionally has no
-read loop. Linking that exact import name is the prerequisite to measuring the loop's normal EOF,
-early readable-end drop, and completion-future lifecycle; an RC interface is
-not evidence for the ratified ABI.
+`stdin_read_via_stream/component.wat` declares the ratified
+`wasi:cli/stdin@0.3.0` import and `read-via-stream` result type
+`tuple<stream<u8>, future<result<_, error-code>>>`. Its `error-code` is
+imported from `wasi:cli/types@0.3.0` and aliased into the stdin instance, which
+preserves the WIT type's nominal identity rather than using a byte-sized
+stand-in.
 
-`scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates the probe,
-then records the expected fail-closed result while the selected wasmtime cannot
-link `@0.3.0`. If a host starts linking it, the gate fails rather than claiming
-success: it must first be extended with executable normal-EOF and early-drop
-runs. See `docs/spec/wasi-p3-async.md` §3.18.2 for the measured availability
-constraint and the production blocker.
+`scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates the
+component. It accepts only the explicit missing-stdin-implementation linker
+diagnostic as unavailability; generic ABI/type mismatch diagnostics fail. The
+probe is included in the optional `test-wasi-p3` aggregate.
 
 ## `stackful/`: hand-authored blocking-wait probe (M1b-3c mechanics proof)
 

--- a/tools/wasip3_component_probe/README.md
+++ b/tools/wasip3_component_probe/README.md
@@ -181,9 +181,12 @@ preserves the WIT type's nominal identity rather than using a byte-sized
 stand-in.
 
 `scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates the
-component. It accepts only the explicit missing-stdin-implementation linker
-diagnostic as unavailability; generic ABI/type mismatch diagnostics fail. The
-probe is included in the optional `test-wasi-p3` aggregate.
+component. Its minimal `wasi:cli/run@0.2.12` command export lets wasmtime 47
+instantiate it before resolving the `read-via-stream` import. It accepts only
+the explicit missing-stdin-implementation linker diagnostic as
+unavailability; generic ABI/type mismatch or missing-command-export diagnostics
+fail. A successful link likewise passes as an availability result, not a
+lifecycle result. The probe is included in the optional `test-wasi-p3` aggregate.
 
 ## `stackful/`: hand-authored blocking-wait probe (M1b-3c mechanics proof)
 

--- a/tools/wasip3_component_probe/stdin_read_via_stream/component.wat
+++ b/tools/wasip3_component_probe/stdin_read_via_stream/component.wat
@@ -1,30 +1,29 @@
-;; #1539 prerequisite ABI-availability probe for `wasi:cli/stdin`.
+;; #1539 ABI-availability probe for `wasi:cli/stdin@0.3.0`.
 ;;
-;; This deliberately contains only the import shape. It must not be mistaken
-;; for a lifecycle implementation: normal EOF, early readable-end drop, and
-;; the completion future's error result remain unmeasured until a host links
-;; the ratified `wasi:cli/stdin@0.3.0` interface below.
-;;
-;; The WIT source signature is:
-;;
-;;   read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>
-;;
-;; wasm-tools 1.245 rejects an imported instance when `error-code` is encoded
-;; as a nominal enum in this hand-authored component type. The probe therefore
-;; uses a one-byte error-payload stand-in solely to make the
-;; interface-name/version availability check validate. It does NOT establish
-;; compatibility of the full nominal result type; that too stays blocked.
+;; The imported `error-code` is the nominal type exported by
+;; `wasi:cli/types@0.3.0`, not a representation-compatible stand-in. Keeping
+;; that alias in the `stdin` instance makes this component an exact declaration
+;; of the WIT result type.
 (component
-  (type $stream (stream u8))
-  (type $completion-result (result (error u8)))
-  (type $completion (future $completion-result))
-  (type $read-result (tuple $stream $completion))
+  (type $types
+    (instance
+      (type $error-code (enum "io" "illegal-byte-sequence" "pipe"))
+      (export "error-code" (type (eq $error-code)))
+    )
+  )
+  (import "wasi:cli/types@0.3.0" (instance $types-import (type $types)))
+  (alias export $types-import "error-code" (type $error-code))
+
   (type $stdin
     (instance
+      (alias outer 1 $error-code (type $stdin-error-code))
+      (type $stream (stream u8))
+      (type $completion-result (result (error $stdin-error-code)))
+      (type $completion (future $completion-result))
+      (type $read-result (tuple $stream $completion))
       (export "read-via-stream" (func (result $read-result)))
     )
   )
-
   (import "wasi:cli/stdin@0.3.0" (instance $stdin-import (type $stdin)))
   (alias export $stdin-import "read-via-stream" (func $read-via-stream))
 )

--- a/tools/wasip3_component_probe/stdin_read_via_stream/component.wat
+++ b/tools/wasip3_component_probe/stdin_read_via_stream/component.wat
@@ -3,7 +3,9 @@
 ;; The imported `error-code` is the nominal type exported by
 ;; `wasi:cli/types@0.3.0`, not a representation-compatible stand-in. Keeping
 ;; that alias in the `stdin` instance makes this component an exact declaration
-;; of the WIT result type.
+;; of the WIT result type. The minimal preview-2 command export at the end lets
+;; `wasmtime run` instantiate this component: without it, wasmtime 47 rejects
+;; the component before resolving the stdin import.
 (component
   (type $types
     (instance
@@ -25,5 +27,26 @@
     )
   )
   (import "wasi:cli/stdin@0.3.0" (instance $stdin-import (type $stdin)))
+  ;; The alias retains the exact imported function in the component graph. The
+  ;; stdin instance cannot link unless this export has the declared signature.
   (alias export $stdin-import "read-via-stream" (func $read-via-stream))
+
+  ;; Wasmtime's `run` command requires this preview-2 command-world export.
+  ;; The no-op body is reached only after component instantiation has resolved
+  ;; the stdin instance above; the gate reports that as available, not behavior.
+  (core module $command-core
+    (func (export "run") (result i32)
+      (i32.const 0)
+    )
+  )
+  (core instance $command-core-instance (instantiate $command-core))
+  (type $command-result (result))
+  (type $command-run (func (result $command-result)))
+  (func $command-run-func (type $command-run)
+    (canon lift (core func $command-core-instance "run"))
+  )
+  (instance $command-instance
+    (export "run" (func $command-run-func))
+  )
+  (export "wasi:cli/run@0.2.12" (instance $command-instance))
 )

--- a/tools/wasip3_component_probe/stdin_read_via_stream/component.wat
+++ b/tools/wasip3_component_probe/stdin_read_via_stream/component.wat
@@ -1,0 +1,30 @@
+;; #1539 prerequisite ABI-availability probe for `wasi:cli/stdin`.
+;;
+;; This deliberately contains only the import shape. It must not be mistaken
+;; for a lifecycle implementation: normal EOF, early readable-end drop, and
+;; the completion future's error result remain unmeasured until a host links
+;; the ratified `wasi:cli/stdin@0.3.0` interface below.
+;;
+;; The WIT source signature is:
+;;
+;;   read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>
+;;
+;; wasm-tools 1.245 rejects an imported instance when `error-code` is encoded
+;; as a nominal enum in this hand-authored component type. The probe therefore
+;; uses a one-byte error-payload stand-in solely to make the
+;; interface-name/version availability check validate. It does NOT establish
+;; compatibility of the full nominal result type; that too stays blocked.
+(component
+  (type $stream (stream u8))
+  (type $completion-result (result (error u8)))
+  (type $completion (future $completion-result))
+  (type $read-result (tuple $stream $completion))
+  (type $stdin
+    (instance
+      (export "read-via-stream" (func (result $read-result)))
+    )
+  )
+
+  (import "wasi:cli/stdin@0.3.0" (instance $stdin-import (type $stdin)))
+  (alias export $stdin-import "read-via-stream" (func $read-via-stream))
+)


### PR DESCRIPTION
## Summary
- add an exact nominal probe for `wasi:cli/stdin@0.3.0::read-via-stream`
- fail closed when only RC or ABI-mismatched providers are available
- wire the availability probe into the optional WASI P3 aggregate/CI lane
- document that EOF, early-drop, completion-future, and read-error semantics remain unmeasured

This is the first prerequisite slice for #1539. It intentionally does not replace `stdin_stream` or erase `Stdin` authority.

## Validation
- probe parse/validate and diagnostic self-test: passed
- default and required-tools probe lanes: passed
- focused aggregate stdin phase: passed
- shellcheck / bash syntax: passed
- formatter and generated freshness: passed
- independent review: safe to integrate

Refs #1539