### PR TITLE
#1878 / #1879: record sentinels through tuple destructure, and reject sibling re-definition of transparent contract types

### DIFF
--- a/fixtures/anon_record_tuple_destructure_test.vibe
+++ b/fixtures/anon_record_tuple_destructure_test.vibe
@@ -1,0 +1,39 @@
+// #1878: dot access on a record binding that came out of a TUPLE
+// destructure. `let (r, n) = t` lowers to an EMatch with a PTuple pattern,
+// which used to drop the anonymous-record sentinel tracking -- the checker
+// accepted `r.a` (CtRecord flows through tuples) but codegen died with an
+// unlocated "unknown struct field". The desugar now threads a compound
+// `__anontup:` sentinel through tuple literals and hands each element's
+// record sentinel to its positional binder.
+
+fn main() -> Int {
+  0
+}
+
+test "record dot access through a let tuple destructure" {
+  let t = (record {
+    a: 1,
+    b: 2
+  }, 3)
+  let (r, n) = t
+  inspect(r.a + n, "4")
+  inspect(r.b, "2")
+}
+
+test "direct tuple-literal destructure" {
+  let (r2, m) = (record {
+    x: 10,
+    y: 20
+  }, 5)
+  inspect(r2.y - r2.x - m, "5")
+}
+
+test "match arm tuple destructure" {
+  let t3 = (record {
+    v: 7
+  }, 1)
+  let got = match t3 {
+    (r3, k) => r3.v + k
+  }
+  inspect(got, "8")
+}

--- a/fixtures/contract_conformance_test.vibe
+++ b/fixtures/contract_conformance_test.vibe
@@ -13,7 +13,7 @@ import ../lib/@vibe/compiler/core {
 }
 
 import ../lib/@vibe/compiler/contract {
-  parse_contract_program, check_contract, contract_hash, package_hash_from_sources, extract_package_version, extract_require_pins, is_strict_semver, is_package_pin, contract_surface_lines, classify_contract_change, semver_bump_kind, verify_publish_bump, contract_facade_source
+  parse_contract_program, check_contract, classify_contract_stmts, contract_hash, package_hash_from_sources, extract_package_version, extract_require_pins, is_strict_semver, is_package_pin, contract_surface_lines, classify_contract_change, semver_bump_kind, verify_publish_bump, contract_facade_source
 }
 
 import ../lib/@vibe/core {
@@ -123,8 +123,12 @@ test "bodyless type arity is tracked and enforced (#739)" {
   assert_eq(Array::length(errs), 1)
   assert(String::contains(errs[0], "arity mismatch"))
   // surface lines carry the arity so Box -> Box[T] classifies as major
-  let l_box0 = contract_surface_lines(decls, [("Box", 0)], no_type_defs())
-  let l_box1 = contract_surface_lines(decls, [("Box", 1)], no_type_defs())
+  let l_box0 = contract_surface_lines(decls, [
+    ("Box", 0)
+  ], no_type_defs())
+  let l_box1 = contract_surface_lines(decls, [
+    ("Box", 1)
+  ], no_type_defs())
   assert(classify_contract_change(l_box0, l_box1) == "major")
 }
 
@@ -154,13 +158,21 @@ test "content-addressing hashes (#730 D-1)" {
   assert(String::starts_with(h1, "ct:sha1:"))
   let (d3, o3, _) = parse_contract_program(lex("fn add(x: Int, y: Int) -> String\nopaque type Counter\nfn get(c: Counter) -> Int"))
   assert(!(contract_hash(d3, o3, no_type_defs()) == h1))
-
   // package_hash: path-order-insensitive, content-sensitive.
-  let p1 = package_hash_from_sources([("index.vibei", "fn a() -> Int"), ("./impl.vibe", "export fn a() -> Int { 1 }")])
-  let p2 = package_hash_from_sources([("./impl.vibe", "export fn a() -> Int { 1 }"), ("index.vibei", "fn a() -> Int")])
+  let p1 = package_hash_from_sources([
+    ("index.vibei", "fn a() -> Int"),
+    ("./impl.vibe", "export fn a() -> Int { 1 }")
+  ])
+  let p2 = package_hash_from_sources([
+    ("./impl.vibe", "export fn a() -> Int { 1 }"),
+    ("index.vibei", "fn a() -> Int")
+  ])
   assert(p1 == p2)
   assert(String::starts_with(p1, "pkg:sha1:"))
-  let p3 = package_hash_from_sources([("index.vibei", "fn a() -> Int"), ("./impl.vibe", "export fn a() -> Int { 2 }")])
+  let p3 = package_hash_from_sources([
+    ("index.vibei", "fn a() -> Int"),
+    ("./impl.vibe", "export fn a() -> Int { 2 }")
+  ])
   assert(!(p3 == p1))
 }
 
@@ -174,7 +186,6 @@ test "require pin extraction and validation (#730 D-2)" {
   assert(is_package_pin("#pkg:sha1:dfd1c758bb64203416db0b64b5854882a43abc11"))
   assert(!is_package_pin("#pkg:sha1:dfd1"))
   assert(!is_package_pin("#ct:sha1:dfd1c758bb64203416db0b64b5854882a43abc11"))
-
   let src = "require @d2/pkg 1.0.0 = #pkg:sha1:dfd1c758bb64203416db0b64b5854882a43abc11\n\nimport @d2/pkg { triple }\nlet x = 1"
   let (pins, blanked) = extract_require_pins(src)
   assert_eq(Array::length(pins), 1)
@@ -202,12 +213,16 @@ test "malformed require lines are rejected (#730 D-2)" {
   let bad1 = handle {
     let _ = extract_require_pins("require @a/b 1.2 = #pkg:sha1:dfd1c758bb64203416db0b64b5854882a43abc11\n")
     false
-  } with Exception { Throw(_) => true }
+  } with Exception {
+    Throw(_) => true
+  }
   assert(bad1)
   let bad2 = handle {
     let _ = extract_require_pins("require @a/b 1.2.3 = #bad\n")
     false
-  } with Exception { Throw(_) => true }
+  } with Exception {
+    Throw(_) => true
+  }
   assert(bad2)
 }
 
@@ -235,7 +250,6 @@ test "semver bump verification (#732 Phase F)" {
   assert(semver_bump_kind("1.2.3", "2.0.0") is Some("major"))
   assert(semver_bump_kind("1.2.3", "1.4.0") is None)
   assert(semver_bump_kind("1.2.3", "1.2.3") is None)
-
   let (d1, o1, _) = parse_contract_program(lex("fn a(x: Int) -> Int"))
   let l1 = contract_surface_lines(d1, o1, no_type_defs())
   let (d2, o2, _) = parse_contract_program(lex("fn a(x: Int) -> Int\nfn b(x: Int) -> Int"))
@@ -357,14 +371,18 @@ test "re-exported symbol matching a declared opaque type is not reported (#847)"
 test "facade generation allocates a declaration satisfied only by re-export (#847)" {
   let (decls, _, _) = parse_contract_program(lex("fn helper(x: Int) -> Int"))
   let unit_stmts = parse_program(lex("export ./other.vibe { helper }"))
-  let facade = contract_facade_source(decls, no_opaques(), no_type_defs(), [("./mid.vibe", unit_stmts)], "")
+  let facade = contract_facade_source(decls, no_opaques(), no_type_defs(), [
+    ("./mid.vibe", unit_stmts)
+  ], "")
   assert(String::contains(facade, "helper"))
 }
 
 test "facade generation allocates a re-exported opaque type (#847)" {
   let (decls, opaques, _) = parse_contract_program(lex("opaque type Counter"))
   let unit_stmts = parse_program(lex("export ./other.vibe { Counter }"))
-  let facade = contract_facade_source(decls, opaques, no_type_defs(), [("./mid.vibe", unit_stmts)], "")
+  let facade = contract_facade_source(decls, opaques, no_type_defs(), [
+    ("./mid.vibe", unit_stmts)
+  ], "")
   assert(String::contains(facade, "Counter"))
 }
 
@@ -396,4 +414,36 @@ test "version directive: malformed forms are rejected (#754)" {
     Throw(msg) => msg
   }
   assert(String::contains(dup, "duplicate version directive"))
+}
+
+test "sibling re-definition of a transparent contract type is rejected (#1879)" {
+  let (decls, opaques, extra) = parse_contract_program(lex("enum Hue {\n  Crimson;\n  Teal(Int)\n}\nfn describe(h: Hue) -> Int"))
+  let (_, type_defs) = classify_contract_stmts(extra)
+  let impls = parse_program(lex("enum Hue {\n  Crimson;\n  Teal(Int)\n}\nexport fn describe(h: Hue) -> Int {\n  0\n}"))
+  let errors = check_contract(decls, opaques, impls, type_defs)
+  let mut found = false
+  let mut i = 0
+  while i < Array::length(errors) {
+    if String::contains(Array::get(errors, i), "transparent contract type 'Hue' is re-defined") {
+      found = true
+    }
+    i = i + 1
+  }
+  assert(found)
+}
+
+test "an implementation that does NOT re-define the contract type passes (#1879)" {
+  let (decls, opaques, extra) = parse_contract_program(lex("enum Hue {\n  Crimson;\n  Teal(Int)\n}\nfn describe(h: Hue) -> Int"))
+  let (_, type_defs) = classify_contract_stmts(extra)
+  let impls = parse_program(lex("export fn describe(h: Hue) -> Int {\n  0\n}"))
+  let errors = check_contract(decls, opaques, impls, type_defs)
+  assert_eq(Array::length(errors), 0)
+}
+
+test "an opaque contract type MUST be defined by a sibling and stays accepted (#1879)" {
+  let (decls, opaques, extra) = parse_contract_program(lex("opaque type Counter\nfn counter_new(n: Int) -> Counter"))
+  let (_, type_defs) = classify_contract_stmts(extra)
+  let impls = parse_program(lex("export struct Counter {\n  v: Int\n}\nexport fn counter_new(n: Int) -> Counter {\n  Counter::{ v: n }\n}"))
+  let errors = check_contract(decls, opaques, impls, type_defs)
+  assert_eq(Array::length(errors), 0)
 }

--- a/fixtures/exn_kind_side_channel_test.vibe
+++ b/fixtures/exn_kind_side_channel_test.vibe
@@ -195,3 +195,34 @@ test "the outer payload survives an inner handled throw" {
   }
   assert_eq(m, "outer")
 }
+
+test "a bound anonymous record publishes no internal sentinel as its kind (#1878)" {
+  let r = record {
+    a: 1,
+    b: 2
+  }
+  let k = handle {
+    throw(r)
+    ""
+  } with Exception {
+    Throw(_) => __exn_kind()
+  }
+  // The var_types entry for `r` is the internal `__anonrec:` shape sentinel;
+  // publishing it as the kind would leak `<__anonrec:a,b>` into erased
+  // sinks. An unresolved kind ("") makes the sink fall back to the safely
+  // rendered payload instead.
+  assert_eq(k, "")
+}
+
+test "a bound tuple carrying a record publishes no internal sentinel (#1878)" {
+  let t = (record {
+    a: 1
+  }, 2)
+  let k = handle {
+    throw(t)
+    ""
+  } with Exception {
+    Throw(_) => __exn_kind()
+  }
+  assert_eq(k, "")
+}

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -732,6 +732,42 @@ export fn check_contract(decls: Array[(String, String)], opaque_names: Array[(St
     }
     rxi = rxi + 1
   }
+  // #1879: a TRANSPARENT contract type (struct / enum / type alias) must not
+  // be re-defined by an implementation file. The contract definition is the
+  // single definition site (#1840's materialized types module); a sibling
+  // re-definition compiles into a SECOND type identity whose enum ctor tags
+  // disagree with the contract's, so matches fall through to a runtime trap
+  // -- or silently take the wrong arm when tags happen to coincide -- with
+  // no diagnostic anywhere. Reject it here, where both surfaces are in hand.
+  // (An OPAQUE contract type is the inverse contract -- declared here,
+  // defined by a sibling -- and stays untouched: contract_type_defs carries
+  // only the transparent definitions.)
+  let impl_type_defs = collect_impl_type_defs(impl_stmts)
+  let tf_defs = contract_type_family_defs(contract_type_defs)
+  let mut tfi = 0
+  while tfi < Array::length(tf_defs) {
+    let tf_name = match Array::get(tf_defs, tfi) {
+      SStruct(_, sname, _, _, _, _) => sname,
+      SEnum(_, ename, _, _, _) => ename,
+      STypeAlias(_, aname, _, _) => aname,
+      _ => ""
+    }
+    if tf_name == "" {
+      ()
+    } else {
+      let mut iti = 0
+      while iti < Array::length(impl_type_defs) {
+        let (itname, _, _) = Array::get(impl_type_defs, iti)
+        if itname == tf_name {
+          Array::push(errors, "transparent contract type '\{tf_name}' is re-defined by an implementation file -- the contract definition is the single definition site; remove the local definition (a re-definition is a second runtime type identity, #1879)")
+          iti = Array::length(impl_type_defs)
+        } else {
+          iti = iti + 1
+        }
+      }
+    }
+    tfi = tfi + 1
+  }
   errors
 }
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1242,6 +1242,53 @@ fn anon_record_prefix() -> String {
   "__anonrec:"
 }
 
+/// #1878: compound sentinel for a TUPLE whose elements include anonymous
+/// records — `__anontup:` + ';'-joined element entries, each either a full
+/// `__anonrec:` sentinel or "" (untracked element). Record sentinels join
+/// fields with ',', so ';' is unambiguous. One level only: a tuple nested
+/// inside a tuple stays untracked, same scope as the parser's positional
+/// sub-tuple destructure support.
+fn anon_tuple_prefix() -> String {
+  "__anontup:"
+}
+
+/// The `__anontup:` sentinel for a tuple literal's elements, or None when no
+/// element is an anonymous record (nothing to track).
+fn tuple_sentinel_from_exprs(items: Array[Expr]) -> Option[String] {
+  let parts = empty_str_array()
+  let mut any = false
+  let mut i = 0
+  while i < Array::length(items) {
+    match Array::get(items, i) {
+      ERecord(rn, fields, _) => if String::length(rn) == 0 {
+        let names = empty_str_array()
+        let mut fi = 0
+        while fi < Array::length(fields) {
+          let (fname, _) = Array::get(fields, fi)
+          Array::push(names, fname)
+          fi = fi + 1
+        }
+        Array::push(parts, anon_record_sentinel(names))
+        any = true
+      } else {
+        Array::push(parts, "")
+      },
+      _ => Array::push(parts, "")
+    }
+    i = i + 1
+  }
+  if any {
+    Some(String::concat(anon_tuple_prefix(), String::join(parts, ";")))
+  } else {
+    None
+  }
+}
+
+/// Split a `__anontup:` sentinel back into its per-element entries.
+fn anon_tuple_elems(sentinel: String) -> Array[String] {
+  String::split(sentinel[String::length(anon_tuple_prefix()): String::length(sentinel)], ";")
+}
+
 /// Encode an ordered field-name list as a `var_types` sentinel value.
 fn anon_record_sentinel(names: Array[String]) -> String {
   let mut s = anon_record_prefix()
@@ -1319,6 +1366,12 @@ fn anon_record_inferred(val: Expr, struct_sets: Array[(String, Array[String])]) 
       }
       Some(anon_record_sentinel(names))
     },
+    // #1878: a tuple literal carrying anonymous records gets the compound
+    // `__anontup:` sentinel, so a later tuple destructure of the binding
+    // (`let (r, n) = t` — an EMatch with a PTuple pattern) can hand each
+    // element's record sentinel to its binder. Sentinel entries are inert
+    // for every other var_types consumer (no struct name ever matches).
+    ETuple(items) => tuple_sentinel_from_exprs(items),
     _ => None
   }
 }
@@ -2657,6 +2710,54 @@ fn eq_shape_bind(var_types: Array[(String, String)], name: String, val: Expr, st
 /// for, not more sentinels. Everything not matched here behaves exactly as
 /// before.
 fn arm_binder_var_types(scrut: Expr, p: Pat, var_types: Array[(String, String)]) -> Array[(String, String)] {
+  // #1878: a PTuple arm over a tuple that carries anonymous records — either
+  // a NAME whose var_types entry is the compound `__anontup:` sentinel, or a
+  // literal tuple scrutinee — hands each element's `__anonrec:` sentinel to
+  // its positional binder, so `let (r, n) = t` followed by `r.a` lowers to
+  // the positional `__rec_field` read instead of dying in codegen's
+  // struct-table EDot path ("unknown struct field", no location).
+  match p {
+    PTuple(tup_pats) => {
+      let tup_sent = match scrut {
+        EIdent(tsn, _) => match lookup_var_type(var_types, tsn) {
+          Some(ts) => ts,
+          None => ""
+        },
+        ETuple(titems) => match tuple_sentinel_from_exprs(titems) {
+          Some(ts) => ts,
+          None => ""
+        },
+        _ => ""
+      }
+      if String::starts_with(tup_sent, anon_tuple_prefix()) {
+        let elems = anon_tuple_elems(tup_sent)
+        let mut tacc = var_types
+        let mut tpi = 0
+        while tpi < Array::length(tup_pats) {
+          if tpi < Array::length(elems) {
+            match Array::get(tup_pats, tpi) {
+              PBind(tv) => {
+                let esent = Array::get(elems, tpi)
+                if String::starts_with(esent, anon_record_prefix()) {
+                  tacc = extend_var_types(tacc, tv, Some(esent))
+                } else {
+                  ()
+                }
+              },
+              _ => ()
+            }
+          } else {
+            ()
+          }
+          tpi = tpi + 1
+        }
+        return tacc
+      } else {
+        ()
+      }
+    },
+    _ => ()
+  }
   match scrut {
     EIdent(sname, _) => match p {
       PCtor(cn, sub) => {
@@ -3778,7 +3879,12 @@ fn railway_rw(expr: Expr, struct_sets: Array[(String, Array[String])], var_types
       let mut i = 0
       while i < Array::length(arms) {
         let (p, b) = Array::get(arms, i)
-        Array::push(out, (p, railway_rw(b, struct_sets, var_types, fn_returns)))
+        // #1878: tuple-destructure arms hand record sentinels to their
+        // binders (see arm_binder_var_types) — this walk runs BEFORE the
+        // checker, so the arm body's `binding.field` reads rewrite to
+        // positional `__rec_field` here too.
+        let arm_vars = arm_binder_var_types(scrut, p, var_types)
+        Array::push(out, (p, railway_rw(b, struct_sets, arm_vars, fn_returns)))
         i = i + 1
       }
       EMatch(railway_rw(scrut, struct_sets, var_types, fn_returns), out)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -4859,9 +4859,22 @@ fn rewrite_expr(expr: Expr, gens: Array[(String, Array[(String, String, Int)])],
         // disagree only by one being MORE conservative (an unresolved name is
         // ""), which costs a kind here and a row precision there, never
         // soundness.
-        let kind = match infer_arg_type_name(perform_throw_payload(args), struct_sets, var_types, fn_returns) {
+        // #1878 (Codex review on #1892): `infer_arg_type_name` can answer
+        // with an internal shape sentinel (`__anonrec:` for a record
+        // binding, `__anontup:` for a tuple carrying one) — inert for every
+        // dispatch consumer, but THIS site publishes the string as the
+        // user-facing exception kind, where a sentinel would render as
+        // `<__anontup:__anonrec:a;>`. Publish "" instead, the same value an
+        // unresolved payload gets (the erased sink then falls back to the
+        // safely rendered payload).
+        let kind0 = match infer_arg_type_name(perform_throw_payload(args), struct_sets, var_types, fn_returns) {
           Some(k) => k,
           None => ""
+        }
+        let kind = if String::starts_with(kind0, anon_record_prefix()) || String::starts_with(kind0, anon_tuple_prefix()) {
+          ""
+        } else {
+          kind0
         }
         let rwargs = for a in args {
           rewrite_expr(a, gens, traits, struct_sets, dict_binds, var_types, fn_returns)


### PR DESCRIPTION
Two P1 follow-ups from the #1839 / #1840 work, both with the mechanism already mapped in their issues.

## #1878 — record dot access through a tuple destructure

`let (r, n) = t` lowers to an `EMatch` with a `PTuple` pattern, which dropped the anonymous-record sentinel tracking: the checker accepted `r.a` (CtRecord flows through tuples since #1867) but codegen died with an unlocated `unknown struct field`.

Fix in `desugar_trait_dict.vibe`:
- a tuple literal carrying anonymous records now records a compound `__anontup:` sentinel (`;`-joined element entries; record sentinels join fields with `,`, so the separators are unambiguous; one nesting level, matching the parser's positional sub-tuple scope)
- `arm_binder_var_types` (the existing #1445 arm-binder hook) hands each element's `__anonrec:` sentinel to its positional `PTuple` binder, for both a named scrutinee (`let (r, n) = t`) and a literal one (`let (r, n) = (record { .. }, 3)`)
- the pre-check railway walk's `EMatch` arm now calls the same hook, so both lowering passes agree

Sentinel entries are inert for every other `var_types` consumer (no struct name ever matches them).

## #1879 — sibling re-definition of a transparent contract type

A sibling impl file re-defining a struct / enum / type alias the contract already defines transparently compiled into a second runtime type identity whose enum ctor tags disagree with the contract's — matches fell through to an unlocated runtime trap (re-measured post-#1882: still a trap).

`check_contract` now rejects it with an actionable message:

```
contract violation: transparent contract type 'Hue' is re-defined by an implementation file -- the contract definition is the single definition site; remove the local definition (a re-definition is a second runtime type identity, #1879)
```

Opaque contract types are untouched — being defined by a sibling is their contract, and the new test pins that inverse.

## Validation

- `fixtures/anon_record_tuple_destructure_test.vibe` — three destructure shapes (let via binding, direct literal, match arm), all green
- `fixtures/contract_conformance_test.vibe` — rejection + conformant + opaque-inverse cases
- Existing record and contract-package fixtures unchanged and green
- `bash scripts/compiler_gate.sh` full pass, stage2==stage3 fixpoint (`5ab59662ef32`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC)_