### PR TITLE
Correct retired Error effect spelling documentation

### DIFF
--- a/docs/exception-effect.md
+++ b/docs/exception-effect.md
@@ -8,13 +8,14 @@ Related: #1218, #1136, #1344, ADR-0016(`handle`/`throw`), ADR-0050(generic effec
 handler), ADR-0071(effectset), ADR-0073(checked `Error`), ADR-0084(effect
 taxonomy)。
 
-> **綴りの追記 (#1461, 2026-08-06):** この文書は当時の綴りのまま `with Error`
-> / `handle .. with Error` を書いている箇所がある。その後 #1461 が **effect
-> row 上の `Error` を退役させた** ので、下記の「compatibility alias」はもう
-> alias ではなく **parse error** である。row を書く場所では読み替えて
-> `with Exception` を使うこと (`vibe fmt` が旧綴りを書き換える)。ハンドラ側の
-> `handle .. with Error` と operation 修飾子 `perform Error::Throw` は row 項目
-> ではないので、この退役の対象外で今も通る。
+> **綴りの追記 (#1461 / #1501, 2026-08-06):** この文書は当時の綴りのまま
+> `with Error` / `handle .. with Error` を書いている箇所がある。その後 #1461 と
+> #1501 が effect row とハンドラ名の `Error` を退役させたので、下記の
+> 「compatibility alias」は現在の surface では **parse error** である。どちらの
+> 位置でも `Exception` を使うこと (`vibe fmt` が旧綴りを書き換える)。operation
+> 修飾子 `perform Error::Throw` だけは row やハンドラ名ではないため、古い生成物を
+> 読む内部互換として今も受理する。新しいソースでは `perform Exception::Throw` を
+> 使う。
 >
 > **実装状況 (2026-08-02, #1344):** typed `Exception[E]` の row は
 > **checker に入った**。`throw(v)` は `Exception[typeof(v)]` を要求し、

--- a/docs/tutorial/05_effects.vibe.md
+++ b/docs/tutorial/05_effects.vibe.md
@@ -7,11 +7,11 @@ vibe は**純粋がデフォルト**。副作用は型の `with ...` 行 (effect
 
 ## Exception 境界 — perform / handle
 
-`Exception` は現在、既存の `Error` と同じ Wasm tag を使う、型引数なしの
-**非再開 (abortive) エフェクト別名**である。`perform Exception::Throw` は継続を
+型引数なしの `Exception` は erased な **非再開 (abortive) エフェクト**で、
+typed `Exception[E]` のどの kind とも互換である。`perform Exception::Throw` は継続を
 再開せず、handler arm で `resume` は使えない。その arm の値が `handle` の結果になる。
-この暫定 alias の payload は既存 `Error` と同じ互換的な String/opaque 扱いで、handler を
-またぐ型引数の保存はしない。[ADR-0085](../exception-effect.md) の typed `Exception[E]` ではない。
+erased な handler の payload は String/opaque 扱いで、handler をまたぐ型引数の保存は
+しない。typed exception との使い分けは [ADR-0085](../exception-effect.md) を参照。
 
 ```vibe run
 import @vibe/prelude {
@@ -50,10 +50,24 @@ safe = -1
 fine = 25
 ```
 
-## Error との互換性
+## 旧 `Error` 綴りからの移行
 
-既存の `Error` と `throw("message")` はこの期間も使える互換名である。`Error` と
-`Exception` のどちらの handler も、同じ abortive `Throw` を捕捉できる。
+`Error` は effect row (`with Error`) とハンドラ名
+(`handle { ... } with Error { ... }`) のどちらでも parse error になる。旧ソースは
+`vibe fmt` で `Exception` へ書き換えられる。`throw("message")` は引き続き使える。
+
+operation 修飾子の `perform Error::Throw(...)` だけは古い生成物を読む内部互換として
+受理されるが、新しいソースでは `perform Exception::Throw(...)` を使う。
+
+拒否される旧綴りの例 (実行例ではなく、移行説明のため `skip`):
+
+```vibe skip
+// Rejected source (kept in comments so `vibe fmt` does not rewrite the example):
+// fn old_row() -> Int with Error { throw("old") }
+// fn old_handler() -> Int {
+//   handle { 1 } with Error { Throw(_) => 0 }
+// }
+```
 
 ## ユーザ定義エフェクト — perform / resume
 


### PR DESCRIPTION
## Summary

- correct stale ADR note: `Error` is rejected in both effect-row and handler-name positions
- correct the effects tutorial’s outdated broad compatibility claim
- retain the precise compatibility boundary for `perform Error::Throw` while recommending canonical `Exception`

No parser or language semantics change.

## Validation

- independent verifier: ACCEPT
- parser smoke: 14 tests passed
- tutorial formatting: 4 blocks passed
- generated freshness and diff checks passed
- full local tutorial execution was not demonstrated because the seed path hits pre-existing prelude contract violations; CI provides the repository gate
