### PR TITLE
test(wasm_runtime): pin wrapped i32 div_s overflow

### DIFF
--- a/lib/@vibex/wasm_runtime/spec_trap_test.vibe
+++ b/lib/@vibex/wasm_runtime/spec_trap_test.vibe
@@ -92,6 +92,10 @@ fn folded_int_min_div_s_module() -> Bytes {
   compile("(module (func (export \"f\") (result i32) i32.const 2147483647 i32.const 1 i32.add i32.const -1 i32.div_s))")
 }
 
+fn wrapped_i64_int_min_div_s_module() -> Bytes {
+  compile("(module (func (export \"f\") (result i32) i64.const 2147483648 i32.wrap_i64 i32.const -1 i32.div_s))")
+}
+
 //# Tests
 
 test "spec trap: i32.load inside the page does not trap" {
@@ -157,6 +161,13 @@ test "spec trap: i32.div_s normalizes computed operands before overflow check" {
   // i32.add leaves 0x80000000 in the host stack as positive 2147483648.
   // div_s must interpret that low-32-bit value as signed INT_MIN.
   assert(traps(folded_int_min_div_s_module(), args0()))
+}
+
+test "spec trap: i32.div_s traps after i32.wrap_i64 produces INT_MIN" {
+  // The same wasm i32 bit pattern must trap regardless of its producer. Before
+  // i32 values were canonicalized on the host stack, wrap_i64 left 0x80000000
+  // as positive 2147483648 and the signed overflow check missed it (#1778).
+  assert(traps(wrapped_i64_int_min_div_s_module(), args0()))
 }
 
 test "spec trap: i32.rem_s does NOT trap on overflow" {

--- a/lib/@vibex/wasm_runtime/wasm_runtime_test.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime_test.vibe
@@ -1978,6 +1978,27 @@ test "i32.wrap_i64" {
   assert(result == 300)
 }
 
+test "gc i32.div_s overflow after i32.wrap_i64" {
+  // i64.const 2147483648, i32.wrap_i64, i32.const -1, i32.div_s
+  // The GC-aware interpreter duplicates the numeric dispatch loop, so pin the
+  // same signed-host representation invariant there as well (#1778).
+  let code = make_bytes([
+    0x42,
+    0x80,
+    0x80,
+    0x80,
+    0x80,
+    0x08,
+    0xA7,
+    0x41,
+    0x7F,
+    0x6D,
+    0x0B
+  ])
+  let (exit, _) = exec_body_gc(code, 0, Bytes::length(code), make_locals(0), empty_stack(), make_memory(1), empty_globals(), empty_funcs(), empty_gc_heap())
+  assert(exit != 0)
+}
+
 test "i64.ge_u" {
   // i64.const 5, i64.const 3, i64.ge_u → 1
   let code = make_bytes([


### PR DESCRIPTION
## 概要

`i64.const 2147483648 -> i32.wrap_i64 -> i32.const -1 -> i32.div_s` が必ず overflow trap になることを、linear interpreter と GC-aware interpreter の双方で回帰テスト化します。

## 背景

#1778 の根本原因だった wasm i32 と host `Int` の表現不整合は、main に入った #1764 で producer と signed consumer の両側から既に修正されています。一方、issue で報告された `wrap_i64` から `div_s` へ流れる経路そのものは固定されていませんでした。

今回、以下を直接 pin します。

- WAT を compile して `exec_module_with_args` で実行する通常経路
- raw opcode を `exec_body_gc` へ渡す GC-aware 経路

旧挙動へ一時的に戻した対照では、どちらの新規テストも失敗することを確認しています。

## 検証

- focused wasm_runtime tests: 92/92 pass
- `pkf run test-affected -- --changed ...`: 2/2 pass
- `pkf run generation`: pass
- `bash scripts/ensure_generated.sh --check`: pass
- `bash scripts/precommit.sh`: pass
- 変更ファイルの formatter `--check`: pass

Closes #1778
