### PR TITLE
feat(cli): vibe check に --single-file を足し、報告契約を統一する (#1567 slice 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ pkf run test              # operation gate (commit 前の主チェック)
 pkf run test-local        # affected tests only (fast inner loop)
 pkf run full-gate         # complete operation gate
 pkf run run -- args       # run main with args
-# 単一ファイルの型検査 / 診断: vibe diagnostics <file.vibe>
+# 型検査 / 診断: vibe check <file.vibe> (空出力 = clean、診断ありは exit 1)
 # selfhost の CST-token formatter (lib/@vibe/compiler/fmt/format.vibe,
 # scripts/vibe_fmt.sh, #854/#1138) は実装済みで `bash scripts/vibe_fmt.sh
 # [--check|--stdout] <file.vibe>` で直接使える。`pkf run fmt`
@@ -212,7 +212,7 @@ CI shard では:
 
 ### 方針: CLI を LLM 向けの IDE 相当クエリ面として育てる
 
-`vibe check` / `vibe diagnostics` / `vibe symbols` / `vibe type-at` /
+`vibe check` (`--single-file` 込み) / `vibe symbols` / `vibe type-at` /
 `vibe binding-at` / `vibe escapes` / `vibe bench` は、エディタが LSP 越しに
 得るのと同じ意味解析を **CLI から直接**取り出すためのもの。**想定する第一の
 読み手は人間ではなく LLM** で、次を満たすことを目標にする:
@@ -233,11 +233,16 @@ CI shard では:
 作業するときのコストとして毎回効いてくる。
 
 現に効いている既知の穴 (どれもこの方針違反として扱う):
-`vibe check` と `vibe diagnostics` が同じ質問に別の答え方をすること
-(**#1567** — 統合提案。import 解決の有無・clean の表現・exit code・
-出力先が全部食い違い、どちらを使うかを呼び出し側が覚えている)、
-型エラーに `line:col` が付かないこと (同 #1567)、
+型エラーに `line:col` が付かないこと (**#1567** の残り)、
+`vibe check --json` が `--single-file` でしか使えないこと (同 #1567 —
+import 解決レーンは診断を文字列で投げるので range が無い)、
 `vibe symbols` が doc comment を返さないこと (Coding Convention 節)。
+
+> **解決済み: 「どちらの動詞を使うか」問題 (#1567)。** かつて `vibe check` と
+> `vibe diagnostics` が同じ質問に別の答え方をしていた (import 解決の有無・
+> clean の表現・exit code・出力先が全部食い違っていた)。今は**動詞は
+> `vibe check` 一つ**で、違いは `--single-file` フラグだけ。`vibe diagnostics`
+> は deprecated (既存エディタ向けに挙動を凍結したまま残置)。
 
 ### Editor query primitives — Semantic Code Navigation
 
@@ -251,10 +256,15 @@ vibe type-at file.vibe <line> <col>
 # カーソル位置の binding の全出現箇所 (START END char offset / 行)。rename/refs の基盤
 vibe binding-at file.vibe <line> <col>
 
-# 全 diagnostics (parse error 全件 + 型エラー)。空出力 = clean
-# ただし単一ファイル解析で import を辿らない → import のあるファイルでは
-# 「未定義」の誤検知を出す。import があるなら `vibe check` で判定すること
-vibe diagnostics file.vibe
+# 全 diagnostics (parse error 全件 + 型エラー)。**空出力 = clean、診断ありは
+# exit 1**、行は stdout に 1件1行。import は FS から解決するので、これ単体で
+# 「このファイルはコンパイルが通るか」に答えられる
+vibe check file.vibe
+
+# 同じ質問をバッファ単位で (import を辿らない)。未保存バッファを見る
+# エディタ用。`--json` は LSP Diagnostic 配列 (このモードのみ)
+vibe check --single-file file.vibe
+vibe check --single-file --json file.vibe
 
 # closure に捕獲されて escape する `let mut` (NAME START END / 行)。
 # = codegen が wasm local ではなく heap ref cell に落とすもの (#1262)。
@@ -275,16 +285,17 @@ vibe grep --pattern '$(f:id)($(a:args))' --where-row '$f with Async' lib
 vibe grep --pattern 'f($(x:exp))' --only-ill-typed lib
 ```
 
-> **`vibe diagnostics` は import を解決しない。** `import ./dep.vibe { Hue as T }`
-> のあるファイルは、正しくても `unknown name: T::Crimson` を返す。空出力が意味
-> するのは「**単体ファイルとして** clean」であって「コンパイルが通る」ではない。
-> **import があるファイルの可否は `vibe check`** で見る (diagnostics はエディタの
-> バッファ単位フィードバック用で、そこでは正しい道具)。逆向き — export されて
-> いない名前の import — は `vibe check` が検査時に報告する (#1521/#1533。
-> 依存が publish する環境は export surface に制限されるので、private も
-> 単なる import 素通しも「is not exported by」になる)。`vibe diagnostics` は
-> 単一ファイル解析なのでこちらは今も見えない。大文字名 (struct / type alias)
-> だけは値環境が判定できず、未検出のまま (#1521 の残り半分)。
+> **`--single-file` は import を解決しない** — これは欠陥ではなく、そのモードの
+> 定義。`import ./dep.vibe { Hue as T }` のあるファイルは、正しくても
+> `unknown name: T::Crimson` を返す。空出力が意味するのは「**単体ファイルとして**
+> clean」であって「コンパイルが通る」ではない。**可否を知りたいならフラグ無しの
+> `vibe check`** を使う (`--single-file` は未保存バッファを見るエディタ用で、
+> そこでは正しい道具)。逆向き — export されていない名前の import — は
+> フラグ無しの `vibe check` が検査時に報告する (#1521/#1533。依存が publish する
+> 環境は export surface に制限されるので、private も単なる import 素通しも
+> 「is not exported by」になる)。`--single-file` は単一ファイル解析なので
+> こちらは見えない。大文字名 (struct / type alias) だけは値環境が判定できず、
+> 未検出のまま (#1521 の残り半分)。
 
 ### `vibe lsp` - Language Server
 
@@ -328,9 +339,10 @@ completion / signature help を提供する。詳細は
 - `pkf run test` — operation gate (`scripts/compiler_gate.sh`)。commit 前の主チェック。
 - `pkf run release-check` — full gate (fmt + info + check + test + operation gates)。
 - `pkf run test-local` — 変更影響範囲のテストのみ (fast inner loop、flaker 経由)。
-- 単一ファイルの型検査 / 診断は `vibe diagnostics <file.vibe>`（空出力 = clean）。
-  **import を辿らないので、import のあるファイルは `vibe check <file.vibe>` で
-  判定すること** — diagnostics は import 由来の名前を「未定義」と誤検知する。
+- 型検査 / 診断は `vibe check <file.vibe>`（空出力 = clean、診断ありは stdout に
+  1件1行 + exit 1）。import は FS から解決するので、これ単体で可否を判定できる。
+  **未保存バッファ相当の単一ファイル解析が要るときだけ `--single-file`** を足す
+  — そのモードは import を辿らないので、import 由来の名前を「未定義」と報告する。
 - selfhost の CST-token formatter は実装済み (`lib/@vibe/compiler/fmt/format.vibe`,
   #854/#1138) — `bash scripts/vibe_fmt.sh [--check|--stdout] <file>` で
   直接使える。`pkf run fmt` (`scripts/vibe_fmt_apply.sh`) は `lib/**/*.vibe`

--- a/clients/js/lsp_server.js
+++ b/clients/js/lsp_server.js
@@ -616,29 +616,42 @@ function runCheck(uri) {
   let diagnostics = [];
   try {
     fs.writeFileSync(tmp, doc.text, "utf8");
-    // `vibe diagnostics` runs the recovering parser and reports EVERY located
-    // syntax error (one per line), or the single located type error on a clean
-    // parse; empty = clean. Be robust: key off STDOUT (a clean file may exit
-    // non-zero) and accept ONLY well-formed located lines ("line N:M: <msg>"),
-    // so a stray/garbled line can never become a spurious diagnostic, and never
-    // fabricate one on a tooling hiccup (which would pollute every document).
-    const dres = spawnSync(VIBE_BIN, ["diagnostics", tmp], { encoding: "utf8" });
-    const located = (dres.stdout || "")
+    // `vibe check --single-file` (#1567) runs the recovering parser over the
+    // BUFFER ALONE and reports EVERY located syntax error (one per line), or
+    // the single located type error on a clean parse; empty = clean. Buffer
+    // scope is what an editor needs: the text here is unsaved, so the on-disk
+    // file's imports are not this buffer's imports. (This used to spell it
+    // `vibe diagnostics`, deprecated in favour of the flag -- same compiler
+    // lane, so the reports are identical apart from the `error: ` prefix.)
+    //
+    // Be robust: key off the OUTPUT (a clean file may exit non-zero) and accept
+    // ONLY well-formed located lines ("line N:M: <msg>"), so a stray/garbled
+    // line can never become a spurious diagnostic, and never fabricate one on
+    // a tooling hiccup (which would pollute every document).
+    //
+    // Errors land on stdout and the #1129 soft-pass warnings on stderr (they
+    // are advisory and must not decide the exit code), so read BOTH -- an
+    // editor wants to see an unused import, it just must not be told the file
+    // is broken. Severity comes from the `warning: ` marker in the message
+    // itself rather than from which stream carried it, so a future routing
+    // change cannot silently turn warnings into errors in the editor.
+    const dres = spawnSync(VIBE_BIN, ["check", "--single-file", tmp], { encoding: "utf8" });
+    const located = `${dres.stdout || ""}\n${dres.stderr || ""}`
       .split(/\r?\n/)
-      .map((l) => l.replace(/\s+$/, ""))
+      .map((l) => l.replace(/\s+$/, "").replace(/^error:\s+/, ""))
       .filter((l) => /^\s*line\s+\d+:\d+:/.test(l));
     if (located.length) {
       diagnostics = located.map((message) => ({
         range: locate(doc.text, message),
-        severity: 1, // Error
+        severity: /^\s*line\s+\d+:\d+(-\d+:\d+)?:\s*warning:/.test(message) ? 2 : 1,
         source: "vibe",
         message: message.trim(),
       }));
     } else {
-      // No located diagnostics: either the file is clean OR `vibe diagnostics`
-      // could not produce them in this environment. Confirm with `vibe check`
-      // (the always-available compile path) — a real error surfaces a single
-      // located diagnostic; a clean file yields none.
+      // No located diagnostics: either the file is clean OR the single-file
+      // pass could not produce them in this environment. Confirm with a plain
+      // `vibe check` (the always-available compile path) — a real error
+      // surfaces a single located diagnostic; a clean file yields none.
       const res = spawnSync(VIBE_BIN, ["check", tmp], { encoding: "utf8" });
       const out = `${res.stdout || ""}\n${res.stderr || ""}`;
       if ((res.status && res.status !== 0) || /\berror:/.test(out)) {

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -28,7 +28,7 @@ vibe build --release app.vibe  # standalone .wasm
 
 ### CLI は IDE 相当のクエリ面 (方針)
 
-`vibe check` / `vibe diagnostics` / `vibe symbols` / `vibe type-at` /
+`vibe check` (`--single-file` 込み) / `vibe symbols` / `vibe type-at` /
 `vibe binding-at` / `vibe escapes` / `vibe bench` は、エディタが LSP 越しに
 得るのと同じ意味解析を **CLI から直接**取り出すためのもの。想定する第一の
 読み手は**人間ではなく LLM** なので、行指向 (1件1行) で grep でき、空出力が
@@ -1382,7 +1382,7 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
 ただし **`vibe check` は #1511(b)/#1536(c) 以降、型検査の後に codegen と同じ
 効き方の適格性判定 (ADR-0076 の effect-lowering prelude) を走らせる**ため、
 `vibe check` / `vibe build` / `vibe test` / doctest のどれでも同じエラーが出る
-(`vibe diagnostics` は単一ファイル解析なので対象外):
+(`vibe check --single-file` は単一ファイル解析なので対象外):
 
 ```
 line 5:12-16: handle of effect 'Ask' cannot be compiled here. Every perform

--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -48,8 +48,9 @@ directly (useful for scripting or wiring a different editor):
 vibe type-at <file.vibe> <line> <col>     # inferred type of the identifier at 1-based (line,col)
 vibe binding-at <file.vibe> <line> <col>  # source spans (START END char offsets) of every occurrence of that binding
 vibe symbols <file.vibe>                  # declaration outline (NAME KIND START END per line)
-vibe diagnostics <file.vibe>              # all diagnostics, one per line; empty output = clean
-vibe diagnostics --json <file.vibe>       # same diagnostics as a JSON array of LSP Diagnostic objects (#820)
+vibe check <file.vibe>                    # all diagnostics, one per line on stdout; empty output = clean, exit 1 if not
+vibe check --single-file <file.vibe>      # same, analysing the buffer ALONE (no FS import resolution)
+vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array of LSP Diagnostic objects (#820)
 ```
 
 - `type-at` powers hover. Empty output means there is no env-visible
@@ -64,22 +65,35 @@ vibe diagnostics --json <file.vibe>       # same diagnostics as a JSON array of 
   parsed AST (not a line regex) it handles multi-line declarations and
   module-nested symbols and never reports a name that only appears in a string
   or comment.
-- **`diagnostics` analyzes ONE file and does not follow its imports**, so on a
+- **`--single-file` analyzes ONE file and does not follow its imports**, so on a
   file with imports it reports names it cannot see as undefined. A file that is
-  perfectly valid under `vibe check` can come back with `unknown name: T::Crimson`
-  here, purely because `import ./dep.vibe { Hue as T }` was never resolved.
-  Empty output therefore means "clean *as a standalone file*", not "compiles".
-  **To judge a file that imports anything, use `vibe check`** (`vibe diagnostics`
-  stays the right tool for the editor's per-buffer feedback, which is what it
-  exists for). The converse gap — a name imported from a module that does not
-  export it — is missed by BOTH and only surfaces at codegen (#1521).
-- `diagnostics` always exits 0 (it is a *report*, not a pass/fail), so a clean
-  file simply yields no output (plain mode) or `[]` (`--json` mode).
-  `--json` reuses the same `[@off=N]`-derived offsets `vibe lsp`'s
-  `publishDiagnostics` uses, wrapped as `{range, severity, source, message}`
-  objects — no separate structured-diagnostic format to keep in sync.
-- Once a file type-checks and codegen-validates cleanly, `diagnostics` also
-  runs two soft, warning-only passes (#1129) that never affect the exit
+  perfectly valid under a plain `vibe check` can come back with
+  `unknown name: T::Crimson` in this mode, purely because
+  `import ./dep.vibe { Hue as T }` was never resolved. Empty output therefore
+  means "clean *as a standalone file*", not "compiles". **To judge a file that
+  imports anything, drop the flag** — buffer scope exists for the editor's
+  per-buffer feedback, where the unsaved text is the thing being asked about.
+  The converse gap — a name imported from a module that does not export it — is
+  missed by the single-file mode and only surfaces at codegen (#1521); a plain
+  `vibe check` reports it (#1521/#1533).
+- Both modes share one contract (#1567): diagnostics on **stdout**, one per
+  line, `error: ` marking each diagnostic start (continuations like `hint: `
+  are indented under it, so `grep -c '^error: '` is an exact count); **clean =
+  empty output + exit 0**; anything reported = **exit 1**.
+- `--json` is available in `--single-file` mode, where the compiler's own
+  structured emitter produces real ranges: it reuses the same `[@off=N]`-derived
+  offsets `vibe lsp`'s `publishDiagnostics` uses, wrapped as
+  `{range, severity, source, message}` objects — no separate
+  structured-diagnostic format to keep in sync. A clean file yields `[]` and
+  exit 0. Without `--single-file` the launcher refuses `--json` rather than
+  inventing ranges: the import-resolving lane reports diagnostics as message
+  text with no per-diagnostic span attached (#1567).
+- `vibe diagnostics` is the **deprecated** spelling of `vibe check
+  --single-file`. It is kept behaviourally frozen (raw lines with no `error: `
+  prefix, always exit 0) for editors already wired to it — see
+  [spec/1.0-freeze.md](spec/1.0-freeze.md).
+- Once a file type-checks and codegen-validates cleanly, the single-file mode
+  also runs two soft, warning-only passes (#1129) that never affect the exit
   code or fail a compile: **unused imports** (a named `import ./f.vibe { a }`
   item, or an `import @pkg @alias` alias, never referenced in the file —
   a whole-program-merge-only alias may still legitimately trip this, since
@@ -161,7 +175,7 @@ matching nothing. Use `vibe symbols` for declarations.
 ### Type-aware filters
 
 Passing any of these switches the sweep into the **typed tier**, which resolves
-imports through the same walk `vibe check` uses — the `vibe diagnostics`
+imports through the same walk a plain `vibe check` uses — the `--single-file`
 import-blind false positives described above are deliberately *not* reproduced
 here. Only files that already have a structural match are typed.
 

--- a/docs/pkfire-pkspec.md
+++ b/docs/pkfire-pkspec.md
@@ -54,7 +54,7 @@ Highlights (post-#594 selfhost-only):
 | `test-local`   | affected tests via `flaker`        | fast inner loop                      |
 | `run`          | `bash scripts/vibe_run.sh $@`      | `acceptsArgs` — pass via `--`        |
 | `release-check`| `deps { compiler-gate }`           | sign-off: bundle/module-source sync + seed→stage1→stage2→stage3 fixpoint + compile/run validation |
-| `info` / `check` / `test-update` | legacy `moon …`  | MoonBit host 依存で #594 以降は無効。検証は `test` / `release-check` / `vibe diagnostics` を使う |
+| `info` / `check` / `test-update` | legacy `moon …`  | MoonBit host 依存で #594 以降は無効。検証は `test` / `release-check` / `vibe check` を使う |
 
 Two helper factories keep the file readable:
 

--- a/docs/spec/1.0-freeze.md
+++ b/docs/spec/1.0-freeze.md
@@ -131,12 +131,13 @@ trait bound の互換は [decisions.md](decisions.md) のロック通り
 | --- | --- |
 | `vibe run <file>` | compile & execute。`--trace` / `--break` はデバッグ用 opt-in。 |
 | `vibe compile` / `vibe build [--release] <file>` | standalone `.wasm` 生成。 |
-| `vibe check <file>` | 型検査のみ。located 診断 (`line N:M:`)。 |
+| `vibe check [--single-file] [--json] <file>` | 型検査のみ。located 診断 (`line N:M:`) を **stdout** に1件1行。**clean = 空出力 + exit 0**、診断ありは exit 1。`--single-file` は import を解決しない単一ファイル解析 (未保存バッファ用)、`--json` はそのモードでのみ (#1567)。 |
 | `vibe test <file|dir>` | テストブロック実行。 |
 | `vibe new` / `vibe add` | プロジェクト初期化 / 依存追加。 |
 | `vibe fetch [--frozen]` / `vibe verify` | module 取得・lock 検証 (テーマ2)。 |
 | `vibe lsp` | LSP サーバ (テーマ4)。 |
-| `vibe type-at` / `vibe binding-at` / `vibe diagnostics` | エディタ統合プリミティブ。診断系は常に exit 0。 |
+| `vibe type-at` / `vibe binding-at` | エディタ統合プリミティブ。常に exit 0 (照会であって判定ではない)。 |
+| `vibe diagnostics` | **deprecated** (#1567): `vibe check --single-file` が後継。既存エディタのために挙動を凍結して残置する — 生の診断行 (`error: ` prefix 無し)、常に exit 0。 |
 | `vibe version` | toolchain version 報告。 |
 | `vibe self update --cli-wasm <path>` | compiler wasm の入れ替え (runner と独立)。 |
 

--- a/docs/tutorial/06_tests.vibe.md
+++ b/docs/tutorial/06_tests.vibe.md
@@ -34,7 +34,7 @@ vibe bench file.vibe         # bench {} ブロックを計測 (ns/op, ops/sec)
 # エディタ級のクエリ (LSP と同じ AST 解析)
 vibe symbols file.vibe               # 宣言アウトライン
 vibe type-at file.vibe <line> <col>  # カーソル位置の型
-vibe diagnostics file.vibe           # 全診断
+vibe check file.vibe                 # 全診断 (空出力 = clean)
 vibe lsp                             # LSP サーバ (stdio)
 
 # パッケージの内容 hash (require pin に使う)

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -1079,9 +1079,23 @@ case "$cmd" in
       fi
     else
       out="$(mktemp -t vibe-check-XXXXXX.wasm)"
-      trap 'rm -f "$out"' EXIT
+      cerr="$(mktemp -t vibe-check-err-XXXXXX)"
+      trap 'rm -f "$out" "$cerr"' EXIT
       # A successful compile implies a clean parse + typecheck; surface failures.
-      if ! compile_to "$src" "$out" main; then
+      #
+      # compile_to reports to STDERR -- correct for the shared BUILD path, where
+      # the wasm is the output and the diagnostic is the aside. This lane inverts
+      # that: the report IS the output, and #1567 puts it on stdout. Without the
+      # capture below, `vibe check` against a compiler old enough to take this
+      # branch would exit 1 with empty stdout, which a stdout-only consumer reads
+      # as "failed, no reason given" -- worse than the contract it replaced.
+      # compile_to already prefixes its line `error: `, so re-emit it verbatim
+      # rather than through emit_check_diagnostics (which would double-prefix).
+      if compile_to "$src" "$out" main 2>"$cerr"; then
+        rm -f "$out" "$cerr"
+      else
+        [ -s "$cerr" ] && cat "$cerr"
+        rm -f "$out" "$cerr"
         exit 1
       fi
     fi

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -41,7 +41,14 @@
 #                                         docs/compiler-parallelism.md)
 #   vibe serve   <handler.vibe> [--port N] compile + compose with the wasi-http
 #                                         P3 adapter + `wasmtime serve` (#537)
-#   vibe check   <file.vibe>              parse + typecheck (no output kept)
+#   vibe check [--single-file] [--json] <file.vibe>
+#                                         parse + typecheck. Diagnostics go to
+#                                         stdout, one per line; clean = EMPTY
+#                                         output + exit 0, anything reported =
+#                                         exit 1. Imports are resolved from the
+#                                         FS unless --single-file (buffer scope,
+#                                         what an editor with unsaved text
+#                                         needs). --json needs --single-file.
 #   vibe type-at <file.vibe> <line> <col> print the inferred type at a position
 #   vibe doc-at  <file.vibe> <line> <col> print the `///` doc comment at a position (#854)
 #   vibe binding-at <file.vibe> <line> <col> print binding occurrence spans (START END per line)
@@ -50,7 +57,10 @@
 #                                         captures -- the ones codegen boxes into
 #                                         a heap ref cell instead of a wasm local
 #                                         (NAME START END per line; empty = none)
-#   vibe diagnostics <file.vibe>          print all syntax/type diagnostics
+#   vibe diagnostics <file.vibe>          DEPRECATED (#1567): use
+#                                         `vibe check --single-file`. Kept
+#                                         unchanged (raw lines, always exit 0)
+#                                         for the editors already on it.
 #   vibe grep --pattern '<pat>' [paths]   AST pattern search (#1572). Metavars
 #                                         are `$(name:kind)`, kind = exp / id /
 #                                         const / arg / args / pat / type.
@@ -329,6 +339,59 @@ compile_to() {
   fi
   rm -f "$out.diag" "$rerr"
   return 1
+}
+
+# #1567: print a diagnostics report, one diagnostic per line, on STDOUT.
+#
+# Both `vibe check` modes funnel through here so the two answer the same
+# question in the same shape -- which is the whole point of the unification:
+# a caller must not have to know which lane produced the report to read it.
+#
+# `error: ` marks a diagnostic START. A single diagnostic can span several
+# LINES (checker_effects.vibe appends a `hint: ...` continuation to an effect
+# row mismatch), so continuations are indented UNDER the diagnostic they belong
+# to rather than prefixed -- otherwise one diagnostic would count as two and
+# `grep -c '^error: '` would stop being an exact diagnostic count (#1625 review,
+# Codex P2). `hint: ` is the only continuation the compiler emits today;
+# leading whitespace is accepted too so a future indented continuation does not
+# silently become a phantom error.
+#
+# awk's `print` always terminates the last line, which also repairs a report
+# whose final line has no trailing newline (the compiler writes the sidecar
+# without one) -- otherwise it ran into whatever the shell printed next.
+emit_check_diagnostics() { # <report-file>
+  awk '/^(hint: |[[:space:]])/ { print "  " $0; next } { print "error: " $0 }' "$1"
+}
+
+# The single-file lane's report can also contain the #1129 soft passes' output
+# (unused imports / unbound non-Unit returns). Those are WARNINGS: advisory,
+# and explicitly documented as never affecting the exit code. They arrive in
+# the same report as the errors, so they have to be split back out here --
+# otherwise `--single-file` would label a warning `error: ` and exit 1 on a
+# file the import-resolving lane calls clean, which is the exact two-lanes-
+# disagree defect #1567 exists to remove.
+#
+# A warning is either bare (`warning: ...`, how the import lane spells it) or
+# located (`line N:C: warning: ...` / `line N:C-N:C: warning: ...`, how the
+# single-file lane spells it). Anchoring on both spellings keeps a message that
+# merely CONTAINS the word from being misclassified. Continuation lines inherit
+# the classification of the diagnostic they hang off.
+#
+# Two passes rather than one awk writing to /dev/stderr: this launcher ships to
+# macOS as well, and not every awk there treats /dev/stderr as a writable file.
+check_warning_re='^(line [0-9]+:[0-9]+(-[0-9]+:[0-9]+)?: )?warning: '
+emit_check_report() { # <report-file> -> exit 1 if it holds at least one ERROR
+  awk -v wre="$check_warning_re" '
+    $0 ~ wre                     { w = 1; print; next }
+    /^(hint: |[[:space:]])/      { if (w) print; next }
+                                 { w = 0 }
+  ' "$1" >&2
+  awk -v wre="$check_warning_re" '
+    $0 ~ wre                     { w = 1; next }
+    /^(hint: |[[:space:]])/      { if (w) next; print "  " $0; next }
+                                 { w = 0; err = 1; print "error: " $0 }
+    END                          { exit(err ? 1 : 0) }
+  ' "$1"
 }
 
 # #906 Phase 2 (real-build wiring): best-effort pre-warm of the persistent
@@ -877,19 +940,91 @@ case "$cmd" in
       rm -f "$dout" "$dout.diag"
       exit "$rc"
     fi
-    src=""; jobs=1
+    src=""; jobs=1; chk_single=0; chk_json=0
+    chk_usage="usage: vibe check [--jobs N] [--single-file] [--json] <file.vibe>"
     while [ "$#" -gt 0 ]; do
       case "$1" in
         --jobs) [ "$#" -ge 2 ] || die "--jobs requires a value"; jobs="$2"; shift 2 ;;
-        *) [ -z "$src" ] || die "usage: vibe check [--jobs N] <file.vibe>"; src="$1"; shift ;;
+        --single-file) chk_single=1; shift ;;
+        --json) chk_json=1; shift ;;
+        *) [ -z "$src" ] || die "$chk_usage"; src="$1"; shift ;;
       esac
     done
-    [ -n "$src" ] || die "usage: vibe check [--jobs N] <file.vibe>"
+    [ -n "$src" ] || die "$chk_usage"
     case "$jobs" in
       ''|*[!0-9]*) die "--jobs must be a positive integer, got: $jobs" ;;
     esac
     [ "$jobs" -ge 1 ] || die "--jobs must be a positive integer, got: $jobs"
     [ -f "$src" ] || die "not found: $src"
+    # #1567 slice 2: `--single-file` analyses the buffer ALONE (no FS import
+    # resolution) -- the one thing `vibe diagnostics` could do that `check`
+    # could not, and the reason an editor needs it: an LSP sees unsaved text,
+    # so the imports of the on-disk file are not the imports of the buffer.
+    # Making it a FLAG rather than a second verb is what removes "which verb
+    # answers this?" from the caller: `vibe check` is the only verb, and the
+    # answer to "does this file compile?" no longer depends on knowing whether
+    # the file happens to have imports.
+    #
+    # Everything else about the contract is shared with the import-resolving
+    # mode below: diagnostics on stdout one per line, clean = empty output,
+    # exit 1 when there is anything to report. `--jobs` does not apply here --
+    # it pre-warms the import walk, and there is no import walk in this mode.
+    if [ "$chk_single" = "1" ]; then
+      cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
+      out="$(mktemp -t vibe-check-sf-XXXXXX)"
+      trap 'rm -f "$out" "$out.diag"' EXIT
+      env -u VIBE_FS_COMPILE -u VIBE_CHECK_ONLY -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+          -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_SYMBOLS -u VIBE_NORMALIZE \
+          -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
+        VIBE_DIAGNOSTICS=1 \
+        VIBE_DIAGNOSTICS_JSON="$([ "$chk_json" = "1" ] && echo 1 || echo "")" \
+        VIBE_IMPORT_ABI=raw \
+        "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
+      # #946(4): a host-level crash (native stack overflow on a pathologically
+      # deep expression) writes the sidecar instead of `$out`. Reported as a
+      # diagnostic, never as clean -- the same rule the diagnostics verb uses.
+      if [ -s "$out.diag" ]; then
+        if [ "$chk_json" = "1" ]; then
+          diag_msg="$(sed 's/\\/\\\\/g; s/"/\\"/g' "$out.diag" | tr '\n' ' ')"
+          printf '[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":1}},"severity":1,"source":"vibe","message":"%s"}]\n' "$diag_msg"
+        else
+          emit_check_diagnostics "$out.diag"
+        fi
+        rm -f "$out" "$out.diag"
+        exit 1
+      fi
+      if [ -s "$out" ]; then
+        if [ "$chk_json" = "1" ]; then
+          cat "$out"; [ -n "$(tail -c 1 "$out")" ] && echo
+          # `severity` is the JSON spelling of the same error/warning split
+          # emit_check_report does in text mode: 1 = Error, 2 = Warning. A
+          # report of nothing but warnings is clean, exactly as it is there
+          # (and `[]`, a clean file, has no severity at all).
+          chk_rc=0
+          grep -q '"severity":1' "$out" && chk_rc=1
+          rm -f "$out" "$out.diag"
+          exit "$chk_rc"
+        fi
+        chk_rc=0
+        emit_check_report "$out" || chk_rc=1
+        rm -f "$out" "$out.diag"
+        exit "$chk_rc"
+      fi
+      # Clean. Text mode says so with empty output; JSON mode must still be
+      # parseable JSON, so it gets the empty array.
+      [ "$chk_json" = "1" ] && echo "[]"
+      rm -f "$out" "$out.diag"
+      exit 0
+    fi
+    if [ "$chk_json" = "1" ]; then
+      # The import-resolving lane reports diagnostics as message TEXT (the
+      # checker throws a string that check_linked_file joins), with no
+      # per-diagnostic range attached -- so there is nothing to build an LSP
+      # Diagnostic's `range` out of without re-parsing the message in the
+      # launcher and guessing. `--single-file` goes through the compiler's own
+      # structured emitter (lsp_diagnostics_json_string) and has real ranges.
+      die "check --json needs --single-file today: the import-resolving lane has no per-diagnostic ranges to emit (#1567)"
+    fi
     # #906 Phase 2 (real-check wiring): same best-effort pre-warm `build`
     # already gets (maybe_warm_frontend_cache above) -- `check` walks the
     # exact same import graph via the exact same persistent type-env cache,
@@ -930,40 +1065,24 @@ case "$cmd" in
       if [ -s "$out" ]; then
         # #deprecated marker warnings (#1262 / ADR-0101): the adapter writes
         # `warning:` lines before the final `ok`. Non-fatal — surface on
-        # stderr, keep exit 0.
+        # stderr, keep exit 0 AND keep stdout empty, so "clean" stays
+        # detectable as empty stdout even for a file that warns.
         grep '^warning: ' "$out" >&2 || true
-        echo "ok: $src"
         rm -f "$out" "$out.diag"
       else
-        if [ -s "$out.diag" ]; then
-          # #1567: the sidecar can now hold SEVERAL diagnostics, one per line
-          # (check_linked_file reports every top-level parse error the
-          # recovering parser collected, not just the first). Prefix each line
-          # so a multi-error report stays one-diagnostic-per-line and grep-able
-          # instead of collapsing into a single smeared `error:` line.
-          #
-          # #1625 review (Codex P2): a single diagnostic can still span several
-          # LINES -- checker_effects.vibe appends a `hint: ...` continuation to
-          # an effect row mismatch. Prefixing that too would make one diagnostic
-          # count as two, which is precisely the grep-ability the prefix exists
-          # to provide. Only diagnostic STARTS get `error: `; a continuation is
-          # indented under the diagnostic it belongs to, so `grep -c '^error: '`
-          # is an exact diagnostic count. `hint: ` is the only continuation the
-          # compiler emits today; leading whitespace is accepted too so a future
-          # indented continuation does not silently become a phantom error.
-          awk '/^(hint: |[[:space:]])/ { print "  " $0; next } { print "error: " $0 }' "$out.diag" >&2
-        fi
+        # #1567: the sidecar can hold SEVERAL diagnostics, one per line
+        # (check_linked_file reports every top-level parse error the recovering
+        # parser collected, not just the first).
+        [ -s "$out.diag" ] && emit_check_diagnostics "$out.diag"
         rm -f "$out" "$out.diag"
-        die "check failed: $src"
+        exit 1
       fi
     else
       out="$(mktemp -t vibe-check-XXXXXX.wasm)"
       trap 'rm -f "$out"' EXIT
       # A successful compile implies a clean parse + typecheck; surface failures.
-      if compile_to "$src" "$out" main; then
-        echo "ok: $src"
-      else
-        die "check failed: $src"
+      if ! compile_to "$src" "$out" main; then
+        exit 1
       fi
     fi
     ;;
@@ -1108,6 +1227,19 @@ case "$cmd" in
     ;;
   diagnostics)
     # vibe diagnostics [--json] <file.vibe>
+    #
+    # DEPRECATED (#1567 slice 2): `vibe check --single-file [--json]` is the
+    # supported spelling. This verb existed only because `check` could not do
+    # buffer-scope analysis; now that it can, having two verbs answer "does
+    # this file compile?" is the defect, not a feature.
+    #
+    # Deliberately NOT rewritten as an alias: this one is frozen for 1.0
+    # (docs/spec/1.0-freeze.md -- raw diagnostic lines, always exit 0), and
+    # editors are on it today. `check --single-file` carries the unified
+    # contract instead (`error: `-prefixed lines, exit 1 when non-clean), so
+    # aliasing would silently change the exit code under existing callers.
+    # Both run the same compiler lane, so they never disagree on WHAT is wrong.
+    #
     # Print ALL diagnostics, one per line: every top-level syntax error (the
     # recovering parser resynchronizes past each failed statement) or, when the
     # file parses clean, the single located type error. Empty output = clean.

--- a/scripts/check_examples_typecheck.sh
+++ b/scripts/check_examples_typecheck.sh
@@ -72,11 +72,10 @@ known_hit=0
 
 for f in examples/*.vibe; do
   checked=$((checked + 1))
-  out="$("$VIBE" check "$f" 2>&1)" || true
-  case "$out" in
-    ok:*) ok=1 ;;
-    *)    ok=0 ;;
-  esac
+  # #1567 slice 2: judge by EXIT STATUS, not by matching an `ok:` line. A clean
+  # check is now silent (empty output + exit 0), so pattern-matching the output
+  # would report every clean example as a failure.
+  if out="$("$VIBE" check "$f" 2>&1)"; then ok=1; else ok=0; fi
   if [ "$ok" -eq 1 ]; then
     if is_known "$f"; then
       fixed_known+=("$f")

--- a/scripts/check_playground_presets.sh
+++ b/scripts/check_playground_presets.sh
@@ -64,15 +64,15 @@ count=0
 while IFS=$'\t' read -r path pid; do
   [ -n "$path" ] || continue
   count=$((count + 1))
-  out="$("$VIBE" check "$path" 2>&1)" || true
-  case "$out" in
-    ok:*) ;;
-    *)
-      fail=$((fail + 1))
-      echo "[playground-presets] FAIL: preset '$pid' ($SRC)" >&2
-      printf '%s\n' "$out" | head -3 | sed 's/^/                      /' >&2
-      ;;
-  esac
+  # #1567 slice 2: judge by EXIT STATUS, not by matching an `ok:` line. A clean
+  # check is now silent (empty output + exit 0), so pattern-matching the output
+  # would report every clean preset as broken -- with an empty reason, since
+  # there is no diagnostic to print.
+  if out="$("$VIBE" check "$path" 2>&1)"; then :; else
+    fail=$((fail + 1))
+    echo "[playground-presets] FAIL: preset '$pid' ($SRC)" >&2
+    printf '%s\n' "$out" | head -3 | sed 's/^/                      /' >&2
+  fi
 done < "$MANIFEST"
 
 if [ "$fail" -gt 0 ]; then

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -10417,7 +10417,10 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$chkdir/multi.vibe" "$chkdir/diag.out" main >/dev/null 2>&1 || true
 # check reports through the .diag sidecar, diagnostics through the output file.
-# That difference is the REST of #1567; this step only pins the counts.
+# That is a COMPILER-side transport difference; the launcher normalizes both to
+# stdout (#1567 slice 2, pinned in scripts/test_vibe_cli_install.sh, which is
+# the layer that owns the user-facing contract). This step stays at the
+# compiler layer and only pins the counts.
 chk_n="$(grep -c '^line ' "$chkdir/check.out.diag" 2>/dev/null || true)"
 diag_n="$(grep -c '^line ' "$chkdir/diag.out" 2>/dev/null || true)"
 [ -n "$chk_n" ] || chk_n=0

--- a/scripts/test_vibe_cli_install.sh
+++ b/scripts/test_vibe_cli_install.sh
@@ -117,6 +117,70 @@ else
   echo "info: compiler did not emit the effect row mismatch hint (seed build); skipping continuation-line assertion"
 fi
 
+# #1567 slice 2: the `vibe check` REPORTING CONTRACT, pinned as a whole. The
+# point of the unification is that a caller can judge a file without knowing
+# which lane answered, so all three properties have to hold together:
+#   diagnostics on STDOUT (not stderr) / clean = EMPTY output / exit 1 when
+#   anything is reported.
+# Splitting stdout from stderr here is deliberate -- the old contract printed
+# diagnostics to stderr and `ok: <file>` to stdout, so a test that merges the
+# two (`2>&1`) cannot tell the two contracts apart.
+chk_stdout="$("$VIBE" check "$proj/bad.vibex" 2>/dev/null || true)"
+check "vibe check writes diagnostics to stdout" \
+  "yes" "$(echo "$chk_stdout" | grep -q '^error: ' && echo yes || echo no)"
+clean_stdout="$("$VIBE" check "$proj/app.vibex" 2>/dev/null || true)"
+check "vibe check is silent on a clean file" "" "$clean_stdout"
+
+# `--single-file` is what makes the second verb (`vibe diagnostics`)
+# unnecessary, so pin the thing that actually distinguishes the two modes:
+# app.vibex imports lib.vibe, so it is CLEAN with FS import resolution and
+# reports an unknown name WITHOUT it. Same file, same verb, one flag.
+sf_out="$("$VIBE" check --single-file "$proj/app.vibex" 2>/dev/null || true)"
+"$VIBE" check --single-file "$proj/app.vibex" >/dev/null 2>&1 && rc=0 || rc=$?
+if echo "$sf_out" | grep -q 'unknown name'; then
+  check "vibe check --single-file does not resolve imports" "1" "$rc"
+  check "vibe check (no flag) does resolve them" "" "$clean_stdout"
+else
+  echo "info: compiler did not report an unresolved import in single-file mode (seed build); skipping --single-file assertion"
+fi
+sf_clean="$("$VIBE" check --single-file "$proj/lib.vibe" 2>/dev/null || true)"
+check "vibe check --single-file is silent on a clean file" "" "$sf_clean"
+
+# The #1129 soft passes (unused import / unbound non-Unit return) are WARNINGS:
+# advisory, documented as never affecting the exit code. They come back in the
+# same report as the errors, so the two modes have to agree on splitting them
+# out -- otherwise `--single-file` calls a file broken that the import-resolving
+# lane calls clean, which is the very disagreement #1567 removes.
+printf 'import ./lib.vibe { add }\n\nexport let main = () -> Int { 42 }\n' > "$proj/warnonly.vibe"
+warn_stdout="$("$VIBE" check --single-file "$proj/warnonly.vibe" 2>/dev/null || true)"
+warn_stderr="$("$VIBE" check --single-file "$proj/warnonly.vibe" 2>&1 >/dev/null || true)"
+"$VIBE" check --single-file "$proj/warnonly.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
+if echo "$warn_stderr" | grep -q 'warning: '; then
+  check "vibe check --single-file exits 0 on warnings alone" "0" "$rc"
+  check "vibe check --single-file keeps warnings off stdout" "" "$warn_stdout"
+  check "vibe check --single-file never labels a warning an error" \
+    "0" "$(echo "$warn_stdout" | grep -c '^error: ')"
+  "$VIBE" check "$proj/warnonly.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
+  check "vibe check (import lane) agrees the same file is clean" "0" "$rc"
+  "$VIBE" check --single-file --json "$proj/warnonly.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
+  check "vibe check --json exits 0 on warnings alone" "0" "$rc"
+else
+  echo "info: compiler did not emit an unused-import warning (seed build); skipping warning-split assertion"
+fi
+
+# --json rides the compiler's own structured emitter, so it is only available
+# in single-file mode; without the flag the launcher must say so instead of
+# emitting something JSON-shaped but rangeless.
+json_out="$("$VIBE" check --single-file --json "$proj/bad.vibex" 2>/dev/null || true)"
+check "vibe check --single-file --json emits a JSON array" \
+  "yes" "$(echo "$json_out" | grep -q '^\[{' && echo yes || echo no)"
+json_clean="$("$VIBE" check --single-file --json "$proj/lib.vibe" 2>/dev/null || true)"
+check "vibe check --json emits [] for a clean file" "[]" "$json_clean"
+"$VIBE" check --single-file --json "$proj/lib.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
+check "vibe check --json exits 0 for a clean file" "0" "$rc"
+"$VIBE" check --json "$proj/lib.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
+check "vibe check --json without --single-file is refused" "1" "$rc"
+
 # test: passing file exits 0, failing file exits non-zero, aggregate fails
 "$VIBE" test "$proj/pass_test.vibe" >/dev/null 2>&1 && rc=0 || rc=$?
 check "vibe test pass exit" "0" "$rc"

--- a/scripts/test_vibe_diagnostics.sh
+++ b/scripts/test_vibe_diagnostics.sh
@@ -209,13 +209,15 @@ else
   printf '%s\n' "$out_deep" >&2
   fail=$((fail + 1))
 fi
-deep_check_err="$WORK/deepexpr_check.stderr"
-"$VIBE" check "$deepexpr" >/dev/null 2>"$deep_check_err" && rc_deep_check=0 || rc_deep_check=$?
-if [ "$rc_deep_check" -ne 0 ] && grep -qi 'too deeply nested' "$deep_check_err" 2>/dev/null; then
-  echo "ok: vibe check on the same file also reports the crash, not just 'check failed'"; pass=$((pass + 1))
+# #1567 slice 2: `vibe check` reports on STDOUT (stderr is for warnings and
+# launcher-level failures), so read the crash report from there.
+deep_check_out="$WORK/deepexpr_check.stdout"
+"$VIBE" check "$deepexpr" >"$deep_check_out" 2>/dev/null && rc_deep_check=0 || rc_deep_check=$?
+if [ "$rc_deep_check" -ne 0 ] && grep -qi 'too deeply nested' "$deep_check_out" 2>/dev/null; then
+  echo "ok: vibe check on the same file also reports the crash, not just failing"; pass=$((pass + 1))
 else
-  echo "FAIL: expected 'vibe check' to fail with a 'too deeply nested' message (rc=$rc_deep_check):" >&2
-  cat "$deep_check_err" >&2 2>/dev/null
+  echo "FAIL: expected 'vibe check' to fail with a 'too deeply nested' message on stdout (rc=$rc_deep_check):" >&2
+  cat "$deep_check_out" >&2 2>/dev/null
   fail=$((fail + 1))
 fi
 


### PR DESCRIPTION
[#1567](https://github.com/mizchi/vibe-lang/issues/1567) の残り 4 軸 — 出力先 / clean の表現 / exit code / 単一ファイル解析 — を倒す。[slice 1 (#1625)](https://github.com/mizchi/vibe-lang/pull/1625) の続き。

**動詞は `vibe check` 一つになり、違いはフラグだけになった。** issue のゴール判定 (AGENTS.md の「`vibe diagnostics` は import を解決しない」という**呼び出し側が覚える規則**の段落を消せること) を達成している。

## 新しい契約

```bash
vibe check file.vibe                       # imports を解決。clean = 空出力 + exit 0
vibe check --single-file file.vibe         # バッファ単位 (import を辿らない)
vibe check --single-file --json file.vibe  # 同じ診断を LSP Diagnostic 配列で
```

| | 旧 `check` | 旧 `diagnostics` | 新 `check` |
|---|---|---|---|
| import | FS から解決 | 解決しない | **フラグで選ぶ** |
| clean | `ok: <file>` | 空 | **空** |
| 出力先 | stderr | stdout | **stdout** |
| exit code | 1 | 常に 0 | **1** |
| `--json` | 無い | ある | **`--single-file` で** |

`--single-file` を**動詞ではなくフラグ**にしたのがこのスライスの本体。`vibe diagnostics` が唯一できて `check` ができなかったのは「未保存バッファを見る LSP のための単一ファイル解析」だけで、それ以外は同じ質問に劣化した答えを返していた。フラグにすると「どちらの動詞が答えるか」が呼び出し側から消える — ファイルを開いて import の有無を確認しなくても `vibe check` で判定できる。

両モードは同じ整形 (`emit_check_diagnostics`) を通る。`error: ` は診断の開始行だけに付き、`hint:` 継続行はその下にインデントされるので `grep -c '^error: '` が正確な診断数のまま (slice 1 の Codex 指摘の不変条件を維持)。

## 実装中に見つけた食い違い: warning

`#1129` の soft pass (unused import / unbound non-Unit return) は **warning** で exit code に影響しないと文書化されているが、単一ファイルレーンでは診断と同じレポートに混ざって返る。素朴に実装すると:

```
$ vibe check --single-file warnonly.vibe
error: line 1:22: warning: imported name 'helper' from './wdep.vibe' is never used in this file
rc=1
$ vibe check warnonly.vibe        # 同じファイル
rc=0
```

警告を `error:` と呼び、import 解決レーンが clean と言う同じファイルを壊れていることにする — **#1567 が消そうとしている「2 レーンが食い違う」そのもの**なので直した。`emit_check_report` が警告を stderr へ分け (bare `warning: ` と located `line N:C: warning: ` の両綴りを anchor)、JSON では `"severity":1` の有無で判定する。両モードとも警告のみなら空 stdout + exit 0。

## `--json` を `--single-file` 限定にした理由

import 解決レーンは診断を**メッセージ文字列**として throw する (`check_linked_file` が join する) ので、per-diagnostic の range が無い。launcher でメッセージを再パースして range を推測するより明示的に断るほうが正直:

```
$ vibe check --json file.vibe
vibe: check --json needs --single-file today: the import-resolving lane has no per-diagnostic ranges to emit (#1567)
```

`--single-file` はコンパイラ自身の `lsp_diagnostics_json_string` を通るので本物の range が付く。import レーンへの `--json` は #1567 の残りとして AGENTS.md の「既知の穴」に記載した。

## `vibe diagnostics` は deprecated (挙動は凍結)

alias にはして**いない**。1.0-freeze で「常に exit 0・生の診断行」を凍結しており、エディタが既に繋がっているので、alias にすると既存呼び出し側の exit code が黙って変わる。同じコンパイラレーンを通るので、**何が間違っているか**については両者が食い違うことはない。

## 呼び出し側の移行

- **`clients/js/lsp_server.js`** → `check --single-file`。警告は stderr から拾い、メッセージ中の `warning:` マーカーで severity 2 を付ける (以前は severity 1 の Error として出ていた — エディタ表示としては改善)
- **`scripts/check_examples_typecheck.sh`** → `case "$out" in ok:*)` をやめ exit status で判定。**契約変更で実際に壊れる消費者だった** (clean が空出力になるので、そのままでは 16 例すべてが「新規失敗」になる — 負の対照で確認済み)
- **`scripts/test_vibe_diagnostics.sh`** → crash 報告を stderr ではなく stdout から読む

## ゲート

| | |
|---|---|
| `compiler_gate.sh` | 100/100 |
| `test_vibe_cli_install.sh` | **55/55** (契約 pin 12 件を追加: stdout / 空 clean / `--single-file` の import 差 / `--json` / warning 分離) |
| `test_vibe_diagnostics.sh` | 19/19 |
| `test_located_diagnostics.sh` | 14/14 |
| `test_vibe_lsp.js` | 20/20 |
| `test_vibe_lsp_workspace.js` | 12/12 |
| `check_examples_typecheck.sh` | 16 examples, 0 new |

契約 pin は launcher の層 (`test_vibe_cli_install.sh`) に置いた — `compiler_gate.sh` は stage2 を直接叩くので launcher を経由せず、ユーザー向け契約はこちらが所有する。gate step 100 のコメントもその旨に更新した。

## 残り

- **型エラーに `line:col` が付かない** (`unknown name` には付くが `return type mismatch` には付かない)
- **import 解決レーンの `--json`** (range を持たせるにはコンパイラ側の作業が要る)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_