### PR TITLE
feat(async): split tail short-circuit suspension

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2890,7 +2890,12 @@ pass で拾われる。callee は名前を付けない — by-name call を loca
 変えてしまうと、それこそ suspend lowering が see-through できない唯一の形になる。
 
 **必ず評価されるとは限らない位置だけがこの ANF では fail-closed のまま**:
-`if` / `match` の枝、`&&` / `||` の右辺。closure literal は
+`if` / `match` の枝、`&&` / `||` の右辺。後続スライスでは、式全体が tail の
+`l && r` / `l || r` だけをそれぞれ `if l { r } else { false }` /
+`if l { true } else { r }` に変換し、既存の branch splitter へ渡す。これにより
+selected RHS は suspend できるが、assignment/call/selection/sequence-head 等に
+ネストした non-tail short-circuit は引き続き fail-closed であり、generic ANF は
+conditional RHS を走査しない。closure literal は
 `scps_prepass_expr` が literal 自身の spine で step-split し、既存の
 nested different-effect handle は handler ownership を保った lowering を使うため、
 この compound ANF が外へ float する対象ではないが blanket reject でもない。
@@ -2908,7 +2913,8 @@ cell 読みになっており、**書き込みが suspension を跨いで黙っ�
 
 **残る不適格**: EForIn(array) HEAD (反復対象が Array であることの静的証明が要る —
 codegen は String を実行時判別する #807)、loop body 内の `return`、row 変数 callee、
-literal param flow、条件付き評価位置の suspension。
+literal param flow、`if` / `match` branch および non-tail `&&` / `||` RHS の
+条件付き suspension。
 
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)

--- a/fixtures/effect_tail_shortcircuit_suspend.vibe
+++ b/fixtures/effect_tail_shortcircuit_suspend.vibe
@@ -1,0 +1,60 @@
+// #1536 tail-only short-circuit lowering. Each case returns the whole && / ||
+// expression from the handle body, so its selected RHS may suspend. The event
+// digits pin bypass/taken paths and operation IDs in order. For each taken RHS,
+// x2 is the handler visit, x3 is the resumed source continuation, and x4 is the
+// handler regaining control after that continuation returns.
+effect Ask {
+  Get(Int) -> Bool
+}
+
+let events: Array[Int] = [
+]
+
+fn run(left: Bool, is_and: Bool, operation_id: Int) -> Bool {
+  handle {
+    Array::push(events, operation_id * 10 + 1)
+    if is_and {
+      left && {
+        let answer = perform Ask::Get(operation_id)
+        Array::push(events, operation_id * 10 + 3)
+        answer
+      }
+    } else {
+      left || {
+        let answer = perform Ask::Get(operation_id)
+        Array::push(events, operation_id * 10 + 3)
+        answer
+      }
+    }
+  } with Ask {
+    Get(id) => {
+      Array::push(events, id * 10 + 2)
+      let k = resume
+      let result = k(id % 2 == 0)
+      Array::push(events, id * 10 + 4)
+      result
+    }
+  }
+}
+
+test "tail short-circuit preserves bypass, order, and exact-once resume" {
+  let false_and = run(false, true, 1)
+  let true_and = run(true, true, 2)
+  let true_or = run(true, false, 3)
+  let false_or = run(false, false, 4)
+  inspect(false_and, "false")
+  inspect(true_and, "true")
+  inspect(true_or, "true")
+  inspect(false_or, "true")
+  inspect(Array::length(events), "10")
+  inspect(Array::get(events, 0), "11")
+  inspect(Array::get(events, 1), "21")
+  inspect(Array::get(events, 2), "22")
+  inspect(Array::get(events, 3), "23")
+  inspect(Array::get(events, 4), "24")
+  inspect(Array::get(events, 5), "31")
+  inspect(Array::get(events, 6), "41")
+  inspect(Array::get(events, 7), "42")
+  inspect(Array::get(events, 8), "43")
+  inspect(Array::get(events, 9), "44")
+}

--- a/fixtures/err_effect_compound_shortcircuit_suspend.vibe
+++ b/fixtures/err_effect_compound_shortcircuit_suspend.vibe
@@ -1,7 +1,6 @@
-// #1536 (a) v8 boundary: the right operand of `&&` / `||` is evaluated only
-// when the left one does not already decide the answer, so a suspension there
-// is not unconditionally reached and stays fail-closed. (The LEFT operand is
-// linearizable, and is covered by the positive compound fixtures.)
+// #1536 boundary: a tail `&&` / `||` can reuse conditional branch splitting,
+// but this short-circuit is nested in an if condition and therefore non-tail.
+// Generic compound ANF must not float its conditionally evaluated RHS.
 effect Ask {
   Get(Int) -> Int
 }

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9299,9 +9299,10 @@ fn scps_need_clone(eff: String, fname: String, st: (Array[Int], Array[String], A
 // first named by a fresh ELet, then the existing spine machinery resumes into
 // selection/assignment or a while condition. A suspension nested in a COMPOUND
 // -- an operand, a call argument, a constructor payload -- is linearized onto
-// the same spine first (scps_anf_compound). A suspension some execution would
-// not reach (an if/match branch or the right operand of `&&` / `||`) still
-// fails closed. Closure literals are handled on their own prepass step spine;
+// the same spine first (scps_anf_compound). Tail `&&` / `||` is first lowered
+// to an equivalent EIf, so its condition and selected RHS can use the existing
+// branch splitter; conditional positions nested in non-tail compounds still
+// fail closed. Closure literals are handled on their own prepass step spine;
 // supported nested different-effect handles keep their existing ownership path.
 
 fn scps_direct_spine_input(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String])) -> Bool {
@@ -9704,6 +9705,24 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
       }
     } else {
       match e {
+        // #1536 tail short-circuit: preserve conditional RHS evaluation by
+        // expressing the whole tail boolean as the equivalent conditional.
+        // Re-entering this function reuses the established EIf condition and
+        // branch splitting, including exact-once resume behavior. This arm is
+        // deliberately tail-only; generic compound ANF still refuses to walk
+        // the RHS of && / || in assignments, calls, selections and seq heads.
+        EBinOp(op, l, r) => if op == "&&" {
+          scps_split_tail(EIf(l, r, EBool(false)), sctx, ctx, st)
+        } else if op == "||" {
+          scps_split_tail(EIf(l, EBool(true), r), sctx, ctx, st)
+        } else {
+          let (aok, abn, abv, e2) = scps_anf_compound(e, sctx, e, site)
+          if aok {
+            scps_split_tail(scps_anf_wrap(abn, abv, e2), sctx, ctx, st)
+          } else {
+            (false, e)
+          }
+        },
         ELet(x, v, b, off) => {
           let vp = scps_as_target_perform(v, ops)
           let vn = scps_as_needing_call(v, sctx)
@@ -10037,8 +10056,10 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
         },
         EWhile(c, b) => scps_split_while(c, b, EUnit, sctx, ctx, st),
         // #1536 (a) v8: a compound in TAIL position (`1 + perform Op()`,
-        // `Some(perform Op())`). Everything not linearizable -- a for form, a
-        // nested closure or handle, a transfer -- still lands on (false, e).
+        // `Some(perform Op())`). Tail && / || was handled above without asking
+        // generic ANF to traverse its conditional RHS. Everything else not
+        // linearizable -- a for form, nested closure/handle, or transfer --
+        // still lands on (false, e).
         _ => {
           let (aok, abn, abv, e2) = scps_anf_compound(e, sctx, e, site)
           if aok {
@@ -10979,7 +11000,7 @@ fn scps_transform_handle(body: Expr, arms: Array[(Pat, Expr)], ctx: (Array[Stmt]
     } else {
       let (split_ok, split_body) = scps_split_tail(body, sctx, ctx, st)
       if !split_ok {
-        Array::push(errs, "a handler arm captures `resume` as a value (suspend class, ADR-0076 Phase 3a/3b), but a perform of the handled effect (or a call to a function that performs it) is not directly on the handle body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of `&&` / `||` -- are not eligible; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)")
+        Array::push(errs, "a handler arm captures `resume` as a value (suspend class, ADR-0076 Phase 3a/3b), but a perform of the handled effect (or a call to a function that performs it) is not directly on the handle body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)")
         None
       } else {
         scps_ensure_effect_runtime(eff, ctx, st)
@@ -12129,7 +12150,7 @@ fn scps_emit_clone(eff: String, fname: String, ctx: (Array[Stmt], Array[(String,
         } else {
           let (split_ok, split_body) = scps_split_tail(fbody2, sctx, ctx, st)
           if !split_ok {
-            Array::push(errs, String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, but a perform of that effect (or a call to a function that performs it) is not directly on its body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of `&&` / `||` -- are not eligible; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817, ADR-0076 Phase 3b)"))
+            Array::push(errs, String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, but a perform of that effect (or a call to a function that performs it) is not directly on its body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817, ADR-0076 Phase 3b)"))
           } else {
             Array::push(scps_st_inj(st), SLet(false, true, scps_clone_name(eff, fname), None, EFn(tps, tbs, cparams, None, None, split_body)))
           }
@@ -12775,7 +12796,7 @@ fn scps_split_literal(tps: Array[String], tbs: Array[(String, Array[String])], p
   } else {
     let (split_ok, split_body) = scps_split_tail(b, sctx, ctx, st)
     if !split_ok {
-      Array::push(errs, String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class, ADR-0076 追記31 Vertical B) performs it (or calls a function that performs it) off the let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of `&&` / `||` -- are not eligible; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)"))
+      Array::push(errs, String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class, ADR-0076 追記31 Vertical B) performs it (or calls a function that performs it) off the let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)"))
       EFn(tps, tbs, params, None, None, b)
     } else {
       scps_ensure_effect_runtime(eff, ctx, st)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6878,6 +6878,12 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_assignment_op_name_collision_test.vibe \
   fixtures/effect_compound_anf_name_collision_test.vibe \
   fixtures/effect_compound_closure_literal_suspend_test.vibe
+# #1536 tail-only short-circuit: the whole boolean expression lowers to EIf,
+# preserving bypass and selected-RHS suspension. The snapshot pins four paths,
+# operation order, handler visits, resumed source-continuation events, and the
+# handler regaining control afterward; exact event counts pin exact-once flow.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_tail_shortcircuit_suspend.vibe
 # #1536: loop bodies carrying `break` / `continue`. The transfers become calls
 # on the CPS spine (exit continuation / loop self-call), dead statements behind
 # a transfer drop, and a nested loop keeps its own transfers. `return` in the
@@ -6892,10 +6898,9 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_loop_nested_break_suspend_test.vibe \
   fixtures/effect_resume_store_loop_break_test.vibe \
   fixtures/effect_loop_ctl_name_collision_test.vibe
-scps_check_reject "err_effect_loop_return_suspend.vibe" "let/seq/tail/branch-tail spine" "loopreturn"
-# #1536 (a) v8 boundary: linearization walks only positions that every
-# execution reaching the compound also reaches. An `if` branch and the right
-# operand of `&&` / `||` are not among them.
+# #1536 boundary: generic linearization walks only positions that every
+# execution reaching a compound also reaches. Tail && / || is supported via
+# EIf, but if/match branches and a non-tail short-circuit RHS remain rejected.
 scps_check_reject "err_effect_compound_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundbranch"
 scps_check_reject "err_effect_compound_match_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundmatchbranch"
 scps_check_reject "err_effect_compound_shortcircuit_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundshortcircuit"


### PR DESCRIPTION
Bounded #1536 slice: support a suspending RHS only when the entire `&&` / `||` expression is in suspend-CPS tail position.

The lowering rewrites that whole tail expression to its semantics-equivalent `if` before generic compound ANF, reusing existing condition/branch splitting. Non-tail assignment/call/selection contexts remain fail-closed.

Evidence:
- source-owned snapshot covers bypass and taken paths for both operators
- records handler entry, resumed source continuation, and handler-after-resume events with exact count/order
- existing short-circuit, if-branch, and match-branch non-tail negatives remain rejected

Validation:
- focused positive: 1/1
- three focused negatives rejected
- fixture accounting 242/242
- seed → stage1 → stage2 → stage3 and stage2/stage3 fixpoint passed
- formatter, generated freshness, and `bit diff --check` passed
- independent review rejected the first evidence shape, one bounded test-only fix was applied, and final rereview ACCEPTED

The broader #1536 remains open for Array-typed `for`, loop-body return, row-variable evidence, residual literal provenance, and non-tail conditional positions.