### PR TITLE
fix(scripts): 生成 fixture test で、トップレベル必須の宣言を持ち上げる (refs #1855)

### DIFF
--- a/scripts/generate_runtime_fixture_tests.mjs
+++ b/scripts/generate_runtime_fixture_tests.mjs
@@ -104,23 +104,48 @@ function splitTopLevelChunks(source) {
   return chunks;
 }
 
+// Chunks that must be HOISTED above the generated `test` block, because vibe
+// only accepts them at the top level.
+//
+// `enum`, `struct`, `type`, `impl`, `trait` and `module` used to be classified
+// as declaration chunks, i.e. left inside the block. They do not compile there:
+// a block-local `enum` is rejected outright ("move `Color` to the top level",
+// #1525) and `trait` does not even parse. `effect` was in neither list, so it
+// fell to the expression wrapper and came out as `let _ = ( effect Console {`.
+//
+// The split is about WHERE a form is legal, so the test for it is the same
+// question: can this appear inside a block? Only bindings can.
 function isPreludeChunk(chunk) {
   const trimmed = chunk.trimStart();
-  return trimmed.startsWith("import ") || trimmed.startsWith("export ");
+  return [
+    "import ",
+    "export ",
+    "use ",
+    "declare ",
+    "enum ",
+    "struct ",
+    "type ",
+    "impl ",
+    "trait ",
+    "effect ",
+    "module ",
+  ].some((kw) => trimmed.startsWith(kw));
 }
 
+// Chunks that are legal inside the block and are NOT expressions, so they are
+// emitted as-is rather than wrapped in `let _ = ( ... )`.
 function isDeclarationChunk(chunk) {
   const trimmed = chunk.trimStart();
-  return (
-    trimmed.startsWith("let ") ||
-    trimmed.startsWith("let rec ") ||
-    trimmed.startsWith("enum ") ||
-    trimmed.startsWith("struct ") ||
-    trimmed.startsWith("type ") ||
-    trimmed.startsWith("impl ") ||
-    trimmed.startsWith("trait ") ||
-    trimmed.startsWith("module ")
-  );
+  return trimmed.startsWith("let ") || trimmed.startsWith("let rec ");
+}
+
+// A chunk with no code in it. Wrapping one as an expression produced
+// `let _ = (\n// Basic effect declaration\n)`, which is a parse error -- the
+// comment is the whole chunk, so there is nothing for the parens to hold.
+function isCommentOnlyChunk(chunk) {
+  return chunk
+    .split("\n")
+    .every((line) => line.trim() === "" || line.trim().startsWith("//"));
 }
 
 /**
@@ -208,6 +233,8 @@ function buildSingleFixtureTestContent(fixturePath) {
   const bodyChunks = [];
   for (const chunk of chunks) {
     if (isPreludeChunk(chunk)) {
+      preludeChunks.push(chunk);
+    } else if (isCommentOnlyChunk(chunk)) {
       preludeChunks.push(chunk);
     } else if (isDeclarationChunk(chunk)) {
       bodyChunks.push(chunk);


### PR DESCRIPTION
#1832 の最後に「`{"last": ...}` fixture はどこからも実行されていないように見える」と
書いた件を追いました。**実行されていません — 214 本中 209 本が。**
計測と全体像は #1855 に書きました。これはその最初の一歩です。

## 直したもの

`generate_runtime_fixture_tests.mjs` は fixture を `test` ブロックに包みますが、
`enum` / `struct` / `type` / `impl` / `trait` / `module` を**ブロック内に置ける宣言**に
分類していました。置けません:

```console
line 2:3: a block-local `enum` declaration is not supported -- move `Color` to the
          top level and refer to it from here. (#1525)
line 2:3: unexpected token: trait
```

`effect` はどちらのリストにも無く、式ラッパに落ちていました:

```vibe
let _ = (
effect Console {
  Print(String) -> Unit;
```

コメントだけの chunk も同じ扱いで、`let _ = (\n// Basic effect declaration\n)` に
なっていました。

分類の基準は**その形がどこに書けるか**なので、そのまま訊く形にしました —
トップレベル必須のものは持ち上げ、ブロック内に置けるのは束縛だけ、
コメントのみの chunk はそのまま出す。

## 計測

generator が自分で発見する fixture に対して:

| | |
|---|---|
| 40 本サンプル | **26 pass → 38 pass** |
| 全 214 本 | **174 pass / 40 fail** |

残り 40 の内訳:

- **13**: generator のもう一つのバグ。生成物が別ディレクトリに置かれるので、
  fixture の `./lib/...` / `./fixtures/...` import が解決しない
- **27**: **fixture 側のドリフト** — `unknown name: Json::parse`、
  `argument type mismatch for MapBuilder::set`、`expected type but got {` など

後者が #1855 の主題です。**期待値を宣言しているのに誰も照合しないので、
腐っても何も起きません。** 直前に #1832 で同じものが 1 本、別経路で見つかっています
(`struct_lit_sugar.vibe` はパーサが一度も受け付けたことのない綴りでした)。

## この PR がやらないこと

**generator をレーンに配線しません。** それをやるには先に 27 本を triage する必要が
あり (直す / 期待値を更新する / 陳腐化として削除する)、それは follow-up 一行では
なくプロジェクトです。順序は #1855 に書きました。

## 検証

- generator は決定的 (同じ入力で 2 回生成してバイト一致を確認)
- `check_vibe_fmt` / `lint_review_regressions` / `lint_architecture_debt` green
- 生成物 (`lib/@vibe/compiler/_generated_runtime_fixtures/`) はコミットしていません
- `origin/main` (0a6cc331c) 上

Refs #1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN)_