### PR TITLE
test infra: branch coverage を union で測れるようにする (#1556) + affected 戦略を import グラフに乗せる (#988)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,31 @@ jobs:
         run: |
           VIBE_SUITE_CLI_WASM="_build/_ci_shard_gen/stage2.wasm" \
             bash scripts/coverage_suite.sh
+      - name: Coverage summary (#1556)
+        # Put the union rates on the run's summary page so the current value is
+        # visible without downloading the artifact or scrolling the log -- the
+        # union numbers are the source-coverage ones (each function/branch
+        # counted once); the entry-weighted pair is kept for continuity with
+        # the older gate and is NOT source coverage.
+        if: always()
+        run: |
+          report=_build/coverage/selfhost-suite/selfhost_suite.report.json
+          [ -f "$report" ] || exit 0
+          python3 - "$report" >> "$GITHUB_STEP_SUMMARY" <<'PY'
+          import json, sys
+          r = json.load(open(sys.argv[1]))
+          fu, bu, w = r["function_union"], r["branch_union"], r["entry_weighted"]
+          print("### selfhost suite coverage\n")
+          print("| metric | hit | total | rate |")
+          print("| --- | ---: | ---: | ---: |")
+          for name, m in (("branch union", bu), ("function union", fu),
+                          ("branch (entry-weighted)", w["branch"]),
+                          ("function (entry-weighted)", w["function"])):
+              print(f"| {name} | {m['hit']} | {m['total']} | {m['rate']}% |")
+          print(f"\ncases {r['entries_passed']}/{r['entries_total']} ({r['case_rate']}%)")
+          if not bu["exact"]:
+              print("\n> branch union is a LOWER BOUND (some entries reported no branch mask).")
+          PY
       - name: Upload compiler suite coverage report
         if: always()
         uses: actions/upload-artifact@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,8 @@ vibe 言語の構文・機能を把握するには、最初に [docs/cheatsheet.
 pkf list                  # show all tasks
 pkf run                   # default: release-check (full sign-off)
 pkf run test              # operation gate (commit 前の主チェック)
-pkf run test-local        # affected tests only (fast inner loop)
+pkf run test-affected     # affected tests only, import-graph selected (#988)
+pkf run test-local        # flaker lane (directory-based selection — see caveat)
 pkf run full-gate         # complete operation gate
 pkf run run -- args       # run main with args
 # 型検査 / 診断: vibe check <file.vibe> (空出力 = clean、診断ありは exit 1)
@@ -271,6 +272,19 @@ vibe check --single-file --json file.vibe
 # 空出力 = ファイル中の `let mut` は全部ただの local
 vibe escapes file.vibe
 
+# 解決済みの import closure (1行1パス、依存先が先、自分自身は除く。#988)。
+# ローダ自身の収集結果 = ビルドが実際にコンパイルする集合なので、実解決
+# (index.vibe facade・.vpkg contract とその兄弟実装・@scope/pkg の
+# store/lib 解決・directory-shared vpkg import・re-export) からずれない。
+# 空出力 = import 無し。**エラーは fatal** (途中まで出た依存リストは
+# 「劣化した答え」ではなく誤答なので、黙って返さない)
+vibe deps file.vibe
+# --direct は 1 hop だけ。index を作るならこちら — 直接エッジはそのファイルの
+# テキストだけの関数なので、キャッシュ無効化がコンパイラの header cache と
+# 同じ粒度になる (1 ファイル編集 → 1 ファイル再問い合わせ)。closure は
+# 中のどこが変わっても全体が無効になるのでこの性質を持たない
+vibe deps --direct file.vibe
+
 # AST パターン検索 (#1572)。上の4つが「位置 → 意味」なのに対しこれは逆向きの
 # 「構造 → 位置」。メタ変数は `$(name:kind)` (kind: exp/id/const/arg/args/pat/type)。
 # 出力は 1件1行 `path:line:col: <マッチ本文>` + tab 区切りの `$var=<capture>`。
@@ -338,7 +352,10 @@ completion / signature help を提供する。詳細は
 
 - `pkf run test` — operation gate (`scripts/compiler_gate.sh`)。commit 前の主チェック。
 - `pkf run release-check` — full gate (fmt + info + check + test + operation gates)。
-- `pkf run test-local` — 変更影響範囲のテストのみ (fast inner loop、flaker 経由)。
+- `pkf run test-affected` — 変更影響範囲のテストのみ (fast inner loop)。選択は
+  コンパイラ自身の解決済み import グラフ (`vibe deps`) を遡る。判定できない
+  変更は全件に倒れる。`pkf run test-local` (flaker) はディレクトリ選択なので
+  別ディレクトリの依存元を落とす — 詳細は "Local Test Execution" 節。
 - 型検査 / 診断は `vibe check <file.vibe>`（空出力 = clean、診断ありは stdout に
   1件1行 + exit 1）。import は FS から解決するので、これ単体で可否を判定できる。
   **未保存バッファ相当の単一ファイル解析が要るときだけ `--single-file`** を足す
@@ -429,21 +446,39 @@ P2 = 機能追加)。「重要そう」は優先度に入れない。新規起�
 
 ## Local Test Execution
 
-ローカルでのテスト実行には `pkf run test-local` を使う。全テスト（1162件、~2分）を毎回流す必要はない。
-これは `scripts/flaker_run.sh` 経由で `flaker` を起動するため、mise の symlink 経由で CLI が no-op になる問題を避けられる。
+**変更影響範囲だけ回すなら `pkf run test-affected` を使う** (#988)。全テストを
+毎回流す必要はない。
 
 ```bash
-# 変更に影響するテストだけ実行（推奨、時間制約120秒）
-pkf run test-local
-
-# CI と同じ hybrid サンプリング（30%）
-pkf run test-local -- --profile ci
-
-# 全テスト実行（データ蓄積用、定期的に）
-pkf run test-local -- --profile scheduled
+pkf run test-affected                       # origin/main との merge-base から差分を取る
+pkf run test-affected -- --dry-run          # 選ばれるファイルを出すだけ
+pkf run test-affected -- --explain          # なぜ選ばれたか (変更 → import 経路) を stderr へ
+pkf run test-affected -- --changed lib/@vibe/parser/token.vibe   # 明示指定
 ```
 
-`pkf run test-local` はデフォルトで `--profile local`（affected 戦略）を使い、`git diff` から影響範囲のテストだけを選択する。データが蓄積されるほど選択精度が上がる。
+選択は**コンパイラ自身が解決した import グラフ**を遡る (`vibe deps --direct` →
+`scripts/affected_tests.mjs`)。グラフを別途導出していないので、`index.vibe`
+facade・`.vpkg` contract とその兄弟実装・`@scope/pkg` の store/lib 解決・
+directory-shared vpkg import・re-export といった実際の解決規則から**ずれない**。
+インクリメンタルビルドの persistent header cache に乗るので、1 ファイル編集なら
+再問い合わせも 1 ファイル (index 全構築は 1068 files / ~32s、warm は ~0.3s)。
+
+**判定できないときは必ず全件に倒れる** (fail open)。import グラフの外の変更
+(`scripts/`・seed・`Taskfile.pkl`・`fixtures/`)、stage2 が無い、index が
+不完全 — いずれも selector が exit 2 を返し、`test_affected.sh` は全件実行に
+切り替える。「判定できなかった」と「影響なし」が同じ green になってはいけない。
+
+> **`pkf run test-local` (flaker) は選択が信用できない。** flaker.toml の
+> `[affected] resolver = "simple"` は**ディレクトリ**で選ぶので、別ディレクトリ
+> から import しているテストを落とす。実測 (575 entries): `core/types.vibe` の
+> 変更は実際には 217 件に影響するが **0 件**しか選ばれない (そのディレクトリに
+> `*_test.vibe` が無いため)。`parser/token.vibe` は 190 件に対して 1 件。
+> flaker 側に custom resolver フックを入れるのが #988 の残り半分。
+
+```bash
+pkf run test-local -- --profile ci          # CI と同じ hybrid サンプリング (30%)
+pkf run test-local -- --profile scheduled   # 全テスト (データ蓄積用)
+```
 
 `pkf run test` は全テスト実行。commit 前の最終確認や CI 用。
 

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -393,6 +393,20 @@ local testLocal = new Task {
   cache = false
 }
 
+// #988: affected tests from the compiler's OWN resolved import graph, no
+// flaker involved. `test-local` picks by DIRECTORY (flaker.toml's `simple`
+// resolver), which misses every test importing the change from elsewhere --
+// editing lib/@vibe/compiler/core/types.vibe reaches 217 of 575 entries and
+// selects 0. This walks `vibe deps` edges upward instead, and falls back to
+// the full battery whenever it cannot prove an answer.
+local testAffected = new Task {
+  name = "test-affected"
+  description = "tests reachable from the change via the real import graph (#988)"
+  cmd = "bash scripts/test_affected.sh $@"
+  acceptsArgs = true
+  cache = false
+}
+
 local testFull = new Task {
   name = "test-full"
   description =
@@ -1118,6 +1132,7 @@ tasks {
   test
   testVibeLibrary
   testLocal
+  testAffected
   testFull
   ciWasmQuickShard
   ciSelfhostGatesShard

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -70,6 +70,15 @@ entry ごとの program 固有**なので entry 間で比較してはいけな�
   entry-weighted の branch rate は分母が entry 数で膨らむので目標には使えない
 - 同じ source 関数が entry ごとに異なる branch 数へ lower される
   (特殊化・辞書渡し) ことがあるため、union は**見えた最大の shape** に広げる
+- **entry ごとに合成される名前 (`_start` / `__test_<名前>` / `__bench_<名前>`)
+  だけは entry path で修飾する** (`union_key`)。これらは source 修飾を持たない
+  ので、別 entry が同じ綴りの test ブロックを持つと同一名に落ちる (実例:
+  `hashmap_test.vibe` と `sortedmap_test.vibe` の `test "empty map"` は branch
+  数が 2 と 4 で違う)。名前だけで束ねると分母から小さい方が消え、片方で踏んだ
+  branch がもう片方の別の branch を covered にしてしまう。逆に `Array::map` /
+  `T::equals` のように source 修飾を持たないが**本当に共通**の名前もあるので、
+  修飾してよいのは合成名だけ (test/bench ブロックは import されないので、
+  この class に限り「同名 = 別関数」が常に成り立つ)
 - mask を持たない (mask 導入前の) coverage JSON が1つでも混ざると
   `branch_union.exact` が `false` になり、値は**下限**として表示される。
   この場合 ratchet は測れなかった数値で落とさないようスキップされる

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -58,8 +58,26 @@ coverage として解釈してはいけない。これは既存 gate の安定�
 `function_union` は per-entry の `hit_fns` / `missed_fns` を source-qualified
 function ID で union した primary 指標である。いずれかの entry で実行された
 関数を一度だけ数えるため、suite 全体が到達した compiler 関数の実態を表す。
-branch JSON は branch ID bitmap を公開していないため、正確な branch union は
-まだ算出できない。branch の report 値は常に entry-weighted と表示される。
+`branch_union` は branch の同じ指標 (#1556)。branch の**大域 index は
+entry ごとの program 固有**なので entry 間で比較してはいけないが、
+**owner 関数の中での ordinal** はその関数の本体を lower した順序そのものなので、
+`(source-qualified な owner 関数名, ordinal)` は同じ source 上の branch を
+どの entry でも同じように名指す。per-entry JSON の
+`branch.per_fn[fn].mask` (branch 1つにつき `'1'`/`'0'` 1文字、ordinal 昇順)
+がこの ordinal を公開しており、report 側はこれを OR して union を出す。
+
+- **`branch_union.rate` が #1556 の「分岐カバレッジ N%」目標の指標**。
+  entry-weighted の branch rate は分母が entry 数で膨らむので目標には使えない
+- 同じ source 関数が entry ごとに異なる branch 数へ lower される
+  (特殊化・辞書渡し) ことがあるため、union は**見えた最大の shape** に広げる
+- mask を持たない (mask 導入前の) coverage JSON が1つでも混ざると
+  `branch_union.exact` が `false` になり、値は**下限**として表示される。
+  この場合 ratchet は測れなかった数値で落とさないようスキップされる
+
+ratchet: `VIBE_SUITE_MIN_BRANCH_UNION_HIT` (絶対数) と
+`VIBE_SUITE_MIN_BRANCH_UNION_RATE` (率)。entry を足すと分母がその import
+closure ぶん増える entry-weighted rate と違い、union の rate は
+「テストを足せば上がる」ので率のラチェットとして意味を持つ。
 
 ### コンパイラ自身を計測
 
@@ -378,7 +396,10 @@ seed に新関数が増えても (fn,local) merge でそのままスケールす
 生成物 (`_build/coverage/selfhost-fn/`):
 - `compiler_cov.wasm` — 計測コンパイラ
 - `report.json` — `{total, hit, missed, rate, hit_fns[], missed_fns[],
-  branch: {total, hit, missed, rate, per_fn{}, top_gaps[]}}`
+  branch: {total, hit, missed, rate, per_fn{}, top_gaps[]}}`。
+  `per_fn[fn]` は `{total, hit, mask}` で、`mask` は branch 1つにつき
+  `'1'`/`'0'` 1文字 (owner 関数内 ordinal の昇順) — 別 program 間で branch を
+  同定できる唯一の鍵 (#1556)
 
 環境変数:
 - `VIBE_COV_SEED` (計測ビルドに使う seed; 既定は committed seed)

--- a/flaker.toml
+++ b/flaker.toml
@@ -23,8 +23,28 @@ list = "node scripts/flaker_vibe_runner.mjs list"
 
 [affected]
 # Path/directory-based (git diff vs origin/main merge-base): a changed file
-# selects the *_test.vibe suites living in/under its directory. Coarse but
-# simple; an import-graph resolver is future work (#988).
+# selects the *_test.vibe suites living in/under its directory.
+#
+# #988: "coarse but simple" undersells the problem -- this resolver does not
+# merely over-select, it UNDER-selects, badly. Measured against the real
+# import graph (575 entries):
+#
+#   changed file                                    graph  directory
+#   lib/@vibe/compiler/core/types.vibe                217          0
+#   lib/@vibe/parser/token.vibe                       190          1
+#   lib/@vibe/compiler/codegen/.../inline_direct_perform.vibe  60   0
+#   lib/@vibex/zlib/zlib.vibe                           1          1
+#
+# The `0` rows are the dangerous ones: those directories hold no *_test.vibe,
+# so a change to the compiler's core types selects NOTHING and the run reports
+# green having exercised none of the 217 tests that import it.
+#
+# Until this points at an import-graph resolver, prefer `pkf run test-affected`
+# (scripts/test_affected.sh) for the affected inner loop: it walks the
+# compiler's own resolved edges (`vibe deps`) and falls back to the full
+# battery whenever it cannot prove an answer. This key is left on "simple"
+# because flaker resolves it in-process; rewiring it needs a flaker-side
+# custom-resolver hook, which is the remaining half of #988.
 resolver = "simple"
 config = ""
 

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -48,6 +48,7 @@ import @vibe/compiler/cache {
 }
 
 import @vibe/compiler/loader {
+  collect_source_groups_fs,
   contract_package_hashes_fs,
   fill_require_pins_fs_mode,
   find_deps_missing,
@@ -141,6 +142,65 @@ fn join_lines(items: Array[String]) -> String {
     }
     StringBuilder::freeze(acc)
   }
+}
+
+/// Flatten `collect_source_groups_fs`'s grouped `(path, source)` result into
+/// the dependency paths alone, one per line, entry excluded (#988).
+///
+/// The set is taken from the loader's OWN collection -- the very sources the
+/// build compiles for this entry -- rather than re-deriving an import graph.
+/// That is the whole point: a separately-maintained graph drifts from the
+/// resolution the compiler actually performs (`index.vibe` facades, `.vpkg`
+/// contracts + their sibling impls, `@scope/pkg` resolving to `.vibe/store`
+/// vs `lib/`, directory-shared vpkg imports, re-exports), and a resolver that
+/// drifts UNDER-selects -- it silently skips the test that would have caught
+/// the change.
+///
+/// Duplicate paths are dropped (a source can appear in more than one group);
+/// order follows collection order, which is dependency-before-dependent.
+fn join_dep_paths(groups: Array[(String, Array[(String, String)])], entry_path: String) -> String {
+  let acc = StringBuilder::new()
+  // Same typed-empty idiom as adapter_split_nonempty_lines below.
+  let seen = Array::slice([
+    ""
+  ], 0, 0)
+  let mut first = true
+  let mut gi = 0
+  while gi < Array::length(groups) {
+    let (_, gsources) = Array::get(groups, gi)
+    let mut si = 0
+    while si < Array::length(gsources) {
+      let (path, _) = Array::get(gsources, si)
+      if path == entry_path || adapter_string_array_contains(seen, path) {
+        ()
+      } else {
+        Array::push(seen, path)
+        if first {
+          StringBuilder::push(acc, path)
+          first = false
+        } else {
+          StringBuilder::push(acc, String::concat("\n", path))
+        }
+      }
+      si = si + 1
+    }
+    gi = gi + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
+fn adapter_string_array_contains(items: Array[String], needle: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) {
+    if Array::get(items, i) == needle {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
 }
 
 /// Render `vibe symbols` records as one `NAME KIND START END` line per declared
@@ -1238,6 +1298,48 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       let src = Fs::read_file(input_path)
       let esc = escape_spans(src)
       Fs::write_bytes(output_path, adapter_string_to_bytes(join_escape_spans(esc)))
+      0
+    } with Exception {
+      Throw(msg) => emit_compile_diag(output_path, msg)
+    }
+  }
+  // `vibe deps` (#988): the resolved import closure of `input_path` -- one
+  // repo-relative path per line, the entry itself excluded, dependency before
+  // dependent. Empty output means the file imports nothing.
+  //
+  // This is the SAME collection the build performs (collect_source_groups_fs),
+  // not a re-derived graph, so it cannot drift from what the compiler actually
+  // resolves. It also rides the incremental build's persistent header cache
+  // (keyed by path + source fingerprint), so re-asking after an unrelated edit
+  // re-parses only the files that changed.
+  //
+  // An unresolvable import IS an error and goes to the `.diag` sidecar (same
+  // convention as VIBE_SYMBOLS), because a caller selecting tests from a
+  // truncated dep list would silently under-select.
+  //
+  // `VIBE_DEPS_DIRECT=1` (`vibe deps --direct`) reports ONE HOP instead: the
+  // file's own resolved imports. That is the form a dependency index wants,
+  // because its cache invalidation then matches the compiler's own -- a file's
+  // direct deps are a function of that file's text alone (which is exactly what
+  // load_or_parse_module_header_fs keys its persistent cache on), so editing
+  // one file re-queries one file. Transitive closures do not have that
+  // property: any edit anywhere in a closure invalidates the whole closure.
+  // Callers that want the closure can walk the direct edges themselves.
+  if Env::get("VIBE_DEPS") == "1" {
+    return handle {
+      if Env::get("VIBE_DEPS_DIRECT") == "1" {
+        // Ingest first, exactly as the collection walk does: a `.vpkg`
+        // contract's imports live in its DESUGARED facade, and a directory
+        // with shared vpkg imports injects them into each member. Reading the
+        // raw bytes instead would under-report both.
+        let raw = Fs::read_file(input_path)
+        let source = ingest_source_text_fs(input_path, raw)
+        let (deps, _, _) = load_or_parse_module_header_fs(input_path, source, 0)
+        Fs::write_bytes(output_path, adapter_string_to_bytes(join_lines(deps)))
+      } else {
+        let groups = collect_source_groups_fs(input_path)
+        Fs::write_bytes(output_path, adapter_string_to_bytes(join_dep_paths(groups, input_path)))
+      }
       0
     } with Exception {
       Throw(msg) => emit_compile_diag(output_path, msg)

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -57,6 +57,15 @@
 #                                         captures -- the ones codegen boxes into
 #                                         a heap ref cell instead of a wasm local
 #                                         (NAME START END per line; empty = none)
+#   vibe deps [--direct] <file.vibe>      print the resolved import closure, one
+#                                         path per line, dependency first (#988).
+#                                         The loader's OWN collection (what the
+#                                         build compiles), so it cannot drift
+#                                         from real resolution. Errors are fatal
+#                                         (a truncated list is a wrong answer).
+#                                         --direct = one hop only; use it to
+#                                         build an index, since a cache over
+#                                         direct edges invalidates per file.
 #   vibe diagnostics <file.vibe>          DEPRECATED (#1567): use
 #                                         `vibe check --single-file`. Kept
 #                                         unchanged (raw lines, always exit 0)
@@ -1239,6 +1248,59 @@ case "$cmd" in
     fi
     if [ -s "$out" ]; then cat "$out"; fi
     ;;
+  deps)
+    # vibe deps <file.vibe>   (#988)
+    #
+    # Print the RESOLVED import closure of the file, one repo-relative path per
+    # line, dependency before dependent, the file itself excluded. Empty output
+    # means it imports nothing.
+    #
+    # This is the loader's own collection -- literally the source set the build
+    # compiles for this entry -- not a separately-derived import graph. That
+    # distinction is the point: a hand-rolled graph drifts from real resolution
+    # (`index.vibe` facades, `.vpkg` contracts plus their sibling impls,
+    # `@scope/pkg` resolving to `.vibe/store` vs `lib/`, directory-shared vpkg
+    # imports, re-exports), and a drifting graph UNDER-selects -- it silently
+    # skips the test that would have caught the change.
+    #
+    # Unlike every other query verb here, an error is FATAL (non-zero exit, no
+    # stdout). A truncated dep list is not a degraded answer, it is a wrong one:
+    # callers select tests from it, so half a list means silently skipping
+    # tests. Better to fail loudly and let the caller fall back to running
+    # everything.
+    #
+    # `--direct` reports one hop instead of the closure. Prefer it when
+    # BUILDING an index: a file's direct deps are a function of that file's
+    # text alone, so a cache over them invalidates per file, the same
+    # granularity the compiler's own header cache uses. A closure has no such
+    # property -- any edit anywhere inside it invalidates the whole thing.
+    deps_direct=0
+    src=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --direct) deps_direct=1; shift ;;
+        *) [ -z "$src" ] || die "usage: vibe deps [--direct] <file.vibe>"; src="$1"; shift ;;
+      esac
+    done
+    [ -n "$src" ] || die "usage: vibe deps [--direct] <file.vibe>"
+    [ -f "$src" ] || die "not found: $src"
+    cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
+    out="$(mktemp -t vibe-deps-XXXXXX)"
+    trap 'rm -f "$out" "$out.diag"' EXIT
+    deps_direct_env=""
+    [ "$deps_direct" = "1" ] && deps_direct_env="VIBE_DEPS_DIRECT=1"
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_COVERAGE -u VIBE_DEBUG \
+        -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE -u VIBE_CHECK_ONLY \
+      VIBE_DEPS=1 ${deps_direct_env} \
+      VIBE_IMPORT_ABI=raw \
+      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
+    if [ -s "$out.diag" ]; then
+      echo "error: $(cat "$out.diag")" >&2
+      exit 1
+    fi
+    if [ -s "$out" ]; then cat "$out"; fi
+    ;;
   diagnostics)
     # vibe diagnostics [--json] <file.vibe>
     #
@@ -1370,7 +1432,7 @@ case "$cmd" in
       # Clear inherited adapter-mode envs so a leaked selector can't divert this
       # into compiling and emitting wasm bytes as "matches".
       env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-          -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_COVERAGE -u VIBE_DEBUG \
+          -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
           -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         VIBE_GREP=1 \
         VIBE_GREP_PATTERN="$g_pattern" \
@@ -1418,7 +1480,7 @@ case "$cmd" in
     # write a hash/report as $out and the default write mode would copy it
     # OVER the user's source file.
     env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_COVERAGE -u VIBE_DEBUG \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
         -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         -u VIBE_HASH -u VIBE_HASH_WRITE \
         -u VIBE_MISSING_VPKG_SCAN -u VIBE_DEPS_MISSING_SCAN -u VIBE_FILL_PINS \

--- a/scripts/affected_tests.mjs
+++ b/scripts/affected_tests.mjs
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+// Import-graph affected test selection (#988).
+//
+// flaker.toml's `[affected] resolver = "simple"` selects the `*_test.vibe`
+// files living in or under a changed file's DIRECTORY. That is wrong in both
+// directions, and the wrong direction matters much more than the wasteful one:
+//
+//   - it OVER-selects siblings that never import the changed file, and
+//   - it UNDER-selects every test that imports the changed file from another
+//     directory -- which is most of them, since `lib/@vibe/compiler/**` is
+//     imported by test files all over the tree.
+//
+// Under-selection is the failure mode to design against: a run that skips the
+// one test that would have caught the change reports green and is believed.
+// So this tool is built to FAIL OPEN. It answers "run these" only when it can
+// prove the answer; anything it cannot reason about exits 2 ("run everything").
+//
+// The graph is not re-derived here. `vibe deps --direct` returns the loader's
+// OWN resolved imports for a file -- the same call the build makes, through
+// the same persistent header cache -- so this cannot drift from the resolution
+// the compiler actually performs (`index.vibe` facades, `.vpkg` contracts and
+// their sibling impls, `@scope/pkg` landing in `.vibe/store` vs `lib/`,
+// directory-shared vpkg imports, re-exports). Riding the incremental build is
+// also what makes the index cheap to maintain: a file's direct deps are a
+// function of that file's own text, so an edit re-queries exactly that file.
+//
+// Usage:
+//   node scripts/affected_tests.mjs [options]
+//
+//   --changed-from <ref>  diff against the merge-base with <ref> (default: origin/main)
+//   --changed <path>      an explicit changed path (repeatable); suppresses git
+//   --index-only          refresh the dependency index and print nothing
+//   --explain             annotate each selected entry with its path to the change (stderr)
+//   --json                emit a JSON object instead of lines
+//   --jobs N              parallel `vibe deps` queries while building the index (default 4)
+//
+// Output: one repo-relative test entry path per line. EMPTY OUTPUT WITH EXIT 0
+// MEANS "nothing is affected" -- a real answer, not a failure.
+//
+// Exit codes:
+//   0  the printed selection is complete and trustworthy
+//   2  cannot determine -- the caller must run the full suite (see fail-open above)
+//   1  hard error (bad usage, unreadable index)
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const INDEX_PATH = join(ROOT, "_build", "affected", "dep_index.json");
+// Bump when the index's meaning changes (not merely its contents), so a stale
+// file from an older layout is discarded instead of misread.
+const INDEX_VERSION = 1;
+
+export function parseArgs(argv) {
+  const args = {
+    changedFrom: "origin/main",
+    changed: null,
+    indexOnly: false,
+    explain: false,
+    json: false,
+    jobs: 4,
+  };
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === "--changed-from") {
+      if (i + 1 >= argv.length) throw new Error("missing value after --changed-from");
+      args.changedFrom = argv[i + 1];
+      i += 2;
+    } else if (arg === "--changed") {
+      if (i + 1 >= argv.length) throw new Error("missing value after --changed");
+      (args.changed ??= []).push(argv[i + 1]);
+      i += 2;
+    } else if (arg === "--jobs") {
+      if (i + 1 >= argv.length) throw new Error("missing value after --jobs");
+      const n = Number(argv[i + 1]);
+      if (!Number.isInteger(n) || n < 1) throw new Error(`--jobs must be a positive integer, got: ${argv[i + 1]}`);
+      args.jobs = n;
+      i += 2;
+    } else if (arg === "--index-only") {
+      args.indexOnly = true;
+      i += 1;
+    } else if (arg === "--explain") {
+      args.explain = true;
+      i += 1;
+    } else if (arg === "--json") {
+      args.json = true;
+      i += 1;
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+  return args;
+}
+
+// A change this tool cannot reason about through the import graph. Anything
+// that is not vibe source under lib/ can affect any test at all: the runner
+// scripts, the seed, the task definitions, a fixture read at run time. Rather
+// than pretend the graph covers them, say so and let the caller run the suite.
+export function isGraphReasonable(path) {
+  if (!path.startsWith("lib/")) return false;
+  return path.endsWith(".vibe") || path.endsWith(".vpkg");
+}
+
+export function classifyChanges(changed) {
+  const known = [];
+  const unknown = [];
+  for (const path of changed) {
+    (isGraphReasonable(path) ? known : unknown).push(path);
+  }
+  return { known, unknown };
+}
+
+// Invert file -> direct deps into dep -> importers, then walk UPWARD from the
+// changed files. This is the cheap direction: it never materializes a closure
+// per test entry, and it visits only the part of the graph above the change.
+//
+// `entries` is the set of selectable test files; a changed file that IS one is
+// selected directly (it needs no importer).
+export function affectedFrom(index, changed, entries) {
+  const importers = new Map();
+  for (const [path, record] of Object.entries(index)) {
+    for (const dep of record.deps) {
+      let list = importers.get(dep);
+      if (!list) {
+        list = [];
+        importers.set(dep, list);
+      }
+      list.push(path);
+    }
+  }
+  const entrySet = new Set(entries);
+  const seen = new Set();
+  // `via` records the first path found from a changed file up to each node --
+  // that is what --explain prints, so a surprising selection can be checked
+  // rather than taken on faith.
+  const via = new Map();
+  const queue = [];
+  for (const path of changed) {
+    if (seen.has(path)) continue;
+    seen.add(path);
+    via.set(path, [path]);
+    queue.push(path);
+  }
+  const selected = [];
+  while (queue.length > 0) {
+    const path = queue.shift();
+    if (entrySet.has(path)) selected.push(path);
+    for (const importer of importers.get(path) ?? []) {
+      if (seen.has(importer)) continue;
+      seen.add(importer);
+      via.set(importer, [...via.get(path), importer]);
+      queue.push(importer);
+    }
+  }
+  selected.sort();
+  return { selected, via };
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function fileHash(absPath) {
+  try {
+    return sha256(readFileSync(absPath));
+  } catch {
+    return null;
+  }
+}
+
+function listTestEntries() {
+  const proc = spawnSync("bash", [join(ROOT, "scripts", "unit_test_runner.sh"), "--list"], {
+    cwd: ROOT,
+    encoding: "utf-8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (proc.status !== 0) {
+    throw new Error(`unit_test_runner.sh --list failed (exit ${proc.status}): ${proc.stderr ?? ""}`);
+  }
+  return (proc.stdout ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"));
+}
+
+function changedFromGit(ref) {
+  const base = spawnSync("git", ["merge-base", "HEAD", ref], { cwd: ROOT, encoding: "utf-8" });
+  // No merge-base (shallow clone, unknown ref) is exactly the "cannot
+  // determine" case -- do not silently fall back to comparing against HEAD,
+  // which would report an empty change set and select nothing.
+  if (base.status !== 0) return null;
+  const range = base.stdout.trim();
+  const out = spawnSync("git", ["diff", "--name-only", range], { cwd: ROOT, encoding: "utf-8" });
+  if (out.status !== 0) return null;
+  const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], {
+    cwd: ROOT,
+    encoding: "utf-8",
+  });
+  const lines = (out.stdout ?? "").split("\n");
+  if (untracked.status === 0) lines.push(...(untracked.stdout ?? "").split("\n"));
+  return [...new Set(lines.map((l) => l.trim()).filter((l) => l !== ""))];
+}
+
+function resolveCli() {
+  const explicit = process.env.VIBE_AFFECTED_CLI_WASM || process.env.VIBE_STAGE2_WASM;
+  if (explicit) return existsSync(explicit) ? explicit : null;
+  // Same rule as coverage_suite.sh: the generation built for THIS checkout,
+  // never the newest by mtime (a worktree can hold another revision's stage2,
+  // and a dep index built from the wrong compiler is quietly wrong).
+  const rev = spawnSync("git", ["rev-parse", "--short", "HEAD"], { cwd: ROOT, encoding: "utf-8" });
+  if (rev.status !== 0) return null;
+  const dir = join(ROOT, "_build", "selfhost", "generations");
+  if (!existsSync(dir)) return null;
+  const suffix = `_${rev.stdout.trim()}`;
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(suffix)) continue;
+    const candidate = join(dir, name, "stage2.wasm");
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+// One `vibe deps --direct` query. Returns the resolved direct deps, or null
+// when the query failed -- null is propagated all the way out as exit 2 rather
+// than treated as "no deps", which would silently prune the graph.
+//
+// Each concurrent query needs its OWN output path: the adapter writes
+// `<out>` and `<out>.diag`, so a shared name would let one query read
+// another's bytes.
+function queryDirectDeps(cli, path, outPath) {
+  return new Promise((resolveQuery) => {
+    rmSync(outPath, { force: true });
+    rmSync(`${outPath}.diag`, { force: true });
+    const child = spawn(
+      "bash",
+      [
+        join(ROOT, "scripts", "run_wasm_vibe_host_runner.sh"),
+        "--invoke",
+        "cli_main",
+        cli,
+        path,
+        outPath,
+        "__no_entry__",
+      ],
+      {
+        cwd: ROOT,
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          VIBE_PREOPEN_DIR: ROOT,
+          VIBE_IMPORT_ABI: "raw",
+          VIBE_DEPS: "1",
+          VIBE_DEPS_DIRECT: "1",
+        },
+      },
+    );
+    child.on("error", (err) => resolveQuery({ deps: null, error: String(err) }));
+    child.on("close", (status) => {
+      if (existsSync(`${outPath}.diag`)) {
+        const diag = readFileSync(`${outPath}.diag`, "utf-8").trim();
+        if (diag !== "") return resolveQuery({ deps: null, error: diag });
+      }
+      if (!existsSync(outPath)) {
+        // No output file at all means the mode never ran -- an older compiler
+        // without VIBE_DEPS falls through to the default compile path. That is
+        // NOT "this file has no imports", and treating it as such would prune
+        // the graph and under-select.
+        return resolveQuery({ deps: null, error: `no output from vibe deps (exit ${status})` });
+      }
+      const deps = readFileSync(outPath, "utf-8")
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l !== "")
+        .map((l) => (l.startsWith("/") ? relative(ROOT, l) : l));
+      resolveQuery({ deps, error: null });
+    });
+  });
+}
+
+function loadIndex() {
+  if (!existsSync(INDEX_PATH)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(INDEX_PATH, "utf-8"));
+    if (parsed?.version !== INDEX_VERSION) return {};
+    return parsed.entries ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function saveIndex(entries) {
+  mkdirSync(dirname(INDEX_PATH), { recursive: true });
+  writeFileSync(INDEX_PATH, `${JSON.stringify({ version: INDEX_VERSION, entries }, null, 0)}\n`);
+}
+
+// Breadth-first from the test entries over direct edges, re-querying only the
+// files whose bytes changed since the index was written. Everything reachable
+// gets an entry, so the inverted map below is complete.
+async function refreshIndex(cli, roots, jobs) {
+  const index = loadIndex();
+  const tmpDir = join(ROOT, "_build", "affected", "tmp");
+  mkdirSync(tmpDir, { recursive: true });
+  const queue = [...roots];
+  const visited = new Set(queue);
+  let queried = 0;
+  let reused = 0;
+  while (queue.length > 0) {
+    // Everything cached is settled without spawning anything; only the stale
+    // files reach the (parallel) query batch. On a warm index with one edited
+    // file, that batch has one element.
+    const batch = [];
+    while (batch.length < jobs && queue.length > 0) {
+      const path = queue.shift();
+      const hash = fileHash(join(ROOT, path));
+      if (hash === null) {
+        // A dep that no longer exists on disk: the graph moved under us, so
+        // the index cannot be completed. Fail open rather than guess.
+        return { index: null, error: `cannot read ${path}` };
+      }
+      const cached = index[path];
+      if (cached && cached.hash === hash) {
+        reused += 1;
+        for (const dep of cached.deps) {
+          if (!visited.has(dep)) {
+            visited.add(dep);
+            queue.push(dep);
+          }
+        }
+      } else {
+        batch.push({ path, hash });
+      }
+    }
+    if (batch.length === 0) continue;
+    const results = await Promise.all(
+      batch.map((item, slot) => queryDirectDeps(cli, item.path, join(tmpDir, `deps${slot}.txt`))),
+    );
+    for (let i = 0; i < batch.length; i += 1) {
+      const { path, hash } = batch[i];
+      const { deps, error } = results[i];
+      if (deps === null) return { index: null, error: `vibe deps ${path}: ${error}` };
+      index[path] = { hash, deps };
+      queried += 1;
+      for (const dep of deps) {
+        if (!visited.has(dep)) {
+          visited.add(dep);
+          queue.push(dep);
+        }
+      }
+    }
+  }
+  saveIndex(index);
+  return { index, error: null, queried, reused };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const entries = listTestEntries();
+
+  const changed = args.changed ?? changedFromGit(args.changedFrom);
+  if (changed === null) {
+    process.stderr.write(`[affected] cannot compute a change set against ${args.changedFrom}\n`);
+    process.exit(2);
+  }
+  const { known, unknown } = classifyChanges(changed);
+  if (unknown.length > 0 && !args.indexOnly) {
+    // Not a failure -- an honest "the import graph does not cover this".
+    process.stderr.write(
+      `[affected] ${unknown.length} change(s) outside the vibe import graph (e.g. ${unknown[0]}); run the full suite\n`,
+    );
+    process.exit(2);
+  }
+
+  const cli = resolveCli();
+  if (cli === null) {
+    process.stderr.write(
+      "[affected] no stage2 for this checkout; run 'pkf run generation' or set VIBE_AFFECTED_CLI_WASM\n",
+    );
+    process.exit(2);
+  }
+
+  const { index, error, queried, reused } = await refreshIndex(cli, entries, args.jobs);
+  if (index === null) {
+    process.stderr.write(`[affected] dependency index incomplete: ${error}\n`);
+    process.exit(2);
+  }
+  process.stderr.write(`[affected] index: ${queried} queried, ${reused} reused, ${Object.keys(index).length} files\n`);
+  if (args.indexOnly) return;
+
+  const { selected, via } = affectedFrom(index, known, entries);
+  if (args.explain) {
+    for (const entry of selected) {
+      process.stderr.write(`[affected] ${entry} <- ${(via.get(entry) ?? [entry]).join(" <- ")}\n`);
+    }
+  }
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify({ changed: known, selected, total_entries: entries.length }, null, 2)}\n`);
+    return;
+  }
+  for (const entry of selected) process.stdout.write(`${entry}\n`);
+}
+
+const isCliEntry = process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isCliEntry) {
+  main().catch((error) => {
+    process.stderr.write(`[affected] ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/affected_tests.test.mjs
+++ b/scripts/affected_tests.test.mjs
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { affectedFrom, classifyChanges, isGraphReasonable, parseArgs } from "./affected_tests.mjs";
+
+test("parseArgs: defaults", () => {
+  const args = parseArgs([]);
+  assert.equal(args.changedFrom, "origin/main");
+  assert.equal(args.changed, null);
+  assert.equal(args.jobs, 4);
+  assert.equal(args.indexOnly, false);
+});
+
+test("parseArgs: repeated --changed accumulates", () => {
+  const args = parseArgs(["--changed", "a.vibe", "--changed", "b.vibe"]);
+  assert.deepEqual(args.changed, ["a.vibe", "b.vibe"]);
+});
+
+test("parseArgs: rejects a non-positive --jobs", () => {
+  assert.throws(() => parseArgs(["--jobs", "0"]), /positive integer/);
+  assert.throws(() => parseArgs(["--jobs", "x"]), /positive integer/);
+});
+
+test("isGraphReasonable: only vibe sources under lib/ are covered", () => {
+  assert.equal(isGraphReasonable("lib/@vibe/compiler/codegen/codegen.vibe"), true);
+  assert.equal(isGraphReasonable("lib/@vibe/compiler/loader/index.vpkg"), true);
+  // The import graph says nothing about these, so they must NOT be silently
+  // treated as "affects nothing".
+  assert.equal(isGraphReasonable("scripts/unit_test_runner.sh"), false);
+  assert.equal(isGraphReasonable("bootstrap/seed.json"), false);
+  assert.equal(isGraphReasonable("fixtures/foo.vibe"), false);
+  assert.equal(isGraphReasonable("Taskfile.pkl"), false);
+});
+
+test("classifyChanges: splits covered from uncovered paths", () => {
+  const { known, unknown } = classifyChanges(["lib/a.vibe", "scripts/x.sh", "lib/b.vpkg"]);
+  assert.deepEqual(known, ["lib/a.vibe", "lib/b.vpkg"]);
+  assert.deepEqual(unknown, ["scripts/x.sh"]);
+});
+
+// The whole point of the tool: a test in an unrelated DIRECTORY that imports
+// the changed file transitively must be selected. The directory-based resolver
+// this replaces misses exactly this case.
+test("affectedFrom: selects a transitively-importing test in another directory", () => {
+  const index = {
+    "lib/pkg/a_test.vibe": { deps: ["lib/other/mid.vibe"] },
+    "lib/other/mid.vibe": { deps: ["lib/deep/leaf.vibe"] },
+    "lib/deep/leaf.vibe": { deps: [] },
+    "lib/unrelated/b_test.vibe": { deps: ["lib/unrelated/util.vibe"] },
+    "lib/unrelated/util.vibe": { deps: [] },
+  };
+  const entries = ["lib/pkg/a_test.vibe", "lib/unrelated/b_test.vibe"];
+
+  const { selected } = affectedFrom(index, ["lib/deep/leaf.vibe"], entries);
+
+  assert.deepEqual(selected, ["lib/pkg/a_test.vibe"]);
+});
+
+test("affectedFrom: a changed test file selects itself with no importer", () => {
+  const index = { "lib/pkg/a_test.vibe": { deps: [] } };
+  const { selected } = affectedFrom(index, ["lib/pkg/a_test.vibe"], ["lib/pkg/a_test.vibe"]);
+  assert.deepEqual(selected, ["lib/pkg/a_test.vibe"]);
+});
+
+test("affectedFrom: a change nothing imports selects nothing", () => {
+  const index = {
+    "lib/pkg/a_test.vibe": { deps: ["lib/pkg/util.vibe"] },
+    "lib/pkg/util.vibe": { deps: [] },
+    "lib/orphan.vibe": { deps: [] },
+  };
+  const { selected } = affectedFrom(index, ["lib/orphan.vibe"], ["lib/pkg/a_test.vibe"]);
+  assert.deepEqual(selected, []);
+});
+
+test("affectedFrom: a shared dep selects every importing test, deduped and sorted", () => {
+  const index = {
+    "lib/z_test.vibe": { deps: ["lib/core.vibe"] },
+    "lib/a_test.vibe": { deps: ["lib/mid.vibe", "lib/core.vibe"] },
+    "lib/mid.vibe": { deps: ["lib/core.vibe"] },
+    "lib/core.vibe": { deps: [] },
+  };
+  const entries = ["lib/z_test.vibe", "lib/a_test.vibe"];
+
+  const { selected } = affectedFrom(index, ["lib/core.vibe"], entries);
+
+  assert.deepEqual(selected, ["lib/a_test.vibe", "lib/z_test.vibe"]);
+});
+
+// An import cycle must not hang the upward walk. The compiler rejects cycles,
+// but a stale index can still contain one, and hanging is a worse failure than
+// over-selecting.
+test("affectedFrom: terminates on a cyclic index", () => {
+  const index = {
+    "lib/a.vibe": { deps: ["lib/b.vibe"] },
+    "lib/b.vibe": { deps: ["lib/a.vibe"] },
+    "lib/t_test.vibe": { deps: ["lib/a.vibe"] },
+  };
+  const { selected } = affectedFrom(index, ["lib/b.vibe"], ["lib/t_test.vibe"]);
+  assert.deepEqual(selected, ["lib/t_test.vibe"]);
+});
+
+test("affectedFrom: explain path runs from the change up to the entry", () => {
+  const index = {
+    "lib/t_test.vibe": { deps: ["lib/mid.vibe"] },
+    "lib/mid.vibe": { deps: ["lib/leaf.vibe"] },
+    "lib/leaf.vibe": { deps: [] },
+  };
+  const { via } = affectedFrom(index, ["lib/leaf.vibe"], ["lib/t_test.vibe"]);
+  assert.deepEqual(via.get("lib/t_test.vibe"), ["lib/leaf.vibe", "lib/mid.vibe", "lib/t_test.vibe"]);
+});

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -10532,4 +10532,69 @@ fi
 rm -rf "$chkdir"
 echo "[compiler-gate] check/diagnostics parse-error parity ok (#1567)"
 
+# --- #988: `vibe deps` -- the resolved import closure ------------------------
+#
+# This verb exists to be MACHINE-consumed (scripts/affected_tests.mjs selects
+# which tests to run from it), so the failure that matters is a list that is
+# quietly incomplete: a caller then skips tests and reports green. Every check
+# below is aimed at that, not at pretty output.
+depdir="_build/_gate_vibe_deps"
+rm -rf "$depdir"; mkdir -p "$depdir"
+dep_run() {
+  # $1 = output basename, $2 = input path, $3.. = extra env assignments
+  local dep_out="$depdir/$1"; local dep_in="$2"; shift 2
+  rm -f "$dep_out" "$dep_out.diag"
+  env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DEPS=1 "$@" \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$dep_in" "$dep_out" __no_entry__ >/dev/null 2>&1 || true
+}
+
+# (a) --direct resolves an `@scope/pkg` import to the package CONTRACT. The
+# import line says `@vibe/ast`; only real resolution turns that into a path,
+# which is precisely what a text scan of import lines cannot do.
+dep_run direct.txt lib/@vibe/parser/parser_smoke_test.vibe VIBE_DEPS_DIRECT=1
+if ! grep -qx 'lib/@vibe/ast/index.vpkg' "$depdir/direct.txt"; then
+  echo "[compiler-gate] FAIL: vibe deps --direct did not resolve '@vibe/ast' to its index.vpkg (#988)" >&2
+  cat "$depdir/direct.txt" "$depdir/direct.txt.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# (b) The closure reaches a contract's SIBLING IMPLEMENTATION. No import line
+# anywhere names lib/@vibe/ast/ast.vibe -- it enters the build only because the
+# loader pulls a .vpkg's impls in. A selection built on anything less would
+# miss every change to that file.
+dep_run closure.txt lib/@vibe/parser/parser_smoke_test.vibe
+if ! grep -qx 'lib/@vibe/ast/ast.vibe' "$depdir/closure.txt"; then
+  echo "[compiler-gate] FAIL: vibe deps closure missed the .vpkg sibling impl lib/@vibe/ast/ast.vibe (#988)" >&2
+  cat "$depdir/closure.txt" "$depdir/closure.txt.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# The closure must cover the direct deps; a closure smaller than one hop means
+# the walk terminated early and every caller under-selects.
+while IFS= read -r dep_line; do
+  [ -n "$dep_line" ] || continue
+  if ! grep -qxF "$dep_line" "$depdir/closure.txt"; then
+    echo "[compiler-gate] FAIL: vibe deps closure is missing direct dep '$dep_line' (#988)" >&2
+    exit 1
+  fi
+done < "$depdir/direct.txt"
+# The entry never lists itself (callers treat the output as "other files").
+if grep -qx 'lib/@vibe/parser/parser_smoke_test.vibe' "$depdir/closure.txt"; then
+  echo "[compiler-gate] FAIL: vibe deps listed the entry itself (#988)" >&2
+  exit 1
+fi
+
+# (c) An unresolvable import is an ERROR on the .diag sidecar with EMPTY output
+# -- never a truncated list. A partial dep list is not a degraded answer, it is
+# a wrong one, and it is the shape that makes a caller silently skip tests.
+printf 'import ./does_not_exist.vibe {\n  nope\n}\n\nexport let a = 1\n' > "$depdir/broken.vibe"
+dep_run broken.txt "$depdir/broken.vibe" VIBE_DEPS_DIRECT=1
+if [ -s "$depdir/broken.txt" ] || [ ! -s "$depdir/broken.txt.diag" ]; then
+  echo "[compiler-gate] FAIL: an unresolvable import did not land on the .diag sidecar with empty output (#988)" >&2
+  cat "$depdir/broken.txt" "$depdir/broken.txt.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$depdir"
+echo "[compiler-gate] vibe deps import-closure ok (#988)"
+
 echo "[compiler-gate] ok"

--- a/scripts/coverage_suite.sh
+++ b/scripts/coverage_suite.sh
@@ -13,25 +13,33 @@
 # Report: _build/coverage/selfhost-suite/selfhost_suite.report.json
 #   { cases: [{entry_path, ok, fn_hit, fn_total, branch_hit, branch_total}],
 #     function_union: {hit, total, rate},
+#     branch_union: {hit, total, rate, exact},
 #     entry_weighted: {function: {hit, total, rate}, branch: {hit, total, rate}},
 #     entries_total/entries_passed/case_rate,
-#     top_branch_gaps: [{entry_path, branch_hit, branch_total, branch_miss}] }
-# `function_union` is the primary source-function metric. Entry-weighted
-# function/branch values retain the existing gate semantics; branch IDs are not
-# available in the per-entry JSON, so branch union cannot be computed exactly.
+#     top_branch_gaps: [{entry_path, branch_hit, branch_total, branch_miss}],
+#     top_branch_union_gaps: [{fn, branch_hit, branch_total, branch_miss}] }
+# `function_union` / `branch_union` (#1556) are the primary source metrics:
+# each source function / branch counted once no matter how many entries link
+# it. The entry-weighted values retain the existing gate semantics and are
+# NOT source coverage -- their denominator is summed per entry, so the same
+# imported module is counted once per test file that pulls it in.
 #
-# Thresholds (percent, env-overridable; shard defaults live in
-# scripts/pkfire/gates_shard.sh — raise them as coverage improves,
-# lowering needs a rationale in the PR):
-#   VIBE_SUITE_MIN_POINT_RATE  — minimum FUNCTION coverage (fn hit/total)
-#   VIBE_SUITE_MIN_LINE_RATE   — minimum CASE PASS rate (entries green)
-#   VIBE_SUITE_MIN_BRANCH_RATE — minimum BRANCH coverage (branch hit/total)
-#   VIBE_SUITE_MIN_FN_HIT      — minimum ABSOLUTE covered functions
-#   VIBE_SUITE_MIN_BRANCH_HIT  — minimum ABSOLUTE covered branches
+# Thresholds (percent, env-overridable; this file is the ONE place they are
+# defined — raise them as coverage improves, lowering needs a rationale in
+# the PR):
+#   VIBE_SUITE_MIN_POINT_RATE        — minimum entry-weighted FUNCTION rate
+#   VIBE_SUITE_MIN_LINE_RATE         — minimum CASE PASS rate (entries green)
+#   VIBE_SUITE_MIN_BRANCH_RATE       — minimum entry-weighted BRANCH rate
+#   VIBE_SUITE_MIN_FN_HIT            — minimum ABSOLUTE covered functions
+#   VIBE_SUITE_MIN_BRANCH_HIT        — minimum ABSOLUTE covered branches
+#   VIBE_SUITE_MIN_BRANCH_UNION_HIT  — minimum UNION covered branches
+#   VIBE_SUITE_MIN_BRANCH_UNION_RATE — minimum UNION branch rate
 #
-# The ABSOLUTE minimums are the primary ratchet: adding a test entry can only
-# raise them, while the RATE floors would punish it (a new entry grows the
-# denominator by its whole import closure). Rates are kept as loose floors.
+# Among the ENTRY-WEIGHTED metrics the ABSOLUTE minimums are the primary
+# ratchet: adding a test entry can only raise them, while their RATE floors
+# would punish it (a new entry grows the denominator by its whole import
+# closure). Those rates are kept as loose floors. The UNION rate has no such
+# problem and is ratcheted directly.
 #
 # Baseline (2026-07-03, 93 allowlist entries, full-visibility #716 stage2):
 #   functions 2263/6491 (34.86%), branches 3814/41967 (9.09%), cases 92/93
@@ -97,6 +105,24 @@ MIN_LINE="${VIBE_SUITE_MIN_LINE_RATE:-97}"
 MIN_BRANCH="${VIBE_SUITE_MIN_BRANCH_RATE:-6}"
 MIN_FN_HIT="${VIBE_SUITE_MIN_FN_HIT:-42000}"
 MIN_BRANCH_HIT="${VIBE_SUITE_MIN_BRANCH_HIT:-113000}"
+# #1556: branch UNION floors. Unlike the entry-weighted numbers above, these
+# count each source branch once no matter how many entries link it, so the
+# rate is the one the issue's "branch coverage >= 60%" target is stated
+# against. Raise as coverage improves; lowering needs a rationale in the PR.
+#
+# Baseline (2026-08-13, 575 entries, all green, at 85f2ace): branch union
+# 25,081/45,543 (55.07%), function union 12,697/14,784 (85.88%). Note how far
+# these sit from the entry-weighted numbers on the SAME run (branches 6.23%,
+# functions 14.04%) -- that gap is entirely denominator dilution, not coverage.
+# Measured at 6df97b0 too (25,078/45,530 = 55.08%), so the metric is stable
+# across bases. Floors are set just under the actuals, same convention as the
+# ratchets above.
+#
+# Unlike the entry-weighted RATE floors, this rate is safe to ratchet: adding a
+# test entry cannot dilute it (a branch is counted once no matter how many
+# entries link it), so a new entry can only hold it level or push it up.
+MIN_BRANCH_UNION_HIT="${VIBE_SUITE_MIN_BRANCH_UNION_HIT:-24500}"
+MIN_BRANCH_UNION="${VIBE_SUITE_MIN_BRANCH_UNION_RATE:-54}"
 
 ALLOWLIST="$(mktemp -t vibe-coverage-entries-XXXXXX)"
 trap 'rm -f "$ALLOWLIST"' EXIT
@@ -110,7 +136,12 @@ COV_DIR="_build/vibe_test/coverage"
 # from another revision, yielding stale coverage failures or false greens.
 cli="${VIBE_SUITE_CLI_WASM:-${VIBE_STAGE2_WASM:-}}"
 if [ -z "$cli" ]; then
-  revision="$(git rev-parse --short=8 HEAD 2>/dev/null || true)"
+  # Must match how scripts/generations.sh NAMES the directory, which uses a
+  # bare `--short` (core.abbrev, 7 by default). Asking for `--short=8` here
+  # made the glob miss every locally-built generation, so the lookup always
+  # fell through to the "no stage2 built for this checkout" error even
+  # straight after a successful build.
+  revision="$(git rev-parse --short HEAD 2>/dev/null || true)"
   if [ -n "$revision" ]; then
     gen="$(ls -d "_build/selfhost/generations/"*"_${revision}/" 2>/dev/null | head -1 || true)"
   else
@@ -203,4 +234,4 @@ esac
 VIBE_TEST_CLI_WASM="$cli_abs" bash scripts/vibe_test.sh --coverage "${entries[@]}" \
   | tee "$run_log" || true
 
-python3 scripts/coverage_suite_report.py "$run_log" "$COV_DIR" "$REPORT" "$MIN_POINT" "$MIN_LINE" "$MIN_BRANCH" "$MIN_FN_HIT" "$MIN_BRANCH_HIT"
+python3 scripts/coverage_suite_report.py "$run_log" "$COV_DIR" "$REPORT" "$MIN_POINT" "$MIN_LINE" "$MIN_BRANCH" "$MIN_FN_HIT" "$MIN_BRANCH_HIT" "$MIN_BRANCH_UNION_HIT" "$MIN_BRANCH_UNION"

--- a/scripts/coverage_suite.sh
+++ b/scripts/coverage_suite.sh
@@ -111,12 +111,18 @@ MIN_BRANCH_HIT="${VIBE_SUITE_MIN_BRANCH_HIT:-113000}"
 # against. Raise as coverage improves; lowering needs a rationale in the PR.
 #
 # Baseline (2026-08-13, 575 entries, all green, at 85f2ace): branch union
-# 25,081/45,543 (55.07%), function union 12,697/14,784 (85.88%). Note how far
+# 25,131/45,638 (55.07%), function union 12,820/14,907 (86.00%). Note how far
 # these sit from the entry-weighted numbers on the SAME run (branches 6.23%,
 # functions 14.04%) -- that gap is entirely denominator dilution, not coverage.
-# Measured at 6df97b0 too (25,078/45,530 = 55.08%), so the metric is stable
-# across bases. Floors are set just under the actuals, same convention as the
-# ratchets above.
+# Measured at 6df97b0 too (55.08%), so the metric is stable across bases.
+# Floors are set just under the actuals, same convention as the ratchets above.
+#
+# Both figures went UP slightly when union_key started source-qualifying the
+# entry-local synthesized names (Codex review on #1668): the un-merged
+# `__test_<name>` collisions and the 575 separate `_start` wrappers are now
+# counted individually instead of collapsing onto one key. The branch RATE is
+# unchanged (55.07%) -- numerator and denominator grew together, which is what
+# de-merging distinct functions should do.
 #
 # Unlike the entry-weighted RATE floors, this rate is safe to ratchet: adding a
 # test entry cannot dilute it (a branch is counted once no matter how many

--- a/scripts/coverage_suite_next_branches.mjs
+++ b/scripts/coverage_suite_next_branches.mjs
@@ -106,13 +106,45 @@ export function topNonAggregateBranchGaps(report) {
   );
 }
 
+// #1556: functions with unreached branches after unioning every entry.  Unlike
+// top_branch_gaps (which ranks ENTRIES, so it mostly surfaces whichever entry
+// links the largest import closure) this names the source to write tests
+// against.  One line per function so the output stays greppable.
+export function topBranchUnionGaps(report) {
+  if (!Array.isArray(report?.top_branch_union_gaps)) {
+    return [];
+  }
+  return report.top_branch_union_gaps.filter(
+    (item) =>
+      item &&
+      typeof item.fn === "string" &&
+      typeof item.branch_miss === "number" &&
+      typeof item.branch_total === "number" &&
+      typeof item.branch_hit === "number",
+  );
+}
+
 export function buildTextReport(report, reportPath) {
   const nextEntries = computeNextBranchEntries(report);
   const gaps = topBranchGaps(report);
   const nonAggregateGaps = topNonAggregateBranchGaps(report);
+  const unionGaps = topBranchUnionGaps(report);
   const lines = [];
   lines.push("selfhost suite next branch targets");
   lines.push(`report: ${reportPath}`);
+  if (report?.branch_union) {
+    const u = report.branch_union;
+    const bound = u.exact === false ? " (lower bound)" : "";
+    lines.push(`branch_union: ${u.hit}/${u.total} (${u.rate}%)${bound}`);
+  }
+  if (unionGaps.length > 0) {
+    lines.push("top_branch_union_gaps:");
+    for (const gap of unionGaps) {
+      lines.push(
+        `- ${gap.fn} ${gap.branch_miss} missed (${gap.branch_hit}/${gap.branch_total})`,
+      );
+    }
+  }
   if (gaps.length > 0) {
     lines.push("top_branch_gaps:");
     for (const gap of gaps) {
@@ -144,6 +176,8 @@ export function buildJsonReport(report, reportPath) {
   return JSON.stringify(
     {
       report_path: reportPath,
+      branch_union: report?.branch_union ?? null,
+      top_branch_union_gaps: topBranchUnionGaps(report),
       top_branch_gaps: topBranchGaps(report),
       top_non_aggregate_branch_gaps: topNonAggregateBranchGaps(report),
       suggested_extra_entries: computeNextBranchEntries(report),

--- a/scripts/coverage_suite_next_branches.test.mjs
+++ b/scripts/coverage_suite_next_branches.test.mjs
@@ -8,7 +8,43 @@ import {
   computeNextBranchEntries,
   parseArgs,
   presetExtraEntries,
+  topBranchUnionGaps,
 } from "./coverage_suite_next_branches.mjs";
+
+test("topBranchUnionGaps: drops malformed rows and keeps well-formed ones", () => {
+  const report = {
+    top_branch_union_gaps: [
+      { fn: "f", branch_hit: 1, branch_total: 4, branch_miss: 3 },
+      { fn: "g", branch_hit: 1, branch_total: 2 },
+      { branch_hit: 0, branch_total: 2, branch_miss: 2 },
+    ],
+  };
+  assert.deepEqual(topBranchUnionGaps(report), [
+    { fn: "f", branch_hit: 1, branch_total: 4, branch_miss: 3 },
+  ]);
+});
+
+test("topBranchUnionGaps: absent section yields no rows", () => {
+  assert.deepEqual(topBranchUnionGaps({}), []);
+});
+
+test("buildTextReport: reports the branch union and its gaps", () => {
+  const text = buildTextReport({
+    branch_union: { hit: 3, total: 10, rate: 30.0, exact: true },
+    top_branch_union_gaps: [{ fn: "f", branch_hit: 1, branch_total: 4, branch_miss: 3 }],
+    cases: [],
+  }, "r.json");
+  assert.match(text, /branch_union: 3\/10 \(30%\)/);
+  assert.match(text, /- f 3 missed \(1\/4\)/);
+});
+
+test("buildTextReport: marks a non-exact branch union as a lower bound", () => {
+  const text = buildTextReport({
+    branch_union: { hit: 3, total: 10, rate: 30.0, exact: false },
+    cases: [],
+  }, "r.json");
+  assert.match(text, /branch_union: 3\/10 \(30%\) \(lower bound\)/);
+});
 
 test("parseArgs: default path and text format", () => {
   const args = parseArgs([]);

--- a/scripts/coverage_suite_report.py
+++ b/scripts/coverage_suite_report.py
@@ -52,27 +52,55 @@ def read_cases(run_log, cov_dir):
     return cases
 
 
+# Names the compiler synthesizes PER ENTRY PROGRAM rather than from an imported
+# source file: the `_start` wrapper, and one `__test_<name>` / `__bench_<name>`
+# per block in the entry itself.  Unlike every other id in the coverage JSON
+# these carry no source qualification, so two entries that happen to spell a
+# block the same lower to the SAME name -- `hashmap_test.vibe` and
+# `sortedmap_test.vibe` both declare `test "empty map"`, both emit
+# `__test_empty map`, and a union keyed on the name alone silently merges two
+# unrelated functions (their branch counts differ: 2 vs 4).  Merging them
+# undercounts the denominator and lets a branch taken in one test mark a
+# different branch covered in another.
+#
+# Test/bench blocks are never imported, so a name in this class appearing in
+# two entries is ALWAYS two distinct functions -- folding the entry in is
+# unconditionally right here.  It would be wrong for anything else: plenty of
+# genuinely shared ids also lack a source suffix (`Array::map`, `T::equals`),
+# and splitting those per entry would inflate the denominator instead.
+_ENTRY_LOCAL_PREFIXES = ("__test_", "__bench_", "_start")
+
+
+def union_key(entry_path, name):
+    if name.startswith(_ENTRY_LOCAL_PREFIXES):
+        return f"{entry_path}::{name}"
+    return name
+
+
 def function_union(cases):
     # Function ids are source-qualified in coverage JSON.  A function is hit
     # if any separately-linked entry executed it; this avoids counting an
-    # imported closure once for every test entry.
+    # imported closure once for every test entry.  Entry-local synthesized
+    # names are the exception -- see union_key.
     states = {}
     for case in cases:
         for name in case["_functions"]["missed"]:
             if isinstance(name, str):
-                states.setdefault(name, False)
+                states.setdefault(union_key(case["entry_path"], name), False)
         for name in case["_functions"]["hit"]:
             if isinstance(name, str):
-                states[name] = True
+                states[union_key(case["entry_path"], name)] = True
     hit, total = sum(states.values()), len(states)
     return {"hit": hit, "total": total, "rate": rate(hit, total)}
 
 
 def branch_union(cases):
     # #1556: the exact branch analogue of function_union.  Branch identity is
-    # (source-qualified owning function, ordinal within that function) -- see
-    # the `mask` note in wasm_vibe_host_runner.js's dumpCoverage.  Global
-    # branch indices differ per entry program and must never be compared.
+    # (owning function, ordinal within that function) -- see the `mask` note in
+    # wasm_vibe_host_runner.js's dumpCoverage.  Global branch indices differ per
+    # entry program and must never be compared.  The owning function is named by
+    # union_key, which source-qualifies the entry-local synthesized ones so two
+    # same-named test blocks in different entries stay distinct.
     #
     # `exact` is False when any passing entry reported branch data without a
     # mask (a coverage JSON produced before masks existed).  Those entries
@@ -85,15 +113,16 @@ def branch_union(cases):
         for fn, entry in case["_branch_per_fn"].items():
             if not isinstance(entry, dict):
                 continue
+            key = union_key(case["entry_path"], fn)
             mask = entry.get("mask")
             total = entry.get("total", 0)
             if mask is None:
                 exact = False
                 mask = ""
-            taken = states.get(fn)
+            taken = states.get(key)
             if taken is None:
                 taken = []
-                states[fn] = taken
+                states[key] = taken
             # A function's branch count can differ between entry programs when
             # the same source function is lowered differently (specialization,
             # dictionary passing).  Widen to the largest shape seen; ordinals

--- a/scripts/coverage_suite_report.py
+++ b/scripts/coverage_suite_report.py
@@ -26,6 +26,7 @@ def read_cases(run_log, cov_dir):
             ok, entry = match.group(1) == "ok", match.group(2)
             fn_hit = fn_total = branch_hit = branch_total = 0
             functions = {"hit": [], "missed": []}
+            branch_per_fn = {}
             path = coverage_path(cov_dir, entry)
             if ok and os.path.isfile(path):
                 with open(path, encoding="utf-8") as coverage_file:
@@ -37,6 +38,7 @@ def read_cases(run_log, cov_dir):
                     "hit": cov.get("hit_fns") or [],
                     "missed": cov.get("missed_fns") or [],
                 }
+                branch_per_fn = branch.get("per_fn") or {}
             cases.append({
                 "entry_path": entry,
                 "ok": ok,
@@ -45,6 +47,7 @@ def read_cases(run_log, cov_dir):
                 "branch_hit": branch_hit,
                 "branch_total": branch_total,
                 "_functions": functions,
+                "_branch_per_fn": branch_per_fn,
             })
     return cases
 
@@ -65,6 +68,62 @@ def function_union(cases):
     return {"hit": hit, "total": total, "rate": rate(hit, total)}
 
 
+def branch_union(cases):
+    # #1556: the exact branch analogue of function_union.  Branch identity is
+    # (source-qualified owning function, ordinal within that function) -- see
+    # the `mask` note in wasm_vibe_host_runner.js's dumpCoverage.  Global
+    # branch indices differ per entry program and must never be compared.
+    #
+    # `exact` is False when any passing entry reported branch data without a
+    # mask (a coverage JSON produced before masks existed).  Those entries
+    # still contribute their `total`, so the union stays a LOWER bound on
+    # coverage rather than silently overstating it -- but the gate must not
+    # ratchet on a number it cannot reproduce, so callers check the flag.
+    states = {}
+    exact = True
+    for case in cases:
+        for fn, entry in case["_branch_per_fn"].items():
+            if not isinstance(entry, dict):
+                continue
+            mask = entry.get("mask")
+            total = entry.get("total", 0)
+            if mask is None:
+                exact = False
+                mask = ""
+            taken = states.get(fn)
+            if taken is None:
+                taken = []
+                states[fn] = taken
+            # A function's branch count can differ between entry programs when
+            # the same source function is lowered differently (specialization,
+            # dictionary passing).  Widen to the largest shape seen; ordinals
+            # below the shared prefix still denote the same source branches.
+            width = max(total, len(mask))
+            if width > len(taken):
+                taken.extend([False] * (width - len(taken)))
+            for ordinal, char in enumerate(mask):
+                if char == "1":
+                    taken[ordinal] = True
+    hit = sum(sum(taken) for taken in states.values())
+    total = sum(len(taken) for taken in states.values())
+    return {"hit": hit, "total": total, "rate": rate(hit, total), "exact": exact}, states
+
+
+def branch_union_gaps(states, limit=25):
+    # Which SOURCE functions still have unreached branches after unioning every
+    # entry.  `top_branch_gaps` ranks entries instead, so it mostly surfaces
+    # whichever entry links the largest import closure -- not where the
+    # coverage actually is.  This list is what to write tests against.
+    gaps = [{
+        "fn": fn,
+        "branch_hit": sum(taken),
+        "branch_total": len(taken),
+        "branch_miss": len(taken) - sum(taken),
+    } for fn, taken in states.items() if sum(taken) < len(taken)]
+    gaps.sort(key=lambda gap: (-gap["branch_miss"], gap["fn"]))
+    return gaps[:limit]
+
+
 def build_report(run_log, cov_dir):
     cases = read_cases(run_log, cov_dir)
     entries_total = len(cases)
@@ -74,6 +133,7 @@ def build_report(run_log, cov_dir):
     branch_hit = sum(case["branch_hit"] for case in cases)
     branch_total = sum(case["branch_total"] for case in cases)
     union = function_union(cases)
+    b_union, b_states = branch_union(cases)
     gaps = [{
         "entry_path": case["entry_path"],
         "branch_hit": case["branch_hit"],
@@ -83,26 +143,33 @@ def build_report(run_log, cov_dir):
     gaps.sort(key=lambda gap: -gap["branch_miss"])
     for case in cases:
         del case["_functions"]
+        del case["_branch_per_fn"]
     return {
         "suite": "selfhost-unit-allowlist",
         "entries_total": entries_total,
         "entries_passed": entries_passed,
         "case_rate": rate(entries_passed, entries_total),
         "function_union": union,
+        "branch_union": b_union,
         "entry_weighted": {
             "function": {"hit": fn_hit, "total": fn_total, "rate": rate(fn_hit, fn_total)},
             "branch": {"hit": branch_hit, "total": branch_total, "rate": rate(branch_hit, branch_total)},
         },
         "cases": cases,
         "top_branch_gaps": gaps[:10],
+        "top_branch_union_gaps": branch_union_gaps(b_states),
         "top_non_aggregate_branch_gaps": [],
     }
 
 
 def main(argv):
-    run_log, cov_dir, report_path, min_point, min_line, min_branch, min_fn_hit, min_branch_hit = argv
+    # The last two (branch-union ratchet, #1556) are optional so an older
+    # caller keeps working; omitting them measures and prints without gating.
+    run_log, cov_dir, report_path, min_point, min_line, min_branch, min_fn_hit, min_branch_hit = argv[:8]
+    min_branch_union_hit, min_branch_union_rate = (argv[8:] + ["0", "0"])[:2]
     min_point, min_line, min_branch = map(float, (min_point, min_line, min_branch))
     min_fn_hit, min_branch_hit = int(min_fn_hit), int(min_branch_hit)
+    min_branch_union_hit, min_branch_union_rate = int(min_branch_union_hit), float(min_branch_union_rate)
     report = build_report(run_log, cov_dir)
     os.makedirs(os.path.dirname(report_path), exist_ok=True)
     with open(report_path, "w", encoding="utf-8") as output:
@@ -112,8 +179,11 @@ def main(argv):
     function = weighted["function"]
     branch = weighted["branch"]
     union = report["function_union"]
+    b_union = report["branch_union"]
+    approx = "" if b_union["exact"] else " (LOWER BOUND: some entries have no branch mask)"
     print(f"[coverage-suite] cases {report['entries_passed']}/{report['entries_total']} ({report['case_rate']}%)")
     print(f"[coverage-suite] function union {union['hit']}/{union['total']} ({union['rate']}%)")
+    print(f"[coverage-suite] branch union {b_union['hit']}/{b_union['total']} ({b_union['rate']}%){approx}")
     print(f"[coverage-suite] entry-weighted functions {function['hit']}/{function['total']} ({function['rate']}%)")
     print(f"[coverage-suite] entry-weighted branches {branch['hit']}/{branch['total']} ({branch['rate']}%)")
     print(f"[coverage-suite] report: {report_path}")
@@ -129,6 +199,18 @@ def main(argv):
         failures.append(f"entry-weighted covered functions {function['hit']} < min {min_fn_hit} (FN_HIT ratchet)")
     if branch["hit"] < min_branch_hit:
         failures.append(f"entry-weighted covered branches {branch['hit']} < min {min_branch_hit} (BRANCH_HIT ratchet)")
+    # #1556: the branch-union floors are the metric the 60% target is stated
+    # against.  Skipped when the union is only a lower bound -- gating on a
+    # number the run could not measure exactly would fail for the wrong reason.
+    if b_union["exact"]:
+        if b_union["hit"] < min_branch_union_hit:
+            failures.append(
+                f"union covered branches {b_union['hit']} < min {min_branch_union_hit} (BRANCH_UNION_HIT ratchet)")
+        if b_union["rate"] < min_branch_union_rate:
+            failures.append(
+                f"branch union coverage {b_union['rate']}% < min {min_branch_union_rate}% (BRANCH_UNION)")
+    elif min_branch_union_hit or min_branch_union_rate:
+        print("[coverage-suite] WARN: branch-union ratchet skipped (union is a lower bound, not exact)")
     if failures:
         for failure in failures:
             print(f"[coverage-suite] GATE FAIL: {failure}")

--- a/scripts/coverage_suite_report_test.py
+++ b/scripts/coverage_suite_report_test.py
@@ -7,13 +7,28 @@ from coverage_suite_report import build_report
 
 
 class CoverageSuiteReportTest(unittest.TestCase):
-    def write_cov(self, directory, entry, *, hit, total, hit_fns, missed_fns, branch_hit=0, branch_total=0):
+    def write_cov(self, directory, entry, *, hit, total, hit_fns, missed_fns, branch_hit=0, branch_total=0,
+                  branch_per_fn=None):
         path = directory / (entry.replace("/", "_").removesuffix(".vibe") + ".json")
+        branch = {"hit": branch_hit, "total": branch_total}
+        if branch_per_fn is not None:
+            branch["per_fn"] = branch_per_fn
         path.write_text(json.dumps({
             "hit": hit, "total": total,
             "hit_fns": hit_fns, "missed_fns": missed_fns,
-            "branch": {"hit": branch_hit, "total": branch_total},
+            "branch": branch,
         }))
+
+    def build(self, cases, log_lines=None):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            cov = root / "coverage"
+            cov.mkdir()
+            log = root / "run.log"
+            log.write_text(log_lines or "".join(f"ok   {entry}\n" for entry in cases))
+            for entry, kwargs in cases.items():
+                self.write_cov(cov, entry, **kwargs)
+            return build_report(str(log), str(cov))
 
     def test_keeps_entry_weighted_metrics_separate_from_function_union(self):
         with tempfile.TemporaryDirectory() as temp:
@@ -32,6 +47,57 @@ class CoverageSuiteReportTest(unittest.TestCase):
         self.assertEqual(report["function_union"], {"hit": 3, "total": 3, "rate": 100.0})
         self.assertNotIn("fn_rate", report)
         self.assertNotIn("branch_rate", report)
+
+    def test_branch_union_counts_each_source_branch_once(self):
+        # `shared` is linked by both entries, which take opposite branches of
+        # it.  Entry-weighted sees 2 of 4 (the function's branches counted
+        # twice); the union sees the source truth: both branches are covered.
+        common = dict(hit=1, total=1, hit_fns=["shared"], missed_fns=[])
+        report = self.build({
+            "test_a.vibe": dict(**common, branch_hit=1, branch_total=2,
+                                branch_per_fn={"shared": {"total": 2, "hit": 1, "mask": "10"}}),
+            "test_b.vibe": dict(**common, branch_hit=1, branch_total=2,
+                                branch_per_fn={"shared": {"total": 2, "hit": 1, "mask": "01"}}),
+        })
+
+        self.assertEqual(report["entry_weighted"]["branch"], {"hit": 2, "total": 4, "rate": 50.0})
+        self.assertEqual(report["branch_union"], {"hit": 2, "total": 2, "rate": 100.0, "exact": True})
+
+    def test_branch_union_widens_to_the_largest_shape_seen_for_a_function(self):
+        # The same source function can lower to a different branch count per
+        # entry program (specialization).  The union must not lose the extra
+        # branches, and unhit trailing ordinals stay counted as missed.
+        common = dict(hit=1, total=1, hit_fns=["f"], missed_fns=[])
+        report = self.build({
+            "test_a.vibe": dict(**common, branch_hit=1, branch_total=2,
+                                branch_per_fn={"f": {"total": 2, "hit": 1, "mask": "10"}}),
+            "test_b.vibe": dict(**common, branch_hit=1, branch_total=4,
+                                branch_per_fn={"f": {"total": 4, "hit": 1, "mask": "0100"}}),
+        })
+
+        self.assertEqual(report["branch_union"], {"hit": 2, "total": 4, "rate": 50.0, "exact": True})
+
+    def test_branch_union_is_flagged_inexact_without_masks(self):
+        # A coverage JSON from before masks existed still contributes its
+        # denominator, so the union stays a lower bound rather than claiming
+        # branches it cannot prove -- but it must announce that it is one.
+        report = self.build({
+            "test_a.vibe": dict(hit=1, total=1, hit_fns=["f"], missed_fns=[],
+                                branch_hit=1, branch_total=2,
+                                branch_per_fn={"f": {"total": 2, "hit": 1}}),
+        })
+
+        self.assertEqual(report["branch_union"], {"hit": 0, "total": 2, "rate": 0.0, "exact": False})
+
+    def test_failing_entries_contribute_no_branch_union(self):
+        report = self.build(
+            {"test_a.vibe": dict(hit=0, total=1, hit_fns=[], missed_fns=["f"],
+                                 branch_hit=0, branch_total=2,
+                                 branch_per_fn={"f": {"total": 2, "hit": 0, "mask": "00"}})},
+            log_lines="FAIL test_a.vibe\n",
+        )
+
+        self.assertEqual(report["branch_union"], {"hit": 0, "total": 0, "rate": 0.0, "exact": True})
 
 
 if __name__ == "__main__":

--- a/scripts/coverage_suite_report_test.py
+++ b/scripts/coverage_suite_report_test.py
@@ -89,6 +89,53 @@ class CoverageSuiteReportTest(unittest.TestCase):
 
         self.assertEqual(report["branch_union"], {"hit": 0, "total": 2, "rate": 0.0, "exact": False})
 
+    def test_same_named_test_blocks_in_different_entries_stay_distinct(self):
+        # Codex review on #1668: `__test_<name>` carries no source qualification,
+        # so two entries that spell a test block the same lower to the same
+        # function name. Real case in the suite: hashmap_test.vibe and
+        # sortedmap_test.vibe both declare `test "empty map"` and their blocks
+        # have DIFFERENT branch counts (2 vs 4). Keyed on the name alone the
+        # union merges them -- the denominator loses the smaller one and a
+        # branch taken in one test marks a different branch covered in the
+        # other. Both blocks must be counted separately: 1 + 2 of 2 + 4.
+        common = dict(hit=1, total=1, hit_fns=[], missed_fns=[])
+        report = self.build({
+            "a_test.vibe": dict(**common, branch_hit=1, branch_total=2,
+                                branch_per_fn={"__test_empty map": {"total": 2, "hit": 1, "mask": "10"}}),
+            "b_test.vibe": dict(**common, branch_hit=2, branch_total=4,
+                                branch_per_fn={"__test_empty map": {"total": 4, "hit": 2, "mask": "0110"}}),
+        })
+
+        self.assertEqual(report["branch_union"], {"hit": 3, "total": 6, "rate": 50.0, "exact": True})
+
+    def test_entry_local_names_do_not_split_genuinely_shared_functions(self):
+        # The other half of the same rule: plenty of genuinely shared ids also
+        # lack a source suffix (`Array::map`, `T::equals`). Folding the entry
+        # into THOSE would inflate the denominator instead, so only the
+        # synthesized per-entry names may be qualified.
+        common = dict(hit=1, total=1, hit_fns=[], missed_fns=[])
+        report = self.build({
+            "a_test.vibe": dict(**common, branch_hit=1, branch_total=2,
+                                branch_per_fn={"Array::map": {"total": 2, "hit": 1, "mask": "10"}}),
+            "b_test.vibe": dict(**common, branch_hit=1, branch_total=2,
+                                branch_per_fn={"Array::map": {"total": 2, "hit": 1, "mask": "01"}}),
+        })
+
+        self.assertEqual(report["branch_union"], {"hit": 2, "total": 2, "rate": 100.0, "exact": True})
+
+    def test_function_union_separates_per_entry_start_wrappers(self):
+        # Every entry emits its own `_start`. Counting them as one function is
+        # the same merge bug on the function metric -- it was there before the
+        # branch union existed.
+        report = self.build({
+            "a_test.vibe": dict(hit=1, total=2, hit_fns=["_start"], missed_fns=["shared"]),
+            "b_test.vibe": dict(hit=0, total=2, hit_fns=[], missed_fns=["_start", "shared"]),
+        })
+
+        # `shared` counted once (missed in both); the two `_start`s counted
+        # separately, one hit.
+        self.assertEqual(report["function_union"], {"hit": 1, "total": 3, "rate": 33.33})
+
     def test_failing_entries_contribute_no_branch_union(self):
         report = self.build(
             {"test_a.vibe": dict(hit=0, total=1, hit_fns=[], missed_fns=["f"],

--- a/scripts/pkfire/gates_shard.sh
+++ b/scripts/pkfire/gates_shard.sh
@@ -57,18 +57,14 @@ case "$shard" in
     bash scripts/test_check_direct_component.sh
     ;;
   coverage)
-    # Rebaselined 2026-07-05 (allowlist 110 -> 224 diluted the rates while
-    # absolute covered counts rose ~5x); rebaselined again 2026-07-15 (#801,
-    # a loader-cache fix let a previously-crashing bench test start
-    # contributing its (below-average) coverage ratio); rebaselined again
-    # 2026-07-15 (#847, mechanical index-facade reroutes grew the
-    # whole-program-merge denominator ~9.8% while absolute hit count rose)
-    # — keep in sync with the defaults in scripts/coverage_suite.sh.
-    VIBE_SUITE_MIN_POINT_RATE="${VIBE_SUITE_MIN_POINT_RATE:-20}" \
-    VIBE_SUITE_MIN_LINE_RATE="${VIBE_SUITE_MIN_LINE_RATE:-97}" \
-    VIBE_SUITE_MIN_BRANCH_RATE="${VIBE_SUITE_MIN_BRANCH_RATE:-7}" \
-    VIBE_SUITE_MIN_FN_HIT="${VIBE_SUITE_MIN_FN_HIT:-12000}" \
-    VIBE_SUITE_MIN_BRANCH_HIT="${VIBE_SUITE_MIN_BRANCH_HIT:-29000}" \
+    # The thresholds live in ONE place: the defaults in
+    # scripts/coverage_suite.sh (every one of them is env-overridable there).
+    # This shard used to duplicate them with a "keep in sync" comment and then
+    # drifted anyway -- it still pinned the pre-2026-07-25 rate floors
+    # (POINT 20 / BRANCH 7) after that rebaseline lowered them to 13/6 for
+    # actuals of 14.07%/6.35%, so running the shard failed on numbers CI (which
+    # invokes coverage_suite.sh directly) was passing. Don't re-add overrides
+    # here; change the defaults at the source instead.
     scripts/coverage_suite.sh
     ;;
   *)

--- a/scripts/test_affected.sh
+++ b/scripts/test_affected.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run only the tests the change can actually reach (#988).
+#
+#   bash scripts/test_affected.sh [--changed-from <ref>] [--changed <path>]...
+#                                 [--dry-run] [--explain] [--jobs N]
+#
+# Selection comes from scripts/affected_tests.mjs, which walks the compiler's
+# OWN resolved import graph (`vibe deps --direct`, backed by the incremental
+# build's persistent header cache) upward from the changed files. Execution is
+# the ordinary scripts/unit_test_runner.sh, handed an explicit subset -- this
+# script chooses WHAT to run and changes nothing about HOW tests run, so a
+# selected test behaves exactly as it does in a full run.
+#
+# FAIL OPEN. The selector exits 2 when it cannot prove an answer (a change
+# outside the vibe import graph, no stage2 for this checkout, an incomplete
+# index). This script turns that into a FULL run, never into an empty one:
+# "we could not tell" and "nothing is affected" must not produce the same
+# green, or the suite quietly stops protecting anything.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+dry_run=0
+sel_args=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1; shift ;;
+    --changed-from|--changed|--jobs) sel_args+=("$1" "${2:?$1 requires a value}"); shift 2 ;;
+    --explain) sel_args+=("$1"); shift ;;
+    -h|--help)
+      sed -n '2,20p' "$0" | sed 's|^# \{0,1\}||'
+      exit 0 ;;
+    *) echo "test_affected: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+selected="$(mktemp -t vibe-affected-XXXXXX)"
+trap 'rm -f "$selected"' EXIT
+
+set +e
+node scripts/affected_tests.mjs "${sel_args[@]}" > "$selected"
+sel_rc=$?
+set -e
+
+if [ "$sel_rc" = "2" ]; then
+  echo "[test-affected] selection undetermined -> running the FULL battery"
+  [ "$dry_run" = "1" ] && exit 0
+  exec bash scripts/unit_test_runner.sh
+fi
+if [ "$sel_rc" != "0" ]; then
+  echo "[test-affected] selector failed (exit $sel_rc)" >&2
+  exit "$sel_rc"
+fi
+
+count="$(grep -cve '^[[:space:]]*$' "$selected" || true)"
+total="$(bash scripts/unit_test_runner.sh --list | grep -cve '^[[:space:]]*\(#\|$\)' || true)"
+if [ "$count" = "0" ]; then
+  # A real answer, not a failure: nothing in the change is reachable from any
+  # test entry. Said out loud so it is never mistaken for a suite that ran.
+  echo "[test-affected] 0 of $total entries affected -- nothing to run"
+  exit 0
+fi
+echo "[test-affected] $count of $total entries affected"
+if [ "$dry_run" = "1" ]; then
+  cat "$selected"
+  exit 0
+fi
+VIBE_UNIT_TEST_ALLOWLIST="$selected" exec bash scripts/unit_test_runner.sh

--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -1537,15 +1537,24 @@ function dumpCoverage(reason) {
       const fnName = cov.names[owner] ?? `#${owner}`;
       const hit = bytes[covb.base + i] ? 1 : 0;
       bhit += hit;
-      const e = perFn.get(fnName) ?? { total: 0, hit: 0 };
+      const e = perFn.get(fnName) ?? { total: 0, hit: 0, bits: [] };
       e.total += 1;
       e.hit += hit;
+      e.bits.push(hit);
       perFn.set(fnName, e);
     }
     const branchPerFn = {};
     const branchGaps = [];
     for (const [fn, e] of perFn) {
-      branchPerFn[fn] = e;
+      // #1556: `mask` gives each branch an identity that survives across
+      // separately-linked entry programs. Global branch indices are per-program
+      // and meaningless to compare, but the ORDINAL of a branch within its
+      // owning function comes from lowering that function's body, so
+      // (source-qualified fn name, ordinal) names the same source branch in
+      // every entry that links the function. That pair is what lets the suite
+      // report compute an exact branch UNION instead of only entry-weighted
+      // sums. One char per branch ('1' taken / '0' not), ordinal-ascending.
+      branchPerFn[fn] = { total: e.total, hit: e.hit, mask: e.bits.join("") };
       if (e.hit < e.total) {
         branchGaps.push({ fn, taken: e.hit, total: e.total });
       }


### PR DESCRIPTION
テスト基盤が**黙って過少報告していた**箇所を 2 つ直す。どちらも「数字は出ていたが、その数字が答えていた質問が違った」という同じ形。

- **commit 1 (#1556)**: 分岐カバレッジは「可視化されていない」のではなく算出できなかった。実測すると 6.23% ではなく **55.07%**
- **commit 2 (#988)**: affected テスト選択がディレクトリ基準で、別ディレクトリの依存元を落としていた。`core/types.vibe` の変更は実際には **217 件**に影響するが **0 件**しか選ばれない

---

# 1. `#1556` — branch coverage を union で測れるようにして 55% で床を張る

`docs/coverage.md` がそう明記していた通り、per-entry の coverage JSON が branch の同定手段を出しておらず union が取れない状態だった:

> branch JSON は branch ID bitmap を公開していないため、正確な branch union はまだ算出できない。

表示されていた 6.23% は entry-weighted 値で、分母が entry ごとに import closure ぶん積み上がる(同じモジュールを 575 entry ぶん重複して数えている)。この定義のままでは 60% は到達不能で、目標が立たないのも当然だった。

## 方法

branch の**大域 index** は program 固有なので entry 間で比較できない。だが **owner 関数の中での ordinal** はその関数の本体を lower した順序そのものなので、`(source-qualified な owner 関数名, ordinal)` は同じ source 上の branch をどの entry でも同じように名指す。runner が `branch.per_fn[fn].mask`(branch 1つにつき `'1'`/`'0'` 1文字、ordinal 昇順)を出すようにして、report 側でこれを OR する。`function_union` が既にやっていたことの branch 版。

## 実測 (575 entry 全 green)

| metric | hit | total | rate |
| --- | ---: | ---: | ---: |
| **branch union** | **25,081** | **45,543** | **55.07%** |
| function union | 12,697 | 14,784 | 85.88% |
| branch (entry-weighted) | 183,272 | 2,943,178 | 6.23% |
| function (entry-weighted) | 71,448 | 508,850 | 14.04% |

base を変えて 2 回実走(`6df7b0` 55.08% / `85f2ace` 55.07%)、安定している。床は `VIBE_SUITE_MIN_BRANCH_UNION_RATE=54` / `_HIT=24500`。entry-weighted の rate 床は「テストを足すと下がる」ので loose にしか張れないが、union の rate は entry 追加で希釈されないので率のラチェットとして機能する。mask を持たない古い JSON が混ざったときは `exact: false` を立てて **ratchet はスキップ**する(測れなかった数値で落とすのは間違った理由の fail)。

`top_branch_union_gaps` も追加。既存の `top_branch_gaps` は *entry* を並べるので実質「import closure が一番大きい entry」が上位に来る。その最上位を追ったら **#1666** が出た — derive された `T::equals` が `==` の使用有無に関係なく全 enum/struct に emit されていて、96 個 / 1,710 branch が hit 0。分母の 3.8% が到達不能コードで、これが落ちるだけで 57.2% になる。

---

# 2. `#988` — affected 戦略をコンパイラの import グラフに乗せる

`flaker.toml` の `[affected] resolver = "simple"` は**ディレクトリ**でテストを選ぶ。コメントは「coarse but simple」と書いているが、実態は over-select より **under-select** が深刻だった。実測(575 entries):

| 変更ファイル | import graph | directory |
| --- | ---: | ---: |
| `lib/@vibe/compiler/core/types.vibe` | 217 | **0** |
| `lib/@vibe/parser/token.vibe` | 190 | **1** |
| `codegen/common_base/inline_direct_perform.vibe` | 60 | **0** |
| `lib/@vibex/zlib/zlib.vibe` | 1 | 1 |

`0` の行が危険な方。そのディレクトリに `*_test.vibe` が無いので、コンパイラのコア型を変えても**何も選ばれず**、217 件を1件も走らせないまま green になる。triage で P0 に置いている silent-wrong そのもの。

## 方法: グラフを導出せず、既にあるものに乗る

- **`vibe deps <file>`** — 解決済み import closure を 1行1パスで出す。中身は loader の `collect_source_groups_fs` = **ビルドが実際にコンパイルする集合そのもの**なので、実解決からずれようがない。ゲートで pin したのはずれたら困る 2 点: `@vibe/ast` が `index.vpkg` に解決されること(import 行は `@vibe/ast` としか書いていない)、closure が `.vpkg` の兄弟実装 `ast.vibe`(**どの import 行も名指さない**)に届くこと
- **`vibe deps --direct`** — 1 hop。index を作るならこちら。直接エッジはそのファイルのテキストだけの関数なので、キャッシュ無効化がインクリメンタルビルドの persistent header cache と同じ粒度になる(1 ファイル編集 → 1 ファイル再問い合わせ)。closure はこの性質を持たない
- **`scripts/affected_tests.mjs`** — 直接エッジを反転して変更ファイルから**上向き**に歩く。per-entry の closure を作らないので、グラフの変更より上だけを訪れる
- **`scripts/test_affected.sh`** / **`pkf run test-affected`** — 選択だけを担い、実行はいつもの `unit_test_runner.sh` に explicit subset を渡す(選ばれたテストの挙動は全件実行時と同一)

## fail open で設計した

「判定できなかった」と「影響なし」が同じ green になってはいけないので、selector は証明できないとき exit 2 を返し、wrapper は**全件実行へ倒す**。倒れる条件: import グラフ外の変更(`scripts/` / seed / `Taskfile.pkl` / `fixtures/`)、stage2 が無い、dep が disk から消えている、`vibe deps` の失敗。

`vibe deps` 自体もこの方針で、**他のクエリ verb と違いエラーは fatal**。途中まで出た依存リストは劣化した答えではなく誤答で、呼び出し側が黙ってテストを飛ばす形になるため。

## 実測コスト

| | |
| --- | --- |
| index 全構築 (cold) | 1068 files / **32s** (8 並列) |
| 選択 (warm) | **0.28s** |
| `zlib.vibe` 変更 → 該当 1 件を実行して終わるまで | **0.88s** |

flaker 側は `simple` のまま残した(in-process で解決するので custom resolver フックが要る)。それが #988 の残り半分で、`flaker.toml` に実測表を書いた。

---

## 検証

- `scripts/compiler_gate.sh` 完走 (exit 0)
- 新 gate 節 4 チェックを stage2 に対して実走: vpkg 解決 / `.vpkg` 兄弟実装 / entry 除外 / 未解決 import が**空出力 + `.diag`**(切り詰めたリストを返さない)
- coverage suite を 2 base で実走、どちらも 575 entry 全 green・`gate ok`
- `scripts/affected_tests.test.mjs` 11 件 pass(別ディレクトリからの推移的依存元を選ぶこと、循環 index で停止すること、非 vibe 変更を unknown に倒すこと)
- `scripts/coverage_suite_report_test.py` 5 件 / `coverage_suite_next_branches.test.mjs` 11 件 pass
- `scripts/check_vibe_fmt.sh` clean (925 files, 0 new violations)

## ついでに直した既存の 3 件

- `coverage_suite.sh` が stage2 を `--short=8` で探していたが `generations.sh` は素の `--short`(既定 7)でディレクトリ名を作る。ビルド直後でも必ず `no stage2 built for this checkout` になっていた
- `gates_shard.sh` の coverage 閾値が二重定義かつ drift(「keep in sync」と書いてあるのに 2026-07-25 の rebaseline 後も `POINT 20`/`BRANCH 7` = 実測 14.07%/6.35% に対して fail する値)。CI は `coverage_suite.sh` を直接呼ぶので露見していなかった。閾値の定義を 1 箇所に寄せた
- CI の coverage-suite job に step summary を追加(artifact を落とさずに現在値が読める)

Refs #1556, #988, #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk