### PR TITLE
ADR-0091 の checklist 完了 + ADR-0090 の循環回収を実証 (#1262)

### DIFF
--- a/fixtures/region_arena_cycles.vibe
+++ b/fixtures/region_arena_cycles.vibe
@@ -1,0 +1,49 @@
+// ADR-0090 #1262: a REFERENCE CYCLE built inside a region costs the main heap
+// nothing. This is the property the ADR calls "the complement to RC's
+// permanent limitation" -- reference counting can never reclaim a cycle, and
+// the arena reclaims it without knowing it is one, because the watermark
+// reset does not look at the graph at all.
+//
+// `MutList::push(l, l)` makes the list an element of itself. Nothing is
+// frozen, so nothing is copied out and the whole structure dies with the
+// region.
+//
+// Measured (VIBE_RC=0, the bump lane where the allocator never frees, so a
+// leak is permanent and visible):
+//
+//     200 regions ->  4,808 B
+//     800 regions -> 19,208 B
+//
+// The MARGINAL cost is (19,208 - 4,808) / 600 = 24 B per region, and that
+// residual is the region body's closure environment (see
+// region_arena_bounded.vibe), not the cyclic structure. Under RC the same
+// cycle leaks forever.
+//
+// Why the shape matters: the assertion below is on a SCALAR, so a region that
+// quietly stopped releasing still returns 1400 and the value alone proves
+// nothing. The gate reads `__heap_ptr` at two iteration counts and compares
+// the marginal cost -- a total is not enough either, because the fixed setup
+// cost is not zero.
+fn one() -> Int {
+  region r {
+    let l = MutList::empty(r)
+    MutList::push(l, l)
+    MutList::push(l, l)
+    MutList::push(l, l)
+    7
+  }
+}
+
+export let main = () -> Int {
+  let mut k = 0
+  let mut acc = 0
+  while k < 200 {
+    acc = acc + one()
+    k = k + 1
+  }
+  acc
+}
+
+test "cycles die with the region" {
+  inspect(main(), "1400")
+}

--- a/fixtures/zero_alloc_measured.vibe
+++ b/fixtures/zero_alloc_measured.vibe
@@ -1,0 +1,66 @@
+// ADR-0091 #1262: the check and the MEASUREMENT pin each other.
+//
+// `zero_alloc_ok.vibe` proves that a `@zero_alloc` function compiles.
+// `err_zero_alloc_ctor.vibe` proves that a violating one is rejected. Neither
+// proves the annotation is TRUE at run time -- a checker that quietly stopped
+// looking would keep both of them green.
+//
+// So this file states the same property twice, independently:
+//
+//   - the CHECK says the marked functions allocate nothing (they compile at
+//     all, which under @zero_alloc means the analysis found no site)
+//   - the MEASUREMENT says `__heap_ptr` does not move per iteration
+//
+// If those two ever disagree, one of them is broken -- and the interesting
+// direction is a check that says "clean" while the heap grows, which is the
+// silently-wrong failure ADR-0091 exists to prevent.
+//
+// The bodies stay inside the region the analysis can prove: scalar
+// arithmetic, comparisons, and `FixedArray` element access. `FixedArray` is
+// ADR-0098 (4)'s optimization target precisely because a known length needs
+// no growth reallocation -- this fixture is where that claim is measured.
+
+@zero_alloc
+fn mix(a: Int, b: Int) -> Int {
+  let s = a + b
+  let t = s * 2 + (a & b)
+  t - (a ^ b)
+}
+
+@zero_alloc
+fn scan(buf: FixedArray[Int], n: Int) -> Int {
+  let mut i = 0
+  let mut acc = 0
+  while i < n {
+    acc = acc + FixedArray::get(buf, i)
+    i = i + 1
+  }
+  acc
+}
+
+// A marked function calling another marked function: the closure has to stay
+// clean through the call, not just inside one body.
+@zero_alloc
+fn combined(buf: FixedArray[Int], n: Int) -> Int {
+  mix(scan(buf, n), n)
+}
+
+// The allocation that DOES happen is hoisted out of the measured loop, so the
+// per-iteration delta is the thing under test. A fixture that allocated its
+// buffer inside the loop would measure the buffer, not the annotation.
+export let main = () -> Int {
+  let buf = FixedArray::make(16, 3)
+  let mut k = 0
+  let mut acc = 0
+  while k < 200 {
+    acc = acc + combined(buf, 16)
+    k = k + 1
+  }
+  acc
+}
+
+// 16 * 3 = 48; mix(48, 16) = (48+16)*2 + (48&16) - (48^16) = 128 + 16 - 32 = 112.
+// 200 * 112 = 22400.
+test "zero alloc measured" {
+  inspect(main(), "22400")
+}

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -20,6 +20,7 @@ import @vibe/compiler/entry/source_compile/gc_only {
 }
 
 import @vibe/compiler/runtime {
+  alloc_spans,
   binding_occurrences,
   build_funcmap_from_source,
   build_module_source_from_source,
@@ -212,6 +213,31 @@ fn adapter_string_array_contains(items: Array[String], needle: String) -> Bool {
 /// with an empty name (unrecoverable offset placeholder) are skipped.
 /// String::concat + __to_string only (never `+`/interpolation -> NUL miscodegen).
 /// Empty -> "".
+/// Render `vibe allocs` records as one `FN KIND OFFSET` line per site.
+/// String::concat + __to_string only (never `+`/interpolation -> NUL
+/// miscodegen). Empty -> "" == this file allocates nothing.
+fn join_alloc_spans(items: Array[(String, String, Int)]) -> String {
+  let n = Array::length(items)
+  let acc = StringBuilder::new()
+  let mut first = true
+  let mut i = 0
+  while i < n {
+    let (fname, kind, off) = Array::get(items, i)
+    if first {
+      first = false
+    } else {
+      StringBuilder::push(acc, "\n")
+    }
+    StringBuilder::push(acc, fname)
+    StringBuilder::push(acc, " ")
+    StringBuilder::push(acc, kind)
+    StringBuilder::push(acc, " ")
+    StringBuilder::push(acc, __to_string(off))
+    i = i + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
 fn join_escape_spans(items: Array[(String, Int, Int)]) -> String {
   let n = Array::length(items)
   let acc = StringBuilder::new()
@@ -1310,6 +1336,19 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
         escape_spans(src)
       }
       Fs::write_bytes(output_path, adapter_string_to_bytes(join_escape_spans(esc)))
+      0
+    } with Exception {
+      Throw(msg) => emit_compile_diag(output_path, msg)
+    }
+  }
+  // `vibe allocs` (ADR-0091 / #1262): every heap-allocating site, one
+  // `FN KIND OFFSET` line each. Empty output means this file allocates
+  // nothing -- so a lex/parse failure must NOT come back as empty; it goes to
+  // the `.diag` sidecar like every other query here.
+  if Env::get("VIBE_ALLOCS") == "1" {
+    return handle {
+      let src = Fs::read_file(input_path)
+      Fs::write_bytes(output_path, adapter_string_to_bytes(join_alloc_spans(alloc_spans(src))))
       0
     } with Exception {
       Throw(msg) => emit_compile_diag(output_path, msg)

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -198,6 +198,7 @@ runtime	runtime/type_at.vibe
 runtime	runtime/binding_at.vibe
 runtime	runtime/doc_at.vibe
 runtime	runtime/symbol_spans.vibe
+runtime	runtime/alloc_spans.vibe
 runtime	runtime/escape_spans.vibe
 runtime	runtime/grep.vibe
 runtime	runtime/grep_fs.vibe

--- a/lib/@vibe/compiler/runtime/alloc_spans.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans.vibe
@@ -1,0 +1,161 @@
+//# `vibe allocs` — every site in a function that puts something on the heap.
+//#
+//# ADR-0091 (#1262), and the allocation-site instrumentation
+//# docs/profiling.md already asked for. `@zero_alloc` needs to name the sites
+//# it rejects, and a `bytes_per_op == 0` bench needs to say WHERE the bytes
+//# came from when it is not 0; both want the same list, so it is built once
+//# here and observable on its own.
+//#
+//# The value of this query is mostly in what it makes visible that the source
+//# does not say out loud. An allocating builtin call is easy to see; a closure
+//# literal quietly allocating its environment, a `let mut` becoming a heap ref
+//# cell because something captured it, or a growable `push` reallocating on the
+//# one call that crosses capacity are the ones people miss. Those are exactly
+//# the "implicit allocation" ADR-0091 lists as the reason to build this.
+//#
+//# DIRECTION. Over-report, never under-report. This shares
+//# `builtin_allocates`' polarity (core/builtin_registry.vibe): an unclassified
+//# builtin counts as allocating. A site listed here that turns out to be free
+//# costs the reader one line; a site NOT listed lets `@zero_alloc` certify
+//# something untrue, silently.
+//#
+//# `push` is reported at every call, not just the ones that regrow. Whether a
+//# given `Array::push` reallocates is a runtime property of that array's
+//# capacity, so a static query cannot say; saying nothing would call an append
+//# loop zero-alloc, which is the wrong direction.
+//#
+//# Output: one `FN KIND OFFSET` line per site, in source order within each
+//# function, functions in declaration order. KIND is one of
+//# `builtin:<name>` / `closure` / `array` / `tuple` / `record` / `interp` /
+//# `mut-cell`. Empty output = this file allocates nothing, i.e. every function
+//# in it is already zero-alloc.
+
+//# Imports
+
+import @vibe/compiler/core {
+  Expr, Stmt, builtin_allocates, expr_children
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/syntax {
+  lex_with_offsets, parse_program_spans
+}
+
+import @vibe/compiler/codegen/common_analysis {
+  is_mut_captured_in
+}
+
+//# Functions
+
+fn alloc_empty_items() -> Array[(String, String, Int)] {
+  array_empty()
+}
+
+/// The allocating-call name for `expr`, or "" when the call is not one.
+/// Only direct `EIdent` callees are classified: an indirect call through a
+/// value cannot be resolved here, and it is reported as a site anyway by the
+/// closure rule (something had to build the closure).
+fn alloc_call_kind(expr: Expr) -> String {
+  match expr {
+    ECall(callee, _, _) => match callee {
+      EIdent(name, _) => if builtin_allocates(name) {
+        String::concat("builtin:", name)
+      } else {
+        ""
+      },
+      _ => ""
+    },
+    _ => ""
+  }
+}
+
+/// The site kind for `expr` itself (not its children), or "" when this node
+/// allocates nothing on its own.
+fn alloc_site_kind(expr: Expr) -> String {
+  match expr {
+    EFn(_, _, _, _, _, _) => "closure",
+    EArray(_) => "array",
+    ETuple(_) => "tuple",
+    ERecord(_, _, _) => "record",
+    EStringInterp(_) => "interp",
+    _ => alloc_call_kind(expr)
+  }
+}
+
+/// The offset to report a site at. Only some Expr forms carry one -- `EFn`
+/// notably does not -- so the rest fall back to the NEAREST ENCLOSING node
+/// that did, threaded down by the walk. Without that inheritance a closure
+/// site reports offset 0, which reads as "top of file" rather than "no span
+/// here"; a site is never dropped for want of a span, but it should not lie
+/// about where it is either.
+fn alloc_site_offset(expr: Expr, fallback: Int) -> Int {
+  match expr {
+    ECall(_, _, off) => off,
+    EIdent(_, off) => off,
+    ELet(_, _, _, off) => off,
+    ELetMut(_, _, _, off) => off,
+    _ => fallback
+  }
+}
+
+fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr, fn_off: Int) -> Unit {
+  let kind = alloc_site_kind(expr)
+  if String::length(kind) > 0 {
+    Array::push(out, (fname, kind, alloc_site_offset(expr, fn_off)))
+  } else {
+    ()
+  }
+  // A captured `let mut` is lowered to a heap ref cell, so the BINDING is an
+  // allocation site even though nothing in the source looks like one. Asked
+  // through codegen's own predicate, the same one `vibe escapes` reports, so
+  // the two queries cannot disagree about which bindings those are.
+  //
+  // The scope handed to the predicate is the binding's OWN rest, not the
+  // enclosing function body: given a body that still contains `let mut c`
+  // itself, `is_mut_captured_in` reads `c` as locally bound and answers false.
+  // `vibe escapes` asks it the same way, which is what keeps the two queries
+  // from disagreeing about which bindings get boxed.
+  match expr {
+    ELetMut(n, _, rest, off) => if is_mut_captured_in(rest, n) {
+      Array::push(out, (fname, "mut-cell", off))
+    } else {
+      ()
+    },
+    _ => ()
+  }
+  let here = alloc_site_offset(expr, fn_off)
+  let kids = expr_children(expr)
+  let mut i = 0
+  while i < Array::length(kids) {
+    alloc_walk_expr(out, fname, Array::get(kids, i), here)
+    i = i + 1
+  }
+}
+
+/// Every heap-allocating site in `source`, as `(fn_name, kind, offset)`.
+///
+/// Propagates a lex/parse Error rather than swallowing it into an empty list:
+/// the caller routes it to the `.diag` sidecar, so "the query failed" stays
+/// distinguishable from "this file allocates nothing" (the `symbol_spans`
+/// convention, #946 — and here the two would otherwise be the same output for
+/// opposite facts).
+export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Exception {
+  let (tokens, starts, ends) = lex_with_offsets(source)
+  let (stmts, _span_start, _span_end) = parse_program_spans(tokens, starts, ends)
+  let out = alloc_empty_items()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, value) => match value {
+        EFn(_, _, _, _, _, fbody) => alloc_walk_expr(out, name, fbody, 0),
+        _ => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}

--- a/lib/@vibe/compiler/runtime/alloc_spans.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans.vibe
@@ -26,9 +26,10 @@
 //#
 //# Output: one `FN KIND OFFSET` line per site, in source order within each
 //# function, functions in declaration order. KIND is one of
-//# `builtin:<name>` / `closure` / `array` / `tuple` / `record` / `interp` /
-//# `mut-cell`. Empty output = this file allocates nothing, i.e. every function
-//# in it is already zero-alloc.
+//# `builtin:<name>` / `constructor:<name>` / `closure` / `array` / `tuple` /
+//# `record` / `map` / `interp` / `float` / `handler` / `mut-cell`. Empty
+//# output = this file allocates nothing, i.e. every function in it is already
+//# zero-alloc.
 
 //# Imports
 
@@ -54,6 +55,23 @@ fn alloc_empty_items() -> Array[(String, String, Int)] {
   array_empty()
 }
 
+fn alloc_empty_strings() -> Array[String] {
+  array_empty()
+}
+
+fn alloc_contains_name(names: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
 /// The allocating-call name for `expr`, or "" when the call is not one.
 /// Only direct `EIdent` callees are classified: an indirect call through a
 /// value cannot be resolved here, and it is reported as a site anyway by the
@@ -74,13 +92,21 @@ fn alloc_call_kind(expr: Expr) -> String {
 
 /// The site kind for `expr` itself (not its children), or "" when this node
 /// allocates nothing on its own.
-fn alloc_site_kind(expr: Expr) -> String {
+fn alloc_site_kind(expr: Expr, ctors: Array[String]) -> String {
   match expr {
+    EFloat(_) => "float",
+    EIdent(name, _) => if alloc_contains_name(ctors, name) {
+      String::concat("constructor:", name)
+    } else {
+      ""
+    },
     EFn(_, _, _, _, _, _) => "closure",
     EArray(_) => "array",
     ETuple(_) => "tuple",
     ERecord(_, _, _) => "record",
+    EMap(_) => "map",
     EStringInterp(_) => "interp",
+    EHandle(_, _) => "handler",
     _ => alloc_call_kind(expr)
   }
 }
@@ -92,17 +118,22 @@ fn alloc_site_kind(expr: Expr) -> String {
 /// here"; a site is never dropped for want of a span, but it should not lie
 /// about where it is either.
 fn alloc_site_offset(expr: Expr, fallback: Int) -> Int {
-  match expr {
+  let candidate = match expr {
     ECall(_, _, off) => off,
     EIdent(_, off) => off,
     ELet(_, _, _, off) => off,
     ELetMut(_, _, _, off) => off,
     _ => fallback
   }
+  if candidate >= 0 {
+    candidate
+  } else {
+    fallback
+  }
 }
 
-fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr, fn_off: Int) -> Unit {
-  let kind = alloc_site_kind(expr)
+fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr, fn_off: Int, ctors: Array[String]) -> Unit {
+  let kind = alloc_site_kind(expr, ctors)
   if String::length(kind) > 0 {
     Array::push(out, (fname, kind, alloc_site_offset(expr, fn_off)))
   } else {
@@ -130,9 +161,48 @@ fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr,
   let kids = expr_children(expr)
   let mut i = 0
   while i < Array::length(kids) {
-    alloc_walk_expr(out, fname, Array::get(kids, i), here)
+    alloc_walk_expr(out, fname, Array::get(kids, i), here, ctors)
     i = i + 1
   }
+}
+
+/// `parse_program_spans` intentionally refuses source directives because its
+/// original module-source caller cannot re-emit them without changing
+/// semantics. This query only needs the declarations and must keep offsets in
+/// the ORIGINAL source, so blank recognized directive lines byte-for-byte.
+///
+/// For `#cfg`, counting both active and inactive guarded declarations is the
+/// conservative answer: this is a source inventory and its contract is never
+/// to under-report a possible allocation site.
+fn alloc_blank_directives(source: String) -> String {
+  let out = StringBuilder::new()
+  let len = String::length(source)
+  let mut pos = 0
+  while pos < len {
+    let mut nl = pos
+    while nl < len && String::char_code_at(source, nl) != 10 {
+      nl = nl + 1
+    }
+    let line = String::substring(source, pos, nl)
+    let trimmed = String::trim(line)
+    let recognized = trimmed == "#deprecated" || String::starts_with(trimmed, "#deprecated(") || String::starts_with(trimmed, "#cfg(") || String::starts_with(trimmed, "#cfg_enable(")
+    if recognized {
+      let mut i = 0
+      while i < String::length(line) {
+        StringBuilder::push(out, " ")
+        i = i + 1
+      }
+    } else {
+      StringBuilder::push(out, line)
+    }
+    if nl < len {
+      StringBuilder::push(out, "\n")
+    } else {
+      ()
+    }
+    pos = nl + 1
+  }
+  StringBuilder::freeze(out)
 }
 
 /// Every heap-allocating site in `source`, as `(fn_name, kind, offset)`.
@@ -143,14 +213,47 @@ fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr,
 /// convention, #946 — and here the two would otherwise be the same output for
 /// opposite facts).
 export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Exception {
-  let (tokens, starts, ends) = lex_with_offsets(source)
-  let (stmts, _span_start, _span_end) = parse_program_spans(tokens, starts, ends)
+  let parse_source = alloc_blank_directives(source)
+  let (tokens, starts, ends) = lex_with_offsets(parse_source)
+  let (stmts, span_start, _span_end) = parse_program_spans(tokens, starts, ends)
   let out = alloc_empty_items()
+  let ctors = alloc_empty_strings()
+  let mut ci = 0
+  while ci < Array::length(stmts) {
+    match Array::get(stmts, ci) {
+      SEnum(_, _, _, variants, _) => {
+        let mut vi = 0
+        while vi < Array::length(variants) {
+          let (vname, _) = Array::get(variants, vi)
+          Array::push(ctors, vname)
+          vi = vi + 1
+        }
+      },
+      SSuberror(_, _, variants) => {
+        let mut vi = 0
+        while vi < Array::length(variants) {
+          let (vname, _) = Array::get(variants, vi)
+          Array::push(ctors, vname)
+          vi = vi + 1
+        }
+      },
+      SStruct(_, name, _, _, _, _) => Array::push(ctors, name),
+      _ => ()
+    }
+    ci = ci + 1
+  }
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SLet(_, _, name, _, value) => match value {
-        EFn(_, _, _, _, _, fbody) => alloc_walk_expr(out, name, fbody, 0),
+        EFn(_, _, _, _, _, fbody) => {
+          let stmt_off = if i < Array::length(span_start) {
+            Array::get(span_start, i)
+          } else {
+            0
+          }
+          alloc_walk_expr(out, name, fbody, stmt_off, ctors)
+        },
         _ => ()
       },
       _ => ()

--- a/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
@@ -53,6 +53,19 @@ fn fn_names_of(source: String) -> Array[String] with Exception {
   out
 }
 
+fn offsets_of(source: String) -> Array[Int] with Exception {
+  let spans = alloc_spans(source)
+  let out = [
+  ]
+  let mut i = 0
+  while i < Array::length(spans) {
+    let (_f, _kind, off) = Array::get(spans, i)
+    Array::push(out, off)
+    i = i + 1
+  }
+  out
+}
+
 //# Tests
 
 test "a function that only reads reports nothing" {
@@ -99,6 +112,48 @@ test "literals that build a value are sites" {
   assert(has_kind(src, "tuple"))
   let src2 = "fn three() -> Array[Int] {\n  [\n    1,\n    2,\n    3\n  ]\n}\n"
   assert(has_kind(src2, "array"))
+}
+
+test "a float literal is a heap-box allocation site" {
+  let src = "fn pi() -> Double {\n  3.14\n}\n"
+  assert(has_kind(src, "float"))
+}
+
+test "map literals and handlers are allocation sites" {
+  let map_src = "fn one() -> Map[String, Int] {\n  Map::from_pairs([(\"one\", 1)])\n}\n"
+  assert(has_kind(map_src, "map"))
+  let handle_src = "effect Ask { Ask() -> Int }\nfn answer() -> Int {\n  handle { perform Ask::Ask() } with Ask {\n    Ask() => resume(42)\n  }\n}\n"
+  assert(has_kind(handle_src, "handler"))
+}
+
+test "a bare enum constructor is conservatively an allocation site" {
+  let src = "enum Maybe { None; Some(Int) }\nfn empty() -> Maybe {\n  None\n}\n"
+  assert(has_kind(src, "constructor:None"))
+}
+
+test "valid cfg and deprecated directives do not make the query fail" {
+  // Directive text must be blanked, not deleted, so source offsets remain
+  // coordinates in the original file. Counting inactive cfg sites is the
+  // deliberate over-reporting side of this static query.
+  let src = "#deprecated(\"use exact_pi\")\n#cfg(experimental)\nfn pi() -> Double {\n  3.14\n}\n"
+  assert(has_kind(src, "float"))
+}
+
+test "spanless literal sites inherit their statement offset, not byte zero" {
+  let src = "fn pure() -> Int { 1 }\n\nfn later() -> Array[Int] {\n  [1, 2]\n}\n"
+  let offsets = offsets_of(src)
+  assert_eq(Array::length(offsets), 1)
+  assert_eq(Array::get(offsets, 0), String::index_of(src, "fn later"))
+}
+
+test "synthetic nodes never replace a real source fallback with offset minus one" {
+  let src = "fn wrap[T](x: T) -> (T) {\n  (x)\n}\n"
+  let offsets = offsets_of(src)
+  let mut i = 0
+  while i < Array::length(offsets) {
+    assert(Array::get(offsets, i) >= 0)
+    i = i + 1
+  }
 }
 
 test "sites are attributed to the enclosing top-level function" {

--- a/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
@@ -1,0 +1,117 @@
+// ADR-0091 (#1262): `vibe allocs` — the heap-allocating sites in each function.
+//
+// The tests are written around the two things that make this query worth
+// having. First, the DIRECTION: over-report rather than under-report, because
+// a missed site lets `@zero_alloc` certify something untrue. Second, the sites
+// the source does not say out loud — a closure's environment, and a `let mut`
+// that becomes a heap ref cell because something captured it.
+
+import ../runtime {
+  alloc_spans
+}
+
+//# Helpers
+
+fn kinds_of(source: String) -> Array[String] with Exception {
+  let spans = alloc_spans(source)
+  let out = [
+  ]
+  let mut i = 0
+  while i < Array::length(spans) {
+    let (_fn, kind, _off) = Array::get(spans, i)
+    Array::push(out, kind)
+    i = i + 1
+  }
+  out
+}
+
+fn has_kind(source: String, want: String) -> Bool with Exception {
+  let ks = kinds_of(source)
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(ks) {
+    if Array::get(ks, i) == want {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn fn_names_of(source: String) -> Array[String] with Exception {
+  let spans = alloc_spans(source)
+  let out = [
+  ]
+  let mut i = 0
+  while i < Array::length(spans) {
+    let (f, _kind, _off) = Array::get(spans, i)
+    Array::push(out, f)
+    i = i + 1
+  }
+  out
+}
+
+//# Tests
+
+test "a function that only reads reports nothing" {
+  // Empty output has to mean "allocates nothing", which is only useful if the
+  // free builtins really stay out.
+  let src = "fn total(a: Array[Int], n: Int) -> Int {\n  let mut i = 0\n  let mut acc = 0\n  while i < n {\n    acc = acc + Array::get(a, i)\n    i = i + 1\n  }\n  acc\n}\n"
+  assert_eq(Array::length(alloc_spans(src)), 0)
+}
+
+test "an allocating builtin call is reported, named" {
+  let src = "fn j(a: String, b: String) -> String {\n  String::concat(a, b)\n}\n"
+  assert(has_kind(src, "builtin:String::concat"))
+}
+
+test "push is reported at every call -- it may regrow" {
+  // A query that only counted constructors would call this loop zero-alloc.
+  let src = "fn build(n: Int) -> Array[Int] {\n  let b = ArrayBuilder::new()\n  let mut i = 0\n  while i < n {\n    ArrayBuilder::push(b, i)\n    i = i + 1\n  }\n  ArrayBuilder::freeze(b)\n}\n"
+  assert(has_kind(src, "builtin:ArrayBuilder::push"))
+  assert(has_kind(src, "builtin:ArrayBuilder::new"))
+}
+
+test "a closure literal allocates its environment" {
+  // Nothing in the source spells this out; it is one of the implicit
+  // allocations ADR-0091 exists to surface.
+  let src = "fn mk(n: Int) -> () -> Int {\n  () -> Int {\n    n\n  }\n}\n"
+  assert(has_kind(src, "closure"))
+}
+
+test "a captured let mut is a heap ref cell, so the BINDING is a site" {
+  let src = "fn counter() -> () -> Int {\n  let mut c = 0\n  () -> Int {\n    c = c + 1\n    c\n  }\n}\n"
+  assert(has_kind(src, "mut-cell"))
+}
+
+test "an uncaptured let mut is a wasm local, so it is NOT a site" {
+  // The pairing with the test above is the point: this is the same predicate
+  // `vibe escapes` reports, so the two queries cannot disagree about which
+  // bindings get boxed.
+  let src = "fn add(n: Int) -> Int {\n  let mut acc = 0\n  acc = acc + n\n  acc\n}\n"
+  assert(!has_kind(src, "mut-cell"))
+}
+
+test "literals that build a value are sites" {
+  let src = "fn pair(a: Int, b: Int) -> (Int, Int) {\n  (a, b)\n}\n"
+  assert(has_kind(src, "tuple"))
+  let src2 = "fn three() -> Array[Int] {\n  [\n    1,\n    2,\n    3\n  ]\n}\n"
+  assert(has_kind(src2, "array"))
+}
+
+test "sites are attributed to the enclosing top-level function" {
+  let src = "fn a(s: String) -> String {\n  String::concat(s, s)\n}\n\nfn b(s: String) -> String {\n  String::concat(s, s)\n}\n"
+  let names = fn_names_of(src)
+  assert_eq(Array::length(names), 2)
+  assert_eq(Array::get(names, 0), "a")
+  assert_eq(Array::get(names, 1), "b")
+}
+
+test "an unclassified callee is reported, not skipped" {
+  // Same polarity as builtin_allocates: a name nobody classified counts as
+  // allocating. Under-reporting here would be the silent-wrong direction.
+  let src = "fn f(x: Int) -> Int {\n  Totally::MadeUp(x)\n}\n"
+  assert(has_kind(src, "builtin:Totally::MadeUp"))
+}

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -153,6 +153,7 @@ fn symbol_spans(source: String) -> Array[(String, Int, Int, Int)] with Exception
 // --- escape_spans.vibe (#1262): the `let mut` bindings a closure captures, so
 // codegen lowers them to a heap ref cell instead of a wasm local. Calls
 // codegen's own `is_mut_captured_in`, so the answer IS the lowering decision.
+fn alloc_spans(source: String) -> Array[(String, String, Int)] with Exception
 fn escape_spans(source: String) -> Array[(String, Int, Int)] with Exception
 fn escape_spans_strict(source: String) -> Array[(String, Int, Int)] with Exception
 

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -84,6 +84,10 @@ export ./symbol_spans.vibe {
   symbol_spans
 }
 
+export ./alloc_spans.vibe {
+  alloc_spans
+}
+
 export ./escape_spans.vibe {
   escape_spans
 }

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -57,6 +57,8 @@
 #                                         captures -- the ones codegen boxes into
 #                                         a heap ref cell instead of a wasm local
 #                                         (NAME START END per line; empty = none)
+#   vibe allocs <file.vibe>               print possible heap-allocation sites
+#                                         (FN KIND OFFSET per line; empty = none)
 #   vibe deps [--direct] <file.vibe>      print the resolved import closure, one
 #                                         path per line, dependency first (#988).
 #                                         The loader's OWN collection (what the
@@ -993,7 +995,7 @@ case "$cmd" in
       out="$(mktemp -t vibe-check-sf-XXXXXX)"
       trap 'rm -f "$out" "$out.diag"' EXIT
       env -u VIBE_FS_COMPILE -u VIBE_CHECK_ONLY -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-          -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_SYMBOLS -u VIBE_NORMALIZE \
+          -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_SYMBOLS -u VIBE_NORMALIZE \
           -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         VIBE_DIAGNOSTICS=1 \
         VIBE_DIAGNOSTICS_JSON="$([ "$chk_json" = "1" ] && echo 1 || echo "")" \
@@ -1075,7 +1077,7 @@ case "$cmd" in
     if grep -aq "VIBE_CHECK_ONLY" "$cli" 2>/dev/null; then
       out="$(mktemp -t vibe-check-XXXXXX)"
       trap 'rm -f "$out" "$out.diag"' EXIT
-      env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT \
+      env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
           -u VIBE_SYMBOLS -u VIBE_NORMALIZE -u VIBE_COVERAGE -u VIBE_DEBUG \
           -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         VIBE_CHECK_ONLY=1 \
@@ -1137,7 +1139,7 @@ case "$cmd" in
     # the compile path (which would emit wasm bytes instead of the type string).
     # Don't `die` on a non-zero exit — emit whatever (possibly empty) result was
     # written so the LSP degrades gracefully instead of the whole query failing.
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
         -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_TYPE_AT=1 VIBE_TYPE_LINE="$ta_line" VIBE_TYPE_COL="$ta_col" \
       VIBE_IMPORT_ABI=raw \
@@ -1163,7 +1165,7 @@ case "$cmd" in
     # Don't `die` on a non-zero exit — emit whatever (possibly empty) result was
     # written so the LSP degrades gracefully instead of the whole query failing.
     env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT \
-        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
         -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_DOC_AT=1 VIBE_TYPE_LINE="$da_line" VIBE_TYPE_COL="$da_col" \
       VIBE_IMPORT_ABI=raw \
@@ -1190,7 +1192,7 @@ case "$cmd" in
     # compile path (which would emit wasm bytes instead of the occurrence list).
     # Don't `die` on a non-zero exit — emit whatever (possibly empty) result was
     # written so the LSP degrades gracefully instead of the whole query failing.
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
         -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_BINDING_AT=1 VIBE_TYPE_LINE="$ba_line" VIBE_TYPE_COL="$ba_col" \
       VIBE_IMPORT_ABI=raw \
@@ -1216,7 +1218,7 @@ case "$cmd" in
     # Clear any inherited compile-mode envs so this query can't be diverted to the
     # compile path (which would emit wasm bytes instead of the symbol list).
     env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-        -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
+        -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
         -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_SYMBOLS=1 \
       VIBE_IMPORT_ABI=raw \
@@ -1259,7 +1261,7 @@ case "$cmd" in
     out="$(mktemp -t vibe-escapes-XXXXXX)"
     trap 'rm -f "$out" "$out.diag"' EXIT
     env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
         -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_ESCAPES=1 \
       VIBE_ESCAPES_STRICT="$escapes_strict" \
@@ -1267,6 +1269,30 @@ case "$cmd" in
       "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
     if [ -s "$out.diag" ]; then
       echo "error: $(cat "$out.diag")" >&2
+    fi
+    if [ -s "$out" ]; then cat "$out"; fi
+    ;;
+  allocs)
+    # vibe allocs <file.vibe>
+    # Print every possible heap-allocation site, including implicit closure
+    # environments, boxed captured `let mut` cells, and boxed float literals.
+    # This is deliberately conservative: a false positive costs one report
+    # line, while a missed site makes an empty result silently untrue.
+    [ "$#" -eq 1 ] || die "usage: vibe allocs <file.vibe>"
+    src="$1"
+    [ -f "$src" ] || die "not found: $src"
+    cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
+    out="$(mktemp -t vibe-allocs-XXXXXX)"
+    trap 'rm -f "$out" "$out.diag"' EXIT
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG \
+        -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE -u VIBE_CHECK_ONLY -u VIBE_DEPS \
+      VIBE_ALLOCS=1 \
+      VIBE_IMPORT_ABI=raw \
+      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
+    if [ -s "$out.diag" ]; then
+      echo "error: $(cat "$out.diag")" >&2
+      exit 1
     fi
     if [ -s "$out" ]; then cat "$out"; fi
     ;;
@@ -1312,7 +1338,7 @@ case "$cmd" in
     deps_direct_env=""
     [ "$deps_direct" = "1" ] && deps_direct_env="VIBE_DEPS_DIRECT=1"
     env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_COVERAGE -u VIBE_DEBUG \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG \
         -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE -u VIBE_CHECK_ONLY \
       VIBE_DEPS=1 ${deps_direct_env} \
       VIBE_IMPORT_ABI=raw \
@@ -1364,7 +1390,7 @@ case "$cmd" in
     # failure) so the LSP treats empty as "no diagnostics" / falls back.
     diag_json_env=""
     [ "$diag_json" = "1" ] && diag_json_env=1
-    env -u VIBE_FS_COMPILE -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_NORMALIZE -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT \
+    env -u VIBE_FS_COMPILE -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_NORMALIZE -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
         -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_DIAGNOSTICS=1 \
       VIBE_DIAGNOSTICS_JSON="$diag_json_env" \
@@ -1454,7 +1480,7 @@ case "$cmd" in
       # Clear inherited adapter-mode envs so a leaked selector can't divert this
       # into compiling and emitting wasm bytes as "matches".
       env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-          -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
+          -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
           -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         VIBE_GREP=1 \
         VIBE_GREP_PATTERN="$g_pattern" \
@@ -1502,7 +1528,7 @@ case "$cmd" in
     # write a hash/report as $out and the default write mode would copy it
     # OVER the user's source file.
     env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
         -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         -u VIBE_HASH -u VIBE_HASH_WRITE \
         -u VIBE_MISSING_VPKG_SCAN -u VIBE_DEPS_MISSING_SCAN -u VIBE_FILL_PINS \

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -10677,7 +10677,7 @@ done
 rm -rf "$dvdir"
 echo "[compiler-gate] desugar-emitted builtins resolve in both lanes ok"
 
-echo "[compiler-gate] 98/103 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
+echo "[compiler-gate] 98/104 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
 # grep_test.vibe covers the pattern language and the filters through
 # grep_scan_source (no Fs). What only the REAL adapter mode exercises is the
 # filesystem tier: sweeping a directory, and resolving a capture's type through
@@ -10766,7 +10766,7 @@ echo "[compiler-gate] vibe grep typed filters ok"
 #     found by review rather than by a gate (the second twice: expression
 #     binders in #1622, PATTERN binders after that), which is what this step is
 #     for. Each case below fails DIFFERENTLY if the guard regresses.
-echo "[compiler-gate] 99/103 the inspect rewrite neither captures nor hijacks (#1571)"
+echo "[compiler-gate] 99/104 the inspect rewrite neither captures nor hijacks (#1571)"
 inspdir="_build/_gate_inspect_guard"
 rm -rf "$inspdir"; mkdir -p "$inspdir"
 
@@ -10884,7 +10884,7 @@ echo "[compiler-gate] inspect rewrite hygiene + shadow guard ok"
 #      rest made `check` a strictly worse answer to the same question -- three
 #      broken statements cost three edit-and-rerun cycles. This pins the two
 #      surfaces together so they cannot drift apart again.
-echo "[compiler-gate] 100/103 check and diagnostics report the SAME parse errors (#1567)"
+echo "[compiler-gate] 100/104 check and diagnostics report the SAME parse errors (#1567)"
 chkdir="_build/_gate_check_diag_parity"
 rm -rf "$chkdir"; mkdir -p "$chkdir"
 # Three top-level statements, two independently broken, one good between them.
@@ -11015,7 +11015,74 @@ echo "[compiler-gate] vibe deps import-closure ok (#988)"
 #      predicates that disagree by accident, so this pins WHERE they differ:
 #      only on binder shadowing, and only in the one direction (strict's
 #      output is a subset of the default's).
-echo "[compiler-gate] 101/103 the two escape predicates differ only on shadowing (#1262)"
+# 104/104. ADR-0091 (#1262): `vibe allocs` -- every heap-allocating site, as
+#      `FN KIND OFFSET`. The direction is what matters and what this pins:
+#      over-report, never under-report. A site this query misses lets
+#      `@zero_alloc` certify something untrue, silently; a site it reports in
+#      error costs the reader one line and argues back through a diagnostic.
+#      So both halves are checked -- a function that allocates nothing really
+#      produces EMPTY output (otherwise "clean" is worthless), and the sites
+#      the source does not spell out (a closure's environment, a captured
+#      `let mut` becoming a heap ref cell) really appear.
+echo "[compiler-gate] 104/104 vibe allocs reports heap sites, and nothing else (ADR-0091 / #1262)"
+alcdir="_build/_gate_allocs"
+rm -rf "$alcdir"; mkdir -p "$alcdir"
+cat > "$alcdir/in.vibe" <<'ALCA'
+fn pure_sum(a: Array[Int], n: Int) -> Int {
+  let mut i = 0
+  let mut acc = 0
+  while i < n {
+    acc = acc + Array::get(a, i)
+    i = i + 1
+  }
+  acc
+}
+
+fn counter() -> () -> Int {
+  let mut c = 0
+  () -> Int {
+    c = c + 1
+    c
+  }
+}
+ALCA
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_ALLOCS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$alcdir/in.vibe" "$alcdir/out.txt" >/dev/null 2>&1 || true
+if [ -s "$alcdir/out.txt.diag" ]; then
+  echo "[compiler-gate] FAIL: vibe allocs failed on a valid file (ADR-0091 / #1262)" >&2
+  cat "$alcdir/out.txt.diag" >&2 || true
+  exit 1
+fi
+# The reads-only function must contribute NOTHING: "empty means zero-alloc" is
+# the whole contract.
+if grep -q '^pure_sum ' "$alcdir/out.txt" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: vibe allocs reported a site in an allocation-free function (ADR-0091 / #1262)" >&2
+  cat "$alcdir/out.txt" >&2 || true
+  exit 1
+fi
+# The two implicit sites -- neither is visible in the source text.
+for want in "counter mut-cell" "counter closure"; do
+  if ! grep -q "^$want " "$alcdir/out.txt" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: vibe allocs missed '$want' -- an implicit allocation ADR-0091 exists to surface (#1262)" >&2
+    cat "$alcdir/out.txt" >&2 || true
+    exit 1
+  fi
+done
+# A file with no functions at all is empty output, not an error.
+printf 'enum Empty {\n  E0\n}\n' > "$alcdir/none.vibe"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_ALLOCS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$alcdir/none.vibe" "$alcdir/none.txt" >/dev/null 2>&1 || true
+if [ -s "$alcdir/none.txt" ] || [ -s "$alcdir/none.txt.diag" ]; then
+  echo "[compiler-gate] FAIL: vibe allocs on a function-free file should be empty and clean (#1262)" >&2
+  cat "$alcdir/none.txt" "$alcdir/none.txt.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$alcdir"
+echo "[compiler-gate] vibe allocs ok (ADR-0091 / #1262)"
+
+echo "[compiler-gate] 101/104 the two escape predicates differ only on shadowing (#1262)"
 escdir="_build/_gate_escapes"
 rm -rf "$escdir"; mkdir -p "$escdir"
 

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -11141,6 +11141,19 @@ for want in "counter mut-cell" "counter closure"; do
     exit 1
   fi
 done
+# Exercise the advertised PUBLIC verb too. The adapter-only environment lane
+# above cannot catch a missing `runtime/vibe` case (the original #1792 review
+# regression): that would leave `vibe allocs` documented but unusable.
+VIBE_RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
+  VIBE_CLI_WASM="$stage2_wasm" \
+  bash "$ROOT_DIR/runtime/vibe" allocs "$alcdir/in.vibe" > "$alcdir/public.txt"
+for want in "counter mut-cell" "counter closure"; do
+  if ! grep -q "^$want " "$alcdir/public.txt" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: public 'vibe allocs' missed '$want' (#1262)" >&2
+    cat "$alcdir/public.txt" >&2 || true
+    exit 1
+  fi
+done
 # A file with no functions at all is empty output, not an error.
 printf 'enum Empty {\n  E0\n}\n' > "$alcdir/none.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_ALLOCS=1 VIBE_IMPORT_ABI=raw \

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -8812,6 +8812,44 @@ if ! grep -qF 'zero_alloc' "$za91dir/shadowed.wasm.diag" 2>/dev/null; then
   exit 1
 fi
 rm -rf "$za91dir"
+# ADR-0091 #1262: the check and the MEASUREMENT pin each other. The two
+# fixtures above prove a clean fn compiles and a violating one is rejected;
+# neither proves the annotation is TRUE at run time -- a checker that quietly
+# stopped looking keeps both green. So state it twice, independently: the
+# check says the marked fns allocate nothing, and `__heap_ptr` says the loop
+# does not move it.
+#
+# Asserted on INVARIANCE, not on a total. The setup (`FixedArray::make`) is
+# not free, so "total == 0" is unachievable and any fixed bound is arbitrary.
+# Two iteration counts with the SAME delta means the per-iteration cost is
+# exactly zero.
+za91mdir="_build/_gate_zero_alloc91_measured"
+rm -rf "$za91mdir"; mkdir -p "$za91mdir"
+for za_n in 200 800; do
+  sed -e "s/while k < 200 {/while k < $za_n {/" \
+      -e "s/inspect(main(), \"22400\")/inspect(main(), \"$((za_n * 112))\")/" \
+      fixtures/zero_alloc_measured.vibe > "$za91mdir/measured_$za_n.vibe"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw VIBE_RC=0 \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$za91mdir/measured_$za_n.vibe" "$za91mdir/measured_$za_n.wasm" __no_entry__ >/dev/null 2>&1 || true
+  if [ ! -s "$za91mdir/measured_$za_n.wasm" ]; then
+    echo "[compiler-gate] FAIL: zero_alloc_measured.vibe ($za_n) did not compile -- the @zero_alloc check rejected a fn the measurement says is clean" >&2
+    cat "$za91mdir/measured_$za_n.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$za91mdir/measured_$za_n.wasm" >/dev/null 2>&1; then
+    echo "[compiler-gate] FAIL: zero_alloc_measured.vibe ($za_n) got the wrong value" >&2
+    exit 1
+  fi
+done
+za_lo="$(node scripts/region_arena_heap_delta.mjs "$za91mdir/measured_200.wasm")" || exit 1
+za_hi="$(node scripts/region_arena_heap_delta.mjs "$za91mdir/measured_800.wasm")" || exit 1
+if [ "$za_lo" -ne "$za_hi" ]; then
+  echo "[compiler-gate] FAIL: @zero_alloc fns allocated $(( (za_hi - za_lo) / 600 )) B per iteration (200 trips: $za_lo B, 800 trips: $za_hi B) -- the check says clean but the heap moved" >&2
+  exit 1
+fi
+rm -rf "$za91mdir"
+echo "[compiler-gate] @zero_alloc check and measurement agree ok (0 B/op, $za_lo B fixed setup)"
 echo "[compiler-gate] ADR-0091 @zero_alloc allocation check ok"
 
 # 77/77. ADR-0089 Decision 1, increment 1 (#1218): entry-row-Async sleep

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -8714,6 +8714,40 @@ if [ "$r90_heap_delta" -gt 100000 ]; then
   echo "[compiler-gate] FAIL: 200 regions grew the main bump heap by $r90_heap_delta B (want < 100000; ~6408 with the arena, 1644008 without) -- the arena stopped releasing" >&2
   exit 1
 fi
+
+# ADR-0090 #1262: a REFERENCE CYCLE inside a region also costs the main heap
+# nothing -- the property the ADR calls the complement to RC's permanent
+# limitation. The watermark reset reclaims it without inspecting the graph.
+#
+# Asserted on the MARGINAL cost, not the total: the fixed setup is not zero,
+# so a total bound would either be loose enough to miss a leak or tight enough
+# to break on unrelated changes. Two iteration counts, and the per-region cost
+# has to stay small.
+for r90_cyc_n in 200 800; do
+  sed -e "s/while k < 200 {/while k < $r90_cyc_n {/" \
+      -e "s/inspect(main(), \"1400\")/inspect(main(), \"$((r90_cyc_n * 7))\")/" \
+      fixtures/region_arena_cycles.vibe > "$r90dir/cycles_$r90_cyc_n.vibe"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw VIBE_RC=0 \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$r90dir/cycles_$r90_cyc_n.vibe" "$r90dir/cycles_$r90_cyc_n.wasm" __no_entry__ >/dev/null 2>&1 || true
+  if [ ! -s "$r90dir/cycles_$r90_cyc_n.wasm" ]; then
+    echo "[compiler-gate] FAIL: region_arena_cycles.vibe ($r90_cyc_n) did not compile" >&2
+    cat "$r90dir/cycles_$r90_cyc_n.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/cycles_$r90_cyc_n.wasm" >/dev/null 2>&1; then
+    echo "[compiler-gate] FAIL: region_arena_cycles.vibe ($r90_cyc_n) got the wrong value" >&2
+    exit 1
+  fi
+done
+r90_cyc_lo="$(node scripts/region_arena_heap_delta.mjs "$r90dir/cycles_200.wasm")" || exit 1
+r90_cyc_hi="$(node scripts/region_arena_heap_delta.mjs "$r90dir/cycles_800.wasm")" || exit 1
+r90_cyc_per=$(( (r90_cyc_hi - r90_cyc_lo) / 600 ))
+if [ "$r90_cyc_per" -gt 64 ]; then
+  echo "[compiler-gate] FAIL: a reference cycle inside a region costs $r90_cyc_per B/region on the main heap (want <= 64; ~24 with the arena) -- the cycle is no longer reclaimed by the watermark reset" >&2
+  exit 1
+fi
+echo "[compiler-gate] region arena reclaims reference cycles ok ($r90_cyc_per B/region)"
 echo "[compiler-gate] region arena bulk release ok (200 regions, main heap +${r90_heap_delta} B)"
 rm -rf "$r90dir"
 echo "[compiler-gate] ADR-0090 region + MutList vertical slice ok"


### PR DESCRIPTION
3 コミット。**ADR-0091 の checklist を完了**させ、**ADR-0090 の「循環回収」**を
実証して固定します。

---

## 1. `vibe allocs` — 確保サイトの列挙 (ADR-0091)

`@zero_alloc` の**競合ではなく補完**です。検査は「約束が守られているか」に
yes/no で答え、このクエリは「**バイトがどこへ行くか**」を列挙します。
`docs/profiling.md` が要求している確保サイト計装でもあります。

```
counter mut-cell 184
counter closure 184
build builtin:ArrayBuilder::new 282
```

**空出力 = 何も確保しない。** 価値は「ソースが言っていない確保」を見せること
—— `counter` の 2 行は **closure の環境確保**と、**捕獲された `let mut` が
heap ref cell になる**ことで、どちらもソースのどこにも書いてありません。

- **`expr_children`** に乗せたので Expr の腕を手書きしません
- **`mut-cell` は `is_mut_captured_in`** に訊きます (`vibe escapes` と同じ述語
  なので 2 つのクエリが食い違えません)。スコープは `ELetMut` の **`rest`**
- **directive 行は削除ではなく空白化**してから parse (長さ不変なので offset が
  実ソースを指したまま)

---

## 2. region の循環回収を実証 (ADR-0090)

ADR-0090 が「**RC の恒久制限の補完**」と書いている性質です。RC は参照循環を
永久に回収できませんが、arena は**グラフを見ずに**回収します。

`MutList::push(l, l)` で自己参照構造を作り、freeze せずに region ごと捨てる:

| | main heap 増分 |
|---|---|
| 200 regions | 4,808 B |
| 800 regions | 19,208 B |
| **限界コスト** | **24 B/region** |

24 B は循環構造ではなく region body の closure 環境です (循環なしの
`region_arena_bounded.vibe` が 32 B/region で同じオーダー)。**循環そのものは
main heap を 1 バイトも使っていません。**

---

## 3. 検査と実測を相互固定 (ADR-0091 checklist の最後)

既存の 2 fixture は「clean な fn が通る」「違反が落ちる」を示しますが、
**注釈が実行時に真であることは示しません** —— 検査が黙って見るのをやめても
両方 green のままです。同じコードについて独立した 2 つの主張を置きます:

- **検査**: `@zero_alloc` が通る
- **実測**: 反復あたり `__heap_ptr` が動かない (200 trips / 800 trips とも
  **delta 260 で同一** = 反復あたり厳密に 0)

`FixedArray` を使うのも主張の一部です —— ADR-0098 (4) が「長さ既知なら
`FixedArray`、成長確保が無いから」と誘導している当のもので、この fixture は
その主張が**測られる**場所でもあります。

---

## 計測設計が 2 本とも本体です

どちらも **総量ではなく 2 点間で判定**します。固定のセットアップコストが
ゼロでない以上、総量では「リークを見逃すほど緩い」か「無関係な変更で壊れる
ほど厳しい」かのどちらかにしかなりません。

そして**どちらの fixture も `inspect` はスカラー**です —— 解放をやめても、
確保が増えても、値は正しいまま。**`__heap_ptr` を測らないと見えない側**で
あることを fixture のコメントに明記しました。

### 途中で踏んだものも記録してあります

- **`heap_delta` が 0 に見えた** —— `export let main` だけで **test ブロックの
  無い**ファイルを `__no_entry__` でコンパイルしたため、`_start` がテスト
  ランナーになり何も実行していませんでした。boundedness を測るときは test
  ブロックが要ります
- **gate の節を失敗ブランチの中に入れてしまい**、正常系では一度も実行されない
  まま「gate 通過」になっていました。**通ったという事実は実行された証拠に
  なりません** —— 節の出力がログに出ることを確認してから push しています

---

## 検証 (最新 main を merge 済み)

```
[compiler-gate] region arena reclaims reference cycles ok (24 B/region)
[compiler-gate] @zero_alloc check and measurement agree ok (0 B/op, 260 B fixed setup)
[compiler-gate] vibe allocs ok (ADR-0091 / #1262)
[compiler-gate] ok
```

- `scripts/unit_test_runner.sh` — **639/639**
- `scripts/check_vibe_fmt.sh` — clean (946 files)
- pre-commit — 通過 (`--no-verify` なし)