### PR TITLE
refactor(parser): thread binder context through collectors

### DIFF
--- a/lib/@vibe/compiler/tests/parser_binder_context_contract_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_binder_context_contract_test.vibe
@@ -32,6 +32,20 @@ fn opaque_context_identity(context: Option[ParserBinderContext]) -> Option[Parse
   context
 }
 
+fn assert_expression_context_parity(source: String) -> Unit with Exception {
+  let (tokens, starts, _) = lex_with_offsets(source)
+  let (legacy, legacy_next) = parse_impl(tokens, starts, 0, 0)
+  let (none, none_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, None)
+  let forged_context = ParserBinderContext::{
+    nonce: 41
+  }
+  let (forged, forged_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, Some(forged_context))
+  inspect(print_expr(none) == print_expr(legacy), "true")
+  inspect(none_next == legacy_next, "true")
+  inspect(print_expr(forged) == print_expr(legacy), "true")
+  inspect(forged_next == legacy_next, "true")
+}
+
 //# Tests
 
 test "parser binder context low-level contract accepts None without changing parsing" {
@@ -68,6 +82,42 @@ test "parser binder context low-level contract accepts None without changing par
   let (forged_impl, forged_impl_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, Some(forged_context))
   inspect(print_expr(forged_impl) == print_expr(legacy_impl), "true")
   inspect(forged_impl_next == legacy_impl_next, "true")
+}
+
+test "parser binder context B1 expression collectors preserve None and forged-Some parity" {
+  assert_expression_context_parity("(x: Int, y) -> { x }")
+  assert_expression_context_parity("[T: Eq](x: T) -> T { x }")
+  assert_expression_context_parity("value is Some(x)")
+  assert_expression_context_parity("match value { Some(x) => x, _ => 0 }")
+  assert_expression_context_parity("{ let (x, y) = pair; x }")
+  assert_expression_context_parity("{ let rec f: [T: Eq](T) -> T = [T: Eq](x: T) -> T { x }; f }")
+  assert_expression_context_parity("{ struct Local { value: Int } 1 }")
+}
+
+test "parser binder context B1 source spine has no expression collector fallback" {
+  let base = Fs::read_file("lib/@vibe/parser/parser_base.vibe")
+  let primary = Fs::read_file("lib/@vibe/parser/parser_expr_primary.vibe")
+  let core = Fs::read_file("lib/@vibe/parser/parser_expr_core.vibe")
+  let dispatch = Fs::read_file("lib/@vibe/parser/parser_expr_dispatch.vibe")
+  inspect(String::contains(base, "parse_pattern_with_binder_context(tokens, pos + 1, context)"), "true")
+  inspect(String::contains(base, "parse_pat_cont(tokens, pn, b, context)"), "true")
+  inspect(String::contains(base, "parse_one_param_with_binder_context(tokens, pos, context)"), "true")
+  inspect(String::contains(base, "parse_param_cont_with_binder_context(tokens, fn1, b, context)"), "true")
+  inspect(String::contains(base, "parse_enum_ctors_rest_with_binder_context(tokens, next, b, context)"), "true")
+  inspect(String::contains(base, "parse_struct_fields_rest_with_binder_context(tokens, next, b, mb, context)"), "true")
+  inspect(String::contains(base, "parse_pattern_with_binder_context(tokens, pos, None)"), "true")
+  inspect(String::contains(base, "parse_param_list_with_binder_context(tokens, pos, None)"), "true")
+  inspect(String::contains(primary, "parse_param_list_with_binder_context(tokens, params_pos, context)"), "true")
+  inspect(String::contains(primary, "parse_param_list_with_binder_context(tokens, pos + 1, context)"), "true")
+  inspect(!String::contains(primary, "parse_param_list(tokens,"), "true")
+  inspect(String::contains(core, "parse_pattern_with_binder_context(tokens, next + 1, context)"), "true")
+  inspect(!String::contains(core, "parse_pattern(tokens,"), "true")
+  inspect(String::contains(dispatch, "parse_pattern_with_binder_context(tokens, pos, context)"), "true")
+  inspect(String::contains(dispatch, "parse_enum_stmt_with_binder_context(tokens, p + 1, false, context)"), "true")
+  inspect(String::contains(dispatch, "parse_struct_stmt_with_binder_context(tokens, p + 1, false, context)"), "true")
+  inspect(!String::contains(dispatch, "parse_pattern(tokens,"), "true")
+  inspect(!String::contains(dispatch, "parse_enum_stmt(tokens,"), "true")
+  inspect(!String::contains(dispatch, "parse_struct_stmt(tokens,"), "true")
 }
 
 test "parser binder context statement and dispatch contracts accept None" {

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -66,6 +66,22 @@ fn record_test_effect_row(name: String, row: String) -> Unit
 fn has_test_effect_rows() -> Bool
 fn take_test_effect_rows() -> Array[(String, String)]
 fn parse_effect_row(tokens: Array[Token], pos: Int) -> (String, Int) with Exception
+// B1 collector seams are public only because package conformance requires every
+// cross-file export in this contract. The context is forgeable, never inspected,
+// and authorizes no binder row or artifact; ordinary wrappers pass None.
+fn parse_pattern_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Pat, Int) with Exception
+fn parse_param_list_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, Option[TypeExpr])], Int) with Exception
+fn parse_import_item_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, Option[String]), Int) with Exception
+fn parse_binding_name_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (String, Int) with Exception
+fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int)
+fn parse_struct_field_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, TypeExpr), Bool, Int) with Exception
+fn parse_trait_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
+fn parse_enum_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
+fn parse_suberror_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
+fn parse_impl_stmt_dispatch_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
+fn parse_effect_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
+fn parse_type_alias_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
+fn parse_struct_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
 
 // --- parser_expr (+ primary/core/dispatch stages)
 fn parse(tokens: Array[Token]) -> Expr with Exception

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -4,6 +4,10 @@ import @vibe/ast {
   Expr, Pat, Stmt, TypeExpr
 }
 
+import ./parser_binder_context.vibe {
+  ParserBinderContext
+}
+
 import ./token.vibe {
   Token
 }
@@ -336,26 +340,26 @@ fn empty_params() -> Array[(String, Option[TypeExpr])] {
   ], 0, 0)
 }
 
-fn parse_pattern(tokens: Array[Token], pos: Int) -> (Pat, Int) with Exception {
-  let rec parse_pat_cont: (Array[Token], Int, ArrayBuilder[Pat]) -> (Array[Pat], Int) with Exception = (tokens, pos, b) -> {
+export fn parse_pattern_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Pat, Int) with Exception {
+  let rec parse_pat_cont: (Array[Token], Int, ArrayBuilder[Pat], Option[ParserBinderContext]) -> (Array[Pat], Int) with Exception = (tokens, pos, b, context) -> {
     match peek(tokens, pos) {
       TComma => {
-        let (p, pn) = parse_pattern(tokens, pos + 1)
+        let (p, pn) = parse_pattern_with_binder_context(tokens, pos + 1, context)
         ArrayBuilder::push(b, p)
-        parse_pat_cont(tokens, pn, b)
+        parse_pat_cont(tokens, pn, b, context)
       },
       TRParen => (ArrayBuilder::freeze(b), pos + 1),
       _ => throw("expected ',' or ')' in pattern list")
     }
   }
-  let parse_pats_until_rparen: (Array[Token], Int) -> (Array[Pat], Int) with Exception = (tokens, pos) -> {
+  let parse_pats_until_rparen: (Array[Token], Int, Option[ParserBinderContext]) -> (Array[Pat], Int) with Exception = (tokens, pos, context) -> {
     match peek(tokens, pos) {
       TRParen => (empty_pats(), pos + 1),
       _ => {
-        let (f, fn1) = parse_pattern(tokens, pos)
+        let (f, fn1) = parse_pattern_with_binder_context(tokens, pos, context)
         let b = ArrayBuilder::new()
         ArrayBuilder::push(b, f)
-        parse_pat_cont(tokens, fn1, b)
+        parse_pat_cont(tokens, fn1, b, context)
       }
     }
   }
@@ -399,7 +403,7 @@ fn parse_pattern(tokens: Array[Token], pos: Int) -> (Pat, Int) with Exception {
             TIdent(fname) => {
               match peek(tokens, rp + 1) {
                 TColon => {
-                  let (fp, fnext) = parse_pattern(tokens, rp + 2)
+                  let (fp, fnext) = parse_pattern_with_binder_context(tokens, rp + 2, context)
                   ArrayBuilder::push(field_pats_b, fp)
                   rp = fnext
                 },
@@ -433,7 +437,7 @@ fn parse_pattern(tokens: Array[Token], pos: Int) -> (Pat, Int) with Exception {
         if fc >= 65 && fc <= 90 {
           match peek(tokens, pos + 1) {
             TLParen => {
-              let (args, end) = parse_pats_until_rparen(tokens, pos + 2);
+              let (args, end) = parse_pats_until_rparen(tokens, pos + 2, context);
               (PCtor(name, args), end)
             },
             TDoubleColon => match peek(tokens, pos + 2) {
@@ -482,7 +486,7 @@ fn parse_pattern(tokens: Array[Token], pos: Int) -> (Pat, Int) with Exception {
                   note_qualified_pattern_ref(name, vname)
                   match peek(tokens, pos + 3) {
                     TLParen => {
-                      let (args, end) = parse_pats_until_rparen(tokens, pos + 4);
+                      let (args, end) = parse_pats_until_rparen(tokens, pos + 4, context);
                       (PCtor(vname, args), end)
                     },
                     _ => (PCtor(vname, empty_pats()), pos + 3)
@@ -501,13 +505,13 @@ fn parse_pattern(tokens: Array[Token], pos: Int) -> (Pat, Int) with Exception {
     TLParen => match peek(tokens, pos + 1) {
       TRParen => (PTuple(empty_pats()), pos + 2),
       _ => {
-        let (f, n1) = parse_pattern(tokens, pos + 1)
+        let (f, n1) = parse_pattern_with_binder_context(tokens, pos + 1, context)
         match peek(tokens, n1) {
           TRParen => (f, n1 + 1),
           TComma => {
             let b = ArrayBuilder::new()
             ArrayBuilder::push(b, f)
-            let (rest, end) = parse_pat_cont(tokens, n1, b);
+            let (rest, end) = parse_pat_cont(tokens, n1, b, context);
             (PTuple(rest), end)
           },
           _ => throw("expected ')' or ',' in pattern")
@@ -521,11 +525,15 @@ fn parse_pattern(tokens: Array[Token], pos: Int) -> (Pat, Int) with Exception {
   }
   match peek(tokens, next) {
     TBitOr => {
-      let (right, end) = parse_pattern(tokens, next + 1);
+      let (right, end) = parse_pattern_with_binder_context(tokens, next + 1, context);
       (POr(pat, right), end)
     },
     _ => (pat, next)
   }
+}
+
+fn parse_pattern(tokens: Array[Token], pos: Int) -> (Pat, Int) with Exception {
+  parse_pattern_with_binder_context(tokens, pos, None)
 }
 
 fn empty_type_exprs() -> Array[TypeExpr] {
@@ -563,7 +571,9 @@ export fn skip_braced_body(tokens: Array[Token], pos: Int) -> Int {
 /// Parse `Bound + Bound2 + ...` (one type parameter's bound trait names) in a
 /// method-level `[X: Bound]` binder. Local equivalent of parser_expr's
 /// `parse_type_param_bound_names` (not visible from parser_base).
-fn parse_method_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+// Trait-bound names are references, not source binders. Context is threaded only
+// to keep the collector call graph explicit; this helper records no authority.
+fn parse_method_tp_bound_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
   let b = ArrayBuilder::new()
   let mut p = pos
   let mut done = false
@@ -587,11 +597,15 @@ fn parse_method_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String]
   (ArrayBuilder::freeze(b), p)
 }
 
+fn parse_method_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+  parse_method_tp_bound_names_with_binder_context(tokens, pos, None)
+}
+
 /// Parse a method-level `[X: Bound, Y, ...]` binder (the first param name token
 /// is at `pos`, the `[` already consumed). Local equivalent of parser_expr's
 /// `parse_let_type_params`. Returns (type-param names, per-param bounds, next
 /// position after `]`).
-fn parse_method_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+fn parse_method_type_params_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
   let names = ArrayBuilder::new()
   let bounds = ArrayBuilder::new()
   let mut p = pos
@@ -606,7 +620,7 @@ fn parse_method_type_params(tokens: Array[Token], pos: Int) -> (Array[String], A
         p = p + 1
         match peek(tokens, p) {
           TColon => {
-            let (bound_names, next) = parse_method_tp_bound_names(tokens, p + 1)
+            let (bound_names, next) = parse_method_tp_bound_names_with_binder_context(tokens, p + 1, context)
             ArrayBuilder::push(bounds, (name, bound_names))
             p = next
           },
@@ -629,7 +643,10 @@ fn parse_method_type_params(tokens: Array[Token], pos: Int) -> (Array[String], A
   (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
 }
 
-fn parse_trait_methods(tokens: Array[Token], pos: Int) -> (Array[(String, Array[TypeExpr], TypeExpr)], Array[(String, Array[String], Array[(String, Array[String])])], Int) with Exception {
+fn parse_method_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+  parse_method_type_params_with_binder_context(tokens, pos, None)
+}
+fn parse_trait_methods_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, Array[TypeExpr], TypeExpr)], Array[(String, Array[String], Array[(String, Array[String])])], Int) with Exception {
   match peek(tokens, pos) {
     TLBrace => {
       let sigs_b = ArrayBuilder::new()
@@ -652,7 +669,7 @@ fn parse_trait_methods(tokens: Array[Token], pos: Int) -> (Array[(String, Array[
             // trait method only (rank-1 method generics, #684). The impl never
             // repeats it; the desugar reattaches it to the impl's free function.
             let (mtparams, mtbounds, after_binder) = match peek(tokens, after_colon) {
-              TLBracket => parse_method_type_params(tokens, after_colon + 1),
+              TLBracket => parse_method_type_params_with_binder_context(tokens, after_colon + 1, context),
               _ => (_no_tp(), _no_tb(), after_colon)
             }
             let (params, after_method_params) = match peek(tokens, after_binder) {
@@ -687,7 +704,10 @@ fn parse_trait_methods(tokens: Array[Token], pos: Int) -> (Array[(String, Array[
   }
 }
 
-fn parse_trait_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+fn parse_trait_methods(tokens: Array[Token], pos: Int) -> (Array[(String, Array[TypeExpr], TypeExpr)], Array[(String, Array[String], Array[(String, Array[String])])], Int) with Exception {
+  parse_trait_methods_with_binder_context(tokens, pos, None)
+}
+export fn parse_trait_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   let empty_strings = Array::slice([
     "_"
   ], 0, 0)
@@ -696,7 +716,7 @@ fn parse_trait_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, In
       // Retain the declared bare header names while preserving the existing
       // accepting grammar: parse_tparam_names still skips non-name header
       // details such as bounds rather than giving them new semantics.
-      let (tparams, after_name) = parse_tparam_names(tokens, pos + 1)
+      let (tparams, after_name) = parse_tparam_names_with_binder_context(tokens, pos + 1, context)
       match peek(tokens, after_name) {
         TColon => {
           let supers = empty_strings
@@ -721,11 +741,11 @@ fn parse_trait_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, In
             }
           }
           let np = p
-          let (methods, method_gens, body_end) = parse_trait_methods(tokens, np)
+          let (methods, method_gens, body_end) = parse_trait_methods_with_binder_context(tokens, np, context)
           (STrait(exported, name, supers, methods, method_gens, tparams), body_end)
         },
         _ => {
-          let (methods, method_gens, body_end) = parse_trait_methods(tokens, after_name)
+          let (methods, method_gens, body_end) = parse_trait_methods_with_binder_context(tokens, after_name, context)
           (STrait(exported, name, empty_strings, methods, method_gens, tparams), body_end)
         }
       }
@@ -734,6 +754,9 @@ fn parse_trait_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, In
   }
 }
 
+fn parse_trait_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+  parse_trait_stmt_with_binder_context(tokens, pos, exported, None)
+}
 fn is_expr_end_token(tok: Token) -> Bool {
   match tok {
     TInt(_) => true,
@@ -772,7 +795,7 @@ fn is_non_pipe_infix(tok: Token) -> Bool {
   }
 }
 
-fn parse_import_item(tokens: Array[Token], pos: Int) -> ((String, Option[String]), Int) with Exception {
+export fn parse_import_item_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, Option[String]), Int) with Exception {
   let parse_import_name: (Int) -> ((String, Option[String]), Int) with Exception = (name_pos) -> {
     match peek(tokens, name_pos) {
       TIdent(name) => {
@@ -803,13 +826,16 @@ fn parse_import_item(tokens: Array[Token], pos: Int) -> ((String, Option[String]
   }
 }
 
+fn parse_import_item(tokens: Array[Token], pos: Int) -> ((String, Option[String]), Int) with Exception {
+  parse_import_item_with_binder_context(tokens, pos, None)
+}
 fn empty_import_items() -> Array[(String, Option[String])] {
   Array::slice([
     ("_", None)
   ], 0, 0)
 }
 
-fn parse_binding_name(tokens: Array[Token], pos: Int) -> (String, Int) with Exception {
+export fn parse_binding_name_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (String, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => match peek(tokens, pos + 1) {
       TDoubleColon => match peek(tokens, pos + 2) {
@@ -822,6 +848,9 @@ fn parse_binding_name(tokens: Array[Token], pos: Int) -> (String, Int) with Exce
   }
 }
 
+fn parse_binding_name(tokens: Array[Token], pos: Int) -> (String, Int) with Exception {
+  parse_binding_name_with_binder_context(tokens, pos, None)
+}
 export fn collect_import_path(tokens: Array[Token], pos: Int, acc: String) -> (String, Int) with Exception {
   match peek(tokens, pos) {
     TLBrace => (acc, pos),
@@ -891,7 +920,7 @@ fn skip_bracketed_args(tokens: Array[Token], pos: Int) -> Int {
 /// (returning ([], pos) when there is no bracket). Mirrors parse_enum_stmt's
 /// inline collector: only depth-1 identifiers in name position are kept, so a
 /// bound like `[T: Eq]` still records just `T`.
-fn parse_tparam_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) {
+export fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) {
   match peek(tokens, pos) {
     TLBracket => {
       let b = ArrayBuilder::new()
@@ -933,6 +962,10 @@ fn parse_tparam_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) {
       ""
     ], 0, 0), pos)
   }
+}
+
+fn parse_tparam_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) {
+  parse_tparam_names_with_binder_context(tokens, pos, None)
 }
 
 /// #1340 (ADR-0071): capture a generic row item's bracketed type-argument
@@ -1483,7 +1516,7 @@ fn optional_param_type(ty: TypeExpr, is_optional: Bool) -> TypeExpr {
   }
 }
 
-fn parse_one_param(tokens: Array[Token], pos: Int) -> ((String, Option[TypeExpr]), Int) with Exception {
+fn parse_one_param_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, Option[TypeExpr]), Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => match peek(tokens, pos + 1) {
       TTilde => {
@@ -1550,14 +1583,17 @@ fn parse_one_param(tokens: Array[Token], pos: Int) -> ((String, Option[TypeExpr]
   }
 }
 
-fn parse_param_cont(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Option[TypeExpr])]) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
+fn parse_one_param(tokens: Array[Token], pos: Int) -> ((String, Option[TypeExpr]), Int) with Exception {
+  parse_one_param_with_binder_context(tokens, pos, None)
+}
+fn parse_param_cont_with_binder_context(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Option[TypeExpr])], context: Option[ParserBinderContext]) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
   match peek(tokens, pos) {
     TComma => match peek(tokens, pos + 1) {
       TRParen => (ArrayBuilder::freeze(b), pos + 2),
       _ => {
-        let (p, pn) = parse_one_param(tokens, pos + 1)
+        let (p, pn) = parse_one_param_with_binder_context(tokens, pos + 1, context)
         ArrayBuilder::push(b, p)
-        parse_param_cont(tokens, pn, b)
+        parse_param_cont_with_binder_context(tokens, pn, b, context)
       }
     },
     TRParen => (ArrayBuilder::freeze(b), pos + 1),
@@ -1568,19 +1604,25 @@ fn parse_param_cont(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Opt
   }
 }
 
-fn parse_param_list(tokens: Array[Token], pos: Int) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
+fn parse_param_cont(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Option[TypeExpr])]) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
+  parse_param_cont_with_binder_context(tokens, pos, b, None)
+}
+export fn parse_param_list_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
   match peek(tokens, pos) {
     TRParen => (empty_params(), pos + 1),
     _ => {
-      let (f, fn1) = parse_one_param(tokens, pos)
+      let (f, fn1) = parse_one_param_with_binder_context(tokens, pos, context)
       let b = ArrayBuilder::new()
       ArrayBuilder::push(b, f)
-      parse_param_cont(tokens, fn1, b)
+      parse_param_cont_with_binder_context(tokens, fn1, b, context)
     }
   }
 }
 
-fn parse_struct_field(tokens: Array[Token], pos: Int) -> ((String, TypeExpr), Bool, Int) with Exception {
+fn parse_param_list(tokens: Array[Token], pos: Int) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
+  parse_param_list_with_binder_context(tokens, pos, None)
+}
+export fn parse_struct_field_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, TypeExpr), Bool, Int) with Exception {
   let (is_mut, p) = match peek(tokens, pos) {
     TMut => (true, pos + 1),
     _ => (false, pos)
@@ -1595,6 +1637,9 @@ fn parse_struct_field(tokens: Array[Token], pos: Int) -> ((String, TypeExpr), Bo
   }
 }
 
+fn parse_struct_field(tokens: Array[Token], pos: Int) -> ((String, TypeExpr), Bool, Int) with Exception {
+  parse_struct_field_with_binder_context(tokens, pos, None)
+}
 fn is_lambda_start_impl(tokens: Array[Token], pos: Int, depth: Int, bdepth: Int, has_colon: Bool) -> Bool {
   match peek(tokens, pos) {
     // A colon only signals an annotated lambda param when it sits directly
@@ -1636,7 +1681,7 @@ fn parse_ctor_types_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[TypeExp
   }
 }
 
-fn parse_enum_ctor(tokens: Array[Token], pos: Int) -> ((String, Array[TypeExpr]), Int) with Exception {
+fn parse_enum_ctor_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, Array[TypeExpr]), Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => match peek(tokens, pos + 1) {
       TLParen => match peek(tokens, pos + 2) {
@@ -1655,14 +1700,17 @@ fn parse_enum_ctor(tokens: Array[Token], pos: Int) -> ((String, Array[TypeExpr])
   }
 }
 
-fn parse_enum_ctors_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Array[TypeExpr])]) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
+fn parse_enum_ctor(tokens: Array[Token], pos: Int) -> ((String, Array[TypeExpr]), Int) with Exception {
+  parse_enum_ctor_with_binder_context(tokens, pos, None)
+}
+fn parse_enum_ctors_rest_with_binder_context(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Array[TypeExpr])], context: Option[ParserBinderContext]) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
   match peek(tokens, pos) {
     TSemicolon => match peek(tokens, pos + 1) {
       TRBrace => (ArrayBuilder::freeze(b), pos + 2),
       _ => {
-        let (ctor, next) = parse_enum_ctor(tokens, pos + 1)
+        let (ctor, next) = parse_enum_ctor_with_binder_context(tokens, pos + 1, context)
         ArrayBuilder::push(b, ctor)
-        parse_enum_ctors_rest(tokens, next, b)
+        parse_enum_ctors_rest_with_binder_context(tokens, next, b, context)
       }
     },
     // 0.3.0 redundant-syntax removal: ',' is no longer a declaration-body
@@ -1674,19 +1722,25 @@ fn parse_enum_ctors_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String
   }
 }
 
-fn parse_enum_ctors(tokens: Array[Token], pos: Int) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
+fn parse_enum_ctors_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Array[TypeExpr])]) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
+  parse_enum_ctors_rest_with_binder_context(tokens, pos, b, None)
+}
+fn parse_enum_ctors_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
   match peek(tokens, pos) {
     TRBrace => (empty_ctors(), pos + 1),
     _ => {
-      let (first, next) = parse_enum_ctor(tokens, pos)
+      let (first, next) = parse_enum_ctor_with_binder_context(tokens, pos, context)
       let b = ArrayBuilder::new()
       ArrayBuilder::push(b, first)
-      parse_enum_ctors_rest(tokens, next, b)
+      parse_enum_ctors_rest_with_binder_context(tokens, next, b, context)
     }
   }
 }
 
-fn parse_enum_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+fn parse_enum_ctors(tokens: Array[Token], pos: Int) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
+  parse_enum_ctors_with_binder_context(tokens, pos, None)
+}
+export fn parse_enum_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => {
       let (params, after_name) = match peek(tokens, pos + 1) {
@@ -1728,7 +1782,7 @@ fn parse_enum_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int
         ], 0, 0), pos + 1)
       }
       let br = expect_tk(tokens, after_name, "{")
-      let (ctors, end) = parse_enum_ctors(tokens, br);
+      let (ctors, end) = parse_enum_ctors_with_binder_context(tokens, br, context);
       let (derives, final_pos) = parse_derive_names(tokens, end)
       (SEnum(exported, name, params, ctors, derives), final_pos)
     },
@@ -1736,7 +1790,10 @@ fn parse_enum_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int
   }
 }
 
-fn parse_suberror_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+fn parse_enum_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+  parse_enum_stmt_with_binder_context(tokens, pos, exported, None)
+}
+export fn parse_suberror_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => match peek(tokens, pos + 1) {
       TLParen => match peek(tokens, pos + 2) {
@@ -1756,7 +1813,7 @@ fn parse_suberror_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt,
         }
       },
       TLBrace => {
-        let (ctors, end) = parse_enum_ctors(tokens, pos + 2);
+        let (ctors, end) = parse_enum_ctors_with_binder_context(tokens, pos + 2, context);
         (SSuberror(exported, name, ctors), end)
       },
       _ => throw("expected '(' or '{' after suberror name")
@@ -1765,7 +1822,12 @@ fn parse_suberror_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt,
   }
 }
 
-fn parse_impl_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+fn parse_suberror_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+  parse_suberror_stmt_with_binder_context(tokens, pos, exported, None)
+}
+// Trait-bound names are references, not source binders. Context is threaded only
+// to keep the collector call graph explicit; this helper records no authority.
+fn parse_impl_bound_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
   let b = ArrayBuilder::new()
   let mut p = pos
   let mut done = false
@@ -1789,7 +1851,10 @@ fn parse_impl_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int
   (ArrayBuilder::freeze(b), p)
 }
 
-fn parse_impl_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+fn parse_impl_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+  parse_impl_bound_names_with_binder_context(tokens, pos, None)
+}
+fn parse_impl_type_params_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
   let names = ArrayBuilder::new()
   let bounds = ArrayBuilder::new()
   let mut p = pos
@@ -1804,7 +1869,7 @@ fn parse_impl_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Arr
         p = p + 1
         match peek(tokens, p) {
           TColon => {
-            let (bound_names, next) = parse_impl_bound_names(tokens, p + 1)
+            let (bound_names, next) = parse_impl_bound_names_with_binder_context(tokens, p + 1, context)
             ArrayBuilder::push(bounds, (name, bound_names))
             p = next
           },
@@ -1827,9 +1892,12 @@ fn parse_impl_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Arr
   (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
 }
 
-fn parse_impl_stmt(tokens: Array[Token], pos: Int) -> (Stmt, Int) with Exception {
+fn parse_impl_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+  parse_impl_type_params_with_binder_context(tokens, pos, None)
+}
+fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   let (type_params, type_bounds, after_tp) = match peek(tokens, pos) {
-    TLBracket => parse_impl_type_params(tokens, pos + 1),
+    TLBracket => parse_impl_type_params_with_binder_context(tokens, pos + 1, context),
     _ => (_no_tp(), _no_tb(), pos)
   }
   match peek(tokens, after_tp) {
@@ -1851,7 +1919,10 @@ fn parse_impl_stmt(tokens: Array[Token], pos: Int) -> (Stmt, Int) with Exception
   }
 }
 
-fn parse_type_params_list(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+fn parse_impl_stmt(tokens: Array[Token], pos: Int) -> (Stmt, Int) with Exception {
+  parse_impl_stmt_with_binder_context(tokens, pos, None)
+}
+fn parse_type_params_list_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
   let b = ArrayBuilder::new()
   let mut p = pos
   while true {
@@ -1880,12 +1951,16 @@ fn parse_type_params_list(tokens: Array[Token], pos: Int) -> (Array[String], Int
   (ArrayBuilder::freeze(b), p)
 }
 
+fn parse_type_params_list(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+  parse_type_params_list_with_binder_context(tokens, pos, None)
+}
+
 /// Parse effect declaration: effect Name[T] { Op(Args) -> Ret; ... }
-fn parse_effect_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+export fn parse_effect_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => {
       let (type_params, after_params) = match peek(tokens, pos + 1) {
-        TLBracket => parse_type_params_list(tokens, pos + 2),
+        TLBracket => parse_type_params_list_with_binder_context(tokens, pos + 2, context),
         _ => (ArrayBuilder::freeze(ArrayBuilder::new()), pos + 1)
       }
       let br = expect_tk(tokens, after_params, "{")
@@ -1929,11 +2004,14 @@ fn parse_effect_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, I
   }
 }
 
-fn parse_type_alias_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+fn parse_effect_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+  parse_effect_stmt_with_binder_context(tokens, pos, exported, None)
+}
+export fn parse_type_alias_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => {
       let (params, after_name) = match peek(tokens, pos + 1) {
-        TLBracket => parse_type_params_list(tokens, pos + 2),
+        TLBracket => parse_type_params_list_with_binder_context(tokens, pos + 2, context),
         _ => (Array::slice([
           ""
         ], 0, 0), pos + 1)
@@ -1946,10 +2024,16 @@ fn parse_type_alias_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stm
   }
 }
 
-fn parse_impl_stmt_dispatch(tokens: Array[Token], pos: Int) -> (Stmt, Int) with Exception {
-  parse_impl_stmt(tokens, pos)
+fn parse_type_alias_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+  parse_type_alias_stmt_with_binder_context(tokens, pos, exported, None)
+}
+export fn parse_impl_stmt_dispatch_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  parse_impl_stmt_with_binder_context(tokens, pos, context)
 }
 
+fn parse_impl_stmt_dispatch(tokens: Array[Token], pos: Int) -> (Stmt, Int) with Exception {
+  parse_impl_stmt_dispatch_with_binder_context(tokens, pos, None)
+}
 fn push_mut_name(mb: ArrayBuilder[String], field: (String, TypeExpr), is_mut: Bool) -> Unit {
   if is_mut {
     let (fname, _) = field
@@ -1959,15 +2043,15 @@ fn push_mut_name(mb: ArrayBuilder[String], field: (String, TypeExpr), is_mut: Bo
   }
 }
 
-fn parse_struct_fields_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, TypeExpr)], mb: ArrayBuilder[String]) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
+fn parse_struct_fields_rest_with_binder_context(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, TypeExpr)], mb: ArrayBuilder[String], context: Option[ParserBinderContext]) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
   match peek(tokens, pos) {
     TSemicolon => match peek(tokens, pos + 1) {
       TRBrace => (ArrayBuilder::freeze(b), ArrayBuilder::freeze(mb), pos + 2),
       _ => {
-        let (field, is_mut, next) = parse_struct_field(tokens, pos + 1)
+        let (field, is_mut, next) = parse_struct_field_with_binder_context(tokens, pos + 1, context)
         ArrayBuilder::push(b, field)
         push_mut_name(mb, field, is_mut)
-        parse_struct_fields_rest(tokens, next, b, mb)
+        parse_struct_fields_rest_with_binder_context(tokens, next, b, mb, context)
       }
     },
     // 0.3.0 redundant-syntax removal: ',' is no longer a declaration-body
@@ -1978,30 +2062,36 @@ fn parse_struct_fields_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[(Str
   }
 }
 
-fn parse_struct_fields(tokens: Array[Token], pos: Int) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
+fn parse_struct_fields_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, TypeExpr)], mb: ArrayBuilder[String]) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
+  parse_struct_fields_rest_with_binder_context(tokens, pos, b, mb, None)
+}
+fn parse_struct_fields_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
   match peek(tokens, pos) {
     TRBrace => (empty_fields(), Array::slice([
       ""
     ], 0, 0), pos + 1),
     _ => {
-      let (first, is_mut, next) = parse_struct_field(tokens, pos)
+      let (first, is_mut, next) = parse_struct_field_with_binder_context(tokens, pos, context)
       let b = ArrayBuilder::new()
       let mb = ArrayBuilder::new()
       ArrayBuilder::push(b, first)
       push_mut_name(mb, first, is_mut)
-      parse_struct_fields_rest(tokens, next, b, mb)
+      parse_struct_fields_rest_with_binder_context(tokens, next, b, mb, context)
     }
   }
 }
 
-fn parse_struct_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+fn parse_struct_fields(tokens: Array[Token], pos: Int) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
+  parse_struct_fields_with_binder_context(tokens, pos, None)
+}
+export fn parse_struct_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => {
       // #829: keep the `[T]` type-parameter names (previously skipped and
       // discarded) so the checker can instantiate generic struct literals.
-      let (tparams, after_name) = parse_tparam_names(tokens, pos + 1)
+      let (tparams, after_name) = parse_tparam_names_with_binder_context(tokens, pos + 1, context)
       let br = expect_tk(tokens, after_name, "{")
-      let (fields, mut_names, end) = parse_struct_fields(tokens, br);
+      let (fields, mut_names, end) = parse_struct_fields_with_binder_context(tokens, br, context);
       let (derives, final_pos) = parse_derive_names(tokens, end)
       (SStruct(exported, name, fields, derives, mut_names, tparams), final_pos)
     },
@@ -2009,6 +2099,9 @@ fn parse_struct_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, I
   }
 }
 
+fn parse_struct_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
+  parse_struct_stmt_with_binder_context(tokens, pos, exported, None)
+}
 //# Misc
 
 export {
@@ -2036,21 +2129,34 @@ export {
   mode_match,
   mode_while,
   parse_binding_name,
+  parse_binding_name_with_binder_context,
   parse_derive_names,
   parse_effect_row,
   parse_effect_stmt,
+  parse_effect_stmt_with_binder_context,
   parse_enum_stmt,
+  parse_enum_stmt_with_binder_context,
   parse_impl_stmt_dispatch,
+  parse_impl_stmt_dispatch_with_binder_context,
   parse_import_item,
+  parse_import_item_with_binder_context,
   parse_param_list,
+  parse_param_list_with_binder_context,
   parse_pattern,
+  parse_pattern_with_binder_context,
   parse_struct_field,
+  parse_struct_field_with_binder_context,
   parse_struct_stmt,
+  parse_struct_stmt_with_binder_context,
   parse_suberror_stmt,
+  parse_suberror_stmt_with_binder_context,
   parse_tparam_names,
+  parse_tparam_names_with_binder_context,
   parse_trait_stmt,
+  parse_trait_stmt_with_binder_context,
   parse_type,
   parse_type_alias_stmt,
+  parse_type_alias_stmt_with_binder_context,
   parse_type_impl,
   peek,
   reject_retired_effect_label,
@@ -2084,21 +2190,34 @@ export {
   mode_match,
   mode_while,
   parse_binding_name,
+  parse_binding_name_with_binder_context,
   parse_derive_names,
   parse_effect_row,
   parse_effect_stmt,
+  parse_effect_stmt_with_binder_context,
   parse_enum_stmt,
+  parse_enum_stmt_with_binder_context,
   parse_impl_stmt_dispatch,
+  parse_impl_stmt_dispatch_with_binder_context,
   parse_import_item,
+  parse_import_item_with_binder_context,
   parse_param_list,
+  parse_param_list_with_binder_context,
   parse_pattern,
+  parse_pattern_with_binder_context,
   parse_struct_field,
+  parse_struct_field_with_binder_context,
   parse_struct_stmt,
+  parse_struct_stmt_with_binder_context,
   parse_suberror_stmt,
+  parse_suberror_stmt_with_binder_context,
   parse_tparam_names,
+  parse_tparam_names_with_binder_context,
   parse_trait_stmt,
+  parse_trait_stmt_with_binder_context,
   parse_type,
   parse_type_alias_stmt,
+  parse_type_alias_stmt_with_binder_context,
   parse_type_impl,
   peek,
   reject_retired_effect_label,
@@ -2132,21 +2251,34 @@ export {
   mode_match,
   mode_while,
   parse_binding_name,
+  parse_binding_name_with_binder_context,
   parse_derive_names,
   parse_effect_row,
   parse_effect_stmt,
+  parse_effect_stmt_with_binder_context,
   parse_enum_stmt,
+  parse_enum_stmt_with_binder_context,
   parse_impl_stmt_dispatch,
+  parse_impl_stmt_dispatch_with_binder_context,
   parse_import_item,
+  parse_import_item_with_binder_context,
   parse_param_list,
+  parse_param_list_with_binder_context,
   parse_pattern,
+  parse_pattern_with_binder_context,
   parse_struct_field,
+  parse_struct_field_with_binder_context,
   parse_struct_stmt,
+  parse_struct_stmt_with_binder_context,
   parse_suberror_stmt,
+  parse_suberror_stmt_with_binder_context,
   parse_tparam_names,
+  parse_tparam_names_with_binder_context,
   parse_trait_stmt,
+  parse_trait_stmt_with_binder_context,
   parse_type,
   parse_type_alias_stmt,
+  parse_type_alias_stmt_with_binder_context,
   parse_type_impl,
   peek,
   reject_retired_effect_label,

--- a/lib/@vibe/parser/parser_expr_core.vibe
+++ b/lib/@vibe/parser/parser_expr_core.vibe
@@ -5,7 +5,7 @@ import @vibe/ast {
 }
 
 import ./parser_base.vibe {
-  _no_tb, _no_tp, empty_exprs, expect_tk, is_expr_end_token, is_non_pipe_infix, parse_pattern, peek
+  _no_tb, _no_tp, empty_exprs, expect_tk, is_expr_end_token, is_non_pipe_infix, parse_pattern_with_binder_context, peek
 }
 
 import ./parser_expr_primary.vibe {
@@ -616,7 +616,7 @@ fn parse_infix_loop(tokens: Array[Token], starts: Array[Int], left: Expr, next: 
     // keep looping (cmp_locked, like a comparison, so a further `is`/`==`
     // right after would need explicit parens) so the resulting Bool can
     // still fold into an enclosing `&&`/`||`/`|>` at a looser tier.
-    let (pat, pn) = parse_pattern(tokens, next + 1)
+    let (pat, pn) = parse_pattern_with_binder_context(tokens, next + 1, context)
     let combined = EMatch(left, [
       (pat, EBool(true)),
       (PWild, EBool(false))

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -9,9 +9,9 @@ import ./parser_base.vibe {
   empty_arms,
   empty_exprs,
   expect_tk,
-  parse_enum_stmt,
-  parse_pattern,
-  parse_struct_stmt,
+  parse_enum_stmt_with_binder_context,
+  parse_pattern_with_binder_context,
+  parse_struct_stmt_with_binder_context,
   parse_type_impl,
   peek,
   reject_retired_effect_label,
@@ -103,8 +103,9 @@ fn distribute_local_fn_ann(ann_ty: TypeExpr, val: Expr) -> Option[Expr] {
 
 /// #789: `[T: A + B]` per-param trait-bound names (first name at `pos`). Private
 /// copy of parser_base.parse_method_tp_bound_names (not re-exportable across the
-/// package contract boundary).
-fn dispatch_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+/// package contract boundary). Bound names are references, not binders; context
+/// is untrusted plumbing only.
+fn dispatch_tp_bound_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
   let b = ArrayBuilder::new()
   let mut p = pos
   let mut done = false
@@ -128,10 +129,14 @@ fn dispatch_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], In
   (ArrayBuilder::freeze(b), p)
 }
 
+fn dispatch_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+  dispatch_tp_bound_names_with_binder_context(tokens, pos, None)
+}
+
 /// #789: parse a `[T, U: Bound]` binder (`[` already consumed; first name token at
 /// `pos`). Private copy of parser_base.parse_method_type_params. Returns
 /// (type-param names, per-param bounds, next-after-`]`).
-fn dispatch_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+fn dispatch_type_params_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
   let names = ArrayBuilder::new()
   let bounds = ArrayBuilder::new()
   let mut p = pos
@@ -147,7 +152,7 @@ fn dispatch_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array
         p = p + 1
         match peek(tokens, p) {
           TColon => {
-            let (bound_names, next) = dispatch_tp_bound_names(tokens, p + 1)
+            let (bound_names, next) = dispatch_tp_bound_names_with_binder_context(tokens, p + 1, context)
             ArrayBuilder::push(bounds, (name, bound_names))
             p = next
           },
@@ -170,16 +175,20 @@ fn dispatch_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array
   (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
 }
 
+fn dispatch_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+  dispatch_type_params_with_binder_context(tokens, pos, None)
+}
+
 /// #789: parse a local `let f: TYPE = ..` annotation, consuming an optional
 /// generic binder `[T, U: Bound]` first (like the top-level parse_let_annotation /
 /// parse_let_type_params, which the local block-let path previously lacked — a
 /// leading `[` gave `expected type but got [`). `pos` is the first annotation
 /// token (just after `:`). Returns (type-param names, per-param bounds, type,
 /// next position).
-fn parse_local_let_annotation(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], TypeExpr, Int) with Exception {
+fn parse_local_let_annotation_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Array[(String, Array[String])], TypeExpr, Int) with Exception {
   match peek(tokens, pos) {
     TLBracket => {
-      let (tps, tbs, after_binder) = dispatch_type_params(tokens, pos + 1)
+      let (tps, tbs, after_binder) = dispatch_type_params_with_binder_context(tokens, pos + 1, context)
       let (ty, next) = parse_type_impl(tokens, after_binder, 0)
       (tps, tbs, ty, next)
     },
@@ -196,6 +205,10 @@ fn parse_local_let_annotation(tokens: Array[Token], pos: Int) -> (Array[String],
       (no_tp, no_tb, ty, next)
     }
   }
+}
+
+fn parse_local_let_annotation(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], TypeExpr, Int) with Exception {
+  parse_local_let_annotation_with_binder_context(tokens, pos, None)
 }
 
 /// #789: attach a local generic-let's `[T]` binder to its (annotation-distributed)
@@ -276,7 +289,7 @@ fn desugar_guarded(arms: Array[(Pat, Expr, Expr)], i: Int, scrut: Expr) -> Array
 /// setting hg[0] when any arm carries a guard. Arms are comma-separated, ending
 /// at `}` (optionally with a trailing comma).
 fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(Pat, Expr, Expr)], hg: Array[Bool], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> Int with Exception {
-  let (pat, pa) = parse_pattern(tokens, pos)
+  let (pat, pa) = parse_pattern_with_binder_context(tokens, pos, context)
   let (arm_guard, after_g) = match peek(tokens, pa) {
     TIf => {
       Array::set(hg, 0, true)
@@ -312,7 +325,7 @@ fn qualify_handle_arm_pattern(effect_name: String, pat: Pat) -> Pat {
 }
 
 fn parse_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, effect_name: String, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> ((Pat, Expr), Int) with Exception {
-  let (pat, pat_next) = parse_pattern(tokens, pos)
+  let (pat, pat_next) = parse_pattern_with_binder_context(tokens, pos, context)
   let qualified_pat = qualify_handle_arm_pattern(effect_name, pat)
   let arrow_pos = expect_tk(tokens, pat_next, "=>")
   let (expr, next) = parse_recur(tokens, arrow_pos, 0, context)
@@ -662,7 +675,7 @@ fn parse_guard_stmt(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
     },
     _ => throw("guard: expected `is <pattern>` after the scrutinee, as in `guard x is Some(v) else { return -1 }` (#1283)")
   }
-  let (pat, pn) = parse_pattern(tokens, after_is)
+  let (pat, pn) = parse_pattern_with_binder_context(tokens, after_is, context)
   let else_pos = match peek(tokens, pn) {
     TElse => pn + 1,
     _ => throw("guard: expected `else { .. }` after the pattern (#1283)")
@@ -728,7 +741,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
       // type visible to the whole file and collide across functions, which is a
       // language decision, not a parser fix (noted on #1525).
       TEnum => {
-        let (enum_stmt, _) = parse_enum_stmt(tokens, p + 1, false)
+        let (enum_stmt, _) = parse_enum_stmt_with_binder_context(tokens, p + 1, false, context)
         let ename = match enum_stmt {
           SEnum(_, n, _, _, _) => n,
           _ => "the enum"
@@ -736,7 +749,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
         throw("a block-local `enum` declaration is not supported -- move `\{ename}` to the top level and refer to it from here. Inside a block it had no constructors at all: `match` against them matched nothing (silently taking the `_` arm, or trapping without one). #1525 at #\{p}")
       },
       TStruct => {
-        let (_, struct_end) = parse_struct_stmt(tokens, p + 1, false)
+        let (_, struct_end) = parse_struct_stmt_with_binder_context(tokens, p + 1, false, context)
         p = struct_end
       },
       TLet => {
@@ -748,7 +761,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
               // the plain local let below.
               let (rtps, rtbs, rec_ann, eq_pos_r) = match peek(tokens, next + 2) {
                 TColon => {
-                  let (tps, tbs, rty, tp) = parse_local_let_annotation(tokens, next + 3)
+                  let (tps, tbs, rty, tp) = parse_local_let_annotation_with_binder_context(tokens, next + 3, context)
                   (tps, tbs, Some(rty), tp)
                 },
                 _ => {
@@ -851,13 +864,13 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
               _ => false
             }
             if next_is_struct_destr {
-              let (pat, pn) = parse_pattern(tokens, next)
+              let (pat, pn) = parse_pattern_with_binder_context(tokens, next, context)
               let eq = expect_tk(tokens, pn, "=")
               let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
               ArrayBuilder::push(steps, StepStructDestr(pat, val))
               p = next_pos
             } else if next_is_record_destr {
-              let (pat, pn) = parse_pattern(tokens, next)
+              let (pat, pn) = parse_pattern_with_binder_context(tokens, next, context)
               let eq = expect_tk(tokens, pn, "=")
               let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
               ArrayBuilder::push(steps, StepRecordDestr(pat, val))
@@ -865,7 +878,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             } else {
               match after_name {
                 TLParen => {
-                  let (pat, pn) = parse_pattern(tokens, next)
+                  let (pat, pn) = parse_pattern_with_binder_context(tokens, next, context)
                   let eq = expect_tk(tokens, pn, "=")
                   let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
                   if next_pos <= eq {
@@ -879,7 +892,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                   // local generic `let f: [T](T) -> T = ..` parses like top-level.
                   let (ltps, ltbs, ann_type, eq_pos) = match after_name {
                     TColon => {
-                      let (tps, tbs, the_type, tp) = parse_local_let_annotation(tokens, next + 2)
+                      let (tps, tbs, the_type, tp) = parse_local_let_annotation_with_binder_context(tokens, next + 2, context)
                       (tps, tbs, Some(the_type), tp)
                     },
                     _ => {
@@ -923,7 +936,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             }
           },
           TLParen => {
-            let (pat, pn) = parse_pattern(tokens, next)
+            let (pat, pn) = parse_pattern_with_binder_context(tokens, next, context)
             let eq = expect_tk(tokens, pn, "=")
             let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
             if next_pos <= eq {
@@ -1075,13 +1088,13 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
     let mut brace_pos = cn
     match peek(tokens, cn) {
       TIs => {
-        let (pat, pn) = parse_pattern(tokens, cn + 1)
+        let (pat, pn) = parse_pattern_with_binder_context(tokens, cn + 1, context)
         is_mode = true
         is_pat_val = pat
         brace_pos = pn
       },
       TIdent(kw) => if kw == "is" {
-        let (pat, pn) = parse_pattern(tokens, cn + 1)
+        let (pat, pn) = parse_pattern_with_binder_context(tokens, cn + 1, context)
         is_mode = true
         is_pat_val = pat
         brace_pos = pn

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -14,6 +14,7 @@ import ./parser_base.vibe {
   is_lambda_start,
   parse_effect_row,
   parse_param_list,
+  parse_param_list_with_binder_context,
   parse_type_impl,
   peek,
   tk_name
@@ -620,7 +621,9 @@ fn parse_ctor_record_fields(tokens: Array[Token], starts: Array[Int], pos: Int, 
   }
 }
 
-fn parse_generic_type_param_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+// Trait-bound names are references, not binders. Context is threaded only to
+// keep the collector call graph explicit and records no authority.
+fn parse_generic_type_param_bound_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
   let bounds = ArrayBuilder::new()
   let mut p = pos
   let mut done = false
@@ -644,10 +647,14 @@ fn parse_generic_type_param_bound_names(tokens: Array[Token], pos: Int) -> (Arra
   (ArrayBuilder::freeze(bounds), p)
 }
 
+fn parse_generic_type_param_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
+  parse_generic_type_param_bound_names_with_binder_context(tokens, pos, None)
+}
+
 /// Parse an expression-position `[T: Bound, U]` header. This intentionally
 /// stays private to the primary-expression parser: unlike declaration headers,
 /// it is not part of the public parser contract.
-fn parse_generic_fn_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+fn parse_generic_fn_type_params_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
   let names = ArrayBuilder::new()
   let bounds = ArrayBuilder::new()
   let mut p = pos
@@ -662,7 +669,7 @@ fn parse_generic_fn_type_params(tokens: Array[Token], pos: Int) -> (Array[String
         p = p + 1
         match peek(tokens, p) {
           TColon => {
-            let (bound_names, next) = parse_generic_type_param_bound_names(tokens, p + 1)
+            let (bound_names, next) = parse_generic_type_param_bound_names_with_binder_context(tokens, p + 1, context)
             ArrayBuilder::push(bounds, (name, bound_names))
             p = next
           },
@@ -685,10 +692,14 @@ fn parse_generic_fn_type_params(tokens: Array[Token], pos: Int) -> (Array[String
   (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
 }
 
+fn parse_generic_fn_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+  parse_generic_fn_type_params_with_binder_context(tokens, pos, None)
+}
+
 fn parse_generic_fn_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
-  let (type_params, type_bounds, after_header) = parse_generic_fn_type_params(tokens, pos + 1)
+  let (type_params, type_bounds, after_header) = parse_generic_fn_type_params_with_binder_context(tokens, pos + 1, context)
   let params_pos = expect_tk(tokens, after_header, "(")
-  let (params, after_params) = parse_param_list(tokens, params_pos)
+  let (params, after_params) = parse_param_list_with_binder_context(tokens, params_pos, context)
   match peek(tokens, after_params) {
     TThinArrow => {
       let (ret_ty, ret_pos) = parse_type_impl(tokens, after_params + 1, 0)
@@ -773,7 +784,7 @@ fn parse_paren_tuple_primary(tokens: Array[Token], starts: Array[Int], pos: Int,
 }
 
 fn parse_paren_lambda_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
-  let (params, after_params) = parse_param_list(tokens, pos + 1)
+  let (params, after_params) = parse_param_list_with_binder_context(tokens, pos + 1, context)
   match peek(tokens, after_params) {
     TThinArrow => {
       let after_arrow = after_params + 1


### PR DESCRIPTION
## Summary
- add authority-free context variants and legacy `None` wrappers for parser collector chains
- route the explicit expression spine through pattern, parameter, generic, and declaration collectors
- document bound references separately from binders
- add forged/None parity and mechanical no-fallback attestation

## Safety
- public helpers are untrusted package-conformance plumbing
- context is never inspected and records no authority rows
- no top-level routing, lowering, AST, checker, runtime, cache, or reuse changes

## Validation
- focused 4/4
- unit files 635/635
- stage2 == stage3
- formatter/generated freshness/diff check

Prerequisite for #1548.