### PR TITLE
perf(lexer): add fused SIMD line-end scanner

### DIFF
--- a/bench/bench_simd_line_end.vibe
+++ b/bench/bench_simd_line_end.vibe
@@ -1,0 +1,34 @@
+// #1902 Phase 1: isolate the fused LF scanner before lexer integration.
+// Both lanes scan the same 1 KiB ordinary prefix and stop at the final LF.
+
+fn make_long_comment() -> String {
+  let mut s = ""
+  let mut i = 0
+  while i < 64 {
+    s = s + "abcdefghijklmnop"
+    i = i + 1
+  }
+  s + "\n"
+}
+
+fn scalar_scan(s: String, len: Int) -> Int {
+  let mut i = 0
+  while i < len && String::char_code_at(s, i) != 10 {
+    i = i + 1
+  }
+  i
+}
+
+let source = make_long_comment()
+let source_len = String::length(source)
+let sink = [
+  0
+]
+
+bench "line_end_1kb_simd" {
+  Array::set(sink, 0, simd_scan_line_end_str(source, 0, source_len))
+}
+
+bench "line_end_1kb_scalar" {
+  Array::set(sink, 0, scalar_scan(source, source_len))
+}

--- a/docs/report/parser-simd-scan-2026-08-15.md
+++ b/docs/report/parser-simd-scan-2026-08-15.md
@@ -98,6 +98,18 @@ changing the short-input path. Line-comment scanning remains a separate
 experiment: its larger byte census does not justify coupling a second lexer
 change to the validated string slice.
 
+Issue #1902 starts that separate experiment with
+`simd_scan_line_end_str(String, Int, Int) -> Int`. Its linear and GC bodies
+share one generator and are pinned against a scalar LF oracle before any lexer
+integration. As with the string scanner, the primitive benchmark is evidence
+for headroom only; adopting it in `skip_until_newline` requires a new seed and
+representative comment-heavy A/B data.
+
+The isolated 1 KiB LF benchmark measured 42 ns p50 for the fused scanner and
+1,709 ns p50 for the scalar loop on the same local runner, with 0 B/op in both
+lanes. This roughly 41x primitive headroom is sufficient to proceed to the
+seed/integration phase; it is not yet a lexer-level result.
+
 Do not start with a full classify/compress token tape. `Token` is still a rich
 enum and identifiers/string tokens materialize substrings, so making every
 punctuation position into a bitmap would add a second representation before

--- a/fixtures/simd_scan_line_end_test.vibe
+++ b/fixtures/simd_scan_line_end_test.vibe
@@ -1,0 +1,37 @@
+// #1902: fused String-native SIMD scan for a line-comment terminator.
+// The builtin returns the LF byte offset, or len when the suffix has no LF.
+
+fn scalar_scan(s: String, pos: Int, len: Int) -> Int {
+  let mut i = pos
+  while i < len && String::char_code_at(s, i) != 10 {
+    i = i + 1
+  }
+  i
+}
+
+#zero_alloc
+fn line_end_scan(s: String, pos: Int, len: Int) -> Int {
+  simd_scan_line_end_str(s, pos, len)
+}
+
+fn same_as_scalar(s: String, pos: Int) -> Bool {
+  let len = String::length(s)
+  line_end_scan(s, pos, len) == scalar_scan(s, pos, len)
+}
+
+test "short tails and EOF match scalar scan" {
+  assert(same_as_scalar("short comment", 0))
+  assert(same_as_scalar("abc\nrest", 0))
+  assert(same_as_scalar("prefix\nrest", 3))
+}
+
+test "full SIMD chunks find LF boundaries" {
+  assert(same_as_scalar("abcdefghijklmnop\nrest", 0))
+  assert(same_as_scalar("abcdefghijklmnopqrstuvwxyzABCDE\nrest", 0))
+  assert(same_as_scalar("0123456789abcdef0123456789abcdefplain", 0))
+}
+
+test "UTF-8 byte offsets and non-zero starts match scalar scan" {
+  assert(same_as_scalar("日本語の長いコメントabcdefghijklmnop\nrest", 0))
+  assert(same_as_scalar("prefix: abcdefghijklmnopqrstuvwxyz\nrest", 8))
+}

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a2.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a2.vibe
@@ -1065,6 +1065,88 @@ export fn gen_simd_scan_string_special_body(enable_rc: Bool) -> Bytes {
   b
 }
 
+/// simd_scan_line_end_str(s: String, pos: Int, len: Int) -> Int
+/// Returns the smallest byte index in [pos, len) containing LF (0x0a), or len
+/// when no LF exists. Complete 16-byte chunks use v128; the first matching
+/// chunk and final partial chunk use the exact scalar oracle.
+///   locals: i32 { 3: addr } ; i64 { 4: p, 5: n, 6: byte }
+export fn gen_simd_scan_line_end_body(enable_rc: Bool) -> Bytes {
+  let b = bytebuf_new()
+  emit_local_get(b, 0)
+  emit_i64_const(b, 32)
+  emit_i64_shr_s(b)
+  emit_i32_wrap_i64(b)
+  emit_local_set(b, 3)
+  emit_local_get(b, 1)
+  if enable_rc {
+    emit_i64_const(b, 1)
+    emit_i64_shr_s(b)
+  }
+  emit_local_set(b, 4)
+  emit_local_get(b, 2)
+  if enable_rc {
+    emit_i64_const(b, 1)
+    emit_i64_shr_s(b)
+  }
+  emit_local_set(b, 5)
+  emit_block_void(b)
+  emit_loop_void(b)
+  emit_local_get(b, 4)
+  emit_i64_const(b, 16)
+  emit_i64_add(b)
+  emit_local_get(b, 5)
+  emit_i64_gt_s(b)
+  emit_br_if(b, 1)
+  emit_local_get(b, 3)
+  emit_local_get(b, 4)
+  emit_i32_wrap_i64(b)
+  emit_i32_add(b)
+  emit_v128_load(b, 0, 0)
+  emit_i64_const(b, 10)
+  emit_i32_wrap_i64(b)
+  emit_i8x16_splat(b)
+  emit_i8x16_eq(b)
+  emit_i8x16_bitmask(b)
+  emit_br_if(b, 1)
+  emit_local_get(b, 4)
+  emit_i64_const(b, 16)
+  emit_i64_add(b)
+  emit_local_set(b, 4)
+  emit_br(b, 0)
+  emit_end(b)
+  emit_end(b)
+  emit_block_void(b)
+  emit_loop_void(b)
+  emit_local_get(b, 4)
+  emit_local_get(b, 5)
+  emit_i64_ge_s(b)
+  emit_br_if(b, 1)
+  emit_local_get(b, 3)
+  emit_local_get(b, 4)
+  emit_i32_wrap_i64(b)
+  emit_i32_add(b)
+  emit_i32_load8_u(b, 0, 0)
+  emit_i64_extend_i32_u(b)
+  emit_local_set(b, 6)
+  emit_local_get(b, 6)
+  emit_i64_const(b, 10)
+  emit_i64_eq(b)
+  emit_br_if(b, 1)
+  emit_local_get(b, 4)
+  emit_i64_const(b, 1)
+  emit_i64_add(b)
+  emit_local_set(b, 4)
+  emit_br(b, 0)
+  emit_end(b)
+  emit_end(b)
+  emit_local_get(b, 4)
+  if enable_rc {
+    emit_i64_const(b, 1)
+    emit_i64_shl(b)
+  }
+  b
+}
+
 export fn gen_bytes_new_body() -> Bytes {
   let b = bytebuf_new()
   emit_global_get(b, 0)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/index.vpkg
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/index.vpkg
@@ -51,6 +51,7 @@ fn gen_bytes_len_body(enable_rc: Bool) -> Bytes
 fn gen_simd_skip_ws_body(enable_rc: Bool) -> Bytes
 fn gen_simd_scan_alnum_body(enable_rc: Bool, is_string: Bool) -> Bytes
 fn gen_simd_scan_string_special_body(enable_rc: Bool) -> Bytes
+fn gen_simd_scan_line_end_body(enable_rc: Bool) -> Bytes
 fn gen_bytes_get_body(enable_rc: Bool) -> Bytes
 fn gen_bytes_set_body(enable_rc: Bool) -> Bytes
 fn gen_bytes_push_body(enable_rc: Bool, arena_ptr_addr: Int, arena_data_base: Int, arena_limit: Int) -> Bytes

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -178,6 +178,7 @@ import @vibe/compiler/codegen/builtin_bodies {
   gen_region_arr_new_body,
   gen_region_bytes_new_body,
   gen_simd_scan_alnum_body,
+  gen_simd_scan_line_end_body,
   gen_simd_scan_string_special_body,
   gen_simd_skip_ws_body,
   gen_str_eq_body,
@@ -1462,9 +1463,9 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // (see the push site near the end of the builtin table). They go LAST so
   // every `hbo + N` ordinal above keeps its meaning in both shapes.
   let num_generated = if need_region_arena {
-    49
+    50
   } else {
-    47
+    48
   }
   // #538: host imports (module "vibe", tagged-i64 ABI -- the same raw ABI the
   // linear backend and the node host runner speak). Gated as a GROUP: pure
@@ -1488,8 +1489,8 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // ADR-0090 (#1262): generated body ordinals are ONE-BASED -- host imports
   // occupy indices 1..hbo, so the first pushed body sits at `hbo + 1` and the
   // last at `hbo + num_generated` (the body match table above ends with
-  // `"simd_scan_string_special_str" => 47`, which was the last body back when
-  // num_generated was 47). The two arena allocators are the last two pushes.
+  // `"simd_scan_line_end_str" => 48` when no arena is present). The two arena
+  // allocators are the last two pushes.
   //
   // Getting this off by one does not fail loudly at codegen: it produces a
   // module that fails wasm VALIDATION with "not enough arguments on the stack
@@ -1578,6 +1579,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
         "simd_scan_alnum" => 44,
         "simd_scan_alnum_str" => 45,
         "simd_scan_string_special_str" => 47,
+        "simd_scan_line_end_str" => 48,
         "Double::from_i64_bits" => 16,
         // #538 P4.5: identity wraps the trait-dict desugar emits around float
         // `==` operands (and int->float widening); all no-ops in the raw-bits
@@ -1936,9 +1938,10 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // ordinals. Array::length is body 7 and Array::slice is body 38.
   push_gc_builtin(gen_array_value_copy_body(hbo + 7, hbo + 38), 0, 0, 3)
   push_gc_builtin(gen_simd_scan_string_special_body(false), 1, 3, 8)
+  push_gc_builtin(gen_simd_scan_line_end_body(false), 1, 3, 8)
   // ADR-0090 (#1262) tier 2: the arena allocators, appended LAST and only
   // when the module has a region -- `num_generated` above counts them the
-  // same way, so ordinals 0..46 (every `hbo + N` reference above) are
+  // same way, so ordinals 0..48 (every `hbo + N` reference above) are
   // untouched either way. The generators are the linear lane's, unchanged:
   // they take the layout as parameters, so the two lanes cannot drift on the
   // segment's shape.

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -84,6 +84,7 @@ import @vibe/compiler/codegen/builtin_bodies {
   gen_region_arr_new_body,
   gen_region_bytes_new_body,
   gen_simd_scan_alnum_body,
+  gen_simd_scan_line_end_body,
   gen_simd_scan_string_special_body,
   gen_simd_skip_ws_body,
   gen_sources_proper_body,
@@ -5104,7 +5105,8 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   let simd_scan_alnum_idx = simd_skip_ws_idx + 1
   let simd_scan_alnum_str_idx = simd_scan_alnum_idx + 1
   let simd_scan_string_special_str_idx = simd_scan_alnum_str_idx + 1
-  let str_lex_diff_idx = simd_scan_string_special_str_idx + 1
+  let simd_scan_line_end_str_idx = simd_scan_string_special_str_idx + 1
+  let str_lex_diff_idx = simd_scan_line_end_str_idx + 1
   // #973: erased-generic `[T: Ord]`/`[T: Add]` runtime dispatch (see the doc
   // comment on gen_generic_rel_diff_body). Linear lane only -- desugar_trait_dicts
   // is only invoked from this file, so no gc-lane index is needed.
@@ -5598,6 +5600,7 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
         "simd_scan_alnum" => simd_scan_alnum_idx,
         "simd_scan_alnum_str" => simd_scan_alnum_str_idx,
         "simd_scan_string_special_str" => simd_scan_string_special_str_idx,
+        "simd_scan_line_end_str" => simd_scan_line_end_str_idx,
         // #746: backs String < > <= >= (desugar rewrites to str_lex_diff(a,b) <op> 0).
         "str_lex_diff" => str_lex_diff_idx,
         // #973: backs `<`/`>`/`<=`/`>=`/`+` on an erased `[T: Ord]`/`[T: Add]`
@@ -5896,6 +5899,7 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   push_builtin(gen_simd_scan_alnum_body(enable_rc, false), 1, 3, 8)
   push_builtin(gen_simd_scan_alnum_body(enable_rc, true), 1, 3, 8)
   push_builtin(gen_simd_scan_string_special_body(enable_rc), 1, 3, 8)
+  push_builtin(gen_simd_scan_line_end_body(enable_rc), 1, 3, 8)
   push_builtin(gen_str_lex_diff_body(enable_rc), 7, 0, 4)
   push_builtin(gen_generic_rel_diff_body(enable_rc, str_lex_diff_idx), 0, 0, 4)
   push_builtin(gen_generic_add_body(str_concat_idx), 0, 0, 4)
@@ -8500,6 +8504,7 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
   Array::set(gen_sec_names, simd_scan_alnum_idx - num_imported_funcs, "__rt_simd_scan_alnum")
   Array::set(gen_sec_names, simd_scan_alnum_str_idx - num_imported_funcs, "__rt_simd_scan_alnum_str")
   Array::set(gen_sec_names, simd_scan_string_special_str_idx - num_imported_funcs, "__rt_simd_scan_string_special_str")
+  Array::set(gen_sec_names, simd_scan_line_end_str_idx - num_imported_funcs, "__rt_simd_scan_line_end_str")
   Array::set(gen_sec_names, str_lex_diff_idx - num_imported_funcs, "__rt_str_lex_diff")
   Array::set(gen_sec_names, generic_rel_diff_idx - num_imported_funcs, "__rt_generic_rel_diff")
   Array::set(gen_sec_names, generic_add_idx - num_imported_funcs, "__rt_generic_add")

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -292,6 +292,7 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("simd_scan_alnum", CtFn(reg_p3(CtBytes, CtInt, CtInt), CtInt, None), true, true, true),
   ("simd_scan_alnum_str", CtFn(reg_p3(CtString, CtInt, CtInt), CtInt, None), true, true, true),
   ("simd_scan_string_special_str", CtFn(reg_p3(CtString, CtInt, CtInt), CtInt, None), true, true, true),
+  ("simd_scan_line_end_str", CtFn(reg_p3(CtString, CtInt, CtInt), CtInt, None), true, true, true),
   ("str_lex_diff", CtFn(reg_p2(CtString, CtString), CtInt, None), true, true, true),
   // #973: erased-generic `[T: Ord]`/`[T: Add]` runtime dispatch for `<` `>`
   // `<=` `>=` `+` (desugar_trait_dict.vibe rewrites the binop when the
@@ -689,7 +690,7 @@ fn builtin_is_non_allocating(name: String) -> Bool {
   // Comparison / logic primitives.
   name == "eq" || name == "not" || name == "str_lex_diff" || name == "__generic_rel_diff" ||
   // SIMD scanners that return an index.
-  name == "simd_skip_ws" || name == "simd_scan_alnum" || name == "simd_scan_alnum_str" || name == "simd_scan_string_special_str" ||
+  name == "simd_skip_ws" || name == "simd_scan_alnum" || name == "simd_scan_alnum_str" || name == "simd_scan_string_special_str" || name == "simd_scan_line_end_str" ||
   // Output and assertions: they consume, they do not produce.
   name == "print" || name == "println" || name == "print_int" || name == "print_str" || name == "assert" || name == "assert_true" || name == "assert_eq" ||
   // Runtime bookkeeping. `vibe_rc_alloc` is NOT here.

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4078,6 +4078,27 @@ fi
 rm -rf "$sssdir"
 echo "[compiler-gate] fused SIMD string-special scan ok"
 
+# 40b3. String-native fused LF scan (#1902 Phase 1). The scalar oracle pins
+# short tails, exact chunk boundaries, UTF-8 byte offsets, non-zero starts,
+# LF, and EOF before the lexer adopts the builtin.
+echo "[compiler-gate] 40b3/40 fused SIMD line-end scan"
+sledir="_build/_gate_simd_line_end"
+rm -rf "$sledir"; mkdir -p "$sledir"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "fixtures/simd_scan_line_end_test.vibe" "$sledir/sle.wasm" __no_entry__ >/dev/null 2>&1
+if [ ! -s "$sledir/sle.wasm" ]; then
+  echo "[compiler-gate] FAIL: SIMD line-end test did not compile" >&2
+  cat "$sledir/sle.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+    --invoke _start "$sledir/sle.wasm" >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: SIMD line-end test trapped" >&2; exit 1
+fi
+rm -rf "$sledir"
+echo "[compiler-gate] fused SIMD line-end scan ok"
+
 # 40c. Region capture (#629 step 2): a `let mut` captured by a closure inside a
 #      struct/record literal, projection, handler, loop, labeled arg, map literal
 #      or spread must still be heap-boxed (by-reference capture), not snapshotted.

--- a/scripts/coverage/cov_lookup2.vibe
+++ b/scripts/coverage/cov_lookup2.vibe
@@ -219,6 +219,7 @@ let lk_names4: () -> Array[String] = () -> {
   Array::push(a, "simd_scan_alnum")
   Array::push(a, "simd_scan_alnum_str")
   Array::push(a, "simd_scan_string_special_str")
+  Array::push(a, "simd_scan_line_end_str")
   Array::push(a, "simd_skip_ws")
   Array::push(a, "sleep")
   Array::push(a, "string_char_at")

--- a/scripts/test_gc_heap_accounting.sh
+++ b/scripts/test_gc_heap_accounting.sh
@@ -585,7 +585,7 @@ printf '%s\n' "$REPORT"
 #
 # ここに置くのは #125 の教訓 — CI に無い検証は腐る。登録を落とすと gc での
 # コンパイルが失敗し、このステップで落ちる。
-for SIMD_FIXTURE in simd_skip_ws_test simd_scan_string_special_test; do
+for SIMD_FIXTURE in simd_skip_ws_test simd_scan_string_special_test simd_scan_line_end_test; do
   SIMD_OUT="$ROOT_DIR/_build/_gc_gate_${SIMD_FIXTURE}.wasm"
   SIMD_OUT_REL="${SIMD_OUT#"$ROOT_DIR"/}"
   VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \


### PR DESCRIPTION
## Summary
- add a shared linear/GC String-native SIMD scanner for LF termination
- pin exact byte-offset behavior against a scalar oracle and both backends
- record the allocation-free primitive benchmark and register compiler/GC gates

## TDD
- Red: the committed compiler rejected simd_scan_line_end_str as unknown
- Green: linear and GC fixtures pass; 1 KiB primitive benchmark is 42 ns p50 vs 1,709 ns scalar, both 0 B/op

## Validation
- pkf run generation-gate
- linear + GC focused fixture
- pkf run test-local (256/256)
- pkf run test-pre-commit

Refs #1902