### PR TITLE
fix(lint): distinguish AST runner failures

### DIFF
--- a/scripts/lint_review_regressions.sh
+++ b/scripts/lint_review_regressions.sh
@@ -90,6 +90,7 @@ if [ -n "$staged_paths" ] && [ "$grep_available" -eq 1 ]; then
       || ! printf '%s\n' "$ast_output" | rg -q '^review-lint:finding\t'; then
       # The runner also uses exit 1 for bootstrap and compile failures. Only a
       # completed lint result with machine-identifiable findings is filterable.
+      ast_tool_error=1
       violations="$ast_output"
     else
       # `vibe grep` sees the complete staged file so it can match multiline AST
@@ -153,7 +154,7 @@ else
     ')"
 fi
 
-if [ -n "$violations" ]; then
+if [ -n "$violations" ] || [ "$ast_tool_error" -eq 1 ]; then
   if [ "$ast_tool_error" -eq 1 ]; then
     echo "review-regressions lint: the AST scan did not run (no finding was made)" >&2
   else

--- a/scripts/lint_review_regressions_test.sh
+++ b/scripts/lint_review_regressions_test.sh
@@ -164,7 +164,7 @@ EOF
 git -C "$TMP_ROOT" add .
 git -C "$TMP_ROOT" commit -qm historical-violation
 cat >> "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe" <<'EOF'
-fn unrelated(e: Expr) -> Expr { e }
+// Documentation-only edit: the historical binder above is unchanged.
 EOF
 git -C "$TMP_ROOT" add .
 
@@ -246,6 +246,38 @@ fi
 if ! rg -q 'bootstrap failed before lint execution' "$TMP_ROOT/runner-fail.out"; then
   echo "review-regressions lint self-test: runner failure diagnostic was lost" >&2
   cat "$TMP_ROOT/runner-fail.out" >&2
+  exit 1
+fi
+if ! rg -q 'the AST scan did not run' "$TMP_ROOT/runner-fail.out"; then
+  echo "review-regressions lint self-test: runner exit 1 was reported as a finding" >&2
+  cat "$TMP_ROOT/runner-fail.out" >&2
+  exit 1
+fi
+if rg -q 'structural regression\(s\) added' "$TMP_ROOT/runner-fail.out"; then
+  echo "review-regressions lint self-test: runner exit 1 accused the staged diff" >&2
+  cat "$TMP_ROOT/runner-fail.out" >&2
+  exit 1
+fi
+
+# A silent runner failure must also fail closed. In this case there is no
+# diagnostic text to make `violations` non-empty, so the tool-error flag itself
+# must drive the final exit status.
+cat > "$TMP_ROOT/fake-vibe-runner-silent-failure" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$TMP_ROOT/fake-vibe-runner-silent-failure"
+
+if VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" \
+  VIBE_REVIEW_LINT_GREP_BIN="$TMP_ROOT/fake-vibe-runner-silent-failure" \
+  VIBE_REVIEW_LINT_RUNNER="$TMP_ROOT/fake-vibe-runner-silent-failure" \
+  "$CHECK_SCRIPT" >"$TMP_ROOT/runner-silent-fail.out" 2>&1; then
+  echo "review-regressions lint self-test: silent runner exit 1 was ignored" >&2
+  exit 1
+fi
+if ! rg -q 'the AST scan did not run' "$TMP_ROOT/runner-silent-fail.out"; then
+  echo "review-regressions lint self-test: silent runner failure diagnostic was lost" >&2
+  cat "$TMP_ROOT/runner-silent-fail.out" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What changed

The review-regression lint now treats an AST runner exit without machine-readable finding markers as a tool failure, not as a structural violation. It remains fail-closed while reporting that the AST scan did not run.

The self-test also pins that edits outside historical debt are not accused of adding the existing finding.

## Validation

- review-regressions lint self-test passed
- precommit passed before rebase
- self-test passed again after rebase

Closes #1753