### PR TITLE
feat(console): expose authority-preserving StdinStream

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -286,6 +286,8 @@ local benchModuleJobPool = new Task {
 local testWasiHttpP3Full =
   scriptTask("test-wasi-http-p3-full", "scripts/test_wasi_http_p3_full_gate.sh")
 local testWasiP3Guarantee = scriptTask("test-wasi-p3", "scripts/test_wasi_p3_guarantee_gate.sh")
+local testWasiStdinProviderSource =
+  scriptTask("test-wasi-stdin-provider-source", "scripts/test_wasi_cli_stdin_provider_source_component_gate.sh")
 local testSimdEmitWasmtime =
   scriptTask("test-simd-emit-wasmtime", "scripts/test_simd_emit_wasmtime.sh")
 
@@ -1036,6 +1038,7 @@ tasks {
   benchModuleJobPool
   testWasiHttpP3Full
   testWasiP3Guarantee
+  testWasiStdinProviderSource
   testSimdEmitWasmtime
   testCoverageScripts
   refreshSelfhostBatchWeights

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -766,6 +766,22 @@ The ordered default and cache-safe owners preserve their existing output.
 Checker row filtering and WIT import filtering use only the predicate-based
 entry/runtime policy; WIT mapping and handler behavior are unchanged.
 
+### Atomic stdin provider stream (#1539)
+
+```text
+Stdin::read_via_stream() -> StdinStream with Stdin
+StdinStream::next(StdinStream) -> Int with Async
+StdinStream::close(StdinStream) -> Unit with Async
+```
+
+`next` yields `0..255`, then `-1` after successful EOF settlement. `close`
+settles an early stop; repeated close and reads after successful settlement are
+idempotent. `StdinStream` is opaque, non-`Send`, and unrelated to `HostStream`
+or eager `Stream[T]`. Keep aliases within one task and explicitly drain or
+close every acquisition. This surface is component-only (linear/RC); GC,
+standalone core, `host_stream_named("stdin")`, and mixed named-provider
+composition are rejected. Legacy `stdin_stream(chunk_size)` is unchanged.
+
 **Naming.** Effect names are CamelCase. A standard provider builtin is a plain
 `Effect::snake_case` function call; a declared operation is CamelCase and is
 emitted with `perform`:

--- a/docs/language-tour/builtins.md
+++ b/docs/language-tour/builtins.md
@@ -148,6 +148,9 @@ reserved and is not part of the current surface syntax.
 | `Stdout::write_char` | `(Int) -> Unit` | `{Stdout}` | Write char to stdout |
 | `Stdin::read_stream` | `(Int) -> String` | `{Stdin}` | Read from stdin |
 | `Stdin::read_char` | `() -> Int` | `{Stdin}` | Read char from stdin |
+| `Stdin::read_via_stream` | `() -> StdinStream` | `{Stdin}` | Acquire an opaque p3 stdin provider stream |
+| `StdinStream::next` | `(StdinStream) -> Int` | `{Async}` | Read one byte, or `-1` after settled EOF |
+| `StdinStream::close` | `(StdinStream) -> Unit` | `{Async}` | Settle an early close (idempotent after success) |
 
 ## JSON
 

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1630,8 +1630,10 @@ unmeasured** (`io`, `illegal-byte-sequence`, and `pipe` have no claimed runtime
 measurement). The forced completion-tag, wrong-byte, and extra-byte
 expected-trap scenarios are controls of cleanup/fail-closed branches, not
 measurements of provider-generated errors. Each byte-mismatch control settles
-and drops both owned ends through the shared close path before trapping. This
-work makes no runtime, console, or checker-visible/source API change.
+and drops both owned ends through the shared close path before trapping. Those
+shadow-scenario controls introduced no API by themselves; the production
+checker-visible `StdinStream` source/console API is the surface documented in
+§3.18.3 above.
 
 ### 3.19 ADR-0089 Decision 3 — `wasi:http` incoming-body の実 provider 配線（未着手 / 設計）
 

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1522,7 +1522,7 @@ does **not** by itself complete the stdin lifecycle: the completion future must
 still be read, its result checked, and then released. This corrects the stale
 short-hand that described stream drop alone as a completed stdin close.
 
-#### Provider-aware contract (shadow lifecycle + checker-hidden core route)
+#### Provider-aware contract (shadow lifecycle + atomic public source route)
 
 The #1539 prerequisite is a distinct, opaque provider-aware handle whose
 adapter state retains both owned ends from `read-via-stream`:
@@ -1534,8 +1534,17 @@ read opaque handle -> byte | EOF                  with Async
 close opaque handle -> lifecycle-complete result  with Async
 ```
 
-This is an internal/lowering contract, not a proposed public Vibe API. Its
-observable authority and effect requirements are fixed as follows:
+The compiler now exposes this contract through one unforgeable nominal scalar:
+
+```text
+Stdin::read_via_stream() -> StdinStream with Stdin
+StdinStream::next(StdinStream) -> Int with Async
+StdinStream::close(StdinStream) -> Unit with Async
+```
+
+`StdinStream` is neither `Int`, generic `HostStream`, nor `Stream[T]`; source
+cannot construct it and it is not `Send`. Its observable authority and effect
+requirements are fixed as follows:
 
 - Acquisition is synchronous but requires `Stdin` authority. It calls
   `read-via-stream` once and transfers ownership of **both** returned readable
@@ -1574,41 +1583,32 @@ canonical stream handle, and completion-future handle never cross into the
 compiled guest. The bridge ABI is `wire = value << 1`; read returns tagged
 bytes or tagged `-1` after settlement and close returns tagged zero.
 
-This does **not** make the route source-reachable: all three registry rows have
-`checker_visible=false`, there is no AST lowering that injects them, and no
-`Stdin`/`ByteStream` API was added. This is deliberate authority preservation,
-not missing plumbing. `stdin_stream`, generic HostStream, and named
-future/stream behavior remain unchanged. A core that mixes the provider imports
-with named future/stream imports is explicitly rejected in this bounded slice.
-Stage 4 (public authority/type/error and effect-level Suspend-token lowering)
-therefore remains undecided:
+The three raw registry rows remain `checker_visible=false`; three public rows
+lower atomically through compiler-owned wrapper functions to those same exact
+imports. The wrappers are required for first-class references/aliases because
+raw imports do not accept the hidden closure-environment argument. Source emits
+only the exact `vibe.stdin_provider_*` core imports and the nominal
+`wasi:cli/types@0.3.0` + `wasi:cli/stdin@0.3.0` component imports.
 
+`stdin_stream`, generic HostStream, and named future/stream behavior remain
+unchanged. `host_stream_named("stdin")` is reserved and rejected. A source core
+that mixes stdin-provider imports with named future/stream imports is explicitly
+rejected in this bounded slice. GC and standalone/non-Async-entry compilation
+are also rejected explicitly; linear and RC component lanes are supported.
 
-1. **ABI boundary:** introduce a provider-specific lowering/adapter route for
-   synchronous `read-via-stream` acquisition. Keep it distinct from
-   `host_stream_named`; retain both readable handles behind an opaque handle.
-2. **Read path:** implement the provider handle's Async read with the canonical
-   stream wait protocol. A BLOCKED read joins its stream end to a waitable set,
-   waits for the expected event, unjoins that end, and drops the set exactly
-   once before retrying/decoding the status.
-3. **Settlement path:** implement one shared Async settlement transition used
-   by both EOF and early close. It drops the stream end if still owned, waits
-   for the completion future when blocked, unjoins before dropping every
-   waitable set, accepts only completion success, then drops the future end.
-4. **Surface migration:** only after the above is proven, decide how the
-   provider path feeds a Vibe consumer. The existing
-   `stdin_stream(chunk_size) -> (() -> Option[String] with Stdin)` remains
-   unchanged in this prerequisite; it continues to use its legacy synchronous
-   `read_n` closure and is not evidence that the provider contract exists.
-5. **Regression gate:** extend implementation validation with the merged
-   executable probe/gate above for both drain-to-EOF and early-drop success,
-   plus explicit lifecycle-error coverage before any public error mapping is
-   proposed.
+The provider permits multiple active acquisitions. Adapter IDs allocate
+monotonically from 16 slots and are never recycled: capacity overflow traps
+before another canonical acquisition, while concurrent/reentrant use of the
+same open slot traps on its non-open phase. Successful EOF/close remains
+idempotent through aliases. Wasmtime 47 source gates measure drain, early close,
+function aliases, a sequential second acquisition, and two simultaneously open
+acquisitions.
 
 Load-bearing invariants for stages 1--3:
 
-- Exactly one acquisition owns exactly one stream end and one completion-future
-  end; neither end may escape as a generic `[3, handle]` HostStream.
+- Each successful acquisition owns exactly one stream end and one
+  completion-future end; up to 16 acquisitions may coexist, and neither end may
+  escape as a generic `[3, handle]` HostStream.
 - EOF and early close converge on one settlement state machine. Once settlement
   begins, subsequent reads/closes are idempotent at the opaque-handle boundary
   and cannot issue a second drop, read, join, or unjoin.
@@ -1805,7 +1805,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 |---|---|---|
 | **suspend lowering の適格性** (#1536) | row-variable callee と literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow、eager `await(Stream::next(s))` retarget、sequence-HEAD let 連鎖の float (`for` 駆動 terminal) は済み (§2.2 末尾) | — (ADR-0076 本体) |
 | **AsyncIter への一本化** (#1538) | eager `Stream[T]` combinator の退役 / AsyncIter 上への再実装。`Stream::next` protocol と host stream read の接続 | 上の適格性 |
-| **stdin provider / `ByteStream` の p3 接続** (#1539) | **checker-hidden core route まで実装**: shadow lifecycle に加え、exact `vibe.stdin_provider_*` raw imports、tagged-i64 bridge、任意 core composer、stdin-first sniff を実装。raw rows は checker-invisible で public/source lowering は未決定、既存 `stdin_stream(chunk_size)` は未変更 (§3.18.3) | generated shadow + compiled-shaped drain/early-close gate; generic `[3, handle]` `HostStream` は使わず、named future/stream との mix は明示拒否 |
+| **stdin provider / `StdinStream` の p3 接続** (#1539) | **atomic public source route まで実装**: unforgeable nominal `StdinStream`、exact authority/effects、exact `vibe.stdin_provider_*` raw imports、tagged-i64 bridge、任意 core composer、stdin-first sniff を実装。既存 `stdin_stream(chunk_size)` は未変更 (§3.18.3) | Wasmtime 47 real-source drain/early-close/function-alias/sequential-reacquire/multiple-active gate; generic `[3, handle]` `HostStream` は使わず、named future/stream との mix は明示拒否 |
 | **実 provider = `wasi:http` incoming-body** (#1540) | serve composition と host-stream composition の統合が要る (§3.19 に構造的な理由と 3 点の分解) | — |
 | **M-conc-2: 真の subtask spawn** (#1537) | waitable-set / `future.cancel-*` による実並行・キャンセル。ADR-0068 の nursery を backend へ落とす | ADR-0076 CPS/suspend lowering |
 | **M1b-3c-1c: interleaving spawn の emitter** (#1537) | ABI 側の問いは §3.11 で解決済み (`waitable-set.wait` の完了順ディスパッチだけで足りる)。残るのは await をまたぐ task 状態の表現 = ADR-0076 の CPS/suspend lowering | 同上 |

--- a/lib/@vibe/compiler/builtins/declarations.vibe
+++ b/lib/@vibe/compiler/builtins/declarations.vibe
@@ -258,6 +258,11 @@ declare Stdout::write_char(Int) -> Unit
 declare Stdin::read_char() -> Int
 declare Stdout::write_stream(String) -> Unit
 declare Stdin::read_stream(Int) -> String
+// #1539: opaque provider-owned stdin lifecycle. The registry carries the
+// exact Stdin/Async rows; these declarations document the public signatures.
+declare Stdin::read_via_stream() -> StdinStream
+declare StdinStream::next(StdinStream) -> Int
+declare StdinStream::close(StdinStream) -> Unit
 
 //# Console (#1460 Phase 1)
 // The merged tty capability that replaces Stdin/Stdout/Stderr. Declared

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -732,6 +732,79 @@ fn host_stream_to_legacy_stream_conflict(expected: Type, actual: Type) -> Bool {
   }
 }
 
+fn is_stdin_stream_internal(t: Type) -> Bool {
+  match t {
+    CtStruct(n) => n == "#vibe_stdin_stream",
+    _ => false
+  }
+}
+
+/// #1539: the opaque stdin provider token is compiler-owned. Unlike ordinary
+/// nullary CtNamed values, no unresolved/generic tolerance may let a different
+/// concrete representation cross this boundary. Recurse through matching
+/// containers/function signatures so aliases cannot launder the token either.
+fn stdin_stream_nominal_conflict(expected: Type, actual: Type) -> Bool {
+  let e_token = is_stdin_stream_internal(expected)
+  let a_token = is_stdin_stream_internal(actual)
+  if e_token || a_token {
+    e_token != a_token
+  } else {
+    match expected {
+      CtArray(e) => match actual {
+        CtArray(a) => stdin_stream_nominal_conflict(e, a),
+        _ => false
+      },
+      CtOption(e) => match actual {
+        CtOption(a) => stdin_stream_nominal_conflict(e, a),
+        _ => false
+      },
+      CtNamed(_, es) => match actual {
+        CtNamed(_, actuals) => if Array::length(es) == Array::length(actuals) {
+          let mut i = 0
+          let mut conflict = false
+          while i < Array::length(es) && !conflict {
+            conflict = stdin_stream_nominal_conflict(Array::get(es, i), Array::get(actuals, i))
+            i = i + 1
+          }
+          conflict
+        } else {
+          false
+        },
+        _ => false
+      },
+      CtTuple(es) => match actual {
+        CtTuple(actuals) => if Array::length(es) == Array::length(actuals) {
+          let mut i = 0
+          let mut conflict = false
+          while i < Array::length(es) && !conflict {
+            conflict = stdin_stream_nominal_conflict(Array::get(es, i), Array::get(actuals, i))
+            i = i + 1
+          }
+          conflict
+        } else {
+          false
+        },
+        _ => false
+      },
+      CtFn(eps, er, _) => match actual {
+        CtFn(aps, ar, _) => if Array::length(eps) == Array::length(aps) {
+          let mut i = 0
+          let mut conflict = stdin_stream_nominal_conflict(er, ar)
+          while i < Array::length(eps) && !conflict {
+            conflict = stdin_stream_nominal_conflict(Array::get(eps, i), Array::get(aps, i))
+            i = i + 1
+          }
+          conflict
+        } else {
+          false
+        },
+        _ => false
+      },
+      _ => false
+    }
+  }
+}
+
 /// True when every declared field type of a struct is ground (the struct is not
 /// generic). `S::{ ... }` for such a struct can safely be typed `CtStruct(S)`.
 fn struct_fields_ground(dfields: Array[(String, Type)]) -> Bool {
@@ -997,8 +1070,9 @@ export fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array
       let expected_zonked = subst_apply(s, expected)
       let actual_zonked = subst_apply(s, actual)
       let host_stream_conflict = host_stream_to_legacy_stream_conflict(expected_zonked, actual_zonked)
+      let stdin_stream_conflict = stdin_stream_nominal_conflict(expected_zonked, actual_zonked)
       let nominal_conflict = nominal_head_conflict(expected_zonked, actual_zonked)
-      if host_stream_conflict || nominal_conflict {
+      if host_stream_conflict || stdin_stream_conflict || nominal_conflict {
         Array::push(errors, String::concat(what, String::concat(": expected ", String::concat(type_to_string(expected_zonked), String::concat(", got ", String::concat(type_to_string(actual_zonked), off_marker(off)))))))
         s
       } else if structural {
@@ -1068,7 +1142,12 @@ fn nominal_name_of(t: Type) -> Option[String] {
     CtOption(_) => Some("Option"),
     CtEnum(n) => Some(n),
     CtStruct(n) => Some(n),
-    CtNamed(n, _) => if type_fully_concrete(t) {
+    CtNamed(n, _) => if n == "HostStream" {
+      // Compiler-owned and always concrete despite the nullary CtNamed shape.
+      // This makes HostStream conflict with #1539's internal StdinStream
+      // identity instead of passing through the generic-name tolerance.
+      Some(n)
+    } else if type_fully_concrete(t) {
       Some(n)
     } else {
       None

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -9,7 +9,9 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   compile_source_wasi_only_coverage,
   compile_source_wasi_only_rc,
   compile_source_wasi_only_rc_shadow,
-  merged_program_source_fs
+  maybe_wrap_stdin_provider_core,
+  merged_program_source_fs,
+  reject_stdin_provider_core
 }
 
 import @vibe/compiler/entry/source_compile/gc_only {
@@ -1048,10 +1050,23 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // both, so they stay untouched; so do `__no_entry__` test/bench builds
       // (gated inside strip_executable_wasm_env).
       let fs_instrumented = Env::get("VIBE_COVERAGE") == "1" || Env::get("VIBE_DEBUG_BREAK") == "1" || Env::get("VIBE_DEBUG") == "1" || Env::get("VIBE_RC") == "shadow"
-      let out_bytes = if fs_instrumented {
+      let core_bytes = if fs_instrumented {
         bytes
       } else {
         strip_executable_wasm_env(bytes, entry_name)
+      }
+      // #1539: file-mode compilation bypasses the source preprocess wrapper.
+      // Never publish its component-private provider ABI as a standalone core:
+      // instrumentation lanes fail before the write, while the ordinary lane
+      // safely composes the exact parsed imports after executable stripping.
+      let out_bytes = if fs_instrumented {
+        reject_stdin_provider_core(core_bytes, if Env::get("VIBE_COVERAGE") == "1" {
+          "VIBE_COVERAGE=1"
+        } else {
+          "this instrumentation mode"
+        })
+      } else {
+        maybe_wrap_stdin_provider_core(core_bytes, entry_name)
       }
       Fs::write_bytes(output_path, out_bytes)
       // #1553: this observes the executable-strip + primary-output boundary.

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -396,7 +396,15 @@ fn idp_pure_builtin_names() -> Array[String] {
     // nothing.
     "host_stream_named",
     "vibe_hs_close_raw",
-    "vibe_hs_read_raw"
+    "vibe_hs_read_raw",
+    // #1539: opaque stdin provider calls are inert host boundaries. Authority
+    // is carried by the checker rows; none can perform a user effect.
+    "Stdin::read_via_stream",
+    "StdinStream::next",
+    "StdinStream::close",
+    "vibe_stdin_provider_acquire_raw",
+    "vibe_stdin_provider_read_raw",
+    "vibe_stdin_provider_close_raw"
   ]
 }
 
@@ -4286,7 +4294,13 @@ fn edp_pure_builtin_names() -> Array[String] {
     // prefix below).
     "host_stream_named",
     "vibe_hs_close_raw",
-    "vibe_hs_read_raw"
+    "vibe_hs_read_raw",
+    "Stdin::read_via_stream",
+    "StdinStream::next",
+    "StdinStream::close",
+    "vibe_stdin_provider_acquire_raw",
+    "vibe_stdin_provider_read_raw",
+    "vibe_stdin_provider_close_raw"
   ]
 }
 

--- a/lib/@vibe/compiler/codegen/common_base/self_tail_call.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/self_tail_call.vibe
@@ -141,7 +141,7 @@ fn stc_params_all_scalar(params: Array[(String, Option[TypeExpr])]) -> Bool {
 
 fn stc_type_is_scalar(oty: Option[TypeExpr]) -> Bool {
   match oty {
-    Some(TyName(n)) => n == "Int" || n == "Bool" || n == "Float" || n == "Double",
+    Some(TyName(n)) => n == "Int" || n == "Bool" || n == "Float" || n == "Double" || n == "StdinStream",
     Some(TyUnit) => true,
     _ => false
   }

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1590,7 +1590,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
         EString(s) => s,
         _ => throw("host_stream_named: the import name must be a string literal (it becomes a component import name, so it is fixed at compile time)")
       }
-      if !cc_is_valid_host_future_name(hs_name) {
+      if hs_name == "stdin" {
+        throw("host_stream_named(\"stdin\") is reserved; use Stdin::read_via_stream()")
+      } else if !cc_is_valid_host_future_name(hs_name) {
         throw("host_stream_named: invalid import name '\{hs_name}' -- must be lower kebab-case ([a-z][a-z0-9-]*), the component-model label shape")
       } else {
         ()
@@ -4660,6 +4662,18 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_end(buf)
       emit_local_get(buf, res_l)
       nl2
+    }
+    else if !ctx.enable_rc && fname == "vibe_stdin_provider_read_raw" {
+      // #1539: the component-private provider ABI is tagged-i64 even on the
+      // default linear lane (the opaque provider ID itself stays tagged and
+      // is passed through unchanged). Decode its byte/EOF result for ordinary
+      // source Int semantics. RC already uses tagged Ints and needs no shim.
+      let (read_idx, _, _) = resolve_func(ctx.func_table, fname)
+      let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
+      emit_call(buf, read_idx)
+      emit_i64_const(buf, 1)
+      emit_i64_shr_s(buf)
+      nl
     }
     else if ctx.enable_rc && (fname == "Env::args_len" || fname == "Env::args_get" || fname == "Fs::exists" || fname == "Fs::is_dir" || fname == "Fs::is_file" || fname == "Fs::stat_token" || fname == "vibe_fs_stat_token_raw" || fname == "Profiler::now_us" || fname == "Profiler::NowUs" || fname == "Profiler::heap_bytes" || fname == "Profiler::HeapBytes" || fname == "Stdin::read_char") {
       // #705: the raw-ABI host imports speak UNTAGGED integers, but RC values

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -313,6 +313,11 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       } else {
         ()
       }
+      if fname == "Stdin::read_via_stream" || fname == "StdinStream::next" || fname == "StdinStream::close" {
+        throw("StdinStream is unsupported on gc backend; compile an Async component with the linear or RC backend")
+      } else {
+        ()
+      }
       let ctor_lookup_idx = ctor_table_index_of(ctx.gc_ctor_table, fname)
       if ctor_lookup_idx >= 0 {
         let tag = Array::get(ctx.gc_ctor_table.tags, ctor_lookup_idx)

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -664,6 +664,11 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       next_local
     },
     EIdent(name, _) => {
+      if name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" {
+        throw("StdinStream is unsupported on gc backend; compile an Async component with the linear or RC backend")
+      } else {
+        ()
+      }
       let len = Array::length(local_names)
       let rec try_local: (Int) -> Int = (i) -> {
         if i < 0 {

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -18,6 +18,7 @@ import @vibe/compiler/core {
   is_exception_effect_name,
   leb128_encode_s64,
   leb128_encode_u32,
+  rewrite_import_alias_expr,
   rewrite_top_level_fn_alias_refs,
   sorted_names_of,
   verify_lane_builtins
@@ -755,6 +756,83 @@ fn lc_row_has_label(eff: Option[String], label: String) -> Bool {
 /// spelled `Error` matches this just as it did before the flip.
 fn lc_row_has_error(eff: Option[String]) -> Bool {
   lc_row_has_label(eff, "Exception")
+}
+
+/// #1539: public provider functions are first-class values, while their exact
+/// raw imports do not accept the hidden closure-environment argument. Retarget
+/// every public reference (not only direct calls) to ordinary compiler-owned
+/// wrapper functions, then let the existing closure machinery handle aliases.
+/// Wrapper bodies alone spell the checker-hidden raw names.
+fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
+  let public_names = [
+    "Stdin::read_via_stream",
+    "StdinStream::next",
+    "StdinStream::close"
+  ]
+  let raw_names = [
+    "__stdin_provider_acquire_surface",
+    "__stdin_provider_next_surface",
+    "__stdin_provider_close_surface"
+  ]
+  let aliases: Array[(String, String)] = [
+    (Array::get(public_names, 0), Array::get(raw_names, 0)),
+    (Array::get(public_names, 1), Array::get(raw_names, 1)),
+    (Array::get(public_names, 2), Array::get(raw_names, 2))
+  ]
+  let mentions = collect_used_builtin_names(stmts, lc_fresh_string_array())
+  let needed = Map::has_key(mentions, Array::get(public_names, 0)) || Map::has_key(mentions, Array::get(public_names, 1)) || Map::has_key(mentions, Array::get(public_names, 2))
+  if needed {
+    let mut i = 0
+    while i < Array::length(stmts) {
+      match Array::get(stmts, i) {
+        SLet(ex, is_rec, name, ty, body) => Array::set(stmts, i, SLet(ex, is_rec, name, ty, rewrite_import_alias_expr(body, aliases))),
+        SLetMut(name, ty, body) => Array::set(stmts, i, SLetMut(name, ty, rewrite_import_alias_expr(body, aliases))),
+        STest(name, body) => Array::set(stmts, i, STest(name, rewrite_import_alias_expr(body, aliases))),
+        SBench(name, body) => Array::set(stmts, i, SBench(name, rewrite_import_alias_expr(body, aliases))),
+        SExpr(body) => Array::set(stmts, i, SExpr(rewrite_import_alias_expr(body, aliases))),
+        SLetPat(pat, body) => Array::set(stmts, i, SLetPat(pat, rewrite_import_alias_expr(body, aliases))),
+        _ => ()
+      }
+      i = i + 1
+    }
+    let no_params: Array[(String, Option[TypeExpr])] = array_empty()
+    let next_param: Array[(String, Option[TypeExpr])] = [
+      ("__stdin_stream", Some(TyName("StdinStream")))
+    ]
+    let close_param: Array[(String, Option[TypeExpr])] = [
+      ("__stdin_stream", Some(TyName("StdinStream")))
+    ]
+    let acquire_body = ECall(EIdent("vibe_stdin_provider_acquire_raw", -1), lc_fresh_expr_array(), -1)
+    let next_body = ECall(EIdent("vibe_stdin_provider_read_raw", -1), [
+      EIdent("__stdin_stream", -1)
+    ], -1)
+    let close_body = ESeq(ECall(EIdent("vibe_stdin_provider_close_raw", -1), [
+      EIdent("__stdin_stream", -1)
+    ], -1), EUnit)
+    Array::push(stmts, SLet(false, false, Array::get(raw_names, 0), None, EFn(lc_fresh_string_array(), array_empty(), no_params, Some(TyName("StdinStream")), None, acquire_body)))
+    Array::push(stmts, SLet(false, false, Array::get(raw_names, 1), None, EFn(lc_fresh_string_array(), array_empty(), next_param, Some(TyName("Int")), None, next_body)))
+    Array::push(stmts, SLet(false, false, Array::get(raw_names, 2), None, EFn(lc_fresh_string_array(), array_empty(), close_param, Some(TyName("Unit")), None, close_body)))
+  } else {
+    ()
+  }
+  needed
+}
+
+fn lc_entry_declares_async(stmts: Array[Stmt], entry_name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, EFn(_, _, _, _, eff, _)) => if name == entry_name && lc_row_has_label(eff, "Async") {
+        found = true
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  found
 }
 
 /// #944 (ADR-0073 stage C): the runtime outermost Error handler. When the
@@ -3197,6 +3275,7 @@ export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked
     // EFn def so calls do not route through the 0-param thunk registration
     // below (invalid wasm for any call arity). See import_alias_rewrite.vibe.
     rewrite_top_level_fn_alias_refs(stmts)
+    let _ = lc_inject_stdin_surface_wrappers(stmts)
     // #805: inline-wasm fns — extract WAT texts + neutralize marker bodies
     // BEFORE any analysis below (see lc_extract_inline_wasm's doc comment).
     lc_extract_inline_wasm(stmts, iw_names, iw_wats)
@@ -3816,6 +3895,15 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   // flag re-walked the whole AST (~40 walks) with a linear fn_names scan per
   // ident inside.
   let used_builtin_names = collect_used_builtin_names(stmts, fn_names_list)
+  let uses_stdin_provider_surface = lc_program_defines_top_level(stmts, "__stdin_provider_acquire_surface")
+  // #1539: these imports are component-internal, not a standalone core ABI.
+  // compile_source_wasi_only wraps only `run : () -> Int with Async`; reject
+  // every other entry explicitly rather than emitting an unsatisfied core.
+  if uses_stdin_provider_surface && (entry_name != "run" || !lc_entry_declares_async(stmts, entry_name)) {
+    throw("Stdin::read_via_stream requires an Async component entry named run; standalone core/library and non-Async entries cannot provide the stdin lifecycle")
+  } else {
+    ()
+  }
   let need_env_get_builtin = Map::has_key(used_builtin_names, "Env::get")
   let need_env_args_len_builtin = Map::has_key(used_builtin_names, "Env::args_len")
   let need_env_args_get_builtin = Map::has_key(used_builtin_names, "Env::args_get")
@@ -3896,13 +3984,11 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   // module bytes are unchanged -- the injected `__hs_close` is the only
   // caller, and it only exists when the source called `host_stream_close`.
   let need_host_stream_close_builtin = Map::has_key(used_builtin_names, "vibe_hs_close_raw")
-  // #1539 core-only stdin provider route. The registry names are checker-
-  // invisible and therefore only compiler-injected/raw AST can request these
-  // imports. Keep each half independently gated so unused registry rows do not
-  // widen a component's authority.
-  let need_stdin_provider_acquire_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_acquire_raw")
-  let need_stdin_provider_read_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_read_raw")
-  let need_stdin_provider_close_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_close_raw")
+  // #1539 public names and checker-hidden raw names share the exact three
+  // component-private import targets. Gate each half independently.
+  let need_stdin_provider_acquire_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_acquire_raw") || Map::has_key(used_builtin_names, "Stdin::read_via_stream")
+  let need_stdin_provider_read_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_read_raw") || Map::has_key(used_builtin_names, "StdinStream::next")
+  let need_stdin_provider_close_builtin = Map::has_key(used_builtin_names, "vibe_stdin_provider_close_raw") || Map::has_key(used_builtin_names, "StdinStream::close")
   // Process effect host imports: `sh(cmd)` runs a shell command (returns 0) and
   // `sh_lines(cmd)` returns its stdout "\n"-joined as ONE string (same packed
   // ABI as fs_read_dir; compile_call lowers the Array[String] surface to a
@@ -5029,10 +5115,14 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
         // ADR-0089 Decision 3 follow-up: shared drop half of the named host
         // streams (`host_stream_close` -> injected `__hs_close`).
         "vibe_hs_close_raw" => hs_close_idx,
-        // #1539 checker-hidden core-only stdin provider bridge.
+        // #1539 public and checker-hidden spellings share the same exact raw
+        // component-private targets, including first-class function aliases.
         "vibe_stdin_provider_acquire_raw" => stdin_provider_acquire_idx,
         "vibe_stdin_provider_read_raw" => stdin_provider_read_idx,
         "vibe_stdin_provider_close_raw" => stdin_provider_close_idx,
+        "Stdin::read_via_stream" => stdin_provider_acquire_idx,
+        "StdinStream::next" => stdin_provider_read_idx,
+        "StdinStream::close" => stdin_provider_close_idx,
         "simd_skip_ws" => simd_skip_ws_idx,
         "simd_scan_alnum" => simd_scan_alnum_idx,
         "simd_scan_alnum_str" => simd_scan_alnum_str_idx,

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -77,6 +77,10 @@ fn reg_opaque(kind: String) -> Type {
   CtUnknown
 }
 
+fn reg_stdin_stream() -> Type {
+  CtStruct("#vibe_stdin_stream")
+}
+
 fn reg_p0() -> Array[Type] {
   array_empty()
 }
@@ -268,14 +272,18 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   // codegen-internal shape as the read half (injected `__hs_close` only),
   // and NOT async: dropping a readable end never blocks.
   ("vibe_hs_close_raw", CtFn(reg_p1(CtInt), CtInt, None), true, false, false),
-  // #1539 core-only stdin provider route. These names are deliberately
-  // checker-invisible: they are reserved for compiler-generated/raw core
-  // calls and must not become a source-level authority surface. The component
-  // adapter owns the nominal stream plus completion future behind an opaque
-  // provider ID; it never exposes either canonical handle as HostStream.
+  // #1539 checker-hidden stdin provider core route. The component adapter
+  // owns the canonical stream plus completion future behind an opaque ID.
   ("vibe_stdin_provider_acquire_raw", CtFn(reg_p0(), CtInt, None), true, false, false),
   ("vibe_stdin_provider_read_raw", CtFn(reg_p1(CtInt), CtInt, None), true, false, false),
   ("vibe_stdin_provider_close_raw", CtFn(reg_p1(CtInt), CtInt, None), true, false, false),
+  // Public source surface over that exact route. The unspellable CtStruct
+  // identity prevents Int/HostStream/user types from forging a handle; the
+  // runtime value remains one tagged scalar provider ID. Acquisition owns
+  // only Stdin authority; operations that may settle carry only Async.
+  ("Stdin::read_via_stream", CtFn(reg_p0(), reg_stdin_stream(), Some("Stdin")), true, false, true),
+  ("StdinStream::next", CtFn(reg_p1(reg_stdin_stream()), CtInt, Some("Async")), true, false, true),
+  ("StdinStream::close", CtFn(reg_p1(reg_stdin_stream()), CtUnit, Some("Async")), true, false, true),
   ("Stdin::read_char", CtFn(reg_p0(), CtInt, Some("Stdin")), true, false, true),
   ("simd_skip_ws", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),
   ("simd_scan_alnum", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),
@@ -417,7 +425,10 @@ export fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)] {
 /// Derived 5-tuple view for the two codegen lanes -- SAME shape as the B-0/B-1
 /// table so wasi/linked_compile.vibe and gc/backend_body.vibe are unchanged:
 /// param_count = the type's parameter count, returns = 0 iff the return type
-/// is CtUnit.
+/// is CtUnit. #1539's StdinStream::close is the one ABI exception: its hidden
+/// raw core route returns tagged zero, which is exactly Unit's value, so it
+/// stays value-returning to preserve the same target for direct calls and
+/// first-class function aliases.
 export fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)] {
   let rows = builtin_registry_typed()
   let out = array_empty()
@@ -427,7 +438,11 @@ export fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)] {
     let (pc, ret) = match ty {
       CtFn(params, ret_ty, _) => {
         let r = match ret_ty {
-          CtUnit => 0,
+          CtUnit => if name == "StdinStream::close" {
+            1
+          } else {
+            0
+          },
           _ => 1
         }
         (Array::length(params), r)

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -575,6 +575,20 @@ fn rewrite_alias_qualified_head(expr: Expr, name: String, am: AliasIdx) -> Expr 
   }
 }
 
+fn rewrite_alias_type_opt(ty: Option[TypeExpr], am: AliasIdx) -> Option[TypeExpr] {
+  match ty {
+    Some(inner) => Some(rewrite_alias_type_expr(inner, am)),
+    None => None
+  }
+}
+
+fn rewrite_alias_param_types(params: Array[(String, Option[TypeExpr])], am: AliasIdx) -> Array[(String, Option[TypeExpr])] {
+  for param in params {
+    let (name, ty) = param
+    (name, rewrite_alias_type_opt(ty, am))
+  }
+}
+
 fn rewrite_alias_expr_ix(expr: Expr, am: AliasIdx) -> Expr {
   // Perf: with no aliases the rewrite is the identity, but the match below
   // still rebuilt EVERY node of the tree. Alias maps only shrink on the way
@@ -651,7 +665,14 @@ fn rewrite_alias_expr_ix(expr: Expr, am: AliasIdx) -> Expr {
       }, off),
       EBinOp(op, left, right) => EBinOp(op, rewrite_alias_expr_ix(left, am), rewrite_alias_expr_ix(right, am)),
       EUnaryOp(op, value) => EUnaryOp(op, rewrite_alias_expr_ix(value, am)),
-      EFn(type_params, bounds, params, ret_ty, effect, body) => EFn(type_params, bounds, params, ret_ty, effect, rewrite_alias_expr_ix(body, aliasidx_without_params(am, params))),
+      EFn(type_params, bounds, params, ret_ty, effect, body) => {
+        // Type formals shadow imported TYPE aliases, independently of value
+        // parameters shadowing imported VALUE aliases. Preserve both
+        // namespaces while canonicalizing imported contract aliases in fn
+        // parameter and return annotations (#1539 StdinStream as S).
+        let type_am = aliasidx_without_names(am, type_params)
+        EFn(type_params, bounds, rewrite_alias_param_types(params, type_am), rewrite_alias_type_opt(ret_ty, type_am), effect, rewrite_alias_expr_ix(body, aliasidx_without_params(am, params)))
+      },
       // #897: `mod.x` written against a qualified-import namespace (`import
       // ... as mod only { x }`) is encoded as the alias key "mod.x" -- see
       // qualify_import_items in lib/@vibe/parser/parser.vibe. A real
@@ -767,8 +788,8 @@ export fn rewrite_import_alias_stmt(stmt: Stmt, aliases: Array[(String, String)]
 
 fn rewrite_alias_stmt_ix(stmt: Stmt, am: AliasIdx) -> Stmt {
   match stmt {
-    SLet(exported, is_rec, name, ty, body) => SLet(exported, is_rec, name, ty, rewrite_alias_expr_ix(body, aliasidx_without_name(am, name))),
-    SLetMut(name, ty, body) => SLetMut(name, ty, rewrite_alias_expr_ix(body, aliasidx_without_name(am, name))),
+    SLet(exported, is_rec, name, ty, body) => SLet(exported, is_rec, name, rewrite_alias_type_opt(ty, am), rewrite_alias_expr_ix(body, aliasidx_without_name(am, name))),
+    SLetMut(name, ty, body) => SLetMut(name, rewrite_alias_type_opt(ty, am), rewrite_alias_expr_ix(body, aliasidx_without_name(am, name))),
     STest(name, body) => STest(name, rewrite_alias_expr_ix(body, am)),
     SBench(name, body) => SBench(name, rewrite_alias_expr_ix(body, am)),
     SExpr(body) => SExpr(rewrite_alias_expr_ix(body, am)),

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1033,7 +1033,14 @@ export fn type_to_string(ty: Type) -> String {
     CtArray(elem) => String::concat("Array[", String::concat(type_to_string(elem), "]")),
     CtOption(elem) => String::concat("Option[", String::concat(type_to_string(elem), "]")),
     CtEnum(name) => name,
-    CtStruct(name) => name,
+    // #1539: the checker identity is deliberately unspellable so source
+    // structs/types cannot forge a provider token. Diagnostics expose only
+    // the public nominal spelling.
+    CtStruct(name) => if name == "#vibe_stdin_stream" {
+      "StdinStream"
+    } else {
+      name
+    },
     CtNamed(name, args) => if Array::length(args) == 0 {
       name
     } else {
@@ -1139,6 +1146,12 @@ export fn resolve_builtin(name: String) -> Option[Type] {
   }
   else if name == "Bytes" {
     Some(CtBytes)
+  }
+  else if name == "StdinStream" {
+    // #1539: compiler-owned opaque scalar token. CtStruct with an unspellable
+    // identity is concrete (unlike a nullary CtNamed) while remaining
+    // impossible for source declarations or literals to manufacture.
+    Some(CtStruct("#vibe_stdin_stream"))
   }
   else if name == "V128" {
     // #536: first-class WebAssembly 128-bit SIMD type. Represented structurally

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -125,6 +125,8 @@ fn compile_source_wasi_only(source: String, entry_name: String) -> Bytes with Ex
 fn compile_source_wasi_only_coverage(source: String, entry_name: String) -> Bytes with Exception
 fn compile_source_wasi_only_rc(source: String, entry_name: String) -> Bytes with Exception
 fn compile_source_wasi_only_rc_shadow(source: String, entry_name: String) -> Bytes with Exception
+fn maybe_wrap_stdin_provider_core(bytes: Bytes, entry_name: String) -> Bytes with Exception
+fn reject_stdin_provider_core(bytes: Bytes, mode: String) -> Bytes with Exception
 
 // --- preprocess_interp.vibe
 fn expand_interp_stmts(stmts: Array[Stmt]) -> Unit with Exception

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess.vibe
@@ -1,7 +1,12 @@
 //# Imports
 
 export ./preprocess_compile.vibe {
-  compile_source_wasi_only, compile_source_wasi_only_coverage, compile_source_wasi_only_rc, compile_source_wasi_only_rc_shadow
+  compile_source_wasi_only,
+  compile_source_wasi_only_coverage,
+  compile_source_wasi_only_rc,
+  compile_source_wasi_only_rc_shadow,
+  maybe_wrap_stdin_provider_core,
+  reject_stdin_provider_core
 }
 
 export ./preprocess_interp.vibe {
@@ -20,5 +25,7 @@ export {
   compile_source_wasi_only_rc,
   compile_source_wasi_only_rc_shadow,
   expand_interp_stmts,
+  maybe_wrap_stdin_provider_core,
+  reject_stdin_provider_core,
   strip_generic_type_params
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
@@ -108,6 +108,38 @@ fn entry_declares_async_int(stmts: Array[Stmt], entry_name: String) -> Bool {
 /// host-future composition (adapter-provided imports + `get-future`
 /// component import + u32 lift, driven by viberun); everything else keeps
 /// the self-contained trampolined-p1 shape byte-identically.
+fn stdin_provider_component_only_diagnostic(mode: String) -> String {
+  String::concat("StdinStream is component-only; ", String::concat(mode, " cannot emit its component-private stdin provider imports. Use an Async component entry named run without this instrumentation mode"))
+}
+
+/// Reject an exact compiled-core stdin-provider import before a caller can
+/// publish that core as a standalone artifact. The import detector parses the
+/// core import section; it does not guess from source names, so shadowed/user
+/// identifiers cannot trigger this boundary.
+export fn reject_stdin_provider_core(bytes: Bytes, mode: String) -> Bytes with Exception {
+  if comp_core_imports_stdin_provider(bytes) {
+    throw(stdin_provider_component_only_diagnostic(mode))
+  } else {
+    bytes
+  }
+}
+
+/// Route an arbitrary compiled core through the production stdin-provider
+/// composer when (and only when) its parsed imports contain the exact private
+/// provider ABI. Used by the import-resolving CLI lane, whose frontend cannot
+/// use compile_source_wasi_only's source-local async wrapper decision.
+export fn maybe_wrap_stdin_provider_core(bytes: Bytes, entry_name: String) -> Bytes with Exception {
+  if comp_core_imports_stdin_provider(bytes) {
+    if entry_name == "run" {
+      comp_emit_component_wasm_async_stdin_provider(bytes, "run")
+    } else {
+      throw("StdinStream is component-only and requires an Async component entry named run")
+    }
+  } else {
+    bytes
+  }
+}
+
 fn maybe_wrap_async_component(bytes: Bytes, wrap_async: Bool) -> Bytes with Exception {
   if wrap_async {
     // #1539: provider routing is first because its nominal stdin lifecycle
@@ -150,7 +182,10 @@ export fn compile_source_wasi_only_coverage(source: String, entry_name: String) 
   expand_interp_stmts(stmts)
   let _ = check_program(stmts)
   strip_generic_type_params(stmts)
-  compile_wasi_module_coverage_impl(stmts, entry_name)
+  // Coverage consumers require a standalone instrumented core. StdinStream's
+  // raw provider ABI is satisfiable only inside the dedicated component, so
+  // parse the emitted core imports and fail before returning any artifact.
+  reject_stdin_provider_core(compile_wasi_module_coverage_impl(stmts, entry_name), "VIBE_COVERAGE=1")
 }
 
 /// ADR-0055 #493 cutover: same pipeline on the Perceus RC codegen path. Lets the

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
@@ -20,7 +20,7 @@ import ./preprocess_strip.vibe {
 }
 
 import @vibe/compiler/core {
-  Stmt, TypeExpr
+  Expr, Stmt, TypeExpr
 }
 
 import ./component_codegen.vibe {
@@ -38,12 +38,25 @@ import ./component_codegen.vibe {
 /// `() -> Int with Async` (no params)? If so its compiled core wasm should be
 /// wrapped into an async-lifted WASM component. Detected from the declared TyFn
 /// effect annotation (before generic-param stripping).
+fn entry_expr_declares_async_int(value: Expr) -> Bool {
+  match value {
+    EFn(_, _, params, ret, eff, _) => match ret {
+      Some(TyName(rn)) => rn == "Int" && Array::length(params) == 0 && match eff {
+        Some(row) => String::contains(row, "Async"),
+        None => false
+      },
+      _ => false
+    },
+    _ => false
+  }
+}
+
 fn entry_declares_async_int(stmts: Array[Stmt], entry_name: String) -> Bool {
   let mut found = false
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(_, _, name, opt_ty, _) => if name == entry_name {
+      SLet(_, _, name, opt_ty, value) => if name == entry_name {
         // Flattened patterns: the pinned selfhost seed does not bind variables
         // inside nested constructor patterns (e.g. `Some(ty)` as a sub-pattern),
         // so match each Option level separately to stay seed-buildable
@@ -67,7 +80,14 @@ fn entry_declares_async_int(stmts: Array[Stmt], entry_name: String) -> Bool {
             },
             _ => ()
           },
-          None => ()
+          None => if entry_expr_declares_async_int(value) {
+            // `fn run() -> Int with Async { ... }` stores its signature on the
+            // EFn rather than an SLet annotation. #1539's public source gate
+            // uses that canonical spelling, so detect both AST forms.
+            found = true
+          } else {
+            ()
+          }
         }
       } else {
         ()

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -645,7 +645,7 @@ fn is_scalar_expr(ctx: PCtx, e: Expr) -> Bool {
     // corrupt it (or an adjacent allocation). Treat the binding as scalar
     // (never dup/drop'd), matching the box's actual bump-only, never-freed
     // lifetime under both backends.
-    ECall(EIdent(fname, _), _, _) => is_v128_box_call(fname) || is_borrow_ret_fname(ctx, fname),
+    ECall(EIdent(fname, _), _, _) => fname == "Stdin::read_via_stream" || is_v128_box_call(fname) || is_borrow_ret_fname(ctx, fname),
     _ => false
   }
 }
@@ -1004,7 +1004,7 @@ fn type_name_is_heap(n: String) -> Bool {
     let c0 = String::char_code_at(n, 0)
     if c0 < 'A' || c0 > 'Z' {
       false
-    } else if n == "Int" || n == "Bool" || n == "Double" || n == "Float" || n == "String" || n == "Bytes" || n == "Char" || n == "Unit" || n == "V128" {
+    } else if n == "Int" || n == "Bool" || n == "Double" || n == "Float" || n == "String" || n == "Bytes" || n == "Char" || n == "Unit" || n == "V128" || n == "StdinStream" {
       // #705: V128 is a tagged pointer to a 16-byte box (see compile_call.vibe
       // v128_load/v128_splat_i8x16/etc), but the box has NO rc header
       // (type_id/refcount) -- it's a bare payload written directly by

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -781,6 +781,22 @@ fn dependency_typedef_projection(dep_env: TypeEnv, names: Array[(String, Option[
         },
         None => ()
       }
+    } else if contains_str(selectable, name) && name == "StdinStream" {
+      // Compiler-owned builtin types have no TypeDef node in the dependency
+      // interface. Preserve this one opaque identity under an explicit import
+      // alias instead of degrading `S` to an ordinary forgeable CtNamed. Keep
+      // the exception exact: user/generic typedef projection is unchanged.
+      match alias {
+        Some(local_name) => if local_name != name {
+          match resolve_builtin(name) {
+            Some(target) => Array::push(selected, TDAlias(local_name, array_empty(), target)),
+            None => ()
+          }
+        } else {
+          ()
+        },
+        None => ()
+      }
     } else {
       ()
     }

--- a/lib/@vibe/compiler/tests/builtins_test.vibe
+++ b/lib/@vibe/compiler/tests/builtins_test.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/checker {
 }
 
 import @vibe/compiler/core {
-  Type, builtin_registry_typed
+  Type, builtin_registry_typed, type_to_string
 }
 
 //# Misc
@@ -37,6 +37,40 @@ test "#1539 stdin provider raw names remain checker-invisible" {
       None => assert(true)
     }
     i = i + 1
+  }
+}
+
+test "#1539 public StdinStream surface is visible with exact effects" {
+  let expected = [
+    "() -> StdinStream with Stdin",
+    "(StdinStream) -> Int with Async",
+    "(StdinStream) -> () with Async"
+  ]
+  let names = [
+    "Stdin::read_via_stream",
+    "StdinStream::next",
+    "StdinStream::close"
+  ]
+  let rows = builtin_registry_typed()
+  let mut ni = 0
+  while ni < Array::length(names) {
+    let mut ri = 0
+    let mut found = false
+    while ri < Array::length(rows) {
+      let (name, ty, linear, gc, visible) = Array::get(rows, ri)
+      if name == Array::get(names, ni) {
+        assert(linear)
+        assert(!gc)
+        assert(visible)
+        assert(type_to_string(ty) == Array::get(expected, ni))
+        found = true
+      } else {
+        ()
+      }
+      ri = ri + 1
+    }
+    assert(found)
+    ni = ni + 1
   }
 }
 

--- a/lib/@vibe/compiler/tests/checker_nominal_head_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_nominal_head_test.vibe
@@ -67,6 +67,35 @@ test "1538: HostStream retains its direct read lane" {
   assert(check_source_ok("fn read(s: HostStream) -> Int with Async { host_stream_next(s) }\nfn main() -> Int with Async { read(host_stream_named(\"body\")) }"))
 }
 
+test "1539: exact StdinStream token is accepted" {
+  assert(check_source_ok("fn use(s: StdinStream) -> Int with Async { StdinStream::next(s) }\nfn run() -> Int with Stdin + Async { use(Stdin::read_via_stream()) }"))
+}
+
+test "1539: StdinStream cannot cross Int, HostStream, Stream, or user-struct boundaries" {
+  assert(check_source_err("fn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(1) }"))
+  assert(check_source_err("fn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(host_stream_named(\"body\")) }"))
+  assert(check_source_err("fn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(Stream::once(1)) }"))
+  assert(check_source_err("struct Fake { value: Int }\nfn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(Fake::{ value: 1 }) }"))
+  assert(check_source_err("fn use(i: Int) -> Int { i }\nfn run() -> Int with Stdin { use(Stdin::read_via_stream()) }"))
+  assert(check_source_err("fn use(s: HostStream) -> Int { 0 }\nfn run() -> Int with Stdin { use(Stdin::read_via_stream()) }"))
+}
+
+test "1539: a source struct named StdinStream cannot forge the token" {
+  assert(check_source_err("struct StdinStream { value: Int }\nfn run() -> Int with Async { let s = StdinStream::{ value: 1 }; StdinStream::next(s) }"))
+}
+
+test "1539: StdinStream does not satisfy Send" {
+  assert(check_source_err("fn require_send[T: Send](x: T) -> Int { 0 }\nfn run() -> Int with Stdin { require_send(Stdin::read_via_stream()) }"))
+}
+
+test "1539: acquisition and operations carry only their exact authority" {
+  assert(check_source_err("fn run() -> Int { let s = Stdin::read_via_stream(); 0 }"))
+  assert(check_source_ok("fn run() -> Int with Stdin { let s = Stdin::read_via_stream(); 0 }"))
+  assert(check_source_err("fn run() -> Int with Stdin { let s = Stdin::read_via_stream(); StdinStream::next(s) }"))
+  assert(check_source_ok("fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); StdinStream::next(s) }"))
+  assert(check_source_ok("fn consume(s: StdinStream) -> Unit with Async { StdinStream::close(s) }\nfn run() -> Int with Stdin + Async { consume(Stdin::read_via_stream()); 0 }"))
+}
+
 test "1001: genuinely generic parameter stays tolerated (no over-rejection)" {
   assert(check_source_ok("struct Box[T] { v: T }\nfn second[T](b: Box[T], d: Int) -> Int { d }\nfn main() -> Int {\n  let b: Box[String] = Box::{ v: \"hello\" }\n  second(b, 42)\n}"))
 }

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -18,3 +18,13 @@ test "append import alias rewrite resolves import aliases" {
   assert(String::contains(printed, "answer()"))
   assert(!String::contains(printed, "local()"))
 }
+
+test "imported type aliases rewrite fn annotations but not type formals" {
+  let stmts = parse_program(lex("import ./dep.vibe { StdinStream as S }\nfn take(stream: S) -> S { stream }\nfn id[S](value: S) -> S { value }"))
+  let out = Array::slice(stmts, 0, 0)
+  append_import_alias_rewritten_non_import_stmts(out, stmts)
+  let printed = print_program(out)
+  assert(String::contains(printed, "StdinStream"))
+  assert(!String::contains(printed, "(stream: S)"))
+  assert(String::contains(printed, "(value: S)"))
+}

--- a/lib/@vibe/console/index.vpkg
+++ b/lib/@vibe/console/index.vpkg
@@ -7,10 +7,9 @@ deps = {}
 generated_hash =
 
 // @vibe/console — stdin/stdout/stderr line- and byte-level I/O primitives
-// (ADR-0070 Phase 3, #897). No opaque/transparent types: every declared name
-// is a pure/effectful fn over primitives (String/Int/Bool/Option/Array) or a
-// `() -> Option[String] with Stdin` closure value (byte_stream.vibe),
-// never a struct/enum, so there is no type surface to declare.
+// (ADR-0070 Phase 3, #897). #1539 adds one compiler-owned opaque type,
+// StdinStream; it is represented by an unforgeable scalar provider token and
+// cannot be constructed as a struct/enum or converted to generic HostStream.
 //
 // `read`/`print`/`println`/`read_char`/`read_line`/`read_n`/`read_all`/
 // `write_char` carry the checker-builtin `Stdin`/`Stdout` effects (no import
@@ -49,6 +48,12 @@ generated_hash =
 // on a no-entry `vibe test` run, EXECUTE) those side-effecting example tests
 // as a hidden side effect of merely importing @vibe/io. Renamed to
 // example_io_test.vibe so it's excluded like any other test file.
+
+// --- atomic stdin provider lifecycle (#1539)
+type StdinStream
+fn Stdin::read_via_stream() -> StdinStream with Stdin
+fn StdinStream::next(stream: StdinStream) -> Int with Async
+fn StdinStream::close(stream: StdinStream) -> Unit with Async
 
 // --- io
 fn read(max_bytes: Int) -> String with Stdin

--- a/lib/@vibe/console/index_import_test.vibe
+++ b/lib/@vibe/console/index_import_test.vibe
@@ -1,10 +1,14 @@
 //# Imports
 
 import .{
-  io_print, io_println, io_read, io_read_char, io_read_line, io_write_char
+  StdinStream, io_print, io_println, io_read, io_read_char, io_read_line, io_write_char
 }
 
 //# Misc
+
+fn stdin_stream_type_name_is_importable(_stream: StdinStream) -> Int {
+  1
+}
 
 test "io index exports canonical aliases" {
   let _ = io_read
@@ -13,5 +17,10 @@ test "io index exports canonical aliases" {
   let _ = io_write_char
   io_print("")
   io_println("")
+  assert(true)
+}
+
+test "console contract exports the opaque stdin stream type" {
+  let _ = stdin_stream_type_name_is_importable
   assert(true)
 }

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -70,6 +70,9 @@ Stderr::write_char	linear-only	host-import	host/linear-memory import; the gc lan
 Stderr::write_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdin::read_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdin::read_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
+Stdin::read_via_stream	linear-only	async-component-only	#1539 public acquisition route; the GC callsite arm is a loud rejection, not an implementation
+StdinStream::close	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
+StdinStream::next	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
 Stdout::write_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdout::write_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stream::empty	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane

--- a/scripts/check_builtin_parity.sh
+++ b/scripts/check_builtin_parity.sh
@@ -35,6 +35,26 @@ def callsite_names(path):
 
 lin_cs = callsite_names(LIN_CALLSITE)
 gc_cs = callsite_names(GC_CALLSITE)
+
+# A loud rejection is not an implementation. Keep this subtraction narrow and
+# mutation-checked: these public rows deliberately appear in one GC condition
+# whose body only throws the component-only diagnostic. If that shape moves,
+# fail instead of silently counting (or excluding) the wrong names.
+gc_text = open(GC_CALLSITE).read()
+gc_throw_only_expected = {
+    "Stdin::read_via_stream", "StdinStream::next", "StdinStream::close"
+}
+throw_only_match = re.search(
+    r'if\s+((?:fname == "(?:Stdin::read_via_stream|StdinStream::next|StdinStream::close)"(?:\s*\|\|\s*)?)+)\s*\{\s*throw\("StdinStream is unsupported on gc backend;',
+    gc_text)
+throw_only_found = (set(re.findall(r'fname == "([^"]+)"', throw_only_match.group(1)))
+                    if throw_only_match else set())
+if throw_only_found != gc_throw_only_expected:
+    print("[builtin-parity] FAIL: GC StdinStream rejection shape changed; "
+          "update the throw-only extraction without counting rejection as "
+          f"implementation (found {sorted(throw_only_found)})", file=sys.stderr)
+    sys.exit(1)
+gc_cs -= throw_only_found
 if not lin_cs or not gc_cs:
     print(f"[builtin-parity] FAIL: extracted no dispatch arms "
           f"(linear {len(lin_cs)}, gc {len(gc_cs)}) -- did the dispatch "

--- a/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
@@ -18,6 +18,7 @@ fi
 [ -n "$COMPILER" ] && [ -s "$COMPILER" ] || COMPILER="$(find _build/ci-artifacts -name stage2.wasm -type f 2>/dev/null | head -1 || true)"
 [ -n "$COMPILER" ] && [ -s "$COMPILER" ] || COMPILER="$ROOT/bootstrap/seed/compiler.wasm"
 [ -s "$COMPILER" ] || { echo "stdin provider source gate FAILED: no compiler" >&2; exit 1; }
+COMPILER="$(cd "$(dirname "$COMPILER")" && pwd)/$(basename "$COMPILER")"
 command -v wasm-tools >/dev/null 2>&1 || { echo "stdin provider source gate FAILED: wasm-tools is required" >&2; exit 1; }
 grep -Fq 'type StdinStream' lib/@vibe/console/index.vpkg
 grep -Fq 'fn Stdin::read_via_stream() -> StdinStream with Stdin' lib/@vibe/console/index.vpkg
@@ -76,13 +77,47 @@ fn run() -> Int with Stdin + Async {
   if a == 10 && b == 15 { 45 } else { 0 }
 }
 EOF
+cat >"$OUT/import-alias.vibe" <<'EOF'
+import @vibe/console { StdinStream as S }
+
+fn acquire() -> StdinStream with Stdin { Stdin::read_via_stream() }
+fn next_alias(stream: S) -> Int with Async { StdinStream::next(stream) }
+fn close_alias(stream: S) -> Unit with Async { StdinStream::close(stream) }
+
+fn run() -> Int with Stdin + Async {
+  let stream = acquire()
+  let first = next_alias(stream)
+  close_alias(stream)
+  if first == 10 { 46 } else { 0 }
+}
+EOF
+# Isolated minimal contract fixture: preserve the exact public package spelling
+# while avoiding unrelated @vibe/console implementation imports in this
+# component-composer test. The type is still compiler-owned (no source body).
+mkdir -p "$OUT/pkg/@vibe/console"
+cat >"$OUT/pkg/@vibe/console/index.vpkg" <<'EOF'
+name = @vibe/console
+version = 0.0.1
+deps = {}
+
+generated_hash =
+
+type StdinStream
+EOF
 
 compile_component() {
-  local name="$1" rc="${2:-0}"
+  local name="$1" rc="${2:-0}" fs="${3:-0}" isolated="${4:-0}"
   rm -f "$OUT/$name.component.wasm" "$OUT/$name.component.wasm.diag"
-  VIBE_RC="$rc" VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
-    bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
-    "$COMPILER" "$OUT/$name.vibe" "$OUT/$name.component.wasm" run >/dev/null
+  local -a envs=(VIBE_RC="$rc" VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw)
+  [ "$fs" != 1 ] || envs+=(VIBE_FS_COMPILE=1)
+  if [ "$isolated" = 1 ]; then
+    (cd "$OUT" && env "${envs[@]}" VIBE_LIB="$OUT/pkg" \
+      bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+      "$COMPILER" "$OUT/$name.vibe" "$OUT/$name.component.wasm" run >/dev/null)
+  else
+    env "${envs[@]}" bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+      "$COMPILER" "$OUT/$name.vibe" "$OUT/$name.component.wasm" run >/dev/null
+  fi
   [ -s "$OUT/$name.component.wasm" ] || { cat "$OUT/$name.component.wasm.diag" >&2 || true; exit 1; }
   [ "$(od -A n -t x1 -N 8 "$OUT/$name.component.wasm" | awk '{print $5}')" = "0d" ]
   wasm-tools validate --features all "$OUT/$name.component.wasm"
@@ -91,6 +126,7 @@ compile_component drain
 compile_component early-alias
 compile_component second
 compile_component multiple-active
+compile_component import-alias 0 1 1
 cp "$OUT/drain.vibe" "$OUT/drain-rc.vibe"
 compile_component drain-rc 1
 
@@ -110,10 +146,11 @@ if grep -Fq 'host_stream_get$stdin' "$WAT" || grep -Fq 'host_stream_read' "$WAT"
 fi
 
 actionable_fail() {
-  local name="$1" entry="$2" expected="$3" backend="${4:-linear}"
+  local name="$1" entry="$2" expected="$3" backend="${4:-linear}" fs="${5:-0}"
   rm -f "$OUT/$name.wasm" "$OUT/$name.wasm.diag"
-  local -a envs=(VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw)
+  local -a envs=(VIBE_LIB="$ROOT/lib" VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw)
   [ "$backend" != gc ] || envs+=(VIBE_BACKEND=gc)
+  [ "$fs" != 1 ] || envs+=(VIBE_FS_COMPILE=1)
   env "${envs[@]}" bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
     "$COMPILER" "$OUT/$name.vibe" "$OUT/$name.wasm" "$entry" >/dev/null 2>&1 || true
   if [ -s "$OUT/$name.wasm" ]; then
@@ -138,6 +175,13 @@ cat >"$OUT/nominal.vibe" <<'EOF'
 fn run() -> Int with Async { StdinStream::next(1) }
 EOF
 actionable_fail nominal run 'expected StdinStream, got Int'
+cat >"$OUT/alias-forgery.vibe" <<'EOF'
+import @vibe/console { StdinStream as S }
+struct Fake { value: Int }
+fn consume(stream: S) -> Int with Async { StdinStream::next(stream) }
+fn run() -> Int with Async { consume(Fake::{ value: 1 }) }
+EOF
+actionable_fail alias-forgery run 'expected StdinStream, got Fake' linear 1
 cat >"$OUT/reserved.vibe" <<'EOF'
 fn run() -> Int with Async { let _ = host_stream_named("stdin"); 0 }
 EOF
@@ -154,6 +198,45 @@ cat >"$OUT/gc.vibe" <<'EOF'
 fn main() -> Int with Stdin { let _ = Stdin::read_via_stream(); 0 }
 EOF
 actionable_fail gc main 'StdinStream is unsupported on gc backend' gc
+cat >"$OUT/coverage.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  StdinStream::close(stream)
+  0
+}
+EOF
+rm -f "$OUT/coverage.wasm" "$OUT/coverage.wasm.diag" "$OUT/coverage.log"
+VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+  "$COMPILER" "$OUT/coverage.vibe" "$OUT/coverage.wasm" run \
+  >"$OUT/coverage.log" 2>&1 || true
+if [ -s "$OUT/coverage.wasm" ]; then
+  echo "stdin provider source gate FAILED: coverage emitted a standalone artifact" >&2
+  exit 1
+fi
+grep -Fq 'StdinStream is component-only; VIBE_COVERAGE=1 cannot emit' "$OUT/coverage.wasm.diag"
+if grep -Fq 'stdin_provider_' "$OUT/coverage.wasm.diag" "$OUT/coverage.log"; then
+  echo "stdin provider source gate FAILED: coverage exposed the raw provider ABI" >&2
+  exit 1
+fi
+# The import-resolving file lane is a second preprocess bypass. Exercise it
+# against the exact aliased public contract and require the same no-artifact,
+# no-raw-ABI result before cli_adapter can write the instrumented core.
+rm -f "$OUT/import-alias-coverage.wasm" "$OUT/import-alias-coverage.wasm.diag" "$OUT/import-alias-coverage.log"
+(cd "$OUT" && VIBE_COVERAGE=1 VIBE_FS_COMPILE=1 VIBE_LIB="$OUT/pkg" \
+  VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+  "$COMPILER" "$OUT/import-alias.vibe" "$OUT/import-alias-coverage.wasm" run \
+  >"$OUT/import-alias-coverage.log" 2>&1 || true)
+if [ -s "$OUT/import-alias-coverage.wasm" ]; then
+  echo "stdin provider source gate FAILED: FS coverage emitted a standalone artifact" >&2
+  exit 1
+fi
+grep -Fq 'StdinStream is component-only; VIBE_COVERAGE=1 cannot emit' "$OUT/import-alias-coverage.wasm.diag"
+if grep -Fq 'stdin_provider_' "$OUT/import-alias-coverage.wasm.diag" "$OUT/import-alias-coverage.log"; then
+  echo "stdin provider source gate FAILED: FS coverage exposed the raw provider ABI" >&2
+  exit 1
+fi
 
 echo "[stdin-provider-source] source compile/structure/negative gates OK"
 WT="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
@@ -180,5 +263,6 @@ run_lane drain 42
 run_lane early-alias 43
 run_lane second 44
 run_lane multiple-active 45
+run_lane import-alias 46
 run_lane drain-rc 42
 echo "wasi cli stdin provider source component gate OK (wasmtime 47.0.2)"

--- a/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# #1539: compile the public StdinStream API from real source, validate its exact
+# component boundary, and run lifecycle/alias/reacquisition scenarios on the
+# pinned Wasmtime 47 lane.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT"
+OUT="$ROOT/_build/bench/wasi_cli_stdin_provider_source"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+COMPILER="${VIBE_STDIN_PROVIDER_GATE_COMPILER:-}"
+if [ -z "$COMPILER" ]; then
+  COMPILER="$(find _build/selfhost/generations -name stage2.wasm -type f 2>/dev/null | sort | tail -1 || true)"
+fi
+[ -n "$COMPILER" ] && [ -s "$COMPILER" ] || COMPILER="$(find _build/ci-artifacts -name stage2.wasm -type f 2>/dev/null | head -1 || true)"
+[ -n "$COMPILER" ] && [ -s "$COMPILER" ] || COMPILER="$ROOT/bootstrap/seed/compiler.wasm"
+[ -s "$COMPILER" ] || { echo "stdin provider source gate FAILED: no compiler" >&2; exit 1; }
+command -v wasm-tools >/dev/null 2>&1 || { echo "stdin provider source gate FAILED: wasm-tools is required" >&2; exit 1; }
+grep -Fq 'type StdinStream' lib/@vibe/console/index.vpkg
+grep -Fq 'fn Stdin::read_via_stream() -> StdinStream with Stdin' lib/@vibe/console/index.vpkg
+grep -Fq 'fn StdinStream::next(stream: StdinStream) -> Int with Async' lib/@vibe/console/index.vpkg
+grep -Fq 'fn StdinStream::close(stream: StdinStream) -> Unit with Async' lib/@vibe/console/index.vpkg
+if grep -Fq 'vibe_stdin_provider_' lib/@vibe/console/index.vpkg; then
+  echo "stdin provider source gate FAILED: raw names leaked into console contract" >&2
+  exit 1
+fi
+
+cat >"$OUT/drain.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let alias = stream
+  let a = StdinStream::next(alias)
+  let b = StdinStream::next(stream)
+  let c = StdinStream::next(alias)
+  let eof1 = StdinStream::next(stream)
+  let eof2 = StdinStream::next(alias)
+  StdinStream::close(stream)
+  if a == 10 && b == 15 && c == 17 && eof1 == -1 && eof2 == -1 { 42 } else { 0 }
+}
+EOF
+cat >"$OUT/early-alias.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let acquire = Stdin::read_via_stream
+  let next = StdinStream::next
+  let close = StdinStream::close
+  let stream = acquire()
+  let alias = stream
+  let a = next(alias)
+  close(stream)
+  close(alias)
+  if a == 10 && next(alias) == -1 { 43 } else { 0 }
+}
+EOF
+cat >"$OUT/second.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let first = Stdin::read_via_stream()
+  let a = StdinStream::next(first)
+  StdinStream::close(first)
+  let second = Stdin::read_via_stream()
+  let b = StdinStream::next(second)
+  StdinStream::close(second)
+  if a == 10 && b == 15 { 44 } else { 0 }
+}
+EOF
+cat >"$OUT/multiple-active.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let first = Stdin::read_via_stream()
+  let second = Stdin::read_via_stream()
+  let a = StdinStream::next(first)
+  let b = StdinStream::next(second)
+  StdinStream::close(first)
+  StdinStream::close(second)
+  if a == 10 && b == 15 { 45 } else { 0 }
+}
+EOF
+
+compile_component() {
+  local name="$1" rc="${2:-0}"
+  rm -f "$OUT/$name.component.wasm" "$OUT/$name.component.wasm.diag"
+  VIBE_RC="$rc" VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+    bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+    "$COMPILER" "$OUT/$name.vibe" "$OUT/$name.component.wasm" run >/dev/null
+  [ -s "$OUT/$name.component.wasm" ] || { cat "$OUT/$name.component.wasm.diag" >&2 || true; exit 1; }
+  [ "$(od -A n -t x1 -N 8 "$OUT/$name.component.wasm" | awk '{print $5}')" = "0d" ]
+  wasm-tools validate --features all "$OUT/$name.component.wasm"
+}
+compile_component drain
+compile_component early-alias
+compile_component second
+compile_component multiple-active
+cp "$OUT/drain.vibe" "$OUT/drain-rc.vibe"
+compile_component drain-rc 1
+
+WIT="$OUT/drain.wit"
+WAT="$OUT/drain.wat"
+wasm-tools component wit "$OUT/drain.component.wasm" >"$WIT"
+wasm-tools print "$OUT/drain.component.wasm" >"$WAT"
+grep -Fq 'import wasi:cli/types@0.3.0;' "$WIT"
+grep -Fq 'import wasi:cli/stdin@0.3.0;' "$WIT"
+grep -Fq 'read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;' "$WIT"
+grep -Fq 'stdin_provider_acquire' "$WAT"
+grep -Fq 'stdin_provider_read' "$WAT"
+grep -Fq 'stdin_provider_close' "$WAT"
+if grep -Fq 'host_stream_get$stdin' "$WAT" || grep -Fq 'host_stream_read' "$WAT" || grep -Fq 'host_stream_close' "$WAT"; then
+  echo "stdin provider source gate FAILED: generic HostStream route leaked" >&2
+  exit 1
+fi
+
+actionable_fail() {
+  local name="$1" entry="$2" expected="$3" backend="${4:-linear}"
+  rm -f "$OUT/$name.wasm" "$OUT/$name.wasm.diag"
+  local -a envs=(VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw)
+  [ "$backend" != gc ] || envs+=(VIBE_BACKEND=gc)
+  env "${envs[@]}" bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+    "$COMPILER" "$OUT/$name.vibe" "$OUT/$name.wasm" "$entry" >/dev/null 2>&1 || true
+  if [ -s "$OUT/$name.wasm" ]; then
+    echo "stdin provider source gate FAILED: negative $name compiled" >&2
+    exit 1
+  fi
+  grep -Fq "$expected" "$OUT/$name.wasm.diag" || { echo "stdin provider source gate FAILED: $name diagnostic" >&2; cat "$OUT/$name.wasm.diag" >&2 || true; exit 1; }
+}
+cat >"$OUT/raw.vibe" <<'EOF'
+fn run() -> Int with Async { vibe_stdin_provider_acquire_raw() }
+EOF
+actionable_fail raw run 'unknown name: vibe_stdin_provider_acquire_raw'
+cat >"$OUT/acquire-effect.vibe" <<'EOF'
+fn run() -> Int { let _ = Stdin::read_via_stream(); 0 }
+EOF
+actionable_fail acquire-effect run 'missing { Stdin::read_via_stream }'
+cat >"$OUT/next-effect.vibe" <<'EOF'
+fn run() -> Int with Stdin { let s = Stdin::read_via_stream(); StdinStream::next(s) }
+EOF
+actionable_fail next-effect run 'effectful call outside effectful context: StdinStream::next'
+cat >"$OUT/nominal.vibe" <<'EOF'
+fn run() -> Int with Async { StdinStream::next(1) }
+EOF
+actionable_fail nominal run 'expected StdinStream, got Int'
+cat >"$OUT/reserved.vibe" <<'EOF'
+fn run() -> Int with Async { let _ = host_stream_named("stdin"); 0 }
+EOF
+actionable_fail reserved run 'host_stream_named("stdin") is reserved; use Stdin::read_via_stream()'
+cat >"$OUT/mixed.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = host_stream_named("body"); StdinStream::close(s); 0 }
+EOF
+actionable_fail mixed run 'mixing stdin-provider imports with named host future/stream imports is not supported'
+cat >"$OUT/noncomponent.vibe" <<'EOF'
+fn main() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); StdinStream::close(s); 0 }
+EOF
+actionable_fail noncomponent main 'requires an Async component entry named run'
+cat >"$OUT/gc.vibe" <<'EOF'
+fn main() -> Int with Stdin { let _ = Stdin::read_via_stream(); 0 }
+EOF
+actionable_fail gc main 'StdinStream is unsupported on gc backend' gc
+
+echo "[stdin-provider-source] source compile/structure/negative gates OK"
+WT="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
+VERSION="$([ -n "$WT" ] && "$WT" --version 2>/dev/null || true)"
+if [[ "$VERSION" != "wasmtime 47.0.2"* ]]; then
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = 1 ]; then
+    echo "stdin provider source gate FAILED: requires wasmtime 47.0.2, got ${VERSION:-unavailable}" >&2
+    exit 1
+  fi
+  echo "[stdin-provider-source] runtime SKIP: requires wasmtime 47.0.2, got ${VERSION:-unavailable}"
+  exit 0
+fi
+INPUT="$OUT/input.bin"
+printf '\012\017\021' >"$INPUT"
+FLAGS=(-Sp3 -W component-model-async=y -W component-model-async-stackful=y -W component-model-more-async-builtins=y)
+run_lane() {
+  local name="$1" expected="$2"
+  local actual
+  actual="$(timeout 60 "$WT" run "${FLAGS[@]}" --invoke 'run()' "$OUT/$name.component.wasm" <"$INPUT")"
+  [ "$actual" = "$expected" ] || { echo "stdin provider source gate FAILED: $name expected $expected, got $actual" >&2; exit 1; }
+  echo "[stdin-provider-source] $name: $actual"
+}
+run_lane drain 42
+run_lane early-alias 43
+run_lane second 44
+run_lane multiple-active 45
+run_lane drain-rc 42
+echo "wasi cli stdin provider source component gate OK (wasmtime 47.0.2)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -77,6 +77,7 @@ case ",$PHASES," in *",stdin,"*)
   echo "[p3-guarantee] phase C: wasi:cli/stdin lifecycle"
   bash "$SCRIPT_DIR/test_wasi_cli_stdin_provider_component_gate.sh"
   bash "$SCRIPT_DIR/test_wasi_cli_stdin_provider_guest_component_gate.sh"
+  bash "$SCRIPT_DIR/test_wasi_cli_stdin_provider_source_component_gate.sh"
   bash "$SCRIPT_DIR/test_wasi_cli_stdin_p3_probe_gate.sh"
   ;;
 esac


### PR DESCRIPTION
## Summary
- add unforgeable compiler-owned `StdinStream`
- expose `Stdin::read_via_stream() -> StdinStream with Stdin`
- expose `StdinStream::next/close` with `Async`
- lower function calls and aliases through the dedicated provider core route
- reserve and reject `host_stream_named("stdin")`
- reject GC, standalone/coverage raw-ABI escape, and mixed provider composition
- preserve legacy `stdin_stream` and generic `HostStream`

`next` returns bytes 0..255 or -1 only after successful EOF settlement. Provider completion/read failures remain fail-closed traps; no public error mapping is claimed.

## Validation
- checker/nominal/effect/alias/contract focused tests: passed
- Wasmtime 47.0.2 real-source drain, early close, function aliases, sequential reacquisition, simultaneous acquisitions, and RC: passed
- coverage/non-component artifact escape negatives: passed
- guest/shadow/hand-WAT lifecycle gates: passed
- exact WIT and no generic HostStream leakage checks: passed
- builtin parity, named HostStream regressions, formatter/freshness/diff, `pkf run test-local`: passed
- independent capability/ownership review: safe to integrate

Known unrelated limitation: doctest/xargs harness path failure; no source/provider assertion failed.

Refs #1539