### PR TITLE
feat(async): split immutable-let short-circuit suspension

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1085,8 +1085,11 @@ perform・concrete needing call・CPS-local call そのものなら、fresh let 
 (`Some(perform Op(i))`)・compound な `while` 条件 (`perform Next() > 0`)・
 `+=` 等の compound assignment は、**元の評価順で let 連鎖へ線形化**されてから
 spine に乗る (#1536 (a) v8)。perform より前に評価されるものは先に名前が付くので
-順序は変わらない。**必ず評価されるとは限らない位置に埋まった perform だけは
-reject のまま** — `if` / `match` の枝の中、`&&` / `||` の右辺。
+順序は変わらない。条件付き位置は原則 reject だが、`&&` / `||` 全体が**不変の
+`let` initializer** で、左辺が suspend せず、選択される右辺が直接対応済みの
+suspension またはその `let` / sequence spine である場合だけ対応する。入れ子の
+short-circuit、呼び出し引数等の compound、`return` / `break` / `continue` で
+終わる spine、`if` / `match` の枝など、より広い条件付き・制御移譲形は reject のまま。
 **concrete な row に
 対象 effect を含む top-level 関数の呼び出しは可** (3b yield bubbling —
 再帰も可; callee には CPS clone が合成され、元の関数は他の呼び出し元

--- a/fixtures/effect_let_shortcircuit_suspend.vibe
+++ b/fixtures/effect_let_shortcircuit_suspend.vibe
@@ -1,0 +1,77 @@
+// #1536 immutable-let short-circuit lowering. Each whole let initializer may
+// conditionally suspend in its RHS. Events pin bypass/selected paths, source
+// continuation order, handler regain, and exact-once execution.
+effect Ask {
+  Get(Int) -> Bool
+}
+
+let events: Array[Int] = [
+]
+
+fn run_and(left: Bool, operation_id: Int) -> Bool {
+  handle {
+    Array::push(events, operation_id * 10 + 1)
+    let result = left && {
+      let answer = perform Ask::Get(operation_id)
+      Array::push(events, operation_id * 10 + 3)
+      answer
+    }
+    Array::push(events, operation_id * 10 + 5)
+    result
+  } with Ask {
+    Get(id) => {
+      Array::push(events, id * 10 + 2)
+      let k = resume
+      let result = k(id % 2 == 0)
+      Array::push(events, id * 10 + 4)
+      result
+    }
+  }
+}
+
+fn run_or(left: Bool, operation_id: Int) -> Bool {
+  handle {
+    Array::push(events, operation_id * 10 + 1)
+    let result = left || {
+      let answer = perform Ask::Get(operation_id)
+      Array::push(events, operation_id * 10 + 3)
+      answer
+    }
+    Array::push(events, operation_id * 10 + 5)
+    result
+  } with Ask {
+    Get(id) => {
+      Array::push(events, id * 10 + 2)
+      let k = resume
+      let result = k(id % 2 == 0)
+      Array::push(events, id * 10 + 4)
+      result
+    }
+  }
+}
+
+test "let short-circuit preserves bypass, order, and exact-once resume" {
+  let false_and = run_and(false, 1)
+  let true_and = run_and(true, 2)
+  let true_or = run_or(true, 3)
+  let false_or = run_or(false, 4)
+  inspect(false_and, "false")
+  inspect(true_and, "true")
+  inspect(true_or, "true")
+  inspect(false_or, "true")
+  inspect(Array::length(events), "14")
+  inspect(Array::get(events, 0), "11")
+  inspect(Array::get(events, 1), "15")
+  inspect(Array::get(events, 2), "21")
+  inspect(Array::get(events, 3), "22")
+  inspect(Array::get(events, 4), "23")
+  inspect(Array::get(events, 5), "25")
+  inspect(Array::get(events, 6), "24")
+  inspect(Array::get(events, 7), "31")
+  inspect(Array::get(events, 8), "35")
+  inspect(Array::get(events, 9), "41")
+  inspect(Array::get(events, 10), "42")
+  inspect(Array::get(events, 11), "43")
+  inspect(Array::get(events, 12), "45")
+  inspect(Array::get(events, 13), "44")
+}

--- a/fixtures/err_effect_let_shortcircuit_call_arg_suspend.vibe
+++ b/fixtures/err_effect_let_shortcircuit_call_arg_suspend.vibe
@@ -1,0 +1,23 @@
+// #1536 boundary: a selected RHS cannot hide its suspension in a call
+// argument. Immutable-let short-circuit lowering must not feed this compound
+// terminal into generic ANF.
+effect Ask {
+  Get(Int) -> Bool
+}
+
+fn identity(value: Bool) -> Bool {
+  value
+}
+
+let _start = () -> Bool {
+  handle {
+    let result = true && identity(perform Ask::Get(1))
+    result
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n > 0)
+    }
+  }
+}
+_start()

--- a/fixtures/err_effect_let_shortcircuit_nested_suspend.vibe
+++ b/fixtures/err_effect_let_shortcircuit_nested_suspend.vibe
@@ -1,0 +1,19 @@
+// #1536 boundary: immutable-let support covers only a whole short-circuit
+// initializer whose selected RHS is a direct suspension or a let/seq spine.
+// A nested short-circuit remains a conditional compound and must fail closed.
+effect Ask {
+  Get(Int) -> Bool
+}
+
+let _start = () -> Bool {
+  handle {
+    let result = true && (true && perform Ask::Get(1))
+    result
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n > 0)
+    }
+  }
+}
+_start()

--- a/fixtures/err_effect_let_shortcircuit_return_suspend.vibe
+++ b/fixtures/err_effect_let_shortcircuit_return_suspend.vibe
@@ -1,0 +1,26 @@
+// #1536 boundary: a selected short-circuit RHS may carry a direct suspension
+// through a let/seq spine, but a terminal return cannot be moved into the
+// synthetic resume continuation and must remain fail-closed.
+effect Ask {
+  Get(Int) -> Bool
+}
+
+fn rejected() -> Bool {
+  handle {
+    let result = true && {
+      let answer = perform Ask::Get(1)
+      return answer
+    }
+    result
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n > 0)
+    }
+  }
+}
+
+let _start = () -> Bool {
+  rejected()
+}
+_start()

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9672,7 +9672,8 @@ fn scps_anf_wrap(bn: Array[String], bv: Array[Expr], body: Expr) -> Expr {
 /// RHS block. Only parser-produced let/sequence continuation spines are
 /// traversed, and every suspending spine element must already be a direct input
 /// accepted by scps_split_tail. A plain terminal is valid only after that spine
-/// carried the selected suspension; arbitrary compound terminals stay closed.
+/// carried the selected suspension; control-transfer and arbitrary compound
+/// terminals stay closed.
 /// Moving the outer continuation under a traversed let widens that binder, so
 /// alpha-rename it first using the seq-float freshness contract.
 fn scps_let_shortcircuit_bind(result: String, rhs: Expr, continuation: Expr, result_off: Int, site: Int, sctx: (String, Array[String], Array[String], Int, Array[String]), carried: Bool) -> Option[Expr] {
@@ -9700,6 +9701,11 @@ fn scps_let_shortcircuit_bind(result: String, rhs: Expr, continuation: Expr, res
         }
       }
     },
+    // A source control transfer cannot be rebound inside the synthetic resume
+    // continuation: it would target that closure rather than its source scope.
+    EReturn(_) => None,
+    EBreak(_) => None,
+    EContinue(_) => None,
     _ => if scps_contains_susp(rhs, sctx) {
       if scps_direct_spine_input(rhs, sctx) {
         Some(ELet(result, rhs, continuation, result_off))

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9668,6 +9668,52 @@ fn scps_anf_wrap(bn: Array[String], bv: Array[Expr], body: Expr) -> Expr {
   out
 }
 
+/// Push one immutable-let binding into the terminal of a selected short-circuit
+/// RHS block. Only parser-produced let/sequence continuation spines are
+/// traversed, and every suspending spine element must already be a direct input
+/// accepted by scps_split_tail. A plain terminal is valid only after that spine
+/// carried the selected suspension; arbitrary compound terminals stay closed.
+/// Moving the outer continuation under a traversed let widens that binder, so
+/// alpha-rename it first using the seq-float freshness contract.
+fn scps_let_shortcircuit_bind(result: String, rhs: Expr, continuation: Expr, result_off: Int, site: Int, sctx: (String, Array[String], Array[String], Int, Array[String]), carried: Bool) -> Option[Expr] {
+  match rhs {
+    ELet(x, v, b, off) => {
+      let susp = scps_contains_susp(v, sctx)
+      if susp && !scps_direct_spine_input(v, sctx) {
+        None
+      } else {
+        let nx = scps_seq_float_fresh(x, b, continuation, site)
+        match scps_let_shortcircuit_bind(result, scps_rename_ident(b, x, nx), continuation, result_off, site, sctx, carried || susp) {
+          Some(rest) => Some(ELet(nx, v, rest, off)),
+          None => None
+        }
+      }
+    },
+    ESeq(a, b) => {
+      let susp = scps_contains_susp(a, sctx)
+      if susp && !scps_direct_spine_input(a, sctx) {
+        None
+      } else {
+        match scps_let_shortcircuit_bind(result, b, continuation, result_off, site, sctx, carried || susp) {
+          Some(rest) => Some(ESeq(a, rest)),
+          None => None
+        }
+      }
+    },
+    _ => if scps_contains_susp(rhs, sctx) {
+      if scps_direct_spine_input(rhs, sctx) {
+        Some(ELet(result, rhs, continuation, result_off))
+      } else {
+        None
+      }
+    } else if carried {
+      Some(ELet(result, rhs, continuation, result_off))
+    } else {
+      None
+    }
+  }
+}
+
 fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), st: (Array[Int], Array[String], Array[String], Array[String], Array[String], Array[Stmt], Array[String])) -> (Bool, Expr) {
   let (eff, ops, _, site, cps_locals) = sctx
   if !scps_contains_susp(e, sctx) {
@@ -9724,78 +9770,104 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           }
         },
         ELet(x, v, b, off) => {
-          let vp = scps_as_target_perform(v, ops)
-          let vn = scps_as_needing_call(v, sctx)
-          let vc = scps_as_cps_local_call(v, sctx)
-          if vp >= 0 {
-            let vargs = scps_perform_args(v)
-            if scps_exprs_contain_susp(vargs, sctx) {
-              (false, e)
-            } else {
-              let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
-              (bok, scps_mk_yield(eff, scps_op_suffix(Array::get(ops, vp)), vargs, x, bexpr))
-            }
-          } else if vn != "" {
-            let vargs = scps_call_args(v)
-            if scps_exprs_contain_susp(vargs, sctx) {
-              (false, e)
-            } else {
-              scps_need_clone(eff, vn, st)
-              let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
-              (bok, ECall(EIdent(scps_bubble_name(eff), -1), [
-                ECall(EIdent(scps_clone_name(eff, vn), -1), vargs, -1),
-                scps_mk_fn1(x, bexpr)
-              ], -1))
-            }
-          } else if vc != "" {
-            // closure-CPS: `let x = f(a) REST` where `f` is a step-typed
-            // closure binding -- bubble the step it returns, no clone.
-            let vargs = scps_call_args(v)
-            if scps_exprs_contain_susp(vargs, sctx) {
-              (false, e)
-            } else {
-              let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
-              (bok, ECall(EIdent(scps_bubble_name(eff), -1), [
-                v,
-                scps_mk_fn1(x, bexpr)
-              ], -1))
-            }
-          } else if scps_contains_susp(v, sctx) {
-            // #1536 (a) v8: the value is a compound around the suspension.
-            let (aok, abn, abv, av) = scps_anf_compound(v, sctx, e, site)
-            if aok {
-              scps_split_tail(scps_anf_wrap(abn, abv, ELet(x, av, b, off)), sctx, ctx, st)
-            } else {
-              (false, e)
-            }
-          } else {
-            // closure-CPS: a let-bound literal the prepass step-split makes
-            // `x` a step-typed binding for the rest of this spine; a
-            // non-step rebind of an existing cps-local name masks it.
-            let is_step_lit = scps_literal_is_step_for(v, eff)
-            let (_, s_ops, s_needing, s_site, s_cps) = sctx
-            let sctx2 = if is_step_lit {
-              let ext = Array::slice(s_cps, 0, Array::length(s_cps))
-              Array::push(ext, x)
-              (eff, s_ops, s_needing, s_site, ext)
-            } else if edp_str_array_contains(s_cps, x) {
-              let masked = array_empty_str()
-              let mut mi = 0
-              while mi < Array::length(s_cps) {
-                let mnm = Array::get(s_cps, mi)
-                if mnm == x {
-                  ()
+          // #1536 immutable-let short-circuit: only a whole initializer with
+          // a non-suspending left operand may distribute its binding and
+          // continuation into the conditionally evaluated branches. Generic
+          // compound ANF remains fail-closed for short-circuit RHS positions.
+          let shortcircuit = match v {
+            EBinOp(op, l, r) => if !scps_contains_susp(l, sctx) && scps_contains_susp(r, sctx) {
+              match scps_let_shortcircuit_bind(x, r, b, off, site, sctx, false) {
+                Some(selected) => if op == "&&" {
+                  Some(EIf(l, selected, ELet(x, EBool(false), b, off)))
+                } else if op == "||" {
+                  Some(EIf(l, ELet(x, EBool(true), b, off), selected))
                 } else {
-                  Array::push(masked, mnm)
-                }
-                mi = mi + 1
+                  None
+                },
+                None => None
               }
-              (eff, s_ops, s_needing, s_site, masked)
             } else {
-              sctx
+              None
+            },
+            _ => None
+          }
+          match shortcircuit {
+            Some(lowered) => scps_split_tail(lowered, sctx, ctx, st),
+            None => {
+              let vp = scps_as_target_perform(v, ops)
+              let vn = scps_as_needing_call(v, sctx)
+              let vc = scps_as_cps_local_call(v, sctx)
+              if vp >= 0 {
+                let vargs = scps_perform_args(v)
+                if scps_exprs_contain_susp(vargs, sctx) {
+                  (false, e)
+                } else {
+                  let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
+                  (bok, scps_mk_yield(eff, scps_op_suffix(Array::get(ops, vp)), vargs, x, bexpr))
+                }
+              } else if vn != "" {
+                let vargs = scps_call_args(v)
+                if scps_exprs_contain_susp(vargs, sctx) {
+                  (false, e)
+                } else {
+                  scps_need_clone(eff, vn, st)
+                  let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
+                  (bok, ECall(EIdent(scps_bubble_name(eff), -1), [
+                    ECall(EIdent(scps_clone_name(eff, vn), -1), vargs, -1),
+                    scps_mk_fn1(x, bexpr)
+                  ], -1))
+                }
+              } else if vc != "" {
+                // closure-CPS: `let x = f(a) REST` where `f` is a step-typed
+                // closure binding -- bubble the step it returns, no clone.
+                let vargs = scps_call_args(v)
+                if scps_exprs_contain_susp(vargs, sctx) {
+                  (false, e)
+                } else {
+                  let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
+                  (bok, ECall(EIdent(scps_bubble_name(eff), -1), [
+                    v,
+                    scps_mk_fn1(x, bexpr)
+                  ], -1))
+                }
+              } else if scps_contains_susp(v, sctx) {
+                // #1536 (a) v8: the value is a compound around the suspension.
+                let (aok, abn, abv, av) = scps_anf_compound(v, sctx, e, site)
+                if aok {
+                  scps_split_tail(scps_anf_wrap(abn, abv, ELet(x, av, b, off)), sctx, ctx, st)
+                } else {
+                  (false, e)
+                }
+              } else {
+                // closure-CPS: a let-bound literal the prepass step-split makes
+                // `x` a step-typed binding for the rest of this spine; a
+                // non-step rebind of an existing cps-local name masks it.
+                let is_step_lit = scps_literal_is_step_for(v, eff)
+                let (_, s_ops, s_needing, s_site, s_cps) = sctx
+                let sctx2 = if is_step_lit {
+                  let ext = Array::slice(s_cps, 0, Array::length(s_cps))
+                  Array::push(ext, x)
+                  (eff, s_ops, s_needing, s_site, ext)
+                } else if edp_str_array_contains(s_cps, x) {
+                  let masked = array_empty_str()
+                  let mut mi = 0
+                  while mi < Array::length(s_cps) {
+                    let mnm = Array::get(s_cps, mi)
+                    if mnm == x {
+                      ()
+                    } else {
+                      Array::push(masked, mnm)
+                    }
+                    mi = mi + 1
+                  }
+                  (eff, s_ops, s_needing, s_site, masked)
+                } else {
+                  sctx
+                }
+                let (bok, bexpr) = scps_split_tail(b, sctx2, ctx, st)
+                (bok, ELet(x, v, bexpr, off))
+              }
             }
-            let (bok, bexpr) = scps_split_tail(b, sctx2, ctx, st)
-            (bok, ELet(x, v, bexpr, off))
           }
         },
         ESeq(a, b) => match a {

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6883,7 +6883,8 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 # operation order, handler visits, resumed source-continuation events, and the
 # handler regaining control afterward; exact event counts pin exact-once flow.
 VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
-  fixtures/effect_tail_shortcircuit_suspend.vibe
+  fixtures/effect_tail_shortcircuit_suspend.vibe \
+  fixtures/effect_let_shortcircuit_suspend.vibe
 # #1536: loop bodies carrying `break` / `continue`. The transfers become calls
 # on the CPS spine (exit continuation / loop self-call), dead statements behind
 # a transfer drop, and a nested loop keeps its own transfers. `return` in the
@@ -6904,6 +6905,10 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 scps_check_reject "err_effect_compound_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundbranch"
 scps_check_reject "err_effect_compound_match_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundmatchbranch"
 scps_check_reject "err_effect_compound_shortcircuit_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundshortcircuit"
+# Immutable-let short-circuit support does not recursively admit another
+# short-circuit or hand a suspending call argument to generic compound ANF.
+scps_check_reject "err_effect_let_shortcircuit_nested_suspend.vibe" "let/seq/tail/branch-tail spine" "letshortcircuitnested"
+scps_check_reject "err_effect_let_shortcircuit_call_arg_suspend.vibe" "let/seq/tail/branch-tail spine" "letshortcircuitcallarg"
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
 # THAT diagnostic, so the fixture cannot silently start passing for the other

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6906,9 +6906,11 @@ scps_check_reject "err_effect_compound_branch_suspend.vibe" "let/seq/tail/branch
 scps_check_reject "err_effect_compound_match_branch_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundmatchbranch"
 scps_check_reject "err_effect_compound_shortcircuit_suspend.vibe" "let/seq/tail/branch-tail spine" "compoundshortcircuit"
 # Immutable-let short-circuit support does not recursively admit another
-# short-circuit or hand a suspending call argument to generic compound ANF.
+# short-circuit, hand a suspending call argument to generic compound ANF, or
+# move a source return into the synthetic resume continuation.
 scps_check_reject "err_effect_let_shortcircuit_nested_suspend.vibe" "let/seq/tail/branch-tail spine" "letshortcircuitnested"
 scps_check_reject "err_effect_let_shortcircuit_call_arg_suspend.vibe" "let/seq/tail/branch-tail spine" "letshortcircuitcallarg"
+scps_check_reject "err_effect_let_shortcircuit_return_suspend.vibe" "let/seq/tail/branch-tail spine" "letshortcircuitreturn"
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
 # THAT diagnostic, so the fixture cannot silently start passing for the other


### PR DESCRIPTION
## Summary

- support a whole immutable `let` initializer whose top-level expression is `&&` / `||` and whose selected RHS carries a direct recognized suspension
- push the result continuation through only a validated `ELet` / `ESeq` spine with alpha-renaming
- remain fail-closed for nested short-circuit and suspending call-argument terminals
- add exact four-path, 14-event snapshots proving bypass, source continuation, handler regain, and exact-once execution

Broader non-tail conditionals, suspending left operands, generic ANF, typed `for-in`, row evidence, loop returns, and literal provenance remain excluded.

## Validation

- fresh stage2/stage3 fixpoint (`71363bdd…`)
- focused positive fixtures: 2/2
- focused new/existing negatives: expected rejection
- formatter checks
- `bash -n scripts/compiler_gate.sh`
- fixture accounting: 245/245
- `bash scripts/ensure_generated.sh --check`
- `bit diff --check HEAD^ HEAD`

Refs #1536