### PR TITLE
fix(interp): read the body when a lambda has no return annotation (#1766 follow-up)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -53,9 +53,10 @@ let s: String = "hello \{x}"   // interpolation with \{expr}
                                // #1392: 補間の値に `T::to_string`
                                // (derive(Show)/derive(Hash) 生成物、または
                                // 手書き) があればそれを呼ぶ。`Option`/`Result`/
-                               // タプル/配列は変数・generic 経由でも構造的に
-                               // 展開される (`"\{Some(p)}"` -> `Some(P { .. })`,
-                               // `"\{xs}"` -> `[1, 2]`)。描画できない型
+                               // タプル/配列は変数・注釈付き名前関数の戻り値・
+                               // generic の pass-through 経由でも構造的に展開される
+                               // (`"\{Some(p)}"` -> `Some(P { .. })`,
+                               // `"\{make_xs()}"` -> `[1, 2]`)。描画できない型
                                // (to_string の無い集約型) は check 時に
                                // `cannot interpolate a value of type ...` で
                                // 落ちる (#1445)。ただし effect handler の

--- a/fixtures/interp_function_return_missing_show_error.vibe
+++ b/fixtures/interp_function_return_missing_show_error.vibe
@@ -1,0 +1,15 @@
+// #1766 negative control: a function result whose nominal type has no
+// renderer must stay a compile-time error, never fall through to pointer text.
+struct Hidden {
+  value: Int
+}
+
+fn hidden() -> Hidden {
+  Hidden::{
+    value: 1
+  }
+}
+
+export let main = () -> Unit {
+  println("\{hidden()}")
+}

--- a/fixtures/interp_function_return_test.vibe
+++ b/fixtures/interp_function_return_test.vibe
@@ -72,3 +72,46 @@ test "local function return shape shadows the top-level function" {
   }
   inspect("\{scalar()}", "[4, 5]")
 }
+
+// #1766 follow-up (review finding on PR #1774): the fix above keyed on the
+// return ANNOTATION, so an unannotated lambda still printed its address --
+// the same symptom the issue was filed for, one spelling over. `fn f() { .. }`
+// does not parse, so this is lambdas only, and lambdas are where the shorthand
+// gets used (`let peek = () -> Array::get(xs, 0)`).
+//
+// `fn_return_head_of` already falls back to the body when there is no
+// annotation; the shape tables now do the same.
+
+let arr_no_annot = () -> {
+  [
+    4,
+    5
+  ]
+}
+
+let tup_no_annot = () -> {
+  (1, "a")
+}
+
+let scalar_no_annot = () -> {
+  42
+}
+
+test "interpolation reads the body when a lambda has no return annotation" {
+  inspect("\{arr_no_annot()}", "[4, 5]")
+  inspect("\{tup_no_annot()}", "(1, a)")
+  inspect("\{Some(arr_no_annot())}", "Some([4, 5])")
+  // A scalar body must stay scalar: the fallback records a shape only when the
+  // body's tail is composite, so this still takes the ordinary path.
+  inspect("\{scalar_no_annot()}", "42")
+}
+
+test "the body fallback also applies to a local unannotated lambda" {
+  let local_arr = () -> {
+    [
+      7,
+      8
+    ]
+  }
+  inspect("\{local_arr()}", "[7, 8]")
+}

--- a/fixtures/interp_function_return_test.vibe
+++ b/fixtures/interp_function_return_test.vibe
@@ -1,0 +1,74 @@
+// #1766: structural values retain their renderer shape through a function
+// return. Before the fix every Array/tuple case below passed the checker but
+// rendered its linear-memory address as a decimal integer.
+
+struct Point {
+  x: Int;
+  y: Int
+} derive (Show)
+
+enum Choice {
+  Pick(Int);
+  Skip
+} derive (Show)
+
+fn ints() -> Array[Int] {
+  [
+    1,
+    2,
+    3
+  ]
+}
+
+fn pair() -> (Int, String) {
+  (7, "seven")
+}
+
+fn point() -> Point {
+  Point::{
+    x: 8, y: 9
+  }
+}
+
+fn choice() -> Choice {
+  Pick(6)
+}
+
+fn scalar() -> Int {
+  9
+}
+
+fn show_generic[T](value: T) -> String {
+  "\{value}"
+}
+
+test "interpolation preserves structural function return shape" {
+  inspect("\{ints()}", "[1, 2, 3]")
+  let xs = ints()
+  inspect("\{xs}", "[1, 2, 3]")
+  inspect("\{pair()}", "(7, seven)")
+  let p = pair()
+  inspect("\{p}", "(7, seven)")
+  inspect("\{Some(ints())}", "Some([1, 2, 3])")
+  inspect(show_generic(ints()), "[1, 2, 3]")
+  // Nominal function returns already worked; keep them as controls so the
+  // structural path cannot steal ordinary T::to_string dispatch.
+  inspect("\{point()}", "Point { x: 8, y: 9 }")
+  inspect("\{choice()}", "Pick(6)")
+}
+
+test "local function return shape shadows the top-level function" {
+  // Aggregate -> scalar: the empty local sentinel must mask the global shape.
+  let ints = () -> Int {
+    1
+  }
+  inspect("\{ints()}", "1")
+  // Scalar -> aggregate: the local annotation must supply the closer shape.
+  let scalar = () -> Array[Int] {
+    [
+      4,
+      5
+    ]
+  }
+  inspect("\{scalar()}", "[4, 5]")
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2273,7 +2273,7 @@ fn bind_shapes(var_types: Array[(String, String)], name: String, val: Expr, stru
   let out = array_empty()
   push_all_var_types(out, shaped)
   let call_result_shape = match val {
-    EFn(tparams, _, _, ret, _, _) => match ret {
+    EFn(tparams, _, _, ret, _, fbody) => match ret {
       Some(rt) => if ty_mentions_name_in(rt, tparams) {
         ""
       } else {
@@ -2284,7 +2284,20 @@ fn bind_shapes(var_types: Array[(String, String)], name: String, val: Expr, stru
           ""
         }
       },
-      None => ""
+      // #1766 follow-up: same body fallback as `collect_fn_return_shapes`, and
+      // here the surrounding scope is already known -- `var_types` carries the
+      // enclosing bindings, so a tail that names one resolves too, not just a
+      // literal.
+      None => if Array::length(tparams) > 0 {
+        ""
+      } else {
+        let sh = infer_shape(fn_body_tail_expr(fbody), struct_sets, c, fn_returns)
+        if shape_is_composite(sh) {
+          sh
+        } else {
+          ""
+        }
+      }
     },
     _ => ""
   }
@@ -2695,7 +2708,7 @@ fn collect_struct_field_types(stmts: Array[Stmt], out: Array[(String, String)]) 
 /// its answer from the other's deliberately different grammar. Equality keeps
 /// Option/Result sentinels; interpolation only records shapes its structural
 /// renderer understands. Generic results stay unknown in both lanes.
-fn collect_fn_return_shapes(out: Array[(String, String)], fname: String, tparams: Array[String], ret: Option[TypeExpr]) -> Unit {
+fn collect_fn_return_shapes(out: Array[(String, String)], fname: String, tparams: Array[String], ret: Option[TypeExpr], fbody: Expr) -> Unit {
   match ret {
     Some(rt) => if ty_mentions_name_in(rt, tparams) {
       ()
@@ -2713,7 +2726,29 @@ fn collect_fn_return_shapes(out: Array[(String, String)], fname: String, tparams
         ()
       }
     },
-    None => ()
+    // #1766 follow-up: an unannotated lambda still HAS a return shape -- its
+    // body's tail expression is the returned value. `fn_return_head_of` already
+    // falls back to the body when `ret` is `None`; without the same fallback
+    // here, `let f = () -> { [4, 5] }` recorded no shape and `"\{f()}"` printed
+    // the array's address. Named functions cannot reach this arm (`fn f() { .. }`
+    // does not parse), so this is the lambda spelling only.
+    //
+    // Interpolation only. The eq lane keeps its own grammar (Option/Result
+    // sentinels) and deriving it from an expression is a separate question.
+    //
+    // No `struct_sets` or `var_types` exist at collection time, so this resolves
+    // literal bodies -- exactly the shapes that were printing pointers. A body
+    // whose tail needs that context yields "" and behaves as before.
+    None => if Array::length(tparams) > 0 {
+      ()
+    } else {
+      let body_sh = infer_shape(fn_body_tail_expr(fbody), array_empty(), array_empty(), out)
+      if shape_is_composite(body_sh) {
+        Array::push(out, (fn_return_shape_key(fname), body_sh))
+      } else {
+        ()
+      }
+    }
   }
 }
 
@@ -2725,7 +2760,7 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
       SLet(_, _, fname, _, body) => match body {
         EFn(tparams, _, _, ret, _, fbody) => {
           Array::push(out, (fname, fn_return_head_of(ret, fbody)))
-          collect_fn_return_shapes(out, fname, tparams, ret)
+          collect_fn_return_shapes(out, fname, tparams, ret, fbody)
         },
         _ => ()
       },
@@ -2737,7 +2772,7 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
       SFnDecl(_, fname, body, _, _) => match body {
         EFn(tparams, _, _, ret, _, fbody) => {
           Array::push(out, (fname, fn_return_head_of(ret, fbody)))
-          collect_fn_return_shapes(out, fname, tparams, ret)
+          collect_fn_return_shapes(out, fname, tparams, ret, fbody)
         },
         _ => ()
       },

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2115,6 +2115,13 @@ fn shape_key(pname: String) -> String {
   String::concat("__shape$", pname)
 }
 
+/// Complete structural shape of an annotated function result, stored in the
+/// shared sorted `fn_returns` table under a collision-proof reserved key.
+/// The ordinary entry remains the head (`Array` / `Tuple`) for routing users.
+fn fn_return_shape_key(fname: String) -> String {
+  String::concat("__retshape$", fname)
+}
+
 fn shape_is_composite(sh: String) -> Bool {
   String::starts_with(sh, "(") || String::starts_with(sh, "[") || String::starts_with(sh, "{o:") || String::starts_with(sh, "{r:")
 }
@@ -2203,6 +2210,25 @@ fn infer_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_types: 
         }
       }
     },
+    ECall(callee, _, _) => match callee {
+      EIdent(fname, _) => match lookup_var_type(var_types, fn_return_shape_key(fname)) {
+        // A local binding is the closer answer, including the empty sentinel:
+        // it may shadow a top-level function with the same name but a different
+        // return shape. Falling through would render with the global ABI.
+        Some(sh) => sh,
+        None => match fn_return_type(fn_returns, fn_return_shape_key(fname)) {
+          Some(sh) => sh,
+          None => match infer_arg_type_name(e, struct_sets, var_types, fn_returns) {
+            Some(t) => t,
+            None => ""
+          }
+        }
+      },
+      _ => match infer_arg_type_name(e, struct_sets, var_types, fn_returns) {
+        Some(t) => t,
+        None => ""
+      }
+    },
     _ => match infer_arg_type_name(e, struct_sets, var_types, fn_returns) {
       Some(t) => t,
       None => ""
@@ -2243,7 +2269,29 @@ fn bind_shapes(var_types: Array[(String, String)], name: String, val: Expr, stru
   let c = ctor_payload_bind(b, name, val, struct_sets, fn_returns)
   // LAST: infer_shape reads the sentinels the three above just wrote, so a
   // binding whose elements are themselves named bindings resolves in one pass.
-  shape_bind(c, name, val, struct_sets, fn_returns)
+  let shaped = shape_bind(c, name, val, struct_sets, fn_returns)
+  let out = array_empty()
+  push_all_var_types(out, shaped)
+  let call_result_shape = match val {
+    EFn(tparams, _, _, ret, _, _) => match ret {
+      Some(rt) => if ty_mentions_name_in(rt, tparams) {
+        ""
+      } else {
+        let sh = texpr_shape(rt)
+        if shape_is_composite(sh) {
+          sh
+        } else {
+          ""
+        }
+      },
+      None => ""
+    },
+    _ => ""
+  }
+  // Always append, even for non-functions/scalar functions: an empty entry is
+  // what prevents a closer local binding from inheriting a top-level shape.
+  Array::push(out, (fn_return_shape_key(name), call_result_shape))
+  out
 }
 
 /// Equality keeps a deeper type shape than the general rendering/type-head
@@ -2643,6 +2691,32 @@ fn collect_struct_field_types(stmts: Array[Stmt], out: Array[(String, String)]) 
   }
 }
 
+/// Record the two consumers' full return shapes without making either derive
+/// its answer from the other's deliberately different grammar. Equality keeps
+/// Option/Result sentinels; interpolation only records shapes its structural
+/// renderer understands. Generic results stay unknown in both lanes.
+fn collect_fn_return_shapes(out: Array[(String, String)], fname: String, tparams: Array[String], ret: Option[TypeExpr]) -> Unit {
+  match ret {
+    Some(rt) => if ty_mentions_name_in(rt, tparams) {
+      ()
+    } else {
+      let eq_sh = ty_to_eq_shape(rt)
+      if shape_is_composite(eq_sh) {
+        Array::push(out, (fn_eq_shape_key(fname), eq_sh))
+      } else {
+        ()
+      }
+      let interp_sh = texpr_shape(rt)
+      if shape_is_composite(interp_sh) {
+        Array::push(out, (fn_return_shape_key(fname), interp_sh))
+      } else {
+        ()
+      }
+    },
+    None => ()
+  }
+}
+
 fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
   let out = array_empty()
   let mut i = 0
@@ -2651,19 +2725,7 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
       SLet(_, _, fname, _, body) => match body {
         EFn(tparams, _, _, ret, _, fbody) => {
           Array::push(out, (fname, fn_return_head_of(ret, fbody)))
-          match ret {
-            Some(rt) => if !ty_mentions_name_in(rt, tparams) {
-              let sh = ty_to_eq_shape(rt)
-              if shape_is_composite(sh) {
-                Array::push(out, (fn_eq_shape_key(fname), sh))
-              } else {
-                ()
-              }
-            } else {
-              ()
-            },
-            None => ()
-          }
+          collect_fn_return_shapes(out, fname, tparams, ret)
         },
         _ => ()
       },
@@ -2675,19 +2737,7 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
       SFnDecl(_, fname, body, _, _) => match body {
         EFn(tparams, _, _, ret, _, fbody) => {
           Array::push(out, (fname, fn_return_head_of(ret, fbody)))
-          match ret {
-            Some(rt) => if !ty_mentions_name_in(rt, tparams) {
-              let sh = ty_to_eq_shape(rt)
-              if shape_is_composite(sh) {
-                Array::push(out, (fn_eq_shape_key(fname), sh))
-              } else {
-                ()
-              }
-            } else {
-              ()
-            },
-            None => ()
-          }
+          collect_fn_return_shapes(out, fname, tparams, ret)
         },
         _ => ()
       },
@@ -4270,13 +4320,20 @@ fn interp_expand_local(arg: Expr, head: String, derived_only: Bool, gens: Array[
         }
       }
     },
-    ECall(callee, cargs, _) => match callee {
-      EIdent(cn, _) => if Array::length(cargs) == 1 && ((head == "Option" && cn == "Some") || (head == "Result" && (cn == "Ok" || cn == "Err"))) {
-        Some(interp_wrap1(cn, Array::get(cargs, 0), derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns))
+    ECall(callee, cargs, _) => {
+      let sh = infer_shape(arg, struct_sets, var_types, fn_returns)
+      if shape_is_composite(sh) {
+        Some(interp_expand_shape(arg, sh, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns))
       } else {
-        interp_expand_by_head(arg, head, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
-      },
-      _ => interp_expand_by_head(arg, head, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+        match callee {
+          EIdent(cn, _) => if Array::length(cargs) == 1 && ((head == "Option" && cn == "Some") || (head == "Result" && (cn == "Ok" || cn == "Err"))) {
+            Some(interp_wrap1(cn, Array::get(cargs, 0), derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns))
+          } else {
+            interp_expand_by_head(arg, head, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+          },
+          _ => interp_expand_by_head(arg, head, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+        }
+      }
     },
     _ => interp_expand_by_head(arg, head, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
   }

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9609,6 +9609,39 @@ fi
 rm -rf "$showdir"
 echo "[compiler-gate] interpolation Show rendering ok"
 
+# #1766: Array/tuple type arguments used to be discarded from fn_returns, so
+# interpolation of a structural function result passed check and printed its
+# raw pointer. The positive fixture covers direct and let-bound results,
+# nesting under Option, plus nominal controls. The negative fixture locks the
+# fail-closed diagnostic for a nominal result without a renderer.
+retshowdir="_build/_gate_interp_function_return"
+rm -rf "$retshowdir"; mkdir -p "$retshowdir"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \
+  "$stage2_wasm" fixtures/interp_function_return_test.vibe "$retshowdir/show.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$retshowdir/show.wasm" ]; then
+  echo "[compiler-gate] FAIL: structural function-return interpolation fixture did not compile (#1766)" >&2
+  exit 1
+fi
+if ! retshow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$retshowdir/show.wasm" 2>&1)"; then
+  echo "[compiler-gate] FAIL: structural function-return interpolation rendered incorrectly (#1766)" >&2
+  printf '%s\n' "$retshow_out" >&2
+  exit 1
+fi
+set +e
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \
+  "$stage2_wasm" fixtures/interp_function_return_missing_show_error.vibe "$retshowdir/missing.wasm" main >/dev/null 2>&1
+retshow_status=$?
+set -e
+if [ "$retshow_status" -eq 0 ] || [ -s "$retshowdir/missing.wasm" ] || ! grep -q 'cannot interpolate a value of type `Hidden`' "$retshowdir/missing.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: missing renderer function result was not rejected actionably (#1766)" >&2
+  cat "$retshowdir/missing.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$retshowdir"
+echo "[compiler-gate] structural function-return interpolation ok"
+
 echo "[compiler-gate] 87/87 uncaught throw reports the payload VALUE (#1374 / #1392 slice 3)"
 # ADR-0085's runtime carries one abortive tag with no kind, so the entry
 # boundary's erased `with Error` arm binds the payload at CtUnknown and can


### PR DESCRIPTION
**#1774 の上に載せる follow-up** です (base = `codex/fix-1766`)。#1774 のレビューで見つけた
取り残しを塞ぎます。単体で main には出せません — #1774 が入れた `infer_shape` に依存しています。

## 何が残っていたか

#1774 は shape を**戻り値の注釈**から取るので、**注釈の無いラムダ**は素通りしていました。
症状は #1766 と同一です:

```vibe
let f = () -> { [4, 5] }
"\{f()}"        // 172         (期待 [4, 5])
"\{Some(f())}"  // Some(172)   ← issue 本文の「構造描画の内側にポインタ混入」と同じ形
```

`fn f() { .. }` は構文として通らない (`expected -> but got {`) ので**ラムダ限定**ですが、
注釈を省くのはラムダの通常の書き方です (`let peek = () -> Array::get(xs, 0)` など)。

## 直し方

非対称はファイル内に既に見えていました — `fn_return_head_of(ret, fbody)` は **`ret` が `None`
なら body を見る**のに、shape 側は `ret` しか見ていない。両方の shape 記録箇所
(`collect_fn_return_shapes` / `bind_shapes`) に同じフォールバックを入れ、#1774 が導入した
`infer_shape` を `fn_body_tail_expr` に掛けています。**tail 式が戻り値そのもの**なので、
新しい判断は増えていません。

## 意図的に狭めたところ

- **補間のみ。** eq レーンは独自の文法 (Option/Result sentinel) を持つので、式から導出するかは別問題
- **ジェネリックなラムダは shape 無しのまま** — 注釈側の規則と揃えた
- collection 時には `struct_sets` / `var_types` が無いので、top-level 側は**直値 body** を解決する
  (ポインタが出ていたのはまさにそれ)。文脈が要る tail は `""` になり従来どおり。局所側
  (`bind_shapes`) は囲みスコープを持つので、束縛を名指しする tail も解決する
- **スカラー body は何も記録しない** ので通常の値は通常の経路のまま (fixture で固定)

## 検証

fixture (#1774 の `interp_function_return_test.vibe`) に 2 test 追加:
配列/タプル/`Some(...)` 包み/**スカラーが変わらないこと**/局所ラムダ。

- `compiler_gate.sh` green (#1774 が足した structural function-return ステップ込み)
- unit-test shard **628/628** × 4
- `check_vibe_fmt` 940 files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN)_