### PR TITLE
fix(control-flow): reject discarded break payloads

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -507,6 +507,9 @@ let result = loop (i = 0, sum = 0) {
 // things. `continue` must pass every parameter (a bare `continue` repeats with
 // them unchanged); a mismatch is a parse error naming both counts. `break` has
 // no arity to match, so `break (a, b)` is one tuple, not two values.
+// A break payload must begin on the same line as `break`. `while`, bare
+// `loop { ... }`, and `for-in` accept only bare `break`; only parameterized
+// `loop (...)` accepts a break value.
 
 // return (early exit from the enclosing function)
 let find_first_neg: (Array[Int]) -> Int = (arr) -> {

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -432,7 +432,11 @@ Rules:
 - `if` and `match` are expressions.
 - `while` is statement-like and returns `Unit`.
 - `for-in` collects body results into an array.
-- `break Expr` returns a value from `loop` / `while`. `break(acc)` is parsed as
+- `while`, bare `loop { ... }`, and `for-in` accept only bare `break`. A payload
+  is rejected rather than evaluated and discarded. `while` and bare `loop`
+  return `Unit`; `for-in` returns the results collected before the break.
+- `break Expr` returns a value only from parameterized `loop (...)`, and the
+  payload must start on the same line as `break`. `break(acc)` is parsed as
   `break` followed by a parenthesized expression -- NOT the same shape as
   `continue(a, b)`'s call-like next-state argument list. `break(a, b)` builds
   the tuple `(a, b)`, it does not break with two separate loop-result values

--- a/docs/vibe.md
+++ b/docs/vibe.md
@@ -882,8 +882,12 @@ yield value
 Rules:
 - `while` condition must be `Bool`.
 - `while` body is type-checked, and the expression result type is always `Unit`.
-- `break` and `continue` are valid only inside `while` loop bodies.
-- Using `break`/`continue` outside `while` is a type error.
+- `break` and `continue` are valid only inside loop bodies.
+- `while`, bare `loop { ... }`, and `for-in` accept only bare `break`. `while`
+  and bare `loop` return `Unit`; `for-in` returns its collected prefix.
+- Only parameterized `loop (...)` accepts `break value`; the payload must begin
+  on the same line as `break`.
+- Using `break`/`continue` outside a loop is a type error.
 - Runtime loop control uses `break` to exit the nearest loop and `continue` to
   start the next iteration.
 - `yield expr` requires `{Async}` and returns `Unit`.

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6912,13 +6912,26 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       // loop (`() -> { break }`). Threaded through env, so if/match/let/seq
       // inside a loop still see it; a nested function does not introduce one, so
       // a `break` there is (conservatively) left unchecked rather than flagged.
-      match env_lookup(env, "__in_loop__") {
-        Some(_) => (),
-        None => Array::push(errors, "`break` outside a loop")
+      let in_loop = match env_lookup(env, "__in_loop__") {
+        Some(_) => true,
+        None => {
+          Array::push(errors, "`break` outside a loop")
+          false
+        }
       }
       match opt {
         Some(e) => {
           let (_, s1, c1) = check_expr_capture(e, env, defs, s, c, errors, tytab, capture, lane)
+          // Parameterized `loop (...)` rewrites `break value` to an assignment
+          // plus a bare break before checking. Any payload that survives here
+          // therefore belongs to a non-value `break` target: `while`, bare
+          // `loop {}`, or `for-in`. Both backends used to omit that expression
+          // entirely, including effects.
+          if in_loop {
+            Array::push(errors, String::concat("this loop form does not accept a `break` value; remove the payload, or use parameterized `loop (...)` to return one", off_marker(railway_expr_off(e))))
+          } else {
+            ()
+          }
           (CtUnit, s1, c1)
         },
         None => (CtUnit, s, c)

--- a/lib/@vibe/compiler/tests/checker_parity_advanced_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_parity_advanced_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./checker_parity_test_support.vibe {
-  check_source_err, check_source_ok
+  check_source_err, check_source_err_contains, check_source_located_err_contains, check_source_ok
 }
 
 //# Misc
@@ -226,6 +226,28 @@ test "parity: loop break value" {
 
 test "parity: while break value" {
   assert(check_source_ok("let _adr69 = () -> { let mut i = 0\nwhile true { if i >= 5 { break }\ni = i + 1 }\ni }"))
+}
+
+test "#1680: while rejects a break payload instead of silently discarding it" {
+  let source = "let side_effect = () -> Unit { () }\nlet run = () -> Unit {\n  while true { break side_effect() }\n}"
+  assert(check_source_err_contains(source, "this loop form does not accept a `break` value"))
+}
+
+test "#1680: break payload rejection is located" {
+  let source = "let side_effect = () -> Unit { () }\nlet run = () -> Unit {\n  while true { break side_effect() }\n}"
+  assert(check_source_located_err_contains(source, "line 3:"))
+}
+
+test "#1680: bare loop rejects a break payload" {
+  assert(check_source_err_contains("let run = () -> Unit { loop { break 42 } }", "this loop form does not accept a `break` value"))
+}
+
+test "#1680: for-in rejects a break payload" {
+  assert(check_source_err_contains("let run = () -> Array[Int] { for x in [1, 2] { break x } }", "this loop form does not accept a `break` value"))
+}
+
+test "#1680: parameterized loop still accepts a same-line break payload" {
+  assert(check_source_ok("let run = () -> Int { loop (i = 0) { if i > 0 { break i } else { continue(i + 1) } } }"))
 }
 
 /// ADR-0069: the old "map int keys" assertion only ever passed because

--- a/lib/@vibe/compiler/tests/checker_parity_test_support.vibe
+++ b/lib/@vibe/compiler/tests/checker_parity_test_support.vibe
@@ -5,7 +5,11 @@ import @vibe/compiler/checker {
 }
 
 import @vibe/compiler/syntax {
-  lex, parse_program
+  lex, lex_with_offsets, parse_program, parse_program_located
+}
+
+import @vibe/compiler/runtime {
+  locate_type_error
 }
 //# Functions
 
@@ -28,5 +32,27 @@ export fn check_source_err(source: String) -> Bool {
     false
   } with Exception {
     Throw(_) => true
+  }
+}
+
+export fn check_source_err_contains(source: String, needle: String) -> Bool {
+  handle {
+    let tokens = lex(source)
+    let stmts = parse_program(tokens)
+    let _env = check_program(stmts)
+    false
+  } with Exception {
+    Throw(msg) => String::contains(msg, needle)
+  }
+}
+
+export fn check_source_located_err_contains(source: String, needle: String) -> Bool {
+  handle {
+    let (tokens, starts, _) = lex_with_offsets(source)
+    let stmts = parse_program_located(tokens, starts, source)
+    let _env = check_program(stmts)
+    false
+  } with Exception {
+    Throw(msg) => String::contains(locate_type_error(source, msg), needle)
   }
 }

--- a/lib/@vibe/compiler/tests/lexer_test.vibe
+++ b/lib/@vibe/compiler/tests/lexer_test.vibe
@@ -300,6 +300,39 @@ test "lex_same_line_bracket_is_subscript" {
   ]))
 }
 
+/// #1680: a newline terminates `break`. Without this synthetic separator the
+/// next statement was greedily parsed as the payload and could then disappear
+/// entirely in a statement-like loop.
+test "lex_newline_after_break_inserts_semicolon" {
+  assert(lex_match("break\nside_effect()", [
+    TBreak,
+    TSemicolon,
+    TIdent("side_effect"),
+    TLParen,
+    TRParen,
+    TEof
+  ]))
+}
+
+test "lex_same_line_break_payload_has_no_semicolon" {
+  assert(lex_match("break side_effect()", [
+    TBreak,
+    TIdent("side_effect"),
+    TLParen,
+    TRParen,
+    TEof
+  ]))
+}
+
+test "lex_newline_after_bare_break_before_close_has_no_semicolon" {
+  assert(lex_match("{ break\n}", [
+    TLBrace,
+    TBreak,
+    TRBrace,
+    TEof
+  ]))
+}
+
 test "lex_newline_bracket_after_nonexpr_no_semicolon" {
   // After a non-expression-ending token (`,`), a newline + `[` does NOT get a
   // synthetic `;` — it is a normal array literal (e.g. a call argument).

--- a/lib/@vibe/parser/lexer.vibe
+++ b/lib/@vibe/parser/lexer.vibe
@@ -669,6 +669,28 @@ fn skip_ws_with_newline(s: String, len: Int, i: Int) -> (Int, Bool) {
   (out, saw_newline)
 }
 
+/// Newlines are normally trivia, but two expression boundaries need a
+/// synthetic statement separator:
+/// - before `(`/`[` after an expression, so they do not become postfix syntax;
+/// - after `break`, whose optional payload is deliberately same-line only.
+///
+/// Keeping this decision in one helper prevents `lex`, offset lexing, and the
+/// recovering lexer from drifting apart.
+fn needs_synthetic_semicolon(c: Int, nl_before: Bool, prev_tok: Token) -> Bool {
+  if !nl_before {
+    false
+  } else {
+    match prev_tok {
+      // A closing delimiter/comma already terminates a bare break. Inserting
+      // `;` there breaks match-arm parsing (`_ => break\n}` makes the
+      // separator look like the next pattern). Only separate a real token
+      // that could otherwise become the optional payload.
+      TBreak => c != '}' && c != ')' && c != ']' && c != ',' && c != ';',
+      _ => (c == '[' || c == '(') && is_expr_ending_tok(prev_tok)
+    }
+  }
+}
+
 fn concat_string_parts(parts: Array[String], tail: String) -> String {
   // O(N) join via StringBuilder; the previous `out = String::concat(out, ...)`
   // per part was O(N²) over the joined length (issue #366).
@@ -1085,7 +1107,7 @@ export fn lex_with_offsets(source: String) -> (Array[Token], Array[Int], Array[I
     while pos < len {
       let c = String::char_code_at(source, pos)
       let (tok, next) = lex_one_token(source, len, pos)
-      if (c == '[' || c == '(') && nl_before && is_expr_ending_tok(prev_tok) {
+      if needs_synthetic_semicolon(c, nl_before, prev_tok) {
         ArrayBuilder::push(b, TSemicolon)
         ArrayBuilder::push(starts, pos)
         ArrayBuilder::push(ends, pos)
@@ -1140,7 +1162,7 @@ export fn lex_with_offsets_recovering(source: String) -> (Array[Token], Array[In
     }
     match res {
       Some((tok, next)) => {
-        if (c == '[' || c == '(') && nl_before && is_expr_ending_tok(prev_tok) {
+        if needs_synthetic_semicolon(c, nl_before, prev_tok) {
           ArrayBuilder::push(b, TSemicolon)
           ArrayBuilder::push(starts, pos)
           ArrayBuilder::push(ends, pos)
@@ -1256,7 +1278,7 @@ export fn lex(source: String) -> Array[Token] with Exception {
       // newline-preceded and follows an expression-ending token; the statement
       // parser already treats `;` as a separator. A same-line `(`/`[` (no
       // newline) still attaches as a call/subscript suffix.
-      if (c == '[' || c == '(') && nl_before && is_expr_ending_tok(prev_tok) {
+      if needs_synthetic_semicolon(c, nl_before, prev_tok) {
         ArrayBuilder::push(b, TSemicolon)
       } else {
         ()


### PR DESCRIPTION
Closes #1680

## What changed

- make an optional break payload same-line only
- reject payloads in statement-like while and bare loop
- preserve parameterized loop values
- document the syntax and add lexer/checker/WIT parser regressions

## Root cause

Newlines were discarded before parsing, so the next statement could become a break payload; the checker and backends then silently discarded payloads in value-less loops.

## Validation

- focused lexer, checker, located diagnostic, and WIT parser tests green
- stage2 generation green
- precommit green