### PR TITLE
perf(lexer): enforce zero-allocation leaves and remove keyword wrappers

### DIFF
--- a/bench/regression/baseline.json
+++ b/bench/regression/baseline.json
@@ -6,5 +6,9 @@
   "alloc_bench.vibe": {
     "bytes_per_op": 10400,
     "ns_p50": 6687
+  },
+  "lexer_keyword_bench.vibe": {
+    "bytes_per_op": 160640,
+    "ns_p50": 0
   }
 }

--- a/bench/regression/lexer_keyword_bench.vibe
+++ b/bench/regression/lexer_keyword_bench.vibe
@@ -1,0 +1,17 @@
+// Ratchets the lexer keyword/identifier hot path. This workload caught an
+// Option[Token] wrapper allocation for every identifier in keyword_lookup.
+import @vibe/parser {
+  lex
+}
+
+let source = "let f: (Int) -> Int = (x) -> { if x > 0 { let mut y = 0 while y < x { y = y + 1 } y } else { 0 } }\nlet g: (Int, Int) -> Int = (a, b) -> { match (a, b) { (0, _) => b, (_, 0) => a, (x, y) => x + y } }\nlet h: (Array[Int]) -> Int = (xs) -> { let mut sum = 0 for x in xs { sum = sum + x } sum }\nlet i: [T: Eq + Ord](T) -> T = (x) -> { x }\n"
+
+bench "lexer_keyword_heavy" {
+  let mut total = 0
+  let mut i = 0
+  while i < 32 {
+    total = total + Array::length(lex(source))
+    i = i + 1
+  }
+  let _ = total
+}

--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "region-starts-guard-2026-08-15",
-    "tag": "seed/region-starts-guard-2026-08-15",
-    "source_commit": "702082bb64851048d3d6a11116cc82b0d73659e4",
+    "name": "zero-alloc-directive-2026-08-15",
+    "tag": "seed/zero-alloc-directive-2026-08-15",
+    "source_commit": "32cdab5e1b4cd6aedb3a5aed9937c8938e2fbb25",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "1841e38ae6289c9984f446558a40a551d4e880c066e99bbfc35c38d605ba5c0c"
+      "sha256": "89446ac143934ce0d6675cb7d099d14922196d9415792e77cad36017818b57f9"
     },
     "runtime": {
       "runner": "moonrun",

--- a/lib/@vibe/parser/lexer.vibe
+++ b/lib/@vibe/parser/lexer.vibe
@@ -10,18 +10,22 @@ import ./float_format.vibe {
 
 //# Functions
 
+#zero_alloc
 fn is_ws(c: Int) -> Bool {
   c == ' ' || c == '\n' || c == '\t' || c == '\r'
 }
 
+#zero_alloc
 fn is_alpha(c: Int) -> Bool {
   (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
 }
 
+#zero_alloc
 fn is_digit(c: Int) -> Bool {
   c >= '0' && c <= '9'
 }
 
+#zero_alloc
 fn is_alnum(c: Int) -> Bool {
   is_alpha(c) || is_digit(c)
 }
@@ -33,6 +37,7 @@ fn is_alnum(c: Int) -> Bool {
 /// all fall back to single-byte granularity -- there is nothing more sensible
 /// to do with a malformed sequence, and 1 keeps the "advance at least one
 /// byte" progress guarantee the recovering lexer relies on).
+#zero_alloc
 fn utf8_seq_len(c: Int) -> Int {
   if c >= 0xF0 && c <= 0xF7 {
     4
@@ -52,6 +57,7 @@ fn utf8_seq_len(c: Int) -> Int {
 /// mainstream tokenizer silently skips a leading BOM, so this lexer does too
 /// -- ONLY at absolute position 0 (a BOM anywhere else in the file is not
 /// special and still lexes -- i.e. fails -- as ordinary bytes).
+#zero_alloc
 fn skip_bom(source: String, len: Int) -> Int {
   if len >= 3 && String::char_code_at(source, 0) == 0xEF && String::char_code_at(source, 1) == 0xBB && String::char_code_at(source, 2) == 0xBF {
     3
@@ -124,6 +130,7 @@ fn lex_char(s: String, len: Int, i: Int) -> (Token, Int) with Exception {
   }
 }
 
+#zero_alloc
 fn slice_eq(source: String, start: Int, end: Int, text: String) -> Bool {
   let len = end - start
   let text_len = String::length(text)
@@ -140,99 +147,100 @@ fn slice_eq(source: String, start: Int, end: Int, text: String) -> Bool {
   }
 }
 
+#zero_alloc
 fn is_hex_digit(c: Int) -> Bool {
   (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 }
 
-fn keyword_lookup(source: String, start: Int, end: Int) -> Option[Token] {
+fn keyword_lookup(source: String, start: Int, end: Int) -> Token {
   let len = end - start
   if len == 2 {
     let c0 = String::char_code_at(source, start)
     if c0 == 'f' {
       if slice_eq(source, start, end, "fn") {
         // #1280: `fn` is a reserved word (TFn), not a soft-keyword ident.
-        Some(TFn)
-      } else None
+        TFn
+      } else TIdent(source[start: end])
     } else if c0 == 'i' {
       if slice_eq(source, start, end, "if") {
-        Some(TIf)
+        TIf
       } else if slice_eq(source, start, end, "in") {
-        Some(TIn)
+        TIn
       } else if slice_eq(source, start, end, "is") {
         // ADR-0023: `expr is pattern` is a Bool-returning pattern test.
-        Some(TIs)
-      } else None
+        TIs
+      } else TIdent(source[start: end])
     } else if c0 == 'd' {
       if slice_eq(source, start, end, "do") {
-        Some(TDo)
-      } else None
+        TDo
+      } else TIdent(source[start: end])
     } else if c0 == 'a' {
       if slice_eq(source, start, end, "as") {
-        Some(TAs)
-      } else None
-    } else None
+        TAs
+      } else TIdent(source[start: end])
+    } else TIdent(source[start: end])
   } else if len == 3 {
     let c0 = String::char_code_at(source, start)
     if c0 == 'l' {
       if slice_eq(source, start, end, "let") {
-        Some(TLet)
-      } else None
+        TLet
+      } else TIdent(source[start: end])
     } else if c0 == 'r' {
       if slice_eq(source, start, end, "rec") {
-        Some(TRec)
-      } else None
+        TRec
+      } else TIdent(source[start: end])
     } else if c0 == 'm' {
       if slice_eq(source, start, end, "mut") {
-        Some(TMut)
-      } else None
+        TMut
+      } else TIdent(source[start: end])
     } else if c0 == 'f' {
       if slice_eq(source, start, end, "for") {
-        Some(TFor)
-      } else None
-    } else None
+        TFor
+      } else TIdent(source[start: end])
+    } else TIdent(source[start: end])
   } else if len == 4 {
     let c0 = String::char_code_at(source, start)
     if c0 == 'e' {
       if slice_eq(source, start, end, "else") {
-        Some(TElse)
+        TElse
       } else if slice_eq(source, start, end, "enum") {
-        Some(TEnum)
-      } else None
+        TEnum
+      } else TIdent(source[start: end])
     } else if c0 == 't' {
       if slice_eq(source, start, end, "true") {
-        Some(TIdent("true"))
+        TIdent("true")
       } else if slice_eq(source, start, end, "type") {
-        Some(TType)
+        TType
       } else if slice_eq(source, start, end, "test") {
-        Some(TTest)
-      } else None
+        TTest
+      } else TIdent(source[start: end])
     } else if c0 == 'w' {
       if slice_eq(source, start, end, "with") {
-        Some(TWith)
-      } else None
+        TWith
+      } else TIdent(source[start: end])
     } else if c0 == 'l' {
       if slice_eq(source, start, end, "loop") {
-        Some(TLoop)
-      } else None
+        TLoop
+      } else TIdent(source[start: end])
     } else if c0 == 'o' {
       if slice_eq(source, start, end, "open") {
-        Some(TOpen)
-      } else None
+        TOpen
+      } else TIdent(source[start: end])
     } else if c0 == 'i' {
       if slice_eq(source, start, end, "impl") {
-        Some(TImpl)
-      } else None
-    } else None
+        TImpl
+      } else TIdent(source[start: end])
+    } else TIdent(source[start: end])
   } else if len == 5 {
     let c0 = String::char_code_at(source, start)
     if c0 == 'f' {
       if slice_eq(source, start, end, "false") {
-        Some(TIdent("false"))
-      } else None
+        TIdent("false")
+      } else TIdent(source[start: end])
     } else if c0 == 'm' {
       if slice_eq(source, start, end, "match") {
-        Some(TMatch)
-      } else None
+        TMatch
+      } else TIdent(source[start: end])
     } else if c0 == 'g' {
       // #1283: `guard` is a HARD keyword, not a soft one. At statement start
       // `guard x is Some(v) else { .. }` and an expression statement naming a
@@ -240,93 +248,94 @@ fn keyword_lookup(source: String, start: Int, end: Int) -> Option[Token] {
       // soft keyword would have to guess. A reserved word means a stale
       // `guard` binding is a named parse error instead of a silent reparse.
       if slice_eq(source, start, end, "guard") {
-        Some(TGuard)
-      } else None
+        TGuard
+      } else TIdent(source[start: end])
     } else if c0 == 't' {
       if slice_eq(source, start, end, "trait") {
-        Some(TTrait)
+        TTrait
       } else if slice_eq(source, start, end, "throw") {
-        Some(TThrow)
-      } else None
+        TThrow
+      } else TIdent(source[start: end])
     } else if c0 == 'w' {
       if slice_eq(source, start, end, "while") {
-        Some(TWhile)
-      } else None
+        TWhile
+      } else TIdent(source[start: end])
     } else if c0 == 'b' {
       if slice_eq(source, start, end, "break") {
-        Some(TBreak)
+        TBreak
       } else if slice_eq(source, start, end, "bench") {
-        Some(TBench)
-      } else None
+        TBench
+      } else TIdent(source[start: end])
     } else if c0 == 'r' {
       if slice_eq(source, start, end, "raise") {
-        Some(TRaise)
-      } else None
+        TRaise
+      } else TIdent(source[start: end])
     } else if c0 == 'y' {
       if slice_eq(source, start, end, "yield") {
-        Some(TYield)
-      } else None
-    } else None
+        TYield
+      } else TIdent(source[start: end])
+    } else TIdent(source[start: end])
   } else if len == 6 {
     let c0 = String::char_code_at(source, start)
     if c0 == 's' {
       if slice_eq(source, start, end, "struct") {
-        Some(TStruct)
-      } else None
+        TStruct
+      } else TIdent(source[start: end])
     } else if c0 == 'e' {
       if slice_eq(source, start, end, "export") {
-        Some(TExport)
-      } else None
+        TExport
+      } else TIdent(source[start: end])
     } else if c0 == 'r' {
       if slice_eq(source, start, end, "return") {
-        Some(TReturn)
+        TReturn
       } else if slice_eq(source, start, end, "region") {
-        Some(TRegion)
-      } else None
+        TRegion
+      } else TIdent(source[start: end])
     } else if c0 == 'h' {
       if slice_eq(source, start, end, "handle") {
-        Some(THandle)
-      } else None
+        THandle
+      } else TIdent(source[start: end])
     } else if c0 == 'm' {
       if slice_eq(source, start, end, "module") {
-        Some(TModule)
-      } else None
+        TModule
+      } else TIdent(source[start: end])
     } else if c0 == 'd' {
       if slice_eq(source, start, end, "derive") {
-        Some(TDerive)
-      } else None
+        TDerive
+      } else TIdent(source[start: end])
     } else if c0 == 'i' {
       if slice_eq(source, start, end, "import") {
-        Some(TImport)
-      } else None
-    } else None
+        TImport
+      } else TIdent(source[start: end])
+    } else TIdent(source[start: end])
   } else if len == 7 {
     if slice_eq(source, start, end, "declare") {
-      Some(TDeclare)
+      TDeclare
     } else if slice_eq(source, start, end, "example") {
       // #819: reserved like `test` / `bench`, for the same reason -- it starts
       // a top-level block form, so a binding of that name at statement
       // position would be indistinguishable until the following token.
-      Some(TExample)
-    } else None
+      TExample
+    } else TIdent(source[start: end])
   } else if len == 8 {
     let c0 = String::char_code_at(source, start)
     if c0 == 'c' {
       if slice_eq(source, start, end, "continue") {
-        Some(TContinue)
-      } else None
+        TContinue
+      } else TIdent(source[start: end])
     } else if c0 == 's' {
       if slice_eq(source, start, end, "suberror") {
-        Some(TSuberror)
-      } else None
-    } else None
+        TSuberror
+      } else TIdent(source[start: end])
+    } else TIdent(source[start: end])
   } else if len == 9 {
     if slice_eq(source, start, end, "taskgroup") {
-      Some(TTaskGroup)
-    } else None
-  } else None
+      TTaskGroup
+    } else TIdent(source[start: end])
+  } else TIdent(source[start: end])
 }
 
+#zero_alloc
 fn scan_ident_end(s: String, len: Int, i: Int) -> Int {
   let mut out = i
   while out < len && is_alnum(String::char_code_at(s, out)) {
@@ -359,13 +368,11 @@ fn lex_ident(s: String, len: Int, i: Int) -> (Token, Int) {
       ri + 1
     })
   } else {
-    match keyword_lookup(s, i, end) {
-      Some(tok) => (tok, end),
-      None => (TIdent(s[i: end]), end)
-    }
+    (keyword_lookup(s, i, end), end)
   }
 }
 
+#zero_alloc
 fn scan_digits_end(s: String, len: Int, i: Int) -> Int {
   let mut out = i
   while out < len && is_digit(String::char_code_at(s, out)) {
@@ -474,6 +481,7 @@ fn empty_string_array() -> Array[String] {
 }
 
 /// 0-based column (char offset from the start of its line) of `pos`.
+#zero_alloc
 fn column_of(source: String, pos: Int) -> Int {
   let mut i = pos
   let mut col = 0
@@ -627,6 +635,7 @@ fn join_doc_lines(lines: Array[String]) -> String {
   StringBuilder::freeze(buf)
 }
 
+#zero_alloc
 fn skip_until_newline(s: String, len: Int, i: Int) -> Int {
   let mut out = i
   let mut done = false
@@ -641,7 +650,11 @@ fn skip_until_newline(s: String, len: Int, i: Int) -> Int {
   out
 }
 
-fn skip_ws_with_newline(s: String, len: Int, i: Int) -> (Int, Bool) {
+/// Pack `(next_offset, saw_newline)` into one tagged Int. This is on every
+/// token boundary; returning a tuple allocated once per token even though the
+/// offset is bounded by wasm linear memory and has a spare low bit.
+#zero_alloc
+fn skip_ws_with_newline(s: String, len: Int, i: Int) -> Int {
   let mut out = i
   let mut saw_newline = false
   let mut skipping = true
@@ -666,7 +679,11 @@ fn skip_ws_with_newline(s: String, len: Int, i: Int) -> (Int, Bool) {
       skipping = false
     }
   }
-  (out, saw_newline)
+  out * 2 + if saw_newline {
+    1
+  } else {
+    0
+  }
 }
 
 /// Newlines are normally trivia, but two expression boundaries need a
@@ -676,6 +693,7 @@ fn skip_ws_with_newline(s: String, len: Int, i: Int) -> (Int, Bool) {
 ///
 /// Keeping this decision in one helper prevents `lex`, offset lexing, and the
 /// recovering lexer from drifting apart.
+#zero_alloc
 fn needs_synthetic_semicolon(c: Int, nl_before: Bool, prev_tok: Token) -> Bool {
   if !nl_before {
     false
@@ -805,6 +823,7 @@ fn lex_string(s: String, len: Int, i: Int) -> (Token, Int) with Exception {
   lex_string_go(s, len, i + 1, i + 1, empty_string_array(), false, ArrayBuilder::new(), ArrayBuilder::new())
 }
 
+#zero_alloc
 fn scan_hex_digits_end(s: String, len: Int, i: Int) -> Int {
   let mut out = i
   while out < len && is_hex_digit(String::char_code_at(s, out)) {
@@ -930,6 +949,7 @@ fn lex_number(s: String, len: Int, i: Int) -> (Token, Int) with Exception {
 /// Can this token end a complete (primary) expression? After such a token, a
 /// newline followed by `[` starts a NEW statement (an array literal), not a
 /// postfix subscript — the lexer inserts a synthetic `;` to disambiguate.
+#zero_alloc
 fn is_expr_ending_tok(t: Token) -> Bool {
   match t {
     TRParen => true,
@@ -1102,8 +1122,8 @@ export fn lex_with_offsets(source: String) -> (Array[Token], Array[Int], Array[I
     let ends = ArrayBuilder::new()
     let mut prev_tok = TEof
     let first_skip = skip_ws_with_newline(source, len, skip_bom(source, len))
-    let mut pos = first_skip.0
-    let mut nl_before = first_skip.1
+    let mut pos = first_skip>>1
+    let mut nl_before = (first_skip&1) == 1
     while pos < len {
       let c = String::char_code_at(source, pos)
       let (tok, next) = lex_one_token(source, len, pos)
@@ -1119,8 +1139,8 @@ export fn lex_with_offsets(source: String) -> (Array[Token], Array[Int], Array[I
       ArrayBuilder::push(ends, next)
       prev_tok = tok
       let skipped = skip_ws_with_newline(source, len, next)
-      pos = skipped.0
-      nl_before = skipped.1
+      pos = skipped>>1
+      nl_before = (skipped&1) == 1
     }
     ArrayBuilder::push(b, TEof)
     ArrayBuilder::push(starts, len)
@@ -1146,8 +1166,8 @@ export fn lex_with_offsets_recovering(source: String) -> (Array[Token], Array[In
   let err_msgs = ArrayBuilder::new()
   let mut prev_tok = TEof
   let first_skip = skip_ws_with_newline(source, len, skip_bom(source, len))
-  let mut pos = first_skip.0
-  let mut nl_before = first_skip.1
+  let mut pos = first_skip>>1
+  let mut nl_before = (first_skip&1) == 1
   while pos < len {
     let c = String::char_code_at(source, pos)
     let res = handle {
@@ -1174,8 +1194,8 @@ export fn lex_with_offsets_recovering(source: String) -> (Array[Token], Array[In
         ArrayBuilder::push(ends, next)
         prev_tok = tok
         let skipped = skip_ws_with_newline(source, len, next)
-        pos = skipped.0
-        nl_before = skipped.1
+        pos = skipped>>1
+        nl_before = (skipped&1) == 1
       },
       None => {
         // #963: resume PAST the failed construct, not inside it. A failure
@@ -1224,8 +1244,8 @@ export fn lex_with_offsets_recovering(source: String) -> (Array[Token], Array[In
           pos + 1
         }
         let skipped = skip_ws_with_newline(source, len, resume)
-        pos = skipped.0
-        nl_before = skipped.1
+        pos = skipped>>1
+        nl_before = (skipped&1) == 1
       }
     }
   }
@@ -1265,8 +1285,8 @@ export fn lex(source: String) -> Array[Token] with Exception {
     let b = ArrayBuilder::new()
     let mut prev_tok = TEof
     let first_skip = skip_ws_with_newline(source, len, skip_bom(source, len))
-    let mut pos = first_skip.0
-    let mut nl_before = first_skip.1
+    let mut pos = first_skip>>1
+    let mut nl_before = (first_skip&1) == 1
     while pos < len {
       let c = String::char_code_at(source, pos)
       let (tok, next) = lex_one_token(source, len, pos)
@@ -1286,8 +1306,8 @@ export fn lex(source: String) -> Array[Token] with Exception {
       ArrayBuilder::push(b, tok)
       prev_tok = tok
       let skipped = skip_ws_with_newline(source, len, next)
-      pos = skipped.0
-      nl_before = skipped.1
+      pos = skipped>>1
+      nl_before = (skipped&1) == 1
     }
     ArrayBuilder::push(b, TEof)
     ArrayBuilder::freeze(b)

--- a/scripts/bench_regression.mjs
+++ b/scripts/bench_regression.mjs
@@ -33,7 +33,7 @@ const ITERS = process.env.BENCH_ITERS || "300";
 const update = process.argv.includes("--update");
 
 // The fixture set the gate covers (must run cleanly on the linear backend).
-const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe"];
+const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe", "lexer_keyword_bench.vibe"];
 
 function runBench(file) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- bump the committed seed to the release that understands canonical #zero_alloc
- annotate allocation-free lexer leaves so future regressions fail at compile time
- return Token directly from keyword_lookup instead of allocating Option[Token] for every identifier
- add a deterministic lexer bytes/op regression fixture

## Measured result
- synthetic keyword-heavy lexer workload: 195,456 -> 160,640 bytes/op (-17.8%)
- equivalent per lex call: about 6,108 -> 5,020 bytes
- stage2 == stage3 after the change

## Validation
- pkf run generation -- --stage3
- parser focused tests: 27/27
- pkf run test-local
- pkf run test-pre-commit
- vibe formatter check, node syntax check, git diff --check
