### PR TITLE
incremental: bind module artifact freshness to exact bytes

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -114,10 +114,14 @@ checking. Ordinary `check_module` makes no artifact construction attempt;
 diagnosed opt-in checks also make none; successful opt-in checks make exactly
 one. An explicit in-memory validator can compare retained v2 bytes with one
 current `ModuleJob.path/source/dep_envs`. It recomputes both identities from the
-already-ingested source, requires ordered dependency assumptions and exactly the
-singleton owner closure, and returns only `Bool`; v1, malformed, stale, or wider
-closure inputs fail closed. Ordinary checks never enter this validator. Its
-attempt counter is test observation, not production telemetry.
+already-ingested source and requires ordered dependency assumptions plus exactly
+the singleton owner closure. Success returns an opaque freshness attestation
+bound to the exact retained bytes; its snapshot accessor returns those bytes
+without decoding or re-encoding. Only an opaque successful `ModuleOutcome` can
+mint it—decoded or manually authored bytes cannot. V1, malformed, stale, missing,
+diagnosed, or wider-closure inputs return `None`. The legacy `Bool` observation
+is only a wrapper over this attestation path. Ordinary checks never enter this
+validator. Its attempt counter is test observation, not production telemetry.
 
 The aggregate and its complete-encoding fingerprint are shadow comparison data
 only. They are not wired to TypeDb, the TypeEnv v5 transport and persistent cache

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -286,6 +286,9 @@ struct ModuleJob {
 // outside the package inspects it yet. Phase 2's driver will need either
 // accessors or a real variant declaration here.
 opaque type ModuleOutcome
+// Proof of exact v2-byte freshness is likewise opaque: only the runtime's
+// successful ModuleOutcome validator can mint it; decoders/manual bytes cannot.
+opaque type CheckedModuleTypingArtifactFreshnessAttestation
 fn check_module(job: ModuleJob) -> ModuleOutcome with Exception
 fn check_module_with_typing_artifact_observation(job: ModuleJob) -> ModuleOutcome with Exception
 // Test-only observation of post-success construction attempts.
@@ -297,6 +300,8 @@ fn reset_checked_module_typing_artifact_validation_attempt_count() -> Unit
 // genuinely successful ModuleOutcome. Diagnosed outcomes return None. This is
 // in-memory observation only: no cache lookup, planner, persistence, or reuse.
 fn checked_module_typing_artifact_observation(outcome: ModuleOutcome) -> Option[String]
+fn checked_module_typing_artifact_freshness_attestation_for_job(job: ModuleJob, outcome: ModuleOutcome) -> Option[CheckedModuleTypingArtifactFreshnessAttestation] with Exception
+fn checked_module_typing_artifact_freshness_attestation_snapshot(attestation: CheckedModuleTypingArtifactFreshnessAttestation) -> String
 fn checked_module_typing_artifact_observation_is_fresh_for_job(job: ModuleJob, outcome: ModuleOutcome) -> Bool with Exception
 // #906 Phase 2: the worker transport entry. `dir` is a job directory and
 // is the worker's ENTIRE filesystem sandbox -- see typecheck_fs.vibe for

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3275,6 +3275,14 @@ export enum ModuleOutcome {
   Diagnosed(String, Array[String])
 }
 
+/// Opaque proof that the exact retained v2 bytes in one successful
+/// ModuleOutcome matched one current, already-ingested ModuleJob. The package
+/// contract hides this constructor: decoded or caller-authored bytes cannot
+/// create an attestation.
+export enum CheckedModuleTypingArtifactFreshnessAttestation {
+  AttestedCheckedModuleTypingArtifact(String)
+}
+
 fn checked_module_dependency_interface_assumptions(dep_envs: Array[(String, TypeEnv)]) -> Array[(String, String)] with Exception {
   let assumptions = array_empty()
   let mut i = 0
@@ -3344,15 +3352,37 @@ export fn checked_module_typing_artifact_observation(outcome: ModuleOutcome) -> 
   }
 }
 
-/// Explicit in-memory freshness observation for one retained successful
-/// outcome against one current, already-ingested ModuleJob. This returns only
-/// Bool and does not publish, persist, plan, or reuse the decoded artifact.
-export fn checked_module_typing_artifact_observation_is_fresh_for_job(job: ModuleJob, outcome: ModuleOutcome) -> Bool with Exception {
+/// Validate one opaque successful outcome against one current, already-ingested
+/// ModuleJob and bind the authority to the exact retained bytes. Validation is
+/// strict v2 decoding plus exact owner, source, implementation, dependency, and
+/// singleton-closure matching. Missing, malformed, stale, or diagnosed inputs
+/// return None. Nothing is published, persisted, planned, cached, or reused.
+export fn checked_module_typing_artifact_freshness_attestation_for_job(job: ModuleJob, outcome: ModuleOutcome) -> Option[CheckedModuleTypingArtifactFreshnessAttestation] with Exception {
   Array::set(checked_module_typing_artifact_validation_attempts, 0, Array::get(checked_module_typing_artifact_validation_attempts, 0) + 1)
   match outcome {
-    Checked(_, _, _, _, _, _, Some(bytes)) => checked_module_typing_artifact_v2_matches_exact_inputs(bytes, job.path, compact_string_fingerprint(job.source), incremental_implementation_identity(job.source), checked_module_dependency_interface_assumptions(job.dep_envs)),
-    Checked(_, _, _, _, _, _, None) => false,
-    Diagnosed(_, _) => false
+    Checked(_, _, _, _, _, _, Some(bytes)) => if checked_module_typing_artifact_v2_matches_exact_inputs(bytes, job.path, compact_string_fingerprint(job.source), incremental_implementation_identity(job.source), checked_module_dependency_interface_assumptions(job.dep_envs)) {
+      Some(AttestedCheckedModuleTypingArtifact(bytes))
+    } else {
+      None
+    },
+    Checked(_, _, _, _, _, _, None) => None,
+    Diagnosed(_, _) => None
+  }
+}
+
+/// Return the exact retained bytes that were validated when the opaque
+/// attestation was minted. This does not decode or re-encode the artifact.
+export fn checked_module_typing_artifact_freshness_attestation_snapshot(attestation: CheckedModuleTypingArtifactFreshnessAttestation) -> String {
+  match attestation {
+    AttestedCheckedModuleTypingArtifact(bytes) => bytes
+  }
+}
+
+/// Compatibility observation over the opaque attestation API.
+export fn checked_module_typing_artifact_observation_is_fresh_for_job(job: ModuleJob, outcome: ModuleOutcome) -> Bool with Exception {
+  match checked_module_typing_artifact_freshness_attestation_for_job(job, outcome) {
+    Some(_) => true,
+    None => false
   }
 }
 

--- a/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_module_typing_artifact_test.vibe
@@ -28,6 +28,8 @@ import @vibe/compiler/runtime {
   check_module,
   check_module_with_typing_artifact_observation,
   checked_module_typing_artifact_construction_attempt_count,
+  checked_module_typing_artifact_freshness_attestation_for_job,
+  checked_module_typing_artifact_freshness_attestation_snapshot,
   checked_module_typing_artifact_observation,
   checked_module_typing_artifact_observation_is_fresh_for_job,
   checked_module_typing_artifact_validation_attempt_count,
@@ -619,23 +621,33 @@ test "v1 canonical bytes remain unchanged after v2 introduction" {
   }
 }
 
-test "opt-in freshness validator accepts only current exact singleton inputs" {
+test "opaque freshness attestation binds current exact singleton inputs and retained bytes" {
   reset_checked_module_typing_artifact_validation_attempt_count()
   let source = "export let api: Int = 1\n"
   let job = mt_module_job("fresh.vibe", source)
   let outcome = check_module_with_typing_artifact_observation(job)
-  assert(checked_module_typing_artifact_observation_is_fresh_for_job(job, outcome))
+  match (checked_module_typing_artifact_observation(outcome), checked_module_typing_artifact_freshness_attestation_for_job(job, outcome)) {
+    (Some(bytes), Some(attestation)) => assert(checked_module_typing_artifact_freshness_attestation_snapshot(attestation) == bytes),
+    _ => assert(false)
+  }
   assert(checked_module_typing_artifact_validation_attempt_count() == 1)
-  // Exact source identity rejects trivia-only changes even when provisional
-  // token identity remains intentionally unchanged.
-  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(mt_module_job("fresh.vibe", "// changed trivia\nexport let api: Int = 1\n"), outcome))
-  // Parser-visible edits, owner changes, v1/malformed bytes, and absent
-  // observations fail closed.
-  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(mt_module_job("fresh.vibe", "export let api: Int = 2\n"), outcome))
-  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(mt_module_job("other.vibe", source), outcome))
-  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(job, check_module(job)))
-  let diagnosed = check_module_with_typing_artifact_observation(mt_module_job("bad.vibe", "export let bad: Int = \"no\"\n"))
-  assert(!checked_module_typing_artifact_observation_is_fresh_for_job(mt_module_job("bad.vibe", "export let bad: Int = \"no\"\n"), diagnosed))
+  // The Bool compatibility API validates through the same opaque path.
+  assert(checked_module_typing_artifact_observation_is_fresh_for_job(job, outcome))
+}
+
+test "opaque freshness attestation fails closed for stale missing and diagnosed outcomes" {
+  let source = "export let api: Int = 1\n"
+  let job = mt_module_job("fresh.vibe", source)
+  let outcome = check_module_with_typing_artifact_observation(job)
+  // Exact source identity rejects trivia-only and parser-visible edits.
+  assert(checked_module_typing_artifact_freshness_attestation_for_job(mt_module_job("fresh.vibe", "// changed trivia\nexport let api: Int = 1\n"), outcome) == None)
+  assert(checked_module_typing_artifact_freshness_attestation_for_job(mt_module_job("fresh.vibe", "export let api: Int = 2\n"), outcome) == None)
+  assert(checked_module_typing_artifact_freshness_attestation_for_job(mt_module_job("other.vibe", source), outcome) == None)
+  // Ordinary checks retain no bytes, and diagnosed outcomes cannot attest.
+  assert(checked_module_typing_artifact_freshness_attestation_for_job(job, check_module(job)) == None)
+  let bad_job = mt_module_job("bad.vibe", "export let bad: Int = \"no\"\n")
+  let diagnosed = check_module_with_typing_artifact_observation(bad_job)
+  assert(checked_module_typing_artifact_freshness_attestation_for_job(bad_job, diagnosed) == None)
 }
 
 test "strict v2 exact-input matcher rejects stale closure dependencies and non-v2 bytes" {


### PR DESCRIPTION
## Summary
- add an opaque in-memory freshness attestation minted only from successful `ModuleOutcome` authority
- bind validation to the exact retained v2 observation bytes and current singleton `ModuleJob` identities
- preserve the legacy Bool query as a wrapper without adding persistence, reuse, planner, cache, or TypeEnv replacement

## Validation
- focused checked-module typing artifact suite: 22/22 passed
- formatter checks passed
- generated freshness passed
- `bit diff --check` passed
- independent review: ACCEPT

## Scope
Bounded #1550 follow-up. This does not complete module/SCC artifact persistence or production reuse, and does not touch #1548 exported-interface fingerprint schemas.

Refs #1550