### PR TITLE
perf(edp): stop statement-position for-in allocations in the handle-site collect walk (#1875 R4)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -5328,6 +5328,23 @@ fn edp_split_qualified(name: String) -> (Option[String], String) {
   }
 }
 
+fn edp_collect_handle_sites_exprs(es: Array[Expr], ename: String, out: Array[(Expr, Array[(Pat, Expr)])]) -> Unit {
+  let mut i = 0
+  while i < Array::length(es) {
+    edp_collect_handle_sites_expr(Array::get(es, i), ename, out)
+    i = i + 1
+  }
+}
+
+fn edp_collect_handle_sites_pairs(pairs: Array[(String, Expr)], ename: String, out: Array[(Expr, Array[(Pat, Expr)])]) -> Unit {
+  let mut i = 0
+  while i < Array::length(pairs) {
+    let (_, v) = Array::get(pairs, i)
+    edp_collect_handle_sites_expr(v, ename, out)
+    i = i + 1
+  }
+}
+
 fn edp_collect_handle_sites_expr(expr: Expr, ename: String, out: Array[(Expr, Array[(Pat, Expr)])]) -> Unit {
   match expr {
     EHandle(body, arms) => if edp_handle_matches_effect(arms, ename) {
@@ -5359,9 +5376,14 @@ fn edp_collect_handle_sites_expr(expr: Expr, ename: String, out: Array[(Expr, Ar
     },
     EMatch(s, arms) => {
       edp_collect_handle_sites_expr(s, ename, out)
-      for a in arms {
-        let (_, ex) = a
+      // #1875 R4: while-index instead of `for` in this walk (and below) --
+      // a statement-position `for` collects a discarded result array per
+      // execution, which a whole-program per-effect walk pays per node.
+      let mut mi = 0
+      while mi < Array::length(arms) {
+        let (_, ex) = Array::get(arms, mi)
         edp_collect_handle_sites_expr(ex, ename, out)
+        mi = mi + 1
       }
     },
     EWhile(c, b) => {
@@ -5374,8 +5396,10 @@ fn edp_collect_handle_sites_expr(expr: Expr, ename: String, out: Array[(Expr, Ar
     },
     ECall(callee, args, _) => {
       edp_collect_handle_sites_expr(callee, ename, out)
-      for a in args {
-        edp_collect_handle_sites_expr(a, ename, out)
+      let mut ai = 0
+      while ai < Array::length(args) {
+        edp_collect_handle_sites_expr(Array::get(args, ai), ename, out)
+        ai = ai + 1
       }
     },
     EBinOp(_, l, r) => {
@@ -5398,29 +5422,14 @@ fn edp_collect_handle_sites_expr(expr: Expr, ename: String, out: Array[(Expr, Ar
       Some(e2) => edp_collect_handle_sites_expr(e2, ename, out),
       None => ()
     },
-    EContinue(args) => for a in args {
-      edp_collect_handle_sites_expr(a, ename, out)
-    },
-    ETuple(elems) => for a in elems {
-      edp_collect_handle_sites_expr(a, ename, out)
-    },
-    EArray(elems) => for a in elems {
-      edp_collect_handle_sites_expr(a, ename, out)
-    },
-    ERecord(_, fields, _) => for f in fields {
-      let (_, v) = f
-      edp_collect_handle_sites_expr(v, ename, out)
-    },
-    EMap(fields) => for f in fields {
-      let (_, v) = f
-      edp_collect_handle_sites_expr(v, ename, out)
-    },
+    EContinue(args) => edp_collect_handle_sites_exprs(args, ename, out),
+    ETuple(elems) => edp_collect_handle_sites_exprs(elems, ename, out),
+    EArray(elems) => edp_collect_handle_sites_exprs(elems, ename, out),
+    ERecord(_, fields, _) => edp_collect_handle_sites_pairs(fields, ename, out),
+    EMap(fields) => edp_collect_handle_sites_pairs(fields, ename, out),
     ESpread(e2) => edp_collect_handle_sites_expr(e2, ename, out),
     ELoop(pairs, b) => {
-      for p in pairs {
-        let (_, v) = p
-        edp_collect_handle_sites_expr(v, ename, out)
-      }
+      edp_collect_handle_sites_pairs(pairs, ename, out)
       edp_collect_handle_sites_expr(b, ename, out)
     },
     _ => ()


### PR DESCRIPTION
## Summary

#1875 round 4: the per-used-effect heap cost drops from **+5.76MB to +1.44MB (4.0×)** on the codegen_lexer_test KPI compile.

The per-effect handle-site collector (`edp_collect_handle_sites_expr`) used statement-position `for` loops over child expression lists. In the residual builtin lowering a statement-position `for` is still a comprehension: it materializes a result array per execution, and the discarded array is never reclaimed, so this whole-program walk paid ~2.1MB of permanent bump-heap growth per used effect per collection (it runs twice for a planned effect: pre- and post-eta-wrap). Rewritten to while-index loops, the same shape the walk's older arms already use.

## Measurements (stage2, warm, deterministic across runs)

Probe = one used effect (declaration + performing fn + handle) added to the core contract, same unit as R1–R3:

| | pre-fix (main 53cad61) | R4 |
|---|---:|---:|
| used-effect delta | +5,755,568 | **+1,444,568** |
| collect-walk region (heap marks) | ~2.1MB | **376 bytes** |

Per-region attribution after the fix (temporary label-pun heap marks, removed before commit): filters 171KB, first collect 376B, eta-wrap 88B, second collect 376B, needing-escape 40B, plan/eligibility 275KB; the rest of the +1.44MB sits in the apply/migration phase. R3's report attributed ~2.1MB to `edp_needing_escape_stmts` — that was a mark-placement error; it allocates 40 bytes.

## Verification

- `stage2 == stage3` fixpoint on the rebuilt generations.
- Pure-optimization proof: old (main) stage2 and fixed stage2 compile `codegen_lexer_test.vibe` to **byte-identical** output wasm.
- `vibe fmt --check` clean; typecheck clean.
- Operation gate: running locally at PR time (a container restart killed the first run); will confirm on this thread alongside CI.

## Investigation by-products (filed separately)

The allocation model behind this fix was pinned down with micro-fixtures and is worth structural fixes beyond hand-rewriting walks:

- **#1916** — statement-position `for` collects a result array nobody reads, and the discarded array leaks under RC (131KB per execution over a 10k-element array; 0 for the `while` twin). Fixing the lowering would make this class of hand-rewrite unnecessary.
- **#1915** — a function that tail-returns a local binding by name (`let out = []; …; out`, the standard builder shape) is classified borrow-returning by the #707 fallback, so **callers never drop its result** — every builder-style return leaks, used or not (same construction inlined: fully reclaimed). Likely a large share of the ~578MB self-compile heap high-water; proposed as R5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ