### PR TITLE
test(async): complete compound suspend review coverage

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2889,8 +2889,11 @@ identifier ではなく、ちゃんと名前が付いて元の位置で読まれ
 pass で拾われる。callee は名前を付けない — by-name call を local binding 経由の呼び出しに
 変えてしまうと、それこそ suspend lowering が see-through できない唯一の形になる。
 
-**必ず評価されるとは限らない位置だけが fail-closed のまま**: `if` / `match` の枝、
-`&&` / `||` の右辺、closure body、nested handle。
+**必ず評価されるとは限らない位置だけがこの ANF では fail-closed のまま**:
+`if` / `match` の枝、`&&` / `||` の右辺。closure literal は
+`scps_prepass_expr` が literal 自身の spine で step-split し、既存の
+nested different-effect handle は handler ownership を保った lowering を使うため、
+この compound ANF が外へ float する対象ではないが blanket reject でもない。
 
 同時に `scps_cellify` の **P0 silent-wrong** を 1 件直した。`EAssignOp` の
 フィールドは `(name, op, value, cont)` だが、この pass の 3 箇所が `(op, name, ..)` と

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -181,7 +181,10 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   `+=` 等の compound assignment — 元の評価順のまま let 連鎖へ線形化する、追記48)
 - **不適格**: ループ内 `return`、配列 `for` 形、**必ず評価されるとは限らない位置に
   埋まった suspension** (`if` / `match` の枝、`&&` / `||` の右辺)、実引数証明が
-  成立しない closure パラメータの呼び出し、row 変数 callee (`with e`)
+  成立しない closure パラメータの呼び出し、row 変数 callee (`with e`)。closure
+  literal は prepass が literal 自身の spine で step-split し、supported nested
+  different-effect handles は既存の handler-ownership lowering を維持するため、
+  compound ANF の blanket rejection には含めない
 
 closure param を**無条件に**許すのは不健全 — closure literal 内の `perform`
 は「リテラルが置かれた関数の row」に字句的に計上されるので (#761)、「宣言

--- a/fixtures/effect_assignment_op_name_collision_test.vibe
+++ b/fixtures/effect_assignment_op_name_collision_test.vibe
@@ -1,0 +1,36 @@
+// #1536 direct compound-assignment RHS: preserve the original operator and
+// evaluate each operation, mutation, and continuation exactly once. User
+// spellings matching the synthetic binder base must remain uncaptured, even
+// when the only occurrence of the first candidate is an EAssignOp target.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let visits = [
+  0
+]
+
+let _start = () -> Int {
+  handle {
+    let mut value = 10
+    let mut __scps_seq_0_assignop = 7
+    let __scps_seq_0_assignop_1 = 11
+    // The first synthetic candidate appears only as this compound-assignment
+    // target inside the expression probed for freshness: there is no ordinary
+    // identifier read here that could mask a target-blind walker.
+    __scps_seq_0_assignop *= perform Ask::Get(0)
+    value *= perform Ask::Get(3)
+    value /= perform Ask::Get(1)
+    value * 10000 + __scps_seq_0_assignop * 100 + __scps_seq_0_assignop_1 * 10 + Array::get(visits, 0)
+  } with Ask {
+    Get(n) => {
+      Array::set(visits, 0, Array::get(visits, 0) + 1)
+      let k = resume
+      k(n + 1)
+    }
+  }
+}
+
+test "direct compound-assignment suspension preserves operators and names" {
+  inspect(_start(), "200813")
+}

--- a/fixtures/effect_assignment_op_rhs_suspend.vibe
+++ b/fixtures/effect_assignment_op_rhs_suspend.vibe
@@ -30,9 +30,7 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{
-  "last": "226"
+test "compound assignment suspension preserves operators" {
+  inspect(_start(), "226")
 }

--- a/fixtures/effect_assignment_rhs_compound_suspend.vibe
+++ b/fixtures/effect_assignment_rhs_compound_suspend.vibe
@@ -29,9 +29,7 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{
-  "last": "1131"
+test "compound assignment RHS preserves evaluation order" {
+  inspect(_start(), "1131")
 }

--- a/fixtures/effect_compound_call_arg_suspend.vibe
+++ b/fixtures/effect_compound_call_arg_suspend.vibe
@@ -25,9 +25,7 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{
-  "last": "1506"
+test "compound call arguments preserve evaluation order" {
+  inspect(_start(), "1506")
 }

--- a/fixtures/effect_seq_head_if_condition_compound_suspend.vibe
+++ b/fixtures/effect_seq_head_if_condition_compound_suspend.vibe
@@ -30,9 +30,7 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{
-  "last": "1011"
+test "compound if condition suspends once" {
+  inspect(_start(), "1011")
 }

--- a/fixtures/effect_seq_head_match_compound_scrutinee_suspend.vibe
+++ b/fixtures/effect_seq_head_match_compound_scrutinee_suspend.vibe
@@ -36,9 +36,7 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{
-  "last": "411"
+test "compound match scrutinee suspends once" {
+  inspect(_start(), "411")
 }

--- a/fixtures/effect_while_condition_compound_suspend.vibe
+++ b/fixtures/effect_while_condition_compound_suspend.vibe
@@ -27,9 +27,7 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{
-  "last": "23"
+test "compound while condition stays inside loop" {
+  inspect(_start(), "23")
 }

--- a/fixtures/err_effect_compound_match_branch_suspend.vibe
+++ b/fixtures/err_effect_compound_match_branch_suspend.vibe
@@ -1,0 +1,28 @@
+// #1536 (a) v8 boundary: a match arm is conditionally evaluated. Floating
+// this suspension outside the match would run it for an unselected arm, so the
+// compound ANF pass must remain fail-closed here.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut value = 0
+    value = 1 + match value {
+      0 => perform Ask::Get(1),
+      _ => 0
+    }
+    value
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "let/seq/tail/branch-tail spine"
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9300,8 +9300,9 @@ fn scps_need_clone(eff: String, fname: String, st: (Array[Int], Array[String], A
 // selection/assignment or a while condition. A suspension nested in a COMPOUND
 // -- an operand, a call argument, a constructor payload -- is linearized onto
 // the same spine first (scps_anf_compound). A suspension some execution would
-// not reach (an if/match branch, the right operand of `&&` / `||`, a closure
-// body, a nested handle) still fails closed.
+// not reach (an if/match branch or the right operand of `&&` / `||`) still
+// fails closed. Closure literals are handled on their own prepass step spine;
+// supported nested different-effect handles keep their existing ownership path.
 
 fn scps_direct_spine_input(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String])) -> Bool {
   let (_, ops, _, _, _) = sctx
@@ -9340,9 +9341,11 @@ fn scps_selection_fresh(e: Expr, site: Int) -> String {
 // rounds as it has suspensions.
 //
 // Only strictly-evaluated positions are traversed. A suspension that some
-// execution reaching the compound would NOT reach -- inside a branch, a loop
-// body, a closure, a handler, or the right operand of `&&` / `||` -- is not
-// linearizable this way and stays fail-closed.
+// execution reaching the compound would NOT reach -- inside an if/match branch
+// or the right operand of `&&` / `||` -- is not linearizable this way and
+// stays fail-closed. Closure literals are step-split by `scps_prepass_expr` on
+// their own spine, and supported nested different-effect handles keep their
+// existing handler-ownership lowering; neither is floated by this helper.
 
 /// Is `e` a recognized suspension whose own inputs are already suspension-free
 /// -- i.e. one the spine can name as it stands?
@@ -10049,9 +10052,9 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
   }
 }
 
-/// Name direct suspension RHS values before mutable-local boxing. Traverse
-/// only continuation-spine positions; values, loop bodies, nested handles and
-/// closure bodies remain untouched and therefore fail closed as before.
+/// Name direct suspension RHS values before mutable-local boxing. This pass
+/// traverses continuation-spine positions; expression normalization separately
+/// handles supported closure and nested-handle forms before this pass.
 fn scps_float_direct_assign(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), site: Int) -> Expr {
   match e {
     EAssign(x, v, b) => if scps_direct_spine_input(v, sctx) {

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6866,15 +6866,16 @@ scps_run_expect "effect_while_condition_suspend.vibe" "3217" "whilecond"
 # these pin evaluation order, not just acceptance (a handler that mutates shared
 # state between perform and resume would show up in the numbers). The `while`
 # case additionally pins that the chain stayed inside the loop closure.
-scps_run_expect "effect_assignment_rhs_compound_suspend.vibe" "1131" "assignrhscompound"
-scps_run_expect "effect_seq_head_if_condition_compound_suspend.vibe" "1011" "seqheadifcompound"
-scps_run_expect "effect_seq_head_match_compound_scrutinee_suspend.vibe" "411" "seqheadmatchcompound"
-scps_run_expect "effect_compound_call_arg_suspend.vibe" "1506" "compoundcallarg"
-scps_run_expect "effect_while_condition_compound_suspend.vibe" "23" "whilecondcompound"
-# Same slice, plus the scps_cellify EAssignOp field-order fix: `x op= v` on a
-# boxed mutable used to drop the write silently (the cell rewrite compared the
-# OPERATOR against the local's name, so it never fired).
-scps_run_expect "effect_assignment_op_rhs_suspend.vibe" "226" "assignoprhs"
+# New positive regressions own their expectations as inspect snapshots. Run
+# them unchanged with the freshly built stage2 that implements this lowering.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_assignment_rhs_compound_suspend.vibe \
+  fixtures/effect_seq_head_if_condition_compound_suspend.vibe \
+  fixtures/effect_seq_head_match_compound_scrutinee_suspend.vibe \
+  fixtures/effect_compound_call_arg_suspend.vibe \
+  fixtures/effect_while_condition_compound_suspend.vibe \
+  fixtures/effect_assignment_op_rhs_suspend.vibe \
+  fixtures/effect_assignment_op_name_collision_test.vibe
 # #1536: loop bodies carrying `break` / `continue`. The transfers become calls
 # on the CPS spine (exit continuation / loop self-call), dead statements behind
 # a transfer drop, and a nested loop keeps its own transfers. `return` in the
@@ -6894,6 +6895,7 @@ scps_check_reject "err_effect_loop_return_suspend.vibe" "let/seq/tail/branch-tai
 # execution reaching the compound also reaches. An `if` branch and the right
 # operand of `&&` / `||` are not among them.
 scps_check_reject "err_effect_compound_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundbranch"
+scps_check_reject "err_effect_compound_match_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundmatchbranch"
 scps_check_reject "err_effect_compound_shortcircuit_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundshortcircuit"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"
 scps_check_reject "err_effect_resume_store_ineligible.vibe" "cannot see through" "inelig"


### PR DESCRIPTION
Follow-up to already-merged #1658, containing only the independently accepted review delta over current main.

- migrates the six new positives to source-owned `inspect(...)` snapshots
- adds target-only `EAssignOp` generated-name collision coverage
- adds gated match-branch fail-closed evidence
- narrows stale closure/nested-handle documentation to actual behavior

No lowering semantics are broadened beyond merged #1658.

Validation: focused seven snapshots and negative gates passed in the reconstruction; formatter checks passed; fixture accounting 240/240; generated artifacts regenerated and freshness check passed; `bit diff --check` passed. Independent final review: ACCEPT.