### PR TITLE
Attest checked-module artifact freshness identities

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -70,9 +70,9 @@ is an ADR-sized decision, not a slice-sized one.
 - Do not paper over missing provenance in a full trait observation by reparsing
   and reprinting source.
 
-### Shadow-only checked module typing aggregate v1 (#1550)
+### Shadow-only checked module typing aggregate v1/v2 (#1550)
 
-`CheckedModuleTypingArtifact` v1 is a bounded checker/artifacts experiment, not a
+`CheckedModuleTypingArtifact` remains a bounded checker/artifacts experiment, not a
 production incremental-build input. `CheckedProgram` remains transparent and
 manually constructible in this slice. Consequently neither the schema nor the
 `shadow_unattested_checked_module_typing_artifact_from_checked_program` builder
@@ -104,14 +104,22 @@ diagnostic completeness are ineligible. Checked body state is only
 `ineligible:lossless_checked_body_unavailable_v1`—there is no TypeEnv target or
 fabricated typed-IR/body reference.
 
+V2 preserves the complete v1 encoding unchanged and adds two separately tagged
+identities derived from the same already-ingested `ModuleJob.source`: exact
+`compact_string_fingerprint(ingested_source)` and the provisional parser-visible
+`provisional_token_stream_v1`. The v2 unattested builder requires observed and
+recorded claims to agree and still validates the implementation-closure owner.
+The opaque opt-in runtime producer derives both values only after successful
+checking. Ordinary `check_module` makes no artifact construction attempt;
+diagnosed opt-in checks also make none; successful opt-in checks make exactly
+one. This counter is test observation, not production telemetry.
+
 The aggregate and its complete-encoding fingerprint are shadow comparison data
-only. They are not wired to filesystem/module workers, TypeDb, `ModuleJob` or
-`ModuleOutcome`, the current TypeEnv v5 transport and persistent cache namespace
-v18, TDRE4, interface-v2, artifact-input traces, planner decisions, reuse, the
-CLI, or a persistent cache namespace. Decoded values establish canonical bytes,
-not a checker invocation. This slice has no producer or publisher. Only a future
-trusted producer invoked after `check_program_result` succeeds may publish the
-artifact; making that boundary trustworthy is explicitly future work.
+only. They are not wired to TypeDb, the TypeEnv v5 transport and persistent cache
+namespace v18, TDRE4, interface-v2, artifact-input traces, planner decisions,
+reuse, CLI, or a persistent cache namespace. Decoded values establish canonical
+bytes, not a checker invocation. Runtime retains v2 bytes only in an opaque,
+in-memory successful `ModuleOutcome`; it does not publish or persist them.
 
 ## User-visible KPI contract
 

--- a/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
@@ -54,6 +54,8 @@ import ./checked_exported_interface_artifact.vibe {
 /// Neither building nor decoding attests that a checker ran.
 export struct CheckedModuleTypingArtifact {
   module_locator: String;
+  source_identity_kind: String;
+  source_identity: String;
   implementation_kind: String;
   implementation_identity: String;
   dependency_interface_assumptions: Array[(String, String)];
@@ -75,6 +77,10 @@ fn module_empty_diagnostic_identity() -> String {
 
 fn module_checked_body_marker() -> String {
   "ineligible:lossless_checked_body_unavailable_v1"
+}
+
+fn module_source_identity_kind_v2() -> String {
+  "compact_string_fingerprint(ingested_source)"
 }
 
 fn module_implementation_kind_valid(kind: String) -> Bool {
@@ -258,8 +264,47 @@ export fn shadow_unattested_checked_module_typing_artifact_from_checked_program(
         } else {
           Some(CheckedModuleTypingArtifact::{
             module_locator: module_locator,
+            source_identity_kind: "",
+            source_identity: "",
             implementation_kind: implementation_kind,
             implementation_identity: implementation_identity,
+            dependency_interface_assumptions: module_dependencies_copy(dependency_interface_assumptions),
+            recorded_implementation_closure: module_closure_sorted(recorded_implementation_closure),
+            exported_interface_bytes: supplied_bytes
+          })
+        }
+      },
+      None => None
+    }
+  }
+}
+
+/// Unattested v2 builder. `observed_*` arguments represent identities derived
+/// by the caller from one already-ingested source value; `recorded_*` are the
+/// claims to freeze. Equality is required before any artifact is constructed.
+/// This remains shadow-only because all arguments and CheckedProgram are
+/// caller-constructible. The opaque runtime producer supplies both observed
+/// identities from the same ModuleJob.source after successful checking.
+export fn shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked: CheckedProgram, module_locator: String, observed_source_identity: String, recorded_source_identity: String, observed_implementation_identity: String, recorded_implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact] {
+  let implementation_kind = "provisional_token_stream_v1"
+  if observed_source_identity != recorded_source_identity || observed_implementation_identity != recorded_implementation_identity || !module_compact_fingerprint_valid(recorded_source_identity) {
+    None
+  } else if !module_inputs_valid(module_locator, implementation_kind, recorded_implementation_identity, dependency_interface_assumptions, recorded_implementation_closure) {
+    None
+  } else {
+    match checked_exported_interface_artifact_from_checked_program(checked) {
+      Some(derived_interface) => {
+        let derived_bytes = encode_checked_exported_interface_artifact_v1(derived_interface)
+        let supplied_bytes = encode_checked_exported_interface_artifact_v1(exported_interface)
+        if derived_bytes != supplied_bytes {
+          None
+        } else {
+          Some(CheckedModuleTypingArtifact::{
+            module_locator: module_locator,
+            source_identity_kind: module_source_identity_kind_v2(),
+            source_identity: recorded_source_identity,
+            implementation_kind: implementation_kind,
+            implementation_identity: recorded_implementation_identity,
             dependency_interface_assumptions: module_dependencies_copy(dependency_interface_assumptions),
             recorded_implementation_closure: module_closure_sorted(recorded_implementation_closure),
             exported_interface_bytes: supplied_bytes
@@ -317,6 +362,29 @@ export fn encode_checked_module_typing_artifact_v1(artifact: CheckedModuleTyping
   module_push_piece(out, artifact.module_locator)
   module_push_piece(out, "1")
   module_push_piece(out, artifact.module_locator)
+  module_push_piece(out, artifact.implementation_kind)
+  module_push_piece(out, artifact.implementation_identity)
+  module_push_piece(out, module_encode_dependencies(artifact.dependency_interface_assumptions))
+  module_push_piece(out, module_encode_closure(artifact.recorded_implementation_closure))
+  module_push_piece(out, artifact.exported_interface_bytes)
+  module_push_piece(out, module_diagnostic_scope_order())
+  module_push_piece(out, module_empty_diagnostic_identity())
+  module_push_piece(out, module_checked_body_marker())
+  StringBuilder::push(out, "]")
+  StringBuilder::freeze(out)
+}
+
+/// Strict v2 transport. It adds exact ingested-source identity alongside the
+/// provisional parser-visible token-stream identity; v1 bytes are unchanged.
+export fn encode_checked_module_typing_artifact_v2(artifact: CheckedModuleTypingArtifact) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, "vibe-checked-module-typing-artifact:v2\n14[")
+  module_push_piece(out, module_unit_kind())
+  module_push_piece(out, artifact.module_locator)
+  module_push_piece(out, "1")
+  module_push_piece(out, artifact.module_locator)
+  module_push_piece(out, artifact.source_identity_kind)
+  module_push_piece(out, artifact.source_identity)
   module_push_piece(out, artifact.implementation_kind)
   module_push_piece(out, artifact.implementation_identity)
   module_push_piece(out, module_encode_dependencies(artifact.dependency_interface_assumptions))
@@ -500,6 +568,8 @@ export fn decode_checked_module_typing_artifact_v1(text: String) -> Option[Check
               } else {
                 let artifact = CheckedModuleTypingArtifact::{
                   module_locator: Array::get(fields, 1),
+                  source_identity_kind: "",
+                  source_identity: "",
                   implementation_kind: Array::get(fields, 4),
                   implementation_identity: Array::get(fields, 5),
                   dependency_interface_assumptions: dependencies,
@@ -507,6 +577,70 @@ export fn decode_checked_module_typing_artifact_v1(text: String) -> Option[Check
                   exported_interface_bytes: nested_bytes
                 }
                 if encode_checked_module_typing_artifact_v1(artifact) == text {
+                  Some(artifact)
+                } else {
+                  None
+                }
+              }
+            },
+            None => None
+          },
+          None => None
+        },
+        None => None
+      }
+    }
+  }
+}
+
+/// Decode exact canonical v2 bytes. Source and implementation identities are
+/// independently tagged and the closure owner must agree with implementation.
+export fn decode_checked_module_typing_artifact_v2(text: String) -> Option[CheckedModuleTypingArtifact] {
+  let prefix = "vibe-checked-module-typing-artifact:v2\n14["
+  let n = String::length(text)
+  if n <= String::length(prefix) || text[0: String::length(prefix)] != prefix {
+    None
+  } else {
+    let fields = array_empty()
+    let mut cursor = String::length(prefix)
+    let mut i = 0
+    let mut valid = true
+    while i < 14 && valid {
+      match module_piece_parse(text, cursor) {
+        Some((field, next)) => {
+          Array::push(fields, field)
+          cursor = next
+        },
+        None => {
+          valid = false
+        }
+      }
+      i = i + 1
+    }
+    if !valid || cursor >= n || String::char_code_at(text, cursor) != 93 || cursor + 1 != n {
+      None
+    } else if Array::get(fields, 0) != module_unit_kind() || Array::get(fields, 2) != "1" || Array::get(fields, 3) != Array::get(fields, 1) || Array::get(fields, 4) != module_source_identity_kind_v2() || !module_compact_fingerprint_valid(Array::get(fields, 5)) || Array::get(fields, 11) != module_diagnostic_scope_order() || Array::get(fields, 12) != module_empty_diagnostic_identity() || Array::get(fields, 13) != module_checked_body_marker() {
+      None
+    } else {
+      match module_decode_dependencies(Array::get(fields, 8)) {
+        Some(dependencies) => match module_decode_closure(Array::get(fields, 9)) {
+          Some(closure) => match decode_checked_exported_interface_artifact_v1(Array::get(fields, 10)) {
+            Some(exported_interface) => {
+              let nested_bytes = encode_checked_exported_interface_artifact_v1(exported_interface)
+              if nested_bytes != Array::get(fields, 10) || !module_closure_is_canonical(closure) || !module_inputs_valid(Array::get(fields, 1), Array::get(fields, 6), Array::get(fields, 7), dependencies, closure) {
+                None
+              } else {
+                let artifact = CheckedModuleTypingArtifact::{
+                  module_locator: Array::get(fields, 1),
+                  source_identity_kind: Array::get(fields, 4),
+                  source_identity: Array::get(fields, 5),
+                  implementation_kind: Array::get(fields, 6),
+                  implementation_identity: Array::get(fields, 7),
+                  dependency_interface_assumptions: dependencies,
+                  recorded_implementation_closure: closure,
+                  exported_interface_bytes: nested_bytes
+                }
+                if encode_checked_module_typing_artifact_v2(artifact) == text {
                   Some(artifact)
                 } else {
                   None
@@ -532,4 +666,8 @@ export fn canonical_checked_module_typing_artifact_snapshot(artifact: CheckedMod
 /// deliberately disconnected from persistent cache lookup and reuse.
 export fn checked_module_typing_artifact_fingerprint_v1(artifact: CheckedModuleTypingArtifact) -> String {
   compact_string_fingerprint(encode_checked_module_typing_artifact_v1(artifact))
+}
+
+export fn checked_module_typing_artifact_fingerprint_v2(artifact: CheckedModuleTypingArtifact) -> String {
+  compact_string_fingerprint(encode_checked_module_typing_artifact_v2(artifact))
 }

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -27,10 +27,14 @@ generated_hash =
 // cache/reuse/planner/persistent-trace integration.
 opaque type CheckedModuleTypingArtifact
 fn shadow_unattested_checked_module_typing_artifact_from_checked_program(checked: CheckedProgram, module_locator: String, implementation_kind: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact]
+fn shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked: CheckedProgram, module_locator: String, observed_source_identity: String, recorded_source_identity: String, observed_implementation_identity: String, recorded_implementation_identity: String, dependency_interface_assumptions: Array[(String, String)], recorded_implementation_closure: Array[(String, String, String)], exported_interface: CheckedExportedInterfaceArtifact) -> Option[CheckedModuleTypingArtifact]
 fn encode_checked_module_typing_artifact_v1(artifact: CheckedModuleTypingArtifact) -> String
+fn encode_checked_module_typing_artifact_v2(artifact: CheckedModuleTypingArtifact) -> String
 fn decode_checked_module_typing_artifact_v1(text: String) -> Option[CheckedModuleTypingArtifact]
+fn decode_checked_module_typing_artifact_v2(text: String) -> Option[CheckedModuleTypingArtifact]
 fn canonical_checked_module_typing_artifact_snapshot(artifact: CheckedModuleTypingArtifact) -> String
 fn checked_module_typing_artifact_fingerprint_v1(artifact: CheckedModuleTypingArtifact) -> String
+fn checked_module_typing_artifact_fingerprint_v2(artifact: CheckedModuleTypingArtifact) -> String
 
 // --- checked_exported_interface_artifact.vibe
 // Shadow-only complete-or-none exported declaration surface from retained

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -288,6 +288,9 @@ struct ModuleJob {
 opaque type ModuleOutcome
 fn check_module(job: ModuleJob) -> ModuleOutcome with Exception
 fn check_module_with_typing_artifact_observation(job: ModuleJob) -> ModuleOutcome with Exception
+// Test-only observation of post-success construction attempts.
+fn checked_module_typing_artifact_construction_attempt_count() -> Int
+fn reset_checked_module_typing_artifact_construction_attempt_count() -> Unit
 // #1550: canonical module typing artifact bytes carried only by an opaque,
 // genuinely successful ModuleOutcome. Diagnosed outcomes return None. This is
 // in-memory observation only: no cache lookup, planner, persistence, or reuse.

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -26,8 +26,8 @@ import @vibe/compiler/checker {
 
 import @vibe/compiler/checker/artifacts {
   checked_exported_interface_artifact_from_checked_program,
-  encode_checked_module_typing_artifact_v1,
-  shadow_unattested_checked_module_typing_artifact_from_checked_program
+  encode_checked_module_typing_artifact_v2,
+  shadow_unattested_checked_module_typing_artifact_v2_from_checked_program
 }
 
 import @vibe/compiler/core {
@@ -3288,13 +3288,31 @@ fn checked_module_dependency_interface_assumptions(dep_envs: Array[(String, Type
   assumptions
 }
 
+let checked_module_typing_artifact_construction_attempts: Array[Int] = [
+  0
+]
+
+/// Test-observation counter. It measures entry into artifact construction, not
+/// checker execution: ordinary and diagnosed paths remain zero.
+export fn checked_module_typing_artifact_construction_attempt_count() -> Int {
+  Array::get(checked_module_typing_artifact_construction_attempts, 0)
+}
+
+export fn reset_checked_module_typing_artifact_construction_attempt_count() -> Unit {
+  Array::set(checked_module_typing_artifact_construction_attempts, 0, 0)
+}
+
 fn checked_module_typing_artifact_bytes(checked: CheckedProgram, job: ModuleJob) -> Option[String] with Exception {
+  Array::set(checked_module_typing_artifact_construction_attempts, 0, Array::get(checked_module_typing_artifact_construction_attempts, 0) + 1)
+  // Both identities are derived here from the exact same already-ingested
+  // ModuleJob.source; there is no filesystem reread or caller identity input.
+  let source_identity = compact_string_fingerprint(job.source)
   let implementation_identity = incremental_implementation_identity(job.source)
   match checked_exported_interface_artifact_from_checked_program(checked) {
-    Some(exported_interface) => match shadow_unattested_checked_module_typing_artifact_from_checked_program(checked, job.path, "provisional_token_stream_v1", implementation_identity, checked_module_dependency_interface_assumptions(job.dep_envs), [
+    Some(exported_interface) => match shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked, job.path, source_identity, source_identity, implementation_identity, implementation_identity, checked_module_dependency_interface_assumptions(job.dep_envs), [
       (job.path, "provisional_token_stream_v1", implementation_identity)
     ], exported_interface) {
-      Some(artifact) => Some(encode_checked_module_typing_artifact_v1(artifact)),
+      Some(artifact) => Some(encode_checked_module_typing_artifact_v2(artifact)),
       None => None
     },
     None => None

--- a/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
@@ -10,9 +10,12 @@ import @vibe/compiler/checker/artifacts {
   checked_exported_interface_artifact_from_checked_program,
   checked_module_typing_artifact_fingerprint_v1,
   decode_checked_module_typing_artifact_v1,
+  decode_checked_module_typing_artifact_v2,
   encode_checked_exported_interface_artifact_v1,
   encode_checked_module_typing_artifact_v1,
-  shadow_unattested_checked_module_typing_artifact_from_checked_program
+  encode_checked_module_typing_artifact_v2,
+  shadow_unattested_checked_module_typing_artifact_from_checked_program,
+  shadow_unattested_checked_module_typing_artifact_v2_from_checked_program
 }
 
 import @vibe/compiler/core {
@@ -20,7 +23,12 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/runtime {
-  ModuleJob, check_module, check_module_with_typing_artifact_observation, checked_module_typing_artifact_observation
+  ModuleJob,
+  check_module,
+  check_module_with_typing_artifact_observation,
+  checked_module_typing_artifact_construction_attempt_count,
+  checked_module_typing_artifact_observation,
+  reset_checked_module_typing_artifact_construction_attempt_count
 }
 
 import @vibe/compiler/syntax {
@@ -99,6 +107,26 @@ fn mt_valid_fields(nested: String) -> Array[String] {
     mt_closure([
       ("owner", "provisional_token_stream_v1", "1:2:3")
     ]),
+    nested,
+    "typing_errors_only:path,start,end,code,message",
+    "vibe-checked-module-typing-artifact:caller-attested-empty-typing-errors:v1",
+    "ineligible:lossless_checked_body_unavailable_v1"
+  ]
+}
+
+// Pre-v2 canonical fixture for the exact owner/identity/empty-dependency input
+// used by the compatibility regression. This deliberately spells every field
+// instead of sharing mt_valid_fields or the production encoder.
+fn mt_v1_empty_dependencies_fields(nested: String) -> Array[String] {
+  [
+    "singleton_semantic_module",
+    "owner",
+    "1",
+    "owner",
+    "provisional_token_stream_v1",
+    "1:2:3",
+    "0[]",
+    "1[5:owner27:provisional_token_stream_v15:1:2:3]",
     nested,
     "typing_errors_only:path,start,end,code,message",
     "vibe-checked-module-typing-artifact:caller-attested-empty-typing-errors:v1",
@@ -499,18 +527,23 @@ test "wrapper around genuine checker failure returns no module artifact bytes" {
   }
 }
 
-test "production module check leaves shadow observation disabled" {
+test "production module check leaves shadow observation disabled and makes zero construction attempts" {
+  reset_checked_module_typing_artifact_construction_attempt_count()
   let outcome = check_module(mt_module_job("default.vibe", "export let api: Int = 1\n"))
   assert(checked_module_typing_artifact_observation(outcome) == None)
+  assert(checked_module_typing_artifact_construction_attempt_count() == 0)
 }
 
-test "opaque successful ModuleOutcome carries one canonical in-memory artifact" {
+test "opaque successful ModuleOutcome carries one canonical v2 artifact after one construction attempt" {
+  reset_checked_module_typing_artifact_construction_attempt_count()
   let outcome = check_module_with_typing_artifact_observation(mt_module_job("owner.vibe", "export let api: Int = 1\n"))
+  assert(checked_module_typing_artifact_construction_attempt_count() == 1)
   match checked_module_typing_artifact_observation(outcome) {
-    Some(bytes) => match decode_checked_module_typing_artifact_v1(bytes) {
+    Some(bytes) => match decode_checked_module_typing_artifact_v2(bytes) {
       Some(artifact) => {
-        assert(encode_checked_module_typing_artifact_v1(artifact) == bytes)
+        assert(encode_checked_module_typing_artifact_v2(artifact) == bytes)
         assert(String::contains(bytes, "owner.vibe"))
+        assert(String::contains(bytes, "compact_string_fingerprint(ingested_source)"))
         assert(String::contains(bytes, "provisional_token_stream_v1"))
         assert(String::contains(bytes, "ineligible:lossless_checked_body_unavailable_v1"))
       },
@@ -520,11 +553,64 @@ test "opaque successful ModuleOutcome carries one canonical in-memory artifact" 
   }
 }
 
-test "opaque ModuleOutcome publishes nothing for ordinary type or effect failures" {
+test "opaque ModuleOutcome publishes nothing and constructs nothing for ordinary type or effect failures" {
+  reset_checked_module_typing_artifact_construction_attempt_count()
   let type_failure = check_module_with_typing_artifact_observation(mt_module_job("type_bad.vibe", "export let bad: Int = \"not an int\"\n"))
   assert(checked_module_typing_artifact_observation(type_failure) == None)
+  assert(checked_module_typing_artifact_construction_attempt_count() == 0)
   let effect_failure = check_module_with_typing_artifact_observation(mt_module_job("effect_bad.vibe", "effect Logger { Log(String) -> Unit }\nexport fn bad() -> Int {\n  perform Logger::Log(\"hi\")\n  1\n}\n"))
   assert(checked_module_typing_artifact_observation(effect_failure) == None)
+  assert(checked_module_typing_artifact_construction_attempt_count() == 0)
+}
+
+test "v2 unattested builder rejects mismatched source implementation and owner closure claims" {
+  let checked = check_program_result([
+    SLet(true, false, "api", None, EInt(1))
+  ])
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(interface) => {
+      match shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked, "owner", "1:2:3", "1:2:4", "1:2:5", "1:2:5", array_empty(), [
+        ("owner", "provisional_token_stream_v1", "1:2:5")
+      ], interface) {
+        Some(_) => assert(false),
+        None => assert(true)
+      }
+      match shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked, "owner", "1:2:3", "1:2:3", "1:2:5", "1:2:6", array_empty(), [
+        ("owner", "provisional_token_stream_v1", "1:2:6")
+      ], interface) {
+        Some(_) => assert(false),
+        None => assert(true)
+      }
+      match shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked, "owner", "1:2:3", "1:2:3", "1:2:5", "1:2:5", array_empty(), [
+        ("owner", "provisional_token_stream_v1", "1:2:6")
+      ], interface) {
+        Some(_) => assert(false),
+        None => assert(true)
+      }
+    },
+    None => assert(false)
+  }
+}
+
+test "v1 canonical bytes remain unchanged after v2 introduction" {
+  let stmts = [
+    SLet(true, false, "api", None, EInt(1))
+  ]
+  // mt_outer is a test-owned length-delimited writer; neither it nor the
+  // explicit field fixture calls the production v1 encoder under test.
+  let expected = mt_outer(mt_v1_empty_dependencies_fields(mt_nested_interface(stmts)))
+  match mt_build_text(stmts, "owner", "provisional_token_stream_v1", "1:2:3", array_empty(), [
+    ("owner", "provisional_token_stream_v1", "1:2:3")
+  ]) {
+    Some(bytes) => {
+      assert(bytes == expected)
+      match decode_checked_module_typing_artifact_v1(bytes) {
+        Some(decoded) => assert(encode_checked_module_typing_artifact_v1(decoded) == bytes),
+        None => assert(false)
+      }
+    },
+    None => assert(false)
+  }
 }
 
 test "later diagnosed outcome cannot reuse a stale successful observation" {


### PR DESCRIPTION
## Summary

- add a versioned checked-module typing artifact encoding with separately tagged exact-source and provisional token-stream implementation identities
- derive both identities from the already-ingested `ModuleJob.source` and reject source, implementation, or owner-closure mismatch
- retain byte-compatible v1 encoding and keep ordinary checks at zero construction attempts

This is an opt-in post-success construction slice only. It adds no persistence, planner/cache reuse, filesystem reread, `TypeEnv` replacement, or CLI exposure. Umbrella #1550 remains open.

## Validation

- independent verifier ACCEPT after one bounded test-fixture correction
- focused checked-module artifact compile + `_start`
- exact v1 canonical byte compatibility fixture
- formatter and generated freshness
- selfcompile heap gate: 992,836,768 bytes <= 1,105,822,775
- clean content-verified reconstruction from accepted writer stack
