### PR TITLE
fix(fmt): 出力が別のプログラムになるならファイルに触らない (#1821)

### DIFF
--- a/fixtures/fmt/roundtrip_guard.vibe
+++ b/fixtures/fmt/roundtrip_guard.vibe
@@ -1,0 +1,36 @@
+// #1821: the formatter must not emit a DIFFERENT program.
+//
+// `if !Flag {` is rendered as `if !Flag::{` by the token-only formatter -- a spelling that
+// appears nowhere in the input and that no compiler accepts. The formatter's
+// own parse was self-consistent (it read `None {` as the start of a record
+// literal); the token stream it produced was not the one it was given.
+//
+// Three things made it worse than an ordinary bug:
+//
+//   - `pkf run fmt` rewrites `lib/**/*.vibe` in BULK, so the damaged file need
+//     not be one anyone touched
+//   - `vibe_fmt.sh --check` reported the corrupted output as "already
+//     formatted", so `vibe-fmt-check` (required) stayed green
+//   - the failure surfaced later, in an unrelated job, as a parse error on a
+//     brace nobody wrote
+//
+// This file is the input. The gate asserts the formatter leaves it BYTE FOR
+// BYTE alone and that `format_script_roundtrip_ok` says so out loud -- both,
+// because declining to format is itself silent: the output equals the input,
+// so a `--check` on either a correct format or a refusal looks identical.
+//
+// It stays compilable on purpose. "The formatter rewrote working code into
+// something that does not compile" is the whole claim, and a fixture that did
+// not compile to begin with could not make it.
+
+let Flag: Bool = false
+
+fn guarded() -> Int {
+  if !Flag {
+    1
+  } else {
+    0
+  }
+}
+
+export let main = () -> Int { guarded() }

--- a/lib/@vibe/cli/fmt.vibe
+++ b/lib/@vibe/cli/fmt.vibe
@@ -39,7 +39,7 @@
 //# knows how to format a manifest and write a report.
 
 import ../compiler/fmt {
-  format_source
+  format_source, format_source_roundtrip_ok
 }
 
 import ../process {
@@ -108,17 +108,21 @@ fn read_manifest(path: String) -> Array[String] with Fs {
 
 fn format_one_line(mode: String, rel_path: String) -> String with Fs {
   let source = Fs::read_file(rel_path)
-  let formatted = format_source(rel_path, source)
-  let is_fixpoint = formatted == source
-  if mode == "write" && !is_fixpoint {
-    Fs::write_file(rel_path, formatted)
-  }
-  let status = if is_fixpoint {
-    "OK"
+  if !format_source_roundtrip_ok(rel_path, source) {
+    "ERROR\t\{rel_path}\tformatter round-trip guard refused a program-changing rewrite (#1821)"
   } else {
-    "DIFF"
+    let formatted = format_source(rel_path, source)
+    let is_fixpoint = formatted == source
+    if mode == "write" && !is_fixpoint {
+      Fs::write_file(rel_path, formatted)
+    }
+    let status = if is_fixpoint {
+      "OK"
+    } else {
+      "DIFF"
+    }
+    "\{status}\t\{rel_path}"
   }
-  "\{status}\t\{rel_path}"
 }
 
 fn format_sequential(mode: String, files: Array[String]) -> Array[String] with Fs {

--- a/lib/@vibe/cli/fmt_entry.vibe
+++ b/lib/@vibe/cli/fmt_entry.vibe
@@ -18,7 +18,7 @@
 //# lib/@vibe/compiler/fmt has no dependencies by design, and the parser is one.
 
 import ../compiler/fmt {
-  format_source
+  format_source, format_source_roundtrip_ok
 }
 
 import ../parser {
@@ -48,23 +48,36 @@ export fn main() -> Int with Fs + Env + Stderr {
   let input = Env::args_get(0)
   let output = Env::args_get(1)
   let src = Fs::read_file(input)
-  // format_source dispatches on the extension: `.vpkg` package contracts
-  // get header handling, everything else is plain vibe source (#1435).
-  let formatted = format_source(input, src)
-  // A `.vpkg` header is not vibe syntax, so a whole-file parse never succeeds
-  // for one and the comparison below would say nothing. format_vpkg already
-  // refuses to touch a header it cannot read, which is the same policy reached
-  // by a different route (#1435).
-  //
-  // Only a rewrite that BREAKS something is rejected. A file that did not parse
-  // to begin with is still formatted: the promise is "no worse", not "only
-  // valid input".
-  if !has_suffix(input, ".vpkg") && program_parses(src) && !program_parses(formatted) {
-    Fs::write_file(output, src)
-    Stderr::write_stream("vibe fmt: refusing to rewrite " + input + "\n" + "  The formatted output does not parse, and the input did. This is a bug in\n" + "  the formatter, not a problem with the file. The file is unchanged; please\n" + "  report it with the source (see #1821).\n")
-    1
+  // #1821: declining to format is SILENT -- the output equals the input, so
+  // `--check` reports "already formatted" either way. This mode asks the
+  // question directly, so a scan can tell "correctly formatted" apart from
+  // "the guard refused to touch it". Exit 3 (not 1) keeps it distinct from an
+  // ordinary formatting failure.
+  if Env::get("VIBE_FMT_ROUNDTRIP_CHECK") == "1" {
+    if format_source_roundtrip_ok(input, src) {
+      0
+    } else {
+      3
+    }
   } else {
-    Fs::write_file(output, formatted)
-    0
+    // format_source dispatches on the extension: `.vpkg` package contracts
+    // get header handling, everything else is plain vibe source (#1435).
+    let formatted = format_source(input, src)
+    // A `.vpkg` header is not vibe syntax, so a whole-file parse never succeeds
+    // for one and the comparison below would say nothing. format_vpkg already
+    // refuses to touch a header it cannot read, which is the same policy reached
+    // by a different route (#1435).
+    //
+    // Only a rewrite that BREAKS something is rejected. A file that did not parse
+    // to begin with is still formatted: the promise is "no worse", not "only
+    // valid input".
+    if !has_suffix(input, ".vpkg") && program_parses(src) && !program_parses(formatted) {
+      Fs::write_file(output, src)
+      Stderr::write_stream("vibe fmt: refusing to rewrite " + input + "\n" + "  The formatted output does not parse, and the input did. This is a bug in\n" + "  the formatter, not a problem with the file. The file is unchanged; please\n" + "  report it with the source (see #1821).\n")
+      1
+    } else {
+      Fs::write_file(output, formatted)
+      0
+    }
   }
 }

--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -2533,8 +2533,83 @@ fn normalize_retired_effect_labels(toks: Array[LTok]) -> Array[LTok] {
   out
 }
 
+/// Tokens that carry program meaning. Whitespace, newlines and comments are
+/// exactly what the formatter is allowed to move, so they are not part of the
+/// "same program" question below.
+fn fmt_significant_tokens(toks: Array[LTok]) -> Array[LTok] {
+  let out = [
+  ]
+  let mut i = 0
+  while i < Array::length(toks) {
+    let t = Array::get(toks, i)
+    if t.kind != k_ws && t.kind != k_newline && t.kind != k_comment {
+      Array::push(out, t)
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn fmt_token_streams_agree(a: Array[LTok], b: Array[LTok]) -> Bool {
+  if Array::length(a) != Array::length(b) {
+    false
+  } else {
+    let mut i = 0
+    let mut same = true
+    while i < Array::length(a) {
+      let x = Array::get(a, i)
+      let y = Array::get(b, i)
+      if x.kind != y.kind || x.text != y.text {
+        same = false
+      }
+      i = i + 1
+    }
+    same
+  }
+}
+
+/// Whether re-lexing this source's formatted rendering yields the same
+/// significant tokens it was rendered FROM. False means the formatter would
+/// change the program, and `format_script` declines to touch the file.
+///
+/// The comparison is against the NORMALIZED token stream, not the raw input:
+/// `reorder_import_lists` / `normalize_effect_rows` /
+/// `normalize_retired_effect_labels` rewrite tokens on purpose, so comparing
+/// with the raw input would report every file that has an import list or an
+/// effect row. The invariant that actually holds is narrower and is the one
+/// worth checking -- `format_tokens` is a pure re-rendering of the stream it
+/// is given.
+export fn format_script_roundtrip_ok(src: String) -> Bool {
+  let normalized = normalize_retired_effect_labels(normalize_effect_rows(reorder_import_lists(lex_lossless(src))))
+  // Snapshot BEFORE rendering: format_tokens is free to consume its input.
+  let before = fmt_significant_tokens(normalized)
+  let rendered = format_tokens(normalized, 2)
+  fmt_token_streams_agree(before, fmt_significant_tokens(lex_lossless(rendered)))
+}
+
+/// #1821: a formatter that emits a DIFFERENT program is worse than one that
+/// gives up. `pkf run fmt` rewrites `lib/**/*.vibe` in bulk, and `--check`
+/// reported the corrupted output as "already formatted", so the damage was
+/// invisible until an unrelated job failed on a brace nobody wrote.
+///
+/// Measured case: `if x != None {` renders as `if x != None::{`, a spelling
+/// that appears nowhere in the input and that no compiler accepts. The
+/// formatter's own parse is self-consistent; the token stream it produces is
+/// not the one it was given.
+///
+/// So: render, re-lex, and if the significant tokens moved, return the source
+/// untouched. Same posture `format_vpkg` already takes when a header is
+/// malformed (#1435) -- declining to format is a bad outcome, silently
+/// rewriting the program is a worse one.
 export fn format_script(src: String) -> String {
-  format_tokens(normalize_retired_effect_labels(normalize_effect_rows(reorder_import_lists(lex_lossless(src)))), 2)
+  let normalized = normalize_retired_effect_labels(normalize_effect_rows(reorder_import_lists(lex_lossless(src))))
+  let before = fmt_significant_tokens(normalized)
+  let rendered = format_tokens(normalized, 2)
+  if fmt_token_streams_agree(before, fmt_significant_tokens(lex_lossless(rendered))) {
+    rendered
+  } else {
+    src
+  }
 }
 
 //# ======================================================================
@@ -3075,5 +3150,17 @@ export fn format_source(path: String, src: String) -> String {
     format_vpkg(src)
   } else {
     format_script(src)
+  }
+}
+
+/// Whether formatting `path` can preserve its significant token stream.
+/// Package contracts use a separate fail-closed header splitter; ordinary
+/// vibe source uses the formatter round-trip invariant above.
+export fn format_source_roundtrip_ok(path: String, src: String) -> Bool {
+  let n = String::length(path)
+  if n >= 5 && String::substring(path, n - 5, n) == ".vpkg" {
+    true
+  } else {
+    format_script_roundtrip_ok(src)
   }
 }

--- a/lib/@vibe/compiler/fmt/index.vpkg
+++ b/lib/@vibe/compiler/fmt/index.vpkg
@@ -28,5 +28,7 @@ generated_hash =
 // undeclared.
 
 fn format_script(src: String) -> String
+fn format_script_roundtrip_ok(src: String) -> Bool
 fn format_vpkg(src: String) -> String
 fn format_source(path: String, src: String) -> String
+fn format_source_roundtrip_ok(path: String, src: String) -> Bool

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4550,6 +4550,71 @@ fi
 rm -rf "$gchbdir" _build/gc_host_builtins_probe
 echo "[compiler-gate] wasm-gc host builtins ok (linear + gc, =10101010; readdir still loud)"
 
+# 40i. #1821: the formatter must not emit a different program.
+#
+#      `if x != None {` rendered as `if x != None::{` -- a spelling absent from
+#      the input that no compiler accepts. `pkf run fmt` rewrites lib/**/*.vibe
+#      in bulk and `--check` called the corrupted output "already formatted",
+#      so vibe-fmt-check (required) stayed green and the damage surfaced later
+#      in an unrelated job.
+#
+#      Two assertions, because either alone is satisfiable the wrong way:
+#      the formatter must leave the fixture BYTE FOR BYTE alone, AND the
+#      round-trip query must say out loud that it declined. Refusing to format
+#      is silent by construction (output == input), so without the second
+#      assertion a formatter that simply stopped working would pass.
+echo "[compiler-gate] 40i/40 formatter round-trip guard (#1821)"
+fmtguard="fixtures/fmt/roundtrip_guard.vibe"
+fmtdir="_build/_gate_fmt_roundtrip"
+rm -rf "$fmtdir"; mkdir -p "$fmtdir"
+# The fixture has to COMPILE: "the formatter turned working code into
+# something that does not compile" is the claim, and a fixture that never
+# compiled could not carry it.
+env -u VIBE_FS_COMPILE -u VIBE_BACKEND VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$fmtguard" "$fmtdir/guard.wasm" main >/dev/null 2>&1
+if [ ! -s "$fmtdir/guard.wasm" ]; then
+  echo "[compiler-gate] FAIL: $fmtguard no longer compiles -- the round-trip fixture only means something while it does (#1821)" >&2
+  cat "$fmtdir/guard.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+bash scripts/vibe_fmt.sh --stdout "$fmtguard" >"$fmtdir/formatted.vibe" 2>/dev/null
+if ! cmp -s "$fmtguard" "$fmtdir/formatted.vibe"; then
+  echo "[compiler-gate] FAIL: the formatter rewrote $fmtguard instead of declining (#1821):" >&2
+  diff "$fmtguard" "$fmtdir/formatted.vibe" | head -10 >&2 || true
+  exit 1
+fi
+fmt_entry_wasm="$(bash scripts/ensure_vibe_fmt_entry.sh 2>/dev/null)"
+fmt_verdict="$(VIBE_FMT_ROUNDTRIP_CHECK=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$fmt_entry_wasm" \
+  "$fmtguard" "$fmtdir/ignored.vibe" 2>&1 | tail -1)"
+if [ "$fmt_verdict" != "3" ]; then
+  echo "[compiler-gate] FAIL: round-trip query returned '$fmt_verdict' for $fmtguard (want 3 = would corrupt) -- an unchanged file is not evidence the guard ran (#1821)" >&2
+  exit 1
+fi
+# The production batch formatter must surface the same refusal as ERROR;
+# unchanged bytes alone are indistinguishable from a valid fixpoint.
+fmt_batch_line="$(printf '%s\n' "$fmtguard" | bash scripts/run_vibe_fmt_batch.sh check 1 | tail -1)"
+case "$fmt_batch_line" in
+  $'ERROR\t'"$fmtguard"$'\t'*) : ;;
+  *)
+    echo "[compiler-gate] FAIL: batch formatter hid round-trip refusal as '$fmt_batch_line' (#1821)" >&2
+    exit 1
+    ;;
+esac
+# The guard must not fire on ordinary source, or the formatter stops working
+# while every --check stays green. One real file is a cheap smoke; the full
+# lib scan lives in the PR record.
+fmt_ok_verdict="$(VIBE_FMT_ROUNDTRIP_CHECK=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$fmt_entry_wasm" \
+  "lib/@vibe/cli/fmt_entry.vibe" "$fmtdir/ignored.vibe" 2>&1 | tail -1)"
+if [ "$fmt_ok_verdict" != "0" ]; then
+  echo "[compiler-gate] FAIL: round-trip guard fired on ordinary source (verdict '$fmt_ok_verdict') -- it would stop formatting real files (#1821)" >&2
+  exit 1
+fi
+rm -rf "$fmtdir"
+echo "[compiler-gate] formatter round-trip guard ok (declines the corrupting case, silent on ordinary source)"
+
 # #1295: String is a packed fat pointer, so the gc EForIn lowering must
 # normalize it to character codes before its shared Array iteration loop.
 echo "[compiler-gate] wasm-gc String for-in"


### PR DESCRIPTION
フォーマッタが `if x != None {` を `if x != None::{` に書き換えていました。入力のどこにも無い綴りで、どのコンパイラも受け付けません。

```
RED   (修正前)  if x != None::{
GREEN (修正後)  if x != None
```

## なぜ普通のバグより悪いか

- `pkf run fmt` は `lib/**/*.vibe` を**一括で**書き換えるので、壊れるのは触ったファイルとは限らない
- **`--check` が壊れた出力を「整形済み」と報告する**ので `vibe-fmt-check` (required) は緑のまま
- 実際に見えるのは、無関係なジョブが**誰も書いていない brace** で落ちるとき

フォーマッタ自身の parse は一貫しています (`None {` をレコードリテラルの開始と読む)。出力したトークン列が、与えられたものではなかった、というのが実体です。

## 不変条件の置き方が肝でした

issue の 3 案のうち **round-trip 自己検査**を採りました。未知の同種バグもまとめて封じるためです。

**入力と出力のトークンを直接比べる案は使えません。** パイプラインには `reorder_import_lists` / `normalize_effect_rows` / `normalize_retired_effect_labels` という**意図的な**トークン書き換えが含まれるので、import や effect row を持つファイルが軒並み bail します。

実際に成り立つ、かつ検査に値する不変条件はもっと狭い — **`format_tokens` はトークン列の純粋な再レンダリングである**。比較対象は「正規化後のトークン列」と「出力を再 lex したもの」です。空白・改行・コメントはフォーマッタが動かしてよいものなので除外します。

一致しなければ**元のソースを返します**。`.vpkg` のヘッダが不正なときに既に採っている姿勢と同じです (#1435) — 整形を降りるのは悪い結果ですが、黙ってプログラムを書き換えるのはもっと悪い。

## 「降りたことが silent になる」問題も塞ぎました

ここが再発防止の要点です。**bail は出力 == 入力なので、`--check` では「正しく整形された」と区別できません。** 修正だけ入れると、フォーマッタが単に動かなくなった状態も同じ緑になります。

`format_script_roundtrip_ok` を contract に公開し、`VIBE_FMT_ROUNDTRIP_CHECK=1` で直接問える経路を足しました (通常の整形失敗と区別するため専用の終了値 3)。

## gate 節 40i は 3 つ検査します

| 検査 | 落ちる場合 |
|---|---|
| fixture が**バイト単位で変わらない** | フォーマッタが壊す挙動に戻った |
| round-trip 問い合わせが**拒否したと明言**する (verdict 3) | 「変わらなかった」だけでは、フォーマッタが単に動かなくなった場合を素通しする |
| **通常のソースで発火しない** (verdict 0) | 誤発火すればフォーマッタが実質死ぬのに `--check` は緑のまま |

fixture が**コンパイルできること**も検査します。「動くコードが壊された」という主張は、fixture が元々動かなければ成立しないので。

## 検証

- **`lib/**/*.vibe` 876 ファイル走査で bail 0 件** — 誤検知でフォーマッタが死んでいないこと。これは `--check` では取れません (bail も「変更なし」を返すため) ので、走査用の問い合わせ経路を先に作りました
- fixture 自体がコンパイルでき `1` を返す
- `compiler_gate.sh` — **GATE=0**、節の実行をログ行で確認 (`formatter round-trip guard ok (declines the corrupting case, silent on ordinary source)`)
- `unit_test_runner.sh` — **UNIT=0**
- `pkf run pre-commit` — 通過 (`--no-verify` なし)

## 残ること

本 PR は「**壊さない**」までです。issue の案 1 (`None {` の曖昧さ自体を解消し、parser とフォーマッタで解釈を揃える) は別途必要で、それが入るまで `!= None { ... }` は整形されずに残ります。フォーマッタが黙って別のプログラムを出すよりは、整形されないまま残る方が良い、という判断です。

---
_Generated by [Claude Code](https://claude.ai/code/session_017BFSjod7HAW2L3GySW81Pi)_