### PR TITLE
fix(cov): cov_helpers の parse_int_or を名指しし、entry file への裸参照を検査で塞ぐ (#1645 follow-up)

### DIFF
--- a/scripts/coverage/cov_helpers.vibe
+++ b/scripts/coverage/cov_helpers.vibe
@@ -18,6 +18,15 @@ import ../../lib/@vibe/compiler/loader/loader.vibe {
   strip_trailing_cr
 }
 
+// Named explicitly: the entry file's own top-level names are the only ones the
+// production merge leaves unrenamed, so a BARE call would bind here by accident
+// rather than by request. (A second, unrelated `parse_int_or` lives in
+// coverage_suite_lib.vibe -- that one is outside the compiler closure, so it is
+// not the function this driver can measure.)
+import ../../lib/@vibe/compiler/cli_adapter.vibe {
+  parse_int_or
+}
+
 import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe {
   comp_valtype_f32,
   comp_valtype_f64,
@@ -32,7 +41,8 @@ import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen
 // Drive each directly across its full input partition:
 //   - comp_valtype_to_core: every valtype constant + an unknown (5 arms)
 //   - strip_trailing_cr: CR-terminated / plain / empty
-//   - parse_int_or: positive / negative / empty / non-digit / trailing-junk
+//   - parse_int_or: positive / empty / leading-'-' / non-digit / trailing-junk
+//     (this copy takes no sign, so "-45" lands in the non-digit arm)
 let cov_h_valtype: () -> Int = () -> {
   let mut acc = 0
   acc = acc + comp_valtype_to_core(comp_valtype_s64)

--- a/scripts/tests/coverage_drivers_test.sh
+++ b/scripts/tests/coverage_drivers_test.sh
@@ -47,26 +47,40 @@ for line in open(entry_path, encoding="utf-8"):
     if m:
         entry_names.add(m.group(1))
 
+def accidental_entry_refs(src):
+    imported = set()
+    for m in re.finditer(r'^import [^\{]*\{([^\}]*)\}', src, re.M):
+        for item in m.group(1).split(","):
+            parts = item.split()
+            if parts:
+                # `import p { original as alias }` binds only `alias`.
+                imported.add(parts[2] if len(parts) == 3 and parts[1] == "as" else parts[0])
+    body = re.sub(r'^import [^\{]*\{[^\}]*\}', '', src, flags=re.M)
+    body = re.sub(r'//[^\n]*', '', body)
+    body = re.sub(r'"(?:\\.|[^"\\])*"', '""', body)
+    local = set(re.findall(r'\b(?:let|fn)\s+(?:rec\s+|mut\s+)?([A-Za-z_][A-Za-z0-9_]*)', body))
+    referenced = {
+        name for name in entry_names
+        if re.search(rf'(?<![:.\w]){re.escape(name)}(?!\w)', body)
+    }
+    return sorted(referenced - imported - local)
+
+# Regression for both review-sensitive cases: an aliased import does not bind
+# the original spelling, and a higher-order value reference is still a binding.
+assert "parse_int_or" in entry_names
+alias_import = "import ./entry.vibe { parse_int_or as cov_parse_int }\n"
+assert accidental_entry_refs(alias_import + "let callback = parse_int_or\n") == ["parse_int_or"]
+assert accidental_entry_refs(alias_import + "let callback = cov_parse_int\n") == []
+assert accidental_entry_refs("import ./entry.vibe { parse_int_or }\nlet callback = parse_int_or\n") == []
+
 bad = []
 for row in sys.argv[1].splitlines():
     if not row.strip():
         continue
     _entry, path, label = row.split()
     src = open(path, encoding="utf-8").read()
-    imported = set()
-    for m in re.finditer(r'^import [^\{]*\{([^\}]*)\}', src, re.M):
-        for item in m.group(1).split(","):
-            parts = item.split()
-            if parts:
-                imported.add(parts[0])
-                if len(parts) == 3:
-                    imported.add(parts[2])
-    body = re.sub(r'^import [^\{]*\{[^\}]*\}', '', src, flags=re.M)
-    body = re.sub(r'//[^\n]*', '', body)
-    local = set(re.findall(r'\b(?:let|fn)\s+(?:rec\s+|mut\s+)?([A-Za-z_][A-Za-z0-9_]*)', body))
-    for name in sorted(set(re.findall(r'(?<![:.\w])([A-Za-z_][A-Za-z0-9_]*)\s*\(', body))):
-        if name in entry_names and name not in imported and name not in local:
-            bad.append(f"{label} ({path}): bare `{name}` binds to {entry_path}'s copy; import it explicitly")
+    for name in accidental_entry_refs(src):
+        bad.append(f"{label} ({path}): bare `{name}` binds to {entry_path}'s copy; import it explicitly")
 for line in bad:
     print("coverage_drivers_test: " + line, file=sys.stderr)
 sys.exit(1 if bad else 0)

--- a/scripts/tests/coverage_drivers_test.sh
+++ b/scripts/tests/coverage_drivers_test.sh
@@ -30,6 +30,48 @@ while read -r entry file label; do
   }
 done <<< "$driver_rows"
 
+# The one way a driver can still bind a compiler value WITHOUT asking for it:
+# the production merge leaves the ENTRY file's own top-level names unrenamed
+# (`transformed_file_stmts` returns the entry's statements as-is), so a bare
+# call in a driver silently resolves to cli_adapter.vibe's copy. That is how
+# `parse_int_or` -- which also exists, differently, in coverage_suite_lib.vibe
+# -- was measured without anyone naming it. Every such reference must be an
+# explicit import, so the driver says which copy it measures.
+python3 - "$driver_rows" <<'PY' || exit 1
+import re, sys
+
+entry_path = "lib/@vibe/compiler/cli_adapter.vibe"
+entry_names = set()
+for line in open(entry_path, encoding="utf-8"):
+    m = re.match(r'(?:export\s+)?(?:fn|let\s+rec|let\s+mut|let)\s+([A-Za-z_][A-Za-z0-9_]*)', line)
+    if m:
+        entry_names.add(m.group(1))
+
+bad = []
+for row in sys.argv[1].splitlines():
+    if not row.strip():
+        continue
+    _entry, path, label = row.split()
+    src = open(path, encoding="utf-8").read()
+    imported = set()
+    for m in re.finditer(r'^import [^\{]*\{([^\}]*)\}', src, re.M):
+        for item in m.group(1).split(","):
+            parts = item.split()
+            if parts:
+                imported.add(parts[0])
+                if len(parts) == 3:
+                    imported.add(parts[2])
+    body = re.sub(r'^import [^\{]*\{[^\}]*\}', '', src, flags=re.M)
+    body = re.sub(r'//[^\n]*', '', body)
+    local = set(re.findall(r'\b(?:let|fn)\s+(?:rec\s+|mut\s+)?([A-Za-z_][A-Za-z0-9_]*)', body))
+    for name in sorted(set(re.findall(r'(?<![:.\w])([A-Za-z_][A-Za-z0-9_]*)\s*\(', body))):
+        if name in entry_names and name not in imported and name not in local:
+            bad.append(f"{label} ({path}): bare `{name}` binds to {entry_path}'s copy; import it explicitly")
+for line in bad:
+    print("coverage_drivers_test: " + line, file=sys.stderr)
+sys.exit(1 if bad else 0)
+PY
+
 # The raw-concatenation lane and its truncated walk are gone; nothing may bring
 # a `merged_nodce` base back without also revisiting this test.
 if grep -q 'merged_nodce' scripts/coverage_drivers.sh; then


### PR DESCRIPTION
[#1645](https://github.com/mizchi/vibe-lang/pull/1645) が **`3c47c73` の時点でマージされた**ため、その後に push した Codex レビュー対応 (P1) が main に入っていない。同じ変更を新しい PR として出し直す。

対象の指摘: [#1645 の review thread](https://github.com/mizchi/vibe-lang/pull/1645#discussion_r3766548019)。

## 何が残っているか

`cov_helpers` が `parse_int_or` を**裸で呼んでいる**。exact-path exposure に載せる移行 (#1633) の中で `parse_int_unwrap` → `parse_int_or` に差し替えたときに import を足し忘れたもので、コンパイルも実行も通ってしまう。

通ってしまう理由がこの PR の本題: **production merge は entry file の top-level 名だけ rename しない** (`transformed_file_stmts` は `path == entry_path` のとき stmts をそのまま返す)。したがって driver の裸参照は `cli_adapter.vibe` のコピーへ事故で束縛される。移行が消したはずの「誰も名指ししていないコピーを測る」状態が 1 箇所だけ残っていた。

どちらのコピーに束縛されていたかは確定できる。もう一方の定義 (`coverage_suite_lib.vibe`、先頭 `-` を受け付ける 32 行版) は exposure resolver が閉包外として拒否する:

```
coverage driver scripts/coverage/cov_helpers.vibe import
  ../../lib/@vibe/compiler/coverage_suite_lib.vibe { parse_int_or } rejected:
  target exists but is outside the collected compiler closure
```

つまり測っていたのは `cli_adapter.vibe` 側 (24 行・符号を扱わない)。

## 変更

- `import ../../lib/@vibe/compiler/cli_adapter.vibe { parse_int_or }` を明示。閉包内に居るのはこのコピーだけなので、測定対象としてはこれが正しい
- driver のコメントを実態に合わせた。この実装は先頭 `-` を受け付けないので、`"-45"` は「負数のアーム」ではなく **non-digit アーム**に落ちる（移行前の綴りの説明をそのまま引き継いでいた）
- `scripts/tests/coverage_drivers_test.sh` に検査を追加: `cli_adapter.vibe` の top-level 名を集め、driver 側で import も局所定義もされていない呼び出しがあれば名前付きで落とす。「import が 1 本でもあれば通る」という既存の検査では、まさにこの抜けを捕まえられなかった

## 検証

- `scripts/tests/coverage_drivers_test.sh` → ok (現在の main の追加検査と併存)
- 新しい import を外した負の確認:
  ```
  coverage_drivers_test: helpers (scripts/coverage/cov_helpers.vibe): bare `parse_int_or`
    binds to lib/@vibe/compiler/cli_adapter.vibe's copy; import it explicitly
  ```
- `cov_helpers` を現在の main 上で再ビルドした instrumented compiler で expose → compile → run: **ok** (src 327,212 B / cov 154,804 B)
- 登録済み 39 本すべてに検査を掛けて、他に該当する裸参照は無し

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_