### PR TITLE
test(async): pin the measured #1536 boundary instead of describing it (#1536)

### DIFF
--- a/fixtures/err_effect_capture_local_closure.vibe
+++ b/fixtures/err_effect_capture_local_closure.vibe
@@ -1,0 +1,45 @@
+// #1536 boundary, measured 2026-08-14. A closure literal passed to an accepted
+// callee may not capture ANOTHER LOCAL CLOSURE: that name could alias a literal
+// the phase-2 prepass step-compiled, and passing it through the plain-call
+// convention would launder a suspending closure (#1602 Codex review).
+//
+// This is narrower than the "literal-param provenance" residual once implied.
+// These all COMPILE today and are not the boundary:
+//   - a closure capturing an `Int`-annotated parameter
+//   - a closure capturing an outer `let` scalar
+//   - a closure capturing a function-typed parameter
+// Only capturing a locally-bound closure is refused.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn run(f: (Int) -> Int, n: Int) -> Int {
+  f(n)
+}
+
+fn helper() -> Int with Ask {
+  let inner = (y: Int) -> Int {
+    y * 2
+  }
+  let a = perform Ask::Get(1)
+  run((y: Int) -> Int {
+    inner(y) + 1
+  }, a)
+}
+
+let _start = () -> Int {
+  handle {
+    helper()
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "cannot see through"
+}

--- a/fixtures/err_effect_for_unproved_iterand.vibe
+++ b/fixtures/err_effect_for_unproved_iterand.vibe
@@ -1,0 +1,45 @@
+// #1536 boundary, measured 2026-08-14. A `for` iterand is lowered only when it
+// is PROVED to be an Array or a String: an annotated parameter, a literal
+// binding, or a call whose callee declares its return type. A selection is none
+// of those, so nothing proves it and the loop keeps its refusal.
+//
+// That refusal is the point: codegen decides String-ness at RUN TIME (#807), so
+// rewriting an unproved iterand could turn a String into a zero-iteration loop
+// and silently answer wrong. Widening the proof is fine; dropping it is not.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn helper(flag: Bool, xs: Array[Int], ys: Array[Int]) -> Int with Ask {
+  let mut acc = 0
+  for x in if flag {
+    xs
+  } else {
+    ys
+  } {
+    acc = acc + perform Ask::Get(x)
+  }
+  acc
+}
+
+let _start = () -> Int {
+  handle {
+    helper(true, [
+      1,
+      2
+    ], [
+      5
+    ])
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 10)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "let/seq/tail/branch-tail spine"
+}

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6987,6 +6987,13 @@ VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
 VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
   fixtures/effect_rowvar_first_order_call_test.vibe
 scps_check_reject "err_effect_rowvar_hof_call.vibe" "cannot see through" "rowvarhof"
+# #1536 boundary, measured 2026-08-14. Both of these are narrower than the
+# residual list implied, so they are pinned rather than described: a closure may
+# capture a scalar param, an outer scalar let, or a function param (all compile)
+# -- only capturing another LOCAL CLOSURE is refused. And a `for` iterand is
+# lowered only when proved; an unannotated callee proves nothing.
+scps_check_reject "err_effect_capture_local_closure.vibe" "cannot see through" "capturelocalclosure"
+scps_check_reject "err_effect_for_unproved_iterand.vibe" "let/seq/tail/branch-tail spine" "forunproved"
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
 # THAT diagnostic, so the fixture cannot silently start passing for the other


### PR DESCRIPTION
## 残件リストが古くなっていた (#1538 の blocker と同じ)

「residual literal-param provenance」を潰そうとして repro を書いたら、**次はどれも既に通っていた**:

| 形 | 実測 |
|---|---|
| closure が `Int` 注釈の**引数**を capture | **OK** (105) |
| closure が外側の `let` スカラを capture | **OK** (105) |
| closure が**関数引数**を capture | **OK** (11) |

実際に refuse されるのは **closure が別のローカル closure を capture する形**だけで、
名前が示すよりずっと狭い。

## 覚えるのではなく検査する

**実測した境界を fixture に固定**した:

| fixture | 何を pin するか |
|---|---|
| `err_effect_capture_local_closure` | closure が**ローカル closure** を capture する形 (step-compiled closure を alias しうる、#1602) |
| `err_effect_for_unproved_iterand` | iterand が **selection** の `for` — 名前でも呼び出しでもないので証明が届かない |

どちらも**なぜ refuse なのか**をコメントに書いてある。将来広げるときに「本物の制約」と
「たまたまの取りこぼし」を区別できるようにするため。

## 1 本目は間違って入れた

`err_effect_for_unproved_iterand` の初版は `fn opaque() { .. }` (戻り型なし) を使っていたが、
**これは vibe の構文として parse できない** — つまりあの "実測" は pass に届いてすらいなかった。
**gate が診断の不一致で捕まえた**ので、selection 形に差し替えた。fixture に期待診断を書かせる
仕組みがそのまま効いた形。

`bash scripts/compiler_gate.sh` (full operation gate) green。

Refs #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_