### PR TITLE
feat(async): eager Stream combinator 5 つを退役 (#1538 スコープ 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,13 @@ lib/@vibe/compiler/.generated.stamp
 *.diag
 !fixtures/warnings/*.diag
 __pycache__/
+
+# Local toolchain shim. `runtime/vibe` resolves its runner as
+# `$TOOLCHAIN_DIR/bin/viberun`, and with the repo root acting as the toolchain
+# dir that is `bin/viberun` here -- which is what makes `vibe grep` (and so
+# scripts/lint_review_regressions.sh's AST backend) resolvable locally after a
+# `cargo build --release` in runtime/viberun. It is a symlink INTO
+# runtime/viberun/target (itself ignored, line 4), so committing it would hand
+# everyone else a dangling link. `scripts/install.sh` writes the real one into
+# a toolchain dir outside the repo.
+/bin/viberun

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -353,7 +353,7 @@ corpus acc.json に (fn_name, local_branch_index) キーで union する。分�
   `analyze_purity` 等）を import するため分母外で無意味。
 - **direct-call drivers** (`coverage_drivers.sh`): seed の under-tested
   関数を crafted 入力で直接叩く。**黒箱 compile では構造的に踏めない category**:
-  - `cov_async.vibe`: inlined async/stream builtin (`Stream::map`/`await`/…)
+  - `cov_async.vibe`: inlined async/stream builtin (`Stream::next`/`await`/…)
     — examples に async プログラムが無い (+32)。`Task::*` を叩いていた分は
     #1227 の eager prototype 撤去で外した。
   - `cov_lookup.vibe`: builtin name→Type dispatch chain

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -83,7 +83,7 @@ vibe には `fn` の色付けが無く、副作用は effect row で表す。し
 
 | state | 意味 | payload | producer |
 |---|---|---|---|
-| 0 | ready | 値 | `Future::ready(x)` / `Stream::next` / `Stream::fold` |
+| 0 | ready | 値 | `Future::ready(x)` / `Stream::next` |
 | 1 | guest 内 pending | 未定 (resolve が書く) | `Future::pending()` |
 | 2 | host future (waitable) | host future handle | `host_future_get()` / `host_future_named("x")` |
 | 3 | host stream セル | readable end の handle | `host_stream_named("x")` |
@@ -252,7 +252,7 @@ ADR-0089 Decision 3) への一本化だが、**今日の実装には 3 つの表
 
 | 型 | 実行時表現 | 用途 | 位置づけ |
 |---|---|---|---|
-| `Stream[T]` | `Array[T]` (eager) | `empty`/`once`/`map`/`filter`/`fold`/`next`、`String::to_bytes`/`Stream::to_string` | **legacy**。ADR-0089 D3 で退役予定 |
+| `Stream[T]` | `Array[T]` (eager) | `next`、`String::to_bytes`/`Stream::to_string` | **legacy**。eager combinator (`empty`/`once`/`map`/`filter`/`fold`) は #1538 で**退役済み**。残るのは `next` (綴りは未決定) と ByteStream 対 |
 | `HostStream` | 2 語セル `[3, handle]` | `host_stream_named`/`host_stream_next`/`host_stream_close` | **generic named-host-stream 専用**の p3 境界実体。stream の readable handle 1本しか保持できず、completion future を伴う provider の所有/lifecycle は表せない (§3.18.3) |
 | AsyncIter | trait (`lib/@vibe/prelude/async_iter.vibe`) | `for x in it` の pull protocol | 目標形、host stream とは未接続 |
 
@@ -260,7 +260,8 @@ ADR-0089 Decision 3) への一本化だが、**今日の実装には 3 つの表
 よる: 同じ静的型だと `for` が array パスを選び、cell の 2 語 (state 3 +
 handle) を足して**それらしい小さい数**を返していた (期待 42 に対し 4)。
 診断も trap も無い最悪の失敗形だったので、**型で分けた**。今は
-`Stream::map` を host stream に適用すると型エラーになる。
+`Stream::next` を host stream に適用すると型エラーになる (host 側の読みは
+`host_stream_next`)。
 
 `for x in s { ... }` は iterand の型で eager ループか await ループかが決まる。
 **`for await` という別綴りは #1350 で廃止** — iteration が suspend しうる
@@ -591,12 +592,11 @@ wasmtime 45 で **42** を実測。
 `future_ready_expr` / `future_state_ready`）に変えた（#1230）。ready しか無い今も
 挙動は同じ（`await` は slot 1 を読むだけ）だが、**pending future を後から足すのに
 表現を作り直さなくて済む** — M1b-3c は `await` に slot 0 の分岐を生やすだけになる。
-future を作る側は `Future::ready` / `Stream::next` / `Stream::fold` の3つで、
+future を作る側は `Future::ready` / `Stream::next` の2つで、
 `Future[T]` を返す user-level コード（`lib/@vibe/prelude/async_iter.vibe` の
 `AsyncIterator::next`）は元から `Future::ready(..)` 経由なので影響しない。
-`Stream::fold` はこの変更まで `Array::fold` への名前 alias だったが、戻り値が
-`Future[A]` なので専用ブランチに分離した（`Stream::map`/`filter` は `Stream` を
-返すので alias のまま）。
+（#1538 以前は `Stream::fold` も future を作っていた。eager combinator ごと
+退役したので、この位置に残るのは上の2つだけ。）
 
 さらに `await` の lowering 位置を `compile_call.vibe` から **AST パス
 `await_poll_pass`** へ移した（#1230）。`compile_call` は wasm を直接吐く位置で、
@@ -1394,8 +1394,9 @@ cell の2語（state 3 + handle 1）を足していた。**診断も trap も出
 - `host_stream_next(HostStream) -> Int with Async`
 - `host_stream_close(HostStream) -> Unit`
 
-これで eager 用の `Stream::map` / `Stream::fold` / `Stream::to_string` を
-host stream に適用するのは**型エラー**になり、静かなゴミではなくなる。
+これで eager 用の `Stream::to_string` を host stream に適用するのは
+**型エラー**になり、静かなゴミではなくなる（記述当時は `Stream::map` /
+`Stream::fold` も同じ barrier の対象だったが、#1538 で退役した）。
 
 その上で desugar（`build_host_stream_for`, desugar_trait_dict.vibe）が
 `for` を read へ落とす:
@@ -1451,8 +1452,9 @@ lane（bytes を読むこと + `{ Async }` 無しの row が reject されるこ
 **#1538 の boundary slice（done）**: `HostStream` は routing key であると同時に、
 **legacy `Stream[T]` consumer への入力では barrier** である。checker は
 `HostStream` を期待する `Stream[T]` に渡すと型エラーにするので、
-`Stream::map` / `Stream::fold` / `Stream::to_string` と、同じ型を受け取る
-ユーザー定義関数は state-3 cell を eager array として読めない。この判定は
+`Stream::to_string` と、同じ型を受け取る
+ユーザー定義関数は state-3 cell を eager array として読めない
+（#1538 前は `Stream::map` / `Stream::fold` も同じ列にいた）。この判定は
 この二つの compiler-owned nominal name にだけ閉じており、`CtNamed` 全体の
 concreteness や通常の user-defined/generic nominal assignability は広げない。
 
@@ -1856,7 +1858,7 @@ wasmtime 46.0.1 リリースに合わせて ratified `wasi:http@0.3.0` への cu
 | 縦串 | 実体 | gate |
 |---|---|---|
 | async component の生成と実行 | `.vibe` の `() -> Int with Async` entry → async lift + trampoline → wasmtime 47 の production runtime (`runtime/viberun`) が `instantiate_async` / `run_concurrent` で駆動 | `test_async_component_gate.sh` |
-| ready future の await | `Future::ready` / `Stream::next` / `Stream::fold` → `[0, payload]`、`__aw_poll` が slot 1 を読む | 同上 (7 lane) |
+| ready future の await | `Future::ready` / `Stream::next` → `[0, payload]`、`__aw_poll` が slot 1 を読む | 同上 (7 lane) |
 | guest 内 pending future | `Future::pending()` → `[1, _]`、`Future::resolve` が完了、await は poll-wait で park。resolve → direct wake の waiter list 付き (§3.15) | `fixtures/async_future_pending.vibe` |
 | host future の await | `host_future_get()` / `host_future_named("x")` → `[2, handle]` → `Suspend(handle+2)` → boundary settle → adapter の `future.read` + `waitable-set.wait` | `test_hostfuture_source_component_gate.sh` / `test_named_hostfutures_component_gate.sh` |
 | 並行 await | 複数 host 操作を同時に in-flight (2×1000ms が 1015ms) | `test_concurrent_awaits_component_gate.sh` |

--- a/docs/wasip3-effect-alignment.md
+++ b/docs/wasip3-effect-alignment.md
@@ -355,7 +355,7 @@ trampoline を将来 `wasi:http/service` の
    **`for` からの消費も landed (#1366、spec §3.18.2)**: ただし戻り型を
    `Stream[Int]` から **`HostStream` へ分離した上で**。同一静的型のままだと
    `for` が eager array パスを選び cell の 2 語を足して**期待 42 に対し 4**
-   を返していた (診断も trap も無い)。型を分けたことで `Stream::map` 等を
+   を返していた (診断も trap も無い)。型を分けたことで eager combinator を
    host stream に適用すると型エラーになる。
    残り (D3 の続き): eager `Stream[T]` combinator の退役と AsyncIter への
    一本化 (#1538)、`ByteStream` の p3 接続 (#1539)、`Stream::next` protocol の

--- a/fixtures/async_await_multi.vibe
+++ b/fixtures/async_await_multi.vibe
@@ -23,21 +23,21 @@
 // Every future here is created ready, so the loop never runs -- what this pins
 // is that the hoist is correct wherever an await appears, and more than once.
 // 40 + 1 + 2 + 3 + 4 = 50.
+//
+// #1538 retired the eager `Stream::fold` / `once` these awaits used to be
+// spelled with. The shapes that matter here are the POSITIONS of the awaits --
+// let value, match scrutinee, tail operand, twice in one function -- not which
+// builtin produced the future, so `Future::ready` and the surviving
+// `Stream::next` over a ByteStream carry them just as well. `"!"` is byte 33.
 export let main = () -> Int with Async {
   let a = await(Future::ready(40))
-  let b = await(Stream::fold(Stream::once(1), 0, (acc, x) -> {
-    acc + x
-  }))
-  let c = await(Stream::fold(Stream::once(2), 0, (acc, x) -> {
-    acc + x
-  }))
-  let d = match await(Stream::next(Stream::once(3))) {
-    Some(v) => v,
+  let b = await(Future::ready(1))
+  let c = await(Future::ready(2))
+  let d = match await(Stream::next(String::to_bytes("!"))) {
+    Some(v) => v - 30,
     None => 0
   }
-  a + b + c + d + await(Stream::fold(Stream::once(4), 0, (acc, x) -> {
-    acc + x
-  }))
+  a + b + c + d + await(Future::ready(4))
 }
 
 // #1571: the expectation lives here, checked by `inspect` and updatable with

--- a/lib/@vibe/compiler/checker/builtins_async.vibe
+++ b/lib/@vibe/compiler/checker/builtins_async.vibe
@@ -101,23 +101,17 @@ fn lookup_future(name: String) -> Option[Type] {
   }
 }
 
-/// Stream[T] — a pull-based async iterator (WASI 0.3 stream<T>), the async
-/// sibling of Iterator (ADR-0044): the same combinator shape (map/filter/fold)
-/// as the sync Iterator, but `next` yields a Future and `fold` is Async.
+/// The `Stream`-headed builtins that survive #1538's retirement of the eager
+/// combinators, plus the `HostStream` reads.
+///
+/// `Stream::empty` / `once` / `map` / `filter` / `fold` are GONE: they were the
+/// eager prototype (a `Stream[T]` was a plain `Array[T]`), which ADR-0089
+/// Decision 3 retires in favour of AsyncIter. What remains under this head is
+/// `Stream::next` (the `Future[Option[T]]` protocol read, whose spelling on a
+/// host stream is still an open decision) and the `ByteStream` pair
+/// `String::to_bytes` / `Stream::to_string` in `lookup_bytestream` below.
 fn lookup_stream(name: String) -> Option[Type] {
-  if name == "Stream::empty" {
-    // Stream::empty: () -> Stream[T]   (pure)
-    Some(CtFn(async_no_params(), CtNamed("Stream", [
-      CtUnknown
-    ]), None))
-  } else if name == "Stream::once" {
-    // Stream::once: (T) -> Stream[T]   (pure; single-element stream)
-    Some(CtFn([
-      CtUnknown
-    ], CtNamed("Stream", [
-      CtUnknown
-    ]), None))
-  } else if name == "Stream::next" {
+  if name == "Stream::next" {
     // Stream::next: (Stream[T]) -> Future[Option[T]] with Async
     // None terminates the stream.
     Some(CtFn([
@@ -187,37 +181,6 @@ fn lookup_stream(name: String) -> Option[Type] {
     Some(CtFn([
       CtNamed("HostStream", array_empty())
     ], CtUnit, None))
-  } else if name == "Stream::map" {
-    // Stream::map: (Stream[T], (T) -> U) -> Stream[U]   (lazy)
-    Some(CtFn([
-      CtNamed("Stream", [
-        CtUnknown
-      ]),
-      CtUnknown
-    ], CtNamed("Stream", [
-      CtUnknown
-    ]), None))
-  } else if name == "Stream::filter" {
-    // Stream::filter: (Stream[T], (T) -> Bool) -> Stream[T]   (lazy)
-    Some(CtFn([
-      CtNamed("Stream", [
-        CtUnknown
-      ]),
-      CtUnknown
-    ], CtNamed("Stream", [
-      CtUnknown
-    ]), None))
-  } else if name == "Stream::fold" {
-    // Stream::fold: (Stream[T], A, (A, T) -> A) -> Future[A] with Async
-    Some(CtFn([
-      CtNamed("Stream", [
-        CtUnknown
-      ]),
-      CtUnknown,
-      CtUnknown
-    ], CtNamed("Future", [
-      CtUnknown
-    ]), Some("Async")))
   } else {
     None
   }

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -647,7 +647,7 @@ fn is_inlined_async_builtin(name: String) -> Bool {
   // straight-line top-level code). That is a DIFFERENT failure from the one
   // fixed here -- shadowing, not import gating -- and `encl` (#1114) is the
   // machinery that would have to cover it.
-  name == "await" || name == "Future::ready" || name == "Future::pending" || name == "Future::resolve" || name == "Stream::empty" || name == "Stream::once" || name == "Stream::map" || name == "Stream::filter" || name == "Stream::fold" || name == "Stream::next" || name == "String::to_bytes" || name == "Stream::to_string" || name == "Path::to_string" || name == "Path::is_absolute" || name == "Path::ref" || name == "Path::resolve" || name == "host_future_get" || name == "host_future_named" || name == "host_stream_named" || name == "host_stream_next" || name == "host_stream_close"
+  name == "await" || name == "Future::ready" || name == "Future::pending" || name == "Future::resolve" || name == "Stream::next" || name == "String::to_bytes" || name == "Stream::to_string" || name == "Path::to_string" || name == "Path::is_absolute" || name == "Path::ref" || name == "Path::resolve" || name == "host_future_get" || name == "host_future_named" || name == "host_stream_named" || name == "host_stream_next" || name == "host_stream_close"
 }
 
 /// #773: the scalar arithmetic/logic intrinsics ("not"/"add"/"sub"/"mul"/"lt")

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1050,7 +1050,7 @@ fn ts_known_int(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Bool wi
 /// `Future[T]` — the two-element array `[state, payload]`.
 ///
 /// Slot 0 is the state, slot 1 the value. Only `ready` (0) exists today: every
-/// in-tree future source (`Future::ready`, `Stream::next`, `Stream::fold`, and
+/// in-tree future source (`Future::ready`, `Stream::next`, and
 /// user code that returns `Future[T]` by calling `Future::ready`) resolves
 /// eagerly, so `await` reads slot 1 unconditionally. Carrying the state slot
 /// now is what lets a PENDING source be added without a second representation
@@ -1356,13 +1356,10 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
     } else {
       fname00
     }
-    // Stream[T] (docs/spec/wasi-p3-async.md §2.4) is backed by the eager Array
-    // machinery on the linear backend: map/fold reuse the existing inline
-    // Array::map / Array::fold lowering verbatim (same arg order, same value
-    // representation). empty/once/filter are handled explicitly below.
-    // Stream::fold is NOT aliased here: it returns `Future[A]`, so it needs its
-    // own branch below to wrap the fold's result (a bare alias would hand back
-    // the accumulator where a future is expected).
+    // #1538: the eager `Stream::empty` / `once` / `map` / `filter` / `fold`
+    // aliases used to live here, backed by the Array machinery. They are
+    // retired -- ADR-0089 Decision 3 makes AsyncIter the one iteration story.
+    // `Stream::next` and the `ByteStream` pair keep their own branches below.
     //
     // ADR-0090 Phase 1: MutList[T, r] is a checker-only phantom over the
     // same growable-array runtime layout ArrayBuilder uses, so push aliases
@@ -1371,9 +1368,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
     // in particular the two exits COPY (mutlist_exit_copy) instead of
     // aliasing, so these freeze rows are only a fallback for a call that got
     // past the checker with the wrong arity.
-    let fname = if fname0 == "Stream::map" {
-      "Array::map"
-    } else if fname0 == "MutList::push" {
+    let fname = if fname0 == "MutList::push" {
       "ArrayBuilder::push"
     } else if fname0 == "MutList::freeze" {
       "ArrayBuilder::freeze"
@@ -1845,94 +1840,6 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       }
       ce(buf, resolved, local_names, next_local, ctx, ld)
     }
-    else if !prefer_bound_call && fname == "Stream::empty" {
-      // Empty stream = empty backing array.
-      let (arr_new_fi, _, _) = resolve_func(ctx.func_table, "array_new")
-      emit_call(buf, arr_new_fi)
-      next_local
-    }
-    else if !prefer_bound_call && fname == "Stream::once" {
-      // Singleton stream = one-element backing array.
-      let (arr_new_fi, _, _) = resolve_func(ctx.func_table, "array_new")
-      let (arr_push_fi, _, _) = resolve_func(ctx.func_table, "Array::push")
-      let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
-      let val_l = nl
-      let arr_l = nl + 1
-      Array::push(local_names, "__once_val")
-      Array::push(local_names, "__once_arr")
-      emit_local_set(buf, val_l)
-      emit_call(buf, arr_new_fi)
-      emit_local_set(buf, arr_l)
-      emit_local_get(buf, arr_l)
-      emit_local_get(buf, val_l)
-      emit_call(buf, arr_push_fi)
-      emit_local_get(buf, arr_l)
-      nl + 2
-    }
-    else if !prefer_bound_call && fname == "Stream::filter" {
-      // Eager filter: walk the backing array, keep elements whose predicate is
-      // truthy. Mirrors the Array::map loop but pushes conditionally.
-      let (arr_new_fi, _, _) = resolve_func(ctx.func_table, "array_new")
-      let (arr_len_fi, _, _) = resolve_func(ctx.func_table, "Array::length")
-      let (arr_get_fi, _, _) = resolve_func(ctx.func_table, "Array::get")
-      let (arr_push_fi, _, _) = resolve_func(ctx.func_table, "Array::push")
-      let mut nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
-      nl = ce(buf, Array::get(args, 1), local_names, nl, ctx, ld)
-      let arr_l = nl
-      let fn_l = nl + 1
-      let res_l = nl + 2
-      let len_l = nl + 3
-      let i_l = nl + 4
-      let slot_l = nl + 5
-      let env_l = nl + 6
-      let elem_l = nl + 7
-      Array::push(local_names, "__filter_arr")
-      Array::push(local_names, "__filter_fn")
-      Array::push(local_names, "__filter_res")
-      Array::push(local_names, "__filter_len")
-      Array::push(local_names, "__filter_i")
-      Array::push(local_names, "__filter_slot")
-      Array::push(local_names, "__filter_env")
-      Array::push(local_names, "__filter_elem")
-      emit_local_set(buf, fn_l)
-      emit_local_set(buf, arr_l)
-      emit_call(buf, arr_new_fi)
-      emit_local_set(buf, res_l)
-      emit_local_get(buf, arr_l)
-      emit_call(buf, arr_len_fi)
-      emit_local_set(buf, len_l)
-      emit_i64_const(buf, 0)
-      emit_local_set(buf, i_l)
-      emit_closure_resolve(buf, fn_l, slot_l, env_l)
-      emit_block_void(buf)
-      emit_loop_void(buf)
-      emit_local_get(buf, i_l)
-      emit_local_get(buf, len_l)
-      emit_i64_ge_s(buf)
-      emit_br_if(buf, 1)
-      emit_local_get(buf, arr_l)
-      emit_local_get(buf, i_l)
-      emit_call(buf, arr_get_fi)
-      emit_local_set(buf, elem_l)
-      emit_local_get(buf, elem_l)
-      emit_closure_call_tail(buf, env_l, slot_l, 9, 1)
-      emit_i64_const(buf, 0)
-      emit_i64_ne(buf)
-      emit_if_void(buf)
-      emit_local_get(buf, res_l)
-      emit_local_get(buf, elem_l)
-      emit_call(buf, arr_push_fi)
-      emit_end(buf)
-      emit_local_get(buf, i_l)
-      emit_index_one(buf, ctx)
-      emit_i64_add(buf)
-      emit_local_set(buf, i_l)
-      emit_br(buf, 0)
-      emit_end(buf)
-      emit_end(buf)
-      emit_local_get(buf, res_l)
-      nl + 8
-    }
     else if !prefer_bound_call && fname == "Stream::next" {
       // Stream::next(s) : Future[Option[T]] (docs/spec §2.4). On the eager
       // Array-backed model `next` peeks the head: Some(s[0]) if non-empty else
@@ -1951,14 +1858,6 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
         ], -1)
       ], -1), ECall(EIdent("None", -1), array_empty(), -1)), -1)
       ce(buf, future_ready_expr(synth), local_names, next_local, ctx, ld)
-    }
-    else if !prefer_bound_call && fname == "Stream::fold" {
-      // Stream::fold(s, init, f) : Future[A] (docs/spec §2.4). The fold itself
-      // is the existing inline Array::fold lowering verbatim -- same arg order,
-      // same value representation -- so synthesize that call and wrap its
-      // result in a ready future. (Stream::map/filter return Streams, not
-      // futures, so they stay plain name aliases of the Array combinators.)
-      ce(buf, future_ready_expr(ECall(EIdent("Array::fold", -1), args, -1)), local_names, next_local, ctx, ld)
     }
     else if !prefer_bound_call && fname == "String::to_bytes" {
       // String::to_bytes(s) : Stream[Int]  (ByteStream, docs/spec §2.4/§4.1).

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1064,16 +1064,12 @@ fn infer_arg_type_name(arg: Expr, struct_sets: Array[(String, Array[String])], v
       EIdent("Map::insert", _) => Some("Map"),
       EIdent("Map::delete", _) => Some("Map"),
       EIdent("MapBuilder::freeze", _) => Some("Map"),
-      // Stream-returning builtins (ADR-0012 eager Array-backed model): lets
-      // `for x in Stream::once(v)` — or a let-bound stream via
-      // extend_var_types — classify as "Stream" so the for-loop classification
-      // lowers it to the plain array loop instead of the pull-closure loop
-      // (#822: the pull desugar called the stream value as a closure —
-      // call_indirect on an array pointer = table OOB trap).
-      EIdent("Stream::once", _) => Some("Stream"),
-      EIdent("Stream::empty", _) => Some("Stream"),
-      EIdent("Stream::map", _) => Some("Stream"),
-      EIdent("Stream::filter", _) => Some("Stream"),
+      // The one Stream-returning builtin left after #1538 retired the eager
+      // combinators: `for b in String::to_bytes(s)` — or a let-bound
+      // ByteStream via extend_var_types — must classify as "Stream" so the
+      // for-loop classification lowers it to the plain array loop instead of
+      // the pull-closure loop (#822: the pull desugar called the stream value
+      // as a closure — call_indirect on an array pointer = table OOB trap).
       EIdent("String::to_bytes", _) => Some("Stream"),
       EIdent(fname, _) => ctor_enum_of_name(fn_returns, fname),
       // `let x: T = e` is desugared to `((__asc: T) -> __asc)(e)` (ascribe_wrap);

--- a/lib/@vibe/compiler/tests/checker_async_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_async_test.vibe
@@ -87,10 +87,15 @@ test "await inside EFn without effect annotation reports error" {
 
 // --- Stream[T] (async iterator) ---
 
-/// `Stream::next(Stream::empty())`
+/// `Stream::next(String::to_bytes(""))`
+///
+/// #1538 retired the eager producers (`Stream::empty` / `once`), so the one
+/// remaining way to spell a `Stream[Int]` is the ByteStream half.
 fn stream_next_call() -> Expr {
   ECall(EIdent("Stream::next", -1), [
-    ECall(EIdent("Stream::empty", -1), array_empty(), -1)
+    ECall(EIdent("String::to_bytes", -1), [
+      EString("")
+    ], -1)
   ], -1)
 }
 
@@ -104,15 +109,43 @@ test "Stream::next is a registered effectful builtin (Async)" {
   }
 }
 
-test "Stream::empty and Stream::map are registered pure builtins" {
+/// #1538: the eager combinators are RETIRED. They must not resolve at all --
+/// a lingering registration would keep the eager Array-backed model reachable
+/// and let `Stream[T]` grow a second meaning next to AsyncIter.
+test "the eager Stream combinators no longer resolve (#1538)" {
   match lookup_builtin("Stream::empty") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match lookup_builtin("Stream::once") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match lookup_builtin("Stream::map") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match lookup_builtin("Stream::filter") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match lookup_builtin("Stream::fold") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
+/// The ByteStream pair survives and stays pure -- it is the only producer of a
+/// `Stream[Int]` left, so `Stream::next` above depends on it.
+test "the ByteStream pair is still registered (#1538)" {
+  match lookup_builtin("String::to_bytes") {
     Some(ty) => match ty {
       CtFn(_, _, None) => assert(true),
       _ => assert(false)
     },
     None => assert(false)
   }
-  match lookup_builtin("Stream::map") {
+  match lookup_builtin("Stream::to_string") {
     Some(ty) => match ty {
       CtFn(_, _, None) => assert(true),
       _ => assert(false)

--- a/lib/@vibe/compiler/tests/checker_nominal_head_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_nominal_head_test.vibe
@@ -59,8 +59,17 @@ test "1538: HostStream is rejected by a legacy Stream consumer" {
   assert(check_source_err("fn consume(s: Stream[Int]) -> Int { 0 }\nfn main() -> Int { consume(host_stream_named(\"body\")) }"))
 }
 
-test "1538: an eager Stream still reaches its legacy consumer" {
-  assert(check_source_ok("fn consume(s: Stream[Int]) -> Int { 0 }\nfn main() -> Int { consume(Stream::once(42)) }"))
+/// #1538 retired the eager producers; `String::to_bytes` is the ByteStream half
+/// that keeps the `Stream[Int]` head inhabited, so a `Stream[Int]` parameter is
+/// still writable and still reachable.
+test "1538: a Stream[Int] parameter still reaches its ByteStream producer" {
+  assert(check_source_ok("fn consume(s: Stream[Int]) -> Int { 0 }\nfn main() -> Int { consume(String::to_bytes(\"*\")) }"))
+}
+
+/// The retired names must not resolve -- an unknown name is the error now.
+test "1538: the eager Stream combinators are gone" {
+  assert(check_source_err("fn main() -> Int { let s = Stream::once(42); 0 }"))
+  assert(check_source_err("fn main() -> Int { let s = Stream::empty(); 0 }"))
 }
 
 test "1538: HostStream retains its direct read lane" {
@@ -74,7 +83,7 @@ test "1539: exact StdinStream token is accepted" {
 test "1539: StdinStream cannot cross Int, HostStream, Stream, or user-struct boundaries" {
   assert(check_source_err("fn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(1) }"))
   assert(check_source_err("fn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(host_stream_named(\"body\")) }"))
-  assert(check_source_err("fn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(Stream::once(1)) }"))
+  assert(check_source_err("fn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(String::to_bytes(\"a\")) }"))
   assert(check_source_err("struct Fake { value: Int }\nfn use(s: StdinStream) -> Int { 0 }\nfn run() -> Int { use(Fake::{ value: 1 }) }"))
   assert(check_source_err("fn use(i: Int) -> Int { i }\nfn run() -> Int with Stdin { use(Stdin::read_via_stream()) }"))
   assert(check_source_err("fn use(s: HostStream) -> Int { 0 }\nfn run() -> Int with Stdin { use(Stdin::read_via_stream()) }"))

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -76,11 +76,7 @@ StdinStream::close	linear-only	async-component-only	#1539 public lifecycle route
 StdinStream::next	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
 Stdout::write_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdout::write_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Stream::empty	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
-Stream::filter	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
-Stream::fold	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 Stream::next	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
-Stream::once	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 Stream::to_string	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 String::to_bytes	linear-only	gc-unported	served on linear (callsite arm/table); no gc arm yet -- gc compile of a user of this name fails loudly
 __float_bits	linear-only	linear-runtime-internal	linear-memory runtime helper; meaningless on the gc heap

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -2707,7 +2707,7 @@ let consume: (Stream[Int]) -> Int = (s) -> {
   }
   sum
 }
-export let _start: () -> Int = () -> { consume(Stream::once(42)) }
+export let _start: () -> Int = () -> { consume(String::to_bytes("*")) }
 EOF
 cat > "$fadir/ok_unannot.vibe" <<'EOF'
 let consume = (s) -> Int {
@@ -2717,7 +2717,7 @@ let consume = (s) -> Int {
   }
   sum
 }
-export let _start: () -> Int = () -> { consume(Stream::once(42)) }
+export let _start: () -> Int = () -> { consume(String::to_bytes("*")) }
 EOF
 # #1350 (Codex P1): the pull-closure loop must fire only when the source
 # POSITIVELY returns a function. A call to a function whose return annotation
@@ -3113,13 +3113,13 @@ EOF
 # #827: Stream[T] is CtNamed (head 0 = tolerated), so the eager Array-backed
 # representation leaked through the Array builtins — these compiled AND ran.
 cat > "$tdir/bad_streamlen.vibe" <<'EOF'
-export let _start: () -> Int = () -> { Array::length(Stream::once(41)) }
+export let _start: () -> Int = () -> { Array::length(String::to_bytes("*")) }
 EOF
 cat > "$tdir/bad_streamget.vibe" <<'EOF'
-export let _start: () -> Int = () -> { Array::get(Stream::once(41), 0) }
+export let _start: () -> Int = () -> { Array::get(String::to_bytes("*"), 0) }
 EOF
 cat > "$tdir/bad_streamset.vibe" <<'EOF'
-export let _start: () -> Int = () -> { Array::set(Stream::once(41), 0, 1); 0 }
+export let _start: () -> Int = () -> { Array::set(String::to_bytes("*"), 0, 1); 0 }
 EOF
 # #805 (0.3.0 redundant-syntax removal): the `\(expr)` string-interpolation
 # spelling was removed — only `\{expr}` remains. A source using the old form

--- a/scripts/coverage/cov_async.vibe
+++ b/scripts/coverage/cov_async.vibe
@@ -7,15 +7,21 @@ import ../../lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compil
 // example/fixture program uses them, so the bulk corpus leaves every one dark.
 // Compile programs exercising each builtin so its compile_call branch runs.
 let cov_async_one: (String) -> Int = (src) -> {
-  handle { Bytes::length(compile_source_wasi_only(src, "main")) } with Exception { Throw(_) => 0 }
+  handle {
+    Bytes::length(compile_source_wasi_only(src, "main"))
+  } with Exception {
+    Throw(_) => 0
+  }
 }
 
 export let cov_async_main: () -> Int = () -> {
-  let progs = Array::slice([""], 0, 0)
+  let progs = Array::slice([
+    ""
+  ], 0, 0)
   Array::push(progs, "export let main: () -> Int = () -> { let f = Future::ready(7); await(f) }")
   Array::push(progs, "export let main: () -> Int = () -> { let bs = String::to_bytes(\"hello\"); Bytes::length(bs) }")
   Array::push(progs, "export let main: () -> Int = () -> { let s = String::to_bytes(\"h\"); let str = Stream::to_string(s); String::length(str) }")
-  Array::push(progs, "export let main: () -> Int = () -> { match Stream::next(String::to_bytes(\"A\")) { Som(x) => x.0, Non => 0 } }")
+  Array::push(progs, "export let main: () -> Int with Async = () -> { match await(Stream::next(String::to_bytes(\"A\"))) { Som(x) => x.0, Non => 0 } }")
   let mut acc = 0
   let mut i = 0
   while i < Array::length(progs) {

--- a/scripts/coverage/cov_async.vibe
+++ b/scripts/coverage/cov_async.vibe
@@ -13,12 +13,9 @@ let cov_async_one: (String) -> Int = (src) -> {
 export let cov_async_main: () -> Int = () -> {
   let progs = Array::slice([""], 0, 0)
   Array::push(progs, "export let main: () -> Int = () -> { let f = Future::ready(7); await(f) }")
-  Array::push(progs, "export let main: () -> Int = () -> { let s = Stream::empty(); let _ = s; 0 }")
-  Array::push(progs, "export let main: () -> Int = () -> { let s = Stream::once(3); match Stream::next(s) { Som(x) => x.0, Non => 0 } }")
-  Array::push(progs, "export let main: () -> Int = () -> { let s = Stream::map(Stream::once(4), _ * 2); match Stream::next(s) { Som(x) => x.0, Non => 0 } }")
-  Array::push(progs, "export let main: () -> Int = () -> { let s = Stream::filter(Stream::once(5), _ > 0); match Stream::next(s) { Som(x) => x.0, Non => 0 } }")
   Array::push(progs, "export let main: () -> Int = () -> { let bs = String::to_bytes(\"hello\"); Bytes::length(bs) }")
-  Array::push(progs, "export let main: () -> Int = () -> { let s = Stream::once(7); let str = Stream::to_string(s); String::length(str) }")
+  Array::push(progs, "export let main: () -> Int = () -> { let s = String::to_bytes(\"h\"); let str = Stream::to_string(s); String::length(str) }")
+  Array::push(progs, "export let main: () -> Int = () -> { match Stream::next(String::to_bytes(\"A\")) { Som(x) => x.0, Non => 0 } }")
   let mut acc = 0
   let mut i = 0
   while i < Array::length(progs) {

--- a/scripts/coverage/cov_lookup2.vibe
+++ b/scripts/coverage/cov_lookup2.vibe
@@ -156,16 +156,11 @@ let lk_names2: () -> Array[String] = () -> {
   Array::push(a, "Stdout::write_char")
   Array::push(a, "Stdout::write_stream")
   Array::push(a, "Stream")
-  Array::push(a, "Stream::empty")
-  Array::push(a, "Stream::filter")
-  Array::push(a, "Stream::fold")
-  Array::push(a, "Stream::map")
   a
 }
 let lk_names3: () -> Array[String] = () -> {
   let a = Array::slice([""], 0, 0)
   Array::push(a, "Stream::next")
-  Array::push(a, "Stream::once")
   Array::push(a, "Stream::to_string")
   Array::push(a, "String::char_code_at")
   Array::push(a, "String::concat")

--- a/scripts/test_async_component_gate.sh
+++ b/scripts/test_async_component_gate.sh
@@ -10,8 +10,7 @@
 #
 # Entries covered (spec milestone table M1b-3b / M-conc-1 / M2a / M2b / M2c):
 #   await      await(Future::ready(42))
-#   stream     Stream once / map / filter / fold (fold is async -> await)
-#   option     Stream::next Some/None
+#   option     Stream::next Some/None over a ByteStream ("*" = 42, "" = None)
 #   body       ByteStream consume: String::to_bytes fold
 #   roundtrip  Stream::to_string(String::to_bytes(...))
 #   control    non-async entry stays a core module (magic layer 0x01)
@@ -66,34 +65,26 @@ let run: () -> Int with Async = () -> {
   await(Future::ready(42))
 }
 EOF
-  cat >"$OUT_DIR/stream.vibe" <<'EOF'
-let run: () -> Int with Async = () -> {
-  let s = Stream::once(20)
-  let m = Stream::map(s, (x) -> { x * 2 })
-  let f = Stream::filter(m, (x) -> { x > 10 })
-  await(Stream::fold(f, 2, (acc, x) -> { acc + x }))
-}
-EOF
   cat >"$OUT_DIR/option.vibe" <<'EOF'
 let run: () -> Int with Async = () -> {
-  let a = match await(Stream::next(Stream::once(40))) {
+  let a = match await(Stream::next(String::to_bytes("*"))) {
     Some(v) => v,
     None => 0
   }
-  let b = match await(Stream::next(Stream::empty())) {
-    Some(v) => v,
-    None => 1
-  }
-  let c = match await(Stream::next(Stream::once(1))) {
+  let b = match await(Stream::next(String::to_bytes(""))) {
     Some(v) => v,
     None => 0
   }
-  a + b + c
+  a + b
 }
 EOF
   cat >"$OUT_DIR/body.vibe" <<'EOF'
 let run: () -> Int with Async = () -> {
-  await(Stream::fold(String::to_bytes("*"), 0, (acc, b) -> { acc + b }))
+  let mut acc = 0
+  for b in String::to_bytes("\n ") {
+    acc = acc + b
+  }
+  acc
 }
 EOF
   cat >"$OUT_DIR/roundtrip.vibe" <<'EOF'
@@ -104,7 +95,7 @@ let run: () -> Int with Async = () -> {
 EOF
   cat >"$OUT_DIR/forawait.vibe" <<'EOF'
 let run: () -> Int with Async = () -> {
-  let s = Stream::once(42)
+  let s = String::to_bytes("*")
   let mut sum = 0
   for x in s {
     sum = sum + x
@@ -158,7 +149,7 @@ run_component_42() {
 
 write_fixtures
 
-ENTRIES="await stream option body roundtrip forawait"
+ENTRIES="await option body roundtrip forawait"
 for name in $ENTRIES; do
   run_component_42 "$name"
 done

--- a/scripts/tests/coverage_drivers_test.sh
+++ b/scripts/tests/coverage_drivers_test.sh
@@ -30,6 +30,15 @@ while read -r entry file label; do
   }
 done <<< "$driver_rows"
 
+# `Stream::next` is effectful and returns a Future.  A coverage probe that
+# matches the Future directly is rejected by `check_program`; cov_async_one
+# catches that exception and returns 0, making the driver look healthy while
+# the intended codegen branch stays dark.
+grep -Fq 'export let main: () -> Int with Async = () -> { match await(Stream::next' scripts/coverage/cov_async.vibe || {
+  echo "coverage_drivers_test: Stream::next probe must await inside an Async entry" >&2
+  exit 1
+}
+
 # The one way a driver can still bind a compiler value WITHOUT asking for it:
 # the production merge leaves the ENTRY file's own top-level names unrenamed
 # (`transformed_file_stmts` returns the entry's statements as-is), so a bare


### PR DESCRIPTION
ADR-0089 Decision 3 は AsyncIter を唯一の反復の形とし、eager `Stream[T]` プロトタイプ
(`Stream[T]` = 素の `Array[T]`、combinator は Array 版への名前 alias) を退役させる、と
決めている。そのうち **`Stream::empty` / `once` / `map` / `filter` / `fold` の 5 つだけ**を
外す。それ以外は触らない。

## 意図的に残したもの

`Stream::next`、`String::to_bytes` / `Stream::to_string`、そして型 `Stream` 自体。

この issue に残る 2 つの決定 (ByteStream の行き先、host stream の read の綴り) は
そこに住んでいる。今回外す 5 つは**どの候補の綴りにも出てこない**ので、決定が着地しても
**この PR の内容を revisit する必要が無い**。

**むしろ `Stream::next` の退役は候補 1 の前提条件**であって障害ではない: checker には
builtin のオーバーロードが無い (`lookup_stream` は名前 1 つに型 1 つ) ので、
`(HostStream) -> Future[Option[Int]] with Async` は eager 版と同名で共存できない。
`next` を据え置くのはこの順序のため。

## 触った面

5 checker arm / 5 compile_call arm (`Stream::map` の名前 alias 含む) / 1 common_analysis /
4 desugar 分類 arm / 4 parity TSV 行 / 5 coverage probe / 2 unit-test ブロック /
3 gate レーン書き換え / 1 fixture / 4 docs。

**2 面は空だった** — eager combinator には `builtin_registry` の行が**元から無く**
(`lookup_async` のフォールバック連鎖だけで型付けされていた)、wasm-gc arm も無い。

コンパイラ外の呼び出し元は **fixture 3 つだけ**。`examples/` / `lib/@vibex/` /
`lib/@vibe/prelude/` にはゼロ。

## 書き換えは `String::to_bytes` (残る唯一の `Stream[Int]` 生成者) へ

- **`async_await_multi.vibe`** が pin しているのは await の**位置** (let 値 / match
  scrutinee / tail オペランド / 1 関数に複数) であって「どの builtin が future を作ったか」
  ではないので、`Future::ready` と `Stream::next` がそのまま担って **50 のまま**
- **`_gate_forawait`** と **#827 の array-op レーン**が見ているのは for-loop の分類と
  表現漏れで、combinator は付随物。`String::to_bytes("*")` はバイト 42 で、
  レーンが元から使っていた値と同じ
- **`test_async_component_gate.sh`** は `stream` エントリを落とす (主題が combinator 連鎖
  そのもの)。`option` は ByteStream 上の Some/None を維持、`body` は `fold` が無くなったので
  `for` でバイトを合計 (`"\n "` = 10 + 32 = 42)

## 新しいテストは「解決しないこと」を assert する

呼んでいる箇所が無いことではなく、**退役した名前が `lookup_builtin` で解決しないこと**を
留める。登録が残っていると eager モデルが到達可能なままになり、`Stream[T]` が AsyncIter
の隣で二つ目の意味を持ってしまう。

## 検証

- `bash scripts/compiler_gate.sh` — green
- `VIBE_STAGE2_WASM=<stage2> bash scripts/unit_test_runner.sh` — **621/621** green
- `bash scripts/test_async_component_gate.sh` — **5 エントリすべて 42** で pass
  (wasmtime / wasm-tools / wac を入れたのでこの環境で実走するようになった)

## 残るスコープ

2 (ByteStream の行き先) と 3 (host stream read の綴り) は**決定待ち**。
`Stream::fold` が消えたことで **ByteStream の終端消費者は `Stream::to_string` と `for`
だけ**になった点は、2 を決めるときの材料になる。

## 関連

#1538、ADR-0089 D3 (docs/wasip3-effect-alignment.md)、#1341、#1366、#827

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_