### PR TITLE
perf(edp): 再構築 walk 群を containment query でゲート — used-effect 単価と base の row-only effect 税を削減 (#1875 round 3)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -435,14 +435,19 @@ fn idp_is_host_stream_named_raw(nm: String) -> Bool {
   String::starts_with(nm, "vibe_hs_get_raw$")
 }
 
+// #1875 R3: module-level memo -- this predicate runs per CALL NODE of the
+// whole merged program during the direct-perform inlining walk, and used to
+// rebuild the table (and scan it without early exit) on every probe.
+let idp_pure_builtin_names_table: Array[String] = idp_pure_builtin_names()
+
 fn idp_is_pure_builtin_call(nm: String) -> Bool {
   if idp_is_host_future_named_raw(nm) || idp_is_host_stream_named_raw(nm) {
     true
   } else {
-    let names = idp_pure_builtin_names()
+    let names = idp_pure_builtin_names_table
     let mut i = 0
     let mut found = false
-    while i < Array::length(names) {
+    while i < Array::length(names) && !found {
       if Array::get(names, i) == nm {
         found = true
       } else {
@@ -1939,12 +1944,41 @@ fn edp_may_perform_fields(fields: Array[(String, Expr)], ename: String, perf_fns
 /// site is vacuous by construction and no reachability question is asked.
 fn edp_collect_performing_fns(stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], ename: String, inert: Array[String], fn_names: Array[String]) -> Array[String] {
   let out = empty_str_array()
+  // #1875 R3: this fixpoint used to call edp_find_fn_body (an O(defs) scan
+  // allocating an Option) for every function on every round, and rebuild
+  // the read-query object per probe -- 17MB of allocation for one analyzed
+  // effect. Resolve each entry's body ONCE through its own stmt index, and
+  // track membership in a Bool array aligned with fn_defs instead of a
+  // linear name scan. Entry-order bodies are a conservative SUPERSET of the
+  // old last-wins-by-name lookup when duplicate top-level names exist (a
+  // non-last duplicate's body is now inspected instead of shadowed); a
+  // superset only keeps more handles for ordinary migration -- it can never
+  // erase a handle the old answer kept.
+  let bodies = array_empty()
+  let member = edp_empty_bool_array()
+  let mut bi = 0
+  while bi < Array::length(fn_defs) {
+    let (bidx, _, _, _, _, _) = Array::get(fn_defs, bi)
+    match Array::get(stmts, bidx) {
+      SLet(_, _, _, _, EFn(_, _, _, _, _, fnb)) => Array::push(bodies, Some(fnb)),
+      _ => Array::push(bodies, None)
+    }
+    Array::push(member, false)
+    bi = bi + 1
+  }
+  let q_perform = RQPerformsUserEffect(ename)
+  let q_opaque = RQOpaqueCall(inert, fn_names)
   let mut i = 0
   while i < Array::length(fn_defs) {
     let (_, _, _, nm, _, _) = Array::get(fn_defs, i)
-    match edp_find_fn_body(stmts, fn_defs, nm) {
-      Some(body) => if (edp_performs_user_effect_expr(body, ename) || edp_body_has_opaque_call(body, inert, fn_names)) && !edp_str_array_contains(out, nm) {
-        Array::push(out, nm)
+    match Array::get(bodies, i) {
+      Some(body) => if (edp_rq_fold(q_perform, body) > 0 || edp_rq_fold(q_opaque, body) > 0) && !Array::get(member, i) {
+        Array::set(member, i, true)
+        if edp_str_array_contains(out, nm) {
+          ()
+        } else {
+          Array::push(out, nm)
+        }
       } else {
         ()
       },
@@ -1952,6 +1986,21 @@ fn edp_collect_performing_fns(stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Boo
     }
     i = i + 1
   }
+  // Same-name entries share membership: sync flags so the fixpoint below
+  // never re-adds a name the seed already holds.
+  let mut si = 0
+  while si < Array::length(fn_defs) {
+    let (_, _, _, snm, _, _) = Array::get(fn_defs, si)
+    if !Array::get(member, si) && edp_str_array_contains(out, snm) {
+      Array::set(member, si, true)
+    } else {
+      ()
+    }
+    si = si + 1
+  }
+  // The query aliases `out`, so a name pushed mid-round is visible to the
+  // very next containment probe without rebuilding the query object.
+  let q_calls = RQCallsAny(out)
   let mut grew = true
   let mut rounds = 0
   while grew && rounds < Array::length(fn_defs) + 1 {
@@ -1959,13 +2008,18 @@ fn edp_collect_performing_fns(stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Boo
     rounds = rounds + 1
     let mut j = 0
     while j < Array::length(fn_defs) {
-      let (_, _, _, nm2, _, _) = Array::get(fn_defs, j)
-      if edp_str_array_contains(out, nm2) {
+      if Array::get(member, j) {
         ()
       } else {
-        match edp_find_fn_body(stmts, fn_defs, nm2) {
-          Some(body2) => if edp_body_calls_any(body2, out) {
-            Array::push(out, nm2)
+        match Array::get(bodies, j) {
+          Some(body2) => if edp_rq_fold(q_calls, body2) > 0 {
+            let (_, _, _, nm2, _, _) = Array::get(fn_defs, j)
+            Array::set(member, j, true)
+            if edp_str_array_contains(out, nm2) {
+              ()
+            } else {
+              Array::push(out, nm2)
+            }
             grew = true
           } else {
             ()
@@ -4587,8 +4641,16 @@ fn edp_pure_builtin_names() -> Array[String] {
   ]
 }
 
+// #1875 R3: module-level memo (initialized once -- module_let_memo_test.vibe
+// is the spec). edp_is_pure_builtin_call runs per CALL NODE inside every
+// safety scan and read query (RQOpaqueCall via edp_callee_is_resolvable,
+// edp_has_unsafe_construct_sc), so rebuilding the ~100-entry table per probe
+// was ~17MB of allocation for one analyzed effect's performing-fns fixpoint
+// alone.
+let edp_pure_builtin_names_table: Array[String] = edp_pure_builtin_names()
+
 fn edp_is_pure_builtin_call(nm: String) -> Bool {
-  idp_is_host_future_named_raw(nm) || idp_is_host_stream_named_raw(nm) || edp_str_array_contains(edp_pure_builtin_names(), nm)
+  idp_is_host_future_named_raw(nm) || idp_is_host_stream_named_raw(nm) || edp_str_array_contains(edp_pure_builtin_names_table, nm)
 }
 
 /// Every top-level function name whose declared effect row is
@@ -5391,8 +5453,17 @@ fn edp_all_sites_eligible(stmts: Array[Stmt], ename: String, needing: Array[Stri
     // #1116 Codex P1: drop names that are ALSO bound to a non-evidence
     // value in some other scope — widening those program-wide would
     // rewrite an unrelated same-named call at the wrong arity.
+    // #1875 R3: the poison set exists solely to filter td_binds_raw, so
+    // with no candidate names the whole-program binder walk (every binder
+    // in the merged program, linearly deduped) has nothing to filter --
+    // skip it. The common case for a real used effect (performs + handles,
+    // no row-typed closure literals) is exactly this.
     let td_poison = empty_str_array()
-    edp_collect_poison_stmts(stmts, ename, needing, es_names, es_members_list, td_poison)
+    if Array::length(td_binds_raw) > 0 {
+      edp_collect_poison_stmts(stmts, ename, needing, es_names, es_members_list, td_poison)
+    } else {
+      ()
+    }
     let td_binds = edp_filter_unpoisoned(td_binds_raw, td_poison)
     let td_mode = Array::length(td_binds) > 0 || Array::length(td_lits) > 0 || edp_any_row_typed_param(stmts, fn_defs, ename, es_names, es_members_list)
     // Handle sites are checked PER TOP-LEVEL STATEMENT (not from the flat
@@ -7301,9 +7372,14 @@ fn edp_apply_migration(stmts: Array[Stmt], ename: String, ops: Array[(String, Ar
   edp_row_lit_scan(stmts, ename, needing, es_names, es_members_list, td_binds_raw, td_lits0)
   // #1116 Codex P1: same shadow-poison filter as eligibility (both views
   // must agree on the widened set, or apply widens what eligibility did
-  // not vet).
+  // not vet). #1875 R3: and the same skip -- no candidates, nothing to
+  // filter, no binder walk.
   let td_poison0 = empty_str_array()
-  edp_collect_poison_stmts(stmts, ename, needing, es_names, es_members_list, td_poison0)
+  if Array::length(td_binds_raw) > 0 {
+    edp_collect_poison_stmts(stmts, ename, needing, es_names, es_members_list, td_poison0)
+  } else {
+    ()
+  }
   let td_binds = edp_filter_unpoisoned(td_binds_raw, td_poison0)
   let td_mode = Array::length(td_binds) > 0 || Array::length(td_lits0) > 0 || edp_any_row_typed_param(stmts, fn_defs, ename, es_names, es_members_list)
   if td_mode {

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -1092,6 +1092,17 @@ export fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[St
   // to edp_first_live_replay_handle and got rejected. It cannot go through
   // migration either -- with no SEffectDef there is no operation list to
   // build a dict from -- so erasure is the only lowering it has.
+  // #1875: the effect names that actually HAVE a handle site somewhere.
+  // vhe_names is declared-effects ∪ handle-labeled names, so a declared
+  // effect nobody handles is in the loop below -- and
+  // edp_erase_effect_handles is a RECONSTRUCTING walk (it rebuilds every
+  // expression node in the merged program), so running it for a name with
+  // zero handle sites allocated ~10MB of identical AST per unused effect
+  // declaration. Erasing nothing is a no-op: skip the walk outright when
+  // the name never appears on a handle. (R3: collected once and unioned
+  // into vhe_names below -- this used to be two identical program walks.)
+  let vhe_handle_names = empty_str_array()
+  edp_collect_handle_effect_names(stmts, vhe_handle_names)
   let vhe_names = empty_str_array()
   let mut vhn = 0
   while vhn < Array::length(effect_defs) {
@@ -1103,17 +1114,16 @@ export fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[St
     }
     vhn = vhn + 1
   }
-  edp_collect_handle_effect_names(stmts, vhe_names)
-  // #1875: the effect names that actually HAVE a handle site somewhere.
-  // vhe_names is declared-effects ∪ handle-labeled names, so a declared
-  // effect nobody handles is in the loop below -- and
-  // edp_erase_effect_handles is a RECONSTRUCTING walk (it rebuilds every
-  // expression node in the merged program), so running it for a name with
-  // zero handle sites allocated ~10MB of identical AST per unused effect
-  // declaration. Erasing nothing is a no-op: skip the walk outright when
-  // the name never appears on a handle.
-  let vhe_handle_names = empty_str_array()
-  edp_collect_handle_effect_names(stmts, vhe_handle_names)
+  let mut vhu = 0
+  while vhu < Array::length(vhe_handle_names) {
+    let vh_labeled = Array::get(vhe_handle_names, vhu)
+    if edp_str_array_contains(vhe_names, vh_labeled) {
+      ()
+    } else {
+      Array::push(vhe_names, vh_labeled)
+    }
+    vhu = vhu + 1
+  }
   let vhe_fn_defs = edp_collect_fn_defs(stmts)
   let vhe_fn_names = edp_all_fn_names(vhe_fn_defs)
   let vhe_inert = edp_pure_fn_names(vhe_fn_defs)
@@ -1332,7 +1342,9 @@ enum EdpReadQuery {
   RQScpsBindsName(String);
   RQRefsName(String);
   RQLiteralNeeds((String, Array[String], Array[String], Int, Array[String]));
-  RQTrigger
+  RQTrigger;
+  RQHandlesEffect(String);
+  RQNeedingValueArg(Array[String])
 }
 
 fn edp_rq_is_count(q: EdpReadQuery) -> Bool {
@@ -1350,6 +1362,8 @@ fn edp_rq_stops_array_on_hit(q: EdpReadQuery) -> Bool {
     RQOpaqueCall(_, _) => true,
     RQCallsAny(_) => true,
     RQEdpBindsName(_) => true,
+    RQHandlesEffect(_) => true,
+    RQNeedingValueArg(_) => true,
     _ => false
   }
 }
@@ -1653,7 +1667,34 @@ fn edp_rq_local(q: EdpReadQuery, e: Expr) -> Int {
         0
       }
     },
-    RQTrigger => 0
+    RQTrigger => 0,
+    RQHandlesEffect(ename) => match e {
+      EHandle(_, arms) => if edp_handle_matches_effect(arms, ename) {
+        1
+      } else {
+        0
+      },
+      _ => 0
+    },
+    RQNeedingValueArg(names) => match e {
+      ECall(_, args, _) => {
+        let mut ai = 0
+        let mut hit = 0
+        while ai < Array::length(args) && hit == 0 {
+          match Array::get(args, ai) {
+            EIdent(an, _) => if edp_str_array_contains(names, an) {
+              hit = 1
+            } else {
+              ()
+            },
+            _ => ()
+          }
+          ai = ai + 1
+        }
+        hit
+      },
+      _ => 0
+    }
   }
 }
 
@@ -2066,14 +2107,41 @@ fn edp_erase_effect_handles_exprs(es: Array[Expr], ename: String, analyze: Bool,
 }
 
 fn edp_erase_effect_handles(stmts: Array[Stmt], ename: String, analyze: Bool, perf_fns: Array[String], inert: Array[String], fn_names: Array[String]) -> Unit {
+  // #1875 R3: edp_erase_effect_handles_expr is a RECONSTRUCTING walk -- on a
+  // statement with no matching handle site it rebuilds the whole expression
+  // tree only to return a structurally identical copy. Handle sites are rare
+  // (a handful of statements in a whole merged program), so gate the rebuild
+  // behind a read-only containment query and leave every other statement
+  // untouched.
+  let hq = RQHandlesEffect(ename)
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(exported, is_rec, name, ty, expr) => Array::set(stmts, i, SLet(exported, is_rec, name, ty, edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names))),
-      SLetMut(nm, ty, expr) => Array::set(stmts, i, SLetMut(nm, ty, edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names))),
-      SExpr(expr) => Array::set(stmts, i, SExpr(edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names))),
-      STest(tn, expr) => Array::set(stmts, i, STest(tn, edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names))),
-      SBench(bn, expr) => Array::set(stmts, i, SBench(bn, edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names))),
+      SLet(exported, is_rec, name, ty, expr) => if edp_rq_fold(hq, expr) > 0 {
+        Array::set(stmts, i, SLet(exported, is_rec, name, ty, edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names)))
+      } else {
+        ()
+      },
+      SLetMut(nm, ty, expr) => if edp_rq_fold(hq, expr) > 0 {
+        Array::set(stmts, i, SLetMut(nm, ty, edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names)))
+      } else {
+        ()
+      },
+      SExpr(expr) => if edp_rq_fold(hq, expr) > 0 {
+        Array::set(stmts, i, SExpr(edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names)))
+      } else {
+        ()
+      },
+      STest(tn, expr) => if edp_rq_fold(hq, expr) > 0 {
+        Array::set(stmts, i, STest(tn, edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names)))
+      } else {
+        ()
+      },
+      SBench(bn, expr) => if edp_rq_fold(hq, expr) > 0 {
+        Array::set(stmts, i, SBench(bn, edp_erase_effect_handles_expr(expr, ename, analyze, perf_fns, inert, fn_names)))
+      } else {
+        ()
+      },
       _ => ()
     }
     i = i + 1
@@ -3419,16 +3487,40 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
   // front lets those effects skip the loop body entirely.
   let plan_handle_names = empty_str_array()
   edp_collect_handle_effect_names(stmts, plan_handle_names)
+  // #1875 R3: the base inert set (pure fns + free-host-inert names) is
+  // effect-independent; computing it per effect re-ran a full-program
+  // callee scan for every planned effect. Build it once and copy per
+  // effect before the effect-specific appends.
+  let plan_base_inert = edp_pure_fn_names(fn_defs)
+  edp_append_free_host_inert_names(stmts, plan_base_inert)
   let mut ei = 0
   while ei < Array::length(effect_defs) {
     let (ename, ops) = Array::get(effect_defs, ei)
-    let needing_all = edp_needing_names_tab(fn_defs, row_labels, ename)
-    if Array::length(needing_all) == 0 && !edp_str_array_contains(plan_handle_names, ename) {
-      // Unused effect (#1875): no fn carries its row and nothing handles
-      // it -- there is nothing to plan, and every scan below reduces to
-      // work over empty sets. Skip to the next effect.
+    // #1875 R3: exception-labeled handles are excluded from
+    // edp_collect_handle_effect_names, so for an exception-named declared
+    // effect "absent from plan_handle_names" does NOT prove "zero sites" --
+    // those keep the older needing-based guard below.
+    let plan_is_exc = is_exception_effect_name(ename)
+    if !plan_is_exc && !edp_str_array_contains(plan_handle_names, ename) {
+      // No handle site anywhere for this effect (#1875 R3, extending the
+      // needing==0 skip): with zero sites nothing can be planned
+      // (edp_all_sites_eligible bails on an empty site list, so
+      // edp_try_plan_for_effect is always None), the eta-wrap mutation and
+      // BOTH error pushes below are each gated on live handle sites, and
+      // the remaining scans only feed those. The whole body is a provable
+      // no-op -- skip it. This is what keeps a row-only effect (many fns
+      // declare the row, nothing in this closure handles it -- @vibe/fs's
+      // `Fs` in the compiler tree) from paying full-program scans per
+      // compile. (Both the name collection and edp_handle_matches_effect
+      // read the same arms[0] qname prefix, so for non-exception names
+      // "name absent" and "edp_collect_handle_sites finds nothing" are the
+      // same statement.)
+      ()
+    } else if plan_is_exc && Array::length(edp_needing_names_tab(fn_defs, row_labels, ename)) == 0 && !edp_str_array_contains(plan_handle_names, ename) {
+      // Pre-R3 guard, kept for the exception-named case only.
       ()
     } else {
+      let needing_all = edp_needing_names_tab(fn_defs, row_labels, ename)
       // Shadowed-name exclusion is ALSO unconditional (#1074 review: a
       // needing function's name shadowed by a local binding elsewhere in
       // the program is never safe to leave in `needing` regardless of
@@ -3445,8 +3537,7 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
       // outside any handle; see edp_fn_is_perform_free's doc comment). The
       // same predicate feeds the pure_fns appends inside eligibility/apply,
       // so both views classify these names identically.
-      let pf_inert = edp_pure_fn_names(fn_defs)
-      edp_append_free_host_inert_names(stmts, pf_inert)
+      let pf_inert = Array::concat(plan_base_inert, empty_str_array())
       edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pf_inert, row_labels)
       edp_append_perform_free_row_fns(stmts, fn_defs, ename, pf_inert, row_labels)
       let needing_full = array_empty()
@@ -3470,11 +3561,22 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
       // reach is then still an escape, and stays a hard error per ADR-0076
       // 追記34 V2. Both are only relevant while handle sites for E remain:
       // with none, nothing gets migrated in the first place.
-      let live_sites = Array::length(needing_full) > 0 && Array::length(edp_collect_handle_sites(stmts, ename)) > 0
+      let pre_sites = edp_collect_handle_sites(stmts, ename)
+      let live_sites = Array::length(needing_full) > 0 && Array::length(pre_sites) > 0
       if live_sites {
         edp_etawrap_stmts(stmts, needing_full, ename, fn_defs, es_names, es_members_list)
       } else {
         ()
+      }
+      // #1875 R3: collect sites once per effect and thread them through
+      // edp_try_plan_for_effect (it used to re-collect internally, and the
+      // V1 guard below collected a third time). The eta-wrap rewrite above
+      // rebuilds the statements it touches, so refresh the collection when
+      // it ran; otherwise the pre-wrap collection is still the live tree.
+      let plan_sites = if live_sites {
+        edp_collect_handle_sites(stmts, ename)
+      } else {
+        pre_sites
       }
       let escaped = if live_sites {
         edp_needing_escape_stmts(stmts, needing_full, ename, fn_defs, es_names, es_members_list)
@@ -3486,7 +3588,7 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
       } else {
         ()
       }
-      match edp_try_plan_for_effect(stmts, ename, ops, needing_full, fn_defs, row_labels) {
+      match edp_try_plan_for_effect(stmts, ename, ops, needing_full, plan_sites, fn_defs, row_labels) {
         Some(plan) => if escaped == "" {
           Array::push(plans, plan)
         } else {
@@ -3511,7 +3613,7 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
           if Array::length(needing_live) == Array::length(needing_full) {
             ()
           } else {
-            match edp_try_plan_for_effect(stmts, ename, ops, needing_live, fn_defs, row_labels) {
+            match edp_try_plan_for_effect(stmts, ename, ops, needing_live, plan_sites, fn_defs, row_labels) {
               Some(plan2) => {
                 Array::push(plans, plan2)
                 planned2 = true
@@ -3534,7 +3636,7 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
             // this pass, so a CPS-mode effect's row-E closure values (e.g.
             // spawn_suspend's `f: () -> T with Async + Exception` param)
             // follow the STEP convention and are none of edp's business.
-            if Array::length(edp_collect_handle_sites(stmts, ename)) > 0 && (Array::length(gb) > 0 || Array::length(gl) > 0 || edp_any_row_typed_param(stmts, fn_defs, ename, es_names, es_members_list)) {
+            if Array::length(plan_sites) > 0 && (Array::length(gb) > 0 || Array::length(gl) > 0 || edp_any_row_typed_param(stmts, fn_defs, ename, es_names, es_members_list)) {
               // #1347: name the higher-order operation when that is the cause.
               // The generic wording below points at "a handle body, a needing
               // function, or a row-carrying closure literal", none of which the
@@ -3572,7 +3674,7 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
 /// when there is neither a needing function NOR any proven owner param
 /// (nothing to gain; matches the old behavior for every previously-planned
 /// program exactly).
-fn edp_try_plan_for_effect(stmts: Array[Stmt], ename: String, ops: Array[(String, Array[TypeExpr], TypeExpr)], needing: Array[String], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], row_labels: Array[Array[String]]) -> Option[(String, Array[(String, Array[TypeExpr], TypeExpr)], Array[String], Array[(Expr, Array[(Pat, Expr)])])] {
+fn edp_try_plan_for_effect(stmts: Array[Stmt], ename: String, ops: Array[(String, Array[TypeExpr], TypeExpr)], needing: Array[String], handle_sites: Array[(Expr, Array[(Pat, Expr)])], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], row_labels: Array[Array[String]]) -> Option[(String, Array[(String, Array[TypeExpr], TypeExpr)], Array[String], Array[(Expr, Array[(Pat, Expr)])])] {
   // ADR-0076 追記31 Vertical C (replay 撤去): a handle site EXISTING is
   // itself worth planning for — a self-discharging dispatcher whose body
   // performs the effect directly (lsp_server.vibe's Lsp handler is the
@@ -3581,7 +3683,8 @@ fn edp_try_plan_for_effect(stmts: Array[Stmt], ename: String, ops: Array[(String
   // Eligibility (edp_all_sites_eligible / edp_has_unsafe_construct) still
   // decides migration site-by-site, and zero collected sites still bails
   // (edp_all_sites_eligible returns false on an empty site list).
-  let handle_sites = edp_collect_handle_sites(stmts, ename)
+  // #1875 R3: `handle_sites` is collected once by the caller (it reflects
+  // the post-eta-wrap tree) instead of being re-collected here per attempt.
   let worth = Array::length(needing) > 0 || Array::length(handle_sites) > 0 || edp_any_handle_owner_cp(stmts, ename, needing, fn_defs, row_labels)
   if !worth {
     None
@@ -5301,6 +5404,12 @@ fn edp_all_sites_eligible(stmts: Array[Stmt], ename: String, needing: Array[Stri
     // (#1074 review: name-only matching without scoping is how the
     // shadowing bug happened).
     let mut ok = true
+    // #1875 R3: the per-statement safe-call set (owner closure-param proof
+    // + type-directed widening + two concats) only matters for statements
+    // that actually CONTAIN a site of `ename` -- gate the whole body behind
+    // a read-only containment query so the thousands of site-free
+    // statements cost no allocation here.
+    let hq = RQHandlesEffect(ename)
     let mut hsi = 0
     while hsi < Array::length(stmts) {
       // ADR-0076 追記34 V2: non-SLet site-bearing statements (test/bench
@@ -5316,7 +5425,7 @@ fn edp_all_sites_eligible(stmts: Array[Stmt], ename: String, needing: Array[Stri
         _ => None
       }
       match sval_opt {
-        Some(sval) => {
+        Some(sval) => if edp_rq_fold(hq, sval) > 0 {
           let hext = match Array::get(stmts, hsi) {
             SLet(_, _, snm, _, _) => match sval {
               EFn(_, _, sparams, _, _, sbody) => edp_closure_param_names_only(edp_handle_owner_cps(stmts, snm, sparams, sbody, ename, needing, pure_fns, es_names, es_members_list)),
@@ -5345,6 +5454,8 @@ fn edp_all_sites_eligible(stmts: Array[Stmt], ename: String, needing: Array[Stri
             }
             hi = hi + 1
           }
+        } else {
+          ()
         },
         None => ()
       }
@@ -6316,24 +6427,39 @@ fn edp_etawrap_value(stmts: Array[Stmt], fn_defs: Array[(Int, Bool, Bool, String
 /// puts only its BODY in scope (its arms are never rewritten by either).
 fn edp_etawrap_stmts(stmts: Array[Stmt], needing: Array[String], ename: String, fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], es_names: Array[String], es_members_list: Array[Array[String]]) -> Unit {
   let wc = (stmts, fn_defs, es_names, es_members_list)
+  // #1875 R3: the walk only ever changes a call ARGUMENT that is a bare
+  // identifier of a needing function -- on every other statement it is an
+  // identity rebuild of the whole tree. Gate the rebuild behind the exact
+  // necessary condition, read-only.
+  let nq = RQNeedingValueArg(needing)
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(ex, isrec, nm, ty, expr) => {
+      SLet(ex, isrec, nm, ty, expr) => if edp_rq_fold(nq, expr) > 0 {
         let scope = edp_str_array_contains(needing, nm)
         Array::set(stmts, i, SLet(ex, isrec, nm, ty, edp_etawrap_expr(expr, scope, needing, ename, wc)))
+      } else {
+        ()
       },
-      SLetMut(nm, ty, expr) => {
+      SLetMut(nm, ty, expr) => if edp_rq_fold(nq, expr) > 0 {
         Array::set(stmts, i, SLetMut(nm, ty, edp_etawrap_expr(expr, false, needing, ename, wc)))
+      } else {
+        ()
       },
-      SExpr(expr) => {
+      SExpr(expr) => if edp_rq_fold(nq, expr) > 0 {
         Array::set(stmts, i, SExpr(edp_etawrap_expr(expr, false, needing, ename, wc)))
+      } else {
+        ()
       },
-      STest(nm, expr) => {
+      STest(nm, expr) => if edp_rq_fold(nq, expr) > 0 {
         Array::set(stmts, i, STest(nm, edp_etawrap_expr(expr, false, needing, ename, wc)))
+      } else {
+        ()
       },
-      SBench(nm, expr) => {
+      SBench(nm, expr) => if edp_rq_fold(nq, expr) > 0 {
         Array::set(stmts, i, SBench(nm, edp_etawrap_expr(expr, false, needing, ename, wc)))
+      } else {
+        ()
       },
       _ => ()
     }
@@ -7208,10 +7334,17 @@ fn edp_apply_migration(stmts: Array[Stmt], ename: String, ops: Array[(String, Ar
   // pass over `stmts`, rewriting each matching EHandle node the moment it
   // is found -- see edp_find_rewrite_handles's doc comment for why this
   // replaced an earlier collect-then-re-find-by-equality design.
+  // #1875 R3: edp_find_rewrite_handles only changes statements that contain
+  // a matching handle site -- everywhere else it is an identity rebuild of
+  // the whole expression tree. Gate each statement behind the read-only
+  // containment query (same superset argument as eligibility's loop: the
+  // query traverses arms of non-matching handles too, so it can never miss
+  // a statement the rewrite would touch).
+  let apq = RQHandlesEffect(ename)
   let mut si = 0
   while si < Array::length(stmts) {
     match Array::get(stmts, si) {
-      SLet(exported, is_rec, name, ty, expr) => {
+      SLet(exported, is_rec, name, ty, expr) => if edp_rq_fold(apq, expr) > 0 {
         // Extend the safe-call set with THIS statement's own proven
         // closure params (if it is a self-discharging owner) so its
         // handle bodies' calls through them get the dict literal
@@ -7228,41 +7361,51 @@ fn edp_apply_migration(stmts: Array[Stmt], ename: String, ops: Array[(String, Ar
         }
         let needing_h = Array::concat(Array::concat(needing, edp_closure_param_names_only(hcps2)), tdh)
         Array::set(stmts, si, SLet(exported, is_rec, name, ty, edp_find_rewrite_handles(expr, ename, needing_h)))
+      } else {
+        ()
       },
       // ADR-0076 追記34 V2: non-SLet site-bearing statements, mirroring
       // eligibility's own coverage (base needing + bare td_binds; no
       // owner-closure-param extension).
-      SLetMut(nm2, ty2, expr) => {
+      SLetMut(nm2, ty2, expr) => if edp_rq_fold(apq, expr) > 0 {
         let tdh2 = if td_mode {
           td_binds
         } else {
           empty_str_array()
         }
         Array::set(stmts, si, SLetMut(nm2, ty2, edp_find_rewrite_handles(expr, ename, Array::concat(needing, tdh2))))
+      } else {
+        ()
       },
-      SExpr(expr) => {
+      SExpr(expr) => if edp_rq_fold(apq, expr) > 0 {
         let tdh2 = if td_mode {
           td_binds
         } else {
           empty_str_array()
         }
         Array::set(stmts, si, SExpr(edp_find_rewrite_handles(expr, ename, Array::concat(needing, tdh2))))
+      } else {
+        ()
       },
-      STest(tn2, expr) => {
+      STest(tn2, expr) => if edp_rq_fold(apq, expr) > 0 {
         let tdh2 = if td_mode {
           td_binds
         } else {
           empty_str_array()
         }
         Array::set(stmts, si, STest(tn2, edp_find_rewrite_handles(expr, ename, Array::concat(needing, tdh2))))
+      } else {
+        ()
       },
-      SBench(bn2, expr) => {
+      SBench(bn2, expr) => if edp_rq_fold(apq, expr) > 0 {
         let tdh2 = if td_mode {
           td_binds
         } else {
           empty_str_array()
         }
         Array::set(stmts, si, SBench(bn2, edp_find_rewrite_handles(expr, ename, Array::concat(needing, tdh2))))
+      } else {
+        ()
       },
       _ => ()
     }


### PR DESCRIPTION
## Summary

#1875 の第 3 ラウンド (commit 2 本)。R2 までで未使用宣言の税はほぼ消えた (+0.36MB) が、**使われている effect** (perform + handle を持つ) の単価と base tree 側の残余があった。probe effect (宣言 + perform 関数 1 + handle 1 を core に追加) を単位とする実測で帰属を確定し、以下を修正。

## 実測 (deterministic cold KPI、main a6ef058 比、現ツリー)

| | unprobed (base tree) | **used effect 1 個の単価** |
|---|---:|---:|
| pre-R3 | 1,073,337,792 | **+46.0MB** |
| **R3 (this PR)** | **1,049,397,536 (−23.9MB)** | **+5.7MB (8.1×)** |

wall も 6.7s → 4.6s (cold selfcompile)。

## Commit 1: 再構築 walk 群を containment query でゲート

rewriting walk (vacuous-handle erasure / eta-wrap / apply の handle rewrite) は effect ごとにプログラム全体を再構築していたが、実際に変わるのは matching handle site (または needing 値引数) を含む数 stmt だけ。read-only の存在 query (`RQHandlesEffect` / `RQNeedingValueArg`、既存 `edp_rq_fold` エンジンの variant) で stmt 単位にゲート。加えて:

- **plan loop の skip 強化**: handle site が 1 つも無い effect は本体丸ごと provable no-op として skip (empty sites では plan 不可能・mutation/error push は全て live-sites ゲート)。base の row-only effect 税 (`@vibe/fs` の `Fs`: row 保持関数多数・closure 内 handle ゼロ) を除去。exception 名は handle 名収集から除外されるため旧ガード維持
- base inert set (pure fns + free-host callees) の per-effect 再構築 → pass 冒頭 1 回
- handle sites の一回収集を `edp_try_plan_for_effect` へスレッディング (内部再収集 + V1 guard の三回目を撤去)
- eligibility の per-stmt loop も site 含有 stmt 以外は owner-param 解析ごと skip

## Commit 2: builtin テーブルの memo 化ほか (一時 heap マークで帰属特定)

label-pun `Profiler::heap_bytes` マークによる区間計測で、残余 +23.9MB の 73% が `edp_collect_performing_fns` 1 回に集中していることを特定:

- **`edp_is_pure_builtin_call` / `idp_is_pure_builtin_call` が呼び出しごとに ~100 要素のテーブルを再構築**していた。両者とも merged program の **call ノード単位**で走る述語 (前者は全 safety scan と `RQOpaqueCall`、後者は direct-perform inlining walk)。module-level let の memo に変更 (module_let_memo_test.vibe が仕様)、idp 側は欠けていた early-exit も追加
- `edp_collect_performing_fns`: fixpoint の毎 round × 全関数で `edp_find_fn_body` (O(defs) 走査 + Option alloc) を呼んでいた → **bodies を各 def の stmt index で 1 回解決**、membership は fn_defs 整列の Bool 配列、query object は fixpoint 前に 1 回構築 (result 配列を alias するので mid-round の push が見える)。entry-order bodies は duplicate 名存在時に旧 last-wins 比で保守的 superset (erase が減る方向のみ — silent-wrong 不可)
- shadow-poison walk (全 binder の線形 dedup 収集) は row-literal 候補のフィルタ専用なので、**候補ゼロなら walk 自体を skip** (実 used effect の共通ケース)

## 検証

- **byte 同値**: 同一入力ツリーを pre-R3 / R3 コンパイラでコンパイルし出力 wasm 一致 (純最適化)
- stage2 == stage3 **fixpoint**
- **full `scripts/compiler_gate.sh` green** (直接実行。`pkf run test` 経由はこの実行環境の nix glibc 不整合で system `sort` が起動できず fail するが、コード無関係の環境問題 — 単体実行・直接実行では全て green)
- `vibe check` clean / fmt --check clean / KPI は ×2 で byte 一致 (決定的)

## 残り (R4 候補、#1875 に記録)

used effect 1 個あたり **~2.1MB × 2 本**の全プログラム walk アロケーションが残存 (needing-escape walk と最初の `edp_collect_handle_sites` — 同一関数の 2 回目の呼び出しは ~0 で、walk とアロケーションモデルの相互作用の疑い)。マーク手法で正確に再現可能。

Refs #1875