### PR TITLE
Land bounded async, wasm-gc alias, and coverage traitenv slices

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1077,8 +1077,10 @@ let/seq/tail/分岐 tail に直接現れる必要がある。**let 連鎖 (brace
 ADR-0076 追記42 — `async_iter_collect` / `_fold` / `_count` が suspend
 body から呼べるのはこれ)。**`if` condition / `match` scrutinee が direct
 perform・concrete needing call・CPS-local call そのものなら、fresh let へ
-一回評価してから selection する形も可** (追記44)。`perform Op() > 0` や
-`Some(perform Op())` のような compound selection input は reject のまま。
+一回評価してから selection する形も可** (追記44)。同じ direct 形そのものは
+**継続 spine 上の通常代入 (`x = perform Op()`) の RHS** でも fresh let を介して
+一回だけ代入できる (追記45)。`perform Op() + 1` のような compound RHS、`+=`
+等の compound assignment、compound selection input は reject のまま。
 **concrete な row に
 対象 effect を含む top-level 関数の呼び出しは可** (3b yield bubbling —
 再帰も可; callee には CPS clone が合成され、元の関数は他の呼び出し元

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -207,8 +207,9 @@ in-scope）を直接叩ける。型/trait/env に加え以下も edge-case 入�
 #### 80% 達成（no-DCE merged source + direct-call drivers）
 
 > **#1633 migration status:** the historical raw concatenation described below
-> is being retired one driver at a time. `cov_units.vibe` now uses compiler-owned
-> exact-path value exposure: its imports name one `.vibe` file in the collected
+> is being retired one driver at a time. `cov_units.vibe` and
+> `cov_traitenv.vibe` now use compiler-owned exact-path value exposure: their
+> imports name one `.vibe` file in the collected
 > compiler closure, the production export/private namespacing plan determines
 > the final target name, and the existing shadow-aware import rewriter updates
 > driver references before entry-based DCE. Missing, duplicate, out-of-closure,
@@ -315,7 +316,8 @@ compile する役割だけ）。merge は command status と `base now total` sc
 coverage run 全体を失敗させる。
 
 #1633 の production exact-path exposure へ移行済みなのは現在 `cov_units.vibe`
-だけ。登録済み active driver の残り **38 本**は legacy raw base のままで、個別に
+と `cov_traitenv.vibe`。登録済み active driver の残り **37 本**は legacy raw base
+のままで、個別に
 exact-path import を宣言して移行する必要がある。`cov_driver.vibe` は現在の
 `coverage_drivers.sh` に登録されない historical monolith なので、移行対象へ戻すか
 退役するかを別途決める。ここで件数へ含めたり暗黙に実行済みとは扱わない。

--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2828,9 +2828,18 @@ fresh な binder を作り `ELet(tmp, input, EIf/EMatch(tmp, ...))` へ正規化
 positive fixtures は if/match の一回評価・tail 一回実行・名前/pattern capture 回避を、
 negative fixtures は compound input の fail-closed 診断を固定する。
 
-**残る不適格**: EForIn(array)/ELoop HEAD、代入 RHS 直書きの perform、compound
-selection input、row 変数
-callee、literal param flow。
+### 追記45 (2026-08-12): direct assignment RHS を継続 spine に名前付けする (#1536 (a) v6)
+
+継続 spine 上の通常代入 `x = rhs` で `rhs` が追記44と同じ **direct target
+perform、concrete needing call、または CPS-local call そのもの**なら、代入式全体を
+scope-blind probe して fresh binder を作り、`let fresh = rhs; x = fresh; rest` として
+既存 split に渡す。probe は identifier だけでなく assignment target も見るため、
+生成名と同じ綴りをユーザーが代入先に使っても capture しない。operation・代入・
+continuation は各一回だけ実行する。compound RHS と `+=` 等の EAssignOp は引き続き
+fail-closed であり、この追記は loop / nested handle / row-variable callee を広げない。
+
+**残る不適格**: EForIn(array)/ELoop HEAD、compound assignment RHS、compound
+selection input、row 変数 callee、literal param flow。
 
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -171,10 +171,12 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   **row-free closure パラメータの呼び出しのうち、全 by-name call site の
   実引数が suspend-inert と証明できるもの** (#1536 (a)。下記)、`if` condition /
   `match` scrutinee が direct target perform・concrete needing call・CPS-local call
-  そのものの形 (fresh let へ一回評価してから selection、ADR-0076 追記44)
+  そのものの形 (fresh let へ一回評価してから selection、ADR-0076 追記44)、
+  **継続 spine 上の通常代入 (`=`) の RHS が同じ direct 形そのもの** (fresh let
+  へ一回評価してから一回だけ代入、追記45)
 - **不適格**: ループ内 `break`/`continue`/`return`、配列 `for` / `loop` 形、
-  selection input が suspend を内包する複合式、代入 RHS 直書きの
-  perform (`acc = perform ..`)、実引数証明が成立しない
+  selection input / 代入 RHS が suspend を内包する複合式、compound assignment
+  (`+=` 等)、実引数証明が成立しない
   closure パラメータの呼び出し、row 変数 callee (`with e`)
 
 closure param を**無条件に**許すのは不健全 — closure literal 内の `perform`

--- a/docs/wasm/gc-value-abi.md
+++ b/docs/wasm/gc-value-abi.md
@@ -151,7 +151,7 @@ checker の静的型から、各スロット (パラメータ / 返り値 / ロ�
 | Phase | 越えられるようになる境界 | 主な作業 | issue / 備考 |
 |---|---|---|---|
 | **A** | **返り値・引数** (非ジェネリックな直接呼び出し) | 関数型を静的型から導出。呼び出し側と定義側で型が一致することの検証 | **#1541**。acceptance の1つ目。ここだけで実用価値が出る |
-| **B** | **別名・局所束縛** | 既存の `gc_native_array_locals` の追跡を関数間へ拡張 | **#1541** (A と同一スライス)。A の自然な帰結 |
+| **B** | **別名・局所束縛** | 既存の `gc_native_array_locals` の追跡を関数間へ拡張 | **#1541** (A と同一スライス)。private concrete `Array[Int]` の直接経路と 1 段の immutable local alias は着地済み。alias 経由で mutate し original 経由で読む identity fixture と native allocation site = 1 の gate で固定。それ以外の join / import / indirect call / aggregate / global は未対応のまま fail-closed |
 | **C** | **集約フィールド** | ユーザ構造体を実 wasm-gc struct へ (ADR-0052 の `struct.set` 経路の一般化) | **#1542**。ヒープモデルの変更を含み、最も重い |
 | **D** | **クロージャ捕捉** | funcref テーブルの型が現状 arity 別 `(i64...)->i64` のみ。型別に増やすか、捕捉は i64 固定にするか | **#1543**。表が型ごとに増える点が最大の論点 |
 

--- a/fixtures/effect_assignment_rhs_suspend.vibe
+++ b/fixtures/effect_assignment_rhs_suspend.vibe
@@ -1,0 +1,33 @@
+// #1536 direct assignment RHS: the operation, assignment, and continuation
+// each execute exactly once. User spellings that match the generated binder
+// base, including an assignment target, must not be captured.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let visits = [0]
+let tails = [0]
+
+let _start = () -> Int {
+  handle {
+    let mut value = 0
+    let mut __scps_seq_0_assign = 100
+    let __scps_seq_0_assign_1 = 1000
+    value = perform Ask::Get(3)
+    __scps_seq_0_assign = __scps_seq_0_assign + 1
+    Array::set(tails, 0, Array::get(tails, 0) + 1)
+    value * 10000 + __scps_seq_0_assign_1 + __scps_seq_0_assign + Array::get(visits, 0) * 10 + Array::get(tails, 0)
+  } with Ask {
+    Get(n) => {
+      Array::set(visits, 0, Array::get(visits, 0) + 1)
+      let k = resume
+      k(n + 1)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "last": "41112"
+}

--- a/fixtures/err_effect_assignment_op_rhs_suspend.vibe
+++ b/fixtures/err_effect_assignment_op_rhs_suspend.vibe
@@ -1,0 +1,24 @@
+// #1536 boundary: compound assignment is not widened by direct assignment RHS
+// support because it also reads the target as part of the operation.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut value = 0
+    value += perform Ask::Get(1)
+    value
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "let/seq/tail/branch-tail spine"
+}

--- a/fixtures/err_effect_assignment_rhs_compound_suspend.vibe
+++ b/fixtures/err_effect_assignment_rhs_compound_suspend.vibe
@@ -1,0 +1,24 @@
+// #1536 boundary: assignment RHS support is limited to the direct recognized
+// suspension itself. A binary expression containing a perform stays rejected.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut value = 0
+    value = perform Ask::Get(1) + 1
+    value
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "let/seq/tail/branch-tail spine"
+}

--- a/fixtures/gc_direct_array_alias_identity_test.vibe
+++ b/fixtures/gc_direct_array_alias_identity_test.vibe
@@ -1,0 +1,14 @@
+// #1541 Phase B characterization: a private concrete Array[Int] remains one
+// native wasm-gc object through exactly one immutable local alias. Mutation
+// through the alias must be visible through the original binding.
+
+test "gc direct array preserves identity through one local alias" {
+  let original = [
+    40,
+    2
+  ]
+  let alias = original
+  Array::set(alias, 1, 3)
+  assert(Array::get(original, 0) == 40)
+  assert(Array::get(original, 1) == 3)
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9293,11 +9293,12 @@ fn scps_need_clone(eff: String, fname: String, st: (Array[Int], Array[String], A
 // producing a __ScpsStep_E value. Suspendables (direct performs of E,
 // calls to needing functions) are only recognized on the
 // let/seq/tail/branch-tail spine. A direct recognized suspension may also
-// occupy an if condition or match scrutinee: it is first named by a fresh
-// ELet, then the existing spine machinery resumes into selection. Compound
-// selection inputs and every other nested suspension still fail closed.
+// occupy an if condition, match scrutinee, or plain-assignment RHS: it is
+// first named by a fresh ELet, then the existing spine machinery resumes into
+// selection/assignment. Compound inputs, compound assignment, and every other
+// nested suspension still fail closed.
 
-fn scps_direct_selection_input(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String])) -> Bool {
+fn scps_direct_spine_input(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String])) -> Bool {
   let (_, ops, _, _, _) = sctx
   scps_as_target_perform(e, ops) >= 0 || scps_as_needing_call(e, sctx) != "" || scps_as_cps_local_call(e, sctx) != ""
 }
@@ -9466,7 +9467,7 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           // branch and its continuation. Branch-local lets remain lexical
           // to their branch because `b` is an ESeq sibling, not their body.
           EIf(c, t, el) => if scps_contains_susp(a, sctx) {
-            if scps_direct_selection_input(c, sctx) {
+            if scps_direct_spine_input(c, sctx) {
               let sx = scps_selection_fresh(e, site)
               scps_split_tail(ELet(sx, c, EIf(EIdent(sx, -1), ESeq(t, b), ESeq(el, b)), -1), sctx, ctx, st)
             } else if scps_contains_susp(c, sctx) {
@@ -9483,7 +9484,7 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           // match originally; without the rename, a pattern binding could
           // capture an outer reference in the duplicated tail.
           EMatch(s, arms) => if scps_contains_susp(a, sctx) {
-            if scps_direct_selection_input(s, sctx) {
+            if scps_direct_spine_input(s, sctx) {
               let sx = scps_selection_fresh(e, site)
               scps_split_tail(ELet(sx, s, EMatch(EIdent(sx, -1), scps_seq_float_match_arms(arms, b, site)), -1), sctx, ctx, st)
             } else if scps_contains_susp(s, sctx) {
@@ -9549,7 +9550,7 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
             }
           }
         },
-        EIf(c, t, el) => if scps_direct_selection_input(c, sctx) {
+        EIf(c, t, el) => if scps_direct_spine_input(c, sctx) {
           let sx = scps_selection_fresh(e, site)
           scps_split_tail(ELet(sx, c, EIf(EIdent(sx, -1), t, el), -1), sctx, ctx, st)
         } else if scps_contains_susp(c, sctx) {
@@ -9563,7 +9564,7 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
             (false, e)
           }
         },
-        EMatch(s, arms) => if scps_direct_selection_input(s, sctx) {
+        EMatch(s, arms) => if scps_direct_spine_input(s, sctx) {
           let sx = scps_selection_fresh(e, site)
           scps_split_tail(ELet(sx, s, EMatch(EIdent(sx, -1), arms), -1), sctx, ctx, st)
         } else if scps_contains_susp(s, sctx) {
@@ -9589,6 +9590,17 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
             (false, e)
           }
         },
+        // #1536 (a) v6: a plain assignment RHS that is itself one direct
+        // recognized suspension can use the established let spine. Probe the
+        // whole assignment when minting the binder so assignment targets and
+        // continuation names cannot collide with it. Compound RHS and
+        // EAssignOp deliberately keep the generic fail-closed path.
+        EAssign(x, v, b) => if scps_direct_spine_input(v, sctx) {
+          let ax = scps_seq_float_fresh("assign", e, EUnit, site)
+          scps_split_tail(ELet(ax, v, EAssign(x, EIdent(ax, -1), b), -1), sctx, ctx, st)
+        } else {
+          (false, e)
+        },
         ELetMut(x, v, b, off) => if scps_contains_susp(v, sctx) {
           (false, e)
         } else {
@@ -9607,7 +9619,11 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
             mi = mi + 1
           }
           let sctx2 = (eff, s_ops, s_needing, s_site, masked)
-          let (bok, bexpr) = scps_split_tail(scps_cellify(b, x), sctx2, ctx, st)
+          // Float a direct assignment suspension before cellification turns a
+          // write to `x` into Array::set(...). After that rewrite the perform
+          // would be nested in a builtin argument and no longer recognizable.
+          let b2 = scps_float_direct_assign(b, sctx2, site)
+          let (bok, bexpr) = scps_split_tail(scps_cellify(b2, x), sctx2, ctx, st)
           let cell = array_empty_expr()
           Array::push(cell, v)
           (bok, ELet(x, EArray(cell), bexpr, off))
@@ -9616,6 +9632,37 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
         _ => (false, e)
       }
     }
+  }
+}
+
+/// Name direct suspension RHS values before mutable-local boxing. Traverse
+/// only continuation-spine positions; values, loop bodies, nested handles and
+/// closure bodies remain untouched and therefore fail closed as before.
+fn scps_float_direct_assign(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), site: Int) -> Expr {
+  match e {
+    EAssign(x, v, b) => if scps_direct_spine_input(v, sctx) {
+      let ax = scps_seq_float_fresh("assign", e, EUnit, site)
+      ELet(ax, v, EAssign(x, EIdent(ax, -1), scps_float_direct_assign(b, sctx, site)), -1)
+    } else {
+      EAssign(x, v, scps_float_direct_assign(b, sctx, site))
+    },
+    EAssignOp(op, x, v, b) => EAssignOp(op, x, v, scps_float_direct_assign(b, sctx, site)),
+    ELet(x, v, b, off) => ELet(x, v, scps_float_direct_assign(b, sctx, site), off),
+    ELetMut(x, v, b, off) => ELetMut(x, v, scps_float_direct_assign(b, sctx, site), off),
+    ELetRec(x, v, b) => ELetRec(x, v, scps_float_direct_assign(b, sctx, site)),
+    ESeq(a, b) => ESeq(a, scps_float_direct_assign(b, sctx, site)),
+    EIf(c, t, el) => EIf(c, scps_float_direct_assign(t, sctx, site), scps_float_direct_assign(el, sctx, site)),
+    EMatch(s, arms) => {
+      let out = scps_empty_arms()
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (p, b) = Array::get(arms, i)
+        Array::push(out, (p, scps_float_direct_assign(b, sctx, site)))
+        i = i + 1
+      }
+      EMatch(s, out)
+    },
+    _ => e
   }
 }
 

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6852,6 +6852,11 @@ scps_run_expect "effect_seq_head_match_suspend.vibe" "3200" "seqheadmatch"
 scps_run_expect "effect_seq_head_if_condition_suspend.vibe" "3210" "seqheadifcond"
 scps_run_expect "effect_seq_head_match_scrutinee_suspend.vibe" "3210" "seqheadmatchscrut"
 scps_run_expect "effect_tail_selection_input_suspend.vibe" "3311" "tailselectinput"
+# #1536 direct plain-assignment RHS: name the resumed value on the CPS spine,
+# then assign and continue once. Compound RHS and EAssignOp remain fail-closed.
+scps_run_expect "effect_assignment_rhs_suspend.vibe" "41112" "assignrhs"
+scps_check_reject "err_effect_assignment_rhs_compound_suspend.vibe" "let/seq/tail/branch-tail spine" "assignrhscompound"
+scps_check_reject "err_effect_assignment_op_rhs_suspend.vibe" "let/seq/tail/branch-tail spine" "assignoprhs"
 scps_check_reject "err_effect_seq_head_if_condition_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadifcompound"
 scps_check_reject "err_effect_seq_head_match_compound_scrutinee_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadmatchcompound"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"

--- a/scripts/coverage/cov_traitenv.vibe
+++ b/scripts/coverage/cov_traitenv.vibe
@@ -1,43 +1,102 @@
+import ../../lib/@vibe/compiler/core/types.vibe {
+  type_implements_check_super as cov_type_implements_check_super
+}
 
 // #cov trait-env driver: type_implements_check_super walks every TypeEnv variant
 // (EnvEmpty / EnvBind / EnvTraitDef / EnvTraitImpl{eq+sub, eq+nosub, neq} /
 // EnvTraitImplGen / EnvFlat / EnvCached) but the corpus only ever feeds it the
 // shapes a real checker builds, leaving most arms dark. Construct env chains that
 // route the walk through each variant and call it directly.
-let cov_te_empty_map: () -> Map[String, Type] = () -> {
-  let b = MapBuilder::new()
-  MapBuilder::freeze(b)
-}
 let cov_te_flat: () -> Array[(String, Type)] = () -> {
-  let a = Array::slice([("", CtInt)], 0, 0)
+  let a = Array::slice([
+    ("", CtInt)
+  ], 0, 0)
   Array::push(a, ("y", CtBool))
   a
 }
 let cov_te_gen_bounds: () -> Array[(String, Array[String])] = () -> {
-  Array::slice([("", Array::slice([""], 0, 0))], 0, 0)
+  Array::slice([
+    ("", Array::slice([
+      ""
+    ], 0, 0))
+  ], 0, 0)
 }
 
 export let cov_traitenv_main: () -> Int = () -> {
   let mut acc = 0
   // chain 1: EnvTraitImpl(Ord, Int) over EnvTraitDef(Ord:Eq) — eq match + subtrait true -> true
-  let def_eq = EnvTraitDef("Eq", Array::slice([""], 0, 0), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0))
-  let def_ord = EnvTraitDef("Ord", Array::slice(["Eq"], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), def_eq, Array::slice([""], 0, 0))
+  let def_eq = EnvTraitDef("Eq", Array::slice([
+    ""
+  ], 0, 0), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([
+    ""
+  ], 0, 0), Array::slice([
+    ("", Array::slice([
+      ""
+    ], 0, 0), cov_te_gen_bounds())
+  ], 0, 0))
+  let def_ord = EnvTraitDef("Ord", Array::slice([
+    "Eq"
+  ], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), def_eq, Array::slice([
+    ""
+  ], 0, 0), Array::slice([
+    ("", Array::slice([
+      ""
+    ], 0, 0), cov_te_gen_bounds())
+  ], 0, 0))
   let env1 = EnvTraitImpl("Ord", CtInt, def_ord)
-  acc = acc + (if type_implements_check_super(env1, env1, "Eq", CtInt) { 1 } else { 0 })
+  acc = acc + (if cov_type_implements_check_super(env1, env1, SubstEmpty, "Eq", CtInt) {
+    1
+  } else {
+    0
+  })
   // chain 2: EnvTraitImpl(Foo, Int) — eq match but Foo is not a subtrait of Eq -> recurse -> EnvEmpty
   let env2 = EnvTraitImpl("Foo", CtInt, def_ord)
-  acc = acc + (if type_implements_check_super(env2, env2, "Eq", CtInt) { 1 } else { 0 })
+  acc = acc + (if cov_type_implements_check_super(env2, env2, SubstEmpty, "Eq", CtInt) {
+    1
+  } else {
+    0
+  })
   // chain 3: EnvTraitImpl(Eq, Bool) — target type mismatch -> recurse -> EnvEmpty
   let env3 = EnvTraitImpl("Eq", CtBool, EnvEmpty)
-  acc = acc + (if type_implements_check_super(env3, env3, "Eq", CtInt) { 1 } else { 0 })
+  acc = acc + (if cov_type_implements_check_super(env3, env3, SubstEmpty, "Eq", CtInt) {
+    1
+  } else {
+    0
+  })
   // chain 4: EnvBind -> EnvTraitImplGen -> EnvFlat (recurse arms then terminal false)
-  let env4 = EnvBind("x", CtInt, EnvTraitImplGen("G", Array::slice([""], 0, 0), cov_te_gen_bounds(), CtInt, EnvFlat(cov_te_flat())))
-  acc = acc + (if type_implements_check_super(env4, env4, "Eq", CtInt) { 1 } else { 0 })
+  let env4 = EnvBind("x", CtInt, EnvTraitImplGen("G", Array::slice([
+    ""
+  ], 0, 0), cov_te_gen_bounds(), CtInt, EnvFlat(cov_te_flat())))
+  acc = acc + (if cov_type_implements_check_super(env4, env4, SubstEmpty, "Eq", CtInt) {
+    1
+  } else {
+    0
+  })
   // chain 5: EnvCached -> EnvEmpty (EnvCached recurse arm)
-  let env5 = EnvCached(cov_te_empty_map(), EnvEmpty)
-  acc = acc + (if type_implements_check_super(env5, env5, "Eq", CtInt) { 1 } else { 0 })
+  let env5 = EnvCached(Array::slice([
+    ""
+  ], 0, 0), Array::slice([
+    CtInt
+  ], 0, 0), EnvEmpty)
+  acc = acc + (if cov_type_implements_check_super(env5, env5, SubstEmpty, "Eq", CtInt) {
+    1
+  } else {
+    0
+  })
   // chain 6: EnvTraitDef recurse then EnvEmpty
-  let env6 = EnvTraitDef("Solo", Array::slice([""], 0, 0), true, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0))
-  acc = acc + (if type_implements_check_super(env6, env6, "Eq", CtInt) { 1 } else { 0 })
+  let env6 = EnvTraitDef("Solo", Array::slice([
+    ""
+  ], 0, 0), true, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([
+    ""
+  ], 0, 0), Array::slice([
+    ("", Array::slice([
+      ""
+    ], 0, 0), cov_te_gen_bounds())
+  ], 0, 0))
+  acc = acc + (if cov_type_implements_check_super(env6, env6, SubstEmpty, "Eq", CtInt) {
+    1
+  } else {
+    0
+  })
   acc
 }

--- a/scripts/coverage_drivers.sh
+++ b/scripts/coverage_drivers.sh
@@ -12,8 +12,8 @@
 # Drivers compile and run against a cycle-free no-DCE compiler source under
 # coverage, unioning executed branches into the corpus acc.json by
 # (fn_name, local_branch_index) — valid because every binary shares the same
-# per-function branch ordering. The migrated `units` driver is merged by the
-# compiler-owned exact-path exposure mode; remaining drivers temporarily retain
+# per-function branch ordering. The migrated `units` and `traitenv` drivers are
+# merged by compiler-owned exact-path exposure mode; remaining drivers retain
 # the legacy raw base until later #1633 slices. Run coverage_corpus.sh FIRST (it
 # builds acc.json + the instrumented compiler_cov.wasm this suite reuses).
 #
@@ -71,12 +71,17 @@ else
   mkdir -p "$WORK"
 fi
 
+coverage_driver_uses_exact_exposure() { # label
+  case "$1" in
+    units|traitenv) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # 1. Regenerate the legacy no-DCE source only for drivers not yet migrated to
-#    exact-path exposure. #1633's first slice migrates `units`; the remaining
-#    drivers deliberately stay on their existing path until separate reviewed
-#    slices move them. A units-only smoke therefore never constructs or trusts
-#    the old raw concatenation.
-if [ "$COVERAGE_DRIVERS_SOURCED" = "0" ] && { [ -z "$DRIVER_FILTER" ] || [ "$DRIVER_FILTER" != "units" ]; }; then
+#    exact-path exposure. Filtered exact-exposure runs never construct or trust
+#    raw concatenation; an unfiltered run still needs it for legacy drivers.
+if [ "$COVERAGE_DRIVERS_SOURCED" = "0" ] && { [ -z "$DRIVER_FILTER" ] || ! coverage_driver_uses_exact_exposure "$DRIVER_FILTER"; }; then
   echo "[drivers] regenerating legacy no-DCE source ..." >&2
   python3 - "lib/@vibe/compiler" "lib/@vibe/compiler/compiler_sources_manifest.tsv" "cli_adapter.vibe" "$MERGED" <<'PY'
 import os, re, sys
@@ -208,9 +213,9 @@ run_driver() { # entry driver_file label
   fi
   DRIVERS_RAN=$((DRIVERS_RAN + 1))
   local d="$WORK/$label"; rm -rf "$d"; mkdir -p "$d"
-  if [ "$label" = "units" ]; then
+  if coverage_driver_uses_exact_exposure "$label"; then
     # The current instrumented compiler owns this internal emit mode. It
-    # collects the production compiler closure, resolves cov_units' exact-file
+    # collects the production compiler closure, resolves the driver's exact-file
     # value requests, and rewrites them to the ordinary merge's final names.
     # The pinned seed only compiles the emitted ordinary source; no seed bump.
     rm -f "$d/src.vibe" "$d/src.vibe.diag"

--- a/scripts/test_gc_heap_accounting.sh
+++ b/scripts/test_gc_heap_accounting.sh
@@ -66,6 +66,17 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
 wasm-tools validate --features all "$DIRECT_OUT" >/dev/null
 "$RUNNER" "$DIRECT_OUT" >/dev/null
 
+# #1541 Phase B characterization: one private concrete Array[Int] literal
+# crosses exactly one immutable local alias. Mutating through that alias and
+# reading through the original proves that lowering preserves object identity.
+ALIAS_OUT="$WORK/direct_array_alias_identity.wasm"
+ALIAS_OUT_REL="${ALIAS_OUT#"$ROOT_DIR"/}"
+VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+  fixtures/gc_direct_array_alias_identity_test.vibe "$ALIAS_OUT_REL" __no_entry__ >/dev/null
+wasm-tools validate --features all "$ALIAS_OUT" >/dev/null
+"$RUNNER" "$ALIAS_OUT" >/dev/null
+
 compile_direct_abi_fallback() {
   local fixture="$1"
   local output="$2"
@@ -84,27 +95,35 @@ compile_direct_abi_fallback fixtures/gc_direct_array_abi_fallback_test.vibe "$FA
 compile_direct_abi_fallback fixtures/gc_direct_array_abi_shadow_fallback_test.vibe "$SHADOW_FALLBACK_OUT"
 compile_direct_abi_fallback fixtures/gc_direct_array_abi_export_fallback_test.vibe "$EXPORT_FALLBACK_OUT"
 
-python3 - "$DIRECT_OUT" "$FALLBACK_OUT" "$SHADOW_FALLBACK_OUT" "$EXPORT_FALLBACK_OUT" <<'PY'
-import sys
-positive = open(sys.argv[1], "rb").read().count(b"\xfb\x07\x0c")
-fallbacks = {
-    "generic": open(sys.argv[2], "rb").read().count(b"\xfb\x07\x0c"),
-    "spelling shadow": open(sys.argv[3], "rb").read().count(b"\xfb\x07\x0c"),
-    "export": open(sys.argv[4], "rb").read().count(b"\xfb\x07\x0c"),
+# Count decoded instructions rather than byte patterns: raw scanning can match
+# non-code sections and also couples this gate to an incidental numeric type
+# index. `wasm-tools print` parses the module and renders instructions with the
+# actual type reference, which we deliberately ignore here.
+count_native_array_allocs() {
+  local wasm="$1"
+  wasm-tools print "$wasm" | awk '$1 == "array.new_default" { count += 1 } END { print count + 0 }'
 }
-if positive != 1:
-    raise SystemExit(
-        "[gc-heap-accounting] FAIL: expected one #1541 direct-ABI native "
-        f"literal, found {positive}"
-    )
-for label, count in fallbacks.items():
-    if count != 0:
-        raise SystemExit(
-            f"[gc-heap-accounting] FAIL: {label} boundary mixed a typed "
-            f"reference into the fallback component ({count} native literals)"
-        )
-PY
-echo "[gc-heap-accounting] ok: direct Array[Int] ABI and fail-closed component fallbacks"
+
+positive="$(count_native_array_allocs "$DIRECT_OUT")"
+alias="$(count_native_array_allocs "$ALIAS_OUT")"
+declare -a fallback_labels=("generic" "spelling shadow" "export")
+declare -a fallback_outputs=("$FALLBACK_OUT" "$SHADOW_FALLBACK_OUT" "$EXPORT_FALLBACK_OUT")
+if [ "$positive" -ne 1 ]; then
+  echo "[gc-heap-accounting] FAIL: expected one #1541 direct-ABI native literal, found $positive" >&2
+  exit 1
+fi
+if [ "$alias" -ne 1 ]; then
+  echo "[gc-heap-accounting] FAIL: expected one #1541 local-alias native literal, found $alias" >&2
+  exit 1
+fi
+for i in "${!fallback_outputs[@]}"; do
+  count="$(count_native_array_allocs "${fallback_outputs[$i]}")"
+  if [ "$count" -ne 0 ]; then
+    echo "[gc-heap-accounting] FAIL: ${fallback_labels[$i]} boundary mixed a typed reference into the fallback component ($count native literals)" >&2
+    exit 1
+  fi
+done
+echo "[gc-heap-accounting] ok: direct Array[Int] ABI, local alias identity, and fail-closed component fallbacks"
 
 REPORT="$(VIBE_MEM=1 "$RUNNER" "$OUT" 2>&1 >/dev/null)" || {
   printf '%s\n' "$REPORT" >&2

--- a/scripts/tests/coverage_driver_exposure_test.sh
+++ b/scripts/tests/coverage_driver_exposure_test.sh
@@ -7,6 +7,7 @@ cd "$ROOT"
 SEED="${VIBE_COV_SEED:-bootstrap/seed/compiler.wasm}"
 RUNNER="scripts/run_wasm_vibe_host_runner.sh"
 FLAT="lib/@vibe/compiler/_cli_adapter_module_source.vibe"
+COMPILER_ENTRY="lib/@vibe/compiler/cli_adapter.vibe"
 TMP="_build/coverage-driver-exposure-test"
 TOOL="$TMP/compiler_cov.wasm"
 export VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --experimental-wasm-inlining --stack-size=131072}"
@@ -46,14 +47,14 @@ import ./dep.vibe { hidden as selected_hidden }
 export fn driver_main() -> Int { selected_hidden(41) }
 VEOF
 
-emit_driver() { # driver output entry
-  local driver="$1" output="$2" entry="$3"
+emit_driver() { # driver output entry [compiler-entry]
+  local driver="$1" output="$2" entry="$3" compiler_entry="${4:-$TMP/root.vibe}"
   rm -f "$output" "$output.diag"
   VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1 \
     VIBE_COVERAGE_DRIVER_PATH="$driver" \
     VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
     bash "$RUNNER" --invoke cli_main "$TOOL" \
-    "$TMP/root.vibe" "$output" "$entry" >/dev/null 2>&1 || true
+    "$compiler_entry" "$output" "$entry" >/dev/null 2>&1 || true
 }
 
 # Positive: a private exact-file value imported under an alias is rewritten by
@@ -69,6 +70,54 @@ VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
   "$TMP/positive.out.vibe" "$TMP/positive.wasm" driver_main >/dev/null
 positive_out="$(VIBE_PREOPEN_DIR="$ROOT" bash "$RUNNER" --invoke driver_main "$TMP/positive.wasm" 2>&1 | tail -1)"
 [ "$positive_out" = "42" ] || { echo "coverage-driver-exposure: positive run got '$positive_out', want 42" >&2; exit 1; }
+
+# Repository migration: cov_traitenv imports its private target from the exact
+# compiler file under an alias. Exercise the real emit/compile/run path so the
+# routing test below cannot pass on text alone.
+emit_driver "scripts/coverage/cov_traitenv.vibe" "$TMP/traitenv.out.vibe" cov_traitenv_main "$COMPILER_ENTRY"
+[ -s "$TMP/traitenv.out.vibe" ] || { cat "$TMP/traitenv.out.vibe.diag" >&2; exit 1; }
+if grep -q 'cov_type_implements_check_super' "$TMP/traitenv.out.vibe"; then
+  echo "coverage-driver-exposure: cov_traitenv alias survived instead of being rewritten" >&2
+  exit 1
+fi
+VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$RUNNER" --invoke cli_main "$SEED" \
+  "$TMP/traitenv.out.vibe" "$TMP/traitenv.wasm" cov_traitenv_main >/dev/null
+traitenv_out="$(VIBE_COV_OUT="$TMP/traitenv.cov.json" VIBE_COV_RAW=1 VIBE_PREOPEN_DIR="$ROOT" bash "$RUNNER" --invoke cov_traitenv_main "$TMP/traitenv.wasm" 2>&1 | tail -1)"
+[ "$traitenv_out" = "1" ] || { echo "coverage-driver-exposure: cov_traitenv run got '$traitenv_out', want 1" >&2; exit 1; }
+[ -s "$TMP/traitenv.cov.json" ] || { echo "coverage-driver-exposure: cov_traitenv dumped no raw coverage" >&2; exit 1; }
+
+# Feed that exact real raw dump through the production checked merge helper.
+# Starting from an identical accumulator makes the expected union precise: the
+# denominator stays stable and the hit count is non-decreasing (equal here).
+python3 - "$TMP/traitenv.cov.json" "$TMP/traitenv.acc.json" <<'PY'
+import json, sys
+run = json.load(open(sys.argv[1]))
+raw = run["raw"]
+json.dump({
+    "fn_names": raw["fn_names"],
+    "br_owners": raw["branch_owners"],
+    "br": raw["branch_bitmap"],
+}, open(sys.argv[2], "w"))
+PY
+VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 source scripts/coverage_drivers.sh
+COMPILER_COV="$TOOL"
+export VIBE_COVERAGE_ACC_TOOL_COMPILER="$TOOL"
+traitenv_merge="$(coverage_driver_merge_checked "$TMP/traitenv.acc.json" "$TMP/traitenv.cov.json")" || {
+  echo "coverage-driver-exposure: cov_traitenv raw coverage failed checked merge" >&2
+  exit 1
+}
+read -r traitenv_base traitenv_now traitenv_total <<<"$traitenv_merge"
+[ "$traitenv_total" -gt 0 ] && [ "$traitenv_now" -ge "$traitenv_base" ] || {
+  echo "coverage-driver-exposure: invalid cov_traitenv merge '$traitenv_merge'" >&2
+  exit 1
+}
+traitenv_after="$(coverage_driver_stat "$TMP/traitenv.acc.json")"
+read -r traitenv_after_hit traitenv_after_total <<<"$traitenv_after"
+[ "$traitenv_after_hit" -eq "$traitenv_now" ] && [ "$traitenv_after_total" -eq "$traitenv_total" ] || {
+  echo "coverage-driver-exposure: cov_traitenv denominator/hits changed after checked merge" >&2
+  exit 1
+}
 
 # Ordinary merged-source mode remains separate and never appends the driver.
 rm -f "$TMP/ordinary.vibe" "$TMP/ordinary.vibe.diag"

--- a/scripts/tests/coverage_drivers_test.sh
+++ b/scripts/tests/coverage_drivers_test.sh
@@ -11,6 +11,16 @@ DRIVER_DIR="$TMP/driver"
 mkdir -p "$DRIVER_DIR"
 : > "$DRIVER_DIR/src.vibe"
 
+# Routing: both migrated labels use exact exposure. A filtered run for either
+# label can therefore skip the legacy merged-source generator; legacy labels
+# still require it.
+coverage_driver_uses_exact_exposure units
+coverage_driver_uses_exact_exposure traitenv
+if coverage_driver_uses_exact_exposure units2; then
+  echo "coverage_drivers_test: units2 unexpectedly routed to exact exposure" >&2
+  exit 1
+fi
+
 # A sidecar diagnostic is deterministic: one attempt and a nonzero status.
 deterministic_attempts=0
 coverage_driver_compile_once() {


### PR DESCRIPTION
## Summary

- characterize the already-supported private `Array[Int]` one-local-alias wasm-gc identity lane with decoded instruction-level allocation counting
- lower direct recognized suspended plain-assignment RHS through the existing collision-safe CPS selection spine while retaining unsupported forms fail-closed
- migrate exactly `cov_traitenv` to production exact-file value exposure and attest real raw coverage through checked monotonic merge

Umbrella issues #1536, #1541, and #1633 remain open for their explicitly documented residual scope.

## Validation

- independent verifier ACCEPT for all three slices
- `bash scripts/test_gc_heap_accounting.sh <current-stage2>`
- `bash scripts/tests/coverage_drivers_test.sh`
- `bash scripts/tests/coverage_pipeline_contract_test.sh`
- `bash scripts/tests/coverage_driver_exposure_test.sh`
- compiler gate passed the new Phase 3a fixtures and subsequent feature phases; repository-wide local run stopped only at the known macOS `xargs: command line cannot be assembled, too long` fixture-typecheck step
- formatter/generated freshness/diff and clean handoff checks
