### PR TITLE
bootstrap: seed を mutbytes-2026-08-15 へ bump (#1801 を seed に取り込み、pilot 適用の前提を解除)

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "region-starts-guard-2026-08-15",
-    "tag": "seed/region-starts-guard-2026-08-15",
-    "source_commit": "702082bb64851048d3d6a11116cc82b0d73659e4",
+    "name": "mutbytes-2026-08-15",
+    "tag": "seed/mutbytes-2026-08-15",
+    "source_commit": "32cdab5e1b4cd6aedb3a5aed9937c8938e2fbb25",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "1841e38ae6289c9984f446558a40a551d4e880c066e99bbfc35c38d605ba5c0c"
+      "sha256": "89446ac143934ce0d6675cb7d099d14922196d9415792e77cad36017818b57f9"
     },
     "runtime": {
       "runner": "moonrun",


### PR DESCRIPTION
## 概要

bootstrap seed を `region-starts-guard-2026-08-15` (1841e38a) から **`mutbytes-2026-08-15` (89446ac1)** へ bump する。#1801 (MutBytes[r] + nested-region regrow guard) を seed に取り込むことで、compiler source 自身が MutBytes を書けるようになり (fmt-check CI 等は seed でコンパイルするため)、#1770 Phase 1 の pilot 適用 (`ast_binary_write_string` の UTF-8 scratch) に進める。

diff は `bootstrap/seed.json` の pin 更新のみ。

## candidate の構築と検証

- 構築: main `32cdab5` (= #1801 の merge commit) から `scripts/generations.sh build --stage3`。**stage2 == stage3 fixpoint** (sha256 `89446ac1...`)。`--source-commit 32cdab5` で adopt
- `bash scripts/compiler_gate.sh` 全 pass (FAIL 0) — MutBytes 縦串 + nested-region regrow guard の新 gate step 込み
- bump の動機の直接実証:
  - `region_bytes_ok` fixture が candidate で compile + 実行 pass
  - **compiler source (`ast_binary.vibe`) に置いた MutBytes 使用を vpkg contract レーン経由でコンパイルできる**ことを確認 (pilot が必要とする形そのもの)

## merge 後の手順 (前回 #1791 と同じ)

`seed-release` workflow の workflow_dispatch をお願いします (bot は 403 で起動不可)。**merge 前にこの PR の head から dispatch して release を先に作れば、CI re-run だけで green になります** (#1791 で実証済みの手順):

- `tag`: `seed/mutbytes-2026-08-15`
- `source_ref`: `32cdab5e1b4cd6aedb3a5aed9937c8938e2fbb25` (seed.json に記録した source_commit = main 上の #1801 merge commit)
- `prior_seed_ref`: `32cdab5e1b4cd6aedb3a5aed9937c8938e2fbb25` (同 commit の seed.json は公開済み `seed/region-starts-guard-2026-08-15` を指しているので stage0 として有効)

## 続き

release publish + merge 後に、pilot PR (`ast_binary_write_string` の scratch を region + MutBytes 化、heap 実測付き) を出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_