### PR TITLE
perf(parser): halve empty array construction cost

### DIFF
--- a/bench/regression/baseline.json
+++ b/bench/regression/baseline.json
@@ -10,5 +10,9 @@
   "lexer_keyword_bench.vibe": {
     "bytes_per_op": 160640,
     "ns_p50": 0
+  },
+  "parser_query_bench.vibe": {
+    "bytes_per_op": 117760,
+    "ns_p50": 0
   }
 }

--- a/bench/regression/parser_query_bench.vibe
+++ b/bench/regression/parser_query_bench.vibe
@@ -1,0 +1,45 @@
+// Ratchets the parser paths used by editor/query commands. The token arrays
+// are cached so bytes/op measures parsing, not lexing.
+import @vibe/parser {
+  Token, lex_with_offsets, parse_program_recovering, parse_program_spans
+}
+
+let source = "fn add(a: Int, b: Int) -> Int { a + b }\nlet answer = add(20, 22)\nfn classify(x: Int) -> Int { match x { 0 => 10, 1 => 20, _ => 30 } }\nfn empty() -> Array[Int] { [] }\nfn call_empty() -> Array[Int] { empty() }\n"
+let empty_tokens: Array[Token] = [
+  TEof
+]
+let empty_ints: Array[Int] = [
+  0
+]
+let token_box: Array[Array[Token]] = [
+  empty_tokens
+]
+let start_box: Array[Array[Int]] = [
+  empty_ints
+]
+let end_box: Array[Array[Int]] = [
+  empty_ints
+]
+
+fn ensure_lexed() -> (Array[Token], Array[Int], Array[Int]) with Exception {
+  if Array::length(token_box[0]) == 1 {
+    let (tokens, starts, ends) = lex_with_offsets(source)
+    token_box[0] = tokens
+    start_box[0] = starts
+    end_box[0] = ends
+  }
+  (token_box[0], start_box[0], end_box[0])
+}
+
+bench "parser_query_paths" with Exception {
+  let (tokens, starts, ends) = ensure_lexed()
+  let mut total = 0
+  let mut i = 0
+  while i < 8 {
+    let (span_stmts, _, _) = parse_program_spans(tokens, starts, ends)
+    let (recovered_stmts, diags) = parse_program_recovering(tokens, starts, source)
+    total = total + Array::length(span_stmts) + Array::length(recovered_stmts) + Array::length(diags)
+    i = i + 1
+  }
+  let _ = total
+}

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -76,9 +76,7 @@ import ./parser_binder_context.vibe {
 let parser_mode_block = 20
 
 fn empty_names() -> Array[String] {
-  Array::slice([
-    "_"
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 /// #1508: `with <row>` between the name and the body widens this test's ambient
@@ -778,6 +776,7 @@ fn cfg_scan_enabled(tokens: Array[Token]) -> Array[String] with Exception {
   out
 }
 
+#zero_alloc
 fn cfg_flag_active(active: Array[String], flag: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -1062,6 +1061,7 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
 /// use a single `if is_recovery_point(...)` test instead of a mixed
 /// constructor/catch-all `match` (the latter traps the seed codegen on this
 /// shape — keep this a flat function returning Bool).
+#zero_alloc
 fn is_recovery_point(t: Token) -> Bool {
   match t {
     TLet => true,

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -21,15 +21,11 @@ export fn peek(tokens: Array[Token], pos: Int) -> Token {
 }
 
 fn _no_tp() -> Array[String] {
-  Array::slice([
-    ""
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 fn _no_tb() -> Array[(String, Array[String])] {
-  Array::slice([
-    ("", _no_tp())
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 let mode_if = 21
@@ -224,6 +220,7 @@ export fn record_test_effect_row(name: String, row: String) -> Unit {
 }
 
 ///|
+#zero_alloc
 export fn has_test_effect_rows() -> Bool {
   Array::length(test_effect_rows) > 0
 }
@@ -258,6 +255,7 @@ export fn take_qualified_pattern_refs() -> Array[(String, String)] {
 /// which parser_bench saw as allocation drift on inputs containing no qualified
 /// pattern at all (parse_deep_binop_chain +1.80%, parse_wide_match +1.42%, both
 /// back to +-0 once callers check this first and skip the drain).
+#zero_alloc
 export fn has_qualified_pattern_refs() -> Bool {
   Array::length(qualified_pattern_refs) > 0
 }
@@ -269,17 +267,11 @@ let mode_match = 22
 let mode_while = 23
 
 fn empty_ctors() -> Array[(String, Array[TypeExpr])] {
-  Array::slice([
-    ("_", Array::slice([
-      TyUnit
-    ], 0, 0))
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 fn empty_exprs() -> Array[Expr] {
-  Array::slice([
-    EUnit
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 let mode_for_in = 25
@@ -329,15 +321,11 @@ export fn skip_derive(tokens: Array[Token], pos: Int) -> Int with Exception {
 }
 
 fn empty_fields() -> Array[(String, TypeExpr)] {
-  Array::slice([
-    ("_", TyUnit)
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 fn empty_params() -> Array[(String, Option[TypeExpr])] {
-  Array::slice([
-    ("", None)
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 export fn parse_pattern_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Pat, Int) with Exception {
@@ -537,9 +525,7 @@ fn parse_pattern(tokens: Array[Token], pos: Int) -> (Pat, Int) with Exception {
 }
 
 fn empty_type_exprs() -> Array[TypeExpr] {
-  Array::slice([
-    TyUnit
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 export fn skip_braced_body(tokens: Array[Token], pos: Int) -> Int {

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -9,7 +9,7 @@ import ./parser.vibe {
 }
 
 import @vibe/ast {
-  Stmt
+  Expr, Stmt
 }
 
 //# Tests
@@ -17,6 +17,13 @@ import @vibe/ast {
 // indirectly through the compiler's syntax/ shims (tests/parser_*_test.vibe
 // in lib/@vibe/compiler). These exercise the package's own lex/parse_program
 // entry points directly, with no compiler layer in between.
+
+fn fn_generic_lanes_at(stmts: Array[Stmt], index: Int) -> (Array[String], Array[(String, Array[String])]) {
+  match Array::get(stmts, index) {
+    SLet(_, _, _, _, EFn(type_params, type_bounds, _, _, _, _)) => (type_params, type_bounds),
+    _ => (ArrayBuilder::freeze(ArrayBuilder::new()), ArrayBuilder::freeze(ArrayBuilder::new()))
+  }
+}
 
 test "lex: simple token stream is non-empty" {
   let tokens = lex("let x = 1")
@@ -83,6 +90,18 @@ test "parse_program: function declaration" {
   let tokens = lex("fn add(a: Int, b: Int) -> Int { a + b }")
   let stmts = parse_program(tokens)
   assert(Array::length(stmts) == 1)
+}
+
+test "parse_program: empty generic lanes stay fresh per declaration" {
+  let stmts = parse_program(lex("fn first() -> Int { 1 }\nfn second() -> Int { 2 }"))
+  let (first_params, first_bounds) = fn_generic_lanes_at(stmts, 0)
+  let (second_params, second_bounds) = fn_generic_lanes_at(stmts, 1)
+  Array::push(first_params, "Injected")
+  Array::push(first_bounds, ("Injected", [
+    "Eq"
+  ]))
+  assert_eq(Array::length(second_params), 0)
+  assert_eq(Array::length(second_bounds), 0)
 }
 
 test "parse_program: taskgroup accepts the empty source-offset lane (#1780)" {

--- a/scripts/bench_regression.mjs
+++ b/scripts/bench_regression.mjs
@@ -33,7 +33,7 @@ const ITERS = process.env.BENCH_ITERS || "300";
 const update = process.argv.includes("--update");
 
 // The fixture set the gate covers (must run cleanly on the linear backend).
-const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe", "lexer_keyword_bench.vibe"];
+const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe", "lexer_keyword_bench.vibe", "parser_query_bench.vibe"];
 
 function runBench(file) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- replace parser empty-array placeholder+slice construction with fresh single-allocation ArrayBuilder arrays
- keep each AST field independently mutable; add a cross-declaration non-aliasing regression
- enforce four allocation-free parser predicates with #zero_alloc
- add a deterministic parser query bytes/op ratchet

## Measured result
The benchmark caches lexed tokens and runs parse_program_spans plus parse_program_recovering eight times each.

- before: 160,512 bytes/op
- after: 117,760 bytes/op
- reduction: 42,752 bytes/op (-26.6%)

A shared empty mutable Array reached about -35%, but was rejected because it would alias independently returned AST fields.

## Validation
- latest main 3a7afe656
- stage2 == stage3
- parser focused tests: 28/28
- pkf run test-local
- pkf run test-pre-commit
- formatter, JS syntax, and git diff checks
