### PR TITLE
feat(async): lower a provably-Array `for-in` to the indexed while form (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -3204,6 +3204,41 @@ hoist の終端を `flag == ""` で分岐させただけで、走査そのもの
 **教訓 2**: 誤った値を見て止めたのは正しかったが、原因の見立ては外れていた。計測環境が
 ゲートと同じ設定かどうかを先に確かめること。
 
+### 追記58 (2026-08-14): Array と示せる `for-in` を while 形へ落とす (#1536)
+
+`for x in xs { .. perform .. }` — async で最も自然な反復 — が長く不適格だった。理由は
+**codegen が `EForIn` を最後まで保持し、実行時に iterand が String かを判別して byte を
+materialize する** (#807) ため。source level で while へ書き換えると **String は 0 回反復に
+なって黙って誤る**。
+
+必要なのは「Array である」証明だが、**checker のチャンネルは要らなかった**。次の**構文的**
+証明で足りる:
+
+- **`Array[..]` と注釈された引数** (`fn total(xs: Array[Int])`)
+- **spine 上で配列リテラルに束縛された `let`** (`let xs = [1, 2]`)
+
+証明できた名前に対してだけ、split の前に while 形へ落とす:
+
+```
+for x in xs { body }  ==>  let mut i = 0
+                           while i < Array::length(xs) {
+                             let x = Array::get(xs, i)
+                             i = i + 1
+                             body
+                           }
+```
+
+`Array::length` は毎回読み直す (`for` の意味論どおり — body が配列を伸ばせばその分回る)。
+**index は body の前に進める**ので、body の `continue` が空回りしない。
+
+**証明できないものは一切書き換えない**ので、この pass が変えられるのは**今日 reject されている
+プログラムだけ** — 現在通っているコードの挙動は変わらない。String は
+`err_effect_string_for_suspend` が「引き続き reject」を pin する (書き換えていたら 0 回反復で
+黙って誤っていた)。
+
+`effect_array_for_suspend_test.vibe` (3855487) が**受理だけでなく意味論**を pin する:
+引数由来 36 / リテラル由来 23 / `break` 23 / `continue` 24 (index が進む) / 伸長 87。
+
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)
   (ICFP 2021) — 本 ADR の中核アルゴリズム。tail-resumptive の直接呼び出し

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -196,7 +196,11 @@ see-through 走査が `lt` を pure callee として知らないため、`while 
   「囲む関数から抜ける」意味なので **cell を handle の外に置いて handle の後で返す**。
   **寄せきれない `return` が残ればその body は refuse される** (追記54) ので、この書き換えが
   不完全であることのコストは拒否であって miscompile ではない
-- **不適格**: 配列 `for` 形、**選ばれた `&&` / `||` 右辺が
+  、**Array と構文的に示せる `for-in`** (`Array[..]` 注釈の引数 / 配列リテラル束縛。
+  split の前に indexed while 形へ落とす。示せない iterand — 特に String — は
+  書き換えない: codegen は実行時に String を判別して byte を materialize するので
+  (#807)、書き換えれば 0 回反復で黙って誤る、追記58)
+- **不適格**: **Array と示せない `for` 形**、**選ばれた `&&` / `||` 右辺が
   `return` / `break` / `continue` する形**、実引数証明が
   成立しない closure パラメータの呼び出し、row 変数 callee (`with e`)。closure
   literal は prepass が literal 自身の spine で step-split し、supported nested

--- a/fixtures/effect_array_for_suspend_test.vibe
+++ b/fixtures/effect_array_for_suspend_test.vibe
@@ -1,0 +1,114 @@
+// #1536: `for x in xs { .. perform .. }` where `xs` is PROVED to hold an Array.
+//
+// The proof is required because codegen keeps `EForIn` to the end and decides
+// at RUN TIME whether the iterand is a String, materializing its bytes first
+// (#807). Rewriting the loop at source level would make a String iterate zero
+// times, so it is only sound where the value cannot be one. The proof here is
+// syntactic -- a parameter annotated `Array[..]`, or a `let` bound to an array
+// literal -- so no checker channel is needed, and anything unproved keeps the
+// treatment it has today (refusal). See err_effect_string_for_suspend.
+//
+// The numbers pin the loop's semantics, not just acceptance:
+//   from_param    36  parameter-annotated array
+//   from_literal  23  array literal bound on the spine
+//   with_break    23  `break` leaves the loop
+//   with_continue 24  `continue` still advances the index (no spin)
+//   grows         87  `Array::length` is re-read, so a body that grows the
+//                     array iterates further
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn from_param(xs: Array[Int]) -> Int with Ask {
+  let mut acc = 0
+  for x in xs {
+    acc = acc + perform Ask::Get(x)
+  }
+  acc
+}
+
+fn from_literal() -> Int with Ask {
+  let xs = [
+    1,
+    2
+  ]
+  let mut acc = 0
+  for x in xs {
+    acc = acc + perform Ask::Get(x)
+  }
+  acc
+}
+
+fn with_break(xs: Array[Int]) -> Int with Ask {
+  let mut acc = 0
+  for x in xs {
+    if x > 2 {
+      break
+    } else {
+      ()
+    }
+    acc = acc + perform Ask::Get(x)
+  }
+  acc
+}
+
+fn with_continue(xs: Array[Int]) -> Int with Ask {
+  let mut acc = 0
+  for x in xs {
+    if x == 2 {
+      continue
+    } else {
+      ()
+    }
+    acc = acc + perform Ask::Get(x)
+  }
+  acc
+}
+
+fn grows(xs: Array[Int]) -> Int with Ask {
+  let mut n = 0
+  for x in xs {
+    n = n + perform Ask::Get(x)
+    if Array::length(xs) < 5 {
+      Array::push(xs, 9)
+    } else {
+      ()
+    }
+  }
+  n
+}
+
+let _start = () -> Int {
+  handle {
+    let a = from_param([
+      1,
+      2,
+      3
+    ])
+    let b = from_literal()
+    let c = with_break([
+      1,
+      2,
+      3,
+      4
+    ])
+    let d = with_continue([
+      1,
+      2,
+      3
+    ])
+    let e = grows([
+      1
+    ])
+    a * 100000 + b * 10000 + c * 1000 + d * 100 + e
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 10)
+    }
+  }
+}
+
+test "effect array for suspend" {
+  inspect(_start(), "3855487")
+}

--- a/fixtures/err_effect_string_for_suspend.vibe
+++ b/fixtures/err_effect_string_for_suspend.vibe
@@ -1,0 +1,32 @@
+// #1536 boundary: the SAME loop over a String stays refused. Codegen decides
+// at run time whether an iterand is a String and materializes its bytes first
+// (#807), so rewriting this at source level would make it iterate zero times
+// and silently return the wrong answer. Only a proved Array is rewritten.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn scan(s: String) -> Int with Ask {
+  let mut acc = 0
+  for c in s {
+    acc = acc + perform Ask::Get(c)
+  }
+  acc
+}
+
+let _start = () -> Int {
+  handle {
+    scan("abc")
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "let/seq/tail/branch-tail spine"
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -10598,6 +10598,153 @@ fn scps_return_in_split_msg(subject: String) -> String {
   String::concat(subject, " cannot contain a `return`: the suspend lowering turns the body into continuations that return a step, so the `return` would hand its own value to the driver instead of leaving the function. Produce the early-exit value instead of returning it (bind it and select on it), or move the `return` outside the handle. A `return` inside a nested closure targets that closure and is fine (#1536, ADR-0076 Phase 3a/3b)")
 }
 
+/// Is this type annotation `Array[..]`? Only the head name is inspected: what
+/// the rewrite below needs is that the value is an array at run time, not what
+/// it holds.
+fn scps_ty_is_array(ty: Option[TypeExpr]) -> Bool {
+  match ty {
+    Some(t) => match t {
+      TyApp(nm, _) => nm == "Array",
+      TyName(nm) => nm == "Array",
+      _ => false
+    },
+    None => false
+  }
+}
+
+/// Names this walk can prove hold an Array, without asking the checker: a
+/// parameter annotated `Array[..]`, or a `let` bound to an array literal or
+/// carrying the same annotation. Anything else is simply not proved, and the
+/// `for` over it keeps the treatment it has today (refusal).
+fn scps_array_names_seed(params: Array[(String, Option[TypeExpr])]) -> Array[String] {
+  let out = array_empty_str()
+  let mut i = 0
+  while i < Array::length(params) {
+    let (nm, ty) = Array::get(params, i)
+    if scps_ty_is_array(ty) {
+      Array::push(out, nm)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn scps_array_names_with(known: Array[String], nm: String, v: Expr, ty: Option[TypeExpr]) -> Array[String] {
+  let out = array_empty_str()
+  let mut i = 0
+  while i < Array::length(known) {
+    let k = Array::get(known, i)
+    if k == nm {
+      ()
+    } else {
+      Array::push(out, k)
+    }
+    i = i + 1
+  }
+  let proved = match v {
+    EArray(_) => true,
+    _ => scps_ty_is_array(ty)
+  }
+  if proved {
+    Array::push(out, nm)
+  } else {
+    ()
+  }
+  out
+}
+
+/// #1536: `for x in xs { .. perform .. }` in statement position, where `xs` is
+/// PROVED to hold an Array.
+///
+/// The proof matters because codegen keeps `EForIn` to the end and decides at
+/// RUN TIME whether the iterand is a String, materializing its bytes first
+/// (#807). Rewriting the loop at source level would make a String iterate zero
+/// times, so it is only sound where the value cannot be one.
+///
+///   for x in xs { body }  ==>  let mut i = 0
+///                              while i < Array::length(xs) {
+///                                let x = Array::get(xs, i)
+///                                i = i + 1
+///                                body
+///                              }
+///
+/// `Array::length` is re-read every iteration, as `for` requires (a body that
+/// grows the array iterates further). The index advances BEFORE the body so a
+/// `continue` in it cannot spin.
+///
+/// Only the shapes this proves are rewritten; every other `for` keeps the
+/// treatment it has today, which for a suspending body is refusal. So this can
+/// only turn a rejection into an acceptance -- no program that compiles today
+/// changes.
+fn scps_array_for_rewrite(name: String, arr: String, body: Expr, iname: String) -> Expr {
+  let len_call = ECall(EIdent("Array::length", -1), [
+    EIdent(arr, -1)
+  ], -1)
+  let get_call = ECall(EIdent("Array::get", -1), [
+    EIdent(arr, -1),
+    EIdent(iname, -1)
+  ], -1)
+  let step = EAssign(iname, EBinOp("+", EIdent(iname, -1), EInt(1)), body)
+  EWhile(EBinOp("<", EIdent(iname, -1), len_call), ELet(name, get_call, step, -1))
+}
+
+/// Walk the spine, tracking which names are proved arrays, and rewrite the
+/// statement-position `for` loops over them. `ctr` keeps generated index names
+/// distinct between sibling loops.
+fn scps_elim_array_for(e: Expr, known: Array[String], site: Int, ctr: Array[Int]) -> Expr {
+  match e {
+    ESeq(a, b) => match a {
+      EForIn(nm, idx, it, fbody) => {
+        let arr = match it {
+          EIdent(inm, _) => if edp_str_array_contains(known, inm) {
+            inm
+          } else {
+            ""
+          },
+          _ => ""
+        }
+        let indexed = match idx {
+          Some(_) => true,
+          None => false
+        }
+        if arr == "" || indexed {
+          ESeq(a, scps_elim_array_for(b, known, site, ctr))
+        } else {
+          // One fresh counter per loop: the ordinal keeps sibling loops apart
+          // and the scope-blind probe keeps it clear of anything the user
+          // spelled in the loop or its continuation.
+          let n = Array::get(ctr, 0)
+          Array::set(ctr, 0, n + 1)
+          let iname = scps_seq_float_fresh(String::concat("foriter", Int::to_string(n)), e, EUnit, site)
+          let lowered = scps_array_for_rewrite(nm, arr, scps_elim_array_for(fbody, known, site, ctr), iname)
+          ELetMut(iname, EInt(0), ESeq(lowered, scps_elim_array_for(b, known, site, ctr)), -1)
+        }
+      },
+      _ => ESeq(a, scps_elim_array_for(b, known, site, ctr))
+    },
+    ELet(x, v, b, off) => ELet(x, v, scps_elim_array_for(b, scps_array_names_with(known, x, v, None), site, ctr), off),
+    ELetMut(x, v, b, off) => ELetMut(x, v, scps_elim_array_for(b, scps_array_names_with(known, x, v, None), site, ctr), off),
+    ELetRec(x, v, b) => ELetRec(x, v, scps_elim_array_for(b, known, site, ctr)),
+    EAssign(x, v, b) => EAssign(x, v, scps_elim_array_for(b, known, site, ctr)),
+    EAssignOp(x, op, v, b) => EAssignOp(x, op, v, scps_elim_array_for(b, known, site, ctr)),
+    EIf(c, t, el) => EIf(c, scps_elim_array_for(t, known, site, ctr), scps_elim_array_for(el, known, site, ctr)),
+    EWhile(c, b) => EWhile(c, scps_elim_array_for(b, known, site, ctr)),
+    EMatch(sc, arms) => {
+      let out = scps_empty_arms()
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (p, ex) = Array::get(arms, i)
+        Array::push(out, (p, scps_elim_array_for(ex, known, site, ctr)))
+        i = i + 1
+      }
+      EMatch(sc, out)
+    },
+    _ => e
+  }
+}
+
 /// #1536: hoist `return` to the tail position it already denotes, so the split
 /// never sees one.
 ///
@@ -12772,9 +12919,14 @@ fn scps_emit_clone(eff: String, fname: String, ctx: (Array[Stmt], Array[(String,
           // #1536: `return v` in this body means "this function's value is v",
           // which is what its tail means -- hoist it there. Anything left
           // unreachable by that hoist is refused below rather than split.
-          let fbody3 = scps_elim_returns(match scps_elim_loop_returns(fbody2, site) {
+          // #1536: rewrite `for x in xs` over a PROVED array into the indexed
+          // while form first -- the split handles `while`, and the proof comes
+          // from this function's own parameter annotations plus array literals
+          // bound on the spine, so no checker channel is needed.
+          let fbody2a = scps_elim_array_for(fbody2, scps_array_names_seed(cparams), site, scps_anf_ctr())
+          let fbody3 = scps_elim_returns(match scps_elim_loop_returns(fbody2a, site) {
             Some(lifted) => lifted,
-            None => fbody2
+            None => fbody2a
           }, site)
           if scps_body_has_return(fbody3) {
             Array::push(errs, scps_return_in_split_msg(String::concat(String::concat(String::concat("function `", fname), String::concat("` (whose row carries ", eff)), ") is called from a suspend-class handle body, so its body")))

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6968,6 +6968,16 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 # suspending loop nested in the handle body.
 VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_return_in_handle_body_test.vibe
+# #1536: `for x in xs` over a PROVED array becomes the indexed while form, which
+# the split already handles. The proof is syntactic (a parameter annotated
+# Array[..], or a let bound to an array literal) -- codegen decides String-ness
+# at run time (#807), so an unproved iterand must not be rewritten. The snapshot
+# pins break / continue / index advance / length re-read, not just acceptance.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_array_for_suspend_test.vibe
+# The same loop over a String stays refused: rewriting it would iterate zero
+# times and silently answer wrong.
+scps_check_reject "err_effect_string_for_suspend.vibe" "let/seq/tail/branch-tail spine" "stringforsusp"
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
 # THAT diagnostic, so the fixture cannot silently start passing for the other


### PR DESCRIPTION
## checker のチャンネルは要らなかった

`for x in xs { .. perform .. }` — async で最も自然な反復 — がずっと不適格だった。理由は
**codegen が `EForIn` を最後まで保持し、実行時に iterand が String かを判別して byte を
materialize する** (#807) ため。source level で while へ書き換えると **String は 0 回反復に
なって黙って誤る**。

必要なのは「Array である」証明だけで、それは**構文的に**取れた:

- **`Array[..]` と注釈された引数** (`fn total(xs: Array[Int])`)
- **spine 上で配列リテラルに束縛された `let`** (`let xs = [1, 2]`)

証明できた名前に対してだけ、split の前に while 形へ落とす:

```
for x in xs { body }  ==>  let mut i = 0
                           while i < Array::length(xs) {
                             let x = Array::get(xs, i)
                             i = i + 1
                             body
                           }
```

`Array::length` は**毎回読み直す** (`for` の意味論どおり — body が配列を伸ばせばその分回る)。
**index は body の前に進める**ので、body の `continue` が空回りしない。

## 影響範囲はゼロ (今日 reject されているものだけが変わる)

**証明できない iterand は一切書き換えない。** したがってこの pass が変えられるのは
**今日 reject されているプログラムだけ**で、現在通っているコードの挙動は変わらない。

String は引き続き reject され、`err_effect_string_for_suspend` がそれを pin する
(書き換えていたら 0 回反復で黙って誤っていた)。実測でも確認済み — 普通のコードの
`for c in "abc"` は 294 (97+98+99) のまま。

## テスト

`fixtures/effect_array_for_suspend_test.vibe` (3855487) は**受理ではなく意味論**を pin する:

| | 値 | 何を pin するか |
|---|---|---|
| `from_param` | 36 | 引数注釈由来の証明 |
| `from_literal` | 23 | 配列リテラル束縛由来の証明 |
| `with_break` | 23 | `break` が loop を出る |
| `with_continue` | 24 | `continue` でも **index が進む** (空回りしない) |
| `grows` | 87 | `Array::length` の**再読み込み** — body が伸ばした分だけ回る |

`bash scripts/compiler_gate.sh` (full operation gate) green、`scripts/vibe_fmt.sh --check`
green、`scripts/check_fixture_execution.sh` green。

## ドキュメント

- ADR-0076 追記58 (`docs/effect-evidence-passing.md`)
- `docs/spec/wasi-p3-async.md` §2.2 — 不適格は「**Array と示せない** `for` 形」に絞られた

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_