### PR TITLE
feat(async): move a binding inward through a block-valued initializer (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2958,6 +2958,28 @@ condition / scrutinee は元の位置に残るので**ちょうど一回・枝�
 **残る不適格**: 追記48 の一覧から「`let` / `let mut` の値そのものである selection」を
 引いたもの。
 
+### 追記50 (2026-08-13): block が束縛値そのものなら束縛を内側へ移す (#1536)
+
+追記49 と同じ「どこに置いたか」問題がもう一段ある。分配した枝の中に**文がある**と、
+枝の値は `{ log(); perform Op() }` という block になり、`ELet(x, ESeq(a, v), b)` の形で
+また generic ANF に落ちて reject される。文位置の同じ block は追記42 の
+sequence-HEAD float が既に受けているので、値位置だけが取り残されていた。
+
+block の文前置は値より先に走るので、**束縛はそれを追い越して内側へ入れる**だけでよい:
+
+```
+let x = { a; v }         REST  ==>  a;           let x = v  REST
+let x = { let y = e; v } REST  ==>  let y' = e;  let x = v[y:=y']  REST
+```
+
+float した `let` binder は継続の上へスコープが広がるので、追記42 と同じ
+`scps_seq_float_fresh` の probe で alpha-rename する (`REST` は元々 block の外に
+あったので、そこで自由な名前は外側の束縛を指す)。`fixtures/effect_let_block_value_suspend_test.vibe`
+が pin — 捕獲すると 762 ではなく 812 を返す。
+
+どちらの書き換えも値を**厳密に小さく**するので、結果を再 split すれば収束する。
+追記49 の分配と合わせて、「文を含む枝」が初めて通る。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -181,7 +181,9 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   `+=` 等の compound assignment — 元の評価順のまま let 連鎖へ線形化する、追記48)、
   **`let` / `let mut` の値そのものである `if` / `match`** (束縛と継続を枝へ分配する。
   condition / scrutinee は元の位置で一回だけ評価され、`match` の腕は継続を移す前に
-  alpha-rename される、追記49)
+  alpha-rename される、追記49)、**`let` / `let mut` の値そのものである block**
+  (`{ 文..; 値 }` — 束縛を文前置の内側へ移す。float した binder は alpha-rename される、
+  追記50。これにより「文を含む枝」が通る)
 - **不適格**: ループ内 `return`、配列 `for` 形、**必ず評価されるとは限らない位置に
   埋まった suspension** (compound の中にネストした `if` / `match` の枝、
   `&&` / `||` の右辺)、実引数証明が

--- a/fixtures/effect_let_block_value_suspend_test.vibe
+++ b/fixtures/effect_let_block_value_suspend_test.vibe
@@ -1,0 +1,47 @@
+// #1536: a BLOCK as the whole bound value. The block's statement prefix runs
+// before its value either way, so the binding moves inward past it and the
+// ordinary spine picks the prefix up. A `let` inside the block widens its
+// scope over the continuation when it floats, so it is alpha-renamed first.
+//
+// `log` counts statement-prefix runs (1 for the block, 1 for the branch), and
+// the second block shadows the outer `n`: the continuation `acc + c + n` was
+// outside that block and must still read 6. Capturing the floated binder
+// instead would read 11 and print 812.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut acc = 0
+    let mut log = 0
+    let a = {
+      log = log + 1
+      perform Ask::Get(2)
+    }
+    acc = acc + a
+    let n = 6
+    let c = {
+      let n = acc + 1
+      perform Ask::Get(n)
+    }
+    acc = acc + c + n
+    let d = if acc == 71 {
+      log = log + 1
+      perform Ask::Get(1)
+    } else {
+      0
+    }
+    acc = acc + d
+    acc * 10 + log
+  } with Ask {
+    Get(m) => {
+      let k = resume
+      k(m * 5)
+    }
+  }
+}
+
+test "effect let block value suspend" {
+  inspect(_start(), "762")
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -9837,9 +9837,10 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
                   ], -1))
                 }
               } else if scps_contains_susp(v, sctx) {
-                // #1536: a selection that IS the whole bound value distributes
-                // the binding and the continuation into its branches instead.
-                match scps_bind_selection_distribute(false, x, v, b, off, site) {
+                // #1536: a block or a selection that IS the whole bound value
+                // moves the binding inward instead of asking the compound ANF
+                // to walk a position it cannot.
+                match scps_bind_value_float(false, x, v, b, off, site) {
                   Some(lowered) => scps_split_tail(lowered, sctx, ctx, st),
                   None => {
                     // #1536 (a) v8: the value is a compound around the suspension.
@@ -10106,10 +10107,10 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           (false, e)
         },
         ELetMut(x, v, b, off) => if scps_contains_susp(v, sctx) {
-          // #1536: selection-valued initializer -- distribute the `let mut`
-          // and its continuation into the branches. Each branch then boxes
-          // its own copy of the continuation, which is what the cell is for.
-          match scps_bind_selection_distribute(true, x, v, b, off, site) {
+          // #1536: block- or selection-valued initializer -- move the
+          // `let mut` inward. A distributed branch then boxes its own copy of
+          // the continuation, which is what the cell is for.
+          match scps_bind_value_float(true, x, v, b, off, site) {
             Some(lowered) => scps_split_tail(lowered, sctx, ctx, st),
             None => {
               // #1536 (a) v8: compound initializer. The binders wrap outside
@@ -11646,6 +11647,37 @@ fn scps_bind_float_match_arms(arms: Array[(Pat, Expr)], is_mut: Bool, x: String,
   out
 }
 
+/// #1536: `let x = { stmt.. ; value } REST` -- a BLOCK as the whole bound
+/// value. The block's statement prefix runs before the value either way, so
+/// the binding can simply move inward past it and let the ordinary spine pick
+/// the prefix up:
+///
+///   let x = { a; v }        REST  ==>  a;              let x = v  REST
+///   let x = { let y = e; v} REST  ==>  let y' = e;     let x = v[y:=y']  REST
+///
+/// A floated `let` binder widens its scope over the continuation, so it is
+/// alpha-renamed first (`REST` was outside the block, so a name free there
+/// refers to an outer binding) -- the same rule and the same fresh-name probe
+/// the sequence-head float uses.
+///
+/// This is what makes a branch with statements in it work after the selection
+/// distribution below: `if c { log(); perform Op() }` becomes a block-valued
+/// binding in the branch it was distributed into.
+fn scps_bind_block_float(is_mut: Bool, x: String, v: Expr, b: Expr, off: Int, site: Int) -> Option[Expr] {
+  match v {
+    ESeq(a, v2) => Some(ESeq(a, scps_mk_bind(is_mut, x, v2, b, off))),
+    ELet(y, v1, v2, o) => {
+      let ny = scps_seq_float_fresh(y, v2, b, site)
+      Some(ELet(ny, v1, scps_mk_bind(is_mut, x, scps_rename_ident(v2, y, ny), b, off), o))
+    },
+    ELetMut(y, v1, v2, o) => {
+      let ny = scps_seq_float_fresh(y, v2, b, site)
+      Some(ELetMut(ny, v1, scps_mk_bind(is_mut, x, scps_rename_ident(v2, y, ny), b, off), o))
+    },
+    _ => None
+  }
+}
+
 /// #1536: `let x = <if/match> REST` where the selection is the WHOLE bound
 /// value. Naming a suspension that lives in one branch is not available here
 /// -- it would run the operation on the path that does not select that branch
@@ -11677,6 +11709,17 @@ fn scps_bind_selection_distribute(is_mut: Bool, x: String, v: Expr, b: Expr, off
       EMatch(s, arms) => Some(EMatch(s, scps_bind_float_match_arms(arms, is_mut, x, b, off, site))),
       _ => None
     }
+  }
+}
+
+/// #1536: move a `let` / `let mut` inward through the shape of its own value.
+/// Both rewrites below strictly shrink that value, so re-splitting the result
+/// converges: a block-valued selection branch floats its statement prefix out,
+/// then binds whatever the branch actually evaluates to.
+fn scps_bind_value_float(is_mut: Bool, x: String, v: Expr, b: Expr, off: Int, site: Int) -> Option[Expr] {
+  match scps_bind_block_float(is_mut, x, v, b, off, site) {
+    Some(lowered) => Some(lowered),
+    None => scps_bind_selection_distribute(is_mut, x, v, b, off, site)
   }
 }
 

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6894,6 +6894,12 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_let_selection_suspend_test.vibe \
   fixtures/effect_let_selection_match_capture_test.vibe \
   fixtures/effect_letmut_selection_suspend_test.vibe
+# #1536 block-valued bindings: `let x = { stmt..; value }` moves the binding
+# inward past the statement prefix, so the ordinary spine picks the prefix up.
+# The snapshot pins the prefix running once per binding and that a `let` inside
+# the block cannot capture the continuation's outer name when it floats.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_let_block_value_suspend_test.vibe
 # #1536: loop bodies carrying `break` / `continue`. The transfers become calls
 # on the CPS spine (exit continuation / loop self-call), dead statements behind
 # a transfer drop, and a nested loop keeps its own transfers. `return` in the


### PR DESCRIPTION
## 何を直したか

#1676 (追記49) で `let x = if c { .. } else { .. }` は枝へ分配されるようになったが、
**枝の中に文があると**まだ通らなかった:

```vibe
let d = if acc == 71 {
  log = log + 1        // ← 文がある
  perform Ask::Get(1)
} else {
  0
}
```

分配した枝の値は `{ 文; 値 }` という block なので `ELet(x, ESeq(a, v), b)` の形になり、
generic compound ANF に落ちて reject される。**文位置の同じ block は追記42 の
sequence-HEAD float が既に受けている**ので、値位置だけが取り残されていた — 追記49 と
同じ「どこに置いたか」問題の一段下。

block の文前置は値より先に走るので、**束縛がそれを追い越して内側へ入る**だけでよい:

```
let x = { a; v }         REST  ==>  a;           let x = v  REST
let x = { let y = e; v } REST  ==>  let y' = e;  let x = v[y:=y']  REST
```

float した `let` binder は継続の上へスコープが広がるので、追記42 と同じ
`scps_seq_float_fresh` の probe で alpha-rename する。どちらの書き換えも値を
**厳密に小さく**するので、結果を再 split すれば収束する。

## テスト

`fixtures/effect_let_block_value_suspend_test.vibe` (inspect snapshot、#1571) を
`scripts/compiler_gate.sh` の scps レーンに追加:

- 文前置つき block-valued 束縛 (`log` が前置の実行回数を pin)
- block 内の `let n` が外側の `n = 6` を shadow する形 — 継続の `acc + c + n` は
  元々 block の外にあったので外側の 6 を読まなければならない。捕獲すると 762 ではなく
  812 を返す
- 追記49 の分配と組み合わせた「文を含む枝」

既存 fixture (`effect_let_selection_*`, `effect_letmut_selection_*`) と reject fixture
(`err_effect_compound_branch_suspend` ほか) の回帰なし。

`bash scripts/compiler_gate.sh` (full operation gate) green、`scripts/vibe_fmt.sh --check`
green、`scripts/check_fixture_execution.sh` green (250 fixtures)。

## ドキュメント

- ADR-0076 追記50 (`docs/effect-evidence-passing.md`)
- `docs/spec/wasi-p3-async.md` §2.2 の適格性境界

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_