### PR TITLE
fix(fmt): struct-literal `::` の書き換えを削除する (#1821)

### DIFF
--- a/fixtures/struct_lit_sugar.vibe
+++ b/fixtures/struct_lit_sugar.vibe
@@ -1,7 +1,17 @@
-// Lightweight struct literal sugar: Type { field: value }
+// A struct literal and field access: `Type::{ field: value }`.
+//
+// This read `Point { x: 3, y: 4 }` until #1821 -- a spelling the parser has
+// never accepted (`unexpected token: :`), left over from a "lightweight sugar"
+// that does not exist. It went unnoticed because the FORMATTER inserted the
+// `::` for it, so anything that formatted the file first saw valid source;
+// that rewrite is gone, and this is now written the way the language spells it.
+//
+// Note the two separators are different and both deliberate: `;` between field
+// DECLARATIONS, `,` between literal fields (fixtures/err_parse_struct_comma_separator.vibe
+// pins the declaration side).
 struct Point { x: Int; y: Int }
 
-let p = Point { x: 3, y: 4 }
+let p = Point::{ x: 3, y: 4 }
 p.x + p.y
 
 __DATA__

--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -1175,15 +1175,6 @@ fn container_forces_list_newlines(c: Int) -> Bool {
   c == c_brace_enum || c == c_bracket_array
 }
 
-fn is_ctor_name_text(text: String) -> Bool {
-  if String::length(text) == 0 {
-    false
-  } else {
-    let f = String::char_code_at(text, 0)
-    f >= 'A' && f <= 'Z'
-  }
-}
-
 //# Token stream queries (operate on parallel kinds/texts arrays)
 
 fn next_non_trivia_kind(toks: Array[LTok], start: Int) -> Int {
@@ -1610,132 +1601,6 @@ fn is_prefix_op(kind: Int, prev_kind: Int) -> Bool {
 ///
 /// This is a strict generalization: with an unqualified name exactly one token
 /// is skipped, so the result is the old two-token lookback.
-fn skip_fmt_trivia_back(toks: Array[LTok], from: Int) -> Int {
-  let mut j = from
-  let mut going = true
-  while going && j >= 0 {
-    let k = Array::get(toks, j).kind
-    if k == k_ws || k == k_newline || k == k_comment {
-      j = j - 1
-    } else {
-      going = false
-    }
-  }
-  j
-}
-
-fn path_governor(toks: Array[LTok], end: Int) -> LTok {
-  let none_tok = LTok::{
-    kind: k_none, text: ""
-  }
-  let head = skip_fmt_trivia_back(toks, end - 1)
-  if head < 0 {
-    none_tok
-  } else if Array::get(toks, head).kind != k_name {
-    Array::get(toks, head)
-  } else {
-    // One name consumed; keep consuming `:: name` pairs behind it.
-    let mut j = skip_fmt_trivia_back(toks, head - 1)
-    let mut going = true
-    while going {
-      if j < 0 {
-        going = false
-      } else if Array::get(toks, j).kind == k_double_colon {
-        let qual = skip_fmt_trivia_back(toks, j - 1)
-        if qual >= 0 && Array::get(toks, qual).kind == k_name {
-          j = skip_fmt_trivia_back(toks, qual - 1)
-        } else {
-          going = false
-        }
-      } else {
-        going = false
-      }
-    }
-    if j < 0 {
-      none_tok
-    } else {
-      Array::get(toks, j)
-    }
-  }
-}
-
-fn should_insert_struct_double_colon(prev_prev_kind: Int, prev_prev_text: String, prev_kind: Int, prev_text: String, curr_kind: Int, in_type_context: Bool) -> Bool {
-  if curr_kind != k_lbrace || in_type_context {
-    false
-  } else if prev_prev_kind == k_struct || prev_prev_kind == k_enum || prev_prev_kind == k_type {
-    false
-  } else if prev_prev_kind == k_trait || prev_prev_kind == k_impl || prev_prev_kind == k_for {
-    // #945: `trait Greet {` / `impl Greet {` / `impl Greet for Int {` are
-    // declaration headers, not struct literals — inserting `::` here
-    // produced unparseable `trait Greet::{`.
-    false
-  } else if prev_prev_text == "effect" || prev_prev_text == "suberror" || prev_prev_text == "with" { false } else if prev_prev_kind == k_plus {
-    // #1429: the tail of a braceless multi-label effect row sits directly
-    // before the BODY brace -- `fn f() -> T with Exception + Fs {` has prev_prev
-    // `+`, prev `Fs`, curr `{`. The `with` guard above only covers the
-    // single-label shape (`with Stdout {`), so without this the row's last
-    // label was rewritten to `Fs::{` and the body parsed as struct-literal
-    // fields: the same corruption family the k_is and k_match/k_while/k_if
-    // guards below were added for. Measured on the tree-wide conversion --
-    // 52 unit-test files regressed and the bundle flatten failed with
-    // "expected qualified operation name after '::' in effect row".
-    //
-    // Cost: `a + Point { x: 1 }` no longer gets the `::` inserted for it.
-    // That spelling is not valid vibe anyway (struct literals are written
-    // `Point::{ .. }`), whereas `with A + B {` is now the shape of EVERY
-    // multi-label row, so the trade is one-sided.
-    false
-  } else if prev_prev_kind == k_thin_arrow {
-    false
-  } else if prev_prev_kind == k_is {
-    // `x is CtUnknown {` (a bare-variant pattern check) followed by an
-    // unrelated `{` that opens the enclosing `if`'s body -- NOT a struct
-    // literal. Confirmed real corruption: checker.vibe's `if hres_now is
-    // CtUnknown {` got rewritten to `if hres_now is CtUnknown::{`, which
-    // parses the block body as bogus struct-literal fields and cascades
-    // into an unrelated "unexpected token" error much later in the file.
-    false
-  } else if prev_prev_kind == k_match || prev_prev_kind == k_while || prev_prev_kind == k_if ||
-  prev_prev_kind == k_loop || prev_prev_kind == k_in {
-    // Same false-positive family as k_is above, pre-empted rather than
-    // waiting for a real corruption to surface one keyword at a time:
-    // `match SomeBareVariant {` / `while SomeFlag {` / `if SomeCond {` /
-    // `loop SomeState {` all put a bare capitalized name directly before a
-    // `{` that opens a match/loop/if BODY, not a struct literal.
-    //
-    // `k_in` joined them for `for x in Items {`, found in review of the #1821
-    // fix -- which is the point the enumeration stopped being the answer. The
-    // entry now PARSES the output and discards a rewrite that breaks it, so a
-    // spelling missing from this list costs a refusal, not a corrupted file.
-    false
-  }
-  else if prev_prev_kind == k_eqeq || prev_prev_kind == k_neq || prev_prev_kind == k_lt ||
-  prev_prev_kind == k_lte || prev_prev_kind == k_gt || prev_prev_kind == k_gte ||
-  prev_prev_kind == k_and_and || prev_prev_kind == k_or_or {
-    // #1821: a COMPARISON before the name, which is how a condition ends before
-    // its body brace: `if x != None {` has prev_prev `!=`, prev `None`, curr
-    // `{`. Every guard above keys off a keyword, and the keyword here is `if`
-    // -- four tokens back, out of reach. The result was `if x != None::{`,
-    // source no parser accepts, written by `pkf run fmt` over source that
-    // compiled, with `--check` then calling the wreck correctly formatted.
-    //
-    // Same one-sided trade as the k_plus case: `a == Point { x: 1 }` no longer
-    // gets a `::` inserted for it, and that spelling is not valid vibe anyway
-    // (struct literals are written `Point::{ .. }`), whereas a comparison
-    // before a body brace is ordinary code.
-    //
-    // This list grows one operator at a time because the guard asks "what came
-    // before the name" and the answer is unbounded. The check that would not
-    // need to enumerate anything -- refuse to write output that does not PARSE
-    // -- is tracked in #1821 and belongs at the entry, which can reach the
-    // parser; this package deliberately has no dependencies.
-    false
-  } else if prev_kind != k_name {
-    false
-  } else {
-    is_ctor_name_text(prev_text)
-  }
-}
 
 fn needs_space(prev_prev_kind: Int, prev_kind: Int, curr_kind: Int, prev_prefix: Bool, prev_pipe: Bool, path_active: Bool) -> Bool {
   if prev_kind == k_none {
@@ -2017,25 +1882,11 @@ fn format_tokens(toks: Array[LTok], indent_size: Int) -> String {
         i = i + 1
       } else {
         let curr_prefix = is_prefix_op(kind, prev_kind)
-        // #1505: the guards want the token governing the whole qualified path,
-        // not the fixed two-token lookback (which is `::` for any qualified
-        // subject). `path_governor` collapses to `prev_prev` for a bare name.
-        let governor = if kind == k_lbrace {
-          path_governor(toks, i)
-        } else {
-          LTok::{
-            kind: prev_prev_kind, text: prev_prev_text
-          }
-        }
-        let insert_double_colon = should_insert_struct_double_colon(governor.kind, governor.text, prev_kind, prev_text, kind, in_type_context)
         let effects_rbrace = kind == k_rbrace && Array::length(container_stack) > 0 &&
         Array::get(container_stack, Array::length(container_stack) - 1) == c_brace_effects
-        if line_has_content && !insert_double_colon &&
+        if line_has_content &&
         (effects_rbrace || needs_space(prev_prev_kind, prev_kind, kind, prev_prefix, prev_pipe, path_active)) {
           Array::push(out, " ")
-        }
-        if insert_double_colon {
-          Array::push(out, "::")
         }
         Array::push(out, rendered_text)
         line_has_content = true

--- a/lib/@vibe/compiler/fmt/struct_double_colon_test.vibe
+++ b/lib/@vibe/compiler/fmt/struct_double_colon_test.vibe
@@ -1,18 +1,25 @@
-//# #1505: the struct-literal `::` normalization must not fire on a `{` that
-// opens a BLOCK whose subject is written with a qualifier.
+//# The formatter used to rewrite `Point { x: 1 }` into `Point::{ x: 1 }`, and
+// that rewrite is GONE (#1821). These tests pin its absence, because the shapes
+// below are the ones it kept corrupting.
 //
-// `should_insert_struct_double_colon` rewrites `Point { x: 1 }` into the
-// canonical `Point::{ x: 1 }`, and guards that with a lookback for the
-// keywords that put a bare name directly before a block brace (`match`, `if`,
-// `while`, `is`, `trait`, `with`, ...). That lookback was a fixed TWO tokens,
-// which any qualifier defeats: in `match Color::Red {` the two-back token is
-// `::`, so every guard missed and the scrutinee became `match Color::Red::{`
-// -- source the parser then reads as struct-literal fields.
+// It decided from the token governing the name before the brace, and every
+// spelling that could sit there had to be excluded by hand:
 //
-// The lookback now skips the whole `Name (:: Name)*` run. It skips ONLY a
-// `::`-joined run, never two adjacent names, because several guards key off
-// contextual keywords that lex as plain names -- `export effect TcpSocket {`
-// regressed exactly that way while this was being written.
+//   #945    `trait Greet {`, `impl Greet for Int {`
+//   #1429   `fn f() -> T with Exception + Fs {`
+//   #1505   `match Color::Red {` -- any qualifier defeated the lookback
+//   #1821   `if x != None {`, then `for x in Items {`
+//
+// Five rounds, and "what can precede a name before a brace" still had no
+// bounded answer. What ended it was measuring what the rewrite was FOR: across
+// 948 files under lib and 727 candidates under fixtures/ and scripts/, it fired
+// exactly once, on fixtures/struct_lit_sugar.vibe -- a fixture for a sugar the
+// compiler rejects (`line 4:18: unexpected token: :`). Its entire useful domain
+// was source that does not compile, and on source that does compile it could
+// only ever misfire.
+//
+// The net that remains is at the entry (lib/@vibe/cli/fmt_entry.vibe): the
+// formatted output is parsed, and a rewrite that breaks a file is discarded.
 
 //# Imports
 
@@ -132,4 +139,14 @@ test "a for-in over a real struct literal keeps its ::" {
   let src = "fn f() -> Int {\n  for x in Items::{ a: 1 } {\n    1\n  }\n  0\n}\n"
   let got = format_script(src)
   assert(contains(got, "Items::{"))
+}
+
+test "the formatter never inserts a struct-literal ::" {
+  // The property, stated directly rather than one guarded keyword at a time.
+  // A name before a brace stays a name before a brace, whatever precedes it --
+  // including spellings no guard ever listed.
+  let src = "fn f(s: Stream) -> Int {\n  handle Reader {\n    1\n  }\n}\n"
+  let got = format_script(src)
+  assert(contains(got, "handle Reader {"))
+  assert(!contains(got, "Reader::{"))
 }

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -3,18 +3,30 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 work="$ROOT_DIR/_build/vibe_fmt_parse_guard_test.$$"
-probe="$work/probe.vibe"
-original="$work/original.vibe"
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work"
 
-# Codex review on #1822: the set of tokens that may precede a capitalized
-# condition tail is unbounded. Unary `!` is intentionally not one of the known
-# governors, so the token-only formatter guesses that `Flag` is a struct
-# literal and emits `Flag::{`. The public formatter must parse its candidate
-# output and refuse the write instead of silently replacing valid source with
-# invalid source.
-cat >"$probe" <<'VIBE'
+# This test used to assert the opposite of what it asserts now, and the change
+# is the point.
+#
+# It was written for #1822, when the formatter still rewrote `Point { x: 1 }`
+# into `Point::{ x: 1 }` and needed a hand-written exclusion for every token
+# that could sit before the brace. `!` was not one of them, so `if !Flag {`
+# became `if !Flag::{` -- and the test asserted that the entry's parse guard
+# CAUGHT that, by requiring vibe_fmt.sh to fail on this input.
+#
+# #1821 then measured what the rewrite was for: across 948 files under lib and
+# 727 candidates under fixtures/ and scripts/, it fired exactly once, on a
+# fixture that does not compile. Its whole useful domain was source the parser
+# rejects; on source it accepts it could only misfire, which it did six times
+# (#945, #1429, #1505, `!=`, `in`, `!`). It is gone.
+#
+# So this input no longer corrupts, and demanding a refusal would demand the bug
+# back. What is worth pinning is the outcome -- the shape formats, and it
+# formats to itself.
+
+pass_input="$work/pass.vibe"
+cat >"$pass_input" <<'VIBE'
 fn f() -> Int {
   if !Flag {
     1
@@ -23,15 +35,33 @@ fn f() -> Int {
   }
 }
 VIBE
-cp "$probe" "$original"
+cp "$pass_input" "$work/pass.original"
 
-if bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$probe" >/dev/null 2>&1; then
-  echo "vibe_fmt_parse_guard_test: formatter accepted its invalid Flag::{ output" >&2
-  sed -n '1,20p' "$probe" >&2
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$pass_input" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: formatter declined a file it should format" >&2
   exit 1
 fi
-if ! cmp -s "$probe" "$original"; then
-  echo "vibe_fmt_parse_guard_test: formatter modified the input after declining it" >&2
+if grep -q '::{' "$pass_input"; then
+  echo "vibe_fmt_parse_guard_test: formatter inserted a struct-literal :: (#1821 regression)" >&2
+  sed -n '1,20p' "$pass_input" >&2
+  exit 1
+fi
+if ! cmp -s "$pass_input" "$work/pass.original"; then
+  echo "vibe_fmt_parse_guard_test: formatter changed a file that was already formatted" >&2
+  diff "$work/pass.original" "$pass_input" >&2 || true
+  exit 1
+fi
+
+# The guard's other half, which IS still reachable: it must not over-refuse.
+# It rejects a rewrite that BREAKS a file, not any file that happens not to
+# parse -- the promise is "no worse", not "only valid input". Getting this
+# backwards would make the formatter useless on exactly the broken files a
+# person most wants to run it on.
+broken="$work/broken.vibe"
+printf 'fn f( {\n  1\n' >"$broken"
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$broken" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: formatter refused a file that never parsed;" >&2
+  echo "  the guard rejects rewrites that BREAK a file, not files already broken" >&2
   exit 1
 fi
 


### PR DESCRIPTION
#1822 で「壊れた出力を書かない」網は張りました。これは**そもそも壊す理由を無くします**。

`Point { x: 1 }` を `Point::{ x: 1 }` に書き換える変換を削除しました。

## なぜ 6 個目のガードを足さなかったか

この変換は、brace の手前に来うる綴りを**一つずつ手で除外**する必要があり、実際に 5 回やりました:

| | |
|---|---|
| #945 | `trait Greet {` / `impl Greet for Int {` |
| #1429 | `fn f() -> T with Exception + Fs {` |
| #1505 | `match Color::Red {` — 修飾子があると lookback が届かない |
| #1821 | `if x != None {`、その修正後に `for x in Items {` |

**どれも壊れてから足しています。** 最後のものは CI に届き、unit-test 4 shard が
「誰も書いていない brace」を指すエラーで落ちました。

「名前の手前に何が来うるか」に有限の答えは無いので、**変換が何のためにあるのかを測りました**:

```
lib 配下 948 ファイル                        発火 0 回
fixtures/ + scripts/ の候補 727 ファイル      発火 1 回
```

その 1 回は `fixtures/struct_lit_sugar.vibe` で、**コンパイルできません**:

```console
fixtures/struct_lit_sugar.vibe: line 4:18: unexpected token: :
```

`Type { field: value }` は vibe ではありません。つまりこの変換の**有効な適用範囲は
「コンパイルできないソース」だけ**で、コンパイルできるソースに対しては**誤爆しかしません**。

## 削除して何も変わりません

削除前に**変換を無効化した状態で測って**確認しています: **948 ファイル、0 violations**。
`path_governor` / `is_ctor_name_text` / `skip_fmt_trivia_back` はこれを支えるためだけに
存在していたので一緒に削除しました。

## 網は残ります

#1822 の entry 側 parse 検証はそのままです。**壊す理由の無いフォーマッタを守る**形になります。

## テスト

壊れていた形はすべて残し、加えて**性質そのもの**を書きました:

```vibe
test "the formatter never inserts a struct-literal ::" {
  // 名前の前に何があろうと、brace の手前の名前は名前のまま
  let src = "fn f(s: Stream) -> Int {\n  handle Reader {\n    1\n  }\n}\n"
  ...
}
```

`handle Reader {` はどのガードにも載っていなかった綴りです。

## そして fixture 自体を直しました

**変換を消したことで、それが隠していたものが見えました。** `struct_lit_sugar.vibe` は
`Point { x: 3, y: 4 }` — **パーサが一度も受け付けたことのない綴り**で書かれていました。
生き延びていたのは**フォーマッタが `::` を補っていたから**で、先に整形したものは
valid なソースを見ることになり、fixture は保守されているように読めていました。

`Point::{ x: 3, y: 4 }` に直しました。`{"last": "7"}` が今も成り立つことは、本体を
直接評価して確認しています (`p.x + p.y == 7`)。

これは `check_fixture_execution.sh` (#1587) がまさに対象にした形
(「uncompilable, and unnoticed, for as long as they existed」) と同じものです。

**なお、この fixture は今もどこからも実行されていないように見えます** — `scripts/` /
`Taskfile.pkl` / `docs/` に言及が無く、`{"last": ...}` を発見する
`generate_runtime_fixture_tests.mjs` 自体もコメントからしか参照されていません。
ソースが正しいかとは別の問題なので、この PR では決着させていません。

## 検証

- `check_vibe_fmt`: **948 ファイル 0 violations**
- `lib/@vibe/compiler/fmt` テストスイート green
- fixture の値: `p.x + p.y == 7` を実行して確認
- `lint_review_regressions` / `lint_architecture_debt` green
- `origin/main` (368aec7fe) 上

Closes #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN