### PR TITLE
Fix normalizeRepoPath test fixture input

### DIFF
--- a/scripts/select_test_shard.test.mjs
+++ b/scripts/select_test_shard.test.mjs
@@ -14,7 +14,7 @@ import {
 test("normalizeRepoPath converts absolute paths to repo-relative slash paths", () => {
   const root = path.join(os.tmpdir(), "repo");
   assert.equal(
-    normalizeRepoPath(path.join(root, "vibe", "compiler", "a_test.vibe"), root),
+    normalizeRepoPath(path.join(root, "lib", "@vibe", "compiler", "a_test.vibe"), root),
     "lib/@vibe/compiler/a_test.vibe",
   );
 });


### PR DESCRIPTION
Fixes #1644.

The test expected a `lib/@vibe/...` relative path but supplied an absolute path without those components. Supply the repository-shaped input; production normalization remains unchanged.

Validation:
- `node --test scripts/select_test_shard.test.mjs`
- `pkf run test-coverage-scripts` (33/33 Node tests plus coverage script checks)