### PR TITLE
feat(gc): Fs::readdir の surface lowering を両レーンで共有する (#1262)

### DIFF
--- a/fixtures/gc_host_builtins.vibe
+++ b/fixtures/gc_host_builtins.vibe
@@ -12,11 +12,21 @@
 // green through the entire bug. `Fs::exists` answering true for a missing
 // path is the shape to keep in mind.
 //
-// `Fs::readdir` is NOT here: it returns Array[String] and the linear lane
-// lowers that surface at the call site on top of the raw import, so wiring
-// only the import yields an empty array on the gc lane. It stays a loud
-// "unknown constructor or function" until that lowering exists -- which is
-// the right failure while it is unimplemented.
+// `Fs::readdir` is here too now (#1262). It returns Array[String] while the
+// import returns the entries "\n"-joined as ONE packed string, so the surface
+// is a source-level rewrite -- shared with the linear lane through
+// `packed_lines_to_array_expr` rather than spelled out per lane.
+//
+// Its checks below are the two the rewrite can get wrong:
+//
+//   - an EMPTY directory must give `[]`. `String::split("", d)` is `[""]`, so
+//     the empty case needs its own branch and a fixture that only ever reads a
+//     populated directory would never notice it missing.
+//   - a call INSIDE A CLOSURE. The rewrite is guarded on the name not
+//     resolving to anything real, and the gc capture scan collected
+//     `Fs::readdir` as a free variable until it was listed as a direct-ABI
+//     spelling -- which made the guard false and skipped the rewrite entirely.
+//     Top-level-only coverage passes straight through that.
 
 fn probe_root() -> String {
   "_build/gc_host_builtins_probe"
@@ -75,6 +85,18 @@ fn remove_check() -> Int with Fs {
 
 // Both ends: the destination must appear AND the source must disappear. A
 // rename lowered as a copy would pass the destination check alone.
+fn readdir_checks() -> Int with Fs {
+  let entries = Fs::readdir(probe_root() + "/rd")
+  let empty = Array::length(Fs::readdir(probe_root() + "/rd_empty"))
+  // Through a closure, with a real capture alongside it: the capture must
+  // still ride the environment while the builtin name must not.
+  let bonus = 3
+  let via_closure = ((p: String) -> Int {
+    Array::length(Fs::readdir(p)) + bonus
+  })(probe_root() + "/rd")
+  Array::length(entries) * 100 + empty * 10 + (via_closure - bonus)
+}
+
 fn rename_check() -> Int with Fs {
   Fs::write_file(probe_root() + "/s1", "z")
   Fs::rename(probe_root() + "/s1", probe_root() + "/s2")
@@ -94,5 +116,5 @@ fn rename_check() -> Int with Fs {
 export let main = () -> Int with Fs + Stdout {
   Stdout::write_stream("gc-host-builtins:")
   // 10 10 10 10 -> 10101010 when every pair reads (affirmative=1, negative=0).
-  dir_checks() * 1000000 + file_checks() * 10000 + remove_check() * 100 + rename_check()
+  (dir_checks() * 1000000 + file_checks() * 10000 + remove_check() * 100 + rename_check()) * 1000 + readdir_checks()
 }

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -3305,3 +3305,38 @@ fn count_lambda_sites_arms(arms: Array[(Pat, Expr)]) -> Int {
   }
   total
 }
+
+/// #729/#730 + #1262: the `Fs::readdir` / `sh_lines` surface, as ordinary AST.
+///
+/// The host import returns the entries "\n"-joined as ONE packed string (the
+/// same ABI as `fs_read_file` -- no host-side array building, RC/bump
+/// agnostic). Turning that into `Array[String]` is a source-level rewrite, not
+/// codegen, so BOTH lanes want the identical expression and neither should
+/// spell it out again: the linear lane had this inline, and reproducing it in
+/// the gc lane is exactly the two-copies-that-drift shape #1809 was about.
+///
+/// Two details are load-bearing:
+///
+///   - the length guard. An empty directory gives "", and `String::split("", d)`
+///     is `[""]`, not `[]` -- so the empty case has to be built separately.
+///     `Array::slice(x, 0, 0)` is how an empty array is spelled here.
+///   - `String::from_char_code(10)` rather than a `"\n"` literal. A synthesized
+///     `EString` is not in the string table (same constraint as
+///     `double_to_string_expr`), so it cannot be emitted as a constant.
+export fn packed_lines_to_array_expr(raw_call: Expr, tmp_name: String) -> Expr {
+  let newline = ECall(EIdent("String::from_char_code", -1), [
+    EInt(10)
+  ], -1)
+  ELet(tmp_name, raw_call, EIf(EBinOp("==", ECall(EIdent("String::length", -1), [
+    EIdent(tmp_name, -1)
+  ], -1), EInt(0)), ECall(EIdent("Array::slice", -1), [
+    EArray([
+      newline
+    ]),
+    EInt(0),
+    EInt(0)
+  ], -1), ECall(EIdent("String::split", -1), [
+    EIdent(tmp_name, -1),
+    newline
+  ], -1)), -1)
+}

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -54,3 +54,4 @@ fn bmask_max_param() -> Int
 fn bmask_has(mask: Int, i: Int) -> Bool
 fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String]
 fn count_lambda_sites_expr(expr: Expr) -> Int
+fn packed_lines_to_array_expr(raw_call: Expr, tmp_name: String) -> Expr

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -25,7 +25,13 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/codegen/common_analysis {
-  collect_free_vars, collect_strings_stmts, emit_closure_call_tail, emit_closure_resolve, emit_i64_extend_i32_u, is_mut_captured_in
+  collect_free_vars,
+  collect_strings_stmts,
+  emit_closure_call_tail,
+  emit_closure_resolve,
+  emit_i64_extend_i32_u,
+  is_mut_captured_in,
+  packed_lines_to_array_expr
 }
 
 import @vibe/compiler/codegen/common_base {
@@ -2633,24 +2639,13 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       // the length guard. String pieces are built with String::from_char_code
       // because a synthesized EString is not in the string table (same
       // constraint as double_to_string_expr).
-      ce(buf, ELet("__rd_names", ECall(EIdent("vibe_fs_read_dir_raw", -1), [
+      // #1262: shared with the gc lane -- the rewrite is source-level, so both
+      // lanes take it from packed_lines_to_array_expr rather than each
+      // spelling it out (see that function for the empty-dir and string-table
+      // constraints).
+      ce(buf, packed_lines_to_array_expr(ECall(EIdent("vibe_fs_read_dir_raw", -1), [
         Array::get(args, 0)
-      ], -1), EIf(EBinOp("==", ECall(EIdent("String::length", -1), [
-        EIdent("__rd_names", -1)
-      ], -1), EInt(0)), ECall(EIdent("Array::slice", -1), [
-        EArray([
-          ECall(EIdent("String::from_char_code", -1), [
-            EInt(10)
-          ], -1)
-        ]),
-        EInt(0),
-        EInt(0)
-      ], -1), ECall(EIdent("String::split", -1), [
-        EIdent("__rd_names", -1),
-        ECall(EIdent("String::from_char_code", -1), [
-          EInt(10)
-        ], -1)
-      ], -1)), -1), local_names, next_local, ctx, ld)
+      ], -1), "__rd_names"), local_names, next_local, ctx, ld)
     }
     else if fname == "sh_lines" && Array::length(args) >= 1 {
       // `sh_lines(cmd) -> Array[String]`: the host import (`vibe_sh_lines_raw`,

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -1410,7 +1410,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // #538: host imports (module "vibe", tagged-i64 ABI -- the same raw ABI the
   // linear backend and the node host runner speak). Gated as a GROUP: pure
   // modules stay import-free (runnable on bare wasmtime); a module touching
-  // any Env::/Fs::/Stdout:: builtin imports ALL of them at indices 1..16,
+  // any Env::/Fs::/Stdout:: builtin imports ALL of them at indices 1..17,
   // shifting every generated-body index by that count (hbo).
   //
   // `hbo` IS that count. FOUR places encode this list -- use_host, host_defs,
@@ -1418,9 +1418,9 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // wrong: the first build that appended imports but left hbo behind produced
   // modules that validated nowhere ("not enough arguments on the stack for
   // call"), because every generated-body index still pointed low.
-  let use_host = stmts_use_builtin(stmts, fn_names_list, "Env::get") || stmts_use_builtin(stmts, fn_names_list, "Env::args_len") || stmts_use_builtin(stmts, fn_names_list, "Env::args_get") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::exists") || stmts_use_builtin(stmts, fn_names_list, "Fs::stat_token") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::publish_immutable_text") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_bytes") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_bytes") || stmts_use_builtin(stmts, fn_names_list, "Profiler::now_us") || stmts_use_builtin(stmts, fn_names_list, "Fs::remove") || stmts_use_builtin(stmts, fn_names_list, "Fs::rename") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_dir") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_file") || stmts_use_builtin(stmts, fn_names_list, "Stdout::write_stream")
+  let use_host = stmts_use_builtin(stmts, fn_names_list, "Env::get") || stmts_use_builtin(stmts, fn_names_list, "Env::args_len") || stmts_use_builtin(stmts, fn_names_list, "Env::args_get") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::exists") || stmts_use_builtin(stmts, fn_names_list, "Fs::stat_token") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::publish_immutable_text") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_bytes") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_bytes") || stmts_use_builtin(stmts, fn_names_list, "Profiler::now_us") || stmts_use_builtin(stmts, fn_names_list, "Fs::remove") || stmts_use_builtin(stmts, fn_names_list, "Fs::rename") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_dir") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_file") || stmts_use_builtin(stmts, fn_names_list, "Stdout::write_stream") || stmts_use_builtin(stmts, fn_names_list, "Fs::readdir")
   let hbo = if use_host {
-    16
+    17
   } else {
     0
   }
@@ -1614,7 +1614,12 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       ("Fs::rename", 2, 13, 0),
       ("Fs::is_dir", 1, 14, 1),
       ("Fs::is_file", 1, 15, 1),
-      ("Stdout::write_stream", 1, 16, 0)
+      ("Stdout::write_stream", 1, 16, 0),
+      // #1262: registered under the RAW name, not `Fs::readdir`. The surface
+      // returns Array[String] while the import returns the entries "\n"-joined
+      // as one packed string; compile_call_gc rewrites the surface onto this
+      // name (shared with the linear lane via packed_lines_to_array_expr).
+      ("vibe_fs_read_dir_raw", 1, 17, 1)
     ]
     let mut __hd = 0
     while __hd < Array::length(host_defs) {
@@ -2291,7 +2296,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
     // 4=(i64,i64)->i64, 5=()->i64, 6=(i64,i64)->()) -- the linear backend's
     // raw tagged ABI.
     let imp_content = bytebuf_new()
-    bytebuf_push_vec_header(imp_content, 17)
+    bytebuf_push_vec_header(imp_content, 18)
     emit_name(imp_content, "wasi_snapshot_preview1")
     emit_name(imp_content, "fd_write")
     bytebuf_push(imp_content, 0)
@@ -2314,7 +2319,8 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       ("fs_rename", 6),
       ("fs_is_dir", 3),
       ("fs_is_file", 3),
-      ("stdout_write_stream", 1)
+      ("stdout_write_stream", 1),
+      ("fs_read_dir", 3)
     ]
     let mut __hi = 0
     while __hi < Array::length(host_imports) {

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -23,7 +23,13 @@ import @vibe/core {
 }
 
 import @vibe/compiler/codegen/common_analysis {
-  collect_free_vars, collect_strings_stmts, emit_closure_call_tail, emit_closure_resolve, emit_i64_extend_i32_u, is_mut_captured_in
+  collect_free_vars,
+  collect_strings_stmts,
+  emit_closure_call_tail,
+  emit_closure_resolve,
+  emit_i64_extend_i32_u,
+  is_mut_captured_in,
+  packed_lines_to_array_expr
 }
 
 import @vibe/compiler/codegen/common_base {
@@ -547,6 +553,18 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       // `FrozenArray::from_array` compiles and runs on both lanes. Listing
       // them would instead claim a user declaration with those names is
       // unsafe, which is not what this branch means.
+      // #729/#730 + #1262: `Fs::readdir` surface. The host import returns the
+      // entries "\n"-joined as ONE packed string, so turning it into
+      // Array[String] is a source-level rewrite -- the SAME rewrite the linear
+      // lane does, taken from the shared builder rather than spelled out again
+      // here (that duplication is what drifted in #1809).
+      if !source_is_bound && fname == "Fs::readdir" && Array::length(args) == 1 {
+        return ce(buf, packed_lines_to_array_expr(ECall(EIdent("vibe_fs_read_dir_raw", -1), [
+          Array::get(args, 0)
+        ], -1), "__rd_names"), local_names, next_local, ld)
+      } else {
+        ()
+      }
       if !source_is_bound && Array::length(args) == 1 && (fname == "FrozenArray::from_array" || fname == "FrozenArray::to_array") {
         // review-lint: allow-gc-direct-abi-unlisted
         let ftmp = if fname == "FrozenArray::from_array" {

--- a/lib/@vibe/compiler/codegen/gc/backend_direct_abi_names.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_direct_abi_names.vibe
@@ -37,6 +37,7 @@ fn gc_direct_abi_names() -> Array[String] {
     "Array::length",
     "Array::get",
     "Array::set",
+    "Fs::readdir",
     "Stdin::read_via_stream",
     "StdinStream::next",
     "StdinStream::close",

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -34,7 +34,6 @@ Fs::copy	linear-only	host-import	host/linear-memory import; the gc lane is the p
 Fs::getcwd	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Fs::mkdir	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Fs::mkdir_p	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Fs::readdir	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Future::pending	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 Future::ready	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
 Future::resolve	linear-only	async-linear-only	continuation/async machinery exists only on the linear lane
@@ -86,7 +85,6 @@ host_stream_close	linear-only	host-import	ADR-0089 D3 host-stream drop surface (
 sleep	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 sleep_blocking	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 sub	linear-only	gc-unported	served on linear (callsite arm/table); no gc arm yet -- gc compile of a user of this name fails loudly
-vibe_fs_read_dir_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_fs_stat_token_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_heap_grow_check	linear-only	linear-runtime-internal	linear-memory runtime helper; meaningless on the gc heap
 vibe_http_close_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4523,8 +4523,10 @@ rm -rf "$gchbdir"; mkdir -p "$gchbdir"
 gchb_out=""
 for gchb_be in linear gc; do
   rm -rf _build/gc_host_builtins_probe
-  mkdir -p _build/gc_host_builtins_probe/adir
+  mkdir -p _build/gc_host_builtins_probe/adir _build/gc_host_builtins_probe/rd _build/gc_host_builtins_probe/rd_empty
   printf 'hello\n' > _build/gc_host_builtins_probe/a.txt
+  printf 'x\n' > _build/gc_host_builtins_probe/rd/f1
+  printf 'y\n' > _build/gc_host_builtins_probe/rd/f2
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gchb_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/gc_host_builtins.vibe" "$gchbdir/$gchb_be.wasm" main >/dev/null 2>&1
@@ -4542,24 +4544,37 @@ for gchb_be in linear gc; do
   fi
 done
 # Pin the value too: agreement alone passes when BOTH lanes break the same way.
-if [ "$gchb_out" != "gc-host-builtins:10101010" ]; then
-  echo "[compiler-gate] FAIL: gc host builtin probe returned '$gchb_out' (want gc-host-builtins:10101010) on both lanes (#1262)" >&2
+if [ "$gchb_out" != "gc-host-builtins:10101010202" ]; then
+  echo "[compiler-gate] FAIL: gc host builtin probe returned '$gchb_out' (want gc-host-builtins:10101010202) on both lanes (#1262)" >&2
   exit 1
 fi
-# Fs::readdir must still fail LOUDLY on the gc lane. Wiring only its import
-# yields an empty array (it needs the call-site surface lowering the linear
-# lane has), and an empty array is the silently-wrong answer this gate exists
-# to keep out. Drop this check when that lowering lands.
-printf 'let main = () -> Int with Fs { Array::length(Fs::readdir("_build")) }\n' > "$gchbdir/readdir.vibe"
+# `Fs::readdir` inside a CLOSURE, kept as its own check rather than folded
+# into the fixture value. The surface rewrite is guarded on the name not
+# resolving to anything real, and the gc capture scan collected `Fs::readdir`
+# as a free variable -- which made that guard false and skipped the rewrite,
+# so the call died with "unknown constructor or function" one lambda deep
+# while the top-level call worked. Listing it as a direct-ABI spelling is what
+# fixes it, and this is the shape that says so.
+printf 'let main = () -> Int with Fs { let f = (p: String) -> Int { Array::length(Fs::readdir(p)) }; f("_build/gc_host_builtins_probe/rd") }\n' > "$gchbdir/rdclosure.vibe"
+rm -rf _build/gc_host_builtins_probe
+mkdir -p _build/gc_host_builtins_probe/rd
+printf 'x\n' > _build/gc_host_builtins_probe/rd/f1
+printf 'y\n' > _build/gc_host_builtins_probe/rd/f2
 env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$gchbdir/readdir.vibe" "$gchbdir/readdir.wasm" main >/dev/null 2>&1 || true
-if [ -s "$gchbdir/readdir.wasm" ]; then
-  echo "[compiler-gate] FAIL: Fs::readdir now compiles on the gc lane -- if its surface lowering landed, verify it against linear and drop this check (#1262)" >&2
+  "$gchbdir/rdclosure.vibe" "$gchbdir/rdclosure.wasm" main >/dev/null 2>&1
+if [ ! -s "$gchbdir/rdclosure.wasm" ]; then
+  echo "[compiler-gate] FAIL: Fs::readdir inside a closure did not compile on the gc lane -- is it still listed in gc_direct_abi_names()? (#1262)" >&2
+  cat "$gchbdir/rdclosure.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+gchb_rd="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gchbdir/rdclosure.wasm" 2>&1 | tail -1)"
+if [ "$gchb_rd" != "2" ]; then
+  echo "[compiler-gate] FAIL: Fs::readdir inside a closure returned '$gchb_rd' (want 2) on the gc lane (#1262)" >&2
   exit 1
 fi
 rm -rf "$gchbdir" _build/gc_host_builtins_probe
-echo "[compiler-gate] wasm-gc host builtins ok (linear + gc, =10101010; readdir still loud)"
+echo "[compiler-gate] wasm-gc host builtins ok (linear + gc, =10101010202; readdir incl. empty dir and closure)"
 
 # #1295: String is a packed fat pointer, so the gc EForIn lowering must
 # normalize it to character codes before its shared Array iteration loop.


### PR DESCRIPTION
gc レーンで `Fs::readdir` が `unknown constructor or function` でした。#1823 で入れなかった残り 3 個のうちの 1 つで、gc 自己ビルド (#1262) の次の停止点でもあります。

## backend の話ではありませんでした

linear の実装を読むと、これは**純粋な AST 書き換え**でした。host import は「エントリを `\n` 連結した 1 個の packed String」を返し (`fs_read_file` と同じ ABI、ホスト側で配列を作らない)、`Array[String]` への変換は source レベルの rewrite です。

なので gc に要るのは host import 1 本と同じ rewrite だけでした。

## 同じ式を 2 箇所に書かない

`packed_lines_to_array_expr` に切り出し、両レーンがそこから取る形にしました。**linear を先に切り替えて挙動不変を確認してから** gc を足しています (`305` のまま)。

同じ集合・同じ式を 2 箇所が別々に持つ構図は #1809 で実際に drift しており、今回は最初から作らない方を選びました。

rewrite で load-bearing な点は 2 つで、どちらも共有関数のコメントに残しています:

- **空ディレクトリは `""` を返し `String::split("", d)` は `[""]`** なので、空の場合は別枝で `[]` を作る必要がある
- **`"\n"` は `EString` ではなく `String::from_char_code(10)`** で作る。合成した `EString` は string table に無い (`double_to_string_expr` と同じ制約)

## 自分が #1809 で入れた lint が的中しました

`fname == "Fs::readdir"` を dispatch に足した時点で、あの lint が指す条件 (「dispatch する綴りは `gc_direct_abi_names()` に載っていること」) に該当します。実測しました:

```
[linear] readdir in closure: 3
[gc]     readdir in closure: FAIL unknown constructor or function: Fs::readdir
```

クロージャ内では捕獲されて `source_is_bound` が真になり、新しい dispatch 腕を素通りして落ちていました。リストに追加して解消。**トップレベルだけ検証していたら通過していた**バグです。

なお main の #1833 (`Fix builtin calls inside closures`) は「別名は大域解決する」規則ですが、`Fs::readdir` は別名でも top-level fn でもないので拾われません。中身を読んで重複でないことを確認済みです。

## fixture は rewrite が間違えうる点を必ず含みます

| 検査 | これが無いと見逃すもの |
|---|---|
| **空ディレクトリが `[]`** | `split("", d)` が `[""]` になる罠。populated なディレクトリしか読まない fixture は永久に緑 |
| **クロージャ内からの呼び出し** | 上記の捕獲バグ。トップレベルだけでは通過する |
| **クロージャ + 実捕獲の併用** | builtin を捕獲集合から外したときに、本物の捕獲まで落としていないか |

gate 節は両レーン一致と値そのもの (`gc-host-builtins:10101010202`) の両方を見ます。一致だけでは両レーンが同じように壊れた場合を素通しします。クロージャのケースは fixture 値に畳まず独立した検査にしました — 落ちたときに原因が一意に読めるようにするためです。

## 検証

- `compiler_gate.sh` — **GATE=0**、節の実行をログ行で確認 (`wasm-gc host builtins ok (linear + gc, =10101010202; readdir incl. empty dir and closure)`)
- `unit_test_runner.sh` — **UNIT=0**、641/641
- `check_builtin_parity.sh` — ok。陳腐化した `Fs::readdir` / `vibe_fs_read_dir_raw` を分類から削除 (`gc serves 125 → 127`)
- `pkf run pre-commit` — 通過 (`--no-verify` なし)
- **最新 main (#1833 / seed bump / DCE 変更を含む) に rebase して全て取り直し**。最初の push が `--force-with-lease` で弾かれたことで、古い土台の結果で出さずに済みました

## #1262 の現在地

| 項目 | 状態 |
|---|---|
| 入力の形 / 型検査 | ✅ |
| クロージャ捕獲 | ✅ #1809 |
| host ABI 宣言 | ✅ #1815 |
| host builtin | 🟡 本 PR で `readdir` 込み 6 個。残るは `Stdin::read_char` / `read_stream` のみ (harness で stdin が両レーンに届かず EOF でしか検証できないため保留) |
| region lowering (`__region_run`) | ❌ |
| `selfbuild_compile_stage2` の backend 分岐 | ❌ |

---
_Generated by [Claude Code](https://claude.ai/code/session_017BFSjod7HAW2L3GySW81Pi)_