### PR TITLE
fix(parser): report reserved function names at the right location

### DIFF
--- a/lib/@vibe/compiler/tests/parser_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/syntax {
-  lex, print_program
+  lex, lex_with_offsets, parse_program_located, print_program
 }
 
 import @vibe/ast {
@@ -739,6 +739,42 @@ test "#1283: `guard` is a reserved word, escapable as r#guard" {
     "ok"
   } with Exception {
     Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(escaped == "ok")
+  let unescapable_source = "fn fn() -> Int { 0 }"
+  let unescapable = handle {
+    let (tokens, starts, _) = lex_with_offsets(unescapable_source)
+    let _ = parse_program_located(tokens, starts, unescapable_source)
+    "ok"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert(String::starts_with(unescapable, "line 1:4: "))
+  assert(String::contains(unescapable, "`fn` is a reserved word"))
+  assert(String::contains(unescapable, "cannot be escaped"))
+  assert(!(String::contains(unescapable, "r#fn")))
+}
+
+test "#1692: reserved fn name reports its own location and raw-name escape" {
+  let source = "fn ok() -> Int { 0 }\nfn guard(x: Int) -> Int { x }"
+  let message = handle {
+    let (tokens, starts, _) = lex_with_offsets(source)
+    let _ = parse_program_located(tokens, starts, source)
+    "ok"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert(String::starts_with(message, "line 2:4: "))
+  assert(String::contains(message, "`guard` is a reserved word"))
+  assert(String::contains(message, "r#guard"))
+  assert(!(String::contains(message, "after 'let'")))
+  let escaped_source = "fn r#guard(x: Int) -> Int { x }"
+  let escaped = handle {
+    let (tokens, starts, _) = lex_with_offsets(escaped_source)
+    let _ = parse_program_located(tokens, starts, escaped_source)
+    "ok"
+  } with Exception {
+    Throw(e) => e
   }
   assert(escaped == "ok")
 }

--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -609,8 +609,30 @@ fn parse_let_stmt(tokens: Array[Token], starts: Array[Int], pos: Int, exported: 
 /// clause (#731, ADR-0064 §7) parses each condition as an ordinary Bool
 /// expression; `ensures` conditions may reference the function result as
 /// `result`. Multiple requires/ensures entries are allowed.
+fn parse_fn_name(tokens: Array[Token], pos: Int) -> (String, Int) with Exception {
+  match peek(tokens, pos) {
+    TIdent(_) => parse_binding_name(tokens, pos),
+    TFn => throw("`fn` is a reserved word and cannot be used as a function name; this keyword cannot be escaped, so choose a different name at #\{pos}"),
+    token => {
+      let actual = tk_name(token)
+      let first = if String::length(actual) > 0 {
+        String::char_code_at(actual, 0)
+      } else {
+        0
+      }
+      let word_token = (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z')
+      let literal_or_eof = actual == "int" || actual == "float" || actual == "string" || actual == "eof"
+      if word_token && !literal_or_eof {
+        throw("`\{actual}` is a reserved word and cannot be used as a function name; write `r#\{actual}` to use it as a name at #\{pos}")
+      } else {
+        throw("expected function name after 'fn', got '\{actual}' at #\{pos}")
+      }
+    }
+  }
+}
+
 export fn parse_fn_signature(tokens: Array[Token], pos: Int) -> ((String, Array[String], Array[(String, Array[String])]), (Array[(String, Option[TypeExpr])], TypeExpr, Option[String]), (Array[Expr], Array[Expr]), Int) with Exception {
-  let (name, name_next) = parse_binding_name(tokens, pos)
+  let (name, name_next) = parse_fn_name(tokens, pos)
   let (tps, tbs, after_gen) = parse_value_bracket_header(tokens, name_next)
   let lp = expect_tk(tokens, after_gen, "(")
   let (params, after_params) = parse_param_list(tokens, lp)


### PR DESCRIPTION
## Summary

- use a function-declaration-specific name parser instead of the `let` binding helper
- classify word-shaped hard-keyword tokens as reserved function names
- attach the failing token index so located diagnostics point at the keyword itself
- suggest the supported raw-name escape (`r#name`)

## User impact

`fn guard(...)` now reports at the `guard` token:

```text
line 2:4: `guard` is a reserved word and cannot be used as a function name; write `r#guard` to use it as a name
```

It no longer points at the start of the declaration or says `expected name after 'let'`.

## Validation

- parser test file: 72/72 pass
- `pkf run test-local`: 444/444 selected tests pass
- formatter, review-derived AST lint, architecture lint, and lock check pass

Closes #1692