### PR TITLE
perf(codegen): per-function code buffer を region + MutBytes に載せる (#1770 Phase 1 初適用、selfcompile heap −5.1MB)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -8089,63 +8089,75 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   }
   let mut ci = 0
   while ci < Array::length(bodies) {
-    let body = Array::get(bodies, ci)
-    let func_buf = bytebuf_new()
-    let ni32 = Array::get(meta_i32, ci)
-    let ni64 = Array::get(meta_i64, ci)
-    // #805 SIMD locals: a third v128 (0x7B) run after the i32/i64 runs.
-    // Zero for every function except inline-wasm fns declaring v128 locals,
-    // so the header bytes are unchanged wherever the feature is unused.
-    let nv128 = Array::get(meta_v128, ci)
-    let mut ngroups = 0
-    if ni32 > 0 {
-      ngroups = ngroups + 1
-    } else {
-      ()
-    }
-    if ni64 > 0 {
-      ngroups = ngroups + 1
-    } else {
-      ()
-    }
-    if nv128 > 0 {
-      ngroups = ngroups + 1
-    } else {
-      ()
-    }
-    leb128_encode_u32(func_buf, ngroups)
-    if ni32 > 0 {
-      leb128_encode_u32(func_buf, ni32)
-      bytebuf_push(func_buf, 127)
-    } else {
-      ()
-    }
-    if ni64 > 0 {
-      leb128_encode_u32(func_buf, ni64)
-      bytebuf_push(func_buf, 126)
-    } else {
-      ()
-    }
-    if nv128 > 0 {
-      leb128_encode_u32(func_buf, nv128)
-      bytebuf_push(func_buf, 123)
-    } else {
-      ()
-    }
-    if linemap_state.enabled {
-      let lm_bi = ci - num_generated
-      if lm_bi >= 0 && lm_bi < num_user_funcs {
-        Array::set(linemap_hdrlen_by_bi, lm_bi, bytebuf_length(func_buf))
+    // ADR-0090 dogfood (#1770): each function's code buffer is built, copied
+    // into code_content, and discarded -- the buffer itself never escapes the
+    // iteration. Backing it with the region arena reclaims the buffer AND its
+    // doubling regrows wholesale at the region end instead of leaking them on
+    // the bump heap (one buffer per emitted function, the hottest
+    // build-and-discard site in a self-compile). The bytebuf_* helpers are
+    // unchanged: arena vs main-heap regrow is a property of the buffer's own
+    // block (gen_bytes_push_body / gen_bytes_append_body), not of the call
+    // site, so a MutBytes flows through them as-is. Needs the
+    // mutbytes-2026-08-15 seed (#1801/#1808).
+    region r {
+      let body = Array::get(bodies, ci)
+      let func_buf = MutBytes::empty(r)
+      let ni32 = Array::get(meta_i32, ci)
+      let ni64 = Array::get(meta_i64, ci)
+      // #805 SIMD locals: a third v128 (0x7B) run after the i32/i64 runs.
+      // Zero for every function except inline-wasm fns declaring v128 locals,
+      // so the header bytes are unchanged wherever the feature is unused.
+      let nv128 = Array::get(meta_v128, ci)
+      let mut ngroups = 0
+      if ni32 > 0 {
+        ngroups = ngroups + 1
       } else {
         ()
       }
-    } else {
-      ()
+      if ni64 > 0 {
+        ngroups = ngroups + 1
+      } else {
+        ()
+      }
+      if nv128 > 0 {
+        ngroups = ngroups + 1
+      } else {
+        ()
+      }
+      leb128_encode_u32(func_buf, ngroups)
+      if ni32 > 0 {
+        leb128_encode_u32(func_buf, ni32)
+        bytebuf_push(func_buf, 127)
+      } else {
+        ()
+      }
+      if ni64 > 0 {
+        leb128_encode_u32(func_buf, ni64)
+        bytebuf_push(func_buf, 126)
+      } else {
+        ()
+      }
+      if nv128 > 0 {
+        leb128_encode_u32(func_buf, nv128)
+        bytebuf_push(func_buf, 123)
+      } else {
+        ()
+      }
+      if linemap_state.enabled {
+        let lm_bi = ci - num_generated
+        if lm_bi >= 0 && lm_bi < num_user_funcs {
+          Array::set(linemap_hdrlen_by_bi, lm_bi, bytebuf_length(func_buf))
+        } else {
+          ()
+        }
+      } else {
+        ()
+      }
+      bytebuf_push_buf(func_buf, body)
+      bytebuf_push(func_buf, 11)
+      leb128_encode_u32(code_content, bytebuf_length(func_buf))
+      bytebuf_push_buf(code_content, func_buf)
     }
-    bytebuf_push_buf(func_buf, body)
-    bytebuf_push(func_buf, 11)
-    leb128_encode_u32(code_content, bytebuf_length(func_buf))
-    bytebuf_push_buf(code_content, func_buf)
     ci = ci + 1
   }
   bytebuf_push_section(out, 10, code_content)


### PR DESCRIPTION
## 概要

**コンパイラ自身のソースで region + MutBytes を使う最初の実適用** (#1770 Phase 1)。対象は `linked_compile.vibe` の関数 emit ループの `func_buf` — 「作る → `code_content` へコピー → 捨てる」を emit する関数の数だけ繰り返す、self-compile 中で最もホットな build-and-discard サイト。

なお当初候補だった `ast_binary_write_string` は調査の結果**テスト専用の休眠モジュール** (本番 heap 削減ゼロ) だったため、#1794 の教訓「数字で勝てる場所にだけ適用する」に従いこちらに変更した。

## 変更 (diff は実質 3 行 + reindent)

- loop body を `region r { ... }` で包む
- `let func_buf = bytebuf_new()` → `let func_buf = MutBytes::empty(r)`

**`bytebuf_*` ヘルパ群は無変更**。arena か main heap かの regrow 判定はバッファ自身の block アドレスで行う #1801 の設計 (「regrow のレーンはバッファの性質であって呼び出し位置の性質ではない」) なので、MutBytes 値は `Bytes` 型引数のヘルパをそのまま流れ、`leb128_encode_u32(func_buf, ...)` 等が無改造で arena 上で動く。exit は `bytebuf_push_buf(code_content, func_buf)` = 既存のコピーそのもので、**#1794 の「copy-out が節約と相殺する」問題は構造的に起きない** (escape する値が無い)。

## 実測 (`scripts/selfcompile_kpi.sh`、決定的指標)

| | heap_ptr_bytes | mem_pages | wall |
|---|---:|---:|---|
| baseline (main `aecd9ed`) | 1,036,333,344 | 18,663 | 4.8-6.9s (ノイズ) |
| **pilot** | **1,031,231,432 (−5,101,912 B)** | 18,663 (不変) | 同範囲 |

残差は region lambda の closure 環境 (既知、fixture と同じ) と `ci` の boxed cell。

## 検証

- **pilot compiler の fixpoint**: pilot stage2 が自身の flat source を再コンパイルして byte 一致
- `scripts/vibe_fmt.sh --check` fixpoint
- `bash scripts/compiler_gate.sh` — selfbuild fixpoint 込み (この PR の push 時点でローカル実行中の最終確認あり、CI でも同 gate が走る)
- 前提 seed: main が pin 済みの `zero-alloc-directive-2026-08-15` (sha256 `89446ac1` = #1801 の MutBytes + nested-region regrow guard 込み)

## 続き (#1770)

- 同型の適用候補: `linked_compile.vibe` のセクション content buffer ~20 本、`component_codegen.vibe` の 183 サイト (いずれも同じヘルパ経由パターン)
- region lambda の closure 環境を alloc しない最適化 (残差 ~40B/region の解消) は ADR-0090 の既知の別項目

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_