### PR TITLE
fix(coverage): 動いていない coverage suite が成功を報告するのをやめる (#1631)

### DIFF
--- a/scripts/coverage_acc_tool_run.sh
+++ b/scripts/coverage_acc_tool_run.sh
@@ -31,9 +31,26 @@ if [ $# -lt 2 ]; then
   exit 2
 fi
 
-compiler="${VIBE_COVERAGE_ACC_TOOL_COMPILER:-bootstrap/seed/compiler.wasm}"
+# The tool is ordinary vibe source in this checkout, so it must be built by a
+# compiler that understands THIS checkout's contracts -- not by the pinned seed.
+# The seed is the previous bootstrap tag; once `lib/@vibe/prelude/index.vpkg`
+# moved past it, a seed build died with
+#
+#   lib/@vibe/prelude/index.vpkg: contract violation: contract declaration
+#   'String::join' has no implementation; ... opaque type 'Int' has no
+#   implementation; ...
+#
+# which reads like a broken prelude but is really "the builder is too old".
+# Prefer a checkout-matched compiler and keep the seed only as a last resort,
+# the same precedence `runtime/vibe`'s pick_cli uses.
+compiler="${VIBE_COVERAGE_ACC_TOOL_COMPILER:-}"
+if [ -z "$compiler" ]; then
+  for cand in dist/cli/vibe-cli.wasm $(ls -t _build/selfhost/generations/*/stage2.wasm 2>/dev/null) bootstrap/seed/compiler.wasm; do
+    [ -s "$cand" ] && { compiler="$cand"; break; }
+  done
+fi
 if [ ! -s "$compiler" ]; then
-  echo "coverage_acc_tool_run.sh: compiler wasm not found: $compiler" >&2
+  echo "coverage_acc_tool_run.sh: compiler wasm not found: ${compiler:-<none>}" >&2
   exit 2
 fi
 

--- a/scripts/coverage_corpus.sh
+++ b/scripts/coverage_corpus.sh
@@ -21,6 +21,14 @@ FLAT_ABS="$ROOT_DIR/lib/@vibe/compiler/_cli_adapter_module_source.vibe"
 OUT_DIR="${VIBE_COV_DIR:-$ROOT_DIR/_build/coverage/selfhost-corpus}"
 COMPILER_COV="$OUT_DIR/compiler_cov.wasm"
 RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
+# Instrumenting the ~5MB flat compiler source recurses deep enough to exhaust
+# node's DEFAULT stack, and the host reports that as
+# `[vibe] stack overflow: expression too deeply nested` -- which reads like the
+# SOURCE is at fault rather than the runner. Every other lane that feeds the
+# same flat source through node already raises this (generate_bundle.sh,
+# generations.sh); this one did not, so `[corpus] building instrumented
+# compiler ...` was the last line it ever printed. Same 131072 they use.
+export VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --experimental-wasm-inlining --stack-size=131072}"
 ACC="$OUT_DIR/acc.json"
 RUN_JSON="$OUT_DIR/run.json"
 FAILS="$OUT_DIR/fails.txt"

--- a/scripts/coverage_drivers.sh
+++ b/scripts/coverage_drivers.sh
@@ -23,6 +23,13 @@ SEED="${VIBE_COV_SEED:-bootstrap/seed/compiler.wasm}"
 OUTDIR="_build/coverage/selfhost-corpus"
 ACC="$OUTDIR/acc.json"
 RUNNER="scripts/run_wasm_vibe_host_runner.sh"
+# Same node-stack requirement as coverage_corpus.sh: every driver compiles the
+# ~5MB merged source (plus the driver) under coverage instrumentation, which
+# recurses past node's default stack. Without this the host overflow surfaces as
+# `expression too deeply nested`, run_driver counts it as a compile failure, and
+# -- because that path used to `return 0` -- the whole suite reported success
+# with EVERY driver silently skipped. Keep in sync with coverage_corpus.sh.
+export VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --experimental-wasm-inlining --stack-size=131072}"
 MERGED="_build/coverage/merged_nodce.vibe"
 WORK="_build/coverage/drivers"; mkdir -p "$WORK"
 [ -s "$ACC" ] || { echo "drivers: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
@@ -105,6 +112,15 @@ PY
 # Run one driver: append <driver>.vibe to the merged source, compile under
 # coverage with the driver entry, run, union into acc.json. Retries: the 36k-line
 # source occasionally OOMs the seed under instrumentation.
+# A driver that cannot compile, or that dumps no coverage, means its branches
+# were NOT measured. Both used to be a note on stderr and `return 0`, so the
+# suite finished green and printed its usual summary line -- indistinguishable
+# from a run where everything worked. That is how the whole suite came to be
+# 0-for-34 without anyone noticing (#1631): the numbers just stopped improving.
+# Count them and fail the suite at the end (after running every driver, so one
+# breakage does not hide the rest).
+DRIVER_FAILS=0
+
 run_driver() { # entry driver_file label
   local entry="$1" file="$2" label="$3"
   local d="$WORK/$label"; rm -rf "$d"; mkdir -p "$d"
@@ -113,10 +129,26 @@ run_driver() { # entry driver_file label
   for t in 1 2 3 4 5 6; do
     rm -f "$d/m.wasm"
     VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
-      bash "$RUNNER" --invoke cli_main "$SEED" "$d/src.vibe" "$d/m.wasm" "$entry" >/dev/null 2>&1 || true
+      bash "$RUNNER" --invoke cli_main "$SEED" "$d/src.vibe" "$d/m.wasm" "$entry" >"$d/compile.log" 2>&1 || true
     [ -s "$d/m.wasm" ] && { ok=1; break; }
   done
-  [ "$ok" = 1 ] || { echo "[$label] compile failed after retries" >&2; return 0; }
+  if [ "$ok" != 1 ]; then
+    # "compile failed after retries" on its own cost a manual re-run to learn
+    # anything. The compiler already wrote the reason to the `.diag` sidecar --
+    # surface it, so the message names what to fix.
+    echo "[$label] compile failed after retries" >&2
+    # awk, not sed: the compiler writes the sidecar WITHOUT a trailing newline,
+    # and sed passes that through -- so the reason ran straight into the next
+    # driver's line (`unknown name: db_new[round] compile failed ...`). awk's
+    # `print` always terminates the line it emits.
+    if [ -s "$d/m.wasm.diag" ]; then
+      awk '{ print "               " $0 }' "$d/m.wasm.diag" >&2
+    elif [ -s "$d/compile.log" ]; then
+      tail -3 "$d/compile.log" | awk '{ print "               " $0 }' >&2
+    fi
+    DRIVER_FAILS=$((DRIVER_FAILS + 1))
+    return 0
+  fi
   VIBE_COV_OUT="$d/cov.json" VIBE_COV_RAW=1 VIBE_PREOPEN_DIR="$ROOT" \
     bash "$RUNNER" "$d/m.wasm" >/dev/null 2>&1 || true
   if [ -s "$d/cov.json" ]; then
@@ -126,6 +158,7 @@ run_driver() { # entry driver_file label
     echo "[$label] $base -> $now/$tot ($pct%) (+$((now-base)))"
   else
     echo "[$label] no coverage dumped" >&2
+    DRIVER_FAILS=$((DRIVER_FAILS + 1))
   fi
 }
 
@@ -187,3 +220,12 @@ read -r now tot < <(bash scripts/coverage_acc_tool_run.sh stat "$ACC")
 scaled=$(( (now * 10000 + tot / 2) / tot ))
 pct="$((scaled / 100)).$(printf '%02d' $((scaled % 100)))"
 echo "[drivers] corpus branches: $base -> $now/$tot ($pct%)  (+$((now-base)))" >&2
+
+# Without this the line above is the whole story, and `+0` reads as "the
+# drivers added nothing new" rather than "no driver ran". Never report a
+# coverage number as if it came from a complete run when it did not.
+if [ "$DRIVER_FAILS" -gt 0 ]; then
+  echo "[drivers] FAIL: $DRIVER_FAILS driver(s) did not contribute coverage (see the per-driver reasons above)" >&2
+  echo "[drivers] the branch numbers above are therefore INCOMPLETE" >&2
+  exit 1
+fi


### PR DESCRIPTION
[#1631](https://github.com/mizchi/vibe-lang/issues/1631)。起票時は「`cov_grab` が 1 つ silent skip されている」と書いたが、確認しようとしたら**前提のツールチェイン全体が動いておらず**、しかもそれが完全に隠れていた。

## 測定した実態

**34 ドライバ中 0 個が成功。それでも suite は exit 0。**

```
[drivers] corpus branches: 10657 -> 10657/25774 (41.35%)  (+0)
$ echo $?
0
```

`+0` は「ドライバが新規カバレッジを足せなかった」と読める。実際は「1 つも走っていない」。**数字だけが残り、走らなかったという事実がどこにも出ない** —— これが #1631 の核心で、`cov_grab` の arity ずれはその陰に隠れていた 1 例にすぎなかった。

## 独立した 4 つの破損

`07adecc` の worktree で再現を確認済み。すべて本セッションの変更より前からで、`coverage_suite.sh` (CI 側) は corpus/drivers を呼ばないため誰も踏んでいなかった。

| # | 破損 | 本 PR |
|---|---|---|
| 1 | corpus の計装ビルドが node のデフォルトスタックを枯渇 | **修正** |
| 2 | acc ツールを固定 seed でビルド (seed-drift) | **修正** |
| 3 | drivers にも同じスタック欠落 | **修正** |
| 4 | MERGED の依存走査がパッケージ import を辿らない | 別issue |

### 1 + 3. node スタック

同じ ~5MB の flat compiler source を node に食わせる他のレーン (`generate_bundle.sh` / `generations.sh`) は `--stack-size=131072` を明示している。corpus と drivers が使う `run_wasm_vibe_host_runner.sh` は既定のままで、結果:

```
[corpus] building instrumented compiler ...
[vibe] stack overflow: expression too deeply nested
```

これは**ホスト側スタックの枯渇を runner が捕捉した**もので、メッセージは「ソースが深すぎる」ように読める。真犯人を指していない診断の典型。他レーンと同値を既定にした (env 上書きは従来どおり可能)。

### 2. seed-drift

`coverage_acc_tool_run.sh` は `lib/@vibe/cli/coverage_acc_tool.vibe` を pinned seed でビルドする。`lib/@vibe/prelude/index.vpkg` が seed より先に進んだ時点で:

```
contract violation: contract declaration 'String::join' has no implementation;
... opaque type 'Int' has no implementation; ...
```

これも **prelude が壊れているように読めて、実際は「ビルダーが古い」**。checkout に合ったコンパイラ (`dist/cli/vibe-cli.wasm` → 最新 generations stage2 → seed) を優先する。優先順は `runtime/vibe` の `pick_cli` と同じ形。

## 本体: 沈黙を潰す

- 失敗 (compile 失敗 / coverage 未 dump) を数え、**全ドライバを走らせた後に exit 1**。1 件の破損が残りを隠さないよう fail-fast にはしない
- **「the branch numbers above are therefore INCOMPLETE」を明示**。不完全な数字が完全な数字の顔で残るのが最悪の壊れ方
- `compile failed after retries` に**実際の `.diag` を添える**。従来はこの 1 行だけで、原因を知るのに手動での再コンパイルが 1 回必要だった (実際に必要だった)
- 添付は `sed` ではなく `awk`。コンパイラは sidecar を末尾改行なしで書くので、sed だと理由が次のドライバ行に食い込む (`unknown name: db_new[round] compile failed ...`)。[#1627](https://github.com/mizchi/vibe-lang/pull/1627) で launcher に入れたのと同じ修正

## 検証

| | before | after |
|---|---|---|
| corpus | `expression too deeply nested` で停止 | 完走 (`compile_ok=8/9`、acc.json 生成、レポート出力) |
| acc ツール | contract violation で失敗 | 成功 |
| drivers suite | **rc=0**、`+0` のみ | **rc=1**、39 件を理由付きで報告 |

```
[async] compile failed after retries
               unknown name: db_new
...
[drivers] FAIL: 39 driver(s) did not contribute coverage (see the per-driver reasons above)
[drivers] the branch numbers above are therefore INCOMPLETE
```

## 残件 (別issueにする)

全ドライバ失敗の直接原因は **MERGED の依存走査がパッケージ import を辿らない**こと。走査の正規表現が相対パス import (`^\s*(?:import|export)\s+(\.[\w./\s-]+?)...\{`) だけを拾うため、`.vpkg` パッケージ import 移行に追従できておらず、マージ結果が **5MB あるべきところ 67KB** に縮んでいる。ドライバはそこに無いコンパイラ内部 (`db_new` 等) を参照して `unknown name` で落ちる。

走査の作り直しが要るので本 PR には含めない。ただし本 PR 以降、**この状態が黙って続くことはない** —— suite が赤くなり、理由が毎回表示される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_