### PR TITLE
perf(perceus): region + MutList worklist in tail_is_borrow_ret_safe (−19.9MB selfcompile heap)

### DIFF
--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -404,93 +404,98 @@ fn is_borrow_ret_fname(ctx: PCtx, fname: String) -> Bool {
 /// form only after confirming compute_borrow_returning_names_test.vibe (or an
 /// equivalent derive(Ord) regression) still passes.
 fn tail_is_borrow_ret_safe(known: Array[String], e0: Expr) -> Bool {
-  let worklist = [
-    e0
-  ]
-  let mut all_safe = true
-  let mut i = 0
-  while i < Array::length(worklist) {
-    match Array::get(worklist, i) {
-      ELet(_, _, b, _) => Array::push(worklist, b),
-      ELetMut(_, _, b, _) => Array::push(worklist, b),
-      ELetRec(_, _, b) => Array::push(worklist, b),
-      ESeq(_, b) => Array::push(worklist, b),
-      EAssign(_, _, b) => Array::push(worklist, b),
-      EAssignOp(_, _, _, b) => Array::push(worklist, b),
-      EIf(_, t, el) => {
-        Array::push(worklist, t)
-        Array::push(worklist, el)
-      },
-      EMatch(_, arms) => {
-        let mut ai = 0
-        while ai < Array::length(arms) {
-          let (_p, ae) = Array::get(arms, ai)
-          Array::push(worklist, ae)
-          ai = ai + 1
-        }
-      },
-      ECall(callee_e, cargs, _) =>
-      match callee_e {
-        EIdent(callee, _) =>
-        if callee == "perform" && Array::length(cargs) == 1 {
-          // #640 Stage 2: `throw(x)` now parses to `perform Exception::Throw(x)`,
-          // so the #715 throwing-tail exemption below (EThrow) must also
-          // recognize this shape — a throwing tail never produces a value, so
-          // it cannot violate the borrow-returning invariant. Without this,
-          // every `match x { Ctor(..) => field, _ => throw(..) }` accessor is
-          // again rejected as borrow-returning and the #715 same-address
-          // double-free returns. Matched step-by-step (NOT one nested
-          // ECall(EIdent(..)) pattern) per the workaround note above.
-          let mut op_is_throw = false
-          match Array::get(cargs, 0) {
-            ECall(op_e, _, _) =>
-            match op_e {
-              EIdent(op_n, _) => if is_exception_throw_operation(op_n) {
-                op_is_throw = true
-              } else {
-                ()
+  // ADR-0090 / #1770: the worklist grows while being consumed in-place and
+  // only the Bool verdict escapes, so its growth garbage goes to the region
+  // arena (MutList) instead of the main heap. Bump lane only; under RC the
+  // list degrades to a plain main-heap array with the same semantics.
+  region r {
+    let worklist = MutList::empty(r)
+    MutList::push(worklist, e0)
+    let mut all_safe = true
+    let mut i = 0
+    while i < MutList::length(worklist) {
+      match MutList::get(worklist, i) {
+        ELet(_, _, b, _) => MutList::push(worklist, b),
+        ELetMut(_, _, b, _) => MutList::push(worklist, b),
+        ELetRec(_, _, b) => MutList::push(worklist, b),
+        ESeq(_, b) => MutList::push(worklist, b),
+        EAssign(_, _, b) => MutList::push(worklist, b),
+        EAssignOp(_, _, _, b) => MutList::push(worklist, b),
+        EIf(_, t, el) => {
+          MutList::push(worklist, t)
+          MutList::push(worklist, el)
+        },
+        EMatch(_, arms) => {
+          let mut ai = 0
+          while ai < Array::length(arms) {
+            let (_p, ae) = Array::get(arms, ai)
+            MutList::push(worklist, ae)
+            ai = ai + 1
+          }
+        },
+        ECall(callee_e, cargs, _) =>
+        match callee_e {
+          EIdent(callee, _) =>
+          if callee == "perform" && Array::length(cargs) == 1 {
+            // #640 Stage 2: `throw(x)` now parses to `perform Exception::Throw(x)`,
+            // so the #715 throwing-tail exemption below (EThrow) must also
+            // recognize this shape — a throwing tail never produces a value, so
+            // it cannot violate the borrow-returning invariant. Without this,
+            // every `match x { Ctor(..) => field, _ => throw(..) }` accessor is
+            // again rejected as borrow-returning and the #715 same-address
+            // double-free returns. Matched step-by-step (NOT one nested
+            // ECall(EIdent(..)) pattern) per the workaround note above.
+            let mut op_is_throw = false
+            match Array::get(cargs, 0) {
+              ECall(op_e, _, _) =>
+              match op_e {
+                EIdent(op_n, _) => if is_exception_throw_operation(op_n) {
+                  op_is_throw = true
+                } else {
+                  ()
+                },
+                _ => ()
               },
               _ => ()
-            },
-            _ => ()
-          }
-          if op_is_throw {
-            ()
+            }
+            if op_is_throw {
+              ()
+            } else if !array_contains_str_pctx(known, callee) {
+              all_safe = false
+            } else {
+              ()
+            }
           } else if !array_contains_str_pctx(known, callee) {
             all_safe = false
           } else {
             ()
+          },
+          _ => {
+            all_safe = false
           }
-        } else if !array_contains_str_pctx(known, callee) {
-          all_safe = false
-        } else {
-          ()
         },
+        EIdent(_, _) => (),
+        // #715: a throwing tail (the ubiquitous `match x { Ctor(..) => field, _
+        // => throw("not X") }` shape used by every common_extractors.vibe
+        // accessor) never actually produces a value along that path, so it
+        // cannot violate the borrow-returning invariant -- there is nothing to
+        // mismanage. Without this, EVERY such accessor (get_efn_params,
+        // get_efn_body, get_ecall_args, ...) fell through to the catch-all
+        // below and was rejected solely because of its own error arm, even
+        // though its real (non-throwing) arm is a plain borrowed field
+        // projection. That misclassification made the caller treat the
+        // extracted field as an independently owned value while the
+        // scrutinee's own later structural drop also reclaims it -- a
+        // same-address double-free (the #715 self-hosting free-list
+        // corruption).
         _ => {
           all_safe = false
         }
-      },
-      EIdent(_, _) => (),
-      // #715: a throwing tail (the ubiquitous `match x { Ctor(..) => field, _
-      // => throw("not X") }` shape used by every common_extractors.vibe
-      // accessor) never actually produces a value along that path, so it
-      // cannot violate the borrow-returning invariant -- there is nothing to
-      // mismanage. Without this, EVERY such accessor (get_efn_params,
-      // get_efn_body, get_ecall_args, ...) fell through to the catch-all
-      // below and was rejected solely because of its own error arm, even
-      // though its real (non-throwing) arm is a plain borrowed field
-      // projection. That misclassification made the caller treat the
-      // extracted field as an independently owned value while the
-      // scrutinee's own later structural drop also reclaims it -- a
-      // same-address double-free (the #715 self-hosting free-list
-      // corruption).
-      _ => {
-        all_safe = false
       }
+      i = i + 1
     }
-    i = i + 1
+    all_safe
   }
-  all_safe
 }
 
 /// Strip let/seq/assign wrappers, same as tail_is_borrow_ret_safe, to find the


### PR DESCRIPTION
## Summary

First compiler-source application of the `MutList::get/length` in-region reads that landed in #1820 (seed: #1825). `tail_is_borrow_ret_safe`'s worklist grows while being consumed in-place and only the `Bool` verdict escapes — exactly the consume-in-region shape identified as "arena is pure profit" after #1794's rejection. The local `Array` worklist becomes a region-scoped `MutList`, moving its growth garbage off the main heap.

## Measurement (deterministic)

| metric | main | this PR | Δ |
|---|---:|---:|---|
| selfcompile heap_ptr_bytes | 1,031,605,976 | 1,011,695,232 | **−19,910,744 (−1.93%)** |

Measured with `scripts/selfcompile_kpi.sh` on a seed-built stage2; ~4× the func_buf pilot (#1816, −5.2MB). The CI perf report should confirm the same number.

## Safety notes

- The function's doc comment documents two load-bearing shape workarounds (iterative walk instead of `let rec`; step-by-step `ECall` → `EIdent` matching) tied to a derive(Ord)-triggered codegen trap. Both are preserved — only the container type changed.
- derive(Ord)/Show `compare`/`to_string` probed through the migrated compiler under both `VIBE_RC=1` and `VIBE_RC=0` (correct results in both).
- `MutList::get` borrow-return semantics under RC are the exact thing #1820's review round fixed and the gate now pins under both RC modes (`fixtures/region_ok_consume_in_region.vibe`).
- `vibe check` clean; fmt fixpoint; full `scripts/compiler_gate.sh` run locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_