### PR TITLE
fix(async): Async boundary の mixing guard を位置非依存にし、実際の注入条件でキーイングする (#1342)

### DIFF
--- a/fixtures/async_boundary_user_sleep_test.vibe
+++ b/fixtures/async_boundary_user_sleep_test.vibe
@@ -1,0 +1,38 @@
+// #1342: the Async-entry / spawn_suspend mixing guard must key on the boundary
+// that is actually INJECTED, not on "the program mentions `sleep` somewhere".
+//
+// This program supplies its OWN top-level `sleep`, so `!user_defines_sleep`
+// makes the boundary machinery stand down -- there is no synthesized
+// tail-resumptive handler for `spawn_suspend`'s suspend-class one to mix with,
+// and the program is perfectly compilable. The guard used to omit that half of
+// the condition, and rejecting here would have been a diagnostic about a
+// boundary that was never going to be built.
+//
+// Swap the local `sleep` out (call the builtin instead) and the same program is
+// correctly rejected -- that is `err_async_boundary_mixed_convention.vibe`.
+//
+// 21 + 21 = 42, and the value is the pin: it can only come from the spawned
+// body actually running to completion through the in-guest scheduler.
+import @vibex/concurrent {
+  TaskGroup, TaskHandle
+}
+
+fn sleep(ms: Int) -> Unit {
+  let mut i = 0
+  while i < ms {
+    i = i + 1
+  }
+}
+
+fn main() -> Int with Async + Exception {
+  sleep(1)
+  TaskGroup::run((g) -> {
+    let h = TaskGroup::spawn_suspend(g, () -> Int with Async + Exception {
+      let _ = perform Async::Suspend(0)
+      21
+    })
+    TaskGroup::pump_all(g)
+    let v = TaskHandle::join(h)
+    v + 21
+  })
+}

--- a/fixtures/err_async_boundary_mixed_operand.vibe
+++ b/fixtures/err_async_boundary_mixed_operand.vibe
@@ -1,0 +1,35 @@
+// #1342: the mixing guard must not depend on WHERE the `spawn_suspend` call
+// sits.
+//
+// Its walker was missing most expression arms -- no `EBinOp`, no `EMatch`, no
+// `EWhile`, no container arms -- so the same program was rejected or accepted
+// depending on the call's position. Measured, before the fix:
+//
+//   let h = TaskGroup::spawn_suspend(..)     -> rejected
+//   TaskGroup::spawn_suspend(..) + n         -> COMPILED
+//
+// A partial walk is the worst shape for a guard: it reads as "this is checked"
+// while answering a narrower question than its message claims.
+//
+// This fixture puts the call in an OPERAND, the position that used to slip
+// through. The let-bound position is covered by
+// `err_async_boundary_mixed_convention.vibe`; the two together are what pin
+// position-independence.
+//
+// `spawn_suspend` here is a plain local function -- the guard is a name-based
+// over-approximation, which is exactly why it has to be applied consistently
+// rather than by accident of where the call landed.
+fn spawn_suspend(x: Int) -> Int {
+  x
+}
+
+fn apply(f: (Int) -> Int) -> Int {
+  f(1)
+}
+
+fn main() -> Int with Async {
+  sleep(1)
+  apply((n) -> {
+    spawn_suspend(41) + n
+  })
+}

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -2743,8 +2743,66 @@ fn lc_expr_has_spawn_suspend(e: Expr) -> Bool {
     ESeq(a, b) => lc_expr_has_spawn_suspend(a) || lc_expr_has_spawn_suspend(b),
     EIf(c, t, el) => lc_expr_has_spawn_suspend(c) || lc_expr_has_spawn_suspend(t) || lc_expr_has_spawn_suspend(el),
     EFn(_, _, _, _, _, body) => lc_expr_has_spawn_suspend(body),
+    // #1342: the arms below were missing, which made the guard depend on WHERE
+    // the call sits rather than whether it is there. Measured: `let h =
+    // TaskGroup::spawn_suspend(..)` was found and rejected, while
+    // `TaskGroup::spawn_suspend(..) + n` -- the same program, the call moved
+    // into an operand -- compiled. A partial walk is the worst shape for a
+    // guard: it reads as "this is checked" while answering a narrower question.
+    EBinOp(_, l, r) => lc_expr_has_spawn_suspend(l) || lc_expr_has_spawn_suspend(r),
+    EUnaryOp(_, a) => lc_expr_has_spawn_suspend(a),
+    EAssign(_, v, b) => lc_expr_has_spawn_suspend(v) || lc_expr_has_spawn_suspend(b),
+    EAssignOp(_, _, v, b) => lc_expr_has_spawn_suspend(v) || lc_expr_has_spawn_suspend(b),
+    EWhile(c, b) => lc_expr_has_spawn_suspend(c) || lc_expr_has_spawn_suspend(b),
+    EForIn(_, _, it, b) => lc_expr_has_spawn_suspend(it) || lc_expr_has_spawn_suspend(b),
+    ELoop(pairs, b) => lc_pairs_have_spawn_suspend(pairs) || lc_expr_has_spawn_suspend(b),
+    EMatch(sc, arms) => lc_expr_has_spawn_suspend(sc) || lc_arms_have_spawn_suspend(arms),
+    EHandle(b, arms) => lc_expr_has_spawn_suspend(b) || lc_arms_have_spawn_suspend(arms),
+    EReturn(a) => lc_expr_has_spawn_suspend(a),
+    EBreak(opt) => match opt {
+      Some(a) => lc_expr_has_spawn_suspend(a),
+      None => false
+    },
+    EContinue(args) => lc_exprs_have_spawn_suspend(args),
+    ETuple(items) => lc_exprs_have_spawn_suspend(items),
+    EArray(items) => lc_exprs_have_spawn_suspend(items),
+    ERecord(_, fields, _) => lc_pairs_have_spawn_suspend(fields),
+    EMap(fields) => lc_pairs_have_spawn_suspend(fields),
+    ESpread(a) => lc_expr_has_spawn_suspend(a),
+    EDot(o, _, _, _) => lc_expr_has_spawn_suspend(o),
+    ELabeledArg(_, _, v) => lc_expr_has_spawn_suspend(v),
     _ => false
   }
+}
+
+fn lc_pairs_have_spawn_suspend(pairs: Array[(String, Expr)]) -> Bool {
+  let mut found = false
+  let mut i = 0
+  while i < Array::length(pairs) {
+    let (_, v) = Array::get(pairs, i)
+    if lc_expr_has_spawn_suspend(v) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn lc_arms_have_spawn_suspend(arms: Array[(Pat, Expr)]) -> Bool {
+  let mut found = false
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (_, b) = Array::get(arms, i)
+    if lc_expr_has_spawn_suspend(b) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
 }
 
 fn lc_exprs_have_spawn_suspend(es: Array[Expr]) -> Bool {
@@ -2998,7 +3056,16 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
     }
     i = i + 1
   }
-  if entry_has_async && (calls_sleep || calls_host_future || calls_host_stream) && has_spawn_suspend {
+  // #1342: key the guard on the machinery that is actually INJECTED, not on
+  // "the program mentions one of these names somewhere". The three predicates
+  // below are the same ones the injection uses further down, hoisted so the
+  // guard cannot disagree with it -- previously the guard omitted the
+  // `!user_defines_*` half, so a program supplying its own `sleep` was told it
+  // was mixing conventions with a boundary that was never going to be built.
+  let sleep_machinery = calls_sleep && !user_defines_sleep && (entry_has_async || has_async_handle)
+  let hf_machinery = calls_host_future && !user_defines_host_future && entry_has_async
+  let hs_machinery = calls_host_stream && !user_defines_host_stream && entry_has_async
+  if entry_has_async && (sleep_machinery || hf_machinery || hs_machinery) && has_spawn_suspend {
     "Async entry boundary and TaskGroup::spawn_suspend are mixing the step convention; handle Async inside the entry instead"
   } else {
     // Keying (#1218, tightened after gate 19 regressed on the first cut):
@@ -3021,7 +3088,10 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
     // checker lets such a handle discharge the builtin row, so its body's
     // sleeps MUST become performs the handler can receive); the boundary
     // wrap itself stays entry-row-keyed.
-    let sleep_machinery = calls_sleep && !user_defines_sleep && (entry_has_async || has_async_handle)
+    // sleep_machinery / hf_machinery / hs_machinery are computed ABOVE now, so
+    // the guard and the injection cannot drift apart (#1342). Their original
+    // rationale:
+    //
     // ADR-0089 step 4 (#1218): the host-future machinery -- a program that
     // calls `host_future_get` under an Async-row entry gets the boundary
     // handler (with the waitable settle arm below) even with zero sleeps.
@@ -3029,13 +3099,12 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
     // Suspend(handle + 2) payload reaches that handler instead, where the
     // in-guest scheduler parks it as a poller (deadlock trap -- no
     // completion source exists in-guest, spec §3.13).
-    let hf_machinery = calls_host_future && !user_defines_host_future && entry_has_async
+    //
     // ADR-0089 Decision 3 (#1218): the host-stream machinery -- same keying
     // discipline as hf_machinery (entry-row-keyed only; under a user
     // `handle ... with Async` the stream payload would reach a handler with
     // no read source, where the in-guest scheduler's poller arm turns it
     // into a deterministic deadlock trap, spec §3.13).
-    let hs_machinery = calls_host_stream && !user_defines_host_stream && entry_has_async
     let decl_needed = !has_async_decl && (sleep_machinery || hf_machinery || hs_machinery || (has_aw_poll && has_async_handle))
     if decl_needed {
       let ops: Array[(String, Array[TypeExpr], TypeExpr)] = [

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -8789,6 +8789,42 @@ if ! grep -qF 'mixing the step convention' "$asb89dir/neg.wasm.diag" 2>/dev/null
   cat "$asb89dir/neg.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+# #1342: the same guard must be POSITION-INDEPENDENT and must key on the
+# boundary that is actually injected.
+#   - err_async_boundary_mixed_operand.vibe puts the `spawn_suspend` call in an
+#     OPERAND. Its walker was missing EBinOp (and most other arms), so this
+#     exact program COMPILED while the let-bound spelling above was rejected.
+#   - async_boundary_user_sleep_test.vibe supplies its OWN `sleep`, so no
+#     boundary is built and there is nothing to mix -- it must COMPILE and
+#     return 42. The guard used to omit that half of the injection's condition.
+cp fixtures/err_async_boundary_mixed_operand.vibe "$asb89dir/negop.vibe"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$asb89dir/negop.vibe" "$asb89dir/negop.wasm" main >/dev/null 2>&1 || true
+if [ -s "$asb89dir/negop.wasm" ]; then
+  echo "[compiler-gate] FAIL: err_async_boundary_mixed_operand.vibe compiled -- the mixing guard is position-dependent again (#1342)" >&2
+  exit 1
+fi
+if ! grep -qF 'mixing the step convention' "$asb89dir/negop.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: err_async_boundary_mixed_operand.vibe did not produce the mixing diagnostic" >&2
+  cat "$asb89dir/negop.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+cp fixtures/async_boundary_user_sleep_test.vibe "$asb89dir/usersleep.vibe"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$asb89dir/usersleep.vibe" "$asb89dir/usersleep.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$asb89dir/usersleep.wasm" ]; then
+  echo "[compiler-gate] FAIL: async_boundary_user_sleep_test.vibe was rejected -- the guard fired without an injected boundary (#1342)" >&2
+  cat "$asb89dir/usersleep.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+asb89_us_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$asb89dir/usersleep.wasm" 2>/dev/null | tail -1)"
+if [ "$asb89_us_out" != "42" ]; then
+  echo "[compiler-gate] FAIL: async_boundary_user_sleep_test.vibe got '$asb89_us_out' (want 42)" >&2
+  exit 1
+fi
+echo "[compiler-gate] async boundary mixing guard: position-independent + injection-keyed ok (#1342)"
 # Increment 2 (#1218): a `handle ... with Async` discharges the builtin
 # row (the enclosing fn needs no `with Async`) and the handler REALLY
 # receives the operations -- sleep(20)+sleep(15) reach the arm as


### PR DESCRIPTION
このガードは「Async-row entry の boundary」と「`TaskGroup::spawn_suspend` の
suspend-class handle」が同じ effect で 2 つの規約を混ぜる前に落とすためのもの。
**判定の仕方に 2 つ問題があった。**

## 1. 走査に arm が足りず、呼び出しの**位置**で答えが変わっていた

`lc_expr_has_spawn_suspend` に `EBinOp` / `EMatch` / `EWhile` / `EForIn` / `ELoop` /
`EAssign` / `EHandle` とコンテナ系の arm が無く、`_ => false` に落ちていた。
親コミットでの実測 — **同じプログラム**、呼び出しの位置だけを変えたもの:

```vibe
let h = TaskGroup::spawn_suspend(..)   // -> 拒否
TaskGroup::spawn_suspend(..) + n       // -> COMPILED
```

**部分的な走査はガードとして最悪の形**で、「ここは検査済み」と読めるのに、メッセージが
主張しているより狭い質問にしか答えていない。

## 2. ガードと注入のキーイングが食い違っていた

ガードは `calls_sleep || calls_host_future || calls_host_stream`、注入側は同じ条件に
加えて `!user_defines_*` を要求していた。**自前の `sleep` を定義しているプログラムには
boundary が作られない**ので混ざりようが無いのに、ガードは「混ざっている」と言っていた。

3 つの述語をガードの手前で 1 回だけ計算して共有するようにしたので、**もう食い違えない**。

## 実測 (9 プローブ)

| 形 | before | after |
|---|---|---|
| import した TaskGroup、実際に混ざる形 | 遅い scps メッセージ | **早い・具体的なガードメッセージ** |
| 自前の `sleep` | 42 | **42**(不変) |
| オペランド位置の呼び出し | 見逃して通過 | **拒否**(let 束縛と一致) |

before の「遅い scps メッセージ」は
`effect Async has step-compiled closure values ... split the effect or make every
handler suspend-class` で、**entry boundary を一言も名指ししない**。実プログラム
(TaskGroup を import する形) は必ずこちらに落ちていたので、ガードが用意していた
`handle Async inside the entry instead` という具体的な指示は誰にも届いていなかった。

## 挙動変更を 1 つ含む

`spawn_suspend` という名前の**ローカル関数**を持ち、Async-row entry で `sleep` も呼ぶ
プログラムは、オペランド位置でも拒否されるようになる (これまでは素通り)。

これは名前ベースの過剰近似のコストで、**一貫して適用することが要点**。
「呼び出しがどこに置かれたかで通ったり通らなかったりする」は誰も学習できない規則で、
CLAUDE.md が「実装都合が言語に漏れている」兆候として挙げているものそのもの。

## fixture

- **`err_async_boundary_mixed_operand.vibe`** — オペランド位置。**これまでコンパイルが
  通っていた**形
- **`async_boundary_user_sleep_test.vibe`** — 自前の `sleep`。コンパイルが通り **42** を
  返すこと。21 は spawn された body から来るので、この値が in-guest scheduler が実際に
  走らせた証拠になる

既存の `err_async_boundary_mixed_convention.vibe` (let 束縛位置) と合わせて、
**位置非依存**が pin される。

## 検証

- `bash scripts/compiler_gate.sh` — green(新レーン含む)
- `VIBE_STAGE2_WASM=<stage2> bash scripts/unit_test_runner.sh` — **627/627** green

## スコープ外

#1342 のスコープ 3 本体 (in-guest scheduler に waitable 第 3 の park 種を実装し、
mixing を**解消**する) はこの PR には入っていない。ここで直したのは**ガードの判定**だけで、
拒否そのものは依然必要 — 規約の選択は effect label 単位でグローバルなので、
注入される tail-resumptive な boundary と suspend-class handle は今も両立しない。

## 関連

#1342、#1218 (ADR-0089 D1/D2/D3)、#1707 (より具体的な姉妹ガード)、ADR-0076

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_