### PR TITLE
feat(console): add bounded stdin provider chunk reads

### DIFF
--- a/docs/builtin_contract_table.generated.md
+++ b/docs/builtin_contract_table.generated.md
@@ -45,7 +45,7 @@ Legend:
 | `Stdin::read_via_stream` | `() -> StdinStream` | `{Stdin}` | component linear/RC only | component linear/RC only |
 | `StdinStream::next` | `(StdinStream) -> Int` | `{Async}` | component linear/RC only | component linear/RC only |
 | `StdinStream::close` | `(StdinStream) -> Unit` | `{Async}` | component linear/RC only | component linear/RC only |
-| `StdinStream::chunks` | `(StdinStream, Int) -> (() -> Option[String] with Async)` | `-` (pull requires `{Async}`) | component linear/RC only | component linear/RC only |
+| `StdinStream::read_chunk` | `(StdinStream, Int) -> Option[String]` | `{Async}` | component linear/RC only | component linear/RC only |
 | `Stdout::write_char` | `(Int) -> Unit` | `{Stdout}` | yes | yes |
 | `Stdout::write_stream` | `(String) -> Unit` | `{Stdout}` | yes | yes |
 | `String::char_code_at` | `(String, Int) -> Int` | `-` | yes | yes |

--- a/docs/builtin_contract_table.generated.md
+++ b/docs/builtin_contract_table.generated.md
@@ -42,6 +42,10 @@ Legend:
 | `MapBuilder::set` | `(MapBuilder[K, V], K, V) -> Unit` | `-` | yes | yes |
 | `Stdin::read_char` | `() -> Int` | `{Stdin}` | yes | yes |
 | `Stdin::read_stream` | `(Int) -> String` | `{Stdin}` | yes | yes |
+| `Stdin::read_via_stream` | `() -> StdinStream` | `{Stdin}` | component linear/RC only | component linear/RC only |
+| `StdinStream::next` | `(StdinStream) -> Int` | `{Async}` | component linear/RC only | component linear/RC only |
+| `StdinStream::close` | `(StdinStream) -> Unit` | `{Async}` | component linear/RC only | component linear/RC only |
+| `StdinStream::chunks` | `(StdinStream, Int) -> (() -> Option[String] with Async)` | `-` (pull requires `{Async}`) | component linear/RC only | component linear/RC only |
 | `Stdout::write_char` | `(Int) -> Unit` | `{Stdout}` | yes | yes |
 | `Stdout::write_stream` | `(String) -> Unit` | `{Stdout}` | yes | yes |
 | `String::char_code_at` | `(String, Int) -> Int` | `-` | yes | yes |

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -778,7 +778,11 @@ StdinStream::read_chunk(StdinStream, Int) -> Option[String] with Async
 `next` yields `0..255`, then `-1` after successful EOF settlement. `close`
 settles an early stop; repeated close and reads after successful settlement are
 idempotent. `StdinStream` is opaque, non-`Send`, and unrelated to `HostStream`
-or eager `Stream[T]`. `read_chunk(stream, n)` directly returns exactly `n`
+or eager `Stream[T]`. All four provider operations are direct-call-only:
+referencing one as a value (including through an alias, container, return value,
+or unknown higher-order call) is rejected. Wrap a direct call in a user function
+whose row explicitly declares `Stdin` or `Async` when transport is needed.
+`read_chunk(stream, n)` directly returns exactly `n`
 bytes per `Some` except for the final short chunk; it does not preserve provider
 read boundaries and preserves arbitrary bytes. EOF settles the provider, after
 which calls return `None`. For `n <= 0`, it returns `None` without reading or

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -772,15 +772,23 @@ entry/runtime policy; WIT mapping and handler behavior are unchanged.
 Stdin::read_via_stream() -> StdinStream with Stdin
 StdinStream::next(StdinStream) -> Int with Async
 StdinStream::close(StdinStream) -> Unit with Async
+StdinStream::chunks(StdinStream, Int) -> (() -> Option[String] with Async)
 ```
 
 `next` yields `0..255`, then `-1` after successful EOF settlement. `close`
 settles an early stop; repeated close and reads after successful settlement are
 idempotent. `StdinStream` is opaque, non-`Send`, and unrelated to `HostStream`
-or eager `Stream[T]`. Keep aliases within one task and explicitly drain or
-close every acquisition. This surface is component-only (linear/RC); GC,
-standalone core, `host_stream_named("stdin")`, and mixed named-provider
-composition are rejected. Legacy `stdin_stream(chunk_size)` is unchanged.
+or eager `Stream[T]`. `chunks(stream, n)` is a pure factory whose captured
+pull closure returns exactly `n` bytes per `Some` except for the final short
+chunk; it does not preserve provider read boundaries. It preserves arbitrary
+bytes. EOF settles the provider, after which pulls return `None`. For `n <= 0`,
+pulls return `None` without reading or settling. Keep the original `stream`
+handle, explicitly drain to EOF or call `close` after stopping early, and note
+that exact multiples need one extra pull to settle EOF. This surface is
+component-only (linear/RC); GC, standalone core,
+`host_stream_named("stdin")`, and mixed named-provider composition are
+rejected. Legacy `stdin_stream(chunk_size)` is standalone-capable and
+unchanged.
 
 **Naming.** Effect names are CamelCase. A standard provider builtin is a plain
 `Effect::snake_case` function call; a declared operation is CamelCase and is

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -772,20 +772,20 @@ entry/runtime policy; WIT mapping and handler behavior are unchanged.
 Stdin::read_via_stream() -> StdinStream with Stdin
 StdinStream::next(StdinStream) -> Int with Async
 StdinStream::close(StdinStream) -> Unit with Async
-StdinStream::chunks(StdinStream, Int) -> (() -> Option[String] with Async)
+StdinStream::read_chunk(StdinStream, Int) -> Option[String] with Async
 ```
 
 `next` yields `0..255`, then `-1` after successful EOF settlement. `close`
 settles an early stop; repeated close and reads after successful settlement are
 idempotent. `StdinStream` is opaque, non-`Send`, and unrelated to `HostStream`
-or eager `Stream[T]`. `chunks(stream, n)` is a pure factory whose captured
-pull closure returns exactly `n` bytes per `Some` except for the final short
-chunk; it does not preserve provider read boundaries. It preserves arbitrary
-bytes. EOF settles the provider, after which pulls return `None`. For `n <= 0`,
-pulls return `None` without reading or settling. Keep the original `stream`
-handle, explicitly drain to EOF or call `close` after stopping early, and note
-that exact multiples need one extra pull to settle EOF. This surface is
-component-only (linear/RC); GC, standalone core,
+or eager `Stream[T]`. `read_chunk(stream, n)` directly returns exactly `n`
+bytes per `Some` except for the final short chunk; it does not preserve provider
+read boundaries and preserves arbitrary bytes. EOF settles the provider, after
+which calls return `None`. For `n <= 0`, it returns `None` without reading or
+settling, so the caller must close the stream. An exact multiple needs one extra
+call to settle EOF. The pull-closure/`for` adapter remains blocked on transitive
+higher-order effect evidence (#1536); do not treat `read_chunk` as directly
+iterable. This surface is component-only (linear/RC); GC, standalone core,
 `host_stream_named("stdin")`, and mixed named-provider composition are
 rejected. Legacy `stdin_stream(chunk_size)` is standalone-capable and
 unchanged.

--- a/docs/language-tour/builtins.md
+++ b/docs/language-tour/builtins.md
@@ -151,7 +151,7 @@ reserved and is not part of the current surface syntax.
 | `Stdin::read_via_stream` | `() -> StdinStream` | `{Stdin}` | Acquire an opaque p3 stdin provider stream |
 | `StdinStream::next` | `(StdinStream) -> Int` | `{Async}` | Read one byte, or `-1` after settled EOF |
 | `StdinStream::close` | `(StdinStream) -> Unit` | `{Async}` | Settle an early close (idempotent after success) |
-| `StdinStream::chunks` | `(StdinStream, Int) -> (() -> Option[String] with Async)` | `-` (pull: `{Async}`) | Pure factory for exact-size binary chunks; caller retains and closes the stream on early stop |
+| `StdinStream::read_chunk` | `(StdinStream, Int) -> Option[String]` | `{Async}` | Read one exact-size binary chunk (except the final short chunk); caller closes after early stop or non-positive size |
 
 ## JSON
 

--- a/docs/language-tour/builtins.md
+++ b/docs/language-tour/builtins.md
@@ -153,6 +153,11 @@ reserved and is not part of the current surface syntax.
 | `StdinStream::close` | `(StdinStream) -> Unit` | `{Async}` | Settle an early close (idempotent after success) |
 | `StdinStream::read_chunk` | `(StdinStream, Int) -> Option[String]` | `{Async}` | Read one exact-size binary chunk (except the final short chunk); caller closes after early stop or non-positive size |
 
+These four stdin-provider builtins are direct-call-only. To pass an operation as
+a value, define a wrapper whose `with` row explicitly declares `Stdin` or
+`Async`; aliases and other value-position references to the builtins are
+rejected by the checker.
+
 ## JSON
 
 | Function | Signature | Description |

--- a/docs/language-tour/builtins.md
+++ b/docs/language-tour/builtins.md
@@ -151,6 +151,7 @@ reserved and is not part of the current surface syntax.
 | `Stdin::read_via_stream` | `() -> StdinStream` | `{Stdin}` | Acquire an opaque p3 stdin provider stream |
 | `StdinStream::next` | `(StdinStream) -> Int` | `{Async}` | Read one byte, or `-1` after settled EOF |
 | `StdinStream::close` | `(StdinStream) -> Unit` | `{Async}` | Settle an early close (idempotent after success) |
+| `StdinStream::chunks` | `(StdinStream, Int) -> (() -> Option[String] with Async)` | `-` (pull: `{Async}`) | Pure factory for exact-size binary chunks; caller retains and closes the stream on early stop |
 
 ## JSON
 

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1540,6 +1540,7 @@ The compiler now exposes this contract through one unforgeable nominal scalar:
 Stdin::read_via_stream() -> StdinStream with Stdin
 StdinStream::next(StdinStream) -> Int with Async
 StdinStream::close(StdinStream) -> Unit with Async
+StdinStream::chunks(StdinStream, Int) -> (() -> Option[String] with Async)
 ```
 
 `StdinStream` is neither `Int`, generic `HostStream`, nor `Stream[T]`; source
@@ -1558,6 +1559,17 @@ requirements are fixed as follows:
 - A completion `error-code` is fail-closed. There is no approved public
   `Stdin`/`Exception`/`Result` mapping yet; an adapter must not turn it into
   EOF, success, a generic integer, or a legacy `Option` value.
+- `chunks(stream, n)` is a compiler-owned, use-gated adapter. Its pure factory
+  retains `stream` and `n` in a pull closure; each pull carries `Async`. For
+  positive `n`, it reads one provider byte at a time and returns exactly `n`
+  bytes except for the final short chunk. Bytes are validated as `0..255` and
+  appended through one-byte `String::from_char_code`, without UTF-8 expansion.
+  It does not promise to preserve internal provider read boundaries. EOF
+  settles before `None`; subsequent pulls return `None`. An exact multiple
+  needs one extra pull to observe EOF. For `n <= 0`, pulls return `None` without
+  reading or settling, so the caller must close the retained stream. Early
+  stopping likewise requires explicit, idempotent `close`; closure drop is not
+  a finalizer.
 
 The existing `host_stream_close(HostStream) -> Unit` is deliberately
 synchronous and only drops its one generic stream handle (§3.18.1). It cannot
@@ -1583,9 +1595,9 @@ canonical stream handle, and completion-future handle never cross into the
 compiled guest. The bridge ABI is `wire = value << 1`; read returns tagged
 bytes or tagged `-1` after settlement and close returns tagged zero.
 
-The three raw registry rows remain `checker_visible=false`; three public rows
-lower atomically through compiler-owned wrapper functions to those same exact
-imports. The wrappers are required for first-class references/aliases because
+The three raw registry rows remain `checker_visible=false`; the four public
+operations (acquire, next, close, and chunks) lower atomically through
+compiler-owned wrapper functions to those same exact imports. The wrappers are required for first-class references/aliases because
 raw imports do not accept the hidden closure-environment argument. Source emits
 only the exact `vibe.stdin_provider_*` core imports and the nominal
 `wasi:cli/types@0.3.0` + `wasi:cli/stdin@0.3.0` component imports.
@@ -1807,7 +1819,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 |---|---|---|
 | **suspend lowering の適格性** (#1536) | row-variable callee と literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow、eager `await(Stream::next(s))` retarget、sequence-HEAD let 連鎖の float (`for` 駆動 terminal) は済み (§2.2 末尾) | — (ADR-0076 本体) |
 | **AsyncIter への一本化** (#1538) | eager `Stream[T]` combinator の退役 / AsyncIter 上への再実装。`Stream::next` protocol と host stream read の接続 | 上の適格性 |
-| **stdin provider / `StdinStream` の p3 接続** (#1539) | **atomic public source route まで実装**: unforgeable nominal `StdinStream`、exact authority/effects、exact `vibe.stdin_provider_*` raw imports、tagged-i64 bridge、任意 core composer、stdin-first sniff を実装。既存 `stdin_stream(chunk_size)` は未変更 (§3.18.3) | Wasmtime 47 real-source drain/early-close/function-alias/sequential-reacquire/multiple-active gate; generic `[3, handle]` `HostStream` は使わず、named future/stream との mix は明示拒否 |
+| **stdin provider / `StdinStream` の p3 接続** (#1539) | **atomic public source route + additive compiler-owned chunk adapter まで実装**: unforgeable nominal `StdinStream`、exact authority/effects、exact `vibe.stdin_provider_*` raw imports、tagged-i64 bridge、任意 core composer、stdin-first sniff、`StdinStream::chunks` を実装。既存 `stdin_stream(chunk_size)` は standalone-capable のまま未変更 (§3.18.3) | Wasmtime 47 real-source drain/early-close/function-alias/sequential-reacquire/multiple-active + binary `00 80 ff 41 42` chunks (linear/RC capture, direct `for`, n=4/1/0/negative, EOF/post-close) gate; GC/standalone/mixed reject; generic `[3, handle]` `HostStream` import は不使用 |
 | **実 provider = `wasi:http` incoming-body** (#1540) | serve composition と host-stream composition の統合が要る (§3.19 に構造的な理由と 3 点の分解) | — |
 | **M-conc-2: 真の subtask spawn** (#1537) | waitable-set / `future.cancel-*` による実並行・キャンセル。ADR-0068 の nursery を backend へ落とす | ADR-0076 CPS/suspend lowering |
 | **M1b-3c-1c: interleaving spawn の emitter** (#1537) | ABI 側の問いは §3.11 で解決済み (`waitable-set.wait` の完了順ディスパッチだけで足りる)。残るのは await をまたぐ task 状態の表現 = ADR-0076 の CPS/suspend lowering | 同上 |

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1544,7 +1544,13 @@ StdinStream::read_chunk(StdinStream, Int) -> Option[String] with Async
 ```
 
 `StdinStream` is neither `Int`, generic `HostStream`, nor `Stream[T]`; source
-cannot construct it and it is not `Send`. Its observable authority and effect
+cannot construct it and it is not `Send`. The four public provider builtins are
+**direct-call-only**: any value-position reference (local/top-level alias,
+chain, compound/container/field, returned value, or unknown HOF transport) is a
+checker error. A user-defined wrapper with an explicit `Stdin` or `Async` row is
+an ordinary function and may be passed as a value under the existing effect
+rules. This deliberately does not add the generic higher-order effect-flow
+propagation deferred by #1536. Their observable authority and effect
 requirements are fixed as follows:
 
 - Acquisition is synchronous but requires `Stdin` authority. It calls
@@ -1595,11 +1601,11 @@ canonical stream handle, and completion-future handle never cross into the
 compiled guest. The bridge ABI is `wire = value << 1`; read returns tagged
 bytes or tagged `-1` after settlement and close returns tagged zero.
 
-The three raw registry rows remain `checker_visible=false`; the four public
-operations (acquire, next, close, and read_chunk) lower atomically through
-compiler-owned wrapper functions to those same exact imports. The wrappers are required for first-class references/aliases because
-raw imports do not accept the hidden closure-environment argument. Source emits
-only the exact `vibe.stdin_provider_*` core imports and the nominal
+The three raw registry rows remain `checker_visible=false`. Exact direct calls
+lower through compiler-owned ABI wrappers to those imports; the `read_chunk`
+wrapper additionally implements repeated hidden raw reads. Public operation
+values never reach codegen because the checker rejects them. Source
+emits only the exact `vibe.stdin_provider_*` core imports and the nominal
 `wasi:cli/types@0.3.0` + `wasi:cli/stdin@0.3.0` component imports.
 
 `stdin_stream`, generic HostStream, and named future/stream behavior remain

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1540,7 +1540,7 @@ The compiler now exposes this contract through one unforgeable nominal scalar:
 Stdin::read_via_stream() -> StdinStream with Stdin
 StdinStream::next(StdinStream) -> Int with Async
 StdinStream::close(StdinStream) -> Unit with Async
-StdinStream::chunks(StdinStream, Int) -> (() -> Option[String] with Async)
+StdinStream::read_chunk(StdinStream, Int) -> Option[String] with Async
 ```
 
 `StdinStream` is neither `Int`, generic `HostStream`, nor `Stream[T]`; source
@@ -1559,17 +1559,17 @@ requirements are fixed as follows:
 - A completion `error-code` is fail-closed. There is no approved public
   `Stdin`/`Exception`/`Result` mapping yet; an adapter must not turn it into
   EOF, success, a generic integer, or a legacy `Option` value.
-- `chunks(stream, n)` is a compiler-owned, use-gated adapter. Its pure factory
-  retains `stream` and `n` in a pull closure; each pull carries `Async`. For
-  positive `n`, it reads one provider byte at a time and returns exactly `n`
-  bytes except for the final short chunk. Bytes are validated as `0..255` and
-  appended through one-byte `String::from_char_code`, without UTF-8 expansion.
-  It does not promise to preserve internal provider read boundaries. EOF
-  settles before `None`; subsequent pulls return `None`. An exact multiple
-  needs one extra pull to observe EOF. For `n <= 0`, pulls return `None` without
-  reading or settling, so the caller must close the retained stream. Early
-  stopping likewise requires explicit, idempotent `close`; closure drop is not
-  a finalizer.
+- `read_chunk(stream, n)` is a direct compiler-owned, use-gated operation with
+  `Async`. For positive `n`, it reads one provider byte at a time and returns
+  exactly `n` bytes except for the final short chunk. Bytes are validated as
+  `0..255` and appended through one-byte `String::from_char_code`, without
+  UTF-8 expansion. It does not promise to preserve internal provider read
+  boundaries. EOF settles before `None`; subsequent calls return `None`. An
+  exact multiple needs one extra call to observe EOF. For `n <= 0`, it returns
+  `None` without reading or settling, so the caller must close the stream.
+  Early stopping likewise requires explicit, idempotent `close`. A pull
+  closure/direct-`for` adapter remains blocked on transitive higher-order
+  effect evidence (#1536) and is not part of this surface.
 
 The existing `host_stream_close(HostStream) -> Unit` is deliberately
 synchronous and only drops its one generic stream handle (§3.18.1). It cannot
@@ -1596,7 +1596,7 @@ compiled guest. The bridge ABI is `wire = value << 1`; read returns tagged
 bytes or tagged `-1` after settlement and close returns tagged zero.
 
 The three raw registry rows remain `checker_visible=false`; the four public
-operations (acquire, next, close, and chunks) lower atomically through
+operations (acquire, next, close, and read_chunk) lower atomically through
 compiler-owned wrapper functions to those same exact imports. The wrappers are required for first-class references/aliases because
 raw imports do not accept the hidden closure-environment argument. Source emits
 only the exact `vibe.stdin_provider_*` core imports and the nominal
@@ -1819,7 +1819,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 |---|---|---|
 | **suspend lowering の適格性** (#1536) | row-variable callee と literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow、eager `await(Stream::next(s))` retarget、sequence-HEAD let 連鎖の float (`for` 駆動 terminal) は済み (§2.2 末尾) | — (ADR-0076 本体) |
 | **AsyncIter への一本化** (#1538) | eager `Stream[T]` combinator の退役 / AsyncIter 上への再実装。`Stream::next` protocol と host stream read の接続 | 上の適格性 |
-| **stdin provider / `StdinStream` の p3 接続** (#1539) | **atomic public source route + additive compiler-owned chunk adapter まで実装**: unforgeable nominal `StdinStream`、exact authority/effects、exact `vibe.stdin_provider_*` raw imports、tagged-i64 bridge、任意 core composer、stdin-first sniff、`StdinStream::chunks` を実装。既存 `stdin_stream(chunk_size)` は standalone-capable のまま未変更 (§3.18.3) | Wasmtime 47 real-source drain/early-close/function-alias/sequential-reacquire/multiple-active + binary `00 80 ff 41 42` chunks (linear/RC capture, direct `for`, n=4/1/0/negative, EOF/post-close) gate; GC/standalone/mixed reject; generic `[3, handle]` `HostStream` import は不使用 |
+| **stdin provider / `StdinStream` の p3 接続** (#1539) | **atomic public source route + additive compiler-owned direct chunk operation まで実装**: unforgeable nominal `StdinStream`、exact authority/effects、exact `vibe.stdin_provider_*` raw imports、tagged-i64 bridge、任意 core composer、stdin-first sniff、`StdinStream::read_chunk` を実装。pull-closure/direct-`for` adapter は transitive HOF effect evidence (#1536) 待ち。既存 `stdin_stream(chunk_size)` は standalone-capable のまま未変更 (§3.18.3) | Wasmtime 47 real-source drain/early-close/function-alias/sequential-reacquire/multiple-active + binary `00 80 ff 41 42` manual while-loop chunks (linear/RC, n=4/1/0/negative, EOF/post-close) gate; GC/standalone/mixed reject; generic `[3, handle]` `HostStream` import は不使用 |
 | **実 provider = `wasi:http` incoming-body** (#1540) | serve composition と host-stream composition の統合が要る (§3.19 に構造的な理由と 3 点の分解) | — |
 | **M-conc-2: 真の subtask spawn** (#1537) | waitable-set / `future.cancel-*` による実並行・キャンセル。ADR-0068 の nursery を backend へ落とす | ADR-0076 CPS/suspend lowering |
 | **M1b-3c-1c: interleaving spawn の emitter** (#1537) | ABI 側の問いは §3.11 で解決済み (`waitable-set.wait` の完了順ディスパッチだけで足りる)。残るのは await をまたぐ task 状態の表現 = ADR-0076 の CPS/suspend lowering | 同上 |

--- a/lib/@vibe/compiler/builtins/declarations.vibe
+++ b/lib/@vibe/compiler/builtins/declarations.vibe
@@ -263,6 +263,7 @@ declare Stdin::read_stream(Int) -> String
 declare Stdin::read_via_stream() -> StdinStream
 declare StdinStream::next(StdinStream) -> Int
 declare StdinStream::close(StdinStream) -> Unit
+declare StdinStream::chunks(StdinStream, Int) -> (() -> Option[String] with Async)
 
 //# Console (#1460 Phase 1)
 // The merged tty capability that replaces Stdin/Stdout/Stderr. Declared

--- a/lib/@vibe/compiler/builtins/declarations.vibe
+++ b/lib/@vibe/compiler/builtins/declarations.vibe
@@ -263,7 +263,7 @@ declare Stdin::read_stream(Int) -> String
 declare Stdin::read_via_stream() -> StdinStream
 declare StdinStream::next(StdinStream) -> Int
 declare StdinStream::close(StdinStream) -> Unit
-declare StdinStream::chunks(StdinStream, Int) -> (() -> Option[String] with Async)
+declare StdinStream::read_chunk(StdinStream, Int) -> Option[String]
 
 //# Console (#1460 Phase 1)
 // The merged tty capability that replaces Stdin/Stdout/Stderr. Declared

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -251,18 +251,32 @@ export fn check_stdin_provider_direct_calls_stmts(stmts: Array[Stmt]) -> Array[E
 
 /// True only for async-effect BUILTIN primitives (await/sleep/Stream::next/...).
 /// A name bound in `env` (a user/prelude function) is intentionally NOT treated
-/// as a primitive even if its type is `with Async`.
+/// as a primitive even if its type is `with Async`, except the four exact
+/// compiler-owned stdin provider names imported from their public contract.
 fn is_async_primitive(name: String, env: TypeEnv) -> Bool {
-  match env_lookup(env, name) {
-    Some(_) => false,
-    None => {
-      let normalized = canonical_builtin_name(name)
-      match lookup_builtin(normalized) {
-        Some(ty) => match ty {
-          CtFn(_, _, eff) => effect_opt_is_async(eff),
-          _ => false
-        },
-        None => false
+  if is_stdin_provider_surface(name) {
+    // Imported package contracts bind these exact public names in env, but
+    // they remain compiler-owned primitives after canonical import rewriting.
+    // Do not let that binding suppress their Async authority requirement.
+    match lookup_builtin(canonical_builtin_name(name)) {
+      Some(ty) => match ty {
+        CtFn(_, _, eff) => effect_opt_is_async(eff),
+        _ => false
+      },
+      None => false
+    }
+  } else {
+    match env_lookup(env, name) {
+      Some(_) => false,
+      None => {
+        let normalized = canonical_builtin_name(name)
+        match lookup_builtin(normalized) {
+          Some(ty) => match ty {
+            CtFn(_, _, eff) => effect_opt_is_async(eff),
+            _ => false
+          },
+          None => false
+        }
       }
     }
   }

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -66,6 +66,9 @@ export enum EffectError {
   // tier in eval/lang-review/repair (05).
   EEEffectRowMismatch(String, String, String, String, Int);
   EEAssignImmutable(String);
+  // #1539: provider-owned stdin lifecycle operations cannot be transported as
+  // values until generic higher-order effect flow is sound (#1536).
+  EEStdinProviderValueReference(String);
   // #1347: a `handle ... with E` whose arms are provably dead because the
   // body cannot reach a perform of E and only invokes an opaque value —
   // the handler-switch footgun. Field: the effect name.
@@ -147,6 +150,7 @@ export fn effect_error_to_string(err: EffectError) -> String {
       }
     },
     EEAssignImmutable(name) => String::concat("cannot assign to immutable binding `", String::concat(name, "` (declare it with `let mut`)")),
+    EEStdinProviderValueReference(name) => String::concat("stdin provider operations are direct-call-only; wrap `", String::concat(name, "` in an explicitly effectful function")),
     EEHandleNeverFires(eff) => {
       let tail = String::concat(eff, "::..` and calls an opaque function value. A continuation captured by another handler carries THAT handler with it, so wrapping its invocation in a new `handle` does not switch handlers (non-scoped resumption is unsupported -- ADR-0089 Part A, #1347). Drive the continuation without the wrapping handle, or handle the effect where it is performed")
       String::concat("handle of effect '", String::concat(eff, String::concat("' can never fire: this body reaches no `perform ", tail)))
@@ -174,75 +178,85 @@ fn effect_opt_is_async(eff: Option[String]) -> Bool {
   effect_row_has_label(effect_row_parse(eff), "Async")
 }
 
-// #1539 follow-up: preserve provider identity only across an exact top-level
-// `let alias = Provider::builtin`. This is deliberately not a generic closure
-// effect inference rule (#1536): alias chains, locals, and compound/escaping
-// values remain opaque. The same evidence feeds the Async and ordinary-row
-// passes so all four provider surfaces agree.
-let provider_alias_names_cell: Array[String] = array_empty()
-let provider_alias_targets_cell: Array[String] = array_empty()
+fn is_stdin_provider_surface(name: String) -> Bool {
+  name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk"
+}
 
-fn stdin_provider_surface_effect(name: String) -> Option[String] {
-  if name == "Stdin::read_via_stream" {
-    Some("Stdin")
-  } else if name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk" {
-    Some("Async")
-  } else {
-    None
+/// #1539: the four public provider operations are syntactic direct-call
+/// primitives, not first-class function values. A direct `ECall` skips its
+/// exact builtin callee but still checks every argument; every other expression
+/// position is traversed structurally. This rejects aliases, chains,
+/// conditionals, returned/container values, and unknown HOF transport without
+/// attempting the generic effect-flow propagation deliberately deferred by
+/// #1536. An explicitly effectful user wrapper remains an ordinary function.
+fn check_stdin_provider_direct_calls_expr(expr: Expr) -> Array[EffectError] {
+  let errors = array_empty()
+  match expr {
+    ECall(EIdent(name, _), args, _) => {
+      if is_stdin_provider_surface(name) {
+        let mut ai = 0
+        while ai < Array::length(args) {
+          append_eff_errs(errors, check_stdin_provider_direct_calls_expr(Array::get(args, ai)))
+          ai = ai + 1
+        }
+      } else {
+        let children = expr_children(expr)
+        let mut i = 0
+        while i < Array::length(children) {
+          append_eff_errs(errors, check_stdin_provider_direct_calls_expr(Array::get(children, i)))
+          i = i + 1
+        }
+      }
+    },
+    EIdent(name, _) => if is_stdin_provider_surface(name) {
+      Array::push(errors, EEStdinProviderValueReference(name))
+    } else {
+      ()
+    },
+    _ => {
+      let children = expr_children(expr)
+      let mut i = 0
+      while i < Array::length(children) {
+        append_eff_errs(errors, check_stdin_provider_direct_calls_expr(Array::get(children, i)))
+        i = i + 1
+      }
+    }
+  }
+  errors
+}
+
+fn check_stdin_provider_direct_calls_stmt(stmt: Stmt) -> Array[EffectError] {
+  match stmt {
+    SLet(_, _, _, _, body) => check_stdin_provider_direct_calls_expr(body),
+    SLetMut(_, _, body) => check_stdin_provider_direct_calls_expr(body),
+    STest(_, body) => check_stdin_provider_direct_calls_expr(body),
+    SBench(_, body) => check_stdin_provider_direct_calls_expr(body),
+    SExample(_, body) => check_stdin_provider_direct_calls_expr(body),
+    SExpr(body) => check_stdin_provider_direct_calls_expr(body),
+    SLetPat(_, body) => check_stdin_provider_direct_calls_expr(body),
+    SModule(_, _, inner) => check_stdin_provider_direct_calls_stmts(inner),
+    _ => array_empty()
   }
 }
 
-fn set_provider_top_level_aliases(stmts: Array[Stmt]) -> Unit {
-  Array::truncate(provider_alias_names_cell, 0)
-  Array::truncate(provider_alias_targets_cell, 0)
+export fn check_stdin_provider_direct_calls_stmts(stmts: Array[Stmt]) -> Array[EffectError] {
+  let errors = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
-    match Array::get(stmts, i) {
-      SLet(_, _, alias, _, EIdent(target, _)) => match stdin_provider_surface_effect(target) {
-        Some(_) => {
-          Array::push(provider_alias_names_cell, alias)
-          Array::push(provider_alias_targets_cell, target)
-        },
-        None => ()
-      },
-      _ => ()
-    }
+    append_eff_errs(errors, check_stdin_provider_direct_calls_stmt(Array::get(stmts, i)))
     i = i + 1
   }
-}
-
-fn provider_top_level_alias_target(name: String) -> Option[String] {
-  let mut i = 0
-  let mut out = None
-  while i < Array::length(provider_alias_names_cell) {
-    if Array::get(provider_alias_names_cell, i) == name {
-      out = Some(Array::get(provider_alias_targets_cell, i))
-      i = Array::length(provider_alias_names_cell)
-    } else {
-      i = i + 1
-    }
-  }
-  out
+  errors
 }
 
 /// True only for async-effect BUILTIN primitives (await/sleep/Stream::next/...).
 /// A name bound in `env` (a user/prelude function) is intentionally NOT treated
 /// as a primitive even if its type is `with Async`.
 fn is_async_primitive(name: String, env: TypeEnv) -> Bool {
-  let resolved = match provider_top_level_alias_target(name) {
-    Some(target) => target,
-    None => name
-  }
   match env_lookup(env, name) {
-    Some(_) => match provider_top_level_alias_target(name) {
-      Some(target) => match stdin_provider_surface_effect(target) {
-        Some(eff) => eff == "Async",
-        None => false
-      },
-      None => false
-    },
+    Some(_) => false,
     None => {
-      let normalized = canonical_builtin_name(resolved)
+      let normalized = canonical_builtin_name(name)
       match lookup_builtin(normalized) {
         Some(ty) => match ty {
           CtFn(_, _, eff) => effect_opt_is_async(eff),
@@ -467,15 +481,7 @@ fn afe_expr_head_name(e: Expr, env: TypeEnv, locals: Array[(String, String)]) ->
       Some(h) => Some(h),
       None => match env_lookup(env, n) {
         Some(t) => afe_type_head_name(t),
-        None => if n == "StdinStream::read_chunk" {
-          // #1539: targeted provenance for the compiler-owned direct adapter.
-          // This deliberately does not infer generic closure effect evidence
-          // (#1536); it only keeps a bare local alias use-gated like the
-          // public builtin it names.
-          Some("#stdin_read_chunk_async_primitive")
-        } else {
-          None
-        }
+        None => None
       }
     },
     // `Counter::{ .. }` -- the struct literal names its own type.
@@ -538,20 +544,7 @@ fn check_async_effects_expr_lo(expr: Expr, env: TypeEnv, in_async: Bool, locals:
   // structural children, then delegate their enumeration to expr_children.
   match expr {
     ECall(EIdent(name, _), _, _) => if !in_async && is_async_primitive(name, env) {
-      let provider_name = match provider_top_level_alias_target(name) {
-        Some(target) => target,
-        None => name
-      }
-      Array::push(errors, EEEffectfulCallOutsideEffect(provider_name))
-    } else if !in_async {
-      match afe_lookup_local(locals, name) {
-        Some(target) => if target == "#stdin_read_chunk_async_primitive" {
-          Array::push(errors, EEEffectfulCallOutsideEffect("StdinStream::read_chunk"))
-        } else {
-          ()
-        },
-        None => ()
-      }
+      Array::push(errors, EEEffectfulCallOutsideEffect(name))
     } else {
       ()
     },
@@ -651,12 +644,13 @@ export fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectErro
 }
 
 export fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError] {
-  set_provider_top_level_aliases(stmts)
+  // Enforce direct-call-only before ordinary Async row checks. These errors are
+  // checker diagnostics, so no artifact reaches codegen for an opaque flow.
+  let errors = check_stdin_provider_direct_calls_stmts(stmts)
   // #1341: rebuild the struct field-type table for THIS program before the
   // walk, so a stale one from a previous module can never classify a
   // same-named field here.
   afe_set_field_types(stmts)
-  let errors = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
     append_eff_errs(errors, check_async_effects_stmt(Array::get(stmts, i), env))
@@ -1197,10 +1191,6 @@ fn builtin_call_op_label(name: String, eff: String) -> String {
 /// discipline) and `Async` (composition-allowed; handled by the async pass) are
 /// deliberately excluded from this slice.
 fn builtin_call_effect(name: String) -> Option[String] {
-  let resolved = match provider_top_level_alias_target(name) {
-    Some(target) => target,
-    None => name
-  }
   // `sh`/`sh_lines` and the checker_visible `vibe_*_raw` dunder builtins
   // (Codex review, PR #909) are the only UNQUALIFIED effectful builtins:
   // they lower to real `vibe.*` host imports that execute shell commands or
@@ -1211,15 +1201,15 @@ fn builtin_call_effect(name: String) -> Option[String] {
   // callable from source); vibe_sh_lines_raw is checker_visible=false (only
   // synthesized internally, never typed by user source) so it needs no
   // entry. Checked before the `::` fast path below.
-  if resolved == "sh" || resolved == "sh_lines"
-  || resolved == "vibe_sh_capture_raw"
-  || resolved == "vibe_sh_capture_exit_code_raw"
-  || resolved == "vibe_sh_capture_stdout_raw"
-  || resolved == "vibe_sh_capture_stderr_raw"
-  || resolved == "vibe_sh_capture_close_raw"
-  || resolved == "vibe_process_exit_raw" {
+  if name == "sh" || name == "sh_lines"
+  || name == "vibe_sh_capture_raw"
+  || name == "vibe_sh_capture_exit_code_raw"
+  || name == "vibe_sh_capture_stdout_raw"
+  || name == "vibe_sh_capture_stderr_raw"
+  || name == "vibe_sh_capture_close_raw"
+  || name == "vibe_process_exit_raw" {
     Some("Process")
-  } else if String::index_of(resolved, "::") < 0 {
+  } else if String::index_of(name, "::") < 0 {
     // Fast path: every OTHER effectful builtin in this slice is a QUALIFIED name
     // (`Fs::read_file`, `Env::args_len`, `Stdin::...`, `Stdout::...`, ...), so a
     // callee with no `::` can never be one. Skipping `lookup_builtin` for the
@@ -1227,7 +1217,7 @@ fn builtin_call_effect(name: String) -> Option[String] {
     // over the whole compiler source within the seed's heap during self-build.
     None
   } else {
-    let normalized = canonical_builtin_name(resolved)
+    let normalized = canonical_builtin_name(name)
     match lookup_builtin(normalized) {
       Some(ty) => match ty {
         // Standard entry/runtime execution handles `Error`/`Exception[K]`
@@ -2735,7 +2725,6 @@ export fn check_perform_effects_stmts(stmts: Array[Stmt]) -> Array[EffectError] 
 }
 
 export fn check_perform_effects_stmts_env(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError] {
-  set_provider_top_level_aliases(stmts)
   // Build the call-graph effect map (parallel arrays) from every top-level
   // binding's declared row — locals first, then the env's (imported)
   // bindings (#812) — then run the per-stmt check WITH transitive

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -406,7 +406,15 @@ fn afe_expr_head_name(e: Expr, env: TypeEnv, locals: Array[(String, String)]) ->
       Some(h) => Some(h),
       None => match env_lookup(env, n) {
         Some(t) => afe_type_head_name(t),
-        None => None
+        None => if n == "StdinStream::read_chunk" {
+          // #1539: targeted provenance for the compiler-owned direct adapter.
+          // This deliberately does not infer generic closure effect evidence
+          // (#1536); it only keeps a bare local alias use-gated like the
+          // public builtin it names.
+          Some("#stdin_read_chunk_async_primitive")
+        } else {
+          None
+        }
       }
     },
     // `Counter::{ .. }` -- the struct literal names its own type.
@@ -470,6 +478,15 @@ fn check_async_effects_expr_lo(expr: Expr, env: TypeEnv, in_async: Bool, locals:
   match expr {
     ECall(EIdent(name, _), _, _) => if !in_async && is_async_primitive(name, env) {
       Array::push(errors, EEEffectfulCallOutsideEffect(name))
+    } else if !in_async {
+      match afe_lookup_local(locals, name) {
+        Some(target) => if target == "#stdin_read_chunk_async_primitive" {
+          Array::push(errors, EEEffectfulCallOutsideEffect("StdinStream::read_chunk"))
+        } else {
+          ()
+        },
+        None => ()
+      }
     } else {
       ()
     },

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -174,14 +174,75 @@ fn effect_opt_is_async(eff: Option[String]) -> Bool {
   effect_row_has_label(effect_row_parse(eff), "Async")
 }
 
+// #1539 follow-up: preserve provider identity only across an exact top-level
+// `let alias = Provider::builtin`. This is deliberately not a generic closure
+// effect inference rule (#1536): alias chains, locals, and compound/escaping
+// values remain opaque. The same evidence feeds the Async and ordinary-row
+// passes so all four provider surfaces agree.
+let provider_alias_names_cell: Array[String] = array_empty()
+let provider_alias_targets_cell: Array[String] = array_empty()
+
+fn stdin_provider_surface_effect(name: String) -> Option[String] {
+  if name == "Stdin::read_via_stream" {
+    Some("Stdin")
+  } else if name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk" {
+    Some("Async")
+  } else {
+    None
+  }
+}
+
+fn set_provider_top_level_aliases(stmts: Array[Stmt]) -> Unit {
+  Array::truncate(provider_alias_names_cell, 0)
+  Array::truncate(provider_alias_targets_cell, 0)
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, alias, _, EIdent(target, _)) => match stdin_provider_surface_effect(target) {
+        Some(_) => {
+          Array::push(provider_alias_names_cell, alias)
+          Array::push(provider_alias_targets_cell, target)
+        },
+        None => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+fn provider_top_level_alias_target(name: String) -> Option[String] {
+  let mut i = 0
+  let mut out = None
+  while i < Array::length(provider_alias_names_cell) {
+    if Array::get(provider_alias_names_cell, i) == name {
+      out = Some(Array::get(provider_alias_targets_cell, i))
+      i = Array::length(provider_alias_names_cell)
+    } else {
+      i = i + 1
+    }
+  }
+  out
+}
+
 /// True only for async-effect BUILTIN primitives (await/sleep/Stream::next/...).
 /// A name bound in `env` (a user/prelude function) is intentionally NOT treated
 /// as a primitive even if its type is `with Async`.
 fn is_async_primitive(name: String, env: TypeEnv) -> Bool {
+  let resolved = match provider_top_level_alias_target(name) {
+    Some(target) => target,
+    None => name
+  }
   match env_lookup(env, name) {
-    Some(_) => false,
+    Some(_) => match provider_top_level_alias_target(name) {
+      Some(target) => match stdin_provider_surface_effect(target) {
+        Some(eff) => eff == "Async",
+        None => false
+      },
+      None => false
+    },
     None => {
-      let normalized = canonical_builtin_name(name)
+      let normalized = canonical_builtin_name(resolved)
       match lookup_builtin(normalized) {
         Some(ty) => match ty {
           CtFn(_, _, eff) => effect_opt_is_async(eff),
@@ -477,7 +538,11 @@ fn check_async_effects_expr_lo(expr: Expr, env: TypeEnv, in_async: Bool, locals:
   // structural children, then delegate their enumeration to expr_children.
   match expr {
     ECall(EIdent(name, _), _, _) => if !in_async && is_async_primitive(name, env) {
-      Array::push(errors, EEEffectfulCallOutsideEffect(name))
+      let provider_name = match provider_top_level_alias_target(name) {
+        Some(target) => target,
+        None => name
+      }
+      Array::push(errors, EEEffectfulCallOutsideEffect(provider_name))
     } else if !in_async {
       match afe_lookup_local(locals, name) {
         Some(target) => if target == "#stdin_read_chunk_async_primitive" {
@@ -586,6 +651,7 @@ export fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectErro
 }
 
 export fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError] {
+  set_provider_top_level_aliases(stmts)
   // #1341: rebuild the struct field-type table for THIS program before the
   // walk, so a stale one from a previous module can never classify a
   // same-named field here.
@@ -1131,6 +1197,10 @@ fn builtin_call_op_label(name: String, eff: String) -> String {
 /// discipline) and `Async` (composition-allowed; handled by the async pass) are
 /// deliberately excluded from this slice.
 fn builtin_call_effect(name: String) -> Option[String] {
+  let resolved = match provider_top_level_alias_target(name) {
+    Some(target) => target,
+    None => name
+  }
   // `sh`/`sh_lines` and the checker_visible `vibe_*_raw` dunder builtins
   // (Codex review, PR #909) are the only UNQUALIFIED effectful builtins:
   // they lower to real `vibe.*` host imports that execute shell commands or
@@ -1141,15 +1211,15 @@ fn builtin_call_effect(name: String) -> Option[String] {
   // callable from source); vibe_sh_lines_raw is checker_visible=false (only
   // synthesized internally, never typed by user source) so it needs no
   // entry. Checked before the `::` fast path below.
-  if name == "sh" || name == "sh_lines"
-  || name == "vibe_sh_capture_raw"
-  || name == "vibe_sh_capture_exit_code_raw"
-  || name == "vibe_sh_capture_stdout_raw"
-  || name == "vibe_sh_capture_stderr_raw"
-  || name == "vibe_sh_capture_close_raw"
-  || name == "vibe_process_exit_raw" {
+  if resolved == "sh" || resolved == "sh_lines"
+  || resolved == "vibe_sh_capture_raw"
+  || resolved == "vibe_sh_capture_exit_code_raw"
+  || resolved == "vibe_sh_capture_stdout_raw"
+  || resolved == "vibe_sh_capture_stderr_raw"
+  || resolved == "vibe_sh_capture_close_raw"
+  || resolved == "vibe_process_exit_raw" {
     Some("Process")
-  } else if String::index_of(name, "::") < 0 {
+  } else if String::index_of(resolved, "::") < 0 {
     // Fast path: every OTHER effectful builtin in this slice is a QUALIFIED name
     // (`Fs::read_file`, `Env::args_len`, `Stdin::...`, `Stdout::...`, ...), so a
     // callee with no `::` can never be one. Skipping `lookup_builtin` for the
@@ -1157,7 +1227,7 @@ fn builtin_call_effect(name: String) -> Option[String] {
     // over the whole compiler source within the seed's heap during self-build.
     None
   } else {
-    let normalized = canonical_builtin_name(name)
+    let normalized = canonical_builtin_name(resolved)
     match lookup_builtin(normalized) {
       Some(ty) => match ty {
         // Standard entry/runtime execution handles `Error`/`Exception[K]`
@@ -2665,6 +2735,7 @@ export fn check_perform_effects_stmts(stmts: Array[Stmt]) -> Array[EffectError] 
 }
 
 export fn check_perform_effects_stmts_env(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError] {
+  set_provider_top_level_aliases(stmts)
   // Build the call-graph effect map (parallel arrays) from every top-level
   // binding's declared row — locals first, then the env's (imported)
   // bindings (#812) — then run the per-stmt check WITH transitive

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -42,6 +42,7 @@ import @vibe/compiler/core {
   is_singleton_resource_kind,
   predeclared_resources,
   resolve_builtin,
+  rewrite_import_alias_stmt,
   sort_perm_by_names,
   subst_apply,
   trait_defined,
@@ -2269,6 +2270,49 @@ fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   }
 }
 
+/// Canonicalize only the imported `StdinStream as S` type head before the
+/// ordinary checker runs. This makes `S::next(..)` the same exact direct-call
+/// AST as `StdinStream::next(..)`, so existing Async authority checks apply;
+/// value imports remain distinct and are rejected at the merged compile
+/// boundary rather than becoming first-class provider operations.
+fn canonicalize_stdin_provider_type_import_heads(stmts: Array[Stmt]) -> Unit {
+  let aliases: Array[(String, String)] = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImport(_, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let (original, alias_opt) = Array::get(items, j)
+          match alias_opt {
+            Some(alias) => if original == "StdinStream" {
+              Array::push(aliases, (alias, original))
+            } else {
+              ()
+            },
+            None => ()
+          }
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  if Array::length(aliases) > 0 {
+    let mut k = 0
+    while k < Array::length(stmts) {
+      match Array::get(stmts, k) {
+        SImport(_, _) => (),
+        _ => Array::set(stmts, k, rewrite_import_alias_stmt(Array::get(stmts, k), aliases))
+      }
+      k = k + 1
+    }
+  } else {
+    ()
+  }
+}
+
 /// Reject stdin provider operation values before inference can replace the
 /// actionable safety diagnostic with a secondary type mismatch. This syntactic
 /// gate intentionally precedes artifact production and generic effect flow.
@@ -2828,6 +2872,7 @@ fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[
   desugar_railway_binds(stmts)
   let errors = ArrayBuilder::new()
   let frozen_errors = ArrayBuilder::freeze(errors)
+  canonicalize_stdin_provider_type_import_heads(stmts)
   collect_stdin_provider_direct_call_errors(stmts, frozen_errors)
   // #1455 step 3: the `Enum::Variant` pattern qualifiers the parser folded into
   // a trailing `SQualifiedPatternRefs` marker (see attach_qualified_pattern_refs).
@@ -3142,6 +3187,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       desugar_railway_binds(stmts)
       let errors = ArrayBuilder::new()
       let frozen_errors = ArrayBuilder::freeze(errors)
+      canonicalize_stdin_provider_type_import_heads(stmts)
       collect_stdin_provider_direct_call_errors(stmts, frozen_errors)
       // #1455 step 3: see check_program.
       let qualified_pattern_refs = collect_qualified_pattern_refs(stmts)

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -9,7 +9,11 @@ import @vibe/core {
 }
 
 import ./checker_effects.vibe {
-  check_async_effects_stmts, check_mutability_stmts, check_perform_effects_stmts_env, effect_error_to_string
+  check_async_effects_stmts,
+  check_mutability_stmts,
+  check_perform_effects_stmts_env,
+  check_stdin_provider_direct_calls_stmts,
+  effect_error_to_string
 }
 
 import ./checker_pattern.vibe {
@@ -2265,6 +2269,18 @@ fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   }
 }
 
+/// Reject stdin provider operation values before inference can replace the
+/// actionable safety diagnostic with a secondary type mismatch. This syntactic
+/// gate intentionally precedes artifact production and generic effect flow.
+fn collect_stdin_provider_direct_call_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
+  let direct_errors = check_stdin_provider_direct_calls_stmts(stmts)
+  let mut i = 0
+  while i < Array::length(direct_errors) {
+    Array::push(errors, effect_error_to_string(Array::get(direct_errors, i)))
+    i = i + 1
+  }
+}
+
 /// Append `Async`-escape diagnostics (an async primitive used outside an
 /// `{Async}` context) to the type-error list, but only when type checking is
 /// otherwise clean so we surface the real error first.
@@ -2812,6 +2828,7 @@ fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[
   desugar_railway_binds(stmts)
   let errors = ArrayBuilder::new()
   let frozen_errors = ArrayBuilder::freeze(errors)
+  collect_stdin_provider_direct_call_errors(stmts, frozen_errors)
   // #1455 step 3: the `Enum::Variant` pattern qualifiers the parser folded into
   // a trailing `SQualifiedPatternRefs` marker (see attach_qualified_pattern_refs).
   // Collected up front; validating them needs the enum table, which only exists
@@ -3125,6 +3142,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       desugar_railway_binds(stmts)
       let errors = ArrayBuilder::new()
       let frozen_errors = ArrayBuilder::freeze(errors)
+      collect_stdin_provider_direct_call_errors(stmts, frozen_errors)
       // #1455 step 3: see check_program.
       let qualified_pattern_refs = collect_qualified_pattern_refs(stmts)
       // #1001: mixed argument-mode validation before desugar (see check_program).

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -274,6 +274,7 @@ fn effect_error_to_string(err: EffectError) -> String
 fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> Array[EffectError]
 fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectError]
 fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError]
+fn check_stdin_provider_direct_calls_stmts(stmts: Array[Stmt]) -> Array[EffectError]
 fn check_perform_effects_expr_tx(root: Expr, root_declared: Array[String], root_in_handle: Bool, fn_names: Array[String], fn_effs: Array[Array[String]], root_ov_names: Array[String], root_ov_effs: Array[Array[String]]) -> Array[EffectError]
 fn check_perform_effects_expr(root: Expr, root_declared: Array[String], root_in_handle: Bool) -> Array[EffectError]
 fn check_perform_effects_stmt(stmt: Stmt) -> Array[EffectError]

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -313,7 +313,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       } else {
         ()
       }
-      if fname == "Stdin::read_via_stream" || fname == "StdinStream::next" || fname == "StdinStream::close" || fname == "StdinStream::chunks" {
+      if fname == "Stdin::read_via_stream" || fname == "StdinStream::next" || fname == "StdinStream::close" || fname == "StdinStream::read_chunk" {
         throw("StdinStream is unsupported on gc backend; compile an Async component with the linear or RC backend")
       } else {
         ()

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -313,7 +313,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       } else {
         ()
       }
-      if fname == "Stdin::read_via_stream" || fname == "StdinStream::next" || fname == "StdinStream::close" {
+      if fname == "Stdin::read_via_stream" || fname == "StdinStream::next" || fname == "StdinStream::close" || fname == "StdinStream::chunks" {
         throw("StdinStream is unsupported on gc backend; compile an Async component with the linear or RC backend")
       } else {
         ()

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -664,7 +664,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       next_local
     },
     EIdent(name, _) => {
-      if name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" {
+      if name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::chunks" {
         throw("StdinStream is unsupported on gc backend; compile an Async component with the linear or RC backend")
       } else {
         ()

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -664,7 +664,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       next_local
     },
     EIdent(name, _) => {
-      if name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::chunks" {
+      if name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk" {
         throw("StdinStream is unsupported on gc backend; compile an Async component with the linear or RC backend")
       } else {
         ()

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -15,6 +15,7 @@ import @vibe/compiler/core {
   bytebuf_push_vec_header,
   bytebuf_to_bytes,
   exception_effect_labels_equal,
+  expr_children,
   is_exception_effect_name,
   leb128_encode_s64,
   leb128_encode_u32,
@@ -758,12 +759,84 @@ fn lc_row_has_error(eff: Option[String]) -> Bool {
   lc_row_has_label(eff, "Exception")
 }
 
+fn lc_is_stdin_provider_surface(name: String) -> Bool {
+  name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk"
+}
+
+fn lc_stdin_provider_value_error(name: String) -> String {
+  String::concat("stdin provider operations are direct-call-only; wrap `", String::concat(name, "` in an explicitly effectful function"))
+}
+
+/// Canonical post-merge validation for #1539. Import value aliases and
+/// qualified type heads have already been rewritten to their exact public
+/// provider names by the merge boundary. Each such name is legal only as the
+/// immediate EIdent callee of a direct ECall; arguments are still traversed.
+/// Returning the first source-order error keeps every compile lane on the same
+/// actionable diagnostic without rerunning type/effect checking.
+fn lc_validate_stdin_provider_expr(expr: Expr) -> String {
+  match expr {
+    ECall(EIdent(name, _), args, _) => if lc_is_stdin_provider_surface(name) {
+      let mut i = 0
+      let mut err = ""
+      while i < Array::length(args) && err == "" {
+        err = lc_validate_stdin_provider_expr(Array::get(args, i))
+        i = i + 1
+      }
+      err
+    } else {
+      let children = expr_children(expr)
+      let mut i = 0
+      let mut err = ""
+      while i < Array::length(children) && err == "" {
+        err = lc_validate_stdin_provider_expr(Array::get(children, i))
+        i = i + 1
+      }
+      err
+    },
+    EIdent(name, _) => if lc_is_stdin_provider_surface(name) {
+      lc_stdin_provider_value_error(name)
+    } else {
+      ""
+    },
+    _ => {
+      let children = expr_children(expr)
+      let mut i = 0
+      let mut err = ""
+      while i < Array::length(children) && err == "" {
+        err = lc_validate_stdin_provider_expr(Array::get(children, i))
+        i = i + 1
+      }
+      err
+    }
+  }
+}
+
+fn lc_validate_stdin_provider_stmts(stmts: Array[Stmt]) -> String {
+  let mut i = 0
+  let mut err = ""
+  while i < Array::length(stmts) && err == "" {
+    err = match Array::get(stmts, i) {
+      SLet(_, _, _, _, body) => lc_validate_stdin_provider_expr(body),
+      SLetMut(_, _, body) => lc_validate_stdin_provider_expr(body),
+      STest(_, body) => lc_validate_stdin_provider_expr(body),
+      SBench(_, body) => lc_validate_stdin_provider_expr(body),
+      SExample(_, body) => lc_validate_stdin_provider_expr(body),
+      SExpr(body) => lc_validate_stdin_provider_expr(body),
+      SLetPat(_, body) => lc_validate_stdin_provider_expr(body),
+      SModule(_, _, inner) => lc_validate_stdin_provider_stmts(inner),
+      _ => ""
+    }
+    i = i + 1
+  }
+  err
+}
+
 /// #1539: direct provider calls are retargeted to compiler-owned wrapper
 /// functions because the raw imports do not accept the closure-environment ABI
-/// used by ordinary functions. The checker rejects every value-position public
-/// reference before codegen, so this is strictly direct-call lowering and does
-/// not provide first-class alias transport. Wrapper bodies alone spell the
-/// checker-hidden raw names.
+/// used by ordinary functions. The canonical compile-boundary validator above
+/// has rejected every value-position public reference, so this is strictly
+/// direct-call lowering and does not provide first-class alias transport.
+/// Wrapper bodies alone spell the checker-hidden raw names.
 fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
   let public_names = [
     "Stdin::read_via_stream",
@@ -3309,11 +3382,25 @@ export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked
     // keep the boxed form, and the rewrite is semantics-preserving so the
     // cross-lane differential gates still agree.
     unbox_tuple_loop_params(stmts)
+    // The fully merged AST now carries canonical import value names and
+    // qualified type heads. Validate provider direct-call-only syntax here,
+    // before top-level alias retargeting could erase a value position and before
+    // wrapper injection can introduce any raw provider ABI.
+    let provider_value_err = lc_validate_stdin_provider_stmts(stmts)
+    if provider_value_err != "" {
+      Array::push(errs, provider_value_err)
+    } else {
+      ()
+    }
     // Top-level `let f = g` function aliases: retarget references to the final
     // EFn def so calls do not route through the 0-param thunk registration
     // below (invalid wasm for any call arity). See import_alias_rewrite.vibe.
-    rewrite_top_level_fn_alias_refs(stmts)
-    let _ = lc_inject_stdin_surface_wrappers(stmts)
+    if Array::length(errs) == 0 {
+      rewrite_top_level_fn_alias_refs(stmts)
+      let _ = lc_inject_stdin_surface_wrappers(stmts)
+    } else {
+      ()
+    }
     // #805: inline-wasm fns — extract WAT texts + neutralize marker bodies
     // BEFORE any analysis below (see lc_extract_inline_wasm's doc comment).
     lc_extract_inline_wasm(stmts, iw_names, iw_wats)

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3312,7 +3312,16 @@ export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked
     // EFn def so calls do not route through the 0-param thunk registration
     // below (invalid wasm for any call arity). See import_alias_rewrite.vibe.
     rewrite_top_level_fn_alias_refs(stmts)
-    let _ = lc_inject_stdin_surface_wrappers(stmts)
+    let injected_stdin_wrappers = lc_inject_stdin_surface_wrappers(stmts)
+    // Provider references are retargeted to wrapper names by the injection
+    // above. Run the exact-alias rewrite again only when that happened, so a
+    // top-level `let read = StdinStream::read_chunk` resolves to the wrapper
+    // EFn instead of the alias's zero-parameter thunk (invalid wasm).
+    if injected_stdin_wrappers {
+      rewrite_top_level_fn_alias_refs(stmts)
+    } else {
+      ()
+    }
     // #805: inline-wasm fns — extract WAT texts + neutralize marker bodies
     // BEFORE any analysis below (see lc_extract_inline_wasm's doc comment).
     lc_extract_inline_wasm(stmts, iw_names, iw_wats)

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -767,20 +767,23 @@ fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
   let public_names = [
     "Stdin::read_via_stream",
     "StdinStream::next",
-    "StdinStream::close"
+    "StdinStream::close",
+    "StdinStream::chunks"
   ]
   let raw_names = [
     "__stdin_provider_acquire_surface",
     "__stdin_provider_next_surface",
-    "__stdin_provider_close_surface"
+    "__stdin_provider_close_surface",
+    "__stdin_provider_chunks_surface"
   ]
   let aliases: Array[(String, String)] = [
     (Array::get(public_names, 0), Array::get(raw_names, 0)),
     (Array::get(public_names, 1), Array::get(raw_names, 1)),
-    (Array::get(public_names, 2), Array::get(raw_names, 2))
+    (Array::get(public_names, 2), Array::get(raw_names, 2)),
+    (Array::get(public_names, 3), Array::get(raw_names, 3))
   ]
   let mentions = collect_used_builtin_names(stmts, lc_fresh_string_array())
-  let needed = Map::has_key(mentions, Array::get(public_names, 0)) || Map::has_key(mentions, Array::get(public_names, 1)) || Map::has_key(mentions, Array::get(public_names, 2))
+  let needed = Map::has_key(mentions, Array::get(public_names, 0)) || Map::has_key(mentions, Array::get(public_names, 1)) || Map::has_key(mentions, Array::get(public_names, 2)) || Map::has_key(mentions, Array::get(public_names, 3))
   if needed {
     let mut i = 0
     while i < Array::length(stmts) {
@@ -802,6 +805,10 @@ fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
     let close_param: Array[(String, Option[TypeExpr])] = [
       ("__stdin_stream", Some(TyName("StdinStream")))
     ]
+    let chunks_params: Array[(String, Option[TypeExpr])] = [
+      ("__stdin_stream", Some(TyName("StdinStream"))),
+      ("__stdin_chunk_size", Some(TyName("Int")))
+    ]
     let acquire_body = ECall(EIdent("vibe_stdin_provider_acquire_raw", -1), lc_fresh_expr_array(), -1)
     let next_body = ECall(EIdent("vibe_stdin_provider_read_raw", -1), [
       EIdent("__stdin_stream", -1)
@@ -809,9 +816,42 @@ fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
     let close_body = ESeq(ECall(EIdent("vibe_stdin_provider_close_raw", -1), [
       EIdent("__stdin_stream", -1)
     ], -1), EUnit)
+    // One-byte String::from_char_code construction preserves every u8 value,
+    // including NUL and bytes that are not valid standalone UTF-8. The raw
+    // route is validated before conversion so an ABI violation traps instead
+    // of being silently truncated by store8.
+    let chunk_read = ECall(EIdent("vibe_stdin_provider_read_raw", -1), [
+      EIdent("__stdin_stream", -1)
+    ], -1)
+    let chunk_byte_valid = EBinOp("&&", EBinOp("<=", EInt(0), EIdent("__stdin_chunk_byte", -1)), EBinOp("<=", EIdent("__stdin_chunk_byte", -1), EInt(255)))
+    let chunk_push = ESeq(ECall(EIdent("StringBuilder::push", -1), [
+      EIdent("__stdin_chunk_builder", -1),
+      ECall(EIdent("String::from_char_code", -1), [
+        EIdent("__stdin_chunk_byte", -1)
+      ], -1)
+    ], -1), EAssign("__stdin_chunk_len", EBinOp("+", EIdent("__stdin_chunk_len", -1), EInt(1)), EUnit))
+    let chunk_accept = EIf(chunk_byte_valid, chunk_push, ECall(EIdent("assert_true", -1), [
+      EBool(false)
+    ], -1))
+    let chunk_step = ELet("__stdin_chunk_byte", chunk_read, EIf(EBinOp("==", EIdent("__stdin_chunk_byte", -1), EInt(0 - 1)), EAssign("__stdin_chunk_eof", EBool(true), EUnit), chunk_accept), -1)
+    let chunk_loop_cond = EBinOp("&&", EBinOp("<", EIdent("__stdin_chunk_len", -1), EIdent("__stdin_chunk_size", -1)), EBinOp("==", EIdent("__stdin_chunk_eof", -1), EBool(false)))
+    let chunk_result = EIf(EBinOp("==", EIdent("__stdin_chunk_len", -1), EInt(0)), ECall(EIdent("None", -1), array_empty(), -1), ECall(EIdent("Some", -1), [
+      ECall(EIdent("StringBuilder::freeze", -1), [
+        EIdent("__stdin_chunk_builder", -1)
+      ], -1)
+    ], -1))
+    let positive_pull = ELet("__stdin_chunk_builder", ECall(EIdent("StringBuilder::new", -1), array_empty(), -1), ELetMut("__stdin_chunk_len", EInt(0), ELetMut("__stdin_chunk_eof", EBool(false), ESeq(EWhile(chunk_loop_cond, chunk_step), chunk_result), -1), -1), -1)
+    let pull_body = EIf(EBinOp("<=", EIdent("__stdin_chunk_size", -1), EInt(0)), ECall(EIdent("None", -1), array_empty(), -1), positive_pull)
+    let chunks_body = EFn(lc_fresh_string_array(), array_empty(), no_params, Some(TyApp("Option", [
+      TyName("String")
+    ])), Some("Async"), pull_body)
+    let chunks_ret = TyFn(array_empty(), TyApp("Option", [
+      TyName("String")
+    ]), Some("Async"))
     Array::push(stmts, SLet(false, false, Array::get(raw_names, 0), None, EFn(lc_fresh_string_array(), array_empty(), no_params, Some(TyName("StdinStream")), None, acquire_body)))
     Array::push(stmts, SLet(false, false, Array::get(raw_names, 1), None, EFn(lc_fresh_string_array(), array_empty(), next_param, Some(TyName("Int")), None, next_body)))
     Array::push(stmts, SLet(false, false, Array::get(raw_names, 2), None, EFn(lc_fresh_string_array(), array_empty(), close_param, Some(TyName("Unit")), None, close_body)))
+    Array::push(stmts, SLet(false, false, Array::get(raw_names, 3), None, EFn(lc_fresh_string_array(), array_empty(), chunks_params, Some(chunks_ret), None, chunks_body)))
   } else {
     ()
   }

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -758,11 +758,12 @@ fn lc_row_has_error(eff: Option[String]) -> Bool {
   lc_row_has_label(eff, "Exception")
 }
 
-/// #1539: public provider functions are first-class values, while their exact
-/// raw imports do not accept the hidden closure-environment argument. Retarget
-/// every public reference (not only direct calls) to ordinary compiler-owned
-/// wrapper functions, then let the existing closure machinery handle aliases.
-/// Wrapper bodies alone spell the checker-hidden raw names.
+/// #1539: direct provider calls are retargeted to compiler-owned wrapper
+/// functions because the raw imports do not accept the closure-environment ABI
+/// used by ordinary functions. The checker rejects every value-position public
+/// reference before codegen, so this is strictly direct-call lowering and does
+/// not provide first-class alias transport. Wrapper bodies alone spell the
+/// checker-hidden raw names.
 fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
   let public_names = [
     "Stdin::read_via_stream",
@@ -3312,16 +3313,7 @@ export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked
     // EFn def so calls do not route through the 0-param thunk registration
     // below (invalid wasm for any call arity). See import_alias_rewrite.vibe.
     rewrite_top_level_fn_alias_refs(stmts)
-    let injected_stdin_wrappers = lc_inject_stdin_surface_wrappers(stmts)
-    // Provider references are retargeted to wrapper names by the injection
-    // above. Run the exact-alias rewrite again only when that happened, so a
-    // top-level `let read = StdinStream::read_chunk` resolves to the wrapper
-    // EFn instead of the alias's zero-parameter thunk (invalid wasm).
-    if injected_stdin_wrappers {
-      rewrite_top_level_fn_alias_refs(stmts)
-    } else {
-      ()
-    }
+    let _ = lc_inject_stdin_surface_wrappers(stmts)
     // #805: inline-wasm fns — extract WAT texts + neutralize marker bodies
     // BEFORE any analysis below (see lc_extract_inline_wasm's doc comment).
     lc_extract_inline_wasm(stmts, iw_names, iw_wats)
@@ -5161,8 +5153,8 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
         // ADR-0089 Decision 3 follow-up: shared drop half of the named host
         // streams (`host_stream_close` -> injected `__hs_close`).
         "vibe_hs_close_raw" => hs_close_idx,
-        // #1539 public and checker-hidden spellings share the same exact raw
-        // component-private targets, including first-class function aliases.
+        // #1539 direct public spellings and checker-hidden compiler wrappers
+        // share the same exact component-private targets.
         "vibe_stdin_provider_acquire_raw" => stdin_provider_acquire_idx,
         "vibe_stdin_provider_read_raw" => stdin_provider_read_idx,
         "vibe_stdin_provider_close_raw" => stdin_provider_close_idx,

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -768,13 +768,13 @@ fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
     "Stdin::read_via_stream",
     "StdinStream::next",
     "StdinStream::close",
-    "StdinStream::chunks"
+    "StdinStream::read_chunk"
   ]
   let raw_names = [
     "__stdin_provider_acquire_surface",
     "__stdin_provider_next_surface",
     "__stdin_provider_close_surface",
-    "__stdin_provider_chunks_surface"
+    "__stdin_provider_read_chunk_surface"
   ]
   let aliases: Array[(String, String)] = [
     (Array::get(public_names, 0), Array::get(raw_names, 0)),
@@ -805,7 +805,7 @@ fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
     let close_param: Array[(String, Option[TypeExpr])] = [
       ("__stdin_stream", Some(TyName("StdinStream")))
     ]
-    let chunks_params: Array[(String, Option[TypeExpr])] = [
+    let read_chunk_params: Array[(String, Option[TypeExpr])] = [
       ("__stdin_stream", Some(TyName("StdinStream"))),
       ("__stdin_chunk_size", Some(TyName("Int")))
     ]
@@ -841,17 +841,14 @@ fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
       ], -1)
     ], -1))
     let positive_pull = ELet("__stdin_chunk_builder", ECall(EIdent("StringBuilder::new", -1), array_empty(), -1), ELetMut("__stdin_chunk_len", EInt(0), ELetMut("__stdin_chunk_eof", EBool(false), ESeq(EWhile(chunk_loop_cond, chunk_step), chunk_result), -1), -1), -1)
-    let pull_body = EIf(EBinOp("<=", EIdent("__stdin_chunk_size", -1), EInt(0)), ECall(EIdent("None", -1), array_empty(), -1), positive_pull)
-    let chunks_body = EFn(lc_fresh_string_array(), array_empty(), no_params, Some(TyApp("Option", [
+    let read_chunk_ret = TyApp("Option", [
       TyName("String")
-    ])), Some("Async"), pull_body)
-    let chunks_ret = TyFn(array_empty(), TyApp("Option", [
-      TyName("String")
-    ]), Some("Async"))
+    ])
+    let read_chunk_body = EIf(EBinOp("<=", EIdent("__stdin_chunk_size", -1), EInt(0)), ECall(EIdent("None", -1), array_empty(), -1), positive_pull)
     Array::push(stmts, SLet(false, false, Array::get(raw_names, 0), None, EFn(lc_fresh_string_array(), array_empty(), no_params, Some(TyName("StdinStream")), None, acquire_body)))
     Array::push(stmts, SLet(false, false, Array::get(raw_names, 1), None, EFn(lc_fresh_string_array(), array_empty(), next_param, Some(TyName("Int")), None, next_body)))
     Array::push(stmts, SLet(false, false, Array::get(raw_names, 2), None, EFn(lc_fresh_string_array(), array_empty(), close_param, Some(TyName("Unit")), None, close_body)))
-    Array::push(stmts, SLet(false, false, Array::get(raw_names, 3), None, EFn(lc_fresh_string_array(), array_empty(), chunks_params, Some(chunks_ret), None, chunks_body)))
+    Array::push(stmts, SLet(false, false, Array::get(raw_names, 3), None, EFn(lc_fresh_string_array(), array_empty(), read_chunk_params, Some(read_chunk_ret), None, read_chunk_body)))
   } else {
     ()
   }

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -284,6 +284,9 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("Stdin::read_via_stream", CtFn(reg_p0(), reg_stdin_stream(), Some("Stdin")), true, false, true),
   ("StdinStream::next", CtFn(reg_p1(reg_stdin_stream()), CtInt, Some("Async")), true, false, true),
   ("StdinStream::close", CtFn(reg_p1(reg_stdin_stream()), CtUnit, Some("Async")), true, false, true),
+  // Additive byte-chunk adapter. The factory is pure; each pull owns the
+  // Async evidence because it may suspend while reading or settling EOF.
+  ("StdinStream::chunks", CtFn(reg_p2(reg_stdin_stream(), CtInt), CtFn(reg_p0(), CtOption(CtString), Some("Async")), None), false, false, true),
   ("Stdin::read_char", CtFn(reg_p0(), CtInt, Some("Stdin")), true, false, true),
   ("simd_skip_ws", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),
   ("simd_scan_alnum", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -284,9 +284,9 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("Stdin::read_via_stream", CtFn(reg_p0(), reg_stdin_stream(), Some("Stdin")), true, false, true),
   ("StdinStream::next", CtFn(reg_p1(reg_stdin_stream()), CtInt, Some("Async")), true, false, true),
   ("StdinStream::close", CtFn(reg_p1(reg_stdin_stream()), CtUnit, Some("Async")), true, false, true),
-  // Additive byte-chunk adapter. The factory is pure; each pull owns the
-  // Async evidence because it may suspend while reading or settling EOF.
-  ("StdinStream::chunks", CtFn(reg_p2(reg_stdin_stream(), CtInt), CtFn(reg_p0(), CtOption(CtString), Some("Async")), None), false, false, true),
+  // Additive compiler-owned byte-chunk operation. Each call owns the Async
+  // evidence because it may suspend while reading or settling EOF.
+  ("StdinStream::read_chunk", CtFn(reg_p2(reg_stdin_stream(), CtInt), CtOption(CtString), Some("Async")), false, false, true),
   ("Stdin::read_char", CtFn(reg_p0(), CtInt, Some("Stdin")), true, false, true),
   ("simd_skip_ws", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),
   ("simd_scan_alnum", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -430,8 +430,8 @@ export fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)] {
 /// param_count = the type's parameter count, returns = 0 iff the return type
 /// is CtUnit. #1539's StdinStream::close is the one ABI exception: its hidden
 /// raw core route returns tagged zero, which is exactly Unit's value, so it
-/// stays value-returning to preserve the same target for direct calls and
-/// first-class function aliases.
+/// stays value-returning so its direct public call shares the raw import's
+/// exact value-returning ABI; source-level operation values are rejected.
 export fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)] {
   let rows = builtin_registry_typed()
   let out = array_empty()

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -868,12 +868,37 @@ export fn stmts_have_import_deep(stmts: Array[Stmt]) -> Bool {
   found
 }
 
+fn is_stdin_provider_import_value(name: String) -> Bool {
+  name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk"
+}
+
+/// Preserve an imported provider value alias as a canonical value-position
+/// marker after the import itself is dropped. The shared pre-codegen provider
+/// validator then rejects the marker just like `let n = StdinStream::next`.
+/// Type aliases such as `StdinStream as S` deliberately add no marker: their
+/// qualified call heads are canonicalized by rewrite_alias_qualified_head.
+fn append_stdin_provider_import_alias_markers(merged: Array[Stmt], items: Array[(String, Option[String])]) -> Unit {
+  let mut i = 0
+  while i < Array::length(items) {
+    let (original, alias_opt) = Array::get(items, i)
+    match alias_opt {
+      Some(_) => if is_stdin_provider_import_value(original) {
+        Array::push(merged, SExpr(EIdent(original, -1)))
+      } else {
+        ()
+      },
+      None => ()
+    }
+    i = i + 1
+  }
+}
+
 export fn append_non_import_stmts_without_alias_rewrite(merged: Array[Stmt], stmts: Array[Stmt]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     let stmt = Array::get(stmts, i)
     match stmt {
-      SImport(_, _) => (),
+      SImport(_, items) => append_stdin_provider_import_alias_markers(merged, items),
       SReExport(_, _) => (),
       SAliasDecl(_, _) => (),
       _ => Array::push(merged, stmt)
@@ -890,7 +915,7 @@ export fn append_import_alias_rewritten_non_import_stmts_skipping(merged: Array[
   while i < Array::length(stmts) {
     let stmt = Array::get(stmts, i)
     match stmt {
-      SImport(_, _) => (),
+      SImport(_, items) => append_stdin_provider_import_alias_markers(merged, items),
       SReExport(_, _) => (),
       SAliasDecl(_, _) => (),
       SModule(_, _, _) => Array::push(merged, rewrite_alias_stmt_ix(stmt, am)),
@@ -2216,7 +2241,7 @@ export fn append_import_alias_rewritten_non_import_stmts_with_renames(merged: Ar
   while i < Array::length(stmts) {
     let stmt = Array::get(stmts, i)
     match stmt {
-      SImport(_, _) => (),
+      SImport(_, items) => append_stdin_provider_import_alias_markers(merged, items),
       SReExport(_, _) => (),
       SAliasDecl(_, _) => (),
       SModule(_, _, _) => Array::push(merged, rewrite_alias_stmt_ix(stmt, am)),

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, TypeExpr, expr_children, is_exception_throw_operation, sort_perm_by_names, str_lt
+  Expr, Pat, Stmt, Type, TypeExpr, expr_children, is_exception_throw_operation, lookup_registry_builtin, sort_perm_by_names, str_lt
 }
 
 import @vibe/core {
@@ -2792,6 +2792,27 @@ fn fn_return_is_fn_type(fn_returns: Array[(String, String)], fname: String) -> B
   }
 }
 
+/// A bodyless registry builtin has no SLet entry for collect_fn_returns to
+/// inspect. Admit it as a pull factory only when its checker type positively
+/// returns CtFn. A source definition with the same name wins: if that
+/// definition has a non-function/unknown return, fail closed instead of
+/// consulting the shadowed builtin. This is classification only; it does not
+/// manufacture or relax Async effect evidence (#1536).
+fn known_fn_returns_pull_closure(fn_returns: Array[(String, String)], fname: String) -> Bool {
+  if fn_exists(fn_returns, fname) {
+    fn_return_is_fn_type(fn_returns, fname)
+  } else match lookup_registry_builtin(fname) {
+    Some(ty) => match ty {
+      CtFn(_, ret, _) => match ret {
+        CtFn(_, _, _) => true,
+        _ => false
+      },
+      _ => false
+    },
+    None => false
+  }
+}
+
 /// Desugar `for x in it { body }` over a struct iterator type `C` into a loop
 /// driven by the functional `C::next(self) -> Option[(T, Self)]`:
 ///
@@ -2978,7 +2999,7 @@ fn for_await_is_pull_source(inner: Expr, fn_returns: Array[(String, String)]) ->
   match inner {
     EFn(_, _, _, _, _, _) => true,
     ECall(callee, _, _) => match callee {
-      EIdent(fname, _) => fn_return_is_fn_type(fn_returns, fname),
+      EIdent(fname, _) => known_fn_returns_pull_closure(fn_returns, fname),
       _ => false
     },
     _ => false

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, Type, TypeExpr, expr_children, is_exception_throw_operation, lookup_registry_builtin, sort_perm_by_names, str_lt
+  Expr, Pat, Stmt, TypeExpr, expr_children, is_exception_throw_operation, sort_perm_by_names, str_lt
 }
 
 import @vibe/core {
@@ -2792,27 +2792,6 @@ fn fn_return_is_fn_type(fn_returns: Array[(String, String)], fname: String) -> B
   }
 }
 
-/// A bodyless registry builtin has no SLet entry for collect_fn_returns to
-/// inspect. Admit it as a pull factory only when its checker type positively
-/// returns CtFn. A source definition with the same name wins: if that
-/// definition has a non-function/unknown return, fail closed instead of
-/// consulting the shadowed builtin. This is classification only; it does not
-/// manufacture or relax Async effect evidence (#1536).
-fn known_fn_returns_pull_closure(fn_returns: Array[(String, String)], fname: String) -> Bool {
-  if fn_exists(fn_returns, fname) {
-    fn_return_is_fn_type(fn_returns, fname)
-  } else match lookup_registry_builtin(fname) {
-    Some(ty) => match ty {
-      CtFn(_, ret, _) => match ret {
-        CtFn(_, _, _) => true,
-        _ => false
-      },
-      _ => false
-    },
-    None => false
-  }
-}
-
 /// Desugar `for x in it { body }` over a struct iterator type `C` into a loop
 /// driven by the functional `C::next(self) -> Option[(T, Self)]`:
 ///
@@ -2999,7 +2978,7 @@ fn for_await_is_pull_source(inner: Expr, fn_returns: Array[(String, String)]) ->
   match inner {
     EFn(_, _, _, _, _, _) => true,
     ECall(callee, _, _) => match callee {
-      EIdent(fname, _) => known_fn_returns_pull_closure(fn_returns, fname),
+      EIdent(fname, _) => fn_return_is_fn_type(fn_returns, fname),
       _ => false
     },
     _ => false

--- a/lib/@vibe/compiler/tests/builtins_test.vibe
+++ b/lib/@vibe/compiler/tests/builtins_test.vibe
@@ -8,6 +8,14 @@ import @vibe/compiler/core {
   Type, builtin_registry_typed, type_to_string
 }
 
+import @vibe/compiler/codegen {
+  desugar_trait_dicts
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program, print_program
+}
+
 //# Misc
 
 test "lookup_builtin normalizes a legacy alias before registry lookup" {
@@ -40,16 +48,35 @@ test "#1539 stdin provider raw names remain checker-invisible" {
   }
 }
 
+test "#1539 bodyless chunks builtin is positively classified as a direct pull source" {
+  let stmts = parse_program(lex("fn run() -> Int with Stdin + Async { let stream = Stdin::read_via_stream(); let mut total = 0; for chunk in StdinStream::chunks(stream, 4) { total = total + String::length(chunk) }; total }"))
+  desugar_trait_dicts(stmts)
+  let printed = print_program(stmts)
+  assert(String::contains(printed, "__pull_next"))
+  assert(!String::contains(printed, "for chunk in StdinStream::chunks"))
+}
+
 test "#1539 public StdinStream surface is visible with exact effects" {
   let expected = [
     "() -> StdinStream with Stdin",
     "(StdinStream) -> Int with Async",
-    "(StdinStream) -> () with Async"
+    "(StdinStream) -> () with Async",
+    "(StdinStream, Int) -> () -> Option[String] with Async"
   ]
   let names = [
     "Stdin::read_via_stream",
     "StdinStream::next",
-    "StdinStream::close"
+    "StdinStream::close",
+    "StdinStream::chunks"
+  ]
+  // chunks is served by the compiler-owned injected factory rather than a
+  // low-level func-table row; the other three map directly to provider ABI
+  // indices after public references have been retargeted.
+  let expected_linear_table = [
+    true,
+    true,
+    true,
+    false
   ]
   let rows = builtin_registry_typed()
   let mut ni = 0
@@ -59,7 +86,7 @@ test "#1539 public StdinStream surface is visible with exact effects" {
     while ri < Array::length(rows) {
       let (name, ty, linear, gc, visible) = Array::get(rows, ri)
       if name == Array::get(names, ni) {
-        assert(linear)
+        assert(linear == Array::get(expected_linear_table, ni))
         assert(!gc)
         assert(visible)
         assert(type_to_string(ty) == Array::get(expected, ni))

--- a/lib/@vibe/compiler/tests/builtins_test.vibe
+++ b/lib/@vibe/compiler/tests/builtins_test.vibe
@@ -8,14 +8,6 @@ import @vibe/compiler/core {
   Type, builtin_registry_typed, type_to_string
 }
 
-import @vibe/compiler/codegen {
-  desugar_trait_dicts
-}
-
-import @vibe/compiler/syntax {
-  lex, parse_program, print_program
-}
-
 //# Misc
 
 test "lookup_builtin normalizes a legacy alias before registry lookup" {
@@ -48,29 +40,21 @@ test "#1539 stdin provider raw names remain checker-invisible" {
   }
 }
 
-test "#1539 bodyless chunks builtin is positively classified as a direct pull source" {
-  let stmts = parse_program(lex("fn run() -> Int with Stdin + Async { let stream = Stdin::read_via_stream(); let mut total = 0; for chunk in StdinStream::chunks(stream, 4) { total = total + String::length(chunk) }; total }"))
-  desugar_trait_dicts(stmts)
-  let printed = print_program(stmts)
-  assert(String::contains(printed, "__pull_next"))
-  assert(!String::contains(printed, "for chunk in StdinStream::chunks"))
-}
-
 test "#1539 public StdinStream surface is visible with exact effects" {
   let expected = [
     "() -> StdinStream with Stdin",
     "(StdinStream) -> Int with Async",
     "(StdinStream) -> () with Async",
-    "(StdinStream, Int) -> () -> Option[String] with Async"
+    "(StdinStream, Int) -> Option[String] with Async"
   ]
   let names = [
     "Stdin::read_via_stream",
     "StdinStream::next",
     "StdinStream::close",
-    "StdinStream::chunks"
+    "StdinStream::read_chunk"
   ]
-  // chunks is served by the compiler-owned injected factory rather than a
-  // low-level func-table row; the other three map directly to provider ABI
+  // read_chunk is served by a compiler-owned injected operation rather than
+  // a low-level func-table row; the other three map directly to provider ABI
   // indices after public references have been retargeted.
   let expected_linear_table = [
     true,

--- a/lib/@vibe/compiler/tests/checker_nominal_head_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_nominal_head_test.vibe
@@ -96,6 +96,21 @@ test "1539: acquisition and operations carry only their exact authority" {
   assert(check_source_ok("fn consume(s: StdinStream) -> Unit with Async { StdinStream::close(s) }\nfn run() -> Int with Stdin + Async { consume(Stdin::read_via_stream()); 0 }"))
 }
 
+test "1539: stdin provider builtins are direct-call-only" {
+  assert(check_source_err("let acquire = Stdin::read_via_stream\nfn run() -> Int { 0 }"))
+  assert(check_source_err("fn run() -> Int { let next = StdinStream::next; 0 }"))
+  assert(check_source_err("fn run() -> Int { let close = StdinStream::close; 0 }"))
+  assert(check_source_err("fn run() -> Int { let read = StdinStream::read_chunk; 0 }"))
+  assert(check_source_err("fn run() -> Int { let op = if true { StdinStream::next } else { StdinStream::next }; 0 }"))
+  assert(check_source_err("fn leak() -> (StdinStream) -> Int with Async { StdinStream::next }\nfn run() -> Int { 0 }"))
+  assert(check_source_err("struct Holder { op: (StdinStream) -> Int with Async }\nfn run() -> Int { let _ = Holder::{ op: StdinStream::next }; 0 }"))
+  assert(check_source_err("fn carry(op: (StdinStream) -> Int with Async) -> Int { 0 }\nfn run() -> Int { carry(StdinStream::next) }"))
+}
+
+test "1539: explicit effectful wrappers remain first-class" {
+  assert(check_source_ok("fn acquire() -> StdinStream with Stdin { Stdin::read_via_stream() }\nfn next(s: StdinStream) -> Int with Async { StdinStream::next(s) }\nfn close(s: StdinStream) -> Unit with Async { StdinStream::close(s) }\nfn read(s: StdinStream, n: Int) -> Option[String] with Async { StdinStream::read_chunk(s, n) }\nfn run() -> Int with Stdin + Async { let a = acquire; let b = next; let c = close; let d = read; let s = a(); let _ = b(s); let _ = d(s, 1); c(s); 0 }"))
+}
+
 test "1001: genuinely generic parameter stays tolerated (no over-rejection)" {
   assert(check_source_ok("struct Box[T] { v: T }\nfn second[T](b: Box[T], d: Int) -> Int { d }\nfn main() -> Int {\n  let b: Box[String] = Box::{ v: \"hello\" }\n  second(b, 42)\n}"))
 }

--- a/lib/@vibe/console/index.vpkg
+++ b/lib/@vibe/console/index.vpkg
@@ -54,7 +54,7 @@ type StdinStream
 fn Stdin::read_via_stream() -> StdinStream with Stdin
 fn StdinStream::next(stream: StdinStream) -> Int with Async
 fn StdinStream::close(stream: StdinStream) -> Unit with Async
-fn StdinStream::chunks(stream: StdinStream, chunk_size: Int) -> (() -> Option[String] with Async)
+fn StdinStream::read_chunk(stream: StdinStream, chunk_size: Int) -> Option[String] with Async
 
 // --- io
 fn read(max_bytes: Int) -> String with Stdin

--- a/lib/@vibe/console/index.vpkg
+++ b/lib/@vibe/console/index.vpkg
@@ -54,6 +54,7 @@ type StdinStream
 fn Stdin::read_via_stream() -> StdinStream with Stdin
 fn StdinStream::next(stream: StdinStream) -> Int with Async
 fn StdinStream::close(stream: StdinStream) -> Unit with Async
+fn StdinStream::chunks(stream: StdinStream, chunk_size: Int) -> (() -> Option[String] with Async)
 
 // --- io
 fn read(max_bytes: Int) -> String with Stdin

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -71,6 +71,7 @@ Stderr::write_stream	linear-only	host-import	host/linear-memory import; the gc l
 Stdin::read_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdin::read_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdin::read_via_stream	linear-only	async-component-only	#1539 public acquisition route; the GC callsite arm is a loud rejection, not an implementation
+StdinStream::chunks	linear-only	async-component-only	#1539 compiler-owned chunk adapter; the GC callsite arm is a loud rejection, not an implementation
 StdinStream::close	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
 StdinStream::next	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
 Stdout::write_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -71,7 +71,7 @@ Stderr::write_stream	linear-only	host-import	host/linear-memory import; the gc l
 Stdin::read_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdin::read_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdin::read_via_stream	linear-only	async-component-only	#1539 public acquisition route; the GC callsite arm is a loud rejection, not an implementation
-StdinStream::chunks	linear-only	async-component-only	#1539 compiler-owned chunk adapter; the GC callsite arm is a loud rejection, not an implementation
+StdinStream::read_chunk	linear-only	async-component-only	#1539 compiler-owned direct chunk operation; the GC callsite arm is a loud rejection, not an implementation
 StdinStream::close	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
 StdinStream::next	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
 Stdout::write_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group

--- a/scripts/check_builtin_parity.sh
+++ b/scripts/check_builtin_parity.sh
@@ -44,10 +44,10 @@ gc_cs = callsite_names(GC_CALLSITE)
 gc_text = open(GC_CALLSITE).read()
 gc_throw_only_expected = {
     "Stdin::read_via_stream", "StdinStream::next", "StdinStream::close",
-    "StdinStream::chunks"
+    "StdinStream::read_chunk"
 }
 throw_only_match = re.search(
-    r'if\s+((?:fname == "(?:Stdin::read_via_stream|StdinStream::next|StdinStream::close|StdinStream::chunks)"(?:\s*\|\|\s*)?)+)\s*\{\s*throw\("StdinStream is unsupported on gc backend;',
+    r'if\s+((?:fname == "(?:Stdin::read_via_stream|StdinStream::next|StdinStream::close|StdinStream::read_chunk)"(?:\s*\|\|\s*)?)+)\s*\{\s*throw\("StdinStream is unsupported on gc backend;',
     gc_text)
 throw_only_found = (set(re.findall(r'fname == "([^"]+)"', throw_only_match.group(1)))
                     if throw_only_match else set())
@@ -75,13 +75,13 @@ if len(rows) < 90:
 reg_lin = {n for n, l, g, v in rows if l == "true"}
 reg_gc = {n for n, l, g, v in rows if g == "true"}
 # Compiler-owned wrappers can implement a checker-visible builtin without a
-# func-table row. Keep this exception exact and mutation-checked: chunks must
-# still be retargeted to its injected linear/RC source factory.
-wrapper_only_expected = {"StdinStream::chunks"}
+# func-table row. Keep this exception exact and mutation-checked: read_chunk
+# must still be retargeted to its injected linear/RC implementation.
+wrapper_only_expected = {"StdinStream::read_chunk"}
 linked_text = open(LINKED).read()
 wrapper_only_found = {
     n for n in wrapper_only_expected
-    if f'"{n}"' in linked_text and "__stdin_provider_chunks_surface" in linked_text
+    if f'"{n}"' in linked_text and "__stdin_provider_read_chunk_surface" in linked_text
 }
 if wrapper_only_found != wrapper_only_expected:
     print("[builtin-parity] FAIL: compiler-owned StdinStream wrapper shape "

--- a/scripts/check_builtin_parity.sh
+++ b/scripts/check_builtin_parity.sh
@@ -28,6 +28,7 @@ import re, sys
 LIN_CALLSITE = "lib/@vibe/compiler/codegen/expr/compile_call.vibe"
 GC_CALLSITE = "lib/@vibe/compiler/codegen/gc/backend_call.vibe"
 REGISTRY = "lib/@vibe/compiler/core/builtin_registry.vibe"
+LINKED = "lib/@vibe/compiler/codegen/wasi/linked_compile.vibe"
 CLASSIFICATION = "scripts/builtin_parity_classification.tsv"
 
 def callsite_names(path):
@@ -42,10 +43,11 @@ gc_cs = callsite_names(GC_CALLSITE)
 # fail instead of silently counting (or excluding) the wrong names.
 gc_text = open(GC_CALLSITE).read()
 gc_throw_only_expected = {
-    "Stdin::read_via_stream", "StdinStream::next", "StdinStream::close"
+    "Stdin::read_via_stream", "StdinStream::next", "StdinStream::close",
+    "StdinStream::chunks"
 }
 throw_only_match = re.search(
-    r'if\s+((?:fname == "(?:Stdin::read_via_stream|StdinStream::next|StdinStream::close)"(?:\s*\|\|\s*)?)+)\s*\{\s*throw\("StdinStream is unsupported on gc backend;',
+    r'if\s+((?:fname == "(?:Stdin::read_via_stream|StdinStream::next|StdinStream::close|StdinStream::chunks)"(?:\s*\|\|\s*)?)+)\s*\{\s*throw\("StdinStream is unsupported on gc backend;',
     gc_text)
 throw_only_found = (set(re.findall(r'fname == "([^"]+)"', throw_only_match.group(1)))
                     if throw_only_match else set())
@@ -72,13 +74,27 @@ if len(rows) < 90:
     sys.exit(1)
 reg_lin = {n for n, l, g, v in rows if l == "true"}
 reg_gc = {n for n, l, g, v in rows if g == "true"}
-neither = sorted(n for n, l, g, v in rows if l == "false" and g == "false")
+# Compiler-owned wrappers can implement a checker-visible builtin without a
+# func-table row. Keep this exception exact and mutation-checked: chunks must
+# still be retargeted to its injected linear/RC source factory.
+wrapper_only_expected = {"StdinStream::chunks"}
+linked_text = open(LINKED).read()
+wrapper_only_found = {
+    n for n in wrapper_only_expected
+    if f'"{n}"' in linked_text and "__stdin_provider_chunks_surface" in linked_text
+}
+if wrapper_only_found != wrapper_only_expected:
+    print("[builtin-parity] FAIL: compiler-owned StdinStream wrapper shape "
+          f"changed (found {sorted(wrapper_only_found)})", file=sys.stderr)
+    sys.exit(1)
+neither = sorted(n for n, l, g, v in rows
+                 if l == "false" and g == "false" and n not in wrapper_only_expected)
 if neither:
     print(f"[builtin-parity] FAIL: registry rows claiming NEITHER lane "
           f"(dead rows?): {', '.join(neither)}", file=sys.stderr)
     sys.exit(1)
 
-served_lin = lin_cs | reg_lin
+served_lin = lin_cs | reg_lin | wrapper_only_expected
 served_gc = gc_cs | reg_gc
 actual = ({(n, "linear-only") for n in served_lin - served_gc}
           | {(n, "gc-only") for n in served_gc - served_lin})

--- a/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
@@ -24,7 +24,7 @@ grep -Fq 'type StdinStream' lib/@vibe/console/index.vpkg
 grep -Fq 'fn Stdin::read_via_stream() -> StdinStream with Stdin' lib/@vibe/console/index.vpkg
 grep -Fq 'fn StdinStream::next(stream: StdinStream) -> Int with Async' lib/@vibe/console/index.vpkg
 grep -Fq 'fn StdinStream::close(stream: StdinStream) -> Unit with Async' lib/@vibe/console/index.vpkg
-grep -Fq 'fn StdinStream::chunks(stream: StdinStream, chunk_size: Int) -> (() -> Option[String] with Async)' lib/@vibe/console/index.vpkg
+grep -Fq 'fn StdinStream::read_chunk(stream: StdinStream, chunk_size: Int) -> Option[String] with Async' lib/@vibe/console/index.vpkg
 if grep -Fq 'vibe_stdin_provider_' lib/@vibe/console/index.vpkg; then
   echo "stdin provider source gate FAILED: raw names leaked into console contract" >&2
   exit 1
@@ -92,36 +92,50 @@ fn run() -> Int with Stdin + Async {
   if first == 10 { 46 } else { 0 }
 }
 EOF
-cat >"$OUT/chunks-direct.vibe" <<'EOF'
+cat >"$OUT/chunk-loop.vibe" <<'EOF'
 fn run() -> Int with Stdin + Async {
   let stream = Stdin::read_via_stream()
   let mut index = 0
   let mut ok = true
-  for chunk in StdinStream::chunks(stream, 4) {
-    if index == 0 {
-      ok = ok && String::length(chunk) == 4 && String::char_code_at(chunk, 0) == 0 && String::char_code_at(chunk, 1) == 128 && String::char_code_at(chunk, 2) == 255 && String::char_code_at(chunk, 3) == 65
-    } else if index == 1 {
-      ok = ok && String::length(chunk) == 1 && String::char_code_at(chunk, 0) == 66
-    } else {
-      ok = false
+  let mut done = false
+  while done == false {
+    match StdinStream::read_chunk(stream, 4) {
+      Some(chunk) => {
+        if index == 0 {
+          ok = ok && String::length(chunk) == 4 && String::char_code_at(chunk, 0) == 0 && String::char_code_at(chunk, 1) == 128 && String::char_code_at(chunk, 2) == 255 && String::char_code_at(chunk, 3) == 65
+        } else if index == 1 {
+          ok = ok && String::length(chunk) == 1 && String::char_code_at(chunk, 0) == 66
+        } else {
+          ok = false
+        }
+        index = index + 1
+      },
+      None => { done = true }
     }
-    index = index + 1
   }
-  if ok && index == 2 { 50 } else { 0 }
+  let post_eof = StdinStream::read_chunk(stream, 4)
+  StdinStream::close(stream)
+  StdinStream::close(stream)
+  match post_eof {
+    None => match StdinStream::read_chunk(stream, 4) {
+      None => if ok && index == 2 { 50 } else { 0 },
+      Some(_) => 0
+    },
+    Some(_) => 0
+  }
 }
 EOF
-cat >"$OUT/chunks-one-alias.vibe" <<'EOF'
+cat >"$OUT/chunk-one-alias.vibe" <<'EOF'
 fn run() -> Int with Stdin + Async {
   let stream = Stdin::read_via_stream()
-  let factory = StdinStream::chunks
-  let pull = factory(stream, 1)
-  let a = pull()
-  let b = pull()
-  let c = pull()
-  let d = pull()
-  let e = pull()
-  let eof1 = pull()
-  let eof2 = pull()
+  let read_chunk = StdinStream::read_chunk
+  let a = read_chunk(stream, 1)
+  let b = read_chunk(stream, 1)
+  let c = read_chunk(stream, 1)
+  let d = read_chunk(stream, 1)
+  let e = read_chunk(stream, 1)
+  let eof1 = read_chunk(stream, 1)
+  let eof2 = read_chunk(stream, 1)
   match a {
     Some(sa) => match b {
       Some(sb) => match c {
@@ -146,47 +160,44 @@ fn run() -> Int with Stdin + Async {
   }
 }
 EOF
-cat >"$OUT/chunks-zero.vibe" <<'EOF'
+cat >"$OUT/chunk-zero.vibe" <<'EOF'
 fn run() -> Int with Stdin + Async {
   let stream = Stdin::read_via_stream()
-  let pull = StdinStream::chunks(stream, 0)
-  match pull() {
+  match StdinStream::read_chunk(stream, 0) {
     Some(_) => 0,
-    None => match pull() {
+    None => match StdinStream::read_chunk(stream, 0) {
       Some(_) => 0,
       None => {
         let first = StdinStream::next(stream)
         StdinStream::close(stream)
         StdinStream::close(stream)
-        match pull() { None => if first == 0 { 52 } else { 0 }, Some(_) => 0 }
+        match StdinStream::read_chunk(stream, 0) { None => if first == 0 { 52 } else { 0 }, Some(_) => 0 }
       }
     }
   }
 }
 EOF
-cat >"$OUT/chunks-negative.vibe" <<'EOF'
+cat >"$OUT/chunk-negative.vibe" <<'EOF'
 fn run() -> Int with Stdin + Async {
   let stream = Stdin::read_via_stream()
-  let pull = StdinStream::chunks(stream, -7)
-  match pull() {
+  match StdinStream::read_chunk(stream, -7) {
     Some(_) => 0,
     None => {
       let first = StdinStream::next(stream)
       StdinStream::close(stream)
-      match pull() { None => if first == 0 { 53 } else { 0 }, Some(_) => 0 }
+      match StdinStream::read_chunk(stream, -7) { None => if first == 0 { 53 } else { 0 }, Some(_) => 0 }
     }
   }
 }
 EOF
-cat >"$OUT/chunks-early-close.vibe" <<'EOF'
+cat >"$OUT/chunk-early-close.vibe" <<'EOF'
 fn run() -> Int with Stdin + Async {
   let stream = Stdin::read_via_stream()
-  let pull = StdinStream::chunks(stream, 4)
-  let first = pull()
+  let first = StdinStream::read_chunk(stream, 4)
   StdinStream::close(stream)
   StdinStream::close(stream)
   match first {
-    Some(chunk) => match pull() {
+    Some(chunk) => match StdinStream::read_chunk(stream, 4) {
       None => if String::length(chunk) == 4 && String::char_code_at(chunk, 0) == 0 && String::char_code_at(chunk, 3) == 65 { 54 } else { 0 },
       Some(_) => 0
     },
@@ -230,15 +241,15 @@ compile_component early-alias
 compile_component second
 compile_component multiple-active
 compile_component import-alias 0 1 1
-compile_component chunks-direct
-compile_component chunks-one-alias
-compile_component chunks-zero
-compile_component chunks-negative
-compile_component chunks-early-close
+compile_component chunk-loop
+compile_component chunk-one-alias
+compile_component chunk-zero
+compile_component chunk-negative
+compile_component chunk-early-close
 cp "$OUT/drain.vibe" "$OUT/drain-rc.vibe"
 compile_component drain-rc 1
-cp "$OUT/chunks-direct.vibe" "$OUT/chunks-direct-rc.vibe"
-compile_component chunks-direct-rc 1
+cp "$OUT/chunk-loop.vibe" "$OUT/chunk-loop-rc.vibe"
+compile_component chunk-loop-rc 1
 
 WIT="$OUT/drain.wit"
 WAT="$OUT/drain.wat"
@@ -250,8 +261,8 @@ grep -Fq 'read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-co
 grep -Fq 'stdin_provider_acquire' "$WAT"
 grep -Fq 'stdin_provider_read' "$WAT"
 grep -Fq 'stdin_provider_close' "$WAT"
-wasm-tools print "$OUT/chunks-direct.component.wasm" >"$OUT/chunks-direct.wat"
-if grep -Fq 'host_stream_get$stdin' "$WAT" "$OUT/chunks-direct.wat" || grep -Fq 'host_stream_read' "$WAT" "$OUT/chunks-direct.wat" || grep -Fq 'host_stream_close' "$WAT" "$OUT/chunks-direct.wat"; then
+wasm-tools print "$OUT/chunk-loop.component.wasm" >"$OUT/chunk-loop.wat"
+if grep -Fq 'host_stream_get$stdin' "$WAT" "$OUT/chunk-loop.wat" || grep -Fq 'host_stream_read' "$WAT" "$OUT/chunk-loop.wat" || grep -Fq 'host_stream_close' "$WAT" "$OUT/chunk-loop.wat"; then
   echo "stdin provider source gate FAILED: generic HostStream route leaked" >&2
   exit 1
 fi
@@ -282,6 +293,31 @@ cat >"$OUT/next-effect.vibe" <<'EOF'
 fn run() -> Int with Stdin { let s = Stdin::read_via_stream(); StdinStream::next(s) }
 EOF
 actionable_fail next-effect run 'effectful call outside effectful context: StdinStream::next'
+cat >"$OUT/read-chunk-effect-direct.vibe" <<'EOF'
+fn pure_read_chunk(stream: StdinStream) -> Option[String] {
+  StdinStream::read_chunk(stream, 4)
+}
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let _ = pure_read_chunk(stream)
+  StdinStream::close(stream)
+  0
+}
+EOF
+actionable_fail read-chunk-effect-direct run 'effectful call outside effectful context: StdinStream::read_chunk'
+cat >"$OUT/read-chunk-effect-alias.vibe" <<'EOF'
+fn pure_read_chunk(stream: StdinStream) -> Option[String] {
+  let read_chunk = StdinStream::read_chunk
+  read_chunk(stream, 4)
+}
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let _ = pure_read_chunk(stream)
+  StdinStream::close(stream)
+  0
+}
+EOF
+actionable_fail read-chunk-effect-alias run 'effectful call outside effectful context'
 cat >"$OUT/nominal.vibe" <<'EOF'
 fn run() -> Int with Async { StdinStream::next(1) }
 EOF
@@ -301,16 +337,16 @@ cat >"$OUT/mixed.vibe" <<'EOF'
 fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = host_stream_named("body"); StdinStream::close(s); 0 }
 EOF
 actionable_fail mixed run 'mixing stdin-provider imports with named host future/stream imports is not supported'
-cat >"$OUT/chunks-mixed.vibe" <<'EOF'
-fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = host_stream_named("body"); let _ = StdinStream::chunks(s, 4); StdinStream::close(s); 0 }
+cat >"$OUT/chunk-mixed.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = host_stream_named("body"); let _ = StdinStream::read_chunk(s, 4); StdinStream::close(s); 0 }
 EOF
-actionable_fail chunks-mixed run 'effect Async has closure values whose row carries it'
+actionable_fail chunk-mixed run 'mixing stdin-provider imports with named host future/stream imports is not supported'
 cat >"$OUT/noncomponent.vibe" <<'EOF'
-fn main() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let pull = StdinStream::chunks(s, 4); let _ = pull(); StdinStream::close(s); 0 }
+fn main() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = StdinStream::read_chunk(s, 4); StdinStream::close(s); 0 }
 EOF
 actionable_fail noncomponent main 'requires an Async component entry named run'
 cat >"$OUT/gc.vibe" <<'EOF'
-fn main() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let pull = StdinStream::chunks(s, 4); let _ = pull(); 0 }
+fn main() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = StdinStream::read_chunk(s, 4); 0 }
 EOF
 actionable_fail gc main 'StdinStream is unsupported on gc backend' gc
 cat >"$OUT/coverage.vibe" <<'EOF'
@@ -405,10 +441,10 @@ run_lane second 44
 run_lane multiple-active 45
 run_lane import-alias 46
 run_lane drain-rc 42
-run_lane chunks-direct 50 "$CHUNK_INPUT"
-run_lane chunks-one-alias 51 "$CHUNK_INPUT"
-run_lane chunks-zero 52 "$CHUNK_INPUT"
-run_lane chunks-negative 53 "$CHUNK_INPUT"
-run_lane chunks-early-close 54 "$CHUNK_INPUT"
-run_lane chunks-direct-rc 50 "$CHUNK_INPUT"
+run_lane chunk-loop 50 "$CHUNK_INPUT"
+run_lane chunk-one-alias 51 "$CHUNK_INPUT"
+run_lane chunk-zero 52 "$CHUNK_INPUT"
+run_lane chunk-negative 53 "$CHUNK_INPUT"
+run_lane chunk-early-close 54 "$CHUNK_INPUT"
+run_lane chunk-loop-rc 50 "$CHUNK_INPUT"
 echo "wasi cli stdin provider source component gate OK (wasmtime 47.0.2)"

--- a/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
@@ -56,6 +56,21 @@ fn run() -> Int with Stdin + Async {
   if a == 10 && next(alias) == -1 { 43 } else { 0 }
 }
 EOF
+cat >"$OUT/top-level-aliases.vibe" <<'EOF'
+let acquire_alias = Stdin::read_via_stream
+let next_alias = StdinStream::next
+let close_alias = StdinStream::close
+let read_chunk_alias = StdinStream::read_chunk
+
+fn use_provider() -> Int with Stdin + Async {
+  let stream = acquire_alias()
+  let first = next_alias(stream)
+  let chunk = read_chunk_alias(stream, 2)
+  close_alias(stream)
+  match chunk { Some(s) => if first == 10 && String::length(s) == 2 { 55 } else { 0 }, None => 0 }
+}
+fn run() -> Int with Stdin + Async { use_provider() }
+EOF
 cat >"$OUT/second.vibe" <<'EOF'
 fn run() -> Int with Stdin + Async {
   let first = Stdin::read_via_stream()
@@ -238,6 +253,7 @@ compile_component() {
 }
 compile_component drain
 compile_component early-alias
+compile_component top-level-aliases
 compile_component second
 compile_component multiple-active
 compile_component import-alias 0 1 1
@@ -318,6 +334,25 @@ fn run() -> Int with Stdin + Async {
 }
 EOF
 actionable_fail read-chunk-effect-alias run 'effectful call outside effectful context'
+cat >"$OUT/top-acquire-effect-alias.vibe" <<'EOF'
+let acquire_alias = Stdin::read_via_stream
+fn pure_acquire() -> StdinStream { acquire_alias() }
+fn run() -> Int with Stdin + Async { let s = pure_acquire(); StdinStream::close(s); 0 }
+EOF
+actionable_fail top-acquire-effect-alias run 'missing { Stdin }'
+for surface in next close read_chunk; do
+  case "$surface" in
+    next) call='next_alias(stream)'; ret='Int' ;;
+    close) call='close_alias(stream)'; ret='Unit' ;;
+    read_chunk) call='read_chunk_alias(stream, 4)'; ret='Option[String]' ;;
+  esac
+  cat >"$OUT/top-$surface-effect-alias.vibe" <<EOF
+let ${surface}_alias = StdinStream::$surface
+fn pure_alias(stream: StdinStream) -> $ret { $call }
+fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = pure_alias(s); StdinStream::close(s); 0 }
+EOF
+  actionable_fail "top-$surface-effect-alias" run 'effectful call outside effectful context:'
+done
 cat >"$OUT/nominal.vibe" <<'EOF'
 fn run() -> Int with Async { StdinStream::next(1) }
 EOF
@@ -437,6 +472,7 @@ run_lane() {
 }
 run_lane drain 42
 run_lane early-alias 43
+run_lane top-level-aliases 55
 run_lane second 44
 run_lane multiple-active 45
 run_lane import-alias 46

--- a/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
@@ -102,8 +102,8 @@ cat >"$OUT/import-alias.vibe" <<'EOF'
 import @vibe/console { StdinStream as S }
 
 fn acquire() -> StdinStream with Stdin { Stdin::read_via_stream() }
-fn next_alias(stream: S) -> Int with Async { StdinStream::next(stream) }
-fn close_alias(stream: S) -> Unit with Async { StdinStream::close(stream) }
+fn next_alias(stream: S) -> Int with Async { S::next(stream) }
+fn close_alias(stream: S) -> Unit with Async { S::close(stream) }
 
 fn run() -> Int with Stdin + Async {
   let stream = acquire()
@@ -238,6 +238,10 @@ deps = {}
 generated_hash =
 
 type StdinStream
+fn Stdin::read_via_stream() -> StdinStream with Stdin
+fn StdinStream::next(stream: StdinStream) -> Int with Async
+fn StdinStream::close(stream: StdinStream) -> Unit with Async
+fn StdinStream::read_chunk(stream: StdinStream, chunk_size: Int) -> Option[String] with Async
 EOF
 
 compile_component() {
@@ -302,6 +306,14 @@ actionable_fail() {
     exit 1
   fi
   grep -Fq "$expected" "$OUT/$name.wasm.diag" || { echo "stdin provider source gate FAILED: $name diagnostic" >&2; cat "$OUT/$name.wasm.diag" >&2 || true; exit 1; }
+}
+provider_alias_fail() {
+  local name="$1" expected="$2"
+  actionable_fail "$name" run "$expected" linear 1
+  if grep -Fq 'stdin_provider_' "$OUT/$name.wasm.diag"; then
+    echo "stdin provider source gate FAILED: $name exposed the raw provider ABI" >&2
+    exit 1
+  fi
 }
 cat >"$OUT/raw.vibe" <<'EOF'
 fn run() -> Int with Async { vibe_stdin_provider_acquire_raw() }
@@ -413,6 +425,73 @@ EOF
 for opaque in alias-chain conditional compound return struct-field array-field map-field unknown-hof; do
   actionable_fail "value-$opaque" run 'stdin provider operations are direct-call-only; wrap `StdinStream::next` in an explicitly effectful function'
 done
+
+# FS/package merge canonicalizes imported value aliases and qualified type
+# heads before the shared compile-boundary validation. Value imports remain
+# forbidden even when called directly through their local alias; a type alias
+# used as the head of S::next above remains a valid direct call with Async.
+cat >"$OUT/fs-type-alias-effect.vibe" <<'EOF'
+import @vibe/console { StdinStream as S }
+fn run() -> Int with Stdin {
+  let stream = Stdin::read_via_stream()
+  S::next(stream)
+}
+EOF
+actionable_fail fs-type-alias-effect run 'effectful call outside effectful context: StdinStream::next' linear 1
+cat >"$OUT/fs-next-value-alias.vibe" <<'EOF'
+import @vibe/console { StdinStream::next as n }
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  n(stream)
+}
+EOF
+cat >"$OUT/fs-acquire-value-alias.vibe" <<'EOF'
+import @vibe/console { Stdin::read_via_stream as acquire }
+fn run() -> Int with Stdin + Async {
+  let stream = acquire()
+  StdinStream::close(stream)
+  0
+}
+EOF
+cat >"$OUT/fs-close-value-alias.vibe" <<'EOF'
+import @vibe/console { StdinStream::close as close }
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  close(stream)
+  0
+}
+EOF
+cat >"$OUT/fs-read-chunk-value-alias.vibe" <<'EOF'
+import @vibe/console { StdinStream::read_chunk as read_chunk }
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let _ = read_chunk(stream, 4)
+  StdinStream::close(stream)
+  0
+}
+EOF
+cat >"$OUT/fs-value-alias-chain.vibe" <<'EOF'
+import @vibe/console { StdinStream::next as n }
+fn run() -> Int {
+  let second = n
+  let _ = second
+  0
+}
+EOF
+cat >"$OUT/fs-value-alias-container.vibe" <<'EOF'
+import @vibe/console { StdinStream::next as n }
+fn run() -> Int {
+  let _ = [n]
+  0
+}
+EOF
+provider_alias_fail fs-next-value-alias 'stdin provider operations are direct-call-only; wrap `StdinStream::next` in an explicitly effectful function'
+provider_alias_fail fs-acquire-value-alias 'stdin provider operations are direct-call-only; wrap `Stdin::read_via_stream` in an explicitly effectful function'
+provider_alias_fail fs-close-value-alias 'stdin provider operations are direct-call-only; wrap `StdinStream::close` in an explicitly effectful function'
+provider_alias_fail fs-read-chunk-value-alias 'stdin provider operations are direct-call-only; wrap `StdinStream::read_chunk` in an explicitly effectful function'
+provider_alias_fail fs-value-alias-chain 'stdin provider operations are direct-call-only; wrap `StdinStream::next` in an explicitly effectful function'
+provider_alias_fail fs-value-alias-container 'stdin provider operations are direct-call-only; wrap `StdinStream::next` in an explicitly effectful function'
+
 cat >"$OUT/nominal.vibe" <<'EOF'
 fn run() -> Int with Async { StdinStream::next(1) }
 EOF

--- a/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
@@ -24,6 +24,7 @@ grep -Fq 'type StdinStream' lib/@vibe/console/index.vpkg
 grep -Fq 'fn Stdin::read_via_stream() -> StdinStream with Stdin' lib/@vibe/console/index.vpkg
 grep -Fq 'fn StdinStream::next(stream: StdinStream) -> Int with Async' lib/@vibe/console/index.vpkg
 grep -Fq 'fn StdinStream::close(stream: StdinStream) -> Unit with Async' lib/@vibe/console/index.vpkg
+grep -Fq 'fn StdinStream::chunks(stream: StdinStream, chunk_size: Int) -> (() -> Option[String] with Async)' lib/@vibe/console/index.vpkg
 if grep -Fq 'vibe_stdin_provider_' lib/@vibe/console/index.vpkg; then
   echo "stdin provider source gate FAILED: raw names leaked into console contract" >&2
   exit 1
@@ -91,6 +92,108 @@ fn run() -> Int with Stdin + Async {
   if first == 10 { 46 } else { 0 }
 }
 EOF
+cat >"$OUT/chunks-direct.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let mut index = 0
+  let mut ok = true
+  for chunk in StdinStream::chunks(stream, 4) {
+    if index == 0 {
+      ok = ok && String::length(chunk) == 4 && String::char_code_at(chunk, 0) == 0 && String::char_code_at(chunk, 1) == 128 && String::char_code_at(chunk, 2) == 255 && String::char_code_at(chunk, 3) == 65
+    } else if index == 1 {
+      ok = ok && String::length(chunk) == 1 && String::char_code_at(chunk, 0) == 66
+    } else {
+      ok = false
+    }
+    index = index + 1
+  }
+  if ok && index == 2 { 50 } else { 0 }
+}
+EOF
+cat >"$OUT/chunks-one-alias.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let factory = StdinStream::chunks
+  let pull = factory(stream, 1)
+  let a = pull()
+  let b = pull()
+  let c = pull()
+  let d = pull()
+  let e = pull()
+  let eof1 = pull()
+  let eof2 = pull()
+  match a {
+    Some(sa) => match b {
+      Some(sb) => match c {
+        Some(sc) => match d {
+          Some(sd) => match e {
+            Some(se) => match eof1 {
+              None => match eof2 {
+                None => if String::length(sa) == 1 && String::char_code_at(sa, 0) == 0 && String::char_code_at(sb, 0) == 128 && String::char_code_at(sc, 0) == 255 && String::char_code_at(sd, 0) == 65 && String::char_code_at(se, 0) == 66 { 51 } else { 0 },
+                Some(_) => 0
+              },
+              Some(_) => 0
+            },
+            None => 0
+          },
+          None => 0
+        },
+        None => 0
+      },
+      None => 0
+    },
+    None => 0
+  }
+}
+EOF
+cat >"$OUT/chunks-zero.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let pull = StdinStream::chunks(stream, 0)
+  match pull() {
+    Some(_) => 0,
+    None => match pull() {
+      Some(_) => 0,
+      None => {
+        let first = StdinStream::next(stream)
+        StdinStream::close(stream)
+        StdinStream::close(stream)
+        match pull() { None => if first == 0 { 52 } else { 0 }, Some(_) => 0 }
+      }
+    }
+  }
+}
+EOF
+cat >"$OUT/chunks-negative.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let pull = StdinStream::chunks(stream, -7)
+  match pull() {
+    Some(_) => 0,
+    None => {
+      let first = StdinStream::next(stream)
+      StdinStream::close(stream)
+      match pull() { None => if first == 0 { 53 } else { 0 }, Some(_) => 0 }
+    }
+  }
+}
+EOF
+cat >"$OUT/chunks-early-close.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async {
+  let stream = Stdin::read_via_stream()
+  let pull = StdinStream::chunks(stream, 4)
+  let first = pull()
+  StdinStream::close(stream)
+  StdinStream::close(stream)
+  match first {
+    Some(chunk) => match pull() {
+      None => if String::length(chunk) == 4 && String::char_code_at(chunk, 0) == 0 && String::char_code_at(chunk, 3) == 65 { 54 } else { 0 },
+      Some(_) => 0
+    },
+    None => 0
+  }
+}
+EOF
 # Isolated minimal contract fixture: preserve the exact public package spelling
 # while avoiding unrelated @vibe/console implementation imports in this
 # component-composer test. The type is still compiler-owned (no source body).
@@ -127,8 +230,15 @@ compile_component early-alias
 compile_component second
 compile_component multiple-active
 compile_component import-alias 0 1 1
+compile_component chunks-direct
+compile_component chunks-one-alias
+compile_component chunks-zero
+compile_component chunks-negative
+compile_component chunks-early-close
 cp "$OUT/drain.vibe" "$OUT/drain-rc.vibe"
 compile_component drain-rc 1
+cp "$OUT/chunks-direct.vibe" "$OUT/chunks-direct-rc.vibe"
+compile_component chunks-direct-rc 1
 
 WIT="$OUT/drain.wit"
 WAT="$OUT/drain.wat"
@@ -140,7 +250,8 @@ grep -Fq 'read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-co
 grep -Fq 'stdin_provider_acquire' "$WAT"
 grep -Fq 'stdin_provider_read' "$WAT"
 grep -Fq 'stdin_provider_close' "$WAT"
-if grep -Fq 'host_stream_get$stdin' "$WAT" || grep -Fq 'host_stream_read' "$WAT" || grep -Fq 'host_stream_close' "$WAT"; then
+wasm-tools print "$OUT/chunks-direct.component.wasm" >"$OUT/chunks-direct.wat"
+if grep -Fq 'host_stream_get$stdin' "$WAT" "$OUT/chunks-direct.wat" || grep -Fq 'host_stream_read' "$WAT" "$OUT/chunks-direct.wat" || grep -Fq 'host_stream_close' "$WAT" "$OUT/chunks-direct.wat"; then
   echo "stdin provider source gate FAILED: generic HostStream route leaked" >&2
   exit 1
 fi
@@ -190,12 +301,16 @@ cat >"$OUT/mixed.vibe" <<'EOF'
 fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = host_stream_named("body"); StdinStream::close(s); 0 }
 EOF
 actionable_fail mixed run 'mixing stdin-provider imports with named host future/stream imports is not supported'
+cat >"$OUT/chunks-mixed.vibe" <<'EOF'
+fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = host_stream_named("body"); let _ = StdinStream::chunks(s, 4); StdinStream::close(s); 0 }
+EOF
+actionable_fail chunks-mixed run 'effect Async has closure values whose row carries it'
 cat >"$OUT/noncomponent.vibe" <<'EOF'
-fn main() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); StdinStream::close(s); 0 }
+fn main() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let pull = StdinStream::chunks(s, 4); let _ = pull(); StdinStream::close(s); 0 }
 EOF
 actionable_fail noncomponent main 'requires an Async component entry named run'
 cat >"$OUT/gc.vibe" <<'EOF'
-fn main() -> Int with Stdin { let _ = Stdin::read_via_stream(); 0 }
+fn main() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let pull = StdinStream::chunks(s, 4); let _ = pull(); 0 }
 EOF
 actionable_fail gc main 'StdinStream is unsupported on gc backend' gc
 cat >"$OUT/coverage.vibe" <<'EOF'
@@ -238,6 +353,29 @@ if grep -Fq 'stdin_provider_' "$OUT/import-alias-coverage.wasm.diag" "$OUT/impor
   exit 1
 fi
 
+# The additive compiler-owned adapter must not poison the unchanged source
+# implementation of legacy stdin_stream or make its standalone core acquire
+# the component-private provider ABI.
+cat >"$OUT/legacy-standalone.vibe" <<'EOF'
+import @vibe/console { stdin_stream }
+fn main() -> Int with Stdin {
+  let pull = stdin_stream(2)
+  match pull() { Some(chunk) => String::length(chunk), None => 0 }
+}
+EOF
+rm -f "$OUT/legacy-standalone.wasm" "$OUT/legacy-standalone.wasm.diag"
+VIBE_FS_COMPILE=1 VIBE_LIB="$ROOT/lib" VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+  "$COMPILER" "$OUT/legacy-standalone.vibe" "$OUT/legacy-standalone.wasm" main >/dev/null
+[ -s "$OUT/legacy-standalone.wasm" ] || { cat "$OUT/legacy-standalone.wasm.diag" >&2 || true; exit 1; }
+[ "$(od -A n -t x1 -N 8 "$OUT/legacy-standalone.wasm" | awk '{print $5}')" = "01" ]
+wasm-tools validate --features all "$OUT/legacy-standalone.wasm"
+wasm-tools print "$OUT/legacy-standalone.wasm" >"$OUT/legacy-standalone.wat"
+if grep -Fq 'stdin_provider_' "$OUT/legacy-standalone.wat"; then
+  echo "stdin provider source gate FAILED: legacy stdin_stream gained provider imports" >&2
+  exit 1
+fi
+
 echo "[stdin-provider-source] source compile/structure/negative gates OK"
 WT="${WASMTIME_BIN:-$(command -v wasmtime || true)}"
 VERSION="$([ -n "$WT" ] && "$WT" --version 2>/dev/null || true)"
@@ -249,13 +387,15 @@ if [[ "$VERSION" != "wasmtime 47.0.2"* ]]; then
   echo "[stdin-provider-source] runtime SKIP: requires wasmtime 47.0.2, got ${VERSION:-unavailable}"
   exit 0
 fi
-INPUT="$OUT/input.bin"
-printf '\012\017\021' >"$INPUT"
+LEGACY_INPUT="$OUT/legacy-input.bin"
+CHUNK_INPUT="$OUT/chunk-input.bin"
+printf '\012\017\021' >"$LEGACY_INPUT"
+printf '\000\200\377AB' >"$CHUNK_INPUT"
 FLAGS=(-Sp3 -W component-model-async=y -W component-model-async-stackful=y -W component-model-more-async-builtins=y)
 run_lane() {
-  local name="$1" expected="$2"
+  local name="$1" expected="$2" input="${3:-$LEGACY_INPUT}"
   local actual
-  actual="$(timeout 60 "$WT" run "${FLAGS[@]}" --invoke 'run()' "$OUT/$name.component.wasm" <"$INPUT")"
+  actual="$(timeout 60 "$WT" run "${FLAGS[@]}" --invoke 'run()' "$OUT/$name.component.wasm" <"$input")"
   [ "$actual" = "$expected" ] || { echo "stdin provider source gate FAILED: $name expected $expected, got $actual" >&2; exit 1; }
   echo "[stdin-provider-source] $name: $actual"
 }
@@ -265,4 +405,10 @@ run_lane second 44
 run_lane multiple-active 45
 run_lane import-alias 46
 run_lane drain-rc 42
+run_lane chunks-direct 50 "$CHUNK_INPUT"
+run_lane chunks-one-alias 51 "$CHUNK_INPUT"
+run_lane chunks-zero 52 "$CHUNK_INPUT"
+run_lane chunks-negative 53 "$CHUNK_INPUT"
+run_lane chunks-early-close 54 "$CHUNK_INPUT"
+run_lane chunks-direct-rc 50 "$CHUNK_INPUT"
 echo "wasi cli stdin provider source component gate OK (wasmtime 47.0.2)"

--- a/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
+++ b/scripts/test_wasi_cli_stdin_provider_source_component_gate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # #1539: compile the public StdinStream API from real source, validate its exact
-# component boundary, and run lifecycle/alias/reacquisition scenarios on the
+# component boundary, and run lifecycle/wrapper/reacquisition scenarios on the
 # pinned Wasmtime 47 lane.
 set -euo pipefail
 
@@ -43,11 +43,12 @@ fn run() -> Int with Stdin + Async {
   if a == 10 && b == 15 && c == 17 && eof1 == -1 && eof2 == -1 { 42 } else { 0 }
 }
 EOF
-cat >"$OUT/early-alias.vibe" <<'EOF'
+cat >"$OUT/early-wrapper.vibe" <<'EOF'
+fn acquire() -> StdinStream with Stdin { Stdin::read_via_stream() }
+fn next(stream: StdinStream) -> Int with Async { StdinStream::next(stream) }
+fn close(stream: StdinStream) -> Unit with Async { StdinStream::close(stream) }
+
 fn run() -> Int with Stdin + Async {
-  let acquire = Stdin::read_via_stream
-  let next = StdinStream::next
-  let close = StdinStream::close
   let stream = acquire()
   let alias = stream
   let a = next(alias)
@@ -56,17 +57,21 @@ fn run() -> Int with Stdin + Async {
   if a == 10 && next(alias) == -1 { 43 } else { 0 }
 }
 EOF
-cat >"$OUT/top-level-aliases.vibe" <<'EOF'
-let acquire_alias = Stdin::read_via_stream
-let next_alias = StdinStream::next
-let close_alias = StdinStream::close
-let read_chunk_alias = StdinStream::read_chunk
+cat >"$OUT/top-level-wrappers.vibe" <<'EOF'
+fn acquire_wrapper() -> StdinStream with Stdin { Stdin::read_via_stream() }
+fn next_wrapper(stream: StdinStream) -> Int with Async { StdinStream::next(stream) }
+fn close_wrapper(stream: StdinStream) -> Unit with Async { StdinStream::close(stream) }
+fn read_chunk_wrapper(stream: StdinStream, size: Int) -> Option[String] with Async { StdinStream::read_chunk(stream, size) }
 
 fn use_provider() -> Int with Stdin + Async {
-  let stream = acquire_alias()
-  let first = next_alias(stream)
-  let chunk = read_chunk_alias(stream, 2)
-  close_alias(stream)
+  let acquire = acquire_wrapper
+  let next = next_wrapper
+  let close = close_wrapper
+  let read_chunk = read_chunk_wrapper
+  let stream = acquire()
+  let first = next(stream)
+  let chunk = read_chunk(stream, 2)
+  close(stream)
   match chunk { Some(s) => if first == 10 && String::length(s) == 2 { 55 } else { 0 }, None => 0 }
 }
 fn run() -> Int with Stdin + Async { use_provider() }
@@ -140,10 +145,11 @@ fn run() -> Int with Stdin + Async {
   }
 }
 EOF
-cat >"$OUT/chunk-one-alias.vibe" <<'EOF'
+cat >"$OUT/chunk-one-wrapper.vibe" <<'EOF'
+fn read_chunk(stream: StdinStream, size: Int) -> Option[String] with Async { StdinStream::read_chunk(stream, size) }
+
 fn run() -> Int with Stdin + Async {
   let stream = Stdin::read_via_stream()
-  let read_chunk = StdinStream::read_chunk
   let a = read_chunk(stream, 1)
   let b = read_chunk(stream, 1)
   let c = read_chunk(stream, 1)
@@ -252,13 +258,13 @@ compile_component() {
   wasm-tools validate --features all "$OUT/$name.component.wasm"
 }
 compile_component drain
-compile_component early-alias
-compile_component top-level-aliases
+compile_component early-wrapper
+compile_component top-level-wrappers
 compile_component second
 compile_component multiple-active
 compile_component import-alias 0 1 1
 compile_component chunk-loop
-compile_component chunk-one-alias
+compile_component chunk-one-wrapper
 compile_component chunk-zero
 compile_component chunk-negative
 compile_component chunk-early-close
@@ -333,13 +339,12 @@ fn run() -> Int with Stdin + Async {
   0
 }
 EOF
-actionable_fail read-chunk-effect-alias run 'effectful call outside effectful context'
-cat >"$OUT/top-acquire-effect-alias.vibe" <<'EOF'
+actionable_fail read-chunk-effect-alias run 'stdin provider operations are direct-call-only; wrap `StdinStream::read_chunk` in an explicitly effectful function'
+cat >"$OUT/top-acquire-value.vibe" <<'EOF'
 let acquire_alias = Stdin::read_via_stream
-fn pure_acquire() -> StdinStream { acquire_alias() }
-fn run() -> Int with Stdin + Async { let s = pure_acquire(); StdinStream::close(s); 0 }
+fn run() -> Int { 0 }
 EOF
-actionable_fail top-acquire-effect-alias run 'missing { Stdin }'
+actionable_fail top-acquire-value run 'stdin provider operations are direct-call-only; wrap `Stdin::read_via_stream` in an explicitly effectful function'
 for surface in next close read_chunk; do
   case "$surface" in
     next) call='next_alias(stream)'; ret='Int' ;;
@@ -351,7 +356,62 @@ let ${surface}_alias = StdinStream::$surface
 fn pure_alias(stream: StdinStream) -> $ret { $call }
 fn run() -> Int with Stdin + Async { let s = Stdin::read_via_stream(); let _ = pure_alias(s); StdinStream::close(s); 0 }
 EOF
-  actionable_fail "top-$surface-effect-alias" run 'effectful call outside effectful context:'
+  actionable_fail "top-$surface-effect-alias" run "stdin provider operations are direct-call-only; wrap \`StdinStream::$surface\` in an explicitly effectful function"
+done
+
+# Every opaque transport shape reviewed for the safety blocker must fail in the
+# checker with the same actionable direct-call-only diagnostic, before artifact
+# creation. The first forbidden provider reference is intentionally identical
+# across these fixtures so the assertion also pins deterministic reporting.
+cat >"$OUT/value-alias-chain.vibe" <<'EOF'
+fn run() -> Int {
+  let first = StdinStream::next
+  let second = first
+  let _ = second
+  0
+}
+EOF
+cat >"$OUT/value-conditional.vibe" <<'EOF'
+fn run() -> Int {
+  let _ = if true { StdinStream::next } else { StdinStream::next }
+  0
+}
+EOF
+cat >"$OUT/value-compound.vibe" <<'EOF'
+fn run() -> Int {
+  let _ = (StdinStream::next, StdinStream::close)
+  0
+}
+EOF
+cat >"$OUT/value-return.vibe" <<'EOF'
+fn leak() -> (StdinStream) -> Int with Async { StdinStream::next }
+fn run() -> Int { 0 }
+EOF
+cat >"$OUT/value-struct-field.vibe" <<'EOF'
+struct Holder { op: (StdinStream) -> Int with Async }
+fn run() -> Int {
+  let _ = Holder::{ op: StdinStream::next }
+  0
+}
+EOF
+cat >"$OUT/value-array-field.vibe" <<'EOF'
+fn run() -> Int {
+  let _ = [StdinStream::next]
+  0
+}
+EOF
+cat >"$OUT/value-map-field.vibe" <<'EOF'
+fn run() -> Int {
+  let _ = Map::from_pairs([("next", StdinStream::next)])
+  0
+}
+EOF
+cat >"$OUT/value-unknown-hof.vibe" <<'EOF'
+fn transport(op: (StdinStream) -> Int with Async) -> Int { 0 }
+fn run() -> Int { transport(StdinStream::next) }
+EOF
+for opaque in alias-chain conditional compound return struct-field array-field map-field unknown-hof; do
+  actionable_fail "value-$opaque" run 'stdin provider operations are direct-call-only; wrap `StdinStream::next` in an explicitly effectful function'
 done
 cat >"$OUT/nominal.vibe" <<'EOF'
 fn run() -> Int with Async { StdinStream::next(1) }
@@ -471,14 +531,14 @@ run_lane() {
   echo "[stdin-provider-source] $name: $actual"
 }
 run_lane drain 42
-run_lane early-alias 43
-run_lane top-level-aliases 55
+run_lane early-wrapper 43
+run_lane top-level-wrappers 55
 run_lane second 44
 run_lane multiple-active 45
 run_lane import-alias 46
 run_lane drain-rc 42
 run_lane chunk-loop 50 "$CHUNK_INPUT"
-run_lane chunk-one-alias 51 "$CHUNK_INPUT"
+run_lane chunk-one-wrapper 51 "$CHUNK_INPUT"
 run_lane chunk-zero 52 "$CHUNK_INPUT"
 run_lane chunk-negative 53 "$CHUNK_INPUT"
 run_lane chunk-early-close 54 "$CHUNK_INPUT"


### PR DESCRIPTION
## Summary
- add `StdinStream::read_chunk(stream, n) -> Option[String] with Async`
- preserve arbitrary input bytes and return bounded/final-short chunks
- keep caller-owned stream lifecycle explicit for drain or early close
- make all stdin provider operations direct-call-only until higher-order effect evidence is sound
- validate direct-call-only use again after import alias canonicalization/merge
- keep legacy `stdin_stream(chunk_size)` and standalone core output unchanged

The initially explored pull-closure/direct-`for` adapter was removed: current higher-order effect flow can erase `Async`, so landing that surface would be silent-wrong. This PR deliberately exposes only the direct bounded read primitive.

## Semantics
- `n > 0`: up to exactly `n` raw bytes; final short chunk is preserved
- EOF: successful settlement then `None`
- `n <= 0`: `None` without reading/settling; caller must close
- only provider byte values 0..255 and EOF -1 are accepted
- completion/read errors remain cleanup-then-trap; no guessed public mapping

## Validation
- Wasmtime 47.0.2 binary 00/80/ff, EOF, short/exact chunks, early/repeated close, multiple streams, bump and RC: passed
- direct/local/top-level/import/type alias, chain/container/HOF safety matrix: unsafe value references rejected before artifact
- positive direct imported type-qualified calls: passed
- GC/standalone/mixed/coverage negatives: passed
- legacy standalone artifact byte-identical to parent
- focused tests, parity, formatter, freshness, diff, test-local: passed
- independent review: safe to integrate

Refs #1539