### PR TITLE
test(coverage): attest fail-closed pipeline inputs

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -316,13 +316,16 @@ local testSimdEmitWasmtime =
 local testCoverageScripts = new Task {
   name = "test-coverage-scripts"
   cmd =
-    "node --test scripts/coverage_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/select_test_shard.test.mjs && python3 scripts/coverage_suite_report_test.py && bash scripts/tests/coverage_drivers_test.sh"
+    "node --test scripts/coverage_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/select_test_shard.test.mjs && python3 scripts/coverage_suite_report_test.py && bash scripts/tests/coverage_drivers_test.sh && bash scripts/tests/coverage_pipeline_contract_test.sh"
   inputs {
     "scripts/**/*.mjs"
     "scripts/coverage_suite_report.py"
     "scripts/coverage_suite_report_test.py"
+    "scripts/coverage_corpus.sh"
     "scripts/coverage_drivers.sh"
+    "scripts/coverage_local_merge_run.sh"
     "scripts/tests/coverage_drivers_test.sh"
+    "scripts/tests/coverage_pipeline_contract_test.sh"
   }
 }
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -303,6 +303,23 @@ scripts/coverage_multimodule.sh
 scripts/coverage_features.sh
 ```
 
+`coverage_corpus.sh` は実行前に生成 compiler source と必須入力の存在・鮮度を
+検証するだけで、自動再生成はしない。不足・stale の場合は
+`bash scripts/ensure_generated.sh` を実行するよう診断する。repository 内の
+host path を Python `relpath` + containment check で作るため、GNU
+`realpath --relative-to` を持たない BSD/macOS でも同じ入力を使う。driver の
+checkout-local merge tool は corpus が生成した現在の `compiler_cov.wasm` で
+compile する（committed seed は compiler が emit した通常の merged source を
+compile する役割だけ）。merge は command status と `base now total` schema を
+検査し、`total > 0`、分母不変、hit 非減少、書込み後 stat 一致を満たさなければ
+coverage run 全体を失敗させる。
+
+#1633 の production exact-path exposure へ移行済みなのは現在 `cov_units.vibe`
+だけ。登録済み active driver の残り **38 本**は legacy raw base のままで、個別に
+exact-path import を宣言して移行する必要がある。`cov_driver.vibe` は現在の
+`coverage_drivers.sh` に登録されない historical monolith なので、移行対象へ戻すか
+退役するかを別途決める。ここで件数へ含めたり暗黙に実行済みとは扱わない。
+
 #### 構造的に到達不能な残差（~19 dark）
 
 80% 到達後も残るのは大半が構造的:

--- a/scripts/coverage_corpus.sh
+++ b/scripts/coverage_corpus.sh
@@ -17,7 +17,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 SEED="${VIBE_COV_SEED:-$ROOT_DIR/bootstrap/seed/compiler.wasm}"
-FLAT_ABS="$ROOT_DIR/lib/@vibe/compiler/_cli_adapter_module_source.vibe"
+FLAT_ABS="${VIBE_COV_FLAT_ABS:-$ROOT_DIR/lib/@vibe/compiler/_cli_adapter_module_source.vibe}"
 OUT_DIR="${VIBE_COV_DIR:-$ROOT_DIR/_build/coverage/selfhost-corpus}"
 COMPILER_COV="$OUT_DIR/compiler_cov.wasm"
 RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
@@ -34,15 +34,100 @@ RUN_JSON="$OUT_DIR/run.json"
 FAILS="$OUT_DIR/fails.txt"
 MAX="${VIBE_COV_MAX:-100000}"
 
+# The flat adapter is generated from compiler sources. Keep this corpus entry
+# validation-only and portable on stock BSD/macOS: require every fixed input,
+# synchronously materialize the discovered source list, then compare mtimes.
+# Any missing/stale input or producer failure is actionable and fail-closed.
+coverage_require_fresh_flat() {
+  local input list_file sorted_file
+  local required=(
+    bootstrap/seed/compiler.wasm
+    lib/@vibe/compiler/compiler_sources_manifest.tsv
+    scripts/generate_bundle.sh
+    scripts/ensure_generated.sh
+  )
+  [ -s "$FLAT_ABS" ] || {
+    echo "corpus: generated flat compiler source missing; run: bash scripts/ensure_generated.sh" >&2
+    return 1
+  }
+  for input in "${required[@]}"; do
+    [ -s "$input" ] || {
+      echo "corpus: required freshness input missing or empty: $input; run: bash scripts/ensure_generated.sh" >&2
+      return 1
+    }
+  done
+  list_file="$(mktemp "${TMPDIR:-/tmp}/vibe-cov-inputs.XXXXXX")" || return 1
+  sorted_file="$list_file.sorted"
+  if ! find lib/@vibe lib/@vibex -type f \
+      \( -name '*.vibe' -o -name '*.vpkg' \) \
+      ! -path '*/tests/*' ! -name '*_test.vibe' ! -name '*_bench.vibe' \
+      ! -name 'compiler_sources_bundle.vibe' \
+      ! -name 'cli_adapter_bundle.vibe' \
+      ! -name 'selfbuild_runtime_entry_bundle.vibe' \
+      ! -name '_cli_adapter_module_source.vibe' \
+      ! -name 'codegen_fingerprint.vibe' >"$list_file"; then
+    echo "corpus: failed to enumerate freshness inputs; run: bash scripts/ensure_generated.sh" >&2
+    rm -f "$list_file" "$sorted_file"
+    return 1
+  fi
+  if ! { printf '%s\n' "${required[@]}"; cat "$list_file"; } | LC_ALL=C sort >"$sorted_file"; then
+    echo "corpus: failed to sort freshness inputs; run: bash scripts/ensure_generated.sh" >&2
+    rm -f "$list_file" "$sorted_file"
+    return 1
+  fi
+  rm -f "$list_file"
+  while IFS= read -r input; do
+    [ -s "$input" ] || {
+      echo "corpus: required freshness input missing or empty: $input; run: bash scripts/ensure_generated.sh" >&2
+      rm -f "$sorted_file"
+      return 1
+    }
+    if [ "$input" -nt "$FLAT_ABS" ]; then
+      echo "corpus: generated flat compiler source is stale after $input; run: bash scripts/ensure_generated.sh" >&2
+      rm -f "$sorted_file"
+      return 1
+    fi
+  done <"$sorted_file"
+  rm -f "$sorted_file"
+}
+
+# BSD/macOS realpath has no GNU --relative-to. Python's relpath is portable and
+# the containment check keeps every wasm-host path inside the preopened root.
+rel() {
+  python3 - "$ROOT_DIR" "$1" <<'PY'
+import os, sys
+root = os.path.realpath(sys.argv[1])
+path = os.path.realpath(sys.argv[2])
+try:
+    inside = os.path.commonpath([root, path]) == root
+except ValueError:
+    inside = False
+if not inside:
+    raise SystemExit(f"corpus: path escapes repository root: {sys.argv[2]}")
+print(os.path.relpath(path, root))
+PY
+}
+
+if [ "${VIBE_COVERAGE_CORPUS_LIB_ONLY:-0}" = "1" ]; then
+  if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    return 0
+  fi
+  exit 0
+fi
+
 [ -s "$SEED" ] || { echo "corpus: seed not found" >&2; exit 1; }
+coverage_require_fresh_flat
 rm -rf "$OUT_DIR"; mkdir -p "$OUT_DIR"; : > "$FAILS"
-rel() { realpath --relative-to="$ROOT_DIR" "$1"; }
 FLAT="$(rel "$FLAT_ABS")"
 
 echo "[corpus] building instrumented compiler ..." >&2
 VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash "$RUNNER" --invoke cli_main "$SEED" "$FLAT" "$(rel "$COMPILER_COV")" cli_main
 [ -s "$COMPILER_COV" ] || { echo "corpus: instrumented compiler not produced" >&2; exit 1; }
+# Checkout-local coverage helper sources follow current package contracts. Use
+# the just-built current compiler rather than allowing their wrappers to fall
+# back to the potentially older committed seed.
+export VIBE_COVERAGE_ACC_TOOL_COMPILER="$COMPILER_COV"
 
 # accumulate one workload run (env... -- runner args); merge via
 # scripts/coverage_acc_tool.vibex (OR RUN_JSON's raw bitmap into ACC,

--- a/scripts/coverage_corpus.sh
+++ b/scripts/coverage_corpus.sh
@@ -17,7 +17,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 SEED="${VIBE_COV_SEED:-$ROOT_DIR/bootstrap/seed/compiler.wasm}"
-FLAT_ABS="${VIBE_COV_FLAT_ABS:-$ROOT_DIR/lib/@vibe/compiler/_cli_adapter_module_source.vibe}"
+FLAT_ABS="$ROOT_DIR/lib/@vibe/compiler/_cli_adapter_module_source.vibe"
 OUT_DIR="${VIBE_COV_DIR:-$ROOT_DIR/_build/coverage/selfhost-corpus}"
 COMPILER_COV="$OUT_DIR/compiler_cov.wasm"
 RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
@@ -39,6 +39,7 @@ MAX="${VIBE_COV_MAX:-100000}"
 # synchronously materialize the discovered source list, then compare mtimes.
 # Any missing/stale input or producer failure is actionable and fail-closed.
 coverage_require_fresh_flat() {
+  local flat_abs="${1:-$FLAT_ABS}"
   local input list_file sorted_file
   local required=(
     bootstrap/seed/compiler.wasm
@@ -46,7 +47,7 @@ coverage_require_fresh_flat() {
     scripts/generate_bundle.sh
     scripts/ensure_generated.sh
   )
-  [ -s "$FLAT_ABS" ] || {
+  [ -s "$flat_abs" ] || {
     echo "corpus: generated flat compiler source missing; run: bash scripts/ensure_generated.sh" >&2
     return 1
   }
@@ -82,7 +83,7 @@ coverage_require_fresh_flat() {
       rm -f "$sorted_file"
       return 1
     }
-    if [ "$input" -nt "$FLAT_ABS" ]; then
+    if [ "$input" -nt "$flat_abs" ]; then
       echo "corpus: generated flat compiler source is stale after $input; run: bash scripts/ensure_generated.sh" >&2
       rm -f "$sorted_file"
       return 1
@@ -108,11 +109,8 @@ print(os.path.relpath(path, root))
 PY
 }
 
-if [ "${VIBE_COVERAGE_CORPUS_LIB_ONLY:-0}" = "1" ]; then
-  if [ "${BASH_SOURCE[0]}" != "$0" ]; then
-    return 0
-  fi
-  exit 0
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  return 0
 fi
 
 [ -s "$SEED" ] || { echo "corpus: seed not found" >&2; exit 1; }

--- a/scripts/coverage_drivers.sh
+++ b/scripts/coverage_drivers.sh
@@ -62,15 +62,21 @@ coverage_driver_compile_with_retries() { # dir entry
 }
 
 cd "$ROOT" || exit 1
-mkdir -p "$WORK"
+COVERAGE_DRIVERS_SOURCED=0
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  COVERAGE_DRIVERS_SOURCED=1
+else
+  [ -s "$ACC" ] || { echo "drivers: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
+  [ -s "$COMPILER_COV" ] || { echo "drivers: run coverage_corpus.sh first (no current compiler_cov.wasm)" >&2; exit 1; }
+  mkdir -p "$WORK"
+fi
 
 # 1. Regenerate the legacy no-DCE source only for drivers not yet migrated to
 #    exact-path exposure. #1633's first slice migrates `units`; the remaining
 #    drivers deliberately stay on their existing path until separate reviewed
 #    slices move them. A units-only smoke therefore never constructs or trusts
 #    the old raw concatenation.
-# Library-only mode skips all setup but still loads the helper contracts below.
-if [ "${VIBE_COVERAGE_DRIVERS_LIB_ONLY:-0}" != "1" ] && { [ -z "$DRIVER_FILTER" ] || [ "$DRIVER_FILTER" != "units" ]; }; then
+if [ "$COVERAGE_DRIVERS_SOURCED" = "0" ] && { [ -z "$DRIVER_FILTER" ] || [ "$DRIVER_FILTER" != "units" ]; }; then
   echo "[drivers] regenerating legacy no-DCE source ..." >&2
   python3 - "lib/@vibe/compiler" "lib/@vibe/compiler/compiler_sources_manifest.tsv" "cli_adapter.vibe" "$MERGED" <<'PY'
 import os, re, sys
@@ -178,15 +184,9 @@ coverage_driver_merge_checked() { # acc_path run_path
   printf '%s %s %s\n' "$base" "$now" "$total"
 }
 
-if [ "${VIBE_COVERAGE_DRIVERS_LIB_ONLY:-0}" = "1" ]; then
-  if [ "${BASH_SOURCE[0]}" != "$0" ]; then
-    return 0
-  fi
-  exit 0
+if [ "$COVERAGE_DRIVERS_SOURCED" = "1" ]; then
+  return 0
 fi
-
-[ -s "$ACC" ] || { echo "drivers: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
-[ -s "$COMPILER_COV" ] || { echo "drivers: run coverage_corpus.sh first (no current compiler_cov.wasm)" >&2; exit 1; }
 
 # Run one driver: append <driver>.vibe to the merged source, compile under
 # coverage with the driver entry, run, union into acc.json. Retries: the 36k-line

--- a/scripts/coverage_drivers.sh
+++ b/scripts/coverage_drivers.sh
@@ -61,24 +61,16 @@ coverage_driver_compile_with_retries() { # dir entry
   return 1
 }
 
-if [ "${VIBE_COVERAGE_DRIVERS_LIB_ONLY:-0}" = "1" ]; then
-  if [ "${BASH_SOURCE[0]}" != "$0" ]; then
-    return 0
-  fi
-  exit 0
-fi
-
 cd "$ROOT" || exit 1
 mkdir -p "$WORK"
-[ -s "$ACC" ] || { echo "drivers: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
-[ -s "$COMPILER_COV" ] || { echo "drivers: run coverage_corpus.sh first (no current compiler_cov.wasm)" >&2; exit 1; }
 
 # 1. Regenerate the legacy no-DCE source only for drivers not yet migrated to
 #    exact-path exposure. #1633's first slice migrates `units`; the remaining
 #    drivers deliberately stay on their existing path until separate reviewed
 #    slices move them. A units-only smoke therefore never constructs or trusts
 #    the old raw concatenation.
-if [ -z "$DRIVER_FILTER" ] || [ "$DRIVER_FILTER" != "units" ]; then
+# Library-only mode skips all setup but still loads the helper contracts below.
+if [ "${VIBE_COVERAGE_DRIVERS_LIB_ONLY:-0}" != "1" ] && { [ -z "$DRIVER_FILTER" ] || [ "$DRIVER_FILTER" != "units" ]; }; then
   echo "[drivers] regenerating legacy no-DCE source ..." >&2
   python3 - "lib/@vibe/compiler" "lib/@vibe/compiler/compiler_sources_manifest.tsv" "cli_adapter.vibe" "$MERGED" <<'PY'
 import os, re, sys
@@ -152,6 +144,50 @@ fi
 # acc.json -- scripts/coverage_local_merge.vibex's `merge` subcommand (native
 # vibe port; see that file's header comment for the algorithm).
 
+coverage_driver_stat() { # acc_path
+  local stat_out hit total extra
+  stat_out="$(bash scripts/coverage_acc_tool_run.sh stat "$1")" || return 1
+  # Command substitution strips trailing newlines, so require exactly one
+  # non-empty record and reject embedded/trailing records fail-closed.
+  [[ "$stat_out" != *$'\n'* ]] || return 1
+  read -r hit total extra <<<"$stat_out"
+  [ -z "${extra:-}" ] || return 1
+  [[ "$hit" =~ ^[0-9]+$ && "$total" =~ ^[0-9]+$ ]] || return 1
+  [ "$total" -gt 0 ] || return 1
+  [ "$hit" -le "$total" ] || return 1
+  printf '%s %s\n' "$hit" "$total"
+}
+
+coverage_driver_merge_checked() { # acc_path run_path
+  local acc="$1" run="$2" before_stat before_hit before_total merge_out base now total extra after_stat after_hit after_total
+  before_stat="$(coverage_driver_stat "$acc")" || return 1
+  read -r before_hit before_total <<<"$before_stat"
+  merge_out="$(VIBE_COVERAGE_LOCAL_MERGE_COMPILER="$COMPILER_COV" \
+    bash scripts/coverage_local_merge_run.sh merge "$acc" "$run")" || return 1
+  [[ "$merge_out" != *$'\n'* ]] || return 1
+  read -r base now total extra <<<"$merge_out"
+  [ -z "${extra:-}" ] || return 1
+  [[ "$base" =~ ^[0-9]+$ && "$now" =~ ^[0-9]+$ && "$total" =~ ^[0-9]+$ ]] || return 1
+  [ "$base" -eq "$before_hit" ] || return 1
+  [ "$total" -eq "$before_total" ] || return 1
+  [ "$total" -gt 0 ] || return 1
+  [ "$now" -ge "$base" ] && [ "$now" -le "$total" ] || return 1
+  after_stat="$(coverage_driver_stat "$acc")" || return 1
+  read -r after_hit after_total <<<"$after_stat"
+  [ "$after_hit" -eq "$now" ] && [ "$after_total" -eq "$total" ] || return 1
+  printf '%s %s %s\n' "$base" "$now" "$total"
+}
+
+if [ "${VIBE_COVERAGE_DRIVERS_LIB_ONLY:-0}" = "1" ]; then
+  if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    return 0
+  fi
+  exit 0
+fi
+
+[ -s "$ACC" ] || { echo "drivers: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
+[ -s "$COMPILER_COV" ] || { echo "drivers: run coverage_corpus.sh first (no current compiler_cov.wasm)" >&2; exit 1; }
+
 # Run one driver: append <driver>.vibe to the merged source, compile under
 # coverage with the driver entry, run, union into acc.json. Retries: the 36k-line
 # source occasionally OOMs the seed under instrumentation.
@@ -221,10 +257,16 @@ run_driver() { # entry driver_file label
   VIBE_COV_OUT="$d/cov.json" VIBE_COV_RAW=1 VIBE_PREOPEN_DIR="$ROOT" \
     bash "$RUNNER" "$d/m.wasm" >/dev/null 2>&1 || true
   if [ -s "$d/cov.json" ]; then
-    read -r base now tot < <(bash scripts/coverage_local_merge_run.sh merge "$ACC" "$d/cov.json")
-    scaled=$(( (now * 10000 + tot / 2) / tot ))
-    pct="$((scaled / 100)).$(printf '%02d' $((scaled % 100)))"
-    echo "[$label] $base -> $now/$tot ($pct%) (+$((now-base)))"
+    local merge_stat
+    if merge_stat="$(coverage_driver_merge_checked "$ACC" "$d/cov.json")"; then
+      read -r base now tot <<<"$merge_stat"
+      scaled=$(( (now * 10000 + tot / 2) / tot ))
+      pct="$((scaled / 100)).$(printf '%02d' $((scaled % 100)))"
+      echo "[$label] $base -> $now/$tot ($pct%) (+$((now-base)))"
+    else
+      echo "[$label] local coverage merge failed validation" >&2
+      DRIVER_FAILS=$((DRIVER_FAILS + 1))
+    fi
   else
     echo "[$label] no coverage dumped" >&2
     DRIVER_FAILS=$((DRIVER_FAILS + 1))
@@ -243,7 +285,11 @@ mkdir -p _build/covfs2
 printf 'export let m: () -> Int = () -> { 7 }\n' > _build/covfs2/main.vibe
 printf '# group\tpath\ngrp\tmain.vibe\n' > _build/covfs2/compiler_sources_manifest.tsv
 
-base=$(bash scripts/coverage_acc_tool_run.sh stat "$ACC" | cut -d' ' -f1)
+initial_stat="$(coverage_driver_stat "$ACC")" || {
+  echo "drivers: invalid or empty acc.json statistics" >&2
+  exit 1
+}
+read -r base _ <<<"$initial_stat"
 run_driver cov_async_main      scripts/coverage/cov_async.vibe      async       # inlined async/stream builtins
 run_driver cov_builtins_main   scripts/coverage/cov_builtins.vibe   builtins    # Array/String/Map/Bytes builtins
 run_driver cov_lookup_main     scripts/coverage/cov_lookup.vibe     lookup      # builtin name->Type dispatch chains
@@ -285,7 +331,11 @@ run_driver cov_namespace3_main scripts/coverage/cov_namespace3.vibe namespace3  
 run_driver cov_round_main      scripts/coverage/cov_round.vibe      round       # parse_enum_stmt/parse_export_name forms + print_stmt SImpl/SModule/SReExport/SEffectDef variants + has_non_pipe_infix_top ranges
 rm -f _build/vibe_selfhost_* 2>/dev/null || true
 
-read -r now tot < <(bash scripts/coverage_acc_tool_run.sh stat "$ACC")
+final_stat="$(coverage_driver_stat "$ACC")" || {
+  echo "[drivers] FAIL: invalid final accumulator statistics" >&2
+  exit 1
+}
+read -r now tot <<<"$final_stat"
 scaled=$(( (now * 10000 + tot / 2) / tot ))
 pct="$((scaled / 100)).$(printf '%02d' $((scaled % 100)))"
 echo "[drivers] corpus branches: $base -> $now/$tot ($pct%)  (+$((now-base)))" >&2

--- a/scripts/coverage_local_merge_run.sh
+++ b/scripts/coverage_local_merge_run.sh
@@ -30,9 +30,14 @@ if [ $# -lt 2 ]; then
   exit 2
 fi
 
-compiler="${VIBE_COVERAGE_LOCAL_MERGE_COMPILER:-bootstrap/seed/compiler.wasm}"
+# This tool imports the checkout-local prelude/json surface, so compile it with
+# the current instrumented compiler produced by coverage_corpus.sh. The pinned
+# seed may compile emitted ordinary merged source, but can be older than this
+# checkout's package contracts.
+compiler="${VIBE_COVERAGE_LOCAL_MERGE_COMPILER:-_build/coverage/selfhost-corpus/compiler_cov.wasm}"
 if [ ! -s "$compiler" ]; then
-  echo "coverage_local_merge_run.sh: compiler wasm not found: $compiler" >&2
+  echo "coverage_local_merge_run.sh: current compiler wasm not found: $compiler" >&2
+  echo "coverage_local_merge_run.sh: run scripts/coverage_corpus.sh first" >&2
   exit 2
 fi
 
@@ -41,7 +46,7 @@ workdir="${VIBE_COVERAGE_LOCAL_MERGE_WORKDIR:-_build/coverage_local_merge_tool}"
 mkdir -p "$workdir"
 tool="$workdir/coverage_local_merge.wasm"
 
-if [ ! -s "$tool" ] || [ "$src" -nt "$tool" ]; then
+if [ ! -s "$tool" ] || [ "$src" -nt "$tool" ] || [ "$compiler" -nt "$tool" ]; then
   rm -f "$tool.diag" "$tool.funcmap"
   build_status=0
   env VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \

--- a/scripts/tests/coverage_pipeline_contract_test.sh
+++ b/scripts/tests/coverage_pipeline_contract_test.sh
@@ -8,7 +8,7 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 # Source the driver helpers without requiring a real corpus.
-VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 source scripts/coverage_drivers.sh
+source scripts/coverage_drivers.sh
 COMPILER_COV="$TMP/compiler_cov.wasm"
 printf wasm > "$COMPILER_COV"
 
@@ -63,23 +63,21 @@ FAKE_BEFORE_STAT='3 10' FAKE_AFTER_STAT='4 10' FAKE_STAT_STATUS=7 expect_reject 
 unset FAKE_MERGE_STATUS FAKE_MERGE_OUTPUT FAKE_BEFORE_STAT FAKE_AFTER_STAT FAKE_STAT_STATUS
 
 # Source corpus freshness helpers without running the corpus.
-VIBE_COVERAGE_CORPUS_LIB_ONLY=1 source scripts/coverage_corpus.sh
-REAL_FIND="$(command -v find)"
-REAL_SORT="$(command -v sort)"
-FLAT_ABS="$TMP/flat.vibe"
-printf flat >"$FLAT_ABS"
+source scripts/coverage_corpus.sh
+TEST_FLAT="$TMP/flat.vibe"
+printf flat >"$TEST_FLAT"
 mkdir -p "$TMP/fresh/bin"
 for required in bootstrap/seed/compiler.wasm lib/@vibe/compiler/compiler_sources_manifest.tsv scripts/generate_bundle.sh scripts/ensure_generated.sh; do
   mkdir -p "$TMP/fresh/$(dirname "$required")"
   printf x >"$TMP/fresh/$required"
 done
 mkdir -p "$TMP/fresh/lib/@vibe" "$TMP/fresh/lib/@vibex"
-touch "$FLAT_ABS"
+touch "$TEST_FLAT"
 (
   cd "$TMP/fresh"
-  coverage_require_fresh_flat
+  coverage_require_fresh_flat "$TEST_FLAT"
   rm bootstrap/seed/compiler.wasm
-  if coverage_require_fresh_flat >/dev/null 2>&1; then
+  if coverage_require_fresh_flat "$TEST_FLAT" >/dev/null 2>&1; then
     echo 'coverage_pipeline_contract_test: missing required input was accepted' >&2
     exit 1
   fi
@@ -90,11 +88,30 @@ printf '%s\n' 'lib/@vibe/plausible.vibe'
 exit 9
 SH
   chmod +x bin/find
-  if PATH="$PWD/bin:$PATH" coverage_require_fresh_flat >/dev/null 2>&1; then
+  if PATH="$PWD/bin:$PATH" coverage_require_fresh_flat "$TEST_FLAT" >/dev/null 2>&1; then
     echo 'coverage_pipeline_contract_test: failing find producer was accepted' >&2
     exit 1
   fi
 )
+
+# Library-only environment variables must not bypass direct production entry.
+# Missing prerequisites make both direct invocations fail before doing work.
+if VIBE_COVERAGE_CORPUS_LIB_ONLY=1 VIBE_COV_SEED="$TMP/missing-seed.wasm" \
+    bash scripts/coverage_corpus.sh >/dev/null 2>&1; then
+  echo 'coverage_pipeline_contract_test: corpus direct invocation bypassed prerequisites' >&2
+  exit 1
+fi
+rm -rf "$TMP/direct-drivers"
+if VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 \
+    VIBE_COV_DIR="$TMP/direct-drivers" \
+    bash scripts/coverage_drivers.sh >/dev/null 2>&1; then
+  echo 'coverage_pipeline_contract_test: drivers direct invocation bypassed prerequisites' >&2
+  exit 1
+fi
+[ ! -e "$TMP/direct-drivers" ] || {
+  echo 'coverage_pipeline_contract_test: drivers modified output before prerequisite checks' >&2
+  exit 1
+}
 
 # The local tool defaults to the current corpus compiler, not the pinned seed,
 # and includes compiler freshness in its cache invalidation condition.
@@ -107,7 +124,7 @@ grep -Fq '[ "$compiler" -nt "$tool" ]' scripts/coverage_local_merge_run.sh
 ! grep -Fq 'realpath --relative-to' scripts/coverage_corpus.sh
 ! grep -Eq '^[[:space:]]*bash scripts/ensure_generated[.]sh' scripts/coverage_corpus.sh
 grep -Fq 'coverage_require_fresh_flat' scripts/coverage_corpus.sh
-grep -Fq 'if [ "$input" -nt "$FLAT_ABS" ]' scripts/coverage_corpus.sh
+grep -Fq 'if [ "$input" -nt "$flat_abs" ]' scripts/coverage_corpus.sh
 grep -Fq 'os.path.commonpath' scripts/coverage_corpus.sh
 grep -Fq 'export VIBE_COVERAGE_ACC_TOOL_COMPILER="$COMPILER_COV"' scripts/coverage_corpus.sh
 

--- a/scripts/tests/coverage_pipeline_contract_test.sh
+++ b/scripts/tests/coverage_pipeline_contract_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Source the driver helpers without requiring a real corpus.
+VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 source scripts/coverage_drivers.sh
+COMPILER_COV="$TMP/compiler_cov.wasm"
+printf wasm > "$COMPILER_COV"
+
+# Stub global stat and local merge tools so validation can be exercised without
+# compiling wasm. Their paths are selected by the scripts under test.
+mkdir -p "$TMP/bin"
+printf '{}\n' > "$TMP/acc.json"
+printf '{}\n' > "$TMP/run.json"
+
+# Valid merge: stable positive denominator, monotone hits, and post-write stat.
+# First stat must be 3/10, then post-merge 4/10; use a stateful bash stub.
+cat > "$TMP/bin/bash" <<'SH'
+#!/bin/bash
+if [[ "$*" == *"coverage_acc_tool_run.sh stat"* ]]; then
+  count=0; [ -f "$FAKE_COUNT_FILE" ] && count=$(cat "$FAKE_COUNT_FILE")
+  count=$((count + 1)); printf '%s' "$count" > "$FAKE_COUNT_FILE"
+  if [ "$count" = 1 ]; then printf '%b\n' "${FAKE_BEFORE_STAT:-3 10}"; else printf '%b\n' "${FAKE_AFTER_STAT:-4 10}"; fi
+  exit "${FAKE_STAT_STATUS:-0}"
+fi
+if [[ "$*" == *"coverage_local_merge_run.sh merge"* ]]; then
+  printf '%b\n' "${FAKE_MERGE_OUTPUT:-3 4 10}"
+  exit "${FAKE_MERGE_STATUS:-0}"
+fi
+exec /bin/bash "$@"
+SH
+chmod +x "$TMP/bin/bash"
+export PATH="$TMP/bin:$PATH"
+export FAKE_COUNT_FILE="$TMP/count"
+rm -f "$FAKE_COUNT_FILE"
+[ "$(coverage_driver_merge_checked "$TMP/acc.json" "$TMP/run.json")" = '3 4 10' ]
+
+# Merge failure, malformed schema, zero/changed total, decreasing hits, and a
+# post-write stat mismatch all fail closed.
+expect_reject() {
+  rm -f "$FAKE_COUNT_FILE"
+  if coverage_driver_merge_checked "$TMP/acc.json" "$TMP/run.json" >/dev/null 2>&1; then
+    echo "coverage_pipeline_contract_test: expected rejection: $1" >&2
+    exit 1
+  fi
+}
+FAKE_MERGE_STATUS=7 expect_reject 'merge status'
+FAKE_MERGE_STATUS=0 FAKE_MERGE_OUTPUT='not stats' expect_reject 'malformed output'
+FAKE_MERGE_OUTPUT='3 4 10\n9 9 9' expect_reject 'trailing merge record'
+FAKE_MERGE_OUTPUT='3 4 10 extra' expect_reject 'trailing merge field'
+FAKE_MERGE_OUTPUT='3 3 0' expect_reject 'zero total'
+FAKE_MERGE_OUTPUT='3 4 11' expect_reject 'changed total'
+FAKE_MERGE_OUTPUT='3 2 10' expect_reject 'decreasing hits'
+FAKE_MERGE_OUTPUT='3 4 10' FAKE_AFTER_STAT='5 10' expect_reject 'post-write mismatch'
+FAKE_MERGE_OUTPUT='3 4 10' FAKE_BEFORE_STAT='3 10\n9 9' expect_reject 'trailing pre-merge stat record'
+FAKE_BEFORE_STAT='3 10' FAKE_AFTER_STAT='4 10\n9 9' expect_reject 'trailing post-merge stat record'
+FAKE_BEFORE_STAT='3 10' FAKE_AFTER_STAT='4 10' FAKE_STAT_STATUS=7 expect_reject 'valid stat data with nonzero status'
+unset FAKE_MERGE_STATUS FAKE_MERGE_OUTPUT FAKE_BEFORE_STAT FAKE_AFTER_STAT FAKE_STAT_STATUS
+
+# Source corpus freshness helpers without running the corpus.
+VIBE_COVERAGE_CORPUS_LIB_ONLY=1 source scripts/coverage_corpus.sh
+REAL_FIND="$(command -v find)"
+REAL_SORT="$(command -v sort)"
+FLAT_ABS="$TMP/flat.vibe"
+printf flat >"$FLAT_ABS"
+mkdir -p "$TMP/fresh/bin"
+for required in bootstrap/seed/compiler.wasm lib/@vibe/compiler/compiler_sources_manifest.tsv scripts/generate_bundle.sh scripts/ensure_generated.sh; do
+  mkdir -p "$TMP/fresh/$(dirname "$required")"
+  printf x >"$TMP/fresh/$required"
+done
+mkdir -p "$TMP/fresh/lib/@vibe" "$TMP/fresh/lib/@vibex"
+touch "$FLAT_ABS"
+(
+  cd "$TMP/fresh"
+  coverage_require_fresh_flat
+  rm bootstrap/seed/compiler.wasm
+  if coverage_require_fresh_flat >/dev/null 2>&1; then
+    echo 'coverage_pipeline_contract_test: missing required input was accepted' >&2
+    exit 1
+  fi
+  printf x > bootstrap/seed/compiler.wasm
+  cat > bin/find <<SH
+#!/bin/sh
+printf '%s\n' 'lib/@vibe/plausible.vibe'
+exit 9
+SH
+  chmod +x bin/find
+  if PATH="$PWD/bin:$PATH" coverage_require_fresh_flat >/dev/null 2>&1; then
+    echo 'coverage_pipeline_contract_test: failing find producer was accepted' >&2
+    exit 1
+  fi
+)
+
+# The local tool defaults to the current corpus compiler, not the pinned seed,
+# and includes compiler freshness in its cache invalidation condition.
+grep -Fq 'VIBE_COVERAGE_LOCAL_MERGE_COMPILER:-_build/coverage/selfhost-corpus/compiler_cov.wasm' scripts/coverage_local_merge_run.sh
+grep -Fq '[ "$compiler" -nt "$tool" ]' scripts/coverage_local_merge_run.sh
+
+# Corpus paths and freshness checks are portable on BSD/macOS: no GNU-only
+# realpath/hash/NUL-sort path is invoked, stale flat input fails closed, and
+# paths are containment checked.
+! grep -Fq 'realpath --relative-to' scripts/coverage_corpus.sh
+! grep -Eq '^[[:space:]]*bash scripts/ensure_generated[.]sh' scripts/coverage_corpus.sh
+grep -Fq 'coverage_require_fresh_flat' scripts/coverage_corpus.sh
+grep -Fq 'if [ "$input" -nt "$FLAT_ABS" ]' scripts/coverage_corpus.sh
+grep -Fq 'os.path.commonpath' scripts/coverage_corpus.sh
+grep -Fq 'export VIBE_COVERAGE_ACC_TOOL_COMPILER="$COMPILER_COV"' scripts/coverage_corpus.sh
+
+echo 'coverage_pipeline_contract_test: ok'


### PR DESCRIPTION
## Summary
- validate canonical coverage corpus inputs and freshness before destructive output setup
- propagate `find`, `sort`, stat, and merge producer failures across shell boundaries
- use the current corpus compiler for local accumulator merging
- add executable negatives for missing inputs, failing producers, bypass attempts, schema/denominator/monotonicity violations, and prerequisite ordering
- document validation-only behavior and cache all directly tested scripts

## Validation
- independent verifier: ACCEPT after one bounded fix pass
- `bash -n` on modified scripts: pass
- `coverage_drivers_test.sh`: pass
- `coverage_pipeline_contract_test.sh`: pass
- aggregate task reaches the unchanged macOS `/private` path-normalization failure in `select_test_shard.test.mjs`

This is a bounded #1633 attestation slice. The umbrella remains open for remaining driver migration and complete corpus-to-merge attestation.