### PR TITLE
Fix invalid wasm local count for handled tuple projection

### DIFF
--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail6.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail6.vibe
@@ -264,7 +264,7 @@ export fn compile_expr_tail6(buf: Bytes, body: Expr, arms: Array[(Pat, Expr)], l
       // index, so plain truncation is the correct scope restore.
       let body_names_start = Array::length(local_names)
       let body_ref_cells_start = Array::length(ctx.ref_cell_names)
-      let _nl1 = compile_expr(buf, body, local_names, next_local, ctx, ld)
+      let body_nl = compile_expr(buf, body, local_names, next_local, ctx, ld)
       let mut mask_i = body_names_start
       while mask_i < Array::length(local_names) {
         Array::set(local_names, mask_i, "")
@@ -367,7 +367,11 @@ export fn compile_expr_tail6(buf: Bytes, body: Expr, arms: Array[(Pat, Expr)], l
         post_mask_i = post_mask_i + 1
       }
       Array::truncate(ctx.ref_cell_names, body_ref_cells_start)
-      nl2
+      if body_nl > nl2 {
+        body_nl
+      } else {
+        nl2
+      }
     }
   } else {
     compile_expr(buf, body, local_names, next_local, ctx, ld)

--- a/lib/@vibe/compiler/tests/handle_body_shadow_test.vibe
+++ b/lib/@vibe/compiler/tests/handle_body_shadow_test.vibe
@@ -83,6 +83,15 @@ fn no_shadow() -> Int {
   }
 }
 
+fn handled_tuple_projection() -> Int {
+  handle {
+    let r = (1, 2)
+    r.0
+  } with Exception {
+    Throw(_m) => 0
+  }
+}
+
 //# Misc
 
 test "965: handler arm reads the OUTER binding when the body shadows it (let)" {
@@ -104,6 +113,10 @@ test "965 review: later match arm reads the OUTER binding after an arm shadows i
 
 test "965: non-shadowing handle unchanged" {
   assert(no_shadow() == 56)
+}
+
+test "1643: handled body tuple projection keeps its scratch local declared" {
+  inspect(handled_tuple_projection(), "1")
 }
 
 test "965: code AFTER a handle still sees enclosing bindings" {


### PR DESCRIPTION
Fixes #1643.

The handled body and handler arm are mutually exclusive control-flow paths, but codegen returned only the arm local high-water. A let-bound tuple projection can allocate a body-only scratch local, producing instructions that reference an undeclared wasm local. Return the maximum high-water while preserving existing allocation starts and scope masking.

Adds the exact `handle { let r = (1, 2); r.0 }` execution regression.

Validation:
- independent verifier ACCEPT
- focused stage2 compile + wasm instantiate + `_start`
- `pkf run test-local` (224 selected tests)
- formatter and generated freshness