### PR TITLE
stdlib レビュー起点の整理 + P0 #1839: 匿名 record の struct 捕獲を撤廃 (#1839, #1841, #1845, #1850)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ vibe 言語の構文・機能を把握するには、最初に [docs/cheatsheet.
    (ADR 番号・pass 名) で行動可能でない、型検査を通り抜けて codegen で初めて
    落ちる、条件が複数軸の相互作用で単独では説明できない。
    実例: #1511 (`handle` の適格性), #1508 (`Http` を使う test/bench が書けない),
-   #1500 (optional 引数 `x?` が未実装)
+   #1500 (optional 引数 `x?` — 起票時は未実装、現在は着地済み)
 
 ## Quick Commands
 

--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -12,7 +12,7 @@
       "sha256": "b0f5f7ec8af12f44923e3e4ad32d055161a59fe70b53cb51f9eb5398bb03eca4"
     },
     "runtime": {
-      "runner": "moonrun",
+      "runner": "node",
       "compile_flag": "--wasm-mvp",
       "wasmtime_flags": "unknown-imports-default=y exceptions=y"
     }

--- a/docs/adding-modules.md
+++ b/docs/adding-modules.md
@@ -6,11 +6,11 @@
 > が正本。設計の経緯は [module-system-v2.md](module-system-v2.md) (ADR-0063/0064)。
 > selfhost-only 前提 ([archive/moonbit-retirement.md](archive/moonbit-retirement.md))。
 
-このリポジトリのライブラリは「テストが allowlist に載っていて、battery が
-回っている」ものだけが生きている。allowlist の外にあるコードはコンパイラで
-一度もコンパイルされず、host 時代の腐敗が溜まる (#742 で json / base64 /
-fmt から発掘された rot がその実例)。**新しいモジュールは必ずテストと
-allowlist をセットで足す。**
+このリポジトリのライブラリは「`*_test.vibe` が battery で回っている」もの
+だけが生きている。テストの無いコードはコンパイラで一度もコンパイルされず、
+host 時代の腐敗が溜まる (#742 で json / base64 / fmt から発掘された rot が
+その実例)。**新しいモジュールは必ずテストをセットで足す** — テストの登録は
+discover() が自動で拾う (旧 allowlist は #1231 で撤廃、§2 手順 3 参照)。
 
 ## 1. どこに置くか
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -798,7 +798,18 @@ let w_check = {
 }
 ```
 
-> **status (#760/#839):**
+> **status (#760/#839/#1839):**
+> - **Anonymous records are structural** (#1839): a named struct that happens
+>   to share a `record { ... }` literal's field-name set no longer captures
+>   it. The literal keeps its own layout (literal field order), so dot access
+>   and same-order destructure read the written values even next to a
+>   colliding struct, and a record whose field set is a strict subset of some
+>   struct's is accepted (it used to be rejected as a construction of that
+>   struct missing fields). Struct construction is spelled `S::{ ... }` only.
+>   Caveat: the checker does not yet REJECT passing an anonymous record where
+>   a struct is expected — that program now reads wrong slots at runtime
+>   instead of being (wrongly) accepted as the struct. Don't do it; #1839
+>   tracks the checker-level rejection.
 > - **Record dot access** (`r.name` on an anonymous `record { ... }`) lowers to
 >   the positional field read the destructure uses, and now resolves in every
 >   expression position — a `let` initializer (including a top-level `let`

--- a/docs/method-bearing-traits-plan.md
+++ b/docs/method-bearing-traits-plan.md
@@ -1,7 +1,14 @@
 # Method-bearing traits — implementation plan (#641)
 
-Status: Phase 1 landed (2026-06-26). Concrete-receiver dispatch works in the
-bumped seed/CI toolchain; PR-2 (bound enforcement + dictionary passing) next.
+Status: **largely landed — the "current state" claims below are historical.**
+Phase 1 landed 2026-06-26; bound enforcement + dictionary passing have since
+landed too (`desugar_trait_dict`, #1503 trait-instance resolution closed as
+implemented). Traits are no longer marker-only: `lib/@vibe/core/map.vibe`'s
+`trait Hash { hash_key(Self) -> String }` ships method-bearing impls and
+`derive(Hash)` generates `Type::hash_key` (#694). This document is kept as
+the design record; read statements about "current" compiler behavior as
+describing 2026-06, not today. (The duplicate marker `Hash` in
+`lib/@vibe/prelude/builtin_traits.vibe` is tracked by #1844.)
 
 ## Build gotcha (read before iterating on the compiler)
 

--- a/fixtures/anon_record_struct_collision_test.vibe
+++ b/fixtures/anon_record_struct_collision_test.vibe
@@ -1,0 +1,86 @@
+// #1839: an explicit anonymous `record { ... }` literal is structural — a
+// named struct sharing its field-name set must not capture it. Before the
+// fix, the checker retyped the literal as the struct, codegen reordered its
+// slots to the struct's DECLARED field order, and the parser's positional
+// record destructure then read swapped values even when the pattern was
+// written in the literal's own order (`a` below came back 9). A record whose
+// field set was a strict SUBSET of some struct was rejected outright
+// ("missing field `source` in construction of struct StringView").
+
+// Declares its fields in the OPPOSITE order of the literals below.
+struct Span {
+  end: Int;
+  start: Int
+}
+
+// Strict superset of the two-field literals below.
+struct StringView {
+  source: String;
+  start: Int;
+  end: Int
+}
+
+fn view_start(v: StringView) -> Int {
+  v.start
+}
+
+fn span_start(s: Span) -> Int {
+  s.start
+}
+
+fn main() -> Int {
+  0
+}
+
+test "anonymous record keeps literal slot order despite a same-set struct" {
+  let r = record {
+    start: 3,
+    end: 9
+  }
+  inspect(__rec_field(r, 0), "3")
+  inspect(__rec_field(r, 1), "9")
+}
+
+test "dot access resolves against the record's own layout" {
+  let r = record {
+    start: 3,
+    end: 9
+  }
+  inspect(r.start, "3")
+  inspect(r.end, "9")
+}
+
+test "same-order destructure binds the written values" {
+  let r = record {
+    start: 3,
+    end: 9
+  }
+  let record {
+    start: a,
+    end: b
+  } = r
+  inspect(a, "3")
+  inspect(b, "9")
+}
+
+test "subset-of-a-struct field set is accepted and correct" {
+  // StringView declares {source, start, end}; this two-field record used to
+  // be rejected as a StringView construction missing `source`.
+  let r = record {
+    start: 4,
+    end: 7
+  }
+  inspect(r.start, "4")
+  inspect(r.end, "7")
+}
+
+test "the named structs still construct and read normally" {
+  let s = Span::{
+    start: 100, end: 200
+  }
+  inspect(span_start(s), "100")
+  let v = StringView::{
+    source: "s", start: 10, end: 20
+  }
+  inspect(view_start(v), "10")
+}

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -7295,15 +7295,18 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           }
         }
       } else {
-        // Check the field values against the matching struct's declared types.
-        let s2 = check_record_fields(defs, field_tys, s1, errors)
-        // Recover the struct identity (when unambiguous) so downstream uses — in
-        // particular `mut`-field write checking — see a concrete `CtStruct`.
-        let rec_ty = match resolve_record_struct_name(defs, field_tys) {
-          Some(sname) => CtStruct(sname),
-          None => CtUnknown
-        }
-        (rec_ty, s2, c1)
+        // #1839: an EXPLICIT `record { ... }` literal (rn == "" comes only
+        // from the `record` keyword since #810 put the parsed name on
+        // `S::{...}`) is structural — it must not be captured by a named
+        // struct that happens to share its field-name set. The field-set
+        // match that used to run here (check_record_fields +
+        // resolve_record_struct_name) silently retyped the literal as the
+        // struct (accepting `fn (s: Span)` calls the writer never meant) and
+        // rejected records whose field set was a strict subset of some
+        // struct ("missing field ... in construction of struct X"). Codegen
+        // and the anon-record dot-access desugar now keep the same rule:
+        // rn == "" always lays out in literal order with tag 0.
+        (CtUnknown, s1, c1)
       }
     },
     ETuple(items) => {

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail4.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail4.vibe
@@ -320,7 +320,7 @@ export fn compile_expr_tail4(buf: Bytes, expr: Expr, local_names: Array[String],
         }
       }
     },
-    ERecord(_, fields, _) => {
+    ERecord(rec_rn, fields, _) => {
       let flen = Array::length(fields)
       // #722: resolve the record to a struct by exact field-name set and, on a
       // match, lay it out in the struct's DECLARED field order with the
@@ -328,7 +328,12 @@ export fn compile_expr_tail4(buf: Bytes, expr: Expr, local_names: Array[String],
       // `S::{...}` ctor construction path (which already reorders). This is
       // what makes the tag-dispatching field access above type-correct for
       // bare-record construction (hand-built ASTs, name-dropped literals).
-      // Unmatched (anonymous) records keep the legacy literal order + tag 0.
+      // #1839: an EXPLICIT anonymous literal (rec_rn == "", the `record`
+      // keyword) is exempt from that resolution — it always keeps literal
+      // order + tag 0, matching the checker (no struct capture) and the
+      // anon-record dot-access desugar (positional reads over literal
+      // order). Reordering it to a same-field-set struct's declared order
+      // made the parser's positional record destructure read swapped values.
       let lit_names = array_empty()
       let mut lni = 0
       while lni < flen {
@@ -336,7 +341,11 @@ export fn compile_expr_tail4(buf: Bytes, expr: Expr, local_names: Array[String],
         Array::push(lit_names, lfn)
         lni = lni + 1
       }
-      let rec_si = struct_index_by_field_set(ctx.ctor_table, lit_names)
+      let rec_si = if rec_rn == "" {
+        -1
+      } else {
+        struct_index_by_field_set(ctx.ctor_table, lit_names)
+      }
       let rec_tag = if rec_si >= 0 {
         struct_tag_by_index(ctx.ctor_table, rec_si)
       } else {

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -1983,12 +1983,15 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
         nl1 + 1
       }
     },
-    ERecord(_, fields, _) => {
+    ERecord(rec_rn, fields, _) => {
       let flen = Array::length(fields)
       // #722: resolve to a struct by exact field-name set; on a match, lay
       // out in DECLARED field order and stamp the struct's ctor tag at
       // value+0 (mirrors the linear backend and the `S::{...}` ctor path) so
       // the tag-dispatching field access above stays type-correct.
+      // #1839: an explicit anonymous literal (rec_rn == "") is exempt — it
+      // always keeps literal order + tag 0 (mirrors the linear backend's
+      // rule; see compile_expr_tail4).
       let lit_names = array_empty()
       let mut lni = 0
       while lni < flen {
@@ -1996,7 +1999,11 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
         Array::push(lit_names, lfn)
         lni = lni + 1
       }
-      let rec_si = struct_index_by_field_set(ctx.gc_ctor_table, lit_names)
+      let rec_si = if rec_rn == "" {
+        -1
+      } else {
+        struct_index_by_field_set(ctx.gc_ctor_table, lit_names)
+      }
       let rec_tag = if rec_si >= 0 {
         struct_tag_by_index(ctx.gc_ctor_table, rec_si)
       } else {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1125,10 +1125,16 @@ fn infer_arg_type_name(arg: Expr, struct_sets: Array[(String, Array[String])], v
     // call`, naming neither the struct nor the call. Declaration order looked
     // like the trigger because it decides which same-shaped struct is first.
     //
-    // Shape matching stays for the ANONYMOUS form (`ERecord("", ..)`, #839
-    // top-level anonymous records and the witness records built by
-    // make_witness_record), where there is no written name to trust.
-    ERecord(rn, fields, _) => if String::length(rn) > 0 && struct_set_has(struct_sets, rn) {
+    // #1839: the ANONYMOUS form (`ERecord("", ..)` — the explicit `record`
+    // keyword) is structural and no longer captured by a same-field-set
+    // struct anywhere (checker / codegen keep it literal-order, tag 0), so
+    // reporting a struct NAME for it here would route `==` / to_string /
+    // UFCS dispatch to that struct's methods, which would read the wrong
+    // slots. Shape matching remains only for a NAMED literal whose name the
+    // merged defs no longer contain (merge-layer private-struct rename).
+    ERecord(rn, fields, _) => if String::length(rn) == 0 {
+      None
+    } else if struct_set_has(struct_sets, rn) {
       Some(rn)
     } else {
       let names = empty_str_array()
@@ -1285,13 +1291,25 @@ fn anon_field_index(sentinel: String, field: String) -> Int {
   }
 }
 
-/// If `val` is a `record { .. }` literal whose field-set matches no declared
-/// struct, the `__anonrec:` sentinel recording its literal field order; else None.
+/// If `val` is an explicit anonymous `record { .. }` literal (rn == ""), the
+/// `__anonrec:` sentinel recording its literal field order; else None.
 /// Threaded into `var_types` at `let`/`let mut` so a later `binding.field` on the
 /// same name resolves positionally.
+///
+/// #1839: EVERY rn == "" literal gets the sentinel — it used to be withheld
+/// when the field set matched a declared struct (leaving `.field` to the EDot
+/// struct-table path), which was consistent only because codegen also
+/// reordered such literals to the struct's declared order. That capture made
+/// the parser's POSITIONAL record destructure read swapped values
+/// (`let record { start: a, end: b } = record { start: 3, end: 9 }` bound
+/// a = 9 whenever a same-field-set struct declared its fields in another
+/// order). Anonymous records now stay in literal order end-to-end, so dot
+/// access must resolve positionally against that order too.
 fn anon_record_inferred(val: Expr, struct_sets: Array[(String, Array[String])]) -> Option[String] {
   match val {
-    ERecord(_, fields, _) => {
+    ERecord(rn, fields, _) => if String::length(rn) > 0 {
+      None
+    } else {
       let names = empty_str_array()
       let mut i = 0
       while i < Array::length(fields) {
@@ -1299,22 +1317,7 @@ fn anon_record_inferred(val: Expr, struct_sets: Array[(String, Array[String])]) 
         Array::push(names, fname)
         i = i + 1
       }
-      let mut j = 0
-      let mut matched = false
-      while j < Array::length(struct_sets) {
-        let (_, sfields) = Array::get(struct_sets, j)
-        if field_sets_match(names, sfields) {
-          matched = true
-          j = Array::length(struct_sets)
-        } else {
-          j = j + 1
-        }
-      }
-      if matched {
-        None
-      } else {
-        Some(anon_record_sentinel(names))
-      }
+      Some(anon_record_sentinel(names))
     },
     _ => None
   }

--- a/lib/@vibe/json/index.vpkg
+++ b/lib/@vibe/json/index.vpkg
@@ -65,6 +65,7 @@ fn stringify(j: Json) -> String
 fn Json::parse(s: String) -> Json
 fn Json::stringify(j: Json) -> String
 fn Json::field(j: Json, key: String) -> Json
+fn Json::get_opt(j: Json, key: String) -> Option[Json]
 fn Json::index(j: Json, idx: Int) -> Json
 fn Json::number(j: Json) -> Double
 fn Json::string(j: Json) -> String

--- a/lib/@vibe/json/json_convenience.vibe
+++ b/lib/@vibe/json/json_convenience.vibe
@@ -63,6 +63,22 @@ export fn Json::field(j: Json, key: String) -> Json {
   }
 }
 
+/// #1845: absence-aware object accessor. `Json::field` conflates a missing
+/// key with an explicit `null` (both come back `JNull`); `get_opt` keeps
+/// them distinct — `None` = key absent (or `j` not an object),
+/// `Some(JNull)` = key present and bound to JSON null.
+export fn Json::get_opt(j: Json, key: String) -> Option[Json] {
+  match j {
+    JObj(m) => if Map::has_key(m, key) {
+      let v: Json = Map::get(m, key)
+      Some(v)
+    } else {
+      None
+    },
+    _ => None
+  }
+}
+
 export fn Json::index(j: Json, idx: Int) -> Json {
   match j {
     JArr(a) => if idx >= 0 && idx < Array::length(a) {

--- a/lib/@vibe/json/json_convenience_import_test.vibe
+++ b/lib/@vibe/json/json_convenience_import_test.vibe
@@ -28,3 +28,26 @@ test "Json:: accessors resolve from a bare type import (#1080)" {
   assert(Array::length(Json::keys(j)) == 4)
   assert(String::length(Json::stringify(j)) > 0)
 }
+
+test "Json::get_opt keeps missing distinct from explicit null (#1845)" {
+  let j = Json::parse("{\"present\":1,\"nul\":null}")
+  match Json::get_opt(j, "present") {
+    Some(v) => assert(Json::number(v) == 1.0),
+    None => assert(false)
+  }
+  // explicit null: key present, value is JSON null
+  match Json::get_opt(j, "nul") {
+    Some(v) => assert(Json::is_null(v)),
+    None => assert(false)
+  }
+  // missing key: None (Json::field would flatten this to JNull)
+  match Json::get_opt(j, "missing") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  // non-object receiver: None
+  match Json::get_opt(Json::parse("[1,2]"), "k") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}

--- a/lib/@vibe/prelude/README.md
+++ b/lib/@vibe/prelude/README.md
@@ -8,7 +8,6 @@ This directory is the vibe core library, self-hosted by porting selected parts o
 |--------|-----------:|-------------|
 | `builtin_traits.vibe` | 8 | Trait-oriented generic API (`Eq`/`Hash`/`Ord`/`Add`/`Signed`, `ord_clamp`, `num_abs`) |
 | `option.vibe` | 13 | Generic Option helpers (`is_some`, `unwrap_or`, `map_opt`, `map_or`, `or_else`, `equals`) |
-| `result.vibe` | 7 | Generic Result helpers (`is_ok`, `is_err`, `map_ok`, `map_err`, `bind`, `unwrap_or`, `to_option`) |
 | `cmp.vibe` | 4 | Compare helpers (`int/float/double/string_compare`, `maximum/minimum`, `*_by`, `*_by_key`) |
 | `int.vibe` | 14 | Integer helpers (`abs`, `max`, `min`, `clamp`, `pow`, `gcd`, `lcm`, `factorial`, `fibonacci`) |
 | `float.vibe` | 7 | Float helpers (`abs`, `signum`, `clamp`, `square`, `lerp`) |
@@ -75,20 +74,16 @@ Boundary enforcement is active in:
 - `option_*` prefixes are no longer exported.
 - `map` itself is reserved in vibe syntax, so Option map is named `map_opt`.
 
-`result.vibe` now exposes short names compatible with current vibe parser constraints:
-
-- `is_ok`, `is_err`, `ok`, `err`
-- `map_ok`, `map_err`, `map_or`, `bind`, `and_then`, `flatten`
-- `unwrap_or`, `unwrap_or_else`, `or`, `or_else`
-- `to_option`, `from_option`, `equals_by`
-- `map` itself is reserved in vibe syntax, so Result map is named `map_ok`.
+`result.vibe` was removed in #1324 (see the header comment in `index.vpkg`):
+`Result` no longer exists as a language- or prelude-provided type. A program
+wanting `Ok`/`Err` declares the enum itself like any other user enum; failure
+is carried by `Exception[E]` effect rows (ADR-0085).
 
 ### Canonical Naming / Alias Policy
 
 `vibe/prelude` では parser 予約語制約を前提に、以下を canonical API 名として扱う。
 
 - Option: `map_opt`, `flatmap`, `map_or`, `unwrap_or`, `unwrap_or_else`
-- Result: `map_ok`, `bind`, `map_or`, `unwrap_or`, `unwrap_or_else`
 - Array: `Array::map`, `flatmap`, `filter`, `fold`
 
 互換 alias 運用ルール:

--- a/lib/@vibex/shell/from_csv.vibe
+++ b/lib/@vibex/shell/from_csv.vibe
@@ -6,44 +6,19 @@
 // direct-value convenience wrappers in json_convenience.vibe instead.
 // #897: directory form (not `../json/index.vibe`) — json is a .vpkg
 // contract package now.
+// #1841: `String::replace_all` was reimplemented locally here to sidestep a
+// selfhost miscompile that no longer reproduces (the trigger was rewritten in
+// #1092); the prelude import is restored. See pipeline.vibe for the pinned
+// regression shape.
+import @vibe/prelude {
+  String::replace_all
+}
+
 import @vibe/json {
   Json::parse
 }
 
 //# Functions
-
-/// #777: `String::replace_all` (`../prelude/string.vibe`) is a real prelude
-/// function needing an explicit import (same class of host-era rot as
-/// #742) — but importing it into THIS file, alongside the dynamic string
-/// slices below (`_csv_parse_line`'s `line[i: i+1]` etc.), trips a real
-/// selfhost codegen bug: the imported function's `let rec` + dynamic-slice
-/// body corrupts an unrelated WASM function in this compile unit ("not
-/// enough arguments on the stack for call" at instantiation — see
-/// pipeline.vibe's `pipeline_replace_all` for the same workaround and a
-/// fuller repro note). Reimplemented locally (iteratively) to sidestep it.
-fn csv_replace_all(s: String, pattern: String, replacement: String) -> String {
-  let pat_len = String::length(pattern)
-  let s_len = String::length(s)
-  if pat_len == 0 || pat_len > s_len {
-    s
-  } else {
-    let sb = StringBuilder::new()
-    let mut i = 0
-    while i <= s_len - pat_len {
-      if s[i: i + pat_len] == pattern {
-        StringBuilder::push(sb, replacement)
-        i = i + pat_len
-      } else {
-        StringBuilder::push(sb, s[i: i + 1])
-        i = i + 1
-      }
-    }
-    if i < s_len {
-      StringBuilder::push(sb, s[i: s_len])
-    }
-    StringBuilder::freeze(sb)
-  }
-}
 
 export fn _csv_is_number(s: String) -> Bool {
   let len = String::length(s)
@@ -213,7 +188,7 @@ export fn _csv_escape_json(s: String) -> String {
 
 export fn from_csv(text: String) -> Json {
   let cr = String::from_char_code(13)
-  let cleaned = csv_replace_all(text, cr, "")
+  let cleaned = String::replace_all(text, cr, "")
   let all_lines = String::split(cleaned, "\n")
   let num_lines = Array::length(all_lines)
   if num_lines < 2 {

--- a/lib/@vibex/shell/from_yaml.vibe
+++ b/lib/@vibex/shell/from_yaml.vibe
@@ -6,44 +6,19 @@
 // wrappers in json_convenience.vibe instead.
 // #897: directory form (not `../json/index.vibe`) — json is a .vpkg
 // contract package now.
+// #1841: `String::replace_all` was reimplemented locally here to sidestep a
+// selfhost miscompile that no longer reproduces (the trigger was rewritten in
+// #1092); the prelude import is restored. See pipeline.vibe for the pinned
+// regression shape.
+import @vibe/prelude {
+  String::replace_all
+}
+
 import @vibe/json {
   Json::parse
 }
 
 //# Functions
-
-/// #777: `String::replace_all` (`../prelude/string.vibe`) needs an explicit
-/// import to use (real prelude function, not a checker builtin — same class
-/// of host-era rot as #742). But importing it into THIS file, alongside the
-/// many dynamic string slices below, trips a real selfhost codegen bug: the
-/// imported function's `let rec` + dynamic-slice body corrupts an unrelated
-/// WASM function in this compile unit ("not enough arguments on the stack
-/// for call" at instantiation — see pipeline.vibe's `pipeline_replace_all`
-/// for the same workaround and a fuller repro note). Reimplemented locally
-/// (iteratively) to sidestep it.
-fn yaml_replace_all(s: String, pattern: String, replacement: String) -> String {
-  let pat_len = String::length(pattern)
-  let s_len = String::length(s)
-  if pat_len == 0 || pat_len > s_len {
-    s
-  } else {
-    let sb = StringBuilder::new()
-    let mut i = 0
-    while i <= s_len - pat_len {
-      if s[i: i + pat_len] == pattern {
-        StringBuilder::push(sb, replacement)
-        i = i + pat_len
-      } else {
-        StringBuilder::push(sb, s[i: i + 1])
-        i = i + 1
-      }
-    }
-    if i < s_len {
-      StringBuilder::push(sb, s[i: s_len])
-    }
-    StringBuilder::freeze(sb)
-  }
-}
 
 /// #777: `ch: String` was wrong — every call site passes `s[i]` (single-
 /// index), which is an Int char code, not a one-char String. Fixed the
@@ -519,7 +494,7 @@ fn _yaml_parse_block(lines_arr: Array[String], indents_arr: Array[Int], num_line
 
 export fn from_yaml(text: String) -> Json {
   let cr = String::from_char_code(13)
-  let cleaned = yaml_replace_all(text, cr, "")
+  let cleaned = String::replace_all(text, cr, "")
   let raw_lines = String::split(cleaned, "\n")
   let num_raw = Array::length(raw_lines)
   {

--- a/lib/@vibex/shell/index.vpkg
+++ b/lib/@vibex/shell/index.vpkg
@@ -4,6 +4,7 @@ description =
   #|@vibex/shell — POSIX-flavored shell command wrappers (commands.vibe /
 deps = {
   @vibe/json : 0.0.1
+  @vibe/prelude : 0.0.1
 }
 
 generated_hash =

--- a/lib/@vibex/shell/pipeline.vibe
+++ b/lib/@vibex/shell/pipeline.vibe
@@ -13,66 +13,23 @@
 // #897: directory form (not `../json/index.vibe`) — json is a .vpkg
 // contract package now; a literal-filename import resolves exactly one
 // candidate and breaks when the file is replaced.
+// #1841: `String::count` / `String::replace_all` used to be reimplemented
+// locally here (`pipeline_count` / `pipeline_replace_all`) to sidestep a
+// selfhost codegen bug that corrupted an unrelated function in this compile
+// unit when the prelude versions were imported. The trigger (the prelude
+// bodies' `let rec` + dynamic-slice recursion) was rewritten iteratively in
+// #1092 and the miscompile no longer reproduces, so the prelude imports are
+// restored. pipeline_test.vibe pins this shape (prelude import + dynamic
+// string slices in `dirname`) as a regression test.
+import @vibe/prelude {
+  String::count, String::replace_all
+}
+
 import @vibe/json {
   Json::field, Json::index, Json::keys, Json::length, Json::number, Json::parse, Json::string, Json::stringify, Json::type_of
 }
 
 //# Functions
-
-/// #777: `String::count`/`String::replace_all` (`../prelude/string.vibe`) are
-/// real prelude functions, not checker builtins — normally that just means
-/// "needs an explicit import" (same class of host-era rot as #742). But
-/// importing EITHER of them into this file, together with `dirname`'s dynamic
-/// string slice below, trips a real selfhost codegen bug: the imported
-/// function's `let rec` + dynamic-slice body corrupts a WASM function
-/// elsewhere in this compile unit ("not enough arguments on the stack for
-/// call" at runtime instantiation, in a function that never even calls the
-/// import). Reimplementing the two helpers locally (iteratively, no `let
-/// rec`) sidesteps the bug without touching codegen. Tracked for a real fix;
-/// do not reintroduce the prelude import here without re-testing.
-fn pipeline_count(s: String, sub: String) -> Int {
-  let s_len = String::length(s)
-  let sub_len = String::length(sub)
-  if sub_len == 0 || sub_len > s_len {
-    0
-  } else {
-    let mut i = 0
-    let mut acc = 0
-    while i <= s_len - sub_len {
-      if s[i: i + sub_len] == sub {
-        acc = acc + 1
-        i = i + sub_len
-      } else {
-        i = i + 1
-      }
-    }
-    acc
-  }
-}
-
-fn pipeline_replace_all(s: String, pattern: String, replacement: String) -> String {
-  let pat_len = String::length(pattern)
-  let s_len = String::length(s)
-  if pat_len == 0 || pat_len > s_len {
-    s
-  } else {
-    let sb = StringBuilder::new()
-    let mut i = 0
-    while i <= s_len - pat_len {
-      if s[i: i + pat_len] == pattern {
-        StringBuilder::push(sb, replacement)
-        i = i + pat_len
-      } else {
-        StringBuilder::push(sb, s[i: i + 1])
-        i = i + 1
-      }
-    }
-    if i < s_len {
-      StringBuilder::push(sb, s[i: s_len])
-    }
-    StringBuilder::freeze(sb)
-  }
-}
 
 export fn jq(text: String, expr: String) -> String {
   let root = Json::parse(text)
@@ -312,7 +269,7 @@ export fn wc_l(text: String) -> Int {
 }
 
 export fn count(text: String, sub: String) -> Int {
-  pipeline_count(text, sub)
+  String::count(text, sub)
 }
 
 export fn lines(text: String) -> Array[String] {
@@ -460,14 +417,14 @@ export fn grep_re(xs: Array[String], pattern: String) -> Array[String] with Proc
   if text == "" {
     xs
   } else {
-    let escaped_text = pipeline_replace_all(text, "'", "'\\''")
-    let escaped_pattern = pipeline_replace_all(pattern, "'", "'\\''")
+    let escaped_text = String::replace_all(text, "'", "'\\''")
+    let escaped_pattern = String::replace_all(pattern, "'", "'\\''")
     sh_lines("printf '%s' '\{escaped_text}' | grep -E '\{escaped_pattern}'")
   }
 }
 
 export fn replace(text: String, pattern: String, replacement: String) -> String {
-  pipeline_replace_all(text, pattern, replacement)
+  String::replace_all(text, pattern, replacement)
 }
 
 export fn rev_str(xs: Array[String]) -> Array[String] {

--- a/scripts/architecture_debt_allowlist.txt
+++ b/scripts/architecture_debt_allowlist.txt
@@ -33,7 +33,7 @@ ARCH011	lib/@vibe/compiler/_cli_adapter_module_source.vibe	*
 # ratchets after the 2026-08-14 review audit. New occurrences are errors.
 
 # --- generated baseline: bash scripts/lint_architecture_debt.sh --update ---
-ARCH010	lib/@vibe/compiler/checker/checker.vibe	5	None => CtUnknown
+ARCH010	lib/@vibe/compiler/checker/checker.vibe	4	None => CtUnknown
 ARCH010	lib/@vibe/compiler/checker/checker_stmt.vibe	2	None => CtUnknown
 ARCH010	lib/@vibe/compiler/checker_struct.vibe	1	None => CtUnknown
 ARCH011	lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe	1	Some(canonical) => if canonical == text {

--- a/scripts/build_compiler_seed_assets.sh
+++ b/scripts/build_compiler_seed_assets.sh
@@ -102,7 +102,7 @@ cat > "$OUT_DIR/.compiler-manifest-fragment.json" <<EOF
   "entry": "$seed_entry",
   "entry_name": "$seed_entry_name",
   "runtime": {
-    "runner": "moonrun",
+    "runner": "node",
     "wasmtime_flags": "unknown-imports-default=y exceptions=y"
   }
 }

--- a/scripts/generations.sh
+++ b/scripts/generations.sh
@@ -804,7 +804,7 @@ data.seed.artifact = data.seed.artifact ?? {};
 data.seed.artifact.path = artifactPath;
 data.seed.artifact.sha256 = sha;
 data.seed.runtime = data.seed.runtime ?? {};
-data.seed.runtime.runner = data.seed.runtime.runner ?? "moonrun";
+data.seed.runtime.runner = data.seed.runtime.runner ?? "node";
 data.seed.runtime.compile_flag = data.seed.runtime.compile_flag ?? "--wasm-mvp";
 data.seed.runtime.wasmtime_flags = data.seed.runtime.wasmtime_flags ?? "unknown-imports-default=y exceptions=y";
 fs.writeFileSync(manifestPath, `${JSON.stringify(data, null, 2)}\n`);

--- a/scripts/generations_test.sh
+++ b/scripts/generations_test.sh
@@ -27,7 +27,7 @@ cat > "$TMP_ROOT/bootstrap/seed.json" <<EOF
       "sha256": "$seed_sha"
     },
     "runtime": {
-      "runner": "moonrun",
+      "runner": "node",
       "compile_flag": "--wasm-mvp",
       "wasmtime_flags": "unknown-imports-default=y exceptions=y"
     }


### PR DESCRIPTION
stdlib レビュー (2026-08-15) の指摘を実測で裏取りし、issue #1839–#1850 に整理した上で、P0 の #1839 を含む 4 件をこの PR で実装する。

## 変更

### #1839 (P0) — 匿名 record リテラルの struct 捕獲を撤廃

明示的な `record { ... }` リテラル (rn == "") が、フィールド名集合の一致する named struct に 4 箇所で解決されていた: checker (型 identity の捕獲 + strict-superset 拒否)、codegen linear/gc (struct 宣言順への並べ替え + ctor tag)、desugar (EDot の struct 表経由・dispatch 用の形状→名前推測)。

調査中に **live な silent-wrong を実測**: parser の record destructure は位置ベースなので、struct 捕獲がスロットを宣言順に並べ替えると、literal と同順で書いた destructure が入れ替わった値を読む:

```vibe
struct Span { end: Int; start: Int }
let r = record { start: 3, end: 9 }
let record { start: a, end: b } = r   // a = 9, b = 3 (無診断)
```

修正: **rn == "" は全レイヤで「struct 不一致」と同じ扱い** — literal 順レイアウト + tag 0、sentinel 経由の位置 dot access、checker は struct identity を与えず、dispatch 名も推測しない。名前付き literal (`S::{...}`) と merge-rename fallback は不変。

- 検証: `fixtures/anon_record_struct_collision_test.vibe` (スロット順・dot access・同順 destructure・旧拒否の subset 形・衝突 struct 自体の健全性) + 既存 anon record テスト green
- **`bash scripts/compiler_gate.sh` フル通過** (104 ステップ、stage2==stage3 fixpoint、RC bootstrap fixpoint)
- 残件 (issue に記録): record を struct 期待位置に渡す形は checker が今も受理する (CtUnknown 許容)。旧挙動では捕獲で「偶然動いて」いたが、今は誤スロットを読む。拒否には第一級 record 型が要る — #1839 は close せず残す。cheatsheet に caveat 追記済み

### #1841 — @vibex/shell の stale miscompile workaround を撤去

3 ファイルの `String::replace_all`/`count` ローカル再実装 (~120 行) を prelude import に復元。起因とされた miscompile は現行 stage2 で再現しない (#1092 で prelude 側が iterative に書き直し済み)。pipeline_test が当時のトリガ形 (prelude import + dynamic slice の同居) を回帰ピン。`index.vpkg` の deps に `@vibe/prelude` を宣言 (compiler-gate の deps scan で検出された)。

### #1850 — 実測で確認した docs/metadata drift 5 件

prelude README の消えた `result.vibe` / adding-modules の撤廃済み allowlist 手順 / AGENTS の #1500 stale / trait plan の marker-only 記述 / `seed.json` ほかの `runner: "moonrun"` (記述メタデータのみ、分岐に使うスクリプト無しを確認) → `"node"` へ。

### #1845 — `Json::get_opt` 追加

`Json::field` は「キー不在」と「値が null」をどちらも `JNull` に潰す。`get_opt` は不在 = `None` / 明示 null = `Some(JNull)` を区別する。契約宣言 + テスト付き。

## レビューから issue 化したもの (この PR に含まれない)

#1840 (P1 sibling enum visibility) / #1842 pqueue/deque 昇格 / #1843 List 三重表記 / #1844 Hash 二重定義 / #1846 companion import (実測で再現せず、要 close 判断) / #1847 generic Array 確保 / #1848 compiler の Map 性能 / #1849 巨大ファイル分割

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC