### PR TITLE
fix(checker): reject unhandled entry effects

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -851,8 +851,18 @@ its declarations and `handle` expressions.
 | runtime scheduling policy | runtime itself | `Async` |
 
 The ordered default and cache-safe owners preserve their existing output.
-Checker row filtering and WIT import filtering use only the predicate-based
-entry/runtime policy; WIT mapping and handler behavior are unchanged.
+At a program entry (`main` or `_start`), the checker admits only the union of
+host-provider labels and entry/runtime-managed labels. A user effect such as
+`Ask` / `Ask::Get` must be discharged by `handle ... with Ask` before that
+boundary; adding it to `main`'s `with` row is rejected with a located diagnostic
+(#1683). Ordinary helper functions still fix a missing effect by adding it to
+their row so callers can decide where to handle it. WIT mapping and handler
+behavior are unchanged. Provider spelling alone grants no authority:
+`Fs::Custom` from `effect Fs { Custom() -> Int }` is still a user operation and
+must be handled, while the registry-owned `Fs::read_file` remains a host
+operation even if another linked module has an unrelated `effect Fs`.
+Entry rows must also be concrete; an unresolved `with e` is rejected with a
+hint to close the row rather than the invalid suggestion `handle ... with e`.
 
 ### Atomic stdin provider stream (#1539)
 

--- a/docs/effect-taxonomy-entry-policy.md
+++ b/docs/effect-taxonomy-entry-policy.md
@@ -8,11 +8,12 @@ Related: #1218, ADR-0071(effectset), ADR-0075(`.vibex` runtime contract),
 ADR-0073(checked `Error`), ADR-0068(concurrency)。背景と選択肢は
 [effect-taxonomy-review.md](effect-taxonomy-review.md) を参照。
 
-> **Prospective model boundary (#1496):** This proposed ADR and the formal
-> `formal/VibeFormal/Effect/Taxonomy*.lean` model describe a future semantic
-> admission model. They are not the current compiler registry. Today,
-> `core/standard_effect_policy.vibe` stores only standard host-provider and
-> entry-execution policy metadata; it does not classify ordinary source effects.
+> **Implementation boundary (#1496, #1683):** The full resource-qualified
+> taxonomy in the formal model remains prospective. The current compiler uses
+> the narrower `core/standard_effect_policy.vibe` registry as an executable
+> entry-admission boundary: a row label is admitted when a standard host
+> provider or the entry/runtime policy owns it; every other source effect must
+> be handled before `main` / `_start`.
 
 ## Context
 
@@ -79,9 +80,12 @@ Phase 2 以降の追加であり、この ADR では構文を決めない。
   どおり利用できる。entry 直前に discharge すればよい。
 - `Error` の既存の entry-boundary 処理は維持する。改名を先に行わないため、
   既存ソースの一括変更や bootstrap bump は不要である。
-- `Fs` / `Env` / `Process` / `Stdout` / `HttpServer` の resource-kind
-  retrofit が完了するまでは、この entry row 検査を有効化しない。現在の
-  string-label checker だけでは分類を表現できないためである。
+- 現在の entry row 検査は standard policy registry に載る既存 provider と
+  entry/runtime owner を許可し、その他を fail-closed にする (#1683)。明示
+  resource kind と metadata-driven classification は後続 phase のままである。
+  同名 effect の user operation は provider authority を得ない。一方、linked
+  module に同名 effect があっても registry-owned operation の authority は失わない。
+  row variable を含む open row も entry contract として reject する。
 
 ## Non-goals
 
@@ -100,8 +104,10 @@ Phase 2 以降の追加であり、この ADR では構文を決めない。
    通ることを確認する。
 2. 明示 resource kind を持つ capability と、resource kind を持たない
    algebraic effect を checker が区別できるようにする。
-3. `.vibex` の `main` に残る row を分類し、algebraic effect を残した最小
-   fixture を reject、capability/core ambient の fixture を accept する。
+3. `.vibex` の `main` / `_start` に残る row を current standard policy で分類し、
+   user effect を reject、host provider / Exception / Async を accept する。
+   **#1683 で current-policy slice は実装済み**。resource-qualified taxonomy
+   への置換は Phase 1/2 の metadata 導入後に行う。
 4. その残余 row のみを WIT / `Entry.requires` / host preflight に渡す。
 
 ## Formal contract
@@ -184,14 +190,15 @@ Implementation sequence 1–4 と compiler fixture は引き続き必要であ�
 | 項目 | 根拠 / 観測 | 結論 |
 | --- | --- | --- |
 | 期待する契約 | ADR-0075 は `main` の closed/exact row と host preflight を要求する | entry row は host が解決可能でなければならない |
-| 実装観測 | `loader/loader.vibe` は `.vibex` の形と explicit row を検証するが、exact operation-row equality は後続 phase と明記している | 本 ADR は直ちに checker を変更しない |
+| 実装観測 | `checker_effects.vibe` は `main` / `_start` の row を `is_entry_admitted_effect` で検査する (#1683) | host/runtime owner のない user effect は WIT/codegen 前に reject する |
 | 実装観測 | `checker_effects.vibe` は effect を文字列ラベルで追跡し、`Error` / `Async` を特別扱いしている | effect class/resource kind metadata が先行条件である |
-| 回帰ガード候補 | `main with Logger` は reject、`main with Fs` と `main with Exception` は accept | Phase 3 の fixture と compiler gate に固定する |
+| 回帰ガード | `main with Ask` / `_start with Ask` は reject、`main with Fs + Exception + Async` は accept | checker test に固定済み (#1683) |
 | 形式モデル | taxonomy-level requirement、entry/host/spawn 判定、handler discharge を Lean で定義した | ADR の意味論は machine-checked。checker 対応は未証明 |
 | metadata classifier | exactly-one metadata lookup と argument shape から complete row を分類し、unknown/duplicate/malformed を fail-closed にした | 実装 metadata はこの contract に対応させる |
 | Oracle corpus | 正負15ケースを Lean から TSV に生成し、stale snapshot を `formal-check` で拒否する | contract の回帰ガードは自動化済み。selfhost differential は metadata API 待ち |
 | contract refinement | exact capability を operation/claim/binding に投影し、taxonomy admission から ADR-0075 preflight への含意を Lean で証明した | taxonomy check は WIT/host projection より前に必須 |
 | path-scope policy | restricted glob の overlap と共通 path の存在が同値で、diagnostic witness の健全性と authority 一意性を証明した | logical/physical の二段階で異権限の重複を exact に reject し、共通 path を報告する |
 
-Phase 3 では上記3 fixture を導入し、checker の許可述語と Lean contract の
-対応を回帰ガードにする。
+Phase 3 の current-policy slice は #1683 の checker test で固定した。完全な
+resource-qualified classifier と Lean contract の correspondence は引き続き
+metadata API 導入後の作業である。

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -527,6 +527,35 @@ handle { greet("world") } with Logger {
 }
 ```
 
+An ordinary function may expose a user-defined effect in its `with` row so a
+caller can handle it. A program entry (`main` or `_start`) cannot: only standard
+host-provider effects (`Fs`, `Env`, `Stdout`, and the other provider labels),
+entry-boundary `Exception`, and runtime-managed `Async` may remain there. Handle
+a user effect before it reaches the entry boundary:
+
+Admission follows operation ownership, not just the base effect spelling. A
+user operation `Fs::Custom` does not acquire the standard `Fs` host provider;
+the registry-owned `Fs::read_file` remains host-owned when an unrelated linked
+module declares another effect named `Fs`.
+Entry rows are closed contracts, so a row variable such as `with e` must be
+made concrete before the entry boundary.
+
+```vibe
+effect Ask {
+  Get() -> Int
+}
+
+fn ask() -> Int with Ask::Get {
+  perform Ask::Get()
+}
+
+fn main() -> Int {
+  handle { ask() } with Ask {
+    Get() => resume(42)
+  }
+}
+```
+
 ## Operators
 
 Precedence is high to low.

--- a/fixtures/contract_effectset_signature_alias_main.vibe
+++ b/fixtures/contract_effectset_signature_alias_main.vibe
@@ -5,7 +5,8 @@
 // fixtures/contract_effectset_vpkg_main.vibe.
 import ./contract_effectset_signature_alias { read_one }
 
-export let main = () -> Int with Ask + Ask::Get {
+// The imported helper exposes Ask; the real entry discharges it (#1683).
+export let main = () -> Int {
   handle {
     read_one()
   } with Ask {

--- a/fixtures/contract_effectset_vpkg_main.vibe
+++ b/fixtures/contract_effectset_vpkg_main.vibe
@@ -8,7 +8,8 @@
 // as fixtures/effect_handle_replay_corruption.vibe and friends.
 import ./contract_effectset_vpkg { read_one }
 
-export let main = () -> Int with Ask + Ask::Get {
+// The imported helper exposes Ask; the real entry discharges it (#1683).
+export let main = () -> Int {
   handle {
     read_one()
   } with Ask {

--- a/fixtures/effect_effectset_expansion.vibe
+++ b/fixtures/effect_effectset_expansion.vibe
@@ -16,7 +16,7 @@ import ../lib/@vibe/core {
 // does not equal "Ask::Get", and outer's declared row would need to spell
 // out the operation directly.
 //
-// `main`'s own `with Ask + Ask::Get` is unrelated to effectset
+// `run_effectset`'s own `with Ask + Ask::Get` is unrelated to effectset
 // expansion -- it satisfies a separate, pre-existing checker requirement
 // that a `handle ... with Effect` expression's enclosing declared row
 // authorize the whole effect name in addition to whatever the handled body
@@ -37,7 +37,9 @@ let outer = () -> Int with AskAll {
   read_one()
 }
 
-export let main = () -> Int with Ask + Ask::Get {
+// This remains an ordinary function because #1683 correctly forbids a user
+// effect from escaping a real `main` entry row.
+export let run_effectset = () -> Int with Ask + Ask::Get {
   handle {
     outer()
   } with Ask {
@@ -49,13 +51,13 @@ test "effectset row expansion authorizes the transitive operation requirement" {
   // #1571: expectation lives beside the code (updatable via `vibe test
   // --update`) instead of in a `__DATA__` tail. The wrapping handle is
   // required because a test block's own row cannot authorize `Ask`, and
-  // `main`'s declared row still names it even though `main` discharges the
+  // `run_effectset`'s declared row still names it even though it discharges the
   // effect itself -- so the outer arm can never actually fire (resume(0) is
   // deliberately NOT the expected value: the inner handler must win). This
   // exact shape -- calling a self-discharging fn from under another handle
   // for the same effect -- was rejected before #1595.
   handle {
-    inspect(main(), "42")
+    inspect(run_effectset(), "42")
   } with Ask {
     Get => resume(0)
   }

--- a/fixtures/effect_effectset_param_expansion.vibe
+++ b/fixtures/effect_effectset_param_expansion.vibe
@@ -33,7 +33,8 @@ let read_one = () -> Int with Ask::Get {
   perform Ask::Get
 }
 
-export let main = () -> Int with Ask + Ask::Get {
+// Ordinary row-carrying function, not an entry (#1683).
+export let run_param_effectset = () -> Int with Ask + Ask::Get {
   handle {
     run_with(read_one)
   } with Ask {
@@ -45,12 +46,12 @@ test "effectset expansion covers a callback parameter's own row" {
   // #1571: expectation lives beside the code (updatable via `vibe test
   // --update`) instead of in a `__DATA__` tail. The wrapping handle is
   // required because a test block's own row cannot authorize `Ask`;
-  // `main` discharges the effect itself, so the outer arm can never fire
+  // `run_param_effectset` discharges the effect itself, so the outer arm can never fire
   // (resume(0) is deliberately NOT the expected value: the inner handler
   // must win). Calling a self-discharging fn from under another handle for
   // the same effect was rejected before #1595.
   handle {
-    inspect(main(), "42")
+    inspect(run_param_effectset(), "42")
   } with Ask {
     Get => resume(0)
   }

--- a/fixtures/effect_row_operation_item.vibe
+++ b/fixtures/effect_row_operation_item.vibe
@@ -17,7 +17,8 @@ let read_one = () -> Int with Ask::Get {
   perform Ask::Get
 }
 
-export let main = () -> Int with Ask::Get {
+// Ordinary row-carrying function, not an entry (#1683).
+export let run_operation_row = () -> Int with Ask::Get {
   handle {
     read_one()
   } with Ask {
@@ -29,12 +30,12 @@ test "an operation-qualified row item parses, checks, and runs" {
   // #1571: expectation lives beside the code (updatable via `vibe test
   // --update`) instead of in a `__DATA__` tail. The wrapping handle is
   // required because a test block's own row cannot authorize `Ask::Get`;
-  // `main` discharges the effect itself, so the outer arm can never fire
+  // `run_operation_row` discharges the effect itself, so the outer arm can never fire
   // (resume(0) is deliberately NOT the expected value: the inner handler
   // must win). Calling a self-discharging fn from under another handle for
   // the same effect was rejected before #1595.
   handle {
-    inspect(main(), "42")
+    inspect(run_operation_row(), "42")
   } with Ask {
     Get => resume(0)
   }

--- a/fixtures/effect_self_discharging_callee.vibe
+++ b/fixtures/effect_self_discharging_callee.vibe
@@ -13,8 +13,8 @@ import ../lib/@vibe/core {
 //      needs one), and
 //   2. calls TO `selfd` are inert (edp_append_self_discharging_row_fns) --
 //      without this the drop was self-defeating: removing `selfd` from
-//      `needing` removed the very membership that made `main`'s call to it
-//      safe in edp_has_unsafe_construct, so `main` went ineligible and the
+//      `needing` removed the very membership that made `run_selfd`'s call to
+//      it safe in edp_has_unsafe_construct, so `run_selfd` went ineligible and the
 //      whole effect's migration failed hard.
 // The handler arm must stay perform-free for half 2 (an arm that
 // re-performs the effect escapes `selfd` -- see
@@ -35,7 +35,10 @@ fn selfd() -> Int with Ask + Ask::Get {
   }
 }
 
-fn main() -> Int with Ask + Ask::Get {
+// This is intentionally not a program entry: #1683 rejects user effects left
+// in a `main` / `_start` row. The fixture exercises an ordinary row-carrying
+// caller, which remains valid.
+fn run_selfd() -> Int with Ask + Ask::Get {
   selfd()
 }
 
@@ -44,7 +47,7 @@ test "calling a self-discharging fn from a row-carrying caller compiles and runs
   // block (a test's own row cannot authorize Ask); `selfd`'s inner handler
   // must win, so resume(0) is deliberately NOT the expected value.
   handle {
-    inspect(main(), "42")
+    inspect(run_selfd(), "42")
   } with Ask {
     Get => resume(0)
   }

--- a/fixtures/err_effect_self_discharge_arm_reperform.vibe
+++ b/fixtures/err_effect_self_discharge_arm_reperform.vibe
@@ -26,7 +26,7 @@ fn selfd() -> Int with Ask + Ask::Get {
   }
 }
 
-fn main() -> Int with Ask + Ask::Get {
+fn main() -> Int {
   handle {
     selfd()
   } with Ask {

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -16,6 +16,7 @@ import @vibe/compiler/core {
   exception_label_kind,
   exception_throw_label_for_kind,
   expr_children,
+  is_entry_admitted_effect,
   is_entry_runtime_managed_effect,
   is_exception_effect_name,
   is_exception_label,
@@ -65,6 +66,13 @@ export enum EffectError {
   // Before this the row mismatch had no position at all -- measured as the worst
   // tier in eval/lang-review/repair (05).
   EEEffectRowMismatch(String, String, String, String, Int);
+  // #1683: a source effect with no host/runtime owner reached a program entry.
+  // Fields: entry name, sorted offending row, sorted bare handler names, offset.
+  EEUndischargedEntryEffect(String, String, String, Int);
+  // An entry row variable has no caller that can instantiate it. Keep this
+  // separate from concrete effects so the fix-it never suggests handling a
+  // type-level row variable as though it were an effect declaration.
+  EEUnresolvedEntryEffectRow(String, String, Int);
   EEAssignImmutable(String);
   // #1539: provider-owned stdin lifecycle operations cannot be transported as
   // values until generic higher-order effect flow is sound (#1536).
@@ -147,6 +155,22 @@ export fn effect_error_to_string(err: EffectError) -> String {
       let body = String::concat(head, String::concat(": missing { ", String::concat(missing, String::concat(" }", String::concat(detail, hint)))))
       // #1514: marker LAST so the hint line stays the visible tail; the decoder
       // strips it before the user ever sees the string.
+      if off >= 0 {
+        String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
+      } else {
+        body
+      }
+    },
+    EEUndischargedEntryEffect(entry_name, effects, handlers, off) => {
+      let body = String::concat("entry point '", String::concat(entry_name, String::concat("' cannot discharge { ", String::concat(effects, String::concat(" }: no host provider or runtime handler owns this effect\nhint: wrap the operation in `handle ... with ", String::concat(row_as_source(handlers), " { ... }` before it reaches the entry boundary"))))))
+      if off >= 0 {
+        String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
+      } else {
+        body
+      }
+    },
+    EEUnresolvedEntryEffectRow(entry_name, variables, off) => {
+      let body = String::concat("entry point '", String::concat(entry_name, String::concat("' has unresolved effect row { ", String::concat(variables, " }: entry rows must be concrete\nhint: close the entry row, or discharge each concrete effect with `handle` before it reaches the entry boundary"))))
       if off >= 0 {
         String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
       } else {
@@ -1340,6 +1364,177 @@ fn make_row_mismatch(fn_name: String, declared: Array[String], missing: Array[St
   EEEffectRowMismatch(fn_name, join_labels(missing_sorted), join_labels(declared), join_labels(required), off)
 }
 
+fn is_program_entry_name(name: String) -> Bool {
+  name == "main" || name == "_start"
+}
+
+// User declarations can legally reuse a provider spelling such as `Fs`.
+// Retain operation identity rather than only the effect name: the selfhost
+// linked program contains private `effect Env { Get ... }` declarations as
+// well as the real host `Env::get` builtin used by its entry point.
+let entry_user_effect_operations: Array[String] = array_empty()
+
+fn collect_entry_user_effect_operations(stmts: Array[Stmt], out: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SEffectDef(_, name, _, ops) => {
+        let mut oi = 0
+        while oi < Array::length(ops) {
+          let (op_name, _, _) = Array::get(ops, oi)
+          let label = String::concat(name, String::concat("::", op_name))
+          if effect_row_has_label(Some(out), label) {
+            ()
+          } else {
+            Array::push(out, label)
+          }
+          oi = oi + 1
+        }
+      },
+      SModule(_, _, body) => collect_entry_user_effect_operations(body, out),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+fn set_entry_user_effect_operations(stmts: Array[Stmt]) -> Unit {
+  Array::truncate(entry_user_effect_operations, 0)
+  collect_entry_user_effect_operations(stmts, entry_user_effect_operations)
+}
+
+fn entry_label_is_user_declared_operation(label: String) -> Bool {
+  String::index_of(label, "::") > 0 && effect_row_has_label(Some(entry_user_effect_operations), label)
+}
+
+fn standard_provider_owns_operation(label: String) -> Bool {
+  match builtin_call_effect(label) {
+    Some(owner) => is_entry_admitted_effect(owner),
+    None => false
+  }
+}
+
+fn entry_user_operation_requires_handler(label: String) -> Bool {
+  entry_label_is_user_declared_operation(label) && !standard_provider_owns_operation(label)
+}
+
+fn entry_unresolved_labels(labels: Array[String]) -> Array[String] {
+  let out = no_str_labels()
+  let mut i = 0
+  while i < Array::length(labels) {
+    let label = Array::get(labels, i)
+    if label_is_effect_var(label) {
+      Array::push(out, label)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  sort_labels(labels_union(no_str_labels(), out))
+}
+
+fn entry_unadmitted_labels(labels: Array[String]) -> Array[String] {
+  let out = no_str_labels()
+  let mut i = 0
+  while i < Array::length(labels) {
+    let label = Array::get(labels, i)
+    // Row variables are separated above so they receive the closed-row hint;
+    // this list contains only concrete effects that lack an entry owner.
+    if !label_is_effect_var(label) && (entry_user_operation_requires_handler(label) || !is_entry_admitted_effect(label)) {
+      Array::push(out, label)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  sort_labels(labels_union(no_str_labels(), out))
+}
+
+fn entry_handler_labels(labels: Array[String]) -> Array[String] {
+  let out = no_str_labels()
+  let mut i = 0
+  while i < Array::length(labels) {
+    let base = effect_name_of_op(Array::get(labels, i))
+    if effect_row_has_label(Some(out), base) {
+      ()
+    } else {
+      Array::push(out, base)
+    }
+    i = i + 1
+  }
+  sort_labels(out)
+}
+
+fn make_contextual_row_error(fn_name: String, declared: Array[String], missing: Array[String], off: Int) -> EffectError {
+  let unresolved = entry_unresolved_labels(missing)
+  let bad = entry_unadmitted_labels(missing)
+  if is_program_entry_name(fn_name) && Array::length(unresolved) > 0 {
+    EEUnresolvedEntryEffectRow(fn_name, join_labels(unresolved), off)
+  } else if is_program_entry_name(fn_name) && Array::length(bad) > 0 {
+    EEUndischargedEntryEffect(fn_name, join_labels(bad), join_labels(entry_handler_labels(bad)), off)
+  } else {
+    make_row_mismatch(fn_name, declared, missing, off)
+  }
+}
+
+fn first_expr_offset(root: Expr) -> Int {
+  let stack = Array::slice([
+    root
+  ], 0, 1)
+  let mut first = 0 - 1
+  while Array::length(stack) > 0 {
+    let n = Array::length(stack)
+    let expr = Array::get(stack, n - 1)
+    Array::truncate(stack, n - 1)
+    let off = match expr {
+      EIdent(_, x) => x,
+      ELet(_, _, _, x) => x,
+      ELetMut(_, _, _, x) => x,
+      ECall(_, _, x) => x,
+      EDot(_, _, x, _) => x,
+      _ => 0 - 1
+    }
+    if off >= 0 && (first < 0 || off < first) {
+      first = off
+    } else {
+      ()
+    }
+    let children = expr_children(expr)
+    let mut i = 0
+    while i < Array::length(children) {
+      Array::push(stack, Array::get(children, i))
+      i = i + 1
+    }
+  }
+  first
+}
+
+fn check_entry_declared_effects(fn_name: String, ty: Option[TypeExpr], body: Expr) -> Array[EffectError] {
+  let errors = array_empty()
+  if is_program_entry_name(fn_name) {
+    let labels = fn_binding_effects(ty, body)
+    let unresolved = entry_unresolved_labels(labels)
+    let bad = entry_unadmitted_labels(labels)
+    if Array::length(unresolved) > 0 || Array::length(bad) > 0 {
+      let inspect_body = match body {
+        EFn(_, _, _, _, _, fbody) => fbody,
+        _ => body
+      }
+      let off = first_expr_offset(inspect_body)
+      if Array::length(unresolved) > 0 {
+        Array::push(errors, EEUnresolvedEntryEffectRow(fn_name, join_labels(unresolved), off))
+      } else {
+        Array::push(errors, EEUndischargedEntryEffect(fn_name, join_labels(bad), join_labels(entry_handler_labels(bad)), off))
+      }
+    } else {
+      ()
+    }
+  } else {
+    ()
+  }
+  errors
+}
+
 /// #626 criterion 2: a `handle ... with E` DISCHARGES E for its body — after
 /// handling E the body need not declare it. The parser qualifies each handler
 /// arm pattern as `E::Op`, so the discharged effect names are recoverable as the
@@ -1835,6 +2030,7 @@ export fn check_perform_effects_expr_tx(root: Expr, root_declared: Array[String]
   // per-parameter table, which switches call-site row unification off and
   // restores the pre-#1485 exemption. Callers of this entry are unit-test and
   // non-stmts paths that have no call-graph parameter types to offer anyway.
+  set_entry_user_effect_operations(array_empty())
   check_perform_effects_expr_tx_in("", root, root_declared, root_in_handle, fn_names, fn_effs, no_param_effs(), root_ov_names, root_ov_effs, no_kind_binds())
 }
 
@@ -1882,8 +2078,10 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                     // sibling operation of the same effect is already
                     // authorized at operation granularity, e.g. `with {
                     // Ask::Other }` + a bare `perform Ask::Get`).
-                    if (!is_exception_effect_name(eff) || error_row_checked()) && !in_handle && !decl_authorizes_op(declared, required_op) {
-                      Array::push(errors, make_row_mismatch(fn_name, declared, [
+                    if is_program_entry_name(fn_name) && !in_handle && entry_user_operation_requires_handler(op_name) && decl_authorizes_op(root_declared, op_name) {
+                      Array::push(errors, EEUndischargedEntryEffect(fn_name, op_name, effect_name_of_op(op_name), call_off))
+                    } else if (!is_exception_effect_name(eff) || error_row_checked()) && !in_handle && !decl_authorizes_op(declared, required_op) {
+                      Array::push(errors, make_contextual_row_error(fn_name, declared, [
                         throw_report_label(op_name, required_op, declared)
                       ], call_off))
                     } else {
@@ -1898,8 +2096,10 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                 // above, just without an args list to look past.
                 EIdent(op_name, _) => {
                   let eff = effect_name_of_op(op_name)
-                  if (!is_exception_effect_name(eff) || error_row_checked()) && !in_handle && !decl_authorizes_op(declared, op_name) {
-                    Array::push(errors, make_row_mismatch(fn_name, declared, [
+                  if is_program_entry_name(fn_name) && !in_handle && entry_user_operation_requires_handler(op_name) && decl_authorizes_op(root_declared, op_name) {
+                    Array::push(errors, EEUndischargedEntryEffect(fn_name, op_name, effect_name_of_op(op_name), call_off))
+                  } else if (!is_exception_effect_name(eff) || error_row_checked()) && !in_handle && !decl_authorizes_op(declared, op_name) {
+                    Array::push(errors, make_contextual_row_error(fn_name, declared, [
                       op_name
                     ], call_off))
                   } else {
@@ -1924,7 +2124,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                     // the fix-it should grant the one operation actually needed,
                     // not widen the row to the whole effect (same rule the
                     // perform path follows since Codex review on PR #1161).
-                    Array::push(errors, make_row_mismatch(fn_name, declared, [
+                    Array::push(errors, make_contextual_row_error(fn_name, declared, [
                       op_label
                     ], call_off))
                   } else {
@@ -2003,7 +2203,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                   ti = ti + 1
                 }
                 if Array::length(missing) > 0 {
-                  Array::push(errors, make_row_mismatch(fn_name, declared, missing, call_off))
+                  Array::push(errors, make_contextual_row_error(fn_name, declared, missing, call_off))
                 } else {
                   ()
                 }
@@ -2037,7 +2237,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                   pi = pi + 1
                 }
                 if Array::length(missing) > 0 {
-                  Array::push(errors, make_row_mismatch(fn_name, declared, missing, call_off))
+                  Array::push(errors, make_contextual_row_error(fn_name, declared, missing, call_off))
                 } else {
                   ()
                 }
@@ -2670,6 +2870,9 @@ export fn check_perform_effects_stmt(stmt: Stmt) -> Array[EffectError] {
   // No env to resolve payload kinds from: clear the table rather than let a
   // previous module's bindings decide this one's throw kinds (#1344).
   set_throw_kind_table(EnvEmpty)
+  set_entry_user_effect_operations(Array::slice([
+    stmt
+  ], 0, 1))
   check_perform_effects_stmt_tx(stmt, no_str_labels(), no_ov_effs(), no_param_effs())
 }
 
@@ -2800,10 +3003,17 @@ export fn check_perform_effects_stmts_env(stmts: Array[Stmt], env: TypeEnv) -> A
   // same checked env, so a typed `Exception[K]` row can be compared against
   // what each throw site actually throws.
   set_throw_kind_table(env)
+  set_entry_user_effect_operations(stmts)
   let errors = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
-    append_eff_errs(errors, check_perform_effects_stmt_tx(Array::get(stmts, i), fn_names, fn_effs, fn_param_effs))
+    let stmt = Array::get(stmts, i)
+    match stmt {
+      SLet(_, _, name, ty, body) => append_eff_errs(errors, check_entry_declared_effects(name, ty, body)),
+      SLetMut(name, ty, body) => append_eff_errs(errors, check_entry_declared_effects(name, ty, body)),
+      _ => ()
+    }
+    append_eff_errs(errors, check_perform_effects_stmt_tx(stmt, fn_names, fn_effs, fn_param_effs))
     i = i + 1
   }
   // #1347: only once the rows themselves check out — on a program with real

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -151,6 +151,7 @@ fn standard_provider_default_resource_kind(label: String) -> String
 fn is_entry_boundary_exception(label: String) -> Bool
 fn is_runtime_scheduled_effect(label: String) -> Bool
 fn is_entry_runtime_managed_effect(label: String) -> Bool
+fn is_entry_admitted_effect(label: String) -> Bool
 fn process_root_resource_kind() -> String
 fn is_singleton_resource_kind(path: String) -> Bool
 fn predeclared_resources() -> Array[(String, String)]

--- a/lib/@vibe/compiler/core/standard_effect_policy.vibe
+++ b/lib/@vibe/compiler/core/standard_effect_policy.vibe
@@ -136,6 +136,14 @@ export fn is_entry_runtime_managed_effect(label: String) -> Bool {
   is_entry_boundary_exception(label) || is_runtime_scheduled_effect(label)
 }
 
+/// True when an effect can cross a program entry boundary. Host-provider
+/// effects are supplied by the process host; runtime-managed effects are
+/// discharged by the entry wrapper. Ordinary user effects have neither owner
+/// and must be handled before `main` / `_start` returns.
+export fn is_entry_admitted_effect(label: String) -> Bool {
+  has_standard_host_provider(label) || is_entry_runtime_managed_effect(label)
+}
+
 //# Resource kinds (ADR-0075 Phase 2 / ADR-0094)
 
 /// The singleton selected by standard provider defaults when resource arguments

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -1,0 +1,98 @@
+//# Entry-boundary effect admission (#1683)
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, lex_with_offsets, parse_program, parse_program_located
+}
+
+import @vibe/compiler/runtime {
+  locate_type_error
+}
+
+fn first_check_error(source: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+fn first_located_check_error(source: String) -> String {
+  handle {
+    let (tokens, starts, _) = lex_with_offsets(source)
+    let _ = check_program(parse_program_located(tokens, starts, source))
+    ""
+  } with Exception {
+    Throw(msg) => locate_type_error(source, msg)
+  }
+}
+
+test "#1683: a declared user effect cannot escape main" {
+  let source = "effect Ask {\n  Get() -> Int\n}\n\nfn main() -> Unit with Ask::Get {\n  let x = perform Ask::Get()\n  println(\"\\{x}\")\n}\n"
+  let msg = first_located_check_error(source)
+  assert(String::contains(msg, "line 6:"))
+  assert(String::contains(msg, "entry point 'main' cannot discharge { Ask::Get }"))
+  assert(String::contains(msg, "handle ... with Ask"))
+  assert(!String::contains(msg, "declare 'fn main"))
+}
+
+test "#1683: a missing user effect at main suggests handling, not widening" {
+  let source = "effect Ask {\n  Get() -> Int\n}\n\nfn main() -> Int {\n  perform Ask::Get()\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "entry point 'main' cannot discharge { Ask::Get }"))
+  assert(String::contains(msg, "handle ... with Ask"))
+  assert(!String::contains(msg, "with Ask::Get'"))
+}
+
+test "#1683: _start is also an entry boundary" {
+  let source = "effect Ask { Get() -> Int }\nfn _start() -> Int with Ask { perform Ask::Get() }\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "entry point '_start' cannot discharge { Ask }"))
+}
+
+test "#1683: an unresolved entry row is rejected fail-closed" {
+  let msg = first_check_error("fn main() -> Int with e { 0 }\n")
+  assert(String::contains(msg, "entry point 'main' has unresolved effect row { e }"))
+  assert(String::contains(msg, "entry rows must be concrete"))
+  assert(String::contains(msg, "close the entry row"))
+  assert(!String::contains(msg, "handle ... with e"))
+}
+
+test "#1683: a user effect named Fs is not admitted as the host provider at main" {
+  let source = "effect Fs {\n  Custom() -> Int\n}\n\nfn main() -> Int with Fs::Custom {\n  perform Fs::Custom()\n}\n"
+  let msg = first_located_check_error(source)
+  assert(String::contains(msg, "line 6:"))
+  assert(String::contains(msg, "entry point 'main' cannot discharge { Fs::Custom }"))
+  assert(String::contains(msg, "handle ... with Fs"))
+  let missing_row_msg = first_check_error("effect Fs { Custom() -> Int }\nfn main() -> Int { perform Fs::Custom() }\n")
+  assert(String::contains(missing_row_msg, "entry point 'main' cannot discharge { Fs::Custom }"))
+  assert(!String::contains(missing_row_msg, "declare 'fn main"))
+}
+
+test "#1683: a user effect named Fs is not admitted as the host provider at _start" {
+  let source = "effect Fs { Custom() -> Int }\nfn _start() -> Int with Fs { perform Fs::Custom() }\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "entry point '_start' cannot discharge { Fs::Custom }"))
+}
+
+test "#1683: an ordinary helper still receives the row-addition hint" {
+  let source = "effect Ask { Get() -> Int }\nfn helper() -> Int { perform Ask::Get() }\nfn main() -> Int { 0 }\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "effect row mismatch for 'helper'"))
+  assert(String::contains(msg, "declare 'fn helper(...) -> T with Ask::Get'"))
+  assert(!String::contains(msg, "entry point"))
+}
+
+test "#1683: host providers and runtime-owned effects remain valid at main" {
+  assert(first_check_error("fn main() -> Unit with Fs + Env + Stdout + Async + Exception { () }\n") == "")
+  assert(first_check_error("fn main() -> Unit with Fs { let _ = Fs::read_file(\"missing\"); () }\n") == "")
+}
+
+test "#1683: unrelated user Env operations do not shadow the host Env provider" {
+  let source = "effect Env { Get(String) -> String }\nfn main() -> String with Env { Env::get(\"VIBE_HOME\") }\n"
+  assert(first_check_error(source) == "")
+}

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -158,6 +158,22 @@ test "check_linked_file: handle body calling a local closure fails eligibility a
   assert(String::contains(msg, "cannot be compiled here"))
 }
 
+test "check_linked_file: an unowned user effect is rejected at the entry boundary (#1683)" {
+  let path = "/tmp/vibe_cli_support_check_entry_effect.vibe"
+  Fs::write_bytes(path, string_to_bytes("effect Ask {\n  Get() -> Int\n}\n\nfn main() -> Unit with Ask::Get {\n  let x = perform Ask::Get()\n  println(\"\\{x}\")\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "line 6:"))
+  assert(String::contains(msg, "entry point 'main' cannot discharge { Ask::Get }"))
+  assert(String::contains(msg, "handle ... with Ask"))
+  assert(!String::contains(msg, "declare 'fn main"))
+  assert(!String::contains(msg, "[@off="))
+}
+
 /// #1514 C (repair 08): the same ineligibility error must now NAME the call
 /// that hides the perform and carry its `line:col` (the culprit `bump` sits at
 /// line 5 col 12 of the source below; the culprit-call marker verifies against

--- a/lib/@vibe/compiler/tests/standard_effect_policy_test.vibe
+++ b/lib/@vibe/compiler/tests/standard_effect_policy_test.vibe
@@ -6,6 +6,7 @@ import @vibe/compiler/core {
   entry_cache_safe_effects,
   has_standard_effect_policy,
   has_standard_host_provider,
+  is_entry_admitted_effect,
   is_entry_boundary_exception,
   is_entry_runtime_managed_effect,
   is_runtime_scheduled_effect,
@@ -53,6 +54,15 @@ test "runtime scheduling policy remains Async-only" {
   assert(not(is_runtime_scheduled_effect("Error")))
   assert(not(is_runtime_scheduled_effect("Fs")))
   assert(not(is_runtime_scheduled_effect("Ask")))
+}
+
+test "entry admission is the union of host and runtime owners" {
+  assert(is_entry_admitted_effect("Fs"))
+  assert(is_entry_admitted_effect("Fs::read_file"))
+  assert(is_entry_admitted_effect("Exception[IoError]"))
+  assert(is_entry_admitted_effect("Async"))
+  assert(!is_entry_admitted_effect("Ask"))
+  assert(!is_entry_admitted_effect("Ask::Get"))
 }
 
 test "entry and runtime management preserves checker and WIT filtering" {

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4345,13 +4345,13 @@ echo "[compiler-gate] wasm-gc backend dead needing function filtering ok (105)"
 #       drops a needing function from consideration when its body is
 #       EXACTLY a bare same-effect `EHandle` (edp_drop_self_discharging_needing)
 #       -- its handle site is already discovered and migrated independently.
-#       fixtures/effect_effectset_expansion.vibe's `main` is exactly this
+#       fixtures/effect_effectset_expansion.vibe's `run_effectset` is exactly this
 #       shape; confirmed via direct testing that it failed under
 #       VIBE_BACKEND=gc with "only `with Error`..." before this change.
 echo "[compiler-gate] 40h4/40 wasm-gc backend: self-discharging needing function no longer blocks effect migration (ADR-0076 gc follow-up)"
 # #1571: fixture is an inspect() test-block suite now, compiled AS-IS (no
 # `sed` strip; its import resolves from fixtures/). Its test block wraps the
-# call to the self-discharging `main` in another `handle ... with Ask`,
+# call to the self-discharging `run_effectset` in another `handle ... with Ask`,
 # which additionally locks #1595 on the gc lane: the CALL to a
 # self-discharging fn must be inert (edp_append_self_discharging_row_fns),
 # not just the fn itself dropped from `needing`.
@@ -4721,7 +4721,7 @@ echo "[compiler-gate] 40m/40 effect row operation-item grammar (ADR-0071 step 1/
 # #1571: the fixture carries its expectation as an inspect() test block now
 # (compiled AS-IS, no `sed` strip -- its `import ../lib/@vibe/core` resolves
 # from fixtures/); the test-block wrapper also locks #1595's shape (calling
-# the self-discharging `main` from under another `handle` for the same
+# the self-discharging `run_operation_row` from under another `handle` for the same
 # effect).
 a71dir="_build/_gate_effectset_row_item"
 rm -rf "$a71dir"; mkdir -p "$a71dir"


### PR DESCRIPTION
Closes #1683

## What changed

- centralize entry-effect admission in the standard effect policy
- reject user effects and unresolved row variables that main or _start cannot discharge
- emit a located, actionable handle hint for entry functions
- retain the existing add-with hint for ordinary helper functions
- admit host-provider and runtime-managed effects such as Fs, Env, Stdout, Async, and Exception

## Regressions

- main and _start with Ask::Get
- explicit and inferred entry rows
- unresolved row variables
- pure helper and host/runtime effect controls
- CLI check integration

## Validation

- focused checker, policy, and CLI tests green
- affected full suite 627/627 green
- stage0 through stage3 fixpoint green
- format, precommit, and diff checks green

The broad local operation gate reached 91/92; its final macOS-only harness invocation hit the existing xargs environment-size limit rather than a test failure.