### PR TITLE
Add builtin Default trait (#1847)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -650,7 +650,8 @@ let b2 = Box[Int]::{ v: 2 }               // explicit type args PIN the instanti
 // struct derive(Show) -> Point::to_string(p) : String ("Point { x: 1, y: 2 }")
 // enum derive(Show) -> E::to_string(v) : String ("B(3)" / "A")
 // derive(Hash) -> T::hash_key(v) (構造キー、to_string も併せて生成)
-// derive(Default) -> T::default()
+// derive(Default) -> T::default() + `impl Default for T` 登録 (#1847) —
+//   derive した型はそのまま `[T: Default]` bound を満たす
 // (Eq は marker: 構造的 `==` は T::equals として常に生成される)
 // #1392: `"\{v}"` は解決できた型の `T::to_string` を呼ぶ。prelude の
 // `to_string(v)` も同じ (body が `__to_string(x)` そのものの 1 引数 pass-through
@@ -668,6 +669,16 @@ impl [T: Eq] Eq for Array[T]              // 宣言はできるが bound には�
 // trait: `[T: Send]` accepts primitives, tuples, Option/Result, and
 // immutable structs/enums built from Send parts; Array/Bytes, closures,
 // and `mut`-field structs are rejected. `impl Send for X` is an error.
+
+// `Default` (#1847) は builtin trait: prelude が marker + primitive impl
+// (Int/Float/Double/Bool/String) を登録するので `[T: Default]` bound は
+// どこでも満たせる。generic code から `T::default()` を呼ぶには
+// method-bearing 宣言 (`trait Default { default() -> Self }`) が要るので
+// `import @vibe/core { Default }` する — witness は Hash と同じ dict 経由。
+// derive(Default) した struct/enum も bound を満たす。呼び出し側で T の
+// 具象型が構文的に決まらない形 (例: `[T: Default]() -> T` を注釈だけで
+// 呼ぶ) は witness が組めず解決されない — T 型の引数 (または Array[T]
+// 引数) を witness carrier にすること。
 ```
 
 ### marker trait の impl は container には効かない (#1503)

--- a/fixtures/derive_default_bound_test.vibe
+++ b/fixtures/derive_default_bound_test.vibe
@@ -1,0 +1,39 @@
+// #1847: `derive(Default)` must satisfy a `[T: Default]` bound. Before the
+// fix, the derive only bound the `T::default()` signature and the bound check
+// reported `no impl Default for P` — this fixture pins the registration
+// (checker_stmt.vibe's EnvTraitImpl("Default", ...) for struct + enum arms).
+import @vibe/core {
+  Default
+}
+
+struct Point {
+  x: Int;
+  y: Int
+} derive (Default, Eq)
+
+enum Mode {
+  Idle;
+  Busy(Int)
+} derive (Default, Eq)
+
+fn fresh[T: Default](witness: T) -> T {
+  T::default()
+}
+
+test "derived struct satisfies [T: Default]" {
+  let p = fresh(Point::{
+    x: 3, y: 4
+  })
+  assert_eq(p.x, 0)
+  assert_eq(p.y, 0)
+}
+
+test "derived enum satisfies [T: Default]" {
+  let m = fresh(Busy(9))
+  assert_true(m == Idle)
+}
+
+test "primitives still dispatch through the same bound" {
+  assert_eq(fresh(7), 0)
+  assert_true(fresh("xyz") == "")
+}

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1707,8 +1707,13 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         } else {
           env_show
         }
+        // #1847: like Hash above, ALSO register `impl Default for E` so a
+        // `[T: Default]` bound is satisfied by the derived enum (previously
+        // only the `E::default` signature was bound, so the bound check
+        // reported `no impl Default for E`).
         let env_default = if struct_derives_has(enum_derives, "Default") {
-          env_bind(env_hash, String::concat(name, "::default"), CtFn(array_empty(), ctor_result_type, None))
+          let env_d = EnvTraitImpl("Default", ctor_result_type, env_hash)
+          env_bind(env_d, String::concat(name, "::default"), CtFn(array_empty(), ctor_result_type, None))
         } else {
           env_hash
         }
@@ -1846,9 +1851,12 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           env4
         }
         // #638: `derive(Default)` generates `T::default() -> T` (a zero-arg fn,
-        // so the CtFn parameter list is empty).
+        // so the CtFn parameter list is empty). #1847: like Hash above, ALSO
+        // register `impl Default for T` so a `[T: Default]` bound is satisfied
+        // by the derived type.
         let env5 = if struct_derives_has(derives, "Default") {
-          env_bind(env_hash, String::concat(name, "::default"), CtFn(array_empty(), CtStruct(name), None))
+          let env_d = EnvTraitImpl("Default", CtStruct(name), env_hash)
+          env_bind(env_d, String::concat(name, "::default"), CtFn(array_empty(), CtStruct(name), None))
         } else {
           env_hash
         }

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -231,6 +231,8 @@ vibe_core	../../../lib/@vibe/core/set.vibe
 vibe_core	../../../lib/@vibe/core/map_get.vibe
 vibe_core	../../../lib/@vibe/core/map.vibe
 vibe_core	../../../lib/@vibe/core/maps.vibe
+vibe_core	../../../lib/@vibe/core/default.vibe
+vibe_core	../../../lib/@vibe/core/defaults.vibe
 vibe_core	../../../lib/@vibe/core/math_extra.vibe
 vibe_core	../../../lib/@vibe/core/base64.vibe
 vibe_core	../../../lib/@vibe/core/diff.vibe

--- a/lib/@vibe/core/default.vibe
+++ b/lib/@vibe/core/default.vibe
@@ -1,0 +1,45 @@
+//# Types
+
+/// `Default` is method-bearing (#1847): `default() -> Self` produces a type's
+/// canonical "empty" value (0 / 0.0 / false / ""). Its purpose is generic
+/// backing-store allocation — a `[T: Default]` collection can fill fresh or
+/// vacated slots with `T::default()` instead of recycling a pushed element
+/// (the @vibex/pqueue / @vibex/deque filler scheme, which extends element
+/// lifetimes). Because the method threads a witness dictionary (#684), a
+/// bounded generic dispatches the concrete type's `default` the same way
+/// `Hash::hash_key` does for Map keys. `derive(Default)` generates a
+/// structural `Type::default()` and registers the impl, so derived structs
+/// and enums satisfy the bound too.
+export trait Default {
+  default() -> Self
+}
+
+impl Default for Int {
+  default() -> Int {
+    0
+  }
+}
+
+impl Default for Float {
+  default() -> Float {
+    0.0
+  }
+}
+
+impl Default for Double {
+  default() -> Double {
+    0.0
+  }
+}
+
+impl Default for Bool {
+  default() -> Bool {
+    false
+  }
+}
+
+impl Default for String {
+  default() -> String {
+    ""
+  }
+}

--- a/lib/@vibe/core/default_test.vibe
+++ b/lib/@vibe/core/default_test.vibe
@@ -1,0 +1,76 @@
+//# Imports
+
+import ./default.vibe {
+  Default
+}
+
+//# Misc
+
+// NOTE: `Int::default()` etc. are NOT called directly here — an impl's free
+// functions are file-local (map_test.vibe never calls `Int::hash_key` either).
+// The public surface is the bound: generic code dispatches through the
+// witness dictionary the call site synthesizes (#684).
+
+fn fresh[T: Default](witness: T) -> T {
+  T::default()
+}
+
+// Generic dispatch through the [T: Default] bound: the call sites below
+// synthesize the witness dictionary from the concrete argument type (#684),
+// so each `T::default()` lands on that type's impl, not a shared fallback.
+test "generic dispatch via bound" {
+  assert(eq(fresh(42), 0))
+  assert(fresh("abc") == "")
+  assert(not(fresh(true)))
+}
+
+struct Pair {
+  a: Int;
+  b: String
+}
+
+impl Default for Pair {
+  default() -> Pair {
+    Pair::{
+      a: 0, b: ""
+    }
+  }
+}
+
+test "user impl satisfies the bound" {
+  let p = fresh(Pair::{
+    a: 9, b: "z"
+  })
+  assert(eq(p.a, 0))
+  assert(p.b == "")
+}
+
+fn refill[T: Default](xs: Array[T]) -> Unit {
+  let mut i = 0
+  while i < Array::length(xs) {
+    Array::set(xs, i, T::default())
+    i = i + 1
+  }
+}
+
+// The #1847 shape: vacate every slot of a generic backing store without
+// holding on to a pushed element. The Array[T] parameter is the witness
+// carrier (#1199's array-element receiver), so callers pass a plain array.
+test "generic backing-store refill" {
+  let xs = [
+    7,
+    8,
+    9
+  ]
+  refill(xs)
+  assert(eq(Array::get(xs, 0), 0))
+  assert(eq(Array::get(xs, 1), 0))
+  assert(eq(Array::get(xs, 2), 0))
+  let ss = [
+    "a",
+    "b"
+  ]
+  refill(ss)
+  assert(Array::get(ss, 0) == "")
+  assert(Array::get(ss, 1) == "")
+}

--- a/lib/@vibe/core/defaults.vibe
+++ b/lib/@vibe/core/defaults.vibe
@@ -1,0 +1,10 @@
+//# Imports
+
+// Same facade shape as maps.vibe's `trait Hash` re-export: the contract's
+// `opaque type Default` has no struct/enum implementation for conformance to
+// find, so this re-export discharges it at face value (#847) and the trait
+// rides the merged program globally — consumers can `import @vibe/core
+// { Default }` and `impl Default for TheirType`.
+export ./default.vibe {
+  trait Default
+}

--- a/lib/@vibe/core/index.vpkg
+++ b/lib/@vibe/core/index.vpkg
@@ -77,6 +77,13 @@ type MutSortedSet[T]
 // --- map (the [K: Hash] generic-key family; see header comment)
 opaque type Hash
 
+// --- default (#1847): method-bearing `trait Default { default() -> Self }`,
+// declared and discharged exactly like Hash above (`defaults.vibe`'s
+// `export ./default.vibe { trait Default }` re-export). Primitive impls
+// (Int/Float/Double/Bool/String) live in default.vibe; `derive(Default)`
+// registers the impl for user structs/enums.
+opaque type Default
+
 fn map_key_to_string[K: Hash](key: K) -> String
 fn get_by[K: Hash, V](m: Map[String, V], key: K) -> Option[V]
 fn has_by[K: Hash, V](m: Map[String, V], key: K) -> Bool

--- a/lib/@vibe/prelude/builtin_traits.vibe
+++ b/lib/@vibe/prelude/builtin_traits.vibe
@@ -16,6 +16,13 @@ export trait Div
 
 export trait Signed
 
+// Marker registration for `[T: Default]` bounds (#1847), mirroring `Hash`:
+// the method-bearing declaration (`trait Default { default() -> Self }`) and
+// the primitive impl bodies live in @vibe/core's default.vibe, so `T::default()`
+// dispatch needs that import; this marker + impls make the BOUND satisfiable
+// for primitives everywhere, same split as Hash's marker here vs. map.vibe.
+export trait Default
+
 // `to_string` carries this source-level bound; its runtime lowering remains
 // unchanged, but full import-path bound enforcement needs real witnesses.
 export trait Show
@@ -95,6 +102,16 @@ impl Signed for Int
 impl Signed for Float
 
 impl Signed for Double
+
+impl Default for Int
+
+impl Default for Float
+
+impl Default for Double
+
+impl Default for Bool
+
+impl Default for String
 
 //# Functions
 
@@ -181,5 +198,9 @@ export fn ord_between[T: Ord + Eq](x: T, min_val: T, max_val: T) -> Bool {
 }
 
 export fn hash_require[T: Hash](x: T) -> T {
+  x
+}
+
+export fn default_require[T: Default](x: T) -> T {
   x
 }

--- a/lib/@vibe/prelude/builtin_traits_test.vibe
+++ b/lib/@vibe/prelude/builtin_traits_test.vibe
@@ -2,6 +2,7 @@
 
 import ./builtin_traits.vibe {
   Add,
+  Default,
   Div,
   Eq,
   Hash,
@@ -10,6 +11,7 @@ import ./builtin_traits.vibe {
   Signed,
   Sub,
   cmp_eq,
+  default_require,
   hash_require,
   num_abs,
   num_add,
@@ -65,4 +67,9 @@ test "to_string generic" {
 test "hash trait bound generic" {
   assert(eq(hash_require(42), 42))
   assert(hash_require("ok") == "ok")
+}
+
+test "default trait bound generic" {
+  assert(eq(default_require(42), 42))
+  assert(default_require("ok") == "ok")
 }

--- a/lib/@vibe/prelude/index.vpkg
+++ b/lib/@vibe/prelude/index.vpkg
@@ -41,7 +41,7 @@ generated_hash =
 // IS declared below (`let eq: (Float, Float) -> Bool`), so that fixture
 // still resolves `eq` through the new contract-enforced surface.
 //
-// Trait declarations (Eq/Add/Div/Mul/Ord/Sub/Hash/Signed, all from
+// Trait declarations (Eq/Add/Div/Mul/Ord/Sub/Hash/Signed/Default, all from
 // `builtin_traits.vibe`): a bodyless `opaque type Name` is satisfied at
 // contract-conformance time purely by NAME, via the same re-export trust
 // boundary #847 already gives any `export ./impl.vibe { name }` line
@@ -52,12 +52,12 @@ generated_hash =
 // `lib/@vibe/core/index.vpkg` already established the pattern for `Hash`
 // (`opaque type Hash`, satisfied by `maps.vibe`'s `export ./r#map.vibe {
 // ..., trait Hash }` re-export) with the same reasoning spelled out in its
-// own header comment. This package is simply the first to need EIGHT of
-// them at once. `prelude.vibe` (renamed from the old `index.vibe` facade —
+// own header comment. This package is simply the first to need this many
+// of them at once. `prelude.vibe` (renamed from the old `index.vibe` facade —
 // a directory may have exactly one of `index.vibe`/`index.vibei`/
 // `index.vpkg`, #729/#897 — content otherwise unchanged) keeps the
 // `export ./builtin_traits.vibe { Eq, Add, Div, Mul, Ord, Sub, Hash,
-// Signed, ... }` line that discharges these eight declarations.
+// Signed, Default, ... }` line that discharges these declarations.
 //
 // Builtin-intrinsic method declarations (`Int::to_double`, `String::
 // utf8_length`, `String::utf16_length`, `String::unicode_length`): these
@@ -126,7 +126,7 @@ generated_hash =
 // `iterator.vibe`'s `Iterable[T]`, `lazy_iter.vibe`'s `Iterator[T]`, and
 // `async_iter.vibe`'s `AsyncIterator[T]` are method-bearing traits used only
 // as generic bounds / impl targets WITHIN this package and never
-// re-exported by any `export ./impl.vibe { ... }` line — unlike the eight
+// re-exported by any `export ./impl.vibe { ... }` line — unlike the
 // `builtin_traits.vibe` traits, they never appear in `collect_reexported_
 // names`, so (being invisible to `collect_impl_type_defs` like every trait)
 // they need no contract declaration at all and are simply absent below.
@@ -151,6 +151,7 @@ opaque type Ord
 opaque type Sub
 opaque type Hash
 opaque type Signed
+opaque type Default
 
 type Byte
 type ParseResult[T]
@@ -177,6 +178,7 @@ fn to_string[T: Show](x: T) -> String
 fn num_square[T: Mul](x: T) -> T
 fn ord_between[T: Ord + Eq](x: T, min_val: T, max_val: T) -> Bool
 fn hash_require[T: Hash](x: T) -> T
+fn default_require[T: Default](x: T) -> T
 
 // --- int
 fn pow(base: Int, exp: Int) -> Int

--- a/lib/@vibe/prelude/prelude.vibe
+++ b/lib/@vibe/prelude/prelude.vibe
@@ -2,6 +2,7 @@
 
 export ./builtin_traits.vibe {
   Add,
+  Default,
   Div,
   Eq,
   Hash,
@@ -11,6 +12,7 @@ export ./builtin_traits.vibe {
   Sub,
   cmp_eq,
   cmp_ne,
+  default_require,
   hash_require,
   num_abs,
   num_add,


### PR DESCRIPTION
## 概要

#1847 (generic `Array[T]` の確保手段が無い) に対し、ビルトインの `Default` trait を実装する。既存の `Hash` の二層構成をそのまま踏襲:

- **`lib/@vibe/core/default.vibe`** — method-bearing `trait Default { default() -> Self }` + primitive impl (Int/Float/Double/Bool/String)。`[T: Default]` generic の中の `T::default()` は Hash と同じ witness dictionary (#684) でディスパッチされる。`defaults.vibe` の re-export facade が contract の `opaque type Default` を放電する (maps.vibe の Hash と同型)
- **`lib/@vibe/prelude/builtin_traits.vibe`** — marker `trait Default` + primitive impls。core を import しなくても `[T: Default]` bound が満たせる。`hash_require` と対になる `default_require` も追加
- **`checker_stmt.vibe`** — `derive(Default)` が struct / enum 両方で `EnvTraitImpl("Default", …)` を**追加登録** (Hash の #694 と同じ形)。従来は `T::default` のシグネチャしか bind されず、derive した型を `[T: Default]` に渡すと `no impl Default for T` になっていた (committed seed で実測)

これで generic なコレクションが「今 push した値で空きを埋める」(@vibex/pqueue / @vibex/deque の filler 方式、要素の生存期間が伸びる) 代わりに `T::default()` で slot を埋め/空けられるようになる。pqueue/deque/hashmap 側の移行は follow-up。

## 検証

- committed seed で core + prelude テスト一式 48 files / 451 tests green (新規 `default_test.vibe` / `builtin_traits_test.vibe` 追加分込み)
- 新 fixture `fixtures/derive_default_bound_test.vibe` は **seed では `no impl Default for Point` で拒否され、修正入り stage2 では pass** — checker 修正が load-bearing であることを両方向で確認
- 修正入り compiler source で seed → stage1 → stage2 selfbuild 成功 (新規 core ファイルは `compiler_sources_manifest.tsv` に登録済み)
- stage2 で `fixtures/derive_*_test.vibe` 全 7 件 green
- 触った `.vibe` / `.vpkg` は `scripts/vibe_fmt.sh --check` clean

## 既知の境界 (docs/cheatsheet.md に明記)

呼び出し側で `T` の具象型が構文的に決まらない形 (`fn make[T: Default]() -> T` を注釈だけで呼ぶ等) は witness が組めず、codegen で `internal compiler error: T::default … reached code generation unresolved` になる。これは zero-arg trait method 全般の既存の穴 (dict-passing first slice の制約) で、`T` 型引数か `Array[T]` 引数 (#1199 の array-element receiver) を witness carrier にすれば動く。診断の改善は別 issue にするのが良さそう。

Closes には**しない** — #1847 の本題 (backing store 表現の一本化と collection 移行) は残るため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsB6tvKetLxFH97UrHCJNt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsB6tvKetLxFH97UrHCJNt)_