### PR TITLE
docs(tutorial): 実装に追い越された記述と壊れた例示を現行仕様に合わせる

### DIFF
--- a/docs/tutorial/01_values_functions.vibe.md
+++ b/docs/tutorial/01_values_functions.vibe.md
@@ -74,25 +74,22 @@ y = 2
 
 ## 関数
 
-**目標の言語**では `fn` は予約語であり、関数宣言の綴りは `fn` のまま保つ。
-[#1280](https://github.com/mizchi/vibe-lang/issues/1280) が着地すれば、binding・引数・型・
-member の名前に `fn` は使えない。既存の名前は `fn_` などへ rename し、`r#fn` のような
-raw identifier は escape hatch にしない。これは目標の probe であり、現在のコンパイラでは実行しない。
+`fn` は予約語 ([#1280](https://github.com/mizchi/vibe-lang/issues/1280) で着地済み)。
+関数宣言の綴りは `fn` で、binding・引数の名前には使えない。`r#fn` のような
+raw identifier も escape hatch にはならない (実測: `let fn = 1` は
+`expected identifier after 'let'`、`fn f(fn: Int)` は `expected parameter name`、
+`let r#fn = 1` も同様に拒否)。既存の名前が衝突したら `fn_` などへ rename する。
 
 ```vibe skip
-// target (#1280): `fn` は予約語。宣言以外の識別子には使えない。
-fn add(x: Int, y: Int) -> Int {
-  x + y
-}
+// skip: 予約語 `fn` の拒否例 (どれも parse error になることを示す断片)
 let fn = 1
-// error: reserved keyword
+// error: expected identifier after 'let'
 let r#fn = 1
-// error: raw identifier は使えない
+// error: raw identifier は escape hatch にしない
 ```
 
-現在のコンパイラは `fn` の予約をまだ実装していないが、以下の宣言形式はすでに
-runnable である。トップレベル関数は完全注釈必須、再帰に `rec` は不要。let 形式・
-ジェネリクス・ラベル付き引数も同じ意味論。
+宣言形式は以下がすべて runnable。トップレベル関数は完全注釈必須、再帰に
+`rec` は不要。let 形式・ジェネリクス・ラベル付き引数も同じ意味論。
 
 ```vibe run
 import @vibe/prelude {

--- a/docs/tutorial/02_control_flow.vibe.md
+++ b/docs/tutorial/02_control_flow.vibe.md
@@ -25,8 +25,10 @@ v = yes
 
 ## while と早期 return（現行）
 
-`return` は関数全体から抜ける (ループだけではない)。これは現行構文であり、
-維持するか代替構文へ移行するかは [#1283](https://github.com/mizchi/vibe-lang/issues/1283) で決める。
+`return` は関数全体から抜ける (ループだけではない)。この構文は
+[#1283](https://github.com/mizchi/vibe-lang/issues/1283) で「維持する」と決着した —
+同じ issue で追加された、パターン束縛付きの早期脱出 `guard ... else { ... }` は
+[04 Option](04_option.vibe.md#guard--束縛するか脱出) で扱う。
 
 ```vibe run
 import @vibe/prelude {

--- a/docs/tutorial/04_option.vibe.md
+++ b/docs/tutorial/04_option.vibe.md
@@ -130,10 +130,11 @@ first_half(4, 3) unwrap_or -1 = -1
 
 `else` は**必ず脱出**する。`match e { PAT => <残り>, _ => else }` に脱糖されるので
 `else` 腕は残りのブロックそのものの代わりに評価される位置にあり、脱出しないと
-束縛されていない `v` を使う経路ができてしまうため。現行で受理する脱出の形は
-`return` **だけ**で、`throw` はまだ受理しない
-([#1283](https://github.com/mizchi/vibe-lang/issues/1283) — ADR-0073 が
-`Error::Throw` を非再開と定めてはいるが、checker 側の abortive 判定は別作業)。
+束縛されていない `v` を使う経路ができてしまうため。受理する脱出の形は
+`return` と直接の `throw(...)` (実測: `guard o is Some(v) else { throw("no value") }`
+は関数の row に `Exception` があればそのまま通り、呼び出し側の `handle` で
+捕まえられる — [05 エフェクト](05_effects.vibe.md) 参照)。他の `perform` は
+resume しうるので脱出とは数えない。
 
 フォールバックが「脱出」ではなく「値」なら `if e is PAT { .. } else { .. }` を使う。
 

--- a/docs/tutorial/05_effects.vibe.md
+++ b/docs/tutorial/05_effects.vibe.md
@@ -103,7 +103,7 @@ v = 42
 
 ユーザー定義 effect は、実装を呼び出し側から差し替える必要がある場合の advanced な
 手段である。これは resumptive かつ one-shot/tail-resumptive という制約を持つ。通常の
-失敗は `Exception`（実装後）を使い、局所的な状態はまず `let mut` を検討する。判断基準は
+失敗は `Exception` を使い、局所的な状態はまず `let mut` を検討する。判断基準は
 [Effects vs let mut](../guide/when-to-use-effects.md) を参照。
 
 ## エフェクト多相

--- a/docs/tutorial/06_tests.vibe.md
+++ b/docs/tutorial/06_tests.vibe.md
@@ -19,8 +19,9 @@ String も内容で比較されるので、連結・関数の返り値・変数�
 `assert_eq` をそのまま使える。
 
 ```bash
-vibe test file_test.vibe     # 1 ファイル
-vibe test docs/tutorial/     # ディレクトリ一括
+vibe test file_test.vibe             # 1 ファイル
+vibe test a_test.vibe b_test.vibe    # 複数ファイル (ディレクトリは渡せない —
+                                     # 引数はファイルのみ、glob はシェルで展開する)
 ```
 
 ## CLI ツーリング

--- a/docs/tutorial/07_modules_packages.vibe.md
+++ b/docs/tutorial/07_modules_packages.vibe.md
@@ -89,13 +89,16 @@ hex_encode("hi") = 6869
 **契約**で、実装との一致はコンパイラが照合する。#1128 以降は構造化ヘッダー
 (`name =` / `version =` / `description =` / `deps = { ... }`) が標準形:
 
-```vibe skip
-// skip: index.vpkg ヘッダー例 (docs/adding-modules.md 参照)
-name = @you / counter
+```text
+// index.vpkg ヘッダー例 (docs/adding-modules.md 参照)。ヘッダ部は vibe 構文
+// ではないので ```text — 実物の綴りは lib/@vibe/*/index.vpkg を見る
+name = @you/counter
 version = 1.0.0
 description =
-"|A tiny counter contract"deps = {
-}
+  #|A tiny counter contract
+deps = {}
+
+generated_hash =
 
 type Counter
 // bodyless: 定義は impl 側
@@ -115,10 +118,12 @@ fn add(x: Int, y: Int) -> Int
 再現可能ビルドでは require 行で **内容 hash** を固定する。ビルドは毎回
 オフラインで hash を再検証するので、置き場所や取得経路は信頼しなくてよい。
 
-```vibe skip
-// skip: require directive は import/export と独立に module header に置く例示
-require @vibe / core0.2.0 = #pkg: sha1: < 40hex >
-// `vibe hash` で計算
+```text
+// require directive は import/export と独立に module header に置く。
+// directive は vibe 構文ではないので ```text (loader の受理形は
+// contract.vibe の "malformed require line" 診断が正)
+require @vibe/core 0.2.0 = #pkg:sha1:<40hex>
+// <40hex> は `vibe hash` で計算
 
 import @vibe/core {
   sha1

--- a/scripts/architecture_debt_allowlist.txt
+++ b/scripts/architecture_debt_allowlist.txt
@@ -19,19 +19,19 @@ ARCH011	lib/@vibe/compiler/_cli_adapter_module_source.vibe	*
 # Baseline when ARCH010/011 were promoted from advisory warnings to blocking
 # ratchets after the 2026-08-14 review audit. New occurrences are errors.
 ARCH010	lib/@vibe/compiler/checker_struct.vibe	91
-ARCH010	lib/@vibe/compiler/checker/checker.vibe	6597
-ARCH010	lib/@vibe/compiler/checker/checker.vibe	6632
-ARCH010	lib/@vibe/compiler/checker/checker.vibe	6648
-ARCH010	lib/@vibe/compiler/checker/checker.vibe	7015
-ARCH010	lib/@vibe/compiler/checker/checker.vibe	7027
-ARCH010	lib/@vibe/compiler/checker/checker_stmt.vibe	829
-ARCH010	lib/@vibe/compiler/checker/checker_stmt.vibe	1278
+ARCH010	lib/@vibe/compiler/checker/checker.vibe	6608
+ARCH010	lib/@vibe/compiler/checker/checker.vibe	6643
+ARCH010	lib/@vibe/compiler/checker/checker.vibe	6659
+ARCH010	lib/@vibe/compiler/checker/checker.vibe	7026
+ARCH010	lib/@vibe/compiler/checker/checker.vibe	7038
+ARCH010	lib/@vibe/compiler/checker/checker_stmt.vibe	825
+ARCH010	lib/@vibe/compiler/checker/checker_stmt.vibe	1274
 ARCH011	lib/@vibe/compiler/contract/contract.vibe	1862
-ARCH011	lib/@vibe/compiler/cli_adapter.vibe	608
+ARCH011	lib/@vibe/compiler/cli_adapter.vibe	612
 ARCH011	lib/@vibe/compiler/normalize/desugar_trait_dict.vibe	3004
 ARCH011	lib/@vibe/compiler/normalize/desugar_trait_dict.vibe	3058
-ARCH011	lib/@vibe/compiler/checker/checker_stmt.vibe	2292
+ARCH011	lib/@vibe/compiler/checker/checker_stmt.vibe	2294
 ARCH011	lib/@vibe/compiler/checker/checker_effects.vibe	539
 ARCH011	lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe	966
-ARCH011	lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe	3388
-ARCH011	lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe	9786
+ARCH011	lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe	3399
+ARCH011	lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe	10060


### PR DESCRIPTION
## 概要

docs/tutorial の全 7 章を現行 stage2 (49f40fb からセルフビルド) に照らして確認した結果の修正。実行ブロック (```vibe run) は **28/28 PASS** で、ズレはすべて検査の届かない場所 (```vibe skip / ```bash / 地の文) にあった。

## 修正内容

| 章 | ズレ | 根拠 (実測) |
|---|---|---|
| 01 | 「`fn` の予約 (#1280) はまだ実装していない」→ **着地済み** | `let fn = 1` → `expected identifier after 'let'`、`fn f(fn: Int)` → `expected parameter name`、`let r#fn = 1` も拒否 |
| 02 | 「return 維持は #1283 で決める」→ 決着済み | #1283 は guard 追加 + return 維持で着地 |
| 04 | 「guard の else で受理するのは `return` だけ、`throw` はまだ」→ **throw も受理される** | `guard o is Some(v) else { throw("no value") }` が check clean + 実行で handle まで動作。cheatsheet/parser 診断とも throw 受理で一致 |
| 05 | 「Exception（実装後）」の stale な括弧書き | 同章の run ブロックで実行済み |
| 06 | `vibe test docs/tutorial/` (ディレクトリ一括) → **動かない** | launcher の test サブコマンドは `[ -f ]` で検証しディレクトリを `not found` で拒否 |
| 07 | vpkg ヘッダー / require pin の例が壊れた構文 (`name = @you / counter`、`"|...`、`require @vibe / core0.2.0 = #pkg: sha1: < 40hex >`) | 実物の vpkg と `contract.vibe:1508` の受理形 (`require @scope/name x.y.z = #pkg:sha1:<40hex>`) に合わせて修正。vibe 構文ではないヘッダー/directive 例は ```text フェンスへ移し、vibe-md の fmt レーン (skip ブロックも vibe として整形する) が再び壊せないようにした |

05 の「handler は checker 用で、実行時は host import に直接 lower される」は現行挙動としては正確だが #1678 (zero-arm handle) の設計決着待ちのため今回は触っていない。

## 別件: architecture_debt_allowlist の行番号 drift 追従 (1 コミット目)

素の main (49f40fb) で pre-commit の `scripts/lint_architecture_debt.sh` が 11 件の「new violations」で落ちる状態だった。allowlist は (rule, path, line) の行番号ピン方式で、最近のコミットが対象ファイルの行をずらした時点で既存エントリが外れていたもの。指している違反は同一 (すべて既知の #1521/#1491 debt) なので行番号だけを現在地へ更新した。

## 検証

- `VIBE_MD_COMPILER=<49f40fb stage2>` で `scripts/vibe_md.sh check docs/tutorial/*.vibe.md` → 28 pass / 0 fail
- 同 `fmt-check docs/tutorial/*.vibe.md` → 31 pass / 0 fail
- `scripts/lint_architecture_debt.sh` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_