### PR TITLE
feat(gc): vibe_process_exit_raw を gc レーンに足す / gate の errexit 罠を潰す (#1262)

### DIFF
--- a/fixtures/gc_process_exit.vibe
+++ b/fixtures/gc_process_exit.vibe
@@ -1,0 +1,23 @@
+// #1262: `vibe_process_exit_raw` on the wasm-gc lane.
+//
+// This was the gc self-build's stopping point. Every builtin LOWERING was
+// already in place by then; what was missing was the host import itself, so
+// codegen reached an unresolved name. The flat compiler source hits it because
+// cli_adapter.vibe ends `main` with it.
+//
+// The exit code is the observable, and it has to be checked as a PROCESS
+// EXIT STATUS rather than a returned value: a lowering that evaluated the
+// argument and fell through would let the program run to completion and exit
+// 0, which is exactly the silently-wrong shape. So the gate runs this and
+// asserts the status, and picks a code that no other failure produces.
+//
+// 7 is chosen for that reason: a trap exits 134, an uncaught throw exits 1,
+// and a clean fallthrough exits 0. None of those can be mistaken for it.
+
+export let main = () -> Int with Process {
+  let side = 1 + 1
+  vibe_process_exit_raw(7)
+  // Unreachable. If the exit lowering is a no-op this returns 0 and the
+  // process exits cleanly -- the failure this fixture exists to catch.
+  side - 2
+}

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -1478,9 +1478,9 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // wrong: the first build that appended imports but left hbo behind produced
   // modules that validated nowhere ("not enough arguments on the stack for
   // call"), because every generated-body index still pointed low.
-  let use_host = stmts_use_builtin(stmts, fn_names_list, "Env::get") || stmts_use_builtin(stmts, fn_names_list, "Env::args_len") || stmts_use_builtin(stmts, fn_names_list, "Env::args_get") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::exists") || stmts_use_builtin(stmts, fn_names_list, "Fs::stat_token") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::publish_immutable_text") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_bytes") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_bytes") || stmts_use_builtin(stmts, fn_names_list, "Profiler::now_us") || stmts_use_builtin(stmts, fn_names_list, "Fs::remove") || stmts_use_builtin(stmts, fn_names_list, "Fs::rename") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_dir") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_file") || stmts_use_builtin(stmts, fn_names_list, "Stdout::write_stream") || stmts_use_builtin(stmts, fn_names_list, "Fs::readdir") || stmts_use_builtin(stmts, fn_names_list, "Stdin::read_char") || stmts_use_builtin(stmts, fn_names_list, "Stdin::read_stream")
+  let use_host = stmts_use_builtin(stmts, fn_names_list, "Env::get") || stmts_use_builtin(stmts, fn_names_list, "Env::args_len") || stmts_use_builtin(stmts, fn_names_list, "Env::args_get") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::exists") || stmts_use_builtin(stmts, fn_names_list, "Fs::stat_token") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::publish_immutable_text") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_bytes") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_bytes") || stmts_use_builtin(stmts, fn_names_list, "Profiler::now_us") || stmts_use_builtin(stmts, fn_names_list, "Fs::remove") || stmts_use_builtin(stmts, fn_names_list, "Fs::rename") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_dir") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_file") || stmts_use_builtin(stmts, fn_names_list, "Stdout::write_stream") || stmts_use_builtin(stmts, fn_names_list, "Fs::readdir") || stmts_use_builtin(stmts, fn_names_list, "Stdin::read_char") || stmts_use_builtin(stmts, fn_names_list, "Stdin::read_stream") || stmts_use_builtin(stmts, fn_names_list, "vibe_process_exit_raw")
   let hbo = if use_host {
-    19
+    20
   } else {
     0
   }
@@ -1707,7 +1707,13 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       // `VIBE_STDIN_BYTES` (an env var, not piped stdin) -- with it these are
       // verifiable against linear on real input, so they land here now.
       ("Stdin::read_char", 0, 18, 1),
-      ("Stdin::read_stream", 1, 19, 1)
+      ("Stdin::read_stream", 1, 19, 1),
+      // #1262: `vibe.process_exit (i64) -> ()` -- void, same shape as
+      // Fs::remove / Stdout::write_stream. This was the gc self-build's
+      // stopping point: the flat compiler source calls it (cli_adapter.vibe
+      // ends `main` with it), so codegen hit an unresolved name here while
+      // every builtin LOWERING was already in place.
+      ("vibe_process_exit_raw", 1, 20, 0)
     ]
     let mut __hd = 0
     while __hd < Array::length(host_defs) {
@@ -2441,7 +2447,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
     // 4=(i64,i64)->i64, 5=()->i64, 6=(i64,i64)->()) -- the linear backend's
     // raw tagged ABI.
     let imp_content = bytebuf_new()
-    bytebuf_push_vec_header(imp_content, 20)
+    bytebuf_push_vec_header(imp_content, 21)
     emit_name(imp_content, "wasi_snapshot_preview1")
     emit_name(imp_content, "fd_write")
     bytebuf_push(imp_content, 0)
@@ -2467,7 +2473,8 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       ("stdout_write_stream", 1),
       ("fs_read_dir", 3),
       ("stdin_read_char", 5),
-      ("stdin_read_stream", 3)
+      ("stdin_read_stream", 3),
+      ("process_exit", 1)
     ]
     let mut __hi = 0
     while __hi < Array::length(host_imports) {

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -79,7 +79,6 @@ vibe_http_request_raw	linear-only	host-import	host/linear-memory import; the gc 
 vibe_http_response_body_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_http_response_header_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_http_response_status_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-vibe_process_exit_raw	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 vibe_rc_alloc	linear-only	linear-runtime-internal	linear-memory runtime helper; meaningless on the gc heap
 vibe_rc_drop	linear-only	linear-runtime-internal	linear-memory runtime helper; meaningless on the gc heap
 vibe_rc_dup	linear-only	linear-runtime-internal	linear-memory runtime helper; meaningless on the gc heap

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4897,8 +4897,14 @@ for gcpe_be in linear gc; do
     cat "$gcpedir/$gcpe_be.wasm.diag" 2>/dev/null >&2 || true
     exit 1
   fi
-  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcpedir/$gcpe_be.wasm" >/dev/null 2>&1
-  gcpe_rc=$?
+  # `if` guard, not a bare call: this script runs under `set -euo pipefail`,
+  # and the SUCCESS case here is a NON-ZERO status (7). A bare call would kill
+  # the gate exactly when the fixture behaves correctly -- and, worse, a
+  # regression that made the exit a no-op would return 0 and sail past. The
+  # detector was inverted: it passed only when broken. The condition part of
+  # `if` is exempt from errexit, so the status reaches the assertion.
+  gcpe_rc=0
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcpedir/$gcpe_be.wasm" >/dev/null 2>&1 || gcpe_rc=$?
   if [ "$gcpe_rc" -ne 7 ]; then
     echo "[compiler-gate] FAIL: gc_process_exit.vibe exited $gcpe_rc on the $gcpe_be backend (want 7; 0 = the exit lowering is a no-op and the program fell through) (#1262)" >&2
     exit 1

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4875,6 +4875,38 @@ fi
 rm -rf "$gcsidir"
 echo "[compiler-gate] wasm-gc stdin + Int::parse ok (linear + gc, real input via VIBE_STDIN_BYTES)"
 
+# 40h-9. #1262: `vibe_process_exit_raw` on the gc lane -- the gc self-build's
+#        stopping point. Every builtin LOWERING was already in place; the host
+#        import itself was missing, so codegen reached an unresolved name.
+#
+#        Checked as a PROCESS EXIT STATUS, not a returned value. A lowering
+#        that evaluated its argument and fell through would run the program to
+#        completion and exit 0, and no value assertion downstream of the call
+#        can see that -- the call is supposed to be the last thing that
+#        happens. 7 is picked because nothing else produces it: a trap exits
+#        134, an uncaught throw exits 1, a clean fallthrough exits 0.
+echo "[compiler-gate] 40h-9/40 wasm-gc process exit (#1262)"
+gcpedir="_build/_gate_gc_process_exit"
+rm -rf "$gcpedir"; mkdir -p "$gcpedir"
+for gcpe_be in linear gc; do
+  env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcpe_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "fixtures/gc_process_exit.vibe" "$gcpedir/$gcpe_be.wasm" main >/dev/null 2>&1
+  if [ ! -s "$gcpedir/$gcpe_be.wasm" ]; then
+    echo "[compiler-gate] FAIL: gc_process_exit.vibe did not compile on the $gcpe_be backend (#1262)" >&2
+    cat "$gcpedir/$gcpe_be.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcpedir/$gcpe_be.wasm" >/dev/null 2>&1
+  gcpe_rc=$?
+  if [ "$gcpe_rc" -ne 7 ]; then
+    echo "[compiler-gate] FAIL: gc_process_exit.vibe exited $gcpe_rc on the $gcpe_be backend (want 7; 0 = the exit lowering is a no-op and the program fell through) (#1262)" >&2
+    exit 1
+  fi
+done
+rm -rf "$gcpedir"
+echo "[compiler-gate] wasm-gc process exit ok (linear + gc, exit status 7)"
+
 # #1295: String is a packed fat pointer, so the gc EForIn lowering must
 # normalize it to character codes before its shared Array iteration loop.
 echo "[compiler-gate] wasm-gc String for-in"


### PR DESCRIPTION
gc 自己ビルドの停止点だった host import を足す。builtin の lowering は既に全部揃っていて、欠けていたのは **import そのもの**だったので codegen が未解決名に到達していた。flat compiler source がこれを踏むのは `cli_adapter.vibe` の `main` が最後にこれを呼ぶため。

レビューを受けて、**gate 側の errexit 罠**も同じ PR で潰した (下記)。

## 自己ビルドの現在地 (誇張しないための注記)

**「gc 自己ビルド成功」ではない。**

| | 結果 |
|---|---|
| flat compiler source を gc でコンパイル | **通る** (EXIT=0 / diag 空 / 3,055,993 B) |
| **その生成物を動かす** | **落ちる** — `memory access out of bounds` (heap_ptr=375460 / memory_size=458752) |

`EXIT=0` と空の diag だけを見て「成功」と報告しかけた。これは #1890 (`generations.sh` が古い出力を成功と誤認する) で自分が指摘したのと同じ罠で、**出力が存在することは動くことの証拠ではない**。生成されたコンパイラに実際にプログラムをコンパイルさせて初めて分かった。原因究明は本 PR の範囲外。

本 PR の主張は「**コンパイルが通るところまで来た**」であって、それ以上ではない。

## 1. vibe_process_exit_raw

4 箇所 (`use_host` / `host_defs` / `host_imports` / `hbo`) を揃えて更新し、import vec header も 20 → 21。**`hbo` を置き忘れると codegen では落ちず wasm validation が全滅する**。import 名 `process_exit` は linear (`linked_compile.vibe:7900`) と host runner (`wasm_vibe_host_runner.js:2380`) の双方に一致することを確認済み。分類表からは `host-import` 行を削除。

**終了ステータスで検査する** (`fixtures/gc_process_exit.vibe` + gate 40h-9)。引数を評価して素通りする lowering はプログラムを最後まで走らせて exit 0 にするが、**呼び出しが最後の出来事である以上、その下流に置いた値の表明では原理的に見えない**。終了コード 7 は他の失敗と衝突しない (trap は 134、未捕捉 throw は 1、素通りは 0)。

## 2. gate の errexit 罠 (Codex P1 起点)

`compiler_gate.sh` は `set -euo pipefail` の下で走るので、非 0 終了が「失敗」ではなく**データ**である箇所を裸で呼ぶと、その行でスクリプトが死に、直後の FAIL 分岐が到達不能になる。実在した 2 箇所:

- **40h-9 (本 PR で追加した節)**: 成功が非 0 (7) なので**完全に反転**していた。正しく動くと gate がサイレント死し、lowering が no-op に退行すると exit 0 で素通りする — **壊れているときだけ通るゲート**だった
- **節 103 (`vibe check @scope/pkg`)**: FAIL 分岐のコメントが「a diagnostic-free failure だけは避けたい」と書いているのに、その分岐自体が errexit で到達不能になっていた

`gate_status` / `gate_status_out` を冒頭に追加し、この 2 箇所をそれで書き直した。ヘッダに使い分けを明記 — ステータスを**読む**なら `gate_status`、非 0 が本当に「gate を止める」意味なら裸呼び出し、意図的に無視して後続の存在確認や内容比較で判定するなら `|| true` のまま。

**スコープは意図的に絞った。** 12,278 行・runner 呼び出し 571 回の一括整理はしていない (差分が巨大になり退行時の切り分けが不能になる)。`|| true` の 511 箇所も罠ではない (ステータスを捨てて後続で判定する設計) ので触っていない。571 呼び出しの「コンパイル → 存在確認 → 実行 → 値比較」反復のヘルパ化は余地があるが、別途段階的にやるべき範囲。

## 検証

- **`scripts/compiler_gate.sh` フルゲート完走 → GATE=0 / FAIL 0 件。** exit code だけでなく、対象節が実際に走ったことをログの自前出力行で確認:
  ```
  305: [compiler-gate] wasm-gc process exit ok (linear + gc, exit status 7)
  659: [compiler-gate] 103/104 vibe check resolves @scope/pkg imports, ...
  ```
  **305 行目が出ていること自体が errexit 修正の証拠** — 修正前はこの節が成功時にサイレント死してこの行に到達できなかった
- gc レーンの全節 green、arena の回収量も維持: `region arena ok (reclamation measured: Array 3208 B, Bytes 3208 B over 200 regions)`
- **ヘルパ単体** (`set -e` 下): 7 / 0 / 134 を正しく読め、出力保持も動作し、スクリプトが生存
- **40h-9 を節ごと切り出して両方向**: 正常系 exit 0 "ok" / 異常系 (exit 呼び出しを削除) exit 1 FAIL
- **節 103**: 失敗を注入して FAIL 分岐に到達し診断が出ることを確認
- `scripts/check_builtin_parity.sh` → ok (linear 245 / gc **161** / both 159 / 分類済み divergence 88)
- fmt: 変更ファイルすべて rc=0

`fixtures/gc_process_exit.vibe` は最初 `effect row mismatch for 'main': missing { Process }` で弾かれた。診断が `hint: declare 'fn main(...) -> T with Process'` と**何を書けば直るかを先頭に**出す形だったので一発で直せている。

## 経緯として残す価値があること

40h-9 の errexit 罠は、**この節を一度もフルゲートで走らせず「フルゲートは CI に任せる」と判断したまま PR を出した**ために自分では気づけなかった。個別実行と fault injection は両方通していたが、**どちらも `set -e` の下ではなかった** — 節を単体で正しく動かしただけでは原理的に見えない欠陥だった。今回はフルゲートを完走させてから検証欄を書いている。

## 関連

- #1890 (P0, 別件): `generations.sh` が失敗した compile を exit 0 で成功として報告する