### PR TITLE
refactor(loader): effect Source pilot — resolve-path 3 copy を perform ベースの単一プローブに統一 (#1872 step 2)

### DIFF
--- a/fixtures/effect_source_pilot_test.vibe
+++ b/fixtures/effect_source_pilot_test.vibe
@@ -1,0 +1,76 @@
+// #1872 (#1770 Phase 2) pilot: the `effect Source` pattern the compiler's
+// read-side lane unification depends on. Pins the three properties the
+// design needs beyond plain perform/handle (which effect_handler_test.vibe
+// already covers):
+//   1. handler SWITCHING -- the same effectful body discharged by an
+//      in-memory handler and a disk-stub handler gives lane-appropriate
+//      answers;
+//   2. handler arms answering from CAPTURED outer state (the LSP overlay /
+//      in-memory sources shape) -- a MutMap read inside the arm;
+//   3. a multi-op effect where ops feed each other's control flow
+//      (Exists gates Read).
+// The real-FS discharge of the same pattern is exercised by the compiler
+// itself: loader/header_cache/merge_sources resolve every import through
+// `resolve_import_path_probe` (`with Source`), so the bootstrap gate breaks
+// if perform regresses in those units (#768/#778 was that regression).
+
+import @vibe/core {
+  type MutMap, MutMap::get, MutMap::new_string, MutMap::set
+}
+
+effect Source {
+  Read(String) -> String
+  Exists(String) -> Bool
+}
+
+fn load(path: String) -> Int with Source {
+  if perform Source::Exists(path) {
+    String::length(perform Source::Read(path))
+  } else {
+    0 - 1
+  }
+}
+
+fn with_memory(docs: MutMap[String, String], path: String) -> Int {
+  handle {
+    load(path)
+  } with Source {
+    Read(p) => {
+      let ans = match MutMap::get(docs, p) {
+        Some(s) => s,
+        None => "disk-content"
+      }
+      resume(ans)
+    };
+    Exists(p) => {
+      let ans = match MutMap::get(docs, p) {
+        Some(_) => true,
+        None => p == "on-disk.vibe"
+      }
+      resume(ans)
+    }
+  }
+}
+
+fn with_disk_stub(path: String) -> Int {
+  handle {
+    load(path)
+  } with Source {
+    Read(_) => resume("disk-content");
+    Exists(p) => resume(p == "on-disk.vibe")
+  }
+}
+
+test "overlay handler answers from captured state, falls back to disk" {
+  let docs = MutMap::new_string()
+  MutMap::set(docs, "open-buffer.vibe", "overlay!")
+  // overlay hit: the captured map's entry (8 chars)
+  inspect(with_memory(docs, "open-buffer.vibe"), "8")
+  // overlay miss, exists on "disk": the fallback content (12 chars)
+  inspect(with_memory(docs, "on-disk.vibe"), "12")
+}
+
+test "the same body under the disk-stub handler" {
+  inspect(with_disk_stub("on-disk.vibe"), "12")
+  inspect(with_disk_stub("missing.vibe"), "-1")
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -1104,6 +1104,16 @@ export fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[St
     vhn = vhn + 1
   }
   edp_collect_handle_effect_names(stmts, vhe_names)
+  // #1875: the effect names that actually HAVE a handle site somewhere.
+  // vhe_names is declared-effects ∪ handle-labeled names, so a declared
+  // effect nobody handles is in the loop below -- and
+  // edp_erase_effect_handles is a RECONSTRUCTING walk (it rebuilds every
+  // expression node in the merged program), so running it for a name with
+  // zero handle sites allocated ~10MB of identical AST per unused effect
+  // declaration. Erasing nothing is a no-op: skip the walk outright when
+  // the name never appears on a handle.
+  let vhe_handle_names = empty_str_array()
+  edp_collect_handle_effect_names(stmts, vhe_handle_names)
   let vhe_fn_defs = edp_collect_fn_defs(stmts)
   let vhe_fn_names = edp_all_fn_names(vhe_fn_defs)
   let vhe_inert = edp_pure_fn_names(vhe_fn_defs)
@@ -1111,7 +1121,12 @@ export fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[St
   let mut vhi = 0
   while vhi < Array::length(vhe_names) {
     let vh_name = Array::get(vhe_names, vhi)
-    if edp_program_user_performs(stmts, vh_name) {
+    if !edp_str_array_contains(vhe_handle_names, vh_name) {
+      // No handle site for this effect anywhere in the program: there is
+      // nothing to erase, and both branches below reduce to the identity
+      // walk. Skip them (#1875).
+      ()
+    } else if edp_program_user_performs(stmts, vh_name) {
       // Per-HANDLE vacuity: some sites of this effect may still be
       // provably dead even though the program performs it elsewhere (see
       // edp_body_may_perform). Erasing those is what keeps a client-only
@@ -3392,132 +3407,147 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
   let es_members_list = array_empty()
   edp_es_collect_into(stmts, es_names, es_members_list)
   let plans = array_empty()
+  // #1875: effect names that still have a handle site after vacuous-handle
+  // erasure. An effect with NO row-carrying fn and NO handle site has
+  // nothing to migrate, and the per-effect scans below (shadow drop,
+  // self-discharge drop, the three inert-set builders, eligibility) walk
+  // the whole merged program per effect. One cheap name collection up
+  // front lets those effects skip the loop body entirely.
+  let plan_handle_names = empty_str_array()
+  edp_collect_handle_effect_names(stmts, plan_handle_names)
   let mut ei = 0
   while ei < Array::length(effect_defs) {
     let (ename, ops) = Array::get(effect_defs, ei)
     let needing_all = edp_needing_names(fn_defs, ename, es_names, es_members_list)
-    // Shadowed-name exclusion is ALSO unconditional (#1074 review: a
-    // needing function's name shadowed by a local binding elsewhere in
-    // the program is never safe to leave in `needing` regardless of
-    // dead-code/self-discharge status -- see edp_drop_shadowed_needing's
-    // own doc comment), so it applies before the self-discharging filter.
-    let needing_unshadowed = edp_drop_shadowed_needing(needing_all, stmts)
-    // Self-discharging exclusion is unconditional (a self-discharging
-    // function never needs the dict for itself, dead or not -- see
-    // edp_drop_self_discharging_needing's doc comment), so it applies to
-    // the FULL set before either eligibility attempt below.
-    let needing_sd = edp_drop_self_discharging_needing(needing_unshadowed, stmts, fn_defs, ename)
-    // ADR-0076 追記34 V2: perform-free exclusion -- a row-E fn that cannot
-    // perform E needs no dict and must NOT get one (its call sites may sit
-    // outside any handle; see edp_fn_is_perform_free's doc comment). The
-    // same predicate feeds the pure_fns appends inside eligibility/apply,
-    // so both views classify these names identically.
-    let pf_inert = edp_pure_fn_names(fn_defs)
-    edp_append_free_host_inert_names(stmts, pf_inert)
-    edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pf_inert)
-    edp_append_perform_free_row_fns(stmts, fn_defs, ename, pf_inert)
-    let needing_full = array_empty()
-    let mut pfi = 0
-    while pfi < Array::length(needing_sd) {
-      let pf_nm = Array::get(needing_sd, pfi)
-      if edp_str_array_contains(pf_inert, pf_nm) {
-        ()
-      } else {
-        Array::push(needing_full, pf_nm)
-      }
-      pfi = pfi + 1
-    }
-    // #1261: a needing function's VALUE reaching a slot the migration cannot
-    // follow would prepend the dict parameter at the definition while the
-    // call through that slot stays at the old arity (a wasm signature-
-    // mismatch trap, not a diagnosable failure). Eta-expand those values
-    // first (edp_etawrap_stmts): the wrapper closes over the evidence and
-    // presents the arity the receiving slot expects, which is exactly what
-    // writing the rows out by hand achieves. Whatever the wrapping cannot
-    // reach is then still an escape, and stays a hard error per ADR-0076
-    // 追記34 V2. Both are only relevant while handle sites for E remain:
-    // with none, nothing gets migrated in the first place.
-    let live_sites = Array::length(needing_full) > 0 && Array::length(edp_collect_handle_sites(stmts, ename)) > 0
-    if live_sites {
-      edp_etawrap_stmts(stmts, needing_full, ename, fn_defs, es_names, es_members_list)
-    } else {
+    if Array::length(needing_all) == 0 && !edp_str_array_contains(plan_handle_names, ename) {
+      // Unused effect (#1875): no fn carries its row and nothing handles
+      // it -- there is nothing to plan, and every scan below reduces to
+      // work over empty sets. Skip to the next effect.
       ()
-    }
-    let escaped = if live_sites {
-      edp_needing_escape_stmts(stmts, needing_full, ename, fn_defs, es_names, es_members_list)
     } else {
-      ""
-    }
-    if escaped != "" {
-      Array::push(errs, String::concat(String::concat(String::concat("function `", escaped), String::concat("` carries effect ", ename)), String::concat(String::concat(" and is passed as a VALUE into a slot whose type does not carry that row, so evidence-passing (ADR-0076) cannot reach the call through it (#1261) -- annotate the receiving parameter (and any binding it flows through) with `with ", ename), "`, or call the function directly instead of passing it")))
-    } else {
-      ()
-    }
-    match edp_try_plan_for_effect(stmts, ename, ops, needing_full, fn_defs) {
-      Some(plan) => if escaped == "" {
-        Array::push(plans, plan)
-      } else {
-        ()
-      },
-      None => {
-        // Fall back to dropping provably-DEAD needing functions and retry
-        // ONLY if the full set was ineligible -- trying the full set FIRST
-        // (rather than always dropping dead functions up front) matters:
-        // an independently-safe dead function (e.g. a hoisted closure
-        // whose own body is a bare `perform`, dlh_hoist_expr's row-
-        // backfill fix, 2026-07-23) should stay in `needing` and get
-        // properly migrated like any other safe function -- gc backend
-        // codegen still has to compile it even though it never runs, and
-        // a dead-but-still-present un-rewritten `perform` is exactly as
-        // fatal there as a live one. Dropping dead functions is only a
-        // NET WIN when the full set fails for some OTHER (unsafe, not
-        // dead) member -- see edp_drop_unreachable_needing's doc comment
-        // for why dropping in that case is always safe.
-        let needing_live = edp_drop_unreachable_needing(needing_full, fn_defs, keep)
-        let mut planned2 = false
-        if Array::length(needing_live) == Array::length(needing_full) {
+      // Shadowed-name exclusion is ALSO unconditional (#1074 review: a
+      // needing function's name shadowed by a local binding elsewhere in
+      // the program is never safe to leave in `needing` regardless of
+      // dead-code/self-discharge status -- see edp_drop_shadowed_needing's
+      // own doc comment), so it applies before the self-discharging filter.
+      let needing_unshadowed = edp_drop_shadowed_needing(needing_all, stmts)
+      // Self-discharging exclusion is unconditional (a self-discharging
+      // function never needs the dict for itself, dead or not -- see
+      // edp_drop_self_discharging_needing's doc comment), so it applies to
+      // the FULL set before either eligibility attempt below.
+      let needing_sd = edp_drop_self_discharging_needing(needing_unshadowed, stmts, fn_defs, ename)
+      // ADR-0076 追記34 V2: perform-free exclusion -- a row-E fn that cannot
+      // perform E needs no dict and must NOT get one (its call sites may sit
+      // outside any handle; see edp_fn_is_perform_free's doc comment). The
+      // same predicate feeds the pure_fns appends inside eligibility/apply,
+      // so both views classify these names identically.
+      let pf_inert = edp_pure_fn_names(fn_defs)
+      edp_append_free_host_inert_names(stmts, pf_inert)
+      edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pf_inert)
+      edp_append_perform_free_row_fns(stmts, fn_defs, ename, pf_inert)
+      let needing_full = array_empty()
+      let mut pfi = 0
+      while pfi < Array::length(needing_sd) {
+        let pf_nm = Array::get(needing_sd, pfi)
+        if edp_str_array_contains(pf_inert, pf_nm) {
           ()
         } else {
-          match edp_try_plan_for_effect(stmts, ename, ops, needing_live, fn_defs) {
-            Some(plan2) => {
-              Array::push(plans, plan2)
-              planned2 = true
-            },
-            None => ()
-          }
+          Array::push(needing_full, pf_nm)
         }
-        // ADR-0076 追記34 V1 guard: a program that holds row-E closure
-        // VALUES compiles them under the __ev-taking convention, so a
-        // failed migration cannot silently fall back to replay (an
-        // unmigrated caller would call a migrated closure at the wrong
-        // arity). Hard error; the message names the effect.
-        if !planned2 {
-          let gb = empty_str_array()
-          let gl = array_empty()
-          edp_row_lit_scan(stmts, ename, needing_full, es_names, es_members_list, gb, gl)
-          // Guard scope: only when HANDLE SITES for E remain in the tree.
-          // Zero sites means nothing can fall to replay — the suspend
-          // lane (ADR-0076 Phase 3a/3b) transforms its handles BEFORE
-          // this pass, so a CPS-mode effect's row-E closure values (e.g.
-          // spawn_suspend's `f: () -> T with Async + Exception` param)
-          // follow the STEP convention and are none of edp's business.
-          if Array::length(edp_collect_handle_sites(stmts, ename)) > 0 && (Array::length(gb) > 0 || Array::length(gl) > 0 || edp_any_row_typed_param(stmts, fn_defs, ename, es_names, es_members_list)) {
-            // #1347: name the higher-order operation when that is the cause.
-            // The generic wording below points at "a handle body, a needing
-            // function, or a row-carrying closure literal", none of which the
-            // reader can fix for this shape -- the gap is the OPERATION's
-            // signature, one level away.
-            let ho = edp_higher_order_block_owner(effect_defs, ename)
-            if String::length(ho) > 0 {
-              Array::push(errs, edp_higher_order_error_msg(ename, ho))
+        pfi = pfi + 1
+      }
+      // #1261: a needing function's VALUE reaching a slot the migration cannot
+      // follow would prepend the dict parameter at the definition while the
+      // call through that slot stays at the old arity (a wasm signature-
+      // mismatch trap, not a diagnosable failure). Eta-expand those values
+      // first (edp_etawrap_stmts): the wrapper closes over the evidence and
+      // presents the arity the receiving slot expects, which is exactly what
+      // writing the rows out by hand achieves. Whatever the wrapping cannot
+      // reach is then still an escape, and stays a hard error per ADR-0076
+      // 追記34 V2. Both are only relevant while handle sites for E remain:
+      // with none, nothing gets migrated in the first place.
+      let live_sites = Array::length(needing_full) > 0 && Array::length(edp_collect_handle_sites(stmts, ename)) > 0
+      if live_sites {
+        edp_etawrap_stmts(stmts, needing_full, ename, fn_defs, es_names, es_members_list)
+      } else {
+        ()
+      }
+      let escaped = if live_sites {
+        edp_needing_escape_stmts(stmts, needing_full, ename, fn_defs, es_names, es_members_list)
+      } else {
+        ""
+      }
+      if escaped != "" {
+        Array::push(errs, String::concat(String::concat(String::concat("function `", escaped), String::concat("` carries effect ", ename)), String::concat(String::concat(" and is passed as a VALUE into a slot whose type does not carry that row, so evidence-passing (ADR-0076) cannot reach the call through it (#1261) -- annotate the receiving parameter (and any binding it flows through) with `with ", ename), "`, or call the function directly instead of passing it")))
+      } else {
+        ()
+      }
+      match edp_try_plan_for_effect(stmts, ename, ops, needing_full, fn_defs) {
+        Some(plan) => if escaped == "" {
+          Array::push(plans, plan)
+        } else {
+          ()
+        },
+        None => {
+          // Fall back to dropping provably-DEAD needing functions and retry
+          // ONLY if the full set was ineligible -- trying the full set FIRST
+          // (rather than always dropping dead functions up front) matters:
+          // an independently-safe dead function (e.g. a hoisted closure
+          // whose own body is a bare `perform`, dlh_hoist_expr's row-
+          // backfill fix, 2026-07-23) should stay in `needing` and get
+          // properly migrated like any other safe function -- gc backend
+          // codegen still has to compile it even though it never runs, and
+          // a dead-but-still-present un-rewritten `perform` is exactly as
+          // fatal there as a live one. Dropping dead functions is only a
+          // NET WIN when the full set fails for some OTHER (unsafe, not
+          // dead) member -- see edp_drop_unreachable_needing's doc comment
+          // for why dropping in that case is always safe.
+          let needing_live = edp_drop_unreachable_needing(needing_full, fn_defs, keep)
+          let mut planned2 = false
+          if Array::length(needing_live) == Array::length(needing_full) {
+            ()
+          } else {
+            match edp_try_plan_for_effect(stmts, ename, ops, needing_live, fn_defs) {
+              Some(plan2) => {
+                Array::push(plans, plan2)
+                planned2 = true
+              },
+              None => ()
+            }
+          }
+          // ADR-0076 追記34 V1 guard: a program that holds row-E closure
+          // VALUES compiles them under the __ev-taking convention, so a
+          // failed migration cannot silently fall back to replay (an
+          // unmigrated caller would call a migrated closure at the wrong
+          // arity). Hard error; the message names the effect.
+          if !planned2 {
+            let gb = empty_str_array()
+            let gl = array_empty()
+            edp_row_lit_scan(stmts, ename, needing_full, es_names, es_members_list, gb, gl)
+            // Guard scope: only when HANDLE SITES for E remain in the tree.
+            // Zero sites means nothing can fall to replay — the suspend
+            // lane (ADR-0076 Phase 3a/3b) transforms its handles BEFORE
+            // this pass, so a CPS-mode effect's row-E closure values (e.g.
+            // spawn_suspend's `f: () -> T with Async + Exception` param)
+            // follow the STEP convention and are none of edp's business.
+            if Array::length(edp_collect_handle_sites(stmts, ename)) > 0 && (Array::length(gb) > 0 || Array::length(gl) > 0 || edp_any_row_typed_param(stmts, fn_defs, ename, es_names, es_members_list)) {
+              // #1347: name the higher-order operation when that is the cause.
+              // The generic wording below points at "a handle body, a needing
+              // function, or a row-carrying closure literal", none of which the
+              // reader can fix for this shape -- the gap is the OPERATION's
+              // signature, one level away.
+              let ho = edp_higher_order_block_owner(effect_defs, ename)
+              if String::length(ho) > 0 {
+                Array::push(errs, edp_higher_order_error_msg(ename, ho))
+              } else {
+                Array::push(errs, String::concat(String::concat("effect ", ename), " has closure values whose row carries it (type-directed evidence, ADR-0076 追記34), but its evidence migration is not fully eligible -- a handle body, a needing function, or a row-carrying closure literal calls something the pass cannot see through; replay fallback is not available for closure-value programs"))
+              }
             } else {
-              Array::push(errs, String::concat(String::concat("effect ", ename), " has closure values whose row carries it (type-directed evidence, ADR-0076 追記34), but its evidence migration is not fully eligible -- a handle body, a needing function, or a row-carrying closure literal calls something the pass cannot see through; replay fallback is not available for closure-value programs"))
+              ()
             }
           } else {
             ()
           }
-        } else {
-          ()
         }
       }
     }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -292,3 +292,13 @@ fn external_lib_roots() -> Array[String]
 fn vibe_env_flag(name: String) -> Bool
 fn resolution_env_seed() -> String
 fn resolve_import_path_candidates(base_dir: String, raw_path: String) -> Array[String]
+
+// #1872 (#1770 Phase 2): read-side source-access effect + the unified
+// import-path existence probe (transparent effect definition, #752's
+// contract convention -- the impl keeps its own `export effect Source`).
+effect Source {
+  Read(String) -> String;
+  Exists(String) -> Bool
+}
+
+fn resolve_import_path_probe(base_dir: String, raw_path: String, self_path: String) -> String with Source

--- a/lib/@vibe/compiler/core/module_graph_path.vibe
+++ b/lib/@vibe/compiler/core/module_graph_path.vibe
@@ -482,3 +482,65 @@ export fn resolve_import_path_candidates(base_dir: String, raw_path: String) -> 
     ]
   }
 }
+
+/// #1872 (#1770 Phase 2): the compiler's read-side source-access effect.
+/// The FS lane discharges it with the real capability builtins
+/// (`Fs::exists` / `Fs::read_file`) at the call boundary; an in-memory lane
+/// (tests, LSP overlay) discharges the SAME code with a lookup handler, so
+/// the two lanes can no longer drift (#729/#730/#740/#749 were all
+/// lane-drift bugs). Read-only by design — cache writes stay on `Fs`
+/// (see #1872 for the split rationale). Spelled `Source::*`, deliberately
+/// NOT `Fs::*`: a fn occupying a capability-builtin name hijacks the
+/// perform lowering (recorded in lib/@vibe/fs/index.vpkg).
+export effect Source {
+  Read(String) -> String
+  Exists(String) -> Bool
+}
+
+/// #1872 pilot: THE import-path existence probe, unified from the three
+/// byte-similar FS copies (loader/loader.vibe resolve_path_fs -- no
+/// self-skip, pass self_path = ""; loader/header_cache.vibe resolve_path_fs
+/// and wasi_only/merge_sources.vibe resolve_existing_import_path -- both
+/// with the self-skip) which had already drifted once (the self_path skip
+/// existed in two copies but not the third).
+///
+/// A directory-style import from a same-named facade file resolves its
+/// plain-file candidate to the IMPORTING file itself (`export ./codegen`
+/// inside codegen.vibe -> codegen.vibe): a self-dep is never meant, it only
+/// manufactures "type_db: import cycle detected", so a candidate equal to
+/// `self_path` is skipped. Falls back to the first non-self candidate so a
+/// genuinely missing import still reports its plain-file path (and to
+/// candidates[0] when every candidate was self).
+export fn resolve_import_path_probe(base_dir: String, raw_path: String, self_path: String) -> String with Source {
+  let candidates = resolve_import_path_candidates(base_dir, raw_path)
+  let mut i = 0
+  let mut found = ""
+  let mut fallback = ""
+  while i < Array::length(candidates) {
+    let candidate = Array::get(candidates, i)
+    if candidate == self_path {
+      ()
+    } else {
+      if fallback == "" {
+        fallback = candidate
+      } else {
+        ()
+      }
+      if found == "" && perform Source::Exists(candidate) {
+        found = candidate
+      } else {
+        ()
+      }
+    }
+    i = i + 1
+  }
+  if found == "" {
+    if fallback == "" {
+      Array::get(candidates, 0)
+    } else {
+      fallback
+    }
+  } else {
+    found
+  }
+}

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -19,6 +19,7 @@ import @vibe/compiler/syntax {
 import @vibe/compiler/core {
   ExportRenamePlan,
   Expr,
+  Source,
   Stmt,
   append_import_alias_rewritten_non_import_stmts_with_renames,
   append_non_import_stmts_without_alias_rewrite,
@@ -37,7 +38,6 @@ import @vibe/compiler/core {
   resolve_import_path,
   resolve_import_path_candidates,
   resolve_import_path_probe,
-  Source,
   rewrite_imported_value_stmt_to_local,
   stmts_have_import_deep
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -36,6 +36,8 @@ import @vibe/compiler/core {
   path_set_new,
   resolve_import_path,
   resolve_import_path_candidates,
+  resolve_import_path_probe,
+  Source,
   rewrite_imported_value_stmt_to_local,
   stmts_have_import_deep
 }
@@ -73,37 +75,16 @@ fn string_array_contains_local(items: Array[String], target: String) -> Bool {
 /// to the first candidate so a genuinely missing import still reports its
 /// plain-file path.
 fn resolve_existing_import_path(base_dir: String, raw_path: String, self_path: String) -> String with Fs {
-  let candidates = resolve_import_path_candidates(base_dir, raw_path)
-  let mut i = 0
-  let mut found = ""
-  let mut fallback = ""
-  while i < Array::length(candidates) {
-    let candidate = Array::get(candidates, i)
-    // Skip a candidate that IS the importing file: `export ./codegen` inside
-    // codegen.vibe means the codegen/ directory, never a self-import (which
-    // would only recurse/cycle). Mirrors loader/header_cache.resolve_path_fs.
-    if candidate == self_path {
-      i = i + 1
-    } else if Fs::exists(candidate) {
-      found = candidate
-      i = Array::length(candidates)
-    } else {
-      if fallback == "" {
-        fallback = candidate
-      } else {
-        ()
-      }
-      i = i + 1
-    }
-  }
-  if found == "" {
-    if fallback == "" {
-      Array::get(candidates, 0)
-    } else {
-      fallback
-    }
-  } else {
-    found
+  // #1872 pilot: probe loop unified in core (resolve_import_path_probe,
+  // `with Source`); observable behavior is unchanged (this copy broke out of
+  // the scan early on a hit and set fallback only on a miss, but `found`
+  // guards both continuations, so first-hit/first-non-self-fallback answers
+  // are identical). The wrapper only discharges Source with the builtins.
+  handle {
+    resolve_import_path_probe(base_dir, raw_path, self_path)
+  } with Source {
+    Read(p) => resume(Fs::read_file(p));
+    Exists(p) => resume(Fs::exists(p))
   }
 }
 

--- a/lib/@vibe/compiler/loader/header_cache.vibe
+++ b/lib/@vibe/compiler/loader/header_cache.vibe
@@ -21,6 +21,7 @@ import @vibe/compiler/cache {
 }
 
 import @vibe/compiler/core {
+  Source,
   Stmt,
   dir_of_path,
   ensure_regular_source_fs,
@@ -28,8 +29,7 @@ import @vibe/compiler/core {
   nearest_vpkg_path_fs,
   path_has_relative_prefix,
   resolve_import_path_candidates,
-  resolve_import_path_probe,
-  Source
+  resolve_import_path_probe
 }
 
 import @vibe/compiler/runtime/eval_loader {

--- a/lib/@vibe/compiler/loader/header_cache.vibe
+++ b/lib/@vibe/compiler/loader/header_cache.vibe
@@ -27,7 +27,9 @@ import @vibe/compiler/core {
   is_contract_ext,
   nearest_vpkg_path_fs,
   path_has_relative_prefix,
-  resolve_import_path_candidates
+  resolve_import_path_candidates,
+  resolve_import_path_probe,
+  Source
 }
 
 import @vibe/compiler/runtime/eval_loader {
@@ -44,41 +46,14 @@ import @vibe/compiler/contract {
 //# Functions
 
 fn resolve_path_fs(base_dir: String, raw_path: String, self_path: String) -> String with Fs {
-  let candidates = resolve_import_path_candidates(base_dir, raw_path)
-  let mut i = 0
-  let mut found = ""
-  let mut fallback = ""
-  while i < Array::length(candidates) {
-    let candidate = Array::get(candidates, i)
-    // A directory-style import from a same-named facade file resolves its
-    // plain-file candidate to the IMPORTING file itself (`export ./codegen`
-    // inside codegen.vibe -> codegen.vibe): a self-dep is never meant, it
-    // only manufactures "type_db: import cycle detected". Skip it so the
-    // probe falls through to <dir>/index.vibe(i).
-    if candidate == self_path {
-      ()
-    } else {
-      if fallback == "" {
-        fallback = candidate
-      } else {
-        ()
-      }
-      if found == "" && Fs::exists(candidate) {
-        found = candidate
-      } else {
-        ()
-      }
-    }
-    i = i + 1
-  }
-  if found == "" {
-    if fallback == "" {
-      Array::get(candidates, 0)
-    } else {
-      fallback
-    }
-  } else {
-    found
+  // #1872 pilot: probe loop unified in core (resolve_import_path_probe,
+  // `with Source` -- carries this copy's self-import skip and first-non-self
+  // fallback); this wrapper only discharges Source with the real builtins.
+  handle {
+    resolve_import_path_probe(base_dir, raw_path, self_path)
+  } with Source {
+    Read(p) => resume(Fs::read_file(p));
+    Exists(p) => resume(Fs::exists(p))
   }
 }
 

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -32,6 +32,8 @@ import @vibe/compiler/core {
   path_set_new,
   resolve_import_path,
   resolve_import_path_candidates,
+  resolve_import_path_probe,
+  Source,
   vibe_env_flag,
   vpkg_path_in_dir
 }
@@ -233,27 +235,18 @@ fn resolve_path_in_sources(base_dir: String, raw_path: String, sources: Array[(S
 }
 
 fn resolve_path_fs(base_dir: String, raw_path: String) -> String with Fs {
-  let candidates = resolve_import_path_candidates(base_dir, raw_path)
-  let mut i = 0
-  let mut found = ""
-  while i < Array::length(candidates) {
-    if found == "" {
-      let candidate = Array::get(candidates, i)
-      // #768/#778: direct-call form, not `perform Fs::Exists` -- matches
-      // loader/header_cache.vibe's sibling resolve_path_fs (already
-      // direct-call) and avoids the perform/effect-op crash risk in a
-      // narrow-effect-surface compiled unit.
-      let candidate_exists = Fs::exists(candidate)
-      if candidate_exists {
-        found = candidate
-      }
-    }
-    i = i + 1
-  }
-  if found == "" {
-    Array::get(candidates, 0)
-  } else {
-    found
+  // #1872 pilot: the probe loop lives once in core (resolve_import_path_probe,
+  // `with Source`); this wrapper only discharges Source with the real
+  // capability builtins. self_path = "" -- this call site never needed the
+  // self-import skip (no candidate equals ""). The old #768/#778 direct-call
+  // retreat is deliberately revisited here: `perform Source::Exists` inside
+  // the probe is the pilot's live test of perform in this compiled unit,
+  // pinned by fixtures/effect_source_pilot_test.vibe and the bootstrap gate.
+  handle {
+    resolve_import_path_probe(base_dir, raw_path, "")
+  } with Source {
+    Read(p) => resume(Fs::read_file(p));
+    Exists(p) => resume(Fs::exists(p))
   }
 }
 

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -10,6 +10,7 @@ import @vibe/core {
 
 import @vibe/compiler/core {
   Expr,
+  Source,
   Stmt,
   Subst,
   Type,
@@ -33,7 +34,6 @@ import @vibe/compiler/core {
   resolve_import_path,
   resolve_import_path_candidates,
   resolve_import_path_probe,
-  Source,
   vibe_env_flag,
   vpkg_path_in_dir
 }


### PR DESCRIPTION
## Summary

#1872 (#1770 Phase 2 の設計 issue) の attack order step 2 = pilot。**`effect Source { Read; Exists }` を core に宣言し、import パスの存在プローブを 1 つの `resolve_import_path_probe` (`with Source`) に統一**。既にドリフトしていた 3 つの byte-similar FS copy:

- `loader/loader.vibe` `resolve_path_fs` (self-skip **無し** — `self_path = ""` を渡す)
- `loader/header_cache.vibe` `resolve_path_fs` (self-import skip あり)
- `wasi_only/merge_sources.vibe` `resolve_existing_import_path` (skip あり、early-exit 変種 — 観測等価)

…は、Source を実 capability builtin (`Fs::exists`/`Fs::read_file`) で discharge する薄い wrapper になります。**シグネチャと row は不変** (公開面に変更なし)。

## これが検証していること (#768/#778 の再訪)

loader は過去に「narrow-effect-surface でコンパイルされる unit 内の `perform Fs::Exists` がクラッシュする」(#768/#778) ため直呼びに退避していました (`loader.vibe` 旧コメント)。#1070 の closure ABI サブケースが全部 fixed + pinned (#1865) になった今、**perform をこの unit に戻すのが pilot の主目的**です。bootstrap は import 解決のたびにこのプローブを踏むので、seed → stage1 → stage2 → gate が通ること自体が回帰検証になります。

## 事前実測 (設計ゲート、詳細は #1872)

- perform/handle オーバーヘッド: direct call 比 ~1.0–1.5× (10M 回、ノイズ支配) — 実 I/O を伴う解決パスでは埋没
- #543 の replay 再実行なし / handler 差し替え / captured-state overlay arm / arm 内の実 Fs builtin — 全部 green

## 変更

- `core/module_graph_path.vibe`: `export effect Source` + `resolve_import_path_probe` (candidates 関数の隣)
- `core/index.vpkg`: transparent effect 宣言 + probe の contract
- 3 copy → wrapper 化
- `fixtures/effect_source_pilot_test.vibe` (新規): handler 差し替え / captured-state overlay / multi-op 制御フローを inspect で固定

## 検証

- 変更 4 ファイル `vibe check` clean
- pilot fixture RC 両レーン green
- seed による stage2 再ビルド + full gate + selfcompile KPI 比較を実行中 (結果はコメントで追記します)

Refs #1872, #1770

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_