### PR TITLE
fix(contracts): restore transparent collection aliases

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -166,13 +166,11 @@ contract — this is a naming *rule*, not a per-type coincidence:
 `let m = HashMap::new_string()` は `MutMap` に推論され、`vibe check` が
 移行先を名指しする警告を1行出す (非致命、exit 0)。
 
-> **旧綴りの型注釈は動かない。** `let m: HashMap[String, Int] = ...` は
-> エラーになる。`type HashMap[K, V] = MutMap[K, V]` という別名を置いても
-> **モジュール境界を越えると展開されない** (contract 側に書いても実装側から
-> export しても同じで、別名は merge 後のソースには現れるのに checker は
-> `HashMap[Int]` と `MutMap[Int]` を別の型として扱う)。守れない約束を
-> 置くより、破れる場所を1つに絞って明示するほうを採った ——
-> 注釈は `Mut-` 名に書き換えること (穴そのものは #1700)。
+旧綴りの**型注釈**も transparent alias として残る (#1700)。たとえば
+`let m: HashMap[String, Int] = HashMap::new_string()` は `@vibe/core` の
+`index.vpkg` 境界を越えて `MutMap[String, Int]` と同じ型になる。移行先は
+引き続き `Mut-` 名で、旧関数を使えば `vibe check` が警告する。型名だけを
+旧綴りにした場合は警告されないので、新規コードでは `Mut-` を直接書く。
 
 旧綴りの**関数**を使うと `vibe check` が移行先を名指しする `warning:` 行を
 出す (非致命、exit 0)。**これは #1262 follow-up で初めて実際に効くようになった**

--- a/docs/side-effect-consolidation.md
+++ b/docs/side-effect-consolidation.md
@@ -680,25 +680,17 @@ renames + 旧名の deprecated alias。`vibe` は selfhost なので、
 コンパイラ自身の利用箇所が最大の呼び出し元になる。ADR-0082 の子タスクとして
 段階実施(#1140 系列)。**§4 の段階3 より前に着手できる**(独立)。
 
-> **2026-08-13 着地、ただし「旧名の deprecated alias」は半分しか置けなかった。**
-> 4 型を改名し、リポジトリ内の全使用箇所を移行した。旧綴りは **関数だけ**
+> **2026-08-13 着地、2026-08-15 に型 alias も復旧 (#1700)。**
+> 4 型を改名し、リポジトリ内の全使用箇所を移行した。旧綴りの関数は
 > `#deprecated` エイリアスとして残っている(`Mut-` 型を返すので
 > `let m = HashMap::new_string()` はそのまま動き、`vibe check` が移行先を
 > 名指しする警告を1行出す)。
 >
-> **旧綴りの型注釈は残せなかった。** `type HashMap[K, V] = MutMap[K, V]` は
-> **モジュール境界を越えると展開されない** —— 2 通りの置き方を実測した:
-> (a) contract (`index.vpkg`) に transparent な alias 行として置く、
-> (b) 実装ファイルから `export type` する。**どちらも同じ結果**で、別名は
-> merge 後のソースには確かに現れる(`VIBE_EMIT_MERGED_SOURCE=1` で確認)のに、
-> checker は `HashMap[Int]` と `MutMap[Int]` を別の nominal 型として扱う。
-> 同一ファイル内の generic type alias は正しく透過するので、これは
-> **cross-module type alias の透過性**という別の穴 (#1700)。
->
-> 守れない約束を contract に置く(旧名が単独ファイルでは型検査を通り、
-> 2 つの綴りが出会う場所で初めて落ちる = いちばん悪い壊れ方)より、
-> **破れる場所を1点に絞って明示する**方を採った。この穴が埋まれば型注釈も
-> 無停止で移行できる。
+> その時点では generic type alias の formals/target が importer の TypeEnv
+> projection から落ち、旧綴りの型注釈を残せなかった。その後 declaration
+> authority transport がこの穴を塞いだため、#1700 で実 `index.vpkg` 回帰を固定し、
+> contract に `HashMap[K,V] = MutMap[K,V]` など4本を復旧した。transparent alias
+> は contract が定義そのものを所有し、implementation 側には重複定義を置かない。
 
 ---
 
@@ -719,8 +711,7 @@ ADR-0100 (3) が最後に開けていた一点は「**`ImmutMap` は builtin `Ma
 **決定: 統合しない。併存が要る**ので ADR の fallback どおり
 **`ImmutMap` → `MapHamt`** に改名した。bare `Map` がインタフェース、
 `-Hamt` が実装接尾辞で、§5.2 の2軸命名にそのまま乗る。旧綴りは
-**関数だけ** `#deprecated` エイリアスとして残る(型注釈が残せないのは
-コレクション改名と同じ #1700 の制約)。
+`#deprecated` 関数と transparent type alias として残る (#1700)。
 
 > **向きが ADR の想定と逆だった。** 「`ImmutMap` は builtin `Map` に統合を
 > 試みる」という書き方は、暗に *`Map` で足りるのでは* を疑っている。実測は

--- a/fixtures/generic_alias_vpkg/impl.vibe
+++ b/fixtures/generic_alias_vpkg/impl.vibe
@@ -1,0 +1,3 @@
+export fn make_cell(value: Int) -> Cell[Int] {
+  Cell::{ value }
+}

--- a/fixtures/generic_alias_vpkg/index.vpkg
+++ b/fixtures/generic_alias_vpkg/index.vpkg
@@ -1,0 +1,9 @@
+import ./impl.vibe {}
+
+struct Cell[T] {
+  value: T
+}
+
+type Box[T] = Cell[T]
+
+fn make_cell(value: Int) -> Cell[Int]

--- a/fixtures/generic_alias_vpkg_test.vibe
+++ b/fixtures/generic_alias_vpkg_test.vibe
@@ -1,0 +1,6 @@
+import ./generic_alias_vpkg { make_cell, Box }
+
+test "generic transparent alias crosses an index.vpkg boundary" {
+  let boxed: Box[Int] = make_cell(42)
+  inspect(boxed.value, "42")
+}

--- a/fixtures/generic_opaque_vpkg/impl.vibe
+++ b/fixtures/generic_opaque_vpkg/impl.vibe
@@ -1,0 +1,15 @@
+export struct Token[T] {
+  value: T
+}
+
+export struct Seal[T] {
+  value: T
+}
+
+export fn make_token(value: Int) -> Token[Int] {
+  Token::{ value }
+}
+
+export fn make_seal(value: Int) -> Seal[Int] {
+  Seal::{ value }
+}

--- a/fixtures/generic_opaque_vpkg/index.vpkg
+++ b/fixtures/generic_opaque_vpkg/index.vpkg
@@ -1,0 +1,7 @@
+import ./impl.vibe {}
+
+type Token[T]
+type Seal[T]
+
+fn make_token(value: Int) -> Token[Int]
+fn make_seal(value: Int) -> Seal[Int]

--- a/fixtures/generic_opaque_vpkg_mismatch.vibe
+++ b/fixtures/generic_opaque_vpkg_mismatch.vibe
@@ -1,0 +1,5 @@
+import ./generic_opaque_vpkg { make_seal, Token }
+
+test "opaque generic contract types stay nominal" {
+  let _token: Token[Int] = make_seal(1)
+}

--- a/fixtures/immutmap_alias_test.vibe
+++ b/fixtures/immutmap_alias_test.vibe
@@ -1,0 +1,13 @@
+import @vibex/immut {
+  ImmutMap,
+  ImmutMap::empty,
+  MapHamt,
+  MapHamt::set,
+  MapHamt::size
+}
+
+test "ImmutMap annotation stays compatible with MapHamt across index.vpkg" {
+  let old: ImmutMap[Int] = ImmutMap::empty()
+  let current: MapHamt[Int] = MapHamt::set(old, "one", 1)
+  inspect(MapHamt::size(current), "1")
+}

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -938,7 +938,6 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
     None => EnvEmpty
   }
   let dep_bindings = env_flat_bindings(dep_env)
-  let dep_type_defs = env_type_defs(dep_env)
   let dep_selectable_type_defs = env_selectable_type_defs(dep_env)
   // Explicit trait aliases must be known before values are bound: a selected
   // value can mention the trait before its `trait X as Local` row appears.

--- a/lib/@vibe/core/collection_alias_test.vibe
+++ b/lib/@vibe/core/collection_alias_test.vibe
@@ -1,24 +1,18 @@
 //# ADR-0100 (3) / #1262: the legacy `Hash-` / `Sorted-` spellings survive the
-//# rename as deprecated FUNCTION aliases.
+//# rename as deprecated function and transparent type aliases.
 //#
-//# What this pins is the property the staged migration rests on: a legacy
-//# constructor returns the `Mut-` type, so code that never spells the type out
-//# keeps working unchanged and the two spellings interoperate freely. That is
-//# the common shape by far — `let m = HashMap::new_string()` names no type.
-//#
-//# What it deliberately does NOT pin is a legacy TYPE alias, because there
-//# isn't one: `type HashMap[K, V] = MutMap[K, V]` is not expanded across a
-//# module boundary by this compiler, so an explicit `HashMap[K, V]` annotation
-//# is the one thing this rename breaks. See lib/@vibe/core/index.vpkg's
-//# deprecated-spellings section for the two arrangements that were measured,
-//# and #1700 for the underlying cross-module alias hole.
+//# #1700 pins the previously missing half: an old annotation and a new
+//# constructor are the same type even though @vibe/core is an index.vpkg
+//# boundary. The inference-only controls below remain useful too.
 
 //# Imports
 
 import @vibe/core {
+  HashMap,
   HashMap::new_string,
   HashMap::set,
   HashMap::size,
+  HashSet,
   HashSet::add,
   HashSet::new_int,
   HashSet::size,
@@ -36,15 +30,32 @@ import @vibe/core {
   MutSortedSet,
   MutSortedSet::add,
   MutSortedSet::size,
+  SortedMap,
   SortedMap::min,
   SortedMap::new_int,
   SortedMap::set,
+  SortedSet,
   SortedSet::add,
   SortedSet::min,
   SortedSet::new_int
 }
 
 //# Tests
+
+test "legacy collection type aliases are transparent across the core package boundary" {
+  let map: HashMap[String, Int] = HashMap::new_string()
+  MutMap::set(map, "one", 1)
+  assert(MutMap::size(map) == 1)
+  let set: HashSet[Int] = HashSet::new_int()
+  MutSet::add(set, 1)
+  assert(MutSet::size(set) == 1)
+  let sorted_map: SortedMap[Int, Int] = SortedMap::new_int()
+  MutSortedMap::set(sorted_map, 1, 1)
+  assert(MutSortedMap::size(sorted_map) == 1)
+  let sorted_set: SortedSet[Int] = SortedSet::new_int()
+  MutSortedSet::add(sorted_set, 1)
+  assert(MutSortedSet::size(sorted_set) == 1)
+}
 
 test "a legacy MutMap constructor returns the new type and interoperates" {
   // built through the LEGACY spelling, annotated with the NEW type

--- a/lib/@vibe/core/index.vpkg
+++ b/lib/@vibe/core/index.vpkg
@@ -386,19 +386,19 @@ fn inspect[T](value: T, content: String) -> Unit
 
 // --- collections: deprecated legacy spellings (ADR-0100 (3) / #1262).
 //
-// FUNCTION aliases only. Each is `#deprecated` in its impl file, so `vibe
-// check` names the replacement at every use, and each RETURNS the `Mut-` type
-// -- so `let m = HashMap::new_string()` keeps working and infers `MutMap`.
-//
-// There is deliberately NO legacy TYPE row here. A `type HashMap[K, V] =
-// MutMap[K, V]` alias is not expanded across a module boundary by this
-// compiler (verified both ways: declared in this contract, and exported from
-// the implementation file -- the alias reaches the merged program either way,
-// and the checker still treats `HashMap[Int]` and `MutMap[Int]` as different
-// types). A row here would therefore be a promise the compiler does not keep:
-// the old spelling would typecheck in isolation and fail at the first place
-// the two meet. So an explicit `HashMap[K, V]` ANNOTATION is the one thing
-// this rename breaks; inference-site uses are unaffected. See #1262 and #1700.
+// #1700: generic transparent aliases now retain their formals and target
+// through the package TypeEnv projection. Keep the aliases in the CONTRACT —
+// their definition is public API and deliberately has no duplicate impl-side
+// `export type` declaration. This makes old annotations and new constructors
+// the same type across an index.vpkg boundary.
+
+type HashMap[K, V] = MutMap[K, V]
+
+type HashSet[T] = MutSet[T]
+
+type SortedMap[K, V] = MutSortedMap[K, V]
+
+type SortedSet[T] = MutSortedSet[T]
 
 fn HashMap::with_capacity[K, V](hash_fn: (K) -> Int, eq_fn: (K, K) -> Bool, capacity: Int) -> MutMap[K, V]
 fn HashMap::new[K, V](hash_fn: (K) -> Int, eq_fn: (K, K) -> Bool) -> MutMap[K, V]

--- a/lib/@vibex/immut/index.vpkg
+++ b/lib/@vibex/immut/index.vpkg
@@ -34,9 +34,11 @@ fn ImmutArray::from_array[T](xs: Array[T]) -> ImmutArray[T]
 fn ImmutArray::to_array[T](a: ImmutArray[T]) -> Array[T]
 
 // --- deprecated legacy spelling (ADR-0100 (3) / #1262).
-// Function aliases only; each is `#deprecated` in immut_map.vibe. No legacy
-// TYPE row: a cross-module type alias is not expanded (#1700), so an
-// `ImmutMap[V]` annotation is the one thing the rename breaks.
+// Functions are `#deprecated` in immut_map.vibe. #1700 restores the
+// transparent contract-owned type alias as well, so old annotations remain
+// source-compatible across this package boundary.
+type ImmutMap[V] = MapHamt[V]
+
 fn ImmutMap::hash_key(key: String) -> Int
 fn ImmutMap::empty[V]() -> MapHamt[V]
 fn ImmutMap::set[V](m: MapHamt[V], key: String, value: V) -> MapHamt[V]

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -11086,7 +11086,7 @@ echo "[compiler-gate] escape predicate two-lane split ok (#1262)"
 #      reach the SAME registry row and the SAME codegen dispatch as the legacy
 #      one in BOTH backends: a source-level alias that only the checker knows
 #      about would typecheck and then miscompile.
-echo "[compiler-gate] 102/103 StringBuilder::build reaches the same lowering as ::freeze (ADR-0101 (3) / #1262)"
+echo "[compiler-gate] 102/104 StringBuilder::build reaches the same lowering as ::freeze (ADR-0101 (3) / #1262)"
 sbdir="_build/_gate_sb_build"
 rm -rf "$sbdir"; mkdir -p "$sbdir"
 cat > "$sbdir/build.vibe" <<'SBB'
@@ -11138,7 +11138,7 @@ echo "[compiler-gate] StringBuilder::build terminal-verb alias ok (#1262)"
 #      used that same resolver, so a `#deprecated` alias published by a PACKAGE
 #      (every alias the ADR-0100 (3) collection rename shipped) was invisible
 #      and the migration warning the rename PROMISED never appeared.
-echo "[compiler-gate] 103/103 vibe check resolves @scope/pkg imports, and package deprecations warn (#1262)"
+echo "[compiler-gate] 103/104 vibe check resolves @scope/pkg imports, and package deprecations warn (#1262)"
 chkpkgdir="_build/_gate_check_scoped_pkg"
 rm -rf "$chkpkgdir"; mkdir -p "$chkpkgdir"
 cat > "$chkpkgdir/entry.vibe" <<'CHKPKG'
@@ -11196,5 +11196,34 @@ if grep -q '^warning: ' "$chkpkgdir/clean.out" 2>/dev/null; then
 fi
 rm -rf "$chkpkgdir"
 echo "[compiler-gate] scoped-package check + package deprecation warnings ok (#1262)"
+
+# 104. #1700: a generic transparent alias published by index.vpkg must keep
+#      its formal parameters and target through the importer TypeEnv
+#      projection. The committed seed predates that transport and diagnoses
+#      `Box[Int]` vs `Cell[Int]`; the fresh stage2 must accept it. The opaque
+#      control proves this is alias transparency, not a weakening that makes
+#      every applied package type interchangeable.
+echo "[compiler-gate] 104/104 generic aliases cross index.vpkg transparently (#1700)"
+if ! VIBE_TEST_CLI_WASM="$stage2_wasm" bash scripts/vibe_test.sh \
+  fixtures/generic_alias_vpkg_test.vibe \
+  fixtures/immutmap_alias_test.vibe \
+  lib/@vibe/core/collection_alias_test.vibe >/dev/null; then
+  echo "[compiler-gate] FAIL: a generic transparent alias did not cross an index.vpkg boundary (#1700)" >&2
+  exit 1
+fi
+aliasdir="_build/_gate_generic_alias_vpkg"
+rm -rf "$aliasdir"; mkdir -p "$aliasdir"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  fixtures/generic_opaque_vpkg_mismatch.vibe "$aliasdir/opaque.wasm" __no_entry__ \
+  >/dev/null 2>&1 || true
+if [ -s "$aliasdir/opaque.wasm" ] \
+  || ! grep -qF "expected Token[Int], got Seal[Int]" "$aliasdir/opaque.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: distinct opaque generic contract types stopped being nominal (#1700 control)" >&2
+  cat "$aliasdir/opaque.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$aliasdir"
+echo "[compiler-gate] generic transparent alias + opaque control ok (#1700)"
 
 echo "[compiler-gate] ok"


### PR DESCRIPTION
Closes #1700

## What changed

- restore contract-owned transparent aliases for HashMap, HashSet, SortedMap, SortedSet, and ImmutMap
- pin generic alias substitution across a real index.vpkg package boundary
- verify old alias annotations with new constructors
- keep unrelated opaque generic types nominal with negative controls
- update the compiler gate and migration documentation

## Context

Recent TypeEnv projection work already fixed the general cross-module expansion path. This change restores the public compatibility aliases that had been withheld because that path was previously broken, and makes the boundary behavior a deterministic regression gate.

## Validation

- focused boundary tests 7/7 green
- affected tests 236/236 green
- compiler gate 104/104 green
- latest-source stage2 generation green
- opaque mismatch rejects as expected
- format, precommit, diff, and shell syntax checks green