### PR TITLE
feat(diag): 位置なしだった型エラー4種に line:col を付ける (#1567)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -456,6 +456,28 @@ fn railway_expr_off(e: Expr) -> Int {
   }
 }
 
+/// Source anchor for a function BODY's implicit return -- the value the return
+/// type is checked against. `railway_expr_off` walks into an `ESeq`'s FIRST
+/// arm, which is the right anchor for a desugar operand but the wrong one here:
+/// in `{ setup(); compute() }` the return value is `compute()`, so a diagnostic
+/// anchored on `setup()` would point at a line that is not the problem. Descend
+/// to the tail first, then reuse the ordinary walk.
+///
+/// A statement body is not only `ESeq`: `let`/`let mut` parse as an `ELet`
+/// whose THIRD field is the rest of the block, so `{ let _ = setup(); mk() }`
+/// is `ELet(_, setup(), mk(), _)` and stopping at `ESeq` alone would miss the
+/// tail entirely (and, via railway_expr_off's ELet-less fallback, report no
+/// location at all).
+fn tail_expr_off(e: Expr) -> Int {
+  match e {
+    ESeq(_, rest) => tail_expr_off(rest),
+    ELet(_, _, rest, _) => tail_expr_off(rest),
+    ELetRec(_, _, rest) => tail_expr_off(rest),
+    ELetMut(_, _, rest, _) => tail_expr_off(rest),
+    _ => railway_expr_off(e)
+  }
+}
+
 fn type_is_ground(t: Type) -> Bool {
   match t {
     CtNamed(_, _) => false,
@@ -2604,12 +2626,27 @@ fn rigid_trait_bound_binop(env: TypeEnv, left_ty: Type, right_ty: Type, trait_na
   }
 }
 
-fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: Subst, errors: Array[String], tytab: Array[(Int, Type)]) -> (Type, Subst) {
+/// `type mismatch in '<op>': <tail>`, carrying the operand anchor as the
+/// strippable `[@off=N]` marker. Every binop mismatch in `infer_binop_type`
+/// goes through here so none of them can silently go back to being unlocated:
+/// the offset is a parameter of the message, not an afterthought at one site.
+/// String::concat only (`+`/interpolation mis-codegen to NUL here).
+fn binop_mismatch_msg(op: String, tail: String, off: Int) -> String {
+  String::concat(String::concat("type mismatch in '", String::concat(op, tail)), off_marker(off))
+}
+
+/// `off` is the source anchor of the offending operator expression (the left
+/// operand's offset, falling back to the right's) -- see the EBinOp arm. -1
+/// when neither operand carries one, which is what a literal-only expression
+/// like `1 + "s"` gives: EInt/EString/EBool/EFloat have no offset slot in the
+/// AST (lib/@vibe/ast/index.vpkg), so there is nothing to point at. off_marker
+/// emits nothing for -1, leaving those messages exactly as they were.
+fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: Subst, errors: Array[String], tytab: Array[(Int, Type)], off: Int) -> (Type, Subst) {
   if is_logic_binop(op) {
     match unify_binop_candidate(left_ty, right_ty, CtBool, s) {
       Some(s1) => (CtBool, s1),
       None => {
-        Array::push(errors, String::concat("type mismatch in '", String::concat(op, "': operands must be Bool")))
+        Array::push(errors, binop_mismatch_msg(op, "': operands must be Bool", off))
         (CtUnknown, s)
       }
     }
@@ -2636,7 +2673,7 @@ fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: 
         if eq_has_named {
           (CtBool, s)
         } else {
-          Array::push(errors, String::concat("type mismatch in '", String::concat(op, "': operands must have same type")))
+          Array::push(errors, binop_mismatch_msg(op, "': operands must have same type", off))
           (CtUnknown, s)
         }
       }
@@ -2652,7 +2689,7 @@ fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: 
           None => match infer_named_trait_binop(env, left_ty, right_ty, "Ord", s) {
             Some((_, s1)) => (CtBool, s1),
             None => {
-              Array::push(errors, String::concat("type mismatch in '", String::concat(op, "': operands must be Int or Double")))
+              Array::push(errors, binop_mismatch_msg(op, "': operands must be Int or Double", off))
               (CtUnknown, s)
             }
           }
@@ -2672,7 +2709,7 @@ fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: 
             None => match infer_named_trait_binop(env, left_ty, right_ty, "Add", s) {
               Some((resolved, s1)) => (resolved, s1),
               None => {
-                Array::push(errors, "type mismatch in '+': operands must be Int, Double, or String")
+                Array::push(errors, binop_mismatch_msg("+", "': operands must be Int, Double, or String", off))
                 (CtUnknown, s)
               }
             }
@@ -2698,7 +2735,7 @@ fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: 
         None => match infer_named_trait_binop(env, left_ty, right_ty, trait_name, s) {
           Some((resolved, s1)) => (resolved, s1),
           None => {
-            Array::push(errors, String::concat("type mismatch in '", String::concat(op, "': operands must be Int or Double")))
+            Array::push(errors, binop_mismatch_msg(op, "': operands must be Int or Double", off))
             (CtUnknown, s)
           }
         }
@@ -2709,7 +2746,7 @@ fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: 
     match unify_binop_candidate(left_ty, right_ty, CtInt, s) {
       Some(s1) => (CtInt, s1),
       None => {
-        Array::push(errors, "type mismatch in '%': operands must be Int")
+        Array::push(errors, binop_mismatch_msg("%", "': operands must be Int", off))
         (CtUnknown, s)
       }
     }
@@ -2718,13 +2755,13 @@ fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: 
     match unify_binop_candidate(left_ty, right_ty, CtInt, s) {
       Some(s1) => (CtInt, s1),
       None => {
-        Array::push(errors, String::concat("type mismatch in '", String::concat(op, "': operands must be Int")))
+        Array::push(errors, binop_mismatch_msg(op, "': operands must be Int", off))
         (CtUnknown, s)
       }
     }
   }
   else {
-    Array::push(errors, String::concat("unknown operator: ", op))
+    Array::push(errors, String::concat(String::concat("unknown operator: ", op), off_marker(off)))
     (CtUnknown, s)
   }
 }
@@ -5666,7 +5703,16 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             // `CtNamed` check itself (its tolerate branch calls
             // `detect_narrowed_generic_mismatch`), so the explicit second
             // call this site used to make would double-report — dropped.
-            let ns2 = check_assignable(resolved, actual, ns0, errors, "binding type mismatch for a local let", call_off)
+            // This ECall is SYNTHETIC (ascribe_wrap builds it), so `call_off`
+            // is -1 and the diagnostic came out unlocated. The bound value is
+            // the sole argument and does have a real position -- anchor there,
+            // which is also where the annotation-vs-value conflict is fixed.
+            let asc_off = if call_off >= 0 {
+              call_off
+            } else {
+              railway_expr_off(Array::get(args, 0))
+            }
+            let ns2 = check_assignable(resolved, actual, ns0, errors, "binding type mismatch for a local let", asc_off)
             let bound_ty = preserve_generic_instantiation(resolved, subst_apply(ns2, actual))
             (tab_call_ty(tytab, call_off, bound_ty, capture, lane), ns2, nc0)
           },
@@ -5771,7 +5817,17 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
     EBinOp(op, left, right) => {
       let (left_ty, s1, c1) = check_expr_capture(left, env, defs, s, c, errors, tytab, capture, lane)
       let (right_ty, s2, c2) = check_expr_capture(right, env, defs, s1, c1, errors, tytab, capture, lane)
-      let (result_ty, s3) = infer_binop_type(op, subst_apply(s2, left_ty), subst_apply(s2, right_ty), env, s2, errors, tytab)
+      // EBinOp carries no offset of its own, so anchor the diagnostic on an
+      // operand: the left one reads as the start of the offending expression,
+      // and the right is the fallback for `1 + x` (a literal left operand has
+      // no offset to give).
+      let bin_left_off = railway_expr_off(left)
+      let bin_off = if bin_left_off >= 0 {
+        bin_left_off
+      } else {
+        railway_expr_off(right)
+      }
+      let (result_ty, s3) = infer_binop_type(op, subst_apply(s2, left_ty), subst_apply(s2, right_ty), env, s2, errors, tytab, bin_off)
       (subst_apply(s3, result_ty), s3, c2)
     },
     EUnaryOp(op, operand) => {
@@ -6743,7 +6799,10 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // pure->effectful direction and still reports the UNSOUND one (an
           // effectful value flowing into a pure-typed slot) via
           // effect_row_dropped, so this loosens nothing that was load-bearing.
-          let ns = check_assignable(resolved_ret, bt, s2, errors, "return type mismatch", 0 - 1)
+          // Anchor on the body's TAIL expression -- the value actually being
+          // returned. -1 (unlocated, as before) when the tail is a literal:
+          // EInt/EString/EBool/EFloat carry no offset in the AST.
+          let ns = check_assignable(resolved_ret, bt, s2, errors, "return type mismatch", tail_expr_off(body))
           (subst_apply(ns, resolved_ret), ns)
         },
         None => (subst_apply(s2, bt), s2)
@@ -7036,7 +7095,9 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         Some(rt) => {
           let rte = subst_apply(s1, rt)
           let ate = subst_apply(s1, et)
-          let _ = check_assignable(rte, ate, s1, errors, "return type mismatch", 0 - 1)
+          // Explicit `return e`: anchor on `e` itself, so this spelling locates
+          // the same way the implicit tail-expression return does above.
+          let _ = check_assignable(rte, ate, s1, errors, "return type mismatch", railway_expr_off(e))
           ()
         },
         None => ()

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1438,7 +1438,11 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             // calls `detect_narrowed_generic_mismatch` — see checker.vibe),
             // so the explicit second call this site used to make would
             // double-report the same diagnostic — dropped.
-            let ns_b = check_assignable(resolved_te, actual_v, ns0, errors, String::concat("binding type mismatch for ", name), 0 - 1)
+            // Anchor on the VALUE being bound, not the annotation: `let x: Int
+            // = f()` is wrong at `f()`, and that is also where the edit goes.
+            // -1 (unlocated, as before) for a literal RHS -- EInt/EString/
+            // EBool/EFloat carry no offset in the AST.
+            let ns_b = check_assignable(resolved_te, actual_v, ns0, errors, String::concat("binding type mismatch for ", name), top_stmt_expr_off(val))
             // Prefer the RHS's real instantiated type over the erasing bare
             // annotation when `resolved_te` is a bare generic-struct
             // reference that `actual_v` already concretely instantiates, so a

--- a/scripts/coverage/cov_grab.vibe
+++ b/scripts/coverage/cov_grab.vibe
@@ -42,7 +42,7 @@ let grab_binop: () -> Int = () -> {
   Array::push(ops, "+"); Array::push(ops, "-"); Array::push(ops, "*"); Array::push(ops, "=="); Array::push(ops, "<"); Array::push(ops, "&&")
   let mut i = 0
   while i < Array::length(ops) {
-    acc = acc + (handle { let (t, _) = infer_binop_type(Array::get(ops, i), CtInt, CtInt, env, SubstEmpty, Array::slice([""], 0, 0)); match t { _ => 1 } } with Exception { Throw(_) => 0 })
+    acc = acc + (handle { let (t, _) = infer_binop_type(Array::get(ops, i), CtInt, CtInt, env, SubstEmpty, Array::slice([""], 0, 0), Array::slice([(0, CtInt)], 0, 0), 0 - 1); match t { _ => 1 } } with Exception { Throw(_) => 0 })
     i = i + 1
   }
   acc

--- a/scripts/test_located_diagnostics.sh
+++ b/scripts/test_located_diagnostics.sh
@@ -101,6 +101,25 @@ expect_contains "bare-fn dot call reports no-method (#953)" 'no method `total` o
 expect_matches "bare-fn dot call no-method located with exact range (#953)" "line 10:5-10:" \
   'enum MyList { Nil; Cons(Int, MyList) }\nfn total(l: MyList) -> Int {\n  match l {\n    Nil => 0,\n    Cons(h, t) => h + total(t)\n  }\n}\nexport let main = () -> Int {\n  let l = Cons(1, Nil)\n  l.total()\n}\n'
 
+# #1567: the type errors that used to arrive with NO location at all. Each
+# passed a hardcoded -1 where the offending expression was in scope; the anchor
+# is now threaded through. Assert the exact line:col, not just "some location" —
+# an anchor on the wrong sub-expression still produces a plausible number.
+expect_contains "implicit tail return locates on the returned expr" "line 3:3:" \
+  'export let mk = () -> String { "s" }\nexport fn f() -> Int {\n  mk()\n}\n'
+expect_contains "explicit return locates on the returned expr" "line 3:10:" \
+  'export let mk = () -> String { "s" }\nexport fn f() -> Int {\n  return mk()\n}\n'
+# A body that opens with a statement parses as ELet(_, val, REST, _), not ESeq,
+# so a tail walk that only knows ESeq drops back to no location here.
+expect_contains "tail return past a let statement still locates on the tail" "line 5:3:" \
+  'export let setup = () -> Int { 1 }\nexport let mk = () -> String { "s" }\nexport fn f() -> Int {\n  let _ = setup()\n  mk()\n}\n'
+# `let x: T = v` desugars to a synthetic call whose own offset is -1; the anchor
+# has to come from the bound VALUE.
+expect_contains "annotated local let locates on the bound value" "line 3:16:" \
+  'export let mk = () -> String { "s" }\nexport fn main() -> Int {\n  let x: Int = mk()\n  0\n}\n'
+expect_contains "binop mismatch locates on an operand" "line 3:3:" \
+  'export let s = "str"\nexport fn main() -> Int {\n  s & 1\n}\n'
+
 # the internal [@off=N] offset marker must never leak into user-facing output.
 expect_missing() { # <desc> <needle-that-must-be-absent> <file.vibe content>
   local desc="$1" needle="$2"; shift 2
@@ -119,6 +138,14 @@ expect_missing "no [@off= marker leak (unknown name)" "[@off=" \
   'export let a = 1\nexport let main = () -> Int { zzz }\n'
 expect_missing "no [@off= marker leak (unknown field)" "[@off=" \
   'struct Point { x: Int; y: Int }\nexport let get = (p: Point) -> Int {\n  p.z\n}\nexport let main = () -> Int { 0 }\n'
+
+# #1567, the flip side of the located type errors above — stated so it reads as
+# a decision rather than an accident: an expression built only from LITERALS has
+# no offset to anchor on (EInt/EFloat/EString/EBool have no offset slot in
+# lib/@vibe/ast/index.vpkg), so it stays unlocated rather than borrowing a
+# nearby node's position and confidently pointing at the wrong thing.
+expect_missing "literal-only mismatch does not invent a location" "line " \
+  'export fn main() -> Int {\n  1 + "s"\n}\n'
 
 # #1567: EXACTLY ONE location per diagnostic, and it must be the crime scene.
 #


### PR DESCRIPTION
[#1567](https://github.com/mizchi/vibe-lang/issues/1567) の残り「**型エラーに `line:col` が付かない**」。[#1627](https://github.com/mizchi/vibe-lang/pull/1627) (動詞の統合) → [#1628](https://github.com/mizchi/vibe-lang/pull/1628) (誤った位置を貼らない) の続きで、これで #1567 の当初の表にあった穴が埋まる。

構文エラーには位置が付くのに型エラーには付かない、という非対称があった。原因は素朴で、**どれも犯行現場の式が呼び出し側の scope にありながら `check_assignable` に `0 - 1` をハードコードで渡していた**。

## 結果

| 診断 | 前 | 後 | アンカー |
|---|---|---|---|
| implicit tail return | 位置なし | `line 3:3` | 本体の**末尾式** |
| explicit `return e` | 位置なし | `line 3:10` | `e` |
| 注釈付き local let | 位置なし | `line 3:16` | 束縛される**値** |
| binop `type mismatch in '<op>'` | 位置なし | `line 3:3` | 左オペランド (無ければ右) |

```
# before
error: t1.vibe: return type mismatch: expected Int, got String
# after
error: t1.vibe: line 3:3: return type mismatch: expected Int, got String
```

`infer_binop_type` の 7 箇所は `binop_mismatch_msg` に集約した。**offset をメッセージの引数にしてしまえば、個別サイトが黙って無位置に戻れない**。この関数はファイルローカルで呼び出し元も 1 箇所なので、引数追加は contract に波及しない。

## 実装中に実測で見つけた 2 つの落とし穴

最初の版はどちらも取りこぼしていて、テストではなく手で流して気付いた。

**1. 関数本体の末尾は `ESeq` とは限らない。** `{ let _ = setup(); mk() }` は `ELet(_, setup(), mk(), _)` にパースされる —— 3 番目のフィールドがブロックの残り。`ESeq` しか降りない末尾走査では末尾に届かず、無位置に戻っていた。`ELet`/`ELetRec`/`ELetMut` の body も降りるようにした。

ここで既存の `railway_expr_off` をそのまま使えないのも同じ理由で、あれは `ESeq` の**先頭**へ降りる (desugar のオペランドを指すための walk)。`{ setup(); compute() }` で返るのは `compute()` なので、`setup()` を指す診断は「問題ではない行」を指すことになる。

**2. `let x: T = v` の ECall は合成ノード。** `ascribe_wrap` が `((__asc: T) -> __asc)(v)` を作るので `call_off` は -1。束縛される値 (唯一の引数) から取り直した。

## 意図的に位置を付けないケース

`1 + "s"` のようにリテラルだけで構成された式は、**`EInt`/`EFloat`/`EString`/`EBool` が AST に offset スロットを持たない** (`lib/@vibe/ast/index.vpkg`) ため、指すべき位置が存在しない。

近傍ノードの位置を借りることもできるが、それは**自信ありげに間違った場所を指す**ことになる —— #1628 で直したばかりの失敗モードそのもの。無位置のまま残す方を選び、決定としてテストに固定した (`literal-only mismatch does not invent a location`)。リテラルに offset を持たせるのは AST contract の変更になるので別件。

## 検証

| | |
|---|---|
| `compiler_gate.sh` | **100/100** (seed→stage1→stage2→stage3 fixpoint 込み) |
| `test_located_diagnostics.sh` | **23/23** (pin 6 件追加) |
| `vibe_fmt.sh --check` | clean |

追加した pin は「位置がある」ではなく **exact な `line:col`** を固定している。別の部分式にアンカーしても、もっともらしい数字は出てしまうため —— 上の落とし穴 1 がまさにそれで、`ESeq` だけ見る版でも「何かしらの位置」は出ていた可能性がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_