### PR TITLE
fix(compiler): inspect 展開の hygiene / shadow を直し、__DATA__ strip を全廃する (#1571)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,6 +571,36 @@ jobs:
           echo "$PWD/p3-tools" >> "$GITHUB_PATH"
       - name: Add wasm32 target for the http adapter
         run: rustup target add wasm32-unknown-unknown
+      # Phase C compiles a harness that IMPORTS `@vibe/compiler/...`, unlike
+      # phases A/B which only drive the compiler as a black box over plain
+      # .vibe inputs. That package's closure includes the five generated
+      # artifacts (gitignored build outputs), so without these steps the
+      # harness compile fails on `lib/@vibe/compiler/cache/index.vpkg:
+      # contract violation: contract declaration 'codegen_fingerprint' has no
+      # implementation`. ensure_generated.sh needs the seed, hence both.
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+      - name: Generated compiler artifacts (fingerprint)
+        id: p3genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Cache generated compiler artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+          key: gen-v1-${{ steps.p3genfp.outputs.fp }}
+      - name: Ensure generated compiler artifacts
+        run: bash scripts/ensure_generated.sh
       - name: Download stage2 artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,10 @@ jobs:
           VIBE_P3_GATE_PHASES: "async,http,stdin"
           VIBE_ASYNC_GATE_COMPILER: ${{ github.workspace }}/_build/ci-artifacts/stage2.wasm
           VIBE_SERVE_CLI_WASM: ${{ github.workspace }}/_build/ci-artifacts/stage2.wasm
+          # This job builds nothing: it has no generations tree and no seed
+          # (it never runs ensure_seed.sh), so phase C's shadow-component gate
+          # has to be pointed at the downloaded stage2 like the other two.
+          VIBE_STDIN_PROVIDER_GATE_COMPILER: ${{ github.workspace }}/_build/ci-artifacts/stage2.wasm
         run: bash scripts/test_wasi_p3_guarantee_gate.sh
 
   # Aggregate required check (branch protection requires "ci-required").

--- a/fixtures/async_await_multi.vibe
+++ b/fixtures/async_await_multi.vibe
@@ -23,7 +23,7 @@
 // Every future here is created ready, so the loop never runs -- what this pins
 // is that the hoist is correct wherever an await appears, and more than once.
 // 40 + 1 + 2 + 3 + 4 = 50.
-let _start = () -> Int with Async {
+export let main = () -> Int with Async {
   let a = await(Future::ready(40))
   let b = await(Stream::fold(Stream::once(1), 0, (acc, x) -> {
     acc + x
@@ -39,7 +39,12 @@ let _start = () -> Int with Async {
     acc + x
   }))
 }
-_start()
 
-__DATA__
-{"last":"50"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Async`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "async await multi" with Async {
+  inspect(main(), "50")
+}

--- a/fixtures/async_future_pending.vibe
+++ b/fixtures/async_future_pending.vibe
@@ -15,7 +15,7 @@
 // representation and the two builtins, not the scheduling.
 //
 // 41 + 1 = 42.
-let _start = () -> Int with Async {
+export let main = () -> Int with Async {
   let f = Future::pending()
   let g = Future::pending()
   Future::resolve(f, 41)
@@ -24,7 +24,12 @@ let _start = () -> Int with Async {
   let b = await(g)
   a + b
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Async`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "async future pending" with Async {
+  inspect(main(), "42")
+}

--- a/fixtures/closure_shadowed_inline_builtin.vibe
+++ b/fixtures/closure_shadowed_inline_builtin.vibe
@@ -55,7 +55,7 @@ fn add_builtin_mut() -> Int {
   add(1, 2)
 }
 
-let _start = () -> Int {
+export let main = () -> Int {
   let b = id_via_shadowed((x: Bool) -> Bool {
     x
   })
@@ -69,5 +69,9 @@ let _start = () -> Int {
   } + add_builtin() + add_builtin_mut()
 }
 
-__DATA__
-{"last": "28"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "closure shadowed inline builtin" {
+  inspect(main(), "28")
+}

--- a/fixtures/dtpw_wrapper_shadowed_by_parameter.vibe
+++ b/fixtures/dtpw_wrapper_shadowed_by_parameter.vibe
@@ -25,5 +25,9 @@ export let main = () -> Int {
   outer((x) -> 99)
 }
 
-__DATA__
-{"last": "99"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "dtpw wrapper shadowed by parameter" {
+  inspect(main(), "99")
+}

--- a/fixtures/effect_async_for_row.vibe
+++ b/fixtures/effect_async_for_row.vibe
@@ -41,5 +41,11 @@ export let main = () -> Int with Async {
   32 + total()
 }
 
-__DATA__
-{"last": "42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Async`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "effect async for row" with Async {
+  inspect(main(), "42")
+}

--- a/fixtures/effect_builtin_operation_row.vibe
+++ b/fixtures/effect_builtin_operation_row.vibe
@@ -21,5 +21,11 @@ export let main = () -> Int with Fs {
   42
 }
 
-__DATA__
-{"last": "42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Fs`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "effect builtin operation row" with Fs {
+  inspect(main(), "42")
+}

--- a/fixtures/effect_generic_row_instantiation.vibe
+++ b/fixtures/effect_generic_row_instantiation.vibe
@@ -23,5 +23,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect generic row instantiation" {
+  inspect(main(), "42")
+}

--- a/fixtures/effect_handle_call_evidence.vibe
+++ b/fixtures/effect_handle_call_evidence.vibe
@@ -48,5 +48,9 @@ export let main = () -> Int {
   count * 1000 + r
 }
 
-__DATA__
-{"last": "3013"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence" {
+  inspect(main(), "3013")
+}

--- a/fixtures/effect_handle_call_evidence_branch.vibe
+++ b/fixtures/effect_handle_call_evidence_branch.vibe
@@ -63,5 +63,9 @@ export let main = () -> Int {
   count * 1000 + r
 }
 
-__DATA__
-{"last": "2007"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence branch" {
+  inspect(main(), "2007")
+}

--- a/fixtures/effect_handle_call_evidence_closure_literal.vibe
+++ b/fixtures/effect_handle_call_evidence_closure_literal.vibe
@@ -53,5 +53,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "6"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence closure literal" {
+  inspect(main(), "6")
+}

--- a/fixtures/effect_handle_call_evidence_effectset_alias.vibe
+++ b/fixtures/effect_handle_call_evidence_effectset_alias.vibe
@@ -63,5 +63,9 @@ export let main = () -> Int {
   count * 1000 + r
 }
 
-__DATA__
-{"last": "2007"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence effectset alias" {
+  inspect(main(), "2007")
+}

--- a/fixtures/effect_handle_call_evidence_error_mix.vibe
+++ b/fixtures/effect_handle_call_evidence_error_mix.vibe
@@ -45,5 +45,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "5"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence error mix" {
+  inspect(main(), "5")
+}

--- a/fixtures/effect_handle_call_evidence_let_bound.vibe
+++ b/fixtures/effect_handle_call_evidence_let_bound.vibe
@@ -50,5 +50,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "6"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence let bound" {
+  inspect(main(), "6")
+}

--- a/fixtures/effect_handle_call_evidence_local_closure_capture_free.vibe
+++ b/fixtures/effect_handle_call_evidence_local_closure_capture_free.vibe
@@ -65,5 +65,9 @@ export let main = () -> Int {
   count * 1000 + r
 }
 
-__DATA__
-{"last": "2007"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence local closure capture free" {
+  inspect(main(), "2007")
+}

--- a/fixtures/effect_handle_call_evidence_pure_helper.vibe
+++ b/fixtures/effect_handle_call_evidence_pure_helper.vibe
@@ -49,5 +49,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "11"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence pure helper" {
+  inspect(main(), "11")
+}

--- a/fixtures/effect_handle_call_evidence_qualified_op.vibe
+++ b/fixtures/effect_handle_call_evidence_qualified_op.vibe
@@ -39,5 +39,9 @@ export let main = () -> Int {
   count * 1000 + r
 }
 
-__DATA__
-{"last": "2007"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence qualified op" {
+  inspect(main(), "2007")
+}

--- a/fixtures/effect_handle_call_evidence_row_variable_tail.vibe
+++ b/fixtures/effect_handle_call_evidence_row_variable_tail.vibe
@@ -54,5 +54,9 @@ export let main = () -> Int {
   count * 1000 + r
 }
 
-__DATA__
-{"last": "2007"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence row variable tail" {
+  inspect(main(), "2007")
+}

--- a/fixtures/effect_handle_call_evidence_struct_field.vibe
+++ b/fixtures/effect_handle_call_evidence_struct_field.vibe
@@ -52,5 +52,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "6"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle call evidence struct field" {
+  inspect(main(), "6")
+}

--- a/fixtures/effect_handle_error_nontail.vibe
+++ b/fixtures/effect_handle_error_nontail.vibe
@@ -19,5 +19,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "1"}
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`. `main` discharges Exception in its own
+// handle, so the test block needs no row.
+test "a non-tail throw aborts the handle body to the arm's value" {
+  inspect(main(), "1")
+}

--- a/fixtures/effect_handle_multi_effect_nested_handles.vibe
+++ b/fixtures/effect_handle_multi_effect_nested_handles.vibe
@@ -64,5 +64,9 @@ export let main = () -> Int {
   compute()
 }
 
-__DATA__
-{"last": "7"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle multi effect nested handles" {
+  inspect(main(), "7")
+}

--- a/fixtures/effect_handle_multi_effect_row_nested.vibe
+++ b/fixtures/effect_handle_multi_effect_row_nested.vibe
@@ -79,5 +79,9 @@ export let main = () -> Int {
   count * 1000 + r
 }
 
-__DATA__
-{"last": "2017"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle multi effect row nested" {
+  inspect(main(), "2017")
+}

--- a/fixtures/effect_handle_operation_level_discharge.vibe
+++ b/fixtures/effect_handle_operation_level_discharge.vibe
@@ -29,5 +29,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle operation level discharge" {
+  inspect(main(), "42")
+}

--- a/fixtures/effect_handle_replay_corruption.vibe
+++ b/fixtures/effect_handle_replay_corruption.vibe
@@ -39,5 +39,9 @@ export let main = () -> Int {
   count * 1000 + r
 }
 
-__DATA__
-{"last": "3013"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect handle replay corruption" {
+  inspect(main(), "3013")
+}

--- a/fixtures/effect_inline_lambda_literal_hof_arg.vibe
+++ b/fixtures/effect_inline_lambda_literal_hof_arg.vibe
@@ -65,5 +65,9 @@ export let main = () -> Int {
   iife_result + hof_result
 }
 
-__DATA__
-{"last": "10"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect inline lambda literal hof arg" {
+  inspect(main(), "10")
+}

--- a/fixtures/effect_inline_lambda_literal_labeled_arg.vibe
+++ b/fixtures/effect_inline_lambda_literal_labeled_arg.vibe
@@ -27,5 +27,9 @@ export let main = () -> Int {
   })
 }
 
-__DATA__
-{"last": "5"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect inline lambda literal labeled arg" {
+  inspect(main(), "5")
+}

--- a/fixtures/effect_local_closure_by_value_hof_escaping.vibe
+++ b/fixtures/effect_local_closure_by_value_hof_escaping.vibe
@@ -39,5 +39,9 @@ export let main = () -> Int {
   direct + via_apply
 }
 
-__DATA__
-{"last": "206"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect local closure by value hof escaping" {
+  inspect(main(), "206")
+}

--- a/fixtures/effect_local_closure_by_value_hof_general.vibe
+++ b/fixtures/effect_local_closure_by_value_hof_general.vibe
@@ -45,5 +45,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "210"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect local closure by value hof general" {
+  inspect(main(), "210")
+}

--- a/fixtures/effect_local_closure_capture_conversion.vibe
+++ b/fixtures/effect_local_closure_capture_conversion.vibe
@@ -47,5 +47,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "1015"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect local closure capture conversion" {
+  inspect(main(), "1015")
+}

--- a/fixtures/effect_local_closure_handle_owner_param.vibe
+++ b/fixtures/effect_local_closure_handle_owner_param.vibe
@@ -46,5 +46,9 @@ export let main = () -> Int {
   run_with_handler(a) + run_with_handler(b)
 }
 
-__DATA__
-{"last": "285"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "effect local closure handle owner param" {
+  inspect(main(), "285")
+}

--- a/fixtures/effect_vacuous_handle_erased.vibe
+++ b/fixtures/effect_vacuous_handle_erased.vibe
@@ -23,10 +23,14 @@ fn read_env_discharged(name: String) -> String {
   }
 }
 
-let _start = () -> Int {
+export let main = () -> Int {
   let v = read_env_discharged("VIBE_V2_VACUOUS_HANDLE_PROBE_UNSET")
   String::length(v) + 46
 }
 
-__DATA__
-{"last": "46"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "effect vacuous handle erased" {
+  inspect(main(), "46")
+}

--- a/fixtures/entry_error_boundary.vibe
+++ b/fixtures/entry_error_boundary.vibe
@@ -19,6 +19,3 @@
 export let main = () -> Int with Exception {
   throw("boom")
 }
-
-__DATA__
-{"last": "1"}

--- a/fixtures/err_async_for_undeclared.vibe
+++ b/fixtures/err_async_for_undeclared.vibe
@@ -36,6 +36,3 @@ fn total() -> Int {
 let main = () -> Int {
   total()
 }
-
-__DATA__
-{"error_contains": "Countdown::next"}

--- a/fixtures/err_effectset_cycle.vibe
+++ b/fixtures/err_effectset_cycle.vibe
@@ -8,6 +8,3 @@ effect Ask {
 
 effectset A = { B }
 effectset B = { A }
-
-__DATA__
-{"error_contains": "effectset cycle: A -> B -> A"}

--- a/fixtures/err_effectset_operation_collision.vibe
+++ b/fixtures/err_effectset_operation_collision.vibe
@@ -8,6 +8,3 @@ effect Env {
 }
 
 effectset Env::Read = { Env::Read }
-
-__DATA__
-{"error_contains": "collides with an operation of the same name"}

--- a/fixtures/err_exception_kind_mismatch.vibe
+++ b/fixtures/err_exception_kind_mismatch.vibe
@@ -20,6 +20,3 @@ let main = () -> Int {
     Throw(_e) => 42
   }
 }
-
-__DATA__
-{"error_contains": "missing { Exception[IoError] }"}

--- a/fixtures/err_exception_local_binder_kind.vibe
+++ b/fixtures/err_exception_local_binder_kind.vibe
@@ -24,6 +24,3 @@ let main = () -> Int {
     Throw(_e) => 42
   }
 }
-
-__DATA__
-{"error_contains": "missing { Exception[IoError] }"}

--- a/fixtures/err_generic_effect_perform_arity.vibe
+++ b/fixtures/err_generic_effect_perform_arity.vibe
@@ -11,6 +11,3 @@ effect State[S] {
 let main = () -> Int with State {
   perform State::Get(1, 2, 3)
 }
-
-__DATA__
-{"error_contains": "perform State::Get expects 0 argument(s), got 3"}

--- a/fixtures/err_generic_effect_row_targ.vibe
+++ b/fixtures/err_generic_effect_row_targ.vibe
@@ -12,6 +12,3 @@ let f = () -> Int with Log[Int] {
 let main = () -> Int {
   f()
 }
-
-__DATA__
-{"error_contains": "effect Log declares no type parameters"}

--- a/fixtures/err_handler_switch_dead_handle.vibe
+++ b/fixtures/err_handler_switch_dead_handle.vibe
@@ -43,6 +43,3 @@ let main = () -> Int {
     }
   }
 }
-
-__DATA__
-{"error_contains": "can never fire"}

--- a/fixtures/err_higher_order_effectful_block.vibe
+++ b/fixtures/err_higher_order_effectful_block.vibe
@@ -32,6 +32,3 @@ let main = () -> Int {
     Emit(_m) => resume(())
   }
 }
-
-__DATA__
-{"error_contains": "Higher-order effects"}

--- a/fixtures/err_local_closure_effect_leak.vibe
+++ b/fixtures/err_local_closure_effect_leak.vibe
@@ -12,6 +12,3 @@ let main = () -> Unit with Stdout {
   }
   println(read_home())
 }
-
-__DATA__
-{"error_contains": "missing { Env }"}

--- a/fixtures/err_region_escape_return.vibe
+++ b/fixtures/err_region_escape_return.vibe
@@ -10,6 +10,3 @@ fn main() -> Unit with Exception {
   })
   ()
 }
-
-__DATA__
-{"error_contains":"region escapes its nursery scope"}

--- a/fixtures/err_spawnable_capture_array.vibe
+++ b/fixtures/err_spawnable_capture_array.vibe
@@ -15,6 +15,3 @@ fn main() -> Unit with Exception {
   })
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Spawnable` for `Array[Int]`"}

--- a/fixtures/err_spawnable_capture_cross_region.vibe
+++ b/fixtures/err_spawnable_capture_cross_region.vibe
@@ -16,6 +16,3 @@ fn main() -> Unit with Exception {
   })
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Spawnable`"}

--- a/fixtures/err_spawnable_capture_letmut.vibe
+++ b/fixtures/err_spawnable_capture_letmut.vibe
@@ -19,6 +19,3 @@ fn main() -> Unit with Exception {
   })
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Spawnable` for a `let mut` binding"}

--- a/fixtures/err_spawnable_capture_letmut_outer_scope.vibe
+++ b/fixtures/err_spawnable_capture_letmut_outer_scope.vibe
@@ -20,6 +20,3 @@ fn main() -> Unit with Exception {
   })
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Spawnable` for a `let mut` binding"}

--- a/fixtures/err_taskgroup_sugar_region_escape.vibe
+++ b/fixtures/err_taskgroup_sugar_region_escape.vibe
@@ -12,6 +12,3 @@ fn main() -> Unit with Exception {
   } }
   ()
 }
-
-__DATA__
-{"error_contains":"region escapes its nursery scope"}

--- a/fixtures/err_type_send_array_bound.vibe
+++ b/fixtures/err_type_send_array_bound.vibe
@@ -6,6 +6,3 @@ fn main {
   let _ = want_send([1, 2, 3])
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Send` for `Array[Int]`"}

--- a/fixtures/err_type_send_closure_bound.vibe
+++ b/fixtures/err_type_send_closure_bound.vibe
@@ -7,6 +7,3 @@ fn main {
   let _ = want_send(f)
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Send` for `"}

--- a/fixtures/err_type_send_frozen_array_of_array_bound.vibe
+++ b/fixtures/err_type_send_frozen_array_of_array_bound.vibe
@@ -15,6 +15,3 @@ fn main {
   let _ = want_send(fa)
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Send` for `FrozenArray[Array[Int]]`"}

--- a/fixtures/err_type_send_mut_struct_bound.vibe
+++ b/fixtures/err_type_send_mut_struct_bound.vibe
@@ -8,6 +8,3 @@ fn main {
   let _ = want_send(Counter::{ n: 0 })
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Send` for `Counter`"}

--- a/fixtures/err_type_send_nonregular_recursion.vibe
+++ b/fixtures/err_type_send_nonregular_recursion.vibe
@@ -12,6 +12,3 @@ fn main {
   let _ = want_send(l)
   ()
 }
-
-__DATA__
-{"error_contains":"no impl `Send` for `LoopT[Int]`"}

--- a/fixtures/err_type_send_user_impl.vibe
+++ b/fixtures/err_type_send_user_impl.vibe
@@ -4,6 +4,3 @@
 struct Pt { x: Int; y: Int }
 
 impl Send for Pt
-
-__DATA__
-{"error_contains":"`Send` is a compiler-judged structural marker"}

--- a/fixtures/evidence_dict_needing_shadowed_by_local.vibe
+++ b/fixtures/evidence_dict_needing_shadowed_by_local.vibe
@@ -45,5 +45,9 @@ export let main = () -> Int {
   }
 }
 
-__DATA__
-{"last": "47"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "evidence dict needing shadowed by local" {
+  inspect(main(), "47")
+}

--- a/fixtures/exception_typed_row.vibe
+++ b/fixtures/exception_typed_row.vibe
@@ -79,5 +79,9 @@ export let main = () -> Int {
   a + b + c + d + e
 }
 
-__DATA__
-{"last": "42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "exception typed row" {
+  inspect(main(), "42")
+}

--- a/fixtures/gc_backend_effect_pure_builtin_index.vibe
+++ b/fixtures/gc_backend_effect_pure_builtin_index.vibe
@@ -37,5 +37,9 @@ export let main = () -> Int {
   Array::length(result)
 }
 
-__DATA__
-{"last": "3"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "gc backend effect pure builtin index" {
+  inspect(main(), "3")
+}

--- a/fixtures/gc_backend_suberror_ctor.vibe
+++ b/fixtures/gc_backend_suberror_ctor.vibe
@@ -32,5 +32,9 @@ export let main = () -> Int {
   r1 * 100 + (r2 + 1) * 10 + (r3 + 1)
 }
 
-__DATA__
-{"last": "4200"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "gc backend suberror ctor" {
+  inspect(main(), "4200")
+}

--- a/fixtures/interp_show_derive.vibe
+++ b/fixtures/interp_show_derive.vibe
@@ -106,7 +106,7 @@ fn bit(ok: Bool, weight: Int) -> Int {
   }
 }
 
-let _start = () -> Int {
+export let main = () -> Int {
   let p = P::{
     x: 1, y: 2
   }
@@ -116,9 +116,10 @@ let _start = () -> Int {
     "CUSTOM"
   }, p) == "CUSTOM", 10000000000000000) + bit("\{Some(p)}" == "Some(P { x: 1, y: 2 })" && show_opt_struct_var(p) == "Some(P { x: 1, y: 2 })", 100000000000000000) + bit(show_nested_payload(Some([p])) == "[P { x: 1, y: 2 }]", 1000000000000000000)
 }
-_start()
 
-__DATA__
-{
-  "last": "1111111111111111111"
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "interp show derive" {
+  inspect(main(), "1111111111111111111")
 }

--- a/fixtures/local_closure_wrapper_wrong_arity_not_inlined.vibe
+++ b/fixtures/local_closure_wrapper_wrong_arity_not_inlined.vibe
@@ -19,5 +19,9 @@ export let main = () -> Int {
   apply_with_arg(g)
 }
 
-__DATA__
-{"last": "6"}
+// #1571: the expectation lives here, checked by `inspect` and updatable
+// with `vibe test --update`, instead of in a `__DATA__` tail the gate has
+// to `sed` off and compare in shell.
+test "local closure wrapper wrong arity not inlined" {
+  inspect(main(), "6")
+}

--- a/fixtures/rc_branch_loop_mixed_consume_test.vibe
+++ b/fixtures/rc_branch_loop_mixed_consume_test.vibe
@@ -72,7 +72,7 @@ fn spawn_r(buf: Array[() -> Unit], count: Int, rc: PRes, k: Int) -> Array[() -> 
   append_r(buf, count, r)
 }
 
-let _start = () -> Int {
+export let main = () -> Int {
   // struct shape: grow on call 1 (loop arm), set on calls 2-3 (real
   // consume arm — these were the over-dropped stores)
   let empty_s: Array[S] = ArrayBuilder::freeze(ArrayBuilder::new())
@@ -99,7 +99,10 @@ let _start = () -> Int {
 
   part1 * 1000 + part2
 }
-_start()
 
-__DATA__
-{"last":"123123"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "rc branch loop mixed consume test" {
+  inspect(main(), "123123")
+}

--- a/fixtures/rc_local_container_element_escape.vibe
+++ b/fixtures/rc_local_container_element_escape.vibe
@@ -39,14 +39,17 @@ fn mk2(v: Int) -> Array[Int] {
   r
 }
 
-let _start = () -> Int {
+export let main = () -> Int {
   let a = mk(40)
   let b = mk(5)
   let c = mk2(100)
   let d = mk2(200)
   Array::get(a, 0) + Array::get(b, 0) + Array::get(c, 0) + Array::get(d, 0)
 }
-_start()
 
-__DATA__
-{"last":"345"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "rc local container element escape" {
+  inspect(main(), "345")
+}

--- a/fixtures/rc_match_payload_closure_capture_test.vibe
+++ b/fixtures/rc_match_payload_closure_capture_test.vibe
@@ -16,7 +16,7 @@ enum Step {
 
 let conts: Array[(Int) -> Int] = []
 
-let _start = () -> Int {
+export let main = () -> Int {
   let log: Array[Int] = []
   let drive0 = (st: Step) -> Int {
     match st {
@@ -68,7 +68,10 @@ let _start = () -> Int {
   }
   (r1 + r2 + x1 + x2) * 1000 + digits
 }
-_start()
 
-__DATA__
-{"last":"38013"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "rc match payload closure capture test" {
+  inspect(main(), "38013")
+}

--- a/fixtures/region_arena_ok.vibe
+++ b/fixtures/region_arena_ok.vibe
@@ -1,5 +1,5 @@
 // ADR-0090 Phase 1 (positive): build inside the region, freeze to escape.
-// Compiles and returns 6; the `_start` wrapper scales it to 42 for the gate.
+// Compiles and returns 6; the `main` wrapper scales it to 42 for the gate.
 fn total() -> Int {
   let frozen = region r {
     let l = MutList::empty(r)
@@ -17,10 +17,13 @@ fn total() -> Int {
   acc
 }
 
-let _start = () -> Int {
+export let main = () -> Int {
   total() * 7
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "region arena ok" {
+  inspect(main(), "42")
+}

--- a/fixtures/region_ok_basic.vibe
+++ b/fixtures/region_ok_basic.vibe
@@ -4,14 +4,19 @@
 // fixtures (err_region_escape_return.vibe, err_region_escape_outer_mut.vibe).
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-let _start = () -> Int with Exception {
+export let main = () -> Int with Exception {
   TaskGroup::run((n) -> {
     let h = TaskGroup::spawn(n, () -> { 40 })
     let v = TaskHandle::join(h)
     v + 2
   })
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Exception`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "region ok basic" with Exception {
+  inspect(main(), "42")
+}

--- a/fixtures/region_ok_frozen_array_basic.vibe
+++ b/fixtures/region_ok_frozen_array_basic.vibe
@@ -8,7 +8,7 @@
 // an Array[Int], read it back through FrozenArray::get/length, then
 // unwrap via to_array and confirm the escape hatch returns a real, usable
 // Array again.
-let _start = () -> Int {
+export let main = () -> Int {
   let a = [40, 1, 1]
   let fa = FrozenArray::from_array(a)
   let g0 = FrozenArray::get(fa, 0)
@@ -17,7 +17,10 @@ let _start = () -> Int {
   let b1 = Array::get(back, 1)
   g0 + len - b1
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "region ok frozen array basic" {
+  inspect(main(), "42")
+}

--- a/fixtures/region_ok_frozen_array_taskgroup_capture.vibe
+++ b/fixtures/region_ok_frozen_array_taskgroup_capture.vibe
@@ -11,7 +11,7 @@
 // TaskGroup::spawn boundary.
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-let _start = () -> Int with Exception {
+export let main = () -> Int with Exception {
   let data = [10, 10, 20]
   let fa = FrozenArray::from_array(data)
   TaskGroup::run((n) -> {
@@ -21,7 +21,12 @@ let _start = () -> Int with Exception {
     TaskHandle::join(t)
   })
 }
-_start()
 
-__DATA__
-{"last":"40"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Exception`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "region ok frozen array taskgroup capture" with Exception {
+  inspect(main(), "40")
+}

--- a/fixtures/region_ok_spawnable_capture.vibe
+++ b/fixtures/region_ok_spawnable_capture.vibe
@@ -6,7 +6,7 @@
 // err_spawnable_capture_cross_region.vibe).
 import @vibex/concurrent { TaskGroup, TaskHandle, Channel, Sender, Receiver }
 
-let _start = () -> Int with Exception {
+export let main = () -> Int with Exception {
   TaskGroup::run((n) -> {
     let (tx, rx) = Channel::bounded(n, 1)
     let t = TaskGroup::spawn(n, () -> {
@@ -21,7 +21,12 @@ let _start = () -> Int with Exception {
     }
   })
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Exception`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "region ok spawnable capture" with Exception {
+  inspect(main(), "42")
+}

--- a/fixtures/region_ok_spawnable_capture_shadowed_letmut.vibe
+++ b/fixtures/region_ok_spawnable_capture_shadowed_letmut.vibe
@@ -11,7 +11,7 @@
 // err_spawnable_capture_letmut.vibe/err_spawnable_capture_letmut_outer_scope.vibe.
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-let _start = () -> Int with Exception {
+export let main = () -> Int with Exception {
   let x = 40
   let result = TaskGroup::run((n) -> {
     let h = TaskGroup::spawn(n, () -> { x + 1 })
@@ -25,7 +25,12 @@ let _start = () -> Int with Exception {
   let extra = helper()
   result + extra
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Exception`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "region ok spawnable capture shadowed letmut" with Exception {
+  inspect(main(), "42")
+}

--- a/fixtures/region_ok_taskgroup_sugar.vibe
+++ b/fixtures/region_ok_taskgroup_sugar.vibe
@@ -6,14 +6,19 @@
 // the same result a hand-written call would.
 import @vibex/concurrent { TaskGroup, TaskHandle }
 
-let _start = () -> Int with Exception {
+export let main = () -> Int with Exception {
   taskgroup { g => {
     let h = TaskGroup::spawn(g, () -> { 40 })
     let v = TaskHandle::join(h)
     v + 2
   } }
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell. The test block declares the entry's own row
+// (`with Exception`, #1508) -- that syntax is what makes an effectful `main`
+// snapshot-testable at all.
+test "region ok taskgroup sugar" with Exception {
+  inspect(main(), "42")
+}

--- a/fixtures/send_bound_frozen_array.vibe
+++ b/fixtures/send_bound_frozen_array.vibe
@@ -11,13 +11,16 @@
 // (Array[Int]) in a FrozenArray does NOT itself confer Send.
 let want_send = [T: Send](x: T) -> T { x }
 
-let _start = () -> Int {
+export let main = () -> Int {
   let a = [1, 2, 39]
   let fa = FrozenArray::from_array(a)
   let ok = want_send(fa)
   FrozenArray::get(ok, 0) + FrozenArray::get(ok, 1) + FrozenArray::get(ok, 2)
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "send bound frozen array" {
+  inspect(main(), "42")
+}

--- a/fixtures/send_bound_structural.vibe
+++ b/fixtures/send_bound_structural.vibe
@@ -26,7 +26,7 @@ enum GList[T] {
 
 let want_send = [T: Send](x: T) -> T { x }
 
-let _start = () -> Int {
+export let main = () -> Int {
   let a = want_send(40)
   let _b = want_send("s")
   let _c = want_send((1, "x", true))
@@ -41,7 +41,10 @@ let _start = () -> Int {
   let _h = want_send(ok)
   a + e.x + e.y
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "send bound structural" {
+  inspect(main(), "42")
+}

--- a/fixtures/trait_bound_ufcs_method.vibe
+++ b/fixtures/trait_bound_ufcs_method.vibe
@@ -23,11 +23,14 @@ let get_ufcs = [K: Hash](k: K) -> Int {
   k.probe_key()
 }
 
-let _start = () -> Int {
+export let main = () -> Int {
   let p = Point::{ x: 3, y: 4 }
   get_qualified(p) * 1000 + get_ufcs(p)
 }
-_start()
 
-__DATA__
-{"last": "97097"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "trait bound ufcs method" {
+  inspect(main(), "97097")
+}

--- a/fixtures/zero_alloc_ok.vibe
+++ b/fixtures/zero_alloc_ok.vibe
@@ -7,10 +7,13 @@ fn hot(a: Int, b: Int) -> Int {
   t - a
 }
 
-let _start = () -> Int {
+export let main = () -> Int {
   hot(14, 14)
 }
-_start()
 
-__DATA__
-{"last":"42"}
+// #1571: the expectation lives here, checked by `inspect` and updatable with
+// `vibe test --update`, instead of in a `__DATA__` tail the gate has to `sed`
+// off and compare in shell.
+test "zero alloc ok" {
+  inspect(main(), "42")
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9242,6 +9242,61 @@ fn stmt_has_labeled_arg(stmt: Stmt) -> Bool {
 /// In-place labeled-argument reordering over a whole program. Rebuilds only the
 /// top-level statements that actually contain a labeled argument (see
 /// expr_has_labeled_arg).
+/// Every name `expr` MENTIONS -- as a reference or as a binder. Used to mint
+/// temporaries that cannot capture anything in the expressions being moved.
+/// Over-approximates (a shadowed inner binder counts too), which only ever
+/// costs a suffix.
+fn dinsp_mentions(expr: Expr, name: String) -> Bool {
+  let here = match expr {
+    EIdent(n, _) => n == name,
+    ELet(n, _, _, _) => n == name,
+    ELetRec(n, _, _) => n == name,
+    ELetMut(n, _, _, _) => n == name,
+    EAssign(n, _, _) => n == name,
+    EAssignOp(_, n, _, _) => n == name,
+    EForIn(v, _, _, _) => v == name,
+    EFn(_, _, params, _, _, _) => dinsp_params_bind(params, name),
+    _ => false
+  }
+  if here {
+    true
+  } else {
+    let kids = expr_children(expr)
+    let mut i = 0
+    let mut found = false
+    while !found && i < Array::length(kids) {
+      found = dinsp_mentions(Array::get(kids, i), name)
+      i = i + 1
+    }
+    found
+  }
+}
+
+fn dinsp_params_bind(params: Array[(String, Option[TypeExpr])], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(params) {
+    let (pn, _) = Array::get(params, i)
+    found = pn == name
+    i = i + 1
+  }
+  found
+}
+
+/// `base`, or `base` with the smallest numeric suffix that neither argument
+/// mentions. Bounded by an occurrence check rather than a global counter so the
+/// expansion stays a pure function of its inputs (two identical `inspect` calls
+/// lower identically, which keeps the pass idempotent).
+fn dinsp_fresh_name(base: String, value: Expr, content: Expr) -> String {
+  let mut candidate = base
+  let mut n = 0
+  while dinsp_mentions(value, candidate) || dinsp_mentions(content, candidate) {
+    n = n + 1
+    candidate = String::concat(base, String::concat("_", __to_string(n)))
+  }
+  candidate
+}
+
 /// #1571: the desugared form of `inspect(value, content)`.
 ///
 /// WHY A BUILTIN AT ALL. `inspect` was deliberately a plain library function in
@@ -9270,9 +9325,16 @@ fn stmt_has_labeled_arg(stmt: Stmt) -> Bool {
 /// Both arguments are let-bound because each is referenced more than once.
 /// Re-evaluating them would make `inspect(next(), ..)` consume two values and
 /// report a different one than it compared.
+///
+/// The temporaries are minted FRESH against both arguments (dinsp_fresh_name).
+/// A fixed name captures: with `let __vibe_inspect_actual = "wrong"`,
+/// `inspect(1, __vibe_inspect_actual)` would move that reference under the new
+/// binding and compare the stringified value against ITSELF -- a failing
+/// assertion that silently passes, which is the worst way this could break
+/// (Codex review on #1621).
 fn inspect_lowering_expr(value: Expr, content: Expr) -> Expr {
-  let actual_name = "__vibe_inspect_actual"
-  let expected_name = "__vibe_inspect_expected"
+  let actual_name = dinsp_fresh_name("__vibe_inspect_actual", value, content)
+  let expected_name = dinsp_fresh_name("__vibe_inspect_expected", value, content)
   let actual = EIdent(actual_name, 0 - 1)
   let expected = EIdent(expected_name, 0 - 1)
   // Nested String::concat rather than one variadic call: `concat` is binary.
@@ -9303,11 +9365,11 @@ fn inspect_lowering_expr(value: Expr, content: Expr) -> Expr {
 
 /// Rewrite every two-argument `inspect(value, content)` call to its expansion.
 ///
-/// A LOCAL definition wins: the guard is on the callee spelling only, so a file
-/// that declares or imports its own `inspect` still gets rewritten -- which is
-/// why the expansion must stay behaviourally identical to `@vibe/core`'s
-/// library `inspect` (assert.vibe), the one every existing importer was
-/// compiled against until now.
+/// Only reached when the file binds NOTHING named `inspect` (see
+/// desugar_inspect_calls). A file that declares, imports or takes a parameter
+/// named `inspect` keeps calling that one, exactly as it did before this pass
+/// existed -- rewriting there would silently swap a user function's body for
+/// snapshot-assertion behaviour (Codex review on #1621).
 fn dinsp_expr(expr: Expr) -> Expr {
   match expr {
     ECall(callee, args, off) => {
@@ -9414,14 +9476,166 @@ fn dinsp_stmts_copy(stmts: Array[Stmt]) -> Array[Stmt] {
   }
 }
 
+/// True when `expr` contains a two-argument `inspect(..)` call anywhere.
+///
+/// This is a READ-ONLY walk, and the reason it exists is measured, not
+/// speculative: `dinsp_children` rebuilds every node it visits, so running the
+/// rewrite unconditionally allocated a fresh copy of the whole AST for every
+/// file -- +1.34% on `selfcompile heap_ptr_bytes`, which the perf gate reports
+/// in its deterministic section where "any drift is real". Almost no file
+/// calls `inspect`, and no file in the compiler's own source does, so checking
+/// first and rebuilding only what needs it makes the pass free for them.
+/// `rewrite_alias_expr_ix` (core/import_alias_rewrite.vibe) carries the same
+/// guard for the same reason.
+fn dinsp_uses(expr: Expr) -> Bool {
+  let hit = match expr {
+    ECall(callee, args, _) => match callee {
+      EIdent(name, _) => name == "inspect" && Array::length(args) == 2,
+      _ => false
+    },
+    _ => false
+  }
+  if hit {
+    true
+  } else {
+    let kids = expr_children(expr)
+    let mut i = 0
+    let mut found = false
+    while !found && i < Array::length(kids) {
+      found = dinsp_uses(Array::get(kids, i))
+      i = i + 1
+    }
+    found
+  }
+}
+
+fn dinsp_stmt_uses(stmt: Stmt) -> Bool {
+  match stmt {
+    SLet(_, _, _, _, body) => dinsp_uses(body),
+    SLetMut(_, _, body) => dinsp_uses(body),
+    SLetPat(_, body) => dinsp_uses(body),
+    STest(_, body) => dinsp_uses(body),
+    SBench(_, body) => dinsp_uses(body),
+    SExample(_, body) => dinsp_uses(body),
+    SExpr(body) => dinsp_uses(body),
+    SFnDecl(_, _, body, _, _) => dinsp_uses(body),
+    SModule(_, _, body) => dinsp_stmts_use(body),
+    _ => false
+  }
+}
+
+fn dinsp_stmts_use(stmts: Array[Stmt]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(stmts) {
+    found = dinsp_stmt_uses(Array::get(stmts, i))
+    i = i + 1
+  }
+  found
+}
+
+/// True when the file binds the name `inspect` anywhere -- an import (under
+/// either spelling), a declaration, or any local binder or parameter.
+///
+/// The whole rewrite stands down for such a file. `inspect` is meant to be
+/// reachable when nothing DEFINES it; where something does, that definition is
+/// what the program meant, and quietly replacing a user function's body with
+/// snapshot-assertion behaviour would be a silent change of meaning. This is
+/// deliberately whole-file rather than scope-accurate: it is the conservative
+/// direction (it can only decline to rewrite), and a file that binds `inspect`
+/// at all is rare enough not to be worth a scope tracker that could get the
+/// direction wrong.
+///
+/// It also puts `@vibe/core`'s library `inspect` and its importers back on
+/// their original path -- assert.vibe binds the name, so its body is live
+/// again, and `import @vibe/core { inspect }` still calls it.
+fn dinsp_binds_inspect(stmts: Array[Stmt]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(stmts) {
+    found = dinsp_stmt_binds(Array::get(stmts, i))
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_import_binds(items: Array[(String, Option[String])]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(items) {
+    let (original, alias) = Array::get(items, i)
+    found = match alias {
+      Some(a) => a == "inspect",
+      None => original == "inspect"
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_stmt_binds(stmt: Stmt) -> Bool {
+  match stmt {
+    SImport(_, items) => dinsp_import_binds(items),
+    SReExport(_, items) => dinsp_import_binds(items),
+    SLet(_, _, name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
+    SLetMut(name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
+    SLetPat(_, body) => dinsp_mentions_binder(body),
+    SFnDecl(_, name, body, _, _) => name == "inspect" || dinsp_mentions_binder(body),
+    STest(_, body) => dinsp_mentions_binder(body),
+    SBench(_, body) => dinsp_mentions_binder(body),
+    SExample(_, body) => dinsp_mentions_binder(body),
+    SExpr(body) => dinsp_mentions_binder(body),
+    SModule(_, _, body) => dinsp_binds_inspect(body),
+    _ => false
+  }
+}
+
+/// A binder named `inspect` INSIDE an expression (a `let`, a lambda parameter,
+/// a `for` variable). A bare reference does not count -- that is the call this
+/// pass exists to rewrite.
+fn dinsp_mentions_binder(expr: Expr) -> Bool {
+  let here = match expr {
+    ELet(n, _, _, _) => n == "inspect",
+    ELetRec(n, _, _) => n == "inspect",
+    ELetMut(n, _, _, _) => n == "inspect",
+    EForIn(v, _, _, _) => v == "inspect",
+    EFn(_, _, params, _, _, _) => dinsp_params_bind(params, "inspect"),
+    _ => false
+  }
+  if here {
+    true
+  } else {
+    let kids = expr_children(expr)
+    let mut i = 0
+    let mut found = false
+    while !found && i < Array::length(kids) {
+      found = dinsp_mentions_binder(Array::get(kids, i))
+      i = i + 1
+    }
+    found
+  }
+}
+
 /// In-place, like the other desugars in this file: `check_program` hands the
 /// SAME array to the checker and then on to codegen, so a fresh array would be
 /// dropped on the floor.
+///
+/// Only statements that actually contain an `inspect(..)` call are rebuilt --
+/// see dinsp_uses for why that guard is load-bearing rather than cosmetic.
 export fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit {
-  let mut i = 0
-  while i < Array::length(stmts) {
-    Array::set(stmts, i, dinsp_stmt(Array::get(stmts, i)))
-    i = i + 1
+  if dinsp_binds_inspect(stmts) {
+    ()
+  } else {
+    let mut i = 0
+    while i < Array::length(stmts) {
+      let stmt = Array::get(stmts, i)
+      if dinsp_stmt_uses(stmt) {
+        Array::set(stmts, i, dinsp_stmt(stmt))
+      } else {
+        ()
+      }
+      i = i + 1
+    }
   }
 }
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9268,6 +9268,8 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       ELetMut(n, _, _, _) => n == "inspect",
       EForIn(v, _, _, _) => v == "inspect",
       EFn(_, _, params, _, _, _) => dinsp_params_bind(params, "inspect"),
+      EMatch(_, arms) => dinsp_arms_bind(arms, "inspect"),
+      EHandle(_, arms) => dinsp_arms_bind(arms, "inspect"),
       _ => false
     }
   } else {
@@ -9280,6 +9282,8 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       EAssignOp(_, n, _, _) => n == name,
       EForIn(v, _, _, _) => v == name,
       EFn(_, _, params, _, _, _) => dinsp_params_bind(params, name),
+      EMatch(_, arms) => dinsp_arms_bind(arms, name),
+      EHandle(_, arms) => dinsp_arms_bind(arms, name),
       _ => false
     }
   }
@@ -9343,6 +9347,61 @@ fn dinsp_scan_fields(fields: Array[(String, Expr)], mode: Int, name: String) -> 
   while !found && i < Array::length(fields) {
     let (_, v) = Array::get(fields, i)
     found = dinsp_scan(v, mode, name)
+    i = i + 1
+  }
+  found
+}
+
+/// A binder named `name` in PATTERN position -- `let (inspect, x) = ..`, a
+/// match/handle arm's `Some(inspect)`, a struct-pattern field bound to it.
+///
+/// Codex review on #1622 (P1): without this the shadow guard only saw binders
+/// spelled in expression position, so a `inspect` introduced by destructuring
+/// left `dinsp_binds_inspect` false and the rewrite went ahead and replaced the
+/// user's own call with snapshot-assertion behaviour -- silently, since the
+/// program still compiled.
+fn dinsp_pat_binds(pat: Pat, name: String) -> Bool {
+  match pat {
+    PWild => false,
+    PBind(n) => n == name,
+    PInt(_) => false,
+    PFloat(_) => false,
+    PString(_) => false,
+    PBool(_) => false,
+    PCtor(_, args) => dinsp_pat_list_binds(args, name),
+    PTuple(items) => dinsp_pat_list_binds(items, name),
+    POr(a, b) => dinsp_pat_binds(a, name) || dinsp_pat_binds(b, name),
+    PStruct(_, fields) => dinsp_pat_fields_bind(fields, name)
+  }
+}
+
+fn dinsp_pat_list_binds(pats: Array[Pat], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(pats) {
+    found = dinsp_pat_binds(Array::get(pats, i), name)
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_pat_fields_bind(fields: Array[(String, Pat)], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(fields) {
+    let (_, p) = Array::get(fields, i)
+    found = dinsp_pat_binds(p, name)
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_arms_bind(arms: Array[(Pat, Expr)], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(arms) {
+    let (p, _) = Array::get(arms, i)
+    found = dinsp_pat_binds(p, name)
     i = i + 1
   }
   found
@@ -9656,7 +9715,7 @@ fn dinsp_stmt_binds(stmt: Stmt) -> Bool {
     SReExport(_, items) => dinsp_import_binds(items),
     SLet(_, _, name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
     SLetMut(name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
-    SLetPat(_, body) => dinsp_mentions_binder(body),
+    SLetPat(pat, body) => dinsp_pat_binds(pat, "inspect") || dinsp_mentions_binder(body),
     SFnDecl(_, name, body, _, _) => name == "inspect" || dinsp_mentions_binder(body),
     STest(_, body) => dinsp_mentions_binder(body),
     SBench(_, body) => dinsp_mentions_binder(body),
@@ -9668,8 +9727,8 @@ fn dinsp_stmt_binds(stmt: Stmt) -> Bool {
 }
 
 /// A binder named `inspect` INSIDE an expression (a `let`, a lambda parameter,
-/// a `for` variable). A bare reference does not count -- that is the call this
-/// pass exists to rewrite.
+/// a `for` variable, or a match/handle arm's pattern). A bare reference does
+/// not count -- that is the call this pass exists to rewrite.
 fn dinsp_mentions_binder(expr: Expr) -> Bool {
   dinsp_scan(expr, 1, "")
 }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9238,38 +9238,133 @@ fn stmt_has_labeled_arg(stmt: Stmt) -> Bool {
   }
 }
 
-///|
-/// In-place labeled-argument reordering over a whole program. Rebuilds only the
-/// top-level statements that actually contain a labeled argument (see
-/// expr_has_labeled_arg).
+/// Read-only scan for one of three questions, in ONE explicit-variant walk:
+///   mode 0 -- does this contain a two-argument `inspect(..)` call?
+///   mode 1 -- does this BIND the name `inspect` (a let / for / fn parameter)?
+///   mode 2 -- does this mention `name` at all, as a reference or a binder?
+///
+/// The variants are enumerated by hand rather than recursed through
+/// `expr_children`, and that is the whole point: `expr_children` ALLOCATES a
+/// fresh array per node, so using it for a "read-only" pre-check cost more
+/// allocation than the rebuild the pre-check exists to avoid. Measured on the
+/// perf gate's deterministic axis: the expr_children version put
+/// `selfcompile heap_ptr_bytes` +2.61% over main; this one is allocation-free.
+///
+/// Enumerated (no `_ =>` catch-all for the recursive shapes) so a new `Expr`
+/// variant is a compile error here instead of a silently unscanned subtree.
+fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
+  let here = if mode == 0 {
+    match expr {
+      ECall(callee, args, _) => match callee {
+        EIdent(n, _) => n == "inspect" && Array::length(args) == 2,
+        _ => false
+      },
+      _ => false
+    }
+  } else if mode == 1 {
+    match expr {
+      ELet(n, _, _, _) => n == "inspect",
+      ELetRec(n, _, _) => n == "inspect",
+      ELetMut(n, _, _, _) => n == "inspect",
+      EForIn(v, _, _, _) => v == "inspect",
+      EFn(_, _, params, _, _, _) => dinsp_params_bind(params, "inspect"),
+      _ => false
+    }
+  } else {
+    match expr {
+      EIdent(n, _) => n == name,
+      ELet(n, _, _, _) => n == name,
+      ELetRec(n, _, _) => n == name,
+      ELetMut(n, _, _, _) => n == name,
+      EAssign(n, _, _) => n == name,
+      EAssignOp(_, n, _, _) => n == name,
+      EForIn(v, _, _, _) => v == name,
+      EFn(_, _, params, _, _, _) => dinsp_params_bind(params, name),
+      _ => false
+    }
+  }
+  if here {
+    true
+  } else {
+    match expr {
+      EInt(_) => false,
+      EFloat(_) => false,
+      EString(_) => false,
+      EBool(_) => false,
+      EUnit => false,
+      EIdent(_, _) => false,
+      EStringInterp(_) => false,
+      ETuple(items) => dinsp_scan_list(items, mode, name),
+      EArray(items) => dinsp_scan_list(items, mode, name),
+      ERecord(_, fields, _) => dinsp_scan_fields(fields, mode, name),
+      EMap(fields) => dinsp_scan_fields(fields, mode, name),
+      EIf(c, t, f) => dinsp_scan(c, mode, name) || dinsp_scan(t, mode, name) || dinsp_scan(f, mode, name),
+      ELet(_, v, b, _) => dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name),
+      ELetRec(_, v, b) => dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name),
+      ELetMut(_, v, b, _) => dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name),
+      EAssign(_, v, b) => dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name),
+      EAssignOp(_, _, v, b) => dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name),
+      ESeq(a, b) => dinsp_scan(a, mode, name) || dinsp_scan(b, mode, name),
+      EMatch(sc, arms) => dinsp_scan(sc, mode, name) || dinsp_scan_arms(arms, mode, name),
+      EHandle(sc, arms) => dinsp_scan(sc, mode, name) || dinsp_scan_arms(arms, mode, name),
+      EWhile(c, b) => dinsp_scan(c, mode, name) || dinsp_scan(b, mode, name),
+      ELoop(params, b) => dinsp_scan_fields(params, mode, name) || dinsp_scan(b, mode, name),
+      EForIn(_, _, it, b) => dinsp_scan(it, mode, name) || dinsp_scan(b, mode, name),
+      ECall(callee, args, _) => dinsp_scan(callee, mode, name) || dinsp_scan_list(args, mode, name),
+      EBinOp(_, l, r) => dinsp_scan(l, mode, name) || dinsp_scan(r, mode, name),
+      EUnaryOp(_, v) => dinsp_scan(v, mode, name),
+      EFn(_, _, _, _, _, body) => dinsp_scan(body, mode, name),
+      EDot(inner, _, _, _) => dinsp_scan(inner, mode, name),
+      ELabeledArg(_, _, v) => dinsp_scan(v, mode, name),
+      EReturn(v) => dinsp_scan(v, mode, name),
+      EBreak(opt) => match opt {
+        Some(v) => dinsp_scan(v, mode, name),
+        None => false
+      },
+      EContinue(args) => dinsp_scan_list(args, mode, name),
+      ESpread(v) => dinsp_scan(v, mode, name)
+    }
+  }
+}
+
+fn dinsp_scan_list(items: Array[Expr], mode: Int, name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(items) {
+    found = dinsp_scan(Array::get(items, i), mode, name)
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_scan_fields(fields: Array[(String, Expr)], mode: Int, name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(fields) {
+    let (_, v) = Array::get(fields, i)
+    found = dinsp_scan(v, mode, name)
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_scan_arms(arms: Array[(Pat, Expr)], mode: Int, name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(arms) {
+    let (_, v) = Array::get(arms, i)
+    found = dinsp_scan(v, mode, name)
+    i = i + 1
+  }
+  found
+}
+
 /// Every name `expr` MENTIONS -- as a reference or as a binder. Used to mint
 /// temporaries that cannot capture anything in the expressions being moved.
 /// Over-approximates (a shadowed inner binder counts too), which only ever
 /// costs a suffix.
 fn dinsp_mentions(expr: Expr, name: String) -> Bool {
-  let here = match expr {
-    EIdent(n, _) => n == name,
-    ELet(n, _, _, _) => n == name,
-    ELetRec(n, _, _) => n == name,
-    ELetMut(n, _, _, _) => n == name,
-    EAssign(n, _, _) => n == name,
-    EAssignOp(_, n, _, _) => n == name,
-    EForIn(v, _, _, _) => v == name,
-    EFn(_, _, params, _, _, _) => dinsp_params_bind(params, name),
-    _ => false
-  }
-  if here {
-    true
-  } else {
-    let kids = expr_children(expr)
-    let mut i = 0
-    let mut found = false
-    while !found && i < Array::length(kids) {
-      found = dinsp_mentions(Array::get(kids, i), name)
-      i = i + 1
-    }
-    found
-  }
+  dinsp_scan(expr, 2, name)
 }
 
 fn dinsp_params_bind(params: Array[(String, Option[TypeExpr])], name: String) -> Bool {
@@ -9488,25 +9583,7 @@ fn dinsp_stmts_copy(stmts: Array[Stmt]) -> Array[Stmt] {
 /// `rewrite_alias_expr_ix` (core/import_alias_rewrite.vibe) carries the same
 /// guard for the same reason.
 fn dinsp_uses(expr: Expr) -> Bool {
-  let hit = match expr {
-    ECall(callee, args, _) => match callee {
-      EIdent(name, _) => name == "inspect" && Array::length(args) == 2,
-      _ => false
-    },
-    _ => false
-  }
-  if hit {
-    true
-  } else {
-    let kids = expr_children(expr)
-    let mut i = 0
-    let mut found = false
-    while !found && i < Array::length(kids) {
-      found = dinsp_uses(Array::get(kids, i))
-      i = i + 1
-    }
-    found
-  }
+  dinsp_scan(expr, 0, "")
 }
 
 fn dinsp_stmt_uses(stmt: Stmt) -> Bool {
@@ -9594,26 +9671,7 @@ fn dinsp_stmt_binds(stmt: Stmt) -> Bool {
 /// a `for` variable). A bare reference does not count -- that is the call this
 /// pass exists to rewrite.
 fn dinsp_mentions_binder(expr: Expr) -> Bool {
-  let here = match expr {
-    ELet(n, _, _, _) => n == "inspect",
-    ELetRec(n, _, _) => n == "inspect",
-    ELetMut(n, _, _, _) => n == "inspect",
-    EForIn(v, _, _, _) => v == "inspect",
-    EFn(_, _, params, _, _, _) => dinsp_params_bind(params, "inspect"),
-    _ => false
-  }
-  if here {
-    true
-  } else {
-    let kids = expr_children(expr)
-    let mut i = 0
-    let mut found = false
-    while !found && i < Array::length(kids) {
-      found = dinsp_mentions_binder(Array::get(kids, i))
-      i = i + 1
-    }
-    found
-  }
+  dinsp_scan(expr, 1, "")
 }
 
 /// In-place, like the other desugars in this file: `check_program` hands the
@@ -9639,6 +9697,9 @@ export fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit {
   }
 }
 
+/// In-place labeled-argument reordering over a whole program. Rebuilds only the
+/// top-level statements that actually contain a labeled argument (see
+/// expr_has_labeled_arg).
 export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   let tbl = collect_fn_param_labels(stmts)
   // #1500: optional-parameter call sites are rewritten by the same walk (see

--- a/lib/@vibe/core/assert.vibe
+++ b/lib/@vibe/core/assert.vibe
@@ -1,18 +1,17 @@
 // @vibe/core — assert_false / inspect (#1061).
 //
 // #1571 UPDATE: `inspect` is now ALSO reachable without importing anything --
-// `desugar_inspect_calls` (compiler normalize/) expands every
-// `inspect(value, content)` call to the same `__to_string` / `String::concat`
-// / `println` / `assert_true` form this function has, before the checker runs.
-// The rewrite keys on the callee NAME, so it fires here too and this body is
-// no longer what a caller executes; it is kept because `@vibe/core` exports it
-// (existing importers stay valid) and because it remains the readable
-// statement of what `inspect` MEANS. Keep the two in step: the expansion is
-// this function, spelled as AST.
+// `desugar_inspect_calls` (compiler normalize/) expands `inspect(value,
+// content)` to the same `__to_string` / `String::concat` / `println` /
+// `assert_true` form this function has, before the checker runs. That is what
+// lets a fixture compiled in the single-file lane -- which resolves no imports
+// at all -- carry an inline snapshot.
 //
-// Why the rewrite exists: migrating the `__DATA__` fixtures to inline
-// snapshots needs `inspect` callable from a fixture compiled in the
-// single-file lane, which resolves no imports at all.
+// This body stays live for everyone who has it in scope: the rewrite stands
+// down for any file that BINDS the name (an import, a declaration, a local),
+// so `import @vibe/core { inspect }` still calls exactly this, and so does
+// this file itself. Keep the two in step -- the expansion is this function,
+// spelled as AST.
 //
 // assert/assert_true/assert_eq are compiler builtins (checker +
 // both codegen backends) that trap with no message on failure; there is

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4390,18 +4390,21 @@ echo "[compiler-gate] self-discharging callee call-inertness ok (#1595/#1591)"
 echo "[compiler-gate] 40h5/40 wasm-gc backend: unannotated hoisted closure literal row backfill (ADR-0076 gc follow-up)"
 gcclosdir="_build/_gate_gc_closure_literal_row"
 rm -rf "$gcclosdir"; mkdir -p "$gcclosdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_closure_literal.vibe > "$gcclosdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$gcclosdir/src.vibe" "$gcclosdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_closure_literal.vibe "$gcclosdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$gcclosdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_closure_literal.vibe did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcclosdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-gcclos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcclosdir/out.wasm" 2>&1 | tail -1)"
-if [ "$gcclos_out" != "6" ]; then
+if ! gcclos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcclosdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_closure_literal.vibe under gc got '$gcclos_out' (want 6) -- hoisted closure row backfill or try-full-before-dropping-dead regressed" >&2
+  echo "$gcclos_out" >&2
   exit 1
 fi
 rm -rf "$gcclosdir"
@@ -4419,18 +4422,21 @@ echo "[compiler-gate] wasm-gc backend closure literal row backfill ok (6)"
 echo "[compiler-gate] 40h6/40 wasm-gc backend: __index/length pure-builtin allowlist gap (ADR-0076 gc follow-up)"
 gcidxdir="_build/_gate_gc_pure_builtin_index"
 rm -rf "$gcidxdir"; mkdir -p "$gcidxdir"
-sed '/^__DATA__$/,$d' fixtures/gc_backend_effect_pure_builtin_index.vibe > "$gcidxdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$gcidxdir/src.vibe" "$gcidxdir/out.wasm" main >/dev/null 2>&1
+  fixtures/gc_backend_effect_pure_builtin_index.vibe "$gcidxdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$gcidxdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc_backend_effect_pure_builtin_index.vibe did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcidxdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-gcidx_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcidxdir/out.wasm" 2>&1 | tail -1)"
-if [ "$gcidx_out" != "3" ]; then
+if ! gcidx_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcidxdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: gc_backend_effect_pure_builtin_index.vibe under gc got '$gcidx_out' (want 3) -- pure-builtin allowlist regressed" >&2
+  echo "$gcidx_out" >&2
   exit 1
 fi
 rm -rf "$gcidxdir"
@@ -4446,18 +4452,21 @@ echo "[compiler-gate] wasm-gc backend pure-builtin allowlist ok (3)"
 echo "[compiler-gate] 40h7/40 wasm-gc backend: suberror constructor registration (gc follow-up)"
 gcsuberrdir="_build/_gate_gc_suberror_ctor"
 rm -rf "$gcsuberrdir"; mkdir -p "$gcsuberrdir"
-sed '/^__DATA__$/,$d' fixtures/gc_backend_suberror_ctor.vibe > "$gcsuberrdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$gcsuberrdir/src.vibe" "$gcsuberrdir/out.wasm" main >/dev/null 2>&1
+  fixtures/gc_backend_suberror_ctor.vibe "$gcsuberrdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$gcsuberrdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc_backend_suberror_ctor.vibe did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcsuberrdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-gcsuberr_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcsuberrdir/out.wasm" 2>&1 | tail -1)"
-if [ "$gcsuberr_out" != "4200" ]; then
+if ! gcsuberr_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcsuberrdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: gc_backend_suberror_ctor.vibe under gc got '$gcsuberr_out' (want 4200) -- suberror ctor registration regressed" >&2
+  echo "$gcsuberr_out" >&2
   exit 1
 fi
 rm -rf "$gcsuberrdir"
@@ -4617,18 +4626,21 @@ echo "[compiler-gate] gc-lane to_string(Bool) regressions ok"
 echo "[compiler-gate] 40l/40 handle-replay side-effect corruption regression guard (M2/#817)"
 m2dir="_build/_gate_effect_replay_m2"
 rm -rf "$m2dir"; mkdir -p "$m2dir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_replay_corruption.vibe > "$m2dir/m2_src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$m2dir/m2_src.vibe" "$m2dir/m2.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_replay_corruption.vibe "$m2dir/m2.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$m2dir/m2.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_replay_corruption.vibe did not compile" >&2
   cat "$m2dir/m2.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-m2_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$m2dir/m2.wasm" 2>&1 | tail -1)"
-if [ "$m2_out" != "3013" ]; then
+if ! m2_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$m2dir/m2.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_replay_corruption got '$m2_out' (want 3013, the ADR-0076 Phase 2 direct-perform-inlining fixed value). This means the fix regressed -- e.g. inline_direct_performs stopped firing for this fixture's shape and it fell back to buggy replay (6016)." >&2
+  echo "$m2_out" >&2
   exit 1
 fi
 rm -rf "$m2dir"
@@ -4793,18 +4805,21 @@ echo "[compiler-gate] effectset parameter-type row expansion ok"
 echo "[compiler-gate] 40q/40 handler operation-level discharge (ADR-0071 step 4/#755)"
 a71edir="_build/_gate_effectset_handle_discharge"
 rm -rf "$a71edir"; mkdir -p "$a71edir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_operation_level_discharge.vibe > "$a71edir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$a71edir/src.vibe" "$a71edir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_operation_level_discharge.vibe "$a71edir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$a71edir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_operation_level_discharge.vibe did not compile -- handler operation-level discharge regressed" >&2
   cat "$a71edir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-a71e_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$a71edir/out.wasm" 2>&1 | tail -1)"
-if [ "$a71e_out" != "42" ]; then
+if ! a71e_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$a71edir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_operation_level_discharge got '$a71e_out' (want 42)" >&2
+  echo "$a71e_out" >&2
   exit 1
 fi
 rm -rf "$a71edir"
@@ -4916,18 +4931,21 @@ echo "[compiler-gate] effect->WIT effectset/qualified resolution ok"
 echo "[compiler-gate] 40u/40 evidence-dict threading through a helper-function call (ADR-0076 Phase 3/#817)"
 edpdir="_build/_gate_evidence_dict_call"
 rm -rf "$edpdir"; mkdir -p "$edpdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence.vibe > "$edpdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpdir/src.vibe" "$edpdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence.vibe "$edpdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence.vibe did not compile" >&2
   cat "$edpdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edp_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edp_out" != "3013" ]; then
+if ! edp_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence.vibe got '$edp_out' (want 3013) -- evidence-dict threading through a helper call regressed" >&2
+  echo "$edp_out" >&2
   exit 1
 fi
 rm -rf "$edpdir"
@@ -4953,18 +4971,21 @@ echo "[compiler-gate] evidence-dict threading through a helper-function call ok"
 echo "[compiler-gate] 40v/40 evidence-dict pass: branching handle body runs correctly via the evidence dict (ADR-0076 Phase 3/#817)"
 edpbdir="_build/_gate_evidence_dict_branch"
 rm -rf "$edpbdir"; mkdir -p "$edpbdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_branch.vibe > "$edpbdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpbdir/src.vibe" "$edpbdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_branch.vibe "$edpbdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpbdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_branch.vibe did not compile" >&2
   cat "$edpbdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpb_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpbdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpb_out" != "2007" ]; then
+if ! edpb_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpbdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_branch.vibe got '$edpb_out' (want 2007) -- either the invalid-wasm crash regressed, or the evidence-dict rewrite for branching bodies regressed" >&2
+  echo "$edpb_out" >&2
   exit 1
 fi
 rm -rf "$edpbdir"
@@ -4986,18 +5007,21 @@ echo "[compiler-gate] evidence-dict pass branching handle body ok"
 echo "[compiler-gate] 40w/40 evidence-dict pass: Error::Throw mixed into a needing function's body compiles (ADR-0076 Phase 3/#817)"
 edpemdir="_build/_gate_evidence_dict_error_mix"
 rm -rf "$edpemdir"; mkdir -p "$edpemdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_error_mix.vibe > "$edpemdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpemdir/src.vibe" "$edpemdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_error_mix.vibe "$edpemdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpemdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_error_mix.vibe did not compile" >&2
   cat "$edpemdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpem_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpemdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpem_out" != "5" ]; then
+if ! edpem_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpemdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_error_mix.vibe got '$edpem_out' (want 5)" >&2
+  echo "$edpem_out" >&2
   exit 1
 fi
 rm -rf "$edpemdir"
@@ -5024,18 +5048,21 @@ echo "[compiler-gate] evidence-dict pass Error::Throw mixing ok"
 echo "[compiler-gate] 40x/40 evidence-dict pass: multi-effect row migrates both effects through a nested handle pair (ADR-0076 Phase 3/#817)"
 edpmedir="_build/_gate_evidence_dict_multi_effect"
 rm -rf "$edpmedir"; mkdir -p "$edpmedir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_multi_effect_row_nested.vibe > "$edpmedir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpmedir/src.vibe" "$edpmedir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_multi_effect_row_nested.vibe "$edpmedir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpmedir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_multi_effect_row_nested.vibe did not compile" >&2
   cat "$edpmedir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpme_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpmedir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpme_out" != "2017" ]; then
+if ! edpme_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpmedir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_multi_effect_row_nested.vibe got '$edpme_out' (want 2017) -- multi-effect nested-handle migration regressed" >&2
+  echo "$edpme_out" >&2
   exit 1
 fi
 rm -rf "$edpmedir"
@@ -5052,18 +5079,21 @@ echo "[compiler-gate] evidence-dict pass multi-effect row nested-handle migratio
 echo "[compiler-gate] 40z/40 evidence-dict pass: minimal directly-nested handle pair, both effects migrate (ADR-0076 Phase 3/#817)"
 edpnhdir="_build/_gate_evidence_dict_nested_handles"
 rm -rf "$edpnhdir"; mkdir -p "$edpnhdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_multi_effect_nested_handles.vibe > "$edpnhdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpnhdir/src.vibe" "$edpnhdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_multi_effect_nested_handles.vibe "$edpnhdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpnhdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_multi_effect_nested_handles.vibe did not compile" >&2
   cat "$edpnhdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpnh_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpnhdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpnh_out" != "7" ]; then
+if ! edpnh_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpnhdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_multi_effect_nested_handles.vibe got '$edpnh_out' (want 7) -- directly-nested handle pair migration regressed" >&2
+  echo "$edpnh_out" >&2
   exit 1
 fi
 rm -rf "$edpnhdir"
@@ -5095,18 +5125,21 @@ echo "[compiler-gate] evidence-dict pass directly-nested handle pair migration o
 echo "[compiler-gate] 40y/40 evidence-dict pass: perform bound via let inside a needing function's own body (ADR-0076 Phase 3/#817)"
 edpletdir="_build/_gate_evidence_dict_let_bound"
 rm -rf "$edpletdir"; mkdir -p "$edpletdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_let_bound.vibe > "$edpletdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpletdir/src.vibe" "$edpletdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_let_bound.vibe "$edpletdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpletdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_let_bound.vibe did not compile" >&2
   cat "$edpletdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edplet_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpletdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edplet_out" != "6" ]; then
+if ! edplet_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpletdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_let_bound.vibe got '$edplet_out' (want 6) -- let-bound perform inside a needing function's body regressed (either an uncaught-exception crash or a wrong value)" >&2
+  echo "$edplet_out" >&2
   exit 1
 fi
 rm -rf "$edpletdir"
@@ -5126,18 +5159,21 @@ echo "[compiler-gate] evidence-dict pass let-bound perform ok"
 echo "[compiler-gate] 40aa/40 evidence-dict pass: call to a plain user-defined pure helper function (ADR-0076 Phase 3/#817)"
 edppurdir="_build/_gate_evidence_dict_pure_helper"
 rm -rf "$edppurdir"; mkdir -p "$edppurdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_pure_helper.vibe > "$edppurdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edppurdir/src.vibe" "$edppurdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_pure_helper.vibe "$edppurdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edppurdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_pure_helper.vibe did not compile" >&2
   cat "$edppurdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edppur_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edppurdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edppur_out" != "11" ]; then
+if ! edppur_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edppurdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_pure_helper.vibe got '$edppur_out' (want 11) -- pure-helper-call eligibility regressed" >&2
+  echo "$edppur_out" >&2
   exit 1
 fi
 rm -rf "$edppurdir"
@@ -5156,18 +5192,21 @@ echo "[compiler-gate] evidence-dict pass pure-helper call ok"
 echo "[compiler-gate] 40ab/40 evidence-dict pass: struct field read via EDot (ADR-0076 Phase 3/#817)"
 edpdotdir="_build/_gate_evidence_dict_struct_field"
 rm -rf "$edpdotdir"; mkdir -p "$edpdotdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_struct_field.vibe > "$edpdotdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpdotdir/src.vibe" "$edpdotdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_struct_field.vibe "$edpdotdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpdotdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_struct_field.vibe did not compile" >&2
   cat "$edpdotdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpdot_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpdotdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpdot_out" != "6" ]; then
+if ! edpdot_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpdotdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_struct_field.vibe got '$edpdot_out' (want 6) -- EDot eligibility regressed" >&2
+  echo "$edpdot_out" >&2
   exit 1
 fi
 rm -rf "$edpdotdir"
@@ -5187,18 +5226,21 @@ echo "[compiler-gate] evidence-dict pass struct field read ok"
 echo "[compiler-gate] 40ac/40 evidence-dict pass: closure literal defining a perform (ADR-0076 Phase 3/#817)"
 edpclodir="_build/_gate_evidence_dict_closure_literal"
 rm -rf "$edpclodir"; mkdir -p "$edpclodir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_closure_literal.vibe > "$edpclodir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpclodir/src.vibe" "$edpclodir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_closure_literal.vibe "$edpclodir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpclodir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_closure_literal.vibe did not compile" >&2
   cat "$edpclodir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpclo_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpclodir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpclo_out" != "6" ]; then
+if ! edpclo_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpclodir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_closure_literal.vibe got '$edpclo_out' (want 6) -- closure-literal eligibility regressed" >&2
+  echo "$edpclo_out" >&2
   exit 1
 fi
 rm -rf "$edpclodir"
@@ -5224,18 +5266,21 @@ echo "[compiler-gate] evidence-dict pass closure literal ok"
 echo "[compiler-gate] 40ad/40 evidence-dict pass: needing function's row spelled via an effectset alias (ADR-0076 Phase 3/#817)"
 edpesdir="_build/_gate_evidence_dict_effectset_alias"
 rm -rf "$edpesdir"; mkdir -p "$edpesdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_effectset_alias.vibe > "$edpesdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpesdir/src.vibe" "$edpesdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_effectset_alias.vibe "$edpesdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpesdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_effectset_alias.vibe did not compile" >&2
   cat "$edpesdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpes_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpesdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpes_out" != "2007" ]; then
+if ! edpes_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpesdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_effectset_alias.vibe got '$edpes_out' (want 2007) -- either effectset-alias row recognition regressed, or it regressed back to the replay-inflated value" >&2
+  echo "$edpes_out" >&2
   exit 1
 fi
 rm -rf "$edpesdir"
@@ -5250,18 +5295,21 @@ echo "[compiler-gate] evidence-dict pass effectset alias ok"
 echo "[compiler-gate] 40ae/40 evidence-dict pass: needing function's row is a directly-qualified operation (ADR-0076 Phase 3/#817)"
 edpqodir="_build/_gate_evidence_dict_qualified_op"
 rm -rf "$edpqodir"; mkdir -p "$edpqodir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_qualified_op.vibe > "$edpqodir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpqodir/src.vibe" "$edpqodir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_qualified_op.vibe "$edpqodir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpqodir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_qualified_op.vibe did not compile" >&2
   cat "$edpqodir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpqo_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpqodir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpqo_out" != "2007" ]; then
+if ! edpqo_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpqodir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_qualified_op.vibe got '$edpqo_out' (want 2007) -- qualified-operation row recognition regressed, or it regressed back to the replay-inflated value" >&2
+  echo "$edpqo_out" >&2
   exit 1
 fi
 rm -rf "$edpqodir"
@@ -5278,18 +5326,21 @@ echo "[compiler-gate] evidence-dict pass qualified-operation row ok"
 echo "[compiler-gate] 40af/40 evidence-dict pass: row combines a concrete effect with an open row-variable tail (ADR-0076 Phase 3/#817)"
 edprvdir="_build/_gate_evidence_dict_row_variable_tail"
 rm -rf "$edprvdir"; mkdir -p "$edprvdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_row_variable_tail.vibe > "$edprvdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edprvdir/src.vibe" "$edprvdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_row_variable_tail.vibe "$edprvdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edprvdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_row_variable_tail.vibe did not compile" >&2
   cat "$edprvdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edprv_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edprvdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edprv_out" != "2007" ]; then
+if ! edprv_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edprvdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_row_variable_tail.vibe got '$edprv_out' (want 2007) -- row-variable-tail row recognition regressed, or it regressed back to the replay-inflated value" >&2
+  echo "$edprv_out" >&2
   exit 1
 fi
 rm -rf "$edprvdir"
@@ -5308,18 +5359,21 @@ echo "[compiler-gate] evidence-dict pass row-variable-tail row ok"
 echo "[compiler-gate] 40ag/40 evidence-dict pass: needing function calls a capture-free local closure (ADR-0076 Phase 3/#817, #786)"
 edplccfdir="_build/_gate_evidence_dict_local_closure_capture_free"
 rm -rf "$edplccfdir"; mkdir -p "$edplccfdir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_call_evidence_local_closure_capture_free.vibe > "$edplccfdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edplccfdir/src.vibe" "$edplccfdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_local_closure_capture_free.vibe "$edplccfdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edplccfdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_local_closure_capture_free.vibe did not compile" >&2
   cat "$edplccfdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edplccf_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edplccfdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edplccf_out" != "2007" ]; then
+if ! edplccf_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edplccfdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_local_closure_capture_free.vibe got '$edplccf_out' (want 2007) -- either #786's hoist regressed or evidence_dict_pass no longer forwards to the hoisted top-level name" >&2
+  echo "$edplccf_out" >&2
   exit 1
 fi
 rm -rf "$edplccfdir"
@@ -5338,18 +5392,21 @@ echo "[compiler-gate] evidence-dict pass capture-free local closure call ok"
 echo "[compiler-gate] 40ah/40 local effectful closure capturing an enclosing local now compiles and runs (#1069)"
 lcccdir="_build/_gate_local_closure_capture_conversion"
 rm -rf "$lcccdir"; mkdir -p "$lcccdir"
-sed '/^__DATA__$/,$d' fixtures/effect_local_closure_capture_conversion.vibe > "$lcccdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$lcccdir/src.vibe" "$lcccdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_local_closure_capture_conversion.vibe "$lcccdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$lcccdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_capture_conversion.vibe did not compile" >&2
   cat "$lcccdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-lccc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$lcccdir/out.wasm" 2>&1 | tail -1)"
-if [ "$lccc_out" != "1015" ]; then
+if ! lccc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$lcccdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_local_closure_capture_conversion.vibe got '$lccc_out' (want 1015) -- #1069's closure conversion regressed" >&2
+  echo "$lccc_out" >&2
   exit 1
 fi
 rm -rf "$lcccdir"
@@ -5429,18 +5486,21 @@ echo "[compiler-gate] trivial-wrapper inlining wrapper-as-value reference ok (#1
 echo "[compiler-gate] 40ak/40 trivial-wrapper inlining does not misfire on wrong-arity wrapper bodies (#1070 narrow slice)"
 lcwadir="_build/_gate_local_closure_wrapper_wrong_arity"
 rm -rf "$lcwadir"; mkdir -p "$lcwadir"
-sed '/^__DATA__$/,$d' fixtures/local_closure_wrapper_wrong_arity_not_inlined.vibe > "$lcwadir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$lcwadir/src.vibe" "$lcwadir/out.wasm" main >/dev/null 2>&1
+  fixtures/local_closure_wrapper_wrong_arity_not_inlined.vibe "$lcwadir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$lcwadir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: local_closure_wrapper_wrong_arity_not_inlined.vibe did not compile" >&2
   cat "$lcwadir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-lcwa_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$lcwadir/out.wasm" 2>&1 | tail -1)"
-if [ "$lcwa_out" != "6" ]; then
+if ! lcwa_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$lcwadir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: local_closure_wrapper_wrong_arity_not_inlined.vibe got '$lcwa_out' (want 6) -- trivial-wrapper pattern misfired on a wrong-arity call" >&2
+  echo "$lcwa_out" >&2
   exit 1
 fi
 rm -rf "$lcwadir"
@@ -5463,18 +5523,21 @@ echo "[compiler-gate] trivial-wrapper inlining wrong-arity non-match ok (#1070 n
 echo "[compiler-gate] 40al/40 inline effectful lambda literal (IIFE / HOF argument, capture-free) no longer crashes"
 illhadir="_build/_gate_inline_lambda_literal_hof_arg"
 rm -rf "$illhadir"; mkdir -p "$illhadir"
-sed '/^__DATA__$/,$d' fixtures/effect_inline_lambda_literal_hof_arg.vibe > "$illhadir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$illhadir/src.vibe" "$illhadir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_inline_lambda_literal_hof_arg.vibe "$illhadir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$illhadir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_inline_lambda_literal_hof_arg.vibe did not compile" >&2
   cat "$illhadir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-illha_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$illhadir/out.wasm" 2>&1 | tail -1)"
-if [ "$illha_out" != "10" ]; then
+if ! illha_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$illhadir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_inline_lambda_literal_hof_arg.vibe got '$illha_out' (want 10) -- inline lambda literal IIFE/HOF-arg fix regressed" >&2
+  echo "$illha_out" >&2
   exit 1
 fi
 rm -rf "$illhadir"
@@ -5489,18 +5552,21 @@ echo "[compiler-gate] inline effectful lambda literal IIFE/HOF-arg fix ok (10)"
 echo "[compiler-gate] 40am/40 inline effectful lambda literal as a LABELED call argument no longer crashes"
 illladir="_build/_gate_inline_lambda_literal_labeled_arg"
 rm -rf "$illladir"; mkdir -p "$illladir"
-sed '/^__DATA__$/,$d' fixtures/effect_inline_lambda_literal_labeled_arg.vibe > "$illladir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$illladir/src.vibe" "$illladir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_inline_lambda_literal_labeled_arg.vibe "$illladir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$illladir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_inline_lambda_literal_labeled_arg.vibe did not compile" >&2
   cat "$illladir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-illla_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$illladir/out.wasm" 2>&1 | tail -1)"
-if [ "$illla_out" != "5" ]; then
+if ! illla_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$illladir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_inline_lambda_literal_labeled_arg.vibe got '$illla_out' (want 5) -- labeled-arg literal fix regressed" >&2
+  echo "$illla_out" >&2
   exit 1
 fi
 rm -rf "$illladir"
@@ -5516,18 +5582,21 @@ echo "[compiler-gate] inline effectful lambda literal labeled-arg fix ok (5)"
 echo "[compiler-gate] 40an/40 trivial-wrapper inlining respects lexical shadowing (#1074 review)"
 dtpwsdir="_build/_gate_dtpw_wrapper_shadowed"
 rm -rf "$dtpwsdir"; mkdir -p "$dtpwsdir"
-sed '/^__DATA__$/,$d' fixtures/dtpw_wrapper_shadowed_by_parameter.vibe > "$dtpwsdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$dtpwsdir/src.vibe" "$dtpwsdir/out.wasm" main >/dev/null 2>&1
+  fixtures/dtpw_wrapper_shadowed_by_parameter.vibe "$dtpwsdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$dtpwsdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: dtpw_wrapper_shadowed_by_parameter.vibe did not compile" >&2
   cat "$dtpwsdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-dtpws_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$dtpwsdir/out.wasm" 2>&1 | tail -1)"
-if [ "$dtpws_out" != "99" ]; then
+if ! dtpws_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$dtpwsdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: dtpw_wrapper_shadowed_by_parameter.vibe got '$dtpws_out' (want 99) -- trivial-wrapper shadowing fix regressed" >&2
+  echo "$dtpws_out" >&2
   exit 1
 fi
 rm -rf "$dtpwsdir"
@@ -5545,18 +5614,21 @@ echo "[compiler-gate] trivial-wrapper inlining shadowing fix ok (99)"
 echo "[compiler-gate] 40ao/40 evidence-dict needing-forwarding respects lexical shadowing (#1074 review)"
 edpsdir="_build/_gate_edp_needing_shadowed"
 rm -rf "$edpsdir"; mkdir -p "$edpsdir"
-sed '/^__DATA__$/,$d' fixtures/evidence_dict_needing_shadowed_by_local.vibe > "$edpsdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpsdir/src.vibe" "$edpsdir/out.wasm" main >/dev/null 2>&1
+  fixtures/evidence_dict_needing_shadowed_by_local.vibe "$edpsdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpsdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: evidence_dict_needing_shadowed_by_local.vibe did not compile" >&2
   cat "$edpsdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edps_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpsdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edps_out" != "47" ]; then
+if ! edps_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpsdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: evidence_dict_needing_shadowed_by_local.vibe got '$edps_out' (want 47) -- evidence-dict needing-forwarding shadowing fix regressed" >&2
+  echo "$edps_out" >&2
   exit 1
 fi
 rm -rf "$edpsdir"
@@ -5581,18 +5653,21 @@ echo "[compiler-gate] evidence-dict needing-forwarding shadowing fix ok (47)"
 echo "[compiler-gate] 40ap/40 evidence-dict forwarding through an own closure-typed HOF parameter (#1070 general case)"
 edpgdir="_build/_gate_edp_closure_hof_general"
 rm -rf "$edpgdir"; mkdir -p "$edpgdir"
-sed '/^__DATA__$/,$d' fixtures/effect_local_closure_by_value_hof_general.vibe > "$edpgdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpgdir/src.vibe" "$edpgdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_local_closure_by_value_hof_general.vibe "$edpgdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpgdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_hof_general.vibe did not compile" >&2
   cat "$edpgdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpg_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpgdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpg_out" != "210" ]; then
+if ! edpg_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpgdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_hof_general.vibe got '$edpg_out' (want 210) -- #1070 general-case closure-HOF-parameter fix regressed" >&2
+  echo "$edpg_out" >&2
   exit 1
 fi
 rm -rf "$edpgdir"
@@ -5611,18 +5686,21 @@ echo "[compiler-gate] evidence-dict forwarding through own closure-typed HOF par
 echo "[compiler-gate] 40aq/40 closure-typed HOF parameter safety boundary: multi-use closure stays unmigrated (#1070 general case)"
 edpedir="_build/_gate_edp_closure_hof_escaping"
 rm -rf "$edpedir"; mkdir -p "$edpedir"
-sed '/^__DATA__$/,$d' fixtures/effect_local_closure_by_value_hof_escaping.vibe > "$edpedir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edpedir/src.vibe" "$edpedir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_local_closure_by_value_hof_escaping.vibe "$edpedir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edpedir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_hof_escaping.vibe did not compile" >&2
   cat "$edpedir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edpe_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edpedir/out.wasm" 2>&1 | tail -1)"
-if [ "$edpe_out" != "206" ]; then
+if ! edpe_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpedir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_hof_escaping.vibe got '$edpe_out' (want 206) -- #1070 closure-HOF-parameter safety boundary regressed" >&2
+  echo "$edpe_out" >&2
   exit 1
 fi
 rm -rf "$edpedir"
@@ -5642,18 +5720,21 @@ echo "[compiler-gate] closure-typed HOF parameter safety boundary ok (206)"
 echo "[compiler-gate] 40ar/40 self-discharging owner's closure-typed parameter (#1070 general case, second slice)"
 edphdir="_build/_gate_edp_handle_owner_param"
 rm -rf "$edphdir"; mkdir -p "$edphdir"
-sed '/^__DATA__$/,$d' fixtures/effect_local_closure_handle_owner_param.vibe > "$edphdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$edphdir/src.vibe" "$edphdir/out.wasm" main >/dev/null 2>&1
+  fixtures/effect_local_closure_handle_owner_param.vibe "$edphdir/out.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$edphdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_handle_owner_param.vibe did not compile" >&2
   cat "$edphdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-edph_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$edphdir/out.wasm" 2>&1 | tail -1)"
-if [ "$edph_out" != "285" ]; then
+if ! edph_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edphdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_local_closure_handle_owner_param.vibe got '$edph_out' (want 285) -- #1070 self-discharging-owner closure-param fix regressed" >&2
+  echo "$edph_out" >&2
   exit 1
 fi
 rm -rf "$edphdir"
@@ -8473,18 +8554,21 @@ echo "[compiler-gate] named host future collector ok"
 echo "[compiler-gate] 79/79 generic effect instantiation registration + rows (ADR-0071/#1340)"
 g1340dir="_build/_gate_1340"
 rm -rf "$g1340dir"; mkdir -p "$g1340dir"
-sed '/^__DATA__$/,$d' fixtures/effect_generic_row_instantiation.vibe > "$g1340dir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g1340dir/pos.vibe" "$g1340dir/pos.wasm" main >/dev/null 2>&1
+  fixtures/effect_generic_row_instantiation.vibe "$g1340dir/pos.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$g1340dir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_generic_row_instantiation.vibe did not compile (with State[Int] row grammar or generic registration regressed)" >&2
   cat "$g1340dir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-g1340_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$g1340dir/pos.wasm" 2>&1 | tail -1)"
-if [ "$g1340_out" != "42" ]; then
+if ! g1340_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g1340dir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_generic_row_instantiation got '$g1340_out' (want 42)" >&2
+  echo "$g1340_out" >&2
   exit 1
 fi
 sed '/^__DATA__$/,$d' fixtures/err_generic_effect_perform_arity.vibe > "$g1340dir/arity.vibe"
@@ -8898,18 +8982,21 @@ echo "[compiler-gate] higher-order effect diagnostic ok"
 echo "[compiler-gate] 85/85 typed Exception[E] rows (ADR-0085/#1344)"
 excdir="_build/_gate_1344"
 rm -rf "$excdir"; mkdir -p "$excdir"
-sed '/^__DATA__$/,$d' fixtures/exception_typed_row.vibe > "$excdir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$excdir/pos.vibe" "$excdir/pos.wasm" main >/dev/null 2>&1
+  fixtures/exception_typed_row.vibe "$excdir/pos.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$excdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: exception_typed_row.vibe did not compile (Exception[E] rows / kinded handle / erased alias regressed)" >&2
   cat "$excdir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-exc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$excdir/pos.wasm" 2>&1 | tail -1)"
-if [ "$exc_out" != "42" ]; then
+if ! exc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$excdir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: exception_typed_row got '$exc_out' (want 42) -- kinded exceptions must share one Wasm tag" >&2
+  echo "$exc_out" >&2
   exit 1
 fi
 sed '/^__DATA__$/,$d' fixtures/err_exception_kind_mismatch.vibe > "$excdir/neg.vibe"

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -10214,7 +10214,7 @@ done
 rm -rf "$dvdir"
 echo "[compiler-gate] desugar-emitted builtins resolve in both lanes ok"
 
-echo "[compiler-gate] 98/98 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
+echo "[compiler-gate] 98/99 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
 # grep_test.vibe covers the pattern language and the filters through
 # grep_scan_source (no Fs). What only the REAL adapter mode exercises is the
 # filesystem tier: sweeping a directory, and resolving a capture's type through
@@ -10296,5 +10296,105 @@ if [ -s "$gvdir/bad.txt" ] || ! grep -q 'unknown metavariable kind' "$gvdir/bad.
 fi
 rm -rf "$gvdir"
 echo "[compiler-gate] vibe grep typed filters ok"
+
+# 99. #1571: `inspect` is a REWRITE, not a function, so the two ways it can be
+#     wrong are both silent -- it can capture a name the user already bound, and
+#     it can hijack a call the user meant for their own `inspect`. Both were
+#     found by review rather than by a gate (the second twice: expression
+#     binders in #1622, PATTERN binders after that), which is what this step is
+#     for. Each case below fails DIFFERENTLY if the guard regresses.
+echo "[compiler-gate] 99/99 the inspect rewrite neither captures nor hijacks (#1571)"
+inspdir="_build/_gate_inspect_guard"
+rm -rf "$inspdir"; mkdir -p "$inspdir"
+
+# (a) Hygiene: the temporaries the expansion introduces must not capture a name
+# the arguments already reference. With a fixed temp name this compared the
+# literal against ITSELF and passed; the assertion has to see "wrong".
+cat > "$inspdir/hygiene.vibe" <<'INSPH'
+fn main() -> Int {
+  let __vibe_inspect_actual = "wrong"
+  inspect(1, __vibe_inspect_actual)
+  0
+}
+INSPH
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$inspdir/hygiene.vibe" "$inspdir/hygiene.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$inspdir/hygiene.wasm" ]; then
+  echo "[compiler-gate] FAIL: the inspect hygiene sample did not compile" >&2
+  cat "$inspdir/hygiene.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if insp_hyg="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$inspdir/hygiene.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: inspect(1, __vibe_inspect_actual) PASSED -- the expansion's temporary captured the argument, so it compared a value against itself (#1571 hygiene)" >&2
+  echo "$insp_hyg" >&2
+  exit 1
+fi
+
+# (b) Shadow, expression binder: a user function named `inspect` must keep its
+# own body. 2 + 5 = 7; the rewrite would return Unit and not type.
+cat > "$inspdir/shadow_fn.vibe" <<'INSPF'
+fn inspect(v: Int, c: String) -> Int {
+  v + 5
+}
+
+fn main() -> Int {
+  inspect(2, "ignored")
+}
+INSPF
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$inspdir/shadow_fn.vibe" "$inspdir/shadow_fn.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$inspdir/shadow_fn.wasm" ]; then
+  echo "[compiler-gate] FAIL: a user-declared \`inspect\` did not compile -- the rewrite hijacked the call (#1571 shadow)" >&2
+  cat "$inspdir/shadow_fn.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+insp_fn_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$inspdir/shadow_fn.wasm" 2>/dev/null | tail -1)"
+if [ "$insp_fn_out" != "7" ]; then
+  echo "[compiler-gate] FAIL: a user-declared \`inspect\` got '$insp_fn_out' (want 7) -- its body did not run (#1571 shadow)" >&2
+  exit 1
+fi
+
+# (c) Shadow, PATTERN binder (Codex review on #1622): the same hijack via a
+# match arm, which the expression-only guard could not see. The side effect is
+# the observable: the rewrite runs a snapshot assertion instead and traps.
+cat > "$inspdir/shadow_pat.vibe" <<'INSPP'
+enum Box {
+  B((Int, String) -> Unit)
+}
+
+fn shout(v: Int, c: String) -> Unit {
+  println(c)
+}
+
+fn main() -> Int {
+  match B(shout) {
+    B(inspect) => {
+      inspect(1, "SIDE EFFECT RAN")
+      7
+    }
+  }
+}
+INSPP
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$inspdir/shadow_pat.vibe" "$inspdir/shadow_pat.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$inspdir/shadow_pat.wasm" ]; then
+  echo "[compiler-gate] FAIL: a pattern-bound \`inspect\` did not compile (#1571 shadow, pattern binders)" >&2
+  cat "$inspdir/shadow_pat.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+insp_pat_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$inspdir/shadow_pat.wasm" 2>&1)"
+case "$insp_pat_out" in
+  *"SIDE EFFECT RAN"*) ;;
+  *)
+    echo "[compiler-gate] FAIL: a match-arm-bound \`inspect\` was rewritten -- the user's function never ran (#1571 shadow; see dinsp_pat_binds in normalize/desugar_trait_dict.vibe)" >&2
+    echo "$insp_pat_out" >&2
+    exit 1
+    ;;
+esac
+rm -rf "$inspdir"
+echo "[compiler-gate] inspect rewrite hygiene + shadow guard ok"
 
 echo "[compiler-gate] ok"

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -1498,18 +1498,21 @@ echo "[compiler-gate] rank-1 trait-method generics regression ok"
 echo "[compiler-gate] 14c/14 UFCS-on-bounded-tparam dict dispatch (#931)"
 ufcsdir="_build/_gate_ufcs_tparam"
 rm -rf "$ufcsdir"; mkdir -p "$ufcsdir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/trait_bound_ufcs_method.vibe > "$ufcsdir/ufcs.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$ufcsdir/ufcs.vibe" "$ufcsdir/ufcs.wasm" _start >/dev/null 2>&1
+  fixtures/trait_bound_ufcs_method.vibe "$ufcsdir/ufcs.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$ufcsdir/ufcs.wasm" ]; then
   echo "[compiler-gate] FAIL: UFCS-on-bounded-tparam program did not compile" >&2
   cat "$ufcsdir/ufcs.wasm.diag" 2>/dev/null >&2; exit 1
 fi
-ufcs_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
-  --invoke _start "$ufcsdir/ufcs.wasm" 2>/dev/null | tr -dc '0-9')"
-if [ "$ufcs_out" != "97097" ]; then
-  echo "[compiler-gate] FAIL: UFCS-on-bounded-tparam mismatch (got '$ufcs_out', want 97097 -> #931 regressed)" >&2
+if ! ufcs_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+  --invoke _start "$ufcsdir/ufcs.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: UFCS-on-bounded-tparam mismatch (want 97097 -> #931 regressed)" >&2
+  echo "$ufcs_out" >&2
   exit 1
 fi
 rm -rf "$ufcsdir"
@@ -6614,18 +6617,21 @@ echo "[compiler-gate] self-hosted vibe lsp round trip ok (incl. completion/signa
 echo "[compiler-gate] 48/48 ADR-0068 Send marker (structural judgment + rejections)"
 senddir="_build/_gate_send_marker"
 rm -rf "$senddir"; mkdir -p "$senddir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/send_bound_structural.vibe > "$senddir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$senddir/pos.vibe" "$senddir/pos.wasm" _start >/dev/null 2>&1 || true
+  fixtures/send_bound_structural.vibe "$senddir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$senddir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: send_bound_structural.vibe did not compile -- structural Send acceptance regressed" >&2
   cat "$senddir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-send_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$senddir/pos.wasm" 2>/dev/null | tail -1)"
-if [ "$send_pos_out" != "42" ]; then
+if ! send_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$senddir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: send_bound_structural got '$send_pos_out' (want 42)" >&2
+  echo "$send_pos_out" >&2
   exit 1
 fi
 send_check_reject() {
@@ -6692,18 +6698,21 @@ echo "[compiler-gate] ADR-0068 Send marker ok"
 echo "[compiler-gate] 49/49 RC branch+loop mixed-consume over-drop (#1085)"
 rc1085dir="_build/_gate_rc_branch_loop"
 rm -rf "$rc1085dir"; mkdir -p "$rc1085dir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/rc_branch_loop_mixed_consume_test.vibe > "$rc1085dir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$rc1085dir/src.vibe" "$rc1085dir/src.wasm" _start >/dev/null 2>&1 || true
+  fixtures/rc_branch_loop_mixed_consume_test.vibe "$rc1085dir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$rc1085dir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_branch_loop_mixed_consume fixture did not compile" >&2
   cat "$rc1085dir/src.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-rc1085_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1085dir/src.wasm" 2>/dev/null | tail -1)"
-if [ "$rc1085_out" != "123123" ]; then
+if ! rc1085_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1085dir/src.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: rc_branch_loop_mixed_consume got '$rc1085_out' (want 123123) -- #1085 over-drop regressed" >&2
+  echo "$rc1085_out" >&2
   exit 1
 fi
 rm -rf "$rc1085dir"
@@ -6888,18 +6897,21 @@ echo "[compiler-gate] ADR-0076 Phase 3a first-class resume ok"
 echo "[compiler-gate] 51/51 RC match-payload closure capture (#1097)"
 rc1097dir="_build/_gate_rc_payload_capture"
 rm -rf "$rc1097dir"; mkdir -p "$rc1097dir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/rc_match_payload_closure_capture_test.vibe > "$rc1097dir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$rc1097dir/src.vibe" "$rc1097dir/src.wasm" _start >/dev/null 2>&1 || true
+  fixtures/rc_match_payload_closure_capture_test.vibe "$rc1097dir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$rc1097dir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_match_payload_closure_capture fixture did not compile" >&2
   cat "$rc1097dir/src.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-rc1097_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1097dir/src.wasm" 2>/dev/null | tail -1)"
-if [ "$rc1097_out" != "38013" ]; then
+if ! rc1097_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1097dir/src.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: rc_match_payload_closure_capture got '$rc1097_out' (want 38013) -- #1097 regressed" >&2
+  echo "$rc1097_out" >&2
   exit 1
 fi
 rm -rf "$rc1097dir"
@@ -6913,18 +6925,21 @@ echo "[compiler-gate] RC match-payload closure capture (#1097) ok"
 #        reused the cell: the two shapes summed to 12 and 207, not 45 and 300).
 rc1272dir="_build/_gate_rc_local_elem_escape"
 rm -rf "$rc1272dir"; mkdir -p "$rc1272dir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/rc_local_container_element_escape.vibe > "$rc1272dir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$rc1272dir/src.vibe" "$rc1272dir/src.wasm" _start >/dev/null 2>&1 || true
+  fixtures/rc_local_container_element_escape.vibe "$rc1272dir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$rc1272dir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_local_container_element_escape fixture did not compile" >&2
   cat "$rc1272dir/src.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-rc1272_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1272dir/src.wasm" 2>/dev/null | tail -1)"
-if [ "$rc1272_out" != "345" ]; then
+if ! rc1272_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1272dir/src.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: rc_local_container_element_escape got '$rc1272_out' (want 345) -- #1272 regressed" >&2
+  echo "$rc1272_out" >&2
   exit 1
 fi
 rm -rf "$rc1272dir"
@@ -6939,18 +6954,20 @@ echo "[compiler-gate] RC local-container element escape (#1272) ok"
 #        recursion once two appeared in one function.
 awmdir="_build/_gate_await_multi"
 rm -rf "$awmdir"; mkdir -p "$awmdir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/async_await_multi.vibe > "$awmdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$awmdir/src.vibe" "$awmdir/src.wasm" _start >/dev/null 2>&1 || true
+  fixtures/async_await_multi.vibe "$awmdir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$awmdir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: async_await_multi fixture did not compile" >&2
   cat "$awmdir/src.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-awm_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$awmdir/src.wasm" 2>/dev/null | tail -1)"
-if [ "$awm_out" != "50" ]; then
+if ! awm_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$awmdir/src.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: async_await_multi got '$awm_out' (want 50) -- #1230 await hoist regressed" >&2
+  echo "$awm_out" >&2
   exit 1
 fi
 rm -rf "$awmdir"
@@ -6962,18 +6979,20 @@ echo "[compiler-gate] multi-position await hoist (#1230) ok"
 #        still-pending await needs a driver parking the continuation).
 fpdir="_build/_gate_future_pending"
 rm -rf "$fpdir"; mkdir -p "$fpdir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/async_future_pending.vibe > "$fpdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$fpdir/src.vibe" "$fpdir/src.wasm" _start >/dev/null 2>&1 || true
+  fixtures/async_future_pending.vibe "$fpdir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$fpdir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: async_future_pending fixture did not compile" >&2
   cat "$fpdir/src.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-fp_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$fpdir/src.wasm" 2>/dev/null | tail -1)"
-if [ "$fp_out" != "42" ]; then
+if ! fp_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$fpdir/src.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: async_future_pending got '$fp_out' (want 42) -- #1230 pending producer regressed" >&2
+  echo "$fp_out" >&2
   exit 1
 fi
 rm -rf "$fpdir"
@@ -7145,18 +7164,21 @@ echo "[compiler-gate] type-directed closure evidence ok"
 echo "[compiler-gate] 55/55 replay frontier removal (ADR-0076 追記34 V2)"
 v2dir="_build/_gate_replay_removed"
 rm -rf "$v2dir"; mkdir -p "$v2dir"
-sed '/^__DATA__$/,$d' fixtures/effect_vacuous_handle_erased.vibe > "$v2dir/vacuous.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$v2dir/vacuous.vibe" "$v2dir/vacuous.wasm" _start >/dev/null 2>&1 || true
+  fixtures/effect_vacuous_handle_erased.vibe "$v2dir/vacuous.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$v2dir/vacuous.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_vacuous_handle_erased fixture did not compile" >&2
   cat "$v2dir/vacuous.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-v2_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$v2dir/vacuous.wasm" 2>/dev/null | tail -1)"
-if [ "$v2_out" != "46" ]; then
+if ! v2_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$v2dir/vacuous.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_vacuous_handle_erased got '$v2_out' (want 46) -- vacuous-handle elimination regressed" >&2
+  echo "$v2_out" >&2
   exit 1
 fi
 rm -f "$v2dir/reject.wasm"
@@ -7187,18 +7209,21 @@ echo "[compiler-gate] replay frontier removal ok"
 echo "[compiler-gate] 56/56 closure captures enclosing-scope shadow of an inlined builtin (#1114)"
 csibdir="_build/_gate_closure_shadow_builtin"
 rm -rf "$csibdir"; mkdir -p "$csibdir"
-sed '/^__DATA__$/,$d' fixtures/closure_shadowed_inline_builtin.vibe > "$csibdir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$csibdir/src.vibe" "$csibdir/out.wasm" _start >/dev/null 2>&1 || true
+  fixtures/closure_shadowed_inline_builtin.vibe "$csibdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$csibdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: closure_shadowed_inline_builtin.vibe did not compile" >&2
   cat "$csibdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-csib_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$csibdir/out.wasm" 2>/dev/null | tail -1)"
-if [ "$csib_out" != "28" ]; then
+if ! csib_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$csibdir/out.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: closure_shadowed_inline_builtin got '$csib_out' (want 28) -- either a shadowed inline builtin fell back to the builtin instead of the captured closure (#1114), or a non-recursive let binder was treated as an enclosing shadow inside its own initializer (#1120 Codex P1)" >&2
+  echo "$csib_out" >&2
   exit 1
 fi
 rm -rf "$csibdir"
@@ -7314,18 +7339,20 @@ fi
 echo "[compiler-gate] 59/59 ADR-0068 region generativity (#1081 step 3)"
 regiondir="_build/_gate_region"
 rm -rf "$regiondir"; mkdir -p "$regiondir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/region_ok_basic.vibe > "$regiondir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$regiondir/pos.vibe" "$regiondir/pos.wasm" _start >/dev/null 2>&1 || true
+  fixtures/region_ok_basic.vibe "$regiondir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$regiondir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_basic.vibe did not compile -- plain non-escaping nursery use regressed" >&2
   cat "$regiondir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-region_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$regiondir/pos.wasm" 2>/dev/null | tail -1)"
-if [ "$region_pos_out" != "42" ]; then
+if ! region_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$regiondir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: region_ok_basic.vibe got '$region_pos_out' (want 42)" >&2
+  echo "$region_pos_out" >&2
   exit 1
 fi
 sed '/^__DATA__$/,$d' fixtures/err_region_escape_return.vibe > "$regiondir/neg.vibe"
@@ -7383,18 +7410,20 @@ echo "[compiler-gate] deps missing-for-imports scan (#1145 follow-up 2) ok"
 echo "[compiler-gate] 61/61 ADR-0068 Spawnable[r] capture check (#1081 step 3 Phase B)"
 spawnabledir="_build/_gate_spawnable"
 rm -rf "$spawnabledir"; mkdir -p "$spawnabledir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/region_ok_spawnable_capture.vibe > "$spawnabledir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$spawnabledir/pos.vibe" "$spawnabledir/pos.wasm" _start >/dev/null 2>&1 || true
+  fixtures/region_ok_spawnable_capture.vibe "$spawnabledir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$spawnabledir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_spawnable_capture.vibe did not compile -- same-region Sender capture regressed" >&2
   cat "$spawnabledir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-spawnable_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$spawnabledir/pos.wasm" 2>/dev/null | tail -1)"
-if [ "$spawnable_pos_out" != "42" ]; then
+if ! spawnable_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$spawnabledir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: region_ok_spawnable_capture.vibe got '$spawnable_pos_out' (want 42)" >&2
+  echo "$spawnable_pos_out" >&2
   exit 1
 fi
 sed '/^__DATA__$/,$d' fixtures/err_spawnable_capture_array.vibe > "$spawnabledir/neg_array.vibe"
@@ -7455,18 +7484,20 @@ fi
 # alone -- so an unrelated `let mut x` in a sibling closure made a
 # lexically-distinct, genuinely-immutable `x` captured elsewhere look
 # mutable too. Must compile and run cleanly.
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/region_ok_spawnable_capture_shadowed_letmut.vibe > "$spawnabledir/pos_shadow.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$spawnabledir/pos_shadow.vibe" "$spawnabledir/pos_shadow.wasm" _start >/dev/null 2>&1 || true
+  fixtures/region_ok_spawnable_capture_shadowed_letmut.vibe "$spawnabledir/pos_shadow.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$spawnabledir/pos_shadow.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_spawnable_capture_shadowed_letmut.vibe did not compile -- scope-blind let-mut false positive regressed" >&2
   cat "$spawnabledir/pos_shadow.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-spawnable_shadow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$spawnabledir/pos_shadow.wasm" 2>/dev/null | tail -1)"
-if [ "$spawnable_shadow_out" != "42" ]; then
+if ! spawnable_shadow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$spawnabledir/pos_shadow.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: region_ok_spawnable_capture_shadowed_letmut.vibe got '$spawnable_shadow_out' (want 42)" >&2
+  echo "$spawnable_shadow_out" >&2
   exit 1
 fi
 # Codex review (PR #1152, P2): the whole-program `let mut` capture pass
@@ -7495,18 +7526,20 @@ echo "[compiler-gate] ADR-0068 Spawnable[r] capture check ok"
 echo "[compiler-gate] 62/67 ADR-0068 taskgroup { g => body } syntax sugar (#1081 step 4)"
 taskgroupdir="_build/_gate_taskgroup_sugar"
 rm -rf "$taskgroupdir"; mkdir -p "$taskgroupdir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/region_ok_taskgroup_sugar.vibe > "$taskgroupdir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$taskgroupdir/pos.vibe" "$taskgroupdir/pos.wasm" _start >/dev/null 2>&1 || true
+  fixtures/region_ok_taskgroup_sugar.vibe "$taskgroupdir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$taskgroupdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_taskgroup_sugar.vibe did not compile" >&2
   cat "$taskgroupdir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-taskgroup_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$taskgroupdir/pos.wasm" 2>/dev/null | tail -1)"
-if [ "$taskgroup_pos_out" != "42" ]; then
+if ! taskgroup_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$taskgroupdir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: region_ok_taskgroup_sugar.vibe got '$taskgroup_pos_out' (want 42)" >&2
+  echo "$taskgroup_pos_out" >&2
   exit 1
 fi
 sed '/^__DATA__$/,$d' fixtures/err_taskgroup_sugar_region_escape.vibe > "$taskgroupdir/neg.vibe"
@@ -7548,32 +7581,38 @@ echo "[compiler-gate] taskgroup { g => body } syntax sugar ok"
 echo "[compiler-gate] 63/67 FrozenArray[T] Send-eligible immutable container (#906)"
 frozenarrdir="_build/_gate_frozen_array"
 rm -rf "$frozenarrdir"; mkdir -p "$frozenarrdir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/region_ok_frozen_array_basic.vibe > "$frozenarrdir/basic.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$frozenarrdir/basic.vibe" "$frozenarrdir/basic.wasm" _start >/dev/null 2>&1 || true
+  fixtures/region_ok_frozen_array_basic.vibe "$frozenarrdir/basic.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$frozenarrdir/basic.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_frozen_array_basic.vibe did not compile" >&2
   cat "$frozenarrdir/basic.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-frozenarr_basic_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/basic.wasm" 2>/dev/null | tail -1)"
-if [ "$frozenarr_basic_out" != "42" ]; then
+if ! frozenarr_basic_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/basic.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: region_ok_frozen_array_basic.vibe got '$frozenarr_basic_out' (want 42)" >&2
+  echo "$frozenarr_basic_out" >&2
   exit 1
 fi
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/send_bound_frozen_array.vibe > "$frozenarrdir/send.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$frozenarrdir/send.vibe" "$frozenarrdir/send.wasm" _start >/dev/null 2>&1 || true
+  fixtures/send_bound_frozen_array.vibe "$frozenarrdir/send.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$frozenarrdir/send.wasm" ]; then
   echo "[compiler-gate] FAIL: send_bound_frozen_array.vibe did not compile -- FrozenArray[Int] Send acceptance regressed" >&2
   cat "$frozenarrdir/send.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-frozenarr_send_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/send.wasm" 2>/dev/null | tail -1)"
-if [ "$frozenarr_send_out" != "42" ]; then
+if ! frozenarr_send_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/send.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: send_bound_frozen_array.vibe got '$frozenarr_send_out' (want 42)" >&2
+  echo "$frozenarr_send_out" >&2
   exit 1
 fi
 sed '/^__DATA__$/,$d' fixtures/err_type_send_frozen_array_of_array_bound.vibe > "$frozenarrdir/neg.vibe"
@@ -7589,18 +7628,20 @@ if ! grep -qF 'no impl `Send` for `FrozenArray[Array[Int]]`' "$frozenarrdir/neg.
   cat "$frozenarrdir/neg.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/region_ok_frozen_array_taskgroup_capture.vibe > "$frozenarrdir/capture.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$frozenarrdir/capture.vibe" "$frozenarrdir/capture.wasm" _start >/dev/null 2>&1 || true
+  fixtures/region_ok_frozen_array_taskgroup_capture.vibe "$frozenarrdir/capture.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$frozenarrdir/capture.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_frozen_array_taskgroup_capture.vibe did not compile -- FrozenArray Spawnable capture regressed" >&2
   cat "$frozenarrdir/capture.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-frozenarr_capture_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/capture.wasm" 2>/dev/null | tail -1)"
-if [ "$frozenarr_capture_out" != "40" ]; then
+if ! frozenarr_capture_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/capture.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: region_ok_frozen_array_taskgroup_capture.vibe got '$frozenarr_capture_out' (want 40)" >&2
+  echo "$frozenarr_capture_out" >&2
   exit 1
 fi
 rm -rf "$frozenarrdir"
@@ -8215,18 +8256,21 @@ echo "[compiler-gate] cross-module diagnostic collection ok (1 fail-fast, 2 coll
 echo "[compiler-gate] 75/75 ADR-0090 region + MutList vertical slice (#1262)"
 r90dir="_build/_gate_region90"
 rm -rf "$r90dir"; mkdir -p "$r90dir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/region_arena_ok.vibe > "$r90dir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$r90dir/pos.vibe" "$r90dir/pos.wasm" _start >/dev/null 2>&1 || true
+  fixtures/region_arena_ok.vibe "$r90dir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_arena_ok.vibe did not compile -- ADR-0090 region/MutList slice regressed" >&2
   cat "$r90dir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-r90_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/pos.wasm" 2>/dev/null | tail -1)"
-if [ "$r90_pos_out" != "42" ]; then
+if ! r90_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: region_arena_ok.vibe got '$r90_pos_out' (want 42)" >&2
+  echo "$r90_pos_out" >&2
   exit 1
 fi
 cp fixtures/err_region_escape_return_value.vibe "$r90dir/neg.vibe"
@@ -8274,18 +8318,21 @@ echo "[compiler-gate] ADR-0090 region + MutList vertical slice ok"
 echo "[compiler-gate] 76/76 ADR-0091 @zero_alloc allocation check (#1262)"
 za91dir="_build/_gate_zero_alloc91"
 rm -rf "$za91dir"; mkdir -p "$za91dir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/zero_alloc_ok.vibe > "$za91dir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$za91dir/pos.vibe" "$za91dir/pos.wasm" _start >/dev/null 2>&1 || true
+  fixtures/zero_alloc_ok.vibe "$za91dir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$za91dir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: zero_alloc_ok.vibe did not compile -- ADR-0091 @zero_alloc slice regressed" >&2
   cat "$za91dir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-za91_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$za91dir/pos.wasm" 2>/dev/null | tail -1)"
-if [ "$za91_pos_out" != "42" ]; then
+if ! za91_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$za91dir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: zero_alloc_ok.vibe got '$za91_pos_out' (want 42)" >&2
+  echo "$za91_pos_out" >&2
   exit 1
 fi
 cp fixtures/err_zero_alloc_ctor.vibe "$za91dir/neg.vibe"
@@ -8616,18 +8663,20 @@ echo "[compiler-gate] generic effect instantiation ok"
 echo "[compiler-gate] 80/80 operation-level rows authorize builtin calls (ADR-0071/#1343)"
 opb="_build/_gate_1343_op_rows"
 rm -rf "$opb"; mkdir -p "$opb"
-sed '/^__DATA__$/,$d' fixtures/effect_builtin_operation_row.vibe > "$opb/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$opb/pos.vibe" "$opb/pos.wasm" main >/dev/null 2>&1
+  fixtures/effect_builtin_operation_row.vibe "$opb/pos.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$opb/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: with Fs::read_file no longer authorizes the Fs::read_file builtin (#1343)" >&2
   cat "$opb/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-op_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$opb/pos.wasm" 2>&1 | tail -1)"
-if [ "$op_out" != "42" ]; then
+if ! op_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$opb/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_builtin_operation_row got '$op_out' (want 42)" >&2
+  echo "$op_out" >&2
   exit 1
 fi
 cat > "$opb/neg.vibe" <<'EOF'
@@ -8683,18 +8732,20 @@ echo "[compiler-gate] operation-level builtin rows ok"
 echo "[compiler-gate] 81/81 async for-loop requires the Async row (#1358)"
 afdir="_build/_gate_1358"
 rm -rf "$afdir"; mkdir -p "$afdir"
-sed '/^__DATA__$/,$d' fixtures/effect_async_for_row.vibe > "$afdir/pos.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block declaring the entry's own row, #1508), so this compiles it AS-IS --
+# no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$afdir/pos.vibe" "$afdir/pos.wasm" main >/dev/null 2>&1
+  fixtures/effect_async_for_row.vibe "$afdir/pos.wasm" __no_entry__ >/dev/null 2>&1
 if [ ! -s "$afdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_async_for_row.vibe did not compile -- a declared `with Async` row must still accept the async for loop (#1358)" >&2
   cat "$afdir/pos.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-af_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$afdir/pos.wasm" 2>&1 | tail -1)"
-if [ "$af_out" != "42" ]; then
+if ! af_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$afdir/pos.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: effect_async_for_row got '$af_out' (want 42) -- the await lowering of the async for loop regressed" >&2
+  echo "$af_out" >&2
   exit 1
 fi
 sed '/^__DATA__$/,$d' fixtures/err_async_for_undeclared.vibe > "$afdir/neg.vibe"
@@ -9114,18 +9165,21 @@ echo "[compiler-gate] 86/86 string interpolation renders derive(Show) structural
 # fixes one spelling and breaks the other cannot pass.
 showdir="_build/_gate_interp_show"
 rm -rf "$showdir"; mkdir -p "$showdir"
-sed '/^_start()$/d; /^__DATA__$/,$d' fixtures/interp_show_derive.vibe > "$showdir/show.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. A mismatch prints inspect's own
+# actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$showdir/show.vibe" "$showdir/show.wasm" _start >/dev/null 2>&1 || true
+  fixtures/interp_show_derive.vibe "$showdir/show.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$showdir/show.wasm" ]; then
   echo "[compiler-gate] FAIL: interp_show_derive.vibe did not compile (#1392)" >&2
   cat "$showdir/show.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-show_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$showdir/show.wasm" 2>/dev/null | tail -1)"
-if [ "$show_out" != "1111111111111111111" ]; then
+if ! show_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$showdir/show.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: interpolation rendering got '$show_out' (want 1111111111111111111) (#1392)" >&2
+  echo "$show_out" >&2
   exit 1
 fi
 rm -rf "$showdir"

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4730,10 +4730,12 @@ echo "[compiler-gate] effectset row expansion ok"
 echo "[compiler-gate] 40o/40 effectset cycle + operation-collision detection (ADR-0071 step 2/#755)"
 a71cdir="_build/_gate_effectset_resolver"
 rm -rf "$a71cdir"; mkdir -p "$a71cdir"
-sed '/^__DATA__$/,$d' fixtures/err_effectset_cycle.vibe > "$a71cdir/cycle.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$a71cdir/cycle.vibe" "$a71cdir/cycle.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_effectset_cycle.vibe "$a71cdir/cycle.wasm" main >/dev/null 2>&1 || true
 if [ -s "$a71cdir/cycle.wasm" ]; then
   echo "[compiler-gate] FAIL: err_effectset_cycle.vibe compiled successfully -- circular effectset references must be rejected" >&2
   exit 1
@@ -4743,10 +4745,12 @@ if ! grep -q "effectset cycle: A -> B -> A" "$a71cdir/cycle.wasm.diag" 2>/dev/nu
   cat "$a71cdir/cycle.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_effectset_operation_collision.vibe > "$a71cdir/collision.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$a71cdir/collision.vibe" "$a71cdir/collision.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_effectset_operation_collision.vibe "$a71cdir/collision.wasm" main >/dev/null 2>&1 || true
 if [ -s "$a71cdir/collision.wasm" ]; then
   echo "[compiler-gate] FAIL: err_effectset_operation_collision.vibe compiled successfully -- an effectset colliding with an operation name must be rejected" >&2
   exit 1
@@ -6302,11 +6306,13 @@ echo "[compiler-gate] opt-in checked-Error row discipline ok (#944 stage A)"
 echo "[compiler-gate] 44c/44 entry-boundary Error handler (#944 stage C)"
 g944cdir="_build/_gate_944c"
 rm -rf "$g944cdir"; mkdir -p "$g944cdir"
-sed '/^__DATA__$/,$d' fixtures/entry_error_boundary.vibe > "$g944cdir/src.vibe"
+# #1571: the entry-boundary behaviour (stderr diagnostic + entry value) is
+# asserted below, so the fixture carries no `__DATA__` tail any more and is
+# compiled AS-IS -- no `sed` strip, no temp copy.
 rm -f "$g944cdir/out.wasm"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g944cdir/src.vibe" "$g944cdir/out.wasm" main >/dev/null 2>&1 || true
+  fixtures/entry_error_boundary.vibe "$g944cdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$g944cdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: entry_error_boundary.vibe did not compile (#944 stage C)" >&2
   cat "$g944cdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -6340,10 +6346,9 @@ fi
 #     what it printed before either fix. This is the additivity check: the
 #     overwhelmingly common case must not have moved.
 rm -f "$g944cdir/typed.wasm" "$g944cdir/typed_stderr.txt"
-sed '/^__DATA__$/,$d' fixtures/err_entry_boundary_typed_payload.vibe > "$g944cdir/typed.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g944cdir/typed.vibe" "$g944cdir/typed.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_entry_boundary_typed_payload.vibe "$g944cdir/typed.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$g944cdir/typed.wasm" ]; then
   echo "[compiler-gate] FAIL: err_entry_boundary_typed_payload.vibe did not compile (#1372 review)" >&2
   cat "$g944cdir/typed.wasm.diag" 2>/dev/null >&2 || true
@@ -6362,10 +6367,9 @@ fi
 # #1374 additivity: a String payload must print verbatim, exactly as it did
 # before the kind channel existed.
 rm -f "$g944cdir/strp.wasm" "$g944cdir/strp_stderr.txt"
-sed '/^__DATA__$/,$d' fixtures/err_entry_boundary_string_payload.vibe > "$g944cdir/strp.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g944cdir/strp.vibe" "$g944cdir/strp.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_entry_boundary_string_payload.vibe "$g944cdir/strp.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$g944cdir/strp.wasm" ]; then
   echo "[compiler-gate] FAIL: err_entry_boundary_string_payload.vibe did not compile (#1374)" >&2
   cat "$g944cdir/strp.wasm.diag" 2>/dev/null >&2 || true
@@ -6393,18 +6397,23 @@ echo "[compiler-gate] entry-boundary Error handler ok (#944 stage C, typed paylo
 echo "[compiler-gate] 44d/44 with-Error non-tail throw abort (#1087)"
 g1087dir="_build/_gate_1087"
 rm -rf "$g1087dir"; mkdir -p "$g1087dir"
-sed '/^__DATA__$/,$d' fixtures/effect_handle_error_nontail.vibe > "$g1087dir/src.vibe"
+# #1571: the expected value lives in the fixture now (an `inspect` test
+# block), so this compiles it AS-IS -- no `__DATA__` strip, no temp copy,
+# and no expected value in shell. Entry is `__no_entry__`, which synthesizes
+# the test-block runner; a mismatch prints inspect's own actual/expected
+# (1 vs 41) from inside the run and fails it.
 rm -f "$g1087dir/out.wasm"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g1087dir/src.vibe" "$g1087dir/out.wasm" main >/dev/null 2>&1 || true
+  fixtures/effect_handle_error_nontail.vibe "$g1087dir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$g1087dir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_error_nontail.vibe did not compile (#1087)" >&2
+  cat "$g1087dir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-g1087_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$g1087dir/out.wasm" 2>/dev/null | tail -1)"
-if [ "$g1087_out" != "1" ]; then
-  echo "[compiler-gate] FAIL: effect_handle_error_nontail got '$g1087_out' (want 1, NOT 41) -- a non-tail throw in a with-Error handle body ran the body's continuation instead of aborting to the arm's value (#1087; check idp_arms_discharge_error in inline_direct_perform.vibe)" >&2
+if ! g1087_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g1087dir/out.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: effect_handle_error_nontail want 1, NOT 41 -- a non-tail throw in a with-Error handle body ran the body's continuation instead of aborting to the arm's value (#1087; check idp_arms_discharge_error in inline_direct_perform.vibe)" >&2
+  echo "$g1087_out" >&2
   exit 1
 fi
 rm -rf "$g1087dir"
@@ -6634,12 +6643,14 @@ if ! send_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_hos
   echo "$send_pos_out" >&2
   exit 1
 fi
+# #1571: the expectation for each rejection is `$needle` right here, so these
+# fixtures no longer carry an unread `__DATA__` error_contains copy and are
+# compiled AS-IS -- no `sed` strip, no temp copy.
 send_check_reject() {
   local fixture="$1" needle="$2" tag="$3"
-  sed '/^__DATA__$/,$d' "fixtures/$fixture" > "$senddir/$tag.vibe"
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "$senddir/$tag.vibe" "$senddir/$tag.wasm" main >/dev/null 2>&1 || true
+    "fixtures/$fixture" "$senddir/$tag.wasm" main >/dev/null 2>&1 || true
   if [ -s "$senddir/$tag.wasm" ]; then
     echo "[compiler-gate] FAIL: $fixture compiled successfully -- must be rejected" >&2
     exit 1
@@ -7355,10 +7366,12 @@ if ! region_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_h
   echo "$region_pos_out" >&2
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_region_escape_return.vibe > "$regiondir/neg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$regiondir/neg.vibe" "$regiondir/neg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_region_escape_return.vibe "$regiondir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$regiondir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: err_region_escape_return.vibe compiled successfully -- must be rejected" >&2
   exit 1
@@ -7426,10 +7439,12 @@ if ! spawnable_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vib
   echo "$spawnable_pos_out" >&2
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_spawnable_capture_array.vibe > "$spawnabledir/neg_array.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$spawnabledir/neg_array.vibe" "$spawnabledir/neg_array.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_spawnable_capture_array.vibe "$spawnabledir/neg_array.wasm" main >/dev/null 2>&1 || true
 if [ -s "$spawnabledir/neg_array.wasm" ]; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_array.vibe compiled successfully -- must be rejected" >&2
   exit 1
@@ -7439,10 +7454,12 @@ if ! grep -qF 'no impl `Spawnable` for `Array[Int]`' "$spawnabledir/neg_array.wa
   cat "$spawnabledir/neg_array.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_spawnable_capture_cross_region.vibe > "$spawnabledir/neg_cross.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$spawnabledir/neg_cross.vibe" "$spawnabledir/neg_cross.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_spawnable_capture_cross_region.vibe "$spawnabledir/neg_cross.wasm" main >/dev/null 2>&1 || true
 if [ -s "$spawnabledir/neg_cross.wasm" ]; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_cross_region.vibe compiled successfully -- must be rejected" >&2
   exit 1
@@ -7452,10 +7469,12 @@ if ! grep -qF 'no impl `Spawnable`' "$spawnabledir/neg_cross.wasm.diag" 2>/dev/n
   cat "$spawnabledir/neg_cross.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_spawnable_capture_letmut.vibe > "$spawnabledir/neg_letmut.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$spawnabledir/neg_letmut.vibe" "$spawnabledir/neg_letmut.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_spawnable_capture_letmut.vibe "$spawnabledir/neg_letmut.wasm" main >/dev/null 2>&1 || true
 if [ -s "$spawnabledir/neg_letmut.wasm" ]; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_letmut.vibe compiled successfully -- must be rejected" >&2
   exit 1
@@ -7465,10 +7484,12 @@ if ! grep -qF "no impl \`Spawnable\` for a \`let mut\` binding" "$spawnabledir/n
   cat "$spawnabledir/neg_letmut.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_spawnable_capture_letmut_outer_scope.vibe > "$spawnabledir/neg_letmut_outer.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$spawnabledir/neg_letmut_outer.vibe" "$spawnabledir/neg_letmut_outer.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_spawnable_capture_letmut_outer_scope.vibe "$spawnabledir/neg_letmut_outer.wasm" main >/dev/null 2>&1 || true
 if [ -s "$spawnabledir/neg_letmut_outer.wasm" ]; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_letmut_outer_scope.vibe compiled successfully -- must be rejected" >&2
   exit 1
@@ -7542,10 +7563,12 @@ if ! taskgroup_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vib
   echo "$taskgroup_pos_out" >&2
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_taskgroup_sugar_region_escape.vibe > "$taskgroupdir/neg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$taskgroupdir/neg.vibe" "$taskgroupdir/neg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_taskgroup_sugar_region_escape.vibe "$taskgroupdir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$taskgroupdir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: err_taskgroup_sugar_region_escape.vibe compiled successfully -- must be rejected" >&2
   exit 1
@@ -7615,10 +7638,12 @@ if ! frozenarr_send_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vi
   echo "$frozenarr_send_out" >&2
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_type_send_frozen_array_of_array_bound.vibe > "$frozenarrdir/neg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$frozenarrdir/neg.vibe" "$frozenarrdir/neg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_type_send_frozen_array_of_array_bound.vibe "$frozenarrdir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$frozenarrdir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: err_type_send_frozen_array_of_array_bound.vibe compiled successfully -- must be rejected" >&2
   exit 1
@@ -8618,10 +8643,12 @@ if ! g1340_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_r
   echo "$g1340_out" >&2
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_generic_effect_perform_arity.vibe > "$g1340dir/arity.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g1340dir/arity.vibe" "$g1340dir/arity.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_generic_effect_perform_arity.vibe "$g1340dir/arity.wasm" main >/dev/null 2>&1 || true
 if [ -s "$g1340dir/arity.wasm" ]; then
   echo "[compiler-gate] FAIL: err_generic_effect_perform_arity.vibe compiled -- the #1218 generic-effect arity hole is back" >&2
   exit 1
@@ -8631,10 +8658,12 @@ if ! grep -q "perform State::Get expects 0 argument(s), got 3" "$g1340dir/arity.
   cat "$g1340dir/arity.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_generic_effect_row_targ.vibe > "$g1340dir/rowtarg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g1340dir/rowtarg.vibe" "$g1340dir/rowtarg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_generic_effect_row_targ.vibe "$g1340dir/rowtarg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$g1340dir/rowtarg.wasm" ]; then
   echo "[compiler-gate] FAIL: err_generic_effect_row_targ.vibe compiled -- a bracketed row item on a non-generic effect must be rejected" >&2
   exit 1
@@ -8748,10 +8777,12 @@ if ! af_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runn
   echo "$af_out" >&2
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_async_for_undeclared.vibe > "$afdir/neg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$afdir/neg.vibe" "$afdir/neg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_async_for_undeclared.vibe "$afdir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$afdir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: err_async_for_undeclared.vibe compiled -- a for loop over a Future-returning iterator must require { Async } (#1358)" >&2
   exit 1
@@ -8857,10 +8888,12 @@ echo "[compiler-gate] async for-loop Async requirement ok"
 echo "[compiler-gate] 82/82 local closure rows leak at the call site (#1361)"
 lcdir="_build/_gate_1361"
 rm -rf "$lcdir"; mkdir -p "$lcdir"
-sed '/^__DATA__$/,$d' fixtures/err_local_closure_effect_leak.vibe > "$lcdir/neg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$lcdir/neg.vibe" "$lcdir/neg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_local_closure_effect_leak.vibe "$lcdir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$lcdir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: err_local_closure_effect_leak.vibe compiled -- a local closure's declared row must leak into its caller (#1361)" >&2
   exit 1
@@ -8921,10 +8954,12 @@ echo "[compiler-gate] local closure row leak ok"
 echo "[compiler-gate] 83/83 a handle that can never fire is rejected (#1347)"
 hsdir="_build/_gate_1347_switch"
 rm -rf "$hsdir"; mkdir -p "$hsdir"
-sed '/^__DATA__$/,$d' fixtures/err_handler_switch_dead_handle.vibe > "$hsdir/neg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$hsdir/neg.vibe" "$hsdir/neg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_handler_switch_dead_handle.vibe "$hsdir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$hsdir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: err_handler_switch_dead_handle.vibe compiled -- the handler-switch no-op is silent again (#1347)" >&2
   exit 1
@@ -9005,10 +9040,12 @@ echo "[compiler-gate] dead-handle rejection ok"
 echo "[compiler-gate] 84/84 higher-order effectful block names the operation (#1347)"
 hodir="_build/_gate_1347_ho"
 rm -rf "$hodir"; mkdir -p "$hodir"
-sed '/^__DATA__$/,$d' fixtures/err_higher_order_effectful_block.vibe > "$hodir/neg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$hodir/neg.vibe" "$hodir/neg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_higher_order_effectful_block.vibe "$hodir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$hodir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: an operation taking an EFFECTFUL block must still be rejected (#1347)" >&2
   exit 1
@@ -9050,10 +9087,12 @@ if ! exc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_run
   echo "$exc_out" >&2
   exit 1
 fi
-sed '/^__DATA__$/,$d' fixtures/err_exception_kind_mismatch.vibe > "$excdir/neg.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$excdir/neg.vibe" "$excdir/neg.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_exception_kind_mismatch.vibe "$excdir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$excdir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: with Exception[ParseError] authorized an IoError throw -- exact-kind rows are not enforced (#1344)" >&2
   exit 1
@@ -9069,10 +9108,12 @@ fi
 # invisible to that (untyped) pass, so the throw fell back to the erased
 # `Error::Throw`, which every exception row authorizes. That exempted exactly
 # the shape #1324's migration produces.
-sed '/^__DATA__$/,$d' fixtures/err_exception_local_binder_kind.vibe > "$excdir/neglocal.vibe"
+# #1571: the expectation for this rejection is the diagnostic grep below,
+# so the fixture no longer carries an unread `__DATA__` error_contains copy
+# and is compiled AS-IS -- no `sed` strip, no temp copy.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$excdir/neglocal.vibe" "$excdir/neglocal.wasm" main >/dev/null 2>&1 || true
+  fixtures/err_exception_local_binder_kind.vibe "$excdir/neglocal.wasm" main >/dev/null 2>&1 || true
 if [ -s "$excdir/neglocal.wasm" ]; then
   echo "[compiler-gate] FAIL: a LOCAL binder's throw payload was not kind-checked (#1344 follow-up)" >&2
   exit 1

--- a/scripts/test_wasi_cli_stdin_provider_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_component_gate.sh
@@ -41,7 +41,22 @@ if [ -z "$COMPILER" ]; then
     fi
   done
   shopt -u nullglob
+  # The CI job that runs this gate (wasi-p3-gate) builds nothing itself: it
+  # downloads compiler-gate's stage2 into _build/ci-artifacts/ and never runs
+  # ensure_seed.sh, so it has NEITHER a generations tree nor a seed. Without
+  # this candidate the search fell through to the seed path, and a path that
+  # does not exist reached the runner as an argument -- surfacing as an ENOENT
+  # stack trace plus a spurious `usage:` line (the runner prints usage for any
+  # pre-instantiation failure), which reads as a broken invocation rather than
+  # a missing compiler.
+  [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/_build/ci-artifacts/stage2.wasm"
   [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
+fi
+if [ ! -f "$COMPILER" ]; then
+  echo "wasi cli stdin provider shadow FAILED: no compiler to generate the shadow component with." >&2
+  echo "  looked for: _build/selfhost/generations/*/stage2.wasm, _build/ci-artifacts/stage2.wasm, bootstrap/seed/compiler.wasm" >&2
+  echo "  set VIBE_STDIN_PROVIDER_GATE_COMPILER=<stage2.wasm> to point at one." >&2
+  exit 1
 fi
 HARNESS="$OUT_DIR/dump.vibex"
 HARNESS_WASM="$OUT_DIR/dump.wasm"

--- a/scripts/test_wasi_cli_stdin_provider_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_component_gate.sh
@@ -73,9 +73,25 @@ fn main() -> Unit with Exception + Fs {
 }
 EOF
 rm -f "$HARNESS_WASM" "$HARNESS_WASM.diag" "$COMPONENT"
-VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+# The CLI writes compile diagnostics to a `<output>.diag` SIDECAR, not to
+# stdout/stderr (#1567), so a failed compile here exits non-zero having printed
+# nothing at all -- under `set -e` that surfaced as a bare
+# "Process completed with exit code 1" with no cause anywhere in the CI log.
+# Echo the sidecar before giving up.
+if ! VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
-  "$COMPILER" "$HARNESS" "$HARNESS_WASM" main >/dev/null
+  "$COMPILER" "$HARNESS" "$HARNESS_WASM" main >/dev/null; then
+  echo "wasi cli stdin provider shadow FAILED: could not compile the generator harness with $COMPILER" >&2
+  if [ -s "$HARNESS_WASM.diag" ]; then
+    # The sidecar has no trailing newline, so give it one rather than letting
+    # it run into whatever the log prints next.
+    cat "$HARNESS_WASM.diag" >&2
+    echo >&2
+  else
+    echo "  (no .diag sidecar was written)" >&2
+  fi
+  exit 1
+fi
 VIBE_PREOPEN_DIR="$PROJECT_ROOT" \
   bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke main "$HARNESS_WASM" >/dev/null
 


### PR DESCRIPTION
#1621 は Codex review が着く前に merge されたので、**指摘をここで直す**。どれも「黙って誤る」側の実バグだった。併せて perf gate が出した実測の退行を直し、`__DATA__` fixture の移行を進めて `compiler_gate.sh` から `sed '/^__DATA__$/,$d'` を **74 → 0 site** で全廃した。ついでに main で赤かった `wasi-p3-gate` も直している (最後の節)。

## Codex P1 (実バグ): 一時変数が capture していた

`__vibe_inspect_actual` という固定名で let 束縛していたので、`content` 側が同名の束縛を参照していると新しい束縛の下に取り込まれる:

```vibe
let __vibe_inspect_actual = "wrong"
inspect(1, __vibe_inspect_actual)   // 1 != "wrong" なのに黙って通っていた
```

`dinsp_fresh_name` が**両引数への出現検査**で fresh な名前を mint するようにした (#1607 の seq-float α-rename と同じやり方)。global counter ではなく出現検査なのは、展開が入力の純関数のままである = pass が冪等であるため。

## Codex P2 (実バグ): user 定義の `inspect` を乗っ取っていた

callee の綴りだけで書き換えていたので、自前の `inspect(v, c)` は本体が実行されずスナップショット assertion に化けていた。**`inspect` という名前を束縛しているファイルでは rewrite ごと降りる**ようにした (import・宣言・local binder・lambda param のいずれでも)。scope 厳密ではなくファイル単位なのは、降りる方向にしか外さない保守的な判定だから。

副作用として `@vibe/core` の `inspect` 本体が**再び生きる**: assert.vibe はその名前を束縛しているので降りるし、`import @vibe/core { inspect }` も従来どおりそれを呼ぶ。#1621 で書いた「本体はもう実行されない」という注記は偽になったので書き直した。

## Codex P1 (2 件目・実バグ): pattern が束縛する `inspect` が guard を抜けていた

上の guard は**式の位置に綴られた束縛しか見ていなかった**ので、destructuring や match arm が導入した `inspect` では guard が false のままになり、rewrite がユーザ自身の呼び出しを置き換えていた:

```vibe
enum Box { B((Int, String) -> Unit) }
fn shout(v: Int, c: String) -> Unit { println(c) }
fn main() -> Int {
  match B(shout) {
    B(inspect) => { inspect(1, "SIDE EFFECT RAN"); 7 }
  }
}
```

修正前は `shout` が走らず `inspect mismatch` で trap していた。`dinsp_pat_binds` を足して `Pat` を走査し、`SLetPat` の pattern と match / handle の arm pattern を guard に入れた。

### gate step 99 を追加した

`inspect` は関数ではなく rewrite なので、壊れ方が 2 つともサイレントで、しかもどちらも gate ではなく review で見つかっている (乗っ取りは 2 回)。3 ケースを固定し、回帰時にそれぞれ別の落ち方をするようにした — hygiene (`inspect(1, __vibe_inspect_actual)` が**落ちる**こと) / shadow-式 (ユーザ宣言の `inspect` が 7 を返す) / shadow-pattern (match arm が束縛した `inspect` の副作用が実際に走る)。

## perf gate の実測退行を 2 度直した

1. **`+1.34%`** — `dinsp_children` は訪れたノードを全て作り直すので、`inspect` を含まないファイルでも AST 全体のコピーを確保していた。読むだけの事前判定を入れ、必要な statement だけ作り直すようにした。
2. **`+2.61%`** — その事前判定自体が `expr_children` で再帰しており、`expr_children` は**ノードごとに配列を確保する**ので、避けたはずの確保を増やしていた。3 つの走査を `dinsp_scan(expr, mode, name)` 1 本にまとめ、`Expr` の variant を手で列挙する確保しない走査に置き換えた。再帰する形に `_ =>` を置いていないので、variant が増えたときは「黙って走査されない部分木」ではなくコンパイルエラーになる。

| stage2 (同一機・同一入力) | `selfcompile heap_ptr_bytes` |
|---|---:|
| `expr_children` 版 | 975,825,480 |
| 本 PR | 941,712,352 |

CI の perf report でも main 比 **-0.75%**。deterministic 軸のその他 (B/op・sample wasm サイズ) は全て ±0。

## 移行: `sed` 74 → 0 site

期待値をシェルの比較から fixture の中へ移し、gate は fixture を**そのままコンパイル**して (`__no_entry__`) `_start` の exit status だけを見る形にした。不一致時は `inspect` の actual/expected がそのまま出る。

**第 1 バッチ (29 site)**: value 比較を持つ機械的な形。

**第 2 バッチ (21 site)**:

- **row-free 12 件** — `let _start = () -> Int` → `export let main` + `test { inspect(main(), "V") }`: trait_bound_ufcs_method (97097), send_bound_structural, rc_branch_loop_mixed_consume_test (123123), rc_match_payload_closure_capture_test (38013), rc_local_container_element_escape (345), region_ok_frozen_array_basic, send_bound_frozen_array, region_arena_ok, zero_alloc_ok, interp_show_derive (1111111111111111111), effect_vacuous_handle_erased (46), closure_shadowed_inline_builtin (28)
- **effect row 持ち 9 件** — test ブロックが entry と同じ row を宣言する形 (`test "..." with Exception|Async|Fs`, #1508): region_ok_basic, region_ok_spawnable_capture, region_ok_spawnable_capture_shadowed_letmut, region_ok_taskgroup_sugar, region_ok_frozen_array_taskgroup_capture (40), async_await_multi (50), async_future_pending, effect_builtin_operation_row, effect_async_for_row

このうち後ろ 2 件 (`with Fs` / `with Async`) は第 1 バッチが「#1508 で effect を持つ test ブロックが書けない」として除外していたもの。**#1508 は着地済みで書ける**ことを実測で確認したので、その除外注記は解消した。

**第 3 バッチ (22 site) — 残り全部**:

- **値を比べる 1 site** (`effect_handle_error_nontail.vibe`) は `test { inspect(main(), "1") }` へ
- **拒否を確かめる 21 site** は、`err_*` fixture の `__DATA__` が持っていた `error_contains` を**読む生きた consumer がいない**ことを確認した上で落とした (`generate_runtime_fixture_tests.mjs` は `error_contains` のある fixture を除外する側で、しかもどのゲートからも呼ばれていない)。実際に効いている期待値は gate が診断に張っている grep のほうで、23 件すべて同じ文字列が gate 側にあることを照合済み。fixture は `fixtures/` から直接コンパイルされるようになり、一時コピーも消えた
- `err_entry_boundary_typed_payload` / `_string_payload` の 2 site はそもそも `__DATA__` を持っておらず、`sed` が no-op のコピーだった

エントリ境界 (`entry_error_boundary.vibe`) は「stderr 診断 + entry 値 1」が性質そのものなので inspect では表せない。`__DATA__` を落として gate 側の assertion を正とした。

`.diag` 側は issue が言うとおり #1567 が先で、手つかず。fixture 側に残る 477 ファイルの `__DATA__` も「一括変換しない」方針どおり触っていない。

### pin が空振りでないことの確認

移行後の緑は「test ブロックが実行されていない」でも成立しうるので、形ごとに**期待値を壊した対照実験**を行い、全て `inspect mismatch` + 非ゼロ終了になることを確認した (row-free / Exception row / Async row / Fs row / `tr -dc` を使っていた UFCS 形 / 多倍長値の interp_show_derive / 第 3 バッチの effect_handle_error_nontail)。

### 途中で踏んで直したもの

- 入出力の stem が違うレーン (`src.vibe` → `out.wasm`) で一括置換が当たらず、作られなくなった temp を指したまま残っていた (closure_shadowed_inline_builtin が「コンパイルできない」で落ちた)。全レーンについて temp 参照が同じ script 内で生成されているかを走査して 0 件を確認
- FAIL メッセージ内の元 `exit 1` が残って診断 echo が dead code になっていた 12 箇所を除去
- `--invoke _start` を使わず既定 start を走らせていた 2 レーンが空文字比較になっていたので同じ形へ揃えた
- #1621 で `desugar_labeled_args` から離れてしまっていた doc comment をその宣言の上へ戻した (残っていた `///|` は落とした)

## おまけ: main の `wasi-p3-gate` の赤も直した

この PR を出した時点で `wasi-p3-gate` は **main で既に赤**だった (#1623 のマージ `e92f4a3b` 以降。1 つ前の main `9ddb78b` は green)。required check ではないが main が赤のままなので、ここで直した。**原因は 2 つあった**。

**1. phase C にコンパイラが渡っていなかった (`4c68b72`)**

#1623 が足した `test_wasi_cli_stdin_provider_component_gate.sh` は shadow component を生成するのに compiler wasm が要るが、探し先が `_build/selfhost/generations/*/stage2.wasm` と `bootstrap/seed/compiler.wasm` の 2 つだけだった。ところが `wasi-p3-gate` job は**自分では何もビルドしない** — compiler-gate の stage2 を `_build/ci-artifacts/` に download するだけで `ensure_seed.sh` も走らせない。結果、探索は存在しない seed のパスに落ち、それがそのまま runner の引数になっていた。

ログが原因を隠していたのも効いた。runner は instantiate 前の失敗をすべて引数エラーとみなして `usage:` を出すので、`usage: node scripts/wasm_vibe_host_runner.js ...` + `ENOENT: ... bootstrap/seed/compiler.wasm` という、「呼び出しが壊れている」ようにしか読めない出力になっていた。

→ 他の 2 phase と同じ綴りで `VIBE_STDIN_PROVIDER_GATE_COMPILER` を渡し、script 側の fallback にも `_build/ci-artifacts/stage2.wasm` を足した。どれも無いときは**存在しないパスを引数として渡さず**、探した場所と env var 名を並べて exit 1 する。

**2. 生成物が用意されていなかった (`38a15c3`)**

1 を直すと今度は**出力ゼロのまま exit 1** になった。phase C の harness は phases A/B と違って `@vibe/compiler/...` を **import する**。そのパッケージ closure には gitignore された 5 つの生成物が含まれるが、この job は `ensure_generated.sh` も走らせないので

```
lib/@vibe/compiler/cache/index.vpkg: contract violation:
  contract declaration 'codegen_fingerprint' has no implementation
```

で落ちる (ローカルで 5 つを退避して再現・確認した)。phases A/B が通っていたのは、あちらがコンパイラを黒箱として plain な `.vibe` に回すだけで `@vibe/compiler/...` を import しないから。

**なぜ原因がログに出なかったか**: CLI は診断を stdout/stderr ではなく `<output>.diag` **サイドカー**に書く (#1567)。script は stdout を `/dev/null` に捨てたうえ `set -e` で即死するので、実際のメッセージがどこにも残らなかった。

→ seed + 生成物の step (cache 込み、他 job と同じ形) を `wasi-p3-gate` に足し、script は harness のコンパイルが失敗したら **`.diag` を読み上げてから** exit するようにした。

結果、phase C は skip ではなく**実測で**通っている: `generated component validate/WIT/prefix/structure OK` / `drain: 42` / `early-close: 43` / 期待 trap 4 件 / probe gate `drain 42`・`drop 43`。

## ゲート

`bash scripts/compiler_gate.sh` 99/99、`scripts/unit_test_runner.sh` 545/545、`scripts/check_vibe_fmt.sh` 923 files (0 violations) すべて green。CI も 18 job すべて green (`wasi-p3-gate` 含む)。

> `pkf run test` はこの環境では `sort` の glibc ABI 不一致で clean tree でも同じ位置で落ちるため (本 PR とは無関係)、内容にあたる `compiler_gate.sh` を直接流して確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_