### PR TITLE
docs(cheatsheet): 補間の構造描画の境界を実測に合わせる — Array/tuple の関数戻り値経由は生ポインタ (#1766)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -52,13 +52,22 @@ let s: String = "hello \{x}"   // interpolation with \{expr}
                                // (旧 `\(x)` は 0.3.0 で削除、`\{x}` を使う)
                                // #1392: 補間の値に `T::to_string`
                                // (derive(Show)/derive(Hash) 生成物、または
-                               // 手書き) があればそれを呼ぶ。`Option`/`Result`/
-                               // タプル/配列は変数・generic 経由でも構造的に
-                               // 展開される (`"\{Some(p)}"` -> `Some(P { .. })`,
-                               // `"\{xs}"` -> `[1, 2]`)。描画できない型
-                               // (to_string の無い集約型) は check 時に
+                               // 手書き) があればそれを呼ぶ。struct/enum/
+                               // `Option`/`Result` は関数戻り値経由でも構造
+                               // 描画される。タプル/配列はリテラル直接・
+                               // リテラル束縛の変数経由なら構造的に展開される
+                               // (`"\{Some(p)}"` -> `Some(P { .. })`,
+                               // `"\{xs}"` -> `[1, 2]`) が、**関数戻り値
+                               // 経由は黙って生ポインタの10進値になる**
+                               // (#1766: `"\{f()}"`・`let b = f()` の束縛・
+                               // `Some(f())` の内側・generic 引数、いずれも。
+                               // 戻り値型注釈があっても変わらない)。
+                               // 描画できない型 (to_string の無い集約型) は
+                               // check 時に
                                // `cannot interpolate a value of type ...` で
-                               // 落ちる (#1445)。ただし effect handler の
+                               // 落ちる (#1445) が、上の経路は Array/tuple に
+                               // renderer 自体はあるためすり抜ける。
+                               // ただし effect handler の
                                // pattern binder (`Throw(err) => "\{err}"`) は
                                // binder の型を補間 rewrite が回収できず、まだ
                                // 生ポインタの10進値になる。variant を match して


### PR DESCRIPTION
## 概要

#1743 (merge 済み) の erratum。あの PR で補間の節を「変数・generic 経由でも構造的に展開される」と一般化したが、region/MutList の probe を書いていて反例を踏んだので境界を実測し直した。**成立するのはリテラル直接・リテラル束縛の変数経由・nominal 型 (struct/enum/Option/Result) の関数戻り値まで**で、**Array/tuple を関数戻り値経由で補間すると check 診断なしで生ポインタの10進値が出る** (#1766 として起票済み)。

## 実測 (stage2 = 49f40fb セルフビルド)

| 式 | 出力 |
|---|---|
| `"\{[1, 2]}"` / `let xs = [1, 2]; "\{xs}"` | `[1, 2]` ok |
| `"\{mk()}"` (`-> P` struct) / `"\{opt()}"` (`-> Option[Int]`) | `P { x: 1, y: 2 }` / `Some(7)` ok |
| `"\{lit3()}"` (`-> Array[Int]`、注釈あり) | **`184` (生ポインタ)** |
| `let b = lit3(); "\{b}"` | **`240` (生ポインタ)** |
| `"\{tup()}"` (`-> (Int, String)`) | **`192` (生ポインタ)** |
| `"\{Some(lit3())}"` | **`Some(344)` — 構造描画の内側に混入** |

#1445 の `cannot interpolate ...` は「renderer が無い型」にしか出ないので、Array/tuple はすり抜ける (renderer 自体はある)。

## 変更

- `docs/cheatsheet.md` 補間の注記: 境界を「経路」ではなく「型の種類 × サイトの解決可否」として書き直し、#1766 を参照。handler pattern binder の既存注記 (#1743 以後に追記されたもの) はそのまま。

## 検証

- `bash scripts/doctest_extract_run.sh docs/cheatsheet.md` → 52 blocks: 29 pass / 0 fail / 23 skip
- pre-commit gates ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_