### PR TITLE
fix(gc): host ABI を vibe.abi セクションで宣言する (#1814)

### DIFF
--- a/fixtures/gc_host_abi_declaration.vibe
+++ b/fixtures/gc_host_abi_declaration.vibe
@@ -1,0 +1,51 @@
+// #1814: the wasm-gc lane must DECLARE the host ABI it speaks.
+//
+// Both lanes talk to the node host runner over the same raw tagged-i64 ABI,
+// but the runner only knows which convention a module uses from the
+// `vibe.abi` custom section (`detectHostImportAbi`). When `VIBE_IMPORT_ABI`
+// is unset -- which is the normal way a built artifact runs -- a module
+// without that section falls back to "tagged", and every host-import result
+// is decoded under the wrong convention.
+//
+// The gc lane emitted no such section. The failure was silent and pointed the
+// wrong way: nothing traps, no diagnostic appears, the module is valid, and
+// the ANSWERS are wrong. `Fs::exists` on a missing path came back TRUE, which
+// is the worst direction for that particular question.
+//
+// Why the checks below are shaped this way:
+//
+//   - the MISSING path is checked, not just the present one. Under the
+//     mis-decode the present case happened to agree with linear, so a
+//     positive-only fixture stays green through the whole bug.
+//   - a String result is measured by LENGTH, not by equality against a
+//     literal. The mis-decode produced 65537 for a 6-byte file, so length is
+//     where the raw packed value shows up.
+//   - the result is a single Int the gate compares across both lanes: the
+//     property is "gc agrees with linear", and hard-coding an expected number
+//     for one lane would not state that.
+
+fn fs_checks() -> Int with Fs {
+  let missing = if Fs::exists("_build/gc_host_abi_probe/nope") {
+    1
+  } else {
+    0
+  }
+  let present = if Fs::exists("_build/gc_host_abi_probe/a.txt") {
+    1
+  } else {
+    0
+  }
+  let read_len = String::length(Fs::read_file("_build/gc_host_abi_probe/a.txt"))
+  // 0 * 100 + 1 * 10 + 6 = 16 when every one is decoded correctly.
+  missing * 100 + present * 10 + read_len
+}
+
+fn env_check() -> Int with Env {
+  // An unset variable is the empty string; under the mis-decode this is a
+  // packed value with a non-zero length.
+  String::length(Env::get("VIBE_GC_HOST_ABI_UNSET_XYZ"))
+}
+
+export let main = () -> Int with Fs + Env {
+  fs_checks() * 10 + env_check()
+}

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -154,6 +154,7 @@ import @vibe/compiler/codegen/wasm_emit {
   emit_table_section_funcref,
   emit_type_section,
   emit_type_section_multi,
+  emit_vibe_abi_custom_section,
   string_to_data
 }
 
@@ -2251,6 +2252,16 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   }
   let out = bytebuf_new()
   emit_header(out)
+  // #1814: the gc lane speaks the SAME raw tagged-i64 host ABI as the linear
+  // lane, but it never said so. The node host runner picks its encoding from
+  // this section when `VIBE_IMPORT_ABI` is unset (`detectHostImportAbi`), and
+  // with no section it falls back to "tagged" -- so every host-import result
+  // came back decoded under the wrong convention while the module itself was
+  // fine. Measured: `Fs::exists` on a MISSING path returned true, and
+  // `String::length(Fs::read_file(f))` returned 65537 for a 6-byte file. Both
+  // agree with linear the moment this section exists (or `VIBE_IMPORT_ABI=raw`
+  // is forced), which is what identified the cause.
+  emit_vibe_abi_custom_section(out, "raw")
   bytebuf_push_section(out, 1, type_content)
   if use_host {
     // fd_write + the ten "vibe" host imports (types: 3=(i64)->i64,

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4310,6 +4310,53 @@ fi
 rm -rf "$gcaliasdir"
 echo "[compiler-gate] wasm-gc closure builtin alias capture ok (gc)"
 
+# 40h-4. #1814: the gc lane must DECLARE its host ABI in the `vibe.abi` custom
+#        section. The node runner picks the decoding convention from that
+#        section when VIBE_IMPORT_ABI is unset -- the normal way a built
+#        artifact runs -- and falls back to "tagged" without it, so every
+#        host-import result came back wrong while the module stayed valid and
+#        silent. `Fs::exists` on a MISSING path answered true.
+#
+#        Deliberately runs the produced modules with NO VIBE_IMPORT_ABI: the
+#        point is that the module says so itself. Forcing the env var here
+#        would make the gate pass with the section absent.
+echo "[compiler-gate] 40h-4/40 wasm-gc host ABI declaration (#1814)"
+gcabidir="_build/_gate_gc_host_abi"
+rm -rf "$gcabidir"; mkdir -p "$gcabidir"
+rm -rf _build/gc_host_abi_probe; mkdir -p _build/gc_host_abi_probe
+printf 'hello\n' > _build/gc_host_abi_probe/a.txt
+gcabi_out=""
+for gcabi_be in linear gc; do
+  env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcabi_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "fixtures/gc_host_abi_declaration.vibe" "$gcabidir/$gcabi_be.wasm" main >/dev/null 2>&1
+  if [ ! -s "$gcabidir/$gcabi_be.wasm" ]; then
+    echo "[compiler-gate] FAIL: gc_host_abi_declaration.vibe did not compile on the $gcabi_be backend (#1814)" >&2
+    cat "$gcabidir/$gcabi_be.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  gcabi_got="$(env -u VIBE_IMPORT_ABI VIBE_PREOPEN_DIR="$ROOT_DIR" \
+    bash scripts/run_wasm_vibe_host_runner.sh "$gcabidir/$gcabi_be.wasm" 2>&1 | tail -1)"
+  if [ "$gcabi_be" = "linear" ]; then
+    gcabi_out="$gcabi_got"
+  elif [ "$gcabi_got" != "$gcabi_out" ]; then
+    echo "[compiler-gate] FAIL: gc host-import results disagree with linear: gc='$gcabi_got' linear='$gcabi_out' (#1814)" >&2
+    exit 1
+  fi
+done
+# 160 = missing:0 present:1 read_len:6 env_len:0 -- pin the value too, so a
+# change that breaks BOTH lanes the same way cannot pass the agreement check.
+if [ "$gcabi_out" != "160" ]; then
+  echo "[compiler-gate] FAIL: host-import probe returned '$gcabi_out' (want 160) on both lanes (#1814)" >&2
+  exit 1
+fi
+if ! grep -qa "vibe.abi" "$gcabidir/gc.wasm"; then
+  echo "[compiler-gate] FAIL: the gc module carries no vibe.abi custom section (#1814)" >&2
+  exit 1
+fi
+rm -rf "$gcabidir" _build/gc_host_abi_probe
+echo "[compiler-gate] wasm-gc host ABI declaration ok (linear + gc, =160)"
+
 # #1295: String is a packed fat pointer, so the gc EForIn lowering must
 # normalize it to character codes before its shared Array iteration loop.
 echo "[compiler-gate] wasm-gc String for-in"


### PR DESCRIPTION
**wasm-gc レーンの host import が黙って誤った答えを返していました。** `Fs::exists` は存在しないパスに `true` を返します。

修正はコンパイラ側 1 行 + import 1 行です。

## 何が起きていたか

gc レーンは linear と同じ raw tagged-i64 の host ABI で喋っているのに、**それを宣言していませんでした**。node host runner は `VIBE_IMPORT_ABI` が未設定のときモジュールの `vibe.abi` カスタムセクションから規約を検出し (`detectHostImportAbi`)、無ければ既定の `"tagged"` に落ちます。

```js
if (!REQUESTED_HOST_IMPORT_ABI) {
  const detectedAbi = detectHostImportAbi(wasmBytes);
  if (detectedAbi !== null) { HOST_IMPORT_ABI = detectedAbi; }
}
```

**ビルド済み成果物を普通に実行する経路がまさに未設定**なので、gc の host import の結果はすべて別の規約で復号されていました。

壊れ方が悪質です。trap もせず、診断も出ず、モジュールは valid で、**答えだけが違う**。

| | linear | gc (修正前) |
|---|---:|---:|
| `Fs::exists("存在しない")` | `0` | **`1`** |
| `String::length(Fs::read_file(f))` (6 バイト) | `6` | **`65537`** |
| `Stdin::read_char()` | `-1` | `-4` |
| `Array::length(Fs::readdir(d))` | `2` | `1627389952` |

## どう特定したか

**同じ gc モジュールを、実行時の環境変数だけ変えて走らせました。**

| gc モジュール (バイト列は同一) | env なし | `VIBE_IMPORT_ABI=raw` |
|---|---:|---:|
| `Fs::exists("存在しない")` | `1` | **`0`** |
| `String::length(Fs::read_file(f))` | `65537` | **`6`** |

バイト列が同じで答えだけ変わるなら、コンパイラ側の変換の話ではありません。ここで原因が確定しました。

> **訂正**: #1814 の当初の診断 (「gc に結果変換層が無い」) は**誤り**でした。症状と実測値は正しいものの、原因は変換層の欠落ではなく 39 バイトのセクションの欠落です。私が**コンパイル時にだけ `VIBE_IMPORT_ABI=raw` を渡し、実行時に渡していなかった**のが読み違えの原因です。issue 側に訂正コメントを入れ、誤った主張と提案を明示的に取り下げてあります。

## 修正

linear と同じ 1 行を `emit_header` の直後に出すだけです。

```vibe
emit_header(out)
emit_vibe_abi_custom_section(out, "raw")
```

## fixture と gate の設計

**否定ケースを必ず含みます。** 誤復号下でも**肯定ケースは偶然一致する**ので、肯定だけの fixture はバグ期間中ずっと緑のままです。実際、調査中に `Fs::is_dir` / `Fs::is_file` を肯定ケースだけで見て「通った」と判定しかけました。否定ケースを足して初めて出ています。

**String は長さで測ります。** 生の packed 値 (`65537`) が現れるのがそこだからです。リテラル等価では、誤復号が String をまったく別のものにしてしまうと比較自体が意味を失います。

**gate は実行時に `VIBE_IMPORT_ABI` を渡しません。** 渡すとセクションが無くても通ってしまい、検査の意味が消えます。この節が検査しているのは「モジュールが自分で宣言しているか」です。

**両レーンの一致と値そのもの (`=160`) の両方を見ます。** 一致だけでは両レーンが同じように壊れた場合を素通しし、値だけでは gc が linear からずれたことを言えません。

さらに、生成された gc モジュールに `vibe.abi` が実在することも直接確認します。

## 検証

```
RED   (修正前 gc) 722023
GREEN (修正後 gc) 160   ← linear と一致
```

- `compiler_gate.sh` — **GATE=0**、節 40h-4 の実行をログで確認 (`wasm-gc host ABI declaration ok (linear + gc, =160)`)
- `unit_test_runner.sh` — **UNIT=0**
- `pkf run pre-commit` — 通過 (`--no-verify` なし)
- セクション分解で `custom:vibe.abi 39` が gc モジュールに出ることを確認

## #1262 への影響

これは gc レーンでの自己ビルド (#1262) を進める中で見つけたものです。次の停止点は未実装 builtin (`Fs::rename` ほか 12 個) ですが、**それらの実装可否は測り直しになります** — 以前「6 個は結果が壊れるので import 追加だけでは駄目」と判定したのは、実行時に ABI を渡していなかった同じ誤りの影響下だったので、判定自体が無効です。本 PR の後に改めて実測します。

---
_Generated by [Claude Code](https://claude.ai/code/session_017BFSjod7HAW2L3GySW81Pi)_