### PR TITLE
fix(loader): round-trip control characters in persistent cache paths

### DIFF
--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/syntax {
 }
 
 import @vibe/core {
-  array_empty
+  array_empty, hex_decode, hex_encode
 }
 
 import @vibe/compiler/core {
@@ -694,6 +694,8 @@ fn parse_persistent_source_list_cache(raw: String) -> (Int, Option[(String, Stri
             version = 2
           } else if version_text == "3" {
             version = 3
+          } else if version_text == "4" {
+            version = 4
           } else {
             throw("invalid persistent source list cache version")
           }
@@ -712,7 +714,12 @@ fn parse_persistent_source_list_cache(raw: String) -> (Int, Option[(String, Stri
             if Array::length(fields) != 4 {
               throw("invalid persistent source list cache manifest row")
             }
-            manifest = Some((Array::get(fields, 1), Array::get(fields, 2), Array::get(fields, 3)))
+            let path = if version == 4 {
+              hex_decode(Array::get(fields, 1))
+            } else {
+              Array::get(fields, 1)
+            }
+            manifest = Some((path, Array::get(fields, 2), Array::get(fields, 3)))
           }
         } else if tag == "source" {
           if version == 1 {
@@ -724,7 +731,12 @@ fn parse_persistent_source_list_cache(raw: String) -> (Int, Option[(String, Stri
             if Array::length(fields) != 4 {
               throw("invalid persistent source list cache source row")
             }
-            Array::push(sources, (Array::get(fields, 1), Array::get(fields, 2), Array::get(fields, 3)))
+            let path = if version == 4 {
+              hex_decode(Array::get(fields, 1))
+            } else {
+              Array::get(fields, 1)
+            }
+            Array::push(sources, (path, Array::get(fields, 2), Array::get(fields, 3)))
           }
         } else {
           throw(String::concat("invalid persistent source list cache row: ", line))
@@ -767,6 +779,8 @@ fn parse_persistent_source_group_cache(raw: String) -> (Int, Option[(String, Str
             version = 2
           } else if version_text == "3" {
             version = 3
+          } else if version_text == "4" {
+            version = 4
           } else {
             throw("invalid persistent source group cache version")
           }
@@ -785,7 +799,12 @@ fn parse_persistent_source_group_cache(raw: String) -> (Int, Option[(String, Str
             if Array::length(fields) != 4 {
               throw("invalid persistent source group cache manifest row")
             }
-            manifest = Some((Array::get(fields, 1), Array::get(fields, 2), Array::get(fields, 3)))
+            let path = if version == 4 {
+              hex_decode(Array::get(fields, 1))
+            } else {
+              Array::get(fields, 1)
+            }
+            manifest = Some((path, Array::get(fields, 2), Array::get(fields, 3)))
           }
         } else if tag == "group" {
           if version == 1 {
@@ -797,7 +816,17 @@ fn parse_persistent_source_group_cache(raw: String) -> (Int, Option[(String, Str
             if Array::length(fields) != 5 {
               throw("invalid persistent source group cache group row")
             }
-            Array::push(rows, (Array::get(fields, 1), Array::get(fields, 2), Array::get(fields, 3), Array::get(fields, 4)))
+            let group_name = if version == 4 {
+              hex_decode(Array::get(fields, 1))
+            } else {
+              Array::get(fields, 1)
+            }
+            let path = if version == 4 {
+              hex_decode(Array::get(fields, 2))
+            } else {
+              Array::get(fields, 2)
+            }
+            Array::push(rows, (group_name, path, Array::get(fields, 3), Array::get(fields, 4)))
           }
         } else {
           throw(String::concat("invalid persistent source group cache row: ", line))
@@ -1243,14 +1272,14 @@ export fn load_persistent_source_group_fingerprint_if_valid(entry_path: String) 
 /// fix and issue class as stable_cache_path's #366 note (lib/@vibe/cache).
 fn build_persistent_sources_cache_text(entry_path: String, manifest_path: Option[String], sources: Array[(String, String)]) -> String with Exception + Fs {
   let sb = StringBuilder::new()
-  StringBuilder::push(sb, "version\t3\n")
+  StringBuilder::push(sb, "version\t4\n")
   StringBuilder::push(sb, "resctx\t")
   StringBuilder::push(sb, persistent_resolution_context_fingerprint_fs(entry_path, source_paths(sources)))
   StringBuilder::push(sb, "\n")
   match manifest_path {
     Some(path) => {
       StringBuilder::push(sb, "manifest\t")
-      StringBuilder::push(sb, path)
+      StringBuilder::push(sb, hex_encode(path))
       StringBuilder::push(sb, "\t")
       StringBuilder::push(sb, __to_string(Fs::stat_token(path)))
       StringBuilder::push(sb, "\t")
@@ -1272,7 +1301,7 @@ fn build_persistent_sources_cache_text(entry_path: String, manifest_path: Option
       ()
     } else {
       StringBuilder::push(sb, "source\t")
-      StringBuilder::push(sb, path)
+      StringBuilder::push(sb, hex_encode(path))
       StringBuilder::push(sb, "\t")
       StringBuilder::push(sb, __to_string(Fs::stat_token(path)))
       StringBuilder::push(sb, "\t")
@@ -1288,14 +1317,14 @@ fn build_persistent_sources_cache_text(entry_path: String, manifest_path: Option
 /// build_persistent_sources_cache_text above.
 fn build_persistent_source_groups_cache_text(entry_path: String, manifest_path: Option[String], groups: Array[(String, Array[(String, String)])]) -> String with Exception + Fs {
   let sb = StringBuilder::new()
-  StringBuilder::push(sb, "version\t3\n")
+  StringBuilder::push(sb, "version\t4\n")
   StringBuilder::push(sb, "resctx\t")
   StringBuilder::push(sb, persistent_resolution_context_fingerprint_fs(entry_path, grouped_source_paths(groups)))
   StringBuilder::push(sb, "\n")
   match manifest_path {
     Some(path) => {
       StringBuilder::push(sb, "manifest\t")
-      StringBuilder::push(sb, path)
+      StringBuilder::push(sb, hex_encode(path))
       StringBuilder::push(sb, "\t")
       StringBuilder::push(sb, __to_string(Fs::stat_token(path)))
       StringBuilder::push(sb, "\t")
@@ -1315,9 +1344,9 @@ fn build_persistent_source_groups_cache_text(entry_path: String, manifest_path: 
         ()
       } else {
         StringBuilder::push(sb, "group\t")
-        StringBuilder::push(sb, group_name)
+        StringBuilder::push(sb, hex_encode(group_name))
         StringBuilder::push(sb, "\t")
-        StringBuilder::push(sb, path)
+        StringBuilder::push(sb, hex_encode(path))
         StringBuilder::push(sb, "\t")
         StringBuilder::push(sb, __to_string(Fs::stat_token(path)))
         StringBuilder::push(sb, "\t")

--- a/lib/@vibe/compiler/tests/loader_persistent_cache_tab_test.vibe
+++ b/lib/@vibe/compiler/tests/loader_persistent_cache_tab_test.vibe
@@ -1,0 +1,62 @@
+import @vibe/compiler/cache {
+  persistent_source_group_cache_path, persistent_source_list_cache_path
+}
+
+import @vibe/compiler/loader {
+  collect_all_sources_fs, collect_source_groups_fs
+}
+
+fn remove_file_if_exists(path: String) -> Unit with Fs {
+  if Fs::exists(path) {
+    Fs::remove(path)
+  } else {
+    ()
+  }
+}
+
+fn has_source_path(sources: Array[(String, String)], target: String) -> Bool {
+  let mut found = false
+  let mut i = 0
+  while i < Array::length(sources) {
+    let (path, _) = Array::get(sources, i)
+    if path == target {
+      found = true
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn groups_have_source_path(groups: Array[(String, Array[(String, String)])], target: String) -> Bool {
+  let mut found = false
+  let mut gi = 0
+  while gi < Array::length(groups) {
+    let (_, sources) = Array::get(groups, gi)
+    if has_source_path(sources, target) {
+      found = true
+    }
+    gi = gi + 1
+  }
+  found
+}
+
+test "persistent source caches round-trip TAB in source paths (#1712)" {
+  let base_dir = "/tmp/vibe_compiler_persistent_tab_path"
+  let helper_path = String::concat(base_dir, "/helper.vibe")
+  let main_path = String::concat(base_dir, "/tab\tapp.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_file(helper_path, "export let add: () -> Int = () -> { 1 }")
+  Fs::write_file(main_path, "import ./helper.vibe { add }\nlet run: () -> Int = () -> { add() }")
+  remove_file_if_exists(persistent_source_group_cache_path(main_path))
+  remove_file_if_exists(persistent_source_list_cache_path(main_path))
+  let first_groups = collect_source_groups_fs(main_path)
+  assert(groups_have_source_path(first_groups, main_path))
+  let warm_groups = collect_source_groups_fs(main_path)
+  assert(groups_have_source_path(warm_groups, main_path))
+  remove_file_if_exists(persistent_source_group_cache_path(main_path))
+  remove_file_if_exists(persistent_source_list_cache_path(main_path))
+  let first_sources = collect_all_sources_fs(main_path)
+  assert(has_source_path(first_sources, main_path))
+  let warm_sources = collect_all_sources_fs(main_path)
+  assert(has_source_path(warm_sources, main_path))
+}


### PR DESCRIPTION
## Summary

- bump persistent source-list/source-group cache rows to format v4
- hex-encode path and group-name fields so TAB/newline bytes cannot collide with TSV framing
- keep readers compatible with v1–v3 caches
- add a focused cold→warm regression test using a TAB-containing entry path for both cache lanes

## Root cause

The cache writer embedded POSIX paths directly into fixed-width TSV rows. TAB is valid in a path, so the writer produced an extra field and the next read failed with `invalid persistent source group cache group row`.

## Validation

- focused regression: 1/1 pass
- `pkf run test-local`: 224/224 selected tests pass
- formatter and `git diff --check`: pass
- review-derived AST precommit lint: pass
- full precommit remains blocked only by existing #1729 on main; its fix is already in PR #1734

Closes #1712