### PR TITLE
fix(async): reject a step-split literal in a plain-convention parameter (#1707)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -3337,3 +3337,35 @@ for x in items() { .. perform .. }        // ← 通るようになった
 stmts を走査して `SLet(_, _, name, _, EFn(_, _, _, ret, _, _))` から読む。最初これを
 取り違えて「証明が効かない」状態になった — **構築側 (`edp_collect_fn_defs`) を読めば
 ビルド 0 回で分かった**。
+
+### 追記61 (2026-08-14): step-split literal を plain な param へ渡す形は reject する (#1707)
+
+**P0 (黙って誤る)。** effect を perform する closure literal は **step を返す**ようにコンパイル
+されるので、**その effect を row に持つパラメータにしか渡せない**。plain なパラメータへ渡すと
+callee は普通の規約で呼び、**step オブジェクトがそのまま値**になる (実測: 5 が 177、15 が 301 —
+ヒープポインタが Int として読まれている)。
+
+prepass には**逆向きの fixup が既にあった** — pure な literal が row 付きパラメータへ来たら
+Done-wrap する。それが `if prow != ""` の内側にあり、**step-split 済み literal が row を持たない
+パラメータへ来る場合**を素通りしていた。
+
+**row 変数のパラメータは免除**する。`TaskGroup::run[T, rg, e](body: (..) -> T with e)` は
+呼び出し側で `e` にその effect を具体化できるので、step 返しの literal を受け取れる。
+**具体的な row が effect を含まない場合だけ**が plain 規約のパラメータ。
+
+#### 3 回失敗してから通った — 手順の記録
+
+| 試行 | 仮説 | 結果 |
+|---|---|---|
+| 1 | `scps_calls_ok` の `EFn` arm が cps_locals を保持している | **効果ゼロ** → literal は既に step-split 済みで、問題は body でなく**渡され方**だと判明 |
+| 2 | arg-position fixup の「鏡」が無い | **P0 は直ったが** `lib/@vibex/concurrent/suspend_test.vibe` (supported な形) を壊した |
+| 3 | needing callee を免除 | `TaskGroup::run` は cneeding に無く、**変わらず** |
+| 4 | **row 変数のパラメータを免除** | **通った** — P0 は reject、suspend_test は 27 tests pass、601/601、gate green |
+
+**教訓 A**: `scripts/compiler_gate.sh` はこの regression を捕まえない。
+**`VIBE_STAGE2_WASM=<stage2> bash scripts/unit_test_runner.sh` (601 files) が捕まえる。**
+この領域を触るときは両方回す。
+
+**教訓 B (追記59 の修正)**: 生成ソースの鮮度を識別子で grep してはいけない — **bundler が
+識別子を潰す**ので、変更が入っていても 0 件になる。**新しい文字列リテラル**
+(診断メッセージなど) で grep すること。

--- a/fixtures/err_effect_step_literal_plain_param.vibe
+++ b/fixtures/err_effect_step_literal_plain_param.vibe
@@ -1,0 +1,46 @@
+// #1707 (P0 regression): a closure literal that performs the handled effect is
+// compiled to return a STEP. It may therefore only land in a parameter whose
+// declared row carries that effect. Passed to a plain-convention parameter,
+// the callee calls it normally and hands the step OBJECT back as the value --
+// which compiled clean and silently returned a heap pointer read as an Int.
+//
+// Measured before the fix: this returned 177 where the answer is 5, and the
+// `+ 1` variant returned 301 where the answer is 15. The equivalent without
+// the intermediate closure, and the effect-free equivalent, both answer
+// correctly -- so the suspending version silently disagreed with them.
+//
+// The arg-position fixup already Done-wrapped a PURE literal landing in a
+// row-carrying parameter; this is that rule's missing mirror.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn run(f: (Int) -> Int, n: Int) -> Int {
+  f(n)
+}
+
+fn helper() -> Int with Ask {
+  let performer = (y: Int) -> Int with Ask {
+    perform Ask::Get(y)
+  }
+  run((y: Int) -> Int {
+    performer(y)
+  }, 1)
+}
+
+let _start = () -> Int {
+  handle {
+    helper()
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n + 4)
+    }
+  }
+}
+_start()
+
+__DATA__
+{
+  "error_contains": "hand the step object back as the value"
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -13913,7 +13913,13 @@ fn scps_prepass_expr(e: Expr, ecfgs: Array[(String, Array[String], Array[String]
                 let mut ei0 = 0
                 while ei0 < Array::length(ecfgs) {
                   let (ceff0, _, _) = Array::get(ecfgs, ei0)
-                  if !scps_row_contains(ctx, prow, ceff0) && scps_literal_is_step_for(Array::get(rargs, aj), ceff0) {
+                  // A parameter whose row is a row VARIABLE is exempt: the
+                  // variable can be instantiated to this effect at the call
+                  // site, which is exactly what makes
+                  // `TaskGroup::run[T, rg, e](body: (..) -> T with e)` able to
+                  // receive a step-returning literal. Only a CONCRETE row that
+                  // does not carry the effect is a plain-convention parameter.
+                  if !scps_row_has_var(prow) && !scps_row_contains(ctx, prow, ceff0) && scps_literal_is_step_for(Array::get(rargs, aj), ceff0) {
                     Array::push(scps_st_errs(st), String::concat(String::concat(String::concat("a closure literal that performs `", ceff0), "` (so it is compiled to return a step) is passed to a parameter of `"), String::concat(String::concat(fname, "` whose type does not declare that effect -- the callee would call it under the plain convention and hand the step object back as the value. Declare the parameter as `(..) -> .. with "), String::concat(ceff0, "`, or move the performing call out of the literal (#1707, ADR-0076 追記31 Vertical B)"))))
                   } else {
                     ()

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -13904,6 +13904,22 @@ fn scps_prepass_expr(e: Expr, ecfgs: Array[(String, Array[String], Array[String]
               if aj < Array::length(fparams) {
                 let (_, pty) = Array::get(fparams, aj)
                 let prow = scps_ty_row(pty)
+                // #1707: the mirror of the fixup below. A literal the prepass
+                // STEP-SPLIT returns `__ScpsStep_E`, so it may only land in a
+                // parameter whose declared row carries E. Passed to a plain
+                // parameter, the callee calls it under the ordinary convention
+                // and hands the step OBJECT back as the value -- that compiled
+                // clean and silently returned a heap pointer as an Int.
+                let mut ei0 = 0
+                while ei0 < Array::length(ecfgs) {
+                  let (ceff0, _, _) = Array::get(ecfgs, ei0)
+                  if !scps_row_contains(ctx, prow, ceff0) && scps_literal_is_step_for(Array::get(rargs, aj), ceff0) {
+                    Array::push(scps_st_errs(st), String::concat(String::concat(String::concat("a closure literal that performs `", ceff0), "` (so it is compiled to return a step) is passed to a parameter of `"), String::concat(String::concat(fname, "` whose type does not declare that effect -- the callee would call it under the plain convention and hand the step object back as the value. Declare the parameter as `(..) -> .. with "), String::concat(ceff0, "`, or move the performing call out of the literal (#1707, ADR-0076 追記31 Vertical B)"))))
+                  } else {
+                    ()
+                  }
+                  ei0 = ei0 + 1
+                }
                 if prow != "" {
                   let mut ei2 = 0
                   while ei2 < Array::length(ecfgs) {

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6993,6 +6993,10 @@ scps_check_reject "err_effect_rowvar_hof_call.vibe" "cannot see through" "rowvar
 # -- only capturing another LOCAL CLOSURE is refused. And a `for` iterand is
 # lowered only when proved; an unannotated callee proves nothing.
 scps_check_reject "err_effect_capture_local_closure.vibe" "cannot see through" "capturelocalclosure"
+# #1707 P0: a step-split literal may only land in a parameter whose row carries
+# the effect. Passed to a plain-convention parameter it used to compile and
+# silently return the step object as the value (5 -> 177, 15 -> 301).
+scps_check_reject "err_effect_step_literal_plain_param.vibe" "hand the step object back as the value" "stepliteralplainparam"
 scps_check_reject "err_effect_for_unproved_iterand.vibe" "let/seq/tail/branch-tail spine" "forunproved"
 # A nested handle inside a compound is refused EARLIER, by the pre-existing
 # see-through rule -- the linearization neither widens nor narrows it. Gated on
@@ -8567,7 +8571,12 @@ if [ -s "$asb89dir/neg.wasm" ]; then
   echo "[compiler-gate] FAIL: err_async_boundary_mixed_convention.vibe compiled successfully -- convention mixing must be rejected" >&2
   exit 1
 fi
-if ! grep -qF 'mixing the step convention' "$asb89dir/neg.wasm.diag" 2>/dev/null; then
+# Either guard may catch this: the ADR-0076 mixing guard, or #1707's more
+# specific one (a step-split literal landing in a plain-convention parameter,
+# which is the same root -- a step value meeting a plain call). What this pins
+# is that it is REJECTED with an actionable diagnostic, not miscompiled.
+if ! grep -qF 'mixing the step convention' "$asb89dir/neg.wasm.diag" 2>/dev/null \
+   && ! grep -qF 'hand the step object back as the value' "$asb89dir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_async_boundary_mixed_convention.vibe did not produce the expected diagnostic" >&2
   cat "$asb89dir/neg.wasm.diag" 2>/dev/null >&2 || true
   exit 1


### PR DESCRIPTION
## P0 (黙って誤る)。ごく普通のコードから届く

effect を perform する closure literal は **step を返す**ようにコンパイルされるので、
**その effect を row に持つパラメータにしか渡せない**。plain なパラメータへ渡すと callee は
普通の規約で呼び、**step オブジェクトがそのまま値**になる。

```vibe
fn run(f: (Int) -> Int, n: Int) -> Int {
  f(n)
}

fn helper() -> Int with Ask {
  let performer = (y: Int) -> Int with Ask {
    perform Ask::Get(y)
  }
  run((y: Int) -> Int {
    performer(y)
  }, 1)
}
```

| | 期待 | 修正前 |
|---|---|---|
| 上の最小形 | 5 | **177** |
| capture を挟まない等価形 | 15 | 15 ✅ |
| effect 抜きの等価形 | 15 | 15 ✅ |
| capture 版 | 15 | **301** |

177 / 301 は**ヒープポインタが Int として読まれた値**。

## 原因と直し方

prepass には**逆向きの fixup が既にあった** — pure な literal が row 付きパラメータへ来たら
Done-wrap して step 規約に合わせる。それが **`if prow != ""` の内側**にあり、
**step-split 済み literal が row を持たないパラメータへ来る場合**を素通りしていた。

**row 変数のパラメータは免除する。**
`TaskGroup::run[T, rg, e](body: (TaskGroup[rg, e]) -> T with e)` は呼び出し側で `e` に
その effect を具体化できるので step 返しの literal を受け取れる — ADR-0089 D1 が
「supported」と呼ぶ *row-free entry + TaskGroup* の形そのもの。**具体的な row が effect を
含まない場合だけ**が plain 規約のパラメータ。

## 4 回目で通った。1〜3 回目が何を否定したか

| 試行 | 仮説 | 結果 |
|---|---|---|
| 1 | `scps_calls_ok` の `EFn` arm が cps_locals を保持している | **効果ゼロ** → literal は既に step-split 済みで、問題は body でなく**渡され方**と判明 |
| 2 | arg-position fixup の「鏡」が無い | **P0 は直ったが** `suspend_test.vibe` (supported な形) を壊した → **CI が検出** |
| 3 | needing callee を免除 | `TaskGroup::run` は cneeding に無く、変わらず |
| 4 | **row 変数のパラメータを免除** | **通った** |

## 検証

- **P0**: reject (診断はパラメータ名と 2 つの直し方を述べる)
- **`lib/@vibex/concurrent/suspend_test.vibe`**: 27 tests pass (試行 2 で壊した形)
- **`unit_test_runner.sh`: 601/601** ← このクラスを捕まえるのはこちら
- **`compiler_gate.sh`**: green
- 回帰確認 8 本 (capture 各形 / rowvar / return / for-in) 不変
- `err_async_boundary_mixed_convention` はこのガードが先に捕まえるので、gate はどちらの診断も
  受け付けるようにした (pin しているのは「reject されること」)

## 手順の記録 (ADR-0076 追記61)

- **`compiler_gate.sh` はこのクラスを捕まえない。`unit_test_runner.sh` (601 files) が捕まえる。**
  この領域を触るときは両方回す
- **追記59 の鮮度チェックは誤りだったので訂正した**: 生成ソースを**識別子**で grep しても
  bundler が潰すので 0 件になる。**新しい文字列リテラル**で grep すること

Closes #1707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_