### PR TITLE
feat(async): admit a first-order row-variable callee (#1536)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -3284,3 +3284,37 @@ closure literal。最初は clone だけに入れており、`handle { for x in 
   はその制約下で設計している (「並行モデル (ADR-0068) との整合」節参照)。
 - `docs/pl-survey-2026-07.md` — 本 ADR の元になったサーベイ項目。
 - `eval/lang-review/findings/2026-07-12-r2.md` M2 — replay の実測バグ。
+
+### 追記59 (2026-08-14): row 変数 callee は「一階なら安全」(#1536)
+
+`with e` を宣言した callee は「provably effect-free」ではないとして一律 reject していた。
+理由は「row 変数は closure 引数経由で migrated effect に具体化されうる」。正しいが、
+**その具体化は引数を通してしか起きない**。
+
+したがって: **宣言された引数の型がどこにも関数型を含まない callee は、call site が
+どうであれ `e` を空 row にしか具体化できない** — 呼び出しは handled effect を perform しえない。
+
+```vibe
+fn twice(x: Int) -> Int with e { x * 2 }        // ← 一階。suspend body から呼べる
+fn apply(f: (Int) -> Int with e, x: Int) -> Int with e { f(x) }   // ← 拒否のまま
+```
+
+判定は宣言だけで閉じる (call site の型推論は要らない)。`Array[(Int) -> Int with e]` のように
+**型引数の中の関数型も数える**ので、`TyFn` を再帰的に探す。注釈の無い引数・定義が見つからない
+callee は従来どおり拒否。
+
+#### 見つけ方 — 5 連続の誤診の原因は「stale な生成ソース」だった
+
+実装後の実測が `REJECTED` のままだったので、また誤診を重ねかけた。今度は最初から
+instrumentation を入れたところ、**そのデバッグ出力自体が現れなかった**。調べると
+`lib/@vibe/compiler/_cli_adapter_module_source.vibe` (生成物) が編集より**古いまま**で、
+`VIBE_PREBUILT_MODULE_SOURCE` でそれを食わせていたため、**ここ数回のビルドは変更を
+一切含んでいなかった**。生成物を消して再生成させたら `generate_bundle: seed could not
+flatten the live tree / unexpected in pattern: =1` — instrumentation の中に書いた
+`None => all = false` (波括弧なしの代入) が seed の parse error だった。
+
+つまり **`ensure_generated.sh` が "ok" を返しても生成物が最新とは限らない**。この直前の
+String iterand の 5 連続誤診も、同じ stale ビルドを見ていた可能性が高い。
+
+**教訓 (今夜 3 つ目)**: 否定的な実測が続いたら、まず**測っている対象が自分の変更を含んで
+いるか**を確かめる。`grep <新しい識別子> <生成ソース>` の一行で済む。

--- a/fixtures/effect_rowvar_first_order_call_test.vibe
+++ b/fixtures/effect_rowvar_first_order_call_test.vibe
@@ -1,0 +1,40 @@
+// #1536: a callee whose declared row is a row VARIABLE (`with e`). Such a
+// callee was never "provably effect-free", because the variable can be
+// instantiated to the handled effect -- but only THROUGH AN ARGUMENT that
+// carries a row. A callee whose declared parameters mention no function type
+// anywhere has no such argument, so `e` can only be instantiated to the empty
+// row: the call cannot perform the handled effect, whatever the call site
+// looks like.
+//
+// `twice` is that shape (`(Int) -> Int with e`), so calling it from a
+// suspend-class handle body is fine: 1 -> resumed 5 -> 10 -> 11. The
+// higher-order companion stays refused -- see err_effect_rowvar_hof_call.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn twice(x: Int) -> Int with e {
+  x * 2
+}
+
+fn bump(x: Int, by: Int) -> Int with e {
+  x + by
+}
+
+let _start = () -> Int {
+  handle {
+    let a = perform Ask::Get(1)
+    let b = twice(a)
+    let c = bump(b, perform Ask::Get(2))
+    c
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+
+test "effect rowvar first order call" {
+  inspect(_start(), "16")
+}

--- a/fixtures/err_effect_rowvar_hof_call.vibe
+++ b/fixtures/err_effect_rowvar_hof_call.vibe
@@ -1,0 +1,32 @@
+// #1536 boundary: a row-variable callee that DOES take a function. `e` can be
+// instantiated through that argument to the handled effect, and this pass
+// cannot see which closure arrives, so the call stays refused. This is the
+// line that keeps the first-order admission sound.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn apply_twice(f: (Int) -> Int with e, x: Int) -> Int with e {
+  f(f(x))
+}
+
+let _start = () -> Int {
+  handle {
+    let a = perform Ask::Get(1)
+    let b = apply_twice((y: Int) -> Int {
+      y * 2
+    }, a)
+    b + 1
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "cannot see through"
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -8288,6 +8288,77 @@ fn scps_fn_row_of(ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExp
   (found, row)
 }
 
+/// Does this annotation mention a FUNCTION type anywhere -- directly, or
+/// nested inside a type argument or a tuple?
+fn scps_ty_has_fn(t: TypeExpr) -> Bool {
+  match t {
+    TyFn(_, _, _) => true,
+    TyApp(_, args) => scps_ty_list_has_fn(args),
+    TyTuple(items) => scps_ty_list_has_fn(items),
+    _ => false
+  }
+}
+
+fn scps_ty_list_has_fn(ts: Array[TypeExpr]) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(ts) {
+    if scps_ty_has_fn(Array::get(ts, i)) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+/// #1536: is this callee FIRST ORDER -- every declared parameter annotated,
+/// and no annotation mentioning a function type anywhere?
+///
+/// That is what makes a row VARIABLE harmless. `fn twice(x: Int) -> Int with e`
+/// declares "performs whatever my arguments perform", and with no argument able
+/// to carry a row, `e` can only be instantiated to the empty row: the call
+/// cannot perform the migrated effect, whatever the call site looks like. A
+/// single function-typed parameter (at any depth -- `Array[(Int) -> Int with e]`
+/// counts) breaks that argument, so those keep the existing rejection, as does
+/// a callee with an unannotated parameter or no definition in scope.
+fn scps_callee_first_order(ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), name: String) -> Bool {
+  let (stmts, _, _, _, _, _) = ctx
+  let mut found = false
+  let mut ok = false
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, snm, _, EFn(_, _, params, _, _, _)) => if snm == name {
+        found = true
+        let mut all = true
+        let mut pi = 0
+        while pi < Array::length(params) {
+          let (_, pty) = Array::get(params, pi)
+          match pty {
+            Some(t) => if scps_ty_has_fn(t) {
+              all = false
+            } else {
+              ()
+            },
+            None => {
+              all = false
+            }
+          }
+          pi = pi + 1
+        }
+        ok = all
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  found && ok
+}
+
 /// A row item starting with a lowercase letter is a row VARIABLE (`with
 /// { e }` / `with X + e`): the variable can be instantiated to the
 /// migrated effect via a closure argument this pass cannot see, so such a
@@ -8902,7 +8973,7 @@ fn scps_calls_ok(e: Expr, sctx: (String, Array[String], Array[String], Int, Arra
         scps_exprs_calls_ok(args, sctx, ctx)
       } else {
         let (is_fn, row) = scps_fn_row_of(ctx, nm)
-        if is_fn && !scps_row_contains(ctx, row, eff) && !scps_row_has_var(row) {
+        if is_fn && !scps_row_contains(ctx, row, eff) && (!scps_row_has_var(row) || scps_callee_first_order(ctx, nm)) {
           scps_exprs_calls_ok(args, sctx, ctx)
         } else {
           false
@@ -9028,7 +9099,7 @@ fn scps_first_bad_call_info(e: Expr, sctx: (String, Array[String], Array[String]
         scps_first_bad_call_info_exprs(args, sctx, ctx)
       } else {
         let (is_fn, row) = scps_fn_row_of(ctx, nm)
-        if is_fn && !scps_row_contains(ctx, row, eff) && !scps_row_has_var(row) {
+        if is_fn && !scps_row_contains(ctx, row, eff) && (!scps_row_has_var(row) || scps_callee_first_order(ctx, nm)) {
           scps_first_bad_call_info_exprs(args, sctx, ctx)
         } else {
           (true, nm, scps_pick_off(ioff, off))
@@ -12456,7 +12527,7 @@ fn scps_inert_taint(e: Expr, eff: String, needing: Array[String], locals: Array[
         scps_inert_taint_exprs(args, eff, needing, locals, ctx)
       } else {
         let (is_fn, row) = scps_fn_row_of(ctx, nm)
-        if is_fn && !scps_row_contains(ctx, row, eff) && !scps_row_has_var(row) {
+        if is_fn && !scps_row_contains(ctx, row, eff) && (!scps_row_has_var(row) || scps_callee_first_order(ctx, nm)) {
           scps_inert_taint_exprs(args, eff, needing, locals, ctx)
         } else {
           true

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6980,6 +6980,13 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 # never rewritten -- that is what keeps a runtime String out of the array form.
 VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_string_for_suspend_test.vibe
+# #1536: a `with e` callee is admitted when its declared parameters mention no
+# function type anywhere -- there is then no argument able to instantiate the
+# row variable, so the call cannot perform the handled effect. A callee that
+# does take a function stays refused; that is what keeps this sound.
+VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/effect_rowvar_first_order_call_test.vibe
+scps_check_reject "err_effect_rowvar_hof_call.vibe" "cannot see through" "rowvarhof"
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
 # THAT diagnostic, so the fixture cannot silently start passing for the other


### PR DESCRIPTION
## row 変数は「引数を通してしか」具体化されない

`with e` を宣言した callee は一律 reject されていた。理由は「row 変数は migrated effect に
具体化されうる」。正しいが、**その具体化は引数を通してしか起きない**。

したがって **宣言された引数の型がどこにも関数型を含まない callee は、call site がどうであれ
`e` を空 row にしか具体化できない** — 呼び出しは handled effect を perform しえない:

```vibe
fn twice(x: Int) -> Int with e { x * 2 }                        // ← 適格になった
fn apply(f: (Int) -> Int with e, x: Int) -> Int with e { .. }   // ← 拒否のまま
```

判定は**宣言だけで閉じる** (call site の型推論は不要)。`Array[(Int) -> Int with e]` のように
**型引数の中の関数型も数える**ので `TyFn` を再帰的に探す。注釈の無い引数・定義が見つからない
callee は従来どおり拒否。

## 見つけ方: 計測が嘘をついていた (stale な生成ソース)

実装後の実測が `REJECTED` のままで、また誤診を重ねかけた。今回は最初から instrumentation を
入れたところ **そのデバッグ出力自体が出てこなかった**。調べると:

- `lib/@vibe/compiler/_cli_adapter_module_source.vibe` (生成物) が**編集より古いまま**
- ビルドは `VIBE_PREBUILT_MODULE_SOURCE` でそれを食っていた
- → **ここ数回のビルドは変更を一切含んでいなかった**

生成物を消して再生成させると
`generate_bundle: seed could not flatten the live tree / unexpected in pattern: =1` —
instrumentation に書いた `None => all = false` (波括弧なしの代入を match arm の body に置いた)
が seed の parse error だった。**本当に新しいビルドで測ったら criterion は一発で通った。**

`ensure_generated.sh` が "ok" を返しても生成物が最新とは限らない。
**`grep <新しい識別子> <生成ソース>` の一行で確かめられる。**

## テスト

- `fixtures/effect_rowvar_first_order_call_test.vibe` (16) — `twice(a)` と
  `bump(b, perform ...)` を suspend body から呼ぶ
- `fixtures/err_effect_rowvar_hof_call.vibe` — 関数を取る row 変数 callee は**拒否のまま**。
  これが一階の受理を健全にしている線

`bash scripts/compiler_gate.sh` (full operation gate) green、`check_fixture_execution.sh` green。

## ドキュメント

- ADR-0076 追記59 (`docs/effect-evidence-passing.md`) — 判定と、stale ビルドの教訓

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_