### PR TITLE
fix(async): refuse `return` on a split body's spine instead of trapping (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -3066,6 +3066,38 @@ bypass は保たれる (`effect_compound_shortcircuit_suspend_test.vibe` の `b`
 元のスコープではなくその closure を指してしまう)、および RHS の spine 要素が
 direct でない suspension を持つ形。条件付き位置そのものはこれで塞がった。
 
+### 追記54 (2026-08-13): split される body の `return` を fail-closed にする (#1536)
+
+上の条件付き位置を潰す作業中に実測で見つけた**先行するバグ**。suspend lowering は body を
+「step を返す部品」へ書き換えるので、その body に書かれた `return` は**もう関数を抜けない** —
+自分の値を step のつもりで driver に手渡す。結果、**型検査を通り、clean にコンパイルされ、
+`return` を通った実行だけが runtime で trap する** (`unreachable`)。
+
+```
+fn helper() -> Int with Ask {
+  let a = perform Ask::Get(1)
+  if a > 0 { return a * 100 } else { () }   // ← compile 成功 / 実行で trap
+  a
+}
+```
+
+チェックされていたのは**ループ body の `return` だけ** (`scps_body_has_return` は
+loop→再帰変換の適格性判定にしか使われていなかった)。ループの外も、そして
+**suspension より前の guard-clause 形も**同じ理由で壊れている — `return` が抜ける先の
+部品は「変換後の関数」であって元の関数ではない。
+
+split する 3 箇所 (handle body / needing fn clone / closure literal) すべてで、split の前に
+`scps_body_has_return` で refuse する。診断は**効く編集を述べる**: 「早期脱出の値を返すのでは
+なく作れ (束縛して後で選べ)、または `return` を handle の外へ出せ」。
+
+**nested closure の `return` はそのまま受理される** — それはその closure を指すので正しく、
+`scps_body_has_return` は `EFn` で走査を止める (`effect_resume_store_loop_nested_return` が
+positive 側、`err_effect_return_in_split_body` /
+`err_effect_return_guard_in_split_body` が negative 側)。
+
+本来の解 (escape 継続を lowering に持たせて `return` を通す) は残件のまま。今回のスライスは
+「黙って壊れる」を「その場で断る」に変えただけで、書けるコードは増えていない。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -190,7 +190,10 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   **non-tail の `&&` / `||`** (同じく右辺へは降りず短絡式を丸ごと名前に束ねる。
   受け側の let-shortcircuit が受理すると判定手続き自身に訊いてからのみ、追記53。
   bypass は保たれる)
-- **不適格**: ループ内 `return`、配列 `for` 形、**選ばれた `&&` / `||` 右辺が
+- **不適格**: **split される body 自身の spine 上の `return`** (ループ内に限らない。
+  変換後の部品は step を返すので `return` は関数を抜けない — 以前は compile が通って
+  実行時に trap していた。nested closure 内の `return` はその closure を指すので適格、
+  追記54)、配列 `for` 形、**選ばれた `&&` / `||` 右辺が
   `return` / `break` / `continue` する形**、実引数証明が
   成立しない closure パラメータの呼び出し、row 変数 callee (`with e`)。closure
   literal は prepass が literal 自身の spine で step-split し、supported nested

--- a/fixtures/err_effect_let_shortcircuit_return_suspend.vibe
+++ b/fixtures/err_effect_let_shortcircuit_return_suspend.vibe
@@ -1,6 +1,12 @@
 // #1536 boundary: a selected short-circuit RHS may carry a direct suspension
 // through a let/seq spine, but a terminal return cannot be moved into the
 // synthetic resume continuation and must remain fail-closed.
+//
+// This is now refused by the general rule -- a `return` anywhere on a split
+// body's own spine is rejected before the split runs, because the split makes
+// those pieces return a step -- so the diagnostic names that edit instead of
+// the spine shape. The short-circuit lowering keeps its own transfer guard as
+// a local invariant.
 effect Ask {
   Get(Int) -> Bool
 }

--- a/fixtures/err_effect_return_guard_in_split_body.vibe
+++ b/fixtures/err_effect_return_guard_in_split_body.vibe
@@ -1,0 +1,35 @@
+// #1536 companion to err_effect_return_in_split_body: the guard-clause shape,
+// where the `return` precedes every suspension. It looks like it should be
+// untouched by the split -- but the piece it returns from IS the transformed
+// function, whose result is a step, so taking this branch trapped at runtime
+// just the same. Refused with the same actionable message.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn helper(x: Int) -> Int with Ask {
+  if x < 0 {
+    return 7
+  } else {
+    ()
+  }
+  let a = perform Ask::Get(1)
+  a
+}
+
+let _start = () -> Int {
+  handle {
+    helper(-1)
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "cannot contain a `return`"
+}

--- a/fixtures/err_effect_return_in_split_body.vibe
+++ b/fixtures/err_effect_return_in_split_body.vibe
@@ -1,0 +1,39 @@
+// #1536: a `return` on the spine of a body the suspend lowering splits used to
+// type-check, compile clean, and TRAP at runtime on the path that took it.
+// The split rewrites the body into pieces that return a step, so the `return`
+// handed its own value to the driver as if it were one.
+//
+// This is the shape that traps AFTER the suspension. The guard-clause shape
+// (a `return` before every suspension) is broken for the same reason -- the
+// piece it returns from is the transformed function, not the original one --
+// so both are refused, and the refusal names the edit that fixes them.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn helper() -> Int with Ask {
+  let a = perform Ask::Get(1)
+  if a > 0 {
+    return a * 100
+  } else {
+    ()
+  }
+  a
+}
+
+let _start = () -> Int {
+  handle {
+    helper()
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "cannot contain a `return`"
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -10585,6 +10585,19 @@ fn scps_cellify_arms(arms: Array[(Pat, Expr)], x: String) -> Array[(Pat, Expr)] 
   out
 }
 
+/// #1536: the suspend lowering rewrites a body into a machine whose pieces
+/// return a STEP, not the body's own value. A `return` written in that body
+/// therefore no longer leaves the enclosing function -- it hands its value to
+/// the driver as if it were a step. Until the lowering can carry an escape,
+/// this is refused up front rather than compiled into a runtime trap: it used
+/// to type-check, compile clean, and trap on the path that took the `return`.
+///
+/// The `return` inside a nested closure is unaffected (it targets that
+/// closure) and stays accepted -- scps_body_has_return stops at EFn.
+fn scps_return_in_split_msg(subject: String) -> String {
+  String::concat(subject, " cannot contain a `return`: the suspend lowering turns the body into continuations that return a step, so the `return` would hand its own value to the driver instead of leaving the function. Produce the early-exit value instead of returning it (bind it and select on it), or move the `return` outside the handle. A `return` inside a nested closure targets that closure and is fine (#1536, ADR-0076 Phase 3a/3b)")
+}
+
 /// A `return` inside the loop body targets the FUNCTION, which a loop closure
 /// cannot express. Nested closures own their own `return`, so the scan stops
 /// at them (the same boundary scps_has_loop_ctl uses).
@@ -11151,6 +11164,9 @@ fn scps_transform_handle(body: Expr, arms: Array[(Pat, Expr)], ctx: (Array[Stmt]
       scps_msg = String::concat(scps_msg, " -- only `perform`, pure builtins, constructors, provably effect-free functions, and functions whose concrete row carries the handled effect may be called in the handled body (#817)")
       scps_msg = String::concat(scps_msg, culprit_marker)
       Array::push(errs, scps_msg)
+      None
+    } else if scps_body_has_return(body) {
+      Array::push(errs, scps_return_in_split_msg("a handler arm captures `resume` as a value, so this handle body"))
       None
     } else {
       let (split_ok, split_body) = scps_split_tail(body, sctx, ctx, st)
@@ -12469,6 +12485,8 @@ fn scps_emit_clone(eff: String, fname: String, ctx: (Array[Stmt], Array[(String,
           scps_msg = String::concat(scps_msg, " (#817, ADR-0076 Phase 3b)")
           scps_msg = String::concat(scps_msg, culprit_marker)
           Array::push(errs, scps_msg)
+        } else if scps_body_has_return(fbody2) {
+          Array::push(errs, scps_return_in_split_msg(String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, so its body")))
         } else {
           let (split_ok, split_body) = scps_split_tail(fbody2, sctx, ctx, st)
           if !split_ok {
@@ -13114,6 +13132,9 @@ fn scps_split_literal(tps: Array[String], tbs: Array[(String, Array[String])], p
     scps_msg = String::concat(scps_msg, " (#817)")
     scps_msg = String::concat(scps_msg, culprit_marker)
     Array::push(errs, scps_msg)
+    EFn(tps, tbs, params, None, None, b)
+  } else if scps_body_has_return(b) {
+    Array::push(errs, scps_return_in_split_msg(String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class) is split into continuations, so its body")))
     EFn(tps, tbs, params, None, None, b)
   } else {
     let (split_ok, split_body) = scps_split_tail(b, sctx, ctx, st)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6935,10 +6935,17 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 # #1536 boundary: generic linearization still walks only positions that every
 # execution reaching a compound also reaches, so it never names a suspension
 # INSIDE a branch or inside a short-circuit RHS. Both are instead named WHOLE
-# (the snapshots above pin that, bypass included). What stays closed is a
-# selected RHS that moves a source return into the synthetic resume
-# continuation -- it would target that closure rather than its source scope.
-scps_check_reject "err_effect_let_shortcircuit_return_suspend.vibe" "let/seq/tail/branch-tail spine" "letshortcircuitreturn"
+# (the snapshots above pin that, bypass included). A selected RHS that returns
+# stays closed -- now via the general rule below, since a `return` anywhere on
+# a split body's spine is refused before the split runs.
+scps_check_reject "err_effect_let_shortcircuit_return_suspend.vibe" "cannot contain a \`return\`" "letshortcircuitreturn"
+# #1536: a `return` anywhere on a split body's own spine. This used to compile
+# clean and trap at runtime on the path that took it, before AND after the
+# suspension alike, because the split makes those pieces return a step. The
+# `return` inside a NESTED CLOSURE targets that closure and stays accepted --
+# effect_resume_store_loop_nested_return above is the positive side.
+scps_check_reject "err_effect_return_in_split_body.vibe" "cannot contain a \`return\`" "returninsplit"
+scps_check_reject "err_effect_return_guard_in_split_body.vibe" "cannot contain a \`return\`" "returnguardsplit"
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
 # THAT diagnostic, so the fixture cannot silently start passing for the other


### PR DESCRIPTION
## 実測で見つけた先行バグ

#1536 の次の残件 (loop body 内の `return`) を実測で切り分けている最中に見つけた。
**ループに限った話ではなかった。**

suspend lowering は body を「**step を返す部品**」へ書き換える。その body に書かれた
`return` は**もう関数を抜けない** — 自分の値を step のつもりで driver に手渡す。結果:

**型検査を通り、clean にコンパイルされ、`return` を通った実行だけが runtime で trap する**
(`unreachable`)。

チェックされていたのは**ループ body の `return` だけ** (`scps_body_has_return` は
loop→再帰変換の適格性判定にしか使われていなかった)。次の 2 形はどちらも compile が通って
trap していた:

```vibe
// (1) suspension の後
let a = perform Ask::Get(1)
if a > 0 { return a * 100 } else { () }
a

// (2) suspension の前 (guard clause) — これも壊れている。
//     `return` が抜ける先の部品は「変換後の関数」であって元の関数ではない
if x < 0 { return 7 } else { () }
let a = perform Ask::Get(1)
a
```

## 直し方

split する 3 箇所 (handle body / needing fn clone / closure literal) すべてで、split の前に
`scps_body_has_return` で refuse する。診断は pass 名ではなく**効く編集**を述べる:

```
... cannot contain a `return`: the suspend lowering turns the body into
continuations that return a step, so the `return` would hand its own value to
the driver instead of leaving the function. Produce the early-exit value
instead of returning it (bind it and select on it), or move the `return`
outside the handle. A `return` inside a nested closure targets that closure
and is fine (#1536, ADR-0076 Phase 3a/3b)
```

**nested closure の `return` はそのまま受理される** — それはその closure を指すので正しく、
`scps_body_has_return` は `EFn` で走査を止める。`effect_resume_store_loop_nested_return`
(112) が positive 側として引き続き通る。

## テスト

- `fixtures/err_effect_return_in_split_body.vibe` — suspension の後の `return`
- `fixtures/err_effect_return_guard_in_split_body.vibe` — suspension の前の guard clause

`err_effect_let_shortcircuit_return_suspend` は引き続き reject されるが、**一般規則の方が
先に効く**ので needle をそちらへ更新した (より行動可能な文面になる)。

## 範囲

**書けるコードは増えていない。** 「黙って壊れる」を「その場で断る」に変えただけ。
本来の解 — escape 継続を lowering に持たせて `return` を通す — は #1536 の残件のまま。

`bash scripts/compiler_gate.sh` (full operation gate) green、`scripts/vibe_fmt.sh --check`
green、`scripts/check_fixture_execution.sh` green。

## ドキュメント

- ADR-0076 追記54 (`docs/effect-evidence-passing.md`)
- `docs/spec/wasi-p3-async.md` §2.2 の適格性境界

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_