### PR TITLE
probe(async): #1540 の合成形状を実測で決着させる

### DIFF
--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1718,27 +1718,46 @@ StreamProducer）を相手に実測されている。production の相手 —
 | compose | `wac plug`（adapter component + guest） | 自前の core module 合成（adapter core module を同梱） |
 
 つまり body は guest に届く時点で既に String に潰れており、`stream<u8>` は
-adapter の内部で消費し終わっている。`host_stream_named("body")` が
-production で意味を持つには:
+adapter の内部で消費し終わっている。
 
-1. **full adapter が body を materialize せず export する**:
-   `world adapter` に `export body: func() -> stream<u8>;` を足し、
-   `Request::consume_body` の `StreamReader` を collect せずそのまま返す
-   （handler import 側は `body: string` 引数を落とす）。adapter は request
-   ごとの reader を持ち回る必要がある。
-2. **serve emitter が host-stream machinery を積んだ component を出す**:
-   string-handler trampoline を export しつつ `body: func() -> stream<u8>`
-   を import し、hoststream adapter core module を同梱する — 現在の2つの
-   emitter の**合流**であって、どちらかの拡張ではない。
-3. **compose が2辺になる**: `wac plug` が handler 辺に加えて body 辺も繋ぐ。
+**実測で棄却した形** (#1540 / #1796): adapter が
+`body: func() -> stream<u8>` を export し、guest がそれを import する「2辺」
+composition は、adapter→guest の `handler` 辺との**循環**になる。`wac plug`
+は接続できない `body` import を root world に押し上げたまま exit 0 となり、
+`wac compose` の字句順 DAG では相互参照自体を書けない。同一 instance の
+`body()` export を request-local slot として使う案も、並行 request の identity
+が無く不健全である。この形を実装対象にしてはならない。
 
-検証には `wasmtime serve` + curl が要る（既存の
-`test_wasi_http_p3_full_gate.sh` と同じ tooling 前提、不在時 skip）。
+**実測で成立した非循環形**: request body を既存の handler 辺の引数に乗せる。
 
-この3点は独立に着手できず、2 が 1 と 3 の両方に依存する。**「incoming-body
-provider を配線する」ではなく「serve composition と host-stream composition を
-統合する」スライスとして起票し直すのが正しい**（現状の見積もりを
-「配線」と書くと規模を誤らせる）。
+```wit
+import handler: func(method: string, url: string, headers: string, body: stream<u8>) -> string;
+```
+
+`wit-bindgen` 0.54 はこの import を生成でき、adapter は
+`Request::consume_body` の reader を collect せず渡せる。probe は componentize
+と validate、`wac plug` 後の root import が host 提供の
+`wasi:http/types@0.3.0` だけであること、`wasmtime serve` への body 付き POST
+が guest 固有応答を返すところまで検証する。再現は
+`scripts/test_http_body_stream_probe_gate.sh`。required-tools CI では
+`scripts/test_wasi_p3_guarantee_gate.sh` の http phase から実行する。
+
+ただし probe guest は stream をまだ**読まない**。残る実装スコープは:
+
+1. `stream.read` を用いる string-bearing async handler の canonical encoding
+   （async lift / `task.return` の memory・realloc・string-encoding option の
+   正確な集合）を byte-level probe で確定する。現 probe はこの option 集合を
+   実測していない。
+2. `emit_canon_lift_async_section` / `emit_canon_task_return` を、1 の実測結果に
+   沿って一般化する。既存 scalar caller の byte 列は不変に保つ。
+3. serve handler を async lift + `stream<u8>` 引数へ拡張する。
+   `validate_serve_handler` の4引数全 String 決め打ちと effect 制約も同時に扱う。
+4. nominal `HostStream` を handler 引数型として綴り、incoming stream handle を
+   guest の stream-read lowering に渡せる frontend / component ABI を定義する。
+
+したがってこれは単純な provider 差し替えではないが、serve と host-stream を
+2辺の循環 composition に合流させる作業でもない。**body stream を handler の
+request-local 引数として運ぶ1辺の async composition** が設計の基準となる。
 
 ## 4. WASI 0.3 境界マッピング
 

--- a/scripts/test_http_body_stream_probe_gate.sh
+++ b/scripts/test_http_body_stream_probe_gate.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #1540 probe gate: can the request body reach the guest as a `stream<u8>`
+# PARAMETER on the handler import, rather than being collected into a String by
+# the adapter first?
+#
+# See tools/wasip3_component_probe/http_body_stream/README.md for why this shape
+# and not the one #1540's scope bullets describe (that one is a composition
+# cycle; `wac plug` silently leaves the second edge unsatisfied and `wac
+# compose` cannot express it at all).
+#
+# Pipeline under test:
+#   1. build a Rust wasi-http P3 adapter whose guest import is
+#        handler: func(method: string, url: string, headers: string,
+#                      body: stream<u8>) -> string
+#      and which hands `Request::consume_body`'s reader straight through --
+#      no `.collect().await`.
+#   2. componentize + validate it.
+#   3. `wac plug` the hand-written probe guest into it; the composed component
+#      must have NO unsatisfied import beyond what the host provides.
+#   4. `wasmtime serve` it; a POST WITH A BODY must get 200 and the guest's
+#      answer.
+#
+# The guest ignores the stream -- this gate answers the composition question,
+# not the stream-read one. Reading it needs `stream.read` plus an async lift,
+# and the emitters are too narrow for that today (README, last section).
+#
+# Skips cleanly when cargo / wasm-tools / wac / wasmtime / curl are missing.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PROBE_DIR="$PROJECT_ROOT/tools/wasip3_component_probe/http_body_stream"
+OUT_DIR="$PROJECT_ROOT/_build/bench/http_body_stream_probe/run-$$"
+SERVE_LOG="$OUT_DIR/serve.log"
+# Separate concurrent probe runs without relying on a repository-global fixed
+# port. More importantly, the response token below proves that curl reached
+# THIS process, not an incumbent listener which happened to answer similarly.
+PORT=$((20000 + ($$ % 20000)))
+ADDR="${VIBE_HTTP_BODY_STREAM_PROBE_ADDR:-127.0.0.1:$PORT}"
+RESPONSE_TOKEN="probe-$(printf '%05d' $(( $$ % 100000 )))"
+
+if [ -n "${VIBE_HTTP_GATE_WASMTIME_FLAGS:-}" ]; then
+  read -r -a WASM_FLAGS <<<"$VIBE_HTTP_GATE_WASMTIME_FLAGS"
+else
+  WASM_FLAGS=(-Sp3 -Shttp -W exceptions=y -W concurrency-support=y -W component-model-async=y -W component-model-async-stackful=y)
+fi
+
+missing_tool() {
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "[body-stream-probe] FAILED: $1 not found (required mode)" >&2; exit 1
+  fi
+  echo "[body-stream-probe] SKIP: $1 not found"; exit 0
+}
+for c in cargo wasm-tools wac curl; do
+  command -v "$c" >/dev/null 2>&1 || missing_tool "$c"
+done
+WASMTIME_BIN="$("$PROJECT_ROOT/scripts/wasmtime_bin.sh" 2>/dev/null || command -v wasmtime || true)"
+if [ -z "${WASMTIME_BIN:-}" ] || ! "$WASMTIME_BIN" --version >/dev/null 2>&1; then
+  missing_tool "wasmtime"
+fi
+
+WIT_PATH="$PROJECT_ROOT/lib/@vibe/wasi/wit/p3"
+if [ ! -f "$WIT_PATH/world.wit" ]; then
+  WIT_PATH="$PROJECT_ROOT/deps/wasmtime/crates/wasi-http/src/p3/wit"
+fi
+[ -f "$WIT_PATH/world.wit" ] || missing_tool "wasi:http p3 WIT"
+
+rm -rf "$OUT_DIR"; mkdir -p "$OUT_DIR"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe_body_stream_adapter.XXXXXX")"
+SERVE_PID=""
+cleanup() {
+  if [ -n "$SERVE_PID" ]; then
+    kill "$SERVE_PID" 2>/dev/null || true
+    wait "$SERVE_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+mkdir -p "$TMP_DIR/src"
+
+cat >"$TMP_DIR/Cargo.toml" <<'EOF'
+[package]
+name = "vibe_body_stream_probe_adapter"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { version = "0.54.0", default-features = false, features = ["macros", "realloc", "bitflags", "async", "async-spawn"] }
+EOF
+
+cat >"$TMP_DIR/src/lib.rs" <<EOF
+wit_bindgen::generate!({
+    inline: r#"
+      package vibe:body-stream-probe;
+
+      world adapter {
+        /// #1540 shape (a): the body arrives as a stream PARAMETER. The
+        /// adapter never materializes it.
+        import handler: func(method: string, url: string, headers: string, body: stream<u8>) -> string;
+        include wasi:http/service@0.3.0;
+      }
+    "#,
+    path: "$WIT_PATH",
+    world: "vibe:body-stream-probe/adapter",
+    pub_export_macro: true,
+    generate_all,
+});
+
+use exports::wasi::http::handler::Guest;
+use wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+struct Component;
+
+impl Guest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let url = request.get_path_with_query().unwrap_or_else(|| "/".to_string());
+        let (_, result_rx) = wit_future::new::<Result<(), ErrorCode>>(|| Ok(()));
+        // The point of the probe: hand the READER over, no .collect().await.
+        let (req_body_rx, _trailers_rx) = Request::consume_body(request, result_rx);
+        let raw = handler("GET", &url, "", req_body_rx);
+
+        let fields = Fields::new();
+        let (mut body_tx, body_rx) = wit_stream::new();
+        let (body_result_tx, body_result_rx) = wit_future::new(|| Ok(None));
+        let (resp, _transmit) = Response::new(fields, Some(body_rx), body_result_rx);
+        resp.set_status_code(200).map_err(|_| ErrorCode::InternalError(None))?;
+        drop(body_result_tx);
+        wit_bindgen::spawn(async move {
+            let remaining = body_tx.write_all(raw.into_bytes()).await;
+            assert!(remaining.is_empty());
+        });
+        Ok(resp)
+    }
+}
+
+export!(Component);
+EOF
+
+echo "[body-stream-probe] building the stream-param adapter"
+(cd "$TMP_DIR" && cargo build --target wasm32-unknown-unknown --release >/dev/null 2>&1) || {
+  echo "[body-stream-probe] FAILED: adapter did not build -- wit-bindgen no longer accepts a stream<u8> parameter on an imported func?" >&2
+  (cd "$TMP_DIR" && cargo build --target wasm32-unknown-unknown --release 2>&1 | tail -20) >&2
+  exit 1
+}
+
+ADAPTER="$OUT_DIR/adapter.component.wasm"
+wasm-tools component new \
+  "$TMP_DIR/target/wasm32-unknown-unknown/release/vibe_body_stream_probe_adapter.wasm" \
+  -o "$ADAPTER"
+wasm-tools validate --features all "$ADAPTER"
+if ! wasm-tools component wit "$ADAPTER" | grep -qF 'body: stream<u8>'; then
+  echo "[body-stream-probe] FAILED: the adapter does not declare a stream<u8> body import" >&2
+  wasm-tools component wit "$ADAPTER" >&2
+  exit 1
+fi
+echo "[body-stream-probe] adapter imports handler(.., body: stream<u8>)"
+
+GUEST="$OUT_DIR/guest.wasm"
+sed "s/probe-00000/$RESPONSE_TOKEN/" "$PROBE_DIR/guest.wat" >"$TMP_DIR/guest.wat"
+wasm-tools parse "$TMP_DIR/guest.wat" -o "$GUEST"
+wasm-tools validate --features all "$GUEST"
+echo "[body-stream-probe] probe guest validates"
+
+COMPOSED="$OUT_DIR/composed.wasm"
+wac plug --plug "$GUEST" "$ADAPTER" -o "$COMPOSED"
+wasm-tools validate --features all "$COMPOSED"
+
+# The cycle shape's failure mode was a composed component that still IMPORTS
+# what it was supposed to have been handed. Assert the stronger documented
+# contract: the root world has exactly the one host-provided HTTP import.
+COMPOSED_WIT="$(wasm-tools component wit "$COMPOSED")"
+ROOT_IMPORTS="$(printf '%s\n' "$COMPOSED_WIT" | awk '
+  /^world root \{$/ { in_world = 1; next }
+  in_world && /^}/ { exit }
+  in_world && /^[[:space:]]+import / {
+    sub(/^[[:space:]]+/, "")
+    print
+  }
+')"
+if [ "$ROOT_IMPORTS" != 'import wasi:http/types@0.3.0;' ]; then
+  echo "[body-stream-probe] FAILED: composed root imports are not exactly the host-provided wasi:http/types edge" >&2
+  printf '%s\n' "$COMPOSED_WIT" | head -20 >&2
+  exit 1
+fi
+echo "[body-stream-probe] composed: handler edge connected; only host wasi:http/types remains"
+
+"$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$COMPOSED" >"$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+ready=0
+for _ in $(seq 1 40); do
+  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+    echo "[body-stream-probe] FAILED: spawned wasmtime exited before accepting requests" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if curl -s -m 1 -o /dev/null "http://$ADDR/" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [ "$ready" != "1" ]; then
+  echo "[body-stream-probe] FAILED: spawned wasmtime did not become ready at $ADDR" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+
+RESPONSE_FILE="$TMP_DIR/response.txt"
+CODE="$(curl -sS --max-time 10 -o "$RESPONSE_FILE" -w '%{http_code}' \
+  -X POST --data-binary "hello-body" "http://$ADDR/probe" 2>&1 || true)"
+OUT="$(cat "$RESPONSE_FILE" 2>/dev/null || true)"
+if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+  echo "[body-stream-probe] FAILED: spawned wasmtime exited while serving the probe request" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+kill "$SERVE_PID" 2>/dev/null || true
+wait "$SERVE_PID" 2>/dev/null || true
+SERVE_PID=""
+
+if [ "$CODE" != "200" ]; then
+  echo "[body-stream-probe] FAILED: POST with a body returned '$CODE' (want 200)" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+if ! printf '%s' "$OUT" | grep -qF "$RESPONSE_TOKEN"; then
+  echo "[body-stream-probe] FAILED: response body was '$OUT' (want this guest's '$RESPONSE_TOKEN')" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+
+echo "[body-stream-probe] POST with a body -> 200, guest answered"
+echo "[body-stream-probe] PASS: a wasi:http request body can reach the guest as a stream<u8> parameter (#1540)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -7,8 +7,9 @@
 #
 #   phase A  async component vertical (test_async_component_gate.sh)
 #            .vibe async entry -> component-model async component -> 42
-#   phase B  wasi:http p3 world (test_wasi_http_p3_full_gate.sh)
-#            componentize -> wac plug -> wasmtime serve -> curl 200/401
+#   phase B  wasi:http p3 world (test_wasi_http_p3_full_gate.sh) plus the
+#            incoming-body stream-parameter composition probe (#1540)
+#            componentize -> wac plug -> wasmtime serve -> curl assertions
 #   phase C  wasi:cli/stdin lifecycle
 #            generated shadow adapter + checker-hidden arbitrary-core route +
 #            hand-WAT provider measurement; exact ratified import,
@@ -71,6 +72,7 @@ case ",$PHASES," in *",http,"*)
   run_http=1
   echo "[p3-guarantee] phase B: wasi:http p3 world"
   bash "$SCRIPT_DIR/test_wasi_http_p3_full_gate.sh"
+  bash "$SCRIPT_DIR/test_http_body_stream_probe_gate.sh"
   ;;
 esac
 case ",$PHASES," in *",stdin,"*)

--- a/scripts/tests/http_body_stream_probe_gate_test.sh
+++ b/scripts/tests/http_body_stream_probe_gate_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+FAKE_BIN="$(mktemp -d "${TMPDIR:-/tmp}/vibe_body_stream_probe_test.XXXXXX")"
+cleanup() { rm -rf "$FAKE_BIN"; }
+trap cleanup EXIT
+
+cat >"$FAKE_BIN/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p target/wasm32-unknown-unknown/release
+: >target/wasm32-unknown-unknown/release/vibe_body_stream_probe_adapter.wasm
+EOF
+
+cat >"$FAKE_BIN/wasm-tools" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1 $2" = "component wit" ]; then
+  case "$3" in
+    *adapter.component.wasm)
+      printf '%s\n' 'world root {' \
+        '  import wasi:http/types@0.3.0;' \
+        '  import handler: func(method: string, url: string, headers: string, body: stream<u8>) -> string;' \
+        '}'
+      ;;
+    *)
+      printf '%s\n' 'world root {' '  import wasi:http/types@0.3.0;' '}'
+      ;;
+  esac
+  exit 0
+fi
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then out="$2"; shift 2; else shift; fi
+done
+[ -z "$out" ] || : >"$out"
+EOF
+
+cat >"$FAKE_BIN/wac" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then out="$2"; shift 2; else shift; fi
+done
+: >"$out"
+EOF
+
+# Simulate the collision from the review: the process spawned by the gate
+# loses the bind race and exits, while an incumbent endpoint answers "ok".
+cat >"$FAKE_BIN/wasmtime" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then echo 'wasmtime 47.0.2'; exit 0; fi
+exit 1
+EOF
+
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+  *" -w "*) printf '200' ;;
+  *" -o /dev/null "*) : ;;
+  *) printf 'ok' ;;
+esac
+EOF
+
+chmod +x "$FAKE_BIN"/*
+
+set +e
+PATH="$FAKE_BIN:$PATH" bash "$SCRIPT_DIR/test_http_body_stream_probe_gate.sh" \
+  >"$FAKE_BIN/out" 2>"$FAKE_BIN/err"
+status=$?
+set -e
+if [ "$status" -eq 0 ]; then
+  echo "FAIL: probe accepted an incumbent endpoint after its own server exited" >&2
+  cat "$FAKE_BIN/out" >&2
+  exit 1
+fi
+
+if ! grep -q 'test_http_body_stream_probe_gate.sh' "$SCRIPT_DIR/test_wasi_p3_guarantee_gate.sh"; then
+  echo "FAIL: body-stream probe is not registered in the WASI p3 guarantee gate" >&2
+  exit 1
+fi
+
+echo "http body stream probe gate regression: PASS"

--- a/tools/wasip3_component_probe/http_body_stream/README.md
+++ b/tools/wasip3_component_probe/http_body_stream/README.md
@@ -1,0 +1,114 @@
+# #1540 probe: how does a request body reach the guest?
+
+`wasi:http` hands the adapter the request body as a `stream<u8>`. The full
+adapter today `collect()`s it into a `String` before calling the guest
+(`scripts/build_wasi_http_p3_full_adapter.sh`), so a vibe handler can never see
+a body larger than memory, and never sees the first byte before the last one
+has arrived.
+
+#1540 proposed fixing that by having the adapter **export** `body: func() ->
+stream<u8>` and the guest **import** it, composed as a second `wac plug` edge.
+This probe exists because that shape does not work, and because the shape that
+does needed measuring before any emitter line was written.
+
+## Result 1: the issue's shape is a composition CYCLE and is not expressible
+
+Under the proposal each component is an instantiation argument to the other:
+
+- adapter imports `handler` from the guest
+- guest imports `body` from the adapter
+
+Measured with two minimal components (`u32` signatures -- the question is
+instantiation topology, not types):
+
+```
+$ wac plug --plug guest.wasm adapter.wasm -o out.wasm     # exit 0
+$ wasm-tools component wit out.wasm
+world root {
+  import body: func() -> u32;      # still unsatisfied
+  export body: func() -> u32;
+}
+```
+
+**`wac plug` does not report an error.** It wires the one edge it can and
+promotes the other component's unsatisfied import to the composed component's
+imports, where it fails at instantiation rather than at compose time. `wac
+compose`'s WAC language cannot express the cycle at all:
+
+```
+let a = new adapter:comp { handler: g["handler"], ... };
+let g = new guest:comp { body: a["body"], ... };
+```
+```
+error: failed to resolve document
+  × undefined name `g`
+```
+
+Instantiation is a DAG resolved in lexical order.
+
+## Result 2: body-as-a-parameter works, end to end
+
+The acyclic shape keeps one edge and moves the body onto it:
+
+```wit
+import handler: func(method: string, url: string, headers: string, body: stream<u8>) -> string;
+```
+
+Measured, all four steps:
+
+1. **`wit-bindgen` 0.54 accepts a `stream<u8>` parameter on an imported func**,
+   and the adapter can hand `Request::consume_body`'s reader straight through
+   without collecting:
+   ```rust
+   let (req_body_rx, _trailers_rx) = Request::consume_body(request, result_rx);
+   let raw = handler("GET", &url, "", req_body_rx);   // no .collect().await
+   ```
+2. the adapter componentizes and validates, declaring exactly that import;
+3. `wac plug` composes it with `guest.wat` here, and the composed component
+   has **no unsatisfied import** -- only `wasi:http/types@0.3.0`, which the
+   host provides;
+4. `wasmtime serve` runs it and a POST with a body gets a response.
+
+`bash scripts/test_http_body_stream_probe_gate.sh` reproduces all of it.
+
+## What this probe does NOT answer
+
+`guest.wat` **ignores** the stream and returns a constant. It answers the
+composition question only.
+
+Still open, and the next thing to measure: what a guest needs in order to READ
+the body stream. That requires `stream.read` plus an async lift. The current
+emitters only cover scalar results:
+`emit_canon_lift_async_section` (`component_codegen.vibe`) emits exactly one
+canonopt (`async`), and `emit_canon_task_return` emits none. This probe does
+**not** establish the exact `memory` / `realloc` / `string-encoding` option set
+for a string-bearing async handler; a separate byte-level probe must establish
+that encoding before those emitters are generalized.
+
+## Consequence for #1540's scope
+
+Scope 3 ("compose becomes two edges") cannot be implemented as written. Scope 1
+("the adapter exports `body: func() -> stream<u8>`") does not survive either --
+`body()` would be a second export on the same instance, and `wasmtime serve`
+handles concurrent requests on one instance, so a per-request slot has no
+request identity to key on. `Request::consume_body` also takes `this: request`
+**by value** (`lib/@vibe/wasi/wit/p3/deps/http.wit`), so the reader must live on
+the `handle` future's own stack and be handed over within that call -- which is
+what shape (a) does.
+
+Shape (a) does add a requirement none of the three scope bullets mention: the
+guest needs a way to SPELL a `HostStream`-typed parameter, since #1341 made
+`host_stream_named` return the nominal `HostStream` rather than `Stream[Int]`.
+
+## Gate integration and process isolation
+
+The probe runs from the required-tools `wasi-p3-gate` through
+`scripts/test_wasi_p3_guarantee_gate.sh`. Missing tools are a local-development
+skip by default and a failure under `VIBE_P3_GATE_REQUIRE_TOOLS=1`, matching the
+other P3 probes.
+
+Each invocation chooses a process-specific port and embeds a fixed-width token
+in its guest response. It checks that the spawned `wasmtime` remains alive and
+that curl receives that token, then cleans up only the recorded child PID. A
+different server already listening cannot satisfy the assertion or be killed
+by cleanup.

--- a/tools/wasip3_component_probe/http_body_stream/guest.wat
+++ b/tools/wasip3_component_probe/http_body_stream/guest.wat
@@ -1,0 +1,34 @@
+;; #1540 shape (a) probe guest: export the handler the adapter imports, with the
+;; request body arriving as a `stream<u8>` PARAMETER rather than a materialized
+;; string. This guest ignores the stream and answers a constant, which is enough
+;; to answer the composition question on its own.
+(component
+  (core module $m
+    (memory (export "memory") 1)
+    ;; The gate replaces the fixed-width suffix with a per-process token. This
+    ;; proves curl reached the wasmtime process started by that gate invocation.
+    ;; "200\n\nprobe-00000" -- the adapter's status/headers/body split
+    (data (i32.const 16) "200\0a\0aprobe-00000")
+    (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32)
+      i32.const 128)
+    ;; 3 strings (ptr,len) + 1 stream handle; the string result is returned as
+    ;; a POINTER to its (ptr,len) pair, not through a retptr parameter.
+    (func (export "handler")
+      (param i32 i32 i32 i32 i32 i32 i32) (result i32)
+      i32.const 64
+      i32.const 16
+      i32.store
+      i32.const 64
+      i32.const 16
+      i32.store offset=4
+      i32.const 64)
+  )
+  (core instance $i (instantiate $m))
+  (func (export "handler")
+    (param "method" string) (param "url" string) (param "headers" string)
+    (param "body" (stream u8)) (result string)
+    (canon lift (core func $i "handler")
+      string-encoding=utf8
+      (memory $i "memory")
+      (realloc (func $i "cabi_realloc"))))
+)


### PR DESCRIPTION
#1540 は「adapter が `body: func() -> stream<u8>` を **export** し、guest が **import** して、
`wac plug` の**2 本目の辺**で繋ぐ」形を提案している。**その形は成立しない。** そして成立する
形の方は、emitter を 1 行も書く前に測っておく必要があった — §3.12 / §3.17 を決めたのと
同じ手順。

## 結果 1: 提案されている形は合成の**循環**

互いが相手の instantiation 引数になる。**`wac plug` はエラーを出さない** — 繋げる方の辺だけ
繋ぎ、もう一方の未充足 import を合成コンポーネントへ押し上げるので、**compose 時ではなく
instantiate 時に壊れる**:

```
$ wac plug --plug guest.wasm adapter.wasm -o out.wasm     # exit 0
world root { import body: ...;  export body: ...; }
```

`wac compose` の WAC 言語では**そもそも書けない** (`undefined name \`g\``) — instantiation は
DAG で字句順に解決される。

## 結果 2: body を**引数**に乗せる形は、4 段すべて動く

```wit
import handler: func(method: string, url: string, headers: string, body: stream<u8>) -> string;
```

1. **wit-bindgen 0.54 は import func の `stream<u8>` 引数を受け付ける**。adapter は
   `Request::consume_body` の reader を **`.collect().await` せずそのまま**渡せる
2. adapter が component 化して validate し、その import を宣言する
3. `wac plug` が probe guest と合成し、**未充足 import が残らない**
   (host が提供する `wasi:http/types` のみ)
4. `wasmtime serve` が動き、**body 付き POST が 200 とゲストの応答**を返す

ゲートは 3 を**否定側でも** assert する — 合成後に `handler` import が残っているのは
循環形の失敗そのものなので、後で壊れる serve へ進む前に落とす。

## この probe が答えていないこと

`guest.wat` は**ストリームを読まない**。答えているのは合成の問いだけ。

body を読むには `stream.read` と async lift が要る。現在の emitter は scalar 結果に限定され、
`emit_canon_lift_async_section` は `async` canonopt だけ、`emit_canon_task_return` は option なし。
ただし string-bearing async handler に必要な memory / realloc / string-encoding の**正確な集合はこの probe では未測定**であり、README と spec では次の byte-level probe の課題として記録した。

## issue のスコープへの帰結

- **スコープ 3 は記述のままでは実装できない**
- **スコープ 1 も成立しない** — `body()` は同一インスタンスの 2 つ目の export で、
  `wasmtime serve` は 1 インスタンスで並行リクエストを捌くため、request ごとの slot は
  request 同一性が無く不健全。`Request::consume_body` は `this: request` を**値で取る**ので、
  reader は `handle` future 自身のスタックに持ってその呼び出し内で渡すしかない —
  それがまさに shape (a)
- shape (a) は**どのスコープ項目にも書かれていない要件**を 1 つ足す:
  #1341 で `host_stream_named` の戻りが nominal `HostStream` になったので、
  ゲスト側に **`HostStream` 型の引数を綴る手段**が要る

## 検証

`bash scripts/test_http_body_stream_probe_gate.sh` — **PASS**
(cargo / wasm-tools / wac / wasmtime / curl 不在時は既存の p3 ゲートと同じ作法で skip、
`VIBE_P3_GATE_REQUIRE_TOOLS=1` で失敗に変わる)

## 関連

#1540、#1341 (`HostStream` の分離)、#1230、spec §3.18 / §3.19

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_
