### PR TITLE
bootstrap: seed を region-starts-guard-2026-08-15 へ bump (#1780 fix を seed に取り込み、#1770 Phase 1 の前提を解除)

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "desugar-builtins-2026-08-09",
-    "tag": "seed/desugar-builtins-2026-08-09",
-    "source_commit": "236695d972e972de18105edda819ac4801904a3b",
+    "name": "region-starts-guard-2026-08-15",
+    "tag": "seed/region-starts-guard-2026-08-15",
+    "source_commit": "702082bb64851048d3d6a11116cc82b0d73659e4",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "24d68cf67a689a67ac567601c83cdeb322efe0496b8af6daed4dd6b7e92d8557"
+      "sha256": "1841e38ae6289c9984f446558a40a551d4e880c066e99bbfc35c38d605ba5c0c"
     },
     "runtime": {
       "runner": "moonrun",


### PR DESCRIPTION
## 概要

bootstrap seed を `desugar-builtins-2026-08-09` (24d68cf6) から **`region-starts-guard-2026-08-15` (1841e38a)** へ bump する。動機: 現 seed は #1780 (region/taskgroup が empty-starts parse レーン = vpkg contract の conformance parse でコンパイラを Array-OOB trap させる) を持っており、**fmt-check CI は seed で `fmt_entry.vibe` をコンパイルする**ため、compiler source (例: `fmt/format.vibe`) に region を書けない。#1783 の fix を seed に取り込むことで #1770 Phase 1 (region のドッグフーディング) が進められるようになる。

diff は `bootstrap/seed.json` の pin 更新のみ (docs/bootstrap.md の手順 3「独立 commit にして PR」)。seed バイナリは非 tracked で、merge 後の `seed-release` workflow dispatch により release asset として publish される。

## candidate の構築と検証

- 構築: main `702082b` と内容同一のツリーから `scripts/generations.sh build --stage3`。**stage2 == stage3 fixpoint** (sha256 `1841e38a...`)。`--source-commit 702082b` で adopt。
- `bash scripts/compiler_gate.sh` 全 pass (FAIL 0、103/103)。
- bump の動機そのものを candidate で直接実証:
  - vpkg contract パッケージ実装内の `region r { MutList... }` を import するプログラムが compile rc=0・実行結果一致 (#1780 の最小 repro)
  - **region 化した `format.vibe` を含む `fmt_entry.vibe` をこの candidate がコンパイルでき**、生成された formatter が既存整形済みファイルで fixpoint (出力バイト一致)
- adopt 後のローカル seed で `scripts/vibe_fmt.sh --check` の entry 再ビルド → 動作確認済み。

## merge 後の手順 (docs/bootstrap.md 手順 4)

merge 後、`seed-release` workflow を `workflow_dispatch` で起動する必要があります (これが済むまで、fresh な CI runner の `ensure_seed.sh` は新 pin の release を fetch できません):

- `tag`: `seed/region-starts-guard-2026-08-15`
- `source_ref`: この PR の merge commit
- `prior_seed_ref`: `702082b` (直近 `seed/desugar-builtins-2026-08-09` release が有効だった commit)

merge を検知したらこちらで dispatch を試みます (権限で弾かれた場合はお願いします)。

## 続き

この PR の merge + release publish 後に、#1770 Phase 1 第一号 (fmt lexer `lex_lossless` の region 化、上で compile/fixpoint 検証済みの diff) を別 PR で出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_