### PR TITLE
fix(wasm-gc): stop a self-recursive export from switching off the island (#1750)

### DIFF
--- a/fixtures/gc_direct_array_export_recursive_test.vibe
+++ b/fixtures/gc_direct_array_export_recursive_test.vibe
@@ -1,0 +1,41 @@
+// #1750: a SELF-RECURSIVE exported array function no longer switches the lane
+// off for everything beside it.
+//
+// #1722 gives an exported declaration a private reference twin. The original and
+// the twin share one body AST, so the tagged copy's self-call resolved to the
+// reference twin and handed it a tagged parameter -- the component then failed
+// closed, which is one declaration silently disabling the island for its
+// neighbours: the exact shape #1541's coexistence work exists to remove.
+//
+// Such a declaration now simply gets no twin. It keeps the tagged lane it was
+// already on, and `double_first` below still crosses on the reference lane --
+// that is what the single native allocation proves.
+
+export let walk: (Array[Int]) -> Array[Int] = (values) -> {
+  if Array::get(values, 0) > 0 {
+    Array::set(values, 0, Array::get(values, 0) - 1)
+    walk(values)
+  } else {
+    values
+  }
+}
+
+fn double_first(values: Array[Int]) -> Unit {
+  Array::set(values, 0, Array::get(values, 0) * 2)
+}
+
+test "a self-recursive export leaves its neighbours on the reference lane" {
+  let xs = [
+    3,
+    9
+  ]
+  let out = walk(xs)
+  inspect(Array::get(out, 0), "0")
+  inspect(Array::get(xs, 1), "9")
+  let ys = [
+    5,
+    1
+  ]
+  double_first(ys)
+  inspect(Array::get(ys, 0), "10")
+}

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -663,7 +663,19 @@ fn gc_add_ref_twins(stmts: Array[Stmt]) -> Unit {
       // the component just fell back to tagged i64 with nothing to show why.
       SLet(_, is_rec, name, ann, value) => if gc_direct_abi_name_is_exported(stmts, name) {
         match ann {
-          Some(t) => if gc_type_mentions_array(t) && gc_name_is_called_in_stmts(stmts, name) {
+          // #1750: a SELF-RECURSIVE exported function gets no twin. The
+          // original and the twin share one body AST, so the tagged copy's
+          // self-call would resolve to the reference twin, hand it a tagged
+          // parameter, and fail the whole component closed -- one declaration
+          // silently switching the lane off for everything beside it, which is
+          // the exact shape #1541 spent its coexistence work removing.
+          //
+          // Skipping the twin costs this declaration its monomorphization and
+          // nothing else: it stays on the tagged lane it was already on, and
+          // its neighbours keep the island. Threading the current function's
+          // identity into the shared lookups would let even this one cross, and
+          // that is what #1750 tracks.
+          Some(t) => if gc_type_mentions_array(t) && gc_name_is_called_in_stmts(stmts, name) && !gc_name_is_called(value, name) {
             match value {
               EFn(_, _, _, _, _, _) => Array::push(twins, SLet(false, is_rec, String::concat(name, "$ref"), Some(t), value)),
               _ => ()

--- a/scripts/test_gc_heap_accounting.sh
+++ b/scripts/test_gc_heap_accounting.sh
@@ -124,6 +124,12 @@ LIST_TWIN_OUT="$WORK/direct_array_export_list_twin.wasm"
 compile_direct_abi_fallback fixtures/gc_direct_array_export_monomorph_test.vibe "$MONOMORPH_OUT"
 compile_direct_abi_fallback fixtures/gc_direct_array_export_twin_test.vibe "$TWIN_OUT"
 compile_direct_abi_fallback fixtures/gc_direct_array_export_list_twin_test.vibe "$LIST_TWIN_OUT"
+# #1750: a self-recursive exported function gets no twin -- the tagged copy's
+# self-call would otherwise resolve to the reference twin and fail the whole
+# component closed. The one allocation here belongs to its NEIGHBOUR, which is
+# the point: one unmonomorphizable declaration must not switch off the island.
+RECURSIVE_EXPORT_OUT="$WORK/direct_array_export_recursive.wasm"
+compile_direct_abi_fallback fixtures/gc_direct_array_export_recursive_test.vibe "$RECURSIVE_EXPORT_OUT"
 # #1541 isolated direct-argument characterization. The native fixture crosses
 # exactly one private concrete Array[Int] parameter boundary; the generic pair
 # must retain the component-wide tagged-i64 fallback.
@@ -361,6 +367,11 @@ fi
 monomorph_native="$(count_native_array_allocs "$MONOMORPH_OUT")"
 twin_native="$(count_native_array_allocs "$TWIN_OUT")"
 list_twin_native="$(count_native_array_allocs "$LIST_TWIN_OUT")"
+recursive_export_native="$(count_native_array_allocs "$RECURSIVE_EXPORT_OUT")"
+if [ "$recursive_export_native" -ne 1 ]; then
+  echo "[gc-heap-accounting] FAIL: expected a self-recursive export to leave one neighbouring native literal on the lane, found $recursive_export_native" >&2
+  exit 1
+fi
 if [ "$monomorph_native" -ne 1 ] || [ "$twin_native" -ne 1 ] || [ "$list_twin_native" -ne 1 ]; then
   echo "[gc-heap-accounting] FAIL: expected one #1722 native literal per monomorphized export, found $monomorph_native/$twin_native/$list_twin_native" >&2
   exit 1


### PR DESCRIPTION
#1739 のレビュー指摘 4 件のうち、**まだ直っていない 4 件目**だけを扱う。

> **範囲を縮小した。** 当初この PR は指摘 1〜3 (参照フィールドへのストア / 証明の無い初期化子 /
> field set の先勝ち解決) も含んでいたが、**#1747 が先に main へ入っていた**ので重複分は捨てた。
> とくに finding 3 は #1747 の解 (record の nominal 名で解決する) の方が私の案
> (曖昧な集合を拒否する) より良い。残ったのは 4 件目だけ。

## 症状 — 起票時の記述を実測で訂正する

レビューは proof mismatch と書いていたが、実際は **component 全体の fallback** で fail-closed
していた。自己再帰する `export let walk: (Array[Int]) -> Array[Int]` を `VIBE_BACKEND=gc` で
コンパイルした実測:

| | 結果 |
|---|---|
| validate | **通る** |
| 実行 | **正しい値** |
| native alloc | **0** |
| 参照を運ぶ署名 | **0** |

不正モジュールにはならない。代わりに**モジュール内の他の宣言まで含めてレーンが丸ごと切れる**。

## なぜ起きるか

#1722 は export された宣言に private な参照双子を与えるが、**元関数と双子は 1 つの body AST を
共有する**。tagged 側のコピーの中の自己呼び出しが参照双子に解決され、tagged パラメータを
渡そうとする → 受理がその crossing を拒否 → component ごと fail-closed。

これは**1 つの宣言が黙って隣の島を消す**形で、#1541 の共存作業が繰り返し消してきたものと同じ。

## 直し方

自己再帰する export には**双子を作らない**。その宣言は元から居た tagged レーンに留まり、
隣の宣言は島を保つ。

fixture が固定しているのは **隣の宣言の native alloc が 1 であること** — 再帰関数側に alloc が
無いことではない。主張が「巻き添えにしない」である以上、そちらを見ないと意味がない。

## 残る enhancement (#1750 に残す)

再帰する宣言**自体**もレーンに乗せるには、共有ルックアップに**現在コンパイル中の関数の同一性**を
渡して、`f` のコンパイル中は `f` が `f$ref` に解決されないようにする必要がある。ルックアップは
3 系統 + 受理経路にあるので、規則を 1 箇所に置かないと #1722 で 2 回踏んだのと同じずれ方をする。

## 検証 (CI と同じ方法)

- unit-test shard — green
- `check_vibe_fmt` 937 files clean
- `compiler_gate.sh` / `test_gc_heap_accounting.sh` / `test_gc_selfbuild.sh` 10/10 — green
- `lint_review_regressions.sh` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN