### PR TITLE
bootstrap: bump seed to mutlist-get-2026-08-15

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "zero-alloc-directive-2026-08-15",
-    "tag": "seed/zero-alloc-directive-2026-08-15",
-    "source_commit": "32cdab5e1b4cd6aedb3a5aed9937c8938e2fbb25",
+    "name": "mutlist-get-2026-08-15",
+    "tag": "seed/mutlist-get-2026-08-15",
+    "source_commit": "4f02d2e061f871399bfad063ae5d8757e6db1bad",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "89446ac143934ce0d6675cb7d099d14922196d9415792e77cad36017818b57f9"
+      "sha256": "b0f5f7ec8af12f44923e3e4ad32d055161a59fe70b53cb51f9eb5398bb03eca4"
     },
     "runtime": {
       "runner": "moonrun",


### PR DESCRIPTION
## Summary

Bump the pinned seed to `mutlist-get-2026-08-15`, built from source commit `4f02d2e061f871399bfad063ae5d8757e6db1bad` (the post-#1820 fixpoint), so compiler source can use `MutList::get` / `MutList::length`.

- Published release: `seed/mutlist-get-2026-08-15`
- Published target/source commit: `4f02d2e061f871399bfad063ae5d8757e6db1bad`
- wasm sha256: `b0f5f7ec8af12f44923e3e4ad32d055161a59fe70b53cb51f9eb5398bb03eca4`
- `ensure_seed.sh` fetch + manifest/sha verification: green
- latest-main rebase + stage0 → stage1 → stage2 generation: green
- precommit and diff check: green

The release workflow used `source_ref=prior_seed_ref=4f02d2e...`. Using the seed-bump PR head as `source_ref` would have published a manifest whose source commit disagreed with `bootstrap/seed.json`.

## Next (separate PR)

Migrate consume-in-region worklists in compiler source to `region` + `MutList` with KPI measurements. Candidates: checker effect worklists, Perceus scratch arrays, and DCE reachability queues.