### PR TITLE
feat(async): emitter だけで async string component を丸ごと組み立てる (#1540)

### DIFF
--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -21,6 +21,7 @@ import @vibe/compiler/codegen/wasm_emit {
   emit_br_if,
   emit_call,
   emit_code_section,
+  emit_data_section,
   emit_end,
   emit_export_memory,
   emit_export_section,
@@ -55,7 +56,8 @@ import @vibe/compiler/codegen/wasm_emit {
   emit_loop_void,
   emit_memory_section,
   emit_name,
-  emit_return
+  emit_return,
+  string_to_data
 }
 
 //# Functions
@@ -1380,7 +1382,7 @@ fn emit_comp_async_functype_section(buf: Bytes, result_valtype: Int) -> Unit {
 /// #1540: the memhost-with-realloc module on its own, so its shape is testable
 /// before the serve-emitter merge gives it a caller.
 export fn comp_emit_memhost_realloc_fixture() -> Bytes {
-  comp_generate_memhost_realloc_module()
+  comp_generate_memhost_realloc_module(1024)
 }
 
 export fn comp_emit_async_string_canon_fixture() -> Bytes {
@@ -1940,6 +1942,147 @@ fn emit_canon_stream_drop_writable(buf: Bytes, type_idx: Int) -> Unit {
 /// guest module itself is instantiated, breaking the "canon options need
 /// memory before the guest/memory exists" circularity documented in
 /// tools/wasip3_component_probe/stackful/README.md bug #2.
+/// #1540: guest core module for the async string shape -- the emitter twin of
+/// `tools/wasip3_component_probe/async_string_lift/component.wat`'s `$m`.
+///
+/// Imports `[export]$root`.`[task-return]<name>` and `env.memory`, and exports
+/// a `<name>` taking the flattened string param `(ptr, len)` and returning
+/// NOTHING: an async lift delivers its result through `task.return`, not
+/// through the core function's own return path. The reply bytes are a data
+/// segment written into the IMPORTED memory at instantiation, which is what
+/// makes them observable to the lift.
+///
+/// Answering a constant is the point at this stage: what has to be proved is
+/// that the emitted CANON SHAPE loads and round-trips a string, not that a
+/// handler computed something.
+fn comp_generate_async_string_guest_module(export_name: String, reply: String) -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  let type_sec = bytebuf_new()
+  bytebuf_push_vec_header(type_sec, 1)
+  emit_func_type_raw(type_sec, [
+    127,
+    127
+  ], array_empty())
+  bytebuf_push_section(out, 1, type_sec)
+  let import_sec = bytebuf_new()
+  leb128_encode_u32(import_sec, 2)
+  emit_name(import_sec, "[export]$root")
+  emit_name(import_sec, String::concat("[task-return]", export_name))
+  bytebuf_push(import_sec, 0)
+  leb128_encode_u32(import_sec, 0)
+  emit_name(import_sec, "env")
+  emit_name(import_sec, "memory")
+  bytebuf_push(import_sec, 2)
+  bytebuf_push(import_sec, 0)
+  leb128_encode_u32(import_sec, 0)
+  bytebuf_push_section(out, 2, import_sec)
+  emit_function_section(out, [
+    0
+  ])
+  emit_export_section(out, export_name, 1)
+  let body = bytebuf_new()
+  emit_i32_const(body, comp_async_string_reply_offset)
+  emit_i32_const(body, String::length(reply))
+  emit_call(body, 0)
+  emit_code_section(out, [
+    body
+  ])
+  emit_data_section(out, comp_async_string_reply_offset, string_to_data(reply))
+  bytebuf_to_bytes(out)
+}
+
+/// Where the guest module above parks its reply bytes. Above the low slots a
+/// caller might use for its own fixed areas and below the memhost realloc's
+/// bump start, so the three never overlap.
+let comp_async_string_reply_offset = 16
+
+fn comp_async_string_heap_start(reply: String) -> Int {
+  let reply_end = comp_async_string_reply_offset + String::length(reply)
+  let aligned = ((reply_end + 63) / 64) * 64
+  if aligned < 1024 {
+    1024
+  } else {
+    aligned
+  }
+}
+
+/// #1540: the whole async string component, assembled from the widened
+/// emitters -- the emitter twin of the async_string_lift probe.
+///
+/// This is the milestone the canon widening was for: every piece the
+/// serve-emitter merge needs (async functype with params, task.return carrying
+/// memory + encoding, async lift carrying memory + realloc + encoding, and a
+/// memhost that supplies both) proved to work TOGETHER, on a component that
+/// wasmtime loads and runs, before any of it is wired to real source.
+///
+/// Instance / index layout, in emission order:
+///   core module    0 = memhost+realloc, 1 = guest
+///   core instance  0 = memhost, 1 = [export]$root (task-return),
+///                  2 = env (memory), 3 = guest
+///   core memory    0 = alias(memhost, "memory")
+///   core func      0 = alias(memhost, "cabi_realloc"), 1 = task.return,
+///                  2 = alias(guest, export_name)
+///   component type 0 = the async functype; component func 0 = the lift
+///
+/// The core-func numbering is the part that is easy to get wrong: aliases and
+/// canon built-ins share ONE index space in emission order, so hoisting the
+/// realloc alias above the canons (which it must be -- `emit_alias_section`
+/// takes the memhost instance, and the canons want the realloc index) shifts
+/// task.return to 1 and the guest alias to 2.
+export fn comp_emit_async_string_component(export_name: String, param_name: String, reply: String) -> Bytes {
+  let buf = bytebuf_new()
+  emit_component_header(buf)
+  emit_core_module_section(buf, comp_generate_memhost_realloc_module(comp_async_string_heap_start(reply)))
+  emit_core_module_section(buf, comp_generate_async_string_guest_module(export_name, reply))
+  emit_core_instance_instantiate_section(buf, 0, array_empty())
+  emit_alias_section(buf, 0, [
+    "memory"
+  ], [
+    core_sort_mem
+  ])
+  emit_alias_section(buf, 0, [
+    "cabi_realloc"
+  ], [
+    core_sort_func
+  ])
+  emit_comp_async_functype_params(buf, [
+    param_name
+  ], [
+    comp_valtype_string
+  ], comp_valtype_string)
+  emit_canon_task_return_opts(buf, comp_valtype_string, 0, true)
+  emit_core_instance_from_exports(buf, 1, [
+    1
+  ], [
+    String::concat("[task-return]", export_name)
+  ], [
+    1
+  ])
+  emit_core_instance_from_exports_sorted(buf, [
+    "memory"
+  ], [
+    core_sort_mem
+  ], [
+    0
+  ])
+  emit_core_instance_instantiate_args(buf, 1, [
+    "[export]$root",
+    "env"
+  ], [
+    1,
+    2
+  ])
+  emit_alias_section(buf, 3, [
+    export_name
+  ], [
+    core_sort_func
+  ])
+  emit_canon_lift_async_opts(buf, 2, 0, 0, 0, true)
+  emit_comp_export_section(buf, export_name, 0)
+  bytebuf_to_bytes(buf)
+}
+
 /// #1540: the memhost, plus a `cabi_realloc` the canon options can point at.
 ///
 /// The async_string_lift probe surfaced this as a structural requirement, not a
@@ -1958,7 +2101,7 @@ fn emit_canon_stream_drop_writable(buf: Bytes, type_idx: Int) -> Unit {
 /// `comp_generate_memhost_module`: every component built today embeds that
 /// module, and adding an export would change all of their bytes for the
 /// benefit of a shape none of them use.
-fn comp_generate_memhost_realloc_module() -> Bytes {
+fn comp_generate_memhost_realloc_module(heap_start: Int) -> Bytes {
   let out = bytebuf_new()
   emit_header(out)
   let tc = bytebuf_new()
@@ -1976,9 +2119,10 @@ fn comp_generate_memhost_realloc_module() -> Bytes {
     0
   ])
   emit_memory_section(out, 1)
-  // The bump pointer starts above the low addresses the callers of this shape
-  // use for their own fixed slots (the probe's return area sits at 64).
-  emit_global_section_i32_mut(out, 1024)
+  // The caller derives this from every fixed data segment that shares the
+  // memory. A fixed 1024 silently overlapped replies longer than 1008 bytes:
+  // canonical lowering wrote its argument into the reply before task.return.
+  emit_global_section_i32_mut(out, heap_start)
   // One export section with a MIXED kind list. `emit_export_memory` and
   // `emit_export_section` each emit their own section 7, and a core module may
   // carry only one -- the first cut did both and produced "section out of

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -27,6 +27,9 @@ import @vibe/compiler/codegen/wasm_emit {
   emit_export_section_multi,
   emit_func_type_raw,
   emit_function_section,
+  emit_global_get,
+  emit_global_section_i32_mut,
+  emit_global_set,
   emit_header,
   emit_i32_add,
   emit_i32_and,
@@ -1374,6 +1377,12 @@ fn emit_comp_async_functype_section(buf: Bytes, result_valtype: Int) -> Unit {
 /// against wasmtime. If wasmtime's accepted encoding moves, the probe gate
 /// fails; if this emitter drifts from it, the unit test fails. Neither can go
 /// stale quietly on its own.
+/// #1540: the memhost-with-realloc module on its own, so its shape is testable
+/// before the serve-emitter merge gives it a caller.
+export fn comp_emit_memhost_realloc_fixture() -> Bytes {
+  comp_generate_memhost_realloc_module()
+}
+
 export fn comp_emit_async_string_canon_fixture() -> Bytes {
   let buf = bytebuf_new()
   emit_comp_async_functype_params(buf, [
@@ -1931,6 +1940,73 @@ fn emit_canon_stream_drop_writable(buf: Bytes, type_idx: Int) -> Unit {
 /// guest module itself is instantiated, breaking the "canon options need
 /// memory before the guest/memory exists" circularity documented in
 /// tools/wasip3_component_probe/stackful/README.md bug #2.
+/// #1540: the memhost, plus a `cabi_realloc` the canon options can point at.
+///
+/// The async_string_lift probe surfaced this as a structural requirement, not a
+/// convenience. `task.return` for a string result needs a memory, the async
+/// lift needs a memory AND a realloc, and BOTH canons are declared before the
+/// guest instance exists -- the guest imports `[task-return]`, so a
+/// guest-owned memory or realloc would be an instantiation cycle. They have to
+/// come from a module instantiated first.
+///
+/// A bump allocator is the whole implementation: nothing in this shape ever
+/// frees, and the lift only needs somewhere to put the caller's arguments for
+/// the duration of one call. It ignores the old-pointer / old-size arguments
+/// for the same reason.
+///
+/// Deliberately a SEPARATE generator rather than an extra export on
+/// `comp_generate_memhost_module`: every component built today embeds that
+/// module, and adding an export would change all of their bytes for the
+/// benefit of a shape none of them use.
+fn comp_generate_memhost_realloc_module() -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  let tc = bytebuf_new()
+  bytebuf_push_vec_header(tc, 1)
+  emit_func_type_raw(tc, [
+    127,
+    127,
+    127,
+    127
+  ], [
+    127
+  ])
+  bytebuf_push_section(out, 1, tc)
+  emit_function_section(out, [
+    0
+  ])
+  emit_memory_section(out, 1)
+  // The bump pointer starts above the low addresses the callers of this shape
+  // use for their own fixed slots (the probe's return area sits at 64).
+  emit_global_section_i32_mut(out, 1024)
+  // One export section with a MIXED kind list. `emit_export_memory` and
+  // `emit_export_section` each emit their own section 7, and a core module may
+  // carry only one -- the first cut did both and produced "section out of
+  // order", caught by `wasm-tools validate` on the emitted bytes rather than by
+  // any test that only inspected them.
+  let exports = bytebuf_new()
+  bytebuf_push_vec_header(exports, 2)
+  emit_name(exports, "memory")
+  bytebuf_push(exports, 2)
+  leb128_encode_u32(exports, 0)
+  emit_name(exports, "cabi_realloc")
+  bytebuf_push(exports, 0)
+  leb128_encode_u32(exports, 0)
+  bytebuf_push_section(out, 7, exports)
+  let body = bytebuf_new()
+  emit_global_get(body, 0)
+  emit_global_get(body, 0)
+  // align the bump by a fixed stride rather than by the requested size: the
+  // shape this serves hands back one region per call and never reuses it.
+  emit_i32_const(body, 64)
+  emit_i32_add(body)
+  emit_global_set(body, 0)
+  emit_code_section(out, [
+    body
+  ])
+  bytebuf_to_bytes(out)
+}
+
 fn comp_generate_memhost_module() -> Bytes {
   let out = bytebuf_new()
   emit_header(out)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -88,6 +88,17 @@ let section_alias = 6
 
 let section_canon = 8
 
+/// #1540: canonical-option opcodes, measured against
+/// tools/wasip3_component_probe/async_string_lift/component.wat rather than
+/// read off a spec draft -- the probe is what the gate keeps true.
+let canonopt_utf8 = 0
+
+let canonopt_memory = 3
+
+let canonopt_realloc = 4
+
+let canonopt_async = 6
+
 let core_sort_func = 0
 
 fn read_name_info(bytes: Bytes, start: Int) -> (Int, Int) {
@@ -1214,13 +1225,55 @@ export fn comp_emit_component_wasm_with_string_lift(core_wasm: Bytes, target_fun
 /// section 0x08, body `01 09 00 <valtype> 00` (count=1; opcode 0x09; result
 /// Some(valtype); empty options).
 fn emit_canon_task_return(buf: Bytes, result_valtype: Int) -> Unit {
+  emit_canon_task_return_opts(buf, result_valtype, -1, false)
+}
+
+/// #1540: the same built-in for a result that lives in guest memory -- a
+/// `string` result cannot be delivered without telling `task.return` which
+/// memory to lift it out of, and in which encoding.
+///
+/// `mem_idx < 0` emits no memory option and `utf8 = false` no encoding one, so
+/// `emit_canon_task_return` above stays byte-identical for every existing
+/// caller.
+///
+/// `realloc` is deliberately absent: wasmtime rejects it outright here
+/// ("cannot specify `realloc` option on `task.return`"), because this built-in
+/// LIFTS the result out of guest memory -- it reads, it never allocates. Its
+/// absence is measured, not assumed; see
+/// tools/wasip3_component_probe/async_string_lift/component.wat.
+///
+/// Measured body for a string result: `01 09 00 73 02 03 <mem> 00`
+/// (count=1; opcode 0x09; result Some(string); 2 options; Memory(mem); UTF8).
+fn emit_canon_task_return_opts(buf: Bytes, result_valtype: Int, mem_idx: Int, utf8: Bool) -> Unit {
   bytebuf_push(buf, section_canon)
   let content = bytebuf_new()
   leb128_encode_u32(content, 1)
   bytebuf_push(content, 9)
   bytebuf_push(content, 0)
   bytebuf_push(content, result_valtype)
-  bytebuf_push(content, 0)
+  let mut nopts = 0
+  if mem_idx >= 0 {
+    nopts = nopts + 1
+  } else {
+    ()
+  }
+  if utf8 {
+    nopts = nopts + 1
+  } else {
+    ()
+  }
+  leb128_encode_u32(content, nopts)
+  if mem_idx >= 0 {
+    bytebuf_push(content, canonopt_memory)
+    leb128_encode_u32(content, mem_idx)
+  } else {
+    ()
+  }
+  if utf8 {
+    bytebuf_push(content, canonopt_utf8)
+  } else {
+    ()
+  }
   emit_raw_content(buf, content)
 }
 
@@ -1228,14 +1281,66 @@ fn emit_canon_task_return(buf: Bytes, result_valtype: Int) -> Unit {
 /// carries the async canonopt (0x06). Verified body: `01 00 00 <core_func_idx>
 /// 01 06 <type_idx>` (count=1; lift; core-func sort; idx; 1 option = async).
 fn emit_canon_lift_async_section(buf: Bytes, core_func_idx: Int, type_idx: Int) -> Unit {
+  emit_canon_lift_async_opts(buf, core_func_idx, type_idx, -1, -1, false)
+}
+
+/// #1540: the async lift for a function whose params or result live in guest
+/// memory. Unlike `task.return` above, this one DOES take `realloc` -- it
+/// lowers the caller's arguments INTO guest memory, so it allocates.
+///
+/// Negative indices and `utf8 = false` drop the corresponding option, so
+/// `emit_canon_lift_async_section` above stays byte-identical.
+///
+/// Measured body with all four: `01 00 00 <idx> 04 06 03 <mem> 04 <realloc> 00 <type>`
+/// (count=1; lift; core-func sort; idx; 4 options = Async, Memory, Realloc,
+/// UTF8; type idx). The order is the one wasmtime emits and accepts.
+///
+/// The component functype this lifts to must ALSO be declared async --
+/// wasmtime rejects the option otherwise ("the `async` canonical option
+/// requires an async function type"), which is why
+/// `emit_comp_async_functype_params` below exists alongside it.
+fn emit_canon_lift_async_opts(buf: Bytes, core_func_idx: Int, type_idx: Int, mem_idx: Int, realloc_idx: Int, utf8: Bool) -> Unit {
   bytebuf_push(buf, section_canon)
   let content = bytebuf_new()
   leb128_encode_u32(content, 1)
   bytebuf_push(content, 0)
   bytebuf_push(content, 0)
   leb128_encode_u32(content, core_func_idx)
-  leb128_encode_u32(content, 1)
-  bytebuf_push(content, 6)
+  let mut nopts = 1
+  if mem_idx >= 0 {
+    nopts = nopts + 1
+  } else {
+    ()
+  }
+  if realloc_idx >= 0 {
+    nopts = nopts + 1
+  } else {
+    ()
+  }
+  if utf8 {
+    nopts = nopts + 1
+  } else {
+    ()
+  }
+  leb128_encode_u32(content, nopts)
+  bytebuf_push(content, canonopt_async)
+  if mem_idx >= 0 {
+    bytebuf_push(content, canonopt_memory)
+    leb128_encode_u32(content, mem_idx)
+  } else {
+    ()
+  }
+  if realloc_idx >= 0 {
+    bytebuf_push(content, canonopt_realloc)
+    leb128_encode_u32(content, realloc_idx)
+  } else {
+    ()
+  }
+  if utf8 {
+    bytebuf_push(content, canonopt_utf8)
+  } else {
+    ()
+  }
   leb128_encode_u32(content, type_idx)
   emit_raw_content(buf, content)
 }
@@ -1244,11 +1349,55 @@ fn emit_canon_lift_async_section(buf: Bytes, core_func_idx: Int, type_idx: Int) 
 /// Verified body: `01 43 00 00 <valtype>` (count=1; async functype opcode 0x43;
 /// 0 params; result-form 0x00 + valtype).
 fn emit_comp_async_functype_section(buf: Bytes, result_valtype: Int) -> Unit {
+  emit_comp_async_functype_params(buf, array_empty(), array_empty(), result_valtype)
+}
+
+/// #1540: the same async functype WITH named params. The zero-param spelling
+/// above delegates here, so it stays byte-identical.
+///
+/// This has to be widened together with `emit_canon_lift_async_opts`: an async
+/// lift is only legal against a functype that is itself declared async, and a
+/// handler that takes its request as parameters needs those parameters on the
+/// type. Measured body for one string param and a string result:
+/// `01 43 01 04 6e 61 6d 65 73 00 73` (count=1; async functype 0x43; 1 param;
+/// name "name"; string; result-form 0x00; string).
+/// #1540: byte-shape fixture for the three widened emitters above.
+///
+/// They have no production caller yet -- the serve-emitter merge that needs
+/// them is the next slice -- so this exists to make the ENCODING testable now,
+/// the same way `comp_emit_component_wasm_async_stdin_provider_fixture` makes a
+/// shape testable without a real source program.
+///
+/// It emits the exact section shapes measured in
+/// `tools/wasip3_component_probe/async_string_lift/component.wat`, so the unit
+/// test can assert byte equality against the sequences the probe gate pins
+/// against wasmtime. If wasmtime's accepted encoding moves, the probe gate
+/// fails; if this emitter drifts from it, the unit test fails. Neither can go
+/// stale quietly on its own.
+export fn comp_emit_async_string_canon_fixture() -> Bytes {
+  let buf = bytebuf_new()
+  emit_comp_async_functype_params(buf, [
+    "name"
+  ], [
+    comp_valtype_string
+  ], comp_valtype_string)
+  emit_canon_task_return_opts(buf, comp_valtype_string, 0, true)
+  emit_canon_lift_async_opts(buf, 2, 0, 0, 0, true)
+  bytebuf_to_bytes(buf)
+}
+
+fn emit_comp_async_functype_params(buf: Bytes, param_names: Array[String], param_valtypes: Array[Int], result_valtype: Int) -> Unit {
   bytebuf_push(buf, section_type)
   let content = bytebuf_new()
   leb128_encode_u32(content, 1)
   bytebuf_push(content, 67)
-  bytebuf_push(content, 0)
+  leb128_encode_u32(content, Array::length(param_names))
+  let mut i = 0
+  while i < Array::length(param_names) {
+    emit_name(content, Array::get(param_names, i))
+    bytebuf_push(content, Array::get(param_valtypes, i))
+    i = i + 1
+  }
   bytebuf_push(content, 0)
   bytebuf_push(content, result_valtype)
   emit_raw_content(buf, content)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -191,6 +191,9 @@ fn comp_emit_async_string_canon_fixture() -> Bytes
 
 // #1540: memhost module that also exports cabi_realloc.
 fn comp_emit_memhost_realloc_fixture() -> Bytes
+
+// #1540: the whole async string component, from the widened emitters alone.
+fn comp_emit_async_string_component(export_name: String, param_name: String, reply: String) -> Bytes
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -188,6 +188,9 @@ fn comp_emit_component_wasm_async_stdin_provider_fixture(mode: Int) -> Bytes wit
 
 // #1540: byte-shape fixture for the widened async canon emitters.
 fn comp_emit_async_string_canon_fixture() -> Bytes
+
+// #1540: memhost module that also exports cabi_realloc.
+fn comp_emit_memhost_realloc_fixture() -> Bytes
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -185,6 +185,9 @@ fn comp_emit_component_wasm_stdin_provider_shadow() -> Bytes
 fn comp_core_imports_stdin_provider(core_wasm: Bytes) -> Bool
 fn comp_emit_component_wasm_async_stdin_provider(main_core_wasm: Bytes, export_name: String) -> Bytes with Exception
 fn comp_emit_component_wasm_async_stdin_provider_fixture(mode: Int) -> Bytes with Exception
+
+// #1540: byte-shape fixture for the widened async canon emitters.
+fn comp_emit_async_string_canon_fixture() -> Bytes
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -14,10 +14,10 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_core_imports_host_future,
   comp_core_imports_host_stream,
   comp_core_imports_stdin_provider,
+  comp_emit_async_string_canon_fixture,
+  comp_emit_async_string_component,
   comp_emit_component_wasm,
   comp_emit_component_wasm_async,
-  comp_emit_async_string_canon_fixture,
-  comp_emit_memhost_realloc_fixture,
   comp_emit_component_wasm_async_concurrent_awaits,
   comp_emit_component_wasm_async_hostfuture,
   comp_emit_component_wasm_async_spawned_future,
@@ -33,6 +33,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_string_handler_stubbed,
   comp_emit_component_wasm_with_lift,
   comp_emit_component_wasm_with_string_lift,
+  comp_emit_memhost_realloc_fixture,
   comp_generate_string_trampoline,
   comp_generate_string_trampoline_packed
 }
@@ -82,6 +83,16 @@ fn component_bytes_contains(hay: Bytes, needle: String) -> Int {
     }
     found
   }
+}
+
+fn repeated_string(piece: String, count: Int) -> String {
+  let out = StringBuilder::new()
+  let mut i = 0
+  while i < count {
+    StringBuilder::push(out, piece)
+    i = i + 1
+  }
+  StringBuilder::freeze(out)
 }
 
 fn build_test_core() -> Bytes {
@@ -551,6 +562,86 @@ test "component async: memhost-with-realloc exports memory and cabi_realloc (#15
     127,
     1,
     127
+  ]) == 1)
+}
+
+/// #1540: the assembled component -- the emitter twin of the async_string_lift
+/// probe, and the milestone the canon widening was for.
+///
+/// The three canon sequences are the same ones the fixture test above pins, so
+/// this test is not about them: it is about the INDICES around them, which the
+/// fixture cannot exercise because it emits the canons into an empty component.
+/// Aliases and canon built-ins share one core-func index space in emission
+/// order, so the realloc alias (which must precede both canons) pushes
+/// task.return to core func 1 and the guest's own export to core func 2. Get
+/// that wrong and every byte here still looks right while the component either
+/// fails to validate or lifts the wrong function.
+///
+/// `scripts/compiler_gate.sh` runs the emitted component under wasmtime; this
+/// test is the always-on half that needs no external tool.
+test "component async: the emitted string component wires the canon indices (#1540)" {
+  let comp = comp_emit_async_string_component("greet", "name", "hi")
+  // async functype: one string param named "name", string result
+  assert(bytes_contains_seq(comp, [
+    67,
+    1,
+    4,
+    110,
+    97,
+    109,
+    101,
+    115,
+    0,
+    115
+  ]) == 1)
+  // task.return: Memory(0) + UTF8, no realloc
+  assert(bytes_contains_seq(comp, [
+    9,
+    0,
+    115,
+    2,
+    3,
+    0,
+    0
+  ]) == 1)
+  // the async lift, lifting CORE FUNC 2 -- the guest alias, not the realloc
+  // alias (0) and not task.return (1)
+  assert(bytes_contains_seq(comp, [
+    0,
+    0,
+    2,
+    4,
+    6,
+    3,
+    0,
+    4,
+    0,
+    0,
+    0
+  ]) == 1)
+  // the guest imports the task-return under the name the export is called
+  assert(component_bytes_contains(comp, "[task-return]greet") == 1)
+  assert(component_bytes_contains(comp, "[export]$root") == 1)
+  // and the reply is a data segment, so it is observable to the lift
+  assert(component_bytes_contains(comp, "hi") == 1)
+}
+
+test "component async: reply data stays below the caller allocation region (#1540)" {
+  let reply = repeated_string("x", 1100)
+  let comp = comp_emit_async_string_component("greet", "name", reply)
+  // reply occupies [16, 1116), so the next 64-byte boundary is 1152. The
+  // memhost global initializer must therefore be i32.const 1152 (80 09), not
+  // the old fixed 1024 (80 08), or canonical lowering overwrites the reply.
+  assert(bytes_contains_seq(comp, [
+    6,
+    7,
+    1,
+    127,
+    1,
+    65,
+    128,
+    9,
+    11
   ]) == 1)
 }
 

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -16,6 +16,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_core_imports_stdin_provider,
   comp_emit_component_wasm,
   comp_emit_component_wasm_async,
+  comp_emit_async_string_canon_fixture,
   comp_emit_component_wasm_async_concurrent_awaits,
   comp_emit_component_wasm_async_hostfuture,
   comp_emit_component_wasm_async_spawned_future,
@@ -433,6 +434,98 @@ test "component async: emits task.return canon, async functype, async lift" {
     0
   ]) == 1)
   assert(component_bytes_contains(comp, "run") == 1)
+}
+
+/// #1540: the widened emitters must produce the encoding the probe measured
+/// against wasmtime, byte for byte.
+///
+/// The sequences below are the ones
+/// `tools/wasip3_component_probe/async_string_lift/component.wat` documents and
+/// `scripts/test_async_string_lift_probe_gate.sh` asserts against a real
+/// wasmtime run. This test is the other half: the probe proves wasmtime accepts
+/// them, this proves the emitter produces them.
+test "component async: widened canon emitters match the measured string encoding (#1540)" {
+  let bytes = comp_emit_async_string_canon_fixture()
+  // async functype, one string param named "name", string result:
+  // 43 01 04 'n' 'a' 'm' 'e' 73 00 73
+  assert(bytes_contains_seq(bytes, [
+    67,
+    1,
+    4,
+    110,
+    97,
+    109,
+    101,
+    115,
+    0,
+    115
+  ]) == 1)
+  // task.return with Memory(0) + UTF8 -- and NO realloc, which wasmtime rejects
+  // on this built-in: 09 00 73 02 03 00 00
+  assert(bytes_contains_seq(bytes, [
+    9,
+    0,
+    115,
+    2,
+    3,
+    0,
+    0
+  ]) == 1)
+  // async lift with Async + Memory(0) + Realloc(0) + UTF8:
+  // 00 00 02 04 06 03 00 04 00 00 00
+  assert(bytes_contains_seq(bytes, [
+    0,
+    0,
+    2,
+    4,
+    6,
+    3,
+    0,
+    4,
+    0,
+    0,
+    0
+  ]) == 1)
+}
+
+/// The zero-option spellings must stay byte-identical -- every existing caller
+/// goes through them, and this slice is meant to add a capability, not move any
+/// bytes.
+test "component async: the narrow spellings are unchanged by the widening (#1540)" {
+  let core = build_async_test_core()
+  let comp = comp_emit_component_wasm_async(core, "run", 120)
+  // task.return with an EMPTY option list
+  assert(bytes_contains_seq(comp, [
+    8,
+    5,
+    1,
+    9,
+    0,
+    120,
+    0
+  ]) == 1)
+  // async functype with ZERO params
+  assert(bytes_contains_seq(comp, [
+    7,
+    5,
+    1,
+    67,
+    0,
+    0,
+    120
+  ]) == 1)
+  // async lift with exactly one option (async)
+  assert(bytes_contains_seq(comp, [
+    8,
+    7,
+    1,
+    0,
+    0,
+    1,
+    1,
+    6,
+    0
+  ]) == 1)
 }
 
 test "component async: sync lift carries no async canonopt" {

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -17,6 +17,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm,
   comp_emit_component_wasm_async,
   comp_emit_async_string_canon_fixture,
+  comp_emit_memhost_realloc_fixture,
   comp_emit_component_wasm_async_concurrent_awaits,
   comp_emit_component_wasm_async_hostfuture,
   comp_emit_component_wasm_async_spawned_future,
@@ -525,6 +526,31 @@ test "component async: the narrow spellings are unchanged by the widening (#1540
     1,
     6,
     0
+  ]) == 1)
+}
+
+/// #1540: the memhost has to grow a `cabi_realloc` for the string shape --
+/// both canons are declared before the guest instance exists, so neither can
+/// point at a guest-owned memory or realloc without an instantiation cycle.
+test "component async: memhost-with-realloc exports memory and cabi_realloc (#1540)" {
+  let m = comp_emit_memhost_realloc_fixture()
+  // core wasm header
+  assert(Bytes::get(m, 0) == 0)
+  assert(Bytes::get(m, 1) == 97)
+  assert(Bytes::get(m, 2) == 115)
+  assert(Bytes::get(m, 3) == 109)
+  assert(component_bytes_contains(m, "memory") == 1)
+  assert(component_bytes_contains(m, "cabi_realloc") == 1)
+  // the realloc's type is (i32,i32,i32,i32) -> i32: 60 04 7f 7f 7f 7f 01 7f
+  assert(bytes_contains_seq(m, [
+    96,
+    4,
+    127,
+    127,
+    127,
+    127,
+    1,
+    127
   ]) == 1)
 }
 

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4090,6 +4090,51 @@ echo "[compiler-gate] region capture ok"
 #      being dropped (#706 — leaked ~84 B per call before its fix) makes it
 #      scale with N (or trap). #700 slipped precisely because no gate asserted
 #      a bounded heap.
+# #1540: the memhost-with-realloc module the async string shape needs must be a
+# VALID core module, not merely well-shaped bytes. The first cut emitted two
+# separate export sections (`emit_export_memory` and `emit_export_section` each
+# emit their own section 7, and a core module may carry only one), which every
+# byte-inspection test happily accepted and `wasm-tools validate` rejected with
+# "section out of order". Emitting and validating is the only assertion that
+# catches that class.
+if command -v wasm-tools >/dev/null 2>&1; then
+  echo "[compiler-gate] 40c3/40 memhost-with-realloc is a valid core module (#1540)"
+  mhdir="_build/_gate_memhost_realloc"
+  rm -rf "$mhdir"; mkdir -p "$mhdir"
+  cat > "$mhdir/emit.vibe" <<'MHEOF'
+import @vibe/compiler/entry/source_compile/wasi_only {
+  comp_emit_memhost_realloc_fixture
+}
+
+fn main() -> Int with Fs {
+  let m = comp_emit_memhost_realloc_fixture()
+  Fs::write_bytes("_build/_gate_memhost_realloc/memhost.wasm", m)
+  Bytes::length(m)
+}
+MHEOF
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$mhdir/emit.vibe" "$mhdir/emit.wasm" main >/dev/null 2>&1 || true
+  if [ ! -s "$mhdir/emit.wasm" ]; then
+    echo "[compiler-gate] FAIL: the memhost-realloc emitter program did not compile" >&2
+    cat "$mhdir/emit.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+    --invoke main "$mhdir/emit.wasm" >/dev/null 2>&1 || true
+  if [ ! -s "$mhdir/memhost.wasm" ]; then
+    echo "[compiler-gate] FAIL: the memhost-realloc emitter wrote no module" >&2
+    exit 1
+  fi
+  if ! wasm-tools validate "$mhdir/memhost.wasm" >/dev/null 2>&1; then
+    echo "[compiler-gate] FAIL: the emitted memhost-realloc module does not validate (#1540)" >&2
+    wasm-tools validate "$mhdir/memhost.wasm" >&2 || true
+    exit 1
+  fi
+  echo "[compiler-gate] memhost-with-realloc validates ok (#1540)"
+else
+  echo "[compiler-gate] note: wasm-tools absent, skipping the memhost-realloc validation (#1540)"
+fi
 # #1746 (RC lane): the raw-ABI shim dispatched on the callee NAME alone, so a
 # program defining its own top-level `fn sleep` had the shim applied to ITS
 # call -- emitting a module that failed validation, with no diagnostic. Only

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4135,6 +4135,95 @@ MHEOF
 else
   echo "[compiler-gate] note: wasm-tools absent, skipping the memhost-realloc validation (#1540)"
 fi
+# #1540: the whole async string component, assembled from the widened emitters
+# alone, must LOAD AND RUN -- not merely carry the right bytes.
+#
+# The unit test in component_codegen_test.vibe pins the canon byte sequences and
+# the core-func indices around them, and that is as far as byte inspection can
+# go: a component whose lift points at the wrong core func, whose data segment
+# never reaches the imported memory, or whose instantiation order is unsound
+# still contains every sequence the test looks for. Running it is the only
+# assertion that separates "emits the documented bytes" from "is the component
+# the probe is".
+#
+# The bar is the hand-written probe's: greet("bob") -> "hi", meaning the string
+# really round-trips out through task.return.
+gate_wasmtime_bin="$(bash scripts/wasmtime_bin.sh 2>/dev/null || command -v wasmtime || true)"
+if command -v wasm-tools >/dev/null 2>&1 && [ -n "$gate_wasmtime_bin" ] \
+   && "$gate_wasmtime_bin" --version >/dev/null 2>&1; then
+  echo "[compiler-gate] 40c4/40 emitted async string component runs (#1540)"
+  asdir="_build/_gate_async_string_component"
+  rm -rf "$asdir"; mkdir -p "$asdir"
+  cat > "$asdir/emit.vibe" <<'ASEOF'
+import @vibe/compiler/entry/source_compile/wasi_only {
+  comp_emit_async_string_component
+}
+
+fn repeat(piece: String, count: Int) -> String {
+  let out = StringBuilder::new()
+  let mut i = 0
+  while i < count {
+    StringBuilder::push(out, piece)
+    i = i + 1
+  }
+  StringBuilder::freeze(out)
+}
+
+fn main() -> Int with Fs {
+  let m = comp_emit_async_string_component("greet", "name", "hi")
+  Fs::write_bytes("_build/_gate_async_string_component/component.wasm", m)
+  let large = comp_emit_async_string_component("greet", "name", repeat("x", 1100))
+  Fs::write_bytes("_build/_gate_async_string_component/component-large.wasm", large)
+  Bytes::length(m)
+}
+ASEOF
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$asdir/emit.vibe" "$asdir/emit.wasm" main >/dev/null 2>&1 || true
+  if [ ! -s "$asdir/emit.wasm" ]; then
+    echo "[compiler-gate] FAIL: the async-string component emitter program did not compile" >&2
+    cat "$asdir/emit.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+    --invoke main "$asdir/emit.wasm" >/dev/null 2>&1 || true
+  if [ ! -s "$asdir/component.wasm" ]; then
+    echo "[compiler-gate] FAIL: the async-string component emitter wrote no component" >&2
+    exit 1
+  fi
+  if ! wasm-tools validate --features all "$asdir/component.wasm" >/dev/null 2>&1; then
+    echo "[compiler-gate] FAIL: the emitted async string component does not validate (#1540)" >&2
+    wasm-tools validate --features all "$asdir/component.wasm" >&2 || true
+    exit 1
+  fi
+  if ! wasm-tools validate --features all "$asdir/component-large.wasm" >/dev/null 2>&1; then
+    echo "[compiler-gate] FAIL: the emitted large-reply component does not validate (#1540)" >&2
+    wasm-tools validate --features all "$asdir/component-large.wasm" >&2 || true
+    exit 1
+  fi
+  as_out="$("$gate_wasmtime_bin" run -W exceptions=y -W concurrency-support=y \
+    -W component-model-async=y -W component-model-async-stackful=y \
+    --invoke 'greet("bob")' "$asdir/component.wasm" 2>&1 || true)"
+  case "$as_out" in
+    *'"hi"'*) ;;
+    *)
+      echo "[compiler-gate] FAIL: emitted greet(\"bob\") returned '$as_out' (want \"hi\") (#1540)" >&2
+      exit 1
+      ;;
+  esac
+  as_large_out="$("$gate_wasmtime_bin" run -W exceptions=y -W concurrency-support=y \
+    -W component-model-async=y -W component-model-async-stackful=y \
+    --invoke 'greet("bob")' "$asdir/component-large.wasm" 2>&1 || true)"
+  as_large_payload="$(printf '%s' "$as_large_out" | tr -d '"(),[:space:]')"
+  as_large_non_x="$(printf '%s' "$as_large_payload" | tr -d 'x')"
+  if [ "${#as_large_payload}" -ne 1100 ] || [ -n "$as_large_non_x" ]; then
+    echo "[compiler-gate] FAIL: large reply was corrupted or truncated (got ${#as_large_payload} bytes) (#1540)" >&2
+    exit 1
+  fi
+  echo "[compiler-gate] emitted async string component: greet(\"bob\") -> \"hi\" (#1540)"
+else
+  echo "[compiler-gate] note: wasm-tools/wasmtime absent, skipping the async string component run (#1540)"
+fi
 # #1746 (RC lane): the raw-ABI shim dispatched on the callee NAME alone, so a
 # program defining its own top-level `fn sleep` had the shim applied to ITS
 # call -- emitting a module that failed validation, with no diagnostic. Only

--- a/tools/wasip3_component_probe/async_string_lift/component.wat
+++ b/tools/wasip3_component_probe/async_string_lift/component.wat
@@ -45,6 +45,14 @@
 ;;
 ;;   option codes  00=UTF8  03 <idx>=Memory  04 <idx>=Realloc  06=Async
 ;;
+;; STATUS: the emitters have since been widened to produce exactly this, and
+;; `comp_emit_async_string_component` (component_codegen.vibe) assembles the
+;; whole component below from them -- validated and run by
+;; `scripts/compiler_gate.sh` lane 40c4, which holds it to this probe's bar
+;; (greet("bob") -> "hi"). This file stays as the HAND-WRITTEN reference: it is
+;; what the emitter was measured against, and the byte sequences documented here
+;; are what both the gate above and component_codegen_test.vibe assert.
+;;
 ;; The structural constraint this probe also demonstrates: memory and realloc
 ;; must live OUTSIDE the guest instance. `task.return` needs them, the guest
 ;; imports `[task-return]`, so a guest-owned memory would be a cycle. That is


### PR DESCRIPTION
#1807 (merged) は `tools/wasip3_component_probe/async_string_lift/component.wat` を**手書き**で置き、
async lift + string `task.return` の canonopt 集合をバイト単位で確定させた。
このPRはその続きで、**同じコンポーネントを emitter だけで出せるようにする**。

到達点: `comp_emit_async_string_component("greet", "name", "hi")` の出力が
`wasm-tools validate --features all` を通り、wasmtime で `greet("bob")` → `"hi"` を返す。
probe と**同じバー**で、文字列が本当に `task.return` 経由で往復する。

## 3 コミット

**1. canon emitter を実測符号化まで広げる**

| 広げた綴り | 出せるようになったもの |
|---|---|
| `emit_canon_task_return_opts` | Memory + UTF8 (**realloc は取らない** — wasmtime が拒否する) |
| `emit_canon_lift_async_opts` | Async + Memory + Realloc + UTF8 |
| `emit_comp_async_functype_params` | 名前付き params を持つ async functype |

負のインデックスと `utf8 = false` でオプションを落とすので、**既存 39 呼び出し元はバイト同一**。
狭い綴り (`emit_canon_task_return` / `emit_canon_lift_async_section` /
`emit_comp_async_functype_section`) は全オプションを落として委譲するだけになった。

**2. memhost に `cabi_realloc` を生やす**

probe が出した構造上の要求。`task.return` は memory を、async lift は memory と realloc を要り、
**両方ともゲストインスタンスが存在する前に宣言される** — ゲストは `[task-return]` を import するので、
ゲスト所有の memory/realloc は循環になる。先にインスタンス化されたモジュールから来るしかない。

既存の `comp_generate_memhost_module` に export を足すのではなく**別の生成関数**にした:
今日コンポーネントを出しているすべての経路があのモジュールを埋め込んでいるので、
export を足すと**この形を使わない全員のバイトが動く**。

ここで1つバグを踏んで潰した。最初の版は export セクションを**2つ**出していた
(`emit_export_memory` と `emit_export_section` がそれぞれ section 7 を出す。core module は1つしか持てない)。
バイトを覗くテストは全部通り、`wasm-tools validate` だけが `section out of order` と言った。
今は kind 混在の export セクションを1つ手で組み立てている。

**3. コンポーネント本体を組み立てる (このPRの本命)**

`comp_emit_async_string_component` が上記の emitter だけから組み立て、
`comp_generate_async_string_guest_module` がそのゲスト core module
(`[export]$root`.`[task-return]<name>` と `env.memory` を import、
`(ptr, len) -> ()` を export — 結果は core 関数の戻り経路ではなく task.return から出る。
返信は **import した** memory への data segment)。

間違えやすいのは canon のバイトではなく、**その周りのインデックス**だった。
alias と canon built-in は**発行順で1つの core-func インデックス空間を共有する**ので、
realloc の alias を両 canon より前に置く (canon がそのインデックスを要るので必然) と
`task.return` が core func 1 に、ゲスト自身の export が 2 にずれる。
**間違ったものを lift しているコンポーネントでも、バイト列検査が探すシーケンスは全部揃っている。**

## 検証

両側を assert する。

- `component_codegen_test.vibe` — canon シーケンス **とインデックス**。外部ツール不要。
  **lift を core func 1 に向けて red を確認済み** (trap する)。
- `compiler_gate.sh` 40c4/40 — 実際に emit → `wasm-tools validate` → **wasmtime で実行**し
  `greet("bob") -> "hi"` を確認。他の P3 レーンと同じくツール不在なら clean skip。
- `bash scripts/test_async_string_lift_probe_gate.sh` — 手書き probe 側、PASS 継続。
- `bash scripts/vibe_fmt.sh --check` — clean。

probe (`component.wat`) は**手書きのリファレンス**として残す。emitter はこれに対して測られたもので、
そこに書かれたバイト列がゲートとテストの両方の期待値になっている。

## 次

これで serve emitter 合流に必要な部品 (params 付き async functype / memory + encoding を運ぶ
`task.return` / memory + realloc + encoding を運ぶ async lift / 両方を供給する memhost) が
**実際に動くコンポーネント上で揃った**。次は `validate_serve_handler`
(`wit_gen.vibe:342-371` — 非 Exception effect を一律 throw、引数4個・全部 String の決め打ち) 側だが、
そちらは**フロントエンドを緩める**変更なので、emitter が先に出せるようになっている今の順序が正しい
(逆だと型検査を通ったプログラムが codegen で落ちる)。

## 関連

#1540、#1807 (手書き probe)、#1796 (合成形状の probe)、#1230

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_