### PR TITLE
Land bounded coverage, async, wasm-gc, and artifact freshness slices

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2838,8 +2838,18 @@ scope-blind probe して fresh binder を作り、`let fresh = rhs; x = fresh; r
 continuation は各一回だけ実行する。compound RHS と `+=` 等の EAssignOp は引き続き
 fail-closed であり、この追記は loop / nested handle / row-variable callee を広げない。
 
-**残る不適格**: EForIn(array)/ELoop HEAD、compound assignment RHS、compound
-selection input、row 変数 callee、literal param flow。
+### 追記46 (2026-08-12): direct while condition を再帰 loop spine に名前付けする (#1536 (a) v7)
+
+`while condition { body }` の condition が追記44と同じ direct recognized suspension
+そのものなら、既存の `let rec lp = () -> ...` loop closure の内側で fresh binder に
+一回だけ束縛し、resumed Bool を `if` で選択する。したがって operation は各 condition
+check ごとに一回、body は true ごとに一回、loop 後の continuation は最初の false
+後に一回だけ実行される。fresh probe は condition/body/continuation 全体を見る。
+compound condition、loop control、for-in/loop、nested-argument suspension は引き続き
+fail-closed。
+
+**残る不適格**: EForIn(array)/ELoop HEAD、compound while/selection input、compound
+assignment RHS、loop control、row 変数 callee、literal param flow。
 
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -112,7 +112,12 @@ recorded claims to agree and still validates the implementation-closure owner.
 The opaque opt-in runtime producer derives both values only after successful
 checking. Ordinary `check_module` makes no artifact construction attempt;
 diagnosed opt-in checks also make none; successful opt-in checks make exactly
-one. This counter is test observation, not production telemetry.
+one. An explicit in-memory validator can compare retained v2 bytes with one
+current `ModuleJob.path/source/dep_envs`. It recomputes both identities from the
+already-ingested source, requires ordered dependency assumptions and exactly the
+singleton owner closure, and returns only `Bool`; v1, malformed, stale, or wider
+closure inputs fail closed. Ordinary checks never enter this validator. Its
+attempt counter is test observation, not production telemetry.
 
 The aggregate and its complete-encoding fingerprint are shadow comparison data
 only. They are not wired to TypeDb, the TypeEnv v5 transport and persistent cache

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -173,9 +173,10 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   `match` scrutinee が direct target perform・concrete needing call・CPS-local call
   そのものの形 (fresh let へ一回評価してから selection、ADR-0076 追記44)、
   **継続 spine 上の通常代入 (`=`) の RHS が同じ direct 形そのもの** (fresh let
-  へ一回評価してから一回だけ代入、追記45)
+  へ一回評価してから一回だけ代入、追記45)、**`while` condition が同じ direct
+  形そのもの** (再帰 loop closure 内で check ごとに一回評価、追記46)
 - **不適格**: ループ内 `break`/`continue`/`return`、配列 `for` / `loop` 形、
-  selection input / 代入 RHS が suspend を内包する複合式、compound assignment
+  selection input / 代入 RHS / while condition が suspend を内包する複合式、compound assignment
   (`+=` 等)、実引数証明が成立しない
   closure パラメータの呼び出し、row 変数 callee (`with e`)
 

--- a/fixtures/effect_while_condition_suspend.vibe
+++ b/fixtures/effect_while_condition_suspend.vibe
@@ -1,0 +1,33 @@
+// #1536 direct while condition: the condition operation executes once for
+// each check (true, true, false), the body runs twice, and the continuation
+// runs once. A user spelling matching the generated binder remains untouched.
+effect Ask {
+  More(Int) -> Bool
+}
+
+let checks = [0]
+let bodies = [0]
+let tails = [0]
+
+let _start = () -> Int {
+  handle {
+    let __scps_seq_0_while = 7
+    while perform Ask::More(Array::get(checks, 0)) {
+      Array::set(bodies, 0, Array::get(bodies, 0) + 1)
+    }
+    Array::set(tails, 0, Array::get(tails, 0) + 1)
+    Array::get(checks, 0) * 1000 + Array::get(bodies, 0) * 100 + Array::get(tails, 0) * 10 + __scps_seq_0_while
+  } with Ask {
+    More(n) => {
+      Array::set(checks, 0, Array::get(checks, 0) + 1)
+      let k = resume
+      k(n < 2)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "last": "3217"
+}

--- a/fixtures/err_effect_while_condition_compound_suspend.vibe
+++ b/fixtures/err_effect_while_condition_compound_suspend.vibe
@@ -1,0 +1,26 @@
+// #1536 boundary: while-condition support is limited to the direct recognized
+// suspension itself. A compound comparison containing a perform stays rejected.
+effect Ask {
+  Next() -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut count = 0
+    while perform Ask::Next() > 0 {
+      count = count + 1
+    }
+    count
+  } with Ask {
+    Next() => {
+      let k = resume
+      k(0)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "let/seq/tail/branch-tail spine"
+}

--- a/fixtures/gc_direct_array_argument_fallback_test.vibe
+++ b/fixtures/gc_direct_array_argument_fallback_test.vibe
@@ -1,0 +1,18 @@
+// #1541 fallback pair: a generic direct function argument cannot use the
+// private concrete typed-reference ABI. The complete component must retain the
+// tagged-i64 representation rather than mix representations.
+
+fn mutate_second_generic[T](values: Array[Int], marker: T) -> Unit {
+  let _ = marker
+  Array::set(values, 1, 3)
+}
+
+test "gc generic array argument remains on the fallback lane" {
+  let original = [
+    40,
+    2
+  ]
+  mutate_second_generic(original, 7)
+  assert(Array::get(original, 0) == 40)
+  assert(Array::get(original, 1) == 3)
+}

--- a/fixtures/gc_direct_array_argument_identity_test.vibe
+++ b/fixtures/gc_direct_array_argument_identity_test.vibe
@@ -1,0 +1,17 @@
+// #1541 direct-argument characterization: one private concrete Array[Int]
+// crosses exactly one non-generic direct function argument boundary. Mutation
+// through the callee parameter must remain visible through the caller binding.
+
+fn mutate_second(values: Array[Int]) -> Unit {
+  Array::set(values, 1, 3)
+}
+
+test "gc direct array argument preserves identity" {
+  let original = [
+    40,
+    2
+  ]
+  mutate_second(original)
+  assert(Array::get(original, 0) == 40)
+  assert(Array::get(original, 1) == 3)
+}

--- a/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_module_typing_artifact.vibe
@@ -657,6 +657,45 @@ export fn decode_checked_module_typing_artifact_v2(text: String) -> Option[Check
   }
 }
 
+fn module_dependencies_equal(left: Array[(String, String)], right: Array[(String, String)]) -> Bool {
+  if Array::length(left) != Array::length(right) {
+    false
+  } else {
+    let mut i = 0
+    let mut equal = true
+    while i < Array::length(left) && equal {
+      let (left_locator, left_identity) = Array::get(left, i)
+      let (right_locator, right_identity) = Array::get(right, i)
+      if left_locator != right_locator || left_identity != right_identity {
+        equal = false
+      } else {
+        i = i + 1
+      }
+    }
+    equal
+  }
+}
+
+/// Strictly match canonical v2 bytes against one current singleton-module
+/// input. This is freshness observation only: it returns no artifact or type
+/// environment and cannot authorize persistence or reuse. The caller supplies
+/// identities derived from its already-ingested source. Additional closure
+/// rows fail closed because this bounded consumer has no authority to validate
+/// dependency implementation inputs.
+export fn checked_module_typing_artifact_v2_matches_exact_inputs(text: String, module_locator: String, source_identity: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)]) -> Bool {
+  match decode_checked_module_typing_artifact_v2(text) {
+    Some(artifact) => if artifact.module_locator != module_locator || artifact.source_identity_kind != module_source_identity_kind_v2() || artifact.source_identity != source_identity || artifact.implementation_kind != "provisional_token_stream_v1" || artifact.implementation_identity != implementation_identity || !module_dependencies_equal(artifact.dependency_interface_assumptions, dependency_interface_assumptions) {
+      false
+    } else if Array::length(artifact.recorded_implementation_closure) != 1 {
+      false
+    } else {
+      let (owner_locator, owner_kind, owner_identity) = Array::get(artifact.recorded_implementation_closure, 0)
+      owner_locator == module_locator && owner_kind == "provisional_token_stream_v1" && owner_identity == implementation_identity
+    },
+    None => false
+  }
+}
+
 /// Canonical complete aggregate bytes for snapshots only.
 export fn canonical_checked_module_typing_artifact_snapshot(artifact: CheckedModuleTypingArtifact) -> String {
   encode_checked_module_typing_artifact_v1(artifact)

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -32,6 +32,7 @@ fn encode_checked_module_typing_artifact_v1(artifact: CheckedModuleTypingArtifac
 fn encode_checked_module_typing_artifact_v2(artifact: CheckedModuleTypingArtifact) -> String
 fn decode_checked_module_typing_artifact_v1(text: String) -> Option[CheckedModuleTypingArtifact]
 fn decode_checked_module_typing_artifact_v2(text: String) -> Option[CheckedModuleTypingArtifact]
+fn checked_module_typing_artifact_v2_matches_exact_inputs(text: String, module_locator: String, source_identity: String, implementation_identity: String, dependency_interface_assumptions: Array[(String, String)]) -> Bool
 fn canonical_checked_module_typing_artifact_snapshot(artifact: CheckedModuleTypingArtifact) -> String
 fn checked_module_typing_artifact_fingerprint_v1(artifact: CheckedModuleTypingArtifact) -> String
 fn checked_module_typing_artifact_fingerprint_v2(artifact: CheckedModuleTypingArtifact) -> String

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9295,8 +9295,8 @@ fn scps_need_clone(eff: String, fname: String, st: (Array[Int], Array[String], A
 // let/seq/tail/branch-tail spine. A direct recognized suspension may also
 // occupy an if condition, match scrutinee, or plain-assignment RHS: it is
 // first named by a fresh ELet, then the existing spine machinery resumes into
-// selection/assignment. Compound inputs, compound assignment, and every other
-// nested suspension still fail closed.
+// selection/assignment or a while condition. Compound inputs, compound
+// assignment, and every other nested suspension still fail closed.
 
 fn scps_direct_spine_input(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String])) -> Bool {
   let (_, ops, _, _, _) = sctx
@@ -10022,7 +10022,7 @@ fn scps_seq_append(e: Expr, k: Expr) -> Expr {
 fn scps_split_while(c: Expr, body: Expr, rest: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), st: (Array[Int], Array[String], Array[String], Array[String], Array[String], Array[Stmt], Array[String])) -> (Bool, Expr) {
   let (eff, s_ops, s_needing, s_site, s_cps) = sctx
   let orig = ESeq(EWhile(c, body), rest)
-  if scps_contains_susp(c, sctx) || scps_has_loop_ctl(body) {
+  if scps_has_loop_ctl(body) {
     (false, orig)
   } else {
     let lp = scps_local("__scps_lp", scps_next_site(st))
@@ -10030,13 +10030,31 @@ fn scps_split_while(c: Expr, body: Expr, rest: Expr, sctx: (String, Array[String
     Array::push(ext, lp)
     let sctx2 = (eff, s_ops, s_needing, s_site, ext)
     let step = scps_seq_append(body, ECall(EIdent(lp, -1), array_empty_expr(), -1))
-    let (iok, ibody) = scps_split_tail(step, sctx2, ctx, st)
-    let (rok, rbody) = scps_split_tail(rest, sctx2, ctx, st)
-    if iok && rok {
-      let lam = EFn(array_empty_str(), scps_empty_tbs(), scps_empty_params(), None, None, EIf(c, ibody, rbody))
-      (true, ELetRec(lp, lam, ECall(EIdent(lp, -1), array_empty_expr(), -1)))
-    } else {
+    if scps_direct_spine_input(c, sctx) {
+      // #1536 (a) v7: evaluate one directly recognized suspending condition
+      // once per loop check, then resume into the existing recursive loop
+      // selection. Probe the whole loop + continuation so the fresh binder
+      // cannot capture a user spelling in the condition, body, or rest.
+      let cx = scps_seq_float_fresh("while", orig, EUnit, s_site)
+      let loop_body = ELet(cx, c, EIf(EIdent(cx, -1), step, rest), -1)
+      let (lok, lowered) = scps_split_tail(loop_body, sctx2, ctx, st)
+      if lok {
+        let lam = EFn(array_empty_str(), scps_empty_tbs(), scps_empty_params(), None, None, lowered)
+        (true, ELetRec(lp, lam, ECall(EIdent(lp, -1), array_empty_expr(), -1)))
+      } else {
+        (false, orig)
+      }
+    } else if scps_contains_susp(c, sctx) {
       (false, orig)
+    } else {
+      let (iok, ibody) = scps_split_tail(step, sctx2, ctx, st)
+      let (rok, rbody) = scps_split_tail(rest, sctx2, ctx, st)
+      if iok && rok {
+        let lam = EFn(array_empty_str(), scps_empty_tbs(), scps_empty_params(), None, None, EIf(c, ibody, rbody))
+        (true, ELetRec(lp, lam, ECall(EIdent(lp, -1), array_empty_expr(), -1)))
+      } else {
+        (false, orig)
+      }
     }
   }
 }

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -291,10 +291,13 @@ fn check_module_with_typing_artifact_observation(job: ModuleJob) -> ModuleOutcom
 // Test-only observation of post-success construction attempts.
 fn checked_module_typing_artifact_construction_attempt_count() -> Int
 fn reset_checked_module_typing_artifact_construction_attempt_count() -> Unit
+fn checked_module_typing_artifact_validation_attempt_count() -> Int
+fn reset_checked_module_typing_artifact_validation_attempt_count() -> Unit
 // #1550: canonical module typing artifact bytes carried only by an opaque,
 // genuinely successful ModuleOutcome. Diagnosed outcomes return None. This is
 // in-memory observation only: no cache lookup, planner, persistence, or reuse.
 fn checked_module_typing_artifact_observation(outcome: ModuleOutcome) -> Option[String]
+fn checked_module_typing_artifact_observation_is_fresh_for_job(job: ModuleJob, outcome: ModuleOutcome) -> Bool with Exception
 // #906 Phase 2: the worker transport entry. `dir` is a job directory and
 // is the worker's ENTIRE filesystem sandbox -- see typecheck_fs.vibe for
 // its layout and for why the job's `path` row must be the module's logical

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -26,6 +26,7 @@ import @vibe/compiler/checker {
 
 import @vibe/compiler/checker/artifacts {
   checked_exported_interface_artifact_from_checked_program,
+  checked_module_typing_artifact_v2_matches_exact_inputs,
   encode_checked_module_typing_artifact_v2,
   shadow_unattested_checked_module_typing_artifact_v2_from_checked_program
 }
@@ -3292,6 +3293,10 @@ let checked_module_typing_artifact_construction_attempts: Array[Int] = [
   0
 ]
 
+let checked_module_typing_artifact_validation_attempts: Array[Int] = [
+  0
+]
+
 /// Test-observation counter. It measures entry into artifact construction, not
 /// checker execution: ordinary and diagnosed paths remain zero.
 export fn checked_module_typing_artifact_construction_attempt_count() -> Int {
@@ -3300,6 +3305,15 @@ export fn checked_module_typing_artifact_construction_attempt_count() -> Int {
 
 export fn reset_checked_module_typing_artifact_construction_attempt_count() -> Unit {
   Array::set(checked_module_typing_artifact_construction_attempts, 0, 0)
+}
+
+/// Test-only count of entries into the explicit freshness validator.
+export fn checked_module_typing_artifact_validation_attempt_count() -> Int {
+  Array::get(checked_module_typing_artifact_validation_attempts, 0)
+}
+
+export fn reset_checked_module_typing_artifact_validation_attempt_count() -> Unit {
+  Array::set(checked_module_typing_artifact_validation_attempts, 0, 0)
 }
 
 fn checked_module_typing_artifact_bytes(checked: CheckedProgram, job: ModuleJob) -> Option[String] with Exception {
@@ -3327,6 +3341,18 @@ export fn checked_module_typing_artifact_observation(outcome: ModuleOutcome) -> 
   match outcome {
     Checked(_, _, _, _, _, _, observation) => observation,
     Diagnosed(_, _) => None
+  }
+}
+
+/// Explicit in-memory freshness observation for one retained successful
+/// outcome against one current, already-ingested ModuleJob. This returns only
+/// Bool and does not publish, persist, plan, or reuse the decoded artifact.
+export fn checked_module_typing_artifact_observation_is_fresh_for_job(job: ModuleJob, outcome: ModuleOutcome) -> Bool with Exception {
+  Array::set(checked_module_typing_artifact_validation_attempts, 0, Array::get(checked_module_typing_artifact_validation_attempts, 0) + 1)
+  match outcome {
+    Checked(_, _, _, _, _, _, Some(bytes)) => checked_module_typing_artifact_v2_matches_exact_inputs(bytes, job.path, compact_string_fingerprint(job.source), incremental_implementation_identity(job.source), checked_module_dependency_interface_assumptions(job.dep_envs)),
+    Checked(_, _, _, _, _, _, None) => false,
+    Diagnosed(_, _) => false
   }
 }
 

--- a/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
@@ -9,6 +9,7 @@ import @vibe/compiler/checker/artifacts {
   checked_exported_interface_artifact_fingerprint_v1,
   checked_exported_interface_artifact_from_checked_program,
   checked_module_typing_artifact_fingerprint_v1,
+  checked_module_typing_artifact_v2_matches_exact_inputs,
   decode_checked_module_typing_artifact_v1,
   decode_checked_module_typing_artifact_v2,
   encode_checked_exported_interface_artifact_v1,
@@ -28,7 +29,10 @@ import @vibe/compiler/runtime {
   check_module_with_typing_artifact_observation,
   checked_module_typing_artifact_construction_attempt_count,
   checked_module_typing_artifact_observation,
-  reset_checked_module_typing_artifact_construction_attempt_count
+  checked_module_typing_artifact_observation_is_fresh_for_job,
+  checked_module_typing_artifact_validation_attempt_count,
+  reset_checked_module_typing_artifact_construction_attempt_count,
+  reset_checked_module_typing_artifact_validation_attempt_count
 }
 
 import @vibe/compiler/syntax {
@@ -527,11 +531,13 @@ test "wrapper around genuine checker failure returns no module artifact bytes" {
   }
 }
 
-test "production module check leaves shadow observation disabled and makes zero construction attempts" {
+test "production module check leaves shadow observation disabled and makes zero construction and validation attempts" {
   reset_checked_module_typing_artifact_construction_attempt_count()
+  reset_checked_module_typing_artifact_validation_attempt_count()
   let outcome = check_module(mt_module_job("default.vibe", "export let api: Int = 1\n"))
   assert(checked_module_typing_artifact_observation(outcome) == None)
   assert(checked_module_typing_artifact_construction_attempt_count() == 0)
+  assert(checked_module_typing_artifact_validation_attempt_count() == 0)
 }
 
 test "opaque successful ModuleOutcome carries one canonical v2 artifact after one construction attempt" {
@@ -606,6 +612,77 @@ test "v1 canonical bytes remain unchanged after v2 introduction" {
       assert(bytes == expected)
       match decode_checked_module_typing_artifact_v1(bytes) {
         Some(decoded) => assert(encode_checked_module_typing_artifact_v1(decoded) == bytes),
+        None => assert(false)
+      }
+    },
+    None => assert(false)
+  }
+}
+
+test "opt-in freshness validator accepts only current exact singleton inputs" {
+  reset_checked_module_typing_artifact_validation_attempt_count()
+  let source = "export let api: Int = 1\n"
+  let job = mt_module_job("fresh.vibe", source)
+  let outcome = check_module_with_typing_artifact_observation(job)
+  assert(checked_module_typing_artifact_observation_is_fresh_for_job(job, outcome))
+  assert(checked_module_typing_artifact_validation_attempt_count() == 1)
+  // Exact source identity rejects trivia-only changes even when provisional
+  // token identity remains intentionally unchanged.
+  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(mt_module_job("fresh.vibe", "// changed trivia\nexport let api: Int = 1\n"), outcome))
+  // Parser-visible edits, owner changes, v1/malformed bytes, and absent
+  // observations fail closed.
+  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(mt_module_job("fresh.vibe", "export let api: Int = 2\n"), outcome))
+  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(mt_module_job("other.vibe", source), outcome))
+  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(job, check_module(job)))
+  let diagnosed = check_module_with_typing_artifact_observation(mt_module_job("bad.vibe", "export let bad: Int = \"no\"\n"))
+  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(mt_module_job("bad.vibe", "export let bad: Int = \"no\"\n"), diagnosed))
+}
+
+test "strict v2 exact-input matcher rejects stale closure dependencies and non-v2 bytes" {
+  inspect(checked_module_typing_artifact_v2_matches_exact_inputs("malformed", "owner", "1:2:3", "1:2:5", array_empty()), "false")
+  let checked = check_program_result([
+    SLet(true, false, "api", None, EInt(1))
+  ])
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(interface) => {
+      let source_identity = "1:2:3"
+      let implementation_identity = "1:2:5"
+      match shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked, "owner", source_identity, source_identity, implementation_identity, implementation_identity, [
+        ("dep-a", "1:2:7"),
+        ("dep-b", "1:2:8")
+      ], [
+        ("owner", "provisional_token_stream_v1", implementation_identity)
+      ], interface) {
+        Some(artifact) => {
+          let bytes = encode_checked_module_typing_artifact_v2(artifact)
+          inspect(checked_module_typing_artifact_v2_matches_exact_inputs(bytes, "owner", source_identity, implementation_identity, [
+            ("dep-a", "1:2:7"),
+            ("dep-b", "1:2:8")
+          ]), "true")
+          inspect(checked_module_typing_artifact_v2_matches_exact_inputs(bytes, "owner", source_identity, implementation_identity, [
+            ("dep-b", "1:2:8"),
+            ("dep-a", "1:2:7")
+          ]), "false")
+          inspect(checked_module_typing_artifact_v2_matches_exact_inputs(String::concat(bytes, "trailing"), "owner", source_identity, implementation_identity, [
+            ("dep-a", "1:2:7"),
+            ("dep-b", "1:2:8")
+          ]), "false")
+        },
+        None => assert(false)
+      }
+      match mt_build_text([
+        SLet(true, false, "api", None, EInt(1))
+      ], "owner", "provisional_token_stream_v1", implementation_identity, array_empty(), [
+        ("owner", "provisional_token_stream_v1", implementation_identity)
+      ]) {
+        Some(v1) => assert(!checked_module_typing_artifact_v2_matches_exact_inputs(v1, "owner", source_identity, implementation_identity, array_empty())),
+        None => assert(false)
+      }
+      match shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked, "owner", source_identity, source_identity, implementation_identity, implementation_identity, array_empty(), [
+        ("extra", "validated_metadata_v1", "1:2:9"),
+        ("owner", "provisional_token_stream_v1", implementation_identity)
+      ], interface) {
+        Some(artifact) => assert(!checked_module_typing_artifact_v2_matches_exact_inputs(encode_checked_module_typing_artifact_v2(artifact), "owner", source_identity, implementation_identity, array_empty())),
         None => assert(false)
       }
     },

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6855,6 +6855,10 @@ scps_run_expect "effect_tail_selection_input_suspend.vibe" "3311" "tailselectinp
 # #1536 direct plain-assignment RHS: name the resumed value on the CPS spine,
 # then assign and continue once. Compound RHS and EAssignOp remain fail-closed.
 scps_run_expect "effect_assignment_rhs_suspend.vibe" "41112" "assignrhs"
+# #1536 direct while condition: resume into the existing recursive loop
+# closure once per condition check. Compound conditions remain fail-closed.
+scps_run_expect "effect_while_condition_suspend.vibe" "3217" "whilecond"
+scps_check_reject "err_effect_while_condition_compound_suspend.vibe" "let/seq/tail/branch-tail spine" "whilecondcompound"
 scps_check_reject "err_effect_assignment_rhs_compound_suspend.vibe" "let/seq/tail/branch-tail spine" "assignrhscompound"
 scps_check_reject "err_effect_assignment_op_rhs_suspend.vibe" "let/seq/tail/branch-tail spine" "assignoprhs"
 scps_check_reject "err_effect_seq_head_if_condition_suspend.vibe" "let/seq/tail/branch-tail spine" "seqheadifcompound"

--- a/scripts/coverage/cov_driver.vibe
+++ b/scripts/coverage/cov_driver.vibe
@@ -1,53 +1,107 @@
-// Coverage driver (#cov): appended to the flat module source
-// (lib/@vibe/compiler/_cli_adapter_module_source.vibe) and compiled+run as
-// its own entry `cov_driver_main`. It calls the compiler's type/trait/env
-// functions directly with edge-case inputs (every Type variant, all unify/
-// types_equal pairs, a trait-bearing TypeEnv) that the black-box corpus never
-// triggers. This is the test-execution coverage lever for the deep checker
-// functions, bypassing the cyclic re-export blocker that stops the in-tree
-// *_test.vibe from FS-compiling (see docs/coverage.md).
-let cov_t1: () -> Array[Type] = () -> {
-  let a = Array::slice([CtInt], 0, 0)
-  Array::push(a, CtInt); Array::push(a, CtDouble); Array::push(a, CtBool)
-  Array::push(a, CtString); Array::push(a, CtChar); Array::push(a, CtUnit)
-  Array::push(a, CtBytes); Array::push(a, CtUnknown)
-  Array::push(a, CtArray(CtInt)); Array::push(a, CtArray(CtArray(CtBool)))
-  Array::push(a, CtOption(CtString)); Array::push(a, CtOption(CtVar(0)))
-  Array::push(a, CtTuple(Array::slice([CtInt, CtBool], 0, 2)))
-  Array::push(a, CtFn(Array::slice([CtInt, CtString], 0, 2), CtBool, None))
-  Array::push(a, CtFn(Array::slice([CtVar(0)], 0, 1), CtVar(0), Some("io")))
-  Array::push(a, CtEnum("Foo")); Array::push(a, CtStruct("Bar"))
-  Array::push(a, CtNamed("Map", Array::slice([CtString, CtInt], 0, 2)))
-  Array::push(a, CtVar(0)); Array::push(a, CtVar(1))
-  Array::push(a, CtForAll(Array::slice([0], 0, 1), Array::slice([(0, Array::slice(["Eq"], 0, 1))], 0, 1), CtVar(0)))
-  a
+import ../../lib/@vibe/compiler/core/types.vibe {
+  collect_subst_bounds_pairs,
+  collect_tvars,
+  env_bind,
+  env_cache,
+  env_flat_bindings,
+  env_lookup,
+  env_lookup_flat,
+  generalize,
+  instantiate,
+  occurs_in,
+  subst_add_bound,
+  subst_apply,
+  subst_lookup,
+  trait_defined,
+  trait_is_subtrait,
+  trait_supers,
+  type_implements_trait,
+  type_to_string,
+  types_equal,
+  unify
 }
-let cov_str: (Array[Type]) -> Int = (ts) -> {
+
+import ../../lib/@vibe/compiler/runtime/persistent_env_codec.vibe {
+  serialize_type
+}
+
+// Historical deep-checker coverage driver, now resolved through exact source
+// provenance rather than inheriting ambient names from a raw concatenation.
+let cov_driver_types: () -> Array[Type] = () -> {
+  let out = [
+    CtInt,
+    CtDouble,
+    CtBool,
+    CtString,
+    CtChar,
+    CtUnit,
+    CtBytes,
+    CtUnknown,
+    CtArray(CtInt),
+    CtOption(CtString),
+    CtTuple([
+      CtInt,
+      CtBool
+    ]),
+    CtFn([
+      CtInt,
+      CtString
+    ], CtBool, None),
+    CtEnum("Foo"),
+    CtStruct("Bar"),
+    CtNamed("Map", [
+      CtString,
+      CtInt
+    ]),
+    CtVar(0),
+    CtForAll([
+      0
+    ], [
+      (0, [
+        "Eq"
+      ])
+    ], CtVar(0))
+  ]
+  out
+}
+
+let cov_driver_type_sweep: (Array[Type]) -> Int = (types) -> {
   let mut acc = 0
-  let mut k = 0
-  while k < Array::length(ts) {
-    let t = Array::get(ts, k)
-    acc = acc + String::length(type_to_string(t)) + String::length(serialize_type(t)) + Array::length(collect_tvars(t))
-    let g = generalize(SubstEmpty, t)
-    acc = acc + String::length(type_to_string(g))
-    let sa = subst_apply(SubstBind(0, CtInt, SubstEmpty), t)
-    acc = acc + String::length(serialize_type(sa))
-    let oc = if occurs_in(0, t) { 1 } else { 0 }
-    acc = acc + oc
-    k = k + 1
+  let mut i = 0
+  while i < Array::length(types) {
+    let t = Array::get(types, i)
+    acc = acc + String::length(type_to_string(t))
+    acc = acc + String::length(serialize_type(t))
+    acc = acc + Array::length(collect_tvars(t))
+    acc = acc + String::length(type_to_string(generalize(SubstEmpty, t)))
+    acc = acc + String::length(serialize_type(subst_apply(SubstBind(0, CtInt, SubstEmpty), t)))
+    acc = acc + (if occurs_in(0, t) {
+      1
+    } else {
+      0
+    })
+    let (instantiated, _, _) = instantiate(t, 50)
+    acc = acc + String::length(serialize_type(instantiated))
+    i = i + 1
   }
   acc
 }
-let cov_pairs: (Array[Type]) -> Int = (ts) -> {
-  let n = Array::length(ts)
+
+let cov_driver_pair_sweep: (Array[Type]) -> Int = (types) -> {
   let mut acc = 0
   let mut i = 0
-  while i < n {
+  while i < Array::length(types) {
     let mut j = 0
-    while j < n {
-      let u = match unify(Array::get(ts, i), Array::get(ts, j), SubstEmpty) { Some(_) => 1, None => 0 }
-      let e = if types_equal(Array::get(ts, i), Array::get(ts, j)) { 1 } else { 0 }
-      acc = acc + u + e
+    while j < Array::length(types) {
+      acc = acc + (match unify(Array::get(types, i), Array::get(types, j), SubstEmpty) {
+        Some(_) => 1,
+        None => 0
+      })
+      acc = acc + (if types_equal(Array::get(types, i), Array::get(types, j)) {
+        1
+      } else {
+        0
+      })
       j = j + 1
     }
     i = i + 1
@@ -55,419 +109,58 @@ let cov_pairs: (Array[Type]) -> Int = (ts) -> {
   acc
 }
 
-let cov_trait_env: () -> TypeEnv = () -> {
-  let e = EnvTraitDef("Eq", Array::slice([""], 0, 0), false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, Array::slice([""], 0, 0))
-  let e2 = EnvTraitDef("Ord", Array::slice(["Eq"], 0, 1), false, ArrayBuilder::freeze(ArrayBuilder::new()), e, Array::slice([""], 0, 0))
-  let e3 = EnvTraitImpl("Eq", CtInt, e2)
-  let e4 = EnvTraitImpl("Ord", CtInt, e3)
-  e4
-}
-let cov_traits: () -> Int = () -> {
-  let env = cov_trait_env()
-  let mut acc = Array::length(trait_supers(env, "Ord")) + Array::length(trait_supers(env, "Eq"))
-  acc = acc + (if trait_defined(env, "Eq") { 1 } else { 0 })
-  acc = acc + (if trait_defined(env, "Nope") { 1 } else { 0 })
-  acc = acc + (if trait_is_subtrait(env, "Ord", "Eq") { 1 } else { 0 })
-  acc = acc + (if trait_is_subtrait(env, "Eq", "Ord") { 1 } else { 0 })
-  acc = acc + (if type_implements_trait(env, SubstEmpty, CtInt, "Eq") { 1 } else { 0 })
-  acc = acc + (if type_implements_trait(env, SubstEmpty, CtBool, "Eq") { 1 } else { 0 })
-  acc
-}
-let cov_more: (Array[Type]) -> Int = (ts) -> {
-  let mut acc = 0
-  let mut k = 0
-  while k < Array::length(ts) {
-    let t = Array::get(ts, k)
-    let (it, _, _) = instantiate(t, 50)
-    acc = acc + String::length(serialize_type(it))
-    let sl = match subst_lookup(SubstBind(0, CtInt, SubstEmpty), 0) { Some(_) => 1, None => 0 }
-    acc = acc + sl
-    let ec = env_cache(env_bind(EnvEmpty, "z", t))
-    let el = match env_lookup(ec, "z") { Some(_) => 1, None => 0 }
-    acc = acc + el
-    k = k + 1
-  }
-  let binds = Array::slice([("a", CtInt), ("b", CtString)], 0, 2)
-  let elf = match env_lookup_flat(binds, "a") { Some(_) => 1, None => 0 }
-  acc + elf
-}
-
-
-let cov_names: (Array[Type]) -> Int = (ts) -> {
-  let names = Array::slice([""], 0, 0)
-  Array::push(names, "Int"); Array::push(names, "Float"); Array::push(names, "String")
-  Array::push(names, "Bool"); Array::push(names, "Array"); Array::push(names, "Map")
-  Array::push(names, "Option"); Array::push(names, "Result"); Array::push(names, "Char")
-  Array::push(names, "Byte"); Array::push(names, "Bytes"); Array::push(names, "Unit")
-  Array::push(names, "length"); Array::push(names, "get"); Array::push(names, "set")
-  Array::push(names, "push"); Array::push(names, "pop"); Array::push(names, "slice")
-  Array::push(names, "map"); Array::push(names, "filter"); Array::push(names, "fold")
-  Array::push(names, "concat"); Array::push(names, "reverse"); Array::push(names, "find")
-  Array::push(names, "any"); Array::push(names, "all"); Array::push(names, "contains")
-  Array::push(names, "index_of"); Array::push(names, "split"); Array::push(names, "trim")
-  Array::push(names, "replace"); Array::push(names, "join"); Array::push(names, "abs")
-  Array::push(names, "to_string"); Array::push(names, "char_code_at"); Array::push(names, "nope")
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(names) {
-    let nm = Array::get(names, i)
-    acc = acc + String::length(canonical_builtin_name(nm))
-    let la = match lookup_arithmetic_helper(nm) { Some(_) => 1, None => 0 }
-    let lb = match lookup_array_group_b(nm) { Some(_) => 1, None => 0 }
-    acc = acc + la + lb
-    i = i + 1
-  }
-  let mut k = 0
-  while k < Array::length(ts) {
-    acc = acc + String::length(type_name_prefix(Array::get(ts, k)))
-    k = k + 1
-  }
-  acc
-}
-let cov_subst: () -> Int = () -> {
-  let s = subst_add_bound(SubstBind(0, CtInt, SubstEmpty), 1, Array::slice(["Eq", "Ord"], 0, 2))
-  let pairs = collect_subst_bounds_pairs(s)
-  let g = generalize(s, CtFn(Array::slice([CtVar(0), CtVar(1)], 0, 2), CtVar(1), None))
-  let fb = env_flat_bindings(env_bind(env_bind(EnvEmpty, "a", CtInt), "b", CtString))
-  Array::length(pairs) + String::length(type_to_string(g)) + Array::length(fb)
-}
-
-
-let cov_tokens: () -> Int = () -> {
-  let toks = Array::slice([TEof], 0, 0)
-  Array::push(toks, TInt(5)); Array::push(toks, TFloat(1.5)); Array::push(toks, TString("s")); Array::push(toks, TIdent("x"))
-  Array::push(toks, TStringInterp(Array::slice(["a"], 0, 1), Array::slice([-1], 0, 1)))
-  Array::push(toks, TLet)
-  Array::push(toks, TRec)
-  Array::push(toks, TMut)
-  Array::push(toks, TFn)
-  Array::push(toks, TIf)
-  Array::push(toks, TElse)
-  Array::push(toks, TMatch)
-  Array::push(toks, TIs)
-  Array::push(toks, TDo)
-  Array::push(toks, TEnum)
-  Array::push(toks, TStruct)
-  Array::push(toks, TType)
-  Array::push(toks, TTrait)
-  Array::push(toks, TImpl)
-  Array::push(toks, TExport)
-  Array::push(toks, TTest)
-  Array::push(toks, TWhile)
-  Array::push(toks, TFor)
-  Array::push(toks, TIn)
-  Array::push(toks, TLoop)
-  Array::push(toks, TBreak)
-  Array::push(toks, TContinue)
-  Array::push(toks, TReturn)
-  Array::push(toks, TWith)
-  Array::push(toks, THandle)
-  Array::push(toks, TThrow)
-  Array::push(toks, TRaise)
-  Array::push(toks, TYield)
-  Array::push(toks, TBench)
-  Array::push(toks, TDeclare)
-  Array::push(toks, TAs)
-  Array::push(toks, TModule)
-  Array::push(toks, TSuberror)
-  Array::push(toks, TDerive)
-  Array::push(toks, TOpen)
-  Array::push(toks, TImport)
-  Array::push(toks, TPlus)
-  Array::push(toks, TMinus)
-  Array::push(toks, TStar)
-  Array::push(toks, TSlash)
-  Array::push(toks, TPercent)
-  Array::push(toks, TEqEq)
-  Array::push(toks, TNeq)
-  Array::push(toks, TLt)
-  Array::push(toks, TLte)
-  Array::push(toks, TGt)
-  Array::push(toks, TGte)
-  Array::push(toks, TAnd)
-  Array::push(toks, TOr)
-  Array::push(toks, TNot)
-  Array::push(toks, TBitAnd)
-  Array::push(toks, TBitOr)
-  Array::push(toks, TBitXor)
-  Array::push(toks, TLShift)
-  Array::push(toks, TRShift)
-  Array::push(toks, TPipeGt)
-  Array::push(toks, TArrow)
-  Array::push(toks, TThinArrow)
-  Array::push(toks, TEq)
-  Array::push(toks, TDot)
-  Array::push(toks, TColon)
-  Array::push(toks, TDoubleColon)
-  Array::push(toks, TComma)
-  Array::push(toks, TSemicolon)
-  Array::push(toks, THash)
-  Array::push(toks, TTilde)
-  Array::push(toks, TQuestion)
-  Array::push(toks, TPlusEq)
-  Array::push(toks, TMinusEq)
-  Array::push(toks, TStarEq)
-  Array::push(toks, TSlashEq)
-  Array::push(toks, TPercentEq)
-  Array::push(toks, TLParen)
-  Array::push(toks, TRParen)
-  Array::push(toks, TLBrace)
-  Array::push(toks, TRBrace)
-  Array::push(toks, TLBracket)
-  Array::push(toks, TRBracket)
-  Array::push(toks, TDotDot)
-  Array::push(toks, TDotDotDot)
-  Array::push(toks, TEof)
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(toks) {
-    let t = Array::get(toks, i)
-    acc = acc + String::length(tk_name(t))
-    let inf = if is_non_pipe_infix(t) { 1 } else { 0 }
-    acc = acc + inf
-    i = i + 1
-  }
+let cov_driver_env_sweep: () -> Int = () -> {
+  let eq = EnvTraitDef("Eq", [
+  ], false, ArrayBuilder::freeze(ArrayBuilder::new()), EnvEmpty, [
+  ], [
+  ])
+  let ord = EnvTraitDef("Ord", [
+    "Eq"
+  ], false, ArrayBuilder::freeze(ArrayBuilder::new()), eq, [
+  ], [
+  ])
+  let env = EnvTraitImpl("Ord", CtInt, EnvTraitImpl("Eq", CtInt, ord))
+  let cached = env_cache(env_bind(env, "z", CtInt))
+  let mut acc = Array::length(trait_supers(env, "Ord"))
+  acc = acc + (if trait_defined(env, "Eq") {
+    1
+  } else {
+    0
+  })
+  acc = acc + (if trait_is_subtrait(env, "Ord", "Eq") {
+    1
+  } else {
+    0
+  })
+  acc = acc + (if type_implements_trait(env, SubstEmpty, CtInt, "Eq") {
+    1
+  } else {
+    0
+  })
+  acc = acc + (match env_lookup(cached, "z") {
+    Some(_) => 1,
+    None => 0
+  })
+  acc = acc + Array::length(env_flat_bindings(cached))
+  acc = acc + (match env_lookup_flat([
+    ("a", CtInt)
+  ], "a") {
+    Some(_) => 1,
+    None => 0
+  })
+  let subst = subst_add_bound(SubstBind(0, CtInt, SubstEmpty), 1, [
+    "Eq",
+    "Ord"
+  ])
+  acc = acc + Array::length(collect_subst_bounds_pairs(subst))
+  acc = acc + (match subst_lookup(subst, 0) {
+    Some(_) => 1,
+    None => 0
+  })
   acc
 }
 
-
-let cov_ints: () -> Int = () -> {
-  let ns = Array::slice([0], 0, 0)
-  Array::push(ns, 0); Array::push(ns, 1234567890); Array::push(ns, -987654321)
-  Array::push(ns, 5); Array::push(ns, -1); Array::push(ns, 100); Array::push(ns, 9090)
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(ns) {
-    acc = acc + String::length(__to_string(Array::get(ns, i)))
-    i = i + 1
-  }
-  acc
-}
-let cov_cache_text: () -> Int = () -> {
-  let txts = Array::slice([""], 0, 0)
-  Array::push(txts, "version\t1\n")
-  Array::push(txts, "version\t2\nmanifest\tm\ts\tf\nentry.vibe\tstat1\tfp1\tdeps\n")
-  Array::push(txts, "version\t2\na.vibe\ts\tf\tg\nb.vibe\ts2\tf2\tg2\n")
-  Array::push(txts, "version\t3\n")
-  Array::push(txts, "version\n")
-  Array::push(txts, "garbage line\n")
-  Array::push(txts, "")
-  Array::push(txts, "version\t2\n\n\nrow\ta\tb\tc\n")
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(txts) {
-    let t = Array::get(txts, i)
-    let r1 = handle { let (v, _, rows) = parse_persistent_manifest_header_cache(t); v + Array::length(rows) } with Exception { Throw(_) => 0 }
-    let r2 = handle { let (v, _, rows) = parse_persistent_source_list_cache(t); v + Array::length(rows) } with Exception { Throw(_) => 0 }
-    let r3 = handle { let (v, _, rows) = parse_persistent_source_group_cache(t); v + Array::length(rows) } with Exception { Throw(_) => 0 }
-    let r4 = Array::length(split_header_values(t))
-    acc = acc + r1 + r2 + r3 + r4
-    i = i + 1
-  }
-  acc
-}
-
-
-let cov_parse: () -> Int = () -> {
-  let srcs = Array::slice([""], 0, 0)
-  Array::push(srcs, "trait Eq\ntrait Ord: Eq\nexport open trait Show\nimpl Eq for Int\nimpl Ord for Int\nimpl [T: Eq] Eq for Array[T]\nexport let main: () -> Int = () -> { 0 }")
-  Array::push(srcs, "export let main: () -> Int = () -> { let r = record { name: \"v\", n: 1 }; r.n }")
-  Array::push(srcs, "let f: (Int) -> Int = (x) -> { x }\nexport let main: () -> Int = () -> { 5 |> f |> f }")
-  Array::push(srcs, "enum E { A; B(Int) }\nstruct S { x: Int; y: Int }\ntype T = Array[Int]\nsuberror Bad(String)\nmodule M { export let k: () -> Int = () -> { 1 } }\nexport let main: () -> Int = () -> { M::k() }")
-  Array::push(srcs, "export let main: () -> Int = () -> { let xs = [1,2,3]; xs[0] + Array::length(xs) }")
-  Array::push(srcs, "let g: [T](T) -> T = (x) -> { x }\nexport let main: () -> Int = () -> { g(1) }")
-  Array::push(srcs, "export let main: () -> Int = () -> { match (1, true) { (0, _) => 0, (n, true) => n, (n, false) => 0 - n } }")
-  Array::push(srcs, "export let main: () -> Int = () -> { let a = 1 + 2 * 3 - 4 / 2 % 3; let b = a << 2 | a >> 1 & 6 ^ 3; if a > b && b <= a || !false { a } else { b } }")
-  Array::push(srcs, "export let f: (x~: Int, y~: Int) -> Int = (x~, y~) -> { x + y }\nexport let main: () -> Int = () -> { f(x=1, y=2) }")
-  Array::push(srcs, "export let main: () -> Int = () -> { for x in [1,2] { () }; while false { () }; loop { break 0 } }")
-  Array::push(srcs, "@#$ bad tokens")
-  Array::push(srcs, "export let main = () -> { let x = ; }")
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(srcs) {
-    let r = handle { Array::length(parse_program(lex(Array::get(srcs, i)))) } with Exception { Throw(_) => 0 }
-    acc = acc + r
-    i = i + 1
-  }
-  acc
-}
-let cov_ast: () -> Int = () -> {
-  let srcs = Array::slice([""], 0, 0)
-  Array::push(srcs, "enum PC { Pr; Pb(Int) }\nstruct PP { x: Int; y: Int }\ntype PT = Array[Int]\nsuberror PErr(String)\nlet mk: () -> PC = () -> { Pb(5) }\nlet use_pp: (PP) -> Int = (p) -> { p.x }\nlet pf: (PC) -> Int = (c) -> { match c { Pr => 0, Pb(n) => n } }\nexport let api: () -> Int = () -> { pf(mk()) }\nexport enum PubC { U1; U2 }")
-  Array::push(srcs, "trait PEq\nimpl PEq for Int\nmodule PHelp { let secret: Int = 1; export let k: () -> Int = () -> { secret } }\nlet mut counter: Int = 0\nlet bump: () -> Int = () -> { counter = counter + 1; counter }\nexport let run: () -> Int = () -> { PHelp::k() + bump() }")
-  Array::push(srcs, "effect PLog { Log(String) -> Int }\nlet emit: () -> Int with PLog = () -> { PLog::Log(\"x\") }\nexport let go: () -> Int = () -> { handle { emit() } with PLog { Log(_) resume => resume(1), return v => v } }")
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(srcs) {
-    let stmts = handle { parse_program(lex(Array::get(srcs, i))) } with Exception { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
-    let ns1 = namespace_private_value_stmts("mod_a.vibe", stmts)
-    let ns2 = namespace_private_value_stmts("dir/mod_b.vibe", stmts)
-    acc = acc + Array::length(ns1) + Array::length(ns2)
-    i = i + 1
-  }
-  acc
-}
-
-
-let cov_canonical: () -> Int = () -> {
-  let ns = Array::slice([""], 0, 0)
-  Array::push(ns, "Env::ArgsGet")
-  Array::push(ns, "Env::ArgsLen")
-  Array::push(ns, "Env::Get")
-  Array::push(ns, "Env::args_get")
-  Array::push(ns, "Env::args_len")
-  Array::push(ns, "Env::get")
-  Array::push(ns, "Fs::Append")
-  Array::push(ns, "Fs::Chdir")
-  Array::push(ns, "Fs::Copy")
-  Array::push(ns, "Fs::Exists")
-  Array::push(ns, "Fs::Getcwd")
-  Array::push(ns, "Fs::IsDir")
-  Array::push(ns, "Fs::IsFile")
-  Array::push(ns, "Fs::Mkdir")
-  Array::push(ns, "Fs::ReadBytes")
-  Array::push(ns, "Fs::ReadDir")
-  Array::push(ns, "Fs::ReadFile")
-  Array::push(ns, "Fs::Remove")
-  Array::push(ns, "Fs::StatToken")
-  Array::push(ns, "Fs::WriteBytes")
-  Array::push(ns, "Fs::WriteFile")
-  Array::push(ns, "Fs::append")
-  Array::push(ns, "Fs::chdir")
-  Array::push(ns, "Fs::copy")
-  Array::push(ns, "Fs::exists")
-  Array::push(ns, "Fs::getcwd")
-  Array::push(ns, "Fs::is_dir")
-  Array::push(ns, "Fs::is_file")
-  Array::push(ns, "Fs::mkdir")
-  Array::push(ns, "Fs::read_bytes")
-  Array::push(ns, "Fs::read_file")
-  Array::push(ns, "Fs::readdir")
-  Array::push(ns, "Fs::remove")
-  Array::push(ns, "Fs::stat_token")
-  Array::push(ns, "Fs::write_bytes")
-  Array::push(ns, "Fs::write_file")
-  Array::push(ns, "Profiler::NowUs")
-  Array::push(ns, "Profiler::now_us")
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(ns) {
-    acc = acc + String::length(canonical_builtin_name(Array::get(ns, i)))
-    i = i + 1
-  }
-  acc
-}
-
-
-let cov_exprs: () -> Array[Expr] = () -> {
-  let a = Array::slice([EUnit], 0, 0)
-  Array::push(a, EInt(1)); Array::push(a, EFloat(1.0)); Array::push(a, EString("s"))
-  Array::push(a, EBool(true)); Array::push(a, EIdent("x")); Array::push(a, EUnit)
-  Array::push(a, ETuple(Array::slice([EInt(1), EIdent("x")], 0, 2)))
-  Array::push(a, EArray(Array::slice([EInt(1)], 0, 1)))
-  Array::push(a, ERecord(Array::slice([("f", EInt(1))], 0, 1)))
-  Array::push(a, EIf(EBool(true), EIdent("x"), EInt(2)))
-  Array::push(a, ELet("y", EInt(1), EIdent("x")))
-  Array::push(a, ELetRec("y", EInt(1), EIdent("y")))
-  Array::push(a, ELetMut("y", EInt(1), EIdent("x")))
-  Array::push(a, EAssign("x", EInt(1), EUnit))
-  Array::push(a, EAssignOp("+", "x", EInt(1), EUnit))
-  Array::push(a, ESeq(EIdent("x"), EInt(2)))
-  Array::push(a, EMatch(EIdent("x"), Array::slice([(PWild, EInt(0))], 0, 1)))
-  Array::push(a, EHandle(EIdent("x"), Array::slice([(PCtor("Throw", Array::slice([PWild], 0, 1)), EInt(0))], 0, 1)))
-  Array::push(a, EWhile(EBool(true), EIdent("x")))
-  Array::push(a, ELoop(Array::slice([("acc", EInt(0))], 0, 1), EIdent("x")))
-  Array::push(a, EForIn("i", None, EArray(Array::slice([EInt(1)], 0, 1)), EIdent("x")))
-  Array::push(a, ECall(EIdent("f"), Array::slice([EIdent("x")], 0, 1)))
-  Array::push(a, EBinOp("+", EIdent("x"), EInt(2)))
-  Array::push(a, EUnaryOp("-", EIdent("x")))
-  Array::push(a, EDot(EIdent("x"), "field"))
-  Array::push(a, ELabeledArg("a", "b", EIdent("x")))
-  Array::push(a, EReturn(EIdent("x")))
-  Array::push(a, EBreak(Some(EInt(1)))); Array::push(a, EBreak(None))
-  Array::push(a, EContinue(Array::slice([EInt(1)], 0, 1)))
-  Array::push(a, EMap(Array::slice([("k", EInt(1))], 0, 1)))
-  Array::push(a, ESpread(EIdent("x")))
-  Array::push(a, EStringInterp(Array::slice(["a", "b"], 0, 2)))
-  a
-}
-let cov_expr: () -> Int = () -> {
-  let es = cov_exprs()
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(es) {
-    let e = Array::get(es, i)
-    let p = if expr_projects_or_matches("x", e) { 1 } else { 0 }
-    let r = if reassign_carry_safe(e, "x") { 1 } else { 0 }
-    let _ = desugar_loop_body(e, Array::slice(["x"], 0, 1))
-    acc = acc + p + r
-    i = i + 1
-  }
-  acc
-}
-
-
-let cov_check: () -> Int = () -> {
-  let es = cov_exprs()
-  let env = env_bind(env_bind(env_bind(EnvEmpty, "x", CtInt), "y", CtString), "f", CtFn(Array::slice([CtInt], 0, 1), CtInt, None))
-  let defs = Array::slice([TDAlias("Dummy", Array::slice([""], 0, 0), CtInt)], 0, 0)
-  let errors = Array::slice([""], 0, 0)
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(es) {
-    let r = handle {
-      let (_, _, _) = check_expr(Array::get(es, i), env, defs, SubstEmpty, 100, errors)
-      1
-    } with Exception { Throw(_) => 0 }
-    let rw = rewrite_private_type_ctor_expr(Array::get(es, i), Array::slice([("Foo", "Foo_x")], 0, 1), Array::slice([("A", "A_x")], 0, 1))
-    let _ = rw
-    acc = acc + r
-    i = i + 1
-  }
-  acc
-}
-
-
-
-
-let cov_expr2: () -> Int = () -> {
-  let es = cov_exprs()
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(es) {
-    let e = Array::get(es, i)
-    let _ = fold_expr(e)
-    let refs = Array::slice([""], 0, 0)
-    let locals = Array::slice(["x"], 0, 1)
-    let _ = collect_refs_into(e, refs, locals)
-    acc = acc + Array::length(refs)
-    i = i + 1
-  }
-  acc
-}
-
-
-let cov_stmts: () -> Int = () -> {
-  let srcs = Array::slice([""], 0, 0)
-  Array::push(srcs, "import ./a.vibe { x }\nimport ./b.vibe { y as z }\nexport ./c.vibe { w }\nexport let main: () -> Int = () -> { 0 }")
-  Array::push(srcs, "import ../d/e.vibe { f, g }\nimport @json { parse }\nexport let main: () -> Int = () -> { 0 }")
-  Array::push(srcs, "enum E { A; B(Int) }\nlet f: (E) -> Int = (e) -> { match e { A => 0, B(n) => n } }\nexport let g: () -> Int = () -> { f(A) }")
-  let env = env_bind(EnvEmpty, "x", CtInt)
-  let defs = Array::slice([TDAlias("D", Array::slice([""], 0, 0), CtInt)], 0, 0)
-  let errors = Array::slice([""], 0, 0)
-  let mut acc = 0
-  let mut i = 0
-  while i < Array::length(srcs) {
-    let stmts = handle { parse_program(lex(Array::get(srcs, i))) } with Exception { Throw(_) => Array::slice([SExpr(EInt(0))], 0, 0) }
-    let deps = handle { collect_import_deps_from_stmts(stmts, "base/dir") } with Exception { Throw(_) => Array::slice([""], 0, 0) }
-    let cs = handle { let (_, _, _) = check_stmts(stmts, 0, env, defs, SubstEmpty, 200, errors); 1 } with Exception { Throw(_) => 0 }
-    acc = acc + Array::length(deps) + cs
-    i = i + 1
-  }
-  acc
-}
-
-let cov_driver_main: () -> Int = () -> {
-  let ts = cov_t1()
-  cov_str(ts) + cov_pairs(ts) + cov_traits() + cov_more(ts) + cov_names(ts) + cov_subst() + cov_tokens() + cov_ints() + cov_cache_text() + cov_parse() + cov_ast() + cov_canonical() + cov_expr() + cov_check() + cov_expr2() + cov_stmts()
+export let cov_driver_main: () -> Int = () -> {
+  let types = cov_driver_types()
+  cov_driver_type_sweep(types) + cov_driver_pair_sweep(types) + cov_driver_env_sweep()
 }

--- a/scripts/coverage_driver.sh
+++ b/scripts/coverage_driver.sh
@@ -1,66 +1,11 @@
 #!/usr/bin/env bash
-# Driver coverage for the selfhost compiler (#cov): append scripts/coverage/
-# cov_driver.vibe to the flat module source, compile it under coverage with
-# entry `cov_driver_main`, run it, and union the executed branches into the
-# corpus acc.json by (fn_name, local_branch_index). The driver calls the
-# compiler's type/trait/env functions directly with edge-case inputs the
-# black-box corpus never triggers (type_to_string of every Type variant, all
-# unify/types_equal pairs, a trait-bearing TypeEnv). This is the test-execution
-# coverage lever for the deep checker functions, bypassing the cyclic re-export
-# blocker that stops the in-tree *_test.vibe from FS-compiling.
-#
-#   scripts/coverage_driver.sh    # merges into _build/coverage/selfhost-corpus/acc.json
+# Compatibility entry for the historical singular coverage driver (#1633).
+# The driver is registered in the production exact-path suite; keep this
+# command as a filtered invocation instead of maintaining a second raw-concat
+# compile/merge implementation.
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-SEED="${VIBE_COV_SEED:-$ROOT_DIR/bootstrap/seed/compiler.wasm}"
-FLAT="lib/@vibe/compiler/_cli_adapter_module_source.vibe"
-DRIVER="scripts/coverage/cov_driver.vibe"
-RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
-ACC="$ROOT_DIR/_build/coverage/selfhost-corpus/acc.json"
-OUT="$ROOT_DIR/_build/coverage/selfhost-driver"
-rm -rf "$OUT"; mkdir -p "$OUT"
-[ -s "$ACC" ] || { echo "driver: corpus acc not found; run coverage_corpus.sh first" >&2; exit 1; }
-
-cat "$FLAT" "$DRIVER" > "$OUT/driver_src.vibe"
-# The seed compiler occasionally OOMs on this huge (29k-line) source under
-# coverage instrumentation; retry a few times (non-deterministic heap pressure).
-ok=0
-for t in 1 2 3 4 5 6 7 8; do
-  rm -f "$OUT/driver.wasm"
-  VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
-    bash "$RUNNER" --invoke cli_main "$SEED" "$OUT/driver_src.vibe" "$OUT/driver.wasm" cov_driver_main >/dev/null 2>&1 || true
-  [ -s "$OUT/driver.wasm" ] && { ok=1; break; }
-done
-[ "$ok" = 1 ] || { echo "driver: compile failed after retries" >&2; exit 1; }
-
-VIBE_COV_OUT="$OUT/cov.json" VIBE_COV_RAW=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
-  bash "$RUNNER" "$OUT/driver.wasm" >/dev/null 2>&1 || true
-[ -s "$OUT/cov.json" ] || { echo "driver: run produced no coverage" >&2; exit 1; }
-
-python3 - "$ACC" "$OUT/cov.json" <<'PY'
-import json, sys, os
-from collections import defaultdict
-acc = json.load(open(sys.argv[1]))
-fnC, owC, brC = acc["fn_names"], acc["br_owners"], acc["br"]
-localC = defaultdict(list)
-for gid, o in enumerate(owC):
-    nm = fnC[o] if 0 <= o < len(fnC) else None
-    if nm is not None: localC[nm].append(gid)
-base = sum(brC)
-raw = json.load(open(sys.argv[2]))["raw"]
-nT, owT, bmT = raw["fn_names"], raw["branch_owners"], raw["branch_bitmap"]
-seen = defaultdict(int)
-for i, o in enumerate(owT):
-    nm = nT[o] if 0 <= o < len(nT) else None
-    li = seen[nm]; seen[nm] += 1
-    if nm is None or not bmT[i]: continue
-    ids = localC.get(nm)
-    if ids and li < len(ids): brC[ids[li]] = 1
-tmp = sys.argv[1] + ".tmp"
-with open(tmp, "w") as fh: json.dump(acc, fh)
-os.replace(tmp, sys.argv[1])
-tot, hit = len(brC), sum(brC)
-print(f"[driver] merged into corpus: {base} -> {hit}/{tot} ({hit/tot*100:.2f}%)  (+{hit-base})")
-PY
+export VIBE_COV_DRIVER_FILTER=driver
+exec bash scripts/coverage_drivers.sh

--- a/scripts/coverage_drivers.sh
+++ b/scripts/coverage_drivers.sh
@@ -30,7 +30,7 @@
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SEED="${VIBE_COV_SEED:-bootstrap/seed/compiler.wasm}"
-OUTDIR="_build/coverage/selfhost-corpus"
+OUTDIR="${VIBE_COV_DIR:-_build/coverage/selfhost-corpus}"
 ACC="$OUTDIR/acc.json"
 COMPILER_COV="$OUTDIR/compiler_cov.wasm"
 COMPILER_ENTRY="lib/@vibe/compiler/cli_adapter.vibe"
@@ -262,6 +262,7 @@ run_driver cov_margin_main     scripts/coverage/cov_margin.vibe     margin      
 run_driver cov_parser5_main    scripts/coverage/cov_parser5.vibe    parser5     # parse_type_impl modes x type forms + parse_pattern/parse_export_stmt/parse_one_param internals
 run_driver cov_namespace3_main scripts/coverage/cov_namespace3.vibe namespace3  # namespace_private_value_stmts SModule/SImpl/SEffectDef/SReExport/SAliasDecl arms
 run_driver cov_round_main      scripts/coverage/cov_round.vibe      round       # parse_enum_stmt/parse_export_name forms + print_stmt SImpl/SModule/SReExport/SEffectDef variants + has_non_pipe_infix_top ranges
+run_driver cov_driver_main     scripts/coverage/cov_driver.vibe     driver      # historical deep checker driver, retained through exact-path exposure
 rm -f _build/vibe_selfhost_* 2>/dev/null || true
 
 final_stat="$(coverage_driver_stat "$ACC")" || {

--- a/scripts/coverage_unittests.sh
+++ b/scripts/coverage_unittests.sh
@@ -1,50 +1,76 @@
 #!/usr/bin/env bash
-# Run the compiler's own *_test.vibe unit tests against the cycle-free FLAT module
-# source (bypassing the cyclic-import blocker). For each test file: strip imports
-# from the relevant *_support.vibe helpers (their deps are top-level in the flat
-# source), append the test bodies + assert helpers, compile+run under coverage,
-# and union into the corpus acc.json. Test files using cli_main-unreachable
-# (DCE'd) functions fail to compile and are skipped.
-set -uo pipefail
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT"
-SEED="bootstrap/seed/compiler.wasm"
-# FLAT defaults to the committed DCE'd flat source; override with VIBE_COV_FLAT
-# (e.g. the no-DCE merged source) to unblock test files that reference
-# cli_main-unreachable (DCE'd) functions. Merge still counts only branches in
-# corpus-present functions, so a richer base only adds executed bits, never
-# inflates the denominator.
-FLAT="${VIBE_COV_FLAT:-lib/@vibe/compiler/_cli_adapter_module_source.vibe}"
+# Execute the compiler root unit tests through compiler-owned exact-path
+# exposure (#1633). The extraction tool removes package/type imports; this
+# wrapper restores exact-file imports for every compiler immutable value used
+# by each generated driver. No flat compiler text is concatenated.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+SEED="${VIBE_COV_SEED:-bootstrap/seed/compiler.wasm}"
+OUTDIR="${VIBE_COV_DIR:-_build/coverage/selfhost-corpus}"
+ACC="$OUTDIR/acc.json"
+COMPILER_COV="$OUTDIR/compiler_cov.wasm"
+COMPILER_ENTRY="lib/@vibe/compiler/cli_adapter.vibe"
 RUNNER="scripts/run_wasm_vibe_host_runner.sh"
-ACC="_build/coverage/selfhost-corpus/acc.json"
-OUT="_build/coverage/selfhost-ut"; rm -rf "$OUT"; mkdir -p "$OUT"
+OUT="_build/coverage/selfhost-ut"
+export VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --experimental-wasm-inlining --stack-size=131072}"
 
-ok=0; fail=0; : > "$OUT/runs.txt"
-DRIVER="$OUT/ut_driver.vibe"
+[ -s "$ACC" ] || { echo "ut: run coverage_corpus.sh first (no acc.json)" >&2; exit 1; }
+[ -s "$COMPILER_COV" ] || { echo "ut: run coverage_corpus.sh first (no current compiler_cov.wasm)" >&2; exit 1; }
+rm -rf "$OUT"; mkdir -p "$OUT"
+VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 source scripts/coverage_drivers.sh
+
+exact_imports() { # test basename
+  case "$1" in
+    cfv_test.vibe)
+      printf 'import ../../../../lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe { collect_free_vars }\n'
+      printf 'let array_empty: [T]() -> Array[T] = () -> { Array::slice([], 0, 0) }\n'
+      ;;
+    cfv_encl_test.vibe)
+      printf 'import ../../../../lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe { collect_free_vars_indexed_self }\n'
+      ;;
+    pctor_test.vibe|pctor2_test.vibe)
+      printf 'import ../../../../lib/@vibe/compiler/codegen/codegen.vibe { compile_wasi_module }\n'
+      printf 'import ../../../../lib/@vibe/parser/lexer.vibe { lex }\n'
+      printf 'import ../../../../lib/@vibe/parser/parser.vibe { parse_program }\n'
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+ok=0
 for f in lib/@vibe/compiler/*_test.vibe; do
   base="$(basename "$f")"
-  SUPPORTS="$(grep -oE "\./[a-z_]+_support\.vibe" "$f" 2>/dev/null | sed "s|\./||" | sort -u | paste -sd, -)"
-  bash scripts/coverage_unittests_run.sh "$SUPPORTS" "$base" "$DRIVER" >/dev/null 2>&1 || { fail=$((fail+1)); continue; }
-  grep -q "cov_ut_1:" "$DRIVER" 2>/dev/null || { continue; }  # no tests
-  cat "$FLAT" "$DRIVER" > "$OUT/src.vibe"
-  built=0
-  for t in 1 2 3; do
-    rm -f "$OUT/ut.wasm"
-    VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw bash "$RUNNER" --invoke cli_main "$SEED" "$OUT/src.vibe" "$OUT/ut.wasm" cov_driver_main >/dev/null 2>&1
-    [ -s "$OUT/ut.wasm" ] && { built=1; break; }
-  done
-  if [ "$built" = 1 ]; then
-    cov="$OUT/${base%.vibe}.json"
-    VIBE_COV_OUT="$cov" VIBE_COV_RAW=1 VIBE_PREOPEN_DIR="$ROOT" bash "$RUNNER" "$OUT/ut.wasm" >/dev/null 2>&1
-    [ -s "$cov" ] && { echo "$cov" >> "$OUT/runs.txt"; ok=$((ok+1)); } || fail=$((fail+1))
-  else
-    fail=$((fail+1))
+  d="$OUT/${base%.vibe}"; mkdir -p "$d"
+  generated="$d/generated.vibe"
+  bash scripts/coverage_unittests_run.sh "" "$base" "$generated" >"$d/generate.log" 2>&1 || {
+    echo "[ut:$base] driver generation failed" >&2; cat "$d/generate.log" >&2; exit 1
+  }
+  grep -q 'cov_ut_1:' "$generated" || { echo "[ut:$base] generated no tests" >&2; exit 1; }
+  { exact_imports "$base"; cat "$generated"; } > "$d/driver.vibe"
+  if [ "$base" = pctor_test.vibe ]; then
+    # The extracted test performs the same Fs write as its source declaration;
+    # the historical extractor retains Exception but cannot infer capability rows.
+    sed -e 's/) -> Int with Exception =/) -> Int with Exception + Fs::write_bytes =/' -e 's/let cov_driver_main: () -> Int =/let cov_driver_main: () -> Int with Fs::write_bytes =/' "$d/driver.vibe" > "$d/driver.tmp"
+    mv "$d/driver.tmp" "$d/driver.vibe"
   fi
+  rm -f "$d/src.vibe" "$d/src.vibe.diag"
+  VIBE_EMIT_COVERAGE_DRIVER_SOURCE=1 VIBE_COVERAGE_DRIVER_PATH="$d/driver.vibe" \
+    VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
+    bash "$RUNNER" --invoke cli_main "$COMPILER_COV" \
+    "$COMPILER_ENTRY" "$d/src.vibe" cov_driver_main >"$d/expose.log" 2>&1 || true
+  [ -s "$d/src.vibe" ] || { echo "[ut:$base] exact-path exposure failed" >&2; cat "$d/src.vibe.diag" 2>/dev/null >&2 || tail -3 "$d/expose.log" >&2; exit 1; }
+  compile_status=0
+  coverage_driver_compile_with_retries "$d" cov_driver_main || compile_status=$?
+  [ "$compile_status" = 0 ] || { echo "[ut:$base] compile failed (status $compile_status)" >&2; cat "$d/m.wasm.diag" 2>/dev/null >&2 || tail -3 "$d/compile.log" >&2; exit 1; }
+  cov="$d/cov.json"
+  VIBE_COV_OUT="$cov" VIBE_COV_RAW=1 VIBE_PREOPEN_DIR="$ROOT" bash "$RUNNER" --invoke _start "$d/m.wasm" >"$d/run.log" 2>&1 || {
+    echo "[ut:$base] execution failed" >&2; tail -5 "$d/run.log" >&2; exit 1
+  }
+  [ -s "$cov" ] || { echo "[ut:$base] run produced no raw coverage" >&2; exit 1; }
+  merge_stat="$(coverage_driver_merge_checked "$ACC" "$cov")" || { echo "[ut:$base] checked coverage merge failed" >&2; exit 1; }
+  echo "[ut:$base] $merge_stat"
+  ok=$((ok + 1))
 done
-echo "[ut] $ok test files ran, $fail skipped (DCE'd fns / no tests)" >&2
-# (fn_name, local_branch_index) union of every run in runs.txt into acc.json
-# -- scripts/coverage_local_merge.vibex's `merge-list` subcommand (native
-# vibe port; see that file's header comment for the algorithm).
-read -r base now tot < <(bash scripts/coverage_local_merge_run.sh merge-list "$ACC" "$OUT/runs.txt")
-scaled=$(( (now * 10000 + tot / 2) / tot ))
-pct="$((scaled / 100)).$(printf '%02d' $((scaled % 100)))"
-echo "[ut] unit-test merge: $base -> $now/$tot ($pct%) (+$((now-base)))"
+[ "$ok" -gt 0 ] || { echo "ut: no root test driver ran" >&2; exit 1; }
+echo "[ut] $ok exact-path test files ran and merged" >&2

--- a/scripts/test_gc_heap_accounting.sh
+++ b/scripts/test_gc_heap_accounting.sh
@@ -95,13 +95,115 @@ compile_direct_abi_fallback fixtures/gc_direct_array_abi_fallback_test.vibe "$FA
 compile_direct_abi_fallback fixtures/gc_direct_array_abi_shadow_fallback_test.vibe "$SHADOW_FALLBACK_OUT"
 compile_direct_abi_fallback fixtures/gc_direct_array_abi_export_fallback_test.vibe "$EXPORT_FALLBACK_OUT"
 
+# #1541 isolated direct-argument characterization. The native fixture crosses
+# exactly one private concrete Array[Int] parameter boundary; the generic pair
+# must retain the component-wide tagged-i64 fallback.
+ARGUMENT_OUT="$WORK/direct_array_argument_identity.wasm"
+ARGUMENT_FALLBACK_OUT="$WORK/direct_array_argument_fallback.wasm"
+compile_direct_abi_fallback fixtures/gc_direct_array_argument_identity_test.vibe "$ARGUMENT_OUT"
+compile_direct_abi_fallback fixtures/gc_direct_array_argument_fallback_test.vibe "$ARGUMENT_FALLBACK_OUT"
+
 # Count decoded instructions rather than byte patterns: raw scanning can match
 # non-code sections and also couples this gate to an incidental numeric type
 # index. `wasm-tools print` parses the module and renders instructions with the
 # actual type reference, which we deliberately ignore here.
-count_native_array_allocs() {
+count_decoded_instruction() {
   local wasm="$1"
-  wasm-tools print "$wasm" | awk '$1 == "array.new_default" { count += 1 } END { print count + 0 }'
+  local instruction="$2"
+  wasm-tools print "$wasm" | awk -v instruction="$instruction" '$1 == instruction { count += 1 } END { print count + 0 }'
+}
+
+count_native_array_allocs() {
+  count_decoded_instruction "$1" "array.new_default"
+}
+
+assert_direct_argument_structure() {
+  local wasm="$1"
+  local printed="$WORK/$(basename "$wasm").wat"
+  wasm-tools print "$wasm" > "$printed"
+
+  # The only native allocation is the caller literal. Its two initializer
+  # writes plus the callee mutation are the complete decoded array.set set.
+  local allocs sets indirect_calls
+  allocs="$(awk '$1 == "array.new_default" { count += 1 } END { print count + 0 }' "$printed")"
+  sets="$(awk '$1 == "array.set" { count += 1 } END { print count + 0 }' "$printed")"
+  indirect_calls="$(awk '$1 == "call_indirect" { count += 1 } END { print count + 0 }' "$printed")"
+  [ "$allocs" -eq 1 ] || {
+    echo "[gc-heap-accounting] FAIL: expected one direct-argument native literal, found $allocs" >&2
+    exit 1
+  }
+  [ "$sets" -eq 3 ] || {
+    echo "[gc-heap-accounting] FAIL: expected two literal initializers plus one callee array.set, found $sets" >&2
+    exit 1
+  }
+  [ "$indirect_calls" -eq 0 ] || {
+    echo "[gc-heap-accounting] FAIL: direct-argument fixture emitted $indirect_calls call_indirect instructions" >&2
+    exit 1
+  }
+
+  # Tie a decoded direct call to the function that both has the native-array
+  # parameter type and performs the callee mutation. Discover all indices from
+  # wasm-tools output; numeric type/function indices are deliberately not
+  # fixed because they are an encoding detail.
+  python3 - "$printed" <<'PY'
+import re
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+typed_types = set()
+for line in lines:
+    match = re.match(
+        r"^  \(type \(;(\d+);\) \(func \(param \(ref null [^)]+\) i64\) \(result i64\)\)\)$",
+        line,
+    )
+    if match:
+        typed_types.add(match.group(1))
+if not typed_types:
+    raise SystemExit(
+        "[gc-heap-accounting] FAIL: missing typed array-ref direct-argument signature"
+    )
+
+functions = []
+current = None
+for line in lines:
+    declaration = re.match(r"^  \(func \(;(\d+);\) \(type (\d+)\)", line)
+    if declaration:
+        if current is not None:
+            functions.append(current)
+        current = {
+            "index": declaration.group(1),
+            "type": declaration.group(2),
+            "lines": [],
+        }
+    elif current is not None:
+        current["lines"].append(line)
+if current is not None:
+    functions.append(current)
+
+# The characterized callee is identified structurally: typed native-array
+# parameter plus the decoded array.set mutation in its body.
+typed_mutators = {
+    function["index"]
+    for function in functions
+    if function["type"] in typed_types
+    and any(re.match(r"^\s+array\.set\b", line) for line in function["lines"])
+}
+if not typed_mutators:
+    raise SystemExit(
+        "[gc-heap-accounting] FAIL: no typed array-ref callee performs array.set"
+    )
+
+direct_targets = {
+    match.group(1)
+    for line in lines
+    if (match := re.match(r"^\s+call (\d+)\s*$", line))
+}
+called_mutators = typed_mutators & direct_targets
+if not called_mutators:
+    raise SystemExit(
+        "[gc-heap-accounting] FAIL: typed array-ref mutator has no decoded direct call"
+    )
+PY
 }
 
 positive="$(count_native_array_allocs "$DIRECT_OUT")"
@@ -123,7 +225,29 @@ for i in "${!fallback_outputs[@]}"; do
     exit 1
   fi
 done
-echo "[gc-heap-accounting] ok: direct Array[Int] ABI, local alias identity, and fail-closed component fallbacks"
+assert_direct_argument_structure "$ARGUMENT_OUT"
+argument_fallback="$(count_native_array_allocs "$ARGUMENT_FALLBACK_OUT")"
+if [ "$argument_fallback" -ne 0 ]; then
+  echo "[gc-heap-accounting] FAIL: generic argument boundary emitted $argument_fallback native literals" >&2
+  exit 1
+fi
+ARGUMENT_REPORT="$(VIBE_MEM=1 "$RUNNER" "$ARGUMENT_OUT" 2>&1 >/dev/null)" || {
+  printf '%s\n' "$ARGUMENT_REPORT" >&2
+  echo "[gc-heap-accounting] FAIL: direct-argument fixture trapped under heap accounting" >&2
+  exit 1
+}
+ARGUMENT_ALLOCATED="$(printf '%s\n' "$ARGUMENT_REPORT" | sed -n 's/.*allocated=\([0-9][0-9]*\).*/\1/p' | head -1)"
+case "$ARGUMENT_ALLOCATED" in
+  ''|*[!0-9]*)
+    echo "[gc-heap-accounting] FAIL: missing direct-argument numeric vibe::mem allocated field" >&2
+    exit 1
+    ;;
+esac
+if [ "$ARGUMENT_ALLOCATED" -gt 4096 ]; then
+  echo "[gc-heap-accounting] FAIL: direct-argument allocated=$ARGUMENT_ALLOCATED, expected <=4096" >&2
+  exit 1
+fi
+echo "[gc-heap-accounting] ok: direct Array[Int] ABI, isolated argument identity, local alias identity, and fail-closed component fallbacks"
 
 REPORT="$(VIBE_MEM=1 "$RUNNER" "$OUT" 2>&1 >/dev/null)" || {
   printf '%s\n' "$REPORT" >&2

--- a/scripts/tests/coverage_drivers_test.sh
+++ b/scripts/tests/coverage_drivers_test.sh
@@ -36,6 +36,14 @@ if grep -q 'merged_nodce' scripts/coverage_drivers.sh; then
   echo "coverage_drivers_test: legacy merged_nodce base reintroduced" >&2
   exit 1
 fi
+if grep -Eq 'VIBE_COV_FLAT|cat .*FLAT' scripts/coverage_driver.sh scripts/coverage_unittests.sh; then
+  echo "coverage_drivers_test: legacy raw flat concatenation remains" >&2
+  exit 1
+fi
+grep -q 'VIBE_COV_DRIVER_FILTER=driver' scripts/coverage_driver.sh || {
+  echo "coverage_drivers_test: singular compatibility wrapper does not select driver" >&2
+  exit 1
+}
 
 # A sidecar diagnostic is deterministic: one attempt and a nonzero status.
 deterministic_attempts=0

--- a/scripts/tests/coverage_singular_pipeline_test.sh
+++ b/scripts/tests/coverage_singular_pipeline_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Executable isolated capped corpus -> singular filtered driver -> checked merge.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+OUT="$ROOT/_build/coverage/singular-pipeline-attestation"
+rm -rf "$OUT"
+VIBE_COV_DIR="$OUT" VIBE_COV_MAX=1 bash scripts/coverage_corpus.sh fixtures/hello.vibe
+before="$(VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 source scripts/coverage_drivers.sh; COMPILER_COV="$OUT/compiler_cov.wasm"; coverage_driver_stat "$OUT/acc.json")"
+VIBE_COV_DIR="$OUT" bash scripts/coverage_driver.sh
+after="$(VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 source scripts/coverage_drivers.sh; COMPILER_COV="$OUT/compiler_cov.wasm"; coverage_driver_stat "$OUT/acc.json")"
+read -r before_hit before_total <<<"$before"
+read -r after_hit after_total <<<"$after"
+[ "$before_total" -gt 0 ]
+[ "$after_total" -eq "$before_total" ]
+[ "$after_hit" -ge "$before_hit" ]
+[ -s _build/coverage/drivers/driver/src.vibe ]
+[ -s _build/coverage/drivers/driver/m.wasm ]
+[ -s _build/coverage/drivers/driver/cov.json ]
+echo "coverage_singular_pipeline_test: ok ($before_hit -> $after_hit/$after_total)"


### PR DESCRIPTION
## Summary

- retire the singular coverage raw-concat path and migrate root unit coverage to exact-path exposure, with real capped corpus → filtered driver → checked monotonic merge attestation
- support exactly direct recognized suspended `while` conditions with exact-once CPS normalization
- characterize the private concrete `Array[Int]` direct argument boundary with decoded direct-call/native/fallback/heap assertions
- add a Bool-only opt-in in-memory artifact-v2 freshness validator against current `ModuleJob` inputs

Umbrella issues #1536, #1541, #1550, and #1633 remain open for their documented broader residuals.

## Validation

- independent verifier ACCEPT for all four lanes
- real capped singular coverage pipeline: `9792 -> 9871/26467`, stable denominator and checked merge
- coverage driver and pipeline contract tests
- wasm-gc heap-accounting gate, decoded direct-call assertion, validation and execution
- focused artifact-v2 compile + `_start`, formatter, freshness, and selfcompile KPI
- `pkf run test-local` in worker lanes (218/224 affected selections)
- combined `compiler_gate.sh --phase 3a` passed all target and subsequent feature gates through phase 91; stopped at the known macOS phase-92 `xargs: command line cannot be assembled, too long`
- content-exact clean reconstruction and generated freshness
