### PR TITLE
feat(parser): retain slot-addressable binder authority

### DIFF
--- a/fixtures/parser_binder_slot_authority_test.vibe
+++ b/fixtures/parser_binder_slot_authority_test.vibe
@@ -1,0 +1,234 @@
+//# Imports
+
+import ../lib/@vibe/ast {
+  Expr, Stmt
+}
+
+import ../lib/@vibe/parser {
+  BinderAuthorityNode,
+  BinderAuthorityNodeKind,
+  BinderAuthoritySlot,
+  BinderSemanticRole,
+  SourceBinder,
+  SyntheticBinderKind,
+  binder_authority_node_children,
+  binder_authority_node_kind,
+  binder_authority_node_slots,
+  binder_authority_slot_binder,
+  binder_authority_slot_role,
+  located_program_binder_authority_nodes,
+  located_program_binder_authority_rows,
+  parse_source_located_with_binder_authority,
+  validate_program_binder_rows
+}
+
+//# Helpers
+
+fn expect_source_slot(slot: BinderAuthoritySlot, role_tag: Int, name: String, start: Int, end: Int, source: String) -> Unit {
+  let actual_role_tag = match binder_authority_slot_role(slot) {
+    StatementLetBinder => 1,
+    StatementLetMutBinder => 2,
+    StatementExternBinder => 3,
+    StatementImportBinder => 4,
+    StatementAliasBinder => 5,
+    StatementTypeBinder => 6,
+    StatementTypeParameterBinder => 7,
+    StatementEffectSetBinder => 8,
+    StatementResourceBinder => 9,
+    ExpressionLetBinder => 10,
+    ExpressionLetRecBinder => 11,
+    ExpressionLetMutBinder => 12,
+    ExpressionFunctionTypeParameterBinder => 13,
+    ExpressionFunctionParameterBinder => 14,
+    ExpressionForValueBinder => 15,
+    ExpressionForIndexBinder => 16,
+    PatternBinder => 17
+  }
+  inspect(actual_role_tag == role_tag, "true")
+  match binder_authority_slot_binder(slot) {
+    SourceToken(actual_name, actual_start, actual_end) => {
+      inspect(actual_name, name)
+      inspect(actual_start == start, "true")
+      inspect(actual_end == end, "true")
+      inspect(String::substring(source, actual_start, actual_end), name)
+    },
+    _ => inspect(false, "true")
+  }
+}
+
+fn count_synthetic_slots(node: BinderAuthorityNode) -> Int {
+  let mut count = 0
+  for slot in binder_authority_node_slots(node) {
+    match binder_authority_slot_binder(slot) {
+      Synthetic(_, _) => {
+        count = count + 1
+      },
+      _ => ()
+    }
+  }
+  for child in binder_authority_node_children(node) {
+    count = count + count_synthetic_slots(child)
+  }
+  count
+}
+
+fn kind_tag(kind: BinderAuthorityNodeKind) -> Int {
+  match kind {
+    AuthorityStmtLet => 1,
+    AuthorityStmtLetMut => 2,
+    AuthorityExprFn => 3,
+    AuthorityExprLet => 4,
+    AuthorityExprLetRec => 5,
+    AuthorityExprLetMut => 6,
+    AuthorityExprMatch => 7,
+    AuthorityExprHandle => 8,
+    AuthorityPatBind => 9,
+    AuthorityPatCtor => 10,
+    AuthorityExprIdent => 11,
+    AuthorityExprForIn => 12,
+    AuthorityStmtImport => 13,
+    AuthorityStmtTypeAlias => 14,
+    _ => 99
+  }
+}
+
+//# Tests
+
+test "paired roots preserve duplicate and nested slot identity with UTF-8 byte spans" {
+  let source = "// é\nlet x = 1\nlet x = (x) -> { let mut x = x; let rec x = () -> { x }; x }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let rows = located_program_binder_authority_rows(authority)
+      let roots = located_program_binder_authority_nodes(authority)
+      inspect(Array::length(rows), "5")
+      inspect(Array::length(roots), "2")
+      let first = Array::get(roots, 0)
+      let second = Array::get(roots, 1)
+      inspect(kind_tag(binder_authority_node_kind(first)), "1")
+      inspect(kind_tag(binder_authority_node_kind(second)), "1")
+      expect_source_slot(Array::get(binder_authority_node_slots(first), 0), 1, "x", 10, 11, source)
+      expect_source_slot(Array::get(binder_authority_node_slots(second), 0), 1, "x", 20, 21, source)
+      let fn_node = Array::get(binder_authority_node_children(second), 0)
+      inspect(kind_tag(binder_authority_node_kind(fn_node)), "3")
+      expect_source_slot(Array::get(binder_authority_node_slots(fn_node), 0), 14, "x", 25, 26, source)
+      let mut_node = Array::get(binder_authority_node_children(fn_node), 0)
+      inspect(kind_tag(binder_authority_node_kind(mut_node)), "6")
+      expect_source_slot(Array::get(binder_authority_node_slots(mut_node), 0), 12, "x", 41, 42, source)
+      let rec_node = Array::get(binder_authority_node_children(mut_node), 1)
+      inspect(kind_tag(binder_authority_node_kind(rec_node)), "5")
+      let recursive_slot = Array::get(binder_authority_node_slots(rec_node), 0)
+      expect_source_slot(recursive_slot, 11, "x", 56, 57, source)
+      // One parser slot is immutable data that future hoist/provisional/final
+      // semantic incarnations may reuse; reuse never appends compatibility rows.
+      expect_source_slot(recursive_slot, 11, "x", 56, 57, source)
+      inspect(Array::length(rows), "5")
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "match handler and block-step patterns retain paired constructor roles" {
+  let source = "let run = (arg) -> { let value = arg; match value { Some(item) => handle { item } with Eff { Op(payload) => payload }, None => 0 } }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let roots = located_program_binder_authority_nodes(authority)
+      let stmt = Array::get(roots, 0)
+      let fn_node = Array::get(binder_authority_node_children(stmt), 0)
+      let let_node = Array::get(binder_authority_node_children(fn_node), 0)
+      let match_node = Array::get(binder_authority_node_children(let_node), 1)
+      inspect(kind_tag(binder_authority_node_kind(let_node)), "4")
+      inspect(kind_tag(binder_authority_node_kind(match_node)), "7")
+      // Match children are scrutinee, then ordered pattern/body pairs.
+      let some_pat = Array::get(binder_authority_node_children(match_node), 1)
+      inspect(kind_tag(binder_authority_node_kind(some_pat)), "10")
+      let item_pat = Array::get(binder_authority_node_children(some_pat), 0)
+      inspect(kind_tag(binder_authority_node_kind(item_pat)), "9")
+      expect_source_slot(Array::get(binder_authority_node_slots(item_pat), 0), 17, "item", 57, 61, source)
+      let handle_node = Array::get(binder_authority_node_children(match_node), 2)
+      inspect(kind_tag(binder_authority_node_kind(handle_node)), "8")
+      let op_pat = Array::get(binder_authority_node_children(handle_node), 1)
+      let payload_pat = Array::get(binder_authority_node_children(op_pat), 0)
+      expect_source_slot(Array::get(binder_authority_node_slots(payload_pat), 0), 17, "payload", 96, 103, source)
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "for-step children and distinct top-level statement roots stay explicitly paired" {
+  let for_source = "let f = (values) -> { for index, value in values { let inner = value; inner } }"
+  match parse_source_located_with_binder_authority(for_source) {
+    Some(authority) => {
+      let stmt = Array::get(located_program_binder_authority_nodes(authority), 0)
+      let fn_node = Array::get(binder_authority_node_children(stmt), 0)
+      let for_node = Array::get(binder_authority_node_children(fn_node), 0)
+      inspect(kind_tag(binder_authority_node_kind(for_node)), "12")
+      inspect(Array::length(binder_authority_node_children(for_node)), "2")
+      let slots = binder_authority_node_slots(for_node)
+      inspect(Array::length(slots), "2")
+      expect_source_slot(Array::get(slots, 0), 15, "value", 33, 38, for_source)
+      expect_source_slot(Array::get(slots, 1), 16, "index", 26, 31, for_source)
+      let body = Array::get(binder_authority_node_children(for_node), 1)
+      inspect(kind_tag(binder_authority_node_kind(body)), "4")
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "distinct top-level statement root kinds stay explicitly paired" {
+  let roots_source = "import ./dep.vibe { Thing as Local }\ntype Box[T] = T\nlet mut state = 0"
+  match parse_source_located_with_binder_authority(roots_source) {
+    Some(authority) => {
+      let roots = located_program_binder_authority_nodes(authority)
+      inspect(Array::length(roots), "3")
+      inspect(kind_tag(binder_authority_node_kind(Array::get(roots, 0))), "13")
+      inspect(kind_tag(binder_authority_node_kind(Array::get(roots, 1))), "14")
+      inspect(kind_tag(binder_authority_node_kind(Array::get(roots, 2))), "2")
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "forgeable sidecar nodes remain data and do not mint parser authority" {
+  let forged = BinderAuthorityNode::{
+    kind: AuthorityExprIdent,
+    slots: [
+      BinderAuthoritySlot::{
+        role: PatternBinder,
+        binder: SourceToken("forged", 0, 6)
+      }
+    ],
+    children: [
+    ]
+  }
+  inspect(kind_tag(binder_authority_node_kind(forged)), "11")
+  inspect(Array::length(binder_authority_node_slots(forged)), "1")
+  inspect(Array::length(binder_authority_node_children(forged)), "0")
+  // There is intentionally no resolver, AST scan, or authority-accepting API.
+}
+
+test "approved represented synthetic slots remain compatible while unsupported synthetic topology fails closed" {
+  let source = "let f = () -> { let x: Int = 1; x }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let roots = located_program_binder_authority_nodes(authority)
+      inspect(Array::length(roots), "1")
+      inspect(count_synthetic_slots(Array::get(roots, 0)), "1")
+    },
+    None => inspect(false, "true")
+  }
+  // This is deliberately forged validator input, not parser authority. ELoop
+  // has synthetic binder topology with no supported final-AST sidecar branch.
+  let forged_program: Array[Stmt] = [
+    SLet(false, false, "f", None, ELoop([
+      ("i", EInt(0))
+    ], EUnit))
+  ]
+  inspect(validate_program_binder_rows(forged_program, [
+    SourceToken("f", 4, 5),
+    Synthetic("i", ParserSynthetic)
+  ], "let f = loop"), "false")
+  inspect(match parse_source_located_with_binder_authority("enum Choice { A; B }") {
+    Some(_) => true,
+    None => false
+  }, "false")
+}

--- a/fixtures/parser_binder_slot_authority_test.vibe
+++ b/fixtures/parser_binder_slot_authority_test.vibe
@@ -206,6 +206,63 @@ test "forgeable sidecar nodes remain data and do not mint parser authority" {
   // There is intentionally no resolver, AST scan, or authority-accepting API.
 }
 
+test "aggregate node materialization is recursively detached across repeated access" {
+  let source = "let f = (x) -> { let inner = x; inner }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let forged = BinderAuthorityNode::{
+        kind: AuthorityExprUnit,
+        slots: [
+        ],
+        children: [
+        ]
+      }
+      let first_roots = located_program_binder_authority_nodes(authority)
+      let first_root = Array::get(first_roots, 0)
+      Array::set(first_root.children, 0, forged)
+      let second_roots = located_program_binder_authority_nodes(authority)
+      let second_root = Array::get(second_roots, 0)
+      let second_fn = Array::get(second_root.children, 0)
+      inspect(kind_tag(second_fn.kind), "3")
+      let forged_slot = BinderAuthoritySlot::{
+        role: PatternBinder,
+        binder: SourceToken("forged", 0, 6)
+      }
+      Array::set(second_fn.slots, 0, forged_slot)
+      let third_roots = located_program_binder_authority_nodes(authority)
+      let third_fn = Array::get(Array::get(third_roots, 0).children, 0)
+      expect_source_slot(Array::get(third_fn.slots, 0), 14, "x", 9, 10, source)
+      Array::set(second_roots, 0, forged)
+      let fourth_roots = located_program_binder_authority_nodes(authority)
+      inspect(kind_tag(Array::get(fourth_roots, 0).kind), "1")
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "leaf accessors terminate on a forged self-aliased public node" {
+  let seed = BinderAuthorityNode::{
+    kind: AuthorityExprUnit,
+    slots: [
+    ],
+    children: [
+    ]
+  }
+  let child_cells = [
+    seed
+  ]
+  let cycle = BinderAuthorityNode::{
+    kind: AuthorityExprIdent,
+    slots: [
+    ],
+    children: child_cells
+  }
+  Array::set(child_cells, 0, cycle)
+  inspect(kind_tag(binder_authority_node_kind(cycle)), "11")
+  inspect(Array::length(binder_authority_node_slots(cycle)), "0")
+  inspect(Array::length(binder_authority_node_children(cycle)), "1")
+}
+
 test "approved represented synthetic slots remain compatible while unsupported synthetic topology fails closed" {
   let source = "let f = () -> { let x: Int = 1; x }"
   match parse_source_located_with_binder_authority(source) {

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -30,12 +30,15 @@ type Token
 // caller context and use only the high-level exhaustively validated aggregate.
 opaque type ParserBinderContext
 
-// Closed parser-authored row schema. Values are data, not authority.
+// Closed parser-authored row and recursive sidecar schemas. Values are
+// forgeable data, not authority; only the source-owning entry's direct return
+// carries invocation-local control-flow provenance.
 type SyntheticBinderKind
 type SourceBinder
-
-// Documentation-opaque aggregate. Nominal possession is never proof; no
-// semantic consumer accepts it as authority.
+type BinderAuthorityNodeKind
+type BinderSemanticRole
+opaque type BinderAuthoritySlot
+opaque type BinderAuthorityNode
 opaque type LocatedProgramBinderAuthority
 
 // Untrusted cross-file parser plumbing. Package conformance requires these
@@ -161,6 +164,12 @@ fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array
 fn parse_source_located_with_binder_authority(source: String) -> Option[LocatedProgramBinderAuthority] with Exception
 fn located_program_binder_authority_program(authority: LocatedProgramBinderAuthority) -> Array[Stmt]
 fn located_program_binder_authority_rows(authority: LocatedProgramBinderAuthority) -> Array[SourceBinder]
+fn located_program_binder_authority_nodes(authority: LocatedProgramBinderAuthority) -> Array[BinderAuthorityNode]
+fn binder_authority_node_kind(node: BinderAuthorityNode) -> BinderAuthorityNodeKind
+fn binder_authority_node_slots(node: BinderAuthorityNode) -> Array[BinderAuthoritySlot]
+fn binder_authority_node_children(node: BinderAuthorityNode) -> Array[BinderAuthorityNode]
+fn binder_authority_slot_role(slot: BinderAuthoritySlot) -> BinderSemanticRole
+fn binder_authority_slot_binder(slot: BinderAuthoritySlot) -> SourceBinder
 fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], src: String) -> (Array[Stmt], Array[String]) with Exception
 fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Array[Int]) -> (Array[Stmt], Array[Int], Array[Int]) with Exception
 

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -64,35 +64,17 @@ import ./token.vibe {
 }
 
 import ./lexer.vibe {
-  lex_with_offsets, offset_to_line_col
+  offset_to_line_col
 }
 
 import ./parser_binder_context.vibe {
   ParserBinderContext,
-  SourceBinder,
-  binder_capture_context,
   binder_capture_discard_from,
   binder_capture_eligibility_mark,
-  binder_capture_is_eligible,
   binder_capture_mark,
   binder_capture_mark_ineligible,
   binder_capture_restore_eligibility,
-  binder_capture_rows,
   binder_capture_source
-}
-
-import ./parser_binder_authority.vibe {
-  validate_program_binder_rows
-}
-
-//# Types
-
-/// Atomically produced parse result plus exhaustively validated binder rows.
-/// The representation is documentation-opaque only; nominal possession is not
-/// proof and no semantic consumer accepts this value as authority.
-export struct LocatedProgramBinderAuthority {
-  program: Array[Stmt];
-  binders: Array[SourceBinder]
 }
 
 //# Functions
@@ -1140,34 +1122,6 @@ export fn parse_program_located_with_untrusted_binder_context(tokens: Array[Toke
 /// never a source of binder authority.
 export fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array[Int], source: String) -> Array[Stmt] with Exception {
   parse_program_located_with_context_impl(tokens, starts, source, None).0
-}
-
-/// Source-owning atomic entry. It alone lexes exact offset tables, creates a
-/// fresh untrusted context, parses to TEof, and publishes only after complete
-/// final-AST row validation.
-export fn parse_source_located_with_binder_authority(source: String) -> Option[LocatedProgramBinderAuthority] with Exception {
-  let (tokens, starts, ends) = lex_with_offsets(source)
-  let context = binder_capture_context(starts, ends)
-  let (program, next) = parse_program_located_with_context_impl(tokens, starts, source, Some(context))
-  let rows = binder_capture_rows(context)
-  if match peek(tokens, next) {
-    TEof => true,
-    _ => false
-  } && binder_capture_is_eligible(context) && validate_program_binder_rows(program, rows, source) {
-    Some(LocatedProgramBinderAuthority::{
-      program: program, binders: rows
-    })
-  } else None
-}
-
-/// Data accessor only. No checker/cache/reuse API accepts this aggregate.
-export fn located_program_binder_authority_program(authority: LocatedProgramBinderAuthority) -> Array[Stmt] {
-  Array::slice(authority.program, 0, Array::length(authority.program))
-}
-
-/// Data accessor only; rows remain non-semantic parser evidence.
-export fn located_program_binder_authority_rows(authority: LocatedProgramBinderAuthority) -> Array[SourceBinder] {
-  Array::slice(authority.binders, 0, Array::length(authority.binders))
 }
 
 export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], source: String) -> (Array[Stmt], Array[String]) with Exception {

--- a/lib/@vibe/parser/parser_binder_authority.vibe
+++ b/lib/@vibe/parser/parser_binder_authority.vibe
@@ -118,12 +118,22 @@ export struct BinderAuthorityNode {
   children: Array[BinderAuthorityNode]
 }
 
+/// Private persistent representation retained by the validated aggregate.
+/// No mutable Array is reachable from this topology. Public forgeable nodes
+/// are materialized only as detached data copies at the accessor boundary.
+enum StoredBinderAuthority {
+  StoredAuthorityNil;
+  StoredAuthoritySlot(BinderAuthoritySlot, StoredBinderAuthority);
+  StoredAuthorityNode(BinderAuthorityNodeKind, StoredBinderAuthority, StoredBinderAuthority);
+  StoredAuthorityChild(StoredBinderAuthority, StoredBinderAuthority)
+}
+
 /// Atomically produced exact-source parse result, compatibility rows, and the
 /// sidecar built in the same exhaustive walk against that exact final AST.
 export struct LocatedProgramBinderAuthority {
   program: Array[Stmt];
   binders: Array[SourceBinder];
-  nodes: Array[BinderAuthorityNode]
+  nodes: StoredBinderAuthority
 }
 
 //# Data accessors
@@ -156,8 +166,56 @@ export fn located_program_binder_authority_rows(authority: LocatedProgramBinderA
   Array::slice(authority.binders, 0, Array::length(authority.binders))
 }
 
+fn append_materialized_slots(stored: StoredBinderAuthority, out: ArrayBuilder[BinderAuthoritySlot]) -> Unit {
+  match stored {
+    StoredAuthoritySlot(slot, rest) => {
+      ArrayBuilder::push(out, slot)
+      append_materialized_slots(rest, out)
+    },
+    _ => ()
+  }
+}
+
+fn materialize_authority_node(stored: StoredBinderAuthority) -> BinderAuthorityNode {
+  match stored {
+    StoredAuthorityNode(kind, slots, children) => {
+      let slot_out = ArrayBuilder::new()
+      append_materialized_slots(slots, slot_out)
+      let child_out = ArrayBuilder::new()
+      append_materialized_nodes(children, child_out)
+      BinderAuthorityNode::{
+        kind,
+        slots: ArrayBuilder::freeze(slot_out),
+        children: ArrayBuilder::freeze(child_out)
+      }
+    },
+    // Private stored values are created only by stored_authority_node. Keep a
+    // total fallback so malformed public data is never involved in recursion.
+    _ => BinderAuthorityNode::{
+      kind: AuthorityExprUnit,
+      slots: ArrayBuilder::freeze(ArrayBuilder::new()),
+      children: ArrayBuilder::freeze(ArrayBuilder::new())
+    }
+  }
+}
+
+fn append_materialized_nodes(stored: StoredBinderAuthority, out: ArrayBuilder[BinderAuthorityNode]) -> Unit {
+  match stored {
+    StoredAuthorityChild(node, rest) => {
+      ArrayBuilder::push(out, materialize_authority_node(node))
+      append_materialized_nodes(rest, out)
+    },
+    _ => ()
+  }
+}
+
+/// Materialize a fresh recursive public data tree on every call. Every slots
+/// and children array at every depth is detached from the aggregate and from
+/// arrays returned by previous calls.
 export fn located_program_binder_authority_nodes(authority: LocatedProgramBinderAuthority) -> Array[BinderAuthorityNode] {
-  Array::slice(authority.nodes, 0, Array::length(authority.nodes))
+  let out = ArrayBuilder::new()
+  append_materialized_nodes(authority.nodes, out)
+  ArrayBuilder::freeze(out)
 }
 
 //# Exhaustive final-AST validation and sidecar construction
@@ -682,6 +740,26 @@ export fn validate_program_binder_rows(program: Array[Stmt], rows: Array[SourceB
   }
 }
 
+fn stored_authority_slots(slots: Array[BinderAuthoritySlot], at: Int) -> StoredBinderAuthority {
+  if at >= Array::length(slots) {
+    StoredAuthorityNil
+  } else {
+    StoredAuthoritySlot(Array::get(slots, at), stored_authority_slots(slots, at + 1))
+  }
+}
+
+fn stored_authority_node(node: BinderAuthorityNode) -> StoredBinderAuthority {
+  StoredAuthorityNode(node.kind, stored_authority_slots(node.slots, 0), stored_authority_nodes(node.children, 0),)
+}
+
+fn stored_authority_nodes(nodes: Array[BinderAuthorityNode], at: Int) -> StoredBinderAuthority {
+  if at >= Array::length(nodes) {
+    StoredAuthorityNil
+  } else {
+    StoredAuthorityChild(stored_authority_node(Array::get(nodes, at)), stored_authority_nodes(nodes, at + 1))
+  }
+}
+
 fn build_program_binder_authority(program: Array[Stmt], rows: Array[SourceBinder], source: String) -> Option[Array[BinderAuthorityNode]] {
   let nodes = ArrayBuilder::new()
   let mut next = 0
@@ -715,7 +793,9 @@ export fn parse_source_located_with_binder_authority(source: String) -> Option[L
   } && binder_capture_is_eligible(context) {
     match build_program_binder_authority(program, rows, source) {
       Some(nodes) => Some(LocatedProgramBinderAuthority::{
-        program, binders: rows, nodes
+        program,
+        binders: rows,
+        nodes: stored_authority_nodes(nodes, 0)
       }),
       None => None
     }

--- a/lib/@vibe/parser/parser_binder_authority.vibe
+++ b/lib/@vibe/parser/parser_binder_authority.vibe
@@ -4,15 +4,198 @@ import @vibe/ast {
   Expr, Pat, Stmt
 }
 
-import ./parser_binder_context.vibe {
-  SourceBinder
+import ./lexer.vibe {
+  lex_with_offsets
 }
 
-//# Validation
+import ./parser.vibe {
+  parse_program_located_with_untrusted_binder_context
+}
 
-fn validate_slot(name: String, rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+import ./parser_base.vibe {
+  peek
+}
+
+import ./parser_binder_context.vibe {
+  SourceBinder, binder_capture_context, binder_capture_is_eligible, binder_capture_rows
+}
+
+//# Types
+
+/// Closed final-AST constructor inventory for the recursive binder sidecar.
+/// Arity is the exact length of a node's ordered children array.
+export enum BinderAuthorityNodeKind {
+  AuthorityPatWild;
+  AuthorityPatBind;
+  AuthorityPatInt;
+  AuthorityPatFloat;
+  AuthorityPatString;
+  AuthorityPatBool;
+  AuthorityPatCtor;
+  AuthorityPatTuple;
+  AuthorityPatStruct;
+  AuthorityExprInt;
+  AuthorityExprFloat;
+  AuthorityExprString;
+  AuthorityExprBool;
+  AuthorityExprIdent;
+  AuthorityExprTuple;
+  AuthorityExprArray;
+  AuthorityExprRecord;
+  AuthorityExprIf;
+  AuthorityExprLet;
+  AuthorityExprLetRec;
+  AuthorityExprLetMut;
+  AuthorityExprAssign;
+  AuthorityExprAssignOp;
+  AuthorityExprSeq;
+  AuthorityExprMatch;
+  AuthorityExprHandle;
+  AuthorityExprFn;
+  AuthorityExprForIn;
+  AuthorityExprWhile;
+  AuthorityExprCall;
+  AuthorityExprBinOp;
+  AuthorityExprUnaryOp;
+  AuthorityExprDot;
+  AuthorityExprLabeledArg;
+  AuthorityExprReturn;
+  AuthorityExprBreak;
+  AuthorityExprContinue;
+  AuthorityExprMap;
+  AuthorityExprSpread;
+  AuthorityExprStringInterp;
+  AuthorityExprUnit;
+  AuthorityStmtLet;
+  AuthorityStmtLetMut;
+  AuthorityStmtExternLet;
+  AuthorityStmtImport;
+  AuthorityStmtAliasDecl;
+  AuthorityStmtTypeAlias;
+  AuthorityStmtEffectSet;
+  AuthorityStmtResource;
+  AuthorityStmtTest;
+  AuthorityStmtBench;
+  AuthorityStmtExample;
+  AuthorityStmtExpr;
+  AuthorityStmtExport;
+  AuthorityStmtReExport;
+  AuthorityStmtQualifiedPatternRefs;
+  AuthorityStmtTestEffectRows
+}
+
+/// Closed semantic role of one binder slot on its exact final-AST node.
+export enum BinderSemanticRole {
+  StatementLetBinder;
+  StatementLetMutBinder;
+  StatementExternBinder;
+  StatementImportBinder;
+  StatementAliasBinder;
+  StatementTypeBinder;
+  StatementTypeParameterBinder;
+  StatementEffectSetBinder;
+  StatementResourceBinder;
+  ExpressionLetBinder;
+  ExpressionLetRecBinder;
+  ExpressionLetMutBinder;
+  ExpressionFunctionTypeParameterBinder;
+  ExpressionFunctionParameterBinder;
+  ExpressionForValueBinder;
+  ExpressionForIndexBinder;
+  PatternBinder
+}
+
+/// Forgeable data pairing one semantic slot role with its existing flat row.
+export struct BinderAuthoritySlot {
+  role: BinderSemanticRole;
+  binder: SourceBinder
+}
+
+/// Forgeable recursive data sidecar. Possession never grants authority.
+export struct BinderAuthorityNode {
+  kind: BinderAuthorityNodeKind;
+  slots: Array[BinderAuthoritySlot];
+  children: Array[BinderAuthorityNode]
+}
+
+/// Atomically produced exact-source parse result, compatibility rows, and the
+/// sidecar built in the same exhaustive walk against that exact final AST.
+export struct LocatedProgramBinderAuthority {
+  program: Array[Stmt];
+  binders: Array[SourceBinder];
+  nodes: Array[BinderAuthorityNode]
+}
+
+//# Data accessors
+
+export fn binder_authority_node_kind(node: BinderAuthorityNode) -> BinderAuthorityNodeKind {
+  node.kind
+}
+
+export fn binder_authority_node_slots(node: BinderAuthorityNode) -> Array[BinderAuthoritySlot] {
+  Array::slice(node.slots, 0, Array::length(node.slots))
+}
+
+export fn binder_authority_node_children(node: BinderAuthorityNode) -> Array[BinderAuthorityNode] {
+  Array::slice(node.children, 0, Array::length(node.children))
+}
+
+export fn binder_authority_slot_role(slot: BinderAuthoritySlot) -> BinderSemanticRole {
+  slot.role
+}
+
+export fn binder_authority_slot_binder(slot: BinderAuthoritySlot) -> SourceBinder {
+  slot.binder
+}
+
+export fn located_program_binder_authority_program(authority: LocatedProgramBinderAuthority) -> Array[Stmt] {
+  Array::slice(authority.program, 0, Array::length(authority.program))
+}
+
+export fn located_program_binder_authority_rows(authority: LocatedProgramBinderAuthority) -> Array[SourceBinder] {
+  Array::slice(authority.binders, 0, Array::length(authority.binders))
+}
+
+export fn located_program_binder_authority_nodes(authority: LocatedProgramBinderAuthority) -> Array[BinderAuthorityNode] {
+  Array::slice(authority.nodes, 0, Array::length(authority.nodes))
+}
+
+//# Exhaustive final-AST validation and sidecar construction
+
+fn no_slots() -> Array[BinderAuthoritySlot] {
+  ArrayBuilder::freeze(ArrayBuilder::new())
+}
+
+fn no_nodes() -> Array[BinderAuthorityNode] {
+  ArrayBuilder::freeze(ArrayBuilder::new())
+}
+
+fn one_node(node: BinderAuthorityNode) -> Array[BinderAuthorityNode] {
+  [
+    node
+  ]
+}
+
+fn two_nodes(first: BinderAuthorityNode, second: BinderAuthorityNode) -> Array[BinderAuthorityNode] {
+  [
+    first,
+    second
+  ]
+}
+
+fn authority_node(kind: BinderAuthorityNodeKind, slots: Array[BinderAuthoritySlot], children: Array[BinderAuthorityNode]) -> BinderAuthorityNode {
+  BinderAuthorityNode::{
+    kind, slots, children
+  }
+}
+
+fn leaf(kind: BinderAuthorityNodeKind) -> BinderAuthorityNode {
+  authority_node(kind, no_slots(), no_nodes())
+}
+
+fn validate_slot(name: String, role: BinderSemanticRole, rows: Array[SourceBinder], source: String, at: Int) -> Option[(BinderAuthoritySlot, Int)] {
   if at < 0 || at >= Array::length(rows) {
-    (false, at)
+    None
   } else match Array::get(rows, at) {
     SourceToken(row_name, start, end) => {
       let n = String::length(source)
@@ -21,258 +204,520 @@ fn validate_slot(name: String, rows: Array[SourceBinder], source: String, at: In
         let spelling = String::substring(source, start, end)
         spelling == name || spelling == String::concat("@", name) || spelling == String::concat("r#", name)
       } else false
-      (row_name == name && exact, at + 1)
+      if row_name == name && exact {
+        Some((BinderAuthoritySlot::{
+          role, binder: Array::get(rows, at)
+        }, at + 1))
+      } else None
     },
-    Synthetic(row_name, _) => (row_name == name, at + 1)
+    // Approved parser lowerings already represented in the exact final AST
+    // retain their compatibility row at this exact semantic slot. Synthetic
+    // topology with no supported final-AST branch (for example ELoop) still
+    // fails closed in the exhaustive node walk.
+    Synthetic(row_name, _) => if row_name == name {
+      Some((BinderAuthoritySlot::{
+        role, binder: Array::get(rows, at)
+      }, at + 1))
+    } else None
   }
 }
 
-fn validate_pattern(pat: Pat, rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+fn validate_pattern(pat: Pat, rows: Array[SourceBinder], source: String, at: Int) -> Option[(BinderAuthorityNode, Int)] {
   match pat {
-    PBind(name) => validate_slot(name, rows, source, at),
-    PCtor(_, args) => validate_patterns(args, rows, source, at),
-    PTuple(args) => validate_patterns(args, rows, source, at),
+    PBind(name) => match validate_slot(name, PatternBinder, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityPatBind, [
+        result.0
+      ], no_nodes()), result.1)),
+      None => None
+    },
+    PCtor(_, args) => match validate_patterns(args, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityPatCtor, no_slots(), result.0), result.1)),
+      None => None
+    },
+    PTuple(args) => match validate_patterns(args, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityPatTuple, no_slots(), result.0), result.1)),
+      None => None
+    },
     PStruct(_, fields) => {
-      let mut ok = true
+      let children = ArrayBuilder::new()
       let mut next = at
       for field in fields {
-        let result = validate_pattern(field.1, rows, source, next)
-        ok = ok && result.0
-        next = result.1
+        match validate_pattern(field.1, rows, source, next) {
+          Some(result) => {
+            ArrayBuilder::push(children, result.0)
+            next = result.1
+          },
+          None => return None
+        }
       }
-      (ok, next)
+      Some((authority_node(AuthorityPatStruct, no_slots(), ArrayBuilder::freeze(children)), next))
     },
-    // POr has two source declarations for one semantic binding. It remains
-    // ineligible until that mapping has an explicit checker contract.
-    POr(_, _) => (false, at),
-    _ => (true, at)
+    // POr has two source declarations for one semantic binding and remains
+    // deliberately unsupported until that semantic contract exists.
+    POr(_, _) => None,
+    PWild => Some((leaf(AuthorityPatWild), at)),
+    PInt(_) => Some((leaf(AuthorityPatInt), at)),
+    PFloat(_) => Some((leaf(AuthorityPatFloat), at)),
+    PString(_) => Some((leaf(AuthorityPatString), at)),
+    PBool(_) => Some((leaf(AuthorityPatBool), at))
   }
 }
 
-fn validate_patterns(pats: Array[Pat], rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
-  let mut ok = true
+fn validate_patterns(pats: Array[Pat], rows: Array[SourceBinder], source: String, at: Int) -> Option[(Array[BinderAuthorityNode], Int)] {
+  let children = ArrayBuilder::new()
   let mut next = at
   for pat in pats {
-    let result = validate_pattern(pat, rows, source, next)
-    ok = ok && result.0
-    next = result.1
+    match validate_pattern(pat, rows, source, next) {
+      Some(result) => {
+        ArrayBuilder::push(children, result.0)
+        next = result.1
+      },
+      None => return None
+    }
   }
-  (ok, next)
+  Some((ArrayBuilder::freeze(children), next))
 }
 
-fn validate_exprs(exprs: Array[Expr], rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
-  let mut ok = true
+fn validate_exprs(exprs: Array[Expr], rows: Array[SourceBinder], source: String, at: Int) -> Option[(Array[BinderAuthorityNode], Int)] {
+  let children = ArrayBuilder::new()
   let mut next = at
   for expr in exprs {
-    let result = validate_expr(expr, rows, source, next)
-    ok = ok && result.0
-    next = result.1
+    match validate_expr(expr, rows, source, next) {
+      Some(result) => {
+        ArrayBuilder::push(children, result.0)
+        next = result.1
+      },
+      None => return None
+    }
   }
-  (ok, next)
+  Some((ArrayBuilder::freeze(children), next))
 }
 
-fn validate_arms(arms: Array[(Pat, Expr)], rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
-  let mut ok = true
+fn validate_arms(arms: Array[(Pat, Expr)], rows: Array[SourceBinder], source: String, at: Int) -> Option[(Array[BinderAuthorityNode], Int)] {
+  let children = ArrayBuilder::new()
   let mut next = at
   for arm in arms {
-    let p = validate_pattern(arm.0, rows, source, next)
-    let e = validate_expr(arm.1, rows, source, p.1)
-    ok = ok && p.0 && e.0
-    next = e.1
+    match validate_pattern(arm.0, rows, source, next) {
+      Some(pattern) => {
+        ArrayBuilder::push(children, pattern.0)
+        match validate_expr(arm.1, rows, source, pattern.1) {
+          Some(body) => {
+            ArrayBuilder::push(children, body.0)
+            next = body.1
+          },
+          None => return None
+        }
+      },
+      None => return None
+    }
   }
-  (ok, next)
+  Some((ArrayBuilder::freeze(children), next))
 }
 
-fn validate_named_exprs(items: Array[(String, Expr)], rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
-  let mut ok = true
+fn validate_named_exprs(items: Array[(String, Expr)], rows: Array[SourceBinder], source: String, at: Int) -> Option[(Array[BinderAuthorityNode], Int)] {
+  let children = ArrayBuilder::new()
   let mut next = at
   for item in items {
-    let result = validate_expr(item.1, rows, source, next)
-    ok = ok && result.0
-    next = result.1
+    match validate_expr(item.1, rows, source, next) {
+      Some(result) => {
+        ArrayBuilder::push(children, result.0)
+        next = result.1
+      },
+      None => return None
+    }
   }
-  (ok, next)
+  Some((ArrayBuilder::freeze(children), next))
 }
 
-fn validate_expr(expr: Expr, rows: Array[SourceBinder], source: String, at: Int) -> (Bool, Int) {
+fn validate_expr(expr: Expr, rows: Array[SourceBinder], source: String, at: Int) -> Option[(BinderAuthorityNode, Int)] {
   match expr {
-    ELet(name, value, body, _) => {
-      let slot = validate_slot(name, rows, source, at)
-      let v = validate_expr(value, rows, source, slot.1)
-      let b = validate_expr(body, rows, source, v.1)
-      (slot.0 && v.0 && b.0, b.1)
+    ELet(name, value, body, _) => match validate_slot(name, ExpressionLetBinder, rows, source, at) {
+      Some(slot) => match validate_expr(value, rows, source, slot.1) {
+        Some(v) => match validate_expr(body, rows, source, v.1) {
+          Some(b) => Some((authority_node(AuthorityExprLet, [
+            slot.0
+          ], two_nodes(v.0, b.0)), b.1)),
+          None => None
+        },
+        None => None
+      },
+      None => None
     },
-    ELetRec(name, value, body) => {
-      let slot = validate_slot(name, rows, source, at)
-      let v = validate_expr(value, rows, source, slot.1)
-      let b = validate_expr(body, rows, source, v.1)
-      (slot.0 && v.0 && b.0, b.1)
+    ELetRec(name, value, body) => match validate_slot(name, ExpressionLetRecBinder, rows, source, at) {
+      Some(slot) => match validate_expr(value, rows, source, slot.1) {
+        Some(v) => match validate_expr(body, rows, source, v.1) {
+          Some(b) => Some((authority_node(AuthorityExprLetRec, [
+            slot.0
+          ], two_nodes(v.0, b.0)), b.1)),
+          None => None
+        },
+        None => None
+      },
+      None => None
     },
-    ELetMut(name, value, body, _) => {
-      let slot = validate_slot(name, rows, source, at)
-      let v = validate_expr(value, rows, source, slot.1)
-      let b = validate_expr(body, rows, source, v.1)
-      (slot.0 && v.0 && b.0, b.1)
+    ELetMut(name, value, body, _) => match validate_slot(name, ExpressionLetMutBinder, rows, source, at) {
+      Some(slot) => match validate_expr(value, rows, source, slot.1) {
+        Some(v) => match validate_expr(body, rows, source, v.1) {
+          Some(b) => Some((authority_node(AuthorityExprLetMut, [
+            slot.0
+          ], two_nodes(v.0, b.0)), b.1)),
+          None => None
+        },
+        None => None
+      },
+      None => None
     },
-    EMatch(scrutinee, arms) => {
-      let s = validate_expr(scrutinee, rows, source, at)
-      let a = validate_arms(arms, rows, source, s.1)
-      (s.0 && a.0, a.1)
+    EMatch(scrutinee, arms) => match validate_expr(scrutinee, rows, source, at) {
+      Some(s) => match validate_arms(arms, rows, source, s.1) {
+        Some(a) => {
+          let children = ArrayBuilder::new()
+          ArrayBuilder::push(children, s.0)
+          for child in a.0 {
+            ArrayBuilder::push(children, child)
+          }
+          Some((authority_node(AuthorityExprMatch, no_slots(), ArrayBuilder::freeze(children)), a.1))
+        },
+        None => None
+      },
+      None => None
     },
-    EHandle(body, arms) => {
-      let b = validate_expr(body, rows, source, at)
-      let a = validate_arms(arms, rows, source, b.1)
-      (b.0 && a.0, a.1)
+    EHandle(body, arms) => match validate_expr(body, rows, source, at) {
+      Some(b) => match validate_arms(arms, rows, source, b.1) {
+        Some(a) => {
+          let children = ArrayBuilder::new()
+          ArrayBuilder::push(children, b.0)
+          for child in a.0 {
+            ArrayBuilder::push(children, child)
+          }
+          Some((authority_node(AuthorityExprHandle, no_slots(), ArrayBuilder::freeze(children)), a.1))
+        },
+        None => None
+      },
+      None => None
     },
     EFn(type_params, _, params, _, _, body) => {
-      let mut ok = true
+      let slots = ArrayBuilder::new()
       let mut next = at
       for name in type_params {
-        let result = validate_slot(name, rows, source, next)
-        ok = ok && result.0
-        next = result.1
+        match validate_slot(name, ExpressionFunctionTypeParameterBinder, rows, source, next) {
+          Some(result) => {
+            ArrayBuilder::push(slots, result.0)
+            next = result.1
+          },
+          None => return None
+        }
       }
       for param in params {
-        let result = validate_slot(param.0, rows, source, next)
-        ok = ok && result.0
-        next = result.1
+        match validate_slot(param.0, ExpressionFunctionParameterBinder, rows, source, next) {
+          Some(result) => {
+            ArrayBuilder::push(slots, result.0)
+            next = result.1
+          },
+          None => return None
+        }
       }
-      let b = validate_expr(body, rows, source, next)
-      (ok && b.0, b.1)
-    },
-    EForIn(name, index_name, iter, body) => {
-      let first = validate_slot(name, rows, source, at)
-      let second = match index_name {
-        Some(index) => validate_slot(index, rows, source, first.1),
-        None => (true, first.1)
+      match validate_expr(body, rows, source, next) {
+        Some(result) => Some((authority_node(AuthorityExprFn, ArrayBuilder::freeze(slots), one_node(result.0)), result.1)),
+        None => None
       }
-      let i = validate_expr(iter, rows, source, second.1)
-      let b = validate_expr(body, rows, source, i.1)
-      (first.0 && second.0 && i.0 && b.0, b.1)
     },
-    // Loop lowering synthesizes binders and remains fail-closed until its row
-    // segment remap is implemented.
-    ELoop(_, _) => (false, at),
-    ETuple(items) => validate_exprs(items, rows, source, at),
-    EArray(items) => validate_exprs(items, rows, source, at),
-    ERecord(_, fields, _) => validate_named_exprs(fields, rows, source, at),
-    EIf(cond, yes, no) => {
-      let c = validate_expr(cond, rows, source, at)
-      let y = validate_expr(yes, rows, source, c.1)
-      let n = validate_expr(no, rows, source, y.1)
-      (c.0 && y.0 && n.0, n.1)
+    EForIn(name, index_name, iter, body) => match validate_slot(name, ExpressionForValueBinder, rows, source, at) {
+      Some(first) => {
+        let slots = ArrayBuilder::new()
+        ArrayBuilder::push(slots, first.0)
+        let mut next = first.1
+        match index_name {
+          Some(index) => match validate_slot(index, ExpressionForIndexBinder, rows, source, next) {
+            Some(second) => {
+              ArrayBuilder::push(slots, second.0)
+              next = second.1
+            },
+            None => return None
+          },
+          None => ()
+        }
+        match validate_expr(iter, rows, source, next) {
+          Some(i) => match validate_expr(body, rows, source, i.1) {
+            Some(b) => Some((authority_node(AuthorityExprForIn, ArrayBuilder::freeze(slots), two_nodes(i.0, b.0)), b.1)),
+            None => None
+          },
+          None => None
+        }
+      },
+      None => None
     },
-    EAssign(_, value, body) => {
-      let v = validate_expr(value, rows, source, at)
-      let b = validate_expr(body, rows, source, v.1)
-      (v.0 && b.0, b.1)
+    // Loop lowering synthesizes binders and remains fail-closed.
+    ELoop(_, _) => None,
+    ETuple(items) => match validate_exprs(items, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprTuple, no_slots(), result.0), result.1)),
+      None => None
     },
-    EAssignOp(_, _, value, body) => {
-      let v = validate_expr(value, rows, source, at)
-      let b = validate_expr(body, rows, source, v.1)
-      (v.0 && b.0, b.1)
+    EArray(items) => match validate_exprs(items, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprArray, no_slots(), result.0), result.1)),
+      None => None
     },
-    ESeq(first, second) => {
-      let f = validate_expr(first, rows, source, at)
-      let s = validate_expr(second, rows, source, f.1)
-      (f.0 && s.0, s.1)
+    ERecord(_, fields, _) => match validate_named_exprs(fields, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprRecord, no_slots(), result.0), result.1)),
+      None => None
     },
-    EWhile(cond, body) => {
-      let c = validate_expr(cond, rows, source, at)
-      let b = validate_expr(body, rows, source, c.1)
-      (c.0 && b.0, b.1)
+    EIf(cond, yes, no) => match validate_expr(cond, rows, source, at) {
+      Some(c) => match validate_expr(yes, rows, source, c.1) {
+        Some(y) => match validate_expr(no, rows, source, y.1) {
+          Some(n) => Some((authority_node(AuthorityExprIf, no_slots(), [
+            c.0,
+            y.0,
+            n.0
+          ]), n.1)),
+          None => None
+        },
+        None => None
+      },
+      None => None
     },
-    ECall(callee, args, _) => {
-      let c = validate_expr(callee, rows, source, at)
-      let a = validate_exprs(args, rows, source, c.1)
-      (c.0 && a.0, a.1)
+    EAssign(_, value, body) => match validate_expr(value, rows, source, at) {
+      Some(v) => match validate_expr(body, rows, source, v.1) {
+        Some(b) => Some((authority_node(AuthorityExprAssign, no_slots(), two_nodes(v.0, b.0)), b.1)),
+        None => None
+      },
+      None => None
     },
-    EBinOp(_, left, right) => {
-      let l = validate_expr(left, rows, source, at)
-      let r = validate_expr(right, rows, source, l.1)
-      (l.0 && r.0, r.1)
+    EAssignOp(_, _, value, body) => match validate_expr(value, rows, source, at) {
+      Some(v) => match validate_expr(body, rows, source, v.1) {
+        Some(b) => Some((authority_node(AuthorityExprAssignOp, no_slots(), two_nodes(v.0, b.0)), b.1)),
+        None => None
+      },
+      None => None
     },
-    EUnaryOp(_, value) => validate_expr(value, rows, source, at),
-    EDot(value, _, _, _) => validate_expr(value, rows, source, at),
-    ELabeledArg(_, _, value) => validate_expr(value, rows, source, at),
-    EReturn(value) => validate_expr(value, rows, source, at),
+    ESeq(first, second) => match validate_expr(first, rows, source, at) {
+      Some(f) => match validate_expr(second, rows, source, f.1) {
+        Some(s) => Some((authority_node(AuthorityExprSeq, no_slots(), two_nodes(f.0, s.0)), s.1)),
+        None => None
+      },
+      None => None
+    },
+    EWhile(cond, body) => match validate_expr(cond, rows, source, at) {
+      Some(c) => match validate_expr(body, rows, source, c.1) {
+        Some(b) => Some((authority_node(AuthorityExprWhile, no_slots(), two_nodes(c.0, b.0)), b.1)),
+        None => None
+      },
+      None => None
+    },
+    ECall(callee, args, _) => match validate_expr(callee, rows, source, at) {
+      Some(c) => match validate_exprs(args, rows, source, c.1) {
+        Some(a) => {
+          let children = ArrayBuilder::new()
+          ArrayBuilder::push(children, c.0)
+          for child in a.0 {
+            ArrayBuilder::push(children, child)
+          }
+          Some((authority_node(AuthorityExprCall, no_slots(), ArrayBuilder::freeze(children)), a.1))
+        },
+        None => None
+      },
+      None => None
+    },
+    EBinOp(_, left, right) => match validate_expr(left, rows, source, at) {
+      Some(l) => match validate_expr(right, rows, source, l.1) {
+        Some(r) => Some((authority_node(AuthorityExprBinOp, no_slots(), two_nodes(l.0, r.0)), r.1)),
+        None => None
+      },
+      None => None
+    },
+    EUnaryOp(_, value) => match validate_expr(value, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprUnaryOp, no_slots(), one_node(result.0)), result.1)),
+      None => None
+    },
+    EDot(value, _, _, _) => match validate_expr(value, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprDot, no_slots(), one_node(result.0)), result.1)),
+      None => None
+    },
+    ELabeledArg(_, _, value) => match validate_expr(value, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprLabeledArg, no_slots(), one_node(result.0)), result.1)),
+      None => None
+    },
+    EReturn(value) => match validate_expr(value, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprReturn, no_slots(), one_node(result.0)), result.1)),
+      None => None
+    },
     EBreak(value) => match value {
-      Some(v) => validate_expr(v, rows, source, at),
-      None => (true, at)
+      Some(v) => match validate_expr(v, rows, source, at) {
+        Some(result) => Some((authority_node(AuthorityExprBreak, no_slots(), one_node(result.0)), result.1)),
+        None => None
+      },
+      None => Some((leaf(AuthorityExprBreak), at))
     },
-    EContinue(values) => validate_exprs(values, rows, source, at),
-    EMap(items) => validate_named_exprs(items, rows, source, at),
-    ESpread(value) => validate_expr(value, rows, source, at),
-    EInt(_) => (true, at),
-    EFloat(_) => (true, at),
-    EString(_) => (true, at),
-    EBool(_) => (true, at),
-    EIdent(_, _) => (true, at),
-    EStringInterp(_) => (true, at),
-    EUnit => (true, at)
+    EContinue(values) => match validate_exprs(values, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprContinue, no_slots(), result.0), result.1)),
+      None => None
+    },
+    EMap(items) => match validate_named_exprs(items, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprMap, no_slots(), result.0), result.1)),
+      None => None
+    },
+    ESpread(value) => match validate_expr(value, rows, source, at) {
+      Some(result) => Some((authority_node(AuthorityExprSpread, no_slots(), one_node(result.0)), result.1)),
+      None => None
+    },
+    EInt(_) => Some((leaf(AuthorityExprInt), at)),
+    EFloat(_) => Some((leaf(AuthorityExprFloat), at)),
+    EString(_) => Some((leaf(AuthorityExprString), at)),
+    EBool(_) => Some((leaf(AuthorityExprBool), at)),
+    EIdent(_, _) => Some((leaf(AuthorityExprIdent), at)),
+    EStringInterp(_) => Some((leaf(AuthorityExprStringInterp), at)),
+    EUnit => Some((leaf(AuthorityExprUnit), at))
   }
 }
 
-/// Exhaustive final-AST validation. Success requires one exact source row for
-/// every supported binder slot and no extra rows.
+fn validate_stmt(stmt: Stmt, rows: Array[SourceBinder], source: String, at: Int) -> Option[(BinderAuthorityNode, Int)] {
+  match stmt {
+    SLet(_, _, name, _, value) => match validate_slot(name, StatementLetBinder, rows, source, at) {
+      Some(slot) => match validate_expr(value, rows, source, slot.1) {
+        Some(expr) => Some((authority_node(AuthorityStmtLet, [
+          slot.0
+        ], one_node(expr.0)), expr.1)),
+        None => None
+      },
+      None => None
+    },
+    SLetMut(name, _, value) => match validate_slot(name, StatementLetMutBinder, rows, source, at) {
+      Some(slot) => match validate_expr(value, rows, source, slot.1) {
+        Some(expr) => Some((authority_node(AuthorityStmtLetMut, [
+          slot.0
+        ], one_node(expr.0)), expr.1)),
+        None => None
+      },
+      None => None
+    },
+    SExternLet(name, _) => match validate_slot(name, StatementExternBinder, rows, source, at) {
+      Some(slot) => Some((authority_node(AuthorityStmtExternLet, [
+        slot.0
+      ], no_nodes()), slot.1)),
+      None => None
+    },
+    SImport(_, items) => {
+      let slots = ArrayBuilder::new()
+      let mut next = at
+      for item in items {
+        let local = match item.1 {
+          Some(alias) => alias,
+          None => item.0
+        }
+        match validate_slot(local, StatementImportBinder, rows, source, next) {
+          Some(slot) => {
+            ArrayBuilder::push(slots, slot.0)
+            next = slot.1
+          },
+          None => return None
+        }
+      }
+      Some((authority_node(AuthorityStmtImport, ArrayBuilder::freeze(slots), no_nodes()), next))
+    },
+    SAliasDecl(name, _) => match validate_slot(name, StatementAliasBinder, rows, source, at) {
+      Some(slot) => Some((authority_node(AuthorityStmtAliasDecl, [
+        slot.0
+      ], no_nodes()), slot.1)),
+      None => None
+    },
+    STypeAlias(_, name, params, _) => match validate_slot(name, StatementTypeBinder, rows, source, at) {
+      Some(first) => {
+        let slots = ArrayBuilder::new()
+        ArrayBuilder::push(slots, first.0)
+        let mut next = first.1
+        for param in params {
+          match validate_slot(param, StatementTypeParameterBinder, rows, source, next) {
+            Some(slot) => {
+              ArrayBuilder::push(slots, slot.0)
+              next = slot.1
+            },
+            None => return None
+          }
+        }
+        Some((authority_node(AuthorityStmtTypeAlias, ArrayBuilder::freeze(slots), no_nodes()), next))
+      },
+      None => None
+    },
+    SEffectSet(_, name, _) => match validate_slot(name, StatementEffectSetBinder, rows, source, at) {
+      Some(slot) => Some((authority_node(AuthorityStmtEffectSet, [
+        slot.0
+      ], no_nodes()), slot.1)),
+      None => None
+    },
+    SResource(name, _) => match validate_slot(name, StatementResourceBinder, rows, source, at) {
+      Some(slot) => Some((authority_node(AuthorityStmtResource, [
+        slot.0
+      ], no_nodes()), slot.1)),
+      None => None
+    },
+    STest(_, body) => match validate_expr(body, rows, source, at) {
+      Some(expr) => Some((authority_node(AuthorityStmtTest, no_slots(), one_node(expr.0)), expr.1)),
+      None => None
+    },
+    SBench(_, body) => match validate_expr(body, rows, source, at) {
+      Some(expr) => Some((authority_node(AuthorityStmtBench, no_slots(), one_node(expr.0)), expr.1)),
+      None => None
+    },
+    SExample(_, body) => match validate_expr(body, rows, source, at) {
+      Some(expr) => Some((authority_node(AuthorityStmtExample, no_slots(), one_node(expr.0)), expr.1)),
+      None => None
+    },
+    SExpr(body) => match validate_expr(body, rows, source, at) {
+      Some(expr) => Some((authority_node(AuthorityStmtExpr, no_slots(), one_node(expr.0)), expr.1)),
+      None => None
+    },
+    SExport(_) => Some((leaf(AuthorityStmtExport), at)),
+    SReExport(_, _) => Some((leaf(AuthorityStmtReExport), at)),
+    SQualifiedPatternRefs(_) => Some((leaf(AuthorityStmtQualifiedPatternRefs), at)),
+    STestEffectRows(_) => Some((leaf(AuthorityStmtTestEffectRows), at)),
+    // Remaining declaration/lowering lanes are deliberately ineligible.
+    _ => None
+  }
+}
+
+/// Compatibility validator. It delegates to the same exhaustive constructor
+/// walk used by the source-owning aggregate and discards only the data tree.
 export fn validate_program_binder_rows(program: Array[Stmt], rows: Array[SourceBinder], source: String) -> Bool {
-  let mut ok = true
+  match build_program_binder_authority(program, rows, source) {
+    Some(_) => true,
+    None => false
+  }
+}
+
+fn build_program_binder_authority(program: Array[Stmt], rows: Array[SourceBinder], source: String) -> Option[Array[BinderAuthorityNode]] {
+  let nodes = ArrayBuilder::new()
   let mut next = 0
   for stmt in program {
-    let result = match stmt {
-      SLet(_, _, name, _, value) => {
-        let slot = validate_slot(name, rows, source, next)
-        let expr = validate_expr(value, rows, source, slot.1)
-        (slot.0 && expr.0, expr.1)
+    match validate_stmt(stmt, rows, source, next) {
+      Some(result) => {
+        ArrayBuilder::push(nodes, result.0)
+        next = result.1
       },
-      SLetMut(name, _, value) => {
-        let slot = validate_slot(name, rows, source, next)
-        let expr = validate_expr(value, rows, source, slot.1)
-        (slot.0 && expr.0, expr.1)
-      },
-      SExternLet(name, _) => validate_slot(name, rows, source, next),
-      SImport(_, items) => {
-        let mut import_ok = true
-        let mut import_next = next
-        for item in items {
-          let local = match item.1 {
-            Some(alias) => alias,
-            None => item.0
-          }
-          let slot = validate_slot(local, rows, source, import_next)
-          import_ok = import_ok && slot.0
-          import_next = slot.1
-        }
-        (import_ok, import_next)
-      },
-      SAliasDecl(name, _) => validate_slot(name, rows, source, next),
-      STypeAlias(_, name, params, _) => {
-        let first = validate_slot(name, rows, source, next)
-        let mut alias_ok = first.0
-        let mut alias_next = first.1
-        for param in params {
-          let slot = validate_slot(param, rows, source, alias_next)
-          alias_ok = alias_ok && slot.0
-          alias_next = slot.1
-        }
-        (alias_ok, alias_next)
-      },
-      SEffectSet(_, name, _) => validate_slot(name, rows, source, next),
-      SResource(name, _) => validate_slot(name, rows, source, next),
-      STest(_, body) => validate_expr(body, rows, source, next),
-      SBench(_, body) => validate_expr(body, rows, source, next),
-      SExample(_, body) => validate_expr(body, rows, source, next),
-      SExpr(body) => validate_expr(body, rows, source, next),
-      SExport(_) => (true, next),
-      SReExport(_, _) => (true, next),
-      SQualifiedPatternRefs(_) => (true, next),
-      STestEffectRows(_) => (true, next),
-      // Remaining declaration/lowering lanes are deliberately ineligible in
-      // this checkpoint; returning false is sticky at aggregate validation.
-      _ => (false, next)
+      None => return None
     }
-    ok = ok && result.0
-    next = result.1
   }
-  ok && next == Array::length(rows)
+  if next == Array::length(rows) {
+    Some(ArrayBuilder::freeze(nodes))
+  } else None
+}
+
+//# Source-owning authority entry
+
+/// Only this entry owns lexing, context creation, parse-to-EOF, and the direct
+/// validation control flow that can publish the aggregate. All exposed values
+/// and accessors remain forgeable data.
+export fn parse_source_located_with_binder_authority(source: String) -> Option[LocatedProgramBinderAuthority] with Exception {
+  let (tokens, starts, ends) = lex_with_offsets(source)
+  let context = binder_capture_context(starts, ends)
+  let (program, next) = parse_program_located_with_untrusted_binder_context(tokens, starts, source, Some(context))
+  let rows = binder_capture_rows(context)
+  if match peek(tokens, next) {
+    TEof => true,
+    _ => false
+  } && binder_capture_is_eligible(context) {
+    match build_program_binder_authority(program, rows, source) {
+      Some(nodes) => Some(LocatedProgramBinderAuthority::{
+        program, binders: rows, nodes
+      }),
+      None => None
+    }
+  } else None
 }

--- a/scripts/parser_binder_context_spine.test.mjs
+++ b/scripts/parser_binder_context_spine.test.mjs
@@ -403,12 +403,15 @@ test("B2 top-level helper bodies carry context and ordinary entries pass None", 
 });
 
 test("atomic binder authority is source-owned, validated, fail-closed, and bundled", () => {
-  assertBody(parserSource, "parse_source_located_with_binder_authority", [
+  assertBody(binderAuthoritySource, "parse_source_located_with_binder_authority", [
     "lex_with_offsets(source)",
     "binder_capture_context(starts, ends)",
-    "parse_program_located_with_context_impl(tokens, starts, source, Some(context))",
+    "parse_program_located_with_untrusted_binder_context(tokens, starts, source, Some(context))",
     "binder_capture_is_eligible(context)",
-    "validate_program_binder_rows(program, rows, source)",
+    "build_program_binder_authority(program, rows, source)",
+    "LocatedProgramBinderAuthority::{",
+    "binders: rows",
+    "nodes",
   ], ["tokens: Array[Token]", "context: Option[ParserBinderContext]"]);
   assertBody(binderContextSource, "binder_capture_source", [
     "Array::get(starts, first_token)",
@@ -425,17 +428,82 @@ test("atomic binder authority is source-owned, validated, fail-closed, and bundl
     "Array::truncate(c.rows, length - removed)",
     "None => ()",
   ], ["Array::slice", "SourceToken", "Synthetic"]);
-  assertBody(parserSource, "parse_source_located_with_binder_authority", [
+  assertBody(binderAuthoritySource, "parse_source_located_with_binder_authority", [
     "binder_capture_context(starts, ends)",
   ]);
   assertBody(binderAuthoritySource, "validate_program_binder_rows", [
+    "build_program_binder_authority(program, rows, source)",
+    "Some(_) => true",
+    "None => false",
+  ]);
+  assertBody(binderAuthoritySource, "build_program_binder_authority", [
     "next == Array::length(rows)",
-    "_ => (false, next)",
+    "ArrayBuilder::push(nodes, result.0)",
   ]);
   assert.match(parserContract, /opaque type LocatedProgramBinderAuthority/);
   assert.match(parserContract, /fn parse_source_located_with_binder_authority\(source: String\)/);
   assert.match(compilerManifest, /parser_binder_authority\.vibe/);
-  assert.equal((parserSource.match(/lex_with_offsets\(source\)/g) ?? []).length, 1, "only source-owning authority entry lexes source with exact offsets");
+  assert.equal((parserSource.match(/lex_with_offsets\(source\)/g) ?? []).length, 0, "ordinary parser module must not own exact-source authority lexing");
+  assert.equal((binderAuthoritySource.match(/lex_with_offsets\(source\)/g) ?? []).length, 1, "only source-owning authority entry lexes source with exact offsets");
+});
+
+test("trivia-aware authority inventory pairs every supported AST branch with one explicit closed node kind", () => {
+  const expected = {
+    validate_pattern: [
+      ["PWild", "AuthorityPatWild"], ["PBind", "AuthorityPatBind"],
+      ["PInt", "AuthorityPatInt"], ["PFloat", "AuthorityPatFloat"],
+      ["PString", "AuthorityPatString"], ["PBool", "AuthorityPatBool"],
+      ["PCtor", "AuthorityPatCtor"], ["PTuple", "AuthorityPatTuple"],
+      ["PStruct", "AuthorityPatStruct"],
+    ],
+    validate_expr: [
+      ["EInt", "AuthorityExprInt"], ["EFloat", "AuthorityExprFloat"],
+      ["EString", "AuthorityExprString"], ["EBool", "AuthorityExprBool"],
+      ["EIdent", "AuthorityExprIdent"], ["ETuple", "AuthorityExprTuple"],
+      ["EArray", "AuthorityExprArray"], ["ERecord", "AuthorityExprRecord"],
+      ["EIf", "AuthorityExprIf"], ["ELet", "AuthorityExprLet"],
+      ["ELetRec", "AuthorityExprLetRec"], ["ELetMut", "AuthorityExprLetMut"],
+      ["EAssign", "AuthorityExprAssign"], ["EAssignOp", "AuthorityExprAssignOp"],
+      ["ESeq", "AuthorityExprSeq"], ["EMatch", "AuthorityExprMatch"],
+      ["EHandle", "AuthorityExprHandle"], ["EWhile", "AuthorityExprWhile"],
+      ["EForIn", "AuthorityExprForIn"], ["ECall", "AuthorityExprCall"],
+      ["EBinOp", "AuthorityExprBinOp"], ["EUnaryOp", "AuthorityExprUnaryOp"],
+      ["EFn", "AuthorityExprFn"], ["EDot", "AuthorityExprDot"],
+      ["ELabeledArg", "AuthorityExprLabeledArg"], ["EReturn", "AuthorityExprReturn"],
+      ["EBreak", "AuthorityExprBreak"], ["EContinue", "AuthorityExprContinue"],
+      ["EMap", "AuthorityExprMap"], ["ESpread", "AuthorityExprSpread"],
+      ["EStringInterp", "AuthorityExprStringInterp"], ["EUnit", "AuthorityExprUnit"],
+    ],
+    validate_stmt: [
+      ["SLet", "AuthorityStmtLet"], ["SLetMut", "AuthorityStmtLetMut"],
+      ["SExternLet", "AuthorityStmtExternLet"], ["SImport", "AuthorityStmtImport"],
+      ["SAliasDecl", "AuthorityStmtAliasDecl"], ["STypeAlias", "AuthorityStmtTypeAlias"],
+      ["SEffectSet", "AuthorityStmtEffectSet"], ["SResource", "AuthorityStmtResource"],
+      ["STest", "AuthorityStmtTest"], ["SBench", "AuthorityStmtBench"],
+      ["SExample", "AuthorityStmtExample"], ["SExpr", "AuthorityStmtExpr"],
+      ["SExport", "AuthorityStmtExport"], ["SReExport", "AuthorityStmtReExport"],
+      ["SQualifiedPatternRefs", "AuthorityStmtQualifiedPatternRefs"],
+      ["STestEffectRows", "AuthorityStmtTestEffectRows"],
+    ],
+  };
+
+  const declaredKinds = vibeTokens(binderAuthoritySource.slice(
+    binderAuthoritySource.indexOf("export enum BinderAuthorityNodeKind"),
+    binderAuthoritySource.indexOf("export enum BinderSemanticRole"),
+  )).map((token) => token.text).filter((text) => text.startsWith("Authority"));
+  const expectedKinds = Object.values(expected).flat().map(([, kind]) => kind);
+  assert.deepEqual([...declaredKinds].sort(), [...expectedKinds].sort(), "closed node-kind enum must exactly match the supported constructor inventory");
+
+  for (const [fn, pairs] of Object.entries(expected)) {
+    const tokens = vibeTokens(functionBody(binderAuthoritySource, fn)).map((token) => token.text);
+    for (const [ctor, kind] of pairs) {
+      assert.ok(tokens.includes(ctor), `${fn}: missing supported AST branch ${ctor}`);
+      assert.equal(tokens.filter((token) => token === kind).length, ctor === "EBreak" ? 2 : 1, `${fn}:${ctor}: must construct exactly one explicit ${kind} per branch (EBreak has Some/None sub-branches)`);
+    }
+    assert.ok(!tokens.includes("true"), `${fn}: supported branches must not regress to bool-only validation`);
+  }
+  assert.ok(functionBody(binderAuthoritySource, "validate_pattern").includes("POr(_, _) => None"));
+  assert.ok(functionBody(binderAuthoritySource, "validate_expr").includes("ELoop(_, _) => None"));
 });
 
 test("malformed binder context failures use guarded poison and fixed append bounds", () => {

--- a/scripts/parser_binder_context_spine.test.mjs
+++ b/scripts/parser_binder_context_spine.test.mjs
@@ -106,6 +106,56 @@ function balancedEnd(tokens, open, left, right) {
   assert.fail(`unterminated balanced ${left}${right} at token ${open}`);
 }
 
+function tokenText(source) {
+  return vibeTokens(source).map((token) => token.text).join(" ");
+}
+
+// Parse only the OUTER match of one validator. Comments/strings are removed by
+// vibeTokens, and commas/arrows count as arm separators only at balanced depth
+// zero inside that match. Nested matches and constructor arguments stay local
+// to their containing arm body/head.
+function outerMatchArms(source, name) {
+  const tokens = vibeTokens(functionBody(source, name));
+  const matchAt = tokens.findIndex((token) => token.text === "match");
+  assert.notEqual(matchAt, -1, `${name}: missing outer match`);
+  const open = tokens.findIndex((token, i) => i > matchAt && token.text === "{");
+  assert.notEqual(open, -1, `${name}: missing outer match body`);
+  const close = balancedEnd(tokens, open, "{", "}");
+  const arms = new Map();
+  let i = open + 1;
+  while (i < close) {
+    while (i < close && tokens[i].text === ",") i += 1;
+    if (i >= close) break;
+    const headStart = i;
+    let depth = 0;
+    let arrow = -1;
+    for (; i < close; i += 1) {
+      const text = tokens[i].text;
+      if (["(", "[", "{"].includes(text)) depth += 1;
+      else if ([")", "]", "}"].includes(text)) depth -= 1;
+      else if (text === "=>" && depth === 0) { arrow = i; break; }
+    }
+    assert.notEqual(arrow, -1, `${name}: unterminated arm head`);
+    const head = tokens.slice(headStart, arrow).map((token) => token.text);
+    const ctor = head[0];
+    const bodyStart = arrow + 1;
+    i = bodyStart;
+    depth = 0;
+    for (; i < close; i += 1) {
+      const text = tokens[i].text;
+      if (["(", "[", "{"].includes(text)) depth += 1;
+      else if ([")", "]", "}"].includes(text)) depth -= 1;
+      else if (text === "," && depth === 0) break;
+    }
+    assert.ok(!arms.has(ctor), `${name}: duplicate outer arm ${ctor}`);
+    arms.set(ctor, {
+      head,
+      body: tokens.slice(bodyStart, i).map((token) => token.text),
+    });
+  }
+  return arms;
+}
+
 function efnInventory(file, source) {
   const tokens = vibeTokens(source);
   const functions = [];
@@ -445,65 +495,146 @@ test("atomic binder authority is source-owned, validated, fail-closed, and bundl
   assert.match(compilerManifest, /parser_binder_authority\.vibe/);
   assert.equal((parserSource.match(/lex_with_offsets\(source\)/g) ?? []).length, 0, "ordinary parser module must not own exact-source authority lexing");
   assert.equal((binderAuthoritySource.match(/lex_with_offsets\(source\)/g) ?? []).length, 1, "only source-owning authority entry lexes source with exact offsets");
+  const storedBlock = binderAuthoritySource.slice(
+    binderAuthoritySource.indexOf("enum StoredBinderAuthority"),
+    binderAuthoritySource.indexOf("/// Atomically produced exact-source parse result"),
+  );
+  const aggregateBlock = binderAuthoritySource.slice(
+    binderAuthoritySource.indexOf("export struct LocatedProgramBinderAuthority"),
+    binderAuthoritySource.indexOf("//# Data accessors"),
+  );
+  assert.ok(aggregateBlock.includes("nodes: StoredBinderAuthority"), "aggregate must retain the private persistent topology");
+  assert.ok(!vibeTokens(storedBlock).some((token) => token.text === "Array"), "no mutable Array may be reachable from stored node topology");
+  assertBody(binderAuthoritySource, "located_program_binder_authority_nodes", [
+    "append_materialized_nodes(authority.nodes, out)",
+    "ArrayBuilder::freeze(out)",
+  ], ["Array::slice"]);
+  for (const leafAccessor of ["binder_authority_node_kind", "binder_authority_node_slots", "binder_authority_node_children"]) {
+    assert.ok(!functionBody(binderAuthoritySource, leafAccessor).includes("materialize_authority_node"), `${leafAccessor}: forged cycles must not trigger recursive copying`);
+  }
 });
 
-test("trivia-aware authority inventory pairs every supported AST branch with one explicit closed node kind", () => {
-  const expected = {
-    validate_pattern: [
-      ["PWild", "AuthorityPatWild"], ["PBind", "AuthorityPatBind"],
-      ["PInt", "AuthorityPatInt"], ["PFloat", "AuthorityPatFloat"],
-      ["PString", "AuthorityPatString"], ["PBool", "AuthorityPatBool"],
-      ["PCtor", "AuthorityPatCtor"], ["PTuple", "AuthorityPatTuple"],
-      ["PStruct", "AuthorityPatStruct"],
-    ],
-    validate_expr: [
-      ["EInt", "AuthorityExprInt"], ["EFloat", "AuthorityExprFloat"],
-      ["EString", "AuthorityExprString"], ["EBool", "AuthorityExprBool"],
-      ["EIdent", "AuthorityExprIdent"], ["ETuple", "AuthorityExprTuple"],
-      ["EArray", "AuthorityExprArray"], ["ERecord", "AuthorityExprRecord"],
-      ["EIf", "AuthorityExprIf"], ["ELet", "AuthorityExprLet"],
-      ["ELetRec", "AuthorityExprLetRec"], ["ELetMut", "AuthorityExprLetMut"],
-      ["EAssign", "AuthorityExprAssign"], ["EAssignOp", "AuthorityExprAssignOp"],
-      ["ESeq", "AuthorityExprSeq"], ["EMatch", "AuthorityExprMatch"],
-      ["EHandle", "AuthorityExprHandle"], ["EWhile", "AuthorityExprWhile"],
-      ["EForIn", "AuthorityExprForIn"], ["ECall", "AuthorityExprCall"],
-      ["EBinOp", "AuthorityExprBinOp"], ["EUnaryOp", "AuthorityExprUnaryOp"],
-      ["EFn", "AuthorityExprFn"], ["EDot", "AuthorityExprDot"],
-      ["ELabeledArg", "AuthorityExprLabeledArg"], ["EReturn", "AuthorityExprReturn"],
-      ["EBreak", "AuthorityExprBreak"], ["EContinue", "AuthorityExprContinue"],
-      ["EMap", "AuthorityExprMap"], ["ESpread", "AuthorityExprSpread"],
-      ["EStringInterp", "AuthorityExprStringInterp"], ["EUnit", "AuthorityExprUnit"],
-    ],
-    validate_stmt: [
-      ["SLet", "AuthorityStmtLet"], ["SLetMut", "AuthorityStmtLetMut"],
-      ["SExternLet", "AuthorityStmtExternLet"], ["SImport", "AuthorityStmtImport"],
-      ["SAliasDecl", "AuthorityStmtAliasDecl"], ["STypeAlias", "AuthorityStmtTypeAlias"],
-      ["SEffectSet", "AuthorityStmtEffectSet"], ["SResource", "AuthorityStmtResource"],
-      ["STest", "AuthorityStmtTest"], ["SBench", "AuthorityStmtBench"],
-      ["SExample", "AuthorityStmtExample"], ["SExpr", "AuthorityStmtExpr"],
-      ["SExport", "AuthorityStmtExport"], ["SReExport", "AuthorityStmtReExport"],
-      ["SQualifiedPatternRefs", "AuthorityStmtQualifiedPatternRefs"],
-      ["STestEffectRows", "AuthorityStmtTestEffectRows"],
-    ],
-  };
+function authoritySpec(kind, build, roles = [], order = []) {
+  return { kind, build: Array.isArray(build) ? build : [build], roles, order };
+}
 
-  const declaredKinds = vibeTokens(binderAuthoritySource.slice(
-    binderAuthoritySource.indexOf("export enum BinderAuthorityNodeKind"),
-    binderAuthoritySource.indexOf("export enum BinderSemanticRole"),
+const authorityArmSpecs = {
+  validate_pattern: {
+    PBind: authoritySpec("AuthorityPatBind", "authority_node(AuthorityPatBind, [result.0], no_nodes())", ["PatternBinder"]),
+    PCtor: authoritySpec("AuthorityPatCtor", "authority_node(AuthorityPatCtor, no_slots(), result.0)", [], ["validate_patterns(args, rows, source, at)"]),
+    PTuple: authoritySpec("AuthorityPatTuple", "authority_node(AuthorityPatTuple, no_slots(), result.0)", [], ["validate_patterns(args, rows, source, at)"]),
+    PStruct: authoritySpec("AuthorityPatStruct", "authority_node(AuthorityPatStruct, no_slots(), ArrayBuilder::freeze(children))", [], ["for field in fields", "validate_pattern(field.1, rows, source, next)", "ArrayBuilder::push(children, result.0)"]),
+    PWild: authoritySpec("AuthorityPatWild", "leaf(AuthorityPatWild)"),
+    PInt: authoritySpec("AuthorityPatInt", "leaf(AuthorityPatInt)"),
+    PFloat: authoritySpec("AuthorityPatFloat", "leaf(AuthorityPatFloat)"),
+    PString: authoritySpec("AuthorityPatString", "leaf(AuthorityPatString)"),
+    PBool: authoritySpec("AuthorityPatBool", "leaf(AuthorityPatBool)"),
+  },
+  validate_expr: {
+    ELet: authoritySpec("AuthorityExprLet", "authority_node(AuthorityExprLet, [slot.0], two_nodes(v.0, b.0))", ["ExpressionLetBinder"]),
+    ELetRec: authoritySpec("AuthorityExprLetRec", "authority_node(AuthorityExprLetRec, [slot.0], two_nodes(v.0, b.0))", ["ExpressionLetRecBinder"]),
+    ELetMut: authoritySpec("AuthorityExprLetMut", "authority_node(AuthorityExprLetMut, [slot.0], two_nodes(v.0, b.0))", ["ExpressionLetMutBinder"]),
+    EMatch: authoritySpec("AuthorityExprMatch", "authority_node(AuthorityExprMatch, no_slots(), ArrayBuilder::freeze(children))", [], ["validate_expr(scrutinee, rows, source, at)", "validate_arms(arms, rows, source, s.1)", "ArrayBuilder::push(children, s.0)", "for child in a.0", "ArrayBuilder::push(children, child)"]),
+    EHandle: authoritySpec("AuthorityExprHandle", "authority_node(AuthorityExprHandle, no_slots(), ArrayBuilder::freeze(children))", [], ["validate_expr(body, rows, source, at)", "validate_arms(arms, rows, source, b.1)", "ArrayBuilder::push(children, b.0)", "for child in a.0", "ArrayBuilder::push(children, child)"]),
+    EFn: authoritySpec("AuthorityExprFn", "authority_node(AuthorityExprFn, ArrayBuilder::freeze(slots), one_node(result.0))", ["ExpressionFunctionTypeParameterBinder", "ExpressionFunctionParameterBinder"], ["for name in type_params", "for param in params", "validate_expr(body, rows, source, next)"]),
+    EForIn: authoritySpec("AuthorityExprForIn", "authority_node(AuthorityExprForIn, ArrayBuilder::freeze(slots), two_nodes(i.0, b.0))", ["ExpressionForValueBinder", "ExpressionForIndexBinder"], ["validate_expr(iter, rows, source, next)", "validate_expr(body, rows, source, i.1)"]),
+    ETuple: authoritySpec("AuthorityExprTuple", "authority_node(AuthorityExprTuple, no_slots(), result.0)", [], ["validate_exprs(items, rows, source, at)"]),
+    EArray: authoritySpec("AuthorityExprArray", "authority_node(AuthorityExprArray, no_slots(), result.0)", [], ["validate_exprs(items, rows, source, at)"]),
+    ERecord: authoritySpec("AuthorityExprRecord", "authority_node(AuthorityExprRecord, no_slots(), result.0)", [], ["validate_named_exprs(fields, rows, source, at)"]),
+    EIf: authoritySpec("AuthorityExprIf", "authority_node(AuthorityExprIf, no_slots(), [c.0, y.0, n.0])", [], ["validate_expr(cond, rows, source, at)", "validate_expr(yes, rows, source, c.1)", "validate_expr(no, rows, source, y.1)"]),
+    EAssign: authoritySpec("AuthorityExprAssign", "authority_node(AuthorityExprAssign, no_slots(), two_nodes(v.0, b.0))"),
+    EAssignOp: authoritySpec("AuthorityExprAssignOp", "authority_node(AuthorityExprAssignOp, no_slots(), two_nodes(v.0, b.0))"),
+    ESeq: authoritySpec("AuthorityExprSeq", "authority_node(AuthorityExprSeq, no_slots(), two_nodes(f.0, s.0))"),
+    EWhile: authoritySpec("AuthorityExprWhile", "authority_node(AuthorityExprWhile, no_slots(), two_nodes(c.0, b.0))"),
+    ECall: authoritySpec("AuthorityExprCall", "authority_node(AuthorityExprCall, no_slots(), ArrayBuilder::freeze(children))", [], ["validate_expr(callee, rows, source, at)", "ArrayBuilder::push(children, c.0)", "for child in a.0", "ArrayBuilder::push(children, child)"]),
+    EBinOp: authoritySpec("AuthorityExprBinOp", "authority_node(AuthorityExprBinOp, no_slots(), two_nodes(l.0, r.0))"),
+    EUnaryOp: authoritySpec("AuthorityExprUnaryOp", "authority_node(AuthorityExprUnaryOp, no_slots(), one_node(result.0))"),
+    EDot: authoritySpec("AuthorityExprDot", "authority_node(AuthorityExprDot, no_slots(), one_node(result.0))"),
+    ELabeledArg: authoritySpec("AuthorityExprLabeledArg", "authority_node(AuthorityExprLabeledArg, no_slots(), one_node(result.0))"),
+    EReturn: authoritySpec("AuthorityExprReturn", "authority_node(AuthorityExprReturn, no_slots(), one_node(result.0))"),
+    EBreak: authoritySpec("AuthorityExprBreak", ["authority_node(AuthorityExprBreak, no_slots(), one_node(result.0))", "leaf(AuthorityExprBreak)"]),
+    EContinue: authoritySpec("AuthorityExprContinue", "authority_node(AuthorityExprContinue, no_slots(), result.0)", [], ["validate_exprs(values, rows, source, at)"]),
+    EMap: authoritySpec("AuthorityExprMap", "authority_node(AuthorityExprMap, no_slots(), result.0)", [], ["validate_named_exprs(items, rows, source, at)"]),
+    ESpread: authoritySpec("AuthorityExprSpread", "authority_node(AuthorityExprSpread, no_slots(), one_node(result.0))"),
+    EInt: authoritySpec("AuthorityExprInt", "leaf(AuthorityExprInt)"),
+    EFloat: authoritySpec("AuthorityExprFloat", "leaf(AuthorityExprFloat)"),
+    EString: authoritySpec("AuthorityExprString", "leaf(AuthorityExprString)"),
+    EBool: authoritySpec("AuthorityExprBool", "leaf(AuthorityExprBool)"),
+    EIdent: authoritySpec("AuthorityExprIdent", "leaf(AuthorityExprIdent)"),
+    EStringInterp: authoritySpec("AuthorityExprStringInterp", "leaf(AuthorityExprStringInterp)"),
+    EUnit: authoritySpec("AuthorityExprUnit", "leaf(AuthorityExprUnit)"),
+  },
+  validate_stmt: {
+    SLet: authoritySpec("AuthorityStmtLet", "authority_node(AuthorityStmtLet, [slot.0], one_node(expr.0))", ["StatementLetBinder"]),
+    SLetMut: authoritySpec("AuthorityStmtLetMut", "authority_node(AuthorityStmtLetMut, [slot.0], one_node(expr.0))", ["StatementLetMutBinder"]),
+    SExternLet: authoritySpec("AuthorityStmtExternLet", "authority_node(AuthorityStmtExternLet, [slot.0], no_nodes())", ["StatementExternBinder"]),
+    SImport: authoritySpec("AuthorityStmtImport", "authority_node(AuthorityStmtImport, ArrayBuilder::freeze(slots), no_nodes())", ["StatementImportBinder"], ["for item in items", "ArrayBuilder::push(slots, slot.0)"]),
+    SAliasDecl: authoritySpec("AuthorityStmtAliasDecl", "authority_node(AuthorityStmtAliasDecl, [slot.0], no_nodes())", ["StatementAliasBinder"]),
+    STypeAlias: authoritySpec("AuthorityStmtTypeAlias", "authority_node(AuthorityStmtTypeAlias, ArrayBuilder::freeze(slots), no_nodes())", ["StatementTypeBinder", "StatementTypeParameterBinder"], ["ArrayBuilder::push(slots, first.0)", "for param in params", "ArrayBuilder::push(slots, slot.0)"]),
+    SEffectSet: authoritySpec("AuthorityStmtEffectSet", "authority_node(AuthorityStmtEffectSet, [slot.0], no_nodes())", ["StatementEffectSetBinder"]),
+    SResource: authoritySpec("AuthorityStmtResource", "authority_node(AuthorityStmtResource, [slot.0], no_nodes())", ["StatementResourceBinder"]),
+    STest: authoritySpec("AuthorityStmtTest", "authority_node(AuthorityStmtTest, no_slots(), one_node(expr.0))"),
+    SBench: authoritySpec("AuthorityStmtBench", "authority_node(AuthorityStmtBench, no_slots(), one_node(expr.0))"),
+    SExample: authoritySpec("AuthorityStmtExample", "authority_node(AuthorityStmtExample, no_slots(), one_node(expr.0))"),
+    SExpr: authoritySpec("AuthorityStmtExpr", "authority_node(AuthorityStmtExpr, no_slots(), one_node(expr.0))"),
+    SExport: authoritySpec("AuthorityStmtExport", "leaf(AuthorityStmtExport)"),
+    SReExport: authoritySpec("AuthorityStmtReExport", "leaf(AuthorityStmtReExport)"),
+    SQualifiedPatternRefs: authoritySpec("AuthorityStmtQualifiedPatternRefs", "leaf(AuthorityStmtQualifiedPatternRefs)"),
+    STestEffectRows: authoritySpec("AuthorityStmtTestEffectRows", "leaf(AuthorityStmtTestEffectRows)"),
+  },
+};
+
+const semanticRoles = tokenText(binderAuthoritySource.slice(
+  binderAuthoritySource.indexOf("export enum BinderSemanticRole"),
+  binderAuthoritySource.indexOf("export struct BinderAuthoritySlot"),
+)).split(" ").filter((token) => token.endsWith("Binder"));
+
+function assertAuthorityArmStructure(source) {
+  const declaredKinds = vibeTokens(source.slice(
+    source.indexOf("export enum BinderAuthorityNodeKind"),
+    source.indexOf("export enum BinderSemanticRole"),
   )).map((token) => token.text).filter((text) => text.startsWith("Authority"));
-  const expectedKinds = Object.values(expected).flat().map(([, kind]) => kind);
-  assert.deepEqual([...declaredKinds].sort(), [...expectedKinds].sort(), "closed node-kind enum must exactly match the supported constructor inventory");
+  const expectedKinds = Object.values(authorityArmSpecs).flatMap((specs) => Object.values(specs).map((spec) => spec.kind));
+  assert.deepEqual([...declaredKinds].sort(), [...expectedKinds].sort(), "closed kind enum must exactly match supported arms");
 
-  for (const [fn, pairs] of Object.entries(expected)) {
-    const tokens = vibeTokens(functionBody(binderAuthoritySource, fn)).map((token) => token.text);
-    for (const [ctor, kind] of pairs) {
-      assert.ok(tokens.includes(ctor), `${fn}: missing supported AST branch ${ctor}`);
-      assert.equal(tokens.filter((token) => token === kind).length, ctor === "EBreak" ? 2 : 1, `${fn}:${ctor}: must construct exactly one explicit ${kind} per branch (EBreak has Some/None sub-branches)`);
+  for (const [fn, specs] of Object.entries(authorityArmSpecs)) {
+    const arms = outerMatchArms(source, fn);
+    const unsupported = fn === "validate_pattern" ? { POr: "None" } : fn === "validate_expr" ? { ELoop: "None" } : { _: "None" };
+    assert.deepEqual([...arms.keys()].sort(), [...Object.keys(specs), ...Object.keys(unsupported)].sort(), `${fn}: outer arm inventory drift`);
+    for (const [ctor, spec] of Object.entries(specs)) {
+      const body = arms.get(ctor).body;
+      const canonical = body.join(" ");
+      const kinds = body.filter((token) => token.startsWith("Authority"));
+      assert.deepEqual(kinds, Array(spec.build.length).fill(spec.kind), `${fn}:${ctor}: arm-local kind association`);
+      const roles = body.filter((token) => semanticRoles.includes(token));
+      assert.deepEqual(roles, spec.roles, `${fn}:${ctor}: arm-local semantic roles`);
+      const constructionCalls = body.filter((token) => token === "authority_node" || token === "leaf").length;
+      assert.equal(constructionCalls, spec.build.length, `${fn}:${ctor}: exact construction count`);
+      for (const build of spec.build) assert.ok(canonical.includes(tokenText(build)), `${fn}:${ctor}: missing exact child/slot construction ${build}`);
+      let previous = -1;
+      for (const ordered of spec.order) {
+        const at = canonical.indexOf(tokenText(ordered), previous + 1);
+        assert.ok(at > previous, `${fn}:${ctor}: missing/out-of-order ${ordered}`);
+        previous = at;
+      }
     }
-    assert.ok(!tokens.includes("true"), `${fn}: supported branches must not regress to bool-only validation`);
+    for (const [ctor, exact] of Object.entries(unsupported)) assert.equal(arms.get(ctor).body.join(" "), exact, `${fn}:${ctor}: unsupported arm must be locally None`);
   }
-  assert.ok(functionBody(binderAuthoritySource, "validate_pattern").includes("POr(_, _) => None"));
-  assert.ok(functionBody(binderAuthoritySource, "validate_expr").includes("ELoop(_, _) => None"));
+}
+
+test("balanced arm-local authority oracle proves exact kind, roles, and ordered children", () => {
+  assertAuthorityArmStructure(binderAuthoritySource);
+});
+
+test("arm-local authority oracle rejects wrong kinds, missing children, and swapped roles", () => {
+  const swappedKinds = binderAuthoritySource
+    .replace("EInt(_) => Some((leaf(AuthorityExprInt)", "EInt(_) => Some((leaf(AuthorityExprFloat)")
+    .replace("EFloat(_) => Some((leaf(AuthorityExprFloat)", "EFloat(_) => Some((leaf(AuthorityExprInt)");
+  assert.throws(() => assertAuthorityArmStructure(swappedKinds), /validate_expr:E(Int|Float): arm-local kind association/);
+  const omittedLetBody = binderAuthoritySource.replace("two_nodes(v.0, b.0)", "one_node(v.0)");
+  assert.throws(() => assertAuthorityArmStructure(omittedLetBody), /validate_expr:ELet: missing exact child\/slot construction/);
+  const swappedRole = binderAuthoritySource.replace("validate_slot(name, ExpressionLetBinder, rows", "validate_slot(name, ExpressionLetRecBinder, rows");
+  assert.throws(() => assertAuthorityArmStructure(swappedRole), /validate_expr:ELet: arm-local semantic roles/);
 });
 
 test("malformed binder context failures use guarded poison and fixed append bounds", () => {


### PR DESCRIPTION
## Summary

Adds the parser-owned slot-addressable binder authority prerequisite for #1548.

The existing exact-source authority API still returns the final parsed program and flat compatibility rows, but now also exposes one recursively paired authority root per final statement. Each supported final-AST node has a closed kind, ordered children, and binder slots labeled with closed semantic roles. The sidecar is constructed in the same exhaustive validator walk that validates row spelling and exact UTF-8 spans; there is no second resolver, AST rescan, name/span map, or checker-authored path.

Validated topology is retained internally as a private persistent array-free tree. Public nodes remain explicitly forgeable data and are freshly materialized at every depth, so caller mutation cannot alter the validated aggregate. Existing represented synthetic rows remain compatible; unsupported topology such as `POr`, `ELoop`, and unsupported declaration lanes remains fail-closed.

This PR intentionally does **not** add checker provenance, TypeEnv/cache/persistence changes, occurrence end spans, or AST constructor changes. Checker occurrence provenance remains a later slice that will consume paired nodes while preserving/poisoning authority through production transformations.

## Why

Independent architecture audits confirmed that flat binder rows cannot identify production checker binding slots after:

- type-declaration reordering;
- top-level let hoisting and final rebinding;
- local recursive provisional/final binding;
- labeled-argument reordering;
- effectset statement copies;
- synthetic desugaring.

The paired parser sidecar is the minimum prerequisite that avoids a forbidden parallel resolver or source/name/offset reconstruction.

## Validation

- final independent architecture review: **ACCEPT**
- focused authority/context suite: **58 passed**
- parser package: **29 passed**
- full unit suite: **657/657**
- structural Node spine: **10/10**
  - includes negative controls for swapped node kinds, omitted `ELet` child authority, swapped semantic roles, and omitted variable-arity child delegation
- formatter and generated freshness: passed
- stage2 == stage3: `a2449048dcb706170732c1fe78b755958e42ad04931cddcabeef9d26887fe88e`
- exact parent/current ordinary parser allocations, 30 iterations:
  - empty metadata: `98,912 / 98,912 B/op`
  - parser query: `116,128 / 116,128 B/op`
- fixed six-fixture allocation gate: passed
- selfcompile heap: `1,079,163,432 <= 1,088,823,640`
- deep stress: 5,000 top-level roots and 1,000 nested lets terminated

The local compiler gate reached gate 92 without a product failure, then hit the known macOS/BSD `xargs -I` replacement-buffer limit (`command line cannot be assembled, too long`). Linux exact-head CI is authoritative for the complete gate.

## Scope and compatibility

Changed only:

- `fixtures/parser_binder_slot_authority_test.vibe`
- `lib/@vibe/parser/index.vpkg`
- `lib/@vibe/parser/parser.vibe`
- `lib/@vibe/parser/parser_binder_authority.vibe`
- `scripts/parser_binder_context_spine.test.mjs`

Ordinary parser APIs continue to use `context=None` and retain exact zero same-path allocation drift. Flat row order and currently approved represented `SourceBinder::Synthetic` behavior are unchanged.
