### PR TITLE
feat(wasm): 宣言をバイナリから検証する — #1133 の本体

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,15 @@ jobs:
             viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-
       - name: wasm-gc heap accounting + validation
         run: bash scripts/test_gc_heap_accounting.sh "$PWD/_build/_ci_gc_gen/stage2.wasm"
+      # Runs HERE and not in a gate of its own for the same two reasons the job
+      # exists: it needs wasm-tools (its oracle) and a stage2, both of which
+      # this job already has. It checks two things about our own output --
+      # that @vibex/wasm_parser's validator never rejects what wasm-tools
+      # accepts and reads every instruction, and that used_by_codegen() still
+      # names every proposal the output requires. Registering the pkf task
+      # without this step would leave both measurements running nowhere.
+      - name: wasm validator parity + feature-declaration scan
+        run: bash scripts/test_wasm_validate_parity.sh "$PWD/_build/_ci_gc_gen/stage2.wasm"
 
   # The 467-file selfhost unit-test battery (#531/#535), weight-balanced into
   # parallel shards (scripts/unit_test_weights.tsv drives the LPT partition

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1189,6 +1189,12 @@ local releaseCheck = new Task {
     vibeMdTutorialGated
     checkExamplesTypecheck
     checkPlaygroundPresets
+    // Skips itself when wasm-tools is absent (it is the oracle), so this
+    // cannot break a machine that lacks it -- but on one that has it, local
+    // sign-off catches an undeclared proposal before CI does. The enforcing
+    // copy is the gc-gate job in .github/workflows/ci.yml, which installs
+    // wasm-tools; a task that is only registered runs nowhere.
+    testWasmValidateParity
   }
 }
 

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -856,6 +856,20 @@ local testGcHeapAccounting = new Task {
   deps { selfhostGeneration }
 }
 
+// Two questions about this compiler's own wasm output, sharing one corpus
+// because compiling the fixtures is the expensive part:
+//   - does @vibex/wasm_parser's validator agree with `wasm-tools validate`
+//     (never rejecting what it accepts), and does it read every instruction?
+//   - does used_by_codegen() still name every proposal the output requires?
+// Skips itself when wasm-tools is absent, since it is the oracle.
+local testWasmValidateParity = new Task {
+  name = "test-wasm-validate-parity"
+  cmd = "bash scripts/test_wasm_validate_parity.sh \"$@\""
+  acceptsArgs = true
+  cache = false
+  deps { selfhostGeneration }
+}
+
 local testSelfhostCliCore = scriptTask("test-cli-core", "scripts/test_cli_core.sh")
 // `test-wasm-vibe-host-runner` retired with the MoonBit host: the test
 // compiled its fixtures with `_build/native/**/vibe.exe` before driving
@@ -1295,6 +1309,7 @@ tasks {
   testGcSelfbuild
   testGcNativeAllocProbe
   testGcHeapAccounting
+  testWasmValidateParity
   testRcEntryResultParity
   testSelfhostCliCore
   testVibeRunSingleInvoke

--- a/docs/wasm/feature-levels.expected.json
+++ b/docs/wasm/feature-levels.expected.json
@@ -2558,6 +2558,14 @@
     }
   },
   "usedByCodegen": {
+    "bulkMemory": {
+      "engineSets": {
+        "v8": true,
+        "web-baseline": true
+      },
+      "evidence": "linear + gc backends: memory.copy (0xFC 10) and memory.fill (0xFC 11) from emit_memory_copy/emit_memory_fill (codegen/common_extractors/common_extractors.vibe), reached from ~18 builtin bodies -- string/array copies and zero-initializing a fresh hash-index table in one instruction instead of a store loop. FOUND BY --scan, not by hand: it was emitted and undeclared",
+      "hostStatus": "supported"
+    },
     "exceptionsFinal": {
       "engineSets": {
         "v8": true,

--- a/docs/wasm/feature-levels.md
+++ b/docs/wasm/feature-levels.md
@@ -53,18 +53,19 @@ compiler-host 水準は engine set を使わず、`Wasmtime` 単独行を単に�
 
 ## 現状: vibe codegen が実際に使っている proposal
 
-`scripts/wasm_feature_levels.vibex` の `used_by_codegen()` に手動でキュレーション
-（コード grep による証拠ベース、**wasm バイナリの opcode 走査による検証では
-ない** — 下記「未実装のスコープ」参照）:
+`scripts/wasm_feature_levels.vibex` の `used_by_codegen()` に宣言する
+（証拠はコード grep、**照合は生成された wasm バイナリに対して行う** —
+下記「`--scan`」参照）:
 
 | proposal | 使用箇所 | 条件 |
 |---|---|---|
+| `bulkMemory` | linear + gc backend: `memory.copy` / `memory.fill` (`codegen/common_extractors/common_extractors.vibe` の `emit_memory_copy` / `emit_memory_fill`) | builtin body 約 18 箇所 — 文字列/配列コピー、hash index table の一括ゼロ初期化 |
 | `gc` | gc backend: RC cell / non-escaping local record の `struct.new/get/set`、reference lane の `array.new_default/get/set/len`、およびそれらの struct/array 型定義 (`codegen/gc/backend_body.vibe`, `codegen/gc/backend_expr.vibe`) | wasm-gc backend 選択時のみ (release 既定は linear) |
 | `exceptionsFinal` | linear + gc backend: `try_table` + tag section (`codegen/wasi/linked_compile.vibe`, `codegen/gc/backend_expr.vibe`, #538/#721) | module が effect/throw を使うときだけ emit（純計算 module はゼロ） |
 | `simd` | linear + gc backend: v128 opcode (`codegen/wasm_emit/simd.vibe`) | `simd_skip_ws` 等、特定 builtin 経由でのみ |
 | `typedFunctionReferences` | gc backend: private callee の typed parameter/result、typed local、および reference lane join の type-index blocktype (`codegen/gc/backend_body.vibe`, `codegen/gc/backend_expr.vibe`) | wasm-gc backend で reference lane が成立するときのみ |
 
-2026-08-15 時点のスナップショットでは、この4つはいずれも `v8` /
+2026-08-15 時点のスナップショットでは、この5つはいずれも `v8` /
 `web-baseline` 両水準で **safe**（`bash scripts/vibe_run.sh scripts/wasm_feature_levels.vibex`
 の出力参照）。tail-call proposal (`return_call`) は compiler-host 側
 (viberun) のみが有効化しており、**codegen は self-tail-call を wasm
@@ -96,10 +97,45 @@ bash scripts/vibe_run.sh scripts/wasm_feature_levels.vibex -- --update-expected
 で運用し、`USED_BY_CODEGEN` の proposal が実際に non-safe に転落した場合の
 対応フローができてから gate 化を検討する。
 
-## 未実装のスコープ (フォローアップ)
+## `--scan`: 宣言をバイナリと突き合わせる (#1133)
 
-`USED_BY_CODEGEN` は **ソースコードの grep による手動キュレーション**であり、
-実際に出力された `.wasm` バイナリの opcode を静的に走査して自動検出した
-ものではない。真の enforcement (「宣言した level を超える proposal を
-codegen が使ったら fail する」) には wasm バイナリのセクション/opcode
-パーサが要る。スコープが大きいため本パスでは見送り、追跡 issue を切った: #1133。
+`used_by_codegen()` は手で書く。手で書いたものは**ずれる** — gc の参照レーンが
+typed function signature を出し始めたとき、気づいたのはバイナリを手で読んだ
+ときでした。`--scan` はこれをバイナリ側から検査します。
+
+```bash
+vibe run scripts/wasm_feature_levels.vibex -- --scan path/to/*.wasm
+```
+
+`@vibex/wasm_parser` の `scan_features_checked` が、型セクション・セクションの
+有無・**命令列の走査**から proposal を導き、`used_by_codegen()` と照合します。
+命令は「バイト列を prefix で grep する」のではなく `next_instruction` で
+**1 命令ずつ歩いて**判定します — 素朴な走査は opcode と、たまたま同じ値を持つ
+即値を区別できないので、使っていない proposal を報告してしまう。宣言と
+突き合わせる道具としては、それは不完全であるより悪い。
+
+判定は**非対称**で、そこが要点です:
+
+| | 扱い |
+|---|---|
+| 出しているのに宣言に無い | **fail**。docs から選んだターゲットが生成 wasm を拒否しうる |
+| 宣言にあるのに出ていない | 報告のみ。その corpus に該当する入力が無いだけかもしれない |
+
+**走査が最後まで届かなかったモジュールは比較しません。** 得られた feature は
+真の部分集合なので、宣言と比べると「宣言が多すぎる」と読めてしまう —
+結論が逆になります。何も言わない方が正直です。
+
+`pkf run test-wasm-validate-parity` から
+`scripts/test_wasm_validate_parity.sh` 経由で走ります（fixture のコンパイルが
+高コストなので、validator の parity 測定と corpus を共有しています）。
+
+初回実行で **`bulkMemory` が出ているのに宣言に無い**ことを検出しました
+(`memory.copy` / `memory.fill`、builtin body 約 18 箇所)。両 engine set で
+supported なので移植性の実害はありませんでしたが、宣言がバイナリを説明して
+いなかったのは事実です。
+
+### 残っているもの
+
+- `memory64` の i64 addressing は未判定 (このコンパイラは出していない)
+- `0xFE` (atomics) は `next_instruction` が未対応なので、使い始めたら
+  「走査が届かない」側に落ちる — 黙って見落とすのではなく skip として出る

--- a/lib/@vibex/wasm_parser/index.vpkg
+++ b/lib/@vibex/wasm_parser/index.vpkg
@@ -39,6 +39,7 @@ fn read_init_expr(bytes: Bytes, offset: Int, end_pos: Int) -> (Int, Int, Int)
 fn parse_types(bytes: Bytes, offset: Int, size: Int) -> Array[(Array[Int], Array[Int])]
 fn parse_type_forms(bytes: Bytes, offset: Int, size: Int) -> Array[Int]
 fn scan_features(wasm_bytes: Bytes) -> Array[String]
+fn scan_features_checked(wasm_bytes: Bytes) -> (Array[String], Bool)
 fn next_instruction(code: Bytes, pc: Int, end_pos: Int) -> (Int, Int)
 fn validate_code_body(code: Bytes, start: Int, end_pos: Int) -> Option[String]
 fn validate_structure(wasm_bytes: Bytes) -> Option[String]

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -1596,6 +1596,19 @@ export fn scan_features_checked(wasm_bytes: Bytes) -> (Array[String], Bool) {
               else if (op == 0x12) || (op == 0x13) {
                 uses_tail_call = true
               }
+              else if op == 0x14 {
+                // call_ref: function-references, no tail call.
+                uses_typed_ref = true
+              }
+              else if op == 0x15 {
+                // return_call_ref straddles two proposals: the instruction is
+                // specified by function-references, but it IS a tail call and
+                // engines gate it on tail-call support. Reporting only one of
+                // the two would let a module through with an undeclared
+                // requirement, so report both.
+                uses_typed_ref = true
+                uses_tail_call = true
+              }
               else if op == 0x1F {
                 uses_exceptions = true
               }

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -1477,27 +1477,46 @@ export fn module_summary(bytes: Bytes) -> String {
 /// signatures, and nothing noticed -- the drift was found by reading a binary
 /// by hand. This answers the same question FROM the binary.
 ///
-/// Deliberately structural only. Everything below is decided by the type
-/// section, a section's presence, or a declaration -- never by scanning code
-/// bytes for opcode prefixes. A naive byte scan cannot tell an opcode from an
-/// immediate that happens to share its value, and would report proposals the
-/// module does not use; being wrong in that direction is worse than being
-/// incomplete, because the whole point is to be trusted against a hand-curated
-/// list. `simd`, `tailCall` and `bulkMemory` therefore need an instruction
-/// walker and are NOT reported yet -- see the package README note.
+/// Decided by the type section, a section's presence, a declaration, or an
+/// instruction reached by WALKING the code -- never by scanning code bytes for
+/// opcode prefixes. A scan cannot tell an opcode from an immediate that happens
+/// to share its value, and would report proposals the module does not use;
+/// being wrong in that direction is worse than being incomplete, because the
+/// whole point is to be trusted against a hand-curated list. The instruction
+/// features here (`simd`, `tailCall`, `bulkMemory`, `saturatedFloatToInt`)
+/// waited for `next_instruction` for exactly that reason.
+///
+/// A partial answer is still possible -- see `scan_features_checked`, which
+/// reports whether every body was walked. Callers comparing against a
+/// declaration should use that one: an under-report reads as "the declaration
+/// claims too much", which is the opposite of the truth.
 export fn scan_features(wasm_bytes: Bytes) -> Array[String] {
+  let (found, _) = scan_features_checked(wasm_bytes)
+  found
+}
+
+/// `scan_features` plus whether every function body was walked to its end.
+///
+/// False means some body stopped at an instruction the stepper cannot decode,
+/// so the feature list is a SUBSET of what the module requires.
+export fn scan_features_checked(wasm_bytes: Bytes) -> (Array[String], Bool) {
   let found = Array::slice([
     ""
   ], 0, 0)
   if !validate_magic(wasm_bytes) {
-    found
+    (found, false)
   } else {
     let sections = list_sections(wasm_bytes)
     let mut uses_gc_types = false
     let mut uses_typed_ref = false
     let mut uses_ref_types = false
-    let mut has_tag_section = false
     let mut memory_count = 0
+    let mut uses_simd = false
+    let mut uses_tail_call = false
+    let mut uses_exceptions = false
+    let mut uses_bulk_memory = false
+    let mut uses_sat_float = false
+    let mut complete = true
     let mut i = 0
     while i < Array::length(sections) {
       let (sid, off, sz) = Array::get(sections, i)
@@ -1531,7 +1550,7 @@ export fn scan_features(wasm_bytes: Bytes) -> Array[String] {
         }
       }
       else if sid == 13 {
-        has_tag_section = true
+        uses_exceptions = true
       }
       else if sid == 5 {
         memory_count = Array::length(parse_memories(wasm_bytes, off, sz))
@@ -1540,7 +1559,7 @@ export fn scan_features(wasm_bytes: Bytes) -> Array[String] {
         let entries = parse_code_entries(wasm_bytes, off, sz)
         let mut e = 0
         while e < Array::length(entries) {
-          let (_, _, locals) = Array::get(entries, e)
+          let (body_off, body_size, locals) = Array::get(entries, e)
           let mut l = 0
           while l < Array::length(locals) {
             let (_, lt) = Array::get(locals, l)
@@ -1556,6 +1575,43 @@ export fn scan_features(wasm_bytes: Bytes) -> Array[String] {
             }
             l = l + 1
           }
+          // Instruction-level features. This walks with next_instruction rather
+          // than scanning bytes: a scan cannot tell an opcode from an immediate
+          // that happens to share its value, and would report proposals the
+          // module does not use. A body the walk cannot finish is not guessed
+          // at -- it clears `complete`, and the caller decides what an
+          // incomplete answer is worth.
+          let (cs, ce) = get_code_body_range(wasm_bytes, body_off, body_size)
+          let mut pc = cs
+          let mut done = false
+          while (pc < ce) && !done {
+            let (op, np) = next_instruction(wasm_bytes, pc, ce)
+            if np < 0 {
+              complete = false
+              done = true
+            } else {
+              if op == 0xFD {
+                uses_simd = true
+              }
+              else if (op == 0x12) || (op == 0x13) {
+                uses_tail_call = true
+              }
+              else if op == 0x1F {
+                uses_exceptions = true
+              }
+              else if op == 0xFC {
+                let (sub, _) = read_uleb128(wasm_bytes, pc + 1)
+                if sub <= 7 {
+                  uses_sat_float = true
+                } else {
+                  uses_bulk_memory = true
+                }
+              } else {
+                ()
+              }
+              pc = np
+            }
+          }
           e = e + 1
         }
       } else {
@@ -1565,7 +1621,12 @@ export fn scan_features(wasm_bytes: Bytes) -> Array[String] {
     }
     // Alphabetical, so the result can be compared against a sorted declaration
     // without the caller sorting first.
-    if has_tag_section {
+    if uses_bulk_memory {
+      Array::push(found, "bulkMemory")
+    } else {
+      ()
+    }
+    if uses_exceptions {
       Array::push(found, "exceptionsFinal")
     } else {
       ()
@@ -1588,12 +1649,27 @@ export fn scan_features(wasm_bytes: Bytes) -> Array[String] {
     } else {
       ()
     }
+    if uses_sat_float {
+      Array::push(found, "saturatedFloatToInt")
+    } else {
+      ()
+    }
+    if uses_simd {
+      Array::push(found, "simd")
+    } else {
+      ()
+    }
+    if uses_tail_call {
+      Array::push(found, "tailCall")
+    } else {
+      ()
+    }
     if uses_typed_ref {
       Array::push(found, "typedFunctionReferences")
     } else {
       ()
     }
-    found
+    (found, complete)
   }
 }
 

--- a/lib/@vibex/wasm_parser/wasm_parser_test.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser_test.vibe
@@ -38,6 +38,7 @@ import ./wasm_parser.vibe {
   read_init_expr,
   read_version,
   scan_features,
+  scan_features_checked,
   section_name,
   validate_code_body,
   validate_magic,
@@ -4384,4 +4385,72 @@ test "parse_type_forms counts every type inside a recursive group" {
   assert(Array::length(forms) == 2)
   assert(Array::get(forms, 0) == 0x60)
   assert(Array::get(forms, 1) == 0x60)
+}
+
+test "scan_features finds tailCall from return_call_ref, not just return_call" {
+  // `return_call_ref` (0x15) is specified by function-references, but it IS a
+  // tail call and engines gate it on tail-call support. Reporting only one of
+  // the two requirements lets a module through with an undeclared proposal --
+  // which is the exact failure --scan exists to prevent.
+  //
+  // header | function(3) size=2 [1, 0] | code(10) size=6
+  //          [1, body size=4: locals=0, return_call_ref 0, end]
+  let m = make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    3,
+    2,
+    1,
+    0,
+    10,
+    6,
+    1,
+    4,
+    0,
+    0x15,
+    0,
+    0x0B
+  ])
+  let fs = scan_features(m)
+  assert(features_contain(fs, "tailCall"))
+  assert(features_contain(fs, "typedFunctionReferences"))
+}
+
+test "scan_features_checked reports an incomplete walk rather than a short list" {
+  // 0xFE (atomics) is not decoded by next_instruction. The feature list from
+  // such a module is a SUBSET of the truth, and a subset compared against a
+  // declaration reads as "the declaration claims too much" -- backwards. The
+  // flag is what lets --scan decline to compare instead.
+  //
+  // header | function(3) size=2 | code(10) size=6 [1, size=4: locals=0, 0xFE .., end]
+  let m = make_bytes([
+    0,
+    97,
+    115,
+    109,
+    1,
+    0,
+    0,
+    0,
+    3,
+    2,
+    1,
+    0,
+    10,
+    6,
+    1,
+    4,
+    0,
+    0xFE,
+    0,
+    0x0B
+  ])
+  let (_, complete) = scan_features_checked(m)
+  assert(!complete)
 }

--- a/scripts/test_wasm_validate_parity.sh
+++ b/scripts/test_wasm_validate_parity.sh
@@ -175,6 +175,23 @@ if [ "$walk_stopped" -ne 0 ]; then
   exit 1
 fi
 
+# 5. #1133 proper: does used_by_codegen() still describe these binaries? Same
+#    corpus, different question -- the oracle above is wasm-tools, the oracle
+#    here is the declaration in docs. Sharing the corpus is deliberate: the
+#    expensive part is compiling the fixtures, and a separate script would grow
+#    its own list that could drift from this one.
+scan="$WORK/scan.wasm"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+  scripts/wasm_feature_levels.vibex "_build/validate_parity/scan.wasm" main >/dev/null 2>&1
+[ -s "$scan" ] || { echo "[validate-parity] FAIL: feature-levels scanner did not compile" >&2; exit 1; }
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+     --invoke main "_build/validate_parity/scan.wasm" --scan "$WORK"/pos/*.wasm; then
+  echo "[validate-parity] FAIL: see above -- generated wasm requires a proposal that" >&2
+  echo "[validate-parity]       scripts/wasm_feature_levels.vibex does not declare" >&2
+  exit 1
+fi
+
 if [ "$pos_total" -eq 0 ] || [ "$neg_total" -eq 0 ]; then
   echo "[validate-parity] FAIL: empty corpus (pos=$pos_total neg=$neg_total)" >&2
   exit 1

--- a/scripts/wasm_feature_levels.vibex
+++ b/scripts/wasm_feature_levels.vibex
@@ -80,6 +80,7 @@
 
 import @vibe/prelude { stdout_write }
 import @vibe/json { Json }
+import @vibex/wasm_parser { scan_features_checked }
 
 // ---------- small string/number utilities (workarounds for #1184/#1185 / missing Array::sort) ----------
 
@@ -253,6 +254,7 @@ let host_engine = "Wasmtime"
 // so it is unaffected by this ordering choice.
 fn used_by_codegen() -> Array[(String, String)] {
   [
+    ("bulkMemory", "linear + gc backends: memory.copy (0xFC 10) and memory.fill (0xFC 11) from emit_memory_copy/emit_memory_fill (codegen/common_extractors/common_extractors.vibe), reached from ~18 builtin bodies -- string/array copies and zero-initializing a fresh hash-index table in one instruction instead of a store loop. FOUND BY --scan, not by hand: it was emitted and undeclared"),
     ("exceptionsFinal", "linear + gc backends: try_table/tag section, emitted only when a module uses effects/throw (codegen/wasi/linked_compile.vibe, codegen/gc/backend_expr.vibe)"),
     ("gc", "gc backend: struct.new/get/set for the RC cell and non-escaping local records (#1702), array.new_default/get/set/len for the reference lane (#1329/#1541), and the struct/array type definitions they need (codegen/gc/backend_body.vibe, backend_expr.vibe)"),
     ("simd", "linear + gc backends: v128 opcodes behind specific builtins e.g. simd_skip_ws (codegen/wasm_emit/simd.vibe, codegen/expr/compile_call.vibe)"),
@@ -560,12 +562,173 @@ fn has_flag(argc: Int, name: String) -> Bool with Env {
   found
 }
 
+
+// ---------- --scan: check the DECLARATION against actual binaries ----------
+
+// #1133's actual subject. used_by_codegen() above is curated by hand, and it
+// has drifted at least once already: the gc reference lane started emitting
+// typed function signatures and nothing noticed until a binary was read by
+// hand. This reads the binaries instead.
+//
+// The comparison is deliberately asymmetric, and the asymmetry is the point:
+//
+//   emitted but NOT declared   FAILS. This is drift in the direction that
+//                              matters -- generated wasm requires a proposal
+//                              the docs do not mention, so a target chosen
+//                              from the docs can reject it.
+//   declared but NOT emitted   reported, does not fail. Some features are
+//                              emitted only by inputs the given corpus does
+//                              not contain, so absence here is not evidence
+//                              the declaration is wrong.
+//
+// A module whose walk did not finish is NOT compared at all. Its feature list
+// is a subset of the truth, and a subset compared against a declaration reads
+// as "the declaration claims too much" -- exactly backwards. Reporting nothing
+// is honest; reporting a reversed conclusion is not.
+fn scan_against_declaration(argc: Int) -> Int with Fs + Env + Stdout + Stderr {
+  let paths = scan_targets(argc)
+  if Array::length(paths) == 0 {
+    Stderr::write_stream("[wasm-feature-levels] --scan needs at least one .wasm path\n")
+    1
+  } else {
+    let declared = used_by_codegen()
+    let seen = Array::slice([""], 0, 0)
+    let mut skipped = 0
+    let mut i = 0
+    while i < Array::length(paths) {
+      let path = Array::get(paths, i)
+      let (found, complete) = scan_features_checked(Fs::read_bytes(path))
+      if !complete {
+        skipped = skipped + 1
+        stdout_write("[wasm-feature-levels] skip (incomplete walk): " + path + "\n")
+      } else {
+        let mut f = 0
+        while f < Array::length(found) {
+          let key = Array::get(found, f)
+          if !string_array_contains(seen, key) {
+            Array::push(seen, key)
+          } else {
+            ()
+          }
+          f = f + 1
+        }
+      }
+      i = i + 1
+    }
+    let undeclared = Array::slice([""], 0, 0)
+    let mut k = 0
+    while k < Array::length(seen) {
+      let key = Array::get(seen, k)
+      if !declared_contains(declared, key) {
+        Array::push(undeclared, key)
+      } else {
+        ()
+      }
+      k = k + 1
+    }
+    let mut d = 0
+    while d < Array::length(declared) {
+      let (key, _) = Array::get(declared, d)
+      if !string_array_contains(seen, key) {
+        stdout_write(
+          "[wasm-feature-levels] declared but not seen in this corpus: " + key + "\n"
+        )
+      } else {
+        ()
+      }
+      d = d + 1
+    }
+    if Array::length(undeclared) > 0 {
+      let mut u = 0
+      while u < Array::length(undeclared) {
+        Stderr::write_stream(
+          "[wasm-feature-levels] FAIL: emitted but not in used_by_codegen(): " +
+          Array::get(undeclared, u) + "\n"
+        )
+        u = u + 1
+      }
+      Stderr::write_stream(
+        "Generated wasm requires a proposal docs/wasm/feature-levels.md does not\n" +
+        "declare. Add it to used_by_codegen() with the codegen site that emits it,\n" +
+        "then re-run --update-expected.\n"
+      )
+      1
+    } else {
+      stdout_write(
+        "[wasm-feature-levels] ok: every proposal found in " +
+        Int::to_string(Array::length(paths) - skipped) + " module(s) is declared\n"
+      )
+      0
+    }
+  }
+}
+
+// Every argument after --scan that looks like a path, so the caller can pass a
+// shell glob and let the shell do the expanding.
+fn scan_targets(argc: Int) -> Array[String] with Env {
+  let paths = Array::slice([""], 0, 0)
+  let mut i = 0
+  let mut after = false
+  while i < argc {
+    let a = Env::args_get(i)
+    if a == "--scan" {
+      after = true
+    }
+    else if after && !string_starts_with(a, "--") {
+      Array::push(paths, a)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  paths
+}
+
+fn string_starts_with(s: String, prefix: String) -> Bool {
+  if String::length(s) < String::length(prefix) {
+    false
+  } else {
+    String::substring(s, 0, String::length(prefix)) == prefix
+  }
+}
+
+fn string_array_contains(xs: Array[String], want: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(xs) {
+    if Array::get(xs, i) == want {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn declared_contains(declared: Array[(String, String)], want: String) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(declared) {
+    let (key, _) = Array::get(declared, i)
+    if key == want {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
 fn main with Fs + Env + Stdout + Stderr + Process {
   let matrix = load_matrix()
   let report = classify(matrix)
   let argc = Env::args_len()
 
-  let code = if has_flag(argc, "--update-expected") {
+  let code = if has_flag(argc, "--scan") {
+    scan_against_declaration(argc)
+  } else if has_flag(argc, "--update-expected") {
     Fs::write_file(expected_path(), json_pretty(report, 0) + "\n")
     stdout_write("[wasm-feature-levels] wrote " + expected_path() + "\n")
     0


### PR DESCRIPTION
#1800 で読み取り側 (`@vibex/wasm_parser` の命令走査と validator) を作りました。
これはその上に **#1133 が本来求めていたもの** — 「生成された wasm から proposal 依存を
導出し、`used_by_codegen()` の宣言と突き合わせて乖離を検出する」— を載せます。

**初回実行でドリフトを検出しました**: `bulkMemory` が出ているのに宣言に無い。

## 1. `scan_features` が命令列からも proposal を導くようになった

`simd` / `tailCall` / `bulkMemory` / `saturatedFloatToInt` を追加しました。
セクションと型から導く既存の 4 つ (`gc` / `exceptionsFinal` / `typedFunctionReferences` /
`multiMemory`) と並びます。

**この 4 つを今まで出していなかったのは意図的**でした。「バイト列を prefix で grep する」
方式は opcode と、たまたま同じ値を持つ即値を区別できないので、**使っていない proposal を
報告します**。宣言と突き合わせる道具としては、それは不完全であるより悪い。
#1800 で `next_instruction` が 527/527 body を歩けるようになったので、
その理由が消えました。

## 2. `--scan`: 宣言をバイナリと突き合わせる

```bash
vibe run scripts/wasm_feature_levels.vibex -- --scan path/to/*.wasm
```

判定は**非対称**で、そこが要点です:

| | 扱い | 理由 |
|---|---|---|
| **出しているのに宣言に無い** | **fail** | docs から選んだターゲットが生成 wasm を拒否しうる |
| 宣言にあるのに出ていない | 報告のみ | その corpus に該当する入力が無いだけかもしれない |

**走査が最後まで届かなかったモジュールは比較しません。** 得られた feature は真の
部分集合なので、宣言と比べると「宣言が多すぎる」と読めてしまう — **結論が逆になります**。
`scan_features_checked` が完走したかを返し、届かなかったものは skip として出ます。
何も言わない方が正直で、黙って逆の結論を出すよりましです。

## 3. 検出したドリフト: `bulkMemory`

```
[wasm-feature-levels] FAIL: emitted but not in used_by_codegen(): bulkMemory
```

`emit_memory_copy` (`0xFC 10`) / `emit_memory_fill` (`0xFC 11`)
(`codegen/common_extractors/common_extractors.vibe`) が、builtin body の**約 18 箇所**から
呼ばれています — 文字列/配列コピーと、hash index table の一括ゼロ初期化です。

移植性の実害はありません (phase 5、両 engine set で supported)。損なわれていたのは
**宣言がバイナリを説明しなくなっていたこと**で、それが #1133 の主題そのものです。
`used_by_codegen()` に追加し、`feature-levels.expected.json` を再生成しました。

## 4. harness をゲートに配線した

**`scripts/test_wasm_validate_parity.sh` はどのゲートからも走っていませんでした** —
計測を作って放置していた形です。`pkf run test-wasm-validate-parity` を追加し、
`--scan` のステップも同じ harness に入れました。fixture のコンパイルが高コストなので
corpus を共有しています (別スクリプトにすると fixture リストが 2 つになって、
それ自体がドリフトします)。

```
[wasm-feature-levels] ok: every proposal found in 8 module(s) is declared
[validate-parity] ok: 8/8 accepted (zero false rejections), 52/54 rejected
[validate-parity]     instruction walk reached the end of 527/527 function bodies
```

## 検証

- `@vibex/wasm_parser` / `@vibex/wasm_runtime` / `@vibex/wasm_wat_encoder` 全スイート green
- `scripts/test_wasm_validate_parity.sh` green (上記)
- `wasm_feature_levels.vibex --check` green (再生成後)
- `check_vibe_fmt` / `lint_review_regressions` / `lint_architecture_debt` green
- `origin/main` (4aefa7d66) 上

## 残っているもの

- **`memory64`** の i64 addressing は未判定 (このコンパイラは出していない)
- **`0xFE` (atomics)** は `next_instruction` が未対応。使い始めたら「走査が届かない」側に
  落ちるので、**黙って見落とすのではなく skip として出ます**
- prefix 系の**オペランド表示** (disassembler)。`struct.get` の型/フィールドインデックスは
  今は出しません — 命令長の知識を 1 箇所に保つためです
- 本物の validation (操作スタックの型検査) は #1745 (5)。別スライス
- `bash scripts/vibe_run.sh <file>.vibex` が現行 main で動きません (seed が現行 prelude
  contract に追いついておらず、`set -euo pipefail` でメッセージも出ず exit 1)。
  この PR の検証は stage2 で行いました。別 issue 化が妥当

Closes #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN)_