### PR TITLE
test(gc): pin Array[Int] control-flow join fallback

### DIFF
--- a/fixtures/gc_direct_array_join_fallback_test.vibe
+++ b/fixtures/gc_direct_array_join_fallback_test.vibe
@@ -1,0 +1,25 @@
+// #1541 fallback boundary: joining native-reference candidates through control
+// flow is outside the private direct Array[Int] ABI proof. The complete
+// component must retain the tagged-i64 representation.
+
+fn choose_array(values: Array[Int], choose_original: Bool) -> Array[Int] {
+  if choose_original {
+    values
+  } else {
+    [
+      1,
+      2
+    ]
+  }
+}
+
+test "gc array control-flow join remains on the fallback lane" {
+  let original = [
+    40,
+    2
+  ]
+  let chosen = choose_array(original, true)
+  Array::set(chosen, 1, 3)
+  inspect(Array::get(original, 0), "40")
+  inspect(Array::get(original, 1), "3")
+}

--- a/scripts/test_gc_heap_accounting.sh
+++ b/scripts/test_gc_heap_accounting.sh
@@ -103,6 +103,12 @@ ARGUMENT_FALLBACK_OUT="$WORK/direct_array_argument_fallback.wasm"
 compile_direct_abi_fallback fixtures/gc_direct_array_argument_identity_test.vibe "$ARGUMENT_OUT"
 compile_direct_abi_fallback fixtures/gc_direct_array_argument_fallback_test.vibe "$ARGUMENT_FALLBACK_OUT"
 
+# #1541 dedicated control-flow join fallback. The annotated Array[Int]
+# parameter/result is a direct-ABI candidate, but joining reference values
+# through `if` is outside the current proof and must clear the whole island.
+JOIN_FALLBACK_OUT="$WORK/direct_array_join_fallback.wasm"
+compile_direct_abi_fallback fixtures/gc_direct_array_join_fallback_test.vibe "$JOIN_FALLBACK_OUT"
+
 # Count decoded instructions rather than byte patterns: raw scanning can match
 # non-code sections and also couples this gate to an incidental numeric type
 # index. `wasm-tools print` parses the module and renders instructions with the
@@ -208,8 +214,8 @@ PY
 
 positive="$(count_native_array_allocs "$DIRECT_OUT")"
 alias="$(count_native_array_allocs "$ALIAS_OUT")"
-declare -a fallback_labels=("generic" "spelling shadow" "export")
-declare -a fallback_outputs=("$FALLBACK_OUT" "$SHADOW_FALLBACK_OUT" "$EXPORT_FALLBACK_OUT")
+declare -a fallback_labels=("generic" "spelling shadow" "export" "control-flow join")
+declare -a fallback_outputs=("$FALLBACK_OUT" "$SHADOW_FALLBACK_OUT" "$EXPORT_FALLBACK_OUT" "$JOIN_FALLBACK_OUT")
 if [ "$positive" -ne 1 ]; then
   echo "[gc-heap-accounting] FAIL: expected one #1541 direct-ABI native literal, found $positive" >&2
   exit 1


### PR DESCRIPTION
## Summary

- add a dedicated explicit `Array[Int]` control-flow join fallback fixture
- verify true-path identity by mutating the selected alias and reading the original
- compile/validate/run it through the existing GC fallback helper
- require decoded `array.new_default` count to remain zero

No ABI or codegen eligibility changes. This is evidence-only follow-up for #1541.

## Validation

- `bash scripts/vibe_fmt.sh --check fixtures/gc_direct_array_join_fallback_test.vibe`
- `bash -n scripts/test_gc_heap_accounting.sh`
- `bash scripts/check_fixture_execution.sh` (245/245)
- `bit diff --check HEAD^ HEAD`
- independent review: ACCEPT

Full local GC execution is unavailable with local Rust 1.92 / missing current stage2; fresh CI must provide authoritative GC execution.

Refs #1541