### PR TITLE
perf(incremental): emit scoped edit-cycle summaries

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -754,8 +754,9 @@ local editCycleKpi = new Task {
 
 local testEditCycleKpi = new Task {
   name = "test-edit-cycle-kpi"
-  description = "validate edit-cycle KPI telemetry sidecar parsing"
-  cmd = "node --test scripts/edit_cycle_kpi.test.mjs"
+  description = "validate edit-cycle KPI telemetry and strict phase summaries"
+  cmd =
+    "node --test scripts/edit_cycle_kpi.test.mjs scripts/incremental_phase_summary.test.mjs"
   cache = false
 }
 

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -755,8 +755,7 @@ local editCycleKpi = new Task {
 local testEditCycleKpi = new Task {
   name = "test-edit-cycle-kpi"
   description = "validate edit-cycle KPI telemetry and strict phase summaries"
-  cmd =
-    "node --test scripts/edit_cycle_kpi.test.mjs scripts/incremental_phase_summary.test.mjs"
+  cmd = "node --test scripts/edit_cycle_kpi.test.mjs scripts/incremental_phase_summary.test.mjs"
   cache = false
 }
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -38,10 +38,12 @@ is an ADR-sized decision, not a slice-sized one.
 - **mtime is a hint, never a semantic identity.** Its only job is to let the
   compiler skip *recomputing* a content identity. A stat-token match may reuse a
   previously computed source fingerprint; it may not stand in for one.
-- **Git commit/author/last-modified dates are never content identity.** For a
-  tracked clean file, the blob OID is the strong identity candidate; dirty and
-  untracked files fall back to stat + content hash. Behavior outside a Git
-  repository must be identical.
+- **Git commit/author/last-modified dates are never content identity.** A Git
+  blob OID is only an evaluation candidate, not production authority: filters,
+  line-ending conversion, racy index state, linked/split indexes, hash formats,
+  and repository availability can make it differ from the bytes actually
+  ingested by the compiler. Production continues to use current working-tree
+  bytes and behaves identically outside a Git repository.
 - Do not conflate `source_fingerprint`, `implementation_fingerprint`,
   `interface_fingerprint`, `checked_env_fingerprint`, normalized typed-IR
   identity, and artifact-input identity. They answer different questions and
@@ -170,10 +172,32 @@ The initial executable baseline is `scripts/edit_cycle_kpi.mjs`. It measures the
 one-shot `vibe check` path for cold, exact warm/no-op, comment-only, private-body,
 and public-interface edits. It requests a disabled-by-default compiler sidecar
 for deterministic `db_typecheck_fs` work counters: modules planned, rechecked,
-reused, and parse operations. It intentionally does not yet measure LSP
-residency, runnable artifacts, or complete invalidation/codegen counts. Its
-purpose is to establish whether current persistent caches produce a measurable
-user-visible effect before implementing a new artifact format.
+reused, and parse operations. The qualified outer record (`schema:
+"edit_cycle_kpi"`, `version: 1`) pins and records persistent ingestion stamps
+off, production-default typing dependency environment reuse
+on, invalidation tracing off, and check-only compilation; inherited environment
+variables cannot silently change those modes. Each record also has a scoped
+`work_summary` and matching `work_scopes`:
+
+- `read_bytes`: all bytes returned by `fs_read_file` plus `fs_read_bytes` host
+  imports, including cache and other host-FS traffic; it is not source-only;
+- `hash_calls`: `ingestion_fingerprint.hash_calls`, counting operations—not
+  proven-distinct files—at the current `fingerprint_file_fs` boundary;
+- `parsed_files`: `current_source_parse_executions`, limited to TypeDb current-
+  source parse-memo misses, excluding loader/header/import-scan parsing;
+- `checked_modules`: `checker_executions`;
+- `codegen_modules`: always zero because the endpoint is check-only.
+
+`scripts/incremental_phase_summary.mjs before.jsonl after.jsonl` emits the
+machine-readable before/after summary. It validates all nested telemetry and
+fails before computing deltas if the outer schema, benchmark, fixture, runner,
+endpoint, process mode, complete case-by-run topology, mode authority, or metric
+scopes differ. Each case has fixed `edit_kind` and `cache_state` metadata.
+Malformed/unsafe counts, ingestion read/hash unit disagreement, stamp activity
+while stamps are pinned off, nondeterministic repetitions, and nonzero codegen
+are also rejected. The KPI intentionally does not yet measure LSP residency,
+runnable artifacts, complete loader reconstruction attribution, or module
+codegen reuse.
 
 ### Initial local result (2026-08-02)
 
@@ -284,6 +308,16 @@ or a control-character nonce, or has the wrong nonce. It records the result as
 `host_fs_scope` alongside—not inside—the compiler-owned
 `incremental_typecheck` telemetry. The feature is disabled by default and does
 not change compiler source loading, persistent formats, cache keys, or reuse.
+
+Production use of Git blob OIDs for source identity is currently **NO-GO**.
+Obtaining an OID from the index does not prove equality to compiler-ingested
+working-tree bytes under attributes, clean/smudge filters, or line-ending
+conversion; racy-clean state, alternate index formats, linked worktrees,
+SHA-256 repositories, sparse state, and non-repository/sandbox execution also
+lack one trusted authority boundary. Invoking Git would add ambient process
+authority. Reconsideration requires a separately authenticated host API that
+proves both clean classification and exact equality to the byte/text stream the
+compiler consumes. No commit timestamp or author/modified date may substitute.
 
 The opt-in persistent ingestion-stamp oracle similarly uses isolated gate-off
 and gate-on cache histories for a copied package. It proves only that unchanged

--- a/scripts/edit_cycle_kpi.mjs
+++ b/scripts/edit_cycle_kpi.mjs
@@ -64,6 +64,83 @@ const ingestionFingerprintKeys = [
 ];
 const ingestionFingerprintCounterKeys = ingestionFingerprintKeys.slice(3);
 
+export const editCycleRecordSchema = "edit_cycle_kpi";
+export const editCycleRecordVersion = 1;
+export const editCycleCaseDefinitions = Object.freeze({
+  cold: Object.freeze({ edit_kind: "none", cache_state: "empty" }),
+  exact_noop: Object.freeze({ edit_kind: "none", cache_state: "preserved" }),
+  comment_edit: Object.freeze({ edit_kind: "non_semantic", cache_state: "preserved" }),
+  private_body_edit: Object.freeze({ edit_kind: "implementation", cache_state: "preserved" }),
+  public_interface_edit: Object.freeze({ edit_kind: "interface", cache_state: "preserved" }),
+});
+export const editCycleCases = Object.freeze(Object.keys(editCycleCaseDefinitions));
+export const editCycleModes = Object.freeze({
+  persistent_ingestion_stamp: "disabled",
+  typing_dependency_env_reuse: "default-on",
+  invalidation_trace: "disabled",
+  compilation: "check-only",
+});
+export const editCycleWorkScopes = Object.freeze({
+  read_bytes: "host_fs_scope.all_host_import_returned_bytes",
+  hash_calls: "ingestion_fingerprint.fingerprint_file_fs_hash_calls",
+  parsed_files: "incremental_typecheck.typedb_current_source_parse_misses",
+  checked_modules: "incremental_typecheck.checker_executions",
+  codegen_modules: "check_endpoint.none",
+});
+
+/// Apply benchmark mode authority after ambient process.env. Empty strings are
+/// deliberate: the CLI treats these optional controls as absent. Keeping this
+/// helper exported makes ambient-mode isolation directly testable.
+export function pinEditCycleModes(env) {
+  return {
+    ...env,
+    VIBE_EXPERIMENTAL_PERSISTENT_INGESTION_STAMP: "",
+    VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE: "",
+    VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "",
+    VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT: "",
+    VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE: "",
+  };
+}
+
+export function parseEditCycleRunCount(rawValue) {
+  const text = rawValue === undefined || rawValue === "" ? "3" : rawValue;
+  if (typeof text !== "string" || !/^[1-9][0-9]*$/u.test(text)) {
+    throw new Error(`VIBE_EDIT_CYCLE_RUNS must be a positive decimal safe integer, got ${rawValue}`);
+  }
+  const runs = Number(text);
+  if (!Number.isSafeInteger(runs)) {
+    throw new Error(`VIBE_EDIT_CYCLE_RUNS must be a positive decimal safe integer, got ${rawValue}`);
+  }
+  return runs;
+}
+
+export function assertDisabledIngestionStamps(telemetry, source = "ingestion fingerprint telemetry") {
+  for (const key of [
+    "stamp_probes",
+    "stamp_hits",
+    "stamp_misses",
+    "stamp_malformed",
+    "stamp_text_units_read",
+    "stamp_publications",
+  ]) {
+    if (telemetry[key] !== 0) throw new Error(`${source}: ${key} must be 0 when ingestion stamps are disabled`);
+  }
+}
+
+export function buildEditCycleWorkSummary(incrementalTypecheck, ingestionFingerprint, hostFsScope) {
+  const readBytes = hostFsScope.read_file_returned_bytes + hostFsScope.read_bytes_returned_bytes;
+  if (!Number.isSafeInteger(readBytes)) {
+    throw new Error("edit-cycle KPI work summary: read_bytes exceeds the safe integer range");
+  }
+  return {
+    read_bytes: readBytes,
+    hash_calls: ingestionFingerprint.hash_calls,
+    parsed_files: incrementalTypecheck.current_source_parse_executions,
+    checked_modules: incrementalTypecheck.checker_executions,
+    codegen_modules: 0,
+  };
+}
+
 /// Parse and validate the compiler-owned incremental typecheck sidecar.
 /// Kept exported so the structural contract has a focused Node regression test
 /// without needing to run a full wasm compiler invocation.
@@ -145,6 +222,9 @@ export function parseIngestionFingerprintTelemetry(text, expectedNonce, source =
   if (telemetry.hash_calls !== telemetry.source_read_calls) {
     throw new Error(`${source}: hash_calls must equal source_read_calls`);
   }
+  if (telemetry.hash_input_string_units !== telemetry.source_read_string_units) {
+    throw new Error(`${source}: hash_input_string_units must equal source_read_string_units`);
+  }
   return telemetry;
 }
 
@@ -206,9 +286,11 @@ function main() {
     }
   }
 
-  const runs = Number.parseInt(process.env.VIBE_EDIT_CYCLE_RUNS || "3", 10);
-  if (!Number.isInteger(runs) || runs < 1) {
-    console.error(`edit-cycle-kpi: VIBE_EDIT_CYCLE_RUNS must be positive, got ${process.env.VIBE_EDIT_CYCLE_RUNS}`);
+  let runs;
+  try {
+    runs = parseEditCycleRunCount(process.env.VIBE_EDIT_CYCLE_RUNS);
+  } catch (error) {
+    console.error(`edit-cycle-kpi: ${error.message}`);
     process.exit(2);
   }
 
@@ -239,7 +321,7 @@ function main() {
       cwd: project,
       encoding: "utf8",
       env: {
-        ...process.env,
+        ...pinEditCycleModes(process.env),
         VIBE_BUILD_CACHE_DIR: cache,
         VIBE_CLI_CWASM: "",
         VIBE_CLI_WASM: stage2,
@@ -278,6 +360,10 @@ function main() {
       ingestionTelemetryNonce,
       `edit-cycle-kpi: ${caseName} ingestion fingerprint telemetry`,
     );
+    assertDisabledIngestionStamps(
+      ingestionFingerprint,
+      `edit-cycle-kpi: ${caseName} ingestion fingerprint telemetry`,
+    );
     if (!existsSync(hostFsScopePath)) {
       throw new Error(`edit-cycle-kpi: ${caseName} omitted host filesystem telemetry sidecar`);
     }
@@ -287,7 +373,8 @@ function main() {
       `edit-cycle-kpi: ${caseName} host filesystem telemetry`,
     );
     records.push({
-      schema: 5,
+      schema: editCycleRecordSchema,
+      version: editCycleRecordVersion,
       benchmark: "user-edit-cycle-check",
       compiler_sha256: compilerSha,
       compiler_file: basename(stage2),
@@ -299,6 +386,9 @@ function main() {
       cache_state: cacheState,
       process_mode: "one-shot",
       endpoint: "check-command-complete",
+      modes: editCycleModes,
+      work_scopes: editCycleWorkScopes,
+      work_summary: buildEditCycleWorkSummary(telemetry, ingestionFingerprint, hostFsScope),
       incremental_typecheck: telemetry,
       ingestion_fingerprint: ingestionFingerprint,
       host_fs_scope: hostFsScope,

--- a/scripts/edit_cycle_kpi.test.mjs
+++ b/scripts/edit_cycle_kpi.test.mjs
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  assertDisabledIngestionStamps,
+  buildEditCycleWorkSummary,
+  editCycleModes,
+  parseEditCycleRunCount,
+  pinEditCycleModes,
   parseHostFsScopeTelemetry,
   parseIncrementalTelemetry,
   parseIngestionFingerprintTelemetry,
@@ -110,6 +115,88 @@ test("edit-cycle KPI accepts a complete host_fs_scope sidecar", () => {
   assert.deepEqual(
     parseHostFsScopeTelemetry(JSON.stringify(validHostFsScope), "run-123"),
     validHostFsScope,
+  );
+});
+
+test("edit-cycle KPI pins authority modes after ambient environment", () => {
+  const env = pinEditCycleModes({
+    KEEP: "yes",
+    VIBE_EXPERIMENTAL_PERSISTENT_INGESTION_STAMP: "1",
+    VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE: "1",
+    VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "1",
+    VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT: "/tmp/ambient",
+    VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE: "ambient",
+  });
+  assert.equal(env.KEEP, "yes");
+  for (const key of [
+    "VIBE_EXPERIMENTAL_PERSISTENT_INGESTION_STAMP",
+    "VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE",
+    "VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE",
+    "VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT",
+    "VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE",
+  ]) assert.equal(env[key], "");
+  assert.deepEqual(editCycleModes, {
+    persistent_ingestion_stamp: "disabled",
+    typing_dependency_env_reuse: "default-on",
+    invalidation_trace: "disabled",
+    compilation: "check-only",
+  });
+});
+
+test("edit-cycle KPI parses only whole positive safe-integer run counts", () => {
+  assert.equal(parseEditCycleRunCount(undefined), 3);
+  assert.equal(parseEditCycleRunCount(""), 3);
+  assert.equal(parseEditCycleRunCount("12"), 12);
+  for (const invalid of ["1x", "1.5", "0x10", "0", "-1", "01", "9007199254740992"]) {
+    assert.throws(() => parseEditCycleRunCount(invalid), /positive decimal safe integer/, invalid);
+  }
+});
+
+test("edit-cycle KPI enforces ingestion unit and disabled-stamp invariants", () => {
+  assert.throws(
+    () => parseIngestionFingerprintTelemetry(
+      JSON.stringify({ ...validIngestionFingerprint, hash_input_string_units: 8 }),
+      "run-123",
+    ),
+    /hash_input_string_units must equal source_read_string_units/,
+  );
+  assert.doesNotThrow(() => assertDisabledIngestionStamps({
+    ...validIngestionFingerprint,
+    stamp_probes: 0,
+    stamp_hits: 0,
+    stamp_misses: 0,
+    stamp_malformed: 0,
+    stamp_text_units_read: 0,
+    stamp_publications: 0,
+  }));
+  assert.throws(
+    () => assertDisabledIngestionStamps(validIngestionFingerprint),
+    /must be 0 when ingestion stamps are disabled/,
+  );
+});
+
+test("edit-cycle KPI derives the scoped check-only work summary", () => {
+  assert.deepEqual(
+    buildEditCycleWorkSummary(
+      JSON.parse(validSidecar),
+      validIngestionFingerprint,
+      validHostFsScope,
+    ),
+    {
+      read_bytes: 18,
+      hash_calls: 2,
+      parsed_files: 1,
+      checked_modules: 1,
+      codegen_modules: 0,
+    },
+  );
+  assert.throws(
+    () => buildEditCycleWorkSummary(
+      JSON.parse(validSidecar),
+      validIngestionFingerprint,
+      { ...validHostFsScope, read_file_returned_bytes: Number.MAX_SAFE_INTEGER },
+    ),
+    /safe integer range/,
   );
 });
 

--- a/scripts/incremental_phase_summary.mjs
+++ b/scripts/incremental_phase_summary.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+// Strict before/after comparator for scripts/edit_cycle_kpi.mjs JSONL.
+// It validates mode and scope authority before computing deterministic deltas.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertDisabledIngestionStamps,
+  buildEditCycleWorkSummary,
+  editCycleCaseDefinitions,
+  editCycleCases,
+  editCycleModes,
+  editCycleRecordSchema,
+  editCycleRecordVersion,
+  editCycleWorkScopes,
+  parseHostFsScopeTelemetry,
+  parseIncrementalTelemetry,
+  parseIngestionFingerprintTelemetry,
+} from "./edit_cycle_kpi.mjs";
+
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const workKeys = [
+  "read_bytes",
+  "hash_calls",
+  "parsed_files",
+  "checked_modules",
+  "codegen_modules",
+];
+const recordKeys = [
+  "schema",
+  "version",
+  "benchmark",
+  "compiler_sha256",
+  "compiler_file",
+  "runner_sha256",
+  "fixture_sha256",
+  "run",
+  "case",
+  "edit_kind",
+  "cache_state",
+  "process_mode",
+  "endpoint",
+  "modes",
+  "work_scopes",
+  "work_summary",
+  "incremental_typecheck",
+  "ingestion_fingerprint",
+  "host_fs_scope",
+  "wall_ms",
+  "success",
+];
+
+function assertExactKeys(value, keys, source) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${source}: expected a JSON object`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error(`${source}: unexpected fields`);
+  }
+}
+
+function assertExactObject(value, expected, source) {
+  assertExactKeys(value, Object.keys(expected), source);
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (value[key] !== expectedValue) {
+      throw new Error(`${source}: ${key} must be ${JSON.stringify(expectedValue)}`);
+    }
+  }
+}
+
+export function parseEditCycleRecord(value, source = "edit-cycle record") {
+  assertExactKeys(value, recordKeys, source);
+  if (value.schema !== editCycleRecordSchema || value.version !== editCycleRecordVersion) {
+    throw new Error(
+      `${source}: unsupported outer schema/version ${JSON.stringify(value.schema)}/${JSON.stringify(value.version)}`,
+    );
+  }
+  if (value.benchmark !== "user-edit-cycle-check") {
+    throw new Error(`${source}: unsupported benchmark ${JSON.stringify(value.benchmark)}`);
+  }
+  for (const key of ["compiler_sha256", "runner_sha256", "fixture_sha256"]) {
+    if (typeof value[key] !== "string" || !sha256Pattern.test(value[key])) {
+      throw new Error(`${source}: ${key} must be a lowercase SHA-256 hex digest`);
+    }
+  }
+  if (typeof value.compiler_file !== "string" || value.compiler_file.length === 0) {
+    throw new Error(`${source}: compiler_file must be non-empty`);
+  }
+  if (!Number.isSafeInteger(value.run) || value.run < 1) {
+    throw new Error(`${source}: run must be a positive safe integer`);
+  }
+  if (typeof value.case !== "string" || !Object.hasOwn(editCycleCaseDefinitions, value.case)) {
+    throw new Error(`${source}: unsupported case ${JSON.stringify(value.case)}`);
+  }
+  const expectedCase = editCycleCaseDefinitions[value.case];
+  for (const key of ["edit_kind", "cache_state"]) {
+    if (value[key] !== expectedCase[key]) {
+      throw new Error(`${source}: ${value.case}.${key} must be ${JSON.stringify(expectedCase[key])}`);
+    }
+  }
+  if (value.process_mode !== "one-shot") {
+    throw new Error(`${source}: process_mode must be one-shot`);
+  }
+  if (value.endpoint !== "check-command-complete") {
+    throw new Error(`${source}: endpoint must be check-command-complete`);
+  }
+  assertExactObject(value.modes, editCycleModes, `${source}: modes`);
+  assertExactObject(value.work_scopes, editCycleWorkScopes, `${source}: work_scopes`);
+  assertExactKeys(value.work_summary, workKeys, `${source}: work_summary`);
+  for (const key of workKeys) {
+    if (!Number.isSafeInteger(value.work_summary[key]) || value.work_summary[key] < 0) {
+      throw new Error(`${source}: work_summary.${key} must be a non-negative safe integer`);
+    }
+  }
+  if (value.work_summary.codegen_modules !== 0) {
+    throw new Error(`${source}: check endpoint requires codegen_modules to be 0`);
+  }
+  if (!Number.isFinite(value.wall_ms) || value.wall_ms < 0) {
+    throw new Error(`${source}: wall_ms must be a non-negative finite number`);
+  }
+  if (value.success !== true) {
+    throw new Error(`${source}: success must be true`);
+  }
+
+  const incremental = parseIncrementalTelemetry(
+    JSON.stringify(value.incremental_typecheck),
+    `${source}: incremental_typecheck`,
+  );
+  const ingestion = parseIngestionFingerprintTelemetry(
+    JSON.stringify(value.ingestion_fingerprint),
+    value.ingestion_fingerprint?.nonce,
+    `${source}: ingestion_fingerprint`,
+  );
+  assertDisabledIngestionStamps(ingestion, `${source}: ingestion_fingerprint`);
+  const hostFs = parseHostFsScopeTelemetry(
+    JSON.stringify(value.host_fs_scope),
+    value.host_fs_scope?.nonce,
+    `${source}: host_fs_scope`,
+  );
+  const derived = buildEditCycleWorkSummary(incremental, ingestion, hostFs);
+  for (const key of workKeys) {
+    if (value.work_summary[key] !== derived[key]) {
+      throw new Error(`${source}: work_summary.${key} does not match scoped telemetry`);
+    }
+  }
+  return value;
+}
+
+export function parseEditCycleJsonl(text, source = "edit-cycle JSONL") {
+  const lines = text.split(/\r?\n/u).filter((line) => line.length > 0);
+  if (lines.length === 0) throw new Error(`${source}: expected at least one record`);
+  return lines.map((line, index) => {
+    let value;
+    try {
+      value = JSON.parse(line);
+    } catch (error) {
+      throw new Error(`${source}:${index + 1}: invalid JSON (${error.message})`);
+    }
+    return parseEditCycleRecord(value, `${source}:${index + 1}`);
+  });
+}
+
+function identityOf(records, source) {
+  const first = records[0];
+  const fixed = {
+    schema: first.schema,
+    version: first.version,
+    benchmark: first.benchmark,
+    fixture_sha256: first.fixture_sha256,
+    runner_sha256: first.runner_sha256,
+    process_mode: first.process_mode,
+    endpoint: first.endpoint,
+    modes: first.modes,
+    work_scopes: first.work_scopes,
+  };
+  const seen = new Set();
+  for (const record of records) {
+    for (const key of ["schema", "version", "benchmark", "fixture_sha256", "runner_sha256", "process_mode", "endpoint"]) {
+      if (record[key] !== fixed[key]) throw new Error(`${source}: mixed ${key}`);
+    }
+    assertExactObject(record.modes, fixed.modes, `${source}: mixed modes`);
+    assertExactObject(record.work_scopes, fixed.work_scopes, `${source}: mixed work_scopes`);
+    const key = `${record.case}\0${record.run}`;
+    if (seen.has(key)) throw new Error(`${source}: duplicate case/run ${record.case}/${record.run}`);
+    seen.add(key);
+  }
+  const actualCases = [...new Set(records.map((record) => record.case))].sort();
+  const expectedCases = [...editCycleCases].sort();
+  if (actualCases.length !== expectedCases.length || actualCases.some((value, index) => value !== expectedCases[index])) {
+    throw new Error(`${source}: case set must be exactly ${editCycleCases.join(", ")}`);
+  }
+  const runs = [...new Set(records.map((record) => record.run))].sort((left, right) => left - right);
+  for (let index = 0; index < runs.length; index += 1) {
+    if (runs[index] !== index + 1) throw new Error(`${source}: runs must be contiguous starting at 1`);
+    for (const caseName of editCycleCases) {
+      if (!seen.has(`${caseName}\0${runs[index]}`)) {
+        throw new Error(`${source}: incomplete case/run matrix at ${caseName}/${runs[index]}`);
+      }
+    }
+  }
+  const compilerShas = [...new Set(records.map((record) => record.compiler_sha256))];
+  if (compilerShas.length !== 1) throw new Error(`${source}: mixed compiler_sha256`);
+  return { ...fixed, compiler_sha256: compilerShas[0], runs };
+}
+
+function stableCaseWork(records, caseName, source) {
+  const rows = records.filter((record) => record.case === caseName);
+  if (rows.length === 0) throw new Error(`${source}: missing case ${caseName}`);
+  const first = rows[0].work_summary;
+  for (const row of rows.slice(1)) {
+    for (const key of workKeys) {
+      if (row.work_summary[key] !== first[key]) {
+        throw new Error(`${source}: nondeterministic ${caseName}.${key} across repetitions`);
+      }
+    }
+  }
+  return first;
+}
+
+export function compareEditCycleRecords(beforeRecords, afterRecords) {
+  if (!Array.isArray(beforeRecords) || beforeRecords.length === 0) throw new Error("before: expected records");
+  if (!Array.isArray(afterRecords) || afterRecords.length === 0) throw new Error("after: expected records");
+  beforeRecords.forEach((record, index) => parseEditCycleRecord(record, `before:${index + 1}`));
+  afterRecords.forEach((record, index) => parseEditCycleRecord(record, `after:${index + 1}`));
+  const beforeIdentity = identityOf(beforeRecords, "before");
+  const afterIdentity = identityOf(afterRecords, "after");
+  for (const key of ["schema", "version", "benchmark", "fixture_sha256", "runner_sha256", "process_mode", "endpoint"]) {
+    if (beforeIdentity[key] !== afterIdentity[key]) throw new Error(`comparison: mismatched ${key}`);
+  }
+  if (
+    beforeIdentity.runs.length !== afterIdentity.runs.length
+    || beforeIdentity.runs.some((run, index) => run !== afterIdentity.runs[index])
+  ) throw new Error("comparison: mismatched run topology");
+  assertExactObject(afterIdentity.modes, beforeIdentity.modes, "comparison: mismatched modes");
+  assertExactObject(afterIdentity.work_scopes, beforeIdentity.work_scopes, "comparison: mismatched work_scopes");
+
+  return {
+    schema: "incremental_phase_summary",
+    version: 1,
+    benchmark: beforeIdentity.benchmark,
+    fixture_sha256: beforeIdentity.fixture_sha256,
+    runner_sha256: beforeIdentity.runner_sha256,
+    process_mode: beforeIdentity.process_mode,
+    endpoint: beforeIdentity.endpoint,
+    runs: beforeIdentity.runs,
+    modes: beforeIdentity.modes,
+    work_scopes: beforeIdentity.work_scopes,
+    before_compiler_sha256: beforeIdentity.compiler_sha256,
+    after_compiler_sha256: afterIdentity.compiler_sha256,
+    cases: editCycleCases.map((caseName) => {
+      const before = stableCaseWork(beforeRecords, caseName, "before");
+      const after = stableCaseWork(afterRecords, caseName, "after");
+      return {
+        case: caseName,
+        before,
+        after,
+        delta: Object.fromEntries(workKeys.map((key) => [key, after[key] - before[key]])),
+      };
+    }),
+  };
+}
+
+function main() {
+  const [beforeArg, afterArg, outputArg] = process.argv.slice(2);
+  if (!beforeArg || !afterArg) {
+    console.error("usage: node scripts/incremental_phase_summary.mjs <before.jsonl> <after.jsonl> [out.json]");
+    process.exit(2);
+  }
+  const load = (arg, label) => {
+    const path = isAbsolute(arg) ? arg : resolve(process.cwd(), arg);
+    return parseEditCycleJsonl(readFileSync(path, "utf8"), label);
+  };
+  const summary = compareEditCycleRecords(load(beforeArg, "before"), load(afterArg, "after"));
+  const json = `${JSON.stringify(summary, null, 2)}\n`;
+  if (outputArg) {
+    const output = isAbsolute(outputArg) ? outputArg : resolve(process.cwd(), outputArg);
+    mkdirSync(dirname(output), { recursive: true });
+    writeFileSync(output, json);
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/incremental_phase_summary.test.mjs
+++ b/scripts/incremental_phase_summary.test.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildEditCycleWorkSummary,
+  editCycleCaseDefinitions,
+  editCycleCases,
+  editCycleModes,
+  editCycleRecordSchema,
+  editCycleRecordVersion,
+  editCycleWorkScopes,
+} from "./edit_cycle_kpi.mjs";
+import {
+  compareEditCycleRecords,
+  parseEditCycleJsonl,
+  parseEditCycleRecord,
+} from "./incremental_phase_summary.mjs";
+
+const sha = (digit) => digit.repeat(64);
+
+function makeRecord(caseName, overrides = {}) {
+  const incremental = {
+    schema: 2,
+    modules_planned: 2,
+    modules_rechecked: 1,
+    modules_reused: 1,
+    parse_operations: 1,
+    modules_failed_or_blocked: 0,
+    current_source_parse_executions: 1,
+    checker_executions: 1,
+    modules_reused_conservative_fingerprint: 0,
+    modules_reused_dependency_transport_env: 1,
+  };
+  const ingestion = {
+    schema: "ingestion_fingerprint",
+    version: 1,
+    nonce: `nonce-${caseName}`,
+    source_read_calls: 2,
+    source_read_string_units: 20,
+    hash_calls: 2,
+    hash_input_string_units: 20,
+    stamp_probes: 0,
+    stamp_hits: 0,
+    stamp_misses: 0,
+    stamp_malformed: 0,
+    stamp_text_units_read: 0,
+    stamp_publications: 0,
+  };
+  const hostFs = {
+    schema: "host_fs_scope",
+    version: 1,
+    nonce: `nonce-${caseName}`,
+    read_file_calls: 3,
+    read_file_returned_bytes: 30,
+    read_bytes_calls: 4,
+    read_bytes_returned_bytes: 40,
+    stat_token_calls: 5,
+    exists_calls: 6,
+  };
+  return {
+    schema: editCycleRecordSchema,
+    version: editCycleRecordVersion,
+    benchmark: "user-edit-cycle-check",
+    compiler_sha256: sha("1"),
+    compiler_file: "stage2.wasm",
+    runner_sha256: sha("2"),
+    fixture_sha256: sha("3"),
+    run: 1,
+    case: caseName,
+    edit_kind: editCycleCaseDefinitions[caseName].edit_kind,
+    cache_state: editCycleCaseDefinitions[caseName].cache_state,
+    process_mode: "one-shot",
+    endpoint: "check-command-complete",
+    modes: { ...editCycleModes },
+    work_scopes: { ...editCycleWorkScopes },
+    work_summary: buildEditCycleWorkSummary(incremental, ingestion, hostFs),
+    incremental_typecheck: incremental,
+    ingestion_fingerprint: ingestion,
+    host_fs_scope: hostFs,
+    wall_ms: 12.5,
+    success: true,
+    ...overrides,
+  };
+}
+
+const makeSet = (overrides = {}, runs = [1]) => runs.flatMap(
+  (run) => editCycleCases.map((caseName) => makeRecord(caseName, { run, ...overrides })),
+);
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+test("phase summary emits scoped deterministic deltas", () => {
+  const before = makeSet();
+  const after = clone(before);
+  for (const record of after) {
+    record.compiler_sha256 = sha("4");
+    record.host_fs_scope.read_bytes_returned_bytes += 5;
+    record.work_summary.read_bytes += 5;
+    record.incremental_typecheck.checker_executions += 1;
+    record.incremental_typecheck.modules_rechecked += 1;
+    record.incremental_typecheck.modules_reused -= 1;
+    record.incremental_typecheck.modules_reused_dependency_transport_env -= 1;
+    record.work_summary.checked_modules += 1;
+  }
+  const summary = compareEditCycleRecords(before, after);
+  assert.equal(summary.schema, "incremental_phase_summary");
+  assert.equal(summary.version, 1);
+  assert.deepEqual(summary.modes, editCycleModes);
+  assert.deepEqual(summary.work_scopes, editCycleWorkScopes);
+  assert.equal(summary.cases.length, editCycleCases.length);
+  assert.deepEqual(summary.cases[0].delta, {
+    read_bytes: 5,
+    hash_calls: 0,
+    parsed_files: 0,
+    checked_modules: 1,
+    codegen_modules: 0,
+  });
+});
+
+test("phase summary parser rejects malformed and unsafe records", () => {
+  assert.throws(() => parseEditCycleJsonl("not-json\n"), /invalid JSON/);
+  assert.throws(() => parseEditCycleJsonl("\n"), /at least one record/);
+  const unsafe = makeRecord("cold");
+  unsafe.work_summary.read_bytes = Number.MAX_SAFE_INTEGER + 1;
+  assert.throws(() => parseEditCycleRecord(unsafe), /non-negative safe integer/);
+  const inconsistent = makeRecord("cold");
+  inconsistent.work_summary.hash_calls += 1;
+  assert.throws(() => parseEditCycleRecord(inconsistent), /does not match scoped telemetry/);
+  const codegen = makeRecord("cold");
+  codegen.work_summary.codegen_modules = 1;
+  assert.throws(() => parseEditCycleRecord(codegen), /codegen_modules to be 0/);
+});
+
+test("phase summary rejects incompatible comparison authority before deltas", () => {
+  const base = makeSet();
+  const checks = [
+    ["benchmark", "other", /benchmark/],
+    ["fixture_sha256", sha("5"), /fixture_sha256/],
+    ["runner_sha256", sha("6"), /runner_sha256/],
+    ["endpoint", "build-command-complete", /endpoint/],
+    ["schema", "other_kpi", /outer schema\/version/],
+    ["version", editCycleRecordVersion + 1, /outer schema\/version/],
+  ];
+  for (const [key, value, pattern] of checks) {
+    const changed = clone(base);
+    for (const record of changed) record[key] = value;
+    assert.throws(() => compareEditCycleRecords(base, changed), pattern, key);
+  }
+
+  const modes = clone(base);
+  for (const record of modes) record.modes.typing_dependency_env_reuse = "disabled";
+  assert.throws(() => compareEditCycleRecords(base, modes), /typing_dependency_env_reuse/);
+
+  const scopes = clone(base);
+  for (const record of scopes) record.work_scopes.read_bytes = "source-only";
+  assert.throws(() => compareEditCycleRecords(base, scopes), /read_bytes/);
+
+  const missingCase = clone(base).slice(0, -1);
+  assert.throws(() => compareEditCycleRecords(base, missingCase), /case set/);
+});
+
+test("phase summary rejects split-case runs and mismatched run topology", () => {
+  const split = editCycleCases.map((caseName, index) => makeRecord(caseName, { run: index + 1 }));
+  assert.throws(() => compareEditCycleRecords(makeSet(), split), /incomplete case\/run matrix/);
+
+  assert.throws(
+    () => compareEditCycleRecords(makeSet({}, [1, 2]), makeSet()),
+    /mismatched run topology/,
+  );
+});
+
+test("phase summary rejects mislabeled case metadata", () => {
+  for (const [key, value] of [["edit_kind", "wrong"], ["cache_state", "empty"]]) {
+    const records = makeSet();
+    records[1][key] = value;
+    assert.throws(() => compareEditCycleRecords(makeSet(), records), new RegExp(`exact_noop\\.${key}`));
+  }
+});
+
+test("phase summary rejects ingestion unit mismatch and disabled stamp activity", () => {
+  const unitMismatch = makeRecord("cold");
+  unitMismatch.ingestion_fingerprint.hash_input_string_units += 1;
+  assert.throws(() => parseEditCycleRecord(unitMismatch), /hash_input_string_units must equal/);
+
+  const stampActivity = makeRecord("cold");
+  stampActivity.ingestion_fingerprint.stamp_probes = 1;
+  stampActivity.ingestion_fingerprint.stamp_hits = 1;
+  assert.throws(() => parseEditCycleRecord(stampActivity), /must be 0 when ingestion stamps are disabled/);
+});
+
+test("phase summary rejects the obsolete hashed_files field", () => {
+  const record = makeRecord("cold");
+  record.work_summary.hashed_files = record.work_summary.hash_calls;
+  delete record.work_summary.hash_calls;
+  assert.throws(() => parseEditCycleRecord(record), /unexpected fields/);
+});
+
+test("phase summary rejects mixed or nondeterministic input records", () => {
+  const before = makeSet({}, [1, 2]);
+  const after = makeSet({}, [1, 2]);
+  const changed = after.find((record) => record.case === "cold" && record.run === 2);
+  changed.work_summary.read_bytes += 1;
+  changed.host_fs_scope.read_file_returned_bytes += 1;
+  assert.throws(() => compareEditCycleRecords(before, after), /nondeterministic cold.read_bytes/);
+
+  const duplicate = makeSet();
+  duplicate.push(clone(duplicate[0]));
+  assert.throws(() => compareEditCycleRecords(makeSet(), duplicate), /duplicate case\/run/);
+});


### PR DESCRIPTION
## Summary

First bounded #1551 ingestion/KPI slice:

- pins and records edit-cycle benchmark modes so ambient stamp/trace settings cannot silently alter comparisons;
- emits qualified `edit_cycle_kpi` v1 records with truthfully scoped host-read bytes, fingerprint `hash_calls`, TypeDb parse misses, checker executions, and check-only zero codegen;
- adds a strict before/after comparator that rejects incompatible identity/modes/scopes/case metadata/run topology, malformed counters, gaps, duplicates, and nondeterministic repetitions;
- documents loader-attribution limits and production Git blob OID **NO-GO** because blob bytes are not authoritative working-tree input bytes under filters/EOL conversion.

No compiler, cache format, schema-2, schema-6, generated artifact, or production Git behavior changes.

## Validation

- `node --test scripts/edit_cycle_kpi.test.mjs scripts/incremental_phase_summary.test.mjs` — 18/18
- `pkf run test-edit-cycle-kpi` — 18/18
- Node syntax checks — pass
- `pkl eval Taskfile.pkl` — pass
- independent review — ACCEPT
- selfhost generation — pass

Full edit-cycle execution could not run locally because Rust 1.92 cannot build current viberun/Wasmtime dependencies requiring Rust 1.94; CI remains authoritative for repository gates.

## Residual work

- loader source-list/group/header/import-scan attribution remains a separate compiler-side slice;
- production Git OID identity remains NO-GO pending authenticated equivalence to ingested working-tree bytes.

Relates to #1551.
