### PR TITLE
test(async): #1536 v8 の境界 3 件を実測で埋める

### DIFF
--- a/fixtures/effect_compound_anf_name_collision_test.vibe
+++ b/fixtures/effect_compound_anf_name_collision_test.vibe
@@ -1,0 +1,61 @@
+// #1536 (a) v8: the linearization's generated binder is spelled
+// `__scps_seq<site>_anf<n>` -- `scps_local` concatenates the site DIRECTLY onto
+// the prefix, so there is no underscore before it (`__scps_seq0_anf0`, the same
+// shape effect_seq_head_reserved_name_collision.vibe already relies on).
+// Nothing stops user code from spelling one, and because these binders wrap the
+// whole rebuilt slot they scope over the continuation as well as the compound:
+// a collision would silently rebind a name the continuation still reads.
+// scps_anf_fresh probes the WHOLE enclosing expression (scope-blind: any
+// occurrence of the candidate disqualifies it) and bumps a numeric suffix.
+//
+// Both candidate ordinals are laid here, under two site spellings, and each is
+// read AFTER the suspension so capture shifts the answer. `anf0_1` / `anf1_1`
+// are the spellings the bump lands on, so they are the second-order collision.
+//
+// CONTROL-MEASURED: with scps_anf_fresh replaced by its bare base this prints
+// 6011823 instead of 3045823 -- `__scps_seq0_anf0` is rebound to the left
+// operand (300) that the first binding names, so the trailing read of it
+// returns 300 instead of 3, and `__scps_seq0_anf1` is rebound to the resumed
+// value. That measurement is why this fixture is here rather than
+// effect_assignment_op_name_collision_test.vibe, which spells its candidate
+// `__scps_seq_0_assignop`: the compiler emits no `assignop` binder at all
+// (`grep assignop` over the compiler is empty -- a compound assignment reaches
+// this pass as the `Array::set` scps_cellify makes of it), and the extra
+// underscore does not match the generated shape either, so that fixture passes
+// with the freshness probe disabled.
+//
+// The target-only EAssignOp case is deliberately NOT covered here: it is not
+// reachable. A `let mut` inside a handle body is boxed by scps_cellify before
+// this probe runs (its occurrences become `Array::get` / `Array::set`
+// arguments, i.e. ordinary identifiers), a `let mut` outside the handle cannot
+// be written from the continuation closures at all
+// (err_type_closure_capture_mut), and any binder inside the probed expression
+// is already found by scps_binds_name. The EAssignOp field-order fix in
+// scps_refs_name is a hardening of the predicate, not a fixed silent-wrong; the
+// one that WAS silent-wrong is scps_cellify (see
+// effect_assignment_op_rhs_suspend.vibe).
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let __scps_seq0_anf0 = 3
+    let __scps_seq0_anf1 = 5
+    let __scps_seq1_anf0 = 7
+    let __scps_seq0_anf0_1 = 11
+    let __scps_seq1_anf0_1 = 13
+    let mut value = 0
+    value = __scps_seq0_anf0 * 100 + perform Ask::Get(0) + __scps_seq0_anf0
+    value * 10000 + __scps_seq0_anf1 * 1000 + __scps_seq1_anf0 * 100 + __scps_seq0_anf0_1 * 10 + __scps_seq1_anf0_1
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 1)
+    }
+  }
+}
+
+test "generated linearization binders never capture a user spelling" {
+  inspect(_start(), "3045823")
+}

--- a/fixtures/effect_compound_closure_literal_suspend_test.vibe
+++ b/fixtures/effect_compound_closure_literal_suspend_test.vibe
@@ -1,0 +1,40 @@
+// #1536 (a) v8, measured boundary correction: a closure literal inside a
+// compound is NOT a fail-closed position, even though its body performs the
+// handled effect.
+//
+// scps_anf_walk has no EFn case, so on its own it would refuse. It never gets
+// the chance: the closure-CPS prepass (ADR-0076 追記31) step-splits an
+// annotated literal before the split runs, so by then the literal's body holds
+// step constructors rather than a recognized suspension, and the compound
+// around it is ordinary. Both spellings below are pinned -- a literal that is
+// only CONSTRUCTED inside the compound (the suspension never runs; 1 + 1) and
+// one that is called there (the suspension runs on the spine of the literal's
+// own step body; 1 + 1).
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut built = 0
+    built = 1 + Array::length([
+      () -> Int with Ask {
+        perform Ask::Get(1)
+      }
+    ])
+    let mut called = 0
+    called = 1 + (() -> Int with Ask {
+      perform Ask::Get(1)
+    })()
+    built * 10 + called
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+
+test "a closure literal in a compound is closure-CPS, not fail-closed" {
+  inspect(_start(), "22")
+}

--- a/fixtures/err_effect_compound_nested_handle_suspend.vibe
+++ b/fixtures/err_effect_compound_nested_handle_suspend.vibe
@@ -1,0 +1,36 @@
+// #1536 (a) v8 boundary, but enforced by an OLDER rule: a nested `handle`
+// inside a compound. The linearization does not widen this -- the body is
+// refused before the split even runs, by the see-through check that already
+// rejects a nested handle anywhere in a suspend-class handle body. The gate
+// pins that diagnostic (`cannot see through`) rather than the spine one, so the
+// fixture cannot quietly start passing for the other reason.
+effect Ask {
+  Get(Int) -> Int
+}
+
+effect Log {
+  Note(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut value = 0
+    value = 1 + handle {
+      perform Log::Note(0) + perform Ask::Get(1)
+    } with Log {
+      Note(n) => resume(n)
+    }
+    value
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "cannot see through"
+}

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6875,7 +6875,9 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_compound_call_arg_suspend.vibe \
   fixtures/effect_while_condition_compound_suspend.vibe \
   fixtures/effect_assignment_op_rhs_suspend.vibe \
-  fixtures/effect_assignment_op_name_collision_test.vibe
+  fixtures/effect_assignment_op_name_collision_test.vibe \
+  fixtures/effect_compound_anf_name_collision_test.vibe \
+  fixtures/effect_compound_closure_literal_suspend_test.vibe
 # #1536: loop bodies carrying `break` / `continue`. The transfers become calls
 # on the CPS spine (exit continuation / loop self-call), dead statements behind
 # a transfer drop, and a nested loop keeps its own transfers. `return` in the
@@ -6897,6 +6899,11 @@ scps_check_reject "err_effect_loop_return_suspend.vibe" "let/seq/tail/branch-tai
 scps_check_reject "err_effect_compound_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundbranch"
 scps_check_reject "err_effect_compound_match_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundmatchbranch"
 scps_check_reject "err_effect_compound_shortcircuit_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundshortcircuit"
+# A nested handle inside a compound is refused EARLIER, by the pre-existing
+# see-through rule -- the linearization neither widens nor narrows it. Gated on
+# THAT diagnostic, so the fixture cannot silently start passing for the other
+# reason if the boundary ever moves.
+scps_check_reject "err_effect_compound_nested_handle_suspend.vibe" "cannot see through" "compoundnestedhandle"
 scps_check_reject "err_resume_non_tail.vibe" "must be the last expression of the handler arm" "nontail"
 scps_check_reject "err_effect_resume_store_ineligible.vibe" "cannot see through" "inelig"
 scps_check_reject "err_effect_closure_param_taint.vibe" "cannot see through" "inerttaint"


### PR DESCRIPTION
main (`d742041`) へ rebase 済み、コンフリクト解消。

rebase の途中で **#1661 / #1663 がこの PR の内容の大半を先に入れている**ことが分かったので、重複分は落とした:

| 元の内容 | 扱い |
|---|---|
| positive 6 件の inspect snapshot 化 | **落とした** — #1661 が同じことを in-place で実施済み |
| `match` 枝の負 fixture | **落とした** — #1661 の `err_effect_compound_match_branch_suspend.vibe` と同一 |
| pass の doc comment 訂正 (closure body / nested handle) | **落とした** — #1661 が同趣旨で訂正済み |
| `EAssignOp` フィールド順の残り 4 箇所 (#1657) | **落とした** — #1663 が修正済み |

**コンパイラのコードは 1 行も変えていない。** 残したのは main に無い fixture 3 件と、その gate エントリだけ。

---

## 1. `effect_compound_anf_name_collision_test.vibe`

生成 binder の実際の綴りは `__scps_seq{site}_anf{n}` — つまり `__scps_seq0_anf0`。`scps_local` が site を prefix に**直に**連結するので **site の前に underscore は入らない**(`effect_seq_head_reserved_name_collision.vibe` が control-measured で依存しているのと同じ形)。候補 2 つを 2 つの site 綴りで、いずれも suspension の**後ろ**で読む形に置いた。

**control 実測** — `scps_anf_fresh` の probe を素の base に差し替えてコンパイラをビルドし、両方の collision fixture を走らせた:

| fixture | probe あり | probe 無し |
|---|---|---|
| `effect_compound_anf_name_collision_test` (本 PR) | 3045823 ✅ | **FAIL** (6011823) |
| `effect_assignment_op_name_collision_test` (main, #1661) | 200813 ✅ | **pass** |

main 側は候補を `__scps_seq_0_assignop` と綴っているが、コンパイラは `assignop` という binder を**一切生成しない**(`grep assignop` が空 — compound assignment は `scps_cellify` が作る `Array::set` としてこの pass に到達する)し、underscore の位置も生成形と違う。したがって probe を殺しても通る = freshness を検査していない。本 fixture は実際に判別する。

**target-only な EAssignOp 衝突は到達しないので covered にしていない。** 3 つ独立に塞がっている: (a) handle body 内の `let mut` は probe より前に `scps_cellify` が箱にするので出現は `Array::get`/`Array::set` の引数になる、(b) handle の外の `let mut` は継続クロージャから書けない (`err_type_closure_capture_mut`)、(c) probed 式の中の binder は `scps_binds_name` が既に見つける。加えてこの binder は常に rebuild した slot 全体を包むので、スコープは必ず probe した式の内側に収まる。#1663 の `scps_refs_name` 修正は predicate の hardening であって、silent-wrong が直ったのは `scps_cellify` の方。この分析は fixture の冒頭にそのまま書いてある。

## 2. `effect_compound_closure_literal_suspend_test.vibe`

closure literal が compound の中にあっても **fail-closed ではない**という実測を pin する(構築だけの形と即時呼び出しの形の両方)。`scps_anf_walk` に EFn ケースが無いので walk 自体は拒否するが、closure-CPS の prepass (ADR-0076 追記31) が注釈付き literal を先に step-split するのでそこへ到達しない。main はこの旨を doc comment に書いたが fixture が無いので、挙動が変わったら気付けるようにする。

## 3. `err_effect_compound_nested_handle_suspend.vibe`

compound の中の nested handle。**v8 の境界ではなく**もっと手前の see-through 規則が拒否しているので、gate の needle も `cannot see through` にした — 別の理由で通り始めたら気付けるようにするため。

## 検証

- `bash scripts/compiler_gate.sh` 完走 (exit 0) — snapshot は 9 件に増えて全 pass
- `bash scripts/check_vibe_fmt.sh` clean (925 files, 0 known debt, 0 new violations)
- `bash scripts/check_fixture_execution.sh` ok (243 test-block fixtures)

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk