### PR TITLE
perf(policy): make selfcompile stat tokens reconstruction-stable

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -122,7 +122,8 @@ local testArtifactInputTrace = new Task {
 
 local testSelfcompileHeapPolicy = new Task {
   name = "test-selfcompile-heap-policy"
-  description = "fail-closed merge-base selfcompile heap policy, content-token, and fixed-workdir tests"
+  description =
+    "fail-closed merge-base selfcompile heap policy, content-token, and fixed-workdir tests"
   cmd =
     "node --test scripts/wasm_vibe_host_runner_stat_token.test.cjs scripts/selfcompile_heap_policy.test.mjs && bash scripts/selfcompile_kpi_work_dir_test.sh"
   inputs {

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -122,12 +122,14 @@ local testArtifactInputTrace = new Task {
 
 local testSelfcompileHeapPolicy = new Task {
   name = "test-selfcompile-heap-policy"
-  description = "fail-closed merge-base selfcompile heap policy and fixed-workdir tests"
+  description = "fail-closed merge-base selfcompile heap policy, content-token, and fixed-workdir tests"
   cmd =
-    "node --test scripts/selfcompile_heap_policy.test.mjs && bash scripts/selfcompile_kpi_work_dir_test.sh"
+    "node --test scripts/wasm_vibe_host_runner_stat_token.test.cjs scripts/selfcompile_heap_policy.test.mjs && bash scripts/selfcompile_kpi_work_dir_test.sh"
   inputs {
     "scripts/selfcompile_heap_policy.mjs"
     "scripts/selfcompile_heap_policy.test.mjs"
+    "scripts/wasm_vibe_host_runner.js"
+    "scripts/wasm_vibe_host_runner_stat_token.test.cjs"
     "scripts/selfcompile_kpi.sh"
     "scripts/selfcompile_kpi_work_dir_test.sh"
     "bench/perf/selfcompile_heap_policy.json"

--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -17,9 +17,10 @@ One real compile through a selfhost stage2, reporting `wall_ms` and
 `heap_ptr_bytes` (linear backend bump-allocator high-water). With a cold
 isolated `VIBE_BUILD_CACHE_DIR` the heap number is byte-deterministic across
 repeated trials in one materialized tree, so — unlike wall time — the current
-absolute gate can use it without flakes. It is **not yet deterministic across
-clean tree reconstructions**: the Phase A comparative smoke found a stable
-16-byte metadata-sensitive split. See the Phase B blocker in
+absolute gate can use it without flakes. The policy controller additionally
+uses CLI-only `content-v1` stat tokens to make identical clean tree
+reconstructions deterministic; this does not change the standalone/default
+metadata token behavior described here. See the remaining Phase B blockers in
 [`docs/selfcompile-heap-policy.md`](../../docs/selfcompile-heap-policy.md).
 
 CI wiring (`.github/workflows/ci.yml`, step "Selfcompile KPI heap gate"):

--- a/docs/selfcompile-heap-policy.md
+++ b/docs/selfcompile-heap-policy.md
@@ -83,8 +83,10 @@ so a PR cannot make its own workload easier.
 
 The trusted Node runner accepts `--policy-stat-token content-v1` only together
 with an absolute `--policy-stat-root`. These controller-owned arguments occur
-before the wasm path, are removed by host CLI parsing, and are absent from the
-guest argv and environment. The runner requires its physical CWD to equal the
+before the wasm path and are removed by host CLI parsing. The controller does
+not put either selector in its constructed environment, and the runner does
+not include them in passthrough guest argv. The runner requires its physical
+CWD to equal the
 physical root, rejects lexical/physical escape and ancestor symlinks, returns
 `-1` for a final symlink, and fails on missing, racing, or unsupported entries.
 Default raw Node, Rust, Preview2, compiler, and cache behavior is unchanged.
@@ -94,14 +96,15 @@ UTF-8-byte-sorted immediate `(name length, name, lstat kind)` sequence. The
 digest is:
 
 ```text
-SHA-256("vibe:selfcompile-policy:stat-token:v1\\0" || kind || u64be(length) || payload)
+SHA-256(ASCII("vibe:selfcompile-policy:stat-token:v1") || NUL || kind || u64be(length) || payload)
 ```
 
 The raw token is `2^60 | (first_u64be & (2^60 - 1))`, always a positive
 19-digit Vibe `Int`; `0` is never emitted. A process-local full-digest registry
-fails closed on a 60-bit projection collision. Preview2 policy mode uses the
-first 128 digest bits. Paths are authority inputs, not digest inputs, because
-all production cache callers already key by path. Content hashing is expected
+fails closed on a 60-bit projection collision. Preview2 remains on its existing
+metadata hash even when the raw-only policy selector is present. Paths are
+authority inputs, not digest inputs, because all production cache callers
+already key by path. Content hashing is expected
 to cost more host I/O and is intentionally confined to this policy mode.
 
 The acceptance smoke ran commit `14891ea0` twice through independent fresh

--- a/docs/selfcompile-heap-policy.md
+++ b/docs/selfcompile-heap-policy.md
@@ -29,9 +29,10 @@ after Phase B. They are never enforcement inputs to the comparative policy.
 1. resolves full base/head/current identities and synthesizes `merge-tree`;
 2. rejects a supplied current merge result whose tree is not that merge tree;
 3. reads policy and benchmark input from the base revision;
-4. atomically creates a private mode-`0700` workspace lease under a physical
-   OS temporary directory (or current-UID-owned `RUNNER_TEMP` on CI), verifies
-   its type, owner, mode, and realpath, and reuses its fixed `lease/root` path;
+4. atomically creates an exclusive, stable-name mode-`0700` workspace lease
+   under a physical OS temporary directory (or current-UID-owned `RUNNER_TEMP`
+   on CI), verifies its type, owner, mode, and realpath, and reuses its fixed
+   `lease/root` path; a concurrent or abandoned lease fails closed;
 5. rejects a tracked `_build` entry in either tree before creating that
    reserved mutation namespace;
 6. before writing or executing extracted content, rejects a pinned input or
@@ -40,13 +41,17 @@ after Phase B. They are never enforcement inputs to the comparative policy.
    caches, HOME, TMPDIR, and VIBE_HOME, never a caller-selected target;
 8. force-generates and verifies the generated fingerprint, then builds stage2
    at one fixed relative path;
-9. records the stage2 SHA-256 and runs two exact cold-cache heap trials
-   through `scripts/selfcompile_kpi.sh`, using `VIBE_KPI_WORK_DIR` for fixed
-   output and cache paths;
-10. rejects any build or heap difference when base and current are the same
+9. records the stage2 SHA-256 and runs two exact cold-cache heap trials with
+   the controller checkout's sibling Node runner (never the materialized
+   tree's KPI shell or runner), recreating fixed output/cache paths each time;
+10. selects CLI-only `content-v1` stat tokens before the wasm path, proves the
+    physical materialized root, parses exactly one runner memory line, and
+    requires a nonempty output wasm;
+11. rejects any build or heap difference when base and current are the same
    tree, catching stable cross-reconstruction drift as well as within-build
    trial drift;
-11. applies the base policy and emits one machine-readable JSON summary.
+12. applies the base policy and emits one machine-readable JSON summary with
+    `stat_token_mode: "content-v1"`.
 
 The controller scrubs inherited `VIBE_*`, credentials, `NODE_OPTIONS`, and
 other ambient state by constructing a small environment from scratch. The
@@ -66,32 +71,50 @@ node scripts/selfcompile_heap_policy.mjs \
 ```
 
 There is deliberately no `--canonical-root`: callers cannot select anything
-the controller recursively deletes. CI will supply an event timestamp and the
+the controller recursively deletes. The controller's stable lease name keeps
+absolute-path bytes identical across independent invocations; exclusive
+creation serializes runs instead of falling back to a path that would change
+the measured allocator input. CI will supply an event timestamp and the
 GitHub merge result with `--current`; the controller itself leases beneath a
 verified `RUNNER_TEMP`. The benchmark root source is always copied from base,
 so a PR cannot make its own workload easier.
 
-## Known Phase B blocker: metadata-sensitive 16-byte drift
+## Policy-only deterministic stat tokens
 
-The real identical-tree smoke is internally stable but differs across clean
-reconstructions:
+The trusted Node runner accepts `--policy-stat-token content-v1` only together
+with an absolute `--policy-stat-root`. These controller-owned arguments occur
+before the wasm path, are removed by host CLI parsing, and are absent from the
+guest argv and environment. The runner requires its physical CWD to equal the
+physical root, rejects lexical/physical escape and ancestor symlinks, returns
+`-1` for a final symlink, and fails on missing, racing, or unsupported entries.
+Default raw Node, Rust, Preview2, compiler, and cache behavior is unchanged.
 
-- base trials: `924,816,456`, `924,816,456`;
-- current trials: `924,816,440`, `924,816,440`;
-- stage2 SHA-256, benchmark bytes, and normalized paths are identical.
+For a regular file the payload is its exact bytes. For a directory it is the
+UTF-8-byte-sorted immediate `(name length, name, lstat kind)` sequence. The
+digest is:
 
-This is source-filesystem metadata sensitivity, not ordinary trial noise.
-`scripts/wasm_vibe_host_runner.js` includes mtime and inode in `Fs::stat_token`,
-and loader cache text stringifies those tokens. Deleting and recreating the
-same bytes changes that metadata; token length/alignment can therefore move
-the guest heap by 16 bytes. For different source trees that hidden drift could
-look like an improvement or unbudgeted growth.
+```text
+SHA-256("vibe:selfcompile-policy:stat-token:v1\\0" || kind || u64be(length) || payload)
+```
 
-**Phase B remains blocked.** Do not wire this controller into required CI or
-use its deltas for budget decisions until a trusted policy-only runner
-normalizes stat tokens and repeated same-tree reconstructions make all four
-readings identical. Phase B must execute the complete controller, generation,
-host-runner, and KPI harness closure from immutable base authority. It must run
+The raw token is `2^60 | (first_u64be & (2^60 - 1))`, always a positive
+19-digit Vibe `Int`; `0` is never emitted. A process-local full-digest registry
+fails closed on a 60-bit projection collision. Preview2 policy mode uses the
+first 128 digest bits. Paths are authority inputs, not digest inputs, because
+all production cache callers already key by path. Content hashing is expected
+to cost more host I/O and is intentionally confined to this policy mode.
+
+The acceptance smoke ran commit `14891ea0` twice through independent fresh
+leases. All eight heap readings were `1,092,143,664`, all four stage2 hashes
+were `4a6e2c8b…beafb2e`, and all eight runner attestations reported 6,158 calls,
+214 unique projections, and transcript `fc99ec15…a308b3`. A three-pair direct
+runner sample measured metadata/content-v1 wall medians of 2.03/2.29 seconds
+(+12.81%); this cost is confined to the unwired policy path.
+
+**Phase B remains blocked.** Deterministic tokens remove the known 16-byte
+reconstruction drift, but do not make the current harness safe for PR CI.
+Phase B must execute the complete controller, generation, host-runner, and KPI
+harness closure from immutable base authority. It must run
 base/current in disposable containers with no network, dropped capabilities
 and no-new-privileges, a read-only trusted harness/root filesystem, only
 container-local temporary writable areas, and no writable host mounts. The
@@ -138,8 +161,8 @@ of an untrusted revision is **not sandboxed**: extracted generation scripts and
 the raw compiler filesystem ABI can access the host as the current user.
 
 Phase B/PR CI is forbidden until the immutable-harness and disposable-container
-requirements above, stat-token normalization, policy-path review ownership,
-and strict latest-base governance all land. Only then may a parallel
+requirements above, policy-path review ownership, and strict latest-base
+governance all land. Only then may a parallel
 `selfcompile-heap-policy` job join `ci-required` and retire the old baseline as
 gate authority. Building base
 and current sequentially is expected to add roughly two clean stage2 builds

--- a/scripts/selfcompile_heap_policy.mjs
+++ b/scripts/selfcompile_heap_policy.mjs
@@ -471,13 +471,14 @@ export function trustedRunnerInvocation({ root, stage2, inputPath, outputPath })
   };
 }
 
-function measureWithTrustedRunner({ root, stage2, inputPath, workDir, env }) {
+function measureWithTrustedRunner({ root, stage2, inputPath, workDir, env, testProcessRunner = null }) {
   rmSync(workDir, { recursive: true, force: true });
   const cacheDir = join(workDir, "cache");
   const outputPath = join(workDir, "out.wasm");
   mkdirSync(cacheDir, { recursive: true });
   const invocation = trustedRunnerInvocation({ root, stage2, inputPath, outputPath });
-  const result = spawnSync(invocation.command, invocation.args, {
+  const processRunner = testProcessRunner ?? spawnSync;
+  const result = processRunner(invocation.command, invocation.args, {
     cwd: root,
     env: {
       ...env,
@@ -508,7 +509,7 @@ function measureWithTrustedRunner({ root, stage2, inputPath, workDir, env }) {
   return parseRunnerMeasurement(String(result.stderr ?? ""));
 }
 
-async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, testDriver }) {
+async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, testDriver, testProcessRunner }) {
   const root = resetWorkspaceRoot(lease);
   await archiveTree(repo, tree, root);
   // The merge tree is untrusted. Validate before writing the pinned base input
@@ -520,8 +521,12 @@ async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, te
   const stage2 = join(generationDir, "stage2.wasm");
   const workDir = join(root, "_build", "selfcompile-policy", "kpi-work");
 
+  if (testProcessRunner && (process.env.VIBE_HEAP_POLICY_TEST_MODE !== "1" || !testDriver)) {
+    fail("test-driver-forbidden");
+  }
   if (testDriver) {
     if (process.env.VIBE_HEAP_POLICY_TEST_MODE !== "1") fail("test-driver-forbidden");
+    if (testProcessRunner !== undefined && typeof testProcessRunner !== "function") fail("test-driver-forbidden");
     runChecked(process.execPath, [testDriver, "build"], root, {
       ...env,
       POLICY_REVISION: label,
@@ -550,7 +555,7 @@ async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, te
   const statTokenAttestations = [];
   for (let trial = 1; trial <= 2; trial += 1) {
     let output;
-    if (testDriver) {
+    if (testDriver && !testProcessRunner) {
       output = runChecked(process.execPath, [testDriver, "measure", String(trial)], root, {
         ...env,
         POLICY_REVISION: label,
@@ -560,7 +565,14 @@ async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, te
         POLICY_WORK_DIR: workDir,
       }, "build-failed", true);
     } else {
-      const measurement = measureWithTrustedRunner({ root, stage2, inputPath, workDir, env });
+      const measurement = measureWithTrustedRunner({
+        root,
+        stage2,
+        inputPath,
+        workDir,
+        env,
+        testProcessRunner,
+      });
       trials.push(measurement.heap);
       statTokenAttestations.push(measurement.attestation);
       continue;
@@ -659,8 +671,26 @@ async function runControllerWithLease(options, lease) {
   const baseCommitTime = Number(git(repo, ["show", "-s", "--format=%ct", base]).trim()) * 1000;
   const asOfMs = options.asOf ? Date.parse(options.asOf) : Date.now();
   if (!Number.isFinite(asOfMs)) fail("invalid-arguments", { argument: "--as-of" });
-  const baseResult = await measureTree({ repo, tree: baseTree, label: "base", lease, inputBlob, policy, testDriver: options.testDriver });
-  const currentResult = await measureTree({ repo, tree: currentTree, label: "current", lease, inputBlob, policy, testDriver: options.testDriver });
+  const baseResult = await measureTree({
+    repo,
+    tree: baseTree,
+    label: "base",
+    lease,
+    inputBlob,
+    policy,
+    testDriver: options.testDriver,
+    testProcessRunner: options.testProcessRunner,
+  });
+  const currentResult = await measureTree({
+    repo,
+    tree: currentTree,
+    label: "current",
+    lease,
+    inputBlob,
+    policy,
+    testDriver: options.testDriver,
+    testProcessRunner: options.testProcessRunner,
+  });
   if (baseTree === currentTree) {
     if (baseResult.stage2_sha256 !== currentResult.stage2_sha256) {
       fail("nondeterministic-build", {

--- a/scripts/selfcompile_heap_policy.mjs
+++ b/scripts/selfcompile_heap_policy.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -7,11 +7,11 @@ import {
   constants,
   lstatSync,
   mkdirSync,
-  mkdtempSync,
   openSync,
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -20,6 +20,8 @@ import { fileURLToPath } from "node:url";
 
 const POLICY_PATH = "bench/perf/selfcompile_heap_policy.json";
 const BUDGET_DIR = "bench/perf/selfcompile_heap_budgets";
+const STAT_TOKEN_MODE = "content-v1";
+const TRUSTED_RUNNER = fileURLToPath(new URL("./run_wasm_vibe_host_runner.sh", import.meta.url));
 const POLICY_KEYS = [
   "budget_max_lifetime_days",
   "emergency_absolute_cap_bytes",
@@ -304,7 +306,16 @@ function createWorkspaceLease() {
   } else {
     tempBase = verifyPhysicalDirectory(realpathSync(os.tmpdir()), { requireOwner: false, reason: "unsafe-local-temp" });
   }
-  const lease = mkdtempSync(join(tempBase, "vibe-selfcompile-policy-"));
+  // A stable absolute root is part of the KPI input: compiler maps contain
+  // absolute source paths, and different path bytes can change persistent-map
+  // allocation even when lengths match. mkdir is the exclusive lease; a
+  // concurrent or abandoned run fails closed rather than choosing a new path.
+  const lease = join(tempBase, "vibe-selfcompile-policy-lease");
+  try {
+    mkdirSync(lease, { mode: 0o700 });
+  } catch (error) {
+    fail("workspace-busy", { lease, code: error.code });
+  }
   chmodSync(lease, 0o700);
   activeWorkspaceLeases.add(lease);
   try {
@@ -423,6 +434,80 @@ function parseMeasurement(output) {
   return value;
 }
 
+function parseRunnerMeasurement(stderr) {
+  const memoryPattern = /^\[wasm-memory\] run pages=([0-9]+) bytes=([0-9]+) heap_ptr=([0-9]+) host_alloc_ptr=([0-9]+) rss=([0-9]+)$/;
+  const attestPattern = /^\[policy-stat-token\] mode=content-v1 calls=([0-9]+) unique=([0-9]+) transcript=([0-9a-f]{64})$/;
+  const lines = stderr.split(/\r?\n/);
+  const memoryLines = lines.filter(line => line.startsWith("[wasm-memory]"));
+  const attestLines = lines.filter(line => line.startsWith("[policy-stat-token]"));
+  if (memoryLines.length !== 1 || attestLines.length !== 1) {
+    fail("malformed-kpi-output", { memory_lines: memoryLines.length, attestation_lines: attestLines.length });
+  }
+  const memory = memoryLines[0].match(memoryPattern);
+  const attestation = attestLines[0].match(attestPattern);
+  if (!memory || !attestation) fail("malformed-kpi-output");
+  const heap = Number(memory[3]);
+  const calls = Number(attestation[1]);
+  const unique = Number(attestation[2]);
+  if (!safeInteger(heap, { positive: true }) || !safeInteger(calls, { positive: true }) || !safeInteger(unique, { positive: true })) {
+    fail("malformed-kpi-output");
+  }
+  return {
+    heap,
+    attestation: { mode: STAT_TOKEN_MODE, calls, unique, transcript: attestation[3] },
+  };
+}
+
+export function trustedRunnerInvocation({ root, stage2, inputPath, outputPath }) {
+  return {
+    command: "bash",
+    args: [
+      TRUSTED_RUNNER,
+      "--policy-stat-token", STAT_TOKEN_MODE,
+      "--policy-stat-root", root,
+      "--invoke", "cli_main",
+      stage2, inputPath, outputPath, "__no_entry__",
+    ],
+  };
+}
+
+function measureWithTrustedRunner({ root, stage2, inputPath, workDir, env }) {
+  rmSync(workDir, { recursive: true, force: true });
+  const cacheDir = join(workDir, "cache");
+  const outputPath = join(workDir, "out.wasm");
+  mkdirSync(cacheDir, { recursive: true });
+  const invocation = trustedRunnerInvocation({ root, stage2, inputPath, outputPath });
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: root,
+    env: {
+      ...env,
+      VIBE_PREOPEN_DIR: root,
+      VIBE_FS_COMPILE: "1",
+      VIBE_IMPORT_ABI: "raw",
+      VIBE_WASM_MEMORY_STATS: "1",
+      VIBE_BUILD_CACHE_DIR: cacheDir,
+    },
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error || result.status !== 0 || result.signal !== null) {
+    fail("build-failed", {
+      command: `${invocation.command} ${invocation.args.join(" ")}`,
+      status: result.status,
+      signal: result.signal,
+      stderr: String(result.stderr ?? "").slice(-4000),
+    });
+  }
+  try {
+    if (!statSync(outputPath).isFile() || statSync(outputPath).size <= 0) fail("build-failed", { missing: outputPath });
+  } catch (error) {
+    if (error instanceof HeapPolicyError) throw error;
+    fail("build-failed", { missing: outputPath });
+  }
+  return parseRunnerMeasurement(String(result.stderr ?? ""));
+}
+
 async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, testDriver }) {
   const root = resetWorkspaceRoot(lease);
   await archiveTree(repo, tree, root);
@@ -462,6 +547,7 @@ async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, te
   }
 
   const trials = [];
+  const statTokenAttestations = [];
   for (let trial = 1; trial <= 2; trial += 1) {
     let output;
     if (testDriver) {
@@ -474,19 +560,23 @@ async function measureTreeOnce({ repo, tree, label, lease, inputBlob, policy, te
         POLICY_WORK_DIR: workDir,
       }, "build-failed", true);
     } else {
-      output = runChecked("bash", ["scripts/selfcompile_kpi.sh", stage2, policy.input], root, {
-        ...env,
-        VIBE_KPI_WORK_DIR: workDir,
-        VIBE_KPI_ALLOWED_WORK_ROOT: join(root, "_build"),
-      }, "build-failed", true);
+      const measurement = measureWithTrustedRunner({ root, stage2, inputPath, workDir, env });
+      trials.push(measurement.heap);
+      statTokenAttestations.push(measurement.attestation);
+      continue;
     }
     trials.push(parseMeasurement(output));
+    statTokenAttestations.push(null);
   }
   if (trials[0] !== trials[1]) fail("nondeterministic-heap", { revision: label, trials });
+  if (!testDriver && JSON.stringify(statTokenAttestations[0]) !== JSON.stringify(statTokenAttestations[1])) {
+    fail("nondeterministic-stat-token", { revision: label, stat_token_attestations: statTokenAttestations });
+  }
   return {
     heap_bytes: trials[0],
     trials,
     stage2_sha256: stage2Sha256,
+    stat_token_attestations: statTokenAttestations,
     normalized_paths: {
       canonical_root: root,
       input: policy.input,
@@ -584,6 +674,13 @@ async function runControllerWithLease(options, lease) {
         trials: [...baseResult.trials, ...currentResult.trials],
       });
     }
+    if (JSON.stringify(baseResult.stat_token_attestations) !== JSON.stringify(currentResult.stat_token_attestations)) {
+      fail("nondeterministic-stat-token", {
+        revision: "identical-tree-reconstruction",
+        base: baseResult.stat_token_attestations,
+        current: currentResult.stat_token_attestations,
+      });
+    }
   }
   const evaluation = evaluatePolicy({
     policy,
@@ -615,8 +712,13 @@ async function runControllerWithLease(options, lease) {
     budget_id: evaluation.budget_id,
     trials: { base: baseResult.trials, current: currentResult.trials },
     stage2_sha256: { base: baseResult.stage2_sha256, current: currentResult.stage2_sha256 },
+    stat_token_attestations: {
+      base: baseResult.stat_token_attestations,
+      current: currentResult.stat_token_attestations,
+    },
     normalized_paths: baseResult.normalized_paths,
     benchmark_input_source_commit: base,
+    stat_token_mode: STAT_TOKEN_MODE,
   };
 }
 

--- a/scripts/selfcompile_heap_policy.test.mjs
+++ b/scripts/selfcompile_heap_policy.test.mjs
@@ -358,16 +358,49 @@ test("trusted runner selectors are controller-owned and precede wasm guest argv"
 test("materialized KPI shell and runner spoofing cannot select the trusted runner", async () => {
   const fixture = makeRepository();
   const driver = makeDriver(fixture.outer);
+  const forgedMarker = join(fixture.outer, "forged-runner-invoked");
   mkdirSync(join(fixture.repo, "scripts"));
-  writeFileSync(join(fixture.repo, "scripts/selfcompile_kpi.sh"), "#!/bin/sh\necho forged\n");
-  writeFileSync(join(fixture.repo, "scripts/wasm_vibe_host_runner.js"), "throw new Error('forged')\n");
+  writeFileSync(
+    join(fixture.repo, "scripts/selfcompile_kpi.sh"),
+    `#!/bin/sh\ntouch ${JSON.stringify(forgedMarker)}\nexit 91\n`,
+  );
+  writeFileSync(
+    join(fixture.repo, "scripts/wasm_vibe_host_runner.js"),
+    `require("node:fs").writeFileSync(${JSON.stringify(forgedMarker)}, "invoked")\nprocess.exit(92)\n`,
+  );
   const head = commitAll(fixture.repo, "spoof materialized harness", "2026-08-01T01:00:00Z");
+  const invocations = [];
+  const testProcessRunner = (commandName, args, options) => {
+    invocations.push({ commandName, args: [...args], cwd: options.cwd, env: { ...options.env } });
+    assert.equal(commandName, "bash");
+    assert.ok(args[0].endsWith("/scripts/run_wasm_vibe_host_runner.sh"));
+    assert.equal(args[0].startsWith(options.cwd), false, "runner must come from controller checkout");
+    assert.deepEqual(args.slice(1, 5), [
+      "--policy-stat-token", "content-v1", "--policy-stat-root", options.cwd,
+    ]);
+    assert.equal(Object.keys(options.env).some(key => key.includes("POLICY_STAT_TOKEN")), false);
+    assert.deepEqual(args.slice(-1), ["__no_entry__"]);
+    const outputPath = args.at(-2);
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, "mock output wasm");
+    return {
+      error: null,
+      status: 0,
+      signal: null,
+      stdout: "",
+      stderr:
+        "[policy-stat-token] mode=content-v1 calls=1 unique=1 transcript=" + "a".repeat(64) + "\n" +
+        "[wasm-memory] run pages=1 bytes=65536 heap_ptr=1000 host_alloc_ptr=0 rss=1\n",
+    };
+  };
   const result = await controller({
     repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
-    prNumber: "1801", testDriver: driver,
+    prNumber: "1801", testDriver: driver, testProcessRunner,
   });
   assert.equal(result.decision, "pass");
   assert.equal(result.stat_token_mode, "content-v1");
+  assert.equal(invocations.length, 4, "both trials for base/current must use measureWithTrustedRunner");
+  assert.equal(existsSync(forgedMarker), false, "materialized spoof must never execute");
 });
 
 test("controller consumes one new base-bound budget and ignores a permissive head policy", async () => {

--- a/scripts/selfcompile_heap_policy.test.mjs
+++ b/scripts/selfcompile_heap_policy.test.mjs
@@ -20,6 +20,7 @@ import {
   parseBudget,
   parsePolicy,
   runController,
+  trustedRunnerInvocation,
 } from "./selfcompile_heap_policy.mjs";
 
 const policy = parsePolicy(JSON.stringify({
@@ -223,6 +224,31 @@ test("CI lease is created under a physical runner-owned RUNNER_TEMP", async () =
   }
 });
 
+test("pre-existing stable lease fails closed and is never deleted", async () => {
+  const fixture = makeRepository();
+  const driver = makeDriver(fixture.outer);
+  const lease = join(fixture.outer, "vibe-selfcompile-policy-lease");
+  mkdirSync(lease, { mode: 0o700 });
+  const marker = join(lease, "must-survive.txt");
+  writeFileSync(marker, "untouched\n");
+  const oldActions = process.env.GITHUB_ACTIONS;
+  const oldRunnerTemp = process.env.RUNNER_TEMP;
+  process.env.GITHUB_ACTIONS = "true";
+  process.env.RUNNER_TEMP = fixture.outer;
+  try {
+    await assert.rejects(() => controller({
+      repo: fixture.repo, base: fixture.initial, head: fixture.initial,
+      synthesizeMerge: true, prNumber: "1801", testDriver: driver,
+    }), error => error.reason === "workspace-busy");
+    assert.equal(readFileSync(marker, "utf8"), "untouched\n");
+  } finally {
+    if (oldActions === undefined) delete process.env.GITHUB_ACTIONS;
+    else process.env.GITHUB_ACTIONS = oldActions;
+    if (oldRunnerTemp === undefined) delete process.env.RUNNER_TEMP;
+    else process.env.RUNNER_TEMP = oldRunnerTemp;
+  }
+});
+
 test("caller-selected canonical roots are rejected and never deleted", async () => {
   const fixture = makeRepository();
   const victim = join(fixture.outer, "caller-selected-victim");
@@ -295,6 +321,7 @@ test("controller synthesizes latest-base merge, pins input, reuses exact paths, 
     asOf: "2026-08-02T00:00:00.000Z", testDriver: driver,
   });
   assert.equal(result.decision, "pass");
+  assert.equal(result.stat_token_mode, "content-v1");
   assert.equal(result.base_heap_bytes, 1000);
   assert.deepEqual(result.trials, { base: [1000, 1000], current: [1000, 1000] });
   const root = result.normalized_paths.canonical_root;
@@ -309,6 +336,38 @@ test("controller synthesizes latest-base merge, pins input, reuses exact paths, 
   for (const key of ["stage2", "input", "work", "home", "tmp", "vibeHome"]) {
     assert.equal(new Set(log.map(row => row[key])).size, 1, `${key} must be identical`);
   }
+});
+
+test("trusted runner selectors are controller-owned and precede wasm guest argv", () => {
+  const root = "/physical/materialized/root";
+  const stage2 = `${root}/_build/stage2.wasm`;
+  const inputPath = `${root}/input.vibe`;
+  const outputPath = `${root}/_build/out.wasm`;
+  const invocation = trustedRunnerInvocation({ root, stage2, inputPath, outputPath });
+  assert.equal(invocation.command, "bash");
+  assert.ok(invocation.args[0].endsWith("/scripts/run_wasm_vibe_host_runner.sh"));
+  assert.equal(invocation.args[0].startsWith(root), false, "materialized runner must not be selected");
+  assert.deepEqual(invocation.args.slice(1), [
+    "--policy-stat-token", "content-v1",
+    "--policy-stat-root", root,
+    "--invoke", "cli_main",
+    stage2, inputPath, outputPath, "__no_entry__",
+  ]);
+});
+
+test("materialized KPI shell and runner spoofing cannot select the trusted runner", async () => {
+  const fixture = makeRepository();
+  const driver = makeDriver(fixture.outer);
+  mkdirSync(join(fixture.repo, "scripts"));
+  writeFileSync(join(fixture.repo, "scripts/selfcompile_kpi.sh"), "#!/bin/sh\necho forged\n");
+  writeFileSync(join(fixture.repo, "scripts/wasm_vibe_host_runner.js"), "throw new Error('forged')\n");
+  const head = commitAll(fixture.repo, "spoof materialized harness", "2026-08-01T01:00:00Z");
+  const result = await controller({
+    repo: fixture.repo, base: fixture.initial, head, synthesizeMerge: true,
+    prNumber: "1801", testDriver: driver,
+  });
+  assert.equal(result.decision, "pass");
+  assert.equal(result.stat_token_mode, "content-v1");
 });
 
 test("controller consumes one new base-bound budget and ignores a permissive head policy", async () => {

--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -1110,7 +1110,7 @@ function u64be(value) {
   return out;
 }
 
-function regularFilePayload(filePath) {
+function regularFilePayload(filePath, config) {
   const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0);
   let fd;
   try {
@@ -1118,6 +1118,11 @@ function regularFilePayload(filePath) {
     const before = fs.fstatSync(fd, { bigint: true });
     if (!before.isFile()) throw new Error(`unsupported policy stat target: ${filePath}`);
     const payload = fs.readFileSync(fd);
+    // Unit tests inject a synchronous mutation here to prove the pre/post
+    // identity check; production configurations never carry this hook.
+    if (typeof config?.testBeforeFinalFileStat === "function") {
+      config.testBeforeFinalFileStat(filePath);
+    }
     const after = fs.fstatSync(fd, { bigint: true });
     if (statIdentity(before) !== statIdentity(after) || BigInt(payload.length) !== after.size) {
       throw new Error(`unstable policy stat observation: ${filePath}`);
@@ -1164,7 +1169,7 @@ function contentStatDigest(filePath, config) {
   let payload;
   if (info.isFile()) {
     kind = 1;
-    payload = regularFilePayload(target.path);
+    payload = regularFilePayload(target.path, config);
   } else if (info.isDirectory()) {
     kind = 2;
     payload = directoryPayload(target.path);
@@ -1211,16 +1216,6 @@ function contentStatToken(filePath, config = policyStatTokenConfig, projectedOve
   }
   recordContentStatDigest(config, 1, result.digest);
   return projectContentStatDigest(result.digest, config, projectedOverride);
-}
-
-function contentStatHashParts(filePath, config = policyStatTokenConfig) {
-  const result = contentStatDigest(filePath, config);
-  if (result.finalSymlink) throw new Error("policy Preview2 metadata hash does not follow symlinks");
-  recordContentStatDigest(config, 2, result.digest);
-  return {
-    lower: result.digest.readBigUInt64BE(0),
-    upper: result.digest.readBigUInt64BE(8),
-  };
 }
 
 function policyStatAttestation(config = policyStatTokenConfig) {
@@ -1430,9 +1425,7 @@ function createPreview2FilesystemHost(projectRoot) {
           writeResultErr(retptr, 44);
           return;
         }
-        const { lower, upper } = policyStatTokenConfig
-          ? contentStatHashParts(filePath)
-          : buildFsMetadataHashParts(filePath);
+        const { lower, upper } = buildFsMetadataHashParts(filePath);
         writeU8(mem, retptr, 0);
         writeU64LE(mem, retptr + 8, lower);
         writeU64LE(mem, retptr + 16, upper);
@@ -3474,7 +3467,6 @@ module.exports = {
   buildFsMetadataHashParts,
   configurePolicyStatToken,
   contentStatDigest,
-  contentStatHashParts,
   contentStatToken,
   parseArgs,
   policyStatAttestation,

--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -4,6 +4,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const cp = require("node:child_process");
+const crypto = require("node:crypto");
 const { Worker, MessageChannel, receiveMessageOnPort } = require("node:worker_threads");
 
 // Guest Fs::write_file / Fs::write_bytes land here. Write via a same-dir temp
@@ -123,7 +124,7 @@ function toU32(value) {
 
 function usage() {
   console.error(
-    "usage: node scripts/wasm_vibe_host_runner.js [--daemon] [--invoke <name>]... [--invoke-batch-dir <dir>] [--bench-count <n> --bench-warmup <n> --bench-setup <name>] <module.wasm> [argv...]",
+    "usage: node scripts/wasm_vibe_host_runner.js [--policy-stat-token content-v1 --policy-stat-root <absolute-root>] [--daemon] [--invoke <name>]... [--invoke-batch-dir <dir>] [--bench-count <n> --bench-warmup <n> --bench-setup <name>] <module.wasm> [argv...]",
   );
 }
 
@@ -136,10 +137,28 @@ function parseArgs(argv) {
   let benchSetup = null;
   let daemon = false;
   let invokeBatchDir = null;
+  let policyStatToken = null;
+  let policyStatRoot = null;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--daemon") {
       daemon = true;
+      continue;
+    }
+    if (arg === "--policy-stat-token") {
+      if (wasmPath !== null || i + 1 >= argv.length || policyStatToken !== null) {
+        throw new Error("--policy-stat-token requires one pre-wasm value");
+      }
+      policyStatToken = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    if (arg === "--policy-stat-root") {
+      if (wasmPath !== null || i + 1 >= argv.length || policyStatRoot !== null) {
+        throw new Error("--policy-stat-root requires one pre-wasm value");
+      }
+      policyStatRoot = argv[i + 1];
+      i += 1;
       continue;
     }
     if (arg === "--invoke-batch-dir") {
@@ -200,10 +219,27 @@ function parseArgs(argv) {
   if (wasmPath === null) {
     throw new Error("missing wasm path");
   }
+  if ((policyStatToken === null) !== (policyStatRoot === null)) {
+    throw new Error("--policy-stat-token and --policy-stat-root must be supplied together");
+  }
+  if (policyStatToken !== null && policyStatToken !== "content-v1") {
+    throw new Error(`unsupported --policy-stat-token: ${policyStatToken}`);
+  }
   if (invokes.length === 0) {
     invokes.push("_start");
   }
-  return { daemon, invokes, wasmPath, passthroughArgs, benchCount, benchWarmup, benchSetup, invokeBatchDir };
+  return {
+    daemon,
+    invokes,
+    wasmPath,
+    passthroughArgs,
+    benchCount,
+    benchWarmup,
+    benchSetup,
+    invokeBatchDir,
+    policyStatToken,
+    policyStatRoot,
+  };
 }
 
 function parsePositiveIntEnv(name) {
@@ -1000,6 +1036,203 @@ function buildFsMetadataHashParts(filePath) {
   return { lower, upper };
 }
 
+const POLICY_STAT_TOKEN_DOMAIN = Buffer.from("vibe:selfcompile-policy:stat-token:v1\0", "ascii");
+const POLICY_TOKEN_HIGH_BIT = 1n << 60n;
+const POLICY_TOKEN_LOW_MASK = POLICY_TOKEN_HIGH_BIT - 1n;
+let policyStatTokenConfig = null;
+
+function isContainedPath(root, candidate) {
+  const rel = path.relative(root, candidate);
+  return rel === "" || (rel !== ".." && !rel.startsWith(".." + path.sep) && !path.isAbsolute(rel));
+}
+
+function configurePolicyStatToken(mode, root) {
+  if (mode === null && root === null) return null;
+  if (mode !== "content-v1" || typeof root !== "string" || !path.isAbsolute(root)) {
+    throw new Error("policy stat-token requires content-v1 and an absolute root");
+  }
+  const lexicalRoot = path.resolve(root);
+  const rootInfo = fs.lstatSync(lexicalRoot);
+  if (!rootInfo.isDirectory() || rootInfo.isSymbolicLink()) {
+    throw new Error("policy stat root must be a physical directory");
+  }
+  const physicalRoot = fs.realpathSync.native(lexicalRoot);
+  if (physicalRoot !== lexicalRoot || fs.realpathSync.native(process.cwd()) !== physicalRoot) {
+    throw new Error("policy stat root must equal the physical cwd");
+  }
+  return {
+    mode,
+    root: physicalRoot,
+    tokens: new Map(),
+    transcript: crypto.createHash("sha256").update("vibe:selfcompile-policy:stat-token-transcript:v1\0", "ascii"),
+    calls: 0,
+  };
+}
+
+function statIdentity(info) {
+  const ns = (name, fallback) =>
+    typeof info[name] === "bigint" ? info[name] : BigInt(Math.round(Number(info[fallback]) * 1e6));
+  return [
+    String(info.dev),
+    String(info.ino),
+    String(info.size),
+    String(ns("mtimeNs", "mtimeMs")),
+    String(ns("ctimeNs", "ctimeMs")),
+    String(info.mode),
+  ].join(":");
+}
+
+function resolvePolicyStatTarget(filePath, config) {
+  const lexical = path.resolve(config.root, filePath);
+  if (!isContainedPath(config.root, lexical)) {
+    throw new Error(`policy stat path escapes root: ${filePath}`);
+  }
+  const rel = path.relative(config.root, lexical);
+  let cursor = config.root;
+  for (const part of rel === "" ? [] : rel.split(path.sep)) {
+    cursor = path.join(cursor, part);
+    const info = fs.lstatSync(cursor, { bigint: true });
+    if (info.isSymbolicLink()) {
+      if (cursor === lexical) return { finalSymlink: true, path: lexical };
+      throw new Error(`policy stat path has a symlink ancestor: ${filePath}`);
+    }
+  }
+  const physical = fs.realpathSync.native(lexical);
+  if (!isContainedPath(config.root, physical)) {
+    throw new Error(`policy stat physical path escapes root: ${filePath}`);
+  }
+  return { finalSymlink: false, path: physical };
+}
+
+function u64be(value) {
+  const out = Buffer.alloc(8);
+  out.writeBigUInt64BE(BigInt(value));
+  return out;
+}
+
+function regularFilePayload(filePath) {
+  const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0);
+  let fd;
+  try {
+    fd = fs.openSync(filePath, flags);
+    const before = fs.fstatSync(fd, { bigint: true });
+    if (!before.isFile()) throw new Error(`unsupported policy stat target: ${filePath}`);
+    const payload = fs.readFileSync(fd);
+    const after = fs.fstatSync(fd, { bigint: true });
+    if (statIdentity(before) !== statIdentity(after) || BigInt(payload.length) !== after.size) {
+      throw new Error(`unstable policy stat observation: ${filePath}`);
+    }
+    return payload;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+function directoryPayload(dirPath) {
+  const before = fs.statSync(dirPath, { bigint: true });
+  if (!before.isDirectory()) throw new Error(`unsupported policy stat target: ${dirPath}`);
+  const names = fs.readdirSync(dirPath, { encoding: "buffer" });
+  names.sort(Buffer.compare);
+  const chunks = [];
+  for (const name of names) {
+    if (name.includes(0)) throw new Error(`invalid directory entry under: ${dirPath}`);
+    const decodedName = name.toString("utf8");
+    if (!Buffer.from(decodedName, "utf8").equals(name)) {
+      throw new Error(`non-UTF-8 directory entry under: ${dirPath}`);
+    }
+    const child = path.join(dirPath, decodedName);
+    const info = fs.lstatSync(child, { bigint: true });
+    let kind;
+    if (info.isFile()) kind = 1;
+    else if (info.isDirectory()) kind = 2;
+    else if (info.isSymbolicLink()) kind = 3;
+    else throw new Error(`unsupported directory entry under: ${dirPath}`);
+    chunks.push(u64be(name.length), name, Buffer.from([kind]));
+  }
+  const after = fs.statSync(dirPath, { bigint: true });
+  if (statIdentity(before) !== statIdentity(after)) {
+    throw new Error(`unstable policy stat observation: ${dirPath}`);
+  }
+  return Buffer.concat(chunks);
+}
+
+function contentStatDigest(filePath, config) {
+  const target = resolvePolicyStatTarget(filePath, config);
+  if (target.finalSymlink) return { finalSymlink: true, digest: null };
+  const info = fs.statSync(target.path, { bigint: true });
+  let kind;
+  let payload;
+  if (info.isFile()) {
+    kind = 1;
+    payload = regularFilePayload(target.path);
+  } else if (info.isDirectory()) {
+    kind = 2;
+    payload = directoryPayload(target.path);
+  } else {
+    throw new Error(`unsupported policy stat target: ${filePath}`);
+  }
+  const digest = crypto.createHash("sha256")
+    .update(POLICY_STAT_TOKEN_DOMAIN)
+    .update(Buffer.from([kind]))
+    .update(u64be(payload.length))
+    .update(payload)
+    .digest();
+  return { finalSymlink: false, digest };
+}
+
+function projectContentStatDigest(digest, config, projectedOverride = null) {
+  const token = projectedOverride === null
+    ? POLICY_TOKEN_HIGH_BIT | (digest.readBigUInt64BE(0) & POLICY_TOKEN_LOW_MASK)
+    : BigInt(projectedOverride);
+  if (token < POLICY_TOKEN_HIGH_BIT || token > (1n << 61n) - 1n) {
+    throw new Error("invalid policy stat-token projection");
+  }
+  const key = token.toString();
+  const full = digest.toString("hex");
+  const prior = config.tokens.get(key);
+  if (prior !== undefined && prior !== full) {
+    throw new Error(`policy stat-token collision: ${key}`);
+  }
+  config.tokens.set(key, full);
+  return token;
+}
+
+function recordContentStatDigest(config, channel, digest) {
+  config.calls += 1;
+  config.transcript.update(Buffer.from([channel])).update(digest);
+}
+
+function contentStatToken(filePath, config = policyStatTokenConfig, projectedOverride = null) {
+  if (!config || config.mode !== "content-v1") throw new Error("policy stat-token is not configured");
+  const result = contentStatDigest(filePath, config);
+  if (result.finalSymlink) {
+    recordContentStatDigest(config, 1, Buffer.alloc(32, 0xff));
+    return -1n;
+  }
+  recordContentStatDigest(config, 1, result.digest);
+  return projectContentStatDigest(result.digest, config, projectedOverride);
+}
+
+function contentStatHashParts(filePath, config = policyStatTokenConfig) {
+  const result = contentStatDigest(filePath, config);
+  if (result.finalSymlink) throw new Error("policy Preview2 metadata hash does not follow symlinks");
+  recordContentStatDigest(config, 2, result.digest);
+  return {
+    lower: result.digest.readBigUInt64BE(0),
+    upper: result.digest.readBigUInt64BE(8),
+  };
+}
+
+function policyStatAttestation(config = policyStatTokenConfig) {
+  if (!config) return null;
+  return {
+    mode: config.mode,
+    calls: config.calls,
+    unique: config.tokens.size,
+    transcript: config.transcript.copy().digest("hex"),
+  };
+}
+
 function createPreview2FilesystemHost(projectRoot) {
   const rootPath = path.resolve(projectRoot);
   const descriptors = new Map([[3, { kind: "dir", path: rootPath }]]);
@@ -1197,7 +1430,9 @@ function createPreview2FilesystemHost(projectRoot) {
           writeResultErr(retptr, 44);
           return;
         }
-        const { lower, upper } = buildFsMetadataHashParts(filePath);
+        const { lower, upper } = policyStatTokenConfig
+          ? contentStatHashParts(filePath)
+          : buildFsMetadataHashParts(filePath);
         writeU8(mem, retptr, 0);
         writeU64LE(mem, retptr + 8, lower);
         writeU64LE(mem, retptr + 16, upper);
@@ -1745,7 +1980,10 @@ async function main() {
     benchWarmup,
     benchSetup,
     invokeBatchDir,
+    policyStatToken,
+    policyStatRoot,
   } = parseArgs(process.argv.slice(2));
+  policyStatTokenConfig = configurePolicyStatToken(policyStatToken, policyStatRoot);
   let passthroughArgs = initialPassthroughArgs.slice();
   passthroughArgsGlobal = passthroughArgs;
   if (passthroughArgs.length > 0) {
@@ -2218,6 +2456,9 @@ async function main() {
       },
       fs_stat_token(pathTagged) {
         const filePath = decodeStringArg(instanceRef, pathTagged);
+        if (policyStatTokenConfig) {
+          return encodeHostInt(contentStatToken(filePath));
+        }
         // Module/package loading reserves -1 as a stable non-regular-source
         // witness. lstat is required here: stat would follow the link and make
         // a symlink indistinguishable from its target.
@@ -3079,6 +3320,12 @@ async function main() {
     if (process.env.VIBE_WASM_MEMORY_STATS !== "1") {
       return;
     }
+    const statAttestation = policyStatAttestation();
+    if (statAttestation) {
+      console.error(
+        `[policy-stat-token] mode=${statAttestation.mode} calls=${statAttestation.calls} unique=${statAttestation.unique} transcript=${statAttestation.transcript}`,
+      );
+    }
     if (HOST_IMPORT_ABI !== "raw") {
       console.error(`[wasm-memory] ${label} skipped abi=${HOST_IMPORT_ABI}`);
       return;
@@ -3223,6 +3470,17 @@ async function main() {
   }
 }
 
+module.exports = {
+  buildFsMetadataHashParts,
+  configurePolicyStatToken,
+  contentStatDigest,
+  contentStatHashParts,
+  contentStatToken,
+  parseArgs,
+  policyStatAttestation,
+  projectContentStatDigest,
+};
+
 if (require.main === module) {
 main().catch((err) => {
   // #946(4): a pathologically deep expression (e.g. thousands of chained
@@ -3330,4 +3588,4 @@ main().catch((err) => {
 });
 }
 
-module.exports = { publishImmutableTextSync };
+module.exports.publishImmutableTextSync = publishImmutableTextSync;

--- a/scripts/wasm_vibe_host_runner_stat_token.test.cjs
+++ b/scripts/wasm_vibe_host_runner_stat_token.test.cjs
@@ -1,0 +1,173 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  buildFsMetadataHashParts,
+  configurePolicyStatToken,
+  contentStatHashParts,
+  contentStatToken,
+  parseArgs,
+  projectContentStatDigest,
+} = require("./wasm_vibe_host_runner.js");
+
+function fixture() {
+  const outer = fs.mkdtempSync(path.join(fs.realpathSync.native(os.tmpdir()), "vibe-stat-token-"));
+  const root = path.join(outer, "root");
+  fs.mkdirSync(root);
+  return { outer, root };
+}
+
+function withCwd(dir, fn) {
+  const old = process.cwd();
+  process.chdir(dir);
+  try { return fn(); } finally { process.chdir(old); }
+}
+
+function config(root) {
+  return withCwd(root, () => configurePolicyStatToken("content-v1", root));
+}
+
+function assertToken(value) {
+  assert.ok(value >= 1n << 60n && value <= (1n << 61n) - 1n);
+  assert.match(value.toString(), /^[1-9][0-9]{18}$/);
+}
+
+test("content-v1 is inode, mtime, root, alias, and path independent", () => {
+  const a = fixture();
+  const b = fixture();
+  try {
+    fs.writeFileSync(path.join(a.root, "one.vibe"), "same bytes\n");
+    fs.writeFileSync(path.join(a.root, "two.vibe"), "same bytes\n");
+    fs.writeFileSync(path.join(b.root, "one.vibe"), "same bytes\n");
+    fs.utimesSync(path.join(a.root, "one.vibe"), new Date(1_000), new Date(1_000));
+    fs.utimesSync(path.join(b.root, "one.vibe"), new Date(9_000), new Date(9_000));
+    const ca = config(a.root);
+    const cb = config(b.root);
+    const token = contentStatToken("one.vibe", ca);
+    assertToken(token);
+    assert.equal(contentStatToken("./one.vibe", ca), token);
+    assert.equal(contentStatToken("x/../one.vibe", ca), token);
+    assert.equal(contentStatToken(path.join(a.root, "one.vibe"), ca), token);
+    assert.equal(contentStatToken("two.vibe", ca), token);
+    assert.equal(contentStatToken("one.vibe", cb), token);
+  } finally {
+    fs.rmSync(a.outer, { recursive: true, force: true });
+    fs.rmSync(b.outer, { recursive: true, force: true });
+  }
+});
+
+test("same-size content changes invalidate even with restored mtime", () => {
+  const f = fixture();
+  try {
+    const file = path.join(f.root, "input.vibe");
+    fs.writeFileSync(file, "aaaa");
+    const stamp = new Date(12_000);
+    fs.utimesSync(file, stamp, stamp);
+    const c = config(f.root);
+    const before = contentStatToken(file, c);
+    fs.writeFileSync(file, "bbbb");
+    fs.utimesSync(file, stamp, stamp);
+    const after = contentStatToken(file, c);
+    assert.notEqual(after, before);
+    assertToken(after);
+  } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
+});
+
+test("directories are byte-sorted, fixed-width, and invalidate on entry changes", () => {
+  const f = fixture();
+  try {
+    const dir = path.join(f.root, "pkg");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "b"), "x");
+    const c = config(f.root);
+    const before = contentStatToken(dir, c);
+    assertToken(before);
+    fs.writeFileSync(path.join(dir, "a"), "x");
+    const added = contentStatToken(dir, c);
+    assert.notEqual(added, before);
+    fs.rmSync(path.join(dir, "a"));
+    fs.mkdirSync(path.join(dir, "a"));
+    const replaced = contentStatToken(dir, c);
+    assert.notEqual(replaced, added);
+    assert.notEqual(replaced, before);
+  } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
+});
+
+test("final symlink is -1 while ancestor and lexical/absolute escapes fail", () => {
+  const f = fixture();
+  try {
+    const outside = path.join(f.outer, "outside");
+    fs.mkdirSync(outside);
+    fs.writeFileSync(path.join(outside, "file"), "outside");
+    fs.writeFileSync(path.join(f.root, "inside"), "inside");
+    fs.symlinkSync("inside", path.join(f.root, "final"));
+    fs.symlinkSync(outside, path.join(f.root, "ancestor"), "dir");
+    const c = config(f.root);
+    assert.equal(contentStatToken("final", c), -1n);
+    assert.throws(() => contentStatToken("ancestor/file", c), /symlink ancestor/);
+    assert.throws(() => contentStatToken("../outside/file", c), /escapes root/);
+    assert.throws(() => contentStatToken(path.join(outside, "file"), c), /escapes root/);
+    assert.throws(() => contentStatToken("missing", c));
+  } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
+});
+
+test("unsupported nonregular entries fail closed", { skip: process.platform === "win32" }, () => {
+  const f = fixture();
+  try {
+    const fifo = path.join(f.root, "fifo");
+    const made = spawnSync("mkfifo", [fifo]);
+    if (made.status !== 0) return;
+    const c = config(f.root);
+    assert.throws(() => contentStatToken(fifo, c), /unsupported/);
+    assert.throws(() => contentStatToken(f.root, c), /unsupported directory entry/);
+  } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
+});
+
+test("truncation collisions fail closed", () => {
+  const f = fixture();
+  try {
+    const c = config(f.root);
+    const one = crypto.createHash("sha256").update("one").digest();
+    const two = crypto.createHash("sha256").update("two").digest();
+    const forced = 1n << 60n;
+    assert.equal(projectContentStatDigest(one, c, forced), forced);
+    assert.throws(() => projectContentStatDigest(two, c, forced), /collision/);
+  } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
+});
+
+test("default metadata helper remains metadata-sensitive; Preview2 policy hash is deterministic", () => {
+  const a = fixture();
+  const b = fixture();
+  try {
+    const ap = path.join(a.root, "x");
+    const bp = path.join(b.root, "x");
+    fs.writeFileSync(ap, "same");
+    fs.writeFileSync(bp, "same");
+    fs.utimesSync(ap, new Date(1_000), new Date(1_000));
+    fs.utimesSync(bp, new Date(8_000), new Date(8_000));
+    assert.notDeepEqual(buildFsMetadataHashParts(ap), buildFsMetadataHashParts(bp));
+    assert.deepEqual(contentStatHashParts(ap, config(a.root)), contentStatHashParts(bp, config(b.root)));
+  } finally {
+    fs.rmSync(a.outer, { recursive: true, force: true });
+    fs.rmSync(b.outer, { recursive: true, force: true });
+  }
+});
+
+test("policy selectors are consumed before wasm and never reach guest argv", () => {
+  const root = path.resolve("/tmp/policy-root");
+  const parsed = parseArgs([
+    "--policy-stat-token", "content-v1", "--policy-stat-root", root,
+    "--invoke", "cli_main", "compiler.wasm", "input.vibe", "out.wasm", "__no_entry__",
+  ]);
+  assert.equal(parsed.policyStatToken, "content-v1");
+  assert.equal(parsed.policyStatRoot, root);
+  assert.deepEqual(parsed.passthroughArgs, ["input.vibe", "out.wasm", "__no_entry__"]);
+  assert.throws(() => parseArgs(["--policy-stat-token", "content-v1", "compiler.wasm"]));
+  assert.throws(() => parseArgs(["compiler.wasm", "--policy-stat-root", root]));
+});

--- a/scripts/wasm_vibe_host_runner_stat_token.test.cjs
+++ b/scripts/wasm_vibe_host_runner_stat_token.test.cjs
@@ -4,13 +4,13 @@ const assert = require("node:assert/strict");
 const crypto = require("node:crypto");
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
+const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const {
   buildFsMetadataHashParts,
   configurePolicyStatToken,
-  contentStatHashParts,
   contentStatToken,
   parseArgs,
   projectContentStatDigest,
@@ -79,6 +79,17 @@ test("same-size content changes invalidate even with restored mtime", () => {
   } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
 });
 
+test("pre/post fstat rejects a deterministic mutation during the read", () => {
+  const f = fixture();
+  try {
+    const file = path.join(f.root, "racy.vibe");
+    fs.writeFileSync(file, "before");
+    const c = config(f.root);
+    c.testBeforeFinalFileStat = target => fs.writeFileSync(target, "changed-during-read");
+    assert.throws(() => contentStatToken(file, c), /unstable policy stat observation/);
+  } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
+});
+
 test("directories are byte-sorted, fixed-width, and invalidate on entry changes", () => {
   const f = fixture();
   try {
@@ -129,6 +140,24 @@ test("unsupported nonregular entries fail closed", { skip: process.platform === 
   } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
 });
 
+test("Unix sockets fail closed as targets and directory entries", { skip: process.platform === "win32" }, async () => {
+  const f = fixture();
+  const socketPath = path.join(f.root, "socket");
+  const server = net.createServer();
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, resolve);
+    });
+    const c = config(f.root);
+    assert.throws(() => contentStatToken(socketPath, c), /unsupported/);
+    assert.throws(() => contentStatToken(f.root, c), /unsupported directory entry/);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+    fs.rmSync(f.outer, { recursive: true, force: true });
+  }
+});
+
 test("truncation collisions fail closed", () => {
   const f = fixture();
   try {
@@ -141,7 +170,7 @@ test("truncation collisions fail closed", () => {
   } finally { fs.rmSync(f.outer, { recursive: true, force: true }); }
 });
 
-test("default metadata helper remains metadata-sensitive; Preview2 policy hash is deterministic", () => {
+test("default metadata helper remains metadata-sensitive", () => {
   const a = fixture();
   const b = fixture();
   try {
@@ -152,7 +181,6 @@ test("default metadata helper remains metadata-sensitive; Preview2 policy hash i
     fs.utimesSync(ap, new Date(1_000), new Date(1_000));
     fs.utimesSync(bp, new Date(8_000), new Date(8_000));
     assert.notDeepEqual(buildFsMetadataHashParts(ap), buildFsMetadataHashParts(bp));
-    assert.deepEqual(contentStatHashParts(ap, config(a.root)), contentStatHashParts(bp, config(b.root)));
   } finally {
     fs.rmSync(a.outer, { recursive: true, force: true });
     fs.rmSync(b.outer, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add a CLI-only raw-ABI `content-v1` stat-token mode to the trusted Node runner
- use fixed-width content-derived tokens so identical fresh source reconstructions allocate identically
- make the policy controller invoke its own sibling runner, not a materialized head KPI shell/runner
- preserve all default raw, Preview2, Rust, compiler, and cache behavior

## Validation
- independent hard review: ACCEPT
- focused policy/runner tests: 27/27
- two independent fresh-lease controller invocations: all 8 heaps exactly `1,092,143,664`
- all four stage2 SHA-256 values: `4a6e2c8be509570f93e40767bf8c90aadc23350679d25d4f81aca9061beafb2e`
- attestations identical: 6,158 calls / 214 unique tokens
- default/content-v1 median wall: 2.03s / 2.29s (+12.81%, policy-only)
- Taskfile lane, Node syntax, review lint, and diff checks pass

## Scope boundary
CI remains unwired. This does not solve immutable base generation-harness authority, disposable no-network isolation, trusted output/tool boundaries, review ownership, or strict latest-base enforcement. No workflow, budget, cap, tolerance, compiler, Rust, Preview2, or standalone KPI-default behavior changes.