### PR TITLE
fix(rc): FrozenArray のコピーを wasm-gc にも (#1733) / feat: `vibe allocs` — 確保サイトの列挙 (ADR-0091 / #1262)

### DIFF
--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -508,6 +508,18 @@ fn gc_reset_join_arm_slots(local_names: Array[String], ctx: CompileCtxGc, names_
   }
 }
 
+/// `Array::slice(v, 0, Array::length(v))` with `v` bound once, so an
+/// effectful argument is evaluated a single time (#1733).
+fn gc_frozen_conversion_copy(value: Expr, tmp: String) -> Expr {
+  ELet(tmp, value, ECall(EIdent("Array::slice", -1), [
+    EIdent(tmp, -1),
+    EInt(0),
+    ECall(EIdent("Array::length", -1), [
+      EIdent(tmp, -1)
+    ], -1)
+  ], -1), -1)
+}
+
 fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, ce: (Bytes, Expr, Array[String], Int, Int) -> Int with Exception) -> Int with Exception {
   match callee {
     EIdent(source_name, _) => {
@@ -518,6 +530,23 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         source_name
       } else {
         canonical_builtin_name(source_name)
+      }
+      // #1733: FrozenArray's two conversions must COPY, on this backend too.
+      // Body 16 (the ArrayBuilder::freeze identity cast) is what they used to
+      // map to in backend_body.vibe, which made `FrozenArray` mutable through
+      // either end and took away the reason it is on the Send allowlist. The
+      // rewrite mirrors the linear lane's (codegen/expr/compile_call.vibe):
+      // bind the value once, then slice it. Guarded on the name not resolving
+      // to anything real, same as every other builtin spelling here.
+      if !source_is_bound && Array::length(args) == 1 && (fname == "FrozenArray::from_array" || fname == "FrozenArray::to_array") {
+        let ftmp = if fname == "FrozenArray::from_array" {
+          "__frozen_in"
+        } else {
+          "__frozen_out"
+        }
+        return ce(buf, gc_frozen_conversion_copy(Array::get(args, 0), ftmp), local_names, next_local, ld)
+      } else {
+        ()
       }
       let native_slot = gc_native_array_receiver_slot(args, local_names, ctx)
       let native_receiver = Array::length(args) > 0 && (native_slot >= 0 || gc_expr_is_native_array_ref(Array::get(args, 0), local_names, ctx))

--- a/lib/@vibe/compiler/core/builtin_allocates_test.vibe
+++ b/lib/@vibe/compiler/core/builtin_allocates_test.vibe
@@ -1,0 +1,110 @@
+// ADR-0091 (#1262): `builtin_allocates` is the first piece of `@zero_alloc` --
+// "does calling this builtin put something new on the heap?".
+//
+// The tests below pin the POLARITY as much as the classification. The two
+// mistakes are not symmetric: over-reporting rejects a valid `@zero_alloc`
+// function with a diagnostic the author can argue with, while under-reporting
+// lets an allocating function pass the check and makes the annotation certify
+// something untrue. So the default must be "allocates", and an unclassified
+// name must land there.
+
+import ../core {
+  builtin_allocates
+}
+
+//# Tests
+
+test "reads and predicates over an existing value do not allocate" {
+  assert(!builtin_allocates("String::length"))
+  assert(!builtin_allocates("String::char_code_at"))
+  assert(!builtin_allocates("String::starts_with"))
+  assert(!builtin_allocates("Array::length"))
+  assert(!builtin_allocates("Array::get"))
+  assert(!builtin_allocates("FrozenArray::get"))
+  assert(!builtin_allocates("Bytes::get"))
+  assert(!builtin_allocates("MapBuilder::has_key"))
+  assert(!builtin_allocates("eq"))
+}
+
+test "writing into storage that already exists does not allocate" {
+  assert(!builtin_allocates("Array::set"))
+  assert(!builtin_allocates("Array::truncate"))
+  assert(!builtin_allocates("FixedArray::set"))
+  assert(!builtin_allocates("FixedArray::unsafe_set"))
+  assert(!builtin_allocates("FixedArray::blit"))
+  assert(!builtin_allocates("Bytes::set"))
+  assert(!builtin_allocates("Bytes::blit"))
+  assert(!builtin_allocates("Bytes::fill"))
+}
+
+test "anything that produces a fresh value allocates" {
+  assert(builtin_allocates("array_new"))
+  assert(builtin_allocates("Array::slice"))
+  assert(builtin_allocates("Array::concat"))
+  assert(builtin_allocates("String::concat"))
+  assert(builtin_allocates("String::substring"))
+  assert(builtin_allocates("String::split"))
+  assert(builtin_allocates("Bytes::new"))
+  assert(builtin_allocates("Bytes::concat"))
+  assert(builtin_allocates("StringBuilder::new"))
+  assert(builtin_allocates("MapBuilder::new"))
+  assert(builtin_allocates("FixedArray::make"))
+  assert(builtin_allocates("Map::keys"))
+  assert(builtin_allocates("vibe_rc_alloc"))
+}
+
+test "a growable push allocates -- it may regrow" {
+  // The point of tracking these: `Array::push` is free on most calls and
+  // reallocates on the one that crosses capacity. A check that only counted
+  // the obvious constructors would call an append loop zero-alloc.
+  assert(builtin_allocates("Array::push"))
+  assert(builtin_allocates("Array::push_all"))
+  assert(builtin_allocates("ArrayBuilder::push"))
+  assert(builtin_allocates("StringBuilder::push"))
+  assert(builtin_allocates("Bytes::push"))
+  assert(builtin_allocates("Bytes::append"))
+}
+
+test "FrozenArray's conversions allocate: they copy now (#1733)" {
+  // These were identity casts until #1760 / #1773 made them copy, which is
+  // what restores FrozenArray's Send eligibility. Classifying them as free
+  // would have been correct before that and is wrong now -- the pairing is
+  // worth pinning so the two do not drift apart again.
+  assert(builtin_allocates("FrozenArray::from_array"))
+  assert(builtin_allocates("FrozenArray::to_array"))
+}
+
+test "host calls that hand back a value allocate" {
+  assert(builtin_allocates("Fs::read_file"))
+  assert(builtin_allocates("Fs::read_bytes"))
+  assert(builtin_allocates("Env::get"))
+  assert(builtin_allocates("sh"))
+}
+
+test "floats are treated as allocating -- the backend heap-boxes them" {
+  // #510: making this implicit boxing visible is one of the stated reasons
+  // ADR-0091 wants the check at all, so the Float family must NOT be on the
+  // free list.
+  assert(builtin_allocates("Int::to_float"))
+  assert(builtin_allocates("Int::to_double"))
+  assert(builtin_allocates("Double::to_float"))
+  assert(builtin_allocates("Float::to_double"))
+  assert(builtin_allocates("Double::from_i64_bits"))
+}
+
+test "output and runtime bookkeeping do not allocate" {
+  assert(!builtin_allocates("println"))
+  assert(!builtin_allocates("print_int"))
+  assert(!builtin_allocates("assert_eq"))
+  assert(!builtin_allocates("vibe_rc_drop"))
+  assert(!builtin_allocates("vibe_rc_dup"))
+  assert(!builtin_allocates("Profiler::now_us"))
+}
+
+test "an unclassified name answers ALLOCATES, not free" {
+  // The safe direction, and the one that matters for a builtin added later
+  // and never classified here.
+  assert(builtin_allocates("Totally::MadeUp"))
+  assert(builtin_allocates(""))
+  assert(builtin_allocates("Array::lenght"))
+}

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -646,3 +646,53 @@ export fn verify_lane_builtins(lane: String, names: Array[String], param_counts:
     ri2 = ri2 + 1
   }
 }
+
+//# ADR-0091 (#1262): does this builtin allocate?
+
+/// True when calling `name` may put something new on the heap.
+///
+/// **The polarity is deliberate: unknown names answer `true`.** This feeds
+/// `@zero_alloc`, and there the two mistakes are not symmetric --
+///
+///   - answering `true` for a builtin that does not allocate REJECTS a valid
+///     `@zero_alloc` function. Wrong, but the author sees a diagnostic naming
+///     the site and can argue with it.
+///   - answering `false` for one that DOES allocate lets an allocating
+///     function pass the check. The annotation then certifies something
+///     untrue, silently -- the P0 failure mode.
+///
+/// So the list below enumerates what provably does NOT allocate, and
+/// everything else (including a builtin added tomorrow and not classified
+/// here) falls through to `true`. A new builtin is over-reported until
+/// someone classifies it, never under-reported.
+///
+/// Floats are treated as allocating (`Int::to_float` and friends): the linear
+/// backend heap-boxes them, which is exactly the implicit allocation ADR-0091
+/// expects this check to make visible (#510).
+export fn builtin_allocates(name: String) -> Bool {
+  !builtin_is_non_allocating(name)
+}
+
+/// The enumerated non-allocating set. Grouped by why they are free.
+fn builtin_is_non_allocating(name: String) -> Bool {
+  // Pure scalar reads and predicates over an existing value.
+  name == "String::length" || name == "String::equals" || name == "String::char_code_at" || name == "String::ends_with" || name == "String::starts_with" || name == "String::contains" || name == "String::index_of" || name == "String::last_index_of" ||
+  // Indexed container access. `set`/`blit`/`fill` write into storage that is
+  // already there; `truncate` only lowers a length.
+  name == "Array::length" || name == "Array::get" || name == "Array::set" || name == "Array::truncate" || name == "FrozenArray::get" || name == "FrozenArray::length" || name == "FixedArray::length" || name == "FixedArray::get" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "FixedArray::blit" || name == "Int64Array::length" || name == "Int64Array::get" || name == "Int64Array::set" || name == "Bytes::length" || name == "Bytes::get" || name == "Bytes::set" || name == "Bytes::blit" || name == "Bytes::fill" ||
+  // Membership questions that return a Bool, not a value.
+  name == "MapBuilder::has_key" || name == "map_has" ||
+  // Int-domain conversions (Char/Int stay unboxed; the Float family does NOT
+  // appear here on purpose -- see the doc above).
+  name == "Char::to_int" || name == "Char::from_int" || name == "Double::to_int" ||
+  // Comparison / logic primitives.
+  name == "eq" || name == "not" || name == "str_lex_diff" || name == "__generic_rel_diff" ||
+  // SIMD scanners that return an index.
+  name == "simd_skip_ws" || name == "simd_scan_alnum" ||
+  // Output and assertions: they consume, they do not produce.
+  name == "print" || name == "println" || name == "print_int" || name == "print_str" || name == "assert" || name == "assert_true" || name == "assert_eq" ||
+  // Runtime bookkeeping. `vibe_rc_alloc` is NOT here.
+  name == "vibe_rc_drop" || name == "vibe_rc_dup" || name == "vibe_heap_grow_check" ||
+  // Profiler probes return an Int.
+  name == "Profiler::now_us" || name == "Profiler::heap_bytes"
+}

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -123,6 +123,7 @@ fn canonical_builtin_name(name: String) -> String
 
 // --- builtin_registry
 fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)]
+fn builtin_allocates(name: String) -> Bool
 fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
 fn lookup_registry_builtin(name: String) -> Option[Type]
 fn registry_builtin_arity(name: String) -> Int


### PR DESCRIPTION
3 コミット。1 本目が **#1733 を閉じ**、2〜3 本目が ADR-0091 の
「per-fn 確保サマリ / 全サイト列挙」を CLI クエリとして足します。

> **経緯の訂正**: この PR は当初 `#zero_alloc` 注釈とその推移閉包も含んでいました。
> **`@zero_alloc` は既に main にあり** (gate 76 / `common_analysis.vibe ::
> zero_alloc_check`、`compile_wasi_module_linked_impl` で linked module 全体を
> 見るので元から cross-file)、私がセッション中の main 進行に気づかず並行実装を
> 作っていたものです。CLAUDE.md の「1 つの概念に 1 つの綴り」に 2 綴りを
> 持ち込む形だったので、**重複分は落としました**。残したのは競合しない部分だけです。

---

## 1. `FrozenArray` のコピーを wasm-gc backend にも (#1733 を closes)

`FrozenArray[T]` は単なる「不変配列」ではなく **Send allowlist の一員**
(ADR-0082 / ADR-0068 / #906) で、Send 適格の根拠が「変わらないこと」です。
両変換が identity cast だったので、その根拠はどちらの向きにも成立して
いませんでした:

```vibe
let f = FrozenArray::from_array(a); Array::push(a, x)    // f が変わる
let o = FrozenArray::to_array(f);   Array::push(o, x)    // f が変わる
```

#1760 で linear 側を直しましたが、**gc backend は別経路**です。
`backend_body.vibe` が両方を `body 16` (= `ArrayBuilder::freeze` と同じ identity
cast) にマップしていたので、`VIBE_TEST_BACKEND=gc` レーンではそのまま両端から
可変な別名が取れるままでした。`compile_call_gc` の先頭で linear と同じ形
(値を temp に 1 回束縛してから `Array::slice(v, 0, Array::length(v))`) に
書き換えます。

| | linear | wasm-gc |
|---|---|---|
| `from_array` | copy (#1760) | **copy (この PR)** |
| `to_array` | copy (#1760) | **copy (この PR)** |

`get` / `length` は Array の body の別名のまま (読むだけ)。
`ArrayBuilder::freeze` も無傷なので build-then-freeze のホットパスには
影響しません。

---

## 2〜3. `vibe allocs` — 確保サイトの列挙

`@zero_alloc` の**競合ではなく補完**です。検査は「約束が守られているか」に
yes/no で答え、このクエリは「**バイトがどこへ行くか**」を列挙します。
ADR-0091 の checklist でも別項目で、`docs/profiling.md` が要求している確保
サイト計装でもあります。

出力は 1 サイト 1 行の `FN KIND OFFSET`、**空出力 = 何も確保しない**:

```
counter mut-cell 184
counter closure 184
build builtin:ArrayBuilder::new 282
build builtin:ArrayBuilder::push 338
build builtin:ArrayBuilder::freeze 383
```

読むだけの関数は 1 行も出ません。

### 価値は「ソースが言っていない確保」を見せること

builtin 呼び出しは見れば分かります。見落とすのは `counter` の 2 行 ——
**closure の環境確保**と、**捕獲された `let mut` が heap ref cell になる**こと。
どちらもソースのどこにも書いてありません。#1262 が「副産物として float
heap-box / closure env / 捕獲 mut セルの暗黙確保が診断で可視化される」と
書いているのがこれです。

### 極性

`builtin_allocates` は **未知の名前に `true` (確保する) を返します**。
確保するものを「しない」と答えるほうが、その逆より高くつくからです ——
過剰報告は読み手の 1 行で済みますが、過少報告は「確保サイトの一覧」を
黙って不完全にします。Float 族は確保扱い (linear backend が heap-box、#510)、
`push` 系も毎回確保扱い (実際に再確保するかは容量という実行時の性質で、
黙ると append ループを確保無しに見せます)。

### 実装で効かせた点

- **`expr_children`** (core の網羅的な子走査) に乗せたので、Expr の腕を手書きで
  並べません。腕が増えたら AST 側 1 箇所の更新で追従します
- **`mut-cell` は codegen 自身の述語 `is_mut_captured_in`** に訊きます ——
  `vibe escapes` と同じものなので、2 つのクエリが「どの束縛が box されるか」で
  食い違えません。スコープは `ELetMut` の **`rest`** を渡すこと: 関数本体全体を
  渡すと `let mut c` の束縛自体が含まれ、述語が局所束縛と読んで false を返します
- **directive 行は削除ではなく空白化**してから parse します。`parse_program_spans`
  はあらゆる `#` directive を拒否する (module-source emission が span を再出力
  するため) ので、そのまま継承すると `#cfg` / `#deprecated` を含むファイルで
  クエリ自体が落ちます。長さ不変なので offset は実ソースを指したまま (テストで固定)
- `__region_run` は確保サイトに数えません —— 確保しているのは closure の環境で、
  既に `closure` として報告済みです (二重計上でした)

---

## 検証

- `scripts/compiler_gate.sh` — **ok** (新設の `vibe allocs` 節を含む)
- `scripts/unit_test_runner.sh` — **628/628**
- `scripts/check_vibe_fmt.sh` — clean (943 files)
- `VIBE_TEST_BACKEND=gc` で FrozenArray fixture 単体も通過

gate の新節は**両方向**を見ます —— 確保しない関数が本当に空を返すことと、
暗黙の 2 サイト (closure env / mut cell) が本当に出ること。片方だけ pin しても
意味がありません。