### PR TITLE
fix(cli): vibe check がパースエラーを全件返すようにする (#1567 slice 1)

### DIFF
--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -335,10 +335,18 @@ export fn check_linked_file(input_path: String) -> Int with Exception + Fs {
   let (tokens, starts, _ends) = lex_with_offsets(entry_source)
   let (entry_stmts, parse_diags) = parse_program_recovering(tokens, starts, entry_source)
   if Array::length(parse_diags) > 0 {
-    // Already a full `line L:col C: msg` string (see the import comment
-    // above) -- report just the first, matching check's one-error-at-a-time
-    // convention (vibe diagnostics is the multi-diagnostic surface).
-    throw(Array::get(parse_diags, 0))
+    // Each is already a full `line L:col C: msg` string (see the import
+    // comment above). Report ALL of them, one per line.
+    //
+    // #1567: this used to throw only `parse_diags[0]`, on the grounds that
+    // one-error-at-a-time was "check's convention" and `vibe diagnostics` was
+    // the multi-diagnostic surface. That split is exactly what #1567 is about:
+    // the recovering parser has already collected every top-level error by
+    // this point, so dropping all but the first made `check` answer a strictly
+    // worse version of the same question -- a file with three broken
+    // statements took three edit-and-rerun cycles instead of one. The two
+    // verbs now agree on COUNT as well as on wording.
+    throw(String::join(parse_diags, "\n"))
   } else {
     ()
   }

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -936,7 +936,12 @@ case "$cmd" in
         rm -f "$out" "$out.diag"
       else
         if [ -s "$out.diag" ]; then
-          echo "error: $(cat "$out.diag")" >&2
+          # #1567: the sidecar can now hold SEVERAL diagnostics, one per line
+          # (check_linked_file reports every top-level parse error the
+          # recovering parser collected, not just the first). Prefix each line
+          # so a multi-error report stays one-diagnostic-per-line and grep-able
+          # instead of collapsing into a single smeared `error:` line.
+          sed 's/^/error: /' "$out.diag" >&2
         fi
         rm -f "$out" "$out.diag"
         die "check failed: $src"

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -941,7 +941,17 @@ case "$cmd" in
           # recovering parser collected, not just the first). Prefix each line
           # so a multi-error report stays one-diagnostic-per-line and grep-able
           # instead of collapsing into a single smeared `error:` line.
-          sed 's/^/error: /' "$out.diag" >&2
+          #
+          # #1625 review (Codex P2): a single diagnostic can still span several
+          # LINES -- checker_effects.vibe appends a `hint: ...` continuation to
+          # an effect row mismatch. Prefixing that too would make one diagnostic
+          # count as two, which is precisely the grep-ability the prefix exists
+          # to provide. Only diagnostic STARTS get `error: `; a continuation is
+          # indented under the diagnostic it belongs to, so `grep -c '^error: '`
+          # is an exact diagnostic count. `hint: ` is the only continuation the
+          # compiler emits today; leading whitespace is accepted too so a future
+          # indented continuation does not silently become a phantom error.
+          awk '/^(hint: |[[:space:]])/ { print "  " $0; next } { print "error: " $0 }' "$out.diag" >&2
         fi
         rm -f "$out" "$out.diag"
         die "check failed: $src"

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -10214,7 +10214,7 @@ done
 rm -rf "$dvdir"
 echo "[compiler-gate] desugar-emitted builtins resolve in both lanes ok"
 
-echo "[compiler-gate] 98/99 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
+echo "[compiler-gate] 98/100 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
 # grep_test.vibe covers the pattern language and the filters through
 # grep_scan_source (no Fs). What only the REAL adapter mode exercises is the
 # filesystem tier: sweeping a directory, and resolving a capture's type through
@@ -10303,7 +10303,7 @@ echo "[compiler-gate] vibe grep typed filters ok"
 #     found by review rather than by a gate (the second twice: expression
 #     binders in #1622, PATTERN binders after that), which is what this step is
 #     for. Each case below fails DIFFERENTLY if the guard regresses.
-echo "[compiler-gate] 99/99 the inspect rewrite neither captures nor hijacks (#1571)"
+echo "[compiler-gate] 99/100 the inspect rewrite neither captures nor hijacks (#1571)"
 inspdir="_build/_gate_inspect_guard"
 rm -rf "$inspdir"; mkdir -p "$inspdir"
 
@@ -10396,5 +10396,65 @@ case "$insp_pat_out" in
 esac
 rm -rf "$inspdir"
 echo "[compiler-gate] inspect rewrite hygiene + shadow guard ok"
+
+# 100. #1567 slice 1: `vibe check` and `vibe diagnostics` must agree on the
+#      COUNT of top-level parse errors, not just on their wording. The
+#      recovering parser has already collected every one by the time
+#      check_linked_file looks, so reporting `parse_diags[0]` and dropping the
+#      rest made `check` a strictly worse answer to the same question -- three
+#      broken statements cost three edit-and-rerun cycles. This pins the two
+#      surfaces together so they cannot drift apart again.
+echo "[compiler-gate] 100/100 check and diagnostics report the SAME parse errors (#1567)"
+chkdir="_build/_gate_check_diag_parity"
+rm -rf "$chkdir"; mkdir -p "$chkdir"
+# Three top-level statements, two independently broken, one good between them.
+# The good statement in the middle is what forces real resynchronization.
+printf 'export let a = = 1\nexport let ok = 1\nexport let b = = 2\n' > "$chkdir/multi.vibe"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$chkdir/multi.vibe" "$chkdir/check.out" main >/dev/null 2>&1 || true
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$chkdir/multi.vibe" "$chkdir/diag.out" main >/dev/null 2>&1 || true
+# check reports through the .diag sidecar, diagnostics through the output file.
+# That difference is the REST of #1567; this step only pins the counts.
+chk_n="$(grep -c '^line ' "$chkdir/check.out.diag" 2>/dev/null || true)"
+diag_n="$(grep -c '^line ' "$chkdir/diag.out" 2>/dev/null || true)"
+[ -n "$chk_n" ] || chk_n=0
+[ -n "$diag_n" ] || diag_n=0
+if [ "$chk_n" != "2" ]; then
+  echo "[compiler-gate] FAIL: vibe check reported $chk_n parse errors, want 2 -- check_linked_file is dropping diagnostics the recovering parser already collected (#1567)" >&2
+  cat "$chkdir/check.out.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if [ "$diag_n" != "2" ]; then
+  echo "[compiler-gate] FAIL: vibe diagnostics reported $diag_n parse errors, want 2 (#1567)" >&2
+  cat "$chkdir/diag.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+# Same errors, not merely the same count: both must name line 1 and line 3.
+for want in 'line 1:' 'line 3:'; do
+  if ! grep -qF "$want" "$chkdir/check.out.diag" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: vibe check's report is missing '$want' (#1567)" >&2
+    cat "$chkdir/check.out.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! grep -qF "$want" "$chkdir/diag.out" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: vibe diagnostics' report is missing '$want' (#1567)" >&2
+    cat "$chkdir/diag.out" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+# A clean file must stay clean on both, with check still exiting 0.
+printf 'export let a = 1\n' > "$chkdir/clean.vibe"
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$chkdir/clean.vibe" "$chkdir/clean.out" main >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: vibe check rejected a clean file (#1567)" >&2
+  cat "$chkdir/clean.out.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$chkdir"
+echo "[compiler-gate] check/diagnostics parse-error parity ok (#1567)"
 
 echo "[compiler-gate] ok"

--- a/scripts/test_vibe_cli_install.sh
+++ b/scripts/test_vibe_cli_install.sh
@@ -99,6 +99,24 @@ else
   echo "info: compiler did not emit a structured diagnostic (seed build); skipping message assertion"
 fi
 
+# #1567 slice 1 + its review (Codex P2): `vibe check` prefixes each sidecar line
+# with `error: ` so a multi-error report stays one-diagnostic-per-line and
+# grep-able. A single diagnostic can still span several LINES, though --
+# checker_effects.vibe appends a `hint: ...` continuation to an effect row
+# mismatch -- so prefixing every line would report ONE diagnostic as TWO. This
+# pins the distinction: exactly one `error: ` line, with the hint present and
+# indented under it rather than counted as its own error.
+printf 'fn leaky() -> String {\n  Env::get("HOME")\n}\n\nfn main {\n  let _ = leaky()\n  ()\n}\n' > "$proj/hint.vibe"
+hint_diag="$("$VIBE" check "$proj/hint.vibe" 2>&1 || true)"
+if echo "$hint_diag" | grep -q "effect row mismatch"; then
+  check "vibe check counts a hint as part of its diagnostic" \
+    "1" "$(echo "$hint_diag" | grep -c '^error: ')"
+  check "vibe check still shows the hint" \
+    "yes" "$(echo "$hint_diag" | grep -q 'hint: ' && echo yes || echo no)"
+else
+  echo "info: compiler did not emit the effect row mismatch hint (seed build); skipping continuation-line assertion"
+fi
+
 # test: passing file exits 0, failing file exits non-zero, aggregate fails
 "$VIBE" test "$proj/pass_test.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
 check "vibe test pass exit" "0" "$rc"


### PR DESCRIPTION
`vibe check` と `vibe diagnostics` が食い違う軸のうち、**パースエラーから復帰するかしないか**を倒す。呼び出し側の契約 (出力先・clean の表現・exit code) は一切変えていないので、影響は「今まで捨てられていた診断が出るようになる」だけ。

## 実測: issue の表を 2 行訂正した

着手にあたって現行 stage2 で取り直したところ、[#1567 の表](https://github.com/mizchi/vibe-lang/issues/1567)は 2 行が実測と違っていた ([issue にコメント済み](https://github.com/mizchi/vibe-lang/issues/1567#issuecomment-5243707016))。

**件数は「両方 1 件で止まる」ではない。** issue の入力 (`fn a() -> Int { 1 + }` × 3) はブレース内の不完全式で、resync が効かない形だった。トップレベル文にすると差が出る:

```
export let a = = 1
export let ok = 1
export let b = = 2
```

| | 返る件数 |
|---|---|
| `vibe check` | **1** (`line 1:16` のみ) |
| `vibe diagnostics` | **2** (`line 1:16` と `line 3:16`) |

つまり「複数エラーが返らない」のは**実装が無いからではなく、`check` が捨てているから**だった。`cli_support.vibe` にそのままコメント付きで書いてある:

```vibe
// Already a full `line L:col C: msg` string -- report just the first, matching
// check's one-error-at-a-time convention (vibe diagnostics is the
// multi-diagnostic surface).
throw(Array::get(parse_diags, 0))
```

recovering parser はこの時点で**既に全件集め終わっている**ので、`check` は同じ質問に「わざと劣化させた答え」を返していた。3 つ壊れていれば 3 往復。

**型エラーの位置も「両方とも無い」ではない。** `return type mismatch` には付かないが `unknown name` には付く (`line 4:9-19: unknown name: T::Crimson`)。正しくは「位置が付く診断と付かない診断が混在している」で、これは別スライス。

## 直したこと

- **`check_linked_file`** — `parse_diags` を全件 (`String::join(.., "\n")`) 返す
- **`runtime/vibe` の `check`** — sidecar を `sed 's/^/error: /'` で 1 行 1 診断にする。以前は `error: $(cat "$out.diag")` だったので、複数行が 1 行に潰れて grep できなくなっていた

## gate step 100

同じ入力に対し `check` と `diagnostics` が**件数も内容も** (line 1 と line 3 の両方を名指しすること) 一致することを固定。clean なファイルが両方で clean のままであることも見る。

負の対照として「1 件しか見ない」版を作り、`vibe check reported 1 parse errors, want 2 -- check_linked_file is dropping diagnostics the recovering parser already collected` で実際に落ちることを確認済み。

## 残り

統合の残り 4 軸 — 出力先を stdout へ / clean = 空 / exit code / `--single-file` + `diagnostics` の alias 化 — はどれも呼び出し側の契約変更なので別スライスにする。issue のゴール判定 (AGENTS.md の「`vibe diagnostics` は import を解決しない」という**呼び出し側が覚える規則**の段落を消せること) はそちらで達成する。

## ゲート

`bash scripts/compiler_gate.sh` 100/100、`scripts/unit_test_runner.sh` 545/545、`scripts/check_vibe_fmt.sh` 923 files (0 violations) すべて green。

> `pkf run test` はこの環境では `sort` の glibc ABI 不一致で clean tree でも同じ位置で落ちるため (本 PR とは無関係)、内容にあたる `compiler_gate.sh` を直接流して確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_