### PR TITLE
perf report にテストカバレッジを表示 — coverage-suite (main-only) の union rate を bench-data 経由で毎 PR に

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,7 +609,27 @@ jobs:
               _build/bench-data/coverage_latest.json > _build/coverage_snapshot.json
             cat _build/coverage_snapshot.json | tr -d '\n' >> _build/bench-data/data/coverage.jsonl
             echo >> _build/bench-data/data/coverage.jsonl
-            cp _build/coverage_snapshot.json _build/bench-data/coverage_latest.json
+            # Latest-pointer guard (Codex P1): two overlapping main pushes can
+            # finish out of order — the retry loop absorbs the push race but
+            # not snapshot ordering. Replace coverage_latest.json only when
+            # this run is not OLDER than the stored one (run_number is
+            # monotonic across pushes and preserved on re-runs); a stale run
+            # still appends its history row above, it just leaves the latest
+            # pointer alone.
+            replace_latest="$(node -e '
+              const fs = require("fs");
+              const cur = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              let stored = null;
+              try { stored = JSON.parse(fs.readFileSync(process.argv[2], "utf8")); } catch {}
+              const ok = stored?.run_number == null || cur.run_number == null
+                || cur.run_number >= stored.run_number;
+              console.log(ok ? "yes" : "no");
+            ' _build/coverage_snapshot.json _build/bench-data/coverage_latest.json)"
+            if [ "$replace_latest" = "yes" ]; then
+              cp _build/coverage_snapshot.json _build/bench-data/coverage_latest.json
+            else
+              echo "::notice::coverage snapshot from an older run (${GITHUB_SHA::9}); history appended, latest pointer left at the newer snapshot"
+            fi
             (
               cd _build/bench-data
               git add -A

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,11 @@ jobs:
     name: coverage-suite (main only)
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    # contents: write for the bench-data append below (same branch the perf
+    # workflow snapshots to; different files, so the writers never conflict
+    # beyond the push race the retry loop already absorbs).
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - name: Cache seed artifact
@@ -576,6 +581,48 @@ jobs:
           name: compiler-suite-coverage
           path: _build/coverage/selfhost-suite/selfhost_suite.report.json
           if-no-files-found: ignore
+      - name: Append coverage snapshot to bench-data
+        # Store the headline union rates on the bench-data branch
+        # (coverage_latest.json + data/coverage.jsonl) so every PR's perf
+        # report can display the repo's current test coverage — this job is
+        # main-only (the suite re-runs the whole battery instrumented), so
+        # the perf report labels the numbers as "measured on main", never as
+        # the PR's own coverage. Same worktree + retry pattern as perf.yml's
+        # snapshot append; the payload is append-only/last-wins so refetch +
+        # reapply + push is always safe.
+        run: |
+          set -euo pipefail
+          report=_build/coverage/selfhost-suite/selfhost_suite.report.json
+          [ -f "$report" ] || { echo "no suite report; skipping snapshot"; exit 0; }
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          for attempt in 1 2 3; do
+            rm -rf _build/bench-data
+            if git fetch --depth 1 origin bench-data 2>/dev/null; then
+              git worktree add _build/bench-data FETCH_HEAD
+            else
+              git worktree add --detach _build/bench-data
+              (cd _build/bench-data && git checkout --orphan bench-data && git rm -rf --quiet . || true)
+            fi
+            mkdir -p _build/bench-data/data
+            node scripts/coverage_bench_snapshot.mjs "$report" \
+              _build/bench-data/coverage_latest.json > _build/coverage_snapshot.json
+            cat _build/coverage_snapshot.json | tr -d '\n' >> _build/bench-data/data/coverage.jsonl
+            echo >> _build/bench-data/data/coverage.jsonl
+            cp _build/coverage_snapshot.json _build/bench-data/coverage_latest.json
+            (
+              cd _build/bench-data
+              git add -A
+              git commit -m "coverage: snapshot ${GITHUB_SHA::9}"
+            )
+            if git -C _build/bench-data push origin HEAD:refs/heads/bench-data; then
+              break
+            fi
+            git worktree remove --force _build/bench-data || true
+            [ "$attempt" -lt 3 ] || { echo "::error::failed to push bench-data after 3 attempts"; exit 1; }
+            sleep $((attempt * 3))
+          done
+          git worktree remove --force _build/bench-data || true
 
   # WASI p3 guarantee (#821): vibe-built async components + the wasi:http p3
   # serve pipeline, plus the optional ratified wasi:cli/stdin availability

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -106,9 +106,12 @@ jobs:
         # coverage-suite job appends it — main-only, so the report labels it
         # "measured on main", never as this PR's own coverage).
         run: |
+          # `git show > file` leaves a 0-byte file when the object is missing
+          # (e.g. no coverage snapshot recorded yet) — remove the husk so the
+          # renderer sees "absent", not "empty JSON".
           if git fetch --depth 1 origin bench-data 2>/dev/null; then
-            git show FETCH_HEAD:latest.json > _build/bench_baseline.json 2>/dev/null || true
-            git show FETCH_HEAD:coverage_latest.json > _build/coverage_latest.json 2>/dev/null || true
+            git show FETCH_HEAD:latest.json > _build/bench_baseline.json 2>/dev/null || rm -f _build/bench_baseline.json
+            git show FETCH_HEAD:coverage_latest.json > _build/coverage_latest.json 2>/dev/null || rm -f _build/coverage_latest.json
           fi
           ls -la _build/bench_baseline.json 2>/dev/null || echo "no baseline yet"
           ls -la _build/coverage_latest.json 2>/dev/null || echo "no coverage snapshot yet"

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -101,15 +101,21 @@ jobs:
           bash scripts/bench_metrics.sh _build/_ci_shard_gen/stage2.wasm _build/bench_metrics.json
           cat _build/bench_metrics.json
       - name: Fetch baseline from bench-data branch
+        # latest.json = perf baseline (last main perf snapshot);
+        # coverage_latest.json = last main coverage-suite run (ci.yml's
+        # coverage-suite job appends it — main-only, so the report labels it
+        # "measured on main", never as this PR's own coverage).
         run: |
           if git fetch --depth 1 origin bench-data 2>/dev/null; then
             git show FETCH_HEAD:latest.json > _build/bench_baseline.json 2>/dev/null || true
+            git show FETCH_HEAD:coverage_latest.json > _build/coverage_latest.json 2>/dev/null || true
           fi
           ls -la _build/bench_baseline.json 2>/dev/null || echo "no baseline yet"
+          ls -la _build/coverage_latest.json 2>/dev/null || echo "no coverage snapshot yet"
       - name: Render report
         run: |
           node scripts/bench_report.mjs _build/bench_metrics.json _build/bench_baseline.json \
-            > _build/bench_report.md
+            _build/coverage_latest.json > _build/bench_report.md
           cat _build/bench_report.md >> "$GITHUB_STEP_SUMMARY"
       - name: Upsert PR comment
         if: github.event_name == 'pull_request'

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -393,6 +393,17 @@ local testWasiStdinProviderSource =
 local testSimdEmitWasmtime =
   scriptTask("test-simd-emit-wasmtime", "scripts/test_simd_emit_wasmtime.sh")
 
+local testPerfReport = new Task {
+  name = "test-perf-report"
+  cmd = "node --test scripts/bench_report.test.mjs scripts/coverage_bench_snapshot.test.mjs"
+  inputs {
+    "scripts/bench_report.mjs"
+    "scripts/bench_report.test.mjs"
+    "scripts/coverage_bench_snapshot.mjs"
+    "scripts/coverage_bench_snapshot.test.mjs"
+  }
+}
+
 local testCoverageScripts = new Task {
   name = "test-coverage-scripts"
   cmd =
@@ -1259,6 +1270,7 @@ tasks {
   testWasiStdinProviderSource
   testSimdEmitWasmtime
   testCoverageScripts
+  testPerfReport
   refreshSelfhostBatchWeights
   testSelfhostBatchWeights
   testFlakerRun

--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -170,6 +170,28 @@ on stderr, one machine-readable line, fresh `.wasm` only — a `.cwasm` was
 serialized without fuel instrumentation). It composes with the existing
 `VIBE_MEM=1` report.
 
+### Test coverage in the perf report (main-only measurement)
+
+The report's "Test coverage" section shows the selfhost suite's **union**
+rates (function / branch — each source function/branch counted once, #1556)
+with a percentage-point trend vs the previous measurement. The numbers come
+from ci.yml's `coverage-suite` job, which is **main-only** (it re-runs the
+whole test battery instrumented — too expensive per PR): after the ratchet
+gate it extracts a compact snapshot (`scripts/coverage_bench_snapshot.mjs`)
+and appends it to the `bench-data` branch (`coverage_latest.json` +
+`data/coverage.jsonl`, same retry pattern as the perf snapshot). The perf
+workflow fetches `coverage_latest.json` alongside the perf baseline and
+passes it to `bench_report.mjs` as the third argument.
+
+Because the measurement is main-only, the section is labeled **"measured on
+main, not this PR"** — a PR's perf comment shows the repo's current coverage
+and its main-to-main trend, never the PR's own effect (implying otherwise
+would be silently wrong). The entry-weighted rates are deliberately not
+shown: their denominator dilutes with every added test entry, which reads as
+a regression when coverage actually grew (see the rebaseline notes in
+`scripts/coverage_suite.sh`). The blocking ratchet stays in the
+coverage-suite job itself. Tests: `pkf run test-perf-report`.
+
 ### Runner normalization (calibration) — history-only since the exec corpus
 
 > **Status:** the calibration record is still collected into every snapshot

--- a/scripts/bench_report.mjs
+++ b/scripts/bench_report.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Render the perf-tracking markdown report from bench_metrics.sh snapshots.
 //
-//   node scripts/bench_report.mjs current.json [baseline.json]
+//   node scripts/bench_report.mjs current.json [baseline.json] [coverage.json]
 //
 // The report renders DETERMINISTIC metrics only (heap, sizes, bytes/op, exec
 // fuel/memory/parity): any change is real, >±2% gets a warning emoji. The
@@ -15,13 +15,17 @@
 // KPI heap step.
 import { readFileSync, existsSync } from "node:fs";
 
-const [curPath, basePath] = process.argv.slice(2);
+const [curPath, basePath, covPath] = process.argv.slice(2);
 if (!curPath) {
-  console.error("usage: bench_report.mjs current.json [baseline.json]");
+  console.error("usage: bench_report.mjs current.json [baseline.json] [coverage.json]");
   process.exit(2);
 }
 const cur = JSON.parse(readFileSync(curPath, "utf8"));
 const base = basePath && existsSync(basePath) ? JSON.parse(readFileSync(basePath, "utf8")) : null;
+// Coverage snapshot from the bench-data branch (scripts/coverage_bench_snapshot.mjs,
+// appended by ci.yml's main-only coverage-suite job). Optional; absent until
+// the first main run lands one.
+const cov = covPath && existsSync(covPath) ? JSON.parse(readFileSync(covPath, "utf8")) : null;
 
 // Human-readable units for table cells. Rounding here loses no signal: the Δ
 // column is computed from the raw values, so "any drift is real" still reads
@@ -144,6 +148,40 @@ if (execCur?.scenarios && Object.keys(execCur.scenarios).length) {
     lines.push(`> exec scenarios: ${execCur.status}`);
     lines.push("");
   }
+}
+
+// Test coverage — the selfhost suite's union rates, measured by ci.yml's
+// main-only coverage-suite job (the suite re-runs the whole test battery
+// instrumented, too expensive per PR). Labeled as main's coverage, never this
+// PR's: implying otherwise would be silently wrong. The Δ column is
+// percentage POINTS vs the previous main measurement (a trend, not a
+// baseline-vs-PR diff).
+if (cov?.function_union && cov?.branch_union) {
+  lines.push("#### Test coverage (selfhost suite — measured on main, not this PR)");
+  lines.push("");
+  const fmtInt = (n) => n == null ? "–" : n.toLocaleString("en-US");
+  const rate = (r) => r == null ? "–" : `${Number(r).toFixed(2)}%`;
+  const trend = (curR, prevR) => {
+    if (curR == null || prevR == null) return "–";
+    const pt = curR - prevR;
+    if (Math.abs(pt) < 0.005) return "±0";
+    const flag = pt <= -0.1 ? " ⚠️" : pt >= 0.1 ? " 🎉" : "";
+    return `${pt > 0 ? "+" : ""}${pt.toFixed(2)}pt${flag}`;
+  };
+  lines.push("| metric | hit | total | rate | Δ vs prev main |");
+  lines.push("|---|---:|---:|---:|---|");
+  lines.push(`| branch union | ${fmtInt(cov.branch_union.hit)} | ${fmtInt(cov.branch_union.total)} | ${rate(cov.branch_union.rate)} | ${trend(cov.branch_union.rate, cov.prev?.branch_union_rate)} |`);
+  lines.push(`| function union | ${fmtInt(cov.function_union.hit)} | ${fmtInt(cov.function_union.total)} | ${rate(cov.function_union.rate)} | ${trend(cov.function_union.rate, cov.prev?.function_union_rate)} |`);
+  lines.push("");
+  const caseLine = (cov.entries_passed != null && cov.entries_total != null)
+    ? `cases ${cov.entries_passed}/${cov.entries_total}` + (cov.case_rate != null ? ` (${cov.case_rate}%)` : "")
+    : null;
+  const measuredAt = `measured at \`${(cov.commit || "?").slice(0, 9)}\`` + (cov.date ? ` (${cov.date.slice(0, 10)})` : "");
+  lines.push(`> ${caseLine ? caseLine + " · " : ""}${measuredAt}`);
+  if (cov.branch_union.exact === false) {
+    lines.push("> branch union is a LOWER BOUND (some entries reported no branch mask)");
+  }
+  lines.push("");
 }
 
 if (cur.micro_status && cur.micro_status !== "ok") {

--- a/scripts/bench_report.mjs
+++ b/scripts/bench_report.mjs
@@ -21,11 +21,20 @@ if (!curPath) {
   process.exit(2);
 }
 const cur = JSON.parse(readFileSync(curPath, "utf8"));
-const base = basePath && existsSync(basePath) ? JSON.parse(readFileSync(basePath, "utf8")) : null;
+// Optional inputs degrade to null instead of killing the report: the perf
+// workflow materializes them with `git show ... > file || true`, which leaves
+// a 0-byte file when the object doesn't exist on bench-data yet (exactly how
+// the first #1883 run died: JSON.parse("") on the not-yet-recorded coverage
+// snapshot).
+const readJsonMaybe = (p) => {
+  if (!p || !existsSync(p)) return null;
+  try { return JSON.parse(readFileSync(p, "utf8")); } catch { return null; }
+};
+const base = readJsonMaybe(basePath);
 // Coverage snapshot from the bench-data branch (scripts/coverage_bench_snapshot.mjs,
 // appended by ci.yml's main-only coverage-suite job). Optional; absent until
 // the first main run lands one.
-const cov = covPath && existsSync(covPath) ? JSON.parse(readFileSync(covPath, "utf8")) : null;
+const cov = readJsonMaybe(covPath);
 
 // Human-readable units for table cells. Rounding here loses no signal: the Δ
 // column is computed from the raw values, so "any drift is real" still reads

--- a/scripts/bench_report.test.mjs
+++ b/scripts/bench_report.test.mjs
@@ -174,6 +174,19 @@ test("coverage snapshot renders as main's coverage with a pt trend, absent when 
       [reportScript.pathname, currentPath], { encoding: "utf8" });
     assert.equal(withoutCov.status, 0, withoutCov.stderr);
     assert.doesNotMatch(withoutCov.stdout, /Test coverage/);
+
+    // A 0-byte optional file (how `git show missing > file` leaves things in
+    // the perf workflow) must degrade like an absent one, not crash the
+    // report — the first #1883 CI run died exactly here.
+    const emptyBase = join(dir, "empty_base.json");
+    const emptyCov = join(dir, "empty_cov.json");
+    writeFileSync(emptyBase, "");
+    writeFileSync(emptyCov, "");
+    const withEmpty = spawnSync(process.execPath,
+      [reportScript.pathname, currentPath, emptyBase, emptyCov], { encoding: "utf8" });
+    assert.equal(withEmpty.status, 0, withEmpty.stderr);
+    assert.doesNotMatch(withEmpty.stdout, /Test coverage/);
+    assert.match(withEmpty.stdout, /baseline: _none yet_/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/bench_report.test.mjs
+++ b/scripts/bench_report.test.mjs
@@ -145,6 +145,40 @@ test("wasmtime version drift omits fuel deltas instead of comparing across cost 
   assert.match(report, /\| demo \| 1\.00M \| – \| 800k \| – \| 0\.80× \|/);
 });
 
+// --- test-coverage section (bench-data coverage snapshot, main-only) ----------
+
+test("coverage snapshot renders as main's coverage with a pt trend, absent when no snapshot", () => {
+  const dir = mkdtempSync(join(tmpdir(), "vibe-bench-report-cov-"));
+  try {
+    const minimal = { commit: "x", selfcompile: {}, sizes: {}, benches: {} };
+    const currentPath = join(dir, "current.json");
+    writeFileSync(currentPath, JSON.stringify(minimal));
+    const covPath = join(dir, "coverage_latest.json");
+    writeFileSync(covPath, JSON.stringify({
+      schema: 1, commit: "covsha1234", date: "2026-08-15T12:00:00Z",
+      function_union: { hit: 12950, total: 14995, rate: 86.36 },
+      branch_union: { hit: 26442, total: 45986, rate: 57.5, exact: false },
+      entries_total: 582, entries_passed: 582, case_rate: 100,
+      prev: { commit: "old", date: "2026-08-14T00:00:00Z", function_union_rate: 86.36, branch_union_rate: 57.07 },
+    }));
+    const withCov = spawnSync(process.execPath,
+      [reportScript.pathname, currentPath, join(dir, "missing.json"), covPath], { encoding: "utf8" });
+    assert.equal(withCov.status, 0, withCov.stderr);
+    assert.match(withCov.stdout, /#### Test coverage \(selfhost suite — measured on main, not this PR\)/);
+    assert.match(withCov.stdout, /\| branch union \| 26,442 \| 45,986 \| 57\.50% \| \+0\.43pt 🎉 \|/);
+    assert.match(withCov.stdout, /\| function union \| 12,950 \| 14,995 \| 86\.36% \| ±0 \|/);
+    assert.match(withCov.stdout, /cases 582\/582 \(100%\) · measured at `covsha123` \(2026-08-15\)/);
+    assert.match(withCov.stdout, /branch union is a LOWER BOUND/);
+
+    const withoutCov = spawnSync(process.execPath,
+      [reportScript.pathname, currentPath], { encoding: "utf8" });
+    assert.equal(withoutCov.status, 0, withoutCov.stderr);
+    assert.doesNotMatch(withoutCov.stdout, /Test coverage/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("a parity mismatch is rendered as a loud silent-wrong flag, a gc gap as a note", () => {
   const cur = { status: "partial", wasmtime: "47.0.2", scenarios: {
     bad: { ...okScenario, output: "parity-mismatch" },

--- a/scripts/coverage_bench_snapshot.mjs
+++ b/scripts/coverage_bench_snapshot.mjs
@@ -50,6 +50,12 @@ if (prevPath && existsSync(prevPath)) {
 const doc = {
   schema: 1,
   commit: process.env.GITHUB_SHA || "",
+  // Monotonic ordering token for the latest-pointer guard in ci.yml: on push
+  // events the workflow run number increases with push order (and main only
+  // fast-forwards), while a RE-RUN of an old run keeps its original number —
+  // so "only replace coverage_latest.json when run_number >= stored" keeps an
+  // older overlapping run from clobbering a newer snapshot (Codex P1, #1883).
+  run_number: Number(process.env.GITHUB_RUN_NUMBER) || null,
   date: new Date().toISOString(),
   function_union: { hit: r.function_union.hit, total: r.function_union.total, rate: r.function_union.rate },
   branch_union: {

--- a/scripts/coverage_bench_snapshot.mjs
+++ b/scripts/coverage_bench_snapshot.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Extract the compact coverage snapshot the continuous perf pipeline stores on
+// the bench-data branch (ci.yml coverage-suite job, main-only → rendered into
+// every PR's perf report by scripts/bench_report.mjs).
+//
+//   node scripts/coverage_bench_snapshot.mjs suite_report.json [prev_snapshot.json]
+//
+// stdout: one compact JSON object. `prev` carries the PREVIOUS snapshot's
+// headline rates (if a previous snapshot was given and parseable) so the
+// report can show a main-to-main trend without fetching the whole history.
+//
+// The union metrics are the source-coverage ones (each function/branch
+// counted once no matter how many test entries link it — #1556); the
+// entry-weighted pair is deliberately NOT propagated here: its denominator
+// dilutes with every added test entry, which reads as a regression when
+// coverage actually grew (see the rebaseline notes in coverage_suite.sh).
+import { readFileSync, existsSync } from "node:fs";
+
+const [reportPath, prevPath] = process.argv.slice(2);
+if (!reportPath) {
+  console.error("usage: coverage_bench_snapshot.mjs suite_report.json [prev_snapshot.json]");
+  process.exit(2);
+}
+const r = JSON.parse(readFileSync(reportPath, "utf8"));
+for (const k of ["function_union", "branch_union"]) {
+  if (!r[k] || typeof r[k].hit !== "number" || typeof r[k].total !== "number") {
+    console.error(`coverage_bench_snapshot: suite report has no usable ${k} — refusing to emit a partial snapshot`);
+    process.exit(1);
+  }
+}
+
+let prev = null;
+if (prevPath && existsSync(prevPath)) {
+  try {
+    const p = JSON.parse(readFileSync(prevPath, "utf8"));
+    if (p?.function_union?.rate != null && p?.branch_union?.rate != null) {
+      prev = {
+        commit: p.commit || null,
+        date: p.date || null,
+        function_union_rate: p.function_union.rate,
+        branch_union_rate: p.branch_union.rate,
+      };
+    }
+  } catch {
+    // A corrupt previous snapshot must not block recording the current one —
+    // the trend line just goes missing for one run.
+  }
+}
+
+const doc = {
+  schema: 1,
+  commit: process.env.GITHUB_SHA || "",
+  date: new Date().toISOString(),
+  function_union: { hit: r.function_union.hit, total: r.function_union.total, rate: r.function_union.rate },
+  branch_union: {
+    hit: r.branch_union.hit,
+    total: r.branch_union.total,
+    rate: r.branch_union.rate,
+    exact: r.branch_union.exact !== false,
+  },
+  entries_total: r.entries_total ?? null,
+  entries_passed: r.entries_passed ?? null,
+  case_rate: r.case_rate ?? null,
+  prev,
+};
+console.log(JSON.stringify(doc, null, 2));

--- a/scripts/coverage_bench_snapshot.test.mjs
+++ b/scripts/coverage_bench_snapshot.test.mjs
@@ -30,7 +30,7 @@ function run(reportDoc, prevDoc, { rawPrev } = {}) {
     }
     return spawnSync(process.execPath, args, {
       encoding: "utf8",
-      env: { ...process.env, GITHUB_SHA: "abc123def456" },
+      env: { ...process.env, GITHUB_SHA: "abc123def456", GITHUB_RUN_NUMBER: "1234" },
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -47,6 +47,9 @@ test("extracts union metrics and embeds the previous snapshot's rates as prev", 
   assert.equal(r.status, 0, r.stderr);
   const doc = JSON.parse(r.stdout);
   assert.equal(doc.commit, "abc123def456");
+  // Ordering token for ci.yml's latest-pointer guard (older overlapping runs
+  // must not clobber a newer coverage_latest.json).
+  assert.equal(doc.run_number, 1234);
   assert.deepEqual(doc.branch_union, { hit: 26442, total: 45986, rate: 57.5, exact: true });
   assert.deepEqual(doc.function_union, { hit: 12950, total: 14995, rate: 86.36 });
   assert.equal(doc.entries_passed, 582);

--- a/scripts/coverage_bench_snapshot.test.mjs
+++ b/scripts/coverage_bench_snapshot.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const script = new URL("./coverage_bench_snapshot.mjs", import.meta.url);
+
+const suiteReport = {
+  cases: [],
+  function_union: { hit: 12950, total: 14995, rate: 86.36 },
+  branch_union: { hit: 26442, total: 45986, rate: 57.5, exact: true },
+  entry_weighted: {},
+  entries_total: 582,
+  entries_passed: 582,
+  case_rate: 100.0,
+};
+
+function run(reportDoc, prevDoc, { rawPrev } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "vibe-cov-snap-"));
+  try {
+    const reportPath = join(dir, "report.json");
+    writeFileSync(reportPath, JSON.stringify(reportDoc));
+    const args = [script.pathname, reportPath];
+    if (prevDoc !== undefined) {
+      const prevPath = join(dir, "prev.json");
+      writeFileSync(prevPath, rawPrev ? prevDoc : JSON.stringify(prevDoc));
+      args.push(prevPath);
+    }
+    return spawnSync(process.execPath, args, {
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_SHA: "abc123def456" },
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("extracts union metrics and embeds the previous snapshot's rates as prev", () => {
+  const prev = {
+    commit: "prevsha", date: "2026-08-14T00:00:00Z",
+    function_union: { hit: 1, total: 2, rate: 86.0 },
+    branch_union: { hit: 1, total: 2, rate: 57.07 },
+  };
+  const r = run(suiteReport, prev);
+  assert.equal(r.status, 0, r.stderr);
+  const doc = JSON.parse(r.stdout);
+  assert.equal(doc.commit, "abc123def456");
+  assert.deepEqual(doc.branch_union, { hit: 26442, total: 45986, rate: 57.5, exact: true });
+  assert.deepEqual(doc.function_union, { hit: 12950, total: 14995, rate: 86.36 });
+  assert.equal(doc.entries_passed, 582);
+  assert.deepEqual(doc.prev, {
+    commit: "prevsha", date: "2026-08-14T00:00:00Z",
+    function_union_rate: 86.0, branch_union_rate: 57.07,
+  });
+});
+
+test("no previous snapshot → prev is null", () => {
+  const r = run(suiteReport);
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(JSON.parse(r.stdout).prev, null);
+});
+
+test("a corrupt previous snapshot degrades to prev null instead of blocking the run", () => {
+  const r = run(suiteReport, "{ not json", { rawPrev: true });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(JSON.parse(r.stdout).prev, null);
+});
+
+test("a suite report without usable union metrics is refused, not emitted partially", () => {
+  const broken = { ...suiteReport, branch_union: { rate: 57.5 } };
+  const r = run(broken);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /no usable branch_union/);
+});


### PR DESCRIPTION
#1876 の follow-up。perf report にテストカバレッジのセクションを追加する。

## 設計: 測定は main-only のまま、表示は毎 PR

カバレッジ計測 (`coverage-suite` job) は全テストを計装再実行するため **main-only** (ci.yml のコメントにある通り、PR ごとに回すとゲートの wall time が倍増する)。なので PR で再測定はせず:

1. **ci.yml `coverage-suite` job** (main push 時): ratchet gate 通過後、`scripts/coverage_bench_snapshot.mjs` が suite report から union rate だけのコンパクトな snapshot を抽出し、`bench-data` ブランチへ append (`coverage_latest.json` + `data/coverage.jsonl`。perf snapshot と同じ worktree + retry パターン、ファイルが別なので衝突しない)。snapshot には前回の rate が `prev` として埋め込まれ、トレンド計算に使う。
2. **perf.yml**: baseline fetch 時に `coverage_latest.json` も取得し、`bench_report.mjs` の第 3 引数へ。
3. **bench_report.mjs**: 「Test coverage (selfhost suite — **measured on main, not this PR**)」セクションを描画。

```
| metric         | hit    | total  | rate   | Δ vs prev main |
| branch union   | 26,442 | 45,986 | 57.50% | +0.43pt 🎉     |
| function union | 12,950 | 14,995 | 86.36% | ±0             |

> cases 582/582 (100%) · measured at `<sha>` (date)
```

## 判断のポイント

- **「この PR のカバレッジ」だと誤読させない**: 測定は main のものなのでラベルに明記。黙って誤るくらいなら正直に「main の現在値 + main間トレンド」として出す。
- **union rate のみ表示**: entry-weighted rate はテストを足すほど分母が希釈されて「カバレッジが上がったのに率が下がる」形になる (coverage_suite.sh の rebaseline 履歴の通り) ので、source coverage を表す union 対 (#1556) だけを載せる。blocking ratchet は従来どおり coverage-suite job 側。
- `branch_union.exact` が false のときは LOWER BOUND 注記を継承。
- snapshot 抽出は union が読めなければ **部分 snapshot を出さず exit 1** (劣化した答えを黙って返さない)。壊れた prev は trend 欠落に留めて記録は続行。

## 検証

- `pkf run test-perf-report` (新設タスク) 10/10 pass — **これまでどのタスクからも配線されていなかった `bench_report.test.mjs` もここで配線した**
- 抽出 → prev 埋め込み → 描画を fake suite report で end-to-end 確認 (snapshot 無し / prev 無し / corrupt prev / exact=false / 部分 report 拒否の各経路)
- coverage-suite job に `permissions: contents: write` を追加 (bench-data push 用)

初回は main に 1 回 push が入って snapshot が録られるまでセクションは出ない (coverage 無しの経路はテスト済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmUnRj4hToeNVXwnQXT2hu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmUnRj4hToeNVXwnQXT2hu)_