### PR TITLE
fix(diag): 位置付き診断に2つ目の誤った位置を貼らない (#1567)

### DIFF
--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3031,26 +3031,64 @@ fn locate_unused_import_msg(source: String, msg: String) -> String {
 /// parsing `^line N:C`) takes. Reporting a confident wrong location is worse
 /// than reporting none, so recognize the path-prefixed shape too.
 ///
-/// Anchored on the FIRST `: ` in the message: the prefix is a file path, which
-/// does not contain `: `, so a `: line N` occurring later (inside the message
-/// prose) cannot be mistaken for the location prefix.
+/// Recognized by SHAPE, at any position: `line <digits>:<digits>` sitting
+/// either at the start of the message or right after a `: ` delimiter. An
+/// earlier revision anchored on the FIRST `: ` on the theory that a path cannot
+/// contain one -- but `: ` is legal in a POSIX path (`/tmp/foo: bar/x.vibe`),
+/// and there the anchor lands inside the path, the guard returns false, and the
+/// heuristic prepends its wrong location again: the exact bug this is here to
+/// stop (#1628 review, Codex P2). Scanning every candidate makes the answer
+/// depend on the message's shape rather than on assumptions about path
+/// contents.
+///
+/// Erring toward "already located" is the safe direction. A false positive
+/// costs a location the heuristic might have guessed; a false negative
+/// reinstates a CONFIDENTLY WRONG one. Missing information beats misinformation
+/// (docs/issue-triage.md ranks silent-wrong above every other failure).
 fn diag_already_located(msg: String) -> Bool {
   let lead = "line "
-  if String::index_of(msg, lead) == 0 {
-    parse_offset_digits(msg, String::length(lead), String::length(lead) + 1) >= 0
-  } else {
-    let sep = String::index_of(msg, ": ")
-    if sep < 0 {
-      false
+  let lead_len = String::length(lead)
+  let total = String::length(msg)
+  let mut cursor = 0
+  let mut found = false
+  while !found && cursor < total {
+    let rel = String::index_of(String::substring(msg, cursor, total), lead)
+    if rel < 0 {
+      cursor = total
     } else {
-      let after = sep + 2
-      let rest = String::substring(msg, after, String::length(msg))
-      if String::index_of(rest, lead) == 0 {
-        parse_offset_digits(rest, String::length(lead), String::length(lead) + 1) >= 0
+      let at = cursor + rel
+      // Delimited: message start, or the `: ` a path prefix ends with. Without
+      // this, prose containing the word "line " would match on shape alone.
+      let delimited = if at == 0 {
+        true
       } else {
-        false
+        at >= 2 && String::char_code_at(msg, at - 2) == ':' && String::char_code_at(msg, at - 1) == ' '
+      }
+      if delimited && location_shape_at(msg, at + lead_len) {
+        found = true
+      } else {
+        cursor = at + lead_len
       }
     }
+  }
+  found
+}
+
+/// Does `msg` read as `<digits>:<digits>` starting at `start`? The `line `
+/// keyword alone is too weak a signal (it occurs in ordinary prose); the
+/// digit-colon-digit shape after it is what makes a location a location.
+fn location_shape_at(msg: String, start: Int) -> Bool {
+  let total = String::length(msg)
+  let mut i = start
+  while i < total && parse_offset_digits(msg, i, i + 1) >= 0 {
+    i = i + 1
+  }
+  if i == start || i >= total {
+    false
+  } else if String::char_code_at(msg, i) != ':' {
+    false
+  } else {
+    i + 1 < total && parse_offset_digits(msg, i + 1, i + 2) >= 0
   }
 }
 

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3009,11 +3009,56 @@ fn locate_unused_import_msg(source: String, msg: String) -> String {
     }
   }
 }
+/// Does `msg` already carry a `line N:C` location?
+///
+/// Two shapes reach the final locate pass already located:
+///   `line 3:3-4: <msg>`                 -- located, not yet path-prefixed
+///   `/path/to/mod.vibe: line 3:3-4: ..` -- located AND path-prefixed by the
+///                                          per-module pass (see the
+///                                          `job.path + ": "` concat below)
+///
+/// The second shape used to slip past the guard, which only tested for the
+/// location at index 0. A path-prefixed message then went through the
+/// first-occurrence heuristic AGAIN -- against the ENTRY module's source, which
+/// is not necessarily the source the error came from -- and got a SECOND,
+/// earlier location glued to its front:
+///
+///   error: line 1:12: /tmp/x.vibe: line 3:3-4: function arity mismatch for g
+///          ^^^^^^^^^ g's DECLARATION      ^^^^^^^^ the actual call site
+///
+/// Both locations are real positions of `g`, so nothing looks malformed; the
+/// first one is simply the wrong one, and it is the one a reader (or an LSP
+/// parsing `^line N:C`) takes. Reporting a confident wrong location is worse
+/// than reporting none, so recognize the path-prefixed shape too.
+///
+/// Anchored on the FIRST `: ` in the message: the prefix is a file path, which
+/// does not contain `: `, so a `: line N` occurring later (inside the message
+/// prose) cannot be mistaken for the location prefix.
+fn diag_already_located(msg: String) -> Bool {
+  let lead = "line "
+  if String::index_of(msg, lead) == 0 {
+    parse_offset_digits(msg, String::length(lead), String::length(lead) + 1) >= 0
+  } else {
+    let sep = String::index_of(msg, ": ")
+    if sep < 0 {
+      false
+    } else {
+      let after = sep + 2
+      let rest = String::substring(msg, after, String::length(msg))
+      if String::index_of(rest, lead) == 0 {
+        parse_offset_digits(rest, String::length(lead), String::length(lead) + 1) >= 0
+      } else {
+        false
+      }
+    }
+  }
+}
+
 /// First-occurrence heuristic locator (the original behavior). Kept separate so
 /// the offset-marker path can fall through to it on the marker-stripped message.
 fn locate_type_error_heuristic(source: String, msg: String) -> String {
   // Already located (e.g. a parse error that bubbled here)? leave it.
-  if String::index_of(msg, "line ") == 0 {
+  if diag_already_located(msg) {
     msg
   } else {
     let with_name = locate_by_marker(source, msg, "unknown name: ")

--- a/scripts/test_located_diagnostics.sh
+++ b/scripts/test_located_diagnostics.sh
@@ -149,6 +149,20 @@ else
   echo "FAIL: expected the call site (line 3:3) in: $dup_out" >&2; fail=$((fail + 1))
 fi
 
+# ...and the guard must not depend on what the PATH contains. `: ` is legal in a
+# POSIX path, so a guard anchored on the first `: ` in the message lands inside
+# the path and falls back to the buggy behaviour (#1628 review, Codex P2).
+locdir="$WORK/foo: bar"
+mkdir -p "$locdir"
+printf 'export let g = (a: Int, b: Int) -> Int { a + b }\nexport fn main() -> Int {\n  g(1)\n}\n' > "$locdir/dup.vibe"
+sep_out="$("$VIBE" check "$locdir/dup.vibe" 2>&1 || true)"
+sep_n="$(printf '%s' "$sep_out" | grep -oE 'line [0-9]+:[0-9]+' | wc -l | tr -d ' ')"
+if [ "$sep_n" = "1" ]; then
+  echo "ok: a path containing ': ' still yields exactly one location"; pass=$((pass + 1))
+else
+  echo "FAIL: expected 1 location for a ': '-containing path, got $sep_n (in: $sep_out)" >&2; fail=$((fail + 1))
+fi
+
 # a good program -> check passes (no error)
 printf 'export let main = () -> Int { 40 + 2 }\n' > "$WORK/ok.vibe"
 if "$VIBE" check "$WORK/ok.vibe" >/dev/null 2>&1; then

--- a/scripts/test_located_diagnostics.sh
+++ b/scripts/test_located_diagnostics.sh
@@ -120,6 +120,35 @@ expect_missing "no [@off= marker leak (unknown name)" "[@off=" \
 expect_missing "no [@off= marker leak (unknown field)" "[@off=" \
   'struct Point { x: Int; y: Int }\nexport let get = (p: Point) -> Int {\n  p.z\n}\nexport let main = () -> Int { 0 }\n'
 
+# #1567: EXACTLY ONE location per diagnostic, and it must be the crime scene.
+#
+# A per-module error is rendered `<path>: line N:C: <msg>` and then handed to a
+# second, entry-level locate pass. That pass only recognized a message as
+# already-located when the location sat at index 0, so the path-prefixed shape
+# fell through to the first-occurrence heuristic and got a SECOND location
+# glued to its front -- the first textual occurrence of the symbol, i.e. its
+# DECLARATION, not the call that is actually wrong:
+#
+#   error: line 1:12: /tmp/x.vibe: line 3:3-4: function arity mismatch for g
+#
+# Both numbers are real positions of `g`, so nothing looks broken; the leading
+# one is just wrong, and it is the one a reader or an `^line N:C`-parsing LSP
+# takes. Pin the count (one `line N:C:`) and the value (line 3, the call).
+locdup="$WORK/dup.vibe"
+printf 'export let g = (a: Int, b: Int) -> Int { a + b }\nexport fn main() -> Int {\n  g(1)\n}\n' > "$locdup"
+dup_out="$("$VIBE" check "$locdup" 2>&1 || true)"
+dup_n="$(printf '%s' "$dup_out" | grep -oE 'line [0-9]+:[0-9]+' | wc -l | tr -d ' ')"
+if [ "$dup_n" = "1" ]; then
+  echo "ok: same-file arity mismatch carries exactly one location"; pass=$((pass + 1))
+else
+  echo "FAIL: expected 1 location, got $dup_n (in: $dup_out)" >&2; fail=$((fail + 1))
+fi
+if printf '%s' "$dup_out" | grep -qE 'line 3:3'; then
+  echo "ok: the location is the call site, not the declaration"; pass=$((pass + 1))
+else
+  echo "FAIL: expected the call site (line 3:3) in: $dup_out" >&2; fail=$((fail + 1))
+fi
+
 # a good program -> check passes (no error)
 printf 'export let main = () -> Int { 40 + 2 }\n' > "$WORK/ok.vibe"
 if "$VIBE" check "$WORK/ok.vibe" >/dev/null 2>&1; then


### PR DESCRIPTION
[#1567](https://github.com/mizchi/vibe-lang/issues/1567) の残り「型エラーに `line:col` が付かない」を調べる過程で見つけた、**位置情報が黙って誤るバグ**の修正。[slice 2 (#1627)](https://github.com/mizchi/vibe-lang/pull/1627) の続き。

## 症状

同一ファイル内の arity mismatch:

```
error: line 1:12: /tmp/x.vibe: line 3:3-4: function arity mismatch for g: expected 2 args, got 1
       ~~~~~~~~~ g の「宣言」    ~~~~~~~~~~ 実際に間違っている呼び出し
```

入力:

```vibe
export let g = (a: Int, b: Int) -> Int { a + b }   // line 1, col 12 = g
export fn main() -> Int {
  g(1)                                              // line 3, col 3 = 本当の犯行現場
}
```

## 原因

診断は 2 段階で位置付けされる:

1. モジュール単位の pass が `<path>: line N:C: <msg>` を作る (正しい位置)
2. entry 層の pass がもう一度 `locate_type_error` に通す

2 の中の「既に位置付きなら触らない」ガードが `String::index_of(msg, "line ") == 0` —— **msg の先頭**が `line ` かどうかしか見ていなかった。1 が付けた path prefix があると先頭は path なのでガードが外れ、first-occurrence heuristic が再発火して**シンボル名の最初の出現＝宣言位置**を先頭に貼り付ける。

## なぜ悪いか

両方とも `g` の**実在する**位置なので、出力は壊れて見えない。そして読まれるのは先頭のほう —— 人間も、`^line N:C` を拾う LSP も、grep も。**自信を持って間違った位置を出すのは位置なしより悪い**ので、triage の「黙って誤る」に当たる。

クロスモジュールでは症状が出ない (シンボル名が entry source に無いので heuristic が空振りする):

```
# dep.vibe にエラー、app.vibe から import — これは元々正しかった
error: /tmp/xmod/dep.vibe: line 2:30-36: function arity mismatch for helper: ...
```

つまり壊れていたのは**同一ファイル、日常的なケースだけ**だった。

## 修正

`diag_already_located` を足してガードを 2 つの形に広げる:

| 形 | 由来 |
|---|---|
| `line 3:3-4: <msg>` | 位置付け済み、path prefix 前 |
| `/path/mod.vibe: line 3:3-4: <msg>` | 位置付け済み + path prefix 済み ← **これを取りこぼしていた** |

判定は**最初の `: ` にアンカー**している。prefix はファイルパスで `: ` を含まないので、メッセージ本文の後ろに現れる `: line N` を位置 prefix と誤認しない。`line ` の直後が数字であることも確認する。

## 検証

| | |
|---|---|
| `compiler_gate.sh` | **100/100** (seed→stage1→stage2→stage3 fixpoint 込み。コンパイラソース変更のため) |
| `test_located_diagnostics.sh` | **16/16** (回帰テスト 2 件を追加) |
| `vibe_fmt.sh --check` | clean |

追加した pin は 2 つ: 診断が持つ位置は**ちょうど 1 個**であること、そしてそれが**宣言ではなく呼び出し側**であること。片方だけだと弱い —— 個数だけ見ると「宣言 1 個」でも通ってしまい、値だけ見ると余計な prefix が付いていても通ってしまう。

手動での before/after (再ビルドした stage2):

```
# before
error: line 1:12: /tmp/loc2.vibe: line 3:3-4: function arity mismatch for g: ...
# after
error: /tmp/loc2.vibe: line 3:3-4: function arity mismatch for g: ...
```

クロスモジュールと `unknown name` の位置は不変であることも確認済み。

## この先 (#1567 の残り)

調査で構造的な制約が判明したので記録しておく。**`EInt` / `EFloat` / `EString` / `EBool` は AST に offset スロットを持たない** —— 持つのは `EIdent` / `ECall` / `EDot` / `ELet` 系だけ (`lib/@vibe/ast/index.vpkg`)。したがって:

- `fn f() -> Int { "s" }` のようなリテラル直返しは、AST を変えない限り**原理的に位置を付けられない** (contract 変更になるので別issue相当)
- 残る 3 種 (`return type mismatch` ×2 / `binding type mismatch for <name>` / binop `type mismatch in '<op>'`) は、いずれも呼び出し側に式が in scope なので、**offset を持つ式なら**位置を付けられる。`infer_binop_type` はファイルローカルで呼び出し元 1 箇所なので引数追加も contract に波及しない

これは別スライスとして分けた (ゲート 1 周が長く、本 PR は単体で完結しているため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_