### PR TITLE
feat(wasm_parser): wasm 検証を「バイナリを実際に読む」層として実装する (refs #1133)

### DIFF
--- a/lib/@vibex/wasm_parser/index.vpkg
+++ b/lib/@vibex/wasm_parser/index.vpkg
@@ -37,6 +37,8 @@ fn list_sections(bytes: Bytes) -> Array[(Int, Int, Int)]
 fn find_section(bytes: Bytes, section_id: Int) -> (Int, Int)
 fn read_init_expr(bytes: Bytes, offset: Int, end_pos: Int) -> (Int, Int, Int)
 fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int], Array[Int])]
+fn parse_type_forms(bytes: Bytes, offset: Int, size: Int) -> Array[Int]
+fn scan_features(wasm_bytes: Bytes) -> Array[String]
 fn parse_imports(bytes: Bytes, offset: Int, size: Int) -> Array[(String, String, Int, Int)]
 fn parse_imports_full(bytes: Bytes, offset: Int, size: Int) -> Array[(String, String, Int, Int, Int, Int)]
 fn parse_functions(bytes: Bytes, offset: Int, size: Int) -> Array[Int]

--- a/lib/@vibex/wasm_parser/index.vpkg
+++ b/lib/@vibex/wasm_parser/index.vpkg
@@ -39,6 +39,7 @@ fn read_init_expr(bytes: Bytes, offset: Int, end_pos: Int) -> (Int, Int, Int)
 fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int], Array[Int])]
 fn parse_type_forms(bytes: Bytes, offset: Int, size: Int) -> Array[Int]
 fn scan_features(wasm_bytes: Bytes) -> Array[String]
+fn validate_structure(wasm_bytes: Bytes) -> Option[String]
 fn parse_imports(bytes: Bytes, offset: Int, size: Int) -> Array[(String, String, Int, Int)]
 fn parse_imports_full(bytes: Bytes, offset: Int, size: Int) -> Array[(String, String, Int, Int, Int, Int)]
 fn parse_functions(bytes: Bytes, offset: Int, size: Int) -> Array[Int]

--- a/lib/@vibex/wasm_parser/index.vpkg
+++ b/lib/@vibex/wasm_parser/index.vpkg
@@ -39,6 +39,8 @@ fn read_init_expr(bytes: Bytes, offset: Int, end_pos: Int) -> (Int, Int, Int)
 fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int], Array[Int])]
 fn parse_type_forms(bytes: Bytes, offset: Int, size: Int) -> Array[Int]
 fn scan_features(wasm_bytes: Bytes) -> Array[String]
+fn next_instruction(code: Bytes, pc: Int, end_pos: Int) -> (Int, Int)
+fn validate_code_body(code: Bytes, start: Int, end_pos: Int) -> Option[String]
 fn validate_structure(wasm_bytes: Bytes) -> Option[String]
 fn parse_imports(bytes: Bytes, offset: Int, size: Int) -> Array[(String, String, Int, Int)]
 fn parse_imports_full(bytes: Bytes, offset: Int, size: Int) -> Array[(String, String, Int, Int, Int, Int)]

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -1580,10 +1580,212 @@ export fn validate_structure(wasm_bytes: Bytes) -> Option[String] {
           } else {
             ()
           }
+          // #1745 (5): the code section is where a malformed module actually
+          // reaches the executor, so walk it here rather than leaving the
+          // section boundaries as the only thing checked.
+          if sid == 10 {
+            err = validate_code_section(wasm_bytes, np, size)
+          }
+          else if sid == 3 {
+            // Index-space bounds are decidable from the sections alone -- no
+            // operand typing needed -- so they belong in this layer even though
+            // "the type this function claims" sounds like a typing question.
+            err = validate_function_type_indices(wasm_bytes, np, size)
+          } else {
+            ()
+          }
           pos = np + size
         }
       }
     }
     err
   }
+}
+
+/// Step over one instruction: `(opcode, position after it)`.
+///
+/// A next position of -1 means "this stepper cannot say" -- either the opcode
+/// is not one it knows, or the instruction's immediates run past `end_pos`.
+/// Callers must treat -1 as "stop", never as "invalid": the prefixed families
+/// (0xFC bulk-memory, 0xFD simd, 0xFB gc) carry per-instruction immediates this
+/// does not enumerate yet, and reporting a module invalid because this function
+/// is incomplete would break the one-sided contract validate_structure keeps.
+///
+/// Immediate shapes are stated HERE rather than at each caller. The
+/// disassembler in @vibex/wasm_runtime carries its own copy today and is blind
+/// to the prefixed families as a result -- it missteps on exactly the gc
+/// instructions vibe's own backend now emits. Folding it onto this is the
+/// follow-up that removes the second copy.
+export fn next_instruction(code: Bytes, pc: Int, end_pos: Int) -> (Int, Int) {
+  if pc >= end_pos {
+    (0, 0 - 1)
+  } else {
+    let op = code[pc]
+    let p = pc + 1
+    if instruction_has_no_immediate(op) {
+      (op, p)
+    }
+    else if (op == 0x0C) || (op == 0x0D) || (op == 0x10) || (op == 0x20) || (op == 0x21) || (op == 0x22) || (op == 0x23) || (op == 0x24) {
+      let (_, np) = read_uleb128(code, p)
+      (op, bounded(np, end_pos))
+    }
+    else if (op == 0x02) || (op == 0x03) || (op == 0x04) {
+      // Blocktype: a negative value type, or a non-negative TYPE INDEX. Both
+      // are one signed LEB, which is why a typed-reference blocktype (the shape
+      // #1541 reserves) needs no special case here.
+      let (_, np) = read_sleb128(code, p)
+      (op, bounded(np, end_pos))
+    }
+    else if (op == 0x41) || (op == 0x42) {
+      let (_, np) = read_sleb128(code, p)
+      (op, bounded(np, end_pos))
+    }
+    else if op == 0x11 {
+      let (_, np) = read_uleb128(code, p)
+      let (_, np2) = read_uleb128(code, np)
+      (op, bounded(np2, end_pos))
+    }
+    else if instruction_is_memarg(op) {
+      let (_, np) = read_uleb128(code, p)
+      let (_, np2) = read_uleb128(code, np)
+      (op, bounded(np2, end_pos))
+    }
+    else if op == 0x0E {
+      // br_table: a vector of label indices, then the default.
+      let (cnt, np) = read_uleb128(code, p)
+      let mut q = np
+      let mut i = 0
+      while (i < cnt) && (q < end_pos) {
+        let (_, nq) = read_uleb128(code, q)
+        q = nq
+        i = i + 1
+      }
+      if i < cnt {
+        (op, 0 - 1)
+      } else {
+        let (_, nq) = read_uleb128(code, q)
+        (op, bounded(nq, end_pos))
+      }
+    } else {
+      (op, 0 - 1)
+    }
+  }
+}
+
+fn bounded(np: Int, end_pos: Int) -> Int {
+  if np > end_pos {
+    0 - 1
+  } else {
+    np
+  }
+}
+
+fn instruction_has_no_immediate(op: Int) -> Bool {
+  (op == 0x00) || (op == 0x01) || (op == 0x05) || (op == 0x0B) || (op == 0x0F) || (op == 0x1A) || (op == 0x1B) || ((op >= 0x45) && (op <= 0xC4))
+}
+
+fn instruction_is_memarg(op: Int) -> Bool {
+  ((op >= 0x28) && (op <= 0x3E))
+}
+
+/// Instruction-level structure of one function body: `None` when the walk found
+/// nothing wrong. Same one-sided contract as validate_structure -- an
+/// instruction this stepper cannot decode ends the walk without a verdict.
+export fn validate_code_body(code: Bytes, start: Int, end_pos: Int) -> Option[String] {
+  let mut pc = start
+  // A function body sits inside an implicit block, which its final `end`
+  // closes. Starting from zero made every valid body look like it had one
+  // `end` too many -- caught by the parity harness's false-rejection gate,
+  // which is the half that is supposed to be unforgiving.
+  let mut depth = 1
+  let mut err = None
+  let mut stop = false
+  while (pc < end_pos) && !stop && (err == None) {
+    let op = code[pc]
+    if instruction_is_reserved(op) {
+      err = Some("reserved opcode")
+    } else {
+      let (_, np) = next_instruction(code, pc, end_pos)
+      if np < 0 {
+        // Either an unknown-to-us opcode or an immediate past the end. The
+        // second IS invalid, but this stepper cannot tell them apart, so it
+        // stops rather than guess -- see next_instruction's contract.
+        stop = true
+      } else {
+        if (op == 0x02) || (op == 0x03) || (op == 0x04) {
+          depth = depth + 1
+        }
+        else if op == 0x0B {
+          depth = depth - 1
+        } else {
+          ()
+        }
+        if depth < 0 {
+          err = Some("more end opcodes than blocks")
+        } else {
+          ()
+        }
+        pc = np
+      }
+    }
+  }
+  err
+}
+
+/// Opcodes the core spec leaves unassigned. A byte landing here is invalid in
+/// any module, whatever its type, so it is safe to reject on -- unlike an
+/// opcode this stepper merely does not know.
+///
+/// Kept to the two ranges that are unassigned no matter which proposals are
+/// enabled. Everything above 0xC4 was in here at first and had to come out:
+/// 0xFB/0xFC/0xFD/0xFE are PREFIXES, and 0xD3 upward are assigned by gc and
+/// function-references (`ref.eq`, `br_on_null`, ...). Both mistakes rejected
+/// modules vibe's own backend emits, and both were caught by the parity
+/// harness's false-rejection gate rather than by reading an opcode table.
+///
+/// The narrower set catches less. That is the correct trade under a contract
+/// whose hard half is "never reject what the oracle accepts": a rule that is
+/// only right for core wasm cannot be applied to modules that are not.
+fn instruction_is_reserved(op: Int) -> Bool {
+  ((op >= 0x06) && (op <= 0x0A)) || (op == 0x27)
+}
+
+/// Every function body in a code section, stopping at the first problem.
+fn validate_code_section(wasm_bytes: Bytes, offset: Int, size: Int) -> Option[String] {
+  let entries = parse_code_entries(wasm_bytes, offset, size)
+  let mut i = 0
+  let mut err = None
+  while (i < Array::length(entries)) && (err == None) {
+    let (body_offset, body_size, _) = Array::get(entries, i)
+    let (code_start, code_end) = get_code_body_range(wasm_bytes, body_offset, body_size)
+    if (code_start < 0) || (code_end > Bytes::length(wasm_bytes)) || (code_start > code_end) {
+      err = Some("function body runs outside the module")
+    } else {
+      err = validate_code_body(wasm_bytes, code_start, code_end)
+    }
+    i = i + 1
+  }
+  err
+}
+
+/// Every function's declared type index must name a type that exists.
+fn validate_function_type_indices(wasm_bytes: Bytes, offset: Int, size: Int) -> Option[String] {
+  let (type_off, type_size) = find_section(wasm_bytes, 1)
+  let type_count = if type_off < 0 {
+    0
+  } else {
+    Array::length(parse_type_forms(wasm_bytes, type_off, type_size))
+  }
+  let indices = parse_functions(wasm_bytes, offset, size)
+  let mut i = 0
+  let mut err = None
+  while (i < Array::length(indices)) && (err == None) {
+    if Array::get(indices, i) >= type_count {
+      err = Some("function declares a type index that does not exist")
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  err
 }

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -99,6 +99,68 @@ fn read_valtype(bytes: Bytes, pos: Int) -> (Int, Int) {
   }
 }
 
+/// The FORM byte of each type in the type section, in index order.
+///
+/// `parse_types` reports a struct or array type as an empty (params, results)
+/// pair, which is indistinguishable from `(func)` -- fine for its callers, but
+/// it means the type section cannot answer "does this module define gc types".
+/// Feature detection needs exactly that, so the forms are reported separately
+/// rather than by widening `parse_types`' established return shape.
+///
+/// 0x60 func, 0x5F struct, 0x5E array, 0x50 rec group, 0x4E sub.
+export fn parse_type_forms(bytes: Bytes, offset: Int, size: Int) -> Array[Int] {
+  let end_pos = offset + size
+  let forms = Array::slice([
+    0
+  ], 0, 0)
+  let (cnt, pos0) = read_uleb128(bytes, offset)
+  let mut pos = pos0
+  let mut t = 0
+  while (t < cnt) && (pos < end_pos) {
+    let form = bytes[pos]
+    pos = pos + 1
+    Array::push(forms, form)
+    if form == 0x60 {
+      let (param_count, pp) = read_uleb128(bytes, pos)
+      pos = pp
+      let mut p = 0
+      while (p < param_count) && (pos < end_pos) {
+        let (_, np) = read_valtype(bytes, pos)
+        pos = np
+        p = p + 1
+      }
+      let (result_count, rp) = read_uleb128(bytes, pos)
+      pos = rp
+      let mut r = 0
+      while (r < result_count) && (pos < end_pos) {
+        let (_, np) = read_valtype(bytes, pos)
+        pos = np
+        r = r + 1
+      }
+    }
+    else if form == 0x5F {
+      let (field_count, fp) = read_uleb128(bytes, pos)
+      pos = fp
+      let mut f = 0
+      while (f < field_count) && (pos < end_pos) {
+        let (_, np) = read_valtype(bytes, pos)
+        pos = np + 1
+        f = f + 1
+      }
+    }
+    else if form == 0x5E {
+      let (_, np) = read_valtype(bytes, pos)
+      pos = np + 1
+    } else {
+      // A rec group or sub type would need its own walk; stop rather than
+      // guess, so a caller never reads a form this function did not decode.
+      t = cnt
+    }
+    t = t + 1
+  }
+  forms
+}
+
 export fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int], Array[Int])] {
   let end_pos = offset + size
   let result = Array::slice([
@@ -1307,4 +1369,163 @@ export fn module_summary(bytes: Bytes) -> String {
     }
     StringBuilder::freeze(out)
   }
+}
+
+/// Which wasm proposals a module's STRUCTURE requires, as feature-matrix.json
+/// keys (docs/wasm/feature-matrix.json), sorted and deduplicated.
+///
+/// #1133: `scripts/wasm_feature_levels.vibex` declares what vibe's codegen is
+/// believed to emit, curated by hand from source greps. That list drifted the
+/// moment the gc backend's reference lane started emitting typed function
+/// signatures, and nothing noticed -- the drift was found by reading a binary
+/// by hand. This answers the same question FROM the binary.
+///
+/// Deliberately structural only. Everything below is decided by the type
+/// section, a section's presence, or a declaration -- never by scanning code
+/// bytes for opcode prefixes. A naive byte scan cannot tell an opcode from an
+/// immediate that happens to share its value, and would report proposals the
+/// module does not use; being wrong in that direction is worse than being
+/// incomplete, because the whole point is to be trusted against a hand-curated
+/// list. `simd`, `tailCall` and `bulkMemory` therefore need an instruction
+/// walker and are NOT reported yet -- see the package README note.
+export fn scan_features(wasm_bytes: Bytes) -> Array[String] {
+  let found = Array::slice([
+    ""
+  ], 0, 0)
+  if !validate_magic(wasm_bytes) {
+    found
+  } else {
+    let sections = list_sections(wasm_bytes)
+    let mut uses_gc_types = false
+    let mut uses_typed_ref = false
+    let mut uses_ref_types = false
+    let mut has_tag_section = false
+    let mut memory_count = 0
+    let mut i = 0
+    while i < Array::length(sections) {
+      let (sid, off, sz) = Array::get(sections, i)
+      if sid == 1 {
+        let forms = parse_type_forms(wasm_bytes, off, sz)
+        let mut f = 0
+        while f < Array::length(forms) {
+          let form = Array::get(forms, f)
+          if (form == 0x5F) || (form == 0x5E) || (form == 0x50) || (form == 0x4E) {
+            uses_gc_types = true
+          } else {
+            ()
+          }
+          f = f + 1
+        }
+        let types = parse_types(wasm_bytes, off, sz)
+        let mut t = 0
+        while t < Array::length(types) {
+          let (params, results) = Array::get(types, t)
+          if valtypes_mention_typed_ref(params) || valtypes_mention_typed_ref(results) {
+            uses_typed_ref = true
+          } else {
+            ()
+          }
+          if valtypes_mention_ref_type(params) || valtypes_mention_ref_type(results) {
+            uses_ref_types = true
+          } else {
+            ()
+          }
+          t = t + 1
+        }
+      }
+      else if sid == 13 {
+        has_tag_section = true
+      }
+      else if sid == 5 {
+        memory_count = Array::length(parse_memories(wasm_bytes, off, sz))
+      }
+      else if sid == 10 {
+        let entries = parse_code_entries(wasm_bytes, off, sz)
+        let mut e = 0
+        while e < Array::length(entries) {
+          let (_, _, locals) = Array::get(entries, e)
+          let mut l = 0
+          while l < Array::length(locals) {
+            let (_, lt) = Array::get(locals, l)
+            if (lt == 0x63) || (lt == 0x64) {
+              uses_typed_ref = true
+            } else {
+              ()
+            }
+            if (lt == 0x70) || (lt == 0x6F) {
+              uses_ref_types = true
+            } else {
+              ()
+            }
+            l = l + 1
+          }
+          e = e + 1
+        }
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    // Alphabetical, so the result can be compared against a sorted declaration
+    // without the caller sorting first.
+    if has_tag_section {
+      Array::push(found, "exceptionsFinal")
+    } else {
+      ()
+    }
+    if uses_gc_types {
+      Array::push(found, "gc")
+    } else {
+      ()
+    }
+    if memory_count > 1 {
+      Array::push(found, "multiMemory")
+    } else {
+      ()
+    }
+    // Only when nothing narrower already covers it: a typed reference IS a
+    // reference type, and reporting both would make the result read as two
+    // independent requirements.
+    if uses_ref_types && !uses_typed_ref {
+      Array::push(found, "referenceTypes")
+    } else {
+      ()
+    }
+    if uses_typed_ref {
+      Array::push(found, "typedFunctionReferences")
+    } else {
+      ()
+    }
+    found
+  }
+}
+
+fn valtypes_mention_typed_ref(vts: Array[Int]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(vts) {
+    let vt = Array::get(vts, i)
+    if (vt == 0x63) || (vt == 0x64) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn valtypes_mention_ref_type(vts: Array[Int]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(vts) {
+    let vt = Array::get(vts, i)
+    if (vt == 0x70) || (vt == 0x6F) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
 }

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -1529,3 +1529,61 @@ fn valtypes_mention_ref_type(vts: Array[Int]) -> Bool {
   }
   found
 }
+
+/// Structural validation: `None` when nothing structurally wrong was found,
+/// `Some(reason)` otherwise.
+///
+/// The contract is deliberately one-sided, and the name says "structure" for
+/// that reason. This is NOT `wasm-tools validate`: it does not type the operand
+/// stack, so it accepts modules a real validator rejects. What it promises is
+/// the other direction --
+///
+///   it must never reject a module `wasm-tools validate` accepts.
+///
+/// That is the half worth having first (#1745 (5)): the interpreter has no
+/// validation at all, so a malformed module reaches the executor and a
+/// guest-chosen byte can take the host down. Refusing obviously broken input is
+/// containment; typing the stack is correctness, and comes next.
+///
+/// Measured both ways against `wasm-tools validate` -- see the harness in
+/// scripts/test_wasm_validate_parity.sh.
+export fn validate_structure(wasm_bytes: Bytes) -> Option[String] {
+  let len = Bytes::length(wasm_bytes)
+  if len < 8 {
+    Some("module is shorter than the 8-byte header")
+  } else if !validate_magic(wasm_bytes) {
+    Some("bad magic: not a wasm module")
+  } else if read_version(wasm_bytes) != 1 {
+    Some("unsupported version")
+  } else {
+    let mut pos = 8
+    let mut err = None
+    let mut last_id = 0
+    while (pos < len) && (err == None) {
+      let sid = wasm_bytes[pos]
+      if sid > 13 {
+        err = Some("unknown section id")
+      } else {
+        let (size, np) = read_uleb128(wasm_bytes, pos + 1)
+        // The size is the section's own claim; a module can claim more than it
+        // carries, which is how a truncated file reads as a section running off
+        // the end. Checking it here is what keeps every parse_* below in range.
+        if (np + size) > len {
+          err = Some("section runs past the end of the module")
+        } else if (sid != 0) && (sid <= last_id) {
+          // Custom sections (id 0) may appear anywhere and repeat; the others
+          // must appear at most once, in ascending id order.
+          err = Some("sections out of order or repeated")
+        } else {
+          if sid != 0 {
+            last_id = sid
+          } else {
+            ()
+          }
+          pos = np + size
+        }
+      }
+    }
+    err
+  }
+}

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -107,20 +107,87 @@ fn read_valtype(bytes: Bytes, pos: Int) -> (Int, Int) {
 /// Feature detection needs exactly that, so the forms are reported separately
 /// rather than by widening `parse_types`' established return shape.
 ///
-/// 0x60 func, 0x5F struct, 0x5E array, 0x50 rec group, 0x4E sub.
+/// 0x60 func, 0x5F struct, 0x5E array, 0x4E rec group, 0x50/0x4F sub.
+///
+/// One form per TYPE INDEX, which is not one per top-level entry: a recursive
+/// group is a single entry declaring N types, and each of the N gets its own
+/// index. Returning the group marker and stopping made the array length
+/// under-count, so `validate_function_type_indices` called a legitimate
+/// reference to the group's second type out of range. Counting entries would
+/// have been the same bug in a different place.
 export fn parse_type_forms(bytes: Bytes, offset: Int, size: Int) -> Array[Int] {
+  let (forms, _) = parse_type_forms_checked(bytes, offset, size)
+  forms
+}
+
+/// `parse_type_forms` plus whether the walk reached the end of the section.
+///
+/// The flag is what separates "there are N types" from "there are at least N
+/// types": on an undecodable form the walk stops, and a caller that treats the
+/// short array as a count will reject valid modules. Only callers that need to
+/// be SURE take this variant.
+fn parse_type_forms_checked(bytes: Bytes, offset: Int, size: Int) -> (Array[Int], Bool) {
   let end_pos = offset + size
+  let mut complete = true
   let forms = Array::slice([
     0
   ], 0, 0)
   let (cnt, pos0) = read_uleb128(bytes, offset)
   let mut pos = pos0
   let mut t = 0
+  // A rec group's members are read by the same loop, so `remaining_in_rec`
+  // holds how many of them are still owed before the next top-level entry.
+  let mut remaining_in_rec = 0
   while (t < cnt) && (pos < end_pos) {
     let form = bytes[pos]
     pos = pos + 1
-    Array::push(forms, form)
-    if form == 0x60 {
+    // The form whose body still has to be walked, or -1 when this turn did not
+    // reach one. A rec group header reaches no form: its members are separate
+    // turns of this loop, and falling through to the walk would have consumed
+    // the first member's bytes as if they were the header's.
+    let mut walk_form = 0 - 1
+    if form == 0x4E {
+      // Recursive group: a count, then that many types, none of which consumes
+      // a top-level entry of its own.
+      let (n, np) = read_uleb128(bytes, pos)
+      pos = np
+      remaining_in_rec = remaining_in_rec + n
+      if n == 0 {
+        t = t + 1
+      } else {
+        ()
+      }
+    }
+    else if (form == 0x50) || (form == 0x4F) {
+      // Sub type: a vector of supertype indices, then the concrete form. The
+      // wrapper is not a type of its own, so re-read the form byte after it.
+      let (sup, np) = read_uleb128(bytes, pos)
+      pos = np
+      let mut s = 0
+      while (s < sup) && (pos < end_pos) {
+        let (_, nq) = read_uleb128(bytes, pos)
+        pos = nq
+        s = s + 1
+      }
+      if pos < end_pos {
+        walk_form = bytes[pos]
+        Array::push(forms, walk_form)
+        pos = pos + 1
+      } else {
+        // The wrapper ran to the section end with no form after it. Nothing was
+        // pushed, so there is no form to walk and no count to trust.
+        complete = false
+        t = cnt
+        remaining_in_rec = 0
+      }
+    } else {
+      walk_form = form
+      Array::push(forms, form)
+    }
+    if walk_form < 0 {
+      ()
+    }
+    else if walk_form == 0x60 {
       let (param_count, pp) = read_uleb128(bytes, pos)
       pos = pp
       let mut p = 0
@@ -138,7 +205,7 @@ export fn parse_type_forms(bytes: Bytes, offset: Int, size: Int) -> Array[Int] {
         r = r + 1
       }
     }
-    else if form == 0x5F {
+    else if walk_form == 0x5F {
       let (field_count, fp) = read_uleb128(bytes, pos)
       pos = fp
       let mut f = 0
@@ -148,17 +215,38 @@ export fn parse_type_forms(bytes: Bytes, offset: Int, size: Int) -> Array[Int] {
         f = f + 1
       }
     }
-    else if form == 0x5E {
+    else if walk_form == 0x5E {
       let (_, np) = read_valtype(bytes, pos)
       pos = np + 1
     } else {
-      // A rec group or sub type would need its own walk; stop rather than
-      // guess, so a caller never reads a form this function did not decode.
+      // A form this function does not decode: stop rather than guess, so a
+      // caller never reads a form that was never walked. The array it gets is
+      // short, which under-reports features and -- since the length is a type
+      // COUNT to validate_function_type_indices -- must never be treated as
+      // authoritative on its own. That caller checks for a short read.
       t = cnt
+      remaining_in_rec = 0
+      complete = false
     }
-    t = t + 1
+    // Only a turn that produced a TYPE advances the counters. A rec group
+    // header produces none -- letting it fall through here spent one of the
+    // group's own member slots on the header, so the last member was never
+    // read and the count came up one short.
+    if walk_form < 0 {
+      ()
+    }
+    else if remaining_in_rec > 0 {
+      remaining_in_rec = remaining_in_rec - 1
+      if remaining_in_rec == 0 {
+        t = t + 1
+      } else {
+        ()
+      }
+    } else {
+      t = t + 1
+    }
   }
-  forms
+  (forms, complete)
 }
 
 export fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int], Array[Int])] {
@@ -1579,13 +1667,16 @@ export fn validate_structure(wasm_bytes: Bytes) -> Option[String] {
         // the end. Checking it here is what keeps every parse_* below in range.
         if (np + size) > len {
           err = Some("section runs past the end of the module")
-        } else if (sid != 0) && (sid <= last_id) {
+        } else if (sid != 0) && (section_rank(sid) <= last_id) {
           // Custom sections (id 0) may appear anywhere and repeat; the others
-          // must appear at most once, in ascending id order.
+          // must appear at most once, in the spec's canonical order -- which is
+          // NOT ascending by id. Tag (13) sits between Memory (5) and Global
+          // (6), and DataCount (12) between Element (9) and Code (10), because
+          // both were added to a numbering that was already fixed.
           err = Some("sections out of order or repeated")
         } else {
           if sid != 0 {
-            last_id = sid
+            last_id = section_rank(sid)
           } else {
             ()
           }
@@ -1608,6 +1699,33 @@ export fn validate_structure(wasm_bytes: Bytes) -> Option[String] {
       }
     }
     err
+  }
+}
+
+/// A section's position in the spec's canonical order.
+///
+/// Not the same as its id. Tag and DataCount were added after the numbering was
+/// fixed, so they carry high ids (13, 12) but sit early: the order is
+/// type, import, function, table, memory, TAG, global, export, start, element,
+/// DATACOUNT, code, data. Comparing ids instead of ranks rejects every module
+/// with an exception tag -- which this compiler emits whenever a module throws.
+fn section_rank(sid: Int) -> Int {
+  if sid == 13 {
+    6
+  }
+  else if (sid >= 6) && (sid <= 9) {
+    sid + 1
+  }
+  else if sid == 12 {
+    11
+  }
+  else if sid == 10 {
+    12
+  }
+  else if sid == 11 {
+    13
+  } else {
+    sid
   }
 }
 
@@ -1634,7 +1752,7 @@ export fn next_instruction(code: Bytes, pc: Int, end_pos: Int) -> (Int, Int) {
     if instruction_has_no_immediate(op) {
       (op, p)
     }
-    else if (op == 0x0C) || (op == 0x0D) || (op == 0x10) || (op == 0x20) || (op == 0x21) || (op == 0x22) || (op == 0x23) || (op == 0x24) || (op == 0x12) || (op == 0x14) || (op == 0x15) || (op == 0x25) || (op == 0x26) || (op == 0x3F) || (op == 0x40) || (op == 0xD2) || (op == 0xD5) || (op == 0xD6) {
+    else if (op == 0x0C) || (op == 0x0D) || (op == 0x10) || (op == 0x20) || (op == 0x21) || (op == 0x22) || (op == 0x23) || (op == 0x24) || (op == 0x12) || (op == 0x14) || (op == 0x15) || (op == 0x25) || (op == 0x26) || (op == 0x3F) || (op == 0x40) || (op == 0xD2) || (op == 0xD5) || (op == 0xD6) || (op == 0x08) {
       // One unsigned index: label, function, local, global, table, memory --
       // or, for 0x14/0x15 (call_ref/return_call_ref), a type.
       let (_, np) = read_uleb128(code, p)
@@ -1672,6 +1790,46 @@ export fn next_instruction(code: Bytes, pc: Int, end_pos: Int) -> (Int, Int) {
       let (_, np) = read_uleb128(code, p)
       let (_, np2) = read_uleb128(code, np)
       (op, bounded(np2, end_pos))
+    }
+    else if op == 0x1F {
+      // try_table: a blocktype, then a vector of catch clauses. The clause kind
+      // decides whether a tag index precedes the label.
+      let (_, np) = read_sleb128(code, p)
+      let (cnt, np2) = read_uleb128(code, np)
+      let mut q = np2
+      let mut i = 0
+      let mut bad = false
+      while (i < cnt) && (q < end_pos) && !bad {
+        let kind = code[q]
+        let r = q + 1
+        if (kind == 0x00) || (kind == 0x01) {
+          let (_, nr) = read_uleb128(code, r)
+          let (_, nr2) = read_uleb128(code, nr)
+          q = nr2
+        }
+        else if (kind == 0x02) || (kind == 0x03) {
+          let (_, nr) = read_uleb128(code, r)
+          q = nr
+        } else {
+          bad = true
+        }
+        i = i + 1
+      }
+      if bad || (i < cnt) {
+        (op, 0 - 1)
+      } else {
+        (op, bounded(q, end_pos))
+      }
+    }
+    else if op == 0x06 {
+      // Legacy exception handling: `try` takes a blocktype, like block/loop/if.
+      let (_, np) = read_sleb128(code, p)
+      (op, bounded(np, end_pos))
+    }
+    else if (op == 0x07) || (op == 0x09) || (op == 0x18) {
+      // Legacy `catch` (tag), `rethrow` (label), `delegate` (label).
+      let (_, np) = read_uleb128(code, p)
+      (op, bounded(np, end_pos))
     }
     else if op == 0xFC {
       let (sub, np) = read_uleb128(code, p)
@@ -1737,7 +1895,7 @@ fn bounded(np: Int, end_pos: Int) -> Int {
 }
 
 fn instruction_has_no_immediate(op: Int) -> Bool {
-  (op == 0x00) || (op == 0x01) || (op == 0x05) || (op == 0x0B) || (op == 0x0F) || (op == 0x1A) || (op == 0x1B) || ((op >= 0x45) && (op <= 0xC4)) || (op == 0xD1) || (op == 0xD3) || (op == 0xD4)
+  (op == 0x00) || (op == 0x01) || (op == 0x05) || (op == 0x0B) || (op == 0x0F) || (op == 0x1A) || (op == 0x1B) || ((op >= 0x45) && (op <= 0xC4)) || (op == 0xD1) || (op == 0xD3) || (op == 0xD4) || (op == 0x0A) || (op == 0x19)
 }
 
 fn instruction_is_memarg(op: Int) -> Bool {
@@ -1886,7 +2044,9 @@ export fn validate_code_body(code: Bytes, start: Int, end_pos: Int) -> Option[St
         // stops rather than guess -- see next_instruction's contract.
         stop = true
       } else {
-        if (op == 0x02) || (op == 0x03) || (op == 0x04) {
+        if (op == 0x02) || (op == 0x03) || (op == 0x04) || (op == 0x1F) || (op == 0x06) {
+          // try_table (0x1F) and legacy try (0x06) open a block too; missing
+          // them would make every exception body look like it had a stray end.
           depth = depth + 1
         }
         else if op == 0x0B {
@@ -1903,25 +2063,40 @@ export fn validate_code_body(code: Bytes, start: Int, end_pos: Int) -> Option[St
       }
     }
   }
-  err
+  // Reached only when the walk covered the WHOLE body -- if it stopped early,
+  // depth says nothing. Under that condition a body whose blocks do not all
+  // close is invalid in any module, so this is safe to reject on. It is also
+  // where most of the catch power went after the reserved-opcode set had to be
+  // narrowed to a single byte: corruption inside a body usually shows up as
+  // structure that no longer balances, not as a byte no proposal has claimed.
+  if (err == None) && !stop && (depth != 0) {
+    Some("function body ends with unclosed blocks")
+  } else {
+    err
+  }
 }
 
 /// Opcodes the core spec leaves unassigned. A byte landing here is invalid in
 /// any module, whatever its type, so it is safe to reject on -- unlike an
 /// opcode this stepper merely does not know.
 ///
-/// Kept to the two ranges that are unassigned no matter which proposals are
-/// enabled. Everything above 0xC4 was in here at first and had to come out:
-/// 0xFB/0xFC/0xFD/0xFE are PREFIXES, and 0xD3 upward are assigned by gc and
-/// function-references (`ref.eq`, `br_on_null`, ...). Both mistakes rejected
-/// modules vibe's own backend emits, and both were caught by the parity
-/// harness's false-rejection gate rather than by reading an opcode table.
+/// This set has now been narrowed THREE times, each time because a rule that
+/// held for core wasm did not hold for a module a proposal made legal:
 ///
-/// The narrower set catches less. That is the correct trade under a contract
-/// whose hard half is "never reject what the oracle accepts": a rule that is
-/// only right for core wasm cannot be applied to modules that are not.
+///   above 0xC4   0xFB/0xFC/0xFD/0xFE are prefixes, and 0xD3 upward is gc and
+///                function-references (`ref.eq`, `br_on_null`, ...)
+///   0x06..0x0A   exception handling. 0x08 is `throw`, which this compiler
+///                emits (codegen/gc/backend_call.vibe), and 0x06/0x07/0x09 are
+///                legacy try/catch/rethrow, which the oracle accepts under
+///                `--features all`
+///
+/// What is left is 0x27 -- a hole between `table.set` and `i32.load` that no
+/// proposal has claimed. The narrower set catches less, and that is the correct
+/// trade under a contract whose hard half is "never reject what the oracle
+/// accepts": a rule that is only right for core wasm cannot be applied to
+/// modules that are not.
 fn instruction_is_reserved(op: Int) -> Bool {
-  ((op >= 0x06) && (op <= 0x0A)) || (op == 0x27)
+  op == 0x27
 }
 
 /// Every function body in a code section, stopping at the first problem.
@@ -1943,23 +2118,41 @@ fn validate_code_section(wasm_bytes: Bytes, offset: Int, size: Int) -> Option[St
 }
 
 /// Every function's declared type index must name a type that exists.
+/// Function-section type indices against the number of types that exist.
+///
+/// `parse_type_forms` stops at a form it cannot decode, so its length is a
+/// LOWER BOUND on the type count, not the count. Rejecting on a lower bound
+/// would fail a valid module the moment the type section used something this
+/// parser has not learned yet -- the same shape of mistake as the reserved
+/// opcode range. So the check runs only when the walk consumed the whole type
+/// section, which is exactly when the count is known to be exact.
 fn validate_function_type_indices(wasm_bytes: Bytes, offset: Int, size: Int) -> Option[String] {
   let (type_off, type_size) = find_section(wasm_bytes, 1)
-  let type_count = if type_off < 0 {
-    0
-  } else {
-    Array::length(parse_type_forms(wasm_bytes, type_off, type_size))
-  }
-  let indices = parse_functions(wasm_bytes, offset, size)
-  let mut i = 0
-  let mut err = None
-  while (i < Array::length(indices)) && (err == None) {
-    if Array::get(indices, i) >= type_count {
-      err = Some("function declares a type index that does not exist")
+  if type_off < 0 {
+    let indices = parse_functions(wasm_bytes, offset, size)
+    if Array::length(indices) > 0 {
+      Some("function declares a type index that does not exist")
     } else {
-      ()
+      None
     }
-    i = i + 1
+  } else {
+    let (forms, complete) = parse_type_forms_checked(wasm_bytes, type_off, type_size)
+    if !complete {
+      None
+    } else {
+      let type_count = Array::length(forms)
+      let indices = parse_functions(wasm_bytes, offset, size)
+      let mut i = 0
+      let mut err = None
+      while (i < Array::length(indices)) && (err == None) {
+        if Array::get(indices, i) >= type_count {
+          err = Some("function declares a type index that does not exist")
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      err
+    }
   }
-  err
 }

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -75,6 +75,30 @@ export fn parse_start(bytes: Bytes, offset: Int, size: Int) -> Int {
   }
 }
 
+/// Read one valtype and return it with the position AFTER it.
+///
+/// Most valtypes are a single byte, but a typed reference is not: `0x63`
+/// (ref null ht) and `0x64` (ref ht) are followed by a heap type, which for a
+/// concrete type is a signed LEB index. Advancing one byte past those leaves
+/// the index in the stream, where it is read as the next valtype -- and from
+/// there the whole section is off by however many bytes the indices took.
+///
+/// The struct and array branches below already did this; the function-type
+/// branch and the local declarations did not, which is why a module whose
+/// SIGNATURES carry typed references desynchronized. vibe's own gc backend
+/// emits exactly that shape (#1541 / #1722 give private callees typed
+/// parameters and results, and reserve a `(func (result (ref null $t)))` for
+/// blocktypes), so the misparse is reachable from the compiler's own output.
+fn read_valtype(bytes: Bytes, pos: Int) -> (Int, Int) {
+  let vt = bytes[pos]
+  if (vt == 0x63) || (vt == 0x64) {
+    let (_, np) = read_sleb128(bytes, pos + 1)
+    (vt, np)
+  } else {
+    (vt, pos + 1)
+  }
+}
+
 export fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int], Array[Int])] {
   let end_pos = offset + size
   let result = Array::slice([
@@ -98,8 +122,9 @@ export fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int]
       ], 0, 0)
       let mut p = 0
       while (p < param_count) && (pos < end_pos) {
-        Array::push(params, bytes[pos])
-        pos = pos + 1
+        let (vt, np) = read_valtype(bytes, pos)
+        Array::push(params, vt)
+        pos = np
         p = p + 1
       }
       let (result_count, rp) = read_uleb128(bytes, pos)
@@ -109,8 +134,9 @@ export fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int]
       ], 0, 0)
       let mut r = 0
       while (r < result_count) && (pos < end_pos) {
-        Array::push(results, bytes[pos])
-        pos = pos + 1
+        let (vt, np) = read_valtype(bytes, pos)
+        Array::push(results, vt)
+        pos = np
         r = r + 1
       }
       Array::push(result, (params, results))
@@ -911,8 +937,11 @@ export fn parse_code_entries(bytes: Bytes, offset: Int, size: Int) -> Array[(Int
       let (lcount, p1) = read_uleb128(bytes, lp)
       lp = p1
       if lp < body_end {
-        let ltype = bytes[lp]
-        lp = lp + 1
+        // A `(local (ref null $t))` is two-plus bytes, same as a typed
+        // reference anywhere else. Reading one byte here left the type index
+        // to be taken as the next declaration's count.
+        let (ltype, lnext) = read_valtype(bytes, lp)
+        lp = lnext
         Array::push(locals, (lcount, ltype))
       } else {
         ()

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -1093,6 +1093,15 @@ export fn parse_imports_full(bytes: Bytes, offset: Int, size: Int) -> Array[(Str
   result
 }
 
+/// Where a function's instructions begin, after its local declarations.
+///
+/// Each declaration is a count and a VALTYPE, and a valtype is not one byte:
+/// `(ref null $t)` is `0x63` plus a type index. Advancing by one skipped past
+/// the count but landed inside the index, so the "code" started mid-declaration
+/// -- on a gc module with typed-ref locals the first byte read as an
+/// instruction was a local count. This is the same one-byte assumption #1795
+/// removed from the type section, in the function that decides where code IS.
+/// It reaches further than parsing: extract_code_body feeds the interpreter.
 export fn get_code_body_range(bytes: Bytes, body_offset: Int, body_size: Int) -> (Int, Int) {
   let body_end = body_offset + body_size
   let (local_decl_count, pos0) = read_uleb128(bytes, body_offset)
@@ -1100,8 +1109,8 @@ export fn get_code_body_range(bytes: Bytes, body_offset: Int, body_size: Int) ->
   let mut d = 0
   while d < local_decl_count {
     let (_, np) = read_uleb128(bytes, pos)
-    pos = np
-    pos = pos + 1
+    let (_, np2) = read_valtype(bytes, np)
+    pos = np2
     d = d + 1
   }
   (pos, body_end)
@@ -1606,16 +1615,16 @@ export fn validate_structure(wasm_bytes: Bytes) -> Option[String] {
 ///
 /// A next position of -1 means "this stepper cannot say" -- either the opcode
 /// is not one it knows, or the instruction's immediates run past `end_pos`.
-/// Callers must treat -1 as "stop", never as "invalid": the prefixed families
-/// (0xFC bulk-memory, 0xFD simd, 0xFB gc) carry per-instruction immediates this
-/// does not enumerate yet, and reporting a module invalid because this function
-/// is incomplete would break the one-sided contract validate_structure keeps.
+/// Callers must treat -1 as "stop", never as "invalid": simd (0xFD) and atomics
+/// (0xFE) carry per-instruction immediates this does not enumerate, and
+/// reporting a module invalid because this function is incomplete would break
+/// the one-sided contract validate_structure keeps.
 ///
-/// Immediate shapes are stated HERE rather than at each caller. The
-/// disassembler in @vibex/wasm_runtime carries its own copy today and is blind
-/// to the prefixed families as a result -- it missteps on exactly the gc
-/// instructions vibe's own backend now emits. Folding it onto this is the
-/// follow-up that removes the second copy.
+/// Immediate shapes are stated HERE rather than at each caller, and
+/// @vibex/wasm_runtime's disassembler steps with this rather than its own copy.
+/// The second copy was blind to the prefixed families, so it misstepped on
+/// exactly the gc instructions vibe's own backend emits -- printing a plausible
+/// listing that was garbage from the first `0xFB` onward.
 export fn next_instruction(code: Bytes, pc: Int, end_pos: Int) -> (Int, Int) {
   if pc >= end_pos {
     (0, 0 - 1)
@@ -1625,9 +1634,56 @@ export fn next_instruction(code: Bytes, pc: Int, end_pos: Int) -> (Int, Int) {
     if instruction_has_no_immediate(op) {
       (op, p)
     }
-    else if (op == 0x0C) || (op == 0x0D) || (op == 0x10) || (op == 0x20) || (op == 0x21) || (op == 0x22) || (op == 0x23) || (op == 0x24) {
+    else if (op == 0x0C) || (op == 0x0D) || (op == 0x10) || (op == 0x20) || (op == 0x21) || (op == 0x22) || (op == 0x23) || (op == 0x24) || (op == 0x12) || (op == 0x14) || (op == 0x15) || (op == 0x25) || (op == 0x26) || (op == 0x3F) || (op == 0x40) || (op == 0xD2) || (op == 0xD5) || (op == 0xD6) {
+      // One unsigned index: label, function, local, global, table, memory --
+      // or, for 0x14/0x15 (call_ref/return_call_ref), a type.
       let (_, np) = read_uleb128(code, p)
       (op, bounded(np, end_pos))
+    }
+    else if op == 0xD0 {
+      // ref.null takes a heap type, which is a signed LEB: negative for the
+      // abstract types, non-negative for a concrete type index.
+      let (_, np) = read_sleb128(code, p)
+      (op, bounded(np, end_pos))
+    }
+    else if op == 0x43 {
+      (op, bounded(p + 4, end_pos))
+    }
+    else if op == 0x44 {
+      (op, bounded(p + 8, end_pos))
+    }
+    else if op == 0x1C {
+      // select with an explicit result-type vector.
+      let (cnt, np) = read_uleb128(code, p)
+      let mut q = np
+      let mut i = 0
+      while (i < cnt) && (q < end_pos) {
+        let (_, nq) = read_valtype(code, q)
+        q = nq
+        i = i + 1
+      }
+      if i < cnt {
+        (op, 0 - 1)
+      } else {
+        (op, bounded(q, end_pos))
+      }
+    }
+    else if op == 0x13 {
+      let (_, np) = read_uleb128(code, p)
+      let (_, np2) = read_uleb128(code, np)
+      (op, bounded(np2, end_pos))
+    }
+    else if op == 0xFC {
+      let (sub, np) = read_uleb128(code, p)
+      (op, bounded(misc_immediate_end(code, sub, np), end_pos))
+    }
+    else if op == 0xFB {
+      let (sub, np) = read_uleb128(code, p)
+      (op, bounded(gc_immediate_end(code, sub, np), end_pos))
+    }
+    else if op == 0xFD {
+      let (sub, np) = read_uleb128(code, p)
+      (op, bounded(simd_immediate_end(code, sub, np), end_pos))
     }
     else if (op == 0x02) || (op == 0x03) || (op == 0x04) {
       // Blocktype: a negative value type, or a non-negative TYPE INDEX. Both
@@ -1681,11 +1737,129 @@ fn bounded(np: Int, end_pos: Int) -> Int {
 }
 
 fn instruction_has_no_immediate(op: Int) -> Bool {
-  (op == 0x00) || (op == 0x01) || (op == 0x05) || (op == 0x0B) || (op == 0x0F) || (op == 0x1A) || (op == 0x1B) || ((op >= 0x45) && (op <= 0xC4))
+  (op == 0x00) || (op == 0x01) || (op == 0x05) || (op == 0x0B) || (op == 0x0F) || (op == 0x1A) || (op == 0x1B) || ((op >= 0x45) && (op <= 0xC4)) || (op == 0xD1) || (op == 0xD3) || (op == 0xD4)
 }
 
 fn instruction_is_memarg(op: Int) -> Bool {
   ((op >= 0x28) && (op <= 0x3E))
+}
+
+/// End of a `0xFC`-prefixed instruction's immediates. The zero bytes after
+/// memory.init/copy/fill are the memory index, reserved to 0 today but still
+/// present in the encoding, so they are counted rather than assumed away.
+fn misc_immediate_end(code: Bytes, sub: Int, p: Int) -> Int {
+  if sub <= 7 {
+    p
+  }
+  else if sub == 8 {
+    let (_, np) = read_uleb128(code, p)
+    np + 1
+  }
+  else if (sub == 9) || (sub == 13) || (sub == 15) || (sub == 16) || (sub == 17) {
+    let (_, np) = read_uleb128(code, p)
+    np
+  }
+  else if sub == 10 {
+    p + 2
+  }
+  else if sub == 11 {
+    p + 1
+  }
+  else if (sub == 12) || (sub == 14) {
+    let (_, np) = read_uleb128(code, p)
+    let (_, np2) = read_uleb128(code, np)
+    np2
+  } else {
+    0 - 1
+  }
+}
+
+/// End of a `0xFD`-prefixed (simd) instruction's immediates.
+///
+/// Worth stating why "everything else takes no immediate" is a rule and not a
+/// guess: in the simd space only the loads/stores (memarg), `v128.const`,
+/// `i8x16.shuffle`, and the lane accessors carry anything. The ~200 remaining
+/// assigned opcodes are operand-stack-only. Enumerating the carriers and
+/// defaulting the rest is therefore exact over the assigned range, which is the
+/// only range a module wasm-tools accepts can reach.
+///
+/// This matters more than it looks. Measured on this compiler's own output,
+/// 0xFD was the ONLY thing stopping the instruction walk -- 6 to 9 bodies per
+/// module, because `simd_skip_ws` and friends emit v128 opcodes. Without this
+/// the walk covered about 88% of bodies and could not see a corruption past the
+/// first vector instruction.
+fn simd_immediate_end(code: Bytes, sub: Int, p: Int) -> Int {
+  if sub <= 11 {
+    // v128.load* / v128.store: memarg.
+    let (_, np) = read_uleb128(code, p)
+    let (_, np2) = read_uleb128(code, np)
+    np2
+  }
+  else if (sub == 12) || (sub == 13) {
+    // v128.const: 16 literal bytes. i8x16.shuffle: 16 lane indices.
+    p + 16
+  }
+  else if (sub >= 21) && (sub <= 34) {
+    // extract_lane / replace_lane: one lane index.
+    p + 1
+  }
+  else if (sub >= 84) && (sub <= 91) {
+    // v128.loadN_lane / storeN_lane: memarg AND a lane index.
+    let (_, np) = read_uleb128(code, p)
+    let (_, np2) = read_uleb128(code, np)
+    np2 + 1
+  }
+  else if (sub == 92) || (sub == 93) {
+    // v128.load32_zero / load64_zero: memarg.
+    let (_, np) = read_uleb128(code, p)
+    let (_, np2) = read_uleb128(code, np)
+    np2
+  }
+  else if sub <= 275 {
+    p
+  } else {
+    0 - 1
+  }
+}
+
+/// End of a `0xFB`-prefixed (gc) instruction's immediates. This is the family
+/// vibe's own gc backend emits, so getting it wrong is not hypothetical -- it
+/// is the difference between reading this compiler's output and inventing a
+/// reading of it.
+fn gc_immediate_end(code: Bytes, sub: Int, p: Int) -> Int {
+  if (sub == 0) || (sub == 1) || (sub == 6) || (sub == 7) || (sub == 11) || (sub == 12) || (sub == 13) || (sub == 14) || (sub == 16) {
+    // One type index: struct.new*, array.new*, array.get*/set, array.fill.
+    let (_, np) = read_uleb128(code, p)
+    np
+  }
+  else if (sub == 2) || (sub == 3) || (sub == 4) || (sub == 5) || (sub == 8) || (sub == 9) || (sub == 10) || (sub == 17) || (sub == 18) || (sub == 19) {
+    // Two indices: struct.get*/set take a field, array.new_fixed a length,
+    // array.copy a second type, array.new_data/init_data a segment.
+    let (_, np) = read_uleb128(code, p)
+    let (_, np2) = read_uleb128(code, np)
+    np2
+  }
+  else if sub == 15 {
+    p
+  }
+  else if (sub >= 20) && (sub <= 23) {
+    // ref.test / ref.cast, both null and non-null forms: one heap type.
+    let (_, np) = read_sleb128(code, p)
+    np
+  }
+  else if (sub == 24) || (sub == 25) {
+    // br_on_cast{,_fail}: a flags byte, a label, then BOTH heap types.
+    let (_, np) = read_uleb128(code, p + 1)
+    let (_, np2) = read_sleb128(code, np)
+    let (_, np3) = read_sleb128(code, np2)
+    np3
+  }
+  else if (sub >= 26) && (sub <= 31) {
+    // any.convert_extern, extern.convert_any, ref.i31, i31.get_s/u.
+    p
+  } else {
+    0 - 1
+  }
 }
 
 /// Instruction-level structure of one function body: `None` when the walk found

--- a/lib/@vibex/wasm_parser/wasm_parser_test.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser_test.vibe
@@ -3899,3 +3899,84 @@ test "rs: big export section 20 exports" {
   let (_, _, i19) = Array::get(exports, 19)
   assert(i19 == 19)
 }
+
+// A typed reference is not one byte (#1133 investigation).
+//
+// `0x63` (ref null ht) and `0x64` (ref ht) carry a heap type, which for a
+// concrete type is a signed LEB index. The struct and array type forms already
+// consumed it; function signatures and local declarations did not, so a module
+// whose SIGNATURES use typed references desynchronized -- every later type was
+// garbage, and on a real module the scan ran past the type section and started
+// reading the import section's name bytes as valtypes.
+//
+// This is reachable from vibe's own compiler: the gc backend's reference lane
+// (#1541 / #1722) gives private callees typed parameters and results, and
+// reserves a `(func (result (ref null $t)))` for blocktypes.
+
+test "parse_types reads a typed reference parameter as one valtype" {
+  // (type (func (param (ref null 0) i64) (result i64)))
+  let ts = parse_types(make_bytes([
+    1,
+    0x60,
+    2,
+    0x63,
+    0,
+    0x7E,
+    1,
+    0x7E
+  ]), 0, 8)
+  assert(Array::length(ts) == 1)
+  let (params, results) = Array::get(ts, 0)
+  // Two parameters, not three: the heap-type index is part of the first.
+  assert(Array::length(params) == 2)
+  assert(Array::get(params, 0) == 0x63)
+  assert(Array::get(params, 1) == 0x7E)
+  assert(Array::length(results) == 1)
+  assert(Array::get(results, 0) == 0x7E)
+}
+
+test "parse_types keeps its place across a typed reference result" {
+  // Two types: `(func (result (ref null 0)))` then `(func (param i64))`.
+  // The second only parses if the first consumed the heap-type index -- this
+  // is the shape the gc backend reserves for blocktypes.
+  let ts = parse_types(make_bytes([
+    2,
+    0x60,
+    0,
+    1,
+    0x63,
+    0,
+    0x60,
+    1,
+    0x7E,
+    0
+  ]), 0, 10)
+  assert(Array::length(ts) == 2)
+  let (p0, r0) = Array::get(ts, 0)
+  assert(Array::length(p0) == 0)
+  assert(Array::length(r0) == 1)
+  assert(Array::get(r0, 0) == 0x63)
+  let (p1, r1) = Array::get(ts, 1)
+  assert(Array::length(p1) == 1)
+  assert(Array::get(p1, 0) == 0x7E)
+  assert(Array::length(r1) == 0)
+}
+
+test "parse_code_entries reads a typed reference local as one declaration" {
+  // One body: locals = [(1, (ref null 0))], code = `end`.
+  let entries = parse_code_entries(make_bytes([
+    1,
+    5,
+    1,
+    1,
+    0x63,
+    0,
+    0x0B
+  ]), 0, 7)
+  assert(Array::length(entries) == 1)
+  let (_, _, locals) = Array::get(entries, 0)
+  assert(Array::length(locals) == 1)
+  let (lcount, ltype) = Array::get(locals, 0)
+  assert(lcount == 1)
+  assert(ltype == 0x63)
+}

--- a/lib/@vibex/wasm_parser/wasm_parser_test.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser_test.vibe
@@ -33,9 +33,11 @@ import ./wasm_parser.vibe {
   parse_memories,
   parse_start,
   parse_tables,
+  parse_type_forms,
   parse_types,
   read_init_expr,
   read_version,
+  scan_features,
   section_name,
   validate_magic,
   valtype_name
@@ -3979,4 +3981,124 @@ test "parse_code_entries reads a typed reference local as one declaration" {
   let (lcount, ltype) = Array::get(locals, 0)
   assert(lcount == 1)
   assert(ltype == 0x63)
+}
+
+// #1133: report proposal requirements FROM the binary.
+//
+// The hand-curated `used_by_codegen()` in scripts/wasm_feature_levels.vibex
+// drifted the moment vibe's gc backend started emitting typed function
+// signatures, and nothing noticed. These pin the structural detections that
+// answer the same question from the bytes.
+
+fn empty_module() -> Bytes {
+  make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0
+  ])
+}
+
+fn features_contain(fs: Array[String], want: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(fs) {
+    if Array::get(fs, i) == want {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+test "scan_features reports nothing for a bare module" {
+  assert(Array::length(scan_features(empty_module())) == 0)
+}
+
+test "scan_features rejects a non-module without reading further" {
+  assert(Array::length(scan_features(make_bytes([
+    1,
+    2,
+    3
+  ]))) == 0)
+}
+
+test "scan_features finds gc from a struct type definition" {
+  // type section: one `(struct (field (mut i64)))`
+  let m = make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    1,
+    5,
+    1,
+    0x5F,
+    1,
+    0x7E,
+    1
+  ])
+  let fs = scan_features(m)
+  assert(features_contain(fs, "gc"))
+  // A gc TYPE alone does not imply typed function references: this backend
+  // used struct types with an all-i64 ABI before the reference lane existed.
+  assert(!features_contain(fs, "typedFunctionReferences"))
+}
+
+test "scan_features finds typedFunctionReferences from a signature" {
+  // type section: `(func (param (ref null 0)) (result i64))`
+  let m = make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    1,
+    7,
+    1,
+    0x60,
+    1,
+    0x63,
+    0,
+    1,
+    0x7E
+  ])
+  let fs = scan_features(m)
+  assert(features_contain(fs, "typedFunctionReferences"))
+  // referenceTypes is not reported alongside it: a typed reference IS a
+  // reference type, and listing both reads as two independent requirements.
+  assert(!features_contain(fs, "referenceTypes"))
+}
+
+test "scan_features finds exceptionsFinal from the tag section" {
+  // section id 13 (tag), one entry.
+  let m = make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    13,
+    3,
+    1,
+    0,
+    0
+  ])
+  assert(features_contain(scan_features(m), "exceptionsFinal"))
 }

--- a/lib/@vibex/wasm_parser/wasm_parser_test.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser_test.vibe
@@ -664,6 +664,32 @@ test "get_code_body_range with locals" {
   assert(bytes[expr_start] == 0x41)
 }
 
+test "get_code_body_range with a typed-reference local" {
+  // Same shape, but the local's valtype is `(ref null $12)` = 0x63 0x0C --
+  // TWO bytes. Advancing by one put the code start on the type index, so the
+  // first "instruction" read was 0x0C (br). Every gc body with a typed-ref
+  // local decoded from one byte too early, and extract_code_body hands that
+  // range to the interpreter.
+  //
+  // body size=8: [local_count=1, (2, ref null 12), i32.const 0, end]
+  let bytes = make_bytes([
+    1,
+    8,
+    1,
+    2,
+    0x63,
+    0x0C,
+    0x41,
+    0,
+    0x0B,
+    0
+  ])
+  let entries = parse_code_entries(bytes, 0, 10)
+  let (off, sz, _) = Array::get(entries, 0)
+  let (expr_start, _) = get_code_body_range(bytes, off, sz)
+  assert(bytes[expr_start] == 0x41)
+}
+
 test "parse_data_segments active" {
   // mode=0, offset=i32.const 0, end, 3 bytes
   let segs = parse_data_segments(make_bytes([

--- a/lib/@vibex/wasm_parser/wasm_parser_test.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser_test.vibe
@@ -39,6 +39,7 @@ import ./wasm_parser.vibe {
   read_version,
   scan_features,
   section_name,
+  validate_code_body,
   validate_magic,
   validate_structure,
   valtype_name
@@ -4262,4 +4263,125 @@ test "validate_structure allows a custom section anywhere" {
     None => assert(true),
     Some(_) => assert(false)
   }
+}
+
+// The three below all pin the same lesson from PR #1800's review: a rule that
+// is right for core wasm is not automatically right for a module some proposal
+// made legal, and the HARD half of the contract has no tolerance for that.
+
+test "validate_structure accepts a tag section between memory and global" {
+  // Section order is the spec's canonical one, NOT ascending by id: tag (13)
+  // sits between memory (5) and global (6). Comparing ids rejected every module
+  // this compiler emits for a `throw` -- it puts the tag exactly there
+  // (codegen/gc/backend_body.vibe, #538).
+  //
+  // header | memory(5) size=3 [1, 0, 0] | tag(13) size=3 [1, 0, 0]
+  //        | global(6) size=1 [0]
+  match validate_structure(make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    5,
+    3,
+    1,
+    0,
+    0,
+    13,
+    3,
+    1,
+    0,
+    0,
+    6,
+    1,
+    0
+  ])) {
+    None => assert(true),
+    Some(_) => assert(false)
+  }
+}
+
+test "validate_structure still rejects a genuinely misordered section pair" {
+  // The rank fix must not make the order check vacuous: global (6) before
+  // memory (5) is out of order under either reading.
+  //
+  // header | global(6) size=1 [0] | memory(5) size=3 [1, 0, 0]
+  match validate_structure(make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    6,
+    1,
+    0,
+    5,
+    3,
+    1,
+    0,
+    0
+  ])) {
+    None => assert(false),
+    Some(_) => assert(true)
+  }
+}
+
+test "validate_code_body accepts throw, which is not a reserved opcode" {
+  // 0x08 is `throw` and 0x06..0x0A is exception handling, not an unassigned
+  // range. This compiler emits 0x08 directly (codegen/gc/backend_call.vibe).
+  //
+  // throw 0 | end
+  let code = make_bytes([
+    0x08,
+    0,
+    0x0B
+  ])
+  match validate_code_body(code, 0, 3) {
+    None => assert(true),
+    Some(_) => assert(false)
+  }
+}
+
+test "validate_code_body rejects a body whose blocks do not close" {
+  // block ... with no matching end. Reachable only because the walk covered
+  // the whole body, which is what makes it safe to reject on.
+  let code = make_bytes([
+    0x02,
+    0x40,
+    0x01,
+    0x0B
+  ])
+  match validate_code_body(code, 0, 4) {
+    None => assert(false),
+    Some(_) => assert(true)
+  }
+}
+
+test "parse_type_forms counts every type inside a recursive group" {
+  // 0x4E declares a group of N types; each gets its own index. Returning the
+  // group marker and stopping made the length under-count, so a function
+  // referring to the group's second type was called out of range.
+  //
+  // count=1 | rec 0x4E n=2 | (func)(func)
+  let forms = parse_type_forms(make_bytes([
+    1,
+    0x4E,
+    2,
+    0x60,
+    0,
+    0,
+    0x60,
+    0,
+    0
+  ]), 0, 9)
+  assert(Array::length(forms) == 2)
+  assert(Array::get(forms, 0) == 0x60)
+  assert(Array::get(forms, 1) == 0x60)
 }

--- a/lib/@vibex/wasm_parser/wasm_parser_test.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser_test.vibe
@@ -40,6 +40,7 @@ import ./wasm_parser.vibe {
   scan_features,
   section_name,
   validate_magic,
+  validate_structure,
   valtype_name
 }
 
@@ -4101,4 +4102,138 @@ test "scan_features finds exceptionsFinal from the tag section" {
     0
   ])
   assert(features_contain(scan_features(m), "exceptionsFinal"))
+}
+
+// Structural validation (#1133 / #1745 (5)).
+//
+// The contract is one-sided: never reject what `wasm-tools validate` accepts,
+// and catch as much of what it rejects as structure alone can decide. The
+// parity harness (scripts/test_wasm_validate_parity.sh) measures both halves
+// against the real tool; these pin the individual decisions.
+
+test "validate_structure accepts the empty module" {
+  // Eight bytes of header IS a valid module -- worth pinning, because a
+  // truncation mutant that happens to stop here must not be counted as a catch.
+  match validate_structure(empty_module()) {
+    None => assert(true),
+    Some(_) => assert(false)
+  }
+}
+
+test "validate_structure rejects a short module" {
+  match validate_structure(make_bytes([
+    0,
+    97,
+    115
+  ])) {
+    None => assert(false),
+    Some(_) => assert(true)
+  }
+}
+
+test "validate_structure rejects bad magic" {
+  match validate_structure(make_bytes([
+    0,
+    0x41,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0
+  ])) {
+    None => assert(false),
+    Some(_) => assert(true)
+  }
+}
+
+test "validate_structure rejects a section running past the end" {
+  // Section id 1 claiming 0x7F bytes in a module that has three.
+  match validate_structure(make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    1,
+    0x7F,
+    0,
+    0
+  ])) {
+    None => assert(false),
+    Some(_) => assert(true)
+  }
+}
+
+test "validate_structure rejects an unknown section id" {
+  match validate_structure(make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    0x7A,
+    2,
+    0,
+    0
+  ])) {
+    None => assert(false),
+    Some(_) => assert(true)
+  }
+}
+
+test "validate_structure rejects repeated non-custom sections" {
+  // Two type sections. Custom sections may repeat; the rest may not.
+  match validate_structure(make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    1,
+    1,
+    0,
+    1,
+    1,
+    0
+  ])) {
+    None => assert(false),
+    Some(_) => assert(true)
+  }
+}
+
+test "validate_structure allows a custom section anywhere" {
+  // id 0 twice, around a type section: legal, and a rule that treats every
+  // section the same would wrongly reject it.
+  match validate_structure(make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    1,
+    1,
+    0,
+    0,
+    1,
+    0
+  ])) {
+    None => assert(true),
+    Some(_) => assert(false)
+  }
 }

--- a/lib/@vibex/wasm_runtime/wasm_runtime.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime.vibe
@@ -1,3 +1,9 @@
+//# Imports
+
+import @vibex/wasm_parser {
+  next_instruction
+}
+
 //# Values
 
 //# Functions
@@ -557,65 +563,212 @@ fn int_to_string(n: Int) -> String {
   }
 }
 
-/// Disassemble code bytes into human-readable instruction strings
+/// Disassemble code bytes into human-readable instruction strings.
+///
+/// How far each instruction reaches is `@vibex/wasm_parser::next_instruction`'s
+/// answer, not this function's. It used to be both, and the copy here knew
+/// nothing about the prefixed families: on `0xFB 0x02 0x0C 0x01` (struct.get)
+/// it printed "unknown" and then decoded the type and field indices as two more
+/// instructions, yielding a listing that read as plausible wasm and described
+/// nothing in the module. Every gc body this compiler emits hit that path.
+///
+/// An instruction the stepper cannot decode ends the listing with a marker.
+/// Stopping is the only safe move -- resuming at the next byte is exactly the
+/// guess that produced the fiction.
 export fn disassemble(code: Bytes, start: Int, end_pos: Int) -> Array[String] {
   let result = Array::slice([
     ""
   ], 0, 0)
   let mut pc = start
-  while pc < end_pos {
+  let mut stop = false
+  while (pc < end_pos) && !stop {
     let op = code[pc]
-    pc = pc + 1
-    let name = opcode_name(op)
-    if (op == 0x0C) || (op == 0x0D) || (op == 0x10) || (op == 0x20) || (op == 0x21) || (op == 0x22) || (op == 0x23) || (op == 0x24) {
-      let (v, np) = read_uleb128(code, pc)
-      pc = np
-      Array::push(result, "\{name} \{int_to_string(v)}")
-    }
-    else if op == 0x11 {
-      let (ti, np) = read_uleb128(code, pc)
-      let (tab, np2) = read_uleb128(code, np)
-      pc = np2
-      Array::push(result, "\{name} \{int_to_string(ti)} \{int_to_string(tab)}")
-    }
-    else if (op == 0x41) || (op == 0x42) {
-      let (v, np) = read_sleb128(code, pc)
-      pc = np
-      Array::push(result, "\{name} \{int_to_string(v)}")
-    }
-    else if op == 0x02 || op == 0x03 || op == 0x04 {
-      let (bt, np) = read_sleb128(code, pc)
-      pc = np
-      Array::push(result, "\{name} \{int_to_string(bt)}")
-    }
-    else if (op == 0x28) || (op == 0x29) || (op == 0x36) || (op == 0x37) || (op == 0x2D) || (op == 0x3A) || (op == 0x2C) || (op == 0x2E) || (op == 0x2F) || (op == 0x3B) {
-      let (align, np) = read_uleb128(code, pc)
-      let (offset, np2) = read_uleb128(code, np)
-      pc = np2
-      Array::push(result, "\{name} align=\{int_to_string(align)} offset=\{int_to_string(offset)}")
-    }
-    else if (op == 0x3F) || (op == 0x40) {
-      pc = pc + 1
-      Array::push(result, name)
-    }
-    else if op == 0x0E {
-      let (count, np) = read_uleb128(code, pc)
-      pc = np
-      let mut s = "\{name} \{int_to_string(count)}"
-      let mut j = 0
-      while j <= count {
-        let (lbl, np2) = read_uleb128(code, pc)
-        pc = np2
-        s = "\{s} \{int_to_string(lbl)}"
-        j = j + 1
-      }
-      Array::push(result, s)
-    }
-    else {
-      Array::push(result, name)
+    let (_, next_pc) = next_instruction(code, pc, end_pos)
+    if next_pc < 0 {
+      Array::push(result, "?? 0x\{int_to_string(op)} (cannot decode; listing stops here)")
+      stop = true
+    } else {
+      Array::push(result, render_instruction(code, op, pc + 1))
+      pc = next_pc
     }
   }
   result
+}
+
+/// One instruction as text, given the position just after its opcode.
+///
+/// Operand rendering is per-family and lives here; how many bytes the operands
+/// occupy is not, which is the split that matters. A family missing from this
+/// function loses its operands in the output -- it can no longer desync the
+/// stream, because the caller advances by the stepper's answer either way.
+fn render_instruction(code: Bytes, op: Int, after_op: Int) -> String {
+  let mut pc = after_op
+  let name = opcode_name(op)
+  if op == 0xFB {
+    let (sub, _) = read_uleb128(code, pc)
+    gc_opcode_name(sub)
+  }
+  else if op == 0xFC {
+    let (sub, _) = read_uleb128(code, pc)
+    misc_opcode_name(sub)
+  }
+  else if (op == 0x0C) || (op == 0x0D) || (op == 0x10) || (op == 0x20) || (op == 0x21) || (op == 0x22) || (op == 0x23) || (op == 0x24) {
+    let (v, _) = read_uleb128(code, pc)
+    "\{name} \{int_to_string(v)}"
+  }
+  else if op == 0x11 {
+    let (ti, np) = read_uleb128(code, pc)
+    let (tab, _) = read_uleb128(code, np)
+    "\{name} \{int_to_string(ti)} \{int_to_string(tab)}"
+  }
+  else if (op == 0x41) || (op == 0x42) {
+    let (v, _) = read_sleb128(code, pc)
+    "\{name} \{int_to_string(v)}"
+  }
+  else if op == 0x02 || op == 0x03 || op == 0x04 {
+    let (bt, _) = read_sleb128(code, pc)
+    "\{name} \{int_to_string(bt)}"
+  }
+  else if (op == 0x28) || (op == 0x29) || (op == 0x36) || (op == 0x37) || (op == 0x2D) || (op == 0x3A) || (op == 0x2C) || (op == 0x2E) || (op == 0x2F) || (op == 0x3B) {
+    let (align, np) = read_uleb128(code, pc)
+    let (offset, _) = read_uleb128(code, np)
+    "\{name} align=\{int_to_string(align)} offset=\{int_to_string(offset)}"
+  }
+  else if op == 0x0E {
+    let (count, np) = read_uleb128(code, pc)
+    pc = np
+    let mut s = "\{name} \{int_to_string(count)}"
+    let mut j = 0
+    while j <= count {
+      let (lbl, np2) = read_uleb128(code, pc)
+      pc = np2
+      s = "\{s} \{int_to_string(lbl)}"
+      j = j + 1
+    }
+    s
+  } else {
+    name
+  }
+}
+
+/// Names for the `0xFB` (gc) family. vibe's gc backend emits these, so leaving
+/// them as "unknown" would make the disassembler useless on exactly the output
+/// it is most often pointed at.
+fn gc_opcode_name(sub: Int) -> String {
+  if sub == 0 {
+    "struct.new"
+  } else if sub == 1 {
+    "struct.new_default"
+  }
+  else if sub == 2 {
+    "struct.get"
+  } else if sub == 3 {
+    "struct.get_s"
+  }
+  else if sub == 4 {
+    "struct.get_u"
+  } else if sub == 5 {
+    "struct.set"
+  }
+  else if sub == 6 {
+    "array.new"
+  } else if sub == 7 {
+    "array.new_default"
+  }
+  else if sub == 8 {
+    "array.new_fixed"
+  } else if sub == 9 {
+    "array.new_data"
+  }
+  else if sub == 10 {
+    "array.new_elem"
+  } else if sub == 11 {
+    "array.get"
+  }
+  else if sub == 12 {
+    "array.get_s"
+  } else if sub == 13 {
+    "array.get_u"
+  }
+  else if sub == 14 {
+    "array.set"
+  } else if sub == 15 {
+    "array.len"
+  }
+  else if sub == 16 {
+    "array.fill"
+  } else if sub == 17 {
+    "array.copy"
+  }
+  else if sub == 18 {
+    "array.init_data"
+  } else if sub == 19 {
+    "array.init_elem"
+  }
+  else if sub == 20 {
+    "ref.test"
+  } else if sub == 21 {
+    "ref.test null"
+  }
+  else if sub == 22 {
+    "ref.cast"
+  } else if sub == 23 {
+    "ref.cast null"
+  }
+  else if sub == 24 {
+    "br_on_cast"
+  } else if sub == 25 {
+    "br_on_cast_fail"
+  }
+  else if sub == 26 {
+    "any.convert_extern"
+  } else if sub == 27 {
+    "extern.convert_any"
+  }
+  else if sub == 28 {
+    "ref.i31"
+  } else if sub == 29 {
+    "i31.get_s"
+  }
+  else if sub == 30 {
+    "i31.get_u"
+  } else {
+    "gc.unknown"
+  }
+}
+
+/// Names for the `0xFC` family: saturating truncation plus bulk memory/table.
+fn misc_opcode_name(sub: Int) -> String {
+  if sub <= 7 {
+    "i32/i64.trunc_sat"
+  } else if sub == 8 {
+    "memory.init"
+  }
+  else if sub == 9 {
+    "data.drop"
+  } else if sub == 10 {
+    "memory.copy"
+  }
+  else if sub == 11 {
+    "memory.fill"
+  } else if sub == 12 {
+    "table.init"
+  }
+  else if sub == 13 {
+    "elem.drop"
+  } else if sub == 14 {
+    "table.copy"
+  }
+  else if sub == 15 {
+    "table.grow"
+  } else if sub == 16 {
+    "table.size"
+  }
+  else if sub == 17 {
+    "table.fill"
+  } else {
+    "misc.unknown"
+  }
 }
 
 fn mem_load_i8_s(m: Bytes, a: Int) -> Int {

--- a/lib/@vibex/wasm_runtime/wasm_runtime_test.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime_test.vibe
@@ -551,6 +551,49 @@ test "disassemble call" {
   assert(Array::get(lines, 1) == "end")
 }
 
+test "disassemble gc instructions do not desync the stream" {
+  // local.get 0 | struct.get $12 1 | ref.cast null $12 | end
+  //
+  // Before the fold onto next_instruction this produced SIX lines --
+  // "unknown", then "block 12" and "nop" decoded out of struct.get's type and
+  // field indices, then "br 11" out of ref.cast's. None of those instructions
+  // are in this body. Every gc body the compiler emits took that path, so the
+  // count is the assertion that matters here.
+  let code = make_bytes([
+    0x20,
+    0,
+    0xFB,
+    2,
+    12,
+    1,
+    0xFB,
+    23,
+    12,
+    0x0B
+  ])
+  let lines = disassemble(code, 0, 10)
+  assert(Array::length(lines) == 4)
+  assert(Array::get(lines, 0) == "local.get 0")
+  assert(Array::get(lines, 1) == "struct.get")
+  assert(Array::get(lines, 2) == "ref.cast null")
+  assert(Array::get(lines, 3) == "end")
+}
+
+test "disassemble stops rather than guess past an undecodable opcode" {
+  // 0xFD is the simd prefix, whose immediates the stepper does not enumerate.
+  // Resuming at the next byte is the guess that made the old listing fiction.
+  let code = make_bytes([
+    0x01,
+    0xFD,
+    12,
+    0x0B
+  ])
+  let lines = disassemble(code, 0, 4)
+  assert(Array::length(lines) == 2)
+  assert(Array::get(lines, 0) == "nop")
+  assert(String::contains(Array::get(lines, 1), "cannot decode"))
+}
+
 test "exec_module simple add" {
   let wasm = make_bytes([
     0x00,

--- a/scripts/test_wasm_validate_parity.sh
+++ b/scripts/test_wasm_validate_parity.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# `@vibex/wasm_parser::validate_structure` against `wasm-tools validate` (#1133).
+#
+# The contract under test is ONE-SIDED, and the two halves are gated
+# differently on purpose:
+#
+#   HARD   never reject a module wasm-tools accepts. A false rejection means
+#          the validator would refuse a legitimate module, so any occurrence
+#          fails this script.
+#   FLOOR  reject as many as possible of the ones wasm-tools rejects. Structural
+#          validation cannot see a type error, so 100% is not the target and
+#          never will be at this layer -- the floor exists to notice a
+#          REGRESSION in what is already caught.
+#
+# The oracle is wasm-tools, never this implementation. Mutants wasm-tools
+# accepts are dropped rather than assumed invalid: truncating a module to its
+# 8-byte header, for instance, produces a perfectly valid empty module.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CLI_WASM="${1:-${VIBE_VALIDATE_PARITY_CLI_WASM:-}}"
+if [ -z "$CLI_WASM" ]; then
+  CLI_WASM="$(ls -t "$ROOT_DIR"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -1 || true)"
+fi
+[ -n "$CLI_WASM" ] && [ -s "$CLI_WASM" ] || {
+  echo "[validate-parity] FAIL: pass a stage2.wasm or build a selfhost generation" >&2
+  exit 1
+}
+command -v wasm-tools >/dev/null 2>&1 || {
+  echo "[validate-parity] SKIP: wasm-tools not on PATH (it is the oracle)" >&2
+  exit 0
+}
+
+WORK="$ROOT_DIR/_build/validate_parity"
+rm -rf "$WORK"; mkdir -p "$WORK/pos" "$WORK/neg"
+
+# 1. Positive corpus: this compiler's own output, both backends. These are the
+#    modules a false rejection would break, so they are the ones worth using.
+FIXTURES=(
+  fixtures/gc_direct_array_abi_test.vibe
+  fixtures/gc_heap_churn_test.vibe
+  fixtures/gc_native_struct_local_test.vibe
+)
+for f in "${FIXTURES[@]}"; do
+  [ -f "$f" ] || continue
+  b="$(basename "$f" .vibe)"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+    "$f" "_build/validate_parity/pos/$b.lin.wasm" __no_entry__ >/dev/null 2>&1 || true
+  VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+    "$f" "_build/validate_parity/pos/$b.gc.wasm" __no_entry__ >/dev/null 2>&1 || true
+done
+for w in "$WORK"/pos/*.wasm; do
+  [ -e "$w" ] || continue
+  wasm-tools validate --features all "$w" >/dev/null 2>&1 || {
+    echo "[validate-parity] FAIL: the oracle rejects our own output: $w" >&2
+    exit 1
+  }
+done
+
+# 2. Negative corpus: structural corruptions, then labelled BY THE ORACLE.
+python3 - "$WORK" <<'PY'
+import os, sys, glob
+work = sys.argv[1]
+for f in sorted(glob.glob(work + '/pos/*.wasm')):
+    b = bytearray(open(f, 'rb').read())
+    base = os.path.basename(f)[:-5]
+    def emit(tag, data):
+        open(f'{work}/neg/{base}.{tag}.wasm', 'wb').write(bytes(data))
+    emit('trunc', b[:int(len(b) * 0.6)])
+    m = bytearray(b); m[1] = 0x41; emit('magic', m)
+    v = bytearray(b); v[4] = 0x09; emit('version', v)
+    s = bytearray(b); s[9] = 0x7F; emit('sectsize', s)
+    u = bytearray(b) + bytes([0x7A, 0x02, 0x00, 0x00]); emit('unknownsect', u)
+PY
+for w in "$WORK"/neg/*.wasm; do
+  [ -e "$w" ] || continue
+  if wasm-tools validate --features all "$w" >/dev/null 2>&1; then rm -f "$w"; fi
+done
+
+# 3. Our verdict, reached the way a caller would reach it.
+probe="$WORK/probe.wasm"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+  scripts/wasm_validate/probe.vibex "_build/validate_parity/probe.wasm" main >/dev/null 2>&1
+[ -s "$probe" ] || { echo "[validate-parity] FAIL: probe did not compile" >&2; exit 1; }
+
+verdict() {
+  cp "$1" "$ROOT_DIR/_build/val_target.wasm"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+    --invoke main "_build/validate_parity/probe.wasm" 2>&1 | head -1
+}
+
+false_rejections=0
+pos_total=0
+for w in "$WORK"/pos/*.wasm; do
+  [ -e "$w" ] || continue
+  pos_total=$((pos_total + 1))
+  case "$(verdict "$w")" in
+    ACCEPT*) ;;
+    *) false_rejections=$((false_rejections + 1)); echo "[validate-parity] false rejection: $w" >&2 ;;
+  esac
+done
+caught=0
+neg_total=0
+for w in "$WORK"/neg/*.wasm; do
+  [ -e "$w" ] || continue
+  neg_total=$((neg_total + 1))
+  case "$(verdict "$w")" in REJECT*) caught=$((caught + 1)) ;; esac
+done
+rm -f "$ROOT_DIR/_build/val_target.wasm"
+
+if [ "$pos_total" -eq 0 ] || [ "$neg_total" -eq 0 ]; then
+  echo "[validate-parity] FAIL: empty corpus (pos=$pos_total neg=$neg_total)" >&2
+  exit 1
+fi
+if [ "$false_rejections" -ne 0 ]; then
+  echo "[validate-parity] FAIL: $false_rejections/$pos_total modules the oracle accepts were rejected" >&2
+  exit 1
+fi
+if [ "$caught" -ne "$neg_total" ]; then
+  echo "[validate-parity] FAIL: caught $caught/$neg_total structural corruptions (was $neg_total/$neg_total)" >&2
+  exit 1
+fi
+echo "[validate-parity] ok: $pos_total/$pos_total accepted, $caught/$neg_total structural corruptions rejected"
+echo "[validate-parity] note: type-level invalidity is NOT covered by this layer -- measured 0/14 on"
+echo "[validate-parity]       bad-opcode and out-of-range-type-index mutants, which is expected until"
+echo "[validate-parity]       the operand-stack layer exists (#1745 (5))."

--- a/scripts/test_wasm_validate_parity.sh
+++ b/scripts/test_wasm_validate_parity.sh
@@ -135,6 +135,38 @@ for w in "$WORK"/neg/*.wasm; do
 done
 rm -f "$ROOT_DIR/_build/val_target.wasm"
 
+# 4. Coverage, which the catch ratio does NOT measure. A stepper that bails on
+#    the first opcode it does not know still catches mutants -- the corruption
+#    is usually before the bail -- while reading almost nothing. Requiring the
+#    walk to reach the end of every body in our own output is the check that
+#    actually noticed 0xFD, and a one-byte valtype assumption that started three
+#    bodies inside their own local declarations.
+walk="$WORK/walk.wasm"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+  scripts/wasm_validate/walk_probe.vibex "_build/validate_parity/walk.wasm" main >/dev/null 2>&1
+[ -s "$walk" ] || { echo "[validate-parity] FAIL: walk probe did not compile" >&2; exit 1; }
+walk_bodies=0
+walk_stopped=0
+for w in "$WORK"/pos/*.wasm; do
+  [ -e "$w" ] || continue
+  cp "$w" "$ROOT_DIR/_build/val_target.wasm"
+  read -r b s <<<"$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+    --invoke main "_build/validate_parity/walk.wasm" 2>/dev/null | head -1)"
+  walk_bodies=$((walk_bodies + ${b:-0}))
+  walk_stopped=$((walk_stopped + ${s:-0}))
+done
+rm -f "$ROOT_DIR/_build/val_target.wasm"
+if [ "$walk_bodies" -eq 0 ]; then
+  echo "[validate-parity] FAIL: walk probe reported no function bodies" >&2
+  exit 1
+fi
+if [ "$walk_stopped" -ne 0 ]; then
+  echo "[validate-parity] FAIL: the stepper gave up inside $walk_stopped/$walk_bodies of our own" >&2
+  echo "[validate-parity]       function bodies, so validation does not reach past that point" >&2
+  exit 1
+fi
+
 if [ "$pos_total" -eq 0 ] || [ "$neg_total" -eq 0 ]; then
   echo "[validate-parity] FAIL: empty corpus (pos=$pos_total neg=$neg_total)" >&2
   exit 1
@@ -152,6 +184,7 @@ if [ "$caught" -lt "$floor_num" ]; then
   exit 1
 fi
 echo "[validate-parity] ok: $pos_total/$pos_total accepted (zero false rejections), $caught/$neg_total rejected"
+echo "[validate-parity]     instruction walk reached the end of $walk_bodies/$walk_bodies function bodies"
 echo "[validate-parity] note: what remains uncaught needs operand-stack typing, which this layer does"
 echo "[validate-parity]       not do (#1745 (5)). A module that is well-formed but ill-TYPED still"
 echo "[validate-parity]       passes here."

--- a/scripts/test_wasm_validate_parity.sh
+++ b/scripts/test_wasm_validate_parity.sh
@@ -38,10 +38,18 @@ rm -rf "$WORK"; mkdir -p "$WORK/pos" "$WORK/neg"
 
 # 1. Positive corpus: this compiler's own output, both backends. These are the
 #    modules a false rejection would break, so they are the ones worth using.
+#
+#    Pick fixtures for the FEATURES they make the backend emit, not for
+#    variety. A corpus of three gc fixtures passed this gate while the
+#    validator rejected every module with an exception tag -- the section order
+#    is not ascending by id there (13 sits between memory and global), and
+#    nothing in the corpus had one. Codex caught it in review; the corpus
+#    should have.
 FIXTURES=(
   fixtures/gc_direct_array_abi_test.vibe
   fixtures/gc_heap_churn_test.vibe
   fixtures/gc_native_struct_local_test.vibe
+  fixtures/cheatsheet_effects_test.vibe
 )
 for f in "${FIXTURES[@]}"; do
   [ -f "$f" ] || continue

--- a/scripts/test_wasm_validate_parity.sh
+++ b/scripts/test_wasm_validate_parity.sh
@@ -75,6 +75,28 @@ for f in sorted(glob.glob(work + '/pos/*.wasm')):
     v = bytearray(b); v[4] = 0x09; emit('version', v)
     s = bytearray(b); s[9] = 0x7F; emit('sectsize', s)
     u = bytearray(b) + bytes([0x7A, 0x02, 0x00, 0x00]); emit('unknownsect', u)
+
+    # Harder class: corruption that leaves the section framing intact, so only
+    # a walk INSIDE a section can see it. Kept in the same corpus rather than a
+    # separate one -- a floor that silently excluded the hard cases would read
+    # as full parity.
+    def sections(buf):
+        p = 8
+        while p < len(buf):
+            sid = buf[p]; p += 1
+            n = 0; sh = 0
+            while True:
+                x = buf[p]; p += 1; n |= (x & 0x7f) << sh; sh += 7
+                if not x & 0x80: break
+            yield sid, p, p + n
+            p += n
+    for sid, st, en in sections(b):
+        if sid == 10:
+            m = bytearray(b); m[st + (en - st) // 2] = 0x06
+            emit('badopcode', m)
+        if sid == 3:
+            m = bytearray(b); m[st + 1] = 0x7E
+            emit('badtypeidx', m)
 PY
 for w in "$WORK"/neg/*.wasm; do
   [ -e "$w" ] || continue
@@ -121,11 +143,15 @@ if [ "$false_rejections" -ne 0 ]; then
   echo "[validate-parity] FAIL: $false_rejections/$pos_total modules the oracle accepts were rejected" >&2
   exit 1
 fi
-if [ "$caught" -ne "$neg_total" ]; then
-  echo "[validate-parity] FAIL: caught $caught/$neg_total structural corruptions (was $neg_total/$neg_total)" >&2
+# The floor is a RATIO, not a total: the corpus size moves with the fixtures.
+# It exists to catch a regression in what is already caught, not to assert
+# parity -- reaching it is not the same as validating.
+floor_num=$((neg_total * 90 / 100))
+if [ "$caught" -lt "$floor_num" ]; then
+  echo "[validate-parity] FAIL: caught $caught/$neg_total, below the $floor_num floor" >&2
   exit 1
 fi
-echo "[validate-parity] ok: $pos_total/$pos_total accepted, $caught/$neg_total structural corruptions rejected"
-echo "[validate-parity] note: type-level invalidity is NOT covered by this layer -- measured 0/14 on"
-echo "[validate-parity]       bad-opcode and out-of-range-type-index mutants, which is expected until"
-echo "[validate-parity]       the operand-stack layer exists (#1745 (5))."
+echo "[validate-parity] ok: $pos_total/$pos_total accepted (zero false rejections), $caught/$neg_total rejected"
+echo "[validate-parity] note: what remains uncaught needs operand-stack typing, which this layer does"
+echo "[validate-parity]       not do (#1745 (5)). A module that is well-formed but ill-TYPED still"
+echo "[validate-parity]       passes here."

--- a/scripts/wasm_validate/probe.vibex
+++ b/scripts/wasm_validate/probe.vibex
@@ -1,0 +1,14 @@
+// Print one verdict for the module at _build/val_target.wasm, for the parity
+// harness (scripts/test_wasm_validate_parity.sh) to compare against
+// `wasm-tools validate`. Kept as a program rather than folded into the harness
+// so the thing under test is reached exactly the way a caller would reach it.
+import @vibex/wasm_parser {
+  validate_structure
+}
+
+fn main with Fs {
+  match validate_structure(Fs::read_bytes("_build/val_target.wasm")) {
+    None => println("ACCEPT"),
+    Some(reason) => println(String::concat("REJECT ", reason))
+  }
+}

--- a/scripts/wasm_validate/walk_probe.vibex
+++ b/scripts/wasm_validate/walk_probe.vibex
@@ -1,0 +1,50 @@
+// Print `<bodies> <stopped>` for the module at _build/val_target.wasm: how many
+// function bodies it has, and how many of them the instruction stepper could
+// NOT walk to the end.
+//
+// The parity harness gates on stopped == 0 over this compiler's own output.
+// That is a sharper measure than the mutant-catch ratio: a stepper that bails
+// on the first instruction it does not know still catches plenty of mutants
+// (the corruption is often before the bail), while covering almost nothing.
+// Measured this way the gap was obvious -- 0xFD stopped 6 to 9 bodies per
+// module, and a one-byte assumption in get_code_body_range started 3 more
+// inside their own local declarations.
+import @vibex/wasm_parser {
+  get_code_body_range, list_sections, next_instruction, parse_code_entries
+}
+
+fn main with Fs {
+  let bytes = Fs::read_bytes("_build/val_target.wasm")
+  let secs = list_sections(bytes)
+  let mut i = 0
+  let mut bodies = 0
+  let mut stopped = 0
+  while i < Array::length(secs) {
+    let (id, off, size) = Array::get(secs, i)
+    if id == 10 {
+      let entries = parse_code_entries(bytes, off, size)
+      let mut k = 0
+      while k < Array::length(entries) {
+        let (body_off, body_size, _) = Array::get(entries, k)
+        let (cs, ce) = get_code_body_range(bytes, body_off, body_size)
+        bodies = bodies + 1
+        let mut pc = cs
+        let mut done = false
+        while (pc < ce) && !done {
+          let (_, np) = next_instruction(bytes, pc, ce)
+          if np < 0 {
+            stopped = stopped + 1
+            done = true
+          } else {
+            pc = np
+          }
+        }
+        k = k + 1
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  println("\{bodies} \{stopped}")
+}


### PR DESCRIPTION
#1795 の続き。あちらは「typed reference を 1 バイトと決め打ちしていた」バグ修正でしたが、
調べていくうちに**もっと構造的な問題**が見えたので、そちらを実装しています。

`used_by_codegen()` の手動キュレーションが参照レーン (#1541 / #1722) の着地でずれていた —
これは「宣言がバイナリを説明しなくなる」の実例で、**#1133 の主題そのもの**でした。
再発防止は「気をつける」ではなく「バイナリから導く」しかないので、既存の
`@vibex/wasm_parser` を読み取り側の土台として育てています。**新規デコーダは作りません** —
wasm 読み取りが 2 実装になるのを避けるためです。

## 何が入るか

### 1. `scan_features` — バイナリから proposal キーを導く

型形式 (struct/array/`sub`) と opcode prefix (`0xFB` / `0xFC` / `0xFD` / `0xFE`)、
typed reference の出現から、そのモジュールが要求する proposal を返します。
`used_by_codegen()` と突き合わせれば、今回のずれは**自動検出できました**。

### 2. `validate_structure` — セクション枠の検証

magic / version / セクション id / セクションサイズが本体を飛び出さないか / 重複 / 末尾の余り。

### 3. `next_instruction` + `validate_code_body` — 命令列の走査

セクション枠だけを見ていると、**枠は正しいが中身が壊れている**モジュールが通ります。
`next_instruction` は 1 命令ぶんの opcode と即値をデコードして次の pc を返し、
`validate_code_body` がそれを本体末尾まで歩きます。
`validate_function_type_indices` は function セクションの型インデックスを型セクションの
実数と突き合わせます。

### 4. 走査を最後まで届かせる + disassembler をそこへ寄せる

ここが最新の追加で、**「どこまで読めているか」を測ったら出てきたもの**です。詳細は下記。

## `wasm-tools validate` との互換性は、レビューではなく計測で担保する

`scripts/test_wasm_validate_parity.sh` を追加しました。**oracle は常に `wasm-tools`** で、
この実装ではありません。契約は**片側**で、三つを別々にゲートしています:

| | 内容 | 扱い |
|---|---|---|
| **HARD** | wasm-tools が受理するものを拒否しない | 1 件でも fail |
| **COVERAGE** | 自分のコンパイラ出力の**全 body** を命令列の末尾まで歩けること | 1 body でも届かなければ fail |
| **FLOOR** | wasm-tools が拒否するものを可能な限り拒否する | 比率で床を敷き、**退行の検知**に使う |

100% は**この層の目標ではありません** — 操作スタックの型検査 (#1745 (5)) をしないので、
well-formed だが ill-typed なモジュールは通ります。

**COVERAGE を分けて測るのが効きました。** 捕捉率は網羅を見ません — 知らない opcode で
即座に降りるステッパでも、変異が降りる手前にあれば普通に捕まえるので、
**ほとんど何も読んでいなくても数字が出ます**。「自分の出力の全 body を最後まで歩けるか」は
それを見ます。以下は**どちらもこの計測が見つけたもの**で、捕捉率は最初から気づきませんでした。

現状:

```
[validate-parity] ok: 6/6 accepted (zero false rejections), 39/40 rejected
[validate-parity]     instruction walk reached the end of 402/402 function bodies
```

正の corpus はこのコンパイラ自身の出力 (linear / gc 両 backend)。偽拒否が壊すのはまさに
それなので、それ以外を使う理由がありません。負の corpus は変異させた上で **oracle に
ラベルを貼らせます** — 8 バイトのヘッダまで切り詰めたモジュールは「空だが完全に valid」なので、
変異 = 不正と仮定すると偽の負例が混ざります。

## 計測が見つけたもの

### `get_code_body_range` が **コードの開始位置**を 1 バイト手前にしていた

ローカル宣言の valtype を 1 バイトと決め打ちしていました。`(ref null $12)` は `0x63` +
型インデックスの **2 バイト**なので、typed-ref ローカルを持つ gc body では
**コード開始位置が型インデックスの上に乗り**、最初に「命令」として読まれたのが
ローカル数でした。**#1795 が型セクションから取り除いたのと同じ決め打ち**が、
「コードがどこにあるか」を決める関数に残っていた形です。

しかもこれは parse だけの話ではありません — `extract_code_body` はその範囲を
**インタプリタに渡します**。

### `next_instruction` が prefix 系で降りていた → **0xFD が本体**

`0xFB` (gc) / `0xFC` (bulk memory) / `0xFD` (simd) / `f32.const` / `f64.const` /
参照命令 / 型ベクタ付き `select` が未対応でした。中でも **0xFD が 1 モジュールあたり
6〜9 body を止めていました** — `simd_skip_ws` などの builtin 経由で v128 opcode が
実際に出ています (`used_by_codegen()` の `simd` 宣言自体は正しかった)。

これらを入れて、走査は **全 body の ~88% → 402/402** になりました。

### disassembler が gc 命令で**もっともらしい嘘**を出していた

`@vibex/wasm_runtime::disassemble` は命令長の知識を独自に持っていて、prefix 系を
知りませんでした。`0xFB 0x02 0x0C 0x01` (struct.get) に対して:

```
修正前  local.get 0 / unknown / block 12 / nop / unknown / unknown / br 11   (7 行)
修正後  local.get 0 / struct.get / ref.cast null / end                        (4 行)
```

`block 12` も `nop` も `br 11` も**この body に存在しません** — struct.get の型/フィールド
インデックスと ref.cast の型インデックスを命令として読んだものです。gc backend が出す
body は**全部**この経路を通っていました。`next_instruction` に寄せて、命令長の知識を
1 箇所にしています。デコードできない opcode では**次のバイトから再開せずに停止**します —
その再開こそが嘘を作っていた推測です。

### 偽拒否は 2 件、どれもコードを読んで見つけたのではない

- **`depth` の初期値**。0 から始めると関数本体の暗黙ブロックを閉じる `end` が
  「余分な end」に見え、**valid なモジュール 8/8 を拒否**しました。正しくは 1
- **予約 opcode の範囲**。当初 `0xFB` prefix を予約扱いにしていて 4 件、
  `0xD3..0xFA` を予約扱いにしていて 1 件の偽拒否。**どちらも gc /
  function-references の opcode で、このコンパイラが今日出しているもの**です。
  最終的に `0x06..0x0A` と `0x27` だけに絞りました

## 検証

- `@vibex/wasm_parser` / `@vibex/wasm_runtime` / `@vibex/wasm_wat_encoder` 全スイート green
  (typed ref のパラメータ/結果/ローカル、typed-ref ローカルの body 開始位置、
  gc 命令で desync しないこと、デコード不能で停止すること、`scan_features`、
  `validate_structure` を追加)
- `scripts/test_wasm_validate_parity.sh` green (上記の数字)
- `check_vibe_fmt` / `lint_review_regressions` / `lint_architecture_debt` すべて green
- `origin/main` (b5a768ac9) へ rebase 済み、コンフリクトなし

## follow-up (この PR では触っていません)

- `scan_features` を `wasm_feature_levels.vibex` の `--scan` モードとして配線すると、
  #1133 の「ずれを検知する」ループが閉じます
- prefix 系の**オペランド表示**。`struct.get` の型/フィールドインデックスは今は出しません
  (命令長の知識を 1 箇所に保つため)。`next_instruction` の隣に即値を返す関数を置けば、
  renderer から形の知識を完全に無くせます
- `0xFE` (atomics) は未対応のまま。このコンパイラは出していません
- 本物の validation (操作スタックの型検査) は #1745 (5)。別スライス
- `bash scripts/vibe_run.sh <file>.vibex` が現行 main で動きません (seed が現行 prelude
  contract に追いついておらず、`set -euo pipefail` でメッセージも出ず exit 1)。別 issue 化が妥当

Refs #1133, #1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN