### PR TITLE
probe(async): body を実際に読むゲスト — adapter の import は `async func` でなければならない (#1540)

### DIFF
--- a/scripts/test_http_body_read_probe_gate.sh
+++ b/scripts/test_http_body_read_probe_gate.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #1540 scope 1 gate: does a guest that actually READS the request body work,
+# end to end, over real HTTP?
+#
+# test_http_body_stream_probe_gate.sh answers the composition question with a
+# guest that ignores the stream and answers a constant. This one asserts the
+# stronger property that scope 4 has to be built on: the bytes POSTed by curl
+# come back in the response, having been pulled out of the stream by the guest
+# one `stream.read` at a time.
+#
+# tools/wasip3_component_probe/http_body_read/guest.wat carries the rationale
+# and the two measurements this gate keeps true:
+#
+#   1. the adapter's import must be spelled `async func` in WIT -- reading the
+#      body blocks, so the handler has to be async-lifted, and `canon lift ...
+#      async` validates only against an async functype;
+#   2. the stream parameter arrives as ONE i32 handle after the strings'
+#      (ptr, len) pairs, and the core function returns nothing.
+#
+# The response body is the request body, so a passing run cannot be satisfied
+# by a constant: the assertion is on a per-process token that only THIS
+# invocation POSTs.
+#
+# Skips cleanly when cargo / wasm-tools / wac / wasmtime / curl are missing, and
+# fails instead under VIBE_P3_GATE_REQUIRE_TOOLS=1, matching the other P3 probes.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PROBE_DIR="$PROJECT_ROOT/tools/wasip3_component_probe/http_body_read"
+OUT_DIR="$PROJECT_ROOT/_build/bench/http_body_read_probe/run-$$"
+SERVE_LOG="$OUT_DIR/serve.log"
+# Per-process port and body token, for the same reason as the sibling probe: a
+# different server already listening cannot satisfy the assertion or be killed
+# by cleanup.
+PORT=$((20000 + ($$ % 20000)))
+ADDR="${VIBE_HTTP_BODY_READ_PROBE_ADDR:-127.0.0.1:$PORT}"
+BODY_TOKEN="vibe-body-$(printf '%05d' $(( $$ % 100000 )))"
+
+if [ -n "${VIBE_HTTP_GATE_WASMTIME_FLAGS:-}" ]; then
+  read -r -a WASM_FLAGS <<<"$VIBE_HTTP_GATE_WASMTIME_FLAGS"
+else
+  WASM_FLAGS=(-Sp3 -Shttp -W exceptions=y -W concurrency-support=y -W component-model-async=y -W component-model-async-stackful=y)
+fi
+
+missing_tool() {
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "[body-read-probe] FAILED: $1 not found (required mode)" >&2; exit 1
+  fi
+  echo "[body-read-probe] SKIP: $1 not found"; exit 0
+}
+for c in cargo wasm-tools wac curl; do
+  command -v "$c" >/dev/null 2>&1 || missing_tool "$c"
+done
+WASMTIME_BIN="$("$PROJECT_ROOT/scripts/wasmtime_bin.sh" 2>/dev/null || command -v wasmtime || true)"
+if [ -z "${WASMTIME_BIN:-}" ] || ! "$WASMTIME_BIN" --version >/dev/null 2>&1; then
+  missing_tool "wasmtime"
+fi
+
+WIT_PATH="$PROJECT_ROOT/lib/@vibe/wasi/wit/p3"
+if [ ! -f "$WIT_PATH/world.wit" ]; then
+  WIT_PATH="$PROJECT_ROOT/deps/wasmtime/crates/wasi-http/src/p3/wit"
+fi
+[ -f "$WIT_PATH/world.wit" ] || missing_tool "wasi:http p3 WIT"
+
+rm -rf "$OUT_DIR"; mkdir -p "$OUT_DIR"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe_body_read_adapter.XXXXXX")"
+SERVE_PID=""
+cleanup() {
+  if [ -n "$SERVE_PID" ]; then
+    kill "$SERVE_PID" 2>/dev/null || true
+    wait "$SERVE_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+mkdir -p "$TMP_DIR/src"
+
+cat >"$TMP_DIR/Cargo.toml" <<'EOF'
+[package]
+name = "vibe_body_read_probe_adapter"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = { version = "0.54.0", default-features = false, features = ["macros", "realloc", "bitflags", "async", "async-spawn"] }
+EOF
+
+# The one line that differs from the sibling adapter -- and the measurement
+# this gate exists to keep: `async func`, not `func`. With a plain `func` the
+# import's functype is async_: false and the guest's `canon lift ... async` is
+# rejected against it, so a guest that has to suspend to read the body cannot
+# be plugged in at all.
+cat >"$TMP_DIR/src/lib.rs" <<EOF
+wit_bindgen::generate!({
+    inline: r#"
+      package vibe:body-read-probe;
+
+      world adapter {
+        import handler: async func(method: string, url: string, headers: string, body: stream<u8>) -> string;
+        include wasi:http/service@0.3.0;
+      }
+    "#,
+    path: "$WIT_PATH",
+    world: "vibe:body-read-probe/adapter",
+    pub_export_macro: true,
+    generate_all,
+});
+
+use exports::wasi::http::handler::Guest;
+use wasi::http::types::{ErrorCode, Fields, Request, Response};
+
+struct Component;
+
+impl Guest for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        let url = request.get_path_with_query().unwrap_or_else(|| "/".to_string());
+        let (_, result_rx) = wit_future::new::<Result<(), ErrorCode>>(|| Ok(()));
+        // Still no .collect().await: the reader goes straight to the guest,
+        // which is now the thing that drains it.
+        let (req_body_rx, _trailers_rx) = Request::consume_body(request, result_rx);
+        // An async import's string params are OWNED (String, not &str).
+        let raw = handler("POST".to_string(), url, String::new(), req_body_rx).await;
+
+        let fields = Fields::new();
+        let (mut body_tx, body_rx) = wit_stream::new();
+        let (body_result_tx, body_result_rx) = wit_future::new(|| Ok(None));
+        let (resp, _transmit) = Response::new(fields, Some(body_rx), body_result_rx);
+        resp.set_status_code(200).map_err(|_| ErrorCode::InternalError(None))?;
+        drop(body_result_tx);
+        wit_bindgen::spawn(async move {
+            let remaining = body_tx.write_all(raw.into_bytes()).await;
+            assert!(remaining.is_empty());
+        });
+        Ok(resp)
+    }
+}
+
+export!(Component);
+EOF
+
+echo "[body-read-probe] building the async-import adapter"
+(cd "$TMP_DIR" && cargo build --target wasm32-unknown-unknown --release >/dev/null 2>&1) || {
+  echo "[body-read-probe] FAILED: adapter did not build -- wit-bindgen no longer accepts an \`async func\` import with a stream<u8> param?" >&2
+  (cd "$TMP_DIR" && cargo build --target wasm32-unknown-unknown --release 2>&1 | tail -20) >&2
+  exit 1
+}
+
+ADAPTER="$OUT_DIR/adapter.component.wasm"
+wasm-tools component new \
+  "$TMP_DIR/target/wasm32-unknown-unknown/release/vibe_body_read_probe_adapter.wasm" \
+  -o "$ADAPTER"
+wasm-tools validate --features all "$ADAPTER"
+# Both checks match against a CAPTURED string with `case`, no pipeline at all.
+# `something | grep -q` is wrong here twice over: grep exits on its first match,
+# the writer gets SIGPIPE, and `set -o pipefail` reports that as a failed check
+# -- indistinguishable from the assertion actually not holding. The first cut of
+# this gate did exactly that and blamed the adapter for a bug in its own plumbing.
+ADAPTER_WIT="$(wasm-tools component wit "$ADAPTER")"
+case "$ADAPTER_WIT" in
+  *'import handler: async func('*) ;;
+  *)
+    echo "[body-read-probe] FAILED: the adapter's handler import is not an \`async func\`" >&2
+    printf '%s\n' "$ADAPTER_WIT" | head -20 >&2
+    exit 1 ;;
+esac
+# The decoded WIT says `async func`; this says the FUNCTYPE carries the async
+# flag, which is what `canon lift ... async` is actually checked against.
+ADAPTER_DUMP="$(wasm-tools dump "$ADAPTER" 2>/dev/null || true)"
+case "$ADAPTER_DUMP" in
+  *'ComponentFuncType { async_: true, params: [("method", Primitive(String))'*) ;;
+  *)
+    echo "[body-read-probe] FAILED: the handler import's functype is not marked async" >&2
+    exit 1 ;;
+esac
+echo "[body-read-probe] adapter imports handler as an async func with a stream<u8> body"
+
+GUEST="$OUT_DIR/guest.wasm"
+wasm-tools parse "$PROBE_DIR/guest.wat" -o "$GUEST"
+wasm-tools validate --features all "$GUEST"
+echo "[body-read-probe] probe guest validates"
+
+COMPOSED="$OUT_DIR/composed.wasm"
+wac plug --plug "$GUEST" "$ADAPTER" -o "$COMPOSED"
+wasm-tools validate --features all "$COMPOSED"
+
+# `wac plug` leaves an unsatisfiable edge as a promoted ROOT IMPORT rather than
+# an error (../http_body_stream/README.md), so assert the composed world, not
+# the exit code.
+COMPOSED_WIT="$(wasm-tools component wit "$COMPOSED")"
+ROOT_IMPORTS="$(printf '%s\n' "$COMPOSED_WIT" | awk '
+  /^world root \{$/ { in_world = 1; next }
+  in_world && /^}/ { exit }
+  in_world && /^[[:space:]]+import / {
+    sub(/^[[:space:]]+/, "")
+    print
+  }
+')"
+if [ "$ROOT_IMPORTS" != 'import wasi:http/types@0.3.0;' ]; then
+  echo "[body-read-probe] FAILED: composed root imports are not exactly the host-provided wasi:http/types edge" >&2
+  printf '%s\n' "$COMPOSED_WIT" | head -20 >&2
+  exit 1
+fi
+echo "[body-read-probe] composed: async handler edge connected; only host wasi:http/types remains"
+
+"$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$COMPOSED" >"$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+ready=0
+for _ in $(seq 1 40); do
+  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+    echo "[body-read-probe] FAILED: spawned wasmtime exited before accepting requests" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if curl -s -m 1 -o /dev/null "http://$ADDR/" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [ "$ready" != "1" ]; then
+  echo "[body-read-probe] FAILED: spawned wasmtime did not become ready at $ADDR" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+
+RESPONSE_FILE="$TMP_DIR/response.txt"
+CODE="$(curl -sS --max-time 10 -o "$RESPONSE_FILE" -w '%{http_code}' \
+  -X POST --data-binary "$BODY_TOKEN" "http://$ADDR/probe" 2>&1 || true)"
+OUT="$(cat "$RESPONSE_FILE" 2>/dev/null || true)"
+if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+  echo "[body-read-probe] FAILED: spawned wasmtime exited while serving the probe request" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+kill "$SERVE_PID" 2>/dev/null || true
+wait "$SERVE_PID" 2>/dev/null || true
+SERVE_PID=""
+
+if [ "$CODE" != "200" ]; then
+  echo "[body-read-probe] FAILED: POST with a body returned '$CODE' (want 200)" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+# The guest returns its diagnostics as strings so a failure names the broken
+# assumption instead of just missing the token.
+case "$OUT" in
+  *ERR-EVENT*)
+    echo "[body-read-probe] FAILED: waitable-set.wait returned a non-STREAM_READ event" >&2; exit 1 ;;
+  *ERR-STATUS*)
+    echo "[body-read-probe] FAILED: a zero-transfer read reported a code other than the measured CLOSED=1" >&2; exit 1 ;;
+  *ERR-OVERRUN*)
+    echo "[body-read-probe] FAILED: the guest read 64 bytes without seeing end-of-stream" >&2; exit 1 ;;
+esac
+if ! printf '%s' "$OUT" | grep -qF "$BODY_TOKEN"; then
+  echo "[body-read-probe] FAILED: response body was '$OUT' (want the POSTed '$BODY_TOKEN')" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+
+echo "[body-read-probe] POST body came back through the guest's stream.read loop"
+echo "[body-read-probe] PASS: a guest can READ the wasi:http request body from its stream<u8> parameter (#1540)"

--- a/scripts/test_http_body_read_probe_gate.sh
+++ b/scripts/test_http_body_read_probe_gate.sh
@@ -228,39 +228,72 @@ if [ "$ready" != "1" ]; then
   exit 1
 fi
 
-RESPONSE_FILE="$TMP_DIR/response.txt"
-CODE="$(curl -sS --max-time 10 -o "$RESPONSE_FILE" -w '%{http_code}' \
-  -X POST --data-binary "$BODY_TOKEN" "http://$ADDR/probe" 2>&1 || true)"
-OUT="$(cat "$RESPONSE_FILE" 2>/dev/null || true)"
-if ! kill -0 "$SERVE_PID" 2>/dev/null; then
-  echo "[body-read-probe] FAILED: spawned wasmtime exited while serving the probe request" >&2
-  cat "$SERVE_LOG" >&2 || true
+# The guest's answer is fully determined -- "200\n\n" followed by exactly the
+# bytes it read -- so assert the WHOLE response, not that the token appears
+# somewhere in it. A reader that duplicated, dropped or padded bytes around an
+# intact token would satisfy a substring check while having corrupted the body,
+# and this gate exists to say the body round-tripped.
+post_and_check() {
+  local what="$1" body="$2" response_file="$TMP_DIR/response-$1.txt" code out want
+  code="$(curl -sS --max-time 10 -o "$response_file" -w '%{http_code}' \
+    -X POST --data-binary "$body" "http://$ADDR/probe" 2>&1 || true)"
+  out="$(cat "$response_file" 2>/dev/null || true)"
+  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+    echo "[body-read-probe] FAILED: spawned wasmtime exited while serving the $what request" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if [ "$code" != "200" ]; then
+    echo "[body-read-probe] FAILED: $what POST returned '$code' (want 200)" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  # The guest returns its diagnostics as strings so a failure names the broken
+  # assumption instead of only reporting a mismatch.
+  case "$out" in
+    *ERR-EVENT*)
+      echo "[body-read-probe] FAILED: waitable-set.wait returned a non-STREAM_READ event" >&2; exit 1 ;;
+    *ERR-STATUS*)
+      echo "[body-read-probe] FAILED: a zero-transfer read reported a code other than the measured CLOSED=1" >&2; exit 1 ;;
+    *ERR-OVERRUN*)
+      echo "[body-read-probe] FAILED: $what body overran the probe guest's 64-byte buffer" >&2; exit 1 ;;
+  esac
+  # Compare the FILES, not shell strings. Command substitution drops NUL bytes
+  # and trailing newlines, so a guest that returned one byte too many -- the
+  # unwritten slot just past what it read -- compared EQUAL as a string while
+  # the response was a byte longer than it should be. `cmp` sees it.
+  want="$TMP_DIR/want-$what.txt"
+  printf '200\n\n%s' "$body" >"$want"
+  if ! cmp -s "$response_file" "$want"; then
+    echo "[body-read-probe] FAILED: $what response is not exactly '200\\n\\n' + the POSTed body" >&2
+    echo "[body-read-probe]   got  ($(wc -c <"$response_file") bytes): $(od -c "$response_file" | head -4)" >&2
+    echo "[body-read-probe]   want ($(wc -c <"$want") bytes): $(od -c "$want" | head -4)" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+}
+
+post_and_check "token" "$BODY_TOKEN"
+echo "[body-read-probe] POST body came back byte for byte through the guest's stream.read loop"
+
+# Exactly the buffer's capacity, which is the interesting boundary and not a
+# round number chosen for symmetry: whether it fits depends on WHERE the end of
+# the stream is reported. A producer that closes inline with the final byte ends
+# the loop at `total` = 64; a buffered one reports the end as a separate
+# zero-transfer read, which only happens if the loop is still allowed to run at
+# `total` = 64. Asserting the exact echo here pins the guard at `> 64` rather
+# than `>= 64`, so the advertised capacity cannot quietly become 63 the next
+# time the runtime's buffering changes.
+BODY_64="$BODY_TOKEN$(printf 'y%.0s' $(seq 1 $((64 - ${#BODY_TOKEN}))))"
+if [ "${#BODY_64}" != "64" ]; then
+  echo "[body-read-probe] FAILED: the boundary body is ${#BODY_64} bytes, not 64" >&2
   exit 1
 fi
+post_and_check "64-byte" "$BODY_64"
+echo "[body-read-probe] a body of exactly the guest's 64-byte capacity round-trips too"
+
 kill "$SERVE_PID" 2>/dev/null || true
 wait "$SERVE_PID" 2>/dev/null || true
 SERVE_PID=""
 
-if [ "$CODE" != "200" ]; then
-  echo "[body-read-probe] FAILED: POST with a body returned '$CODE' (want 200)" >&2
-  cat "$SERVE_LOG" >&2 || true
-  exit 1
-fi
-# The guest returns its diagnostics as strings so a failure names the broken
-# assumption instead of just missing the token.
-case "$OUT" in
-  *ERR-EVENT*)
-    echo "[body-read-probe] FAILED: waitable-set.wait returned a non-STREAM_READ event" >&2; exit 1 ;;
-  *ERR-STATUS*)
-    echo "[body-read-probe] FAILED: a zero-transfer read reported a code other than the measured CLOSED=1" >&2; exit 1 ;;
-  *ERR-OVERRUN*)
-    echo "[body-read-probe] FAILED: the guest read 64 bytes without seeing end-of-stream" >&2; exit 1 ;;
-esac
-if ! printf '%s' "$OUT" | grep -qF "$BODY_TOKEN"; then
-  echo "[body-read-probe] FAILED: response body was '$OUT' (want the POSTed '$BODY_TOKEN')" >&2
-  cat "$SERVE_LOG" >&2 || true
-  exit 1
-fi
-
-echo "[body-read-probe] POST body came back through the guest's stream.read loop"
 echo "[body-read-probe] PASS: a guest can READ the wasi:http request body from its stream<u8> parameter (#1540)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -75,6 +75,7 @@ case ",$PHASES," in *",http,"*)
   echo "[p3-guarantee] phase B: wasi:http p3 world"
   bash "$SCRIPT_DIR/test_wasi_http_p3_full_gate.sh"
   bash "$SCRIPT_DIR/test_http_body_stream_probe_gate.sh"
+  bash "$SCRIPT_DIR/test_http_body_read_probe_gate.sh"
   bash "$SCRIPT_DIR/test_async_string_lift_probe_gate.sh"
   ;;
 esac

--- a/tools/wasip3_component_probe/http_body_read/README.md
+++ b/tools/wasip3_component_probe/http_body_read/README.md
@@ -71,7 +71,23 @@ The guest reads at most 64 bytes and answers `ERR-OVERRUN` past that. It is a
 probe: the point is that the bytes arrive through `stream.read`, not that this
 guest is a general reader. Diagnostics come back as recognisable strings
 (`ERR-EVENT`, `ERR-STATUS`, `ERR-OVERRUN`) so a failing gate names the broken
-assumption instead of only reporting a missing token.
+assumption instead of only reporting a mismatch.
+
+"At most 64" is exact, and the gate POSTs a 64-byte body to keep it that way.
+The boundary is not cosmetic: whether a 64-byte body fits depends on **where**
+the end of the stream is reported. A producer that closes inline with its final
+byte ends the loop at `total` = 64, but the buffered producer `host_stream_value`
+measured reports the end as a separate zero-transfer read — which only happens
+if the loop is still allowed to run at `total` = 64. Guarding with `>= 64`
+instead of `> 64` makes the real capacity 63, and only under one of the two
+producer shapes.
+
+The gate compares the whole response against `"200\n\n"` + the POSTed body, as
+**files** rather than shell strings. A substring check for a token would accept
+a reader that duplicated or padded bytes around it, and command substitution
+drops NUL bytes and trailing newlines — a guest returning one byte too many
+(the unwritten slot just past what it read) compared equal as a string and was
+caught only by `cmp`.
 
 ## Still open for #1540 scope 3/4
 

--- a/tools/wasip3_component_probe/http_body_read/README.md
+++ b/tools/wasip3_component_probe/http_body_read/README.md
@@ -1,0 +1,82 @@
+# #1540 probe: what does a guest have to do to READ the body?
+
+`../http_body_stream` established that a `wasi:http` request body can reach the
+guest as a `stream<u8>` **parameter**, and its README closes by naming what it
+does not answer: its guest ignores the stream and returns a constant, so
+"reading it needs `stream.read` plus an async lift" stayed open.
+
+This probe closes that. `guest.wat` drains the body stream one `stream.read` at
+a time and returns what it read, and `scripts/test_http_body_read_probe_gate.sh`
+POSTs a per-process token over real HTTP and asserts that token comes back. A
+constant cannot pass it.
+
+## Result 1: the adapter's import must be spelled `async func`
+
+Not a style choice — a requirement that falls out of reading the body.
+
+Reading blocks, so the handler has to be async-lifted; `canon lift ... async`
+validates only against an async functype (`../async_string_lift`); and the
+functype in question is the one the **adapter** declares for its import. With
+the sibling probe's spelling:
+
+```wit
+import handler: func(method: string, url: string, headers: string, body: stream<u8>) -> string;
+```
+
+the import's functype is `async_: false`, and no async-lifted guest can plug
+into it. With `async func`:
+
+```wit
+import handler: async func(method: string, url: string, headers: string, body: stream<u8>) -> string;
+```
+
+it is `async_: true`. Measured on wit-bindgen 0.54: the spelling is accepted,
+and the generated import is awaitable with **owned** string params (`String`,
+not `&str`).
+
+So the eventual serve adapter has to declare the handler import async, and that
+is decided by whether the handler can suspend — which, for anything that reads
+a body, it can.
+
+## Result 2: the stream parameter is one i32 handle, and the result leaves through `task.return`
+
+The core function the async lift wraps takes 7 i32 — three `(ptr, len)` pairs
+for the strings, then the stream handle — and returns **nothing**:
+
+```wat
+(func (export "handler")
+  (param i32 i32 i32 i32 i32 i32 i32)   ;; method, url, headers, body handle
+  ...)
+```
+
+Compare the sibling probe's sync lift, whose core function returns an i32
+pointer to the result's `(ptr, len)` pair. Under an async lift the string comes
+back through `task.return` instead.
+
+## What this probe reuses rather than re-measures
+
+- `../host_stream_value` — `stream.read`'s status encoding (`BLOCKED` =
+  `0xffffffff`, completion packs `(amount << 4) | code`), both end-of-stream
+  shapes, and the unjoin-before-drop rule.
+- `../async_string_lift` — the canonopt set for a string-result async lift, and
+  why memory and realloc must live outside the guest instance.
+- `../http_body_stream` — the acyclic adapter/guest composition, and why the
+  two-edge shape in #1540's scope bullets is not expressible.
+
+What is new is that they hold **together** on one export.
+
+## Limits
+
+The guest reads at most 64 bytes and answers `ERR-OVERRUN` past that. It is a
+probe: the point is that the bytes arrive through `stream.read`, not that this
+guest is a general reader. Diagnostics come back as recognisable strings
+(`ERR-EVENT`, `ERR-STATUS`, `ERR-OVERRUN`) so a failing gate names the broken
+assumption instead of only reporting a missing token.
+
+## Still open for #1540 scope 3/4
+
+The guest here is hand-written WAT. Emitting it from vibe source needs a way to
+**spell** a `HostStream`-typed handler parameter (#1341 made `host_stream_named`
+return the nominal `HostStream` rather than `Stream[Int]`), and
+`validate_serve_handler` currently requires exactly four `String` params and
+rejects every non-`Exception` effect.

--- a/tools/wasip3_component_probe/http_body_read/guest.wat
+++ b/tools/wasip3_component_probe/http_body_read/guest.wat
@@ -72,7 +72,8 @@
     (import "env" "memory" (memory 1))
 
     ;; Written into the IMPORTED (memhost) memory at instantiation.
-    ;;   64  "200\n\n" + up to 64 body bytes read from the stream
+    ;;   64  "200\n\n" + up to 64 body bytes read from the stream, plus one
+    ;;       slot past them (133) that only ever holds an OVERRUN byte
     ;;  300  diagnostics, each already carrying the status/header prefix
     ;;  512  waitable-set.wait payload[0] / [1]
     ;; The memhost's realloc bump starts at 1024, above all of these, so the
@@ -98,7 +99,16 @@
         (loop $again
           ;; One byte at a time: the shape a byte-oriented reader needs, and
           ;; the worst case for status handling.
-          (if (i32.ge_u (local.get $total) (i32.const 64))
+          ;;
+          ;; `> 64`, not `>= 64`: a 64-byte body whose end arrives as a
+          ;; SEPARATE zero-transfer completion (the buffered-producer shape
+          ;; ../host_stream_value measured) still has one read to go when
+          ;; `total` reaches 64. Erroring before it would make the documented
+          ;; 64-byte capacity actually 63, and only when the producer happens
+          ;; not to close inline -- a limit that moves with the runtime's
+          ;; buffering. The 65th byte lands at 133 and is never returned:
+          ;; reaching this branch means the body was too big for the probe.
+          (if (i32.gt_u (local.get $total) (i32.const 64))
             (then
               (call $task_return (i32.const 340) (i32.const 16))
               (return)

--- a/tools/wasip3_component_probe/http_body_read/guest.wat
+++ b/tools/wasip3_component_probe/http_body_read/guest.wat
@@ -1,0 +1,189 @@
+;; #1540 scope 1, completed: a guest that actually READS the request body.
+;;
+;; ../http_body_stream established that the body can REACH the guest as a
+;; `stream<u8>` parameter, but its guest ignores the stream and answers a
+;; constant -- it answers the composition question only, and its own README
+;; says so. This probe answers the remaining one: what a guest has to do to
+;; read that stream, and what the component has to look like around it.
+;;
+;; The pieces are individually measured elsewhere; what is new here is that
+;; they have to hold TOGETHER on one export:
+;;
+;;   ../host_stream_value      stream.read's status encoding and the two
+;;                             end-of-stream shapes
+;;   ../async_string_lift      the canonopt set for an async lift whose
+;;                             result is a string, and why memory + realloc
+;;                             must live outside the guest instance
+;;   ../http_body_stream       the acyclic adapter/guest composition
+;;
+;; MEASURED HERE (wasmtime 47.0.2 / wasm-tools 1.255.0 / wit-bindgen 0.54):
+;;
+;;   1. The adapter's import must be spelled `async func` in WIT.
+;;      `import handler: func(..) -> string` produces a functype with
+;;      async_: false, and `canon lift ... async` is rejected against it
+;;      ("the `async` canonical option requires an async function type").
+;;      Reading the body BLOCKS, so the handler MUST be async-lifted -- which
+;;      makes `async func` a requirement on the adapter side, not a choice.
+;;      wit-bindgen 0.54 accepts it and generates an awaitable import whose
+;;      string params are OWNED (`String`, not `&str`).
+;;
+;;   2. The stream parameter arrives as one i32 handle, after the three
+;;      strings' (ptr, len) pairs: the core function takes 7 i32 and returns
+;;      NOTHING, since an async lift's result leaves through task.return.
+;;
+;; Diagnostics are returned as recognisable STRINGS rather than numbers: the
+;; result of this export is a string, and a gate that greps the HTTP response
+;; can then say which assumption broke instead of just "did not match".
+(component
+  ;; memory + realloc OUTSIDE the guest instance. `task.return` needs a
+  ;; memory and the async lift needs both, and both canons are declared
+  ;; before the guest instance exists -- the guest imports `[task-return]`,
+  ;; so a guest-owned memory would be an instantiation cycle.
+  (core module $memhost
+    (memory (export "memory") 1)
+    (global $bump (mut i32) (i32.const 1024))
+    (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32)
+      (local $p i32)
+      (local.set $p (global.get $bump))
+      (global.set $bump (i32.add (global.get $bump) (i32.const 256)))
+      (local.get $p))
+  )
+  (core instance $mh (instantiate $memhost))
+  (alias core export $mh "memory" (core memory $mem))
+  (alias core export $mh "cabi_realloc" (core func $realloc))
+
+  (type $sty (stream u8))
+  (core func $sread (canon stream.read $sty async (memory $mem)))
+  (core func $sdrop_r (canon stream.drop-readable $sty))
+  (core func $ws_new (canon waitable-set.new))
+  (core func $waitable_join (canon waitable.join))
+  (core func $ws_wait (canon waitable-set.wait (memory $mem)))
+  (core func $ws_drop (canon waitable-set.drop))
+  (core func $tr (canon task.return (result string) (memory $mem) string-encoding=utf8))
+
+  (core module $m
+    (import "$root" "[async-lower][stream-read-0]body" (func $sread (param i32 i32 i32) (result i32)))
+    (import "$root" "[stream-drop-readable-0]body" (func $sdrop_r (param i32)))
+    (import "$root" "[waitable-set-new]" (func $ws_new (result i32)))
+    (import "$root" "[waitable-join]" (func $waitable_join (param i32 i32)))
+    (import "$root" "[waitable-set-wait]" (func $ws_wait (param i32 i32) (result i32)))
+    (import "$root" "[waitable-set-drop]" (func $ws_drop (param i32)))
+    (import "[export]$root" "[task-return]handler" (func $task_return (param i32 i32)))
+    (import "env" "memory" (memory 1))
+
+    ;; Written into the IMPORTED (memhost) memory at instantiation.
+    ;;   64  "200\n\n" + up to 64 body bytes read from the stream
+    ;;  300  diagnostics, each already carrying the status/header prefix
+    ;;  512  waitable-set.wait payload[0] / [1]
+    ;; The memhost's realloc bump starts at 1024, above all of these, so the
+    ;; three string params it lowers cannot land on them.
+    (data (i32.const 64) "200\0a\0a")
+    (data (i32.const 300) "200\0a\0aERR-EVENT")
+    (data (i32.const 320) "200\0a\0aERR-STATUS")
+    (data (i32.const 340) "200\0a\0aERR-OVERRUN")
+
+    ;; 3 strings flattened to (ptr, len) pairs + the stream handle. No
+    ;; result: an async lift returns through task.return.
+    (func (export "handler")
+      (param $method_p i32) (param $method_n i32)
+      (param $url_p i32) (param $url_n i32)
+      (param $headers_p i32) (param $headers_n i32)
+      (param $body i32)
+      (local $st i32)
+      (local $ws i32)
+      (local $ev i32)
+      (local $total i32)
+
+      (block $done
+        (loop $again
+          ;; One byte at a time: the shape a byte-oriented reader needs, and
+          ;; the worst case for status handling.
+          (if (i32.ge_u (local.get $total) (i32.const 64))
+            (then
+              (call $task_return (i32.const 340) (i32.const 16))
+              (return)
+            )
+          )
+          (local.set $st
+            (call $sread (local.get $body)
+              (i32.add (i32.const 69) (local.get $total))
+              (i32.const 1)))
+
+          ;; BLOCKED: park until the producer delivers. UNJOIN before
+          ;; dropping the set -- dropping a set that still has members traps
+          ;; with "resource has children" (../host_stream_value).
+          (if (i32.eq (local.get $st) (i32.const 0xffffffff))
+            (then
+              (local.set $ws (call $ws_new))
+              (call $waitable_join (local.get $body) (local.get $ws))
+              (local.set $ev (call $ws_wait (local.get $ws) (i32.const 512)))
+              (call $waitable_join (local.get $body) (i32.const 0))
+              (call $ws_drop (local.get $ws))
+              (if (i32.ne (local.get $ev) (i32.const 2))
+                (then
+                  (call $task_return (i32.const 300) (i32.const 14))
+                  (return)
+                )
+              )
+              ;; payload[1] is the completion status; payload[0] is the
+              ;; waitable index.
+              (local.set $st (i32.load (i32.const 516)))
+            )
+          )
+
+          ;; Nothing transferred = the end of the stream, reported inline by
+          ;; the read that found the writer gone (code 1). Any other
+          ;; zero-transfer code is an assumption that moved: say so loudly
+          ;; rather than answer a truncated body as if it were complete.
+          (if (i32.eqz (i32.shr_u (local.get $st) (i32.const 4)))
+            (then
+              (if (i32.ne (i32.and (local.get $st) (i32.const 0xf)) (i32.const 1))
+                (then
+                  (call $task_return (i32.const 320) (i32.const 15))
+                  (return)
+                )
+              )
+              (br $done)
+            )
+          )
+
+          (local.set $total (i32.add (local.get $total) (i32.const 1)))
+          ;; The end can also arrive INLINE with the final byte (amount 1,
+          ;; code 1), and reading again after that notification traps.
+          (br_if $done
+            (i32.eq (i32.and (local.get $st) (i32.const 0xf)) (i32.const 1)))
+          (br $again)
+        )
+      )
+
+      (call $sdrop_r (local.get $body))
+      ;; "200\n\n" + everything read: the response body IS the request body,
+      ;; so a gate can assert the bytes round-tripped rather than that some
+      ;; constant came back.
+      (call $task_return (i32.const 64) (i32.add (i32.const 5) (local.get $total)))
+    )
+  )
+
+  (core instance $gi (instantiate $m
+    (with "$root" (instance
+      (export "[async-lower][stream-read-0]body" (func $sread))
+      (export "[stream-drop-readable-0]body" (func $sdrop_r))
+      (export "[waitable-set-new]" (func $ws_new))
+      (export "[waitable-join]" (func $waitable_join))
+      (export "[waitable-set-wait]" (func $ws_wait))
+      (export "[waitable-set-drop]" (func $ws_drop))
+    ))
+    (with "[export]$root" (instance
+      (export "[task-return]handler" (func $tr))
+    ))
+    (with "env" (instance
+      (export "memory" (memory $mem))
+    ))
+  ))
+
+  (type $ft (func async
+    (param "method" string) (param "url" string) (param "headers" string)
+    (param "body" $sty) (result string)))
+  (func (export "handler") (type $ft)
+    (canon lift (core func $gi "handler") async (memory $mem) (realloc $realloc) string-encoding=utf8))
+)

--- a/tools/wasip3_component_probe/http_body_stream/README.md
+++ b/tools/wasip3_component_probe/http_body_stream/README.md
@@ -76,14 +76,19 @@ Measured, all four steps:
 `guest.wat` **ignores** the stream and returns a constant. It answers the
 composition question only.
 
-Still open, and the next thing to measure: what a guest needs in order to READ
-the body stream. That requires `stream.read` plus an async lift. The current
-emitters only cover scalar results:
-`emit_canon_lift_async_section` (`component_codegen.vibe`) emits exactly one
-canonopt (`async`), and `emit_canon_task_return` emits none. This probe does
-**not** establish the exact `memory` / `realloc` / `string-encoding` option set
-for a string-bearing async handler; a separate byte-level probe must establish
-that encoding before those emitters are generalized.
+Both follow-ups it named have since been measured, and this probe stays as the
+composition ratchet underneath them:
+
+- `../async_string_lift` established the `memory` / `realloc` /
+  `string-encoding` option set for a string-bearing async handler, byte for
+  byte. `emit_canon_lift_async_section` / `emit_canon_task_return` were
+  generalized against it, and `comp_emit_async_string_component` now emits that
+  whole component.
+- `../http_body_read` answers the reading question: a guest that drains the body
+  with `stream.read` and returns what it read. It also found the constraint this
+  probe could not see — the adapter's import has to be spelled **`async func`**,
+  since a guest that suspends must be async-lifted and `canon lift ... async`
+  validates only against an async functype.
 
 ## Consequence for #1540's scope
 


### PR DESCRIPTION
#1796 の http_body_stream probe は「body が `stream<u8>` 引数としてゲストに**届く**」ところまでを確定させたが、
そのゲストは stream を無視して定数を返す。同 README が「**読む**方は未解決」と明記している通り。
このPRがそれを閉じる: ゲストが `stream.read` で body を読み切り、読んだものを返す。
ゲートは per-process トークンを実 HTTP で POST し、**そのトークンが返ってくること**を assert する。
定数では通らない。

## 実測 1: adapter の import は `async func` でなければならない

これは書き方の好みではなく、**body を読むことから必然的に落ちてくる制約**。

body を読むと block する → handler は async lift でなければならない →
`canon lift ... async` は **async functype に対してしか** validate しない
(#1807 で実測) → そしてその functype は **adapter が宣言している**もの。

```wit
import handler: func(method: string, url: string, headers: string, body: stream<u8>) -> string;
```
→ `ComponentFuncType { async_: false, ... }`。**async lift したゲストは plug できない。**

```wit
import handler: async func(method: string, url: string, headers: string, body: stream<u8>) -> string;
```
→ `async_: true`。wit-bindgen 0.54 はこの綴りを受理し、await 可能な import を生成する
(文字列引数は `&str` ではなく**所有された `String`**)。

つまり serve adapter 側も handler import を async にする必要があり、それは
「handler が suspend しうるか」で決まる — body を読むものは常にしうる。

## 実測 2: stream 引数は i32 ハンドル 1 個、結果は `task.return` から出る

async lift が包む core 関数は **i32 を 7 個**取り、**何も返さない**:

```wat
(func (export "handler")
  (param i32 i32 i32 i32 i32 i32 i32)   ;; method, url, headers, body handle
  ...)
```

sibling の sync lift は結果の `(ptr,len)` へのポインタを i32 で返していた。
async lift では文字列は `task.return` から出る。

## 再測定していないもの（既存 probe の再利用）

| 何を | どこで測ってあるか |
|---|---|
| `stream.read` の status 符号化 / 終端 2 形態 / unjoin→drop 順序 | `host_stream_value` |
| string 結果 async lift の canonopt 集合、memory/realloc をゲスト外に置く理由 | `async_string_lift` (#1807) |
| 非循環の adapter/guest 合成 | `http_body_stream` (#1796) |

**新しいのは、これらが1つの export の上で同時に成り立つこと。**

## 診断は文字列で返す

ゲストは `ERR-EVENT` / `ERR-STATUS` / `ERR-OVERRUN` を返す。この export の結果は文字列なので、
HTTP 応答を grep するゲートが「トークンが無い」ではなく**どの仮定が壊れたか**を言える。

`total` を足さずに prefix だけ返す版で **red 確認済み**
(`response body was '200' (want the POSTed 'vibe-body-20131')`)。

## 自分で踏んだバグを1つ記録しておく

ゲートの最初の版は 1.8MB の `wasm-tools dump` を `grep -q` にパイプしていた。
grep は最初のマッチで抜け、wasm-tools が SIGPIPE を受け、`set -o pipefail` がそれを
**失敗した assertion と区別できない形**に変える — 実際 adapter は正しいのに
「async ではない」と報告した。今は両方の検査を `case` で captured 文字列に対して行う（パイプ無し）。
このリポジトリが繰り返し見つけている「黙って誤る」クラスそのもの。

## 検証

```
bash scripts/test_http_body_read_probe_gate.sh
[body-read-probe] adapter imports handler as an async func with a stream<u8> body
[body-read-probe] probe guest validates
[body-read-probe] composed: async handler edge connected; only host wasi:http/types remains
[body-read-probe] POST body came back through the guest's stream.read loop
[body-read-probe] PASS
```

p3 guarantee gate の phase B に sibling probe の隣へ配線済み。ツール不在なら clean skip、
`VIBE_P3_GATE_REQUIRE_TOOLS=1` では失敗。

## #1540 の残り

これで scope 1 (byte-level probe) が本当に閉じ、scope 2 (emitter 一般化) は #1819 で着地済み。
残るのは:

- **scope 3** — vibe source で `HostStream` 型の handler 引数を綴れるようにする
  (#1341 で `host_stream_named` は nominal `HostStream` を返すようになった)
- **scope 4** — serve 統合。`validate_serve_handler` は今 **String 4 引数固定**で、
  **非 Exception effect を一律 throw** する

このPRのゲストは手書き WAT なので、両方ともまだフロントエンド側の話。

## 関連

#1540、#1796、#1807、#1819、#1341

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_