### PR TITLE
fix(wasm_runtime): 実行前にモジュールを検証する (#1745 (5))

### DIFF
--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -2189,21 +2189,103 @@ fn instruction_is_reserved(op: Int) -> Bool {
 }
 
 /// Every function body in a code section, stopping at the first problem.
-fn validate_code_section(wasm_bytes: Bytes, offset: Int, size: Int) -> Option[String] {
-  let entries = parse_code_entries(wasm_bytes, offset, size)
-  let mut i = 0
-  let mut err = None
-  while (i < Array::length(entries)) && (err == None) {
-    let (body_offset, body_size, _) = Array::get(entries, i)
-    let (code_start, code_end) = get_code_body_range(wasm_bytes, body_offset, body_size)
-    if (code_start < 0) || (code_end > Bytes::length(wasm_bytes)) || (code_start > code_end) {
-      err = Some("function body runs outside the module")
+fn leb_end_within(bytes: Bytes, offset: Int, end_pos: Int, max_bytes: Int) -> Int {
+  let mut pos = offset
+  let mut count = 0
+  let mut result = 0 - 1
+  while (result < 0) && (pos < end_pos) && (count < max_bytes) {
+    let byte = bytes[pos]
+    pos = pos + 1
+    count = count + 1
+    if (byte&0x80) == 0 {
+      result = pos
     } else {
-      err = validate_code_body(wasm_bytes, code_start, code_end)
+      ()
+    }
+  }
+  result
+}
+
+fn read_u32_leb_within(bytes: Bytes, offset: Int, end_pos: Int) -> (Int, Int, Bool) {
+  let leb_end = leb_end_within(bytes, offset, end_pos, 5)
+  if leb_end < 0 {
+    (0, offset, false)
+  } else {
+    let (value, _) = read_uleb128(bytes, offset)
+    (value, leb_end, true)
+  }
+}
+
+fn skip_valtype_within(bytes: Bytes, offset: Int, end_pos: Int) -> Int {
+  if offset >= end_pos {
+    0 - 1
+  } else {
+    let valtype = bytes[offset]
+    if (valtype == 0x63) || (valtype == 0x64) {
+      // Concrete heap types use a signed 33-bit LEB, hence at most five
+      // bytes. We only need its boundary here; decoding belongs to the parser.
+      leb_end_within(bytes, offset + 1, end_pos, 5)
+    } else {
+      offset + 1
+    }
+  }
+}
+
+fn validate_code_section(wasm_bytes: Bytes, offset: Int, size: Int) -> Option[String] {
+  let end_pos = offset + size
+  let (entry_count, pos0, count_ok) = read_u32_leb_within(wasm_bytes, offset, end_pos)
+  let mut pos = pos0
+  let mut i = 0
+  let mut err = if count_ok {
+    None
+  } else {
+    Some("code section has a truncated function count")
+  }
+  while (i < entry_count) && (err == None) {
+    let (body_size, body_start, size_ok) = read_u32_leb_within(wasm_bytes, pos, end_pos)
+    if !size_ok || (body_size > (end_pos - body_start)) {
+      err = Some("function body runs outside the code section")
+    } else {
+      let body_end = body_start + body_size
+      let (local_count, locals_start, locals_ok) = read_u32_leb_within(wasm_bytes, body_start, body_end)
+      if !locals_ok {
+        err = Some("function body has a truncated local declaration count")
+      } else {
+        let mut local_pos = locals_start
+        let mut local_index = 0
+        while (local_index < local_count) && (err == None) {
+          let (_, valtype_start, local_size_ok) = read_u32_leb_within(wasm_bytes, local_pos, body_end)
+          if !local_size_ok {
+            err = Some("function body has a truncated local declaration")
+          } else {
+            let next = skip_valtype_within(wasm_bytes, valtype_start, body_end)
+            if next < 0 {
+              err = Some("function body has a truncated local valtype")
+            } else {
+              local_pos = next
+            }
+          }
+          local_index = local_index + 1
+        }
+        if err == None {
+          err = validate_code_body(wasm_bytes, local_pos, body_end)
+        } else {
+          ()
+        }
+      }
+      pos = body_end
     }
     i = i + 1
   }
-  err
+  if err != None {
+    err
+  } else if i < entry_count {
+    Some("code section ends before all function bodies")
+  } else if pos != end_pos {
+    Some("code section has trailing bytes")
+  } else {
+    None
+  }
 }
 
 /// Every function's declared type index must name a type that exists.

--- a/lib/@vibex/wasm_parser/wasm_parser.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser.vibe
@@ -1190,29 +1190,80 @@ export fn parse_imports_full(bytes: Bytes, offset: Int, size: Int) -> Array[(Str
 /// instruction was a local count. This is the same one-byte assumption #1795
 /// removed from the type section, in the function that decides where code IS.
 /// It reaches further than parsing: extract_code_body feeds the interpreter.
+/// A start of -1 means the declarations do not fit the body; there is no range
+/// to return and callers must not read from one.
+///
+/// The bound is not defensive tidying. Without it a body whose bytes end right
+/// after a nonzero local-declaration count -- `01 01 01` is enough -- walks
+/// read_valtype off the end of the module and traps, killing the host process.
+/// That reaches everything downstream: extract_code_body hands this range to
+/// the interpreter, and validate_structure calls it while deciding whether a
+/// module is safe to run at all. A validator that dies on the input it is
+/// judging is worse than no validator, because callers stop bounds-checking
+/// once they believe something else does it.
 export fn get_code_body_range(bytes: Bytes, body_offset: Int, body_size: Int) -> (Int, Int) {
   let body_end = body_offset + body_size
-  let (local_decl_count, pos0) = read_uleb128(bytes, body_offset)
-  let mut pos = pos0
-  let mut d = 0
-  while d < local_decl_count {
-    let (_, np) = read_uleb128(bytes, pos)
-    let (_, np2) = read_valtype(bytes, np)
-    pos = np2
-    d = d + 1
+  let limit = if body_end > Bytes::length(bytes) {
+    Bytes::length(bytes)
+  } else {
+    body_end
   }
-  (pos, body_end)
+  if (body_offset < 0) || (body_offset >= limit) {
+    (0 - 1, body_end)
+  } else {
+    let (local_decl_count, pos0) = read_uleb128(bytes, body_offset)
+    let mut pos = pos0
+    let mut d = 0
+    let mut overrun = pos > limit
+    while (d < local_decl_count) && !overrun {
+      // Each read is checked BEFORE it happens: read_uleb128 and read_valtype
+      // both index `bytes` directly and have no bound of their own.
+      if pos >= limit {
+        overrun = true
+      } else {
+        let (_, np) = read_uleb128(bytes, pos)
+        if np >= limit {
+          overrun = true
+        } else {
+          let (_, np2) = read_valtype(bytes, np)
+          if np2 > limit {
+            overrun = true
+          } else {
+            pos = np2
+          }
+        }
+      }
+      d = d + 1
+    }
+    if overrun {
+      (0 - 1, body_end)
+    } else {
+      (pos, body_end)
+    }
+  }
 }
 
+/// Empty when the body's declarations do not fit it -- see get_code_body_range.
+/// Starting the copy at -1 would index `bytes` backwards, which is the same
+/// class of host death the bound exists to stop, one call further out.
 export fn extract_code_body(bytes: Bytes, body_offset: Int, body_size: Int) -> Bytes {
   let (expr_start, expr_end) = get_code_body_range(bytes, body_offset, body_size)
   let result = Bytes::new()
-  let mut i = expr_start
-  while i < expr_end {
-    Bytes::push(result, bytes[i])
-    i = i + 1
+  if expr_start < 0 {
+    result
+  } else {
+    let limit = if expr_end > Bytes::length(bytes) {
+      Bytes::length(bytes)
+    } else {
+      expr_end
+    }
+    let mut i = expr_start
+    while i < limit {
+      Bytes::push(result, bytes[i])
+      i = i + 1
+    }
+    result
   }
-  result
 }
 
 export fn module_imports_full(bytes: Bytes) -> Array[(String, String, Int, Int, Int, Int)] {

--- a/lib/@vibex/wasm_parser/wasm_parser_test.vibe
+++ b/lib/@vibex/wasm_parser/wasm_parser_test.vibe
@@ -4196,6 +4196,29 @@ test "validate_structure rejects a section running past the end" {
   }
 }
 
+test "validate_structure rejects a truncated local declaration" {
+  // code payload 01 01 01: one body of size one whose only byte declares one
+  // local group. The group count and valtype are missing at the body boundary.
+  match validate_structure(make_bytes([
+    0x00,
+    0x61,
+    0x73,
+    0x6D,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x0A,
+    0x03,
+    0x01,
+    0x01,
+    0x01
+  ])) {
+    Some(reason) => assert(String::contains(reason, "truncated local declaration")),
+    None => assert(false)
+  }
+}
+
 test "validate_structure rejects an unknown section id" {
   match validate_structure(make_bytes([
     0,

--- a/lib/@vibex/wasm_runtime/wasm_runtime.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime.vibe
@@ -2483,6 +2483,21 @@ export fn exec_body_gc(code: Bytes, pc_start: Int, pc_end: Int, locals: Array[In
   (exit_code, ret_val)
 }
 
+/// Whether validate_structure found anything, as a Bool.
+///
+/// Spelled with `match` rather than `validate_structure(b) != None` at the call
+/// site. In an `else if` condition the parser reads `None {` as the start of a
+/// record literal, and `pkf run fmt` then REWRITES it to `None::{` -- output
+/// that does not parse at all. The first form compiled on one stage2 and not on
+/// the one CI builds; the second compiles nowhere. Neither failure names the
+/// real problem, so the comparison form is worth avoiding here entirely.
+fn module_is_structurally_invalid(wasm_bytes: Bytes) -> Bool {
+  match validate_structure(wasm_bytes) {
+    None => false,
+    Some(_) => true
+  }
+}
+
 export fn exec_module_with_args(wasm_bytes: Bytes, export_name: String, args: Array[Int]) -> (Int, Int) {
   let len = Bytes::length(wasm_bytes)
   if len < 8 {
@@ -2491,7 +2506,7 @@ export fn exec_module_with_args(wasm_bytes: Bytes, export_name: String, args: Ar
   else if (wasm_bytes[0] != 0x00) || (wasm_bytes[1] != 0x61) || (wasm_bytes[2] != 0x73) || (wasm_bytes[3] != 0x6D) {
     (-1, 0)
   }
-  else if validate_structure(wasm_bytes) != None::{
+  else if module_is_structurally_invalid(wasm_bytes) {
     // #1745 (5). Length and magic were the only things checked here, so a
     // module whose sections do not survive their own size field reached the
     // executor: one corrupted length byte in a corpus of 54 killed the host

--- a/lib/@vibex/wasm_runtime/wasm_runtime.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibex/wasm_parser {
-  next_instruction
+  next_instruction, validate_structure
 }
 
 //# Values
@@ -2489,6 +2489,24 @@ export fn exec_module_with_args(wasm_bytes: Bytes, export_name: String, args: Ar
     (-1, 0)
   }
   else if (wasm_bytes[0] != 0x00) || (wasm_bytes[1] != 0x61) || (wasm_bytes[2] != 0x73) || (wasm_bytes[3] != 0x6D) {
+    (-1, 0)
+  }
+  else if validate_structure(wasm_bytes) != None::{
+    // #1745 (5). Length and magic were the only things checked here, so a
+    // module whose sections do not survive their own size field reached the
+    // executor: one corrupted length byte in a corpus of 54 killed the host
+    // PROCESS, uncatchable by this function's caller, which is a containment
+    // breach in the one place that exists to run untrusted wasm.
+    //
+    // Safe to put in front of execution because the never-reject half of
+    // validate_structure's contract is MEASURED, not assumed
+    // (scripts/test_wasm_validate_parity.sh, against wasm-tools as the
+    // oracle). A validator that guessed here would turn a containment fix
+    // into a new way to refuse legitimate modules.
+    //
+    // It still does not type the operand stack, so an ill-TYPED module gets
+    // through -- that is the other half of #1745 (5), and it needs a different
+    // machine than this one.
     (-1, 0)
   }
   else {

--- a/lib/@vibex/wasm_runtime/wasm_runtime_test.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime_test.vibe
@@ -2157,3 +2157,30 @@ test "exec_module refuses a module whose section runs past the end" {
   assert(ec == -1)
   assert(result == 0)
 }
+
+test "exec_module refuses a truncated local declaration" {
+  // code payload: one body, size one, whose only byte says there is one local
+  // declaration group. The group count and valtype are both missing. A
+  // structural validator on this untrusted execution path must reject it
+  // before get_code_body_range can read the valtype at the body boundary.
+  let wasm = make_bytes([
+    0x00,
+    0x61,
+    0x73,
+    0x6D,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x0A,
+    0x03,
+    0x01,
+    0x01,
+    0x01
+  ])
+  let (ec, result) = exec_module_with_args(wasm, "f", Array::slice([
+    0
+  ], 0, 0))
+  assert(ec == -1)
+  assert(result == 0)
+}

--- a/lib/@vibex/wasm_runtime/wasm_runtime_test.vibe
+++ b/lib/@vibex/wasm_runtime/wasm_runtime_test.vibe
@@ -801,12 +801,16 @@ test "exec_module with locals" {
     0x66,
     0x00,
     0x00,
-    // code section
+    // code section. The two sizes below were each one short of the bytes that
+    // follow -- 0x0E/0x0C for 15/13 -- and `wasm-tools validate` rejects the
+    // result. It went unnoticed because exec_module_with_args checked only
+    // length and magic; the validator added there for #1745 (5) caught it on
+    // the first run.
     0x0A,
-    0x0E,
+    0x0F,
     0x01,
-    0x0C,
-    // body size = 12
+    0x0D,
+    // body size = 13
     0x01,
     // 1 local declaration group
     0x01,
@@ -879,9 +883,12 @@ test "exec_module multi-function call" {
     0x6E,
     0x00,
     0x01,
-    // code section: 2 bodies
+    // code section: 2 bodies. The size was 0x11 for 16 bytes of content
+    // (1 count + 1+7 + 1+6), which `wasm-tools validate` rejects. Same class
+    // as the one in "exec_module with locals" above, and unnoticed for the
+    // same reason: nothing checked section sizes before #1745 (5).
     0x0A,
-    0x11,
+    0x10,
     0x02,
     // func 0: size=7, 0 locals, local.get 0, local.get 0, i32.add, end
     0x07,
@@ -2118,4 +2125,35 @@ test "local.tee" {
   let (exit, result) = exec_body(code, 0, 5, locals, empty_stack(), make_memory(1), empty_globals(), empty_funcs())
   assert(exit == 0)
   assert(result == 42)
+}
+
+test "exec_module refuses a module whose section runs past the end" {
+  // #1745 (5). Before validate_structure ran here, length and magic were the
+  // only checks, so a section size larger than the bytes behind it reached the
+  // executor. On the parity corpus one such module killed the host PROCESS --
+  // not a trap this function could report, a death its caller could not catch.
+  //
+  // A regression here fails loudly by construction: if the guard comes out,
+  // this test does not assert false, it takes the test binary down with it.
+  //
+  // header | type(1) claiming 127 bytes with 2 behind it
+  let wasm = make_bytes([
+    0x00,
+    0x61,
+    0x73,
+    0x6D,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x01,
+    0x7F,
+    0x01,
+    0x60
+  ])
+  let (ec, result) = exec_module_with_args(wasm, "f", Array::slice([
+    0
+  ], 0, 0))
+  assert(ec == -1)
+  assert(result == 0)
 }

--- a/scripts/test_wasm_validate_parity.sh
+++ b/scripts/test_wasm_validate_parity.sh
@@ -175,6 +175,71 @@ if [ "$walk_stopped" -ne 0 ]; then
   exit 1
 fi
 
+# 4b. Neither the validator nor the interpreter may DIE on malformed input.
+#     Distinct from the accept/reject measurement above, which only compares
+#     verdicts that were reached at all. A wrong verdict is a bug; a host
+#     process killed by guest bytes is a containment breach, and it is worse
+#     because callers stop bounds-checking once they believe something else
+#     does. Both were real: one corrupted section-size byte killed the host
+#     before the validator guarded execution (#1745 (5)), and then the
+#     validator itself died on `01 01 01` -- a body ending right after a
+#     nonzero local-declaration count -- because get_code_body_range read
+#     valtypes past the end while deciding whether the module was safe to run.
+exec_probe="$WORK/exec.wasm"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
+  scripts/wasm_validate/exec_probe.vibex "_build/validate_parity/exec.wasm" main >/dev/null 2>&1
+[ -s "$exec_probe" ] || { echo "[validate-parity] FAIL: exec probe did not compile" >&2; exit 1; }
+
+# Truncations and single-byte pokes spread across our own output. Deterministic
+# rather than random: a fuzz corpus that differs per run reports a different
+# subset of the same bugs each time and never ratchets.
+mkdir -p "$WORK/fuzz"
+python3 - "$WORK" <<'PY'
+import sys, glob, os
+work = sys.argv[1]
+for f in sorted(glob.glob(work + '/pos/*.wasm'))[:3]:
+    b = bytearray(open(f, 'rb').read())
+    base = os.path.basename(f)[:-5]
+    for i in range(1, 40):
+        open(f'{work}/fuzz/{base}.t{i}.wasm', 'wb').write(bytes(b[:len(b) * i // 40]))
+    for i in range(1, 30):
+        m = bytearray(b)
+        p = len(b) * i // 30
+        if p < len(m):
+            m[p] = (m[p] + 0x55) & 0xFF
+            open(f'{work}/fuzz/{base}.p{i}.wasm', 'wb').write(bytes(m))
+# The minimal case from PR #1818's review, kept by hand: a code section framed
+# correctly around a body that ends immediately after declaring one local group.
+open(f'{work}/fuzz/local_decl_at_eof.wasm', 'wb').write(
+    bytes([0, 0x61, 0x73, 0x6D, 1, 0, 0, 0, 10, 3, 1, 1, 1]))
+PY
+
+survivors=0
+deaths=0
+for w in "$WORK"/fuzz/*.wasm "$WORK"/neg/*.wasm; do
+  [ -e "$w" ] || continue
+  cp "$w" "$ROOT_DIR/_build/val_target.wasm"
+  v="$(verdict "$w")"
+  e="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+       --invoke main "_build/validate_parity/exec.wasm" 2>&1 | head -1)"
+  case "$v" in
+    ACCEPT*|REJECT*) ;;
+    *) deaths=$((deaths + 1)); echo "[validate-parity] validator died on: $w" >&2 ;;
+  esac
+  case "$e" in
+    ok\ *) ;;
+    *) deaths=$((deaths + 1)); echo "[validate-parity] interpreter died on: $w" >&2 ;;
+  esac
+  survivors=$((survivors + 1))
+done
+rm -f "$ROOT_DIR/_build/val_target.wasm"
+if [ "$deaths" -ne 0 ]; then
+  echo "[validate-parity] FAIL: $deaths host death(s) on malformed input. Guest bytes must" >&2
+  echo "[validate-parity]       produce a verdict or an error tuple, never end the process." >&2
+  exit 1
+fi
+
 # 5. #1133 proper: does used_by_codegen() still describe these binaries? Same
 #    corpus, different question -- the oracle above is wasm-tools, the oracle
 #    here is the declaration in docs. Sharing the corpus is deliberate: the
@@ -210,6 +275,7 @@ if [ "$caught" -lt "$floor_num" ]; then
 fi
 echo "[validate-parity] ok: $pos_total/$pos_total accepted (zero false rejections), $caught/$neg_total rejected"
 echo "[validate-parity]     instruction walk reached the end of $walk_bodies/$walk_bodies function bodies"
+echo "[validate-parity]     $survivors malformed modules produced a verdict; none killed the host"
 echo "[validate-parity] note: what remains uncaught needs operand-stack typing, which this layer does"
 echo "[validate-parity]       not do (#1745 (5)). A module that is well-formed but ill-TYPED still"
 echo "[validate-parity]       passes here."

--- a/scripts/wasm_validate/exec_probe.vibex
+++ b/scripts/wasm_validate/exec_probe.vibex
@@ -1,0 +1,21 @@
+// Run the module at _build/val_target.wasm through the interpreter and print
+// `ok <exit_code> <result>`.
+//
+// The harness does not care what the numbers are. It cares that this line is
+// printed AT ALL: any other output means exec_module_with_args did not return,
+// which for malformed input means guest bytes ended the host process instead of
+// producing an error tuple its caller could handle.
+import @vibex/wasm_runtime {
+  exec_module_with_args
+}
+
+fn main with Fs {
+  let (ec, res) = exec_module_with_args(
+    Fs::read_bytes("_build/val_target.wasm"),
+    "f",
+    Array::slice([
+      0
+    ], 0, 0)
+  )
+  println("ok \{ec} \{res}")
+}


### PR DESCRIPTION
#1800 / #1806 で検証器を作りました。**インタプリタは今もそれを使わずに未検証の入力を
走らせています。** #1745 の (5) は「別スライス」として送られていた部分で、これがそれです。

## 封じ込めの破れ

`exec_module_with_args` は**長さと magic しか見ていません**でした。その後は
何が来ても実行します。

parity corpus の不正モジュール 54 件を食わせて実測:

```
survived=53 died=1
DIED: gc_direct_array_abi_test.lin.sectsize.wasm :: RuntimeError: unreachable
```

**セクションサイズの 1 バイトが壊れているだけで host プロセスが落ちます。**
この関数が報告できる trap ではなく、**呼び出し側が捕捉できない死**です。
信用できない wasm を走らせるためにある場所としては、これは封じ込めの破れです。

`validate_structure` を実行前に置いて **54/54 が survive** になりました。

## なぜここに置いて安全なのか

契約の「受理するものを拒否しない」半分が**計測されている**からです
(`scripts/test_wasm_validate_parity.sh`、oracle は `wasm-tools`、現在
8/8 受理・偽拒否 0)。ここで推測する検証器を置いたら、封じ込めのバグを
**正当なモジュールを拒否する新しい方法**と交換するだけになります。

前の 2 PR で偽拒否を潰し続けたのは、この一手のためでした。

## 初回実行で不正な fixture を 2 件検出した

どちらもこのパッケージ自身のテストで、`wasm-tools validate` も拒否します:

| test | 問題 |
|---|---|
| `exec_module with locals` | code セクション `0x0E` / body `0x0C` に対して実バイトは 15 / 13 |
| `exec_module multi-function call` | code セクション `0x11` に対して実バイトは 16 |

**どちらも一度も valid だったことがありません。** 通っていたのは
**セクションサイズを誰も見ていなかったから**で、それは host が落ちうる理由と
同じものです。両方直しました。

テストファイル中の手書きモジュールを全件 oracle にかけて、他に不正なものが
無いことも確認しています。

## 回帰テスト

```vibe
// header | type(1) が 127 バイトを主張、実際は 2 バイト
let (ec, result) = exec_module_with_args(wasm, "f", ...)
assert(ec == -1)
```

ガードを外すと、このテストは `assert(false)` ではなく**テストバイナリごと落ちます** —
構造上、静かに緑にはなりません。

## 残っているもの

**操作スタックの型検査はしていません**ので、well-formed だが ill-typed な
モジュールは依然として通ります。それが #1745 (5) の残り半分で、別の機械が要ります
(この層は「バイト列として筋が通っているか」しか答えられない)。

## 検証

- `@vibex/wasm_runtime` / `@vibex/wasm_parser` / `@vibex/wasm_wat_encoder` 全スイート green
- 不正モジュール corpus **54/54 survive** (修正前 53/54)
- `scripts/test_wasm_validate_parity.sh` green
  (8/8 受理・偽拒否 0、52/54 拒否、527/527 body 踏破)
- `check_vibe_fmt` / `lint_review_regressions` / `lint_architecture_debt` green
- `origin/main` (3d6464190) 上

Refs #1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN)_