### PR TITLE
fix(wat): round decimal f64 literals exactly

### DIFF
--- a/docs/perceus-reuse.md
+++ b/docs/perceus-reuse.md
@@ -1498,8 +1498,9 @@ emit_f64_const_lohi(buf, Double::to_i64_bits_lo(v), Double::to_i64_bits_hi(v))
 | 0.001 | 2281127254458684670 | 4562254508917369340 |
 
 すべてちょうど半分。2305843009213693952 = 2^61 = **`Int::max_value` + 1** で、
-Int としてそもそも不正。`lib/@vibex/wasm_wat_encoder` の `parse_f64_bits(String)
--> Int` が今もこれを経由している (未修正、別 issue)。
+Int としてそもそも不正。`lib/@vibex/wasm_wat_encoder` も以前は同じ罠を踏んで
+いたが、#1737 で decimal を exact BigInt ratio のまま nearest-even に丸め、
+`(hi, lo)` を直接返す実装へ移した。
 
 ### 回帰ロックが静的である理由
 

--- a/docs/spec/uniform-value-repr.md
+++ b/docs/spec/uniform-value-repr.md
@@ -139,8 +139,10 @@ no bootstrap risk):
 >      trap for user code too, not just codegen: under the production default
 >      (`VIBE_RC=1`) it returns exactly half the true pattern for every double
 >      (`2.0` → 2305843009213693952 = `Int::max_value + 1`, not
->      4611686018427387904). `lib/@vibex/wasm_wat_encoder`'s `parse_f64_bits`
->      still routes through it. Callers must use the `_lo` / `_hi` pair.
+>      4611686018427387904). Callers must use the `_lo` / `_hi` pair.
+>      `lib/@vibex/wasm_wat_encoder` no longer converts decimal WAT literals
+>      through a `Double` at all: it keeps an exact BigInt ratio, rounds once
+>      to nearest-even, and returns the two 32-bit halves directly (#1737).
 > 3. ✅ **Float-ness through `let` bindings (Blocker-3) — FIXED.** The AST is
 >    untyped, so `expr_is_floatish` was purely syntactic and could not see that
 >    a *variable* held a float (`let x = 1.5; x + y` took the integer `+`).

--- a/lib/@vibex/wasm_wat_encoder/index.vpkg
+++ b/lib/@vibex/wasm_wat_encoder/index.vpkg
@@ -2,7 +2,9 @@ name = @vibex/wasm_wat_encoder
 version = 0.0.1
 description =
   #|@vibex/wasm_wat_encoder — WAT text → core-wasm binary compiler; the
-deps = {}
+deps = {
+  @vibe/core : 0.2.0
+}
 
 generated_hash =
 

--- a/lib/@vibex/wasm_wat_encoder/wat_encoder.vibe
+++ b/lib/@vibex/wasm_wat_encoder/wat_encoder.vibe
@@ -1,3 +1,9 @@
+//# Imports
+
+import @vibe/core {
+  type BigInt, BigInt::cmp, BigInt::divmod, BigInt::from_int, BigInt::is_zero, BigInt::mul, BigInt::parse, BigInt::pow, BigInt::to_int
+}
+
 //# Values
 
 //# Functions
@@ -440,25 +446,78 @@ fn emit_section(out: Bytes, section_id: Int, payload: Bytes) -> Unit {
   }
 }
 
-/// #776: there is no `Double::parse` (or any string->Double parser) builtin
-/// anywhere in the selfhost compiler/stdlib — `Double::parse` isn't even a
-/// checker-known name (unlike e.g. `Llm::complete`, which at least type-checks
-/// but lacks codegen). WASM has no "parse decimal string" instruction either,
-/// so this hand-rolls plain-decimal (`[+-]?digits[.digits][eE[+-]?digits]`)
-/// parsing via Int/Double arithmetic instead. Good enough for WAT `f64.const` /
-/// `f32.const` literals (hex-float `0x1.8p3` forms are not handled — none of
-/// the wasm fixtures use them).
-fn pow10(n: Int) -> Double {
-  let mut result = 1.0
-  let mut i = 0
-  while i < n {
-    result = result * 10.0
-    i = i + 1
+/// Compare `num / den` with powers of two and return
+/// `floor(log2(num / den))`. Both inputs must be positive.
+fn decimal_binary_exponent(num: BigInt, den: BigInt) -> Int {
+  let two = BigInt::from_int(2)
+  if BigInt::cmp(num, den) >= 0 {
+    let mut scaled = den
+    let mut exponent = 0
+    let mut next = BigInt::mul(scaled, two)
+    while BigInt::cmp(num, next) >= 0 {
+      scaled = next
+      exponent = exponent + 1
+      next = BigInt::mul(scaled, two)
+    }
+    exponent
+  } else {
+    let mut scaled = num
+    let mut exponent = 0
+    while BigInt::cmp(scaled, den) < 0 {
+      scaled = BigInt::mul(scaled, two)
+      exponent = exponent - 1
+    }
+    exponent
   }
-  result
 }
 
-fn parse_decimal_double(s: String) -> Option[Double] {
+/// Divide positive integers and round the result to nearest, ties to even.
+/// The caller scales the ratio so the quotient fits in vibe's tagged Int.
+fn rounded_big_ratio(num: BigInt, den: BigInt) -> Option[Int] {
+  match BigInt::divmod(num, den) {
+    None => None,
+    Some((q_big, remainder)) => {
+      match BigInt::to_int(q_big) {
+        None => None,
+        Some(q) => {
+          let twice_remainder = BigInt::mul(remainder, BigInt::from_int(2))
+          let half_cmp = BigInt::cmp(twice_remainder, den)
+          if half_cmp > 0 || (half_cmp == 0 && q % 2 == 1) {
+            Some(q + 1)
+          } else {
+            Some(q)
+          }
+        },
+      }
+    },
+  }
+}
+
+fn signed_f64_zero(neg: Bool) -> (Int, Int) {
+  if neg {
+    (0x80000000, 0)
+  } else {
+    (0, 0)
+  }
+}
+
+fn signed_f64_inf(neg: Bool) -> (Int, Int) {
+  if neg {
+    (0xFFF00000, 0)
+  } else {
+    (0x7FF00000, 0)
+  }
+}
+
+/// Parse a plain decimal WAT float into IEEE-754 binary64 bits.
+///
+/// The decimal significand and power of ten stay as exact BigInts. Only the
+/// final 53-bit quotient is rounded, once, with the IEEE nearest-even rule.
+/// This avoids all three silent-wrong modes of the old Double-arithmetic
+/// parser: tagged-Int overflow, accumulated pow10 error, and pow10 saturation.
+/// Inputs with more than 768 significant decimal digits fail closed: the WAT
+/// encoder is intentionally bounded and must never emit guessed bits.
+fn parse_decimal_f64_bits(s: String) -> Option[(Int, Int)] {
   let len = String::length(s)
   if len == 0 {
     None
@@ -484,18 +543,35 @@ fn parse_decimal_double(s: String) -> Option[Double] {
     } else {
       len
     }
-    let mut mantissa = 0
+    let digits_builder = StringBuilder::new()
     let mut frac_digits = 0
     let mut seen_dot = false
     let mut seen_digit = false
+    let mut significant_digits = 0
+    let mut seen_nonzero = false
+    let mut leading_zeros = 0
+    let mut trailing_zeros = 0
+    let mut digit_count = 0
     let mut ok = true
     let mut j = i
     while j < mantissa_end {
       let c = String::char_code_at(s, j)
       if is_digit(c) {
-        mantissa = mantissa * 10 + (c - 48)
+        StringBuilder::push(digits_builder, String::from_char_code(c))
+        digit_count = digit_count + 1
         if seen_dot {
           frac_digits = frac_digits + 1
+        }
+        if not(seen_nonzero) && c == 48 {
+          leading_zeros = leading_zeros + 1
+        } else {
+          seen_nonzero = true
+          significant_digits = significant_digits + 1
+          if c == 48 {
+            trailing_zeros = trailing_zeros + 1
+          } else {
+            trailing_zeros = 0
+          }
         }
         seen_digit = true
       } else if c == 46 && not(seen_dot) {
@@ -522,11 +598,25 @@ fn parse_decimal_double(s: String) -> Option[Double] {
           k = 1
         }
         let mut exp_val = 0
+        // Any exponent larger than the whole source plus this IEEE-sized
+        // margin cannot be cancelled by decimal point placement or trailing
+        // zeros. Saturating relative to the source length preserves exact
+        // cancellation while still bounding enormous exponent strings.
+        let exp_limit = len + 1100
         let mut exp_seen_digit = false
         while k < exp_len {
           let c = String::char_code_at(exp_str, k)
           if is_digit(c) {
-            exp_val = exp_val * 10 + (c - 48)
+            if exp_val <= exp_limit {
+              if exp_val > exp_limit / 10 {
+                exp_val = exp_limit + 1
+              } else {
+                exp_val = exp_val * 10 + (c - 48)
+                if exp_val > exp_limit {
+                  exp_val = exp_limit + 1
+                }
+              }
+            }
             exp_seen_digit = true
           } else {
             ok = false
@@ -543,22 +633,92 @@ fn parse_decimal_double(s: String) -> Option[Double] {
         }
       }
     }
-    if not(ok) || not(seen_digit) {
+    if not(ok) || not(seen_digit) || i >= mantissa_end {
+      None
+    } else if not(seen_nonzero) {
+      Some(signed_f64_zero(neg))
+    } else if significant_digits - trailing_zeros > 768 {
       None
     } else {
-      let total_exp = exp - frac_digits
-      let mag = Int::to_double(mantissa)
-      let scaled = if total_exp >= 0 {
-        mag * pow10(total_exp)
+      let canonical_digits = significant_digits - trailing_zeros
+      let total_exp = exp - frac_digits + trailing_zeros
+      let decimal_order = canonical_digits - 1 + total_exp
+      if decimal_order > 309 {
+        Some(signed_f64_inf(neg))
+      } else if decimal_order < -325 {
+        Some(signed_f64_zero(neg))
       } else {
-        mag / pow10(0 - total_exp)
+        let all_digits = StringBuilder::freeze(digits_builder)
+        let digits = String::substring(all_digits, leading_zeros, digit_count - trailing_zeros)
+        match BigInt::parse(digits) {
+          None => None,
+          Some(mantissa) => {
+            let ten = BigInt::from_int(10)
+            let num = if total_exp >= 0 {
+              BigInt::mul(mantissa, BigInt::pow(ten, total_exp))
+            } else {
+              mantissa
+            }
+            let den = if total_exp < 0 {
+              BigInt::pow(ten, 0 - total_exp)
+            } else {
+              BigInt::from_int(1)
+            }
+            if BigInt::is_zero(num) {
+              Some(signed_f64_zero(neg))
+            } else {
+              let mut exponent = decimal_binary_exponent(num, den)
+              let shift = if exponent < -1022 {
+                1074
+              } else {
+                52 - exponent
+              }
+              let scaled_num = if shift >= 0 {
+                BigInt::mul(num, BigInt::pow(BigInt::from_int(2), shift))
+              } else {
+                num
+              }
+              let scaled_den = if shift < 0 {
+                BigInt::mul(den, BigInt::pow(BigInt::from_int(2), 0 - shift))
+              } else {
+                den
+              }
+              match rounded_big_ratio(scaled_num, scaled_den) {
+                None => None,
+                Some(rounded) => {
+                  let sign_hi = if neg {
+                    0x80000000
+                  } else {
+                    0
+                  }
+                  if exponent < -1022 {
+                    if rounded == 0 {
+                      Some((sign_hi, 0))
+                    } else if rounded >= (1<<52) {
+                      Some((sign_hi|(1<<20), 0))
+                    } else {
+                      Some((sign_hi|((rounded>>32)&0xFFFFF), rounded&0xFFFFFFFF))
+                    }
+                  } else {
+                    let mut significand = rounded
+                    if significand >= (1<<53) {
+                      significand = significand / 2
+                      exponent = exponent + 1
+                    }
+                    if exponent > 1023 {
+                      Some(signed_f64_inf(neg))
+                    } else {
+                      let fraction = significand - (1<<52)
+                      let hi = sign_hi|((exponent + 1023)<<20)|((fraction>>32)&0xFFFFF)
+                      Some((hi, fraction&0xFFFFFFFF))
+                    }
+                  }
+                },
+              }
+            }
+          },
+        }
       }
-      let signed = if neg {
-        0.0 - scaled
-      } else {
-        scaled
-      }
-      Some(signed)
     }
   }
 }
@@ -599,15 +759,14 @@ fn parse_f64_bits(s: String) -> (Int, Int) {
       }
       i = i + 1
     }
-    let parsed = parse_decimal_double(clean)
+    let parsed = parse_decimal_f64_bits(clean)
     match parsed {
-      Some(v) => (Double::to_i64_bits_hi(v), Double::to_i64_bits_lo(v)),
+      Some(bits) => bits,
       None => {
-        // Malformed f64 literal: the tokenizer only emits float tokens for
-        // forms that `parse_decimal_double` should accept (nan/inf/signed-nan/
-        // signed-inf are handled by the branches above). Hitting `None` here
-        // means the input is not a valid numeric literal; trap loudly rather
-        // than silently emit zero bytes.
+        // Malformed or deliberately out-of-budget f64 literal. The exact
+        // converter is bounded at 768 significant decimal digits; exceeding
+        // that contract traps just like malformed input. Never guess or emit
+        // zero bytes for a valid-looking value that was not converted.
         assert(false)
         (0, 0)
       },

--- a/lib/@vibex/wasm_wat_encoder/wat_encoder_test.vibe
+++ b/lib/@vibex/wasm_wat_encoder/wat_encoder_test.vibe
@@ -51,6 +51,37 @@ fn f32_const_bits(lit: String) -> String {
   out
 }
 
+/// Encode `(f64.const <lit>)` and return the 8 literal bytes as big-endian
+/// hex. Keeping the assertion at the binary boundary catches a valid module
+/// that silently contains a different number from the source literal.
+fn f64_const_bits(lit: String) -> String {
+  let src = String::concat(String::concat("(module (func (export \"f\") (result f64) f64.const ", lit), "))",)
+  let bytes = f64_operand(compile(src))
+  if Array::length(bytes) != 8 {
+    "NOT-FOUND"
+  } else {
+    let out = StringBuilder::new()
+    let mut i = 7
+    while i >= 0 {
+      StringBuilder::push(out, hex2(Array::get(bytes, i)))
+      i = i - 1
+    }
+    StringBuilder::freeze(out)
+  }
+}
+
+fn decimal_with_zeros(prefix: String, zero_count: Int, suffix: String) -> String {
+  let out = StringBuilder::new()
+  StringBuilder::push(out, prefix)
+  let mut i = 0
+  while i < zero_count {
+    StringBuilder::push(out, "0")
+    i = i + 1
+  }
+  StringBuilder::push(out, suffix)
+  StringBuilder::freeze(out)
+}
+
 fn find_export(bytes: Bytes, name: String) -> Bool {
   let len = Bytes::length(bytes)
   let mut i = 8
@@ -436,6 +467,51 @@ test "f64.const emits the IEEE-754 little-endian bit pattern" {
     240,
     127
   ])
+}
+
+test "f64 decimal literals are rounded once without Int overflow" {
+  // Ordinary values and the previously-correct 1e23 remain unchanged.
+  inspect(f64_const_bits("0.1"), "3FB999999999999A")
+  inspect(f64_const_bits("1e23"), "44B52D02C7E14AF6")
+  inspect(f64_const_bits("-0.0"), "8000000000000000")
+  // A 20-digit significand used to overflow the tagged 62-bit Int while it
+  // was being accumulated and changed a positive literal into a negative.
+  inspect(f64_const_bits("12345678901234567890"), "43E56A95319D63E1")
+  inspect(f64_const_bits("1.2345678901234567890123"), "3FF3C0CA428C59FB")
+  // Decimal extremes exercise normal/subnormal boundaries. The old pow10
+  // loop saturated to infinity, turning the finite endpoints into inf/zero.
+  inspect(f64_const_bits("1.7976931348623157e308"), "7FEFFFFFFFFFFFFF")
+  inspect(f64_const_bits("2.2250738585072014e-308"), "0010000000000000")
+  inspect(f64_const_bits("5e-324"), "0000000000000001")
+  // Repeated multiplication/division by ten was one ULP off at both ends.
+  inspect(f64_const_bits("1e300"), "7E37E43C8800759C")
+  inspect(f64_const_bits("1e-300"), "01A56E1FC2F8F359")
+}
+
+test "f64 decimal exponent preserves cancellation with insignificant zeros" {
+  // The exponent must remain relative to frac_digits. Saturating it at a
+  // fixed 10000 changed these exact +/-1 values into +/-0.1.
+  let positive = decimal_with_zeros("0.", 10000, "1e10001")
+  let negative = decimal_with_zeros("-0.", 10000, "1e10001")
+  inspect(f64_const_bits(positive), "3FF0000000000000")
+  inspect(f64_const_bits(negative), "BFF0000000000000")
+  // The inverse cancellation is equally exact: trailing integer zeros move
+  // into the decimal exponent before the bounded significand is converted.
+  let negative_exp = decimal_with_zeros("1", 10000, "e-10000")
+  let signed_negative_exp = decimal_with_zeros("-1", 10000, "e-10000")
+  inspect(f64_const_bits(negative_exp), "3FF0000000000000")
+  inspect(f64_const_bits(signed_negative_exp), "BFF0000000000000")
+  // Leading integer zeros are insignificant too and do not consume the
+  // exact-conversion digit budget.
+  let leading_integer_zeros = decimal_with_zeros("", 10000, "1e0")
+  inspect(f64_const_bits(leading_integer_zeros), "3FF0000000000000")
+}
+
+test "f64 special literals keep their canonical payloads" {
+  inspect(f64_const_bits("inf"), "7FF0000000000000")
+  inspect(f64_const_bits("-inf"), "FFF0000000000000")
+  inspect(f64_const_bits("nan"), "7FF8000000000000")
+  inspect(f64_const_bits("-nan"), "FFF8000000000000")
 }
 
 test "f32 const" {


### PR DESCRIPTION
Closes #1737

## What changed

- keep decimal significands and powers as exact BigInt ratios
- round once to binary64 using nearest-even
- emit exact bits for normal, subnormal, overflow, underflow, and signed zero cases
- fail closed above the documented 768-significant-digit budget
- add binary-boundary regressions for DBL_MAX, DBL_MIN, minimum subnormal, long mantissas, and extreme exponents

## Root cause

The old parser accumulated the mantissa in tagged Int and scaled with repeated Double multiplication or division. Int overflow, accumulated rounding, and pow10 saturation could silently emit a different valid f64 value.

## Validation

- fresh seed to stage2 generation green
- focused WAT encoder tests green
- affected WAT/runtime tests 5/5 green, including the latest i32 runtime changes
- precommit and diff check green