### PR TITLE
fix(parser): guard empty source offsets for region syntax

### DIFF
--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -1223,7 +1223,7 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
     // lookup, so the caller still needs `import @vibex/concurrent {
     // TaskGroup }` in scope (matching every hand-written call site today;
     // there is no auto-import mechanism in this compiler to inject one).
-    let off = Array::get(starts, pos)
+    let off = blk_offset_at(starts, pos)
     let br = expect_tk(tokens, pos, "{")
     let (gname, gn) = match peek(tokens, br) {
       TIdent(name) => (name, br + 1),
@@ -1251,7 +1251,7 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
     // convention), so the checker's literal-name special case cannot be
     // bypassed by aliasing: the hole ADR-0090 records for TaskGroup::run
     // does not exist here by construction.
-    let off = Array::get(starts, pos)
+    let off = blk_offset_at(starts, pos)
     let (rname, rn) = match peek(tokens, pos) {
       TIdent(name) => (name, pos + 1),
       _ => throw("expected a region binder name after 'region'")

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -45,6 +45,17 @@ test "parse_program: function declaration" {
   assert(Array::length(stmts) == 1)
 }
 
+test "parse_program: taskgroup accepts the empty source-offset lane (#1780)" {
+  let stmts =
+  parse_program(lex("fn run() -> Int { taskgroup { g => 7 } }"))
+  assert(Array::length(stmts) == 1)
+}
+
+test "parse_program: region accepts the empty source-offset lane (#1780)" {
+  let stmts = parse_program(lex("fn build() -> Array[Int] { region r { [7] } }"))
+  assert(Array::length(stmts) == 1)
+}
+
 test "parse_program: vibex import is rejected" {
   let result = handle {
     let _ = parse_program(lex("import ./tool.vibex { run }"))


### PR DESCRIPTION
Closes #1780\n\n- use the established safe source-offset lookup for taskgroup and region parse modes\n- add direct parse_program regression tests for the empty-offset lane\n- verified focused parser tests, affected local gate, selfhost generation, and precommit