### PR TITLE
test(wasi): measure P3 stdin success lifecycle

### DIFF
--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1466,25 +1466,36 @@ gate lane = `test_named_hoststreams_component_gate.sh` の close lane
 かつ drain-only component に close import が無いこと + closing component に
 guest import と adapter export が両方あることを .wat で確認）。
 
-### 3.18.2 #1539 — `wasi:cli/stdin@0.3.0` ABI availability probe
+### 3.18.2 #1539 — `wasi:cli/stdin@0.3.0` success lifecycle measurement
 
-`tools/wasip3_component_probe/stdin_read_via_stream/component.wat` declares
-`wasi:cli/stdin@0.3.0` and its `read-via-stream` result type:
-`tuple<stream<u8>, future<result<_, error-code>>>`. The component imports
-`wasi:cli/types@0.3.0` and aliases its nominal `error-code` into the stdin
-instance, so the declaration does not substitute a representation-compatible
-payload for the WIT type.
+`tools/wasip3_component_probe/stdin_read_via_stream/component.wat` retains the
+ratified `wasi:cli/stdin@0.3.0` result type
+`tuple<stream<u8>, future<result<_, error-code>>>`, including the nominal
+`wasi:cli/types@0.3.0/error-code` alias. It also retains the preview-2
+`wasi:cli/run@0.2.12` command export. Thus an error result cannot be silently
+accepted as a representation-compatible non-nominal value.
 
-`bash scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates that
-component. Its minimal `wasi:cli/run@0.2.12` command export makes wasmtime 47
-instantiate the component before it resolves the retained stdin function
-import, rather than rejecting it for lacking a command export. Generic ABI/type
-mismatch or missing-command-export diagnostics are failures. Wasmtime's
-explicit missing-stdin-implementation diagnostic skips the local default lane
-but fails required mode; only a successful link passes the required
-availability gate. Link success remains not a passing lifecycle/behavioral
-result. The optional `test-wasi-p3` aggregate includes this probe; its CI job
+**Measured on pinned wasmtime 47.0.2:** with binary stdin `10,15,17`, `drain`
+performs canonical async `stream.read` calls for each byte, observes the
+separate zero-item EOF status, drops the readable stream, and awaits canonical
+`future.read` completion success; it returns `42`. `drop` obtains the same
+pair, drops its readable stream immediately, awaits completion success, and
+returns `43`. BLOCKED stream/future reads use `waitable-set.new`,
+`waitable.join`, and `waitable-set.wait`; the end is unjoined before its set is
+dropped. Other statuses, events, byte values, EOF forms, and result tags are
+diagnostic return paths, not success.
+
+`bash scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses, validates, and
+prints the component, generates that deterministic binary input, and executes
+both async-lifted lanes. Required mode requires exactly wasmtime 47.0.2;
+missing tools, an unpinned provider, and ABI/type/link/command-export failures
+fail closed. The default local mode skips unavailable tools or an unpinned
+provider. The optional `test-wasi-p3` aggregate includes this probe; its CI job
 remains outside `ci-required`.
+
+This is only the successful-close lifecycle slice. **Read-error injection is
+unmeasured** (`io`, `illegal-byte-sequence`, and `pipe` have no claimed runtime
+measurement), and this work makes no compiler or console change.
 
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 

--- a/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
+++ b/scripts/test_wasi_cli_stdin_p3_probe_gate.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
-# #1539: fail-closed availability check for wasi:cli/stdin@0.3.0.
+# #1539: executable, fail-closed stdin lifecycle measurement for
+# wasi:cli/stdin@0.3.0 on the pinned wasmtime 47.0.2 provider.
 #
-# The probe declares the ratified WIT import, including the nominal
-# wasi:cli/types@0.3.0 error-code used in the completion result. It checks
-# linkage only. A successful link passes; the exact missing-implementation
-# diagnostic skips locally and fails in required mode. Neither is a completed
-# behavioral test.
+# The WAT retains the ratified nominal wasi:cli/types@0.3.0 error-code and a
+# preview-2 command export. Its two explicitly invoked async lanes measure:
+#   drain: bytes 10,15,17 -> EOF -> completion future success -> 42
+#   drop:  drop readable stream -> completion future success -> 43
+# Unexpected statuses/events/bytes/EOF/result variants return diagnostic codes
+# from the guest and therefore fail this gate rather than being accepted.
 #
 # Env:
 #   WASMTIME_BIN                 wasmtime binary under test (default: PATH)
-#   VIBE_P3_GATE_REQUIRE_TOOLS=1 missing tools = FAIL instead of skip
+#   VIBE_P3_GATE_REQUIRE_TOOLS=1 missing/wrong-version tools = FAIL, not skip
 set -euo pipefail
+
+PINNED_WASMTIME_VERSION="wasmtime 47.0.2"
 
 is_expected_unavailability() {
   local log="$1"
@@ -79,6 +83,11 @@ require_or_skip() {
 command -v wasm-tools >/dev/null 2>&1 || require_or_skip "wasm-tools not installed"
 WASMTIME_BIN="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
 [ -n "$WASMTIME_BIN" ] || require_or_skip "wasmtime not installed"
+WASMTIME_VERSION="$("$WASMTIME_BIN" --version 2>/dev/null || true)"
+case "$WASMTIME_VERSION" in
+  "$PINNED_WASMTIME_VERSION"\ *) ;;
+  *) require_or_skip "requires $PINNED_WASMTIME_VERSION, got ${WASMTIME_VERSION:-unavailable}" ;;
+esac
 
 WAT="$PROJECT_ROOT/tools/wasip3_component_probe/stdin_read_via_stream/component.wat"
 COMPONENT="$OUT_DIR/stdin_read_via_stream.wasm"
@@ -91,22 +100,42 @@ grep -Fq 'wasi:cli/stdin@0.3.0' "$PRINTED"
 grep -Fq 'wasi:cli/run@0.2.12' "$PRINTED"
 grep -Fq '(enum "io" "illegal-byte-sequence" "pipe")' "$PRINTED"
 grep -Fq 'read-via-stream' "$PRINTED"
+grep -Fq 'canon stream.read' "$PRINTED"
+grep -Fq 'canon future.read' "$PRINTED"
+grep -Fq 'canon waitable-set.wait' "$PRINTED"
+grep -Fq 'canon task.return' "$PRINTED"
 
-LOG="$OUT_DIR/wasmtime.log"
-if "$WASMTIME_BIN" run -Sp3 -Wcomponent-model-async=y "$COMPONENT" >"$LOG" 2>&1; then
-  echo "[wasi-cli-stdin-p3-probe] validated exact ratified @0.3.0 imports; wasmtime linked stdin"
-  echo "wasi cli stdin p3 probe gate OK (availability only; lifecycle remains unmeasured)"
-  exit 0
-fi
+# Binary input avoids platform/text-mode ambiguity: the drain lane requires
+# exactly these three u8 values followed by EOF.
+INPUT="$OUT_DIR/stdin-10-15-17.bin"
+printf '\012\017\021' >"$INPUT"
+run_lane() {
+  local lane="$1" expected="$2" log got
+  log="$OUT_DIR/$lane.log"
+  if ! timeout 60 "$WASMTIME_BIN" run -Sp3 \
+      -W component-model-async=y -W component-model-async-stackful=y \
+      -W component-model-more-async-builtins=y \
+      --invoke "$lane()" "$COMPONENT" <"$INPUT" >"$log" 2>&1; then
+    # Keep the old availability boundary fail-closed: only this exact missing
+    # stdin-provider diagnostic may skip locally. An ABI/type/command error is
+    # evidence against the probe and must always remain a failure.
+    if is_expected_unavailability "$log"; then
+      echo "[wasi-cli-stdin-p3-probe] validated exact ratified @0.3.0 imports; wasmtime has no matching stdin implementation"
+      require_or_skip "wasmtime has no matching wasi:cli/stdin@0.3.0 implementation"
+    fi
+    echo "wasi cli stdin p3 probe FAILED: $lane lane did not exit 0" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+  got="$(cat "$log")"
+  if [ "$got" != "$expected" ]; then
+    echo "wasi cli stdin p3 probe FAILED: $lane expected $expected, got: $got" >&2
+    exit 1
+  fi
+  echo "[wasi-cli-stdin-p3-probe] $lane: $got"
+}
 
-# A generic `wrong type`, `function implementation is missing`, or missing
-# command export is not evidence of stdin availability. Preserve the exact log
-# for review.
-if ! is_expected_unavailability "$LOG"; then
-  echo "wasi cli stdin p3 probe FAILED: unexpected wasmtime rejection" >&2
-  cat "$LOG" >&2
-  exit 1
-fi
+run_lane drain 42
+run_lane drop 43
 
-echo "[wasi-cli-stdin-p3-probe] validated exact ratified @0.3.0 imports; wasmtime has no matching stdin implementation"
-require_or_skip "wasmtime has no matching wasi:cli/stdin@0.3.0 implementation"
+echo "wasi cli stdin p3 probe gate OK ($PINNED_WASMTIME_VERSION; drain EOF/completion=42, early-drop/completion=43)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -2,15 +2,15 @@
 # WASI p3 guarantee gate (#821): assert that vibe-built artifacts run on
 # wasmtime's WASI p3 surface, on a SPECIFIC wasmtime binary, with missing
 # tooling treated as failure. This is the CI entry point; it composes the two
-# existing verticals, the optional stdin availability probe, and a WIT
+# existing verticals, the optional stdin success-lifecycle probe, and a WIT
 # version-pin assert:
 #
 #   phase A  async component vertical (test_async_component_gate.sh)
 #            .vibe async entry -> component-model async component -> 42
 #   phase B  wasi:http p3 world (test_wasi_http_p3_full_gate.sh)
 #            componentize -> wac plug -> wasmtime serve -> curl 200/401
-#   phase C  wasi:cli/stdin availability (test_wasi_cli_stdin_p3_probe_gate.sh)
-#            exact ratified import; explicit missing implementation is expected
+#   phase C  wasi:cli/stdin lifecycle (test_wasi_cli_stdin_p3_probe_gate.sh)
+#            exact ratified import; drain-to-EOF and early-drop completion
 #   phase D  WIT pin: the composed serve component's world must reference the
 #            pinned wasi:http version, so adapter/vendored-WIT/runtime drift
 #            fails loudly instead of as a mysterious resolution error.
@@ -72,7 +72,7 @@ case ",$PHASES," in *",http,"*)
   ;;
 esac
 case ",$PHASES," in *",stdin,"*)
-  echo "[p3-guarantee] phase C: wasi:cli/stdin availability"
+  echo "[p3-guarantee] phase C: wasi:cli/stdin lifecycle"
   bash "$SCRIPT_DIR/test_wasi_cli_stdin_p3_probe_gate.sh"
   ;;
 esac

--- a/tools/wasip3_component_probe/README.md
+++ b/tools/wasip3_component_probe/README.md
@@ -171,23 +171,37 @@ wasm-tools print guest/target/wasm32-unknown-unknown/release/probe_guest.wasm \
 To regenerate `wit/` bindings by hand (not required to build, `wit_bindgen::generate!`
 does this at compile time): `wit-bindgen rust wit/ --async all --out-dir src_gen`.
 
-## `stdin_read_via_stream/`: ratified stdin ABI availability check (#1539)
+## `stdin_read_via_stream/`: ratified stdin lifecycle measurement (#1539)
 
 `stdin_read_via_stream/component.wat` declares the ratified
-`wasi:cli/stdin@0.3.0` import and `read-via-stream` result type
+`wasi:cli/stdin@0.3.0` `read-via-stream` result
 `tuple<stream<u8>, future<result<_, error-code>>>`. Its `error-code` is
-imported from `wasi:cli/types@0.3.0` and aliased into the stdin instance, which
-preserves the WIT type's nominal identity rather than using a byte-sized
-stand-in.
+imported from `wasi:cli/types@0.3.0` and aliased into the stdin instance, so
+completion errors retain their nominal identity rather than using a
+representation-compatible stand-in. The preview-2 `wasi:cli/run@0.2.12`
+command export remains present for command instantiation.
 
-`scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses and validates the
-component. Its minimal `wasi:cli/run@0.2.12` command export lets wasmtime 47
-instantiate it before resolving the `read-via-stream` import. Generic ABI/type
-mismatch or missing-command-export diagnostics fail. An explicit
-missing-stdin-implementation diagnostic skips the local default lane and fails
-required mode; only a successful link passes required mode. Link success is an
-availability result, not a lifecycle result. The probe is included in the
-optional `test-wasi-p3` aggregate.
+Measured on **wasmtime 47.0.2**: the `drain` async-lifted lane reads the exact
+binary input bytes `10,15,17`, observes the separate zero-item EOF status, then
+reads the completion future as success and returns `42`. The `drop` lane drops
+the readable stream immediately, reads that completion future as success, and
+returns `43`. Stream and future reads use canonical async `stream.read` /
+`future.read`; BLOCKED is awaited with `waitable-set.new`, `waitable.join`, and
+`waitable-set.wait`, with joined ends removed before the set is dropped.
+Unexpected status, event, byte, EOF, or result variants return diagnostic
+values instead of being accepted.
+
+`scripts/test_wasi_cli_stdin_p3_probe_gate.sh` parses, validates, and prints
+the component, creates the deterministic binary input, and executes both
+lanes. Required mode accepts only wasmtime 47.0.2; missing tools, a different
+provider version, failed linkage, and generic ABI/type or command-export
+failures are strict failures (the default local mode reports unavailable tools
+or an unpinned provider as a skip). The probe remains in the optional
+`test-wasi-p3` aggregate.
+
+Read-error injection is deliberately **unmeasured**: these success-only lanes
+do not claim behavior for `io`, `illegal-byte-sequence`, or `pipe`. This probe
+changes no compiler or console implementation.
 
 ## `stackful/`: hand-authored blocking-wait probe (M1b-3c mechanics proof)
 

--- a/tools/wasip3_component_probe/stdin_read_via_stream/component.wat
+++ b/tools/wasip3_component_probe/stdin_read_via_stream/component.wat
@@ -1,11 +1,10 @@
-;; #1539 ABI-availability probe for `wasi:cli/stdin@0.3.0`.
+;; #1539 executable stdin lifecycle probe for `wasi:cli/stdin@0.3.0`.
 ;;
-;; The imported `error-code` is the nominal type exported by
-;; `wasi:cli/types@0.3.0`, not a representation-compatible stand-in. Keeping
-;; that alias in the `stdin` instance makes this component an exact declaration
-;; of the WIT result type. The minimal preview-2 command export at the end lets
-;; `wasmtime run` instantiate this component: without it, wasmtime 47 rejects
-;; the component before resolving the stdin import.
+;; This preserves the ratified WIT's nominal `wasi:cli/types@0.3.0/error-code`
+;; in the completion future. `drain` consumes exactly 10, 15, 17 then EOF and
+;; awaits a successful completion (42); `drop` drops the readable stream then
+;; awaits the same successful completion (43). Every unexpected status, event,
+;; byte, EOF, or completion result takes a distinct diagnostic return path.
 (component
   (type $types
     (instance
@@ -27,17 +26,219 @@
     )
   )
   (import "wasi:cli/stdin@0.3.0" (instance $stdin-import (type $stdin)))
-  ;; The alias retains the exact imported function in the component graph. The
-  ;; stdin instance cannot link unless this export has the declared signature.
   (alias export $stdin-import "read-via-stream" (func $read-via-stream))
 
-  ;; Wasmtime's `run` command requires this preview-2 command-world export.
-  ;; The no-op body is reached only after component instantiation has resolved
-  ;; the stdin instance above; the gate reports that as available, not behavior.
-  (core module $command-core
-    (func (export "run") (result i32)
-      (i32.const 0)
+  (core module $guest
+    ;; `read-via-stream` writes its two handles to the supplied return area.
+    (import "$root" "read-via-stream" (func $stdin (param i32)))
+    (import "$root" "[async-lower][stream-read-0]read-via-stream" (func $sread (param i32 i32 i32) (result i32)))
+    (import "$root" "[stream-drop-readable-0]read-via-stream" (func $sdrop (param i32)))
+    (import "$root" "[async-lower][future-read-1]read-via-stream" (func $fread (param i32 i32) (result i32)))
+    (import "$root" "[future-drop-readable-1]read-via-stream" (func $fdrop (param i32)))
+    (import "$root" "[waitable-set-new]" (func $ws-new (result i32)))
+    (import "$root" "[waitable-join]" (func $waitable-join (param i32 i32)))
+    (import "$root" "[waitable-set-wait]" (func $ws-wait (param i32 i32) (result i32)))
+    (import "$root" "[waitable-set-drop]" (func $ws-drop (param i32)))
+    (import "[export]$root" "[task-return]drain" (func $drain-return (param i32)))
+    (import "[export]$root" "[task-return]drop" (func $drop-return (param i32)))
+    (import "env" "memory" (memory 1))
+
+    ;; Memory layout:
+    ;;   0  one-byte stream.read landing slot
+    ;;   8  read-via-stream tuple return area (stream, completion future)
+    ;;  16  waitable-set.wait payload (waitable, completion status)
+    ;;  32  future<result<_, error-code>> landing area (result tag, error)
+
+    ;; Dispose both ends once no set owns either. The caller supplies its own
+    ;; task-return function so both exported async tasks retain correct scope.
+    (func $finish-drain (param $stream i32) (param $future i32) (param $code i32)
+      (call $sdrop (local.get $stream))
+      (call $fdrop (local.get $future))
+      (call $drain-return (local.get $code))
     )
+    (func $finish-after-drain (param $future i32) (param $code i32)
+      (call $fdrop (local.get $future))
+      (call $drain-return (local.get $code))
+    )
+    (func $finish-drop (param $future i32) (param $code i32)
+      (call $fdrop (local.get $future))
+      (call $drop-return (local.get $code))
+    )
+
+    ;; A stdin stream read commonly parks even when the shell has already
+    ;; supplied a finite file. Its completion is therefore collected through
+    ;; the stream's waitable (STREAM_READ = 2) before the status is checked.
+    (func $read-one (param $stream i32) (result i32)
+      (local $status i32)
+      (local $set i32)
+      (local $event i32)
+      (local.set $status (call $sread (local.get $stream) (i32.const 0) (i32.const 1)))
+      (if (i32.eq (local.get $status) (i32.const 0xffffffff))
+        (then
+          (local.set $set (call $ws-new))
+          (call $waitable-join (local.get $stream) (local.get $set))
+          (local.set $event (call $ws-wait (local.get $set) (i32.const 16)))
+          (call $waitable-join (local.get $stream) (i32.const 0))
+          (call $ws-drop (local.get $set))
+          (if (i32.ne (local.get $event) (i32.const 2))
+            (then (return (i32.add (i32.const 0xfffff000) (local.get $event)))))
+          (local.set $status (i32.load (i32.const 20)))
+        )
+      )
+      (local.get $status)
+    )
+
+    ;; Await a completion future after its stream end is no longer owned. It
+    ;; permits only COMPLETED (0) or BLOCKED followed by FUTURE_READ (4); the
+    ;; result landing area must contain the success discriminant (0).
+    (func $await-drain (param $future i32)
+      (local $status i32)
+      (local $set i32)
+      (local $event i32)
+      (local.set $status (call $fread (local.get $future) (i32.const 32)))
+      (if (i32.eq (local.get $status) (i32.const 0xffffffff))
+        (then
+          (local.set $set (call $ws-new))
+          (call $waitable-join (local.get $future) (local.get $set))
+          (local.set $event (call $ws-wait (local.get $set) (i32.const 16)))
+          ;; Unjoin before dropping the set: a set with children traps.
+          (call $waitable-join (local.get $future) (i32.const 0))
+          (call $ws-drop (local.get $set))
+          (if (i32.ne (local.get $event) (i32.const 4))
+            (then (call $finish-after-drain (local.get $future) (i32.add (i32.const 3000) (local.get $event))) (return))
+          )
+          (local.set $status (i32.load (i32.const 20)))
+        )
+      )
+      (if (i32.ne (local.get $status) (i32.const 0))
+        (then (call $finish-after-drain (local.get $future) (i32.add (i32.const 4000) (local.get $status))) (return))
+      )
+      ;; `result<_, error-code>`: only tag 0 is success. A nonzero tag is an
+      ;; error of the imported nominal type, never a representation stand-in.
+      (if (i32.ne (i32.load (i32.const 32)) (i32.const 0))
+        (then (call $finish-after-drain (local.get $future) (i32.add (i32.const 5000) (i32.load (i32.const 32)))) (return))
+      )
+      (call $fdrop (local.get $future))
+      (call $drain-return (i32.const 42))
+    )
+
+    (func (export "drain")
+      (local $stream i32)
+      (local $future i32)
+      (local $status i32)
+      (call $stdin (i32.const 8))
+      (local.set $stream (i32.load (i32.const 8)))
+      (local.set $future (i32.load (i32.const 12)))
+
+      (local.set $status (call $read-one (local.get $stream)))
+      (if (i32.ne (local.get $status) (i32.const 16))
+        (then (call $finish-drain (local.get $stream) (local.get $future) (i32.add (i32.const 100) (local.get $status))) (return)))
+      (if (i32.ne (i32.load8_u (i32.const 0)) (i32.const 10))
+        (then (call $finish-drain (local.get $stream) (local.get $future) (i32.const 200)) (return)))
+
+      (local.set $status (call $read-one (local.get $stream)))
+      (if (i32.ne (local.get $status) (i32.const 16))
+        (then (call $finish-drain (local.get $stream) (local.get $future) (i32.add (i32.const 300) (local.get $status))) (return)))
+      (if (i32.ne (i32.load8_u (i32.const 0)) (i32.const 15))
+        (then (call $finish-drain (local.get $stream) (local.get $future) (i32.const 400)) (return)))
+
+      (local.set $status (call $read-one (local.get $stream)))
+      (if (i32.ne (local.get $status) (i32.const 16))
+        (then (call $finish-drain (local.get $stream) (local.get $future) (i32.add (i32.const 500) (local.get $status))) (return)))
+      (if (i32.ne (i32.load8_u (i32.const 0)) (i32.const 17))
+        (then (call $finish-drain (local.get $stream) (local.get $future) (i32.const 600)) (return)))
+
+      ;; A buffered stdin EOF is a separate zero-item CLOSED status: 1.
+      (local.set $status (call $read-one (local.get $stream)))
+      (if (i32.ne (local.get $status) (i32.const 1))
+        (then (call $finish-drain (local.get $stream) (local.get $future) (i32.add (i32.const 700) (local.get $status))) (return)))
+      (call $sdrop (local.get $stream))
+      (call $await-drain (local.get $future))
+    )
+
+    (func (export "drop")
+      (local $stream i32)
+      (local $future i32)
+      (local $status i32)
+      (local $set i32)
+      (local $event i32)
+      (call $stdin (i32.const 8))
+      (local.set $stream (i32.load (i32.const 8)))
+      (local.set $future (i32.load (i32.const 12)))
+      (call $sdrop (local.get $stream))
+      (local.set $status (call $fread (local.get $future) (i32.const 32)))
+      (if (i32.eq (local.get $status) (i32.const 0xffffffff))
+        (then
+          (local.set $set (call $ws-new))
+          (call $waitable-join (local.get $future) (local.get $set))
+          (local.set $event (call $ws-wait (local.get $set) (i32.const 16)))
+          (call $waitable-join (local.get $future) (i32.const 0))
+          (call $ws-drop (local.get $set))
+          (if (i32.ne (local.get $event) (i32.const 4))
+            (then (call $finish-drop (local.get $future) (i32.add (i32.const 8000) (local.get $event))) (return)))
+          (local.set $status (i32.load (i32.const 20)))
+        )
+      )
+      (if (i32.ne (local.get $status) (i32.const 0))
+        (then (call $finish-drop (local.get $future) (i32.add (i32.const 9000) (local.get $status))) (return)))
+      (if (i32.ne (i32.load (i32.const 32)) (i32.const 0))
+        (then (call $finish-drop (local.get $future) (i32.add (i32.const 10000) (i32.load (i32.const 32)))) (return)))
+      (call $fdrop (local.get $future))
+      (call $drop-return (i32.const 43))
+    )
+  )
+
+  (core module $memhost
+    (memory (export "memory") 1)
+  )
+  (core instance $mem-inst (instantiate $memhost))
+
+  ;; `read-via-stream` needs the same memory as its guest because its tuple is
+  ;; returned indirectly. The literal stream/future operations are async.
+  (core func $core-stdin (canon lower (func $read-via-stream) (memory $mem-inst "memory")))
+  (type $stream (stream u8))
+  (type $completion-result (result (error $error-code)))
+  (type $completion (future $completion-result))
+  (core func $core-sread (canon stream.read $stream async (memory $mem-inst "memory")))
+  (core func $core-sdrop (canon stream.drop-readable $stream))
+  (core func $core-fread (canon future.read $completion async (memory $mem-inst "memory")))
+  (core func $core-fdrop (canon future.drop-readable $completion))
+  (core func $core-ws-new (canon waitable-set.new))
+  (core func $core-waitable-join (canon waitable.join))
+  (core func $core-ws-wait (canon waitable-set.wait (memory $mem-inst "memory")))
+  (core func $core-ws-drop (canon waitable-set.drop))
+  (core func $core-drain-return (canon task.return (result u32)))
+  (core func $core-drop-return (canon task.return (result u32)))
+
+  (core instance $guest-inst (instantiate $guest
+    (with "$root" (instance
+      (export "read-via-stream" (func $core-stdin))
+      (export "[async-lower][stream-read-0]read-via-stream" (func $core-sread))
+      (export "[stream-drop-readable-0]read-via-stream" (func $core-sdrop))
+      (export "[async-lower][future-read-1]read-via-stream" (func $core-fread))
+      (export "[future-drop-readable-1]read-via-stream" (func $core-fdrop))
+      (export "[waitable-set-new]" (func $core-ws-new))
+      (export "[waitable-join]" (func $core-waitable-join))
+      (export "[waitable-set-wait]" (func $core-ws-wait))
+      (export "[waitable-set-drop]" (func $core-ws-drop))
+    ))
+    (with "[export]$root" (instance
+      (export "[task-return]drain" (func $core-drain-return))
+      (export "[task-return]drop" (func $core-drop-return))
+    ))
+    (with "env" (instance (export "memory" (memory $mem-inst "memory"))))
+  ))
+
+  (type $run-type (func async (result u32)))
+  (func $drain (type $run-type) (canon lift (core func $guest-inst "drain") async))
+  (func $drop (type $run-type) (canon lift (core func $guest-inst "drop") async))
+  (export "drain" (func $drain))
+  (export "drop" (func $drop))
+
+  ;; Keep the preview-2 command export so `wasmtime run` instantiates this
+  ;; component. The lifecycle lanes above are invoked explicitly by the gate.
+  (core module $command-core
+    (func (export "run") (result i32) (i32.const 0))
   )
   (core instance $command-core-instance (instantiate $command-core))
   (type $command-result (result))
@@ -45,8 +246,6 @@
   (func $command-run-func (type $command-run)
     (canon lift (core func $command-core-instance "run"))
   )
-  (instance $command-instance
-    (export "run" (func $command-run-func))
-  )
+  (instance $command-instance (export "run" (func $command-run-func)))
   (export "wasi:cli/run@0.2.12" (instance $command-instance))
 )


### PR DESCRIPTION
## Summary
- execute ratified `wasi:cli/stdin@0.3.0::read-via-stream` instead of checking linkage only
- measure deterministic drain-to-EOF plus completion-future success (`42`)
- measure early readable-end drop plus completion-future success (`43`)
- pin required execution to Wasmtime 47.0.2 and fail closed on status/event/byte/error mismatches

This is a prerequisite slice for #1539. Read-error injection remains explicitly unmeasured; compiler and console APIs are unchanged.

## Validation
- pinned Wasmtime 47.0.2 required probe: drain 42, drop 43
- focused `VIBE_P3_GATE_PHASES=stdin` aggregate: passed
- WAT parse/validate/print: passed
- shellcheck, formatter, generated freshness, diff checks: passed
- independent review: safe to integrate

Refs #1539