### PR TITLE
Expose honest String byte APIs and document Char alias semantics

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -60,7 +60,7 @@ let s: String = "hello \{x}"   // interpolation with \{expr}
                                // タプル/配列はまだ生ポインタの10進数 (#1392)
                                // prelude の `to_string(v)` も同じ描画になる
                                // (補間と同じ書き換えを call site で受ける)
-let c: Char = 'A'              // char code (Int alias)
+let c: Char = 'A'              // byte value 65; Char is a transparent Int alias
 let b: Bool = true
 let u: Unit = ()
 ```
@@ -1197,7 +1197,11 @@ vibe test dir/            # run all tests in directory (examples run too)
 
 ## Key Builtins
 
-**String**: `String::length`, `concat`, `substring`, `contains`, `index_of`, `split`, `trim`, `replace`, `starts_with`, `ends_with`, `join`
+**String**: byte string (`length`/indexes/slices use byte counts and offsets;
+iteration yields byte-valued `Int`). `String::length`, `byte_at`, `from_byte`,
+`concat`, `substring`, `contains`, `index_of`, `split`, `trim`, `replace`,
+`starts_with`, `ends_with`, `join`. Unicode code-point/grapheme operations are
+not part of this API.
 
 **Array**: `Array::length`, `get`, `slice`, `map`, `filter`, `fold`, `find`, `any`, `all`, `reverse`, `concat`
 
@@ -1256,7 +1260,7 @@ Profiler::heap_bytes()  // with Profiler - current bump-heap pointer
                         // way now_us deltas attribute time (heap never shrinks)
 ```
 
-**Conversion**: `Int::to_string`, `Int::to_double`, `Double::to_int`, `String::from_char_code`, `Int::parse(s) -> Option[Int]` (10 進、先頭 `-` 可; 空文字列・非数字・`Int::max_value` 超えは `None`), `Double::parse(s) -> Option[Double]` (符号・整数部・小数点付き小数部; 指数表記 `1e10` は非対応。linear backend のみ、gc backend は未対応)
+**Conversion**: `Int::to_string`, `Int::to_double`, `Double::to_int`, `String::from_byte`, `Int::parse(s) -> Option[Int]` (10 進、先頭 `-` 可; 空文字列・非数字・`Int::max_value` 超えは `None`), `Double::parse(s) -> Option[Double]` (符号・整数部・小数点付き小数部; 指数表記 `1e10` は非対応。linear backend のみ、gc backend は未対応)
 
 ## Idioms
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -108,8 +108,14 @@ Rules:
 - Decimal literals without `f` are `Double`; decimal literals with `f` are
   `Float`.
 - Strings support escapes and interpolation with `\{Expr}`. The former
-  `\(Expr)` spelling was removed in 0.3.0 and is now a lex error.
-- `Char` is represented as an integer character code.
+  `\(Expr)` spelling was removed in 0.3.0 and is now a lex error. A `String`
+  is a byte string: `String::length`, indexes, slices, and iteration use byte
+  counts/offsets, and iteration yields byte-valued `Int`s. Use
+  `String::byte_at` and `String::from_byte` for single-byte operations;
+  Unicode code-point or grapheme semantics are not implied.
+- `Char` is a transparent `Int` alias used as a readability hint. A character
+  literal such as `'A'` is numeric literal syntax (the byte value `65`), not a
+  distinct Unicode-scalar type; `Char` and `Int` unify without conversion.
 
 ## Program Structure
 

--- a/fixtures/string_byte_alias_shadow_test.vibe
+++ b/fixtures/string_byte_alias_shadow_test.vibe
@@ -1,0 +1,13 @@
+//# String byte API aliases preserve ordinary builtin shadowing.
+
+let String::byte_at = (_s: String, i: Int) -> Int {
+  700 + i
+}
+let String::from_byte = (_code: Int) -> String {
+  "shadowed"
+}
+
+test "String byte aliases do not override source bindings" {
+  assert(String::byte_at("A", 3) == 703)
+  assert(String::from_byte(65) == "shadowed")
+}

--- a/fixtures/string_byte_semantics_test.vibe
+++ b/fixtures/string_byte_semantics_test.vibe
@@ -1,0 +1,29 @@
+//# String byte semantics (ADR-0098)
+
+test "String length, indexing, and iteration use bytes" {
+  let s = "é"
+  assert(String::length(s) == 2)
+  assert(String::byte_at(s, 0) == 0xC3)
+  assert(String::byte_at(s, 1) == 0xA9)
+  assert(String::byte_at(s, 0) == String::char_code_at(s, 0))
+  assert(String::byte_at(s, 1) == String::char_code_at(s, 1))
+  let bytes = for b in s {
+    b
+  }
+  assert(Array::length(bytes) == 2)
+  assert(Array::get(bytes, 0) == 0xC3)
+  assert(Array::get(bytes, 1) == 0xA9)
+}
+
+test "canonical byte constructors preserve the legacy operation" {
+  assert(String::from_byte(0x41) == "A")
+  assert(String::from_byte(0xC3) == String::from_char_code(0xC3))
+}
+
+test "Char is a transparent Int alias" {
+  let c: Char = 65
+  let i: Int = 'A'
+  assert(c == 'A')
+  assert(i == 65)
+  assert('A' == 65)
+}

--- a/lib/@vibe/compiler/builtins/declarations.vibe
+++ b/lib/@vibe/compiler/builtins/declarations.vibe
@@ -81,6 +81,7 @@ declare String::length(String) -> Int
 declare String::utf8_length(String) -> Int
 declare String::utf16_length(String) -> Int
 declare String::unicode_length(String) -> Int
+declare String::byte_at(String, Int) -> Int
 declare String::char_code_at(String, Int) -> Int
 declare String::substring(String, Int, Int) -> String
 declare String::concat(String, String) -> String
@@ -99,6 +100,7 @@ declare String::replace(String, String, String) -> String
 declare String::replace_all(String, String, String) -> String
 declare String::to_upper(String) -> String
 declare String::to_lower(String) -> String
+declare String::from_byte(Int) -> String
 declare String::from_char_code(Int) -> String
 declare String::join(Array[String], String) -> String
 

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -8,6 +8,7 @@ import @vibe/compiler/core {
   TypeDef,
   TypeEnv,
   TypeExpr,
+  canonical_builtin_name,
   env_bind,
   env_lookup,
   exception_effect_kind,
@@ -2122,7 +2123,7 @@ fn direct_builtin_return(name: String) -> Option[Type] {
 fn direct_call_return(env: TypeEnv, name: String) -> Option[Type] {
   match env_lookup(env, name) {
     Some(_) => None,
-    None => direct_builtin_return(name)
+    None => direct_builtin_return(canonical_builtin_name(name))
   }
 }
 
@@ -2239,6 +2240,7 @@ fn builtin_arg_head_rest(name: String, i: Int) -> Int {
 /// arity is certain are listed; anything variadic-ish or unsure stays -1.
 /// `Bytes::new` is handled separately (0 or 1 capacity arg).
 fn builtin_fixed_arity(name: String) -> Int {
+  let name = canonical_builtin_name(name)
   if name == "Array::length" || name == "Array::reverse" || name == "String::length" || name == "String::trim" || name == "String::to_lower" || name == "String::to_upper" || name == "String::from_char_code" || name == "String::iter_length" || name == "Bytes::length" || name == "Bytes::to_array" || name == "Bytes::from_array" || name == "Map::keys" || name == "Map::iter_length" || name == "Char::to_int" || name == "Char::from_int" || name == "Double::to_int" || name == "Double::from_i64_bits" || name == "Int::to_double" || name == "not" || name == "print" || name == "println" || name == "assert" || name == "assert_true" || name == "__to_string" || name == "FixedArray::length" || name == "Int64Array::length" {
     1
   } else if name == "Array::get" || name == "Array::push" || name == "Array::push_all" || name == "Array::truncate" || name == "Array::concat" || name == "Array::contains" || name == "Array::any" || name == "Array::all" || name == "Array::find" || name == "Array::filter" || name == "Array::join" || name == "Array::foreach" || name == "String::equals" || name == "String::concat" || name == "String::char_code_at" || name == "String::index_of" || name == "String::last_index_of" || name == "String::contains" || name == "String::starts_with" || name == "String::ends_with" || name == "String::split" || name == "String::join" || name == "String::iter_get" || name == "Bytes::get" || name == "Bytes::push" || name == "Bytes::append" || name == "Bytes::concat" || name == "Map::has_key" || name == "map_has" || name == "MapBuilder::has_key" || name == "MapBuilder::get" || name == "eq" || name == "assert_eq" || name == "FixedArray::get" || name == "FixedArray::make" || name == "Int64Array::get" || name == "Int64Array::make" {
@@ -2279,15 +2281,16 @@ fn builtin_fixed_arity(name: String) -> Int {
 /// A registry parameter typed `CtUnknown` maps to head 0 = tolerate, which is
 /// how `assert_eq` and friends stay unchecked.
 fn builtin_param_head(name: String, i: Int) -> Int {
+  let normalized = canonical_builtin_name(name)
   let hand = if i == 0 {
-    builtin_first_arg_head(name)
+    builtin_first_arg_head(normalized)
   } else {
-    builtin_arg_head_rest(name, i)
+    builtin_arg_head_rest(normalized, i)
   }
   if hand != 0 {
     hand
   } else {
-    match registry_builtin_param_type(name, i) {
+    match registry_builtin_param_type(normalized, i) {
       Some(t) => head_fold_char(head_kind(t)),
       None => 0
     }

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1153,7 +1153,16 @@ fn http_client_surface_to_raw(name: String) -> String {
 
 fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, ce: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception {
   if is_eident(callee) {
-    let fname00 = canonical_builtin_name(get_eident_name(callee))
+    let source_name = get_eident_name(callee)
+    // Builtin aliases are source-compatible fallbacks, not reserved names.
+    // Preserve the same shadowing rule as the checker: resolve the original
+    // spelling first, and canonicalize only when no function/local binds it.
+    let source_is_bound = func_table_index_of(ctx.func_table, source_name) >= 0 || array_contains_str(local_names, source_name)
+    let fname00 = if source_is_bound {
+      source_name
+    } else {
+      canonical_builtin_name(source_name)
+    }
     // #1508 second barrier: the five CLIENT-side `Http::*` builtins are
     // checker-legal as direct spellings (checker/builtins_net.vibe), but only
     // the raw dunder names lib/@vibe/http calls internally (#794) had codegen

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -48,6 +48,7 @@ import @vibe/compiler/codegen/common_base {
   expr_tag,
   find_func_stmt,
   find_local_slot,
+  func_table_index_of,
   is_eident,
   resolve_func,
   resolve_local,
@@ -368,7 +369,15 @@ fn gc_compile_native_array_ref(buf: Bytes, expr: Expr, local_names: Array[String
 
 fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, ce: (Bytes, Expr, Array[String], Int, Int) -> Int with Exception) -> Int with Exception {
   match callee {
-    EIdent(fname, _) => {
+    EIdent(source_name, _) => {
+      // Match checker/linear shadowing: an alias spelling is a builtin only
+      // when the original source name has no function or local binding.
+      let source_is_bound = func_table_index_of(ctx.func_table, source_name) >= 0 || find_local_slot(local_names, source_name) >= 0
+      let fname = if source_is_bound {
+        source_name
+      } else {
+        canonical_builtin_name(source_name)
+      }
       let native_slot = gc_native_array_receiver_slot(args, local_names, ctx)
       let native_receiver = Array::length(args) > 0 && (native_slot >= 0 || gc_expr_is_native_array_ref(Array::get(args, 0), local_names, ctx))
       if native_receiver && fname == "Array::length" && Array::length(args) == 1 {

--- a/lib/@vibe/compiler/core/builtin_name.vibe
+++ b/lib/@vibe/compiler/core/builtin_name.vibe
@@ -24,6 +24,10 @@ export fn canonical_builtin_name(name: String) -> String {
     "Env::ArgsGet" => "Env::args_get",
     "Profiler::NowUs" => "Profiler::now_us",
     "Profiler::HeapBytes" => "Profiler::heap_bytes",
+    // ADR-0098 Phase 1: expose names that state the runtime's byte semantics
+    // honestly while retaining the legacy spellings for source compatibility.
+    "String::byte_at" => "String::char_code_at",
+    "String::from_byte" => "String::from_char_code",
     _ => name
   }
 }

--- a/lib/@vibe/compiler/tests/builtin_name_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_name_test.vibe
@@ -29,7 +29,9 @@ test "canonical_builtin_name normalizes every legacy alias" {
     ("Env::ArgsLen", "Env::args_len"),
     ("Env::ArgsGet", "Env::args_get"),
     ("Profiler::NowUs", "Profiler::now_us"),
-    ("Profiler::HeapBytes", "Profiler::heap_bytes")
+    ("Profiler::HeapBytes", "Profiler::heap_bytes"),
+    ("String::byte_at", "String::char_code_at"),
+    ("String::from_byte", "String::from_char_code")
   ]
   let mut i = 0
   while i < Array::length(aliases) {

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4474,6 +4474,8 @@ if ! VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_BACKEND=gc \
   bash scripts/vibe_test.sh \
     fixtures/eq_structural_aggregates_test.vibe \
     fixtures/map_builder_growth_test.vibe \
+    fixtures/string_byte_alias_shadow_test.vibe \
+    fixtures/string_byte_semantics_test.vibe \
     fixtures/struct_field_collision_test.vibe \
     fixtures/to_string_shadow_gc_test.vibe; then
   echo "[compiler-gate] FAIL: wasm-gc test-block runtime regression suite" >&2


### PR DESCRIPTION
## Summary

- add canonical `String::byte_at` and `String::from_byte` spellings backed by the existing byte operations
- preserve ordinary top-level/import/local/closure shadowing before builtin alias canonicalization on linear and wasm-gc
- document String byte offsets/iteration and transparent `Char`/`Int` semantics
- add non-ASCII byte behavior and shadowing regressions on both backends

Legacy String names remain accepted. Unicode APIs, nominal Char, warnings/removals, and seed bump remain out of scope for this Phase 1 slice.

## Validation

- independent final verifier: ACCEPT
- fresh seed → stage1 → stage2 → stage3; `stage2 == stage3`
- linear: 3 files / 5 tests passed
- wasm-gc: both new fixtures passed
- shadowing fixture rerun after formatter on linear and wasm-gc
- `pkf run test-local`: 405/565 affected tests passed in worker lane
- formatter fixpoint and generated freshness passed
