### PR TITLE
fix(async): lower a provably-Array `for-in` at every split site (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -3236,8 +3236,14 @@ for x in xs { body }  ==>  let mut i = 0
 `err_effect_string_for_suspend` が「引き続き reject」を pin する (書き換えていたら 0 回反復で
 黙って誤っていた)。
 
-`effect_array_for_suspend_test.vibe` (3855487) が**受理だけでなく意味論**を pin する:
-引数由来 36 / リテラル由来 23 / `break` 23 / `continue` 24 (index が進む) / 伸長 87。
+`effect_array_for_suspend_test.vibe` (385548729) が**受理だけでなく意味論**を pin する:
+引数由来 36 / リテラル由来 23 / `break` 23 / `continue` 24 (index が進む) / 伸長 87 /
+handle body に直接書いた形 29。
+
+書き換えは **3 つの split site すべて**に置く — needing fn の clone、handle body 自身、
+closure literal。最初は clone だけに入れており、`handle { for x in xs { .. perform .. } }` と
+直接書いた形が取り残されていた (handle body も他と同じ spine で、そこでは引数が無いので
+証明は spine 上の配列リテラル束縛から来る)。
 
 - N. Xie, D. Leijen, [Generalized Evidence Passing for Effect
   Handlers](https://www.microsoft.com/en-us/research/publication/generalized-evidence-passing-for-effect-handlers/)

--- a/fixtures/effect_array_for_suspend_test.vibe
+++ b/fixtures/effect_array_for_suspend_test.vibe
@@ -15,6 +15,10 @@
 //   with_continue 24  `continue` still advances the index (no spin)
 //   grows         87  `Array::length` is re-read, so a body that grows the
 //                     array iterates further
+//   inline_acc    29  the same loop written DIRECTLY in the handle body, not
+//                     inside a needing fn -- the handle body is a spine like
+//                     any other, and its proof comes from the array literal
+//                     bound on it
 effect Ask {
   Get(Int) -> Int
 }
@@ -80,6 +84,14 @@ fn grows(xs: Array[Int]) -> Int with Ask {
 
 let _start = () -> Int {
   handle {
+    let ys = [
+      4,
+      5
+    ]
+    let mut inline_acc = 0
+    for y in ys {
+      inline_acc = inline_acc + perform Ask::Get(y)
+    }
     let a = from_param([
       1,
       2,
@@ -100,7 +112,7 @@ let _start = () -> Int {
     let e = grows([
       1
     ])
-    a * 100000 + b * 10000 + c * 1000 + d * 100 + e
+    (a * 100000 + b * 10000 + c * 1000 + d * 100 + e) * 100 + inline_acc
   } with Ask {
     Get(n) => {
       let k = resume
@@ -110,5 +122,5 @@ let _start = () -> Int {
 }
 
 test "effect array for suspend" {
-  inspect(_start(), "3855487")
+  inspect(_start(), "385548729")
 }

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -11599,7 +11599,12 @@ fn scps_transform_handle(body: Expr, arms: Array[(Pat, Expr)], ctx: (Array[Stmt]
       Array::push(errs, scps_msg)
       None
     } else {
-      let (split_ok, split_body) = scps_split_tail(body, sctx, ctx, st)
+      // #1536: a `for` over a proved array is lowered here too, not only in a
+      // needing fn's clone -- the handle body is a spine like any other. It has
+      // no parameters of its own, so the proof comes from array literals bound
+      // on that spine.
+      let body2 = scps_elim_array_for(body, array_empty_str(), site, scps_anf_ctr())
+      let (split_ok, split_body) = scps_split_tail(body2, sctx, ctx, st)
       if !split_ok {
         Array::push(errs, "a handler arm captures `resume` as a value (suspend class, ADR-0076 Phase 3a/3b), but a perform of the handled effect (or a call to a function that performs it) is not directly on the handle body's let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a selected `&&` / `||` right operand that transfers control with `return` / `break` / `continue` are not eligible; a suspension inside an `if` / `match` branch or a `&&` / `||` right operand IS eligible wherever the selection or the short-circuit itself is strictly evaluated (a statement, the tail, the whole value of a `let` / `let mut` / assignment, or a strictly evaluated part of a compound); a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)")
         None
@@ -13618,10 +13623,10 @@ fn scps_split_literal(tps: Array[String], tbs: Array[(String, Array[String])], p
   } else {
     // #1536: same hoist -- `return v` in a closure literal is that closure's
     // own value, which is what its tail is.
-    let (split_ok, split_body) = scps_split_tail(scps_elim_returns(match scps_elim_loop_returns(b, site) {
+    let (split_ok, split_body) = scps_split_tail(scps_elim_array_for(scps_elim_returns(match scps_elim_loop_returns(b, site) {
       Some(lifted) => lifted,
       None => b
-    }, site), sctx, ctx, st)
+    }, site), scps_array_names_seed(params), site, scps_anf_ctr()), sctx, ctx, st)
     if !split_ok {
       Array::push(errs, String::concat(String::concat("a closure literal whose row carries ", eff), " (suspend class, ADR-0076 追記31 Vertical B) performs it (or calls a function that performs it) off the let/seq/tail/branch-tail spine (a loop body containing `return`, a `for` form, nested closures/handles, and a selected `&&` / `||` right operand that transfers control with `return` / `break` / `continue` are not eligible; a suspension inside an `if` / `match` branch or a `&&` / `||` right operand IS eligible wherever the selection or the short-circuit itself is strictly evaluated (a statement, the tail, the whole value of a `let` / `let mut` / assignment, or a strictly evaluated part of a compound); a `while` / `loop` spine is, including one carrying `break` / `continue`, and so is a suspension inside an operand, a call argument or a constructor payload, #1230/#1536) (#817)"))
       EFn(tps, tbs, params, None, None, b)


### PR DESCRIPTION
## #1698 の穴

書き換えを **needing fn の clone にしか入れていなかった**ので、同じループを handle body に
直接書くとまだ reject されていた:

```vibe
handle {
  let xs = [1, 2, 3]
  let mut acc = 0
  for x in xs {
    acc = acc + perform Ask::Get(x)     // ← reject されていた
  }
  acc
} with Ask { .. }
```

**handle body も他と同じ spine**。そこには引数が無いので、証明は spine 上の配列リテラル束縛から
来る。closure literal site は clone と同じく自分の引数を seed にする。

これは**この issue がずっと相手にしてきた「どこに書いたかで受理が変わる」そのもの**だったので、
3 つの split site を揃えた。

## テスト

`fixtures/effect_array_for_suspend_test.vibe` に handle body へ直接書いた形を追加 (29)。
snapshot は 3855487 → **385548729**。3 site が食い違わないことを pin する。

`bash scripts/compiler_gate.sh` (full operation gate) green。

## ドキュメント

- ADR-0076 追記58 (`docs/effect-evidence-passing.md`) に site の話を追記

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_