### PR TITLE
compiler: route checker-hidden stdin provider core imports

### DIFF
--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1522,7 +1522,7 @@ does **not** by itself complete the stdin lifecycle: the completion future must
 still be read, its result checked, and then released. This corrects the stale
 short-hand that described stream drop alone as a completed stdin close.
 
-#### Provider-aware contract (implemented only as a production-unused shadow)
+#### Provider-aware contract (shadow lifecycle + checker-hidden core route)
 
 The #1539 prerequisite is a distinct, opaque provider-aware handle whose
 adapter state retains both owned ends from `read-via-stream`:
@@ -1558,13 +1558,30 @@ future or silently report a failed lifecycle as a successful close.
 
 #### Staged prerequisite and invariants
 
-Stages 1--3 are implemented only by the production-unused shadow emitter
+Stages 1--3 were first implemented by the production-unused shadow emitter
 `comp_emit_component_wasm_stdin_provider_shadow` and its private component
-scenarios. It is intentionally not routed by `linked_compile`, checker,
-runtime, console, `stdin_stream`, generic HostStream, or any public API.
-Stage 4 therefore remains undecided. The shadow is structural/runtime gate
-evidence for the internal prerequisite, not a claim that Vibe programs can
-consume stdin through it:
+scenarios. #1539 now also has a bounded **core-only** route: `linked_compile`
+reserves checker-invisible raw rows for exact core imports
+`vibe.stdin_provider_acquire () -> i64`, `stdin_provider_read (i64) -> i64`,
+and `stdin_provider_close (i64) -> i64`; the stdin-first wrapper sniffs parsed
+module/name pairs and the dedicated arbitrary-core composer validates exact
+signatures before composing the nominal stdin/types imports.
+
+The guest receives only a tagged-i64 bridge instance. The bridge rejects odd
+or high-bit-aliased wire IDs before i32 narrowing, and only then calls the
+proven opaque lifecycle functions. The full shadow instance, scenario exports,
+canonical stream handle, and completion-future handle never cross into the
+compiled guest. The bridge ABI is `wire = value << 1`; read returns tagged
+bytes or tagged `-1` after settlement and close returns tagged zero.
+
+This does **not** make the route source-reachable: all three registry rows have
+`checker_visible=false`, there is no AST lowering that injects them, and no
+`Stdin`/`ByteStream` API was added. This is deliberate authority preservation,
+not missing plumbing. `stdin_stream`, generic HostStream, and named
+future/stream behavior remain unchanged. A core that mixes the provider imports
+with named future/stream imports is explicitly rejected in this bounded slice.
+Stage 4 (public authority/type/error and effect-level Suspend-token lowering)
+therefore remains undecided:
 
 
 1. **ABI boundary:** introduce a provider-specific lowering/adapter route for
@@ -1602,13 +1619,19 @@ Load-bearing invariants for stages 1--3:
   transition, never EOF or successful close. Public propagation remains
   intentionally undecided and fail-closed.
 
+The synthetic compiled-shaped drain and early-close cores are composed and
+validated by `test_wasi_cli_stdin_provider_guest_component_gate.sh`; they check
+bytes 10/15/17, EOF/repeated reads, early settlement, and repeated close on the
+pinned Wasmtime 47.0.2 lane. The original shadow gate and exact 208-byte nominal
+prefix remain separately preserved.
+
 This is only the successful-close lifecycle slice. **Read-error injection is
 unmeasured** (`io`, `illegal-byte-sequence`, and `pipe` have no claimed runtime
 measurement). The forced completion-tag, wrong-byte, and extra-byte
 expected-trap scenarios are controls of cleanup/fail-closed branches, not
 measurements of provider-generated errors. Each byte-mismatch control settles
 and drops both owned ends through the shared close path before trapping. This
-work makes no runtime, console, or public compiler-routing change.
+work makes no runtime, console, or checker-visible/source API change.
 
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 
@@ -1782,7 +1805,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 |---|---|---|
 | **suspend lowering の適格性** (#1536) | row-variable callee と literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow、eager `await(Stream::next(s))` retarget、sequence-HEAD let 連鎖の float (`for` 駆動 terminal) は済み (§2.2 末尾) | — (ADR-0076 本体) |
 | **AsyncIter への一本化** (#1538) | eager `Stream[T]` combinator の退役 / AsyncIter 上への再実装。`Stream::next` protocol と host stream read の接続 | 上の適格性 |
-| **stdin provider / `ByteStream` の p3 接続** (#1539) | **shadow 前提のみ実装**: production-unused emitter が ratified `read-via-stream` の stream + completion future を opaque provider handle に保持し、EOF/early close を Async settlement する (§3.18.3)。public routing と既存 `stdin_stream(chunk_size)` は未変更 | generated shadow + merged stdin lifecycle probe/gate (§3.18.3); generic `[3, handle]` `HostStream` は使えない |
+| **stdin provider / `ByteStream` の p3 接続** (#1539) | **checker-hidden core route まで実装**: shadow lifecycle に加え、exact `vibe.stdin_provider_*` raw imports、tagged-i64 bridge、任意 core composer、stdin-first sniff を実装。raw rows は checker-invisible で public/source lowering は未決定、既存 `stdin_stream(chunk_size)` は未変更 (§3.18.3) | generated shadow + compiled-shaped drain/early-close gate; generic `[3, handle]` `HostStream` は使わず、named future/stream との mix は明示拒否 |
 | **実 provider = `wasi:http` incoming-body** (#1540) | serve composition と host-stream composition の統合が要る (§3.19 に構造的な理由と 3 点の分解) | — |
 | **M-conc-2: 真の subtask spawn** (#1537) | waitable-set / `future.cancel-*` による実並行・キャンセル。ADR-0068 の nursery を backend へ落とす | ADR-0076 CPS/suspend lowering |
 | **M1b-3c-1c: interleaving spawn の emitter** (#1537) | ABI 側の問いは §3.11 で解決済み (`waitable-set.wait` の完了順ディスパッチだけで足りる)。残るのは await をまたぐ task 状態の表現 = ADR-0076 の CPS/suspend lowering | 同上 |

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3896,6 +3896,13 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   // module bytes are unchanged -- the injected `__hs_close` is the only
   // caller, and it only exists when the source called `host_stream_close`.
   let need_host_stream_close_builtin = Map::has_key(used_builtin_names, "vibe_hs_close_raw")
+  // #1539 core-only stdin provider route. The registry names are checker-
+  // invisible and therefore only compiler-injected/raw AST can request these
+  // imports. Keep each half independently gated so unused registry rows do not
+  // widen a component's authority.
+  let need_stdin_provider_acquire_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_acquire_raw")
+  let need_stdin_provider_read_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_read_raw")
+  let need_stdin_provider_close_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_close_raw")
   // Process effect host imports: `sh(cmd)` runs a shell command (returns 0) and
   // `sh_lines(cmd)` returns its stdout "\n"-joined as ONE string (same packed
   // ABI as fs_read_dir; compile_call lowers the Array[String] surface to a
@@ -4156,6 +4163,29 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
     -1
   }
   let hs_close_import_idx = if need_host_stream_close_builtin {
+    let idx = next_import_idx
+    next_import_idx = next_import_idx + 1
+    idx
+  } else {
+    -1
+  }
+  // #1539: exact private provider imports follow the generic host-stream
+  // pair. This is a separate lifecycle/authority band, not HostStream.
+  let stdin_provider_acquire_import_idx = if need_stdin_provider_acquire_builtin {
+    let idx = next_import_idx
+    next_import_idx = next_import_idx + 1
+    idx
+  } else {
+    -1
+  }
+  let stdin_provider_read_import_idx = if need_stdin_provider_read_builtin {
+    let idx = next_import_idx
+    next_import_idx = next_import_idx + 1
+    idx
+  } else {
+    -1
+  }
+  let stdin_provider_close_import_idx = if need_stdin_provider_close_builtin {
     let idx = next_import_idx
     next_import_idx = next_import_idx + 1
     idx
@@ -4664,6 +4694,23 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   } else {
     fs_read_file_stub_idx
   }
+  // #1539 private stdin-provider call targets. Their shapes match the
+  // existing never-called ()->i64 and (i64)->i64 fallbacks.
+  let stdin_provider_acquire_idx = if stdin_provider_acquire_import_idx >= 0 {
+    stdin_provider_acquire_import_idx
+  } else {
+    env_args_len_idx
+  }
+  let stdin_provider_read_idx = if stdin_provider_read_import_idx >= 0 {
+    stdin_provider_read_import_idx
+  } else {
+    fs_read_file_stub_idx
+  }
+  let stdin_provider_close_idx = if stdin_provider_close_import_idx >= 0 {
+    stdin_provider_close_import_idx
+  } else {
+    fs_read_file_stub_idx
+  }
   // sh / sh_lines call targets: the import when reserved, else the fs_read_file
   // stub (a `(i64)->i64` never-called placeholder) — the real call site only
   // exists when the import is reserved (i.e. when the program uses sh/sh_lines).
@@ -4982,6 +5029,10 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
         // ADR-0089 Decision 3 follow-up: shared drop half of the named host
         // streams (`host_stream_close` -> injected `__hs_close`).
         "vibe_hs_close_raw" => hs_close_idx,
+        // #1539 checker-hidden core-only stdin provider bridge.
+        "vibe_stdin_provider_acquire_raw" => stdin_provider_acquire_idx,
+        "vibe_stdin_provider_read_raw" => stdin_provider_read_idx,
+        "vibe_stdin_provider_close_raw" => stdin_provider_close_idx,
         "simd_skip_ws" => simd_skip_ws_idx,
         "simd_scan_alnum" => simd_scan_alnum_idx,
         "simd_scan_alnum_str" => simd_scan_alnum_str_idx,
@@ -6906,6 +6957,32 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   if hs_close_import_idx >= 0 {
     emit_name(import_content, "vibe")
     emit_name(import_content, "host_stream_close")
+    bytebuf_push(import_content, 0)
+    leb128_encode_u32(import_content, 3)
+  } else {
+    ()
+  }
+  // #1539: the dedicated stdin provider route uses exact names and tagged
+  // i64s. It is intentionally separate from generic HostStream imports.
+  if stdin_provider_acquire_import_idx >= 0 {
+    emit_name(import_content, "vibe")
+    emit_name(import_content, "stdin_provider_acquire")
+    bytebuf_push(import_content, 0)
+    leb128_encode_u32(import_content, 5)
+  } else {
+    ()
+  }
+  if stdin_provider_read_import_idx >= 0 {
+    emit_name(import_content, "vibe")
+    emit_name(import_content, "stdin_provider_read")
+    bytebuf_push(import_content, 0)
+    leb128_encode_u32(import_content, 3)
+  } else {
+    ()
+  }
+  if stdin_provider_close_import_idx >= 0 {
+    emit_name(import_content, "vibe")
+    emit_name(import_content, "stdin_provider_close")
     bytebuf_push(import_content, 0)
     leb128_encode_u32(import_content, 3)
   } else {

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -268,6 +268,14 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   // codegen-internal shape as the read half (injected `__hs_close` only),
   // and NOT async: dropping a readable end never blocks.
   ("vibe_hs_close_raw", CtFn(reg_p1(CtInt), CtInt, None), true, false, false),
+  // #1539 core-only stdin provider route. These names are deliberately
+  // checker-invisible: they are reserved for compiler-generated/raw core
+  // calls and must not become a source-level authority surface. The component
+  // adapter owns the nominal stream plus completion future behind an opaque
+  // provider ID; it never exposes either canonical handle as HostStream.
+  ("vibe_stdin_provider_acquire_raw", CtFn(reg_p0(), CtInt, None), true, false, false),
+  ("vibe_stdin_provider_read_raw", CtFn(reg_p1(CtInt), CtInt, None), true, false, false),
+  ("vibe_stdin_provider_close_raw", CtFn(reg_p1(CtInt), CtInt, None), true, false, false),
   ("Stdin::read_char", CtFn(reg_p0(), CtInt, Some("Stdin")), true, false, true),
   ("simd_skip_ws", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),
   ("simd_scan_alnum", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -3902,63 +3902,81 @@ fn comp_generate_stdin_provider_synthetic_core(mode: Int) -> Bytes {
   leb128_encode_u32(body, 1)
   leb128_encode_u32(body, 1)
   bytebuf_push(body, 126)
-  emit_call(body, 1)
-  emit_local_set(body, 1)
-  let expected = if mode == 0 {
-    [
-      20,
-      30,
-      34,
-      -2,
+  if mode < 2 {
+    emit_call(body, 1)
+    emit_local_set(body, 1)
+    let expected = if mode == 0 {
+      [
+        20,
+        30,
+        34,
+        -2,
+        -2
+      ]
+    } else {
+      [
+        20
+      ]
+    }
+    let mut ei = 0
+    while ei < Array::length(expected) {
+      emit_local_get(body, 1)
+      emit_call(body, 2)
+      emit_i64_const(body, Array::get(expected, ei))
+      bytebuf_push(body, 82)
+      // i64.ne
+      emit_if_void(body)
+      bytebuf_push(body, 0)
+      emit_end(body)
+      ei = ei + 1
+    }
+    emit_local_get(body, 1)
+    emit_call(body, 3)
+    emit_i64_const(body, 0)
+    bytebuf_push(body, 82)
+    emit_if_void(body)
+    bytebuf_push(body, 0)
+    emit_end(body)
+    emit_local_get(body, 1)
+    emit_call(body, 3)
+    emit_i64_const(body, 0)
+    bytebuf_push(body, 82)
+    emit_if_void(body)
+    bytebuf_push(body, 0)
+    emit_end(body)
+    if mode != 0 {
+      emit_local_get(body, 1)
+      emit_call(body, 2)
+      emit_i64_const(body, -2)
+      bytebuf_push(body, 82)
+      emit_if_void(body)
+      bytebuf_push(body, 0)
+      emit_end(body)
+    } else {
+      ()
+    }
+    emit_i64_const(body, if mode == 0 {
+      42
+    } else {
+      43
+    })
+  } else {
+    // Expected-trap controls call read directly with malformed tagged wires:
+    // odd, positive above u32, and signed high-bit respectively. The bridge
+    // decode must reject each before calling the lifecycle shadow.
+    emit_i64_const(body, if mode == 2 {
+      1
+    } else if mode == 3 {
+      4294967296
+    } else {
       -2
-    ]
-  } else {
-    [
-      20
-    ]
-  }
-  let mut ei = 0
-  while ei < Array::length(expected) {
-    emit_local_get(body, 1)
+    })
     emit_call(body, 2)
-    emit_i64_const(body, Array::get(expected, ei))
-    bytebuf_push(body, 82)
-    // i64.ne
-    emit_if_void(body)
+    bytebuf_push(body, 26)
+    // If validation accidentally returns, keep the control fail-closed.
     bytebuf_push(body, 0)
-    emit_end(body)
-    ei = ei + 1
+    emit_i64_const(body, 0)
   }
-  emit_local_get(body, 1)
-  emit_call(body, 3)
-  emit_i64_const(body, 0)
-  bytebuf_push(body, 82)
-  emit_if_void(body)
-  bytebuf_push(body, 0)
-  emit_end(body)
-  emit_local_get(body, 1)
-  emit_call(body, 3)
-  emit_i64_const(body, 0)
-  bytebuf_push(body, 82)
-  emit_if_void(body)
-  bytebuf_push(body, 0)
-  emit_end(body)
-  if mode != 0 {
-    emit_local_get(body, 1)
-    emit_call(body, 2)
-    emit_i64_const(body, -2)
-    bytebuf_push(body, 82)
-    emit_if_void(body)
-    bytebuf_push(body, 0)
-    emit_end(body)
-  } else {
-    ()
-  }
-  emit_i64_const(body, if mode == 0 {
-    42
-  } else {
-    43
-  })
   bytebuf_push(body, 11)
   // Write this body's section directly because it has an explicit local.
   let code = bytebuf_new()
@@ -5608,7 +5626,8 @@ export fn comp_emit_component_wasm_async_stdin_provider(main_core_wasm: Bytes, e
   bytebuf_to_bytes(buf)
 }
 
-/// Internal runtime-gate fixture: 0=drain (42), 1=early close (43).
+/// Internal runtime-gate fixture: 0=drain (42), 1=early close (43), and
+/// 2/3/4=odd/out-of-u32/high-bit malformed tagged-wire trap controls.
 export fn comp_emit_component_wasm_async_stdin_provider_fixture(mode: Int) -> Bytes with Exception {
   comp_emit_component_wasm_async_stdin_provider(comp_generate_stdin_provider_synthetic_core(mode), "run")
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -3699,6 +3699,276 @@ fn comp_generate_stdin_provider_adapter_core_module() -> Bytes {
   bytebuf_to_bytes(out)
 }
 
+/// #1539 tagged-i64 bridge over the proven shadow lifecycle. The guest sees
+/// only these three exports; canonical stream/future handles and the shadow's
+/// scenario exports remain confined to private component instances.
+fn comp_generate_stdin_provider_tagged_bridge_core_module() -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  // 0 ()->i32; 1 (i32)->i32; 2 ()->i64; 3 (i64)->i64;
+  // 4 (i64)->i32 (validated decode helper).
+  let tc = bytebuf_new()
+  bytebuf_push_vec_header(tc, 5)
+  emit_func_type_raw(tc, array_empty(), [
+    127
+  ])
+  emit_func_type_raw(tc, [
+    127
+  ], [
+    127
+  ])
+  emit_func_type_raw(tc, array_empty(), [
+    126
+  ])
+  emit_func_type_raw(tc, [
+    126
+  ], [
+    126
+  ])
+  emit_func_type_raw(tc, [
+    126
+  ], [
+    127
+  ])
+  bytebuf_push_section(out, 1, tc)
+  let ic = bytebuf_new()
+  bytebuf_push_vec_header(ic, 3)
+  let shadow_names = [
+    "stdin-provider-shadow-acquire",
+    "stdin-provider-shadow-read",
+    "stdin-provider-shadow-close"
+  ]
+  let shadow_types = [
+    0,
+    1,
+    1
+  ]
+  let mut ii = 0
+  while ii < 3 {
+    emit_name(ic, "shadow")
+    emit_name(ic, Array::get(shadow_names, ii))
+    bytebuf_push(ic, 0)
+    leb128_encode_u32(ic, Array::get(shadow_types, ii))
+    ii = ii + 1
+  }
+  bytebuf_push_section(out, 2, ic)
+  // imports 0..2; locals 3=decode, 4=acquire, 5=read, 6=close.
+  emit_function_section(out, [
+    4,
+    2,
+    3,
+    3
+  ])
+  emit_export_section_multi(out, [
+    "stdin_provider_acquire",
+    "stdin_provider_read",
+    "stdin_provider_close"
+  ], [
+    4,
+    5,
+    6
+  ])
+  let code = bytebuf_new()
+  leb128_encode_u32(code, 4)
+  // decode(wire): tagged integers are even. Reject every value above the
+  // largest non-negative i32 wire value before i32.wrap_i64, so malformed
+  // high bits cannot alias a valid provider ID during narrowing.
+  let decode = bytebuf_new()
+  leb128_encode_u32(decode, 0)
+  emit_local_get(decode, 0)
+  emit_i64_const(decode, 1)
+  bytebuf_push(decode, 131)
+  // i64.and
+  bytebuf_push(decode, 80)
+  // i64.eqz
+  emit_i32_eqz(decode)
+  emit_if_void(decode)
+  bytebuf_push(decode, 0)
+  emit_end(decode)
+  emit_local_get(decode, 0)
+  emit_i64_const(decode, 4294967294)
+  bytebuf_push(decode, 86)
+  // i64.gt_u
+  emit_if_void(decode)
+  bytebuf_push(decode, 0)
+  emit_end(decode)
+  emit_local_get(decode, 0)
+  emit_i64_const(decode, 1)
+  emit_i64_shr_s(decode)
+  emit_i32_wrap_i64(decode)
+  bytebuf_push(decode, 11)
+  leb128_encode_u32(code, Bytes::length(decode))
+  bytebuf_push_buf(code, decode)
+  let acquire = bytebuf_new()
+  leb128_encode_u32(acquire, 0)
+  emit_call(acquire, 0)
+  bytebuf_push(acquire, 173)
+  // i64.extend_i32_u
+  emit_i64_const(acquire, 1)
+  emit_i64_shl(acquire)
+  bytebuf_push(acquire, 11)
+  leb128_encode_u32(code, Bytes::length(acquire))
+  bytebuf_push_buf(code, acquire)
+  let read = bytebuf_new()
+  leb128_encode_u32(read, 0)
+  emit_local_get(read, 0)
+  emit_call(read, 3)
+  emit_call(read, 1)
+  bytebuf_push(read, 172)
+  // i64.extend_i32_s (preserves EOF = -1)
+  emit_i64_const(read, 1)
+  emit_i64_shl(read)
+  bytebuf_push(read, 11)
+  leb128_encode_u32(code, Bytes::length(read))
+  bytebuf_push_buf(code, read)
+  let close = bytebuf_new()
+  leb128_encode_u32(close, 0)
+  emit_local_get(close, 0)
+  emit_call(close, 3)
+  emit_call(close, 2)
+  bytebuf_push(close, 26)
+  // drop shadow's i32 zero
+  emit_i64_const(close, 0)
+  bytebuf_push(close, 11)
+  leb128_encode_u32(code, Bytes::length(close))
+  bytebuf_push_buf(code, close)
+  bytebuf_push_section(out, 10, code)
+  bytebuf_to_bytes(out)
+}
+
+/// A compiled-shaped synthetic guest for the runtime gate. It imports the
+/// exact private provider ABI plus the ordinary preview1 fd_write preamble and
+/// exports `run : (i64) -> i64`. Mode 0 drains 10/15/17 through EOF; mode 1
+/// consumes one byte then closes early. Every observed value is checked in
+/// core wasm before returning 42/43.
+fn comp_generate_stdin_provider_synthetic_core(mode: Int) -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  let tc = bytebuf_new()
+  bytebuf_push_vec_header(tc, 4)
+  emit_func_type_raw(tc, [
+    127,
+    127,
+    127,
+    127
+  ], [
+    127
+  ])
+  emit_func_type_raw(tc, array_empty(), [
+    126
+  ])
+  emit_func_type_raw(tc, [
+    126
+  ], [
+    126
+  ])
+  emit_func_type_raw(tc, [
+    126
+  ], [
+    126
+  ])
+  bytebuf_push_section(out, 1, tc)
+  let ic = bytebuf_new()
+  bytebuf_push_vec_header(ic, 4)
+  emit_name(ic, "wasi_snapshot_preview1")
+  emit_name(ic, "fd_write")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 0)
+  let provider_names = [
+    "stdin_provider_acquire",
+    "stdin_provider_read",
+    "stdin_provider_close"
+  ]
+  let provider_types = [
+    1,
+    2,
+    2
+  ]
+  let mut ii = 0
+  while ii < 3 {
+    emit_name(ic, "vibe")
+    emit_name(ic, Array::get(provider_names, ii))
+    bytebuf_push(ic, 0)
+    bytebuf_push(ic, Array::get(provider_types, ii))
+    ii = ii + 1
+  }
+  bytebuf_push_section(out, 2, ic)
+  emit_function_section(out, [
+    3
+  ])
+  emit_export_section(out, "run", 4)
+  let body = bytebuf_new()
+  // one i64 local for the opaque tagged provider ID
+  leb128_encode_u32(body, 1)
+  leb128_encode_u32(body, 1)
+  bytebuf_push(body, 126)
+  emit_call(body, 1)
+  emit_local_set(body, 1)
+  let expected = if mode == 0 {
+    [
+      20,
+      30,
+      34,
+      -2,
+      -2
+    ]
+  } else {
+    [
+      20
+    ]
+  }
+  let mut ei = 0
+  while ei < Array::length(expected) {
+    emit_local_get(body, 1)
+    emit_call(body, 2)
+    emit_i64_const(body, Array::get(expected, ei))
+    bytebuf_push(body, 82)
+    // i64.ne
+    emit_if_void(body)
+    bytebuf_push(body, 0)
+    emit_end(body)
+    ei = ei + 1
+  }
+  emit_local_get(body, 1)
+  emit_call(body, 3)
+  emit_i64_const(body, 0)
+  bytebuf_push(body, 82)
+  emit_if_void(body)
+  bytebuf_push(body, 0)
+  emit_end(body)
+  emit_local_get(body, 1)
+  emit_call(body, 3)
+  emit_i64_const(body, 0)
+  bytebuf_push(body, 82)
+  emit_if_void(body)
+  bytebuf_push(body, 0)
+  emit_end(body)
+  if mode != 0 {
+    emit_local_get(body, 1)
+    emit_call(body, 2)
+    emit_i64_const(body, -2)
+    bytebuf_push(body, 82)
+    emit_if_void(body)
+    bytebuf_push(body, 0)
+    emit_end(body)
+  } else {
+    ()
+  }
+  emit_i64_const(body, if mode == 0 {
+    42
+  } else {
+    43
+  })
+  bytebuf_push(body, 11)
+  // Write this body's section directly because it has an explicit local.
+  let code = bytebuf_new()
+  leb128_encode_u32(code, 1)
+  leb128_encode_u32(code, Bytes::length(body))
+  bytebuf_push_buf(code, body)
+  bytebuf_push_section(out, 10, code)
+  bytebuf_to_bytes(out)
+}
+
 /// Emit the production-unused #1539 shadow component. Its first 208 bytes are
 /// exactly comp_emit_wasi_cli_stdin_import_surface_for_test(). Scenario exports
 /// are private gates, not a Stdin effect or HostStream API.
@@ -5047,6 +5317,300 @@ fn comp_generate_async_trampoline_hostfuture() -> Bytes {
     body
   ])
   bytebuf_to_bytes(out)
+}
+
+fn comp_core_sig_is_p0_i64(sig: Array[Int]) -> Bool {
+  Array::length(sig) == 3 && Array::get(sig, 0) == 0 && Array::get(sig, 1) == 1 && Array::get(sig, 2) == 126
+}
+
+fn comp_core_sig_is_p1_i64_i64(sig: Array[Int]) -> Bool {
+  Array::length(sig) == 4 && Array::get(sig, 0) == 1 && Array::get(sig, 1) == 126 && Array::get(sig, 2) == 1 && Array::get(sig, 3) == 126
+}
+
+fn comp_core_sig_is_fd_write(sig: Array[Int]) -> Bool {
+  Array::length(sig) == 7 && Array::get(sig, 0) == 4 && Array::get(sig, 1) == 127 && Array::get(sig, 2) == 127 && Array::get(sig, 3) == 127 && Array::get(sig, 4) == 127 && Array::get(sig, 5) == 1 && Array::get(sig, 6) == 127
+}
+
+fn comp_is_stdin_provider_import_name(name: String) -> Bool {
+  name == "stdin_provider_acquire" || name == "stdin_provider_read" || name == "stdin_provider_close"
+}
+
+/// #1539 exact parsed-import routing key. A malformed exact provider import
+/// still returns true so the stdin composer, rather than an unrelated wrapper,
+/// produces the actionable signature diagnostic.
+export fn comp_core_imports_stdin_provider(core_wasm: Bytes) -> Bool {
+  let modules = array_empty()
+  let names = array_empty()
+  let indices = new_int_array()
+  let sigs = array_empty()
+  let count = parse_core_imports(core_wasm, modules, names, indices, sigs)
+  let mut found = false
+  let mut i = 0
+  while i < count {
+    if Array::get(modules, i) == "vibe" && comp_is_stdin_provider_import_name(Array::get(names, i)) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// #1539 bounded arbitrary-core composer. The nominal stdin instance and
+/// canonical handles terminate at the shadow lifecycle instance; a distinct
+/// tagged-i64 bridge is the only `vibe` instance passed to the compiled guest.
+export fn comp_emit_component_wasm_async_stdin_provider(main_core_wasm: Bytes, export_name: String) -> Bytes with Exception {
+  let export_names = array_empty()
+  let export_func_indices = new_int_array()
+  let export_sigs = array_empty()
+  let _ = parse_core_exports(main_core_wasm, export_names, export_func_indices, export_sigs)
+  let mut run_ok = false
+  let mut ei = 0
+  while ei < Array::length(export_names) {
+    if Array::get(export_names, ei) == "run" {
+      let sig = Array::get(export_sigs, ei)
+      run_ok = Array::length(sig) == 4 && Array::get(sig, 0) == 1 && Array::get(sig, 1) == 126 && Array::get(sig, 2) == 1 && Array::get(sig, 3) == 126
+    } else {
+      ()
+    }
+    ei = ei + 1
+  }
+  if !run_ok {
+    throw("component(async-stdin-provider): core module must export 'run : (i64) -> i64' (compile with entry name \"run\")")
+  } else {
+    ()
+  }
+  let modules = array_empty()
+  let names = array_empty()
+  let indices = new_int_array()
+  let sigs = array_empty()
+  let count = parse_core_imports(main_core_wasm, modules, names, indices, sigs)
+  // Diagnose the bounded-slice composition conflict before the allowlist walk:
+  // linked_compile emits the shared stream/future operations before some
+  // per-name getters, so waiting for declaration order could produce a generic
+  // unsupported-import error instead of the required explicit rejection.
+  if comp_core_imports_host_future(main_core_wasm) || comp_core_imports_host_stream(main_core_wasm) {
+    throw("component(async-stdin-provider): mixing stdin-provider imports with named host future/stream imports is not supported in this bounded route")
+  } else {
+    ()
+  }
+  let mut acquire_count = 0
+  let mut read_count = 0
+  let mut close_count = 0
+  let mut i = 0
+  while i < count {
+    let module_name = Array::get(modules, i)
+    let name = Array::get(names, i)
+    let type_idx = Array::get(indices, i)
+    if type_idx < 0 || type_idx >= Array::length(sigs) {
+      throw("component(async-stdin-provider): import '\{module_name}.\{name}' has an invalid core type index")
+    } else {
+      ()
+    }
+    let sig = Array::get(sigs, type_idx)
+    if module_name == "wasi_snapshot_preview1" && name == "fd_write" {
+      if !comp_core_sig_is_fd_write(sig) {
+        throw("component(async-stdin-provider): wasi_snapshot_preview1.fd_write must have signature (i32, i32, i32, i32) -> i32")
+      } else {
+        ()
+      }
+    } else if module_name == "vibe" && name == "stdin_provider_acquire" {
+      acquire_count = acquire_count + 1
+      if !comp_core_sig_is_p0_i64(sig) {
+        throw("component(async-stdin-provider): vibe.stdin_provider_acquire must have signature () -> i64")
+      } else {
+        ()
+      }
+    } else if module_name == "vibe" && name == "stdin_provider_read" {
+      read_count = read_count + 1
+      if !comp_core_sig_is_p1_i64_i64(sig) {
+        throw("component(async-stdin-provider): vibe.stdin_provider_read must have signature (i64) -> i64")
+      } else {
+        ()
+      }
+    } else if module_name == "vibe" && name == "stdin_provider_close" {
+      close_count = close_count + 1
+      if !comp_core_sig_is_p1_i64_i64(sig) {
+        throw("component(async-stdin-provider): vibe.stdin_provider_close must have signature (i64) -> i64")
+      } else {
+        ()
+      }
+    } else {
+      throw("component(async-stdin-provider): core module uses host import '\{module_name}.\{name}' (only fd_write and the three exact vibe.stdin_provider_* imports are satisfiable)")
+    }
+    i = i + 1
+  }
+  if acquire_count > 1 || read_count > 1 || close_count > 1 {
+    throw("component(async-stdin-provider): duplicate stdin-provider core import")
+  } else if acquire_count == 0 {
+    throw("component(async-stdin-provider): stdin_provider_read/close requires exactly one stdin_provider_acquire import")
+  } else if read_count + close_count == 0 {
+    throw("component(async-stdin-provider): stdin_provider_acquire requires at least one consuming read or close import")
+  } else {
+    ()
+  }
+  let buf = bytebuf_new()
+  emit_component_header(buf)
+  // Keep #1620/#1623's exact 208-byte nominal prefix first.
+  emit_comp_wasi_cli_stdin_import_prefix(buf)
+  // modules: 0 main, 1 lifecycle shadow, 2 tagged bridge, 3 trampoline,
+  // 4 fd_write stub, 5 memhost.
+  emit_core_module_section(buf, main_core_wasm)
+  emit_core_module_section(buf, comp_generate_stdin_provider_adapter_core_module())
+  emit_core_module_section(buf, comp_generate_stdin_provider_tagged_bridge_core_module())
+  emit_core_module_section(buf, comp_generate_async_trampoline_hostfuture())
+  emit_core_module_section(buf, comp_generate_wasi_fd_write_stub())
+  emit_core_module_section(buf, comp_generate_memhost_module())
+  let memhost_inst = 0
+  emit_core_instance_instantiate_section(buf, 5, array_empty())
+  let mem_alias_idx = 0
+  emit_alias_section(buf, memhost_inst, [
+    "memory"
+  ], [
+    core_sort_mem
+  ])
+  let stream_type_idx = 3
+  let completion_result_type_idx = 4
+  let completion_future_type_idx = 5
+  emit_comp_stream_type_section(buf, comp_valtype_u8)
+  emit_comp_result_error_type_section(buf, 1)
+  emit_comp_future_type_section(buf, completion_result_type_idx)
+  emit_canon_lower_memory_section(buf, 0, mem_alias_idx)
+  emit_canon_stream_read(buf, stream_type_idx, mem_alias_idx)
+  emit_canon_stream_drop_readable(buf, stream_type_idx)
+  emit_canon_future_read(buf, completion_future_type_idx, mem_alias_idx)
+  emit_canon_future_drop_readable(buf, completion_future_type_idx)
+  emit_canon_waitable_set_new(buf)
+  emit_canon_waitable_join(buf)
+  emit_canon_waitable_set_wait(buf, mem_alias_idx)
+  emit_canon_waitable_set_drop(buf)
+  emit_canon_task_return(buf, comp_valtype_u32)
+  let root_inst = 1
+  emit_core_instance_from_exports(buf, 1, [
+    9
+  ], [
+    "read-via-stream",
+    "[async-lower][stream-read-0]read-via-stream",
+    "[stream-drop-readable-0]read-via-stream",
+    "[async-lower][future-read-1]read-via-stream",
+    "[future-drop-readable-1]read-via-stream",
+    "[waitable-set-new]",
+    "[waitable-join]",
+    "[waitable-set-wait]",
+    "[waitable-set-drop]"
+  ], [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+  ])
+  // The scenario imports exist only because the proven lifecycle module is
+  // reused byte-for-byte. They all bind the same unreachable-from-production
+  // task-return function and are never passed to the main guest.
+  let export_root_inst = 2
+  emit_core_instance_from_exports(buf, 1, [
+    6
+  ], [
+    "[task-return]drain",
+    "[task-return]early-close",
+    "[task-return]forced-completion-tag-control",
+    "[task-return]foreign-provider-control",
+    "[task-return]wrong-byte-cleanup-control",
+    "[task-return]extra-byte-cleanup-control"
+  ], [
+    9,
+    9,
+    9,
+    9,
+    9,
+    9
+  ])
+  let env_inst = 3
+  emit_core_instance_from_exports_sorted(buf, [
+    "memory"
+  ], [
+    core_sort_mem
+  ], [
+    mem_alias_idx
+  ])
+  let shadow_inst = 4
+  emit_core_instance_instantiate_args(buf, 1, [
+    "$root",
+    "[export]$root",
+    "env"
+  ], [
+    root_inst,
+    export_root_inst,
+    env_inst
+  ])
+  let bridge_inst = 5
+  emit_core_instance_instantiate_args(buf, 2, [
+    "shadow"
+  ], [
+    shadow_inst
+  ])
+  let stub_inst = 6
+  emit_core_instance_instantiate_section(buf, 4, array_empty())
+  let main_inst = 7
+  emit_core_instance_instantiate_args(buf, 0, [
+    "wasi_snapshot_preview1",
+    "vibe"
+  ], [
+    stub_inst,
+    bridge_inst
+  ])
+  let main_run_func_idx = 10
+  emit_alias_section(buf, main_inst, [
+    "run"
+  ], [
+    core_sort_func
+  ])
+  let main_arg_inst = 8
+  emit_core_instance_from_exports(buf, 1, [
+    1
+  ], [
+    "run"
+  ], [
+    main_run_func_idx
+  ])
+  let cm_arg_inst = 9
+  emit_core_instance_from_exports(buf, 1, [
+    1
+  ], [
+    "task-return"
+  ], [
+    9
+  ])
+  let tramp_inst = 10
+  emit_core_instance_instantiate_args(buf, 3, [
+    "main",
+    "cm"
+  ], [
+    main_arg_inst,
+    cm_arg_inst
+  ])
+  let async_type_idx = 6
+  emit_comp_async_functype_section(buf, comp_valtype_u32)
+  let tramp_run_func_idx = 11
+  emit_alias_section(buf, tramp_inst, [
+    "run"
+  ], [
+    core_sort_func
+  ])
+  emit_canon_lift_async_section(buf, tramp_run_func_idx, async_type_idx)
+  emit_comp_export_section(buf, export_name, 1)
+  bytebuf_to_bytes(buf)
+}
+
+/// Internal runtime-gate fixture: 0=drain (42), 1=early close (43).
+export fn comp_emit_component_wasm_async_stdin_provider_fixture(mode: Int) -> Bytes with Exception {
+  comp_emit_component_wasm_async_stdin_provider(comp_generate_stdin_provider_synthetic_core(mode), "run")
 }
 
 /// ADR-0089 step 4 (#1218): wrap a REAL compiled core module -- one whose

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -174,6 +174,11 @@ fn comp_emit_component_wasm_host_future_value(export_name: String, comp_result_v
 // #1539: production-unused stdin provider shadow component. This is an
 // internal gate emitter only; it has no end-user API or linked_compile route.
 fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes
+// #1539 bounded checker-hidden core route. The fixture is internal to the
+// structural/runtime gate (mode 0 drain, mode 1 early close).
+fn comp_core_imports_stdin_provider(core_wasm: Bytes) -> Bool
+fn comp_emit_component_wasm_async_stdin_provider(main_core_wasm: Bytes, export_name: String) -> Bytes with Exception
+fn comp_emit_component_wasm_async_stdin_provider_fixture(mode: Int) -> Bytes with Exception
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -175,7 +175,7 @@ fn comp_emit_component_wasm_host_future_value(export_name: String, comp_result_v
 // internal gate emitter only; it has no end-user API or linked_compile route.
 fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes
 // #1539 bounded checker-hidden core route. The fixture is internal to the
-// structural/runtime gate (mode 0 drain, mode 1 early close).
+// structural/runtime gate (0 drain, 1 early close, 2/3/4 malformed-wire traps).
 fn comp_core_imports_stdin_provider(core_wasm: Bytes) -> Bool
 fn comp_emit_component_wasm_async_stdin_provider(main_core_wasm: Bytes, export_name: String) -> Bytes with Exception
 fn comp_emit_component_wasm_async_stdin_provider_fixture(mode: Int) -> Bytes with Exception

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
@@ -26,7 +26,9 @@ import @vibe/compiler/core {
 import ./component_codegen.vibe {
   comp_core_imports_host_future,
   comp_core_imports_host_stream,
+  comp_core_imports_stdin_provider,
   comp_emit_component_wasm_async_hostfuture,
+  comp_emit_component_wasm_async_stdin_provider,
   comp_emit_component_wasm_async_trampolined_p1
 }
 
@@ -88,7 +90,12 @@ fn entry_declares_async_int(stmts: Array[Stmt], entry_name: String) -> Bool {
 /// the self-contained trampolined-p1 shape byte-identically.
 fn maybe_wrap_async_component(bytes: Bytes, wrap_async: Bool) -> Bytes with Exception {
   if wrap_async {
-    if comp_core_imports_host_future(bytes) || comp_core_imports_host_stream(bytes) {
+    // #1539: provider routing is first because its nominal stdin lifecycle
+    // cannot be satisfied by (or safely mixed into) generic named streams.
+    // The dedicated composer validates signatures and rejects mixing.
+    if comp_core_imports_stdin_provider(bytes) {
+      comp_emit_component_wasm_async_stdin_provider(bytes, "run")
+    } else if comp_core_imports_host_future(bytes) || comp_core_imports_host_stream(bytes) {
       // ADR-0089 Decision 3 (#1218): host STREAMS
       // (`vibe.host_stream_get$<name>`) key the same composition -- the
       // composer emits per-name `stream<u8>` component imports alongside

--- a/lib/@vibe/compiler/tests/builtins_test.vibe
+++ b/lib/@vibe/compiler/tests/builtins_test.vibe
@@ -24,6 +24,22 @@ test "lookup_builtin hides codegen-internal registry rows" {
   }
 }
 
+test "#1539 stdin provider raw names remain checker-invisible" {
+  let names = [
+    "vibe_stdin_provider_acquire_raw",
+    "vibe_stdin_provider_read_raw",
+    "vibe_stdin_provider_close_raw"
+  ]
+  let mut i = 0
+  while i < Array::length(names) {
+    match lookup_builtin(Array::get(names, i)) {
+      Some(_) => assert(false),
+      None => assert(true)
+    }
+    i = i + 1
+  }
+}
+
 test "lookup_builtin Array::length" {
   match lookup_builtin("Array::length") {
     Some(_) => assert(true),

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -13,11 +13,14 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_core_host_stream_names,
   comp_core_imports_host_future,
   comp_core_imports_host_stream,
+  comp_core_imports_stdin_provider,
   comp_emit_component_wasm,
   comp_emit_component_wasm_async,
   comp_emit_component_wasm_async_concurrent_awaits,
   comp_emit_component_wasm_async_hostfuture,
   comp_emit_component_wasm_async_spawned_future,
+  comp_emit_component_wasm_async_stdin_provider,
+  comp_emit_component_wasm_async_stdin_provider_fixture,
   comp_emit_component_wasm_async_trampolined,
   comp_emit_component_wasm_async_trampolined_p1,
   comp_emit_component_wasm_future_value,
@@ -1369,6 +1372,112 @@ test "component async hostfuture: the anonymous host future is a one-name list (
   assert(Array::length(comp_core_host_future_names(build_main_i64_core_p1())) == 0)
 }
 
+fn build_main_i64_core_stdin_provider(module_name: String, include_acquire: Bool, malformed_acquire: Bool, include_read: Bool, include_close: Bool, include_named_stream: Bool) -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  // 0 fd_write; 1 ()->i64; 2 (i64)->i64; 3 (i64)->i64 malformed
+  // acquire; 4 (i64)->i64 run.
+  let tc = bytebuf_new()
+  bytebuf_push_vec_header(tc, 5)
+  emit_func_type_raw(tc, [
+    127,
+    127,
+    127,
+    127
+  ], [
+    127
+  ])
+  emit_func_type_raw(tc, array_empty(), [
+    126
+  ])
+  emit_func_type_raw(tc, [
+    126
+  ], [
+    126
+  ])
+  emit_func_type_raw(tc, [
+    126
+  ], [
+    126
+  ])
+  emit_func_type_raw(tc, [
+    126
+  ], [
+    126
+  ])
+  bytebuf_push_section(out, 1, tc)
+  let import_count = 1 + if include_acquire {
+    1
+  } else {
+    0
+  } + if include_read {
+    1
+  } else {
+    0
+  } + if include_close {
+    1
+  } else {
+    0
+  } + if include_named_stream {
+    1
+  } else {
+    0
+  }
+  let ic = bytebuf_new()
+  bytebuf_push_vec_header(ic, import_count)
+  emit_name(ic, "wasi_snapshot_preview1")
+  emit_name(ic, "fd_write")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 0)
+  if include_acquire {
+    emit_name(ic, module_name)
+    emit_name(ic, "stdin_provider_acquire")
+    bytebuf_push(ic, 0)
+    bytebuf_push(ic, if malformed_acquire {
+      3
+    } else {
+      1
+    })
+  } else {
+    ()
+  }
+  if include_read {
+    emit_name(ic, module_name)
+    emit_name(ic, "stdin_provider_read")
+    bytebuf_push(ic, 0)
+    bytebuf_push(ic, 2)
+  } else {
+    ()
+  }
+  if include_close {
+    emit_name(ic, module_name)
+    emit_name(ic, "stdin_provider_close")
+    bytebuf_push(ic, 0)
+    bytebuf_push(ic, 2)
+  } else {
+    ()
+  }
+  if include_named_stream {
+    emit_name(ic, "vibe")
+    emit_name(ic, "host_stream_get$body")
+    bytebuf_push(ic, 0)
+    bytebuf_push(ic, 1)
+  } else {
+    ()
+  }
+  bytebuf_push_section(out, 2, ic)
+  emit_function_section(out, [
+    4
+  ])
+  emit_export_section(out, "run", import_count)
+  let body = bytebuf_new()
+  emit_i64_const(body, 42)
+  emit_code_section(out, [
+    body
+  ])
+  bytebuf_to_bytes(out)
+}
+
 fn build_main_i64_core_hoststream_named(with_future: Bool) -> Bytes {
   let out = bytebuf_new()
   emit_header(out)
@@ -1459,6 +1568,63 @@ test "component stdin provider shadow: distinct lifecycle adapter remains unrout
   assert(component_bytes_contains(comp, "[waitable-set-wait]") == 1)
   assert(component_bytes_contains(comp, "host_stream_get$stdin") == 0)
   assert(component_bytes_contains(comp, "host_stream_close") == 0)
+}
+
+// #1539 bounded production route: parsed exact imports key the nominal stdin
+// composer, while the main guest receives only the tagged bridge instance.
+test "component stdin provider: exact core imports compose through tagged bridge (#1539)" {
+  let core = build_main_i64_core_stdin_provider("vibe", true, false, true, true, false)
+  assert(comp_core_imports_stdin_provider(core))
+  let comp = comp_emit_component_wasm_async_stdin_provider(core, "run")
+  assert(component_bytes_contains(comp, "wasi:cli/types@0.3.0") == 1)
+  assert(component_bytes_contains(comp, "wasi:cli/stdin@0.3.0") == 1)
+  assert(component_bytes_contains(comp, "stdin_provider_acquire") == 1)
+  assert(component_bytes_contains(comp, "stdin_provider_read") == 1)
+  assert(component_bytes_contains(comp, "stdin_provider_close") == 1)
+  assert(component_bytes_contains(comp, "[async-lower][stream-read-0]read-via-stream") == 1)
+  assert(component_bytes_contains(comp, "[async-lower][future-read-1]read-via-stream") == 1)
+  assert(component_bytes_contains(comp, "host_stream_get$stdin") == 0)
+  assert(component_bytes_contains(comp, "host_stream_read") == 0)
+  assert(component_bytes_contains(comp, "host_stream_close") == 0)
+  let drain = comp_emit_component_wasm_async_stdin_provider_fixture(0)
+  let early = comp_emit_component_wasm_async_stdin_provider_fixture(1)
+  assert(Bytes::length(drain) > 208)
+  assert(Bytes::length(early) > 208)
+  assert(Bytes::length(drain) != Bytes::length(early))
+}
+
+fn stdin_provider_compose_rejected(core: Bytes) -> Bool {
+  handle {
+    let _ = comp_emit_component_wasm_async_stdin_provider(core, "run")
+    false
+  } with Exception {
+    Throw(_) => true
+  }
+}
+
+test "component stdin provider: malformed signature is rejected (#1539)" {
+  let core = build_main_i64_core_stdin_provider("vibe", true, true, true, false, false)
+  assert(comp_core_imports_stdin_provider(core))
+  assert(stdin_provider_compose_rejected(core))
+}
+
+test "component stdin provider: wrong module is rejected (#1539)" {
+  let core = build_main_i64_core_stdin_provider("wrong", true, false, true, false, false)
+  assert(comp_core_imports_stdin_provider(core) == false)
+  assert(stdin_provider_compose_rejected(core))
+}
+
+test "component stdin provider: read without acquire is rejected (#1539)" {
+  let core = build_main_i64_core_stdin_provider("vibe", false, false, true, false, false)
+  assert(comp_core_imports_stdin_provider(core))
+  assert(stdin_provider_compose_rejected(core))
+}
+
+test "component stdin provider: named stream mixing is rejected (#1539)" {
+  let core = build_main_i64_core_stdin_provider("vibe", true, false, true, true, true)
+  assert(comp_core_imports_stdin_provider(core))
+  assert(comp_core_imports_host_stream(core))
+  assert(stdin_provider_compose_rejected(core))
 }
 
 // ADR-0089 Decision 3 (#1218): a named host STREAM composes into a

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -1372,7 +1372,7 @@ test "component async hostfuture: the anonymous host future is a one-name list (
   assert(Array::length(comp_core_host_future_names(build_main_i64_core_p1())) == 0)
 }
 
-fn build_main_i64_core_stdin_provider(module_name: String, include_acquire: Bool, malformed_acquire: Bool, include_read: Bool, include_close: Bool, include_named_stream: Bool) -> Bytes {
+fn build_main_i64_core_stdin_provider(module_name: String, include_acquire: Bool, duplicate_acquire: Bool, malformed_acquire: Bool, include_read: Bool, include_close: Bool, include_named_stream: Bool) -> Bytes {
   let out = bytebuf_new()
   emit_header(out)
   // 0 fd_write; 1 ()->i64; 2 (i64)->i64; 3 (i64)->i64 malformed
@@ -1410,6 +1410,10 @@ fn build_main_i64_core_stdin_provider(module_name: String, include_acquire: Bool
     1
   } else {
     0
+  } + if duplicate_acquire {
+    1
+  } else {
+    0
   } + if include_read {
     1
   } else {
@@ -1438,6 +1442,14 @@ fn build_main_i64_core_stdin_provider(module_name: String, include_acquire: Bool
     } else {
       1
     })
+  } else {
+    ()
+  }
+  if duplicate_acquire {
+    emit_name(ic, module_name)
+    emit_name(ic, "stdin_provider_acquire")
+    bytebuf_push(ic, 0)
+    bytebuf_push(ic, 1)
   } else {
     ()
   }
@@ -1573,7 +1585,7 @@ test "component stdin provider shadow: distinct lifecycle adapter remains unrout
 // #1539 bounded production route: parsed exact imports key the nominal stdin
 // composer, while the main guest receives only the tagged bridge instance.
 test "component stdin provider: exact core imports compose through tagged bridge (#1539)" {
-  let core = build_main_i64_core_stdin_provider("vibe", true, false, true, true, false)
+  let core = build_main_i64_core_stdin_provider("vibe", true, false, false, true, true, false)
   assert(comp_core_imports_stdin_provider(core))
   let comp = comp_emit_component_wasm_async_stdin_provider(core, "run")
   assert(component_bytes_contains(comp, "wasi:cli/types@0.3.0") == 1)
@@ -1593,35 +1605,51 @@ test "component stdin provider: exact core imports compose through tagged bridge
   assert(Bytes::length(drain) != Bytes::length(early))
 }
 
-fn stdin_provider_compose_rejected(core: Bytes) -> Bool {
+fn stdin_provider_compose_rejection(core: Bytes) -> String {
   handle {
     let _ = comp_emit_component_wasm_async_stdin_provider(core, "run")
-    false
+    ""
   } with Exception {
-    Throw(_) => true
+    Throw(message) => message
   }
 }
 
+fn stdin_provider_compose_rejected(core: Bytes) -> Bool {
+  stdin_provider_compose_rejection(core) != ""
+}
+
 test "component stdin provider: malformed signature is rejected (#1539)" {
-  let core = build_main_i64_core_stdin_provider("vibe", true, true, true, false, false)
+  let core = build_main_i64_core_stdin_provider("vibe", true, false, true, true, false, false)
   assert(comp_core_imports_stdin_provider(core))
   assert(stdin_provider_compose_rejected(core))
 }
 
 test "component stdin provider: wrong module is rejected (#1539)" {
-  let core = build_main_i64_core_stdin_provider("wrong", true, false, true, false, false)
+  let core = build_main_i64_core_stdin_provider("wrong", true, false, false, true, false, false)
   assert(comp_core_imports_stdin_provider(core) == false)
   assert(stdin_provider_compose_rejected(core))
 }
 
 test "component stdin provider: read without acquire is rejected (#1539)" {
-  let core = build_main_i64_core_stdin_provider("vibe", false, false, true, false, false)
+  let core = build_main_i64_core_stdin_provider("vibe", false, false, false, true, false, false)
   assert(comp_core_imports_stdin_provider(core))
   assert(stdin_provider_compose_rejected(core))
 }
 
+test "component stdin provider: duplicate provider import is rejected (#1539)" {
+  let core = build_main_i64_core_stdin_provider("vibe", true, true, false, true, false, false)
+  assert(comp_core_imports_stdin_provider(core))
+  assert(stdin_provider_compose_rejection(core) == "component(async-stdin-provider): duplicate stdin-provider core import")
+}
+
+test "component stdin provider: acquire without consumer is rejected (#1539)" {
+  let core = build_main_i64_core_stdin_provider("vibe", true, false, false, false, false, false)
+  assert(comp_core_imports_stdin_provider(core))
+  assert(stdin_provider_compose_rejection(core) == "component(async-stdin-provider): stdin_provider_acquire requires at least one consuming read or close import")
+}
+
 test "component stdin provider: named stream mixing is rejected (#1539)" {
-  let core = build_main_i64_core_stdin_provider("vibe", true, false, true, true, true)
+  let core = build_main_i64_core_stdin_provider("vibe", true, false, false, true, true, true)
   assert(comp_core_imports_stdin_provider(core))
   assert(comp_core_imports_host_stream(core))
   assert(stdin_provider_compose_rejected(core))

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -110,6 +110,9 @@ vibe_hf_get_raw	linear-only	host-import	ADR-0089 step 4 host-future raw half; ho
 vibe_hf_wait_raw	linear-only	host-import	ADR-0089 step 4 host-future raw half; host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_hs_read_raw	linear-only	host-import	ADR-0089 D3 host-stream raw read half; host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_hs_close_raw	linear-only	host-import	ADR-0089 D3 host-stream raw drop half; host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
+vibe_stdin_provider_acquire_raw	linear-only	host-import	#1539 checker-hidden stdin provider core route; canonical async composition is linear-memory only
+vibe_stdin_provider_close_raw	linear-only	host-import	#1539 checker-hidden stdin provider core route; canonical async composition is linear-memory only
+vibe_stdin_provider_read_raw	linear-only	host-import	#1539 checker-hidden stdin provider core route; canonical async composition is linear-memory only
 vibe_http_request_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_http_response_body_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_http_response_header_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group

--- a/scripts/test_wasi_cli_stdin_provider_guest_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_guest_component_gate.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# #1539: bounded arbitrary-core stdin-provider route. Generates two
-# compiled-shaped guests (drain and early close), validates their nominal WIT
-# and bridge structure, then runs them on pinned Wasmtime 47.0.2 when the
-# ratified stdin provider is available.
+# #1539: bounded arbitrary-core stdin-provider route. Generates compiled-shaped
+# drain/early-close guests plus odd/out-of-u32/high-bit tagged-wire trap
+# controls, validates their nominal WIT and bridge structure, then runs them on
+# pinned Wasmtime 47.0.2 when the ratified stdin provider is available.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -42,6 +42,9 @@ HARNESS="$OUT_DIR/dump.vibex"
 HARNESS_WASM="$OUT_DIR/dump.wasm"
 DRAIN="$OUT_DIR/drain.component.wasm"
 EARLY="$OUT_DIR/early-close.component.wasm"
+ODD_WIRE="$OUT_DIR/odd-wire.component.wasm"
+OUT_OF_U32_WIRE="$OUT_DIR/out-of-u32-wire.component.wasm"
+HIGH_BIT_WIRE="$OUT_DIR/high-bit-wire.component.wasm"
 cat >"$HARNESS" <<'EOF'
 import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_async_stdin_provider_fixture
@@ -50,16 +53,19 @@ import @vibe/compiler/entry/source_compile/wasi_only {
 fn main() -> Unit with Exception + Fs {
   Fs::write_bytes("_build/bench/wasi_cli_stdin_provider_guest/drain.component.wasm", comp_emit_component_wasm_async_stdin_provider_fixture(0))
   Fs::write_bytes("_build/bench/wasi_cli_stdin_provider_guest/early-close.component.wasm", comp_emit_component_wasm_async_stdin_provider_fixture(1))
+  Fs::write_bytes("_build/bench/wasi_cli_stdin_provider_guest/odd-wire.component.wasm", comp_emit_component_wasm_async_stdin_provider_fixture(2))
+  Fs::write_bytes("_build/bench/wasi_cli_stdin_provider_guest/out-of-u32-wire.component.wasm", comp_emit_component_wasm_async_stdin_provider_fixture(3))
+  Fs::write_bytes("_build/bench/wasi_cli_stdin_provider_guest/high-bit-wire.component.wasm", comp_emit_component_wasm_async_stdin_provider_fixture(4))
 }
 EOF
-rm -f "$HARNESS_WASM" "$HARNESS_WASM.diag" "$DRAIN" "$EARLY"
+rm -f "$HARNESS_WASM" "$HARNESS_WASM.diag" "$DRAIN" "$EARLY" "$ODD_WIRE" "$OUT_OF_U32_WIRE" "$HIGH_BIT_WIRE"
 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
   "$COMPILER" "$HARNESS" "$HARNESS_WASM" main >/dev/null
 VIBE_PREOPEN_DIR="$PROJECT_ROOT" \
   bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke main "$HARNESS_WASM" >/dev/null
 
-for lane in drain early-close; do
+for lane in drain early-close odd-wire out-of-u32-wire high-bit-wire; do
   component="$OUT_DIR/$lane.component.wasm"
   printed="$OUT_DIR/$lane.wat"
   wit="$OUT_DIR/$lane.wit"
@@ -91,7 +97,69 @@ for lane in drain early-close; do
     exit 1
   fi
 done
-echo "[wasi-cli-stdin-provider-guest] generated components validate/WIT/structure OK"
+
+check_malformed_control_guest() {
+  local lane="$1" wire="$2"
+  local body="$OUT_DIR/$lane-control.wat"
+  sed -n '/  (core module (;0;)/,/^  )/p' "$OUT_DIR/$lane.wat" \
+    | sed -n '/    (func (;4;)/,/^    )/p' >"$body"
+  grep -Fq "i64.const $wire" "$body"
+  # The control directly invokes bridge read (import 2): it neither acquires
+  # provider state nor closes it before exercising malformed-wire validation.
+  [ "$(grep -c '^      call 2$' "$body")" -eq 1 ]
+  if grep -Eq '^      call (1|3)$' "$body"; then
+    echo "wasi cli stdin provider guest FAILED: $lane touches provider lifecycle before validation" >&2
+    exit 1
+  fi
+}
+check_malformed_control_guest odd-wire 1
+check_malformed_control_guest out-of-u32-wire 4294967296
+check_malformed_control_guest high-bit-wire -2
+
+# The bridge is core module 2 in this bounded composer. It owns no memory, and
+# decode (func 3) must complete both wire checks before narrowing. Read/close
+# must call decode before the first lifecycle-shadow call, proving malformed
+# wires cannot reach provider state or any canonical stream/future operation.
+BRIDGE_WAT="$OUT_DIR/bridge.wat"
+sed -n '/  (core module (;2;)/,/^  )/p' "$OUT_DIR/drain.wat" >"$BRIDGE_WAT"
+grep -Fq 'i64.and' "$BRIDGE_WAT"
+grep -Fq 'i64.gt_u' "$BRIDGE_WAT"
+grep -Fq 'i32.wrap_i64' "$BRIDGE_WAT"
+if grep -Eq 'i32\.(load|store)|memory\.' "$BRIDGE_WAT"; then
+  echo "wasi cli stdin provider guest FAILED: tagged bridge accesses state directly" >&2
+  exit 1
+fi
+check_bridge_call_order() {
+  local func_idx="$1" provider_call="$2"
+  local body="$OUT_DIR/bridge-func-$func_idx.wat"
+  sed -n "/    (func (;$func_idx;)/,/^    )/p" "$BRIDGE_WAT" >"$body"
+  awk -v provider_call="$provider_call" '
+    /^      call [0-9]+$/ {
+      calls += 1
+      if (calls == 1 && $2 != 3) bad = 1
+      if (calls == 2 && $2 != provider_call) bad = 1
+    }
+    END { exit !(calls == 2 && bad != 1) }
+  ' "$body"
+}
+# func 5 read: decode (3), then shadow read (1); func 6 close: decode, shadow close (2).
+check_bridge_call_order 5 1
+check_bridge_call_order 6 2
+# Decode itself is pure validation/narrowing: no state access and no imports.
+DECODE_WAT="$OUT_DIR/bridge-func-3.wat"
+sed -n '/    (func (;3;)/,/^    )/p' "$BRIDGE_WAT" >"$DECODE_WAT"
+if grep -Eq '^      call ' "$DECODE_WAT"; then
+  echo "wasi cli stdin provider guest FAILED: decode calls provider before validation" >&2
+  exit 1
+fi
+[ "$(grep -c '^        unreachable$' "$DECODE_WAT")" -eq 2 ]
+awk '
+  /i64\.and/ { odd_check = NR }
+  /i64\.gt_u/ { range_check = NR }
+  /i32\.wrap_i64/ { narrow = NR }
+  END { exit !(odd_check < range_check && range_check < narrow) }
+' "$DECODE_WAT"
+echo "[wasi-cli-stdin-provider-guest] generated components validate/WIT/bridge ordering OK"
 
 WASMTIME_BIN="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
 [ -n "$WASMTIME_BIN" ] || require_or_skip_runtime "wasmtime not installed"
@@ -121,7 +189,24 @@ run_lane() {
   }
   echo "[wasi-cli-stdin-provider-guest] $lane: $expected"
 }
+run_trap() {
+  local lane="$1"
+  local log="$OUT_DIR/run.$lane.log"
+  if timeout 60 "$WASMTIME_BIN" run "${FLAGS[@]}" --invoke 'run()' "$OUT_DIR/$lane.component.wasm" <"$INPUT" >"$log" 2>&1; then
+    echo "wasi cli stdin provider guest FAILED: $lane unexpectedly succeeded" >&2
+    exit 1
+  fi
+  grep -Eqi 'unreachable|wasm trap' "$log" || {
+    echo "wasi cli stdin provider guest FAILED: $lane failed without the expected trap" >&2
+    cat "$log" >&2
+    exit 1
+  }
+  echo "[wasi-cli-stdin-provider-guest] $lane: expected trap"
+}
 run_lane drain 42
 run_lane early-close 43
+run_trap odd-wire
+run_trap out-of-u32-wire
+run_trap high-bit-wire
 
 echo "wasi cli stdin provider guest component gate OK (wasmtime 47.0.2)"

--- a/scripts/test_wasi_cli_stdin_provider_guest_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_guest_component_gate.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# #1539: bounded arbitrary-core stdin-provider route. Generates two
+# compiled-shaped guests (drain and early close), validates their nominal WIT
+# and bridge structure, then runs them on pinned Wasmtime 47.0.2 when the
+# ratified stdin provider is available.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+OUT_DIR="$PROJECT_ROOT/_build/bench/wasi_cli_stdin_provider_guest"
+mkdir -p "$OUT_DIR"
+
+require_or_skip_runtime() {
+  local what="$1"
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "wasi cli stdin provider guest FAILED: $what (required mode)" >&2
+    exit 1
+  fi
+  echo "[wasi-cli-stdin-provider-guest] runtime SKIP: $what"
+  echo "wasi cli stdin provider guest structural gate OK"
+  exit 0
+}
+
+command -v wasm-tools >/dev/null 2>&1 || {
+  echo "wasi cli stdin provider guest FAILED: wasm-tools is required" >&2
+  exit 1
+}
+
+COMPILER="${VIBE_STDIN_PROVIDER_GATE_COMPILER:-}"
+if [ -z "$COMPILER" ]; then
+  shopt -s nullglob
+  for candidate in "$PROJECT_ROOT"/_build/selfhost/generations/*/stage2.wasm; do
+    if [ -z "$COMPILER" ] || [ "$candidate" -nt "$COMPILER" ]; then
+      COMPILER="$candidate"
+    fi
+  done
+  shopt -u nullglob
+  [ -f "$COMPILER" ] || COMPILER="$PROJECT_ROOT/bootstrap/seed/compiler.wasm"
+fi
+HARNESS="$OUT_DIR/dump.vibex"
+HARNESS_WASM="$OUT_DIR/dump.wasm"
+DRAIN="$OUT_DIR/drain.component.wasm"
+EARLY="$OUT_DIR/early-close.component.wasm"
+cat >"$HARNESS" <<'EOF'
+import @vibe/compiler/entry/source_compile/wasi_only {
+  comp_emit_component_wasm_async_stdin_provider_fixture
+}
+
+fn main() -> Unit with Exception + Fs {
+  Fs::write_bytes("_build/bench/wasi_cli_stdin_provider_guest/drain.component.wasm", comp_emit_component_wasm_async_stdin_provider_fixture(0))
+  Fs::write_bytes("_build/bench/wasi_cli_stdin_provider_guest/early-close.component.wasm", comp_emit_component_wasm_async_stdin_provider_fixture(1))
+}
+EOF
+rm -f "$HARNESS_WASM" "$HARNESS_WASM.diag" "$DRAIN" "$EARLY"
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+  "$COMPILER" "$HARNESS" "$HARNESS_WASM" main >/dev/null
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke main "$HARNESS_WASM" >/dev/null
+
+for lane in drain early-close; do
+  component="$OUT_DIR/$lane.component.wasm"
+  printed="$OUT_DIR/$lane.wat"
+  wit="$OUT_DIR/$lane.wit"
+  wasm-tools validate --features all "$component"
+  wasm-tools print "$component" >"$printed"
+  wasm-tools component wit "$component" >"$wit"
+  prefix_sha="$(dd if="$component" bs=1 count=208 2>/dev/null | shasum -a 256 | awk '{print $1}')"
+  [ "$prefix_sha" = "9e0ecf27d3a3e5515f503f3fc0867e0ae5e02164adc32f279f9e6b1efd921c5e" ] || {
+    echo "wasi cli stdin provider guest FAILED: nominal prefix drifted ($prefix_sha)" >&2
+    exit 1
+  }
+  grep -Fq 'import wasi:cli/types@0.3.0;' "$wit"
+  grep -Fq 'import wasi:cli/stdin@0.3.0;' "$wit"
+  grep -Fq 'read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;' "$wit"
+  grep -Fq 'stdin_provider_acquire' "$printed"
+  grep -Fq 'stdin_provider_read' "$printed"
+  grep -Fq 'stdin_provider_close' "$printed"
+  grep -Fq '(core func (;0;) (canon lower (func 0) (memory 0)))' "$printed"
+  grep -Fq 'canon stream.read 3 async (memory 0)' "$printed"
+  grep -Fq 'canon future.read 5 async (memory 0)' "$printed"
+  # The full shadow instance and its scenario exports are not guest imports.
+  if grep -Fq 'host_stream_read' "$printed" || grep -Fq 'host_stream_close' "$printed"; then
+    echo "wasi cli stdin provider guest FAILED: generic HostStream leaked" >&2
+    exit 1
+  fi
+  # shellcheck disable=SC2016
+  if grep -Fq 'host_stream_get$stdin' "$printed"; then
+    echo "wasi cli stdin provider guest FAILED: named stdin HostStream leaked" >&2
+    exit 1
+  fi
+done
+echo "[wasi-cli-stdin-provider-guest] generated components validate/WIT/structure OK"
+
+WASMTIME_BIN="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
+[ -n "$WASMTIME_BIN" ] || require_or_skip_runtime "wasmtime not installed"
+WASMTIME_VERSION="$("$WASMTIME_BIN" --version 2>/dev/null || true)"
+case "$WASMTIME_VERSION" in
+  "wasmtime 47.0.2"\ *) ;;
+  *) require_or_skip_runtime "requires wasmtime 47.0.2, got ${WASMTIME_VERSION:-unavailable}" ;;
+esac
+
+INPUT="$OUT_DIR/stdin-10-15-17.bin"
+printf '\012\017\021' >"$INPUT"
+FLAGS=(-Sp3 -W component-model-async=y -W component-model-async-stackful=y -W component-model-more-async-builtins=y)
+run_lane() {
+  local lane="$1" expected="$2"
+  local log="$OUT_DIR/run.$lane.log"
+  if ! timeout 60 "$WASMTIME_BIN" run "${FLAGS[@]}" --invoke 'run()' "$OUT_DIR/$lane.component.wasm" <"$INPUT" >"$log" 2>&1; then
+    if grep -Eq 'component imports instance .wasi:cli/stdin@0\.3\.0., but a matching implementation was not found in (the )?linker' "$log"; then
+      require_or_skip_runtime "wasmtime has no matching wasi:cli/stdin@0.3.0 implementation"
+    fi
+    cat "$log" >&2
+    echo "wasi cli stdin provider guest FAILED: $lane did not exit 0" >&2
+    exit 1
+  fi
+  [ "$(cat "$log")" = "$expected" ] || {
+    echo "wasi cli stdin provider guest FAILED: $lane expected $expected, got $(cat "$log")" >&2
+    exit 1
+  }
+  echo "[wasi-cli-stdin-provider-guest] $lane: $expected"
+}
+run_lane drain 42
+run_lane early-close 43
+
+echo "wasi cli stdin provider guest component gate OK (wasmtime 47.0.2)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -10,8 +10,9 @@
 #   phase B  wasi:http p3 world (test_wasi_http_p3_full_gate.sh)
 #            componentize -> wac plug -> wasmtime serve -> curl 200/401
 #   phase C  wasi:cli/stdin lifecycle
-#            generated shadow adapter + hand-WAT provider measurement; exact
-#            ratified import, drain-to-EOF, and early-drop completion
+#            generated shadow adapter + checker-hidden arbitrary-core route +
+#            hand-WAT provider measurement; exact ratified import,
+#            drain-to-EOF, and early-drop completion
 #   phase D  WIT pin: the composed serve component's world must reference the
 #            pinned wasi:http version, so adapter/vendored-WIT/runtime drift
 #            fails loudly instead of as a mysterious resolution error.
@@ -75,6 +76,7 @@ esac
 case ",$PHASES," in *",stdin,"*)
   echo "[p3-guarantee] phase C: wasi:cli/stdin lifecycle"
   bash "$SCRIPT_DIR/test_wasi_cli_stdin_provider_component_gate.sh"
+  bash "$SCRIPT_DIR/test_wasi_cli_stdin_provider_guest_component_gate.sh"
   bash "$SCRIPT_DIR/test_wasi_cli_stdin_p3_probe_gate.sh"
   ;;
 esac


### PR DESCRIPTION
## Summary
- add checker-hidden dedicated stdin provider core imports and linked compiler wiring
- compose arbitrary guest cores through the proven provider lifecycle adapter
- bridge tagged i64 guest values to opaque provider IDs without exposing canonical handles
- select the exact ratified stdin composer before generic async composers
- fail explicitly on malformed, incomplete, duplicate, or mixed provider imports
- add compiled-shaped drain/partial-close and malformed-ID lifecycle gates

No checker-visible/public Stdin API, legacy `stdin_stream` change, generic HostStream change, or `host_stream_named("stdin")` route is introduced.

## Validation
- focused component/codegen tests: passed
- exact nominal import + wasm-tools WIT validation: passed
- Wasmtime 47.0.2: guest drain 42, partial close 43, malformed controls trap before provider calls
- shadow adapter and hand-WAT lifecycle parity: passed
- named HostStream/future behavior and bytes unchanged
- shellcheck, formatter, freshness, diff, `pkf run test-local`: passed
- independent review: safe to integrate

Full operation gate separately reaches the known host BSD xargs command-line-too-long failure at fixture phase 92.

Refs #1539