### PR TITLE
refactor(parser): thread context through binder lowerings

### DIFF
--- a/fixtures/parser_binder_context_test.vibe
+++ b/fixtures/parser_binder_context_test.vibe
@@ -1,6 +1,6 @@
 //# Imports
 
-import @vibe/compiler/syntax {
+import ../lib/@vibe/parser {
   lex_with_offsets, parse_program_located, parse_program_located_with_binder_context, print_program
 }
 
@@ -39,6 +39,29 @@ test "parser binder context B2 preserves whole-program declarations and impl met
   let ordinary = print_program(parse_program_located(tokens, starts, source))
   let contextual = print_program(parse_program_located_with_binder_context(tokens, starts, source))
   inspect(ordinary == contextual, "true")
+}
+
+test "parser binder context preserves immediate binder lowering and remap families" {
+  let sources = [
+    "fn positive(x: Int) -> Int where { ensures: result > 0 } { let y: Int = x; y }\nlet (a, (b, c)) = (1, (2, 3))",
+    "struct Pair { fst: Int; snd: Int }\nfn unpack(p: Pair) -> Int { let Pair::{ fst, snd } = p; let record { x, y } = record { x: fst, y: snd }; x + y }",
+    "fn guarded(x: Int) -> Int { match x { y if y > 0 => y, _ => 0 } }",
+    "fn iterate() -> Int { loop (i = 0) { if i > 2 { break(i) } else { continue(i + 1) } } }",
+    "fn placeholders() -> Int { Array::map([1], _ + 1)[0] }",
+    "fn grouped() -> Int { taskgroup { g => 1 } }\nfn allocated() -> Int { region r { 1 } }",
+    "fn interpolated() -> String { \"value=\\{((x) -> { x })(1)}\" }"
+  ]
+  let mut same = true
+  let mut i = 0
+  while i < Array::length(sources) {
+    let source = Array::get(sources, i)
+    let (tokens, starts, _) = lex_with_offsets(source)
+    let ordinary = print_program(parse_program_located(tokens, starts, source))
+    let contextual = print_program(parse_program_located_with_binder_context(tokens, starts, source))
+    same = same && ordinary == contextual
+    i = i + 1
+  }
+  inspect(same, "true")
 }
 
 test "parser binder context is isolated across sequential invocations" {

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -106,6 +106,7 @@ fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: Array[I
 
 // --- parser_expr (fn-declaration lowering, ADR-0064 #727/#731)
 fn lower_fn_decl_stmt(stmt: Stmt) -> Stmt
+fn lower_fn_decl_stmt_with_binder_context(stmt: Stmt, context: Option[ParserBinderContext]) -> Stmt
 fn lower_fn_decl_stmts(stmts: Array[Stmt]) -> Array[Stmt]
 
 // --- parser_expr (#1281): expand a top-level irrefutable pattern `let` into a
@@ -113,6 +114,7 @@ fn lower_fn_decl_stmts(stmts: Array[Stmt]) -> Array[Stmt]
 // the value is evaluated once and codegen sees only plain top-level `SLet`s.
 // Applied by every parse_program* variant that feeds the checker/codegen.
 fn expand_top_level_pattern_lets(stmts: Array[Stmt]) -> Array[Stmt]
+fn expand_top_level_pattern_lets_with_binder_context(stmts: Array[Stmt], context: Option[ParserBinderContext]) -> Array[Stmt]
 
 // --- parser
 fn parse_stmt(tokens: Array[Token], starts: Array[Int], pos: Int) -> (Stmt, Int) with Exception

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -46,7 +46,9 @@ import ./parser_base.vibe {
 
 import ./parser_expr.vibe {
   expand_top_level_pattern_lets,
+  expand_top_level_pattern_lets_with_binder_context,
   lower_fn_decl_stmt,
+  lower_fn_decl_stmt_with_binder_context,
   lower_fn_decl_stmts,
   parse,
   parse_expr,
@@ -623,7 +625,7 @@ export fn parse_stmt(tokens: Array[Token], starts: Array[Int], pos: Int) -> (Stm
 
 export fn parse_stmt_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   let (stmt, next) = parse_stmt_preserving_with_binder_context(tokens, starts, pos, context)
-  (lower_fn_decl_stmt(stmt), next)
+  (lower_fn_decl_stmt_with_binder_context(stmt, context), next)
 }
 
 /// Expand an impl body `{ method(params) -> ret { body } ... }` into the impl
@@ -1011,7 +1013,7 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
       }
     }
   }
-  (attach_qualified_pattern_refs(expand_top_level_pattern_lets(ArrayBuilder::freeze(b))), pos)
+  (attach_qualified_pattern_refs(expand_top_level_pattern_lets_with_binder_context(ArrayBuilder::freeze(b), context)), pos)
 }
 
 /// True when `t` is a resynchronization point for `parse_program_recovering`:
@@ -1286,21 +1288,6 @@ export fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Ar
 }
 
 //# Misc
-
-export {
-  Expr,
-  Pat,
-  Stmt,
-  TypeExpr,
-  parse,
-  parse_expr,
-  parse_ok,
-  parse_program,
-  parse_program_preserving,
-  parse_stmt,
-  parse_stmt_preserving,
-  parse_type
-}
 
 export {
   Expr,

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -568,12 +568,9 @@ export fn skip_braced_body(tokens: Array[Token], pos: Int) -> Int {
   }
 }
 
-/// Parse `Bound + Bound2 + ...` (one type parameter's bound trait names) in a
-/// method-level `[X: Bound]` binder. Local equivalent of parser_expr's
-/// `parse_type_param_bound_names` (not visible from parser_base).
-// Trait-bound names are references, not source binders. Context is threaded only
-// to keep the collector call graph explicit; this helper records no authority.
-fn parse_method_tp_bound_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
+/// Parse `Bound + Bound2 + ...` trait references for a bounded type parameter.
+// Trait-bound names are references, not source binders.
+fn parse_trait_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
   let b = ArrayBuilder::new()
   let mut p = pos
   let mut done = false
@@ -597,15 +594,10 @@ fn parse_method_tp_bound_names_with_binder_context(tokens: Array[Token], pos: In
   (ArrayBuilder::freeze(b), p)
 }
 
-fn parse_method_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
-  parse_method_tp_bound_names_with_binder_context(tokens, pos, None)
-}
-
-/// Parse a method-level `[X: Bound, Y, ...]` binder (the first param name token
-/// is at `pos`, the `[` already consumed). Local equivalent of parser_expr's
-/// `parse_let_type_params`. Returns (type-param names, per-param bounds, next
-/// position after `]`).
-fn parse_method_type_params_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
+/// Parse a `[X: Bound, Y, ...]` binder after `[`. `separator_error` preserves
+/// each caller's existing diagnostic; `allow_bounds = false` leaves `:` for
+/// that separator diagnostic instead of accepting a bound.
+fn parse_bounded_type_params_with_binder_context(tokens: Array[Token], pos: Int, allow_bounds: Bool, separator_error: String, context: Option[ParserBinderContext]) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
   let names = ArrayBuilder::new()
   let bounds = ArrayBuilder::new()
   let mut p = pos
@@ -619,10 +611,12 @@ fn parse_method_type_params_with_binder_context(tokens: Array[Token], pos: Int, 
         ArrayBuilder::push(names, name)
         p = p + 1
         match peek(tokens, p) {
-          TColon => {
-            let (bound_names, next) = parse_method_tp_bound_names_with_binder_context(tokens, p + 1, context)
+          TColon => if allow_bounds {
+            let (bound_names, next) = parse_trait_bound_names(tokens, p + 1)
             ArrayBuilder::push(bounds, (name, bound_names))
             p = next
+          } else {
+            ()
           },
           _ => ()
         }
@@ -634,7 +628,7 @@ fn parse_method_type_params_with_binder_context(tokens: Array[Token], pos: Int, 
             p = p + 1
             break
           },
-          _ => throw("expected ',' or ']' in method type params")
+          _ => throw(separator_error)
         }
       },
       _ => throw("expected type parameter name or ']'")
@@ -643,9 +637,6 @@ fn parse_method_type_params_with_binder_context(tokens: Array[Token], pos: Int, 
   (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
 }
 
-fn parse_method_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
-  parse_method_type_params_with_binder_context(tokens, pos, None)
-}
 fn parse_trait_methods_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, Array[TypeExpr], TypeExpr)], Array[(String, Array[String], Array[(String, Array[String])])], Int) with Exception {
   match peek(tokens, pos) {
     TLBrace => {
@@ -669,7 +660,7 @@ fn parse_trait_methods_with_binder_context(tokens: Array[Token], pos: Int, conte
             // trait method only (rank-1 method generics, #684). The impl never
             // repeats it; the desugar reattaches it to the impl's free function.
             let (mtparams, mtbounds, after_binder) = match peek(tokens, after_colon) {
-              TLBracket => parse_method_type_params_with_binder_context(tokens, after_colon + 1, context),
+              TLBracket => parse_bounded_type_params_with_binder_context(tokens, after_colon + 1, true, "expected ',' or ']' in method type params", context),
               _ => (_no_tp(), _no_tb(), after_colon)
             }
             let (params, after_method_params) = match peek(tokens, after_binder) {
@@ -704,9 +695,6 @@ fn parse_trait_methods_with_binder_context(tokens: Array[Token], pos: Int, conte
   }
 }
 
-fn parse_trait_methods(tokens: Array[Token], pos: Int) -> (Array[(String, Array[TypeExpr], TypeExpr)], Array[(String, Array[String], Array[(String, Array[String])])], Int) with Exception {
-  parse_trait_methods_with_binder_context(tokens, pos, None)
-}
 export fn parse_trait_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   let empty_strings = Array::slice([
     "_"
@@ -1583,9 +1571,6 @@ fn parse_one_param_with_binder_context(tokens: Array[Token], pos: Int, context: 
   }
 }
 
-fn parse_one_param(tokens: Array[Token], pos: Int) -> ((String, Option[TypeExpr]), Int) with Exception {
-  parse_one_param_with_binder_context(tokens, pos, None)
-}
 fn parse_param_cont_with_binder_context(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Option[TypeExpr])], context: Option[ParserBinderContext]) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
   match peek(tokens, pos) {
     TComma => match peek(tokens, pos + 1) {
@@ -1604,9 +1589,6 @@ fn parse_param_cont_with_binder_context(tokens: Array[Token], pos: Int, b: Array
   }
 }
 
-fn parse_param_cont(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Option[TypeExpr])]) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
-  parse_param_cont_with_binder_context(tokens, pos, b, None)
-}
 export fn parse_param_list_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, Option[TypeExpr])], Int) with Exception {
   match peek(tokens, pos) {
     TRParen => (empty_params(), pos + 1),
@@ -1700,9 +1682,6 @@ fn parse_enum_ctor_with_binder_context(tokens: Array[Token], pos: Int, context: 
   }
 }
 
-fn parse_enum_ctor(tokens: Array[Token], pos: Int) -> ((String, Array[TypeExpr]), Int) with Exception {
-  parse_enum_ctor_with_binder_context(tokens, pos, None)
-}
 fn parse_enum_ctors_rest_with_binder_context(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Array[TypeExpr])], context: Option[ParserBinderContext]) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
   match peek(tokens, pos) {
     TSemicolon => match peek(tokens, pos + 1) {
@@ -1722,9 +1701,6 @@ fn parse_enum_ctors_rest_with_binder_context(tokens: Array[Token], pos: Int, b: 
   }
 }
 
-fn parse_enum_ctors_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, Array[TypeExpr])]) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
-  parse_enum_ctors_rest_with_binder_context(tokens, pos, b, None)
-}
 fn parse_enum_ctors_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
   match peek(tokens, pos) {
     TRBrace => (empty_ctors(), pos + 1),
@@ -1737,9 +1713,6 @@ fn parse_enum_ctors_with_binder_context(tokens: Array[Token], pos: Int, context:
   }
 }
 
-fn parse_enum_ctors(tokens: Array[Token], pos: Int) -> (Array[(String, Array[TypeExpr])], Int) with Exception {
-  parse_enum_ctors_with_binder_context(tokens, pos, None)
-}
 export fn parse_enum_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => {
@@ -1825,79 +1798,9 @@ export fn parse_suberror_stmt_with_binder_context(tokens: Array[Token], pos: Int
 fn parse_suberror_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int) with Exception {
   parse_suberror_stmt_with_binder_context(tokens, pos, exported, None)
 }
-// Trait-bound names are references, not source binders. Context is threaded only
-// to keep the collector call graph explicit; this helper records no authority.
-fn parse_impl_bound_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
-  let b = ArrayBuilder::new()
-  let mut p = pos
-  let mut done = false
-  while !done {
-    match peek(tokens, p) {
-      TIdent(name) => {
-        ArrayBuilder::push(b, name)
-        p = p + 1
-        match peek(tokens, p) {
-          TPlus => {
-            p = p + 1
-          },
-          _ => {
-            done = true
-          }
-        }
-      },
-      _ => throw("expected trait bound name")
-    }
-  }
-  (ArrayBuilder::freeze(b), p)
-}
-
-fn parse_impl_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
-  parse_impl_bound_names_with_binder_context(tokens, pos, None)
-}
-fn parse_impl_type_params_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
-  let names = ArrayBuilder::new()
-  let bounds = ArrayBuilder::new()
-  let mut p = pos
-  while true {
-    match peek(tokens, p) {
-      TRBracket => {
-        p = p + 1
-        break
-      },
-      TIdent(name) => {
-        ArrayBuilder::push(names, name)
-        p = p + 1
-        match peek(tokens, p) {
-          TColon => {
-            let (bound_names, next) = parse_impl_bound_names_with_binder_context(tokens, p + 1, context)
-            ArrayBuilder::push(bounds, (name, bound_names))
-            p = next
-          },
-          _ => ()
-        }
-        match peek(tokens, p) {
-          TComma => {
-            p = p + 1
-          },
-          TRBracket => {
-            p = p + 1
-            break
-          },
-          _ => throw("expected ',' or ']' in impl type params")
-        }
-      },
-      _ => throw("expected type parameter name or ']'")
-    }
-  }
-  (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
-}
-
-fn parse_impl_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
-  parse_impl_type_params_with_binder_context(tokens, pos, None)
-}
 fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   let (type_params, type_bounds, after_tp) = match peek(tokens, pos) {
-    TLBracket => parse_impl_type_params_with_binder_context(tokens, pos + 1, context),
+    TLBracket => parse_bounded_type_params_with_binder_context(tokens, pos + 1, true, "expected ',' or ']' in impl type params", context),
     _ => (_no_tp(), _no_tb(), pos)
   }
   match peek(tokens, after_tp) {
@@ -1919,48 +1822,15 @@ fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: 
   }
 }
 
-fn parse_impl_stmt(tokens: Array[Token], pos: Int) -> (Stmt, Int) with Exception {
-  parse_impl_stmt_with_binder_context(tokens, pos, None)
-}
-fn parse_type_params_list_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
-  let b = ArrayBuilder::new()
-  let mut p = pos
-  while true {
-    match peek(tokens, p) {
-      TRBracket => {
-        p = p + 1
-        break
-      },
-      TIdent(name) => {
-        ArrayBuilder::push(b, name)
-        p = p + 1
-        match peek(tokens, p) {
-          TComma => {
-            p = p + 1
-          },
-          TRBracket => {
-            p = p + 1
-            break
-          },
-          _ => throw("expected ',' or ']' in type params")
-        }
-      },
-      _ => throw("expected type parameter name or ']'")
-    }
-  }
-  (ArrayBuilder::freeze(b), p)
-}
-
-fn parse_type_params_list(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
-  parse_type_params_list_with_binder_context(tokens, pos, None)
-}
-
 /// Parse effect declaration: effect Name[T] { Op(Args) -> Ret; ... }
 export fn parse_effect_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => {
       let (type_params, after_params) = match peek(tokens, pos + 1) {
-        TLBracket => parse_type_params_list_with_binder_context(tokens, pos + 2, context),
+        TLBracket => {
+          let (names, _, next) = parse_bounded_type_params_with_binder_context(tokens, pos + 2, false, "expected ',' or ']' in type params", context)
+          (names, next)
+        },
         _ => (ArrayBuilder::freeze(ArrayBuilder::new()), pos + 1)
       }
       let br = expect_tk(tokens, after_params, "{")
@@ -2011,7 +1881,10 @@ export fn parse_type_alias_stmt_with_binder_context(tokens: Array[Token], pos: I
   match peek(tokens, pos) {
     TIdent(name) => {
       let (params, after_name) = match peek(tokens, pos + 1) {
-        TLBracket => parse_type_params_list_with_binder_context(tokens, pos + 2, context),
+        TLBracket => {
+          let (names, _, next) = parse_bounded_type_params_with_binder_context(tokens, pos + 2, false, "expected ',' or ']' in type params", context)
+          (names, next)
+        },
         _ => (Array::slice([
           ""
         ], 0, 0), pos + 1)
@@ -2062,9 +1935,6 @@ fn parse_struct_fields_rest_with_binder_context(tokens: Array[Token], pos: Int, 
   }
 }
 
-fn parse_struct_fields_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[(String, TypeExpr)], mb: ArrayBuilder[String]) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
-  parse_struct_fields_rest_with_binder_context(tokens, pos, b, mb, None)
-}
 fn parse_struct_fields_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
   match peek(tokens, pos) {
     TRBrace => (empty_fields(), Array::slice([
@@ -2081,9 +1951,6 @@ fn parse_struct_fields_with_binder_context(tokens: Array[Token], pos: Int, conte
   }
 }
 
-fn parse_struct_fields(tokens: Array[Token], pos: Int) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
-  parse_struct_fields_with_binder_context(tokens, pos, None)
-}
 export fn parse_struct_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => {
@@ -2103,128 +1970,6 @@ fn parse_struct_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, I
   parse_struct_stmt_with_binder_context(tokens, pos, exported, None)
 }
 //# Misc
-
-export {
-  _no_tb,
-  _no_tp,
-  collect_effect_names,
-  collect_import_path,
-  collect_row_item_targs,
-  empty_arms,
-  empty_exprs,
-  empty_fields,
-  empty_import_items,
-  empty_params,
-  empty_pats,
-  empty_type_exprs,
-  expect_tk,
-  is_expr_end_token,
-  is_lambda_start,
-  is_non_pipe_infix,
-  is_tk,
-  mode_block,
-  mode_for_in,
-  mode_handle,
-  mode_if,
-  mode_match,
-  mode_while,
-  parse_binding_name,
-  parse_binding_name_with_binder_context,
-  parse_derive_names,
-  parse_effect_row,
-  parse_effect_stmt,
-  parse_effect_stmt_with_binder_context,
-  parse_enum_stmt,
-  parse_enum_stmt_with_binder_context,
-  parse_impl_stmt_dispatch,
-  parse_impl_stmt_dispatch_with_binder_context,
-  parse_import_item,
-  parse_import_item_with_binder_context,
-  parse_param_list,
-  parse_param_list_with_binder_context,
-  parse_pattern,
-  parse_pattern_with_binder_context,
-  parse_struct_field,
-  parse_struct_field_with_binder_context,
-  parse_struct_stmt,
-  parse_struct_stmt_with_binder_context,
-  parse_suberror_stmt,
-  parse_suberror_stmt_with_binder_context,
-  parse_tparam_names,
-  parse_tparam_names_with_binder_context,
-  parse_trait_stmt,
-  parse_trait_stmt_with_binder_context,
-  parse_type,
-  parse_type_alias_stmt,
-  parse_type_alias_stmt_with_binder_context,
-  parse_type_impl,
-  peek,
-  reject_retired_effect_label,
-  skip_derive,
-  skip_semi,
-  tk_name
-}
-
-export {
-  _no_tb,
-  _no_tp,
-  collect_effect_names,
-  collect_import_path,
-  collect_row_item_targs,
-  empty_arms,
-  empty_exprs,
-  empty_fields,
-  empty_import_items,
-  empty_params,
-  empty_pats,
-  empty_type_exprs,
-  expect_tk,
-  is_expr_end_token,
-  is_lambda_start,
-  is_non_pipe_infix,
-  is_tk,
-  mode_block,
-  mode_for_in,
-  mode_handle,
-  mode_if,
-  mode_match,
-  mode_while,
-  parse_binding_name,
-  parse_binding_name_with_binder_context,
-  parse_derive_names,
-  parse_effect_row,
-  parse_effect_stmt,
-  parse_effect_stmt_with_binder_context,
-  parse_enum_stmt,
-  parse_enum_stmt_with_binder_context,
-  parse_impl_stmt_dispatch,
-  parse_impl_stmt_dispatch_with_binder_context,
-  parse_import_item,
-  parse_import_item_with_binder_context,
-  parse_param_list,
-  parse_param_list_with_binder_context,
-  parse_pattern,
-  parse_pattern_with_binder_context,
-  parse_struct_field,
-  parse_struct_field_with_binder_context,
-  parse_struct_stmt,
-  parse_struct_stmt_with_binder_context,
-  parse_suberror_stmt,
-  parse_suberror_stmt_with_binder_context,
-  parse_tparam_names,
-  parse_tparam_names_with_binder_context,
-  parse_trait_stmt,
-  parse_trait_stmt_with_binder_context,
-  parse_type,
-  parse_type_alias_stmt,
-  parse_type_alias_stmt_with_binder_context,
-  parse_type_impl,
-  peek,
-  reject_retired_effect_label,
-  skip_derive,
-  skip_semi,
-  tk_name
-}
 
 export {
   _no_tb,

--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -173,7 +173,7 @@ fn parse_let_annotation(tokens: Array[Token], pos: Int, context: Option[ParserBi
   }
 }
 
-fn apply_fn_annotation_params(params: Array[(String, Option[TypeExpr])], param_types: Array[TypeExpr]) -> Array[(String, Option[TypeExpr])] {
+fn apply_fn_annotation_params(params: Array[(String, Option[TypeExpr])], param_types: Array[TypeExpr], context: Option[ParserBinderContext]) -> Array[(String, Option[TypeExpr])] {
   if Array::length(params) != Array::length(param_types) {
     params
   } else {
@@ -192,10 +192,10 @@ fn apply_fn_annotation_params(params: Array[(String, Option[TypeExpr])], param_t
   }
 }
 
-fn apply_generic_fn_annotation(type_params: Array[String], type_bounds: Array[(String, Array[String])], ann: Option[TypeExpr], val: Expr, param_types: Array[TypeExpr], ret_ty: TypeExpr, effect_name: Option[String]) -> (Option[TypeExpr], Expr) {
+fn apply_generic_fn_annotation(type_params: Array[String], type_bounds: Array[(String, Array[String])], ann: Option[TypeExpr], val: Expr, param_types: Array[TypeExpr], ret_ty: TypeExpr, effect_name: Option[String], context: Option[ParserBinderContext]) -> (Option[TypeExpr], Expr) {
   match val {
     EFn(existing_type_params, existing_type_bounds, params, ret_opt, effect_opt, body) => {
-      let next_params = apply_fn_annotation_params(params, param_types)
+      let next_params = apply_fn_annotation_params(params, param_types, context)
       let next_ret = match ret_opt {
         Some(_) => ret_opt,
         None => Some(ret_ty)
@@ -219,10 +219,10 @@ fn apply_generic_fn_annotation(type_params: Array[String], type_bounds: Array[(S
   }
 }
 
-fn apply_generic_let_annotation(type_params: Array[String], type_bounds: Array[(String, Array[String])], ann: Option[TypeExpr], val: Expr) -> (Option[TypeExpr], Expr) {
+fn apply_generic_let_annotation(type_params: Array[String], type_bounds: Array[(String, Array[String])], ann: Option[TypeExpr], val: Expr, context: Option[ParserBinderContext]) -> (Option[TypeExpr], Expr) {
   match ann {
     Some(ann_ty) => match ann_ty {
-      TyFn(param_types, ret_ty, effect_name) => apply_generic_fn_annotation(type_params, type_bounds, ann, val, param_types, ret_ty, effect_name),
+      TyFn(param_types, ret_ty, effect_name) => apply_generic_fn_annotation(type_params, type_bounds, ann, val, param_types, ret_ty, effect_name, context),
       _ => (ann, val)
     },
     _ => (ann, val)
@@ -235,7 +235,7 @@ fn apply_generic_let_annotation(type_params: Array[String], type_bounds: Array[(
 /// params: the body checked with `T` as a concrete `CtNamed("T")` rather than a
 /// bound type variable. That happened to work standalone (unresolved type names
 /// are tolerated) but broke once the module was re-exported and re-checked.
-fn apply_value_bracket_type_params(tps: Array[String], tbs: Array[(String, Array[String])], val: Expr) -> Expr {
+fn apply_value_bracket_type_params(tps: Array[String], tbs: Array[(String, Array[String])], val: Expr, context: Option[ParserBinderContext]) -> Expr {
   if Array::length(tps) == 0 {
     val
   } else {
@@ -374,7 +374,7 @@ fn reject_pattern_let_annotation(tokens: Array[Token], pos: Int) -> Int with Exc
 /// are not recovered by `parse_pattern` — the record path is positional, the
 /// same convention the block-level `__rec_field` desugar uses — so the marker
 /// carries empty names and the expansion reads by index.
-fn record_destr_marker(p: Pat) -> Pat {
+fn record_destr_marker(p: Pat, context: Option[ParserBinderContext]) -> Pat {
   match p {
     PTuple(elems) => {
       let fields = ArrayBuilder::new()
@@ -392,7 +392,7 @@ fn record_destr_marker(p: Pat) -> Pat {
 /// `SLetPat` carries no `exported` flag, so an exported pattern `let` has
 /// nowhere to record that; point at the two-statement spelling instead of
 /// silently dropping the export.
-fn top_level_pattern_let(exported: Bool, pat: Pat, val: Expr) -> Stmt with Exception {
+fn top_level_pattern_let(exported: Bool, pat: Pat, val: Expr, context: Option[ParserBinderContext]) -> Stmt with Exception {
   if exported {
     throw("top-level 'export let <pattern> = <expr>' is not supported (#1281); write 'let <pattern> = <expr>' and export the names with a separate 'export { a, b }'")
   } else {
@@ -413,7 +413,7 @@ fn top_level_pattern_let(exported: Bool, pat: Pat, val: Expr) -> Stmt with Excep
 /// level. Struct fields project by name (`<tmp>.field`); anonymous-record
 /// fields project positionally through `__rec_field`, the same read the
 /// block-level destructure emits.
-export fn expand_top_level_pattern_lets(stmts: Array[Stmt]) -> Array[Stmt] {
+export fn expand_top_level_pattern_lets_with_binder_context(stmts: Array[Stmt], context: Option[ParserBinderContext]) -> Array[Stmt] {
   let out = ArrayBuilder::new()
   let mut i = 0
   while i < Array::length(stmts) {
@@ -421,7 +421,7 @@ export fn expand_top_level_pattern_lets(stmts: Array[Stmt]) -> Array[Stmt] {
       SLetPat(pat, val) => {
         let tmp = String::concat("__dst", __to_string(i))
         ArrayBuilder::push(out, SLet(false, false, tmp, None, val))
-        emit_top_level_pat_bindings(out, pat, tmp)
+        emit_top_level_pat_bindings(out, pat, tmp, context)
       },
       _ => ArrayBuilder::push(out, Array::get(stmts, i))
     }
@@ -430,15 +430,19 @@ export fn expand_top_level_pattern_lets(stmts: Array[Stmt]) -> Array[Stmt] {
   ArrayBuilder::freeze(out)
 }
 
+export fn expand_top_level_pattern_lets(stmts: Array[Stmt]) -> Array[Stmt] {
+  expand_top_level_pattern_lets_with_binder_context(stmts, None)
+}
+
 /// Bind every name in `pat` from the already-bound `src` binding.
-fn emit_top_level_pat_bindings(out: ArrayBuilder[Stmt], pat: Pat, src: String) -> Unit {
+fn emit_top_level_pat_bindings(out: ArrayBuilder[Stmt], pat: Pat, src: String, context: Option[ParserBinderContext]) -> Unit {
   match pat {
     PBind(name) => ArrayBuilder::push(out, SLet(false, false, name, None, EIdent(src, 0 - 1))),
     PWild => (),
     PTuple(elems) => {
       let mut i = 0
       while i < Array::length(elems) {
-        emit_top_level_pat_projection(out, Array::get(elems, i), EDot(EIdent(src, 0 - 1), __to_string(i), 0 - 1, 0 - 1), src, i)
+        emit_top_level_pat_projection(out, Array::get(elems, i), EDot(EIdent(src, 0 - 1), __to_string(i), 0 - 1, 0 - 1), src, i, context)
         i = i + 1
       }
     },
@@ -454,7 +458,7 @@ fn emit_top_level_pat_bindings(out: ArrayBuilder[Stmt], pat: Pat, src: String) -
         } else {
           EDot(EIdent(src, 0 - 1), fname, 0 - 1, 0 - 1)
         }
-        emit_top_level_pat_projection(out, fpat, read, src, i)
+        emit_top_level_pat_projection(out, fpat, read, src, i, context)
         i = i + 1
       }
     },
@@ -465,14 +469,14 @@ fn emit_top_level_pat_bindings(out: ArrayBuilder[Stmt], pat: Pat, src: String) -
 /// One field of a destructured value: bind it directly when the sub-pattern is
 /// a name, drop it when it is `_`, otherwise park it in a hidden binding and
 /// keep destructuring from there.
-fn emit_top_level_pat_projection(out: ArrayBuilder[Stmt], sub: Pat, read: Expr, src: String, index: Int) -> Unit {
+fn emit_top_level_pat_projection(out: ArrayBuilder[Stmt], sub: Pat, read: Expr, src: String, index: Int, context: Option[ParserBinderContext]) -> Unit {
   match sub {
     PBind(name) => ArrayBuilder::push(out, SLet(false, false, name, None, read)),
     PWild => (),
     _ => {
       let nested = String::concat(src, String::concat("_", __to_string(index)))
       ArrayBuilder::push(out, SLet(false, false, nested, None, read))
-      emit_top_level_pat_bindings(out, sub, nested)
+      emit_top_level_pat_bindings(out, sub, nested, context)
     }
   }
 }
@@ -491,8 +495,8 @@ export fn parse_let_stmt_with_binder_context(tokens: Array[Token], starts: Array
       let ep = expect_tk(tokens, eq_pos, "=")
       let (bracket_tps, bracket_tbs, val_start_r) = parse_value_bracket_header(tokens, ep, context)
       let val_pair = parse_impl_with_binder_context(tokens, starts, val_start_r, 0, context)
-      let val_with_tp = apply_value_bracket_type_params(bracket_tps, bracket_tbs, val_pair.0)
-      let (final_ty_opt, val) = apply_generic_let_annotation(type_params, type_bounds, ty_opt, val_with_tp)
+      let val_with_tp = apply_value_bracket_type_params(bracket_tps, bracket_tbs, val_pair.0, context)
+      let (final_ty_opt, val) = apply_generic_let_annotation(type_params, type_bounds, ty_opt, val_with_tp, context)
       let val_next = val_pair.1
       (SLet(exported, true, name, final_ty_opt, val), val_next)
     },
@@ -527,7 +531,7 @@ export fn parse_let_stmt_with_binder_context(tokens: Array[Token], starts: Array
       require_irrefutable_top_level_pat(pat)
       let ep = expect_tk(tokens, reject_pattern_let_annotation(tokens, after_pat), "=")
       let val_pair = parse_impl_with_binder_context(tokens, starts, ep, 0, context)
-      (top_level_pattern_let(exported, pat, val_pair.0), val_pair.1)
+      (top_level_pattern_let(exported, pat, val_pair.0, context), val_pair.1)
     },
     TIdent(_name0) => {
       // #1281 (was #830): `let record { a, b } = r` — the anonymous-record
@@ -559,11 +563,11 @@ export fn parse_let_stmt_with_binder_context(tokens: Array[Token], starts: Array
         let pep = expect_tk(tokens, reject_pattern_let_annotation(tokens, after_ppat), "=")
         let pval_pair = parse_impl_with_binder_context(tokens, starts, pep, 0, context)
         let marked = if is_top_level_record_destr {
-          record_destr_marker(ppat)
+          record_destr_marker(ppat, context)
         } else {
           ppat
         }
-        (top_level_pattern_let(exported, marked, pval_pair.0), pval_pair.1)
+        (top_level_pattern_let(exported, marked, pval_pair.0, context), pval_pair.1)
       } else {
         // `let Some(x) = e` and friends: a variant pattern reads as a binding
         // name followed by `(`, which used to surface as a bare
@@ -591,8 +595,8 @@ export fn parse_let_stmt_with_binder_context(tokens: Array[Token], starts: Array
         let ep = expect_tk(tokens, eq_pos, "=")
         let (bracket_tps, bracket_tbs, val_start) = parse_value_bracket_header(tokens, ep, context)
         let val_pair = parse_impl_with_binder_context(tokens, starts, val_start, 0, context)
-        let val_with_tp = apply_value_bracket_type_params(bracket_tps, bracket_tbs, val_pair.0)
-        let (final_ty_opt, val) = apply_generic_let_annotation(type_params, type_bounds, ty_opt, val_with_tp)
+        let val_with_tp = apply_value_bracket_type_params(bracket_tps, bracket_tbs, val_pair.0, context)
+        let (final_ty_opt, val) = apply_generic_let_annotation(type_params, type_bounds, ty_opt, val_with_tp, context)
         let val_next = val_pair.1
         (SLet(exported, false, name, final_ty_opt, val), val_next)
       }
@@ -767,7 +771,7 @@ export fn parse_fn_stmt_with_binder_context(tokens: Array[Token], starts: Array[
 /// strings). v0.3 slice restrictions enforced here: monomorphic, empty
 /// effect row, no where-contracts, and every param + the return type spelled
 /// literally `Int` (raw 62-bit tagged i64 at the boundary, ADR-0055).
-fn parse_fn_wasm_body(tokens: Array[Token], pos: Int, exported: Bool, name: String, tps: Array[String], tbs: Array[(String, Array[String])], params: Array[(String, Option[TypeExpr])], ret_ty: TypeExpr, eff_opt: Option[String], reqs: Array[Expr], enss: Array[Expr]) -> (Stmt, Int) with Exception {
+fn parse_fn_wasm_body(tokens: Array[Token], pos: Int, exported: Bool, name: String, tps: Array[String], tbs: Array[(String, Array[String])], params: Array[(String, Option[TypeExpr])], ret_ty: TypeExpr, eff_opt: Option[String], reqs: Array[Expr], enss: Array[Expr], context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   // pos is at the token AFTER `= wasm`.
   if Array::length(tps) > 0 {
     throw("inline wasm fn '\{name}' cannot take type parameters (v0.3: monomorphic only) at #\{pos}")
@@ -849,7 +853,7 @@ fn parse_fn_stmt_general(tokens: Array[Token], starts: Array[Int], pos: Int, exp
     _ => false
   }
   if is_wasm_body {
-    parse_fn_wasm_body(tokens, where_next + 2, exported, name, tps, tbs, params, ret_ty, eff_opt, reqs, enss)
+    parse_fn_wasm_body(tokens, where_next + 2, exported, name, tps, tbs, params, ret_ty, eff_opt, reqs, enss, context)
   } else {
     let br = expect_tk(tokens, where_next, "{")
     let (body, end) = parse_impl_with_binder_context(tokens, starts, br, mode_block, context)
@@ -874,7 +878,7 @@ fn parse_fn_stmt_general(tokens: Array[Token], starts: Array[Int], pos: Int, exp
 /// (parse_stmt / parse_program*) so checker/codegen keep seeing the
 /// pre-#727 `SLet(exported, true, name, None, EFn(..))` shape; only the
 /// *_preserving entry points hand out SFnDecl.
-export fn lower_fn_decl_stmt(stmt: Stmt) -> Stmt {
+export fn lower_fn_decl_stmt_with_binder_context(stmt: Stmt, context: Option[ParserBinderContext]) -> Stmt {
   match stmt {
     SFnDecl(exported, name, fn_value, reqs, enss) => match fn_value {
       EFn(tps, tbs, params, ret_opt, eff_opt, body) => {
@@ -912,41 +916,17 @@ export fn lower_fn_decl_stmt(stmt: Stmt) -> Stmt {
   }
 }
 
+export fn lower_fn_decl_stmt(stmt: Stmt) -> Stmt {
+  lower_fn_decl_stmt_with_binder_context(stmt, None)
+}
+
 export fn lower_fn_decl_stmts(stmts: Array[Stmt]) -> Array[Stmt] {
   for s in stmts {
-    lower_fn_decl_stmt(s)
+    lower_fn_decl_stmt_with_binder_context(s, None)
   }
 }
 
 //# Misc
-
-export {
-  collect_import_path,
-  empty_fields,
-  empty_import_items,
-  expand_top_level_pattern_lets,
-  expect_tk,
-  is_tk,
-  lower_fn_decl_stmt,
-  lower_fn_decl_stmts,
-  parse,
-  parse_effect_stmt,
-  parse_enum_stmt,
-  parse_expr,
-  parse_fn_stmt_with_binder_context,
-  parse_impl,
-  parse_impl_stmt_dispatch,
-  parse_import_item,
-  parse_let_stmt_with_binder_context,
-  parse_ok,
-  parse_struct_field,
-  parse_suberror_stmt,
-  parse_trait_stmt,
-  parse_type,
-  parse_type_alias_stmt,
-  peek,
-  tk_name
-}
 
 export {
   collect_import_path,

--- a/lib/@vibe/parser/parser_expr_core.vibe
+++ b/lib/@vibe/parser/parser_expr_core.vibe
@@ -273,7 +273,7 @@ fn slice_from_zero_expr(cur_expr: Expr, end_expr: Expr) -> Expr {
   ECall(EIdent("__slice", -1), args, -1)
 }
 
-fn wrap_placeholder_arg(arg: Expr) -> Expr {
+fn wrap_placeholder_arg(arg: Expr, context: Option[ParserBinderContext]) -> Expr {
   let mut pc = 0
   let params = Array::slice([
     ("", None)
@@ -353,7 +353,7 @@ fn has_non_pipe_infix_top(tokens: Array[Token], start: Int, end: Int) -> Bool {
   go(start, 0, false)
 }
 
-fn desugar_placeholder_args(args: Array[Expr]) -> Array[Expr] {
+fn desugar_placeholder_args(args: Array[Expr], context: Option[ParserBinderContext]) -> Array[Expr] {
   let out = Array::slice([
     EUnit
   ], 0, 0)
@@ -365,7 +365,7 @@ fn desugar_placeholder_args(args: Array[Expr]) -> Array[Expr] {
       // piped value at this position; compound placeholders still lower.
       Array::push(out, arg)
     } else if has_placeholder_arg(arg) {
-      Array::push(out, wrap_placeholder_arg(arg))
+      Array::push(out, wrap_placeholder_arg(arg, context))
     } else {
       Array::push(out, arg)
     }
@@ -477,7 +477,7 @@ fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr,
           let (args, end_pos) = parse_call_args_rest(tokens, starts, next_pos, b, parse_recur, context)
           let close_pos = expect_tk(tokens, end_pos, ")")
           let call_args = if has_placeholder_args(args) {
-            desugar_placeholder_args(args)
+            desugar_placeholder_args(args, context)
           } else {
             args
           }

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -37,7 +37,7 @@ import ./parser_binder_context.vibe {
 /// `ty` (enforced by the call-argument check) while evaluating to `val` itself.
 /// Used to type-check a local `let x: T = e`, whose annotation `ELet` cannot
 /// store. Uses only EFn/ECall, so every downstream pass handles it unchanged.
-fn ascribe_wrap(val: Expr, ty: TypeExpr) -> Expr {
+fn ascribe_wrap(val: Expr, ty: TypeExpr, context: Option[ParserBinderContext]) -> Expr {
   let tparams = Array::slice([
     ""
   ], 0, 0)
@@ -66,7 +66,7 @@ fn ascribe_wrap(val: Expr, ty: TypeExpr) -> Expr {
 /// Returns None when the annotation is not a TyFn, the value is not a lambda,
 /// or the arity does not match; callers fall back to ascribe_wrap (plain let)
 /// or the bare value (let rec, which previously discarded the annotation).
-fn distribute_local_fn_ann(ann_ty: TypeExpr, val: Expr) -> Option[Expr] {
+fn distribute_local_fn_ann(ann_ty: TypeExpr, val: Expr, context: Option[ParserBinderContext]) -> Option[Expr] {
   match ann_ty {
     TyFn(param_types, ret_ty, effect_name) => match val {
       EFn(tp, tb, params, ret_opt, effect_opt, body) => {
@@ -101,11 +101,8 @@ fn distribute_local_fn_ann(ann_ty: TypeExpr, val: Expr) -> Option[Expr] {
   }
 }
 
-/// #789: `[T: A + B]` per-param trait-bound names (first name at `pos`). Private
-/// copy of parser_base.parse_method_tp_bound_names (not re-exportable across the
-/// package contract boundary). Bound names are references, not binders; context
-/// is untrusted plumbing only.
-fn dispatch_tp_bound_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
+/// #789: `[T: A + B]` trait references (first name at `pos`).
+fn dispatch_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
   let b = ArrayBuilder::new()
   let mut p = pos
   let mut done = false
@@ -129,10 +126,6 @@ fn dispatch_tp_bound_names_with_binder_context(tokens: Array[Token], pos: Int, c
   (ArrayBuilder::freeze(b), p)
 }
 
-fn dispatch_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
-  dispatch_tp_bound_names_with_binder_context(tokens, pos, None)
-}
-
 /// #789: parse a `[T, U: Bound]` binder (`[` already consumed; first name token at
 /// `pos`). Private copy of parser_base.parse_method_type_params. Returns
 /// (type-param names, per-param bounds, next-after-`]`).
@@ -152,7 +145,7 @@ fn dispatch_type_params_with_binder_context(tokens: Array[Token], pos: Int, cont
         p = p + 1
         match peek(tokens, p) {
           TColon => {
-            let (bound_names, next) = dispatch_tp_bound_names_with_binder_context(tokens, p + 1, context)
+            let (bound_names, next) = dispatch_tp_bound_names(tokens, p + 1)
             ArrayBuilder::push(bounds, (name, bound_names))
             p = next
           },
@@ -173,10 +166,6 @@ fn dispatch_type_params_with_binder_context(tokens: Array[Token], pos: Int, cont
     }
   }
   (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
-}
-
-fn dispatch_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
-  dispatch_type_params_with_binder_context(tokens, pos, None)
 }
 
 /// #789: parse a local `let f: TYPE = ..` annotation, consuming an optional
@@ -207,14 +196,10 @@ fn parse_local_let_annotation_with_binder_context(tokens: Array[Token], pos: Int
   }
 }
 
-fn parse_local_let_annotation(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], TypeExpr, Int) with Exception {
-  parse_local_let_annotation_with_binder_context(tokens, pos, None)
-}
-
 /// #789: attach a local generic-let's `[T]` binder to its (annotation-distributed)
 /// lambda, mirroring apply_generic_fn_annotation so the local function stays
 /// polymorphic. No-op when there are no type params or the value is not a lambda.
-fn apply_local_let_tp(tps: Array[String], tbs: Array[(String, Array[String])], val: Expr) -> Expr {
+fn apply_local_let_tp(tps: Array[String], tbs: Array[(String, Array[String])], val: Expr, context: Option[ParserBinderContext]) -> Expr {
   if Array::length(tps) > 0 {
     match val {
       EFn(_, _, params, ret, eff, body) => EFn(tps, tbs, params, ret, eff, body),
@@ -259,12 +244,12 @@ enum BlockStep {
 /// guard's Bool-check and codegen come for free via `EIf`. `scrut` must be a
 /// re-evaluable reference (the caller binds the scrutinee to a temp), so the
 /// nested match never re-runs a side-effecting scrutinee.
-fn desugar_guarded(arms: Array[(Pat, Expr, Expr)], i: Int, scrut: Expr) -> Array[(Pat, Expr)] {
+fn desugar_guarded(arms: Array[(Pat, Expr, Expr)], i: Int, scrut: Expr, context: Option[ParserBinderContext]) -> Array[(Pat, Expr)] {
   if i >= Array::length(arms) {
     empty_arms()
   } else {
     let (pat, arm_guard, body) = Array::get(arms, i)
-    let rest = desugar_guarded(arms, i + 1, scrut)
+    let rest = desugar_guarded(arms, i + 1, scrut, context)
     let no_guard = match arm_guard {
       EBool(bv) => bv,
       _ => false
@@ -312,21 +297,21 @@ fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: Arr
   }
 }
 
-fn qualify_handle_arm_pattern(effect_name: String, pat: Pat) -> Pat {
+fn qualify_handle_arm_pattern(effect_name: String, pat: Pat, context: Option[ParserBinderContext]) -> Pat {
   match pat {
     PCtor(name, args) => if String::contains(name, "::") {
       PCtor(name, args)
     } else {
       PCtor(String::concat(effect_name, String::concat("::", name)), args)
     },
-    POr(left, right) => POr(qualify_handle_arm_pattern(effect_name, left), qualify_handle_arm_pattern(effect_name, right)),
+    POr(left, right) => POr(qualify_handle_arm_pattern(effect_name, left, context), qualify_handle_arm_pattern(effect_name, right, context)),
     _ => pat
   }
 }
 
 fn parse_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, effect_name: String, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> ((Pat, Expr), Int) with Exception {
   let (pat, pat_next) = parse_pattern_with_binder_context(tokens, pos, context)
-  let qualified_pat = qualify_handle_arm_pattern(effect_name, pat)
+  let qualified_pat = qualify_handle_arm_pattern(effect_name, pat, context)
   let arrow_pos = expect_tk(tokens, pat_next, "=>")
   let (expr, next) = parse_recur(tokens, arrow_pos, 0, context)
   ((qualified_pat, expr), next)
@@ -482,7 +467,7 @@ fn parse_block_value_only(tokens: Array[Token], value_pos: Int, parse_recur: (Ar
   (val_pair.0, skip_semi(tokens, val_pair.1))
 }
 
-fn apply_struct_destr(pat: Pat, val: Expr, rest: Expr) -> Expr {
+fn apply_struct_destr(pat: Pat, val: Expr, rest: Expr, context: Option[ParserBinderContext]) -> Expr {
   let val_name = "__struct_destr"
   let mut desugar = rest
   match pat {
@@ -504,7 +489,7 @@ fn apply_struct_destr(pat: Pat, val: Expr, rest: Expr) -> Expr {
   ELet(val_name, val, desugar, -1)
 }
 
-fn apply_record_destr(pat: Pat, val: Expr, rest: Expr) -> Expr {
+fn apply_record_destr(pat: Pat, val: Expr, rest: Expr, context: Option[ParserBinderContext]) -> Expr {
   let val_name = "__rec_destr"
   let mut desugar = rest
   match pat {
@@ -546,7 +531,7 @@ fn apply_record_destr(pat: Pat, val: Expr, rest: Expr) -> Expr {
   ELet(val_name, val, desugar, -1)
 }
 
-fn apply_block_step(step: BlockStep, rest: Expr) -> Expr {
+fn apply_block_step(step: BlockStep, rest: Expr, context: Option[ParserBinderContext]) -> Expr {
   match step {
     StepSeq(expr) => ESeq(expr, rest),
     StepValue(expr) => expr,
@@ -566,8 +551,8 @@ fn apply_block_step(step: BlockStep, rest: Expr) -> Expr {
       (pat, rest),
       (PWild, alt)
     ]),
-    StepStructDestr(pat, val) => apply_struct_destr(pat, val, rest),
-    StepRecordDestr(pat, val) => apply_record_destr(pat, val, rest),
+    StepStructDestr(pat, val) => apply_struct_destr(pat, val, rest, context),
+    StepRecordDestr(pat, val) => apply_record_destr(pat, val, rest, context),
     // `let* x = e` (railway bind, #635): short-circuit on the failure case,
     // continue on the success case. The parser has no type info, so it emits a
     // type-directed sentinel `__try_bind(val, (x) -> rest)` that the pre-check
@@ -591,11 +576,11 @@ fn apply_block_step(step: BlockStep, rest: Expr) -> Expr {
   }
 }
 
-fn fold_block_steps(steps: Array[BlockStep]) -> Expr {
+fn fold_block_steps(steps: Array[BlockStep], context: Option[ParserBinderContext]) -> Expr {
   let mut result = EUnit
   let mut i = Array::length(steps) - 1
   while i >= 0 {
-    result = apply_block_step(Array::get(steps, i), result)
+    result = apply_block_step(Array::get(steps, i), result, context)
     i = i - 1
   }
   result
@@ -704,7 +689,7 @@ fn reject_let_else(tokens: Array[Token], pos: Int) -> Int with Exception {
 }
 
 /// Push a refutable pattern-let step. Returns the position past it.
-fn push_pattern_let_step(tokens: Array[Token], steps: ArrayBuilder[BlockStep], pat: Pat, val: Expr, next_pos: Int) -> Int with Exception {
+fn push_pattern_let_step(tokens: Array[Token], steps: ArrayBuilder[BlockStep], pat: Pat, val: Expr, next_pos: Int, context: Option[ParserBinderContext]) -> Int with Exception {
   let after = reject_let_else(tokens, next_pos)
   ArrayBuilder::push(steps, StepPattern(pat, val))
   after
@@ -787,8 +772,8 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                 // wrapped value would break letrec's direct-lambda shape).
                 // #789: re-attach a `[T]` binder to the distributed lambda.
                 let val2 = match rec_ann {
-                  Some(the_type) => match distribute_local_fn_ann(the_type, val) {
-                    Some(distributed) => apply_local_let_tp(rtps, rtbs, distributed),
+                  Some(the_type) => match distribute_local_fn_ann(the_type, val, context) {
+                    Some(distributed) => apply_local_let_tp(rtps, rtbs, distributed, context),
                     None => val
                   },
                   None => val
@@ -818,9 +803,9 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                 throw("internal parser error: block let-mut parser did not advance")
               } else {
                 let val2 = match m_ann {
-                  Some(the_type) => match distribute_local_fn_ann(the_type, val) {
+                  Some(the_type) => match distribute_local_fn_ann(the_type, val, context) {
                     Some(distributed) => distributed,
-                    None => ascribe_wrap(val, the_type)
+                    None => ascribe_wrap(val, the_type, context)
                   },
                   None => val
                 }
@@ -884,7 +869,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                   if next_pos <= eq {
                     throw("internal parser error: block let-ctor-pat parser did not advance")
                   } else {
-                    p = push_pattern_let_step(tokens, steps, pat, val, next_pos)
+                    p = push_pattern_let_step(tokens, steps, pat, val, next_pos, context)
                   }
                 },
                 _ => {
@@ -922,9 +907,9 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                     // Perceus param heap-inference sees the param types. #789: a
                     // `[T]` binder is re-attached to the distributed lambda.
                     let val2 = match ann_type {
-                      Some(the_type) => match distribute_local_fn_ann(the_type, val) {
-                        Some(distributed) => apply_local_let_tp(ltps, ltbs, distributed),
-                        None => ascribe_wrap(val, the_type)
+                      Some(the_type) => match distribute_local_fn_ann(the_type, val, context) {
+                        Some(distributed) => apply_local_let_tp(ltps, ltbs, distributed, context),
+                        None => ascribe_wrap(val, the_type, context)
                       },
                       None => val
                     }
@@ -942,7 +927,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             if next_pos <= eq {
               throw("internal parser error: block let-pat parser did not advance")
             } else {
-              p = push_pattern_let_step(tokens, steps, pat, val, next_pos)
+              p = push_pattern_let_step(tokens, steps, pat, val, next_pos, context)
             }
           },
           _ => throw("expected identifier after 'let'")
@@ -1061,7 +1046,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
       }
     }
   }
-  (fold_block_steps(ArrayBuilder::freeze(steps)), end_pos)
+  (fold_block_steps(ArrayBuilder::freeze(steps), context), end_pos)
 }
 
 // #1350: `for await x in s` was RETIRED. It parsed to
@@ -1137,7 +1122,7 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
         let endpos = collect_match_arms(tokens, starts, br, ab, hg, parse_recur, context)
         let arms3 = ArrayBuilder::freeze(ab)
         if Array::get(hg, 0) {
-          let final_arms = desugar_guarded(arms3, 0, EIdent("__mg", 0 - 1))
+          let final_arms = desugar_guarded(arms3, 0, EIdent("__mg", 0 - 1), context)
           (ELet("__mg", scrutinee, EMatch(EIdent("__mg", 0 - 1), final_arms), -1), endpos)
         } else {
           let plain = ArrayBuilder::new()

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -50,7 +50,7 @@ fn map_located_off(off: Int, f: (Int) -> Int) -> Int {
   }
 }
 
-fn map_expr_offsets(expr: Expr, f: (Int) -> Int) -> Expr {
+fn map_expr_offsets(expr: Expr, f: (Int) -> Int, context: Option[ParserBinderContext]) -> Expr {
   {
     match expr {
       EInt(_) => expr,
@@ -59,64 +59,57 @@ fn map_expr_offsets(expr: Expr, f: (Int) -> Int) -> Expr {
       EBool(_) => expr,
       EUnit => expr,
       EIdent(name, off) => EIdent(name, map_located_off(off, f)),
-      ETuple(items) => ETuple(map_exprs(items, f)),
-      EArray(items) => EArray(map_exprs(items, f)),
-      ERecord(rn, fields, targs) => ERecord(rn, map_field_exprs(fields, f), targs),
-      EIf(c, t, e) => EIf(map_expr_offsets(c, f), map_expr_offsets(t, f), map_expr_offsets(e, f)),
-      ELet(n, v, b, soff) => ELet(n, map_expr_offsets(v, f), map_expr_offsets(b, f), map_located_off(soff, f)),
-      ELetRec(n, v, b) => ELetRec(n, map_expr_offsets(v, f), map_expr_offsets(b, f)),
-      ELetMut(n, v, b, soff) => ELetMut(n, map_expr_offsets(v, f), map_expr_offsets(b, f), map_located_off(soff, f)),
-      EAssign(n, v, b) => EAssign(n, map_expr_offsets(v, f), map_expr_offsets(b, f)),
-      EAssignOp(n, op, v, b) => EAssignOp(n, op, map_expr_offsets(v, f), map_expr_offsets(b, f)),
-      ESeq(a, b) => ESeq(map_expr_offsets(a, f), map_expr_offsets(b, f)),
-      EMatch(s, arms) => EMatch(map_expr_offsets(s, f), map_arm_exprs(arms, f)),
-      EHandle(s, arms) => EHandle(map_expr_offsets(s, f), map_arm_exprs(arms, f)),
-      EWhile(c, b) => EWhile(map_expr_offsets(c, f), map_expr_offsets(b, f)),
-      ELoop(params, b) => ELoop(map_loop_param_exprs(params, f), map_expr_offsets(b, f)),
-      EForIn(n, idx, it, b) => EForIn(n, idx, map_expr_offsets(it, f), map_expr_offsets(b, f)),
-      ECall(callee, args, off) => ECall(map_expr_offsets(callee, f), map_exprs(args, f), map_located_off(off, f)),
-      EBinOp(op, l, r) => EBinOp(op, map_expr_offsets(l, f), map_expr_offsets(r, f)),
-      EUnaryOp(op, e) => EUnaryOp(op, map_expr_offsets(e, f)),
-      EFn(tp, tb, params, ret, eff, body) => EFn(tp, tb, params, ret, eff, map_expr_offsets(body, f)),
-      EDot(e, field, off, fdoff) => EDot(map_expr_offsets(e, f), field, map_located_off(off, f), map_located_off(fdoff, f)),
-      ELabeledArg(l, n, v) => ELabeledArg(l, n, map_expr_offsets(v, f)),
-      EReturn(e) => EReturn(map_expr_offsets(e, f)),
+      ETuple(items) => ETuple(map_exprs(items, f, context)),
+      EArray(items) => EArray(map_exprs(items, f, context)),
+      ERecord(rn, fields, targs) => ERecord(rn, map_named_exprs(fields, f, context), targs),
+      EIf(c, t, e) => EIf(map_expr_offsets(c, f, context), map_expr_offsets(t, f, context), map_expr_offsets(e, f, context)),
+      ELet(n, v, b, soff) => ELet(n, map_expr_offsets(v, f, context), map_expr_offsets(b, f, context), map_located_off(soff, f)),
+      ELetRec(n, v, b) => ELetRec(n, map_expr_offsets(v, f, context), map_expr_offsets(b, f, context)),
+      ELetMut(n, v, b, soff) => ELetMut(n, map_expr_offsets(v, f, context), map_expr_offsets(b, f, context), map_located_off(soff, f)),
+      EAssign(n, v, b) => EAssign(n, map_expr_offsets(v, f, context), map_expr_offsets(b, f, context)),
+      EAssignOp(n, op, v, b) => EAssignOp(n, op, map_expr_offsets(v, f, context), map_expr_offsets(b, f, context)),
+      ESeq(a, b) => ESeq(map_expr_offsets(a, f, context), map_expr_offsets(b, f, context)),
+      EMatch(s, arms) => EMatch(map_expr_offsets(s, f, context), map_arm_exprs(arms, f, context)),
+      EHandle(s, arms) => EHandle(map_expr_offsets(s, f, context), map_arm_exprs(arms, f, context)),
+      EWhile(c, b) => EWhile(map_expr_offsets(c, f, context), map_expr_offsets(b, f, context)),
+      ELoop(params, b) => ELoop(map_named_exprs(params, f, context), map_expr_offsets(b, f, context)),
+      EForIn(n, idx, it, b) => EForIn(n, idx, map_expr_offsets(it, f, context), map_expr_offsets(b, f, context)),
+      ECall(callee, args, off) => ECall(map_expr_offsets(callee, f, context), map_exprs(args, f, context), map_located_off(off, f)),
+      EBinOp(op, l, r) => EBinOp(op, map_expr_offsets(l, f, context), map_expr_offsets(r, f, context)),
+      EUnaryOp(op, e) => EUnaryOp(op, map_expr_offsets(e, f, context)),
+      EFn(tp, tb, params, ret, eff, body) => EFn(tp, tb, params, ret, eff, map_expr_offsets(body, f, context)),
+      EDot(e, field, off, fdoff) => EDot(map_expr_offsets(e, f, context), field, map_located_off(off, f), map_located_off(fdoff, f)),
+      ELabeledArg(l, n, v) => ELabeledArg(l, n, map_expr_offsets(v, f, context)),
+      EReturn(e) => EReturn(map_expr_offsets(e, f, context)),
       EBreak(opt) => match opt {
-        Some(v) => EBreak(Some(map_expr_offsets(v, f))),
+        Some(v) => EBreak(Some(map_expr_offsets(v, f, context))),
         None => expr
       },
-      EContinue(args) => EContinue(map_exprs(args, f)),
-      EMap(fields) => EMap(map_field_exprs(fields, f)),
-      ESpread(e) => ESpread(map_expr_offsets(e, f)),
+      EContinue(args) => EContinue(map_exprs(args, f, context)),
+      EMap(fields) => EMap(map_named_exprs(fields, f, context)),
+      ESpread(e) => ESpread(map_expr_offsets(e, f, context)),
       EStringInterp(_) => expr
     }
   }
 }
 
-fn map_exprs(items: Array[Expr], f: (Int) -> Int) -> Array[Expr] {
+fn map_exprs(items: Array[Expr], f: (Int) -> Int, context: Option[ParserBinderContext]) -> Array[Expr] {
   for it in items {
-    map_expr_offsets(it, f)
+    map_expr_offsets(it, f, context)
   }
 }
 
-fn map_field_exprs(fields: Array[(String, Expr)], f: (Int) -> Int) -> Array[(String, Expr)] {
+fn map_named_exprs(fields: Array[(String, Expr)], f: (Int) -> Int, context: Option[ParserBinderContext]) -> Array[(String, Expr)] {
   for fld in fields {
     let (n, v) = fld
-    (n, map_expr_offsets(v, f))
+    (n, map_expr_offsets(v, f, context))
   }
 }
 
-fn map_arm_exprs(arms: Array[(Pat, Expr)], f: (Int) -> Int) -> Array[(Pat, Expr)] {
+fn map_arm_exprs(arms: Array[(Pat, Expr)], f: (Int) -> Int, context: Option[ParserBinderContext]) -> Array[(Pat, Expr)] {
   for a in arms {
     let (p, e) = a
-    (p, map_expr_offsets(e, f))
-  }
-}
-
-fn map_loop_param_exprs(params: Array[(String, Expr)], f: (Int) -> Int) -> Array[(String, Expr)] {
-  for p in params {
-    let (n, init) = p
-    (n, map_expr_offsets(init, f))
+    (p, map_expr_offsets(e, f, context))
   }
 }
 
@@ -209,7 +202,7 @@ fn build_interp_expr(parts: Array[String], offsets: Array[Int], outer_starts: Ar
         -1
       }
       let pe = if frag_off >= 0 {
-        map_expr_offsets(pe0, (o) -> remap_frag_off(o, outer_starts, fstarts, frag_off))
+        map_expr_offsets(pe0, (o) -> remap_frag_off(o, outer_starts, fstarts, frag_off), context)
       } else {
         pe0
       }
@@ -258,10 +251,10 @@ fn join_loop_params(param_names: Array[String]) -> String {
 /// infinite loop, the same failure mode #808 fixed for match arms), and too
 /// few updated a positional PREFIX of the parameters and left the rest
 /// unchanged, which no document ever specified.
-fn desugar_loop_body(expr: Expr, param_names: Array[String]) -> Expr with Exception {
+fn desugar_loop_body(expr: Expr, param_names: Array[String], context: Option[ParserBinderContext]) -> Expr with Exception {
   match expr {
     EBreak(opt) => match opt {
-      Some(val) => EAssign("__loop_result", desugar_loop_body(val, param_names), EBreak(None)),
+      Some(val) => EAssign("__loop_result", desugar_loop_body(val, param_names, context), EBreak(None)),
       None => EBreak(None)
     },
     EContinue(args) => {
@@ -284,7 +277,7 @@ fn desugar_loop_body(expr: Expr, param_names: Array[String]) -> Expr with Except
           }
           let mut ci2 = nargs - 1
           while ci2 >= 0 {
-            result = ELet(String::concat("__lt", __to_string(ci2)), desugar_loop_body(Array::get(args, ci2), param_names), result, -1)
+            result = ELet(String::concat("__lt", __to_string(ci2)), desugar_loop_body(Array::get(args, ci2), param_names, context), result, -1)
             ci2 = ci2 - 1
           }
           result
@@ -294,11 +287,11 @@ fn desugar_loop_body(expr: Expr, param_names: Array[String]) -> Expr with Except
     EWhile(_, _) => expr,
     ELoop(_, _) => expr,
     EFn(_, _, _, _, _, _) => expr,
-    EIf(c, t, e) => EIf(desugar_loop_body(c, param_names), desugar_loop_body(t, param_names), desugar_loop_body(e, param_names)),
-    ELet(n, v, b, soff) => ELet(n, desugar_loop_body(v, param_names), desugar_loop_body(b, param_names), soff),
-    ELetMut(n, v, b, soff) => ELetMut(n, desugar_loop_body(v, param_names), desugar_loop_body(b, param_names), soff),
-    ESeq(a, b) => ESeq(desugar_loop_body(a, param_names), desugar_loop_body(b, param_names)),
-    EAssign(n, v, c) => EAssign(n, desugar_loop_body(v, param_names), desugar_loop_body(c, param_names)),
+    EIf(c, t, e) => EIf(desugar_loop_body(c, param_names, context), desugar_loop_body(t, param_names, context), desugar_loop_body(e, param_names, context)),
+    ELet(n, v, b, soff) => ELet(n, desugar_loop_body(v, param_names, context), desugar_loop_body(b, param_names, context), soff),
+    ELetMut(n, v, b, soff) => ELetMut(n, desugar_loop_body(v, param_names, context), desugar_loop_body(b, param_names, context), soff),
+    ESeq(a, b) => ESeq(desugar_loop_body(a, param_names, context), desugar_loop_body(b, param_names, context)),
+    EAssign(n, v, c) => EAssign(n, desugar_loop_body(v, param_names, context), desugar_loop_body(c, param_names, context)),
     // #808: recurse into match/handle arm bodies so `break v` / `continue(args)`
     // inside an arm get the loop desugar (the raw EBreak/EContinue otherwise
     // reach codegen with their payloads dropped — `continue(i + 1)` looped
@@ -306,38 +299,38 @@ fn desugar_loop_body(expr: Expr, param_names: Array[String]) -> Expr with Except
     // was a workaround for the retired MoonBit host (#594) crashing on
     // (Pat, Expr) tuple ops; the selfhost parser handles arm tuples fine
     // (same idiom as expand_interp.vibe). Patterns are left untouched.
-    EMatch(s, arms) => EMatch(desugar_loop_body(s, param_names), for a in arms {
+    EMatch(s, arms) => EMatch(desugar_loop_body(s, param_names, context), for a in arms {
       let (p, ex) = a
-      (p, desugar_loop_body(ex, param_names))
+      (p, desugar_loop_body(ex, param_names, context))
     }),
-    EHandle(body, arms) => EHandle(desugar_loop_body(body, param_names), for a in arms {
+    EHandle(body, arms) => EHandle(desugar_loop_body(body, param_names, context), for a in arms {
       let (p, ex) = a
-      (p, desugar_loop_body(ex, param_names))
+      (p, desugar_loop_body(ex, param_names, context))
     }),
-    EBinOp(op, l, r) => EBinOp(op, desugar_loop_body(l, param_names), desugar_loop_body(r, param_names)),
-    ECall(callee, args, off) => ECall(desugar_loop_body(callee, param_names), for arg in args {
-      desugar_loop_body(arg, param_names)
+    EBinOp(op, l, r) => EBinOp(op, desugar_loop_body(l, param_names, context), desugar_loop_body(r, param_names, context)),
+    ECall(callee, args, off) => ECall(desugar_loop_body(callee, param_names, context), for arg in args {
+      desugar_loop_body(arg, param_names, context)
     }, off),
     ETuple(items) => ETuple(for item in items {
-      desugar_loop_body(item, param_names)
+      desugar_loop_body(item, param_names, context)
     }),
     EArray(items) => EArray(for item in items {
-      desugar_loop_body(item, param_names)
+      desugar_loop_body(item, param_names, context)
     }),
     ERecord(name, fields, targs) => ERecord(name, for field in fields {
       let (field_name, value) = field
-      (field_name, desugar_loop_body(value, param_names))
+      (field_name, desugar_loop_body(value, param_names, context))
     }, targs),
     EMap(fields) => EMap(for field in fields {
       let (field_name, value) = field
-      (field_name, desugar_loop_body(value, param_names))
+      (field_name, desugar_loop_body(value, param_names, context))
     }),
-    ELabeledArg(label, name, value) => ELabeledArg(label, name, desugar_loop_body(value, param_names)),
-    ESpread(value) => ESpread(desugar_loop_body(value, param_names)),
-    ELetRec(n, v, b) => ELetRec(n, desugar_loop_body(v, param_names), desugar_loop_body(b, param_names)),
-    EUnaryOp(op, e) => EUnaryOp(op, desugar_loop_body(e, param_names)),
-    EDot(obj, field, off, fdoff) => EDot(desugar_loop_body(obj, param_names), field, off, fdoff),
-    EAssignOp(n, op, v, c) => EAssignOp(n, op, desugar_loop_body(v, param_names), desugar_loop_body(c, param_names)),
+    ELabeledArg(label, name, value) => ELabeledArg(label, name, desugar_loop_body(value, param_names, context)),
+    ESpread(value) => ESpread(desugar_loop_body(value, param_names, context)),
+    ELetRec(n, v, b) => ELetRec(n, desugar_loop_body(v, param_names, context), desugar_loop_body(b, param_names, context)),
+    EUnaryOp(op, e) => EUnaryOp(op, desugar_loop_body(e, param_names, context)),
+    EDot(obj, field, off, fdoff) => EDot(desugar_loop_body(obj, param_names, context), field, off, fdoff),
+    EAssignOp(n, op, v, c) => EAssignOp(n, op, desugar_loop_body(v, param_names, context), desugar_loop_body(c, param_names, context)),
     _ => expr
   }
 }
@@ -379,7 +372,7 @@ fn parse_loop_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_
       // Desugar ELoop into ELetMut + EWhile
       let pnames = ArrayBuilder::freeze(param_names_b)
       let pinits = ArrayBuilder::freeze(param_inits_b)
-      let transformed_body = desugar_loop_body(body, pnames)
+      let transformed_body = desugar_loop_body(body, pnames, context)
       let while_expr = EWhile(EBool(true), transformed_body)
       let result = ELetMut("__loop_result", EInt(0), ESeq(while_expr, EIdent("__loop_result", -1)), -1)
       let mut wrapped = result
@@ -621,9 +614,8 @@ fn parse_ctor_record_fields(tokens: Array[Token], starts: Array[Int], pos: Int, 
   }
 }
 
-// Trait-bound names are references, not binders. Context is threaded only to
-// keep the collector call graph explicit and records no authority.
-fn parse_generic_type_param_bound_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
+// Trait-bound names are references, not binders.
+fn parse_generic_type_param_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
   let bounds = ArrayBuilder::new()
   let mut p = pos
   let mut done = false
@@ -647,10 +639,6 @@ fn parse_generic_type_param_bound_names_with_binder_context(tokens: Array[Token]
   (ArrayBuilder::freeze(bounds), p)
 }
 
-fn parse_generic_type_param_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
-  parse_generic_type_param_bound_names_with_binder_context(tokens, pos, None)
-}
-
 /// Parse an expression-position `[T: Bound, U]` header. This intentionally
 /// stays private to the primary-expression parser: unlike declaration headers,
 /// it is not part of the public parser contract.
@@ -669,7 +657,7 @@ fn parse_generic_fn_type_params_with_binder_context(tokens: Array[Token], pos: I
         p = p + 1
         match peek(tokens, p) {
           TColon => {
-            let (bound_names, next) = parse_generic_type_param_bound_names_with_binder_context(tokens, p + 1, context)
+            let (bound_names, next) = parse_generic_type_param_bound_names(tokens, p + 1)
             ArrayBuilder::push(bounds, (name, bound_names))
             p = next
           },
@@ -690,10 +678,6 @@ fn parse_generic_fn_type_params_with_binder_context(tokens: Array[Token], pos: I
     }
   }
   (ArrayBuilder::freeze(names), ArrayBuilder::freeze(bounds), p)
-}
-
-fn parse_generic_fn_type_params(tokens: Array[Token], pos: Int) -> (Array[String], Array[(String, Array[String])], Int) with Exception {
-  parse_generic_fn_type_params_with_binder_context(tokens, pos, None)
 }
 
 fn parse_generic_fn_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {

--- a/scripts/parser_binder_context_spine.test.mjs
+++ b/scripts/parser_binder_context_spine.test.mjs
@@ -3,7 +3,11 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+const baseSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_base.vibe", import.meta.url)), "utf8");
 const exprSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_expr.vibe", import.meta.url)), "utf8");
+const coreSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_expr_core.vibe", import.meta.url)), "utf8");
+const dispatchSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_expr_dispatch.vibe", import.meta.url)), "utf8");
+const primarySource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_expr_primary.vibe", import.meta.url)), "utf8");
 const parserSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser.vibe", import.meta.url)), "utf8");
 
 function regexEscape(value) {
@@ -258,4 +262,97 @@ test("B2 top-level helper bodies carry context and ordinary entries pass None", 
   assertContextual(parserSource, "parse_program_located_with_untrusted_binder_context", ["parse_program_located_with_context_impl(tokens, starts, source, context)"], ["ParserBinderContext::{"]);
   // High-level entry has no caller context parameter and mints fresh plumbing.
   assertBody(parserSource, "parse_program_located_with_binder_context", ["parse_program_located_with_context_impl(tokens, starts, source, Some(ParserBinderContext::{"], ["context: Option[ParserBinderContext]"]);
+});
+
+test("parser binder context crosses every immediate binder-bearing lowering and remap seam", () => {
+  for (const helper of [
+    "apply_fn_annotation_params",
+    "apply_generic_fn_annotation",
+    "apply_generic_let_annotation",
+    "apply_value_bracket_type_params",
+    "record_destr_marker",
+    "top_level_pattern_let",
+    "emit_top_level_pat_bindings",
+    "emit_top_level_pat_projection",
+    "parse_fn_wasm_body",
+  ]) {
+    assertContextual(exprSource, helper, []);
+  }
+  assertContextual(exprSource, "expand_top_level_pattern_lets_with_binder_context", [
+    "emit_top_level_pat_bindings(out, pat, tmp, context)",
+  ], ["emit_top_level_pat_bindings(out, pat, tmp)"]);
+  assertNoneWrapper(exprSource, "expand_top_level_pattern_lets", "expand_top_level_pattern_lets_with_binder_context(stmts, None)");
+  assertContextual(exprSource, "lower_fn_decl_stmt_with_binder_context", [
+    'ELet("result", body, exit_expr, -1)',
+    "SLet(exported, true, name, None, EFn",
+  ]);
+  assertNoneWrapper(exprSource, "lower_fn_decl_stmt", "lower_fn_decl_stmt_with_binder_context(stmt, None)");
+  assertBody(exprSource, "lower_fn_decl_stmts", ["lower_fn_decl_stmt_with_binder_context(s, None)"], ["lower_fn_decl_stmt(s)"]);
+
+  assertContextual(parserSource, "parse_stmt_with_binder_context", [
+    "lower_fn_decl_stmt_with_binder_context(stmt, context)",
+  ], ["lower_fn_decl_stmt(stmt)"]);
+  assertContextual(parserSource, "parse_program_located_with_context_impl", [
+    "expand_top_level_pattern_lets_with_binder_context(ArrayBuilder::freeze(b), context)",
+    "parse_impl_methods(tokens, hp, simpl, context)",
+  ], ["expand_top_level_pattern_lets(ArrayBuilder::freeze(b))"]);
+
+  assertContextual(coreSource, "wrap_placeholder_arg", ['String::concat("__ph", __to_string(pc))']);
+  assertContextual(coreSource, "desugar_placeholder_args", ["wrap_placeholder_arg(arg, context)"], ["wrap_placeholder_arg(arg)"]);
+  assertContextual(coreSource, "parse_postfix", ["desugar_placeholder_args(args, context)"], ["desugar_placeholder_args(args)"]);
+
+  for (const helper of ["map_expr_offsets", "map_exprs", "map_named_exprs", "map_arm_exprs"]) {
+    assertContextual(primarySource, helper, []);
+  }
+  assertContextual(baseSource, "parse_bounded_type_params_with_binder_context", ["parse_trait_bound_names(tokens, p + 1)"], ["parse_trait_bound_names(tokens, p + 1, context)"]);
+  assertBody(baseSource, "parse_trait_bound_names", [], ["context"]);
+  assertContextual(dispatchSource, "dispatch_type_params_with_binder_context", ["dispatch_tp_bound_names(tokens, p + 1)"], ["dispatch_tp_bound_names(tokens, p + 1, context)"]);
+  assertBody(dispatchSource, "dispatch_tp_bound_names", [], ["context"]);
+  assertContextual(primarySource, "parse_generic_fn_type_params_with_binder_context", ["parse_generic_type_param_bound_names(tokens, p + 1)"], ["parse_generic_type_param_bound_names(tokens, p + 1, context)"]);
+  assertBody(primarySource, "parse_generic_type_param_bound_names", [], ["context"]);
+  assertContextual(primarySource, "build_interp_expr", [
+    "map_expr_offsets(pe0, (o) -> remap_frag_off(o, outer_starts, fstarts, frag_off), context)",
+  ], ["map_expr_offsets(pe0, (o) -> remap_frag_off(o, outer_starts, fstarts, frag_off))"]);
+  assertContextual(primarySource, "desugar_loop_body", [
+    "desugar_loop_body(val, param_names, context)",
+    'String::concat("__lt", __to_string(ci2))',
+  ], ["desugar_loop_body(val, param_names)"]);
+  assertContextual(primarySource, "parse_loop_primary", [
+    "desugar_loop_body(body, pnames, context)",
+    'ELetMut("__loop_result"',
+  ], ["desugar_loop_body(body, pnames)"]);
+
+  for (const helper of [
+    "ascribe_wrap",
+    "distribute_local_fn_ann",
+    "apply_local_let_tp",
+    "desugar_guarded",
+    "qualify_handle_arm_pattern",
+    "apply_struct_destr",
+    "apply_record_destr",
+    "apply_block_step",
+    "fold_block_steps",
+    "push_pattern_let_step",
+  ]) {
+    assertContextual(dispatchSource, helper, []);
+  }
+  assertContextual(dispatchSource, "parse_handle_arm", ["qualify_handle_arm_pattern(effect_name, pat, context)"], ["qualify_handle_arm_pattern(effect_name, pat)"]);
+  assertContextual(dispatchSource, "parse_impl_block", [
+    "fold_block_steps(ArrayBuilder::freeze(steps), context)",
+    "ascribe_wrap(val, the_type, context)",
+    "push_pattern_let_step(tokens, steps, pat, val, next_pos, context)",
+  ], [
+    "fold_block_steps(ArrayBuilder::freeze(steps))",
+    "ascribe_wrap(val, the_type)",
+    "push_pattern_let_step(tokens, steps, pat, val, next_pos)",
+  ]);
+  assertContextual(dispatchSource, "parse_impl_dispatch_with_binder_context", [
+    'desugar_guarded(arms3, 0, EIdent("__mg", 0 - 1), context)',
+    "parse_recur(tokens, arrow, 0, context)",
+    "parse_recur(tokens, br, 20, context)",
+    "(gname, None)",
+    "(rname, None)",
+  ], [
+    'desugar_guarded(arms3, 0, EIdent("__mg", 0 - 1))',
+  ]);
 });


### PR DESCRIPTION
## Summary
- thread untrusted parser binder context through immediate binder-bearing lowering and remap seams
- consolidate parser helper duplication while preserving AST, names, token advancement, and diagnostics
- move parser-context parity coverage to fixture scope and add mechanical Node spine attestation

## Validation
- independent review: ACCEPT
- Node spine attestation: 3/3
- unit suite: 638/638
- stage2 -> stage3 generation gate: pass
- generated freshness / formatter / diff checks: pass
- selfcompile heap: 1,104,552,440 <= 1,105,822,775 (baseline unchanged; 1,270,335 bytes residual headroom)

Local task: 6613326c