### PR TITLE
Reject undispatchable trait-method calls at check time (#1858)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -675,10 +675,10 @@ impl [T: Eq] Eq for Array[T]              // 宣言はできるが bound には�
 // どこでも満たせる。generic code から `T::default()` を呼ぶには
 // method-bearing 宣言 (`trait Default { default() -> Self }`) が要るので
 // `import @vibe/core { Default }` する — witness は Hash と同じ dict 経由。
-// derive(Default) した struct/enum も bound を満たす。呼び出し側で T の
-// 具象型が構文的に決まらない形 (例: `[T: Default]() -> T` を注釈だけで
-// 呼ぶ) は witness が組めず解決されない — T 型の引数 (または Array[T]
-// 引数) を witness carrier にすること。
+// derive(Default) した struct/enum も bound を満たす。witness を運べない
+// 定義 (例: `[T: Default]() -> T` — T 型の引数も Array[T] 引数も無い) は
+// `vibe check` が「cannot be dispatched here」で拒否する (#1858) —
+// T 型の引数 (または Array[T] 引数) を witness carrier にすること。
 ```
 
 ### marker trait の impl は container には効かない (#1503)

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -77,7 +77,11 @@ import ./checker_resolve.vibe {
 }
 
 import @vibe/compiler/normalize {
-  desugar_inspect_calls, desugar_labeled_args, desugar_railway_binds, inject_trait_method_generics
+  collect_undispatchable_trait_method_errors,
+  desugar_inspect_calls,
+  desugar_labeled_args,
+  desugar_railway_binds,
+  inject_trait_method_generics
 }
 
 //# Types
@@ -2097,6 +2101,14 @@ fn unsatisfied_bound_hint(env: TypeEnv, trait_name: String, resolved: Type) -> S
 /// error per unsatisfied bound (matches fixtures/err_type_trait_*bound* messages).
 /// Import projection supplies the selected trait authority and implementations,
 /// so this is enforced identically for standalone and FS/import checking.
+fn push_error_strings(msgs: Array[String], errors: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(msgs) {
+    Array::push(errors, Array::get(msgs, i))
+    i = i + 1
+  }
+}
+
 fn check_program_bounds(env: TypeEnv, s: Subst, defs: Array[TypeDef], errors: Array[String]) -> Unit {
   let pairs = collect_subst_bounds_pairs(s)
   let n = Array::length(pairs)
@@ -2942,6 +2954,12 @@ fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[
   }
   let (env, final_s, _) = check_stmts_with_binders(expanded_stmts, 0, seeded_env, empty_defs, type_def_binders, 0, SubstEmpty, 0, frozen_errors, tytab, statement_parent_path, capture, role_lane_capture, false)
   check_program_bounds(env, final_s, empty_defs, frozen_errors)
+  // #1858: a bounded generic whose body calls `T::m` but whose signature has
+  // no witness-carrying parameter would sail through checking and ICE in
+  // codegen (`T::m reached code generation unresolved`) — reject it here with
+  // an actionable message instead. The capability predicate lives next to
+  // build_gens in desugar_trait_dict.vibe.
+  push_error_strings(collect_undispatchable_trait_method_errors(stmts, env), frozen_errors)
   collect_async_effect_errors(expanded_stmts, env, frozen_errors)
   // #1455 step 3: `empty_defs` is the finished enum table by now, so the
   // qualifiers drained above can finally be checked against it.
@@ -3233,6 +3251,11 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       // this environment, so user-trait bounds are checked here with the same
       // rule as the standalone path.
       check_program_bounds(env, final_s, empty_defs, frozen_errors)
+      // #1858: same witness-carrier validation as the standalone path — the
+      // projected env supplies imported traits' method tables, so a module
+      // using an imported method-bearing trait (e.g. @vibe/core's Default)
+      // is covered too.
+      push_error_strings(collect_undispatchable_trait_method_errors(stmts, env), frozen_errors)
       collect_async_effect_errors(expanded_stmts, env, frozen_errors)
       // #1455 step 3: `empty_defs` holds the imported enums seeded above plus
       // this module's own, which is exactly the set a qualifier may name.

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, TypeExpr, expr_children, is_exception_throw_operation, sort_perm_by_names, str_lt
+  Expr, Pat, Stmt, TypeEnv, TypeExpr, expr_children, is_exception_throw_operation, sort_perm_by_names, str_lt, trait_method_sig_binders_deep
 }
 
 import @vibe/core {
@@ -1575,6 +1575,108 @@ fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[Ty
     i = i + 1
   }
   out
+}
+
+/// #1858: definition-side witness-carrier validation, run by the CHECKER (both
+/// check_program pipelines) so `vibe check` reports what would otherwise
+/// surface as a codegen ICE ("`T::default` reached code generation
+/// unresolved").
+///
+/// A top-level generic `f = [T: Tr](params)` whose body references `T::m` (a
+/// method of the method-bearing trait `Tr`) can only be dispatched when this
+/// pass can thread a witness dictionary for `T` — and build_gens above derives
+/// that ability purely from the signature: a parameter of type `T`
+/// (find_recv_index), a parameter of type `Array[T]`
+/// (find_array_elem_recv_index, #1199), or the function being a bounded
+/// generic-impl method (collect_generic_impl_types — its dict arrives with the
+/// impl witness instead). A bounded generic with NONE of those is never
+/// registered in `gens`, its body is never rewritten, and `T::m` reaches
+/// codegen unresolved. This function is the checker-facing mirror of exactly
+/// that condition — if build_gens grows a new receiver kind, this must learn
+/// it too, which is why it lives next to build_gens rather than in the
+/// checker.
+///
+/// `env` supplies the trait method tables (trait_method_sig_binders_deep), so
+/// traits imported from another module (e.g. @vibe/core's `Default`) are
+/// covered, not just same-file declarations. Marker traits have no methods, so
+/// no `T::m` can name one and the scan stays inert for them — same reason the
+/// checker's own `resolve_trait_method_ident` never resolves through a marker
+/// bound.
+export fn collect_undispatchable_trait_method_errors(stmts: Array[Stmt], env: TypeEnv) -> Array[String] {
+  let out = empty_str_array()
+  let gimpl_types = collect_generic_impl_types(stmts)
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, fname, _, body) => match body {
+        EFn(_, bounds, params, _, _, fbody) => if already_threaded(params) {
+          ()
+        } else {
+          let mut bi = 0
+          while bi < Array::length(bounds) {
+            let (tp, trait_list) = Array::get(bounds, bi)
+            let has_carrier = find_recv_index(params, tp) >= 0 || find_array_elem_recv_index(params, tp) >= 0 || str_array_contains(gimpl_types, qualified_head(fname))
+            if has_carrier {
+              ()
+            } else {
+              push_undispatchable_refs(fbody, fname, tp, trait_list, env, out)
+            }
+            bi = bi + 1
+          }
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// Scan one carrier-less bound's function body for `tp::member` references
+/// that name a method of one of the bound traits, pushing one actionable
+/// diagnostic per distinct reference. Values and calls are both caught — an
+/// unrewritten `T::m` is equally unresolvable either way.
+fn push_undispatchable_refs(e: Expr, fname: String, tp: String, trait_list: Array[String], env: TypeEnv, out: Array[String]) -> Unit {
+  match e {
+    EIdent(nm, _) => match split_qualified(nm) {
+      Some(parts) => {
+        let (head, member) = parts
+        if head == tp {
+          let mut ti = 0
+          let mut reported = false
+          while ti < Array::length(trait_list) {
+            let tr = Array::get(trait_list, ti)
+            if !reported && tr != "" {
+              match trait_method_sig_binders_deep(env, tr, member) {
+                Some(_) => {
+                  reported = true
+                  let msg = String::concat(fname, String::concat(": `", String::concat(nm, String::concat("` cannot be dispatched here: no parameter of `", String::concat(fname, String::concat("` carries the `[", String::concat(tp, String::concat(": ", String::concat(tr, String::concat("]` witness. Add a parameter of type `", String::concat(tp, String::concat("` (or `Array[", String::concat(tp, String::concat("]`) so call sites can supply the impl, or call `", String::concat(member, "` on a concrete type instead.")))))))))))))))
+                  if str_array_contains(out, msg) {
+                    ()
+                  } else {
+                    Array::push(out, msg)
+                  }
+                },
+                None => ()
+              }
+            }
+            ti = ti + 1
+          }
+        } else {
+          ()
+        }
+      },
+      None => ()
+    },
+    _ => ()
+  }
+  let kids = expr_children(e)
+  let mut ki = 0
+  while ki < Array::length(kids) {
+    push_undispatchable_refs(Array::get(kids, ki), fname, tp, trait_list, env, out)
+    ki = ki + 1
+  }
 }
 
 fn lookup_gen(gens: Array[(String, Array[(String, String, Int)])], name: String) -> Option[Array[(String, String, Int)]] {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1368,12 +1368,38 @@ fn empty_dict_binds() -> Array[(String, String, String, Array[String])] {
 
 /// A function already carries a threaded dict parameter (idempotency guard
 /// against desugaring the same stmts twice while bounds are still present).
-fn already_threaded(params: Array[(String, Option[TypeExpr])]) -> Bool {
+/// Whether this EFn was already transformed by a prior run of this pass.
+/// Codex P1 on #1869: a bare `starts_with(pname, "__dict_")` prefix test let a
+/// USER-WRITTEN parameter that merely borrows the prefix (`__dict_dummy: Int`
+/// is a legal identifier) exempt the whole function from threading AND from
+/// the #1858 witness-carrier validation — `vibe check` stayed clean while the
+/// body's `T::m` reached codegen unresolved. The generated shape is exact and
+/// checkable instead: `thread_dict_params` prepends `__dict_<Trait>_<Tparam>`
+/// where `(Tparam, Trait)` is one of THIS function's own bound pairs (the
+/// transform preserves `bounds`, see rewrite_stmt's SLet arm), so only that
+/// exact first-parameter name counts as "already threaded".
+fn already_threaded(bounds: Array[(String, Array[String])], params: Array[(String, Option[TypeExpr])]) -> Bool {
   if Array::length(params) == 0 {
     false
   } else {
     let (pname, _) = Array::get(params, 0)
-    String::starts_with(pname, "__dict_")
+    let mut found = false
+    let mut bi = 0
+    while bi < Array::length(bounds) {
+      let (tp, trait_list) = Array::get(bounds, bi)
+      let mut ti = 0
+      while ti < Array::length(trait_list) {
+        let tr = Array::get(trait_list, ti)
+        if tr != "" && pname == dict_param_name(tr, tp) {
+          found = true
+        } else {
+          ()
+        }
+        ti = ti + 1
+      }
+      bi = bi + 1
+    }
+    found
   }
 }
 
@@ -1516,7 +1542,7 @@ fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[Ty
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SLet(_, _, fname, _, body) => match body {
-        EFn(_, bounds, params, _, _, _) => if already_threaded(params) {
+        EFn(_, bounds, params, _, _, _) => if already_threaded(bounds, params) {
           ()
         } else {
           let threaded = empty_threaded()
@@ -1609,7 +1635,7 @@ export fn collect_undispatchable_trait_method_errors(stmts: Array[Stmt], env: Ty
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SLet(_, _, fname, _, body) => match body {
-        EFn(_, bounds, params, _, _, fbody) => if already_threaded(params) {
+        EFn(_, bounds, params, _, _, fbody) => if already_threaded(bounds, params) {
           ()
         } else {
           let mut bi = 0

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1366,40 +1366,58 @@ fn empty_dict_binds() -> Array[(String, String, String, Array[String])] {
   array_empty()
 }
 
-/// A function already carries a threaded dict parameter (idempotency guard
-/// against desugaring the same stmts twice while bounds are still present).
-/// Whether this EFn was already transformed by a prior run of this pass.
-/// Codex P1 on #1869: a bare `starts_with(pname, "__dict_")` prefix test let a
-/// USER-WRITTEN parameter that merely borrows the prefix (`__dict_dummy: Int`
-/// is a legal identifier) exempt the whole function from threading AND from
-/// the #1858 witness-carrier validation — `vibe check` stayed clean while the
-/// body's `T::m` reached codegen unresolved. The generated shape is exact and
-/// checkable instead: `thread_dict_params` prepends `__dict_<Trait>_<Tparam>`
-/// where `(Tparam, Trait)` is one of THIS function's own bound pairs (the
-/// transform preserves `bounds`, see rewrite_stmt's SLet arm), so only that
-/// exact first-parameter name counts as "already threaded".
+/// Whether this EFn was already transformed by a prior run of this pass
+/// (idempotency guard against desugaring the same stmts twice while bounds
+/// are still present).
+///
+/// Codex P1 on #1869 (twice): a bare `starts_with(pname, "__dict_")` prefix
+/// test let a USER-WRITTEN parameter that merely borrows the prefix
+/// (`__dict_dummy: Int` is a legal identifier) exempt the whole function from
+/// threading AND from the #1858 witness-carrier validation — and a name-only
+/// exact match still left the same hole for a parameter spelled exactly
+/// `__dict_<Trait>_<Tparam>`. So the guard now demands the FULL generated
+/// shape from `thread_dict_params`: first parameter named
+/// `__dict_<Trait>_<Tparam>` AND annotated `<Trait>Dict[<Tparam>]`, for one
+/// of THIS function's own bound pairs (the transform preserves `bounds`, see
+/// rewrite_stmt's SLet arm). User source cannot pass this at check time: the
+/// `<Trait>Dict` witness struct is synthesized by this pass, which runs after
+/// checking, so a hand-written `x: DefaultDict[T]` annotation is an unknown
+/// type to the checker while the genuinely generated shape (re-checked or
+/// re-desugared downstream) matches exactly.
 fn already_threaded(bounds: Array[(String, Array[String])], params: Array[(String, Option[TypeExpr])]) -> Bool {
   if Array::length(params) == 0 {
     false
   } else {
-    let (pname, _) = Array::get(params, 0)
-    let mut found = false
-    let mut bi = 0
-    while bi < Array::length(bounds) {
-      let (tp, trait_list) = Array::get(bounds, bi)
-      let mut ti = 0
-      while ti < Array::length(trait_list) {
-        let tr = Array::get(trait_list, ti)
-        if tr != "" && pname == dict_param_name(tr, tp) {
-          found = true
-        } else {
-          ()
+    let (pname, ann) = Array::get(params, 0)
+    match ann {
+      Some(TyApp(dname, targs)) => if Array::length(targs) == 1 {
+        let mut found = false
+        let mut bi = 0
+        while bi < Array::length(bounds) {
+          let (tp, trait_list) = Array::get(bounds, bi)
+          let elem_is_tp = match Array::get(targs, 0) {
+            TyName(tn) => tn == tp,
+            _ => false
+          }
+          let mut ti = 0
+          while ti < Array::length(trait_list) {
+            let tr = Array::get(trait_list, ti)
+            if tr != "" && elem_is_tp && pname == dict_param_name(tr, tp) && dname == dict_struct_name(tr) {
+              found = true
+              ti = Array::length(trait_list)
+              bi = Array::length(bounds) - 1
+            } else {
+              ti = ti + 1
+            }
+          }
+          bi = bi + 1
         }
-        ti = ti + 1
-      }
-      bi = bi + 1
+        found
+      } else {
+        false
+      },
+      _ => false
     }
-    found
   }
 }
 
@@ -1635,9 +1653,33 @@ export fn collect_undispatchable_trait_method_errors(stmts: Array[Stmt], env: Ty
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SLet(_, _, fname, _, body) => match body {
-        EFn(_, bounds, params, _, _, fbody) => if already_threaded(bounds, params) {
-          ()
-        } else {
+        EFn(_, bounds, params, _, _, fbody) => {
+          // Codex P1 on #1869 (round 2): the `__dict_` parameter-name prefix
+          // is RESERVED for the dict-passing desugar's generated witness
+          // parameters. Genuinely generated parameters never reach the
+          // checker (desugar_trait_dicts runs post-check, and the printed
+          // bundles carry no threaded params — verified), so at check time
+          // any such name is user-written. Rejecting it outright is what
+          // makes already_threaded's shape test sound: without this, a
+          // parameter spelled exactly `__dict_<Trait>_<T>` (any annotation —
+          // the checker tolerates unknown annotation types, measured) would
+          // fake threading, skip both build_gens and this validation, and
+          // resurrect the check-clean/codegen-ICE hole.
+          let mut pi = 0
+          while pi < Array::length(params) {
+            let (pname, _) = Array::get(params, pi)
+            if String::starts_with(pname, "__dict_") {
+              let rmsg = String::concat(fname, String::concat(": parameter `", String::concat(pname, "` uses the reserved `__dict_` prefix (compiler-generated witness dictionaries) — rename the parameter.")))
+              if str_array_contains(out, rmsg) {
+                ()
+              } else {
+                Array::push(out, rmsg)
+              }
+            } else {
+              ()
+            }
+            pi = pi + 1
+          }
           let mut bi = 0
           while bi < Array::length(bounds) {
             let (tp, trait_list) = Array::get(bounds, bi)

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -45,6 +45,10 @@ fn normalize_dot_calls(stmts: Array[Stmt]) -> Array[Stmt]
 // verbatim from codegen/common_base; common_base re-exports these contracts for
 // source compatibility with existing codegen callers.
 fn inject_trait_method_generics(stmts: Array[Stmt]) -> Unit
+// #1858: checker-facing mirror of build_gens' witness-threading capability —
+// a bounded generic whose body references `T::m` without a witness-carrying
+// parameter is reported here instead of ICE-ing in codegen.
+fn collect_undispatchable_trait_method_errors(stmts: Array[Stmt], env: TypeEnv) -> Array[String]
 fn exn_kind_read_expr() -> Expr
 fn exn_msg_read_expr() -> Expr
 fn ensure_exn_kind_cell(stmts: Array[Stmt]) -> Unit

--- a/lib/@vibe/compiler/tests/checker_undispatchable_trait_method_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_undispatchable_trait_method_test.vibe
@@ -1,0 +1,74 @@
+//# Imports
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+/// First checker error message for `source`, or "" when it checks clean.
+/// (check_program throws the first collected diagnostic.)
+fn first_check_error(source: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+//# Misc
+
+// #1858: a bounded generic whose body calls `T::m` (a method of a
+// method-bearing trait) but whose signature carries no witness for `T` used to
+// sail through `vibe check` and die in codegen with an internal compiler
+// error ("`T::default` reached code generation unresolved"). The checker now
+// mirrors the dict-passing desugar's threading capability (build_gens in
+// desugar_trait_dict.vibe) and reports an actionable diagnostic instead.
+
+test "zero-arg trait method without witness carrier is rejected at check time" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn make_default[T: Default]() -> T { T::default() }\nfn main() -> Int { 0 }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "make_default"))
+  assert(String::contains(msg, "T::default"))
+  assert(String::contains(msg, "cannot be dispatched"))
+  assert(String::contains(msg, "Array[T]"))
+}
+
+test "value-position reference without carrier is rejected too" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn grab[T: Default]() -> Int { let f = T::default\n  0 }\nfn main() -> Int { 0 }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "T::default"))
+  assert(String::contains(msg, "cannot be dispatched"))
+}
+
+test "supertrait method without carrier is rejected through the child bound" {
+  let src = "trait Base { default() -> Self }\ntrait Child: Base\nimpl Base for Int { default() -> Int { 0 } }\nfn mk[T: Child]() -> T { T::default() }\nfn main() -> Int { 0 }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "T::default"))
+  assert(String::contains(msg, "cannot be dispatched"))
+}
+
+test "direct T parameter carries the witness (stays accepted)" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn fresh[T: Default](witness: T) -> T { T::default() }\nfn main() -> Int { fresh(5) }\n"
+  assert(first_check_error(src) == "")
+}
+
+test "Array[T] parameter carries the witness (stays accepted)" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn refill[T: Default](xs: Array[T]) -> Unit { Array::set(xs, 0, T::default()) }\nfn main() -> Int { let a = [1]\n  refill(a)\n  Array::get(a, 0) }\n"
+  assert(first_check_error(src) == "")
+}
+
+test "bound without any body reference to the method stays accepted" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn tag[T: Default]() -> Int { 7 }\nfn main() -> Int { tag() }\n"
+  assert(first_check_error(src) == "")
+}
+
+test "marker trait bound without carrier stays accepted (no methods to call)" {
+  let src = "trait Marker\nimpl Marker for Int\nfn note[T: Marker]() -> Int { 1 }\nfn main() -> Int { note() }\n"
+  assert(first_check_error(src) == "")
+}

--- a/lib/@vibe/compiler/tests/checker_undispatchable_trait_method_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_undispatchable_trait_method_test.vibe
@@ -72,3 +72,19 @@ test "marker trait bound without carrier stays accepted (no methods to call)" {
   let src = "trait Marker\nimpl Marker for Int\nfn note[T: Marker]() -> Int { 1 }\nfn main() -> Int { note() }\n"
   assert(first_check_error(src) == "")
 }
+
+// Codex P1 on #1869: a USER-WRITTEN parameter that merely borrows the
+// "__dict_" prefix must not exempt the function — already_threaded now
+// verifies the exact generated name (`__dict_<Trait>_<T>` for one of the
+// fn's own bound pairs), so this carrier-less fn is rejected, not ICE'd.
+test "a user param merely prefixed __dict_ does not fake threading" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn sneaky[T: Default](__dict_dummy: Int) -> T { T::default() }\nfn main() -> Int { 0 }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "T::default"))
+  assert(String::contains(msg, "cannot be dispatched"))
+}
+
+test "a __dict_-prefixed user param plus a real carrier stays accepted" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn odd_name[T: Default](__dict_dummy: Int, witness: T) -> T { T::default() }\nfn main() -> Int { odd_name(1, 5) }\n"
+  assert(first_check_error(src) == "")
+}

--- a/lib/@vibe/compiler/tests/checker_undispatchable_trait_method_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_undispatchable_trait_method_test.vibe
@@ -73,18 +73,38 @@ test "marker trait bound without carrier stays accepted (no methods to call)" {
   assert(first_check_error(src) == "")
 }
 
-// Codex P1 on #1869: a USER-WRITTEN parameter that merely borrows the
-// "__dict_" prefix must not exempt the function — already_threaded now
-// verifies the exact generated name (`__dict_<Trait>_<T>` for one of the
-// fn's own bound pairs), so this carrier-less fn is rejected, not ICE'd.
-test "a user param merely prefixed __dict_ does not fake threading" {
+// Codex P1 on #1869 (both rounds): user-written parameters cannot borrow the
+// generated witness namespace. A name-only or shape-only guard always leaves
+// a spelling that fakes threading (the checker tolerates unknown annotation
+// types, so even `__dict_Default_T: DefaultDict[T]` passes the annotation
+// route), so the `__dict_` prefix is simply RESERVED at check time —
+// genuinely generated parameters never reach the checker.
+
+test "a user param merely prefixed __dict_ is rejected as reserved" {
   let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn sneaky[T: Default](__dict_dummy: Int) -> T { T::default() }\nfn main() -> Int { 0 }\n"
   let msg = first_check_error(src)
-  assert(String::contains(msg, "T::default"))
-  assert(String::contains(msg, "cannot be dispatched"))
+  assert(String::contains(msg, "sneaky"))
+  assert(String::contains(msg, "__dict_dummy"))
+  assert(String::contains(msg, "reserved"))
 }
 
-test "a __dict_-prefixed user param plus a real carrier stays accepted" {
-  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn odd_name[T: Default](__dict_dummy: Int, witness: T) -> T { T::default() }\nfn main() -> Int { odd_name(1, 5) }\n"
-  assert(first_check_error(src) == "")
+test "the exact generated dict name cannot fake threading" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn sneaky[T: Default](__dict_Default_T: Int) -> T { T::default() }\nfn main() -> Int { 0 }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "__dict_Default_T"))
+  assert(String::contains(msg, "reserved"))
+}
+
+test "the full generated dict shape (name + Dict annotation) cannot fake threading" {
+  let src = "trait Default { default() -> Self }\nimpl Default for Int { default() -> Int { 0 } }\nfn sneaky[T: Default](__dict_Default_T: DefaultDict[T]) -> T { T::default() }\nfn main() -> Int { 0 }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "__dict_Default_T"))
+  assert(String::contains(msg, "reserved"))
+}
+
+test "reserved prefix is rejected on unbounded functions too" {
+  let src = "fn plain(__dict_x: Int) -> Int { __dict_x }\nfn main() -> Int { plain(1) }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "__dict_x"))
+  assert(String::contains(msg, "reserved"))
 }


### PR DESCRIPTION
Closes #1858.

## 問題

`[T: Tr]` bound を持つ generic の本文が `T::m`(method-bearing trait のメソッド)を参照しているのに、signature に witness を運ぶ引数が無い場合、`vibe check` は clean を返すのに build が codegen の ICE で落ちていた:

```
internal compiler error: `T::default` (local, @call) reached code generation unresolved. ...
```

「型検査を通り抜けて codegen で初めて落ちる」パターン(CLAUDE.md の実装都合リークの兆候そのもの)で、#1847 の builtin `Default` trait 実装 (PR #1857) 中に実測した。

## 修正

dict-passing desugar の `build_gens` が witness を thread できる条件は signature だけから決まる — `T` 型の引数 (`find_recv_index`) / `Array[T]` 引数 (#1199, `find_array_elem_recv_index`) / bounded generic-impl method (`collect_generic_impl_types`)。そのどれも無い bounded generic は `gens` に登録されず、本文の `T::m` は書き換えられないまま codegen に到達する。

新設の `collect_undispatchable_trait_method_errors` はこの条件を checker 向けにミラーし、**`build_gens` の隣**(`desugar_trait_dict.vibe`)に置いた — 将来 receiver 種別が増えたとき条件がドリフトしない配置。standalone / with_env(FS レーン)両方の check_program パイプラインに配線し、行動可能な診断を返す:

```
make_default: `T::default` cannot be dispatched here: no parameter of `make_default` carries the `[T: Default]` witness. Add a parameter of type `T` (or `Array[T]`) so call sites can supply the impl, or call `default` on a concrete type instead.
```

trait のメソッド表は checked env から引く (`trait_method_sig_binders_deep`) ので、**import された trait**(@vibe/core の `Default` 等)や supertrait 経由のメソッドもカバーする。marker trait はメソッドを持たないため、この検査は inert(従来どおり)。

## Codex P1 対応 (2 ラウンド)

round 1 (67823f4): `already_threaded` の `__dict_` prefix 判定はユーザーが書ける識別子で偽装できた → bounds 照合の shape 検証に強化。

round 2 (1b66822): 自己レビューで round 1 の残穴を stage2 実機で実証 — 生成名と完全一致する `__dict_Default_T` は name 照合を通過し、さらに checker が未知の型注釈を許容する(実測)ため annotation 併用でも `__dict_Default_T: DefaultDict[T]` が残る。最終形は Codex の提案どおり **`__dict_` 引数 prefix を check 時に予約語として一律拒否**。生成 dict 引数は check を通らない(desugar は check 後に走り、bundle にも threaded param は存在しない — 実物確認)ので誤爆しない。`already_threaded` は name+annotation の full-shape 照合として desugar 再実行の冪等性ガードに残す。

## テスト

- `lib/@vibe/compiler/tests/checker_undispatchable_trait_method_test.vibe`(11 件): negative 3(zero-arg method / value-position 参照 / supertrait 経由)+ positive 4(`T` carrier / `Array[T]` carrier / メソッド未参照の bound / marker trait)+ 予約 prefix 4(裸 prefix / 生成名完全一致 / full shape / unbounded fn)
- cheatsheet の boundary 記述を新診断に合わせて更新

## 検証 (head 1b66822、ローカル全 green)

- seed → stage1 → stage2 → stage3 selfbuild、**stage2 == stage3 fixpoint 確認**
- e2e: 旧 ICE 再現ケース(`import @vibe/core { Default }` + carrier 無し)が stage2 FS レーンで **ICE ではなく上記の行動可能な診断**を出して reject されることを確認
- e2e: 正常系(witness 引数 / `Array[T]` / derive / user impl)は従来どおり compile + run
- e2e: 予約 `__dict_` prefix が stage2 経由で reject されることを確認
- unit test battery **646/646 passed**
- `scripts/compiler_gate.sh` full gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsB6tvKetLxFH97UrHCJNt