### PR TITLE
fix(show): 型付けできない内側の let が外側の束縛をマスクする (#1896 レビュー)

### DIFF
--- a/fixtures/show_array_from_call_test.vibe
+++ b/fixtures/show_array_from_call_test.vibe
@@ -236,3 +236,50 @@ test "a body this pass cannot type claims nothing" {
     Some(x)
   }, "[Some(1), Some(2)]")
 }
+
+test "an inner let that cannot be typed masks the outer binding" {
+  // Codex review on PR #1896. When a loop-body `let` shadows an outer binding
+  // and its value cannot be classified, keeping the outer entry visible let
+  // the tail resolve to the OUTER type:
+  //
+  //   let y = "outer"
+  //   for x in [1, 2] { let y = Some(x)  y }   ->  [276, 288]
+  //
+  // -- pointers laid out inside a structurally-rendered array, because the
+  // loop was given shape `[String]`. Strictly worse than the bare pointer the
+  // same body produces with no outer `y` in scope: it looks like real output.
+  //
+  // Asserting the VALUES does not catch this: they were always the right
+  // Options. Red-checked -- a value-only version of this test passes with the
+  // fix reverted. The defect is in the RENDERING, so the assertion has to be
+  // about the rendered string.
+  //
+  // A bare pointer is not a fixed string, so what is pinned is the invariant
+  // rather than the output: IF this renders as an array, its elements must be
+  // the Options that were built. That fails on `[276, 288]`, passes on the
+  // unclaimed pointer, and would also pass if a later change makes the pass
+  // able to type this body properly -- pinning "must not be an array" would
+  // instead fail on that improvement.
+  let y = "outer"
+  assert_true(String::length(y) == 5)
+  let shadowed = for x in [
+    1,
+    2
+  ] {
+    let y = Some(x)
+    y
+  }
+  let rendered = __to_string(shadowed)
+  assert_true(!String::starts_with(rendered, "[") || rendered == "[Some(1), Some(2)]")
+  // The elements are checked too, so a fix that got the rendering right by
+  // building a different array would not pass.
+  assert_true(Array::length(shadowed) == 2)
+  match Array::get(shadowed, 0) {
+    Some(v) => inspect(v, "1"),
+    None => assert_true(false)
+  }
+  match Array::get(shadowed, 1) {
+    Some(v) => inspect(v, "2"),
+    None => assert_true(false)
+  }
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2554,6 +2554,20 @@ fn dtd_elem_preserving_shape(fname: String, cargs: Array[Expr], struct_sets: Arr
 ///
 /// Scope is deliberately small: literals, a bound name, and arithmetic over
 /// them. Anything else is "" -- no claim.
+/// Shadow any outer binding of `name` with an explicit UNKNOWN.
+///
+/// `extend_var_types(.., None)` cannot do this -- it returns `var_types`
+/// unchanged, which is the behaviour being fixed. An empty-string entry is the
+/// masking convention this file already uses (`mask_stale_array_elem`), and it
+/// reads back as unknown here because `dtd_scalar_shape`'s `EIdent` arm returns
+/// the looked-up string as-is.
+fn dtd_mask_var_type(var_types: Array[(String, String)], name: String) -> Array[(String, String)] {
+  let out = array_empty()
+  push_all_var_types(out, var_types)
+  Array::push(out, (name, ""))
+  out
+}
+
 fn dtd_scalar_shape(e: Expr, var_types: Array[(String, String)]) -> String {
   match e {
     EInt(_) => "Int",
@@ -2592,7 +2606,26 @@ fn dtd_scalar_shape(e: Expr, var_types: Array[(String, String)]) -> String {
       let inner = if String::length(lty) > 0 {
         extend_var_types(var_types, lname, Some(lty))
       } else {
-        var_types
+        // A value this pass cannot classify must MASK any outer binding of the
+        // same name, not leave it visible. Passing `var_types` through was
+        // strictly worse than claiming nothing (Codex review on PR #1896):
+        //
+        //   let y = "outer"
+        //   for x in [1, 2] { let y = Some(x)
+        //     y }
+        //
+        // resolved the tail `y` to the OUTER String, so the loop got shape
+        // `[String]` and the renderer printed each `Some` as a string --
+        // `[276, 288]`, pointers laid out inside a structurally-rendered
+        // array. Without the outer binding the same body renders `192`, the
+        // old bare pointer. The stale answer is the more dangerous one: it
+        // looks like real output.
+        //
+        // Same hazard `mask_stale_array_elem` handles for the array sentinel,
+        // and the same reason `shape_bind` records even a non-composite: with
+        // `lookup_var_type` returning the LAST match, a shadowed entry stays
+        // the live answer unless something overwrites it.
+        dtd_mask_var_type(var_types, lname)
       }
       dtd_scalar_shape(rest, inner)
     },


### PR DESCRIPTION
PR #1896 の Codex レビュー (P1) への対応です。指摘は正しく、**実測すると指摘より悪い**挙動でした。

## 症状

`dtd_scalar_shape` の `ELet` は、値を型付けできたときだけ束縛を記録し、できなければ
`var_types` をそのまま渡していました。同名の**外側の束縛が見えたまま**になります:

```vibe
let y = "outer"
for x in [1, 2] { let y = Some(x)
  y }
```

```
before: [276, 288]      ← 構造化された配列の中にポインタ
after : 192             ← 主張しない (従来どおり)
```

外側の `y: String` から loop に `[String]` の shape が付き、レンダラが各 `Some` を
文字列として描画した結果です。同じ body でも**外側に `y` が無ければ** `192`
(ただのポインタ) になります。

**stale な方が危険です。** ポインタは見るからにおかしいのに対し、`[276, 288]` は
本物の出力に見えます。

## 修正

`extend_var_types(.., None)` ではこれを表現できません — `var_types` をそのまま
返す実装で、それが今回直している挙動そのものだからです。マスクは空文字列の
エントリで、これはこのファイルが既に使っている規約
(`mask_stale_array_elem`)。`EIdent` 分岐が引いた文字列をそのまま返すので、
unknown として読み戻されます。

`shape_bind` が非合成の束縛まで必ず記録しているのと同じ理由です:
`lookup_var_type` が**最後の一致**を返す以上、シャドウされたエントリは何かが
上書きするまで生きた答えのままになります。

## 回帰テストは2度書いています

1度目は**バグを捕まえませんでした**。値 (`Array::get(shadowed, 0)` が `Some(v)`)
を固定しましたが、要素は常に正しい Option で、壊れていたのは**レンダリング**
です。修正を戻しても通ることを Red チェックで確認して書き直しました。

ポインタは固定文字列にできないので、出力ではなく**不変条件**を固定しています —
*配列としてレンダリングされるなら、その要素は構築された Option でなければ
ならない*。

- `[276, 288]` では落ちる
- 主張しないポインタでは通る
- 将来この body を型付けできるようになっても通る

「配列であってはならない」を固定すると、最後の1つで**改善に対して落ちます**。

Red/Green は両方向で確認済み (マスクだけを戻すと `trap: RuntimeError:
unreachable`)。

## 検証

- `fixtures/show_array_from_call_test.vibe` 12 tests green
- 既存の parity fixture 3本 (array_hof / batch2 / batch3) も green
- `origin/main` (53cad6155) 上で stage2 を再ビルドして確認

Refs #1880

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEBpLwdSu7mBcvFaQw9ZFN)_