### PR TITLE
fix(allocs): fail closed and cover test and bench bodies

### DIFF
--- a/lib/@vibe/compiler/runtime/alloc_spans.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans.vibe
@@ -76,10 +76,15 @@ fn alloc_contains_name(names: Array[String], name: String) -> Bool {
 /// Only direct `EIdent` callees are classified: an indirect call through a
 /// value cannot be resolved here, and it is reported as a site anyway by the
 /// closure rule (something had to build the closure).
-fn alloc_call_kind(expr: Expr) -> String {
+fn alloc_call_kind(expr: Expr, ctors: Array[String]) -> String {
   match expr {
     ECall(callee, _, _) => match callee {
-      EIdent(name, _) => if builtin_allocates(name) {
+      // The callee EIdent is visited as a child and owns the constructor
+      // record. Do not also mislabel the same source site as an unknown
+      // builtin merely because constructors are absent from that registry.
+      EIdent(name, _) => if alloc_contains_name(ctors, name) {
+        ""
+      } else if builtin_allocates(name) {
         String::concat("builtin:", name)
       } else {
         ""
@@ -107,7 +112,7 @@ fn alloc_site_kind(expr: Expr, ctors: Array[String]) -> String {
     EMap(_) => "map",
     EStringInterp(_) => "interp",
     EHandle(_, _) => "handler",
-    _ => alloc_call_kind(expr)
+    _ => alloc_call_kind(expr, ctors)
   }
 }
 
@@ -244,18 +249,22 @@ export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Excep
   }
   let mut i = 0
   while i < Array::length(stmts) {
+    let stmt_off = if i < Array::length(span_start) {
+      Array::get(span_start, i)
+    } else {
+      0
+    }
     match Array::get(stmts, i) {
       SLet(_, _, name, _, value) => match value {
-        EFn(_, _, _, _, _, fbody) => {
-          let stmt_off = if i < Array::length(span_start) {
-            Array::get(span_start, i)
-          } else {
-            0
-          }
-          alloc_walk_expr(out, name, fbody, stmt_off, ctors)
-        },
+        EFn(_, _, _, _, _, fbody) => alloc_walk_expr(out, name, fbody, stmt_off, ctors),
         _ => ()
       },
+      // Tests and benches lower to real executable functions. In particular,
+      // a bytes-per-op regression asks about the bench body itself, so
+      // skipping SBench would turn an allocating benchmark into false-clean
+      // output. Keep the owner names identical to linked_compile's lowering.
+      STest(test_name, test_body) => alloc_walk_expr(out, String::concat("__test_", test_name), test_body, stmt_off, ctors),
+      SBench(bench_name, bench_body) => alloc_walk_expr(out, String::concat("__bench_", bench_name), bench_body, stmt_off, ctors),
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/runtime/alloc_spans.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans.vibe
@@ -72,6 +72,31 @@ fn alloc_contains_name(names: Array[String], name: String) -> Bool {
   found
 }
 
+fn alloc_hex_nibble(n: Int) -> String {
+  String::substring("0123456789ABCDEF", n, n + 1)
+}
+
+/// Encode an owner as one whitespace-free output field. Test and bench names
+/// are arbitrary string literals, so their lowered function names may contain
+/// spaces, newlines, tabs, or `%` itself. Percent-encoding those bytes keeps
+/// `FN KIND OFFSET` exactly three fields and remains reversible.
+fn alloc_encode_owner(name: String) -> String {
+  let out = StringBuilder::new()
+  let mut i = 0
+  while i < String::length(name) {
+    let c = String::char_code_at(name, i)
+    if c <= 32 || c == 37 || c == 127 {
+      StringBuilder::push(out, "%")
+      StringBuilder::push(out, alloc_hex_nibble((c / 16) % 16))
+      StringBuilder::push(out, alloc_hex_nibble(c % 16))
+    } else {
+      StringBuilder::push(out, String::substring(name, i, i + 1))
+    }
+    i = i + 1
+  }
+  StringBuilder::freeze(out)
+}
+
 /// The allocating-call name for `expr`, or "" when the call is not one.
 /// Only direct `EIdent` callees are classified: an indirect call through a
 /// value cannot be resolved here, and it is reported as a site anyway by the
@@ -263,8 +288,8 @@ export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Excep
       // a bytes-per-op regression asks about the bench body itself, so
       // skipping SBench would turn an allocating benchmark into false-clean
       // output. Keep the owner names identical to linked_compile's lowering.
-      STest(test_name, test_body) => alloc_walk_expr(out, String::concat("__test_", test_name), test_body, stmt_off, ctors),
-      SBench(bench_name, bench_body) => alloc_walk_expr(out, String::concat("__bench_", bench_name), bench_body, stmt_off, ctors),
+      STest(test_name, test_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__test_", test_name)), test_body, stmt_off, ctors),
+      SBench(bench_name, bench_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__bench_", bench_name)), bench_body, stmt_off, ctors),
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
@@ -185,14 +185,14 @@ test "sites are attributed to the enclosing top-level function" {
   assert_eq(Array::get(names, 1), "b")
 }
 
-test "test and bench bodies are allocation owners too" {
+test "test and bench bodies use whitespace-free allocation owners" {
   // `allocs` is also the diagnostics surface for bytes-per-op regressions;
   // silently skipping SBench would make precisely that use case report clean.
-  let src = "test \"makes array\" {\n  let xs = [1, 2]\n  assert_eq(Array::length(xs), 2)\n}\nbench \"build array\" {\n  [3, 4]\n}\n"
+  let src = "test \"makes array\" {\n  let xs = [1, 2]\n  assert_eq(Array::length(xs), 2)\n}\nbench \"line\\nbreak 100%\" {\n  [3, 4]\n}\n"
   let names = fn_names_of(src)
   assert_eq(Array::length(names), 2)
-  assert_eq(Array::get(names, 0), "__test_makes array")
-  assert_eq(Array::get(names, 1), "__bench_build array")
+  assert_eq(Array::get(names, 0), "__test_makes%20array")
+  assert_eq(Array::get(names, 1), "__bench_line%0Abreak%20100%25")
 }
 
 test "an unclassified callee is reported, not skipped" {

--- a/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
@@ -40,6 +40,21 @@ fn has_kind(source: String, want: String) -> Bool with Exception {
   found
 }
 
+fn count_kind(source: String, want: String) -> Int with Exception {
+  let ks = kinds_of(source)
+  let mut i = 0
+  let mut count = 0
+  while i < Array::length(ks) {
+    if Array::get(ks, i) == want {
+      count = count + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  count
+}
+
 fn fn_names_of(source: String) -> Array[String] with Exception {
   let spans = alloc_spans(source)
   let out = [
@@ -131,6 +146,12 @@ test "a bare enum constructor is conservatively an allocation site" {
   assert(has_kind(src, "constructor:None"))
 }
 
+test "a payload constructor is one constructor site, not an unknown builtin too" {
+  let src = "enum Maybe { None; Some(Int) }\nfn one() -> Maybe {\n  Some(1)\n}\n"
+  assert_eq(count_kind(src, "constructor:Some"), 1)
+  assert(!has_kind(src, "builtin:Some"))
+}
+
 test "valid cfg and deprecated directives do not make the query fail" {
   // Directive text must be blanked, not deleted, so source offsets remain
   // coordinates in the original file. Counting inactive cfg sites is the
@@ -162,6 +183,16 @@ test "sites are attributed to the enclosing top-level function" {
   assert_eq(Array::length(names), 2)
   assert_eq(Array::get(names, 0), "a")
   assert_eq(Array::get(names, 1), "b")
+}
+
+test "test and bench bodies are allocation owners too" {
+  // `allocs` is also the diagnostics surface for bytes-per-op regressions;
+  // silently skipping SBench would make precisely that use case report clean.
+  let src = "test \"makes array\" {\n  let xs = [1, 2]\n  assert_eq(Array::length(xs), 2)\n}\nbench \"build array\" {\n  [3, 4]\n}\n"
+  let names = fn_names_of(src)
+  assert_eq(Array::length(names), 2)
+  assert_eq(Array::get(names, 0), "__test_makes array")
+  assert_eq(Array::get(names, 1), "__bench_build array")
 }
 
 test "an unclassified callee is reported, not skipped" {

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -1284,15 +1284,37 @@ case "$cmd" in
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
     out="$(mktemp -t vibe-allocs-XXXXXX)"
     trap 'rm -f "$out" "$out.diag"' EXIT
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG \
-        -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE -u VIBE_CHECK_ONLY -u VIBE_DEPS \
+    # The adapter is also an internal multiplexer. Do not let a compiler-mode
+    # variable inherited from the caller select an earlier branch (VIBE_HASH,
+    # for example, is checked before VIBE_ALLOCS). The public verb owns the
+    # mode selection completely.
+    allocs_status=0
+    if env -u VIBE_FS_COMPILE -u VIBE_LSP -u VIBE_HASH -u VIBE_HASH_WRITE \
+        -u VIBE_MISSING_VPKG_SCAN -u VIBE_DEPS_MISSING_SCAN -u VIBE_FILL_PINS \
+        -u VIBE_PUBLISH_CHECK -u VIBE_MODULE_JOB_DIR -u VIBE_PUBLISH_ENV_CACHE \
+        -u VIBE_LIST_DEPS -u VIBE_MODULE_PLAN -u VIBE_CHECK_ONLY \
+        -u VIBE_NORMALIZE -u VIBE_INSPECT_UPDATE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT \
+        -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_DEPS_DIRECT -u VIBE_GREP \
+        -u VIBE_DIAGNOSTICS -u VIBE_DIAGNOSTICS_JSON \
+        -u VIBE_EMIT_COVERAGE_DRIVER_SOURCE -u VIBE_EMIT_MERGED_SOURCE \
+        -u VIBE_EMIT_WIT -u VIBE_SERVE_COMPONENT -u VIBE_EMIT_MODULE_SOURCE \
+        -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
+        -u VIBE_ARTIFACT_INPUT_TRACE_OUT -u VIBE_ARTIFACT_INPUT_TRACE_NONCE \
       VIBE_ALLOCS=1 \
       VIBE_IMPORT_ABI=raw \
-      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
+      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1; then
+      allocs_status=0
+    else
+      allocs_status=$?
+    fi
     if [ -s "$out.diag" ]; then
       echo "error: $(cat "$out.diag")" >&2
       exit 1
+    fi
+    if [ "$allocs_status" -ne 0 ]; then
+      echo "error: vibe allocs runner failed with status $allocs_status" >&2
+      exit "$allocs_status"
     fi
     if [ -s "$out" ]; then cat "$out"; fi
     ;;

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -11097,6 +11097,7 @@ echo "[compiler-gate] vibe deps import-closure ok (#988)"
 #      the source does not spell out (a closure's environment, a captured
 #      `let mut` becoming a heap ref cell) really appear.
 echo "[compiler-gate] 104/104 vibe allocs reports heap sites, and nothing else (ADR-0091 / #1262)"
+bash "$ROOT_DIR/scripts/test_vibe_allocs_launcher.sh"
 alcdir="_build/_gate_allocs"
 rm -rf "$alcdir"; mkdir -p "$alcdir"
 cat > "$alcdir/in.vibe" <<'ALCA'

--- a/scripts/test_vibe_allocs_launcher.sh
+++ b/scripts/test_vibe_allocs_launcher.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe-allocs-launcher.XXXXXX")"
+cleanup() {
+  local status=$?
+  rm -rf "$TMP_DIR"
+  exit "$status"
+}
+trap cleanup EXIT
+
+SRC="$TMP_DIR/in.vibe"
+CLI="$TMP_DIR/vibe-cli.wasm"
+OUT="$TMP_DIR/stdout.txt"
+ERR="$TMP_DIR/stderr.txt"
+
+printf 'fn main() -> Array[Int] { [1] }\n' > "$SRC"
+: > "$CLI"
+
+# A runner crash without a .diag sidecar must not be indistinguishable from
+# the allocation query's clean (empty output) result.
+FAIL_RUNNER="$TMP_DIR/fail-runner"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 23' > "$FAIL_RUNNER"
+chmod +x "$FAIL_RUNNER"
+if VIBE_RUNNER="$FAIL_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" allocs "$SRC" > "$OUT" 2> "$ERR"; then
+  echo "[vibe-allocs-launcher] FAIL: runner exit 23 was reported as a clean query" >&2
+  exit 1
+fi
+if ! grep -q 'runner failed with status 23' "$ERR"; then
+  echo "[vibe-allocs-launcher] FAIL: runner failure did not explain its status" >&2
+  cat "$ERR" >&2
+  exit 1
+fi
+
+# Public subcommands must select their own adapter mode even when invoked from
+# a shell that inherited an internal compiler-mode variable. VIBE_HASH is
+# evaluated before VIBE_ALLOCS in cli_adapter, so leaking it changes the verb.
+ENV_RUNNER="$TMP_DIR/env-runner"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [ "${VIBE_HASH:-}" = "1" ]; then exit 41; fi' \
+  'printf "main array 0\n" > "$3"' > "$ENV_RUNNER"
+chmod +x "$ENV_RUNNER"
+VIBE_HASH=1 VIBE_RUNNER="$ENV_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" allocs "$SRC" > "$OUT" 2> "$ERR"
+if [ "$(cat "$OUT")" != "main array 0" ]; then
+  echo "[vibe-allocs-launcher] FAIL: inherited VIBE_HASH diverted the allocs query" >&2
+  cat "$ERR" >&2
+  exit 1
+fi
+
+echo "[vibe-allocs-launcher] ok"


### PR DESCRIPTION
## Summary

Follow-up to #1792 review feedback.

- make the public `vibe allocs` launcher fail closed when its runner exits without a diagnostic
- isolate the allocs adapter mode from inherited internal query environment variables
- include `test` and `bench` bodies in allocation-site output using their real lowered owner names
- avoid reporting payload constructors twice as both constructors and unknown builtins

## Why

The original review correctly treated empty output as a machine-consumed clean result. Two remaining paths could still produce a false clean result: a crashed public launcher and allocating `SBench`/`STest` bodies that the statement walk skipped.

## Verification

- Red: runner exit 23 was reported as clean; allocating test/bench bodies produced zero records; payload constructors produced duplicate kinds
- Green: `bash scripts/test_vibe_allocs_launcher.sh`
- Green: fresh stage0 -> stage1 -> stage2 generation
- Green: `VIBE_TEST_CLI_WASM=<fresh-stage2> bash scripts/vibe_test.sh lib/@vibe/compiler/runtime/alloc_spans_test.vibe` (17 tests)
- Green: public `vibe allocs` against the fresh stage2
- Green: `pkf run test-local` (7 selected)
- Green: `pkf run test-pre-commit` and `bash scripts/precommit.sh`

Follow-up: #1792