### PR TITLE
feat(async): support direct suspended selection inputs

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1075,7 +1075,11 @@ let/seq/tail/分岐 tail に直接現れる必要がある。**let 連鎖 (brace
 文や文位置の async-iterator `for` の脱糖出力) が文の途中 (sequence HEAD)
 に立つ形は、split が継続 spine へ float して受理する** (#1536 (a) v3,
 ADR-0076 追記42 — `async_iter_collect` / `_fold` / `_count` が suspend
-body から呼べるのはこれ)。**concrete な row に
+body から呼べるのはこれ)。**`if` condition / `match` scrutinee が direct
+perform・concrete needing call・CPS-local call そのものなら、fresh let へ
+一回評価してから selection する形も可** (追記44)。`perform Op() > 0` や
+`Some(perform Op())` のような compound selection input は reject のまま。
+**concrete な row に
 対象 effect を含む top-level 関数の呼び出しは可** (3b yield bubbling —
 再帰も可; callee には CPS clone が合成され、元の関数は他の呼び出し元
 向けに無変更)。それ以外に呼べるのは perform / pure builtin / ctor /

--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2813,10 +2813,23 @@ match の pattern binder は tail の元の外側参照を捕獲し得るため�
 分配する。freshness は pattern・arm body・shared tail の全出現を probe する。
 `effect_seq_head_if_suspend.vibe` (want 41100) は condition 一回評価と branch-local
 shadow を、`effect_seq_head_match_suspend.vibe` (want 3200) は scrutinee 一回評価と
-pattern capture を pin する。suspend が condition / scrutinee 自身にある形は選択前の
-継続を要するためこの slice の範囲外で、negative fixture で拒否を固定する。
+pattern capture を pin する。
 
-**残る不適格**: EForIn(array)/ELoop HEAD、代入 RHS 直書きの perform、row 変数
+### 追記44 (2026-08-12): direct selection input を継続 spine に名前付けする (#1536 (a) v5)
+
+`if` condition / `match` scrutinee が **direct target perform、concrete needing call、
+または既に step-typed な CPS-local call そのもの**なら、scope-blind collision probe で
+fresh な binder を作り `ELet(tmp, input, EIf/EMatch(tmp, ...))` へ正規化する。これで
+入力は一回だけ評価され、既存の let/bubble spine が selection 後の branch/arm と tail
+を処理する。tail-position と sequence-HEAD の両方で同じ変換を使う。
+
+`perform Op() > 0` や `Some(perform Op())` のように suspend を内包する compound input
+は direct shape ではなく、評価順序の一般 CPS 化を暗黙に始めないため拒否を維持する。
+positive fixtures は if/match の一回評価・tail 一回実行・名前/pattern capture 回避を、
+negative fixtures は compound input の fail-closed 診断を固定する。
+
+**残る不適格**: EForIn(array)/ELoop HEAD、代入 RHS 直書きの perform、compound
+selection input、row 変数
 callee、literal param flow。
 
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect

--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -66,7 +66,7 @@ Phase A が実バグと同じ棚に並んでしまう。
 
 | # | blocker | 内容 |
 |---|---|---|
-| #1536 | ✔ | suspend CPS split の see-through。row-free closure param flow 証明と eager `Stream::next` retarget は済み。残り = row-variable callee / literal-param flow |
+| #1536 | ✔ | suspend CPS split の see-through。row-free closure param flow、eager `Stream::next` retarget、direct if-condition/match-scrutinee は済み。残り = row-variable callee / residual literal-param flow / compound selection input |
 | #1511 | | `handle` の適格性制約が型検査を通り抜ける。(c) エラー文は済み、(b) は #1536 のスライスと同一機構 |
 | #1520 | | builtin レジストリの検証。提案 1 は済み、残り = 85 件の二重宣言の一括整理 + 提案 3 の正例コーパス |
 | #1508 | | `Http` を実行する test / bench。row 構文は済み、残り = test/bench 経路での `Http::*` lowering |

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -169,9 +169,11 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   (brace block 文・文位置の async-iterator `for` の脱糖出力 — #1536 (a) v3
   の let-floating が継続 spine へ再バランスする、ADR-0076 追記42)、
   **row-free closure パラメータの呼び出しのうち、全 by-name call site の
-  実引数が suspend-inert と証明できるもの** (#1536 (a)。下記)
+  実引数が suspend-inert と証明できるもの** (#1536 (a)。下記)、`if` condition /
+  `match` scrutinee が direct target perform・concrete needing call・CPS-local call
+  そのものの形 (fresh let へ一回評価してから selection、ADR-0076 追記44)
 - **不適格**: ループ内 `break`/`continue`/`return`、配列 `for` / `loop` 形、
-  sequence HEAD に立つ perform 抱えの `if`/`match` 複合式、代入 RHS 直書きの
+  selection input が suspend を内包する複合式、代入 RHS 直書きの
   perform (`acc = perform ..`)、実引数証明が成立しない
   closure パラメータの呼び出し、row 変数 callee (`with e`)
 
@@ -1823,7 +1825,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 
 | 項目 | 内容 | 依存 |
 |---|---|---|
-| **suspend lowering の適格性** (#1536) | row-variable callee と literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow、eager `await(Stream::next(s))` retarget、sequence-HEAD let 連鎖の float (`for` 駆動 terminal) は済み (§2.2 末尾) | — (ADR-0076 本体) |
+| **suspend lowering の適格性** (#1536) | row-variable callee と residual literal-param flow が `scps_calls_ok` を通らない。row-free closure-param flow、eager `await(Stream::next(s))` retarget、sequence-HEAD let 連鎖の float (`for` 駆動 terminal)、direct if-condition/match-scrutinee は済み (§2.2 末尾) | — (ADR-0076 本体) |
 | **AsyncIter への一本化** (#1538) | eager `Stream[T]` combinator の退役 / AsyncIter 上への再実装。`Stream::next` protocol と host stream read の接続 | 上の適格性 |
 | **stdin provider / `StdinStream` の p3 接続** (#1539) | **atomic public source route + additive compiler-owned direct chunk operation まで実装**: unforgeable nominal `StdinStream`、exact authority/effects、exact `vibe.stdin_provider_*` raw imports、tagged-i64 bridge、任意 core composer、stdin-first sniff、`StdinStream::read_chunk` を実装。pull-closure/direct-`for` adapter は transitive HOF effect evidence (#1536) 待ち。既存 `stdin_stream(chunk_size)` は standalone-capable のまま未変更 (§3.18.3) | Wasmtime 47 real-source drain/early-close/function-alias/sequential-reacquire/multiple-active + binary `00 80 ff 41 42` manual while-loop chunks (linear/RC, n=4/1/0/negative, EOF/post-close) gate; GC/standalone/mixed reject; generic `[3, handle]` `HostStream` import は不使用 |
 | **実 provider = `wasi:http` incoming-body** (#1540) | serve composition と host-stream composition の統合が要る (§3.19 に構造的な理由と 3 点の分解) | — |

--- a/fixtures/effect_seq_head_if_condition_suspend.vibe
+++ b/fixtures/effect_seq_head_if_condition_suspend.vibe
@@ -1,0 +1,39 @@
+// #1536 direct selection input: a direct perform in an if condition is named
+// once on the CPS spine before branch selection. The user collision name must
+// remain untouched, and the sequence tail runs exactly once.
+effect Ask {
+  Get(Int) -> Bool
+}
+
+let visits = [
+  0
+]
+let tails = [
+  0
+]
+
+let _start = () -> Int {
+  handle {
+    let __scps_seq_0_select = 100
+    let mut got = 0
+    if perform Ask::Get(1) {
+      got = 3
+    } else {
+      got = 9
+    }
+    Array::set(tails, 0, Array::get(tails, 0) + 1)
+    got * 1000 + Array::get(visits, 0) * 100 + Array::get(tails, 0) * 10 + __scps_seq_0_select
+  } with Ask {
+    Get(n) => {
+      Array::set(visits, 0, Array::get(visits, 0) + 1)
+      let k = resume
+      k(n == 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "last": "3210"
+}

--- a/fixtures/effect_seq_head_match_scrutinee_suspend.vibe
+++ b/fixtures/effect_seq_head_match_scrutinee_suspend.vibe
@@ -1,0 +1,44 @@
+// #1536 direct selection input: a direct perform in a match scrutinee is named
+// once on the CPS spine. Pattern selection and the sequence tail each execute
+// once, while the outer binding remains capture-safe.
+effect Ask {
+  Get(Int) -> Option[Int]
+}
+
+let visits = [
+  0
+]
+let tails = [
+  0
+]
+
+let _start = () -> Int {
+  handle {
+    let outer = 100
+    let mut got = 0
+    match perform Ask::Get(2) {
+      Some(outer) => {
+        got = outer + 1
+        got
+      },
+      None => {
+        got = 9
+        got
+      }
+    }
+    Array::set(tails, 0, Array::get(tails, 0) + 1)
+    got * 1000 + Array::get(visits, 0) * 100 + Array::get(tails, 0) * 10 + outer
+  } with Ask {
+    Get(n) => {
+      Array::set(visits, 0, Array::get(visits, 0) + 1)
+      let k = resume
+      k(Some(n))
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "last": "3210"
+}

--- a/fixtures/effect_tail_selection_input_suspend.vibe
+++ b/fixtures/effect_tail_selection_input_suspend.vibe
@@ -1,0 +1,58 @@
+// #1536 direct selection input: direct performs are also supported when the
+// if/match itself is in tail position. Each operation and selected arm runs
+// exactly once; the encoded result pins both selections and visit counts.
+effect AskBool {
+  Get(Int) -> Bool
+}
+
+effect AskOption {
+  Get(Int) -> Option[Int]
+}
+
+let bool_visits = [
+  0
+]
+let option_visits = [
+  0
+]
+
+let tail_if = () -> Int {
+  handle {
+    if perform AskBool::Get(1) {
+      3
+    } else {
+      9
+    }
+  } with AskBool {
+    Get(n) => {
+      Array::set(bool_visits, 0, Array::get(bool_visits, 0) + 1)
+      let k = resume
+      k(n == 1)
+    }
+  }
+}
+
+let tail_match = () -> Int {
+  handle {
+    match perform AskOption::Get(2) {
+      Some(value) => value + 1,
+      None => 9
+    }
+  } with AskOption {
+    Get(n) => {
+      Array::set(option_visits, 0, Array::get(option_visits, 0) + 1)
+      let k = resume
+      k(Some(n))
+    }
+  }
+}
+
+let _start = () -> Int {
+  tail_if() * 1000 + tail_match() * 100 + Array::get(bool_visits, 0) * 10 + Array::get(option_visits, 0)
+}
+_start()
+
+__DATA__
+{
+  "last": "3311"
+}

--- a/fixtures/err_effect_seq_head_if_condition_suspend.vibe
+++ b/fixtures/err_effect_seq_head_if_condition_suspend.vibe
@@ -1,6 +1,5 @@
-// #1536 (a) v4 boundary: only a branch-local suspend can receive the
-// distributed sequence continuation. A suspend in the condition precedes
-// branch selection and remains unsupported by this slice.
+// #1536 boundary: only a direct recognized suspension may be normalized as a
+// selection input. This compound binary condition remains fail-closed.
 effect Ask {
   Get(Int) -> Int
 }

--- a/fixtures/err_effect_seq_head_match_compound_scrutinee_suspend.vibe
+++ b/fixtures/err_effect_seq_head_match_compound_scrutinee_suspend.vibe
@@ -1,14 +1,14 @@
-// #1536 (a) v4 boundary: a suspend in the match scrutinee precedes pattern
-// selection, so it cannot use the branch-continuation distribution here.
+// #1536 boundary: a constructor wrapping a suspension is compound rather than
+// a direct recognized selection input, so it remains fail-closed.
 effect Ask {
   Get(Int) -> Int
 }
 
 let _start = () -> Int {
   handle {
-    match perform Ask::Get(1) {
-      1 => 10,
-      _ => 20
+    match Some(perform Ask::Get(1)) {
+      Some(n) => n,
+      None => 0
     }
     0
   } with Ask {

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9292,8 +9292,22 @@ fn scps_need_clone(eff: String, fname: String, st: (Array[Int], Array[String], A
 // lowered (a handle body or a clone body); the result is an expression
 // producing a __ScpsStep_E value. Suspendables (direct performs of E,
 // calls to needing functions) are only recognized on the
-// let/seq/tail/branch-tail spine -- anything else containing one fails
-// the split (returned Bool = false).
+// let/seq/tail/branch-tail spine. A direct recognized suspension may also
+// occupy an if condition or match scrutinee: it is first named by a fresh
+// ELet, then the existing spine machinery resumes into selection. Compound
+// selection inputs and every other nested suspension still fail closed.
+
+fn scps_direct_selection_input(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String])) -> Bool {
+  let (_, ops, _, _, _) = sctx
+  scps_as_target_perform(e, ops) >= 0 || scps_as_needing_call(e, sctx) != "" || scps_as_cps_local_call(e, sctx) != ""
+}
+
+fn scps_selection_fresh(e: Expr, site: Int) -> String {
+  // Reuse the scope-blind collision probe used by sequence-head floating.
+  // Passing the whole selection expression ensures the generated binder is
+  // absent from both the input and every continuation branch/arm.
+  scps_seq_float_fresh("select", e, EUnit, site)
+}
 
 fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), st: (Array[Int], Array[String], Array[String], Array[String], Array[String], Array[Stmt], Array[String])) -> (Bool, Expr) {
   let (eff, ops, _, site, cps_locals) = sctx
@@ -9452,7 +9466,10 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           // branch and its continuation. Branch-local lets remain lexical
           // to their branch because `b` is an ESeq sibling, not their body.
           EIf(c, t, el) => if scps_contains_susp(a, sctx) {
-            if scps_contains_susp(c, sctx) {
+            if scps_direct_selection_input(c, sctx) {
+              let sx = scps_selection_fresh(e, site)
+              scps_split_tail(ELet(sx, c, EIf(EIdent(sx, -1), ESeq(t, b), ESeq(el, b)), -1), sctx, ctx, st)
+            } else if scps_contains_susp(c, sctx) {
               (false, e)
             } else {
               scps_split_tail(EIf(c, ESeq(t, b), ESeq(el, b)), sctx, ctx, st)
@@ -9466,7 +9483,10 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           // match originally; without the rename, a pattern binding could
           // capture an outer reference in the duplicated tail.
           EMatch(s, arms) => if scps_contains_susp(a, sctx) {
-            if scps_contains_susp(s, sctx) {
+            if scps_direct_selection_input(s, sctx) {
+              let sx = scps_selection_fresh(e, site)
+              scps_split_tail(ELet(sx, s, EMatch(EIdent(sx, -1), scps_seq_float_match_arms(arms, b, site)), -1), sctx, ctx, st)
+            } else if scps_contains_susp(s, sctx) {
               (false, e)
             } else {
               scps_split_tail(EMatch(s, scps_seq_float_match_arms(arms, b, site)), sctx, ctx, st)
@@ -9529,7 +9549,10 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
             }
           }
         },
-        EIf(c, t, el) => if scps_contains_susp(c, sctx) {
+        EIf(c, t, el) => if scps_direct_selection_input(c, sctx) {
+          let sx = scps_selection_fresh(e, site)
+          scps_split_tail(ELet(sx, c, EIf(EIdent(sx, -1), t, el), -1), sctx, ctx, st)
+        } else if scps_contains_susp(c, sctx) {
           (false, e)
         } else {
           let (tok, te) = scps_split_tail(t, sctx, ctx, st)
@@ -9540,7 +9563,10 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
             (false, e)
           }
         },
-        EMatch(s, arms) => if scps_contains_susp(s, sctx) {
+        EMatch(s, arms) => if scps_direct_selection_input(s, sctx) {
+          let sx = scps_selection_fresh(e, site)
+          scps_split_tail(ELet(sx, s, EMatch(EIdent(sx, -1), arms), -1), sctx, ctx, st)
+        } else if scps_contains_susp(s, sctx) {
           (false, e)
         } else {
           let out = scps_empty_arms()

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6846,10 +6846,14 @@ scps_run_expect "effect_seq_head_reserved_name_collision.vibe" "3011" "seqheadfr
 # condition/scrutinee and capture-safe branch/pattern bindings.
 scps_run_expect "effect_seq_head_if_suspend.vibe" "41100" "seqheadif"
 scps_run_expect "effect_seq_head_match_suspend.vibe" "3200" "seqheadmatch"
-# This continuation distribution deliberately starts AFTER selection; a
-# suspendable if condition or match scrutinee remains an ineligible head.
-scps_check_reject "err_effect_seq_head_if_condition_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadifcond"
-scps_check_reject "err_effect_seq_head_match_scrutinee_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadmatchscrut"
+# #1536 direct selection input: a recognized direct perform is first named on
+# the CPS spine, evaluates once, then selects a branch/arm whose continuation
+# runs once. Compound inputs remain fail-closed.
+scps_run_expect "effect_seq_head_if_condition_suspend.vibe" "3210" "seqheadifcond"
+scps_run_expect "effect_seq_head_match_scrutinee_suspend.vibe" "3210" "seqheadmatchscrut"
+scps_run_expect "effect_tail_selection_input_suspend.vibe" "3311" "tailselectinput"
+scps_check_reject "err_effect_seq_head_if_condition_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadifcompound"
+scps_check_reject "err_effect_seq_head_match_compound_scrutinee_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadmatchcompound"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"
 scps_check_reject "err_effect_resume_store_ineligible.vibe" "cannot see through" "inelig"
 scps_check_reject "err_effect_closure_param_taint.vibe" "cannot see through" "inerttaint"


### PR DESCRIPTION
Replacement for #1638, reconstructed as a narrow patch on current main after detecting stale-clone full-file drift.

## Summary
- normalize direct recognized suspension in `if` conditions and `match` scrutinees onto the existing CPS `let` spine
- cover sequence-head and tail forms with collision-safe fresh binders
- preserve fail-closed rejection for compound inputs and provenance-sensitive cases
- update ADR/spec/cheatsheet/triage docs

## Validation
- independent verifier accepted after obsolete negative fixture removal
- focused Phase 3a gate passed in source checkout
- test-local selected suites passed in source checkout; current standalone clone also reaches the unchanged select_test_shard baseline failure
- generated freshness and formatter passed

#1536 remains open for row-variable evidence, residual literal provenance, loops/for-in, and assignment RHS.