### PR TITLE
perf(parser): reduce empty metadata allocations

### DIFF
--- a/bench/regression/baseline.json
+++ b/bench/regression/baseline.json
@@ -11,8 +11,12 @@
     "bytes_per_op": 160640,
     "ns_p50": 0
   },
+  "parser_empty_metadata_bench.vibe": {
+    "bytes_per_op": 99872,
+    "ns_p50": 0
+  },
   "parser_query_bench.vibe": {
-    "bytes_per_op": 117760,
+    "bytes_per_op": 117088,
     "ns_p50": 0
   }
 }

--- a/bench/regression/parser_empty_metadata_bench.vibe
+++ b/bench/regression/parser_empty_metadata_bench.vibe
@@ -1,0 +1,45 @@
+// Ratchets parser paths whose AST nodes carry fresh empty metadata arrays.
+// The token arrays are cached so bytes/op measures parsing, not lexing.
+import @vibe/parser {
+  Token, lex_with_offsets, parse_program_recovering, parse_program_spans
+}
+
+let source = "import @vibe/core {}\nenum Choice { A; B } derive(Eq)\nfn classify_choice(x: Choice) -> Int { match x { A => 10, B => 20 } }\nfn empty_match(x: Int) -> Int { match x {} }\nfn typed_local() -> Int { let x: Int = 1; x }\n"
+let token_box: Array[Array[Token]] = [
+  [
+    TEof
+  ]
+]
+let start_box: Array[Array[Int]] = [
+  [
+    0
+  ]
+]
+let end_box: Array[Array[Int]] = [
+  [
+    0
+  ]
+]
+
+fn ensure_lexed() -> (Array[Token], Array[Int], Array[Int]) with Exception {
+  if Array::length(token_box[0]) == 1 {
+    let (tokens, starts, ends) = lex_with_offsets(source)
+    token_box[0] = tokens
+    start_box[0] = starts
+    end_box[0] = ends
+  }
+  (token_box[0], start_box[0], end_box[0])
+}
+
+bench "parser_empty_metadata" with Exception {
+  let (tokens, starts, ends) = ensure_lexed()
+  let mut total = 0
+  let mut i = 0
+  while i < 8 {
+    let (span_stmts, _, _) = parse_program_spans(tokens, starts, ends)
+    let (recovered_stmts, diags) = parse_program_recovering(tokens, starts, source)
+    total = total + Array::length(span_stmts) + Array::length(recovered_stmts) + Array::length(diags)
+    i = i + 1
+  }
+  let _ = total
+}

--- a/docs/report/parser-simd-scan-2026-08-15.md
+++ b/docs/report/parser-simd-scan-2026-08-15.md
@@ -1,0 +1,84 @@
+# Parser SIMD scan assessment (2026-08-15)
+
+This note evaluates the lexer pipeline from
+[SIMD Lexer Pipeline: classify, carve, coalesce, compress](https://gist.github.com/mizchi/1ba06e646dbc6396a50798a2f9678d15)
+against vibe's current selfhost parser.
+
+## Existing advantages
+
+vibe already has three prerequisites that the pipeline recommends:
+
+- `String` is a UTF-8 byte string, so a `v128.load` does not need a UTF-16
+  gather;
+- `lex_with_offsets` produces separate token, start, and end arrays;
+- parsing is unfused and performs lookahead over the completed token stream.
+
+The compiler also has allocation-free fused SIMD scan bodies for whitespace
+and identifier bytes. They keep `v128` values on the operand stack instead of
+boxing every intrinsic result.
+
+## Identifier experiment: do not integrate
+
+Replacing `scan_ident_end` with the existing `simd_scan_alnum_str` was neutral
+on `lexer_keyword_bench.vibe`:
+
+| implementation | median time for the benchmark body |
+|---|---:|
+| scalar | about 93.1 us |
+| fused SIMD | about 93.0 us |
+
+The difference is below run-to-run noise. Typical identifiers are too short to
+repay SIMD setup, matching the earlier whitespace-run result in
+`docs/spec/simd-api-design.md`. The experiment also exposed a tooling gap:
+`#zero_alloc` does not yet recognize `simd_scan_alnum_str` as allocation-free,
+although its fused runtime body allocates nothing.
+
+## Where the bytes are
+
+A census of the 946 tracked `lib/**/*.vibe` and `lib/**/*.vpkg` files gives the
+following opportunity sizes. String runs are bytes between quote/backslash
+events; comment runs are bytes after `//` until newline. The identifier count is
+a lexical upper bound because the simple census also sees words in strings and
+comments.
+
+| run class | total runs | runs >= 16 B | bytes in runs >= 16 B |
+|---|---:|---:|---:|
+| identifier-shaped | 1,160,550 | 45,275 | 1,063,603 |
+| ordinary string segment | 60,337 | 15,253 | 635,324 |
+| line comment body | 41,884 | 37,994 | 2,486,838 |
+
+Long comments and ordinary string segments are therefore better SIMD targets
+than identifiers or whitespace.
+
+## Recommended next slice
+
+Add specialized fused, unboxed scanners rather than exposing per-operation
+`V128` values to lexer code:
+
+1. `simd_scan_line_end_str(String, pos, len) -> Int` finds LF while skipping
+   ordinary 16-byte chunks. Wire it into `skip_until_newline` with a scalar
+   tail.
+2. `simd_scan_string_special_str(String, pos, len) -> Int` finds the next
+   quote, backslash, interpolation dollar, newline, or control byte. Keep the
+   existing scalar state machine for the returned sparse event.
+3. Teach the `#zero_alloc` call graph that these fused scalar-result builtins
+   are allocation-free, using the builtin registry as the source of truth.
+
+Do not start with a full classify/compress token tape. `Token` is still a rich
+enum and identifiers/string tokens materialize substrings, so making every
+punctuation position into a bitmap would add a second representation before
+removing the first. A compact token-kind tape becomes worthwhile only together
+with lazy source slices or a token ABI change.
+
+## Acceptance gates
+
+The SIMD follow-up should carry three benchmark lanes:
+
+- representative compiler source: no statistically significant regression;
+- comment-heavy source with 32-256 byte comment bodies: clear improvement;
+- string-heavy source with long ordinary spans plus escape/interpolation
+  controls: byte-identical tokens and clear improvement.
+
+Allocation must remain unchanged, `#zero_alloc` must stay on the scalar wrapper,
+and both linear and GC backends must run the same correctness fixtures because
+`String` remains in linear memory on both lanes.

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -316,9 +316,7 @@ fn parse_toplevel_struct_fields_rest(tokens: Array[Token], pos: Int, b: ArrayBui
 
 fn parse_toplevel_struct_fields(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
   match peek(tokens, pos) {
-    TRBrace => (empty_fields(), Array::slice([
-      ""
-    ], 0, 0), pos + 1),
+    TRBrace => (empty_fields(), ArrayBuilder::freeze(ArrayBuilder::new()), pos + 1),
     _ => {
       let (first, is_mut, next) = parse_struct_field_with_binder_context(tokens, pos, context)
       let b = ArrayBuilder::new()
@@ -361,9 +359,7 @@ fn parse_effectset_stmt(tokens: Array[Token], pos: Int, exported: Bool, context:
   let bp = expect_tk(tokens, ep, "{")
   let (joined, next) = collect_effect_names(tokens, bp, "")
   let members = if String::length(joined) == 0 {
-    Array::slice([
-      ""
-    ], 0, 0)
+    ArrayBuilder::freeze(ArrayBuilder::new())
   } else {
     String::split(joined, ", ")
   }
@@ -554,9 +550,7 @@ export fn parse_stmt_preserving_with_binder_context(tokens: Array[Token], starts
               }
               if is_index && Array::length(idx_args) == 2 {
                 let (val, vn) = parse_impl_with_binder_context(tokens, starts, next + 1, 0, context)
-                let set_args = Array::slice([
-                  EUnit
-                ], 0, 0)
+                let set_args = ArrayBuilder::freeze(ArrayBuilder::new())
                 Array::push(set_args, Array::get(idx_args, 0))
                 Array::push(set_args, Array::get(idx_args, 1))
                 Array::push(set_args, val)
@@ -648,17 +642,11 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
       // Increment B). Non-generic impls have an empty list → methods unchanged.
       let impl_tparams = match simpl {
         SImpl(tp, _, _, _) => tp,
-        _ => Array::slice([
-          ""
-        ], 0, 0)
+        _ => ArrayBuilder::freeze(ArrayBuilder::new())
       }
       let impl_tbounds = match simpl {
         SImpl(_, tb, _, _) => tb,
-        _ => Array::slice([
-          ("", Array::slice([
-            ""
-          ], 0, 0))
-        ], 0, 0)
+        _ => ArrayBuilder::freeze(ArrayBuilder::new())
       }
       let mut p = pos + 1
       let mut done = false
@@ -750,11 +738,10 @@ fn parse_cfg_directive(tokens: Array[Token], pos: Int) -> (String, String, Int) 
 }
 
 /// Pre-scan the whole token stream for `#cfg_enable(name)` directives and
-/// return the active flag set. O(tokens), no allocation unless a THash exists.
+/// return the active flag set. O(tokens), with one fresh result allocation;
+/// the result does not grow unless a THash enables a flag.
 fn cfg_scan_enabled(tokens: Array[Token]) -> Array[String] with Exception {
-  let out = Array::slice([
-    ""
-  ], 0, 0)
+  let out = ArrayBuilder::freeze(ArrayBuilder::new())
   let mut i = 0
   let n = Array::length(tokens)
   while i < n {
@@ -1118,9 +1105,7 @@ export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], sou
   let cfg_active = handle {
     cfg_scan_enabled(tokens)
   } with Exception {
-    Throw(_) => Array::slice([
-      ""
-    ], 0, 0)
+    Throw(_) => ArrayBuilder::freeze(ArrayBuilder::new())
   }
   let b = ArrayBuilder::new()
   let diags = ArrayBuilder::new()
@@ -1246,9 +1231,7 @@ export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], sou
               }
               rp
             }
-            Some((Array::slice([
-              SExport(empty_names())
-            ], 0, 0), resync_pos))
+            Some((ArrayBuilder::freeze(ArrayBuilder::new()), resync_pos))
           }
         }
         match res {

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -149,15 +149,11 @@ export fn skip_semi(tokens: Array[Token], pos: Int) -> Int {
 }
 
 fn empty_arms() -> Array[(Pat, Expr)] {
-  Array::slice([
-    (PWild, EUnit)
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 fn empty_pats() -> Array[Pat] {
-  Array::slice([
-    PWild
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 //# Qualified variant pattern side channel (#1455 step 3)
@@ -283,9 +279,7 @@ let mode_handle = 24
 /// structurally-derivable traits is validated later); a missing clause yields an
 /// empty list. Supports multiple comma-separated names (#638).
 export fn parse_derive_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
-  let names = Array::slice([
-    ""
-  ], 0, 0)
+  let names = ArrayBuilder::freeze(ArrayBuilder::new())
   match peek(tokens, pos) {
     TDerive => match peek(tokens, pos + 1) {
       TLParen => {
@@ -682,9 +676,7 @@ fn parse_trait_methods_with_binder_context(tokens: Array[Token], pos: Int, conte
 }
 
 export fn parse_trait_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
-  let empty_strings = Array::slice([
-    "_"
-  ], 0, 0)
+  let empty_strings = ArrayBuilder::freeze(ArrayBuilder::new())
   match peek(tokens, pos) {
     TIdent(name) => {
       // Retain the declared bare header names while preserving the existing
@@ -804,9 +796,7 @@ fn parse_import_item(tokens: Array[Token], pos: Int) -> ((String, Option[String]
   parse_import_item_with_binder_context(tokens, pos, None)
 }
 fn empty_import_items() -> Array[(String, Option[String])] {
-  Array::slice([
-    ("_", None)
-  ], 0, 0)
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 export fn parse_binding_name_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (String, Int) with Exception {
@@ -932,9 +922,7 @@ export fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int,
       }
       (ArrayBuilder::freeze(b), skip)
     },
-    _ => (Array::slice([
-      ""
-    ], 0, 0), pos)
+    _ => (ArrayBuilder::freeze(ArrayBuilder::new()), pos)
   }
 }
 
@@ -1736,9 +1724,7 @@ export fn parse_enum_stmt_with_binder_context(tokens: Array[Token], pos: Int, ex
           }
           (ArrayBuilder::freeze(b), skip)
         },
-        _ => (Array::slice([
-          ""
-        ], 0, 0), pos + 1)
+        _ => (ArrayBuilder::freeze(ArrayBuilder::new()), pos + 1)
       }
       let br = expect_tk(tokens, after_name, "{")
       let (ctors, end) = parse_enum_ctors_with_binder_context(tokens, br, context);
@@ -1871,9 +1857,7 @@ export fn parse_type_alias_stmt_with_binder_context(tokens: Array[Token], pos: I
           let (names, _, next) = parse_bounded_type_params_with_binder_context(tokens, pos + 2, false, "expected ',' or ']' in type params", context)
           (names, next)
         },
-        _ => (Array::slice([
-          ""
-        ], 0, 0), pos + 1)
+        _ => (ArrayBuilder::freeze(ArrayBuilder::new()), pos + 1)
       }
       let ep = expect_tk(tokens, after_name, "=")
       let (ty, next) = parse_type_impl(tokens, ep, 0);
@@ -1923,9 +1907,7 @@ fn parse_struct_fields_rest_with_binder_context(tokens: Array[Token], pos: Int, 
 
 fn parse_struct_fields_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, TypeExpr)], Array[String], Int) with Exception {
   match peek(tokens, pos) {
-    TRBrace => (empty_fields(), Array::slice([
-      ""
-    ], 0, 0), pos + 1),
+    TRBrace => (empty_fields(), ArrayBuilder::freeze(ArrayBuilder::new()), pos + 1),
     _ => {
       let (first, is_mut, next) = parse_struct_field_with_binder_context(tokens, pos, context)
       let b = ArrayBuilder::new()

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -5,6 +5,8 @@ import @vibe/ast {
 }
 
 import ./parser_base.vibe {
+  _no_tb,
+  _no_tp,
   collect_row_item_targs,
   empty_arms,
   empty_exprs,
@@ -38,14 +40,8 @@ import ./parser_binder_context.vibe {
 /// Used to type-check a local `let x: T = e`, whose annotation `ELet` cannot
 /// store. Uses only EFn/ECall, so every downstream pass handles it unchanged.
 fn ascribe_wrap(val: Expr, ty: TypeExpr, context: Option[ParserBinderContext]) -> Expr {
-  let tparams = Array::slice([
-    ""
-  ], 0, 0)
-  let tbounds = Array::slice([
-    ("", Array::slice([
-      ""
-    ], 0, 0))
-  ], 0, 0)
+  let tparams = _no_tp()
+  let tbounds = _no_tb()
   let params = [
     ("__asc", Some(ty))
   ]
@@ -183,14 +179,8 @@ fn parse_local_let_annotation_with_binder_context(tokens: Array[Token], pos: Int
     },
     _ => {
       let (ty, next) = parse_type_impl(tokens, pos, 0)
-      let no_tp = Array::slice([
-        ""
-      ], 0, 0)
-      let no_tb = Array::slice([
-        ("", Array::slice([
-          ""
-        ], 0, 0))
-      ], 0, 0)
+      let no_tp = _no_tp()
+      let no_tb = _no_tb()
       (no_tp, no_tb, ty, next)
     }
   }
@@ -563,13 +553,7 @@ fn apply_block_step(step: BlockStep, rest: Expr, context: Option[ParserBinderCon
     // The continuation closure carries `x` + `rest` so `rest`'s scope is exact.
     StepBind(name, val) => ECall(EIdent("__try_bind", -1), [
       val,
-      EFn(Array::slice([
-        ""
-      ], 0, 0), Array::slice([
-        ("", Array::slice([
-          ""
-        ], 0, 0))
-      ], 0, 0), [
+      EFn(_no_tp(), _no_tb(), [
         (name, None)
       ], None, None, rest)
     ], -1)
@@ -750,14 +734,8 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                   (tps, tbs, Some(rty), tp)
                 },
                 _ => {
-                  let no_tp = Array::slice([
-                    ""
-                  ], 0, 0)
-                  let no_tb = Array::slice([
-                    ("", Array::slice([
-                      ""
-                    ], 0, 0))
-                  ], 0, 0)
+                  let no_tp = _no_tp()
+                  let no_tb = _no_tb()
                   (no_tp, no_tb, None, next + 2)
                 }
               }
@@ -881,14 +859,8 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                       (tps, tbs, Some(the_type), tp)
                     },
                     _ => {
-                      let no_tp = Array::slice([
-                        ""
-                      ], 0, 0)
-                      let no_tb = Array::slice([
-                        ("", Array::slice([
-                          ""
-                        ], 0, 0))
-                      ], 0, 0)
+                      let no_tp = _no_tp()
+                      let no_tb = _no_tb()
                       (no_tp, no_tb, None, next + 1)
                     }
                   }
@@ -1234,12 +1206,8 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
     let arrow = expect_tk(tokens, gn, "=>")
     let (body, bn) = parse_recur(tokens, arrow, 0, context)
     let close = expect_tk(tokens, bn, "}")
-    let tparams = Array::slice([
-      ""
-    ], 0, 0)
-    let tbounds = Array::slice([
-      ("", tparams)
-    ], 0, 0)
+    let tparams = _no_tp()
+    let tbounds = _no_tb()
     let lam = EFn(tparams, tbounds, [
       (gname, None)
     ], None, None, body)
@@ -1263,12 +1231,8 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
     // consumes the closing brace -- region bodies are blocks, not single
     // expressions.
     let (body, close) = parse_recur(tokens, br, 20, context)
-    let tparams = Array::slice([
-      ""
-    ], 0, 0)
-    let tbounds = Array::slice([
-      ("", tparams)
-    ], 0, 0)
+    let tparams = _no_tp()
+    let tbounds = _no_tb()
     let lam = EFn(tparams, tbounds, [
       (rname, None)
     ], None, None, body)

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -104,6 +104,20 @@ test "parse_program: empty generic lanes stay fresh per declaration" {
   assert_eq(Array::length(second_bounds), 0)
 }
 
+test "parse_program: empty import item arrays stay fresh per declaration" {
+  let stmts = parse_program(lex("import ./first.vibe {}\nimport ./second.vibe {}"))
+  let first_items = match Array::get(stmts, 0) {
+    SImport(_, items) => items,
+    _ => ArrayBuilder::freeze(ArrayBuilder::new())
+  }
+  let second_items = match Array::get(stmts, 1) {
+    SImport(_, items) => items,
+    _ => ArrayBuilder::freeze(ArrayBuilder::new())
+  }
+  Array::push(first_items, ("Injected", None))
+  assert_eq(Array::length(second_items), 0)
+}
+
 test "parse_program: taskgroup accepts the empty source-offset lane (#1780)" {
   let stmts =
   parse_program(lex("fn run() -> Int { taskgroup { g => 7 } }"))

--- a/scripts/bench_regression.mjs
+++ b/scripts/bench_regression.mjs
@@ -33,7 +33,7 @@ const ITERS = process.env.BENCH_ITERS || "300";
 const update = process.argv.includes("--update");
 
 // The fixture set the gate covers (must run cleanly on the linear backend).
-const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe", "lexer_keyword_bench.vibe", "parser_query_bench.vibe"];
+const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe", "lexer_keyword_bench.vibe", "parser_empty_metadata_bench.vibe", "parser_query_bench.vibe"];
 
 function runBench(file) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What

- replace parser-side dummy-element `Array::slice(..., 0, 0)` empty metadata arrays with fresh one-allocation `ArrayBuilder` results
- reuse the parser's typed empty-array helpers in expression lowering
- add a freshness regression and a deterministic parser allocation benchmark
- record the SIMD lexer experiment and the next evidence-backed targets

## Why

The old empty-array idiom allocated a backing array containing a dummy value and then allocated a zero-length slice. Parser metadata creates these arrays frequently. A fresh empty array is still required because parser consumers may mutate it, but the dummy backing allocation is unnecessary.

On the same latest-main source and compiler, the new focused fixture improves from 122,688 to 99,872 B/op (-18.6%). The existing parser query fixture improves from 117,760 to 117,088 B/op (-0.57%).

The SIMD experiment found that identifier scanning is neutral on representative source. The follow-up should target long comment and string spans with fused unboxed scanners instead of adding a second token representation now.

## Validation

- `pkf run generation -- --stage3` (stage2/stage3 fixpoint)
- parser focused suite: 4 files / 188 tests
- isolated latest-main allocation A/B
- `node scripts/bench_regression.mjs` (5/5 allocation ratchets)
- `pkf run test-local` (2/2 selected)
- `pkf run test-pre-commit`
- formatter, JavaScript syntax, and `git diff --check`
