### PR TITLE
fix(fmt): 出力を parse して検証する — brace の手前を列挙するのをやめる (#1821)

### DIFF
--- a/lib/@vibe/cli/fmt_entry.vibe
+++ b/lib/@vibe/cli/fmt_entry.vibe
@@ -2,18 +2,69 @@
 //#
 //# argv[0] = input path, argv[1] = output path (both repo-root-relative, under
 //# the wasm preopen dir). Driven by scripts/vibe_fmt.sh.
+//#
+//# The formatter must never turn source that compiles into source that does
+//# not. It did, four times, each a different token in the slot before a brace
+//# (#945, #1429, #1505, #1821), and each fix taught the guard one more spelling
+//# it must not rewrite. `--check` then reported the wreckage as correctly
+//# formatted, so the CI fmt gate stayed green on files no parser accepts.
+//#
+//# So the decision here is not made by enumerating anything. The output is
+//# PARSED: if the input was a program and the output is not, the rewrite is
+//# discarded and the run fails. That question has a bounded answer, and it
+//# holds for the next spelling nobody has thought of yet.
+//#
+//# The check lives at the entry rather than inside the formatter because
+//# lib/@vibe/compiler/fmt has no dependencies by design, and the parser is one.
 
 import ../compiler/fmt {
   format_source
 }
 
-export fn main() -> Int with Fs + Env {
+import ../parser {
+  lex, parse_program
+}
+
+fn program_parses(src: String) -> Bool {
+  handle {
+    let _ = parse_program(lex(src))
+    true
+  } with Exception {
+    Throw(_) => false
+  }
+}
+
+fn has_suffix(s: String, suffix: String) -> Bool {
+  let n = String::length(s)
+  let m = String::length(suffix)
+  if n < m {
+    false
+  } else {
+    String::substring(s, n - m, n) == suffix
+  }
+}
+
+export fn main() -> Int with Fs + Env + Stderr {
   let input = Env::args_get(0)
   let output = Env::args_get(1)
   let src = Fs::read_file(input)
   // format_source dispatches on the extension: `.vpkg` package contracts
   // get header handling, everything else is plain vibe source (#1435).
   let formatted = format_source(input, src)
-  Fs::write_file(output, formatted)
-  0
+  // A `.vpkg` header is not vibe syntax, so a whole-file parse never succeeds
+  // for one and the comparison below would say nothing. format_vpkg already
+  // refuses to touch a header it cannot read, which is the same policy reached
+  // by a different route (#1435).
+  //
+  // Only a rewrite that BREAKS something is rejected. A file that did not parse
+  // to begin with is still formatted: the promise is "no worse", not "only
+  // valid input".
+  if !has_suffix(input, ".vpkg") && program_parses(src) && !program_parses(formatted) {
+    Fs::write_file(output, src)
+    Stderr::write_stream("vibe fmt: refusing to rewrite " + input + "\n" + "  The formatted output does not parse, and the input did. This is a bug in\n" + "  the formatter, not a problem with the file. The file is unchanged; please\n" + "  report it with the source (see #1821).\n")
+    1
+  } else {
+    Fs::write_file(output, formatted)
+    0
+  }
 }

--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -1696,12 +1696,17 @@ fn should_insert_struct_double_colon(prev_prev_kind: Int, prev_prev_text: String
     // into an unrelated "unexpected token" error much later in the file.
     false
   } else if prev_prev_kind == k_match || prev_prev_kind == k_while || prev_prev_kind == k_if ||
-  prev_prev_kind == k_loop {
+  prev_prev_kind == k_loop || prev_prev_kind == k_in {
     // Same false-positive family as k_is above, pre-empted rather than
     // waiting for a real corruption to surface one keyword at a time:
     // `match SomeBareVariant {` / `while SomeFlag {` / `if SomeCond {` /
     // `loop SomeState {` all put a bare capitalized name directly before a
     // `{` that opens a match/loop/if BODY, not a struct literal.
+    //
+    // `k_in` joined them for `for x in Items {`, found in review of the #1821
+    // fix -- which is the point the enumeration stopped being the answer. The
+    // entry now PARSES the output and discards a rewrite that breaks it, so a
+    // spelling missing from this list costs a refusal, not a corrupted file.
     false
   }
   else if prev_prev_kind == k_eqeq || prev_prev_kind == k_neq || prev_prev_kind == k_lt ||

--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -1703,6 +1703,28 @@ fn should_insert_struct_double_colon(prev_prev_kind: Int, prev_prev_text: String
     // `loop SomeState {` all put a bare capitalized name directly before a
     // `{` that opens a match/loop/if BODY, not a struct literal.
     false
+  }
+  else if prev_prev_kind == k_eqeq || prev_prev_kind == k_neq || prev_prev_kind == k_lt ||
+  prev_prev_kind == k_lte || prev_prev_kind == k_gt || prev_prev_kind == k_gte ||
+  prev_prev_kind == k_and_and || prev_prev_kind == k_or_or {
+    // #1821: a COMPARISON before the name, which is how a condition ends before
+    // its body brace: `if x != None {` has prev_prev `!=`, prev `None`, curr
+    // `{`. Every guard above keys off a keyword, and the keyword here is `if`
+    // -- four tokens back, out of reach. The result was `if x != None::{`,
+    // source no parser accepts, written by `pkf run fmt` over source that
+    // compiled, with `--check` then calling the wreck correctly formatted.
+    //
+    // Same one-sided trade as the k_plus case: `a == Point { x: 1 }` no longer
+    // gets a `::` inserted for it, and that spelling is not valid vibe anyway
+    // (struct literals are written `Point::{ .. }`), whereas a comparison
+    // before a body brace is ordinary code.
+    //
+    // This list grows one operator at a time because the guard asks "what came
+    // before the name" and the answer is unbounded. The check that would not
+    // need to enumerate anything -- refuse to write output that does not PARSE
+    // -- is tracked in #1821 and belongs at the entry, which can reach the
+    // parser; this package deliberately has no dependencies.
+    false
   } else if prev_kind != k_name {
     false
   } else {
@@ -3050,3 +3072,4 @@ export fn format_source(path: String, src: String) -> String {
     format_script(src)
   }
 }
+

--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -3077,4 +3077,3 @@ export fn format_source(path: String, src: String) -> String {
     format_script(src)
   }
 }
-

--- a/lib/@vibe/compiler/fmt/struct_double_colon_test.vibe
+++ b/lib/@vibe/compiler/fmt/struct_double_colon_test.vibe
@@ -111,3 +111,25 @@ test "a struct literal after a comparison is still spelled with ::" {
   let got = format_script(src)
   assert(contains(got, "Point::{"))
 }
+
+test "a for-in iterable keeps its block brace" {
+  // `for x in Items {` — found reviewing the #1821 fix, after the comparison
+  // operators were added. `path_governor` reports `in`, which no guard covered,
+  // so the loop body became struct-literal fields.
+  //
+  // This is where enumerating stopped being the answer: four rounds of "one
+  // more token in that slot" (#945, #1429, #1505, #1821) and the question
+  // "what can precede the name" still has no bounded answer. The entry now
+  // parses the formatter's output and discards a rewrite that breaks it, so a
+  // spelling missing from the guard costs a refusal instead of a broken file.
+  let src = "fn f() -> Int {\n  for x in Items {\n    1\n  }\n  0\n}\n"
+  let got = format_script(src)
+  assert(contains(got, "for x in Items {"))
+  assert(!contains(got, "Items::{"))
+}
+
+test "a for-in over a real struct literal keeps its ::" {
+  let src = "fn f() -> Int {\n  for x in Items::{ a: 1 } {\n    1\n  }\n  0\n}\n"
+  let got = format_script(src)
+  assert(contains(got, "Items::{"))
+}

--- a/lib/@vibe/compiler/fmt/struct_double_colon_test.vibe
+++ b/lib/@vibe/compiler/fmt/struct_double_colon_test.vibe
@@ -71,3 +71,43 @@ test "formatting is a fixpoint for a qualified scrutinee" {
   let once = format_script(src)
   assert(format_script(once) == once)
 }
+
+//# #1821: the same false positive, reached through a COMPARISON rather than a
+// keyword. Every guard above looks at what sits two tokens before the brace and
+// expects a keyword there; in `if x != None {` that slot holds `!=` and the
+// `if` is four tokens back, out of reach. The output was `if x != None::{`.
+//
+// This one was not found by reading the guard. `pkf run fmt` rewrote source
+// that compiled into source no parser accepts, `--check` then reported the
+// wreck as correctly formatted, and it surfaced as four red CI shards pointing
+// at a brace nobody wrote.
+
+test "a comparison before a capitalized name keeps its block brace" {
+  let src = "fn f(x: Option[Int]) -> Int {\n  if x != None {\n    1\n  } else {\n    0\n  }\n}\n"
+  let got = format_script(src)
+  assert(contains(got, "if x != None {"))
+  assert(!contains(got, "None::{"))
+}
+
+test "the other comparisons are guarded too" {
+  let src = "fn f(y: Int) -> Int {\n  if y > Limit {\n    1\n  } else {\n    0\n  }\n}\n"
+  let got = format_script(src)
+  assert(contains(got, "if y > Limit {"))
+  assert(!contains(got, "Limit::{"))
+}
+
+test "a boolean operator before a capitalized name keeps its block brace" {
+  let src = "fn f(a: Option[Int], b: Int) -> Int {\n  if a == None && b < Cap {\n    1\n  } else {\n    0\n  }\n}\n"
+  let got = format_script(src)
+  assert(contains(got, "b < Cap {"))
+  assert(!contains(got, "Cap::{"))
+}
+
+test "a struct literal after a comparison is still spelled with ::" {
+  // The trade this guard makes, pinned: `a == Point { x: 1 }` no longer gets a
+  // `::` inserted for it. The canonical spelling already carries one, so
+  // nothing that was valid stops being valid.
+  let src = "fn f(a: Point) -> Bool {\n  a == Point::{ x: 1 }\n}\n"
+  let got = format_script(src)
+  assert(contains(got, "Point::{"))
+}

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -27,6 +27,11 @@ bash scripts/check_inline_builtin_capture.sh
 # selfbuild rather than after it.
 bash scripts/check_fixture_execution.sh
 
+# #1821 / Codex review on #1822: the token formatter may conservatively miss
+# an ambiguous `Name {` shape, but the public writer must never replace valid
+# source with a candidate that no parser accepts.
+bash scripts/vibe_fmt_parse_guard_test.sh
+
 # B2 parser binder-context routing is intentionally semantically inert, so its
 # no-fallback proof is structural. Keep the large source-body assertion table
 # out of the Vibe unit and run the strict scanner directly under Node.

--- a/scripts/ensure_vibe_fmt_entry.sh
+++ b/scripts/ensure_vibe_fmt_entry.sh
@@ -20,7 +20,10 @@ entry_wasm_rel="_build/vibe_fmt/fmt_entry.wasm"
 
 if [ ! -s "$ROOT_DIR/$entry_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ]; then
+   || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/parser/lexer.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/parser/parser.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/parser/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ]; then
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
     --invoke cli_main "$seed" "$entry_src" "$entry_wasm_rel" main >&2

--- a/scripts/vibe_fmt.sh
+++ b/scripts/vibe_fmt.sh
@@ -45,9 +45,17 @@ entry_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh")"
 out_rel="_build/vibe_fmt/out.$$.vibe"
 mkdir -p "$ROOT_DIR/_build/vibe_fmt"
 trap 'rm -f "$ROOT_DIR/$out_rel"' EXIT
-VIBE_PREOPEN_DIR="$ROOT_DIR" \
+# The runner exits 0 whatever `main` returns, printing the return value as the
+# last stdout line instead. Discarding stdout therefore discarded the entry's
+# only way to say "I refused to format this" -- so a formatter that declined to
+# rewrite a file looked exactly like one that had nothing to change (#1821).
+entry_rc="$(VIBE_PREOPEN_DIR="$ROOT_DIR" \
   bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-  --invoke main "$entry_wasm_rel" "$src_rel" "$out_rel" >/dev/null
+  --invoke main "$entry_wasm_rel" "$src_rel" "$out_rel" | tail -1)"
+if [ "$entry_rc" != "0" ]; then
+  echo "vibe_fmt.sh: formatter declined to rewrite $src_rel; the file is untouched" >&2
+  exit 1
+fi
 
 [ -f "$ROOT_DIR/$out_rel" ] || { echo "vibe_fmt.sh: formatter produced no output" >&2; exit 1; }
 

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work="$ROOT_DIR/_build/vibe_fmt_parse_guard_test.$$"
+probe="$work/probe.vibe"
+original="$work/original.vibe"
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work"
+
+# Codex review on #1822: the set of tokens that may precede a capitalized
+# condition tail is unbounded. Unary `!` is intentionally not one of the known
+# governors, so the token-only formatter guesses that `Flag` is a struct
+# literal and emits `Flag::{`. The public formatter must parse its candidate
+# output and refuse the write instead of silently replacing valid source with
+# invalid source.
+cat >"$probe" <<'VIBE'
+fn f() -> Int {
+  if !Flag {
+    1
+  } else {
+    0
+  }
+}
+VIBE
+cp "$probe" "$original"
+
+if bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$probe" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: formatter accepted its invalid Flag::{ output" >&2
+  sed -n '1,20p' "$probe" >&2
+  exit 1
+fi
+if ! cmp -s "$probe" "$original"; then
+  echo "vibe_fmt_parse_guard_test: formatter modified the input after declining it" >&2
+  exit 1
+fi
+
+echo "vibe_fmt_parse_guard_test: ok"


### PR DESCRIPTION
#1821 の修正です。`pkf run fmt` が**コンパイルできるコードを、どのコンパイラも
受け付けない形に書き換えて**いました。

```console
$ bash scripts/vibe_fmt.sh --stdout t.vibe   # 修正前
  if x != None::{
```

`None::{` は入力のどこにもありません。しかも壊れた出力に `--check` を掛けると
**exit 0** (整形済み) なので、`vibe-fmt-check` (required) は緑のままです。
PR #1818 で踏み、unit-test 4 shard が「誰も書いていない brace」を指すエラーで
全部落ちました。

## 列挙では終わらないと分かった

最初は `should_insert_struct_double_colon` に比較演算子を足しました。
`if x != None {` の brace の 2 つ手前は `!=` で、既存ガードはそこに**キーワードがある
前提**だったからです。

**その修正を入れた状態で、レビューが次のケースを見つけました**:

```console
$ bash scripts/vibe_fmt.sh --stdout t.vibe
  for x in Items::{
```

`path_governor` は `in` を返し、どのガードにも無い。#945 → #1429 → #1505 →
`!=` → `in` で **5 回目**です。「名前の手前に何が来うるか」という問いに
**有限の答えは無い**。

## 出力を parse する

entry がフォーマッタの出力を **`lex` + `parse_program` に通します**。
入力がプログラムで出力がそうでないなら、書き換えを**捨て**、ファイルに触らず、
**失敗します**。

**`for ... in` のケースは、`in` を一切知らないこの検査が捕まえます。**
これが列挙との差で、まだ誰も思いついていない綴りにも同じように効きます。

**fail closed になっていなかった点も直しました**: 旧 `main` は結果を無条件に書いて
0 を返すので、下流は拒否と no-op を区別できませんでした。
`scripts/vibe_fmt.sh` 側も entry の失敗を拾います — runner は main の戻り値に
関わらず exit 0 で、戻り値は stdout の最終行に出るだけなのに、driver がその stdout を
捨てていました。

### 適用範囲 (両方向)

- **`.vpkg` は対象外** — ヘッダは vibe 構文ではないので全体 parse は決して成功せず、
  比較が何も言いません。`format_vpkg` は既に「読めないヘッダには触らない」を
  やっているので (#1435)、別経路の同じ方針です
- **元から parse できないファイルは、そのまま整形します**。約束は「悪化させない」で
  あって「正しい入力しか受けない」ではありません

### 置き場所

`lib/@vibe/compiler/fmt` は意図的に無依存で、parser は依存になります。なので entry 側です。

## ガードも直してあります (`!=` 系 + `in`)

**拒否は床であって目標ではない**ので、判明している綴りは「壊さない」ではなく
「正しく整形される」ようにしてあります。`== != < <= > >= && ||` と `in` を追加しました。

`k_plus` のガードが既に文書化しているのと同じ片側のトレードです —
`a == Point { x: 1 }` に `::` が挿入されなくなりますが、**その綴りはそもそも vibe
として不正** (struct literal は `Point::{ .. }`) で、一方「比較や `in` の後ろに body の
brace」は普通のコードです。どちらもテストで固定しました。

## 捨てた案 (同じ道を二度歩かないための記録)

「出力を再 lex して、フォーマッタが受け取ったトークン列と一致するか」を先に実装し、
**実測で否定しました**。正規化器が `format_tokens` に渡す列では一部のトークン
(戻り値型の `->` を含む) が `k_none` の tombstone になっていて renderer が
再生成するため、素朴に比べると**正しい出力が全部拒否されます**
(`fn f() -> Int { 1 }` で index 4 が `k_none:''` vs `64:'->'`)。
この結果は #1821 にも残してあります。

## 検証

- `lib` 配下 **947 ファイル: 0 violations**、かつ **どれも parse 検査に引っかかりません**
- `lib/@vibe/compiler/fmt` テストスイート green (回帰 6 本追加 — 比較 3 種、
  `for ... in` 2 種、`::` 付き struct literal が保たれること)
- `.vpkg` の整形が従来どおり動くこと (`--check` exit 0)
- `lint_review_regressions` / `lint_architecture_debt` green
- `origin/main` (01a952baa) 上

Refs #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN