### PR TITLE
fix(checker): respect lexical effect shadows

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1134,6 +1134,13 @@ fn main with Stdout {
 ```
 
 継続呼び出しは `resume(v)` が canonical (one-shot tail-resumptive, ADR-0050)。
+
+Effect row の呼び出し解決も通常の値解決と同じ lexical scope に従う。局所
+closure・関数 parameter・pattern/loop binder が top-level `fn` と同名なら、
+局所 binding が優先される。したがって、純粋な局所 `take` が同名の
+`fn take(..) with Ask` を隠している間、その呼び出しに `Ask` は計上されない。
+局所 scope を抜けると top-level の row が再び有効になる。
+
 > **evidence-passing 実装 (#817, ADR-0076 追記34 V2 で replay 全廃)**:
 > handler は evidence dict への直接呼び出し (tail-resumptive) か
 > suspend CPS (first-class resume) にコンパイルされ、handle body は

--- a/fixtures/effect_checker_local_shadow_test.vibe
+++ b/fixtures/effect_checker_local_shadow_test.vibe
@@ -1,0 +1,72 @@
+// #1723: effect-row inference must resolve a call against the lexical binding
+// before consulting the module-level function table.
+
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn take(f: () -> Int with Ask) -> Int with Ask {
+  f()
+}
+
+fn pure_shadow() -> Int {
+  let take = (f: () -> Int) -> Int {
+    f() + 1
+  }
+  take(() -> Int {
+    7
+  })
+}
+
+fn nested_shadow() -> Int {
+  let take = (f: () -> Int) -> Int {
+    let take = (g: () -> Int) -> Int {
+      g() + 1
+    }
+    take(f)
+  }
+  take(() -> Int {
+    6
+  })
+}
+
+fn parameter_shadow(take: (() -> Int) -> Int) -> Int {
+  take(() -> Int {
+    7
+  })
+}
+
+fn apply_row(f: () -> Int with e) -> Int with e {
+  f()
+}
+
+fn asker() -> Int with Ask {
+  perform Ask::Get(1)
+}
+
+// The shadowed name is an ARGUMENT to a row-polymorphic callee. Resolving its
+// row must use the same local-first order as resolving the callee name.
+fn rowvar_argument_shadow() -> Int {
+  let asker = () -> Int {
+    8
+  }
+  apply_row(asker)
+}
+
+test "local function shadows top-level effect row" {
+  assert_eq(pure_shadow(), 8)
+}
+
+test "nested lexical shadows remain local" {
+  assert_eq(nested_shadow(), 7)
+}
+
+test "a callback parameter shadows a top-level function row" {
+  assert_eq(parameter_shadow((f: () -> Int) -> Int {
+    f() + 1
+  }), 8)
+}
+
+test "a row-variable argument resolves its local shadow first" {
+  assert_eq(rowvar_argument_shadow(), 8)
+}

--- a/fixtures/effect_scps_param_shadow_test.vibe
+++ b/fixtures/effect_scps_param_shadow_test.vibe
@@ -1,0 +1,34 @@
+// #1723: suspend-CPS argument convention lookup must not apply a top-level
+// function's row-carrying parameter signature to a same-named local closure.
+
+effect Yield {
+  Y(Int) -> Int
+}
+
+fn take(f: () -> Int with Yield) -> Int with Yield {
+  f()
+}
+
+fn probe() -> Int {
+  let take = (f: () -> Int) -> Int {
+    f() + 1
+  }
+  take(() -> Int {
+    7
+  })
+}
+
+fn trigger() -> Int {
+  handle {
+    perform Yield::Y(0)
+  } with Yield {
+    Y(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+
+let _start = () -> Int {
+  probe() + trigger()
+}

--- a/fixtures/effect_scps_top_level_alias_test.vibe
+++ b/fixtures/effect_scps_top_level_alias_test.vibe
@@ -1,0 +1,25 @@
+// #1723 review: an immutable local alias of a known top-level function keeps
+// that function's suspend-CPS argument convention. Treating every local as
+// opaque leaves this pure literal unwrapped and returns a step pointer.
+
+effect Yield {
+  Y(Int) -> Int
+}
+
+fn run_with(f: () -> Int with Yield) -> Int {
+  handle {
+    f()
+  } with Yield {
+    Y(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+
+let _start = () -> Int {
+  let run_with = run_with
+  run_with(() -> Int {
+    7
+  })
+}

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1730,7 +1730,10 @@ fn resolve_row_var_instantiation(row_var: String, callee_param_effs: Array[Array
             // nothing either table knows (an import this pass cannot see) is a
             // bail-out, not an empty row -- treating "unknown" as "pure" would
             // silently authorize the very leak this is closing.
-            match lookup_fn_effs(fn_names, fn_effs, argname) {
+            // #1723: argument names obey the same lexical precedence as the
+            // callee itself. An explicit empty overlay entry is a pure local
+            // shadow, not permission to consult a same-named top-level fn.
+            match lookup_fn_effs(ov_names, ov_effs, argname) {
               Some(argeffs) => {
                 let mut k = 0
                 while k < Array::length(argeffs) {
@@ -1743,7 +1746,7 @@ fn resolve_row_var_instantiation(row_var: String, callee_param_effs: Array[Array
                   k = k + 1
                 }
               },
-              None => match lookup_fn_effs(ov_names, ov_effs, argname) {
+              None => match lookup_fn_effs(fn_names, fn_effs, argname) {
                 Some(argeffs2) => {
                   let mut k2 = 0
                   while k2 < Array::length(argeffs2) {
@@ -1843,6 +1846,61 @@ fn shadow_overlay(names: Array[String], effs: Array[Array[String]], name: String
   (out_names, out_effs)
 }
 
+/// Add lexical bindings that carry no effect row. These empty entries are
+/// semantically meaningful: they stop lookup from falling through to a
+/// same-named top-level function (#1723).
+fn effect_name_exists(names: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) && !found {
+    found = Array::get(names, i) == name
+    i = i + 1
+  }
+  found
+}
+
+fn overlay_bind_empty(names: Array[String], effs: Array[Array[String]], name: String, fn_names: Array[String]) -> (Array[String], Array[Array[String]]) {
+  let (sn, se) = shadow_overlay(names, effs, name)
+  // Most locals cannot fall through to a top-level function, so retaining an
+  // empty marker for every binding only lengthens every descendant snapshot.
+  // The marker is needed exactly when the fallback table contains this name.
+  if !effect_name_exists(fn_names, name) {
+    return (sn, se)
+  }
+  let out_names = [
+    name
+  ]
+  let out_effs = [
+    no_str_labels()
+  ]
+  let mut i = 0
+  while i < Array::length(sn) {
+    Array::push(out_names, Array::get(sn, i))
+    Array::push(out_effs, Array::get(se, i))
+    i = i + 1
+  }
+  (out_names, out_effs)
+}
+
+fn overlay_bind_empty_names(names: Array[String], effs: Array[Array[String]], bound: Array[String], fn_names: Array[String]) -> (Array[String], Array[Array[String]]) {
+  let mut cur_names = names
+  let mut cur_effs = effs
+  let mut i = 0
+  while i < Array::length(bound) {
+    let next = overlay_bind_empty(cur_names, cur_effs, Array::get(bound, i), fn_names)
+    cur_names = next.0
+    cur_effs = next.1
+    i = i + 1
+  }
+  (cur_names, cur_effs)
+}
+
+fn overlay_bind_empty_pat(names: Array[String], effs: Array[Array[String]], pat: Pat, fn_names: Array[String]) -> (Array[String], Array[Array[String]]) {
+  let bound = array_empty()
+  collect_pat_binds_into(pat, bound)
+  overlay_bind_empty_names(names, effs, bound, fn_names)
+}
+
 /// #885 (split off from #838, originally scoped out at #626): a function-typed
 /// PARAMETER (a callback, e.g. `f: (T) -> T with e`) is a call-graph leaf
 /// exactly like a named top-level function, but `fn_names`/`fn_effs` above is
@@ -1934,43 +1992,46 @@ fn overlay_bind_local(names: Array[String], effs: Array[Array[String]], name: St
   // rebinds to the OUTER `f`, so the lookup must see the entry the shadow is
   // about to remove.
   let labels = local_fn_overlay_labels(val, names, effs, fn_names, fn_effs)
-  if Array::length(labels) == 0 {
-    shadowed
-  } else {
-    let out_names = [
-      name
-    ]
-    let out_effs = [
-      labels
-    ]
-    let (sn, se) = shadowed
-    let mut i = 0
-    while i < Array::length(sn) {
-      Array::push(out_names, Array::get(sn, i))
-      Array::push(out_effs, Array::get(se, i))
-      i = i + 1
-    }
-    (out_names, out_effs)
+  // #1723: an empty row is still a lexical binding. Keeping an explicit
+  // empty entry is what distinguishes "a pure local shadows this name" from
+  // "no local binding; consult the top-level function table".
+  if Array::length(labels) == 0 && !effect_name_exists(fn_names, name) {
+    return shadowed
   }
+  let out_names = [
+    name
+  ]
+  let out_effs = [
+    labels
+  ]
+  let (sn, se) = shadowed
+  let mut i = 0
+  while i < Array::length(sn) {
+    Array::push(out_names, Array::get(sn, i))
+    Array::push(out_effs, Array::get(se, i))
+    i = i + 1
+  }
+  (out_names, out_effs)
 }
 
-fn build_param_overlay(params: Array[(String, Option[TypeExpr])]) -> (Array[String], Array[Array[String]]) {
+fn build_param_overlay(params: Array[(String, Option[TypeExpr])], fn_names: Array[String]) -> (Array[String], Array[Array[String]]) {
   let names = array_empty()
   let effs = array_empty()
   let mut i = 0
   while i < Array::length(params) {
     let (pname, ptype) = Array::get(params, i)
-    match ptype {
-      Some(TyFn(_, _, eff)) => {
-        let labels = effect_row_labels(effect_row_parse(eff))
-        if Array::length(labels) > 0 {
-          Array::push(names, pname)
-          Array::push(effs, labels)
-        } else {
-          ()
-        }
-      },
-      _ => ()
+    let labels = match ptype {
+      Some(TyFn(_, _, eff)) => effect_row_labels(effect_row_parse(eff)),
+      _ => no_str_labels()
+    }
+    // #1723: all parameters are lexical bindings. A pure callback (or even a
+    // non-function parameter later rejected by typing) must mask a same-named
+    // top-level function during this independent effect walk.
+    if Array::length(labels) > 0 || effect_name_exists(fn_names, pname) {
+      Array::push(names, pname)
+      Array::push(effs, labels)
+    } else {
+      ()
     }
     i = i + 1
   }
@@ -2051,6 +2112,10 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
       ECall(callee, args, call_off) => {
         match callee {
           EIdent(name, _) => {
+            // #1723: the overlay is also the lexical-binding environment.
+            // Some([]) means a pure local binding; only None may fall through
+            // to the module-level function table.
+            let lexical_callee = lookup_fn_effs(ov_names, ov_effs, name)
             if name == "perform" && Array::length(args) == 1 {
               match Array::get(args, 0) {
                 ECall(op_callee, opargs, _) => match op_callee {
@@ -2146,7 +2211,11 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
             // unification (#885 tracks that separately); naively requiring the
             // row-variable TOKEN itself in the caller's declared row produces
             // false positives (see `generic_effect_matrix_ok_passthrough_pure`).
-            match lookup_fn_effs(fn_names, fn_effs, name) {
+            let top_level_callee = match lexical_callee {
+              Some(_) => None,
+              None => lookup_fn_effs(fn_names, fn_effs, name)
+            }
+            match top_level_callee {
               Some(callee_effs) => {
                 // #639: aggregate every effect this call site leaks into ONE
                 // set-difference diagnostic ("missing { Env, Fs }") instead of
@@ -2219,7 +2288,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
             // signature, so the token `e` denotes the identical variable in
             // both places (no cross-call-site instantiation to resolve), and
             // literal-name membership is a sound check.
-            match lookup_fn_effs(ov_names, ov_effs, name) {
+            match lexical_callee {
               Some(param_effs) => {
                 // #639: aggregated exactly like the named-callee case above.
                 let missing = no_str_labels()
@@ -2288,7 +2357,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
         // effect row.
         let shadowed = shadow_overlay_names(ov_names, ov_effs, params)
         let (shadowed_ov_names, shadowed_ov_effs) = shadowed
-        let (local_names, local_effs) = build_param_overlay(params)
+        let (local_names, local_effs) = build_param_overlay(params, fn_names)
         let body_ov_names = if Array::length(local_names) == 0 {
           shadowed_ov_names
         } else {
@@ -2334,7 +2403,8 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
         let mut ai = 0
         while ai < Array::length(arms) {
           let (arm_pat, arm_body) = Array::get(arms, ai)
-          Array::push(stack, (arm_body, declared, in_handle, ov_names, ov_effs, throw_kind_bind_pat(kinds, arm_pat)))
+          let (arm_ov_names, arm_ov_effs) = overlay_bind_empty_pat(ov_names, ov_effs, arm_pat, fn_names)
+          Array::push(stack, (arm_body, declared, in_handle, arm_ov_names, arm_ov_effs, throw_kind_bind_pat(kinds, arm_pat)))
           ai = ai + 1
         }
       },
@@ -2387,7 +2457,8 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
         let mut ai = 0
         while ai < Array::length(arms) {
           let (arm_pat, arm_body) = Array::get(arms, ai)
-          Array::push(stack, (arm_body, declared, in_handle, ov_names, ov_effs, throw_kind_bind_pat(kinds, arm_pat)))
+          let (arm_ov_names, arm_ov_effs) = overlay_bind_empty_pat(ov_names, ov_effs, arm_pat, fn_names)
+          Array::push(stack, (arm_body, declared, in_handle, arm_ov_names, arm_ov_effs, throw_kind_bind_pat(kinds, arm_pat)))
           ai = ai + 1
         }
       },
@@ -2399,14 +2470,17 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
         // A loop parameter is re-bound by every `continue`, so its initializer's
         // kind does not describe it for the whole body: it binds unresolvable.
         let mut body_kinds = kinds
+        let loop_names = array_empty()
         let mut i = 0
         while i < Array::length(params) {
           let (pname, init) = Array::get(params, i)
           Array::push(stack, (init, declared, in_handle, ov_names, ov_effs, kinds))
           body_kinds = throw_kind_bind(body_kinds, pname, "")
+          Array::push(loop_names, pname)
           i = i + 1
         }
-        Array::push(stack, (body, declared, in_handle, ov_names, ov_effs, body_kinds))
+        let (body_ov_names, body_ov_effs) = overlay_bind_empty_names(ov_names, ov_effs, loop_names, fn_names)
+        Array::push(stack, (body, declared, in_handle, body_ov_names, body_ov_effs, body_kinds))
       },
       EForIn(value_name, index_name, iter, body) => {
         // The element (and optional index) binder has no syntactic kind here --
@@ -2418,7 +2492,12 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
           None => throw_kind_bind(kinds, value_name, "")
         }
         Array::push(stack, (iter, declared, in_handle, ov_names, ov_effs, kinds))
-        Array::push(stack, (body, declared, in_handle, ov_names, ov_effs, for_kinds))
+        let (value_ov_names, value_ov_effs) = overlay_bind_empty(ov_names, ov_effs, value_name, fn_names)
+        let for_overlay = match index_name {
+          Some(iname) => overlay_bind_empty(value_ov_names, value_ov_effs, iname, fn_names),
+          None => (value_ov_names, value_ov_effs)
+        }
+        Array::push(stack, (body, declared, in_handle, for_overlay.0, for_overlay.1, for_kinds))
       },
       EBinOp(_, left, right) => {
         Array::push(stack, (left, declared, in_handle, ov_names, ov_effs, kinds))
@@ -2704,7 +2783,7 @@ fn check_perform_effects_binding_tx(fn_name: String, ty: Option[TypeExpr], body:
       // frame -- the walk never re-descends through this EFn to pick the
       // parameters up on its own.
       let merged_params = merge_param_types_with_sig(ty, params)
-      let (ov_names, ov_effs) = build_param_overlay(merged_params)
+      let (ov_names, ov_effs) = build_param_overlay(merged_params, fn_names)
       check_perform_effects_expr_tx_in(fn_name, fbody, labels_union(sig_labels, effect_row_labels(effect_row_parse(eff))), false, fn_names, fn_effs, fn_param_effs, ov_names, ov_effs, throw_kind_bind_params(no_kind_binds(), merged_params))
     },
     _ => {
@@ -3349,7 +3428,7 @@ fn dh_check_expr(expr: Expr, declared: Array[String], performed: Array[String], 
       }
     },
     EFn(_, _, params, _, _, body) => {
-      let (bn, be) = dh_overlay_with_params(ov_names, ov_effs, params)
+      let (bn, be) = dh_overlay_with_params(ov_names, ov_effs, params, fn_names)
       dh_check_expr(body, declared, performed, fn_names, fn_effs, bn, be, errors)
     },
     ELet(name, val, body, _) => {
@@ -3397,9 +3476,9 @@ fn dh_param_base_name(n: String) -> String {
   }
 }
 
-fn dh_overlay_with_params(ov_names: Array[String], ov_effs: Array[Array[String]], params: Array[(String, Option[TypeExpr])]) -> (Array[String], Array[Array[String]]) {
+fn dh_overlay_with_params(ov_names: Array[String], ov_effs: Array[Array[String]], params: Array[(String, Option[TypeExpr])], fn_names: Array[String]) -> (Array[String], Array[Array[String]]) {
   let (sn, se) = shadow_overlay_names(ov_names, ov_effs, params)
-  let (raw_ln, le) = build_param_overlay(params)
+  let (raw_ln, le) = build_param_overlay(params, fn_names)
   let ln = for n in raw_ln {
     dh_param_base_name(n)
   }
@@ -3425,7 +3504,7 @@ fn dh_check_binding(ty: Option[TypeExpr], body: Expr, declared: Array[String], p
     // `fbody` would otherwise lose them (the top-level annotation, not the
     // EFn node, is where a separately-typed signature keeps its rows).
     EFn(_, _, params, _, _, fbody) => {
-      let (n, e) = dh_overlay_with_params(no_str_labels(), no_ov_effs(), merge_param_types_with_sig(ty, params))
+      let (n, e) = dh_overlay_with_params(no_str_labels(), no_ov_effs(), merge_param_types_with_sig(ty, params), fn_names)
       dh_check_expr(fbody, declared, performed, fn_names, fn_effs, n, e, errors)
     },
     _ => dh_check_expr(body, declared, performed, fn_names, fn_effs, no_str_labels(), no_ov_effs(), errors)

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -8021,16 +8021,16 @@ export fn suspend_cps_pass(stmts: Array[Stmt]) -> Array[String] {
         // material. Splitting it here double-wrapped the clone (emit_clone
         // re-split an already-split body into Done(Y(..))).
         SLet(exported, is_rec, name, ty, expr) => Array::set(stmts, ip, SLet(exported, is_rec, name, ty, match expr {
-          EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, scps_prepass_expr(b, ecfgs, ctx, st, split_effs)),
-          _ => scps_prepass_expr(expr, ecfgs, ctx, st, split_effs)
+          EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind_params(array_empty_scope(), params, "", ctx))),
+          _ => scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope())
         })),
         SLetMut(name, ty, expr) => Array::set(stmts, ip, SLetMut(name, ty, match expr {
-          EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, scps_prepass_expr(b, ecfgs, ctx, st, split_effs)),
-          _ => scps_prepass_expr(expr, ecfgs, ctx, st, split_effs)
+          EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind_params(array_empty_scope(), params, "", ctx))),
+          _ => scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope())
         })),
-        SExpr(expr) => Array::set(stmts, ip, SExpr(scps_prepass_expr(expr, ecfgs, ctx, st, split_effs))),
-        STest(tn, expr) => Array::set(stmts, ip, STest(tn, scps_prepass_expr(expr, ecfgs, ctx, st, split_effs))),
-        SBench(bn, expr) => Array::set(stmts, ip, SBench(bn, scps_prepass_expr(expr, ecfgs, ctx, st, split_effs))),
+        SExpr(expr) => Array::set(stmts, ip, SExpr(scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope()))),
+        STest(tn, expr) => Array::set(stmts, ip, STest(tn, scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope()))),
+        SBench(bn, expr) => Array::set(stmts, ip, SBench(bn, scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope()))),
         _ => ()
       }
       ip = ip + 1
@@ -14082,8 +14082,8 @@ fn scps_ecfg_for(ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr
   (eff, ops_qnames, scps_needing_for(ctx, eff))
 }
 
-fn scps_fn_def_params(ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), name: String) -> Option[Array[(String, Option[TypeExpr])]] {
-  let (stmts, _, fn_defs, _, _, _) = ctx
+fn scps_fn_def_index(ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), name: String) -> Int {
+  let (_, _, fn_defs, _, _, _) = ctx
   let mut def_idx = -1
   let mut fi = 0
   while fi < Array::length(fn_defs) {
@@ -14095,13 +14095,60 @@ fn scps_fn_def_params(ctx: (Array[Stmt], Array[(String, Array[(String, Array[Typ
     }
     fi = fi + 1
   }
-  if def_idx < 0 {
+  def_idx
+}
+
+fn scps_fn_def_params_at(ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), def_idx: Int) -> Option[Array[(String, Option[TypeExpr])]] {
+  let (stmts, _, _, _, _, _) = ctx
+  if def_idx < 0 || def_idx >= Array::length(stmts) {
     None
   } else {
     match Array::get(stmts, def_idx) {
       SLet(_, _, _, _, EFn(_, _, params, _, _, _)) => Some(params),
       _ => None
     }
+  }
+}
+
+fn scps_fn_def_params(ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), name: String) -> Option[Array[(String, Option[TypeExpr])]] {
+  scps_fn_def_params_at(ctx, scps_fn_def_index(ctx, name))
+}
+
+// Prepass-only scope provenance. 0/1/2 retain the eligibility classes above;
+// 3 + statement index means this local is an immutable alias of that known
+// top-level function, so its parameter convention must survive the rename.
+fn scps_prepass_alias_class(scope: Array[(String, Int)], target: String, ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Int {
+  let local = scps_local_class(scope, target)
+  if local >= 3 {
+    local
+  } else if local >= 0 {
+    0
+  } else {
+    let def_idx = scps_fn_def_index(ctx, target)
+    if def_idx >= 0 {
+      def_idx + 3
+    } else {
+      0
+    }
+  }
+}
+
+fn scps_prepass_bind_local(scope: Array[(String, Int)], name: String, value: Expr, ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Array[(String, Int)] {
+  let kind = match value {
+    EIdent(target, _) => scps_prepass_alias_class(scope, target, ctx),
+    _ => 0
+  }
+  scps_scope_bind(scope, name, kind)
+}
+
+fn scps_prepass_callee_params(scope: Array[(String, Int)], name: String, ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String])) -> Option[Array[(String, Option[TypeExpr])]] {
+  let local = scps_local_class(scope, name)
+  if local >= 3 {
+    scps_fn_def_params_at(ctx, local - 3)
+  } else if local >= 0 {
+    None
+  } else {
+    scps_fn_def_params(ctx, name)
   }
 }
 
@@ -14157,10 +14204,10 @@ fn scps_split_literal(tps: Array[String], tbs: Array[(String, Array[String])], p
   }
 }
 
-fn scps_prepass_expr(e: Expr, ecfgs: Array[(String, Array[String], Array[String])], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), st: (Array[Int], Array[String], Array[String], Array[String], Array[String], Array[Stmt], Array[String]), split_effs: Array[String]) -> Expr {
+fn scps_prepass_expr(e: Expr, ecfgs: Array[(String, Array[String], Array[String])], ctx: (Array[Stmt], Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], Array[String], Array[Array[String]], Array[String]), st: (Array[Int], Array[String], Array[String], Array[String], Array[String], Array[Stmt], Array[String]), split_effs: Array[String], scope: Array[(String, Int)]) -> Expr {
   match e {
     EFn(tps, tbs, params, ret, eff, b) => {
-      let b2 = scps_prepass_expr(b, ecfgs, ctx, st, split_effs)
+      let b2 = scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind_params(scope, params, "", ctx))
       let mut hit_eff = ""
       let mut multi = false
       let mut ei = 0
@@ -14204,9 +14251,9 @@ fn scps_prepass_expr(e: Expr, ecfgs: Array[(String, Array[String], Array[String]
       }
     },
     ECall(callee, args, off) => {
-      let rcallee = scps_prepass_expr(callee, ecfgs, ctx, st, split_effs)
+      let mut rcallee = scps_prepass_expr(callee, ecfgs, ctx, st, split_effs, scope)
       let rargs = for a in args {
-        scps_prepass_expr(a, ecfgs, ctx, st, split_effs)
+        scps_prepass_expr(a, ecfgs, ctx, st, split_effs, scope)
       }
       // arg-position convention fixups against the callee's declared params.
       //
@@ -14220,145 +14267,161 @@ fn scps_prepass_expr(e: Expr, ecfgs: Array[(String, Array[String], Array[String]
       // the checker and this opens: thread a locals set through
       // scps_prepass_expr in the same change.
       match rcallee {
-        EIdent(fname, _) => match scps_fn_def_params(ctx, fname) {
-          Some(fparams) => {
-            let mut aj = 0
-            while aj < Array::length(rargs) {
-              if aj < Array::length(fparams) {
-                let (_, pty) = Array::get(fparams, aj)
-                let prow = scps_ty_row(pty)
-                // #1707: the mirror of the fixup below. A literal the prepass
-                // STEP-SPLIT returns `__ScpsStep_E`, so it may only land in a
-                // parameter whose declared row carries E. Passed to a plain
-                // parameter, the callee calls it under the ordinary convention
-                // and hands the step OBJECT back as the value -- that compiled
-                // clean and silently returned a heap pointer as an Int.
-                let mut ei0 = 0
-                while ei0 < Array::length(ecfgs) {
-                  let (ceff0, _, _) = Array::get(ecfgs, ei0)
-                  // A parameter whose row is a row VARIABLE is exempt: the
-                  // variable can be instantiated to this effect at the call
-                  // site, which is exactly what makes
-                  // `TaskGroup::run[T, rg, e](body: (..) -> T with e)` able to
-                  // receive a step-returning literal. Only a CONCRETE row that
-                  // does not carry the effect is a plain-convention parameter.
-                  if !scps_row_has_var(prow) && !scps_row_contains(ctx, prow, ceff0) && scps_literal_is_step_for(Array::get(rargs, aj), ceff0) {
-                    Array::push(scps_st_errs(st), String::concat(String::concat(String::concat("a closure literal that performs `", ceff0), "` (so it is compiled to return a step) is passed to a parameter of `"), String::concat(String::concat(fname, "` whose type does not declare that effect -- the callee would call it under the plain convention and hand the step object back as the value. Declare the parameter as `(..) -> .. with "), String::concat(ceff0, "`, or move the performing call out of the literal (#1707, ADR-0076 追記31 Vertical B)"))))
-                  } else {
-                    ()
-                  }
-                  ei0 = ei0 + 1
-                }
-                if prow != "" {
-                  let mut ei2 = 0
-                  while ei2 < Array::length(ecfgs) {
-                    let (ceff, _, cneeding) = Array::get(ecfgs, ei2)
-                    if scps_row_contains(ctx, prow, ceff) {
-                      match Array::get(rargs, aj) {
-                        EFn(atps, atbs, aparams, aret, aeff, ab) => if scps_literal_is_step_for(Array::get(rargs, aj), ceff) {
-                          ()
-                        } else {
-                          // pure literal in an E-row position: Done-wrap so
-                          // it matches the step convention.
-                          let mut cfg2 = ("", array_empty_str(), array_empty_str())
-                          let mut ci2 = 0
-                          while ci2 < Array::length(ecfgs) {
-                            let (ceff2, _, _) = Array::get(ecfgs, ci2)
-                            if ceff2 == ceff {
-                              cfg2 = Array::get(ecfgs, ci2)
-                            } else {
-                              ()
-                            }
-                            ci2 = ci2 + 1
-                          }
-                          if edp_str_array_contains(split_effs, ceff) {
-                            ()
-                          } else {
-                            Array::push(split_effs, ceff)
-                          }
-                          Array::set(rargs, aj, scps_split_literal(atps, atbs, aparams, ab, cfg2, ctx, st))
-                        },
-                        EIdent(anm, aoff) => if edp_str_array_contains(cneeding, anm) {
-                          scps_need_clone(ceff, anm, st)
-                          if edp_str_array_contains(split_effs, ceff) {
-                            ()
-                          } else {
-                            Array::push(split_effs, ceff)
-                          }
-                          Array::set(rargs, aj, EIdent(scps_clone_name(ceff, anm), aoff))
-                        } else {
-                          ()
-                        },
-                        _ => ()
-                      }
+        EIdent(fname, _) => {
+          match scps_prepass_callee_params(scope, fname, ctx) {
+            Some(fparams) => {
+              let mut aj = 0
+              while aj < Array::length(rargs) {
+                if aj < Array::length(fparams) {
+                  let (_, pty) = Array::get(fparams, aj)
+                  let prow = scps_ty_row(pty)
+                  // #1707: the mirror of the fixup below. A literal the prepass
+                  // STEP-SPLIT returns `__ScpsStep_E`, so it may only land in a
+                  // parameter whose declared row carries E. Passed to a plain
+                  // parameter, the callee calls it under the ordinary convention
+                  // and hands the step OBJECT back as the value -- that compiled
+                  // clean and silently returned a heap pointer as an Int.
+                  let mut ei0 = 0
+                  while ei0 < Array::length(ecfgs) {
+                    let (ceff0, _, _) = Array::get(ecfgs, ei0)
+                    // A parameter whose row is a row VARIABLE is exempt: the
+                    // variable can be instantiated to this effect at the call
+                    // site, which is exactly what makes
+                    // `TaskGroup::run[T, rg, e](body: (..) -> T with e)` able to
+                    // receive a step-returning literal. Only a CONCRETE row that
+                    // does not carry the effect is a plain-convention parameter.
+                    if !scps_row_has_var(prow) && !scps_row_contains(ctx, prow, ceff0) && scps_literal_is_step_for(Array::get(rargs, aj), ceff0) {
+                      Array::push(scps_st_errs(st), String::concat(String::concat(String::concat("a closure literal that performs `", ceff0), "` (so it is compiled to return a step) is passed to a parameter of `"), String::concat(String::concat(fname, "` whose type does not declare that effect -- the callee would call it under the plain convention and hand the step object back as the value. Declare the parameter as `(..) -> .. with "), String::concat(ceff0, "`, or move the performing call out of the literal (#1707, ADR-0076 追記31 Vertical B)"))))
                     } else {
                       ()
                     }
-                    ei2 = ei2 + 1
+                    ei0 = ei0 + 1
+                  }
+                  if prow != "" {
+                    let mut ei2 = 0
+                    while ei2 < Array::length(ecfgs) {
+                      let (ceff, _, cneeding) = Array::get(ecfgs, ei2)
+                      if scps_row_contains(ctx, prow, ceff) {
+                        match Array::get(rargs, aj) {
+                          EFn(atps, atbs, aparams, aret, aeff, ab) => if scps_literal_is_step_for(Array::get(rargs, aj), ceff) {
+                            ()
+                          } else {
+                            // pure literal in an E-row position: Done-wrap so
+                            // it matches the step convention.
+                            let mut cfg2 = ("", array_empty_str(), array_empty_str())
+                            let mut ci2 = 0
+                            while ci2 < Array::length(ecfgs) {
+                              let (ceff2, _, _) = Array::get(ecfgs, ci2)
+                              if ceff2 == ceff {
+                                cfg2 = Array::get(ecfgs, ci2)
+                              } else {
+                                ()
+                              }
+                              ci2 = ci2 + 1
+                            }
+                            if edp_str_array_contains(split_effs, ceff) {
+                              ()
+                            } else {
+                              Array::push(split_effs, ceff)
+                            }
+                            Array::set(rargs, aj, scps_split_literal(atps, atbs, aparams, ab, cfg2, ctx, st))
+                          },
+                          EIdent(anm, aoff) => if edp_str_array_contains(cneeding, anm) {
+                            scps_need_clone(ceff, anm, st)
+                            if edp_str_array_contains(split_effs, ceff) {
+                              ()
+                            } else {
+                              Array::push(split_effs, ceff)
+                            }
+                            Array::set(rargs, aj, EIdent(scps_clone_name(ceff, anm), aoff))
+                          } else {
+                            ()
+                          },
+                          _ => ()
+                        }
+                      } else {
+                        ()
+                      }
+                      ei2 = ei2 + 1
+                    }
+                  } else {
+                    ()
                   }
                 } else {
                   ()
                 }
-              } else {
-                ()
+                aj = aj + 1
               }
-              aj = aj + 1
-            }
-          },
-          None => ()
+            },
+            None => ()
+          }
         },
         _ => ()
       }
       ECall(rcallee, rargs, off)
     },
-    EHandle(b, arms) => EHandle(scps_prepass_expr(b, ecfgs, ctx, st, split_effs), for a in arms {
+    EHandle(b, arms) => EHandle(scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scope), for a in arms {
       let (p, ex) = a
-      (p, scps_prepass_expr(ex, ecfgs, ctx, st, split_effs))
+      (p, scps_prepass_expr(ex, ecfgs, ctx, st, split_effs, scps_scope_bind_pat(scope, p)))
     }),
-    ELet(n, v, b, off) => ELet(n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs), scps_prepass_expr(b, ecfgs, ctx, st, split_effs), off),
-    ELetMut(n, v, b, off) => ELetMut(n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs), scps_prepass_expr(b, ecfgs, ctx, st, split_effs), off),
-    ELetRec(n, v, b) => ELetRec(n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs), scps_prepass_expr(b, ecfgs, ctx, st, split_effs)),
-    ESeq(a, b) => ESeq(scps_prepass_expr(a, ecfgs, ctx, st, split_effs), scps_prepass_expr(b, ecfgs, ctx, st, split_effs)),
-    EIf(c, t, el) => EIf(scps_prepass_expr(c, ecfgs, ctx, st, split_effs), scps_prepass_expr(t, ecfgs, ctx, st, split_effs), scps_prepass_expr(el, ecfgs, ctx, st, split_effs)),
-    EMatch(s, arms) => EMatch(scps_prepass_expr(s, ecfgs, ctx, st, split_effs), for a in arms {
+    ELet(n, v, b, off) => {
+      let v2 = scps_prepass_expr(v, ecfgs, ctx, st, split_effs, scope)
+      ELet(n, v2, scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_prepass_bind_local(scope, n, v2, ctx)), off)
+    },
+    ELetMut(n, v, b, off) => ELetMut(n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind(scope, n, 0)), off),
+    ELetRec(n, v, b) => {
+      let inner = scps_scope_bind(scope, n, 0)
+      ELetRec(n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs, inner), scps_prepass_expr(b, ecfgs, ctx, st, split_effs, inner))
+    },
+    ESeq(a, b) => ESeq(scps_prepass_expr(a, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scope)),
+    EIf(c, t, el) => EIf(scps_prepass_expr(c, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(t, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(el, ecfgs, ctx, st, split_effs, scope)),
+    EMatch(s, arms) => EMatch(scps_prepass_expr(s, ecfgs, ctx, st, split_effs, scope), for a in arms {
       let (p, ex) = a
-      (p, scps_prepass_expr(ex, ecfgs, ctx, st, split_effs))
+      (p, scps_prepass_expr(ex, ecfgs, ctx, st, split_effs, scps_scope_bind_pat(scope, p)))
     }),
-    EWhile(c, b) => EWhile(scps_prepass_expr(c, ecfgs, ctx, st, split_effs), scps_prepass_expr(b, ecfgs, ctx, st, split_effs)),
-    EForIn(n, idx, it, b) => EForIn(n, idx, scps_prepass_expr(it, ecfgs, ctx, st, split_effs), scps_prepass_expr(b, ecfgs, ctx, st, split_effs)),
-    EBinOp(op, l, r) => EBinOp(op, scps_prepass_expr(l, ecfgs, ctx, st, split_effs), scps_prepass_expr(r, ecfgs, ctx, st, split_effs)),
-    EUnaryOp(op, x) => EUnaryOp(op, scps_prepass_expr(x, ecfgs, ctx, st, split_effs)),
-    EAssign(n, v, c) => EAssign(n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs), scps_prepass_expr(c, ecfgs, ctx, st, split_effs)),
-    EAssignOp(n, op, v, c) => EAssignOp(n, op, scps_prepass_expr(v, ecfgs, ctx, st, split_effs), scps_prepass_expr(c, ecfgs, ctx, st, split_effs)),
-    EDot(o, f, off1, off2) => EDot(scps_prepass_expr(o, ecfgs, ctx, st, split_effs), f, off1, off2),
-    ELabeledArg(l, n, v) => ELabeledArg(l, n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs)),
-    EReturn(x) => EReturn(scps_prepass_expr(x, ecfgs, ctx, st, split_effs)),
+    EWhile(c, b) => EWhile(scps_prepass_expr(c, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scope)),
+    EForIn(n, idx, it, b) => {
+      let inner = scps_scope_bind_opt(scps_scope_bind(scope, n, 0), idx, 0)
+      EForIn(n, idx, scps_prepass_expr(it, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(b, ecfgs, ctx, st, split_effs, inner))
+    },
+    EBinOp(op, l, r) => EBinOp(op, scps_prepass_expr(l, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(r, ecfgs, ctx, st, split_effs, scope)),
+    EUnaryOp(op, x) => EUnaryOp(op, scps_prepass_expr(x, ecfgs, ctx, st, split_effs, scope)),
+    EAssign(n, v, c) => EAssign(n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(c, ecfgs, ctx, st, split_effs, scope)),
+    EAssignOp(n, op, v, c) => EAssignOp(n, op, scps_prepass_expr(v, ecfgs, ctx, st, split_effs, scope), scps_prepass_expr(c, ecfgs, ctx, st, split_effs, scope)),
+    EDot(o, f, off1, off2) => EDot(scps_prepass_expr(o, ecfgs, ctx, st, split_effs, scope), f, off1, off2),
+    ELabeledArg(l, n, v) => ELabeledArg(l, n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs, scope)),
+    EReturn(x) => EReturn(scps_prepass_expr(x, ecfgs, ctx, st, split_effs, scope)),
     EBreak(opt) => EBreak(match opt {
-      Some(x) => Some(scps_prepass_expr(x, ecfgs, ctx, st, split_effs)),
+      Some(x) => Some(scps_prepass_expr(x, ecfgs, ctx, st, split_effs, scope)),
       None => None
     }),
     EContinue(args) => EContinue(for a in args {
-      scps_prepass_expr(a, ecfgs, ctx, st, split_effs)
+      scps_prepass_expr(a, ecfgs, ctx, st, split_effs, scope)
     }),
     ETuple(items) => ETuple(for a in items {
-      scps_prepass_expr(a, ecfgs, ctx, st, split_effs)
+      scps_prepass_expr(a, ecfgs, ctx, st, split_effs, scope)
     }),
     EArray(items) => EArray(for a in items {
-      scps_prepass_expr(a, ecfgs, ctx, st, split_effs)
+      scps_prepass_expr(a, ecfgs, ctx, st, split_effs, scope)
     }),
     ERecord(n, fields, tas) => ERecord(n, for f in fields {
       let (fn2, v) = f
-      (fn2, scps_prepass_expr(v, ecfgs, ctx, st, split_effs))
+      (fn2, scps_prepass_expr(v, ecfgs, ctx, st, split_effs, scope))
     }, tas),
     EMap(fields) => EMap(for f in fields {
       let (fn2, v) = f
-      (fn2, scps_prepass_expr(v, ecfgs, ctx, st, split_effs))
+      (fn2, scps_prepass_expr(v, ecfgs, ctx, st, split_effs, scope))
     }),
-    ESpread(x) => ESpread(scps_prepass_expr(x, ecfgs, ctx, st, split_effs)),
-    ELoop(pairs, b) => ELoop(for p in pairs {
-      let (n, v) = p
-      (n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs))
-    }, scps_prepass_expr(b, ecfgs, ctx, st, split_effs)),
+    ESpread(x) => ESpread(scps_prepass_expr(x, ecfgs, ctx, st, split_effs, scope)),
+    ELoop(pairs, b) => {
+      let names = array_empty_str()
+      let rpairs = for p in pairs {
+        let (n, v) = p
+        Array::push(names, n)
+        (n, scps_prepass_expr(v, ecfgs, ctx, st, split_effs, scope))
+      }
+      ELoop(rpairs, scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind_names(scope, names, 0)))
+    },
     _ => e
   }
 }

--- a/lib/@vibe/compiler/tests/checker_perform_effects_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_perform_effects_test.vibe
@@ -332,6 +332,75 @@ test "a later pure binding shadows an effectful local closure" {
   assert(eq(Array::length(errors), 0))
 }
 
+test "a pure local binding shadows a same-named effectful top-level fn (#1723)" {
+  let top = SLet(false, false, "take", None, fn_with(Some("Ask"), EInt(0)))
+  let pure = fn_with(None, EInt(8))
+  let probe = SLet(false, false, "probe", None, fn_with(None, ELet("take", pure, ECall(EIdent("take", -1), array_empty(), -1), -1)))
+  let errors = check_perform_effects_stmts([
+    top,
+    probe
+  ])
+  assert(eq(Array::length(errors), 0))
+}
+
+test "a pure callback parameter shadows a same-named effectful top-level fn (#1723)" {
+  let top = SLet(false, false, "take", None, fn_with(Some("Ask"), EInt(0)))
+  let pure_callback = TyFn(array_empty(), TyName("Int"), None)
+  let probe_body = EFn(array_empty(), array_empty(), [
+    ("take", Some(pure_callback))
+  ], Some(TyName("Int")), None, ECall(EIdent("take", -1), array_empty(), -1))
+  let errors = check_perform_effects_stmts([
+    top,
+    SLet(false, false, "probe", None, probe_body)
+  ])
+  assert(eq(Array::length(errors), 0))
+}
+
+test "an effectful local binding shadows a same-named pure top-level fn (#1723)" {
+  let top = SLet(false, false, "take", None, fn_with(None, EInt(0)))
+  let effectful = fn_with(Some("Ask"), EInt(8))
+  let probe = SLet(false, false, "probe", None, fn_with(None, ELet("take", effectful, ECall(EIdent("take", -1), array_empty(), -1), -1)))
+  let errors = check_perform_effects_stmts([
+    top,
+    probe
+  ])
+  assert(eq(Array::length(errors), 1))
+  assert(String::contains(effect_error_to_string(Array::get(errors, 0)), "missing { Ask }"))
+}
+
+test "top-level effect lookup resumes after a local shadow scope ends (#1723)" {
+  let top = SLet(false, false, "take", None, fn_with(Some("Ask"), EInt(0)))
+  let pure = fn_with(None, EInt(8))
+  let scoped_local = ELet("take", pure, ECall(EIdent("take", -1), array_empty(), -1), -1)
+  let after_scope = ECall(EIdent("take", -1), array_empty(), -1)
+  let probe = SLet(false, false, "probe", None, fn_with(None, ESeq(scoped_local, after_scope)))
+  let errors = check_perform_effects_stmts([
+    top,
+    probe
+  ])
+  assert(eq(Array::length(errors), 1))
+  assert(String::contains(effect_error_to_string(Array::get(errors, 0)), "missing { Ask }"))
+}
+
+test "pattern and loop binders mask same-named top-level rows (#1723)" {
+  let top = SLet(false, false, "take", None, fn_with(Some("Ask"), EInt(0)))
+  let call_take = ECall(EIdent("take", -1), array_empty(), -1)
+  let match_probe = SLet(false, false, "match_probe", None, fn_with(None, EMatch(EInt(0), [
+    (PBind("take"), call_take)
+  ])))
+  let for_probe = SLet(false, false, "for_probe", None, fn_with(None, EForIn("take", None, EArray(array_empty()), call_take)))
+  let loop_probe = SLet(false, false, "loop_probe", None, fn_with(None, ELoop([
+    ("take", EInt(0))
+  ], call_take)))
+  let errors = check_perform_effects_stmts([
+    top,
+    match_probe,
+    for_probe,
+    loop_probe
+  ])
+  assert(eq(Array::length(errors), 0))
+}
+
 test "a handle around the call discharges the local closure's row" {
   let closure = fn_with(Some("Env"), EInt(1))
   let call = ECall(EIdent("f", -1), array_empty(), -1)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6899,6 +6899,11 @@ scps_run_expect "effect_stream_next_suspend_retarget.vibe" "42" "streamnext"
 # `__sn_next` must not capture the retarget and shadowed Future::ready must
 # not change empty-stream layout (None fallback = 7).
 scps_run_expect "effect_stream_next_retarget_hygiene.vibe" "7" "streamnexthygiene"
+# #1723: a local pure closure shadows a top-level function whose callback
+# parameter carries the suspend effect. The prepass must leave the literal on
+# the plain convention; Done-wrapping it returns a step pointer instead of 8.
+scps_run_expect "effect_scps_param_shadow_test.vibe" "8" "localparamshadow"
+scps_run_expect "effect_scps_top_level_alias_test.vibe" "7" "toplevelalias"
 # #1536 (a) v3 (let-floating): an async-iterator `for` in statement position
 # desugars to a let-chain in SEQUENCE HEAD position; scps_split_tail floats
 # it onto the continuation spine. Two sequential loops pin repeated floats


### PR DESCRIPTION
## Summary

- make checker effect-row inference respect lexical bindings before top-level function lookup
- track lexical shadowing in the suspend-CPS prepass so callback arguments keep the local calling convention
- retain empty shadow markers only for actual top-level name collisions to keep compiler heap growth bounded
- add checker, nested-scope, row-variable argument, and runtime regression coverage

## Root cause

Runtime name resolution selected local bindings, but the independent checker effect walk and the suspend-CPS prepass still resolved same-named calls through the top-level function tables. The checker therefore rejected valid programs, and fixing only that layer would expose a silent wrong-result path in the prepass.

## Validation

- `pkf run generation-gate` (stage0 -> stage3 fixpoint)
- focused checker tests: 3 files / 54 tests
- SCPS regression runtime result: `8`
- affected tests: 142/142
- `pkf run test-pre-commit`
- changed-file formatter checks and `git diff --check`
- selfcompile KPI: `heap_ptr_bytes=1099555728` (CI limit `1105822775`)

Closes #1723
