### PR TITLE
Land bounded coverage, perf, wasm-gc, and incremental slices

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -294,11 +294,13 @@ local testSimdEmitWasmtime =
 local testCoverageScripts = new Task {
   name = "test-coverage-scripts"
   cmd =
-    "node --test scripts/coverage_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/select_test_shard.test.mjs && python3 scripts/coverage_suite_report_test.py"
+    "node --test scripts/coverage_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/select_test_shard.test.mjs && python3 scripts/coverage_suite_report_test.py && bash scripts/tests/coverage_drivers_test.sh"
   inputs {
     "scripts/**/*.mjs"
     "scripts/coverage_suite_report.py"
     "scripts/coverage_suite_report_test.py"
+    "scripts/coverage_drivers.sh"
+    "scripts/tests/coverage_drivers_test.sh"
   }
 }
 

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -120,13 +120,16 @@ local testArtifactInputTrace = new Task {
   }
 }
 
-local testBenchReport = new Task {
-  name = "test-bench-report"
-  description = "runner-calibration plausibility and advisory-delta report tests"
-  cmd = "node --test scripts/bench_report.test.mjs"
+local testCoverageDriverExposure = new Task {
+  name = "test-coverage-driver-exposure"
+  description = "exact-path coverage-driver exposure positive/negative integration test"
+  cmd = "bash scripts/tests/coverage_driver_exposure_test.sh"
   inputs {
-    "scripts/bench_report.mjs"
-    "scripts/bench_report.test.mjs"
+    "scripts/tests/coverage_driver_exposure_test.sh"
+    "scripts/coverage/cov_units.vibe"
+    "lib/@vibe/compiler/cli_adapter.vibe"
+    "lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe"
+    "lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg"
   }
 }
 
@@ -995,7 +998,6 @@ local releaseCheck = new Task {
     selfhostOnlyGate
     checkVibeFmt
     checkMethodStyleNaming
-    testBenchReport
     doctestGated
     checkExamplesTypecheck
     checkPlaygroundPresets
@@ -1018,7 +1020,7 @@ tasks {
   testIncrementalInvalidationOracle
   testIncrementalInvalidationTrace
   testArtifactInputTrace
-  testBenchReport
+  testCoverageDriverExposure
   formalSelfhostOracle
   formalSelfhostIncrementalOracle
   testParallelSchedulerPrototype

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -300,7 +300,10 @@ local testWasiHttpP3Full =
   scriptTask("test-wasi-http-p3-full", "scripts/test_wasi_http_p3_full_gate.sh")
 local testWasiP3Guarantee = scriptTask("test-wasi-p3", "scripts/test_wasi_p3_guarantee_gate.sh")
 local testWasiStdinProviderSource =
-  scriptTask("test-wasi-stdin-provider-source", "scripts/test_wasi_cli_stdin_provider_source_component_gate.sh")
+  scriptTask(
+    "test-wasi-stdin-provider-source",
+    "scripts/test_wasi_cli_stdin_provider_source_component_gate.sh",
+  )
 local testSimdEmitWasmtime =
   scriptTask("test-simd-emit-wasmtime", "scripts/test_simd_emit_wasmtime.sh")
 

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -120,6 +120,16 @@ local testArtifactInputTrace = new Task {
   }
 }
 
+local testBenchReport = new Task {
+  name = "test-bench-report"
+  description = "runner-calibration plausibility and advisory-delta report tests"
+  cmd = "node --test scripts/bench_report.test.mjs"
+  inputs {
+    "scripts/bench_report.mjs"
+    "scripts/bench_report.test.mjs"
+  }
+}
+
 local formalSelfhostOracle = new Task {
   name = "formal-selfhost-oracle"
   description =
@@ -985,6 +995,7 @@ local releaseCheck = new Task {
     selfhostOnlyGate
     checkVibeFmt
     checkMethodStyleNaming
+    testBenchReport
     doctestGated
     checkExamplesTypecheck
     checkPlaygroundPresets
@@ -1007,6 +1018,7 @@ tasks {
   testIncrementalInvalidationOracle
   testIncrementalInvalidationTrace
   testArtifactInputTrace
+  testBenchReport
   formalSelfhostOracle
   formalSelfhostIncrementalOracle
   testParallelSchedulerPrototype

--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -163,11 +163,17 @@ the baseline's to get a `runnerFactor`, and divides every advisory
 that's uniformly N% slower today no longer shows up as an N% regression on
 every single benchmark. Deterministic metrics (heap, sizes, bytes/op) are
 never normalized; they don't depend on runner speed to begin with.
-Normalization is skipped, falling back to raw deltas with a note in the
-report, when either snapshot lacks calibration data (e.g. an older
-snapshot predating this feature) or `seed_sha256` differs between them (a
-bootstrap bump landed between the two commits, making the calibration
-readings themselves not comparable).
+
+A single calibration series is not trusted outside the inclusive
+**0.85–1.18×** plausibility range. Such a reading is reported as a `runner
+mismatch`, and advisory rows show raw deltas rather than normalized warning
+conclusions. This is deliberately fail-open: an uncorrected noisy reading is
+more honest than dividing every row by an implausible factor. Normalization is
+also skipped, falling back to raw deltas with a note in the report, when either
+snapshot lacks calibration data (e.g. an older snapshot predating this
+feature) or any recorded calibration input hash differs between them (for
+example, a bootstrap bump landed between the two commits, making the readings
+not comparable).
 
 To track a new micro bench, add its file to `tracked_benches.txt` (keep the
 whole list fast — it runs on every PR). To track a new size sample, drop a

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -244,6 +244,13 @@ flatten を最終出力に使わないのは、それが一世代古く、`merge
 ない) から。この切り替え時に、seed だけから作った5成果物が従来の commit 済み
 コピーと **byte-identical** であることを確認している。
 
+`coverage_drivers.sh` の #1633 exact-path exposure も同じ世代境界を守る。
+新しい内部 mode は current source から作る `compiler_cov.wasm` が実行し、driver
+entry から DCE した通常の vibe source を出力する。固定 seed が担当するのはその
+出力の coverage compile だけであり、新しい mode を seed 自身が理解する必要は
+ない。このため syntax 追加も seed bump も伴わず、通常の
+`VIBE_EMIT_MERGED_SOURCE` 出力も変更しない。
+
 ### なぜ tracking をやめたか
 
 - compiler source に触る PR が2本あれば**必ず**5ファイル全部で衝突し、

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -206,6 +206,18 @@ in-scope）を直接叩ける。型/trait/env に加え以下も edge-case 入�
 
 #### 80% 達成（no-DCE merged source + direct-call drivers）
 
+> **#1633 migration status:** the historical raw concatenation described below
+> is being retired one driver at a time. `cov_units.vibe` now uses compiler-owned
+> exact-path value exposure: its imports name one `.vibe` file in the collected
+> compiler closure, the production export/private namespacing plan determines
+> the final target name, and the existing shadow-aware import rewriter updates
+> driver references before entry-based DCE. Missing, duplicate, out-of-closure,
+> type/constructor, mutable-global, extern, method, and collision requests fail
+> with a diagnostic. The internal mode (`VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1` +
+> `VIBE_COVERAGE_DRIVER_PATH`) is invoked only by `coverage_drivers.sh`; it does
+> not widen normal import visibility or change `VIBE_EMIT_MERGED_SOURCE` output.
+> The other drivers retain the legacy base until their own reviewed slices.
+
 **分岐 5711/6694 (85.32%)**・関数 1037/1176 (88.18%) に到達（85% = 5690 に対し +21 のマージン、下限ガード 80% に対し +355）。
 74% で頭打ちだった主因（コンパイラ自身の unit test 120/148 が builtins⇄checker
 の循環 re-export で FS-compile 不能）を、**循環 re-export を直さずに**回避した。

--- a/fixtures/gc_direct_array_abi_export_fallback_test.vibe
+++ b/fixtures/gc_direct_array_abi_export_fallback_test.vibe
@@ -1,0 +1,15 @@
+// #1541 export fallback: public declarations cross a host/component boundary
+// whose ABI remains tagged i64. An exported Array[Int] function therefore
+// disables the private direct-reference island for the complete component.
+
+export let exported_array_identity: (Array[Int]) -> Array[Int] = (values) -> values
+
+let internal_array_identity: (Array[Int]) -> Array[Int] = (values) -> values
+
+test "gc direct array ABI falls back for an exported declaration" {
+  let values = internal_array_identity([
+    40,
+    2
+  ])
+  assert(Array::get(exported_array_identity(values), 1) == 2)
+}

--- a/fixtures/gc_direct_array_abi_fallback_test.vibe
+++ b/fixtures/gc_direct_array_abi_fallback_test.vibe
@@ -1,0 +1,20 @@
+// #1541 fallback pair: the generic call would require a representation
+// conversion that does not exist. The complete component must therefore keep
+// the established tagged-i64 ABI rather than mixing one typed signature into
+// an otherwise erased/generic path.
+
+fn generic_array_identity[T](values: Array[Int], marker: T) -> Array[Int] {
+  let _ = marker
+  values
+}
+
+let direct_array_identity_fallback: (Array[Int]) -> Array[Int] = (values) -> values
+
+test "gc direct array ABI falls back around a generic boundary" {
+  let input = [
+    40,
+    2
+  ]
+  let output = generic_array_identity(input, 7)
+  assert(Array::get(direct_array_identity_fallback(output), 0) == 40)
+}

--- a/fixtures/gc_direct_array_abi_shadow_fallback_test.vibe
+++ b/fixtures/gc_direct_array_abi_shadow_fallback_test.vibe
@@ -1,0 +1,16 @@
+// #1541 spelling fallback: backend_call intercepts `print` before ordinary
+// func-table dispatch. A user function with that spelling must therefore keep
+// the whole component on the established tagged-i64 boundary ABI.
+
+let print: (Array[Int]) -> Int = (values) -> Array::length(values)
+
+let shadow_array_identity: (Array[Int]) -> Array[Int] = (values) -> values
+
+test "gc direct array ABI falls back for spelling-routed user functions" {
+  let values = shadow_array_identity([
+    40,
+    2
+  ])
+  let _ = print(values)
+  assert(true)
+}

--- a/fixtures/gc_direct_array_abi_test.vibe
+++ b/fixtures/gc_direct_array_abi_test.vibe
@@ -1,0 +1,22 @@
+// #1541 positive island: Array[Int] stays a typed wasm-gc reference across
+// non-generic direct parameters, results, calls, and plain local aliases.
+
+let direct_array_identity: (Array[Int]) -> Array[Int] = (values) -> {
+  let alias = values
+  alias
+}
+
+let direct_array_sum: (Array[Int]) -> Int = (values) -> {
+  Array::length(values) + Array::get(values, 0) + Array::get(values, 1)
+}
+
+test "gc direct array ABI carries parameters, results, and aliases" {
+  let input = [
+    40,
+    1
+  ]
+  let alias = input
+  let output = direct_array_identity(alias)
+  assert(direct_array_sum(output) == 43)
+  assert(Array::get(direct_array_identity(output), 0) == 40)
+}

--- a/fixtures/gc_heap_churn_test.vibe
+++ b/fixtures/gc_heap_churn_test.vibe
@@ -169,7 +169,7 @@ test "gc lane: an array a deeper lambda captures stays on the linear fallback" {
   assert(lambda_array_captured_by_deeper_lambda() == 7)
 }
 
-test "gc lane: aliases, push, and return retain the linear fallback" {
+test "gc lane: aliases work in the native lane while push and return can fall back" {
   assert(escaped_alias() == 7)
   assert(pushed() == 9)
   assert(Array::get(returned(), 0) == 8)

--- a/lib/@vibe/compiler/_cli_gc_entry.vibe
+++ b/lib/@vibe/compiler/_cli_gc_entry.vibe
@@ -7,7 +7,7 @@ import @vibe/compiler/checker {
   check_program
 }
 import @vibe/compiler/codegen/gc {
-  compile_wasi_module_gc, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_safe, gc_to_string_resolves_to_show_wrapper
 }
 
 //# Functions
@@ -43,7 +43,8 @@ fn cli_main() -> Int with Exception + Fs + Env {
     // needs (see its doc comment / gc_only.vibe's call for why ORDER
     // matters when a strip pass IS in the pipeline).
     let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
-    let bytes = compile_wasi_module_gc(stmts, entry_name, gc_to_string_is_wrapper)
+    let direct_abi_pre_erasure_safe = gc_direct_abi_pre_erasure_safe(stmts)
+    let bytes = compile_wasi_module_gc(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_pre_erasure_safe)
     Fs::write_bytes(output_path, bytes)
     0
   }

--- a/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
@@ -4,8 +4,10 @@
 // construct one and obtain this artifact, so neither the schema nor the
 // `shadow_unattested` builder proves checker success, cryptographically or
 // through the type system. The trusted first producer lives at the opaque
-// `runtime::ModuleOutcome` boundary: it invokes the real checker itself and
-// retains canonical bytes only in a successful outcome. This package's builder
+// opt-in `runtime::check_module_with_typing_artifact_observation` boundary: it
+// invokes the real checker itself and retains canonical bytes only in a successful
+// opaque ModuleOutcome. The ordinary production check avoids unconsumed shadow
+// allocation. This package's builder
 // remains explicitly unattested and cannot authorize that observation. Nothing
 // publishes these bytes. There is no cache, reuse, planner, persistent trace,
 // CLI, or filesystem read/write path for them. Values

--- a/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
@@ -3,10 +3,12 @@
 // IMPORTANT: `CheckedProgram` is transparent in this slice. Callers can manually
 // construct one and obtain this artifact, so neither the schema nor the
 // `shadow_unattested` builder proves checker success, cryptographically or
-// through the type system. Only a future trusted producer invoked after
-// `check_program_result` succeeds may publish these bytes; this slice adds no
-// producer or publisher. It is observation-only: no cache, reuse, planner,
-// trace, CLI, filesystem, or module-worker path reads or publishes it. Values
+// through the type system. The trusted first producer lives at the opaque
+// `runtime::ModuleOutcome` boundary: it invokes the real checker itself and
+// retains canonical bytes only in a successful outcome. This package's builder
+// remains explicitly unattested and cannot authorize that observation. Nothing
+// publishes these bytes. There is no cache, reuse, planner, persistent trace,
+// CLI, or filesystem read/write path for them. Values
 // describe exactly one semantic module and therefore one singleton SCC.
 //
 // Dependency interface assumptions are ordered typing inputs. They deliberately

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -20,10 +20,11 @@ generated_hash =
 // Bounded unattested shadow-only singleton semantic-module/SCC aggregate.
 // CheckedProgram is transparent and manually constructible, so neither this
 // schema nor its builder cryptographically or type-system-proves checker success.
-// Canonical empty diagnostics mean only a caller-attested successful typing-error
-// set, not proof. Only a future trusted producer
-// called after check_program_result succeeds may publish; this slice has no
-// producer or publisher and no cache/reuse/planner/trace integration.
+// Canonical empty diagnostics here mean only a caller-attested successful
+// typing-error set, not proof. The first trusted producer is owned by runtime's
+// opaque ModuleOutcome and runs the real checker before retaining canonical
+// bytes in memory. This package still has no publisher and no
+// cache/reuse/planner/persistent-trace integration.
 opaque type CheckedModuleTypingArtifact
 fn shadow_unattested_checked_module_typing_artifact_from_checked_program(checked: CheckedProgram, module_locator: String, implementation_kind: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact]
 fn encode_checked_module_typing_artifact_v1(artifact: CheckedModuleTypingArtifact) -> String

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -9,6 +9,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   compile_source_wasi_only_coverage,
   compile_source_wasi_only_rc,
   compile_source_wasi_only_rc_shadow,
+  coverage_driver_program_source_fs,
   maybe_wrap_stdin_provider_core,
   merged_program_source_fs,
   reject_stdin_provider_core
@@ -1289,6 +1290,41 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   // Adding this adapter -> merge_sources import edge is safe now that the
   // committed bundle is itself merge-built (zero duplicate defs, no
   // first-match roulette to reshuffle).
+  // #1633 internal coverage-driver exposure. This is deliberately a separate
+  // mode from VIBE_EMIT_MERGED_SOURCE: ordinary flatten output remains byte-
+  // for-byte governed by merged_program_source_fs, while this mode appends one
+  // driver after resolving its exact-file value imports through the same
+  // production rename plan. It is not surfaced as an end-user CLI command.
+  if Env::get("VIBE_EMIT_COVERAGE_DRIVER_SOURCE") == "1" {
+    return handle {
+      if Env::get("VIBE_EMIT_MERGED_SOURCE") == "1" {
+        throw("VIBE_EMIT_COVERAGE_DRIVER_SOURCE cannot be combined with VIBE_EMIT_MERGED_SOURCE")
+      } else {
+        ()
+      }
+      let driver_path = own_host_string(Env::get("VIBE_COVERAGE_DRIVER_PATH"))
+      if driver_path == "" {
+        throw("VIBE_EMIT_COVERAGE_DRIVER_SOURCE requires VIBE_COVERAGE_DRIVER_PATH")
+      } else {
+        ()
+      }
+      if entry_name == "" {
+        throw("VIBE_EMIT_COVERAGE_DRIVER_SOURCE requires the driver entry name")
+      } else {
+        ()
+      }
+      let merged_src = coverage_driver_program_source_fs(input_path, driver_path)
+      // Prune before the pinned seed type-checks the result. The full no-DCE
+      // compiler contains intentionally dormant generic scaffolding that is
+      // not a valid standalone program; the driver and every exact target it
+      // reaches remain in the emitted ordinary source.
+      let driver_src = build_module_source_from_source(merged_src, entry_name)
+      Fs::write_file(output_path, driver_src)
+      0
+    } with Exception {
+      Throw(msg) => emit_compile_diag(output_path, msg)
+    }
+  }
   if Env::get("VIBE_EMIT_MERGED_SOURCE") == "1" {
     return handle {
       let merged_src = merged_program_source_fs(input_path)

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -879,6 +879,18 @@ export struct CompileCtxGc {
   // the rows stop lining up with LambdaTable.bodies. Appended in
   // record_lambda_meta_gc, which is the single writer of that table.
   gc_lambda_native_array_locals: Array[Array[Int]];
+  // #1541: conservative, module-wide direct-call reference ABI evidence.
+  // Empty tables mean the whole module fell back to the tagged-i64 ABI.
+  // When populated, rows are parallel: each named top-level function has one
+  // parameter-reference row and one result-reference flag. Only direct calls
+  // may consume this evidence; closures, globals, generics, aggregates, and
+  // unsupported control-flow crossings make the producer leave all rows empty.
+  gc_direct_abi_names: Array[String];
+  gc_direct_abi_param_refs: Array[Array[Bool]];
+  gc_direct_abi_return_refs: Array[Bool];
+  // Per-body result expectation. This is true only while compiling a proven
+  // direct-ABI function whose wasm result is `(ref null $native_i64_array)`.
+  gc_direct_abi_current_return_ref: Bool;
   // #1015: computed ONCE per compile (backend_body.vibe's
   // gc_to_string_resolves_to_show_wrapper, before any CompileCtxGc is
   // constructed) and copied unchanged into every ctx thereafter (including

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -13,6 +13,7 @@ import @vibe/compiler/core {
   bytebuf_push_section,
   bytebuf_push_vec_header,
   bytebuf_to_bytes,
+  expr_children,
   leb128_encode_s64,
   leb128_encode_u32,
   rewrite_top_level_fn_alias_refs,
@@ -237,6 +238,270 @@ fn gc_type_expr_is_unit(t: TypeExpr) -> Bool {
   }
 }
 
+/// #1541 deliberately starts with the single element representation already
+/// implemented by `$native_i64_array`. Nested arrays and erased/generic
+/// element names stay on the tagged-i64 ABI until an explicit conversion
+/// exists; guessing here would create an untraceable reference in an i64 cell.
+fn gc_direct_abi_is_native_array_type(t: TypeExpr) -> Bool {
+  match t {
+    TyApp(name, args) => name == "Array" && Array::length(args) == 1 && (match Array::get(args, 0) {
+      TyName(elem) => elem == "Int",
+      _ => false
+    }),
+    _ => false
+  }
+}
+
+fn gc_direct_abi_type_mentions_array(t: TypeExpr) -> Bool {
+  match t {
+    TyApp(name, args) => {
+      let mut found = name == "Array"
+      let mut i = 0
+      while i < Array::length(args) {
+        if gc_direct_abi_type_mentions_array(Array::get(args, i)) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    TyFn(params, ret, _) => {
+      let mut found = gc_direct_abi_type_mentions_array(ret)
+      let mut i = 0
+      while i < Array::length(params) {
+        if gc_direct_abi_type_mentions_array(Array::get(params, i)) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    _ => false
+  }
+}
+
+fn gc_direct_abi_name_index(names: Array[String], name: String) -> Int {
+  let mut i = 0
+  let mut found = -1
+  while i < Array::length(names) {
+    if found < 0 && Array::get(names, i) == name {
+      found = i
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn gc_direct_abi_name_in(names: Array[String], name: String) -> Bool {
+  gc_direct_abi_name_index(names, name) >= 0
+}
+
+/// Static representation proof used before emitting any typed function type.
+/// Result: -1 = unsupported crossing, 0 = tagged i64, 1 = native array ref.
+/// Once a module has a candidate reference signature, an array literal bound
+/// by `let` is analyzed in that same lane. Any unsupported use rejects the
+/// complete module evidence table; codegen then retries the whole component
+/// through its pre-existing tagged-i64 ABI. There is no mixed partial island.
+fn gc_direct_abi_expr_kind(expr: Expr, native_names: Array[String], abi_names: Array[String], abi_param_refs: Array[Array[Bool]], abi_return_refs: Array[Bool]) -> Int {
+  match expr {
+    EIdent(name, _) => if gc_direct_abi_name_in(native_names, name) {
+      1
+    } else if gc_direct_abi_name_in(abi_names, name) {
+      // A typed function used as a value would enter the universal closure
+      // table. #1541 has no typed call_indirect lane, so reject the module.
+      -1
+    } else {
+      0
+    },
+    EArray(elems) => {
+      let mut ok = true
+      let mut i = 0
+      while i < Array::length(elems) {
+        if gc_direct_abi_expr_kind(Array::get(elems, i), native_names, abi_names, abi_param_refs, abi_return_refs) != 0 {
+          ok = false
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      if ok {
+        1
+      } else {
+        -1
+      }
+    },
+    ELet(name, value, body, _) => match value {
+      EArray(_) => {
+        let floor = Array::length(native_names)
+        Array::push(native_names, name)
+        let native_body = gc_direct_abi_expr_kind(body, native_names, abi_names, abi_param_refs, abi_return_refs)
+        Array::truncate(native_names, floor)
+        native_body
+      },
+      _ => {
+        let value_kind = gc_direct_abi_expr_kind(value, native_names, abi_names, abi_param_refs, abi_return_refs)
+        if value_kind < 0 {
+          -1
+        } else if value_kind == 1 {
+          let floor = Array::length(native_names)
+          Array::push(native_names, name)
+          let body_kind = gc_direct_abi_expr_kind(body, native_names, abi_names, abi_param_refs, abi_return_refs)
+          Array::truncate(native_names, floor)
+          body_kind
+        } else {
+          gc_direct_abi_expr_kind(body, native_names, abi_names, abi_param_refs, abi_return_refs)
+        }
+      }
+    },
+    ECall(callee, args, _) => match callee {
+      EIdent(fname, _) => {
+        let abi_idx = gc_direct_abi_name_index(abi_names, fname)
+        if abi_idx >= 0 {
+          let refs = Array::get(abi_param_refs, abi_idx)
+          if Array::length(refs) != Array::length(args) {
+            -1
+          } else {
+            let mut ok = true
+            let mut i = 0
+            while i < Array::length(args) {
+              let kind = gc_direct_abi_expr_kind(Array::get(args, i), native_names, abi_names, abi_param_refs, abi_return_refs)
+              if kind < 0 || (Array::get(refs, i) && kind != 1) || (!Array::get(refs, i) && kind != 0) {
+                ok = false
+              } else {
+                ()
+              }
+              i = i + 1
+            }
+            if ok {
+              if Array::get(abi_return_refs, abi_idx) {
+                1
+              } else {
+                0
+              }
+            } else {
+              -1
+            }
+          }
+        } else {
+          let native_array_op = (fname == "Array::length" && Array::length(args) == 1) || (fname == "Array::get" && Array::length(args) == 2) || (fname == "Array::set" && Array::length(args) == 3)
+          let mut saw_native = false
+          let mut ok = true
+          let mut i = 0
+          while i < Array::length(args) {
+            let kind = gc_direct_abi_expr_kind(Array::get(args, i), native_names, abi_names, abi_param_refs, abi_return_refs)
+            if kind < 0 {
+              ok = false
+            } else if kind == 1 {
+              if i == 0 && native_array_op {
+                saw_native = true
+              } else {
+                ok = false
+              }
+            } else {
+              ()
+            }
+            i = i + 1
+          }
+          if ok {
+            // Native Array length/get/set all produce an i64/Unit result.
+            let _ = saw_native
+            0
+          } else {
+            -1
+          }
+        }
+      },
+      _ => {
+        let callee_kind = gc_direct_abi_expr_kind(callee, native_names, abi_names, abi_param_refs, abi_return_refs)
+        let mut ok = callee_kind == 0
+        let mut i = 0
+        while i < Array::length(args) {
+          if gc_direct_abi_expr_kind(Array::get(args, i), native_names, abi_names, abi_param_refs, abi_return_refs) != 0 {
+            ok = false
+          } else {
+            ()
+          }
+          i = i + 1
+        }
+        if ok {
+          0
+        } else {
+          -1
+        }
+      }
+    },
+    EReturn(value) => gc_direct_abi_expr_kind(value, native_names, abi_names, abi_param_refs, abi_return_refs),
+    _ => {
+      let children = expr_children(expr)
+      let mut ok = true
+      let mut i = 0
+      while i < Array::length(children) {
+        if gc_direct_abi_expr_kind(Array::get(children, i), native_names, abi_names, abi_param_refs, abi_return_refs) != 0 {
+          ok = false
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      if ok {
+        0
+      } else {
+        -1
+      }
+    }
+  }
+}
+
+fn gc_direct_abi_expr_mentions_name(expr: Expr, names: Array[String]) -> Bool {
+  match expr {
+    EIdent(name, _) => gc_direct_abi_name_in(names, name),
+    _ => {
+      let children = expr_children(expr)
+      let mut found = false
+      let mut i = 0
+      while i < Array::length(children) {
+        if gc_direct_abi_expr_mentions_name(Array::get(children, i), names) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    }
+  }
+}
+
+fn emit_gc_direct_func_type(buf: Bytes, param_refs: Array[Bool], return_ref: Bool, native_array_type_idx: Int) -> Unit {
+  bytebuf_push(buf, 96)
+  // User functions always carry the hidden closure environment parameter.
+  leb128_encode_u32(buf, Array::length(param_refs) + 1)
+  let mut i = 0
+  while i < Array::length(param_refs) {
+    if Array::get(param_refs, i) {
+      bytebuf_push(buf, 99)
+      leb128_encode_u32(buf, native_array_type_idx)
+    } else {
+      bytebuf_push(buf, 126)
+    }
+    i = i + 1
+  }
+  bytebuf_push(buf, 126)
+  leb128_encode_u32(buf, 1)
+  if return_ref {
+    bytebuf_push(buf, 99)
+    leb128_encode_u32(buf, native_array_type_idx)
+  } else {
+    bytebuf_push(buf, 126)
+  }
+}
+
 /// #805 (ADR-0072): inline wasm (`fn f(..) -> Int = wasm "..."`, carried as
 /// the parser-internal `%wasm("<WAT>")` marker body) is LINEAR-BACKEND ONLY —
 /// the WAT text is written against the linear backend's raw 62-bit tagged i64
@@ -379,7 +644,80 @@ fn gc_body_is_to_string_forward(body: Expr, pname: String) -> Bool {
   }
 }
 
-export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool) -> Bytes with Exception {
+/// Preserve the one pre-erasure fact the direct Array ABI must consume.
+/// `strip_generic_type_params` deliberately removes every EFn binder, so the
+/// gc-only source pipeline computes this before stripping and passes it into
+/// codegen. One generic declaration disables the component-wide island: there
+/// is no trustworthy post-strip way to distinguish its erased signature.
+export fn gc_direct_abi_pre_erasure_safe(stmts: Array[Stmt]) -> Bool {
+  let mut i = 0
+  let mut safe = true
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, _, _, EFn(type_params, _, _, _, _, _)) => if Array::length(type_params) > 0 {
+        safe = false
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  safe
+}
+
+/// Names intercepted by spelling before ordinary func-table dispatch in
+/// backend_call.vibe. A user declaration with any of these spellings makes
+/// typed user signatures unsafe: the call site can otherwise take a builtin
+/// path while the body/type sections describe a `(ref null array)` user ABI.
+/// Keep this list in sync with the `fname == ...` dispatch chain there.
+fn gc_direct_abi_name_has_spelling_lowering(name: String) -> Bool {
+  name == "Array::length" || name == "Array::get" || name == "Array::set" ||
+  name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk" ||
+  name == "__slice" || name == "__index" || name == "__set_field" || name == "__rec_field" || name == "__len" ||
+  name == "Array::slice" || name == "Array::concat" || name == "Array::truncate" || name == "Array::push_all" ||
+  name == "perform" || name == "eq" || name == "not" ||
+  name == "Double::from_i64_bits" || name == "Double::to_i64_bits_lo" || name == "Double::to_i64_bits_hi" ||
+  name == "__to_string" || name == "to_string" || name == "Int::to_string" ||
+  name == "MapBuilder::new" || name == "MapBuilder::set" || name == "MapBuilder::freeze" || name == "MapBuilder::has_key" || name == "MapBuilder::get" ||
+  name == "Map::set" || name == "Map::get" || name == "Map::has_key" || name == "map_has" || name == "Map::keys" ||
+  name == "StringBuilder::new" || name == "StringBuilder::push" || name == "StringBuilder::freeze" ||
+  name == "print" || name == "println" || name == "assert" || name == "assert_true" || name == "assert_eq" ||
+  name == "FixedArray::make" || name == "Int64Array::make" || name == "FixedArray::length" || name == "Int64Array::length" ||
+  name == "FixedArray::get" || name == "Int64Array::get" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "Int64Array::set" || name == "FixedArray::blit" ||
+  name == "v128_load" || name == "v128_store" || name == "v128_splat_i8x16" || name == "v128_eq_i8x16" || name == "v128_le_u_i8x16" || name == "v128_ge_u_i8x16" ||
+  name == "v128_and" || name == "v128_or" || name == "v128_not" || name == "v128_bitmask_i8x16" || name == "v128_any_true" || name == "v128_all_true_i8x16"
+}
+
+fn gc_direct_abi_name_is_exported(stmts: Array[Stmt], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(exported, _, stmt_name, _, _) => if exported && stmt_name == name {
+        found = true
+      } else {
+        ()
+      },
+      SExport(names) => {
+        let mut j = 0
+        while j < Array::length(names) {
+          if Array::get(names, j) == name {
+            found = true
+          } else {
+            ()
+          }
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_pre_erasure_safe: Bool) -> Bytes with Exception {
   // #805: inline-wasm fns are linear-backend only — reject before any work.
   gc_reject_inline_wasm(stmts)
   // #1015: `gc_to_string_is_wrapper` is a PARAMETER, not computed here --
@@ -437,6 +775,178 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       _ => 0
     }
     i = i + 1
+  }
+  // #1541: derive one conservative module-wide ABI decision before emitting
+  // any body or type. Any unsupported Array signature/use clears the complete
+  // table, leaving the pre-existing tagged-i64 backend byte-for-byte in charge
+  // of user function boundaries. Partial evidence is never consumed.
+  let gc_direct_abi_names_l = array_empty()
+  let gc_direct_abi_param_refs_l = array_empty()
+  let gc_direct_abi_return_refs_l = array_empty()
+  let mut gc_direct_abi_ok = direct_abi_pre_erasure_safe
+  let mut dai = 0
+  while dai < Array::length(user_func_stmts) {
+    match Array::get(user_func_stmts, dai) {
+      SLet(_, _, dai_name, dai_ann, dai_value) => match dai_value {
+        EFn(dai_tparams, _, dai_params, dai_ret_ann, _, _) => {
+          let param_refs = array_empty()
+          let sig_params = match dai_ann {
+            Some(TyFn(ps, _, _)) => if Array::length(ps) == Array::length(dai_params) {
+              Some(ps)
+            } else {
+              None
+            },
+            _ => None
+          }
+          let mut has_ref = false
+          let mut pi = 0
+          while pi < Array::length(dai_params) {
+            let pty = match sig_params {
+              Some(ps) => Some(Array::get(ps, pi)),
+              None => {
+                let (_, own_ann) = Array::get(dai_params, pi)
+                own_ann
+              }
+            }
+            let is_ref = match pty {
+              Some(t) => gc_direct_abi_is_native_array_type(t),
+              None => false
+            }
+            match pty {
+              Some(t) => if gc_direct_abi_type_mentions_array(t) && !is_ref {
+                gc_direct_abi_ok = false
+              } else {
+                ()
+              },
+              None => ()
+            }
+            Array::push(param_refs, is_ref)
+            if is_ref {
+              has_ref = true
+            } else {
+              ()
+            }
+            pi = pi + 1
+          }
+          let ret_ty = match dai_ann {
+            Some(TyFn(_, ret, _)) => Some(ret),
+            _ => dai_ret_ann
+          }
+          let return_ref = match ret_ty {
+            Some(t) => gc_direct_abi_is_native_array_type(t),
+            None => false
+          }
+          match ret_ty {
+            Some(t) => if gc_direct_abi_type_mentions_array(t) && !return_ref {
+              gc_direct_abi_ok = false
+            } else {
+              ()
+            },
+            None => ()
+          }
+          if return_ref {
+            has_ref = true
+          } else {
+            ()
+          }
+          // A generic signature cannot enter the reference lane. The common
+          // preprocessor may erase the parameter list, so concrete Array[Int]
+          // is additionally required above; a surviving type parameter in the
+          // element position has already made gc_direct_abi_ok false.
+          if Array::length(dai_tparams) > 0 && has_ref {
+            gc_direct_abi_ok = false
+          } else {
+            ()
+          }
+          // The CLI entry, every public declaration, and every spelling-routed
+          // builtin collision stays outside the private typed island. Any such
+          // declaration fails closed for the whole component so no body, call,
+          // or type section can consume partial evidence.
+          if gc_direct_abi_name_has_spelling_lowering(dai_name) {
+            gc_direct_abi_ok = false
+          } else {
+            ()
+          }
+          if (dai_name == entry_name || gc_direct_abi_name_is_exported(stmts, dai_name)) && has_ref {
+            gc_direct_abi_ok = false
+          } else if has_ref {
+            Array::push(gc_direct_abi_names_l, dai_name)
+            Array::push(gc_direct_abi_param_refs_l, param_refs)
+            Array::push(gc_direct_abi_return_refs_l, return_ref)
+          } else {
+            ()
+          }
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    dai = dai + 1
+  }
+  if gc_direct_abi_ok && Array::length(gc_direct_abi_names_l) > 0 {
+    let mut si = 0
+    while si < Array::length(user_func_stmts) {
+      match Array::get(user_func_stmts, si) {
+        SLet(_, _, si_name, _, EFn(_, _, si_params, _, _, si_body)) => {
+          let native_params = array_empty()
+          let sig_idx = gc_direct_abi_name_index(gc_direct_abi_names_l, si_name)
+          if sig_idx >= 0 {
+            let refs = Array::get(gc_direct_abi_param_refs_l, sig_idx)
+            let mut spi = 0
+            while spi < Array::length(refs) {
+              if Array::get(refs, spi) {
+                let (pname, _) = Array::get(si_params, spi)
+                Array::push(native_params, pname)
+              } else {
+                ()
+              }
+              spi = spi + 1
+            }
+          } else {
+            ()
+          }
+          let body_kind = gc_direct_abi_expr_kind(si_body, native_params, gc_direct_abi_names_l, gc_direct_abi_param_refs_l, gc_direct_abi_return_refs_l)
+          let expected_kind = if sig_idx >= 0 && Array::get(gc_direct_abi_return_refs_l, sig_idx) {
+            1
+          } else {
+            0
+          }
+          if body_kind != expected_kind {
+            gc_direct_abi_ok = false
+          } else {
+            ()
+          }
+        },
+        _ => ()
+      }
+      si = si + 1
+    }
+    // Computed module globals share `_start`'s raw i64 frame and must not
+    // observe a typed function, even if the reference is consumed immediately.
+    let mut gi = 0
+    while gi < Array::length(stmts) {
+      match Array::get(stmts, gi) {
+        SLet(_, _, _, _, value) => match value {
+          EFn(_, _, _, _, _, _) => (),
+          _ => if gc_direct_abi_expr_mentions_name(value, gc_direct_abi_names_l) {
+            gc_direct_abi_ok = false
+          } else {
+            ()
+          }
+        },
+        _ => ()
+      }
+      gi = gi + 1
+    }
+  } else {
+    ()
+  }
+  if !gc_direct_abi_ok {
+    Array::truncate(gc_direct_abi_names_l, 0)
+    Array::truncate(gc_direct_abi_param_refs_l, 0)
+    Array::truncate(gc_direct_abi_return_refs_l, 0)
+  } else {
+    ()
   }
   let ctor_names_list = Array::slice([
     "None",
@@ -968,7 +1478,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   while bi < num_user_funcs {
     let stmt = Array::get(user_func_stmts, bi)
     match stmt {
-      SLet(_, _, _, gc_fn_ann, expr) => match expr {
+      SLet(_, _, gc_fn_name, gc_fn_ann, expr) => match expr {
         EFn(_, _, params, _, _, body) => {
           let body_buf = bytebuf_new()
           let local_names = array_empty()
@@ -1038,6 +1548,23 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
           }
           let ref_cell_names_f = array_empty()
           let ref_local_indices_f = array_empty()
+          let direct_sig_idx = gc_direct_abi_name_index(gc_direct_abi_names_l, gc_fn_name)
+          let direct_param_slots_f = array_empty()
+          let direct_return_ref_f = direct_sig_idx >= 0 && Array::get(gc_direct_abi_return_refs_l, direct_sig_idx)
+          if direct_sig_idx >= 0 {
+            let direct_refs = Array::get(gc_direct_abi_param_refs_l, direct_sig_idx)
+            let mut dri = 0
+            while dri < Array::length(direct_refs) {
+              if Array::get(direct_refs, dri) {
+                Array::push(direct_param_slots_f, dri)
+              } else {
+                ()
+              }
+              dri = dri + 1
+            }
+          } else {
+            ()
+          }
           let ft = FuncTable::{
             names: ft_names,
             indices: ft_indices,
@@ -1068,11 +1595,15 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
             gc_global_names: gc_global_names_l,
             gc_float_locals: gc_float_slots_f,
             gc_bool_locals: gc_bool_slots_f,
-            gc_native_array_locals: array_empty(),
+            gc_native_array_locals: direct_param_slots_f,
             gc_native_array_local_types: array_empty(),
             gc_native_array_type_idx: gc_native_array_type_idx,
             gc_native_array_frame_ok: true,
             gc_lambda_native_array_locals: gc_lambda_native_array_locals_l,
+            gc_direct_abi_names: gc_direct_abi_names_l,
+            gc_direct_abi_param_refs: gc_direct_abi_param_refs_l,
+            gc_direct_abi_return_refs: gc_direct_abi_return_refs_l,
+            gc_direct_abi_current_return_ref: direct_return_ref_f,
             gc_to_string_is_show_wrapper: gc_to_string_is_wrapper,
             gc_agg_local_slots: gc_agg_slots_f,
             gc_agg_ret_names: gc_agg_ret_names_l,
@@ -1162,6 +1693,11 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       gc_native_array_type_idx: gc_native_array_type_idx,
       gc_native_array_frame_ok: false,
       gc_lambda_native_array_locals: gc_lambda_native_array_locals_l,
+      // `_start` stays entirely outside the private direct-call ABI island.
+      gc_direct_abi_names: gc_direct_abi_names_l,
+      gc_direct_abi_param_refs: gc_direct_abi_param_refs_l,
+      gc_direct_abi_return_refs: gc_direct_abi_return_refs_l,
+      gc_direct_abi_current_return_ref: false,
       gc_to_string_is_show_wrapper: gc_to_string_is_wrapper,
       gc_agg_local_slots: array_empty(),
       gc_agg_ret_names: gc_agg_ret_names_l,
@@ -1269,8 +1805,21 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
     0
   }
   let num_base_types = 13
+  let gc_direct_type_indices = array_empty()
+  let mut gc_direct_type_count = 0
+  let mut dti = 0
+  while dti < num_user_funcs {
+    let sig_idx = gc_direct_abi_name_index(gc_direct_abi_names_l, Array::get(fn_names_list, dti))
+    if sig_idx >= 0 {
+      Array::push(gc_direct_type_indices, num_base_types + num_closure_types + gc_direct_type_count)
+      gc_direct_type_count = gc_direct_type_count + 1
+    } else {
+      Array::push(gc_direct_type_indices, -1)
+    }
+    dti = dti + 1
+  }
   let type_content = bytebuf_new()
-  bytebuf_push_vec_header(type_content, num_base_types + num_closure_types)
+  bytebuf_push_vec_header(type_content, num_base_types + num_closure_types + gc_direct_type_count)
   emit_func_type_raw(type_content, [
     127,
     127,
@@ -1340,6 +1889,16 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
     ])
     cti = cti + 1
   }
+  let mut dte = 0
+  while dte < num_user_funcs {
+    if Array::get(gc_direct_type_indices, dte) >= 0 {
+      let sig_idx = gc_direct_abi_name_index(gc_direct_abi_names_l, Array::get(fn_names_list, dte))
+      emit_gc_direct_func_type(type_content, Array::get(gc_direct_abi_param_refs_l, sig_idx), Array::get(gc_direct_abi_return_refs_l, sig_idx), gc_native_array_type_idx)
+    } else {
+      ()
+    }
+    dte = dte + 1
+  }
   let out = bytebuf_new()
   emit_header(out)
   bytebuf_push_section(out, 1, type_content)
@@ -1389,8 +1948,13 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   }
   let mut fti = 0
   while fti < num_user_funcs {
-    let upc = Array::get(ft_params, fti)
-    Array::push(func_type_indices, closure_type_base + upc)
+    let direct_type_idx = Array::get(gc_direct_type_indices, fti)
+    if direct_type_idx >= 0 {
+      Array::push(func_type_indices, direct_type_idx)
+    } else {
+      let upc = Array::get(ft_params, fti)
+      Array::push(func_type_indices, closure_type_base + upc)
+    }
     fti = fti + 1
   }
   Array::push(func_type_indices, 2)

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -70,6 +70,7 @@ import @vibe/compiler/codegen/common_extractors {
 import @vibe/compiler/codegen/wasm_emit {
   emit_array_get,
   emit_array_len,
+  emit_array_new_default,
   emit_array_set,
   emit_block_i64,
   emit_block_void,
@@ -287,24 +288,118 @@ fn gc_native_array_receiver_slot(args: Array[Expr], local_names: Array[String], 
   }
 }
 
+fn gc_direct_abi_call_index(ctx: CompileCtxGc, name: String) -> Int {
+  let mut i = 0
+  let mut found = -1
+  while i < Array::length(ctx.gc_direct_abi_names) {
+    if found < 0 && Array::get(ctx.gc_direct_abi_names, i) == name {
+      found = i
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn gc_expr_is_native_array_ref(expr: Expr, local_names: Array[String], ctx: CompileCtxGc) -> Bool {
+  match expr {
+    EIdent(name, _) => {
+      let slot = find_local_slot(local_names, name)
+      slot >= 0 && array_contains_int(ctx.gc_native_array_locals, slot)
+    },
+    EArray(_) => true,
+    ECall(EIdent(name, _), _, _) => {
+      let idx = gc_direct_abi_call_index(ctx, name)
+      idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx)
+    },
+    _ => false
+  }
+}
+
+/// Emit one value already proven to inhabit the direct reference lane.
+/// Unsupported shapes are an internal proof failure and abort compilation;
+/// they are never reinterpreted as i64.
+fn gc_compile_native_array_ref(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, ce: (Bytes, Expr, Array[String], Int, Int) -> Int with Exception) -> Int with Exception {
+  match expr {
+    EIdent(name, _) => {
+      let slot = find_local_slot(local_names, name)
+      if slot >= 0 && array_contains_int(ctx.gc_native_array_locals, slot) {
+        emit_local_get(buf, slot)
+        next_local
+      } else {
+        throw("gc direct ABI proof mismatch: expected native array local")
+      }
+    },
+    EArray(elems) => {
+      let slot = next_local
+      Array::push(local_names, "__gc_direct_array_arg")
+      Array::push(ctx.gc_native_array_locals, slot)
+      Array::push(ctx.gc_native_array_local_types, slot)
+      emit_i32_const(buf, Array::length(elems))
+      emit_array_new_default(buf, ctx.gc_native_array_type_idx)
+      emit_local_set(buf, slot)
+      let mut nl = next_local + 1
+      let mut i = 0
+      while i < Array::length(elems) {
+        emit_local_get(buf, slot)
+        emit_i32_const(buf, i)
+        nl = ce(buf, Array::get(elems, i), local_names, nl, ld)
+        emit_array_set(buf, ctx.gc_native_array_type_idx)
+        i = i + 1
+      }
+      emit_local_get(buf, slot)
+      nl
+    },
+    ECall(callee, args, _) => match callee {
+      EIdent(name, _) => {
+        let idx = gc_direct_abi_call_index(ctx, name)
+        if idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx) {
+          compile_call_gc(buf, callee, args, local_names, next_local, ctx, ld, ce)
+        } else {
+          throw("gc direct ABI proof mismatch: call does not return a native array")
+        }
+      },
+      _ => throw("gc direct ABI proof mismatch: indirect native array call")
+    },
+    _ => throw("gc direct ABI proof mismatch: unsupported native array expression")
+  }
+}
+
 fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, ce: (Bytes, Expr, Array[String], Int, Int) -> Int with Exception) -> Int with Exception {
   match callee {
     EIdent(fname, _) => {
       let native_slot = gc_native_array_receiver_slot(args, local_names, ctx)
-      if native_slot >= 0 && fname == "Array::length" && Array::length(args) == 1 {
-        emit_local_get(buf, native_slot)
+      let native_receiver = Array::length(args) > 0 && (native_slot >= 0 || gc_expr_is_native_array_ref(Array::get(args, 0), local_names, ctx))
+      if native_receiver && fname == "Array::length" && Array::length(args) == 1 {
+        let nl = if native_slot >= 0 {
+          emit_local_get(buf, native_slot)
+          next_local
+        } else {
+          gc_compile_native_array_ref(buf, Array::get(args, 0), local_names, next_local, ctx, ld, ce)
+        }
         emit_array_len(buf)
         emit_i64_extend_i32_u(buf)
-        return next_local
-      } else if native_slot >= 0 && fname == "Array::get" && Array::length(args) == 2 {
-        emit_local_get(buf, native_slot)
-        let nl = ce(buf, Array::get(args, 1), local_names, next_local, ld)
+        return nl
+      } else if native_receiver && fname == "Array::get" && Array::length(args) == 2 {
+        let nl0 = if native_slot >= 0 {
+          emit_local_get(buf, native_slot)
+          next_local
+        } else {
+          gc_compile_native_array_ref(buf, Array::get(args, 0), local_names, next_local, ctx, ld, ce)
+        }
+        let nl = ce(buf, Array::get(args, 1), local_names, nl0, ld)
         emit_i32_wrap_i64(buf)
         emit_array_get(buf, ctx.gc_native_array_type_idx)
         return nl
-      } else if native_slot >= 0 && fname == "Array::set" && Array::length(args) == 3 {
-        emit_local_get(buf, native_slot)
-        let nl1 = ce(buf, Array::get(args, 1), local_names, next_local, ld)
+      } else if native_receiver && fname == "Array::set" && Array::length(args) == 3 {
+        let nl0 = if native_slot >= 0 {
+          emit_local_get(buf, native_slot)
+          next_local
+        } else {
+          gc_compile_native_array_ref(buf, Array::get(args, 0), local_names, next_local, ctx, ld, ce)
+        }
+        let nl1 = ce(buf, Array::get(args, 1), local_names, nl0, ld)
         emit_i32_wrap_i64(buf)
         let nl2 = ce(buf, Array::get(args, 2), local_names, nl1, ld)
         emit_array_set(buf, ctx.gc_native_array_type_idx)
@@ -1897,10 +1992,15 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         if fn_idx_in_list >= 0 {
           let fidx = Array::get(ctx.func_table.indices, fn_idx_in_list)
           let has_ret = Array::get(ctx.func_table.returns, fn_idx_in_list)
+          let direct_idx = gc_direct_abi_call_index(ctx, fname)
           let mut nl = next_local
           let mut ci = 0
           while ci < Array::length(args) {
-            nl = ce(buf, Array::get(args, ci), local_names, nl, ld)
+            if direct_idx >= 0 && Array::get(Array::get(ctx.gc_direct_abi_param_refs, direct_idx), ci) {
+              nl = gc_compile_native_array_ref(buf, Array::get(args, ci), local_names, nl, ctx, ld, ce)
+            } else {
+              nl = ce(buf, Array::get(args, ci), local_names, nl, ld)
+            }
             ci = ci + 1
           }
           if ctx.func_offset > 0 {

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -489,75 +489,140 @@ fn emit_gc_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String]
   }
 }
 
-/// Conservative escape gate for the first user-visible native GC value. The
-/// reference stays in one typed local and may only be the receiver of direct
-/// Array::length/get/set calls; all control forms that can capture, return, or
-/// ambiguously bind it are rejected until typed-reference handling grows.
-fn gc_native_array_body_is_safe(expr: Expr, name: String) -> Bool {
+fn gc_direct_abi_expr_index(ctx: CompileCtxGc, name: String) -> Int {
+  let mut i = 0
+  let mut found = -1
+  while i < Array::length(ctx.gc_direct_abi_names) {
+    if found < 0 && Array::get(ctx.gc_direct_abi_names, i) == name {
+      found = i
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// Conservative escape gate for native locals, extended in #1541 to admit a
+/// reference in a proven direct-call parameter position and in the tail of a
+/// proven reference-result body. `allow_tail` is reset for ordinary children,
+/// so aggregates, indirect calls, captures, and joins remain impossible.
+fn gc_native_array_body_is_safe_tail(expr: Expr, name: String, allow_tail: Bool, ctx: CompileCtxGc) -> Bool {
   match expr {
-    EIdent(n, _) => n != name,
+    EIdent(n, _) => n != name || allow_tail,
     ECall(EIdent(fname, _), args, _) => {
-      let expected = if fname == "Array::length" {
-        1
-      } else if fname == "Array::get" {
-        2
-      } else if fname == "Array::set" {
-        3
-      } else {
-        -1
-      }
-      if expected > 0 && Array::length(args) == expected {
-        match Array::get(args, 0) {
-          EIdent(n, _) => if n == name {
-            let mut i = 1
-            let mut ok = true
-            while i < Array::length(args) {
-              if !gc_native_array_body_is_safe(Array::get(args, i), name) {
-                ok = false
-              }
-              i = i + 1
+      let direct_idx = gc_direct_abi_expr_index(ctx, fname)
+      if direct_idx >= 0 {
+        let refs = Array::get(ctx.gc_direct_abi_param_refs, direct_idx)
+        let mut i = 0
+        let mut ok = Array::length(refs) == Array::length(args)
+        while i < Array::length(args) {
+          let is_target = match Array::get(args, i) {
+            EIdent(n, _) => n == name,
+            _ => false
+          }
+          if is_target {
+            if !Array::get(refs, i) {
+              ok = false
+            } else {
+              ()
             }
-            ok
+          } else if !gc_native_array_body_is_safe_tail(Array::get(args, i), name, false, ctx) {
+            ok = false
           } else {
-            gc_native_array_children_are_safe(expr, name)
-          },
-          _ => gc_native_array_children_are_safe(expr, name)
+            ()
+          }
+          i = i + 1
         }
+        ok
       } else {
-        gc_native_array_children_are_safe(expr, name)
+        let expected = if fname == "Array::length" {
+          1
+        } else if fname == "Array::get" {
+          2
+        } else if fname == "Array::set" {
+          3
+        } else {
+          -1
+        }
+        if expected > 0 && Array::length(args) == expected {
+          match Array::get(args, 0) {
+            EIdent(n, _) => if n == name {
+              let mut i = 1
+              let mut ok = true
+              while i < Array::length(args) {
+                if !gc_native_array_body_is_safe_tail(Array::get(args, i), name, false, ctx) {
+                  ok = false
+                }
+                i = i + 1
+              }
+              ok
+            } else {
+              gc_native_array_children_are_safe(expr, name, ctx)
+            },
+            _ => gc_native_array_children_are_safe(expr, name, ctx)
+          }
+        } else {
+          gc_native_array_children_are_safe(expr, name, ctx)
+        }
       }
     },
-    // Same-name nesting makes the simple syntactic ownership proof ambiguous.
-    ELet(n, _, _, _) => n != name && gc_native_array_children_are_safe(expr, name),
-    ELetMut(n, _, _, _) => n != name && gc_native_array_children_are_safe(expr, name),
-    ELetRec(n, _, _) => n != name && gc_native_array_children_are_safe(expr, name),
-    EAssign(n, _, _) => n != name && gc_native_array_children_are_safe(expr, name),
-    EAssignOp(n, _, _, _) => n != name && gc_native_array_children_are_safe(expr, name),
+    // A plain alias remains in the same typed reference lane. Its own uses
+    // are checked when that ELet is compiled and logged as a typed local.
+    ELet(alias, EIdent(source, _), body, _) => if alias != name && source == name {
+      // Check both spellings: the original binding remains in scope after a
+      // plain alias and must not be smuggled into an unsupported i64 use.
+      gc_native_array_body_is_safe_tail(body, alias, allow_tail, ctx) && gc_native_array_body_is_safe_tail(body, name, allow_tail, ctx)
+    } else {
+      alias != name && gc_native_array_children_are_safe(expr, name, ctx)
+    },
+    ELet(n, _, _, _) => n != name && gc_native_array_children_are_safe(expr, name, ctx),
+    ELetMut(n, _, _, _) => n != name && gc_native_array_children_are_safe(expr, name, ctx),
+    ELetRec(n, _, _) => n != name && gc_native_array_children_are_safe(expr, name, ctx),
+    EAssign(n, _, _) => n != name && gc_native_array_children_are_safe(expr, name, ctx),
+    EAssignOp(n, _, _, _) => n != name && gc_native_array_children_are_safe(expr, name, ctx),
     EFn(_, _, _, _, _, _) => false,
     EMatch(_, _) => false,
     EHandle(_, _) => false,
     EForIn(_, _, _, _) => false,
     ELoop(_, _) => false,
-    // A scalar result may be returned; returning the reference itself is
-    // still rejected by the recursive EIdent check.
-    EReturn(_) => gc_native_array_children_are_safe(expr, name),
+    EReturn(value) => gc_native_array_body_is_safe_tail(value, name, allow_tail, ctx),
     EBreak(_) => false,
     EContinue(_) => false,
-    _ => gc_native_array_children_are_safe(expr, name)
+    _ => gc_native_array_children_are_safe(expr, name, ctx)
   }
 }
 
-fn gc_native_array_children_are_safe(expr: Expr, name: String) -> Bool {
+fn gc_native_array_children_are_safe(expr: Expr, name: String, ctx: CompileCtxGc) -> Bool {
   let children = expr_children(expr)
   let mut i = 0
   let mut ok = true
   while i < Array::length(children) {
-    if !gc_native_array_body_is_safe(Array::get(children, i), name) {
+    if !gc_native_array_body_is_safe_tail(Array::get(children, i), name, false, ctx) {
       ok = false
     }
     i = i + 1
   }
   ok
+}
+
+fn gc_direct_abi_result_is_native(expr: Expr, ctx: CompileCtxGc) -> Bool {
+  match expr {
+    ECall(EIdent(name, _), _, _) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(ctx.gc_direct_abi_names) {
+        if Array::get(ctx.gc_direct_abi_names, i) == name && Array::get(ctx.gc_direct_abi_return_refs, i) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    _ => false
+  }
 }
 
 /// i64 fallback for an ELet after its name has already been pushed into
@@ -986,9 +1051,8 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       let local_idx = next_local
       Array::push(local_names, name)
       match value {
-        EArray(native_elems) => if ctx.gc_native_array_frame_ok && ctx.gc_native_array_type_idx >= 0 && gc_native_array_body_is_safe(body, name) {
+        EArray(native_elems) => if ctx.gc_native_array_frame_ok && ctx.gc_native_array_type_idx >= 0 && gc_native_array_body_is_safe_tail(body, name, ctx.gc_direct_abi_current_return_ref, ctx) {
           // This local is a `(ref null $native_i64_array)`, never an i64.
-          // Only the direct native Array call paths below may read it.
           Array::push(ctx.gc_native_array_locals, local_idx)
           Array::push(ctx.gc_native_array_local_types, local_idx)
           emit_i32_const(buf, Array::length(native_elems))
@@ -1003,6 +1067,27 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
             emit_array_set(buf, ctx.gc_native_array_type_idx)
             ni = ni + 1
           }
+          ce(buf, body, local_names, native_nl, ld)
+        } else {
+          gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
+        },
+        EIdent(source, _) => {
+          let source_slot = find_local_slot(local_names, source)
+          if source_slot >= 0 && array_contains_int(ctx.gc_native_array_locals, source_slot) && gc_native_array_body_is_safe_tail(body, name, ctx.gc_direct_abi_current_return_ref, ctx) {
+            Array::push(ctx.gc_native_array_locals, local_idx)
+            Array::push(ctx.gc_native_array_local_types, local_idx)
+            emit_local_get(buf, source_slot)
+            emit_local_set(buf, local_idx)
+            ce(buf, body, local_names, next_local + 1, ld)
+          } else {
+            gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
+          }
+        },
+        ECall(_, _, _) => if gc_direct_abi_result_is_native(value, ctx) && gc_native_array_body_is_safe_tail(body, name, ctx.gc_direct_abi_current_return_ref, ctx) {
+          Array::push(ctx.gc_native_array_locals, local_idx)
+          Array::push(ctx.gc_native_array_local_types, local_idx)
+          let native_nl = ce(buf, value, local_names, next_local + 1, ld)
+          emit_local_set(buf, local_idx)
           ce(buf, body, local_names, native_nl, ld)
         } else {
           gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)

--- a/lib/@vibe/compiler/codegen/gc/backend_lambda_ctx.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_lambda_ctx.vibe
@@ -51,6 +51,12 @@ fn make_lambda_ctx_gc(ctx: CompileCtxGc, ref_cell_names: Array[String], ref_loca
     // land in the one module-level array to stay parallel to
     // LambdaTable.bodies.
     gc_lambda_native_array_locals: ctx.gc_lambda_native_array_locals,
+    // Direct calls made inside a lambda may use a proven callee signature,
+    // but the lambda's own closure ABI remains tagged-i64 in #1541.
+    gc_direct_abi_names: ctx.gc_direct_abi_names,
+    gc_direct_abi_param_refs: ctx.gc_direct_abi_param_refs,
+    gc_direct_abi_return_refs: ctx.gc_direct_abi_return_refs,
+    gc_direct_abi_current_return_ref: false,
     // #1015: computed once per compile, never per-scope -- pass through
     // unchanged (see the doc comment on CompileCtxGc.gc_to_string_is_show_wrapper).
     gc_to_string_is_show_wrapper: ctx.gc_to_string_is_show_wrapper,

--- a/lib/@vibe/compiler/codegen/gc/gc.vibe
+++ b/lib/@vibe/compiler/codegen/gc/gc.vibe
@@ -1,7 +1,7 @@
 import ./backend_body.vibe {
-  compile_wasi_module_gc, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_safe, gc_to_string_resolves_to_show_wrapper
 }
 
 export {
-  compile_wasi_module_gc, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_safe, gc_to_string_resolves_to_show_wrapper
 }

--- a/lib/@vibe/compiler/codegen/gc/index.vpkg
+++ b/lib/@vibe/compiler/codegen/gc/index.vpkg
@@ -20,7 +20,8 @@ generated_hash =
 // backend_builtins_*.vibe (array/numeric/print/string body generators),
 // backend_lambda_*.vibe (wasm-gc lambda codegen).
 
-fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool) -> Bytes with Exception
+fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_pre_erasure_safe: Bool) -> Bytes with Exception
+fn gc_direct_abi_pre_erasure_safe(stmts: Array[Stmt]) -> Bool
 fn gc_to_string_resolves_to_show_wrapper(stmts: Array[Stmt]) -> Bool
 fn gc_gen_arr_len_body() -> Bytes
 fn gc_gen_arr_new_body() -> Bytes

--- a/lib/@vibe/compiler/codegen_gc.vibe
+++ b/lib/@vibe/compiler/codegen_gc.vibe
@@ -1,11 +1,11 @@
 //# Imports
 
 import @vibe/compiler/codegen/gc {
-  compile_wasi_module_gc, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_safe, gc_to_string_resolves_to_show_wrapper
 }
 
 //# Misc
 
 export {
-  compile_wasi_module_gc, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_safe, gc_to_string_resolves_to_show_wrapper
 }

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -69,6 +69,8 @@ checker	checker/canonical_checked_type_state.vibe
 checker	checker/index.vpkg
 checker	checker/checker_facade.vibe
 checker	checker/artifacts/index.vpkg
+checker	checker/artifacts/checked_exported_interface_artifact.vibe
+checker	checker/artifacts/checked_module_typing_artifact.vibe
 checker	checker/artifacts/checked_direct_expression_return_artifact.vibe
 checker	checker/artifacts/checked_expression_kind_direct_return_artifact.vibe
 checker	checker/artifacts/checked_expression_leaf_payload_direct_return_artifact.vibe

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -16,7 +16,7 @@ import @vibe/compiler/codegen {
 }
 
 import @vibe/compiler/codegen/gc {
-  compile_wasi_module_gc, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_safe, gc_to_string_resolves_to_show_wrapper
 }
 
 // #847 Phase C exception: this file drives the wasm-gc backend
@@ -276,10 +276,11 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   // to_string(Bool) call-site fast path (codegen/gc/backend_call.vibe).
   // See the doc comment on gc_to_string_resolves_to_show_wrapper.
   let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
+  let direct_abi_pre_erasure_safe = gc_direct_abi_pre_erasure_safe(stmts)
   // Same effective order as the linear lane: strip source-level generic
   // params, then the trait-dict desugar (compile_wasi_module_linked_impl
   // runs it as its first step).
   strip_generic_type_params(stmts)
   desugar_trait_dicts(stmts)
-  compile_wasi_module_gc(stmts, effective_entry, gc_to_string_is_wrapper)
+  compile_wasi_module_gc(stmts, effective_entry, gc_to_string_is_wrapper, direct_abi_pre_erasure_safe)
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -118,6 +118,9 @@ fn compile_file_wasi_library(dep_path: String) -> Bytes with Exception + Fs
 
 // --- merge_sources.vibe
 fn merged_program_source_fs(entry_path: String) -> String with Exception + Fs
+// Internal #1633 coverage harness: exact-file value imports only; ordinary
+// module visibility and the public CLI surface remain unchanged.
+fn coverage_driver_program_source_fs(entry_path: String, driver_path: String) -> String with Exception + Fs
 fn compile_file_wasi_only(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
 
 // --- preprocess_compile.vibe

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -193,25 +193,26 @@ fn collect_parsed_sources_recursive(path: String, file_paths: Array[String], fil
   }
 }
 
-fn collect_merged_stmts_recursive(entry_path: String, merged: Array[Stmt], visited: Array[Array[String]]) -> Unit with Exception + Fs {
-  let file_paths = array_empty()
-  let file_stmts = array_empty()
-  collect_parsed_sources_recursive(entry_path, file_paths, file_stmts, visited)
+fn transformed_file_stmts(entry_path: String, path: String, stmts: Array[Stmt], plan: ExportRenamePlan) -> Array[Stmt] {
+  let export_renamed = if path == entry_path {
+    stmts
+  } else {
+    apply_export_renames_stmts(stmts, export_plan_renames_for(plan, path))
+  }
+  if path == entry_path {
+    export_renamed
+  } else {
+    namespace_private_value_stmts(path, export_renamed)
+  }
+}
+
+fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], file_stmts: Array[Array[Stmt]], merged: Array[Stmt]) -> ExportRenamePlan with Exception + Fs {
   let plan = build_export_rename_plan(file_paths, file_stmts, entry_path)
   let mut fi = 0
   while fi < Array::length(file_paths) {
     let path = Array::get(file_paths, fi)
     let stmts = Array::get(file_stmts, fi)
-    let export_renamed = if path == entry_path {
-      stmts
-    } else {
-      apply_export_renames_stmts(stmts, export_plan_renames_for(plan, path))
-    }
-    let namespaced_stmts = if path == entry_path {
-      export_renamed
-    } else {
-      namespace_private_value_stmts(path, export_renamed)
-    }
+    let namespaced_stmts = transformed_file_stmts(entry_path, path, stmts, plan)
     if stmts_have_import_deep(stmts) {
       let import_renames = collect_import_value_renames(plan, path, stmts)
       let skipped_locals = collect_import_alias_collision_locals(stmts)
@@ -222,6 +223,328 @@ fn collect_merged_stmts_recursive(entry_path: String, merged: Array[Stmt], visit
     }
     fi = fi + 1
   }
+  plan
+}
+
+fn collect_merged_stmts_recursive(entry_path: String, merged: Array[Stmt], visited: Array[Array[String]]) -> Unit with Exception + Fs {
+  let file_paths = array_empty()
+  let file_stmts = array_empty()
+  collect_parsed_sources_recursive(entry_path, file_paths, file_stmts, visited)
+  let _ = append_parsed_merged_stmts(entry_path, file_paths, file_stmts, merged)
+  ()
+}
+
+fn coverage_driver_import_error(driver_path: String, raw_path: String, name: String, reason: String) -> Unit with Exception {
+  throw(String::concat("coverage driver ", String::concat(driver_path, String::concat(" import ", String::concat(raw_path, String::concat(" { ", String::concat(name, String::concat(" } rejected: ", reason))))))))
+}
+
+fn closure_path_index_for_coverage_import(file_paths: Array[String], driver_path: String, raw_path: String, name: String) -> Int with Exception + Fs {
+  if !String::ends_with(raw_path, ".vibe") {
+    coverage_driver_import_error(driver_path, raw_path, name, "use one exact .vibe file path; package/directory imports are unsupported")
+    0 - 1
+  } else {
+    let candidates = resolve_import_path_candidates(dir_of_path(driver_path), raw_path)
+    let mut chosen = 0 - 1
+    let mut matches = 0
+    let mut exists_outside = false
+    let mut ci = 0
+    while ci < Array::length(candidates) {
+      let candidate = Array::get(candidates, ci)
+      let mut fi = 0
+      while fi < Array::length(file_paths) {
+        if Array::get(file_paths, fi) == candidate {
+          chosen = fi
+          matches = matches + 1
+        } else {
+          ()
+        }
+        fi = fi + 1
+      }
+      if Fs::exists(candidate) && matches == 0 {
+        exists_outside = true
+      } else {
+        ()
+      }
+      ci = ci + 1
+    }
+    if matches == 1 {
+      chosen
+    } else if matches > 1 {
+      coverage_driver_import_error(driver_path, raw_path, name, "path resolves more than once inside the compiler closure")
+      0 - 1
+    } else if exists_outside {
+      coverage_driver_import_error(driver_path, raw_path, name, "target exists but is outside the collected compiler closure")
+      0 - 1
+    } else {
+      coverage_driver_import_error(driver_path, raw_path, name, "target file is missing from the collected compiler closure")
+      0 - 1
+    }
+  }
+}
+
+fn stmt_declares_named_ctor(stmt: Stmt, name: String) -> Bool {
+  match stmt {
+    SEnum(_, _, _, ctors, _) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(ctors) && !found {
+        let (ctor_name, _) = Array::get(ctors, i)
+        if ctor_name == name {
+          found = true
+        } else {
+          i = i + 1
+        }
+      }
+      found
+    },
+    SSuberror(_, _, ctors) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(ctors) && !found {
+        let (ctor_name, _) = Array::get(ctors, i)
+        if ctor_name == name {
+          found = true
+        } else {
+          i = i + 1
+        }
+      }
+      found
+    },
+    _ => false
+  }
+}
+
+fn coverage_target_unsupported_kind(stmt: Stmt, name: String) -> String {
+  match stmt {
+    SLetMut(stmt_name, _, _) => if stmt_name == name {
+      "mutable global"
+    } else {
+      ""
+    },
+    SExternLet(stmt_name, _) => if stmt_name == name {
+      "extern value"
+    } else {
+      ""
+    },
+    SEnum(_, stmt_name, _, _, _) => if stmt_name == name {
+      "type"
+    } else if stmt_declares_named_ctor(stmt, name) {
+      "constructor"
+    } else {
+      ""
+    },
+    SSuberror(_, stmt_name, _) => if stmt_name == name {
+      "type"
+    } else if stmt_declares_named_ctor(stmt, name) {
+      "constructor"
+    } else {
+      ""
+    },
+    SStruct(_, stmt_name, _, _, _, _) => if stmt_name == name {
+      "type"
+    } else {
+      ""
+    },
+    STypeAlias(_, stmt_name, _, _) => if stmt_name == name {
+      "type"
+    } else {
+      ""
+    },
+    STrait(_, stmt_name, _, _, _, _) => if stmt_name == name {
+      "trait"
+    } else {
+      ""
+    },
+    SModule(_, stmt_name, _) => if stmt_name == name {
+      "module"
+    } else {
+      ""
+    },
+    SEffectDef(_, stmt_name, _, ops) => if stmt_name == name {
+      "effect"
+    } else {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(ops) && !found {
+        let (op_name, _, _) = Array::get(ops, i)
+        if op_name == name {
+          found = true
+        } else {
+          i = i + 1
+        }
+      }
+      if found {
+        "effect operation"
+      } else {
+        ""
+      }
+    },
+    _ => ""
+  }
+}
+
+fn merged_value_name_count(stmts: Array[Stmt], name: String) -> Int {
+  let mut count = 0
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, stmt_name, _, _) => if stmt_name == name {
+        count = count + 1
+      } else {
+        ()
+      },
+      SLetMut(stmt_name, _, _) => if stmt_name == name {
+        count = count + 1
+      } else {
+        ()
+      },
+      SExternLet(stmt_name, _) => if stmt_name == name {
+        count = count + 1
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  count
+}
+
+fn resolve_coverage_value_target(entry_path: String, file_paths: Array[String], file_stmts: Array[Array[Stmt]], plan: ExportRenamePlan, merged: Array[Stmt], driver_path: String, raw_path: String, original: String) -> String with Exception + Fs {
+  if String::contains(original, "::") {
+    coverage_driver_import_error(driver_path, raw_path, original, "method and qualified targets are unsupported")
+    ""
+  } else {
+    let path_index = closure_path_index_for_coverage_import(file_paths, driver_path, raw_path, original)
+    let target_path = Array::get(file_paths, path_index)
+    let original_stmts = Array::get(file_stmts, path_index)
+    let transformed_stmts = transformed_file_stmts(entry_path, target_path, original_stmts, plan)
+    let mut matches = 0
+    let mut final_name = ""
+    let mut unsupported = ""
+    let mut i = 0
+    while i < Array::length(original_stmts) {
+      let stmt = Array::get(original_stmts, i)
+      match stmt {
+        SLet(_, _, stmt_name, _, _) => if stmt_name == original {
+          matches = matches + 1
+          match Array::get(transformed_stmts, i) {
+            SLet(_, _, transformed_name, _, _) => {
+              final_name = transformed_name
+            },
+            _ => coverage_driver_import_error(driver_path, raw_path, original, "production merge changed the target into a non-value declaration")
+          }
+        } else {
+          ()
+        },
+        _ => {
+          let kind = coverage_target_unsupported_kind(stmt, original)
+          if kind != "" {
+            unsupported = kind
+          } else {
+            ()
+          }
+        }
+      }
+      i = i + 1
+    }
+    if unsupported != "" {
+      coverage_driver_import_error(driver_path, raw_path, original, String::concat("unsupported ", unsupported))
+      ""
+    } else if matches == 0 {
+      coverage_driver_import_error(driver_path, raw_path, original, "no top-level immutable value with that exact name exists in the target file")
+      ""
+    } else if matches > 1 {
+      coverage_driver_import_error(driver_path, raw_path, original, "duplicate top-level value declarations in the target file")
+      ""
+    } else if merged_value_name_count(merged, final_name) != 1 {
+      coverage_driver_import_error(driver_path, raw_path, original, "the production transformed name is not unique in the merged compiler")
+      ""
+    } else {
+      final_name
+    }
+  }
+}
+
+fn append_coverage_driver_stmts(entry_path: String, driver_path: String, driver_stmts: Array[Stmt], file_paths: Array[String], file_stmts: Array[Array[Stmt]], plan: ExportRenamePlan, merged: Array[Stmt]) -> Unit with Exception + Fs {
+  let renames = array_empty()
+  let imported_locals = array_empty()
+  let imported_finals = array_empty()
+  let mut i = 0
+  while i < Array::length(driver_stmts) {
+    match Array::get(driver_stmts, i) {
+      SImport(raw_path, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let (original, alias_opt) = Array::get(items, j)
+          let local = match alias_opt {
+            Some(alias) => alias,
+            None => original
+          }
+          if string_array_contains_local(imported_locals, local) {
+            coverage_driver_import_error(driver_path, raw_path, original, String::concat("local import name collides with another request: ", local))
+          } else {
+            let final_name = resolve_coverage_value_target(entry_path, file_paths, file_stmts, plan, merged, driver_path, raw_path, original)
+            if string_array_contains_local(imported_finals, final_name) {
+              coverage_driver_import_error(driver_path, raw_path, original, "multiple requests resolve to the same transformed compiler value")
+            } else {
+              Array::push(imported_locals, local)
+              Array::push(imported_finals, final_name)
+              Array::push(renames, (local, final_name))
+            }
+          }
+          j = j + 1
+        }
+      },
+      SReExport(raw_path, _) => coverage_driver_import_error(driver_path, raw_path, "*", "re-export requests are unsupported"),
+      _ => ()
+    }
+    i = i + 1
+  }
+  let driver_values = array_empty()
+  let mut di = 0
+  while di < Array::length(driver_stmts) {
+    let stmt = Array::get(driver_stmts, di)
+    let driver_name = match stmt {
+      SLet(_, _, name, _, _) => name,
+      SLetMut(name, _, _) => name,
+      SExternLet(name, _) => name,
+      _ => ""
+    }
+    if driver_name != "" {
+      if string_array_contains_local(driver_values, driver_name) {
+        coverage_driver_import_error(driver_path, driver_path, driver_name, "duplicate top-level value in the driver")
+      } else if string_array_contains_local(imported_locals, driver_name) {
+        coverage_driver_import_error(driver_path, driver_path, driver_name, "driver top-level value collides with an imported local name")
+      } else if merged_value_name_count(merged, driver_name) > 0 {
+        coverage_driver_import_error(driver_path, driver_path, driver_name, "driver top-level value collides with the merged compiler")
+      } else {
+        Array::push(driver_values, driver_name)
+      }
+    } else {
+      ()
+    }
+    di = di + 1
+  }
+  append_import_alias_rewritten_non_import_stmts_with_renames(merged, driver_stmts, array_empty(), renames)
+}
+
+/// #1633: merge the compiler entry with one coverage driver whose imports name
+/// exact source files in that compiler closure. Import items may expose only
+/// top-level immutable values. Their references are rewritten to the exact
+/// names produced by the ordinary export/private namespacing pipeline; no
+/// guessed mangling or visibility broadening is involved.
+export fn coverage_driver_program_source_fs(entry_path: String, driver_path: String) -> String with Exception + Fs {
+  let file_paths = array_empty()
+  let file_stmts = array_empty()
+  let visited = path_set_new()
+  collect_parsed_sources_recursive(entry_path, file_paths, file_stmts, visited)
+  let merged = empty_stmt_array()
+  let plan = append_parsed_merged_stmts(entry_path, file_paths, file_stmts, merged)
+  let driver_source = ingest_source_text_fs(driver_path, Fs::read_file(driver_path))
+  let driver_stmts = parse_program(lex(driver_source))
+  append_coverage_driver_stmts(entry_path, driver_path, driver_stmts, file_paths, file_stmts, plan, merged)
+  print_program(merged)
 }
 
 /// #726: the merged whole program AS SOURCE TEXT. Resolves imports from the

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -5,6 +5,7 @@ description =
 deps = {
   @vibe/compiler/cache : 0.0.1
   @vibe/compiler/checker : 0.0.1
+  @vibe/compiler/checker/artifacts : 0.0.1
   @vibe/compiler/codegen : 0.0.1
   @vibe/compiler/codegen/common_analysis : 0.0.1
   @vibe/compiler/core : 0.0.1
@@ -286,6 +287,10 @@ struct ModuleJob {
 // accessors or a real variant declaration here.
 opaque type ModuleOutcome
 fn check_module(job: ModuleJob) -> ModuleOutcome with Exception
+// #1550: canonical module typing artifact bytes carried only by an opaque,
+// genuinely successful ModuleOutcome. Diagnosed outcomes return None. This is
+// in-memory observation only: no cache lookup, planner, persistence, or reuse.
+fn checked_module_typing_artifact_observation(outcome: ModuleOutcome) -> Option[String]
 // #906 Phase 2: the worker transport entry. `dir` is a job directory and
 // is the worker's ENTIRE filesystem sandbox -- see typecheck_fs.vibe for
 // its layout and for why the job's `path` row must be the module's logical

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -287,6 +287,7 @@ struct ModuleJob {
 // accessors or a real variant declaration here.
 opaque type ModuleOutcome
 fn check_module(job: ModuleJob) -> ModuleOutcome with Exception
+fn check_module_with_typing_artifact_observation(job: ModuleJob) -> ModuleOutcome with Exception
 // #1550: canonical module typing artifact bytes carried only by an opaque,
 // genuinely successful ModuleOutcome. Diagnosed outcomes return None. This is
 // in-memory observation only: no cache lookup, planner, persistence, or reuse.

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -15,7 +15,19 @@ import @vibe/core {
 }
 
 import @vibe/compiler/checker {
-  check_program, check_program_type_table, check_program_with_env, detect_unbound_nonunit_returns, detect_unused_imports
+  CheckedProgram,
+  check_program,
+  check_program_result,
+  check_program_type_table,
+  check_program_with_env_result,
+  detect_unbound_nonunit_returns,
+  detect_unused_imports
+}
+
+import @vibe/compiler/checker/artifacts {
+  checked_exported_interface_artifact_from_checked_program,
+  encode_checked_module_typing_artifact_v1,
+  shadow_unattested_checked_module_typing_artifact_from_checked_program
 }
 
 import @vibe/compiler/core {
@@ -3254,10 +3266,52 @@ export enum ModuleOutcome {
   // The final strings are trace-only interface, checked-value-env, and
   // complete persistent TypeEnv v4 transport identities. They are computed
   // from this successful check's typed environment, never used as cache
-  // inputs, and are empty unless the invalidation trace is enabled.
-  Checked(String, String, TypeEnv, String, String, String);
+  // inputs, and are empty unless the invalidation trace is enabled. The final
+  // optional string is a canonical in-memory-only #1550 module artifact
+  // observation. ModuleOutcome is opaque at the package boundary, so only this
+  // real checker-success path can authorize a present observation.
+  Checked(String, String, TypeEnv, String, String, String, Option[String]);
   Diagnosed(String, Array[String])
 }
+
+fn checked_module_dependency_interface_assumptions(dep_envs: Array[(String, TypeEnv)]) -> Array[(String, String)] with Exception {
+  let assumptions = array_empty()
+  let mut i = 0
+  while i < Array::length(dep_envs) {
+    let (path, env) = Array::get(dep_envs, i)
+    // check_module receives dependency environments only after they have been
+    // restricted to their published export surfaces. Preserve their actual
+    // import order and fingerprint exactly that checker-visible interface.
+    Array::push(assumptions, (path, incremental_persistent_type_env_transport_identity(env)))
+    i = i + 1
+  }
+  assumptions
+}
+
+fn checked_module_typing_artifact_bytes(checked: CheckedProgram, job: ModuleJob) -> Option[String] with Exception {
+  let implementation_identity = incremental_implementation_identity(job.source)
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(exported_interface) => match shadow_unattested_checked_module_typing_artifact_from_checked_program(checked, job.path, "provisional_token_stream_v1", implementation_identity, checked_module_dependency_interface_assumptions(job.dep_envs), [
+      (job.path, "provisional_token_stream_v1", implementation_identity)
+    ], exported_interface) {
+      Some(artifact) => Some(encode_checked_module_typing_artifact_v1(artifact)),
+      None => None
+    },
+    None => None
+  }
+}
+
+/// Observe only canonical bytes retained by an opaque successful ModuleOutcome.
+/// Diagnosed outcomes have no observation, and callers cannot construct either
+/// variant through the runtime package contract. The bytes are not persisted or
+/// consulted by planning, cache lookup, TypeEnv assembly, or reuse.
+export fn checked_module_typing_artifact_observation(outcome: ModuleOutcome) -> Option[String] {
+  match outcome {
+    Checked(_, _, _, _, _, _, observation) => observation,
+    Diagnosed(_, _) => None
+  }
+}
+
 /// Pure module check. No Fs: the dependency environments it needs are
 /// already values inside the job.
 export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
@@ -3287,10 +3341,14 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
     })
   } else {
     handle {
-      let full_checked_env = match import_env {
-        EnvEmpty => check_program(stmts),
-        _ => check_program_with_env(stmts, import_env)
+      // Retain the opaque-producing checker result from this exact production
+      // invocation. No caller-supplied CheckedProgram or diagnostic assertion
+      // participates in the #1550 observation.
+      let checked_program = match import_env {
+        EnvEmpty => check_program_result(stmts),
+        _ => check_program_with_env_result(stmts, import_env)
       }
+      let full_checked_env = checked_program.final_env
       // #1533: what leaves this function is the module's PUBLISHED
       // environment -- restricted to its export surface -- because every
       // consumer of `Checked`'s env (env cache, persistent store, worker
@@ -3312,7 +3370,8 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
       } else {
         ""
       }
-      Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity)
+      let module_typing_artifact = checked_module_typing_artifact_bytes(checked_program, job)
+      Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity, module_typing_artifact)
     } with Exception {
       Throw(msg) => Diagnosed(job.path, [
         String::concat(String::concat(job.path, ": "), locate_type_error(job.source, msg))
@@ -3333,7 +3392,7 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
     } else {
       throw(String::concat(job.path, ": type error"))
     },
-    Checked(path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity) => {
+    Checked(path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity, _) => {
       // Serialize the TypeEnv once. Production-default TDRE4 publication binds
       // the exact same text as the conservative target; serializing it a second
       // time materially inflates fresh selfcompile heap without adding evidence.
@@ -3517,7 +3576,7 @@ fn parse_job_rows(job_text: String) -> (String, Array[String], Array[String]) wi
   // so a worker killed mid-write leaves an obviously unfinished job dir
   // rather than a plausible-looking wrong answer.
   match outcome {
-    Checked(_, fingerprint, env, _, _, _) => {
+    Checked(_, fingerprint, env, _, _, _, _) => {
       Fs::write_file(job_dir_path(dir, "env.out"), persistent_type_env_cache_text(env))
       // The module's own identity, as check_module computed it -- an
       // OUTPUT of this job, needed by the coordinator to build the NEXT

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3312,9 +3312,10 @@ export fn checked_module_typing_artifact_observation(outcome: ModuleOutcome) -> 
   }
 }
 
-/// Pure module check. No Fs: the dependency environments it needs are
-/// already values inside the job.
-export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
+/// Pure module check implementation. Artifact observation is explicitly opt-in:
+/// the production incremental path must not allocate canonical shadow bytes for
+/// every checked module when no observer consumes them.
+fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOutcome with Exception {
   // Parse stays OUTSIDE the handler below: parse errors currently
   // propagate verbatim, while type errors get located and path-prefixed.
   // Folding both into one handler would relabel every parse diagnostic.
@@ -3370,7 +3371,11 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
       } else {
         ""
       }
-      let module_typing_artifact = checked_module_typing_artifact_bytes(checked_program, job)
+      let module_typing_artifact = if observe_typing_artifact {
+        checked_module_typing_artifact_bytes(checked_program, job)
+      } else {
+        None
+      }
       Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity, module_typing_artifact)
     } with Exception {
       Throw(msg) => Diagnosed(job.path, [
@@ -3379,6 +3384,19 @@ export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
     }
   }
 }
+
+/// Production module check. No Fs: dependency environments are already values
+/// inside the job. Shadow artifact observation stays disabled by default.
+export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
+  check_module_impl(job, false)
+}
+
+/// Opt-in trusted #1550 observation producer. This runs the same complete module
+/// checker and retains canonical bytes only in its opaque successful outcome.
+export fn check_module_with_typing_artifact_observation(job: ModuleJob) -> ModuleOutcome with Exception {
+  check_module_impl(job, true)
+}
+
 /// Coordinator-owned commit. Every filesystem and accumulator write for a
 /// module happens here and nowhere else.
 fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, job: ModuleJob, outcome: ModuleOutcome) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {

--- a/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
@@ -19,6 +19,10 @@ import @vibe/compiler/core {
   Expr, Stmt, TypeExpr
 }
 
+import @vibe/compiler/runtime {
+  ModuleJob, check_module, checked_module_typing_artifact_observation
+}
+
 import @vibe/compiler/syntax {
   lex
 }
@@ -125,6 +129,16 @@ fn mt_assert_decode_none(text: String) -> Unit {
   match decode_checked_module_typing_artifact_v1(text) {
     Some(_) => assert(false),
     None => assert(true)
+  }
+}
+
+fn mt_module_job(path: String, source: String) -> ModuleJob {
+  ModuleJob::{
+    path: path,
+    source: source,
+    deps: array_empty(),
+    dep_fps: array_empty(),
+    dep_envs: array_empty()
   }
 }
 
@@ -483,4 +497,37 @@ test "wrapper around genuine checker failure returns no module artifact bytes" {
     Some(_) => assert(false),
     None => assert(true)
   }
+}
+
+test "opaque successful ModuleOutcome carries one canonical in-memory artifact" {
+  let outcome = check_module(mt_module_job("owner.vibe", "export let api: Int = 1\n"))
+  match checked_module_typing_artifact_observation(outcome) {
+    Some(bytes) => match decode_checked_module_typing_artifact_v1(bytes) {
+      Some(artifact) => {
+        assert(encode_checked_module_typing_artifact_v1(artifact) == bytes)
+        assert(String::contains(bytes, "owner.vibe"))
+        assert(String::contains(bytes, "provisional_token_stream_v1"))
+        assert(String::contains(bytes, "ineligible:lossless_checked_body_unavailable_v1"))
+      },
+      None => assert(false)
+    },
+    None => assert(false)
+  }
+}
+
+test "opaque ModuleOutcome publishes nothing for ordinary type or effect failures" {
+  let type_failure = check_module(mt_module_job("type_bad.vibe", "export let bad: Int = \"not an int\"\n"))
+  assert(checked_module_typing_artifact_observation(type_failure) == None)
+  let effect_failure = check_module(mt_module_job("effect_bad.vibe", "effect Logger { Log(String) -> Unit }\nexport fn bad() -> Int {\n  perform Logger::Log(\"hi\")\n  1\n}\n"))
+  assert(checked_module_typing_artifact_observation(effect_failure) == None)
+}
+
+test "later diagnosed outcome cannot reuse a stale successful observation" {
+  let successful = check_module(mt_module_job("same.vibe", "export let api: Int = 1\n"))
+  match checked_module_typing_artifact_observation(successful) {
+    Some(_) => assert(true),
+    None => assert(false)
+  }
+  let diagnosed = check_module(mt_module_job("same.vibe", "export let api: Int = \"stale\"\n"))
+  assert(checked_module_typing_artifact_observation(diagnosed) == None)
 }

--- a/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
@@ -20,7 +20,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/runtime {
-  ModuleJob, check_module, checked_module_typing_artifact_observation
+  ModuleJob, check_module, check_module_with_typing_artifact_observation, checked_module_typing_artifact_observation
 }
 
 import @vibe/compiler/syntax {
@@ -499,8 +499,13 @@ test "wrapper around genuine checker failure returns no module artifact bytes" {
   }
 }
 
+test "production module check leaves shadow observation disabled" {
+  let outcome = check_module(mt_module_job("default.vibe", "export let api: Int = 1\n"))
+  assert(checked_module_typing_artifact_observation(outcome) == None)
+}
+
 test "opaque successful ModuleOutcome carries one canonical in-memory artifact" {
-  let outcome = check_module(mt_module_job("owner.vibe", "export let api: Int = 1\n"))
+  let outcome = check_module_with_typing_artifact_observation(mt_module_job("owner.vibe", "export let api: Int = 1\n"))
   match checked_module_typing_artifact_observation(outcome) {
     Some(bytes) => match decode_checked_module_typing_artifact_v1(bytes) {
       Some(artifact) => {
@@ -516,18 +521,18 @@ test "opaque successful ModuleOutcome carries one canonical in-memory artifact" 
 }
 
 test "opaque ModuleOutcome publishes nothing for ordinary type or effect failures" {
-  let type_failure = check_module(mt_module_job("type_bad.vibe", "export let bad: Int = \"not an int\"\n"))
+  let type_failure = check_module_with_typing_artifact_observation(mt_module_job("type_bad.vibe", "export let bad: Int = \"not an int\"\n"))
   assert(checked_module_typing_artifact_observation(type_failure) == None)
-  let effect_failure = check_module(mt_module_job("effect_bad.vibe", "effect Logger { Log(String) -> Unit }\nexport fn bad() -> Int {\n  perform Logger::Log(\"hi\")\n  1\n}\n"))
+  let effect_failure = check_module_with_typing_artifact_observation(mt_module_job("effect_bad.vibe", "effect Logger { Log(String) -> Unit }\nexport fn bad() -> Int {\n  perform Logger::Log(\"hi\")\n  1\n}\n"))
   assert(checked_module_typing_artifact_observation(effect_failure) == None)
 }
 
 test "later diagnosed outcome cannot reuse a stale successful observation" {
-  let successful = check_module(mt_module_job("same.vibe", "export let api: Int = 1\n"))
+  let successful = check_module_with_typing_artifact_observation(mt_module_job("same.vibe", "export let api: Int = 1\n"))
   match checked_module_typing_artifact_observation(successful) {
     Some(_) => assert(true),
     None => assert(false)
   }
-  let diagnosed = check_module(mt_module_job("same.vibe", "export let api: Int = \"stale\"\n"))
+  let diagnosed = check_module_with_typing_artifact_observation(mt_module_job("same.vibe", "export let api: Int = \"stale\"\n"))
   assert(checked_module_typing_artifact_observation(diagnosed) == None)
 }

--- a/lib/@vibe/compiler/tests/codegen_test_support.vibe
+++ b/lib/@vibe/compiler/tests/codegen_test_support.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/codegen {
 }
 
 import @vibe/compiler/codegen/gc {
-  compile_wasi_module_gc, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_safe, gc_to_string_resolves_to_show_wrapper
 }
 
 import @vibe/compiler/syntax {
@@ -55,7 +55,8 @@ export fn compile_wasi_gc(source: String, entry: String) -> Bytes with Exception
   // is already the pre-strip shape gc_to_string_resolves_to_show_wrapper
   // needs.
   let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
-  compile_wasi_module_gc(stmts, entry, gc_to_string_is_wrapper)
+  let direct_abi_pre_erasure_safe = gc_direct_abi_pre_erasure_safe(stmts)
+  compile_wasi_module_gc(stmts, entry, gc_to_string_is_wrapper, direct_abi_pre_erasure_safe)
 }
 
 export fn compile_wasi_with_imports(import_sources: Array[String], source: String, entry: String) -> Bytes with Exception {

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -19,7 +19,7 @@ import @vibe/compiler/codegen/wasi {
 }
 
 import ../codegen_gc.vibe {
-  compile_wasi_module_gc, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_safe, gc_to_string_resolves_to_show_wrapper
 }
 
 import @vibe/compiler/codegen {
@@ -54,7 +54,8 @@ fn gc_err(src: String) -> String {
     // #1015: no strip pass runs here, so `stmts` is still the pre-strip
     // shape gc_to_string_resolves_to_show_wrapper needs.
     let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
-    let _ = compile_wasi_module_gc(stmts, "__no_entry__", gc_to_string_is_wrapper)
+    let direct_abi_pre_erasure_safe = gc_direct_abi_pre_erasure_safe(stmts)
+    let _ = compile_wasi_module_gc(stmts, "__no_entry__", gc_to_string_is_wrapper, direct_abi_pre_erasure_safe)
     ""
   } with Exception {
     Throw(msg) => msg

--- a/scripts/bench_report.mjs
+++ b/scripts/bench_report.mjs
@@ -38,6 +38,8 @@ const fmt = (n) => n == null ? "–" : n.toLocaleString("en-US");
 // change misread as host-speed drift and divided out of every advisory
 // delta (found in review, #1209) — so all three hashes must be present
 // and equal on both snapshots before normalizing.
+const RUNNER_FACTOR_MIN = 0.85;
+const RUNNER_FACTOR_MAX = 1.18;
 let runnerFactor = null;
 let calibNote = "no calibration data (older baseline snapshot, or runner/seed unavailable) — deltas below are raw, uncorrected for runner speed";
 {
@@ -51,8 +53,14 @@ let calibNote = "no calibration data (older baseline snapshot, or runner/seed un
     } else if (mismatched.length) {
       calibNote = `calibration inputs changed between baseline and current (${mismatched.join(", ")}) — not comparable (bootstrap bump, or a change to runtime/viberun or the calibration bench), deltas below are raw`;
     } else if (b.ns_p50 > 0) {
-      runnerFactor = c.ns_p50 / b.ns_p50;
-      calibNote = `runner factor ${runnerFactor.toFixed(3)}× (${c.label || "calibration"}: current ${fmt(c.ns_p50)}ns vs baseline ${fmt(b.ns_p50)}ns p50) — advisory deltas below are normalized to correct for it`;
+      const candidateFactor = c.ns_p50 / b.ns_p50;
+      const reading = `${c.label || "calibration"}: current ${fmt(c.ns_p50)}ns vs baseline ${fmt(b.ns_p50)}ns p50`;
+      if (candidateFactor >= RUNNER_FACTOR_MIN && candidateFactor <= RUNNER_FACTOR_MAX) {
+        runnerFactor = candidateFactor;
+        calibNote = `runner factor ${runnerFactor.toFixed(3)}× (${reading}) — advisory deltas below are normalized to correct for it`;
+      } else {
+        calibNote = `runner mismatch: calibration factor ${String(candidateFactor)}× is outside the plausible ${RUNNER_FACTOR_MIN.toFixed(2)}–${RUNNER_FACTOR_MAX.toFixed(2)}× range (${reading}) — advisory deltas below are raw`;
+      }
     }
   }
 }

--- a/scripts/bench_report.test.mjs
+++ b/scripts/bench_report.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const reportScript = new URL("./bench_report.mjs", import.meta.url);
+const hashes = {
+  seed_sha256: "seed",
+  runner_sha256: "runner",
+  bench_sha256: "bench",
+};
+
+function renderReport({ factor, currentWall, baselineWall = 100 }) {
+  const dir = mkdtempSync(join(tmpdir(), "vibe-bench-report-"));
+  try {
+    const baseline = {
+      commit: "baseline",
+      date: "2026-08-11",
+      selfcompile: { wall_ms_median: baselineWall },
+      sizes: {},
+      benches: {},
+      calibration: { label: "build_100", ns_p50: 10000, ...hashes },
+    };
+    const current = {
+      commit: "current",
+      selfcompile: { wall_ms_median: currentWall },
+      sizes: {},
+      benches: {},
+      calibration: { label: "build_100", ns_p50: Math.round(factor * 10000), ...hashes },
+    };
+    const currentPath = join(dir, "current.json");
+    const baselinePath = join(dir, "baseline.json");
+    writeFileSync(currentPath, JSON.stringify(current));
+    writeFileSync(baselinePath, JSON.stringify(baseline));
+    const result = spawnSync(process.execPath, [reportScript.pathname, currentPath, baselinePath], {
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function advisoryWallRow(report) {
+  return report.split("\n").find((line) => line.startsWith("| selfcompile wall_ms"));
+}
+
+test("0.586 runner mismatch fails open to the raw advisory delta", () => {
+  const report = renderReport({ factor: 0.586, currentWall: 80 });
+  assert.match(report, /runner mismatch: calibration factor 0\.586× is outside the plausible 0\.85–1\.18× range/);
+  assert.equal(advisoryWallRow(report), "| selfcompile wall_ms (median) | 80 | 100 | -20.00% 🎉 |");
+  assert.doesNotMatch(advisoryWallRow(report), /\(norm\)/);
+});
+
+test("0.807 runner mismatch does not turn a flat raw reading into a normalized warning", () => {
+  const report = renderReport({ factor: 0.807, currentWall: 100 });
+  assert.match(report, /runner mismatch: calibration factor 0\.807×/);
+  assert.equal(advisoryWallRow(report), "| selfcompile wall_ms (median) | 100 | 100 | ±0 |");
+  assert.doesNotMatch(advisoryWallRow(report), /⚠️|\(norm\)/);
+});
+
+test("1.132 plausible factor preserves existing normalized behavior", () => {
+  const report = renderReport({ factor: 1.132, currentWall: 120 });
+  assert.match(report, /runner factor 1\.132× .* advisory deltas below are normalized/);
+  assert.equal(advisoryWallRow(report), "| selfcompile wall_ms (median) | 120 | 100 | +6.01% (norm) |");
+});
+
+test("plausible normalization may expose sign disagreement without a false warning", () => {
+  const report = renderReport({ factor: 1.132, currentWall: 105 });
+  assert.equal(advisoryWallRow(report), "| selfcompile wall_ms (median) | 105 | 100 | -7.24% (norm) |");
+  assert.doesNotMatch(advisoryWallRow(report), /⚠️|🎉/);
+});
+
+test("plausibility range is inclusive and reports adjacent rejections honestly", () => {
+  assert.match(renderReport({ factor: 0.85, currentWall: 100 }), /runner factor 0\.850×/);
+  assert.match(renderReport({ factor: 1.18, currentWall: 100 }), /runner factor 1\.180×/);
+  assert.match(renderReport({ factor: 0.8499, currentWall: 100 }), /runner mismatch: calibration factor 0\.8499×/);
+  assert.match(renderReport({ factor: 1.1801, currentWall: 100 }), /runner mismatch: calibration factor 1\.1801×/);
+});

--- a/scripts/coverage/cov_units.vibe
+++ b/scripts/coverage/cov_units.vibe
@@ -1,3 +1,26 @@
+import ../../lib/@vibe/compiler/core/bytebuf.vibe {
+  bytebuf_new
+}
+
+import ../../lib/@vibe/compiler/codegen/common_extractors/common_extractors.vibe {
+  emit_assignop_op as cov_emit_assignop_op
+}
+
+import ../../lib/@vibe/compiler/checker/builtins_misc.vibe {
+  lookup_iter_intrinsic as cov_lookup_iter_intrinsic
+}
+
+import ../../lib/@vibe/compiler/runtime/eval_loader/eval_loader.vibe {
+  load_and_parse
+}
+
+import ../../lib/@vibe/compiler/core/dce.vibe {
+  dce_reachable_names
+}
+
+import ../../lib/@vibe/compiler/loader/loader.vibe {
+  collect_import_deps_from_stmts, strip_trailing_cr
+}
 
 // #cov unit driver: call small pure/low-dependency compiler helpers directly with
 // crafted inputs so their fully/mostly-dark validation and dispatch arms run —
@@ -5,16 +28,16 @@
 // collect_import_deps_from_stmts, pat_binds_name. These never see edge inputs in a
 // normal compile of the examples/fixtures corpus.
 let cov_u_assignop: (String) -> Int = (op) -> {
-  handle { let buf = bytebuf_new(); emit_assignop_op(buf, op); Bytes::length(buf) } with Exception { Throw(_) => 0 }
+  handle { let buf = bytebuf_new(); cov_emit_assignop_op(buf, op); Bytes::length(buf) } with Exception { Throw(_) => 0 }
 }
 let cov_u_iter: (String) -> Int = (name) -> {
-  match lookup_iter_intrinsic(name) { Some(_) => 1, None => 0 }
+  match cov_lookup_iter_intrinsic(name) { Some(_) => 1, None => 0 }
 }
 let cov_u_parse: (String) -> Array[Stmt] = (src) -> {
   handle { load_and_parse(src) } with Exception { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
 }
 
-export let cov_units_main: () -> Int = () -> {
+export let cov_units_main: () -> Int with Exception + Fs = () -> {
   let mut acc = 0
   // strip_trailing_cr: with CR, without CR, empty, single char
   acc = acc + String::length(strip_trailing_cr("hello\r"))

--- a/scripts/coverage_drivers.sh
+++ b/scripts/coverage_drivers.sh
@@ -9,12 +9,13 @@
 #   - TypeEnv-walking trait helpers fed only checker-built shapes
 #   - the linked_imports>0 / library_mode arms of compile_wasi_module_linked_impl
 #
-# Each driver below APPENDS a small entry to the cycle-free *no-DCE merged source*
-# (every top-level fn in scope, no import cycle) and compiles+runs it under
-# coverage, unioning the executed branches into the corpus acc.json by
+# Drivers compile and run against a cycle-free no-DCE compiler source under
+# coverage, unioning executed branches into the corpus acc.json by
 # (fn_name, local_branch_index) — valid because every binary shares the same
-# per-function branch ordering. Run coverage_corpus.sh FIRST (it builds
-# acc.json + the instrumented compiler_cov.wasm this suite reuses).
+# per-function branch ordering. The migrated `units` driver is merged by the
+# compiler-owned exact-path exposure mode; remaining drivers temporarily retain
+# the legacy raw base until later #1633 slices. Run coverage_corpus.sh FIRST (it
+# builds acc.json + the instrumented compiler_cov.wasm this suite reuses).
 #
 #   scripts/coverage_drivers.sh
 set -uo pipefail
@@ -22,6 +23,9 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SEED="${VIBE_COV_SEED:-bootstrap/seed/compiler.wasm}"
 OUTDIR="_build/coverage/selfhost-corpus"
 ACC="$OUTDIR/acc.json"
+COMPILER_COV="$OUTDIR/compiler_cov.wasm"
+COMPILER_ENTRY="lib/@vibe/compiler/cli_adapter.vibe"
+DRIVER_FILTER="${VIBE_COV_DRIVER_FILTER:-}"
 RUNNER="scripts/run_wasm_vibe_host_runner.sh"
 # Same node-stack requirement as coverage_corpus.sh: every driver compiles the
 # ~5MB merged source (plus the driver) under coverage instrumentation, which
@@ -67,12 +71,16 @@ fi
 cd "$ROOT" || exit 1
 mkdir -p "$WORK"
 [ -s "$ACC" ] || { echo "drivers: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
+[ -s "$COMPILER_COV" ] || { echo "drivers: run coverage_corpus.sh first (no current compiler_cov.wasm)" >&2; exit 1; }
 
-# 1. Regenerate the no-DCE merged source: every manifest file, imports stripped,
-#    concatenated (the pre-DCE input to build_module_source_from_source). This is
-#    the base every driver appends to.
-echo "[drivers] regenerating no-DCE merged source ..." >&2
-python3 - "lib/@vibe/compiler" "lib/@vibe/compiler/compiler_sources_manifest.tsv" "cli_adapter.vibe" "$MERGED" <<'PY'
+# 1. Regenerate the legacy no-DCE source only for drivers not yet migrated to
+#    exact-path exposure. #1633's first slice migrates `units`; the remaining
+#    drivers deliberately stay on their existing path until separate reviewed
+#    slices move them. A units-only smoke therefore never constructs or trusts
+#    the old raw concatenation.
+if [ -z "$DRIVER_FILTER" ] || [ "$DRIVER_FILTER" != "units" ]; then
+  echo "[drivers] regenerating legacy no-DCE source ..." >&2
+  python3 - "lib/@vibe/compiler" "lib/@vibe/compiler/compiler_sources_manifest.tsv" "cli_adapter.vibe" "$MERGED" <<'PY'
 import os, re, sys
 compiler_dir, manifest_path, root_rel, out_path = sys.argv[1:]
 rows=[]
@@ -137,7 +145,8 @@ with open(out_path,"w",encoding="utf-8") as f:
         if first: m=m.lstrip("\r\n"); first=False
         f.write(m)
 PY
-[ -s "$MERGED" ] || { echo "drivers: merged source generation failed" >&2; exit 1; }
+  [ -s "$MERGED" ] || { echo "drivers: merged source generation failed" >&2; exit 1; }
+fi
 
 # (fn_name, local_branch_index) union of a driver's raw coverage dump into
 # acc.json -- scripts/coverage_local_merge.vibex's `merge` subcommand (native
@@ -154,11 +163,39 @@ PY
 # Count them and fail the suite at the end (after running every driver, so one
 # breakage does not hide the rest).
 DRIVER_FAILS=0
+DRIVERS_RAN=0
 
 run_driver() { # entry driver_file label
   local entry="$1" file="$2" label="$3"
+  if [ -n "$DRIVER_FILTER" ] && [ "$DRIVER_FILTER" != "$label" ]; then
+    return 0
+  fi
+  DRIVERS_RAN=$((DRIVERS_RAN + 1))
   local d="$WORK/$label"; rm -rf "$d"; mkdir -p "$d"
-  cat "$MERGED" "$file" > "$d/src.vibe"
+  if [ "$label" = "units" ]; then
+    # The current instrumented compiler owns this internal emit mode. It
+    # collects the production compiler closure, resolves cov_units' exact-file
+    # value requests, and rewrites them to the ordinary merge's final names.
+    # The pinned seed only compiles the emitted ordinary source; no seed bump.
+    rm -f "$d/src.vibe" "$d/src.vibe.diag"
+    VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1 \
+      VIBE_COVERAGE_DRIVER_PATH="$file" \
+      VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+      bash "$RUNNER" --invoke cli_main "$COMPILER_COV" \
+      "$COMPILER_ENTRY" "$d/src.vibe" "$entry" >"$d/expose.log" 2>&1 || true
+    if [ ! -s "$d/src.vibe" ]; then
+      echo "[$label] exact-path exposure failed" >&2
+      if [ -s "$d/src.vibe.diag" ]; then
+        awk '{ print "               " $0 }' "$d/src.vibe.diag" >&2
+      elif [ -s "$d/expose.log" ]; then
+        tail -3 "$d/expose.log" | awk '{ print "               " $0 }' >&2
+      fi
+      DRIVER_FAILS=$((DRIVER_FAILS + 1))
+      return 0
+    fi
+  else
+    cat "$MERGED" "$file" > "$d/src.vibe"
+  fi
   local compile_status=0
   coverage_driver_compile_with_retries "$d" "$entry" || compile_status=$?
   if [ "$compile_status" != 0 ]; then
@@ -256,6 +293,10 @@ echo "[drivers] corpus branches: $base -> $now/$tot ($pct%)  (+$((now-base)))" >
 # Without this the line above is the whole story, and `+0` reads as "the
 # drivers added nothing new" rather than "no driver ran". Never report a
 # coverage number as if it came from a complete run when it did not.
+if [ "$DRIVERS_RAN" -eq 0 ]; then
+  echo "[drivers] FAIL: VIBE_COV_DRIVER_FILTER='$DRIVER_FILTER' selected no driver" >&2
+  exit 1
+fi
 if [ "$DRIVER_FAILS" -gt 0 ]; then
   echo "[drivers] FAIL: $DRIVER_FAILS driver(s) did not contribute coverage (see the per-driver reasons above)" >&2
   echo "[drivers] the branch numbers above are therefore INCOMPLETE" >&2

--- a/scripts/coverage_drivers.sh
+++ b/scripts/coverage_drivers.sh
@@ -18,7 +18,7 @@
 #
 #   scripts/coverage_drivers.sh
 set -uo pipefail
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SEED="${VIBE_COV_SEED:-bootstrap/seed/compiler.wasm}"
 OUTDIR="_build/coverage/selfhost-corpus"
 ACC="$OUTDIR/acc.json"
@@ -31,7 +31,41 @@ RUNNER="scripts/run_wasm_vibe_host_runner.sh"
 # with EVERY driver silently skipped. Keep in sync with coverage_corpus.sh.
 export VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --experimental-wasm-inlining --stack-size=131072}"
 MERGED="_build/coverage/merged_nodce.vibe"
-WORK="_build/coverage/drivers"; mkdir -p "$WORK"
+WORK="_build/coverage/drivers"
+
+# Split out one attempt so the deterministic-vs-transient retry contract has a
+# focused shell test without invoking the full coverage corpus.
+coverage_driver_compile_once() { # dir entry
+  local driver_dir="$1" entry="$2"
+  VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+    bash "$RUNNER" --invoke cli_main "$SEED" "$driver_dir/src.vibe" "$driver_dir/m.wasm" "$entry" >"$driver_dir/compile.log" 2>&1
+}
+
+COVERAGE_DRIVER_COMPILE_ATTEMPTS=0
+coverage_driver_compile_with_retries() { # dir entry
+  local driver_dir="$1" entry="$2" attempt
+  COVERAGE_DRIVER_COMPILE_ATTEMPTS=0
+  for attempt in 1 2 3 4 5 6; do
+    COVERAGE_DRIVER_COMPILE_ATTEMPTS="$attempt"
+    rm -f "$driver_dir/m.wasm" "$driver_dir/m.wasm.diag"
+    coverage_driver_compile_once "$driver_dir" "$entry" || true
+    [ -s "$driver_dir/m.wasm" ] && return 0
+    # A compiler diagnostic is deterministic. Only host/OOM failures without a
+    # diagnostic are eligible for another attempt.
+    [ -s "$driver_dir/m.wasm.diag" ] && return 2
+  done
+  return 1
+}
+
+if [ "${VIBE_COVERAGE_DRIVERS_LIB_ONLY:-0}" = "1" ]; then
+  if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    return 0
+  fi
+  exit 0
+fi
+
+cd "$ROOT" || exit 1
+mkdir -p "$WORK"
 [ -s "$ACC" ] || { echo "drivers: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
 
 # 1. Regenerate the no-DCE merged source: every manifest file, imports stripped,
@@ -125,18 +159,16 @@ run_driver() { # entry driver_file label
   local entry="$1" file="$2" label="$3"
   local d="$WORK/$label"; rm -rf "$d"; mkdir -p "$d"
   cat "$MERGED" "$file" > "$d/src.vibe"
-  local ok=0 t
-  for t in 1 2 3 4 5 6; do
-    rm -f "$d/m.wasm"
-    VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
-      bash "$RUNNER" --invoke cli_main "$SEED" "$d/src.vibe" "$d/m.wasm" "$entry" >"$d/compile.log" 2>&1 || true
-    [ -s "$d/m.wasm" ] && { ok=1; break; }
-  done
-  if [ "$ok" != 1 ]; then
-    # "compile failed after retries" on its own cost a manual re-run to learn
-    # anything. The compiler already wrote the reason to the `.diag` sidecar --
-    # surface it, so the message names what to fix.
-    echo "[$label] compile failed after retries" >&2
+  local compile_status=0
+  coverage_driver_compile_with_retries "$d" "$entry" || compile_status=$?
+  if [ "$compile_status" != 0 ]; then
+    # Surface deterministic diagnostics immediately; only diagnostic-free host
+    # failures consume the six-attempt retry budget.
+    if [ "$compile_status" = 2 ]; then
+      echo "[$label] deterministic compile failure (not retried)" >&2
+    else
+      echo "[$label] compile failed after $COVERAGE_DRIVER_COMPILE_ATTEMPTS transient attempts" >&2
+    fi
     # awk, not sed: the compiler writes the sidecar WITHOUT a trailing newline,
     # and sed passes that through -- so the reason ran straight into the next
     # driver's line (`unknown name: db_new[round] compile failed ...`). awk's

--- a/scripts/test_gc_heap_accounting.sh
+++ b/scripts/test_gc_heap_accounting.sh
@@ -34,20 +34,17 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   exit 1
 }
 
-# Churn, the if branch, the match branch, and (since #1332) the nested lambda
-# body and a lambda created inside a module initializer each have one eligible
-# literal -- five in total. Alias/push/return, an array a DEEPER lambda
-# captures, and an array bound directly in an initializer's own `_start` frame
-# still use the linear fallback. This guards typed-ref/i64 sibling-control-flow
-# regressions, the lambda/capture boundary, and the frame-vs-module halves of
-# the eligibility split, all at Wasm emission.
+# Churn, the if branch, the match branch, the #1332 nested-lambda sites, and
+# the #1541 plain local alias each have one eligible literal -- six in total.
+# Push/return (this mixed fixture disables the direct ABI island), a deeper
+# lambda capture, and an initializer-frame binding retain the linear fallback.
 python3 - "$OUT" <<'PY'
 import sys
 wasm = open(sys.argv[1], "rb").read()
 count = wasm.count(b"\xfb\x07\x0c")
-if count != 5:
+if count != 6:
     raise SystemExit(
-        "[gc-heap-accounting] FAIL: expected five eligible native "
+        "[gc-heap-accounting] FAIL: expected six eligible native "
         f"array.new_default type 12 instructions, found {count}"
     )
 PY
@@ -56,6 +53,58 @@ PY
 # records DO describe typed native-array locals, so this is the check that the
 # lambda code section declares (ref null $array) for exactly those slots.
 wasm-tools validate --features all "$OUT" >/dev/null
+
+# #1541 direct-call ABI pair. The positive fixture has one native literal that
+# crosses a typed Array[Int] parameter/result/alias chain. The fallback fixture
+# contains the same candidate signature plus a generic crossing; its complete
+# component must retain the tagged-i64 ABI, so no native literal is emitted.
+DIRECT_OUT="$WORK/direct_array_abi.wasm"
+DIRECT_OUT_REL="${DIRECT_OUT#"$ROOT_DIR"/}"
+VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+  fixtures/gc_direct_array_abi_test.vibe "$DIRECT_OUT_REL" __no_entry__ >/dev/null
+wasm-tools validate --features all "$DIRECT_OUT" >/dev/null
+"$RUNNER" "$DIRECT_OUT" >/dev/null
+
+compile_direct_abi_fallback() {
+  local fixture="$1"
+  local output="$2"
+  local output_rel="${output#"$ROOT_DIR"/}"
+  VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+    "$fixture" "$output_rel" __no_entry__ >/dev/null
+  wasm-tools validate --features all "$output" >/dev/null
+  "$RUNNER" "$output" >/dev/null
+}
+
+FALLBACK_OUT="$WORK/direct_array_abi_fallback.wasm"
+SHADOW_FALLBACK_OUT="$WORK/direct_array_abi_shadow_fallback.wasm"
+EXPORT_FALLBACK_OUT="$WORK/direct_array_abi_export_fallback.wasm"
+compile_direct_abi_fallback fixtures/gc_direct_array_abi_fallback_test.vibe "$FALLBACK_OUT"
+compile_direct_abi_fallback fixtures/gc_direct_array_abi_shadow_fallback_test.vibe "$SHADOW_FALLBACK_OUT"
+compile_direct_abi_fallback fixtures/gc_direct_array_abi_export_fallback_test.vibe "$EXPORT_FALLBACK_OUT"
+
+python3 - "$DIRECT_OUT" "$FALLBACK_OUT" "$SHADOW_FALLBACK_OUT" "$EXPORT_FALLBACK_OUT" <<'PY'
+import sys
+positive = open(sys.argv[1], "rb").read().count(b"\xfb\x07\x0c")
+fallbacks = {
+    "generic": open(sys.argv[2], "rb").read().count(b"\xfb\x07\x0c"),
+    "spelling shadow": open(sys.argv[3], "rb").read().count(b"\xfb\x07\x0c"),
+    "export": open(sys.argv[4], "rb").read().count(b"\xfb\x07\x0c"),
+}
+if positive != 1:
+    raise SystemExit(
+        "[gc-heap-accounting] FAIL: expected one #1541 direct-ABI native "
+        f"literal, found {positive}"
+    )
+for label, count in fallbacks.items():
+    if count != 0:
+        raise SystemExit(
+            f"[gc-heap-accounting] FAIL: {label} boundary mixed a typed "
+            f"reference into the fallback component ({count} native literals)"
+        )
+PY
+echo "[gc-heap-accounting] ok: direct Array[Int] ABI and fail-closed component fallbacks"
 
 REPORT="$(VIBE_MEM=1 "$RUNNER" "$OUT" 2>&1 >/dev/null)" || {
   printf '%s\n' "$REPORT" >&2
@@ -95,11 +144,9 @@ case "$ALLOCATED" in
     ;;
 esac
 
-# The fixture's 8192 churn literals are native GC arrays. The current fixture
-# also deliberately executes several linear fallback examples (alias, push,
-# return, a module-level initializer, and since #1332 an array a DEEPER lambda
-# captures), so its observed fixed baseline is 396 B -- it has moved 228 -> 304
-# -> 380 -> 396 as those fallback cases were added.
+# The fixture's 8192 churn literals are native GC arrays. It also deliberately
+# executes several linear fallback examples (push, return, a module-level
+# initializer, and a deeper-lambda capture). The alias is native since #1541.
 # Do not assert that exact value: startup/layout and fallback
 # fixture changes may move it. The old linear churn lowering was hundreds of
 # KiB, therefore this bounded allowance remains the regression property.

--- a/scripts/tests/coverage_driver_exposure_test.sh
+++ b/scripts/tests/coverage_driver_exposure_test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# #1633: compiler-owned exact-path coverage-driver exposure.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+SEED="${VIBE_COV_SEED:-bootstrap/seed/compiler.wasm}"
+RUNNER="scripts/run_wasm_vibe_host_runner.sh"
+FLAT="lib/@vibe/compiler/_cli_adapter_module_source.vibe"
+TMP="_build/coverage-driver-exposure-test"
+TOOL="$TMP/compiler_cov.wasm"
+export VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --experimental-wasm-inlining --stack-size=131072}"
+
+rm -rf "$TMP"
+mkdir -p "$TMP"
+bash scripts/ensure_generated.sh >/dev/null
+
+# Build the CURRENT compiler under instrumentation. The pinned seed only
+# compiles this emitted ordinary source; it does not need to know the new mode.
+VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$RUNNER" --invoke cli_main "$SEED" "$FLAT" "$TOOL" cli_main >/dev/null
+[ -s "$TOOL" ] || { echo "coverage-driver-exposure: current compiler_cov.wasm was not produced" >&2; exit 1; }
+
+cat > "$TMP/dep.vibe" <<'VEOF'
+fn hidden(x: Int) -> Int { x + 1 }
+export fn public_value() -> Int { 40 }
+enum Secret { HiddenCtor }
+let mut mutable_state = 1
+extern let %host_value: (Int) -> Int
+VEOF
+cat > "$TMP/dup.vibe" <<'VEOF'
+fn repeated() -> Int { 1 }
+fn repeated() -> Int { 2 }
+export fn keep() -> Int { 2 }
+VEOF
+cat > "$TMP/outside.vibe" <<'VEOF'
+fn outside_value() -> Int { 9 }
+VEOF
+cat > "$TMP/root.vibe" <<'VEOF'
+import ./dep.vibe { public_value }
+import ./dup.vibe { keep }
+export fn root_main() -> Int { public_value() + keep() }
+VEOF
+cat > "$TMP/positive.vibe" <<'VEOF'
+import ./dep.vibe { hidden as selected_hidden }
+export fn driver_main() -> Int { selected_hidden(41) }
+VEOF
+
+emit_driver() { # driver output entry
+  local driver="$1" output="$2" entry="$3"
+  rm -f "$output" "$output.diag"
+  VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1 \
+    VIBE_COVERAGE_DRIVER_PATH="$driver" \
+    VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+    bash "$RUNNER" --invoke cli_main "$TOOL" \
+    "$TMP/root.vibe" "$output" "$entry" >/dev/null 2>&1 || true
+}
+
+# Positive: a private exact-file value imported under an alias is rewritten by
+# the shadow-aware production rewriter, retained by DCE, compiled, and run.
+emit_driver "$TMP/positive.vibe" "$TMP/positive.out.vibe" driver_main
+[ -s "$TMP/positive.out.vibe" ] || { cat "$TMP/positive.out.vibe.diag" >&2; exit 1; }
+if grep -q 'selected_hidden' "$TMP/positive.out.vibe"; then
+  echo "coverage-driver-exposure: import alias survived instead of being rewritten" >&2
+  exit 1
+fi
+VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$RUNNER" --invoke cli_main "$SEED" \
+  "$TMP/positive.out.vibe" "$TMP/positive.wasm" driver_main >/dev/null
+positive_out="$(VIBE_PREOPEN_DIR="$ROOT" bash "$RUNNER" --invoke driver_main "$TMP/positive.wasm" 2>&1 | tail -1)"
+[ "$positive_out" = "42" ] || { echo "coverage-driver-exposure: positive run got '$positive_out', want 42" >&2; exit 1; }
+
+# Ordinary merged-source mode remains separate and never appends the driver.
+rm -f "$TMP/ordinary.vibe" "$TMP/ordinary.vibe.diag"
+VIBE_EMIT_MERGED_SOURCE=1 VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$RUNNER" --invoke cli_main "$TOOL" \
+  "$TMP/root.vibe" "$TMP/ordinary.vibe" root_main >/dev/null 2>&1 || true
+[ -s "$TMP/ordinary.vibe" ] || { cat "$TMP/ordinary.vibe.diag" >&2; exit 1; }
+if grep -q 'driver_main' "$TMP/ordinary.vibe"; then
+  echo "coverage-driver-exposure: ordinary merged output contains coverage driver" >&2
+  exit 1
+fi
+
+expect_rejected() { # label driver source diagnostic-fragment
+  local label="$1" source="$2" expected="$3"
+  local driver="$TMP/$label.vibe" output="$TMP/$label.out.vibe"
+  printf '%s\n' "$source" > "$driver"
+  emit_driver "$driver" "$output" driver_main
+  if [ -s "$output" ]; then
+    echo "coverage-driver-exposure: $label unexpectedly emitted source" >&2
+    exit 1
+  fi
+  if [ ! -s "$output.diag" ] || ! grep -Fq "$expected" "$output.diag"; then
+    echo "coverage-driver-exposure: $label missing diagnostic '$expected'" >&2
+    cat "$output.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+}
+
+expect_rejected missing \
+  'import ./does-not-exist.vibe { nope }
+export fn driver_main() -> Int { 0 }' \
+  'target file is missing from the collected compiler closure'
+expect_rejected outside \
+  'import ./outside.vibe { outside_value }
+export fn driver_main() -> Int { outside_value() }' \
+  'target exists but is outside the collected compiler closure'
+expect_rejected type \
+  'import ./dep.vibe { Secret }
+export fn driver_main() -> Int { 0 }' \
+  'unsupported type'
+expect_rejected ctor \
+  'import ./dep.vibe { HiddenCtor }
+export fn driver_main() -> Int { 0 }' \
+  'unsupported constructor'
+expect_rejected mutable \
+  'import ./dep.vibe { mutable_state }
+export fn driver_main() -> Int { 0 }' \
+  'unsupported mutable global'
+# Extern names require the `%` spelling, which import-item syntax rejects
+# before exposure resolution. This is still fail-closed at the parser boundary.
+expect_rejected extern \
+  'import ./dep.vibe { %host_value }
+export fn driver_main() -> Int { 0 }' \
+  'expected import item name'
+expect_rejected duplicate \
+  'import ./dup.vibe { repeated }
+export fn driver_main() -> Int { repeated() }' \
+  'duplicate top-level value declarations'
+expect_rejected local_collision \
+  'import ./dep.vibe { hidden as same }
+import ./dup.vibe { keep as same }
+export fn driver_main() -> Int { same() }' \
+  'local import name collides with another request'
+expect_rejected driver_collision \
+  'import ./dep.vibe { hidden as driver_main }
+export fn driver_main() -> Int { 0 }' \
+  'driver top-level value collides with an imported local name'
+expect_rejected method \
+  'import ./dep.vibe { String::hidden_method }
+export fn driver_main() -> Int { 0 }' \
+  'method and qualified targets are unsupported'
+
+printf 'coverage_driver_exposure_test: ok\n'

--- a/scripts/tests/coverage_drivers_test.sh
+++ b/scripts/tests/coverage_drivers_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 source scripts/coverage_drivers.sh
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+DRIVER_DIR="$TMP/driver"
+mkdir -p "$DRIVER_DIR"
+: > "$DRIVER_DIR/src.vibe"
+
+# A sidecar diagnostic is deterministic: one attempt and a nonzero status.
+deterministic_attempts=0
+coverage_driver_compile_once() {
+  deterministic_attempts=$((deterministic_attempts + 1))
+  printf 'unknown name: db_new\n' > "$1/m.wasm.diag"
+  return 1
+}
+status=0
+coverage_driver_compile_with_retries "$DRIVER_DIR" main || status=$?
+[ "$status" = 2 ]
+[ "$deterministic_attempts" = 1 ]
+[ "$COVERAGE_DRIVER_COMPILE_ATTEMPTS" = 1 ]
+
+# A diagnostic-free transient failure remains retryable and may succeed on the
+# sixth and final attempt.
+transient_attempts=0
+coverage_driver_compile_once() {
+  transient_attempts=$((transient_attempts + 1))
+  if [ "$transient_attempts" = 6 ]; then
+    printf 'wasm' > "$1/m.wasm"
+    return 0
+  fi
+  return 1
+}
+coverage_driver_compile_with_retries "$DRIVER_DIR" main
+[ "$transient_attempts" = 6 ]
+[ "$COVERAGE_DRIVER_COMPILE_ATTEMPTS" = 6 ]
+
+# A persistent diagnostic-free host failure stops after exactly six attempts.
+host_attempts=0
+coverage_driver_compile_once() {
+  host_attempts=$((host_attempts + 1))
+  return 1
+}
+status=0
+coverage_driver_compile_with_retries "$DRIVER_DIR" main || status=$?
+[ "$status" = 1 ]
+[ "$host_attempts" = 6 ]
+[ "$COVERAGE_DRIVER_COMPILE_ATTEMPTS" = 6 ]
+
+echo 'coverage_drivers_test: ok'


### PR DESCRIPTION
## Summary

- stop retrying deterministic coverage-driver diagnostics while retaining six bounded retries for transient failures
- add production-merge-owned exact-path value exposure and migrate `cov_units`
- fail open for implausible benchmark runner calibration
- add a fail-closed private direct `Array[Int]` wasm-gc ABI island
- retain a trusted, post-check, in-memory-only module typing artifact observation

## Validation

- `pkf run test-gc-heap-accounting`
- `pkf run test-gc-native-alloc-probe`
- `bash scripts/tests/coverage_drivers_test.sh`
- `bash scripts/tests/coverage_driver_exposure_test.sh`
- `node --test scripts/bench_report.test.mjs`
- `bash scripts/vibe_test.sh lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe`
- independent reviewer passes for coverage, wasm-gc, incremental, and performance changes
- content transfer into the integration branch verified by exact blob IDs

`pkf run release-check` progressed through the compiler fixed point and all checks through compiler-gate 91, then hit an unchanged macOS/BSD `xargs -I` replacement-size portability failure at typecheck-fixture gate 92 (`command line cannot be assembled, too long`). Re-running with a minimal environment reproduced it. Coverage corpus also retains unchanged BSD `realpath --relative-to` and pinned-seed/prelude limitations.

## Residual scope

- #1633 remains open for the other 39 coverage drivers and full corpus/merge attestation.
- #1541 remains open for non-`Array[Int]` representations and indirect/import/aggregate/global/control-flow/conversion boundaries.
- #1550 remains open for persistent/reuse authority and broader artifact shapes.
- #1536 async evidence work was rejected by review and is intentionally absent.

Closes #1555
Closes #1635
