### PR TITLE
fix(gc): クロージャ内の builtin 呼び出しを自由変数として捕獲しない

### DIFF
--- a/fixtures/gc_closure_builtin_alias_test.vibe
+++ b/fixtures/gc_closure_builtin_alias_test.vibe
@@ -1,0 +1,62 @@
+// wasm-gc lane: a builtin reached through a SOURCE ALIAS must not be captured
+// either.
+//
+// Companion to gc_closure_builtin_capture_test.vibe. Sharing the direct-ABI
+// list between the call dispatcher and the capture scan was not enough:
+// `compile_call_gc` canonicalizes the callee with `canonical_builtin_name`
+// BEFORE dispatching, while the capture scan sees the SOURCE spelling. So
+// `StringBuilder::build` -- an alias of `StringBuilder::freeze` -- matched
+// neither the func table nor the list and was still captured, giving the same
+// "reached code generation unresolved" death one lambda deep.
+//
+// `String::byte_at` is the case that shows why canonicalizing against the
+// direct-ABI list alone is not enough: its canonical form
+// (`String::char_code_at`) is resolved through the FUNC TABLE, not by
+// spelling. The capture test therefore canonicalizes and then re-checks both
+// sets.
+//
+// GC LANE ONLY. The linear backend emits an INVALID module for every one of
+// these (`invalid signature index`) while reporting a successful compile --
+// a pre-existing bug unrelated to the capture scan, tracked as #1811. Widen
+// this to both lanes once that lands; until then linear coverage would just
+// pin a known-broken artifact.
+
+fn alias_string_builder_in_closure() -> Int {
+  let f = () -> String {
+    let b = StringBuilder::new()
+    StringBuilder::push(b, "ab")
+    StringBuilder::build(b)
+  }
+  String::length(f())
+}
+
+fn alias_byte_at_in_closure() -> Int {
+  let f = (s: String) -> Int {
+    String::byte_at(s, 0)
+  }
+  f("A")
+}
+
+fn alias_from_byte_in_closure() -> Int {
+  let f = (c: Int) -> String {
+    String::from_byte(c)
+  }
+  String::length(f(65))
+}
+
+// The alias and a real local in the same closure: `n` must still ride the
+// environment while the alias must not.
+fn alias_and_local_together() -> Int {
+  let n = 3
+  let f = (s: String) -> Int {
+    String::byte_at(s, 0) + n
+  }
+  f("A")
+}
+
+test "source aliases canonicalize before the capture decision" {
+  inspect(alias_string_builder_in_closure(), "2")
+  inspect(alias_byte_at_in_closure(), "65")
+  inspect(alias_from_byte_in_closure(), "1")
+  inspect(alias_and_local_together(), "68")
+}

--- a/fixtures/gc_closure_builtin_capture_test.vibe
+++ b/fixtures/gc_closure_builtin_capture_test.vibe
@@ -1,0 +1,106 @@
+// wasm-gc lane: a builtin called from INSIDE a closure must not be captured as
+// a free variable.
+//
+// `compile_call_gc` dispatches ~60 builtins by spelling before ordinary
+// func-table lookup. The lambda capture scan has to know that same set, or it
+// classifies the builtin's own spelling as a free variable of the lambda body
+// and `emit_lambda_closure_gc` dies on it:
+//
+//     internal compiler error: `Double::to_i64_bits_lo` (local, @gc_cap)
+//     reached code generation unresolved.
+//
+// The two lists had drifted: the capture scan carried 6 of the names (the
+// `__`-prefixed desugar builtins) and the dispatch chain carried all ~60. So
+// the failure was not "this builtin is unsupported" -- the SAME call compiles
+// fine at statement level and only breaks one lambda deep, which is why it
+// survived: every gc fixture called these at the top level.
+//
+// The spellings in the first group were measured broken on the pre-fix
+// compiler and those in the second were measured already working; both are in
+// on purpose. Excluding too MUCH from the capture set is the worse bug -- a
+// closure over a real local would silently lose its capture instead of
+// raising -- so the working half guards the over-exclusion direction.
+//
+// Runs on both backends: `vibe test` (linear) and VIBE_TEST_BACKEND=gc.
+
+// --- measured broken before the fix ---
+
+fn bits_lo_in_closure() -> Int {
+  let f = (x: Double) -> Int { Double::to_i64_bits_lo(x) }
+  f(1.5)
+}
+
+fn bits_hi_in_closure() -> Int {
+  let f = (x: Double) -> Int { Double::to_i64_bits_hi(x) }
+  // 1.5 as f64 is 0x3FF8000000000000: the high half is 0x3FF80000, the low
+  // half is 0. Asserting on the HIGH half matters -- a fixture that only read
+  // the low half would pass on a lane that returned a constant 0.
+  f(1.5)
+}
+
+fn int_to_string_in_closure() -> Int {
+  let f = (x: Int) -> String { Int::to_string(x) }
+  String::length(f(42))
+}
+
+fn map_has_key_in_closure() -> Int {
+  let m = Map::new()
+  let f = (k: String) -> Int { if Map::has_key(m, k) { 1 } else { 0 } }
+  f("absent")
+}
+
+// --- measured working before the fix (over-exclusion guard) ---
+
+fn array_length_in_closure() -> Int {
+  let a = [1, 2, 3]
+  let f = () -> Int { Array::length(a) }
+  f()
+}
+
+fn array_slice_in_closure() -> Int {
+  let a = [1, 2, 3, 4]
+  let f = (n: Int) -> Int { Array::length(Array::slice(a, 0, n)) }
+  f(3)
+}
+
+fn fixed_array_get_in_closure() -> Int {
+  let a = FixedArray::make(4, 7)
+  let f = (i: Int) -> Int { FixedArray::get(a, i) }
+  f(2)
+}
+
+fn string_builder_in_closure() -> Int {
+  let f = () -> String {
+    let b = StringBuilder::new()
+    StringBuilder::push(b, "ab")
+    StringBuilder::freeze(b)
+  }
+  String::length(f())
+}
+
+// A real local captured alongside a builtin call. This is the case that breaks
+// if the capture set is widened past namespaced spellings: `n` must still ride
+// the closure environment while `Int::to_string` must not.
+fn local_and_builtin_together() -> Int {
+  let n = 7
+  let f = () -> Int { String::length(Int::to_string(n)) + n }
+  f()
+}
+
+test "namespaced builtins called inside a closure are not captured" {
+  inspect(bits_lo_in_closure(), "0")
+  inspect(bits_hi_in_closure(), "1073217536")
+  inspect(int_to_string_in_closure(), "2")
+  inspect(map_has_key_in_closure(), "0")
+}
+
+test "capture set stays narrow enough for the working spellings" {
+  inspect(array_length_in_closure(), "3")
+  inspect(array_slice_in_closure(), "3")
+  inspect(fixed_array_get_in_closure(), "7")
+  inspect(string_builder_in_closure(), "2")
+}
+
+test "a real local still rides the closure environment" {
+  inspect(local_and_builtin_together(), "8")
+}

--- a/fixtures/gc_closure_builtin_capture_test.vibe
+++ b/fixtures/gc_closure_builtin_capture_test.vibe
@@ -26,12 +26,16 @@
 // --- measured broken before the fix ---
 
 fn bits_lo_in_closure() -> Int {
-  let f = (x: Double) -> Int { Double::to_i64_bits_lo(x) }
+  let f = (x: Double) -> Int {
+    Double::to_i64_bits_lo(x)
+  }
   f(1.5)
 }
 
 fn bits_hi_in_closure() -> Int {
-  let f = (x: Double) -> Int { Double::to_i64_bits_hi(x) }
+  let f = (x: Double) -> Int {
+    Double::to_i64_bits_hi(x)
+  }
   // 1.5 as f64 is 0x3FF8000000000000: the high half is 0x3FF80000, the low
   // half is 0. Asserting on the HIGH half matters -- a fixture that only read
   // the low half would pass on a lane that returned a constant 0.
@@ -39,33 +43,56 @@ fn bits_hi_in_closure() -> Int {
 }
 
 fn int_to_string_in_closure() -> Int {
-  let f = (x: Int) -> String { Int::to_string(x) }
+  let f = (x: Int) -> String {
+    Int::to_string(x)
+  }
   String::length(f(42))
 }
 
 fn map_has_key_in_closure() -> Int {
   let m = Map::new()
-  let f = (k: String) -> Int { if Map::has_key(m, k) { 1 } else { 0 } }
+  let f = (k: String) -> Int {
+    if Map::has_key(m, k) {
+      1
+    } else {
+      0
+    }
+  }
   f("absent")
 }
 
 // --- measured working before the fix (over-exclusion guard) ---
 
 fn array_length_in_closure() -> Int {
-  let a = [1, 2, 3]
-  let f = () -> Int { Array::length(a) }
+  let a = [
+    1,
+    2,
+    3
+  ]
+  let f = () -> Int {
+    Array::length(a)
+  }
   f()
 }
 
 fn array_slice_in_closure() -> Int {
-  let a = [1, 2, 3, 4]
-  let f = (n: Int) -> Int { Array::length(Array::slice(a, 0, n)) }
+  let a = [
+    1,
+    2,
+    3,
+    4
+  ]
+  let f = (n: Int) -> Int {
+    Array::length(Array::slice(a, 0, n))
+  }
   f(3)
 }
 
 fn fixed_array_get_in_closure() -> Int {
   let a = FixedArray::make(4, 7)
-  let f = (i: Int) -> Int { FixedArray::get(a, i) }
+  let f = (i: Int) -> Int {
+    FixedArray::get(a, i)
+  }
   f(2)
 }
 
@@ -83,7 +110,9 @@ fn string_builder_in_closure() -> Int {
 // the closure environment while `Int::to_string` must not.
 fn local_and_builtin_together() -> Int {
   let n = 7
-  let f = () -> Int { String::length(Int::to_string(n)) + n }
+  let f = () -> Int {
+    String::length(Int::to_string(n)) + n
+  }
   f()
 }
 

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -185,6 +185,10 @@ import @vibe/compiler/codegen/builtin_bodies {
   gen_string_trim_body
 }
 
+import ./backend_direct_abi_names.vibe {
+  gc_direct_abi_name_has_spelling_lowering
+}
+
 import ./backend_builtins_array_alloc.vibe {
   gc_gen_arr_concat_body,
   gc_gen_arr_len_body,
@@ -916,29 +920,6 @@ export fn gc_direct_abi_pre_erasure_generic_names(stmts: Array[Stmt]) -> Array[S
     i = i + 1
   }
   names
-}
-
-/// Names intercepted by spelling before ordinary func-table dispatch in
-/// backend_call.vibe. A user declaration with any of these spellings makes
-/// typed user signatures unsafe: the call site can otherwise take a builtin
-/// path while the body/type sections describe a `(ref null array)` user ABI.
-/// Keep this list in sync with the `fname == ...` dispatch chain there.
-fn gc_direct_abi_name_has_spelling_lowering(name: String) -> Bool {
-  name == "Array::length" || name == "Array::get" || name == "Array::set" ||
-  name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk" ||
-  name == "__slice" || name == "__index" || name == "__set_field" || name == "__rec_field" || name == "__len" ||
-  name == "Array::slice" || name == "Array::concat" || name == "Array::truncate" || name == "Array::push_all" ||
-  name == "perform" || name == "eq" || name == "not" ||
-  name == "Double::from_i64_bits" || name == "Double::to_i64_bits_lo" || name == "Double::to_i64_bits_hi" ||
-  name == "__to_string" || name == "to_string" || name == "Int::to_string" ||
-  name == "MapBuilder::new" || name == "MapBuilder::set" || name == "MapBuilder::freeze" || name == "MapBuilder::has_key" || name == "MapBuilder::get" ||
-  name == "Map::set" || name == "Map::get" || name == "Map::has_key" || name == "map_has" || name == "Map::keys" ||
-  name == "StringBuilder::new" || name == "StringBuilder::push" || name == "StringBuilder::freeze" ||
-  name == "print" || name == "println" || name == "assert" || name == "assert_true" || name == "assert_eq" ||
-  name == "FixedArray::make" || name == "Int64Array::make" || name == "FixedArray::length" || name == "Int64Array::length" ||
-  name == "FixedArray::get" || name == "Int64Array::get" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "Int64Array::set" || name == "FixedArray::blit" ||
-  name == "v128_load" || name == "v128_store" || name == "v128_splat_i8x16" || name == "v128_eq_i8x16" || name == "v128_le_u_i8x16" || name == "v128_ge_u_i8x16" ||
-  name == "v128_and" || name == "v128_or" || name == "v128_not" || name == "v128_bitmask_i8x16" || name == "v128_any_true" || name == "v128_all_true_i8x16"
 }
 
 fn gc_direct_abi_name_is_exported(stmts: Array[Stmt], name: String) -> Bool {

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -538,8 +538,19 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       // rewrite mirrors the linear lane's (codegen/expr/compile_call.vibe):
       // bind the value once, then slice it. Guarded on the name not resolving
       // to anything real, same as every other builtin spelling here.
+      //
+      // The marker on the next line suppresses the gc_direct_abi_names() drift
+      // rule, deliberately: both conversions have real func-table bodies, so
+      // `globals` already keeps the lambda capture scan off them -- this is a
+      // rewrite of a call that already resolves, not a spelling that exists
+      // only here. Measured before suppressing: a closure calling
+      // `FrozenArray::from_array` compiles and runs on both lanes. Listing
+      // them would instead claim a user declaration with those names is
+      // unsafe, which is not what this branch means.
       if !source_is_bound && Array::length(args) == 1 && (fname == "FrozenArray::from_array" || fname == "FrozenArray::to_array") {
+        // review-lint: allow-gc-direct-abi-unlisted
         let ftmp = if fname == "FrozenArray::from_array" {
+          // review-lint: allow-gc-direct-abi-unlisted
           "__frozen_in"
         } else {
           "__frozen_out"

--- a/lib/@vibe/compiler/codegen/gc/backend_direct_abi_names.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_direct_abi_names.vibe
@@ -20,6 +20,16 @@
 //
 // Keep in sync with the `fname == ...` dispatch chain in backend_call.vibe.
 
+//# Imports
+
+import @vibe/compiler/core {
+  canonical_builtin_name
+}
+
+import @vibe/compiler/codegen/common_extractors {
+  array_contains_str
+}
+
 //# Functions
 
 fn gc_direct_abi_names() -> Array[String] {
@@ -107,34 +117,42 @@ fn gc_direct_abi_name_has_spelling_lowering(name: String) -> Bool {
   found
 }
 
-/// The subset the lambda capture scan may treat as globals. Restricted to
-/// NAMESPACED spellings on purpose: `Foo::bar` is not a legal binding name
-/// (the parser rejects `let Array::length = ..` at the `::`), so such a name
-/// can never denote an enclosing local and dropping it from the capture set
-/// can never drop a real capture.
+/// Whether the lambda capture scan must treat `name` as resolving globally
+/// (so it is NOT an environment slot of the closure).
 ///
-/// The bare names above (`print`, `eq`, `not`, `to_string`, the `v128_*`
+/// Two things have to line up with `compile_call_gc`, and both were wrong
+/// before:
+///
+///  1. It canonicalizes with `canonical_builtin_name` BEFORE dispatching, so
+///     the capture scan has to canonicalize too. The scan sees the SOURCE
+///     spelling, so `StringBuilder::build` (alias of `StringBuilder::freeze`)
+///     was still captured and died in codegen even after the direct list was
+///     shared. Canonicalizing here covers every present and future alias --
+///     listing the aliases would just be a third copy to drift. The canonical
+///     form is checked against `globals` too, not only the direct-ABI list:
+///     `String::byte_at` canonicalizes to `String::char_code_at`, which the gc
+///     lane resolves through the func table rather than by spelling.
+///  2. Only NAMESPACED spellings qualify. `Foo::bar` is not a legal binding
+///     name (the parser rejects `let Array::length = ..` at the `::`), so such
+///     a name can never denote an enclosing local and dropping it can never
+///     drop a real capture.
+///
+/// The bare names in the list (`print`, `eq`, `not`, `to_string`, the `v128_*`
 /// family, ...) ARE legal binding names, so excluding them unconditionally
 /// would be the worse failure: a closure over a user local named `print` would
 /// silently lose its capture instead of raising. Those need shadowing-aware
 /// resolution, not a name list.
-fn gc_capture_global_builtin_names() -> Array[String] {
-  let names = gc_direct_abi_names()
-  let out = [
-  ]
-  let mut i = 0
-  while i < Array::length(names) {
-    let n = Array::get(names, i)
-    if String::contains(n, "::") {
-      Array::push(out, n)
-    }
-    i = i + 1
+fn gc_capture_resolves_globally(name: String, globals: Array[String]) -> Bool {
+  if String::contains(name, "::") {
+    let canonical = canonical_builtin_name(name)
+    gc_direct_abi_name_has_spelling_lowering(canonical) || array_contains_str(globals, canonical)
+  } else {
+    false
   }
-  out
 }
 
 //# Misc
 
 export {
-  gc_capture_global_builtin_names, gc_direct_abi_name_has_spelling_lowering
+  gc_capture_resolves_globally, gc_direct_abi_name_has_spelling_lowering
 }

--- a/lib/@vibe/compiler/codegen/gc/backend_direct_abi_names.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_direct_abi_names.vibe
@@ -1,0 +1,140 @@
+//# Direct-ABI builtin names (gc lane)
+//
+// The names `compile_call_gc` intercepts by spelling before ordinary
+// func-table dispatch. TWO passes need this set and they sit on opposite sides
+// of the package's import graph:
+//
+//   - `backend_body.vibe` rejects user declarations with these spellings (a
+//     user body would otherwise describe a `(ref null array)` ABI while the
+//     call site takes the builtin path)
+//   - `backend_lambda_collect.vibe` must not collect them as free variables of
+//     a lambda -- they resolve globally, so capturing them lands in
+//     `emit_lambda_closure_gc` as "reached code generation unresolved"
+//
+// The second copy had drifted to 6 of the ~60 names, so a lambda calling e.g.
+// `Double::to_i64_bits_lo` died while the same call at statement level
+// compiled. This file exists so there is one copy: it deliberately has NO
+// imports, because `backend_body.vibe` already reaches
+// `backend_lambda_collect.vibe` transitively and putting the list in either
+// one closes an import cycle.
+//
+// Keep in sync with the `fname == ...` dispatch chain in backend_call.vibe.
+
+//# Functions
+
+fn gc_direct_abi_names() -> Array[String] {
+  [
+    "Array::length",
+    "Array::get",
+    "Array::set",
+    "Stdin::read_via_stream",
+    "StdinStream::next",
+    "StdinStream::close",
+    "StdinStream::read_chunk",
+    "__slice",
+    "__index",
+    "__set_field",
+    "__rec_field",
+    "__len",
+    "Array::slice",
+    "Array::concat",
+    "Array::truncate",
+    "Array::push_all",
+    "perform",
+    "eq",
+    "not",
+    "Double::from_i64_bits",
+    "Double::to_i64_bits_lo",
+    "Double::to_i64_bits_hi",
+    "__to_string",
+    "to_string",
+    "Int::to_string",
+    "MapBuilder::new",
+    "MapBuilder::set",
+    "MapBuilder::freeze",
+    "MapBuilder::has_key",
+    "MapBuilder::get",
+    "Map::set",
+    "Map::get",
+    "Map::has_key",
+    "map_has",
+    "Map::keys",
+    "StringBuilder::new",
+    "StringBuilder::push",
+    "StringBuilder::freeze",
+    "print",
+    "println",
+    "assert",
+    "assert_true",
+    "assert_eq",
+    "FixedArray::make",
+    "Int64Array::make",
+    "FixedArray::length",
+    "Int64Array::length",
+    "FixedArray::get",
+    "Int64Array::get",
+    "FixedArray::set",
+    "FixedArray::unsafe_set",
+    "Int64Array::set",
+    "FixedArray::blit",
+    "v128_load",
+    "v128_store",
+    "v128_splat_i8x16",
+    "v128_eq_i8x16",
+    "v128_le_u_i8x16",
+    "v128_ge_u_i8x16",
+    "v128_and",
+    "v128_or",
+    "v128_not",
+    "v128_bitmask_i8x16",
+    "v128_any_true",
+    "v128_all_true_i8x16"
+  ]
+}
+
+/// A user declaration with any of these spellings makes typed user signatures
+/// unsafe -- see the header.
+fn gc_direct_abi_name_has_spelling_lowering(name: String) -> Bool {
+  let names = gc_direct_abi_names()
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = true
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// The subset the lambda capture scan may treat as globals. Restricted to
+/// NAMESPACED spellings on purpose: `Foo::bar` is not a legal binding name
+/// (the parser rejects `let Array::length = ..` at the `::`), so such a name
+/// can never denote an enclosing local and dropping it from the capture set
+/// can never drop a real capture.
+///
+/// The bare names above (`print`, `eq`, `not`, `to_string`, the `v128_*`
+/// family, ...) ARE legal binding names, so excluding them unconditionally
+/// would be the worse failure: a closure over a user local named `print` would
+/// silently lose its capture instead of raising. Those need shadowing-aware
+/// resolution, not a name list.
+fn gc_capture_global_builtin_names() -> Array[String] {
+  let names = gc_direct_abi_names()
+  let out = [
+  ]
+  let mut i = 0
+  while i < Array::length(names) {
+    let n = Array::get(names, i)
+    if String::contains(n, "::") {
+      Array::push(out, n)
+    }
+    i = i + 1
+  }
+  out
+}
+
+//# Misc
+
+export {
+  gc_capture_global_builtin_names, gc_direct_abi_name_has_spelling_lowering
+}

--- a/lib/@vibe/compiler/codegen/gc/backend_lambda_collect.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_lambda_collect.vibe
@@ -13,7 +13,7 @@ import @vibe/compiler/codegen/common_analysis {
 }
 
 import ./backend_direct_abi_names.vibe {
-  gc_capture_global_builtin_names
+  gc_capture_resolves_globally
 }
 
 import @vibe/compiler/codegen/common_base {
@@ -50,12 +50,25 @@ export fn collect_lambda_captures_gc(params: Array[(String, Option[TypeExpr])], 
   // `compile_call_gc` dispatches by spelling, and this list had drifted from
   // that one: a closure calling any of the others captured the builtin's own
   // spelling as a free variable, then died in `emit_lambda_closure_gc` with
-  // "reached code generation unresolved". Take the namespaced ones from the
-  // single list in backend_direct_abi_names.vibe instead of restating them
-  // here -- see
-  // `gc_capture_global_builtin_names` for why bare spellings are excluded.
-  globals = Array::concat(globals, gc_capture_global_builtin_names())
-  let captures = collect_free_vars(fn_body, param_names_arr, globals)
+  // "reached code generation unresolved".
+  //
+  // The rest is a POST-filter rather than more entries in `globals` because
+  // `compile_call_gc` canonicalizes the callee before dispatching, and a name
+  // list cannot express that: `StringBuilder::build` is a source alias of
+  // `StringBuilder::freeze`, so the scan sees a spelling that is in neither
+  // the func table nor the direct-ABI list. Asking the shared predicate --
+  // which canonicalizes, then re-checks BOTH the direct-ABI list and the
+  // `globals` computed above -- covers every alias, present and future.
+  let raw_captures = collect_free_vars(fn_body, param_names_arr, globals)
+  let captures = array_empty()
+  let mut ci = 0
+  while ci < Array::length(raw_captures) {
+    let cap = Array::get(raw_captures, ci)
+    if !gc_capture_resolves_globally(cap, globals) {
+      Array::push(captures, cap)
+    }
+    ci = ci + 1
+  }
   let num_captures = Array::length(captures)
   let user_params = Array::length(params)
   (captures, num_captures, user_params)

--- a/lib/@vibe/compiler/codegen/gc/backend_lambda_collect.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_lambda_collect.vibe
@@ -12,6 +12,10 @@ import @vibe/compiler/codegen/common_analysis {
   collect_free_vars
 }
 
+import ./backend_direct_abi_names.vibe {
+  gc_capture_global_builtin_names
+}
+
 import @vibe/compiler/codegen/common_base {
   CompileCtxGc, CtorTable, FuncTable
 }
@@ -42,6 +46,15 @@ export fn collect_lambda_captures_gc(params: Array[(String, Option[TypeExpr])], 
     "__slice",
     "__rec_field"
   ])
+  // The `__`-prefixed desugar builtins above are only 6 of the ~60 names
+  // `compile_call_gc` dispatches by spelling, and this list had drifted from
+  // that one: a closure calling any of the others captured the builtin's own
+  // spelling as a free variable, then died in `emit_lambda_closure_gc` with
+  // "reached code generation unresolved". Take the namespaced ones from the
+  // single list in backend_direct_abi_names.vibe instead of restating them
+  // here -- see
+  // `gc_capture_global_builtin_names` for why bare spellings are excluded.
+  globals = Array::concat(globals, gc_capture_global_builtin_names())
   let captures = collect_free_vars(fn_body, param_names_arr, globals)
   let num_captures = Array::length(captures)
   let user_params = Array::length(params)

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -172,6 +172,7 @@ codegen	codegen/gc/backend_builtins_numeric.vibe
 codegen	codegen/gc/backend_builtins.vibe
 codegen	codegen/gc/backend_core.vibe
 codegen	codegen/gc/backend_entry.vibe
+codegen	codegen/gc/backend_direct_abi_names.vibe
 codegen	codegen/gc/backend_body.vibe
 codegen	codegen/gc/backend_expr.vibe
 codegen	codegen/gc/backend_call.vibe

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4250,6 +4250,39 @@ fi
 rm -rf "$gcdir"
 echo "[compiler-gate] wasm-gc backend smoke ok (101557)"
 
+# 40h-2. wasm-gc lane: a builtin called from INSIDE a closure must not be
+#        collected as a free variable of that closure. `compile_call_gc`
+#        dispatches ~60 builtins by spelling and the lambda capture scan has to
+#        know the same set; the two lists had drifted (capture scan carried 6),
+#        so a lambda calling e.g. `Double::to_i64_bits_lo` died with
+#        "reached code generation unresolved" while the SAME call at statement
+#        level compiled fine. Every gc fixture called these at the top level,
+#        which is why it survived. The fixture also asserts the over-exclusion
+#        direction (a real local must still be captured) -- widening the set
+#        past namespaced spellings would drop real captures silently, which is
+#        worse than the ICE. Runs on BOTH lanes: the bug is gc-only, so linear
+#        is the control that proves the fixture is not vacuous.
+echo "[compiler-gate] 40h-2/40 wasm-gc closure builtin capture"
+gccapdir="_build/_gate_gc_closure_capture"
+rm -rf "$gccapdir"; mkdir -p "$gccapdir"
+for gccap_be in linear gc; do
+  env -u VIBE_FS_COMPILE VIBE_BACKEND="$gccap_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "fixtures/gc_closure_builtin_capture_test.vibe" "$gccapdir/$gccap_be.wasm" __no_entry__ >/dev/null 2>&1
+  if [ ! -s "$gccapdir/$gccap_be.wasm" ]; then
+    echo "[compiler-gate] FAIL: gc_closure_builtin_capture_test.vibe did not compile on the $gccap_be backend" >&2
+    cat "$gccapdir/$gccap_be.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gccapdir/$gccap_be.wasm" >"$gccapdir/$gccap_be.out" 2>&1; then
+    echo "[compiler-gate] FAIL: gc_closure_builtin_capture_test.vibe failed at run time on the $gccap_be backend" >&2
+    cat "$gccapdir/$gccap_be.out" >&2
+    exit 1
+  fi
+done
+rm -rf "$gccapdir"
+echo "[compiler-gate] wasm-gc closure builtin capture ok (linear + gc)"
+
 # #1295: String is a packed fat pointer, so the gc EForIn lowering must
 # normalize it to character codes before its shared Array iteration loop.
 echo "[compiler-gate] wasm-gc String for-in"

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4283,6 +4283,33 @@ done
 rm -rf "$gccapdir"
 echo "[compiler-gate] wasm-gc closure builtin capture ok (linear + gc)"
 
+# 40h-3. Same rule reached through a SOURCE ALIAS. `compile_call_gc`
+#        canonicalizes the callee before dispatching while the capture scan
+#        sees the source spelling, so sharing the direct-ABI list was not
+#        enough: `StringBuilder::build` (alias of `StringBuilder::freeze`)
+#        matched neither the func table nor the list and was still captured.
+#        GC LANE ONLY -- the linear backend emits an INVALID module for these
+#        while reporting a successful compile (#1811), so linear coverage would
+#        pin a known-broken artifact rather than prove anything.
+echo "[compiler-gate] 40h-3/40 wasm-gc closure builtin alias capture"
+gcaliasdir="_build/_gate_gc_closure_alias"
+rm -rf "$gcaliasdir"; mkdir -p "$gcaliasdir"
+env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "fixtures/gc_closure_builtin_alias_test.vibe" "$gcaliasdir/alias.wasm" __no_entry__ >/dev/null 2>&1
+if [ ! -s "$gcaliasdir/alias.wasm" ]; then
+  echo "[compiler-gate] FAIL: gc_closure_builtin_alias_test.vibe did not compile on the gc backend" >&2
+  cat "$gcaliasdir/alias.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcaliasdir/alias.wasm" >"$gcaliasdir/alias.out" 2>&1; then
+  echo "[compiler-gate] FAIL: gc_closure_builtin_alias_test.vibe failed at run time on the gc backend" >&2
+  cat "$gcaliasdir/alias.out" >&2
+  exit 1
+fi
+rm -rf "$gcaliasdir"
+echo "[compiler-gate] wasm-gc closure builtin alias capture ok (gc)"
+
 # #1295: String is a packed fat pointer, so the gc EForIn lowering must
 # normalize it to character codes before its shared Array iteration loop.
 echo "[compiler-gate] wasm-gc String for-in"

--- a/scripts/review_lint.vibex
+++ b/scripts/review_lint.vibex
@@ -208,6 +208,19 @@ fn report_async_substring_hits(raw: String, emit: Bool) -> Int with Stderr {
 // The set now lives once, in `gc_direct_abi_names()`. This rule keeps the
 // dispatch chain from growing past it: every `fname == "..."` literal in
 // backend_call.vibe must appear in that file.
+// The marker is looked for in a small window, not on the hit line alone. The
+// vibe formatter relocates a trailing `//` comment onto the FOLLOWING line, so
+// a strictly-hit-line key (what the fixed-synthetic-name rule uses) silently
+// stops matching the first time anyone runs `pkf run fmt` -- and a suppression
+// that stops suppressing turns into a spurious finding, not a missed one, so
+// it would at least be loud. The window keeps it correct either way.
+fn gc_drift_suppressed(path: String, line: Int) -> Bool with Fs {
+  let marker = "review-lint: allow-gc-direct-abi-unlisted"
+  String::contains(source_line(path, line), marker) ||
+  String::contains(source_line(path, line + 1), marker) ||
+  String::contains(source_line(path, line - 1), marker)
+}
+
 fn report_gc_direct_abi_drift(raw: String, names_source: String, emit: Bool) -> Int with Fs + Stderr {
   let hits = Json::parse(raw)
   let mut i = 0
@@ -225,7 +238,7 @@ fn report_gc_direct_abi_drift(raw: String, names_source: String, emit: Bool) -> 
     // that already resolves, so `globals` keeps the capture scan off them and
     // listing them would instead claim a user declaration with those names is
     // unsafe. Measured before suppressing, not assumed.
-    let suppressed = String::contains(source_line(path, line), "review-lint: allow-gc-direct-abi-unlisted")
+    let suppressed = gc_drift_suppressed(path, line)
     if String::contains(path, "codegen/gc/backend_call.vibe") && !suppressed && !String::contains(names_source, literal) {
       if emit {
         report_finding(
@@ -257,13 +270,28 @@ fn run_grep(vibe: String, root: String, pattern: String) -> (Int, String) with P
 }
 
 fn gc_direct_abi_names_source(root: String) -> String with Fs {
-  // Absent when the lint runs over a subtree that does not contain the gc
-  // backend (or a staged snapshot that did not touch it). Returning "" makes
-  // the rule report every dispatch literal, so skip it instead -- a lint that
-  // fires on "I could not read the list" is noise, not a finding.
-  let path = root + "/codegen/gc/backend_direct_abi_names.vibe"
-  if Fs::exists(path) {
-    Fs::read_file(path)
+  // `--root` arrives in two shapes: the package subtree (`lib/@vibe/compiler`)
+  // when run by hand, and a REPO-ROOT-shaped staged snapshot from
+  // lint_review_regressions.sh. Try both, then fall back to the working tree.
+  //
+  // The fallback is the point, not a convenience. The snapshot only
+  // materializes STAGED paths, so a commit that adds a dispatch spelling to
+  // backend_call.vibe without touching the list -- exactly what this rule
+  // exists to catch -- would leave the list file absent and the rule would
+  // skip itself. Reading the working tree gives the authoritative list
+  // regardless of what happens to be staged.
+  let suffix = "/codegen/gc/backend_direct_abi_names.vibe"
+  let in_subtree = root + suffix
+  let in_snapshot = root + "/lib/@vibe/compiler" + suffix
+  let in_worktree = "lib/@vibe/compiler" + suffix
+  if Fs::exists(in_subtree) {
+    Fs::read_file(in_subtree)
+  } else if Fs::exists(in_snapshot) {
+    Fs::read_file(in_snapshot)
+  } else if Fs::exists(in_worktree) {
+    // Genuinely absent from every candidate means the gc backend is not in
+    // this tree at all, so there is no list to stay in sync with.
+    Fs::read_file(in_worktree)
   } else {
     ""
   }
@@ -323,11 +351,20 @@ fn gc_dispatch_hit(literal: String) -> String {
   "[{\"path\":\"/repo/lib/@vibe/compiler/codegen/gc/backend_call.vibe\",\"line\":9,\"text\":\"fname == " + literal + "\",\"captures\":{\"name\":{\"text\":\"" + literal + "\"}}}]"
 }
 
-// The suppression is keyed to the hit's own line, like the fixed-synthetic-name
-// rule, so the marker has to sit on the comparison itself. This synthetic hit
-// points at a real repository line carrying the marker.
-fn gc_suppressed_hit(root: String) -> String {
-  "[{\"path\":\"" + root + "/codegen/gc/backend_call.vibe\",\"line\":550,\"text\":\"fname == \\\"FrozenArray::from_array\\\"\",\"captures\":{\"name\":{\"text\":\"\\\"FrozenArray::from_array\\\"\"}}}]"
+// Written to disk rather than pointed at a repository line: keying the
+// self-test to a line number in backend_call.vibe would make it fail whenever
+// that file grows a line, which tests the wrong thing.
+fn gc_write_suppression_probe(path: String, with_marker: Bool) -> Unit with Fs {
+  let body = if with_marker {
+    "fname == \"Whatever::nope\"\n// review-lint: allow-gc-direct-abi-unlisted\n"
+  } else {
+    "fname == \"Whatever::nope\"\n// ordinary comment\n"
+  }
+  Fs::write_file(path, body)
+}
+
+fn gc_probe_hit(path: String) -> String {
+  "[{\"path\":\"" + path + "\",\"line\":1,\"text\":\"fname == \\\"Whatever::nope\\\"\",\"captures\":{\"name\":{\"text\":\"\\\"Whatever::nope\\\"\"}}}]"
 }
 
 fn gc_other_file_hit() -> String {
@@ -340,6 +377,12 @@ fn self_test() -> Int with Fs + Stderr {
   let good_assign = "[{\"path\":\"/repo/lib/@vibe/compiler/runtime/grep.vibe\",\"line\":2,\"text\":\"EAssignOp(name, op, v, b)\",\"captures\":{\"operator\":{\"text\":\"op\"}}}]"
   let bad_async = "[{\"path\":\"/repo/lib/@vibe/compiler/entry/preprocess.vibe\",\"line\":3,\"text\":\"String::contains(row, Async)\",\"captures\":{}}]"
   let gc_names_sample = gc_names_sample()
+  // The probes carry "codegen/gc/backend_call.vibe" in their path so the rule's
+  // file filter accepts them, while living under _build.
+  let probe_marked = "_build/_review_lint_probe/codegen/gc/backend_call.vibe"
+  let probe_plain = "_build/_review_lint_probe_plain/codegen/gc/backend_call.vibe"
+  gc_write_suppression_probe(probe_marked, true)
+  gc_write_suppression_probe(probe_plain, false)
   if !starts_with_synthetic_literal("\"__tmp\"") {
     Stderr::write_stream("review-lint self-test: synthetic literal was not recognized\n")
     1
@@ -367,8 +410,20 @@ fn self_test() -> Int with Fs + Stderr {
   } else if report_gc_direct_abi_drift(gc_other_file_hit(), gc_names_sample, false) != 0 {
     Stderr::write_stream("review-lint self-test: a comparison outside backend_call.vibe was reported\n")
     1
-  } else if report_gc_direct_abi_drift(gc_suppressed_hit("lib/@vibe/compiler"), gc_names_sample, false) != 0 {
+  } else if report_gc_direct_abi_drift(gc_probe_hit(probe_marked), gc_names_sample, false) != 0 {
     Stderr::write_stream("review-lint self-test: the reasoned suppression marker was ignored\n")
+    1
+  } else if report_gc_direct_abi_drift(gc_probe_hit(probe_plain), gc_names_sample, false) != 1 {
+    Stderr::write_stream("review-lint self-test: an unmarked comparison was suppressed anyway\n")
+    1
+  } else if !String::contains(gc_direct_abi_names_source("/nonexistent-staged-snapshot"), "\"Array::length\"") {
+    // The staged snapshot only materializes staged paths, so the rule has to
+    // reach the working tree to stay armed when only backend_call.vibe is
+    // staged -- the very commit shape it exists to catch.
+    Stderr::write_stream("review-lint self-test: the list lookup did not fall back to the working tree\n")
+    1
+  } else if gc_direct_abi_names_source("/nonexistent") == "" {
+    Stderr::write_stream("review-lint self-test: the list lookup returned empty and would skip the rule\n")
     1
   } else {
     0

--- a/scripts/review_lint.vibex
+++ b/scripts/review_lint.vibex
@@ -197,6 +197,55 @@ fn report_async_substring_hits(raw: String, emit: Bool) -> Int with Stderr {
   count
 }
 
+// #1809: the gc backend intercepts builtins by SPELLING in `compile_call_gc`
+// before ordinary func-table dispatch, and the lambda capture scan has to know
+// that same set -- a name it does not know is collected as a free variable of
+// the closure and dies in `emit_lambda_closure_gc` with "reached code
+// generation unresolved". The two copies drifted once already (the capture
+// scan carried 6 of ~60 names), and the failure only shows one lambda deep, so
+// every top-level fixture stayed green.
+//
+// The set now lives once, in `gc_direct_abi_names()`. This rule keeps the
+// dispatch chain from growing past it: every `fname == "..."` literal in
+// backend_call.vibe must appear in that file.
+fn report_gc_direct_abi_drift(raw: String, names_source: String, emit: Bool) -> Int with Fs + Stderr {
+  let hits = Json::parse(raw)
+  let mut i = 0
+  let mut count = 0
+  while i < Json::length(hits) {
+    let hit = Json::index(hits, i)
+    let path = Json::string(Json::field(hit, "path"))
+    let literal = Json::string(Json::field(Json::field(Json::field(hit, "captures"), "name"), "text"))
+    // `literal` still carries its quotes, and the single list stores quoted
+    // strings too, so a containment test cannot match a bare substring of a
+    // longer name (`"Map::get"` never matches `"MapBuilder::get"`).
+    let line = Double::to_int(Json::number(Json::field(hit, "line")))
+    // Not every spelling in the chain belongs in the list. `FrozenArray`'s two
+    // conversions have real func-table bodies -- the branch rewrites a call
+    // that already resolves, so `globals` keeps the capture scan off them and
+    // listing them would instead claim a user declaration with those names is
+    // unsafe. Measured before suppressing, not assumed.
+    let suppressed = String::contains(source_line(path, line), "review-lint: allow-gc-direct-abi-unlisted")
+    if String::contains(path, "codegen/gc/backend_call.vibe") && !suppressed && !String::contains(names_source, literal) {
+      if emit {
+        report_finding(
+          path,
+          line,
+          Json::string(Json::field(hit, "text")),
+          "gc dispatches " + literal + " by spelling but gc_direct_abi_names() does not list it; the lambda capture scan will collect it as a free variable and codegen will fail on it"
+        )
+      } else {
+        ()
+      }
+      count = count + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  count
+}
+
 fn run_grep(vibe: String, root: String, pattern: String) -> (Int, String) with Process {
   let cmd = shell_quote(vibe) + " grep --json --pattern " + shell_quote(pattern) + " " + shell_quote(root)
   let result = sh_capture(cmd)
@@ -207,12 +256,26 @@ fn run_grep(vibe: String, root: String, pattern: String) -> (Int, String) with P
   }
 }
 
+fn gc_direct_abi_names_source(root: String) -> String with Fs {
+  // Absent when the lint runs over a subtree that does not contain the gc
+  // backend (or a staged snapshot that did not touch it). Returning "" makes
+  // the rule report every dispatch literal, so skip it instead -- a lint that
+  // fires on "I could not read the list" is noise, not a finding.
+  let path = root + "/codegen/gc/backend_direct_abi_names.vibe"
+  if Fs::exists(path) {
+    Fs::read_file(path)
+  } else {
+    ""
+  }
+}
+
 fn lint(root: String, vibe: String) -> Int with Fs + Process + Stderr {
   let patterns = [
     "$(ctor:id)($(name:const), $(rest:args))",
     "SLet($(a:arg), $(b:arg), $(name:const), $(rest:args))",
     "EAssignOp($(target:arg), $(operator:id), $(rest:args))",
-    "String::contains($(row:exp), \"Async\")"
+    "String::contains($(row:exp), \"Async\")",
+    "fname == $(name:const)"
   ]
   let mut i = 0
   let mut violations = 0
@@ -227,8 +290,15 @@ fn lint(root: String, vibe: String) -> Int with Fs + Process + Stderr {
         violations = violations + report_hits(output, i == 0, true)
       } else if i == 2 {
         violations = violations + report_assign_op_hits(output, true)
-      } else {
+      } else if i == 3 {
         violations = violations + report_async_substring_hits(output, true)
+      } else {
+        let names_source = gc_direct_abi_names_source(root)
+        if names_source == "" {
+          ()
+        } else {
+          violations = violations + report_gc_direct_abi_drift(output, names_source, true)
+        }
       }
     }
     i = i + 1
@@ -243,11 +313,33 @@ fn lint(root: String, vibe: String) -> Int with Fs + Process + Stderr {
   }
 }
 
+// The list stores quoted strings, so `"Map::get"` must not be satisfied by
+// `"MapBuilder::get"` appearing in the file.
+fn gc_names_sample() -> String {
+  "  [\n    \"Array::length\",\n    \"MapBuilder::get\",\n    \"Map::get\"\n  ]"
+}
+
+fn gc_dispatch_hit(literal: String) -> String {
+  "[{\"path\":\"/repo/lib/@vibe/compiler/codegen/gc/backend_call.vibe\",\"line\":9,\"text\":\"fname == " + literal + "\",\"captures\":{\"name\":{\"text\":\"" + literal + "\"}}}]"
+}
+
+// The suppression is keyed to the hit's own line, like the fixed-synthetic-name
+// rule, so the marker has to sit on the comparison itself. This synthetic hit
+// points at a real repository line carrying the marker.
+fn gc_suppressed_hit(root: String) -> String {
+  "[{\"path\":\"" + root + "/codegen/gc/backend_call.vibe\",\"line\":550,\"text\":\"fname == \\\"FrozenArray::from_array\\\"\",\"captures\":{\"name\":{\"text\":\"\\\"FrozenArray::from_array\\\"\"}}}]"
+}
+
+fn gc_other_file_hit() -> String {
+  "[{\"path\":\"/repo/lib/@vibe/compiler/codegen/expr/compile_call.vibe\",\"line\":9,\"text\":\"fname == \\\"Nope::nope\\\"\",\"captures\":{\"name\":{\"text\":\"\\\"Nope::nope\\\"\"}}}]"
+}
+
 fn self_test() -> Int with Fs + Stderr {
   let raw = "[{\"path\":\"/repo/lib/@vibe/compiler/normalize/pass.vibe\",\"line\":1,\"text\":\"ELet(\\\"__tmp\\\", e, e, -1)\",\"captures\":{\"name\":{\"text\":\"\\\"__tmp\\\"\"}}}]"
   let bad_assign = "[{\"path\":\"/repo/lib/@vibe/compiler/runtime/grep.vibe\",\"line\":2,\"text\":\"EAssignOp(_, name, v, b)\",\"captures\":{\"operator\":{\"text\":\"name\"}}}]"
   let good_assign = "[{\"path\":\"/repo/lib/@vibe/compiler/runtime/grep.vibe\",\"line\":2,\"text\":\"EAssignOp(name, op, v, b)\",\"captures\":{\"operator\":{\"text\":\"op\"}}}]"
   let bad_async = "[{\"path\":\"/repo/lib/@vibe/compiler/entry/preprocess.vibe\",\"line\":3,\"text\":\"String::contains(row, Async)\",\"captures\":{}}]"
+  let gc_names_sample = gc_names_sample()
   if !starts_with_synthetic_literal("\"__tmp\"") {
     Stderr::write_stream("review-lint self-test: synthetic literal was not recognized\n")
     1
@@ -262,6 +354,21 @@ fn self_test() -> Int with Fs + Stderr {
     1
   } else if report_async_substring_hits(bad_async, false) != 1 {
     Stderr::write_stream("review-lint self-test: Async substring rule failed\n")
+    1
+  } else if report_gc_direct_abi_drift(gc_dispatch_hit("\\\"Array::brand_new\\\""), gc_names_sample, false) != 1 {
+    Stderr::write_stream("review-lint self-test: gc direct-ABI drift was not reported\n")
+    1
+  } else if report_gc_direct_abi_drift(gc_dispatch_hit("\\\"Array::length\\\""), gc_names_sample, false) != 0 {
+    Stderr::write_stream("review-lint self-test: a listed gc dispatch name was reported as drift\n")
+    1
+  } else if report_gc_direct_abi_drift(gc_dispatch_hit("\\\"Map::get\\\""), gc_names_sample, false) != 0 {
+    Stderr::write_stream("review-lint self-test: quoted containment matched a longer name\n")
+    1
+  } else if report_gc_direct_abi_drift(gc_other_file_hit(), gc_names_sample, false) != 0 {
+    Stderr::write_stream("review-lint self-test: a comparison outside backend_call.vibe was reported\n")
+    1
+  } else if report_gc_direct_abi_drift(gc_suppressed_hit("lib/@vibe/compiler"), gc_names_sample, false) != 0 {
+    Stderr::write_stream("review-lint self-test: the reasoned suppression marker was ignored\n")
     1
   } else {
     0

--- a/scripts/unit_test_runner.sh
+++ b/scripts/unit_test_runner.sh
@@ -57,6 +57,14 @@ EXCLUDE_PATTERNS=(
   # is that same category, not something this generic linear-backend runner
   # can be made to pass.
   '^fixtures/to_string_bool_gc_test\.vibe$'
+  # wasm-gc backend only, and for a reason that is NOT a gc gap: this fixture
+  # calls builtins through their source aliases (`StringBuilder::build`,
+  # `String::byte_at`) from inside a closure, and the LINEAR backend emits an
+  # invalid module for that while reporting a successful compile (#1811).
+  # compiler_gate.sh 40h-3 runs it on the gc lane, where it passes. Widen it
+  # back to this runner once #1811 lands -- keeping it here would pin a
+  # known-broken linear artifact instead of testing the capture scan.
+  '^fixtures/gc_closure_builtin_alias_test\.vibe$'
   # wasi p3 http client: currently failing, under active work on a separate
   # branch. Remove once that lands.
   '^fixtures/runtime/http_p3_client_test\.vibe$'


### PR DESCRIPTION
wasm-gc レーンで、**ラムダの中から builtin を呼ぶと ICE** になっていました。

```
internal compiler error: `Double::to_i64_bits_lo` (local, @gc_cap)
reached code generation unresolved.
```

同じ呼び出しが**文レベルなら通り、ラムダ 1 つ分内側に入った時だけ壊れます**。既存の gc fixture はどれもトップレベルで呼んでいたので見つかっていませんでした。

## 原因: リストの二重管理

`compile_call_gc` は約 60 個の builtin を**綴りで横取り**してから func-table 引きに落ちるので、ラムダの捕獲走査も同じ集合を知っている必要があります。ところが捕獲側 (`backend_lambda_collect.vibe`) は `__` 接頭辞の desugar builtin **6 個**しか持っておらず、残りは builtin の綴り自体が自由変数として集められ、`emit_lambda_closure_gc` の `resolve_local` で死んでいました。

`backend_body.vibe` 側のリストには doc コメントで「dispatch chain と同期を保て」と書いてありましたが、**同期すべき箇所がもう一つあることは誰も知らない状態**でした。

## 直し方: 葉ファイルに 1 本化

リストを依存を持たない葉ファイル `codegen/gc/backend_direct_abi_names.vibe` に移し、宣言側と捕獲側の両方がそこを見る形にしました。

最初はリストを `backend_body.vibe` に置いて捕獲側から import しましたが、**import cycle** になりました (`backend_body` は `backend_lambda_collect` へ推移的に到達している):

```
type_db: import cycle detected at lib/@vibe/compiler/codegen/gc/backend_body.vibe
```

葉ファイルなら循環が構造的に起こらないので、コメントの「同期を保て」に頼らなくて済みます。

## 捕獲集合から外すのは名前空間付きの綴りだけ

ここが判断の要ります。**外しすぎる方が悪い失敗**だからです。

- `Foo::bar` は束縛名として**構文エラー**になる (`let Array::length = ..` が `::` で落ちる)。したがって enclosing local を指すことがあり得ず、捕獲集合から外しても本物の捕獲を落とせません
- 一方 `print` / `eq` / `not` / `to_string` / `v128_*` のような**裸の綴りは正当な束縛名**です。無条件に外すと、ユーザの局所変数 `print` を捕獲し損ねて**黙って壊れます** — ICE より悪い

後者は名前リストではなく shadowing を見る解決が要るので、この PR では手を付けていません。

## 検証: Red → Green (linear が対照)

`fixtures/gc_closure_builtin_capture_test.vibe` を追加しました。

| | 修正前のコンパイラ | 修正後 |
|---|---|---|
| **gc** | ICE (`@gc_cap` unresolved) | exit 0 |
| **linear** | exit 0 | exit 0 |

linear が両方 green なのが重要で、これが**fixture が空回りしていない対照**になります (バグは gc 固有)。gate 40h-2 は両レーンで走らせています。

fixture には修正前に実際に壊れていた綴り (`Double::to_i64_bits_lo` / `to_i64_bits_hi` / `Int::to_string` / `Map::has_key`) だけでなく、**元から通っていた綴り** (`Array::length` / `Array::slice` / `FixedArray::get` / `StringBuilder::new`) と「実局所変数と builtin を同じクロージャで使う」ケースも入れました。後者が外しすぎ方向のガードです。

## どうやって見つけたか

「セルフビルドを wasm-gc backend で通せるか」を実測していて踏みました。コンパイラ自身の flat source (5.2 MB) を gc レーンに食わせると、**linear と同じ約 50 秒かけて型検査を通り切ってから** codegen のこの 1 点で落ちます。

ついでに分かった周辺情報 (この PR のスコープ外):

- 自己ビルドの入力は import を持たない flat source 1 本なので、「gc は direct source compile 専用」制約には**当たらない**
- この修正の先には builtin 12 個 (Fs 5 / Stdin・Stdout 3 / `Int::parse` / `Map::delete` / MutList 2) と region lowering (`__region_run`) が残る
- `selfbuild_compile_stage2` は `compile_source_wasi_only` を直接呼んでおり `VIBE_BACKEND` を見ない

また `Double::from_i64_bits` をクロージャで呼ぶと **linear が実行時に trap** するのを踏んだので、別件として #1805 に起票しました (修正前後どちらのコンパイラでも起きる既存バグ)。

## 検証状況

- fixture: Red → Green を上表のとおり実測
- `fixtures/gc_backend_smoke_test.vibe`: 101557 で不変
- `VIBE_MODULE_PLAN` (import cycle が落としていた箇所): 44,795 B の manifest を出力、診断なし
- `pkf run pre-commit`: 通過 (`--no-verify` なし)
- `scripts/vibe_fmt.sh --check`: 通過
- フルゲート + `unit_test_runner.sh`: **実行中**。結果は追ってこのスレッドに報告します

---
_Generated by [Claude Code](https://claude.ai/code/session_017BFSjod7HAW2L3GySW81Pi)_