### PR TITLE
feat(async): stream 引数の body-read コンポーネント + serve の async レーン (#1540)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -2822,7 +2822,80 @@ fn lc_exprs_have_spawn_suspend(es: Array[Expr]) -> Bool {
   found
 }
 
+/// #1540 scope 3: which function the Async boundary wraps.
+///
+/// Normally that is `entry_name`. The component lanes compile with the
+/// `__no_entry__` sentinel, though -- a component's surface is its EXPORT, not
+/// an entry -- so nothing ever matched and the boundary could not be built at
+/// all: a serve handler that reads a host stream failed with "requires an
+/// Async-row entry" no matter how it was written.
+///
+/// When there is no entry, the boundary is the exported Async function, and
+/// only when there is EXACTLY ONE. Two of them have no single boundary, and
+/// picking one silently would wrap the wrong function's suspends -- so that
+/// case keeps the old behaviour (no boundary, and the same loud error) rather
+/// than guess.
+fn lc_resolve_boundary_name(stmts: Array[Stmt], entry_name: String) -> String {
+  if lc_defines_top_level(stmts, entry_name) {
+    entry_name
+  } else {
+    let mut found = ""
+    let mut count = 0
+    let mut i = 0
+    while i < Array::length(stmts) {
+      match Array::get(stmts, i) {
+        SLet(exported, _, name, _, EFn(_, _, _, _, eff, _)) => if exported && lc_row_has_label(eff, "Async") {
+          found = name
+          count = count + 1
+        } else {
+          ()
+        },
+        _ => ()
+      }
+      i = i + 1
+    }
+    if count == 1 {
+      found
+    } else {
+      entry_name
+    }
+  }
+}
+
+/// #1540 scope 3: rebind each `HostStream` PARAMETER to the state-3 cell the
+/// read path expects.
+///
+/// A host stream reaches vibe code as `[3, handle]` -- state 3 plus the
+/// readable end's handle -- which `host_stream_named` builds in codegen. A
+/// parameter arrives as the bare handle instead, since that is what the
+/// component ABI hands over, so `host_stream_next(body)` would read state and
+/// handle out of an integer.
+///
+/// The fix is local: shadow the parameter with the cell at the top of the
+/// body, so everything below sees the same shape a named stream produces. This
+/// runs inside the codegen-side lowering prelude, after typechecking, which is
+/// why the cell can be an ordinary array literal here.
+fn lc_wrap_host_stream_params(params: Array[(String, Option[TypeExpr])], body: Expr) -> Expr {
+  let mut out = body
+  let mut i = Array::length(params)
+  while i > 0 {
+    i = i - 1
+    let (pname, pty) = Array::get(params, i)
+    match pty {
+      Some(TyName("HostStream")) => {
+        out = ELet(pname, EArray([
+          EInt(3),
+          EIdent(pname, -1)
+        ]), out, -1)
+      },
+      _ => ()
+    }
+  }
+  out
+}
+
 fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> String {
+  let boundary_name = lc_resolve_boundary_name(stmts, entry_name)
   let mut entry_has_async = false
   let mut user_defines_sleep = false
   let mut has_async_decl = false
@@ -2844,7 +2917,7 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SLet(_, _, name, _, EFn(_, _, _, _, eff, fbody)) => {
-        if name == entry_name && lc_row_has_label(eff, "Async") {
+        if name == boundary_name && lc_row_has_label(eff, "Async") {
           entry_has_async = true
         } else {
           ()
@@ -3399,8 +3472,15 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
       let mut j = 0
       while j < Array::length(stmts) {
         match Array::get(stmts, j) {
-          SLet(exported, is_rec, name, ty, EFn(tps, tbs, params, ret, eff, body)) => if name == entry_name {
-            let wrapped = EHandle(body, [
+          SLet(exported, is_rec, name, ty, EFn(tps, tbs, params, ret, eff, body)) => if name == boundary_name {
+            // The cell rebinding goes INSIDE the handler: it is ordinary code
+            // that runs on entry, not something the boundary needs to see.
+            let with_cells = if hs_machinery {
+              lc_wrap_host_stream_params(params, body)
+            } else {
+              body
+            }
+            let wrapped = EHandle(with_cells, [
               (PCtor("Async::Suspend", [
                 PBind("__entry_slp_req")
               ]), arm)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -1,12 +1,12 @@
 //# Imports
 
 import @vibe/compiler/core {
+  bytebuf_length,
   bytebuf_new,
   bytebuf_push,
   bytebuf_push_buf,
   bytebuf_push_section,
   bytebuf_push_vec_header,
-  bytebuf_length,
   bytebuf_to_bytes,
   leb128_encode_s64,
   leb128_encode_u32

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -6,6 +6,7 @@ import @vibe/compiler/core {
   bytebuf_push_buf,
   bytebuf_push_section,
   bytebuf_push_vec_header,
+  bytebuf_length,
   bytebuf_to_bytes,
   leb128_encode_s64,
   leb128_encode_u32
@@ -22,6 +23,7 @@ import @vibe/compiler/codegen/wasm_emit {
   emit_call,
   emit_code_section,
   emit_data_section,
+  emit_data_section_multi,
   emit_end,
   emit_export_memory,
   emit_export_section,
@@ -2079,6 +2081,409 @@ export fn comp_emit_async_string_component(export_name: String, param_name: Stri
     core_sort_func
   ])
   emit_canon_lift_async_opts(buf, 2, 0, 0, 0, true)
+  emit_comp_export_section(buf, export_name, 0)
+  bytebuf_to_bytes(buf)
+}
+
+/// #1540: where the body-read shape parks its fixed areas -- all below the
+/// memhost realloc's bump start, so the string params it lowers cannot land on
+/// them.
+///   64  "200\n\n" + up to 64 body bytes, plus one slot past them that only
+///       ever holds an OVERRUN byte
+///  300 / 320 / 340  diagnostics, each already carrying the status prefix
+///  512  waitable-set.wait payload[0] / [1]
+let comp_body_read_prefix_offset = 64
+
+let comp_body_read_capacity = 64
+
+let comp_body_read_diag_event = 300
+
+let comp_body_read_diag_status = 320
+
+let comp_body_read_diag_overrun = 340
+
+let comp_body_read_wait_payload = 512
+
+let comp_body_read_heap_start = 1024
+
+/// The status prefix the body is appended to. `vibe serve`'s handler contract
+/// is "STATUS\n<header lines>\n\n<body>", so a bare 200 with no headers is the
+/// prefix plus its blank line.
+fn comp_body_read_prefix_text() -> String {
+  "200\n\n"
+}
+
+/// Diagnostics are STRINGS, not numbers: this export's result is a string, so a
+/// gate that reads the HTTP response can name the broken assumption instead of
+/// only reporting a mismatch. Each carries the prefix so it is still a
+/// well-formed answer.
+fn comp_body_read_diag_event_text() -> String {
+  "200\n\nERR-EVENT"
+}
+
+fn comp_body_read_diag_status_text() -> String {
+  "200\n\nERR-STATUS"
+}
+
+fn comp_body_read_diag_overrun_text() -> String {
+  "200\n\nERR-OVERRUN"
+}
+
+/// #1540: guest core module for the body-read shape -- the emitter twin of
+/// `tools/wasip3_component_probe/http_body_read/guest.wat`'s `$m`.
+///
+/// `string_param_count` strings arrive flattened as (ptr, len) pairs, then ONE
+/// i32 stream handle, and the function returns NOTHING: an async lift delivers
+/// its result through task.return.
+///
+/// The loop is the probe's, and every constant in it is a measurement rather
+/// than a choice (tools/wasip3_component_probe/host_stream_value): BLOCKED is
+/// 0xffffffff, a completion packs `(amount << 4) | code`, the wake event for a
+/// read is 2, the wait payload's SECOND word is the status, and the end of the
+/// stream is reported INLINE by the read that finds the writer gone -- either
+/// as a zero-transfer code 1, or riding along with the final byte. Both
+/// terminal shapes are real and reading again after either one traps, so both
+/// end the loop.
+///
+/// Answering with the bytes it read is the point: a guest that returned a
+/// constant would prove the wiring type-checks, not that anything moved.
+fn comp_generate_body_read_guest_module(export_name: String, string_param_count: Int) -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  // types: 0 = stream.read (handle, ptr, n) -> status; 1 = (handle) -> () for
+  // stream.drop-readable and waitable-set.drop; 2 = () -> handle for
+  // waitable-set.new; 3 = (a, b) -> () for waitable.join and task.return;
+  // 4 = (set, ptr) -> event for waitable-set.wait; 5 = the handler itself.
+  let tc = bytebuf_new()
+  bytebuf_push_vec_header(tc, 6)
+  emit_func_type_raw(tc, [
+    127,
+    127,
+    127
+  ], [
+    127
+  ])
+  emit_func_type_raw(tc, [
+    127
+  ], array_empty())
+  emit_func_type_raw(tc, array_empty(), [
+    127
+  ])
+  emit_func_type_raw(tc, [
+    127,
+    127
+  ], array_empty())
+  emit_func_type_raw(tc, [
+    127,
+    127
+  ], [
+    127
+  ])
+  let handler_params = array_empty()
+  let mut pi = 0
+  while pi < ((string_param_count * 2) + 1) {
+    Array::push(handler_params, 127)
+    pi = pi + 1
+  }
+  emit_func_type_raw(tc, handler_params, array_empty())
+  bytebuf_push_section(out, 1, tc)
+  // imports 0-6 are the canons, then the memory. Local func index = 7.
+  let ic = bytebuf_new()
+  bytebuf_push_vec_header(ic, 8)
+  emit_name(ic, "$root")
+  emit_name(ic, "[async-lower][stream-read-0]body")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 0)
+  emit_name(ic, "$root")
+  emit_name(ic, "[stream-drop-readable-0]body")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 1)
+  emit_name(ic, "$root")
+  emit_name(ic, "[waitable-set-new]")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 2)
+  emit_name(ic, "$root")
+  emit_name(ic, "[waitable-join]")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 3)
+  emit_name(ic, "$root")
+  emit_name(ic, "[waitable-set-wait]")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 4)
+  emit_name(ic, "$root")
+  emit_name(ic, "[waitable-set-drop]")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 1)
+  emit_name(ic, "[export]$root")
+  emit_name(ic, String::concat("[task-return]", export_name))
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 3)
+  emit_name(ic, "env")
+  emit_name(ic, "memory")
+  bytebuf_push(ic, 2)
+  bytebuf_push(ic, 0)
+  leb128_encode_u32(ic, 1)
+  bytebuf_push_section(out, 2, ic)
+  emit_function_section(out, [
+    5
+  ])
+  emit_export_section(out, export_name, 7)
+  // All i32: the stream handle is the last param, and st / ws / ev / total
+  // follow it as locals.
+  let body_local = string_param_count * 2
+  let st = body_local + 1
+  let ws = body_local + 2
+  let ev = body_local + 3
+  let total = body_local + 4
+  let b = bytebuf_new()
+  emit_block_void(b)
+  emit_loop_void(b)
+  // `> capacity`, not `>=`: a body of exactly the capacity still has its
+  // end-of-stream read to go when the producer reports the end separately.
+  // Erroring here would make the advertised capacity one byte smaller, and
+  // only under one of the two terminal shapes.
+  emit_local_get(b, total)
+  emit_i32_const(b, comp_body_read_capacity)
+  emit_i32_gt_u(b)
+  emit_if_void(b)
+  emit_i32_const(b, comp_body_read_diag_overrun)
+  emit_i32_const(b, String::length(comp_body_read_diag_overrun_text()))
+  emit_call(b, 6)
+  emit_return(b)
+  emit_end(b)
+  // One byte at a time: the shape a byte-oriented reader needs, and the worst
+  // case for status handling.
+  emit_local_get(b, body_local)
+  emit_i32_const(b, comp_body_read_prefix_offset + String::length(comp_body_read_prefix_text()))
+  emit_local_get(b, total)
+  emit_i32_add(b)
+  emit_i32_const(b, 1)
+  emit_call(b, 0)
+  emit_local_set(b, st)
+  emit_local_get(b, st)
+  emit_i32_const(b, -1)
+  emit_i32_eq(b)
+  emit_if_void(b)
+  // BLOCKED: park until the producer delivers. UNJOIN before dropping the set
+  // -- dropping a set that still has members traps.
+  emit_call(b, 2)
+  emit_local_set(b, ws)
+  emit_local_get(b, body_local)
+  emit_local_get(b, ws)
+  emit_call(b, 3)
+  emit_local_get(b, ws)
+  emit_i32_const(b, comp_body_read_wait_payload)
+  emit_call(b, 4)
+  emit_local_set(b, ev)
+  emit_local_get(b, body_local)
+  emit_i32_const(b, 0)
+  emit_call(b, 3)
+  emit_local_get(b, ws)
+  emit_call(b, 5)
+  emit_local_get(b, ev)
+  emit_i32_const(b, 2)
+  emit_i32_ne(b)
+  emit_if_void(b)
+  emit_i32_const(b, comp_body_read_diag_event)
+  emit_i32_const(b, String::length(comp_body_read_diag_event_text()))
+  emit_call(b, 6)
+  emit_return(b)
+  emit_end(b)
+  // payload[1] is the completion status; payload[0] is the waitable index.
+  emit_i32_const(b, comp_body_read_wait_payload + 4)
+  emit_i32_load(b, 2, 0)
+  emit_local_set(b, st)
+  emit_end(b)
+  // Nothing transferred = the end of the stream. Any other zero-transfer code
+  // is an assumption that moved: say so loudly rather than answer a truncated
+  // body as if it were complete.
+  emit_local_get(b, st)
+  emit_i32_const(b, 4)
+  emit_i32_shr_u(b)
+  emit_i32_eqz(b)
+  emit_if_void(b)
+  emit_local_get(b, st)
+  emit_i32_const(b, 15)
+  emit_i32_and(b)
+  emit_i32_const(b, 1)
+  emit_i32_ne(b)
+  emit_if_void(b)
+  emit_i32_const(b, comp_body_read_diag_status)
+  emit_i32_const(b, String::length(comp_body_read_diag_status_text()))
+  emit_call(b, 6)
+  emit_return(b)
+  emit_end(b)
+  // past the if, the loop and the block
+  emit_br(b, 2)
+  emit_end(b)
+  emit_local_get(b, total)
+  emit_i32_const(b, 1)
+  emit_i32_add(b)
+  emit_local_set(b, total)
+  // The end can also arrive INLINE with the final byte, and reading again
+  // after that notification traps.
+  emit_local_get(b, st)
+  emit_i32_const(b, 15)
+  emit_i32_and(b)
+  emit_i32_const(b, 1)
+  emit_i32_eq(b)
+  emit_br_if(b, 1)
+  emit_br(b, 0)
+  emit_end(b)
+  emit_end(b)
+  emit_local_get(b, body_local)
+  emit_call(b, 1)
+  // The prefix plus everything read: the answer IS the request body.
+  emit_i32_const(b, comp_body_read_prefix_offset)
+  emit_i32_const(b, String::length(comp_body_read_prefix_text()))
+  emit_local_get(b, total)
+  emit_i32_add(b)
+  emit_call(b, 6)
+  // Hand-built rather than emit_code_section_with_locals, which declares its
+  // locals as i64.
+  let code_sec = bytebuf_new()
+  leb128_encode_u32(code_sec, 1)
+  let fb = bytebuf_new()
+  leb128_encode_u32(fb, 1)
+  leb128_encode_u32(fb, 4)
+  bytebuf_push(fb, 127)
+  bytebuf_push_buf(fb, b)
+  bytebuf_push(fb, 11)
+  leb128_encode_u32(code_sec, bytebuf_length(fb))
+  bytebuf_push_buf(code_sec, fb)
+  bytebuf_push_section(out, 10, code_sec)
+  emit_data_section_multi(out, [
+    comp_body_read_prefix_offset,
+    comp_body_read_diag_event,
+    comp_body_read_diag_status,
+    comp_body_read_diag_overrun
+  ], [
+    string_to_data(comp_body_read_prefix_text()),
+    string_to_data(comp_body_read_diag_event_text()),
+    string_to_data(comp_body_read_diag_status_text()),
+    string_to_data(comp_body_read_diag_overrun_text())
+  ])
+  bytebuf_to_bytes(out)
+}
+
+/// #1540: the whole body-read component, assembled from the emitters -- the
+/// emitter twin of the http_body_read probe, and the shape the serve emitter
+/// has to produce once a vibe handler can name a stream parameter.
+///
+/// What is new here over `comp_emit_async_string_component` is the STREAM
+/// PARAMETER: the component functype's last param is a type INDEX rather than
+/// a primitive valtype, and the guest reaches the handle behind it through the
+/// stream canons, which have to be declared and instantiated around it.
+///
+/// Instance / index layout, in emission order:
+///   core module    0 = memhost+realloc, 1 = guest
+///   core memory    0 = alias(memhost, "memory")
+///   core func      0 = alias(memhost, "cabi_realloc"), 1 = stream.read,
+///                  2 = stream.drop-readable, 3 = waitable-set.new,
+///                  4 = waitable.join, 5 = waitable-set.wait,
+///                  6 = waitable-set.drop, 7 = task.return,
+///                  8 = alias(guest, export_name)
+///   core instance  0 = memhost, 1 = $root (the six canons the guest calls),
+///                  2 = [export]$root (task-return), 3 = env (memory),
+///                  4 = guest
+///   component type 0 = stream u8, 1 = the async functype
+///   component func 0 = the lift
+///
+/// Aliases and canon built-ins share ONE core-func index space in emission
+/// order, so every canon below is numbered by where it appears, not by what it
+/// is -- the same thing that makes the async string component's lift point at
+/// core func 2.
+export fn comp_emit_body_read_component(export_name: String, string_param_names: Array[String], stream_param_name: String) -> Bytes {
+  let buf = bytebuf_new()
+  emit_component_header(buf)
+  emit_core_module_section(buf, comp_generate_memhost_realloc_module(comp_body_read_heap_start))
+  emit_core_module_section(buf, comp_generate_body_read_guest_module(export_name, Array::length(string_param_names)))
+  emit_core_instance_instantiate_section(buf, 0, array_empty())
+  emit_alias_section(buf, 0, [
+    "memory"
+  ], [
+    core_sort_mem
+  ])
+  emit_alias_section(buf, 0, [
+    "cabi_realloc"
+  ], [
+    core_sort_func
+  ])
+  emit_comp_stream_type_section(buf, comp_valtype_u8)
+  emit_canon_stream_read(buf, 0, 0)
+  emit_canon_stream_drop_readable(buf, 0)
+  emit_canon_waitable_set_new(buf)
+  emit_canon_waitable_join(buf)
+  emit_canon_waitable_set_wait(buf, 0)
+  emit_canon_waitable_set_drop(buf)
+  emit_canon_task_return_opts(buf, comp_valtype_string, 0, true)
+  // The stream param's valtype is the stream TYPE INDEX (0), not a primitive
+  // code. The component model's valtype encoding is a single byte for the
+  // primitives (0x73..0x7f) and a LEB type index otherwise, so a small index
+  // and a primitive are told apart by value -- which is why this reads as a
+  // bare 0 next to `comp_valtype_string`.
+  let param_names = array_empty()
+  let param_valtypes = array_empty()
+  let mut i = 0
+  while i < Array::length(string_param_names) {
+    Array::push(param_names, Array::get(string_param_names, i))
+    Array::push(param_valtypes, comp_valtype_string)
+    i = i + 1
+  }
+  Array::push(param_names, stream_param_name)
+  Array::push(param_valtypes, 0)
+  emit_comp_async_functype_params(buf, param_names, param_valtypes, comp_valtype_string)
+  emit_core_instance_from_exports_sorted(buf, [
+    "[async-lower][stream-read-0]body",
+    "[stream-drop-readable-0]body",
+    "[waitable-set-new]",
+    "[waitable-join]",
+    "[waitable-set-wait]",
+    "[waitable-set-drop]"
+  ], [
+    core_sort_func,
+    core_sort_func,
+    core_sort_func,
+    core_sort_func,
+    core_sort_func,
+    core_sort_func
+  ], [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6
+  ])
+  emit_core_instance_from_exports(buf, 1, [
+    1
+  ], [
+    String::concat("[task-return]", export_name)
+  ], [
+    7
+  ])
+  emit_core_instance_from_exports_sorted(buf, [
+    "memory"
+  ], [
+    core_sort_mem
+  ], [
+    0
+  ])
+  emit_core_instance_instantiate_args(buf, 1, [
+    "$root",
+    "[export]$root",
+    "env"
+  ], [
+    1,
+    2,
+    3
+  ])
+  emit_alias_section(buf, 4, [
+    export_name
+  ], [
+    core_sort_func
+  ])
+  emit_canon_lift_async_opts(buf, 8, 1, 0, 0, true)
   emit_comp_export_section(buf, export_name, 0)
   bytebuf_to_bytes(buf)
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -7046,6 +7046,188 @@ fn emit_core_instance_from_exports_sorted(buf: Bytes, names: Array[String], sort
   emit_raw_content(buf, content)
 }
 
+/// #1540 scope 4: the ASYNC twin of `comp_generate_string_trampoline_packed`.
+///
+/// Same job -- turn the canonical ABI's (ptr, len) pairs into packed vibe
+/// string values, call the handler, hand the result back -- with the one
+/// difference an async lift forces: the core function returns NOTHING and the
+/// result leaves through `task.return`, so there is no return area to allocate
+/// and no retptr to hand back.
+///
+/// `cabi_realloc` stays, because the LIFT still needs it to lower the caller's
+/// string params into the main memory. Only the result path changes.
+///
+/// Imports (func 0 = target_func, func 1 = task-return), then local funcs
+/// 2 = canon_func and 3 = cabi_realloc -- the extra import shifts every call
+/// index by one against the sync trampoline, which is why this is a separate
+/// generator rather than a flag on that one.
+fn comp_generate_string_trampoline_packed_async(string_param_count: Int, export_name: String) -> Bytes {
+  let buf = bytebuf_new()
+  emit_header(buf)
+  // types: 0 = target_func (i64 x N+1) -> i64; 1 = canon_func (i32 x 2N) -> ();
+  // 2 = cabi_realloc (i32,i32,i32,i32) -> i32; 3 = task.return (i32, i32) -> ()
+  let type_sec = bytebuf_new()
+  bytebuf_push_vec_header(type_sec, 4)
+  emit_func_type_raw(type_sec, comp_repeat_valtype(126, string_param_count + 1), [
+    126
+  ])
+  emit_func_type_raw(type_sec, comp_repeat_valtype(127, string_param_count * 2), array_empty())
+  emit_func_type_raw(type_sec, comp_repeat_valtype(127, 4), [
+    127
+  ])
+  emit_func_type_raw(type_sec, comp_repeat_valtype(127, 2), array_empty())
+  bytebuf_push_section(buf, 1, type_sec)
+  let import_sec = bytebuf_new()
+  leb128_encode_u32(import_sec, 4)
+  emit_name(import_sec, "env")
+  emit_name(import_sec, "target_func")
+  bytebuf_push(import_sec, 0)
+  leb128_encode_u32(import_sec, 0)
+  emit_name(import_sec, "[export]$root")
+  emit_name(import_sec, String::concat("[task-return]", export_name))
+  bytebuf_push(import_sec, 0)
+  leb128_encode_u32(import_sec, 3)
+  emit_name(import_sec, "env")
+  emit_name(import_sec, "__heap_ptr")
+  bytebuf_push(import_sec, 3)
+  bytebuf_push(import_sec, 127)
+  bytebuf_push(import_sec, 1)
+  emit_name(import_sec, "env")
+  emit_name(import_sec, "memory")
+  bytebuf_push(import_sec, 2)
+  bytebuf_push(import_sec, 0)
+  leb128_encode_u32(import_sec, 0)
+  bytebuf_push_section(buf, 2, import_sec)
+  let func_sec = bytebuf_new()
+  leb128_encode_u32(func_sec, 2)
+  leb128_encode_u32(func_sec, 1)
+  leb128_encode_u32(func_sec, 2)
+  bytebuf_push_section(buf, 3, func_sec)
+  let export_sec = bytebuf_new()
+  leb128_encode_u32(export_sec, 2)
+  emit_name(export_sec, "canon_func")
+  bytebuf_push(export_sec, 0)
+  leb128_encode_u32(export_sec, 2)
+  emit_name(export_sec, "cabi_realloc")
+  bytebuf_push(export_sec, 0)
+  leb128_encode_u32(export_sec, 3)
+  bytebuf_push_section(buf, 7, export_sec)
+  let code_sec = bytebuf_new()
+  leb128_encode_u32(code_sec, 2)
+  // canon_func: params 0..2N-1 (i32), local 2N = the packed result (i64).
+  let canon_body = bytebuf_new()
+  leb128_encode_u32(canon_body, 1)
+  leb128_encode_u32(canon_body, 1)
+  bytebuf_push(canon_body, 126)
+  let result_local = string_param_count * 2
+  let mut si = 0
+  while si < string_param_count {
+    // (extend_u(ptr) << 32) | extend_u(len)
+    emit_local_get(canon_body, si * 2)
+    bytebuf_push(canon_body, 173)
+    emit_i64_const(canon_body, 32)
+    bytebuf_push(canon_body, 134)
+    emit_local_get(canon_body, (si * 2) + 1)
+    bytebuf_push(canon_body, 173)
+    bytebuf_push(canon_body, 132)
+    si = si + 1
+  }
+  // Trailing closure-env argument (0 for a top-level function).
+  emit_i64_const(canon_body, 0)
+  emit_call(canon_body, 0)
+  emit_local_set(canon_body, result_local)
+  // task.return(ptr, len) -- the two halves of the packed string value, which
+  // already point into the main memory the canon lifts from. Nothing is
+  // copied and nothing is allocated: this is the whole reason the async shape
+  // needs no return area.
+  emit_local_get(canon_body, result_local)
+  emit_i64_const(canon_body, 32)
+  bytebuf_push(canon_body, 136)
+  bytebuf_push(canon_body, 167)
+  emit_local_get(canon_body, result_local)
+  bytebuf_push(canon_body, 167)
+  emit_call(canon_body, 1)
+  bytebuf_push(canon_body, 11)
+  leb128_encode_u32(code_sec, Bytes::length(canon_body))
+  bytebuf_push_buf(code_sec, canon_body)
+  bytebuf_push_buf(code_sec, comp_generate_bump_realloc_body())
+  bytebuf_push_section(buf, 10, code_sec)
+  bytebuf_to_bytes(buf)
+}
+
+/// #1540: `<count>` copies of one core valtype -- the shape both trampolines
+/// spell out param lists with.
+fn comp_repeat_valtype(valtype: Int, count: Int) -> Array[Int] {
+  let out = new_int_array()
+  let mut i = 0
+  while i < count {
+    Array::push(out, valtype)
+    i = i + 1
+  }
+  out
+}
+
+/// #1540: the `__heap_ptr`-bumping `cabi_realloc` body, LENGTH-PREFIXED for a
+/// code section -- shared by both string trampolines so the allocator the
+/// canonical ABI lowers through cannot drift between the sync and async lanes.
+///
+/// params: 0 = old_ptr, 1 = old_size, 2 = align, 3 = new_size; local 4 = the
+/// aligned pointer. Fresh allocations only: the canonical lowering of bare
+/// string params never reallocates, so old_ptr / old_size are ignored.
+fn comp_generate_bump_realloc_body() -> Bytes {
+  let realloc_body = bytebuf_new()
+  leb128_encode_u32(realloc_body, 1)
+  leb128_encode_u32(realloc_body, 1)
+  bytebuf_push(realloc_body, 127)
+  // p = (heap + align - 1) & (0 - align)
+  bytebuf_push(realloc_body, 35)
+  leb128_encode_u32(realloc_body, 0)
+  emit_local_get(realloc_body, 2)
+  emit_i32_add(realloc_body)
+  emit_i32_const(realloc_body, 1)
+  bytebuf_push(realloc_body, 107)
+  emit_i32_const(realloc_body, 0)
+  emit_local_get(realloc_body, 2)
+  bytebuf_push(realloc_body, 107)
+  bytebuf_push(realloc_body, 113)
+  emit_local_set(realloc_body, 4)
+  // __heap_ptr = p + new_size
+  emit_local_get(realloc_body, 4)
+  emit_local_get(realloc_body, 3)
+  emit_i32_add(realloc_body)
+  bytebuf_push(realloc_body, 36)
+  leb128_encode_u32(realloc_body, 0)
+  // if (__heap_ptr > memory.size << 16) memory.grow(pages needed)
+  bytebuf_push(realloc_body, 35)
+  leb128_encode_u32(realloc_body, 0)
+  bytebuf_push(realloc_body, 63)
+  bytebuf_push(realloc_body, 0)
+  emit_i32_const(realloc_body, 16)
+  bytebuf_push(realloc_body, 116)
+  bytebuf_push(realloc_body, 75)
+  bytebuf_push(realloc_body, 4)
+  bytebuf_push(realloc_body, 64)
+  bytebuf_push(realloc_body, 35)
+  leb128_encode_u32(realloc_body, 0)
+  emit_i32_const(realloc_body, 65535)
+  emit_i32_add(realloc_body)
+  emit_i32_const(realloc_body, 16)
+  bytebuf_push(realloc_body, 118)
+  bytebuf_push(realloc_body, 63)
+  bytebuf_push(realloc_body, 0)
+  bytebuf_push(realloc_body, 107)
+  bytebuf_push(realloc_body, 64)
+  bytebuf_push(realloc_body, 0)
+  bytebuf_push(realloc_body, 26)
+  bytebuf_push(realloc_body, 11)
+  emit_local_get(realloc_body, 4)
+  bytebuf_push(realloc_body, 11)
+  let out = bytebuf_new()
+  leb128_encode_u32(out, Bytes::length(realloc_body))
+  bytebuf_push_buf(out, realloc_body)
+  bytebuf_to_bytes(out)
+}
+
 /// #537: string trampoline for the CURRENT wasi linear backend ABI.
 /// A vibe string value is the packed i64 `(byte_offset << 32) | byte_len`
 /// (mode-invariant: identical under bump and RC; see gen_str_len_body /
@@ -7189,57 +7371,9 @@ export fn comp_generate_string_trampoline_packed(string_param_count: Int) -> Byt
   bytebuf_push(canon_body, 11)
   leb128_encode_u32(code_sec, Bytes::length(canon_body))
   bytebuf_push_buf(code_sec, canon_body)
-  // cabi_realloc body. params: 0=old_ptr 1=old_size 2=align 3=new_size;
-  // local 4 = aligned ptr.
-  let realloc_body = bytebuf_new()
-  leb128_encode_u32(realloc_body, 1)
-  leb128_encode_u32(realloc_body, 1)
-  bytebuf_push(realloc_body, 127)
-  // p = (heap + align - 1) & (0 - align)
-  bytebuf_push(realloc_body, 35)
-  leb128_encode_u32(realloc_body, 0)
-  emit_local_get(realloc_body, 2)
-  emit_i32_add(realloc_body)
-  emit_i32_const(realloc_body, 1)
-  bytebuf_push(realloc_body, 107)
-  emit_i32_const(realloc_body, 0)
-  emit_local_get(realloc_body, 2)
-  bytebuf_push(realloc_body, 107)
-  bytebuf_push(realloc_body, 113)
-  emit_local_set(realloc_body, 4)
-  // __heap_ptr = p + new_size
-  emit_local_get(realloc_body, 4)
-  emit_local_get(realloc_body, 3)
-  emit_i32_add(realloc_body)
-  bytebuf_push(realloc_body, 36)
-  leb128_encode_u32(realloc_body, 0)
-  // if (__heap_ptr > memory.size << 16) memory.grow(pages needed)
-  bytebuf_push(realloc_body, 35)
-  leb128_encode_u32(realloc_body, 0)
-  bytebuf_push(realloc_body, 63)
-  bytebuf_push(realloc_body, 0)
-  emit_i32_const(realloc_body, 16)
-  bytebuf_push(realloc_body, 116)
-  bytebuf_push(realloc_body, 75)
-  bytebuf_push(realloc_body, 4)
-  bytebuf_push(realloc_body, 64)
-  bytebuf_push(realloc_body, 35)
-  leb128_encode_u32(realloc_body, 0)
-  emit_i32_const(realloc_body, 65535)
-  emit_i32_add(realloc_body)
-  emit_i32_const(realloc_body, 16)
-  bytebuf_push(realloc_body, 118)
-  bytebuf_push(realloc_body, 63)
-  bytebuf_push(realloc_body, 0)
-  bytebuf_push(realloc_body, 107)
-  bytebuf_push(realloc_body, 64)
-  bytebuf_push(realloc_body, 0)
-  bytebuf_push(realloc_body, 26)
-  bytebuf_push(realloc_body, 11)
-  emit_local_get(realloc_body, 4)
-  bytebuf_push(realloc_body, 11)
-  leb128_encode_u32(code_sec, Bytes::length(realloc_body))
-  bytebuf_push_buf(code_sec, realloc_body)
+  // The allocator the canonical ABI lowers through, shared with the async
+  // trampoline so the two lanes cannot drift apart.
+  bytebuf_push_buf(code_sec, comp_generate_bump_realloc_body())
   bytebuf_push_section(buf, 10, code_sec)
   bytebuf_to_bytes(buf)
 }
@@ -7375,8 +7509,122 @@ fn comp_generate_host_stub_module(vibe_names: Array[String], vibe_sigs: Array[Ar
   bytebuf_to_bytes(out)
 }
 
-fn comp_emit_string_handler_impl(core_wasm: Bytes, target_func_name: String, export_name: String, param_names: Array[String], stub_vibe: Bool) -> Bytes with Exception {
+/// #1540 scope 4: the ASYNC serve component -- same handler surface as
+/// `comp_emit_component_wasm_string_handler`, lifted async so the handler may
+/// suspend.
+///
+/// A handler that awaits anything (a sleep today, a body read next) cannot go
+/// under the sync lift: it would have to return before it resumes. Async
+/// lifting is what makes suspension expressible, and it moves the result off
+/// the core function's return path onto `task.return`
+/// (tools/wasip3_component_probe/async_string_lift).
+///
+/// There is NO instantiation cycle here, unlike the standalone async shapes:
+/// `task.return` needs a memory, and the memory it needs belongs to the MAIN
+/// core module, which does not import `[task-return]` -- only the trampoline
+/// does, and the trampoline is instantiated after it. That is why this lane
+/// needs no memhost.
+///
+/// Index layout, in emission order:
+///   core module    0 = main, 1 = async trampoline, 2 = host stub
+///   core instance  0 = stub, 1 = main, 2 = env {target, __heap_ptr, memory},
+///                  3 = [export]$root (task-return), 4 = trampoline
+///   core func      0 = alias(main, target), 1 = task.return,
+///                  2 = alias(trampoline, canon_func),
+///                  3 = alias(trampoline, cabi_realloc)
+///   component type 0 = the async functype; component func 0 = the lift
+export fn comp_emit_component_wasm_string_handler_async(core_wasm: Bytes, target_func_name: String, export_name: String, param_names: Array[String]) -> Bytes with Exception {
   let string_param_count = Array::length(param_names)
+  comp_check_string_handler_target(core_wasm, target_func_name, string_param_count)
+  let vibe_stub_names = array_empty()
+  let vibe_stub_sigs = array_empty()
+  comp_collect_handler_host_imports(core_wasm, true, vibe_stub_names, vibe_stub_sigs)
+  let buf = bytebuf_new()
+  emit_component_header(buf)
+  emit_core_module_section(buf, core_wasm)
+  emit_core_module_section(buf, comp_generate_string_trampoline_packed_async(string_param_count, export_name))
+  emit_core_module_section(buf, comp_generate_host_stub_module(vibe_stub_names, vibe_stub_sigs))
+  emit_core_instance_instantiate_section(buf, 2, array_empty())
+  emit_core_instance_instantiate_args(buf, 0, [
+    "wasi_snapshot_preview1",
+    "vibe"
+  ], [
+    0,
+    0
+  ])
+  emit_alias_section(buf, 1, [
+    target_func_name
+  ], [
+    core_sort_func
+  ])
+  emit_alias_section(buf, 1, [
+    "memory"
+  ], [
+    core_sort_mem
+  ])
+  emit_alias_section(buf, 1, [
+    "__heap_ptr"
+  ], [
+    core_sort_global
+  ])
+  // task.return lifts the result OUT of the main memory, so it reads but never
+  // allocates -- `realloc` on this built-in is a hard wasmtime error.
+  emit_canon_task_return_opts(buf, comp_valtype_string, 0, true)
+  emit_core_instance_from_exports_sorted(buf, [
+    "target_func",
+    "__heap_ptr",
+    "memory"
+  ], [
+    core_sort_func,
+    core_sort_global,
+    core_sort_mem
+  ], [
+    0,
+    0,
+    0
+  ])
+  emit_core_instance_from_exports(buf, 1, [
+    1
+  ], [
+    String::concat("[task-return]", export_name)
+  ], [
+    1
+  ])
+  emit_core_instance_instantiate_args(buf, 1, [
+    "env",
+    "[export]$root"
+  ], [
+    2,
+    3
+  ])
+  emit_alias_section(buf, 4, [
+    "canon_func",
+    "cabi_realloc"
+  ], [
+    core_sort_func,
+    core_sort_func
+  ])
+  let comp_param_valtypes = new_int_array()
+  let mut pt = 0
+  while pt < string_param_count {
+    Array::push(comp_param_valtypes, comp_valtype_string)
+    pt = pt + 1
+  }
+  // The functype must ALSO be async: wasmtime rejects the `async` canonopt
+  // against a sync one ("the `async` canonical option requires an async
+  // function type").
+  emit_comp_async_functype_params(buf, param_names, comp_param_valtypes, comp_valtype_string)
+  emit_canon_lift_async_opts(buf, 2, 0, 0, 3, true)
+  emit_comp_export_section(buf, export_name, 0)
+  bytebuf_to_bytes(buf)
+}
+
+/// #1540: the packed-string handler's target-export contract, shared by the
+/// sync and async serve lanes so they cannot disagree about what a handler is.
+///
+/// Core shape is `(i64 x N+1) -> i64`: one i64 per String param plus the
+/// trailing closure-env param every top-level vibe function carries.
+fn comp_check_string_handler_target(core_wasm: Bytes, target_func_name: String, string_param_count: Int) -> Unit with Exception {
   // Validate the target export exists with the packed-string core signature.
   let export_names = array_empty()
   let export_func_indices = new_int_array()
@@ -7420,6 +7668,14 @@ fn comp_emit_string_handler_impl(core_wasm: Bytes, target_func_name: String, exp
   if !target_sig_ok {
     throw("component: '\{target_func_name}' must take \{string_param_count} String params and return String")
   }
+}
+
+/// #1540: the handler's host-import contract, shared by both serve lanes.
+///
+/// `fd_write` is the one host import a handler may keep (stdout). With
+/// `stub_vibe`, `vibe.*` imports are collected for the local stub module
+/// instead of rejected.
+fn comp_collect_handler_host_imports(core_wasm: Bytes, stub_vibe: Bool, vibe_stub_names: Array[String], vibe_stub_sigs: Array[Array[Int]]) -> Unit with Exception {
   // Reject host imports the stub cannot satisfy (stub_vibe additionally
   // hosts `vibe.*` imports with local stubs — see the _stubbed wrapper).
   let imp_modules = array_empty()
@@ -7427,8 +7683,6 @@ fn comp_emit_string_handler_impl(core_wasm: Bytes, target_func_name: String, exp
   let imp_type_indices = new_int_array()
   let imp_type_sigs = array_empty()
   let import_count = parse_core_imports(core_wasm, imp_modules, imp_names, imp_type_indices, imp_type_sigs)
-  let vibe_stub_names = array_empty()
-  let vibe_stub_sigs = array_empty()
   let mut ii = 0
   while ii < import_count {
     let im = Array::get(imp_modules, ii)
@@ -7443,6 +7697,14 @@ fn comp_emit_string_handler_impl(core_wasm: Bytes, target_func_name: String, exp
     }
     ii = ii + 1
   }
+}
+
+fn comp_emit_string_handler_impl(core_wasm: Bytes, target_func_name: String, export_name: String, param_names: Array[String], stub_vibe: Bool) -> Bytes with Exception {
+  let string_param_count = Array::length(param_names)
+  comp_check_string_handler_target(core_wasm, target_func_name, string_param_count)
+  let vibe_stub_names = array_empty()
+  let vibe_stub_sigs = array_empty()
+  comp_collect_handler_host_imports(core_wasm, stub_vibe, vibe_stub_names, vibe_stub_sigs)
   let buf = bytebuf_new()
   emit_component_header(buf)
   emit_core_module_section(buf, core_wasm)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -197,6 +197,9 @@ fn comp_emit_async_string_component(export_name: String, param_name: String, rep
 
 // #1540: the body-read component -- a handler whose last param is a stream.
 fn comp_emit_body_read_component(export_name: String, string_param_names: Array[String], stream_param_name: String) -> Bytes
+
+// #1540: the ASYNC serve lane -- same handler surface, async lift + task.return.
+fn comp_emit_component_wasm_string_handler_async(core_wasm: Bytes, target_func_name: String, export_name: String, param_names: Array[String]) -> Bytes with Exception
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -194,6 +194,9 @@ fn comp_emit_memhost_realloc_fixture() -> Bytes
 
 // #1540: the whole async string component, from the widened emitters alone.
 fn comp_emit_async_string_component(export_name: String, param_name: String, reply: String) -> Bytes
+
+// #1540: the body-read component -- a handler whose last param is a stream.
+fn comp_emit_body_read_component(export_name: String, string_param_names: Array[String], stream_param_name: String) -> Bytes
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -16,6 +16,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_core_imports_stdin_provider,
   comp_emit_async_string_canon_fixture,
   comp_emit_async_string_component,
+  comp_emit_body_read_component,
   comp_emit_component_wasm,
   comp_emit_component_wasm_async,
   comp_emit_component_wasm_async_concurrent_awaits,
@@ -643,6 +644,80 @@ test "component async: reply data stays below the caller allocation region (#154
     9,
     11
   ]) == 1)
+}
+
+/// #1540: the body-read component -- the emitter twin of the http_body_read
+/// probe, and the first emitted shape whose handler takes a STREAM.
+///
+/// The stream param is the part a reader is most likely to misread, so it is
+/// the part this pins: in the component model's valtype encoding a primitive
+/// is a single byte in 0x73..0x7f and anything smaller is a TYPE INDEX, so the
+/// `body` param's `0` is the stream type declared above it, not some empty or
+/// defaulted valtype. Get it wrong and the handler silently takes a different
+/// type.
+///
+/// `scripts/test_http_body_read_probe_gate.sh` runs the emitted component
+/// under `wasmtime serve` against the same POST assertions as the hand-written
+/// probe; this is the always-on half that needs no external tool.
+test "component async: the emitted body-read component takes a stream param (#1540)" {
+  let comp = comp_emit_body_read_component("handler", [
+    "method",
+    "url",
+    "headers"
+  ], "body")
+  // stream<u8> component type: 66 01 7d
+  assert(bytes_contains_seq(comp, [
+    102,
+    1,
+    125
+  ]) == 1)
+  // stream.read with Async + Memory(0): 0f 00 02 06 03 00
+  assert(bytes_contains_seq(comp, [
+    15,
+    0,
+    2,
+    6,
+    3,
+    0
+  ]) == 1)
+  // async functype, 4 params
+  assert(bytes_contains_seq(comp, [
+    67,
+    4
+  ]) == 1)
+  // ... whose last param is "body" typed as TYPE INDEX 0, result string:
+  // 04 'b' 'o' 'd' 'y' 00 | 00 73
+  assert(bytes_contains_seq(comp, [
+    4,
+    98,
+    111,
+    100,
+    121,
+    0,
+    0,
+    115
+  ]) == 1)
+  // the async lift, lifting CORE FUNC 8 -- the guest alias, which lands there
+  // only because the realloc alias and all seven canons precede it in the one
+  // shared core-func index space
+  assert(bytes_contains_seq(comp, [
+    0,
+    0,
+    8,
+    4,
+    6,
+    3,
+    0,
+    4,
+    0,
+    0,
+    1
+  ]) == 1)
+  // the guest reaches the stream through the canons under these names
+  assert(component_bytes_contains(comp, "[async-lower][stream-read-0]body") == 1)
+  assert(component_bytes_contains(comp, "[task-return]handler") == 1)
+  // and its diagnostics are strings, so a failure can name what broke
+  assert(component_bytes_contains(comp, "ERR-OVERRUN") == 1)
 }
 
 test "component async: sync lift carries no async canonopt" {

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -146,6 +146,55 @@ test "validate_serve_handler: rejects a missing handler export" {
   assert(rejected)
 }
 
+/// #1540: `Async` gets its own rejection, because the generic one gives advice
+/// that cannot be followed. `Async` is not a capability and has no operations,
+/// so "discharge the effect with `handle`" sends the reader after something
+/// that does not exist -- the actual answer is that the async serve lane is
+/// not selected by the CLI yet.
+test "validate_serve_handler: an Async handler is rejected with an Async-specific reason (#1540)" {
+  let async_ann = TyFn([
+    TyName("String"),
+    TyName("String"),
+    TyName("String"),
+    TyName("String")
+  ], TyName("String"), Some("Async"))
+  let stmts = [
+    SLet(true, false, "handler", Some(async_ann), efn_of_string_params(serve_handler_param_names()))
+  ]
+  let msg = handle {
+    validate_serve_handler(stmts)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "`Async` handler is not wired up yet"))
+  // The advice the generic arm gives must NOT appear here: there is nothing to
+  // handle, and following it would waste the reader's time.
+  assert(!String::contains(msg, "discharge the effect with `handle`"))
+}
+
+/// The generic arm still answers for real capability effects -- this is a new
+/// branch, not a replacement.
+test "validate_serve_handler: a capability effect keeps the discharge advice (#1540)" {
+  let fs_ann = TyFn([
+    TyName("String"),
+    TyName("String"),
+    TyName("String"),
+    TyName("String")
+  ], TyName("String"), Some("Fs"))
+  let stmts = [
+    SLet(true, false, "handler", Some(fs_ann), efn_of_string_params(serve_handler_param_names()))
+  ]
+  let msg = handle {
+    validate_serve_handler(stmts)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "requires capability effect 'Fs'"))
+  assert(String::contains(msg, "discharge the effect with `handle`"))
+}
+
 test "wit_type_text: Future projects to future, ByteStream to stream<u8> (ADR-0089 D5)" {
   assert(wit_type_text(TyApp("Future", [
     TyName("Int")

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -362,7 +362,18 @@ export fn validate_serve_handler(entry_stmts: Array[Stmt]) -> Unit with Exceptio
       while ei < Array::length(sig_effects) {
         let ename = Array::get(sig_effects, ei)
         if !is_exception_effect_name(ename) {
-          throw("serve: handler requires capability effect '\{ename}'; a serve handler must be a pure function of its request params (discharge the effect with `handle` inside the file)")
+          // `Async` is not a capability and cannot be discharged with
+          // `handle`, so it gets its own answer: telling someone to handle it
+          // sends them after an effect that has no operations to handle. What
+          // it actually needs is the async serve lane
+          // (comp_emit_component_wasm_string_handler_async, #1540), which the
+          // CLI does not select yet -- say THAT rather than misname the
+          // effect. #1540 scope 3/4 is the work that removes this arm.
+          if ename == "Async" {
+            throw("serve: an `Async` handler is not wired up yet -- the async serve lane exists (async lift + task.return) but `vibe serve` still emits the sync one, so the handler cannot suspend (#1540). Drop `with Async` for now; a handler that awaits is the next slice, not something `handle` can discharge here")
+          } else {
+            throw("serve: handler requires capability effect '\{ename}'; a serve handler must be a pure function of its request params (discharge the effect with `handle` inside the file)")
+          }
         }
         ei = ei + 1
       }

--- a/scripts/build_wasi_http_p3_full_adapter.sh
+++ b/scripts/build_wasi_http_p3_full_adapter.sh
@@ -21,6 +21,22 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 OUT_PATH="${1:-$PROJECT_ROOT/_build/http_adapter/vibe_http_p3_full_adapter.component.wasm}"
+# #1540: with VIBE_HTTP_ADAPTER_ASYNC_HANDLER=1 the handler import is declared
+# `async func` and awaited. This is not a style switch: a handler that suspends
+# must be async-LIFTED, and `canon lift ... async` validates only against an
+# async functype -- which is the one the ADAPTER declares. A sync import here
+# makes an async-lifted handler unpluggable
+# (tools/wasip3_component_probe/http_body_read/README.md).
+ASYNC_HANDLER="${VIBE_HTTP_ADAPTER_ASYNC_HANDLER:-0}"
+if [ "$ASYNC_HANDLER" = "1" ]; then
+  HANDLER_IMPORT_DECL="import handler: async func(method: string, url: string, headers: string, body: string) -> string;"
+  # An async import owns its string params (String, not &str) and returns a
+  # future.
+  HANDLER_CALL="handler(method, url, req_headers, req_body).await"
+else
+  HANDLER_IMPORT_DECL="import handler: func(method: string, url: string, headers: string, body: string) -> string;"
+  HANDLER_CALL="handler(&method, &url, &req_headers, &req_body)"
+fi
 TMP_DIR="$(mktemp -d /tmp/vibe_http_p3_full_adapter.XXXXXX)"
 
 cleanup() {
@@ -77,7 +93,7 @@ wit_bindgen::generate!({
         /// vibe handler: (method, url, request-headers, request-body) ->
         ///   "STATUS\n<Header: value lines>\n\n<body>".
         /// request-headers are passed as "name: value\n" lines.
-        import handler: func(method: string, url: string, headers: string, body: string) -> string;
+        $HANDLER_IMPORT_DECL
         include wasi:http/service@0.3.0;
       }
     "#,
@@ -121,7 +137,7 @@ impl Guest for Component {
         let req_body = String::from_utf8_lossy(&req_body_rx.collect().await).into_owned();
 
         // The vibe handler returns "STATUS\n<headers>\n\n<body>" (headers optional).
-        let raw = handler(&method, &url, &req_headers, &req_body);
+        let raw = $HANDLER_CALL;
         let (status_line, rest) = raw.split_once('\n').unwrap_or(("200", raw.as_str()));
         let status_code = status_line.trim().parse::<u16>().unwrap_or(200);
         let (headers_block, body) = rest.split_once("\n\n").unwrap_or(("", rest));

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4229,6 +4229,80 @@ ASEOF
 else
   echo "[compiler-gate] note: wasm-tools/wasmtime absent, skipping the async string component run (#1540)"
 fi
+# #1540 scope 3: a HostStream PARAMETER on the component surface.
+#
+# Two things had to change together for this to compile, and this lane pins
+# both because each is silently undone by the other's absence.
+#
+#   1. The Async boundary is wrapped around `entry_name`, and the component
+#      lanes compile with the `__no_entry__` sentinel -- so nothing ever
+#      matched and no boundary was built. It now falls back to the exported
+#      Async function, and ONLY when there is exactly one.
+#   2. A host stream reaches vibe code as the cell `[3, handle]`, which
+#      `host_stream_named` builds. A PARAMETER arrives as the bare handle, so
+#      the reads would have pulled state and handle out of an integer. The
+#      parameter is now shadowed by the cell at the top of the body.
+#
+# The import list is the assertion that says the stream came from the
+# PARAMETER: `vibe.host_stream_read` present, and NO `host_stream_get$<name>`,
+# which is the named-import lane #1540 ruled out as a composition cycle.
+echo "[compiler-gate] 40c5/40 HostStream parameter on the component surface (#1540)"
+hsdir="_build/_gate_hoststream_param"
+rm -rf "$hsdir"; mkdir -p "$hsdir"
+cat > "$hsdir/handler.vibe" <<'HSEOF'
+export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {
+  let mut total = 0
+  let mut go = true
+  while go {
+    let b = host_stream_next(body)
+    if b < 0 { go = false } else { total = total + b }
+  }
+  "200\n\nsum:\{total}"
+}
+HSEOF
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$hsdir/handler.vibe" "$hsdir/handler.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$hsdir/handler.wasm" ]; then
+  echo "[compiler-gate] FAIL: a HostStream-parameter handler did not compile (#1540)" >&2
+  cat "$hsdir/handler.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if command -v wasm-tools >/dev/null 2>&1; then
+  hs_imports="$(wasm-tools print "$hsdir/handler.wasm" 2>/dev/null | grep -c 'vibe" "host_stream_read"' || true)"
+  [ -n "$hs_imports" ] || hs_imports=0
+  if [ "$hs_imports" = "0" ]; then
+    echo "[compiler-gate] FAIL: the handler does not import vibe.host_stream_read (#1540)" >&2
+    exit 1
+  fi
+  hs_named="$(wasm-tools print "$hsdir/handler.wasm" 2>/dev/null | grep -c 'host_stream_get' || true)"
+  [ -n "$hs_named" ] || hs_named=0
+  if [ "$hs_named" != "0" ]; then
+    echo "[compiler-gate] FAIL: the stream came from a NAMED import, not the parameter (#1540)" >&2
+    exit 1
+  fi
+  echo "[compiler-gate] HostStream parameter: reads via host_stream_read, no named get (#1540)"
+fi
+# The other half: with TWO exported Async functions there is no single
+# boundary, and picking one would wrap the wrong function's suspends. That case
+# must keep failing loudly rather than guess.
+cat > "$hsdir/two.vibe" <<'HSEOF'
+export let handler = (body: HostStream) -> Int with Async {
+  host_stream_next(body)
+}
+
+export let other = (body: HostStream) -> Int with Async {
+  host_stream_next(body)
+}
+HSEOF
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$hsdir/two.vibe" "$hsdir/two.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$hsdir/two.wasm" ]; then
+  echo "[compiler-gate] FAIL: two exported Async functions silently picked a boundary (#1540)" >&2
+  exit 1
+fi
+echo "[compiler-gate] two exported Async functions still refuse to guess a boundary (#1540)"
 # #1746 (RC lane): the raw-ABI shim dispatched on the callee NAME alone, so a
 # program defining its own top-level `fn sleep` had the shim applied to ITS
 # call -- emitting a module that failed validation, with no diagnostic. Only

--- a/scripts/test_http_body_read_probe_gate.sh
+++ b/scripts/test_http_body_read_probe_gate.sh
@@ -179,72 +179,25 @@ case "$ADAPTER_DUMP" in
 esac
 echo "[body-read-probe] adapter imports handler as an async func with a stream<u8> body"
 
-GUEST="$OUT_DIR/guest.wasm"
-wasm-tools parse "$PROBE_DIR/guest.wat" -o "$GUEST"
-wasm-tools validate --features all "$GUEST"
-echo "[body-read-probe] probe guest validates"
-
-COMPOSED="$OUT_DIR/composed.wasm"
-wac plug --plug "$GUEST" "$ADAPTER" -o "$COMPOSED"
-wasm-tools validate --features all "$COMPOSED"
-
-# `wac plug` leaves an unsatisfiable edge as a promoted ROOT IMPORT rather than
-# an error (../http_body_stream/README.md), so assert the composed world, not
-# the exit code.
-COMPOSED_WIT="$(wasm-tools component wit "$COMPOSED")"
-ROOT_IMPORTS="$(printf '%s\n' "$COMPOSED_WIT" | awk '
-  /^world root \{$/ { in_world = 1; next }
-  in_world && /^}/ { exit }
-  in_world && /^[[:space:]]+import / {
-    sub(/^[[:space:]]+/, "")
-    print
-  }
-')"
-if [ "$ROOT_IMPORTS" != 'import wasi:http/types@0.3.0;' ]; then
-  echo "[body-read-probe] FAILED: composed root imports are not exactly the host-provided wasi:http/types edge" >&2
-  printf '%s\n' "$COMPOSED_WIT" | head -20 >&2
-  exit 1
-fi
-echo "[body-read-probe] composed: async handler edge connected; only host wasi:http/types remains"
-
-"$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$COMPOSED" >"$SERVE_LOG" 2>&1 &
-SERVE_PID=$!
-ready=0
-for _ in $(seq 1 40); do
-  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
-    echo "[body-read-probe] FAILED: spawned wasmtime exited before accepting requests" >&2
-    cat "$SERVE_LOG" >&2 || true
-    exit 1
-  fi
-  if curl -s -m 1 -o /dev/null "http://$ADDR/" 2>/dev/null; then
-    ready=1
-    break
-  fi
-  sleep 0.25
-done
-if [ "$ready" != "1" ]; then
-  echo "[body-read-probe] FAILED: spawned wasmtime did not become ready at $ADDR" >&2
-  cat "$SERVE_LOG" >&2 || true
-  exit 1
-fi
-
-# The guest's answer is fully determined -- "200\n\n" followed by exactly the
-# bytes it read -- so assert the WHOLE response, not that the token appears
-# somewhere in it. A reader that duplicated, dropped or padded bytes around an
-# intact token would satisfy a substring check while having corrupted the body,
-# and this gate exists to say the body round-tripped.
+# One POST + one full-response assertion. The guest's answer is fully
+# determined -- "200\n\n" followed by exactly the bytes it read -- so this
+# asserts the WHOLE response rather than that the token appears somewhere in
+# it. A reader that duplicated, dropped or padded bytes around an intact token
+# would satisfy a substring check while having corrupted the body, and this
+# gate exists to say the body round-tripped.
 post_and_check() {
-  local what="$1" body="$2" response_file="$TMP_DIR/response-$1.txt" code out want
+  local label="$1" what="$2" body="$3"
+  local response_file="$TMP_DIR/response-$label-$what.txt" code out want
   code="$(curl -sS --max-time 10 -o "$response_file" -w '%{http_code}' \
     -X POST --data-binary "$body" "http://$ADDR/probe" 2>&1 || true)"
   out="$(cat "$response_file" 2>/dev/null || true)"
   if ! kill -0 "$SERVE_PID" 2>/dev/null; then
-    echo "[body-read-probe] FAILED: spawned wasmtime exited while serving the $what request" >&2
+    echo "[body-read-probe] FAILED [$label]: wasmtime exited while serving the $what request" >&2
     cat "$SERVE_LOG" >&2 || true
     exit 1
   fi
   if [ "$code" != "200" ]; then
-    echo "[body-read-probe] FAILED: $what POST returned '$code' (want 200)" >&2
+    echo "[body-read-probe] FAILED [$label]: $what POST returned '$code' (want 200)" >&2
     cat "$SERVE_LOG" >&2 || true
     exit 1
   fi
@@ -252,20 +205,20 @@ post_and_check() {
   # assumption instead of only reporting a mismatch.
   case "$out" in
     *ERR-EVENT*)
-      echo "[body-read-probe] FAILED: waitable-set.wait returned a non-STREAM_READ event" >&2; exit 1 ;;
+      echo "[body-read-probe] FAILED [$label]: waitable-set.wait returned a non-STREAM_READ event" >&2; exit 1 ;;
     *ERR-STATUS*)
-      echo "[body-read-probe] FAILED: a zero-transfer read reported a code other than the measured CLOSED=1" >&2; exit 1 ;;
+      echo "[body-read-probe] FAILED [$label]: a zero-transfer read reported a code other than the measured CLOSED=1" >&2; exit 1 ;;
     *ERR-OVERRUN*)
-      echo "[body-read-probe] FAILED: $what body overran the probe guest's 64-byte buffer" >&2; exit 1 ;;
+      echo "[body-read-probe] FAILED [$label]: $what body overran the guest's 64-byte buffer" >&2; exit 1 ;;
   esac
   # Compare the FILES, not shell strings. Command substitution drops NUL bytes
   # and trailing newlines, so a guest that returned one byte too many -- the
   # unwritten slot just past what it read -- compared EQUAL as a string while
   # the response was a byte longer than it should be. `cmp` sees it.
-  want="$TMP_DIR/want-$what.txt"
+  want="$TMP_DIR/want-$label-$what.txt"
   printf '200\n\n%s' "$body" >"$want"
   if ! cmp -s "$response_file" "$want"; then
-    echo "[body-read-probe] FAILED: $what response is not exactly '200\\n\\n' + the POSTed body" >&2
+    echo "[body-read-probe] FAILED [$label]: response is not exactly '200\\n\\n' + the POSTed body" >&2
     echo "[body-read-probe]   got  ($(wc -c <"$response_file") bytes): $(od -c "$response_file" | head -4)" >&2
     echo "[body-read-probe]   want ($(wc -c <"$want") bytes): $(od -c "$want" | head -4)" >&2
     cat "$SERVE_LOG" >&2 || true
@@ -273,8 +226,68 @@ post_and_check() {
   fi
 }
 
-post_and_check "token" "$BODY_TOKEN"
-echo "[body-read-probe] POST body came back byte for byte through the guest's stream.read loop"
+# Compose one guest with the adapter, serve it, and run every body assertion
+# against it. Both guests -- the hand-written probe and the one the emitters
+# produce -- go through this same path, so "the emitter twin works" means the
+# identical bar, not a weaker one.
+run_guest_suite() {
+  local label="$1" guest="$2"
+  local composed="$OUT_DIR/composed-$label.wasm"
+
+  wasm-tools validate --features all "$guest"
+  wac plug --plug "$guest" "$ADAPTER" -o "$composed"
+  wasm-tools validate --features all "$composed"
+
+  # `wac plug` leaves an unsatisfiable edge as a promoted ROOT IMPORT rather
+  # than an error (../http_body_stream/README.md), so assert the composed
+  # world, not the exit code.
+  local composed_wit root_imports
+  composed_wit="$(wasm-tools component wit "$composed")"
+  root_imports="$(printf '%s\n' "$composed_wit" | awk '
+    /^world root \{$/ { in_world = 1; next }
+    in_world && /^}/ { exit }
+    in_world && /^[[:space:]]+import / {
+      sub(/^[[:space:]]+/, "")
+      print
+    }
+  ')"
+  if [ "$root_imports" != 'import wasi:http/types@0.3.0;' ]; then
+    echo "[body-read-probe] FAILED [$label]: composed root imports are not exactly the host-provided wasi:http/types edge" >&2
+    printf '%s\n' "$composed_wit" | head -20 >&2
+    exit 1
+  fi
+  echo "[body-read-probe] [$label] composed: async handler edge connected; only host wasi:http/types remains"
+
+  "$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$composed" >"$SERVE_LOG" 2>&1 &
+  SERVE_PID=$!
+  local ready=0
+  for _ in $(seq 1 40); do
+    if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+      echo "[body-read-probe] FAILED [$label]: wasmtime exited before accepting requests" >&2
+      cat "$SERVE_LOG" >&2 || true
+      exit 1
+    fi
+    if curl -s -m 1 -o /dev/null "http://$ADDR/" 2>/dev/null; then
+      ready=1
+      break
+    fi
+    sleep 0.25
+  done
+  if [ "$ready" != "1" ]; then
+    echo "[body-read-probe] FAILED [$label]: wasmtime did not become ready at $ADDR" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+
+  post_and_check "$label" "token" "$BODY_TOKEN"
+  echo "[body-read-probe] [$label] POST body came back byte for byte through the guest's stream.read loop"
+  post_and_check "$label" "64-byte" "$BODY_64"
+  echo "[body-read-probe] [$label] a body of exactly the guest's 64-byte capacity round-trips too"
+
+  kill "$SERVE_PID" 2>/dev/null || true
+  wait "$SERVE_PID" 2>/dev/null || true
+  SERVE_PID=""
+}
 
 # Exactly the buffer's capacity, which is the interesting boundary and not a
 # round number chosen for symmetry: whether it fits depends on WHERE the end of
@@ -289,11 +302,64 @@ if [ "${#BODY_64}" != "64" ]; then
   echo "[body-read-probe] FAILED: the boundary body is ${#BODY_64} bytes, not 64" >&2
   exit 1
 fi
-post_and_check "64-byte" "$BODY_64"
-echo "[body-read-probe] a body of exactly the guest's 64-byte capacity round-trips too"
 
-kill "$SERVE_PID" 2>/dev/null || true
-wait "$SERVE_PID" 2>/dev/null || true
-SERVE_PID=""
+HANDWRITTEN="$OUT_DIR/guest.wasm"
+wasm-tools parse "$PROBE_DIR/guest.wat" -o "$HANDWRITTEN"
+run_guest_suite "handwritten" "$HANDWRITTEN"
 
-echo "[body-read-probe] PASS: a guest can READ the wasi:http request body from its stream<u8> parameter (#1540)"
+# The emitter twin. `comp_emit_body_read_component` assembles the same
+# component from component_codegen.vibe's emitters, and it is held to THIS bar
+# rather than to a byte inspection: a component whose lift points at the wrong
+# core func, or whose stream canons are wired to the wrong instance, still
+# contains every byte a structural check looks for.
+EMITTER_COMPILER="${VIBE_BODY_READ_GATE_COMPILER:-${VIBE_SERVE_CLI_WASM:-${VIBE_ASYNC_GATE_COMPILER:-}}}"
+if [ -z "$EMITTER_COMPILER" ]; then
+  EMITTER_COMPILER="$(ls -t "$PROJECT_ROOT"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -1 || true)"
+fi
+if [ -z "$EMITTER_COMPILER" ] || [ ! -s "$EMITTER_COMPILER" ]; then
+  # Same rule as a missing tool: a local run may skip, a required run may not.
+  # Skipping silently here would mean the emitter half of this gate could rot
+  # while the gate still reported PASS.
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "[body-read-probe] FAILED: no stage2 compiler for the emitter twin (required mode)" >&2
+    exit 1
+  fi
+  echo "[body-read-probe] SKIP: no stage2 compiler, emitter twin not exercised"
+  echo "[body-read-probe] PASS: a guest can READ the wasi:http request body from its stream<u8> parameter (#1540)"
+  exit 0
+fi
+
+REL_OUT="${OUT_DIR#"$PROJECT_ROOT"/}"
+cat >"$OUT_DIR/emit.vibe" <<EMITEOF
+import @vibe/compiler/entry/source_compile/wasi_only {
+  comp_emit_body_read_component
+}
+
+fn main() -> Int with Fs {
+  let m = comp_emit_body_read_component("handler", [
+    "method",
+    "url",
+    "headers"
+  ], "body")
+  Fs::write_bytes("$REL_OUT/emitted-guest.wasm", m)
+  Bytes::length(m)
+}
+EMITEOF
+echo "[body-read-probe] emitting the component from component_codegen.vibe"
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash "$PROJECT_ROOT/scripts/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+  "$EMITTER_COMPILER" "$OUT_DIR/emit.vibe" "$OUT_DIR/emit.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$OUT_DIR/emit.wasm" ]; then
+  echo "[body-read-probe] FAILED: the emitter program did not compile" >&2
+  cat "$OUT_DIR/emit.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" bash "$PROJECT_ROOT/scripts/run_wasm_vibe_host_runner.sh" \
+  --invoke main "$OUT_DIR/emit.wasm" >/dev/null 2>&1 || true
+if [ ! -s "$OUT_DIR/emitted-guest.wasm" ]; then
+  echo "[body-read-probe] FAILED: the emitter wrote no component" >&2
+  exit 1
+fi
+run_guest_suite "emitted" "$OUT_DIR/emitted-guest.wasm"
+
+echo "[body-read-probe] PASS: a guest can READ the wasi:http request body from its stream<u8> parameter, hand-written AND emitted (#1540)"

--- a/scripts/test_serve_async_lift_gate.sh
+++ b/scripts/test_serve_async_lift_gate.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #1540 scope 4: can a `vibe serve` handler component be ASYNC-LIFTED and still
+# serve real HTTP?
+#
+# The existing serve lane (test_wasi_http_p3_full_gate.sh) lifts the handler
+# SYNC. That works only for a handler that never suspends -- and everything
+# #1540 is heading for (reading the request body) suspends. Async lifting is
+# what makes suspension expressible, and it moves the result off the core
+# function's return path onto `task.return`.
+#
+# This gate holds the async lane to the sync lane's own bar, on the same
+# handler fixture: 200 with a body when the request carries `x-token: secret`,
+# 401 without. Same handler, same answers, different lift.
+#
+# What it exercises:
+#   comp_generate_string_trampoline_packed_async   task.return instead of a
+#                                                  retptr, no return area
+#   comp_emit_component_wasm_string_handler_async  async functype + async lift
+#                                                  over the REAL compiled core
+#   build_wasi_http_p3_full_adapter.sh             VIBE_HTTP_ADAPTER_ASYNC_HANDLER=1
+#
+# That last one is not optional and not cosmetic: `canon lift ... async`
+# validates only against an async functype, and the functype in question is the
+# one the ADAPTER declares. A sync import makes an async-lifted handler
+# unpluggable (tools/wasip3_component_probe/http_body_read/README.md).
+#
+# Skips cleanly when cargo / wasm-tools / wac / wasmtime / curl are missing, and
+# fails instead under VIBE_P3_GATE_REQUIRE_TOOLS=1, matching the other P3 gates.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUT_DIR="$PROJECT_ROOT/_build/bench/serve_async_lift/run-$$"
+SERVE_LOG="$OUT_DIR/serve.log"
+HANDLER_SRC="fixtures/serve_handler_smoke.vibe"
+PORT=$((20000 + ($$ % 20000)))
+ADDR="${VIBE_SERVE_ASYNC_GATE_ADDR:-127.0.0.1:$PORT}"
+
+if [ -n "${VIBE_HTTP_GATE_WASMTIME_FLAGS:-}" ]; then
+  read -r -a WASM_FLAGS <<<"$VIBE_HTTP_GATE_WASMTIME_FLAGS"
+else
+  WASM_FLAGS=(-Sp3 -Shttp -W exceptions=y -W concurrency-support=y -W component-model-async=y -W component-model-async-stackful=y)
+fi
+
+missing_tool() {
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "[serve-async] FAILED: $1 not found (required mode)" >&2; exit 1
+  fi
+  echo "[serve-async] SKIP: $1 not found"; exit 0
+}
+for c in cargo wasm-tools wac curl; do
+  command -v "$c" >/dev/null 2>&1 || missing_tool "$c"
+done
+WASMTIME_BIN="$("$PROJECT_ROOT/scripts/wasmtime_bin.sh" 2>/dev/null || command -v wasmtime || true)"
+if [ -z "${WASMTIME_BIN:-}" ] || ! "$WASMTIME_BIN" --version >/dev/null 2>&1; then
+  missing_tool "wasmtime"
+fi
+
+CLI_WASM="${VIBE_SERVE_CLI_WASM:-${VIBE_ASYNC_GATE_COMPILER:-}}"
+if [ -z "$CLI_WASM" ]; then
+  CLI_WASM="$(ls -t "$PROJECT_ROOT"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -1 || true)"
+fi
+if [ -z "$CLI_WASM" ] || [ ! -s "$CLI_WASM" ]; then
+  # A missing compiler is treated like a missing tool rather than a silent
+  # pass: this gate has nothing to assert without one.
+  missing_tool "a stage2 compiler"
+fi
+
+rm -rf "$OUT_DIR"; mkdir -p "$OUT_DIR"
+SERVE_PID=""
+cleanup() {
+  if [ -n "$SERVE_PID" ]; then
+    kill "$SERVE_PID" 2>/dev/null || true
+    wait "$SERVE_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "[serve-async] selfhost cli: $CLI_WASM"
+
+ADAPTER="$OUT_DIR/adapter.component.wasm"
+echo "[serve-async] build the full adapter with an ASYNC handler import"
+VIBE_HTTP_ADAPTER_ASYNC_HANDLER=1 bash "$SCRIPT_DIR/build_wasi_http_p3_full_adapter.sh" "$ADAPTER" >/dev/null
+ADAPTER_WIT="$(wasm-tools component wit "$ADAPTER")"
+case "$ADAPTER_WIT" in
+  *'import handler: async func('*) ;;
+  *)
+    echo "[serve-async] FAILED: VIBE_HTTP_ADAPTER_ASYNC_HANDLER=1 did not produce an async handler import" >&2
+    printf '%s\n' "$ADAPTER_WIT" | head -12 >&2
+    exit 1 ;;
+esac
+echo "[serve-async] adapter imports handler as an async func"
+
+REL_OUT="${OUT_DIR#"$PROJECT_ROOT"/}"
+cat >"$OUT_DIR/emit.vibe" <<EMITEOF
+import @vibe/compiler/entry/source_compile/wasi_only {
+  comp_emit_component_wasm_string_handler_async,
+  compile_file_wasi_only
+}
+
+fn main() -> Int with Fs + Exception {
+  let core = compile_file_wasi_only("$HANDLER_SRC", "__no_entry__")
+  let comp = comp_emit_component_wasm_string_handler_async(core, "handler", "handler", [
+    "method",
+    "url",
+    "headers",
+    "body"
+  ])
+  Fs::write_bytes("$REL_OUT/handler.component.wasm", comp)
+  Bytes::length(comp)
+}
+EMITEOF
+echo "[serve-async] componentize the handler through the async lane"
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+  "$CLI_WASM" "$OUT_DIR/emit.vibe" "$OUT_DIR/emit.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$OUT_DIR/emit.wasm" ]; then
+  echo "[serve-async] FAILED: the componentizer program did not compile" >&2
+  cat "$OUT_DIR/emit.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+VIBE_PREOPEN_DIR="$PROJECT_ROOT" bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" \
+  --invoke main "$OUT_DIR/emit.wasm" >/dev/null 2>&1 || true
+COMPONENT="$OUT_DIR/handler.component.wasm"
+if [ ! -s "$COMPONENT" ]; then
+  echo "[serve-async] FAILED: the async lane produced no component" >&2
+  exit 1
+fi
+wasm-tools validate --features all "$COMPONENT" >/dev/null
+
+# The option set is the async_string_lift probe's, on a REAL compiled core:
+# task.return carries memory + encoding and never realloc, the lift carries all
+# four. Checked on a captured string, never piped into `grep -q` -- grep exits
+# on its first match and `set -o pipefail` would report the SIGPIPE as a failed
+# assertion.
+COMPONENT_DUMP="$(wasm-tools dump "$COMPONENT" 2>/dev/null || true)"
+case "$COMPONENT_DUMP" in
+  *'TaskReturn { result: Some(Primitive(String)), options: [Memory(0), UTF8] }'*) ;;
+  *)
+    echo "[serve-async] FAILED: task.return's option set is not [Memory(0), UTF8]" >&2
+    exit 1 ;;
+esac
+case "$COMPONENT_DUMP" in
+  *'options: [Async, Memory(0), Realloc(3), UTF8]'*) ;;
+  *)
+    echo "[serve-async] FAILED: the handler is not lifted with [Async, Memory(0), Realloc(3), UTF8]" >&2
+    exit 1 ;;
+esac
+case "$COMPONENT_DUMP" in
+  *'ComponentFuncType { async_: true, params: [("method", Primitive(String))'*) ;;
+  *)
+    echo "[serve-async] FAILED: the exported handler's functype is not async" >&2
+    exit 1 ;;
+esac
+echo "[serve-async] handler component: async functype, async lift, string task.return"
+
+COMPOSED="$OUT_DIR/handler.serve.wasm"
+wac plug --plug "$COMPONENT" "$ADAPTER" -o "$COMPOSED"
+wasm-tools validate --features all "$COMPOSED" >/dev/null
+echo "[serve-async] composed with the async adapter"
+
+"$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$COMPOSED" >"$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+ready=0
+for _ in $(seq 1 40); do
+  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+    echo "[serve-async] FAILED: wasmtime exited before accepting requests" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if curl -s -m 1 -o /dev/null "http://$ADDR/" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [ "$ready" != "1" ]; then
+  echo "[serve-async] FAILED: wasmtime did not become ready at $ADDR" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+
+# Both arms of the fixture's own contract. Asserting only the 200 would accept
+# a handler whose branch collapsed -- the 401 is what says the request actually
+# reached the vibe code and was decided there.
+check_request() {
+  local what="$1" want_code="$2" want_body="$3"
+  shift 3
+  local file="$OUT_DIR/response-$what.txt" code
+  code="$(curl -sS --max-time 10 -o "$file" -w '%{http_code}' "$@" "http://$ADDR/hello" 2>&1 || true)"
+  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+    echo "[serve-async] FAILED: wasmtime exited while serving the $what request" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if [ "$code" != "$want_code" ]; then
+    echo "[serve-async] FAILED: $what returned '$code' (want $want_code)" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  # Containment, not equality, and for one specific reason: the adapter splits
+  # the handler's "STATUS\n<headers>\n\n<body>" answer with `split_once("\n\n")`
+  # and falls back to the WHOLE remainder when there is no header block, so the
+  # header-less 401 arm comes back as "\nunauthorized". That is the adapter's
+  # behaviour in both lanes, not something this lift changed -- the sibling
+  # sync gate asserts containment for the same reason.
+  local body
+  body="$(cat "$file" 2>/dev/null || true)"
+  case "$body" in
+    *"$want_body"*) ;;
+    *)
+      echo "[serve-async] FAILED: $what body was '$body' (want it to contain '$want_body')" >&2
+      exit 1 ;;
+  esac
+}
+
+check_request "with-token" 200 "ok:GET:/hello" -H 'x-token: secret'
+check_request "without-token" 401 "unauthorized"
+echo "[serve-async] with x-token -> 200 ok:GET:/hello; without -> 401 unauthorized"
+
+kill "$SERVE_PID" 2>/dev/null || true
+wait "$SERVE_PID" 2>/dev/null || true
+SERVE_PID=""
+
+echo "[serve-async] PASS: a serve handler component can be async-lifted and still serve (#1540)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -76,6 +76,7 @@ case ",$PHASES," in *",http,"*)
   bash "$SCRIPT_DIR/test_wasi_http_p3_full_gate.sh"
   bash "$SCRIPT_DIR/test_http_body_stream_probe_gate.sh"
   bash "$SCRIPT_DIR/test_http_body_read_probe_gate.sh"
+  bash "$SCRIPT_DIR/test_serve_async_lift_gate.sh"
   bash "$SCRIPT_DIR/test_async_string_lift_probe_gate.sh"
   ;;
 esac

--- a/tools/wasip3_component_probe/http_body_read/README.md
+++ b/tools/wasip3_component_probe/http_body_read/README.md
@@ -89,10 +89,28 @@ drops NUL bytes and trailing newlines — a guest returning one byte too many
 (the unwritten slot just past what it read) compared equal as a string and was
 caught only by `cmp`.
 
+## The emitter twin
+
+`comp_emit_body_read_component` (`component_codegen.vibe`) assembles the same
+component from the emitters, and the gate holds it to **this probe's bar**: it
+is composed with the same adapter, served by the same `wasmtime serve`, and
+answers the same two POSTs. Both guests run through one code path in the gate,
+so "the emitter twin works" cannot quietly mean a weaker check.
+
+That is deliberate rather than belt-and-braces. A component whose lift points at
+the wrong core func, or whose stream canons are wired to the wrong instance,
+still contains every byte a structural check looks for — aliases and canon
+built-ins share one core-func index space in emission order, so the guest's own
+export lands at core func 8 only because the realloc alias and all seven canons
+precede it.
+
+This probe stays as the hand-written reference the emitter was measured against.
+
 ## Still open for #1540 scope 3/4
 
-The guest here is hand-written WAT. Emitting it from vibe source needs a way to
-**spell** a `HostStream`-typed handler parameter (#1341 made `host_stream_named`
-return the nominal `HostStream` rather than `Stream[Int]`), and
-`validate_serve_handler` currently requires exactly four `String` params and
+The emitted guest's READER is still fixed: `comp_generate_body_read_guest_module`
+emits the loop, rather than compiling it from vibe source. Closing that needs a
+way to **spell** a `HostStream`-typed handler parameter (#1341 made
+`host_stream_named` return the nominal `HostStream` rather than `Stream[Int]`),
+and `validate_serve_handler` currently requires exactly four `String` params and
 rejects every non-`Exception` effect.


### PR DESCRIPTION
#1540 の emitter 側を 2 段進める。

## 1. body-read コンポーネントを emitter だけで組む (#1860 の emitter twin)

`comp_emit_body_read_component`。#1819 の string component との差分は **stream 引数**で、
component functype の最後の param が primitive valtype ではなく**型インデックス**になる:

```
43 04 06 method 73 03 url 73 07 headers 73 04 body 00 | 00 73
                                              ^^ 型インデックス 0 = stream<u8>
```

component model の valtype 符号化は primitive が 1 バイト (0x73..0x7f)、それより小さい値は型インデックス、
という値による使い分け。ゲストはそのハンドルの先へ 6 つの stream/waitable canon 経由で届く。

**バイト検査では守れない部分がある**: alias と canon built-in は発行順で 1 つの core-func
インデックス空間を共有するので、ゲスト自身の export が core func 8 に落ちるのは realloc alias と
7 つの canon がその前にあるからでしかない。間違ったものを lift していても構造検査は通る。

なのでゲートは**動かす** — emitted component を同じ adapter に wac plug し、同じ `wasmtime serve` で、
同じ 2 つの POST に答えさせる。両ゲストは `run_guest_suite` という**1 つのコードパス**を通る。

## 2. serve の ASYNC レーン (scope 4 の前半)

現在の serve は handler を **sync lift** する。それは suspend しない handler でしか成立せず、
#1540 が向かっている先 (body を読む) は必ず suspend する。

| 追加 | 役割 |
|---|---|
| `comp_generate_string_trampoline_packed_async` | 何も返さず `task.return(ptr, len)`。**戻り領域を確保しない** — 結果は既にメインメモリにある |
| `comp_emit_component_wasm_string_handler_async` | **実際にコンパイルされた core module** に async functype + async lift |
| `build_wasi_http_p3_full_adapter.sh` の `VIBE_HTTP_ADAPTER_ASYNC_HANDLER=1` | handler import を `async func` にして await |

最後のものは必然で、様式の選択ではない: `canon lift ... async` は async functype にしか通らず、
その functype を宣言しているのは **adapter** 側 (#1860 の実測)。

**ここには memhost が要らない**のが単体 async 形との違い。`task.return` はメモリを要るが、
そのメモリは**メインの core module** のもので、メインは `[task-return]` を import しない —
import するのは trampoline だけで、しかも後からインスタンス化される。循環しない。

import が 1 本増える分**全ての call インデックスが sync 版と 1 ずれる**ので、フラグではなく別 generator。
一方 bump `cabi_realloc` の本体は**共有**した (canonical ABI が通るアロケータが 2 レーンで
食い違わないように) — sync serve component を前後で emit して**バイト同一**を確認済み
(sha256 `28a3639f…`)。

検証ブロック 2 つ (target export のシグネチャ / host import) も同じ理由で共有ヘルパへ。
その途中で shadowing バグを 1 つ潰した: 抽出した import ヘルパが out-param を再宣言していて、
呼び出し側の配列が空のまま返るところだった。

## 検証

```
[serve-async] adapter imports handler as an async func
[serve-async] handler component: async functype, async lift, string task.return
[serve-async] composed with the async adapter
[serve-async] with x-token -> 200 ok:GET:/hello; without -> 401 unauthorized
[serve-async] PASS
```

- `scripts/test_serve_async_lift_gate.sh` (新規、p3 gate phase B に配線) — **両アーム**を assert する。
  200 だけ見ると分岐が潰れた handler も通ってしまう
- `scripts/test_http_body_read_probe_gate.sh` — handwritten / emitted 両方 PASS
- `scripts/test_wasi_http_p3_full_gate.sh` (既存 sync レーン) — PASS 継続
- `component_codegen_test.vibe` — body-read の構造を外部ツール無しで固定、**lift を core func 7 に
  向けて red 確認済み**
- sync serve component のバイト同一性
- `scripts/check_vibe_fmt.sh` clean

## フロントエンドは意図的にまだ緩めていない

`validate_serve_handler` は非 Exception effect を今も拒否し、`sleep` を呼ぶ handler は
`vibe.sleep` の import で今も落ちる。**emitter が先** — レーンが無いうちに契約を緩めるのが、
型検査を通ったプログラムが codegen で死ぬ道筋なので。

残り: scope 3 (`HostStream` 引数を entry 境界で受ける — 現状 `__no_entry__` レーンでは
境界機構が発火しない) と、それを踏まえた `validate_serve_handler` の更新。

## 関連

#1540、#1860、#1819、#1807、#1796、#1341