### PR TITLE
feat(gc): host import に Fs::remove/rename/is_dir/is_file と Stdout::write_stream を足す (#1262)

### DIFF
--- a/fixtures/gc_host_builtins.vibe
+++ b/fixtures/gc_host_builtins.vibe
@@ -1,0 +1,98 @@
+// #1262: the wasm-gc lane's host-import surface, extended.
+//
+// These five were "unknown constructor or function" on the gc lane, so any
+// program using them was gc-uncompilable. Wiring them is three appended rows
+// (use_host / host_defs / host_imports) plus `hbo`, the count those indices
+// are relative to.
+//
+// Every check is a PAIR -- the affirmative and the negative of the same
+// question -- because that is what the failure mode demands. Under #1814's
+// mis-decoded ABI these builtins agreed with linear on the affirmative case
+// and disagreed on the negative one, so an affirmative-only fixture stayed
+// green through the entire bug. `Fs::exists` answering true for a missing
+// path is the shape to keep in mind.
+//
+// `Fs::readdir` is NOT here: it returns Array[String] and the linear lane
+// lowers that surface at the call site on top of the raw import, so wiring
+// only the import yields an empty array on the gc lane. It stays a loud
+// "unknown constructor or function" until that lowering exists -- which is
+// the right failure while it is unimplemented.
+
+fn probe_root() -> String {
+  "_build/gc_host_builtins_probe"
+}
+
+fn dir_checks() -> Int with Fs {
+  let yes = if Fs::is_dir(probe_root() + "/adir") {
+    1
+  } else {
+    0
+  }
+  let no = if Fs::is_dir(probe_root() + "/nope") {
+    1
+  } else {
+    0
+  }
+  yes * 10 + no
+}
+
+fn file_checks() -> Int with Fs {
+  let yes = if Fs::is_file(probe_root() + "/a.txt") {
+    1
+  } else {
+    0
+  }
+  // A DIRECTORY, not a missing path: is_file must distinguish the two, and a
+  // mis-decode that answers "true for anything that exists" passes a
+  // missing-path check.
+  let no = if Fs::is_file(probe_root() + "/adir") {
+    1
+  } else {
+    0
+  }
+  yes * 10 + no
+}
+
+// Observed through Fs::exists on both sides of the operation, so a builtin
+// that silently does nothing is visible. `Fs::remove` did exactly that before
+// #1814 -- the host swallows errors (`fs.rmSync(.., { force: true })`), so a
+// broken argument looks like success.
+fn remove_check() -> Int with Fs {
+  Fs::write_file(probe_root() + "/r1", "z")
+  let before = if Fs::exists(probe_root() + "/r1") {
+    1
+  } else {
+    0
+  }
+  Fs::remove(probe_root() + "/r1")
+  let after = if Fs::exists(probe_root() + "/r1") {
+    1
+  } else {
+    0
+  }
+  before * 10 + after
+}
+
+// Both ends: the destination must appear AND the source must disappear. A
+// rename lowered as a copy would pass the destination check alone.
+fn rename_check() -> Int with Fs {
+  Fs::write_file(probe_root() + "/s1", "z")
+  Fs::rename(probe_root() + "/s1", probe_root() + "/s2")
+  let dst = if Fs::exists(probe_root() + "/s2") {
+    1
+  } else {
+    0
+  }
+  let src = if Fs::exists(probe_root() + "/s1") {
+    1
+  } else {
+    0
+  }
+  dst * 10 + src
+}
+
+export let main = () -> Int with Fs + Stdout {
+  Stdout::write_stream("gc-host-builtins:")
+  // 10 10 10 10 -> 10101010 when every pair reads (affirmative=1, negative=0).
+  dir_checks() * 1000000 + file_checks() * 10000 + remove_check() * 100 + rename_check()
+}

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -1410,11 +1410,17 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // #538: host imports (module "vibe", tagged-i64 ABI -- the same raw ABI the
   // linear backend and the node host runner speak). Gated as a GROUP: pure
   // modules stay import-free (runnable on bare wasmtime); a module touching
-  // any Env::/Fs:: builtin imports all nine at indices 1..9, shifting every
-  // generated-body index by 9 (hbo).
-  let use_host = stmts_use_builtin(stmts, fn_names_list, "Env::get") || stmts_use_builtin(stmts, fn_names_list, "Env::args_len") || stmts_use_builtin(stmts, fn_names_list, "Env::args_get") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::exists") || stmts_use_builtin(stmts, fn_names_list, "Fs::stat_token") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::publish_immutable_text") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_bytes") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_bytes") || stmts_use_builtin(stmts, fn_names_list, "Profiler::now_us")
+  // any Env::/Fs::/Stdout:: builtin imports ALL of them at indices 1..16,
+  // shifting every generated-body index by that count (hbo).
+  //
+  // `hbo` IS that count. FOUR places encode this list -- use_host, host_defs,
+  // host_imports, and hbo -- and moving one without the others is silently
+  // wrong: the first build that appended imports but left hbo behind produced
+  // modules that validated nowhere ("not enough arguments on the stack for
+  // call"), because every generated-body index still pointed low.
+  let use_host = stmts_use_builtin(stmts, fn_names_list, "Env::get") || stmts_use_builtin(stmts, fn_names_list, "Env::args_len") || stmts_use_builtin(stmts, fn_names_list, "Env::args_get") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::exists") || stmts_use_builtin(stmts, fn_names_list, "Fs::stat_token") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::publish_immutable_text") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_bytes") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_bytes") || stmts_use_builtin(stmts, fn_names_list, "Profiler::now_us") || stmts_use_builtin(stmts, fn_names_list, "Fs::remove") || stmts_use_builtin(stmts, fn_names_list, "Fs::rename") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_dir") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_file") || stmts_use_builtin(stmts, fn_names_list, "Stdout::write_stream")
   let hbo = if use_host {
-    11
+    16
   } else {
     0
   }
@@ -1591,7 +1597,24 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       ("Fs::publish_immutable_text", 2, 8, 1),
       ("Fs::write_bytes", 2, 9, 0),
       ("Fs::read_bytes", 1, 10, 1),
-      ("Profiler::now_us", 0, 11, 1)
+      ("Profiler::now_us", 0, 11, 1),
+      // #1262: appended, never inserted -- the indices above are absolute, so
+      // an insertion would silently repoint every existing call.
+      //
+      // `Fs::readdir` is deliberately absent. It returns Array[String] and the
+      // linear lane lowers that surface at the call site on top of the raw
+      // import ("RAW half of Fs::readdir -- compile_call lowers the surface");
+      // wiring only the import gives an empty array on the gc lane (measured:
+      // linear 3 entries, gc 0). `Stdin::read_char` / `Stdin::read_stream` are
+      // absent for a different reason -- they wire identically to these, but
+      // stdin reaches neither lane in the test harness, so both return EOF and
+      // agreement proves nothing. Shipping wiring that is only EOF-verified is
+      // how a silently-wrong builtin gets in.
+      ("Fs::remove", 1, 12, 0),
+      ("Fs::rename", 2, 13, 0),
+      ("Fs::is_dir", 1, 14, 1),
+      ("Fs::is_file", 1, 15, 1),
+      ("Stdout::write_stream", 1, 16, 0)
     ]
     let mut __hd = 0
     while __hd < Array::length(host_defs) {
@@ -2268,7 +2291,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
     // 4=(i64,i64)->i64, 5=()->i64, 6=(i64,i64)->()) -- the linear backend's
     // raw tagged ABI.
     let imp_content = bytebuf_new()
-    bytebuf_push_vec_header(imp_content, 12)
+    bytebuf_push_vec_header(imp_content, 17)
     emit_name(imp_content, "wasi_snapshot_preview1")
     emit_name(imp_content, "fd_write")
     bytebuf_push(imp_content, 0)
@@ -2284,7 +2307,14 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       ("fs_publish_immutable_text", 4),
       ("fs_write_bytes", 6),
       ("fs_read_bytes", 3),
-      ("profile-now-us", 5)
+      ("profile-now-us", 5),
+      // Same order as host_defs above; type indices are the shared base types
+      // (1 = (i64)->(), 3 = (i64)->i64, 6 = (i64,i64)->()).
+      ("fs_remove", 1),
+      ("fs_rename", 6),
+      ("fs_is_dir", 3),
+      ("fs_is_file", 3),
+      ("stdout_write_stream", 1)
     ]
     let mut __hi = 0
     while __hi < Array::length(host_imports) {

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -26,29 +26,15 @@ Double::max	linear-only	gc-unported	served on linear (callsite arm/table); no gc
 Double::min	linear-only	gc-unported	served on linear (callsite arm/table); no gc arm yet -- gc compile of a user of this name fails loudly
 Double::parse	linear-only	gc-unported	served on linear (callsite arm/table); no gc arm yet -- gc compile of a user of this name fails loudly
 Double::to_string	linear-only	gc-unported	served on linear (callsite arm/table); no gc arm yet -- gc compile of a user of this name fails loudly
-Env::args_get	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Env::args_len	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Env::get	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Float::to_int	linear-only	gc-unported	served on linear (callsite arm/table); no gc arm yet -- gc compile of a user of this name fails loudly
 Float::to_string	linear-only	gc-unported	served on linear (callsite arm/table); no gc arm yet -- gc compile of a user of this name fails loudly
 Fs::append	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Fs::chdir	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Fs::copy	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::exists	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Fs::getcwd	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::is_dir	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::is_file	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Fs::mkdir	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Fs::mkdir_p	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::publish_immutable_text	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::read_bytes	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::read_file	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Fs::readdir	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::remove	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::rename	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::stat_token	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::write_bytes	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::write_file	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Future::pending	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 Future::ready	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 Future::resolve	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
@@ -65,7 +51,6 @@ Path::to_string	linear-only	gc-unported	served on linear (callsite arm/table); n
 Profiler::HeapBytes	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Profiler::NowUs	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Profiler::heap_bytes	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Profiler::now_us	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stderr::write_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stderr::write_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdin::read_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
@@ -75,7 +60,6 @@ StdinStream::read_chunk	linear-only	async-component-only	#1539 compiler-owned di
 StdinStream::close	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
 StdinStream::next	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation
 Stdout::write_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Stdout::write_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stream::next	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 Stream::to_string	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 String::to_bytes	linear-only	gc-unported	served on linear (callsite arm/table); no gc arm yet -- gc compile of a user of this name fails loudly

--- a/scripts/check_builtin_parity.sh
+++ b/scripts/check_builtin_parity.sh
@@ -29,6 +29,7 @@ LIN_CALLSITE = "lib/@vibe/compiler/codegen/expr/compile_call.vibe"
 GC_CALLSITE = "lib/@vibe/compiler/codegen/gc/backend_call.vibe"
 REGISTRY = "lib/@vibe/compiler/core/builtin_registry.vibe"
 LINKED = "lib/@vibe/compiler/codegen/wasi/linked_compile.vibe"
+GC_BODY = "lib/@vibe/compiler/codegen/gc/backend_body.vibe"
 CLASSIFICATION = "scripts/builtin_parity_classification.tsv"
 
 def callsite_names(path):
@@ -94,8 +95,33 @@ if neither:
           f"(dead rows?): {', '.join(neither)}", file=sys.stderr)
     sys.exit(1)
 
+# The gc lane serves host builtins through an import table in backend_body.vibe,
+# not through a `fname == ...` dispatch arm and not through a registry in_gc
+# row -- so neither source above sees them. That was not a gap introduced by
+# any one change: every gc host import (Env::get, Fs::read_file, Fs::exists,
+# ...) was already served and already recorded as `linear-only`, with a reason
+# line saying the gc lane "gates these out as a group". It does not.
+#
+# Same posture as the extractions above: pin the shape, and FAIL rather than
+# silently count zero if it moves. A parity guard that quietly stops seeing a
+# lane is worse than one that breaks loudly.
+gc_body_text = open(GC_BODY).read()
+host_defs_match = re.search(r'let host_defs = \[(.*?)\n    \]', gc_body_text, re.S)
+if not host_defs_match:
+    print("[builtin-parity] FAIL: could not find the gc host_defs table in "
+          f"{GC_BODY} -- did it move or change shape? Update "
+          "scripts/check_builtin_parity.sh alongside it.", file=sys.stderr)
+    sys.exit(1)
+gc_host = set(re.findall(r'\(\s*"([^"]+)"\s*,\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)',
+                         host_defs_match.group(1)))
+if len(gc_host) < 10:
+    print(f"[builtin-parity] FAIL: parsed only {len(gc_host)} gc host imports "
+          "(expected 10+) -- host_defs row shape changed? Update "
+          "scripts/check_builtin_parity.sh alongside it.", file=sys.stderr)
+    sys.exit(1)
+
 served_lin = lin_cs | reg_lin | wrapper_only_expected
-served_gc = gc_cs | reg_gc
+served_gc = gc_cs | reg_gc | gc_host
 actual = ({(n, "linear-only") for n in served_lin - served_gc}
           | {(n, "gc-only") for n in served_gc - served_lin})
 

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4357,6 +4357,60 @@ fi
 rm -rf "$gcabidir" _build/gc_host_abi_probe
 echo "[compiler-gate] wasm-gc host ABI declaration ok (linear + gc, =160)"
 
+# 40h-5. #1262: the gc lane's host-import surface, extended by five builtins
+#        that were "unknown constructor or function" there. Runs with NO
+#        VIBE_IMPORT_ABI for the same reason as 40h-4 -- the module declares
+#        its own ABI, and forcing the variable would hide a regression in that
+#        declaration.
+#
+#        Every check is an affirmative/negative PAIR. Under #1814's mis-decode
+#        these builtins agreed with linear on the affirmative case and
+#        disagreed on the negative one, so a one-sided fixture stayed green
+#        through the whole bug.
+echo "[compiler-gate] 40h-5/40 wasm-gc host builtins (#1262)"
+gchbdir="_build/_gate_gc_host_builtins"
+rm -rf "$gchbdir"; mkdir -p "$gchbdir"
+gchb_out=""
+for gchb_be in linear gc; do
+  rm -rf _build/gc_host_builtins_probe
+  mkdir -p _build/gc_host_builtins_probe/adir
+  printf 'hello\n' > _build/gc_host_builtins_probe/a.txt
+  env -u VIBE_FS_COMPILE VIBE_BACKEND="$gchb_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "fixtures/gc_host_builtins.vibe" "$gchbdir/$gchb_be.wasm" main >/dev/null 2>&1
+  if [ ! -s "$gchbdir/$gchb_be.wasm" ]; then
+    echo "[compiler-gate] FAIL: gc_host_builtins.vibe did not compile on the $gchb_be backend (#1262)" >&2
+    cat "$gchbdir/$gchb_be.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  gchb_got="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gchbdir/$gchb_be.wasm" 2>&1 | tail -1)"
+  if [ "$gchb_be" = "linear" ]; then
+    gchb_out="$gchb_got"
+  elif [ "$gchb_got" != "$gchb_out" ]; then
+    echo "[compiler-gate] FAIL: gc host builtins disagree with linear: gc='$gchb_got' linear='$gchb_out' (#1262)" >&2
+    exit 1
+  fi
+done
+# Pin the value too: agreement alone passes when BOTH lanes break the same way.
+if [ "$gchb_out" != "gc-host-builtins:10101010" ]; then
+  echo "[compiler-gate] FAIL: gc host builtin probe returned '$gchb_out' (want gc-host-builtins:10101010) on both lanes (#1262)" >&2
+  exit 1
+fi
+# Fs::readdir must still fail LOUDLY on the gc lane. Wiring only its import
+# yields an empty array (it needs the call-site surface lowering the linear
+# lane has), and an empty array is the silently-wrong answer this gate exists
+# to keep out. Drop this check when that lowering lands.
+printf 'let main = () -> Int with Fs { Array::length(Fs::readdir("_build")) }\n' > "$gchbdir/readdir.vibe"
+env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$gchbdir/readdir.vibe" "$gchbdir/readdir.wasm" main >/dev/null 2>&1 || true
+if [ -s "$gchbdir/readdir.wasm" ]; then
+  echo "[compiler-gate] FAIL: Fs::readdir now compiles on the gc lane -- if its surface lowering landed, verify it against linear and drop this check (#1262)" >&2
+  exit 1
+fi
+rm -rf "$gchbdir" _build/gc_host_builtins_probe
+echo "[compiler-gate] wasm-gc host builtins ok (linear + gc, =10101010; readdir still loud)"
+
 # #1295: String is a packed fat pointer, so the gc EForIn lowering must
 # normalize it to character codes before its shared Array iteration loop.
 echo "[compiler-gate] wasm-gc String for-in"


### PR DESCRIPTION
gc レーンでこの 5 つは `unknown constructor or function` だったので、使うプログラムは gc でコンパイルできませんでした。#1815 で host ABI を宣言するようになり、**素の import 追加だけで linear と一致する**ようになったので入れます。

## #1815 の効果

同じ import 追加パッチを #1815 の前後で測ると、判定がひっくり返ります。

| | #1815 前の実測 | #1815 後 |
|---|---|---|
| `Fs::remove` | 黙って何も削除しない | ✅ 一致 |
| `Fs::is_dir` / `is_file` | 否定ケースで食い違い | ✅ 肯定・否定とも一致 |
| `Fs::rename` | 一致 | ✅ 一致 |
| `Stdout::write_stream` | 一致 | ✅ 一致 |
| `Stdin::read_char` | `-4` (linear は `-1`) | ✅ 一致 |
| `Stdin::read_stream` | `65537` | ✅ 一致 |
| `Fs::readdir` | `1627389952` | ❌ 空配列 |

#1814 で「結果変換層が要る」と書いた 6 個のうち 5 個は、**ABI 宣言が無かっただけ**でした。

## 入れなかった 2 種類と、その理由

**`Fs::readdir`** は本当に呼び出し面の lowering が要ります。`Array[String]` を返し、linear は raw import の上に lowering を持っています (`RAW half of Fs::readdir -- compile_call lowers the surface`)。import だけ足すと gc は**空配列**を返します (実測: linear 3 件、gc 0 件) — silently-wrong を 1 つ増やすことになるので入れていません。

代わりに gate 節へ「**`readdir` が gc で大声で失敗し続けること**」の検査を置きました。lowering が入った瞬間に落ちるので、そのとき linear と突き合わせて検証するよう促せます。

**`Stdin::read_char` / `read_stream`** は配線が他の 5 つと同一で linear とも一致しますが、**この harness では linear にも stdin が届かず両方 EOF を返します**。「何も起きていない値どうしの一致」は何も証明していないので外しました。EOF でしか検証していない配線を通すのは、silently-wrong な builtin が入る経路そのものです。

## 配線は 4 箇所で、1 つ忘れると黙って壊れる

`use_host` / `host_defs` / `host_imports` に追記し、**`hbo`** (それらの絶対インデックスが相対する個数) を動かします。

`hbo` を動かし忘れた最初のビルドは**どのモジュールも validate しませんでした** (`not enough arguments on the stack for call`) — 生成関数のインデックスが全部低いままを指すためです。4 箇所であることをコメントに明記しました。インデックスは末尾追加のみで、既存の 1..11 は動かしていません。

## fixture は全て肯定・否定の対

#1814 の誤復号下ではこれらの builtin は**肯定ケースで linear と一致し否定ケースで食い違って**いました。片側だけの fixture はバグ期間中ずっと緑のままです。実際、調査中に `Fs::is_dir` / `is_file` を肯定だけ見て「通った」と判定しかけました。

- **`is_file` の否定はディレクトリ** (存在しないパスではない) — 「存在するものは何でも true」型の誤りを missing-path 検査は素通しします
- **`remove` は操作の前後を観測** — 黙って何もしない実装が見えます。#1814 以前の実際の壊れ方で、ホストが `fs.rmSync(.., { force: true })` でエラーを飲むため成功に見えていました
- **`rename` は両端** — 宛先の出現と元の消失。コピーとして lower された実装は宛先だけの検査を通ります

## gate 節 40h-5

実行時に `VIBE_IMPORT_ABI` を渡しません (40h-4 と同じ理由 — モジュール自身の宣言を検査しているため)。**両レーンの一致と値そのもの (`=10101010`) の両方**を見ます。一致だけでは両レーンが同じように壊れた場合を素通しし、値だけでは gc が linear からずれたことを言えません。

## 検証

```
RED   (import 追加前 gc) GC codegen: unknown constructor or function: Fs::is_dir
GREEN (追加後 gc)        gc-host-builtins:10101010
GREEN (追加後 linear)    gc-host-builtins:10101010
```

- `compiler_gate.sh` — **GATE=0**、節 40h-5 の実行をログ行で確認 (`wasm-gc host builtins ok (linear + gc, =10101010; readdir still loud)`)
- `unit_test_runner.sh` — **UNIT=0**、640/640
- `pkf run pre-commit` — 通過 (`--no-verify` なし)
- 既存 builtin (`Env::get` / `Fs::read_file`) と pure モジュールの import-free 性が無変化であることを確認 (`hbo` 変更の回帰ガード)
- 最新 main (#1818 マージ後) に載せ替えて再実測し、両レーン一致を再確認

## #1262 の現在地

| 項目 | 状態 |
|---|---|
| 入力の形 (flat source) | ✅ |
| 型検査 (5.2 MB 全体) | ✅ |
| クロージャ捕獲 | ✅ #1809 |
| host ABI 宣言 | ✅ #1815 |
| host builtin | 🟡 本 PR で 5 個。`readdir` + stdin 2 個が残 |
| region lowering (`__region_run`) | ❌ |
| `selfbuild_compile_stage2` の backend 分岐 | ❌ |

---
_Generated by [Claude Code](https://claude.ai/code/session_017BFSjod7HAW2L3GySW81Pi)_