### PR TITLE
refactor(parser): thread invocation-local binder context spine

### DIFF
--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -7,6 +7,7 @@ vibe_parser	../../../lib/@vibe/parser/token.vibe
 vibe_parser	../../../lib/@vibe/parser/float_format.vibe
 vibe_parser	../../../lib/@vibe/parser/lexer.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_base.vibe
+vibe_parser	../../../lib/@vibe/parser/parser_binder_context.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_expr_primary.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_expr_core.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_expr_dispatch.vibe

--- a/lib/@vibe/compiler/syntax/index.vpkg
+++ b/lib/@vibe/compiler/syntax/index.vpkg
@@ -63,6 +63,7 @@ fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: Int) -> 
 fn parse_program(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn parse_program_located(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
+fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
 fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], src: String) -> (Array[Stmt], Array[String]) with Exception
 fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Array[Int]) -> (Array[Stmt], Array[Int], Array[Int]) with Exception
 

--- a/lib/@vibe/compiler/syntax/syntax.vibe
+++ b/lib/@vibe/compiler/syntax/syntax.vibe
@@ -4,5 +4,5 @@
 // @vibe/parser contract package; this module is a re-export shim so the
 // compiler's existing import spellings keep working.
 export ../../../../lib/@vibe/parser {
-  Token, double_to_string_compiler, lex, lex_ok, lex_with_offsets, lex_with_offsets_recovering, offset_to_line_col, parse, parse_expr, parse_ok, parse_program, parse_program_located, parse_program_preserving, parse_program_recovering, parse_program_spans, parse_stmt, parse_stmt_preserving, print_expr, print_pat, print_program, print_stmt, print_type_expr, token_to_string, parse_type, peek, tk_name, skip_semi, collect_import_path, parse_fn_signature
+  Token, double_to_string_compiler, lex, lex_ok, lex_with_offsets, lex_with_offsets_recovering, offset_to_line_col, parse, parse_expr, parse_ok, parse_program, parse_program_located, parse_program_located_with_binder_context, parse_program_preserving, parse_program_recovering, parse_program_spans, parse_stmt, parse_stmt_preserving, print_expr, print_pat, print_program, print_stmt, print_type_expr, token_to_string, parse_type, peek, tk_name, skip_semi, collect_import_path, parse_fn_signature
 }

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -80,6 +80,22 @@ test "check_linked_file: comment-only file has nothing to check -- succeeds" {
   assert(rc == 0)
 }
 
+test "parser binder context contract opacity is documentation-only" {
+  let path = "/tmp/vibe_parser_binder_context_private_constructor.vibe"
+  let source = "import @vibe/parser { type ParserBinderContext }\nlet forged: ParserBinderContext = ParserBinderContext::{ nonce: 0 }\n"
+  Fs::write_bytes(path, string_to_bytes(source))
+  let message = handle {
+    let _ = check_linked_file(path)
+    ""
+  } with Exception {
+    Throw(error) => error
+  }
+  // This is intentionally clean today: `opaque type` does not hide fields.
+  // The context is therefore untrusted and authority-free; the direct parser
+  // contract test proves a forged value cannot change parsing.
+  inspect(message, "")
+}
+
 /// #946(4): check_linked_file also runs the SAME inline-wasm codegen
 /// validation `vibe diagnostics` runs (check_inline_wasm_fns) — a bad SIMD
 /// lane index used to compile-fail with a located error while never being

--- a/lib/@vibe/compiler/tests/codegen_parser_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_parser_test.vibe
@@ -36,6 +36,7 @@ test "wasi: parser.vibe import - compile and run" {
     "lib/@vibe/parser/float_format.vibe",
     "lib/@vibe/parser/lexer.vibe",
     "lib/@vibe/parser/parser_base.vibe",
+    "lib/@vibe/parser/parser_binder_context.vibe",
     "lib/@vibe/parser/parser_expr_primary.vibe",
     "lib/@vibe/parser/parser_expr_core.vibe",
     "lib/@vibe/parser/parser_expr_dispatch.vibe",

--- a/lib/@vibe/compiler/tests/parser_binder_context_contract_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_binder_context_contract_test.vibe
@@ -1,0 +1,92 @@
+//# Imports
+
+import @vibe/ast {
+  Expr
+}
+
+import @vibe/parser {
+  type ParserBinderContext,
+  Token,
+  lex_with_offsets,
+  parse_impl,
+  parse_impl_dispatch,
+  parse_impl_dispatch_with_binder_context,
+  parse_impl_with_binder_context,
+  parse_infix,
+  parse_infix_no_is,
+  parse_infix_no_is_with_binder_context,
+  parse_infix_with_binder_context,
+  parse_primary,
+  parse_primary_with_binder_context,
+  parse_stmt,
+  parse_stmt_preserving,
+  parse_stmt_preserving_with_binder_context,
+  parse_stmt_with_binder_context,
+  print_expr,
+  print_stmt
+}
+
+//# Functions
+
+fn opaque_context_identity(context: Option[ParserBinderContext]) -> Option[ParserBinderContext] {
+  context
+}
+
+//# Tests
+
+test "parser binder context low-level contract accepts None without changing parsing" {
+  let source = "1 + 2"
+  let (tokens, starts, _) = lex_with_offsets(source)
+  let legacy_recur = (rtoks: Array[Token], rpos: Int, rmode: Int) -> parse_impl(rtoks, starts, rpos, rmode)
+  let context_recur = (rtoks: Array[Token], rpos: Int, rmode: Int, context: Option[ParserBinderContext]) -> parse_impl_with_binder_context(rtoks, starts, rpos, rmode, context)
+  let (legacy_impl, legacy_impl_next) = parse_impl(tokens, starts, 0, 0)
+  let (context_impl, context_impl_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, None)
+  inspect(print_expr(context_impl) == print_expr(legacy_impl), "true")
+  inspect(context_impl_next == legacy_impl_next, "true")
+  let (legacy_primary, legacy_primary_next) = parse_primary(tokens, starts, 0, legacy_recur)
+  let (context_primary, context_primary_next) = parse_primary_with_binder_context(tokens, starts, 0, context_recur, None)
+  inspect(print_expr(context_primary) == print_expr(legacy_primary), "true")
+  inspect(context_primary_next == legacy_primary_next, "true")
+  let (legacy_infix, legacy_infix_next) = parse_infix(tokens, starts, 0, 0, 0, legacy_recur)
+  let (context_infix, context_infix_next) = parse_infix_with_binder_context(tokens, starts, 0, 0, 0, context_recur, None)
+  inspect(print_expr(context_infix) == print_expr(legacy_infix), "true")
+  inspect(context_infix_next == legacy_infix_next, "true")
+  let (legacy_no_is, legacy_no_is_next) = parse_infix_no_is(tokens, starts, 0, 0, 0, legacy_recur)
+  let (context_no_is, context_no_is_next) = parse_infix_no_is_with_binder_context(tokens, starts, 0, 0, 0, context_recur, None)
+  inspect(print_expr(context_no_is) == print_expr(legacy_no_is), "true")
+  inspect(context_no_is_next == legacy_no_is_next, "true")
+  match opaque_context_identity(None) {
+    None => inspect(true, "true"),
+    Some(_) => inspect(false, "true")
+  }
+  // Contract opacity is currently documentation-only. Prove this external
+  // package can forge the representation, then prove that passing it carries
+  // no authority and changes no parse result in this infrastructure phase.
+  let forged_context = ParserBinderContext::{
+    nonce: 0
+  }
+  let (forged_impl, forged_impl_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, Some(forged_context))
+  inspect(print_expr(forged_impl) == print_expr(legacy_impl), "true")
+  inspect(forged_impl_next == legacy_impl_next, "true")
+}
+
+test "parser binder context statement and dispatch contracts accept None" {
+  let block_source = "1 }"
+  let (block_tokens, block_starts, _) = lex_with_offsets(block_source)
+  let legacy_recur = (rtoks: Array[Token], rpos: Int, rmode: Int) -> parse_impl(rtoks, block_starts, rpos, rmode)
+  let context_recur = (rtoks: Array[Token], rpos: Int, rmode: Int, context: Option[ParserBinderContext]) -> parse_impl_with_binder_context(rtoks, block_starts, rpos, rmode, context)
+  let (legacy_block, legacy_block_next) = parse_impl_dispatch(block_tokens, block_starts, 0, 20, legacy_recur)
+  let (context_block, context_block_next) = parse_impl_dispatch_with_binder_context(block_tokens, block_starts, 0, 20, context_recur, None)
+  inspect(print_expr(context_block) == print_expr(legacy_block), "true")
+  inspect(context_block_next == legacy_block_next, "true")
+  let stmt_source = "let value = 1"
+  let (stmt_tokens, stmt_starts, _) = lex_with_offsets(stmt_source)
+  let (legacy_stmt, legacy_stmt_next) = parse_stmt(stmt_tokens, stmt_starts, 0)
+  let (context_stmt, context_stmt_next) = parse_stmt_with_binder_context(stmt_tokens, stmt_starts, 0, None)
+  inspect(print_stmt(context_stmt) == print_stmt(legacy_stmt), "true")
+  inspect(context_stmt_next == legacy_stmt_next, "true")
+  let (legacy_preserving, legacy_preserving_next) = parse_stmt_preserving(stmt_tokens, stmt_starts, 0)
+  let (context_preserving, context_preserving_next) = parse_stmt_preserving_with_binder_context(stmt_tokens, stmt_starts, 0, None)
+  inspect(print_stmt(context_preserving) == print_stmt(legacy_preserving), "true")
+  inspect(context_preserving_next == legacy_preserving_next, "true")
+}

--- a/lib/@vibe/compiler/tests/parser_binder_context_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_binder_context_test.vibe
@@ -33,7 +33,7 @@ test "parser binder context spine preserves diagnostics" {
   inspect(ordinary == contextual, "true")
 }
 
-test "parser binder context is invocation-local and reentrant" {
+test "parser binder context is isolated across sequential invocations" {
   let left = "((x) -> { x + 1 })(1)"
   let right = "if false { 0 } else { 2 }"
   let (left_tokens, left_starts, _) = lex_with_offsets(left)

--- a/lib/@vibe/compiler/tests/parser_binder_context_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_binder_context_test.vibe
@@ -1,0 +1,46 @@
+//# Imports
+
+import @vibe/compiler/syntax {
+  lex_with_offsets, parse_program_located, parse_program_located_with_binder_context, print_program
+}
+
+//# Tests
+
+test "parser binder context spine preserves located output" {
+  let source = "if ready && item is None { f((x) -> { g(x + 1) }, [1, 2]) } else { match item { Some(x) => x, None => 0 } }"
+  let (tokens, starts, _) = lex_with_offsets(source)
+  let ordinary = print_program(parse_program_located(tokens, starts, source))
+  let contextual = print_program(parse_program_located_with_binder_context(tokens, starts, source))
+  inspect(ordinary == contextual, "true")
+}
+
+test "parser binder context spine preserves diagnostics" {
+  let source = "if true {"
+  let (tokens, starts, _) = lex_with_offsets(source)
+  let ordinary = handle {
+    let _ = parse_program_located(tokens, starts, source)
+    "ok"
+  } with Exception {
+    Throw(message) => message
+  }
+  let contextual = handle {
+    let _ = parse_program_located_with_binder_context(tokens, starts, source)
+    "ok"
+  } with Exception {
+    Throw(message) => message
+  }
+  inspect(String::length(ordinary) > 0, "true")
+  inspect(ordinary == contextual, "true")
+}
+
+test "parser binder context is invocation-local and reentrant" {
+  let left = "((x) -> { x + 1 })(1)"
+  let right = "if false { 0 } else { 2 }"
+  let (left_tokens, left_starts, _) = lex_with_offsets(left)
+  let (right_tokens, right_starts, _) = lex_with_offsets(right)
+  let left_first = print_program(parse_program_located_with_binder_context(left_tokens, left_starts, left))
+  let right_value = print_program(parse_program_located_with_binder_context(right_tokens, right_starts, right))
+  let left_second = print_program(parse_program_located_with_binder_context(left_tokens, left_starts, left))
+  inspect(left_first == left_second, "true")
+  inspect(String::length(right_value) > 0, "true")
+}

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -23,6 +23,12 @@ generated_hash =
 
 type Token
 
+// Untrusted invocation-local plumbing for the opt-in binder-authority parser.
+// The constructor is hidden, but callers may pass None to the public low-level
+// helpers. This phase carries no authority rows; future authority publication
+// must use only the high-level atomic parse aggregate.
+opaque type ParserBinderContext
+
 // --- polyfill
 
 // --- token
@@ -65,11 +71,16 @@ fn parse(tokens: Array[Token]) -> Expr with Exception
 fn parse_ok(tokens: Array[Token]) -> Bool
 fn parse_expr(tokens: Array[Token], pos: Int) -> (Expr, Int) with Exception
 fn parse_impl(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int) -> (Expr, Int) with Exception
+fn parse_impl_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception
 fn parse_fn_signature(tokens: Array[Token], pos: Int) -> ((String, Array[String], Array[(String, Array[String])]), (Array[(String, Option[TypeExpr])], TypeExpr, Option[String]), (Array[Expr], Array[Expr]), Int) with Exception
 fn parse_primary(tokens: Array[Token], starts: Array[Int], pos: Int, k: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception
+fn parse_primary_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, k: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception
 fn parse_infix(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, depth: Int, k: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception
+fn parse_infix_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, depth: Int, k: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception
 fn parse_infix_no_is(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, depth: Int, k: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception
+fn parse_infix_no_is_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, depth: Int, k: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception
 fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int, depth: Int, k: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception
+fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, depth: Int, k: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception
 
 // --- parser_expr (fn-declaration lowering, ADR-0064 #727/#731)
 fn lower_fn_decl_stmt(stmt: Stmt) -> Stmt
@@ -83,10 +94,13 @@ fn expand_top_level_pattern_lets(stmts: Array[Stmt]) -> Array[Stmt]
 
 // --- parser
 fn parse_stmt(tokens: Array[Token], starts: Array[Int], pos: Int) -> (Stmt, Int) with Exception
+fn parse_stmt_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
 fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: Int) -> (Stmt, Int) with Exception
+fn parse_stmt_preserving_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
 fn parse_program(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn parse_program_located(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
+fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
 fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], src: String) -> (Array[Stmt], Array[String]) with Exception
 fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Array[Int]) -> (Array[Stmt], Array[Int], Array[Int]) with Exception
 

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -24,9 +24,10 @@ generated_hash =
 type Token
 
 // Untrusted invocation-local plumbing for the opt-in binder-authority parser.
-// The constructor is hidden, but callers may pass None to the public low-level
-// helpers. This phase carries no authority rows; future authority publication
-// must use only the high-level atomic parse aggregate.
+// `opaque type` is currently documentation-only, so external callers can forge
+// this representation and pass it (or None) to the low-level helpers. This
+// phase carries no authority rows. Future authority publication must ignore
+// caller context and use only the high-level exhaustively validated aggregate.
 opaque type ParserBinderContext
 
 // --- polyfill

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -1048,7 +1048,9 @@ export fn parse_program_located(tokens: Array[Token], starts: Array[Int], source
 /// rows; it only proves that one invocation-local context reaches the recursive
 /// expression callback spine without changing the parsed program.
 export fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array[Int], source: String) -> Array[Stmt] with Exception {
-  parse_program_located_with_context_impl(tokens, starts, source, Some(ParserBinderContext))
+  parse_program_located_with_context_impl(tokens, starts, source, Some(ParserBinderContext::{
+    nonce: 0
+  }))
 }
 
 export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], source: String) -> (Array[Stmt], Array[String]) with Exception {

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -42,6 +42,7 @@ import ./parser_expr.vibe {
   parse_expr,
   parse_fn_stmt,
   parse_impl,
+  parse_impl_with_binder_context,
   parse_let_stmt,
   parse_ok
 }
@@ -52,6 +53,10 @@ import ./token.vibe {
 
 import ./lexer.vibe {
   offset_to_line_col
+}
+
+import ./parser_binder_context.vibe {
+  ParserBinderContext
 }
 
 //# Functions
@@ -482,7 +487,7 @@ fn parse_extern_let_stmt(tokens: Array[Token], pos: Int) -> (Stmt, Int) with Exc
 /// round-tripping (ADR-0064 #727). Everything that feeds the checker or
 /// codegen should use `parse_stmt` / `parse_program*` below, which lower
 /// SFnDecl to the legacy SLet shape.
-export fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: Int) -> (Stmt, Int) with Exception {
+export fn parse_stmt_preserving_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   let raw_head = peek(tokens, pos)
   // #1343: rewrite `resource` to a name no identifier can have UNLESS it
   // starts a declaration, so the dispatch below routes `resource = f()` /
@@ -523,11 +528,11 @@ export fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: I
       "extern" => parse_extern_let_stmt(tokens, pos + 1),
       "use" => throw("'use' syntax is removed; use 'import <module-ref> { ... }'"),
       _ => {
-        let (e, next) = parse_impl(tokens, starts, pos, 0)
+        let (e, next) = parse_impl_with_binder_context(tokens, starts, pos, 0, context)
         match peek(tokens, next) {
           TEq => match e {
             EIdent(name, _) => {
-              let (val, vn) = parse_impl(tokens, starts, next + 1, 0)
+              let (val, vn) = parse_impl_with_binder_context(tokens, starts, next + 1, 0, context)
               (SExpr(EAssign(name, val, EUnit)), vn)
             },
             ECall(idx_callee, idx_args, _) => {
@@ -538,7 +543,7 @@ export fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: I
                 _ => false
               }
               if is_index && Array::length(idx_args) == 2 {
-                let (val, vn) = parse_impl(tokens, starts, next + 1, 0)
+                let (val, vn) = parse_impl_with_binder_context(tokens, starts, next + 1, 0, context)
                 let set_args = Array::slice([
                   EUnit
                 ], 0, 0)
@@ -554,28 +559,28 @@ export fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: I
           },
           TPlusEq => match e {
             EIdent(name, _) => {
-              let (val, vn) = parse_impl(tokens, starts, next + 1, 0)
+              let (val, vn) = parse_impl_with_binder_context(tokens, starts, next + 1, 0, context)
               (SExpr(EAssignOp(name, "+", val, EUnit)), vn)
             },
             _ => (SExpr(e), next)
           },
           TMinusEq => match e {
             EIdent(name, _) => {
-              let (val, vn) = parse_impl(tokens, starts, next + 1, 0)
+              let (val, vn) = parse_impl_with_binder_context(tokens, starts, next + 1, 0, context)
               (SExpr(EAssignOp(name, "-", val, EUnit)), vn)
             },
             _ => (SExpr(e), next)
           },
           TStarEq => match e {
             EIdent(name, _) => {
-              let (val, vn) = parse_impl(tokens, starts, next + 1, 0)
+              let (val, vn) = parse_impl_with_binder_context(tokens, starts, next + 1, 0, context)
               (SExpr(EAssignOp(name, "*", val, EUnit)), vn)
             },
             _ => (SExpr(e), next)
           },
           TSlashEq => match e {
             EIdent(name, _) => {
-              let (val, vn) = parse_impl(tokens, starts, next + 1, 0)
+              let (val, vn) = parse_impl_with_binder_context(tokens, starts, next + 1, 0, context)
               (SExpr(EAssignOp(name, "/", val, EUnit)), vn)
             },
             _ => (SExpr(e), next)
@@ -585,10 +590,14 @@ export fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: I
       }
     },
     _ => {
-      let (e, next) = parse_impl(tokens, starts, pos, 0);
+      let (e, next) = parse_impl_with_binder_context(tokens, starts, pos, 0, context);
       (SExpr(e), next)
     }
   }
+}
+
+export fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: Int) -> (Stmt, Int) with Exception {
+  parse_stmt_preserving_with_binder_context(tokens, starts, pos, None)
 }
 
 /// Default statement entry: identical to parse_stmt_preserving except that a
@@ -599,6 +608,11 @@ export fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: I
 /// contract engine, ...) keep seeing the pre-#727 AST.
 export fn parse_stmt(tokens: Array[Token], starts: Array[Int], pos: Int) -> (Stmt, Int) with Exception {
   let (stmt, next) = parse_stmt_preserving(tokens, starts, pos)
+  (lower_fn_decl_stmt(stmt), next)
+}
+
+export fn parse_stmt_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  let (stmt, next) = parse_stmt_preserving_with_binder_context(tokens, starts, pos, context)
   (lower_fn_decl_stmt(stmt), next)
 }
 
@@ -913,7 +927,7 @@ fn extract_err_token_pos(msg: String, fallback_pos: Int) -> (Int, String) {
   }
 }
 
-export fn parse_program_located(tokens: Array[Token], starts: Array[Int], source: String) -> Array[Stmt] with Exception {
+fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[Int], source: String, context: Option[ParserBinderContext]) -> Array[Stmt] with Exception {
   let cfg_active = cfg_scan_enabled(tokens)
   let b = ArrayBuilder::new()
   let mut pos = 0
@@ -938,7 +952,7 @@ export fn parse_program_located(tokens: Array[Token], starts: Array[Int], source
               pos = dn
             },
             _ => {
-              let (_dropped, dn) = parse_stmt(tokens, starts, dnext)
+              let (_dropped, dn) = parse_stmt_with_binder_context(tokens, starts, dnext, context)
               pos = dn
             }
           }
@@ -953,7 +967,7 @@ export fn parse_program_located(tokens: Array[Token], starts: Array[Int], source
               parse_impl_methods(tokens, hp, simpl)
             },
             _ => {
-              let (stmt, n) = parse_stmt(tokens, starts, pos)
+              let (stmt, n) = parse_stmt_with_binder_context(tokens, starts, pos, context)
               ([
                 stmt
               ], n)
@@ -1025,6 +1039,18 @@ fn is_recovery_point(t: Token) -> Bool {
 /// progress. Returns the partial AST plus all collected diagnostics. Build all
 /// strings with String::concat (not `+`/interpolation) to avoid selfhost
 /// string-concat NUL fragility. Foundation: collect-all parse diagnostics (LSP).
+
+export fn parse_program_located(tokens: Array[Token], starts: Array[Int], source: String) -> Array[Stmt] with Exception {
+  parse_program_located_with_context_impl(tokens, starts, source, None)
+}
+
+/// Opt-in parser-context infrastructure. This phase publishes no authority
+/// rows; it only proves that one invocation-local context reaches the recursive
+/// expression callback spine without changing the parsed program.
+export fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array[Int], source: String) -> Array[Stmt] with Exception {
+  parse_program_located_with_context_impl(tokens, starts, source, Some(ParserBinderContext))
+}
+
 export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], source: String) -> (Array[Stmt], Array[String]) with Exception {
   let cfg_active = handle {
     cfg_scan_enabled(tokens)

--- a/lib/@vibe/parser/parser_binder_context.vibe
+++ b/lib/@vibe/parser/parser_binder_context.vibe
@@ -3,10 +3,11 @@
 /// Invocation-local parser context reserved for binder-authority capture.
 ///
 /// This first infrastructure slice deliberately carries no rows. The package
-/// contract exposes this as an opaque type because cross-file parser helpers
-/// must export their signatures, but hides the constructor. Those helpers are
-/// untrusted plumbing: future authority must come only from the high-level
-/// atomic parse aggregate after exhaustive completeness validation.
-export enum ParserBinderContext {
-  ParserBinderContext
+/// contract spells this `opaque type`, but contract opacity is currently
+/// documentation-only: external code can still forge the representation.
+/// Therefore this context and every low-level helper are untrusted plumbing.
+/// Future authority must come only from the high-level atomic parse aggregate
+/// after exhaustive completeness validation, never from caller context.
+export struct ParserBinderContext {
+  nonce: Int
 }

--- a/lib/@vibe/parser/parser_binder_context.vibe
+++ b/lib/@vibe/parser/parser_binder_context.vibe
@@ -1,0 +1,12 @@
+//# Types
+
+/// Invocation-local parser context reserved for binder-authority capture.
+///
+/// This first infrastructure slice deliberately carries no rows. The package
+/// contract exposes this as an opaque type because cross-file parser helpers
+/// must export their signatures, but hides the constructor. Those helpers are
+/// untrusted plumbing: future authority must come only from the high-level
+/// atomic parse aggregate after exhaustive completeness validation.
+export enum ParserBinderContext {
+  ParserBinderContext
+}

--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -36,28 +36,36 @@ import ./parser_base.vibe {
 }
 
 import ./parser_expr_core.vibe {
-  parse_infix
+  parse_infix_with_binder_context
 }
 
 import ./parser_expr_dispatch.vibe {
-  parse_impl_dispatch
+  parse_impl_dispatch_with_binder_context
 }
 
 import ./token.vibe {
   Token
 }
 
+import ./parser_binder_context.vibe {
+  ParserBinderContext
+}
+
 //# Functions
 
-export fn parse_impl(tokens: Array[Token], starts: Array[Int], pos: Int, mode: Int) -> (Expr, Int) with Exception {
-  let rec parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception = (rtoks, rpos, rmode) -> {
+export fn parse_impl_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, mode: Int, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
+  let rec parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception = (rtoks, rpos, rmode, recur_context) -> {
     if rmode >= 0 && rmode <= 10 {
-      parse_infix(rtoks, starts, rpos, rmode, rpos, parse_recur)
+      parse_infix_with_binder_context(rtoks, starts, rpos, rmode, rpos, parse_recur, recur_context)
     } else {
-      parse_impl_dispatch(rtoks, starts, rpos, rmode, parse_recur)
+      parse_impl_dispatch_with_binder_context(rtoks, starts, rpos, rmode, parse_recur, recur_context)
     }
   }
-  parse_recur(tokens, pos, mode)
+  parse_recur(tokens, pos, mode, context)
+}
+
+export fn parse_impl(tokens: Array[Token], starts: Array[Int], pos: Int, mode: Int) -> (Expr, Int) with Exception {
+  parse_impl_with_binder_context(tokens, starts, pos, mode, None)
 }
 
 export fn parse(tokens: Array[Token]) -> Expr with Exception {

--- a/lib/@vibe/parser/parser_expr_core.vibe
+++ b/lib/@vibe/parser/parser_expr_core.vibe
@@ -9,11 +9,15 @@ import ./parser_base.vibe {
 }
 
 import ./parser_expr_primary.vibe {
-  parse_primary
+  parse_primary_with_binder_context
 }
 
 import ./token.vibe {
   Token
+}
+
+import ./parser_binder_context.vibe {
+  ParserBinderContext
 }
 
 //# Functions
@@ -170,36 +174,36 @@ fn pipe_desugar(lhs: Expr, rhs: Expr) -> Expr {
   }
 }
 
-fn parse_call_arg(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_call_arg(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => match peek(tokens, pos + 1) {
       TThinArrow => {
-        let (body, end) = parse_recur(tokens, pos + 2, 0)
+        let (body, end) = parse_recur(tokens, pos + 2, 0, context)
         (EFn(_no_tp(), _no_tb(), [
           (name, None)
         ], None, None, body), end)
       },
       TTilde => match peek(tokens, pos + 2) {
         TEq => {
-          let (val, end) = parse_recur(tokens, pos + 3, 0)
+          let (val, end) = parse_recur(tokens, pos + 3, 0, context)
           (ELabeledArg(name, "~", val), end)
         },
-        _ => parse_recur(tokens, pos, 0)
+        _ => parse_recur(tokens, pos, 0, context)
       },
       TQuestion => match peek(tokens, pos + 2) {
         TEq => {
-          let (val, end) = parse_recur(tokens, pos + 3, 0)
+          let (val, end) = parse_recur(tokens, pos + 3, 0, context)
           (ELabeledArg(name, "?", val), end)
         },
-        _ => parse_recur(tokens, pos, 0)
+        _ => parse_recur(tokens, pos, 0, context)
       },
       TEq => {
-        let (val, end) = parse_recur(tokens, pos + 2, 0)
+        let (val, end) = parse_recur(tokens, pos + 2, 0, context)
         (ELabeledArg(name, "~", val), end)
       },
-      _ => parse_recur(tokens, pos, 0)
+      _ => parse_recur(tokens, pos, 0, context)
     },
-    _ => parse_recur(tokens, pos, 0)
+    _ => parse_recur(tokens, pos, 0, context)
   }
 }
 
@@ -236,7 +240,7 @@ fn has_placeholder_args(args: Array[Expr]) -> Bool {
   found
 }
 
-fn parse_call_args_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[Expr], parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Array[Expr], Int) with Exception {
+fn parse_call_args_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[Expr], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Array[Expr], Int) with Exception {
   let mut p = pos
   let mut done = false
   while !done {
@@ -247,7 +251,7 @@ fn parse_call_args_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: A
           done = true
         },
         _ => {
-          let (e, next) = parse_call_arg(tokens, starts, p + 1, parse_recur)
+          let (e, next) = parse_call_arg(tokens, starts, p + 1, parse_recur, context)
           ArrayBuilder::push(b, e)
           p = next
         }
@@ -437,7 +441,7 @@ fn build_call_expr(expr: Expr, args: Array[Expr], pos: Int) -> Expr with Excepti
   }
 }
 
-fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos) {
     TLParen => match expr {
       // NOTE: an ECall left is deliberately NOT blocked here — a same-line
@@ -465,19 +469,19 @@ fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr,
       EForIn(_, _, _, _) => (expr, pos),
       EHandle(_, _) => (expr, pos),
       _ => match peek(tokens, pos + 1) {
-        TRParen => parse_postfix(tokens, starts, pos + 2, build_call_expr(expr, empty_exprs(), pos), parse_recur),
+        TRParen => parse_postfix(tokens, starts, pos + 2, build_call_expr(expr, empty_exprs(), pos), parse_recur, context),
         _ => {
           let b = ArrayBuilder::new()
-          let (first_arg, next_pos) = parse_call_arg(tokens, starts, pos + 1, parse_recur)
+          let (first_arg, next_pos) = parse_call_arg(tokens, starts, pos + 1, parse_recur, context)
           ArrayBuilder::push(b, first_arg)
-          let (args, end_pos) = parse_call_args_rest(tokens, starts, next_pos, b, parse_recur)
+          let (args, end_pos) = parse_call_args_rest(tokens, starts, next_pos, b, parse_recur, context)
           let close_pos = expect_tk(tokens, end_pos, ")")
           let call_args = if has_placeholder_args(args) {
             desugar_placeholder_args(args)
           } else {
             args
           }
-          parse_postfix(tokens, starts, close_pos, build_call_expr(expr, call_args, pos), parse_recur)
+          parse_postfix(tokens, starts, close_pos, build_call_expr(expr, call_args, pos), parse_recur, context)
         }
       },
     },
@@ -487,34 +491,34 @@ fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr,
           let end_expr = ECall(EIdent("__len", -1), [
             expr
           ], -1)
-          parse_postfix(tokens, starts, pos + 3, slice_from_zero_expr(expr, end_expr), parse_recur)
+          parse_postfix(tokens, starts, pos + 3, slice_from_zero_expr(expr, end_expr), parse_recur, context)
         },
         _ => {
-          let (end_expr, end_next) = parse_recur(tokens, pos + 2, 0)
+          let (end_expr, end_next) = parse_recur(tokens, pos + 2, 0, context)
           let close_pos = match peek(tokens, end_next) {
             TRBracket => end_next + 1,
             _ => throw("expected ']'")
           }
-          parse_postfix(tokens, starts, close_pos, slice_from_zero_expr(expr, end_expr), parse_recur)
+          parse_postfix(tokens, starts, close_pos, slice_from_zero_expr(expr, end_expr), parse_recur, context)
         }
       },
       _ => {
-        let (idx, idx_next) = parse_recur(tokens, pos + 1, 0)
+        let (idx, idx_next) = parse_recur(tokens, pos + 1, 0, context)
         match peek(tokens, idx_next) {
           TColon => match peek(tokens, idx_next + 1) {
             TRBracket => {
               let end_expr = ECall(EIdent("__len", -1), [
                 expr
               ], -1)
-              parse_postfix(tokens, starts, idx_next + 2, slice_from_idx_expr(expr, idx, end_expr), parse_recur)
+              parse_postfix(tokens, starts, idx_next + 2, slice_from_idx_expr(expr, idx, end_expr), parse_recur, context)
             },
             _ => {
-              let (end_expr, end_next) = parse_recur(tokens, idx_next + 1, 0)
+              let (end_expr, end_next) = parse_recur(tokens, idx_next + 1, 0, context)
               let close_pos = match peek(tokens, end_next) {
                 TRBracket => end_next + 1,
                 _ => throw("expected ']'")
               }
-              parse_postfix(tokens, starts, close_pos, slice_from_idx_expr(expr, idx, end_expr), parse_recur)
+              parse_postfix(tokens, starts, close_pos, slice_from_idx_expr(expr, idx, end_expr), parse_recur, context)
             }
           },
           _ => {
@@ -522,14 +526,14 @@ fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr,
               TRBracket => idx_next + 1,
               _ => throw("expected ']'")
             }
-            parse_postfix(tokens, starts, close_pos, index_expr(expr, idx), parse_recur)
+            parse_postfix(tokens, starts, close_pos, index_expr(expr, idx), parse_recur, context)
           }
         }
       }
     },
     TDot => match peek(tokens, pos + 1) {
-      TIdent(field) => parse_postfix(tokens, starts, pos + 2, EDot(expr, field, callee_offset(expr), field_offset_at(starts, pos + 1)), parse_recur),
-      TInt(idx) => parse_postfix(tokens, starts, pos + 2, EDot(expr, __to_string(idx), callee_offset(expr), field_offset_at(starts, pos + 1)), parse_recur),
+      TIdent(field) => parse_postfix(tokens, starts, pos + 2, EDot(expr, field, callee_offset(expr), field_offset_at(starts, pos + 1)), parse_recur, context),
+      TInt(idx) => parse_postfix(tokens, starts, pos + 2, EDot(expr, __to_string(idx), callee_offset(expr), field_offset_at(starts, pos + 1)), parse_recur, context),
       _ => (expr, pos)
     },
     // `expr?` (railway try, #635): emit the type-directed sentinel
@@ -540,24 +544,24 @@ fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr,
     // parsing so `f(x)?.field` chains.
     TQuestion => parse_postfix(tokens, starts, pos + 1, ECall(EIdent("__try_op", -1), [
       expr
-    ], -1), parse_recur),
+    ], -1), parse_recur, context),
     _ => (expr, pos)
   }
 }
 
-fn parse_prefix(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_prefix(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos) {
     TMinus => {
-      let (e, next) = parse_prefix(tokens, starts, pos + 1, parse_recur)
+      let (e, next) = parse_prefix(tokens, starts, pos + 1, parse_recur, context)
       (EUnaryOp("-", e), next)
     },
     TNot => {
-      let (e, next) = parse_prefix(tokens, starts, pos + 1, parse_recur)
+      let (e, next) = parse_prefix(tokens, starts, pos + 1, parse_recur, context)
       (EUnaryOp("!", e), next)
     },
     _ => {
-      let (e, next) = parse_primary(tokens, starts, pos, parse_recur)
-      parse_postfix(tokens, starts, next, e, parse_recur)
+      let (e, next) = parse_primary_with_binder_context(tokens, starts, pos, parse_recur, context)
+      parse_postfix(tokens, starts, next, e, parse_recur, context)
     }
   }
 }
@@ -595,7 +599,7 @@ fn is_is_token(tok: Token) -> Bool {
   }
 }
 
-fn parse_infix_loop(tokens: Array[Token], starts: Array[Int], left: Expr, next: Int, min_prec: Int, expr_start: Int, cmp_locked: Bool, consume_is: Bool, is_top_atom: Bool, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_infix_loop(tokens: Array[Token], starts: Array[Int], left: Expr, next: Int, min_prec: Int, expr_start: Int, cmp_locked: Bool, consume_is: Bool, is_top_atom: Bool, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   let tok = peek(tokens, next)
   if consume_is && !cmp_locked && 3 >= min_prec && is_is_token(tok) && is_top_atom {
     // #979 review (if-cond): a trailing `is pattern` on the UNFOLDED top
@@ -617,7 +621,7 @@ fn parse_infix_loop(tokens: Array[Token], starts: Array[Int], left: Expr, next: 
       (pat, EBool(true)),
       (PWild, EBool(false))
     ])
-    parse_infix_loop(tokens, starts, combined, pn, min_prec, expr_start, true, consume_is, false, parse_recur)
+    parse_infix_loop(tokens, starts, combined, pn, min_prec, expr_start, true, consume_is, false, parse_recur, context)
   } else {
     let prec = binop_prec(tok)
     let should_stop = if prec < min_prec {
@@ -652,8 +656,8 @@ fn parse_infix_loop(tokens: Array[Token], starts: Array[Int], left: Expr, next: 
           throw("cannot mix '|>' with other infix operators without explicit parentheses")
         }
       }
-      let (right0, right_next0) = parse_prefix(tokens, starts, next + 1, parse_recur)
-      let (right, rn) = parse_infix_loop(tokens, starts, right0, right_next0, prec + 1, next + 1, false, consume_is, false, parse_recur)
+      let (right0, right_next0) = parse_prefix(tokens, starts, next + 1, parse_recur, context)
+      let (right, rn) = parse_infix_loop(tokens, starts, right0, right_next0, prec + 1, next + 1, false, consume_is, false, parse_recur, context)
       if is_pipe {
         if has_non_pipe_infix_top(tokens, next + 1, rn) {
           throw("cannot mix '|>' with other infix operators without explicit parentheses")
@@ -669,7 +673,7 @@ fn parse_infix_loop(tokens: Array[Token], starts: Array[Int], left: Expr, next: 
       } else {
         cmp_locked
       }
-      parse_infix_loop(tokens, starts, combined, rn, min_prec, expr_start, next_cmp_locked, consume_is, false, parse_recur)
+      parse_infix_loop(tokens, starts, combined, rn, min_prec, expr_start, next_cmp_locked, consume_is, false, parse_recur, context)
     }
   }
 }
@@ -695,9 +699,14 @@ fn parse_infix_loop(tokens: Array[Token], starts: Array[Int], left: Expr, next: 
 /// now parses as `if (ready && (value is None)) { }`, matching the
 /// documented precedence, while `if x is Some(v) { use(v) }` still binds
 /// `v` in the then-branch exactly as before.
+export fn parse_infix_no_is_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, expr_start: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
+  let (left0, next0) = parse_prefix(tokens, starts, pos, parse_recur, context)
+  parse_infix_loop(tokens, starts, left0, next0, min_prec, expr_start, false, true, true, parse_recur, context)
+}
+
 export fn parse_infix_no_is(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, expr_start: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
-  let (left0, next0) = parse_prefix(tokens, starts, pos, parse_recur)
-  parse_infix_loop(tokens, starts, left0, next0, min_prec, expr_start, false, true, true, parse_recur)
+  let adapted = (rtoks, rpos, rmode, _context) -> parse_recur(rtoks, rpos, rmode)
+  parse_infix_no_is_with_binder_context(tokens, starts, pos, min_prec, expr_start, adapted, None)
 }
 
 /// #979: `is` is folded directly into the precedence ladder (tier 3, same as
@@ -706,7 +715,12 @@ export fn parse_infix_no_is(tokens: Array[Token], starts: Array[Int], pos: Int, 
 /// `(a && b) is None`. `is_top_atom = false` unconditionally here -- outside
 /// an if-condition there is no special pattern-binding form, so even a bare
 /// `x is Some(v)` folds straight to a Bool `EMatch` with no binding.
+export fn parse_infix_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, expr_start: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
+  let (left0, next0) = parse_prefix(tokens, starts, pos, parse_recur, context)
+  parse_infix_loop(tokens, starts, left0, next0, min_prec, expr_start, false, true, false, parse_recur, context)
+}
+
 export fn parse_infix(tokens: Array[Token], starts: Array[Int], pos: Int, min_prec: Int, expr_start: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
-  let (left0, next0) = parse_prefix(tokens, starts, pos, parse_recur)
-  parse_infix_loop(tokens, starts, left0, next0, min_prec, expr_start, false, true, false, parse_recur)
+  let adapted = (rtoks, rpos, rmode, _context) -> parse_recur(rtoks, rpos, rmode)
+  parse_infix_with_binder_context(tokens, starts, pos, min_prec, expr_start, adapted, None)
 }

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -20,11 +20,15 @@ import ./parser_base.vibe {
 }
 
 import ./parser_expr_core.vibe {
-  parse_infix_no_is
+  parse_infix_no_is_with_binder_context
 }
 
 import ./token.vibe {
   Token
+}
+
+import ./parser_binder_context.vibe {
+  ParserBinderContext
 }
 
 //# Functions
@@ -271,27 +275,27 @@ fn desugar_guarded(arms: Array[(Pat, Expr, Expr)], i: Int, scrut: Expr) -> Array
 /// #666: parse all match arms into `b` as (pattern, guard|EBool(true), body),
 /// setting hg[0] when any arm carries a guard. Arms are comma-separated, ending
 /// at `}` (optionally with a trailing comma).
-fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(Pat, Expr, Expr)], hg: Array[Bool], parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> Int with Exception {
+fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(Pat, Expr, Expr)], hg: Array[Bool], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> Int with Exception {
   let (pat, pa) = parse_pattern(tokens, pos)
   let (arm_guard, after_g) = match peek(tokens, pa) {
     TIf => {
       Array::set(hg, 0, true)
-      parse_recur(tokens, pa + 1, 0)
+      parse_recur(tokens, pa + 1, 0, context)
     },
     _ => (EBool(true), pa)
   }
   let arrow = expect_tk(tokens, after_g, "=>")
-  let (body, bn) = parse_recur(tokens, arrow, 0)
+  let (body, bn) = parse_recur(tokens, arrow, 0, context)
   ArrayBuilder::push(b, (pat, arm_guard, body))
   match peek(tokens, bn) {
     TComma => match peek(tokens, bn + 1) {
       TRBrace => bn + 2,
-      _ => collect_match_arms(tokens, starts, bn + 1, b, hg, parse_recur)
+      _ => collect_match_arms(tokens, starts, bn + 1, b, hg, parse_recur, context)
     },
     TRBrace => bn + 1,
     // Comma-less arm separation: mirror the old parse_match_rest fall-through,
     // which parsed the next arm's pattern without consuming a separator.
-    _ => collect_match_arms(tokens, starts, bn, b, hg, parse_recur)
+    _ => collect_match_arms(tokens, starts, bn, b, hg, parse_recur, context)
   }
 }
 
@@ -307,22 +311,22 @@ fn qualify_handle_arm_pattern(effect_name: String, pat: Pat) -> Pat {
   }
 }
 
-fn parse_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, effect_name: String, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> ((Pat, Expr), Int) with Exception {
+fn parse_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, effect_name: String, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> ((Pat, Expr), Int) with Exception {
   let (pat, pat_next) = parse_pattern(tokens, pos)
   let qualified_pat = qualify_handle_arm_pattern(effect_name, pat)
   let arrow_pos = expect_tk(tokens, pat_next, "=>")
-  let (expr, next) = parse_recur(tokens, arrow_pos, 0)
+  let (expr, next) = parse_recur(tokens, arrow_pos, 0, context)
   ((qualified_pat, expr), next)
 }
 
-fn parse_handle_rest(tokens: Array[Token], starts: Array[Int], pos: Int, body: Expr, effect_name: String, b: ArrayBuilder[(Pat, Expr)], parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_handle_rest(tokens: Array[Token], starts: Array[Int], pos: Int, body: Expr, effect_name: String, b: ArrayBuilder[(Pat, Expr)], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos) {
     TSemicolon => match peek(tokens, pos + 1) {
       TRBrace => (EHandle(body, ArrayBuilder::freeze(b)), pos + 2),
       _ => {
-        let (arm, next) = parse_handle_arm(tokens, starts, pos + 1, effect_name, parse_recur)
+        let (arm, next) = parse_handle_arm(tokens, starts, pos + 1, effect_name, parse_recur, context)
         ArrayBuilder::push(b, arm)
-        parse_handle_rest(tokens, starts, next, body, effect_name, b, parse_recur)
+        parse_handle_rest(tokens, starts, next, body, effect_name, b, parse_recur, context)
       }
     },
     TRBrace => (EHandle(body, ArrayBuilder::freeze(b)), pos + 1),
@@ -330,28 +334,28 @@ fn parse_handle_rest(tokens: Array[Token], starts: Array[Int], pos: Int, body: E
   }
 }
 
-fn parse_block_after_expr(tokens: Array[Token], pos: Int, e: Expr, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_block_after_expr(tokens: Array[Token], pos: Int, e: Expr, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos) {
     TRBrace => (e, pos + 1),
     TSemicolon => {
-      let (rest, end) = parse_recur(tokens, pos + 1, 20)
+      let (rest, end) = parse_recur(tokens, pos + 1, 20, context)
       (ESeq(e, rest), end)
     },
     TEq => match e {
       EIdent(name, _) => {
-        let val_pair = parse_recur(tokens, pos + 1, 0)
+        let val_pair = parse_recur(tokens, pos + 1, 0, context)
         let val = val_pair.0
         let val_next = val_pair.1
         let a = skip_semi(tokens, val_next)
-        let (rest, end) = parse_recur(tokens, a, 20)
+        let (rest, end) = parse_recur(tokens, a, 20, context)
         (EAssign(name, val, rest), end)
       },
       EDot(obj, field, _, _) => {
-        let val_pair = parse_recur(tokens, pos + 1, 0)
+        let val_pair = parse_recur(tokens, pos + 1, 0, context)
         let val = val_pair.0
         let val_next = val_pair.1
         let a = skip_semi(tokens, val_next)
-        let (rest, end) = parse_recur(tokens, a, 20)
+        let (rest, end) = parse_recur(tokens, a, 20, context)
         let set_args = empty_exprs()
         Array::push(set_args, obj)
         Array::push(set_args, EString(field))
@@ -369,11 +373,11 @@ fn parse_block_after_expr(tokens: Array[Token], pos: Int, e: Expr, parse_recur: 
           _ => false
         }
         if is_index && Array::length(idx_args) == 2 {
-          let val_pair = parse_recur(tokens, pos + 1, 0)
+          let val_pair = parse_recur(tokens, pos + 1, 0, context)
           let val = val_pair.0
           let val_next = val_pair.1
           let a = skip_semi(tokens, val_next)
-          let (rest, end) = parse_recur(tokens, a, 20)
+          let (rest, end) = parse_recur(tokens, a, 20, context)
           let set_args = empty_exprs()
           Array::push(set_args, Array::get(idx_args, 0))
           Array::push(set_args, Array::get(idx_args, 1))
@@ -387,61 +391,61 @@ fn parse_block_after_expr(tokens: Array[Token], pos: Int, e: Expr, parse_recur: 
     },
     TPlusEq => match e {
       EIdent(name, _) => {
-        let val_pair = parse_recur(tokens, pos + 1, 0)
+        let val_pair = parse_recur(tokens, pos + 1, 0, context)
         let val = val_pair.0
         let val_next = val_pair.1
         let a = skip_semi(tokens, val_next)
-        let (rest, end) = parse_recur(tokens, a, 20)
+        let (rest, end) = parse_recur(tokens, a, 20, context)
         (EAssignOp(name, "+", val, rest), end)
       },
       _ => throw("invalid assignment target")
     },
     TMinusEq => match e {
       EIdent(name, _) => {
-        let val_pair = parse_recur(tokens, pos + 1, 0)
+        let val_pair = parse_recur(tokens, pos + 1, 0, context)
         let val = val_pair.0
         let val_next = val_pair.1
         let a = skip_semi(tokens, val_next)
-        let (rest, end) = parse_recur(tokens, a, 20)
+        let (rest, end) = parse_recur(tokens, a, 20, context)
         (EAssignOp(name, "-", val, rest), end)
       },
       _ => throw("invalid assignment target")
     },
     TStarEq => match e {
       EIdent(name, _) => {
-        let val_pair = parse_recur(tokens, pos + 1, 0)
+        let val_pair = parse_recur(tokens, pos + 1, 0, context)
         let val = val_pair.0
         let val_next = val_pair.1
         let a = skip_semi(tokens, val_next)
-        let (rest, end) = parse_recur(tokens, a, 20)
+        let (rest, end) = parse_recur(tokens, a, 20, context)
         (EAssignOp(name, "*", val, rest), end)
       },
       _ => throw("invalid assignment target")
     },
     TSlashEq => match e {
       EIdent(name, _) => {
-        let val_pair = parse_recur(tokens, pos + 1, 0)
+        let val_pair = parse_recur(tokens, pos + 1, 0, context)
         let val = val_pair.0
         let val_next = val_pair.1
         let a = skip_semi(tokens, val_next)
-        let (rest, end) = parse_recur(tokens, a, 20)
+        let (rest, end) = parse_recur(tokens, a, 20, context)
         (EAssignOp(name, "/", val, rest), end)
       },
       _ => throw("invalid assignment target")
     },
     TPercentEq => match e {
       EIdent(name, _) => {
-        let val_pair = parse_recur(tokens, pos + 1, 0)
+        let val_pair = parse_recur(tokens, pos + 1, 0, context)
         let val = val_pair.0
         let val_next = val_pair.1
         let a = skip_semi(tokens, val_next)
-        let (rest, end) = parse_recur(tokens, a, 20)
+        let (rest, end) = parse_recur(tokens, a, 20, context)
         (EAssignOp(name, "%", val, rest), end)
       },
       _ => throw("invalid assignment target")
     },
     _ => {
-      let (rest, end) = parse_recur(tokens, pos, 20)
+      let (rest, end) = parse_recur(tokens, pos, 20, context)
       if end <= pos {
         throw("internal parser error: block continuation did not advance")
       } else {
@@ -451,17 +455,17 @@ fn parse_block_after_expr(tokens: Array[Token], pos: Int, e: Expr, parse_recur: 
   }
 }
 
-fn parse_block_value_body(tokens: Array[Token], eq: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Expr, Int, Int) with Exception {
-  let val_pair = parse_recur(tokens, eq, 0)
+fn parse_block_value_body(tokens: Array[Token], eq: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Expr, Int, Int) with Exception {
+  let val_pair = parse_recur(tokens, eq, 0, context)
   let val = val_pair.0
   let val_next = val_pair.1
   let a = skip_semi(tokens, val_next)
-  let (body, end) = parse_recur(tokens, a, 20)
+  let (body, end) = parse_recur(tokens, a, 20, context)
   (val, body, end, a)
 }
 
-fn parse_block_value_only(tokens: Array[Token], value_pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
-  let val_pair = parse_recur(tokens, value_pos, 0)
+fn parse_block_value_only(tokens: Array[Token], value_pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
+  let val_pair = parse_recur(tokens, value_pos, 0, context)
   (val_pair.0, skip_semi(tokens, val_pair.1))
 }
 
@@ -644,11 +648,11 @@ fn expr_always_exits_guard(e: Expr) -> Bool {
 /// pattern's bindings scope over the REST of the block, and the else arm
 /// becomes the fallthrough. Scrutinee is evaluated exactly once (it is bound
 /// into the match's discriminant position, not re-parsed per arm).
-fn parse_guard_stmt(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Pat, Expr, Expr, Int) with Exception {
+fn parse_guard_stmt(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Pat, Expr, Expr, Int) with Exception {
   // Parse the scrutinee with the no-is variant, exactly as `if` does (mode
   // 21): otherwise a trailing `is pattern` collapses into a Bool match instead
   // of landing in the guard's pattern slot.
-  let (scrut, sn) = parse_infix_no_is(tokens, starts, pos, 0, pos, parse_recur)
+  let (scrut, sn) = parse_infix_no_is_with_binder_context(tokens, starts, pos, 0, pos, parse_recur, context)
   let after_is = match peek(tokens, sn) {
     TIs => sn + 1,
     TIdent(kw) => if kw == "is" {
@@ -664,7 +668,7 @@ fn parse_guard_stmt(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
     _ => throw("guard: expected `else { .. }` after the pattern (#1283)")
   }
   let br = expect_tk(tokens, else_pos, "{")
-  let (alt, end) = parse_recur(tokens, br, 20)
+  let (alt, end) = parse_recur(tokens, br, 20, context)
   if expr_always_exits_guard(alt) {
     (pat, scrut, alt, end)
   } else {
@@ -693,7 +697,7 @@ fn push_pattern_let_step(tokens: Array[Token], steps: ArrayBuilder[BlockStep], p
   after
 }
 
-fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   let steps = ArrayBuilder::new()
   let mut p = pos
   let mut end_pos = pos
@@ -760,7 +764,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                 }
               }
               let eq = expect_tk(tokens, eq_pos_r, "=")
-              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur)
+              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
               if next_pos <= eq {
                 throw("internal parser error: block let-rec parser did not advance")
               } else {
@@ -796,7 +800,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                 _ => (None, next + 2)
               }
               let eq = expect_tk(tokens, eq_pos_m, "=")
-              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur)
+              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
               if next_pos <= eq {
                 throw("internal parser error: block let-mut parser did not advance")
               } else {
@@ -816,7 +820,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
           TStar => match peek(tokens, next + 1) {
             TIdent(name) => {
               let eq = expect_tk(tokens, next + 2, "=")
-              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur)
+              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
               if next_pos <= eq {
                 throw("internal parser error: block let* parser did not advance")
               } else {
@@ -849,13 +853,13 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             if next_is_struct_destr {
               let (pat, pn) = parse_pattern(tokens, next)
               let eq = expect_tk(tokens, pn, "=")
-              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur)
+              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
               ArrayBuilder::push(steps, StepStructDestr(pat, val))
               p = next_pos
             } else if next_is_record_destr {
               let (pat, pn) = parse_pattern(tokens, next)
               let eq = expect_tk(tokens, pn, "=")
-              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur)
+              let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
               ArrayBuilder::push(steps, StepRecordDestr(pat, val))
               p = next_pos
             } else {
@@ -863,7 +867,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                 TLParen => {
                   let (pat, pn) = parse_pattern(tokens, next)
                   let eq = expect_tk(tokens, pn, "=")
-                  let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur)
+                  let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
                   if next_pos <= eq {
                     throw("internal parser error: block let-ctor-pat parser did not advance")
                   } else {
@@ -891,7 +895,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                     }
                   }
                   let eq = expect_tk(tokens, eq_pos, "=")
-                  let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur)
+                  let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
                   if next_pos <= eq {
                     throw("internal parser error: block let parser did not advance")
                   } else {
@@ -921,7 +925,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
           TLParen => {
             let (pat, pn) = parse_pattern(tokens, next)
             let eq = expect_tk(tokens, pn, "=")
-            let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur)
+            let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
             if next_pos <= eq {
               throw("internal parser error: block let-pat parser did not advance")
             } else {
@@ -937,7 +941,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
       // same shape the retired let-else used, now with a divergence
       // requirement on the else arm that makes the binding unconditional.
       TGuard => {
-        let (gpat, gscrut, galt, gnext) = parse_guard_stmt(tokens, starts, p + 1, parse_recur)
+        let (gpat, gscrut, galt, gnext) = parse_guard_stmt(tokens, starts, p + 1, parse_recur, context)
         ArrayBuilder::push(steps, StepPatternElse(gpat, gscrut, galt))
         // A guard is a statement, so consume the separator the lexer's ASI
         // inserts after the else block's `}` — without this, the next
@@ -945,7 +949,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
         p = skip_semi(tokens, gnext)
       },
       _ => {
-        let (e, next) = parse_recur(tokens, p, 0)
+        let (e, next) = parse_recur(tokens, p, 0, context)
         if next <= p {
           throw("internal parser error: block expr parser did not advance")
         } else {
@@ -961,12 +965,12 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             },
             TEq => match e {
               EIdent(name, _) => {
-                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur)
+                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur, context)
                 ArrayBuilder::push(steps, StepAssign(name, val))
                 p = next_pos
               },
               EDot(obj, field, _, _) => {
-                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur)
+                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur, context)
                 let set_args = empty_exprs()
                 Array::push(set_args, obj)
                 Array::push(set_args, EString(field))
@@ -982,7 +986,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                   _ => false
                 }
                 if s_is_index && Array::length(sidx_args) == 2 {
-                  let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur)
+                  let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur, context)
                   let set_args = empty_exprs()
                   Array::push(set_args, Array::get(sidx_args, 0))
                   Array::push(set_args, Array::get(sidx_args, 1))
@@ -997,7 +1001,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             },
             TPlusEq => match e {
               EIdent(name, _) => {
-                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur)
+                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur, context)
                 ArrayBuilder::push(steps, StepAssignOp(name, "+", val))
                 p = next_pos
               },
@@ -1005,7 +1009,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             },
             TMinusEq => match e {
               EIdent(name, _) => {
-                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur)
+                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur, context)
                 ArrayBuilder::push(steps, StepAssignOp(name, "-", val))
                 p = next_pos
               },
@@ -1013,7 +1017,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             },
             TStarEq => match e {
               EIdent(name, _) => {
-                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur)
+                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur, context)
                 ArrayBuilder::push(steps, StepAssignOp(name, "*", val))
                 p = next_pos
               },
@@ -1021,7 +1025,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             },
             TSlashEq => match e {
               EIdent(name, _) => {
-                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur)
+                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur, context)
                 ArrayBuilder::push(steps, StepAssignOp(name, "/", val))
                 p = next_pos
               },
@@ -1029,7 +1033,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             },
             TPercentEq => match e {
               EIdent(name, _) => {
-                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur)
+                let (val, next_pos) = parse_block_value_only(tokens, next + 1, parse_recur, context)
                 ArrayBuilder::push(steps, StepAssignOp(name, "%", val))
                 p = next_pos
               },
@@ -1059,13 +1063,13 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
 // (see classify_sync_for_loop in desugar_trait_dict.vibe), and `await` in
 // that position is an ordinary binding name again.
 
-export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int, mode: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, mode: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   if mode == 20 {
-    parse_impl_block(tokens, starts, pos, parse_recur)
+    parse_impl_block(tokens, starts, pos, parse_recur, context)
   } else if mode == 21 {
     // Parse cond with the no-is variant so a trailing `is pattern` belongs
     // to the if-cond pattern slot rather than collapsing into a Bool match.
-    let (cond, cn) = parse_infix_no_is(tokens, starts, pos, 0, pos, parse_recur)
+    let (cond, cn) = parse_infix_no_is_with_binder_context(tokens, starts, pos, 0, pos, parse_recur, context)
     let mut is_mode = false
     let mut is_pat_val = PWild
     let mut brace_pos = cn
@@ -1085,12 +1089,12 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
       _ => ()
     }
     let br = expect_tk(tokens, brace_pos, "{")
-    let (then_e, tn) = parse_recur(tokens, br, 20)
+    let (then_e, tn) = parse_recur(tokens, br, 20, context)
     let (else_e, end_pos) = match peek(tokens, tn) {
       TElse => match peek(tokens, tn + 1) {
-        TIf => parse_recur(tokens, tn + 2, 21),
-        TLBrace => parse_recur(tokens, tn + 2, 20),
-        _ => parse_recur(tokens, tn + 1, 0)
+        TIf => parse_recur(tokens, tn + 2, 21, context),
+        TLBrace => parse_recur(tokens, tn + 2, 20, context),
+        _ => parse_recur(tokens, tn + 1, 0, context)
       },
       _ => (EUnit, tn)
     }
@@ -1103,7 +1107,7 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
       (EIf(cond, then_e, else_e), end_pos)
     }
   } else if mode == 22 {
-    let (scrutinee, sn) = parse_recur(tokens, pos, 0)
+    let (scrutinee, sn) = parse_recur(tokens, pos, 0, context)
     let br = expect_tk(tokens, sn, "{")
     match peek(tokens, br) {
       TRBrace => (EMatch(scrutinee, empty_arms()), br + 1),
@@ -1117,7 +1121,7 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
         let hg = [
           false
         ]
-        let endpos = collect_match_arms(tokens, starts, br, ab, hg, parse_recur)
+        let endpos = collect_match_arms(tokens, starts, br, ab, hg, parse_recur, context)
         let arms3 = ArrayBuilder::freeze(ab)
         if Array::get(hg, 0) {
           let final_arms = desugar_guarded(arms3, 0, EIdent("__mg", 0 - 1))
@@ -1135,13 +1139,13 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
       }
     }
   } else if mode == 23 {
-    let (cond, cn) = parse_recur(tokens, pos, 0)
+    let (cond, cn) = parse_recur(tokens, pos, 0, context)
     let br = expect_tk(tokens, cn, "{")
-    let (body, end) = parse_recur(tokens, br, 20)
+    let (body, end) = parse_recur(tokens, br, 20, context)
     (EWhile(cond, body), end)
   } else if mode == 24 {
     let br = expect_tk(tokens, pos, "{")
-    let (body, bn) = parse_recur(tokens, br, 20)
+    let (body, bn) = parse_recur(tokens, br, 20, context)
     let wp = expect_tk(tokens, bn, "with")
     // ADR-0085 (#1344): the handled effect may be a generic INSTANTIATION
     // (`handle { .. } with Exception[IoError] { Throw(e) => .. }`), so the
@@ -1174,9 +1178,9 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
       TRBrace => throw(String::concat("handler for `", String::concat(effect_name, "` must contain at least one arm"))),
       _ => {
         let b = ArrayBuilder::new()
-        let (arm, next) = parse_handle_arm(tokens, starts, hb, effect_name, parse_recur)
+        let (arm, next) = parse_handle_arm(tokens, starts, hb, effect_name, parse_recur, context)
         ArrayBuilder::push(b, arm)
-        parse_handle_rest(tokens, starts, next, body, effect_name, b, parse_recur)
+        parse_handle_rest(tokens, starts, next, body, effect_name, b, parse_recur, context)
       }
     }
   } else if mode == 25 {
@@ -1190,10 +1194,10 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
         TComma => match peek(tokens, start + 2) {
           TIdent(second_name) => {
             let ip = expect_tk(tokens, start + 3, "in")
-            match parse_recur(tokens, ip, 0) {
+            match parse_recur(tokens, ip, 0, context) {
               (iterable, after_iter) => {
                 let bb = expect_tk(tokens, after_iter, "{")
-                let (body, end) = parse_recur(tokens, bb, 20)
+                let (body, end) = parse_recur(tokens, bb, 20, context)
                 (EForIn(second_name, Some(first_name), iterable, body), end)
               },
               _ => throw("unreachable: parse_recur for for-in")
@@ -1203,10 +1207,10 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
         },
         _ => {
           let ip = expect_tk(tokens, start + 1, "in")
-          match parse_recur(tokens, ip, 0) {
+          match parse_recur(tokens, ip, 0, context) {
             (iterable, after_iter) => {
               let bb = expect_tk(tokens, after_iter, "{")
-              let (body, end) = parse_recur(tokens, bb, 20)
+              let (body, end) = parse_recur(tokens, bb, 20, context)
               (EForIn(first_name, None, iterable, body), end)
             },
             _ => throw("unreachable: parse_recur for for-in")
@@ -1230,7 +1234,7 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
       _ => throw("expected a binder name after 'taskgroup {'")
     }
     let arrow = expect_tk(tokens, gn, "=>")
-    let (body, bn) = parse_recur(tokens, arrow, 0)
+    let (body, bn) = parse_recur(tokens, arrow, 0, context)
     let close = expect_tk(tokens, bn, "}")
     let tparams = Array::slice([
       ""
@@ -1260,7 +1264,7 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
     // Mode 20 parses a full statement block (let/expr sequence) and
     // consumes the closing brace -- region bodies are blocks, not single
     // expressions.
-    let (body, close) = parse_recur(tokens, br, 20)
+    let (body, close) = parse_recur(tokens, br, 20, context)
     let tparams = Array::slice([
       ""
     ], 0, 0)
@@ -1277,4 +1281,9 @@ export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int
     let actual = tk_name(peek(tokens, pos))
     throw("internal parser error: unknown parse mode \{mode} at #\{pos} token=\{actual}")
   }
+}
+
+export fn parse_impl_dispatch(tokens: Array[Token], starts: Array[Int], pos: Int, mode: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+  let adapted = (rtoks, rpos, rmode, _context) -> parse_recur(rtoks, rpos, rmode)
+  parse_impl_dispatch_with_binder_context(tokens, starts, pos, mode, adapted, None)
 }

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -23,6 +23,10 @@ import ./token.vibe {
   Token
 }
 
+import ./parser_binder_context.vibe {
+  ParserBinderContext
+}
+
 import ./lexer.vibe {
   lex_with_offsets
 }
@@ -170,7 +174,7 @@ fn remap_frag_off(off: Int, outer_starts: Array[Int], frag_starts: Array[Int], f
 /// fragment base), so identifiers referenced inside `\{...}` carry their real
 /// file position for any fragment shape (leading spaces, multi-token
 /// expressions), not just a single token at the fragment start.
-fn build_interp_expr(parts: Array[String], offsets: Array[Int], outer_starts: Array[Int], parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> Expr with Exception {
+fn build_interp_expr(parts: Array[String], offsets: Array[Int], outer_starts: Array[Int], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> Expr with Exception {
   let concat_expr: (Expr, Expr) -> Expr = (a, b) -> {
     ECall(EIdent("String::concat", -1), [
       a,
@@ -197,7 +201,7 @@ fn build_interp_expr(parts: Array[String], offsets: Array[Int], outer_starts: Ar
       }
     } else {
       let (ftoks, fstarts, _fends) = lex_with_offsets(part)
-      let (pe0, _) = parse_recur(ftoks, 0, 0)
+      let (pe0, _) = parse_recur(ftoks, 0, 0, context)
       let frag_off = if i < Array::length(offsets) {
         Array::get(offsets, i)
       } else {
@@ -337,7 +341,7 @@ fn desugar_loop_body(expr: Expr, param_names: Array[String]) -> Expr with Except
   }
 }
 
-fn parse_loop_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_loop_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos + 1) {
     TLParen => {
       let param_names_b = ArrayBuilder::new()
@@ -352,7 +356,7 @@ fn parse_loop_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_
           },
           TIdent(name) => {
             let eq_pos = expect_tk(tokens, cur + 1, "=")
-            let (init, next_pos) = parse_recur(tokens, eq_pos, 0)
+            let (init, next_pos) = parse_recur(tokens, eq_pos, 0, context)
             ArrayBuilder::push(param_names_b, name)
             ArrayBuilder::push(param_inits_b, init)
             match peek(tokens, next_pos) {
@@ -370,7 +374,7 @@ fn parse_loop_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_
         }
       }
       let body_pos = expect_tk(tokens, cur, "{")
-      let (body, end_pos) = parse_recur(tokens, body_pos, 20)
+      let (body, end_pos) = parse_recur(tokens, body_pos, 20, context)
       // Desugar ELoop into ELetMut + EWhile
       let pnames = ArrayBuilder::freeze(param_names_b)
       let pinits = ArrayBuilder::freeze(param_inits_b)
@@ -387,19 +391,19 @@ fn parse_loop_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_
     },
     _ => {
       let body_pos = expect_tk(tokens, pos + 1, "{")
-      let (body, end_pos) = parse_recur(tokens, body_pos, 20)
+      let (body, end_pos) = parse_recur(tokens, body_pos, 20, context)
       (EWhile(EBool(true), body), end_pos)
     }
   }
 }
 
-fn parse_break_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_break_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos + 1) {
     TRBrace => (EBreak(None), pos + 1),
     TSemicolon => (EBreak(None), pos + 1),
     TEof => (EBreak(None), pos + 1),
     _ => {
-      let (expr, next_pos) = parse_recur(tokens, pos + 1, 0)
+      let (expr, next_pos) = parse_recur(tokens, pos + 1, 0, context)
       (EBreak(Some(expr)), next_pos)
     }
   }
@@ -426,9 +430,9 @@ fn parse_break_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse
 /// the printer's re-sugar is the one exact comparison and it now matches both
 /// (it cannot import the predicate -- @vibe/parser must not depend on the
 /// compiler package).
-fn parse_throw_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_throw_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   let open_pos = expect_tk(tokens, pos + 1, "(")
-  let (expr, next_pos) = parse_recur(tokens, open_pos, 0)
+  let (expr, next_pos) = parse_recur(tokens, open_pos, 0, context)
   let close_pos = expect_tk(tokens, next_pos, ")")
   let off = offset_at(starts, pos)
   (ECall(EIdent("perform", off), [
@@ -438,19 +442,19 @@ fn parse_throw_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse
   ], off), close_pos)
 }
 
-fn parse_return_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_return_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos + 1) {
     TRBrace => (EReturn(EUnit), pos + 1),
     TSemicolon => (EReturn(EUnit), pos + 1),
     TEof => (EReturn(EUnit), pos + 1),
     _ => {
-      let (expr, next_pos) = parse_recur(tokens, pos + 1, 0)
+      let (expr, next_pos) = parse_recur(tokens, pos + 1, 0, context)
       (EReturn(expr), next_pos)
     }
   }
 }
 
-fn parse_perform_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_perform_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos + 1) {
     TRParen => (EIdent("perform", -1), pos + 1),
     TRBracket => (EIdent("perform", -1), pos + 1),
@@ -466,7 +470,7 @@ fn parse_perform_primary(tokens: Array[Token], starts: Array[Int], pos: Int, par
       // `perform (A::Op + perform B::Op)` (#550). min_prec 10 is above the
       // highest binop precedence (9, see binop_prec), so parse_infix_loop
       // stops before consuming any operator.
-      let (arg, next_pos) = parse_recur(tokens, pos + 1, 10)
+      let (arg, next_pos) = parse_recur(tokens, pos + 1, 10, context)
       (ECall(EIdent("perform", -1), [
         arg
       ], offset_at(starts, pos)), next_pos)
@@ -474,21 +478,21 @@ fn parse_perform_primary(tokens: Array[Token], starts: Array[Int], pos: Int, par
   }
 }
 
-fn parse_array_elems_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[Expr], parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Array[Expr], Int) with Exception {
+fn parse_array_elems_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[Expr], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Array[Expr], Int) with Exception {
   match peek(tokens, pos) {
     TComma => {
       let next_pos = pos + 1
       match peek(tokens, next_pos) {
         TRBracket => (ArrayBuilder::freeze(b), next_pos),
         TDotDotDot => {
-          let (expr, end_pos) = parse_recur(tokens, next_pos + 1, 0)
+          let (expr, end_pos) = parse_recur(tokens, next_pos + 1, 0, context)
           ArrayBuilder::push(b, ESpread(expr))
-          parse_array_elems_rest(tokens, starts, end_pos, b, parse_recur)
+          parse_array_elems_rest(tokens, starts, end_pos, b, parse_recur, context)
         },
         _ => {
-          let (expr, end_pos) = parse_recur(tokens, next_pos, 0)
+          let (expr, end_pos) = parse_recur(tokens, next_pos, 0, context)
           ArrayBuilder::push(b, expr)
-          parse_array_elems_rest(tokens, starts, end_pos, b, parse_recur)
+          parse_array_elems_rest(tokens, starts, end_pos, b, parse_recur, context)
         }
       }
     },
@@ -496,29 +500,29 @@ fn parse_array_elems_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b:
   }
 }
 
-fn parse_array_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_array_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos + 1) {
     TRBracket => (EArray(empty_exprs()), pos + 2),
     TDotDotDot => {
       let b = ArrayBuilder::new()
-      let (first, next_pos) = parse_recur(tokens, pos + 2, 0)
+      let (first, next_pos) = parse_recur(tokens, pos + 2, 0, context)
       ArrayBuilder::push(b, ESpread(first))
-      let (items, end_pos) = parse_array_elems_rest(tokens, starts, next_pos, b, parse_recur)
+      let (items, end_pos) = parse_array_elems_rest(tokens, starts, next_pos, b, parse_recur, context)
       let close_pos = expect_tk(tokens, end_pos, "]")
       (EArray(items), close_pos)
     },
     _ => {
       let b = ArrayBuilder::new()
-      let (first, next_pos) = parse_recur(tokens, pos + 1, 0)
+      let (first, next_pos) = parse_recur(tokens, pos + 1, 0, context)
       ArrayBuilder::push(b, first)
-      let (items, end_pos) = parse_array_elems_rest(tokens, starts, next_pos, b, parse_recur)
+      let (items, end_pos) = parse_array_elems_rest(tokens, starts, next_pos, b, parse_recur, context)
       let close_pos = expect_tk(tokens, end_pos, "]")
       (EArray(items), close_pos)
     }
   }
 }
 
-fn parse_comma_exprs_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[Expr], parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Array[Expr], Int) with Exception {
+fn parse_comma_exprs_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[Expr], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Array[Expr], Int) with Exception {
   match peek(tokens, pos) {
     TComma => {
       // Allow a trailing comma before the closing `)` in tuples and call
@@ -526,9 +530,9 @@ fn parse_comma_exprs_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b:
       match peek(tokens, pos + 1) {
         TRParen => (ArrayBuilder::freeze(b), pos + 1),
         _ => {
-          let (e, next) = parse_recur(tokens, pos + 1, 0)
+          let (e, next) = parse_recur(tokens, pos + 1, 0, context)
           ArrayBuilder::push(b, e)
-          parse_comma_exprs_rest(tokens, starts, next, b, parse_recur)
+          parse_comma_exprs_rest(tokens, starts, next, b, parse_recur, context)
         }
       }
     },
@@ -536,16 +540,16 @@ fn parse_comma_exprs_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b:
   }
 }
 
-fn parse_continue_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_continue_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos + 1) {
     TLParen => {
       let b = ArrayBuilder::new()
       match peek(tokens, pos + 2) {
         TRParen => (EContinue(empty_exprs()), pos + 3),
         _ => {
-          let (first, next_pos) = parse_recur(tokens, pos + 2, 0)
+          let (first, next_pos) = parse_recur(tokens, pos + 2, 0, context)
           ArrayBuilder::push(b, first)
-          let (args, end_pos) = parse_comma_exprs_rest(tokens, starts, next_pos, b, parse_recur)
+          let (args, end_pos) = parse_comma_exprs_rest(tokens, starts, next_pos, b, parse_recur, context)
           let close_pos = expect_tk(tokens, end_pos, ")")
           (EContinue(args), close_pos)
         }
@@ -555,23 +559,23 @@ fn parse_continue_primary(tokens: Array[Token], starts: Array[Int], pos: Int, pa
   }
 }
 
-fn parse_control_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_control_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos) {
-    TLBrace => parse_recur(tokens, pos + 1, 20),
-    TIf => parse_recur(tokens, pos + 1, 21),
-    TMatch => parse_recur(tokens, pos + 1, 22),
-    THandle => parse_recur(tokens, pos + 1, 24),
-    TWhile => parse_recur(tokens, pos + 1, 23),
-    TFor => parse_recur(tokens, pos + 1, 25),
-    TTaskGroup => parse_recur(tokens, pos + 1, 26),
-    TRegion => parse_recur(tokens, pos + 1, 27),
-    TThrow => parse_throw_primary(tokens, starts, pos, parse_recur),
-    TBreak => parse_break_primary(tokens, starts, pos, parse_recur),
-    TContinue => parse_continue_primary(tokens, starts, pos, parse_recur),
+    TLBrace => parse_recur(tokens, pos + 1, 20, context),
+    TIf => parse_recur(tokens, pos + 1, 21, context),
+    TMatch => parse_recur(tokens, pos + 1, 22, context),
+    THandle => parse_recur(tokens, pos + 1, 24, context),
+    TWhile => parse_recur(tokens, pos + 1, 23, context),
+    TFor => parse_recur(tokens, pos + 1, 25, context),
+    TTaskGroup => parse_recur(tokens, pos + 1, 26, context),
+    TRegion => parse_recur(tokens, pos + 1, 27, context),
+    TThrow => parse_throw_primary(tokens, starts, pos, parse_recur, context),
+    TBreak => parse_break_primary(tokens, starts, pos, parse_recur, context),
+    TContinue => parse_continue_primary(tokens, starts, pos, parse_recur, context),
     TRaise => throw("'raise' is deprecated, use 'throw(expr)' instead"),
-    TReturn => parse_return_primary(tokens, starts, pos, parse_recur),
+    TReturn => parse_return_primary(tokens, starts, pos, parse_recur, context),
     TDo => throw("'do' is reserved; use 'while' or 'for' instead"),
-    TLoop => parse_loop_primary(tokens, starts, pos, parse_recur),
+    TLoop => parse_loop_primary(tokens, starts, pos, parse_recur, context),
     TYield => throw("'yield' is not supported"),
     TDeclare => throw("'declare' is not supported"),
     _ => {
@@ -593,7 +597,7 @@ fn parse_control_primary(tokens: Array[Token], starts: Array[Int], pos: Int, par
 /// `Name::{ left: left, right: right }` by matching a bare identifier field to
 /// an in-scope binding of the same name. Mirrors `parse_record_literal_fields`
 /// exactly so both literal forms stay in sync.
-fn parse_ctor_record_fields(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(String, Expr)], parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Array[(String, Expr)], Int) with Exception {
+fn parse_ctor_record_fields(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(String, Expr)], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Array[(String, Expr)], Int) with Exception {
   match peek(tokens, pos) {
     TRBrace => (ArrayBuilder::freeze(b), pos + 1),
     TIdent(fname) => {
@@ -602,12 +606,12 @@ fn parse_ctor_record_fields(tokens: Array[Token], starts: Array[Int], pos: Int, 
         TRBrace => (EIdent(fname, -1), pos + 1),
         _ => {
           let colon_pos = expect_tk(tokens, pos + 1, ":")
-          parse_recur(tokens, colon_pos, 0)
+          parse_recur(tokens, colon_pos, 0, context)
         }
       }
       ArrayBuilder::push(b, (fname, val))
       match peek(tokens, next_pos) {
-        TComma => parse_ctor_record_fields(tokens, starts, next_pos + 1, b, parse_recur),
+        TComma => parse_ctor_record_fields(tokens, starts, next_pos + 1, b, parse_recur, context),
         TRBrace => (ArrayBuilder::freeze(b), next_pos + 1),
         _ => throw("expected ',' or '}' in record literal")
       }
@@ -681,7 +685,7 @@ fn parse_generic_fn_type_params(tokens: Array[Token], pos: Int) -> (Array[String
   (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
 }
 
-fn parse_generic_fn_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_generic_fn_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   let (type_params, type_bounds, after_header) = parse_generic_fn_type_params(tokens, pos + 1)
   let params_pos = expect_tk(tokens, after_header, "(")
   let (params, after_params) = parse_param_list(tokens, params_pos)
@@ -700,11 +704,11 @@ fn parse_generic_fn_primary(tokens: Array[Token], starts: Array[Int], pos: Int, 
       let effect = effect_pair.0
       let effect_next = effect_pair.1
       let body_pos = expect_tk(tokens, effect_next, "{")
-      let (body, end_pos) = parse_recur(tokens, body_pos, 20)
+      let (body, end_pos) = parse_recur(tokens, body_pos, 20, context)
       (EFn(type_params, type_bounds, params, Some(ret_ty), effect, body), end_pos)
     },
     TLBrace => {
-      let (body, end_pos) = parse_recur(tokens, after_params + 1, 20)
+      let (body, end_pos) = parse_recur(tokens, after_params + 1, 20, context)
       (EFn(type_params, type_bounds, params, None, None, body), end_pos)
     },
     _ => throw("expected '->' or '{' after generic function params")
@@ -740,25 +744,25 @@ fn is_generic_fn_start(tokens: Array[Token], pos: Int) -> Bool {
   }
 }
 
-fn parse_bracket_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_bracket_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   if is_generic_fn_start(tokens, pos) {
-    parse_generic_fn_primary(tokens, starts, pos, parse_recur)
+    parse_generic_fn_primary(tokens, starts, pos, parse_recur, context)
   } else {
-    parse_array_primary(tokens, starts, pos, parse_recur)
+    parse_array_primary(tokens, starts, pos, parse_recur, context)
   }
 }
 
-fn parse_paren_tuple_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_paren_tuple_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos + 1) {
     TRParen => (EUnit, pos + 2),
     _ => {
-      let (first, next_pos) = parse_recur(tokens, pos + 1, 0)
+      let (first, next_pos) = parse_recur(tokens, pos + 1, 0, context)
       match peek(tokens, next_pos) {
         TRParen => (first, next_pos + 1),
         TComma => {
           let b = ArrayBuilder::new()
           ArrayBuilder::push(b, first)
-          let (items, end_pos) = parse_comma_exprs_rest(tokens, starts, next_pos, b, parse_recur)
+          let (items, end_pos) = parse_comma_exprs_rest(tokens, starts, next_pos, b, parse_recur, context)
           let close_pos = expect_tk(tokens, end_pos, ")")
           (ETuple(items), close_pos)
         },
@@ -768,7 +772,7 @@ fn parse_paren_tuple_primary(tokens: Array[Token], starts: Array[Int], pos: Int,
   }
 }
 
-fn parse_paren_lambda_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_paren_lambda_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   let (params, after_params) = parse_param_list(tokens, pos + 1)
   match peek(tokens, after_params) {
     TThinArrow => {
@@ -778,7 +782,7 @@ fn parse_paren_lambda_primary(tokens: Array[Token], starts: Array[Int], pos: Int
           let (ty, ty_pos) = parse_type_impl(tokens, after_arrow, 0)
           match peek(tokens, ty_pos) {
             TLBrace => {
-              let (body, end) = parse_recur(tokens, ty_pos + 1, 20)
+              let (body, end) = parse_recur(tokens, ty_pos + 1, 20, context)
               (EFn(_no_tp(), _no_tb(), params, Some(ty), None, body), end)
             },
             TWith => {
@@ -786,11 +790,11 @@ fn parse_paren_lambda_primary(tokens: Array[Token], starts: Array[Int], pos: Int
               let effect_name = effect_pair.0
               let effect_next = effect_pair.1
               let body_pos = expect_tk(tokens, effect_next, "{")
-              let (body, end) = parse_recur(tokens, body_pos, 20)
+              let (body, end) = parse_recur(tokens, body_pos, 20, context)
               (EFn(_no_tp(), _no_tb(), params, Some(ty), Some(effect_name), body), end)
             },
             _ => {
-              let (body, end) = parse_recur(tokens, after_arrow, 0)
+              let (body, end) = parse_recur(tokens, after_arrow, 0, context)
               (EFn(_no_tp(), _no_tb(), params, None, None, body), end)
             }
           }
@@ -815,7 +819,7 @@ fn parse_paren_lambda_primary(tokens: Array[Token], starts: Array[Int], pos: Int
               let (ty, ty_pos) = pair
               match peek(tokens, ty_pos) {
                 TLBrace => {
-                  let (body, end) = parse_recur(tokens, ty_pos + 1, 20)
+                  let (body, end) = parse_recur(tokens, ty_pos + 1, 20, context)
                   (EFn(_no_tp(), _no_tb(), params, Some(ty), None, body), end)
                 },
                 TWith => {
@@ -823,44 +827,44 @@ fn parse_paren_lambda_primary(tokens: Array[Token], starts: Array[Int], pos: Int
                   let effect_name = effect_pair.0
                   let effect_next = effect_pair.1
                   let body_pos = expect_tk(tokens, effect_next, "{")
-                  let (body, end) = parse_recur(tokens, body_pos, 20)
+                  let (body, end) = parse_recur(tokens, body_pos, 20, context)
                   (EFn(_no_tp(), _no_tb(), params, Some(ty), Some(effect_name), body), end)
                 },
                 _ => {
-                  let (body, end) = parse_recur(tokens, after_arrow, 0)
+                  let (body, end) = parse_recur(tokens, after_arrow, 0, context)
                   (EFn(_no_tp(), _no_tb(), params, None, None, body), end)
                 }
               }
             },
             None => {
-              let (body, end) = parse_recur(tokens, after_arrow, 0)
+              let (body, end) = parse_recur(tokens, after_arrow, 0, context)
               (EFn(_no_tp(), _no_tb(), params, None, None, body), end)
             }
           }
         },
         _ => {
-          let (body, end) = parse_recur(tokens, after_arrow, 0)
+          let (body, end) = parse_recur(tokens, after_arrow, 0, context)
           (EFn(_no_tp(), _no_tb(), params, None, None, body), end)
         }
       }
     },
     TLBrace => {
-      let (body, end) = parse_recur(tokens, after_params + 1, 20)
+      let (body, end) = parse_recur(tokens, after_params + 1, 20, context)
       (EFn(_no_tp(), _no_tb(), params, None, None, body), end)
     },
     _ => throw("expected '->' or '{' after fn params")
   }
 }
 
-fn parse_paren_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_paren_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   if is_lambda_start(tokens, pos + 1) {
-    parse_paren_lambda_primary(tokens, starts, pos, parse_recur)
+    parse_paren_lambda_primary(tokens, starts, pos, parse_recur, context)
   } else {
-    parse_paren_tuple_primary(tokens, starts, pos, parse_recur)
+    parse_paren_tuple_primary(tokens, starts, pos, parse_recur, context)
   }
 }
 
-fn parse_record_literal_fields(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(String, Expr)], parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Array[(String, Expr)], Int) with Exception {
+fn parse_record_literal_fields(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(String, Expr)], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Array[(String, Expr)], Int) with Exception {
   match peek(tokens, pos) {
     TRBrace => (ArrayBuilder::freeze(b), pos + 1),
     TIdent(fname) => {
@@ -869,12 +873,12 @@ fn parse_record_literal_fields(tokens: Array[Token], starts: Array[Int], pos: In
         TRBrace => (EIdent(fname, -1), pos + 1),
         _ => {
           let colon_pos = expect_tk(tokens, pos + 1, ":")
-          parse_recur(tokens, colon_pos, 0)
+          parse_recur(tokens, colon_pos, 0, context)
         }
       }
       ArrayBuilder::push(b, (fname, val))
       match peek(tokens, next_pos) {
-        TComma => parse_record_literal_fields(tokens, starts, next_pos + 1, b, parse_recur),
+        TComma => parse_record_literal_fields(tokens, starts, next_pos + 1, b, parse_recur, context),
         TRBrace => (ArrayBuilder::freeze(b), next_pos + 1),
         _ => throw("expected ',' or '}' in record literal")
       }
@@ -954,18 +958,18 @@ fn parse_struct_ctor_targs(tokens: Array[Token], pos: Int, name: String) -> (Arr
   }
 }
 
-fn parse_ident_primary(tokens: Array[Token], starts: Array[Int], pos: Int, name: String, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+fn parse_ident_primary(tokens: Array[Token], starts: Array[Int], pos: Int, name: String, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   if name == "true" {
     (EBool(true), pos + 1)
   } else if name == "false" {
     (EBool(false), pos + 1)
   } else if name == "perform" {
-    parse_perform_primary(tokens, starts, pos, parse_recur)
+    parse_perform_primary(tokens, starts, pos, parse_recur, context)
   } else if name == "record" {
     match peek(tokens, pos + 1) {
       TLBrace => {
         let b = ArrayBuilder::new()
-        let (fields, end_pos) = parse_record_literal_fields(tokens, starts, pos + 2, b, parse_recur)
+        let (fields, end_pos) = parse_record_literal_fields(tokens, starts, pos + 2, b, parse_recur, context)
         (ERecord("", fields, empty_type_exprs()), end_pos)
       },
       _ => (EIdent(name, offset_at(starts, pos)), pos + 1)
@@ -985,7 +989,7 @@ fn parse_ident_primary(tokens: Array[Token], starts: Array[Int], pos: Int, name:
         TIdent(member) => (EIdent(String::concat(name, String::concat("::", member)), offset_at(starts, pos)), pos + 3),
         TLBrace => {
           let b = ArrayBuilder::new()
-          let (fields, end_pos) = parse_ctor_record_fields(tokens, starts, pos + 3, b, parse_recur)
+          let (fields, end_pos) = parse_ctor_record_fields(tokens, starts, pos + 3, b, parse_recur, context)
           (ERecord(name, fields, empty_type_exprs()), end_pos)
         },
         _ => (EIdent(name, offset_at(starts, pos)), pos + 1)
@@ -1002,7 +1006,7 @@ fn parse_ident_primary(tokens: Array[Token], starts: Array[Int], pos: Int, name:
         let dc_pos = expect_tk(tokens, after_targs, "::")
         let brace_pos = expect_tk(tokens, dc_pos, "{")
         let b = ArrayBuilder::new()
-        let (fields, end_pos) = parse_ctor_record_fields(tokens, starts, brace_pos, b, parse_recur)
+        let (fields, end_pos) = parse_ctor_record_fields(tokens, starts, brace_pos, b, parse_recur, context)
         (ERecord(name, fields, targs), end_pos)
       } else {
         (EIdent(name, offset_at(starts, pos)), pos + 1)
@@ -1012,15 +1016,20 @@ fn parse_ident_primary(tokens: Array[Token], starts: Array[Int], pos: Int, name:
   }
 }
 
-export fn parse_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+export fn parse_primary_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   match peek(tokens, pos) {
     TInt(n) => (EInt(n), pos + 1),
     TFloat(n) => (EFloat(n), pos + 1),
     TString(s) => (EString(s), pos + 1),
-    TStringInterp(parts, offs) => (build_interp_expr(parts, offs, starts, parse_recur), pos + 1),
-    TIdent(name) => parse_ident_primary(tokens, starts, pos, name, parse_recur),
-    TLParen => parse_paren_primary(tokens, starts, pos, parse_recur),
-    TLBracket => parse_bracket_primary(tokens, starts, pos, parse_recur),
-    _ => parse_control_primary(tokens, starts, pos, parse_recur)
+    TStringInterp(parts, offs) => (build_interp_expr(parts, offs, starts, parse_recur, context), pos + 1),
+    TIdent(name) => parse_ident_primary(tokens, starts, pos, name, parse_recur, context),
+    TLParen => parse_paren_primary(tokens, starts, pos, parse_recur, context),
+    TLBracket => parse_bracket_primary(tokens, starts, pos, parse_recur, context),
+    _ => parse_control_primary(tokens, starts, pos, parse_recur, context)
   }
+}
+
+export fn parse_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int) -> (Expr, Int) with Exception) -> (Expr, Int) with Exception {
+  let adapted = (rtoks, rpos, rmode, _context) -> parse_recur(rtoks, rpos, rmode)
+  parse_primary_with_binder_context(tokens, starts, pos, adapted, None)
 }


### PR DESCRIPTION
## Summary
- add invocation-local parser binder context plumbing with explicit four-argument recursion through primary/core/dispatch
- preserve existing high-level parser behavior via `None` wrappers
- expose current cross-file helpers as explicitly untrusted plumbing required by package conformance
- add parity, invocation-isolation, low-level `None`, and externally forged-context tests

## Safety boundary
- context carries no authority rows and cannot authorize future artifacts
- future authority must come from a high-level atomic parse aggregate with exhaustive validation
- no AST, checker, runtime, cache, or production reuse changes

## Validation
- unit tests: 631/631
- stage2 == stage3
- formatter and generated freshness
- diff check

Prerequisite for #1548.