### PR TITLE
feat(async): distribute selection-valued bindings into their branches (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2916,6 +2916,48 @@ codegen は String を実行時判別する #807)、loop body 内の `return`、
 literal param flow、`if` / `match` branch および non-tail `&&` / `||` RHS の
 条件付き suspension。
 
+### 追記49 (2026-08-13): selection が束縛値そのものなら束縛ごと枝へ分配する (#1536)
+
+追記43 は `if` / `match` が **sequence HEAD** (= 文位置) に立つときだけ継続を枝へ
+分配していた。値として使われる同じ selection —
+
+```
+let v = if ready { perform Op(1) } else { 0 }
+v + 1
+```
+
+— は追記48 の generic ANF に落ちて reject される。ANF は「必ず評価される位置」しか
+歩かないので、枝の中の suspension に名前を付けることはできない (選ばれない枝の
+operation を走らせてしまう)。つまりここでも**受理される綴りが「何をしたか」ではなく
+「どこに置いたか」で決まっていた** — 文位置の `if` は通り、同じ `if` を `let` に
+束縛した瞬間に通らない。
+
+名前を付けられないだけで、**束縛を selection の外に置いておく理由は無い**:
+
+```
+let x = if c { t } else { e }  REST
+  ==>  if c { let x = t  REST } else { let x = e  REST }
+```
+
+condition / scrutinee は元の位置に残るので**ちょうど一回・枝より先に**評価され、
+各枝は自分の値を `x` に束縛して継続を一回だけ走らせる。追記43 が sequence HEAD で
+やっている継続分配と同じ機構で、違いは枝の値が捨てられるか binder に食われるかだけ。
+`let mut` 初期化子も同じ (分配後は枝ごとに継続を box する — cell はそのためにある)。
+
+`match` の腕は追記43 と同様、継続を腕の下へ移す前に**パターン binder を alpha-rename**
+する: 継続は元々 match の外にあったので、そこで自由な名前が腕の束縛に捕まっては
+ならない (`fixtures/effect_let_selection_match_capture_test.vibe` が pin。捕獲すると
+17 ではなく 16 を返す)。追記43 と共有の `scps_float_match_arm_rename` に切り出した。
+
+**`break` / `continue` / `return` を含む selection は fail-closed のまま** — transfer は
+このパスが組む loop 形に対して書き換えられるので、その下へ継続を複製するのは
+このスライスの範囲外。selection が compound の中にネストしている形
+(`1 + (if c { perform .. } else { 0 })`) も従来どおり reject
+(`fixtures/err_effect_compound_branch_suspend.vibe`)。
+
+**残る不適格**: 追記48 の一覧から「`let` / `let mut` の値そのものである selection」を
+引いたもの。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -178,9 +178,13 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   **ループ内の `break` / `continue`** (脱出継続を closure に切り出し、transfer を
   CPS spine 上の呼び出しにする、追記47)、**複合式に埋まった suspension**
   (被演算子・呼び出し引数・コンストラクタ引数・compound な `while` 条件・
-  `+=` 等の compound assignment — 元の評価順のまま let 連鎖へ線形化する、追記48)
+  `+=` 等の compound assignment — 元の評価順のまま let 連鎖へ線形化する、追記48)、
+  **`let` / `let mut` の値そのものである `if` / `match`** (束縛と継続を枝へ分配する。
+  condition / scrutinee は元の位置で一回だけ評価され、`match` の腕は継続を移す前に
+  alpha-rename される、追記49)
 - **不適格**: ループ内 `return`、配列 `for` 形、**必ず評価されるとは限らない位置に
-  埋まった suspension** (`if` / `match` の枝、`&&` / `||` の右辺)、実引数証明が
+  埋まった suspension** (compound の中にネストした `if` / `match` の枝、
+  `&&` / `||` の右辺)、実引数証明が
   成立しない closure パラメータの呼び出し、row 変数 callee (`with e`)。closure
   literal は prepass が literal 自身の spine で step-split し、supported nested
   different-effect handles は既存の handler-ownership lowering を維持するため、

--- a/fixtures/effect_let_selection_match_capture_test.vibe
+++ b/fixtures/effect_let_selection_match_capture_test.vibe
@@ -1,0 +1,39 @@
+// #1536 capture pin for the selection-valued binding distribution: the
+// continuation is moved UNDER a match arm, so an arm's pattern binder must not
+// capture a name that continuation reads from an outer binding.
+//
+// The selected arm binds `n`, shadowing the outer `n = 6` inside the arm only.
+// The continuation `acc + n + g` was outside the match originally and must
+// still read 6. Capturing it would read the scrutinee value (5) instead and
+// print 16 rather than 17.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let n = 6
+    let mut acc = 0
+    let a = if acc == 0 {
+      perform Ask::Get(1)
+    } else {
+      0
+    }
+    acc = acc + a
+    let g = match acc {
+      99 => perform Ask::Get(2),
+      n => n + 1
+    }
+    acc = acc + n + g
+    acc
+  } with Ask {
+    Get(m) => {
+      let k = resume
+      k(m * 5)
+    }
+  }
+}
+
+test "effect let selection match capture" {
+  inspect(_start(), "17")
+}

--- a/fixtures/effect_let_selection_suspend_test.vibe
+++ b/fixtures/effect_let_selection_suspend_test.vibe
@@ -1,0 +1,48 @@
+// #1536: an `if` / `match` that IS the whole bound value distributes the
+// binding and its continuation into the selected branch, so a suspension
+// living in one branch sits on the CPS spine after all. Nothing is floated
+// out of a branch: the operation still runs only on the path that selects it.
+//
+// `steps` counts how many times each distributed continuation ran -- one per
+// binding, never twice -- and the third selection pins that the branch WITHOUT
+// the suspension is still selected normally.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut acc = 0
+    let mut steps = 0
+    let a = if acc == 0 {
+      perform Ask::Get(3)
+    } else {
+      0
+    }
+    steps = steps + 1
+    acc = acc + a
+    let b = match acc {
+      15 => perform Ask::Get(5),
+      _ => 0
+    }
+    steps = steps + 1
+    acc = acc + b
+    let c = if acc > 1000 {
+      perform Ask::Get(7)
+    } else {
+      2
+    }
+    steps = steps + 1
+    acc = acc + c
+    acc * 100 + steps
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n * 5)
+    }
+  }
+}
+
+test "effect let selection suspend" {
+  inspect(_start(), "4203")
+}

--- a/fixtures/effect_letmut_selection_suspend_test.vibe
+++ b/fixtures/effect_letmut_selection_suspend_test.vibe
@@ -1,0 +1,30 @@
+// #1536: the same distribution for a `let mut` initializer. The binding moves
+// into each branch, so each branch boxes its own copy of the continuation --
+// the writes after the resume must still land in the cell the continuation
+// reads (`v = v + 3` then `base = base + v`).
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut base = 1
+    let mut v = if base == 1 {
+      perform Ask::Get(2)
+    } else {
+      0
+    }
+    v = v + 3
+    base = base + v
+    base * 10
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n * 5)
+    }
+  }
+}
+
+test "effect let mut selection suspend" {
+  inspect(_start(), "140")
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9837,12 +9837,19 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
                   ], -1))
                 }
               } else if scps_contains_susp(v, sctx) {
-                // #1536 (a) v8: the value is a compound around the suspension.
-                let (aok, abn, abv, av) = scps_anf_compound(v, sctx, e, site)
-                if aok {
-                  scps_split_tail(scps_anf_wrap(abn, abv, ELet(x, av, b, off)), sctx, ctx, st)
-                } else {
-                  (false, e)
+                // #1536: a selection that IS the whole bound value distributes
+                // the binding and the continuation into its branches instead.
+                match scps_bind_selection_distribute(false, x, v, b, off, site) {
+                  Some(lowered) => scps_split_tail(lowered, sctx, ctx, st),
+                  None => {
+                    // #1536 (a) v8: the value is a compound around the suspension.
+                    let (aok, abn, abv, av) = scps_anf_compound(v, sctx, e, site)
+                    if aok {
+                      scps_split_tail(scps_anf_wrap(abn, abv, ELet(x, av, b, off)), sctx, ctx, st)
+                    } else {
+                      (false, e)
+                    }
+                  }
                 }
               } else {
                 // closure-CPS: a let-bound literal the prepass step-split makes
@@ -10099,13 +10106,21 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           (false, e)
         },
         ELetMut(x, v, b, off) => if scps_contains_susp(v, sctx) {
-          // #1536 (a) v8: compound initializer. The binders wrap outside the
-          // `let mut`, so the cell is still created after they run.
-          let (aok, abn, abv, av) = scps_anf_compound(v, sctx, e, site)
-          if aok {
-            scps_split_tail(scps_anf_wrap(abn, abv, ELetMut(x, av, b, off)), sctx, ctx, st)
-          } else {
-            (false, e)
+          // #1536: selection-valued initializer -- distribute the `let mut`
+          // and its continuation into the branches. Each branch then boxes
+          // its own copy of the continuation, which is what the cell is for.
+          match scps_bind_selection_distribute(true, x, v, b, off, site) {
+            Some(lowered) => scps_split_tail(lowered, sctx, ctx, st),
+            None => {
+              // #1536 (a) v8: compound initializer. The binders wrap outside
+              // the `let mut`, so the cell is still created after they run.
+              let (aok, abn, abv, av) = scps_anf_compound(v, sctx, e, site)
+              if aok {
+                scps_split_tail(scps_anf_wrap(abn, abv, ELetMut(x, av, b, off)), sctx, ctx, st)
+              } else {
+                (false, e)
+              }
+            }
           }
         } else {
           // #1230: box the mutable local so every continuation closure on
@@ -11078,7 +11093,7 @@ fn scps_transform_handle(body: Expr, arms: Array[(Pat, Expr)], ctx: (Array[Stmt]
     } else {
       let (split_ok, split_body) = scps_split_tail(body, sctx, ctx, st)
       if !split_ok {
-        Array::push(errs, "a handler arm captures `resume` as a value (suspend class, ADR-0076 Phase 3a/3b), but a perform of the handled effect (or a call to a function that performs it) is not directly on the handle body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)")
+        Array::push(errs, "a handler arm captures `resume` as a value (suspend class, ADR-0076 Phase 3a/3b), but a perform of the handled effect (or a call to a function that performs it) is not directly on the handle body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch where the selection is nested inside a compound instead of being a statement, the tail, or the whole value of a `let` / `let mut`, or one in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)")
         None
       } else {
         scps_ensure_effect_runtime(eff, ctx, st)
@@ -11558,6 +11573,41 @@ fn scps_seq_float_fresh(x: String, k: Expr, b: Expr, site: Int) -> String {
   nx
 }
 
+/// Alpha-rename one arm's pattern binders away from every name the code that
+/// is about to be moved UNDER that arm (`b`) reads, and rename the arm body to
+/// match. `b` was outside the match originally, so any name free in it refers
+/// to an outer binding and must keep doing so once it sits inside the arm.
+/// Shared by every distribution below so they all get the same guarantee.
+fn scps_float_match_arm_rename(p: Pat, body: Expr, b: Expr, site: Int, arm: Int) -> (Pat, Expr) {
+  let names = array_empty()
+  scps_pat_collect_binds(p, names)
+  let mut p2 = p
+  let mut body2 = body
+  let mut ni = 0
+  while ni < Array::length(names) {
+    let nm = Array::get(names, ni)
+    let mut seen = false
+    let mut prev = 0
+    while prev < ni {
+      if Array::get(names, prev) == nm {
+        seen = true
+      } else {
+        ()
+      }
+      prev = prev + 1
+    }
+    if seen {
+      ()
+    } else {
+      let nx = scps_seq_float_match_fresh(nm, p2, body2, b, site, arm)
+      p2 = scps_rename_pat_ident(p2, nm, nx)
+      body2 = scps_rename_ident(body2, nm, nx)
+    }
+    ni = ni + 1
+  }
+  (p2, body2)
+}
+
 /// Append the original sequence tail to every match arm without letting a
 /// pattern binder capture a name in that tail. Each arm gets fresh binders
 /// and a correspondingly alpha-renamed body before `b` is placed under the
@@ -11567,36 +11617,67 @@ fn scps_seq_float_match_arms(arms: Array[(Pat, Expr)], b: Expr, site: Int) -> Ar
   let mut i = 0
   while i < Array::length(arms) {
     let (p, body) = Array::get(arms, i)
-    let names = array_empty()
-    scps_pat_collect_binds(p, names)
-    let mut p2 = p
-    let mut body2 = body
-    let mut ni = 0
-    while ni < Array::length(names) {
-      let nm = Array::get(names, ni)
-      let mut seen = false
-      let mut prev = 0
-      while prev < ni {
-        if Array::get(names, prev) == nm {
-          seen = true
-        } else {
-          ()
-        }
-        prev = prev + 1
-      }
-      if seen {
-        ()
-      } else {
-        let nx = scps_seq_float_match_fresh(nm, p2, body2, b, site, i)
-        p2 = scps_rename_pat_ident(p2, nm, nx)
-        body2 = scps_rename_ident(body2, nm, nx)
-      }
-      ni = ni + 1
-    }
+    let (p2, body2) = scps_float_match_arm_rename(p, body, b, site, i)
     Array::push(out, (p2, ESeq(body2, b)))
     i = i + 1
   }
   out
+}
+
+/// Rebuild the binding a distributed selection branch now owns.
+fn scps_mk_bind(is_mut: Bool, x: String, v: Expr, b: Expr, off: Int) -> Expr {
+  if is_mut {
+    ELetMut(x, v, b, off)
+  } else {
+    ELet(x, v, b, off)
+  }
+}
+
+/// Bind each arm's own value and continue there, capture-safely.
+fn scps_bind_float_match_arms(arms: Array[(Pat, Expr)], is_mut: Bool, x: String, b: Expr, off: Int, site: Int) -> Array[(Pat, Expr)] {
+  let out = scps_empty_arms()
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (p, body) = Array::get(arms, i)
+    let (p2, body2) = scps_float_match_arm_rename(p, body, b, site, i)
+    Array::push(out, (p2, scps_mk_bind(is_mut, x, body2, b, off)))
+    i = i + 1
+  }
+  out
+}
+
+/// #1536: `let x = <if/match> REST` where the selection is the WHOLE bound
+/// value. Naming a suspension that lives in one branch is not available here
+/// -- it would run the operation on the path that does not select that branch
+/// -- but the binding does not have to stay outside the selection:
+///
+///   let x = if c { t } else { e }  REST
+///     ==>  if c { let x = t  REST } else { let x = e  REST }
+///
+/// The condition/scrutinee stays where it was, so it is still evaluated
+/// exactly once and before exactly one branch; each branch's own value is
+/// what `x` is bound to there, and the continuation runs once after it. This
+/// is the same continuation distribution a selection in SEQUENCE HEAD
+/// position already gets (#1610) -- the only difference is that the branch
+/// value is consumed by a binder instead of discarded.
+///
+/// Match arms additionally alpha-rename their pattern binders, because the
+/// continuation was outside the match and its free names must not be
+/// captured by an arm binding.
+///
+/// A selection carrying `break` / `continue` / `return` stays fail-closed:
+/// those transfers are rewritten against the loop shape this pass builds, and
+/// duplicating the continuation under them is not part of this slice.
+fn scps_bind_selection_distribute(is_mut: Bool, x: String, v: Expr, b: Expr, off: Int, site: Int) -> Option[Expr] {
+  if scps_has_loop_ctl(v) {
+    None
+  } else {
+    match v {
+      EIf(c, t, el) => Some(EIf(c, scps_mk_bind(is_mut, x, t, b, off), scps_mk_bind(is_mut, x, el, b, off))),
+      EMatch(s, arms) => Some(EMatch(s, scps_bind_float_match_arms(arms, is_mut, x, b, off, site))),
+      _ => None
+    }
+  }
 }
 
 /// Fresh name for one distributed match arm. Besides the arm body and shared
@@ -12228,7 +12309,7 @@ fn scps_emit_clone(eff: String, fname: String, ctx: (Array[Stmt], Array[(String,
         } else {
           let (split_ok, split_body) = scps_split_tail(fbody2, sctx, ctx, st)
           if !split_ok {
-            Array::push(errs, String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, but a perform of that effect (or a call to a function that performs it) is not directly on its body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817, ADR-0076 Phase 3b)"))
+            Array::push(errs, String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, but a perform of that effect (or a call to a function that performs it) is not directly on its body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch where the selection is nested inside a compound instead of being a statement, the tail, or the whole value of a `let` / `let mut`, or one in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817, ADR-0076 Phase 3b)"))
           } else {
             Array::push(scps_st_inj(st), SLet(false, true, scps_clone_name(eff, fname), None, EFn(tps, tbs, cparams, None, None, split_body)))
           }
@@ -12874,7 +12955,7 @@ fn scps_split_literal(tps: Array[String], tbs: Array[(String, Array[String])], p
   } else {
     let (split_ok, split_body) = scps_split_tail(b, sctx, ctx, st)
     if !split_ok {
-      Array::push(errs, String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class, ADR-0076 追記31 Vertical B) performs it (or calls a function that performs it) off the let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch, or in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)"))
+      Array::push(errs, String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class, ADR-0076 追記31 Vertical B) performs it (or calls a function that performs it) off the let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a suspension some execution would not reach -- one inside an `if` / `match` branch where the selection is nested inside a compound instead of being a statement, the tail, or the whole value of a `let` / `let mut`, or one in the right operand of a non-tail `&&` / `||` -- are not eligible; tail `&&` / `||` is supported; a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)"))
       EFn(tps, tbs, params, None, None, b)
     } else {
       scps_ensure_effect_runtime(eff, ctx, st)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6885,6 +6885,15 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_tail_shortcircuit_suspend.vibe \
   fixtures/effect_let_shortcircuit_suspend.vibe
+# #1536 selection-valued bindings: an `if` / `match` that IS the whole bound
+# value distributes the binding and the continuation into its branches. The
+# snapshots pin exact-once continuation runs, that the non-suspending branch is
+# still selected normally, that a `let mut` cell survives the distribution, and
+# that an arm binder cannot capture a name the moved continuation reads.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_let_selection_suspend_test.vibe \
+  fixtures/effect_let_selection_match_capture_test.vibe \
+  fixtures/effect_letmut_selection_suspend_test.vibe
 # #1536: loop bodies carrying `break` / `continue`. The transfers become calls
 # on the CPS spine (exit continuation / loop self-call), dead statements behind
 # a transfer drop, and a nested loop keeps its own transfers. `return` in the


### PR DESCRIPTION
## 何を直したか

`if` / `match` が **`let` / `let mut` の値そのもの**であるとき、枝の中の suspension が
reject されていた。同じ selection を**文位置**に置けば #1610 以来通るので、**受理される
綴りが「何をしたか」ではなく「どこに置いたか」で決まっていた**。

```vibe
let v = if ready { perform Op(1) } else { 0 }   // reject されていた
v + 1
```

generic compound ANF (追記48) は「必ず評価される位置」しか歩かないので、枝の中の
suspension に名前を付けることはできない — 選ばれない枝の operation を走らせてしまう。
だが**名前を付けられないだけで、束縛を selection の外に置いておく理由は無い**:

```
let x = if c { t } else { e }  REST
  ==>  if c { let x = t  REST } else { let x = e  REST }
```

condition / scrutinee は元の位置に残るので**ちょうど一回・枝より先に**評価され、
各枝は自分の値を `x` に束縛して継続を一回だけ走らせる。追記43 が sequence HEAD で
やっている継続分配と同じ機構で、違いは枝の値が捨てられるか binder に食われるかだけ。

## 実装

- `scps_bind_selection_distribute` — `ELet` / `ELetMut` の値が selection なら分配する
  (`scps_split_tail` の compound ANF fallback の手前)
- `scps_float_match_arm_rename` — 追記43 の arm 別 alpha-rename を切り出して共有。
  継続は元々 match の外にあったので、そこで自由な名前が腕の binder に捕まってはならない
- **fail-closed のまま**: `break` / `continue` / `return` を含む selection (transfer は
  このパスが組む loop 形に対して書き換えられるので、その下へ継続を複製するのは範囲外)、
  compound にネストした selection (`1 + (if c { perform .. } else { 0 })`)
- 3 箇所の適格性 diagnostics の文面を更新 — 「`if` / `match` の枝は全部不適格」ではなく
  「compound にネストしている場合」と正確に述べる

## テスト

新規 fixture は inspect snapshot (#1571)。`scripts/compiler_gate.sh` の scps レーンに追加:

- `effect_let_selection_suspend_test.vibe` — `if` 枝 / `match` 腕 / 非 suspend 側の枝の
  3 形。`steps` が継続の exact-once を pin (4203)
- `effect_let_selection_match_capture_test.vibe` — 選択された腕が外側 `n` を shadow する
  形。捕獲すると 17 ではなく 16 を返す
- `effect_letmut_selection_suspend_test.vibe` — `let mut` 初期化子。分配後も cell 経由の
  書き込みが継続に見えることを pin (140)

既存の reject fixture (`err_effect_compound_branch_suspend` /
`err_effect_compound_match_branch_suspend` ほか) は引き続き reject されることを確認済み。

`bash scripts/compiler_gate.sh` (full operation gate) green、`scripts/vibe_fmt.sh --check`
green、`scripts/check_fixture_execution.sh` green。

## ドキュメント

- ADR-0076 追記49 (`docs/effect-evidence-passing.md`)
- `docs/spec/wasi-p3-async.md` §2.2 の適格性境界

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_