### PR TITLE
docs: document SIMD line-end scanner

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1403,6 +1403,7 @@ not part of this API.
 | `simd_scan_alnum(buf, pos, len) -> Int` | 識別子バイトの終端位置 |
 | `simd_scan_alnum_str(s, pos, len) -> Int` | 同上の `String` 版 |
 | `simd_scan_string_special_str(s, pos, len) -> Int` | quote / backslash / ASCII control byte の最初の位置 |
+| `simd_scan_line_end_str(s, pos, len) -> Int` | LF (`0x0a`) の最初のバイト位置。見つからなければ `len` |
 
 > SIMD は linear memory 上でのみ成立する。`v128.load` はメモリアドレスを取る
 > 命令で、wasm-gc の配列はアドレス可能なメモリではないため、`(array i8)` から


### PR DESCRIPTION
Follow-up for the review on #1903: add simd_scan_line_end_str to the canonical SIMD builtin table with its LF/EOF return contract.