### PR TITLE
Fix builtin calls inside closures

### DIFF
--- a/fixtures/gc_closure_builtin_alias_test.vibe
+++ b/fixtures/gc_closure_builtin_alias_test.vibe
@@ -15,11 +15,9 @@
 // spelling. The capture test therefore canonicalizes and then re-checks both
 // sets.
 //
-// GC LANE ONLY. The linear backend emits an INVALID module for every one of
-// these (`invalid signature index`) while reporting a successful compile --
-// a pre-existing bug unrelated to the capture scan, tracked as #1811. Widen
-// this to both lanes once that lands; until then linear coverage would just
-// pin a known-broken artifact.
+// Runs on both backends. In particular, linear used to emit an INVALID module
+// for every one of these (`invalid signature index`) while reporting a
+// successful compile (#1811).
 
 fn alias_string_builder_in_closure() -> Int {
   let f = () -> String {

--- a/fixtures/gc_closure_builtin_capture_test.vibe
+++ b/fixtures/gc_closure_builtin_capture_test.vibe
@@ -42,6 +42,15 @@ fn bits_hi_in_closure() -> Int {
   f(1.5)
 }
 
+fn from_bits_in_closure() -> Int {
+  let f = (bits: Int) -> Double {
+    Double::from_i64_bits(bits)
+  }
+  // Use a non-zero low bit so the RC lane must untag the Int before boxing
+  // the Double; zero would pass even if that conversion were omitted.
+  Double::to_i64_bits_lo(f(1))
+}
+
 fn int_to_string_in_closure() -> Int {
   let f = (x: Int) -> String {
     Int::to_string(x)
@@ -119,6 +128,7 @@ fn local_and_builtin_together() -> Int {
 test "namespaced builtins called inside a closure are not captured" {
   inspect(bits_lo_in_closure(), "0")
   inspect(bits_hi_in_closure(), "1073217536")
+  inspect(from_bits_in_closure(), "1")
   inspect(int_to_string_in_closure(), "2")
   inspect(map_has_key_in_closure(), "0")
 }

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, TypeExpr, bsearch_leftmost, bytebuf_push, is_exception_throw_operation, sorted_names_of
+  Expr, Pat, Stmt, TypeExpr, bsearch_leftmost, bytebuf_push, canonical_builtin_name, is_exception_throw_operation, sorted_names_of
 }
 
 import @vibe/core {
@@ -680,7 +680,22 @@ fn is_inlined_async_builtin(name: String) -> Bool {
 /// signature mismatch" instead of the expected "unreachable" trap that the
 /// same code produces at top level.
 fn is_inlined_scalar_builtin(name: String) -> Bool {
-  name == "not" || name == "add" || name == "sub" || name == "mul" || name == "lt" || name == "assert"
+  name == "not" || name == "add" || name == "sub" || name == "mul" || name == "lt" || name == "assert" || name == "Double::from_i64_bits"
+}
+
+/// A namespaced source alias recognized by the builtin registry resolves
+/// globally, just like its canonical spelling. An unchanged canonical name is
+/// accepted only when an actual top-level function provides it.
+/// Namespaced spellings cannot be local binders, so this cannot hide a real
+/// capture. The exact-name lookup remains first and keeps user/global shadows
+/// authoritative.
+fn canonical_builtin_resolves_globally(name: String, fn_names: Array[String]) -> Bool {
+  if String::contains(name, "::") {
+    let canonical = canonical_builtin_name(name)
+    canonical != name || bsearch_leftmost(fn_names, canonical) >= 0
+  } else {
+    false
+  }
 }
 
 /// #1348: the SIMD intrinsics (`lib/@vibex/simd`) are inline-dispatched by
@@ -823,7 +838,7 @@ fn collect_free_vars_expr_sc(expr: Expr, bound: Array[String], fn_names: Array[S
           0
         }
       }
-    } else if skip_inlined && !array_contains_str(bound, cname) && !(bsearch_leftmost(fn_names, cname) >= 0) && !array_contains_str(encl, cname) && (is_inlined_async_builtin(cname) || is_inlined_scalar_builtin(cname) || is_inlined_simd_builtin(cname)) {
+    } else if skip_inlined && !array_contains_str(bound, cname) && !(bsearch_leftmost(fn_names, cname) >= 0) && !array_contains_str(encl, cname) && (canonical_builtin_resolves_globally(cname, fn_names) || is_inlined_async_builtin(cname) || is_inlined_scalar_builtin(cname) || is_inlined_simd_builtin(cname)) {
       let mut i = 0
       while i < Array::length(args) {
         collect_free_vars_expr_sc(Array::get(args, i), bound, fn_names, encl, skip_inlined, out)

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1758,6 +1758,24 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       }
       nl
     }
+    else if fname == "Double::from_i64_bits" {
+      // The linear value ABI carries Double as raw f64 bits in an i64 (boxed
+      // under RC). This builtin is therefore an inline representation
+      // conversion, not a function-table call. Keeping it inline also means a
+      // closure body cannot accidentally capture and call a nonexistent
+      // first-class builtin slot (#1805).
+      let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
+      if ctx.enable_rc {
+        emit_i64_const(buf, 1)
+        emit_i64_shr_s(buf)
+        Array::push(local_names, "__from_bits_raw")
+        Array::push(local_names, "__from_bits_box")
+        emit_box_float(buf, ctx, nl, nl + 1)
+        nl + 2
+      } else {
+        nl
+      }
+    }
     else if !prefer_bound_call && fname == "await" {
       // M1b-3b (docs/spec/wasi-p3-async.md): a `Future[T]` is the two-element
       // array `[state, payload]` (future_state_ready() = 0), so awaiting a

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4404,50 +4404,61 @@ echo "[compiler-gate] wasm-gc backend smoke ok (101557)"
 echo "[compiler-gate] 40h-2/40 wasm-gc closure builtin capture"
 gccapdir="_build/_gate_gc_closure_capture"
 rm -rf "$gccapdir"; mkdir -p "$gccapdir"
-for gccap_be in linear gc; do
-  env -u VIBE_FS_COMPILE VIBE_BACKEND="$gccap_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+for gccap_lane in linear-rc0 linear-rc1 gc; do
+  case "$gccap_lane" in
+    linear-rc0) gccap_be=linear; gccap_rc=0 ;;
+    linear-rc1) gccap_be=linear; gccap_rc=1 ;;
+    gc) gccap_be=gc; gccap_rc=0 ;;
+  esac
+  env -u VIBE_FS_COMPILE VIBE_RC="$gccap_rc" VIBE_BACKEND="$gccap_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_closure_builtin_capture_test.vibe" "$gccapdir/$gccap_be.wasm" __no_entry__ >/dev/null 2>&1
-  if [ ! -s "$gccapdir/$gccap_be.wasm" ]; then
-    echo "[compiler-gate] FAIL: gc_closure_builtin_capture_test.vibe did not compile on the $gccap_be backend" >&2
-    cat "$gccapdir/$gccap_be.wasm.diag" 2>/dev/null >&2 || true
+    "fixtures/gc_closure_builtin_capture_test.vibe" "$gccapdir/$gccap_lane.wasm" __no_entry__ >/dev/null 2>&1
+  if [ ! -s "$gccapdir/$gccap_lane.wasm" ]; then
+    echo "[compiler-gate] FAIL: gc_closure_builtin_capture_test.vibe did not compile on $gccap_lane" >&2
+    cat "$gccapdir/$gccap_lane.wasm.diag" 2>/dev/null >&2 || true
     exit 1
   fi
-  if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gccapdir/$gccap_be.wasm" >"$gccapdir/$gccap_be.out" 2>&1; then
-    echo "[compiler-gate] FAIL: gc_closure_builtin_capture_test.vibe failed at run time on the $gccap_be backend" >&2
-    cat "$gccapdir/$gccap_be.out" >&2
+  if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gccapdir/$gccap_lane.wasm" >"$gccapdir/$gccap_lane.out" 2>&1; then
+    echo "[compiler-gate] FAIL: gc_closure_builtin_capture_test.vibe failed at run time on $gccap_lane" >&2
+    cat "$gccapdir/$gccap_lane.out" >&2
     exit 1
   fi
 done
 rm -rf "$gccapdir"
-echo "[compiler-gate] wasm-gc closure builtin capture ok (linear + gc)"
+echo "[compiler-gate] closure builtin capture ok (linear rc0/rc1 + gc)"
 
 # 40h-3. Same rule reached through a SOURCE ALIAS. `compile_call_gc`
 #        canonicalizes the callee before dispatching while the capture scan
 #        sees the source spelling, so sharing the direct-ABI list was not
 #        enough: `StringBuilder::build` (alias of `StringBuilder::freeze`)
 #        matched neither the func table nor the list and was still captured.
-#        GC LANE ONLY -- the linear backend emits an INVALID module for these
-#        while reporting a successful compile (#1811), so linear coverage would
-#        pin a known-broken artifact rather than prove anything.
+#        Runs on BOTH lanes. Linear used to emit an invalid module while
+#        reporting a successful compile (#1811).
 echo "[compiler-gate] 40h-3/40 wasm-gc closure builtin alias capture"
 gcaliasdir="_build/_gate_gc_closure_alias"
 rm -rf "$gcaliasdir"; mkdir -p "$gcaliasdir"
-env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
-  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/gc_closure_builtin_alias_test.vibe" "$gcaliasdir/alias.wasm" __no_entry__ >/dev/null 2>&1
-if [ ! -s "$gcaliasdir/alias.wasm" ]; then
-  echo "[compiler-gate] FAIL: gc_closure_builtin_alias_test.vibe did not compile on the gc backend" >&2
-  cat "$gcaliasdir/alias.wasm.diag" 2>/dev/null >&2 || true
-  exit 1
-fi
-if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcaliasdir/alias.wasm" >"$gcaliasdir/alias.out" 2>&1; then
-  echo "[compiler-gate] FAIL: gc_closure_builtin_alias_test.vibe failed at run time on the gc backend" >&2
-  cat "$gcaliasdir/alias.out" >&2
-  exit 1
-fi
+for gcalias_lane in linear-rc0 linear-rc1 gc; do
+  case "$gcalias_lane" in
+    linear-rc0) gcalias_be=linear; gcalias_rc=0 ;;
+    linear-rc1) gcalias_be=linear; gcalias_rc=1 ;;
+    gc) gcalias_be=gc; gcalias_rc=0 ;;
+  esac
+  env -u VIBE_FS_COMPILE VIBE_RC="$gcalias_rc" VIBE_BACKEND="$gcalias_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "fixtures/gc_closure_builtin_alias_test.vibe" "$gcaliasdir/$gcalias_lane.wasm" __no_entry__ >/dev/null 2>&1
+  if [ ! -s "$gcaliasdir/$gcalias_lane.wasm" ]; then
+    echo "[compiler-gate] FAIL: gc_closure_builtin_alias_test.vibe did not compile on $gcalias_lane" >&2
+    cat "$gcaliasdir/$gcalias_lane.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcaliasdir/$gcalias_lane.wasm" >"$gcaliasdir/$gcalias_lane.out" 2>&1; then
+    echo "[compiler-gate] FAIL: gc_closure_builtin_alias_test.vibe failed at run time on $gcalias_lane" >&2
+    cat "$gcaliasdir/$gcalias_lane.out" >&2
+    exit 1
+  fi
+done
 rm -rf "$gcaliasdir"
-echo "[compiler-gate] wasm-gc closure builtin alias capture ok (gc)"
+echo "[compiler-gate] closure builtin alias capture ok (linear rc0/rc1 + gc)"
 
 # 40h-4. #1814: the gc lane must DECLARE its host ABI in the `vibe.abi` custom
 #        section. The node runner picks the decoding convention from that


### PR DESCRIPTION
## Summary

- treat canonical namespaced builtin aliases as global during closure capture analysis
- inline `Double::from_i64_bits` with the correct linear RC representation conversion
- run builtin closure capture and alias fixtures on linear RC0, linear RC1, and wasm-gc

## Root cause

Closure capture analysis classified namespaced builtin aliases as local captures even when code generation canonicalized them to direct builtins. Linear codegen then emitted calls through nonexistent or mismatched function-table slots. `Double::from_i64_bits` also lacked the inline linear lowering needed to untag its `Int` argument before boxing the `Double` result under RC.

## Validation

- Red: alias fixture failed linear instantiation with `invalid signature index: 11`
- Red: `Double::from_i64_bits` inside a closure failed with a null/signature-mismatch call
- fresh stage0 → stage1 → stage2 generation after rebasing onto latest main
- alias and capture fixtures pass on linear RC0, linear RC1, and wasm-gc
- `pkf run test-local` — 482/482 selected tests passed
- `pkf run generation-gate`
- `pkf run test-pre-commit`
- `bash scripts/check_inline_builtin_capture.sh`
- formatter, shell syntax, and `git diff --check`

Closes #1811
Closes #1805
