### PR TITLE
Make binding occurrences token-accurate

### DIFF
--- a/lib/@vibe/compiler/runtime/binding_at.vibe
+++ b/lib/@vibe/compiler/runtime/binding_at.vibe
@@ -23,10 +23,9 @@
 //
 // BINDER OFFSET RECOVERY: the AST stores binder NAMES as plain Strings without
 // offsets (only `EIdent` carries an offset). We recover a binder's source span by
-// scanning the source for the next whole-word occurrence of the name from a
-// monotonically-advancing floor, walking constructs in source order. This is the
-// same whole-word-scan machinery the previous name-wide implementation used for
-// top-level binding names, generalized to nested binders.
+// scanning the lexer's IDENTIFIER tokens for the next matching name from a
+// monotonically-advancing floor, walking constructs in source order. Raw text
+// is deliberately never searched: comments and strings are not bindings.
 //
 // FALLBACK (honest): for `match`/`handle` arms whose patterns introduce nested
 // sub-binders (ctor / tuple / struct / or patterns) the names ARE introduced into
@@ -47,7 +46,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/syntax {
-  lex_with_offsets, parse_program_located
+  Token, lex_with_offsets, parse_program_located
 }
 
 //# Functions
@@ -111,42 +110,29 @@ fn bind_empty_hits() -> Array[BindHit] {
   array_empty()
 }
 
-/// True when `source[off]` is NOT an identifier char (or off out of range) — a
-/// word boundary. Used to match a binding name as a whole word.
-fn bind_is_boundary_at(source: String, off: Int) -> Bool {
-  if off < 0 || off >= String::length(source) {
-    true
-  } else {
-    let c = String::char_code_at(source, off)
-    let is_id = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
-    !is_id
-  }
-}
-
-/// Find the start offset of the first whole-word occurrence of `name` in
-/// `source` at or after `from`. Returns -1 when not found. Recovers a source
-/// offset for a binder NAME, which the parser stores only as a String.
-fn bind_find_word(source: String, name: String, from: Int) -> Int {
-  let nlen = String::length(name)
-  if nlen == 0 {
-    -1
-  } else {
-    let limit = String::length(source)
-    let mut i = if from < 0 {
-      0
-    } else {
-      from
-    }
-    let mut found = -1
-    while found < 0 && i + nlen <= limit {
-      if String::substring(source, i, i + nlen) == name && bind_is_boundary_at(source, i - 1) && bind_is_boundary_at(source, i + nlen) {
-        found = i
-      } else {
-        i = i + 1
+/// Find the first identifier token named `name` at or after `from`. The lexer
+/// has already removed comments and kept string contents inside TString, so
+/// neither can steal a binder's source span.
+fn bind_find_ident_token(tokens: Array[Token], starts: Array[Int], name: String, from: Int) -> Int {
+  let mut i = 0
+  let mut found = -1
+  while found < 0 && i < Array::length(tokens) {
+    let off = Array::get(starts, i)
+    if off >= from {
+      match Array::get(tokens, i) {
+        TIdent(token_name) => if token_name == name {
+          found = off
+        } else {
+          ()
+        },
+        _ => ()
       }
+    } else {
+      ()
     }
-    found
+    i = i + 1
   }
+  found
 }
 
 /// Mutable walk state threaded through the AST traversal:
@@ -154,7 +140,8 @@ fn bind_find_word(source: String, name: String, from: Int) -> Int {
 ///   scope_names — scope-stack of in-scope binder names (parallel to scope_ids)
 ///   scope_ids   — scope-stack of binder ids (parallel to scope_names)
 ///   floor       — boxed monotonically-advancing scan floor for binder recovery
-///   source      — the program text
+///   tokens      — lexer tokens (comments/string contents excluded as binders)
+///   starts      — token source offsets, parallel to tokens
 ///
 /// Binding ids are NOT a separate counter: each binder's canonical id is its
 /// recovered source offset + 1 (unique per binder, and >= 1 so it never collides
@@ -164,7 +151,8 @@ struct BindState {
   scope_names: Array[String];
   scope_ids: Array[Int];
   floor: Array[Int];
-  source: String
+  tokens: Array[Token];
+  starts: Array[Int]
 }
 
 /// A fresh single-cell mutable Int array holding `v` (a poor-man's mutable box).
@@ -176,13 +164,14 @@ fn bind_box_int(v: Int) -> Array[Int] {
   arr
 }
 
-fn bind_new_state(source: String) -> BindState {
+fn bind_new_state(tokens: Array[Token], starts: Array[Int]) -> BindState {
   BindState::{
     hits: bind_empty_hits(),
     scope_names: array_empty(),
     scope_ids: array_empty(),
     floor: bind_box_int(0),
-    source: source
+    tokens: tokens,
+    starts: starts
   }
 }
 
@@ -218,7 +207,7 @@ fn bind_pop_scope(st: BindState, mark: Int) -> Unit {
 /// before v, yet not have x in scope while walking v).
 fn bind_recover_binder(st: BindState, name: String) -> Int {
   let from = Array::get(st.floor, 0)
-  let off = bind_find_word(st.source, name, from)
+  let off = bind_find_ident_token(st.tokens, st.starts, name, from)
   let id = if off >= 0 {
     off + 1
   } else {
@@ -270,7 +259,7 @@ fn bind_record_ref(st: BindState, name: String, off: Int) -> Unit {
 fn bind_record_assign_target(st: BindState, name: String) -> Unit {
   let key = bind_resolve(st, name)
   let from = Array::get(st.floor, 0)
-  let off = bind_find_word(st.source, name, from)
+  let off = bind_find_ident_token(st.tokens, st.starts, name, from)
   if off >= 0 {
     Array::push(st.hits, BindHit(name, off, key))
     Array::set(st.floor, 0, off + String::length(name))
@@ -484,7 +473,7 @@ fn bind_walk_arms(st: BindState, arms: Array[(Pat, Expr)]) -> Unit {
 /// binder's offset from the floor.
 fn bind_record_module_binder(st: BindState, name: String) -> Unit {
   let from = Array::get(st.floor, 0)
-  let off = bind_find_word(st.source, name, from)
+  let off = bind_find_ident_token(st.tokens, st.starts, name, from)
   if off >= 0 {
     Array::push(st.hits, BindHit(name, off, 0))
     Array::set(st.floor, 0, off + String::length(name))
@@ -606,7 +595,7 @@ fn binding_occurrences_impl(source: String, line: Int, col: Int) -> Array[(Int, 
     } else {
       let (tokens, starts, _ends) = lex_with_offsets(source)
       let stmts = parse_program_located(tokens, starts, source)
-      let st = bind_new_state(source)
+      let st = bind_new_state(tokens, starts)
       bind_walk_stmts(st, stmts)
       let hits = st.hits
       let (name, key) = bind_pick_at(hits, tgt)

--- a/lib/@vibe/compiler/runtime/editor_query_test.vibe
+++ b/lib/@vibe/compiler/runtime/editor_query_test.vibe
@@ -150,6 +150,35 @@ test "binding-at: CRLF end-of-line clamp does not spill into the next line" {
   assert(occ_len(binding_occurrences(src, 1, 17)) == 0)
 }
 
+/// Binder recovery must follow lexer identifier tokens, not same-spelled raw
+/// text. A comment before the declaration used to steal the binder offset, so
+/// querying the call returned the comment plus the call and omitted `fn apply`.
+test "binding-at: top-level fn excludes comment and string text and includes its declaration" {
+  let src = "// apply: documentation label\nfn apply(x: Int) -> Int { x }\nlet y = apply(1)\nlet text = \"apply\"\n"
+  let from_decl = binding_occurrences(src, 2, 4)
+  let from_use = binding_occurrences(src, 3, 9)
+  // declaration starts after the 30-byte comment line; call starts at 68.
+  assert(occ_len(from_decl) == 2)
+  assert(occ_contains(from_decl, 33, 38))
+  assert(occ_contains(from_decl, 68, 73))
+  assert(occ_len(from_use) == 2)
+  assert(occ_contains(from_use, 33, 38))
+  assert(occ_contains(from_use, 68, 73))
+  // Neither the comment at 3 nor the string contents at 89 is an occurrence.
+  assert(not(occ_contains(from_use, 3, 8)))
+  assert(not(occ_contains(from_use, 89, 94)))
+}
+
+test "binding-at: same-spelled local remains separate from the top-level fn" {
+  let src = "fn apply(x: Int) -> Int { x }\nfn local() -> Int {\n  let apply = (x: Int) -> Int { x + 1 }\n  apply(1)\n}\nlet y = apply(2)\n"
+  let local_occ = binding_occurrences(src, 4, 3)
+  let global_occ = binding_occurrences(src, 6, 9)
+  assert(occ_len(local_occ) == 2)
+  assert(occ_len(global_occ) == 2)
+  assert(not(occ_contains(local_occ, 0, 5)))
+  assert(occ_contains(global_occ, 3, 8))
+}
+
 /// --- doc-at (#854): `///` doc comment lookup via the declaration site
 /// binding_at.vibe already recovers. Hovering the declaration name itself
 /// resolves the doc; hovering a later USE of the same top-level name resolves


### PR DESCRIPTION
## Summary

- recover binder spans from lexer `TIdent` offsets instead of raw source substrings
- exclude same-spelled text in comments and string literals from binding occurrences
- include the real top-level function declaration when queried from either declaration or use
- preserve lexical separation for same-spelled shadowed locals

## Root cause

The located AST stores reference offsets but binder names as plain strings. `binding-at` reconstructed binder positions by scanning raw source text from a moving floor. A comment such as `// apply:` before `fn apply` therefore stole the binder ID: references grouped with the comment span while the declaration disappeared.

The lexer already provides the exact semantic boundary required here. Binder recovery now searches only identifier tokens and uses their source offsets; comments and string contents cannot participate.

## Validation

- Red: the regression returned the comment plus call and omitted `fn apply`
- Green: declaration + call only from both cursor positions; comment/string/shadowed local excluded
- real `examples/effects.vibe`: `apply` returns declaration `166–171` plus its two uses, not the comment
- fresh stage0 → stage1 → stage2 generation
- `editor_query_test.vibe`: 14/14
- `pkf run test-local`: 244/244 selected tests
- `pkf run generation-gate`
- `pkf run test-pre-commit`
- formatter and `git diff --check`

Closes #1835
