### PR TITLE
#1840: 契約の透明型を materialized types module 化 — sibling から enum constructor が解決される

### DIFF
--- a/docs/module-system-oracle.md
+++ b/docs/module-system-oracle.md
@@ -83,6 +83,16 @@ package 境界モデルとは別レイヤ — in-repo の `lib/@scope/pkg` は
    content-addressed hash closure の両方に入り、最寄り owner の `index.vpkg`
    shared import を継承する。
 7. module source、contract、import target に symlink は使えない。
+8. **契約の透明型は package 内で ambient である (#1840)。** `index.vpkg` に
+   透明に定義された struct / enum / type alias は、loader が
+   `_build/vibe_vpkg_types/` 配下へ content-keyed の実 source
+   (**materialized types module**、ownerless) として書き出し、facade は
+   それを re-export、各 sibling implementation は directory-shared import
+   prefix 経由でそれを import する。これにより enum constructor が sibling
+   から通常の import 機構で解決される (定義サイトは常に 1 つ — 同名 enum の
+   二重定義は別 identity になり実行時 trap する、#1879)。model 上は新しい
+   規則ではなく、ownerless source への合法 import (規則 2) の適用である。
+   effect / effectset / opaque 宣言は従来どおり facade に残る。
 
 ## Oracle と実装の対応
 

--- a/fixtures/contract_conformance_test.vibe
+++ b/fixtures/contract_conformance_test.vibe
@@ -357,14 +357,14 @@ test "re-exported symbol matching a declared opaque type is not reported (#847)"
 test "facade generation allocates a declaration satisfied only by re-export (#847)" {
   let (decls, _, _) = parse_contract_program(lex("fn helper(x: Int) -> Int"))
   let unit_stmts = parse_program(lex("export ./other.vibe { helper }"))
-  let facade = contract_facade_source(decls, no_opaques(), no_type_defs(), [("./mid.vibe", unit_stmts)])
+  let facade = contract_facade_source(decls, no_opaques(), no_type_defs(), [("./mid.vibe", unit_stmts)], "")
   assert(String::contains(facade, "helper"))
 }
 
 test "facade generation allocates a re-exported opaque type (#847)" {
   let (decls, opaques, _) = parse_contract_program(lex("opaque type Counter"))
   let unit_stmts = parse_program(lex("export ./other.vibe { Counter }"))
-  let facade = contract_facade_source(decls, opaques, no_type_defs(), [("./mid.vibe", unit_stmts)])
+  let facade = contract_facade_source(decls, opaques, no_type_defs(), [("./mid.vibe", unit_stmts)], "")
   assert(String::contains(facade, "Counter"))
 }
 

--- a/fixtures/contract_enum_pkg/impl.vibe
+++ b/fixtures/contract_enum_pkg/impl.vibe
@@ -1,0 +1,10 @@
+export fn describe(h: Hue) -> Int {
+  match h {
+    Crimson => 1,
+    Teal(n) => n
+  }
+}
+
+export fn make_teal(n: Int) -> Hue {
+  Teal(n)
+}

--- a/fixtures/contract_enum_pkg/index.vpkg
+++ b/fixtures/contract_enum_pkg/index.vpkg
@@ -1,0 +1,13 @@
+// #1840: a TRANSPARENT enum declared in the contract. Its constructors must
+// resolve from sibling impl units (impl.vibe constructs and matches them
+// without importing anything) and from external importers of the facade —
+// the loader materializes the contract's type family as an importable types
+// module, re-exported here and import-prefixed into every sibling.
+
+enum Hue {
+  Crimson;
+  Teal(Int)
+}
+
+fn describe(h: Hue) -> Int
+fn make_teal(n: Int) -> Hue

--- a/fixtures/contract_enum_pkg_test.vibe
+++ b/fixtures/contract_enum_pkg_test.vibe
@@ -1,0 +1,27 @@
+// #1840: a transparent enum declared in a .vpkg contract is constructible
+// and matchable from sibling impl units (bare constructor names), and its
+// qualified constructors resolve for importers of the facade. Before the
+// types-module materialization the sibling failed to check with
+// `unknown name: Teal`, and re-defining the enum locally compiled into a
+// second identity whose ctor tags trap at runtime (#1879).
+
+import ./contract_enum_pkg {
+  type Hue, describe, make_teal
+}
+
+fn main() -> Int {
+  0
+}
+
+test "sibling constructs and matches the contract enum" {
+  inspect(describe(make_teal(42)), "42")
+}
+
+test "importer uses qualified constructors through the facade" {
+  inspect(describe(Hue::Crimson), "1")
+  inspect(describe(Hue::Teal(7)), "7")
+}
+
+test "importer uses bare constructors through the facade" {
+  inspect(describe(Crimson), "1")
+}

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -784,6 +784,74 @@ export fn contract_impl_import_raw_paths(stmts: Array[Stmt]) -> Array[String] wi
   raws
 }
 
+/// #1840: the TYPE-FAMILY subset of a contract's transparent definitions
+/// (struct / enum / type alias). These move out of the facade into a
+/// materialized "types module" the loader writes under the build cache, so
+/// sibling impl units can IMPORT them — which is what gives enum
+/// constructors real value bindings in every lane (an enum living only in
+/// the facade left siblings failing with `unknown name: <Ctor>`, and
+/// re-defining it locally compiled into a second identity that trapped at
+/// runtime, #1879). Effects / effectsets stay in the facade: their use
+/// sites resolve through the row machinery, not through value names.
+export fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(type_defs) {
+    let td = Array::get(type_defs, i)
+    match td {
+      SStruct(_, _, _, _, _, _) => Array::push(out, td),
+      SEnum(_, _, _, _, _) => Array::push(out, td),
+      STypeAlias(_, _, _, _) => Array::push(out, td),
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #1840: idempotency marker for the materialized types module (mirrors
+/// `contract_facade_marker` / `vpkg_shared_import_marker`).
+export let vpkg_types_module_marker: String = "// vibe: vpkg contract types module (#1840)\n"
+
+/// #1840: the materialized types module's source text — the contract's
+/// type-family definitions verbatim (they are already exported by
+/// `classify_contract_stmts`), behind the idempotency marker.
+export fn contract_types_module_text(tds: Array[Stmt]) -> String {
+  let lines = array_empty()
+  Array::push(lines, vpkg_types_module_marker)
+  let mut i = 0
+  while i < Array::length(tds) {
+    Array::push(lines, print_stmt(Array::get(tds, i)))
+    i = i + 1
+  }
+  String::concat(String::join(lines, "\n"), "\n")
+}
+
+/// #1840: the `type <Name>` item list for importing / re-exporting the
+/// materialized types module (a `type` import binds the typedef AND, for an
+/// enum, its constructors — both bare and `Enum::Ctor`-qualified).
+export fn contract_types_item_names(tds: Array[Stmt]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(tds) {
+    match Array::get(tds, i) {
+      SStruct(_, name, _, _, _, _) => Array::push(out, String::concat("type ", name)),
+      SEnum(_, name, _, _, _) => Array::push(out, String::concat("type ", name)),
+      STypeAlias(_, name, _, _) => Array::push(out, String::concat("type ", name)),
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #1840: one source line importing (keyword `import`) or re-exporting
+/// (keyword `export`) the materialized types module.
+export fn contract_types_module_line(keyword: String, types_path: String, tds: Array[Stmt]) -> String {
+  let items = contract_types_item_names(tds)
+  String::concat(keyword, String::concat(" ", String::concat(types_path, String::concat(" { ", String::concat(String::join(items, ", "), " }\n")))))
+}
+
 /// #897 (ADR-0070 Phase 1): does every item of a qualified `import <path> as
 /// <mod> only { x, y }` import get its dot-joined "mod.x" alias (parser.vibe's
 /// `qualify_import_items`)? Real identifiers can never contain '.', so a "."
@@ -871,11 +939,37 @@ export fn contract_directory_shared_import_prefix_text(stmts: Array[Stmt]) -> St
 /// source, so everything downstream of the loader (type db, merge plan,
 /// codegen) needs no .vibei awareness — it rides the #716 re-export
 /// machinery unchanged.
-export fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(String, Int)], type_defs: Array[Stmt], impl_units: Array[(String, Array[Stmt])]) -> String with Exception {
+export fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(String, Int)], type_defs: Array[Stmt], impl_units: Array[(String, Array[Stmt])], types_path: String) -> String with Exception {
   let lines = array_empty()
+  // #1840: when the loader materialized a types module, the facade
+  // RE-EXPORTS the type family from it instead of defining it verbatim —
+  // the definitions must have exactly ONE site (a second identity for the
+  // same enum traps at runtime, #1879), and that site must be importable by
+  // sibling impl units (the facade is not: facade → impl would become a
+  // cycle). Effects / effectsets / anything non-type-family stay verbatim.
+  if types_path != "" {
+    Array::push(lines, contract_types_module_line("export", types_path, type_defs))
+  } else {
+    ()
+  }
   let mut tdi = 0
   while tdi < Array::length(type_defs) {
-    Array::push(lines, print_stmt(Array::get(type_defs, tdi)))
+    let td = Array::get(type_defs, tdi)
+    let in_types_module = if types_path == "" {
+      false
+    } else {
+      match td {
+        SStruct(_, _, _, _, _, _) => true,
+        SEnum(_, _, _, _, _) => true,
+        STypeAlias(_, _, _, _) => true,
+        _ => false
+      }
+    }
+    if in_types_module {
+      ()
+    } else {
+      Array::push(lines, print_stmt(td))
+    }
     tdi = tdi + 1
   }
   let allocated = array_empty()

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -33,9 +33,10 @@ generated_hash =
 // (which only sees SLet defs and SReExport), and stays verbatim in
 // contract.vibe. No `version` binding existed (compiler-internal package).
 
-// --- facade / shared-import markers (#740/#753, #897)
+// --- facade / shared-import markers (#740/#753, #897, #1840)
 let contract_facade_marker: String
 let vpkg_shared_import_marker: String
+let vpkg_types_module_marker: String
 
 // --- contract grammar
 fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt]) with Exception
@@ -50,7 +51,13 @@ fn collect_impl_type_defs(stmts: Array[Stmt]) -> Array[(String, Bool, Int)]
 fn check_contract(decls: Array[(String, String)], opaque_names: Array[(String, Int)], impl_stmts: Array[Stmt], contract_type_defs: Array[Stmt]) -> Array[String]
 
 // --- facade generation
-fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(String, Int)], type_defs: Array[Stmt], impl_units: Array[(String, Array[Stmt])]) -> String with Exception
+fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(String, Int)], type_defs: Array[Stmt], impl_units: Array[(String, Array[Stmt])], types_path: String) -> String with Exception
+
+// --- materialized types module (#1840)
+fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
+fn contract_types_module_text(tds: Array[Stmt]) -> String
+fn contract_types_item_names(tds: Array[Stmt]) -> Array[String]
+fn contract_types_module_line(keyword: String, types_path: String, tds: Array[Stmt]) -> String
 
 // --- hashing
 fn contract_hash(fn_decls: Array[(String, String)], opaque_names: Array[(String, Int)], type_defs: Array[Stmt]) -> String

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -986,6 +986,38 @@ fn validate_index_layout_fs(path: String) -> Unit with Exception + Fs {
 /// a cycle. The path is content-keyed (package identity + text), so a
 /// contract edit that changes the type family moves the path and every
 /// dependent header invalidates naturally; the write is idempotent.
+/// #1840: process-local registry of materialized types modules —
+/// (contract path, types-module path, types-module text). Fixed-source-set
+/// merge consumers (the s5 selfbuild bundle, any lane that hands
+/// collect_merged_stmts a pre-collected list) have no FS walk to pick the
+/// materialized file up, so the merge would silently LOSE the contract's
+/// type family (the facade only re-exports it now). collect_merged_stmts
+/// re-injects from this registry, gated on "this compile's source set
+/// contains the originating contract" so a long-lived process (test daemon)
+/// never leaks another package's types into an unrelated merge.
+let vpkg_types_registry_contracts: Array[String] = [
+] let vpkg_types_registry_paths: Array[String] = [
+] let vpkg_types_registry_texts: Array[String] = [
+] fn vpkg_types_registry_note(contract_path: String, types_path: String, text: String) -> Unit {
+  let mut i = 0
+  let mut seen = false
+  while i < Array::length(vpkg_types_registry_paths) {
+    if Array::get(vpkg_types_registry_paths, i) == types_path {
+      seen = true
+      i = Array::length(vpkg_types_registry_paths)
+    } else {
+      i = i + 1
+    }
+  }
+  if seen {
+    ()
+  } else {
+    Array::push(vpkg_types_registry_contracts, contract_path)
+    Array::push(vpkg_types_registry_paths, types_path)
+    Array::push(vpkg_types_registry_texts, text)
+  }
+}
+
 /// Returns "" when the contract declares no type-family definitions, or when
 /// the package lives outside the repo-relative tree (an absolute VIBE_LIB
 /// external root — the relative import spelling below cannot reach _build
@@ -1027,6 +1059,7 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String 
     } else {
       Fs::write_file(types_path, text)
     }
+    vpkg_types_registry_note(vpkg_path, types_path, text)
     types_path
   }
 }
@@ -2618,10 +2651,50 @@ export fn collect_source_groups_fs(entry_path: String) -> Array[(String, Array[(
 /// per-statement rewrite only suppresses the map inside the declaring
 /// statement), so those aliases are dropped from the map up front.
 export fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] with Exception {
+  // #1840: a fixed source set that contains an ingested contract's FACADE
+  // but not its materialized types module would lose the contract's type
+  // family entirely (the facade re-exports it; this merge skips
+  // import-family statements). Re-inject each registered types module whose
+  // originating contract is in THIS set and whose own path is not already a
+  // source (the FS-walk lanes collect the file itself — no duplication).
+  let sources_all = array_empty()
+  let mut ci = 0
+  while ci < Array::length(sources) {
+    Array::push(sources_all, Array::get(sources, ci))
+    ci = ci + 1
+  }
+  let mut ri = 0
+  while ri < Array::length(vpkg_types_registry_paths) {
+    let r_contract = Array::get(vpkg_types_registry_contracts, ri)
+    let r_path = Array::get(vpkg_types_registry_paths, ri)
+    let mut has_contract = false
+    let mut has_types = false
+    let mut pi = 0
+    while pi < Array::length(sources) {
+      let (sp, _) = Array::get(sources, pi)
+      if sp == r_contract {
+        has_contract = true
+      } else {
+        ()
+      }
+      if sp == r_path {
+        has_types = true
+      } else {
+        ()
+      }
+      pi = pi + 1
+    }
+    if has_contract && !has_types {
+      Array::push(sources_all, (r_path, Array::get(vpkg_types_registry_texts, ri)))
+    } else {
+      ()
+    }
+    ri = ri + 1
+  }
   let merged = array_empty()
   let mut si = 0
-  while si < Array::length(sources) {
-    let (_, src) = Array::get(sources, si)
+  while si < Array::length(sources_all) {
+    let (_, src) = Array::get(sources_all, si)
     // Use lex+parse_program directly (skip resolve_interp_stmt to reduce heap pressure)
     let stmts = parse_program(lex(src))
     let top_level_value_names = array_empty()

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -57,6 +57,9 @@ import @vibe/compiler/contract {
   contract_facade_source,
   contract_hash,
   contract_surface_lines,
+  contract_type_family_defs,
+  contract_types_module_line,
+  contract_types_module_text,
   deps_missing_for_imports,
   extract_package_deps,
   extract_package_name,
@@ -973,6 +976,92 @@ fn validate_index_layout_fs(path: String) -> Unit with Exception + Fs {
 /// everything the value was derived from).
 /// Scoped to `.vpkg` only (#897 issue comments: `.vibei`'s legacy either/or
 /// import behavior is deliberately left unchanged by this feature).
+/// #1840: materialize a vpkg contract's type-family definitions (struct /
+/// enum / type alias) as a real source file under the build cache. The type
+/// family needs exactly ONE definition site (a second identity for the same
+/// enum traps at runtime, #1879) that BOTH the facade (re-export) and every
+/// sibling impl unit (shared-prefix import) can reach through ordinary
+/// import machinery — the facade itself cannot be that site for siblings,
+/// because facade → impl is already an edge and the reverse import would be
+/// a cycle. The path is content-keyed (package identity + text), so a
+/// contract edit that changes the type family moves the path and every
+/// dependent header invalidates naturally; the write is idempotent.
+/// Returns "" when the contract declares no type-family definitions, or when
+/// the package lives outside the repo-relative tree (an absolute VIBE_LIB
+/// external root — the relative import spelling below cannot reach _build
+/// from there, so those packages keep the verbatim-facade behavior).
+fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String with Exception + Fs {
+  if String::starts_with(vpkg_path, "/") {
+    return ""
+  } else {
+    ()
+  }
+  let (_, type_defs) = classify_contract_stmts(extra)
+  let tds = contract_type_family_defs(type_defs)
+  if Array::length(tds) == 0 {
+    ""
+  } else {
+    let text = contract_types_module_text(tds)
+    let raw_key = compact_string_fingerprint(String::concat(vpkg_path, String::concat("|", text)))
+    // Identifier-safe basename: the import-path grammar (parser_base.vibe's
+    // collect_import_path) lexes path segments as identifier/keyword tokens,
+    // so a digit-leading segment lexes as TInt and the fingerprint's ':'
+    // separators are not path tokens at all — both fail with "unexpected
+    // token in import path". `types_` + [a-z0-9_] keeps the whole basename
+    // one TIdent.
+    let key_sb = StringBuilder::new()
+    let mut kci = 0
+    while kci < String::length(raw_key) {
+      let kc = String::char_code_at(raw_key, kci)
+      let is_ident_char = (kc >= '0' && kc <= '9') || (kc >= 'a' && kc <= 'z') || (kc >= 'A' && kc <= 'Z') || kc == '_'
+      if is_ident_char {
+        StringBuilder::push(key_sb, raw_key[kci: kci + 1])
+      } else {
+        StringBuilder::push(key_sb, "_")
+      }
+      kci = kci + 1
+    }
+    let types_path = String::concat("_build/vibe_vpkg_types/types_", String::concat(StringBuilder::freeze(key_sb), ".vibe"))
+    if Fs::exists(types_path) {
+      ()
+    } else {
+      Fs::write_file(types_path, text)
+    }
+    types_path
+  }
+}
+
+/// #1840: the RELATIVE spelling of `canonical` (a repo-root-relative path)
+/// as seen from `dir` (also repo-root-relative) — `../` per path segment of
+/// `dir`, then the canonical path. Both the facade re-export and the sibling
+/// prefix import need this: the import-path grammar accepts a leading `../`
+/// chain, while a bare root-relative `_build/...` fails the export
+/// statement's head-token check.
+fn relative_spelling_from_dir(dir: String, canonical: String) -> String {
+  let mut segments = if dir == "" {
+    0
+  } else {
+    1
+  }
+  let mut si = 0
+  while si < String::length(dir) {
+    if String::char_code_at(dir, si) == '/' {
+      segments = segments + 1
+    } else {
+      ()
+    }
+    si = si + 1
+  }
+  let sb = StringBuilder::new()
+  let mut ui = 0
+  while ui < segments {
+    StringBuilder::push(sb, "../")
+    ui = ui + 1
+  }
+  StringBuilder::push(sb, canonical)
+  StringBuilder::freeze(sb)
+}
+
 fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception + Fs {
   if is_contract_ext(path) {
     ""
@@ -1012,14 +1101,48 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       } else {
         ""
       }
-      if String::starts_with(cached_prefix, "v1\n") {
-        cached_prefix[3: String::length(cached_prefix)]
+      // #1840: v2 rows carry the materialized types-module path on their
+      // second line (empty when the contract has no type-family defs) so a
+      // hit can verify the file still exists — the prefix cache and the
+      // types module live under different roots when VIBE_BUILD_CACHE_DIR
+      // rebases the caches, so one can survive a clean of the other. A
+      // missing file falls through to full regeneration (idempotent write).
+      let cached_hit = if String::starts_with(cached_prefix, "v2\n") {
+        let rest = cached_prefix[3: String::length(cached_prefix)]
+        let nl = String::index_of(rest, "\n")
+        if nl < 0 {
+          ""
+        } else {
+          let cached_types_path = rest[0: nl]
+          if cached_types_path == "" || Fs::exists(cached_types_path) {
+            rest[nl + 1: String::length(rest)]
+          } else {
+            ""
+          }
+        }
+      } else {
+        ""
+      }
+      if cached_hit != "" || String::starts_with(cached_prefix, "v2\n\n") {
+        cached_hit
       } else {
         let vpkg_raw = Fs::read_file(vpkg_path)
         let (_, vpkg_pin_blanked) = extract_require_pins(vpkg_raw)
         let (_, _, vpkg_extra) = parse_contract_program(lex(vpkg_pin_blanked))
-        let prefix_text = contract_directory_shared_import_prefix_text(vpkg_extra)
-        Fs::write_file(prefix_cache_path, String::concat("v1\n", prefix_text))
+        let shared_text = contract_directory_shared_import_prefix_text(vpkg_extra)
+        // #1840: siblings import the contract's type family from the
+        // materialized types module — this is what gives enum constructors
+        // real value bindings inside impl units (the facade cannot be
+        // imported from a sibling: facade → impl is already an edge).
+        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra)
+        let prefix_text = if types_path == "" {
+          shared_text
+        } else {
+          let (_, vpkg_type_defs) = classify_contract_stmts(vpkg_extra)
+          let types_rel = relative_spelling_from_dir(dir_of_path(vpkg_path), types_path)
+          String::concat(contract_types_module_line("import", types_rel, contract_type_family_defs(vpkg_type_defs)), shared_text)
+        }
+        Fs::write_file(prefix_cache_path, String::concat("v2\n", String::concat(types_path, String::concat("\n", prefix_text))))
         prefix_text
       }
     }
@@ -1724,8 +1847,24 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   } else {
     ""
   }
-  if String::starts_with(cached_facade, "v1\n") {
-    return cached_facade[3: String::length(cached_facade)]
+  // #1840: v2 rows carry the materialized types-module path on their second
+  // line (empty when the contract has no type-family defs) so a hit can
+  // verify the file still exists (see the prefix cache's twin comment). A
+  // missing file falls through to full regeneration, which re-materializes
+  // it idempotently.
+  if String::starts_with(cached_facade, "v2\n") {
+    let fc_rest = cached_facade[3: String::length(cached_facade)]
+    let fc_nl = String::index_of(fc_rest, "\n")
+    if fc_nl >= 0 {
+      let fc_types_path = fc_rest[0: fc_nl]
+      if fc_types_path == "" || Fs::exists(fc_types_path) {
+        return fc_rest[fc_nl + 1: String::length(fc_rest)]
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
   } else {
     ()
   }
@@ -1789,7 +1928,18 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   if Array::length(errors) > 0 {
     throw("\{path}: contract violation: \{String::join(errors, "; ")}")
   } else ()
-  let facade = contract_facade_source(decls, opaque_names, type_defs, impl_units)
+  // #1840: materialize the type family once and hand the facade its path —
+  // the facade re-exports it, siblings import it (shared prefix). The facade
+  // text needs the package-dir-RELATIVE spelling (the export grammar rejects
+  // a bare root-relative head token); the cache row below keeps the
+  // canonical root-relative path for its existence re-check.
+  let facade_types_path = ensure_vpkg_types_module_fs(path, extra)
+  let facade_types_rel = if facade_types_path == "" {
+    ""
+  } else {
+    relative_spelling_from_dir(dir_of_path(path), facade_types_path)
+  }
+  let facade = contract_facade_source(decls, opaque_names, type_defs, impl_units, facade_types_rel)
   let facade_final = if pkg_version == "" {
     facade
   } else {
@@ -1805,7 +1955,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // the fingerprint pass and the reads above — see the comment at
   // fresh_fp_sb's construction).
   let fresh_closure_fp = compact_string_fingerprint(StringBuilder::freeze(fresh_fp_sb))
-  Fs::write_file(persistent_contract_facade_cache_path(path, fresh_closure_fp), String::concat("v1\n", facade_final))
+  Fs::write_file(persistent_contract_facade_cache_path(path, fresh_closure_fp), String::concat("v2\n", String::concat(facade_types_path, String::concat("\n", facade_final))))
   facade_final
 }
 

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1891,6 +1891,17 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
     if fc_nl >= 0 {
       let fc_types_path = fc_rest[0: fc_nl]
       if fc_types_path == "" || Fs::exists(fc_types_path) {
+        // #1840: the registry note must happen on the HIT path too —
+        // collect_merged_stmts' fixed-source-set re-injection reads the
+        // process-local registry, and a warm facade cache would otherwise
+        // skip ensure_vpkg_types_module_fs entirely (found the hard way:
+        // the s5 bundle merge lost the AST enums, `PInt ... reached code
+        // generation unresolved`).
+        if fc_types_path == "" {
+          ()
+        } else {
+          vpkg_types_registry_note(path, fc_types_path, Fs::read_file(fc_types_path))
+        }
         return fc_rest[fc_nl + 1: String::length(fc_rest)]
       } else {
         ()

--- a/lib/@vibe/compiler/tests/codegen_parser_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_parser_test.vibe
@@ -12,8 +12,8 @@ import ../parser.vibe {
   parse_program
 }
 
-import @vibe/compiler/loader {
-  ingest_source_text_fs
+import @vibe/compiler/contract {
+  classify_contract_stmts, contract_type_family_defs, extract_require_pins, parse_contract_program
 }
 
 //# Misc
@@ -27,7 +27,6 @@ import @vibe/compiler/loader {
 test "wasi: parser.vibe import - compile and run" {
   let token_source = Fs::read_file("lib/@vibe/parser/token.vibe")
   let ast_path = "lib/@vibe/ast/index.vpkg"
-  let ast_source = ingest_source_text_fs(ast_path, Fs::read_file(ast_path))
   let syntax_paths = [
     // #956: the lexer's float-literal construction moved to
     // float_format.vibe (parse_decimal_float), which in turn uses the
@@ -58,14 +57,18 @@ test "wasi: parser.vibe import - compile and run" {
     };
     ti = ti + 1
   }
-  // AST enums
-  let ast_tokens = lex(ast_source)
-  let ast_stmts = parse_program(ast_tokens)
+  // AST enums — taken from the CONTRACT text itself (#1840: the ingested
+  // facade no longer carries the type family verbatim; it re-exports the
+  // materialized types module, so scraping the facade finds no SEnum).
+  let (_, ast_blanked) = extract_require_pins(Fs::read_file(ast_path))
+  let (_, _, ast_extra) = parse_contract_program(lex(ast_blanked))
+  let (_, ast_type_defs) = classify_contract_stmts(ast_extra)
+  let ast_tds = contract_type_family_defs(ast_type_defs)
   let mut ai = 0
-  while ai < Array::length(ast_stmts) {
-    match Array::get(ast_stmts, ai) {
+  while ai < Array::length(ast_tds) {
+    match Array::get(ast_tds, ai) {
       SEnum(_, _, _, _, _) => {
-        ArrayBuilder::push(all_stmts, Array::get(ast_stmts, ai)); 0
+        ArrayBuilder::push(all_stmts, Array::get(ast_tds, ai)); 0
       },
       _ => 0
     };


### PR DESCRIPTION
#1840 の修正 (機構は issue コメントで整理した A 案)。`index.vpkg` に透明に定義した enum の constructor が sibling impl unit から `unknown name: <Ctor>` になり、json が `opaque type` に逃げていた問題。

## 機構

型ファミリ (struct / enum / type alias) は**定義サイトが 1 つ**でなければならず (同名 enum の二重定義は別 identity になり ctor tag が食い違って実行時 trap する — #1879 で実測)、かつその 1 つは sibling から import 可能でなければならない。facade はその場所になれない (facade → impl が既にエッジで、逆向き import は循環)。

そこで loader が契約の型ファミリを **content-keyed の実ファイル** `_build/vibe_vpkg_types/types_<key>.vibe` (ownerless) として書き出し:

- **facade** は `export <相対path> { type A, ... }` で re-export (verbatim 定義をやめる)
- **各 sibling** は directory-shared import prefix (#897 の既存 seam) 経由で `import <相対path> { type A, ... }` を前置される — `type` import は typedef と enum constructor (bare / qualified とも) を束縛する (実測済み)

以降はすべて既存の import/plan/cache 機構に乗る。effect / effectset / opaque 宣言は従来どおり facade に残る。model 上は新規則ではなく ownerless source への合法 import の適用 (oracle doc に規則 8 として追記)。

## 実装で踏んだ落とし穴 (コメントに記録)

- import path 文法は数字始まりトークン (TInt) とコロンを受けない → ファイル名を identifier-safe に (`types_` + `[a-zA-Z0-9_]`)
- export 文の頭トークンは root-relative の `_build/...` を受けない → package dir からの相対綴り (`../../../_build/...`) を両方の行で使用
- prefix / facade の persistent cache は v2 行に types-module path を持ち、hit 時に実在を再確認 (別 root が独立に消えても idempotent に再生成)

絶対 path の外部 root (VIBE_LIB) package は相対綴りが届かないため従来動作 (verbatim facade) に fallback。

## 検証

- 新 fixture `fixtures/contract_enum_pkg_test.vibe` — sibling の bare ctor 構築/match、facade 越しの qualified/bare ctor 使用 (旧コンパイラでは `unknown name: Teal` で fail するのを併記確認)
- 既存 vpkg fixtures (contract_pkg_vpkg / implicit / contract_pkg)、shell / json パッケージテスト green
- stage2 再ビルド (seed→stage1→stage2、sample validation 込み) green — flatten が compiler 自身の vpkg (runtime の ModuleJob 等) を新機構で処理
- `bash scripts/compiler_gate.sh` はローカル実行中 (CI と同一 gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC)_