### PR TITLE
perf(policy): add trusted selfcompile heap delta substrate

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -120,6 +120,21 @@ local testArtifactInputTrace = new Task {
   }
 }
 
+local testSelfcompileHeapPolicy = new Task {
+  name = "test-selfcompile-heap-policy"
+  description = "fail-closed merge-base selfcompile heap policy and fixed-workdir tests"
+  cmd =
+    "node --test scripts/selfcompile_heap_policy.test.mjs && bash scripts/selfcompile_kpi_work_dir_test.sh"
+  inputs {
+    "scripts/selfcompile_heap_policy.mjs"
+    "scripts/selfcompile_heap_policy.test.mjs"
+    "scripts/selfcompile_kpi.sh"
+    "scripts/selfcompile_kpi_work_dir_test.sh"
+    "bench/perf/selfcompile_heap_policy.json"
+  }
+  cache = false
+}
+
 local testCoverageDriverExposure = new Task {
   name = "test-coverage-driver-exposure"
   description = "exact-path coverage-driver exposure positive/negative integration test"
@@ -1166,6 +1181,7 @@ tasks {
   testIncrementalInvalidationOracle
   testIncrementalInvalidationTrace
   testArtifactInputTrace
+  testSelfcompileHeapPolicy
   testCoverageDriverExposure
   formalSelfhostOracle
   formalSelfhostIncrementalOracle

--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -15,9 +15,12 @@ Driver: `scripts/selfcompile_kpi.sh <stage2.wasm> [input.vibe]`.
 
 One real compile through a selfhost stage2, reporting `wall_ms` and
 `heap_ptr_bytes` (linear backend bump-allocator high-water). With a cold
-isolated `VIBE_BUILD_CACHE_DIR` the heap number is **byte-deterministic**
-for a fixed (stage2, input) pair, so — unlike wall time — it gates CI
-without flakes.
+isolated `VIBE_BUILD_CACHE_DIR` the heap number is byte-deterministic across
+repeated trials in one materialized tree, so — unlike wall time — the current
+absolute gate can use it without flakes. It is **not yet deterministic across
+clean tree reconstructions**: the Phase A comparative smoke found a stable
+16-byte metadata-sensitive split. See the Phase B blocker in
+[`docs/selfcompile-heap-policy.md`](../../docs/selfcompile-heap-policy.md).
 
 CI wiring (`.github/workflows/ci.yml`, step "Selfcompile KPI heap gate"):
 the compiler-gate job runs the script against its freshly-built stage2 and

--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -7,6 +7,12 @@ compiler / checker.
 
 Driver: `scripts/selfcompile_kpi.sh <stage2.wasm> [input.vibe]`.
 
+> Phase A of the merge-base delta replacement is documented in
+> [`docs/selfcompile-heap-policy.md`](../../docs/selfcompile-heap-policy.md).
+> Its controller/policy substrate is not wired into required CI yet. Until the
+> trusted-base Phase B wiring lands, the absolute gate described below remains
+> authoritative; the new policy does not relax it.
+
 One real compile through a selfhost stage2, reporting `wall_ms` and
 `heap_ptr_bytes` (linear backend bump-allocator high-water). With a cold
 isolated `VIBE_BUILD_CACHE_DIR` the heap number is **byte-deterministic**
@@ -20,9 +26,11 @@ fails when `heap_ptr_bytes` exceeds the committed baseline in
 (`VIBE_KPI_MAX_HEAP_BYTES = baseline * 110 / 100`).
 
 The baseline tracks the compiler itself: any change to
-`lib/@vibe/compiler/` (or the default input file) can move it. Rebaseline
-alongside intentional changes — in either direction; ratchet it down after
-an allocation win so the gate protects the win:
+`lib/@vibe/compiler/` (or the default input file) can move it. During the
+Phase A transition, rebaseline alongside intentional changes — in either
+direction; ratchet it down after an allocation win so the old gate protects
+the win. After Phase B this file remains investigation history only; it is not
+an authority for the comparative gate:
 
 ```bash
 bash scripts/generations.sh build --out-dir /tmp/kpi_gen

--- a/bench/perf/selfcompile_heap_policy.json
+++ b/bench/perf/selfcompile_heap_policy.json
@@ -1,0 +1,8 @@
+{
+  "schema": 1,
+  "input": "lib/@vibe/compiler/tests/codegen_lexer_test.vibe",
+  "entry": "__no_entry__",
+  "tolerance_bytes": 0,
+  "emergency_absolute_cap_bytes": 1105822775,
+  "budget_max_lifetime_days": 30
+}

--- a/docs/selfcompile-heap-policy.md
+++ b/docs/selfcompile-heap-policy.md
@@ -29,21 +29,24 @@ after Phase B. They are never enforcement inputs to the comparative policy.
 1. resolves full base/head/current identities and synthesizes `merge-tree`;
 2. rejects a supplied current merge result whose tree is not that merge tree;
 3. reads policy and benchmark input from the base revision;
-4. rejects symlinks in every existing canonical-root ancestor before any
-   recursive deletion, then archives base and current sequentially there;
-5. before writing or executing extracted content, rejects a pinned input or
+4. atomically creates a private mode-`0700` workspace lease under a physical
+   OS temporary directory (or current-UID-owned `RUNNER_TEMP` on CI), verifies
+   its type, owner, mode, and realpath, and reuses its fixed `lease/root` path;
+5. rejects a tracked `_build` entry in either tree before creating that
+   reserved mutation namespace;
+6. before writing or executing extracted content, rejects a pinned input or
    input ancestor symlink and proves its real parent remains under the root;
-6. deletes that root, generated files, caches, HOME, TMPDIR, and VIBE_HOME
-   between revisions;
-7. force-generates and verifies the generated fingerprint, then builds stage2
+7. deletes only the controller-created lease, including generated files,
+   caches, HOME, TMPDIR, and VIBE_HOME, never a caller-selected target;
+8. force-generates and verifies the generated fingerprint, then builds stage2
    at one fixed relative path;
-8. records the stage2 SHA-256 and runs two exact cold-cache heap trials
+9. records the stage2 SHA-256 and runs two exact cold-cache heap trials
    through `scripts/selfcompile_kpi.sh`, using `VIBE_KPI_WORK_DIR` for fixed
    output and cache paths;
-9. rejects any build or heap difference when base and current are the same
+10. rejects any build or heap difference when base and current are the same
    tree, catching stable cross-reconstruction drift as well as within-build
    trial drift;
-10. applies the base policy and emits one machine-readable JSON summary.
+11. applies the base policy and emits one machine-readable JSON summary.
 
 The controller scrubs inherited `VIBE_*`, credentials, `NODE_OPTIONS`, and
 other ambient state by constructing a small environment from scratch. The
@@ -54,21 +57,19 @@ malformed output, and nondeterminism fail closed.
 Local shape (expensive: two clean generation builds and four compiles):
 
 ```bash
-CANONICAL_TMP="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
 node scripts/selfcompile_heap_policy.mjs \
   --repo . \
   --base origin/main \
   --head HEAD \
   --synthesize-merge \
-  --pr-number 1801 \
-  --canonical-root "$CANONICAL_TMP/vibe-selfcompile-policy/root"
+  --pr-number 1801
 ```
 
-CI supplies an event timestamp and the GitHub merge result with `--current`.
-The benchmark root source is always copied from base, so a PR cannot make its
-own workload easier. Every already-existing component of the canonical path
-must be a real directory, not a symlink; resolve a temporary root physically
-as above rather than passing macOS's symlinked `/tmp` spelling.
+There is deliberately no `--canonical-root`: callers cannot select anything
+the controller recursively deletes. CI will supply an event timestamp and the
+GitHub merge result with `--current`; the controller itself leases beneath a
+verified `RUNNER_TEMP`. The benchmark root source is always copied from base,
+so a PR cannot make its own workload easier.
 
 ## Known Phase B blocker: metadata-sensitive 16-byte drift
 
@@ -89,9 +90,12 @@ look like an improvement or unbudgeted growth.
 **Phase B remains blocked.** Do not wire this controller into required CI or
 use its deltas for budget decisions until a trusted policy-only runner
 normalizes stat tokens and repeated same-tree reconstructions make all four
-readings identical. Phase B must also execute the KPI measurement harness from
-base authority (or prove its executable closure unchanged); trusting only the
-base controller is insufficient.
+readings identical. Phase B must execute the complete controller, generation,
+host-runner, and KPI harness closure from immutable base authority. It must run
+base/current in disposable containers with no network, dropped capabilities
+and no-new-privileges, a read-only trusted harness/root filesystem, only
+container-local temporary writable areas, and no writable host mounts. The
+pinned seed and measurement output must also cross trusted boundaries.
 
 ## One-shot growth budgets
 
@@ -126,9 +130,18 @@ work.
 ## Two-phase rollout and repository authority
 
 Phase A lands policy, controller, tests, documentation, and fixed-workdir
-support while retaining the old gate. Phase B must execute the controller
-from the trusted base checkout, add a parallel `selfcompile-heap-policy` job to
-`ci-required`, then retire the old baseline as gate authority. Building base
+support while retaining the old gate. Its threat boundary covers static
+archive redirects for the pinned input/reserved `_build` namespace and
+pre-existing redirects or other-UID attacks on temporary workspace selection.
+A hostile concurrent same-UID process is explicitly excluded. Local execution
+of an untrusted revision is **not sandboxed**: extracted generation scripts and
+the raw compiler filesystem ABI can access the host as the current user.
+
+Phase B/PR CI is forbidden until the immutable-harness and disposable-container
+requirements above, stat-token normalization, policy-path review ownership,
+and strict latest-base governance all land. Only then may a parallel
+`selfcompile-heap-policy` job join `ci-required` and retire the old baseline as
+gate authority. Building base
 and current sequentially is expected to add roughly two clean stage2 builds
 plus four KPI compiles, so the job should run in parallel rather than doubling
 `compiler-gate`'s critical path.

--- a/docs/selfcompile-heap-policy.md
+++ b/docs/selfcompile-heap-policy.md
@@ -1,0 +1,113 @@
+# Selfcompile heap delta policy
+
+Status: **Phase A substrate; not a required CI check yet.** The existing
+absolute gate in `ci.yml` remains authoritative until Phase B lands from a
+base revision that already contains this controller.
+
+## Why compare base and current in one run
+
+`bench/perf/heap_baseline.txt` is useful investigation history, but one old
+absolute number plus a percentage accumulates unrelated growth until a later
+change trips it. The delta policy instead reconstructs the latest target base
+and the PR merge tree, builds them sequentially at one canonical path, and
+measures each twice with cold state. A lower result becomes the next PR's base
+automatically; CI never rewrites a baseline.
+
+The base revision's `bench/perf/selfcompile_heap_policy.json` is the authority
+for a run. Editing that policy cannot make the same PR pass. Its emergency cap
+is `1,105,822,775` bytes, exactly the maximum enforced by the existing gate;
+Phase A does not raise or rebaseline it. The tolerance is zero. A difference
+between either pair of trials is an error rather than tolerated noise.
+
+`bench-data` snapshots and `heap_baseline.txt` remain reporting/history only
+after Phase B. They are never enforcement inputs to the comparative policy.
+
+## Normalized reconstruction
+
+`scripts/selfcompile_heap_policy.mjs`:
+
+1. resolves full base/head/current identities and synthesizes `merge-tree`;
+2. rejects a supplied current merge result whose tree is not that merge tree;
+3. reads policy and benchmark input from the base revision;
+4. archives base and current sequentially into the same canonical root;
+5. deletes that root, generated files, caches, HOME, TMPDIR, and VIBE_HOME
+   between revisions;
+6. force-generates and verifies the generated fingerprint, then builds stage2
+   at one fixed relative path;
+7. records the stage2 SHA-256 and runs two exact cold-cache heap trials
+   through `scripts/selfcompile_kpi.sh`, using `VIBE_KPI_WORK_DIR` for fixed
+   output and cache paths;
+8. rejects any build or heap difference when base and current are the same
+   tree, catching stable cross-reconstruction drift as well as within-build
+   trial drift;
+9. applies the base policy and emits one machine-readable JSON summary.
+
+The controller scrubs inherited `VIBE_*`, credentials, `NODE_OPTIONS`, and
+other ambient state by constructing a small environment from scratch. The
+pinned seed is verified/fetched by the existing generation scripts. Missing
+revisions, conflicts, stale merge results, generation/build failures,
+malformed output, and nondeterminism fail closed.
+
+Local shape (expensive: two clean generation builds and four compiles):
+
+```bash
+node scripts/selfcompile_heap_policy.mjs \
+  --repo . \
+  --base origin/main \
+  --head HEAD \
+  --synthesize-merge \
+  --pr-number 1801 \
+  --canonical-root /tmp/vibe-selfcompile-policy/root
+```
+
+CI supplies an event timestamp and the GitHub merge result with `--current`.
+The benchmark root source is always copied from base, so a PR cannot make its
+own workload easier.
+
+## One-shot growth budgets
+
+Stable growth above zero requires exactly one newly added file under
+`bench/perf/selfcompile_heap_budgets/`. Existing, edited, deleted, stacked,
+expired, wrong-PR, or wrong-base records cannot authorize growth. A budget on
+a non-growing PR is rejected. Unused bytes do not carry forward, and no budget
+can override the emergency cap.
+
+Budget schema 1 has exactly these fields:
+
+```json
+{
+  "schema": 1,
+  "id": "pr-1801-feature-name",
+  "pull_request": 1801,
+  "base_commit": "0123456789abcdef0123456789abcdef01234567",
+  "max_increase_bytes": 8000000,
+  "expires_at": "2026-09-01T00:00:00.000Z",
+  "issue": "https://github.com/mizchi/vibe-lang/issues/1800",
+  "feature": "short feature name",
+  "rationale": "why this measured growth is necessary"
+}
+```
+
+The filename must be `<id>.json`; unknown fields fail. Expiry must be after the
+run timestamp and no more than 30 days after the base commit. A merged record
+is an inert audit record because only a file absent from base can be consumed.
+There is intentionally no budget or exception for parser binder authority
+work.
+
+## Two-phase rollout and repository authority
+
+Phase A lands policy, controller, tests, documentation, and fixed-workdir
+support while retaining the old gate. Phase B must execute the controller
+from the trusted base checkout, add a parallel `selfcompile-heap-policy` job to
+`ci-required`, then retire the old baseline as gate authority. Building base
+and current sequentially is expected to add roughly two clean stage2 builds
+plus four KPI compiles, so the job should run in parallel rather than doubling
+`compiler-gate`'s critical path.
+
+As of Phase A, GitHub's main ruleset requires no review and does not require
+branches to be current with main. Therefore explicit metadata is validated,
+but CI alone cannot attest that a person reviewed it, and stale-green TOCTOU
+remains possible. Before calling budget approvals “repository-reviewed,”
+repository authority must separately require approval/ownership for policy
+and budget paths and strict latest-base checks (or a merge queue). Policy code
+does not pretend to manufacture those permissions.

--- a/docs/selfcompile-heap-policy.md
+++ b/docs/selfcompile-heap-policy.md
@@ -29,18 +29,21 @@ after Phase B. They are never enforcement inputs to the comparative policy.
 1. resolves full base/head/current identities and synthesizes `merge-tree`;
 2. rejects a supplied current merge result whose tree is not that merge tree;
 3. reads policy and benchmark input from the base revision;
-4. archives base and current sequentially into the same canonical root;
-5. deletes that root, generated files, caches, HOME, TMPDIR, and VIBE_HOME
+4. rejects symlinks in every existing canonical-root ancestor before any
+   recursive deletion, then archives base and current sequentially there;
+5. before writing or executing extracted content, rejects a pinned input or
+   input ancestor symlink and proves its real parent remains under the root;
+6. deletes that root, generated files, caches, HOME, TMPDIR, and VIBE_HOME
    between revisions;
-6. force-generates and verifies the generated fingerprint, then builds stage2
+7. force-generates and verifies the generated fingerprint, then builds stage2
    at one fixed relative path;
-7. records the stage2 SHA-256 and runs two exact cold-cache heap trials
+8. records the stage2 SHA-256 and runs two exact cold-cache heap trials
    through `scripts/selfcompile_kpi.sh`, using `VIBE_KPI_WORK_DIR` for fixed
    output and cache paths;
-8. rejects any build or heap difference when base and current are the same
+9. rejects any build or heap difference when base and current are the same
    tree, catching stable cross-reconstruction drift as well as within-build
    trial drift;
-9. applies the base policy and emits one machine-readable JSON summary.
+10. applies the base policy and emits one machine-readable JSON summary.
 
 The controller scrubs inherited `VIBE_*`, credentials, `NODE_OPTIONS`, and
 other ambient state by constructing a small environment from scratch. The
@@ -51,18 +54,44 @@ malformed output, and nondeterminism fail closed.
 Local shape (expensive: two clean generation builds and four compiles):
 
 ```bash
+CANONICAL_TMP="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
 node scripts/selfcompile_heap_policy.mjs \
   --repo . \
   --base origin/main \
   --head HEAD \
   --synthesize-merge \
   --pr-number 1801 \
-  --canonical-root /tmp/vibe-selfcompile-policy/root
+  --canonical-root "$CANONICAL_TMP/vibe-selfcompile-policy/root"
 ```
 
 CI supplies an event timestamp and the GitHub merge result with `--current`.
 The benchmark root source is always copied from base, so a PR cannot make its
-own workload easier.
+own workload easier. Every already-existing component of the canonical path
+must be a real directory, not a symlink; resolve a temporary root physically
+as above rather than passing macOS's symlinked `/tmp` spelling.
+
+## Known Phase B blocker: metadata-sensitive 16-byte drift
+
+The real identical-tree smoke is internally stable but differs across clean
+reconstructions:
+
+- base trials: `924,816,456`, `924,816,456`;
+- current trials: `924,816,440`, `924,816,440`;
+- stage2 SHA-256, benchmark bytes, and normalized paths are identical.
+
+This is source-filesystem metadata sensitivity, not ordinary trial noise.
+`scripts/wasm_vibe_host_runner.js` includes mtime and inode in `Fs::stat_token`,
+and loader cache text stringifies those tokens. Deleting and recreating the
+same bytes changes that metadata; token length/alignment can therefore move
+the guest heap by 16 bytes. For different source trees that hidden drift could
+look like an improvement or unbudgeted growth.
+
+**Phase B remains blocked.** Do not wire this controller into required CI or
+use its deltas for budget decisions until a trusted policy-only runner
+normalizes stat tokens and repeated same-tree reconstructions make all four
+readings identical. Phase B must also execute the KPI measurement harness from
+base authority (or prove its executable closure unchanged); trusting only the
+base controller is insufficient.
 
 ## One-shot growth budgets
 

--- a/scripts/selfcompile_heap_policy.mjs
+++ b/scripts/selfcompile_heap_policy.mjs
@@ -1,0 +1,508 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, writeFileSync, lstatSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const POLICY_PATH = "bench/perf/selfcompile_heap_policy.json";
+const BUDGET_DIR = "bench/perf/selfcompile_heap_budgets";
+const POLICY_KEYS = [
+  "budget_max_lifetime_days",
+  "emergency_absolute_cap_bytes",
+  "entry",
+  "input",
+  "schema",
+  "tolerance_bytes",
+];
+const BUDGET_KEYS = [
+  "base_commit",
+  "expires_at",
+  "feature",
+  "id",
+  "issue",
+  "max_increase_bytes",
+  "pull_request",
+  "rationale",
+  "schema",
+];
+
+export class HeapPolicyError extends Error {
+  constructor(reason, details = {}) {
+    super(reason);
+    this.name = "HeapPolicyError";
+    this.reason = reason;
+    this.details = details;
+  }
+}
+
+function fail(reason, details = {}) {
+  throw new HeapPolicyError(reason, details);
+}
+
+function exactKeys(value, keys, reason) {
+  if (value === null || Array.isArray(value) || typeof value !== "object") fail(reason);
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, i) => key !== expected[i])) {
+    fail(reason, { expected_fields: expected, actual_fields: actual });
+  }
+}
+
+function safeInteger(value, { positive = false, nonnegative = false } = {}) {
+  if (!Number.isSafeInteger(value)) return false;
+  if (positive && value <= 0) return false;
+  if (nonnegative && value < 0) return false;
+  return true;
+}
+
+export function parsePolicy(text) {
+  let policy;
+  try {
+    policy = JSON.parse(text);
+  } catch {
+    fail("malformed-policy");
+  }
+  exactKeys(policy, POLICY_KEYS, "malformed-policy");
+  if (
+    policy.schema !== 1 ||
+    typeof policy.input !== "string" || policy.input.length === 0 || policy.input.startsWith("/") || policy.input.includes("..") ||
+    policy.entry !== "__no_entry__" ||
+    !safeInteger(policy.tolerance_bytes, { nonnegative: true }) ||
+    !safeInteger(policy.emergency_absolute_cap_bytes, { positive: true }) ||
+    !safeInteger(policy.budget_max_lifetime_days, { positive: true })
+  ) fail("malformed-policy");
+  return policy;
+}
+
+export function parseBudget(text, filename) {
+  let budget;
+  try {
+    budget = JSON.parse(text);
+  } catch {
+    fail("malformed-budget", { filename });
+  }
+  exactKeys(budget, BUDGET_KEYS, "malformed-budget");
+  if (
+    budget.schema !== 1 ||
+    typeof budget.id !== "string" || !/^[a-z0-9][a-z0-9-]*$/.test(budget.id) ||
+    filename !== `${budget.id}.json` ||
+    !safeInteger(budget.pull_request, { positive: true }) ||
+    !/^[0-9a-f]{40}$/.test(budget.base_commit) ||
+    !safeInteger(budget.max_increase_bytes, { positive: true }) ||
+    typeof budget.expires_at !== "string" ||
+    typeof budget.issue !== "string" || !/^https:\/\/github\.com\/.+\/issues\/[1-9][0-9]*$/.test(budget.issue) ||
+    typeof budget.feature !== "string" || budget.feature.trim().length === 0 ||
+    typeof budget.rationale !== "string" || budget.rationale.trim().length === 0
+  ) fail("malformed-budget", { filename });
+  const expires = Date.parse(budget.expires_at);
+  if (!Number.isFinite(expires) || new Date(expires).toISOString() !== budget.expires_at) {
+    fail("malformed-budget", { filename });
+  }
+  return { ...budget, expires_ms: expires };
+}
+
+export function evaluatePolicy({
+  policy,
+  baseHeap,
+  currentHeap,
+  budget = null,
+  budgetChangeCount = 0,
+  budgetHasInvalidChange = false,
+  prNumber,
+  baseCommit,
+  baseCommitTimeMs,
+  asOfMs,
+}) {
+  if (!safeInteger(baseHeap, { positive: true }) || !safeInteger(currentHeap, { positive: true })) {
+    fail("malformed-kpi-output");
+  }
+  const delta = currentHeap - baseHeap;
+  if (currentHeap > policy.emergency_absolute_cap_bytes) {
+    fail("absolute-cap-exceeded", {
+      base_heap_bytes: baseHeap,
+      current_heap_bytes: currentHeap,
+      delta_bytes: delta,
+      emergency_absolute_cap_bytes: policy.emergency_absolute_cap_bytes,
+    });
+  }
+  if (budgetHasInvalidChange) fail("budget-reused");
+  if (budgetChangeCount > 1) fail("multiple-budgets");
+  if (delta <= policy.tolerance_bytes) {
+    if (budgetChangeCount !== 0) fail("budget-unnecessary", { delta_bytes: delta });
+    return { decision: "pass", delta_bytes: delta, budget_id: null };
+  }
+  if (!budget || budgetChangeCount === 0) fail("budget-missing", { delta_bytes: delta });
+  if (budget.pull_request !== prNumber) fail("budget-wrong-pr");
+  if (budget.base_commit !== baseCommit) fail("budget-wrong-base");
+  if (budget.expires_ms <= asOfMs) fail("budget-expired");
+  const maxExpiry = baseCommitTimeMs + policy.budget_max_lifetime_days * 86_400_000;
+  if (budget.expires_ms > maxExpiry) fail("budget-expired", { maximum_expires_at: new Date(maxExpiry).toISOString() });
+  if (delta > budget.max_increase_bytes) {
+    fail("budget-over-consumed", { delta_bytes: delta, max_increase_bytes: budget.max_increase_bytes });
+  }
+  return { decision: "pass", delta_bytes: delta, budget_id: budget.id };
+}
+
+function git(repo, args, options = {}) {
+  try {
+    return execFileSync("git", ["-C", repo, ...args], {
+      encoding: options.encoding === null ? null : "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    if (options.reason) fail(options.reason, { command: `git ${args[0]}` });
+    throw error;
+  }
+}
+
+function resolveCommit(repo, revision) {
+  const oid = git(repo, ["rev-parse", "--verify", `${revision}^{commit}`], { reason: "missing-revision" }).trim();
+  if (!/^[0-9a-f]{40}$/.test(oid)) fail("missing-revision", { revision });
+  return oid;
+}
+
+function treeOf(repo, revision) {
+  return git(repo, ["rev-parse", "--verify", `${revision}^{tree}`], { reason: "missing-revision" }).trim();
+}
+
+function synthesizeMergeTree(repo, base, head) {
+  try {
+    const output = git(repo, ["merge-tree", "--write-tree", base, head]).trim().split("\n")[0];
+    if (!/^[0-9a-f]{40}$/.test(output)) fail("merge-conflict");
+    return output;
+  } catch (error) {
+    if (error instanceof HeapPolicyError) throw error;
+    fail("merge-conflict");
+  }
+}
+
+function readTreeFile(repo, treeish, path, reason) {
+  try {
+    return git(repo, ["show", `${treeish}:${path}`], { encoding: null });
+  } catch {
+    fail(reason, { path });
+  }
+}
+
+function treeFileExists(repo, treeish, path) {
+  try {
+    git(repo, ["cat-file", "-e", `${treeish}:${path}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function archiveTree(repo, tree, destination) {
+  mkdirSync(destination, { recursive: true });
+  const archivePath = `${destination}.tar`;
+  rmSync(archivePath, { force: true });
+  try {
+    execFileSync("git", ["-C", repo, "archive", "--format=tar", `--output=${archivePath}`, tree], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    execFileSync("tar", ["-xf", archivePath, "-C", destination], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+  } catch (error) {
+    fail("materialize-failed", { stderr: String(error.stderr ?? "").slice(-4000) });
+  } finally {
+    rmSync(archivePath, { force: true });
+  }
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--synthesize-merge") options.synthesizeMerge = true;
+    else if (arg.startsWith("--")) {
+      const key = arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      if (i + 1 >= argv.length || argv[i + 1].startsWith("--")) fail("invalid-arguments", { argument: arg });
+      options[key] = argv[++i];
+    } else fail("invalid-arguments", { argument: arg });
+  }
+  return options;
+}
+
+function canonicalRootSafe(repo, root) {
+  if (!isAbsolute(root)) fail("unsafe-canonical-root");
+  const resolvedRepo = resolve(repo);
+  const resolvedRoot = resolve(root);
+  if (resolvedRoot === "/" || resolvedRoot === resolvedRepo || !resolvedRoot.includes("vibe-selfcompile-policy")) {
+    fail("unsafe-canonical-root", { canonical_root: resolvedRoot });
+  }
+  const rel = relative(resolvedRepo, resolvedRoot);
+  if (rel === "" || (!rel.startsWith(".." + sep) && rel !== "..")) fail("unsafe-canonical-root");
+  try {
+    if (lstatSync(resolvedRoot).isSymbolicLink()) fail("unsafe-canonical-root");
+  } catch (error) {
+    if (error instanceof HeapPolicyError) throw error;
+    if (error.code !== "ENOENT") throw error;
+  }
+  return resolvedRoot;
+}
+
+function cleanEnvironment(root) {
+  const envRoot = join(root, "_build", "selfcompile-policy", "environment");
+  const home = join(envRoot, "home");
+  const tmp = join(envRoot, "tmp");
+  const vibeHome = join(envRoot, "vibe-home");
+  mkdirSync(home, { recursive: true });
+  mkdirSync(tmp, { recursive: true });
+  mkdirSync(vibeHome, { recursive: true });
+  return {
+    PATH: process.env.PATH ?? "/usr/bin:/bin",
+    HOME: home,
+    TMPDIR: tmp,
+    VIBE_HOME: vibeHome,
+    LC_ALL: "C",
+    LANG: "C",
+    TZ: "UTC",
+    SOURCE_DATE_EPOCH: "0",
+    VIBE_RC: "0",
+    VIBE_DISABLE_PERSISTENT_ARTIFACT_CACHE: "1",
+  };
+}
+
+function runChecked(command, args, cwd, env, reason, capture = false) {
+  try {
+    return execFileSync(command, args, {
+      cwd,
+      env,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ["ignore", capture ? "pipe" : "ignore", "pipe"],
+    });
+  } catch (error) {
+    fail(reason, { command: `${command} ${args.join(" ")}`, stderr: String(error.stderr ?? "").slice(-4000) });
+  }
+}
+
+function parseMeasurement(output) {
+  const lines = output.split(/\r?\n/).filter(line => line.startsWith("[selfcompile-kpi] input="));
+  if (lines.length !== 1) fail("malformed-kpi-output", { kpi_lines: lines.length });
+  const match = lines[0].match(/\bheap_ptr_bytes=([0-9]+)\b/);
+  if (!match) fail("malformed-kpi-output");
+  const value = Number(match[1]);
+  if (!safeInteger(value, { positive: true })) fail("malformed-kpi-output");
+  return value;
+}
+
+async function measureTreeOnce({ repo, tree, label, root, inputBlob, policy, testDriver }) {
+  rmSync(root, { recursive: true, force: true });
+  await archiveTree(repo, tree, root);
+  const inputPath = join(root, policy.input);
+  mkdirSync(dirname(inputPath), { recursive: true });
+  writeFileSync(inputPath, inputBlob);
+  const env = cleanEnvironment(root);
+  const generationDir = join(root, "_build", "selfcompile-policy", "generation");
+  const stage2 = join(generationDir, "stage2.wasm");
+  const workDir = join(root, "_build", "selfcompile-policy", "kpi-work");
+
+  if (testDriver) {
+    if (process.env.VIBE_HEAP_POLICY_TEST_MODE !== "1") fail("test-driver-forbidden");
+    runChecked(process.execPath, [testDriver, "build"], root, {
+      ...env,
+      POLICY_REVISION: label,
+      POLICY_CANONICAL_ROOT: root,
+      POLICY_STAGE2: stage2,
+      POLICY_INPUT: inputPath,
+      POLICY_WORK_DIR: workDir,
+    }, "build-failed");
+  } else {
+    runChecked("bash", ["scripts/ensure_generated.sh", "--force"], root, env, "generated-failed");
+    const expected = runChecked("bash", ["scripts/ensure_generated.sh", "--print-fingerprint"], root, env, "generated-failed", true).trim();
+    let stamp = "";
+    try { stamp = readFileSync(join(root, "lib/@vibe/compiler/.generated.stamp"), "utf8").trim(); } catch {}
+    if (stamp !== expected) fail("generated-fingerprint-mismatch", { expected, actual: stamp });
+    runChecked("bash", ["scripts/generations.sh", "build", "--out-dir", generationDir, "--skip-run-validation"], root, env, "build-failed");
+  }
+
+  let stage2Sha256;
+  try {
+    stage2Sha256 = createHash("sha256").update(readFileSync(stage2)).digest("hex");
+  } catch {
+    fail("build-failed", { missing: stage2 });
+  }
+
+  const trials = [];
+  for (let trial = 1; trial <= 2; trial += 1) {
+    let output;
+    if (testDriver) {
+      output = runChecked(process.execPath, [testDriver, "measure", String(trial)], root, {
+        ...env,
+        POLICY_REVISION: label,
+        POLICY_CANONICAL_ROOT: root,
+        POLICY_STAGE2: stage2,
+        POLICY_INPUT: inputPath,
+        POLICY_WORK_DIR: workDir,
+      }, "build-failed", true);
+    } else {
+      output = runChecked("bash", ["scripts/selfcompile_kpi.sh", stage2, policy.input], root, {
+        ...env,
+        VIBE_KPI_WORK_DIR: workDir,
+        VIBE_KPI_ALLOWED_WORK_ROOT: join(root, "_build"),
+      }, "build-failed", true);
+    }
+    trials.push(parseMeasurement(output));
+  }
+  if (trials[0] !== trials[1]) fail("nondeterministic-heap", { revision: label, trials });
+  return {
+    heap_bytes: trials[0],
+    trials,
+    stage2_sha256: stage2Sha256,
+    normalized_paths: {
+      canonical_root: root,
+      input: policy.input,
+      stage2: "_build/selfcompile-policy/generation/stage2.wasm",
+      output: "_build/selfcompile-policy/kpi-work/out.wasm",
+      cache: "_build/selfcompile-policy/kpi-work/cache",
+      home: "_build/selfcompile-policy/environment/home",
+      tmpdir: "_build/selfcompile-policy/environment/tmp",
+      vibe_home: "_build/selfcompile-policy/environment/vibe-home",
+    },
+  };
+}
+
+async function measureTree(args) {
+  try {
+    return await measureTreeOnce(args);
+  } finally {
+    rmSync(args.root, { recursive: true, force: true });
+  }
+}
+
+function budgetChanges(repo, base, currentTree) {
+  let output = "";
+  try {
+    output = git(repo, ["diff", "--no-renames", "--name-status", "-z", base, currentTree, "--", BUDGET_DIR]);
+  } catch {
+    fail("budget-diff-failed");
+  }
+  const parts = output.split("\0").filter(Boolean);
+  const added = [];
+  let invalid = false;
+  for (let i = 0; i < parts.length; i += 2) {
+    const status = parts[i];
+    const path = parts[i + 1];
+    if (!path) fail("budget-diff-failed");
+    if (status === "A") added.push(path);
+    else invalid = true;
+  }
+  return { added, invalid };
+}
+
+export async function runController(options) {
+  const repo = resolve(options.repo ?? ".");
+  const root = canonicalRootSafe(repo, options.canonicalRoot ?? "");
+  if (!options.base || !options.head || !options.prNumber) fail("invalid-arguments");
+  const prNumber = Number(options.prNumber);
+  if (!safeInteger(prNumber, { positive: true })) fail("invalid-arguments");
+  const base = resolveCommit(repo, options.base);
+  const head = resolveCommit(repo, options.head);
+  const mergeTree = synthesizeMergeTree(repo, base, head);
+  let currentTree = mergeTree;
+  let current = null;
+  if (options.current) {
+    current = resolveCommit(repo, options.current);
+    try {
+      git(repo, ["merge-base", "--is-ancestor", base, current]);
+    } catch {
+      fail("stale-or-wrong-merge-result");
+    }
+    const actualTree = treeOf(repo, current);
+    if (actualTree !== mergeTree) fail("stale-or-wrong-merge-result", { expected_tree: mergeTree, actual_tree: actualTree });
+    currentTree = actualTree;
+  } else if (!options.synthesizeMerge) {
+    fail("invalid-arguments", { missing: "--current or --synthesize-merge" });
+  }
+
+  const policyText = readTreeFile(repo, base, POLICY_PATH, "malformed-policy").toString("utf8");
+  const policy = parsePolicy(policyText);
+  if (!treeFileExists(repo, currentTree, POLICY_PATH)) fail("malformed-policy", { path: POLICY_PATH });
+  const currentPolicyText = readTreeFile(repo, currentTree, POLICY_PATH, "malformed-policy").toString("utf8");
+  parsePolicy(currentPolicyText); // Future/base policy must remain usable even though it cannot authorize this run.
+  const policyChanged = currentPolicyText !== policyText;
+  const inputBlob = readTreeFile(repo, base, policy.input, "benchmark-input-missing");
+  const changes = budgetChanges(repo, base, currentTree);
+  let budget = null;
+  if (changes.added.length === 1) {
+    const path = changes.added[0];
+    if (dirname(path) !== BUDGET_DIR) fail("malformed-budget", { path });
+    budget = parseBudget(readTreeFile(repo, currentTree, path, "malformed-budget").toString("utf8"), path.slice(BUDGET_DIR.length + 1));
+  }
+
+  const baseCommitTime = Number(git(repo, ["show", "-s", "--format=%ct", base]).trim()) * 1000;
+  const asOfMs = options.asOf ? Date.parse(options.asOf) : Date.now();
+  if (!Number.isFinite(asOfMs)) fail("invalid-arguments", { argument: "--as-of" });
+  const baseResult = await measureTree({ repo, tree: treeOf(repo, base), label: "base", root, inputBlob, policy, testDriver: options.testDriver });
+  const currentResult = await measureTree({ repo, tree: currentTree, label: "current", root, inputBlob, policy, testDriver: options.testDriver });
+  if (treeOf(repo, base) === currentTree) {
+    if (baseResult.stage2_sha256 !== currentResult.stage2_sha256) {
+      fail("nondeterministic-build", {
+        base_stage2_sha256: baseResult.stage2_sha256,
+        current_stage2_sha256: currentResult.stage2_sha256,
+      });
+    }
+    if (baseResult.heap_bytes !== currentResult.heap_bytes) {
+      fail("nondeterministic-heap", {
+        revision: "identical-tree-reconstruction",
+        trials: [...baseResult.trials, ...currentResult.trials],
+      });
+    }
+  }
+  const evaluation = evaluatePolicy({
+    policy,
+    baseHeap: baseResult.heap_bytes,
+    currentHeap: currentResult.heap_bytes,
+    budget,
+    budgetChangeCount: changes.added.length,
+    budgetHasInvalidChange: changes.invalid,
+    prNumber,
+    baseCommit: base,
+    baseCommitTimeMs: baseCommitTime,
+    asOfMs,
+  });
+  rmSync(root, { recursive: true, force: true });
+  return {
+    schema: 1,
+    decision: evaluation.decision,
+    base_commit: base,
+    head_commit: head,
+    current_commit: current,
+    measured_tree: currentTree,
+    policy_source_commit: base,
+    policy_change_effective_this_run: false,
+    policy_changed: policyChanged,
+    base_heap_bytes: baseResult.heap_bytes,
+    current_heap_bytes: currentResult.heap_bytes,
+    delta_bytes: evaluation.delta_bytes,
+    tolerance_bytes: policy.tolerance_bytes,
+    emergency_absolute_cap_bytes: policy.emergency_absolute_cap_bytes,
+    budget_id: evaluation.budget_id,
+    trials: { base: baseResult.trials, current: currentResult.trials },
+    stage2_sha256: { base: baseResult.stage2_sha256, current: currentResult.stage2_sha256 },
+    normalized_paths: baseResult.normalized_paths,
+    benchmark_input_source_commit: base,
+  };
+}
+
+async function main() {
+  try {
+    const result = await runController(parseArgs(process.argv.slice(2)));
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    const reason = error instanceof HeapPolicyError ? error.reason : "internal-error";
+    const details = error instanceof HeapPolicyError ? error.details : { message: String(error?.stack ?? error) };
+    process.stderr.write(`[heap-policy] FAIL reason=${reason}\n`);
+    process.stdout.write(`${JSON.stringify({ schema: 1, decision: "fail", reason, ...details })}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/selfcompile_heap_policy.mjs
+++ b/scripts/selfcompile_heap_policy.mjs
@@ -1,7 +1,17 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, rmSync, writeFileSync, lstatSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -227,6 +237,15 @@ function parseArgs(argv) {
   return options;
 }
 
+function lstatIfPresent(path) {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
 function canonicalRootSafe(repo, root) {
   if (!isAbsolute(root)) fail("unsafe-canonical-root");
   const resolvedRepo = resolve(repo);
@@ -236,13 +255,81 @@ function canonicalRootSafe(repo, root) {
   }
   const rel = relative(resolvedRepo, resolvedRoot);
   if (rel === "" || (!rel.startsWith(".." + sep) && rel !== "..")) fail("unsafe-canonical-root");
-  try {
-    if (lstatSync(resolvedRoot).isSymbolicLink()) fail("unsafe-canonical-root");
-  } catch (error) {
-    if (error instanceof HeapPolicyError) throw error;
-    if (error.code !== "ENOENT") throw error;
+
+  const ancestry = [];
+  let cursor = resolvedRoot;
+  while (true) {
+    ancestry.push(cursor);
+    const parent = dirname(cursor);
+    if (parent === cursor) break;
+    cursor = parent;
   }
+  ancestry.reverse();
+  let nearestExisting = null;
+  for (const path of ancestry) {
+    const info = lstatIfPresent(path);
+    if (!info) break;
+    if (info.isSymbolicLink()) fail("unsafe-canonical-root", { symlink: path });
+    if (!info.isDirectory()) fail("unsafe-canonical-root", { non_directory: path });
+    nearestExisting = path;
+  }
+  if (!nearestExisting) fail("unsafe-canonical-root");
+  const nearestReal = realpathSync(nearestExisting);
+  const projectedRoot = resolve(nearestReal, relative(nearestExisting, resolvedRoot));
+  const projectedRelative = relative(nearestReal, projectedRoot);
+  if (
+    projectedRoot !== resolvedRoot ||
+    projectedRelative === ".." || projectedRelative.startsWith(".." + sep) || isAbsolute(projectedRelative)
+  ) fail("unsafe-canonical-root", { canonical_root: resolvedRoot, nearest_existing_realpath: nearestReal });
   return resolvedRoot;
+}
+
+function removeCanonicalRoot(repo, root) {
+  const safeRoot = canonicalRootSafe(repo, root);
+  rmSync(safeRoot, { recursive: true, force: true });
+}
+
+function pinnedInputPathSafe(root, input) {
+  const rootReal = realpathSync(root);
+  if (rootReal !== root) fail("unsafe-pinned-input", { root, root_realpath: rootReal });
+  const inputPath = join(root, input);
+  const inputRelative = relative(root, inputPath);
+  if (inputRelative === "" || inputRelative === ".." || inputRelative.startsWith(".." + sep) || isAbsolute(inputRelative)) {
+    fail("unsafe-pinned-input", { input });
+  }
+  const parts = inputRelative.split(sep);
+  let cursor = root;
+  for (let i = 0; i < parts.length; i += 1) {
+    cursor = join(cursor, parts[i]);
+    const info = lstatIfPresent(cursor);
+    const isFinal = i === parts.length - 1;
+    if (!info) {
+      if (!isFinal) fail("unsafe-pinned-input", { missing_ancestor: cursor });
+      break;
+    }
+    if (info.isSymbolicLink()) fail("unsafe-pinned-input", { symlink: cursor });
+    if (!isFinal && !info.isDirectory()) fail("unsafe-pinned-input", { non_directory_ancestor: cursor });
+    if (isFinal && !info.isFile()) fail("unsafe-pinned-input", { non_file: cursor });
+  }
+  const parent = dirname(inputPath);
+  const parentReal = realpathSync(parent);
+  const parentRelative = relative(rootReal, parentReal);
+  if (parentRelative === ".." || parentRelative.startsWith(".." + sep) || isAbsolute(parentRelative)) {
+    fail("unsafe-pinned-input", { input_parent_realpath: parentReal });
+  }
+  return inputPath;
+}
+
+function overwritePinnedInput(inputPath, inputBlob) {
+  let fd;
+  try {
+    fd = openSync(inputPath, constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW, 0o600);
+    writeFileSync(fd, inputBlob);
+  } catch (error) {
+    fail("unsafe-pinned-input", { path: inputPath, code: error.code });
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
 }
 
 function cleanEnvironment(root) {
@@ -292,11 +379,12 @@ function parseMeasurement(output) {
 }
 
 async function measureTreeOnce({ repo, tree, label, root, inputBlob, policy, testDriver }) {
-  rmSync(root, { recursive: true, force: true });
+  removeCanonicalRoot(repo, root);
   await archiveTree(repo, tree, root);
-  const inputPath = join(root, policy.input);
-  mkdirSync(dirname(inputPath), { recursive: true });
-  writeFileSync(inputPath, inputBlob);
+  // The merge tree is untrusted. Validate before writing the pinned base input
+  // or executing any extracted script; tracked symlinks must not escape root.
+  const inputPath = pinnedInputPathSafe(root, policy.input);
+  overwritePinnedInput(inputPath, inputBlob);
   const env = cleanEnvironment(root);
   const generationDir = join(root, "_build", "selfcompile-policy", "generation");
   const stage2 = join(generationDir, "stage2.wasm");
@@ -371,7 +459,7 @@ async function measureTree(args) {
   try {
     return await measureTreeOnce(args);
   } finally {
-    rmSync(args.root, { recursive: true, force: true });
+    removeCanonicalRoot(args.repo, args.root);
   }
 }
 
@@ -466,7 +554,7 @@ export async function runController(options) {
     baseCommitTimeMs: baseCommitTime,
     asOfMs,
   });
-  rmSync(root, { recursive: true, force: true });
+  removeCanonicalRoot(repo, root);
   return {
     schema: 1,
     decision: evaluation.decision,

--- a/scripts/selfcompile_heap_policy.mjs
+++ b/scripts/selfcompile_heap_policy.mjs
@@ -2,16 +2,19 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  chmodSync,
   closeSync,
   constants,
   lstatSync,
   mkdirSync,
+  mkdtempSync,
   openSync,
   readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import os from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -205,6 +208,14 @@ function treeFileExists(repo, treeish, path) {
   }
 }
 
+function rejectReservedTreeEntries(repo, trees) {
+  for (const tree of trees) {
+    if (treeFileExists(repo, tree, "_build")) {
+      fail("reserved-path-present", { tree, path: "_build" });
+    }
+  }
+}
+
 function archiveTree(repo, tree, destination) {
   mkdirSync(destination, { recursive: true });
   const archivePath = `${destination}.tar`;
@@ -227,6 +238,7 @@ function parseArgs(argv) {
   const options = {};
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
+    if (arg === "--canonical-root") fail("invalid-arguments", { removed: "--canonical-root" });
     if (arg === "--synthesize-merge") options.synthesizeMerge = true;
     else if (arg.startsWith("--")) {
       const key = arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
@@ -246,47 +258,80 @@ function lstatIfPresent(path) {
   }
 }
 
-function canonicalRootSafe(repo, root) {
-  if (!isAbsolute(root)) fail("unsafe-canonical-root");
-  const resolvedRepo = resolve(repo);
-  const resolvedRoot = resolve(root);
-  if (resolvedRoot === "/" || resolvedRoot === resolvedRepo || !resolvedRoot.includes("vibe-selfcompile-policy")) {
-    fail("unsafe-canonical-root", { canonical_root: resolvedRoot });
-  }
-  const rel = relative(resolvedRepo, resolvedRoot);
-  if (rel === "" || (!rel.startsWith(".." + sep) && rel !== "..")) fail("unsafe-canonical-root");
-
+function verifyPhysicalDirectory(path, { requireOwner, reason }) {
+  if (!isAbsolute(path)) fail(reason, { path });
+  const resolved = resolve(path);
   const ancestry = [];
-  let cursor = resolvedRoot;
+  let cursor = resolved;
   while (true) {
     ancestry.push(cursor);
     const parent = dirname(cursor);
     if (parent === cursor) break;
     cursor = parent;
   }
-  ancestry.reverse();
-  let nearestExisting = null;
-  for (const path of ancestry) {
-    const info = lstatIfPresent(path);
-    if (!info) break;
-    if (info.isSymbolicLink()) fail("unsafe-canonical-root", { symlink: path });
-    if (!info.isDirectory()) fail("unsafe-canonical-root", { non_directory: path });
-    nearestExisting = path;
+  for (const ancestor of ancestry.reverse()) {
+    const info = lstatIfPresent(ancestor);
+    if (!info) fail(reason, { missing: ancestor });
+    if (info.isSymbolicLink() || !info.isDirectory()) fail(reason, { unsafe_ancestor: ancestor });
   }
-  if (!nearestExisting) fail("unsafe-canonical-root");
-  const nearestReal = realpathSync(nearestExisting);
-  const projectedRoot = resolve(nearestReal, relative(nearestExisting, resolvedRoot));
-  const projectedRelative = relative(nearestReal, projectedRoot);
-  if (
-    projectedRoot !== resolvedRoot ||
-    projectedRelative === ".." || projectedRelative.startsWith(".." + sep) || isAbsolute(projectedRelative)
-  ) fail("unsafe-canonical-root", { canonical_root: resolvedRoot, nearest_existing_realpath: nearestReal });
-  return resolvedRoot;
+  const info = lstatSync(resolved);
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (requireOwner && uid !== null && info.uid !== uid) fail(reason, { path: resolved, expected_uid: uid, actual_uid: info.uid });
+  if (realpathSync(resolved) !== resolved) fail(reason, { path: resolved, realpath: realpathSync(resolved) });
+  return resolved;
 }
 
-function removeCanonicalRoot(repo, root) {
-  const safeRoot = canonicalRootSafe(repo, root);
-  rmSync(safeRoot, { recursive: true, force: true });
+const activeWorkspaceLeases = new Set();
+
+function verifyWorkspaceLease(lease) {
+  if (!activeWorkspaceLeases.has(lease)) fail("unsafe-workspace-lease", { lease });
+  const info = lstatSync(lease);
+  const uid = typeof process.getuid === "function" ? process.getuid() : null;
+  if (
+    info.isSymbolicLink() || !info.isDirectory() ||
+    (uid !== null && info.uid !== uid) ||
+    (info.mode & 0o777) !== 0o700 ||
+    realpathSync(lease) !== lease
+  ) fail("unsafe-workspace-lease", { lease });
+}
+
+function createWorkspaceLease() {
+  const ci = process.env.GITHUB_ACTIONS === "true";
+  let tempBase;
+  if (ci) {
+    if (!process.env.RUNNER_TEMP) fail("unsafe-runner-temp");
+    tempBase = verifyPhysicalDirectory(process.env.RUNNER_TEMP, { requireOwner: true, reason: "unsafe-runner-temp" });
+  } else {
+    tempBase = verifyPhysicalDirectory(realpathSync(os.tmpdir()), { requireOwner: false, reason: "unsafe-local-temp" });
+  }
+  const lease = mkdtempSync(join(tempBase, "vibe-selfcompile-policy-"));
+  chmodSync(lease, 0o700);
+  activeWorkspaceLeases.add(lease);
+  try {
+    verifyWorkspaceLease(lease);
+  } catch (error) {
+    activeWorkspaceLeases.delete(lease);
+    rmSync(lease, { recursive: true, force: true });
+    throw error;
+  }
+  return lease;
+}
+
+function resetWorkspaceRoot(lease) {
+  verifyWorkspaceLease(lease);
+  const root = join(lease, "root");
+  const info = lstatIfPresent(root);
+  if (info?.isSymbolicLink()) fail("unsafe-workspace-lease", { symlink: root });
+  if (info && !info.isDirectory()) fail("unsafe-workspace-lease", { non_directory: root });
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(root, { mode: 0o700 });
+  return root;
+}
+
+function removeWorkspaceLease(lease) {
+  verifyWorkspaceLease(lease);
+  rmSync(lease, { recursive: true, force: true });
+  activeWorkspaceLeases.delete(lease);
 }
 
 function pinnedInputPathSafe(root, input) {
@@ -378,8 +423,8 @@ function parseMeasurement(output) {
   return value;
 }
 
-async function measureTreeOnce({ repo, tree, label, root, inputBlob, policy, testDriver }) {
-  removeCanonicalRoot(repo, root);
+async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, testDriver }) {
+  const root = resetWorkspaceRoot(lease);
   await archiveTree(repo, tree, root);
   // The merge tree is untrusted. Validate before writing the pinned base input
   // or executing any extracted script; tracked symlinks must not escape root.
@@ -456,11 +501,7 @@ async function measureTreeOnce({ repo, tree, label, root, inputBlob, policy, tes
 }
 
 async function measureTree(args) {
-  try {
-    return await measureTreeOnce(args);
-  } finally {
-    removeCanonicalRoot(args.repo, args.root);
-  }
+  return await measureTreeOnce(args);
 }
 
 function budgetChanges(repo, base, currentTree) {
@@ -483,9 +524,9 @@ function budgetChanges(repo, base, currentTree) {
   return { added, invalid };
 }
 
-export async function runController(options) {
+async function runControllerWithLease(options, lease) {
   const repo = resolve(options.repo ?? ".");
-  const root = canonicalRootSafe(repo, options.canonicalRoot ?? "");
+  const root = join(lease, "root");
   if (!options.base || !options.head || !options.prNumber) fail("invalid-arguments");
   const prNumber = Number(options.prNumber);
   if (!safeInteger(prNumber, { positive: true })) fail("invalid-arguments");
@@ -507,6 +548,8 @@ export async function runController(options) {
   } else if (!options.synthesizeMerge) {
     fail("invalid-arguments", { missing: "--current or --synthesize-merge" });
   }
+  const baseTree = treeOf(repo, base);
+  rejectReservedTreeEntries(repo, [baseTree, currentTree]);
 
   const policyText = readTreeFile(repo, base, POLICY_PATH, "malformed-policy").toString("utf8");
   const policy = parsePolicy(policyText);
@@ -526,9 +569,9 @@ export async function runController(options) {
   const baseCommitTime = Number(git(repo, ["show", "-s", "--format=%ct", base]).trim()) * 1000;
   const asOfMs = options.asOf ? Date.parse(options.asOf) : Date.now();
   if (!Number.isFinite(asOfMs)) fail("invalid-arguments", { argument: "--as-of" });
-  const baseResult = await measureTree({ repo, tree: treeOf(repo, base), label: "base", root, inputBlob, policy, testDriver: options.testDriver });
-  const currentResult = await measureTree({ repo, tree: currentTree, label: "current", root, inputBlob, policy, testDriver: options.testDriver });
-  if (treeOf(repo, base) === currentTree) {
+  const baseResult = await measureTree({ repo, tree: baseTree, label: "base", lease, inputBlob, policy, testDriver: options.testDriver });
+  const currentResult = await measureTree({ repo, tree: currentTree, label: "current", lease, inputBlob, policy, testDriver: options.testDriver });
+  if (baseTree === currentTree) {
     if (baseResult.stage2_sha256 !== currentResult.stage2_sha256) {
       fail("nondeterministic-build", {
         base_stage2_sha256: baseResult.stage2_sha256,
@@ -554,7 +597,6 @@ export async function runController(options) {
     baseCommitTimeMs: baseCommitTime,
     asOfMs,
   });
-  removeCanonicalRoot(repo, root);
   return {
     schema: 1,
     decision: evaluation.decision,
@@ -576,6 +618,16 @@ export async function runController(options) {
     normalized_paths: baseResult.normalized_paths,
     benchmark_input_source_commit: base,
   };
+}
+
+export async function runController(options) {
+  if (options.canonicalRoot !== undefined) fail("invalid-arguments", { removed: "--canonical-root" });
+  const lease = createWorkspaceLease();
+  try {
+    return await runControllerWithLease(options, lease);
+  } finally {
+    removeWorkspaceLease(lease);
+  }
 }
 
 async function main() {

--- a/scripts/selfcompile_heap_policy.test.mjs
+++ b/scripts/selfcompile_heap_policy.test.mjs
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -124,7 +132,7 @@ function commitAll(repo, message, date) {
 }
 
 function makeRepository() {
-  const outer = mkdtempSync(join(os.tmpdir(), "heap-policy-test-"));
+  const outer = mkdtempSync(join(realpathSync(os.tmpdir()), "heap-policy-test-"));
   const repo = join(outer, "repo");
   mkdirSync(repo);
   command(repo, ["init", "-q"]);
@@ -180,6 +188,51 @@ async function controller(options) {
     else process.env.VIBE_HEAP_POLICY_TEST_MODE = old;
   }
 }
+
+test("canonical root rejects a symlinked existing parent before recursive deletion", async () => {
+  const fixture = makeRepository();
+  const driver = makeDriver(fixture.outer);
+  const victim = join(fixture.outer, "victim");
+  const victimRoot = join(victim, "root");
+  mkdirSync(victimRoot, { recursive: true });
+  const marker = join(victimRoot, "must-survive.txt");
+  writeFileSync(marker, "untouched\n");
+  const symlinkParent = join(fixture.outer, "vibe-selfcompile-policy-attack");
+  symlinkSync(victim, symlinkParent, "dir");
+  await assert.rejects(() => controller({
+    repo: fixture.repo, base: fixture.initial, head: fixture.initial,
+    synthesizeMerge: true, prNumber: "1801",
+    canonicalRoot: join(symlinkParent, "root"), testDriver: driver,
+  }), error => error.reason === "unsafe-canonical-root");
+  assert.equal(readFileSync(marker, "utf8"), "untouched\n");
+});
+
+test("tracked escaping input symlinks fail before the pinned input write", async () => {
+  for (const symlinkAt of ["input", "ancestor"]) {
+    const fixture = makeRepository();
+    const driver = makeDriver(fixture.outer);
+    const external = join(fixture.outer, `external-${symlinkAt}`);
+    mkdirSync(external);
+    const target = join(external, "target.vibe");
+    writeFileSync(target, "must remain unchanged\n");
+    const inputPath = join(fixture.repo, fixture.input);
+    if (symlinkAt === "input") {
+      rmSync(inputPath);
+      symlinkSync(target, inputPath);
+    } else {
+      const inputParent = dirname(inputPath);
+      rmSync(inputParent, { recursive: true });
+      symlinkSync(external, inputParent, "dir");
+    }
+    const head = commitAll(fixture.repo, `escaping ${symlinkAt} symlink`, "2026-08-01T01:00:00Z");
+    const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
+    await assert.rejects(() => controller({
+      repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
+      prNumber: "1801", canonicalRoot: root, testDriver: driver,
+    }), error => error.reason === "unsafe-pinned-input");
+    assert.equal(readFileSync(target, "utf8"), "must remain unchanged\n");
+  }
+});
 
 test("controller synthesizes latest-base merge, pins input, reuses exact paths, and isolates revisions", async () => {
   const fixture = makeRepository();

--- a/scripts/selfcompile_heap_policy.test.mjs
+++ b/scripts/selfcompile_heap_policy.test.mjs
@@ -1,0 +1,292 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import {
+  HeapPolicyError,
+  evaluatePolicy,
+  parseBudget,
+  parsePolicy,
+  runController,
+} from "./selfcompile_heap_policy.mjs";
+
+const policy = parsePolicy(JSON.stringify({
+  schema: 1,
+  input: "lib/@vibe/compiler/tests/codegen_lexer_test.vibe",
+  entry: "__no_entry__",
+  tolerance_bytes: 0,
+  emergency_absolute_cap_bytes: 1_105_822_775,
+  budget_max_lifetime_days: 30,
+}));
+const baseCommit = "a".repeat(40);
+const baseTime = Date.parse("2026-08-01T00:00:00.000Z");
+const asOf = Date.parse("2026-08-02T00:00:00.000Z");
+
+function budget(overrides = {}) {
+  const raw = {
+    schema: 1,
+    id: "pr-1801-feature",
+    pull_request: 1801,
+    base_commit: baseCommit,
+    max_increase_bytes: 8_000_000,
+    expires_at: "2026-08-10T00:00:00.000Z",
+    issue: "https://github.com/mizchi/vibe-lang/issues/1800",
+    feature: "feature",
+    rationale: "measured and reviewed growth",
+    ...overrides,
+  };
+  return parseBudget(JSON.stringify(raw), `${raw.id}.json`);
+}
+
+function evaluate(overrides = {}) {
+  return evaluatePolicy({
+    policy,
+    baseHeap: 1_000_000_000,
+    currentHeap: 1_000_000_000,
+    budget: null,
+    budgetChangeCount: 0,
+    budgetHasInvalidChange: false,
+    prNumber: 1801,
+    baseCommit,
+    baseCommitTimeMs: baseTime,
+    asOfMs: asOf,
+    ...overrides,
+  });
+}
+
+function reason(fn, expected) {
+  assert.throws(fn, error => error instanceof HeapPolicyError && error.reason === expected);
+}
+
+test("equal and improvements pass without creating authority", () => {
+  assert.equal(evaluate().delta_bytes, 0);
+  assert.equal(evaluate({ currentHeap: 900_000_000 }).delta_bytes, -100_000_000);
+  // The improved current becomes the next comparison's base: one byte back is red.
+  reason(() => evaluate({ baseHeap: 900_000_000, currentHeap: 900_000_001 }), "budget-missing");
+});
+
+test("one byte growth is fail-closed and a valid one-shot budget is bounded", () => {
+  reason(() => evaluate({ currentHeap: 1_000_000_001 }), "budget-missing");
+  assert.equal(evaluate({
+    currentHeap: 1_000_000_001,
+    budget: budget(),
+    budgetChangeCount: 1,
+  }).budget_id, "pr-1801-feature");
+  reason(() => evaluate({
+    currentHeap: 1_009_000_000,
+    budget: budget(),
+    budgetChangeCount: 1,
+  }), "budget-over-consumed");
+});
+
+test("budget provenance, expiry, reuse, multiplicity, and necessity are enforced", () => {
+  const growing = { currentHeap: 1_000_000_001, budgetChangeCount: 1 };
+  reason(() => evaluate({ ...growing, budget: budget({ pull_request: 1802 }) }), "budget-wrong-pr");
+  reason(() => evaluate({ ...growing, budget: budget({ base_commit: "b".repeat(40) }) }), "budget-wrong-base");
+  reason(() => evaluate({ ...growing, budget: budget({ expires_at: "2026-08-01T00:00:00.000Z" }) }), "budget-expired");
+  reason(() => evaluate({ ...growing, budget: budget({ expires_at: "2026-09-10T00:00:00.000Z" }) }), "budget-expired");
+  reason(() => evaluate({ ...growing, budget: budget(), budgetHasInvalidChange: true }), "budget-reused");
+  reason(() => evaluate({ ...growing, budget: budget(), budgetChangeCount: 2 }), "multiple-budgets");
+  reason(() => evaluate({ budget: budget(), budgetChangeCount: 1 }), "budget-unnecessary");
+});
+
+test("the emergency cap cannot be overridden by a budget", () => {
+  reason(() => evaluate({
+    baseHeap: 1_105_000_000,
+    currentHeap: 1_105_822_776,
+    budget: budget({ max_increase_bytes: 100_000_000 }),
+    budgetChangeCount: 1,
+  }), "absolute-cap-exceeded");
+});
+
+test("policy and budget schemas reject unknown, unsafe, and forged fields", () => {
+  reason(() => parsePolicy(JSON.stringify({ ...policy, extra: true })), "malformed-policy");
+  reason(() => parseBudget(JSON.stringify({ ...budget(), id: "../escape" }), "../escape.json"), "malformed-budget");
+  const raw = { ...budget() };
+  delete raw.expires_ms;
+  raw.extra = true;
+  reason(() => parseBudget(JSON.stringify(raw), `${raw.id}.json`), "malformed-budget");
+});
+
+function command(repo, args, env = {}) {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf8", env: { ...process.env, ...env } }).trim();
+}
+
+function commitAll(repo, message, date) {
+  command(repo, ["add", "."]);
+  command(repo, ["commit", "-m", message], {
+    GIT_AUTHOR_DATE: date,
+    GIT_COMMITTER_DATE: date,
+  });
+  return command(repo, ["rev-parse", "HEAD"]);
+}
+
+function makeRepository() {
+  const outer = mkdtempSync(join(os.tmpdir(), "heap-policy-test-"));
+  const repo = join(outer, "repo");
+  mkdirSync(repo);
+  command(repo, ["init", "-q"]);
+  command(repo, ["config", "user.email", "test@example.invalid"]);
+  command(repo, ["config", "user.name", "Heap Policy Test"]);
+  const input = "lib/@vibe/compiler/tests/codegen_lexer_test.vibe";
+  mkdirSync(join(repo, "bench/perf"), { recursive: true });
+  mkdirSync(join(repo, "lib/@vibe/compiler/tests"), { recursive: true });
+  writeFileSync(join(repo, "bench/perf/selfcompile_heap_policy.json"), JSON.stringify(policy, null, 2) + "\n");
+  writeFileSync(join(repo, input), "base benchmark input\n");
+  writeFileSync(join(repo, "heap.txt"), "1000\n");
+  const initial = commitAll(repo, "initial", "2026-08-01T00:00:00Z");
+  return { outer, repo, input, initial };
+}
+
+function makeDriver(outer) {
+  const path = join(outer, "driver.mjs");
+  writeFileSync(path, `
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+const [phase, trial] = process.argv.slice(2);
+const root = process.env.POLICY_CANONICAL_ROOT;
+const log = join(dirname(root), "driver-log.jsonl");
+appendFileSync(log, JSON.stringify({
+  phase, trial, revision: process.env.POLICY_REVISION, root,
+  stage2: process.env.POLICY_STAGE2, input: process.env.POLICY_INPUT,
+  work: process.env.POLICY_WORK_DIR, home: process.env.HOME,
+  tmp: process.env.TMPDIR, vibeHome: process.env.VIBE_HOME,
+  inputText: readFileSync(process.env.POLICY_INPUT, "utf8"),
+}) + "\\n");
+if (phase === "build") {
+  if (process.env.POLICY_REVISION === "current" && existsSync(join(root, ".base-only"))) process.exit(9);
+  if (process.env.POLICY_REVISION === "base") writeFileSync(join(root, ".base-only"), "must be deleted");
+  mkdirSync(dirname(process.env.POLICY_STAGE2), { recursive: true });
+  const buildSuffix = existsSync(join(root, "build-drift.txt")) ? process.env.POLICY_REVISION : "";
+  writeFileSync(process.env.POLICY_STAGE2, "mock wasm" + buildSuffix);
+} else {
+  let heap = Number(readFileSync(join(root, "heap.txt"), "utf8"));
+  if (existsSync(join(root, "nondeterministic.txt")) && trial === "2") heap += 1;
+  if (existsSync(join(root, "reconstruction-drift.txt")) && process.env.POLICY_REVISION === "current") heap += 1;
+  process.stdout.write(\`[selfcompile-kpi] input=x wall_ms=1 heap_ptr_bytes=\${heap} mem_pages=1\\n\`);
+}
+`);
+  return path;
+}
+
+async function controller(options) {
+  const old = process.env.VIBE_HEAP_POLICY_TEST_MODE;
+  process.env.VIBE_HEAP_POLICY_TEST_MODE = "1";
+  try { return await runController(options); }
+  finally {
+    if (old === undefined) delete process.env.VIBE_HEAP_POLICY_TEST_MODE;
+    else process.env.VIBE_HEAP_POLICY_TEST_MODE = old;
+  }
+}
+
+test("controller synthesizes latest-base merge, pins input, reuses exact paths, and isolates revisions", async () => {
+  const fixture = makeRepository();
+  const driver = makeDriver(fixture.outer);
+  command(fixture.repo, ["checkout", "-q", "-b", "feature", fixture.initial]);
+  writeFileSync(join(fixture.repo, fixture.input), "head tried to replace benchmark\n");
+  writeFileSync(join(fixture.repo, "feature.txt"), "feature\n");
+  const head = commitAll(fixture.repo, "feature", "2026-08-01T01:00:00Z");
+  command(fixture.repo, ["checkout", "-q", "main"]);
+  writeFileSync(join(fixture.repo, "main.txt"), "latest base\n");
+  const base = commitAll(fixture.repo, "main advance", "2026-08-01T02:00:00Z");
+  const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
+  const result = await controller({
+    repo: fixture.repo, base, head, synthesizeMerge: true, prNumber: "1801",
+    asOf: "2026-08-02T00:00:00.000Z", canonicalRoot: root, testDriver: driver,
+  });
+  assert.equal(result.decision, "pass");
+  assert.equal(result.base_heap_bytes, 1000);
+  assert.deepEqual(result.trials, { base: [1000, 1000], current: [1000, 1000] });
+  const log = readFileSync(join(dirname(root), "driver-log.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+  assert.equal(log.length, 6);
+  assert.ok(log.every(row => row.root === root));
+  assert.ok(log.every(row => row.inputText === "base benchmark input\n"));
+  for (const key of ["stage2", "input", "work", "home", "tmp", "vibeHome"]) {
+    assert.equal(new Set(log.map(row => row[key])).size, 1, `${key} must be identical`);
+  }
+});
+
+test("controller consumes one new base-bound budget and ignores a permissive head policy", async () => {
+  const fixture = makeRepository();
+  const driver = makeDriver(fixture.outer);
+  writeFileSync(join(fixture.repo, "heap.txt"), "1001\n");
+  mkdirSync(join(fixture.repo, "bench/perf/selfcompile_heap_budgets"), { recursive: true });
+  const record = {
+    schema: 1,
+    id: "pr-1801-integration",
+    pull_request: 1801,
+    base_commit: fixture.initial,
+    max_increase_bytes: 1,
+    expires_at: "2026-08-10T00:00:00.000Z",
+    issue: "https://github.com/mizchi/vibe-lang/issues/1800",
+    feature: "integration fixture",
+    rationale: "exercise one-shot diff authority",
+  };
+  writeFileSync(join(fixture.repo, "bench/perf/selfcompile_heap_budgets/pr-1801-integration.json"), JSON.stringify(record, null, 2));
+  const headPolicy = { ...policy, tolerance_bytes: 999_999_999 };
+  writeFileSync(join(fixture.repo, "bench/perf/selfcompile_heap_policy.json"), JSON.stringify(headPolicy, null, 2));
+  const head = commitAll(fixture.repo, "budgeted growth", "2026-08-01T01:00:00Z");
+  const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
+  const result = await controller({
+    repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
+    prNumber: "1801", asOf: "2026-08-02T00:00:00.000Z",
+    canonicalRoot: root, testDriver: driver,
+  });
+  assert.equal(result.delta_bytes, 1);
+  assert.equal(result.budget_id, record.id);
+  assert.equal(result.policy_changed, true);
+  assert.equal(result.tolerance_bytes, 0);
+  assert.equal(result.policy_source_commit, fixture.initial);
+});
+
+test("controller rejects merge conflicts", async () => {
+  const fixture = makeRepository();
+  const driver = makeDriver(fixture.outer);
+  command(fixture.repo, ["checkout", "-q", "-b", "feature", fixture.initial]);
+  writeFileSync(join(fixture.repo, "heap.txt"), "1001\n");
+  const head = commitAll(fixture.repo, "feature heap", "2026-08-01T01:00:00Z");
+  command(fixture.repo, ["checkout", "-q", "main"]);
+  writeFileSync(join(fixture.repo, "heap.txt"), "999\n");
+  const base = commitAll(fixture.repo, "base heap", "2026-08-01T02:00:00Z");
+  const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
+  await assert.rejects(() => controller({
+    repo: fixture.repo, base, head, synthesizeMerge: true,
+    prNumber: "1801", canonicalRoot: root, testDriver: driver,
+  }), error => error.reason === "merge-conflict");
+});
+
+test("identical trees reject stable cross-reconstruction drift", async () => {
+  for (const [marker, expected] of [["reconstruction-drift.txt", "nondeterministic-heap"], ["build-drift.txt", "nondeterministic-build"]]) {
+    const fixture = makeRepository();
+    const driver = makeDriver(fixture.outer);
+    writeFileSync(join(fixture.repo, marker), "yes\n");
+    const same = commitAll(fixture.repo, marker, "2026-08-01T01:00:00Z");
+    const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
+    await assert.rejects(() => controller({
+      repo: fixture.repo, base: same, head: same, synthesizeMerge: true,
+      prNumber: "1801", canonicalRoot: root, testDriver: driver,
+    }), error => error.reason === expected);
+  }
+});
+
+test("controller rejects nondeterminism, missing revisions, and wrong merge results", async () => {
+  const fixture = makeRepository();
+  const driver = makeDriver(fixture.outer);
+  writeFileSync(join(fixture.repo, "nondeterministic.txt"), "yes\n");
+  const head = commitAll(fixture.repo, "nondeterministic", "2026-08-01T01:00:00Z");
+  const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
+  await assert.rejects(() => controller({
+    repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
+    prNumber: "1801", canonicalRoot: root, testDriver: driver,
+  }), error => error.reason === "nondeterministic-heap");
+  await assert.rejects(() => controller({
+    repo: fixture.repo, base: "missing", head, synthesizeMerge: true,
+    prNumber: "1801", canonicalRoot: root, testDriver: driver,
+  }), error => error.reason === "missing-revision");
+  await assert.rejects(() => controller({
+    repo: fixture.repo, base: fixture.initial, head, current: fixture.initial,
+    prNumber: "1801", canonicalRoot: root, testDriver: driver,
+  }), error => error.reason === "stale-or-wrong-merge-result");
+});

--- a/scripts/selfcompile_heap_policy.test.mjs
+++ b/scripts/selfcompile_heap_policy.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -151,16 +153,20 @@ function makeRepository() {
 function makeDriver(outer) {
   const path = join(outer, "driver.mjs");
   writeFileSync(path, `
-import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 const [phase, trial] = process.argv.slice(2);
 const root = process.env.POLICY_CANONICAL_ROOT;
-const log = join(dirname(root), "driver-log.jsonl");
+const lease = dirname(root);
+const log = join(dirname(fileURLToPath(import.meta.url)), "driver-log.jsonl");
 appendFileSync(log, JSON.stringify({
   phase, trial, revision: process.env.POLICY_REVISION, root,
   stage2: process.env.POLICY_STAGE2, input: process.env.POLICY_INPUT,
   work: process.env.POLICY_WORK_DIR, home: process.env.HOME,
   tmp: process.env.TMPDIR, vibeHome: process.env.VIBE_HOME,
+  leaseMode: statSync(lease).mode & 0o777, leaseUid: statSync(lease).uid,
+  leaseRealpath: realpathSync(lease),
   inputText: readFileSync(process.env.POLICY_INPUT, "utf8"),
 }) + "\\n");
 if (phase === "build") {
@@ -189,21 +195,44 @@ async function controller(options) {
   }
 }
 
-test("canonical root rejects a symlinked existing parent before recursive deletion", async () => {
+test("CI lease is created under a physical runner-owned RUNNER_TEMP", async () => {
   const fixture = makeRepository();
   const driver = makeDriver(fixture.outer);
-  const victim = join(fixture.outer, "victim");
-  const victimRoot = join(victim, "root");
-  mkdirSync(victimRoot, { recursive: true });
-  const marker = join(victimRoot, "must-survive.txt");
+  const oldActions = process.env.GITHUB_ACTIONS;
+  const oldRunnerTemp = process.env.RUNNER_TEMP;
+  process.env.GITHUB_ACTIONS = "true";
+  process.env.RUNNER_TEMP = fixture.outer;
+  try {
+    const result = await controller({
+      repo: fixture.repo, base: fixture.initial, head: fixture.initial,
+      synthesizeMerge: true, prNumber: "1801", testDriver: driver,
+    });
+    assert.ok(result.normalized_paths.canonical_root.startsWith(`${fixture.outer}/vibe-selfcompile-policy-`));
+    const redirected = join(fixture.outer, "runner-temp-link");
+    symlinkSync(fixture.outer, redirected, "dir");
+    process.env.RUNNER_TEMP = redirected;
+    await assert.rejects(() => controller({
+      repo: fixture.repo, base: fixture.initial, head: fixture.initial,
+      synthesizeMerge: true, prNumber: "1801", testDriver: driver,
+    }), error => error.reason === "unsafe-runner-temp");
+  } finally {
+    if (oldActions === undefined) delete process.env.GITHUB_ACTIONS;
+    else process.env.GITHUB_ACTIONS = oldActions;
+    if (oldRunnerTemp === undefined) delete process.env.RUNNER_TEMP;
+    else process.env.RUNNER_TEMP = oldRunnerTemp;
+  }
+});
+
+test("caller-selected canonical roots are rejected and never deleted", async () => {
+  const fixture = makeRepository();
+  const victim = join(fixture.outer, "caller-selected-victim");
+  mkdirSync(victim);
+  const marker = join(victim, "must-survive.txt");
   writeFileSync(marker, "untouched\n");
-  const symlinkParent = join(fixture.outer, "vibe-selfcompile-policy-attack");
-  symlinkSync(victim, symlinkParent, "dir");
   await assert.rejects(() => controller({
     repo: fixture.repo, base: fixture.initial, head: fixture.initial,
-    synthesizeMerge: true, prNumber: "1801",
-    canonicalRoot: join(symlinkParent, "root"), testDriver: driver,
-  }), error => error.reason === "unsafe-canonical-root");
+    synthesizeMerge: true, prNumber: "1801", canonicalRoot: victim,
+  }), error => error.reason === "invalid-arguments");
   assert.equal(readFileSync(marker, "utf8"), "untouched\n");
 });
 
@@ -225,13 +254,30 @@ test("tracked escaping input symlinks fail before the pinned input write", async
       symlinkSync(external, inputParent, "dir");
     }
     const head = commitAll(fixture.repo, `escaping ${symlinkAt} symlink`, "2026-08-01T01:00:00Z");
-    const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
     await assert.rejects(() => controller({
       repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
-      prNumber: "1801", canonicalRoot: root, testDriver: driver,
+      prNumber: "1801", testDriver: driver,
     }), error => error.reason === "unsafe-pinned-input");
     assert.equal(readFileSync(target, "utf8"), "must remain unchanged\n");
   }
+});
+
+test("tracked _build symlink is rejected before reserved namespace creation", async () => {
+  const fixture = makeRepository();
+  const driver = makeDriver(fixture.outer);
+  const external = join(fixture.outer, "external-build-target");
+  mkdirSync(external);
+  const marker = join(external, "must-survive.txt");
+  writeFileSync(marker, "untouched\n");
+  symlinkSync(external, join(fixture.repo, "_build"), "dir");
+  command(fixture.repo, ["add", "-f", "_build"]);
+  const head = commitAll(fixture.repo, "tracked build redirect", "2026-08-01T01:00:00Z");
+  await assert.rejects(() => controller({
+    repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
+    prNumber: "1801", testDriver: driver,
+  }), error => error.reason === "reserved-path-present");
+  assert.equal(readFileSync(marker, "utf8"), "untouched\n");
+  assert.deepEqual(readdirSync(external), ["must-survive.txt"]);
 });
 
 test("controller synthesizes latest-base merge, pins input, reuses exact paths, and isolates revisions", async () => {
@@ -244,17 +290,21 @@ test("controller synthesizes latest-base merge, pins input, reuses exact paths, 
   command(fixture.repo, ["checkout", "-q", "main"]);
   writeFileSync(join(fixture.repo, "main.txt"), "latest base\n");
   const base = commitAll(fixture.repo, "main advance", "2026-08-01T02:00:00Z");
-  const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
   const result = await controller({
     repo: fixture.repo, base, head, synthesizeMerge: true, prNumber: "1801",
-    asOf: "2026-08-02T00:00:00.000Z", canonicalRoot: root, testDriver: driver,
+    asOf: "2026-08-02T00:00:00.000Z", testDriver: driver,
   });
   assert.equal(result.decision, "pass");
   assert.equal(result.base_heap_bytes, 1000);
   assert.deepEqual(result.trials, { base: [1000, 1000], current: [1000, 1000] });
-  const log = readFileSync(join(dirname(root), "driver-log.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
+  const root = result.normalized_paths.canonical_root;
+  const log = readFileSync(join(fixture.outer, "driver-log.jsonl"), "utf8").trim().split("\n").map(JSON.parse);
   assert.equal(log.length, 6);
   assert.ok(log.every(row => row.root === root));
+  assert.ok(log.every(row => row.leaseMode === 0o700));
+  assert.ok(log.every(row => row.leaseRealpath === dirname(root)));
+  if (typeof process.getuid === "function") assert.ok(log.every(row => row.leaseUid === process.getuid()));
+  assert.equal(existsSync(dirname(root)), false, "controller-created lease must be removed");
   assert.ok(log.every(row => row.inputText === "base benchmark input\n"));
   for (const key of ["stage2", "input", "work", "home", "tmp", "vibeHome"]) {
     assert.equal(new Set(log.map(row => row[key])).size, 1, `${key} must be identical`);
@@ -281,11 +331,10 @@ test("controller consumes one new base-bound budget and ignores a permissive hea
   const headPolicy = { ...policy, tolerance_bytes: 999_999_999 };
   writeFileSync(join(fixture.repo, "bench/perf/selfcompile_heap_policy.json"), JSON.stringify(headPolicy, null, 2));
   const head = commitAll(fixture.repo, "budgeted growth", "2026-08-01T01:00:00Z");
-  const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
   const result = await controller({
     repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
     prNumber: "1801", asOf: "2026-08-02T00:00:00.000Z",
-    canonicalRoot: root, testDriver: driver,
+    testDriver: driver,
   });
   assert.equal(result.delta_bytes, 1);
   assert.equal(result.budget_id, record.id);
@@ -303,10 +352,9 @@ test("controller rejects merge conflicts", async () => {
   command(fixture.repo, ["checkout", "-q", "main"]);
   writeFileSync(join(fixture.repo, "heap.txt"), "999\n");
   const base = commitAll(fixture.repo, "base heap", "2026-08-01T02:00:00Z");
-  const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
   await assert.rejects(() => controller({
     repo: fixture.repo, base, head, synthesizeMerge: true,
-    prNumber: "1801", canonicalRoot: root, testDriver: driver,
+    prNumber: "1801", testDriver: driver,
   }), error => error.reason === "merge-conflict");
 });
 
@@ -316,10 +364,9 @@ test("identical trees reject stable cross-reconstruction drift", async () => {
     const driver = makeDriver(fixture.outer);
     writeFileSync(join(fixture.repo, marker), "yes\n");
     const same = commitAll(fixture.repo, marker, "2026-08-01T01:00:00Z");
-    const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
     await assert.rejects(() => controller({
       repo: fixture.repo, base: same, head: same, synthesizeMerge: true,
-      prNumber: "1801", canonicalRoot: root, testDriver: driver,
+      prNumber: "1801", testDriver: driver,
     }), error => error.reason === expected);
   }
 });
@@ -329,17 +376,16 @@ test("controller rejects nondeterminism, missing revisions, and wrong merge resu
   const driver = makeDriver(fixture.outer);
   writeFileSync(join(fixture.repo, "nondeterministic.txt"), "yes\n");
   const head = commitAll(fixture.repo, "nondeterministic", "2026-08-01T01:00:00Z");
-  const root = join(fixture.outer, "vibe-selfcompile-policy", "root");
   await assert.rejects(() => controller({
     repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
-    prNumber: "1801", canonicalRoot: root, testDriver: driver,
+    prNumber: "1801", testDriver: driver,
   }), error => error.reason === "nondeterministic-heap");
   await assert.rejects(() => controller({
     repo: fixture.repo, base: "missing", head, synthesizeMerge: true,
-    prNumber: "1801", canonicalRoot: root, testDriver: driver,
+    prNumber: "1801", testDriver: driver,
   }), error => error.reason === "missing-revision");
   await assert.rejects(() => controller({
     repo: fixture.repo, base: fixture.initial, head, current: fixture.initial,
-    prNumber: "1801", canonicalRoot: root, testDriver: driver,
+    prNumber: "1801", testDriver: driver,
   }), error => error.reason === "stale-or-wrong-merge-result");
 });

--- a/scripts/selfcompile_kpi.sh
+++ b/scripts/selfcompile_kpi.sh
@@ -19,6 +19,10 @@
 #   VIBE_KPI_MAX_WALL_MS=<n>     exit 1 if wall_ms exceeds this (advisory —
 #                                wall time IS machine/load dependent; prefer
 #                                the heap gate for CI)
+#   VIBE_KPI_WORK_DIR=<path>      use one fixed empty directory under
+#                                VIBE_KPI_ALLOWED_WORK_ROOT (default: _build)
+#                                instead of mktemp; the directory is removed
+#                                on exit. This is used by comparative policy.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -35,8 +39,82 @@ if [ ! -f "$INPUT" ]; then
   exit 2
 fi
 
-OUT_DIR="$(mktemp -d)"
-trap 'rm -rf "$OUT_DIR"' EXIT
+cleanup_out_dir() {
+  if [ -n "${OUT_DIR:-}" ]; then
+    rm -rf -- "$OUT_DIR"
+  fi
+}
+
+if [ -n "${VIBE_KPI_WORK_DIR:-}" ]; then
+  case "$VIBE_KPI_WORK_DIR" in
+    /*) ;;
+    *)
+      echo "[selfcompile-kpi] VIBE_KPI_WORK_DIR must be absolute" >&2
+      exit 2
+      ;;
+  esac
+  if [ -L "$VIBE_KPI_WORK_DIR" ]; then
+    echo "[selfcompile-kpi] VIBE_KPI_WORK_DIR must not be a symlink" >&2
+    exit 2
+  fi
+  if [ -e "$VIBE_KPI_WORK_DIR" ] && [ ! -d "$VIBE_KPI_WORK_DIR" ]; then
+    echo "[selfcompile-kpi] VIBE_KPI_WORK_DIR must be a directory" >&2
+    exit 2
+  fi
+  if [ -d "$VIBE_KPI_WORK_DIR" ] && [ -n "$(find "$VIBE_KPI_WORK_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+    echo "[selfcompile-kpi] VIBE_KPI_WORK_DIR must be empty" >&2
+    exit 2
+  fi
+
+  ALLOWED_WORK_ROOT="${VIBE_KPI_ALLOWED_WORK_ROOT:-$ROOT_DIR/_build}"
+  case "$ALLOWED_WORK_ROOT" in
+    /*) ;;
+    *)
+      echo "[selfcompile-kpi] VIBE_KPI_ALLOWED_WORK_ROOT must be absolute" >&2
+      exit 2
+      ;;
+  esac
+  mkdir -p -- "$ALLOWED_WORK_ROOT"
+  ALLOWED_WORK_ROOT_REAL="$(cd "$ALLOWED_WORK_ROOT" && pwd -P)"
+  WORK_PARENT="$(dirname "$VIBE_KPI_WORK_DIR")"
+  case "$WORK_PARENT/" in
+    "$ALLOWED_WORK_ROOT"/|"$ALLOWED_WORK_ROOT"/*/) ;;
+    *)
+      echo "[selfcompile-kpi] VIBE_KPI_WORK_DIR must be under $ALLOWED_WORK_ROOT_REAL" >&2
+      exit 2
+      ;;
+  esac
+  mkdir -p -- "$WORK_PARENT"
+  WORK_PARENT_REAL="$(cd "$WORK_PARENT" && pwd -P)"
+  WORK_PARENT_SUFFIX="${WORK_PARENT#"$ALLOWED_WORK_ROOT"}"
+  WORK_PARENT_SUFFIX="${WORK_PARENT_SUFFIX#/}"
+  EXPECTED_WORK_PARENT_REAL="$ALLOWED_WORK_ROOT_REAL"
+  if [ -n "$WORK_PARENT_SUFFIX" ]; then
+    EXPECTED_WORK_PARENT_REAL="$EXPECTED_WORK_PARENT_REAL/$WORK_PARENT_SUFFIX"
+  fi
+  if [ "$WORK_PARENT_REAL" != "$EXPECTED_WORK_PARENT_REAL" ]; then
+    echo "[selfcompile-kpi] VIBE_KPI_WORK_DIR must not contain symlinked directories" >&2
+    exit 2
+  fi
+  case "$WORK_PARENT_REAL/" in
+    "$ALLOWED_WORK_ROOT_REAL"/|"$ALLOWED_WORK_ROOT_REAL"/*/) ;;
+    *)
+      echo "[selfcompile-kpi] VIBE_KPI_WORK_DIR must be under $ALLOWED_WORK_ROOT_REAL" >&2
+      exit 2
+      ;;
+  esac
+  case "$VIBE_KPI_WORK_DIR" in
+    /|"$ROOT_DIR"|"$ALLOWED_WORK_ROOT_REAL")
+      echo "[selfcompile-kpi] unsafe VIBE_KPI_WORK_DIR: $VIBE_KPI_WORK_DIR" >&2
+      exit 2
+      ;;
+  esac
+  OUT_DIR="$VIBE_KPI_WORK_DIR"
+  [ -d "$OUT_DIR" ] || mkdir -- "$OUT_DIR"
+else
+  OUT_DIR="$(mktemp -d)"
+fi
+trap cleanup_out_dir EXIT
 OUT_WASM="$OUT_DIR/out.wasm"
 STATS_FILE="$OUT_DIR/stats.txt"
 
@@ -49,7 +127,7 @@ mkdir -p "$CACHE_DIR"
 start_ns=$(date +%s%N)
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   VIBE_WASM_MEMORY_STATS=1 VIBE_BUILD_CACHE_DIR="$CACHE_DIR" \
-  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" \
+  bash "${VIBE_KPI_RUNNER_SCRIPT:-scripts/run_wasm_vibe_host_runner.sh}" --invoke cli_main "$STAGE2" \
   "$INPUT" "$OUT_WASM" __no_entry__ 2>"$STATS_FILE"
 end_ns=$(date +%s%N)
 wall_ms=$(( (end_ns - start_ns) / 1000000 ))

--- a/scripts/selfcompile_kpi_work_dir_test.sh
+++ b/scripts/selfcompile_kpi_work_dir_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" "$ROOT_DIR/_build/kpi-work-dir-test"' EXIT
+STAGE2="$TMP/stage2.wasm"
+INPUT="$TMP/input.vibe"
+RUNNER="$TMP/mock-runner.sh"
+printf 'wasm' >"$STAGE2"
+printf 'fn main() -> Unit { () }\n' >"$INPUT"
+cat >"$RUNNER" <<'RUNNER'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'wasm output' >"$5"
+echo '[wasm-memory] heap_ptr=12345 pages=2' >&2
+RUNNER
+chmod +x "$RUNNER"
+
+WORK="$ROOT_DIR/_build/kpi-work-dir-test/work"
+mkdir -p "$WORK"
+out="$(
+  VIBE_KPI_WORK_DIR="$WORK" \
+  VIBE_KPI_ALLOWED_WORK_ROOT="$ROOT_DIR/_build/kpi-work-dir-test" \
+  VIBE_KPI_RUNNER_SCRIPT="$RUNNER" \
+  bash "$ROOT_DIR/scripts/selfcompile_kpi.sh" "$STAGE2" "$INPUT"
+)"
+grep -q 'heap_ptr_bytes=12345' <<<"$out"
+[ ! -e "$WORK" ] || { echo "fixed work directory was not removed" >&2; exit 1; }
+
+expect_reject() {
+  local expected="$1"
+  shift
+  set +e
+  output="$("$@" 2>&1)"
+  rc=$?
+  set -e
+  [ "$rc" -eq 2 ] || { echo "expected exit 2, got $rc: $output" >&2; exit 1; }
+  grep -q "$expected" <<<"$output" || { echo "missing rejection '$expected': $output" >&2; exit 1; }
+}
+
+mkdir -p "$TMP/outside"
+expect_reject 'must be under' env \
+  VIBE_KPI_WORK_DIR="$TMP/outside/work" \
+  VIBE_KPI_ALLOWED_WORK_ROOT="$ROOT_DIR/_build/kpi-work-dir-test" \
+  VIBE_KPI_RUNNER_SCRIPT="$RUNNER" \
+  bash "$ROOT_DIR/scripts/selfcompile_kpi.sh" "$STAGE2" "$INPUT"
+
+mkdir -p "$ROOT_DIR/_build/kpi-work-dir-test/nonempty"
+printf stale >"$ROOT_DIR/_build/kpi-work-dir-test/nonempty/stale"
+expect_reject 'must be empty' env \
+  VIBE_KPI_WORK_DIR="$ROOT_DIR/_build/kpi-work-dir-test/nonempty" \
+  VIBE_KPI_ALLOWED_WORK_ROOT="$ROOT_DIR/_build/kpi-work-dir-test" \
+  VIBE_KPI_RUNNER_SCRIPT="$RUNNER" \
+  bash "$ROOT_DIR/scripts/selfcompile_kpi.sh" "$STAGE2" "$INPUT"
+
+ln -s "$TMP/outside" "$ROOT_DIR/_build/kpi-work-dir-test/link"
+expect_reject 'must not be a symlink' env \
+  VIBE_KPI_WORK_DIR="$ROOT_DIR/_build/kpi-work-dir-test/link" \
+  VIBE_KPI_ALLOWED_WORK_ROOT="$ROOT_DIR/_build/kpi-work-dir-test" \
+  VIBE_KPI_RUNNER_SCRIPT="$RUNNER" \
+  bash "$ROOT_DIR/scripts/selfcompile_kpi.sh" "$STAGE2" "$INPUT"
+
+echo "selfcompile_kpi fixed work directory: ok"


### PR DESCRIPTION
## Summary
- add fail-closed merge-base/current selfcompile heap policy substrate with zero default tolerance and one-shot base/PR-bound budgets
- retain the existing 1,105,822,775-byte emergency maximum and leave the existing CI gate unchanged
- add same-path reconstruction, two-trial determinism checks, pinned workload, private lease safety, and fixed KPI work-directory support
- document the two-phase rollout and explicitly keep Phase B/CI wiring blocked

## Validation
- independent hard review: ACCEPT
- controller policy tests: 14/14
- fixed KPI work-directory shell tests: pass
- standalone KPI: pass (`heap_ptr_bytes=1,042,508,496`)
- Node/Bash syntax, Taskfile lane, diff checks, review lint: pass

## Known blockers intentionally retained
- same-tree clean reconstructions differ by a stable 16 bytes due filesystem metadata/stat-token sensitivity
- complete measurement harness must execute from immutable base authority in disposable no-network isolation
- required review ownership and strict latest-base governance are not configured

Therefore this PR installs trusted Phase A substrate only. It does not wire required CI, remove or relax the old gate, add a feature budget, change compiler behavior, unblock `df9f223d`, or complete task `6c741b3e`.