### PR TITLE
checker: add shadow module typing artifact v1

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -73,11 +73,14 @@ is an ADR-sized decision, not a slice-sized one.
 ### Shadow-only checked module typing aggregate v1 (#1550)
 
 `CheckedModuleTypingArtifact` v1 is a bounded checker/artifacts experiment, not a
-production incremental-build input. Its builder requires an already successful
-`CheckedProgram` and a byte-matching `CheckedExportedInterfaceArtifact` v1; it
-returns no artifact when the exported-interface extraction is incomplete. The
-codec embeds those exact canonical interface bytes and validates them by strict
-decode/re-encode.
+production incremental-build input. `CheckedProgram` remains transparent and
+manually constructible in this slice. Consequently neither the schema nor the
+`shadow_unattested_checked_module_typing_artifact_from_checked_program` builder
+cryptographically or type-system-proves that checking succeeded. The builder
+checks only metadata shape and byte agreement with a supplied
+`CheckedExportedInterfaceArtifact` v1; manually constructed matching inputs can
+produce an artifact. The codec embeds those exact canonical interface bytes and
+validates them by strict decode/re-encode.
 
 The v1 commit unit is exactly one semantic module and therefore one singleton
 SCC. Multi-member declaration SCC production requires a later producer and
@@ -91,10 +94,13 @@ conflated.
 
 Own and closure implementation identities use a closed tag:
 `provisional_token_stream_v1` or `validated_metadata_v1`. The former is explicit
-conservative syntax identity, not normalized typed IR. Diagnostics encode only
-the canonical empty successful typing-error identity with the fixed ordering and
-scope `path,start,end,code,message`; non-empty structured diagnostics, warnings,
-and CLI/LSP diagnostic completeness are ineligible. Checked body state is only
+conservative syntax identity, not normalized typed IR. All implementation and
+dependency identities use the exact positive-length compact fingerprint shape;
+the two hash components are bounded by 2147483646 and 2147483628 respectively.
+Canonical empty diagnostics mean only a caller-attested successful typing-error
+set with the fixed ordering and scope `path,start,end,code,message`; they are not
+proof that checking ran. Non-empty structured diagnostics, warnings, and CLI/LSP
+diagnostic completeness are ineligible. Checked body state is only
 `ineligible:lossless_checked_body_unavailable_v1`—there is no TypeEnv target or
 fabricated typed-IR/body reference.
 
@@ -102,9 +108,10 @@ The aggregate and its complete-encoding fingerprint are shadow comparison data
 only. They are not wired to filesystem/module workers, TypeDb, `ModuleJob` or
 `ModuleOutcome`, the current TypeEnv v5 transport and persistent cache namespace
 v18, TDRE4, interface-v2, artifact-input traces, planner decisions, reuse, the
-CLI, or a persistent cache namespace. Decoded values attest canonical bytes, not
-a checker invocation. Reused modules cannot produce v1 without retained
-successful-check authority.
+CLI, or a persistent cache namespace. Decoded values establish canonical bytes,
+not a checker invocation. This slice has no producer or publisher. Only a future
+trusted producer invoked after `check_program_result` succeeds may publish the
+artifact; making that boundary trustworthy is explicitly future work.
 
 ## User-visible KPI contract
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -70,6 +70,42 @@ is an ADR-sized decision, not a slice-sized one.
 - Do not paper over missing provenance in a full trait observation by reparsing
   and reprinting source.
 
+### Shadow-only checked module typing aggregate v1 (#1550)
+
+`CheckedModuleTypingArtifact` v1 is a bounded checker/artifacts experiment, not a
+production incremental-build input. Its builder requires an already successful
+`CheckedProgram` and a byte-matching `CheckedExportedInterfaceArtifact` v1; it
+returns no artifact when the exported-interface extraction is incomplete. The
+codec embeds those exact canonical interface bytes and validates them by strict
+decode/re-encode.
+
+The v1 commit unit is exactly one semantic module and therefore one singleton
+SCC. Multi-member declaration SCC production requires a later producer and
+schema revision. Its ordered dependency rows contain only semantic locators and
+exported-interface fingerprints, preserving import order and duplicate
+occurrences. A separate recorded implementation closure contains the owner and
+is sorted lexicographically by semantic locator; duplicate locators are invalid.
+Dependency implementations appear in that closure only when actually embedded
+or referenced, so interface assumptions and implementation freshness are never
+conflated.
+
+Own and closure implementation identities use a closed tag:
+`provisional_token_stream_v1` or `validated_metadata_v1`. The former is explicit
+conservative syntax identity, not normalized typed IR. Diagnostics encode only
+the canonical empty successful typing-error identity with the fixed ordering and
+scope `path,start,end,code,message`; non-empty structured diagnostics, warnings,
+and CLI/LSP diagnostic completeness are ineligible. Checked body state is only
+`ineligible:lossless_checked_body_unavailable_v1`—there is no TypeEnv target or
+fabricated typed-IR/body reference.
+
+The aggregate and its complete-encoding fingerprint are shadow comparison data
+only. They are not wired to filesystem/module workers, TypeDb, `ModuleJob` or
+`ModuleOutcome`, the current TypeEnv v5 transport and persistent cache namespace
+v18, TDRE4, interface-v2, artifact-input traces, planner decisions, reuse, the
+CLI, or a persistent cache namespace. Decoded values attest canonical bytes, not
+a checker invocation. Reused modules cannot produce v1 without retained
+successful-check authority.
+
 ## User-visible KPI contract
 
 Measure these endpoints separately:

--- a/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
@@ -1,10 +1,13 @@
 //# Bounded shadow-only checked module typing artifact (#1550)
 //
-// This v1 aggregate is built only from an already successful `CheckedProgram`
-// and its matching checked exported-interface artifact. It is observation-only:
-// no cache, reuse, planner, trace, CLI, filesystem, or module-worker path reads
-// or publishes it. Current producers describe exactly one semantic module, and
-// therefore one singleton SCC.
+// IMPORTANT: `CheckedProgram` is transparent in this slice. Callers can manually
+// construct one and obtain this artifact, so neither the schema nor the
+// `shadow_unattested` builder proves checker success, cryptographically or
+// through the type system. Only a future trusted producer invoked after
+// `check_program_result` succeeds may publish these bytes; this slice adds no
+// producer or publisher. It is observation-only: no cache, reuse, planner,
+// trace, CLI, filesystem, or module-worker path reads or publishes it. Values
+// describe exactly one semantic module and therefore one singleton SCC.
 //
 // Dependency interface assumptions are ordered typing inputs. They deliberately
 // preserve repeated import occurrences. The separately recorded implementation
@@ -13,9 +16,11 @@
 // referenced. Neither dimension is a substitute for the other.
 //
 // The implementation identity is explicitly tagged provisional token-stream or
-// validated metadata. It is never called typed IR. Structured non-empty typing
-// diagnostics and lossless checked bodies are unavailable in v1 and fail closed
-// through fixed closed markers in the codec.
+// validated metadata. It is never called typed IR. Canonical empty diagnostics
+// mean only that the caller attests the successful typing-error set is empty;
+// they are not evidence that checking ran.
+// Structured non-empty typing diagnostics and lossless checked bodies are
+// unavailable in v1 and fail closed through fixed closed markers in the codec.
 
 import @vibe/cache {
   compact_string_fingerprint
@@ -40,9 +45,9 @@ import ./checked_exported_interface_artifact.vibe {
   encode_checked_exported_interface_artifact_v1
 }
 
-/// Opaque aggregate for shadow comparison only. Decoding canonical bytes does
-/// not attest that a checker ran; only the successful-result builder consumes
-/// `CheckedProgram` authority.
+/// Aggregate for shadow comparison only. It is opaque at the package boundary,
+/// but the input `CheckedProgram` remains transparent and manually constructible.
+/// Neither building nor decoding attests that a checker ran.
 export struct CheckedModuleTypingArtifact {
   module_locator: String;
   implementation_kind: String;
@@ -61,7 +66,7 @@ fn module_diagnostic_scope_order() -> String {
 }
 
 fn module_empty_diagnostic_identity() -> String {
-  "vibe-checked-module-typing-artifact:empty-typing-errors:v1"
+  "vibe-checked-module-typing-artifact:caller-attested-empty-typing-errors:v1"
 }
 
 fn module_checked_body_marker() -> String {
@@ -130,12 +135,16 @@ fn module_compact_fingerprint_valid(text: String) -> Bool {
     false
   } else {
     match module_decimal(text, 0, first, 2305843009213693951) {
-      Some(_) => match module_decimal(text, first + 1, second, 2147483647) {
-        Some(_) => match module_decimal(text, second + 1, n, 2147483647) {
-          Some(_) => true,
+      Some(count) => if count <= 0 {
+        false
+      } else {
+        match module_decimal(text, first + 1, second, 2147483646) {
+          Some(_) => match module_decimal(text, second + 1, n, 2147483628) {
+            Some(_) => true,
+            None => false
+          },
           None => false
-        },
-        None => false
+        }
       },
       None => false
     }
@@ -180,7 +189,7 @@ fn module_closure_sorted(rows: Array[(String, String, String)]) -> Array[(String
 }
 
 fn module_inputs_valid(module_locator: String, implementation_kind: String, implementation_identity: String, dependencies: Array[(String, String)], closure: Array[(String, String, String)]) -> Bool {
-  if !module_metadata_text_valid(module_locator) || !module_implementation_kind_valid(implementation_kind) || !module_metadata_text_valid(implementation_identity) {
+  if !module_metadata_text_valid(module_locator) || !module_implementation_kind_valid(implementation_kind) || !module_compact_fingerprint_valid(implementation_identity) {
     false
   } else {
     let mut valid = true
@@ -197,7 +206,7 @@ fn module_inputs_valid(module_locator: String, implementation_kind: String, impl
     i = 0
     while i < Array::length(closure) && valid {
       let (locator, kind, identity) = Array::get(closure, i)
-      if !module_metadata_text_valid(locator) || !module_implementation_kind_valid(kind) || !module_metadata_text_valid(identity) {
+      if !module_metadata_text_valid(locator) || !module_implementation_kind_valid(kind) || !module_compact_fingerprint_valid(identity) {
         valid = false
       } else {
         if locator == module_locator {
@@ -226,11 +235,13 @@ fn module_inputs_valid(module_locator: String, implementation_kind: String, impl
   }
 }
 
-/// Build only when successful checker authority and the caller-provided #1548
-/// artifact agree byte-for-byte. Missing nested export provenance, malformed
-/// metadata, duplicate closure locators, or a missing/mismatched owner returns
-/// None; callers therefore have no artifact bytes to publish.
-export fn checked_module_typing_artifact_from_checked_program(checked: CheckedProgram, module_locator: String, implementation_kind: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact] {
+/// Unattested shadow builder. It checks metadata shape and byte agreement with
+/// the caller-provided #1548 artifact, but `CheckedProgram` is transparent: a
+/// manually constructed value can pass these checks. This function provides no
+/// checker-success authority and publishes nothing. Missing nested export data,
+/// malformed metadata, duplicate closure locators, or a missing/mismatched owner
+/// returns None.
+export fn shadow_unattested_checked_module_typing_artifact_from_checked_program(checked: CheckedProgram, module_locator: String, implementation_kind: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact] {
   if !module_inputs_valid(module_locator, implementation_kind, implementation_identity, dependency_interface_assumptions, recorded_implementation_closure) {
     None
   } else {

--- a/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
@@ -1,0 +1,520 @@
+//# Bounded shadow-only checked module typing artifact (#1550)
+//
+// This v1 aggregate is built only from an already successful `CheckedProgram`
+// and its matching checked exported-interface artifact. It is observation-only:
+// no cache, reuse, planner, trace, CLI, filesystem, or module-worker path reads
+// or publishes it. Current producers describe exactly one semantic module, and
+// therefore one singleton SCC.
+//
+// Dependency interface assumptions are ordered typing inputs. They deliberately
+// preserve repeated import occurrences. The separately recorded implementation
+// closure is canonical freshness metadata only; v1 records no dependency
+// implementation unless the caller says its implementation was embedded or
+// referenced. Neither dimension is a substitute for the other.
+//
+// The implementation identity is explicitly tagged provisional token-stream or
+// validated metadata. It is never called typed IR. Structured non-empty typing
+// diagnostics and lossless checked bodies are unavailable in v1 and fail closed
+// through fixed closed markers in the codec.
+
+import @vibe/cache {
+  compact_string_fingerprint
+}
+
+import @vibe/compiler/checker {
+  CheckedProgram
+}
+
+import @vibe/compiler/core {
+  str_lt
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import ./checked_exported_interface_artifact.vibe {
+  CheckedExportedInterfaceArtifact,
+  checked_exported_interface_artifact_from_checked_program,
+  decode_checked_exported_interface_artifact_v1,
+  encode_checked_exported_interface_artifact_v1
+}
+
+/// Opaque aggregate for shadow comparison only. Decoding canonical bytes does
+/// not attest that a checker ran; only the successful-result builder consumes
+/// `CheckedProgram` authority.
+export struct CheckedModuleTypingArtifact {
+  module_locator: String;
+  implementation_kind: String;
+  implementation_identity: String;
+  dependency_interface_assumptions: Array[(String, String)];
+  recorded_implementation_closure: Array[(String, String, String)];
+  exported_interface_bytes: String
+}
+
+fn module_unit_kind() -> String {
+  "singleton_semantic_module"
+}
+
+fn module_diagnostic_scope_order() -> String {
+  "typing_errors_only:path,start,end,code,message"
+}
+
+fn module_empty_diagnostic_identity() -> String {
+  "vibe-checked-module-typing-artifact:empty-typing-errors:v1"
+}
+
+fn module_checked_body_marker() -> String {
+  "ineligible:lossless_checked_body_unavailable_v1"
+}
+
+fn module_implementation_kind_valid(kind: String) -> Bool {
+  kind == "provisional_token_stream_v1" || kind == "validated_metadata_v1"
+}
+
+fn module_metadata_text_valid(text: String) -> Bool {
+  let n = String::length(text)
+  let mut i = 0
+  let mut valid = n > 0
+  while i < n && valid {
+    let c = String::char_code_at(text, i)
+    if c < 32 || c == 127 {
+      valid = false
+    } else {
+      i = i + 1
+    }
+  }
+  valid
+}
+
+fn module_decimal(text: String, start: Int, end: Int, bound: Int) -> Option[Int] {
+  if start >= end || bound < 0 {
+    None
+  } else {
+    let mut i = start
+    let mut value = 0
+    let mut valid = true
+    if end - start > 1 && String::char_code_at(text, start) == 48 {
+      valid = false
+    } else {
+      ()
+    }
+    while i < end && valid {
+      let digit = String::char_code_at(text, i) - 48
+      if digit < 0 || digit > 9 || value > (bound - digit) / 10 {
+        valid = false
+      } else {
+        value = value * 10 + digit
+        i = i + 1
+      }
+    }
+    if valid {
+      Some(value)
+    } else {
+      None
+    }
+  }
+}
+
+fn module_compact_fingerprint_valid(text: String) -> Bool {
+  let n = String::length(text)
+  let mut first = 0
+  while first < n && String::char_code_at(text, first) != 58 {
+    first = first + 1
+  }
+  let mut second = first + 1
+  while second < n && String::char_code_at(text, second) != 58 {
+    second = second + 1
+  }
+  if first == 0 || first >= n || second == first + 1 || second >= n || second + 1 >= n {
+    false
+  } else {
+    match module_decimal(text, 0, first, 2305843009213693951) {
+      Some(_) => match module_decimal(text, first + 1, second, 2147483647) {
+        Some(_) => match module_decimal(text, second + 1, n, 2147483647) {
+          Some(_) => true,
+          None => false
+        },
+        None => false
+      },
+      None => false
+    }
+  }
+}
+
+fn module_dependencies_copy(rows: Array[(String, String)]) -> Array[(String, String)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(rows) {
+    Array::push(out, Array::get(rows, i))
+    i = i + 1
+  }
+  out
+}
+
+fn module_closure_sorted(rows: Array[(String, String, String)]) -> Array[(String, String, String)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(rows) {
+    let row = Array::get(rows, i)
+    let mut at = Array::length(out)
+    let mut j = 0
+    while j < Array::length(out) && at == Array::length(out) {
+      let (other_locator, _, _) = Array::get(out, j)
+      if str_lt(row.0, other_locator) {
+        at = j
+      } else {
+        j = j + 1
+      }
+    }
+    Array::push(out, row)
+    let mut k = Array::length(out) - 1
+    while k > at {
+      Array::set(out, k, Array::get(out, k - 1))
+      k = k - 1
+    }
+    Array::set(out, at, row)
+    i = i + 1
+  }
+  out
+}
+
+fn module_inputs_valid(module_locator: String, implementation_kind: String, implementation_identity: String, dependencies: Array[(String, String)], closure: Array[(String, String, String)]) -> Bool {
+  if !module_metadata_text_valid(module_locator) || !module_implementation_kind_valid(implementation_kind) || !module_metadata_text_valid(implementation_identity) {
+    false
+  } else {
+    let mut valid = true
+    let mut i = 0
+    while i < Array::length(dependencies) && valid {
+      let (locator, fingerprint) = Array::get(dependencies, i)
+      if !module_metadata_text_valid(locator) || !module_compact_fingerprint_valid(fingerprint) {
+        valid = false
+      } else {
+        i = i + 1
+      }
+    }
+    let mut owner_count = 0
+    i = 0
+    while i < Array::length(closure) && valid {
+      let (locator, kind, identity) = Array::get(closure, i)
+      if !module_metadata_text_valid(locator) || !module_implementation_kind_valid(kind) || !module_metadata_text_valid(identity) {
+        valid = false
+      } else {
+        if locator == module_locator {
+          owner_count = owner_count + 1
+          if kind != implementation_kind || identity != implementation_identity {
+            valid = false
+          } else {
+            ()
+          }
+        } else {
+          ()
+        }
+        let mut j = 0
+        while j < i && valid {
+          let (previous, _, _) = Array::get(closure, j)
+          if previous == locator {
+            valid = false
+          } else {
+            j = j + 1
+          }
+        }
+        i = i + 1
+      }
+    }
+    valid && owner_count == 1
+  }
+}
+
+/// Build only when successful checker authority and the caller-provided #1548
+/// artifact agree byte-for-byte. Missing nested export provenance, malformed
+/// metadata, duplicate closure locators, or a missing/mismatched owner returns
+/// None; callers therefore have no artifact bytes to publish.
+export fn checked_module_typing_artifact_from_checked_program(checked: CheckedProgram, module_locator: String, implementation_kind: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact] {
+  if !module_inputs_valid(module_locator, implementation_kind, implementation_identity, dependency_interface_assumptions, recorded_implementation_closure) {
+    None
+  } else {
+    match checked_exported_interface_artifact_from_checked_program(checked) {
+      Some(derived_interface) => {
+        let derived_bytes = encode_checked_exported_interface_artifact_v1(derived_interface)
+        let supplied_bytes = encode_checked_exported_interface_artifact_v1(exported_interface)
+        if derived_bytes != supplied_bytes {
+          None
+        } else {
+          Some(CheckedModuleTypingArtifact::{
+            module_locator: module_locator,
+            implementation_kind: implementation_kind,
+            implementation_identity: implementation_identity,
+            dependency_interface_assumptions: module_dependencies_copy(dependency_interface_assumptions),
+            recorded_implementation_closure: module_closure_sorted(recorded_implementation_closure),
+            exported_interface_bytes: supplied_bytes
+          })
+        }
+      },
+      None => None
+    }
+  }
+}
+
+fn module_push_piece(out: StringBuilder, text: String) -> Unit {
+  StringBuilder::push(out, __to_string(String::length(text)))
+  StringBuilder::push(out, ":")
+  StringBuilder::push(out, text)
+}
+
+fn module_encode_dependencies(rows: Array[(String, String)]) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, __to_string(Array::length(rows)))
+  StringBuilder::push(out, "[")
+  let mut i = 0
+  while i < Array::length(rows) {
+    let (locator, fingerprint) = Array::get(rows, i)
+    module_push_piece(out, locator)
+    module_push_piece(out, fingerprint)
+    i = i + 1
+  }
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+fn module_encode_closure(rows: Array[(String, String, String)]) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, __to_string(Array::length(rows)))
+  StringBuilder::push(out, "[")
+  let mut i = 0
+  while i < Array::length(rows) {
+    let (locator, kind, identity) = Array::get(rows, i)
+    module_push_piece(out, locator)
+    module_push_piece(out, kind)
+    module_push_piece(out, identity)
+    i = i + 1
+  }
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+/// Strict, versioned and length-delimited shadow transport. Its fingerprint is
+/// a comparison token only, never a production lookup key.
+export fn encode_checked_module_typing_artifact_v1(artifact: CheckedModuleTypingArtifact) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, "vibe-checked-module-typing-artifact:v1\n12[")
+  module_push_piece(out, module_unit_kind())
+  module_push_piece(out, artifact.module_locator)
+  module_push_piece(out, "1")
+  module_push_piece(out, artifact.module_locator)
+  module_push_piece(out, artifact.implementation_kind)
+  module_push_piece(out, artifact.implementation_identity)
+  module_push_piece(out, module_encode_dependencies(artifact.dependency_interface_assumptions))
+  module_push_piece(out, module_encode_closure(artifact.recorded_implementation_closure))
+  module_push_piece(out, artifact.exported_interface_bytes)
+  module_push_piece(out, module_diagnostic_scope_order())
+  module_push_piece(out, module_empty_diagnostic_identity())
+  module_push_piece(out, module_checked_body_marker())
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+fn module_piece_parse(text: String, pos: Int) -> Option[(String, Int)] {
+  let n = String::length(text)
+  let mut at = pos
+  while at < n && String::char_code_at(text, at) != 58 {
+    at = at + 1
+  }
+  if at == pos || at >= n {
+    None
+  } else {
+    match module_decimal(text, pos, at, n - at - 1) {
+      Some(size) => {
+        let start = at + 1
+        let end = start + size
+        if end < start || end > n {
+          None
+        } else {
+          Some((text[start: end], end))
+        }
+      },
+      None => None
+    }
+  }
+}
+
+fn module_decode_dependencies(text: String) -> Option[Array[(String, String)]] {
+  let n = String::length(text)
+  let mut open_at = 0
+  while open_at < n && String::char_code_at(text, open_at) != 91 {
+    open_at = open_at + 1
+  }
+  if open_at == 0 || open_at >= n {
+    None
+  } else {
+    match module_decimal(text, 0, open_at, n - open_at - 1) {
+      Some(count) => {
+        let rows = array_empty()
+        let mut cursor = open_at + 1
+        let mut i = 0
+        let mut valid = true
+        while i < count && valid {
+          match module_piece_parse(text, cursor) {
+            Some((locator, after_locator)) => match module_piece_parse(text, after_locator) {
+              Some((fingerprint, next)) => {
+                Array::push(rows, (locator, fingerprint))
+                cursor = next
+              },
+              None => {
+                valid = false
+              }
+            },
+            None => {
+              valid = false
+            }
+          }
+          i = i + 1
+        }
+        if valid && cursor < n && String::char_code_at(text, cursor) == 93 && cursor + 1 == n && module_encode_dependencies(rows) == text {
+          Some(rows)
+        } else {
+          None
+        }
+      },
+      None => None
+    }
+  }
+}
+
+fn module_decode_closure(text: String) -> Option[Array[(String, String, String)]] {
+  let n = String::length(text)
+  let mut open_at = 0
+  while open_at < n && String::char_code_at(text, open_at) != 91 {
+    open_at = open_at + 1
+  }
+  if open_at == 0 || open_at >= n {
+    None
+  } else {
+    match module_decimal(text, 0, open_at, n - open_at - 1) {
+      Some(count) => {
+        let rows = array_empty()
+        let mut cursor = open_at + 1
+        let mut i = 0
+        let mut valid = true
+        while i < count && valid {
+          match module_piece_parse(text, cursor) {
+            Some((locator, after_locator)) => match module_piece_parse(text, after_locator) {
+              Some((kind, after_kind)) => match module_piece_parse(text, after_kind) {
+                Some((identity, next)) => {
+                  Array::push(rows, (locator, kind, identity))
+                  cursor = next
+                },
+                None => {
+                  valid = false
+                }
+              },
+              None => {
+                valid = false
+              }
+            },
+            None => {
+              valid = false
+            }
+          }
+          i = i + 1
+        }
+        if valid && cursor < n && String::char_code_at(text, cursor) == 93 && cursor + 1 == n && module_encode_closure(rows) == text {
+          Some(rows)
+        } else {
+          None
+        }
+      },
+      None => None
+    }
+  }
+}
+
+fn module_closure_is_canonical(rows: Array[(String, String, String)]) -> Bool {
+  let mut i = 1
+  let mut valid = true
+  while i < Array::length(rows) && valid {
+    let (previous, _, _) = Array::get(rows, i - 1)
+    let (current, _, _) = Array::get(rows, i)
+    if previous == current || str_lt(current, previous) {
+      valid = false
+    } else {
+      i = i + 1
+    }
+  }
+  valid
+}
+
+/// Decode only exact canonical v1 bytes. Alternate tags, malformed/noncanonical
+/// lengths or counts, hostile truncation, trailing bytes, noncanonical closure
+/// order, duplicate locators, malformed nested #1548 bytes, non-empty diagnostic
+/// states, and any checked-body substitute are rejected.
+export fn decode_checked_module_typing_artifact_v1(text: String) -> Option[CheckedModuleTypingArtifact] {
+  let prefix = "vibe-checked-module-typing-artifact:v1\n12["
+  let n = String::length(text)
+  if n <= String::length(prefix) || text[0: String::length(prefix)] != prefix {
+    None
+  } else {
+    let fields = array_empty()
+    let mut cursor = String::length(prefix)
+    let mut i = 0
+    let mut valid = true
+    while i < 12 && valid {
+      match module_piece_parse(text, cursor) {
+        Some((field, next)) => {
+          Array::push(fields, field)
+          cursor = next
+        },
+        None => {
+          valid = false
+        }
+      }
+      i = i + 1
+    }
+    if !valid || cursor >= n || String::char_code_at(text, cursor) != 93 || cursor + 1 != n {
+      None
+    } else if Array::get(fields, 0) != module_unit_kind() || Array::get(fields, 2) != "1" || Array::get(fields, 3) != Array::get(fields, 1) || Array::get(fields, 9) != module_diagnostic_scope_order() || Array::get(fields, 10) != module_empty_diagnostic_identity() || Array::get(fields, 11) != module_checked_body_marker() {
+      None
+    } else {
+      match module_decode_dependencies(Array::get(fields, 6)) {
+        Some(dependencies) => match module_decode_closure(Array::get(fields, 7)) {
+          Some(closure) => match decode_checked_exported_interface_artifact_v1(Array::get(fields, 8)) {
+            Some(exported_interface) => {
+              let nested_bytes = encode_checked_exported_interface_artifact_v1(exported_interface)
+              if nested_bytes != Array::get(fields, 8) || !module_closure_is_canonical(closure) || !module_inputs_valid(Array::get(fields, 1), Array::get(fields, 4), Array::get(fields, 5), dependencies, closure) {
+                None
+              } else {
+                let artifact = CheckedModuleTypingArtifact::{
+                  module_locator: Array::get(fields, 1),
+                  implementation_kind: Array::get(fields, 4),
+                  implementation_identity: Array::get(fields, 5),
+                  dependency_interface_assumptions: dependencies,
+                  recorded_implementation_closure: closure,
+                  exported_interface_bytes: nested_bytes
+                }
+                if encode_checked_module_typing_artifact_v1(artifact) == text {
+                  Some(artifact)
+                } else {
+                  None
+                }
+              }
+            },
+            None => None
+          },
+          None => None
+        },
+        None => None
+      }
+    }
+  }
+}
+
+/// Canonical complete aggregate bytes for snapshots only.
+export fn canonical_checked_module_typing_artifact_snapshot(artifact: CheckedModuleTypingArtifact) -> String {
+  encode_checked_module_typing_artifact_v1(artifact)
+}
+
+/// Compact shadow-comparison identity of the complete versioned encoding. It is
+/// deliberately disconnected from persistent cache lookup and reuse.
+export fn checked_module_typing_artifact_fingerprint_v1(artifact: CheckedModuleTypingArtifact) -> String {
+  compact_string_fingerprint(encode_checked_module_typing_artifact_v1(artifact))
+}

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -17,13 +17,15 @@ generated_hash =
 // expression-structure observation/artifact transport.
 
 // --- checked_module_typing_artifact.vibe
-// Bounded shadow-only singleton semantic-module/SCC aggregate. It requires a
-// successful CheckedProgram and matching #1548 exported-interface artifact,
-// keeps ordered dependency interface assumptions separate from its canonical
-// recorded implementation closure, and encodes only empty typing errors plus a
-// fixed checked-body ineligible marker. No cache/reuse/planner/trace integration.
+// Bounded unattested shadow-only singleton semantic-module/SCC aggregate.
+// CheckedProgram is transparent and manually constructible, so neither this
+// schema nor its builder cryptographically or type-system-proves checker success.
+// Canonical empty diagnostics mean only a caller-attested successful typing-error
+// set, not proof. Only a future trusted producer
+// called after check_program_result succeeds may publish; this slice has no
+// producer or publisher and no cache/reuse/planner/trace integration.
 opaque type CheckedModuleTypingArtifact
-fn checked_module_typing_artifact_from_checked_program(checked: CheckedProgram, module_locator: String, implementation_kind: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact]
+fn shadow_unattested_checked_module_typing_artifact_from_checked_program(checked: CheckedProgram, module_locator: String, implementation_kind: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact]
 fn encode_checked_module_typing_artifact_v1(artifact: CheckedModuleTypingArtifact) -> String
 fn decode_checked_module_typing_artifact_v1(text: String) -> Option[CheckedModuleTypingArtifact]
 fn canonical_checked_module_typing_artifact_snapshot(artifact: CheckedModuleTypingArtifact) -> String

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -16,10 +16,23 @@ generated_hash =
 // checked effect-set declaration, effective-effect-row, and checked
 // expression-structure observation/artifact transport.
 
+// --- checked_module_typing_artifact.vibe
+// Bounded shadow-only singleton semantic-module/SCC aggregate. It requires a
+// successful CheckedProgram and matching #1548 exported-interface artifact,
+// keeps ordered dependency interface assumptions separate from its canonical
+// recorded implementation closure, and encodes only empty typing errors plus a
+// fixed checked-body ineligible marker. No cache/reuse/planner/trace integration.
+opaque type CheckedModuleTypingArtifact
+fn checked_module_typing_artifact_from_checked_program(checked: CheckedProgram, module_locator: String, implementation_kind: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact]
+fn encode_checked_module_typing_artifact_v1(artifact: CheckedModuleTypingArtifact) -> String
+fn decode_checked_module_typing_artifact_v1(text: String) -> Option[CheckedModuleTypingArtifact]
+fn canonical_checked_module_typing_artifact_snapshot(artifact: CheckedModuleTypingArtifact) -> String
+fn checked_module_typing_artifact_fingerprint_v1(artifact: CheckedModuleTypingArtifact) -> String
+
 // --- checked_exported_interface_artifact.vibe
 // Shadow-only complete-or-none exported declaration surface from retained
 // successful CheckedProgram data. It is not a cache/reuse input, interface-v2,
-// TypeEnv-v3 transport, artifact-input trace, or planner decision. Exported
+// TypeEnv-v5 transport, artifact-input trace, or planner decision. Exported
 // nested values fail closed because CheckedProgram retains no nested TypeEnv.
 opaque type CheckedExportedInterfaceArtifact
 fn checked_exported_interface_artifact_from_checked_program(checked: CheckedProgram) -> Option[CheckedExportedInterfaceArtifact]

--- a/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
@@ -1,7 +1,7 @@
 //# #1550 bounded shadow-only checked module typing artifact tests.
 
 import @vibe/compiler/checker {
-  check_program_result
+  CheckedProgram, check_program_result
 }
 
 import @vibe/compiler/checker/artifacts {
@@ -9,10 +9,10 @@ import @vibe/compiler/checker/artifacts {
   checked_exported_interface_artifact_fingerprint_v1,
   checked_exported_interface_artifact_from_checked_program,
   checked_module_typing_artifact_fingerprint_v1,
-  checked_module_typing_artifact_from_checked_program,
   decode_checked_module_typing_artifact_v1,
   encode_checked_exported_interface_artifact_v1,
-  encode_checked_module_typing_artifact_v1
+  encode_checked_module_typing_artifact_v1,
+  shadow_unattested_checked_module_typing_artifact_from_checked_program
 }
 
 import @vibe/compiler/core {
@@ -87,17 +87,17 @@ fn mt_valid_fields(nested: String) -> Array[String] {
     "1",
     "owner",
     "provisional_token_stream_v1",
-    "impl-owner",
+    "1:2:3",
     mt_dependencies([
       ("dep", "1:2:3"),
       ("dep", "1:2:3")
     ]),
     mt_closure([
-      ("owner", "provisional_token_stream_v1", "impl-owner")
+      ("owner", "provisional_token_stream_v1", "1:2:3")
     ]),
     nested,
     "typing_errors_only:path,start,end,code,message",
-    "vibe-checked-module-typing-artifact:empty-typing-errors:v1",
+    "vibe-checked-module-typing-artifact:caller-attested-empty-typing-errors:v1",
     "ineligible:lossless_checked_body_unavailable_v1"
   ]
 }
@@ -113,7 +113,7 @@ fn mt_nested_interface(stmts: Array[Stmt]) -> String with Exception {
 fn mt_build_text(stmts: Array[Stmt], owner: String, kind: String, identity: String, dependencies: Array[(String, String)], closure: Array[(String, String, String)]) -> Option[String] with Exception {
   let checked = check_program_result(stmts)
   match checked_exported_interface_artifact_from_checked_program(checked) {
-    Some(interface) => match checked_module_typing_artifact_from_checked_program(checked, owner, kind, identity, dependencies, closure, interface) {
+    Some(interface) => match shadow_unattested_checked_module_typing_artifact_from_checked_program(checked, owner, kind, identity, dependencies, closure, interface) {
       Some(artifact) => Some(encode_checked_module_typing_artifact_v1(artifact)),
       None => None
     },
@@ -142,16 +142,16 @@ fn mt_set(fields: Array[String], at: Int, value: String) -> Array[String] {
   out
 }
 
-test "checked module typing artifact round-trips successful singleton authority" {
+test "checked module typing artifact round-trips caller-supplied singleton metadata" {
   let stmts = [
     SLet(true, false, "api", Some(TyName("Int")), EInt(1))
   ]
   let checked = check_program_result(stmts)
   match checked_exported_interface_artifact_from_checked_program(checked) {
-    Some(interface) => match checked_module_typing_artifact_from_checked_program(checked, "pkg::owner", "provisional_token_stream_v1", "tokens:one", [
+    Some(interface) => match shadow_unattested_checked_module_typing_artifact_from_checked_program(checked, "pkg::owner", "provisional_token_stream_v1", "1:2:3", [
       ("pkg::dep", checked_exported_interface_artifact_fingerprint_v1(interface))
     ], [
-      ("pkg::owner", "provisional_token_stream_v1", "tokens:one")
+      ("pkg::owner", "provisional_token_stream_v1", "1:2:3")
     ], interface) {
       Some(artifact) => {
         let text = encode_checked_module_typing_artifact_v1(artifact)
@@ -162,7 +162,7 @@ test "checked module typing artifact round-trips successful singleton authority"
             assert(checked_module_typing_artifact_fingerprint_v1(decoded) == checked_module_typing_artifact_fingerprint_v1(artifact))
             assert(String::contains(text, "singleton_semantic_module"))
             assert(String::contains(text, "typing_errors_only:path,start,end,code,message"))
-            assert(String::contains(text, "empty-typing-errors:v1"))
+            assert(String::contains(text, "caller-attested-empty-typing-errors:v1"))
             assert(String::contains(text, "ineligible:lossless_checked_body_unavailable_v1"))
             assert(!String::contains(text, "TypeEnv"))
             assert(!String::contains(text, "typed_ir"))
@@ -182,7 +182,31 @@ test "checked module typing artifact round-trips successful singleton authority"
   }
 }
 
-test "module aggregate requires matching #1548 artifact and propagates missing provenance" {
+test "manually constructed CheckedProgram can produce an unattested shadow artifact" {
+  let checked = check_program_result([
+    SLet(true, false, "api", Some(TyName("Int")), EInt(1))
+  ])
+  let manual = CheckedProgram::{
+    checked_stmts: [
+      SLet(true, false, "api", Some(TyName("Int")), EString("not checked against copied type state"))
+    ],
+    final_env: checked.final_env,
+    type_defs: checked.type_defs,
+    final_subst: checked.final_subst,
+    typed_occurrences: checked.typed_occurrences
+  }
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(interface) => match shadow_unattested_checked_module_typing_artifact_from_checked_program(manual, "owner", "validated_metadata_v1", "1:2:3", array_empty(), [
+      ("owner", "validated_metadata_v1", "1:2:3")
+    ], interface) {
+      Some(artifact) => assert(String::length(encode_checked_module_typing_artifact_v1(artifact)) > 0),
+      None => assert(false)
+    },
+    None => assert(false)
+  }
+}
+
+test "unattested shadow builder requires matching #1548 bytes and propagates missing provenance" {
   let first = check_program_result([
     SLet(true, false, "api", None, EInt(1))
   ])
@@ -190,8 +214,8 @@ test "module aggregate requires matching #1548 artifact and propagates missing p
     SLet(true, false, "api", None, EString("different"))
   ])
   match checked_exported_interface_artifact_from_checked_program(second) {
-    Some(wrong_interface) => match checked_module_typing_artifact_from_checked_program(first, "owner", "validated_metadata_v1", "impl", array_empty(), [
-      ("owner", "validated_metadata_v1", "impl")
+    Some(wrong_interface) => match shadow_unattested_checked_module_typing_artifact_from_checked_program(first, "owner", "validated_metadata_v1", "1:2:3", array_empty(), [
+      ("owner", "validated_metadata_v1", "1:2:3")
     ], wrong_interface) {
       Some(_) => assert(false),
       None => assert(true)
@@ -216,15 +240,15 @@ test "own identity and recorded implementation closure change aggregate identity
   let deps = [
     ("dep", "1:2:3")
   ]
-  let first = mt_build_text(stmts, "owner", "validated_metadata_v1", "impl-a", deps, [
-    ("owner", "validated_metadata_v1", "impl-a")
+  let first = mt_build_text(stmts, "owner", "validated_metadata_v1", "1:2:3", deps, [
+    ("owner", "validated_metadata_v1", "1:2:3")
   ])
-  let second = mt_build_text(stmts, "owner", "validated_metadata_v1", "impl-b", deps, [
-    ("owner", "validated_metadata_v1", "impl-b")
+  let second = mt_build_text(stmts, "owner", "validated_metadata_v1", "1:2:4", deps, [
+    ("owner", "validated_metadata_v1", "1:2:4")
   ])
-  let closure_changed = mt_build_text(stmts, "owner", "validated_metadata_v1", "impl-a", deps, [
-    ("dep", "validated_metadata_v1", "embedded-new"),
-    ("owner", "validated_metadata_v1", "impl-a")
+  let closure_changed = mt_build_text(stmts, "owner", "validated_metadata_v1", "1:2:3", deps, [
+    ("dep", "validated_metadata_v1", "1:2:5"),
+    ("owner", "validated_metadata_v1", "1:2:3")
   ])
   match (first, second, closure_changed) {
     (Some(a), Some(b), Some(c)) => {
@@ -245,8 +269,8 @@ test "dependency typing assumptions preserve order and duplicate occurrences" {
   ]
   match mt_build_text([
     SLet(true, false, "api", None, EInt(1))
-  ], "owner", "validated_metadata_v1", "impl", deps, [
-    ("owner", "validated_metadata_v1", "impl")
+  ], "owner", "validated_metadata_v1", "1:2:3", deps, [
+    ("owner", "validated_metadata_v1", "1:2:3")
   ]) {
     Some(text) => {
       assert(String::contains(text, mt_piece(mt_dependencies(deps))))
@@ -259,7 +283,7 @@ test "dependency typing assumptions preserve order and duplicate occurrences" {
   }
 }
 
-test "module builder snapshots caller-owned row arrays" {
+test "unattested shadow builder snapshots caller-owned row arrays" {
   let checked = check_program_result([
     SLet(true, false, "api", None, EInt(1))
   ])
@@ -267,10 +291,10 @@ test "module builder snapshots caller-owned row arrays" {
     ("dep", "1:2:3")
   ]
   let closure = [
-    ("owner", "validated_metadata_v1", "impl")
+    ("owner", "validated_metadata_v1", "1:2:3")
   ]
   match checked_exported_interface_artifact_from_checked_program(checked) {
-    Some(interface) => match checked_module_typing_artifact_from_checked_program(checked, "owner", "validated_metadata_v1", "impl", dependencies, closure, interface) {
+    Some(interface) => match shadow_unattested_checked_module_typing_artifact_from_checked_program(checked, "owner", "validated_metadata_v1", "1:2:3", dependencies, closure, interface) {
       Some(artifact) => {
         let before = encode_checked_module_typing_artifact_v1(artifact)
         Array::set(dependencies, 0, ("mutated", "9:9:9"))
@@ -288,61 +312,107 @@ test "recorded implementation closure sorts lexically and rejects duplicate or i
     SLet(true, false, "api", None, EInt(1))
   ]
   let lexical = [
-    ("aa", "validated_metadata_v1", "dep-impl"),
-    ("b", "validated_metadata_v1", "owner-impl")
+    ("aa", "validated_metadata_v1", "1:2:4"),
+    ("b", "validated_metadata_v1", "1:2:3")
   ]
-  match mt_build_text(stmts, "b", "validated_metadata_v1", "owner-impl", array_empty(), [
-    ("b", "validated_metadata_v1", "owner-impl"),
-    ("aa", "validated_metadata_v1", "dep-impl")
+  match mt_build_text(stmts, "b", "validated_metadata_v1", "1:2:3", array_empty(), [
+    ("b", "validated_metadata_v1", "1:2:3"),
+    ("aa", "validated_metadata_v1", "1:2:4")
   ]) {
     Some(text) => assert(String::contains(text, mt_piece(mt_closure(lexical)))),
     None => assert(false)
   }
-  match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", array_empty(), [
-    ("owner", "validated_metadata_v1", "impl"),
-    ("owner", "validated_metadata_v1", "impl")
+  match mt_build_text(stmts, "owner", "validated_metadata_v1", "1:2:3", array_empty(), [
+    ("owner", "validated_metadata_v1", "1:2:3"),
+    ("owner", "validated_metadata_v1", "1:2:3")
   ]) {
     Some(_) => assert(false),
     None => assert(true)
   }
-  match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", array_empty(), [
-    ("other", "validated_metadata_v1", "impl")
+  match mt_build_text(stmts, "owner", "validated_metadata_v1", "1:2:3", array_empty(), [
+    ("other", "validated_metadata_v1", "1:2:3")
   ]) {
     Some(_) => assert(false),
     None => assert(true)
   }
-  match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", array_empty(), [
-    ("owner", "validated_metadata_v1", "different")
+  match mt_build_text(stmts, "owner", "validated_metadata_v1", "1:2:3", array_empty(), [
+    ("owner", "validated_metadata_v1", "1:2:4")
   ]) {
     Some(_) => assert(false),
     None => assert(true)
   }
 }
 
-test "module builder fails closed for invalid tags locators and interface fingerprints" {
+test "unattested shadow builder rejects invalid tags locators and compact fingerprints" {
   let stmts = [
     SLet(true, false, "api", None, EInt(1))
   ]
-  match mt_build_text(stmts, "owner", "typed_ir", "impl", array_empty(), [
-    ("owner", "typed_ir", "impl")
+  match mt_build_text(stmts, "owner", "typed_ir", "1:2:3", array_empty(), [
+    ("owner", "typed_ir", "1:2:3")
   ]) {
     Some(_) => assert(false),
     None => assert(true)
   }
-  match mt_build_text(stmts, "owner\nother", "validated_metadata_v1", "impl", array_empty(), [
-    ("owner\nother", "validated_metadata_v1", "impl")
+  match mt_build_text(stmts, "owner\nother", "validated_metadata_v1", "1:2:3", array_empty(), [
+    ("owner\nother", "validated_metadata_v1", "1:2:3")
   ]) {
     Some(_) => assert(false),
     None => assert(true)
   }
-  match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", [
+  match mt_build_text(stmts, "owner", "validated_metadata_v1", "1:2:3", [
     ("dep", "01:2:3")
   ], [
-    ("owner", "validated_metadata_v1", "impl")
+    ("owner", "validated_metadata_v1", "1:2:3")
   ]) {
     Some(_) => assert(false),
     None => assert(true)
   }
+}
+
+test "compact fingerprints enforce positive count and exact hash maxima for own dependency and closure identities" {
+  let nested = mt_nested_interface([
+    SLet(true, false, "api", None, EInt(1))
+  ])
+  let maximum = "1:2147483646:2147483628"
+  let first_maximum_plus_one = "1:2147483647:2147483628"
+  let second_maximum_plus_one = "1:2147483646:2147483629"
+  let fields = mt_set(mt_valid_fields(nested), 5, maximum)
+  let valid = mt_set(mt_set(fields, 6, mt_dependencies([
+    ("dep", maximum)
+  ])), 7, mt_closure([
+    ("dep", "validated_metadata_v1", maximum),
+    ("owner", "provisional_token_stream_v1", maximum)
+  ]))
+  match decode_checked_module_typing_artifact_v1(mt_outer(valid)) {
+    Some(_) => assert(true),
+    None => assert(false)
+  }
+  mt_assert_decode_none(mt_outer(mt_set(mt_set(valid, 5, first_maximum_plus_one), 7, mt_closure([
+    ("dep", "validated_metadata_v1", maximum),
+    ("owner", "provisional_token_stream_v1", first_maximum_plus_one)
+  ]))))
+  mt_assert_decode_none(mt_outer(mt_set(mt_set(valid, 5, second_maximum_plus_one), 7, mt_closure([
+    ("dep", "validated_metadata_v1", maximum),
+    ("owner", "provisional_token_stream_v1", second_maximum_plus_one)
+  ]))))
+  mt_assert_decode_none(mt_outer(mt_set(valid, 6, mt_dependencies([
+    ("dep", first_maximum_plus_one)
+  ]))))
+  mt_assert_decode_none(mt_outer(mt_set(valid, 6, mt_dependencies([
+    ("dep", second_maximum_plus_one)
+  ]))))
+  mt_assert_decode_none(mt_outer(mt_set(valid, 7, mt_closure([
+    ("dep", "validated_metadata_v1", first_maximum_plus_one),
+    ("owner", "provisional_token_stream_v1", maximum)
+  ]))))
+  mt_assert_decode_none(mt_outer(mt_set(valid, 7, mt_closure([
+    ("dep", "validated_metadata_v1", second_maximum_plus_one),
+    ("owner", "provisional_token_stream_v1", maximum)
+  ]))))
+  mt_assert_decode_none(mt_outer(mt_set(mt_set(valid, 5, "0:17:29"), 7, mt_closure([
+    ("dep", "validated_metadata_v1", maximum),
+    ("owner", "provisional_token_stream_v1", "0:17:29")
+  ]))))
 }
 
 test "strict decoder rejects wrong version decimals hostile counts truncation and trailing bytes" {
@@ -375,18 +445,18 @@ test "strict decoder rejects noncanonical structure nested interface and closure
   mt_assert_decode_none(mt_outer(mt_set(fields, 6, "02[]")))
   mt_assert_decode_none(mt_outer(mt_set(fields, 6, "999999999999999999999999[")))
   mt_assert_decode_none(mt_outer(mt_set(fields, 7, mt_closure([
-    ("owner", "provisional_token_stream_v1", "impl-owner"),
-    ("aa", "validated_metadata_v1", "dep")
+    ("owner", "provisional_token_stream_v1", "1:2:3"),
+    ("aa", "validated_metadata_v1", "1:2:4")
   ]))))
   mt_assert_decode_none(mt_outer(mt_set(fields, 7, mt_closure([
-    ("owner", "provisional_token_stream_v1", "impl-owner"),
-    ("owner", "provisional_token_stream_v1", "impl-owner")
+    ("owner", "provisional_token_stream_v1", "1:2:3"),
+    ("owner", "provisional_token_stream_v1", "1:2:3")
   ]))))
   mt_assert_decode_none(mt_outer(mt_set(fields, 8, "vibe-checked-exported-interface-artifact:v1\n0[]trailing")))
   mt_assert_decode_none(mt_outer(mt_set(fields, 8, "vibe-checked-exported-interface-artifact:v2\n0[]")))
 }
 
-test "strict decoder accepts only canonical empty typing errors and fixed body ineligibility" {
+test "strict decoder accepts only caller-attested empty typing errors and fixed body ineligibility" {
   let nested = mt_nested_interface([
     SLet(true, false, "api", None, EInt(1))
   ])
@@ -397,11 +467,11 @@ test "strict decoder accepts only canonical empty typing errors and fixed body i
   mt_assert_decode_none(mt_outer(mt_set(fields, 11, "typed_ir:fragment")))
 }
 
-test "checker failure returns no module artifact bytes" {
+test "wrapper around genuine checker failure returns no module artifact bytes" {
   let produced = handle {
     let stmts = parse_program(lex("export let bad: Int = \"not an int\"\n"))
-    match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", array_empty(), [
-      ("owner", "validated_metadata_v1", "impl")
+    match mt_build_text(stmts, "owner", "validated_metadata_v1", "1:2:3", array_empty(), [
+      ("owner", "validated_metadata_v1", "1:2:3")
     ]) {
       Some(bytes) => Some(bytes),
       None => None

--- a/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
@@ -1,0 +1,416 @@
+//# #1550 bounded shadow-only checked module typing artifact tests.
+
+import @vibe/compiler/checker {
+  check_program_result
+}
+
+import @vibe/compiler/checker/artifacts {
+  canonical_checked_module_typing_artifact_snapshot,
+  checked_exported_interface_artifact_fingerprint_v1,
+  checked_exported_interface_artifact_from_checked_program,
+  checked_module_typing_artifact_fingerprint_v1,
+  checked_module_typing_artifact_from_checked_program,
+  decode_checked_module_typing_artifact_v1,
+  encode_checked_exported_interface_artifact_v1,
+  encode_checked_module_typing_artifact_v1
+}
+
+import @vibe/compiler/core {
+  Expr, Stmt, TypeExpr
+}
+
+import @vibe/compiler/syntax {
+  lex
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import ../parser.vibe {
+  parse_program
+}
+
+fn mt_piece(text: String) -> String {
+  String::concat(__to_string(String::length(text)), String::concat(":", text))
+}
+
+fn mt_dependencies(rows: Array[(String, String)]) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, __to_string(Array::length(rows)))
+  StringBuilder::push(out, "[")
+  let mut i = 0
+  while i < Array::length(rows) {
+    let (locator, fingerprint) = Array::get(rows, i)
+    StringBuilder::push(out, mt_piece(locator))
+    StringBuilder::push(out, mt_piece(fingerprint))
+    i = i + 1
+  }
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+fn mt_closure(rows: Array[(String, String, String)]) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, __to_string(Array::length(rows)))
+  StringBuilder::push(out, "[")
+  let mut i = 0
+  while i < Array::length(rows) {
+    let (locator, kind, identity) = Array::get(rows, i)
+    StringBuilder::push(out, mt_piece(locator))
+    StringBuilder::push(out, mt_piece(kind))
+    StringBuilder::push(out, mt_piece(identity))
+    i = i + 1
+  }
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+fn mt_outer(fields: Array[String]) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, "vibe-checked-module-typing-artifact:v1\n")
+  StringBuilder::push(out, __to_string(Array::length(fields)))
+  StringBuilder::push(out, "[")
+  let mut i = 0
+  while i < Array::length(fields) {
+    StringBuilder::push(out, mt_piece(Array::get(fields, i)))
+    i = i + 1
+  }
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+fn mt_valid_fields(nested: String) -> Array[String] {
+  [
+    "singleton_semantic_module",
+    "owner",
+    "1",
+    "owner",
+    "provisional_token_stream_v1",
+    "impl-owner",
+    mt_dependencies([
+      ("dep", "1:2:3"),
+      ("dep", "1:2:3")
+    ]),
+    mt_closure([
+      ("owner", "provisional_token_stream_v1", "impl-owner")
+    ]),
+    nested,
+    "typing_errors_only:path,start,end,code,message",
+    "vibe-checked-module-typing-artifact:empty-typing-errors:v1",
+    "ineligible:lossless_checked_body_unavailable_v1"
+  ]
+}
+
+fn mt_nested_interface(stmts: Array[Stmt]) -> String with Exception {
+  let checked = check_program_result(stmts)
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(artifact) => encode_checked_exported_interface_artifact_v1(artifact),
+    None => "<none>"
+  }
+}
+
+fn mt_build_text(stmts: Array[Stmt], owner: String, kind: String, identity: String, dependencies: Array[(String, String)], closure: Array[(String, String, String)]) -> Option[String] with Exception {
+  let checked = check_program_result(stmts)
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(interface) => match checked_module_typing_artifact_from_checked_program(checked, owner, kind, identity, dependencies, closure, interface) {
+      Some(artifact) => Some(encode_checked_module_typing_artifact_v1(artifact)),
+      None => None
+    },
+    None => None
+  }
+}
+
+fn mt_assert_decode_none(text: String) -> Unit {
+  match decode_checked_module_typing_artifact_v1(text) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
+fn mt_set(fields: Array[String], at: Int, value: String) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(fields) {
+    if i == at {
+      Array::push(out, value)
+    } else {
+      Array::push(out, Array::get(fields, i))
+    }
+    i = i + 1
+  }
+  out
+}
+
+test "checked module typing artifact round-trips successful singleton authority" {
+  let stmts = [
+    SLet(true, false, "api", Some(TyName("Int")), EInt(1))
+  ]
+  let checked = check_program_result(stmts)
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(interface) => match checked_module_typing_artifact_from_checked_program(checked, "pkg::owner", "provisional_token_stream_v1", "tokens:one", [
+      ("pkg::dep", checked_exported_interface_artifact_fingerprint_v1(interface))
+    ], [
+      ("pkg::owner", "provisional_token_stream_v1", "tokens:one")
+    ], interface) {
+      Some(artifact) => {
+        let text = encode_checked_module_typing_artifact_v1(artifact)
+        match decode_checked_module_typing_artifact_v1(text) {
+          Some(decoded) => {
+            assert(encode_checked_module_typing_artifact_v1(decoded) == text)
+            assert(canonical_checked_module_typing_artifact_snapshot(decoded) == text)
+            assert(checked_module_typing_artifact_fingerprint_v1(decoded) == checked_module_typing_artifact_fingerprint_v1(artifact))
+            assert(String::contains(text, "singleton_semantic_module"))
+            assert(String::contains(text, "typing_errors_only:path,start,end,code,message"))
+            assert(String::contains(text, "empty-typing-errors:v1"))
+            assert(String::contains(text, "ineligible:lossless_checked_body_unavailable_v1"))
+            assert(!String::contains(text, "TypeEnv"))
+            assert(!String::contains(text, "typed_ir"))
+            assert(!String::contains(text, "source_text"))
+            assert(!String::contains(text, "CST"))
+            assert(!String::contains(text, "span"))
+            assert(!String::contains(text, "mtime"))
+            assert(!String::contains(text, "stat_token"))
+            assert(!String::contains(text, "cache_fingerprint"))
+          },
+          None => assert(false)
+        }
+      },
+      None => assert(false)
+    },
+    None => assert(false)
+  }
+}
+
+test "module aggregate requires matching #1548 artifact and propagates missing provenance" {
+  let first = check_program_result([
+    SLet(true, false, "api", None, EInt(1))
+  ])
+  let second = check_program_result([
+    SLet(true, false, "api", None, EString("different"))
+  ])
+  match checked_exported_interface_artifact_from_checked_program(second) {
+    Some(wrong_interface) => match checked_module_typing_artifact_from_checked_program(first, "owner", "validated_metadata_v1", "impl", array_empty(), [
+      ("owner", "validated_metadata_v1", "impl")
+    ], wrong_interface) {
+      Some(_) => assert(false),
+      None => assert(true)
+    },
+    None => assert(false)
+  }
+  let nested = check_program_result([
+    SModule(true, "Public", [
+      SLet(true, false, "value", None, EInt(1))
+    ])
+  ])
+  match checked_exported_interface_artifact_from_checked_program(nested) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
+test "own identity and recorded implementation closure change aggregate identity" {
+  let stmts = [
+    SLet(true, false, "api", None, EInt(1))
+  ]
+  let deps = [
+    ("dep", "1:2:3")
+  ]
+  let first = mt_build_text(stmts, "owner", "validated_metadata_v1", "impl-a", deps, [
+    ("owner", "validated_metadata_v1", "impl-a")
+  ])
+  let second = mt_build_text(stmts, "owner", "validated_metadata_v1", "impl-b", deps, [
+    ("owner", "validated_metadata_v1", "impl-b")
+  ])
+  let closure_changed = mt_build_text(stmts, "owner", "validated_metadata_v1", "impl-a", deps, [
+    ("dep", "validated_metadata_v1", "embedded-new"),
+    ("owner", "validated_metadata_v1", "impl-a")
+  ])
+  match (first, second, closure_changed) {
+    (Some(a), Some(b), Some(c)) => {
+      assert(a != b)
+      assert(a != c)
+      assert(String::contains(a, mt_piece(mt_dependencies(deps))))
+      assert(String::contains(c, mt_piece(mt_dependencies(deps))))
+    },
+    _ => assert(false)
+  }
+}
+
+test "dependency typing assumptions preserve order and duplicate occurrences" {
+  let deps = [
+    ("z", "1:2:3"),
+    ("aa", "4:5:6"),
+    ("z", "1:2:3")
+  ]
+  match mt_build_text([
+    SLet(true, false, "api", None, EInt(1))
+  ], "owner", "validated_metadata_v1", "impl", deps, [
+    ("owner", "validated_metadata_v1", "impl")
+  ]) {
+    Some(text) => {
+      assert(String::contains(text, mt_piece(mt_dependencies(deps))))
+      match decode_checked_module_typing_artifact_v1(text) {
+        Some(decoded) => assert(encode_checked_module_typing_artifact_v1(decoded) == text),
+        None => assert(false)
+      }
+    },
+    None => assert(false)
+  }
+}
+
+test "module builder snapshots caller-owned row arrays" {
+  let checked = check_program_result([
+    SLet(true, false, "api", None, EInt(1))
+  ])
+  let dependencies = [
+    ("dep", "1:2:3")
+  ]
+  let closure = [
+    ("owner", "validated_metadata_v1", "impl")
+  ]
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(interface) => match checked_module_typing_artifact_from_checked_program(checked, "owner", "validated_metadata_v1", "impl", dependencies, closure, interface) {
+      Some(artifact) => {
+        let before = encode_checked_module_typing_artifact_v1(artifact)
+        Array::set(dependencies, 0, ("mutated", "9:9:9"))
+        Array::set(closure, 0, ("mutated", "validated_metadata_v1", "mutated"))
+        assert(encode_checked_module_typing_artifact_v1(artifact) == before)
+      },
+      None => assert(false)
+    },
+    None => assert(false)
+  }
+}
+
+test "recorded implementation closure sorts lexically and rejects duplicate or inconsistent owners" {
+  let stmts = [
+    SLet(true, false, "api", None, EInt(1))
+  ]
+  let lexical = [
+    ("aa", "validated_metadata_v1", "dep-impl"),
+    ("b", "validated_metadata_v1", "owner-impl")
+  ]
+  match mt_build_text(stmts, "b", "validated_metadata_v1", "owner-impl", array_empty(), [
+    ("b", "validated_metadata_v1", "owner-impl"),
+    ("aa", "validated_metadata_v1", "dep-impl")
+  ]) {
+    Some(text) => assert(String::contains(text, mt_piece(mt_closure(lexical)))),
+    None => assert(false)
+  }
+  match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", array_empty(), [
+    ("owner", "validated_metadata_v1", "impl"),
+    ("owner", "validated_metadata_v1", "impl")
+  ]) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", array_empty(), [
+    ("other", "validated_metadata_v1", "impl")
+  ]) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", array_empty(), [
+    ("owner", "validated_metadata_v1", "different")
+  ]) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
+test "module builder fails closed for invalid tags locators and interface fingerprints" {
+  let stmts = [
+    SLet(true, false, "api", None, EInt(1))
+  ]
+  match mt_build_text(stmts, "owner", "typed_ir", "impl", array_empty(), [
+    ("owner", "typed_ir", "impl")
+  ]) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match mt_build_text(stmts, "owner\nother", "validated_metadata_v1", "impl", array_empty(), [
+    ("owner\nother", "validated_metadata_v1", "impl")
+  ]) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", [
+    ("dep", "01:2:3")
+  ], [
+    ("owner", "validated_metadata_v1", "impl")
+  ]) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
+test "strict decoder rejects wrong version decimals hostile counts truncation and trailing bytes" {
+  let nested = mt_nested_interface([
+    SLet(true, false, "api", None, EInt(1))
+  ])
+  let canonical = mt_outer(mt_valid_fields(nested))
+  match decode_checked_module_typing_artifact_v1(canonical) {
+    Some(decoded) => assert(encode_checked_module_typing_artifact_v1(decoded) == canonical),
+    None => assert(false)
+  }
+  let header = "vibe-checked-module-typing-artifact:v1\n"
+  let suffix = canonical[String::length(header): String::length(canonical)]
+  mt_assert_decode_none(String::concat("vibe-checked-module-typing-artifact:v2\n", suffix))
+  mt_assert_decode_none(String::concat(String::concat(header, "012"), canonical[String::length(header) + 2: String::length(canonical)]))
+  mt_assert_decode_none("vibe-checked-module-typing-artifact:v1\n12[999999999999999999999999999:")
+  mt_assert_decode_none(canonical[0: String::length(canonical) - 1])
+  mt_assert_decode_none(String::concat(canonical, "trailing"))
+}
+
+test "strict decoder rejects noncanonical structure nested interface and closure order" {
+  let nested = mt_nested_interface([
+    SLet(true, false, "api", None, EInt(1))
+  ])
+  let fields = mt_valid_fields(nested)
+  mt_assert_decode_none(mt_outer(mt_set(fields, 0, "multi_member_scc")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 2, "2")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 3, "other")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 4, "typed_ir")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 6, "02[]")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 6, "999999999999999999999999[")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 7, mt_closure([
+    ("owner", "provisional_token_stream_v1", "impl-owner"),
+    ("aa", "validated_metadata_v1", "dep")
+  ]))))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 7, mt_closure([
+    ("owner", "provisional_token_stream_v1", "impl-owner"),
+    ("owner", "provisional_token_stream_v1", "impl-owner")
+  ]))))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 8, "vibe-checked-exported-interface-artifact:v1\n0[]trailing")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 8, "vibe-checked-exported-interface-artifact:v2\n0[]")))
+}
+
+test "strict decoder accepts only canonical empty typing errors and fixed body ineligibility" {
+  let nested = mt_nested_interface([
+    SLet(true, false, "api", None, EInt(1))
+  ])
+  let fields = mt_valid_fields(nested)
+  mt_assert_decode_none(mt_outer(mt_set(fields, 9, "message,path")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 10, "non-empty:error")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 11, "TypeEnv-v5:target")))
+  mt_assert_decode_none(mt_outer(mt_set(fields, 11, "typed_ir:fragment")))
+}
+
+test "checker failure returns no module artifact bytes" {
+  let produced = handle {
+    let stmts = parse_program(lex("export let bad: Int = \"not an int\"\n"))
+    match mt_build_text(stmts, "owner", "validated_metadata_v1", "impl", array_empty(), [
+      ("owner", "validated_metadata_v1", "impl")
+    ]) {
+      Some(bytes) => Some(bytes),
+      None => None
+    }
+  } with Exception {
+    Throw(_) => None
+  }
+  match produced {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}


### PR DESCRIPTION
## Summary
- define strict shadow-only `CheckedModuleTypingArtifact` v1
- keep ordered dependency interface assumptions separate from recorded implementation closure
- embed and strictly revalidate the existing checked exported-interface artifact
- represent checked-body availability explicitly as ineligible
- encode only caller-attested empty successful typing diagnostics
- support only singleton semantic module/SCC units in v1

The builder is deliberately named `shadow_unattested_*`: `CheckedProgram` is currently transparent, so this artifact does not prove successful checking. There is no publisher, cache consumer, planner hook, or production reuse path in this slice.

## Non-goals
- no TypeDb/runtime/module-worker changes
- no persistent namespace/cache key
- no interface-v2 or TypeEnv-v5 change
- no typed-IR fabrication
- no artifact-input trace/planner/reuse decision change

## Validation
- 13 focused codec/schema tests, including hostile bounds/order/truncation/nested artifacts: passed
- test-local: passed
- formatter, generated freshness, diff: passed
- independent review: safe to integrate

Refs #1550