### PR TITLE
fix(zero-alloc): reject allocating typed operators

### DIFF
--- a/docs/zero-alloc-check.md
+++ b/docs/zero-alloc-check.md
@@ -131,14 +131,16 @@ RC default のまま `#zero_alloc` は成立する。
   両方)、tuple/array/record/map literal、string interpolation、closure
   literal、float literal(linear backend の heap-box)、effect handler、
   safe-builtin allowlist(read / in-place write 系のみ)外の builtin 呼び、
-  間接呼び出し。top-level fn 呼びは推移的に走査(visited set で再帰安全)。
+  間接呼び出し、String `+`、Double `+ - * /` / unary `-`。演算子は関数注釈と
+  ローカルのスカラー値から lexical に型を伝播し、型が確定しない算術は
+  fail-closed で拒否する(リンク後もファイル-local offset に依存しない)。
+  top-level fn 呼びは推移的に走査(visited set で再帰安全)。
   診断は `zero_alloc: fn 'X' may allocate: <site>`(経由呼び出しは
   `call to 'Y' which may allocate: ...` で連鎖)。
-- **既知ギャップ(Phase 1 で許容)**: 二項演算子は type-blind — String/
-  Double 型の**変数**への `+` 等(確保する concat / boxing に落ちる)は
-  検出できない(literal operand のみ検出)。per-fn サマリの codegen 計装
-  (ADR 本文 step 1 の「確保サイト計装」)は未着手 — 検査は AST 走査で
-  先行。module body 内の fn、wasm-gc backend、`bytes_per_op == 0` bench
+- **既知ギャップ(Phase 1 で許容)**: per-fn サマリの codegen 計装
+  (ADR 本文 step 1 の「確保サイト計装」)は未着手 — 検査は lexical 型伝播を
+  伴う AST 走査で先行。module body 内の fn、wasm-gc backend、
+  `bytes_per_op == 0` bench
   series、ADR-0092 reuse / ADR-0090 arena との合流(step 4-5)も未着手。
 - **gate**: `compiler_gate.sh` §75(positive `zero_alloc_ok.vibe` = 42 /
   negative `err_zero_alloc_ctor.vibe` needle "zero_alloc")。

--- a/fixtures/err_zero_alloc_double_operator.vibe
+++ b/fixtures/err_zero_alloc_double_operator.vibe
@@ -1,0 +1,11 @@
+// Double arithmetic is heap-boxed by the linear backend. The typed
+// #zero_alloc analysis must reject it even when neither operand is a literal.
+#zero_alloc
+fn add(a: Double, b: Double) -> Double {
+  a + b
+}
+
+export let main = () -> Int {
+  let _ = add(1.0, 2.0)
+  0
+}

--- a/fixtures/err_zero_alloc_shadowed_operator.vibe
+++ b/fixtures/err_zero_alloc_shadowed_operator.vibe
@@ -1,0 +1,12 @@
+// The nearest lexical binding owns the operator type. An unrecognized inner
+// initializer must not inherit a same-named outer Int and become false-clean.
+#zero_alloc
+fn add(x: Int, a: Double, b: Double, c: Bool) -> Double {
+  let x = if c { a } else { b }
+  x + a
+}
+
+export let main = () -> Int {
+  let _ = add(0, 1.0, 2.0, true)
+  0
+}

--- a/fixtures/err_zero_alloc_string_operator.vibe
+++ b/fixtures/err_zero_alloc_string_operator.vibe
@@ -1,0 +1,11 @@
+// String `+` lowers to concatenation. It must not become false-clean merely
+// because both operands arrive through parameters.
+#zero_alloc
+fn join(a: String, b: String) -> String {
+  a + b
+}
+
+export let main = () -> Int {
+  let _ = join("a", "b")
+  0
+}

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -1967,11 +1967,11 @@ fn za_first(a: String, b: String) -> String {
 
 /// Extract plain binder names from an EFn parameter list, stripping the
 /// `~`/`?` label-sugar suffix (the call-site spelling binds the bare name).
-fn za_param_names(ps: Array[(String, Option[TypeExpr])]) -> Array[String] {
+fn za_param_facts(ps: Array[(String, Option[TypeExpr])]) -> Array[String] {
   let out = array_empty()
   let mut pi = 0
   while pi < Array::length(ps) {
-    let (raw, _) = Array::get(ps, pi)
+    let (raw, annotation) = Array::get(ps, pi)
     let rl = String::length(raw)
     let stripped = if rl > 0 {
       let lc = String::char_code_at(raw, rl - 1)
@@ -1983,10 +1983,125 @@ fn za_param_names(ps: Array[(String, Option[TypeExpr])]) -> Array[String] {
     } else {
       raw
     }
-    Array::push(out, stripped)
+    Array::push(out, String::concat(stripped, String::concat("\n", typed_alloc_annotation_kind(annotation))))
     pi = pi + 1
   }
   out
+}
+
+fn za_param_fact_name(fact: String) -> String {
+  let sep = String::index_of(fact, "\n")
+  if sep >= 0 {
+    String::substring(fact, 0, sep)
+  } else {
+    fact
+  }
+}
+
+fn za_param_fact_kind(fact: String) -> String {
+  let sep = String::index_of(fact, "\n")
+  if sep >= 0 {
+    String::substring(fact, sep + 1, String::length(fact))
+  } else {
+    ""
+  }
+}
+
+fn typed_alloc_name_kind(names: Array[String], kinds: Array[String], name: String) -> String {
+  let mut i = Array::length(names) - 1
+  let mut matched = false
+  let mut found = ""
+  while i >= 0 && !matched {
+    if Array::get(names, i) == name && i < Array::length(kinds) {
+      matched = true
+      found = Array::get(kinds, i)
+    } else {
+      ()
+    }
+    i = i - 1
+  }
+  if matched && found == "" {
+    "<unknown>"
+  } else {
+    found
+  }
+}
+
+fn typed_alloc_expr_kind(expr: Expr, names: Array[String], kinds: Array[String]) -> String {
+  match expr {
+    EInt(_) => "Int",
+    EFloat(_) => "Double",
+    EString(_) => "String",
+    EBool(_) => "Bool",
+    EIdent(name, _) => typed_alloc_name_kind(names, kinds, name),
+    EBinOp(op, lhs, _) => if op == "==" || op == "!=" || op == "<" || op == "<=" || op == ">" || op == ">=" || op == "&&" || op == "||" {
+      "Bool"
+    } else {
+      typed_alloc_expr_kind(lhs, names, kinds)
+    },
+    EUnaryOp(op, operand) => if op == "!" {
+      "Bool"
+    } else {
+      typed_alloc_expr_kind(operand, names, kinds)
+    },
+    _ => ""
+  }
+}
+
+fn typed_alloc_annotation_kind(annotation: Option[TypeExpr]) -> String {
+  match annotation {
+    Some(TyName(name)) => if name == "Int" || name == "Double" || name == "String" || name == "Bool" {
+      name
+    } else {
+      ""
+    },
+    _ => ""
+  }
+}
+
+fn typed_alloc_copy_strings(items: Array[String]) -> Array[String] {
+  Array::slice(items, 0, Array::length(items))
+}
+
+/// Classify source operators whose statically evident overload allocates on
+/// the linear backend. Lexical type facts survive package linking without
+/// relying on file-local offsets. Unknown arithmetic is conservatively
+/// reported rather than silently certified by `#zero_alloc`.
+export fn typed_operator_alloc_kind(expr: Expr, names: Array[String], kinds: Array[String]) -> String {
+  match expr {
+    EBinOp(op, lhs, rhs) => if op == "+" || op == "-" || op == "*" || op == "/" {
+      let left_kind = typed_alloc_expr_kind(lhs, names, kinds)
+      let kind = if left_kind == "" || left_kind == "<unknown>" {
+        typed_alloc_expr_kind(rhs, names, kinds)
+      } else {
+        left_kind
+      }
+      if kind == "Double" {
+        String::concat("operator:Double:", op)
+      } else if kind == "String" && op == "+" {
+        "operator:String:+"
+      } else if kind == "Int" {
+        ""
+      } else {
+        String::concat("operator:unknown:", op)
+      }
+    } else {
+      ""
+    },
+    EUnaryOp(op, operand) => if op == "-" {
+      let kind = typed_alloc_expr_kind(operand, names, kinds)
+      if kind == "Double" {
+        "operator:Double:-"
+      } else if kind == "Int" {
+        ""
+      } else {
+        "operator:unknown:-"
+      }
+    } else {
+      ""
+    },
+    _ => ""
+  }
 }
 
 /// Walk an expression under `@zero_alloc` and return "" when it is proven
@@ -1994,11 +2109,10 @@ fn za_param_names(ps: Array[(String, Option[TypeExpr])]) -> Array[String] {
 /// Conservative Phase 1 (ADR-0091): constructors, container/closure/string
 /// literals, float literals (heap-boxed on the linear backend), effect
 /// handlers, and any call not on the safe-builtin list or resolvable to a
-/// proven-clean top-level fn are all rejected. Known accepted gap: binary
-/// operators are type-blind here, so `+` on String/Double-typed VARIABLES
-/// (which lowers to an allocating concat / a boxing op) is not caught --
-/// only literal operands are.
-fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Array[Expr], fn_params: Array[Array[String]], visited: Array[String], bound: Array[String]) -> String {
+/// proven-clean top-level fn are all rejected. Operators are classified from
+/// package-stable lexical type facts so String concatenation and boxed Double
+/// arithmetic cannot pass merely because their operands are variables.
+fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Array[Expr], fn_params: Array[Array[String]], visited: Array[String], bound: Array[String], typed_table: Array[String], typed_subst: Array[String]) -> String {
   match e {
     EInt(_) => "",
     EFloat(_) => "float literal (heap-boxed on the linear backend)",
@@ -2020,30 +2134,47 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
     EMap(_) => "map literal",
     EStringInterp(_) => "string interpolation",
     EFn(_, _, _, _, _, _) => "closure literal (allocates its environment)",
-    EIf(zc, zt, zf) => za_first(za_walk(zc, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_first(za_walk(zt, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zf, ctors, fn_names, fn_bodies, fn_params, visited, bound))),
+    EIf(zc, zt, zf) => za_first(za_walk(zc, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_first(za_walk(zt, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_walk(zf, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst))),
     ELet(zl_name, zv, zb, _) => {
-      Array::push(bound, zl_name)
-      za_first(za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound))
+      let value_result = za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)
+      let body_bound = typed_alloc_copy_strings(bound)
+      let body_names = typed_alloc_copy_strings(typed_table)
+      let body_kinds = typed_alloc_copy_strings(typed_subst)
+      Array::push(body_bound, zl_name)
+      Array::push(body_names, zl_name)
+      Array::push(body_kinds, typed_alloc_expr_kind(zv, typed_table, typed_subst))
+      za_first(value_result, za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, body_bound, body_names, body_kinds))
     },
     ELetRec(zlr_name, zv, zb) => {
-      Array::push(bound, zlr_name)
-      za_first(za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound))
+      let body_bound = typed_alloc_copy_strings(bound)
+      let body_names = typed_alloc_copy_strings(typed_table)
+      let body_kinds = typed_alloc_copy_strings(typed_subst)
+      Array::push(body_bound, zlr_name)
+      Array::push(body_names, zlr_name)
+      Array::push(body_kinds, typed_alloc_expr_kind(zv, typed_table, typed_subst))
+      za_first(za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, body_bound, body_names, body_kinds), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, body_bound, body_names, body_kinds))
     },
     ELetMut(zlm_name, zv, zb, _) => {
-      Array::push(bound, zlm_name)
-      za_first(za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound))
+      let value_result = za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)
+      let body_bound = typed_alloc_copy_strings(bound)
+      let body_names = typed_alloc_copy_strings(typed_table)
+      let body_kinds = typed_alloc_copy_strings(typed_subst)
+      Array::push(body_bound, zlm_name)
+      Array::push(body_names, zlm_name)
+      Array::push(body_kinds, typed_alloc_expr_kind(zv, typed_table, typed_subst))
+      za_first(value_result, za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, body_bound, body_names, body_kinds))
     },
-    EAssign(_, zv, zb) => za_first(za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound)),
-    EAssignOp(_, _, zv, zb) => za_first(za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound)),
-    ESeq(za, zb) => za_first(za_walk(za, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound)),
+    EAssign(_, zv, zb) => za_first(za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)),
+    EAssignOp(_, _, zv, zb) => za_first(za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)),
+    ESeq(za, zb) => za_first(za_walk(za, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)),
     EMatch(scr, arms) => {
-      let mut r = za_walk(scr, ctors, fn_names, fn_bodies, fn_params, visited, bound)
+      let mut r = za_walk(scr, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)
       let mut ai = 0
       while ai < Array::length(arms) {
         let (arm_pat, arm_body) = Array::get(arms, ai)
         let _ = collect_pattern_bindings(arm_pat, bound)
         if r == "" {
-          r = za_walk(arm_body, ctors, fn_names, fn_bodies, fn_params, visited, bound)
+          r = za_walk(arm_body, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)
         } else {
           ()
         }
@@ -2052,21 +2183,27 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
       r
     },
     EHandle(_, _) => "effect handler (allocates evidence)",
-    EWhile(zc, zb) => za_first(za_walk(zc, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound)),
+    EWhile(zc, zb) => za_first(za_walk(zc, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)),
     ELoop(inits, zb) => {
       let mut r = ""
+      let loop_bound = typed_alloc_copy_strings(bound)
+      let loop_names = typed_alloc_copy_strings(typed_table)
+      let loop_kinds = typed_alloc_copy_strings(typed_subst)
       let mut li = 0
       while li < Array::length(inits) {
         let (zloop_name, init_e) = Array::get(inits, li)
-        Array::push(bound, zloop_name)
         if r == "" {
-          r = za_walk(init_e, ctors, fn_names, fn_bodies, fn_params, visited, bound)
+          r = za_walk(init_e, ctors, fn_names, fn_bodies, fn_params, visited, loop_bound, loop_names, loop_kinds)
         } else {
           ()
         }
+        let init_kind = typed_alloc_expr_kind(init_e, loop_names, loop_kinds)
+        Array::push(loop_bound, zloop_name)
+        Array::push(loop_names, zloop_name)
+        Array::push(loop_kinds, init_kind)
         li = li + 1
       }
-      za_first(r, za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound))
+      za_first(r, za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, loop_bound, loop_names, loop_kinds))
     },
     EForIn(zfi_name, zfi_snd, zsrc, zb) => {
       Array::push(bound, zfi_name)
@@ -2074,14 +2211,14 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
         Some(zfi_n2) => Array::push(bound, zfi_n2),
         None => ()
       }
-      za_first(za_walk(zsrc, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound))
+      za_first(za_walk(zsrc, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst))
     },
     ECall(callee, cargs, _) => {
       let mut r = ""
       let mut ci = 0
       while ci < Array::length(cargs) {
         if r == "" {
-          r = za_walk(Array::get(cargs, ci), ctors, fn_names, fn_bodies, fn_params, visited, bound)
+          r = za_walk(Array::get(cargs, ci), ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)
         } else {
           ()
         }
@@ -2119,13 +2256,19 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
                 // Fresh scope for the callee: its own params are its only
                 // lexical bindings (the caller's do not leak in).
                 let callee_bound = array_empty()
+                let callee_typed_names = array_empty()
+                let callee_typed_kinds = array_empty()
                 let callee_ps = Array::get(fn_params, fidx)
                 let mut cbi = 0
                 while cbi < Array::length(callee_ps) {
-                  Array::push(callee_bound, Array::get(callee_ps, cbi))
+                  let callee_fact = Array::get(callee_ps, cbi)
+                  let callee_name = za_param_fact_name(callee_fact)
+                  Array::push(callee_bound, callee_name)
+                  Array::push(callee_typed_names, callee_name)
+                  Array::push(callee_typed_kinds, za_param_fact_kind(callee_fact))
                   cbi = cbi + 1
                 }
-                let inner = za_walk(Array::get(fn_bodies, fidx), ctors, fn_names, fn_bodies, fn_params, visited, callee_bound)
+                let inner = za_walk(Array::get(fn_bodies, fidx), ctors, fn_names, fn_bodies, fn_params, visited, callee_bound, callee_typed_names, callee_typed_kinds)
                 if inner == "" {
                   ""
                 } else {
@@ -2140,13 +2283,13 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
         }
       }
     },
-    EBinOp(_, za, zb) => za_first(za_walk(za, ctors, fn_names, fn_bodies, fn_params, visited, bound), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound)),
-    EUnaryOp(_, za) => za_walk(za, ctors, fn_names, fn_bodies, fn_params, visited, bound),
-    EDot(zobj, _, _, _) => za_walk(zobj, ctors, fn_names, fn_bodies, fn_params, visited, bound),
-    ELabeledArg(_, _, zv) => za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound),
-    EReturn(zv) => za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound),
+    EBinOp(_, za, zb) => za_first(za_first(za_walk(za, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_walk(zb, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)), typed_operator_alloc_kind(e, typed_table, typed_subst)),
+    EUnaryOp(_, za) => za_first(za_walk(za, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), typed_operator_alloc_kind(e, typed_table, typed_subst)),
+    EDot(zobj, _, _, _) => za_walk(zobj, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst),
+    ELabeledArg(_, _, zv) => za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst),
+    EReturn(zv) => za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst),
     EBreak(zo) => match zo {
-      Some(zv) => za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound),
+      Some(zv) => za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst),
       None => ""
     },
     EContinue(zvs) => {
@@ -2154,7 +2297,7 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
       let mut vi = 0
       while vi < Array::length(zvs) {
         if r == "" {
-          r = za_walk(Array::get(zvs, vi), ctors, fn_names, fn_bodies, fn_params, visited, bound)
+          r = za_walk(Array::get(zvs, vi), ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)
         } else {
           ()
         }
@@ -2162,7 +2305,7 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
       }
       r
     },
-    ESpread(zv) => za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound),
+    ESpread(zv) => za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst),
     EUnit => ""
   }
 }
@@ -2186,7 +2329,7 @@ export fn zero_alloc_check(stmts: Array[Stmt]) -> String {
         EFn(_, _, efn_params, _, _, fb) => {
           Array::push(fn_names, lname)
           Array::push(fn_bodies, fb)
-          Array::push(fn_params, za_param_names(efn_params))
+          Array::push(fn_params, za_param_facts(efn_params))
         },
         _ => ()
       },
@@ -2250,13 +2393,19 @@ export fn zero_alloc_check(stmts: Array[Stmt]) -> String {
           let visited = array_empty()
           Array::push(visited, target_name)
           let seed_bound = array_empty()
+          let seed_typed_names = array_empty()
+          let seed_typed_kinds = array_empty()
           let seed_ps = Array::get(fn_params, fidx2)
           let mut sbi = 0
           while sbi < Array::length(seed_ps) {
-            Array::push(seed_bound, Array::get(seed_ps, sbi))
+            let seed_fact = Array::get(seed_ps, sbi)
+            let seed_name = za_param_fact_name(seed_fact)
+            Array::push(seed_bound, seed_name)
+            Array::push(seed_typed_names, seed_name)
+            Array::push(seed_typed_kinds, za_param_fact_kind(seed_fact))
             sbi = sbi + 1
           }
-          let r = za_walk(Array::get(fn_bodies, fidx2), ctors, fn_names, fn_bodies, fn_params, visited, seed_bound)
+          let r = za_walk(Array::get(fn_bodies, fidx2), ctors, fn_names, fn_bodies, fn_params, visited, seed_bound, seed_typed_names, seed_typed_kinds)
           if r != "" {
             msg = String::concat("zero_alloc: fn '", String::concat(target_name, String::concat("' may allocate: ", r)))
           } else {

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -49,6 +49,7 @@ fn md_consume_count_b(e: Expr, name: String, bfns: Array[String], bmasks: Array[
 fn md_shadow_zeroed_bmasks(e: Expr, bfns: Array[String], bmasks: Array[Int]) -> Array[Int]
 fn md_consume_count_pre(e: Expr, name: String, bfns: Array[String], bmasks_zeroed: Array[Int]) -> Int
 fn zero_alloc_check(stmts: Array[Stmt]) -> String
+fn typed_operator_alloc_kind(expr: Expr, names: Array[String], kinds: Array[String]) -> String
 fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String]
 fn bmask_max_param() -> Int
 fn bmask_has(mask: Int, i: Int) -> Bool

--- a/lib/@vibe/compiler/runtime/alloc_spans.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans.vibe
@@ -27,14 +27,15 @@
 //# Output: one `FN KIND OFFSET` line per site, in source order within each
 //# function, functions in declaration order. KIND is one of
 //# `builtin:<name>` / `constructor:<name>` / `closure` / `array` / `tuple` /
-//# `record` / `map` / `interp` / `float` / `handler` / `mut-cell`. Empty
+//# `record` / `map` / `interp` / `float` / `handler` / `mut-cell` /
+//# `operator:<type>:<op>`. Empty
 //# output = this file allocates nothing, i.e. every function in it is already
 //# zero-alloc.
 
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Stmt, builtin_allocates, expr_children
+  Expr, Stmt, TypeExpr, builtin_allocates, expr_children
 }
 
 import @vibe/core {
@@ -46,7 +47,7 @@ import @vibe/compiler/syntax {
 }
 
 import @vibe/compiler/codegen/common_analysis {
-  is_mut_captured_in
+  is_mut_captured_in, typed_operator_alloc_kind
 }
 
 //# Functions
@@ -57,6 +58,93 @@ fn alloc_empty_items() -> Array[(String, String, Int)] {
 
 fn alloc_empty_strings() -> Array[String] {
   array_empty()
+}
+
+struct AllocWalkContext {
+  ctors: Array[String];
+  names: Array[String];
+  kinds: Array[String]
+}
+
+fn alloc_annotation_kind(annotation: Option[TypeExpr]) -> String {
+  match annotation {
+    Some(TyName(name)) => if name == "Int" || name == "Double" || name == "String" || name == "Bool" {
+      name
+    } else {
+      ""
+    },
+    _ => ""
+  }
+}
+
+fn alloc_context(ctors: Array[String], params: Array[(String, Option[TypeExpr])]) -> AllocWalkContext {
+  let names = alloc_empty_strings()
+  let kinds = alloc_empty_strings()
+  let mut i = 0
+  while i < Array::length(params) {
+    let (raw_name, annotation) = Array::get(params, i)
+    let len = String::length(raw_name)
+    let name = if len > 0 && (String::char_code_at(raw_name, len - 1) == 126 || String::char_code_at(raw_name, len - 1) == 63) {
+      String::substring(raw_name, 0, len - 1)
+    } else {
+      raw_name
+    }
+    Array::push(names, name)
+    Array::push(kinds, alloc_annotation_kind(annotation))
+    i = i + 1
+  }
+  AllocWalkContext::{
+    ctors: ctors,
+    names: names,
+    kinds: kinds
+  }
+}
+
+fn alloc_name_kind(ctx: AllocWalkContext, name: String) -> String {
+  let mut i = Array::length(ctx.names) - 1
+  let mut found = ""
+  while i >= 0 && found == "" {
+    if Array::get(ctx.names, i) == name {
+      found = Array::get(ctx.kinds, i)
+    } else {
+      ()
+    }
+    i = i - 1
+  }
+  found
+}
+
+fn alloc_expr_kind(expr: Expr, ctx: AllocWalkContext) -> String {
+  match expr {
+    EInt(_) => "Int",
+    EFloat(_) => "Double",
+    EString(_) => "String",
+    EBool(_) => "Bool",
+    EIdent(name, _) => alloc_name_kind(ctx, name),
+    EBinOp(op, lhs, _) => if op == "==" || op == "!=" || op == "<" || op == "<=" || op == ">" || op == ">=" || op == "&&" || op == "||" {
+      "Bool"
+    } else {
+      alloc_expr_kind(lhs, ctx)
+    },
+    EUnaryOp(op, operand) => if op == "!" {
+      "Bool"
+    } else {
+      alloc_expr_kind(operand, ctx)
+    },
+    _ => ""
+  }
+}
+
+fn alloc_context_with_binding(ctx: AllocWalkContext, name: String, value: Expr) -> AllocWalkContext {
+  let names = Array::slice(ctx.names, 0, Array::length(ctx.names))
+  let kinds = Array::slice(ctx.kinds, 0, Array::length(ctx.kinds))
+  Array::push(names, name)
+  Array::push(kinds, alloc_expr_kind(value, ctx))
+  AllocWalkContext::{
+    ctors: ctx.ctors,
+    names: names,
+    kinds: kinds
+  }
 }
 
 fn alloc_contains_name(names: Array[String], name: String) -> Bool {
@@ -122,22 +210,27 @@ fn alloc_call_kind(expr: Expr, ctors: Array[String]) -> String {
 
 /// The site kind for `expr` itself (not its children), or "" when this node
 /// allocates nothing on its own.
-fn alloc_site_kind(expr: Expr, ctors: Array[String]) -> String {
-  match expr {
-    EFloat(_) => "float",
-    EIdent(name, _) => if alloc_contains_name(ctors, name) {
-      String::concat("constructor:", name)
-    } else {
-      ""
-    },
-    EFn(_, _, _, _, _, _) => "closure",
-    EArray(_) => "array",
-    ETuple(_) => "tuple",
-    ERecord(_, _, _) => "record",
-    EMap(_) => "map",
-    EStringInterp(_) => "interp",
-    EHandle(_, _) => "handler",
-    _ => alloc_call_kind(expr, ctors)
+fn alloc_site_kind(expr: Expr, ctx: AllocWalkContext) -> String {
+  let typed_operator = typed_operator_alloc_kind(expr, ctx.names, ctx.kinds)
+  if typed_operator != "" {
+    typed_operator
+  } else {
+    match expr {
+      EFloat(_) => "float",
+      EIdent(name, _) => if alloc_contains_name(ctx.ctors, name) {
+        String::concat("constructor:", name)
+      } else {
+        ""
+      },
+      EFn(_, _, _, _, _, _) => "closure",
+      EArray(_) => "array",
+      ETuple(_) => "tuple",
+      ERecord(_, _, _) => "record",
+      EMap(_) => "map",
+      EStringInterp(_) => "interp",
+      EHandle(_, _) => "handler",
+      _ => alloc_call_kind(expr, ctx.ctors)
+    }
   }
 }
 
@@ -162,8 +255,8 @@ fn alloc_site_offset(expr: Expr, fallback: Int) -> Int {
   }
 }
 
-fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr, fn_off: Int, ctors: Array[String]) -> Unit {
-  let kind = alloc_site_kind(expr, ctors)
+fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr, fn_off: Int, ctx: AllocWalkContext) -> Unit {
+  let kind = alloc_site_kind(expr, ctx)
   if String::length(kind) > 0 {
     Array::push(out, (fname, kind, alloc_site_offset(expr, fn_off)))
   } else {
@@ -188,11 +281,28 @@ fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr,
     _ => ()
   }
   let here = alloc_site_offset(expr, fn_off)
-  let kids = expr_children(expr)
-  let mut i = 0
-  while i < Array::length(kids) {
-    alloc_walk_expr(out, fname, Array::get(kids, i), here, ctors)
-    i = i + 1
+  match expr {
+    ELet(name, value, rest, _) => {
+      alloc_walk_expr(out, fname, value, here, ctx)
+      alloc_walk_expr(out, fname, rest, here, alloc_context_with_binding(ctx, name, value))
+    },
+    ELetRec(name, value, rest) => {
+      let body_ctx = alloc_context_with_binding(ctx, name, value)
+      alloc_walk_expr(out, fname, value, here, body_ctx)
+      alloc_walk_expr(out, fname, rest, here, body_ctx)
+    },
+    ELetMut(name, value, rest, _) => {
+      alloc_walk_expr(out, fname, value, here, ctx)
+      alloc_walk_expr(out, fname, rest, here, alloc_context_with_binding(ctx, name, value))
+    },
+    _ => {
+      let kids = expr_children(expr)
+      let mut i = 0
+      while i < Array::length(kids) {
+        alloc_walk_expr(out, fname, Array::get(kids, i), here, ctx)
+        i = i + 1
+      }
+    }
   }
 }
 
@@ -281,15 +391,15 @@ export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Excep
     }
     match Array::get(stmts, i) {
       SLet(_, _, name, _, value) => match value {
-        EFn(_, _, _, _, _, fbody) => alloc_walk_expr(out, name, fbody, stmt_off, ctors),
+        EFn(_, _, params, _, _, fbody) => alloc_walk_expr(out, name, fbody, stmt_off, alloc_context(ctors, params)),
         _ => ()
       },
       // Tests and benches lower to real executable functions. In particular,
       // a bytes-per-op regression asks about the bench body itself, so
       // skipping SBench would turn an allocating benchmark into false-clean
       // output. Keep the owner names identical to linked_compile's lowering.
-      STest(test_name, test_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__test_", test_name)), test_body, stmt_off, ctors),
-      SBench(bench_name, bench_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__bench_", bench_name)), bench_body, stmt_off, ctors),
+      STest(test_name, test_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__test_", test_name)), test_body, stmt_off, alloc_context(ctors, array_empty())),
+      SBench(bench_name, bench_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__bench_", bench_name)), bench_body, stmt_off, alloc_context(ctors, array_empty())),
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
@@ -6,7 +6,7 @@
 // the source does not say out loud — a closure's environment, and a `let mut`
 // that becomes a heap ref cell because something captured it.
 
-import ../runtime {
+import ./alloc_spans.vibe {
   alloc_spans
 }
 

--- a/lib/@vibe/compiler/runtime/typed_operator_alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/typed_operator_alloc_spans_test.vibe
@@ -1,0 +1,55 @@
+// #1838: operators are overloaded, so their allocation behavior is a typed
+// fact rather than a property of the surface operator token alone.
+
+import ./alloc_spans.vibe {
+  alloc_spans
+}
+
+import @vibe/compiler/codegen/common_analysis {
+  zero_alloc_check
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+fn has_kind(source: String, want: String) -> Bool with Exception {
+  let spans = alloc_spans(source)
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(spans) {
+    let (_fn, kind, _off) = Array::get(spans, i)
+    if kind == want {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+test "Double arithmetic operators are typed allocation sites" {
+  let double_add = "fn add(a: Double, b: Double) -> Double {\n  let sum = a + b\n  -sum\n}\n"
+  assert(has_kind(double_add, "operator:Double:+"))
+  assert(has_kind(double_add, "operator:Double:-"))
+}
+
+test "String addition is a typed allocation site" {
+  let string_add = "fn join(a: String, b: String) -> String {\n  a + b\n}\n"
+  assert(has_kind(string_add, "operator:String:+"))
+}
+
+test "typed scalar operators that do not allocate stay clean" {
+  let int_add = "fn add(a: Int, b: Int) -> Int {\n  a + b\n}\n"
+  assert_eq(Array::length(alloc_spans(int_add)), 0)
+  let double_cmp = "fn below(a: Double, b: Double) -> Bool {\n  a < b\n}\n"
+  assert_eq(Array::length(alloc_spans(double_cmp)), 0)
+}
+
+test "an unknown inner binding does not inherit a shadowed outer scalar kind" {
+  let shadowed = "fn f(x: Int, a: Double, b: Double, c: Bool) -> Double {\n  let x = if c { a } else { b }\n  x + a\n}\n"
+  assert(has_kind(shadowed, "operator:Double:+"))
+  let marked = String::concat("#zero_alloc\n", shadowed)
+  assert(String::contains(zero_alloc_check(parse_program(lex(marked))), "operator:Double:+"))
+}

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9239,6 +9239,25 @@ if ! grep -qF 'zero_alloc' "$za91dir/shadowed.wasm.diag" 2>/dev/null; then
   cat "$za91dir/shadowed.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+# #1838: typed operators can allocate even when their operands are variables.
+# Pin both allocating overloads: linear Double arithmetic boxes its result,
+# and String `+` lowers to concatenation. Int arithmetic remains covered by
+# the positive fixture above.
+for za_typed in double_operator string_operator shadowed_operator; do
+  cp "fixtures/err_zero_alloc_${za_typed}.vibe" "$za91dir/${za_typed}.vibe"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$za91dir/${za_typed}.vibe" "$za91dir/${za_typed}.wasm" __no_entry__ >/dev/null 2>&1 || true
+  if [ -s "$za91dir/${za_typed}.wasm" ]; then
+    echo "[compiler-gate] FAIL: err_zero_alloc_${za_typed}.vibe compiled successfully -- typed allocating operator must be rejected" >&2
+    exit 1
+  fi
+  if ! grep -qF 'zero_alloc' "$za91dir/${za_typed}.wasm.diag" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: err_zero_alloc_${za_typed}.vibe did not produce the expected diagnostic" >&2
+    cat "$za91dir/${za_typed}.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
 rm -rf "$za91dir"
 # ADR-0091 #1262: the check and the MEASUREMENT pin each other. The two
 # fixtures above prove a clean fn compiles and a violating one is rejected;


### PR DESCRIPTION
## Summary
- classify String concatenation and boxed Double arithmetic in the shared allocation analysis
- propagate package-stable lexical scalar facts instead of relying on colliding file-local offsets
- make unknown arithmetic fail closed and expose the same sites through vibe allocs
- add Red/Green compiler fixtures and focused query coverage

## Validation
- fresh stage0 -> stage1 -> stage2 -> stage3 generation gate
- alloc_spans focused: 20 tests green
- #zero_alloc Double/String negative fixtures reject; existing Int positive compiles
- pkf run test-local: 245/245
- pkf run test-pre-commit

Closes #1838