### PR TITLE
feat(cli): `vibe grep` — AST パターン検索 + 型情報で filter できる structural search (#1572)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,19 @@ vibe diagnostics file.vibe
 # = codegen が wasm local ではなく heap ref cell に落とすもの (#1262)。
 # 空出力 = ファイル中の `let mut` は全部ただの local
 vibe escapes file.vibe
+
+# AST パターン検索 (#1572)。上の4つが「位置 → 意味」なのに対しこれは逆向きの
+# 「構造 → 位置」。メタ変数は `$(name:kind)` (kind: exp/id/const/arg/args/pat/type)。
+# 出力は 1件1行 `path:line:col: <マッチ本文>` + tab 区切りの `$var=<capture>`。
+# 空出力 = マッチなし (--json では `[]`)
+vibe grep --pattern 'Iterator::map($(a:args))' lib
+# **文法だけで止まらない**のが moongrep / ast-grep との差: filter は checker の
+# 答え (推論型・effect row・解決済み名・型エラー) で書く。これらを付けると
+# `vibe check` と同じ import 解決レーンに乗る (typed tier)
+vibe grep --pattern 'f($(x:exp))' --where '$x : Array[_]' lib
+vibe grep --pattern '$(f:id)($(a:args))' --where '$f = Iterator::map' lib
+vibe grep --pattern '$(f:id)($(a:args))' --where-row '$f with Async' lib
+vibe grep --pattern 'f($(x:exp))' --only-ill-typed lib
 ```
 
 > **`vibe diagnostics` は import を解決しない。** `import ./dep.vibe { Hue as T }`

--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -142,8 +142,17 @@ they get the same desugaring. Measured on the current parser:
 - `xs |> map(f)` and `map(xs, f)` are the same AST and match each other;
 - `xs.map(f)` keeps its `EDot` callee and matches only the method spelling.
 
-Unifying those call forms is the **resolved-name filter**'s job (below), not
-structural matching's.
+Structural matching keeps the method form separate on purpose. The
+resolved-name filter below closes the **alias** half of that gap (`It::map` and
+`Iterator::map` are one query), but it does **not** yet relate `xs.map(f)` to
+`Iterator::map`: a method callee is an `EDot`, and the checker's member
+resolution is not exposed as a name anywhere this can read. A sweep that must
+cover both spellings needs two queries today:
+
+```bash
+vibe grep --pattern 'Iterator::map($(a:args))'   lib
+vibe grep --pattern '$(r:exp).map($(a:args))'    lib
+```
 
 **Limitation (v1):** declaration-shaped patterns (`fn …`, top-level `let … =
 …`, `enum …`) are rejected with a message saying so, rather than silently
@@ -191,9 +200,12 @@ Where a capture's type comes from, and what that costs:
   AST, so a bare literal capture (`$(k:const)` bound to `1`) has nothing to
   look its type up *by*. Dropped, not guessed.
 - When the import graph itself fails to check, the file has **no** type table:
-  every `--where` drops, and every match counts as ill-typed. "We could not
-  resolve this" must not read as "it is not an `Array[Int]`", and a program
-  that does not compile must not answer `--only-well-typed`.
+  every `--where` drops — **including `=`** — and every match counts as
+  ill-typed. "We could not resolve this" must not read as "it is not an
+  `Array[Int]`", a program that does not compile must not answer
+  `--only-well-typed`, and a name filter must not silently fall back to the
+  syntactic alias table and call an unvalidated import *resolved*. Pure syntax
+  is what the parse-only tier is for.
 - `--only-ill-typed` is per *declaration*: the checker reports one type error
   per file, and a match counts as ill-typed when it sits in the same top-level
   declaration as that error. An error with no position covers the whole file.
@@ -227,8 +239,11 @@ trailing punctuation and literals are not counted. Use `text`, not `[start,
 end)`, when you need to know what the match was.
 
 A file that does not parse is skipped, not fatal: a repo sweep must not stop at
-the first work-in-progress file. `_build`, `node_modules`, `dist`, `target` and
-dot-directories are never descended into.
+the first work-in-progress file. Recursion skips `_build`, `node_modules`,
+`dist`, `target`, dot-directories, and `deps` (where `vibe fetch` vendors
+packages — and, since relative imports nest, each vendored package's own
+`deps` below that). Naming one of those directly still searches it:
+`vibe grep --pattern '…' deps` asks for exactly that.
 
 ---
 

--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -6,6 +6,7 @@ interactive debugger, both driven by the same `vibe` launcher you installed
 
 - [Language Server (`vibe lsp`)](#language-server-vibe-lsp)
 - [Editor query primitives](#editor-query-primitives)
+- [Structural search (`vibe grep`)](#structural-search-vibe-grep)
 - [Interactive debugging (`vibe run --break` / `--trace`)](#interactive-debugging)
 - [VS Code integration (DAP)](#vs-code-integration)
 - [Keeping the compiler up to date (`vibe self update`)](#keeping-the-compiler-up-to-date)
@@ -97,6 +98,137 @@ vibe diagnostics --json <file.vibe>       # same diagnostics as a JSON array of 
   span in the diagnostic itself — the checker only tracks function names and
   effect rows today, not per-declaration source spans, so `data` doesn't
   pretend otherwise.
+
+---
+
+## Structural search (`vibe grep`)
+
+Every primitive above answers **"position → meaning"**. `vibe grep` runs the
+other way — **"structure → positions"** — and its filters run on the checker's
+answers, not on the grammar alone the way [moongrep](https://github.com/moonbit-community/moongrep)
+and ast-grep do (their guards can only regex an identifier capture). #1572.
+
+```bash
+vibe grep --pattern 'match $(v:exp) { Some($(x:pat)) => $(b:exp), None => $(n:exp) }' lib
+vibe grep --pattern 'Iterator::map($(a:args))' --json lib
+```
+
+### Pattern language
+
+A pattern is a single **expression**, written in ordinary vibe syntax, with
+`$(name:kind)` metavariables:
+
+| kind | matches | capture text |
+| --- | --- | --- |
+| `exp` | any single expression | the printed expression |
+| `id` | an identifier only — also a field / binder / constructor / type NAME where one is grammatical | the name |
+| `const` | a literal only (Int / Double / String / Bool / unit) | the literal |
+| `arg` | one argument position (like `exp`, but also matches a labeled argument `l=e`) | the printed argument |
+| `args` | **zero or more** consecutive argument positions; at most one per list | the arguments, comma-joined |
+| `pat` | any single pattern (match arm / destructuring) | the printed pattern |
+| `type` | any single type expression | the printed type |
+
+`$(_:kind)` is anonymous and never has to agree with another occurrence; any
+other name must match the **same text** everywhere it appears in the pattern.
+
+`args` is an addition to the six kinds #1572 lists. Without it a pattern could
+only ever match one fixed arity, so "every call to this, whatever it is passed"
+— the thing a migration sweep actually needs — would not be expressible.
+
+Matching is on the **AST**, so newlines, indentation and comments cannot affect
+it. Both the pattern and the file go through the *same* parser, which means
+they get the same desugaring. Measured on the current parser:
+
+- `xs |> map(f)` and `map(xs, f)` are the same AST and match each other;
+- `xs.map(f)` keeps its `EDot` callee and matches only the method spelling.
+
+Unifying those call forms is the **resolved-name filter**'s job (below), not
+structural matching's.
+
+**Limitation (v1):** declaration-shaped patterns (`fn …`, top-level `let … =
+…`, `enum …`) are rejected with a message saying so, rather than silently
+matching nothing. Use `vibe symbols` for declarations.
+
+### Type-aware filters
+
+Passing any of these switches the sweep into the **typed tier**, which resolves
+imports through the same walk `vibe check` uses — the `vibe diagnostics`
+import-blind false positives described above are deliberately *not* reproduced
+here. Only files that already have a structural match are typed.
+
+```bash
+# the capture's INFERRED type (`_` is a wildcard inside the type)
+vibe grep --pattern 'f($(x:exp))' --where '$x : Array[_]' lib
+
+# the capture's RESOLVED name — sees through `import ./m.vibe { Iterator as It }`,
+# so `It::map(...)` and `Iterator::map(...)` are one query
+vibe grep --pattern '$(f:id)($(a:args))' --where '$f = Iterator::map' lib
+
+# the capture's effect ROW (a bare effect name also matches its operations)
+vibe grep --pattern '$(f:id)($(a:args))' --where-row '$f with Async' lib
+vibe grep --pattern '$(f:id)($(a:args))' --where-row '$f without Fs' lib
+
+# matches inside declarations that do (or do not) type-check
+vibe grep --pattern 'f($(x:exp))' --only-ill-typed lib
+vibe grep --pattern 'f($(x:exp))' --only-well-typed lib
+```
+
+`--where` and `--where-row` are repeatable and AND together.
+
+Where a capture's type comes from, and what that costs:
+
+- A capture in **callee** position resolves through the final type
+  environment (plus the builtin table, so `Fs::read_file` carries its row).
+  The checker records a call's *result* at the callee's own offset, so
+  reading the offset table there would confidently report the wrong type.
+- Every other capture resolves through the per-offset type table — the same
+  one `vibe type-at` uses.
+- **A callee that is a local or a parameter has no type here** (it is not in
+  the final environment): the filter drops the match rather than guessing.
+  Same boundary `vibe type-at` documents for locals.
+- **A capture containing no identifier-shaped token has no type here either.**
+  Only identifiers, call callees and field names carry source offsets in this
+  AST, so a bare literal capture (`$(k:const)` bound to `1`) has nothing to
+  look its type up *by*. Dropped, not guessed.
+- When the import graph itself fails to check, the file has **no** type table:
+  every `--where` drops, and every match counts as ill-typed. "We could not
+  resolve this" must not read as "it is not an `Array[Int]`", and a program
+  that does not compile must not answer `--only-well-typed`.
+- `--only-ill-typed` is per *declaration*: the checker reports one type error
+  per file, and a match counts as ill-typed when it sits in the same top-level
+  declaration as that error. An error with no position covers the whole file.
+- `CtUnknown` is treated as *no answer*, not as a type. An unresolvable name
+  therefore matches neither `--where-row '$f with E'` nor `'$f without E'`.
+
+### Output
+
+One match per line, fixed field order, greppable — `path:line:col: <matched
+text>` then tab-separated `$var=<capture>`:
+
+```
+lib/@vibe/x/y.vibe:41:11: readit(q)	$f=readit	$x=q
+```
+
+`--json` emits the same matches as a JSON array; each match carries `start` /
+`end` char offsets and per-capture `{text, start}`, plus `type` when the typed
+tier ran. Empty output (`[]` in JSON) means no match, and `vibe grep` exits 0 —
+it is a *report*. Only a bad pattern or a bad filter is an error, and those say
+what to write instead:
+
+```
+$ vibe grep --pattern 'f($(x:expr))' lib
+error: grep pattern: unknown metavariable kind `expr` — use one of exp, id, const, arg, args, pat, type
+```
+
+`text` is the **printer's canonical rendering** of the matched node and is the
+exact, complete description of what matched. `end` is a *lower bound* on the
+source extent: only identifier-shaped tokens carry offsets in this AST, so
+trailing punctuation and literals are not counted. Use `text`, not `[start,
+end)`, when you need to know what the match was.
+
+A file that does not parse is skipped, not fatal: a repo sweep must not stop at
+the first work-in-progress file. `_build`, `node_modules`, `dist`, `target` and
+dot-directories are never descended into.
 
 ---
 

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -23,6 +23,7 @@ import @vibe/compiler/runtime {
   collect_all_diagnostics,
   doc_at_source,
   escape_spans,
+  grep_scan_fs,
   incremental_invalidation_trace_json,
   incremental_typecheck_telemetry_json,
   locate_type_error,
@@ -242,6 +243,28 @@ fn parse_int_or(s: String, default: Int) -> Int {
       default
     }
   }
+}
+
+/// Split a newline-separated env var into its non-empty lines. `vibe grep`
+/// passes repeatable `--where` / `--where-row` clauses this way: a clause can
+/// contain spaces, commas and `:` (they are type syntax), so newline is the
+/// only separator that never needs quoting.
+fn adapter_split_nonempty_lines(text: String) -> Array[String] {
+  let out = Array::slice([
+    ""
+  ], 0, 0)
+  let parts = String::split(text, "\n")
+  let mut i = 0
+  while i < Array::length(parts) {
+    let part = String::trim(Array::get(parts, i))
+    if String::length(part) > 0 {
+      Array::push(out, part)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
 }
 
 fn adapter_string_to_bytes(s: String) -> Bytes {
@@ -1199,6 +1222,22 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       let src = Fs::read_file(input_path)
       let esc = escape_spans(src)
       Fs::write_bytes(output_path, adapter_string_to_bytes(join_escape_spans(esc)))
+      0
+    } with Exception {
+      Throw(msg) => emit_compile_diag(output_path, msg)
+    }
+  }
+  // `vibe grep` (#1572): AST pattern search. `input_path` is the root to sweep
+  // (a file or a directory); the pattern and the filters arrive as env vars so
+  // this keeps the same (input, output) interface every other query mode uses.
+  // A report, not a failure: no match is empty output (`[]` in JSON), and only
+  // a bad PATTERN or filter is an error -- routed to the `.diag` sidecar, the
+  // same convention VIBE_SYMBOLS uses, so `output_path` never carries a
+  // plausible-but-wrong result list.
+  if Env::get("VIBE_GREP") == "1" {
+    return handle {
+      let text = grep_scan_fs(input_path, Env::get("VIBE_GREP_PATTERN"), adapter_split_nonempty_lines(Env::get("VIBE_GREP_WHERE")), adapter_split_nonempty_lines(Env::get("VIBE_GREP_WHERE_ROW")), Env::get("VIBE_GREP_ONLY"), Env::get("VIBE_GREP_JSON") == "1")
+      Fs::write_bytes(output_path, adapter_string_to_bytes(text))
       0
     } with Exception {
       Throw(msg) => emit_compile_diag(output_path, msg)

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -195,6 +195,8 @@ runtime	runtime/binding_at.vibe
 runtime	runtime/doc_at.vibe
 runtime	runtime/symbol_spans.vibe
 runtime	runtime/escape_spans.vibe
+runtime	runtime/grep.vibe
+runtime	runtime/grep_fs.vibe
 runtime	runtime/deprecated_scan.vibe
 runtime	runtime/persistent_env_codec.vibe
 runtime	runtime/module_source.vibe

--- a/lib/@vibe/compiler/runtime/grep.vibe
+++ b/lib/@vibe/compiler/runtime/grep.vibe
@@ -1,0 +1,2085 @@
+//# Imports
+
+// `vibe grep` (#1572) — AST pattern search with TYPE-aware filters.
+//
+// The other editor query primitives (`vibe symbols` / `type-at` / `binding-at`
+// / `escapes`) all answer "position -> meaning". This one runs the other way:
+// "structure -> positions". moongrep / ast-grep stop at the grammar (their
+// guards can only regex an identifier capture); the filters here run on the
+// CHECKER's answers instead — a capture's inferred type, a capture's effect
+// row, the name a capture resolves to after import aliases, and whether the
+// declaration around the match type-checks at all.
+//
+// PATTERN LANGUAGE
+//   `$(name:kind)` is a metavariable, kind one of:
+//     exp    any single expression
+//     id     an identifier only (also matches a FIELD / binder / constructor /
+//            type NAME where one is grammatical) — captures the name text
+//     const  a literal only (Int / Double / String / Bool / unit)
+//     arg    one argument position (like `exp`, but also matches a LABELED
+//            argument `name=expr`, which `exp` does not)
+//     args   ZERO OR MORE consecutive argument positions (the variadic form;
+//            at most one per argument list)
+//     pat    any single pattern (match-arm / destructuring position)
+//     type   any single type expression
+//   `$(_:kind)` is anonymous: it never has to agree with another occurrence.
+//   Any other name must match the SAME text everywhere it appears.
+//
+//   `args` is an addition to the six kinds #1572 lists. Without it a pattern
+//   can only match a fixed arity, so `Iterator::map($(a:args))` — "every call
+//   to this, whatever it is passed" — would not be expressible at all, which
+//   is the single most common thing a migration sweep needs.
+//
+// HOW A PATTERN IS PARSED (design point 1 in #1572)
+//   `$(` is not lexable today, so the spelling cannot collide with real
+//   source. Each metavariable is rewritten to a reserved identifier
+//   (`__vgm_<kind>__<name>`) and the result goes through the ORDINARY parser
+//   — this is AST matching, never a text regex, and formatting differences
+//   (newlines, indentation, comments) cannot affect it.
+//
+//   Both sides go through the SAME parser, so both sides get the same
+//   desugaring. Measured on the current parser: `xs |> f(y)` and `f(xs, y)`
+//   both parse to `f(xs, y)` and therefore match each other, while `x.f(y)`
+//   stays an `EDot` callee and matches only the method spelling. That is the
+//   honest description of today's behaviour — #1572's design point 1 wants
+//   surface fidelity for structure and leaves call-form unification to the
+//   resolved-name filter, and the pipe case is the one place the parser
+//   already decided otherwise.
+//
+// LIMITATION (v1): a pattern must be a single EXPRESSION. Declaration-shaped
+// patterns (`fn ...`, `let ... = ...` at statement level, `enum ...`) are
+// rejected with an actionable message rather than silently matching nothing.
+//
+// All strings are built with String::concat only (never `+`, never "\{x}"
+// interpolation): both mis-codegen to NUL here. Ints stringify via
+// __to_string.
+
+import @vibe/compiler/core {
+  Expr, Pat, Stmt, Subst, Type, TypeDef, TypeEnv, TypeExpr, collect_import_aliases, env_lookup, expr_children, subst_apply, type_to_string
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/checker {
+  check_program_with_env_result, lookup_builtin, resolve_type_expr
+}
+
+import @vibe/compiler/syntax {
+  lex,
+  lex_with_offsets,
+  offset_to_line_col,
+  parse_program,
+  parse_program_located,
+  parse_program_spans,
+  parse_type,
+  print_expr,
+  print_pat,
+  print_type_expr
+}
+
+//# Types
+
+/// One structural match. `offset`/`end_offset` are char offsets; `end_offset`
+/// is a LOWER BOUND on the true extent (see grep_expr_span: only identifier-
+/// shaped tokens carry offsets in this AST, so trailing punctuation and
+/// literals are not counted). `text` is the printer's canonical rendering of
+/// the matched node and is the exact, complete description of what matched.
+export struct GrepHit {
+  path: String;
+  offset: Int;
+  end_offset: Int;
+  text: String;
+  captures: Array[(String, String, Int, Bool)]
+}
+
+/// A compiled pattern: the parsed template plus the metavariable names it
+/// declares, in source order (so `--where` can reject a name the pattern
+/// never captures instead of silently filtering nothing out).
+export struct GrepPattern {
+  template: Expr;
+  vars: Array[String]
+}
+
+/// Everything the typed filters need about ONE file. `type_error` is "" when
+/// the file checks cleanly; otherwise it is the checker's raw message, and
+/// `type_error_offset` is the source offset its own ` [@off=N]` marker points
+/// at (-1 when it carries none). Reading the marker directly is both simpler
+/// and more precise than re-parsing a rendered `line L:C:` prefix back into an
+/// offset.
+export struct GrepTyped {
+  tytab: Array[(Int, Type)];
+  /// Added to a hit's offset before it is looked up in `tytab` / compared
+  /// with `stmt_lo`/`stmt_hi`. Matching runs on the file as written (so
+  /// `line:col` names a real position in it), while typing runs on the
+  /// INGESTED source the loader hands the checker, which may carry a prepended
+  /// directory-shared import. That prefix is the whole difference, so one
+  /// delta translates between the two.
+  offset_delta: Int;
+  env: TypeEnv;
+  subst: Subst;
+  defs: Array[TypeDef];
+  aliases: Array[(String, String)];
+  type_error: String;
+  type_error_offset: Int;
+  stmt_lo: Array[Int];
+  stmt_hi: Array[Int]
+}
+
+//# Functions
+
+export fn grep_empty_hits() -> Array[GrepHit] {
+  array_empty()
+}
+
+fn grep_empty_binds() -> Array[(String, String, Int, Bool)] {
+  array_empty()
+}
+
+fn grep_empty_ints() -> Array[Int] {
+  array_empty()
+}
+
+export fn grep_empty_strings() -> Array[String] {
+  array_empty()
+}
+
+fn grep_empty_tytab() -> Array[(Int, Type)] {
+  array_empty()
+}
+
+fn grep_empty_defs() -> Array[TypeDef] {
+  array_empty()
+}
+
+fn grep_empty_pairs() -> Array[(String, String)] {
+  array_empty()
+}
+
+/// True for the characters a metavariable NAME and a metavariable KIND may
+/// use. Deliberately narrow: everything else in `$(...)` is a spelling
+/// mistake we want to report, not guess at.
+fn grep_is_meta_char(c: Int) -> Bool {
+  (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+fn grep_is_ident_char(c: Int) -> Bool {
+  grep_is_meta_char(c)
+}
+
+/// The reserved identifier a metavariable becomes. `kind` never contains `_`,
+/// so the `__` after it is an unambiguous separator no matter what the user
+/// named the variable.
+fn grep_mangle(kind: String, name: String) -> String {
+  String::concat("__vgm_", String::concat(kind, String::concat("__", name)))
+}
+
+fn grep_kind_is_known(kind: String) -> Bool {
+  kind == "exp" || kind == "id" || kind == "const" || kind == "arg" || kind == "args" || kind == "pat" || kind == "type"
+}
+
+/// Decode a reserved identifier back to `(kind, name)`, or `("", "")` when the
+/// identifier is an ordinary one. Kinds contain no `_`, so the separator is
+/// the first `__` at or after the prefix.
+fn grep_meta_of(ident: String) -> (String, String) {
+  if !String::starts_with(ident, "__vgm_") {
+    ("", "")
+  } else {
+    let len = String::length(ident)
+    let mut i = 6
+    let mut sep = -1
+    while sep < 0 && i + 1 < len {
+      if String::char_code_at(ident, i) == '_' && String::char_code_at(ident, i + 1) == '_' {
+        sep = i
+      } else {
+        i = i + 1
+      }
+    }
+    if sep < 0 {
+      ("", "")
+    } else {
+      let kind = String::substring(ident, 6, sep)
+      let name = String::substring(ident, sep + 2, len)
+      if grep_kind_is_known(kind) {
+        (kind, name)
+      } else {
+        ("", "")
+      }
+    }
+  }
+}
+
+/// Rewrite every `$(name:kind)` in `pattern` to its reserved identifier, and
+/// collect the declared variable names in source order.
+///
+/// String literals are skipped verbatim so a pattern can look for a literal
+/// that happens to contain `$(`. A `$` that does not begin a well-formed
+/// metavariable is an ERROR, not a literal `$`: `$` is not lexable in vibe
+/// source, so leaving it in place could only ever produce a confusing lexer
+/// message pointing at the rewritten text rather than at what was typed.
+fn grep_expand_metavars(pattern: String, vars: Array[String]) -> String with Exception {
+  let len = String::length(pattern)
+  let mut out = ""
+  let mut i = 0
+  while i < len {
+    let c = String::char_code_at(pattern, i)
+    if c == '"' {
+      // Copy the whole string literal, honouring backslash escapes.
+      let start = i
+      let mut j = i + 1
+      let mut closed = false
+      while !closed && j < len {
+        let d = String::char_code_at(pattern, j)
+        if d == 92 {
+          j = j + 2
+        } else if d == '"' {
+          closed = true
+          j = j + 1
+        } else {
+          j = j + 1
+        }
+      }
+      out = String::concat(out, String::substring(pattern, start, j))
+      i = j
+    } else if c == '$' {
+      if i + 1 >= len || String::char_code_at(pattern, i + 1) != '(' {
+        throw("grep pattern: `$` must start a metavariable `$(name:kind)`")
+      } else {
+        let mut j = i + 2
+        while j < len && grep_is_meta_char(String::char_code_at(pattern, j)) {
+          j = j + 1
+        }
+        let name = String::substring(pattern, i + 2, j)
+        if String::length(name) == 0 || j >= len || String::char_code_at(pattern, j) != ':' {
+          throw("grep pattern: expected `$(name:kind)`, e.g. `$(x:exp)`")
+        } else {
+          let kstart = j + 1
+          let mut k = kstart
+          while k < len && grep_is_meta_char(String::char_code_at(pattern, k)) {
+            k = k + 1
+          }
+          let kind = String::substring(pattern, kstart, k)
+          if k >= len || String::char_code_at(pattern, k) != ')' {
+            throw("grep pattern: unterminated metavariable — expected `)` after `$(name:kind)`")
+          } else if !grep_kind_is_known(kind) {
+            throw(String::concat("grep pattern: unknown metavariable kind `", String::concat(kind, "` — use one of exp, id, const, arg, args, pat, type")))
+          } else {
+            out = String::concat(out, grep_mangle(kind, name))
+            if name != "_" {
+              Array::push(vars, name)
+            } else {
+              ()
+            }
+            i = k + 1
+          }
+        }
+      }
+    } else {
+      out = String::concat(out, String::substring(pattern, i, i + 1))
+      i = i + 1
+    }
+  }
+  out
+}
+
+/// Reject a pattern with two variadic holes in one list BEFORE any file is
+/// searched. Resolving `f($(a:args), $(b:args))` would need a rule for where
+/// to split that nobody wrote down, and diagnosing it only when a call happens
+/// to be encountered would make the error depend on which files were scanned.
+fn grep_validate_holes(e: Expr) -> Unit with Exception {
+  match e {
+    ECall(_, args, _) => grep_check_holes(args),
+    ETuple(items) => grep_check_holes(items),
+    EArray(items) => grep_check_holes(items),
+    EContinue(args) => grep_check_holes(args),
+    _ => ()
+  }
+  let kids = expr_children(e)
+  let mut i = 0
+  while i < Array::length(kids) {
+    grep_validate_holes(Array::get(kids, i))
+    i = i + 1
+  }
+}
+
+fn grep_check_holes(items: Array[Expr]) -> Unit with Exception {
+  if grep_args_hole(items) == -2 {
+    throw("grep pattern: at most one `args` metavariable per argument list")
+  } else {
+    ()
+  }
+}
+
+/// Parse a pattern into its template expression. A pattern that parses to
+/// anything other than exactly one expression statement is rejected here with
+/// the shape it actually produced, rather than being matched against nothing.
+export fn grep_compile_pattern(pattern: String) -> GrepPattern with Exception {
+  let vars = grep_empty_strings()
+  let expanded = grep_expand_metavars(pattern, vars)
+  // Prefix a lex/parse failure so the reader can tell "your PATTERN does not
+  // parse" from "the file being searched does not parse" -- the two arrive on
+  // the same channel and are otherwise indistinguishable.
+  let stmts = handle {
+    parse_program(lex(expanded))
+  } with Exception {
+    Throw(msg) => throw(String::concat("grep pattern: ", msg))
+  }
+  if Array::length(stmts) == 0 {
+    throw("grep pattern: empty pattern")
+  } else if Array::length(stmts) > 1 {
+    throw("grep pattern: expected ONE expression; got several statements")
+  } else {
+    match Array::get(stmts, 0) {
+      SExpr(e) => {
+        grep_validate_holes(e)
+        GrepPattern::{
+          template: e, vars: vars
+        }
+      },
+      _ => throw("grep pattern: must be a single EXPRESSION — declaration patterns (`fn`, top-level `let`, `enum`, ...) are not supported yet; use `vibe symbols` for declarations")
+    }
+  }
+}
+
+//# Functions — span recovery
+
+/// Accumulate `[min located offset, max located end)` for `e` into `acc`
+/// (a two-cell box). Only identifier-shaped tokens carry offsets in this AST,
+/// so the result is exact at the start and a LOWER BOUND at the end.
+fn grep_note_span(acc: Array[Int], off: Int, len: Int) -> Unit {
+  if off < 0 {
+    ()
+  } else {
+    if Array::get(acc, 0) < 0 || off < Array::get(acc, 0) {
+      Array::set(acc, 0, off)
+    } else {
+      ()
+    }
+    if off + len > Array::get(acc, 1) {
+      Array::set(acc, 1, off + len)
+    } else {
+      ()
+    }
+  }
+}
+
+fn grep_span_exprs(items: Array[Expr], acc: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(items) {
+    grep_span_expr(Array::get(items, i), acc)
+    i = i + 1
+  }
+}
+
+fn grep_span_fields(fields: Array[(String, Expr)], acc: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(fields) {
+    let (_, v) = Array::get(fields, i)
+    grep_span_expr(v, acc)
+    i = i + 1
+  }
+}
+
+fn grep_span_arms(arms: Array[(Pat, Expr)], acc: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (_, v) = Array::get(arms, i)
+    grep_span_expr(v, acc)
+    i = i + 1
+  }
+}
+
+fn grep_span_expr(e: Expr, acc: Array[Int]) -> Unit {
+  match e {
+    EInt(_) => (),
+    EFloat(_) => (),
+    EString(_) => (),
+    EBool(_) => (),
+    EUnit => (),
+    EStringInterp(_) => (),
+    EIdent(name, off) => grep_note_span(acc, off, String::length(name)),
+    ETuple(items) => grep_span_exprs(items, acc),
+    EArray(items) => grep_span_exprs(items, acc),
+    ERecord(_, fields, _) => grep_span_fields(fields, acc),
+    EMap(fields) => grep_span_fields(fields, acc),
+    EIf(c, t, f) => {
+      grep_span_expr(c, acc)
+      grep_span_expr(t, acc)
+      grep_span_expr(f, acc)
+    },
+    ELet(name, v, b, off) => {
+      grep_note_span(acc, off, String::length(name))
+      grep_span_expr(v, acc)
+      grep_span_expr(b, acc)
+    },
+    ELetRec(_, v, b) => {
+      grep_span_expr(v, acc)
+      grep_span_expr(b, acc)
+    },
+    ELetMut(name, v, b, off) => {
+      grep_note_span(acc, off, String::length(name))
+      grep_span_expr(v, acc)
+      grep_span_expr(b, acc)
+    },
+    EAssign(_, v, b) => {
+      grep_span_expr(v, acc)
+      grep_span_expr(b, acc)
+    },
+    EAssignOp(_, _, v, b) => {
+      grep_span_expr(v, acc)
+      grep_span_expr(b, acc)
+    },
+    ESeq(a, b) => {
+      grep_span_expr(a, acc)
+      grep_span_expr(b, acc)
+    },
+    EMatch(s, arms) => {
+      grep_span_expr(s, acc)
+      grep_span_arms(arms, acc)
+    },
+    EHandle(s, arms) => {
+      grep_span_expr(s, acc)
+      grep_span_arms(arms, acc)
+    },
+    EWhile(c, b) => {
+      grep_span_expr(c, acc)
+      grep_span_expr(b, acc)
+    },
+    ELoop(params, b) => {
+      grep_span_fields(params, acc)
+      grep_span_expr(b, acc)
+    },
+    EForIn(_, _, it, b) => {
+      grep_span_expr(it, acc)
+      grep_span_expr(b, acc)
+    },
+    ECall(callee, args, off) => {
+      grep_note_span(acc, off, 0)
+      grep_span_expr(callee, acc)
+      grep_span_exprs(args, acc)
+    },
+    EBinOp(_, l, r) => {
+      grep_span_expr(l, acc)
+      grep_span_expr(r, acc)
+    },
+    EUnaryOp(_, v) => grep_span_expr(v, acc),
+    EFn(_, _, _, _, _, body) => grep_span_expr(body, acc),
+    EDot(inner, field, off, field_off) => {
+      grep_note_span(acc, off, 0)
+      grep_note_span(acc, field_off, String::length(field))
+      grep_span_expr(inner, acc)
+    },
+    ELabeledArg(_, _, v) => grep_span_expr(v, acc),
+    EReturn(v) => grep_span_expr(v, acc),
+    EBreak(opt) => match opt {
+      Some(v) => grep_span_expr(v, acc),
+      None => ()
+    },
+    EContinue(args) => grep_span_exprs(args, acc),
+    ESpread(v) => grep_span_expr(v, acc)
+  }
+}
+
+/// `(start, end)` for `e`, both -1 when nothing inside it carries an offset
+/// (a fully synthetic subtree — string interpolation parts, desugared sugar).
+fn grep_expr_span(e: Expr) -> (Int, Int) {
+  let acc = grep_empty_ints()
+  Array::push(acc, -1)
+  Array::push(acc, -1)
+  grep_span_expr(e, acc)
+  (Array::get(acc, 0), Array::get(acc, 1))
+}
+
+//# Functions — matching
+
+/// Record `name := (text, offset)`. An anonymous `_` capture is never
+/// recorded and never has to agree. A repeated name must describe the same
+/// text as its first occurrence.
+fn grep_bind(binds: Array[(String, String, Int, Bool)], name: String, text: String, off: Int, is_callee: Bool) -> Bool {
+  if name == "_" {
+    true
+  } else {
+    let mut i = 0
+    let mut seen = false
+    let mut ok = true
+    while i < Array::length(binds) && !seen {
+      let (n, t, _, _) = Array::get(binds, i)
+      if n == name {
+        seen = true
+        ok = t == text
+      } else {
+        i = i + 1
+      }
+    }
+    if seen {
+      ok
+    } else {
+      Array::push(binds, (name, text, off, is_callee))
+      true
+    }
+  }
+}
+
+/// True when a literal-only (`const`) metavariable may take `e`.
+fn grep_is_const_expr(e: Expr) -> Bool {
+  match e {
+    EInt(_) => true,
+    EFloat(_) => true,
+    EString(_) => true,
+    EBool(_) => true,
+    EUnit => true,
+    _ => false
+  }
+}
+
+/// Bind one expression-position metavariable, or fail because its kind does
+/// not admit `t`.
+fn grep_meta_match_expr(kind: String, name: String, t: Expr, binds: Array[(String, String, Int, Bool)], is_callee: Bool) -> Bool {
+  let admits = if kind == "exp" {
+    // A labeled argument is an argument, not an expression: `arg` is the kind
+    // that takes one. Accepting it here too would make the two kinds exact
+    // synonyms.
+    match t {
+      ELabeledArg(_, _, _) => false,
+      _ => true
+    }
+  } else if kind == "arg" {
+    true
+  } else if kind == "const" {
+    grep_is_const_expr(t)
+  } else if kind == "id" {
+    match t {
+      EIdent(_, _) => true,
+      _ => false
+    }
+  } else {
+    // `args` only means anything inside an argument list (handled by
+    // grep_match_exprs); `pat` / `type` are not expression kinds.
+    false
+  }
+  if !admits {
+    false
+  } else {
+    let (off, _) = grep_expr_span(t)
+    let text = match t {
+      EIdent(n, _) => n,
+      _ => print_expr(t)
+    }
+    grep_bind(binds, name, text, off, is_callee)
+  }
+}
+
+/// Match a NAME slot (a field name, a binder, a constructor, a type name) that
+/// the AST stores as a bare String. Only the `id` kind is meaningful there.
+fn grep_match_name(pname: String, tname: String, binds: Array[(String, String, Int, Bool)]) -> Bool {
+  let (kind, var) = grep_meta_of(pname)
+  if kind == "" {
+    pname == tname
+  } else if kind == "id" {
+    grep_bind(binds, var, tname, -1, false)
+  } else {
+    false
+  }
+}
+
+/// The index of the single `args` metavariable in a pattern argument list, or
+/// -1. A second one is rejected by the caller: two variadic holes in one list
+/// have no unambiguous split, and silently picking one would make the result
+/// depend on an unwritten rule.
+fn grep_args_hole(ps: Array[Expr]) -> Int {
+  let mut i = 0
+  let mut found = -1
+  let mut extra = false
+  while i < Array::length(ps) {
+    match Array::get(ps, i) {
+      EIdent(pn, _) => {
+        let (kind, _) = grep_meta_of(pn)
+        if kind == "args" {
+          if found >= 0 {
+            extra = true
+          } else {
+            found = i
+          }
+        } else {
+          ()
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  if extra {
+    -2
+  } else {
+    found
+  }
+}
+
+/// Render a run of captured arguments the way the source spells an argument
+/// list, so an `args` capture reads back as something you could paste.
+fn grep_join_args(ts: Array[Expr], lo: Int, hi: Int) -> String {
+  let mut out = ""
+  let mut i = lo
+  while i < hi {
+    let piece = print_expr(Array::get(ts, i))
+    out = if i == lo {
+      piece
+    } else {
+      String::concat(out, String::concat(", ", piece))
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// Match two expression lists. With no `args` hole this is positional; with
+/// one, the elements before it match from the front, the elements after it
+/// match from the back, and the hole takes everything left over.
+fn grep_match_exprs(ps: Array[Expr], ts: Array[Expr], binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  let hole = grep_args_hole(ps)
+  if hole == -2 {
+    throw("grep pattern: at most one `args` metavariable per argument list")
+  } else if hole < 0 {
+    if Array::length(ps) != Array::length(ts) {
+      false
+    } else {
+      let mut i = 0
+      let mut ok = true
+      while ok && i < Array::length(ps) {
+        ok = grep_match_expr(Array::get(ps, i), Array::get(ts, i), binds)
+        i = i + 1
+      }
+      ok
+    }
+  } else {
+    let after = Array::length(ps) - hole - 1
+    if Array::length(ts) < hole + after {
+      false
+    } else {
+      let mut ok = true
+      let mut i = 0
+      while ok && i < hole {
+        ok = grep_match_expr(Array::get(ps, i), Array::get(ts, i), binds)
+        i = i + 1
+      }
+      let tail_lo = Array::length(ts) - after
+      let mut j = 0
+      while ok && j < after {
+        ok = grep_match_expr(Array::get(ps, hole + 1 + j), Array::get(ts, tail_lo + j), binds)
+        j = j + 1
+      }
+      if !ok {
+        false
+      } else {
+        match Array::get(ps, hole) {
+          EIdent(pn, _) => {
+            let (_, var) = grep_meta_of(pn)
+            let off = if hole < tail_lo {
+              let (o, _) = grep_expr_span(Array::get(ts, hole))
+              o
+            } else {
+              -1
+            }
+            grep_bind(binds, var, grep_join_args(ts, hole, tail_lo), off, false)
+          },
+          _ => false
+        }
+      }
+    }
+  }
+}
+
+fn grep_match_fields(ps: Array[(String, Expr)], ts: Array[(String, Expr)], binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  if Array::length(ps) != Array::length(ts) {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < Array::length(ps) {
+      let (pn, pv) = Array::get(ps, i)
+      let (tn, tv) = Array::get(ts, i)
+      ok = grep_match_name(pn, tn, binds) && grep_match_expr(pv, tv, binds)
+      i = i + 1
+    }
+    ok
+  }
+}
+
+fn grep_match_arms(ps: Array[(Pat, Expr)], ts: Array[(Pat, Expr)], binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  if Array::length(ps) != Array::length(ts) {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < Array::length(ps) {
+      let (pp, pe) = Array::get(ps, i)
+      let (tp, te) = Array::get(ts, i)
+      ok = grep_match_pat(pp, tp, binds) && grep_match_expr(pe, te, binds)
+      i = i + 1
+    }
+    ok
+  }
+}
+
+fn grep_match_pats(ps: Array[Pat], ts: Array[Pat], binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  if Array::length(ps) != Array::length(ts) {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < Array::length(ps) {
+      ok = grep_match_pat(Array::get(ps, i), Array::get(ts, i), binds)
+      i = i + 1
+    }
+    ok
+  }
+}
+
+fn grep_match_pat_fields(ps: Array[(String, Pat)], ts: Array[(String, Pat)], binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  if Array::length(ps) != Array::length(ts) {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < Array::length(ps) {
+      let (pn, pv) = Array::get(ps, i)
+      let (tn, tv) = Array::get(ts, i)
+      ok = grep_match_name(pn, tn, binds) && grep_match_pat(pv, tv, binds)
+      i = i + 1
+    }
+    ok
+  }
+}
+
+fn grep_match_pat(p: Pat, t: Pat, binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  match p {
+    PBind(pn) => {
+      let (kind, var) = grep_meta_of(pn)
+      if kind == "pat" {
+        grep_bind(binds, var, print_pat(t), -1, false)
+      } else if kind == "id" {
+        match t {
+          PBind(tn) => grep_bind(binds, var, tn, -1, false),
+          _ => false
+        }
+      } else if kind != "" {
+        false
+      } else {
+        match t {
+          PBind(tn) => tn == pn,
+          _ => false
+        }
+      }
+    },
+    PWild => match t {
+      PWild => true,
+      _ => false
+    },
+    PInt(pv) => match t {
+      PInt(tv) => pv == tv,
+      _ => false
+    },
+    PFloat(pv) => match t {
+      PFloat(tv) => pv == tv,
+      _ => false
+    },
+    PString(pv) => match t {
+      PString(tv) => pv == tv,
+      _ => false
+    },
+    PBool(pv) => match t {
+      PBool(tv) => pv == tv,
+      _ => false
+    },
+    PCtor(pn, pargs) => match t {
+      PCtor(tn, targs) => grep_match_name(pn, tn, binds) && grep_match_pats(pargs, targs, binds),
+      _ => false
+    },
+    PTuple(pitems) => match t {
+      PTuple(titems) => grep_match_pats(pitems, titems, binds),
+      _ => false
+    },
+    POr(pa, pb) => match t {
+      POr(ta, tb) => grep_match_pat(pa, ta, binds) && grep_match_pat(pb, tb, binds),
+      _ => false
+    },
+    PStruct(pn, pfields) => match t {
+      PStruct(tn, tfields) => grep_match_name(pn, tn, binds) && grep_match_pat_fields(pfields, tfields, binds),
+      _ => false
+    }
+  }
+}
+
+fn grep_match_types(ps: Array[TypeExpr], ts: Array[TypeExpr], binds: Array[(String, String, Int, Bool)]) -> Bool {
+  if Array::length(ps) != Array::length(ts) {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < Array::length(ps) {
+      ok = grep_match_type(Array::get(ps, i), Array::get(ts, i), binds)
+      i = i + 1
+    }
+    ok
+  }
+}
+
+fn grep_match_type(p: TypeExpr, t: TypeExpr, binds: Array[(String, String, Int, Bool)]) -> Bool {
+  match p {
+    TyName(pn) => {
+      let (kind, var) = grep_meta_of(pn)
+      if kind == "type" {
+        grep_bind(binds, var, print_type_expr(t), -1, false)
+      } else if kind == "id" {
+        match t {
+          TyName(tn) => grep_bind(binds, var, tn, -1, false),
+          _ => false
+        }
+      } else if kind != "" {
+        false
+      } else {
+        match t {
+          TyName(tn) => tn == pn,
+          _ => false
+        }
+      }
+    },
+    TyApp(pn, pargs) => match t {
+      TyApp(tn, targs) => grep_match_name(pn, tn, binds) && grep_match_types(pargs, targs, binds),
+      _ => false
+    },
+    TyFn(pparams, pret, prow) => match t {
+      TyFn(tparams, tret, trow) => grep_match_types(pparams, tparams, binds) && grep_match_type(pret, tret, binds) && grep_match_opt_row(prow, trow),
+      _ => false
+    },
+    TyTuple(pitems) => match t {
+      TyTuple(titems) => grep_match_types(pitems, titems, binds),
+      _ => false
+    },
+    TyUnit => match t {
+      TyUnit => true,
+      _ => false
+    }
+  }
+}
+
+fn grep_match_opt_row(p: Option[String], t: Option[String]) -> Bool {
+  match p {
+    None => match t {
+      None => true,
+      _ => false
+    },
+    Some(pr) => match t {
+      Some(tr) => pr == tr,
+      None => false
+    }
+  }
+}
+
+fn grep_match_opt_type(p: Option[TypeExpr], t: Option[TypeExpr], binds: Array[(String, String, Int, Bool)]) -> Bool {
+  match p {
+    None => match t {
+      None => true,
+      _ => false
+    },
+    Some(pt) => match t {
+      Some(tt) => grep_match_type(pt, tt, binds),
+      None => false
+    }
+  }
+}
+
+fn grep_match_opt_name(p: Option[String], t: Option[String], binds: Array[(String, String, Int, Bool)]) -> Bool {
+  match p {
+    None => match t {
+      None => true,
+      _ => false
+    },
+    Some(pn) => match t {
+      Some(tn) => grep_match_name(pn, tn, binds),
+      None => false
+    }
+  }
+}
+
+fn grep_match_opt_expr(p: Option[Expr], t: Option[Expr], binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  match p {
+    None => match t {
+      None => true,
+      _ => false
+    },
+    Some(pe) => match t {
+      Some(te) => grep_match_expr(pe, te, binds),
+      None => false
+    }
+  }
+}
+
+fn grep_match_strings(ps: Array[String], ts: Array[String]) -> Bool {
+  if Array::length(ps) != Array::length(ts) {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < Array::length(ps) {
+      ok = Array::get(ps, i) == Array::get(ts, i)
+      i = i + 1
+    }
+    ok
+  }
+}
+
+fn grep_match_params(ps: Array[(String, Option[TypeExpr])], ts: Array[(String, Option[TypeExpr])], binds: Array[(String, String, Int, Bool)]) -> Bool {
+  if Array::length(ps) != Array::length(ts) {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < Array::length(ps) {
+      let (pn, pt) = Array::get(ps, i)
+      let (tn, tt) = Array::get(ts, i)
+      ok = grep_match_name(pn, tn, binds) && grep_match_opt_type(pt, tt, binds)
+      i = i + 1
+    }
+    ok
+  }
+}
+
+fn grep_match_loop_params(ps: Array[(String, Expr)], ts: Array[(String, Expr)], binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  grep_match_fields(ps, ts, binds)
+}
+
+/// Match the CALLEE slot of a call. Identical to grep_match_expr except that a
+/// metavariable bound here is flagged as a callee — the checker records a
+/// call's RESULT type at the callee's own offset, so a callee capture's type
+/// has to come from the environment instead of from the offset table
+/// (grep_capture_type).
+fn grep_match_callee(p: Expr, t: Expr, binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  match p {
+    EIdent(pn, _) => {
+      let (kind, var) = grep_meta_of(pn)
+      if kind != "" {
+        grep_meta_match_expr(kind, var, t, binds, true)
+      } else {
+        match t {
+          EIdent(tn, _) => tn == pn,
+          _ => false
+        }
+      }
+    },
+    _ => grep_match_expr(p, t, binds)
+  }
+}
+
+/// Structural match of one pattern node against one target node. Every offset
+/// slot is ignored: the pattern text and the file text never share positions.
+fn grep_match_expr(p: Expr, t: Expr, binds: Array[(String, String, Int, Bool)]) -> Bool with Exception {
+  match p {
+    EIdent(pn, _) => {
+      let (kind, var) = grep_meta_of(pn)
+      if kind != "" {
+        grep_meta_match_expr(kind, var, t, binds, false)
+      } else {
+        match t {
+          EIdent(tn, _) => tn == pn,
+          _ => false
+        }
+      }
+    },
+    EInt(pv) => match t {
+      EInt(tv) => pv == tv,
+      _ => false
+    },
+    EFloat(pv) => match t {
+      EFloat(tv) => pv == tv,
+      _ => false
+    },
+    EString(pv) => match t {
+      EString(tv) => pv == tv,
+      _ => false
+    },
+    EBool(pv) => match t {
+      EBool(tv) => pv == tv,
+      _ => false
+    },
+    EUnit => match t {
+      EUnit => true,
+      _ => false
+    },
+    EStringInterp(pparts) => match t {
+      EStringInterp(tparts) => grep_match_strings(pparts, tparts),
+      _ => false
+    },
+    ETuple(pitems) => match t {
+      ETuple(titems) => grep_match_exprs(pitems, titems, binds),
+      _ => false
+    },
+    EArray(pitems) => match t {
+      EArray(titems) => grep_match_exprs(pitems, titems, binds),
+      _ => false
+    },
+    ERecord(pn, pfields, ptys) => match t {
+      ERecord(tn, tfields, ttys) => grep_match_name(pn, tn, binds) && grep_match_types(ptys, ttys, binds) && grep_match_fields(pfields, tfields, binds),
+      _ => false
+    },
+    EMap(pfields) => match t {
+      EMap(tfields) => grep_match_fields(pfields, tfields, binds),
+      _ => false
+    },
+    EIf(pc, pt, pf) => match t {
+      EIf(tc, tt, tf) => grep_match_expr(pc, tc, binds) && grep_match_expr(pt, tt, binds) && grep_match_expr(pf, tf, binds),
+      _ => false
+    },
+    ELet(pn, pv, pb, _) => match t {
+      ELet(tn, tv, tb, _) => grep_match_name(pn, tn, binds) && grep_match_expr(pv, tv, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    ELetRec(pn, pv, pb) => match t {
+      ELetRec(tn, tv, tb) => grep_match_name(pn, tn, binds) && grep_match_expr(pv, tv, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    ELetMut(pn, pv, pb, _) => match t {
+      ELetMut(tn, tv, tb, _) => grep_match_name(pn, tn, binds) && grep_match_expr(pv, tv, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    EAssign(pn, pv, pb) => match t {
+      EAssign(tn, tv, tb) => grep_match_name(pn, tn, binds) && grep_match_expr(pv, tv, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    EAssignOp(pop, pn, pv, pb) => match t {
+      EAssignOp(top, tn, tv, tb) => pop == top && grep_match_name(pn, tn, binds) && grep_match_expr(pv, tv, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    ESeq(pa, pb) => match t {
+      ESeq(ta, tb) => grep_match_expr(pa, ta, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    EMatch(ps, parms) => match t {
+      EMatch(ts, tarms) => grep_match_expr(ps, ts, binds) && grep_match_arms(parms, tarms, binds),
+      _ => false
+    },
+    EHandle(ps, parms) => match t {
+      EHandle(ts, tarms) => grep_match_expr(ps, ts, binds) && grep_match_arms(parms, tarms, binds),
+      _ => false
+    },
+    EWhile(pc, pb) => match t {
+      EWhile(tc, tb) => grep_match_expr(pc, tc, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    ELoop(pparams, pb) => match t {
+      ELoop(tparams, tb) => grep_match_loop_params(pparams, tparams, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    EForIn(pv, pk, pit, pb) => match t {
+      EForIn(tv, tk, tit, tb) => grep_match_name(pv, tv, binds) && grep_match_opt_name(pk, tk, binds) && grep_match_expr(pit, tit, binds) && grep_match_expr(pb, tb, binds),
+      _ => false
+    },
+    ECall(pcallee, pargs, _) => match t {
+      ECall(tcallee, targs, _) => grep_match_callee(pcallee, tcallee, binds) && grep_match_exprs(pargs, targs, binds),
+      _ => false
+    },
+    EBinOp(pop, pl, pr) => match t {
+      EBinOp(top, tl, tr) => pop == top && grep_match_expr(pl, tl, binds) && grep_match_expr(pr, tr, binds),
+      _ => false
+    },
+    EUnaryOp(pop, pv) => match t {
+      EUnaryOp(top, tv) => pop == top && grep_match_expr(pv, tv, binds),
+      _ => false
+    },
+    EFn(pgens, pbounds, pparams, pret, prow, pbody) => match t {
+      EFn(tgens, tbounds, tparams, tret, trow, tbody) => grep_match_strings(pgens, tgens) && Array::length(pbounds) == Array::length(tbounds) && grep_match_params(pparams, tparams, binds) && grep_match_opt_type(pret, tret, binds) && grep_match_opt_row(prow, trow) && grep_match_expr(pbody, tbody, binds),
+      _ => false
+    },
+    EDot(pinner, pfield, _, _) => match t {
+      EDot(tinner, tfield, _, _) => grep_match_name(pfield, tfield, binds) && grep_match_expr(pinner, tinner, binds),
+      _ => false
+    },
+    ELabeledArg(plabel, psuffix, pv) => match t {
+      ELabeledArg(tlabel, tsuffix, tv) => grep_match_name(plabel, tlabel, binds) && psuffix == tsuffix && grep_match_expr(pv, tv, binds),
+      _ => false
+    },
+    EReturn(pv) => match t {
+      EReturn(tv) => grep_match_expr(pv, tv, binds),
+      _ => false
+    },
+    EBreak(pv) => match t {
+      EBreak(tv) => grep_match_opt_expr(pv, tv, binds),
+      _ => false
+    },
+    EContinue(pargs) => match t {
+      EContinue(targs) => grep_match_exprs(pargs, targs, binds),
+      _ => false
+    },
+    ESpread(pv) => match t {
+      ESpread(tv) => grep_match_expr(pv, tv, binds),
+      _ => false
+    }
+  }
+}
+
+//# Functions — walking a target file
+
+/// `text` for a hit, flattened to one line: the output contract is one match
+/// per line, and a lambda body can print across several.
+fn grep_flatten(text: String) -> String {
+  let len = String::length(text)
+  let mut out = ""
+  let mut i = 0
+  while i < len {
+    let c = String::char_code_at(text, i)
+    out = if c == 10 || c == 13 || c == 9 {
+      String::concat(out, " ")
+    } else {
+      String::concat(out, String::substring(text, i, i + 1))
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn grep_try_match(pat: GrepPattern, node: Expr, path: String, out: Array[GrepHit]) -> Unit with Exception {
+  let binds = grep_empty_binds()
+  if grep_match_expr(pat.template, node, binds) {
+    let (lo, hi) = grep_expr_span(node)
+    Array::push(out, GrepHit::{
+      path: path,
+      offset: lo,
+      end_offset: hi,
+      text: grep_flatten(print_expr(node)),
+      captures: binds
+    })
+  } else {
+    ()
+  }
+}
+
+fn grep_walk_exprs(items: Array[Expr], pat: GrepPattern, path: String, out: Array[GrepHit]) -> Unit with Exception {
+  let mut i = 0
+  while i < Array::length(items) {
+    grep_walk_expr(Array::get(items, i), pat, path, out)
+    i = i + 1
+  }
+}
+
+fn grep_walk_fields(fields: Array[(String, Expr)], pat: GrepPattern, path: String, out: Array[GrepHit]) -> Unit with Exception {
+  let mut i = 0
+  while i < Array::length(fields) {
+    let (_, v) = Array::get(fields, i)
+    grep_walk_expr(v, pat, path, out)
+    i = i + 1
+  }
+}
+
+fn grep_walk_arms(arms: Array[(Pat, Expr)], pat: GrepPattern, path: String, out: Array[GrepHit]) -> Unit with Exception {
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (_, v) = Array::get(arms, i)
+    grep_walk_expr(v, pat, path, out)
+    i = i + 1
+  }
+}
+
+/// Visit every expression node, trying the pattern at each. Outer nodes are
+/// tried BEFORE their children, so results come out in source-structure order
+/// and a pattern that matches an outer node also reports the nested matches it
+/// contains (they are genuinely separate sites).
+fn grep_walk_expr(e: Expr, pat: GrepPattern, path: String, out: Array[GrepHit]) -> Unit with Exception {
+  grep_try_match(pat, e, path, out)
+  match e {
+    EInt(_) => (),
+    EFloat(_) => (),
+    EString(_) => (),
+    EBool(_) => (),
+    EUnit => (),
+    EStringInterp(_) => (),
+    EIdent(_, _) => (),
+    ETuple(items) => grep_walk_exprs(items, pat, path, out),
+    EArray(items) => grep_walk_exprs(items, pat, path, out),
+    ERecord(_, fields, _) => grep_walk_fields(fields, pat, path, out),
+    EMap(fields) => grep_walk_fields(fields, pat, path, out),
+    EIf(c, t, f) => {
+      grep_walk_expr(c, pat, path, out)
+      grep_walk_expr(t, pat, path, out)
+      grep_walk_expr(f, pat, path, out)
+    },
+    ELet(_, v, b, _) => {
+      grep_walk_expr(v, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    ELetRec(_, v, b) => {
+      grep_walk_expr(v, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    ELetMut(_, v, b, _) => {
+      grep_walk_expr(v, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    EAssign(_, v, b) => {
+      grep_walk_expr(v, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    EAssignOp(_, _, v, b) => {
+      grep_walk_expr(v, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    ESeq(a, b) => {
+      grep_walk_expr(a, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    EMatch(s, arms) => {
+      grep_walk_expr(s, pat, path, out)
+      grep_walk_arms(arms, pat, path, out)
+    },
+    EHandle(s, arms) => {
+      grep_walk_expr(s, pat, path, out)
+      grep_walk_arms(arms, pat, path, out)
+    },
+    EWhile(c, b) => {
+      grep_walk_expr(c, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    ELoop(params, b) => {
+      grep_walk_fields(params, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    EForIn(_, _, it, b) => {
+      grep_walk_expr(it, pat, path, out)
+      grep_walk_expr(b, pat, path, out)
+    },
+    ECall(callee, args, _) => {
+      grep_walk_expr(callee, pat, path, out)
+      grep_walk_exprs(args, pat, path, out)
+    },
+    EBinOp(_, l, r) => {
+      grep_walk_expr(l, pat, path, out)
+      grep_walk_expr(r, pat, path, out)
+    },
+    EUnaryOp(_, v) => grep_walk_expr(v, pat, path, out),
+    EFn(_, _, _, _, _, body) => grep_walk_expr(body, pat, path, out),
+    EDot(inner, _, _, _) => grep_walk_expr(inner, pat, path, out),
+    ELabeledArg(_, _, v) => grep_walk_expr(v, pat, path, out),
+    EReturn(v) => grep_walk_expr(v, pat, path, out),
+    EBreak(opt) => match opt {
+      Some(v) => grep_walk_expr(v, pat, path, out),
+      None => ()
+    },
+    EContinue(args) => grep_walk_exprs(args, pat, path, out),
+    ESpread(v) => grep_walk_expr(v, pat, path, out)
+  }
+}
+
+fn grep_walk_stmts(stmts: Array[Stmt], pat: GrepPattern, path: String, out: Array[GrepHit]) -> Unit with Exception {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, _, _, body) => grep_walk_expr(body, pat, path, out),
+      SLetMut(_, _, body) => grep_walk_expr(body, pat, path, out),
+      SLetPat(_, body) => grep_walk_expr(body, pat, path, out),
+      STest(_, body) => grep_walk_expr(body, pat, path, out),
+      SBench(_, body) => grep_walk_expr(body, pat, path, out),
+      SExample(_, body) => grep_walk_expr(body, pat, path, out),
+      SExpr(body) => grep_walk_expr(body, pat, path, out),
+      SFnDecl(_, _, body, _, _) => grep_walk_expr(body, pat, path, out),
+      SModule(_, _, body) => grep_walk_stmts(body, pat, path, out),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+//# Functions — typed context
+
+fn grep_empty_typed(aliases: Array[(String, String)], stmt_lo: Array[Int], stmt_hi: Array[Int], type_error: String, type_error_offset: Int) -> GrepTyped {
+  GrepTyped::{
+    tytab: grep_empty_tytab(),
+    offset_delta: 0,
+    env: EnvEmpty,
+    subst: SubstEmpty,
+    defs: grep_empty_defs(),
+    aliases: aliases,
+    type_error: type_error,
+    type_error_offset: type_error_offset,
+    stmt_lo: stmt_lo,
+    stmt_hi: stmt_hi
+  }
+}
+
+/// The context to use when no typed filter was requested: nothing in it is
+/// ever read, and building it costs no type-check.
+export fn grep_untyped_context() -> GrepTyped {
+  grep_empty_typed(grep_empty_pairs(), grep_empty_ints(), grep_empty_ints(), "", -1)
+}
+
+/// The source offset a checker diagnostic points at, taken from its own
+/// ` [@off=N]` / ` [@off=N:M]` evidence marker. -1 when the message carries
+/// none (an unlocated diagnostic), which the `--only-ill-typed` filter treats
+/// as covering the whole file.
+fn grep_marker_offset(msg: String) -> Int {
+  let marker = " [@off="
+  let mi = String::index_of(msg, marker)
+  if mi < 0 {
+    -1
+  } else {
+    let len = String::length(msg)
+    let mut i = mi + String::length(marker)
+    let mut n = 0
+    let mut digits = 0
+    while i < len && String::char_code_at(msg, i) >= '0' && String::char_code_at(msg, i) <= '9' {
+      n = n * 10 + (String::char_code_at(msg, i) - '0')
+      digits = digits + 1
+      i = i + 1
+    }
+    if digits == 0 {
+      -1
+    } else {
+      n
+    }
+  }
+}
+
+/// Top-level statement spans, used to decide WHICH matches an `--only-ill-typed`
+/// file's single type error covers. A file whose spans cannot be recovered
+/// simply gets empty arrays: the filter then treats the whole file as covered,
+/// which over-reports rather than silently dropping sites.
+fn grep_stmt_spans(source: String, lo: Array[Int], hi: Array[Int]) -> Unit {
+  handle {
+    let (tokens, starts, ends) = lex_with_offsets(source)
+    let (_, span_start, span_end) = parse_program_spans(tokens, starts, ends)
+    let mut i = 0
+    while i < Array::length(span_start) {
+      Array::push(lo, Array::get(span_start, i))
+      Array::push(hi, if i < Array::length(span_end) {
+        Array::get(span_end, i)
+      } else {
+        String::length(source)
+      })
+      i = i + 1
+    }
+  } with Exception {
+    Throw(_) => ()
+  }
+}
+
+/// Type one file with `import_env` already resolved, and package everything
+/// the filters read. A type error is NOT propagated: it becomes `type_error`,
+/// which is exactly what `--only-ill-typed` is asking about. A file that does
+/// not even parse yields the empty context (its structural matches, if any,
+/// came from a parse this one just failed to repeat, so there is nothing to
+/// type).
+export fn grep_typed_context(source: String, typed_source: String, import_env: TypeEnv) -> GrepTyped {
+  let delta = String::length(typed_source) - String::length(source)
+  if delta < 0 {
+    // The ingested source is SHORTER than the file, so it is not the file plus
+    // a prefix and no single delta relates their offsets. Refusing to type is
+    // the honest answer: typing anyway would attribute types and errors to the
+    // wrong positions.
+    grep_untyped_context()
+  } else {
+    let lo = grep_empty_ints()
+    let hi = grep_empty_ints()
+    grep_stmt_spans(typed_source, lo, hi)
+    handle {
+      // A fresh parse on purpose: check_program mutates the statement array it
+      // is handed, so it must never share one with the matcher's own walk.
+      let (tokens, starts, _) = lex_with_offsets(typed_source)
+      let stmts = parse_program_located(tokens, starts, typed_source)
+      let aliases = collect_import_aliases(stmts)
+      handle {
+        let checked = check_program_with_env_result(stmts, import_env)
+        GrepTyped::{
+          tytab: checked.typed_occurrences,
+          offset_delta: delta,
+          env: checked.final_env,
+          subst: checked.final_subst,
+          defs: checked.type_defs,
+          aliases: aliases,
+          type_error: "",
+          type_error_offset: -1,
+          stmt_lo: lo,
+          stmt_hi: hi
+        }
+      } with Exception {
+        Throw(msg) => grep_shift(grep_empty_typed(aliases, lo, hi, msg, grep_marker_offset(msg)), delta)
+      }
+    } with Exception {
+      Throw(_) => grep_untyped_context()
+    }
+  }
+}
+
+/// The context for a file whose TYPING could not be performed at all -- the
+/// import graph itself failed to check, so no type table exists.
+///
+/// `type_error` is set, which is the whole point: the alternative (an empty
+/// context) reports the file as clean, so `--only-well-typed` would hand back
+/// sites from a program that does not compile. Every `--where` filter drops
+/// its matches here, because "we do not know this capture's type" must not
+/// read as "it is not an Array[Int]".
+///
+/// The error may belong to a DEPENDENCY rather than to this file. Covering the
+/// whole file over-reports for `--only-ill-typed`, which is the safe direction
+/// for a "show me the broken sites" filter.
+export fn grep_typed_context_error(source: String, message: String) -> GrepTyped {
+  let lo = grep_empty_ints()
+  let hi = grep_empty_ints()
+  grep_stmt_spans(source, lo, hi)
+  let aliases = handle {
+    collect_import_aliases(parse_program(lex(source)))
+  } with Exception {
+    Throw(_) => grep_empty_pairs()
+  }
+  grep_empty_typed(aliases, lo, hi, message, grep_marker_offset(message))
+}
+
+fn grep_shift(ctx: GrepTyped, delta: Int) -> GrepTyped {
+  GrepTyped::{
+    tytab: ctx.tytab,
+    offset_delta: delta,
+    env: ctx.env,
+    subst: ctx.subst,
+    defs: ctx.defs,
+    aliases: ctx.aliases,
+    type_error: ctx.type_error,
+    type_error_offset: ctx.type_error_offset,
+    stmt_lo: ctx.stmt_lo,
+    stmt_hi: ctx.stmt_hi
+  }
+}
+
+//# Functions — filters
+
+fn grep_trim(s: String) -> String {
+  String::trim(s)
+}
+
+/// Split `$name <op> <rest>` into its three parts. The accepted operators are
+/// `:` (inferred type), `=` (resolved name) and the `with` / `without` row
+/// keywords; the first one that appears wins.
+fn grep_split_filter(item: String, what: String) -> (String, String, String) with Exception {
+  let text = grep_trim(item)
+  let len = String::length(text)
+  if len == 0 || String::char_code_at(text, 0) != '$' {
+    throw(String::concat(what, ": must start with a captured metavariable, e.g. `$x : Array[Int]`"))
+  } else {
+    let mut i = 1
+    while i < len && grep_is_ident_char(String::char_code_at(text, i)) {
+      i = i + 1
+    }
+    let var = String::substring(text, 1, i)
+    if String::length(var) == 0 {
+      throw(String::concat(what, ": expected a metavariable name after `$`"))
+    } else {
+      let rest = grep_trim(String::substring(text, i, len))
+      let rlen = String::length(rest)
+      if rlen == 0 {
+        throw(String::concat(what, ": nothing to compare against"))
+      } else if String::char_code_at(rest, 0) == ':' {
+        (var, ":", grep_trim(String::substring(rest, 1, rlen)))
+      } else if String::char_code_at(rest, 0) == '=' {
+        (var, "=", grep_trim(String::substring(rest, 1, rlen)))
+      } else if String::starts_with(rest, "without ") {
+        (var, "without", grep_trim(String::substring(rest, 8, rlen)))
+      } else if String::starts_with(rest, "with ") {
+        (var, "with", grep_trim(String::substring(rest, 5, rlen)))
+      } else {
+        throw(String::concat(what, String::concat(": expected `:` (type), `=` (resolved name), `with` or `without` (effect row) after `$", String::concat(var, "`"))))
+      }
+    }
+  }
+}
+
+fn grep_pattern_declares(pat: GrepPattern, var: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(pat.vars) {
+    if Array::get(pat.vars, i) == var {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn grep_check_clauses(pat: GrepPattern, clauses: Array[String], what: String) -> Unit with Exception {
+  let mut i = 0
+  while i < Array::length(clauses) {
+    let (var, _, _) = grep_split_filter(Array::get(clauses, i), what)
+    if !grep_pattern_declares(pat, var) {
+      throw(String::concat(what, String::concat(": the pattern never captures `$", String::concat(var, "`"))))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}
+
+/// Reject a filter clause naming a metavariable the pattern never declares,
+/// BEFORE any file is read.
+///
+/// Checking this per hit instead would only report it on a file that already
+/// matched: a typo'd `--where '$fn = ...'` against a pattern that binds `$f`
+/// would sweep the whole repo, drop everything, and come back with the empty
+/// output that means "clean" -- the exact "quietly matches nothing" failure a
+/// filter must never have.
+export fn grep_check_filters(pat: GrepPattern, wheres: Array[String], where_rows: Array[String]) -> Unit with Exception {
+  grep_check_clauses(pat, wheres, "--where")
+  grep_check_clauses(pat, where_rows, "--where-row")
+}
+
+fn grep_find_capture(hit: GrepHit, var: String) -> Option[(String, Int, Bool)] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(hit.captures) && found == None {
+    let (n, t, o, callee) = Array::get(hit.captures, i)
+    if n == var {
+      found = Some((t, o, callee))
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// The type the checker recorded at `off`. `prefer_first` picks the earliest
+/// role recorded there: a call records its RESULT at the callee's own offset,
+/// so an identifier that is also an argument has its own type first and the
+/// enclosing call's result last. The table carries no role tag, so first/last
+/// is the whole vocabulary available.
+fn grep_type_at_offset(ctx: GrepTyped, raw_off: Int, prefer_first: Bool) -> Option[Type] {
+  if raw_off < 0 {
+    None
+  } else {
+    let off = raw_off + ctx.offset_delta
+    let mut i = 0
+    let mut found = None
+    while i < Array::length(ctx.tytab) {
+      let (toff, ty) = Array::get(ctx.tytab, i)
+      if toff == off {
+        if prefer_first {
+          if found == None {
+            found = Some(ty)
+          } else {
+            ()
+          }
+        } else {
+          found = Some(ty)
+        }
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    match found {
+      Some(ty) => Some(subst_apply(ctx.subst, ty)),
+      None => None
+    }
+  }
+}
+
+/// The type of one capture.
+///
+/// A CALLEE never consults the offset table: the checker resolves a named
+/// callee without going through the identifier arm, so the only thing recorded
+/// at that offset is the call's RESULT — reporting that as the function's type
+/// would be a confidently wrong answer, which is the failure mode this
+/// codebase ranks worst. Callees resolve through the final environment
+/// instead, after import-alias resolution, which is also what makes
+/// `--where-row '$f with Fs'` mean the callee's effect row.
+///
+/// LIMITATION: a callee that is a local or a parameter is not in the final
+/// environment, so it has no type here (the filter drops it rather than
+/// guessing). Same boundary `vibe type-at` documents.
+fn grep_capture_type(ctx: GrepTyped, text: String, off: Int, is_callee: Bool) -> Option[Type] {
+  grep_known(grep_capture_type_raw(ctx, text, off, is_callee))
+}
+
+/// `CtUnknown` is the checker's "I could not resolve this" placeholder, not a
+/// type. Answering a filter from it would report `--where-row '$f without
+/// Async'` as TRUE for a name whose row is simply unknown -- a confident wrong
+/// answer, the failure mode this codebase ranks above crashing. Drop it, so an
+/// unresolvable capture matches neither `with` nor `without`.
+fn grep_known(ty: Option[Type]) -> Option[Type] {
+  match ty {
+    Some(CtUnknown) => None,
+    _ => ty
+  }
+}
+
+fn grep_capture_type_raw(ctx: GrepTyped, text: String, off: Int, is_callee: Bool) -> Option[Type] {
+  if is_callee {
+    // As WRITTEN first: an importing module's environment is keyed by the
+    // name in this file, so `import ./dep.vibe { helper as h }` binds `h`, not
+    // `helper`. The alias-resolved spelling is the fallback, for the whole-
+    // program-merged shape where the original name is what survives.
+    match env_lookup(ctx.env, text) {
+      Some(t) => Some(t),
+      None => {
+        let resolved = grep_resolve_name(ctx, text)
+        match env_lookup(ctx.env, resolved) {
+          Some(t) => Some(t),
+          // Capability builtins (`Fs::read_file`, `Env::get`, ...) are never
+          // in a module environment, and they are exactly what an effect-row
+          // filter is usually hunting for.
+          None => match lookup_builtin(text) {
+            Some(t) => Some(t),
+            None => lookup_builtin(resolved)
+          }
+        }
+      }
+    }
+  } else {
+    grep_type_at_offset(ctx, off, grep_capture_is_ident(text))
+  }
+}
+
+/// True when the capture text names an identifier (so the IDENTIFIER role is
+/// the one wanted at its offset).
+fn grep_capture_is_ident(text: String) -> Bool {
+  let len = String::length(text)
+  if len == 0 {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < len {
+      let c = String::char_code_at(text, i)
+      ok = grep_is_ident_char(c) || c == ':'
+      i = i + 1
+    }
+    ok
+  }
+}
+
+/// Structural type comparison with `_` as a wildcard on the EXPECTED side.
+/// This is the "unify" of #1572 scope 2 restricted to what a CLI flag can
+/// honestly express: an inference variable in the actual type matches only a
+/// wildcard, because claiming `?t3` equals `Int` would be exactly the silent
+/// wrong answer the triage policy ranks worst.
+fn grep_type_matches(expected: Type, actual: Type) -> Bool {
+  match expected {
+    CtNamed(name, args) => if name == "_" && Array::length(args) == 0 {
+      true
+    } else {
+      match actual {
+        CtNamed(aname, aargs) => name == aname && grep_type_list_matches(args, aargs),
+        CtEnum(aname) => name == aname && Array::length(args) == 0,
+        CtStruct(aname) => name == aname && Array::length(args) == 0,
+        _ => false
+      }
+    },
+    CtInt => match actual {
+      CtInt => true,
+      _ => false
+    },
+    CtDouble => match actual {
+      CtDouble => true,
+      _ => false
+    },
+    CtBool => match actual {
+      CtBool => true,
+      _ => false
+    },
+    CtString => match actual {
+      CtString => true,
+      _ => false
+    },
+    CtChar => match actual {
+      CtChar => true,
+      _ => false
+    },
+    CtUnit => match actual {
+      CtUnit => true,
+      _ => false
+    },
+    CtBytes => match actual {
+      CtBytes => true,
+      _ => false
+    },
+    CtArray(e) => match actual {
+      CtArray(a) => grep_type_matches(e, a),
+      _ => false
+    },
+    CtOption(e) => match actual {
+      CtOption(a) => grep_type_matches(e, a),
+      _ => false
+    },
+    CtTuple(es) => match actual {
+      CtTuple(as_) => grep_type_list_matches(es, as_),
+      _ => false
+    },
+    CtFn(eps, er, erow) => match actual {
+      CtFn(aps, ar, arow) => grep_type_list_matches(eps, aps) && grep_type_matches(er, ar) && grep_row_equiv(erow, arow),
+      _ => false
+    },
+    CtEnum(name) => match actual {
+      CtEnum(aname) => name == aname,
+      CtNamed(aname, aargs) => name == aname && Array::length(aargs) == 0,
+      _ => false
+    },
+    CtStruct(name) => match actual {
+      CtStruct(aname) => name == aname,
+      CtNamed(aname, aargs) => name == aname && Array::length(aargs) == 0,
+      _ => false
+    },
+    CtVar(_) => false,
+    CtForAll(_, _, body) => grep_type_matches(body, actual),
+    CtUnknown => false
+  }
+}
+
+fn grep_type_list_matches(es: Array[Type], as_: Array[Type]) -> Bool {
+  if Array::length(es) != Array::length(as_) {
+    false
+  } else {
+    let mut i = 0
+    let mut ok = true
+    while ok && i < Array::length(es) {
+      ok = grep_type_matches(Array::get(es, i), Array::get(as_, i))
+      i = i + 1
+    }
+    ok
+  }
+}
+
+/// An unwritten row on the expected side means "don't care"; a written one
+/// must name the same effects.
+fn grep_row_equiv(expected: Option[String], actual: Option[String]) -> Bool {
+  match expected {
+    None => true,
+    Some(er) => match actual {
+      Some(ar) => er == ar,
+      None => false
+    }
+  }
+}
+
+/// Split an effect row string (`"Async + Exception"`) into its items.
+fn grep_row_items(row: String) -> Array[String] {
+  let parts = String::split(row, "+")
+  let out = grep_empty_strings()
+  let mut i = 0
+  while i < Array::length(parts) {
+    let item = grep_trim(Array::get(parts, i))
+    if String::length(item) > 0 {
+      Array::push(out, item)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// True when `row` mentions `want`. An `Effect::op` request matches only that
+/// exact operation item; a bare effect NAME matches both the whole effect and
+/// any of its operations, so `with Fs` finds `Fs::read_file` too.
+fn grep_row_has(row: Option[String], want: String) -> Bool {
+  match row {
+    None => false,
+    Some(text) => {
+      let items = grep_row_items(text)
+      let prefix = String::concat(want, "::")
+      let mut i = 0
+      let mut hit = false
+      while !hit && i < Array::length(items) {
+        let item = Array::get(items, i)
+        hit = item == want || (String::index_of(want, "::") < 0 && String::starts_with(item, prefix))
+        i = i + 1
+      }
+      hit
+    }
+  }
+}
+
+fn grep_row_of(ty: Type) -> Option[String] {
+  match ty {
+    CtFn(_, _, row) => row,
+    CtForAll(_, _, body) => grep_row_of(body),
+    _ => None
+  }
+}
+
+/// Resolve a captured name through this file's import aliases, so `--where
+/// '$f = Iterator::map'` finds the site even when the file wrote
+/// `import ... { Iterator as It }` and called `It::map`.
+fn grep_resolve_name(ctx: GrepTyped, name: String) -> String {
+  let mut i = 0
+  let mut out = name
+  let mut done = false
+  while !done && i < Array::length(ctx.aliases) {
+    let (alias, original) = Array::get(ctx.aliases, i)
+    if alias == name {
+      out = original
+      done = true
+    } else {
+      i = i + 1
+    }
+  }
+  if done {
+    out
+  } else {
+    let qi = String::index_of(name, "::")
+    if qi < 0 {
+      name
+    } else {
+      let head = String::substring(name, 0, qi)
+      let mut j = 0
+      let mut resolved = name
+      while j < Array::length(ctx.aliases) {
+        let (alias, original) = Array::get(ctx.aliases, j)
+        if alias == head {
+          resolved = String::concat(original, String::substring(name, qi, String::length(name)))
+        } else {
+          ()
+        }
+        j = j + 1
+      }
+      resolved
+    }
+  }
+}
+
+/// Apply one `--where` / `--where-row` clause to one hit. A clause naming a
+/// metavariable the pattern never captured is an ERROR, not a silent
+/// no-match: a filter that quietly matches nothing is indistinguishable from
+/// a clean result.
+fn grep_filter_keeps(ctx: GrepTyped, hit: GrepHit, clause: String, what: String) -> Bool with Exception {
+  let (var, op, rhs) = grep_split_filter(clause, what)
+  match grep_find_capture(hit, var) {
+    None => throw(String::concat(what, String::concat(": the pattern never captures `$", String::concat(var, "`")))),
+    Some((text, off, is_callee)) => if op == "=" {
+      grep_resolve_name(ctx, text) == rhs
+    } else if op == ":" {
+      let expected = resolve_type_expr(parse_type(lex(rhs), 0).0, ctx.defs)
+      match grep_capture_type(ctx, text, off, is_callee) {
+        None => false,
+        Some(actual) => grep_type_matches(expected, actual)
+      }
+    } else {
+      match grep_capture_type(ctx, text, off, is_callee) {
+        None => false,
+        Some(actual) => {
+          let has = grep_row_has(grep_row_of(actual), rhs)
+          if op == "with" { has } else {
+            !has
+          }
+        }
+      }
+    }
+  }
+}
+
+/// True when the file's type error lands in the same top-level declaration as
+/// `hit`. An unlocated error (or unknown statement spans) covers the whole
+/// file: over-reporting is the safe direction for a "show me the broken
+/// sites" filter.
+fn grep_hit_is_ill_typed(ctx: GrepTyped, hit: GrepHit) -> Bool {
+  if ctx.type_error == "" {
+    false
+  } else {
+    let err_off = ctx.type_error_offset
+    if err_off < 0 || Array::length(ctx.stmt_lo) == 0 || hit.offset < 0 {
+      true
+    } else {
+      let hit_off = hit.offset + ctx.offset_delta
+      let mut i = 0
+      let mut covered = false
+      while !covered && i < Array::length(ctx.stmt_lo) {
+        let lo = Array::get(ctx.stmt_lo, i)
+        let hi = Array::get(ctx.stmt_hi, i)
+        if lo <= err_off && err_off < hi {
+          covered = lo <= hit_off && hit_off < hi
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      covered
+    }
+  }
+}
+
+//# Functions — rendering
+
+fn grep_json_escape(s: String) -> String {
+  let len = String::length(s)
+  let mut out = ""
+  let mut i = 0
+  while i < len {
+    let c = String::char_code_at(s, i)
+    let piece = if c == '"' {
+      "\\\""
+    } else if c == 92 {
+      "\\\\"
+    } else if c == 10 {
+      "\\n"
+    } else if c == 13 {
+      "\\r"
+    } else if c == 9 {
+      "\\t"
+    } else if c < 32 {
+      // Control characters have no short escape here; drop them rather than
+      // emit a byte a JSON parser would reject.
+      ""
+    } else {
+      String::substring(s, i, i + 1)
+    }
+    out = String::concat(out, piece)
+    i = i + 1
+  }
+  out
+}
+
+fn grep_int(n: Int) -> String {
+  __to_string(n)
+}
+
+/// `path:line:col: <matched text>` followed by tab-separated `$var=<text>`
+/// captures — one match per line, fixed field order, greppable.
+fn grep_render_line(hit: GrepHit, line: Int, col: Int) -> String {
+  let head = String::concat(hit.path, String::concat(":", String::concat(grep_int(line), String::concat(":", String::concat(grep_int(col), String::concat(": ", hit.text))))))
+  let mut out = head
+  let mut i = 0
+  while i < Array::length(hit.captures) {
+    let (n, t, _, _) = Array::get(hit.captures, i)
+    out = String::concat(out, String::concat("\t$", String::concat(n, String::concat("=", grep_flatten(t)))))
+    i = i + 1
+  }
+  out
+}
+
+fn grep_render_json(ctx: GrepTyped, typed: Bool, hit: GrepHit, line: Int, col: Int) -> String {
+  let head = String::concat("{\"path\":\"", String::concat(grep_json_escape(hit.path), String::concat("\",\"line\":", String::concat(grep_int(line), String::concat(",\"col\":", String::concat(grep_int(col), String::concat(",\"start\":", String::concat(grep_int(hit.offset), String::concat(",\"end\":", String::concat(grep_int(hit.end_offset), String::concat(",\"text\":\"", String::concat(grep_json_escape(hit.text), "\",\"captures\":{"))))))))))))
+  let mut body = ""
+  let mut i = 0
+  while i < Array::length(hit.captures) {
+    let (n, t, o, is_callee) = Array::get(hit.captures, i)
+    let ty = if typed {
+      match grep_capture_type(ctx, t, o, is_callee) {
+        Some(actual) => String::concat(",\"type\":\"", String::concat(grep_json_escape(type_to_string(actual)), "\"")),
+        None => ""
+      }
+    } else {
+      ""
+    }
+    let entry = String::concat("\"", String::concat(grep_json_escape(n), String::concat("\":{\"text\":\"", String::concat(grep_json_escape(t), String::concat("\",\"start\":", String::concat(grep_int(o), String::concat(ty, "}")))))))
+    body = if i == 0 {
+      entry
+    } else {
+      String::concat(body, String::concat(",", entry))
+    }
+    i = i + 1
+  }
+  String::concat(head, String::concat(body, "}}"))
+}
+
+//# Functions — per-file driver
+
+export fn grep_file_hits(path: String, source: String, pat: GrepPattern) -> Array[GrepHit] with Exception {
+  let (tokens, starts, _) = lex_with_offsets(source)
+  let stmts = parse_program_located(tokens, starts, source)
+  let out = grep_empty_hits()
+  grep_walk_stmts(stmts, pat, path, out)
+  out
+}
+
+export fn grep_needs_typing(wheres: Array[String], where_rows: Array[String], only: String) -> Bool {
+  Array::length(wheres) > 0 || Array::length(where_rows) > 0 || only != ""
+}
+
+/// Filter `hits` and append their rendered form to `out`.
+export fn grep_emit_hits(source: String, hits: Array[GrepHit], ctx: GrepTyped, typed: Bool, wheres: Array[String], where_rows: Array[String], only: String, json: Bool, out: Array[String]) -> Unit with Exception {
+  let mut i = 0
+  while i < Array::length(hits) {
+    let hit = Array::get(hits, i)
+    let mut keep = true
+    let mut w = 0
+    while keep && w < Array::length(wheres) {
+      keep = grep_filter_keeps(ctx, hit, Array::get(wheres, w), "--where")
+      w = w + 1
+    }
+    let mut r = 0
+    while keep && r < Array::length(where_rows) {
+      keep = grep_filter_keeps(ctx, hit, Array::get(where_rows, r), "--where-row")
+      r = r + 1
+    }
+    if keep && only != "" {
+      let ill = grep_hit_is_ill_typed(ctx, hit)
+      keep = if only == "ill" {
+        ill
+      } else if only == "well" {
+        !ill
+      } else {
+        throw(String::concat("grep: unknown --only mode `", String::concat(only, "` — expected `ill` or `well`")))
+      }
+    } else {
+      ()
+    }
+    if keep {
+      let (line, col) = if hit.offset >= 0 {
+        offset_to_line_col(source, hit.offset)
+      } else {
+        (0, 0)
+      }
+      Array::push(out, if json {
+        grep_render_json(ctx, typed, hit, line, col)
+      } else {
+        grep_render_line(hit, line, col)
+      })
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}
+
+//# Functions — entry points
+
+export fn grep_join_lines(lines: Array[String], json: Bool) -> String {
+  if json {
+    let mut body = ""
+    let mut i = 0
+    while i < Array::length(lines) {
+      body = if i == 0 {
+        String::concat("\n  ", Array::get(lines, i))
+      } else {
+        String::concat(body, String::concat(",\n  ", Array::get(lines, i)))
+      }
+      i = i + 1
+    }
+    if Array::length(lines) == 0 {
+      "[]\n"
+    } else {
+      String::concat("[", String::concat(body, "\n]\n"))
+    }
+  } else {
+    let mut out = ""
+    let mut i = 0
+    while i < Array::length(lines) {
+      out = String::concat(out, String::concat(Array::get(lines, i), "\n"))
+      i = i + 1
+    }
+    out
+  }
+}
+
+/// Single-source entry: parse-only matching plus the typed filters resolved
+/// against THIS FILE ALONE (no import resolution). This is the seam the unit
+/// tests drive; `vibe grep` itself always uses grep_scan_fs, which resolves
+/// imports the way `vibe check` does.
+export fn grep_scan_source(path: String, source: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> String with Exception {
+  let pat = grep_compile_pattern(pattern)
+  grep_check_filters(pat, wheres, where_rows)
+  let hits = grep_file_hits(path, source, pat)
+  let out = grep_empty_strings()
+  let typed = grep_needs_typing(wheres, where_rows, only)
+  let ctx = if typed && Array::length(hits) > 0 {
+    grep_typed_context(source, source, EnvEmpty)
+  } else {
+    grep_untyped_context()
+  }
+  grep_emit_hits(source, hits, ctx, typed, wheres, where_rows, only, json, out)
+  grep_join_lines(out, json)
+}

--- a/lib/@vibe/compiler/runtime/grep.vibe
+++ b/lib/@vibe/compiler/runtime/grep.vibe
@@ -42,9 +42,15 @@
 //   both parse to `f(xs, y)` and therefore match each other, while `x.f(y)`
 //   stays an `EDot` callee and matches only the method spelling. That is the
 //   honest description of today's behaviour — #1572's design point 1 wants
-//   surface fidelity for structure and leaves call-form unification to the
-//   resolved-name filter, and the pipe case is the one place the parser
-//   already decided otherwise.
+//   surface fidelity for structure, and the pipe case is the one place the
+//   parser already decided otherwise.
+//
+//   The resolved-name filter closes the ALIAS half of call-form unification
+//   (`It::map` and `Iterator::map` are one query). It does NOT relate
+//   `xs.map(f)` to `Iterator::map`: a method callee is an `EDot`, and the
+//   checker's member resolution is not exposed as a NAME anywhere this can
+//   read (the type table records the field's type, not what it resolved to).
+//   Covering both spellings takes two queries today.
 //
 // LIMITATION (v1): a pattern must be a single EXPRESSION. Declaration-shaped
 // patterns (`fn ...`, `let ... = ...` at statement level, `enum ...`) are

--- a/lib/@vibe/compiler/runtime/grep.vibe
+++ b/lib/@vibe/compiler/runtime/grep.vibe
@@ -1373,8 +1373,11 @@ export fn grep_typed_context(source: String, typed_source: String, import_env: T
     // The ingested source is SHORTER than the file, so it is not the file plus
     // a prefix and no single delta relates their offsets. Refusing to type is
     // the honest answer: typing anyway would attribute types and errors to the
-    // wrong positions.
-    grep_untyped_context()
+    // wrong positions. It has to be the ERROR context rather than the untyped
+    // one -- an untyped context reads as "this file is clean", which would let
+    // `--only-well-typed` and the resolved-name filter answer from a typing
+    // that never happened.
+    grep_typed_context_error(source, "grep: refusing to type this file -- its ingested source is not the file plus a prefix")
   } else {
     let lo = grep_empty_ints()
     let hi = grep_empty_ints()
@@ -1403,7 +1406,7 @@ export fn grep_typed_context(source: String, typed_source: String, import_env: T
         Throw(msg) => grep_shift(grep_empty_typed(aliases, lo, hi, msg, grep_marker_offset(msg)), delta)
       }
     } with Exception {
-      Throw(_) => grep_untyped_context()
+      Throw(msg) => grep_typed_context_error(source, msg)
     }
   }
 }
@@ -1453,6 +1456,21 @@ fn grep_trim(s: String) -> String {
   String::trim(s)
 }
 
+/// One split filter clause, rejecting an empty operand.
+///
+/// `--where '$x :'` and `--where '$f ='` otherwise pass the up-front
+/// validation and only misbehave later: the `=` form compares against the
+/// empty name (never true), and the `:` form only fails once some file
+/// actually matches -- so a sweep with no structural hits returns the empty
+/// output that means "no match" and the typo is never reported.
+fn grep_operand(what: String, var: String, op: String, rhs: String) -> (String, String, String) with Exception {
+  if String::length(rhs) == 0 {
+    throw(String::concat(what, String::concat(": nothing after `", String::concat(op, String::concat("` in `$", String::concat(var, "`"))))))
+  } else {
+    (var, op, rhs)
+  }
+}
+
 /// Split `$name <op> <rest>` into its three parts. The accepted operators are
 /// `:` (inferred type), `=` (resolved name) and the `with` / `without` row
 /// keywords; the first one that appears wins.
@@ -1475,14 +1493,19 @@ fn grep_split_filter(item: String, what: String) -> (String, String, String) wit
       if rlen == 0 {
         throw(String::concat(what, ": nothing to compare against"))
       } else if String::char_code_at(rest, 0) == ':' {
-        (var, ":", grep_trim(String::substring(rest, 1, rlen)))
+        grep_operand(what, var, ":", grep_trim(String::substring(rest, 1, rlen)))
       } else if String::char_code_at(rest, 0) == '=' {
-        (var, "=", grep_trim(String::substring(rest, 1, rlen)))
+        grep_operand(what, var, "=", grep_trim(String::substring(rest, 1, rlen)))
       } else if String::starts_with(rest, "without ") {
-        (var, "without", grep_trim(String::substring(rest, 8, rlen)))
+        grep_operand(what, var, "without", grep_trim(String::substring(rest, 8, rlen)))
       } else if String::starts_with(rest, "with ") {
-        (var, "with", grep_trim(String::substring(rest, 5, rlen)))
-      } else {
+        grep_operand(what, var, "with", grep_trim(String::substring(rest, 5, rlen)))
+      } else if rest == "without" {
+        // The row keywords are the only operators spelled as a word, so a bare
+        // one has already been trimmed of the space that would identify it.
+        // Reach grep_operand anyway, for the precise "nothing after" message.
+        grep_operand(what, var, "without", "")
+      } else if rest == "with" { grep_operand(what, var, "with", "") } else {
         throw(String::concat(what, String::concat(": expected `:` (type), `=` (resolved name), `with` or `without` (effect row) after `$", String::concat(var, "`"))))
       }
     }
@@ -1850,7 +1873,15 @@ fn grep_filter_keeps(ctx: GrepTyped, hit: GrepHit, clause: String, what: String)
   match grep_find_capture(hit, var) {
     None => throw(String::concat(what, String::concat(": the pattern never captures `$", String::concat(var, "`")))),
     Some((text, off, is_callee)) => if op == "=" {
-      grep_resolve_name(ctx, text) == rhs
+      // The alias table is syntactic and survives a failed typing, so this
+      // branch could answer TRUE for `$f = helper` on a file whose import of
+      // `helper` the checker never validated (missing module, or a name the
+      // dependency does not export -- #1533). Every other filter already drops
+      // there; this one claimed to have RESOLVED a name it only spelled out.
+      // A resolved-name filter that degrades to syntax when the graph is
+      // broken is exactly the silently-wrong answer the typed tier exists to
+      // avoid, so it drops too. Pure syntax is what the parse-only tier is for.
+      ctx.type_error == "" && grep_resolve_name(ctx, text) == rhs
     } else if op == ":" {
       let expected = resolve_type_expr(parse_type(lex(rhs), 0).0, ctx.defs)
       match grep_capture_type(ctx, text, off, is_callee) {

--- a/lib/@vibe/compiler/runtime/grep_fs.vibe
+++ b/lib/@vibe/compiler/runtime/grep_fs.vibe
@@ -1,0 +1,244 @@
+//# Imports
+
+// `vibe grep`'s filesystem tier (#1572 scope 3). Kept apart from grep.vibe on
+// purpose: this file imports typecheck_fs.vibe, whose `ModuleJob` is declared
+// in the package CONTRACT rather than in the file itself, so anything that
+// reaches typecheck_fs.vibe can only be compiled with index.vpkg in scope.
+// grep.vibe stays free of that dependency, which is what lets grep_test.vibe
+// drive the whole pattern language and every typed filter as plain sibling
+// leaf imports.
+//
+// The two tiers #1572 specifies:
+//   * no typed filter  -> parse only, no import resolution, one pass per file;
+//   * any typed filter -> the file is typed through the SAME FS import walk
+//     `vibe check` uses, so this cannot reproduce the `vibe diagnostics`
+//     import-blind false positives the issue calls out.
+
+import @vibe/compiler/core {
+  TypeEnv
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/loader {
+  collect_source_groups_fs
+}
+
+import @vibe/graph {
+  RippleDb, ripple_get_deps, ripple_get_fingerprint, ripple_new, ripple_set_source
+}
+
+import ./grep.vibe {
+  GrepTyped,
+  grep_check_filters,
+  grep_compile_pattern,
+  grep_emit_hits,
+  grep_empty_hits,
+  grep_empty_strings,
+  grep_file_hits,
+  grep_join_lines,
+  grep_needs_typing,
+  grep_typed_context,
+  grep_typed_context_error,
+  grep_untyped_context
+}
+
+import ./persistent_env_codec.vibe {
+  load_persistent_type_env
+}
+
+import ./typecheck_fs.vibe {
+  ensure_fingerprint_fs_impl, projected_import_env_for_test
+}
+
+//# Functions
+
+fn grep_fs_empty_env_cache() -> Array[(String, TypeEnv)] {
+  array_empty()
+}
+
+fn grep_fs_empty_pairs() -> Array[(String, String)] {
+  array_empty()
+}
+
+fn grep_fs_is_source_name(name: String) -> Bool {
+  String::ends_with(name, ".vibe") || String::ends_with(name, ".vibex")
+}
+
+/// Directories a repo sweep must never descend into: build output and vendored
+/// trees are not the user's source, and walking them dominates the runtime.
+fn grep_fs_skip_dir(name: String) -> Bool {
+  String::starts_with(name, ".") || name == "_build" || name == "node_modules" || name == "dist" || name == "target"
+}
+
+fn grep_fs_join(dir: String, name: String) -> String {
+  if String::ends_with(dir, "/") {
+    String::concat(dir, name)
+  } else {
+    String::concat(dir, String::concat("/", name))
+  }
+}
+
+/// Collect the `.vibe` / `.vibex` files under `root`, in directory order. An
+/// explicitly named file is taken whatever its extension: the caller asked for
+/// that file by name.
+fn grep_fs_collect_files(root: String, out: Array[String]) -> Unit with Fs {
+  if Fs::is_dir(root) {
+    let names = Fs::readdir(root)
+    let mut i = 0
+    while i < Array::length(names) {
+      let name = Array::get(names, i)
+      let child = grep_fs_join(root, name)
+      if Fs::is_dir(child) {
+        if !grep_fs_skip_dir(name) {
+          grep_fs_collect_files(child, out)
+        } else {
+          ()
+        }
+      } else if grep_fs_is_source_name(name) {
+        Array::push(out, child)
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+  } else if Fs::is_file(root) {
+    Array::push(out, root)
+  } else {
+    ()
+  }
+}
+
+/// The typed context for `path`, resolved the way `vibe check` resolves it.
+///
+/// `vibe check`'s pipeline is: collect every reachable module's INGESTED source
+/// (collect_source_groups_fs), seed them all into the ripple db, then walk.
+/// The seeding is load-bearing -- the walk short-circuits on any module whose
+/// source it cannot find, so skipping it makes every import resolve to
+/// `CtUnknown` and quietly turns every typed filter into a coin flip.
+///
+/// `projected_import_env_for_test` is the exported name for the exact
+/// dependency projection production uses for `ModuleJob.dep_envs`
+/// (typecheck_fs.vibe) -- test-only in NAME, not in behaviour.
+///
+/// Degrades to single-file typing when the graph cannot be resolved at all, so
+/// one broken dependency costs precision on that file instead of killing the
+/// sweep. On a file with imports that fallback reports imported names as
+/// unknown, which makes `--only-ill-typed` over-report rather than miss sites.
+fn grep_fs_typed_context(path: String, raw_source: String) -> GrepTyped with Fs {
+  handle {
+    let groups = collect_source_groups_fs(path)
+    let mut rdb = ripple_new()
+    let mut entry_source = raw_source
+    let mut gi = 0
+    while gi < Array::length(groups) {
+      let (_, sources) = Array::get(groups, gi)
+      let mut si = 0
+      while si < Array::length(sources) {
+        let (p, text) = Array::get(sources, si)
+        rdb = ripple_set_source(rdb, p, text)
+        if p == path {
+          entry_source = text
+        } else {
+          ()
+        }
+        si = si + 1
+      }
+      gi = gi + 1
+    }
+    let (_, walked, env_cache, _, _) = ensure_fingerprint_fs_impl(rdb, grep_fs_empty_env_cache(), grep_fs_empty_pairs(), 0, path)
+    let deps = match ripple_get_deps(walked, path) {
+      Some(d) => d,
+      None => grep_empty_strings()
+    }
+    let import_env = projected_import_env_for_test(entry_source, path, deps, grep_fs_fill_dep_envs(walked, env_cache, deps))
+    grep_typed_context(raw_source, entry_source, import_env)
+  } with Exception {
+    // The graph did not check. That is a real answer, not a reason to fall
+    // back to single-file typing: doing so would type-check this file against
+    // an empty environment, find nothing wrong with it, and report every match
+    // in a program that does not compile as `--only-well-typed`.
+    Throw(msg) => grep_typed_context_error(raw_source, msg)
+  }
+}
+
+fn grep_fs_cache_has(cache: Array[(String, TypeEnv)], path: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(cache) {
+    let (p, _) = Array::get(cache, i)
+    if p == path {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// Fill in the dependency environments the walk did NOT return in-memory.
+///
+/// `ensure_fingerprint_fs_impl` only adds a module to its env cache when it
+/// actually re-checks it; a module whose persistent environment was already on
+/// disk is recorded in the ripple db and skipped. That is the normal (warm)
+/// case, so without this step a repeat run resolves imports against an empty
+/// cache -- `projected_import_env_for_test` then throws and every imported name
+/// types as `CtUnknown`. Reading each missing dependency back from the same
+/// persistent store the walk published to is what makes the typed tier behave
+/// the same warm as cold.
+fn grep_fs_fill_dep_envs(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], deps: Array[String]) -> Array[(String, TypeEnv)] with Exception + Fs {
+  let mut i = 0
+  while i < Array::length(deps) {
+    let dep = Array::get(deps, i)
+    if !grep_fs_cache_has(env_cache, dep) {
+      match ripple_get_fingerprint(rdb, dep) {
+        Some(fingerprint) => match load_persistent_type_env(fingerprint) {
+          Some(dep_env) => Array::push(env_cache, (dep, dep_env)),
+          None => ()
+        },
+        None => ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  env_cache
+}
+
+/// `vibe grep <root>` proper. Typing runs only for files that already have a
+/// structural match: typing a file the pattern never hits would be pure cost.
+export fn grep_scan_fs(root: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> String with Exception + Fs {
+  let pat = grep_compile_pattern(pattern)
+  grep_check_filters(pat, wheres, where_rows)
+  let files = grep_empty_strings()
+  grep_fs_collect_files(root, files)
+  let typed = grep_needs_typing(wheres, where_rows, only)
+  let out = grep_empty_strings()
+  let mut i = 0
+  while i < Array::length(files) {
+    let path = Array::get(files, i)
+    let source = Fs::read_file(path)
+    // A file that does not parse is not a match and not a failure: a repo
+    // sweep must not stop at the first work-in-progress file.
+    let hits = handle {
+      grep_file_hits(path, source, pat)
+    } with Exception {
+      Throw(_) => grep_empty_hits()
+    }
+    if Array::length(hits) > 0 {
+      let ctx = if typed {
+        grep_fs_typed_context(path, source)
+      } else {
+        grep_untyped_context()
+      }
+      grep_emit_hits(source, hits, ctx, typed, wheres, where_rows, only, json, out)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  grep_join_lines(out, json)
+}

--- a/lib/@vibe/compiler/runtime/grep_fs.vibe
+++ b/lib/@vibe/compiler/runtime/grep_fs.vibe
@@ -67,10 +67,18 @@ fn grep_fs_is_source_name(name: String) -> Bool {
   String::ends_with(name, ".vibe") || String::ends_with(name, ".vibex")
 }
 
-/// Directories a repo sweep must never descend into: build output and vendored
-/// trees are not the user's source, and walking them dominates the runtime.
+/// Directories a recursive sweep does not descend into: build output and
+/// vendored trees are not the user's source, and walking them dominates the
+/// runtime. `deps` is where `vibe fetch` vendors packages (and, since relative
+/// imports nest, each vendored package's own `deps` under that), so the
+/// default `vibe grep ... .` would otherwise report the whole transitive
+/// dependency tree as if it were project code.
+///
+/// This only applies while RECURSING. A directory named here is still searched
+/// when the caller names it: `vibe grep --pattern '..' deps` asks for exactly
+/// that, and a skip list must not override what was asked for.
 fn grep_fs_skip_dir(name: String) -> Bool {
-  String::starts_with(name, ".") || name == "_build" || name == "node_modules" || name == "dist" || name == "target"
+  String::starts_with(name, ".") || name == "_build" || name == "node_modules" || name == "dist" || name == "target" || name == "deps"
 }
 
 fn grep_fs_join(dir: String, name: String) -> String {

--- a/lib/@vibe/compiler/runtime/grep_test.vibe
+++ b/lib/@vibe/compiler/runtime/grep_test.vibe
@@ -56,9 +56,13 @@ fn scan_err(source: String, pattern: String, wheres: Array[String]) -> String {
 /// The same scan the FS tier performs when the import graph fails to check:
 /// matching still runs, but the typed context carries the failure.
 fn grep_error_scan(source: String, pattern: String, only: String) -> String with Exception {
+  grep_error_scan_where(source, pattern, no_strings(), only)
+}
+
+fn grep_error_scan_where(source: String, pattern: String, wheres: Array[String], only: String) -> String with Exception {
   let hits = grep_file_hits("a.vibe", source, grep_compile_pattern(pattern))
   let out = grep_empty_strings()
-  grep_emit_hits(source, hits, grep_typed_context_error(source, "dep.vibe: line 1:1: boom"), true, no_strings(), no_strings(), only, false, out)
+  grep_emit_hits(source, hits, grep_typed_context_error(source, "dep.vibe: line 1:1: boom"), true, wheres, no_strings(), only, false, out)
   grep_join_lines(out, false)
 }
 
@@ -200,6 +204,23 @@ test "grep: a file whose typing failed outright is never reported well-typed" {
   // source offset, so there is nothing to look the type up BY -- the filter
   // drops it instead of guessing. Same boundary the docs state.
   inspect(scan_where(src, "f($(x:const))", "$x : Int"), "")
+}
+
+test "grep --where `=`: a failed typing drops the match instead of answering from the alias table" {
+  // The alias table is SYNTACTIC and survives a failed typing, so `$f = helper`
+  // could otherwise report a name as RESOLVED that the checker never validated
+  // -- a missing module, or a name the dependency does not export (#1533).
+  let src = "import ./dep.vibe {\n  helper as h\n}\nlet a = h(1)\n"
+  inspect(scan_where(src, "$(f:id)($(_:exp))", "$f = helper"), "a.vibe:4:9: h(1)\t$f=h\n")
+  inspect(grep_error_scan_where(src, "$(f:id)($(_:exp))", one_string("$f = helper"), ""), "")
+}
+
+test "grep: a filter with nothing after its operator is an error" {
+  // Otherwise `--where '$x :'` only misbehaves on a file that happens to match,
+  // so a sweep with no hits returns the empty output that means "no match".
+  inspect(scan_err("let a = f(1)\n", "f($(x:exp))", one_string("$x :")), "--where: nothing after `:` in `$x`")
+  inspect(scan_err("let a = f(1)\n", "f($(x:exp))", one_string("$x =")), "--where: nothing after `=` in `$x`")
+  inspect(scan_err("let a = f(1)\n", "f($(x:exp))", one_string("$x with ")), "--where: nothing after `with` in `$x`")
 }
 
 test "grep: a malformed pattern says what to write instead of matching nothing" {

--- a/lib/@vibe/compiler/runtime/grep_test.vibe
+++ b/lib/@vibe/compiler/runtime/grep_test.vibe
@@ -1,0 +1,221 @@
+//# Imports
+
+// #1572 `vibe grep`: structural AST search plus the type-aware filters.
+// Every case here drives grep_scan_source (the no-Fs seam) so the whole
+// pattern language, the capture wire format and the typed filters are
+// covered without touching the filesystem.
+
+import ./grep.vibe {
+  grep_compile_pattern, grep_emit_hits, grep_empty_strings, grep_file_hits, grep_join_lines, grep_scan_source, grep_typed_context_error
+}
+
+import @vibe/core {
+  array_empty, inspect
+}
+
+//# Functions
+
+fn no_strings() -> Array[String] {
+  array_empty()
+}
+
+fn one_string(a: String) -> Array[String] {
+  let out = no_strings()
+  Array::push(out, a)
+  out
+}
+
+fn scan(source: String, pattern: String) -> String with Exception {
+  grep_scan_source("a.vibe", source, pattern, no_strings(), no_strings(), "", false)
+}
+
+fn scan_where(source: String, pattern: String, where_clause: String) -> String with Exception {
+  grep_scan_source("a.vibe", source, pattern, one_string(where_clause), no_strings(), "", false)
+}
+
+fn scan_row(source: String, pattern: String, row_clause: String) -> String with Exception {
+  grep_scan_source("a.vibe", source, pattern, no_strings(), one_string(row_clause), "", false)
+}
+
+fn scan_only(source: String, pattern: String, only: String) -> String with Exception {
+  grep_scan_source("a.vibe", source, pattern, no_strings(), no_strings(), only, false)
+}
+
+/// The error message a bad pattern / bad filter produces, or "" when the scan
+/// unexpectedly succeeded. The whole point of these cases is that the message
+/// tells the caller what to type instead.
+fn scan_err(source: String, pattern: String, wheres: Array[String]) -> String {
+  handle {
+    let _ = grep_scan_source("a.vibe", source, pattern, wheres, no_strings(), "", false)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+/// The same scan the FS tier performs when the import graph fails to check:
+/// matching still runs, but the typed context carries the failure.
+fn grep_error_scan(source: String, pattern: String, only: String) -> String with Exception {
+  let hits = grep_file_hits("a.vibe", source, grep_compile_pattern(pattern))
+  let out = grep_empty_strings()
+  grep_emit_hits(source, hits, grep_typed_context_error(source, "dep.vibe: line 1:1: boom"), true, no_strings(), no_strings(), only, false, out)
+  grep_join_lines(out, false)
+}
+
+fn count_lines(text: String) -> Int {
+  let len = String::length(text)
+  let mut i = 0
+  let mut n = 0
+  while i < len {
+    if String::char_code_at(text, i) == 10 {
+      n = n + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  n
+}
+
+//# Tests
+
+test "grep: a literal pattern matches only the identical call" {
+  let src = "let a = f(1)\nlet b = f(2)\nlet c = g(1)\n"
+  inspect(scan(src, "f(1)"), "a.vibe:1:9: f(1)\n")
+}
+
+test "grep: an `exp` metavariable matches any argument and captures it" {
+  let src = "let a = f(1)\nlet b = f(g(2))\n"
+  inspect(scan(src, "f($(x:exp))"), "a.vibe:1:9: f(1)\t$x=1\na.vibe:2:9: f(g(2))\t$x=g(2)\n")
+}
+
+test "grep: `args` matches any arity, including zero" {
+  let src = "let a = f()\nlet b = f(1)\nlet c = f(1, 2, 3)\n"
+  inspect(scan(src, "f($(a:args))"), "a.vibe:1:9: f()\t$a=\na.vibe:2:9: f(1)\t$a=1\na.vibe:3:9: f(1, 2, 3)\t$a=1, 2, 3\n")
+}
+
+test "grep: `args` in the middle keeps the fixed head and tail positions" {
+  let src = "let a = f(1, 9)\nlet b = f(1, 5, 6, 9)\nlet c = f(2, 9)\n"
+  inspect(scan(src, "f(1, $(mid:args), 9)"), "a.vibe:1:9: f(1, 9)\t$mid=\na.vibe:2:9: f(1, 5, 6, 9)\t$mid=5, 6\n")
+}
+
+test "grep: `id` only takes identifiers, `const` only literals" {
+  let src = "let a = f(1)\nlet b = f(x)\n"
+  inspect(scan(src, "f($(n:id))"), "a.vibe:2:9: f(x)\t$n=x\n")
+  inspect(scan(src, "f($(k:const))"), "a.vibe:1:9: f(1)\t$k=1\n")
+}
+
+test "grep: a repeated metavariable must agree, `_` never has to" {
+  let src = "let a = f(x, x)\nlet b = f(x, y)\n"
+  inspect(scan(src, "f($(v:exp), $(v:exp))"), "a.vibe:1:9: f(x, x)\t$v=x\n")
+  inspect(count_lines(scan(src, "f($(_:exp), $(_:exp))")), "2")
+}
+
+test "grep: matching is formatting-insensitive (AST, not text)" {
+  let spread = "let a = f(\n  1,\n  2\n)\n"
+  inspect(scan(spread, "f(1, 2)"), "a.vibe:1:9: f(1, 2)\n")
+}
+
+test "grep: match arms with a `pat` metavariable" {
+  let src = "let a = match v { Some(k) => k, None => 0 }\n"
+  inspect(scan(src, "match $(s:exp) { Some($(p:pat)) => $(b:exp), None => 0 }"), "a.vibe:1:15: match v { Some(k) => k, None => 0 }\t$s=v\t$p=k\t$b=k\n")
+}
+
+test "grep: a `type` metavariable matches a lambda's annotation" {
+  let src = "let a = (x: Int) -> Int { x }\n"
+  inspect(scan(src, "(x: $(t:type)) -> Int { x }"), "a.vibe:1:27: (x: Int) -> Int { x }\t$t=Int\n")
+}
+
+test "grep: a method call keeps its shape; the pipe form parses to a plain call" {
+  let src = "let a = xs.map(f)\nlet b = xs |> map(f)\nlet c = map(xs, f)\n"
+  inspect(scan(src, "$(r:exp).map($(f:exp))"), "a.vibe:1:9: xs.map(f)\t$r=xs\t$f=f\n")
+  inspect(scan(src, "map($(a:args))"), "a.vibe:2:9: map(xs, f)\t$a=xs, f\na.vibe:3:9: map(xs, f)\t$a=xs, f\n")
+}
+
+test "grep: nested matches are reported as the separate sites they are" {
+  let src = "let a = f(f(1))\n"
+  inspect(scan(src, "f($(x:exp))"), "a.vibe:1:9: f(f(1))\t$x=f(1)\na.vibe:1:11: f(1)\t$x=1\n")
+}
+
+test "grep: JSON output carries offsets and per-capture spans" {
+  let src = "let a = f(1)\n"
+  inspect(grep_scan_source("a.vibe", src, "f($(x:const))", no_strings(), no_strings(), "", true), "[\n  {\"path\":\"a.vibe\",\"line\":1,\"col\":9,\"start\":8,\"end\":9,\"text\":\"f(1)\",\"captures\":{\"x\":{\"text\":\"1\",\"start\":-1}}}\n]\n")
+}
+
+test "grep: no match is empty output, in both text and JSON form" {
+  let src = "let a = f(1)\n"
+  inspect(scan(src, "zzz(1)"), "")
+  inspect(grep_scan_source("a.vibe", src, "zzz(1)", no_strings(), no_strings(), "", true), "[]\n")
+}
+
+test "grep --where: filter a capture by its inferred type" {
+  let src = "let f = (v: Int) -> Int { v }\nlet g = (v: String) -> String { v }\nlet n = 1\nlet s = \"x\"\nlet a = f(n)\nlet b = g(s)\n"
+  inspect(scan_where(src, "$(c:id)($(x:exp))", "$x : Int"), "a.vibe:5:9: f(n)\t$c=f\t$x=n\n")
+  inspect(scan_where(src, "$(c:id)($(x:exp))", "$x : String"), "a.vibe:6:9: g(s)\t$c=g\t$x=s\n")
+}
+
+test "grep --where: `_` is a wildcard inside the requested type" {
+  let src = "let f = (v: Array[Int]) -> Int { 0 }\nlet xs = [\n  1\n]\nlet a = f(xs)\n"
+  inspect(scan_where(src, "f($(x:exp))", "$x : Array[_]"), "a.vibe:5:9: f(xs)\t$x=xs\n")
+  inspect(scan_where(src, "f($(x:exp))", "$x : Array[String]"), "")
+}
+
+test "grep --where: `=` compares the RESOLVED name, seeing through an alias" {
+  let src = "import ./dep.vibe {\n  helper as h\n}\nlet other = (v: Int) -> Int { v }\nlet a = h(1)\nlet b = other(1)\n"
+  inspect(scan_where(src, "$(f:id)($(_:exp))", "$f = helper"), "a.vibe:5:9: h(1)\t$f=h\n")
+  inspect(scan_where(src, "$(f:id)($(_:exp))", "$f = h"), "")
+}
+
+test "grep: `exp` declines a labeled argument, `arg` takes one" {
+  let src = "let f = (a: Int, b: Int) -> Int { a + b }\nlet x = f(1, b=2)\n"
+  inspect(scan(src, "f(1, $(v:exp))"), "")
+  inspect(scan(src, "f(1, $(v:arg))"), "a.vibe:2:9: f(1, b=2)\t$v=b=2\n")
+}
+
+test "grep --where-row: keep or drop by what a callee's effect row carries" {
+  let src = "let readit = (p: String) -> String with Fs {\n  Fs::read_file(p)\n}\nlet plain = (p: String) -> String {\n  p\n}\nlet run = (q: String) -> String with Fs {\n  let a = readit(q)\n  plain(a)\n}\n"
+  // A capability builtin carries the row too, so it is a genuine hit here.
+  inspect(scan_row(src, "$(f:id)($(x:id))", "$f with Fs"), "a.vibe:2:3: Fs::read_file(p)\t$f=Fs::read_file\t$x=p\na.vibe:8:11: readit(q)\t$f=readit\t$x=q\n")
+  inspect(scan_row(src, "$(f:id)($(x:id))", "$f without Fs"), "a.vibe:9:3: plain(a)\t$f=plain\t$x=a\n")
+}
+
+test "grep --only-well-typed / --only-ill-typed split a file by its type error" {
+  let good = "let f = (x: Int) -> Int { x }\nlet a = f(1)\n"
+  inspect(scan_only(good, "f($(x:exp))", "well"), "a.vibe:2:9: f(1)\t$x=1\n")
+  inspect(scan_only(good, "f($(x:exp))", "ill"), "")
+  let bad = "let f = (x: Int) -> Int { x }\nlet a = f(\"s\")\n"
+  inspect(scan_only(bad, "f($(x:exp))", "ill"), "a.vibe:2:9: f(\"s\")\t$x=\"s\"\n")
+  inspect(scan_only(bad, "f($(x:exp))", "well"), "")
+}
+
+test "grep: a file whose typing failed outright is never reported well-typed" {
+  // The FS tier lands here whenever the import graph itself fails to check
+  // (grep_fs.vibe). An empty context would call the file clean; this one must
+  // not, and its `--where` filters must drop rather than guess.
+  let src = "let f = (x: Int) -> Int { x }\nlet a = f(1)\n"
+  inspect(grep_scan_source("a.vibe", src, "f($(x:exp))", no_strings(), no_strings(), "well", false), "a.vibe:2:9: f(1)\t$x=1\n")
+  inspect(grep_error_scan(src, "f($(x:exp))", "well"), "")
+  inspect(grep_error_scan(src, "f($(x:exp))", "ill"), "a.vibe:2:9: f(1)\t$x=1\n")
+  // A capture with no identifier-shaped token (a bare literal) carries no
+  // source offset, so there is nothing to look the type up BY -- the filter
+  // drops it instead of guessing. Same boundary the docs state.
+  inspect(scan_where(src, "f($(x:const))", "$x : Int"), "")
+}
+
+test "grep: a malformed pattern says what to write instead of matching nothing" {
+  inspect(scan_err("let a = 1\n", "f($x)", no_strings()), "grep pattern: `$` must start a metavariable `$(name:kind)`")
+  inspect(scan_err("let a = 1\n", "f($(x))", no_strings()), "grep pattern: expected `$(name:kind)`, e.g. `$(x:exp)`")
+  inspect(scan_err("let a = 1\n", "f($(x:exp", no_strings()), "grep pattern: unterminated metavariable — expected `)` after `$(name:kind)`")
+  inspect(scan_err("let a = 1\n", "f($(x:exp)", no_strings()), "grep pattern: expected ) but got eof at #3")
+  inspect(scan_err("let a = 1\n", "f($(x:expr))", no_strings()), "grep pattern: unknown metavariable kind `expr` — use one of exp, id, const, arg, args, pat, type")
+  inspect(scan_err("let a = 1\n", "f($(a:args), $(b:args))", no_strings()), "grep pattern: at most one `args` metavariable per argument list")
+  inspect(scan_err("let a = 1\n", "let x = 1", no_strings()), "grep pattern: must be a single EXPRESSION — declaration patterns (`fn`, top-level `let`, `enum`, ...) are not supported yet; use `vibe symbols` for declarations")
+}
+
+test "grep --where: a clause naming an uncaptured metavariable is an error" {
+  inspect(scan_err("let a = f(1)\n", "f($(x:exp))", one_string("$y : Int")), "--where: the pattern never captures `$y`")
+  // ...even when nothing in the searched source matches the pattern at all.
+  // Reporting this only on a matching file would let a typo'd clause come back
+  // as the empty output that means "clean".
+  inspect(scan_err("let a = 1\n", "f($(x:exp))", one_string("$y : Int")), "--where: the pattern never captures `$y`")
+}

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -154,6 +154,43 @@ fn symbol_spans(source: String) -> Array[(String, Int, Int, Int)] with Exception
 // codegen's own `is_mut_captured_in`, so the answer IS the lowering decision.
 fn escape_spans(source: String) -> Array[(String, Int, Int)] with Exception
 
+// --- grep.vibe (#1572): `vibe grep` — AST pattern search whose filters run on
+// the CHECKER's answers (a capture's inferred type / effect row / resolved
+// name, and whether the declaration around the match type-checks), not on the
+// grammar alone the way moongrep and ast-grep do.
+//
+// The three types are `opaque` for the same reason graph's `RippleDb` and this
+// package's own `ModuleOutcome` are: the only thing outside grep.vibe that
+// ever holds one is grep_fs.vibe, and it exclusively passes them back in.
+// Everything below except `grep_scan_fs` exists to serve that one caller plus
+// grep_test.vibe -- grep.vibe deliberately does not import typecheck_fs.vibe
+// (whose `ModuleJob` is declared here rather than in the file, so any file
+// reaching it needs this contract in scope), which is what keeps the whole
+// pattern language testable through plain sibling leaf imports.
+opaque type GrepHit
+opaque type GrepPattern
+opaque type GrepTyped
+
+fn grep_compile_pattern(pattern: String) -> GrepPattern with Exception
+fn grep_check_filters(pat: GrepPattern, wheres: Array[String], where_rows: Array[String]) -> Unit with Exception
+fn grep_file_hits(path: String, source: String, pat: GrepPattern) -> Array[GrepHit] with Exception
+fn grep_empty_hits() -> Array[GrepHit]
+fn grep_empty_strings() -> Array[String]
+fn grep_needs_typing(wheres: Array[String], where_rows: Array[String], only: String) -> Bool
+fn grep_typed_context(source: String, typed_source: String, import_env: TypeEnv) -> GrepTyped
+fn grep_untyped_context() -> GrepTyped
+fn grep_typed_context_error(source: String, message: String) -> GrepTyped
+fn grep_emit_hits(source: String, hits: Array[GrepHit], ctx: GrepTyped, typed: Bool, wheres: Array[String], where_rows: Array[String], only: String, json: Bool, out: Array[String]) -> Unit with Exception
+fn grep_join_lines(lines: Array[String], json: Bool) -> String
+// Single-source seam: typed filters resolved against THIS FILE ALONE. Only
+// grep_test.vibe uses it; `vibe grep` always goes through grep_scan_fs.
+fn grep_scan_source(path: String, source: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> String with Exception
+
+// --- grep_fs.vibe (#1572 scope 3): the filesystem tier. Typing runs only for
+// files that already have a structural match, through the same FS import walk
+// `vibe check` uses.
+fn grep_scan_fs(root: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> String with Exception + Fs
+
 // --- deprecated_scan.vibe (#1262 / ADR-0101): uses, in entry_source, of
 // names whose declarations carry a `#deprecated` marker (in the entry itself
 // or any dep source). Token-level; one formatted `warning:` line per use.

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -51,6 +51,16 @@
 #                                         a heap ref cell instead of a wasm local
 #                                         (NAME START END per line; empty = none)
 #   vibe diagnostics <file.vibe>          print all syntax/type diagnostics
+#   vibe grep --pattern '<pat>' [paths]   AST pattern search (#1572). Metavars
+#                                         are `$(name:kind)`, kind = exp / id /
+#                                         const / arg / args / pat / type.
+#                                         Type-aware filters (these resolve
+#                                         imports like `vibe check` does):
+#                                           --where '$x : Array[Int]'  inferred type
+#                                           --where '$f = Iterator::map' resolved name
+#                                           --where-row '$f with Async'  effect row
+#                                           --only-ill-typed / --only-well-typed
+#                                         --json for machine-readable output
 #   vibe normalize [--check|--stdout] <file.vibe>
 #                                         canonicalize a source file in place
 #                                         (--check: exit 1 if not normalized;
@@ -1142,6 +1152,82 @@ case "$cmd" in
     # A clean file yields empty output; this subcommand always exits 0 (a report,
     # not a failure), so the LSP can treat empty as "no diagnostics".
     if [ -s "$out" ]; then cat "$out"; fi
+    ;;
+  grep)
+    # vibe grep [flags] --pattern '<pattern>' [paths...]        (#1572)
+    #
+    # Structural AST search. Unlike moongrep / ast-grep, the filters run on the
+    # CHECKER's answers, not on the grammar alone:
+    #   --where '$x : Array[Int]'    the capture's INFERRED type (`_` wildcard)
+    #   --where '$f = Iterator::map' the capture's RESOLVED name (sees through
+    #                                `import { Iterator as It }`)
+    #   --where-row '$f with Async' / '$f without Async'
+    #                                the capture's effect ROW
+    #   --only-ill-typed / --only-well-typed
+    #                                keep matches in declarations that do (not)
+    #                                type-check
+    # Any of those switches the sweep into the typed tier, which resolves
+    # imports through the same walk `vibe check` uses -- `vibe diagnostics`'s
+    # import-blind false positives are not reproduced here.
+    #
+    # Output is one match per line, `path:line:col: <matched text>` followed by
+    # tab-separated `$var=<capture>`; `--json` emits the same matches as a JSON
+    # array (each capture carrying its inferred type when the typed tier ran).
+    # Empty output = no match. A report, not a failure: only a bad pattern or a
+    # bad filter is an error.
+    g_pattern=""; g_json=0; g_only=""; g_where=""; g_where_row=""
+    g_paths=()
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --pattern) [ "$#" -ge 2 ] || die "vibe grep: --pattern needs an argument"; g_pattern="$2"; shift 2 ;;
+        --pattern=*) g_pattern="${1#--pattern=}"; shift ;;
+        --json|--output-json) g_json=1; shift ;;
+        --where) [ "$#" -ge 2 ] || die "vibe grep: --where needs an argument"; g_where="$g_where$2"$'\n'; shift 2 ;;
+        --where=*) g_where="$g_where${1#--where=}"$'\n'; shift ;;
+        --where-row) [ "$#" -ge 2 ] || die "vibe grep: --where-row needs an argument"; g_where_row="$g_where_row$2"$'\n'; shift 2 ;;
+        --where-row=*) g_where_row="$g_where_row${1#--where-row=}"$'\n'; shift ;;
+        --only-ill-typed) g_only="ill"; shift ;;
+        --only-well-typed) g_only="well"; shift ;;
+        --) shift; while [ "$#" -gt 0 ]; do g_paths+=("$1"); shift; done ;;
+        -*) die "vibe grep: unknown flag: $1" ;;
+        *) g_paths+=("$1"); shift ;;
+      esac
+    done
+    [ -n "$g_pattern" ] || die "usage: vibe grep --pattern '<pattern>' [--where '\$x : T'] [--where-row '\$f with E'] [--only-ill-typed|--only-well-typed] [--json] [paths...]"
+    # No path means "here", the same default `grep -r` and `rg` use.
+    [ "${#g_paths[@]}" -gt 0 ] || g_paths=(".")
+    # Each root produces its own JSON array, so several roots could not be one
+    # document. Reject that instead of emitting text no JSON parser accepts.
+    if [ "$g_json" = "1" ] && [ "${#g_paths[@]}" -gt 1 ]; then
+      die "vibe grep --json: one path at a time (JSON output is a single array)"
+    fi
+    cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
+    out="$(mktemp -t vibe-grep-XXXXXX)"
+    trap 'rm -f "$out" "$out.diag"' EXIT
+    for g_path in "${g_paths[@]}"; do
+      [ -e "$g_path" ] || die "not found: $g_path"
+      # Clear inherited adapter-mode envs so a leaked selector can't divert this
+      # into compiling and emitting wasm bytes as "matches".
+      env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+          -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_COVERAGE -u VIBE_DEBUG \
+          -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
+        VIBE_GREP=1 \
+        VIBE_GREP_PATTERN="$g_pattern" \
+        VIBE_GREP_WHERE="$g_where" \
+        VIBE_GREP_WHERE_ROW="$g_where_row" \
+        VIBE_GREP_ONLY="$g_only" \
+        VIBE_GREP_JSON="$g_json" \
+        VIBE_IMPORT_ABI=raw \
+        "$RUNNER" "$cli" "$g_path" "$out" >/dev/null 2>&1 || true
+      # A bad pattern is the caller's mistake, not a partial result: stop
+      # instead of sweeping the remaining roots with the same broken pattern.
+      if [ -s "$out.diag" ]; then
+        echo "error: $(cat "$out.diag")" >&2
+        die "grep failed"
+      fi
+      if [ -s "$out" ]; then cat "$out"; fi
+      : >"$out"
+    done
     ;;
   normalize)
     # vibe normalize [--check|--stdout] <file.vibe>  (#882)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -10026,4 +10026,87 @@ done
 rm -rf "$dvdir"
 echo "[compiler-gate] desugar-emitted builtins resolve in both lanes ok"
 
+echo "[compiler-gate] 98/98 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
+# grep_test.vibe covers the pattern language and the filters through
+# grep_scan_source (no Fs). What only the REAL adapter mode exercises is the
+# filesystem tier: sweeping a directory, and resolving a capture's type through
+# the same FS import walk `vibe check` uses. That resolution is the whole point
+# of the feature and it is the part that silently degrades -- seeding the module
+# sources wrong makes every import type as `CtUnknown`, at which point the
+# filters keep answering, just wrongly.
+gvdir="_build/_gate_vibe_grep"
+rm -rf "$gvdir"; mkdir -p "$gvdir"
+cat > "$gvdir/dep.vibe" <<'VEOF'
+export fn helper(v: Int) -> Int {
+  v + 1
+}
+VEOF
+cat > "$gvdir/main.vibe" <<'VEOF'
+import ./dep.vibe {
+  helper as h
+}
+
+fn readit(p: String) -> String with Fs {
+  Fs::read_file(p)
+}
+
+fn plain(p: String) -> String {
+  p
+}
+
+fn run(q: String) -> String with Fs {
+  let a = readit(q)
+  let b = h(1)
+  String::concat(plain(a), __to_string(b))
+}
+VEOF
+gv_run() {
+  # $1 = output basename, $2.. = extra env assignments (name=value)
+  local gv_out="$gvdir/$1"; shift
+  rm -f "$gv_out" "$gv_out.diag"
+  env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_GREP=1 "$@" \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$gvdir" "$gv_out" >/dev/null 2>&1 || true
+}
+# Parse-only tier: every call in the directory, whatever its arity.
+gv_run all.txt VIBE_GREP_PATTERN='$(f:id)($(a:args))'
+for gv_want in 'readit(q)' 'h(1)' 'plain(a)' 'Fs::read_file(p)'; do
+  if ! grep -qF "$gv_want" "$gvdir/all.txt"; then
+    echo "[compiler-gate] FAIL: vibe grep did not find $gv_want" >&2
+    cat "$gvdir/all.txt" "$gvdir/all.txt.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+if ! grep -q '^.*main\.vibe:[0-9][0-9]*:[0-9][0-9]*: ' "$gvdir/all.txt"; then
+  echo "[compiler-gate] FAIL: vibe grep output is not path:line:col-prefixed" >&2
+  cat "$gvdir/all.txt" >&2
+  exit 1
+fi
+# Typed tier: the effect row of the CALLEE, which only exists if the import
+# walk actually resolved the module graph.
+gv_run row.txt VIBE_GREP_PATTERN='$(f:id)($(a:args))' VIBE_GREP_WHERE_ROW='$f with Fs'
+if ! grep -qF 'readit(q)' "$gvdir/row.txt" || grep -qF 'plain(a)' "$gvdir/row.txt"; then
+  echo "[compiler-gate] FAIL: --where-row '\$f with Fs' kept the wrong sites" >&2
+  cat "$gvdir/row.txt" "$gvdir/row.txt.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# Resolved-name filter: `h` is an ALIAS for dep.vibe's `helper`, so a text grep
+# for `helper(` finds nothing here and this must still find it.
+gv_run alias.txt VIBE_GREP_PATTERN='$(f:id)($(a:args))' VIBE_GREP_WHERE='$f = helper'
+if ! grep -qF 'h(1)' "$gvdir/alias.txt"; then
+  echo "[compiler-gate] FAIL: --where '\$f = helper' did not resolve the import alias" >&2
+  cat "$gvdir/alias.txt" "$gvdir/alias.txt.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# A bad pattern is an ERROR on the .diag sidecar, never a plausible-but-wrong
+# match list on output_path (the VIBE_SYMBOLS convention).
+gv_run bad.txt VIBE_GREP_PATTERN='f($(x:expr))'
+if [ -s "$gvdir/bad.txt" ] || ! grep -q 'unknown metavariable kind' "$gvdir/bad.txt.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a bad grep pattern did not land on the .diag sidecar" >&2
+  cat "$gvdir/bad.txt" "$gvdir/bad.txt.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$gvdir"
+echo "[compiler-gate] vibe grep typed filters ok"
+
 echo "[compiler-gate] ok"


### PR DESCRIPTION
Closes #1572.

`vibe symbols` / `type-at` / `binding-at` / `escapes` はどれも「位置 → 意味」の道具だった。`vibe grep` は逆向きの **「構造 → 位置」** で、editor query primitives の欠けていた 1 枚を埋める。

moongrep / ast-grep との差別化点は **filter が文法の語彙で閉じていない**こと。guard に正規表現を書くのではなく、checker の答え — capture の推論型・effect row・import alias 解決後の名前・型エラーの有無 — で絞る。

```bash
# 構造だけ (parse-only、import 解決なし)
vibe grep --pattern 'match $(v:exp) { Some($(x:pat)) => $(b:exp), None => $(n:exp) }' lib

# checker の答えで絞る (typed tier — `vibe check` と同じ import 解決に乗る)
vibe grep --pattern 'f($(x:exp))'          --where '$x : Array[_]'        lib
vibe grep --pattern '$(f:id)($(a:args))'   --where '$f = Iterator::map'   lib
vibe grep --pattern '$(f:id)($(a:args))'   --where-row '$f with Async'    lib
vibe grep --pattern 'f($(x:exp))'          --only-ill-typed               lib
```

出力は 1 件 1 行 `path:line:col: <マッチ本文>` + tab 区切り `$var=<capture>`。`--json` で機械可読（typed tier が走ったときは capture の推論型も載る）。空出力 = マッチなし、exit 0。

---

## スコープ 1: AST パターン照合

- メタ変数は moongrep の `$(name:kind)` 綴りを踏襲。kind は `exp` / `id` / `const` / `arg` / `pat` / `type` **+ `args`**
- **`args`**（0 個以上の連続引数、1 リストに 1 つまで）は #1572 の 6 kind への追加。これが無いと固定 arity しか書けず、移行作業が本当に必要とする「この関数の呼び出しサイト全部」(`Iterator::map($(a:args))`) が表現できない
- `$(` は現行 lexer で不正なので綴りは実ソースと衝突しない。メタ変数は予約識別子 (`__vgm_<kind>__<name>`) に書き換えて **通常の parser** に通す — テキスト正規表現ではなく AST 照合なので、改行・インデント・コメントの差は照合に影響しない
- 設計論点 1（desugar 前 AST）は **実測して書いた**: 両側が同じ parser を通るので desugar も同じで、`xs |> f(y)` と `f(xs, y)` は同一 AST として互いにマッチし、`x.f(y)` は `EDot` callee のまま method 綴りだけにマッチする
- **v1 の制約**: パターンは単一の**式**。宣言形 (`fn` / top-level `let` / `enum`) は「何にもマッチしない」のではなく、そう言うメッセージで拒否する

## スコープ 2: 型情報 filter

| flag | 意味 |
| --- | --- |
| `--where '$x : Array[_]'` | capture の推論型（`_` は wildcard） |
| `--where '$f = Iterator::map'` | **解決済みの名前**。`import { Iterator as It }` 越しの `It::map(...)` も同じクエリで拾える |
| `--where-row '$f with Async'` / `'$f without Fs'` | capture の effect row（bare な effect 名は operation にもマッチするので `with Fs` は `Fs::read_file` も拾う） |
| `--only-ill-typed` / `--only-well-typed` | 宣言単位。checker が報告する 1 件の型エラーと同じ top-level 宣言に居るマッチを ill-typed とする |

`--where` / `--where-row` は繰り返し可、AND で合成。

**「黙って誤らない」を型解決の各所に効かせた**（どれも実装中に実測で見つけた誤答）:

- **callee の型は offset テーブルではなく final environment から引く。** checker は call の *結果* を callee 自身の offset に記録するので、テーブルを読むと関数の型として結果型を自信満々に返してしまう（実測で `readit` が `String` になっていた）
- **`CtUnknown` は型ではなく「解決できなかった」印**なので answer として使わない。未解決の名前は `with` にも `without` にもマッチしない
- **import graph が check に失敗したファイルは型テーブルを持たない。** 単一ファイル typing にフォールバックすると「imports を知らないので綺麗に見える」ため、そこは必ず ill-typed 側に倒す（コンパイルの通らないプログラムが `--only-well-typed` に答えることは無い）
- **capture を持たない filter 節はファイルを読む前に弾く。** マッチしたファイルで初めて報告する形だと、typo した節が「空出力 = clean」として返ってしまう

型が取れない境界は docs に明記した: callee が local / parameter のとき、capture が識別子形のトークンを含まないとき（裸のリテラル）— いずれも推測せず落とす。

## スコープ 3: 実行モードの二層

- **parse-only（既定）**: import 解決なしで 1 ファイル 1 パス。`lib/@vibe` 全掃引が実測 **1.5 秒**
- **typed**（`--where` / `--where-row` / `--only-*` 指定時）: `vibe check` と **同じ** FS import walk に乗せる。#1572 が名指しした「`vibe diagnostics` が import を辿らず誤検知する罠」をこの機能で再生産しない。既に構造マッチのあるファイルだけ型付けする

## 実装配置

- `lib/@vibe/compiler/runtime/grep.vibe` — パターン compile / AST 照合 / filter / 出力。`typecheck_fs.vibe` を**意図的に import しない**（`ModuleJob` が contract 側宣言なので、辿ると `index.vpkg` 無しではコンパイルできなくなる）。おかげで `grep_test.vibe` が sibling leaf import だけで全機能を検査できる
- `lib/@vibe/compiler/runtime/grep_fs.vibe` — FS 層。`collect_source_groups_fs` で全モジュールの ingested source を seed してから walk する（seed しないと walk が全部 short-circuit して、あらゆる import が `CtUnknown` に落ちる — これも実測で踏んだ）
- 照合はファイル本文（`line:col` が実在の位置を指す）、型付けは ingested source（directory-shared import が前置される）。両者の差は前置分だけなので 1 つの offset delta で変換する

## テスト

- `grep_test.vibe` — 21 test。パターン言語（各 kind・`args` の前後固定・整形差非依存・重複メタ変数の一致・`_` の匿名性・ネストしたマッチ）、capture の wire format、JSON 形、型 filter 4 種、そして**エラーメッセージそのもの**（不正な kind / 二重 `args` / 宣言パターン / 未 capture の節）
- `compiler_gate.sh` 98/98 — adapter モードでしか通らない FS 層をディレクトリ掃引・effect row 振り分け・alias 解決・`.diag` sidecar の 4 点で押さえる

`bash scripts/compiler_gate.sh` (98/98)、`scripts/unit_test_runner.sh` (543/543)、`scripts/check_vibe_fmt.sh` (917 files) すべて green。

> `pkf run test` はこの環境では `sort` の glibc ABI 不一致で clean tree でも同じ位置で落ちるため（本 PR とは無関係）、内容にあたる `compiler_gate.sh` を直接流して確認した。

## 次の一手（本 PR 外）

- 宣言パターン（`fn` / `enum` shape）
- `projected_import_env_for_test` は production の依存射影そのものなので、名前から `_for_test` を落とすリネーム
- ADR-0096 Phase 1 / #1564 / #1559 の一括変換ツールをこの上に書く

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_