### PR TITLE
fix(incremental): isolate typing caches by checker mode

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -751,19 +751,18 @@ it, making the over-invalidation residual visible per run. The artifact
 records current conservative behavior only — none of its fields is a
 production cache key or reuse decision.
 
-The existing private body case is also emitted under the explicit observation
+The historical private-body observation is emitted under the explicit
 classification `private_dependency_edit_externally_unchanged`. That classifier
 fails closed unless `app` has exactly `library` as its sole direct dependency in
 both snapshots, the dependency's source and provisional token-stream
 implementation identities change, its interface-v2 identity does not change,
 and all of the consumer's own observed identities stay unchanged. The
-persistent TypeEnv-v3 transport result for the dependency is reported as a
+persistent TypeEnv-v5 transport result for the dependency is reported as a
 separate `changed`/`unchanged` observation rather than being treated as the
-exported interface. The current consumer decision must still be `rechecked` and
-is reported as `conservative_rechecked`; this is a record of current
-conservative behavior, not a new reuse rule. This classifier does not change
-trace schema 6, cache namespace v17, TypeEnv-v3/TDRE4 transport, production
-artifact reuse, or default-gate wiring; it strengthens the existing observation gate's assertions.
+exported interface. Production TDRE5 may reuse the unaffected consumer; the
+shadow classifier remains observation-only and does not authorize that reuse.
+It does not change trace schema 6, cache namespace v19, TypeEnv-v5/TDRE5
+transport, production artifact reuse, or default-gate wiring.
 
 For this comparison, `source_fingerprint` is ingestion telemetry only;
 `implementation_fingerprint` is the provisional owner-change trigger. It is
@@ -837,9 +836,9 @@ context evidence is explicit trace-only extra filesystem work after the
 ordinary production compile. Because it is a post-compile recollection, the
 sidecar is not an atomic snapshot of the bytes used to produce the wasm; a
 concurrent filesystem or resolution-context change may describe a later
-snapshot. It never changes cache namespace `v17`, artifact
-fingerprints, artifact lookup/store/reuse decisions, interface-v2, TypeEnv-v3,
-TDRE4, or trace schema 6. A separately named shadow fingerprint uses a versioned,
+snapshot. It never changes cache namespace `v19`, artifact
+fingerprints, artifact lookup/store/reuse decisions, interface-v2, TypeEnv-v5,
+TDRE5, or trace schema 6. A separately named shadow fingerprint uses a versioned,
 fixed-order, length-prefixed `vibe-artifact-input-observation:v2` preimage and
 existing compact fingerprint. It is observation-only and is never passed to a
 load/store/database reuse API. This remains neither a normalized implementation

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -125,7 +125,7 @@ validator. Its attempt counter is test observation, not production telemetry.
 
 The aggregate and its complete-encoding fingerprint are shadow comparison data
 only. They are not wired to TypeDb, the TypeEnv v5 transport and persistent cache
-namespace v18, TDRE4, interface-v2, artifact-input traces, planner decisions,
+namespace v19, TDRE5, interface-v2, artifact-input traces, planner decisions,
 reuse, CLI, or a persistent cache namespace. Decoded values establish canonical
 bytes, not a checker invocation. Runtime retains v2 bytes only in an opaque,
 in-memory successful `ModuleOutcome`; it does not publish or persist them.
@@ -275,10 +275,10 @@ claim.
 
 ## Dependency transport-environment typing reuse
 
-TDRE4 TypeEnv reuse is enabled by default for the `vibe check` filesystem
+TDRE5 TypeEnv reuse is enabled by default for the `vibe check` filesystem
 check-only lane. Build, codegen, LSP, and direct FS typecheck consumers remain
 conservative pending a compact exact-publication design: publishing the current
-exact TDRE4A/TDRE4W texts on a fresh selfcompile exceeds the signed 2 GiB guest
+exact TDRE5A/TDRE5W texts on a fresh selfcompile exceeds the signed 2 GiB guest
 heap boundary, while the conservative compile lane remains near 1.11 GB.
 `VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE=1` is the strict emergency opt-out for
 check-only reuse;
@@ -289,16 +289,17 @@ invalidation trace automatically forces reuse off so the trace stays
 observation-only. For compatibility, explicitly combining legacy `1` with an
 invalidation trace remains rejected.
 
-TDRE4 aliases the exact logical
+TDRE5 aliases the exact logical
 `ModuleJob` checker input to a previously checked TypeEnv: canonical owner path,
-byte-exact owner source, `resolution_env_seed()`, and every `(path, canonical
-TypeEnv-v3 transport text)` row in the exact ordered resolved direct-dependency
-projection. The coordinator retains the full accumulated environment cache only
+byte-exact owner source, the canonical effective typing-semantics seed (currently
+checked versus unchecked `Exception` rows), `resolution_env_seed()`, and every
+`(path, canonical TypeEnv-v5 transport text)` row in the exact ordered resolved
+direct-dependency projection. The coordinator retains the full accumulated environment cache only
 for graph coordination and upsert; it projects each `deps` occurrence in order,
 preserves duplicate paths and first-match cache lookup, and fails closed if any
 resolved row is missing. The same projected array is passed to `check_module`
-and to TDRE4 lookup/publication, so ambient non-direct cache mutations are
-semantically irrelevant and avoid quadratic canonical serialization. TDRE4 does
+and to TDRE5 lookup/publication, so ambient non-direct cache mutations are
+semantically irrelevant and avoid quadratic canonical serialization. TDRE5 does
 not replace exact transport text with a compact fingerprint. It validates and
 republishes the decoded environment under the ordinary conservative fingerprint.
 It does not use the
@@ -307,16 +308,16 @@ malformed, missing, stale, torn, or cross-spliced aliases, witnesses, and target
 fall back to a full check. The alias remains incompatible with the incremental
 invalidation trace lane so the two identities cannot be confused.
 
-The v3 TypeEnv codec round-trips every current `TypeEnv` variant, including
+The v5 TypeEnv codec round-trips every current `TypeEnv` variant, including
 trait definitions, impls, generic impl bounds, trait-header parameters,
 positional method-generic binders/bounds, and method `TypeExpr` metadata. The
-production-default promotion bumps the global persistent cache namespace from
-v16 to v17 because reuse policy changed. It keeps the TypeEnv-v3 envelope,
-TDRE4 alias and eligibility-witness namespaces, and `TDRE4A` / `TDRE4W`
-envelopes unchanged. A sidecar is still only an alias to a conservative
+checked-row cache isolation bumps the global persistent cache namespace from
+v18 to v19 and replaces TDRE4 aliases/witnesses with disjoint TDRE5 namespaces
+and `TDRE5A` / `TDRE5W` envelopes. Old entries are never reinterpreted. A
+sidecar is still only an alias to a conservative
 TypeEnv commit, not a `CheckedProgram` or lossless typed-IR transport.
 
-A witness is published only after that module's canonical TypeEnv-v3 target and
+A witness is published only after that module's canonical TypeEnv-v5 target and
 when every direct dependency already has a validated witness for its conservative
 fingerprint. Alias and witness both bind the logical input, target conservative
 fingerprint, and exact canonical target text. Reuse reads the raw target,

--- a/lib/@vibe/compiler/_selfbuild_gate_block_a.vibe
+++ b/lib/@vibe/compiler/_selfbuild_gate_block_a.vibe
@@ -325,7 +325,7 @@ export fn selfbuild_probe_fn_count() -> Int with Exception {
 }
 
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(source)
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:checked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let (dep_path, dep_fp) = Array::get(dep_fps, i)

--- a/lib/@vibe/compiler/_selfbuild_gate_block_a.vibe
+++ b/lib/@vibe/compiler/_selfbuild_gate_block_a.vibe
@@ -325,7 +325,7 @@ export fn selfbuild_probe_fn_count() -> Int with Exception {
 }
 
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:checked|source:", source))
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let (dep_path, dep_fp) = Array::get(dep_fps, i)

--- a/lib/@vibe/compiler/cache/index.vpkg
+++ b/lib/@vibe/compiler/cache/index.vpkg
@@ -4,6 +4,7 @@ description =
   #|@vibe/compiler/cache — ADR-0070 / #897 compiler-internal contract. This
 deps = {
   @vibe/cache : 0.0.1
+  @vibe/compiler/checker : 0.0.1
   @vibe/compiler/core : 0.0.1
 }
 

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -95,6 +95,7 @@ export ../../../../lib/@vibe/cache {
 ///    invalidates stale artifacts; no manual bump needed (#630). `vNN` is still a
 ///    manual knob for pure cache-FORMAT changes that don't change the source hash.
 fn persistent_cache_version_tag() -> String {
+  // v19: effective checked-Exception-row semantics are bound into module, leaf, and TDRE5 identities. All v18 typing entries cold-miss.
   // v18: TypeEnv v5 declaration-authority transport and TDRE4 reuse is production-default for CLI check-only. The global namespace makes every v4 and earlier declaration transport a cold miss.
   // v17: TDRE4 TypeEnv reuse is production-default for CLI check-only.
   // v16: persistent TypeEnv v3 retains trait method-generic provenance. The
@@ -115,7 +116,7 @@ fn persistent_cache_version_tag() -> String {
   // (`.bin`, via Fs::write_bytes / Fs::read_bytes) — a cache FORMAT change, so
   // the manual `vNN` knob is bumped. Old `.hex` entries are now unreferenced
   // (different key + suffix) and reclaimable via `pkf run cache-clean` (#631).
-  String::concat("v18|cg-", codegen_fingerprint())
+  String::concat("v19|cg-", codegen_fingerprint())
 }
 
 /// Read-only trace evidence for the exact existing persistent cache identity.
@@ -144,18 +145,18 @@ export fn persistent_type_env_cache_path(fingerprint: String) -> String {
   cache_persistent_type_env_cache_path(persistent_cache_version_tag(), fingerprint)
 }
 
-/// TDRE4 typing-input aliases are deliberately separate from the TypeEnv-v5
+/// TDRE5 typing-input aliases are deliberately separate from the TypeEnv-v5
 /// artifact namespace and all earlier TDRE namespaces. The referenced TypeEnv
 /// remains in its conservative fingerprint-addressed cache entry.
 export fn persistent_typing_dependency_env_reuse_sidecar_path(typing_input_key: String) -> String {
-  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v4", typing_input_key)
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v5", typing_input_key)
 }
 
-/// TDRE4 eligibility witnesses are isolated from prior marker formats and keyed
+/// TDRE5 eligibility witnesses are isolated from prior marker formats and keyed
 /// by the ordinary conservative module fingerprint. Their strict envelope also
 /// binds the logical input and exact canonical target TypeEnv-v5 text.
 export fn persistent_typing_dependency_env_reuse_eligibility_path(fingerprint: String) -> String {
-  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v4", fingerprint)
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v5", fingerprint)
 }
 
 export fn persistent_source_list_cache_path(entry_path: String) -> String {

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -44,6 +44,10 @@ import @vibe/compiler/core {
   is_contract_ext, resolution_env_seed, resolve_import_path_candidates
 }
 
+import @vibe/compiler/checker {
+  typing_semantics_seed
+}
+
 //# Misc
 
 // #897 (cache/ vpkg migration): rewritten from the old bare
@@ -125,16 +129,20 @@ export fn persistent_cache_version_tag_for_observation() -> String {
   persistent_cache_version_tag()
 }
 
+fn persistent_artifact_typing_fingerprint(fingerprint: String) -> String {
+  compact_string_fingerprint(String::concat("typing-semantics:", String::concat(typing_semantics_seed(), String::concat("|artifact:", fingerprint))))
+}
+
 export fn persistent_artifact_cache_path(kind: String, entry_name: String, fingerprint: String) -> String {
-  cache_persistent_artifact_cache_path(persistent_cache_version_tag(), kind, entry_name, fingerprint)
+  cache_persistent_artifact_cache_path(persistent_cache_version_tag(), kind, entry_name, persistent_artifact_typing_fingerprint(fingerprint))
 }
 
 export fn store_persistent_artifact(kind: String, entry_name: String, fingerprint: String, bytes: Bytes) -> Unit with Exception + Fs {
-  cache_store_persistent_artifact(persistent_cache_version_tag(), kind, entry_name, fingerprint, bytes)
+  cache_store_persistent_artifact(persistent_cache_version_tag(), kind, entry_name, persistent_artifact_typing_fingerprint(fingerprint), bytes)
 }
 
 export fn load_persistent_artifact(kind: String, entry_name: String, fingerprint: String) -> Option[Bytes] with Exception + Fs {
-  cache_load_persistent_artifact(persistent_cache_version_tag(), kind, entry_name, fingerprint)
+  cache_load_persistent_artifact(persistent_cache_version_tag(), kind, entry_name, persistent_artifact_typing_fingerprint(fingerprint))
 }
 
 export fn persistent_dep_list_cache_path(path: String, source_fingerprint: String) -> String {

--- a/lib/@vibe/compiler/cache_probe_support.vibe
+++ b/lib/@vibe/compiler/cache_probe_support.vibe
@@ -56,7 +56,7 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
 }
 
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:checked|source:", source))
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let dep_pair = Array::get(dep_fps, i)

--- a/lib/@vibe/compiler/cache_probe_support.vibe
+++ b/lib/@vibe/compiler/cache_probe_support.vibe
@@ -56,7 +56,7 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
 }
 
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(source)
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:checked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let dep_pair = Array::get(dep_fps, i)

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -2540,6 +2540,17 @@ fn error_row_checked() -> Bool {
   Array::length(error_row_mode_cell) > 0 && Array::get(error_row_mode_cell, 0) == 1
 }
 
+/// Canonical cache identity for the actual process-wide checker mode. Direct
+/// callers that do not configure the cell are unchecked, matching
+/// error_row_checked(); CLI callers set the cell explicitly every invocation.
+export fn typing_semantics_seed() -> String {
+  if error_row_checked() {
+    "checked"
+  } else {
+    "unchecked"
+  }
+}
+
 // Test/bench default rows are derived from core/standard_effect_policy.vibe
 // (`test_bench_default_effects`) rather than a local literal. Each item's
 // existing operation-granularity evidence is retained in the policy table.

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -270,6 +270,8 @@ fn validate_impl_no_overlap(env: TypeEnv, trait_name: String, target: Type) -> B
 // --- checker_effects.vibe (relocated here, see header note above)
 type EffectError
 fn set_error_row_checked(on: Bool) -> Unit
+// Canonical identity for the actual checked-Exception-row mode.
+fn typing_semantics_seed() -> String
 fn effect_error_to_string(err: EffectError) -> String
 fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> Array[EffectError]
 fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectError]

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -39,7 +39,6 @@ import @vibe/compiler/runtime {
   set_incremental_interface_trace_enabled,
   set_incremental_typecheck_telemetry_enabled,
   set_scheduler_trace_path,
-  set_typing_semantics_seed,
   symbol_spans,
   type_at_source
 }
@@ -532,11 +531,9 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
     "checked"
   }
   let checked_error_row = artifact_input_trace_checked_error_row_mode == "checked"
-  // Reset both process-wide authorities on every invocation. Long-lived CLI
-  // hosts must not inherit either checker behavior or persistent-cache identity
-  // from a prior opt-out request.
+  // This is the sole process-wide authority for both checker behavior and its
+  // cache identity. Long-lived CLI hosts reset it on every invocation.
   set_error_row_checked(checked_error_row)
-  set_typing_semantics_seed(artifact_input_trace_checked_error_row_mode)
   // #906 Phase 0: dependency-visit-order oracle. A non-zero seed permutes
   // each node's dep visit order (set_dep_order_seed, runtime/typecheck_fs.vibe);
   // the compiled output must stay byte-identical across seeds, which is what

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -39,6 +39,7 @@ import @vibe/compiler/runtime {
   set_incremental_interface_trace_enabled,
   set_incremental_typecheck_telemetry_enabled,
   set_scheduler_trace_path,
+  set_typing_semantics_seed,
   symbol_spans,
   type_at_source
 }
@@ -530,11 +531,12 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   } else {
     "checked"
   }
-  if artifact_input_trace_checked_error_row_mode == "checked" {
-    set_error_row_checked(true)
-  } else {
-    ()
-  }
+  let checked_error_row = artifact_input_trace_checked_error_row_mode == "checked"
+  // Reset both process-wide authorities on every invocation. Long-lived CLI
+  // hosts must not inherit either checker behavior or persistent-cache identity
+  // from a prior opt-out request.
+  set_error_row_checked(checked_error_row)
+  set_typing_semantics_seed(artifact_input_trace_checked_error_row_mode)
   // #906 Phase 0: dependency-visit-order oracle. A non-zero seed permutes
   // each node's dep visit order (set_dep_order_seed, runtime/typecheck_fs.vibe);
   // the compiled output must stay byte-identical across seeds, which is what
@@ -582,11 +584,9 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   } else {
     "fail-fast"
   }
-  if artifact_input_trace_diagnostics_mode == "all" {
-    set_collect_module_diagnostics(true)
-  } else {
-    ()
-  }
+  // Presentation/scheduling policy is not a successful typing identity, but
+  // its process-wide cell still needs an explicit per-invocation reset.
+  set_collect_module_diagnostics(artifact_input_trace_diagnostics_mode == "all")
   // #1259 (#1239 step 8): dump the walk's planned graph and its actual step
   // sequence for scripts/scheduler_trace_oracle.sh, which checks them against
   // Scheduler.lean's Project / Ready / StoreCorrect / Complete. Read with the

--- a/lib/@vibe/compiler/entry/cli_cache/cli_cache.vibe
+++ b/lib/@vibe/compiler/entry/cli_cache/cli_cache.vibe
@@ -63,7 +63,7 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
 }
 
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:checked|source:", source))
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let dep_pair = Array::get(dep_fps, i)

--- a/lib/@vibe/compiler/entry/cli_cache/cli_cache.vibe
+++ b/lib/@vibe/compiler/entry/cli_cache/cli_cache.vibe
@@ -63,7 +63,7 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
 }
 
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(source)
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:checked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let dep_pair = Array::get(dep_fps, i)

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -244,9 +244,6 @@ fn set_scheduler_trace_path(path: String) -> Unit
 fn set_incremental_typecheck_telemetry_enabled(enabled: Bool) -> Unit
 fn set_incremental_interface_trace_enabled(enabled: Bool) -> Unit
 fn set_experimental_typing_dependency_env_reuse_enabled(enabled: Bool) -> Unit
-// Canonical effective checker-semantics identity, set by every CLI invocation
-// before any cache lookup. Currently contains checked-Exception-row mode only.
-fn set_typing_semantics_seed(seed: String) -> Unit
 fn incremental_typecheck_telemetry_json() -> String
 fn incremental_invalidation_trace_json(entry_path: String, run_nonce: String) -> String with Exception + Fs
 // Test-only seam for malformed transparent STrait provenance.

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -244,6 +244,9 @@ fn set_scheduler_trace_path(path: String) -> Unit
 fn set_incremental_typecheck_telemetry_enabled(enabled: Bool) -> Unit
 fn set_incremental_interface_trace_enabled(enabled: Bool) -> Unit
 fn set_experimental_typing_dependency_env_reuse_enabled(enabled: Bool) -> Unit
+// Canonical effective checker-semantics identity, set by every CLI invocation
+// before any cache lookup. Currently contains checked-Exception-row mode only.
+fn set_typing_semantics_seed(seed: String) -> Unit
 fn incremental_typecheck_telemetry_json() -> String
 fn incremental_invalidation_trace_json(entry_path: String, run_nonce: String) -> String with Exception + Fs
 // Test-only seam for malformed transparent STrait provenance.
@@ -336,5 +339,5 @@ fn load_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with Excepti
 // transitive source snapshot -- so the driver hands them over as values.
 fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Exception
 fn persistent_type_env_cache_text(env: TypeEnv) -> String
-fn load_persistent_leaf_fingerprint(path: String, source: String) -> Option[String] with Exception + Fs
-fn persistent_leaf_fingerprint_text(fingerprint: String) -> String
+fn load_persistent_leaf_fingerprint(path: String, source: String, typing_semantics_seed: String) -> Option[String] with Exception + Fs
+fn persistent_leaf_fingerprint_text(fingerprint: String, typing_semantics_seed: String) -> String

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -945,13 +945,13 @@ export fn persistent_type_env_cache_text(env: TypeEnv) -> String {
   String::concat("version\t5\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
 }
 
-export fn load_persistent_leaf_fingerprint(path: String, source: String) -> Option[String] with Exception + Fs {
+export fn load_persistent_leaf_fingerprint(path: String, source: String, typing_semantics_seed: String) -> Option[String] with Exception + Fs {
   let cache_path = persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(source))
   if !(Fs::exists(cache_path)) {
     None
   } else {
     let text = normalize_persistent_cache_text(Fs::read_file(cache_path))
-    let prefix = "version\t1\n"
+    let prefix = String::concat("version\t2\ntyping-semantics\t", String::concat(typing_semantics_seed, "\n"))
     if String::length(text) > String::length(prefix) &&
     text[0: String::length(prefix)] == prefix {
       Some(String::substring(text, String::length(prefix), String::length(text) - 1))
@@ -961,6 +961,6 @@ export fn load_persistent_leaf_fingerprint(path: String, source: String) -> Opti
   }
 }
 
-export fn persistent_leaf_fingerprint_text(fingerprint: String) -> String {
-  String::concat("version\t1\n", String::concat(fingerprint, "\n"))
+export fn persistent_leaf_fingerprint_text(fingerprint: String, typing_semantics_seed: String) -> String {
+  String::concat("version\t2\ntyping-semantics\t", String::concat(typing_semantics_seed, String::concat("\n", String::concat(fingerprint, "\n"))))
 }

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -31,7 +31,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/checker {
-  check_program_with_env
+  check_program_with_env, typing_semantics_seed
 }
 
 import @vibe/compiler/runtime/eval_loader {
@@ -850,7 +850,7 @@ export fn db_module_source(db: TypeDb, fingerprint: String, source: String) -> (
 }
 
 fn artifact_cache_key(kind: String, entry_name: String) -> String {
-  String::concat(kind, String::concat("|", entry_name))
+  String::concat(typing_semantics_seed(), String::concat("|", String::concat(kind, String::concat("|", entry_name))))
 }
 
 fn bytes_to_hex_digit(n: Int) -> String {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -21,7 +21,8 @@ import @vibe/compiler/checker {
   check_program_type_table,
   check_program_with_env_result,
   detect_unbound_nonunit_returns,
-  detect_unused_imports
+  detect_unused_imports,
+  typing_semantics_seed
 }
 
 import @vibe/compiler/checker/artifacts {
@@ -1098,23 +1099,6 @@ fn project_exact_dependency_envs(deps: Array[String], full_cache: Array[(String,
 export fn projected_import_env_for_test(source: String, path: String, deps: Array[String], full_cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception {
   let dep_envs = project_exact_dependency_envs(deps, full_cache)
   build_import_env(parse_program_with_path(path, source), dir_of_path(path), dep_envs)
-}
-
-// Effective checker semantics are explicit cache authority. The CLI resets this
-// seed before every invocation; non-CLI callers get the safe checked default.
-let typing_semantics_seed_cell = array_empty()
-
-export fn set_typing_semantics_seed(seed: String) -> Unit {
-  Array::truncate(typing_semantics_seed_cell, 0)
-  Array::push(typing_semantics_seed_cell, seed)
-}
-
-fn typing_semantics_seed() -> String {
-  if Array::length(typing_semantics_seed_cell) > 0 {
-    Array::get(typing_semantics_seed_cell, 0)
-  } else {
-    "checked"
-  }
 }
 
 fn build_fingerprint(source: String, dep_fps: Array[(String, String)], semantics_seed: String) -> String {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -105,7 +105,7 @@ fn valid_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with Except
 }
 
 fn valid_persistent_leaf_fingerprint(path: String, source: String) -> Option[String] with Exception + Fs {
-  match load_persistent_leaf_fingerprint(path, source) {
+  match load_persistent_leaf_fingerprint(path, source, typing_semantics_seed()) {
     Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
       Some(_) => Some(fingerprint),
       None => None
@@ -1100,8 +1100,25 @@ export fn projected_import_env_for_test(source: String, path: String, deps: Arra
   build_import_env(parse_program_with_path(path, source), dir_of_path(path), dep_envs)
 }
 
-fn build_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(source)
+// Effective checker semantics are explicit cache authority. The CLI resets this
+// seed before every invocation; non-CLI callers get the safe checked default.
+let typing_semantics_seed_cell = array_empty()
+
+export fn set_typing_semantics_seed(seed: String) -> Unit {
+  Array::truncate(typing_semantics_seed_cell, 0)
+  Array::push(typing_semantics_seed_cell, seed)
+}
+
+fn typing_semantics_seed() -> String {
+  if Array::length(typing_semantics_seed_cell) > 0 {
+    Array::get(typing_semantics_seed_cell, 0)
+  } else {
+    "checked"
+  }
+}
+
+fn build_fingerprint(source: String, dep_fps: Array[(String, String)], semantics_seed: String) -> String {
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:", String::concat(semantics_seed, String::concat("|source:", source))))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let dep_pair = Array::get(dep_fps, i)
@@ -2670,14 +2687,14 @@ let parse_memo_paths: Array[String] = [
   text
 }
 
-// TDRE4 is deliberately independent from the TypeEnv v4 envelope and from
-// every production artifact/cache identity. Both v4 envelopes use strict
+// TDRE5 is deliberately independent from the TypeEnv v5 envelope and from
+// every production artifact/cache identity. Both v5 envelopes use strict
 // decimal length-delimited fields and bind the logical checker input, target
-// conservative fingerprint, and exact canonical TypeEnv-v4 transport text.
+// conservative fingerprint, and exact canonical TypeEnv-v5 transport text.
 // The target text is intentionally not replaced by a compact fingerprint:
 // cache corruption must not turn a fingerprint collision into checker reuse.
-let typing_dependency_env_reuse_alias_v4_tag = "TDRE4A"
-let typing_dependency_env_reuse_witness_v4_tag = "TDRE4W"
+let typing_dependency_env_reuse_alias_v5_tag = "TDRE5A"
+let typing_dependency_env_reuse_witness_v5_tag = "TDRE5W"
 
 fn typing_reuse_segment(text: String) -> String {
   String::concat(__to_string(String::length(text)), String::concat(":", text))
@@ -2741,16 +2758,17 @@ fn parse_typing_dependency_reuse_binding(text: String, tag: String) -> Option[(S
 }
 
 /// Exact logical input to check_module: canonical owner path, byte-exact owner
-/// source, resolution authority, and every resolved direct dependency row of
+/// source, effective typing semantics, resolution authority, and every resolved direct dependency row of
 /// ModuleJob.dep_envs in its actual array order. finish_typecheck_fs_impl builds
 /// this table once with project_exact_dependency_envs and gives the same value
 /// to both check_module and TDRE4 lookup/publication, so ambient coordinator
 /// cache rows are neither checker-visible nor part of this canonical text.
-fn typing_dependency_transport_input_key(path: String, source: String, dep_envs: Array[(String, TypeEnv)]) -> String {
+fn typing_dependency_transport_input_key(path: String, source: String, semantics_seed: String, dep_envs: Array[(String, TypeEnv)]) -> String {
   let out = StringBuilder::new()
-  StringBuilder::push(out, "vibe-typing-dependency-transport-env:v4")
+  StringBuilder::push(out, "vibe-typing-dependency-transport-env:v5")
   StringBuilder::push(out, typing_reuse_segment(normalize_path(path)))
   StringBuilder::push(out, typing_reuse_segment(source))
+  StringBuilder::push(out, typing_reuse_segment(semantics_seed))
   StringBuilder::push(out, typing_reuse_segment(resolution_env_seed()))
   StringBuilder::push(out, typing_reuse_segment(__to_string(Array::length(dep_envs))))
   let mut i = 0
@@ -2796,7 +2814,7 @@ fn typing_dependency_env_reuse_witness_binding(fingerprint: String) -> Option[(S
   if !Fs::exists(witness_path) {
     None
   } else {
-    match parse_typing_dependency_reuse_binding(Fs::read_file(witness_path), typing_dependency_env_reuse_witness_v4_tag) {
+    match parse_typing_dependency_reuse_binding(Fs::read_file(witness_path), typing_dependency_env_reuse_witness_v5_tag) {
       Some((input_key, target_fingerprint, target_text)) =>
       if target_fingerprint != fingerprint {
         None
@@ -2818,7 +2836,7 @@ fn typing_dependency_env_reuse_eligibility_is_valid(fingerprint: String) -> Bool
   }
 }
 
-/// Eligibility is transitively witnessed by successful canonical TypeEnv-v4
+/// Eligibility is transitively witnessed by successful canonical TypeEnv-v5
 /// commits. Missing, malformed, stale, torn, or cross-spliced witnesses fail
 /// closed before the alias lookup.
 fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> Bool with Fs {
@@ -2837,7 +2855,7 @@ fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> 
 }
 
 fn publish_typing_dependency_env_reuse_eligibility(input_key: String, fingerprint: String, target_text: String) -> Unit with Fs {
-  let witness_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_witness_v4_tag, input_key, fingerprint, target_text)
+  let witness_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_witness_v5_tag, input_key, fingerprint, target_text)
   Fs::write_file(persistent_typing_dependency_env_reuse_eligibility_path(fingerprint), witness_text)
 }
 
@@ -2846,7 +2864,7 @@ fn load_typing_dependency_env_reuse_target(input_key: String) -> Option[(String,
   if !Fs::exists(sidecar_path) {
     None
   } else {
-    match parse_typing_dependency_reuse_binding(Fs::read_file(sidecar_path), typing_dependency_env_reuse_alias_v4_tag) {
+    match parse_typing_dependency_reuse_binding(Fs::read_file(sidecar_path), typing_dependency_env_reuse_alias_v5_tag) {
       Some((alias_input_key, target_fingerprint, target_text)) =>
       if alias_input_key != input_key {
         None
@@ -2873,7 +2891,7 @@ fn load_typing_dependency_env_reuse_target(input_key: String) -> Option[(String,
 }
 
 fn write_typing_dependency_env_reuse_sidecar(input_key: String, target_fingerprint: String, target_text: String) -> Unit with Fs {
-  let alias_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_alias_v4_tag, input_key, target_fingerprint, target_text)
+  let alias_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_alias_v5_tag, input_key, target_fingerprint, target_text)
   Fs::write_file(persistent_typing_dependency_env_reuse_sidecar_path(input_key), alias_text)
 }
 
@@ -3409,7 +3427,7 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
   // handed to it -- could publish a checked environment that the serial
   // driver would never look up, which would make a parallel pre-check pass
   // silently do nothing.
-  let fingerprint = build_fingerprint(job.source, job.dep_fps)
+  let fingerprint = build_fingerprint(job.source, job.dep_fps, typing_semantics_seed())
   if Array::length(unresolved_imports) > 0 {
     Diagnosed(job.path, for msg in unresolved_imports {
       String::concat(String::concat(job.path, ": "), msg)
@@ -3494,7 +3512,7 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
       // the extra canonical target text and input serialization wholly inside
       // the enabled, transitively eligible experimental lane.
       if experimental_typing_dependency_env_reuse_enabled() && typing_dependency_env_reuse_is_eligible(job.dep_fps) {
-        let input_key = typing_dependency_transport_input_key(path, job.source, job.dep_envs)
+        let input_key = typing_dependency_transport_input_key(path, job.source, typing_semantics_seed(), job.dep_envs)
         publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
         write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
       } else {
@@ -3510,7 +3528,7 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
         ()
       }
       if Array::length(job.deps) == 0 {
-        Fs::write_file(persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(job.source)), persistent_leaf_fingerprint_text(fingerprint))
+        Fs::write_file(persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(job.source)), persistent_leaf_fingerprint_text(fingerprint, typing_semantics_seed()))
       } else {
         ()
       }
@@ -3769,7 +3787,7 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
       let projected_dep_envs = project_exact_dependency_envs(deps, coordinated_env_cache)
       let reused_env = if experimental_typing_dependency_env_reuse_enabled() {
         if typing_dependency_env_reuse_is_eligible(dep_fps) {
-          let input_key = typing_dependency_transport_input_key(path, source, projected_dep_envs)
+          let input_key = typing_dependency_transport_input_key(path, source, typing_semantics_seed(), projected_dep_envs)
           match load_typing_dependency_env_reuse_target(input_key) {
             Some((target_fingerprint, target_text, target_env)) => Some((input_key, target_fingerprint, target_text, target_env)),
             None => None
@@ -4005,7 +4023,7 @@ fn commit_leaf_fingerprint_fs(rdb: RippleDb, env_cache: Array[(String, TypeEnv)]
       let next_db = ripple_record_eval(rdb, path, leaf_fingerprint, empty_stack())
       (leaf_fingerprint, next_db, env_cache, next_dep_source_cache, parse_count)
     },
-    None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(source, empty_dep_fps()))
+    None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(source, empty_dep_fps(), typing_semantics_seed()))
   }
 }
 /// One module's step, once its dependency list is known and every dependency
@@ -4028,7 +4046,7 @@ fn commit_with_deps_fs(fps: Array[(String, String)], rdb: RippleDb, env_cache: A
     }
     i = i + 1
   }
-  let fingerprint = build_fingerprint(source, dep_fps)
+  let fingerprint = build_fingerprint(source, dep_fps, typing_semantics_seed())
   match ripple_get_fingerprint(rdb, path) {
     Some(cached_fp) =>
     if cached_fp == fingerprint {

--- a/lib/@vibe/compiler/tests/persistent_cache_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_cache_test.vibe
@@ -128,7 +128,7 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
 }
 
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:checked|source:", source))
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let (dep_path, dep_fp) = Array::get(dep_fps, i)

--- a/lib/@vibe/compiler/tests/persistent_cache_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_cache_test.vibe
@@ -36,14 +36,14 @@ import ../type_db.vibe {
 
 //# Functions
 
-test "TDRE4 cache paths use isolated alias and witness namespaces" {
+test "TDRE5 cache paths use isolated alias and witness namespaces" {
   let alias_path = persistent_typing_dependency_env_reuse_sidecar_path("logical-input")
   let witness_path = persistent_typing_dependency_env_reuse_eligibility_path("conservative-target")
-  assert(String::index_of(alias_path, "selfhost_typing_dependency_env_reuse_v4") >= 0)
-  assert(String::index_of(witness_path, "selfhost_typing_dependency_env_reuse_eligibility_v4") >= 0)
+  assert(String::index_of(alias_path, "selfhost_typing_dependency_env_reuse_v5") >= 0)
+  assert(String::index_of(witness_path, "selfhost_typing_dependency_env_reuse_eligibility_v5") >= 0)
   assert(alias_path != witness_path)
-  assert(String::index_of(alias_path, "reuse_v3") < 0)
-  assert(String::index_of(witness_path, "eligibility_v3") < 0)
+  assert(String::index_of(alias_path, "reuse_v4") < 0)
+  assert(String::index_of(witness_path, "eligibility_v4") < 0)
 }
 
 test "source-group compact fingerprint preserves paths and equals full fingerprint" {
@@ -128,7 +128,7 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
 }
 
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(source)
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:checked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let (dep_path, dep_fp) = Array::get(dep_fps, i)

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -51,7 +51,7 @@ fn string_to_bytes(s: String) -> Bytes {
 }
 
 fn build_test_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(source)
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
   let mut i = 0
   while i < Array::length(dep_fps) {
     let (dep_path, dep_fp) = Array::get(dep_fps, i)

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -148,7 +148,7 @@ function check(stage2, project, cache, gate, name, allowFailure = false, extraEn
   }
 }
 
-function compile(stage2, project, cache, enabled, name) {
+function compile(stage2, project, cache, enabled, name, allowFailure = false, extraEnv = {}) {
   const out = `${name}.wasm`;
   const result = spawnSync("bash", [join(root, "scripts/run_wasm_vibe_host_runner.sh"), "--invoke", "cli_main", stage2, "app.vibe", out, "main"], {
     cwd: project,
@@ -163,10 +163,15 @@ function compile(stage2, project, cache, enabled, name) {
       VIBE_PREOPEN_DIR: project,
       VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE: enabled ? "" : "1",
       VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "",
+      ...extraEnv,
     },
   });
-  if (result.status !== 0) fail(`${name} failed: ${(result.stderr || result.stdout).trim()}`);
-  return readFileSync(join(project, out));
+  const outputPath = join(project, out);
+  if (result.status !== 0) {
+    if (!allowFailure) fail(`${name} failed: ${(result.stderr || result.stdout).trim()}`);
+    return { status: result.status, diagnostic: readFileSync(`${outputPath}.diag`, "utf8") };
+  }
+  return { status: result.status, bytes: readFileSync(outputPath) };
 }
 
 function expectCounts(name, actual, rechecked, reused, planned = 2) {
@@ -448,7 +453,24 @@ function run(stage2) {
     makeProject(compileDefaultProject);
     const compileControl = compile(stage2, compileControlProject, join(work, "compile-control-cache"), false, "compile-control");
     const compileDefault = compile(stage2, compileDefaultProject, join(work, "compile-default-cache"), true, "compile-default");
-    if (!compileControl.equals(compileDefault)) fail("FS compile default-on/explicit-disable output mismatch");
+    if (!compileControl.bytes.equals(compileDefault.bytes)) fail("FS compile default-on/explicit-disable output mismatch");
+
+    const buildUncheckedFirstProject = join(work, "build-row-unchecked-first-project");
+    const buildUncheckedFirstCache = join(work, "build-row-unchecked-first-cache");
+    makeCheckedRowProject(buildUncheckedFirstProject);
+    const buildUncheckedCold = compile(stage2, buildUncheckedFirstProject, buildUncheckedFirstCache, true, "build-row-unchecked-cold", false, { VIBE_CHECK_ERROR_ROW: "0" });
+    const buildUncheckedWarm = compile(stage2, buildUncheckedFirstProject, buildUncheckedFirstCache, true, "build-row-unchecked-warm", false, { VIBE_CHECK_ERROR_ROW: "0" });
+    if (!buildUncheckedCold.bytes.equals(buildUncheckedWarm.bytes)) fail("same-mode unchecked build cache changed output");
+    const buildCheckedAfterUnchecked = compile(stage2, buildUncheckedFirstProject, buildUncheckedFirstCache, true, "build-row-checked-after-unchecked", true, { VIBE_CHECK_ERROR_ROW: "1" });
+    if (buildCheckedAfterUnchecked.status === 0 || !buildCheckedAfterUnchecked.diagnostic.includes("missing { Exception }")) fail("checked build reused unchecked compiled artifact");
+
+    const buildCheckedFirstProject = join(work, "build-row-checked-first-project");
+    const buildCheckedFirstCache = join(work, "build-row-checked-first-cache");
+    makeCheckedRowProject(buildCheckedFirstProject);
+    const buildCheckedCold = compile(stage2, buildCheckedFirstProject, buildCheckedFirstCache, true, "build-row-checked-cold", true, { VIBE_CHECK_ERROR_ROW: "1" });
+    const buildCheckedWarm = compile(stage2, buildCheckedFirstProject, buildCheckedFirstCache, true, "build-row-checked-warm", true, { VIBE_CHECK_ERROR_ROW: "1" });
+    if (buildCheckedCold.status === 0 || buildCheckedWarm.status === 0 || !buildCheckedCold.diagnostic.includes("missing { Exception }") || !buildCheckedWarm.diagnostic.includes("missing { Exception }")) fail("checked cold/warm build did not reject row-less caller");
+    const buildUncheckedAfterChecked = compile(stage2, buildCheckedFirstProject, buildCheckedFirstCache, true, "build-row-unchecked-after-checked", false, { VIBE_CHECK_ERROR_ROW: "0" });
 
     privateEdit(offProject);
     privateEdit(onProject);
@@ -721,6 +743,12 @@ function run(stage2) {
           unchecked_same_mode_warm: uncheckedWarm.telemetry,
           checked_after_unchecked_rejected: true,
           unchecked_after_checked: uncheckedAfterChecked.telemetry,
+          compiled_artifact: {
+            unchecked_same_mode_bytes_equal: buildUncheckedCold.bytes.equals(buildUncheckedWarm.bytes),
+            checked_after_unchecked_rejected: true,
+            checked_cold_and_warm_rejected: true,
+            unchecked_after_checked_succeeded: buildUncheckedAfterChecked.status === 0,
+          },
         },
       },
       comment_only: { default_on: commentOn.telemetry },

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Production E2E oracle for default-on check-only TDRE4 TypeEnv reuse. The
+// Production E2E oracle for default-on check-only TDRE5 TypeEnv reuse. The
 // explicit disable flag is the conservative control. Trace-only observations
 // force reuse off and are never used to establish a production reuse key.
 import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -24,6 +24,16 @@ function makeProject(project) {
   mkdirSync(project, { recursive: true });
   writeFileSync(join(project, "helper.vibe"), "export fn value() -> Int { 1 }\n");
   writeFileSync(join(project, "app.vibe"), "import ./helper.vibe { value }\nfn main() -> Int { let _ = value()\n0 }\n");
+}
+
+function makeCheckedRowProject(project) {
+  mkdirSync(project, { recursive: true });
+  writeFileSync(join(project, "helper.vibe"), "export fn boom() -> Int with Exception { throw(\"boom\") }\n");
+  writeFileSync(join(project, "app.vibe"), "import ./helper.vibe { boom }\nfn main() -> Int { boom() }\n");
+}
+
+function commentEdit(project) {
+  writeFileSync(join(project, "helper.vibe"), "// implementation-only comment\nexport fn value() -> Int { 1 }\n");
 }
 
 function privateEdit(project) {
@@ -117,7 +127,7 @@ function check(stage2, project, cache, gate, name, allowFailure = false, extraEn
       VIBE_CHECK_ONLY: "1",
       VIBE_INCREMENTAL_TELEMETRY_OUT: telemetryOut,
       VIBE_IMPORT_ABI: "raw",
-      // Resolution authority is part of the TDRE4 logical input. Keep it
+      // Resolution authority is part of the TDRE5 logical input. Keep it
       // stable within each scenario; varying it per invocation would correctly
       // force a full check rather than exercise reuse.
       VIBE_HOME: join(project, ".home"),
@@ -190,51 +200,52 @@ function bindingFiles(cache, namespace) {
 }
 
 function appSidecar(cache, appSource) {
-  const candidates = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v4");
+  const candidates = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v5");
   const path = candidates.find((candidate) => {
     const text = readFileSync(candidate, "utf8");
-    return text.startsWith("TDRE4A") && text.includes(appSource);
+    return text.startsWith("TDRE5A") && text.includes(appSource);
   });
-  if (!path) fail(`non-vacuous TDRE4 app sidecar missing in ${basename(cache)}`);
-  return { path, ...parseBinding(readFileSync(path, "utf8"), "TDRE4A") };
+  if (!path) fail(`non-vacuous TDRE5 app sidecar missing in ${basename(cache)}`);
+  return { path, ...parseBinding(readFileSync(path, "utf8"), "TDRE5A") };
 }
 
 function otherSidecar(cache, target) {
-  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v4")) {
-    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE4A");
+  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v5")) {
+    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE5A");
     if (binding.target !== target) return { path, ...binding };
   }
-  fail("second valid TDRE4 target missing");
+  fail("second valid TDRE5 target missing");
 }
 
 function targetWitness(cache, target) {
-  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v4")) {
-    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE4W");
+  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v5")) {
+    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE5W");
     if (binding.target === target) return { path, ...binding };
   }
-  fail(`bound TDRE4 witness missing for ${target}`);
+  fail(`bound TDRE5 witness missing for ${target}`);
 }
 
 function aliasText(input, target, targetText) {
-  return `TDRE4A${segment(input)}${segment(target)}${segment(targetText)}`;
+  return `TDRE5A${segment(input)}${segment(target)}${segment(targetText)}`;
 }
 
 function witnessText(input, target, targetText) {
-  return `TDRE4W${segment(input)}${segment(target)}${segment(targetText)}`;
+  return `TDRE5W${segment(input)}${segment(target)}${segment(targetText)}`;
 }
 
-const logicalInputTag = "vibe-typing-dependency-transport-env:v4";
+const logicalInputTag = "vibe-typing-dependency-transport-env:v5";
 function parseLogicalInput(input) {
-  if (!input.startsWith(logicalInputTag)) fail("TDRE4 logical input tag changed");
+  if (!input.startsWith(logicalInputTag)) fail("TDRE5 logical input tag changed");
   let cursor = logicalInputTag.length;
   const fields = [];
-  for (let i = 0; i < 4; i += 1) {
+  for (let i = 0; i < 5; i += 1) {
     const [field, next] = parseSegment(input, cursor);
     fields.push(field);
     cursor = next;
   }
-  const count = Number(fields[3]);
-  if (!Number.isInteger(count) || count < 0) fail("invalid TDRE4 dep_env count");
+  if (fields[2] !== "checked" && fields[2] !== "unchecked") fail("invalid TDRE5 typing semantics seed");
+  const count = Number(fields[4]);
+  if (!Number.isInteger(count) || count < 0) fail("invalid TDRE5 dep_env count");
   const rows = [];
   for (let i = 0; i < count; i += 1) {
     const [path, afterPath] = parseSegment(input, cursor);
@@ -242,12 +253,12 @@ function parseLogicalInput(input) {
     rows.push([path, text]);
     cursor = afterText;
   }
-  if (cursor !== input.length) fail("TDRE4 logical input has trailing data");
-  return { owner: fields[0], source: fields[1], resolutionSeed: fields[2], rows };
+  if (cursor !== input.length) fail("TDRE5 logical input has trailing data");
+  return { owner: fields[0], source: fields[1], typingSemantics: fields[2], resolutionSeed: fields[3], rows };
 }
 
-function logicalInputText({ owner, source, resolutionSeed, rows }) {
-  return `${logicalInputTag}${segment(owner)}${segment(source)}${segment(resolutionSeed)}${segment(String(rows.length))}${rows.map(([path, text]) => `${segment(path)}${segment(text)}`).join("")}`;
+function logicalInputText({ owner, source, typingSemantics, resolutionSeed, rows }) {
+  return `${logicalInputTag}${segment(owner)}${segment(source)}${segment(typingSemantics)}${segment(resolutionSeed)}${segment(String(rows.length))}${rows.map(([path, text]) => `${segment(path)}${segment(text)}`).join("")}`;
 }
 
 function compactFingerprint(source) {
@@ -278,7 +289,7 @@ function stableCachePath(cache, version, prefix, seed, suffix) {
   return join(cache, `vibe_${prefix}_${token}${suffix}`);
 }
 
-function typeEnvPath(stage2, cache, target, major = "v18") {
+function typeEnvPath(stage2, cache, target, major = "v19") {
   return stableCachePath(cache, `${major}|cg-${stageCodegenFingerprint(stage2)}`, "selfhost_type_env_v5", target, ".tsv");
 }
 
@@ -318,17 +329,17 @@ function expectTraceLaneRejected(stage2, project, cache) {
 }
 
 function traceForcedOff(stage2, project, cache) {
-  const beforeAliases = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v4").length;
-  const beforeWitnesses = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v4").length;
+  const beforeAliases = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v5").length;
+  const beforeWitnesses = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v5").length;
   const result = check(stage2, project, cache, true, "trace-forced-off", false, {
     VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT: "trace-forced-off.json",
     VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE: "trace-forced-off",
   });
   expectCounts("ordinary trace forced off", result.telemetry, 2, 0);
   if (!existsSync(join(project, "trace-forced-off.json"))) fail("ordinary trace omitted observation sidecar");
-  if (bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v4").length !== beforeAliases ||
-      bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v4").length !== beforeWitnesses) {
-    fail("observation-only trace published TDRE4 state");
+  if (bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v5").length !== beforeAliases ||
+      bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v5").length !== beforeWitnesses) {
+    fail("observation-only trace published TDRE5 state");
   }
   return result.telemetry;
 }
@@ -356,29 +367,29 @@ function expectInvalidEnvRejected(stage2, project, cache, variable, value) {
   if (!diagnostic.includes(variable)) fail(`${variable} rejection omitted strict diagnostic`);
 }
 
-function expectV16Isolation(stage2, work) {
-  const project = join(work, "v16-isolation-project");
-  const currentCache = join(work, "v16-isolation-current-cache");
-  const oldCache = join(work, "v16-isolation-old-cache");
+function expectV18Isolation(stage2, work) {
+  const project = join(work, "v18-isolation-project");
+  const currentCache = join(work, "v18-isolation-current-cache");
+  const oldCache = join(work, "v18-isolation-old-cache");
   makeProject(project);
-  check(stage2, project, currentCache, true, "v16-source-cold");
+  check(stage2, project, currentCache, true, "v18-source-cold");
   mkdirSync(oldCache, { recursive: true });
-  const oldVersion = `v16|cg-${stageCodegenFingerprint(stage2)}`;
-  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_v4")) {
+  const oldVersion = `v18|cg-${stageCodegenFingerprint(stage2)}`;
+  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_v5")) {
     const text = readFileSync(path, "utf8");
-    const binding = parseBinding(text, "TDRE4A");
-    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_v4", binding.input, ".txt"), text);
-    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v16"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
+    const binding = parseBinding(text, "TDRE5A");
+    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_v5", binding.input, ".txt"), text);
+    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v18"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
   }
-  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_eligibility_v4")) {
+  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_eligibility_v5")) {
     const text = readFileSync(path, "utf8");
-    const binding = parseBinding(text, "TDRE4W");
-    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_eligibility_v4", binding.target, ".txt"), text);
-    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v16"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
+    const binding = parseBinding(text, "TDRE5W");
+    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_eligibility_v5", binding.target, ".txt"), text);
+    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v18"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
   }
-  if (bindingFiles(oldCache, "selfhost_typing_dependency_env_reuse_v4").length === 0) fail("v16 isolation fixture omitted valid old aliases");
-  const isolated = check(stage2, project, oldCache, true, "v16-isolated-default");
-  expectCounts("v16 namespace isolation", isolated.telemetry, 2, 0);
+  if (bindingFiles(oldCache, "selfhost_typing_dependency_env_reuse_v5").length === 0) fail("v18 isolation fixture omitted valid old aliases");
+  const isolated = check(stage2, project, oldCache, true, "v18-isolated-default");
+  expectCounts("v18 namespace isolation", isolated.telemetry, 2, 0);
   return isolated.telemetry;
 }
 
@@ -400,10 +411,36 @@ function run(stage2) {
 
     const warmOn = check(stage2, onProject, onCache, true, "warm-on");
     expectCounts("warm default-on", warmOn.telemetry, 0, 2);
+
+    // #1669: checker semantics are cache authority. An unchecked successful
+    // publication must never satisfy a later checked invocation, and a checked
+    // partial cache from a rejected run must not satisfy unchecked mode either.
+    const uncheckedFirstProject = join(work, "row-mode-unchecked-first-project");
+    const uncheckedFirstCache = join(work, "row-mode-unchecked-first-cache");
+    makeCheckedRowProject(uncheckedFirstProject);
+    const uncheckedCold = check(stage2, uncheckedFirstProject, uncheckedFirstCache, true, "row-unchecked-cold", false, { VIBE_CHECK_ERROR_ROW: "0" });
+    expectCounts("unchecked mode cold", uncheckedCold.telemetry, 2, 0);
+    const checkedAfterUnchecked = check(stage2, uncheckedFirstProject, uncheckedFirstCache, true, "row-checked-after-unchecked", true, { VIBE_CHECK_ERROR_ROW: "1" });
+    if (checkedAfterUnchecked.status === 0 || !checkedAfterUnchecked.output.includes("missing { Exception }")) fail("checked mode reused unchecked typing result");
+    const uncheckedWarm = check(stage2, uncheckedFirstProject, uncheckedFirstCache, true, "row-unchecked-warm", false, { VIBE_CHECK_ERROR_ROW: "0" });
+    expectCounts("unchecked same-mode warm", uncheckedWarm.telemetry, 0, 2);
+
+    const checkedFirstProject = join(work, "row-mode-checked-first-project");
+    const checkedFirstCache = join(work, "row-mode-checked-first-cache");
+    makeCheckedRowProject(checkedFirstProject);
+    const checkedCold = check(stage2, checkedFirstProject, checkedFirstCache, true, "row-checked-cold", true, { VIBE_CHECK_ERROR_ROW: "1" });
+    if (checkedCold.status === 0 || !checkedCold.output.includes("missing { Exception }")) fail("cold checked mode did not reject row-less caller");
+    const uncheckedAfterChecked = check(stage2, checkedFirstProject, checkedFirstCache, true, "row-unchecked-after-checked", false, { VIBE_CHECK_ERROR_ROW: "0" });
+    expectCounts("unchecked after checked mode isolation", uncheckedAfterChecked.telemetry, 2, 0);
+    const modeSeeds = bindingFiles(uncheckedFirstCache, "selfhost_typing_dependency_env_reuse_v5").map((path) => parseLogicalInput(parseBinding(readFileSync(path, "utf8"), "TDRE5A").input).typingSemantics);
+    if (!modeSeeds.includes("checked") || !modeSeeds.includes("unchecked")) fail("TDRE5 aliases did not retain disjoint typing semantics seeds");
     const legacyCompat = check(stage2, onProject, onCache, true, "legacy-compat", false, {
       VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "1",
     });
     expectCounts("legacy 1 compatibility no-op", legacyCompat.telemetry, 0, 2);
+    commentEdit(onProject);
+    const commentOn = check(stage2, onProject, onCache, true, "comment-on");
+    expectCounts("comment-only consumer reuse", commentOn.telemetry, 1, 1);
 
     const compileControlProject = join(work, "compile-control-project");
     const compileDefaultProject = join(work, "compile-default-project");
@@ -435,7 +472,7 @@ function run(stage2) {
     expectTraceLaneRejected(stage2, onProject, onCache);
     expectInvalidEnvRejected(stage2, onProject, onCache, "VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE", "true");
     expectInvalidEnvRejected(stage2, onProject, onCache, "VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE", "0");
-    const v16Isolation = expectV16Isolation(stage2, work);
+    const v18Isolation = expectV18Isolation(stage2, work);
 
     const malformedProject = join(work, "malformed-target-project");
     const malformedCache = join(work, "malformed-target-cache");
@@ -540,7 +577,7 @@ function run(stage2) {
     makeProject(malformedWitnessProject);
     check(stage2, malformedWitnessProject, malformedWitnessCache, true, "malformed-witness-cold");
     const malformedWitnessApp = appSidecar(malformedWitnessCache, readFileSync(join(malformedWitnessProject, "app.vibe"), "utf8"));
-    writeFileSync(targetWitness(malformedWitnessCache, malformedWitnessApp.target).path, "TDRE4W1:x");
+    writeFileSync(targetWitness(malformedWitnessCache, malformedWitnessApp.target).path, "TDRE5W1:x");
     privateEdit(malformedWitnessProject);
     const malformedWitnessFallback = check(stage2, malformedWitnessProject, malformedWitnessCache, true, "malformed-witness-fallback");
     expectCounts("malformed witness fallback", malformedWitnessFallback.telemetry, 2, 0);
@@ -553,14 +590,14 @@ function run(stage2) {
     const ambientColdApp = appSidecar(ambientCache, readFileSync(join(ambientProject, "app.vibe"), "utf8"));
     const ambientColdInput = parseLogicalInput(ambientColdApp.input);
     if (ambientColdInput.rows.length !== 1 || basename(ambientColdInput.rows[0][0]) !== "middle.vibe") {
-      fail("TDRE4 app logical input was not the exact direct-dependency projection");
+      fail("TDRE5 app logical input was not the exact direct-dependency projection");
     }
     ambientOnlyTransportEdit(ambientProject);
     const ambientReuse = check(stage2, ambientProject, ambientCache, true, "ambient-change-reuse");
     expectCounts("ambient non-direct cache change reuse", ambientReuse.telemetry, 2, 1, 3);
     const ambientWarmApp = appSidecar(ambientCache, readFileSync(join(ambientProject, "app.vibe"), "utf8"));
     if (ambientWarmApp.input !== ambientColdApp.input || ambientWarmApp.path !== ambientColdApp.path) {
-      fail("ambient non-direct cache mutation changed the app TDRE4 input key");
+      fail("ambient non-direct cache mutation changed the app TDRE5 input key");
     }
 
     const resolutionProject = join(work, "resolution-seed-project");
@@ -580,7 +617,7 @@ function run(stage2) {
     const rowApp = appSidecar(rowCache, readFileSync(join(rowProject, "app.vibe"), "utf8"));
     const parsedRowInput = parseLogicalInput(rowApp.input);
     if (parsedRowInput.rows.length !== 1 || basename(parsedRowInput.rows[0][0]) !== "helper.vibe") {
-      fail("TDRE4 direct dependency row missing before row mutation");
+      fail("TDRE5 direct dependency row missing before row mutation");
     }
     const changedRowInput = logicalInputText({
       ...parsedRowInput,
@@ -600,7 +637,7 @@ function run(stage2) {
     const parsedOrderInput = parseLogicalInput(orderApp.input);
     const orderPaths = parsedOrderInput.rows.map(([path]) => basename(path)).sort();
     if (parsedOrderInput.rows.length !== 2 || orderPaths[0] !== "a.vibe" || orderPaths[1] !== "b.vibe") {
-      fail("TDRE4 app logical input omitted exact dep_env rows");
+      fail("TDRE5 app logical input omitted exact dep_env rows");
     }
     const swappedOrderInput = logicalInputText({
       ...parsedOrderInput,
@@ -661,10 +698,10 @@ function run(stage2) {
     writeFileSync(join(noPublishProject, "app.vibe"), failingSource);
     const noPublish = check(stage2, noPublishProject, noPublishCache, true, "diagnostic-no-publish", true);
     if (noPublish.status === 0) fail("diagnostic no-publish scenario unexpectedly succeeded");
-    const noPublishAliases = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_v4");
-    const noPublishWitnesses = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_eligibility_v4");
-    if (noPublishAliases.length !== 1 || noPublishWitnesses.length !== 1) fail("diagnosed module published TDRE4 alias or witness");
-    if (noPublishAliases.some((path) => readFileSync(path, "utf8").includes(failingSource))) fail("diagnosed owner source appeared in TDRE4 alias");
+    const noPublishAliases = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_v5");
+    const noPublishWitnesses = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_eligibility_v5");
+    if (noPublishAliases.length !== 1 || noPublishWitnesses.length !== 1) fail("diagnosed module published TDRE5 alias or witness");
+    if (noPublishAliases.some((path) => readFileSync(path, "utf8").includes(failingSource))) fail("diagnosed owner source appeared in TDRE5 alias");
 
     console.log(JSON.stringify({
       schema: 1,
@@ -676,10 +713,17 @@ function run(stage2) {
         explicit_disable_control: coldOff.telemetry,
         trace_forced_off: traceForcedOffTelemetry,
         post_trace_default: postTraceDefault.telemetry,
-        v16_namespace_isolation: v16Isolation,
+        v18_namespace_isolation: v18Isolation,
         conservative_compile_output_parity: true,
         invalid_env_diagnostics: true,
+        checked_error_row_mode_isolation: {
+          unchecked_cold: uncheckedCold.telemetry,
+          unchecked_same_mode_warm: uncheckedWarm.telemetry,
+          checked_after_unchecked_rejected: true,
+          unchecked_after_checked: uncheckedAfterChecked.telemetry,
+        },
       },
+      comment_only: { default_on: commentOn.telemetry },
       private_body: { explicit_disable: privateOff.telemetry, default_on: privateOn.telemetry },
       public_interface: { explicit_disable: publicOff.telemetry, default_on: publicOn.telemetry },
       malformed_target_fallback: malformedTargetFallback.telemetry,


### PR DESCRIPTION
## Summary

- bind effective checked-Exception-row semantics into ordinary module fingerprints, leaf pointers, and TDRE logical inputs
- reset checker and diagnostic-collection process state on every CLI invocation
- bump persistent namespace to v19 and TDRE envelopes/namespaces to v5 without interpreting old entries
- add cross-mode warm-cache regressions in both directions while preserving same-mode, private/comment, and chain reuse

## Validation

- focused `persistent_cache_test.vibe` compile/run
- production TDRE oracle including cross-mode isolation and hostile fallbacks
- stage2/stage3 fixpoint (`dd32309837a0…`)
- formatter checks
- `bash -n scripts/compiler_gate.sh`
- fixture accounting 246/246
- generated freshness
- `bit diff --check`

Fixes #1669
Blocks broader promotion in #1548 until merged.