### PR TITLE
feat(checker): retain value binding provenance

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_effective_effect_row_observation.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_effective_effect_row_observation.vibe
@@ -89,8 +89,8 @@ fn owner_env_lookup(env: TypeEnv, wanted: String) -> Option[Type] {
       EnvEmpty => {
         done = true
       },
-      EnvBind(name, ty, rest) => if name == wanted {
-        result = Some(ty)
+      EnvBind(name, binding, rest) => if name == wanted {
+        result = Some(binding.ty)
         done = true
       } else {
         cur = rest
@@ -110,9 +110,9 @@ fn owner_env_lookup(env: TypeEnv, wanted: String) -> Option[Type] {
       EnvFlat(bindings) => {
         let mut i = 0
         while i < Array::length(bindings) && !done {
-          let (name, ty) = Array::get(bindings, i)
+          let (name, binding) = Array::get(bindings, i)
           if name == wanted {
-            result = Some(ty)
+            result = Some(binding.ty)
             done = true
           } else {
             i = i + 1
@@ -141,7 +141,7 @@ fn owner_env_lookup(env: TypeEnv, wanted: String) -> Option[Type] {
             let mut i = 0
             while i < Array::length(names) && !done {
               if Array::get(names, i) == wanted {
-                result = Some(Array::get(types, i))
+                result = Some(Array::get(types, i).ty)
                 done = true
               } else {
                 i = i + 1

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -381,11 +381,11 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
       EnvEmpty => {
         done = true
       },
-      EnvBind(name, ty, rest) => {
+      EnvBind(name, binding, rest) => {
         if !canonical_name_seen(seen, name) {
           Array::push(seen, name)
           if !String::starts_with(name, "__fn_ret__:") {
-            Array::push(out, (name, ty))
+            Array::push(out, (name, binding.ty))
           }
         }
         cur = rest
@@ -405,11 +405,11 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
       EnvFlat(bindings) => {
         let mut i = 0
         while i < Array::length(bindings) {
-          let (name, ty) = Array::get(bindings, i)
+          let (name, binding) = Array::get(bindings, i)
           if !canonical_name_seen(seen, name) {
             Array::push(seen, name)
             if !String::starts_with(name, "__fn_ret__:") {
-              Array::push(out, (name, ty))
+              Array::push(out, (name, binding.ty))
             }
           }
           i = i + 1
@@ -423,7 +423,7 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
           if !canonical_name_seen(seen, name) {
             Array::push(seen, name)
             if !String::starts_with(name, "__fn_ret__:") {
-              Array::push(out, (name, Array::get(types, i)))
+              Array::push(out, (name, Array::get(types, i).ty))
             }
           }
           i = i + 1

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -633,8 +633,8 @@ fn type_mentions_named(ty: Type, name: String) -> Bool {
 fn collect_env_bindings(env: TypeEnv, acc: Array[(String, Type)]) -> Unit {
   match env {
     EnvEmpty => (),
-    EnvBind(n, ty, rest) => {
-      Array::push(acc, (n, ty))
+    EnvBind(n, binding, rest) => {
+      Array::push(acc, (n, binding.ty))
       collect_env_bindings(rest, acc)
     },
     EnvTraitDef(_, _, _, _, rest, _, _) => collect_env_bindings(rest, acc),
@@ -644,14 +644,15 @@ fn collect_env_bindings(env: TypeEnv, acc: Array[(String, Type)]) -> Unit {
     EnvFlat(bindings) => {
       let mut i = 0
       while i < Array::length(bindings) {
-        Array::push(acc, Array::get(bindings, i))
+        let (name, binding) = Array::get(bindings, i)
+        Array::push(acc, (name, binding.ty))
         i = i + 1
       }
     },
     EnvCached(names, types, rest) => {
       let mut i = 0
       while i < Array::length(names) {
-        Array::push(acc, (Array::get(names, i), Array::get(types, i)))
+        Array::push(acc, (Array::get(names, i), Array::get(types, i).ty))
         i = i + 1
       }
       collect_env_bindings(rest, acc)

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -982,8 +982,8 @@ fn set_throw_kind_table(env: TypeEnv) -> Unit {
   let mut looping = true
   while looping {
     match cur {
-      EnvBind(name, ty, rest) => {
-        throw_kind_push(name, ty)
+      EnvBind(name, binding, rest) => {
+        throw_kind_push(name, binding.ty)
         cur = rest
       },
       EnvTraitDef(_, _, _, _, rest, _, _) => {
@@ -1005,7 +1005,7 @@ fn set_throw_kind_table(env: TypeEnv) -> Unit {
         // on which entry point asked.
         let mut ci = 0
         while ci < Array::length(cnames) && ci < Array::length(ctypes) {
-          throw_kind_push(Array::get(cnames, ci), Array::get(ctypes, ci))
+          throw_kind_push(Array::get(cnames, ci), Array::get(ctypes, ci).ty)
           ci = ci + 1
         }
         cur = rest
@@ -1016,8 +1016,8 @@ fn set_throw_kind_table(env: TypeEnv) -> Unit {
       EnvFlat(entries) => {
         let mut ei = 0
         while ei < Array::length(entries) {
-          let (ename, ety) = Array::get(entries, ei)
-          throw_kind_push(ename, ety)
+          let (ename, binding) = Array::get(entries, ei)
+          throw_kind_push(ename, binding.ty)
           ei = ei + 1
         }
         looping = false
@@ -2690,8 +2690,8 @@ fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[
   let mut looping = true
   while looping {
     match cur {
-      EnvBind(name, ty, rest) => {
-        push_env_fn_eff(name, ty, fn_names, fn_effs, fn_param_effs)
+      EnvBind(name, binding, rest) => {
+        push_env_fn_eff(name, binding.ty, fn_names, fn_effs, fn_param_effs)
         cur = rest
       },
       EnvTraitDef(_, _, _, _, rest, _, _) => {
@@ -2712,8 +2712,8 @@ fn seed_env_fn_effs(env: TypeEnv, fn_names: Array[String], fn_effs: Array[Array[
       EnvFlat(entries) => {
         let mut ei = 0
         while ei < Array::length(entries) {
-          let (ename, ety) = Array::get(entries, ei)
-          push_env_fn_eff(ename, ety, fn_names, fn_effs, fn_param_effs)
+          let (ename, binding) = Array::get(entries, ei)
+          push_env_fn_eff(ename, binding.ty, fn_names, fn_effs, fn_param_effs)
           ei = ei + 1
         }
         looping = false

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -65,6 +65,8 @@ export ./standard_effect_policy.vibe {
 }
 
 export ./types.vibe {
+  BindingOrigin,
+  EnvValueBinding,
   Subst,
   Type,
   TypeDef,
@@ -73,12 +75,16 @@ export ./types.vibe {
   collect_tvars,
   env_bind,
   env_bind_all,
+  env_bind_with_origin,
   env_cache,
   env_flat_bindings,
   env_lookup,
+  env_lookup_binding,
   env_lookup_flat,
   env_selectable_type_defs,
   env_type_defs,
+  env_value_binding,
+  env_value_binding_with_origin,
   find_typedef,
   fresh_var,
   generalize,

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -110,6 +110,8 @@ type Type
 type TypeDef
 type TypeEnv
 type Subst
+type BindingOrigin
+type EnvValueBinding
 
 // --- core (facade)
 
@@ -183,10 +185,14 @@ fn dce_keep_flags(stmts: Array[Stmt], entry_names: Array[String]) -> Array[Bool]
 
 // --- types
 fn env_bind(env: TypeEnv, name: String, ty: Type) -> TypeEnv
+fn env_bind_with_origin(env: TypeEnv, name: String, ty: Type, origin: BindingOrigin) -> TypeEnv
+fn env_value_binding(ty: Type) -> EnvValueBinding
+fn env_value_binding_with_origin(ty: Type, origin: BindingOrigin) -> EnvValueBinding
 fn env_cache(env: TypeEnv) -> TypeEnv
 fn fresh_var(c: Int) -> (Type, Int)
 fn occurs_in(id: Int, ty: Type) -> Bool
 fn env_lookup(env: TypeEnv, name: String) -> Option[Type]
+fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBinding]
 fn env_bind_all(env: TypeEnv, bindings: Array[(String, Type)]) -> TypeEnv
 fn find_typedef(defs: Array[TypeDef], name: String) -> Option[TypeDef]
 fn find_enum_typedef(defs: Array[TypeDef], name: String) -> Option[TypeDef]

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -57,9 +57,35 @@ export enum TypeDef {
   TDEffectSet(String, Array[String])
 }
 
+/// Checker-internal authority for where a value binding was resolved.
+/// Persistent/public TypeEnv transport intentionally drops this payload.
+export enum BindingOrigin {
+  BindingOriginUnavailable;
+  BindingOriginModuleExport(String, String)
+}
+
+export struct EnvValueBinding {
+  ty: Type;
+  origin: BindingOrigin
+}
+
+export fn env_value_binding(ty: Type) -> EnvValueBinding {
+  EnvValueBinding::{
+    ty: ty,
+    origin: BindingOriginUnavailable
+  }
+}
+
+export fn env_value_binding_with_origin(ty: Type, origin: BindingOrigin) -> EnvValueBinding {
+  EnvValueBinding::{
+    ty: ty,
+    origin: origin
+  }
+}
+
 export enum TypeEnv {
   EnvEmpty;
-  EnvBind(String, Type, TypeEnv);
+  EnvBind(String, EnvValueBinding, TypeEnv);
   // Header params are sixth and method generic provenance is appended seventh,
   // so every older positional slot, including rest, retains its meaning.
   // Both are retained checker provenance.
@@ -73,14 +99,14 @@ export enum TypeEnv {
   // separate prevents a private dependency of an exported signature from
   // becoming importable by name.
   EnvTypeDefs(Array[TypeDef], Array[String], TypeEnv);
-  EnvFlat(Array[(String, Type)]);
+  EnvFlat(Array[(String, EnvValueBinding)]);
   // Sorted names/types pair (see core/sorted_index.vibe), instead of a
   // Map[String, Type]: this compiler's `Map` is a flat assoc list, so
   // `Map::has_key` + `Map::get` were TWO O(entries) linear scans per lookup
   // -- exactly the "Map membership index is still linear" trap from #799.
   // Names are unique (built by env_cache below), so a stable sort + leftmost
   // bsearch gives the same result in O(log N) with no dedup step needed.
-  EnvCached(Array[String], Array[Type], TypeEnv)
+  EnvCached(Array[String], Array[EnvValueBinding], TypeEnv)
 }
 
 export enum Subst {
@@ -99,6 +125,11 @@ export enum Subst {
 //# Functions
 
 export fn env_bind(env: TypeEnv, name: String, ty: Type) -> TypeEnv {
+  env_bind_with_origin(env, name, ty, BindingOriginUnavailable)
+}
+
+export fn env_bind_with_origin(env: TypeEnv, name: String, ty: Type, origin: BindingOrigin) -> TypeEnv {
+  let binding = env_value_binding_with_origin(ty, origin)
   match env {
     // Keeping the cache at the head is only sound while the new binding's
     // name is NOT in the cached index: env_lookup consults the index first,
@@ -107,11 +138,11 @@ export fn env_bind(env: TypeEnv, name: String, ty: Type) -> TypeEnv {
     // function body is checked, and a parameter named like an import then
     // resolved to the import). Bind shadowing names IN FRONT of the cache.
     EnvCached(names_sorted, types_sorted, rest) => if bsearch_leftmost(names_sorted, name) >= 0 {
-      EnvBind(name, ty, env)
+      EnvBind(name, binding, env)
     } else {
-      EnvCached(names_sorted, types_sorted, EnvBind(name, ty, rest))
+      EnvCached(names_sorted, types_sorted, EnvBind(name, binding, rest))
     },
-    _ => EnvBind(name, ty, env)
+    _ => EnvBind(name, binding, env)
   }
 }
 
@@ -217,9 +248,9 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
         EnvEmpty => {
           done = true
         },
-        EnvBind(n, ty, rest) => {
+        EnvBind(n, binding, rest) => {
           ArrayBuilder::push(names, n)
-          ArrayBuilder::push(types, ty)
+          ArrayBuilder::push(types, binding)
           cur = rest
         },
         EnvTraitDef(_, _, _, _, rest, _, _) => {
@@ -237,9 +268,9 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
         EnvFlat(bindings) => {
           let mut j = 0
           while j < Array::length(bindings) {
-            let (n, ty) = Array::get(bindings, j)
+            let (n, binding) = Array::get(bindings, j)
             ArrayBuilder::push(names, n)
-            ArrayBuilder::push(types, ty)
+            ArrayBuilder::push(types, binding)
             j = j + 1
           }
           done = true
@@ -310,6 +341,13 @@ export fn occurs_in(id: Int, ty: Type) -> Bool {
 }
 
 export fn env_lookup(env: TypeEnv, name: String) -> Option[Type] {
+  match env_lookup_binding(env, name) {
+    Some(binding) => Some(binding.ty),
+    None => None
+  }
+}
+
+export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBinding] {
   let mut cur = env
   let mut result = None
   let mut done = false
@@ -318,8 +356,8 @@ export fn env_lookup(env: TypeEnv, name: String) -> Option[Type] {
       EnvEmpty => {
         done = true
       },
-      EnvBind(n, ty, rest) => if n == name {
-        result = Some(ty)
+      EnvBind(n, binding, rest) => if n == name {
+        result = Some(binding)
         done = true
       } else {
         cur = rest
@@ -339,9 +377,9 @@ export fn env_lookup(env: TypeEnv, name: String) -> Option[Type] {
       EnvFlat(bindings) => {
         let mut j = 0
         while j < Array::length(bindings) && !done {
-          let (n, ty) = Array::get(bindings, j)
+          let (n, binding) = Array::get(bindings, j)
           if n == name {
-            result = Some(ty)
+            result = Some(binding)
             done = true
           } else {
             j = j + 1
@@ -1470,10 +1508,18 @@ fn empty_env_bindings() -> Array[(String, Type)] {
 }
 
 export fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)] {
+  let out = empty_env_bindings()
   match env {
-    EnvFlat(bindings) => bindings,
+    EnvFlat(bindings) => {
+      let mut i = 0
+      while i < Array::length(bindings) {
+        let (name, binding) = Array::get(bindings, i)
+        Array::push(out, (name, binding.ty))
+        i = i + 1
+      }
+      out
+    },
     _ => {
-      let out = empty_env_bindings()
       let mut cur = env
       let mut done = false
       while !done {
@@ -1481,8 +1527,8 @@ export fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)] {
           EnvEmpty => {
             done = true
           },
-          EnvBind(name, ty, rest) => {
-            Array::push(out, (name, ty))
+          EnvBind(name, binding, rest) => {
+            Array::push(out, (name, binding.ty))
             cur = rest
           },
           EnvTraitDef(_, _, _, _, rest, _, _) => {
@@ -1500,7 +1546,8 @@ export fn env_flat_bindings(env: TypeEnv) -> Array[(String, Type)] {
           EnvFlat(bindings) => {
             let mut j = 0
             while j < Array::length(bindings) {
-              Array::push(out, Array::get(bindings, j))
+              let (name, binding) = Array::get(bindings, j)
+              Array::push(out, (name, binding.ty))
               j = j + 1
             }
             done = true

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -14,7 +14,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Type, TypeDef, TypeEnv, TypeExpr, env_cache
+  EnvValueBinding, Type, TypeDef, TypeEnv, TypeExpr, env_cache, env_value_binding
 }
 
 //# Functions
@@ -659,6 +659,17 @@ fn parse_type_defs(text: String, pos: Int) -> (Array[TypeDef], Int) with Excepti
   }
 }
 
+fn serialize_value_bindings(items: Array[(String, EnvValueBinding)]) -> String {
+  let plain = array_empty()
+  let mut i = 0
+  while i < Array::length(items) {
+    let (name, binding) = Array::get(items, i)
+    Array::push(plain, (name, binding.ty))
+    i = i + 1
+  }
+  serialize_bindings(plain)
+}
+
 fn serialize_bindings(items: Array[(String, Type)]) -> String {
   let buf = StringBuilder::new()
   StringBuilder::push(buf, __to_string(Array::length(items)))
@@ -696,10 +707,10 @@ fn parse_bindings(text: String, pos: Int) -> (Array[(String, Type)], Int) with E
 fn serialize_type_env_into(buf: StringBuilder, env: TypeEnv) -> Unit {
   match env {
     EnvEmpty => StringBuilder::push(buf, "0"),
-    EnvBind(name, ty, rest) => {
+    EnvBind(name, binding, rest) => {
       StringBuilder::push(buf, "B")
       StringBuilder::push(buf, serialize_segment(name))
-      StringBuilder::push(buf, serialize_type(ty))
+      StringBuilder::push(buf, serialize_type(binding.ty))
       serialize_type_env_into(buf, rest)
     },
     EnvTraitDef(name, supers, is_auto, methods, rest, params, method_gens) => {
@@ -738,7 +749,7 @@ fn serialize_type_env_into(buf: StringBuilder, env: TypeEnv) -> Unit {
     },
     EnvFlat(bindings) => {
       StringBuilder::push(buf, "L")
-      StringBuilder::push(buf, serialize_bindings(bindings))
+      StringBuilder::push(buf, serialize_value_bindings(bindings))
     },
     EnvCached(_, _, rest) => {
       // Cached arrays are acceleration state, not trusted semantics. Emit the
@@ -748,7 +759,13 @@ fn serialize_type_env_into(buf: StringBuilder, env: TypeEnv) -> Unit {
         EnvCached(names, types, _) => {
           StringBuilder::push(buf, "C")
           StringBuilder::push(buf, serialize_string_array(names))
-          StringBuilder::push(buf, serialize_type_array(types))
+          let plain_types = array_empty()
+          let mut i = 0
+          while i < Array::length(types) {
+            Array::push(plain_types, Array::get(types, i).ty)
+            i = i + 1
+          }
+          StringBuilder::push(buf, serialize_type_array(plain_types))
           serialize_type_env_into(buf, rest)
         },
         _ => serialize_type_env_into(buf, rest)
@@ -773,7 +790,7 @@ fn parse_persistent_type_env_payload(text: String, pos: Int) -> (TypeEnv, Int) w
         let (name, after_name) = parse_segment(text, pos + 1)
         let (ty, after_ty) = parse_cached_type(text, after_name)
         let (rest, next) = parse_persistent_type_env_payload(text, after_ty)
-        (EnvBind(name, ty, rest), next)
+        (EnvBind(name, env_value_binding(ty), rest), next)
       },
       'D' => {
         let (name, after_name) = parse_segment(text, pos + 1)
@@ -818,7 +835,14 @@ fn parse_persistent_type_env_payload(text: String, pos: Int) -> (TypeEnv, Int) w
       },
       'L' => {
         let (bindings, next) = parse_bindings(text, pos + 1)
-        (EnvFlat(bindings), next)
+        let value_bindings = array_empty()
+        let mut i = 0
+        while i < Array::length(bindings) {
+          let (name, ty) = Array::get(bindings, i)
+          Array::push(value_bindings, (name, env_value_binding(ty)))
+          i = i + 1
+        }
+        (EnvFlat(value_bindings), next)
       },
       'C' => {
         let (names, after_names) = parse_string_array(text, pos + 1)

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -33,6 +33,7 @@ import @vibe/compiler/checker/artifacts {
 }
 
 import @vibe/compiler/core {
+  BindingOrigin,
   Expr,
   Stmt,
   Type,
@@ -41,11 +42,13 @@ import @vibe/compiler/core {
   bsearch_leftmost,
   dir_of_path,
   env_bind,
+  env_bind_with_origin,
   env_flat_bindings,
   env_lookup,
   env_lookup_flat,
   env_selectable_type_defs,
   env_type_defs,
+  env_value_binding,
   has_standard_effect_policy,
   lookup_registry_builtin,
   normalize_path,
@@ -228,14 +231,14 @@ fn is_selected_type_companion(name: String, ty: Type, type_surface: Array[String
 /// coincidence) but "unknown name: Json::string" for the other 8 of the
 /// 11 documented accessors. The bundle-merge lane resolves these by name
 /// against the merged unit and never had the gap; only this FS lane did.
-fn bind_enum_constructor_companions(acc: TypeEnv, dep_bindings: Array[(String, Type)], enum_name: String, trait_mappings: Array[(String, String)]) -> TypeEnv {
+fn bind_enum_constructor_companions(acc: TypeEnv, resolved: String, dep_bindings: Array[(String, Type)], enum_name: String, trait_mappings: Array[(String, String)]) -> TypeEnv {
   let qual_prefix = String::concat(enum_name, "::")
   let mut out = acc
   let mut i = 0
   while i < Array::length(dep_bindings) {
     let (candidate_name, candidate_ty) = Array::get(dep_bindings, i)
     if candidate_name != enum_name && starts_with_upper(candidate_name) && (type_returns_name(candidate_ty, enum_name) || String::starts_with(candidate_name, qual_prefix)) {
-      out = env_bind(out, candidate_name, trait_projection_map_type_bounds(candidate_ty, trait_mappings))
+      out = env_bind_with_origin(out, candidate_name, trait_projection_map_type_bounds(candidate_ty, trait_mappings), BindingOriginModuleExport(resolved, candidate_name))
     }
     i = i + 1
   }
@@ -955,7 +958,8 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
         Some(a) => a,
         None => name
       }
-      let ty = match env_lookup_flat(dep_bindings, name) {
+      let imported_ty = env_lookup_flat(dep_bindings, name)
+      let ty = match imported_ty {
         Some(t) => trait_projection_map_type_bounds(t, trait_mappings),
         None => {
           // Declaration authority travels explicitly in EnvTypeDefs, so
@@ -969,11 +973,14 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
           CtUnknown
         }
       }
-      let with_name = env_bind(nacc, bound_name, ty)
+      let with_name = match imported_ty {
+        Some(_) => env_bind_with_origin(nacc, bound_name, ty, BindingOriginModuleExport(resolved, name)),
+        None => env_bind(nacc, bound_name, ty)
+      }
       let with_companions = match ty {
-        CtEnum(enum_name) => bind_enum_constructor_companions(with_name, dep_bindings, enum_name, trait_mappings),
+        CtEnum(enum_name) => bind_enum_constructor_companions(with_name, resolved, dep_bindings, enum_name, trait_mappings),
         _ => if starts_with_upper(name) {
-          bind_enum_constructor_companions(with_name, dep_bindings, name, trait_mappings)
+          bind_enum_constructor_companions(with_name, resolved, dep_bindings, name, trait_mappings)
         } else {
           with_name
         }
@@ -2001,10 +2008,10 @@ fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arra
 fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: Array[String], type_surface: Array[String], env: TypeEnv) -> TypeEnv {
   match env {
     EnvEmpty => EnvEmpty,
-    EnvBind(name, ty, rest) => {
+    EnvBind(name, binding, rest) => {
       let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
-      if bsearch_leftmost(value_surface, name) >= 0 || is_selected_type_companion(name, ty, type_surface) {
-        EnvBind(name, ty, restricted)
+      if bsearch_leftmost(value_surface, name) >= 0 || is_selected_type_companion(name, binding.ty, type_surface) {
+        EnvBind(name, env_value_binding(binding.ty), restricted)
       } else {
         restricted
       }
@@ -2067,9 +2074,9 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
       let kept = array_empty()
       let mut i = 0
       while i < Array::length(bindings) {
-        let (name, ty) = Array::get(bindings, i)
-        if bsearch_leftmost(value_surface, name) >= 0 || is_selected_type_companion(name, ty, type_surface) {
-          Array::push(kept, (name, ty))
+        let (name, binding) = Array::get(bindings, i)
+        if bsearch_leftmost(value_surface, name) >= 0 || is_selected_type_companion(name, binding.ty, type_surface) {
+          Array::push(kept, (name, env_value_binding(binding.ty)))
         } else {
           ()
         }
@@ -2100,7 +2107,7 @@ fn prepend_explicit_builtin_value_markers(value_surface: Array[String], env: Typ
   while i < Array::length(value_surface) {
     let name = Array::get(value_surface, i)
     if is_explicit_builtin_declaration(name) && env_lookup(env, name) == None {
-      out = EnvBind(name, CtUnknown, out)
+      out = EnvBind(name, env_value_binding(CtUnknown), out)
     } else {
       ()
     }

--- a/lib/@vibe/compiler/tests/canonical_checked_type_state_test.vibe
+++ b/lib/@vibe/compiler/tests/canonical_checked_type_state_test.vibe
@@ -10,7 +10,7 @@ import @vibe/compiler/checker {
 }
 
 import @vibe/compiler/core {
-  Expr, Stmt, Subst, Type, TypeDef, TypeEnv, TypeExpr, sort_perm_by_names, str_lt
+  Expr, Stmt, Subst, Type, TypeDef, TypeEnv, TypeExpr, env_value_binding, sort_perm_by_names, str_lt
 }
 
 import @vibe/core {
@@ -66,14 +66,14 @@ fn trait_method_gens_snapshot(env: TypeEnv) -> String {
 }
 
 test "canonical checked state preserves EnvBind EnvFlat and EnvCached first-match shadows" {
-  let bind_flat = EnvBind("__fn_ret__:bind", CtUnit, EnvBind("value", CtInt, EnvFlat([
-    ("value", CtBool),
-    ("outer", CtString),
-    ("__fn_ret__:flat", CtDouble)
+  let bind_flat = EnvBind("__fn_ret__:bind", env_value_binding(CtUnit), EnvBind("value", env_value_binding(CtInt), EnvFlat([
+    ("value", env_value_binding(CtBool)),
+    ("outer", env_value_binding(CtString)),
+    ("__fn_ret__:flat", env_value_binding(CtDouble))
   ])))
   let expected = EnvFlat([
-    ("outer", CtString),
-    ("value", CtInt)
+    ("outer", env_value_binding(CtString)),
+    ("value", env_value_binding(CtInt))
   ])
   assert(snapshot(bind_flat, SubstEmpty) == snapshot(expected, SubstEmpty))
   let cached = EnvCached([
@@ -82,27 +82,27 @@ test "canonical checked state preserves EnvBind EnvFlat and EnvCached first-matc
     "__fn_ret__:cached",
     "z"
   ], [
-    CtBool,
-    CtInt,
-    CtDouble,
-    CtString
-  ], EnvBind("z", CtUnit, EnvEmpty))
-  let cached_expected = EnvBind("alpha", CtBool, EnvBind("z", CtString, EnvEmpty))
+    env_value_binding(CtBool),
+    env_value_binding(CtInt),
+    env_value_binding(CtDouble),
+    env_value_binding(CtString)
+  ], EnvBind("z", env_value_binding(CtUnit), EnvEmpty))
+  let cached_expected = EnvBind("alpha", env_value_binding(CtBool), EnvBind("z", env_value_binding(CtString), EnvEmpty))
   assert(snapshot(cached, SubstEmpty) == snapshot(cached_expected, SubstEmpty))
 }
 
 test "canonical checked state shares free alpha variables across sorted values" {
   let left = EnvFlat([
-    ("z", CtVar(91)),
-    ("a", CtVar(91))
+    ("z", env_value_binding(CtVar(91))),
+    ("a", env_value_binding(CtVar(91)))
   ])
   let alpha_equivalent = EnvFlat([
-    ("a", CtVar(4)),
-    ("z", CtVar(4))
+    ("a", env_value_binding(CtVar(4))),
+    ("z", env_value_binding(CtVar(4)))
   ])
   let changed_relation = EnvFlat([
-    ("a", CtVar(4)),
-    ("z", CtVar(5))
+    ("a", env_value_binding(CtVar(4))),
+    ("z", env_value_binding(CtVar(5)))
   ])
   assert(snapshot(left, SubstEmpty) == snapshot(alpha_equivalent, SubstEmpty))
   assert(snapshot(left, SubstEmpty) != snapshot(changed_relation, SubstEmpty))
@@ -156,14 +156,14 @@ test "canonical checked state alpha-normalizes forall bounds without moving them
     CtVar(9)
   ]))
   assert(snapshot(EnvFlat([
-    ("f", left)
+    ("f", env_value_binding(left))
   ]), SubstEmpty) == snapshot(EnvFlat([
-    ("f", reordered)
+    ("f", env_value_binding(reordered))
   ]), SubstEmpty))
   assert(snapshot(EnvFlat([
-    ("f", left)
+    ("f", env_value_binding(left))
   ]), SubstEmpty) != snapshot(EnvFlat([
-    ("f", moved)
+    ("f", env_value_binding(moved))
   ]), SubstEmpty))
 }
 
@@ -190,9 +190,9 @@ test "canonical checked state keeps quantified ids out of substitution" {
     CtInt
   ]))
   assert(snapshot(EnvFlat([
-    ("f", source)
+    ("f", env_value_binding(source))
   ]), subst) == snapshot(EnvFlat([
-    ("f", expected)
+    ("f", env_value_binding(expected))
   ]), SubstEmpty))
 }
 
@@ -208,23 +208,23 @@ test "canonical checked state sorts effect rows and resolves effect substitution
   ], CtUnit, Some("e"))
   let effect_subst = SubstEffBind("e", "State[String], Fs, State[Int], Fs", SubstEmpty)
   assert(snapshot(EnvFlat([
-    ("f", permuted)
+    ("f", env_value_binding(permuted))
   ]), SubstEmpty) == snapshot(EnvFlat([
-    ("f", normalized)
+    ("f", env_value_binding(normalized))
   ]), SubstEmpty))
   assert(snapshot(EnvFlat([
-    ("f", via_var)
+    ("f", env_value_binding(via_var))
   ]), effect_subst) == snapshot(EnvFlat([
-    ("f", CtFn([
+    ("f", env_value_binding(CtFn([
       CtInt
-    ], CtUnit, Some("Fs, State[Int], State[String]")))
+    ], CtUnit, Some("Fs, State[Int], State[String]"))))
   ]), SubstEmpty))
   assert(snapshot(EnvFlat([
-    ("f", CtFn([
-    ], CtUnit, Some("State[Int]")))
+    ("f", env_value_binding(CtFn([
+    ], CtUnit, Some("State[Int]"))))
   ]), SubstEmpty) != snapshot(EnvFlat([
-    ("f", CtFn([
-    ], CtUnit, Some("State[String]")))
+    ("f", env_value_binding(CtFn([
+    ], CtUnit, Some("State[String]"))))
   ]), SubstEmpty))
 }
 
@@ -388,12 +388,12 @@ test "canonical retained typedefs preserve definition and member order" {
 test "canonical checked wrappers isolate value and typedef observations" {
   // String ordering must be lexical, not the runtime's length-first ordering.
   let ordered = snapshot(EnvFlat([
-    ("aa", CtInt),
-    ("a", CtBool)
+    ("aa", env_value_binding(CtInt)),
+    ("a", env_value_binding(CtBool))
   ]), SubstEmpty)
   let expected = snapshot(EnvFlat([
-    ("a", CtBool),
-    ("aa", CtInt)
+    ("a", env_value_binding(CtBool)),
+    ("aa", env_value_binding(CtInt))
   ]), SubstEmpty)
   assert(ordered == expected)
   let type_defs = [
@@ -407,7 +407,7 @@ test "canonical checked wrappers isolate value and typedef observations" {
   let first = CheckedProgram::{
     checked_stmts: array_empty(),
     final_env: EnvFlat([
-      ("value", CtInt)
+      ("value", env_value_binding(CtInt))
     ]),
     type_defs: type_defs,
     final_subst: SubstEmpty,
@@ -417,7 +417,7 @@ test "canonical checked wrappers isolate value and typedef observations" {
     checked_stmts: [
       SLet(false, false, "ignored", None, EInt(1))
     ],
-    final_env: EnvBind("other", CtString, EnvTraitImpl("Eq", CtInt, EnvEmpty)),
+    final_env: EnvBind("other", env_value_binding(CtString), EnvTraitImpl("Eq", CtInt, EnvEmpty)),
     type_defs: type_defs,
     final_subst: SubstEmpty,
     typed_occurrences: [
@@ -427,7 +427,7 @@ test "canonical checked wrappers isolate value and typedef observations" {
   let value_only = CheckedProgram::{
     checked_stmts: array_empty(),
     final_env: EnvFlat([
-      ("value", CtInt)
+      ("value", env_value_binding(CtInt))
     ]),
     type_defs: array_empty(),
     final_subst: SubstEmpty,
@@ -449,10 +449,10 @@ test "canonical checked wrappers isolate value and typedef observations" {
 }
 
 test "canonical trait impl snapshot retains entries in final-env traversal order" {
-  let retained = EnvBind("value", CtInt, EnvTraitImpl("Later", CtString, EnvTraitDef("Ignored", array_empty(), false, array_empty(), EnvCached([
+  let retained = EnvBind("value", env_value_binding(CtInt), EnvTraitImpl("Later", CtString, EnvTraitDef("Ignored", array_empty(), false, array_empty(), EnvCached([
     "cached"
   ], [
-    CtBool
+    env_value_binding(CtBool)
   ], EnvTraitImpl("Earlier", CtInt, EnvEmpty)), [
     "T",
     "U"
@@ -460,7 +460,7 @@ test "canonical trait impl snapshot retains entries in final-env traversal order
   let expected = EnvTraitImpl("Later", CtString, EnvTraitImpl("Earlier", CtInt, EnvEmpty))
   assert(trait_impl_snapshot(retained, SubstEmpty) == trait_impl_snapshot(expected, SubstEmpty))
   assert(trait_impl_snapshot(EnvFlat([
-    ("not_traversed", CtInt)
+    ("not_traversed", env_value_binding(CtInt))
   ]), SubstEmpty) == trait_impl_snapshot(EnvEmpty, SubstEmpty))
 }
 

--- a/lib/@vibe/compiler/tests/checked_effective_effect_row_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_effective_effect_row_artifact_test.vibe
@@ -14,7 +14,7 @@ import @vibe/compiler/checker/artifacts {
 }
 
 import @vibe/compiler/core {
-  Expr, Stmt, Subst, Type, TypeEnv, TypeExpr
+  Expr, Stmt, Subst, Type, TypeEnv, TypeExpr, env_value_binding
 }
 
 import @vibe/core {
@@ -142,43 +142,43 @@ test "effective-row artifact v1 is sensitive to every retained tuple field" {
   let base = artifact_text(checked_with([
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, Some("Annotation"))), direct_fn(Some("Source"), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Final")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Final"))))
   ])))
   let shifted_owner = artifact_text(checked_with([
     SExpr(EUnit),
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, Some("Annotation"))), direct_fn(Some("Source"), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Final")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Final"))))
   ])))
   let renamed = artifact_text(checked_with([
     SLet(false, false, "g", Some(TyFn(array_empty(), TyUnit, Some("Annotation"))), direct_fn(Some("Source"), EUnit))
   ], EnvFlat([
-    ("g", CtFn(array_empty(), CtUnit, Some("Final")))
+    ("g", env_value_binding(CtFn(array_empty(), CtUnit, Some("Final"))))
   ])))
   let absent_annotation = artifact_text(checked_with([
     SLet(false, false, "f", None, direct_fn(Some("Source"), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Final")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Final"))))
   ])))
   let non_function_annotation = artifact_text(checked_with([
     SLet(false, false, "f", Some(TyName("NotFn")), direct_fn(Some("Source"), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Final")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Final"))))
   ])))
   let missing_annotation_row = artifact_text(checked_with([
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, None)), direct_fn(Some("Source"), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Final")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Final"))))
   ])))
   let empty_source_row = artifact_text(checked_with([
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, Some("Annotation"))), direct_fn(Some(""), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Final")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Final"))))
   ])))
   let changed_final_row = artifact_text(checked_with([
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, Some("Annotation"))), direct_fn(Some("Source"), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Other")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Other"))))
   ])))
   assert(base != shifted_owner)
   assert(base != renamed)
@@ -194,7 +194,7 @@ test "effective-row artifact v1 preserves delimiters unicode and None versus Som
   let unusual = artifact_text(checked_with([
     SLet(false, false, "f:[]雪", Some(TyFn(array_empty(), TyUnit, Some("Ann:S[]雪"))), direct_fn(Some("Src:N[]雪"), EUnit))
   ], EnvFlat([
-    ("f:[]雪", CtFn(array_empty(), CtUnit, Some("Final:S[]雪")))
+    ("f:[]雪", env_value_binding(CtFn(array_empty(), CtUnit, Some("Final:S[]雪"))))
   ])))
   match decode_checked_effective_effect_row_artifact_v1(unusual) {
     Some(decoded) => assert(encode_checked_effective_effect_row_artifact_v1(decoded) == unusual),
@@ -203,12 +203,12 @@ test "effective-row artifact v1 preserves delimiters unicode and None versus Som
   let missing = artifact_text(checked_with([
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, None)), direct_fn(None, EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, None))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, None)))
   ])))
   let empty = artifact_text(checked_with([
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, Some(""))), direct_fn(Some(""), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some(""))))
   ])))
   assert(missing != empty)
   match decode_checked_effective_effect_row_artifact_v1(missing) {

--- a/lib/@vibe/compiler/tests/checked_effective_effect_row_observation_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_effective_effect_row_observation_test.vibe
@@ -9,7 +9,7 @@ import @vibe/compiler/checker/artifacts {
 }
 
 import @vibe/compiler/core {
-  Expr, Stmt, Subst, Type, TypeEnv, TypeExpr, env_bind
+  Expr, Stmt, Subst, Type, TypeEnv, TypeExpr, env_bind, env_value_binding
 }
 
 import @vibe/core {
@@ -52,7 +52,7 @@ test "effective row observation keeps raw source options and canonicalizes only 
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, Some("Source, Source"))), direct_fn(Some(""), EUnit))
   ]
   let checked = checked_with(stmts, EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Fs, Error, Fs")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Fs, Error, Fs"))))
   ]), SubstEmpty)
   let snapshot = assert_some_text(observed_snapshot(checked))
   assert(String::contains(snapshot, "S14:Source, Source"))
@@ -61,7 +61,7 @@ test "effective row observation keeps raw source options and canonicalizes only 
   let no_source_row = checked_with([
     SLet(false, false, "f", Some(TyFn(array_empty(), TyUnit, Some("Source, Source"))), direct_fn(None, EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("Error, Fs")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Error, Fs"))))
   ]), SubstEmpty)
   assert(snapshot != assert_some_text(observed_snapshot(no_source_row)))
   assert(canonical_checked_effect_row_snapshot(SubstEmpty, Some("Fs, Error, Fs")) == canonical_checked_effect_row_snapshot(SubstEmpty, Some("Error, Fs")))
@@ -72,7 +72,7 @@ test "effective row observation resolves transitive effect variables" {
   let checked = checked_with([
     SLet(false, false, "f", None, direct_fn(Some("e"), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("e")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("e"))))
   ]), SubstEffBind("e", "x", SubstEffBind("x", "Fs, Fs", SubstEmpty)))
   let snapshot = assert_some_text(observed_snapshot(checked))
   assert(String::contains(snapshot, canonical_checked_effect_row_snapshot(SubstEmpty, Some("Fs"))))
@@ -83,7 +83,7 @@ test "effective row observation selects active root shadows in source order and 
     SLet(false, false, "a", None, direct_fn(Some("A"), EUnit)),
     SLet(false, false, "f", None, direct_fn(Some("Old"), EUnit)),
     SLet(false, false, "f", None, direct_fn(Some("New"), EUnit))
-  ], EnvBind("f", CtFn(array_empty(), CtUnit, Some("New")), EnvBind("a", CtFn(array_empty(), CtUnit, Some("A")), EnvEmpty)), SubstEmpty)
+  ], EnvBind("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("New"))), EnvBind("a", env_value_binding(CtFn(array_empty(), CtUnit, Some("A"))), EnvEmpty)), SubstEmpty)
   let snapshot = assert_some_text(observed_snapshot(checked))
   assert(String::starts_with(snapshot, "vibe-checked-effective-effect-rows-observation:v1\n2:0:1:a"))
   assert(String::contains(snapshot, "2:1:f"))
@@ -93,7 +93,7 @@ test "effective row observation selects active root shadows in source order and 
     SLet(false, false, "a", None, direct_fn(Some("A"), EUnit)),
     SLet(false, false, "f", None, direct_fn(Some("Old"), EUnit)),
     SLet(false, false, "f", None, direct_fn(Some("New"), EUnit))
-  ], EnvBind("f", CtFn(array_empty(), CtUnit, Some("New")), EnvBind("a", CtFn(array_empty(), CtUnit, Some("A")), EnvEmpty)), SubstEmpty)
+  ], EnvBind("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("New"))), EnvBind("a", env_value_binding(CtFn(array_empty(), CtUnit, Some("A"))), EnvEmpty)), SubstEmpty)
   assert(snapshot != assert_some_text(observed_snapshot(shifted)))
 }
 
@@ -105,7 +105,7 @@ test "effective row observation excludes non-root and mutable candidates and fai
     ]),
     SLet(false, false, "outer", Some(TyName("NotFn")), direct_fn(Some("Root"), direct_fn(Some("NestedFn"), EUnit)))
   ], EnvFlat([
-    ("outer", CtFn(array_empty(), CtUnit, Some("Root")))
+    ("outer", env_value_binding(CtFn(array_empty(), CtUnit, Some("Root"))))
   ]), SubstEmpty)
   let snapshot = assert_some_text(observed_snapshot(checked))
   assert(String::starts_with(snapshot, "vibe-checked-effective-effect-rows-observation:v1\n1:"))
@@ -123,8 +123,8 @@ test "effective row observation excludes non-root and mutable candidates and fai
   let duplicate_flat = checked_with([
     SLet(false, false, "f", None, direct_fn(None, EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("First"))),
-    ("f", CtFn(array_empty(), CtUnit, Some("Second")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("First")))),
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("Second"))))
   ]), SubstEmpty)
   let duplicate_flat_snapshot = assert_some_text(observed_snapshot(duplicate_flat))
   assert(String::contains(duplicate_flat_snapshot, canonical_checked_effect_row_snapshot(SubstEmpty, Some("First"))))
@@ -154,7 +154,7 @@ test "effective row observation skips any earlier root binding shadowed by final
     SLet(false, false, "f", None, direct_fn(Some("Old"), EUnit)),
     SLet(false, false, "f", None, EInt(1))
   ], EnvFlat([
-    ("f", CtInt)
+    ("f", env_value_binding(CtInt))
   ]), SubstEmpty)
   let later_let_snapshot = assert_some_text(observed_snapshot(later_let))
   assert(later_let_snapshot == "vibe-checked-effective-effect-rows-observation:v1\n0:")
@@ -162,7 +162,7 @@ test "effective row observation skips any earlier root binding shadowed by final
     SLet(false, false, "f", None, direct_fn(Some("Old"), EUnit)),
     SLetMut("f", None, EInt(1))
   ], EnvFlat([
-    ("f", CtInt)
+    ("f", env_value_binding(CtInt))
   ]), SubstEmpty)
   let later_mut_snapshot = assert_some_text(observed_snapshot(later_mut))
   assert(later_mut_snapshot == "vibe-checked-effective-effect-rows-observation:v1\n0:")
@@ -176,8 +176,8 @@ test "effective row observation validates cached env state and keeps valid cache
     "f",
     "f"
   ], [
-    CtFn(array_empty(), CtUnit, Some("First")),
-    CtFn(array_empty(), CtUnit, Some("Second"))
+    env_value_binding(CtFn(array_empty(), CtUnit, Some("First"))),
+    env_value_binding(CtFn(array_empty(), CtUnit, Some("Second")))
   ], EnvEmpty), SubstEmpty)
   let cached_duplicate_snapshot = assert_some_text(observed_snapshot(cached_duplicates))
   assert(String::contains(cached_duplicate_snapshot, canonical_checked_effect_row_snapshot(SubstEmpty, Some("First"))))
@@ -186,8 +186,8 @@ test "effective row observation validates cached env state and keeps valid cache
     "z",
     "f"
   ], [
-    CtFn(array_empty(), CtUnit, Some("Z")),
-    CtFn(array_empty(), CtUnit, Some("F"))
+    env_value_binding(CtFn(array_empty(), CtUnit, Some("Z"))),
+    env_value_binding(CtFn(array_empty(), CtUnit, Some("F")))
   ], EnvEmpty), SubstEmpty)
   match observed_snapshot(unsorted_cached) {
     None => assert(true),
@@ -218,14 +218,14 @@ test "effective row observation resolves CtVar and effect chains without accepti
   let via_type_var = checked_with([
     SLet(false, false, "f", None, direct_fn(Some("e"), EUnit))
   ], EnvFlat([
-    ("f", CtVar(1))
+    ("f", env_value_binding(CtVar(1)))
   ]), SubstBind(1, CtVar(2), SubstBind(2, CtFn(array_empty(), CtUnit, Some("e")), SubstEffBind("e", "x", SubstEffBind("x", "Fs", SubstEmpty)))))
   let via_type_var_snapshot = assert_some_text(observed_snapshot(via_type_var))
   assert(String::contains(via_type_var_snapshot, canonical_checked_effect_row_snapshot(SubstEmpty, Some("Fs"))))
   let cyclic_effect = checked_with([
     SLet(false, false, "f", None, direct_fn(Some("e"), EUnit))
   ], EnvFlat([
-    ("f", CtFn(array_empty(), CtUnit, Some("e")))
+    ("f", env_value_binding(CtFn(array_empty(), CtUnit, Some("e"))))
   ]), SubstEffBind("e", "x", SubstEffBind("x", "e", SubstEmpty)))
   match observed_snapshot(cyclic_effect) {
     None => assert(true),

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -1,7 +1,20 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Type, TypeDef, TypeEnv, TypeExpr, env_lookup, env_selectable_type_defs, env_type_defs, trait_method_sig, trait_supers, types_equal
+  BindingOrigin,
+  Type,
+  TypeDef,
+  TypeEnv,
+  TypeExpr,
+  env_bind_with_origin,
+  env_lookup,
+  env_lookup_binding,
+  env_selectable_type_defs,
+  env_type_defs,
+  env_value_binding,
+  trait_method_sig,
+  trait_supers,
+  types_equal
 }
 
 import @vibe/compiler/runtime {
@@ -30,12 +43,12 @@ fn cached_polymorphic_type() -> Type {
 
 fn cached_flat_rest() -> TypeEnv {
   EnvFlat([
-    ("shadow", CtInt),
-    ("flat", CtTuple([
+    ("shadow", env_value_binding(CtInt)),
+    ("flat", env_value_binding(CtTuple([
       CtChar,
       CtBytes
-    ])),
-    ("cached", cached_polymorphic_type())
+    ]))),
+    ("cached", env_value_binding(cached_polymorphic_type()))
   ])
 }
 
@@ -58,7 +71,7 @@ fn codec_fixture() -> TypeEnv {
       TyName("T")
     ]), None))
   ]
-  EnvBind("shadow", CtString, EnvTraitImplGen("Functor", [
+  EnvBind("shadow", env_value_binding(CtString), EnvTraitImplGen("Functor", [
     "T"
   ], [
     ("T", [
@@ -77,12 +90,12 @@ fn codec_fixture() -> TypeEnv {
     "flat",
     "shadow"
   ], [
-    cached_polymorphic_type(),
-    CtTuple([
+    env_value_binding(cached_polymorphic_type()),
+    env_value_binding(CtTuple([
       CtChar,
       CtBytes
-    ]),
-    CtInt
+    ])),
+    env_value_binding(CtInt)
   ], cached_flat_rest()), [
     "T",
     "E"
@@ -166,6 +179,24 @@ fn malformed_rejected(text: String) -> Bool {
 
 //# Tests
 
+test "persistent TypeEnv v5 bytes ignore binding provenance and decode it unavailable" {
+  let plain = EnvBind("x", env_value_binding(CtInt), EnvEmpty)
+  let originated = env_bind_with_origin(EnvEmpty, "x", CtInt, BindingOriginModuleExport("/dep.vibe", "source_x"))
+  let plain_text = persistent_type_env_cache_text(plain)
+  let originated_text = persistent_type_env_cache_text(originated)
+  assert(plain_text == originated_text)
+  match parse_persistent_type_env(originated_text) {
+    Some(decoded) => match env_lookup_binding(decoded, "x") {
+      Some(binding) => match binding.origin {
+        BindingOriginUnavailable => assert(true),
+        _ => assert(false)
+      },
+      None => assert(false)
+    },
+    None => assert(false)
+  }
+}
+
 test "persistent module interface v5 round-trips every variant and trait payload" {
   let env = codec_fixture()
   let encoded = persistent_type_env_cache_text(env)
@@ -248,7 +279,7 @@ test "persistent module interface v5 round-trips enum struct and alias authority
     "Choice",
     "Box",
     "ChoiceBox"
-  ], EnvBind("Choice", CtEnum("Choice"), EnvEmpty))
+  ], EnvBind("Choice", env_value_binding(CtEnum("Choice")), EnvEmpty))
   match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
     Some(decoded) => {
       let decoded_defs = env_type_defs(decoded)
@@ -320,11 +351,11 @@ test "legacy enum carrier bytes cannot alter v5 typedef authority" {
     declared
   ], [
     "Choice"
-  ], EnvBind("Choice::__variants__", CtNamed("__variants__", [
+  ], EnvBind("Choice::__variants__", env_value_binding(CtNamed("__variants__", [
     CtNamed("Corrupt", [
       CtString
     ])
-  ]), EnvEmpty))
+  ])), EnvEmpty))
   match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
     Some(decoded) => {
       let defs = env_type_defs(decoded)
@@ -350,9 +381,9 @@ test "persistent module interface v5 rebuilds untrusted cached lookup indexes" {
     "shadow",
     "cached"
   ], [
-    CtBool,
-    CtString,
-    CtUnit
+    env_value_binding(CtBool),
+    env_value_binding(CtString),
+    env_value_binding(CtUnit)
   ], cached_flat_rest())
   match parse_persistent_type_env(persistent_type_env_cache_text(corrupt)) {
     Some(decoded) => {

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -10,7 +10,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Type, TypeEnv, env_lookup, trait_defined
+  Type, TypeEnv, env_lookup, env_value_binding, trait_defined
 }
 
 import @vibe/compiler/runtime {
@@ -335,7 +335,7 @@ test "exact dep projection gives explicit trait aliases precedence over selected
   ], CtVar(7), None))
   let dep_env = EnvTraitDef("Marker", [
   ], false, [
-  ], EnvTraitImpl("Marker", CtInt, EnvBind("accept", generic_value, EnvEmpty)), [
+  ], EnvTraitImpl("Marker", CtInt, EnvBind("accept", env_value_binding(generic_value), EnvEmpty)), [
   ], [
   ])
   let value_first = projected_import_env_for_test("import ./dep.vibe { accept, trait Marker as Local }", "workspace/main.vibe", [

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -5,6 +5,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
+  BindingOrigin,
   Type,
   TypeDef,
   TypeEnv,
@@ -12,10 +13,13 @@ import @vibe/compiler/core {
   collect_tvars,
   env_bind,
   env_bind_all,
+  env_bind_with_origin,
   env_cache,
   env_flat_bindings,
   env_lookup,
+  env_lookup_binding,
   env_lookup_flat,
+  env_value_binding,
   type_to_string,
   types_compatible,
   types_equal
@@ -60,8 +64,8 @@ test "env_lookup shadows outer" {
 
 test "env_lookup handles flat env" {
   let env = EnvFlat([
-    ("x", CtString),
-    ("x", CtInt)
+    ("x", env_value_binding(CtString)),
+    ("x", env_value_binding(CtInt))
   ])
   match env_lookup(env, "x") {
     Some(t) => assert(types_equal(t, CtString)),
@@ -71,7 +75,7 @@ test "env_lookup handles flat env" {
 
 test "env_bind shadows flat env" {
   let flat = EnvFlat([
-    ("x", CtInt)
+    ("x", env_value_binding(CtInt))
   ])
   let env = env_bind(flat, "x", CtString)
   match env_lookup(env, "x") {
@@ -252,6 +256,43 @@ test "type_to_string composite" {
   assert(type_to_string(CtForAll([
     0
   ], array_empty(), CtVar(0))) == "forall ?t0. ?t0")
+}
+
+test "value binding provenance follows first-match lookup through bind flat and cache" {
+  let imported = env_bind_with_origin(EnvEmpty, "x", CtInt, BindingOriginModuleExport("/dep.vibe", "source_x"))
+  let shadowed = env_bind(imported, "x", CtString)
+  match env_lookup_binding(shadowed, "x") {
+    Some(binding) => {
+      assert(types_equal(binding.ty, CtString))
+      match binding.origin {
+        BindingOriginUnavailable => assert(true),
+        _ => assert(false)
+      }
+    },
+    None => assert(false)
+  }
+  let flat = EnvFlat([
+    ("x", env_value_binding(CtBool)),
+    ("x", env_value_binding(CtDouble))
+  ])
+  match env_lookup_binding(flat, "x") {
+    Some(binding) => assert(types_equal(binding.ty, CtBool)),
+    None => assert(false)
+  }
+  let cached = env_cache(env_bind_with_origin(env_bind(EnvEmpty, "x", CtInt), "x", CtChar, BindingOriginModuleExport("/dep.vibe", "x")))
+  match env_lookup_binding(cached, "x") {
+    Some(binding) => {
+      assert(types_equal(binding.ty, CtChar))
+      match binding.origin {
+        BindingOriginModuleExport(path, source) => {
+          assert(path == "/dep.vibe")
+          assert(source == "x")
+        },
+        _ => assert(false)
+      }
+    },
+    None => assert(false)
+  }
 }
 
 test "collect_tvars deduplicates in first-seen order" {


### PR DESCRIPTION
## Summary
- carry optional binding provenance on the existing TypeEnv value bind/cache/lookup path
- attach immediate module-export origins at authoritative import projection
- keep public projection and persistent TypeEnv-v5 transport provenance-free and byte-compatible

## Deliberate limits
This is prerequisite infrastructure only. It adds no resolved-occurrence artifact, local-binder identity, implementation fingerprint, cache/reuse/planner decision, schema bump, or non-TypeEnv resolution authority.

## Validation
- independent review: ACCEPT, no blockers
- stage2/stage3 fixpoint: `3d6cd26d6dcfbaf30e820bc88976e1cfae2c69fb09062d71ec0700eeacc269cc`
- unit suite: 575/575 passed
- formatter and `bit diff --check` passed
- focused tests cover first-match payload pairing, local shadowing, v5 byte parity, and deliberate origin loss

Related: #1548