### PR TITLE
fix(checker): type slice syntax by receiver

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -331,6 +331,21 @@ Array::fold(xs, 0, _ + _)
 
 Assignment: `=` `+=` `-=` `*=` `/=` `%=` (statement, not expr)
 
+Slice is a postfix `[]` form with four spellings:
+
+```vibe
+let s = "hello"
+let whole: String = s[:]       // start = 0, end = length
+let prefix: String = s[:2]     // start = 0
+let suffix: String = s[2:]     // end = length
+let middle: String = s[1:4]
+```
+
+The receiver must be `String`, `Bytes`, or `Array[T]`, and the result has the
+same type as the receiver. Explicit `start` and `end` values are `Int`.
+`String` slicing uses byte offsets; it does not imply Unicode code-point or
+grapheme boundaries.
+
 ### `Array` / `Bytes` の `==` (#1526)
 
 ランタイムの `eq` は型を見ないので、配列の `==` は**コンパイル時に要素型を

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -468,6 +468,10 @@ Array::map(xs, _ * 2)
 point.x
 tuple.0
 arr[0]
+arr[:]
+arr[:end]
+arr[start:]
+arr[start:end]
 map_value["key"]
 arr[0] = value
 ```
@@ -479,6 +483,13 @@ that rewrite only when it can recover the receiver type locally, and otherwise
 leaves the dot form unchanged rather than guessing. Builtins use qualified or
 pipe-style calls (for example `String::length(s)`), while a function stored in
 a field must be invoked as `(obj.callback)(args)`.
+
+Slice syntax accepts exactly the four forms `value[:]`, `value[:end]`,
+`value[start:]`, and `value[start:end]`. The receiver must be a `String`,
+`Bytes`, or `Array[T]`; the result has the same type as the receiver (including
+the `T` in `Array[T]`). An omitted start means `0`, and an omitted end means the
+receiver's length. Both explicit bounds are `Int`. String bounds are byte
+offsets, not Unicode code-point or grapheme offsets.
 
 ### Collections
 

--- a/lib/@vibe/compiler/checker/builtins_misc.vibe
+++ b/lib/@vibe/compiler/checker/builtins_misc.vibe
@@ -91,21 +91,6 @@ fn lookup_throw(name: String) -> Option[Type] {
   else None
 }
 
-fn misc_three_params(a: Type, b: Type, c: Type) -> Array[Type] {
-  let arr = misc_no_params()
-  Array::push(arr, a)
-  Array::push(arr, b)
-  Array::push(arr, c)
-  arr
-}
-
-fn lookup_slice(name: String) -> Option[Type] {
-  if name == "__slice" {
-    Some(CtFn(misc_three_params(CtUnknown, CtInt, CtInt), CtUnknown, None))
-  }
-  else None
-}
-
 /// #1374: the static type name of the payload of the throw currently being
 /// handled, or "" when the throw site's payload type was not syntactically
 /// resolvable. Only meaningful INSIDE an exception handler arm.
@@ -128,13 +113,6 @@ fn lookup_slice(name: String) -> Option[Type] {
 fn lookup_exn_kind(name: String) -> Option[Type] {
   if name == "__exn_kind" || name == "__exn_message" {
     Some(CtFn(misc_no_params(), CtString, None))
-  }
-  else None
-}
-
-fn lookup_len(name: String) -> Option[Type] {
-  if name == "__len" {
-    Some(CtFn(misc_one_param(CtUnknown), CtInt, None))
   }
   else None
 }
@@ -166,10 +144,11 @@ fn lookup_misc_group_a(name: String) -> Option[Type] {
       Some(t) => Some(t),
       None => match lookup_exn_kind(name) {
         Some(t) => Some(t),
-        None => match lookup_len(name) {
-          Some(t) => Some(t),
-          None => lookup_index(name)
-        }
+        // `__slice` / `__len` are deliberately NOT first-class builtins.
+        // Their direct parser-generated calls are type-directed in checker.vibe;
+        // exposing an all-Unknown function signature here would let an alias
+        // bypass those receiver and same-result-type checks (#1682).
+        None => lookup_index(name)
       }
     }
   }
@@ -290,16 +269,13 @@ fn lookup_misc_group_f(name: String) -> Option[Type] {
 export fn lookup_misc(name: String) -> Option[Type] {
   match lookup_misc_group_a(name) {
     Some(t) => Some(t),
-    None => match lookup_slice(name) {
+    None => match lookup_misc_group_c(name) {
       Some(t) => Some(t),
-      None => match lookup_misc_group_c(name) {
+      None => match lookup_misc_group_d(name) {
         Some(t) => Some(t),
-        None => match lookup_misc_group_d(name) {
+        None => match lookup_misc_group_e(name) {
           Some(t) => Some(t),
-          None => match lookup_misc_group_e(name) {
-            Some(t) => Some(t),
-            None => lookup_misc_group_f(name)
-          }
+          None => lookup_misc_group_f(name)
         }
       }
     }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -729,6 +729,33 @@ fn head_kind(t: Type) -> Int {
   }
 }
 
+/// The surface slice forms lower to `__slice(receiver, start, end)`. Runtime
+/// dispatch supports exactly these three receiver representations and returns
+/// the same representation (including an Array's element slot).
+fn slice_result_type(receiver: Type) -> Type {
+  match receiver {
+    CtString => CtString,
+    CtBytes => CtBytes,
+    CtArray(elem) => CtArray(elem),
+    _ => CtUnknown
+  }
+}
+
+/// Unknown is retained only when checking THIS receiver expression already
+/// emitted a diagnostic. `CtUnknown` is also a legitimate result of tolerant
+/// builtins such as `iter_get`, so accepting every unknown receiver would leave
+/// `iter_get(xs, 0)[:]` to unsafe runtime representation dispatch (#1682).
+/// A fresh/generic/named type has no Sliceable bound in the language either.
+fn slice_receiver_is_invalid(receiver: Type, receiver_had_error: Bool) -> Bool {
+  match receiver {
+    CtString => false,
+    CtBytes => false,
+    CtArray(_) => false,
+    CtUnknown => !receiver_had_error,
+    _ => true
+  }
+}
+
 /// #827: `Stream[T]` is `CtNamed` (head_kind 0 = tolerated), so the Array
 /// builtins' receiver head check let `Array::length(stream)` / `Array::get(s,
 /// 0)` through — observably leaking the eager Array-backed representation
@@ -4510,6 +4537,40 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             _ => CtUnknown
           }
           (tab_call_ty(tytab, call_off, result, capture, lane), s2, c2)
+        } else if name == "__slice" && Array::length(args) == 3 {
+          // #1682: the old fallback signature was
+          // `(CtUnknown, Int, Int) -> CtUnknown`, so both the receiver and
+          // result unified with anything. In particular
+          // `let n: Int = "hello"[0:2]` checked clean and then performed
+          // pointer arithmetic at runtime. Mirror the runtime's three-way
+          // dispatch explicitly and preserve an Array receiver's element type.
+          let receiver_errors_before = Array::length(errors)
+          let (obj_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
+          let receiver_had_error = Array::length(errors) > receiver_errors_before
+          let (start_ty, s2, c2) = check_expr_capture(Array::get(args, 1), env, defs, s1, c1, errors, tytab, capture, lane)
+          let s2b = check_assignable(CtInt, subst_apply(s2, start_ty), s2, errors, "slice start must be Int", call_off)
+          let (end_ty, s3, c3) = check_expr_capture(Array::get(args, 2), env, defs, s2b, c2, errors, tytab, capture, lane)
+          let s3b = check_assignable(CtInt, subst_apply(s3, end_ty), s3, errors, "slice end must be Int", call_off)
+          let receiver = subst_apply(s3b, obj_ty)
+          if slice_receiver_is_invalid(receiver, receiver_had_error) {
+            Array::push(errors, String::concat("slice receiver must be String, Bytes, or Array, got ", String::concat(type_to_string(receiver), off_marker_len(callee_off, String::length(name)))))
+          } else {
+            ()
+          }
+          (tab_call_ty(tytab, call_off, slice_result_type(receiver), capture, lane), s3b, c3)
+        } else if name == "__len" && Array::length(args) == 1 {
+          // Open-ended slices synthesize `__len(receiver)`. Keep its accepted
+          // receiver set identical to `__slice` and the runtime dispatch.
+          let receiver_errors_before = Array::length(errors)
+          let (obj_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
+          let receiver_had_error = Array::length(errors) > receiver_errors_before
+          let receiver = subst_apply(s1, obj_ty)
+          if slice_receiver_is_invalid(receiver, receiver_had_error) {
+            Array::push(errors, String::concat("slice receiver must be String, Bytes, or Array, got ", String::concat(type_to_string(receiver), off_marker_len(callee_off, String::length(name)))))
+          } else {
+            ()
+          }
+          (tab_call_ty(tytab, call_off, CtInt, capture, lane), s1, c1)
         } else if name == "ArrayBuilder::new" && Array::length(args) == 0 {
           // #938: the builder ops were typed all-CtUnknown, so
           // `ArrayBuilder::push(b, 1); ArrayBuilder::push(b, "two")` compiled

--- a/lib/@vibe/compiler/tests/checker_parity_builtins_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_parity_builtins_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./checker_parity_test_support.vibe {
-  check_source_err, check_source_ok
+  check_source_err, check_source_error_message, check_source_ok
 }
 
 //# Misc
@@ -36,6 +36,47 @@ test "parity builtin: String::split" {
 
 test "parity builtin: string slice to end syntax" {
   assert(check_source_ok("let s = \"hello\"\nlet _adr69 = () -> { s[2:] }"))
+}
+
+test "1682: slice syntax preserves String Bytes and Array receiver types" {
+  assert(check_source_ok("fn main() -> Unit {\n  let s0: String = \"hello\"[:]\n  let s1: String = \"hello\"[:2]\n  let s2: String = \"hello\"[1:]\n  let s3: String = \"hello\"[1:3]\n  let b = Bytes::from_array([65, 66, 67])\n  let b0: Bytes = b[:]\n  let b1: Bytes = b[:2]\n  let b2: Bytes = b[1:]\n  let b3: Bytes = b[1:3]\n  let a = [1, 2, 3]\n  let a0: Array[Int] = a[:]\n  let a1: Array[Int] = a[:2]\n  let a2: Array[Int] = a[1:]\n  let a3: Array[Int] = a[1:3]\n}"))
+}
+
+test "1682: slice result cannot be annotated as Int" {
+  assert(check_source_err("fn main() -> Unit { let n: Int = \"hello\"[0:2] }"))
+  assert(check_source_err("fn main() -> Unit { let n: Int = Bytes::from_array([1, 2])[0:1] }"))
+  assert(check_source_err("fn main() -> Unit { let n: Int = [1, 2][0:1] }"))
+}
+
+test "1682: slice and open-end length reject non-sliceable receivers" {
+  assert(check_source_err("fn main() -> Unit { let x = 42[0:1] }"))
+  assert(check_source_err("fn main() -> Unit { let x = true[:] }"))
+}
+
+test "1682: internal slice intrinsics cannot be aliased around receiver checks" {
+  assert(check_source_err("fn main() -> Unit { let slicer = __slice\nlet n: Int = slicer(\"hello\", 0, 2) }"))
+  assert(check_source_err("fn main() -> Unit { let length = __len\nlet n: Int = length(42) }"))
+}
+
+test "1682: generic and non-sliceable function results are rejected actionably" {
+  let generic_closed = check_source_error_message("fn bad[T](x: T) -> T { x[0:1] }")
+  let generic_open = check_source_error_message("fn bad[T](x: T) -> T { x[:] }")
+  let int_result = check_source_error_message("fn answer() -> Int { 42 }\nfn main() -> Unit { let x = answer()[:] }")
+  assert(String::contains(generic_closed, "slice receiver must be String, Bytes, or Array"))
+  assert(String::contains(generic_open, "slice receiver must be String, Bytes, or Array"))
+  assert(String::contains(int_result, "slice receiver must be String, Bytes, or Array"))
+}
+
+test "1682: a generic function result resolved to String remains sliceable" {
+  assert(check_source_ok("fn identity[T](x: T) -> T { x }\nfn main() -> Unit { let s: String = identity(\"hello\")[:] }"))
+}
+
+test "1682 review: unknown receiver is rejected unless its expression already failed" {
+  let unknown_receiver = check_source_error_message("fn main() -> Unit { let x = iter_get([1], 0)[:] }")
+  let already_failed = check_source_error_message("fn main() -> Unit { let x = missing()[:] }")
+  assert(String::contains(unknown_receiver, "slice receiver must be String, Bytes, or Array"))
+  assert(String::contains(already_failed, "unknown name: missing"))
+  assert(!String::contains(already_failed, "slice receiver must be String, Bytes, or Array"))
 }
 
 test "parity builtin: Array::get" {

--- a/lib/@vibe/compiler/tests/checker_parity_test_support.vibe
+++ b/lib/@vibe/compiler/tests/checker_parity_test_support.vibe
@@ -56,3 +56,14 @@ export fn check_source_located_err_contains(source: String, needle: String) -> B
     Throw(msg) => String::contains(locate_type_error(source, msg), needle)
   }
 }
+
+export fn check_source_error_message(source: String) -> String {
+  handle {
+    let tokens = lex(source)
+    let stmts = parse_program(tokens)
+    let _env = check_program(stmts)
+    ""
+  } with Exception {
+    Throw(message) => message
+  }
+}

--- a/lib/@vibex/shell/commands_extra.vibe
+++ b/lib/@vibex/shell/commands_extra.vibe
@@ -29,7 +29,7 @@ export fn tree(dir: String) -> String with Process {
         let mut d = 0
         let mut j = 0
         while j < String::length(rel) {
-          if rel[j] == "/" {
+          if rel[j] == '/' {
             d = d + 1
           }
           j = j + 1


### PR DESCRIPTION
Closes #1682

## What changed

- type String, Bytes, and Array slices with their concrete result types
- require Int bounds and reject unsupported receivers
- close direct alias and generic receiver bypasses for compiler-owned slice helpers
- document all four slice forms and add checker regressions

## Root cause

The checker exposed Unknown-based signatures while runtime dispatch only supports String, Bytes, and Array.

## Validation

- focused 60 tests green
- selfhost generation stage0 through stage2 green
- precommit green
- affected 124/127 green; remaining 3 are pre-existing shell equality mismatches on main