### PR TITLE
#1839 slice 2: 匿名 record に第一級の checker 型 CtRecord — record-as-struct を located に拒否

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -806,10 +806,11 @@ let w_check = {
 >   colliding struct, and a record whose field set is a strict subset of some
 >   struct's is accepted (it used to be rejected as a construction of that
 >   struct missing fields). Struct construction is spelled `S::{ ... }` only.
->   Caveat: the checker does not yet REJECT passing an anonymous record where
->   a struct is expected — that program now reads wrong slots at runtime
->   instead of being (wrongly) accepted as the struct. Don't do it; #1839
->   tracks the checker-level rejection.
+>   The literal's checker type is a structural record (`record { start: Int,
+>   end: Int }` in diagnostics): passing it where a struct is expected is a
+>   located type mismatch (`expected Span, got record { start: Int, end:
+>   Int }`), and `.field` reads are typed against the record's own fields
+>   (an unknown field is a located error).
 > - **Record dot access** (`r.name` on an anonymous `record { ... }`) lowers to
 >   the positional field read the destructure uses, and now resolves in every
 >   expression position — a `let` initializer (including a top-level `let`

--- a/lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe
@@ -150,6 +150,18 @@ fn artifact_type(ty: Type) -> String {
       }
       String::concat("T", artifact_array(encoded))
     },
+    // #1839: anonymous record — each array item is a name piece followed by
+    // the field's type encoding, literal field order preserved.
+    CtRecord(rfields) => {
+      let kencoded = array_empty()
+      let mut ki = 0
+      while ki < Array::length(rfields) {
+        let (kname, kty) = Array::get(rfields, ki)
+        Array::push(kencoded, String::concat(artifact_piece(kname), artifact_type(kty)))
+        ki = ki + 1
+      }
+      String::concat("K", artifact_array(kencoded))
+    },
     CtArray(item) => String::concat("A", artifact_type(item)),
     CtOption(item) => String::concat("O", artifact_type(item)),
     CtFn(params, ret, effect) => {
@@ -526,6 +538,41 @@ fn artifact_type_parse(text: String, pos: Int) -> Option[(Type, Int)] {
           }
           if valid {
             Some((CtTuple(out), next))
+          } else {
+            None
+          }
+        },
+        None => None
+      }
+    } else if tag == 75 {
+      // #1839: 'K' anonymous record — each item is a name piece followed by
+      // the field's type encoding.
+      match artifact_array_parse(text, pos + 1) {
+        Some((raws, next)) => {
+          let rfields = array_empty()
+          let mut ki = 0
+          let mut kvalid = true
+          while ki < Array::length(raws) {
+            let raw = Array::get(raws, ki)
+            match artifact_piece_parse(raw, 0) {
+              Some((kname, after_name)) => match artifact_type_parse(raw, after_name) {
+                Some((kty, kend)) => if kend == String::length(raw) {
+                  Array::push(rfields, (kname, kty))
+                } else {
+                  kvalid = false
+                },
+                None => {
+                  kvalid = false
+                }
+              },
+              None => {
+                kvalid = false
+              }
+            }
+            ki = ki + 1
+          }
+          if kvalid {
+            Some((CtRecord(rfields), next))
           } else {
             None
           }

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -297,6 +297,19 @@ fn canonical_type(ty: Type, s: Subst, bound_ids: Array[Int], bound_names: Array[
       }
       canonical_node("T", fields)
     },
+    // #1839: anonymous record — field names participate in the canonical
+    // form (they are part of the type), literal order preserved.
+    CtRecord(rfields) => {
+      let kfields = array_empty()
+      let mut ki = 0
+      while ki < Array::length(rfields) {
+        let (kname, kty) = Array::get(rfields, ki)
+        Array::push(kfields, kname)
+        Array::push(kfields, canonical_type(kty, s, bound_ids, bound_names, free_ids, free_names, resolving))
+        ki = ki + 1
+      }
+      canonical_node("K", kfields)
+    },
     CtArray(item) => canonical_node("A", [
       canonical_type(item, s, bound_ids, bound_names, free_ids, free_names, resolving)
     ]),

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -742,6 +742,11 @@ fn head_kind(t: Type) -> Int {
     CtStruct(_) => 11,
     CtEnum(_) => 12,
     CtFn(_, _, _) => 13,
+    // #1839 (Codex review on #1867): a concrete head, NOT the `_ => 0`
+    // "unresolved; tolerate" bucket — otherwise representation-specific
+    // builtin receiver checks (`Array::get(record { a: 1 }, 0)` etc.) pass
+    // and codegen reads the record layout as the wrong representation.
+    CtRecord(_) => 14,
     _ => 0
   }
 }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6860,6 +6860,33 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               },
               None => CtUnknown
             },
+            // #1839: field read on an anonymous record — resolve by name in
+            // the record's own field list (literal order). An unknown field
+            // is a located error; the codegen/desugar positional read would
+            // otherwise reach an out-of-range slot.
+            CtRecord(rec_fields) => {
+              let rec find_field_r: (Int) -> Option[Type] = (i) -> {
+                if i >= Array::length(rec_fields) {
+                  None
+                } else {
+                  let (fname, ftype) = Array::get(rec_fields, i)
+                  if fname == field {
+                    Some(ftype)
+                  } else find_field_r(i + 1)
+                }
+              }
+              match find_field_r(0) {
+                Some(ft) => ft,
+                None => {
+                  Array::push(errors, String::concat(String::concat("unknown field '", String::concat(field, String::concat("' on ", type_to_string(resolved)))), if field_off >= 0 {
+                    off_marker_len(field_off, String::length(field))
+                  } else {
+                    off_marker(dot_off)
+                  }))
+                  CtUnknown
+                }
+              }
+            },
             // #829: field read through an INSTANTIATED generic struct value —
             // substitute the declared type params with the receiver's type args so
             // `b.v` on `Box[Int]` is `Int` (previously the whole read was
@@ -7304,9 +7331,14 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         // struct (accepting `fn (s: Span)` calls the writer never meant) and
         // rejected records whose field set was a strict subset of some
         // struct ("missing field ... in construction of struct X"). Codegen
-        // and the anon-record dot-access desugar now keep the same rule:
+        // and the anon-record dot-access desugar keep the same rule:
         // rn == "" always lays out in literal order with tag 0.
-        (CtUnknown, s1, c1)
+        //
+        // Slice 2: the literal now gets a real structural type. CtRecord
+        // unifies only with a same-shaped record, so passing a record where
+        // a struct is expected is a located type mismatch instead of a
+        // CtUnknown pass-through that read wrong slots at runtime.
+        (CtRecord(field_tys), s1, c1)
       }
     },
     ETuple(items) => {

--- a/lib/@vibe/compiler/checker/checker_trait.vibe
+++ b/lib/@vibe/compiler/checker/checker_trait.vibe
@@ -281,6 +281,12 @@ fn send_ok_rec(env: TypeEnv, s: Subst, defs: Array[TypeDef], ty: Type, seen: Arr
     CtChar => true,
     CtUnit => true,
     CtTuple(ts) => send_ok_all(env, s, defs, ts, seen),
+    // #1839: an anonymous record is an immutable aggregate (no mut fields),
+    // so like a tuple it is Send exactly when every field type is.
+    CtRecord(rfs) => send_ok_all(env, s, defs, for rf in rfs {
+      let (_, rft) = rf
+      rft
+    }, seen),
     CtOption(e) => send_ok_rec(env, s, defs, e, seen),
     CtArray(_) => false,
     CtBytes => false,

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -35,7 +35,13 @@ export enum Type {
   CtNamed(String, Array[Type]);
   CtVar(Int);
   CtForAll(Array[Int], Array[(Int, Array[String])], Type);
-  CtUnknown
+  CtUnknown;
+  // #1839: an explicit anonymous `record { ... }` literal. Structural, field
+  // order = LITERAL order (which is also the runtime slot layout, tag 0), so
+  // equality/unification are order-sensitive. Distinct from CtStruct so a
+  // record can never silently flow into a nominal struct position — unify
+  // rejects the pair, and the diagnostic prints the record's shape.
+  CtRecord(Array[(String, Type)])
 }
 
 export enum TypeDef {
@@ -413,6 +419,20 @@ export fn occurs_in(id: Int, ty: Type) -> Bool {
     },
     CtArray(elem) => occurs_in(id, elem),
     CtOption(elem) => occurs_in(id, elem),
+    CtRecord(rfields) => {
+      let mut ri = 0
+      let mut rfound = false
+      while ri < Array::length(rfields) {
+        let (_, rft) = Array::get(rfields, ri)
+        if occurs_in(id, rft) {
+          rfound = true
+          ri = Array::length(rfields)
+        } else {
+          ri = ri + 1
+        }
+      }
+      rfound
+    },
     CtTuple(elems) => {
       let mut i = 0
       let mut found = false
@@ -1098,6 +1118,10 @@ export fn subst_apply(s: Subst, ty: Type) -> Type {
     CtTuple(elems) => CtTuple(for e in elems {
       subst_apply(s, e)
     }),
+    CtRecord(rfields) => CtRecord(for rf in rfields {
+      let (rfn, rft) = rf
+      (rfn, subst_apply(s, rft))
+    }),
     CtNamed(name, args) => CtNamed(name, for arg in args {
       subst_apply(s, arg)
     }),
@@ -1207,6 +1231,19 @@ export fn type_to_string(ty: Type) -> String {
         i = i + 1
       }
       String::concat("(", String::concat(joined, ")"))
+    },
+    CtRecord(rfields) => {
+      let mut ri = 0
+      let mut rjoined = ""
+      while ri < Array::length(rfields) {
+        let (rfn, rft) = Array::get(rfields, ri)
+        let rpart = String::concat(rfn, String::concat(": ", type_to_string(rft)))
+        rjoined = if ri > 0 {
+          String::concat(rjoined, String::concat(", ", rpart))
+        } else rpart
+        ri = ri + 1
+      }
+      String::concat("record { ", String::concat(rjoined, " }"))
     },
     CtFn(params, ret, effect_name) => {
       let parts = for p in params {
@@ -1385,6 +1422,13 @@ fn collect_effect_vars_walk(t: Type, out: Array[String]) -> Int {
     },
     CtArray(elem) => collect_effect_vars_walk(elem, out),
     CtOption(elem) => collect_effect_vars_walk(elem, out),
+    CtRecord(rfields) => {
+      for rf in rfields {
+        let (_, rft) = rf
+        let _ = collect_effect_vars_walk(rft, out)
+      }
+      0
+    },
     CtTuple(elems) => {
       for e in elems {
         let _ = collect_effect_vars_walk(e, out)
@@ -1440,6 +1484,16 @@ fn rename_effect_vars(t: Type, pairs: Array[(String, String)]) -> Type {
         i = i + 1
       }
       CtTuple(out)
+    },
+    CtRecord(rfields) => {
+      let rout = array_empty()
+      let mut ri = 0
+      while ri < Array::length(rfields) {
+        let (rfn, rft) = Array::get(rfields, ri)
+        Array::push(rout, (rfn, rename_effect_vars(rft, pairs)))
+        ri = ri + 1
+      }
+      CtRecord(rout)
     },
     CtNamed(name, args) => {
       let out = array_empty()
@@ -1571,6 +1625,13 @@ fn collect_tvars_walk(t: Type, out: Array[Int]) -> Int {
     },
     CtArray(elem) => collect_tvars_walk(elem, out),
     CtOption(elem) => collect_tvars_walk(elem, out),
+    CtRecord(rfields) => {
+      for rf in rfields {
+        let (_, rft) = rf
+        let _ = collect_tvars_walk(rft, out)
+      }
+      0
+    },
     CtTuple(elems) => {
       for e in elems {
         let _ = collect_tvars_walk(e, out)
@@ -2009,6 +2070,36 @@ export fn types_equal(a: Type, b: Type) -> Bool {
       },
       _ => false
     },
+    // #1839: records are structural with LITERAL field order (order IS the
+    // runtime slot layout), so equality is order-sensitive: same names in the
+    // same positions with equal types.
+    CtRecord(arf) => match b {
+      CtRecord(brf) =>
+      if Array::length(arf) != Array::length(brf) {
+        false
+      } else {
+        let rql = Array::length(arf)
+        let mut rqi = 0
+        let mut rq_result = true
+        let mut rq_done = false
+        while !rq_done {
+          if rqi >= rql {
+            rq_done = true
+          } else {
+            let (afn, aft) = Array::get(arf, rqi)
+            let (bfn, bft) = Array::get(brf, rqi)
+            if afn == bfn && types_equal(aft, bft) {
+              rqi = rqi + 1
+            } else {
+              rq_result = false
+              rq_done = true
+            }
+          }
+        }
+        rq_result
+      },
+      _ => false
+    },
     CtFn(aparams, aret, aeffect) => match b {
       CtFn(bparams, bret, beffect) =>
       if Array::length(aparams) != Array::length(bparams) {
@@ -2244,6 +2335,50 @@ export fn unify(a: Type, b: Type, s: Subst) -> Option[Subst] {
                       }
                     }
                     ul_result2
+                  },
+                  _ => None
+                },
+                // #1839: records unify only with records of the same shape —
+                // same field names in the same order (order IS the runtime
+                // slot layout), field types unified pairwise. Against any
+                // nominal type (CtStruct/CtNamed/...) the catch-all below
+                // rejects, which is the point: an anonymous record can never
+                // silently satisfy a struct-typed position.
+                CtRecord(raf) => match tb {
+                  CtRecord(rbf) => if Array::length(raf) != Array::length(rbf) {
+                    None
+                  }
+                  else {
+                    let ur_len = Array::length(raf)
+                    let mut ur_i = 0
+                    let mut ur_acc = s
+                    let mut ur_result = Some(s)
+                    let mut ur_done = false
+                    while !ur_done {
+                      if ur_i >= ur_len {
+                        ur_result = Some(ur_acc)
+                        ur_done = true
+                      } else {
+                        let (ur_an, ur_at) = Array::get(raf, ur_i)
+                        let (ur_bn, ur_bt) = Array::get(rbf, ur_i)
+                        if ur_an != ur_bn {
+                          ur_result = None
+                          ur_done = true
+                        } else {
+                          match unify(ur_at, ur_bt, ur_acc) {
+                            Some(s2) => {
+                              ur_acc = s2
+                              ur_i = ur_i + 1
+                            },
+                            None => {
+                              ur_result = None
+                              ur_done = true
+                            }
+                          }
+                        }
+                      }
+                    }
+                    ur_result
                   },
                   _ => None
                 },

--- a/lib/@vibe/compiler/core/types_eq_test.vibe
+++ b/lib/@vibe/compiler/core/types_eq_test.vibe
@@ -55,7 +55,8 @@ fn type_tag(v: Type) -> Int {
     CtNamed(_, _) => 13,
     CtVar(_) => 14,
     CtForAll(_, _, _) => 15,
-    CtUnknown => 16
+    CtUnknown => 16,
+    CtRecord(_) => 17
   }
 }
 
@@ -90,7 +91,10 @@ fn every_type() -> Array[Type] {
         "C"
       ])
     ], CtUnit),
-    CtUnknown
+    CtUnknown,
+    CtRecord([
+      ("f", CtUnit)
+    ])
   ]
 }
 
@@ -131,7 +135,10 @@ fn every_type_same() -> Array[Type] {
         "C"
       ])
     ], CtUnit),
-    CtUnknown
+    CtUnknown,
+    CtRecord([
+      ("f", CtUnit)
+    ])
   ]
 }
 
@@ -169,7 +176,10 @@ fn every_type_alt() -> Array[Type] {
         "D"
       ])
     ], CtInt),
-    CtUnknown
+    CtUnknown,
+    CtRecord([
+      ("g", CtInt)
+    ])
   ]
 }
 
@@ -383,7 +393,7 @@ test "Type ==: every variant is structurally equal to itself" {
     }
     i = i + 1
   }
-  inspect(same, "17")
+  inspect(same, "18")
 }
 
 test "Type ==: distinct variants are never equal" {
@@ -406,7 +416,7 @@ test "Type ==: distinct variants are never equal" {
     }
     i = i + 1
   }
-  inspect(differ, "17")
+  inspect(differ, "18")
 }
 
 test "Type ==: structurally equal but distinct values are equal" {
@@ -427,7 +437,7 @@ test "Type ==: structurally equal but distinct values are equal" {
   }
   // Every variant, including the ones carrying arrays and nested values. A
   // regression from structural to reference comparison drops this below n.
-  inspect(equal, "17")
+  inspect(equal, "18")
 }
 
 test "Type: every represented variant is the declared one, in order" {
@@ -456,7 +466,8 @@ test "Type: every represented variant is the declared one, in order" {
     13,
     14,
     15,
-    16
+    16,
+    17
   ]
   let vs = every_type()
   let n = Array::length(vs)
@@ -471,8 +482,8 @@ test "Type: every represented variant is the declared one, in order" {
     }
     i = i + 1
   }
-  inspect(Array::length(want), "17")
-  inspect(in_order, "17")
+  inspect(Array::length(want), "18")
+  inspect(in_order, "18")
 }
 
 test "Type ==: same variant with different payloads is not equal" {
@@ -494,8 +505,8 @@ test "Type ==: same variant with different payloads is not equal" {
   // Exactly the variants that CARRY a payload must differ; the nullary ones
   // rebuild identically and must still compare equal. A derive that compared
   // tags only would report 0 here.
-  inspect(Array::length(alt), "17")
-  inspect(differ, "9")
+  inspect(Array::length(alt), "18")
+  inspect(differ, "10")
 }
 
 test "TypeDef ==: every variant is structurally equal to itself" {

--- a/lib/@vibe/compiler/runtime/grep.vibe
+++ b/lib/@vibe/compiler/runtime/grep.vibe
@@ -1738,6 +1738,28 @@ fn grep_type_matches(expected: Type, actual: Type) -> Bool {
       CtTuple(as_) => grep_type_list_matches(es, as_),
       _ => false
     },
+    // #1839: anonymous record — matches a record with the same field names
+    // in the same order and matching field types.
+    CtRecord(efs) => match actual {
+      CtRecord(afs) => if Array::length(efs) != Array::length(afs) {
+        false
+      } else {
+        let mut kri = 0
+        let mut krok = true
+        while kri < Array::length(efs) {
+          let (ekn, ekt) = Array::get(efs, kri)
+          let (akn, akt) = Array::get(afs, kri)
+          if ekn == akn && grep_type_matches(ekt, akt) {
+            kri = kri + 1
+          } else {
+            krok = false
+            kri = Array::length(efs)
+          }
+        }
+        krok
+      },
+      _ => false
+    },
     CtFn(eps, er, erow) => match actual {
       CtFn(aps, ar, arow) => grep_type_list_matches(eps, aps) && grep_type_matches(er, ar) && grep_row_equiv(erow, arow),
       _ => false

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -275,6 +275,31 @@ fn parse_cached_type(source: String, pos: Int) -> (Type, Int) with Exception {
         let (body, next) = parse_cached_type(source, after_bounds)
         (CtForAll(vars, bounds, body), next)
       },
+      // #1839: anonymous record — count-headed list of (name segment, type
+      // segment) pairs, literal field order preserved.
+      'K' => {
+        let (count, start) = parse_count_header(source, pos + 1, '[')
+        let rfields = array_empty()
+        let mut ki = 0
+        let mut kcursor = start
+        while ki < count {
+          let (kname, after_name) = parse_segment(source, kcursor)
+          let (kraw, after_ty) = parse_segment(source, after_name)
+          let (kty, kend) = parse_cached_type(kraw, 0)
+          if kend != String::length(kraw) {
+            throw("invalid persistent type env record field type")
+          } else {
+            Array::push(rfields, (kname, kty))
+            kcursor = after_ty
+            ki = ki + 1
+          }
+        }
+        if kcursor >= String::length(source) || String::char_code_at(source, kcursor) != ']' {
+          throw("invalid persistent type env record field list")
+        } else {
+          (CtRecord(rfields), kcursor + 1)
+        }
+      },
       _ => throw("invalid persistent type env type tag")
     }
   }
@@ -305,7 +330,24 @@ fn serialize_type(ty: Type) -> String {
       String::concat("F", String::concat(serialize_segment(effect), String::concat(serialize_type_array(params), serialize_type(ret))))
     },
     CtNamed(name, args) => String::concat("N", String::concat(serialize_segment(name), serialize_type_array(args))),
-    CtForAll(vars, bounds, body) => String::concat("Q", String::concat(serialize_int_array(vars), String::concat(serialize_bounds_array(bounds), serialize_type(body))))
+    CtForAll(vars, bounds, body) => String::concat("Q", String::concat(serialize_int_array(vars), String::concat(serialize_bounds_array(bounds), serialize_type(body)))),
+    // #1839: anonymous record — count-headed (name segment, type segment)
+    // pairs in literal field order (mirrors the 'K' parser above).
+    CtRecord(rfields) => {
+      let kbuf = StringBuilder::new()
+      StringBuilder::push(kbuf, "K")
+      StringBuilder::push(kbuf, __to_string(Array::length(rfields)))
+      StringBuilder::push(kbuf, "[")
+      let mut ki = 0
+      while ki < Array::length(rfields) {
+        let (kname, kty) = Array::get(rfields, ki)
+        StringBuilder::push(kbuf, serialize_segment(kname))
+        StringBuilder::push(kbuf, serialize_segment(serialize_type(kty)))
+        ki = ki + 1
+      }
+      StringBuilder::push(kbuf, "]")
+      StringBuilder::freeze(kbuf)
+    }
   }
 }
 

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1618,6 +1618,17 @@ fn interface_canonical_type(ty: Type, ids: Array[Int], names: Array[String]) -> 
     CtArray(elem) => String::concat("array:", interface_segment(interface_canonical_type(elem, ids, names))),
     CtOption(elem) => String::concat("option:", interface_segment(interface_canonical_type(elem, ids, names))),
     CtTuple(items) => String::concat("tuple:", types(items, ids, names)),
+    // #1839: anonymous record — names are part of the canonical form.
+    CtRecord(rfields) => {
+      let mut kacc = "record:"
+      let mut ki = 0
+      while ki < Array::length(rfields) {
+        let (kname, kty) = Array::get(rfields, ki)
+        kacc = String::concat(kacc, String::concat(interface_segment(kname), interface_segment(interface_canonical_type(kty, ids, names))))
+        ki = ki + 1
+      }
+      kacc
+    },
     CtNamed(name, args) => String::concat("named:", String::concat(interface_segment(name), types(args, ids, names))),
     CtFn(params, ret, effects) => String::concat("fn:", String::concat(types(params, ids, names), String::concat(interface_segment(interface_canonical_type(ret, ids, names)), interface_effect_set(effects)))),
     CtForAll(vars, bounds, body) => {

--- a/scripts/test_located_diagnostics.sh
+++ b/scripts/test_located_diagnostics.sh
@@ -190,6 +190,27 @@ else
   echo "FAIL: expected 1 location for a ': '-containing path, got $sep_n (in: $sep_out)" >&2; fail=$((fail + 1))
 fi
 
+# #1839: an anonymous `record { ... }` literal is CtRecord (structural), so
+# passing it where a nominal struct is expected is a LOCATED type mismatch
+# whose message prints the record's shape -- it used to typecheck (record
+# captured as the struct, then CtUnknown) and read wrong slots at runtime.
+expect_contains "record-into-struct-arg rejected with the record's shape (#1839)" \
+  "expected Span, got record { start: Int, end: Int }" \
+  'struct Span { end: Int; start: Int }\nfn span_width(s: Span) -> Int { s.end - s.start }\nexport fn main() -> Int {\n  span_width(record { start: 3, end: 9 })\n}\n'
+
+expect_contains "record-into-struct-annotation rejected (#1839)" \
+  "expected Span, got record { start: Int, end: Int }" \
+  'struct Span { end: Int; start: Int }\nexport fn main() -> Int {\n  let r: Span = record { start: 3, end: 9 }\n  r.start\n}\n'
+
+# ...while a record used AS a record stays accepted (same colliding struct in
+# scope; literal-order dot access).
+printf 'struct Span { end: Int; start: Int }\nexport fn main() -> Int {\n  let r = record { start: 3, end: 9 }\n  r.start + r.end\n}\n' > "$WORK/rec_ok.vibe"
+if "$VIBE" check "$WORK/rec_ok.vibe" >/dev/null 2>&1; then
+  echo "ok: record used structurally checks clean beside a colliding struct"; pass=$((pass + 1))
+else
+  echo "FAIL: structural record use should check clean (got: $("$VIBE" check "$WORK/rec_ok.vibe" 2>&1 | head -2))" >&2; fail=$((fail + 1))
+fi
+
 # a good program -> check passes (no error)
 printf 'export let main = () -> Int { 40 + 2 }\n' > "$WORK/ok.vibe"
 if "$VIBE" check "$WORK/ok.vibe" >/dev/null 2>&1; then

--- a/scripts/test_located_diagnostics.sh
+++ b/scripts/test_located_diagnostics.sh
@@ -202,6 +202,14 @@ expect_contains "record-into-struct-annotation rejected (#1839)" \
   "expected Span, got record { start: Int, end: Int }" \
   'struct Span { end: Int; start: Int }\nexport fn main() -> Int {\n  let r: Span = record { start: 3, end: 9 }\n  r.start\n}\n'
 
+# ...a representation-specific builtin receiver check also rejects a record
+# (head_kind gives CtRecord a concrete head instead of the tolerate bucket;
+# Codex review on #1867 -- Array::get on a record used to pass and read the
+# record layout as an array)...
+expect_contains "record rejected as an Array builtin receiver (#1839)" \
+  "Array::get" \
+  'export fn main() -> Int {\n  Array::get(record { a: 1 }, 0)\n}\n'
+
 # ...while a record used AS a record stays accepted (same colliding struct in
 # scope; literal-order dot access).
 printf 'struct Span { end: Int; start: Int }\nexport fn main() -> Int {\n  let r = record { start: 3, end: 9 }\n  r.start + r.end\n}\n' > "$WORK/rec_ok.vibe"


### PR DESCRIPTION
#1839 の残件 (PR #1852 の slice 1 で予告したもの)。slice 1 は struct 捕獲を撤廃したが、匿名 record を `CtUnknown` に落としたため、**record を struct 期待位置に渡すプログラムが型検査を通り、実行時に誤スロットを読む** (`span_width(record { start: 3, end: 9 })` → -6、無診断) 状態が残っていた。

## 変更

`record { ... }` リテラルが構造的な第一級の型 **`CtRecord(Array[(String, Type)])`** を持つようになった。フィールド順は literal 順 (= 実行時スロットレイアウト) で、等価・単一化とも順序敏感。

- **core/types.vibe**: variant 追加 + occurs_in / subst_apply / type_to_string (`record { a: Int }` 形式で診断に出る) / collect_effect_vars_walk / rename_effect_vars / collect_tvars_walk / types_equal / unify (record×record は同名・同順・フィールド pairwise、nominal 型とは不一致 → これが本命)
- **checker.vibe**: rn == "" の ERecord が `CtRecord(field_tys)` を返す。EDot の CtRecord receiver はフィールドを名前解決して**型付きの読み**になり、無いフィールドは located エラー
- **checker_trait.vibe**: record の Send 判定は tuple と同じ「全フィールドが Send なら Send」
- **codec 3 面**: persistent_env_codec / checked_type_defs_artifact に 'K' タグ (名前+型ペア、literal 順で round-trip)、canonical_checked_type_state / typecheck_fs の interface canonical form、runtime/grep の型 matcher

## 挙動 (実測、再ビルドした stage2)

拒否 (どちらも located、record の形が診断に出る):

```
line 18:11: argument type mismatch for span_width: expected Span, got record { start: Int, end: Int }
binding type mismatch for a local let: expected Span, got record { start: Int, end: Int }
```

受理 (不変): 衝突 struct の隣での構造的使用・dot access・同順 destructure (`fixtures/anon_record_struct_collision_test.vibe`)、既存の anon record テスト、helper fn 経由・binding 伝播。

## 検証

- `vibe check` でコンパイラ + CLI + LSP エントリの closure 全体 clean (CtRecord 追加で網羅 match が壊れた 7 箇所は checker が列挙 → 全対応)
- stage2 再ビルド (seed→stage1→stage2、sample 検証込み) green
- `scripts/test_located_diagnostics.sh` **26/26** (新規 3 ケース: arg 拒否 / annotation 拒否 / 構造的使用は clean — cli-install workflow で enforce される)
- `bash scripts/compiler_gate.sh` はローカルで実行中 (CI でも同 gate が回る)

## 既知の残りギャップ (pre-existing、この PR で挙動不変)

tuple destructure で取り出した record binding への dot access (`let (r, _) = (record { a: 1 }, 2); r.a`) は checker (CtRecord で型付け) を通るが codegen の sentinel 追跡が binding を追えず `unknown struct field` で落ちる — slice 1 以前からの既存ギャップで、#1839 にコメントで記録する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC)_