### PR TITLE
feat(async): reshape selection- and block-valued assignment RHS (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2980,6 +2980,35 @@ float した `let` binder は継続の上へスコープが広がるので、追
 どちらの書き換えも値を**厳密に小さく**するので、結果を再 split すれば収束する。
 追記49 の分配と合わせて、「文を含む枝」が初めて通る。
 
+block の文前置は `ESeq` とは限らない — 中の代入文は**残りの block を自分の継続として
+持つ** (`EAssign(y, v1, <残り>)`) ので、`ESeq` / `EAssign` / `EAssignOp` の 3 綴りを
+同じ「何も束縛しない前置」として扱う。
+
+### 追記51 (2026-08-13): 代入の RHS にも同じ 2 つの書き換えを与える (#1536)
+
+追記49/50 は束縛 (`let` / `let mut`) だけだった。同じ形を代入で書くと
+(`acc = if c { perform .. } else { 0 }`, `acc = { log(); perform .. }`) まだ reject される。
+値が新しい binder に入るか既存の target に入るかは、suspension の位置とは無関係な違い。
+
+書き換えは同じ (binder を作らない分だけ簡単):
+
+```
+x = if c { t } else { e }  REST  ==>  if c { x = t  REST } else { x = e  REST }
+x = { a; v }               REST  ==>  a;  x = v  REST
+```
+
+**適用箇所が 2 つある**のがこのスライスの本質:
+
+- **cellify より前** (`scps_float_direct_assign`) — この spine が box した target 向け。
+  `x = v` が `Array::set(x, 0, v)` になった後では `v` は builtin の引数であり、そこから
+  float すると**他の引数の評価を複製する**ことになる。だから box 化の前に形を直す
+- **継続 spine 上** (`scps_split_tail` の `EAssign` arm) — spine の外で束縛された target 向け。
+  こちらは代入のまま split に届く
+
+両者が食い違うと綴りによって受理が変わるので、fixture を 2 本置いて同じ書き換えを pin した
+(`effect_assign_selection_suspend_test.vibe` / `effect_assign_outer_selection_suspend_test.vibe`)。
+`match` の腕の alpha-rename と `break` / `continue` / `return` の fail-closed は追記49 と同じ。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -183,7 +183,9 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   condition / scrutinee は元の位置で一回だけ評価され、`match` の腕は継続を移す前に
   alpha-rename される、追記49)、**`let` / `let mut` の値そのものである block**
   (`{ 文..; 値 }` — 束縛を文前置の内側へ移す。float した binder は alpha-rename される、
-  追記50。これにより「文を含む枝」が通る)
+  追記50。これにより「文を含む枝」が通る)、**代入 (`=`) の RHS が同じ selection / block
+  そのもの** (box した target は cellify の前に、spine 外の target は継続 spine 上で、
+  同じ 2 つの書き換えを受ける、追記51)
 - **不適格**: ループ内 `return`、配列 `for` 形、**必ず評価されるとは限らない位置に
   埋まった suspension** (compound の中にネストした `if` / `match` の枝、
   `&&` / `||` の右辺)、実引数証明が

--- a/fixtures/effect_assign_outer_selection_suspend_test.vibe
+++ b/fixtures/effect_assign_outer_selection_suspend_test.vibe
@@ -1,0 +1,32 @@
+// #1536: the same assignment reshaping for a target bound OUTSIDE the handle
+// body. That target is not boxed by this spine, so the assignment is still an
+// assignment when the split reaches it -- this is the continuation-spine arm
+// rather than the pre-cellification one, and both have to agree.
+//
+// The write must be visible after the handle returns: `r` is the handle's
+// value (6) and `outer` is what the resumed branch assigned (5).
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  let mut outer = 0
+  let r = handle {
+    outer = if outer == 0 {
+      perform Ask::Get(1)
+    } else {
+      0
+    }
+    outer + 1
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n * 5)
+    }
+  }
+  r * 10 + outer
+}
+
+test "effect assign outer selection suspend" {
+  inspect(_start(), "65")
+}

--- a/fixtures/effect_assign_selection_suspend_test.vibe
+++ b/fixtures/effect_assign_selection_suspend_test.vibe
@@ -1,0 +1,46 @@
+// #1536: the assignment mirror of the binding distribution. `x = <if/match>`
+// and `x = { stmt..; value }` move the assignment inward the same way a
+// binding does, so a suspension in a branch or after a statement prefix is on
+// the spine. For a target this spine boxed, that has to happen BEFORE
+// cellification -- once `x = v` is `Array::set(x, 0, v)`, `v` is a builtin
+// argument and floating it out would duplicate the other arguments.
+//
+// The `match` step pins capture safety: the selected arm binds `n`, shadowing
+// the outer `n = 6` inside the arm only. The continuation moved under that arm
+// still reads 6, so `acc` becomes 12 and the last operation sees 12. Capturing
+// the arm binder instead would read 5 and print 551.
+effect Ask {
+  Get(Int) -> Int
+}
+
+let _start = () -> Int {
+  handle {
+    let mut acc = 0
+    let mut log = 0
+    acc = if acc == 0 {
+      perform Ask::Get(1)
+    } else {
+      0
+    }
+    let n = 6
+    acc = match acc {
+      99 => perform Ask::Get(2),
+      n => n + 1
+    }
+    acc = acc + n
+    acc = {
+      log = log + 1
+      perform Ask::Get(acc)
+    }
+    acc * 10 + log
+  } with Ask {
+    Get(m) => {
+      let k = resume
+      k(m * 5)
+    }
+  }
+}
+
+test "effect assign selection suspend" {
+  inspect(_start(), "601")
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -10095,13 +10095,23 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
           let ax = scps_seq_float_fresh("assign", e, EUnit, site)
           scps_split_tail(ELet(ax, v, EAssign(x, EIdent(ax, -1), b), -1), sctx, ctx, st)
         } else if scps_contains_susp(v, sctx) {
-          // #1536 (a) v8: compound RHS (`x = f(perform Op())`). An `x op=` RHS
-          // arrives here too, as the `Array::set` head scps_cellify makes of it.
-          let (aok, abn, abv, av) = scps_anf_compound(v, sctx, e, site)
-          if aok {
-            scps_split_tail(scps_anf_wrap(abn, abv, EAssign(x, av, b)), sctx, ctx, st)
-          } else {
-            (false, e)
+          // #1536: a block or a selection as the whole RHS moves the assignment
+          // inward, exactly as a binding does. A target boxed by cellification
+          // was already reshaped before that rewrite (scps_float_direct_assign);
+          // this arm covers targets bound outside this spine.
+          match scps_assign_value_float(x, v, b, site) {
+            Some(lowered) => scps_split_tail(lowered, sctx, ctx, st),
+            None => {
+              // #1536 (a) v8: compound RHS (`x = f(perform Op())`). An `x op=`
+              // RHS arrives here too, as the `Array::set` head scps_cellify
+              // makes of it.
+              let (aok, abn, abv, av) = scps_anf_compound(v, sctx, e, site)
+              if aok {
+                scps_split_tail(scps_anf_wrap(abn, abv, EAssign(x, av, b)), sctx, ctx, st)
+              } else {
+                (false, e)
+              }
+            }
           }
         } else {
           (false, e)
@@ -10170,11 +10180,23 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
 /// Name direct suspension RHS values before mutable-local boxing. This pass
 /// traverses continuation-spine positions; expression normalization separately
 /// handles supported closure and nested-handle forms before this pass.
+///
+/// #1536: a block- or selection-valued RHS is reshaped here too, and for the
+/// same reason it has to happen BEFORE cellification: once `x = v` has become
+/// `Array::set(x, 0, v)`, `v` is a builtin argument, and floating it out of
+/// there would mean duplicating the evaluation of the other arguments.
 fn scps_float_direct_assign(e: Expr, sctx: (String, Array[String], Array[String], Int, Array[String]), site: Int) -> Expr {
   match e {
     EAssign(x, v, b) => if scps_direct_spine_input(v, sctx) {
       let ax = scps_seq_float_fresh("assign", e, EUnit, site)
       ELet(ax, v, EAssign(x, EIdent(ax, -1), scps_float_direct_assign(b, sctx, site)), -1)
+    } else if scps_contains_susp(v, sctx) {
+      match scps_assign_value_float(x, v, b, site) {
+        // Each float strictly shrinks the RHS, so re-running this walk on the
+        // result converges instead of looping.
+        Some(lowered) => scps_float_direct_assign(lowered, sctx, site),
+        None => EAssign(x, v, scps_float_direct_assign(b, sctx, site))
+      }
     } else {
       EAssign(x, v, scps_float_direct_assign(b, sctx, site))
     },
@@ -11666,6 +11688,13 @@ fn scps_bind_float_match_arms(arms: Array[(Pat, Expr)], is_mut: Bool, x: String,
 fn scps_bind_block_float(is_mut: Bool, x: String, v: Expr, b: Expr, off: Int, site: Int) -> Option[Expr] {
   match v {
     ESeq(a, v2) => Some(ESeq(a, scps_mk_bind(is_mut, x, v2, b, off))),
+    // An assignment statement inside the block carries the rest of the block
+    // as its own continuation rather than appearing as an ESeq head. It binds
+    // nothing, so it moves out unchanged. (A write to a mutable this spine
+    // boxed has already become an `Array::set` statement by now; this is the
+    // spelling a target bound outside the spine still has.)
+    EAssign(y, v1, v2) => Some(EAssign(y, v1, scps_mk_bind(is_mut, x, v2, b, off))),
+    EAssignOp(y, op, v1, v2) => Some(EAssignOp(y, op, v1, scps_mk_bind(is_mut, x, v2, b, off))),
     ELet(y, v1, v2, o) => {
       let ny = scps_seq_float_fresh(y, v2, b, site)
       Some(ELet(ny, v1, scps_mk_bind(is_mut, x, scps_rename_ident(v2, y, ny), b, off), o))
@@ -11709,6 +11738,58 @@ fn scps_bind_selection_distribute(is_mut: Bool, x: String, v: Expr, b: Expr, off
       EMatch(s, arms) => Some(EMatch(s, scps_bind_float_match_arms(arms, is_mut, x, b, off, site))),
       _ => None
     }
+  }
+}
+
+/// Assign each arm's own value to the same target and continue there.
+fn scps_assign_float_match_arms(arms: Array[(Pat, Expr)], x: String, b: Expr, site: Int) -> Array[(Pat, Expr)] {
+  let out = scps_empty_arms()
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (p, body) = Array::get(arms, i)
+    let (p2, body2) = scps_float_match_arm_rename(p, body, b, site, i)
+    Array::push(out, (p2, EAssign(x, body2, b)))
+    i = i + 1
+  }
+  out
+}
+
+/// #1536: the assignment mirror of `scps_bind_value_float`. `x = { a; v } REST`
+/// and `x = if c { t } else { e } REST` are the same two shapes, and the same
+/// two rewrites apply -- the only difference is that the value lands in an
+/// existing target instead of a new binder, so no binder needs minting.
+///
+/// The target name is untouched, so it still refers to whatever it referred to
+/// before: a `let` floated out of the block is alpha-renamed (it would
+/// otherwise widen its scope over the continuation), and a distributed match
+/// arm renames its pattern binders (the continuation was outside the match).
+fn scps_assign_value_float(x: String, v: Expr, b: Expr, site: Int) -> Option[Expr] {
+  match v {
+    ESeq(a, v2) => Some(ESeq(a, EAssign(x, v2, b))),
+    // An assignment statement inside the block carries the rest of the block
+    // as its own continuation, so the prefix is already spelled this way
+    // rather than as an ESeq. It binds nothing, so it just moves out.
+    EAssign(y, v1, v2) => Some(EAssign(y, v1, EAssign(x, v2, b))),
+    EAssignOp(y, op, v1, v2) => Some(EAssignOp(y, op, v1, EAssign(x, v2, b))),
+    ELet(y, v1, v2, o) => {
+      let ny = scps_seq_float_fresh(y, v2, b, site)
+      Some(ELet(ny, v1, EAssign(x, scps_rename_ident(v2, y, ny), b), o))
+    },
+    ELetMut(y, v1, v2, o) => {
+      let ny = scps_seq_float_fresh(y, v2, b, site)
+      Some(ELetMut(ny, v1, EAssign(x, scps_rename_ident(v2, y, ny), b), o))
+    },
+    EIf(c, t, el) => if scps_has_loop_ctl(v) {
+      None
+    } else {
+      Some(EIf(c, EAssign(x, t, b), EAssign(x, el, b)))
+    },
+    EMatch(s, arms) => if scps_has_loop_ctl(v) {
+      None
+    } else {
+      Some(EMatch(s, scps_assign_float_match_arms(arms, x, b, site)))
+    },
+    _ => None
   }
 }
 

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6900,6 +6900,12 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 # the block cannot capture the continuation's outer name when it floats.
 VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_let_block_value_suspend_test.vibe
+# #1536 assignment mirror: `x = <if/match>` / `x = { stmt..; value }`. A boxed
+# target is reshaped before cellification, a target bound outside the spine on
+# the continuation spine; the two snapshots pin both arms agreeing.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_assign_selection_suspend_test.vibe \
+  fixtures/effect_assign_outer_selection_suspend_test.vibe
 # #1536: loop bodies carrying `break` / `continue`. The transfers become calls
 # on the CPS spine (exit continuation / loop self-call), dead statements behind
 # a transfer drop, and a nested loop keeps its own transfers. `return` in the


### PR DESCRIPTION
## 何を直したか

#1676 / #1687 の束縛分配は `let` / `let mut` だけだった。同じ形を**代入**で書くと
まだ reject される:

```vibe
acc = if c { perform Ask::Get(1) } else { 0 }
acc = { log = log + 1; perform Ask::Get(acc) }
```

値が新しい binder に入るか既存の target に入るかは、suspension がどこにあるかとは
無関係な違い。書き換えは binder を作らない分だけ簡単:

```
x = if c { t } else { e }  REST  ==>  if c { x = t  REST } else { x = e  REST }
x = { a; v }               REST  ==>  a;  x = v  REST
```

## 適用箇所が 2 つあるのがこのスライスの本質

- **cellify より前** (`scps_float_direct_assign`) — この spine が box した target 向け。
  `x = v` が `Array::set(x, 0, v)` になった後では `v` は builtin の引数であり、そこから
  float すると**他の引数の評価を複製する**ことになる。だから box 化の前に形を直す
- **継続 spine 上** (`scps_split_tail` の `EAssign` arm) — spine の外で束縛された target 向け。
  こちらは代入のまま split に届く

両者が食い違うと**また綴りで受理が変わる**ので、fixture を 2 本置いて同じ書き換えを pin した。

## block の文前置は `ESeq` とは限らない

中の代入文は**残りの block を自分の継続として持つ** (`EAssign(y, v1, <残り>)`) ので、
`ESeq` / `EAssign` / `EAssignOp` の 3 綴りを同じ「何も束縛しない前置」として扱う。
(`let` 側の fixture が通っていたのは、そこでは cellify が既に `Array::set` 文にしていて
`ESeq` になっていたから — spine 外の target ではこの綴りが残る。)

## テスト

- `fixtures/effect_assign_selection_suspend_test.vibe` — box された target。`if` / `match` /
  block の 3 形と、選択された腕が外側 `n` を shadow する capture pin (捕獲すると 601 ではなく 551)
- `fixtures/effect_assign_outer_selection_suspend_test.vibe` — handle body の外で束縛された
  target。継続 spine 側の arm を通り、resume 後の書き込みが handle を抜けても見える (65)

`match` の腕の alpha-rename と `break` / `continue` / `return` の fail-closed は #1676 と同じ。

`bash scripts/compiler_gate.sh` (full operation gate) green、`scripts/vibe_fmt.sh --check`
green、`scripts/check_fixture_execution.sh` green (252 fixtures)。

## ドキュメント

- ADR-0076 追記51 (`docs/effect-evidence-passing.md`)
- `docs/spec/wasi-p3-async.md` §2.2 の適格性境界

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_