### PR TITLE
feat(parser): mint atomic binder authority

### DIFF
--- a/fixtures/parser_binder_authority_test.vibe
+++ b/fixtures/parser_binder_authority_test.vibe
@@ -1,0 +1,371 @@
+//# Imports
+
+import ../lib/@vibe/parser {
+  SourceBinder,
+  binder_capture_context,
+  binder_capture_source,
+  located_program_binder_authority_program,
+  located_program_binder_authority_rows,
+  parse_source_located_with_binder_authority,
+  validate_program_binder_rows
+}
+
+//# Tests
+
+test "source-owning binder authority publishes exact supported rows" {
+  let source = "let f = (x) -> { x }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "2")
+      match Array::get(rows, 0) {
+        SourceToken(name, start, end) => {
+          inspect(name, "f")
+          inspect(String::substring(source, start, end), "f")
+        },
+        _ => inspect(false, "true")
+      }
+      match Array::get(rows, 1) {
+        SourceToken(name, start, end) => {
+          inspect(name, "x")
+          inspect(String::substring(source, start, end), "x")
+        },
+        _ => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "binder spans are UTF-8 byte offsets and shadowing rows stay distinct" {
+  let source = "let x = \"é\"\nlet x = 2"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "2")
+      match (Array::get(rows, 0), Array::get(rows, 1)) {
+        (SourceToken(left, ls, le), SourceToken(right, rs, re)) => {
+          inspect(left, "x")
+          inspect(right, "x")
+          inspect(ls != rs, "true")
+          inspect(String::substring(source, ls, le), "x")
+          inspect(String::substring(source, rs, re), "x")
+        },
+        _ => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "supported declaration and import rows publish in final AST order" {
+  let source = "import ./dep.vibe { Thing as Local }\ntype Box[T] = T\neffectset Audit = { Log }\nresource Posts : S3::Bucket\nextern let %read_file: (String) -> String"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "6")
+      let expected = [
+        "Local",
+        "Box",
+        "T",
+        "Audit",
+        "Posts",
+        "%read_file"
+      ]
+      let mut i = 0
+      while i < Array::length(rows) {
+        match Array::get(rows, i) {
+          SourceToken(name, _, _) => inspect(name == Array::get(expected, i), "true"),
+          _ => inspect(false, "true")
+        }
+        i = i + 1
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "interpolation binder spans remain absolute source bytes" {
+  let source = "let f = (x) -> { \"é=\\{((y) -> { y })(x)}\" }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      match Array::get(rows, 2) {
+        SourceToken(name, start, end) => {
+          inspect(name, "y")
+          inspect(String::substring(source, start, end), "y")
+          inspect(start > 20, "true")
+        },
+        _ => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "unsupported and forged lanes fail closed" {
+  let unsupported = [
+    "struct Cell { value: Int }"
+  ]
+  for source in unsupported {
+    inspect(match parse_source_located_with_binder_authority(source) {
+      Some(_) => true,
+      None => false
+    }, "false")
+  }
+  let source = "let x = 1"
+  let forged = binder_capture_context([
+    0
+  ], [
+    99
+  ])
+  binder_capture_source(Some(forged), "x", 0, 0)
+  // The forged context cannot be passed to the source-owning entry.
+  inspect(match parse_source_located_with_binder_authority(source) {
+    Some(_) => true,
+    None => false
+  }, "true")
+}
+
+test "contract rows follow lowered requires result body ensures order" {
+  let source = "fn f(x: Int) -> Int where { requires: ((r) -> { r })(true), ensures: ((e) -> { e })(true) } { ((b) -> { b })(x) }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "6")
+      let expected = [
+        "f",
+        "x",
+        "r",
+        "result",
+        "b",
+        "e"
+      ]
+      let mut i = 0
+      for row in rows {
+        match row {
+          SourceToken(name, start, end) => {
+            inspect(name == Array::get(expected, i), "true")
+            inspect(String::substring(source, start, end), name)
+          },
+          Synthetic(name, _) => {
+            inspect(i, "3")
+            inspect(name, "result")
+          }
+        }
+        i = i + 1
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "block-local nested record destructuring rows mirror every lowered slot" {
+  let source = "let f = () -> { let record { x: a, y: (b, c) } = record { x: 1, y: (2, 3) }; a + b + c }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "6")
+      let expected = [
+        "f",
+        "__rec_destr",
+        "a",
+        "__rec_sub_1",
+        "b",
+        "c"
+      ]
+      let mut i = 0
+      for row in rows {
+        match row {
+          SourceToken(name, start, end) => {
+            inspect(name == Array::get(expected, i), "true")
+            inspect(String::substring(source, start, end), name)
+          },
+          Synthetic(name, _) => inspect(name == Array::get(expected, i), "true")
+        }
+        i = i + 1
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "inactive cfg rollback discards rows and restores eligibility" {
+  let source = "#cfg(dev)\nstruct Hidden { value: Int }\n#cfg(dev)\nlet hidden = (leaked) -> { leaked }\nlet live = (kept) -> { kept }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "2")
+      match (Array::get(rows, 0), Array::get(rows, 1)) {
+        (SourceToken(first, fs, fe), SourceToken(second, ss, se)) => {
+          inspect(first, "live")
+          inspect(second, "kept")
+          inspect(String::substring(source, fs, fe), "live")
+          inspect(String::substring(source, ss, se), "kept")
+        },
+        _ => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "nested top-level destructuring rows name every synthetic slot" {
+  let source = "let ((a, b), c) = ((1, 2), 3)"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "5")
+      let expected = [
+        "__dst0",
+        "__dst0_0",
+        "a",
+        "b",
+        "c"
+      ]
+      let mut i = 0
+      for row in rows {
+        match row {
+          SourceToken(name, start, end) => {
+            inspect(name == Array::get(expected, i), "true")
+            inspect(String::substring(source, start, end), name)
+          },
+          Synthetic(name, _) => inspect(name == Array::get(expected, i), "true")
+        }
+        i = i + 1
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "recursive loop rows include result and continue temporaries" {
+  let source = "let f = () -> { loop (i = 0) { continue(((c) -> { c })(i + 1)) } }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "5")
+      let expected = [
+        "f",
+        "i",
+        "__loop_result",
+        "__lt0",
+        "c"
+      ]
+      let mut i = 0
+      for row in rows {
+        match row {
+          SourceToken(name, start, end) => {
+            inspect(name == Array::get(expected, i), "true")
+            inspect(String::substring(source, start, end), name)
+          },
+          Synthetic(name, _) => inspect(name == Array::get(expected, i), "true")
+        }
+        i = i + 1
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "guarded match rows duplicate the lowered rest exactly" {
+  let source = "fn f(x: Int) -> Int { match x { y if ((g) -> { g })(true) => ((b) -> { b })(y), z => ((r) -> { r })(z) } }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "10")
+      let expected = [
+        "f",
+        "x",
+        "__mg",
+        "y",
+        "g",
+        "b",
+        "z",
+        "r",
+        "z",
+        "r"
+      ]
+      let mut i = 0
+      for row in rows {
+        match row {
+          SourceToken(name, start, end) => {
+            inspect(name == Array::get(expected, i), "true")
+            inspect(String::substring(source, start, end), name)
+          },
+          Synthetic(name, _) => {
+            inspect(i, "2")
+            inspect(name, "__mg")
+          }
+        }
+        i = i + 1
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "placeholder argument segments insert synthetic params before argument binders" {
+  let source = "let f = () -> { Array::map([1], ((q) -> { q })(1) + _) }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      inspect(Array::length(rows), "3")
+      match (Array::get(rows, 1), Array::get(rows, 2)) {
+        (Synthetic(param, _), SourceToken(name, start, end)) => {
+          inspect(param, "__ph0")
+          inspect(name, "q")
+          inspect(String::substring(source, start, end), "q")
+        },
+        _ => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "approved synthetic lowerings publish explicit rows" {
+  let source = "let f = () -> { let x: Int = 1; x }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      let mut synthetic = 0
+      for row in rows {
+        match row {
+          Synthetic(name, _) => {
+            inspect(name, "__asc")
+            synthetic = synthetic + 1
+          },
+          SourceToken(_, start, end) => inspect(start < end, "true")
+        }
+      }
+      inspect(synthetic, "1")
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "validator rejects missing extra reordered and invalid spans" {
+  let source = "let x = 1"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let program = located_program_binder_authority_program(authority)
+      inspect(validate_program_binder_rows(program, [
+      ], source), "false")
+      inspect(validate_program_binder_rows(program, [
+        SourceToken("x", 4, 5),
+        SourceToken("extra", 0, 3)
+      ], source), "false")
+      inspect(validate_program_binder_rows(program, [
+        SourceToken("x", 0, 3)
+      ], source), "false")
+      inspect(validate_program_binder_rows(program, [
+        SourceToken("x", 4, 4)
+      ], source), "false")
+      inspect(validate_program_binder_rows(program, [
+        SourceToken("x", 4, 99)
+      ], source), "false")
+    },
+    None => inspect(false, "true")
+  }
+}

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -8,6 +8,7 @@ vibe_parser	../../../lib/@vibe/parser/float_format.vibe
 vibe_parser	../../../lib/@vibe/parser/lexer.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_base.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_binder_context.vibe
+vibe_parser	../../../lib/@vibe/parser/parser_binder_authority.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_expr_primary.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_expr_core.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_expr_dispatch.vibe

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -80,9 +80,9 @@ test "check_linked_file: comment-only file has nothing to check -- succeeds" {
   assert(rc == 0)
 }
 
-test "parser binder context contract opacity is documentation-only" {
-  let path = "/tmp/vibe_parser_binder_context_private_constructor.vibe"
-  let source = "import @vibe/parser { type ParserBinderContext }\nlet forged: ParserBinderContext = ParserBinderContext::{ nonce: 0 }\n"
+test "parser binder context low-level constructor is public but untrusted" {
+  let path = "/tmp/vibe_parser_binder_context_untrusted_constructor.vibe"
+  let source = "import @vibe/parser { type ParserBinderContext, binder_capture_context }\nlet empty: Array[Int] = []\nlet forged: ParserBinderContext = binder_capture_context(empty, empty)\n"
   Fs::write_bytes(path, string_to_bytes(source))
   let message = handle {
     let _ = check_linked_file(path)
@@ -90,9 +90,8 @@ test "parser binder context contract opacity is documentation-only" {
   } with Exception {
     Throw(error) => error
   }
-  // This is intentionally clean today: `opaque type` does not hide fields.
-  // The context is therefore untrusted and authority-free; the direct parser
-  // contract test proves a forged value cannot change parsing.
+  // This is intentionally clean: the constructor is public cross-file
+  // plumbing, but remains untrusted and cannot publish authority.
   inspect(message, "")
 }
 

--- a/lib/@vibe/compiler/tests/codegen_parser_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_parser_test.vibe
@@ -37,6 +37,7 @@ test "wasi: parser.vibe import - compile and run" {
     "lib/@vibe/parser/lexer.vibe",
     "lib/@vibe/parser/parser_base.vibe",
     "lib/@vibe/parser/parser_binder_context.vibe",
+    "lib/@vibe/parser/parser_binder_authority.vibe",
     "lib/@vibe/parser/parser_expr_primary.vibe",
     "lib/@vibe/parser/parser_expr_core.vibe",
     "lib/@vibe/parser/parser_expr_dispatch.vibe",

--- a/lib/@vibe/compiler/tests/parser_binder_context_contract_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_binder_context_contract_test.vibe
@@ -7,6 +7,7 @@ import @vibe/ast {
 import @vibe/parser {
   type ParserBinderContext,
   Token,
+  binder_capture_context,
   lex_with_offsets,
   parse_impl,
   parse_impl_dispatch,
@@ -35,13 +36,18 @@ fn opaque_context_identity(context: Option[ParserBinderContext]) -> Option[Parse
   context
 }
 
+fn forged_context() -> ParserBinderContext {
+  let empty = Array::slice([
+    0
+  ], 0, 0)
+  binder_capture_context(empty, empty)
+}
+
 fn assert_expression_context_parity(source: String) -> Unit with Exception {
   let (tokens, starts, _) = lex_with_offsets(source)
   let (legacy, legacy_next) = parse_impl(tokens, starts, 0, 0)
   let (none, none_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, None)
-  let forged_context = ParserBinderContext::{
-    nonce: 41
-  }
+  let forged_context = forged_context()
   let (forged, forged_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, Some(forged_context))
   inspect(print_expr(none) == print_expr(legacy), "true")
   inspect(none_next == legacy_next, "true")
@@ -53,9 +59,7 @@ fn assert_statement_context_parity(source: String) -> Unit with Exception {
   let (tokens, starts, _) = lex_with_offsets(source)
   let (legacy, legacy_next) = parse_stmt_preserving(tokens, starts, 0)
   let (none, none_next) = parse_stmt_preserving_with_binder_context(tokens, starts, 0, None)
-  let forged_context = ParserBinderContext::{
-    nonce: 73
-  }
+  let forged_context = forged_context()
   let (forged, forged_next) = parse_stmt_preserving_with_binder_context(tokens, starts, 0, Some(forged_context))
   inspect(print_stmt(none) == print_stmt(legacy), "true")
   inspect(none_next == legacy_next, "true")
@@ -113,9 +117,7 @@ test "parser binder context low-level contract accepts None without changing par
   // Contract opacity is currently documentation-only. Prove this external
   // package can forge the representation, then prove that passing it carries
   // no authority and changes no parse result in this infrastructure phase.
-  let forged_context = ParserBinderContext::{
-    nonce: 0
-  }
+  let forged_context = forged_context()
   let (forged_impl, forged_impl_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, Some(forged_context))
   inspect(print_expr(forged_impl) == print_expr(legacy_impl), "true")
   inspect(forged_impl_next == legacy_impl_next, "true")
@@ -180,9 +182,7 @@ test "parser binder context B2 whole-program None and forged-Some parity" {
   let (tokens, starts, _) = lex_with_offsets(source)
   let ordinary = parse_program_located(tokens, starts, source)
   let (none, none_next) = parse_program_located_with_untrusted_binder_context(tokens, starts, source, None)
-  let forged = ParserBinderContext::{
-    nonce: 97
-  }
+  let forged = forged_context()
   let (some, some_next) = parse_program_located_with_untrusted_binder_context(tokens, starts, source, Some(forged))
   inspect(print_program(none) == print_program(ordinary), "true")
   inspect(print_program(some) == print_program(ordinary), "true")
@@ -196,9 +196,7 @@ test "parser binder context B2 whole-program None and forged-Some parity" {
   for bad_source in malformed {
     let ordinary_diag = ordinary_located_program_diag(bad_source)
     let none_diag = located_program_diag(bad_source, None)
-    let forged_diag = located_program_diag(bad_source, Some(ParserBinderContext::{
-      nonce: 101
-    }))
+    let forged_diag = located_program_diag(bad_source, Some(forged_context()))
     inspect(ordinary_diag != "ok", "true")
     inspect(none_diag == ordinary_diag, "true")
     inspect(forged_diag == ordinary_diag, "true")

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -30,6 +30,35 @@ type Token
 // caller context and use only the high-level exhaustively validated aggregate.
 opaque type ParserBinderContext
 
+// Closed parser-authored row schema. Values are data, not authority.
+type SyntheticBinderKind
+type SourceBinder
+
+// Documentation-opaque aggregate. Nominal possession is never proof; no
+// semantic consumer accepts it as authority.
+opaque type LocatedProgramBinderAuthority
+
+// Untrusted cross-file parser plumbing. Package conformance requires these
+// exports; only parse_source_located_with_binder_authority may publish rows.
+fn binder_capture_context(starts: Array[Int], ends: Array[Int]) -> ParserBinderContext
+fn binder_capture_mark(context: Option[ParserBinderContext]) -> Int
+fn binder_capture_eligibility_mark(context: Option[ParserBinderContext]) -> Bool
+fn binder_capture_restore_eligibility(context: Option[ParserBinderContext], eligible: Bool) -> Unit
+fn binder_capture_source(context: Option[ParserBinderContext], name: String, first_token: Int, last_token: Int) -> Unit
+fn binder_capture_synthetic(context: Option[ParserBinderContext], name: String) -> Unit
+fn binder_capture_insert_synthetic_at(context: Option[ParserBinderContext], mark: Int, name: String) -> Unit
+fn binder_capture_swap_segments(context: Option[ParserBinderContext], start: Int, middle: Int) -> Unit
+fn binder_capture_discard_from(context: Option[ParserBinderContext], mark: Int) -> Unit
+fn binder_capture_take_from(context: Option[ParserBinderContext], mark: Int) -> Array[SourceBinder]
+fn binder_capture_append(context: Option[ParserBinderContext], rows: Array[SourceBinder]) -> Unit
+fn binder_capture_rename_first_synthetic(context: Option[ParserBinderContext], from: String, to: String) -> Unit
+fn binder_capture_push_fragment(context: Option[ParserBinderContext], starts: Array[Int], ends: Array[Int], base: Int) -> Unit
+fn binder_capture_pop_fragment(context: Option[ParserBinderContext]) -> Unit
+fn binder_capture_mark_ineligible(context: Option[ParserBinderContext]) -> Unit
+fn binder_capture_is_eligible(context: ParserBinderContext) -> Bool
+fn binder_capture_rows(context: ParserBinderContext) -> Array[SourceBinder]
+fn validate_program_binder_rows(program: Array[Stmt], rows: Array[SourceBinder], source: String) -> Bool
+
 // --- polyfill
 
 // --- token
@@ -128,6 +157,9 @@ fn parse_program_located(tokens: Array[Token], starts: Array[Int], src: String) 
 // authorize binder provenance, semantic artifacts, reuse, or codegen.
 fn parse_program_located_with_untrusted_binder_context(tokens: Array[Token], starts: Array[Int], src: String, context: Option[ParserBinderContext]) -> (Array[Stmt], Int) with Exception
 fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
+fn parse_source_located_with_binder_authority(source: String) -> Option[LocatedProgramBinderAuthority] with Exception
+fn located_program_binder_authority_program(authority: LocatedProgramBinderAuthority) -> Array[Stmt]
+fn located_program_binder_authority_rows(authority: LocatedProgramBinderAuthority) -> Array[SourceBinder]
 fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], src: String) -> (Array[Stmt], Array[String]) with Exception
 fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Array[Int]) -> (Array[Stmt], Array[Int], Array[Int]) with Exception
 

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -64,11 +64,35 @@ import ./token.vibe {
 }
 
 import ./lexer.vibe {
-  offset_to_line_col
+  lex_with_offsets, offset_to_line_col
 }
 
 import ./parser_binder_context.vibe {
-  ParserBinderContext
+  ParserBinderContext,
+  SourceBinder,
+  binder_capture_context,
+  binder_capture_discard_from,
+  binder_capture_eligibility_mark,
+  binder_capture_is_eligible,
+  binder_capture_mark,
+  binder_capture_mark_ineligible,
+  binder_capture_restore_eligibility,
+  binder_capture_rows,
+  binder_capture_source
+}
+
+import ./parser_binder_authority.vibe {
+  validate_program_binder_rows
+}
+
+//# Types
+
+/// Atomically produced parse result plus exhaustively validated binder rows.
+/// The representation is documentation-opaque only; nominal possession is not
+/// proof and no semantic consumer accepts this value as authority.
+export struct LocatedProgramBinderAuthority {
+  program: Array[Stmt];
+  binders: Array[SourceBinder]
 }
 
 //# Functions
@@ -219,6 +243,7 @@ fn qualify_import_items(mod_name: String, items: Array[(String, Option[String])]
 }
 
 fn parse_qualified_import_tail(tokens: Array[Token], pos: Int, path: String, mod_name: String, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_mark_ineligible(context)
   match peek(tokens, pos) {
     TIdent(only_kw) => if only_kw == "only" {
       let br = expect_tk(tokens, pos + 1, "{")
@@ -255,6 +280,7 @@ fn parse_import_path_tail(tokens: Array[Token], bp: Int, path: String, context: 
     },
     TIdent(alias_name) => if String::length(alias_name) > 1 && String::char_code_at(alias_name, 0) == '@' {
       let alias_str = String::substring(alias_name, 1, String::length(alias_name))
+      binder_capture_source(context, alias_str, bp, bp)
       (SAliasDecl(alias_str, path), bp + 1)
     } else {
       let br = expect_tk(tokens, bp, "{")
@@ -329,8 +355,10 @@ fn parse_toplevel_struct_fields(tokens: Array[Token], pos: Int, context: Option[
 }
 
 fn parse_toplevel_struct_stmt(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_mark_ineligible(context)
   match peek(tokens, pos) {
     TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
       // Optional type-parameter header `struct Foo[T] { ... }`. #829: the
       // param NAMES are kept on the SStruct (they used to be discarded) so
       // the checker can instantiate generic struct literals; representation
@@ -395,7 +423,10 @@ fn is_resource_decl_head(tokens: Array[Token], pos: Int) -> Bool {
 /// as belonging to some provider (`S3::Bucket`, `Process::Root`).
 fn parse_resource_stmt(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   let name = match peek(tokens, pos) {
-    TIdent(n) => n,
+    TIdent(n) => {
+      binder_capture_source(context, n, pos, pos)
+      n
+    },
     _ => throw("expected a resource name after 'resource'")
   }
   match peek(tokens, pos + 1) {
@@ -475,7 +506,11 @@ fn parse_export_stmt(tokens: Array[Token], starts: Array[Int], pos: Int, context
 fn parse_percent_symbol_name(tokens: Array[Token], pos: Int, label: String, context: Option[ParserBinderContext]) -> (String, Int) with Exception {
   let pp = expect_tk(tokens, pos, "%")
   match peek(tokens, pp) {
-    TIdent(name) => ("%\{name}", pp + 1),
+    TIdent(name) => {
+      let full_name = "%\{name}"
+      binder_capture_source(context, full_name, pos, pp)
+      (full_name, pp + 1)
+    },
     _ => throw("expected \{label} after '%'")
   }
 }
@@ -984,6 +1019,8 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
         } else if dname == "deprecated" || dname == "cfg_enable" || cfg_flag_active(cfg_active, flag) {
           pos = dnext
         } else {
+          let capture_mark = binder_capture_mark(context)
+          let eligibility_mark = binder_capture_eligibility_mark(context)
           match peek(tokens, dnext) {
             TImpl => {
               let (simpl_d, hp_d) = parse_impl_stmt_dispatch_with_binder_context(tokens, dnext + 1, context)
@@ -995,6 +1032,8 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
               pos = dn
             }
           }
+          binder_capture_discard_from(context, capture_mark)
+          binder_capture_restore_eligibility(context, eligibility_mark)
         }
       },
       _ => {
@@ -1002,6 +1041,7 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
         let (stmts, next) = handle {
           match peek(tokens, pos) {
             TImpl => {
+              binder_capture_mark_ineligible(context)
               let (simpl, hp) = parse_impl_stmt_dispatch_with_binder_context(tokens, pos + 1, context)
               parse_impl_methods(tokens, hp, simpl, context)
             },
@@ -1092,13 +1132,38 @@ export fn parse_program_located_with_untrusted_binder_context(tokens: Array[Toke
   parse_program_located_with_context_impl(tokens, starts, source, context)
 }
 
-/// Opt-in high-level parser-context infrastructure. It deliberately mints its
-/// own invocation-local plumbing context instead of trusting caller input. This
-/// phase publishes no authority rows and does not change the parsed program.
+/// Compatibility API retained authority-free: caller-provided token arrays are
+/// never a source of binder authority.
 export fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array[Int], source: String) -> Array[Stmt] with Exception {
-  parse_program_located_with_context_impl(tokens, starts, source, Some(ParserBinderContext::{
-    nonce: 0
-  })).0
+  parse_program_located_with_context_impl(tokens, starts, source, None).0
+}
+
+/// Source-owning atomic entry. It alone lexes exact offset tables, creates a
+/// fresh untrusted context, parses to TEof, and publishes only after complete
+/// final-AST row validation.
+export fn parse_source_located_with_binder_authority(source: String) -> Option[LocatedProgramBinderAuthority] with Exception {
+  let (tokens, starts, ends) = lex_with_offsets(source)
+  let context = binder_capture_context(starts, ends)
+  let (program, next) = parse_program_located_with_context_impl(tokens, starts, source, Some(context))
+  let rows = binder_capture_rows(context)
+  if match peek(tokens, next) {
+    TEof => true,
+    _ => false
+  } && binder_capture_is_eligible(context) && validate_program_binder_rows(program, rows, source) {
+    Some(LocatedProgramBinderAuthority::{
+      program: program, binders: rows
+    })
+  } else None
+}
+
+/// Data accessor only. No checker/cache/reuse API accepts this aggregate.
+export fn located_program_binder_authority_program(authority: LocatedProgramBinderAuthority) -> Array[Stmt] {
+  Array::slice(authority.program, 0, Array::length(authority.program))
+}
+
+/// Data accessor only; rows remain non-semantic parser evidence.
+export fn located_program_binder_authority_rows(authority: LocatedProgramBinderAuthority) -> Array[SourceBinder] {
+  Array::slice(authority.binders, 0, Array::length(authority.binders))
 }
 
 export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], source: String) -> (Array[Stmt], Array[String]) with Exception {

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -5,7 +5,7 @@ import @vibe/ast {
 }
 
 import ./parser_binder_context.vibe {
-  ParserBinderContext
+  ParserBinderContext, binder_capture_mark_ineligible, binder_capture_source
 }
 
 import ./token.vibe {
@@ -390,12 +390,15 @@ export fn parse_pattern_with_binder_context(tokens: Array[Token], pos: Int, cont
                   rp = fnext
                 },
                 TComma => {
+                  binder_capture_source(context, fname, rp, rp)
                   ArrayBuilder::push(field_pats_b, PBind(fname)); rp = rp + 1
                 },
                 TRBrace => {
+                  binder_capture_source(context, fname, rp, rp)
                   ArrayBuilder::push(field_pats_b, PBind(fname)); rp = rp + 1
                 },
                 _ => {
+                  binder_capture_source(context, fname, rp, rp)
                   ArrayBuilder::push(field_pats_b, PBind(fname)); rp = rp + 1
                 }
               }
@@ -433,6 +436,7 @@ export fn parse_pattern_with_binder_context(tokens: Array[Token], pos: Int, cont
                       sd = false
                     },
                     TIdent(fname) => {
+                      binder_capture_source(context, fname, sp, sp)
                       ArrayBuilder::push(field_pats, (fname, PBind(fname)))
                       sp = sp + 1
                       match peek(tokens, sp) {
@@ -481,7 +485,10 @@ export fn parse_pattern_with_binder_context(tokens: Array[Token], pos: Int, cont
             },
             _ => (PCtor(name, empty_pats()), pos + 1)
           }
-        } else (PBind(name), pos + 1)
+        } else {
+          binder_capture_source(context, name, pos, pos)
+          (PBind(name), pos + 1)
+        }
       }
     },
     TLParen => match peek(tokens, pos + 1) {
@@ -507,6 +514,7 @@ export fn parse_pattern_with_binder_context(tokens: Array[Token], pos: Int, cont
   }
   match peek(tokens, next) {
     TBitOr => {
+      binder_capture_mark_ineligible(context)
       let (right, end) = parse_pattern_with_binder_context(tokens, next + 1, context);
       (POr(pat, right), end)
     },
@@ -588,6 +596,7 @@ fn parse_bounded_type_params_with_binder_context(tokens: Array[Token], pos: Int,
         break
       },
       TIdent(name) => {
+        binder_capture_source(context, name, p, p)
         ArrayBuilder::push(names, name)
         p = p + 1
         match peek(tokens, p) {
@@ -630,6 +639,7 @@ fn parse_trait_methods_with_binder_context(tokens: Array[Token], pos: Int, conte
             break
           },
           TIdent(method_name) => {
+            binder_capture_source(context, method_name, p, p)
             // Optional `:` after the method name, so both
             // `m(Self) -> R` and `m: [X: Bound](Self, X) -> R` parse (#684).
             let after_colon = match peek(tokens, p + 1) {
@@ -676,9 +686,11 @@ fn parse_trait_methods_with_binder_context(tokens: Array[Token], pos: Int, conte
 }
 
 export fn parse_trait_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_mark_ineligible(context)
   let empty_strings = ArrayBuilder::freeze(ArrayBuilder::new())
   match peek(tokens, pos) {
     TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
       // Retain the declared bare header names while preserving the existing
       // accepting grammar: parse_tparam_names still skips non-name header
       // details such as bounds rather than giving them new semantics.
@@ -775,10 +787,16 @@ export fn parse_import_item_with_binder_context(tokens: Array[Token], pos: Int, 
         }
         match peek(tokens, after) {
           TAs => match peek(tokens, after + 1) {
-            TIdent(alias) => ((base, Some(alias)), after + 2),
+            TIdent(alias) => {
+              binder_capture_source(context, alias, after + 1, after + 1)
+              ((base, Some(alias)), after + 2)
+            },
             _ => throw("expected alias name after 'as'")
           },
-          _ => ((base, None), after)
+          _ => {
+            binder_capture_source(context, base, name_pos, after - 1)
+            ((base, None), after)
+          }
         }
       },
       _ => throw("expected import item name")
@@ -803,10 +821,17 @@ export fn parse_binding_name_with_binder_context(tokens: Array[Token], pos: Int,
   match peek(tokens, pos) {
     TIdent(name) => match peek(tokens, pos + 1) {
       TDoubleColon => match peek(tokens, pos + 2) {
-        TIdent(member) => (String::concat(name, String::concat("::", member)), pos + 3),
+        TIdent(member) => {
+          let qualified = String::concat(name, String::concat("::", member))
+          binder_capture_source(context, qualified, pos, pos + 2)
+          (qualified, pos + 3)
+        },
         _ => throw("expected qualified member name after '::'")
       },
-      _ => (name, pos + 1)
+      _ => {
+        binder_capture_source(context, name, pos, pos)
+        (name, pos + 1)
+      }
     },
     _ => throw("expected name after 'let'")
   }
@@ -907,6 +932,7 @@ export fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int,
           },
           TIdent(nm) => {
             if depth == 1 && expect_name {
+              binder_capture_source(context, nm, skip, skip)
               ArrayBuilder::push(b, nm)
               expect_name = false
             }
@@ -1480,63 +1506,66 @@ fn optional_param_type(ty: TypeExpr, is_optional: Bool) -> TypeExpr {
 
 fn parse_one_param_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, Option[TypeExpr]), Int) with Exception {
   match peek(tokens, pos) {
-    TIdent(name) => match peek(tokens, pos + 1) {
-      TTilde => {
-        let labeled_name = "\{name}~"
-        match peek(tokens, pos + 2) {
-          TColon => {
-            let (ty, tp) = parse_type_impl(tokens, pos + 3, 0);
-            ((labeled_name, Some(ty)), tp)
-          },
-          _ => ((labeled_name, None), pos + 2)
-        }
-      },
-      TQuestion => {
-        let opt_name = "\{name}?"
-        match peek(tokens, pos + 2) {
-          TColon => {
-            let (ty, tp) = parse_type_impl(tokens, pos + 3, 0);
-            // #1500: an optional parameter is declared `Option[T]`. The body
-            // sees an `Option` (that is what the omitted case has to produce),
-            // and `desugar_optional_args` makes the call site agree -- omitted
-            // slots become `None`, supplied ones `Some(v)`. The `?` used to be
-            // recorded only on the NAME, so the declared type stayed `T` and
-            // the parameter was optional in spelling alone.
-            ((opt_name, Some(optional_param_type(ty, true))), tp)
-          },
-          _ => ((opt_name, None), pos + 2)
-        }
-      },
-      TColon => {
-        let (ty, tp) = parse_type_impl(tokens, pos + 2, 0);
-        let tp2 = match peek(tokens, tp) {
-          TColon => {
-            let mut bp = tp + 1
-            let mut bd = true
-            while bd {
-              match peek(tokens, bp) {
-                TIdent(_) => {
-                  bp = bp + 1; match peek(tokens, bp) {
-                    TPlus => {
-                      bp = bp + 1
-                    },
-                    _ => {
-                      bd = false
+    TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
+      match peek(tokens, pos + 1) {
+        TTilde => {
+          let labeled_name = "\{name}~"
+          match peek(tokens, pos + 2) {
+            TColon => {
+              let (ty, tp) = parse_type_impl(tokens, pos + 3, 0);
+              ((labeled_name, Some(ty)), tp)
+            },
+            _ => ((labeled_name, None), pos + 2)
+          }
+        },
+        TQuestion => {
+          let opt_name = "\{name}?"
+          match peek(tokens, pos + 2) {
+            TColon => {
+              let (ty, tp) = parse_type_impl(tokens, pos + 3, 0);
+              // #1500: an optional parameter is declared `Option[T]`. The body
+              // sees an `Option` (that is what the omitted case has to produce),
+              // and `desugar_optional_args` makes the call site agree -- omitted
+              // slots become `None`, supplied ones `Some(v)`. The `?` used to be
+              // recorded only on the NAME, so the declared type stayed `T` and
+              // the parameter was optional in spelling alone.
+              ((opt_name, Some(optional_param_type(ty, true))), tp)
+            },
+            _ => ((opt_name, None), pos + 2)
+          }
+        },
+        TColon => {
+          let (ty, tp) = parse_type_impl(tokens, pos + 2, 0);
+          let tp2 = match peek(tokens, tp) {
+            TColon => {
+              let mut bp = tp + 1
+              let mut bd = true
+              while bd {
+                match peek(tokens, bp) {
+                  TIdent(_) => {
+                    bp = bp + 1; match peek(tokens, bp) {
+                      TPlus => {
+                        bp = bp + 1
+                      },
+                      _ => {
+                        bd = false
+                      }
                     }
+                  },
+                  _ => {
+                    bd = false
                   }
-                },
-                _ => {
-                  bd = false
                 }
               }
-            }
-            bp
-          },
-          _ => tp
-        }
-        ((name, Some(ty)), tp2)
-      },
-      _ => ((name, None), pos + 1)
+              bp
+            },
+            _ => tp
+          }
+          ((name, Some(ty)), tp2)
+        },
+        _ => ((name, None), pos + 1)
+      }
     },
     _ => {
       let actual = tk_name(peek(tokens, pos))
@@ -1585,6 +1614,7 @@ export fn parse_struct_field_with_binder_context(tokens: Array[Token], pos: Int,
   }
   match peek(tokens, p) {
     TIdent(name) => {
+      binder_capture_source(context, name, p, p)
       let cn = expect_tk(tokens, p + 1, ":")
       let (ty, next) = parse_type_impl(tokens, cn, 0);
       ((name, ty), is_mut, next)
@@ -1639,18 +1669,21 @@ fn parse_ctor_types_rest(tokens: Array[Token], pos: Int, b: ArrayBuilder[TypeExp
 
 fn parse_enum_ctor_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, Array[TypeExpr]), Int) with Exception {
   match peek(tokens, pos) {
-    TIdent(name) => match peek(tokens, pos + 1) {
-      TLParen => match peek(tokens, pos + 2) {
-        TRParen => ((name, empty_type_exprs()), pos + 3),
-        _ => {
-          let (first, n1) = parse_type_impl(tokens, pos + 2, 0)
-          let b = ArrayBuilder::new()
-          ArrayBuilder::push(b, first)
-          let (types, end) = parse_ctor_types_rest(tokens, n1, b);
-          ((name, types), end)
-        }
-      },
-      _ => ((name, empty_type_exprs()), pos + 1)
+    TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
+      match peek(tokens, pos + 1) {
+        TLParen => match peek(tokens, pos + 2) {
+          TRParen => ((name, empty_type_exprs()), pos + 3),
+          _ => {
+            let (first, n1) = parse_type_impl(tokens, pos + 2, 0)
+            let b = ArrayBuilder::new()
+            ArrayBuilder::push(b, first)
+            let (types, end) = parse_ctor_types_rest(tokens, n1, b);
+            ((name, types), end)
+          }
+        },
+        _ => ((name, empty_type_exprs()), pos + 1)
+      }
     },
     _ => throw("expected constructor name")
   }
@@ -1688,8 +1721,10 @@ fn parse_enum_ctors_with_binder_context(tokens: Array[Token], pos: Int, context:
 }
 
 export fn parse_enum_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_mark_ineligible(context)
   match peek(tokens, pos) {
     TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
       let (params, after_name) = match peek(tokens, pos + 1) {
         TLBracket => {
           let b = ArrayBuilder::new()
@@ -1712,6 +1747,7 @@ export fn parse_enum_stmt_with_binder_context(tokens: Array[Token], pos: Int, ex
               },
               TIdent(nm) => {
                 if depth == 1 && expect_name {
+                  binder_capture_source(context, nm, skip, skip)
                   ArrayBuilder::push(b, nm)
                   expect_name = false
                 }
@@ -1739,29 +1775,33 @@ fn parse_enum_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, Int
   parse_enum_stmt_with_binder_context(tokens, pos, exported, None)
 }
 export fn parse_suberror_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_mark_ineligible(context)
   match peek(tokens, pos) {
-    TIdent(name) => match peek(tokens, pos + 1) {
-      TLParen => match peek(tokens, pos + 2) {
-        TRParen => {
-          let b = ArrayBuilder::new()
-          ArrayBuilder::push(b, (name, empty_type_exprs()))
-          (SSuberror(exported, name, ArrayBuilder::freeze(b)), pos + 3)
+    TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
+      match peek(tokens, pos + 1) {
+        TLParen => match peek(tokens, pos + 2) {
+          TRParen => {
+            let b = ArrayBuilder::new()
+            ArrayBuilder::push(b, (name, empty_type_exprs()))
+            (SSuberror(exported, name, ArrayBuilder::freeze(b)), pos + 3)
+          },
+          _ => {
+            let (first, n1) = parse_type_impl(tokens, pos + 2, 0)
+            let args_b = ArrayBuilder::new()
+            ArrayBuilder::push(args_b, first)
+            let (args, end) = parse_ctor_types_rest(tokens, n1, args_b)
+            let ctors_b = ArrayBuilder::new()
+            ArrayBuilder::push(ctors_b, (name, args))
+            (SSuberror(exported, name, ArrayBuilder::freeze(ctors_b)), end)
+          }
         },
-        _ => {
-          let (first, n1) = parse_type_impl(tokens, pos + 2, 0)
-          let args_b = ArrayBuilder::new()
-          ArrayBuilder::push(args_b, first)
-          let (args, end) = parse_ctor_types_rest(tokens, n1, args_b)
-          let ctors_b = ArrayBuilder::new()
-          ArrayBuilder::push(ctors_b, (name, args))
-          (SSuberror(exported, name, ArrayBuilder::freeze(ctors_b)), end)
-        }
-      },
-      TLBrace => {
-        let (ctors, end) = parse_enum_ctors_with_binder_context(tokens, pos + 2, context);
-        (SSuberror(exported, name, ctors), end)
-      },
-      _ => throw("expected '(' or '{' after suberror name")
+        TLBrace => {
+          let (ctors, end) = parse_enum_ctors_with_binder_context(tokens, pos + 2, context);
+          (SSuberror(exported, name, ctors), end)
+        },
+        _ => throw("expected '(' or '{' after suberror name")
+      }
     },
     _ => throw("expected suberror name")
   }
@@ -1771,6 +1811,7 @@ fn parse_suberror_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt,
   parse_suberror_stmt_with_binder_context(tokens, pos, exported, None)
 }
 fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_mark_ineligible(context)
   let (type_params, type_bounds, after_tp) = match peek(tokens, pos) {
     TLBracket => parse_bounded_type_params_with_binder_context(tokens, pos + 1, true, "expected ',' or ']' in impl type params", context),
     _ => (_no_tp(), _no_tb(), pos)
@@ -1796,8 +1837,10 @@ fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: 
 
 /// Parse effect declaration: effect Name[T] { Op(Args) -> Ret; ... }
 export fn parse_effect_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_mark_ineligible(context)
   match peek(tokens, pos) {
     TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
       let (type_params, after_params) = match peek(tokens, pos + 1) {
         TLBracket => {
           let (names, _, next) = parse_bounded_type_params_with_binder_context(tokens, pos + 2, false, "expected ',' or ']' in type params", context)
@@ -1815,6 +1858,7 @@ export fn parse_effect_stmt_with_binder_context(tokens: Array[Token], pos: Int, 
             break
           },
           TIdent(op_name) => {
+            binder_capture_source(context, op_name, p, p)
             let (params, after_op_params) = match peek(tokens, p + 1) {
               TLParen => {
                 let (params_ty, after_paren) = parse_type_impl(tokens, p + 1, 1)
@@ -1852,6 +1896,7 @@ fn parse_effect_stmt(tokens: Array[Token], pos: Int, exported: Bool) -> (Stmt, I
 export fn parse_type_alias_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
       let (params, after_name) = match peek(tokens, pos + 1) {
         TLBracket => {
           let (names, _, next) = parse_bounded_type_params_with_binder_context(tokens, pos + 2, false, "expected ',' or ']' in type params", context)
@@ -1920,8 +1965,10 @@ fn parse_struct_fields_with_binder_context(tokens: Array[Token], pos: Int, conte
 }
 
 export fn parse_struct_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_mark_ineligible(context)
   match peek(tokens, pos) {
     TIdent(name) => {
+      binder_capture_source(context, name, pos, pos)
       // #829: keep the `[T]` type-parameter names (previously skipped and
       // discarded) so the checker can instantiate generic struct literals.
       let (tparams, after_name) = parse_tparam_names_with_binder_context(tokens, pos + 1, context)

--- a/lib/@vibe/parser/parser_binder_authority.vibe
+++ b/lib/@vibe/parser/parser_binder_authority.vibe
@@ -1,0 +1,278 @@
+//# Imports
+
+import @vibe/ast {
+  Expr, Pat, Stmt
+}
+
+import ./parser_binder_context.vibe {
+  SourceBinder
+}
+
+//# Validation
+
+fn validate_slot(name: String, rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+  if at < 0 || at >= Array::length(rows) {
+    (false, at)
+  } else match Array::get(rows, at) {
+    SourceToken(row_name, start, end) => {
+      let n = String::length(source)
+      let valid_span = start >= 0 && start < end && end <= n
+      let exact = if valid_span {
+        let spelling = String::substring(source, start, end)
+        spelling == name || spelling == String::concat("@", name) || spelling == String::concat("r#", name)
+      } else false
+      (row_name == name && exact, at + 1)
+    },
+    Synthetic(row_name, _) => (row_name == name, at + 1)
+  }
+}
+
+fn validate_pattern(pat: Pat, rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+  match pat {
+    PBind(name) => validate_slot(name, rows, source, at),
+    PCtor(_, args) => validate_patterns(args, rows, source, at),
+    PTuple(args) => validate_patterns(args, rows, source, at),
+    PStruct(_, fields) => {
+      let mut ok = true
+      let mut next = at
+      for field in fields {
+        let result = validate_pattern(field.1, rows, source, next)
+        ok = ok && result.0
+        next = result.1
+      }
+      (ok, next)
+    },
+    // POr has two source declarations for one semantic binding. It remains
+    // ineligible until that mapping has an explicit checker contract.
+    POr(_, _) => (false, at),
+    _ => (true, at)
+  }
+}
+
+fn validate_patterns(pats: Array[Pat], rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+  let mut ok = true
+  let mut next = at
+  for pat in pats {
+    let result = validate_pattern(pat, rows, source, next)
+    ok = ok && result.0
+    next = result.1
+  }
+  (ok, next)
+}
+
+fn validate_exprs(exprs: Array[Expr], rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+  let mut ok = true
+  let mut next = at
+  for expr in exprs {
+    let result = validate_expr(expr, rows, source, next)
+    ok = ok && result.0
+    next = result.1
+  }
+  (ok, next)
+}
+
+fn validate_arms(arms: Array[(Pat, Expr)], rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+  let mut ok = true
+  let mut next = at
+  for arm in arms {
+    let p = validate_pattern(arm.0, rows, source, next)
+    let e = validate_expr(arm.1, rows, source, p.1)
+    ok = ok && p.0 && e.0
+    next = e.1
+  }
+  (ok, next)
+}
+
+fn validate_named_exprs(items: Array[(String, Expr)], rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+  let mut ok = true
+  let mut next = at
+  for item in items {
+    let result = validate_expr(item.1, rows, source, next)
+    ok = ok && result.0
+    next = result.1
+  }
+  (ok, next)
+}
+
+fn validate_expr(expr: Expr, rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+  match expr {
+    ELet(name, value, body, _) => {
+      let slot = validate_slot(name, rows, source, at)
+      let v = validate_expr(value, rows, source, slot.1)
+      let b = validate_expr(body, rows, source, v.1)
+      (slot.0 && v.0 && b.0, b.1)
+    },
+    ELetRec(name, value, body) => {
+      let slot = validate_slot(name, rows, source, at)
+      let v = validate_expr(value, rows, source, slot.1)
+      let b = validate_expr(body, rows, source, v.1)
+      (slot.0 && v.0 && b.0, b.1)
+    },
+    ELetMut(name, value, body, _) => {
+      let slot = validate_slot(name, rows, source, at)
+      let v = validate_expr(value, rows, source, slot.1)
+      let b = validate_expr(body, rows, source, v.1)
+      (slot.0 && v.0 && b.0, b.1)
+    },
+    EMatch(scrutinee, arms) => {
+      let s = validate_expr(scrutinee, rows, source, at)
+      let a = validate_arms(arms, rows, source, s.1)
+      (s.0 && a.0, a.1)
+    },
+    EHandle(body, arms) => {
+      let b = validate_expr(body, rows, source, at)
+      let a = validate_arms(arms, rows, source, b.1)
+      (b.0 && a.0, a.1)
+    },
+    EFn(type_params, _, params, _, _, body) => {
+      let mut ok = true
+      let mut next = at
+      for name in type_params {
+        let result = validate_slot(name, rows, source, next)
+        ok = ok && result.0
+        next = result.1
+      }
+      for param in params {
+        let result = validate_slot(param.0, rows, source, next)
+        ok = ok && result.0
+        next = result.1
+      }
+      let b = validate_expr(body, rows, source, next)
+      (ok && b.0, b.1)
+    },
+    EForIn(name, index_name, iter, body) => {
+      let first = validate_slot(name, rows, source, at)
+      let second = match index_name {
+        Some(index) => validate_slot(index, rows, source, first.1),
+        None => (true, first.1)
+      }
+      let i = validate_expr(iter, rows, source, second.1)
+      let b = validate_expr(body, rows, source, i.1)
+      (first.0 && second.0 && i.0 && b.0, b.1)
+    },
+    // Loop lowering synthesizes binders and remains fail-closed until its row
+    // segment remap is implemented.
+    ELoop(_, _) => (false, at),
+    ETuple(items) => validate_exprs(items, rows, source, at),
+    EArray(items) => validate_exprs(items, rows, source, at),
+    ERecord(_, fields, _) => validate_named_exprs(fields, rows, source, at),
+    EIf(cond, yes, no) => {
+      let c = validate_expr(cond, rows, source, at)
+      let y = validate_expr(yes, rows, source, c.1)
+      let n = validate_expr(no, rows, source, y.1)
+      (c.0 && y.0 && n.0, n.1)
+    },
+    EAssign(_, value, body) => {
+      let v = validate_expr(value, rows, source, at)
+      let b = validate_expr(body, rows, source, v.1)
+      (v.0 && b.0, b.1)
+    },
+    EAssignOp(_, _, value, body) => {
+      let v = validate_expr(value, rows, source, at)
+      let b = validate_expr(body, rows, source, v.1)
+      (v.0 && b.0, b.1)
+    },
+    ESeq(first, second) => {
+      let f = validate_expr(first, rows, source, at)
+      let s = validate_expr(second, rows, source, f.1)
+      (f.0 && s.0, s.1)
+    },
+    EWhile(cond, body) => {
+      let c = validate_expr(cond, rows, source, at)
+      let b = validate_expr(body, rows, source, c.1)
+      (c.0 && b.0, b.1)
+    },
+    ECall(callee, args, _) => {
+      let c = validate_expr(callee, rows, source, at)
+      let a = validate_exprs(args, rows, source, c.1)
+      (c.0 && a.0, a.1)
+    },
+    EBinOp(_, left, right) => {
+      let l = validate_expr(left, rows, source, at)
+      let r = validate_expr(right, rows, source, l.1)
+      (l.0 && r.0, r.1)
+    },
+    EUnaryOp(_, value) => validate_expr(value, rows, source, at),
+    EDot(value, _, _, _) => validate_expr(value, rows, source, at),
+    ELabeledArg(_, _, value) => validate_expr(value, rows, source, at),
+    EReturn(value) => validate_expr(value, rows, source, at),
+    EBreak(value) => match value {
+      Some(v) => validate_expr(v, rows, source, at),
+      None => (true, at)
+    },
+    EContinue(values) => validate_exprs(values, rows, source, at),
+    EMap(items) => validate_named_exprs(items, rows, source, at),
+    ESpread(value) => validate_expr(value, rows, source, at),
+    EInt(_) => (true, at),
+    EFloat(_) => (true, at),
+    EString(_) => (true, at),
+    EBool(_) => (true, at),
+    EIdent(_, _) => (true, at),
+    EStringInterp(_) => (true, at),
+    EUnit => (true, at)
+  }
+}
+
+/// Exhaustive final-AST validation. Success requires one exact source row for
+/// every supported binder slot and no extra rows.
+export fn validate_program_binder_rows(program: Array[Stmt], rows: Array[SourceBinder], source: String) -> Bool {
+  let mut ok = true
+  let mut next = 0
+  for stmt in program {
+    let result = match stmt {
+      SLet(_, _, name, _, value) => {
+        let slot = validate_slot(name, rows, source, next)
+        let expr = validate_expr(value, rows, source, slot.1)
+        (slot.0 && expr.0, expr.1)
+      },
+      SLetMut(name, _, value) => {
+        let slot = validate_slot(name, rows, source, next)
+        let expr = validate_expr(value, rows, source, slot.1)
+        (slot.0 && expr.0, expr.1)
+      },
+      SExternLet(name, _) => validate_slot(name, rows, source, next),
+      SImport(_, items) => {
+        let mut import_ok = true
+        let mut import_next = next
+        for item in items {
+          let local = match item.1 {
+            Some(alias) => alias,
+            None => item.0
+          }
+          let slot = validate_slot(local, rows, source, import_next)
+          import_ok = import_ok && slot.0
+          import_next = slot.1
+        }
+        (import_ok, import_next)
+      },
+      SAliasDecl(name, _) => validate_slot(name, rows, source, next),
+      STypeAlias(_, name, params, _) => {
+        let first = validate_slot(name, rows, source, next)
+        let mut alias_ok = first.0
+        let mut alias_next = first.1
+        for param in params {
+          let slot = validate_slot(param, rows, source, alias_next)
+          alias_ok = alias_ok && slot.0
+          alias_next = slot.1
+        }
+        (alias_ok, alias_next)
+      },
+      SEffectSet(_, name, _) => validate_slot(name, rows, source, next),
+      SResource(name, _) => validate_slot(name, rows, source, next),
+      STest(_, body) => validate_expr(body, rows, source, next),
+      SBench(_, body) => validate_expr(body, rows, source, next),
+      SExample(_, body) => validate_expr(body, rows, source, next),
+      SExpr(body) => validate_expr(body, rows, source, next),
+      SExport(_) => (true, next),
+      SReExport(_, _) => (true, next),
+      SQualifiedPatternRefs(_) => (true, next),
+      STestEffectRows(_) => (true, next),
+      // Remaining declaration/lowering lanes are deliberately ineligible in
+      // this checkpoint; returning false is sticky at aggregate validation.
+      _ => (false, next)
+    }
+    ok = ok && result.0
+    next = result.1
+  }
+  ok && next == Array::length(rows)
+}

--- a/lib/@vibe/parser/parser_binder_context.vibe
+++ b/lib/@vibe/parser/parser_binder_context.vibe
@@ -1,13 +1,221 @@
 //# Types
 
-/// Invocation-local parser context reserved for binder-authority capture.
-///
-/// This first infrastructure slice deliberately carries no rows. The package
-/// contract spells this `opaque type`, but contract opacity is currently
-/// documentation-only: external code can still forge the representation.
-/// Therefore this context and every low-level helper are untrusted plumbing.
-/// Future authority must come only from the high-level atomic parse aggregate
-/// after exhaustive completeness validation, never from caller context.
+/// Closed classification for binders synthesized by parse-time lowering.
+export enum SyntheticBinderKind {
+  ParserSynthetic
+}
+
+/// Parser-authored origin for one binder slot in the final located AST.
+export enum SourceBinder {
+  SourceToken(String, Int, Int);
+  Synthetic(String, SyntheticBinderKind)
+}
+
+/// Invocation-local capture state. This type and every helper are forgeable
+/// untrusted plumbing; only the source-owning parser entry may validate rows.
 export struct ParserBinderContext {
-  nonce: Int
+  rows: Array[SourceBinder];
+  starts_stack: Array[Array[Int]];
+  ends_stack: Array[Array[Int]];
+  bases: Array[Int];
+  eligible: Array[Bool]
+}
+
+fn empty_binders() -> Array[SourceBinder] {
+  ArrayBuilder::freeze(ArrayBuilder::new())
+}
+
+/// Untrusted plumbing constructor. Possession is never authority.
+export fn binder_capture_context(starts: Array[Int], ends: Array[Int]) -> ParserBinderContext {
+  ParserBinderContext::{
+    rows: empty_binders(),
+    starts_stack: [
+      starts
+    ],
+    ends_stack: [
+      ends
+    ],
+    bases: [
+      0
+    ],
+    eligible: [
+      true
+    ]
+  }
+}
+
+fn with_context(context: Option[ParserBinderContext], f: (ParserBinderContext) -> Unit) -> Unit {
+  match context {
+    Some(c) => f(c),
+    None => ()
+  }
+}
+
+export fn binder_capture_mark(context: Option[ParserBinderContext]) -> Int {
+  match context {
+    Some(c) => Array::length(c.rows),
+    None => 0
+  }
+}
+
+export fn binder_capture_eligibility_mark(context: Option[ParserBinderContext]) -> Bool {
+  match context {
+    Some(c) => Array::length(c.eligible) == 1 && Array::get(c.eligible, 0),
+    None => true
+  }
+}
+
+/// Roll back eligibility only for a parser-controlled discarded transaction
+/// such as an inactive cfg statement. This helper is untrusted plumbing and
+/// cannot publish authority by itself.
+export fn binder_capture_restore_eligibility(context: Option[ParserBinderContext], eligible: Bool) -> Unit {
+  with_context(context, (c) -> {
+    if Array::length(c.eligible) == 1 {
+      Array::set(c.eligible, 0, eligible)
+    } else {
+      ()
+    }
+  })
+}
+
+export fn binder_capture_source(context: Option[ParserBinderContext], name: String, first_token: Int, last_token: Int) -> Unit {
+  with_context(context, (c) -> {
+    let depth = Array::length(c.starts_stack)
+    if depth == 0 || first_token < 0 || last_token < first_token {
+      Array::set(c.eligible, 0, false)
+    } else {
+      let starts = Array::get(c.starts_stack, depth - 1)
+      let ends = Array::get(c.ends_stack, depth - 1)
+      let base = Array::get(c.bases, depth - 1)
+      if first_token >= Array::length(starts) || last_token >= Array::length(ends) {
+        Array::set(c.eligible, 0, false)
+      } else {
+        Array::push(c.rows, SourceToken(name, base + Array::get(starts, first_token), base + Array::get(ends, last_token)))
+      }
+    }
+  })
+}
+
+export fn binder_capture_synthetic(context: Option[ParserBinderContext], name: String) -> Unit {
+  with_context(context, (c) -> {
+    Array::push(c.rows, Synthetic(name, ParserSynthetic))
+  })
+}
+
+/// Insert a parser-authored synthetic row before every row captured since
+/// `mark`. The source-owning entry still validates the final AST exhaustively;
+/// synthetic rows are authority only when their exact final binder slot exists.
+export fn binder_capture_insert_synthetic_at(context: Option[ParserBinderContext], mark: Int, name: String) -> Unit {
+  let tail = binder_capture_take_from(context, mark)
+  binder_capture_synthetic(context, name)
+  binder_capture_append(context, tail)
+}
+
+/// Swap two adjacent capture segments `[start, middle)` and `[middle, end)`.
+/// Marks are invocation-local row indices, never source coordinates.
+export fn binder_capture_swap_segments(context: Option[ParserBinderContext], start: Int, middle: Int) -> Unit {
+  match context {
+    Some(c) => {
+      let end = Array::length(c.rows)
+      if start < 0 || middle < start || middle > end {
+        Array::set(c.eligible, 0, false)
+      } else {
+        let all = binder_capture_take_from(context, start)
+        let cut = middle - start
+        binder_capture_append(context, Array::slice(all, cut, Array::length(all)))
+        binder_capture_append(context, Array::slice(all, 0, cut))
+      }
+    },
+    None => ()
+  }
+}
+
+export fn binder_capture_discard_from(context: Option[ParserBinderContext], mark: Int) -> Unit {
+  with_context(context, (c) -> {
+    if mark < 0 || mark > Array::length(c.rows) {
+      Array::set(c.eligible, 0, false)
+    } else {
+      Array::truncate(c.rows, mark)
+    }
+  })
+}
+
+export fn binder_capture_take_from(context: Option[ParserBinderContext], mark: Int) -> Array[SourceBinder] {
+  match context {
+    Some(c) => if mark < 0 || mark > Array::length(c.rows) {
+      Array::set(c.eligible, 0, false)
+      empty_binders()
+    } else {
+      let out = Array::slice(c.rows, mark, Array::length(c.rows))
+      Array::truncate(c.rows, mark)
+      out
+    },
+    None => empty_binders()
+  }
+}
+
+export fn binder_capture_append(context: Option[ParserBinderContext], rows: Array[SourceBinder]) -> Unit {
+  with_context(context, (c) -> {
+    for row in rows {
+      Array::push(c.rows, row)
+    }
+    ()
+  })
+}
+
+export fn binder_capture_rename_first_synthetic(context: Option[ParserBinderContext], from: String, to: String) -> Unit {
+  with_context(context, (c) -> {
+    let mut i = 0
+    let mut found = false
+    while i < Array::length(c.rows) && !found {
+      match Array::get(c.rows, i) {
+        Synthetic(name, kind) => if name == from {
+          Array::set(c.rows, i, Synthetic(to, kind))
+          found = true
+        } else {
+          ()
+        },
+        _ => ()
+      }
+      i = i + 1
+    }
+    if !found {
+      Array::set(c.eligible, 0, false)
+    } else {
+      ()
+    }
+  })
+}
+
+export fn binder_capture_push_fragment(context: Option[ParserBinderContext], starts: Array[Int], ends: Array[Int], base: Int) -> Unit {
+  with_context(context, (c) -> {
+    Array::push(c.starts_stack, starts)
+    Array::push(c.ends_stack, ends)
+    Array::push(c.bases, base)
+  })
+}
+
+export fn binder_capture_pop_fragment(context: Option[ParserBinderContext]) -> Unit {
+  with_context(context, (c) -> {
+    let n = Array::length(c.starts_stack)
+    if n <= 1 || Array::length(c.ends_stack) != n || Array::length(c.bases) != n {
+      Array::set(c.eligible, 0, false)
+    } else {
+      Array::truncate(c.starts_stack, n - 1)
+      Array::truncate(c.ends_stack, n - 1)
+      Array::truncate(c.bases, n - 1)
+    }
+  })
+}
+
+export fn binder_capture_mark_ineligible(context: Option[ParserBinderContext]) -> Unit {
+  with_context(context, (c) -> Array::set(c.eligible, 0, false))
+}
+
+export fn binder_capture_is_eligible(context: ParserBinderContext) -> Bool {
+  Array::length(context.eligible) == 1 && Array::get(context.eligible, 0) && Array::length(context.starts_stack) == 1 && Array::length(context.ends_stack) == 1 && Array::length(context.bases) == 1
+}
+
+export fn binder_capture_rows(context: ParserBinderContext) -> Array[SourceBinder] {
+  Array::slice(context.rows, 0, Array::length(context.rows))
 }

--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -51,7 +51,17 @@ import ./token.vibe {
 }
 
 import ./parser_binder_context.vibe {
-  ParserBinderContext
+  ParserBinderContext,
+  SourceBinder,
+  SyntheticBinderKind,
+  binder_capture_append,
+  binder_capture_insert_synthetic_at,
+  binder_capture_mark,
+  binder_capture_rename_first_synthetic,
+  binder_capture_source,
+  binder_capture_swap_segments,
+  binder_capture_synthetic,
+  binder_capture_take_from
 }
 
 //# Functions
@@ -132,6 +142,7 @@ fn parse_let_type_params(tokens: Array[Token], pos: Int, context: Option[ParserB
         break
       },
       TIdent(name) => {
+        binder_capture_source(context, name, p, p)
         ArrayBuilder::push(names, name)
         p = p + 1
         match peek(tokens, p) {
@@ -374,6 +385,55 @@ fn reject_pattern_let_annotation(tokens: Array[Token], pos: Int) -> Int with Exc
 /// are not recovered by `parse_pattern` — the record path is positional, the
 /// same convention the block-level `__rec_field` desugar uses — so the marker
 /// carries empty names and the expansion reads by index.
+fn remap_top_pattern_rows(pat: Pat, rows: Array[SourceBinder], at: Int, out: ArrayBuilder[SourceBinder], nested: Bool) -> Int {
+  match pat {
+    PBind(_) => {
+      if at < Array::length(rows) {
+        ArrayBuilder::push(out, Array::get(rows, at))
+        at + 1
+      } else {
+        at
+      }
+    },
+    PWild => at,
+    PTuple(items) => {
+      if nested {
+        ArrayBuilder::push(out, Synthetic("__dst_nested", ParserSynthetic))
+      } else {
+        ()
+      }
+      let mut next = at
+      for item in items {
+        next = remap_top_pattern_rows(item, rows, next, out, true)
+      }
+      next
+    },
+    PStruct(_, fields) => {
+      if nested {
+        ArrayBuilder::push(out, Synthetic("__dst_nested", ParserSynthetic))
+      } else {
+        ()
+      }
+      let mut next = at
+      for field in fields {
+        next = remap_top_pattern_rows(field.1, rows, next, out, true)
+      }
+      next
+    },
+    _ => at
+  }
+}
+
+fn remapped_top_pattern_rows(pat: Pat, rows: Array[SourceBinder]) -> Array[SourceBinder] {
+  let out = ArrayBuilder::new()
+  let consumed = remap_top_pattern_rows(pat, rows, 0, out, false)
+  if consumed == Array::length(rows) {
+    ArrayBuilder::freeze(out)
+  } else {
+    rows
+  }
+}
+
 fn record_destr_marker(p: Pat, context: Option[ParserBinderContext]) -> Pat {
   match p {
     PTuple(elems) => {
@@ -420,6 +480,7 @@ export fn expand_top_level_pattern_lets_with_binder_context(stmts: Array[Stmt], 
     match Array::get(stmts, i) {
       SLetPat(pat, val) => {
         let tmp = String::concat("__dst", __to_string(i))
+        binder_capture_rename_first_synthetic(context, "__dst", tmp)
         ArrayBuilder::push(out, SLet(false, false, tmp, None, val))
         emit_top_level_pat_bindings(out, pat, tmp, context)
       },
@@ -475,6 +536,7 @@ fn emit_top_level_pat_projection(out: ArrayBuilder[Stmt], sub: Pat, read: Expr, 
     PWild => (),
     _ => {
       let nested = String::concat(src, String::concat("_", __to_string(index)))
+      binder_capture_rename_first_synthetic(context, "__dst_nested", nested)
       ArrayBuilder::push(out, SLet(false, false, nested, None, read))
       emit_top_level_pat_bindings(out, sub, nested, context)
     }
@@ -502,6 +564,7 @@ export fn parse_let_stmt_with_binder_context(tokens: Array[Token], starts: Array
     },
     TMut => match peek(tokens, pos + 1) {
       TIdent(name) => {
+        binder_capture_source(context, name, pos + 1, pos + 1)
         let (ty_opt, eq_pos) = match peek(tokens, pos + 2) {
           TColon => {
             let (ty, tp) = parse_type_impl(tokens, pos + 3, 0)
@@ -527,10 +590,14 @@ export fn parse_let_stmt_with_binder_context(tokens: Array[Token], starts: Array
     // literals, `|`) are rejected here — they can fail, and a top-level
     // binding has nowhere to fail to.
     TLParen => {
+      let pattern_mark = binder_capture_mark(context)
       let (pat, after_pat) = parse_pattern_with_binder_context(tokens, pos, context)
       require_irrefutable_top_level_pat(pat)
+      let pattern_rows = binder_capture_take_from(context, pattern_mark)
       let ep = expect_tk(tokens, reject_pattern_let_annotation(tokens, after_pat), "=")
       let val_pair = parse_impl_with_binder_context(tokens, starts, ep, 0, context)
+      binder_capture_insert_synthetic_at(context, pattern_mark, "__dst")
+      binder_capture_append(context, remapped_top_pattern_rows(pat, pattern_rows))
       (top_level_pattern_let(exported, pat, val_pair.0, context), val_pair.1)
     },
     TIdent(_name0) => {
@@ -558,10 +625,14 @@ export fn parse_let_stmt_with_binder_context(tokens: Array[Token], starts: Array
       // `parse_pattern` returns `PStruct(name, [(field, PBind field), ..])`,
       // which the expansion turns into one `<tmp>.field` projection each.
       if is_top_level_record_destr || is_struct_destructure {
+        let pattern_mark = binder_capture_mark(context)
         let (ppat, after_ppat) = parse_pattern_with_binder_context(tokens, pos, context)
         require_irrefutable_top_level_pat(ppat)
+        let pattern_rows = binder_capture_take_from(context, pattern_mark)
         let pep = expect_tk(tokens, reject_pattern_let_annotation(tokens, after_ppat), "=")
         let pval_pair = parse_impl_with_binder_context(tokens, starts, pep, 0, context)
+        binder_capture_insert_synthetic_at(context, pattern_mark, "__dst")
+        binder_capture_append(context, remapped_top_pattern_rows(ppat, pattern_rows))
         let marked = if is_top_level_record_destr {
           record_destr_marker(ppat, context)
         } else {
@@ -646,7 +717,7 @@ fn parse_fn_name(tokens: Array[Token], pos: Int, context: Option[ParserBinderCon
   }
 }
 
-fn parse_fn_signature_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, Array[String], Array[(String, Array[String])]), (Array[(String, Option[TypeExpr])], TypeExpr, Option[String]), (Array[Expr], Array[Expr]), Int) with Exception {
+fn parse_fn_signature_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, Array[String], Array[(String, Array[String])]), (Array[(String, Option[TypeExpr])], TypeExpr, Option[String]), (Array[Expr], Array[Expr]), Int, (Array[SourceBinder], Array[SourceBinder])) with Exception {
   let (name, name_next) = parse_fn_name(tokens, pos, context)
   let (tps, tbs, after_gen) = parse_value_bracket_header(tokens, name_next, context)
   let lp = expect_tk(tokens, after_gen, "(")
@@ -676,6 +747,12 @@ fn parse_fn_signature_with_binder_context(tokens: Array[Token], pos: Int, contex
   let enss = Array::slice([
     EIdent("", 0 - 1)
   ], 0, 0)
+  let req_rows = Array::slice([
+    SourceToken("", 0, 0)
+  ], 0, 0)
+  let ens_rows = Array::slice([
+    SourceToken("", 0, 0)
+  ], 0, 0)
   let where_next = match peek(tokens, eff_next) {
     TIdent(w) => if w == "where" {
       let mut wp = expect_tk(tokens, eff_next + 1, "{")
@@ -688,12 +765,20 @@ fn parse_fn_signature_with_binder_context(tokens: Array[Token], pos: Int, contex
           },
           TIdent(kind) => {
             let cp = expect_tk(tokens, wp + 1, ":")
+            let cond_mark = binder_capture_mark(context)
             let (cond, cnext) = parse_impl_with_binder_context(tokens, [
             ], cp, 0, context)
+            let cond_rows = binder_capture_take_from(context, cond_mark)
             if kind == "requires" {
               Array::push(reqs, cond)
+              for row in cond_rows {
+                Array::push(req_rows, row)
+              }
             } else if kind == "ensures" {
               Array::push(enss, cond)
+              for row in cond_rows {
+                Array::push(ens_rows, row)
+              }
             } else {
               throw("expected 'requires' or 'ensures' in where clause, got '\{kind}'")
             }
@@ -709,11 +794,12 @@ fn parse_fn_signature_with_binder_context(tokens: Array[Token], pos: Int, contex
     } else eff_next,
     _ => eff_next
   }
-  ((name, tps, tbs), (params, ret_ty, eff_opt), (reqs, enss), where_next)
+  ((name, tps, tbs), (params, ret_ty, eff_opt), (reqs, enss), where_next, (req_rows, ens_rows))
 }
 
 export fn parse_fn_signature(tokens: Array[Token], pos: Int) -> ((String, Array[String], Array[(String, Array[String])]), (Array[(String, Option[TypeExpr])], TypeExpr, Option[String]), (Array[Expr], Array[Expr]), Int) with Exception {
-  parse_fn_signature_with_binder_context(tokens, pos, None)
+  let (head, sig, contracts, next, _) = parse_fn_signature_with_binder_context(tokens, pos, None)
+  (head, sig, contracts, next)
 }
 
 /// ADR-0069 Phase 1: `fn main { ... }` / `fn main with Fs { ... }` — the ONE
@@ -724,6 +810,7 @@ export fn parse_fn_signature(tokens: Array[Token], pos: Int) -> ((String, Array[
 /// checker, codegen, and the printer round-trip (which prints the annotated
 /// `fn main() -> Unit` spelling — same meaning) are all untouched.
 fn parse_fn_main_stmt(tokens: Array[Token], starts: Array[Int], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  binder_capture_source(context, "main", pos, pos)
   // pos points at the `main` identifier; the caller verified the next token
   // is `{` (body) or `with` (capability row then body).
   let (eff_opt, body_start) = match peek(tokens, pos + 1) {
@@ -840,10 +927,11 @@ fn parse_fn_wasm_body(tokens: Array[Token], pos: Int, exported: Bool, name: Stri
 }
 
 fn parse_fn_stmt_general(tokens: Array[Token], starts: Array[Int], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
-  let (head, sig, contracts, where_next) = parse_fn_signature_with_binder_context(tokens, pos, context)
+  let (head, sig, contracts, where_next, contract_rows) = parse_fn_signature_with_binder_context(tokens, pos, context)
   let (name, tps, tbs) = head
   let (params, ret_ty, eff_opt) = sig
   let (reqs, enss) = contracts
+  let (req_rows, ens_rows) = contract_rows
   // #805: `= wasm "..."` inline-wasm body form (see parse_fn_wasm_body).
   let is_wasm_body = match peek(tokens, where_next) {
     TEq => match peek(tokens, where_next + 1) {
@@ -856,7 +944,17 @@ fn parse_fn_stmt_general(tokens: Array[Token], starts: Array[Int], pos: Int, exp
     parse_fn_wasm_body(tokens, where_next + 2, exported, name, tps, tbs, params, ret_ty, eff_opt, reqs, enss, context)
   } else {
     let br = expect_tk(tokens, where_next, "{")
+    let body_mark = binder_capture_mark(context)
     let (body, end) = parse_impl_with_binder_context(tokens, starts, br, mode_block, context)
+    let body_rows = binder_capture_take_from(context, body_mark)
+    binder_capture_append(context, req_rows)
+    if Array::length(enss) > 0 {
+      binder_capture_synthetic(context, "result")
+    } else {
+      ()
+    }
+    binder_capture_append(context, body_rows)
+    binder_capture_append(context, ens_rows)
     // ADR-0064 (#727/#731): keep the declaration form — including the where
     // contract's requires/ensures conditions — in the AST so the printer and
     // normalize can round-trip `fn`. The runtime contract desugar (identical

--- a/lib/@vibe/parser/parser_expr_core.vibe
+++ b/lib/@vibe/parser/parser_expr_core.vibe
@@ -17,7 +17,7 @@ import ./token.vibe {
 }
 
 import ./parser_binder_context.vibe {
-  ParserBinderContext
+  ParserBinderContext, binder_capture_insert_synthetic_at, binder_capture_mark
 }
 
 //# Functions
@@ -240,7 +240,7 @@ fn has_placeholder_args(args: Array[Expr]) -> Bool {
   found
 }
 
-fn parse_call_args_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[Expr], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Array[Expr], Int) with Exception {
+fn parse_call_args_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[Expr], row_marks: ArrayBuilder[Int], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Array[Expr], Int) with Exception {
   let mut p = pos
   let mut done = false
   while !done {
@@ -251,6 +251,7 @@ fn parse_call_args_rest(tokens: Array[Token], starts: Array[Int], pos: Int, b: A
           done = true
         },
         _ => {
+          ArrayBuilder::push(row_marks, binder_capture_mark(context))
           let (e, next) = parse_call_arg(tokens, starts, p + 1, parse_recur, context)
           ArrayBuilder::push(b, e)
           p = next
@@ -273,7 +274,7 @@ fn slice_from_zero_expr(cur_expr: Expr, end_expr: Expr) -> Expr {
   ECall(EIdent("__slice", -1), args, -1)
 }
 
-fn wrap_placeholder_arg(arg: Expr, context: Option[ParserBinderContext]) -> Expr {
+fn wrap_placeholder_arg(arg: Expr, _context: Option[ParserBinderContext]) -> Expr {
   let mut pc = 0
   let params = Array::slice([
     ("", None)
@@ -351,6 +352,35 @@ fn has_non_pipe_infix_top(tokens: Array[Token], start: Int, end: Int) -> Bool {
     }
   }
   go(start, 0, false)
+}
+
+fn placeholder_count(arg: Expr) -> Int {
+  match arg {
+    EIdent(n, _) => if n == "_" {
+      1
+    } else {
+      0
+    },
+    EBinOp(_, l, r) => placeholder_count(l) + placeholder_count(r),
+    _ => 0
+  }
+}
+
+fn insert_placeholder_rows(args: Array[Expr], row_marks: Array[Int], context: Option[ParserBinderContext]) -> Unit {
+  let mut i = Array::length(args) - 1
+  while i >= 0 {
+    let arg = Array::get(args, i)
+    if !pipe_arg_is_hole(arg) {
+      let mut p = placeholder_count(arg) - 1
+      while p >= 0 {
+        binder_capture_insert_synthetic_at(context, Array::get(row_marks, i), String::concat("__ph", __to_string(p)))
+        p = p - 1
+      }
+    } else {
+      ()
+    }
+    i = i - 1
+  }
 }
 
 fn desugar_placeholder_args(args: Array[Expr], context: Option[ParserBinderContext]) -> Array[Expr] {
@@ -472,11 +502,14 @@ fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr,
         TRParen => parse_postfix(tokens, starts, pos + 2, build_call_expr(expr, empty_exprs(), pos), parse_recur, context),
         _ => {
           let b = ArrayBuilder::new()
+          let row_marks = ArrayBuilder::new()
+          ArrayBuilder::push(row_marks, binder_capture_mark(context))
           let (first_arg, next_pos) = parse_call_arg(tokens, starts, pos + 1, parse_recur, context)
           ArrayBuilder::push(b, first_arg)
-          let (args, end_pos) = parse_call_args_rest(tokens, starts, next_pos, b, parse_recur, context)
+          let (args, end_pos) = parse_call_args_rest(tokens, starts, next_pos, b, row_marks, parse_recur, context)
           let close_pos = expect_tk(tokens, end_pos, ")")
           let call_args = if has_placeholder_args(args) {
+            insert_placeholder_rows(args, ArrayBuilder::freeze(row_marks), context)
             desugar_placeholder_args(args, context)
           } else {
             args

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -30,7 +30,16 @@ import ./token.vibe {
 }
 
 import ./parser_binder_context.vibe {
-  ParserBinderContext
+  ParserBinderContext,
+  SourceBinder,
+  SyntheticBinderKind,
+  binder_capture_append,
+  binder_capture_insert_synthetic_at,
+  binder_capture_mark,
+  binder_capture_mark_ineligible,
+  binder_capture_source,
+  binder_capture_swap_segments,
+  binder_capture_take_from
 }
 
 //# Functions
@@ -39,7 +48,8 @@ import ./parser_binder_context.vibe {
 /// `ty` (enforced by the call-argument check) while evaluating to `val` itself.
 /// Used to type-check a local `let x: T = e`, whose annotation `ELet` cannot
 /// store. Uses only EFn/ECall, so every downstream pass handles it unchanged.
-fn ascribe_wrap(val: Expr, ty: TypeExpr, context: Option[ParserBinderContext]) -> Expr {
+fn ascribe_wrap(val: Expr, ty: TypeExpr, capture_mark: Int, context: Option[ParserBinderContext]) -> Expr {
+  binder_capture_insert_synthetic_at(context, capture_mark, "__asc")
   let tparams = _no_tp()
   let tbounds = _no_tb()
   let params = [
@@ -137,6 +147,7 @@ fn dispatch_type_params_with_binder_context(tokens: Array[Token], pos: Int, cont
         done = true
       },
       TIdent(name) => {
+        binder_capture_source(context, name, p, p)
         ArrayBuilder::push(names, name)
         p = p + 1
         match peek(tokens, p) {
@@ -263,27 +274,66 @@ fn desugar_guarded(arms: Array[(Pat, Expr, Expr)], i: Int, scrut: Expr, context:
 /// #666: parse all match arms into `b` as (pattern, guard|EBool(true), body),
 /// setting hg[0] when any arm carries a guard. Arms are comma-separated, ending
 /// at `}` (optionally with a trailing comma).
-fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(Pat, Expr, Expr)], hg: Array[Bool], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> Int with Exception {
+fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: ArrayBuilder[(Pat, Expr, Expr)], row_b: ArrayBuilder[(Array[SourceBinder], Array[SourceBinder], Array[SourceBinder])], hg: Array[Bool], parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> Int with Exception {
+  let pat_mark = binder_capture_mark(context)
   let (pat, pa) = parse_pattern_with_binder_context(tokens, pos, context)
-  let (arm_guard, after_g) = match peek(tokens, pa) {
+  let pat_rows = binder_capture_take_from(context, pat_mark)
+  let (arm_guard, guard_rows, after_g) = match peek(tokens, pa) {
     TIf => {
       Array::set(hg, 0, true)
-      parse_recur(tokens, pa + 1, 0, context)
+      let guard_mark = binder_capture_mark(context)
+      let (guard_expr, next) = parse_recur(tokens, pa + 1, 0, context)
+      (guard_expr, binder_capture_take_from(context, guard_mark), next)
     },
-    _ => (EBool(true), pa)
+    _ => (EBool(true), ArrayBuilder::freeze(ArrayBuilder::new()), pa)
   }
   let arrow = expect_tk(tokens, after_g, "=>")
+  let body_mark = binder_capture_mark(context)
   let (body, bn) = parse_recur(tokens, arrow, 0, context)
+  let body_rows = binder_capture_take_from(context, body_mark)
   ArrayBuilder::push(b, (pat, arm_guard, body))
+  ArrayBuilder::push(row_b, (pat_rows, guard_rows, body_rows))
   match peek(tokens, bn) {
     TComma => match peek(tokens, bn + 1) {
       TRBrace => bn + 2,
-      _ => collect_match_arms(tokens, starts, bn + 1, b, hg, parse_recur, context)
+      _ => collect_match_arms(tokens, starts, bn + 1, b, row_b, hg, parse_recur, context)
     },
     TRBrace => bn + 1,
     // Comma-less arm separation: mirror the old parse_match_rest fall-through,
     // which parsed the next arm's pattern without consuming a separator.
-    _ => collect_match_arms(tokens, starts, bn, b, hg, parse_recur, context)
+    _ => collect_match_arms(tokens, starts, bn, b, row_b, hg, parse_recur, context)
+  }
+}
+
+fn append_source_rows(out: ArrayBuilder[SourceBinder], rows: Array[SourceBinder]) -> Unit {
+  for row in rows {
+    ArrayBuilder::push(out, row)
+  }
+  ()
+}
+
+fn desugar_guarded_rows(arms: Array[(Pat, Expr, Expr)], rows: Array[(Array[SourceBinder], Array[SourceBinder], Array[SourceBinder])], i: Int) -> Array[SourceBinder] {
+  if i >= Array::length(arms) {
+    ArrayBuilder::freeze(ArrayBuilder::new())
+  } else {
+    let (_, arm_guard, _) = Array::get(arms, i)
+    let (pat_rows, guard_rows, body_rows) = Array::get(rows, i)
+    let rest = desugar_guarded_rows(arms, rows, i + 1)
+    let no_guard = match arm_guard {
+      EBool(bv) => bv,
+      _ => false
+    }
+    let out = ArrayBuilder::new()
+    append_source_rows(out, pat_rows)
+    if no_guard {
+      append_source_rows(out, body_rows)
+    } else {
+      append_source_rows(out, guard_rows)
+      append_source_rows(out, body_rows)
+      append_source_rows(out, rest)
+    }
+    append_source_rows(out, rest)
+    ArrayBuilder::freeze(out)
   }
 }
 
@@ -455,6 +505,83 @@ fn parse_block_value_body(tokens: Array[Token], eq: Int, parse_recur: (Array[Tok
 fn parse_block_value_only(tokens: Array[Token], value_pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
   let val_pair = parse_recur(tokens, value_pos, 0, context)
   (val_pair.0, skip_semi(tokens, val_pair.1))
+}
+
+fn remap_struct_destr_rows(pat: Pat, rows: Array[SourceBinder], context: Option[ParserBinderContext]) -> Array[SourceBinder] {
+  let out = ArrayBuilder::new()
+  let mut at = 0
+  match pat {
+    PStruct(_, fields) => for field in fields {
+      match field.1 {
+        PBind(_) => {
+          if at < Array::length(rows) {
+            ArrayBuilder::push(out, Array::get(rows, at))
+            at = at + 1
+          } else {
+            binder_capture_mark_ineligible(context)
+          }
+        },
+        PWild => (),
+        _ => binder_capture_mark_ineligible(context)
+      }
+    },
+    _ => binder_capture_mark_ineligible(context)
+  }
+  if at != Array::length(rows) {
+    binder_capture_mark_ineligible(context)
+  } else {
+    ()
+  }
+  ArrayBuilder::freeze(out)
+}
+
+fn remap_record_destr_rows(pat: Pat, rows: Array[SourceBinder], context: Option[ParserBinderContext]) -> Array[SourceBinder] {
+  let out = ArrayBuilder::new()
+  let mut at = 0
+  match pat {
+    PTuple(fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        match Array::get(fields, i) {
+          PBind(_) => {
+            if at < Array::length(rows) {
+              ArrayBuilder::push(out, Array::get(rows, at))
+              at = at + 1
+            } else {
+              binder_capture_mark_ineligible(context)
+            }
+          },
+          PWild => (),
+          PTuple(sub) => {
+            ArrayBuilder::push(out, Synthetic(String::concat("__rec_sub_", __to_string(i)), ParserSynthetic))
+            for item in sub {
+              match item {
+                PBind(_) => {
+                  if at < Array::length(rows) {
+                    ArrayBuilder::push(out, Array::get(rows, at))
+                    at = at + 1
+                  } else {
+                    binder_capture_mark_ineligible(context)
+                  }
+                },
+                PWild => (),
+                _ => binder_capture_mark_ineligible(context)
+              }
+            }
+          },
+          _ => binder_capture_mark_ineligible(context)
+        }
+        i = i + 1
+      }
+    },
+    _ => binder_capture_mark_ineligible(context)
+  }
+  if at != Array::length(rows) {
+    binder_capture_mark_ineligible(context)
+  } else {
+    ()
+  }
+  ArrayBuilder::freeze(out)
 }
 
 fn apply_struct_destr(pat: Pat, val: Expr, rest: Expr, context: Option[ParserBinderContext]) -> Expr {
@@ -726,6 +853,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
         match peek(tokens, next) {
           TRec => match peek(tokens, next + 1) {
             TIdent(name) => {
+              binder_capture_source(context, name, next + 1, next + 1)
               // #789: consume an optional `[T]` binder before the type, as for
               // the plain local let below.
               let (rtps, rtbs, rec_ann, eq_pos_r) = match peek(tokens, next + 2) {
@@ -775,7 +903,9 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                 },
                 _ => (None, next + 2)
               }
+              binder_capture_source(context, name, next + 1, next + 1)
               let eq = expect_tk(tokens, eq_pos_m, "=")
+              let value_mark = binder_capture_mark(context)
               let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
               if next_pos <= eq {
                 throw("internal parser error: block let-mut parser did not advance")
@@ -783,7 +913,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                 let val2 = match m_ann {
                   Some(the_type) => match distribute_local_fn_ann(the_type, val, context) {
                     Some(distributed) => distributed,
-                    None => ascribe_wrap(val, the_type, context)
+                    None => ascribe_wrap(val, the_type, value_mark, context)
                   },
                   None => val
                 }
@@ -795,8 +925,12 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
           },
           TStar => match peek(tokens, next + 1) {
             TIdent(name) => {
+              let bind_mark = binder_capture_mark(context)
+              binder_capture_source(context, name, next + 1, next + 1)
+              let value_mark = binder_capture_mark(context)
               let eq = expect_tk(tokens, next + 2, "=")
               let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
+              binder_capture_swap_segments(context, bind_mark, value_mark)
               if next_pos <= eq {
                 throw("internal parser error: block let* parser did not advance")
               } else {
@@ -827,23 +961,34 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
               _ => false
             }
             if next_is_struct_destr {
+              let pattern_mark = binder_capture_mark(context)
               let (pat, pn) = parse_pattern_with_binder_context(tokens, next, context)
+              let pattern_rows = binder_capture_take_from(context, pattern_mark)
               let eq = expect_tk(tokens, pn, "=")
               let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
+              binder_capture_insert_synthetic_at(context, pattern_mark, "__struct_destr")
+              binder_capture_append(context, remap_struct_destr_rows(pat, pattern_rows, context))
               ArrayBuilder::push(steps, StepStructDestr(pat, val))
               p = next_pos
             } else if next_is_record_destr {
+              let pattern_mark = binder_capture_mark(context)
               let (pat, pn) = parse_pattern_with_binder_context(tokens, next, context)
+              let pattern_rows = binder_capture_take_from(context, pattern_mark)
               let eq = expect_tk(tokens, pn, "=")
               let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
+              binder_capture_insert_synthetic_at(context, pattern_mark, "__rec_destr")
+              binder_capture_append(context, remap_record_destr_rows(pat, pattern_rows, context))
               ArrayBuilder::push(steps, StepRecordDestr(pat, val))
               p = next_pos
             } else {
               match after_name {
                 TLParen => {
+                  let pattern_mark = binder_capture_mark(context)
                   let (pat, pn) = parse_pattern_with_binder_context(tokens, next, context)
+                  let value_mark = binder_capture_mark(context)
                   let eq = expect_tk(tokens, pn, "=")
                   let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
+                  binder_capture_swap_segments(context, pattern_mark, value_mark)
                   if next_pos <= eq {
                     throw("internal parser error: block let-ctor-pat parser did not advance")
                   } else {
@@ -864,7 +1009,9 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                       (no_tp, no_tb, None, next + 1)
                     }
                   }
+                  binder_capture_source(context, name, next, next)
                   let eq = expect_tk(tokens, eq_pos, "=")
+                  let value_mark = binder_capture_mark(context)
                   let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
                   if next_pos <= eq {
                     throw("internal parser error: block let parser did not advance")
@@ -881,7 +1028,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                     let val2 = match ann_type {
                       Some(the_type) => match distribute_local_fn_ann(the_type, val, context) {
                         Some(distributed) => apply_local_let_tp(ltps, ltbs, distributed, context),
-                        None => ascribe_wrap(val, the_type, context)
+                        None => ascribe_wrap(val, the_type, value_mark, context)
                       },
                       None => val
                     }
@@ -893,9 +1040,12 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
             }
           },
           TLParen => {
+            let pattern_mark = binder_capture_mark(context)
             let (pat, pn) = parse_pattern_with_binder_context(tokens, next, context)
+            let value_mark = binder_capture_mark(context)
             let eq = expect_tk(tokens, pn, "=")
             let (val, next_pos) = parse_block_value_only(tokens, eq, parse_recur, context)
+            binder_capture_swap_segments(context, pattern_mark, value_mark)
             if next_pos <= eq {
               throw("internal parser error: block let-pat parser did not advance")
             } else {
@@ -1077,6 +1227,7 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
       (EIf(cond, then_e, else_e), end_pos)
     }
   } else if mode == 22 {
+    let match_mark = binder_capture_mark(context)
     let (scrutinee, sn) = parse_recur(tokens, pos, 0, context)
     let br = expect_tk(tokens, sn, "{")
     match peek(tokens, br) {
@@ -1088,12 +1239,16 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
         // scrutinee) and desugar guards into nested EIf/EMatch. Otherwise emit
         // a plain EMatch.
         let ab = ArrayBuilder::new()
+        let row_b = ArrayBuilder::new()
         let hg = [
           false
         ]
-        let endpos = collect_match_arms(tokens, starts, br, ab, hg, parse_recur, context)
+        let endpos = collect_match_arms(tokens, starts, br, ab, row_b, hg, parse_recur, context)
         let arms3 = ArrayBuilder::freeze(ab)
+        let arm_rows = ArrayBuilder::freeze(row_b)
         if Array::get(hg, 0) {
+          binder_capture_insert_synthetic_at(context, match_mark, "__mg")
+          binder_capture_append(context, desugar_guarded_rows(arms3, arm_rows, 0))
           let final_arms = desugar_guarded(arms3, 0, EIdent("__mg", 0 - 1), context)
           (ELet("__mg", scrutinee, EMatch(EIdent("__mg", 0 - 1), final_arms), -1), endpos)
         } else {
@@ -1101,6 +1256,9 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
           let mut k = 0
           while k < Array::length(arms3) {
             let (p, _, bd) = Array::get(arms3, k)
+            let (pat_rows, _, body_rows) = Array::get(arm_rows, k)
+            binder_capture_append(context, pat_rows)
+            binder_capture_append(context, body_rows)
             ArrayBuilder::push(plain, (p, bd))
             k = k + 1
           }
@@ -1163,6 +1321,8 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
       TIdent(first_name) => match peek(tokens, start + 1) {
         TComma => match peek(tokens, start + 2) {
           TIdent(second_name) => {
+            binder_capture_source(context, second_name, start + 2, start + 2)
+            binder_capture_source(context, first_name, start, start)
             let ip = expect_tk(tokens, start + 3, "in")
             match parse_recur(tokens, ip, 0, context) {
               (iterable, after_iter) => {
@@ -1176,6 +1336,7 @@ export fn parse_impl_dispatch_with_binder_context(tokens: Array[Token], starts: 
           _ => throw("expected value binding name after ','")
         },
         _ => {
+          binder_capture_source(context, first_name, start, start)
           let ip = expect_tk(tokens, start + 1, "in")
           match parse_recur(tokens, ip, 0, context) {
             (iterable, after_iter) => {

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -25,7 +25,13 @@ import ./token.vibe {
 }
 
 import ./parser_binder_context.vibe {
-  ParserBinderContext
+  ParserBinderContext,
+  binder_capture_insert_synthetic_at,
+  binder_capture_mark,
+  binder_capture_mark_ineligible,
+  binder_capture_pop_fragment,
+  binder_capture_push_fragment,
+  binder_capture_source
 }
 
 import ./lexer.vibe {
@@ -194,12 +200,22 @@ fn build_interp_expr(parts: Array[String], offsets: Array[Int], outer_starts: Ar
         ()
       }
     } else {
-      let (ftoks, fstarts, _fends) = lex_with_offsets(part)
-      let (pe0, _) = parse_recur(ftoks, 0, 0, context)
+      let (ftoks, fstarts, fends) = lex_with_offsets(part)
       let frag_off = if i < Array::length(offsets) {
         Array::get(offsets, i)
       } else {
         -1
+      }
+      if frag_off >= 0 {
+        binder_capture_push_fragment(context, fstarts, fends, frag_off)
+      } else {
+        binder_capture_mark_ineligible(context)
+      }
+      let (pe0, _) = parse_recur(ftoks, 0, 0, context)
+      if frag_off >= 0 {
+        binder_capture_pop_fragment(context)
+      } else {
+        ()
       }
       let pe = if frag_off >= 0 {
         map_expr_offsets(pe0, (o) -> remap_frag_off(o, outer_starts, fstarts, frag_off), context)
@@ -349,6 +365,7 @@ fn parse_loop_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_
             done = true
           },
           TIdent(name) => {
+            binder_capture_source(context, name, cur, cur)
             let eq_pos = expect_tk(tokens, cur + 1, "=")
             let (init, next_pos) = parse_recur(tokens, eq_pos, 0, context)
             ArrayBuilder::push(param_names_b, name)
@@ -368,7 +385,9 @@ fn parse_loop_primary(tokens: Array[Token], starts: Array[Int], pos: Int, parse_
         }
       }
       let body_pos = expect_tk(tokens, cur, "{")
+      let body_mark = binder_capture_mark(context)
       let (body, end_pos) = parse_recur(tokens, body_pos, 20, context)
+      binder_capture_insert_synthetic_at(context, body_mark, "__loop_result")
       // Desugar ELoop into ELetMut + EWhile
       let pnames = ArrayBuilder::freeze(param_names_b)
       let pinits = ArrayBuilder::freeze(param_inits_b)
@@ -538,14 +557,35 @@ fn parse_continue_primary(tokens: Array[Token], starts: Array[Int], pos: Int, pa
   match peek(tokens, pos + 1) {
     TLParen => {
       let b = ArrayBuilder::new()
+      let marks = ArrayBuilder::new()
       match peek(tokens, pos + 2) {
         TRParen => (EContinue(empty_exprs()), pos + 3),
         _ => {
-          let (first, next_pos) = parse_recur(tokens, pos + 2, 0, context)
-          ArrayBuilder::push(b, first)
-          let (args, end_pos) = parse_comma_exprs_rest(tokens, starts, next_pos, b, parse_recur, context)
-          let close_pos = expect_tk(tokens, end_pos, ")")
-          (EContinue(args), close_pos)
+          let mut p = pos + 2
+          let mut done = false
+          while !done {
+            ArrayBuilder::push(marks, binder_capture_mark(context))
+            let (arg, next) = parse_recur(tokens, p, 0, context)
+            ArrayBuilder::push(b, arg)
+            match peek(tokens, next) {
+              TComma => {
+                p = next + 1
+              },
+              TRParen => {
+                p = next + 1
+                done = true
+              },
+              _ => throw("expected ',' or ')' after continue argument")
+            }
+          }
+          let args = ArrayBuilder::freeze(b)
+          let row_marks = ArrayBuilder::freeze(marks)
+          let mut i = Array::length(args) - 1
+          while i >= 0 {
+            binder_capture_insert_synthetic_at(context, Array::get(row_marks, i), String::concat("__lt", __to_string(i)))
+            i = i - 1
+          }
+          (EContinue(args), p)
         }
       }
     },

--- a/scripts/parser_binder_context_spine.test.mjs
+++ b/scripts/parser_binder_context_spine.test.mjs
@@ -9,6 +9,10 @@ const coreSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parse
 const dispatchSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_expr_dispatch.vibe", import.meta.url)), "utf8");
 const primarySource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_expr_primary.vibe", import.meta.url)), "utf8");
 const parserSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser.vibe", import.meta.url)), "utf8");
+const binderContextSource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_binder_context.vibe", import.meta.url)), "utf8");
+const binderAuthoritySource = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/parser_binder_authority.vibe", import.meta.url)), "utf8");
+const parserContract = readFileSync(fileURLToPath(new URL("../lib/@vibe/parser/index.vpkg", import.meta.url)), "utf8");
+const compilerManifest = readFileSync(fileURLToPath(new URL("../lib/@vibe/compiler/compiler_sources_manifest.tsv", import.meta.url)), "utf8");
 
 function regexEscape(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -110,7 +114,10 @@ test("B2 expression helper bodies carry context without private duplicate wrappe
     "parse_param_list(tokens,",
     "parse_impl(tokens,",
   ]);
-  assertNoneWrapper(exprSource, "parse_fn_signature", "parse_fn_signature_with_binder_context(tokens, pos, None)");
+  assertBody(exprSource, "parse_fn_signature", [
+    "parse_fn_signature_with_binder_context(tokens, pos, None)",
+    "(head, sig, contracts, next)",
+  ], ["Some(ParserBinderContext"]);
   assertContextual(exprSource, "parse_fn_main_stmt", [
     "parse_impl_with_binder_context(tokens, starts, br, mode_block, context)",
   ], ["parse_impl(tokens,"]);
@@ -260,8 +267,39 @@ test("B2 top-level helper bodies carry context and ordinary entries pass None", 
 
   assertNoneWrapper(parserSource, "parse_program_located", "parse_program_located_with_context_impl(tokens, starts, source, None).0");
   assertContextual(parserSource, "parse_program_located_with_untrusted_binder_context", ["parse_program_located_with_context_impl(tokens, starts, source, context)"], ["ParserBinderContext::{"]);
-  // High-level entry has no caller context parameter and mints fresh plumbing.
-  assertBody(parserSource, "parse_program_located_with_binder_context", ["parse_program_located_with_context_impl(tokens, starts, source, Some(ParserBinderContext::{"], ["context: Option[ParserBinderContext]"]);
+  // Compatibility entry remains authority-free; only the source-owning entry
+  // may mint a context with exact start/end tables.
+  assertBody(parserSource, "parse_program_located_with_binder_context", ["parse_program_located_with_context_impl(tokens, starts, source, None).0"], ["Some(ParserBinderContext::{", "binder_capture_context"]);
+});
+
+test("atomic binder authority is source-owned, validated, fail-closed, and bundled", () => {
+  assertBody(parserSource, "parse_source_located_with_binder_authority", [
+    "lex_with_offsets(source)",
+    "binder_capture_context(starts, ends)",
+    "parse_program_located_with_context_impl(tokens, starts, source, Some(context))",
+    "binder_capture_is_eligible(context)",
+    "validate_program_binder_rows(program, rows, source)",
+  ], ["tokens: Array[Token]", "context: Option[ParserBinderContext]"]);
+  assertBody(binderContextSource, "binder_capture_source", [
+    "Array::get(starts, first_token)",
+    "Array::get(ends, last_token)",
+  ]);
+  assertBody(binderContextSource, "binder_capture_swap_segments", [
+    "binder_capture_take_from(context, start)",
+    "Array::slice(all, cut, Array::length(all))",
+    "Array::slice(all, 0, cut)",
+  ]);
+  assertBody(parserSource, "parse_source_located_with_binder_authority", [
+    "binder_capture_context(starts, ends)",
+  ]);
+  assertBody(binderAuthoritySource, "validate_program_binder_rows", [
+    "next == Array::length(rows)",
+    "_ => (false, next)",
+  ]);
+  assert.match(parserContract, /opaque type LocatedProgramBinderAuthority/);
+  assert.match(parserContract, /fn parse_source_located_with_binder_authority\(source: String\)/);
+  assert.match(compilerManifest, /parser_binder_authority\.vibe/);
+  assert.equal((parserSource.match(/lex_with_offsets\(source\)/g) ?? []).length, 1, "only source-owning authority entry lexes source with exact offsets");
 });
 
 test("parser binder context crosses every immediate binder-bearing lowering and remap seam", () => {
@@ -339,7 +377,7 @@ test("parser binder context crosses every immediate binder-bearing lowering and 
   assertContextual(dispatchSource, "parse_handle_arm", ["qualify_handle_arm_pattern(effect_name, pat, context)"], ["qualify_handle_arm_pattern(effect_name, pat)"]);
   assertContextual(dispatchSource, "parse_impl_block", [
     "fold_block_steps(ArrayBuilder::freeze(steps), context)",
-    "ascribe_wrap(val, the_type, context)",
+    "ascribe_wrap(val, the_type, value_mark, context)",
     "push_pattern_let_step(tokens, steps, pat, val, next_pos, context)",
   ], [
     "fold_block_steps(ArrayBuilder::freeze(steps))",


### PR DESCRIPTION
## Summary

- add a source-owning parser entry that atomically returns the final located AST with exhaustively validated binder provenance;
- capture exact lexer-authored UTF-8 byte spans and closed synthetic-binder kinds through existing parse/lowering control flow;
- fail closed for unsupported, incomplete, extra, recovery, manual/CST, ambiguous impl, nested-module, and `POr` lanes;
- preserve all existing no-capture parser APIs, AST behavior, diagnostics, current-main allocation optimizations, and parser package contracts.

This is prerequisite authority for #1548. It does **not** change the checker, `TypeEnv`, caches, persistence, planner decisions, or production reuse.

## Authority boundary

`parse_source_located_with_binder_authority` owns `lex_with_offsets`, creates its invocation-local capture context, parses to EOF, validates exactly one row per final admitted AST binder with no extras, and publishes the aggregate only after successful validation. Caller-created `ParserBinderContext` remains an explicitly untrusted seam and nominal aggregate possession is not treated as proof elsewhere.

## Validation

- independent semantic review: **ACCEPT**
- parser binder authority fixture: 14/14
- parser context fixture: 5/5
- parser context contract: 6/6
- Node parser spine: 4/4
- unit suite: 642/642
- formatter: 948 files, zero violations
- generated-source freshness: current
- stage2 == stage3: `c0be9a9365f610d0374340f8fb8ea5f57a3a8146ff1d2b2aaf344bd2aff7b6a8`
- deterministic selfcompile heap: `1,076,387,560` bytes ×3
- fixed authority threshold: `1,088,823,640` (margin `12,436,080` bytes)
- heap baseline/cap unchanged

## Notes

The earlier heap rejection measured the accepted authority checkpoint on a stale pre-#1813 parser tree. This reconstruction applies only the authority diff onto current `main` and preserves #1813's empty-metadata/`#zero_alloc` reductions. Linux exact-head CI remains the authoritative complete operation gate.
