### PR TITLE
compiler: add stdin provider lifecycle shadow adapter

### DIFF
--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1604,10 +1604,11 @@ Load-bearing invariants for stages 1--3:
 
 This is only the successful-close lifecycle slice. **Read-error injection is
 unmeasured** (`io`, `illegal-byte-sequence`, and `pipe` have no claimed runtime
-measurement). The forced completion-tag expected-trap scenario is a control of
-the cleanup/fail-closed branch, not a measurement of a provider-generated
-error, and this work makes no runtime, console, or public compiler-routing
-change.
+measurement). The forced completion-tag, wrong-byte, and extra-byte
+expected-trap scenarios are controls of cleanup/fail-closed branches, not
+measurements of provider-generated errors. Each byte-mismatch control settles
+and drops both owned ends through the shared close path before trapping. This
+work makes no runtime, console, or public compiler-routing change.
 
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1469,7 +1469,7 @@ gate lane = `test_named_hoststreams_component_gate.sh` の close lane
 かつ drain-only component に close import が無いこと + closing component に
 guest import と adapter export が両方あることを .wat で確認）。
 
-### 3.18.3 #1539 — `wasi:cli/stdin@0.3.0` lifecycle measurement and provider prerequisite (design only)
+### 3.18.3 #1539 — `wasi:cli/stdin@0.3.0` lifecycle measurement and shadow provider prerequisite
 
 `tools/wasip3_component_probe/stdin_read_via_stream/component.wat` retains the
 ratified `wasi:cli/stdin@0.3.0` result type
@@ -1489,8 +1489,9 @@ dropped. Other statuses, events, byte values, EOF forms, and result tags are
 diagnostic return paths, not success.
 
 `bash scripts/test_wasi_cli_stdin_p3_probe_gate.sh` is the merged executable
-probe/gate for this measurement; phase C of
-`scripts/test_wasi_p3_guarantee_gate.sh` (`pkf run test-wasi-p3`) invokes it.
+probe/gate for this measurement. The generated shadow is validated by
+`bash scripts/test_wasi_cli_stdin_provider_component_gate.sh`; phase C of
+`scripts/test_wasi_p3_guarantee_gate.sh` (`pkf run test-wasi-p3`) invokes both.
 It parses, validates, and prints the component, generates deterministic binary
 input, and executes both async-lifted lanes. Required mode requires exactly
 wasmtime 47.0.2; missing tools, an unpinned provider, and
@@ -1521,7 +1522,7 @@ does **not** by itself complete the stdin lifecycle: the completion future must
 still be read, its result checked, and then released. This corrects the stale
 short-hand that described stream drop alone as a completed stdin close.
 
-#### Required provider-aware contract (not implemented)
+#### Provider-aware contract (implemented only as a production-unused shadow)
 
 The #1539 prerequisite is a distinct, opaque provider-aware handle whose
 adapter state retains both owned ends from `read-via-stream`:
@@ -1557,8 +1558,14 @@ future or silently report a failed lifecycle as a successful close.
 
 #### Staged prerequisite and invariants
 
-No compiler, runtime, or console change is claimed by this section. An
-implementation may start only after these stages are satisfied:
+Stages 1--3 are implemented only by the production-unused shadow emitter
+`comp_emit_component_wasm_stdin_provider_shadow` and its private component
+scenarios. It is intentionally not routed by `linked_compile`, checker,
+runtime, console, `stdin_stream`, generic HostStream, or any public API.
+Stage 4 therefore remains undecided. The shadow is structural/runtime gate
+evidence for the internal prerequisite, not a claim that Vibe programs can
+consume stdin through it:
+
 
 1. **ABI boundary:** introduce a provider-specific lowering/adapter route for
    synchronous `read-via-stream` acquisition. Keep it distinct from
@@ -1597,7 +1604,10 @@ Load-bearing invariants for stages 1--3:
 
 This is only the successful-close lifecycle slice. **Read-error injection is
 unmeasured** (`io`, `illegal-byte-sequence`, and `pipe` have no claimed runtime
-measurement), and this work makes no compiler or console change.
+measurement). The forced completion-tag expected-trap scenario is a control of
+the cleanup/fail-closed branch, not a measurement of a provider-generated
+error, and this work makes no runtime, console, or public compiler-routing
+change.
 
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 
@@ -1771,7 +1781,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 |---|---|---|
 | **suspend lowering の適格性** (#1536) | row-variable callee と literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow、eager `await(Stream::next(s))` retarget、sequence-HEAD let 連鎖の float (`for` 駆動 terminal) は済み (§2.2 末尾) | — (ADR-0076 本体) |
 | **AsyncIter への一本化** (#1538) | eager `Stream[T]` combinator の退役 / AsyncIter 上への再実装。`Stream::next` protocol と host stream read の接続 | 上の適格性 |
-| **stdin provider / `ByteStream` の p3 接続** (#1539) | **未実装の前提契約**: ratified `read-via-stream` の stream + completion future を opaque provider handle に保持し、EOF/early close を Async settlement する (§3.18.3)。既存 `stdin_stream(chunk_size)` は変更しない | merged stdin lifecycle probe/gate (§3.18.3); generic `[3, handle]` `HostStream` は使えない |
+| **stdin provider / `ByteStream` の p3 接続** (#1539) | **shadow 前提のみ実装**: production-unused emitter が ratified `read-via-stream` の stream + completion future を opaque provider handle に保持し、EOF/early close を Async settlement する (§3.18.3)。public routing と既存 `stdin_stream(chunk_size)` は未変更 | generated shadow + merged stdin lifecycle probe/gate (§3.18.3); generic `[3, handle]` `HostStream` は使えない |
 | **実 provider = `wasi:http` incoming-body** (#1540) | serve composition と host-stream composition の統合が要る (§3.19 に構造的な理由と 3 点の分解) | — |
 | **M-conc-2: 真の subtask spawn** (#1537) | waitable-set / `future.cancel-*` による実並行・キャンセル。ADR-0068 の nursery を backend へ落とす | ADR-0076 CPS/suspend lowering |
 | **M1b-3c-1c: interleaving spawn の emitter** (#1537) | ABI 側の問いは §3.11 で解決済み (`waitable-set.wait` の完了順ディスパッチだけで足りる)。残るのは await をまたぐ task 状態の表現 = ADR-0076 の CPS/suspend lowering | 同上 |

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -3011,9 +3011,9 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
     127
   ])
   bytebuf_push_section(out, 1, tc)
-  // Canonical imports 0..8, four scenario task-return imports 9..12, memory.
+  // Canonical imports 0..8, six scenario task-return imports 9..14, memory.
   let ic = bytebuf_new()
-  bytebuf_push_vec_header(ic, 14)
+  bytebuf_push_vec_header(ic, 16)
   let import_modules = [
     "$root",
     "$root",
@@ -3024,6 +3024,8 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
     "$root",
     "$root",
     "$root",
+    "[export]$root",
+    "[export]$root",
     "[export]$root",
     "[export]$root",
     "[export]$root",
@@ -3042,7 +3044,9 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
     "[task-return]drain",
     "[task-return]early-close",
     "[task-return]forced-completion-tag-control",
-    "[task-return]foreign-provider-control"
+    "[task-return]foreign-provider-control",
+    "[task-return]wrong-byte-cleanup-control",
+    "[task-return]extra-byte-cleanup-control"
   ]
   let import_types = [
     0,
@@ -3057,10 +3061,12 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
     0,
     0,
     0,
+    0,
+    0,
     0
   ]
   let mut ii = 0
-  while ii < 13 {
+  while ii < 15 {
     emit_name(ic, Array::get(import_modules, ii))
     emit_name(ic, Array::get(import_names, ii))
     bytebuf_push(ic, 0)
@@ -3073,7 +3079,7 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   bytebuf_push(ic, 0)
   leb128_encode_u32(ic, 1)
   bytebuf_push_section(out, 2, ic)
-  // locals 13..18 are decode/acquire/fail/settle/read/close; 19..22 scenarios.
+  // locals 15..20 are decode/acquire/fail/settle/read/close; 21..26 scenarios.
   emit_function_section(out, [
     5,
     3,
@@ -3081,6 +3087,8 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
     7,
     5,
     5,
+    6,
+    6,
     6,
     6,
     6,
@@ -3096,10 +3104,10 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
     "drain",
     "early-close",
     "forced-completion-tag-control",
-    "foreign-provider-control"
+    "foreign-provider-control",
+    "wrong-byte-cleanup-control",
+    "extra-byte-cleanup-control"
   ], [
-    13,
-    14,
     15,
     16,
     17,
@@ -3107,10 +3115,14 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
     19,
     20,
     21,
-    22
+    22,
+    23,
+    24,
+    25,
+    26
   ])
   let code_sec = bytebuf_new()
-  leb128_encode_u32(code_sec, 10)
+  leb128_encode_u32(code_sec, 12)
   // decode(id) -> record address. Prefix, capacity, record tag and published
   // phase are checked before a caller can reach any canonical operation.
   let decode = bytebuf_new()
@@ -3379,7 +3391,7 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   leb128_encode_u32(read, 5)
   bytebuf_push(read, 127)
   emit_local_get(read, 0)
-  emit_call(read, 13)
+  emit_call(read, 15)
   emit_local_set(read, 1)
   emit_local_get(read, 1)
   emit_i32_load(read, 2, 0)
@@ -3435,7 +3447,7 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   emit_i32_ne(read)
   emit_if_void(read)
   emit_local_get(read, 1)
-  emit_call(read, 15)
+  emit_call(read, 17)
   emit_end(read)
   emit_local_get(read, 1)
   emit_i32_load(read, 2, 44)
@@ -3458,13 +3470,13 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   emit_if_void(read)
   emit_local_get(read, 1)
   emit_i32_const(read, 0)
-  emit_call(read, 16)
+  emit_call(read, 18)
   emit_local_set(read, 5)
   emit_i32_const(read, -1)
   emit_return(read)
   emit_end(read)
   emit_local_get(read, 1)
-  emit_call(read, 15)
+  emit_call(read, 17)
   bytebuf_push(read, 0)
   emit_end(read)
   leb128_encode_u32(code_sec, Bytes::length(read))
@@ -3476,7 +3488,7 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   leb128_encode_u32(close, 2)
   bytebuf_push(close, 127)
   emit_local_get(close, 0)
-  emit_call(close, 13)
+  emit_call(close, 15)
   emit_local_set(close, 1)
   emit_local_get(close, 1)
   emit_i32_load(close, 2, 0)
@@ -3496,18 +3508,20 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   emit_end(close)
   emit_local_get(close, 1)
   emit_i32_const(close, 0)
-  emit_call(close, 16)
+  emit_call(close, 18)
   emit_local_set(close, 2)
   emit_i32_const(close, 0)
   bytebuf_push(close, 11)
   leb128_encode_u32(code_sec, Bytes::length(close))
   bytebuf_push_buf(code_sec, close)
   // drain scenario: exact bytes, shared EOF settlement, repeated EOF/close.
+  // Every scenario diagnostic after acquisition closes through the shared
+  // lifecycle-complete path before trapping.
   let drain = bytebuf_new()
   leb128_encode_u32(drain, 1)
   leb128_encode_u32(drain, 2)
   bytebuf_push(drain, 127)
-  emit_call(drain, 14)
+  emit_call(drain, 16)
   emit_local_set(drain, 0)
   let expected_bytes = [
     10,
@@ -3517,33 +3531,42 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   let mut di = 0
   while di < 3 {
     emit_local_get(drain, 0)
-    emit_call(drain, 17)
+    emit_call(drain, 19)
     emit_i32_const(drain, Array::get(expected_bytes, di))
     emit_i32_ne(drain)
     emit_if_void(drain)
+    emit_local_get(drain, 0)
+    emit_call(drain, 20)
+    emit_local_set(drain, 1)
     bytebuf_push(drain, 0)
     emit_end(drain)
     di = di + 1
   }
   emit_local_get(drain, 0)
-  emit_call(drain, 17)
+  emit_call(drain, 19)
   emit_i32_const(drain, -1)
   emit_i32_ne(drain)
   emit_if_void(drain)
+  emit_local_get(drain, 0)
+  emit_call(drain, 20)
+  emit_local_set(drain, 1)
   bytebuf_push(drain, 0)
   emit_end(drain)
   emit_local_get(drain, 0)
-  emit_call(drain, 17)
+  emit_call(drain, 19)
   emit_i32_const(drain, -1)
   emit_i32_ne(drain)
   emit_if_void(drain)
+  emit_local_get(drain, 0)
+  emit_call(drain, 20)
+  emit_local_set(drain, 1)
   bytebuf_push(drain, 0)
   emit_end(drain)
   emit_local_get(drain, 0)
-  emit_call(drain, 18)
+  emit_call(drain, 20)
   emit_local_set(drain, 1)
   emit_local_get(drain, 0)
-  emit_call(drain, 18)
+  emit_call(drain, 20)
   emit_local_set(drain, 1)
   emit_i32_const(drain, 42)
   emit_call(drain, 9)
@@ -3554,19 +3577,22 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   leb128_encode_u32(early, 1)
   leb128_encode_u32(early, 2)
   bytebuf_push(early, 127)
-  emit_call(early, 14)
+  emit_call(early, 16)
   emit_local_set(early, 0)
   emit_local_get(early, 0)
-  emit_call(early, 18)
+  emit_call(early, 20)
   emit_local_set(early, 1)
   emit_local_get(early, 0)
-  emit_call(early, 18)
+  emit_call(early, 20)
   emit_local_set(early, 1)
   emit_local_get(early, 0)
-  emit_call(early, 17)
+  emit_call(early, 19)
   emit_i32_const(early, -1)
   emit_i32_ne(early)
   emit_if_void(early)
+  emit_local_get(early, 0)
+  emit_call(early, 20)
+  emit_local_set(early, 1)
   bytebuf_push(early, 0)
   emit_end(early)
   emit_i32_const(early, 43)
@@ -3580,14 +3606,14 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   leb128_encode_u32(forced, 1)
   leb128_encode_u32(forced, 2)
   bytebuf_push(forced, 127)
-  emit_call(forced, 14)
+  emit_call(forced, 16)
   emit_local_set(forced, 0)
   emit_local_get(forced, 0)
-  emit_call(forced, 13)
+  emit_call(forced, 15)
   emit_local_set(forced, 1)
   emit_local_get(forced, 1)
   emit_i32_const(forced, 1)
-  emit_call(forced, 16)
+  emit_call(forced, 18)
   emit_local_set(forced, 0)
   bytebuf_push(forced, 0)
   emit_end(forced)
@@ -3599,12 +3625,76 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   leb128_encode_u32(foreign, 1)
   bytebuf_push(foreign, 127)
   emit_i32_const(foreign, 1409286145)
-  emit_call(foreign, 17)
+  emit_call(foreign, 19)
   emit_local_set(foreign, 0)
   bytebuf_push(foreign, 0)
   emit_end(foreign)
   leb128_encode_u32(code_sec, Bytes::length(foreign))
   bytebuf_push_buf(code_sec, foreign)
+  // Expected-trap controls for the scenario checks that motivated #1539's
+  // cleanup review. They perturb guest expectations only; neither control is
+  // a measurement of provider byte errors. Both close while OPEN, settling
+  // and dropping the stream/future exactly once, before unreachable.
+  let wrong_byte = bytebuf_new()
+  leb128_encode_u32(wrong_byte, 1)
+  leb128_encode_u32(wrong_byte, 2)
+  bytebuf_push(wrong_byte, 127)
+  emit_call(wrong_byte, 16)
+  emit_local_set(wrong_byte, 0)
+  emit_local_get(wrong_byte, 0)
+  emit_call(wrong_byte, 19)
+  emit_i32_const(wrong_byte, 11)
+  emit_i32_ne(wrong_byte)
+  emit_if_void(wrong_byte)
+  emit_local_get(wrong_byte, 0)
+  emit_call(wrong_byte, 20)
+  emit_local_set(wrong_byte, 1)
+  bytebuf_push(wrong_byte, 0)
+  emit_end(wrong_byte)
+  emit_i32_const(wrong_byte, 0)
+  emit_call(wrong_byte, 13)
+  bytebuf_push(wrong_byte, 11)
+  leb128_encode_u32(code_sec, Bytes::length(wrong_byte))
+  bytebuf_push_buf(code_sec, wrong_byte)
+  let extra_byte = bytebuf_new()
+  leb128_encode_u32(extra_byte, 1)
+  leb128_encode_u32(extra_byte, 2)
+  bytebuf_push(extra_byte, 127)
+  emit_call(extra_byte, 16)
+  emit_local_set(extra_byte, 0)
+  let extra_expected_bytes = [
+    10,
+    15
+  ]
+  let mut ei = 0
+  while ei < 2 {
+    emit_local_get(extra_byte, 0)
+    emit_call(extra_byte, 19)
+    emit_i32_const(extra_byte, Array::get(extra_expected_bytes, ei))
+    emit_i32_ne(extra_byte)
+    emit_if_void(extra_byte)
+    emit_local_get(extra_byte, 0)
+    emit_call(extra_byte, 20)
+    emit_local_set(extra_byte, 1)
+    bytebuf_push(extra_byte, 0)
+    emit_end(extra_byte)
+    ei = ei + 1
+  }
+  emit_local_get(extra_byte, 0)
+  emit_call(extra_byte, 19)
+  emit_i32_const(extra_byte, -1)
+  emit_i32_ne(extra_byte)
+  emit_if_void(extra_byte)
+  emit_local_get(extra_byte, 0)
+  emit_call(extra_byte, 20)
+  emit_local_set(extra_byte, 1)
+  bytebuf_push(extra_byte, 0)
+  emit_end(extra_byte)
+  emit_i32_const(extra_byte, 0)
+  emit_call(extra_byte, 14)
+  bytebuf_push(extra_byte, 11)
+  leb128_encode_u32(code_sec, Bytes::length(extra_byte))
+  bytebuf_push_buf(code_sec, extra_byte)
   bytebuf_push_section(out, 10, code_sec)
   bytebuf_to_bytes(out)
 }
@@ -3647,6 +3737,8 @@ export fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes {
   emit_canon_task_return(buf, comp_valtype_u32)
   emit_canon_task_return(buf, comp_valtype_u32)
   emit_canon_task_return(buf, comp_valtype_u32)
+  emit_canon_task_return(buf, comp_valtype_u32)
+  emit_canon_task_return(buf, comp_valtype_u32)
   let root_inst = 1
   emit_core_instance_from_exports(buf, 1, [
     9
@@ -3673,17 +3765,21 @@ export fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes {
   ])
   let export_root_inst = 2
   emit_core_instance_from_exports(buf, 1, [
-    4
+    6
   ], [
     "[task-return]drain",
     "[task-return]early-close",
     "[task-return]forced-completion-tag-control",
-    "[task-return]foreign-provider-control"
+    "[task-return]foreign-provider-control",
+    "[task-return]wrong-byte-cleanup-control",
+    "[task-return]extra-byte-cleanup-control"
   ], [
     9,
     10,
     11,
-    12
+    12,
+    13,
+    14
   ])
   emit_core_instance_from_exports_sorted(buf, [
     "memory"
@@ -3709,22 +3805,28 @@ export fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes {
     "drain",
     "early-close",
     "forced-completion-tag-control",
-    "foreign-provider-control"
+    "foreign-provider-control",
+    "wrong-byte-cleanup-control",
+    "extra-byte-cleanup-control"
   ], [
+    core_sort_func,
+    core_sort_func,
     core_sort_func,
     core_sort_func,
     core_sort_func,
     core_sort_func
   ])
   let mut lift_i = 0
-  while lift_i < 4 {
-    emit_canon_lift_async_section(buf, 13 + lift_i, async_type_idx)
+  while lift_i < 6 {
+    emit_canon_lift_async_section(buf, 15 + lift_i, async_type_idx)
     lift_i = lift_i + 1
   }
   emit_comp_export_section(buf, "drain", 1)
   emit_comp_export_section(buf, "early-close", 2)
   emit_comp_export_section(buf, "forced-completion-tag-control", 3)
   emit_comp_export_section(buf, "foreign-provider-control", 4)
+  emit_comp_export_section(buf, "wrong-byte-cleanup-control", 5)
+  emit_comp_export_section(buf, "extra-byte-cleanup-control", 6)
   bytebuf_to_bytes(buf)
 }
 

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -2876,11 +2876,10 @@ fn emit_comp_wasi_cli_stdin_instance_type_for_test(buf: Bytes) -> Unit {
 }
 
 /// Exact, fixed-prefix ratified wasi:cli stdin import surface for #1539.
-/// The root indexes below are load-bearing for this 208-byte test fixture;
-/// this is not a general instance-import builder and has no production caller.
-fn comp_emit_wasi_cli_stdin_import_surface_for_test() -> Bytes {
-  let buf = bytebuf_new()
-  emit_component_header(buf)
+/// The root indexes below are load-bearing: the golden fixture and the shadow
+/// provider component both call this emitter, so the nominal error-code alias
+/// cannot drift between the proof fixture and the production-unused adapter.
+fn emit_comp_wasi_cli_stdin_import_prefix(buf: Bytes) -> Unit {
   // root type 0, then imported component instance 0
   emit_comp_wasi_cli_types_instance_type_for_test(buf)
   emit_comp_instance_import_section(buf, "wasi:cli/types@0.3.0", 0)
@@ -2891,6 +2890,841 @@ fn comp_emit_wasi_cli_stdin_import_surface_for_test() -> Bytes {
   emit_comp_instance_import_section(buf, "wasi:cli/stdin@0.3.0", 2)
   // root component function 0
   emit_comp_instance_export_alias_section(buf, 1, "read-via-stream", comp_extern_func)
+}
+
+fn comp_emit_wasi_cli_stdin_import_surface_for_test() -> Bytes {
+  let buf = bytebuf_new()
+  emit_component_header(buf)
+  emit_comp_wasi_cli_stdin_import_prefix(buf)
+  bytebuf_to_bytes(buf)
+}
+
+/// Synchronous canon lower with an explicit memory option. Unlike async lower,
+/// read-via-stream returns its `(stream, future)` tuple indirectly but does not
+/// itself suspend. Encoding: lower, reserved, function, one option, memory.
+fn emit_canon_lower_memory_section(buf: Bytes, comp_func_idx: Int, memory_core_idx: Int) -> Unit {
+  bytebuf_push(buf, section_canon)
+  let content = bytebuf_new()
+  leb128_encode_u32(content, 1)
+  bytebuf_push(content, 1)
+  bytebuf_push(content, 0)
+  leb128_encode_u32(content, comp_func_idx)
+  leb128_encode_u32(content, 1)
+  bytebuf_push(content, 3)
+  leb128_encode_u32(content, memory_core_idx)
+  emit_raw_content(buf, content)
+}
+
+fn emit_comp_result_error_type_section(buf: Bytes, error_type_idx: Int) -> Unit {
+  bytebuf_push(buf, section_type)
+  let content = bytebuf_new()
+  leb128_encode_u32(content, 1)
+  bytebuf_push(content, 106)
+  bytebuf_push(content, 0)
+  bytebuf_push(content, 1)
+  leb128_encode_u32(content, error_type_idx)
+  emit_raw_content(buf, content)
+}
+
+fn comp_stdin_provider_phase_open() -> Int {
+  1
+}
+
+fn comp_stdin_provider_phase_reading() -> Int {
+  2
+}
+
+fn comp_stdin_provider_phase_settling() -> Int {
+  3
+}
+
+fn comp_stdin_provider_phase_settled_ok() -> Int {
+  4
+}
+
+fn comp_stdin_provider_phase_settled_failed() -> Int {
+  5
+}
+
+fn comp_stdin_provider_tag() -> Int {
+  1398031433
+}
+
+fn comp_stdin_provider_id_prefix() -> Int {
+  1392508928
+}
+
+fn comp_stdin_provider_slot_base() -> Int {
+  64
+}
+
+fn comp_stdin_provider_slot_capacity() -> Int {
+  16
+}
+
+/// #1539 shadow-only provider adapter. Canonical stream/future handles never
+/// escape: monotonically allocated opaque IDs address 64-byte records which
+/// own both ends and all landing/wait scratch. The component exports only
+/// private lifecycle scenarios; linked_compile and public HostStream routing
+/// deliberately do not reference this module.
+fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  // 0 (i32)->(); 1 (i32,i32,i32)->i32; 2 (i32,i32)->i32;
+  // 3 ()->i32; 4 (i32,i32)->(); 5 (i32)->i32; 6 ()->();
+  // 7 (i32,i32)->i32.
+  let tc = bytebuf_new()
+  bytebuf_push_vec_header(tc, 8)
+  emit_func_type_raw(tc, [
+    127
+  ], array_empty())
+  emit_func_type_raw(tc, [
+    127,
+    127,
+    127
+  ], [
+    127
+  ])
+  emit_func_type_raw(tc, [
+    127,
+    127
+  ], [
+    127
+  ])
+  emit_func_type_raw(tc, array_empty(), [
+    127
+  ])
+  emit_func_type_raw(tc, [
+    127,
+    127
+  ], array_empty())
+  emit_func_type_raw(tc, [
+    127
+  ], [
+    127
+  ])
+  emit_func_type_raw(tc, array_empty(), array_empty())
+  emit_func_type_raw(tc, [
+    127,
+    127
+  ], [
+    127
+  ])
+  bytebuf_push_section(out, 1, tc)
+  // Canonical imports 0..8, four scenario task-return imports 9..12, memory.
+  let ic = bytebuf_new()
+  bytebuf_push_vec_header(ic, 14)
+  let import_modules = [
+    "$root",
+    "$root",
+    "$root",
+    "$root",
+    "$root",
+    "$root",
+    "$root",
+    "$root",
+    "$root",
+    "[export]$root",
+    "[export]$root",
+    "[export]$root",
+    "[export]$root"
+  ]
+  let import_names = [
+    "read-via-stream",
+    "[async-lower][stream-read-0]read-via-stream",
+    "[stream-drop-readable-0]read-via-stream",
+    "[async-lower][future-read-1]read-via-stream",
+    "[future-drop-readable-1]read-via-stream",
+    "[waitable-set-new]",
+    "[waitable-join]",
+    "[waitable-set-wait]",
+    "[waitable-set-drop]",
+    "[task-return]drain",
+    "[task-return]early-close",
+    "[task-return]forced-completion-tag-control",
+    "[task-return]foreign-provider-control"
+  ]
+  let import_types = [
+    0,
+    1,
+    0,
+    2,
+    0,
+    3,
+    4,
+    2,
+    0,
+    0,
+    0,
+    0,
+    0
+  ]
+  let mut ii = 0
+  while ii < 13 {
+    emit_name(ic, Array::get(import_modules, ii))
+    emit_name(ic, Array::get(import_names, ii))
+    bytebuf_push(ic, 0)
+    leb128_encode_u32(ic, Array::get(import_types, ii))
+    ii = ii + 1
+  }
+  emit_name(ic, "env")
+  emit_name(ic, "memory")
+  bytebuf_push(ic, 2)
+  bytebuf_push(ic, 0)
+  leb128_encode_u32(ic, 1)
+  bytebuf_push_section(out, 2, ic)
+  // locals 13..18 are decode/acquire/fail/settle/read/close; 19..22 scenarios.
+  emit_function_section(out, [
+    5,
+    3,
+    0,
+    7,
+    5,
+    5,
+    6,
+    6,
+    6,
+    6
+  ])
+  emit_export_section_multi(out, [
+    "stdin-provider-shadow-decode",
+    "stdin-provider-shadow-acquire",
+    "stdin-provider-shadow-fail-cleanup",
+    "stdin-provider-shadow-settle",
+    "stdin-provider-shadow-read",
+    "stdin-provider-shadow-close",
+    "drain",
+    "early-close",
+    "forced-completion-tag-control",
+    "foreign-provider-control"
+  ], [
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22
+  ])
+  let code_sec = bytebuf_new()
+  leb128_encode_u32(code_sec, 10)
+  // decode(id) -> record address. Prefix, capacity, record tag and published
+  // phase are checked before a caller can reach any canonical operation.
+  let decode = bytebuf_new()
+  leb128_encode_u32(decode, 1)
+  leb128_encode_u32(decode, 2)
+  bytebuf_push(decode, 127)
+  emit_local_get(decode, 0)
+  emit_i32_const(decode, -16777216)
+  emit_i32_and(decode)
+  emit_i32_const(decode, comp_stdin_provider_id_prefix())
+  emit_i32_ne(decode)
+  emit_if_void(decode)
+  bytebuf_push(decode, 0)
+  emit_end(decode)
+  emit_local_get(decode, 0)
+  emit_i32_const(decode, 16777215)
+  emit_i32_and(decode)
+  emit_local_set(decode, 1)
+  emit_local_get(decode, 1)
+  emit_i32_eqz(decode)
+  emit_if_void(decode)
+  bytebuf_push(decode, 0)
+  emit_end(decode)
+  emit_local_get(decode, 1)
+  emit_i32_const(decode, comp_stdin_provider_slot_capacity())
+  emit_i32_gt_u(decode)
+  emit_if_void(decode)
+  bytebuf_push(decode, 0)
+  emit_end(decode)
+  emit_local_get(decode, 1)
+  emit_i32_const(decode, 1)
+  emit_i32_sub(decode)
+  emit_i32_const(decode, 6)
+  emit_i32_shl(decode)
+  emit_i32_const(decode, comp_stdin_provider_slot_base())
+  emit_i32_add(decode)
+  emit_local_set(decode, 2)
+  emit_local_get(decode, 2)
+  emit_i32_load(decode, 2, 4)
+  emit_i32_const(decode, comp_stdin_provider_tag())
+  emit_i32_ne(decode)
+  emit_if_void(decode)
+  bytebuf_push(decode, 0)
+  emit_end(decode)
+  emit_local_get(decode, 2)
+  emit_i32_load(decode, 2, 0)
+  emit_i32_eqz(decode)
+  emit_if_void(decode)
+  bytebuf_push(decode, 0)
+  emit_end(decode)
+  emit_local_get(decode, 2)
+  bytebuf_push(decode, 11)
+  leb128_encode_u32(code_sec, Bytes::length(decode))
+  bytebuf_push_buf(code_sec, decode)
+  // acquire() -> opaque provider id. Capacity is checked before authority is
+  // exercised. The synchronous lower lands the two handles directly in the
+  // record; ownership/tag are initialized before OPEN is published last.
+  let acquire = bytebuf_new()
+  leb128_encode_u32(acquire, 1)
+  leb128_encode_u32(acquire, 2)
+  bytebuf_push(acquire, 127)
+  emit_i32_const(acquire, 0)
+  emit_i32_load(acquire, 2, 0)
+  emit_local_set(acquire, 0)
+  emit_local_get(acquire, 0)
+  emit_i32_const(acquire, comp_stdin_provider_slot_capacity() - 1)
+  emit_i32_gt_u(acquire)
+  emit_if_void(acquire)
+  bytebuf_push(acquire, 0)
+  emit_end(acquire)
+  emit_local_get(acquire, 0)
+  emit_i32_const(acquire, 6)
+  emit_i32_shl(acquire)
+  emit_i32_const(acquire, comp_stdin_provider_slot_base())
+  emit_i32_add(acquire)
+  emit_local_set(acquire, 1)
+  emit_local_get(acquire, 1)
+  emit_i32_const(acquire, 8)
+  emit_i32_add(acquire)
+  emit_call(acquire, 0)
+  emit_local_get(acquire, 1)
+  emit_i32_const(acquire, 3)
+  emit_i32_store(acquire, 2, 16)
+  emit_local_get(acquire, 1)
+  emit_i32_const(acquire, comp_stdin_provider_tag())
+  emit_i32_store(acquire, 2, 4)
+  emit_local_get(acquire, 1)
+  emit_i32_const(acquire, comp_stdin_provider_phase_open())
+  emit_i32_store(acquire, 2, 0)
+  emit_i32_const(acquire, 0)
+  emit_local_get(acquire, 0)
+  emit_i32_const(acquire, 1)
+  emit_i32_add(acquire)
+  emit_i32_store(acquire, 2, 0)
+  emit_i32_const(acquire, comp_stdin_provider_id_prefix())
+  emit_local_get(acquire, 0)
+  emit_i32_add(acquire)
+  emit_i32_const(acquire, 1)
+  emit_i32_add(acquire)
+  bytebuf_push(acquire, 11)
+  leb128_encode_u32(code_sec, Bytes::length(acquire))
+  bytebuf_push_buf(code_sec, acquire)
+  // fail_cleanup(addr): release each still-owned canonical end once, mark the
+  // tombstone FAILED, then trap. No waitable set is live at its call sites.
+  let fail = bytebuf_new()
+  leb128_encode_u32(fail, 0)
+  emit_local_get(fail, 0)
+  emit_i32_load(fail, 2, 16)
+  emit_i32_const(fail, 1)
+  emit_i32_and(fail)
+  emit_if_void(fail)
+  emit_local_get(fail, 0)
+  emit_i32_load(fail, 2, 8)
+  emit_call(fail, 2)
+  emit_local_get(fail, 0)
+  emit_local_get(fail, 0)
+  emit_i32_load(fail, 2, 16)
+  emit_i32_const(fail, -2)
+  emit_i32_and(fail)
+  emit_i32_store(fail, 2, 16)
+  emit_end(fail)
+  emit_local_get(fail, 0)
+  emit_i32_load(fail, 2, 16)
+  emit_i32_const(fail, 2)
+  emit_i32_and(fail)
+  emit_if_void(fail)
+  emit_local_get(fail, 0)
+  emit_i32_load(fail, 2, 12)
+  emit_call(fail, 4)
+  emit_local_get(fail, 0)
+  emit_local_get(fail, 0)
+  emit_i32_load(fail, 2, 16)
+  emit_i32_const(fail, -3)
+  emit_i32_and(fail)
+  emit_i32_store(fail, 2, 16)
+  emit_end(fail)
+  emit_local_get(fail, 0)
+  emit_i32_const(fail, comp_stdin_provider_phase_settled_failed())
+  emit_i32_store(fail, 2, 0)
+  bytebuf_push(fail, 0)
+  emit_end(fail)
+  leb128_encode_u32(code_sec, Bytes::length(fail))
+  bytebuf_push_buf(code_sec, fail)
+  // settle(addr, force_tag) -> 0. This single path is used by EOF and close.
+  // Every BLOCKED future read is new/join/wait/unjoin/drop. Validation is
+  // delayed until after future.drop-readable and ownership-bit clearing.
+  let settle = bytebuf_new()
+  leb128_encode_u32(settle, 1)
+  leb128_encode_u32(settle, 4)
+  bytebuf_push(settle, 127)
+  emit_local_get(settle, 0)
+  emit_i32_const(settle, comp_stdin_provider_phase_settling())
+  emit_i32_store(settle, 2, 0)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 16)
+  emit_i32_const(settle, 1)
+  emit_i32_and(settle)
+  emit_if_void(settle)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 8)
+  emit_call(settle, 2)
+  emit_local_get(settle, 0)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 16)
+  emit_i32_const(settle, -2)
+  emit_i32_and(settle)
+  emit_i32_store(settle, 2, 16)
+  emit_end(settle)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 16)
+  emit_i32_const(settle, 2)
+  emit_i32_and(settle)
+  emit_i32_eqz(settle)
+  emit_if_void(settle)
+  emit_local_get(settle, 0)
+  emit_i32_const(settle, comp_stdin_provider_phase_settled_failed())
+  emit_i32_store(settle, 2, 0)
+  bytebuf_push(settle, 0)
+  emit_end(settle)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 12)
+  emit_local_get(settle, 0)
+  emit_i32_const(settle, 32)
+  emit_i32_add(settle)
+  emit_call(settle, 3)
+  emit_local_set(settle, 2)
+  emit_local_get(settle, 2)
+  emit_i32_const(settle, -1)
+  emit_i32_eq(settle)
+  emit_if_void(settle)
+  emit_call(settle, 5)
+  emit_local_set(settle, 3)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 12)
+  emit_local_get(settle, 3)
+  emit_call(settle, 6)
+  emit_local_get(settle, 3)
+  emit_local_get(settle, 0)
+  emit_i32_const(settle, 40)
+  emit_i32_add(settle)
+  emit_call(settle, 7)
+  emit_local_set(settle, 4)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 12)
+  emit_i32_const(settle, 0)
+  emit_call(settle, 6)
+  emit_local_get(settle, 3)
+  emit_call(settle, 8)
+  emit_local_get(settle, 4)
+  emit_i32_const(settle, 4)
+  emit_i32_ne(settle)
+  emit_if_void(settle)
+  emit_i32_const(settle, 1)
+  emit_local_set(settle, 5)
+  emit_end(settle)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 44)
+  emit_local_set(settle, 2)
+  emit_end(settle)
+  // Negative control only: perturb the already-read discriminant. This is
+  // not evidence that a provider emitted an error.
+  emit_local_get(settle, 1)
+  emit_if_void(settle)
+  emit_local_get(settle, 0)
+  emit_i32_const(settle, 1)
+  emit_i32_store(settle, 2, 32)
+  emit_end(settle)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 12)
+  emit_call(settle, 4)
+  emit_local_get(settle, 0)
+  emit_i32_const(settle, 0)
+  emit_i32_store(settle, 2, 16)
+  emit_local_get(settle, 2)
+  emit_i32_const(settle, 0)
+  emit_i32_ne(settle)
+  emit_if_void(settle)
+  emit_i32_const(settle, 1)
+  emit_local_set(settle, 5)
+  emit_end(settle)
+  emit_local_get(settle, 0)
+  emit_i32_load(settle, 2, 32)
+  emit_if_void(settle)
+  emit_i32_const(settle, 1)
+  emit_local_set(settle, 5)
+  emit_end(settle)
+  emit_local_get(settle, 5)
+  emit_if_void(settle)
+  emit_local_get(settle, 0)
+  emit_i32_const(settle, comp_stdin_provider_phase_settled_failed())
+  emit_i32_store(settle, 2, 0)
+  bytebuf_push(settle, 0)
+  emit_end(settle)
+  emit_local_get(settle, 0)
+  emit_i32_const(settle, comp_stdin_provider_phase_settled_ok())
+  emit_i32_store(settle, 2, 0)
+  emit_i32_const(settle, 0)
+  bytebuf_push(settle, 11)
+  leb128_encode_u32(code_sec, Bytes::length(settle))
+  bytebuf_push_buf(code_sec, settle)
+  // read(id) -> byte or -1. Only OPEN reaches stream.read. READING is
+  // published before the call, so same-slot in-flight re-entry fails in
+  // decode/phase checks without a second canonical operation.
+  let read = bytebuf_new()
+  leb128_encode_u32(read, 1)
+  leb128_encode_u32(read, 5)
+  bytebuf_push(read, 127)
+  emit_local_get(read, 0)
+  emit_call(read, 13)
+  emit_local_set(read, 1)
+  emit_local_get(read, 1)
+  emit_i32_load(read, 2, 0)
+  emit_local_set(read, 2)
+  emit_local_get(read, 2)
+  emit_i32_const(read, comp_stdin_provider_phase_settled_ok())
+  emit_i32_eq(read)
+  emit_if_void(read)
+  emit_i32_const(read, -1)
+  emit_return(read)
+  emit_end(read)
+  emit_local_get(read, 2)
+  emit_i32_const(read, comp_stdin_provider_phase_open())
+  emit_i32_ne(read)
+  emit_if_void(read)
+  bytebuf_push(read, 0)
+  emit_end(read)
+  emit_local_get(read, 1)
+  emit_i32_const(read, comp_stdin_provider_phase_reading())
+  emit_i32_store(read, 2, 0)
+  emit_local_get(read, 1)
+  emit_i32_load(read, 2, 8)
+  emit_local_get(read, 1)
+  emit_i32_const(read, 24)
+  emit_i32_add(read)
+  emit_i32_const(read, 1)
+  emit_call(read, 1)
+  emit_local_set(read, 2)
+  emit_local_get(read, 2)
+  emit_i32_const(read, -1)
+  emit_i32_eq(read)
+  emit_if_void(read)
+  emit_call(read, 5)
+  emit_local_set(read, 3)
+  emit_local_get(read, 1)
+  emit_i32_load(read, 2, 8)
+  emit_local_get(read, 3)
+  emit_call(read, 6)
+  emit_local_get(read, 3)
+  emit_local_get(read, 1)
+  emit_i32_const(read, 40)
+  emit_i32_add(read)
+  emit_call(read, 7)
+  emit_local_set(read, 4)
+  emit_local_get(read, 1)
+  emit_i32_load(read, 2, 8)
+  emit_i32_const(read, 0)
+  emit_call(read, 6)
+  emit_local_get(read, 3)
+  emit_call(read, 8)
+  emit_local_get(read, 4)
+  emit_i32_const(read, 2)
+  emit_i32_ne(read)
+  emit_if_void(read)
+  emit_local_get(read, 1)
+  emit_call(read, 15)
+  emit_end(read)
+  emit_local_get(read, 1)
+  emit_i32_load(read, 2, 44)
+  emit_local_set(read, 2)
+  emit_end(read)
+  emit_local_get(read, 2)
+  emit_i32_const(read, 16)
+  emit_i32_eq(read)
+  emit_if_void(read)
+  emit_local_get(read, 1)
+  emit_i32_const(read, comp_stdin_provider_phase_open())
+  emit_i32_store(read, 2, 0)
+  emit_local_get(read, 1)
+  emit_i32_load8_u(read, 0, 24)
+  emit_return(read)
+  emit_end(read)
+  emit_local_get(read, 2)
+  emit_i32_const(read, 1)
+  emit_i32_eq(read)
+  emit_if_void(read)
+  emit_local_get(read, 1)
+  emit_i32_const(read, 0)
+  emit_call(read, 16)
+  emit_local_set(read, 5)
+  emit_i32_const(read, -1)
+  emit_return(read)
+  emit_end(read)
+  emit_local_get(read, 1)
+  emit_call(read, 15)
+  bytebuf_push(read, 0)
+  emit_end(read)
+  leb128_encode_u32(code_sec, Bytes::length(read))
+  bytebuf_push_buf(code_sec, read)
+  // close(id): successful settlement is idempotent; every other non-OPEN
+  // phase traps before calling the shared settlement path.
+  let close = bytebuf_new()
+  leb128_encode_u32(close, 1)
+  leb128_encode_u32(close, 2)
+  bytebuf_push(close, 127)
+  emit_local_get(close, 0)
+  emit_call(close, 13)
+  emit_local_set(close, 1)
+  emit_local_get(close, 1)
+  emit_i32_load(close, 2, 0)
+  emit_local_set(close, 2)
+  emit_local_get(close, 2)
+  emit_i32_const(close, comp_stdin_provider_phase_settled_ok())
+  emit_i32_eq(close)
+  emit_if_void(close)
+  emit_i32_const(close, 0)
+  emit_return(close)
+  emit_end(close)
+  emit_local_get(close, 2)
+  emit_i32_const(close, comp_stdin_provider_phase_open())
+  emit_i32_ne(close)
+  emit_if_void(close)
+  bytebuf_push(close, 0)
+  emit_end(close)
+  emit_local_get(close, 1)
+  emit_i32_const(close, 0)
+  emit_call(close, 16)
+  emit_local_set(close, 2)
+  emit_i32_const(close, 0)
+  bytebuf_push(close, 11)
+  leb128_encode_u32(code_sec, Bytes::length(close))
+  bytebuf_push_buf(code_sec, close)
+  // drain scenario: exact bytes, shared EOF settlement, repeated EOF/close.
+  let drain = bytebuf_new()
+  leb128_encode_u32(drain, 1)
+  leb128_encode_u32(drain, 2)
+  bytebuf_push(drain, 127)
+  emit_call(drain, 14)
+  emit_local_set(drain, 0)
+  let expected_bytes = [
+    10,
+    15,
+    17
+  ]
+  let mut di = 0
+  while di < 3 {
+    emit_local_get(drain, 0)
+    emit_call(drain, 17)
+    emit_i32_const(drain, Array::get(expected_bytes, di))
+    emit_i32_ne(drain)
+    emit_if_void(drain)
+    bytebuf_push(drain, 0)
+    emit_end(drain)
+    di = di + 1
+  }
+  emit_local_get(drain, 0)
+  emit_call(drain, 17)
+  emit_i32_const(drain, -1)
+  emit_i32_ne(drain)
+  emit_if_void(drain)
+  bytebuf_push(drain, 0)
+  emit_end(drain)
+  emit_local_get(drain, 0)
+  emit_call(drain, 17)
+  emit_i32_const(drain, -1)
+  emit_i32_ne(drain)
+  emit_if_void(drain)
+  bytebuf_push(drain, 0)
+  emit_end(drain)
+  emit_local_get(drain, 0)
+  emit_call(drain, 18)
+  emit_local_set(drain, 1)
+  emit_local_get(drain, 0)
+  emit_call(drain, 18)
+  emit_local_set(drain, 1)
+  emit_i32_const(drain, 42)
+  emit_call(drain, 9)
+  bytebuf_push(drain, 11)
+  leb128_encode_u32(code_sec, Bytes::length(drain))
+  bytebuf_push_buf(code_sec, drain)
+  let early = bytebuf_new()
+  leb128_encode_u32(early, 1)
+  leb128_encode_u32(early, 2)
+  bytebuf_push(early, 127)
+  emit_call(early, 14)
+  emit_local_set(early, 0)
+  emit_local_get(early, 0)
+  emit_call(early, 18)
+  emit_local_set(early, 1)
+  emit_local_get(early, 0)
+  emit_call(early, 18)
+  emit_local_set(early, 1)
+  emit_local_get(early, 0)
+  emit_call(early, 17)
+  emit_i32_const(early, -1)
+  emit_i32_ne(early)
+  emit_if_void(early)
+  bytebuf_push(early, 0)
+  emit_end(early)
+  emit_i32_const(early, 43)
+  emit_call(early, 10)
+  bytebuf_push(early, 11)
+  leb128_encode_u32(code_sec, Bytes::length(early))
+  bytebuf_push_buf(code_sec, early)
+  // Expected trap after common cleanup; deliberately not a provider-error
+  // measurement (force_tag only changes the already-landed result tag).
+  let forced = bytebuf_new()
+  leb128_encode_u32(forced, 1)
+  leb128_encode_u32(forced, 2)
+  bytebuf_push(forced, 127)
+  emit_call(forced, 14)
+  emit_local_set(forced, 0)
+  emit_local_get(forced, 0)
+  emit_call(forced, 13)
+  emit_local_set(forced, 1)
+  emit_local_get(forced, 1)
+  emit_i32_const(forced, 1)
+  emit_call(forced, 16)
+  emit_local_set(forced, 0)
+  bytebuf_push(forced, 0)
+  emit_end(forced)
+  leb128_encode_u32(code_sec, Bytes::length(forced))
+  bytebuf_push_buf(code_sec, forced)
+  // Foreign discriminator must trap in decode before any canonical call.
+  let foreign = bytebuf_new()
+  leb128_encode_u32(foreign, 1)
+  leb128_encode_u32(foreign, 1)
+  bytebuf_push(foreign, 127)
+  emit_i32_const(foreign, 1409286145)
+  emit_call(foreign, 17)
+  emit_local_set(foreign, 0)
+  bytebuf_push(foreign, 0)
+  emit_end(foreign)
+  leb128_encode_u32(code_sec, Bytes::length(foreign))
+  bytebuf_push_buf(code_sec, foreign)
+  bytebuf_push_section(out, 10, code_sec)
+  bytebuf_to_bytes(out)
+}
+
+/// Emit the production-unused #1539 shadow component. Its first 208 bytes are
+/// exactly comp_emit_wasi_cli_stdin_import_surface_for_test(). Scenario exports
+/// are private gates, not a Stdin effect or HostStream API.
+export fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes {
+  let buf = bytebuf_new()
+  emit_component_header(buf)
+  emit_comp_wasi_cli_stdin_import_prefix(buf)
+  emit_core_module_section(buf, comp_generate_stdin_provider_adapter_core_module())
+  emit_core_module_section(buf, comp_generate_memhost_module())
+  let memhost_inst = 0
+  emit_core_instance_instantiate_section(buf, 1, array_empty())
+  let mem_alias_idx = 0
+  emit_alias_section(buf, memhost_inst, [
+    "memory"
+  ], [
+    core_sort_mem
+  ])
+  // Root types 3..5 mirror the nested stdin result's stream and nominal
+  // completion future. Function 0 is the imported read-via-stream alias.
+  let stream_type_idx = 3
+  let completion_result_type_idx = 4
+  let completion_future_type_idx = 5
+  emit_comp_stream_type_section(buf, comp_valtype_u8)
+  emit_comp_result_error_type_section(buf, 1)
+  emit_comp_future_type_section(buf, completion_result_type_idx)
+  emit_canon_lower_memory_section(buf, 0, mem_alias_idx)
+  emit_canon_stream_read(buf, stream_type_idx, mem_alias_idx)
+  emit_canon_stream_drop_readable(buf, stream_type_idx)
+  emit_canon_future_read(buf, completion_future_type_idx, mem_alias_idx)
+  emit_canon_future_drop_readable(buf, completion_future_type_idx)
+  emit_canon_waitable_set_new(buf)
+  emit_canon_waitable_join(buf)
+  emit_canon_waitable_set_wait(buf, mem_alias_idx)
+  emit_canon_waitable_set_drop(buf)
+  emit_canon_task_return(buf, comp_valtype_u32)
+  emit_canon_task_return(buf, comp_valtype_u32)
+  emit_canon_task_return(buf, comp_valtype_u32)
+  emit_canon_task_return(buf, comp_valtype_u32)
+  let root_inst = 1
+  emit_core_instance_from_exports(buf, 1, [
+    9
+  ], [
+    "read-via-stream",
+    "[async-lower][stream-read-0]read-via-stream",
+    "[stream-drop-readable-0]read-via-stream",
+    "[async-lower][future-read-1]read-via-stream",
+    "[future-drop-readable-1]read-via-stream",
+    "[waitable-set-new]",
+    "[waitable-join]",
+    "[waitable-set-wait]",
+    "[waitable-set-drop]"
+  ], [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ])
+  let export_root_inst = 2
+  emit_core_instance_from_exports(buf, 1, [
+    4
+  ], [
+    "[task-return]drain",
+    "[task-return]early-close",
+    "[task-return]forced-completion-tag-control",
+    "[task-return]foreign-provider-control"
+  ], [
+    9,
+    10,
+    11,
+    12
+  ])
+  emit_core_instance_from_exports_sorted(buf, [
+    "memory"
+  ], [
+    core_sort_mem
+  ], [
+    mem_alias_idx
+  ])
+  let env_inst = 3
+  let guest_inst = 4
+  emit_core_instance_instantiate_args(buf, 0, [
+    "$root",
+    "[export]$root",
+    "env"
+  ], [
+    root_inst,
+    export_root_inst,
+    env_inst
+  ])
+  let async_type_idx = 6
+  emit_comp_async_functype_section(buf, comp_valtype_u32)
+  emit_alias_section(buf, guest_inst, [
+    "drain",
+    "early-close",
+    "forced-completion-tag-control",
+    "foreign-provider-control"
+  ], [
+    core_sort_func,
+    core_sort_func,
+    core_sort_func,
+    core_sort_func
+  ])
+  let mut lift_i = 0
+  while lift_i < 4 {
+    emit_canon_lift_async_section(buf, 13 + lift_i, async_type_idx)
+    lift_i = lift_i + 1
+  }
+  emit_comp_export_section(buf, "drain", 1)
+  emit_comp_export_section(buf, "early-close", 2)
+  emit_comp_export_section(buf, "forced-completion-tag-control", 3)
+  emit_comp_export_section(buf, "foreign-provider-control", 4)
   bytebuf_to_bytes(buf)
 }
 

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen_instance_import_test.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen_instance_import_test.vibe
@@ -1,5 +1,5 @@
 import ./component_codegen.vibe {
-  comp_emit_wasi_cli_stdin_import_surface_for_test
+  comp_emit_component_wasm_stdin_provider_shadow, comp_emit_wasi_cli_stdin_import_surface_for_test
 }
 
 fn first_component_byte_mismatch(actual: Bytes, expected: Array[Int]) -> String {
@@ -239,4 +239,14 @@ test "#1539: exact ratified wasi cli stdin instance-import surface" {
   ]
   let actual = comp_emit_wasi_cli_stdin_import_surface_for_test()
   assert_eq(first_component_byte_mismatch(actual, expected), "")
+  let shadow = comp_emit_component_wasm_stdin_provider_shadow()
+  let mut i = 0
+  let mut prefix_mismatch = ""
+  while (i < Array::length(expected)) && (prefix_mismatch == "") {
+    if Bytes::get(shadow, i) != Array::get(expected, i) {
+      prefix_mismatch = String::concat("shadow prefix mismatch at index ", Int::to_string(i))
+    }
+    i = i + 1
+  }
+  assert_eq(prefix_mismatch, "")
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -171,6 +171,9 @@ fn comp_emit_component_wasm_stream_value(export_name: String, comp_result_valtyp
 // `get-future`, parks the read on waitable-set.wait until the host's
 // producer resolves (driven by runtime/viberun's FutureReader import).
 fn comp_emit_component_wasm_host_future_value(export_name: String, comp_result_valtype: Int) -> Bytes with Exception
+// #1539: production-unused stdin provider shadow component. This is an
+// internal gate emitter only; it is not routed from linked_compile.
+fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -172,7 +172,7 @@ fn comp_emit_component_wasm_stream_value(export_name: String, comp_result_valtyp
 // producer resolves (driven by runtime/viberun's FutureReader import).
 fn comp_emit_component_wasm_host_future_value(export_name: String, comp_result_valtype: Int) -> Bytes with Exception
 // #1539: production-unused stdin provider shadow component. This is an
-// internal gate emitter only; it is not routed from linked_compile.
+// internal gate emitter only; it has no end-user API or linked_compile route.
 fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -1452,6 +1452,8 @@ test "component stdin provider shadow: distinct lifecycle adapter remains unrout
   assert(component_bytes_contains(comp, "early-close") == 1)
   assert(component_bytes_contains(comp, "forced-completion-tag-control") == 1)
   assert(component_bytes_contains(comp, "foreign-provider-control") == 1)
+  assert(component_bytes_contains(comp, "wrong-byte-cleanup-control") == 1)
+  assert(component_bytes_contains(comp, "extra-byte-cleanup-control") == 1)
   assert(component_bytes_contains(comp, "[async-lower][stream-read-0]read-via-stream") == 1)
   assert(component_bytes_contains(comp, "[async-lower][future-read-1]read-via-stream") == 1)
   assert(component_bytes_contains(comp, "[waitable-set-wait]") == 1)

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -22,6 +22,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_async_trampolined_p1,
   comp_emit_component_wasm_future_value,
   comp_emit_component_wasm_host_future_value,
+  comp_emit_component_wasm_stdin_provider_shadow,
   comp_emit_component_wasm_stream_value,
   comp_emit_component_wasm_string_handler,
   comp_emit_component_wasm_string_handler_stubbed,
@@ -1435,6 +1436,27 @@ fn build_main_i64_core_hoststream_named(with_future: Bool) -> Bytes {
     body
   ])
   bytebuf_to_bytes(out)
+}
+
+// #1539 is intentionally a separate, production-unused component: exact
+// stdin imports plus an opaque provider-table adapter and private scenarios.
+test "component stdin provider shadow: distinct lifecycle adapter remains unrouted (#1539)" {
+  let comp = comp_emit_component_wasm_stdin_provider_shadow()
+  assert(component_bytes_contains(comp, "wasi:cli/types@0.3.0") == 1)
+  assert(component_bytes_contains(comp, "wasi:cli/stdin@0.3.0") == 1)
+  assert(component_bytes_contains(comp, "read-via-stream") == 1)
+  assert(component_bytes_contains(comp, "stdin-provider-shadow-acquire") == 1)
+  assert(component_bytes_contains(comp, "stdin-provider-shadow-read") == 1)
+  assert(component_bytes_contains(comp, "stdin-provider-shadow-settle") == 1)
+  assert(component_bytes_contains(comp, "drain") == 1)
+  assert(component_bytes_contains(comp, "early-close") == 1)
+  assert(component_bytes_contains(comp, "forced-completion-tag-control") == 1)
+  assert(component_bytes_contains(comp, "foreign-provider-control") == 1)
+  assert(component_bytes_contains(comp, "[async-lower][stream-read-0]read-via-stream") == 1)
+  assert(component_bytes_contains(comp, "[async-lower][future-read-1]read-via-stream") == 1)
+  assert(component_bytes_contains(comp, "[waitable-set-wait]") == 1)
+  assert(component_bytes_contains(comp, "host_stream_get$stdin") == 0)
+  assert(component_bytes_contains(comp, "host_stream_close") == 0)
 }
 
 // ADR-0089 Decision 3 (#1218): a named host STREAM composes into a

--- a/scripts/test_wasi_cli_stdin_provider_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_component_gate.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# #1539: generated, production-unused stdin provider shadow component gate.
+# Structural checks always cover the exact nominal import prefix, synchronous
+# memory-bearing read-via-stream lower, private adapter/scenario surface, and
+# component WIT. Wasmtime 47.0.2 additionally runs drain/early-close and the
+# two expected-trap controls when its ratified stdin provider is available.
+# The forced completion tag is a control of cleanup/fail-closed code, not a
+# measurement of a provider-generated completion error.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/wasi_cli_stdin_provider_shadow}"
+mkdir -p "$OUT_DIR"
+
+require_or_skip_runtime() {
+  local what="$1"
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "wasi cli stdin provider shadow FAILED: $what (required mode)" >&2
+    exit 1
+  fi
+  echo "[wasi-cli-stdin-provider-shadow] runtime SKIP: $what"
+  echo "wasi cli stdin provider shadow structural gate OK"
+  exit 0
+}
+
+command -v wasm-tools >/dev/null 2>&1 || {
+  echo "wasi cli stdin provider shadow FAILED: wasm-tools is required for generated structural validation" >&2
+  exit 1
+}
+
+COMPILER="${VIBE_STDIN_PROVIDER_GATE_COMPILER:-}"
+if [ -z "$COMPILER" ]; then
+  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
+  [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
+fi
+HARNESS="$OUT_DIR/dump.vibex"
+HARNESS_WASM="$OUT_DIR/dump.wasm"
+COMPONENT="$OUT_DIR/generated.component.wasm"
+PRINTED="$OUT_DIR/generated.wat"
+WIT="$OUT_DIR/generated.wit"
+cat >"$HARNESS" <<'EOF'
+import @vibe/compiler/entry/source_compile/wasi_only {
+  comp_emit_component_wasm_stdin_provider_shadow
+}
+
+fn main() -> Unit with Exception + Fs {
+  Fs::write_bytes("_build/bench/wasi_cli_stdin_provider_shadow/generated.component.wasm", comp_emit_component_wasm_stdin_provider_shadow())
+}
+EOF
+rm -f "$HARNESS_WASM" "$HARNESS_WASM.diag" "$COMPONENT"
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+  "$COMPILER" "$HARNESS" "$HARNESS_WASM" main >/dev/null
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke main "$HARNESS_WASM" >/dev/null
+
+wasm-tools validate --features all "$COMPONENT"
+wasm-tools print "$COMPONENT" >"$PRINTED"
+wasm-tools component wit "$COMPONENT" >"$WIT"
+
+# #1620's independently-derived 208-byte golden, now a shared exact prefix.
+PREFIX_SHA="$(dd if="$COMPONENT" bs=1 count=208 2>/dev/null | shasum -a 256 | awk '{print $1}')"
+[ "$PREFIX_SHA" = "9e0ecf27d3a3e5515f503f3fc0867e0ae5e02164adc32f279f9e6b1efd921c5e" ] || {
+  echo "wasi cli stdin provider shadow FAILED: exact nominal import prefix drifted ($PREFIX_SHA)" >&2
+  exit 1
+}
+grep -Fq 'import wasi:cli/types@0.3.0;' "$WIT"
+grep -Fq 'import wasi:cli/stdin@0.3.0;' "$WIT"
+grep -Fq 'read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;' "$WIT"
+grep -Fq '(core func (;0;) (canon lower (func 0) (memory 0)))' "$PRINTED"
+grep -Fq 'canon stream.read 3 async (memory 0)' "$PRINTED"
+grep -Fq 'canon future.read 5 async (memory 0)' "$PRINTED"
+grep -Fq 'stdin-provider-shadow-acquire' "$PRINTED"
+grep -Fq 'stdin-provider-shadow-settle' "$PRINTED"
+grep -Fq 'forced-completion-tag-control' "$PRINTED"
+grep -Fq 'foreign-provider-control' "$PRINTED"
+if grep -Fq 'host_stream_get$stdin' "$PRINTED" || grep -Fq 'host_stream_close' "$PRINTED"; then
+  echo "wasi cli stdin provider shadow FAILED: generic HostStream machinery leaked into shadow" >&2
+  exit 1
+fi
+# Both BLOCKED branches encode join(handle,set), wait, join(handle,0), set.drop.
+[ "$(grep -c 'call 6' "$PRINTED")" -ge 4 ]
+[ "$(grep -c 'call 8' "$PRINTED")" -eq 2 ]
+echo "[wasi-cli-stdin-provider-shadow] generated component validate/WIT/prefix/structure OK"
+
+WASMTIME_BIN="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
+[ -n "$WASMTIME_BIN" ] || require_or_skip_runtime "wasmtime not installed"
+WASMTIME_VERSION="$("$WASMTIME_BIN" --version 2>/dev/null || true)"
+case "$WASMTIME_VERSION" in
+  "wasmtime 47.0.2"\ *) ;;
+  *) require_or_skip_runtime "requires wasmtime 47.0.2, got ${WASMTIME_VERSION:-unavailable}" ;;
+esac
+
+INPUT="$OUT_DIR/stdin-10-15-17.bin"
+printf '\012\017\021' >"$INPUT"
+FLAGS=(-Sp3 -W component-model-async=y -W component-model-async-stackful=y -W component-model-more-async-builtins=y)
+run_success() {
+  local lane="$1" expected="$2"
+  local log="$OUT_DIR/run.$lane.log"
+  if ! timeout 60 "$WASMTIME_BIN" run "${FLAGS[@]}" --invoke "$lane()" "$COMPONENT" <"$INPUT" >"$log" 2>&1; then
+    if grep -Eq 'component imports instance .wasi:cli/stdin@0\.3\.0., but a matching implementation was not found in (the )?linker' "$log"; then
+      require_or_skip_runtime "wasmtime has no matching wasi:cli/stdin@0.3.0 implementation"
+    fi
+    cat "$log" >&2
+    echo "wasi cli stdin provider shadow FAILED: $lane did not exit 0" >&2
+    exit 1
+  fi
+  [ "$(cat "$log")" = "$expected" ] || {
+    echo "wasi cli stdin provider shadow FAILED: $lane expected $expected, got $(cat "$log")" >&2
+    exit 1
+  }
+  echo "[wasi-cli-stdin-provider-shadow] $lane: $expected"
+}
+run_trap() {
+  local lane="$1"
+  local log="$OUT_DIR/run.$lane.log"
+  if timeout 60 "$WASMTIME_BIN" run "${FLAGS[@]}" --invoke "$lane()" "$COMPONENT" <"$INPUT" >"$log" 2>&1; then
+    echo "wasi cli stdin provider shadow FAILED: $lane unexpectedly succeeded" >&2
+    exit 1
+  fi
+  grep -Eqi 'unreachable|wasm trap' "$log" || {
+    echo "wasi cli stdin provider shadow FAILED: $lane failed without the expected trap" >&2
+    cat "$log" >&2
+    exit 1
+  }
+  echo "[wasi-cli-stdin-provider-shadow] $lane: expected trap"
+}
+
+run_success drain 42
+run_success early-close 43
+run_trap forced-completion-tag-control
+run_trap foreign-provider-control
+
+echo "wasi cli stdin provider shadow component gate OK (wasmtime 47.0.2)"

--- a/scripts/test_wasi_cli_stdin_provider_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_component_gate.sh
@@ -3,15 +3,17 @@
 # Structural checks always cover the exact nominal import prefix, synchronous
 # memory-bearing read-via-stream lower, private adapter/scenario surface, and
 # component WIT. Wasmtime 47.0.2 additionally runs drain/early-close and the
-# two expected-trap controls when its ratified stdin provider is available.
-# The forced completion tag is a control of cleanup/fail-closed code, not a
-# measurement of a provider-generated completion error.
+# expected-trap controls when its ratified stdin provider is available. The
+# forced completion tag and byte-mismatch controls exercise cleanup/fail-closed
+# code; they do not measure provider-generated errors.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
-OUT_DIR="${OUT_DIR:-$PROJECT_ROOT/_build/bench/wasi_cli_stdin_provider_shadow}"
+# Keep this fixed because the generated Vibe harness writes the same path.
+# There is intentionally no OUT_DIR override with a divergent guest target.
+OUT_DIR="$PROJECT_ROOT/_build/bench/wasi_cli_stdin_provider_shadow"
 mkdir -p "$OUT_DIR"
 
 require_or_skip_runtime() {
@@ -32,7 +34,13 @@ command -v wasm-tools >/dev/null 2>&1 || {
 
 COMPILER="${VIBE_STDIN_PROVIDER_GATE_COMPILER:-}"
 if [ -z "$COMPILER" ]; then
-  COMPILER="$(ls -td "$PROJECT_ROOT"/_build/selfhost/generations/*/ 2>/dev/null | head -1 || true)stage2.wasm"
+  shopt -s nullglob
+  for candidate in "$PROJECT_ROOT"/_build/selfhost/generations/*/stage2.wasm; do
+    if [ -z "$COMPILER" ] || [ "$candidate" -nt "$COMPILER" ]; then
+      COMPILER="$candidate"
+    fi
+  done
+  shopt -u nullglob
   [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
 fi
 HARNESS="$OUT_DIR/dump.vibex"
@@ -76,6 +84,10 @@ grep -Fq 'stdin-provider-shadow-acquire' "$PRINTED"
 grep -Fq 'stdin-provider-shadow-settle' "$PRINTED"
 grep -Fq 'forced-completion-tag-control' "$PRINTED"
 grep -Fq 'foreign-provider-control' "$PRINTED"
+grep -Fq 'wrong-byte-cleanup-control' "$PRINTED"
+grep -Fq 'extra-byte-cleanup-control' "$PRINTED"
+# The dollar sign is part of the literal canonical import name.
+# shellcheck disable=SC2016
 if grep -Fq 'host_stream_get$stdin' "$PRINTED" || grep -Fq 'host_stream_close' "$PRINTED"; then
   echo "wasi cli stdin provider shadow FAILED: generic HostStream machinery leaked into shadow" >&2
   exit 1
@@ -83,6 +95,25 @@ fi
 # Both BLOCKED branches encode join(handle,set), wait, join(handle,0), set.drop.
 [ "$(grep -c 'call 6' "$PRINTED")" -ge 4 ]
 [ "$(grep -c 'call 8' "$PRINTED")" -eq 2 ]
+# Scenario mismatch traps must be immediately preceded by close(id) and its
+# result local.set. These fixed indices are part of this byte-level shadow gate.
+check_cleanup_before_traps() {
+  local func_idx="$1" expected_traps="$2"
+  local body="$OUT_DIR/func-$func_idx.wat"
+  sed -n "/    (func (;$func_idx;) (type 6)/,/^    )/p" "$PRINTED" >"$body"
+  awk -v expected="$expected_traps" '
+    /^        call 20$/ { close_line = NR }
+    /^        unreachable$/ {
+      traps += 1
+      if (close_line != NR - 2) bad = 1
+    }
+    END { exit !(traps == expected && bad != 1) }
+  ' "$body"
+}
+check_cleanup_before_traps 21 5 # drain wrong-byte + extra-byte diagnostics
+check_cleanup_before_traps 22 1 # post-close scenario diagnostic
+check_cleanup_before_traps 25 1 # wrong-byte cleanup control
+check_cleanup_before_traps 26 3 # extra-byte cleanup control and prefix guards
 echo "[wasi-cli-stdin-provider-shadow] generated component validate/WIT/prefix/structure OK"
 
 WASMTIME_BIN="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
@@ -132,5 +163,7 @@ run_success drain 42
 run_success early-close 43
 run_trap forced-completion-tag-control
 run_trap foreign-provider-control
+run_trap wrong-byte-cleanup-control
+run_trap extra-byte-cleanup-control
 
 echo "wasi cli stdin provider shadow component gate OK (wasmtime 47.0.2)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -9,8 +9,9 @@
 #            .vibe async entry -> component-model async component -> 42
 #   phase B  wasi:http p3 world (test_wasi_http_p3_full_gate.sh)
 #            componentize -> wac plug -> wasmtime serve -> curl 200/401
-#   phase C  wasi:cli/stdin lifecycle (test_wasi_cli_stdin_p3_probe_gate.sh)
-#            exact ratified import; drain-to-EOF and early-drop completion
+#   phase C  wasi:cli/stdin lifecycle
+#            generated shadow adapter + hand-WAT provider measurement; exact
+#            ratified import, drain-to-EOF, and early-drop completion
 #   phase D  WIT pin: the composed serve component's world must reference the
 #            pinned wasi:http version, so adapter/vendored-WIT/runtime drift
 #            fails loudly instead of as a mysterious resolution error.
@@ -73,6 +74,7 @@ case ",$PHASES," in *",http,"*)
 esac
 case ",$PHASES," in *",stdin,"*)
   echo "[p3-guarantee] phase C: wasi:cli/stdin lifecycle"
+  bash "$SCRIPT_DIR/test_wasi_cli_stdin_provider_component_gate.sh"
   bash "$SCRIPT_DIR/test_wasi_cli_stdin_p3_probe_gate.sh"
   ;;
 esac


### PR DESCRIPTION
## Summary
- add a production-unused shadow adapter for ratified stdin provider ownership
- retain stream and completion future behind provider-tagged opaque slots
- implement synchronous acquisition, Async read, and shared EOF/early-close settlement
- enforce join/wait/unjoin/drop ordering and exactly-once stream/future cleanup
- fail closed after cleanup on unexpected completion/status paths
- add generated Wasmtime lifecycle and cleanup-control gates

No public Stdin API, linked compiler routing, generic HostStream behavior, or legacy `stdin_stream` behavior changes in this PR.

## Validation
- exact 208-byte nominal import golden: passed
- wasm-tools validate/print/WIT: passed
- pinned Wasmtime 47.0.2: drain 42, early-close 43, four cleanup controls trapped as expected
- hand-WAT lifecycle parity: passed
- named HostStream regression gate: passed
- shellcheck/bash-n, formatter, freshness, diff: passed
- `pkf run test-local`: 218/545 affected tests passed
- independent ownership/lifecycle review: safe to integrate

Full `pkf run test` reached the known BSD xargs command-line-too-long harness failure; no related assertion failed.

Refs #1539