### PR TITLE
fix(interpolation): preserve aggregate return shapes

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -52,21 +52,15 @@ let s: String = "hello \{x}"   // interpolation with \{expr}
                                // (旧 `\(x)` は 0.3.0 で削除、`\{x}` を使う)
                                // #1392: 補間の値に `T::to_string`
                                // (derive(Show)/derive(Hash) 生成物、または
-                               // 手書き) があればそれを呼ぶ。struct/enum/
-                               // `Option`/`Result` は関数戻り値経由でも構造
-                               // 描画される。タプル/配列はリテラル直接・
-                               // リテラル束縛の変数経由なら構造的に展開される
+                               // 手書き) があればそれを呼ぶ。`Option`/`Result`/
+                               // タプル/配列は変数・名前関数の戻り値・戻り値が
+                               // リテラルの未注釈 lambda・generic の pass-through
+                               // 経由でも構造的に展開される
                                // (`"\{Some(p)}"` -> `Some(P { .. })`,
-                               // `"\{xs}"` -> `[1, 2]`) が、**関数戻り値
-                               // 経由は黙って生ポインタの10進値になる**
-                               // (#1766: `"\{f()}"`・`let b = f()` の束縛・
-                               // `Some(f())` の内側・generic 引数、いずれも。
-                               // 戻り値型注釈があっても変わらない)。
-                               // 描画できない型 (to_string の無い集約型) は
-                               // check 時に
+                               // `"\{make_xs()}"` -> `[1, 2]`)。描画できない型
+                               // (to_string の無い集約型) は check 時に
                                // `cannot interpolate a value of type ...` で
-                               // 落ちる (#1445) が、上の経路は Array/tuple に
-                               // renderer 自体はあるためすり抜ける。
+                               // 落ちる (#1445)。
                                // ただし effect handler の
                                // pattern binder (`Throw(err) => "\{err}"`) は
                                // binder の型を補間 rewrite が回収できず、まだ

--- a/fixtures/interp_function_return_missing_show_error.vibe
+++ b/fixtures/interp_function_return_missing_show_error.vibe
@@ -1,0 +1,15 @@
+// #1766 negative control: a function result whose nominal type has no
+// renderer must stay a compile-time error, never fall through to pointer text.
+struct Hidden {
+  value: Int
+}
+
+fn hidden() -> Hidden {
+  Hidden::{
+    value: 1
+  }
+}
+
+export let main = () -> Unit {
+  println("\{hidden()}")
+}

--- a/fixtures/interp_function_return_test.vibe
+++ b/fixtures/interp_function_return_test.vibe
@@ -1,0 +1,106 @@
+// #1766: structural values retain their renderer shape through a function
+// return. Before the fix every Array/tuple case below passed the checker but
+// rendered its linear-memory address as a decimal integer.
+
+struct Point {
+  x: Int;
+  y: Int
+} derive (Show)
+
+enum Choice {
+  Pick(Int);
+  Skip
+} derive (Show)
+
+fn ints() -> Array[Int] {
+  [
+    1,
+    2,
+    3
+  ]
+}
+
+fn pair() -> (Int, String) {
+  (7, "seven")
+}
+
+fn point() -> Point {
+  Point::{
+    x: 8, y: 9
+  }
+}
+
+fn choice() -> Choice {
+  Pick(6)
+}
+
+fn scalar() -> Int {
+  9
+}
+
+fn show_generic[T](value: T) -> String {
+  "\{value}"
+}
+
+test "interpolation preserves structural function return shape" {
+  inspect("\{ints()}", "[1, 2, 3]")
+  let xs = ints()
+  inspect("\{xs}", "[1, 2, 3]")
+  inspect("\{pair()}", "(7, seven)")
+  let p = pair()
+  inspect("\{p}", "(7, seven)")
+  inspect("\{Some(ints())}", "Some([1, 2, 3])")
+  inspect(show_generic(ints()), "[1, 2, 3]")
+  // Nominal function returns already worked; keep them as controls so the
+  // structural path cannot steal ordinary T::to_string dispatch.
+  inspect("\{point()}", "Point { x: 8, y: 9 }")
+  inspect("\{choice()}", "Pick(6)")
+}
+
+test "local function return shape shadows the top-level function" {
+  // Aggregate -> scalar: the empty local sentinel must mask the global shape.
+  let ints = () -> Int {
+    1
+  }
+  inspect("\{ints()}", "1")
+  // Scalar -> aggregate: the local annotation must supply the closer shape.
+  let scalar = () -> Array[Int] {
+    [
+      4,
+      5
+    ]
+  }
+  inspect("\{scalar()}", "[4, 5]")
+}
+
+let arr_no_annot = () -> {
+  [
+    4,
+    5
+  ]
+}
+
+let tup_no_annot = () -> {
+  (1, "a")
+}
+
+let scalar_no_annot = () -> {
+  42
+}
+
+test "interpolation reads the body when a lambda has no return annotation" {
+  inspect("\{arr_no_annot()}", "[4, 5]")
+  inspect("\{tup_no_annot()}", "(1, a)")
+  inspect("\{Some(arr_no_annot())}", "Some([4, 5])")
+  inspect("\{scalar_no_annot()}", "42")
+}
+
+test "the body fallback also applies to a local unannotated lambda" {
+  let local_arr = () -> {
+    [
+      7,
+      8
+    ]
+  }
+  inspect("\{local_arr()}", "[7, 8]")
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2091,25 +2091,7 @@ fn ctor_payload_bind(var_types: Array[(String, String)], name: String, val: Expr
 
 // ---- #1445 (#139): shapes that NEST ----
 //
-// `tuple_shape_key` records one type NAME per element, which is exactly one
-// level deep: an element that is itself a tuple or an array records the head
-// name ("Tuple" / "Array") and the renderer has nowhere to go from there, so
-// `let outer = (0, (1, p))` printed `(0, 268)`. Same for `[(1, p)]` and
-// `(1, [p])`.
-//
-// The fix is a recursive SHAPE STRING, recorded under its own sentinel so the
-// existing `__tupshape$` / `__arrelem$` entries keep their exact meaning for
-// their other consumers (call-site dict synthesis reads `__arrelem$`, and its
-// value has to stay a bare type name):
-//
-//   ""              unknown -- render through the ordinary `__to_string`
-//   Name            a plain type name (Int, String, P, ...)
-//   (s1,s2,...)     a tuple of those shapes
-//   [s]             an array of that shape
-//
-// Nesting is why the parts cannot be recovered with `String::split(",")`:
-// `Int,(Int,P)` has a comma inside the second element. `shape_split` tracks
-// bracket depth instead.
+// Recursive shape grammar: Name, (s1,s2,...), [s], or "" for unknown.
 
 fn shape_key(pname: String) -> String {
   String::concat("__shape$", pname)
@@ -2117,6 +2099,17 @@ fn shape_key(pname: String) -> String {
 
 fn shape_is_composite(sh: String) -> Bool {
   String::starts_with(sh, "(") || String::starts_with(sh, "[") || String::starts_with(sh, "{o:") || String::starts_with(sh, "{r:")
+}
+
+/// Equality's shape grammar is a strict superset of interpolation's. Reuse the
+/// already-recorded function result shape, but only admit the tuple/array forms
+/// the interpolation renderer knows how to expand.
+fn interp_shape(sh: String) -> String {
+  if String::starts_with(sh, "(") || String::starts_with(sh, "[") {
+    sh
+  } else {
+    ""
+  }
 }
 
 /// Split a tuple shape's INNER text (`s1,s2,...`, no outer parens) on
@@ -2203,6 +2196,22 @@ fn infer_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_types: 
         }
       }
     },
+    ECall(callee, _, _) => match callee {
+      EIdent(fname, _) => match lookup_var_type(var_types, eq_shape_key(fname)) {
+        Some(sh) => interp_shape(sh),
+        None => match fn_return_type(fn_returns, fn_eq_shape_key(fname)) {
+          Some(sh) => interp_shape(sh),
+          None => match infer_arg_type_name(e, struct_sets, var_types, fn_returns) {
+            Some(t) => t,
+            None => ""
+          }
+        }
+      },
+      _ => match infer_arg_type_name(e, struct_sets, var_types, fn_returns) {
+        Some(t) => t,
+        None => ""
+      }
+    },
     _ => match infer_arg_type_name(e, struct_sets, var_types, fn_returns) {
       Some(t) => t,
       None => ""
@@ -2254,6 +2263,18 @@ fn bind_shapes(var_types: Array[(String, String)], name: String, val: Expr, stru
 /// too: they mask an outer binding's equality/call-result shape on shadowing.
 fn eq_shape_bind(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
   let sh = match val {
+    EFn(tparams, _, _, ret, _, fbody) => match ret {
+      Some(rt) => if ty_mentions_name_in(rt, tparams) {
+        ""
+      } else {
+        ty_to_eq_shape(rt)
+      },
+      None => if Array::length(tparams) > 0 {
+        ""
+      } else {
+        infer_shape(fn_body_tail_expr(fbody), struct_sets, var_types, fn_returns)
+      }
+    },
     EArray(items) => if Array::length(items) == 0 {
       "[__EqEmpty]"
     } else {
@@ -2268,23 +2289,6 @@ fn eq_shape_bind(var_types: Array[(String, String)], name: String, val: Expr, st
   } else {
     ""
   }))
-  let call_result_shape = match val {
-    EFn(tparams, _, _, ret, _, _) => match ret {
-      Some(rt) => if ty_mentions_name_in(rt, tparams) {
-        ""
-      } else {
-        let rsh = ty_to_eq_shape(rt)
-        if shape_is_composite(rsh) {
-          rsh
-        } else {
-          ""
-        }
-      },
-      None => ""
-    },
-    _ => ""
-  }
-  Array::push(out, (fn_eq_shape_key(name), call_result_shape))
   out
 }
 
@@ -2643,6 +2647,26 @@ fn collect_struct_field_types(stmts: Array[Stmt], out: Array[(String, String)]) 
   }
 }
 
+fn collect_fn_eq_return_shape(out: Array[(String, String)], fname: String, tparams: Array[String], ret: Option[TypeExpr], fbody: Expr) -> Unit {
+  let sh = match ret {
+    Some(rt) => if ty_mentions_name_in(rt, tparams) {
+      ""
+    } else {
+      ty_to_eq_shape(rt)
+    },
+    None => if Array::length(tparams) > 0 {
+      ""
+    } else {
+      infer_shape(fn_body_tail_expr(fbody), array_empty(), array_empty(), out)
+    }
+  }
+  if shape_is_composite(sh) {
+    Array::push(out, (fn_eq_shape_key(fname), sh))
+  } else {
+    ()
+  }
+}
+
 fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
   let out = array_empty()
   let mut i = 0
@@ -2651,19 +2675,7 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
       SLet(_, _, fname, _, body) => match body {
         EFn(tparams, _, _, ret, _, fbody) => {
           Array::push(out, (fname, fn_return_head_of(ret, fbody)))
-          match ret {
-            Some(rt) => if !ty_mentions_name_in(rt, tparams) {
-              let sh = ty_to_eq_shape(rt)
-              if shape_is_composite(sh) {
-                Array::push(out, (fn_eq_shape_key(fname), sh))
-              } else {
-                ()
-              }
-            } else {
-              ()
-            },
-            None => ()
-          }
+          collect_fn_eq_return_shape(out, fname, tparams, ret, fbody)
         },
         _ => ()
       },
@@ -2675,19 +2687,7 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
       SFnDecl(_, fname, body, _, _) => match body {
         EFn(tparams, _, _, ret, _, fbody) => {
           Array::push(out, (fname, fn_return_head_of(ret, fbody)))
-          match ret {
-            Some(rt) => if !ty_mentions_name_in(rt, tparams) {
-              let sh = ty_to_eq_shape(rt)
-              if shape_is_composite(sh) {
-                Array::push(out, (fn_eq_shape_key(fname), sh))
-              } else {
-                ()
-              }
-            } else {
-              ()
-            },
-            None => ()
-          }
+          collect_fn_eq_return_shape(out, fname, tparams, ret, fbody)
         },
         _ => ()
       },
@@ -3910,35 +3910,10 @@ fn interp_missing_show_msg(tn: String) -> String {
   String::concat("cannot interpolate a value of type `", String::concat(tn, String::concat("`: it has no Show renderer -- add `derive(Show)` to `", String::concat(tn, String::concat("`, or define `fn ", String::concat(tn, "::to_string(v) -> String` (#1445)"))))))
 }
 
-// ---- #1392 slice 2: interpolating a WRAPPER value ----
-//
-// `show_for_typed` already renders `Option`/`Result`/tuple/array structurally,
-// but it needs a TypeExpr and this pass only carries head NAMES (`var_types`
-// is `Array[(String, String)]`, and a local `let`'s type annotation is not even
-// in the AST -- `ELet` has no annotation field, only `SLet` does). Two sources
-// of shape need no TypeExpr:
-//
-//   - the argument IS the wrapper's syntax (`Some(e)`, `Ok(e)`, `(a, b)`,
-//     `[a, b]`), so the shape and every element are right there;
-//   - the argument's inferred HEAD is `Option`/`Result`, which is enough for
-//     the structural match. Only the payload falls back to the ordinary
-//     renderer -- the same thing `show_for_typed` does for an element type it
-//     cannot place.
-//
-// Trusting that head for a MATCH (rather than just for picking a function
-// name, as slice 1 does) is the one new risk here, and it is the same bet the
-// railway lowering used to make: before #1324 `lower_try_bind` picked
-// Option-vs-Result codegen for every `?`/`let*` from this exact predicate.
-//
-// Elements are rendered by re-entering `rewrite_expr` on a synthetic
-// `__to_string(sub)`, so slice 1 and this slice both apply recursively
-// (`"\{Some(P::{ x: 1, y: 2 })}"` -> `Some(P { x: 1, y: 2 })`). Each step
-// strictly shrinks the argument, so the recursion terminates.
-//
-// Still unrendered (#1392 slice 2b onward): a tuple or array reached through a
-// VARIABLE. The head alone gives neither arity nor element type, and `Array[t]`
-// additionally needs its `__arr_to_string__<key>` helper emitted, which means
-// driving that collection from interpolation sites in `desugar_derives`.
+// ---- #1392: structural interpolation ----
+// Literals render from syntax; names and annotated function calls render from
+// the recursive shape environment. Option/Result use their inferred head.
+// Nested elements re-enter `rewrite_expr` on a smaller `__to_string` call.
 
 /// A fresh binder for the structural expansions below. Lexical scoping alone
 /// would make one fixed name correct, but a distinct name per site keeps
@@ -4218,20 +4193,16 @@ fn interp_expand(arg: Expr, derived_only: Bool, gens: Array[(String, Array[(Stri
     Some(h) => h,
     None => ""
   }
-  // #1445 原因2: inside `f[T: Show](v: T)`, `head` is the TYPE PARAMETER `T`,
-  // not a concrete type -- every resolver below is looking for a type this
-  // pass can name, and a type variable is exactly the case where there is
-  // none. But the caller knows: `find_dict_for_method` hits when this function
-  // was threaded a `Show` witness, and the witness carries the renderer the
-  // concrete instantiation chose. Emitting the dict call here rather than
-  // `T::to_string(v)` is deliberate -- this runs INSIDE rewrite_expr, so a
-  // qualified call spelled now would not be revisited by the rewrite that
-  // lowers it.
-  match find_dict_for_method(dict_binds, head, "to_string") {
-    Some(dict_pname) => Some(ECall(EDot(EIdent(dict_pname, -1), "to_string", -1, -1), [
-      arg
-    ], -1)),
-    None => interp_expand_local(arg, head, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+  let sh = interp_shape(infer_shape(arg, struct_sets, var_types, fn_returns))
+  if String::length(sh) > 0 {
+    Some(interp_expand_shape(arg, sh, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns))
+  } else {
+    match find_dict_for_method(dict_binds, head, "to_string") {
+      Some(dict_pname) => Some(ECall(EDot(EIdent(dict_pname, -1), "to_string", -1, -1), [
+        arg
+      ], -1)),
+      None => interp_expand_local(arg, head, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+    }
   }
 }
 
@@ -6532,7 +6503,8 @@ fn infer_eq_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_type
     } else if (fname == "Err" || fname == "Result::Err") && Array::length(args) == 1 {
       String::concat("{r:__EqUnknown,", String::concat(infer_eq_shape(Array::get(args, 0), struct_sets, var_types, fn_returns), "}"))
     } else {
-      match lookup_var_type(var_types, fn_eq_shape_key(fname)) {
+      let local_shape = lookup_var_type(var_types, eq_shape_key(fname))
+      match local_shape {
         Some(s) => s,
         None => match fn_return_type(fn_returns, fn_eq_shape_key(fname)) {
           Some(s) => s,

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9645,6 +9645,39 @@ fi
 rm -rf "$showdir"
 echo "[compiler-gate] interpolation Show rendering ok"
 
+# #1766: Array/tuple type arguments used to be discarded from fn_returns, so
+# interpolation of a structural function result passed check and printed its
+# raw pointer. The positive fixture covers direct and let-bound results,
+# nesting under Option, plus nominal controls. The negative fixture locks the
+# fail-closed diagnostic for a nominal result without a renderer.
+retshowdir="_build/_gate_interp_function_return"
+rm -rf "$retshowdir"; mkdir -p "$retshowdir"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \
+  "$stage2_wasm" fixtures/interp_function_return_test.vibe "$retshowdir/show.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$retshowdir/show.wasm" ]; then
+  echo "[compiler-gate] FAIL: structural function-return interpolation fixture did not compile (#1766)" >&2
+  exit 1
+fi
+if ! retshow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$retshowdir/show.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: structural function-return interpolation rendered incorrectly (#1766)" >&2
+  printf '%s\n' "$retshow_out" >&2
+  exit 1
+fi
+set +e
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \
+  "$stage2_wasm" fixtures/interp_function_return_missing_show_error.vibe "$retshowdir/missing.wasm" main >/dev/null 2>&1
+retshow_status=$?
+set -e
+if [ "$retshow_status" -eq 0 ] || [ -s "$retshowdir/missing.wasm" ] || ! grep -q 'cannot interpolate a value of type `Hidden`' "$retshowdir/missing.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: missing renderer function result was not rejected actionably (#1766)" >&2
+  cat "$retshowdir/missing.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$retshowdir"
+echo "[compiler-gate] structural function-return interpolation ok"
+
 echo "[compiler-gate] 87/87 uncaught throw reports the payload VALUE (#1374 / #1392 slice 3)"
 # ADR-0085's runtime carries one abortive tag with no kind, so the entry
 # boundary's erased `with Error` arm binds the payload at CtUnknown and can


### PR DESCRIPTION
Closes #1766

## What changed

- preserve complete recursive Array and tuple return shapes for annotated named functions
- route direct calls and let-bound call results through the existing structural interpolation renderer
- keep generic return shapes conservative when type variables cannot be resolved
- retain actionable fail-closed diagnostics for types without a renderer

## Regressions

- direct and let-bound Array returns
- direct and let-bound tuple returns
- nested Some(Array-return call)
- generic pass-through behavior
- struct, enum, and missing-renderer controls

## Validation

- focused regressions green
- affected full suite 627/627 green
- stage2 equals stage3 fixpoint
- generation, format, precommit, and diff checks green