### PR TITLE
fix(wasm-gc): validate native struct ref lanes

### DIFF
--- a/fixtures/gc_native_struct_ref_field_fallback_test.vibe
+++ b/fixtures/gc_native_struct_ref_field_fallback_test.vibe
@@ -10,6 +10,41 @@ struct Bag {
   items: Array[Int]
 }
 
+// An exported function keeps the tagged-i64 ABI. A native struct cannot put
+// that result directly into its reference field, so this binding must fall
+// back as a whole instead of failing a reference-lane proof during codegen.
+export fn tagged_items() -> Array[Int] {
+  [
+    3,
+    4
+  ]
+}
+
+fn call_initialized_field() -> Int {
+  let b = Bag::{
+    label: "call", items: tagged_items()
+  }
+  Array::get(b.items, 0) + Array::get(b.items, 1)
+}
+
+// The names are deliberately identical while the representations disagree.
+// Nominal construction of ScalarShape must not select RefShape merely because
+// RefShape appeared first in the ctor table.
+struct RefShape {
+  value: Array[Int]
+}
+
+struct ScalarShape {
+  value: Int
+}
+
+fn nominal_scalar_shape() -> Int {
+  let s = ScalarShape::{
+    value: 9
+  }
+  s.value
+}
+
 // The field is read into a plain binding, so the reference would have to become
 // a value.
 fn aliased_field() -> Int {
@@ -39,4 +74,6 @@ fn escaping_bag() -> Bag {
 test "reference-lane fields that leave receiver position keep the linear layout" {
   inspect(aliased_field(), "2")
   inspect(Array::get(escaping_bag().items, 0), "7")
+  inspect(call_initialized_field(), "7")
+  inspect(nominal_scalar_shape(), "9")
 }

--- a/fixtures/gc_native_struct_ref_field_test.vibe
+++ b/fixtures/gc_native_struct_ref_field_test.vibe
@@ -13,7 +13,7 @@
 
 struct Bag {
   label: String;
-  items: Array[Int]
+  mut items: Array[Int]
 }
 
 fn bag_total() -> Int {
@@ -24,6 +24,10 @@ fn bag_total() -> Int {
       5
     ]
   }
+  b.items = [
+    40,
+    5
+  ]
   Array::set(b.items, 0, 40)
   Array::get(b.items, 0) + Array::get(b.items, 1) + Array::length(b.items)
 }

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -351,6 +351,26 @@ fn gc_expr_is_native_array_ref(expr: Expr, local_names: Array[String], ctx: Comp
   }
 }
 
+/// Whether `gc_compile_native_array_ref` can produce `expr` on the reference
+/// lane at this program point. This is deliberately stricter than "has type
+/// Array": calls that retain the tagged-i64 ABI cannot be converted implicitly.
+export fn gc_expr_can_compile_native_array_ref(expr: Expr, local_names: Array[String], ctx: CompileCtxGc) -> Bool {
+  match expr {
+    EIdent(name, _) => {
+      let slot = find_local_slot(local_names, name)
+      slot >= 0 && array_contains_int(ctx.gc_native_array_locals, slot)
+    },
+    EArray(_) => true,
+    EDot(EIdent(ns_obj, _), ns_field, _, _) => gc_ctor_field_is_ref(ctx.gc_ctor_table, gc_slot_map_get(ctx.gc_native_struct_scope, find_local_slot(local_names, ns_obj)), ns_field),
+    ECall(EIdent(name, _), _, _) => {
+      let idx = gc_direct_abi_call_index(ctx, name)
+      idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx)
+    },
+    EIf(_, then_e, else_e) => gc_expr_can_compile_native_array_ref(then_e, local_names, ctx) && gc_expr_can_compile_native_array_ref(else_e, local_names, ctx),
+    _ => false
+  }
+}
+
 /// Values that ALREADY inhabit the reference lane here, as opposed to values
 /// whose representation their consumer still picks. A bare `[1, 2]` is the
 /// second kind: `gc_compile_native_array_ref` will happily give it a native
@@ -769,6 +789,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
           let ns_struct_idx = gc_slot_map_get(ctx.gc_native_struct_scope, ns_slot)
           if ns_struct_idx >= 0 {
             let ns_declared = Array::get(ctx.gc_ctor_table.struct_field_names, ns_struct_idx)
+            let ns_field_refs = Array::get(ctx.gc_ctor_table.struct_field_is_ref, ns_struct_idx)
             let mut ns_fidx = 0 - 1
             let mut ns_i = 0
             while ns_i < Array::length(ns_declared) {
@@ -785,7 +806,11 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
               ()
             }
             emit_local_get(buf, ns_slot)
-            let ns_nl = ce(buf, Array::get(args, 2), local_names, next_local, ld)
+            let ns_nl = if Array::get(ns_field_refs, ns_fidx) {
+              gc_compile_native_array_ref(buf, Array::get(args, 2), local_names, next_local, ctx, ld, ce)
+            } else {
+              ce(buf, Array::get(args, 2), local_names, next_local, ld)
+            }
             emit_struct_set(buf, ctx.gc_native_struct_type_base + ns_struct_idx, ns_fidx)
             emit_i64_const(buf, 1)
             return ns_nl

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -191,7 +191,7 @@ import ./backend_builtins_string_extra.vibe {
 }
 
 import ./backend_call.vibe {
-  compile_call_gc, gc_compile_native_array_ref, gc_join_is_native_ref
+  compile_call_gc, gc_compile_native_array_ref, gc_expr_can_compile_native_array_ref, gc_join_is_native_ref
 }
 
 import ./backend_lambda_body.vibe {
@@ -647,43 +647,56 @@ fn gc_native_array_children_are_safe(expr: Expr, name: String, abi_names: Array[
 /// #1542: reading a reference-lane FIELD yields a reference, not a tagged i64,
 /// so unlike a scalar field it cannot be handed to arbitrary code. Only the
 /// receiver position of a native array op consumes it correctly.
-fn gc_native_struct_ref_field_reads_are_ops(expr: Expr, name: String, ctx: CompileCtxGc, ns_struct_idx: Int) -> Bool {
+fn gc_native_struct_ref_field_reads_are_ops(expr: Expr, name: String, ctx: CompileCtxGc, ns_struct_idx: Int, local_names: Array[String]) -> Bool {
   match expr {
     EDot(EIdent(obj, _), field, _, _) => obj != name || !gc_ctor_field_is_ref(ctx.gc_ctor_table, ns_struct_idx, field),
     ECall(EIdent(fname, _), args, _) => {
-      let is_op = (fname == "Array::length" && Array::length(args) == 1) || (fname == "Array::get" && Array::length(args) == 2) || (fname == "Array::set" && Array::length(args) == 3)
-      let mut ok = true
-      let mut i = 0
-      while i < Array::length(args) {
-        let arg = Array::get(args, i)
-        let receiver_ok = i == 0 && is_op && (match arg {
-          EDot(EIdent(obj2, _), _, _, _) => obj2 == name,
-          _ => false
-        })
-        if !receiver_ok && !gc_native_struct_ref_field_reads_are_ops(arg, name, ctx, ns_struct_idx) {
-          ok = false
-        } else {
-          ()
+      if fname == "__set_field" && Array::length(args) == 3 {
+        match (Array::get(args, 0), Array::get(args, 1)) {
+          (EIdent(obj, _), EString(field)) => if obj == name && gc_ctor_field_is_ref(ctx.gc_ctor_table, ns_struct_idx, field) {
+            gc_expr_can_compile_native_array_ref(Array::get(args, 2), local_names, ctx)
+          } else {
+            gc_native_struct_ref_field_reads_are_ops(Array::get(args, 2), name, ctx, ns_struct_idx, local_names)
+          },
+          _ => gc_native_struct_ref_field_children_are_ops(expr, name, ctx, ns_struct_idx, local_names)
         }
-        i = i + 1
+      } else {
+        let is_op = (fname == "Array::length" && Array::length(args) == 1) || (fname == "Array::get" && Array::length(args) == 2) || (fname == "Array::set" && Array::length(args) == 3)
+        let mut ok = true
+        let mut i = 0
+        while i < Array::length(args) {
+          let arg = Array::get(args, i)
+          let receiver_ok = i == 0 && is_op && (match arg {
+            EDot(EIdent(obj2, _), _, _, _) => obj2 == name,
+            _ => false
+          })
+          if !receiver_ok && !gc_native_struct_ref_field_reads_are_ops(arg, name, ctx, ns_struct_idx, local_names) {
+            ok = false
+          } else {
+            ()
+          }
+          i = i + 1
+        }
+        ok
       }
-      ok
     },
-    _ => {
-      let children = expr_children(expr)
-      let mut i = 0
-      let mut ok = true
-      while i < Array::length(children) {
-        if !gc_native_struct_ref_field_reads_are_ops(Array::get(children, i), name, ctx, ns_struct_idx) {
-          ok = false
-        } else {
-          ()
-        }
-        i = i + 1
-      }
-      ok
-    }
+    _ => gc_native_struct_ref_field_children_are_ops(expr, name, ctx, ns_struct_idx, local_names)
   }
+}
+
+fn gc_native_struct_ref_field_children_are_ops(expr: Expr, name: String, ctx: CompileCtxGc, ns_struct_idx: Int, local_names: Array[String]) -> Bool {
+  let children = expr_children(expr)
+  let mut i = 0
+  let mut ok = true
+  while i < Array::length(children) {
+    if !gc_native_struct_ref_field_reads_are_ops(Array::get(children, i), name, ctx, ns_struct_idx, local_names) {
+      ok = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  ok
 }
 
 fn gc_native_struct_scope_is_safe(expr: Expr, name: String) -> Bool {
@@ -741,19 +754,103 @@ fn gc_native_struct_children_are_safe(expr: Expr, name: String) -> Bool {
 /// names no declared struct (an anonymous record has no declared field order to
 /// fix a struct type to) or has no fields (a zero-field struct type is not
 /// reserved and buys nothing).
-fn gc_native_struct_binding_index(ctx: CompileCtxGc, fields: Array[(String, Expr)]) -> Int {
+fn gc_native_struct_field_set_matches(declared: Array[String], fields: Array[(String, Expr)]) -> Bool {
+  if Array::length(declared) != Array::length(fields) {
+    false
+  } else {
+    let mut di = 0
+    let mut all = true
+    while di < Array::length(declared) {
+      let target = Array::get(declared, di)
+      let mut fi = 0
+      let mut found = false
+      while fi < Array::length(fields) {
+        let (fname, _) = Array::get(fields, fi)
+        if fname == target {
+          found = true
+          fi = Array::length(fields)
+        } else {
+          fi = fi + 1
+        }
+      }
+      if !found {
+        all = false
+      } else {
+        ()
+      }
+      di = di + 1
+    }
+    all
+  }
+}
+
+fn gc_native_struct_binding_index(ctx: CompileCtxGc, record_name: String, fields: Array[(String, Expr)]) -> Int {
   if Array::length(fields) == 0 {
     0 - 1
-  } else {
-    let lit_names = array_empty()
-    let mut i = 0
-    while i < Array::length(fields) {
-      let (fname, _) = Array::get(fields, i)
-      Array::push(lit_names, fname)
-      i = i + 1
+  } else if String::length(record_name) > 0 {
+    let mut si = 0
+    let mut found = 0 - 1
+    while si < Array::length(ctx.gc_ctor_table.struct_names) {
+      if Array::get(ctx.gc_ctor_table.struct_names, si) == record_name {
+        found = si
+        si = Array::length(ctx.gc_ctor_table.struct_names)
+      } else {
+        si = si + 1
+      }
     }
-    struct_index_by_field_set(ctx.gc_ctor_table, lit_names)
+    found
+  } else {
+    // Anonymous records have only shape evidence. Fail closed when more than
+    // one nominal struct shares that shape, because their wasm field lanes may
+    // differ even though their names do not.
+    let mut si = 0
+    let mut found = 0 - 1
+    while si < Array::length(ctx.gc_ctor_table.struct_names) {
+      if gc_native_struct_field_set_matches(Array::get(ctx.gc_ctor_table.struct_field_names, si), fields) {
+        if found >= 0 {
+          return 0 - 1
+        } else {
+          found = si
+        }
+      } else {
+        ()
+      }
+      si = si + 1
+    }
+    found
   }
+}
+
+fn gc_native_struct_ref_initializers_are_compatible(ctx: CompileCtxGc, ns_struct_idx: Int, fields: Array[(String, Expr)], local_names: Array[String]) -> Bool {
+  let declared = Array::get(ctx.gc_ctor_table.struct_field_names, ns_struct_idx)
+  let refs = Array::get(ctx.gc_ctor_table.struct_field_is_ref, ns_struct_idx)
+  let mut di = 0
+  let mut ok = true
+  while di < Array::length(declared) {
+    if Array::get(refs, di) {
+      let target = Array::get(declared, di)
+      let mut fi = 0
+      let mut compatible = false
+      while fi < Array::length(fields) {
+        let (fname, value) = Array::get(fields, fi)
+        if fname == target {
+          compatible = gc_expr_can_compile_native_array_ref(value, local_names, ctx)
+          fi = Array::length(fields)
+        } else {
+          fi = fi + 1
+        }
+      }
+      if !compatible {
+        ok = false
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    di = di + 1
+  }
+  ok
 }
 
 fn gc_arg_is_reference_join(arg: Expr) -> Bool {
@@ -1251,49 +1348,51 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       match value {
         // #1702: a record literal bound to a local that never leaves field-read
         // position lives in a real wasm-gc struct instead of linear memory.
-        ERecord(_, ns_fields, _) => if ctx.gc_native_struct_type_base >= 0 && ctx.gc_native_array_frame_ok && gc_native_struct_binding_index(ctx, ns_fields) >= 0 && gc_native_struct_scope_is_safe(body, name) && gc_native_struct_ref_field_reads_are_ops(body, name, ctx, gc_native_struct_binding_index(ctx, ns_fields)) {
-          let ns_struct_idx = gc_native_struct_binding_index(ctx, ns_fields)
-          let ns_declared = Array::get(ctx.gc_ctor_table.struct_field_names, ns_struct_idx)
-          let ns_field_refs = Array::get(ctx.gc_ctor_table.struct_field_is_ref, ns_struct_idx)
-          gc_slot_map_set(ctx.gc_native_struct_scope, local_idx, ns_struct_idx)
-          gc_slot_map_set(ctx.gc_native_struct_decl, local_idx, ns_struct_idx)
-          // struct.new takes its fields as operands, so they go on the stack in
-          // DECLARED order however the literal spelled them.
-          let mut ns_nl = next_local + 1
-          let mut ns_di = 0
-          while ns_di < Array::length(ns_declared) {
-            let ns_target = Array::get(ns_declared, ns_di)
-            let mut ns_fi = 0
-            let mut ns_emitted = false
-            while ns_fi < Array::length(ns_fields) {
-              let (ns_fname, ns_fval) = Array::get(ns_fields, ns_fi)
-              if !ns_emitted && ns_fname == ns_target {
-                // #1542: a field declared `Array[Int]` holds `(ref null $array)`,
-                // so its operand has to be produced on the reference lane rather
-                // than as a tagged i64.
-                ns_nl = if Array::get(ns_field_refs, ns_di) {
-                  gc_compile_native_array_ref(buf, ns_fval, local_names, ns_nl, ctx, ld, ce)
+        ERecord(ns_name, ns_fields, _) => {
+          let ns_struct_idx = gc_native_struct_binding_index(ctx, ns_name, ns_fields)
+          if ctx.gc_native_struct_type_base >= 0 && ctx.gc_native_array_frame_ok && ns_struct_idx >= 0 && gc_native_struct_ref_initializers_are_compatible(ctx, ns_struct_idx, ns_fields, local_names) && gc_native_struct_scope_is_safe(body, name) && gc_native_struct_ref_field_reads_are_ops(body, name, ctx, ns_struct_idx, local_names) {
+            let ns_declared = Array::get(ctx.gc_ctor_table.struct_field_names, ns_struct_idx)
+            let ns_field_refs = Array::get(ctx.gc_ctor_table.struct_field_is_ref, ns_struct_idx)
+            gc_slot_map_set(ctx.gc_native_struct_scope, local_idx, ns_struct_idx)
+            gc_slot_map_set(ctx.gc_native_struct_decl, local_idx, ns_struct_idx)
+            // struct.new takes its fields as operands, so they go on the stack in
+            // DECLARED order however the literal spelled them.
+            let mut ns_nl = next_local + 1
+            let mut ns_di = 0
+            while ns_di < Array::length(ns_declared) {
+              let ns_target = Array::get(ns_declared, ns_di)
+              let mut ns_fi = 0
+              let mut ns_emitted = false
+              while ns_fi < Array::length(ns_fields) {
+                let (ns_fname, ns_fval) = Array::get(ns_fields, ns_fi)
+                if !ns_emitted && ns_fname == ns_target {
+                  // #1542: a field declared `Array[Int]` holds `(ref null $array)`,
+                  // so its operand has to be produced on the reference lane rather
+                  // than as a tagged i64.
+                  ns_nl = if Array::get(ns_field_refs, ns_di) {
+                    gc_compile_native_array_ref(buf, ns_fval, local_names, ns_nl, ctx, ld, ce)
+                  } else {
+                    ce(buf, ns_fval, local_names, ns_nl, ld)
+                  }
+                  ns_emitted = true
                 } else {
-                  ce(buf, ns_fval, local_names, ns_nl, ld)
+                  ()
                 }
-                ns_emitted = true
+                ns_fi = ns_fi + 1
+              }
+              if !ns_emitted {
+                throw("gc native struct: literal is missing declared field")
               } else {
                 ()
               }
-              ns_fi = ns_fi + 1
+              ns_di = ns_di + 1
             }
-            if !ns_emitted {
-              throw("gc native struct: literal is missing declared field")
-            } else {
-              ()
-            }
-            ns_di = ns_di + 1
+            emit_struct_new(buf, ctx.gc_native_struct_type_base + ns_struct_idx)
+            emit_local_set(buf, local_idx)
+            ce(buf, body, local_names, ns_nl, ld)
+          } else {
+            gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
           }
-          emit_struct_new(buf, ctx.gc_native_struct_type_base + ns_struct_idx)
-          emit_local_set(buf, local_idx)
-          ce(buf, body, local_names, ns_nl, ld)
-        } else {
-          gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
         },
         EArray(native_elems) => if ctx.gc_native_array_frame_ok && ctx.gc_native_array_type_idx >= 0 && gc_native_array_body_is_safe_tail(body, name, ctx.gc_direct_abi_current_return_ref, ctx) {
           // This local is a `(ref null $native_i64_array)`, never an i64.

--- a/lib/@vibe/compiler/codegen/gc/index.vpkg
+++ b/lib/@vibe/compiler/codegen/gc/index.vpkg
@@ -53,3 +53,4 @@ fn record_lambda_meta_gc(ctx: CompileCtxGc, lam_buf: Bytes, user_params: Int, ca
 // operand is produced by the same helper that produces a reference-lane call
 // argument -- two spellings of "put this value on the lane" would drift.
 fn gc_compile_native_array_ref(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, ce: (Bytes, Expr, Array[String], Int, Int) -> Int with Exception) -> Int with Exception
+fn gc_expr_can_compile_native_array_ref(expr: Expr, local_names: Array[String], ctx: CompileCtxGc) -> Bool

--- a/scripts/test_gc_heap_accounting.sh
+++ b/scripts/test_gc_heap_accounting.sh
@@ -382,18 +382,19 @@ fi
 # declared `Array[Int]` now has the wasm type `(mut (ref null $array))`, so
 # struct types are registered per DECLARED STRUCT rather than per field count.
 #
-# The positive fixture allocates ONE native array and puts it in the field, then
-# mutates through the field -- a field that copied on the way in would still
-# report the right length and the wrong value. Its fallback pair reads the field
-# out of receiver position and keeps the linear layout for the whole record.
+# The positive fixture allocates one native array for the initializer and one
+# for a subsequent mutable-field replacement, then mutates through the field --
+# a field that copied on either store would still report the right length and
+# the wrong value. Its fallback pair reads the field out of receiver position
+# and keeps the linear layout for the whole record.
 REF_FIELD_OUT="$WORK/native_struct_ref_field.wasm"
 REF_FIELD_FALLBACK_OUT="$WORK/native_struct_ref_field_fallback.wasm"
 compile_direct_abi_fallback fixtures/gc_native_struct_ref_field_test.vibe "$REF_FIELD_OUT"
 compile_direct_abi_fallback fixtures/gc_native_struct_ref_field_fallback_test.vibe "$REF_FIELD_FALLBACK_OUT"
 ref_field_native="$(count_native_array_allocs "$REF_FIELD_OUT")"
 ref_field_fallback_native="$(count_native_array_allocs "$REF_FIELD_FALLBACK_OUT")"
-if [ "$ref_field_native" -ne 1 ] || [ "$ref_field_fallback_native" -ne 0 ]; then
-  echo "[gc-heap-accounting] FAIL: expected one #1542 reference-lane field array and none in its fallback, found $ref_field_native/$ref_field_fallback_native" >&2
+if [ "$ref_field_native" -ne 2 ] || [ "$ref_field_fallback_native" -ne 0 ]; then
+  echo "[gc-heap-accounting] FAIL: expected two #1542 reference-lane field arrays and none in its fallback, found $ref_field_native/$ref_field_fallback_native" >&2
   exit 1
 fi
 # The representation claim: the struct type itself declares a typed reference


### PR DESCRIPTION
## Summary

Follow up on the actionable review findings from #1739 after that PR merged:

- compile mutable native-struct reference-field stores on the reference lane
- fall back the whole record when a reference-field initializer or later store lacks native-lane proof
- resolve named record literals by their nominal struct name and reject ambiguous anonymous shapes

## Root cause

Native-struct eligibility was based on field-name shape and usage, but did not prove that every reference-field producer could emit a Wasm reference. Field stores also always used the tagged-i64 compiler path. With same-shaped nominal structs, the first shape match could select a declaration with a different field representation.

## Regression coverage

- mutable `Array[Int]` field replacement with an array literal
- exported/tagged array-returning initializer falling back to the linear record
- same-shaped structs whose fields use scalar versus reference lanes

## Validation

- `RUSTUP_TOOLCHAIN=1.95.0 pkf run test-gc-heap-accounting`
- `RUSTUP_TOOLCHAIN=1.95.0 bash scripts/precommit.sh`
- `pkf run test` passed through the compiler/selfhost/GC gates; the existing macOS scheduler prototype later stopped at `xargs: command line cannot be assembled, too long`

Follow-up to #1739.
