### PR TITLE
chore(bootstrap): adopt SIMD string scanner seed

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "mutlist-get-2026-08-15",
-    "tag": "seed/mutlist-get-2026-08-15",
-    "source_commit": "4f02d2e061f871399bfad063ae5d8757e6db1bad",
+    "name": "simd-string-special-2026-08-16",
+    "tag": "seed/simd-string-special-2026-08-16",
+    "source_commit": "6728eefb670db136e4ccf861137ed1d2f2b5d34c",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "b0f5f7ec8af12f44923e3e4ad32d055161a59fe70b53cb51f9eb5398bb03eca4"
+      "sha256": "0b9b221a26808f1fc784d9b3c8338f6a22a945a1022e3f9088efc032f252bb8f"
     },
     "runtime": {
       "runner": "node",


### PR DESCRIPTION
## Summary
- pin the compiler produced by merged PR #1874 as `seed/simd-string-special-2026-08-16`
- keep the bootstrap bump isolated to `bootstrap/seed.json`

## Provenance
- source commit: `6728eefb670db136e4ccf861137ed1d2f2b5d34c`
- compiler SHA-256: `0b9b221a26808f1fc784d9b3c8338f6a22a945a1022e3f9088efc032f252bb8f`
- stage0 == stage1 == stage2 == stage3

## Validation
- fresh generation through stage3
- `bash scripts/ensure_generated.sh --force` and `--check`
- `pkf run test-pre-commit`
- PR #1874 full CI green before adoption

Refs #1868