### PR TITLE
feat(async): return out of a handle body through a cell (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -3173,6 +3173,37 @@ selection は**全枝が transfer するときだけ**真。nested loop / closur
 **教訓**: 追記55 の hoist は設計上正しかったが、土台が壊れていた。既存 fixture は transfer を
 **suspension より前**にしか置いておらず、resume の後ろの transfer を誰も見ていなかった。
 
+### 追記57 (2026-08-13): handle body の `return` は cell で外へ出す (#1536)
+
+needing fn の clone と違い、handle body の `return v` は「**handle の値**」ではなく
+「**囲む関数から抜ける**」意味なので、追記55 の hoist (tail へ寄せる) は使えない。
+代わりに **cell を handle の外に置く**:
+
+```
+let r = handle { .. return v .. } with E { .. }   REST
+  ==>  let mut returned = false
+       let mut slot = 0
+       let r = handle { .. slot = v; returned = true; 0 .. } with E { .. }
+       if returned { return slot } else { REST }
+```
+
+handle の外に出た `return` は**普通の spine 上の return** なので、この handle 式自体が
+split される body の中にあれば追記55 がそれを拾う。loop pass が spine 上へ持ち上げた
+`return` も、この capture が cell 書き込みへ変換するので合成できる (`loop_early` が pin)。
+
+hoist の終端を `flag == ""` で分岐させただけで、走査そのものは追記55 と同じものを共有する。
+
+#### 撤回して戻した経緯 — 原因は async ではなかった
+
+最初の実測で **`return 777` が 1554**、`return a * 100` (a=5) が 1000 と、**きっちり 2 倍**の
+値が返った。`return` を取らない経路は正しかった。黙って誤るので一度撤回したが、原因は
+**probe スクリプトが `VIBE_RC` を pin しておらず RC レーンで走っていた**ことで、
+**RC backend では entry 関数の `return` が untag されない** (#1696、P0) という別のバグだった。
+`VIBE_RC=0` (ゲートと同じ) で測り直すと 500 / 6 / 777 と正しい。
+
+**教訓 2**: 誤った値を見て止めたのは正しかったが、原因の見立ては外れていた。計測環境が
+ゲートと同じ設定かどうかを先に確かめること。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -189,13 +189,14 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   (枝へは降りず selection を丸ごと名前に束ねてから追記49 の分配へ渡す、追記52)、
   **non-tail の `&&` / `||`** (同じく右辺へは降りず短絡式を丸ごと名前に束ねる。
   受け側の let-shortcircuit が受理すると判定手続き自身に訊いてからのみ、追記53。
-  bypass は保たれる)
-- **不適格**: **handle body 内の `return`** (囲む関数から抜ける意味で handle の値ではない)。
-  **needing fn / closure literal の spine 上の `return` は適格** — そこでは
-  `return v` = 「この computation の値が v」なので split の前に tail へ寄せる (追記55)。
-  **loop 内の `return` も適格** — 値を控えて `break` で出て loop の外で返す。入れ子 loop でも
-  各段に guard を置いて exit を 1 段ずつ外へ運ぶ (追記56)。
-  寄せきれない `return` が残れば追記54 の refuse に落ちる、配列 `for` 形、**選ばれた `&&` / `||` 右辺が
+  bypass は保たれる)、**`return`** (追記55-57)。`return` の扱いは置かれた場所で決まる:
+  needing fn の clone / closure literal では `return v` = 「この computation の値が v」なので
+  **split の前に tail へ寄せる**; loop 内では値を控えて `break` で出て loop の外で返す
+  (入れ子 loop は各段に guard を置いて exit を 1 段ずつ外へ運ぶ); handle body 内では
+  「囲む関数から抜ける」意味なので **cell を handle の外に置いて handle の後で返す**。
+  **寄せきれない `return` が残ればその body は refuse される** (追記54) ので、この書き換えが
+  不完全であることのコストは拒否であって miscompile ではない
+- **不適格**: 配列 `for` 形、**選ばれた `&&` / `||` 右辺が
   `return` / `break` / `continue` する形**、実引数証明が
   成立しない closure パラメータの呼び出し、row 変数 callee (`with e`)。closure
   literal は prepass が literal 自身の spine で step-split し、supported nested

--- a/fixtures/effect_return_in_handle_body_test.vibe
+++ b/fixtures/effect_return_in_handle_body_test.vibe
@@ -1,0 +1,63 @@
+// #1536: `return` inside a HANDLE body. Unlike a needing fn's clone, here
+// `return v` does NOT mean "the handle's value" -- it means "leave the
+// enclosing function" -- so it cannot be hoisted to the body's tail. The value
+// is recorded in a cell declared OUTSIDE the handle, the body finishes with a
+// placeholder, and the real return happens after the handle, where it is an
+// ordinary spine return.
+//
+// `early(0)` takes the return (500), `early(99)` does not and the handle's own
+// value comes back normally (5 + 1 = 6), and `loop_early` returns from inside a
+// suspending loop nested in the handle body (70): the loop pass lifts that onto
+// the spine as an ordinary return, which the cell capture then picks up.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn early(limit: Int) -> Int {
+  let r = handle {
+    let a = perform Ask::Get(1)
+    if a > limit {
+      return a * 100
+    } else {
+      ()
+    }
+    a
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+  r + 1
+}
+
+fn loop_early() -> Int {
+  let r = handle {
+    let mut i = 0
+    let mut acc = 0
+    while i < 5 {
+      let v = perform Ask::Get(i)
+      if v > 6 {
+        return v * 10
+      } else {
+        acc = acc + v
+      }
+      i = i + 1
+    }
+    acc
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+  r + 1000
+}
+
+let _start = () -> Int {
+  early(0) * 100000 + early(99) * 1000 + loop_early()
+}
+
+test "effect return in handle body" {
+  inspect(_start(), "50006070")
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -10793,36 +10793,53 @@ fn scps_elim_loop_returns(e: Expr, site: Int) -> Option[Expr] {
   }
 }
 
+/// What a hoisted `return v` becomes. With no cell (`flag == ""`) the value IS
+/// the result -- the function case, where the body's tail is what `return`
+/// already denotes. With a cell, the value is recorded and the body finishes
+/// with a placeholder, because the caller (a handle) must hand its own value
+/// back before the real return can happen outside it.
+fn scps_return_terminal(v: Expr, flag: String, slot: String) -> Expr {
+  if flag == "" {
+    v
+  } else {
+    EAssign(slot, v, EAssign(flag, EBool(true), EInt(0)))
+  }
+}
+
 fn scps_elim_returns(e: Expr, site: Int) -> Expr {
+  scps_elim_returns_to(e, site, "", "")
+}
+
+fn scps_elim_returns_to(e: Expr, site: Int, flag: String, slot: String) -> Expr {
   match e {
-    EReturn(v) => v,
+    EReturn(v) => scps_return_terminal(v, flag, slot),
     ESeq(a, b) => match a {
       // A transfer makes the rest of the sequence unreachable.
-      EReturn(v) => v,
+      EReturn(v) => scps_return_terminal(v, flag, slot),
       EIf(c, t, el) => if scps_body_has_return(t) || scps_body_has_return(el) {
-        scps_elim_returns(EIf(c, ESeq(t, b), ESeq(el, b)), site)
+        scps_elim_returns_to(EIf(c, ESeq(t, b), ESeq(el, b)), site, flag, slot)
       } else {
-        ESeq(a, scps_elim_returns(b, site))
+        ESeq(a, scps_elim_returns_to(b, site, flag, slot))
       },
       EMatch(s, arms) => if scps_body_arms_have_return(arms) {
-        scps_elim_returns(EMatch(s, scps_seq_float_match_arms(arms, b, site)), site)
+        scps_elim_returns_to(EMatch(s, scps_seq_float_match_arms(arms, b, site)), site, flag, slot)
       } else {
-        ESeq(a, scps_elim_returns(b, site))
+        ESeq(a, scps_elim_returns_to(b, site, flag, slot))
       },
-      _ => ESeq(a, scps_elim_returns(b, site))
+      _ => ESeq(a, scps_elim_returns_to(b, site, flag, slot))
     },
-    ELet(x, v, b, off) => ELet(x, v, scps_elim_returns(b, site), off),
-    ELetMut(x, v, b, off) => ELetMut(x, v, scps_elim_returns(b, site), off),
-    ELetRec(x, v, b) => ELetRec(x, v, scps_elim_returns(b, site)),
-    EAssign(x, v, b) => EAssign(x, v, scps_elim_returns(b, site)),
-    EAssignOp(x, op, v, b) => EAssignOp(x, op, v, scps_elim_returns(b, site)),
-    EIf(c, t, el) => EIf(c, scps_elim_returns(t, site), scps_elim_returns(el, site)),
+    ELet(x, v, b, off) => ELet(x, v, scps_elim_returns_to(b, site, flag, slot), off),
+    ELetMut(x, v, b, off) => ELetMut(x, v, scps_elim_returns_to(b, site, flag, slot), off),
+    ELetRec(x, v, b) => ELetRec(x, v, scps_elim_returns_to(b, site, flag, slot)),
+    EAssign(x, v, b) => EAssign(x, v, scps_elim_returns_to(b, site, flag, slot)),
+    EAssignOp(x, op, v, b) => EAssignOp(x, op, v, scps_elim_returns_to(b, site, flag, slot)),
+    EIf(c, t, el) => EIf(c, scps_elim_returns_to(t, site, flag, slot), scps_elim_returns_to(el, site, flag, slot)),
     EMatch(s, arms) => {
       let out = scps_empty_arms()
       let mut i = 0
       while i < Array::length(arms) {
         let (p, body) = Array::get(arms, i)
-        Array::push(out, (p, scps_elim_returns(body, site)))
+        Array::push(out, (p, scps_elim_returns_to(body, site, flag, slot)))
         i = i + 1
       }
       EMatch(s, out)
@@ -11433,9 +11450,6 @@ fn scps_transform_handle(body: Expr, arms: Array[(Pat, Expr)], ctx: (Array[Stmt]
       scps_msg = String::concat(scps_msg, " -- only `perform`, pure builtins, constructors, provably effect-free functions, and functions whose concrete row carries the handled effect may be called in the handled body (#817)")
       scps_msg = String::concat(scps_msg, culprit_marker)
       Array::push(errs, scps_msg)
-      None
-    } else if scps_body_has_return(body) {
-      Array::push(errs, scps_return_in_split_msg("a handler arm captures `resume` as a value, so this handle body"))
       None
     } else {
       let (split_ok, split_body) = scps_split_tail(body, sctx, ctx, st)
@@ -12861,9 +12875,41 @@ fn scps_rewrite(e: Expr, ctx: (Array[Stmt], Array[(String, Array[(String, Array[
         ai = ai + 1
       }
       if triggered {
-        match scps_transform_handle(rbody, rarms, ctx, st, scope) {
-          Some(t) => t,
-          None => EHandle(rbody, rarms)
+        // #1536: a `return` in a HANDLE body means "leave the enclosing
+        // function", not "the handle's value", so it cannot be hoisted to the
+        // body's tail the way a function's own return is. The value is
+        // recorded in a cell declared OUTSIDE the handle, the body finishes
+        // with a placeholder, and the real return happens after the handle --
+        // where it is an ordinary spine return the hoist handles if this whole
+        // thing is itself inside a body being split.
+        if scps_body_has_return(rbody) {
+          let hsite = scps_next_site(st)
+          let probe = EHandle(rbody, rarms)
+          let flag = scps_seq_float_fresh("hreturned", probe, EUnit, hsite)
+          let slot = scps_seq_float_fresh("hretslot", probe, EUnit, hsite)
+          let hv = scps_seq_float_fresh("hvalue", probe, EUnit, hsite)
+          // The loop pass lifts a loop return onto the spine as an ordinary
+          // `return`; the capture then turns THAT into the cell write, so the
+          // two compose without the loop pass knowing about the cell.
+          let captured = scps_elim_returns_to(match scps_elim_loop_returns(rbody, hsite) {
+            Some(lifted) => lifted,
+            None => rbody
+          }, hsite, flag, slot)
+          if scps_body_has_return(captured) {
+            Array::push(scps_st_errs(st), scps_return_in_split_msg("a handler arm captures `resume` as a value, so this handle body"))
+            EHandle(rbody, rarms)
+          } else {
+            let inner = match scps_transform_handle(captured, rarms, ctx, st, scope) {
+              Some(t) => t,
+              None => EHandle(captured, rarms)
+            }
+            ELetMut(flag, EBool(false), ELetMut(slot, EInt(0), ELet(hv, inner, EIf(EIdent(flag, -1), EReturn(EIdent(slot, -1)), EIdent(hv, -1)), -1), -1), -1)
+          }
+        } else {
+          match scps_transform_handle(rbody, rarms, ctx, st, scope) {
+            Some(t) => t,
+            None => EHandle(rbody, rarms)
+          }
         }
       } else {
         EHandle(rbody, rarms)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6962,6 +6962,12 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 # The snapshot covers two and three levels deep, and a return never taken.
 VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_return_nested_loop_test.vibe
+# #1536: `return` in a HANDLE body means "leave the enclosing function", not
+# "the handle's value", so it is captured in a cell declared outside the handle
+# and returned after it. The snapshot pins taken / not-taken / from inside a
+# suspending loop nested in the handle body.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_return_in_handle_body_test.vibe
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
 # THAT diagnostic, so the fixture cannot silently start passing for the other


### PR DESCRIPTION
## `return` 残件の最後

needing fn の clone と違い、handle body の `return v` は「**handle の値**」ではなく
「**囲む関数から抜ける**」意味なので、#1693 の hoist (tail へ寄せる) は使えない。
代わりに **cell を handle の外に置く**:

```
let r = handle { .. return v .. } with E { .. }   REST
  ==>  let mut returned = false
       let mut slot = 0
       let r = handle { .. slot = v; returned = true; 0 .. } with E { .. }
       if returned { return slot } else { REST }
```

handle の外に出た `return` は**普通の spine 上の return** なので、この handle 式自体が
split される body の中にあれば #1693 の hoist がそれを拾う。loop pass (#1694/#1695) は
loop 内の `return` を spine 上の普通の `return` へ持ち上げるので、この capture がそれを
cell 書き込みへ変換する — **両者は互いを知らずに合成できる** (fixture の `loop_early` が pin)。

実装は hoist の**終端だけ**を `flag == ""` で分岐させたもので、走査そのものは #1693 と共有。

## 一度撤回して戻した経緯 — 原因は async ではなかった

最初の実測で **`return 777` が 1554**、`return a * 100` (a=5) が 1000 と**きっちり 2 倍**の値が
返った (return を取らない経路は正しかった)。黙って誤るので撤回したが、原因は

**probe スクリプトが `VIBE_RC` を pin しておらず RC レーンで走っていた**

ことだった。**RC backend では export される entry の `return` が untag されない** —
別件の P0 として #1696 に起票した (async とは無関係。`let _start = () -> Int { 777 }` は
RC でも 777、`return 777` にすると 1554)。ゲートと同じ `VIBE_RC=0` で測り直すと本 PR の
lowering は正しい。

## テスト

`fixtures/effect_return_in_handle_body_test.vibe` (50006070):

- `early(0)` — return を取る (500)
- `early(99)` — return を取らず handle 自身の値が返る (5 + 1 = 6)
- `loop_early` — **handle body の中の suspending loop から** return (70)。loop pass と
  cell capture の合成を pin

`bash scripts/compiler_gate.sh` (full operation gate) green、`scripts/vibe_fmt.sh --check`
green、`scripts/check_fixture_execution.sh` green (261 fixtures)。

## ドキュメント

- ADR-0076 追記57 (`docs/effect-evidence-passing.md`) — 書き換えと、撤回→復帰の経緯
- `docs/spec/wasi-p3-async.md` §2.2 — `return` の扱いを「置かれた場所で決まる」形に整理。
  **不適格から `return` が消えた**

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_