### PR TITLE
feat(fmt): lex_lossless のトークン蓄積を region + MutList に載せる (#1770 Phase 1 第一号)

### DIFF
--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -1096,24 +1096,32 @@ fn lx_next(lx: LX) -> LTok {
   }
 }
 
+/// ADR-0090 dogfood (#1770 Phase 1): the token list is accumulate-only until
+/// the single exit, so its backing storage lives in a region arena and is
+/// reclaimed wholesale at the region end; `to_array` copies the final list
+/// out to the main heap. First in-compiler use of `region` -- needs the
+/// region-starts-guard-2026-08-15 seed (#1780/#1791: older seeds trap on
+/// region syntax reaching the vpkg contract member parse, which is exactly
+/// how fmt_entry.vibe compiles this file).
 fn lex_lossless(src: String) -> Array[LTok] {
   let lx = LX::{
     input: src, len: String::length(src), pos: 0
   }
-  let toks = [
-  ]
-  let mut going = true
-  while going {
-    if lx.pos >= lx.len {
-      going = false
-    } else {
-      Array::push(toks, lx_next(lx))
+  region r {
+    let toks = MutList::empty(r)
+    let mut going = true
+    while going {
+      if lx.pos >= lx.len {
+        going = false
+      } else {
+        MutList::push(toks, lx_next(lx))
+      }
     }
+    MutList::push(toks, LTok::{
+      kind: k_eof, text: ""
+    })
+    MutList::to_array(toks)
   }
-  Array::push(toks, LTok::{
-    kind: k_eof, text: ""
-  })
-  toks
 }
 
 //# Predicate helpers (kind classification)


### PR DESCRIPTION
## 概要

**コンパイラ自身のソースで `region` を使う最初の適用** (#1770 Phase 1 第一号)。fmt の CST lexer `lex_lossless` はトークン列を push だけで組み立てて単一の出口で返す accumulate-only の形 — region の教科書形なので、backing storage を region arena に置き、終端の `MutList::to_array` で main heap へコピーアウトする形に書き換えた。

昨日この diff を最初に試した際に #1780 (region 構文が vpkg contract の member parse でコンパイラを trap) を踏んで発見→ #1783 で修正 → seed bump #1791 で seed に取り込み、という経緯を経ての本体。`fmt_entry.vibe` は seed がこの file を vpkg レーンでコンパイルする消費者そのものなので、**region-starts-guard-2026-08-15 seed (#1791) が前提**。

## 変更

- `lib/@vibe/compiler/fmt/format.vibe` の `lex_lossless`: `let toks = []` + `Array::push` → `region r { MutList::empty(r) / push / to_array }`。doc comment に seed 前提と経緯を記載。

## 検証 (新 seed `1841e38a` + そのセルフビルド stage2 で実施)

- 新 seed が patch 適用済みの `fmt_entry.vibe` をコンパイルできることを確認 (旧 seed では #1780 で trap する経路)
- **patch 適用後の formatter 自身が fixpoint**: `scripts/vibe_fmt.sh --check` が `format.vibe` (自分自身)・`checker.vibe`・`lexer.vibe` で rc=0
- fmt package tests (`vpkg_format_test.vibe` / `struct_double_colon_test.vibe`) PASS
- `bash scripts/compiler_gate.sh` 全 pass — `format.vibe` は compiler bundle 外 (fmt/index.vpkg 参照) のため selfbuild fixpoint へは非影響
- vpkg × region の言語側の動作は #1783 の回帰テストと fixtures (`region_arena_*`) が pin 済み

## 備考

- MutList は Phase 1 API (empty/push/freeze/to_array のみ)。`get`/`length` が無いため、蓄積中に読み戻す形 (perceus の worklist 等) はまだ移行できない — #1770 に記録済みの既知の制約
- 次の候補は #1770 の Phase 1 リスト (parser lexer の builder 群、ast_binary の scratch、linked_compile のセクション buffer ~20 本 = 要 `MutBytes[r]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_