### PR TITLE
fix(wasm_runtime): #1745 — 抜けていた trap 条件を塞ぐ (範囲外 load/store・負アドレスでの host crash・div_s overflow)

### DIFF
--- a/lib/@vibex/wasm_runtime/spec_trap_test.vibe
+++ b/lib/@vibex/wasm_runtime/spec_trap_test.vibe
@@ -1,0 +1,153 @@
+// Trap conditions (#1745).
+//
+// These were found by running the SAME module bytes through this interpreter
+// and through the host platform's WebAssembly engine and comparing: 538 cases
+// over the i32 opcodes, memory, and select, of which 532 already agreed. The
+// six that did not are pinned here, plus the negative-address case that used
+// to kill the host process before it could be compared at all.
+//
+// Expected results come from the wasm spec (and agree with the engine), not
+// from this implementation. A trap is `exit_code = 1` from
+// `exec_module_with_args`; the accompanying value is meaningless.
+//
+// Why none of this showed up before: every other test here asks only "what
+// value came back". A read past the end of memory returned 0, which is a
+// perfectly ordinary value, so "the guest read out of bounds" and "that byte
+// really was 0" were the same answer.
+
+//# Imports
+
+import ./wasm_runtime.vibe {
+  exec_module_with_args
+}
+
+import @vibex/wasm_wat_encoder {
+  compile
+}
+
+//# Functions
+
+fn args1(a: Int) -> Array[Int] {
+  let xs = Array::slice([
+    0
+  ], 0, 0)
+  Array::push(xs, a)
+  xs
+}
+
+fn args2(a: Int, b: Int) -> Array[Int] {
+  let xs = Array::slice([
+    0
+  ], 0, 0)
+  Array::push(xs, a)
+  Array::push(xs, b)
+  xs
+}
+
+/// `true` when the call trapped. `exec_module_with_args` reports a trap as a
+/// non-zero exit code, the same channel division by zero already used.
+fn traps(wasm: Bytes, args: Array[Int]) -> Bool {
+  let (ec, _) = exec_module_with_args(wasm, "f", args)
+  ec != 0
+}
+
+fn value(wasm: Bytes, args: Array[Int]) -> Int {
+  let (ec, res) = exec_module_with_args(wasm, "f", args)
+  if ec != 0 {
+    -99999
+  } else {
+    res
+  }
+}
+
+/// One linear memory of a single page, so the last in-bounds i32 address is
+/// 65536 - 4 = 65532.
+fn mem_module(body: String) -> Bytes {
+  compile("(module (memory 1) (func (export \"f\") (param i32) (result i32) " + body + "))")
+}
+
+fn load_i32_module() -> Bytes {
+  mem_module("local.get 0 i32.load")
+}
+
+fn load8_u_module() -> Bytes {
+  mem_module("local.get 0 i32.load8_u")
+}
+
+fn store_i32_module() -> Bytes {
+  mem_module("local.get 0 i32.const 7 i32.store local.get 0 i32.load")
+}
+
+fn div_s_module() -> Bytes {
+  compile("(module (func (export \"f\") (param i32 i32) (result i32) local.get 0 local.get 1 i32.div_s))")
+}
+
+//# Tests
+
+test "spec trap: i32.load inside the page does not trap" {
+  assert(value(load_i32_module(), args1(0)) == 0)
+  assert(value(load_i32_module(), args1(65532)) == 0)
+}
+
+test "spec trap: i32.load straddling the end of memory traps" {
+  // Starts in bounds, ends one byte past. Returned 0 before -- the case a
+  // check written as `addr < length` cannot see.
+  assert(traps(load_i32_module(), args1(65533)))
+  assert(traps(load_i32_module(), args1(65534)))
+  assert(traps(load_i32_module(), args1(65535)))
+}
+
+test "spec trap: i32.load past the end of memory traps" {
+  assert(traps(load_i32_module(), args1(65536)))
+  assert(traps(load_i32_module(), args1(70000)))
+}
+
+test "spec trap: a wasm address is unsigned, so a negative host value is huge" {
+  // wasm memory addresses are unsigned i32: -1 on the operand stack means
+  // 0xFFFFFFFF. Indexing `Bytes` at -1 used to trap the HOST -- an
+  // uncatchable process exit driven by a value the guest picks.
+  assert(traps(load_i32_module(), args1(-1)))
+  assert(traps(load_i32_module(), args1(-4)))
+  assert(traps(load_i32_module(), args1(-2147483648)))
+}
+
+test "spec trap: narrower loads use their own width" {
+  // 65535 is the last addressable byte, so a byte load there is fine while an
+  // i32 load at the same address is not.
+  assert(value(load8_u_module(), args1(65535)) == 0)
+  assert(traps(load8_u_module(), args1(65536)))
+  assert(traps(load8_u_module(), args1(-1)))
+}
+
+test "spec trap: out-of-bounds stores trap instead of being discarded" {
+  // The store used to be silently dropped, so the guest saw a successful write
+  // that never happened.
+  assert(value(store_i32_module(), args1(0)) == 7)
+  assert(value(store_i32_module(), args1(65532)) == 7)
+  assert(traps(store_i32_module(), args1(65533)))
+  assert(traps(store_i32_module(), args1(65536)))
+  assert(traps(store_i32_module(), args1(-1)))
+}
+
+test "spec trap: i32.div_s traps on overflow, not just on zero" {
+  // The spec traps div_s when the divisor is zero OR the division overflows.
+  // Only the zero case was implemented, so INT_MIN / -1 returned the
+  // two's-complement wrap (INT_MIN) where the engine traps.
+  assert(traps(div_s_module(), args2(-2147483648, -1)))
+  assert(traps(div_s_module(), args2(7, 0)))
+  assert(traps(div_s_module(), args2(-2147483648, 0)))
+  // Neighbours that must NOT trap, so the new condition is not over-broad.
+  assert(value(div_s_module(), args2(-2147483648, 1)) == -2147483648)
+  assert(value(div_s_module(), args2(-2147483647, -1)) == 2147483647)
+  assert(value(div_s_module(), args2(2147483647, -1)) == -2147483647)
+  assert(value(div_s_module(), args2(-7, -1)) == 7)
+}
+
+test "spec trap: i32.rem_s does NOT trap on overflow" {
+  // Same operands as the div_s overflow case. The spec singles out div_s
+  // here: rem_s(INT_MIN, -1) is 0, not a trap.
+  let rem =
+  compile("(module (func (export \"f\") (param i32 i32) (result i32) local.get 0 local.get 1 i32.rem_s))")
+  assert(value(rem, args2(-2147483648, -1)) == 0)
+  assert(traps(rem, args2(7, 0)))
+}

--- a/lib/@vibex/wasm_runtime/spec_trap_test.vibe
+++ b/lib/@vibex/wasm_runtime/spec_trap_test.vibe
@@ -35,6 +35,12 @@ fn args1(a: Int) -> Array[Int] {
   xs
 }
 
+fn args0() -> Array[Int] {
+  Array::slice([
+    0
+  ], 0, 0)
+}
+
 fn args2(a: Int, b: Int) -> Array[Int] {
   let xs = Array::slice([
     0
@@ -80,6 +86,10 @@ fn store_i32_module() -> Bytes {
 
 fn div_s_module() -> Bytes {
   compile("(module (func (export \"f\") (param i32 i32) (result i32) local.get 0 local.get 1 i32.div_s))")
+}
+
+fn folded_int_min_div_s_module() -> Bytes {
+  compile("(module (func (export \"f\") (result i32) i32.const 2147483647 i32.const 1 i32.add i32.const -1 i32.div_s))")
 }
 
 //# Tests
@@ -141,6 +151,12 @@ test "spec trap: i32.div_s traps on overflow, not just on zero" {
   assert(value(div_s_module(), args2(-2147483647, -1)) == 2147483647)
   assert(value(div_s_module(), args2(2147483647, -1)) == -2147483647)
   assert(value(div_s_module(), args2(-7, -1)) == 7)
+}
+
+test "spec trap: i32.div_s normalizes computed operands before overflow check" {
+  // i32.add leaves 0x80000000 in the host stack as positive 2147483648.
+  // div_s must interpret that low-32-bit value as signed INT_MIN.
+  assert(traps(folded_int_min_div_s_module(), args0()))
 }
 
 test "spec trap: i32.rem_s does NOT trap on overflow" {

--- a/lib/@vibex/wasm_runtime/wasm_runtime.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime.vibe
@@ -18,6 +18,18 @@ fn br_to(block_stack: Array[(Int, Int)], depth: Int) -> Int {
   }
 }
 
+/// Interpret the low 32 bits of a host `Int` as a signed wasm i32.
+/// Arithmetic opcodes can leave values such as 0x80000000 in their unsigned
+/// host representation, while wasm's signed opcodes must see INT_MIN.
+fn signed_i32(n: Int) -> Int {
+  let v = n&0xFFFFFFFF
+  if v >= 0x80000000 {
+    v - 0x100000000
+  } else {
+    v
+  }
+}
+
 fn clz32(n: Int) -> Int {
   let v = n&0xFFFFFFFF
   if v == 0 {
@@ -834,8 +846,8 @@ export fn exec_body(code: Bytes, pc_start: Int, pc_end: Int, locals: Array[Int],
       let b = stack_pop(stack); stack_push(stack, stack_pop(stack) * b)
     }
     else if op == 0x6D {
-      let b = stack_pop(stack)
-      let a = stack_pop(stack)
+      let b = signed_i32(stack_pop(stack))
+      let a = signed_i32(stack_pop(stack))
       // The spec traps i32.div_s on division by zero OR on overflow. Only the
       // zero case was here, so INT_MIN / -1 returned the two's-complement
       // wrap (INT_MIN again) where the engine traps (#1745).
@@ -1487,8 +1499,8 @@ export fn exec_body_gc(code: Bytes, pc_start: Int, pc_end: Int, locals: Array[In
       let b = stack_pop(stack); stack_push(stack, stack_pop(stack) * b)
     }
     else if op == 0x6D {
-      let b = stack_pop(stack)
-      let a = stack_pop(stack)
+      let b = signed_i32(stack_pop(stack))
+      let a = signed_i32(stack_pop(stack))
       // The spec traps i32.div_s on division by zero OR on overflow. Only the
       // zero case was here, so INT_MIN / -1 returned the two's-complement
       // wrap (INT_MIN again) where the engine traps (#1745).

--- a/lib/@vibex/wasm_runtime/wasm_runtime.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime.vibe
@@ -408,8 +408,31 @@ export fn opcode_name(op: Int) -> String {
   }
 }
 
+/// wasm memory addresses are UNSIGNED i32. The operand stack carries them as
+/// host `Int`s, so `0xFFFFFFFF` arrives here as `-1` -- a huge address, not a
+/// backwards one. Mask before use: without this the bounds checks below are
+/// bypassed entirely and `m[-1]` takes the whole host process down with an
+/// uncatchable trap, on an address the guest chooses (#1745).
+fn mem_addr(raw: Int, off: Int) -> Int {
+  (raw&0xFFFFFFFF) + off
+}
+
+/// An access must lie entirely inside the memory, so `width` (the access size
+/// in bytes) is part of the question. An access that STARTS in bounds and runs
+/// off the end still traps -- address 65533 of a one-page memory is in bounds
+/// for a byte and out of bounds for an i32.
+fn mem_in_bounds(m: Bytes, a: Int, width: Int) -> Bool {
+  (a >= 0) && ((a + width) <= Bytes::length(m))
+}
+
+// The mem_load_*/mem_store_* helpers return a value (or Unit), so they have no
+// way to say "this trapped" -- which is why out-of-bounds used to read as 0 and
+// write as a silent no-op, making "the guest read past the end" and "that byte
+// really was 0" the same answer. The bounds decision now lives at the opcode
+// dispatch, where `exit_code = 1` is reachable; these keep their old clamping
+// only as a second line of defence for a caller that skips the check.
 fn mem_load_i32(m: Bytes, a: Int) -> Int {
-  if (a + 4) > Bytes::length(m) {
+  if (a < 0) || ((a + 4) > Bytes::length(m)) {
     0
   } else {
     m[a]|(m[a + 1]<<8)|(m[a + 2]<<16)|(m[a + 3]<<24)
@@ -570,7 +593,7 @@ export fn disassemble(code: Bytes, start: Int, end_pos: Int) -> Array[String] {
 }
 
 fn mem_load_i8_s(m: Bytes, a: Int) -> Int {
-  if a >= Bytes::length(m) {
+  if (a < 0) || (a >= Bytes::length(m)) {
     0
   }
   else {
@@ -584,13 +607,13 @@ fn mem_load_i8_s(m: Bytes, a: Int) -> Int {
 }
 
 fn mem_store_i16(m: Bytes, a: Int, v: Int) -> Unit {
-  if (a + 2) <= Bytes::length(m) {
+  if (a >= 0) && ((a + 2) <= Bytes::length(m)) {
     Bytes::set(m, a, v&0xFF); Bytes::set(m, a + 1, (v>>8)&0xFF)
   }
 }
 
 fn mem_store_i32(m: Bytes, a: Int, v: Int) -> Unit {
-  if (a + 4) <= Bytes::length(m) {
+  if (a >= 0) && ((a + 4) <= Bytes::length(m)) {
     Bytes::set(m, a, v&0xFF); Bytes::set(m, a + 1, (v>>8)&0xFF); Bytes::set(m, a + 2, (v>>16)&0xFF); Bytes::set(m, a + 3, (v>>24)&0xFF)
   }
 }
@@ -600,7 +623,7 @@ fn mem_store_i64(m: Bytes, a: Int, v: Int) -> Unit {
 }
 
 fn mem_load_i16_s(m: Bytes, a: Int) -> Int {
-  if (a + 2) > Bytes::length(m) {
+  if (a < 0) || ((a + 2) > Bytes::length(m)) {
     0
   }
   else {
@@ -614,7 +637,7 @@ fn mem_load_i16_s(m: Bytes, a: Int) -> Int {
 }
 
 fn mem_load_i16_u(m: Bytes, a: Int) -> Int {
-  if (a + 2) > Bytes::length(m) {
+  if (a < 0) || ((a + 2) > Bytes::length(m)) {
     0
   } else {
     m[a]|(m[a + 1]<<8)
@@ -811,7 +834,12 @@ export fn exec_body(code: Bytes, pc_start: Int, pc_end: Int, locals: Array[Int],
       let b = stack_pop(stack); stack_push(stack, stack_pop(stack) * b)
     }
     else if op == 0x6D {
-      let b = stack_pop(stack); let a = stack_pop(stack); if b == 0 {
+      let b = stack_pop(stack)
+      let a = stack_pop(stack)
+      // The spec traps i32.div_s on division by zero OR on overflow. Only the
+      // zero case was here, so INT_MIN / -1 returned the two's-complement
+      // wrap (INT_MIN again) where the engine traps (#1745).
+      if (b == 0) || ((a == -2147483648) && (b == -1)) {
         exit_code = 1
       } else {
         stack_push(stack, a / b)
@@ -1117,68 +1145,118 @@ export fn exec_body(code: Bytes, pc_start: Int, pc_end: Int, locals: Array[Int],
       stack_push(stack, stack_pop(stack)&0xFFFFFFFF)
     }
     else if op == 0x28 {
-      let (_, np) = read_uleb128(code, pc); let (off, np2) = read_uleb128(code, np); pc = np2; stack_push(stack, mem_load_i32(memory, stack_pop(stack) + off))
+      let (_, np) = read_uleb128(code, pc)
+      let (off, np2) = read_uleb128(code, np)
+      pc = np2
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 4) {
+        stack_push(stack, mem_load_i32(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x29 {
-      let (_, np) = read_uleb128(code, pc); let (off, np2) = read_uleb128(code, np); pc = np2; stack_push(stack, mem_load_i64(memory, stack_pop(stack) + off))
+      let (_, np) = read_uleb128(code, pc)
+      let (off, np2) = read_uleb128(code, np)
+      pc = np2
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 8) {
+        stack_push(stack, mem_load_i64(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x36 {
-      let (_, np) = read_uleb128(code, pc); let (off, np2) = read_uleb128(code, np); pc = np2; let v = stack_pop(stack); mem_store_i32(memory, stack_pop(stack) + off, v)
+      let (_, np) = read_uleb128(code, pc)
+      let (off, np2) = read_uleb128(code, np)
+      pc = np2
+      let v = stack_pop(stack)
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 4) {
+        mem_store_i32(memory, addr, v)
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x37 {
-      let (_, np) = read_uleb128(code, pc); let (off, np2) = read_uleb128(code, np); pc = np2; let v = stack_pop(stack); mem_store_i64(memory, stack_pop(stack) + off, v)
+      let (_, np) = read_uleb128(code, pc)
+      let (off, np2) = read_uleb128(code, np)
+      pc = np2
+      let v = stack_pop(stack)
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 8) {
+        mem_store_i64(memory, addr, v)
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x2D {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
-      let addr = stack_pop(stack) + off
-      stack_push(stack, if addr < Bytes::length(memory) {
-        memory[addr]
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 1) {
+        stack_push(stack, memory[addr])
       } else {
-        0
-      })
+        exit_code = 1
+      }
     }
     else if op == 0x3A {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
       let v = stack_pop(stack)
-      let addr = stack_pop(stack) + off
-      if addr < Bytes::length(memory) {
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 1) {
         Bytes::set(memory, addr, v&0xFF)
       } else {
-        ()
+        exit_code = 1
       }
     }
     else if op == 0x2C {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
-      let addr = stack_pop(stack) + off
-      stack_push(stack, mem_load_i8_s(memory, addr))
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 1) {
+        stack_push(stack, mem_load_i8_s(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x2E {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
-      let addr = stack_pop(stack) + off
-      stack_push(stack, mem_load_i16_s(memory, addr))
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 2) {
+        stack_push(stack, mem_load_i16_s(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x2F {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
-      let addr = stack_pop(stack) + off
-      stack_push(stack, mem_load_i16_u(memory, addr))
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 2) {
+        stack_push(stack, mem_load_i16_u(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x3B {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
       let v = stack_pop(stack)
-      let addr = stack_pop(stack) + off
-      mem_store_i16(memory, addr, v)
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 2) {
+        mem_store_i16(memory, addr, v)
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x11 {
       let (_, np) = read_uleb128(code, pc)
@@ -1409,7 +1487,12 @@ export fn exec_body_gc(code: Bytes, pc_start: Int, pc_end: Int, locals: Array[In
       let b = stack_pop(stack); stack_push(stack, stack_pop(stack) * b)
     }
     else if op == 0x6D {
-      let b = stack_pop(stack); let a = stack_pop(stack); if b == 0 {
+      let b = stack_pop(stack)
+      let a = stack_pop(stack)
+      // The spec traps i32.div_s on division by zero OR on overflow. Only the
+      // zero case was here, so INT_MIN / -1 returned the two's-complement
+      // wrap (INT_MIN again) where the engine traps (#1745).
+      if (b == 0) || ((a == -2147483648) && (b == -1)) {
         exit_code = 1
       } else {
         stack_push(stack, a / b)
@@ -1715,68 +1798,118 @@ export fn exec_body_gc(code: Bytes, pc_start: Int, pc_end: Int, locals: Array[In
       stack_push(stack, stack_pop(stack)&0xFFFFFFFF)
     }
     else if op == 0x28 {
-      let (_, np) = read_uleb128(code, pc); let (off, np2) = read_uleb128(code, np); pc = np2; stack_push(stack, mem_load_i32(memory, stack_pop(stack) + off))
+      let (_, np) = read_uleb128(code, pc)
+      let (off, np2) = read_uleb128(code, np)
+      pc = np2
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 4) {
+        stack_push(stack, mem_load_i32(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x29 {
-      let (_, np) = read_uleb128(code, pc); let (off, np2) = read_uleb128(code, np); pc = np2; stack_push(stack, mem_load_i64(memory, stack_pop(stack) + off))
+      let (_, np) = read_uleb128(code, pc)
+      let (off, np2) = read_uleb128(code, np)
+      pc = np2
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 8) {
+        stack_push(stack, mem_load_i64(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x36 {
-      let (_, np) = read_uleb128(code, pc); let (off, np2) = read_uleb128(code, np); pc = np2; let v = stack_pop(stack); mem_store_i32(memory, stack_pop(stack) + off, v)
+      let (_, np) = read_uleb128(code, pc)
+      let (off, np2) = read_uleb128(code, np)
+      pc = np2
+      let v = stack_pop(stack)
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 4) {
+        mem_store_i32(memory, addr, v)
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x37 {
-      let (_, np) = read_uleb128(code, pc); let (off, np2) = read_uleb128(code, np); pc = np2; let v = stack_pop(stack); mem_store_i64(memory, stack_pop(stack) + off, v)
+      let (_, np) = read_uleb128(code, pc)
+      let (off, np2) = read_uleb128(code, np)
+      pc = np2
+      let v = stack_pop(stack)
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 8) {
+        mem_store_i64(memory, addr, v)
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x2D {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
-      let addr = stack_pop(stack) + off
-      stack_push(stack, if addr < Bytes::length(memory) {
-        memory[addr]
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 1) {
+        stack_push(stack, memory[addr])
       } else {
-        0
-      })
+        exit_code = 1
+      }
     }
     else if op == 0x3A {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
       let v = stack_pop(stack)
-      let addr = stack_pop(stack) + off
-      if addr < Bytes::length(memory) {
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 1) {
         Bytes::set(memory, addr, v&0xFF)
       } else {
-        ()
+        exit_code = 1
       }
     }
     else if op == 0x2C {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
-      let addr = stack_pop(stack) + off
-      stack_push(stack, mem_load_i8_s(memory, addr))
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 1) {
+        stack_push(stack, mem_load_i8_s(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x2E {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
-      let addr = stack_pop(stack) + off
-      stack_push(stack, mem_load_i16_s(memory, addr))
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 2) {
+        stack_push(stack, mem_load_i16_s(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x2F {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
-      let addr = stack_pop(stack) + off
-      stack_push(stack, mem_load_i16_u(memory, addr))
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 2) {
+        stack_push(stack, mem_load_i16_u(memory, addr))
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x3B {
       let (_, np) = read_uleb128(code, pc)
       let (off, np2) = read_uleb128(code, np)
       pc = np2
       let v = stack_pop(stack)
-      let addr = stack_pop(stack) + off
-      mem_store_i16(memory, addr, v)
+      let addr = mem_addr(stack_pop(stack), off)
+      if mem_in_bounds(memory, addr, 2) {
+        mem_store_i16(memory, addr, v)
+      } else {
+        exit_code = 1
+      }
     }
     else if op == 0x11 {
       let (_, np) = read_uleb128(code, pc)


### PR DESCRIPTION
#1745 の (1)〜(4)。#1556 のカバレッジ調査で `exec_body_gc` が 143/358 だったので叩いた。

## 見つけ方: エンジンを正解にした差分テスト

`wat_encoder` で WAT をコンパイルし、**同じバイト列**を (a) このインタプリタ (b) node の `WebAssembly` で実行して突き合わせた。エンジンが正解なので、食い違いは必ずどちらかのバグになる。

i32 二項演算 25 種 × 20 引数 + 単項 4 種 + memory + select で **538 ケース、うち 532 件は元から一致**。数値演算は境界値込みで正しく、`i32.mul` が 62-bit host `Int` を溢れても低位 32 bit が保存されるので結果が合う点まで確認した。零除算も正しく trap する。以下が残りだった。

| | 修正前 | エンジン |
|---|---|---|
| `i32.load` @65533(4 バイトが末尾をはみ出す) | `0` | trap |
| `i32.load` @65536 | `0` | trap |
| `i32.load8_u` @65536 | `0` | trap |
| `i32.store` @65533 / @65536 | 黙って捨てる | trap |
| `i32.load` @`-1` | **host プロセスが死ぬ** | trap |
| `i32.div_s(INT_MIN, -1)` | `-2147483648` | trap |

## アドレスは符号なし i32 だった

wasm のメモリアドレスは符号なしなので、オペランドスタックの `-1` は「後ろ向き」ではなく `0xFFFFFFFF` という**巨大アドレス**を意味する。境界検査が上端 (`(a + 4) > len`) しか見ていなかったので負値が素通りし、`m[-1]` に到達していた:

```
about to load at 65536      -> ec=0 res=0
about to load at -1
RuntimeError: unreachable       ← プロセスごと終了。"survived" に到達しない
```

**インタプリタは信用できない wasm を走らせるためのものなので、ゲストが選んだ値で host が捕捉不能に落ちるのは封じ込めの破れになる。**

`mem_addr(raw, off) = (raw & 0xFFFFFFFF) + off` でマスクし、`mem_in_bounds(m, a, width)` で幅込みに判定する。幅を持たせたのは「始点は in-bounds だが末尾がはみ出す」(65533 の i32 load) を落とすため — `addr < length` という書き方では原理的に見えない case。

## trap を伝える経路が無かった

`mem_load_*` / `mem_store_*` は値(または `Unit`)を返すので、trap を表現できない。これが「範囲外読み出しが 0」「範囲外書き込みが no-op」の正体で、**「範囲外を読んだ」と「そこが本当に 0 だった」が同じ答え**になっていた。

判定を opcode ディスパッチ側へ移した — `exec_body` / `exec_body_gc` の memory opcode 10 種 × 2 = **20 サイト**で、既存の div-by-zero と同じ `exit_code = 1` を立てる。ヘルパ側の clamp は、検査を通さない呼び出し元に対する二重の防御として残し、負値も弾くようにした。

## div_s

spec は div_s の trap 条件を「除数 0 **または** overflow」と定めている。零除算だけが実装されていたので、条件に `(a == INT_MIN) && (b == -1)` を足した。

`rem_s` は同じ引数で trap **しない**(`0` を返す)のが spec 通りで、probe でも一致していたので触っていない。テストにその区別も固定した。

## 検証

- 差分ハーネスを再実行: **542 ケース、mismatch 0**、エンジンが拒否したモジュール 0。負アドレスのケースも host を落とさず完走するようになった
- `spec_trap_test.vibe`(8 tests)を追加。**期待値は spec / エンジンから取っており、この実装からは取っていない。** 過剰に trap していないことを確かめる近傍(`INT_MIN / 1`、`-2147483647 / -1`、`2147483647 / -1`、byte load @65535)も入れた
- **control**: 修正前のインタプリタに対して新テストを走らせ、落ちることを確認済み
- 既存の `@vibex/wasm_runtime` + `@vibex/wasm_wat_encoder` **175 tests 緑**
- `scripts/compiler_gate.sh` **完走 (exit 0)**、`scripts/vibe_fmt.sh --check` clean

## 含めていないもの

#1745 の (5)(検証が無いので不正なモジュールでも host が死ぬ)は入れていない。入口は **#1744**(エンコーダが折りたたみ形式のオペランドを黙って落とす)で、そちらと合わせて別スライスで扱うべきもの。差分ハーネスからも折りたたみ形式のケースを外してある(エンコーダが無効なモジュールを吐くので、このハーネスでは測れない)。

Refs #1745, #1744, #1556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_