### PR TITLE
fix(checker): reject non-Array for values

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -495,7 +495,7 @@ while cond { body }
 // for-in (collects into array)
 for x in arr { x * 2 }         // -> Array
 for i, x in arr { i + x }      // with index
-for b in pull { b }            // async iterator (struct: next() -> Future[Option[(T,Self)]], await-driven) or a () -> Option[T] pull closure (-> None).
+for b in pull { use(b) }       // statement only: async iterator (struct: next() -> Future[Option[(T,Self)]], await-driven) or a () -> Option[T] pull closure (-> None).
                                // 同期/非同期の選択は iterand の型だけで決まる — `for await` は #1350 で廃止 (suspend は effect row が語る)
 
 // loop (parameterized tail-recursion)
@@ -518,6 +518,12 @@ let find_first_neg: (Array[Int]) -> Int = (arr) -> {
   -1
 }
 ```
+
+`for` が body の値を `Array` に集めるのは Array/String など builtin の
+collection iterand だけ。pull closure・trait iterator・HostStream などの
+非Array iterator は statement-shaped loop なので、値位置 (`let xs = for ...`)
+では located error になる (#1679)。配列が必要なら iterator 固有の `collect`
+関数を使うか、文位置の loop から `ArrayBuilder` へ明示的に蓄積する。
 
 ## Pattern Matching
 

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3104,7 +3104,7 @@ fn tab_dot_field_name_ty(tytab: Array[(Int, Type)], field_off: Int, ty: Type, ca
 /// forward reference). Semantics are identical to the recursive arms: each `let`
 /// binds its (generalized, or raw for `mut`) value type into the env seen by the
 /// rest of the spine, and the final non-spine expression's result is returned.
-fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)], capture: Option[TypedOccurrenceRoleLaneCapture], lane: String, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)], Option[TypedOccurrenceRoleLaneCapture], String) -> (Type, Subst, Int)) -> (Type, Subst, Int) {
+fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)], capture: Option[TypedOccurrenceRoleLaneCapture], lane: String, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)], Option[TypedOccurrenceRoleLaneCapture], String) -> (Type, Subst, Int), ce_discarded_root: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)], Option[TypedOccurrenceRoleLaneCapture], String) -> (Type, Subst, Int)) -> (Type, Subst, Int) {
   let mut cur = expr
   let mut cenv = env
   let mut s1 = s
@@ -3115,7 +3115,14 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
   while !done {
     match cur {
       ESeq(left, right) => {
-        let (_, ns, nc) = ce(left, cenv, defs, s1, c1, errors, tytab, capture, lane)
+        // Only a DIRECT EForIn at the head of a sequence is statement-shaped.
+        // Do not put this context in TypeEnv: an ambient sentinel leaks through
+        // if/lambda/block children (and can collide with a user binding), which
+        // would let a nested consumed iterator result revive #1679.
+        let (_, ns, nc) = match left {
+          EForIn(_, _, _, _) => ce_discarded_root(left, cenv, defs, s1, c1, errors, tytab, capture, lane),
+          _ => ce(left, cenv, defs, s1, c1, errors, tytab, capture, lane)
+        }
         s1 = ns
         c1 = nc
         // The right child is processed by this iterative loop, not by a
@@ -3188,7 +3195,7 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
       _ => {
         // `cur` already owns the active virtual right-child frame. Calling
         // the wrapper here would add a fictional child before checking it.
-        result = check_expr_capture_impl(cur, cenv, defs, s1, c1, errors, tytab, capture, lane)
+        result = check_expr_capture_impl(cur, cenv, defs, s1, c1, errors, tytab, capture, lane, false)
         done = true
       }
     }
@@ -4129,7 +4136,7 @@ fn check_resume_values(e: Expr, ret_ty: Type, env: TypeEnv, defs: Array[TypeDef]
   }
 }
 
-fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)], capture: Option[TypedOccurrenceRoleLaneCapture], lane: String) -> (Type, Subst, Int) {
+fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)], capture: Option[TypedOccurrenceRoleLaneCapture], lane: String, discarded_root: Bool) -> (Type, Subst, Int) {
   match expr {
     EInt(_) => (CtInt, s, c),
     EFloat(_) => (CtDouble, s, c),
@@ -4207,10 +4214,10 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         }
       }
     },
-    ESeq(_, _) => check_seq_spine(expr, env, defs, s, c, errors, tytab, capture, lane, check_expr_capture),
-    ELet(_, _, _, _) => check_seq_spine(expr, env, defs, s, c, errors, tytab, capture, lane, check_expr_capture),
-    ELetRec(_, _, _) => check_seq_spine(expr, env, defs, s, c, errors, tytab, capture, lane, check_expr_capture),
-    ELetMut(_, _, _, _) => check_seq_spine(expr, env, defs, s, c, errors, tytab, capture, lane, check_expr_capture),
+    ESeq(_, _) => check_seq_spine(expr, env, defs, s, c, errors, tytab, capture, lane, check_expr_capture, check_expr_capture_discarded_root),
+    ELet(_, _, _, _) => check_seq_spine(expr, env, defs, s, c, errors, tytab, capture, lane, check_expr_capture, check_expr_capture_discarded_root),
+    ELetRec(_, _, _) => check_seq_spine(expr, env, defs, s, c, errors, tytab, capture, lane, check_expr_capture, check_expr_capture_discarded_root),
+    ELetMut(_, _, _, _) => check_seq_spine(expr, env, defs, s, c, errors, tytab, capture, lane, check_expr_capture, check_expr_capture_discarded_root),
     EIf(cond, then_e, else_e) => {
       let (ct, s1, c1) = check_expr_capture(cond, env, defs, s, c, errors, tytab, capture, lane)
       let resolved_ct = subst_apply(s1, ct)
@@ -6512,6 +6519,69 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       //     element instead of `CtUnknown` silently accepting any element use and
       //     dropping element-type safety.
       let it_resolved = subst_apply(s1, it)
+      // #1679: only the residual builtin EForIn lowering collects body values.
+      // Trait iterators, pull closures, HostStream and indexed user Iterables
+      // are rewritten after checking to a Unit-valued EWhile.  Claiming
+      // CtArray here for those shapes let a Unit zero be reinterpreted as an
+      // Array pointer.  Keep statement-position loops working, but reject a
+      // non-collecting loop when its value is consumed.  An unresolved head is
+      // not evidence that collection happens: fail closed rather than revive
+      // the silent-wrong path.
+      //
+      //  1 = residual collection (Array/String/builtin eager containers)
+      //  0 = positively non-collecting iterator lowering
+      // -1 = classification unavailable
+      let collection_class = match it_resolved {
+        CtArray(_) => 1,
+        CtString => 1,
+        CtNamed(nm, _) => if nm == "Map" || nm == "Stream" {
+          1
+        } else if type_name_has_iterator_impl(env, nm) {
+          0
+        } else match find_typedef(defs, nm) {
+          Some(_) => 0,
+          None => -1
+        },
+        CtStruct(_) => 0,
+        CtEnum(_) => 0,
+        CtFn(_, _, _) => 0,
+        CtUnknown => -1,
+        CtVar(_) => -1,
+        CtForAll(_, _, _) => -1,
+        _ => 0
+      }
+      // Two non-collecting lowerings deliberately preserve
+      // `for index, value in ...`: indexed-Iterable binds its generated loop
+      // counter, and build_pull_for_in creates/increments an index cell.  The
+      // next-based and HostStream lowerings do not, which is the silent index
+      // drop diagnosed below (#1763 review).
+      let index_preserved = match it_resolved {
+        CtFn(_, _, _) => true,
+        CtNamed(nm, _) => match (env_lookup(env, String::concat(nm, "::iter_length")), env_lookup(env, String::concat(nm, "::iter_get"))) {
+          (Some(_), Some(_)) => true,
+          _ => false
+        },
+        CtStruct(nm) => match (env_lookup(env, String::concat(nm, "::iter_length")), env_lookup(env, String::concat(nm, "::iter_get"))) {
+          (Some(_), Some(_)) => true,
+          _ => false
+        },
+        _ => false
+      }
+      if collection_class == 0 && !discarded_root {
+        Array::push(errors, String::concat("non-Array `for` does not produce a value; use it as a statement and accumulate explicitly, or call an iterator collection function", off_marker(railway_expr_off(iterable))))
+      } else if collection_class < 0 && !discarded_root {
+        Array::push(errors, String::concat("cannot determine whether this `for` produces an Array; give the iterand a concrete Array type or use the loop as a statement", off_marker(railway_expr_off(iterable))))
+      } else {
+        ()
+      }
+      match index_name {
+        Some(_) => if collection_class != 1 && !index_preserved {
+          Array::push(errors, String::concat("a `for` index binding is only supported when the iterator lowering preserves a counter; this iterator lowering would drop the index", off_marker(railway_expr_off(iterable))))
+        } else {
+          ()
+        },
+        None => ()
+      }
       let (et, c1b) = match it_resolved {
         CtArray(elem) => (elem, c1),
         CtNamed(nm, args) => if Array::length(args) > 0 {
@@ -7216,10 +7286,26 @@ export fn check_expr_capture(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: 
   // Production calls carry None. Avoid enter/exit Option dispatches for every
   // recursive expression while preserving them exactly for opt-in capture.
   match capture {
-    None => check_expr_capture_impl(expr, env, defs, s, c, errors, tytab, None, lane),
+    None => check_expr_capture_impl(expr, env, defs, s, c, errors, tytab, None, lane, false),
     Some(_) => {
       typed_occurrence_capture_enter_expression(capture, expr)
-      let result = check_expr_capture_impl(expr, env, defs, s, c, errors, tytab, capture, lane)
+      let result = check_expr_capture_impl(expr, env, defs, s, c, errors, tytab, capture, lane, false)
+      typed_occurrence_capture_record_direct_return(capture, result.0, lane)
+      typed_occurrence_capture_exit_expression(capture)
+      result
+    }
+  }
+}
+
+/// Check exactly this expression root as a discarded statement. Recursive
+/// children go back through `check_expr_capture`, so the flag cannot leak into
+/// a nested value position (#1679 review follow-up).
+fn check_expr_capture_discarded_root(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)], capture: Option[TypedOccurrenceRoleLaneCapture], lane: String) -> (Type, Subst, Int) {
+  match capture {
+    None => check_expr_capture_impl(expr, env, defs, s, c, errors, tytab, None, lane, true),
+    Some(_) => {
+      typed_occurrence_capture_enter_expression(capture, expr)
+      let result = check_expr_capture_impl(expr, env, defs, s, c, errors, tytab, capture, lane, true)
       typed_occurrence_capture_record_direct_return(capture, result.0, lane)
       typed_occurrence_capture_exit_expression(capture)
       result
@@ -7228,7 +7314,7 @@ export fn check_expr_capture(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: 
 }
 
 export fn check_expr(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)]) -> (Type, Subst, Int) {
-  check_expr_capture_impl(expr, env, defs, s, c, errors, tytab, None, "Primary")
+  check_expr_capture_impl(expr, env, defs, s, c, errors, tytab, None, "Primary", false)
 }
 
 fn map_literal_ground(t: Type) -> Bool {

--- a/lib/@vibe/compiler/tests/checker_for_in_value_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_for_in_value_test.vibe
@@ -1,0 +1,100 @@
+//# Imports
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, lex_with_offsets, parse_program, parse_program_located
+}
+
+import @vibe/compiler/runtime {
+  locate_type_error
+}
+
+//# Helpers
+
+fn first_check_error(source: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+fn first_located_check_error(source: String) -> String {
+  handle {
+    let (tokens, starts, _) = lex_with_offsets(source)
+    let _ = check_program(parse_program_located(tokens, starts, source))
+    ""
+  } with Exception {
+    Throw(msg) => locate_type_error(source, msg)
+  }
+}
+
+//# Tests
+
+test "#1679: pull-closure for cannot be consumed as an Array value" {
+  let source = "fn main() -> Int {\n  let pull: () -> Option[Int] = () -> { None }\n  let xs = for x in pull { x }\n  Array::length(xs)\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "non-Array `for` does not produce a value"))
+}
+
+test "#1679: non-Array value diagnostic points at the iterand" {
+  let source = "fn main() -> Int {\n  let pull: () -> Option[Int] = () -> { None }\n  let xs = for x in pull { x }\n  Array::length(xs)\n}\n"
+  let msg = first_located_check_error(source)
+  assert(String::starts_with(msg, "line 3:"))
+  assert(String::contains(msg, "non-Array `for` does not produce a value"))
+}
+
+test "#1679: an unclassifiable for iterand fails closed in value position" {
+  let source = "fn consume[T](it: T) -> Int {\n  let xs = for x in it { x }\n  Array::length(xs)\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "cannot determine whether this `for` produces an Array"))
+}
+
+test "#1679: statement-position pull-closure for remains valid" {
+  let source = "fn main() -> Unit {\n  let pull: () -> Option[Int] = () -> { None }\n  for x in pull { let _ = x; () }\n  ()\n}\n"
+  assert(first_check_error(source) == "")
+}
+
+test "#1679 review: discarded if does not make a consumed nested for statement-shaped" {
+  let source = "fn main() -> Unit {\n  let pull: () -> Option[Int] = () -> { None }\n  if true {\n    let xs = for x in pull { x }\n    let _ = Array::length(xs)\n    ()\n  } else { () }\n  ()\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "non-Array `for` does not produce a value"))
+}
+
+test "#1679 review: discarded block does not hide a consumed nested for" {
+  let source = "fn main() -> Unit {\n  let pull: () -> Option[Int] = () -> { None }\n  {\n    let xs = for x in pull { x }\n    let _ = Array::length(xs)\n    ()\n  }\n  ()\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "non-Array `for` does not produce a value"))
+}
+
+test "#1679 review: discarded inline call does not leak discard into its lambda body" {
+  let source = "fn main() -> Unit {\n  let pull: () -> Option[Int] = () -> { None }\n  (() -> Unit {\n    let xs = for x in pull { x }\n    let _ = Array::length(xs)\n    ()\n  })()\n  ()\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "non-Array `for` does not produce a value"))
+}
+
+test "#1679 review: a user binding cannot forge statement position" {
+  let source = "fn main() -> Int {\n  let __discarded_expression_root__ = ()\n  let pull: () -> Option[Int] = () -> { None }\n  let xs = for x in pull { x }\n  Array::length(xs)\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "non-Array `for` does not produce a value"))
+}
+
+test "#1679: Array for still produces a value" {
+  let source = "fn main() -> Int {\n  let xs = for x in [1, 2, 3] { x + 1 }\n  Array::length(xs)\n}\n"
+  assert(first_check_error(source) == "")
+}
+
+test "#1679 review: pull-closure iterator preserves its index binding" {
+  let source = "fn main() -> Unit {\n  let pull: () -> Option[Int] = () -> { None }\n  for i, x in pull { let _ = x + i; () }\n  ()\n}\n"
+  assert(first_check_error(source) == "")
+}
+
+test "#1679: HostStream index binding is rejected instead of dropped" {
+  let source = "fn consume(stream: HostStream) -> Unit with Async {\n  for i, byte in stream { let _ = byte + i; () }\n  ()\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "index binding is only supported"))
+}

--- a/lib/@vibe/console/stdin_stream_test.vibe
+++ b/lib/@vibe/console/stdin_stream_test.vibe
@@ -66,11 +66,13 @@ test "ByteStream over empty stdin yields nothing" {
 
 test "for over empty host stream yields no iterations" {
   // `for x in <pull-closure>` desugars to a pull-to-EOF loop. With no
-  // VIBE_STDIN_BYTES the stream is empty, so zero iterations; the for-in
-  // expression collects each body result, so the result is an empty Array.
+  // VIBE_STDIN_BYTES the stream is empty, so zero iterations. Non-Array
+  // iterator loops are statement-shaped; use stream_collect when an Array is
+  // wanted (covered immediately above).
   // The fed case (echo a body) is checked by scripts/test_host_stream_bridge.sh.
-  let collected = for chunk in stdin_stream(4) {
-    chunk
+  let mut seen = 0
+  for _chunk in stdin_stream(4) {
+    seen = seen + 1
   }
-  assert(Array::length(collected) == 0)
+  assert(seen == 0)
 }

--- a/lib/@vibe/core/list_test.vibe
+++ b/lib/@vibe/core/list_test.vibe
@@ -191,9 +191,8 @@ test "list_iter_zip_flatmap" {
 
 test "list_for_in_iterable" {
   let mut total = 0
-  let _mapped = for x in list_of3(1, 2, 3) {
+  for x in list_of3(1, 2, 3) {
     total = total + x
-    x + 1
   }
   assert(eq(total, 6))
 }


### PR DESCRIPTION
Closes #1679

## What changed

- reject consumed for results for pull/next/HostStream and unclassified iterators
- preserve statement-position iteration and eager Array/String collection
- keep indexed Iterable behavior explicit and reject silently ignored indexes
- add fail-closed checker regressions, including nested discard-context cases

## Root cause

The checker assigned Array[body] to every for expression even when desugaring produced a statement-like Unit loop.

## Validation

- related 5 files / 62 tests green
- precommit green