### PR TITLE
fix(cov): coverage driver 39 本すべてを exact-path exposure へ移し、壊れた raw concat レーンを削除する (#1633)

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -206,31 +206,41 @@ in-scope）を直接叩ける。型/trait/env に加え以下も edge-case 入�
 
 #### 80% 達成（no-DCE merged source + direct-call drivers）
 
-> **#1633 migration status:** the historical raw concatenation described below
-> is being retired one driver at a time. `cov_units.vibe` and
-> `cov_traitenv.vibe` now use compiler-owned exact-path value exposure: their
-> imports name one `.vibe` file in the collected
-> compiler closure, the production export/private namespacing plan determines
-> the final target name, and the existing shadow-aware import rewriter updates
-> driver references before entry-based DCE. Missing, duplicate, out-of-closure,
-> type/constructor, mutable-global, extern, method, and collision requests fail
-> with a diagnostic. The internal mode (`VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1` +
-> `VIBE_COVERAGE_DRIVER_PATH`) is invoked only by `coverage_drivers.sh`; it does
-> not widen normal import visibility or change `VIBE_EMIT_MERGED_SOURCE` output.
-> The other drivers retain the legacy base until their own reviewed slices.
+> **#1633 migration status: done for `coverage_drivers.sh`.** The historical raw
+> concatenation described below has been deleted; all 39 registered drivers use
+> compiler-owned exact-path value exposure. Their imports name one `.vibe` file
+> in the collected compiler closure, the production export/private namespacing
+> plan determines the final target name, and the existing shadow-aware import
+> rewriter updates driver references before entry-based DCE. Missing, duplicate,
+> out-of-closure, type/constructor, mutable-global, extern, method, and collision
+> requests fail with a diagnostic. The internal mode
+> (`VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1` + `VIBE_COVERAGE_DRIVER_PATH`) is invoked
+> only by `coverage_drivers.sh`; it does not widen normal import visibility or
+> change `VIBE_EMIT_MERGED_SOURCE` output.
+>
+> なぜ raw concat を残せなかったか: あの walk は**相対 import しか辿らない**ので
+> `.vpkg` パッケージ import (#1269/#897) 以降は数ホップで止まり、~5MB のはずの
+> base が 67KB しか出ていなかった (= 全 driver が `unknown name` で死ぬ)。
+> 仮に walk を直しても、300 ファイルを無資格に連結した base は同名の private
+> ヘルパを first-match roulette で解決するので、どの関数のカバレッジを測ったのか
+> が決まらない。exposure が production の rename plan を経由するのはそのため。
 
 **分岐 5711/6694 (85.32%)**・関数 1037/1176 (88.18%) に到達（85% = 5690 に対し +21 のマージン、下限ガード 80% に対し +355）。
 74% で頭打ちだった主因（コンパイラ自身の unit test 120/148 が builtins⇄checker
 の循環 re-export で FS-compile 不能）を、**循環 re-export を直さずに**回避した。
 
-鍵は **no-DCE merged source** (`_build/coverage/merged_nodce.vibe`)。flat module
-source (`_cli_adapter_module_source.vibe`) は `build_module_source_from_source`
-が entry `cli_main` から DCE するため、テストだけが使う ~530 関数が欠落していた。
-代わりに `build_exact_adapter_merged_source` 相当の **DCE 前 merged source**
-（manifest 全ファイルを import 除去で連結 = 全 top-level 関数が in-scope、しかも
-import 文が無いので循環 re-export blocker も踏まない）を base にする。
+鍵は **DCE を跨いで関数へ到達する**こと。flat module source
+(`_cli_adapter_module_source.vibe`) は `build_module_source_from_source` が
+entry `cli_main` から DCE するため、テストだけが使う ~530 関数が欠落していた。
 
-この base へ小さな entry を append し、coverage 付き compile+run して実行分岐を
+当時の答えは **no-DCE merged source** (`_build/coverage/merged_nodce.vibe`)
+＝ manifest 全ファイルを import 除去で連結した base だった（全 top-level 関数が
+in-scope、import 文が無いので循環 re-export blocker も踏まない）。**この lane は
+#1633 で削除済み**（上の blockquote 参照）。今は driver 側が exact-path import で
+必要な関数を名指しし、その driver entry を根に DCE する — 目的（テストしか呼ばない
+関数へ到達する）は同じで、どの関数を測っているかが名前で決まる点だけが違う。
+
+driver を base へ足したものを coverage 付き compile+run し、実行分岐を
 corpus acc.json に (fn_name, local_branch_index) キーで union する。分母（seed
 コンパイラの分岐）は不変なので、seed に存在する関数の未踏 arm だけが点灯する。
 
@@ -245,7 +255,7 @@ corpus acc.json に (fn_name, local_branch_index) キーで union する。分�
     — examples に async プログラムが無い (+32)。`Task::*` を叩いていた分は
     #1227 の eager prototype 撤去で外した。
   - `cov_lookup.vibe`: builtin name→Type dispatch chain
-    (`lookup_array_group_b`/`lookup_io_b`) を全 builtin 名で呼ぶ (+25)。
+    (`lookup_array`/`lookup_io_b`) を全 builtin 名で呼ぶ (+25)。
   - `cov_cachetext.vibe`: persistent-cache フォーマット parser の version/arity/
     unknown-tag/CR arm を crafted TSV で (+16)。
   - `cov_units.vibe` / `cov_units2.vibe`: 小 helper を直接呼ぶ
@@ -297,7 +307,7 @@ corpus acc.json に (fn_name, local_branch_index) キーで union する。分�
 再現:
 ```bash
 scripts/coverage_corpus.sh        # base acc.json + compiler_cov.wasm
-scripts/coverage_unittests.sh     # VIBE_COV_FLAT=_build/coverage/merged_nodce.vibe で再実行も可
+scripts/coverage_unittests.sh     # base は flat module source (#1633 で no-DCE merged base は無くなった)
 scripts/coverage_drivers.sh       # async/lookup/cachetext/units/traitenv/link/helpers/…
 scripts/coverage_manifestcache.sh
 scripts/coverage_multimodule.sh
@@ -315,12 +325,23 @@ compile する役割だけ）。merge は command status と `base now total` sc
 検査し、`total > 0`、分母不変、hit 非減少、書込み後 stat 一致を満たさなければ
 coverage run 全体を失敗させる。
 
-#1633 の production exact-path exposure へ移行済みなのは現在 `cov_units.vibe`
-と `cov_traitenv.vibe`。登録済み active driver の残り **37 本**は legacy raw base
-のままで、個別に
-exact-path import を宣言して移行する必要がある。`cov_driver.vibe` は現在の
-`coverage_drivers.sh` に登録されない historical monolith なので、移行対象へ戻すか
-退役するかを別途決める。ここで件数へ含めたり暗黙に実行済みとは扱わない。
+#1633 の production exact-path exposure へは、`coverage_drivers.sh` に登録された
+**39 本すべてが移行済み**。legacy raw base (`_build/coverage/merged_nodce.vibe`)
+とそれを作っていた Python walk は削除した。`cov_driver.vibe` は現在の
+`coverage_drivers.sh` に登録されない historical monolith（`coverage_driver.sh`
+単数形からのみ参照され、そちらは flat module source への raw concat のまま）なので、
+移行対象へ戻すか退役するかを別途決める。ここで件数へ含めたり暗黙に実行済みとは
+扱わない。
+
+移行で分かったこと: 全 driver が壊れたまま放置されていた間に、driver が呼ぶ
+コンパイラ側 API が動いていた。AST ノードのアリティ (`EIdent`/`ECall`/`EDot` の
+byte offset スロット、`SEnum` の derives、`SStruct` の #829 スロット)、
+parser 内部の `starts: Array[Int]` (#1567 located diagnostics) と `parse_recur`
+コールバック、`check_pattern` の errors シンク、`flatten_module_body` が
+alias 配列ではなく rewriter を取るようになった点など。消えた target
+(`lookup_array_group_b` → `lookup_array`、`lookup_io_c` → `lookup_io_b` へ吸収、
+`lookup_assert` → checker.vibe のインライン名前判定、`parse_int_unwrap` →
+`parse_int_or`) は現行の後継へ差し替えるか、後継が無いものは理由付きで削った。
 
 #### 構造的に到達不能な残差（~19 dark）
 

--- a/scripts/coverage/cov_async.vibe
+++ b/scripts/coverage/cov_async.vibe
@@ -1,3 +1,6 @@
+import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe {
+  compile_source_wasi_only
+}
 
 // #cov async/stream driver: the inlined async builtins (await, Future::ready,
 // to_string, String::to_bytes) each have a dedicated compile_call arm, but NO

--- a/scripts/coverage/cov_block.vibe
+++ b/scripts/coverage/cov_block.vibe
@@ -1,10 +1,31 @@
+import ../../lib/@vibe/parser/parser_expr.vibe {
+  parse_impl
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex_with_offsets
+}
+
+import ../../lib/@vibe/parser/parser_expr_dispatch.vibe {
+  parse_impl_block
+}
 
 // #cov block driver: parse_impl_block (block-body parser) reached directly via the
 // parse_impl callback. Drive its block-local let-rec / let-mut / let-star / enum /
 // struct arms plus its error throws (eof-in-block, "expected identifier after
 // 'let rec'/'let mut'", "did not advance") with well-formed and malformed bodies.
+// parse_impl_block takes the token START offsets (#1567 located diagnostics) and
+// a `parse_recur` callback shaped (tokens, pos, mode); parse_impl closes over the
+// offsets, exactly as parser_expr.vibe's own recur does.
 let blk: (String) -> Int = (s) -> {
-  handle { let r = parse_impl_block(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    let (toks, starts, _) = lex_with_offsets(s)
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (t, p, m) -> {
+      parse_impl(t, starts, p, m)
+    }
+    let r = parse_impl_block(toks, starts, 0, recur)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 
 let blk_ok: () -> Int = () -> {

--- a/scripts/coverage/cov_builtins.vibe
+++ b/scripts/coverage/cov_builtins.vibe
@@ -1,3 +1,6 @@
+import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe {
+  compile_source_wasi_only
+}
 
 // #cov builtins driver: every Array/String/Map/Bytes/Int builtin has its own
 // checker dispatch arm (lookup_array_group_*, lookup_string_*, lookup_map_*,

--- a/scripts/coverage/cov_cache2.vibe
+++ b/scripts/coverage/cov_cache2.vibe
@@ -1,3 +1,12 @@
+import ../../lib/@vibe/compiler/loader/manifest_sources.vibe {
+  parse_persistent_manifest_header_cache,
+  parse_source_manifest_rows
+}
+
+import ../../lib/@vibe/compiler/core/module_graph_path.vibe {
+  normalize_path
+}
+
 
 // #cov cache2 driver: string-input path/manifest/header-cache parsers —
 // normalize_path (absolute / '.' / '..' / empty / double-sep arms),
@@ -7,8 +16,14 @@ let c2_np: (String) -> Int = (p) -> { String::length(normalize_path(p)) }
 let c2_rows: (String) -> Int = (s) -> {
   handle { Array::length(parse_source_manifest_rows(s)) } with Exception { Throw(_) => 0 }
 }
+// `match` rather than `let r = ..; r.0`: a tuple projection off a let-bound value
+// inside a `handle` body makes codegen emit a module that fails wasm validation
+// ("invalid local index"), with both `vibe check` and `vibe build` reporting
+// success (#1643).
 let c2_hdr: (String) -> Int = (s) -> {
-  handle { let r = parse_persistent_manifest_header_cache(s); r.0 } with Exception { Throw(_) => 0 }
+  handle {
+    match parse_persistent_manifest_header_cache(s) { (v, _, _) => v }
+  } with Exception { Throw(_) => 0 }
 }
 
 export let cov_cache2_main: () -> Int = () -> {

--- a/scripts/coverage/cov_cachetext.vibe
+++ b/scripts/coverage/cov_cachetext.vibe
@@ -1,3 +1,7 @@
+import ../../lib/@vibe/compiler/loader/loader.vibe {
+  parse_persistent_source_group_cache,
+  parse_persistent_source_list_cache
+}
 
 // #cov cache-text driver: parse_persistent_source_group_cache /
 // parse_persistent_source_list_cache parse the on-disk cache format and have many
@@ -7,13 +11,13 @@
 // cache texts so every validation branch runs.
 let cov_ct_group: (String) -> Int = (raw) -> {
   handle {
-    let (v, _, rows) = parse_persistent_source_group_cache(raw)
+    let (v, _, rows, _) = parse_persistent_source_group_cache(raw)
     v + Array::length(rows)
   } with Exception { Throw(_) => 0 }
 }
 let cov_ct_list: (String) -> Int = (raw) -> {
   handle {
-    let (v, _, srcs) = parse_persistent_source_list_cache(raw)
+    let (v, _, srcs, _) = parse_persistent_source_list_cache(raw)
     v + Array::length(srcs)
   } with Exception { Throw(_) => 0 }
 }

--- a/scripts/coverage/cov_checker.vibe
+++ b/scripts/coverage/cov_checker.vibe
@@ -1,3 +1,10 @@
+import ../../lib/@vibe/compiler/core/types.vibe {
+  occurs_in,
+  subst_apply,
+  subst_lookup,
+  types_equal,
+  unify
+}
 
 // #cov checker driver: drive the unique type-inference primitives directly with
 // constructed Type/Subst/Pat values — unify (var-bind / occurs / structural

--- a/scripts/coverage/cov_exprwalk.vibe
+++ b/scripts/coverage/cov_exprwalk.vibe
@@ -1,3 +1,19 @@
+import ../../lib/@vibe/compiler/perceus/perceus.vibe {
+  expr_projects_or_matches
+}
+
+import ../../lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe {
+  is_mut_captured_in
+}
+
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  pat_binds_name,
+  rewrite_import_alias_expr
+}
+
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  wrap_placeholder_arg
+}
 
 // #cov expr-walk driver: is_mut_captured_in / rewrite_import_alias_expr /
 // wrap_placeholder_arg are unique recursive Expr walkers whose per-variant arms
@@ -19,8 +35,8 @@ export let cov_exprwalk_main: () -> Int = () -> {
   let mut acc = 0
   let al = Array::slice([("x", "y")], 0, 1)        // alias map [("x","y")]
   let noexpr = Array::slice([EUnit], 0, 0)          // empty Array[Expr]
-  let xid = EIdent("x")
-  let ph = EIdent("_")
+  let xid = EIdent("x", 0)
+  let ph = EIdent("_", 0)
   let es = Array::slice([xid], 0, 0)                 // empty Array[Expr]
   Array::push(es, xid)
   // one Expr per branched variant (leaves + every recursive shape)
@@ -34,22 +50,22 @@ export let cov_exprwalk_main: () -> Int = () -> {
   Array::push(progs, ph)
   Array::push(progs, ETuple(es))
   Array::push(progs, EArray(es))
-  Array::push(progs, ERecord(Array::slice([("f", xid)], 0, 1)))
+  Array::push(progs, ERecord("", Array::slice([("f", xid)], 0, 1), Array::slice([TyName("Int")], 0, 0)))
   Array::push(progs, EMap(Array::slice([("k", xid)], 0, 1)))
   Array::push(progs, EIf(xid, EInt(1), EInt(2)))
-  Array::push(progs, ELet("a", xid, EIdent("a")))
-  Array::push(progs, ELetRec("a", xid, EIdent("a")))
-  Array::push(progs, ELetMut("a", xid, EAssign("a", EInt(1), EUnit)))
+  Array::push(progs, ELet("a", xid, EIdent("a", 0), 0))
+  Array::push(progs, ELetRec("a", xid, EIdent("a", 0)))
+  Array::push(progs, ELetMut("a", xid, EAssign("a", EInt(1), EUnit), 0))
   Array::push(progs, EAssign("x", EInt(1), EUnit))
   Array::push(progs, EAssignOp("+", "x", EInt(1), EUnit))
   Array::push(progs, ESeq(xid, EUnit))
   Array::push(progs, EWhile(xid, EUnit))
   Array::push(progs, EForIn("i", None, xid, EUnit))
-  Array::push(progs, ECall(EIdent("f"), Array::slice([xid, ph], 0, 2)))
+  Array::push(progs, ECall(EIdent("f", 0), Array::slice([xid, ph], 0, 2), 0))
   Array::push(progs, EBinOp("+", xid, ph))
   Array::push(progs, EBinOp("+", EInt(1), EInt(2)))
   Array::push(progs, EUnaryOp("-", xid))
-  Array::push(progs, EDot(ph, "field"))
+  Array::push(progs, EDot(ph, "field", 0, 0))
   Array::push(progs, EReturn(xid))
   Array::push(progs, EBreak(Some(xid)))
   Array::push(progs, EBreak(None))
@@ -61,11 +77,11 @@ export let cov_exprwalk_main: () -> Int = () -> {
   Array::push(progs, EBinOp("+", EInt(1), xid))          // x in rhs only
   Array::push(progs, EIf(EInt(0), EInt(1), xid))         // x in else only
   Array::push(progs, EIf(EInt(0), xid, EInt(1)))         // x in then only
-  Array::push(progs, ECall(EIdent("f"), Array::slice([EInt(1), xid], 0, 2)))  // x in later arg
-  Array::push(progs, ECall(xid, noexpr))                 // x in callee
-  Array::push(progs, ELet("x", EInt(1), EIdent("x")))    // shadowing: n == name
-  Array::push(progs, ELetRec("x", EInt(1), EIdent("x"))) // shadowing
-  Array::push(progs, ELetMut("x", EInt(1), EIdent("x"))) // shadowing
+  Array::push(progs, ECall(EIdent("f", 0), Array::slice([EInt(1), xid], 0, 2), 0))  // x in later arg
+  Array::push(progs, ECall(xid, noexpr, 0))                 // x in callee
+  Array::push(progs, ELet("x", EInt(1), EIdent("x", 0), 0))    // shadowing: n == name
+  Array::push(progs, ELetRec("x", EInt(1), EIdent("x", 0))) // shadowing
+  Array::push(progs, ELetMut("x", EInt(1), EIdent("x", 0), 0)) // shadowing
   Array::push(progs, EForIn("i", None, EInt(0), xid))    // x in body only
   Array::push(progs, EWhile(EInt(0), xid))               // x in body only
   Array::push(progs, ESeq(EInt(0), xid))                 // x in second only
@@ -76,11 +92,11 @@ export let cov_exprwalk_main: () -> Int = () -> {
   // expr_projects_or_matches: EIdent / EDot / EMatch / EHandle (+ default)
   let arms = Array::slice([(PWild, EUnit)], 0, 1)         // one arm [(PWild, EUnit)]
   let pexprs = Array::slice([EUnit], 0, 0)
-  Array::push(pexprs, EIdent("x"))
-  Array::push(pexprs, EIdent("z"))
-  Array::push(pexprs, EDot(EIdent("x"), "f"))
-  Array::push(pexprs, EMatch(EIdent("x"), arms))
-  Array::push(pexprs, EHandle(EIdent("x"), arms))
+  Array::push(pexprs, EIdent("x", 0))
+  Array::push(pexprs, EIdent("z", 0))
+  Array::push(pexprs, EDot(EIdent("x", 0), "f", 0, 0))
+  Array::push(pexprs, EMatch(EIdent("x", 0), arms))
+  Array::push(pexprs, EHandle(EIdent("x", 0), arms))
   Array::push(pexprs, EInt(1))
   let mut j = 0
   while j < Array::length(pexprs) { acc = acc + cov_ew_proj(Array::get(pexprs, j)); j = j + 1 }

--- a/scripts/coverage/cov_final.vibe
+++ b/scripts/coverage/cov_final.vibe
@@ -1,3 +1,24 @@
+import ../../lib/@vibe/compiler/normalize/normalize.vibe {
+  module_value_aliases
+}
+
+import ../../lib/@vibe/compiler/loader/loader.vibe {
+  collect_source_groups_fs,
+  push_grouped_source
+}
+
+import ../../lib/@vibe/parser/parser_base.vibe {
+  collect_import_path
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex
+}
+
+import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe {
+  entry_declares_async_int
+}
+
 
 // #cov final driver: residual arms of entry_declares_async_int (async-Int entry
 // signature variations), collect_import_path (token import paths), and the
@@ -37,7 +58,7 @@ let fin_import: () -> Int = () -> {
   }
   acc
 }
-let fin_groups: () -> Int = () -> {
+let fin_groups: () -> Int with Fs = () -> {
   let mut acc = 0
   let groups = Array::slice([("", Array::slice([("", "")], 0, 0))], 0, 0)
   push_grouped_source(groups, "g1", "a.vibe", "sa")
@@ -46,8 +67,8 @@ let fin_groups: () -> Int = () -> {
   push_grouped_source(groups, "g1", "d.vibe", "sd")
   acc = acc + Array::length(groups)
   let body = Array::slice([SExpr(EUnit)], 0, 0)
-  Array::push(body, SLet(true, false, "k", None, EIdent("k")))
-  Array::push(body, SLet(false, false, "p", None, ECall(EIdent("k"), Array::slice([EUnit], 0, 0))))
+  Array::push(body, SLet(true, false, "k", None, EIdent("k", 0)))
+  Array::push(body, SLet(false, false, "p", None, ECall(EIdent("k", 0), Array::slice([EUnit], 0, 0), 0)))
   Array::push(body, SExport(Array::slice(["k"], 0, 1)))
   acc = acc + module_value_aliases(body, "M", Array::slice([("k", "M_k"), ("p", "M_p")], 0, 2))
   acc = acc + module_value_aliases(body, "M", Array::slice([("", "")], 0, 0))
@@ -55,6 +76,6 @@ let fin_groups: () -> Int = () -> {
   acc
 }
 
-export let cov_final_main: () -> Int = () -> {
+export let cov_final_main: () -> Int with Fs = () -> {
   fin_async() + fin_import() + fin_groups()
 }

--- a/scripts/coverage/cov_final2.vibe
+++ b/scripts/coverage/cov_final2.vibe
@@ -1,3 +1,27 @@
+import ../../lib/@vibe/compiler/loader/manifest_sources.vibe {
+  scan_header_import_dep
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex
+}
+
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  rewrite_import_alias_expr
+}
+
+import ../../lib/@vibe/compiler/checker/checker_resolve.vibe {
+  resolve_type_expr
+}
+
+import ../../lib/@vibe/compiler/core/types.vibe {
+  env_lookup
+}
+
+import ../../lib/@vibe/parser/printer.vibe {
+  print_stmt
+}
+
 
 // #cov final2 driver: print_stmt for the type-decl Stmt variants (SEnum/SStruct/
 // SSuberror/STrait/STypeAlias), env_lookup over the remaining TypeEnv variants,
@@ -5,17 +29,17 @@
 // variants + scan_header_import_dep aliased/@-prefixed headers.
 let f2_ps: (Stmt) -> Int = (s) -> { String::length(print_stmt(s)) }
 let f2_env: (TypeEnv) -> Int = (e) -> { match env_lookup(e, "x") { Some(_) => 1, None => 0 } }
-let f2_rte: (TypeExpr) -> Int = (te) -> { match resolve_type_expr(te, Array::slice([TDStruct("S", Array::slice([("v", CtInt)], 0, 1))], 0, 0)) { _ => 1 } }
+let f2_rte: (TypeExpr) -> Int = (te) -> { match resolve_type_expr(te, Array::slice([TDStruct("S", Array::slice([("v", CtInt)], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0))], 0, 0)) { _ => 1 } }
 let f2_rw: (Expr) -> Int = (e) -> { match rewrite_import_alias_expr(e, Array::slice([("x", "y")], 0, 1)) { _ => 1 } }
 
 let f2_prints: () -> Int = () -> {
   let mut acc = 0
   let ii = Array::slice([TyName("Int")], 0, 1)
   let no = Array::slice([TyName("Int")], 0, 0)
-  acc = acc + f2_ps(SEnum(false, "E", Array::slice([""], 0, 0), Array::slice([("A", no), ("B", ii)], 0, 2)))
-  acc = acc + f2_ps(SEnum(true, "PE", Array::slice(["a"], 0, 1), Array::slice([("C", no)], 0, 1)))
-  acc = acc + f2_ps(SStruct(false, "S", Array::slice([("f", TyName("Int")), ("g", TyName("Bool"))], 0, 2)))
-  acc = acc + f2_ps(SStruct(true, "PS", Array::slice([("h", TyName("Int"))], 0, 1)))
+  acc = acc + f2_ps(SEnum(false, "E", Array::slice([""], 0, 0), Array::slice([("A", no), ("B", ii)], 0, 2), Array::slice([""], 0, 0)))
+  acc = acc + f2_ps(SEnum(true, "PE", Array::slice(["a"], 0, 1), Array::slice([("C", no)], 0, 1), Array::slice([""], 0, 0)))
+  acc = acc + f2_ps(SStruct(false, "S", Array::slice([("f", TyName("Int")), ("g", TyName("Bool"))], 0, 2), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
+  acc = acc + f2_ps(SStruct(true, "PS", Array::slice([("h", TyName("Int"))], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
   acc = acc + f2_ps(SSuberror(false, "Er", Array::slice([("X", ii), ("Y", no)], 0, 2)))
   acc = acc + f2_ps(STrait(false, "Tr", Array::slice(["f", "g"], 0, 2), ArrayBuilder::freeze(ArrayBuilder::new()), ArrayBuilder::freeze(ArrayBuilder::new()), Array::slice([""], 0, 0)))
   acc = acc + f2_ps(STrait(true, "PT", Array::slice([""], 0, 0), ArrayBuilder::freeze(ArrayBuilder::new()), ArrayBuilder::freeze(ArrayBuilder::new()), Array::slice([""], 0, 0)))
@@ -25,8 +49,8 @@ let f2_prints: () -> Int = () -> {
 }
 let f2_envs: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + f2_env(EnvCached(MapBuilder::freeze(MapBuilder::new()), EnvBind("x", CtInt, EnvEmpty)))
-  acc = acc + f2_env(EnvTraitDef("Eq", Array::slice([""], 0, 0), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvBind("x", CtInt, EnvEmpty), Array::slice([""], 0, 0)))
+  acc = acc + f2_env(EnvCached(Array::slice(["x"], 0, 1), Array::slice([CtInt], 0, 1), EnvBind("y", CtInt, EnvEmpty)))
+  acc = acc + f2_env(EnvTraitDef("Eq", Array::slice([""], 0, 0), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvBind("x", CtInt, EnvEmpty), Array::slice([""], 0, 0), ArrayBuilder::freeze(ArrayBuilder::new())))
   acc = acc + f2_env(EnvTraitImpl("Eq", CtInt, EnvFlat(Array::slice([("x", CtBool)], 0, 1))))
   acc = acc + f2_env(EnvTraitImplGen("G", Array::slice([""], 0, 0), Array::slice([("", Array::slice([""], 0, 0))], 0, 0), CtInt, EnvBind("x", CtInt, EnvEmpty)))
   acc = acc + f2_env(EnvEmpty)
@@ -41,14 +65,14 @@ let f2_types: () -> Int = () -> {
   acc = acc + f2_rte(TyApp("Option", Array::slice([TyName("Int")], 0, 1)))
   acc
 }
-let f2_rewrite: () -> Int = () -> {
+let f2_rewrite: () -> Int with Exception + Fs = () -> {
   let mut acc = 0
-  let x = EIdent("x")
+  let x = EIdent("x", 0)
   acc = acc + f2_rw(EMatch(x, Array::slice([(PWild, x)], 0, 1)))
   acc = acc + f2_rw(EHandle(x, Array::slice([(PWild, x)], 0, 1)))
-  acc = acc + f2_rw(ECall(x, Array::slice([x], 0, 1)))
+  acc = acc + f2_rw(ECall(x, Array::slice([x], 0, 1), 0))
   acc = acc + f2_rw(EBinOp("+", x, x))
-  acc = acc + f2_rw(EDot(x, "f"))
+  acc = acc + f2_rw(EDot(x, "f", 0, 0))
   acc = acc + f2_rw(EWhile(x, x))
   acc = acc + f2_rw(EForIn("i", None, x, x))
   acc = acc + (handle { let r = scan_header_import_dep(lex("@pkg/m { y }"), 0, "b", MapBuilder::freeze(MapBuilder::new())); String::length(r.0) } with Exception { Throw(_) => 0 })
@@ -56,6 +80,6 @@ let f2_rewrite: () -> Int = () -> {
   acc
 }
 
-export let cov_final2_main: () -> Int = () -> {
+export let cov_final2_main: () -> Int with Exception + Fs = () -> {
   f2_prints() + f2_envs() + f2_types() + f2_rewrite()
 }

--- a/scripts/coverage/cov_fs2.vibe
+++ b/scripts/coverage/cov_fs2.vibe
@@ -1,3 +1,17 @@
+import ../../lib/@vibe/compiler/runtime/persistent_env_codec.vibe {
+  load_persistent_dep_list,
+  load_persistent_type_env
+}
+
+import ../../lib/@vibe/compiler/loader/loader.vibe {
+  collect_all_sources_fs,
+  collect_source_groups_fs
+}
+
+import ../../lib/@vibe/compiler/runtime/module_source.vibe {
+  build_module_source_from_source
+}
+
 
 // #cov fs2 driver: build_module_source_from_source (source-text -> DCE'd module
 // source; no FS) over several entry/DCE shapes, plus the cold-path arms of the
@@ -8,20 +22,20 @@
 let f_bms: (String) -> Int = (src) -> {
   handle { String::length(build_module_source_from_source(src, "m")) } with Exception { Throw(_) => 0 }
 }
-let f_all: (String) -> Int = (p) -> {
+let f_all: (String) -> Int with Fs = (p) -> {
   handle { Array::length(collect_all_sources_fs(p)) } with Exception { Throw(_) => 0 }
 }
-let f_grp: (String) -> Int = (p) -> {
+let f_grp: (String) -> Int with Fs = (p) -> {
   handle { Array::length(collect_source_groups_fs(p)) } with Exception { Throw(_) => 0 }
 }
-let f_dep: (String, String) -> Int = (a, b) -> {
+let f_dep: (String, String) -> Int with Fs = (a, b) -> {
   handle { match load_persistent_dep_list(a, b) { Some(_) => 1, None => 0 } } with Exception { Throw(_) => 0 }
 }
-let f_env: (String) -> Int = (p) -> {
+let f_env: (String) -> Int with Fs = (p) -> {
   handle { match load_persistent_type_env(p) { Some(_) => 1, None => 0 } } with Exception { Throw(_) => 0 }
 }
 
-export let cov_fs2_main: () -> Int = () -> {
+export let cov_fs2_main: () -> Int with Fs = () -> {
   let mut acc = 0
   // build_module_source_from_source: DCE keep/drop, multiple decls, unused private
   acc = acc + f_bms("export let m: () -> Int = () -> { 1 }")

--- a/scripts/coverage/cov_fscache.vibe
+++ b/scripts/coverage/cov_fscache.vibe
@@ -1,3 +1,11 @@
+import ../../lib/@vibe/cache/cache.vibe {
+  compact_string_fingerprint
+}
+
+import ../../lib/@vibe/compiler/loader/loader.vibe {
+  load_source_if_cached_file_spec_matches
+}
+
 
 // #cov fs-cache driver: load_source_if_cached_file_spec_matches(path, stat_token,
 // fingerprint) is a unique 8-path Fs validator — missing / stat-match /
@@ -5,7 +13,7 @@
 // no-stat+fp-miss / no-stat+fp-empty. The corpus only hits the happy paths. Read a
 // real fixture's actual stat_token + fingerprint, then feed matching and
 // deliberately-wrong values to route through every arm. Needs _build/covfs/f.vibe.
-let cov_fc_one: (String, String, String) -> Int = (p, st, fp) -> {
+let cov_fc_one: (String, String, String) -> Int with Fs = (p, st, fp) -> {
   handle {
     match load_source_if_cached_file_spec_matches(p, st, fp) {
       Some(_) => 1,
@@ -16,7 +24,7 @@ let cov_fc_one: (String, String, String) -> Int = (p, st, fp) -> {
   }
 }
 
-export let cov_fscache_main: () -> Int = () -> {
+export let cov_fscache_main: () -> Int with Fs = () -> {
   let mut acc = 0
   let path = "_build/covfs/f.vibe"
   // missing file

--- a/scripts/coverage/cov_grab.vibe
+++ b/scripts/coverage/cov_grab.vibe
@@ -1,3 +1,59 @@
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  has_non_pipe_infix_top
+}
+
+import ../../lib/@vibe/parser/parser_base.vibe {
+  collect_import_path,
+  skip_derive
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex
+}
+
+import ../../lib/@vibe/parser/printer.vibe {
+  print_stmt
+}
+
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  make_import_alias_rewriter
+}
+
+import ../../lib/@vibe/compiler/core/dce.vibe {
+  dce_reachable_names
+}
+
+import ../../lib/@vibe/compiler/normalize/normalize.vibe {
+  exported_value_names,
+  flatten_module_body,
+  module_value_aliases
+}
+
+import ../../lib/@vibe/compiler/checker/checker.vibe {
+  infer_binop_type
+}
+
+import ../../lib/@vibe/compiler/perceus/perceus.vibe {
+  all_calls_heap_at,
+  is_heap_literal,
+  type_contains_fn,
+  type_expr_is_heap
+}
+
+import ../../lib/@vibe/compiler/checker/checker_resolve.vibe {
+  subst_type_params
+}
+
+import ../../lib/@vibe/compiler/core/types.vibe {
+  env_cache,
+  env_flat_bindings,
+  env_lookup,
+  trait_defined,
+  trait_is_subtrait,
+  type_implements_check_env,
+  type_to_string
+}
+
 
 // #cov grab driver: sweep the long tail of small tractable type/trait/env/heap/
 // token/AST helpers, each driven directly with constructed inputs. Split into many
@@ -49,15 +105,15 @@ let grab_binop: () -> Int = () -> {
 }
 let grab_env: () -> Int = () -> {
   let mut acc = 0
-  let def_eq = EnvTraitDef("Eq", Array::slice([""], 0, 0), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0))
-  let def_ord = EnvTraitDef("Ord", Array::slice(["Eq"], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), def_eq, Array::slice([""], 0, 0))
+  let def_eq = EnvTraitDef("Eq", Array::slice([""], 0, 0), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0), ArrayBuilder::freeze(ArrayBuilder::new()))
+  let def_ord = EnvTraitDef("Ord", Array::slice(["Eq"], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), def_eq, Array::slice([""], 0, 0), ArrayBuilder::freeze(ArrayBuilder::new()))
   let env = EnvTraitImpl("Ord", CtInt, def_ord)
   acc = acc + (if trait_defined(env, "Ord") { 1 } else { 0 })
   acc = acc + (if trait_defined(env, "Nope") { 1 } else { 0 })
   acc = acc + (if trait_is_subtrait(env, "Ord", "Eq") { 1 } else { 0 })
   acc = acc + (if trait_is_subtrait(env, "Eq", "Ord") { 1 } else { 0 })
-  acc = acc + (if type_implements_check_env(env, "Ord", CtInt) { 1 } else { 0 })
-  acc = acc + (if type_implements_check_env(env, "Ord", CtBool) { 1 } else { 0 })
+  acc = acc + (if type_implements_check_env(env, env, "Ord", CtInt) { 1 } else { 0 })
+  acc = acc + (if type_implements_check_env(env, env, "Ord", CtBool) { 1 } else { 0 })
   acc = acc + Array::length(env_flat_bindings(EnvBind("x", CtInt, EnvFlat(Array::slice([("y", CtBool)], 0, 1)))))
   acc = acc + (match env_cache(EnvBind("x", CtInt, EnvEmpty)) { _ => 1 })
   acc = acc + (match env_lookup(EnvFlat(Array::slice([("x", CtInt)], 0, 1)), "x") { Some(_) => 1, None => 0 })
@@ -80,13 +136,13 @@ let grab_ast: () -> Int = () -> {
   let mut acc = 0
   let body = Array::slice([SExpr(EUnit)], 0, 0)
   Array::push(body, SLet(true, false, "k", None, EInt(1)))
-  Array::push(body, SLet(false, false, "p", None, ECall(EIdent("k"), Array::slice([EUnit], 0, 0))))
+  Array::push(body, SLet(false, false, "p", None, ECall(EIdent("k", 0), Array::slice([EUnit], 0, 0), 0)))
   Array::push(body, SExport(Array::slice(["k"], 0, 1)))
   acc = acc + Array::length(exported_value_names(body))
   acc = acc + Array::length(dce_reachable_names(body, Array::slice(["p"], 0, 1)))
   acc = acc + module_value_aliases(body, "M", Array::slice([("k", "M_k")], 0, 1))
   let out = Array::slice([SExpr(EUnit)], 0, 0)
-  acc = acc + flatten_module_body(body, "M", Array::slice([("k", "M_k")], 0, 1), out)
+  acc = acc + flatten_module_body(body, "M", make_import_alias_rewriter(Array::slice([("k", "M_k")], 0, 1)), out)
   acc = acc + String::length(print_stmt(SImport("m", Array::slice([("x", Some("y"))], 0, 1))))
   acc = acc + String::length(print_stmt(SExport(Array::slice(["a"], 0, 1))))
   acc

--- a/scripts/coverage/cov_grind.vibe
+++ b/scripts/coverage/cov_grind.vibe
@@ -1,3 +1,11 @@
+import ../../lib/@vibe/compiler/loader/manifest_sources.vibe {
+  collect_needed_paths_from_manifest_headers,
+  empty_path_index
+}
+
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  collect_private_type_renames
+}
 
 // #cov grind driver: constructible-input residual arms.
 //  - collect_private_type_renames: private SEnum/SStruct/STypeAlias/SSuberror with
@@ -8,17 +16,17 @@ let g_renames: (Array[String]) -> Int = (exported) -> {
   let body = Array::slice([SExpr(EUnit)], 0, 0)
   let no = Array::slice([TyName("Int")], 0, 0)
   let ii = Array::slice([TyName("Int")], 0, 1)
-  Array::push(body, SEnum(false, "PE", Array::slice([""], 0, 0), Array::slice([("A", no)], 0, 1)))
-  Array::push(body, SStruct(false, "PS", Array::slice([("f", TyName("Int"))], 0, 1)))
+  Array::push(body, SEnum(false, "PE", Array::slice([""], 0, 0), Array::slice([("A", no)], 0, 1), Array::slice([""], 0, 0)))
+  Array::push(body, SStruct(false, "PS", Array::slice([("f", TyName("Int"))], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
   Array::push(body, STypeAlias(false, "PT", Array::slice([""], 0, 0), TyName("Int")))
   Array::push(body, SSuberror(false, "PER", Array::slice([("X", ii)], 0, 1)))
-  Array::push(body, SEnum(true, "PubE", Array::slice([""], 0, 0), Array::slice([("B", no)], 0, 1)))
+  Array::push(body, SEnum(true, "PubE", Array::slice([""], 0, 0), Array::slice([("B", no)], 0, 1), Array::slice([""], 0, 0)))
   let box = Array::slice([""], 0, 0)
   Array::length(collect_private_type_renames("M", body, box, exported))
 }
 let g_rows4: (String, String) -> (String, String, String, String) = (a, b) -> { (a, b, "", "") }
 
-export let cov_grind_main: () -> Int = () -> {
+export let cov_grind_main: () -> Int with Fs = () -> {
   let mut acc = 0
   // renames: nothing exported (all private pushed)
   acc = acc + g_renames(Array::slice([""], 0, 0))

--- a/scripts/coverage/cov_grind2.vibe
+++ b/scripts/coverage/cov_grind2.vibe
@@ -1,39 +1,78 @@
+import ../../lib/@vibe/parser/parser_expr.vibe {
+  parse_impl
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex_with_offsets
+}
+
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  namespace_private_value_stmts
+}
+
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  parse_call_arg
+}
+
+import ../../lib/@vibe/parser/parser_expr_primary.vibe {
+  parse_generic_fn_primary,
+  parse_perform_primary
+}
 
 // #cov grind2 driver: namespace_private_value_stmts over a body exercising the
 // Stmt kinds its first driver missed — STest / SBench / SLetPat / SExpr /
 // SExternLet — each referencing the private enum/struct (so the ctor/type rewrite
 // walks their bodies). Plus parser primaries parse_perform_primary /
 // parse_generic_fn_primary / parse_call_arg via the parse_impl callback.
-let pe_a: () -> Expr = () -> { ECall(EIdent("A"), Array::slice([EInt(1)], 0, 1)) }
+let pe_a: () -> Expr = () -> { ECall(EIdent("A", 0), Array::slice([EInt(1)], 0, 1), 0) }
 
 let gr2_ns: () -> Int = () -> {
   let body = Array::slice([SExpr(EUnit)], 0, 0)
   let no = Array::slice([TyName("Int")], 0, 0)
   let ii = Array::slice([TyName("Int")], 0, 1)
-  Array::push(body, SEnum(false, "PE", Array::slice([""], 0, 0), Array::slice([("A", ii), ("N", no)], 0, 2)))
-  Array::push(body, SStruct(false, "PS", Array::slice([("f", TyName("Int"))], 0, 1)))
+  Array::push(body, SEnum(false, "PE", Array::slice([""], 0, 0), Array::slice([("A", ii), ("N", no)], 0, 2), Array::slice([""], 0, 0)))
+  Array::push(body, SStruct(false, "PS", Array::slice([("f", TyName("Int"))], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
   // refs to the private ctor/type across many Stmt kinds:
   Array::push(body, SExpr(pe_a()))
-  let arms = Array::slice([(PCtor("A", Array::slice([PBind("x")], 0, 1)), EIdent("x"))], 0, 1)
+  let arms = Array::slice([(PCtor("A", Array::slice([PBind("x")], 0, 1)), EIdent("x", 0))], 0, 1)
   Array::push(arms, (PCtor("N", Array::slice([PWild], 0, 0)), EInt(0)))
   Array::push(body, STest("t", EMatch(pe_a(), arms)))
   Array::push(body, SBench("b", pe_a()))
   Array::push(body, SLetPat(PCtor("A", Array::slice([PBind("y")], 0, 1)), pe_a()))
-  Array::push(body, SLetMut("mv", Some(TyName("PS")), ERecord(Array::slice([("f", EInt(2))], 0, 1))))
+  Array::push(body, SLetMut("mv", Some(TyName("PS")), ERecord("", Array::slice([("f", EInt(2))], 0, 1), Array::slice([TyName("Int")], 0, 0))))
   Array::push(body, SExternLet("ext", TyName("PS")))
   Array::push(body, SLet(true, false, "use_it", Some(TyName("PE")), pe_a()))
   Array::push(body, SExport(Array::slice(["use_it"], 0, 1)))
   Array::length(namespace_private_value_stmts("M", body)) + Array::length(namespace_private_value_stmts("X", namespace_private_value_stmts("M", body)))
 }
+// These primaries take the token START offsets (#1567 located diagnostics) and a
+// `parse_recur` callback shaped (tokens, pos, mode); parse_impl closes over the
+// offsets, exactly as parser_expr.vibe's own recur does.
+let gr2_prim: (Int, String) -> Int = (which, s) -> {
+  handle {
+    let (t, st, _) = lex_with_offsets(s)
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (tt, p, m) -> {
+      parse_impl(tt, st, p, m)
+    }
+    let r = if which == 0 {
+      parse_perform_primary(t, st, 1, recur)
+    } else if which == 1 {
+      parse_generic_fn_primary(t, st, 1, recur)
+    } else {
+      parse_call_arg(t, st, 0, recur)
+    }
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
+}
 let gr2_perform: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + (handle { let r = parse_perform_primary(lex("perform St::get()"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_perform_primary(lex("perform Eff::put(1, 2)"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a, b](x: a, y: b) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a](x: a) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("lbl: 5"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("...rest"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("plain"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + gr2_prim(0, "perform St::get()")
+  acc = acc + gr2_prim(0, "perform Eff::put(1, 2)")
+  acc = acc + gr2_prim(1, "fn[a, b](x: a, y: b) -> a { x }")
+  acc = acc + gr2_prim(1, "fn[a](x: a) -> a { x }")
+  acc = acc + gr2_prim(2, "lbl: 5")
+  acc = acc + gr2_prim(2, "...rest")
+  acc = acc + gr2_prim(2, "plain")
   acc
 }
 

--- a/scripts/coverage/cov_helpers.vibe
+++ b/scripts/coverage/cov_helpers.vibe
@@ -1,10 +1,38 @@
+import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe {
+  entry_declares_async_int
+}
+
+import ../../lib/@vibe/compiler/runtime/eval_loader/eval_loader.vibe {
+  load_and_parse
+}
+
+import ../../lib/@vibe/parser/float_format.vibe {
+  double_to_string_compiler
+}
+
+import ../../lib/@vibe/compiler/checker/builtins_system.vibe {
+  lookup_io_a
+}
+
+import ../../lib/@vibe/compiler/loader/loader.vibe {
+  strip_trailing_cr
+}
+
+import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe {
+  comp_valtype_f32,
+  comp_valtype_f64,
+  comp_valtype_s32,
+  comp_valtype_s64,
+  comp_valtype_to_core
+}
+
 
 // #cov helpers driver: small pure helpers whose every-arm coverage the corpus
 // never completes because real programs only feed them one or two shapes.
 // Drive each directly across its full input partition:
 //   - comp_valtype_to_core: every valtype constant + an unknown (5 arms)
 //   - strip_trailing_cr: CR-terminated / plain / empty
-//   - parse_int_unwrap: positive / negative / empty / non-digit / trailing-junk
+//   - parse_int_or: positive / negative / empty / non-digit / trailing-junk
 let cov_h_valtype: () -> Int = () -> {
   let mut acc = 0
   acc = acc + comp_valtype_to_core(comp_valtype_s64)
@@ -23,19 +51,21 @@ let cov_h_cr: () -> Int = () -> {
 }
 let cov_h_int: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + parse_int_unwrap("123", 7)
-  acc = acc + parse_int_unwrap("-45", 7)
-  acc = acc + parse_int_unwrap("", 7)
-  acc = acc + parse_int_unwrap("12x", 7)
-  acc = acc + parse_int_unwrap("x9", 7)
-  acc = acc + parse_int_unwrap("0", 7)
+  acc = acc + parse_int_or("123", 7)
+  acc = acc + parse_int_or("-45", 7)
+  acc = acc + parse_int_or("", 7)
+  acc = acc + parse_int_or("12x", 7)
+  acc = acc + parse_int_or("x9", 7)
+  acc = acc + parse_int_or("0", 7)
   acc
 }
 
-// lookup_io_a / lookup_io_c are unique sibling dispatch chains to lookup_io_b
-// (covered separately) whose Some-arms the corpus never exercises. Hit each name.
+// lookup_io_a is the sibling dispatch chain to lookup_io_b (covered by cov_lookup)
+// whose Some-arms the corpus never exercises. Hit each name.
+// The third chain this driver used to call (`lookup_io_c`) no longer exists: its
+// names (Lines::*/Llm::*/Rlm::*) moved into lookup_io_b, where cov_lookup drives
+// them.
 let cov_h_io_a: (String) -> Int = (n) -> { match lookup_io_a(n) { Some(_) => 1, None => 0 } }
-let cov_h_io_c: (String) -> Int = (n) -> { match lookup_io_c(n) { Some(_) => 1, None => 0 } }
 let cov_h_io: () -> Int = () -> {
   let mut acc = 0
   let a = Array::slice([""], 0, 0)
@@ -45,12 +75,6 @@ let cov_h_io: () -> Int = () -> {
   Array::push(a, "Stdin::read_stream"); Array::push(a, "IO::nope")
   let mut i = 0
   while i < Array::length(a) { acc = acc + cov_h_io_a(Array::get(a, i)); i = i + 1 }
-  let c = Array::slice([""], 0, 0)
-  Array::push(c, "Lines::parse"); Array::push(c, "Lines::stringify")
-  Array::push(c, "Llm::complete"); Array::push(c, "Rlm::run")
-  Array::push(c, "Rlm::finalize"); Array::push(c, "IO::nope")
-  let mut j = 0
-  while j < Array::length(c) { acc = acc + cov_h_io_c(Array::get(c, j)); j = j + 1 }
   acc
 }
 
@@ -69,7 +93,7 @@ let cov_h_dbl: () -> Int = () -> {
 
 // entry_declares_async_int over a parsed entry that returns an async Int vs one
 // that does not — drives both the found-and-async and the not-found arms.
-let cov_h_async_int: () -> Int = () -> {
+let cov_h_async_int: () -> Int with Exception = () -> {
   let mut acc = 0
   let p1 = load_and_parse("export let main: () -> Int = () -> { 1 }")
   acc = acc + (if entry_declares_async_int(p1, "main") { 1 } else { 0 })
@@ -77,6 +101,6 @@ let cov_h_async_int: () -> Int = () -> {
   acc
 }
 
-export let cov_helpers_main: () -> Int = () -> {
+export let cov_helpers_main: () -> Int with Exception = () -> {
   cov_h_valtype() + cov_h_cr() + cov_h_int() + cov_h_io() + cov_h_dbl() + cov_h_async_int()
 }

--- a/scripts/coverage/cov_link.vibe
+++ b/scripts/coverage/cov_link.vibe
@@ -1,3 +1,15 @@
+import ../../lib/@vibe/compiler/codegen/common_base/common_base.vibe {
+  codegen_body_cache_new,
+  empty_dbg_prov
+}
+
+import ../../lib/@vibe/compiler/codegen/wasi/linked_compile.vibe {
+  compile_wasi_module_linked_impl
+}
+
+import ../../lib/@vibe/compiler/runtime/eval_loader/eval_loader.vibe {
+  load_and_parse
+}
 
 // #cov linked/library driver: the linked_imports>0 and library_mode=true arms of
 // compile_wasi_module_linked_impl are reached in the shipped compiler only through
@@ -17,9 +29,13 @@ let cov_link_linked: () -> Array[(String, String, Int, Int)] = () -> {
 
 let cov_link_compile_one: (String, String, Bool, Bool, Bool) -> Int with Exception = (src, entry, library_mode, enable_rc, coverage) -> {
   let stmts = load_and_parse(src)
+  // Trailing slots added since this driver was written: debug_trace / debug_break /
+  // rc_shadow, the debug provenance, the in/out codegen body caches and the
+  // body slice bounds -- passed exactly as the compiler's own callers do.
   let bytes = compile_wasi_module_linked_impl(
     stmts, entry, cov_link_empty_pairs(), cov_link_linked(),
-    library_mode, enable_rc, coverage
+    library_mode, enable_rc, coverage, false, false, false,
+    empty_dbg_prov(), codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1
   )
   Bytes::length(bytes)
 }

--- a/scripts/coverage/cov_lookup.vibe
+++ b/scripts/coverage/cov_lookup.vibe
@@ -1,8 +1,15 @@
+import ../../lib/@vibe/compiler/checker/builtins_array.vibe {
+  lookup_array
+}
 
-// #cov lookup driver: lookup_array_group_b / lookup_io_b are linear name->Type
-// builtin dispatch chains; the corpus only uses a few of the builtins, leaving
+import ../../lib/@vibe/compiler/checker/builtins_system.vibe {
+  lookup_io_b
+}
+
+// #cov lookup driver: lookup_array / lookup_io_b are name->Type builtin
+// dispatch chains; the corpus only uses a few of the builtins, leaving
 // most Some-arms dark. Call each directly with every dispatched name.
-let cov_lk_arr: (String) -> Int = (n) -> { match lookup_array_group_b(n) { Some(_) => 1, None => 0 } }
+let cov_lk_arr: (String) -> Int = (n) -> { match lookup_array(n) { Some(_) => 1, None => 0 } }
 let cov_lk_io: (String) -> Int = (n) -> { match lookup_io_b(n) { Some(_) => 1, None => 0 } }
 
 export let cov_lookup_main: () -> Int = () -> {

--- a/scripts/coverage/cov_lookup2.vibe
+++ b/scripts/coverage/cov_lookup2.vibe
@@ -1,3 +1,31 @@
+import ../../lib/@vibe/compiler/checker/builtins_bytes.vibe {
+  lookup_bytes
+}
+
+import ../../lib/@vibe/compiler/checker/builtins_fs.vibe {
+  lookup_fs
+}
+
+import ../../lib/@vibe/compiler/checker/builtins_net.vibe {
+  lookup_net,
+  lookup_net_group_c
+}
+
+import ../../lib/@vibe/compiler/checker/builtins_misc.vibe {
+  lookup_misc,
+  lookup_misc_group_a,
+  lookup_misc_group_d,
+  lookup_misc_group_e
+}
+
+import ../../lib/@vibe/compiler/checker/builtins_string1.vibe {
+  lookup_string1
+}
+
+import ../../lib/@vibe/compiler/checker/builtins_string2.vibe {
+  lookup_string2
+}
+
 // #cov lookup-chain driver: call every dark lookup_* builtin dispatcher with the
 // full union of builtin names extracted from all lookup_* bodies, so each Some-arm
 // (and the None-cascade between group fns) is taken. Generated; names split into
@@ -220,14 +248,18 @@ let lk_all_names: () -> Array[String] = () -> {
 export let cov_lookup2_main: () -> Int = () -> {
   let ns = lk_all_names()
   let mut acc = 0
+  // The `*_group_b/c` split this driver was generated against is gone from the
+  // bytes/fs/string/net registries; drive the family heads (which cascade through
+  // whatever per-name arms replaced them) plus the group fns that still exist.
   acc = acc + cov_lk_one(lookup_bytes, ns)
-  acc = acc + cov_lk_one(lookup_bytes_group_c, ns)
-  acc = acc + cov_lk_one(lookup_fs_group_c, ns)
+  acc = acc + cov_lk_one(lookup_fs, ns)
+  acc = acc + cov_lk_one(lookup_net, ns)
+  acc = acc + cov_lk_one(lookup_net_group_c, ns)
+  acc = acc + cov_lk_one(lookup_misc, ns)
   acc = acc + cov_lk_one(lookup_misc_group_a, ns)
   acc = acc + cov_lk_one(lookup_misc_group_d, ns)
   acc = acc + cov_lk_one(lookup_misc_group_e, ns)
-  acc = acc + cov_lk_one(lookup_net_group_a, ns)
-  acc = acc + cov_lk_one(lookup_net_group_c, ns)
-  acc = acc + cov_lk_one(lookup_string_group_c, ns)
+  acc = acc + cov_lk_one(lookup_string1, ns)
+  acc = acc + cov_lk_one(lookup_string2, ns)
   acc
 }

--- a/scripts/coverage/cov_margin.vibe
+++ b/scripts/coverage/cov_margin.vibe
@@ -1,16 +1,55 @@
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  parse_call_arg
+}
+
+import ../../lib/@vibe/parser/parser_expr.vibe {
+  parse_impl
+}
+
+import ../../lib/@vibe/parser/parser_expr_primary.vibe {
+  parse_generic_fn_primary,
+  parse_perform_primary
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex_with_offsets
+}
+
 
 // #cov margin driver: the precise token-position arms of parse_perform_primary
 // (stop-token after 'perform': )/]/}/,/;/EOF vs arg), parse_call_arg (name-> / name~=
 // / name?= / name~ / name? / plain / non-ident), parse_generic_fn_primary (bracket
 // depth + after-params dispatch). Called directly with parse_impl as parse_recur.
+// These primaries take the token START offsets and a (tokens, pos, mode) recur.
 let m_perf: (String) -> Int = (s) -> {
-  handle { let r = parse_perform_primary(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    let (t, st, _) = lex_with_offsets(s)
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (tt, p, m) -> {
+      parse_impl(tt, st, p, m)
+    }
+    let r = parse_perform_primary(t, st, 0, recur)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 let m_arg: (String) -> Int = (s) -> {
-  handle { let r = parse_call_arg(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    let (t, st, _) = lex_with_offsets(s)
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (tt, p, m) -> {
+      parse_impl(tt, st, p, m)
+    }
+    let r = parse_call_arg(t, st, 0, recur)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 let m_gen: (String) -> Int = (s) -> {
-  handle { let r = parse_generic_fn_primary(lex(s), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    let (t, st, _) = lex_with_offsets(s)
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (tt, p, m) -> {
+      parse_impl(tt, st, p, m)
+    }
+    let r = parse_generic_fn_primary(t, st, 0, recur)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 
 let m_performs: () -> Int = () -> {

--- a/scripts/coverage/cov_misc.vibe
+++ b/scripts/coverage/cov_misc.vibe
@@ -1,3 +1,29 @@
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  make_import_alias_rewriter
+}
+
+import ../../lib/@vibe/compiler/checker/checker_pattern.vibe {
+  check_pattern
+}
+
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  has_non_pipe_infix_top
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex
+}
+
+import ../../lib/@vibe/parser/parser_base.vibe {
+  is_expr_end_token
+}
+
+import ../../lib/@vibe/compiler/normalize/normalize.vibe {
+  flatten_module_body,
+  module_value_aliases,
+  stmt_section
+}
+
 
 // #cov misc driver: remaining unique single-value walkers/classifiers —
 // stmt_section (Stmt -> section int, all variants), is_expr_end_token (Token, all
@@ -12,7 +38,7 @@ let m_infix: (String) -> Int = (src) -> {
   } with Exception { Throw(_) => 0 }
 }
 let m_cp: (Pat, Type) -> Int = (pp, ty) -> {
-  handle { match check_pattern(pp, ty, EnvEmpty, Array::slice([TDAlias("T", Array::slice([""], 0, 0), CtInt)], 0, 0)) { _ => 1 } }
+  handle { match check_pattern(pp, ty, EnvEmpty, Array::slice([TDAlias("T", Array::slice([""], 0, 0), CtInt)], 0, 0), Array::slice([""], 0, 0)) { _ => 1 } }
   with Exception { Throw(_) => 0 }
 }
 
@@ -23,9 +49,9 @@ export let cov_misc_main: () -> Int = () -> {
   let ss = Array::slice([SExpr(EUnit)], 0, 0)
   Array::push(ss, SImport("m", Array::slice([("x", None)], 0, 1)))
   Array::push(ss, SAliasDecl("a", "b"))
-  Array::push(ss, SEnum(false, "E", Array::slice([""], 0, 0), Array::slice([("A", Array::slice([CtInt], 0, 0))], 0, 1)))
-  Array::push(ss, SSuberror(false, "Er", Array::slice([("B", Array::slice([CtInt], 0, 0))], 0, 1)))
-  Array::push(ss, SStruct(false, "S", Array::slice([("f", intty)], 0, 1)))
+  Array::push(ss, SEnum(false, "E", Array::slice([""], 0, 0), Array::slice([("A", Array::slice([TyName("Int")], 0, 0))], 0, 1), Array::slice([""], 0, 0)))
+  Array::push(ss, SSuberror(false, "Er", Array::slice([("B", Array::slice([TyName("Int")], 0, 0))], 0, 1)))
+  Array::push(ss, SStruct(false, "S", Array::slice([("f", intty)], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
   Array::push(ss, STypeAlias(false, "T", Array::slice([""], 0, 0), intty))
   Array::push(ss, STrait(false, "Tr", Array::slice([""], 0, 0), ArrayBuilder::freeze(ArrayBuilder::new()), ArrayBuilder::freeze(ArrayBuilder::new()), Array::slice([""], 0, 0)))
   Array::push(ss, SExternLet("h", intty))
@@ -66,6 +92,6 @@ export let cov_misc_main: () -> Int = () -> {
   let al = Array::slice([("k", "M_k")], 0, 1)
   acc = acc + module_value_aliases(body, "M", al)
   let out = Array::slice([SExpr(EUnit)], 0, 0)
-  acc = acc + flatten_module_body(body, "M", al, out)
+  acc = acc + flatten_module_body(body, "M", make_import_alias_rewriter(al), out)
   acc
 }

--- a/scripts/coverage/cov_namespace.vibe
+++ b/scripts/coverage/cov_namespace.vibe
@@ -1,3 +1,6 @@
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  namespace_private_value_stmts
+}
 
 // #cov namespace driver: namespace_private_value_stmts renames a module's PRIVATE
 // (non-exported) type/enum/struct/suberror/alias decls and rewrites references to
@@ -11,22 +14,22 @@ export let cov_namespace_main: () -> Int = () -> {
   let body = Array::slice([SExpr(EUnit)], 0, 0)
   // private enum + exported enum
   Array::push(body, SEnum(false, "PrivE", Array::slice([""], 0, 0),
-    Array::slice([("PA", ns_empty()), ("PB", ns_int())], 0, 2)))
+    Array::slice([("PA", ns_empty()), ("PB", ns_int())], 0, 2), Array::slice([""], 0, 0)))
   Array::push(body, SEnum(true, "PubE", Array::slice([""], 0, 0),
-    Array::slice([("EA", ns_empty())], 0, 1)))
+    Array::slice([("EA", ns_empty())], 0, 1), Array::slice([""], 0, 0)))
   // private struct + exported struct
-  Array::push(body, SStruct(false, "PrivS", Array::slice([("f", TyName("Int"))], 0, 1)))
-  Array::push(body, SStruct(true, "PubS", Array::slice([("g", TyName("Int"))], 0, 1)))
+  Array::push(body, SStruct(false, "PrivS", Array::slice([("f", TyName("Int"))], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
+  Array::push(body, SStruct(true, "PubS", Array::slice([("g", TyName("Int"))], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
   // private suberror + private type alias
   Array::push(body, SSuberror(false, "PrivErr", Array::slice([("PErr", ns_int())], 0, 1)))
   Array::push(body, STypeAlias(false, "PrivAlias", Array::slice([""], 0, 0), TyName("PrivS")))
   Array::push(body, STypeAlias(true, "PubAlias", Array::slice([""], 0, 0), TyName("Int")))
   // values referencing private ctors / types (drive ctor/type rewrite in bodies)
   Array::push(body, SLet(false, false, "v1", Some(TyName("PrivE")),
-    ECall(EIdent("PB"), Array::slice([EInt(1)], 0, 1))))
+    ECall(EIdent("PB", 0), Array::slice([EInt(1)], 0, 1), 0)))
   Array::push(body, SLet(true, false, "exp1", None,
-    EMatch(EIdent("v1"), Array::slice([(PCtor("PA", Array::slice([PWild], 0, 0)), EInt(0)), (PCtor("PB", Array::slice([PBind("n")], 0, 1)), EIdent("n"))], 0, 2))))
-  Array::push(body, SLetMut("v2", Some(TyName("PrivS")), ERecord(Array::slice([("f", EInt(2))], 0, 1))))
+    EMatch(EIdent("v1", 0), Array::slice([(PCtor("PA", Array::slice([PWild], 0, 0)), EInt(0)), (PCtor("PB", Array::slice([PBind("n")], 0, 1)), EIdent("n", 0))], 0, 2))))
+  Array::push(body, SLetMut("v2", Some(TyName("PrivS")), ERecord("", Array::slice([("f", EInt(2))], 0, 1), Array::slice([TyName("Int")], 0, 0))))
   Array::push(body, SExport(Array::slice(["exp1", "PubE"], 0, 2)))
   let renamed = namespace_private_value_stmts("Mod", body)
   let renamed2 = namespace_private_value_stmts("Other", renamed)

--- a/scripts/coverage/cov_namespace3.vibe
+++ b/scripts/coverage/cov_namespace3.vibe
@@ -1,3 +1,6 @@
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  namespace_private_value_stmts
+}
 
 // #cov namespace #3: the Stmt kinds namespace_private_value_stmts handles that the
 // earlier drivers missed — SModule (recurses into nested body), SImpl, SEffectDef,
@@ -11,8 +14,8 @@ let ns3_effops: () -> Array[(String, Array[TypeExpr], TypeExpr)] = () -> {
 
 let ns3_inner_body: () -> Array[Stmt] = () -> {
   let b = Array::slice([SExpr(EUnit)], 0, 0)
-  Array::push(b, SEnum(false, "IE", Array::slice([""], 0, 0), Array::slice([("IA", ns3_no())], 0, 1)))
-  Array::push(b, SLet(false, false, "iv", Some(TyName("IE")), ECall(EIdent("IA"), Array::slice([EUnit], 0, 0))))
+  Array::push(b, SEnum(false, "IE", Array::slice([""], 0, 0), Array::slice([("IA", ns3_no())], 0, 1), Array::slice([""], 0, 0)))
+  Array::push(b, SLet(false, false, "iv", Some(TyName("IE")), ECall(EIdent("IA", 0), Array::slice([EUnit], 0, 0), 0)))
   Array::push(b, SExport(Array::slice(["iv"], 0, 1)))
   b
 }
@@ -21,8 +24,8 @@ export let cov_namespace3_main: () -> Int = () -> {
   let body = Array::slice([SExpr(EUnit)], 0, 0)
   // private trait + struct + enum the impl/refs use
   Array::push(body, STrait(false, "PT", Array::slice(["m"], 0, 1), ArrayBuilder::freeze(ArrayBuilder::new()), ArrayBuilder::freeze(ArrayBuilder::new()), Array::slice([""], 0, 0)))
-  Array::push(body, SStruct(false, "PW", Array::slice([("v", TyName("Int"))], 0, 1)))
-  Array::push(body, SEnum(false, "PE", Array::slice([""], 0, 0), Array::slice([("A", ns3_int())], 0, 1)))
+  Array::push(body, SStruct(false, "PW", Array::slice([("v", TyName("Int"))], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
+  Array::push(body, SEnum(false, "PE", Array::slice([""], 0, 0), Array::slice([("A", ns3_int())], 0, 1), Array::slice([""], 0, 0)))
   // SImpl over private trait+type
   Array::push(body, SImpl(Array::slice([""], 0, 0), ns3_nobound(), "PT", "PW"))
   // SEffectDef (private)
@@ -34,7 +37,7 @@ export let cov_namespace3_main: () -> Int = () -> {
   Array::push(body, SReExport("./m.vibe", Array::slice([("x", Some("y"))], 0, 1)))
   Array::push(body, SAliasDecl("PE", "PEalias"))
   // a value using the private enum ctor
-  Array::push(body, SLet(true, false, "use_pe", Some(TyName("PE")), ECall(EIdent("A"), ns3_int_e())))
+  Array::push(body, SLet(true, false, "use_pe", Some(TyName("PE")), ECall(EIdent("A", 0), ns3_int_e(), 0)))
   Array::push(body, SExport(Array::slice(["use_pe"], 0, 1)))
   let r1 = namespace_private_value_stmts("Mod", body)
   let r2 = namespace_private_value_stmts("Other", r1)

--- a/scripts/coverage/cov_parse.vibe
+++ b/scripts/coverage/cov_parse.vibe
@@ -1,3 +1,6 @@
+import ../../lib/@vibe/compiler/runtime/eval_loader/eval_loader.vibe {
+  load_and_parse
+}
 
 // #cov parse driver: parser arms (parse_impl_block / parse_impl_dispatch /
 // parse_type_impl / parse_postfix / parse_pattern / parse_stmt /

--- a/scripts/coverage/cov_parser2.vibe
+++ b/scripts/coverage/cov_parser2.vibe
@@ -1,3 +1,6 @@
+import ../../lib/@vibe/compiler/runtime/eval_loader/eval_loader.vibe {
+  load_and_parse
+}
 
 // #cov parser-breadth driver: feed ~50 exotic-but-valid and deliberately-malformed
 // snippets through load_and_parse. Malformed input takes the `expect_tk ... else

--- a/scripts/coverage/cov_parser3.vibe
+++ b/scripts/coverage/cov_parser3.vibe
@@ -1,17 +1,54 @@
+import ../../lib/@vibe/parser/parser_expr_dispatch.vibe {
+  parse_impl_block
+}
+
+import ../../lib/@vibe/parser/parser_expr.vibe {
+  parse_impl
+}
+
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  parse_postfix
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex_with_offsets
+}
+
 
 // #cov parser-internals driver: parse_impl matches the parse_recur callback
 // signature, so the mutually-recursive parser primitives can be called directly.
 // Drive parse_postfix's expr-type stop-cases (a while/loop/for/handle/match/if expr
 // immediately followed by '(' is NOT a call) — shapes normal parsing never yields —
 // plus parse_impl across its mode dispatch and parse_impl_block on block bodies.
+// parse_postfix / parse_impl_block take the token START offsets (#1567 located
+// diagnostics) and a `parse_recur` callback shaped (tokens, pos, mode); parse_impl
+// closes over the offsets, exactly as parser_expr.vibe's own recur does.
 let pp: (Expr) -> Int = (e) -> {
-  handle { let r = parse_postfix(lex("(a)"), 0, e, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    let (t, st, _) = lex_with_offsets("(a)")
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (tt, p, m) -> {
+      parse_impl(tt, st, p, m)
+    }
+    let r = parse_postfix(t, st, 0, e, recur)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 let pm: (Int) -> Int = (mode) -> {
-  handle { let r = parse_impl(lex("a + b"), 0, mode); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    let (t, st, _) = lex_with_offsets("a + b")
+    let r = parse_impl(t, st, 0, mode)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 let pblk: (String) -> Int = (src) -> {
-  handle { let r = parse_impl_block(lex(src), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    let (t, st, _) = lex_with_offsets(src)
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (tt, p, m) -> {
+      parse_impl(tt, st, p, m)
+    }
+    let r = parse_impl_block(t, st, 0, recur)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 
 let pp_stopcases: () -> Int = () -> {
@@ -25,7 +62,7 @@ let pp_stopcases: () -> Int = () -> {
   acc = acc + pp(EInt(1))
   acc = acc + pp(EArray(Array::slice([EInt(1)], 0, 1)))
   acc = acc + pp(ETuple(Array::slice([EInt(1)], 0, 1)))
-  acc = acc + pp(ERecord(Array::slice([("f", EInt(1))], 0, 1)))
+  acc = acc + pp(ERecord("", Array::slice([("f", EInt(1))], 0, 1), Array::slice([TyName("Int")], 0, 0)))
   acc = acc + pp(EString("s"))
   acc = acc + pp(EStringInterp(Array::slice(["a"], 0, 1)))
   acc = acc + pp(EBool(true))

--- a/scripts/coverage/cov_parser4.vibe
+++ b/scripts/coverage/cov_parser4.vibe
@@ -1,3 +1,39 @@
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  parse_call_arg
+}
+
+import ../../lib/@vibe/parser/parser_expr_primary.vibe {
+  parse_generic_fn_primary,
+  parse_perform_primary
+}
+
+import ../../lib/@vibe/parser/parser_expr.vibe {
+  parse_impl
+}
+
+import ../../lib/@vibe/parser/parser_expr_dispatch.vibe {
+  parse_impl_dispatch
+}
+
+import ../../lib/@vibe/parser/parser.vibe {
+  parse_export_name,
+  parse_export_stmt,
+  parse_stmt
+}
+
+import ../../lib/@vibe/parser/parser_base.vibe {
+  parse_enum_stmt,
+  parse_impl_type_params,
+  parse_one_param,
+  parse_pattern,
+  parse_type_impl
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex,
+  lex_with_offsets
+}
+
 
 // #cov parser-internals driver #2: call the remaining parser primitives directly
 // with lexed token sequences (and parse_impl as the parse_recur callback) to reach
@@ -8,11 +44,41 @@ let p4_pat: (String) -> Int = (s) -> {
 let p4_ty: (String, Int) -> Int = (s, m) -> {
   handle { let r = parse_type_impl(lex(s), 0, m); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
+// These primaries take the token START offsets and a (tokens, pos, mode) recur.
+let p4_prim: (Int, String) -> Int = (which, s) -> {
+  handle {
+    let (t, st, _) = lex_with_offsets(s)
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (tt, p, m) -> {
+      parse_impl(tt, st, p, m)
+    }
+    let r = if which == 0 {
+      parse_perform_primary(t, st, 1, recur)
+    } else if which == 1 {
+      parse_generic_fn_primary(t, st, 1, recur)
+    } else {
+      parse_call_arg(t, st, 0, recur)
+    }
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
+}
 let p4_stmt: (String) -> Int = (s) -> {
-  handle { let r = parse_stmt(lex(s), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    // parse_stmt takes the token START offsets (#1567 located diagnostics)
+    let (t, st, _) = lex_with_offsets(s)
+    let r = parse_stmt(t, st, 0)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 let p4_disp: (String, Int) -> Int = (s, m) -> {
-  handle { let r = parse_impl_dispatch(lex(s), 0, m, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    // (tokens, starts, pos, mode, parse_recur) -- parse_impl closes over the offsets
+    let (t, st, _) = lex_with_offsets(s)
+    let rec recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (tt, p, mm) -> {
+      parse_impl(tt, st, p, mm)
+    }
+    let r = parse_impl_dispatch(t, st, 0, m, recur)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 
 let p4_patterns: () -> Int = () -> {
@@ -44,10 +110,10 @@ let p4_stmts: () -> Int = () -> {
 }
 let p4_primaries: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + (handle { let r = parse_perform_primary(lex("perform St::get()"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_generic_fn_primary(lex("fn[a](x: a) -> a { x }"), 1, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("label: 1"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_call_arg(lex("42"), 0, parse_impl); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + p4_prim(0, "perform St::get()")
+  acc = acc + p4_prim(1, "fn[a](x: a) -> a { x }")
+  acc = acc + p4_prim(2, "label: 1")
+  acc = acc + p4_prim(2, "42")
   let mut m = 20
   while m < 28 { acc = acc + p4_disp("if a { 1 } else { 2 }", m); m = m + 1 }
   acc
@@ -56,7 +122,12 @@ let p4_decls: () -> Int = () -> {
   let mut acc = 0
   acc = acc + (handle { let r = parse_enum_stmt(lex("E { A; B(Int); C(Int, Bool) }"), 0, false); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
   acc = acc + (handle { let r = parse_enum_stmt(lex("E { A }"), 0, true); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
-  acc = acc + (handle { let r = parse_export_stmt(lex("export { a, b as c }"), 1); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
+  acc = acc + (handle {
+    // parse_export_stmt takes the token START offsets (#1567 located diagnostics)
+    let (t, st, _) = lex_with_offsets("export { a, b as c }")
+    let r = parse_export_stmt(t, st, 1)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 })
   acc = acc + (handle { let r = parse_one_param(lex("x: Int"), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
   acc = acc + (handle { let r = parse_one_param(lex("y"), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })
   acc = acc + (handle { let r = parse_impl_type_params(lex("[a, b]"), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 })

--- a/scripts/coverage/cov_parser5.vibe
+++ b/scripts/coverage/cov_parser5.vibe
@@ -1,3 +1,18 @@
+import ../../lib/@vibe/parser/parser.vibe {
+  parse_export_stmt
+}
+
+import ../../lib/@vibe/parser/parser_base.vibe {
+  parse_one_param,
+  parse_pattern,
+  parse_type_impl
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex,
+  lex_with_offsets
+}
+
 
 // #cov parser-internals #3: parse_type_impl across modes x type forms, parse_pattern
 // exotic forms, parse_export_stmt export forms, parse_one_param labeled/optional/
@@ -8,8 +23,14 @@ let p5_ty: (String, Int) -> Int = (s, m) -> {
 let p5_pat: (String) -> Int = (s) -> {
   handle { let r = parse_pattern(lex(s), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
 }
+// parse_export_stmt takes the token START offsets (#1567 located diagnostics);
+// the other three still take (tokens, pos, ..).
 let p5_exp: (String) -> Int = (s) -> {
-  handle { let r = parse_export_stmt(lex(s), 1); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }
+  handle {
+    let (t, st, _) = lex_with_offsets(s)
+    let r = parse_export_stmt(t, st, 1)
+    match r.0 { _ => 1 }
+  } with Exception { Throw(_) => 0 }
 }
 let p5_param: (String) -> Int = (s) -> {
   handle { let r = parse_one_param(lex(s), 0); match r.0 { _ => 1 } } with Exception { Throw(_) => 0 }

--- a/scripts/coverage/cov_push85.vibe
+++ b/scripts/coverage/cov_push85.vibe
@@ -1,3 +1,23 @@
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  namespace_private_value_stmts
+}
+
+import ../../lib/@vibe/compiler/loader/manifest_sources.vibe {
+  scan_header_import_dep
+}
+
+import ../../lib/@vibe/parser/parser_base.vibe {
+  collect_import_path
+}
+
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  has_non_pipe_infix_top
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex
+}
+
 
 // #cov push85 driver: remaining token / import-header / namespace arms.
 //  - has_non_pipe_infix_top: depth tracking (parens/brackets/braces) + top-level
@@ -11,7 +31,7 @@ let h_cip: (String) -> Int = (s) -> {
   handle { let r = collect_import_path(lex(s), 0, "base"); String::length(r.0) } with Exception { Throw(_) => 0 }
 }
 let h_empty_map: () -> Map[String, Bool] = () -> { MapBuilder::freeze(MapBuilder::new()) }
-let h_shd: (String, Int) -> Int = (s, p) -> {
+let h_shd: (String, Int) -> Int with Exception + Fs = (s, p) -> {
   handle { let r = scan_header_import_dep(lex(s), p, "base", h_empty_map()); String::length(r.0) } with Exception { Throw(_) => 0 }
 }
 
@@ -24,7 +44,7 @@ let push_infix: () -> Int = () -> {
   acc = acc + h_inf("a == b && c < d") + h_inf("[a, b][0] + 1")
   acc
 }
-let push_import: () -> Int = () -> {
+let push_import: () -> Int with Exception + Fs = () -> {
   let mut acc = 0
   acc = acc + h_cip("./a/b.vibe") + h_cip("../m.vibe") + h_cip("./x.vibe")
   acc = acc + h_cip("a/b/c.vibe") + h_cip("@scope/pkg")
@@ -35,14 +55,14 @@ let push_import: () -> Int = () -> {
 let push_ns: () -> Int = () -> {
   let body = Array::slice([SExpr(EUnit)], 0, 0)
   Array::push(body, STrait(false, "PrivTr", Array::slice(["f"], 0, 1), ArrayBuilder::freeze(ArrayBuilder::new()), ArrayBuilder::freeze(ArrayBuilder::new()), Array::slice([""], 0, 0)))
-  Array::push(body, SStruct(false, "PrivW", Array::slice([("v", TyName("Int"))], 0, 1)))
+  Array::push(body, SStruct(false, "PrivW", Array::slice([("v", TyName("Int"))], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
   Array::push(body, SImpl(Array::slice([""], 0, 0), Array::slice([("", Array::slice([""], 0, 0))], 0, 0), "PrivTr", "PrivW"))
-  Array::push(body, SLet(false, false, "mk", None, ERecord(Array::slice([("v", EInt(1))], 0, 1))))
-  Array::push(body, SLet(true, false, "use_priv", Some(TyName("PrivW")), EIdent("mk")))
+  Array::push(body, SLet(false, false, "mk", None, ERecord("", Array::slice([("v", EInt(1))], 0, 1), Array::slice([TyName("Int")], 0, 0))))
+  Array::push(body, SLet(true, false, "use_priv", Some(TyName("PrivW")), EIdent("mk", 0)))
   Array::push(body, SExport(Array::slice(["use_priv"], 0, 1)))
   Array::length(namespace_private_value_stmts("NS", body))
 }
 
-export let cov_push85_main: () -> Int = () -> {
+export let cov_push85_main: () -> Int with Exception + Fs = () -> {
   push_infix() + push_import() + push_ns()
 }

--- a/scripts/coverage/cov_remainder.vibe
+++ b/scripts/coverage/cov_remainder.vibe
@@ -1,3 +1,33 @@
+import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe {
+  entry_declares_async_int
+}
+
+import ../../lib/@vibe/compiler/normalize/desugar_trait_dict.vibe {
+  build_pull_for_in
+}
+
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  has_non_pipe_infix_top
+}
+
+import ../../lib/@vibe/parser/parser_base.vibe {
+  collect_import_path
+}
+
+import ../../lib/@vibe/compiler/loader/manifest_sources.vibe {
+  skip_brace_list
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex
+}
+
+import ../../lib/@vibe/compiler/normalize/normalize.vibe {
+  annotate_literal_let,
+  exported_value_names,
+  literal_type
+}
+
 
 // #cov remainder driver: the remaining small tractable helpers — literal_type
 // (Expr literal arms), annotate_literal_let, build_pull_for_in (index Some/None),
@@ -19,15 +49,15 @@ export let cov_remainder_main: () -> Int = () -> {
   let mut acc = 0
   // literal_type: each literal arm + default
   acc = acc + r_lit(EInt(1)) + r_lit(EBool(true)) + r_lit(EString("s"))
-  acc = acc + r_lit(EFloat(1.0)) + r_lit(EIdent("x")) + r_lit(EUnit)
+  acc = acc + r_lit(EFloat(1.0)) + r_lit(EIdent("x", 0)) + r_lit(EUnit)
   // annotate_literal_let: SLet with no type + literal body (annotated), with type (kept), non-literal
   acc = acc + (match annotate_literal_let(SLet(false, false, "a", None, EInt(1))) { _ => 1 })
   acc = acc + (match annotate_literal_let(SLet(false, false, "a", Some(TyName("Int")), EInt(1))) { _ => 1 })
-  acc = acc + (match annotate_literal_let(SLet(false, false, "a", None, EIdent("x"))) { _ => 1 })
+  acc = acc + (match annotate_literal_let(SLet(false, false, "a", None, EIdent("x", 0))) { _ => 1 })
   acc = acc + (match annotate_literal_let(SExpr(EUnit)) { _ => 1 })
   // build_pull_for_in: index Some vs None
-  acc = acc + (match build_pull_for_in("v", Some("i"), EIdent("xs"), EIdent("v"), 0) { _ => 1 })
-  acc = acc + (match build_pull_for_in("v", None, EIdent("xs"), EIdent("v"), 1) { _ => 1 })
+  acc = acc + (match build_pull_for_in("v", Some("i"), EIdent("xs", 0), EIdent("v", 0)) { _ => 1 })
+  acc = acc + (match build_pull_for_in("v", None, EIdent("xs", 0), EIdent("v", 0)) { _ => 1 })
   // skip_brace_list: nested braces / non-brace
   acc = acc + r_skip("{ a b { c d } e }")
   acc = acc + r_skip("a b")

--- a/scripts/coverage/cov_round.vibe
+++ b/scripts/coverage/cov_round.vibe
@@ -1,3 +1,23 @@
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  has_non_pipe_infix_top
+}
+
+import ../../lib/@vibe/parser/printer.vibe {
+  print_stmt
+}
+
+import ../../lib/@vibe/parser/parser.vibe {
+  parse_export_name
+}
+
+import ../../lib/@vibe/parser/parser_base.vibe {
+  parse_enum_stmt
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex
+}
+
 
 // #cov round driver: 4-dark residuals — parse_enum_stmt forms, parse_export_name
 // (plain / aliased), print_stmt remaining Stmt variants (SImpl/SModule/SReExport/

--- a/scripts/coverage/cov_serialize.vibe
+++ b/scripts/coverage/cov_serialize.vibe
@@ -1,8 +1,25 @@
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  collect_private_type_renames
+}
+
+import ../../lib/@vibe/compiler/loader/manifest_sources.vibe {
+  ensure_grouped_source_bucket_seeded
+}
+
+import ../../lib/@vibe/compiler/loader/loader.vibe {
+  push_grouped_source
+}
+
+import ../../lib/@vibe/compiler/runtime/persistent_env_codec.vibe {
+  parse_cached_type,
+  serialize_type
+}
+
 
 // #cov serialize driver: serialize_type (Type -> cache string) and parse_cached_type
 // (cache string -> Type) are an inverse pair; round-tripping every Type variant
 // covers both walkers' arms at once. Plus the grouped-source accumulators
-// (push_grouped_source / ensure_grouped_source_bucket: new-bucket vs existing) and
+// (push_grouped_source / ensure_grouped_source_bucket_seeded: new vs existing) and
 // collect_private_type_renames over a private-decl Stmt body.
 let s_rt: (Type) -> Int = (ty) -> {
   let enc = serialize_type(ty)
@@ -38,14 +55,16 @@ export let cov_serialize_main: () -> Int = () -> {
   push_grouped_source(groups, "g1", "b.vibe", "src_b")    // existing bucket
   push_grouped_source(groups, "g2", "c.vibe", "src_c")    // new bucket
   acc = acc + Array::length(groups)
-  let bucket = ensure_grouped_source_bucket(groups, "g1")  // existing
+  // ensure_grouped_source_bucket is now the *_seeded form: it takes the path and
+  // source to seed a freshly created bucket with.
+  let bucket = ensure_grouped_source_bucket_seeded(groups, "g1", "d.vibe", "src_d")  // existing
   acc = acc + Array::length(bucket)
-  let bucket2 = ensure_grouped_source_bucket(groups, "g3") // new
+  let bucket2 = ensure_grouped_source_bucket_seeded(groups, "g3", "e.vibe", "src_e") // new
   acc = acc + Array::length(bucket2)
   // collect_private_type_renames over a body with private + exported type decls
   let body = Array::slice([SExpr(EUnit)], 0, 0)
-  Array::push(body, SStruct(false, "Priv", Array::slice([("f", TyName("Int"))], 0, 1)))
-  Array::push(body, SEnum(true, "Pub", Array::slice([""], 0, 0), Array::slice([("A", Array::slice([CtInt], 0, 0))], 0, 1)))
+  Array::push(body, SStruct(false, "Priv", Array::slice([("f", TyName("Int"))], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
+  Array::push(body, SEnum(true, "Pub", Array::slice([""], 0, 0), Array::slice([("A", Array::slice([TyName("Int")], 0, 0))], 0, 1), Array::slice([""], 0, 0)))
   Array::push(body, STypeAlias(false, "PrivAlias", Array::slice([""], 0, 0), TyName("Int")))
   acc = acc + Array::length(collect_private_type_renames("M", body, Array::slice(["Pub"], 0, 1), Array::slice([""], 0, 0)))
   acc

--- a/scripts/coverage/cov_syntax.vibe
+++ b/scripts/coverage/cov_syntax.vibe
@@ -1,3 +1,6 @@
+import ../../lib/@vibe/compiler/runtime/eval_loader/eval_loader.vibe {
+  load_and_parse
+}
 
 // #cov syntax-breadth driver: route the parser through arms the 728-file corpus
 // leaves dark — slice forms, postfix chains on unusual exprs, block-local

--- a/scripts/coverage/cov_transform.vibe
+++ b/scripts/coverage/cov_transform.vibe
@@ -1,10 +1,39 @@
+import ../../lib/@vibe/compiler/runtime/runtime.vibe {
+  add_dep
+}
+
+import ../../lib/@vibe/parser/parser_expr_dispatch.vibe {
+  qualify_handle_arm_pattern
+}
+
+import ../../lib/@vibe/compiler/core/types.vibe {
+  env_lookup,
+  trait_supers
+}
+
+import ../../lib/@vibe/compiler/core/import_alias_rewrite.vibe {
+  namespace_private_value_stmts,
+  rewrite_import_alias_stmt,
+  rewrite_imported_value_stmt_to_local,
+  rewrite_private_type_ctor_pat,
+  rewrite_private_type_expr
+}
+
+import ../../lib/@vibe/compiler/perceus/perceus.vibe {
+  type_contains_fn
+}
+
+import ../../lib/@vibe/compiler/checker/checker_resolve.vibe {
+  resolve_type_expr
+}
+
 
 // #cov transform/IR + type-resolve driver: drive the unique TypeExpr / TypeEnv /
 // Stmt / Pat transform walkers directly across every variant — resolve_type_expr,
 // type_contains_fn, rewrite_private_type_expr (TypeExpr); env_lookup, trait_supers
 // (TypeEnv); rewrite_import_alias_stmt, rewrite_imported_value_stmt_to_local,
 // namespace_private_value_stmts (Stmt); rewrite_private_type_ctor_pat,
-// qualify_handle_arm_pattern (Pat); lookup_assert (builtin names); add_dep.
+// qualify_handle_arm_pattern (Pat); add_dep.
 let t_rte: (TypeExpr) -> Int = (te) -> { match resolve_type_expr(te, cov_tx_typedefs()) { _ => 1 } }
 let t_cfn: (TypeExpr) -> Int = (te) -> { if type_contains_fn(te) { 1 } else { 0 } }
 let t_rpte: (TypeExpr) -> Int = (te) -> { match rewrite_private_type_expr(te, cov_tx_renames()) { _ => 1 } }
@@ -14,10 +43,9 @@ let t_ras: (Stmt) -> Int = (s) -> { match rewrite_import_alias_stmt(s, cov_tx_al
 let t_riv: (Stmt) -> Int = (s) -> { match rewrite_imported_value_stmt_to_local(s, "m", "p") { Some(_) => 1, None => 0 } }
 let t_pat: (Pat) -> Int = (pp) -> { match rewrite_private_type_ctor_pat(pp, cov_tx_renames(), cov_tx_renames()) { _ => 1 } }
 let t_qual: (Pat) -> Int = (pp) -> { match qualify_handle_arm_pattern("Eff", pp) { _ => 1 } }
-let t_asrt: (String) -> Int = (n) -> { match lookup_assert(n) { Some(_) => 1, None => 0 } }
 
 let cov_tx_typedefs: () -> Array[TypeDef] = () -> {
-  let a = Array::slice([TDStruct("S", Array::slice([("f", CtInt)], 0, 1))], 0, 1)
+  let a = Array::slice([TDStruct("S", Array::slice([("f", CtInt)], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0))], 0, 1)
   Array::push(a, TDEnum("E", Array::slice([""], 0, 0), Array::slice([("A", Array::slice([CtInt], 0, 0))], 0, 1)))
   Array::push(a, TDAlias("T", Array::slice([""], 0, 0), CtInt))
   a
@@ -47,19 +75,19 @@ export let cov_transform_main: () -> Int = () -> {
   Array::push(envs, EnvBind("x", CtInt, EnvEmpty))
   Array::push(envs, EnvBind("z", CtInt, EnvBind("x", CtBool, EnvEmpty)))
   Array::push(envs, EnvFlat(Array::slice([("x", CtInt)], 0, 1)))
-  Array::push(envs, EnvTraitDef("Ord", Array::slice(["Eq"], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0)))
-  Array::push(envs, EnvTraitImpl("Ord", CtInt, EnvTraitDef("Ord", Array::slice(["Eq"], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0))))
+  Array::push(envs, EnvTraitDef("Ord", Array::slice(["Eq"], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0), ArrayBuilder::freeze(ArrayBuilder::new())))
+  Array::push(envs, EnvTraitImpl("Ord", CtInt, EnvTraitDef("Ord", Array::slice(["Eq"], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0), ArrayBuilder::freeze(ArrayBuilder::new()))))
   let mut j = 0
   while j < Array::length(envs) { let e = Array::get(envs, j); acc = acc + t_env(e) + t_sup(e); j = j + 1 }
   // Stmt battery
   let intty = TyName("Int")
   let ss = Array::slice([SExpr(EUnit)], 0, 0)
-  Array::push(ss, SLet(false, false, "x", None, EIdent("x")))
-  Array::push(ss, SLet(true, false, "x", Some(intty), EIdent("x")))
-  Array::push(ss, SLetMut("x", None, EIdent("x")))
-  Array::push(ss, SLetPat(PBind("x"), EIdent("x")))
-  Array::push(ss, SExpr(ECall(EIdent("x"), Array::slice([EIdent("x")], 0, 1))))
-  Array::push(ss, STest("t", EIdent("x"))); Array::push(ss, SBench("b", EIdent("x")))
+  Array::push(ss, SLet(false, false, "x", None, EIdent("x", 0)))
+  Array::push(ss, SLet(true, false, "x", Some(intty), EIdent("x", 0)))
+  Array::push(ss, SLetMut("x", None, EIdent("x", 0)))
+  Array::push(ss, SLetPat(PBind("x"), EIdent("x", 0)))
+  Array::push(ss, SExpr(ECall(EIdent("x", 0), Array::slice([EIdent("x", 0)], 0, 1), 0)))
+  Array::push(ss, STest("t", EIdent("x", 0))); Array::push(ss, SBench("b", EIdent("x", 0)))
   Array::push(ss, SImport("m", Array::slice([("x", Some("y"))], 0, 1)))
   Array::push(ss, SExport(Array::slice(["x"], 0, 1)))
   let mut k = 0
@@ -74,11 +102,8 @@ export let cov_transform_main: () -> Int = () -> {
   Array::push(ps, PStruct("S", Array::slice([("f", PBind("x"))], 0, 1)))
   let mut m = 0
   while m < Array::length(ps) { let pp = Array::get(ps, m); acc = acc + t_pat(pp) + t_qual(pp); m = m + 1 }
-  // lookup_assert names
-  let ns = Array::slice([""], 0, 0)
-  Array::push(ns, "assert"); Array::push(ns, "assert_true"); Array::push(ns, "assert_eq"); Array::push(ns, "nope")
-  let mut q = 0
-  while q < Array::length(ns) { acc = acc + t_asrt(Array::get(ns, q)); q = q + 1 }
+  // (the `lookup_assert` dispatcher this driver used to drive is gone: the assert
+  // builtins are now recognized by inline name tests inside checker.vibe)
   // add_dep: new dep / duplicate dep
   let deps = Array::slice([""], 0, 0)
   let d1 = add_dep(deps, "a", "x")

--- a/scripts/coverage/cov_typeeq.vibe
+++ b/scripts/coverage/cov_typeeq.vibe
@@ -1,3 +1,7 @@
+import ../../lib/@vibe/compiler/core/types.vibe {
+  types_equal,
+  unify
+}
 
 // #cov typeeq driver: the loop-mismatch-mid-iteration branches of types_equal's
 // CtNamed / CtTuple / CtFn / CtForAll arms — reached only when a multi-element type

--- a/scripts/coverage/cov_units2.vibe
+++ b/scripts/coverage/cov_units2.vibe
@@ -1,10 +1,31 @@
+import ../../lib/@vibe/cache/cache.vibe {
+  compact_string_fingerprint
+}
+
+import ../../lib/@vibe/parser/parser_expr_core.vibe {
+  has_non_pipe_infix_top
+}
+
+import ../../lib/@vibe/parser/lexer.vibe {
+  lex
+}
+
+import ../../lib/@vibe/compiler/runtime/eval_loader/eval_loader.vibe {
+  load_and_parse
+}
+
+import ../../lib/@vibe/compiler/loader/loader.vibe {
+  collect_import_deps_from_stmts,
+  matches_cached_file_spec
+}
+
 
 // #cov unit driver 2 (Fs): cover the Fs-touching validators and parse-time
 // helpers that need crafted inputs — matches_cached_file_spec (every
 // exists/stat-token/fingerprint arm), collect_import_deps_from_stmts,
 // parse_struct_fields_rest, has_non_pipe_infix_top. Requires _build/covproj/a.vibe
 // to exist (the harness recreates it before running).
-let cov_u2_spec: (String, String, String) -> Int = (path, stat, fp) -> {
+let cov_u2_spec: (String, String, String) -> Int with Exception + Fs = (path, stat, fp) -> {
   handle { if matches_cached_file_spec(path, stat, fp) { 1 } else { 0 } } with Exception { Throw(_) => 0 }
 }
 let cov_u2_parse: (String) -> Array[Stmt] = (src) -> {

--- a/scripts/coverage/cov_walk3.vibe
+++ b/scripts/coverage/cov_walk3.vibe
@@ -1,3 +1,10 @@
+import ../../lib/@vibe/compiler/perceus/perceus.vibe {
+  expr_projects_or_matches
+}
+
+import ../../lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe {
+  is_mut_captured_in
+}
 
 // #cov walk3 driver: the residual recursion arms of expr_projects_or_matches and
 // is_mut_captured_in — reached only when the name appears in a *specific* sub-
@@ -7,27 +14,27 @@ let w3_proj: (Expr) -> Int = (e) -> { if expr_projects_or_matches("x", e) { 1 } 
 let w3_mut: (Expr) -> Int = (e) -> { if is_mut_captured_in(e, "x") { 1 } else { 0 } }
 let w3_both: (Expr) -> Int = (e) -> { w3_proj(e) + w3_mut(e) }
 
-let xi: () -> Expr = () -> { EIdent("x") }
-let arm_x: () -> Array[(Pat, Expr)] = () -> { Array::slice([(PWild, EIdent("x"))], 0, 1) }
+let xi: () -> Expr = () -> { EIdent("x", 0) }
+let arm_x: () -> Array[(Pat, Expr)] = () -> { Array::slice([(PWild, EIdent("x", 0))], 0, 1) }
 let arm_z: () -> Array[(Pat, Expr)] = () -> { Array::slice([(PWild, EInt(0))], 0, 1) }
 
 let w3_dot_match: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + w3_both(EDot(EBinOp("+", xi(), EInt(1)), "f"))     // dot, non-ident obj recurse
-  acc = acc + w3_both(EDot(EIdent("z"), "f"))                    // dot, ident != name
+  acc = acc + w3_both(EDot(EBinOp("+", xi(), EInt(1)), "f", 0, 0))     // dot, non-ident obj recurse
+  acc = acc + w3_both(EDot(EIdent("z", 0), "f", 0, 0))                    // dot, ident != name
   acc = acc + w3_both(EMatch(xi(), arm_z()))                     // scrut is name
-  acc = acc + w3_both(EMatch(EIdent("z"), arm_x()))              // arm body has name
+  acc = acc + w3_both(EMatch(EIdent("z", 0), arm_x()))              // arm body has name
   acc = acc + w3_both(EMatch(EBinOp("+", xi(), EInt(1)), arm_z())) // scrut recurse
-  acc = acc + w3_both(EMatch(EIdent("z"), arm_z()))              // neither -> false
-  acc = acc + w3_both(EHandle(EIdent("z"), arm_x()))             // handle arm has name
+  acc = acc + w3_both(EMatch(EIdent("z", 0), arm_z()))              // neither -> false
+  acc = acc + w3_both(EHandle(EIdent("z", 0), arm_x()))             // handle arm has name
   acc = acc + w3_both(EHandle(xi(), arm_z()))                    // handle body has name
   acc
 }
 let w3_bind: () -> Int = () -> {
   let mut acc = 0
-  acc = acc + w3_both(ELet("a", xi(), EUnit)) + w3_both(ELet("a", EUnit, xi()))
+  acc = acc + w3_both(ELet("a", xi(), EUnit, 0)) + w3_both(ELet("a", EUnit, xi(), 0))
   acc = acc + w3_both(ELetRec("a", xi(), EUnit)) + w3_both(ELetRec("a", EUnit, xi()))
-  acc = acc + w3_both(ELetMut("a", xi(), EUnit)) + w3_both(ELetMut("a", EUnit, xi()))
+  acc = acc + w3_both(ELetMut("a", xi(), EUnit, 0)) + w3_both(ELetMut("a", EUnit, xi(), 0))
   acc = acc + w3_both(EAssign("a", xi(), EUnit)) + w3_both(EAssign("a", EUnit, xi()))
   acc = acc + w3_both(EAssignOp("+", "a", xi(), EUnit)) + w3_both(EAssignOp("+", "a", EUnit, xi()))
   acc
@@ -38,7 +45,7 @@ let w3_ctrl: () -> Int = () -> {
   acc = acc + w3_both(ESeq(xi(), EUnit)) + w3_both(ESeq(EUnit, xi()))
   acc = acc + w3_both(EWhile(xi(), EUnit)) + w3_both(EWhile(EInt(0), xi()))
   acc = acc + w3_both(EForIn("i", None, xi(), EUnit)) + w3_both(EForIn("i", None, EInt(0), xi()))
-  acc = acc + w3_both(ECall(xi(), Array::slice([EUnit], 0, 0))) + w3_both(ECall(EIdent("f"), Array::slice([EInt(1), xi()], 0, 2)))
+  acc = acc + w3_both(ECall(xi(), Array::slice([EUnit], 0, 0), 0)) + w3_both(ECall(EIdent("f", 0), Array::slice([EInt(1), xi()], 0, 2), 0))
   acc = acc + w3_both(EInt(1))
   acc
 }

--- a/scripts/coverage/cov_walker2.vibe
+++ b/scripts/coverage/cov_walker2.vibe
@@ -1,3 +1,31 @@
+import ../../lib/@vibe/compiler/codegen/wasi/linked_helpers.vibe {
+  stmts_use_builtin
+}
+
+import ../../lib/@vibe/compiler/core/dce.vibe {
+  dce_keep_stmt,
+  dce_reachable_names,
+  is_type_or_structural
+}
+
+import ../../lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe {
+  reassign_self_reusable
+}
+
+import ../../lib/@vibe/parser/parser_expr_primary.vibe {
+  desugar_loop_body
+}
+
+import ../../lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe {
+  scope_tail_proj_root
+}
+
+import ../../lib/@vibe/parser/printer.vibe {
+  infer_handle_effect_name_from_pat,
+  print_expr,
+  print_stmt
+}
+
 
 // #cov walker-breadth driver #2: drive the remaining unique full-AST-walk
 // functions directly with one constructed value per variant — printers
@@ -7,7 +35,7 @@
 // infer_handle_effect_name_from_pat). No compile needed; covers every arm.
 let w_pe: (Expr) -> Int = (e) -> { String::length(print_expr(e)) }
 let w_proj: (Expr) -> Int = (e) -> { String::length(scope_tail_proj_root(e)) }
-let w_desugar: (Expr) -> Int = (e) -> { match desugar_loop_body(e, Array::slice([""], 0, 0)) { _ => 1 } }
+let w_desugar: (Expr) -> Int with Exception = (e) -> { match desugar_loop_body(e, Array::slice([""], 0, 0)) { _ => 1 } }
 let w_reassign: (Expr) -> Int = (e) -> {
   handle { if reassign_self_reusable(e, "x") { 1 } else { 0 } } with Exception { Throw(_) => 0 }
 }
@@ -18,22 +46,22 @@ let w_dcek: (Stmt) -> Int = (s) -> {
 }
 let w_pat: (Pat) -> Int = (pp) -> { match infer_handle_effect_name_from_pat(pp) { Some(_) => 1, None => 0 } }
 
-export let cov_walker2_main: () -> Int = () -> {
+export let cov_walker2_main: () -> Int with Exception = () -> {
   let mut acc = 0
-  let xid = EIdent("x")
+  let xid = EIdent("x", 0)
   // Expr battery (every variant) -> print_expr / scope_tail_proj_root / desugar / reassign
   let es = Array::slice([EUnit], 0, 0)
   Array::push(es, EInt(1)); Array::push(es, EFloat(1.0)); Array::push(es, EString("s"))
   Array::push(es, EBool(true)); Array::push(es, EUnit); Array::push(es, xid)
   Array::push(es, ETuple(Array::slice([xid], 0, 1))); Array::push(es, EArray(Array::slice([xid], 0, 1)))
-  Array::push(es, ERecord(Array::slice([("f", xid)], 0, 1))); Array::push(es, EMap(Array::slice([("k", xid)], 0, 1)))
-  Array::push(es, EIf(xid, EInt(1), EInt(2))); Array::push(es, ELet("a", xid, EIdent("a")))
-  Array::push(es, ELetRec("a", xid, EIdent("a"))); Array::push(es, ELetMut("a", xid, EUnit))
+  Array::push(es, ERecord("", Array::slice([("f", xid)], 0, 1), Array::slice([TyName("Int")], 0, 0))); Array::push(es, EMap(Array::slice([("k", xid)], 0, 1)))
+  Array::push(es, EIf(xid, EInt(1), EInt(2))); Array::push(es, ELet("a", xid, EIdent("a", 0), 0))
+  Array::push(es, ELetRec("a", xid, EIdent("a", 0))); Array::push(es, ELetMut("a", xid, EUnit, 0))
   Array::push(es, EAssign("x", EInt(1), EUnit)); Array::push(es, EAssignOp("+", "x", EInt(1), EUnit))
   Array::push(es, ESeq(xid, EUnit)); Array::push(es, EWhile(xid, EUnit))
   Array::push(es, EForIn("i", None, xid, EUnit)); Array::push(es, EForIn("i", Some("j"), xid, EUnit))
-  Array::push(es, ECall(EIdent("f"), Array::slice([xid], 0, 1))); Array::push(es, EBinOp("+", xid, EInt(1)))
-  Array::push(es, EUnaryOp("-", xid)); Array::push(es, EDot(xid, "field"))
+  Array::push(es, ECall(EIdent("f", 0), Array::slice([xid], 0, 1), 0)); Array::push(es, EBinOp("+", xid, EInt(1)))
+  Array::push(es, EUnaryOp("-", xid)); Array::push(es, EDot(xid, "field", 0, 0))
   Array::push(es, EReturn(xid))
   Array::push(es, EBreak(Some(xid))); Array::push(es, EBreak(None))
   Array::push(es, EContinue(Array::slice([xid], 0, 1))); Array::push(es, ESpread(xid))
@@ -51,8 +79,8 @@ export let cov_walker2_main: () -> Int = () -> {
   Array::push(ss, SLet(false, false, "a", None, EInt(1)))
   Array::push(ss, SLet(true, false, "a", Some(intty), EInt(1)))     // exported + typed
   Array::push(ss, SLetMut("b", None, EInt(2)))
-  Array::push(ss, SStruct(false, "S", Array::slice([("f", intty)], 0, 1)))
-  Array::push(ss, SEnum(false, "E", Array::slice([""], 0, 0), Array::slice([("A", Array::slice([intty], 0, 0))], 0, 1)))
+  Array::push(ss, SStruct(false, "S", Array::slice([("f", intty)], 0, 1), Array::slice([""], 0, 0), Array::slice([""], 0, 0), Array::slice([""], 0, 0)))
+  Array::push(ss, SEnum(false, "E", Array::slice([""], 0, 0), Array::slice([("A", Array::slice([intty], 0, 0))], 0, 1), Array::slice([""], 0, 0)))
   Array::push(ss, SSuberror(false, "Err", Array::slice([("Bad", Array::slice([intty], 0, 0))], 0, 1)))
   Array::push(ss, STypeAlias(false, "T", Array::slice([""], 0, 0), intty))
   Array::push(ss, STrait(false, "Tr", Array::slice([""], 0, 0), ArrayBuilder::freeze(ArrayBuilder::new()), ArrayBuilder::freeze(ArrayBuilder::new()), Array::slice([""], 0, 0)))

--- a/scripts/coverage_drivers.sh
+++ b/scripts/coverage_drivers.sh
@@ -9,13 +9,22 @@
 #   - TypeEnv-walking trait helpers fed only checker-built shapes
 #   - the linked_imports>0 / library_mode arms of compile_wasi_module_linked_impl
 #
-# Drivers compile and run against a cycle-free no-DCE compiler source under
-# coverage, unioning executed branches into the corpus acc.json by
+# Every driver is merged by the compiler-owned exact-path exposure mode (#1633):
+# the driver names the exact source file each compiler value comes from, and the
+# instrumented compiler rewrites those references to the names the ordinary
+# production merge produced. Executed branches union into the corpus acc.json by
 # (fn_name, local_branch_index) — valid because every binary shares the same
-# per-function branch ordering. The migrated `units` and `traitenv` drivers are
-# merged by compiler-owned exact-path exposure mode; remaining drivers retain
-# the legacy raw base until later #1633 slices. Run coverage_corpus.sh FIRST (it
-# builds acc.json + the instrumented compiler_cov.wasm this suite reuses).
+# per-function branch ordering. Run coverage_corpus.sh FIRST (it builds acc.json
+# + the instrumented compiler_cov.wasm this suite reuses).
+#
+# There used to be a second lane: a Python walk that concatenated the compiler
+# sources with their imports stripped, which drivers were appended to verbatim.
+# It followed only RELATIVE imports, so after the .vpkg package-import migration
+# (#1269/#897) it walked a few hops and stopped — 67KB of a ~5MB compiler — and
+# every driver on it died with `unknown name`. Nothing can rescue that shape:
+# unqualified concatenation of 300 files resolves duplicate private helpers by
+# first-match roulette, which is why exposure resolves through the production
+# rename plan instead.
 #
 #   scripts/coverage_drivers.sh
 set -uo pipefail
@@ -27,14 +36,13 @@ COMPILER_COV="$OUTDIR/compiler_cov.wasm"
 COMPILER_ENTRY="lib/@vibe/compiler/cli_adapter.vibe"
 DRIVER_FILTER="${VIBE_COV_DRIVER_FILTER:-}"
 RUNNER="scripts/run_wasm_vibe_host_runner.sh"
-# Same node-stack requirement as coverage_corpus.sh: every driver compiles the
-# ~5MB merged source (plus the driver) under coverage instrumentation, which
-# recurses past node's default stack. Without this the host overflow surfaces as
-# `expression too deeply nested`, run_driver counts it as a compile failure, and
-# -- because that path used to `return 0` -- the whole suite reported success
-# with EVERY driver silently skipped. Keep in sync with coverage_corpus.sh.
+# Same node-stack requirement as coverage_corpus.sh: exposing a driver walks the
+# whole ~5MB compiler closure, which recurses past node's default stack. Without
+# this the host overflow surfaces as `expression too deeply nested`, run_driver
+# counts it as a failure, and -- because that path used to `return 0` -- the
+# whole suite reported success with EVERY driver silently skipped. Keep in sync
+# with coverage_corpus.sh.
 export VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --experimental-wasm-inlining --stack-size=131072}"
-MERGED="_build/coverage/merged_nodce.vibe"
 WORK="_build/coverage/drivers"
 
 # Split out one attempt so the deterministic-vs-transient retry contract has a
@@ -69,86 +77,6 @@ else
   [ -s "$ACC" ] || { echo "drivers: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
   [ -s "$COMPILER_COV" ] || { echo "drivers: run coverage_corpus.sh first (no current compiler_cov.wasm)" >&2; exit 1; }
   mkdir -p "$WORK"
-fi
-
-coverage_driver_uses_exact_exposure() { # label
-  case "$1" in
-    units|traitenv) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
-# 1. Regenerate the legacy no-DCE source only for drivers not yet migrated to
-#    exact-path exposure. Filtered exact-exposure runs never construct or trust
-#    raw concatenation; an unfiltered run still needs it for legacy drivers.
-if [ "$COVERAGE_DRIVERS_SOURCED" = "0" ] && { [ -z "$DRIVER_FILTER" ] || ! coverage_driver_uses_exact_exposure "$DRIVER_FILTER"; }; then
-  echo "[drivers] regenerating legacy no-DCE source ..." >&2
-  python3 - "lib/@vibe/compiler" "lib/@vibe/compiler/compiler_sources_manifest.tsv" "cli_adapter.vibe" "$MERGED" <<'PY'
-import os, re, sys
-compiler_dir, manifest_path, root_rel, out_path = sys.argv[1:]
-rows=[]
-for raw in open(manifest_path):
-    line=raw.rstrip("\n")
-    if not line or line.startswith("#"): continue
-    p=line.split("\t")
-    if len(p)==2: rows.append((p[0],p[1]))
-src_by={}
-for _,rel in rows:
-    full=os.path.join(compiler_dir,rel)
-    if os.path.isfile(full): src_by[rel]=open(full,encoding="utf-8").read()
-dep=re.compile(r'^\s*(?:import|export)\s+(\.[\w./\s-]+?)(?:\.vibe)?\s*\{',re.M)
-drop=re.compile(r'^\s*(?:import|export)\s+[.][^\s{]+')
-def norm(p):
-    out=[]
-    for s in p.split("/"):
-        if s in("","."):continue
-        if s=="..":
-            if out:out.pop()
-            continue
-        out.append(s)
-    return "/".join(out)
-def resolve(base,raw):
-    bd=os.path.dirname(base); raw=re.sub(r'\s*/\s*','/',raw.strip())
-    j=norm((bd+"/"+raw) if (raw.startswith("./") or raw.startswith("../")) and bd else raw)
-    cands=[j] if j.endswith(".vibe") else [j+".vibe", j+"/index.vibe"]
-    for c in cands:
-        if c in src_by: return c
-    return cands[0]
-vis=set(); order=[]
-def visit(rel):
-    if rel in vis: return
-    s=src_by.get(rel)
-    if s is None: return
-    vis.add(rel)
-    for d in dep.findall(s): visit(resolve(rel,d))
-    order.append(rel)
-def strip(s):
-    out=[]; skip=False; depth=0
-    for line in s.splitlines(True):
-        st=line.lstrip()
-        if st.startswith("//"): continue
-        if not skip and drop.match(line):
-            depth=line.count("{")-line.count("}")
-            if depth>0: skip=True
-            continue
-        if skip:
-            depth+=line.count("{")-line.count("}")
-            if depth<=0: skip=False
-            continue
-        out.append(line)
-    m="".join(out)
-    return m if (not m or m.endswith("\n")) else m+"\n"
-visit(root_rel)
-first=True
-with open(out_path,"w",encoding="utf-8") as f:
-    for rel in order:
-        s=src_by.get(rel)
-        if s is None: continue
-        m=strip(s)
-        if first: m=m.lstrip("\r\n"); first=False
-        f.write(m)
-PY
-  [ -s "$MERGED" ] || { echo "drivers: merged source generation failed" >&2; exit 1; }
 fi
 
 # (fn_name, local_branch_index) union of a driver's raw coverage dump into
@@ -213,29 +141,25 @@ run_driver() { # entry driver_file label
   fi
   DRIVERS_RAN=$((DRIVERS_RAN + 1))
   local d="$WORK/$label"; rm -rf "$d"; mkdir -p "$d"
-  if coverage_driver_uses_exact_exposure "$label"; then
-    # The current instrumented compiler owns this internal emit mode. It
-    # collects the production compiler closure, resolves the driver's exact-file
-    # value requests, and rewrites them to the ordinary merge's final names.
-    # The pinned seed only compiles the emitted ordinary source; no seed bump.
-    rm -f "$d/src.vibe" "$d/src.vibe.diag"
-    VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1 \
-      VIBE_COVERAGE_DRIVER_PATH="$file" \
-      VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
-      bash "$RUNNER" --invoke cli_main "$COMPILER_COV" \
-      "$COMPILER_ENTRY" "$d/src.vibe" "$entry" >"$d/expose.log" 2>&1 || true
-    if [ ! -s "$d/src.vibe" ]; then
-      echo "[$label] exact-path exposure failed" >&2
-      if [ -s "$d/src.vibe.diag" ]; then
-        awk '{ print "               " $0 }' "$d/src.vibe.diag" >&2
-      elif [ -s "$d/expose.log" ]; then
-        tail -3 "$d/expose.log" | awk '{ print "               " $0 }' >&2
-      fi
-      DRIVER_FAILS=$((DRIVER_FAILS + 1))
-      return 0
+  # The current instrumented compiler owns this internal emit mode. It
+  # collects the production compiler closure, resolves the driver's exact-file
+  # value requests, and rewrites them to the ordinary merge's final names.
+  # The pinned seed only compiles the emitted ordinary source; no seed bump.
+  rm -f "$d/src.vibe" "$d/src.vibe.diag"
+  VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1 \
+    VIBE_COVERAGE_DRIVER_PATH="$file" \
+    VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+    bash "$RUNNER" --invoke cli_main "$COMPILER_COV" \
+    "$COMPILER_ENTRY" "$d/src.vibe" "$entry" >"$d/expose.log" 2>&1 || true
+  if [ ! -s "$d/src.vibe" ]; then
+    echo "[$label] exact-path exposure failed" >&2
+    if [ -s "$d/src.vibe.diag" ]; then
+      awk '{ print "               " $0 }' "$d/src.vibe.diag" >&2
+    elif [ -s "$d/expose.log" ]; then
+      tail -3 "$d/expose.log" | awk '{ print "               " $0 }' >&2
     fi
-  else
-    cat "$MERGED" "$file" > "$d/src.vibe"
+    DRIVER_FAILS=$((DRIVER_FAILS + 1))
+    return 0
   fi
   local compile_status=0
   coverage_driver_compile_with_retries "$d" "$entry" || compile_status=$?
@@ -262,7 +186,11 @@ run_driver() { # entry driver_file label
   VIBE_COV_OUT="$d/cov.json" VIBE_COV_RAW=1 VIBE_PREOPEN_DIR="$ROOT" \
     bash "$RUNNER" "$d/m.wasm" >/dev/null 2>&1 || true
   if [ -s "$d/cov.json" ]; then
-    local merge_stat
+    # `local`, because the final suite summary reports `$base` -- the hit count
+    # taken BEFORE any driver ran. Unqualified, each driver overwrote it with
+    # its own pre-merge count, so the closing line reported only the last
+    # driver's delta (+9) as if it were the whole suite's (+633).
+    local merge_stat base now tot scaled pct
     if merge_stat="$(coverage_driver_merge_checked "$ACC" "$d/cov.json")"; then
       read -r base now tot <<<"$merge_stat"
       scaled=$(( (now * 10000 + tot / 2) / tot ))

--- a/scripts/tests/coverage_drivers_test.sh
+++ b/scripts/tests/coverage_drivers_test.sh
@@ -11,13 +11,29 @@ DRIVER_DIR="$TMP/driver"
 mkdir -p "$DRIVER_DIR"
 : > "$DRIVER_DIR/src.vibe"
 
-# Routing: both migrated labels use exact exposure. A filtered run for either
-# label can therefore skip the legacy merged-source generator; legacy labels
-# still require it.
-coverage_driver_uses_exact_exposure units
-coverage_driver_uses_exact_exposure traitenv
-if coverage_driver_uses_exact_exposure units2; then
-  echo "coverage_drivers_test: units2 unexpectedly routed to exact exposure" >&2
+# Every driver goes through exact-path exposure (#1633), so every driver must
+# name the compiler values it uses with `import <exact file> { .. }`. A driver
+# with no imports only ever worked under the deleted raw-concatenation lane,
+# where it inherited whatever names the concatenation happened to expose; on the
+# exposure lane it compiles against nothing and dies with `unknown name`.
+driver_rows="$(grep -E '^run_driver ' scripts/coverage_drivers.sh | awk '{ print $2, $3, $4 }')"
+[ -n "$driver_rows" ] || { echo "coverage_drivers_test: no run_driver rows found" >&2; exit 1; }
+while read -r entry file label; do
+  [ -f "$file" ] || { echo "coverage_drivers_test: $label driver missing: $file" >&2; exit 1; }
+  grep -qE '^import [^ ]+\.vibe \{' "$file" || {
+    echo "coverage_drivers_test: $label ($file) has no exact-file import" >&2
+    exit 1
+  }
+  grep -qE "^export let $entry:" "$file" || {
+    echo "coverage_drivers_test: $label ($file) does not export its entry $entry" >&2
+    exit 1
+  }
+done <<< "$driver_rows"
+
+# The raw-concatenation lane and its truncated walk are gone; nothing may bring
+# a `merged_nodce` base back without also revisiting this test.
+if grep -q 'merged_nodce' scripts/coverage_drivers.sh; then
+  echo "coverage_drivers_test: legacy merged_nodce base reintroduced" >&2
   exit 1
 fi
 


### PR DESCRIPTION
[#1633](https://github.com/mizchi/vibe-lang/issues/1633)。driver suite の base を作っていた Python walk を削除し、登録済み **39 本すべて**を compiler-owned exact-path exposure に載せた。

## 何が壊れていたか

`coverage_drivers.sh` の base は「manifest の全ファイルを import 剥がしで連結した no-DCE ソース」だった。その依存走査が**相対 import しか辿らない**:

```python
dep=re.compile(r'^\s*(?:import|export)\s+(\.[\w./\s-]+?)(?:\.vibe)?\s*\{',re.M)
```

`.vpkg` パッケージ import (#1269/#897) 以降、起点 `cli_adapter.vibe` からは数ホップで walk が尽きる。実測で **2,164 行 / 66KB** ——真の merged source は 5.88MB。全 driver が `unknown name: db_new` の類で死ぬ。

**walk を直すだけでは足りない。** 300 ファイルを無資格に連結した base は、同名の private ヘルパを first-match roulette で解決する。実際に重複しているもの:

| 名前 | 定義ファイル数 |
|---|---|
| `strip_trailing_cr` | 4 (`loader/loader` `loader/manifest_sources` `cache/header_codec` `entry/cli_cache`) |
| `normalize_path` | 2 (`core/module_graph_path` `fs_compile/closure_order`) |
| `matches_cached_file_spec` | 2 (`loader/loader` `loader/manifest_sources`) |
| `compact_string_fingerprint` | 2 (`cache/cache` `compiler/runtime/runtime`) |

どのコピーの分岐を測ったのかが決まらない数字は、カバレッジとして意味がない。#1637 が入れた exposure モードは production の rename plan 経由で解決するので、driver が名指ししたファイルのコピーだけが点灯する。

## 変更

各 driver が使うコンパイラ値を**exact file で import** する形へ移した:

```vibe
import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe {
  compile_source_wasi_only
}
```

そのうえで削除したもの: Python walk 本体 / `_build/coverage/merged_nodce.vibe` base / `coverage_driver_uses_exact_exposure` ルーティング述語 / `run_driver` の `cat "$MERGED" "$file"` 分岐。

## 移行して分かったこと: driver は壊れている間に腐っていた

レーンが動いていなかったので、driver が呼ぶ API の変化が誰にも当たっていなかった。現行コンパイラに合わせて直したもの:

- **AST のアリティ** — `EIdent`/`ECall`/`EDot`/`ELet`/`ELetMut` の byte offset スロット、`SEnum` の derives、`SStruct` の #829 スロット、`ERecord` の名前 + 明示型引数、`EnvTraitDef`(7) / `EnvCached`(names/types/rest) / `TDStruct`(4)
- **parser 内部** — `starts: Array[Int]` (#1567 located diagnostics) と `parse_recur` コールバック。`parse_impl_block` / `parse_postfix` / `parse_stmt` / `parse_export_stmt` / 各 primary が対象。driver 側は `lex_with_offsets` + `parse_impl` を包む recur で呼ぶ (parser_expr.vibe 自身と同じ形)
- **シグネチャ変化** — `check_pattern` の errors シンク、`flatten_module_body` が alias 配列ではなく rewriter を取る、`compile_wasi_module_linked_impl` の末尾 8 スロット、`parse_persistent_source_*_cache` の 4-tuple 化
- **未宣言の effect row** — `with Fs` / `with Exception`
- **消えた target** — `lookup_array_group_b` → `lookup_array`、`lookup_io_c` → `lookup_io_b` へ吸収 (名前は cov_lookup 側で網羅済み)、`lookup_assert` → checker.vibe のインライン名前判定、`parse_int_unwrap` → `parse_int_or`、`ensure_grouped_source_bucket` → `_seeded` 形。後継があるものは差し替え、無いものは理由をコメントに残して削除

## 副産物: codegen バグ [#1643](https://github.com/mizchi/vibe-lang/issues/1643)

`cov_cache2` が instantiate できず、最小形まで縮めた:

```vibe
fn g() -> Int { handle { let r = (1, 2); r.0 } with Exception { Throw(_) => 0 } }
```

`vibe check` も `vibe build` も成功するのに、生成 wasm が `invalid local index` で validation を通らない。`handle` と「let 束縛経由の tuple 射影」の両方が要る (直接射影・`match`・handle 無しはいずれも通る)。別 issue にして、driver 側は `match` で回避した。

## suite サマリの嘘も直した

`run_driver` が `base` を `local` 宣言せずに代入していたため、最後の driver の値で上書きされ、締めの行が suite 全体の寄与ではなく**最後の 1 本の差分**を報告していた (`+9` vs 実際の `+633`)。

## 検証

| | 結果 |
|---|---|
| 39 driver 個別 (expose → seed compile → run → cov.json) | **39/39 ok, FAIL 0** |
| `coverage_corpus.sh` (`VIBE_COV_MAX=40`) → `coverage_drivers.sh` | **exit 0**、`11375 -> 12008/26457 (45.39%) (+633)`、全 driver が寄与 |
| `scripts/tests/coverage_drivers_test.sh` | ok (新しい不変条件付き) |
| `scripts/tests/coverage_pipeline_contract_test.sh` | ok |
| `pkf run test-coverage-driver-exposure` | ok |

corpus は時間の都合で `VIBE_COV_MAX=40` の capped 実行。パーセンテージは full corpus の値ではなく、この PR 内の before/after 比較用。

`coverage_drivers_test.sh` の routing アサーションは、述語が消えたので**より強い不変条件**に置き換えた: run list の各 driver が exact-file import と宣言どおりの entry を持つこと、`merged_nodce` base が再導入されていないこと。

### 既知の無関係な赤

`pkf run test-coverage-scripts` は `select_test_shard.test.mjs` の 1 ケースで落ちるが、`origin/main` の worktree でも同じく落ちる (アサーション自体が実装に無い変換を期待している)。本 PR は該当ファイルに触れていない。[#1644](https://github.com/mizchi/vibe-lang/issues/1644) に切り出した。

## #1633 に残るもの

- `scripts/coverage_driver.sh` (単数形、`cov_driver.vibe`) と `VIBE_COV_FLAT` の unit-test レーンは flat module source への raw concat のまま
- corpus → filtered driver → merge の attestation (#1640 の続き)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_