### PR TITLE
Keep typed grep repository sweeps running

### DIFF
--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -28,7 +28,7 @@ import @vibe/compiler/runtime {
   doc_at_source,
   escape_spans,
   escape_spans_strict,
-  grep_scan_fs,
+  grep_scan_fs_report,
   incremental_invalidation_trace_json,
   incremental_typecheck_telemetry_json,
   locate_type_error,
@@ -1442,8 +1442,9 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   // plausible-but-wrong result list.
   if Env::get("VIBE_GREP") == "1" {
     return handle {
-      let text = grep_scan_fs(input_path, Env::get("VIBE_GREP_PATTERN"), adapter_split_nonempty_lines(Env::get("VIBE_GREP_WHERE")), adapter_split_nonempty_lines(Env::get("VIBE_GREP_WHERE_ROW")), Env::get("VIBE_GREP_ONLY"), Env::get("VIBE_GREP_JSON") == "1")
+      let (text, warnings) = grep_scan_fs_report(input_path, Env::get("VIBE_GREP_PATTERN"), adapter_split_nonempty_lines(Env::get("VIBE_GREP_WHERE")), adapter_split_nonempty_lines(Env::get("VIBE_GREP_WHERE_ROW")), Env::get("VIBE_GREP_ONLY"), Env::get("VIBE_GREP_JSON") == "1")
       Fs::write_bytes(output_path, adapter_string_to_bytes(text))
+      Fs::write_bytes(String::concat(output_path, ".warn"), adapter_string_to_bytes(warnings))
       0
     } with Exception {
       Throw(msg) => emit_compile_diag(output_path, msg)

--- a/lib/@vibe/compiler/runtime/grep_fs.vibe
+++ b/lib/@vibe/compiler/runtime/grep_fs.vibe
@@ -218,13 +218,15 @@ fn grep_fs_fill_dep_envs(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
 
 /// `vibe grep <root>` proper. Typing runs only for files that already have a
 /// structural match: typing a file the pattern never hits would be pure cost.
-export fn grep_scan_fs(root: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> String with Exception + Fs {
+export fn grep_scan_fs_report(root: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> (String, String) with Exception + Fs {
   let pat = grep_compile_pattern(pattern)
   grep_check_filters(pat, wheres, where_rows)
   let files = grep_empty_strings()
   grep_fs_collect_files(root, files)
   let typed = grep_needs_typing(wheres, where_rows, only)
+  let has_typed_filter = Array::length(wheres) > 0 || Array::length(where_rows) > 0
   let out = grep_empty_strings()
+  let warnings = grep_empty_strings()
   let mut i = 0
   while i < Array::length(files) {
     let path = Array::get(files, i)
@@ -242,11 +244,24 @@ export fn grep_scan_fs(root: String, pattern: String, wheres: Array[String], whe
       } else {
         grep_untyped_context()
       }
-      grep_emit_hits(source, hits, ctx, typed, wheres, where_rows, only, json, out)
+      if has_typed_filter && ctx.type_error != "" {
+        // The typed answer for this file is untrustworthy, but the remaining
+        // files are independent. Fail closed for this file and keep sweeping.
+        Array::push(warnings, String::concat("warning: grep: skipped `", String::concat(path, String::concat("` because it could not be typed: ", ctx.type_error))))
+      } else {
+        grep_emit_hits(source, hits, ctx, typed, wheres, where_rows, only, json, out)
+      }
     } else {
       ()
     }
     i = i + 1
   }
-  grep_join_lines(out, json)
+  (grep_join_lines(out, json), grep_join_lines(warnings, false))
+}
+
+/// Library-compatible result-only wrapper. The public CLI uses
+/// `grep_scan_fs_report` so it can route per-file skips to stderr.
+export fn grep_scan_fs(root: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> String with Exception + Fs {
+  let (result, _) = grep_scan_fs_report(root, pattern, wheres, where_rows, only, json)
+  result
 }

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -193,6 +193,7 @@ fn grep_scan_source(path: String, source: String, pattern: String, wheres: Array
 // files that already have a structural match, through the same FS import walk
 // `vibe check` uses.
 fn grep_scan_fs(root: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> String with Exception + Fs
+fn grep_scan_fs_report(root: String, pattern: String, wheres: Array[String], where_rows: Array[String], only: String, json: Bool) -> (String, String) with Exception + Fs
 
 // --- deprecated_scan.vibe (#1262 / ADR-0101): uses, in entry_source, of
 // names whose declarations carry a `#deprecated` marker (in the entry itself

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -1496,7 +1496,7 @@ case "$cmd" in
     fi
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
     out="$(mktemp -t vibe-grep-XXXXXX)"
-    trap 'rm -f "$out" "$out.diag"' EXIT
+    trap 'rm -f "$out" "$out.diag" "$out.warn"' EXIT
     for g_path in "${g_paths[@]}"; do
       [ -e "$g_path" ] || die "not found: $g_path"
       # Clear inherited adapter-mode envs so a leaked selector can't divert this
@@ -1518,8 +1518,9 @@ case "$cmd" in
         echo "error: $(cat "$out.diag")" >&2
         die "grep failed"
       fi
+      if [ -s "$out.warn" ]; then cat "$out.warn" >&2; fi
       if [ -s "$out" ]; then cat "$out"; fi
-      : >"$out"
+      : >"$out"; : >"$out.warn"
     done
     ;;
   normalize)

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -11199,7 +11199,7 @@ VEOF
 gv_run() {
   # $1 = output basename, $2.. = extra env assignments (name=value)
   local gv_out="$gvdir/$1"; shift
-  rm -f "$gv_out" "$gv_out.diag"
+  rm -f "$gv_out" "$gv_out.diag" "$gv_out.warn"
   env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_GREP=1 "$@" \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "$gvdir" "$gv_out" >/dev/null 2>&1 || true
@@ -11240,6 +11240,46 @@ gv_run bad.txt VIBE_GREP_PATTERN='f($(x:expr))'
 if [ -s "$gvdir/bad.txt" ] || ! grep -q 'unknown metavariable kind' "$gvdir/bad.txt.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a bad grep pattern did not land on the .diag sidecar" >&2
   cat "$gvdir/bad.txt" "$gvdir/bad.txt.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# A typing failure belongs to ONE file, not to the whole repository sweep.
+# Keep the trustworthy hits on either side, drop the broken file, and report
+# that skip once on the warning sidecar. This preserves fail-closed filtering
+# without turning a work-in-progress file into a repo-wide abort (#1834).
+cat > "$gvdir/a_sweep_good.vibe" <<'VEOF'
+fn good_before() -> Int {
+  let xs = [1]
+  Array::length(xs)
+}
+VEOF
+cat > "$gvdir/b_sweep_bad.vibe" <<'VEOF'
+fn broken_between() -> Int {
+  let wrong: String = 1
+  let xs = [2]
+  Array::length(xs)
+}
+VEOF
+cat > "$gvdir/c_sweep_good.vibe" <<'VEOF'
+fn good_after() -> Int {
+  let xs = [3]
+  Array::length(xs)
+}
+VEOF
+gv_run sweep.txt VIBE_GREP_PATTERN='Array::length($(x:exp))' VIBE_GREP_WHERE='$x : Array[Int]'
+if ! grep -qF 'a_sweep_good.vibe' "$gvdir/sweep.txt" || ! grep -qF 'c_sweep_good.vibe' "$gvdir/sweep.txt"; then
+  echo "[compiler-gate] FAIL: a broken file aborted the typed grep repo sweep" >&2
+  cat "$gvdir/sweep.txt" "$gvdir/sweep.txt.diag" "$gvdir/sweep.txt.warn" 2>/dev/null >&2 || true
+  exit 1
+fi
+if grep -qF 'b_sweep_bad.vibe' "$gvdir/sweep.txt" || [ -s "$gvdir/sweep.txt.diag" ]; then
+  echo "[compiler-gate] FAIL: typed grep did not fail closed per broken file" >&2
+  cat "$gvdir/sweep.txt" "$gvdir/sweep.txt.diag" "$gvdir/sweep.txt.warn" 2>/dev/null >&2 || true
+  exit 1
+fi
+if [ "$(grep -cF 'b_sweep_bad.vibe' "$gvdir/sweep.txt.warn" 2>/dev/null || true)" -ne 1 ]; then
+  echo "[compiler-gate] FAIL: typed grep did not report the skipped file exactly once" >&2
+  cat "$gvdir/sweep.txt.warn" 2>/dev/null >&2 || true
   exit 1
 fi
 rm -rf "$gvdir"


### PR DESCRIPTION
## Summary

- make typed `vibe grep` failures file-local during filesystem/repository sweeps
- keep trustworthy hits from other files and emit one stderr warning for each skipped file
- preserve valid JSON output while routing warnings through a separate sidecar
- retain the strict single-file API and invalid-query failure behavior

## Root cause

The filesystem driver passed every file directly to the strict per-file emitter. That emitter correctly refuses typed filters when the file did not type-check, but its exception escaped the loop and aborted the entire repository sweep.

The fix keeps that strict emitter unchanged and handles an untrustworthy typed context at the FS sweep boundary: the file is dropped, the warning is collected, and scanning continues.

## Validation

- Red: a bad file between two valid matching files produced only a fatal `.diag` and no hits
- Green: both valid hits remain, the bad file is absent, and stderr names it exactly once
- JSON output remains a valid two-element array with the same warning on stderr
- fresh stage0 → stage1 → stage2 generation after rebasing onto current main
- `grep_test.vibe`: 26/26
- `pkf run test-local`: 245/245 selected tests
- `pkf run generation-gate`
- `pkf run test-pre-commit`
- formatter, shell syntax, and `git diff --check`

Closes #1834
