### PR TITLE
fix(async): treat a transfer with a statement in front of it as a transfer (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -3128,6 +3128,49 @@ handle body は対象外 — そこの `return` は**囲む関数**から抜け�
 前の early exit (取る/取らない)、tail return、そして腕の binder が外側 `n` を shadow する
 match — 捕獲すると 311 ではなく 306 になる。
 
+### 追記56 (2026-08-13): loop 内の `return` と、その下で見つかった P0 (#1536)
+
+ループ body の `return` は追記55 の hoist では扱えない — **loop body の tail は「次の反復」で
+あって関数の値ではない**から。だが新しい機構は要らなかった: `break` は既にこの loop を
+出られる (追記47) し、loop の**後ろ**の spine 上の `return` は追記55 が扱える。だから
+「値を控えて、loop を出て、外で返す」に書き換えるだけでよい:
+
+```
+while c { .. return v .. }   ==>  let mut returned = false
+REST                              let mut slot = 0
+                                  while c { .. slot = v; returned = true; break .. }
+                                  if returned { return slot } else { REST }
+```
+
+**入れ子の loop の中の `return` は refuse** (`break` は最内 loop しか出ないので、間違った
+段で止まる)。`err_effect_return_nested_loop_suspend` が pin。
+
+#### この書き換えが最初に誤答した — 原因は先行する P0 だった
+
+実装後の最初の実測が **700 ではなく 800** を返した。切り分けると、原因は `return` ではなく
+**`break` そのもの**だった:
+
+```vibe
+while i < 5 {
+  let v = perform Ask::Get(i)
+  if v > 6 { acc = v * 100; break } else { () }   // ← 前に文が 1 つある
+  i = i + 1
+}
+```
+
+`scps_is_ctl_terminator` が**裸の** `break` / `continue` しか transfer と認めていなかったため、
+「文が 1 つ前に付いた transfer」= 普通の綴りが transfer と見なされず、normalizer は継続を
+落とさず、rewrite も切らなかった。rewrite 後の transfer は**ただの呼び出し** (`k(v)`) なので、
+実行は**それを素通りして loop を続けた**。同じ loop を effect 抜きで書けば 700、
+suspension を入れると 800 — **黙って別の答えを返していた** (P0)。
+
+`scps_is_ctl_terminator` を「この式は必ず transfer するか」に広げた (spine の tail を辿り、
+selection は**全枝が transfer するときだけ**真。nested loop / closure / handle には入らない)。
+`effect_transfer_after_resume_test.vibe` が pin (70011302)。
+
+**教訓**: 追記55 の hoist は設計上正しかったが、土台が壊れていた。既存 fixture は transfer を
+**suspension より前**にしか置いておらず、resume の後ろの transfer を誰も見ていなかった。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -190,10 +190,11 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   **non-tail の `&&` / `||`** (同じく右辺へは降りず短絡式を丸ごと名前に束ねる。
   受け側の let-shortcircuit が受理すると判定手続き自身に訊いてからのみ、追記53。
   bypass は保たれる)
-- **不適格**: **ループ body 内・handle body 内の `return`** (前者は `bubble(lp(), k)` が
-  done 値をループの値として渡すので escape しない、後者は囲む関数から抜ける意味で handle の
-  値ではない)。**needing fn / closure literal の spine 上の `return` は適格** — そこでは
-  `return v` = 「この computation の値が v」なので、split の前に tail へ寄せる (追記55)。
+- **不適格**: **入れ子 loop 内・handle body 内の `return`** (前者は `break` が最内 loop しか
+  出ないため間違った段で止まる、後者は囲む関数から抜ける意味で handle の値ではない)。
+  **needing fn / closure literal の spine 上の `return` は適格** — そこでは
+  `return v` = 「この computation の値が v」なので split の前に tail へ寄せる (追記55)。
+  **単一 loop 内の `return` も適格** — 値を控えて `break` で出て loop の外で返す (追記56)。
   寄せきれない `return` が残れば追記54 の refuse に落ちる、配列 `for` 形、**選ばれた `&&` / `||` 右辺が
   `return` / `break` / `continue` する形**、実引数証明が
   成立しない closure パラメータの呼び出し、row 変数 callee (`with e`)。closure

--- a/fixtures/effect_return_in_loop_test.vibe
+++ b/fixtures/effect_return_in_loop_test.vibe
@@ -1,0 +1,59 @@
+// #1536: a `return` inside a suspending `while` body. The hoist cannot move it
+// to the body's tail -- a loop body's tail is the NEXT ITERATION, not the
+// function's value -- and the loop closure the split builds cannot return from
+// the function around it. Nothing new is needed to express it, though: `break`
+// already leaves such a loop, and a `return` on the spine after the loop is
+// already handled. So the value is recorded, the loop is left, and the return
+// happens outside it.
+//
+// `first_big` returns from inside the loop (700); `sums` never takes its
+// return and falls out of the loop normally (15).
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn first_big() -> Int with Ask {
+  let mut i = 0
+  while i < 5 {
+    let v = perform Ask::Get(i)
+    if v > 6 {
+      return v * 100
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  0
+}
+
+fn sums() -> Int with Ask {
+  let mut i = 0
+  let mut acc = 0
+  while i < 3 {
+    let v = perform Ask::Get(i)
+    if v > 100 {
+      return 1
+    } else {
+      acc = acc + v
+    }
+    i = i + 1
+  }
+  acc
+}
+
+let _start = () -> Int {
+  handle {
+    let a = first_big()
+    let b = sums()
+    a * 100 + b
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+
+test "effect return in loop" {
+  inspect(_start(), "70015")
+}

--- a/fixtures/effect_transfer_after_resume_test.vibe
+++ b/fixtures/effect_transfer_after_resume_test.vibe
@@ -1,0 +1,65 @@
+// #1536 P0 regression: a `break` / `continue` with a STATEMENT in front of it,
+// in a loop that suspends. The transfer test used to recognize only a BARE
+// transfer, so the ordinary spelling `if done { acc = v; break }` was not seen
+// as a transfer at all: the continuation was neither dropped by the normalizer
+// nor cut by the rewrite, and since a rewritten transfer is a plain call
+// (`k(v)`), execution FELL THROUGH it and kept looping.
+//
+// That compiled clean and silently answered differently than the same loop
+// without a suspension. `scan` is the control: written without effects it is
+// 700, and it must stay 700 here (it used to be 800 -- one iteration too many).
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn scan() -> Int with Ask {
+  let mut i = 0
+  let mut acc = 0
+  while i < 5 {
+    let v = perform Ask::Get(i)
+    if v > 6 {
+      acc = v * 100
+      break
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  acc
+}
+
+fn skip() -> Int with Ask {
+  let mut i = 0
+  let mut trips = 0
+  let mut acc = 0
+  while i < 5 {
+    i = i + 1
+    let v = perform Ask::Get(i)
+    if v > 6 {
+      trips = trips + 100
+      continue
+    } else {
+      ()
+    }
+    acc = acc + v
+    trips = trips + 1
+  }
+  acc * 1000 + trips
+}
+
+let _start = () -> Int {
+  handle {
+    let a = scan()
+    let b = skip()
+    a * 100000 + b
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+
+test "effect transfer after resume" {
+  inspect(_start(), "70011302")
+}

--- a/fixtures/err_effect_return_nested_loop_suspend.vibe
+++ b/fixtures/err_effect_return_nested_loop_suspend.vibe
@@ -1,0 +1,42 @@
+// #1536 boundary: a `return` inside a loop NESTED in another loop. The rewrite
+// records the value and leaves the loop with `break`, but `break` only leaves
+// the INNERMOST loop, so the return would stop at the wrong level. Refused
+// rather than guessed at.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn nested() -> Int with Ask {
+  let mut i = 0
+  while i < 3 {
+    let mut j = 0
+    while j < 3 {
+      let v = perform Ask::Get(j)
+      if v > 5 {
+        return v
+      } else {
+        ()
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  0
+}
+
+let _start = () -> Int {
+  handle {
+    nested()
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "cannot contain a `return`"
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -10621,6 +10621,164 @@ fn scps_return_in_split_msg(subject: String) -> String {
 ///
 /// A nested closure is not entered: its `return` targets that closure and is
 /// already correct (`_ => e` covers EFn, EWhile, ELoop and EForIn alike).
+/// Does this expression contain a `return` that the loop rewrite below cannot
+/// reach -- one inside a loop NESTED in the loop it is rewriting? `break` only
+/// leaves the innermost loop, so such a return would stop at the wrong level.
+/// Nested closures are not entered (their `return` is their own).
+fn scps_loop_return_nested(e: Expr) -> Bool {
+  match e {
+    EFn(_, _, _, _, _, _) => false,
+    EWhile(_, b) => scps_body_has_return(b),
+    ELoop(_, b) => scps_body_has_return(b),
+    EForIn(_, _, _, b) => scps_body_has_return(b),
+    ELet(_, v, b, _) => scps_loop_return_nested(v) || scps_loop_return_nested(b),
+    ELetMut(_, v, b, _) => scps_loop_return_nested(v) || scps_loop_return_nested(b),
+    ELetRec(_, v, b) => scps_loop_return_nested(v) || scps_loop_return_nested(b),
+    ESeq(a, b) => scps_loop_return_nested(a) || scps_loop_return_nested(b),
+    EAssign(_, v, b) => scps_loop_return_nested(v) || scps_loop_return_nested(b),
+    EAssignOp(_, _, v, b) => scps_loop_return_nested(v) || scps_loop_return_nested(b),
+    EIf(c, t, el) => scps_loop_return_nested(c) || scps_loop_return_nested(t) || scps_loop_return_nested(el),
+    EMatch(s, arms) => scps_loop_return_nested(s) || scps_loop_arms_return_nested(arms),
+    EHandle(b, arms) => scps_loop_return_nested(b) || scps_loop_arms_return_nested(arms),
+    _ => false
+  }
+}
+
+fn scps_loop_arms_return_nested(arms: Array[(Pat, Expr)]) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(arms) {
+    let (_, ex) = Array::get(arms, i)
+    if scps_loop_return_nested(ex) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+/// Replace every `return v` in a loop body with "record and leave the loop".
+/// The recorded value is picked up by the `if returned { return .. }` the
+/// caller places after the loop, where the ordinary hoist can reach it.
+/// Nested closures keep their own `return` (`_ => e` covers EFn).
+fn scps_loop_return_to_break(e: Expr, flag: String, slot: String) -> Expr {
+  match e {
+    EReturn(v) => EAssign(slot, v, EAssign(flag, EBool(true), EBreak(None))),
+    ESeq(a, b) => match a {
+      EReturn(v) => EAssign(slot, v, EAssign(flag, EBool(true), EBreak(None))),
+      _ => ESeq(scps_loop_return_to_break(a, flag, slot), scps_loop_return_to_break(b, flag, slot))
+    },
+    ELet(x, v, b, off) => ELet(x, v, scps_loop_return_to_break(b, flag, slot), off),
+    ELetMut(x, v, b, off) => ELetMut(x, v, scps_loop_return_to_break(b, flag, slot), off),
+    ELetRec(x, v, b) => ELetRec(x, v, scps_loop_return_to_break(b, flag, slot)),
+    EAssign(x, v, b) => EAssign(x, v, scps_loop_return_to_break(b, flag, slot)),
+    EAssignOp(x, op, v, b) => EAssignOp(x, op, v, scps_loop_return_to_break(b, flag, slot)),
+    EIf(c, t, el) => EIf(c, scps_loop_return_to_break(t, flag, slot), scps_loop_return_to_break(el, flag, slot)),
+    EMatch(s, arms) => {
+      let out = scps_empty_arms()
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (p, body) = Array::get(arms, i)
+        Array::push(out, (p, scps_loop_return_to_break(body, flag, slot)))
+        i = i + 1
+      }
+      EMatch(s, out)
+    },
+    _ => e
+  }
+}
+
+/// #1536: a `return` inside a suspending `while` body. The hoist below cannot
+/// move it to the body's tail -- a loop body's tail is the NEXT ITERATION, not
+/// the function's value -- and the loop closure the split builds cannot return
+/// from the function around it. Nothing new is needed to express it, though:
+/// `break` already leaves such a loop (追記47), and a `return` on the spine
+/// AFTER the loop is already handled. So record the value, leave the loop, and
+/// return it outside:
+///
+///   while c { .. return v .. }   ==>  let mut returned = false
+///   REST                              let mut slot = 0
+///                                     while c { .. slot = v; returned = true; break .. }
+///                                     if returned { return slot } else { REST }
+///
+/// The trailing `return` is then hoisted by scps_elim_returns like any other.
+/// Both binders are minted with the usual scope-blind freshness probe.
+///
+/// Returns None -- leaving the body untouched for the caller to refuse -- when
+/// a `return` sits inside a loop NESTED in this one, because `break` would stop
+/// at the wrong level.
+fn scps_elim_loop_returns(e: Expr, site: Int) -> Option[Expr] {
+  match e {
+    ESeq(a, b) => match a {
+      EWhile(c, wb) => if scps_body_has_return(wb) {
+        if scps_loop_return_nested(wb) {
+          None
+        } else {
+          let flag = scps_seq_float_fresh("returned", e, EUnit, site)
+          let slot = scps_seq_float_fresh("retslot", e, EUnit, site)
+          let wb2 = scps_loop_return_to_break(wb, flag, slot)
+          Some(ELetMut(flag, EBool(false), ELetMut(slot, EInt(0), ESeq(EWhile(c, wb2), EIf(EIdent(flag, -1), EReturn(EIdent(slot, -1)), b)), -1), -1))
+        }
+      } else {
+        match scps_elim_loop_returns(b, site) {
+          Some(b2) => Some(ESeq(a, b2)),
+          None => None
+        }
+      },
+      _ => match scps_elim_loop_returns(b, site) {
+        Some(b2) => Some(ESeq(a, b2)),
+        None => None
+      }
+    },
+    ELet(x, v, b, off) => match scps_elim_loop_returns(b, site) {
+      Some(b2) => Some(ELet(x, v, b2, off)),
+      None => None
+    },
+    ELetMut(x, v, b, off) => match scps_elim_loop_returns(b, site) {
+      Some(b2) => Some(ELetMut(x, v, b2, off)),
+      None => None
+    },
+    ELetRec(x, v, b) => match scps_elim_loop_returns(b, site) {
+      Some(b2) => Some(ELetRec(x, v, b2)),
+      None => None
+    },
+    EAssign(x, v, b) => match scps_elim_loop_returns(b, site) {
+      Some(b2) => Some(EAssign(x, v, b2)),
+      None => None
+    },
+    EAssignOp(x, op, v, b) => match scps_elim_loop_returns(b, site) {
+      Some(b2) => Some(EAssignOp(x, op, v, b2)),
+      None => None
+    },
+    // A bare loop in TAIL position has no continuation to guard; the `return`
+    // becomes the value of what follows it, which is nothing.
+    EWhile(c, wb) => if scps_body_has_return(wb) {
+      if scps_loop_return_nested(wb) {
+        None
+      } else {
+        let flag = scps_seq_float_fresh("returned", e, EUnit, site)
+        let slot = scps_seq_float_fresh("retslot", e, EUnit, site)
+        let wb2 = scps_loop_return_to_break(wb, flag, slot)
+        Some(ELetMut(flag, EBool(false), ELetMut(slot, EInt(0), ESeq(EWhile(c, wb2), EIf(EIdent(flag, -1), EReturn(EIdent(slot, -1)), EUnit)), -1), -1))
+      }
+    } else {
+      Some(e)
+    },
+    // Everything else passes through UNCHANGED. A plain `return` here is not
+    // this rewrite's business -- scps_elim_returns hoists it. Only a `return`
+    // sitting inside a loop this walk did not reach (one held by a selection
+    // branch, an initializer, an operand) is refused, by returning None for
+    // the caller to turn into the #1691 diagnostic.
+    _ => if scps_loop_return_nested(e) {
+      None
+    } else {
+      Some(e)
+    }
+  }
+}
+
 fn scps_elim_returns(e: Expr, site: Int) -> Expr {
   match e {
     EReturn(v) => v,
@@ -10744,12 +10902,48 @@ fn scps_body_fields_have_return(fields: Array[(String, Expr)]) -> Bool {
 /// #1536: is this expression an unconditional transfer out of the enclosing
 /// loop iteration? Nothing sequenced after one runs, which is what lets the
 /// repeat-append and the ctl rewrite below drop the dead tail.
+/// Does every execution of `e` leave the loop (or restart it)?
+///
+/// #1536 P0: this used to recognize only a BARE `break` / `continue`, so the
+/// ordinary spelling `if done { acc = v; break }` -- a transfer with a
+/// statement in front of it -- was not seen as a transfer at all. The
+/// continuation was then neither dropped by the normalizer nor cut by the
+/// rewrite, and since a rewritten transfer is a plain CALL (`k(v)`), execution
+/// FELL THROUGH it and kept looping. That compiled clean and silently returned
+/// a different answer than the same loop without a suspension in it.
+///
+/// A selection counts only when EVERY branch transfers. Nested loops, closures
+/// and handles are not entered: their transfers are not this loop's.
 fn scps_is_ctl_terminator(e: Expr) -> Bool {
   match e {
     EBreak(_) => true,
     EContinue(_) => true,
+    ESeq(_, b) => scps_is_ctl_terminator(b),
+    ELet(_, _, b, _) => scps_is_ctl_terminator(b),
+    ELetMut(_, _, b, _) => scps_is_ctl_terminator(b),
+    ELetRec(_, _, b) => scps_is_ctl_terminator(b),
+    EAssign(_, _, b) => scps_is_ctl_terminator(b),
+    EAssignOp(_, _, _, b) => scps_is_ctl_terminator(b),
+    EIf(_, t, el) => scps_is_ctl_terminator(t) && scps_is_ctl_terminator(el),
+    EMatch(_, arms) => scps_arms_are_ctl_terminators(arms),
     _ => false
   }
+}
+
+/// Every arm transfers -- and an empty arm list does not (nothing transfers).
+fn scps_arms_are_ctl_terminators(arms: Array[(Pat, Expr)]) -> Bool {
+  let mut i = 0
+  let mut all = Array::length(arms) > 0
+  while i < Array::length(arms) {
+    let (_, ex) = Array::get(arms, i)
+    if scps_is_ctl_terminator(ex) {
+      ()
+    } else {
+      all = false
+    }
+    i = i + 1
+  }
+  all
 }
 
 /// Put every transfer of THIS loop in a TAIL slot of the body, so the append
@@ -12550,7 +12744,10 @@ fn scps_emit_clone(eff: String, fname: String, ctx: (Array[Stmt], Array[(String,
           // #1536: `return v` in this body means "this function's value is v",
           // which is what its tail means -- hoist it there. Anything left
           // unreachable by that hoist is refused below rather than split.
-          let fbody3 = scps_elim_returns(fbody2, site)
+          let fbody3 = scps_elim_returns(match scps_elim_loop_returns(fbody2, site) {
+            Some(lifted) => lifted,
+            None => fbody2
+          }, site)
           if scps_body_has_return(fbody3) {
             Array::push(errs, scps_return_in_split_msg(String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, so its body")))
           } else {
@@ -13200,13 +13397,19 @@ fn scps_split_literal(tps: Array[String], tbs: Array[(String, Array[String])], p
     scps_msg = String::concat(scps_msg, culprit_marker)
     Array::push(errs, scps_msg)
     EFn(tps, tbs, params, None, None, b)
-  } else if scps_body_has_return(scps_elim_returns(b, site)) {
+  } else if scps_body_has_return(scps_elim_returns(match scps_elim_loop_returns(b, site) {
+    Some(lifted) => lifted,
+    None => b
+  }, site)) {
     Array::push(errs, scps_return_in_split_msg(String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class) is split into continuations, so its body")))
     EFn(tps, tbs, params, None, None, b)
   } else {
     // #1536: same hoist -- `return v` in a closure literal is that closure's
     // own value, which is what its tail is.
-    let (split_ok, split_body) = scps_split_tail(scps_elim_returns(b, site), sctx, ctx, st)
+    let (split_ok, split_body) = scps_split_tail(scps_elim_returns(match scps_elim_loop_returns(b, site) {
+      Some(lifted) => lifted,
+      None => b
+    }, site), sctx, ctx, st)
     if !split_ok {
       Array::push(errs, String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class, ADR-0076 追記31 Vertical B) performs it (or calls a function that performs it) off the let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a selected `&&` / `||` right operand that transfers control with `return` / `break` / `continue` are not eligible; a suspension inside an `if` / `match` branch or a `&&` / `||` right operand IS eligible wherever the selection or the short-circuit itself is strictly evaluated (a statement, the tail, the whole value of a `let` / `let mut` / assignment, or a strictly evaluated part of a compound); a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)"))
       EFn(tps, tbs, params, None, None, b)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6947,7 +6947,19 @@ scps_check_reject "err_effect_let_shortcircuit_return_suspend.vibe" "cannot cont
 # reach -- inside a loop -- is still refused (err_effect_loop_return_suspend).
 VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_return_in_split_body_test.vibe \
-  fixtures/effect_return_match_arm_split_test.vibe
+  fixtures/effect_return_match_arm_split_test.vibe \
+  fixtures/effect_return_in_loop_test.vibe
+# #1536 P0: a transfer with a STATEMENT in front of it, after a resume. The
+# transfer test used to see only a BARE break/continue, so `if d { acc = v;
+# break }` was not a transfer, the continuation was not dropped, and execution
+# fell through the rewritten call and kept looping -- silently answering
+# differently than the same loop without a suspension. `scan` is 700 with and
+# without effects; it used to be 800 here.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_transfer_after_resume_test.vibe
+# `break` leaves only the INNERMOST loop, so a return nested one loop deeper
+# would stop at the wrong level: refused rather than guessed at.
+scps_check_reject "err_effect_return_nested_loop_suspend.vibe" "cannot contain a \`return\`" "returnnestedloop"
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
 # THAT diagnostic, so the fixture cannot silently start passing for the other


### PR DESCRIPTION
## P0 (黙って誤る) を 1 件。loop 内 `return` の実装中に発見

loop 内 `return` の書き換えを入れて最初に実測したら、**effect 抜きなら 700 を返す同じ loop が
800 を返した**。切り分けると原因は `return` ではなく **`break` そのもの**だった:

```vibe
while i < 5 {
  let v = perform Ask::Get(i)
  if v > 6 { acc = v * 100; break } else { () }   // ← 前に文が 1 つある
  i = i + 1
}
```

`scps_is_ctl_terminator` が**裸の** `break` / `continue` しか transfer と認めていなかったため、
**これ (普通の綴り) が transfer と見なされなかった**。normalizer は継続を落とさず、rewrite も
切らない。そして rewrite 後の transfer は**ただの呼び出し** (`k(v)`) なので、実行は
**それを素通りして loop を続けた**。

**compile は通り、実行も落ちず、答えだけが違う。** 既存 fixture が見逃していたのは、transfer を
**suspension より前**にしか置いていなかったから (`effect_while_break_continue_suspend_test` は
`continue` が perform の前にある)。

### 直し方

判定を「**この式は必ず transfer するか**」に広げた: spine の tail を辿り、selection は
**全枝が transfer するときだけ**真。nested loop / closure / handle には入らない (そこの
transfer はこの loop のものではない)。

## その上で: loop 内の `return` が通るようになった

こちらも新しい機構は要らなかった。hoist (#1693) では届かない — **loop body の tail は
「次の反復」であって関数の値ではない**から。だが `break` は既にこの loop を出られ、
loop の**後ろ**の `return` は #1693 が扱える。だから:

```
while c { .. return v .. }   ==>  let mut returned = false
REST                              let mut slot = 0
                                  while c { .. slot = v; returned = true; break .. }
                                  if returned { return slot } else { REST }
```

**入れ子の loop の中の `return` は refuse** — `break` は最内 loop しか出ないので間違った段で
止まる。推測せず断る。

## テスト

- `effect_transfer_after_resume_test.vibe` — **P0 の回帰**。`break` (文が前にある) と
  `continue` (同) を resume の後ろに置く。`scan` は effect 抜きでも 700 で、ここでも 700 で
  なければならない (**以前は 800**)。70011302
- `effect_return_in_loop_test.vibe` — loop 内 `return` (取る / 取らない)。70015
- `err_effect_return_nested_loop_suspend.vibe` — 入れ子 loop の `return` は refuse

`bash scripts/compiler_gate.sh` (full operation gate) green、`scripts/vibe_fmt.sh --check`
green、`scripts/check_fixture_execution.sh` green (259 fixtures)。

## ドキュメント

- ADR-0076 追記56 (`docs/effect-evidence-passing.md`) — 書き換えと、その下で見つかった P0
- `docs/spec/wasi-p3-async.md` §2.2 の適格性境界

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_