### PR TITLE
test: #1803 P2 follow-up (unshadowed row の negative pin) + #1070 最終サブケース (store される closure) の regression pin

### DIFF
--- a/fixtures/closure_by_value_store_test.vibe
+++ b/fixtures/closure_by_value_store_test.vibe
@@ -1,0 +1,127 @@
+// #1070 final sub-case, now RESOLVED: a capturing closure passed BY VALUE
+// into a callee that STORES it (the closure outlives the callee frame).
+// Pure -- no effects, so no edp_* eligibility path is involved; this is the
+// closure-value ABI itself.
+//
+// History: 2 stored closures passed, the 3rd trapped (`unreachable` on a
+// corrupted status read under the RC lane), and inlining the store into the
+// caller made the same scenario pass -- so the trigger was exactly the
+// closure crossing a function boundary before being stored. The
+// @vibex/concurrent Nursery::spawn inline-store workaround was the live
+// canary. Verified fixed on main 92c4796 under all four of
+// {VIBE_RC=1, VIBE_RC=0} x {node runner, wasmtime}.
+
+struct PRes { mut value: Int }
+
+struct PN {
+  mut runners: Array[() -> Unit];
+  mut count: Int
+}
+
+fn p_append_runner(buf: Array[() -> Unit], count: Int, v: () -> Unit) -> Array[() -> Unit] {
+  let cap = Array::length(buf)
+  if count < cap {
+    Array::set(buf, count, v)
+    buf
+  } else {
+    let b = ArrayBuilder::new()
+    let mut i = 0
+    while i < 8 {
+      ArrayBuilder::push(b, v)
+      i = i + 1
+    }
+    let nb = ArrayBuilder::freeze(b)
+    let mut j = 0
+    while j < count {
+      Array::set(nb, j, Array::get(buf, j))
+      j = j + 1
+    }
+    nb
+  }
+}
+
+fn p_new() -> PN {
+  PN::{ runners: ArrayBuilder::freeze(ArrayBuilder::new()), count: 0 }
+}
+
+fn p_spawn(n: PN, rc: PRes, k: Int) -> Unit {
+  let runner: () -> Unit = () -> {
+    rc.value = k
+  }
+  n.runners = p_append_runner(n.runners, n.count, runner)
+  n.count = n.count + 1
+}
+
+// The stored runner ALSO captures and calls a closure parameter -- the
+// variant #1070's boundary probes listed separately.
+fn p_spawn_f(n: PN, rc: PRes, k: Int, f: () -> Int) -> Unit {
+  let runner: () -> Unit = () -> {
+    rc.value = k + f()
+  }
+  n.runners = p_append_runner(n.runners, n.count, runner)
+  n.count = n.count + 1
+}
+
+fn p_run(n: PN, i: Int) -> Unit {
+  let r = Array::get(n.runners, i)
+  r()
+}
+
+fn store_three() -> Int {
+  let n = p_new()
+  let r1 = PRes::{ value: 0 }
+  let r2 = PRes::{ value: 0 }
+  let r3 = PRes::{ value: 0 }
+  p_spawn(n, r1, 1)
+  p_spawn(n, r2, 2)
+  p_spawn(n, r3, 3)
+  p_run(n, 0)
+  p_run(n, 1)
+  p_run(n, 2)
+  r1.value * 100 + r2.value * 10 + r3.value
+}
+
+fn store_five_capture_param_reused() -> Int {
+  let n = p_new()
+  let r1 = PRes::{ value: 0 }
+  let r2 = PRes::{ value: 0 }
+  let r3 = PRes::{ value: 0 }
+  let r4 = PRes::{ value: 0 }
+  let r5 = PRes::{ value: 0 }
+  p_spawn_f(n, r1, 1, () -> Int {
+    10
+  })
+  p_spawn_f(n, r2, 2, () -> Int {
+    20
+  })
+  p_spawn_f(n, r3, 3, () -> Int {
+    30
+  })
+  p_spawn_f(n, r4, 4, () -> Int {
+    40
+  })
+  p_spawn_f(n, r5, 5, () -> Int {
+    50
+  })
+  let mut i = 0
+  while i < 5 {
+    p_run(n, i)
+    i = i + 1
+  }
+  // run each a second time: the stored closure must survive its first call
+  let mut j = 0
+  while j < 5 {
+    p_run(n, j)
+    j = j + 1
+  }
+  r1.value + r2.value + r3.value + r4.value + r5.value
+}
+
+test "3+ capturing closures stored via a by-value param" {
+  // Historically 2 passed and the 3rd corrupted the heap.
+  inspect(store_three(), "123")
+}
+
+test "stored runner captures + calls a closure param, and is reusable" {
+  inspect(store_five_capture_param_reused(), "165")
+}

--- a/fixtures/err_effect_unshadowed_row_charged.vibe
+++ b/fixtures/err_effect_unshadowed_row_charged.vibe
@@ -1,0 +1,32 @@
+// #1803 P2 follow-up (#1723): effect_row_local_shadow_test.vibe's "the
+// unshadowed effectful call runs when its row is handled" control sits inside
+// `handle`, where the missing-effect diagnostic is deliberately suppressed
+// (in_handle) -- so on its own it cannot pin "an unshadowed top-level callee
+// still charges its declared row". This is the un-suppressed half: the same
+// call shape with NO local shadow and NO handler must be refused, because
+// `caller` omits `with Ask`. `take` is the exact top-level fn the shadow test
+// shadows; here it stays visible, so the row must land on `caller`. The
+// accepted twin (a pure local `take` shadowing this fn, caller stays
+// row-free) is test 1 of effect_row_local_shadow_test.vibe -- together they
+// pin #1723's fix from both directions: shadowing drops the row, NOT
+// shadowing keeps it.
+
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn take(f: () -> Int with Ask) -> Int with Ask {
+  f()
+}
+
+fn caller() -> Int {
+  take(() -> Int with Ask {
+    perform Ask::Get(1)
+  })
+}
+
+let _start = () -> Int {
+  caller()
+}
+
+_start()

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -7236,6 +7236,13 @@ scps_run_expect "effect_stream_next_retarget_hygiene.vibe" "7" "streamnexthygien
 # the plain convention; Done-wrapping it returns a step pointer instead of 8.
 scps_run_expect "effect_scps_param_shadow_test.vibe" "8" "localparamshadow"
 scps_run_expect "effect_scps_top_level_alias_test.vibe" "7" "toplevelalias"
+# #1723 / #1803 P2 follow-up: effect_row_local_shadow_test.vibe's "unshadowed
+# effectful call" control sits inside `handle`, where the missing-effect
+# diagnostic is suppressed (in_handle), so it cannot pin "still charged when
+# NOT shadowed" by itself. This is the un-suppressed half: with no local
+# shadow and no handler, the row lands on the caller and a row-free caller is
+# refused. The accepted twin is test 1 of effect_row_local_shadow_test.vibe.
+scps_check_reject "err_effect_unshadowed_row_charged.vibe" "effect row mismatch for 'caller': missing { Ask }" "unshadowedrow"
 # #1536 (a) v3 (let-floating): an async-iterator `for` in statement position
 # desugars to a let-chain in SEQUENCE HEAD position; scps_split_tail floats
 # it onto the continuation spine. Two sequential loops pin repeated floats

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -6103,6 +6103,32 @@ if ! edpe_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_ru
 fi
 rm -rf "$edpedir"
 echo "[compiler-gate] closure-typed HOF parameter safety boundary ok (206)"
+# #1070 final sub-case (pure closure STORED through a by-value param,
+# outliving the callee frame): historically the 3rd stored closure corrupted
+# the RC heap (`unreachable` on a later read), and only an inline-store
+# workaround avoided it (@vibex/concurrent Nursery::spawn was the canary).
+# Now fixed; pin BOTH RC lanes -- the corruption was RC bookkeeping, so the
+# bump lane alone cannot see a regression.
+cbvsdir="_build/_gate_closure_by_value_store"
+rm -rf "$cbvsdir"; mkdir -p "$cbvsdir"
+for cbvs_rc in 1 0; do
+  VIBE_RC="$cbvs_rc" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    fixtures/closure_by_value_store_test.vibe "$cbvsdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  if [ ! -s "$cbvsdir/out.wasm" ]; then
+    echo "[compiler-gate] FAIL: closure_by_value_store_test.vibe did not compile under VIBE_RC=$cbvs_rc" >&2
+    cat "$cbvsdir/out.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! cbvs_out="$(VIBE_RC="$cbvs_rc" VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$cbvsdir/out.wasm" 2>&1)"; then
+    echo "[compiler-gate] FAIL: closure_by_value_store_test.vibe under VIBE_RC=$cbvs_rc got '$cbvs_out' -- #1070 stored-closure ABI regressed" >&2
+    echo "$cbvs_out" >&2
+    exit 1
+  fi
+  rm -f "$cbvsdir/out.wasm" "$cbvsdir/out.wasm.diag"
+done
+rm -rf "$cbvsdir"
+echo "[compiler-gate] stored-by-value closure ABI ok (#1070 final sub-case, RC both modes)"
 
 # 40ar. #1070 (general case, second slice -- docs/effect-evidence-passing.md
 #       追記25): a SELF-DISCHARGING owner -- a function with NO `with Ask`


### PR DESCRIPTION
test-only の regression pin 2 件 (commit ごとに独立)。

## 1. #1803 P2 follow-up (d08822d)

merge 済み #1803 の Codex P2 指摘への対応。#1803 の 3 本目の対照テスト (「シャドウされていない effectful 呼び出しは row が handled なら動く」) は `handle` の**内側**にあるため、missing-effect 診断が `in_handle` で抑制される — 「unshadowed な top-level 呼び出しが宣言 row を計上しなくなる」regression が起きてもあのテストは green のままで、主張したかった性質を固定できていなかった。

- **`fixtures/err_effect_unshadowed_row_charged.vibe`** (新規): 抑制されない側の片割れ。ローカル shadow なし・handler なしで、effectful top-level `take` を呼ぶ row なしの `caller` が **`effect row mismatch for 'caller': missing { Ask }`** で拒否されることを固定。shadow して受理される双子は `effect_row_local_shadow_test.vibe` の test 1 で、両方向から #1723 の修正を挟む
- gate: 既存の #1723 pin 群の隣に `scps_check_reject` で配線。`__DATA__` は持たない (#1571 の方針)
- P1 指摘 (assert → inspect) は merge 版で対応済みだったため変更なし

## 2. #1070 最終サブケースの pin (0394579)

#1070 で最後まで残っていた「純粋 capturing closure を値渡しした callee が **store** する (frame より長生きする)」形 — 歴史的には 3 個目の store で RC heap が壊れ (`unreachable`)、inline-store ワークアラウンドだけが回避策だった — が **現行 main (92c4796) で再現しなくなっている**ことを確認した:

| | node runner | wasmtime |
|---|---|---|
| VIBE_RC=1 | ✅ | ✅ |
| VIBE_RC=0 | ✅ | ✅ |

検証したのは issue の `p_append_runner` repro そのまま + boundary probe にあった「stored runner が closure param を capture して呼ぶ」変種 + 5 個 store + 初回呼び出し後の再利用。closure ABI 系の作業の副作用で直っていたが pin が無かったので:

- **`fixtures/closure_by_value_store_test.vibe`** (新規): 上記 2 形を `inspect` の test block で固定
- gate: **RC 両レーン**で実行 (壊れ方が RC bookkeeping なので bump レーンだけでは regression が見えない)

ついでに効いている副作用: `@vibex/concurrent` `Nursery::spawn` の inline-store ワークアラウンドは外せる状態 (このPRでは触っていない — canary として残すか外すかは別判断)。#1070 の効果側 repro (`run_with_handler`、ADR-0076 追記34 V1 で解決) が 285 を返し続けることも同時に確認済み (既存 pin あり)。

## 検証

- 両 fixture とも gate の新ステップと同一レシピで手元実行済み (拒否 + needle / RC 両レーン inspect green)
- full `scripts/compiler_gate.sh` はローカルで実行中 + CI

Refs #1723, #1803, #1070