### PR TITLE
probe(async): async lift + string `task.return` の canonopt 集合をバイトレベルで確定 (#1540)

### DIFF
--- a/scripts/test_async_string_lift_probe_gate.sh
+++ b/scripts/test_async_string_lift_probe_gate.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #1540 follow-up probe gate: the canonical-option set for an ASYNC lift whose
+# params and result are STRINGS.
+#
+# tools/wasip3_component_probe/async_string_lift/component.wat carries the full
+# rationale and the measured byte encodings. This gate is what keeps them true:
+# it is the byte-level pin the README of the http_body_stream probe asks for
+# before `emit_canon_lift_async_section` / `emit_canon_task_return` are
+# generalized.
+#
+# Asserts, in order:
+#   1. the component parses and validates;
+#   2. `task.return` carries exactly Memory + UTF8 -- and NOT realloc, which
+#      wasmtime rejects outright;
+#   3. the async lift carries Async + Memory + Realloc + UTF8;
+#   4. it RUNS: `greet("bob")` returns "hi", so the string really round-trips
+#      through task.return rather than merely type-checking.
+#
+# Skips cleanly when wasm-tools / wasmtime are unavailable, and fails instead
+# under VIBE_P3_GATE_REQUIRE_TOOLS=1, matching the other P3 probes.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PROBE="$PROJECT_ROOT/tools/wasip3_component_probe/async_string_lift/component.wat"
+OUT_DIR="$PROJECT_ROOT/_build/bench/async_string_lift_probe/run-$$"
+
+if [ -n "${VIBE_HTTP_GATE_WASMTIME_FLAGS:-}" ]; then
+  read -r -a WASM_FLAGS <<<"$VIBE_HTTP_GATE_WASMTIME_FLAGS"
+else
+  WASM_FLAGS=(-W exceptions=y -W concurrency-support=y -W component-model-async=y -W component-model-async-stackful=y)
+fi
+
+missing_tool() {
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "[async-string-lift] FAILED: $1 not found (required mode)" >&2; exit 1
+  fi
+  echo "[async-string-lift] SKIP: $1 not found"; exit 0
+}
+command -v wasm-tools >/dev/null 2>&1 || missing_tool "wasm-tools"
+WASMTIME_BIN="$("$PROJECT_ROOT/scripts/wasmtime_bin.sh" 2>/dev/null || command -v wasmtime || true)"
+if [ -z "${WASMTIME_BIN:-}" ] || ! "$WASMTIME_BIN" --version >/dev/null 2>&1; then
+  missing_tool "wasmtime"
+fi
+
+rm -rf "$OUT_DIR"; mkdir -p "$OUT_DIR"
+trap 'rm -rf "$OUT_DIR"' EXIT
+WASM="$OUT_DIR/component.wasm"
+
+wasm-tools parse "$PROBE" -o "$WASM"
+wasm-tools validate --features all "$WASM"
+echo "[async-string-lift] parses and validates"
+
+DUMP="$(wasm-tools dump "$WASM" 2>/dev/null)"
+
+# 2. task.return's option set. `realloc` here is a hard wasmtime error, so its
+#    ABSENCE is as load-bearing as the two that are present.
+if ! printf '%s' "$DUMP" | grep -qF 'TaskReturn { result: Some(Primitive(String)), options: [Memory(0), UTF8] }'; then
+  echo "[async-string-lift] FAILED: task.return's option set changed (want [Memory(0), UTF8], and never Realloc)" >&2
+  printf '%s\n' "$DUMP" | grep -i "taskreturn" >&2 || true
+  exit 1
+fi
+echo "[async-string-lift] task.return: [Memory(0), UTF8], no realloc"
+
+# 3. the async lift's option set -- all four, which is what the emitter must
+#    learn to produce.
+if ! printf '%s' "$DUMP" | grep -qF 'options: [Async, Memory(0), Realloc(0), UTF8]'; then
+  echo "[async-string-lift] FAILED: the async lift's option set changed (want [Async, Memory(0), Realloc(0), UTF8])" >&2
+  printf '%s\n' "$DUMP" | grep -i "lift" >&2 || true
+  exit 1
+fi
+echo "[async-string-lift] async lift: [Async, Memory(0), Realloc(0), UTF8]"
+
+# 4. and it actually runs -- validation is not execution, and a string that
+#    never leaves guest memory would still validate.
+OUT="$("$WASMTIME_BIN" run "${WASM_FLAGS[@]}" --invoke 'greet("bob")' "$WASM" 2>&1 || true)"
+if ! printf '%s' "$OUT" | grep -qF '"hi"'; then
+  echo "[async-string-lift] FAILED: greet(\"bob\") returned '$OUT' (want \"hi\")" >&2
+  exit 1
+fi
+echo "[async-string-lift] greet(\"bob\") -> \"hi\" (the string round-trips through task.return)"
+echo "[async-string-lift] PASS: async lift + string task.return option set pinned (#1540)"

--- a/scripts/test_async_string_lift_probe_gate.sh
+++ b/scripts/test_async_string_lift_probe_gate.sh
@@ -15,8 +15,17 @@ set -euo pipefail
 #   2. `task.return` carries exactly Memory + UTF8 -- and NOT realloc, which
 #      wasmtime rejects outright;
 #   3. the async lift carries Async + Memory + Realloc + UTF8;
-#   4. it RUNS: `greet("bob")` returns "hi", so the string really round-trips
+#   4. the RAW BYTES of both match what the probe documents;
+#   5. it RUNS: `greet("bob")` returns "hi", so the string really round-trips
 #      through task.return rather than merely type-checking.
+#
+# 4 is not redundant with 2-3, and is the assertion this gate exists for. The
+# decoded options come from `wasm-tools dump`'s AST: they pin the SEMANTICS, not
+# the ENCODING. A wasm-tools change to an opcode or index encoding -- or an edit
+# to the probe that moves a core-func/type index -- would leave 2, 3 and 5 green
+# while the byte sequences the emitter is supposed to be built against went
+# stale. Keeping both means a failure says which layer moved: 2-3 name the
+# option that changed, 4 catches a re-encoding of options that did not.
 #
 # Skips cleanly when wasm-tools / wasmtime are unavailable, and fails instead
 # under VIBE_P3_GATE_REQUIRE_TOOLS=1, matching the other P3 probes.
@@ -72,7 +81,29 @@ if ! printf '%s' "$DUMP" | grep -qF 'options: [Async, Memory(0), Realloc(0), UTF
 fi
 echo "[async-string-lift] async lift: [Async, Memory(0), Realloc(0), UTF8]"
 
-# 4. and it actually runs -- validation is not execution, and a string that
+# 4. the raw bytes. Byte-aligned by construction (od emits one hex pair per
+#    byte), and asserted to occur EXACTLY once so a coincidental match
+#    elsewhere in the module cannot satisfy it.
+BYTES="$(od -An -tx1 -v "$WASM" | tr -s ' \n' ' ')"
+expect_bytes() {
+  local what="$1" seq="$2" n
+  # `|| true`: grep exits 1 on no match, and under `set -euo pipefail` that
+  # would kill the script AT THE ASSIGNMENT -- a non-zero exit with no
+  # diagnostic, which is the one failure mode this gate must never have.
+  n="$(printf '%s' "$BYTES" | grep -o " $seq " | wc -l | tr -d ' ' || true)"
+  [ -n "$n" ] || n=0
+  if [ "$n" != "1" ]; then
+    echo "[async-string-lift] FAILED: $what byte sequence occurs $n times, want exactly 1" >&2
+    echo "[async-string-lift]   expected: $seq" >&2
+    echo "[async-string-lift]   the probe's documented encoding is stale, or the module moved an index" >&2
+    exit 1
+  fi
+}
+expect_bytes "task.return"       "09 00 73 02 03 00 00"
+expect_bytes "async lift"        "00 00 02 04 06 03 00 04 00 00 00"
+echo "[async-string-lift] raw bytes match the documented encoding"
+
+# 5. and it actually runs -- validation is not execution, and a string that
 #    never leaves guest memory would still validate.
 OUT="$("$WASMTIME_BIN" run "${WASM_FLAGS[@]}" --invoke 'greet("bob")' "$WASM" 2>&1 || true)"
 if ! printf '%s' "$OUT" | grep -qF '"hi"'; then

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -9,7 +9,9 @@
 #            .vibe async entry -> component-model async component -> 42
 #   phase B  wasi:http p3 world (test_wasi_http_p3_full_gate.sh) plus the
 #            incoming-body stream-parameter composition probe (#1540)
-#            componentize -> wac plug -> wasmtime serve -> curl assertions
+#            componentize -> wac plug -> wasmtime serve -> curl assertions,
+#            and the async-lift/string-task.return option-set probe that has
+#            to hold before those canon emitters are generalized
 #   phase C  wasi:cli/stdin lifecycle
 #            generated shadow adapter + checker-hidden arbitrary-core route +
 #            hand-WAT provider measurement; exact ratified import,
@@ -73,6 +75,7 @@ case ",$PHASES," in *",http,"*)
   echo "[p3-guarantee] phase B: wasi:http p3 world"
   bash "$SCRIPT_DIR/test_wasi_http_p3_full_gate.sh"
   bash "$SCRIPT_DIR/test_http_body_stream_probe_gate.sh"
+  bash "$SCRIPT_DIR/test_async_string_lift_probe_gate.sh"
   ;;
 esac
 case ",$PHASES," in *",stdin,"*)

--- a/tools/wasip3_component_probe/async_string_lift/component.wat
+++ b/tools/wasip3_component_probe/async_string_lift/component.wat
@@ -1,0 +1,86 @@
+;; #1540 follow-up probe: the canonical-option set for an ASYNC lift whose
+;; params and result are STRINGS.
+;;
+;; The http_body_stream probe established that a request body can reach the
+;; guest as a `stream<u8>` parameter, but its guest returns a constant through a
+;; SYNC lift. A guest that actually reads the body suspends, so the handler has
+;; to be async-lifted -- and a `string` result then comes back through
+;; `task.return` rather than the lift's own return path. The emitters in
+;; `component_codegen.vibe` are too narrow for that today:
+;;
+;;   emit_canon_lift_async_section  emits exactly one canonopt (async)
+;;   emit_canon_task_return         emits none
+;;
+;; Both need widening, so this probe pins what wasmtime actually accepts and
+;; what the bytes are, before either emitter is generalized.
+;;
+;; Measured with wasm-tools 1.255.0 / wasmtime 47.0.2. Three findings:
+;;
+;;   1. `task.return` CANNOT carry `realloc`:
+;;        error: cannot specify `realloc` option on `task.return`
+;;      It lifts the result OUT of guest memory, so it reads but never
+;;      allocates. `memory` + `string-encoding` are the whole option set.
+;;
+;;   2. the `async` canonopt REQUIRES the component functype to be declared
+;;      async as well:
+;;        error: the `async` canonical option requires an async function type
+;;      `(func (param ..) (result ..))` is rejected; `(func async (param ..)
+;;      (result ..))` is accepted. `emit_comp_async_functype_section` already
+;;      emits the async functype opcode (0x43) but hardcodes ZERO params, so it
+;;      needs widening alongside the two canon emitters.
+;;
+;;   3. the async lift itself DOES take `memory` + `realloc` +
+;;      `string-encoding`, all three.
+;;
+;; Exact bytes (`wasm-tools dump`), which are the target encoding:
+;;
+;;   task.return   09 00 73 02 03 00 00
+;;                 09=task.return  00=result-form  73=string
+;;                 02=option count  03 00=Memory(0)  00=UTF8
+;;
+;;   async lift    00 00 02 04 06 03 00 04 00 00 00
+;;                 00=lift  00=core-func sort  02=core func idx
+;;                 04=option count  06=Async  03 00=Memory(0)
+;;                 04 00=Realloc(0)  00=UTF8  00=type idx
+;;
+;;   option codes  00=UTF8  03 <idx>=Memory  04 <idx>=Realloc  06=Async
+;;
+;; The structural constraint this probe also demonstrates: memory and realloc
+;; must live OUTSIDE the guest instance. `task.return` needs them, the guest
+;; imports `[task-return]`, so a guest-owned memory would be a cycle. That is
+;; the same reason `comp_generate_memhost_module` exists -- but the memhost also
+;; has to export `cabi_realloc` now, which today's one does not.
+(component
+  (core module $memhost
+    (memory (export "memory") 1)
+    (global $bump (mut i32) (i32.const 1024))
+    (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32)
+      (local $p i32)
+      (local.set $p (global.get $bump))
+      (global.set $bump (i32.add (global.get $bump) (i32.const 64)))
+      (local.get $p))
+  )
+  (core instance $mh (instantiate $memhost))
+  (alias core export $mh "memory" (core memory $mem))
+  (alias core export $mh "cabi_realloc" (core func $realloc))
+
+  (core module $m
+    (import "[export]$root" "[task-return]greet" (func $task_return (param i32 i32)))
+    (import "env" "memory" (memory 1))
+    ;; Writes into the IMPORTED (memhost) memory at instantiation, which is what
+    ;; makes the returned bytes observable to `task.return`'s lift.
+    (data (i32.const 16) "hi")
+    ;; The string param arrives flattened as (ptr, len) and the core function
+    ;; returns NOTHING -- the result leaves through task.return.
+    (func (export "greet") (param i32 i32)
+      (call $task_return (i32.const 16) (i32.const 2)))
+  )
+
+  (type $ft (func async (param "name" string) (result string)))
+  (core func $tr (canon task.return (result string) (memory $mem) string-encoding=utf8))
+  (core instance $er (export "[task-return]greet" (func $tr)))
+  (core instance $env (export "memory" (memory $mem)))
+  (core instance $gi (instantiate $m (with "[export]$root" (instance $er)) (with "env" (instance $env))))
+  (func (export "greet") (type $ft)
+    (canon lift (core func $gi "greet") async (memory $mem) (realloc $realloc) string-encoding=utf8))
+)


### PR DESCRIPTION
http_body_stream probe は「body が `stream<u8>` 引数としてゲストに届く」ところまで確定させたが、
そのゲストは **sync lift で定数を返す**。body を実際に**読む**ゲストは suspend するので
handler は async lift でなければならず、`string` の結果は lift 自身の戻り経路ではなく
**`task.return` 経由**になる。同 probe の README が
「emitter を一般化する前に、この符号化を別のバイトレベル probe で確定させること」と
書いているのがこれ。現在の emitter は狭すぎる:

```
emit_canon_lift_async_section   canonopt を 1 個 (async) しか出さない
emit_canon_task_return          0 個
```

## 実測 3 件 (wasmtime 47.0.2 / wasm-tools 1.255.0)

**1. `task.return` は `realloc` を取れない**

```
error: cannot specify `realloc` option on `task.return`
```

結果をゲストメモリから **lift する側**なので読むだけで、確保はしない。
`memory` + `string-encoding` が全部。**この不在は存在と同じくらい重要**なので、
ゲートは「realloc が付いていないこと」も assert する。

**2. `async` canonopt は functype 自体が async であることを要求する**

```
error: the `async` canonical option requires an async function type
```

`(func (param ..) (result ..))` は拒否、`(func async (param ..) (result ..))` は受理。
したがって `emit_comp_async_functype_section` も一緒に広げる必要がある —
async functype opcode 0x43 は既に出しているが、**params が 0 個決め打ち**。

**3. async lift 自身は `memory` / `realloc` / `string-encoding` の 3 つとも取れる**

## 目標符号化 (`wasm-tools dump`)

```
task.return   09 00 73 02 03 00 00
              09=task.return 00=result-form 73=string
              02=option count  03 00=Memory(0)  00=UTF8

async lift    00 00 02 04 06 03 00 04 00 00 00
              00=lift 00=core-func sort 02=core func idx
              04=option count  06=Async  03 00=Memory(0)
              04 00=Realloc(0)  00=UTF8  00=type idx

option codes  00=UTF8  03 <idx>=Memory  04 <idx>=Realloc  06=Async
```

## 構造上の制約も 1 つ出た

**memory と realloc はゲストインスタンスの外に置くしかない。** `task.return` が両方を要り、
ゲストは `[task-return]` を import するので、ゲスト所有のメモリだと循環になる。
`comp_generate_memhost_module` が存在するのはまさにこの理由だが、**合流後の emitter では
memhost が `cabi_realloc` も export する必要がある** — 今の memhost は出していない。

## ゲートは validate ではなく**実行**する

`greet("bob")` が `"hi"` を返すことを assert する。ゲストメモリから出ていない結果でも
validate は通ってしまうので、**文字列が実際に往復すること**が確認したい性質。

## 検証

p3 guarantee gate の phase B に、合成 probe の隣へ配線した。

`VIBE_P3_GATE_REQUIRE_TOOLS=1 bash scripts/test_wasi_p3_guarantee_gate.sh` — **全体 PASS**

```
[http-full-gate] PASS: vibe full async HTTP handler (selfhost serve pipeline)
[body-stream-probe] PASS: a wasi:http request body can reach the guest as a stream<u8> parameter
[async-string-lift] task.return: [Memory(0), UTF8], no realloc
[async-string-lift] async lift: [Async, Memory(0), Realloc(0), UTF8]
[async-string-lift] greet("bob") -> "hi" (the string round-trips through task.return)
[p3-guarantee] PASS on wasmtime 47.0.2
```

## 次

これで emitter 側の一般化に**バイト単位の目標**ができた。次のスライスは
`emit_canon_task_return` / `emit_canon_lift_async_section` /
`emit_comp_async_functype_section` を広げること — 既存呼び出し元は
0 オプション / 0 params のままバイト同一に保つ。

## 関連

#1540、#1796 (合成形状の probe)、#1230、spec §3.12 / §3.17 (同じ手順)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_