### PR TITLE
feat(async): vibe serve が request body を stream で handler に渡す (#1540 scope 3/4)

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -99,6 +99,35 @@ returning `"STATUS\n<Header: value lines>\n\n<body>"`. Internally the handler
 may use algebraic effects (`perform` / `handle`, e.g. `lib/@vibe/wasi/p3/`), as
 long as they are discharged inside the file.
 
+The last parameter may instead be a `HostStream` — the request body as it
+arrives, rather than collected into a `String` first (#1540):
+
+```vibe skip
+export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {
+  let mut out = ""
+  let mut go = true
+  while go {
+    let b = host_stream_next(body)
+    if b < 0 { go = false } else { out = String::concat(out, String::from_char_code(b)) }
+  }
+  "200\n\n\{out}"
+}
+```
+
+`host_stream_next` suspends, so this form carries `with Async` — and the two
+go together in both directions: `with Async` without a `HostStream` body has
+nothing to await, and a `HostStream` body without `Async` could never be read.
+`vibe serve` rejects either half on its own with that reason.
+
+The stream form needs the **stream-body adapter**, whose `handler` import takes
+`body: stream<u8>`; the launcher picks it by reading the WIT sidecar, so the
+only manual step is building it:
+
+```
+VIBE_HTTP_ADAPTER_BODY_STREAM=1 scripts/build_wasi_http_p3_full_adapter.sh \
+  _build/http_adapter/vibe_http_p3_body_stream_adapter.component.wasm
+```
+
 - Artifact generation lives in the compiler (`VIBE_SERVE_COMPONENT=1`); adapter
   resolution, composition, and serving live in the launcher — the compiled
   `<handler>.component.wasm` + `<handler>.wit` are reusable on their own.
@@ -106,7 +135,9 @@ long as they are discharged inside the file.
   `wasmtime` (v45+). The P3 adapter component is built once by
   `scripts/build_wasi_http_p3_full_adapter.sh` (cargo + wasm-tools) or passed
   via `--adapter` / `VIBE_HTTP_ADAPTER`.
-- E2E gate: `scripts/test_wasi_http_p3_full_gate.sh`.
+- E2E gates: `scripts/test_wasi_http_p3_full_gate.sh` (String body),
+  `scripts/test_serve_async_lift_gate.sh` (async lift, same String contract),
+  `scripts/test_serve_body_stream_gate.sh` (`HostStream` body, byte-exact echo).
 
 ### precompile
 

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1565,7 +1565,7 @@ export let handler = (method: String, url: String, headers: String, body: HostSt
   whose import is `handler(.., body: stream<u8>)`. There is no
   `.collect().await` anywhere in it; the reader goes straight through.
 
-> **Known gap (#1913): reads in this lane must complete EAGERLY today.** Every
+> **Known gap (#1924): reads in this lane must complete EAGERLY today.** Every
 > body the gate serves arrives buffered, so each `stream.read` returns a byte
 > without blocking. Two shapes trap in the guest with `uninitialized element`
 > inside the injected `__hs_next` — a chunked upload slow enough that a read

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1516,6 +1516,59 @@ gate lane = `test_named_hoststreams_component_gate.sh` の close lane
 かつ drain-only component に close import が無いこと + closing component に
 guest import と adapter export が両方あることを .wat で確認）。
 
+#### 3.18.4 `HostStream` を**パラメータ**で受ける — serve lane の request body（done, #1540）
+
+§3.18 の `HostStream` は `host_stream_named("body")` で **名前**から取っていた。
+`vibe serve` の handler はそれでは足りない: body は component の呼び出し
+引数として渡ってくるもので、名前で取りに行くものではない。#1540 scope 3/4 で
+`HostStream` は**関数パラメータとして**受け取れるようになった。
+
+```vibe skip
+export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {
+  let mut out = ""
+  let mut go = true
+  while go {
+    let b = host_stream_next(body)
+    if b < 0 { go = false } else { out = String::concat(out, String::from_char_code(b)) }
+  }
+  "200\n\n\{out}"
+}
+```
+
+- **boundary**: `lc_wrap_host_stream_params` が handler の入口で `HostStream`
+  型注釈の付いたパラメータを 2 語セル `[3, handle]` に包み直す。以降は §3.18 と
+  同一の read 経路（`__hs_next` → stream 帯 `handle + 2048` の Suspend →
+  `__entry_settle` → `vibe_hs_read_raw`）。名前つき getter は生えないので、
+  compile された core は `vibe.host_stream_read` **だけ**を import する
+- **trampoline**: canonical ABI は `stream<u8>` を strings の (ptr, len) 対の
+  後ろに i32 handle 1 本として flatten し、async lift なので core func は
+  何も返さない（結果は `task.return`）
+- **adapter**: `comp_generate_serve_stream_adapter_module` — §3.18 の read
+  ループと同じ実測（BLOCKED / STREAM_READ = 2 / unjoin してから set drop /
+  終端2形状 + closed latch）を、**名前を1つも持たずに**実装したもの。
+  `comp_generate_hostfuture_adapter_core_module` を流用しないのは、あちらの
+  index 配置が named future/stream 数から導出されていて「名前ゼロ、それでも
+  reader」を足すと他 4 lane の index が全部動くから。ダミー名を与えるのは
+  #1796 が composition cycle として退けた `[async-lower]<label>` component
+  import を戻すことになる
+- **CLI**: `serve_handler_takes_body_stream` が lane を選ぶ。`with Async` と
+  `body: HostStream` は**両方向に必須** — 片方だけはどちらも診断で落ちる
+  （Async 単独は await するものが無い、HostStream 単独は read が suspend
+  なので永久に読めない）
+- **adapter (Rust)**: `VIBE_HTTP_ADAPTER_BODY_STREAM=1` で
+  `handler(.., body: stream<u8>)` を import する版が出る。`.collect().await`
+  はどこにも無く、reader がそのまま渡る
+
+> **落とし穴（実測 2026-08-16）: `vibe.*` の Int ABI は「常に tagged」ではない。**
+> §3.13/§3.18 が「i64 値は guest-tagged on the wire（adapter が shift する）」と
+> 書いているのは、あの lane の core が **CLI の RC compile**（`enable_rc` on、
+> `linked_compile` の tag_mode 1 = `value << 1`）で出ているから。`vibe serve` の
+> core は `compile_wasi_module_no_dce_impl`（`enable_rc` **off**）なので、
+> Int は素の i64 である。**同じ `vibe.host_stream_read` という import 名に、
+> compile mode 由来の2つの値表現がある。** 混同しても trap しない — 読んだ
+> byte が黙って 2 倍になるだけで、`sum=588` が `294` の代わりに返る（これが
+> 実際に起きた形）。serve lane の trampoline と adapter は両方 untagged。
+
 ### 3.18.3 #1539 — `wasi:cli/stdin@0.3.0` lifecycle measurement and shadow provider prerequisite
 
 `tools/wasip3_component_probe/stdin_read_via_stream/component.wat` retains the

--- a/docs/spec/wasi-p3-async.md
+++ b/docs/spec/wasi-p3-async.md
@@ -1516,12 +1516,12 @@ gate lane = `test_named_hoststreams_component_gate.sh` の close lane
 かつ drain-only component に close import が無いこと + closing component に
 guest import と adapter export が両方あることを .wat で確認）。
 
-#### 3.18.4 `HostStream` を**パラメータ**で受ける — serve lane の request body（done, #1540）
+#### 3.18.4 `HostStream` as a PARAMETER — the serve lane's request body (done, #1540)
 
-§3.18 の `HostStream` は `host_stream_named("body")` で **名前**から取っていた。
-`vibe serve` の handler はそれでは足りない: body は component の呼び出し
-引数として渡ってくるもので、名前で取りに行くものではない。#1540 scope 3/4 で
-`HostStream` は**関数パラメータとして**受け取れるようになった。
+§3.18's `HostStream` came from a NAME: `host_stream_named("body")`. That is not
+enough for a `vibe serve` handler, where the body is an argument of the call,
+not something to go and fetch. Since #1540 scope 3/4 a `HostStream` can be a
+function PARAMETER.
 
 ```vibe skip
 export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {
@@ -1535,39 +1535,56 @@ export let handler = (method: String, url: String, headers: String, body: HostSt
 }
 ```
 
-- **boundary**: `lc_wrap_host_stream_params` が handler の入口で `HostStream`
-  型注釈の付いたパラメータを 2 語セル `[3, handle]` に包み直す。以降は §3.18 と
-  同一の read 経路（`__hs_next` → stream 帯 `handle + 2048` の Suspend →
-  `__entry_settle` → `vibe_hs_read_raw`）。名前つき getter は生えないので、
-  compile された core は `vibe.host_stream_read` **だけ**を import する
-- **trampoline**: canonical ABI は `stream<u8>` を strings の (ptr, len) 対の
-  後ろに i32 handle 1 本として flatten し、async lift なので core func は
-  何も返さない（結果は `task.return`）
-- **adapter**: `comp_generate_serve_stream_adapter_module` — §3.18 の read
-  ループと同じ実測（BLOCKED / STREAM_READ = 2 / unjoin してから set drop /
-  終端2形状 + closed latch）を、**名前を1つも持たずに**実装したもの。
-  `comp_generate_hostfuture_adapter_core_module` を流用しないのは、あちらの
-  index 配置が named future/stream 数から導出されていて「名前ゼロ、それでも
-  reader」を足すと他 4 lane の index が全部動くから。ダミー名を与えるのは
-  #1796 が composition cycle として退けた `[async-lower]<label>` component
-  import を戻すことになる
-- **CLI**: `serve_handler_takes_body_stream` が lane を選ぶ。`with Async` と
-  `body: HostStream` は**両方向に必須** — 片方だけはどちらも診断で落ちる
-  （Async 単独は await するものが無い、HostStream 単独は read が suspend
-  なので永久に読めない）
-- **adapter (Rust)**: `VIBE_HTTP_ADAPTER_BODY_STREAM=1` で
-  `handler(.., body: stream<u8>)` を import する版が出る。`.collect().await`
-  はどこにも無く、reader がそのまま渡る
+- **boundary**: `lc_wrap_host_stream_params` rewraps every parameter annotated
+  `HostStream` into the two-word cell `[3, handle]` on entry to the handler.
+  From there the read path is §3.18's, unchanged: `__hs_next` → a Suspend in
+  the stream band (`handle + 2048`) → `__entry_settle` → `vibe_hs_read_raw`.
+  No named getter is injected, so the compiled core imports
+  `vibe.host_stream_read` and nothing else — plus `vibe.host_stream_close` if
+  the handler stops reading early (§3.18.1).
+- **trampoline**: the canonical ABI flattens `stream<u8>` to one i32 handle
+  after the strings' (ptr, len) pairs, and the lift is async, so the core
+  function returns nothing — the result leaves through `task.return`.
+- **adapter**: `comp_generate_serve_stream_adapter_module` — §3.18's measured
+  read loop (BLOCKED / STREAM_READ = 2 / unjoin before dropping the set / the
+  two terminal shapes and the CLOSED latch), implemented with NO names at all.
+  It is deliberately not `comp_generate_hostfuture_adapter_core_module`: that
+  module's whole index layout is derived from the named future/stream counts,
+  so teaching it "no names, still a reader" moves every index four other lanes
+  depend on, and supplying a dummy name would reintroduce the
+  `[async-lower]<label>` component import #1796 ruled out as a composition
+  cycle. Every band is indexed by handle — a serve instance carries many
+  request tasks at once, and `stream.read` registers its landing address with
+  the canon BEFORE blocking, so a shared slot would let two producers write to
+  one address.
+- **CLI**: `serve_handler_takes_body_stream` picks the lane. `with Async` and
+  `body: HostStream` REQUIRE EACH OTHER — either alone is a diagnostic naming
+  the other, because Async alone has nothing to await and a HostStream alone
+  can never be read (reading suspends).
+- **adapter (Rust)**: `VIBE_HTTP_ADAPTER_BODY_STREAM=1` builds the variant
+  whose import is `handler(.., body: stream<u8>)`. There is no
+  `.collect().await` anywhere in it; the reader goes straight through.
 
-> **落とし穴（実測 2026-08-16）: `vibe.*` の Int ABI は「常に tagged」ではない。**
-> §3.13/§3.18 が「i64 値は guest-tagged on the wire（adapter が shift する）」と
-> 書いているのは、あの lane の core が **CLI の RC compile**（`enable_rc` on、
-> `linked_compile` の tag_mode 1 = `value << 1`）で出ているから。`vibe serve` の
-> core は `compile_wasi_module_no_dce_impl`（`enable_rc` **off**）なので、
-> Int は素の i64 である。**同じ `vibe.host_stream_read` という import 名に、
-> compile mode 由来の2つの値表現がある。** 混同しても trap しない — 読んだ
-> byte が黙って 2 倍になるだけで、`sum=588` が `294` の代わりに返る（これが
-> 実際に起きた形）。serve lane の trampoline と adapter は両方 untagged。
+> **Known gap (#1913): reads in this lane must complete EAGERLY today.** Every
+> body the gate serves arrives buffered, so each `stream.read` returns a byte
+> without blocking. Two shapes trap in the guest with `uninitialized element`
+> inside the injected `__hs_next` — a chunked upload slow enough that a read
+> actually parks, and a handler that stops reading before end of stream. Both
+> are main's CPS lowering, not the adapter (which has no tables at all), and
+> both reproduce against the emitter as first committed. The named-host-stream
+> lane's delayed path parks correctly under the same compiler, so this is
+> specific to the serve lane rather than to parking in general.
+
+> **Pitfall (measured 2026-08-16): the `vibe.*` Int ABI is NOT "always tagged".**
+> §3.13/§3.18 say "i64 values are guest-tagged on the wire (the adapter
+> shifts)". That holds for THAT lane, whose core comes from the CLI's **RC
+> compile** (`enable_rc` on, `linked_compile`'s tag_mode 1 = `value << 1`).
+> `vibe serve`'s core comes from `compile_wasi_module_no_dce_impl`, which
+> passes `enable_rc` **off**, so an Int there is a plain i64. **One import
+> name, `vibe.host_stream_read`, with two value representations decided by the
+> compile mode.** Mixing them does not trap: every byte the handler reads is
+> silently doubled, which is how "abc" came back as `sum=588` instead of 294.
+> The serve lane's trampoline and adapter are both untagged.
 
 ### 3.18.3 #1539 — `wasi:cli/stdin@0.3.0` lifecycle measurement and shadow provider prerequisite
 

--- a/lib/@vibe/cli/dispatch.vibe
+++ b/lib/@vibe/cli/dispatch.vibe
@@ -4,12 +4,13 @@ import ../compiler {
   check_linked_file, compile_release_file_mode, compile_release_file_mode_profiled,
   compile_release_file_mode_uncached, compile_release_file_mode_uncached_profiled,
   write_linked_debug_build, strip_executable_wasm_env,
-  serve_handler_param_names, validate_serve_handler, wit_from_program,
+  serve_handler_param_names, serve_handler_takes_body_stream, validate_serve_handler,
+  wit_from_program,
   lex, parse_program
 }
 
 import ../compiler/entry/source_compile/wasi_only {
-  comp_emit_component_wasm_string_handler
+  comp_emit_component_wasm_stream_handler, comp_emit_component_wasm_string_handler
 }
 
 //# Effects
@@ -671,7 +672,17 @@ export fn selfhost_cli_serve_args(args: Array[String]) -> Int with Exception + F
     // export alive. `__no_entry__` is the explicit sentinel — any other unknown
     // entry name is a compile error since ADR-0069.
     let core = compile_release_file_mode(input_path, "__no_entry__", "release")
-    let component = comp_emit_component_wasm_string_handler(core, "handler", "handler", serve_handler_param_names())
+    // #1540 scope 4: two lanes, chosen by the handler's own signature. A
+    // `body: HostStream` handler is async-lifted and takes the body as a
+    // component `stream<u8>`, so it sees the first byte before the last one
+    // has arrived; a String handler keeps the sync lift and the collected
+    // body. `validate_serve_handler` above has already rejected every other
+    // shape, so this is a two-way choice, not a guess.
+    let component = if serve_handler_takes_body_stream(entry_stmts) {
+      comp_emit_component_wasm_stream_handler(core, "handler", "handler", serve_handler_param_names())
+    } else {
+      comp_emit_component_wasm_string_handler(core, "handler", "handler", serve_handler_param_names())
+    }
     Fs::write_bytes(output_path, component)
     Fs::write_file(wit_output_path, wit_from_program(entry_stmts, entry_stmts, basename_without_vibe_suffix(input_path)))
     0

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -4,6 +4,7 @@
 // these used to be two separate leaf imports (preprocess.vibe,
 // merge_sources.vibe), now merged into one.
 import @vibe/compiler/entry/source_compile/wasi_only {
+  comp_emit_component_wasm_stream_handler,
   comp_emit_component_wasm_string_handler,
   compile_source_wasi_only,
   compile_source_wasi_only_coverage,
@@ -86,7 +87,7 @@ import ./inspect_update.vibe {
 }
 
 import ./wit_gen.vibe {
-  serve_handler_param_names, validate_serve_handler, wit_from_program
+  serve_handler_param_names, serve_handler_takes_body_stream, validate_serve_handler, wit_from_program
 }
 
 import @vibe/compiler/syntax {
@@ -579,7 +580,15 @@ fn adapter_serve_component(input_path: String, output_path: String) -> Int with 
     // is the explicit sentinel — any other unknown entry name is a compile
     // error since ADR-0069.
     let core = compile_file_fs_mode(input_path, "__no_entry__", "no-dce")
-    let component = comp_emit_component_wasm_string_handler(core, "handler", "handler", serve_handler_param_names())
+    // #1540 scope 4: a `body: HostStream` handler goes down the stream lane
+    // (async lift + a component `stream<u8>` param) so it can read the body
+    // as it arrives; everything else keeps the sync lift and the collected
+    // String. validate_serve_handler has already rejected every other shape.
+    let component = if serve_handler_takes_body_stream(entry_stmts) {
+      comp_emit_component_wasm_stream_handler(core, "handler", "handler", serve_handler_param_names())
+    } else {
+      comp_emit_component_wasm_string_handler(core, "handler", "handler", serve_handler_param_names())
+    }
     Fs::write_bytes(output_path, component)
     let wit_out = Env::get("VIBE_SERVE_WIT_OUT")
     if wit_out != "" {

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -7159,11 +7159,18 @@ fn comp_generate_string_trampoline_packed_async_opt(string_param_count: Int, exp
     si = si + 1
   }
   if stream_param {
-    // The stream handle, tagged: extend_u then << 1.
+    // The stream handle as a PLAIN i64 -- zero-extended, NOT tagged.
+    //
+    // `vibe.*` Int imports are usually described as "guest-tagged on the
+    // wire", and that is true of the lane those words were written for: the
+    // named-host-stream adapter talks to a core the CLI compiled with RC on,
+    // where an Int is `value << 1` (linked_compile's tag_mode). THIS lane's
+    // core is compiled by `compile_release_file_mode(.., "release")` ->
+    // `compile_wasi_module_no_dce_impl`, which passes enable_rc = false, so
+    // an Int here is a plain i64. Tagging the handle would hand the guest
+    // twice the handle it must hand back.
     emit_local_get(canon_body, string_param_count * 2)
     bytebuf_push(canon_body, 173)
-    emit_i64_const(canon_body, 1)
-    bytebuf_push(canon_body, 134)
   } else {
     ()
   }
@@ -7552,6 +7559,425 @@ fn comp_generate_host_stub_module(vibe_names: Array[String], vibe_sigs: Array[Ar
   }
   emit_code_section(out, bodies)
   bytebuf_to_bytes(out)
+}
+
+/// #1540 scope 4: scratch layout for the serve lane's host-stream adapter.
+///
+/// These are addresses in a memhost page the adapter OWNS, not in the main
+/// module's memory. That is the whole reason the memhost exists here: the
+/// canons need a memory for the read landing slot and the wait payload, and
+/// the only other memory in this component is the vibe heap. Writing fixed
+/// addresses into that would corrupt whatever the program had there.
+let comp_ss_scratch = 0
+
+let comp_ss_payload = 16
+
+/// One word per handle, indexed by handle * 4. The adapter caps handles at
+/// comp_hf_max_handles() (1023), so this band ends below 4160 -- inside the
+/// single page and clear of the two slots above.
+let comp_ss_closed_base = 64
+
+/// #1540 scope 4: `vibe.host_stream_read` for the serve lane.
+///
+/// The compiled handler imports `vibe.host_stream_read (i64) -> (i64)` and
+/// nothing else (#1871 scope 3) -- the stream arrives as a parameter, so there
+/// is no named getter. This module is what satisfies it.
+///
+/// Deliberately NOT `comp_generate_hostfuture_adapter_core_module`, which
+/// implements the same function: that one emits it only when there is at least
+/// one NAMED stream, and its entire index layout is derived from the named
+/// future/stream counts. Teaching it "no names, still a reader" moves every
+/// index in a module four other lanes depend on, and supplying a dummy name
+/// would reintroduce the `[async-lower]<label>` component import that #1796
+/// ruled out as a composition cycle.
+///
+/// The loop is the measured one (tools/wasip3_component_probe/host_stream_value
+/// and http_body_read): BLOCKED is 0xffffffff, a completion packs
+/// `(amount << 4) | code`, the read wake event is 2, the wait payload's SECOND
+/// word is the status, and the end of the stream arrives EITHER as a
+/// zero-transfer code 1 OR riding along with the final byte. That second shape
+/// is why there is a latch: reading again after an inline close traps, so the
+/// close is recorded and settled on the NEXT call.
+///
+/// Values cross as PLAIN i64 -- no tag shift on either side, unlike the named
+/// adapter's half. Both are right for their own lane: an Int's representation
+/// is `enable_rc`'s (linked_compile's tag_mode), the named lane's core comes
+/// from the CLI's RC compile (`value << 1`), and this lane's comes from
+/// `compile_wasi_module_no_dce_impl` with enable_rc = false (plain i64).
+/// Mixing them is the whole failure mode this convention exists to avoid: it
+/// does not trap, it silently doubles every byte the handler reads.
+///
+/// So: the handle arrives untagged from the trampoline, the byte goes back
+/// untagged, and end of stream is a plain `-1` -- the value the injected
+/// `__hs_fin` latches on.
+fn comp_generate_serve_stream_adapter_module() -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  // types: 0 = stream.read (h, ptr, n) -> status; 1 = (h) -> () for
+  // drop-readable and waitable-set.drop; 2 = () -> set; 3 = (a, b) -> () for
+  // waitable.join; 4 = (set, ptr) -> event; 5 = host_stream_read (i64) -> i64.
+  let tc = bytebuf_new()
+  bytebuf_push_vec_header(tc, 6)
+  emit_func_type_raw(tc, comp_repeat_valtype(127, 3), [
+    127
+  ])
+  emit_func_type_raw(tc, comp_repeat_valtype(127, 1), array_empty())
+  emit_func_type_raw(tc, array_empty(), [
+    127
+  ])
+  emit_func_type_raw(tc, comp_repeat_valtype(127, 2), array_empty())
+  emit_func_type_raw(tc, comp_repeat_valtype(127, 2), [
+    127
+  ])
+  emit_func_type_raw(tc, [
+    126
+  ], [
+    126
+  ])
+  bytebuf_push_section(out, 1, tc)
+  let ic = bytebuf_new()
+  bytebuf_push_vec_header(ic, 7)
+  emit_name(ic, "$root")
+  emit_name(ic, "[async-lower][stream-read-0]body")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 0)
+  emit_name(ic, "$root")
+  emit_name(ic, "[stream-drop-readable-0]body")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 1)
+  emit_name(ic, "$root")
+  emit_name(ic, "[waitable-set-new]")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 2)
+  emit_name(ic, "$root")
+  emit_name(ic, "[waitable-join]")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 3)
+  emit_name(ic, "$root")
+  emit_name(ic, "[waitable-set-wait]")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 4)
+  emit_name(ic, "$root")
+  emit_name(ic, "[waitable-set-drop]")
+  bytebuf_push(ic, 0)
+  bytebuf_push(ic, 1)
+  emit_name(ic, "env")
+  emit_name(ic, "memory")
+  bytebuf_push(ic, 2)
+  bytebuf_push(ic, 0)
+  leb128_encode_u32(ic, 1)
+  bytebuf_push_section(out, 2, ic)
+  emit_function_section(out, [
+    5
+  ])
+  emit_export_section(out, "host_stream_read", 6)
+  // param 0 = the handle (i64, untagged); locals (i32) 1 = handle, 2 = status,
+  // 3 = waitable set, 4 = event, 5 = the latch address.
+  let b = bytebuf_new()
+  emit_local_get(b, 0)
+  emit_i32_wrap_i64(b)
+  emit_local_set(b, 1)
+  // Same cap the named adapter enforces, for the same reason: the latch band
+  // is `handle * 4 + comp_ss_closed_base` in a ONE-page memory, so an
+  // unbounded handle would silently walk past the page instead of saying so.
+  // Trapping here names the limit; growing past it is a change to the band,
+  // not something to discover as an out-of-bounds store.
+  emit_local_get(b, 1)
+  emit_i32_const(b, comp_hf_max_handles())
+  emit_i32_gt_u(b)
+  emit_if_void(b)
+  bytebuf_push(b, 0)
+  emit_end(b)
+  emit_local_get(b, 1)
+  emit_i32_const(b, 2)
+  emit_i32_shl(b)
+  emit_i32_const(b, comp_ss_closed_base)
+  emit_i32_add(b)
+  emit_local_set(b, 5)
+  // A latch set by a previous inline close: this call is the settle it was
+  // waiting for. Drop the readable end now and report the end of the stream.
+  emit_local_get(b, 5)
+  emit_i32_load(b, 2, 0)
+  emit_if_void(b)
+  emit_local_get(b, 5)
+  emit_i32_const(b, 0)
+  emit_i32_store(b, 2, 0)
+  emit_local_get(b, 1)
+  emit_call(b, 1)
+  emit_i64_const(b, 0 - 1)
+  emit_return(b)
+  emit_end(b)
+  // One byte per call: the shape ByteStream::next needs, and the worst case
+  // for status handling.
+  emit_local_get(b, 1)
+  emit_i32_const(b, comp_ss_scratch)
+  emit_i32_const(b, 1)
+  emit_call(b, 0)
+  emit_local_set(b, 2)
+  emit_local_get(b, 2)
+  emit_i32_const(b, -1)
+  emit_i32_eq(b)
+  emit_if_void(b)
+  // BLOCKED: park until the producer delivers, then UNJOIN before dropping
+  // the set -- dropping one that still has members traps.
+  emit_call(b, 2)
+  emit_local_set(b, 3)
+  emit_local_get(b, 1)
+  emit_local_get(b, 3)
+  emit_call(b, 3)
+  emit_local_get(b, 3)
+  emit_i32_const(b, comp_ss_payload)
+  emit_call(b, 4)
+  emit_local_set(b, 4)
+  emit_local_get(b, 1)
+  emit_i32_const(b, 0)
+  emit_call(b, 3)
+  emit_local_get(b, 3)
+  emit_call(b, 5)
+  emit_local_get(b, 4)
+  emit_i32_const(b, 2)
+  emit_i32_ne(b)
+  emit_if_void(b)
+  bytebuf_push(b, 0)
+  emit_end(b)
+  emit_i32_const(b, comp_ss_payload + 4)
+  emit_i32_load(b, 2, 0)
+  emit_local_set(b, 2)
+  emit_end(b)
+  // Nothing transferred = the end of the stream. Any zero-transfer code other
+  // than the measured CLOSED (1) is an assumption that moved: trap rather than
+  // report an end that may not be one.
+  emit_local_get(b, 2)
+  emit_i32_const(b, 4)
+  emit_i32_shr_u(b)
+  emit_i32_eqz(b)
+  emit_if_void(b)
+  emit_local_get(b, 2)
+  emit_i32_const(b, 15)
+  emit_i32_and(b)
+  emit_i32_const(b, 1)
+  emit_i32_ne(b)
+  emit_if_void(b)
+  bytebuf_push(b, 0)
+  emit_end(b)
+  emit_local_get(b, 1)
+  emit_call(b, 1)
+  emit_i64_const(b, 0 - 1)
+  emit_return(b)
+  emit_end(b)
+  // A byte landed. If the end came WITH it, latch that: reading again after
+  // the notification traps, so the drop happens on the next call instead.
+  emit_local_get(b, 2)
+  emit_i32_const(b, 15)
+  emit_i32_and(b)
+  emit_i32_const(b, 1)
+  emit_i32_eq(b)
+  emit_if_void(b)
+  emit_local_get(b, 5)
+  emit_i32_const(b, 1)
+  emit_i32_store(b, 2, 0)
+  emit_end(b)
+  emit_i32_const(b, comp_ss_scratch)
+  emit_i32_load8_u(b, 0, 0)
+  bytebuf_push(b, 173)
+  let code_sec = bytebuf_new()
+  leb128_encode_u32(code_sec, 1)
+  let fb = bytebuf_new()
+  leb128_encode_u32(fb, 1)
+  leb128_encode_u32(fb, 5)
+  bytebuf_push(fb, 127)
+  bytebuf_push_buf(fb, b)
+  bytebuf_push(fb, 11)
+  leb128_encode_u32(code_sec, bytebuf_length(fb))
+  bytebuf_push_buf(code_sec, fb)
+  bytebuf_push_section(out, 10, code_sec)
+  bytebuf_to_bytes(out)
+}
+
+/// #1540 scope 4: the serve component for a handler whose last parameter is a
+/// `HostStream` -- the request body, read without ever materializing it.
+///
+/// This is the join of everything the issue built: the async lift and string
+/// `task.return` of the sync-shaped async lane, the stream parameter's
+/// type-index encoding, the trampoline that tags the handle, and the adapter
+/// above that turns `vibe.host_stream_read` into real canon calls.
+///
+/// TWO memories, on purpose. The canons need one for the read landing slot and
+/// the wait payload; the only other memory here is the vibe heap, and fixed
+/// addresses in that would corrupt whatever the program had there. So the
+/// canons get a memhost page and `task.return` / the lift keep the MAIN memory,
+/// which is where the result string and the lowered params actually live.
+///
+/// Nothing here is a cycle: the adapter depends on the canons, main depends on
+/// the adapter, the trampoline depends on main -- and only the trampoline
+/// imports `[task-return]`, so the memory that canon needs (main's) exists
+/// before the instance that imports it.
+///
+/// Index layout, in emission order:
+///   core module    0 = main, 1 = trampoline, 2 = host stub, 3 = adapter,
+///                  4 = memhost
+///   core memory    0 = memhost page, 1 = main memory
+///   core func      0..5 = stream.read, drop-readable, ws.new, join, ws.wait,
+///                  ws.drop; 6 = adapter's host_stream_read;
+///                  7 = main's target; 8 = task.return;
+///                  9 = canon_func, 10 = cabi_realloc
+///   core instance  0 = memhost, 1 = $root, 2 = adapter env, 3 = adapter,
+///                  4 = stub, 5 = vibe imports, 6 = main, 7 = tramp env,
+///                  8 = [export]$root, 9 = trampoline
+///   component type 0 = stream u8, 1 = the async functype
+export fn comp_emit_component_wasm_stream_handler(core_wasm: Bytes, target_func_name: String, export_name: String, param_names: Array[String]) -> Bytes with Exception {
+  let string_param_count = Array::length(param_names) - 1
+  comp_check_stream_handler_target(core_wasm, target_func_name, string_param_count)
+  let buf = bytebuf_new()
+  emit_component_header(buf)
+  emit_core_module_section(buf, core_wasm)
+  emit_core_module_section(buf, comp_generate_string_trampoline_packed_async_opt(string_param_count, export_name, true))
+  emit_core_module_section(buf, comp_generate_host_stub_module(array_empty(), array_empty()))
+  emit_core_module_section(buf, comp_generate_serve_stream_adapter_module())
+  emit_core_module_section(buf, comp_generate_memhost_module())
+  emit_core_instance_instantiate_section(buf, 4, array_empty())
+  emit_alias_section(buf, 0, [
+    "memory"
+  ], [
+    core_sort_mem
+  ])
+  emit_comp_stream_type_section(buf, comp_valtype_u8)
+  emit_canon_stream_read(buf, 0, 0)
+  emit_canon_stream_drop_readable(buf, 0)
+  emit_canon_waitable_set_new(buf)
+  emit_canon_waitable_join(buf)
+  emit_canon_waitable_set_wait(buf, 0)
+  emit_canon_waitable_set_drop(buf)
+  emit_core_instance_from_exports_sorted(buf, [
+    "[async-lower][stream-read-0]body",
+    "[stream-drop-readable-0]body",
+    "[waitable-set-new]",
+    "[waitable-join]",
+    "[waitable-set-wait]",
+    "[waitable-set-drop]"
+  ], [
+    core_sort_func,
+    core_sort_func,
+    core_sort_func,
+    core_sort_func,
+    core_sort_func,
+    core_sort_func
+  ], [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5
+  ])
+  emit_core_instance_from_exports_sorted(buf, [
+    "memory"
+  ], [
+    core_sort_mem
+  ], [
+    0
+  ])
+  emit_core_instance_instantiate_args(buf, 3, [
+    "$root",
+    "env"
+  ], [
+    1,
+    2
+  ])
+  emit_core_instance_instantiate_section(buf, 2, array_empty())
+  emit_alias_section(buf, 3, [
+    "host_stream_read"
+  ], [
+    core_sort_func
+  ])
+  emit_core_instance_from_exports(buf, 1, [
+    1
+  ], [
+    "host_stream_read"
+  ], [
+    6
+  ])
+  emit_core_instance_instantiate_args(buf, 0, [
+    "wasi_snapshot_preview1",
+    "vibe"
+  ], [
+    4,
+    5
+  ])
+  emit_alias_section(buf, 6, [
+    target_func_name
+  ], [
+    core_sort_func
+  ])
+  emit_alias_section(buf, 6, [
+    "memory"
+  ], [
+    core_sort_mem
+  ])
+  emit_alias_section(buf, 6, [
+    "__heap_ptr"
+  ], [
+    core_sort_global
+  ])
+  // Memory 1 is main's: the result string the lift reads lives in the vibe
+  // heap, not in the memhost page the canons use.
+  emit_canon_task_return_opts(buf, comp_valtype_string, 1, true)
+  emit_core_instance_from_exports_sorted(buf, [
+    "target_func",
+    "__heap_ptr",
+    "memory"
+  ], [
+    core_sort_func,
+    core_sort_global,
+    core_sort_mem
+  ], [
+    7,
+    0,
+    1
+  ])
+  emit_core_instance_from_exports(buf, 1, [
+    1
+  ], [
+    String::concat("[task-return]", export_name)
+  ], [
+    8
+  ])
+  emit_core_instance_instantiate_args(buf, 1, [
+    "env",
+    "[export]$root"
+  ], [
+    7,
+    8
+  ])
+  emit_alias_section(buf, 9, [
+    "canon_func",
+    "cabi_realloc"
+  ], [
+    core_sort_func,
+    core_sort_func
+  ])
+  let comp_param_valtypes = new_int_array()
+  let mut pt = 0
+  while pt < string_param_count {
+    Array::push(comp_param_valtypes, comp_valtype_string)
+    pt = pt + 1
+  }
+  // The body param's valtype is the stream TYPE INDEX (0), not a primitive.
+  Array::push(comp_param_valtypes, 0)
+  emit_comp_async_functype_params(buf, param_names, comp_param_valtypes, comp_valtype_string)
+  emit_canon_lift_async_opts(buf, 9, 1, 1, 10, true)
+  emit_comp_export_section(buf, export_name, 0)
+  bytebuf_to_bytes(buf)
+}
+
+/// #1540 scope 4: the stream handler's target-export contract.
+///
+/// Same as the string handler's, plus one: the core signature carries an extra
+/// i64 for the stream handle. Every param is an i64 either way, so what this
+/// really pins is the COUNT -- and getting it wrong would hand the handler a
+/// shifted argument list rather than fail.
+fn comp_check_stream_handler_target(core_wasm: Bytes, target_func_name: String, string_param_count: Int) -> Unit with Exception {
+  comp_check_string_handler_target(core_wasm, target_func_name, string_param_count + 1)
 }
 
 /// #1540 scope 4: the ASYNC serve component -- same handler surface as

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -7568,20 +7568,40 @@ fn comp_generate_host_stub_module(vibe_names: Array[String], vibe_sigs: Array[Ar
 /// canons need a memory for the read landing slot and the wait payload, and
 /// the only other memory in this component is the vibe heap. Writing fixed
 /// addresses into that would corrupt whatever the program had there.
-let comp_ss_scratch = 0
+///
+/// EVERY band is indexed by handle, because a serve component instance
+/// carries MANY request tasks at once. The load-bearing one is the read
+/// landing slot: `stream.read(h, addr, 1)` registers `addr` with the canon
+/// and then blocks, so the producer writes there whenever it delivers -- and
+/// two requests blocked on their own bodies would be handing the same address
+/// to two producers. That is the reason the named adapter bands its own slot
+/// (comp_hs_value_base), and it corrupts bodies silently rather than trapping.
+///
+/// Handles are capped at comp_hf_max_handles() (1023), so the three bands end
+/// at 16384, well inside the single page.
 
-let comp_ss_payload = 16
+/// One WORD per handle (the byte lands in its low end), indexed by handle * 4.
+let comp_ss_scratch_base = 0
 
-/// One word per handle, indexed by handle * 4. The adapter caps handles at
-/// comp_hf_max_handles() (1023), so this band ends below 4160 -- inside the
-/// single page and clear of the two slots above.
-let comp_ss_closed_base = 64
+/// TWO words per handle, indexed by handle * 8: `waitable-set.wait` writes the
+/// event in the first and the status in the second. Unlike the slot above this
+/// one is written at RESUME time, with no suspension point between the wait
+/// returning and the load -- so sharing it would in fact be safe. It is banded
+/// anyway: the page is the adapter's own and 8 KiB of it is free, and a
+/// layout where one band is per-handle "because it must be" and its neighbour
+/// is shared "because the argument works out" is one refactor away from being
+/// wrong.
+let comp_ss_payload_base = 4096
+
+/// One word per handle, indexed by handle * 4 -- the CLOSED latch.
+let comp_ss_closed_base = 12288
 
 /// #1540 scope 4: `vibe.host_stream_read` for the serve lane.
 ///
-/// The compiled handler imports `vibe.host_stream_read (i64) -> (i64)` and
-/// nothing else (#1871 scope 3) -- the stream arrives as a parameter, so there
-/// is no named getter. This module is what satisfies it.
+/// The compiled handler imports `vibe.host_stream_read (i64) -> (i64)` -- and
+/// `vibe.host_stream_close` too if it stops reading early -- and nothing else
+/// (#1871 scope 3): the stream arrives as a parameter, so there is no named
+/// getter. This module exports both halves, unconditionally.
 ///
 /// Deliberately NOT `comp_generate_hostfuture_adapter_core_module`, which
 /// implements the same function: that one emits it only when there is at least
@@ -7615,7 +7635,8 @@ fn comp_generate_serve_stream_adapter_module() -> Bytes {
   emit_header(out)
   // types: 0 = stream.read (h, ptr, n) -> status; 1 = (h) -> () for
   // drop-readable and waitable-set.drop; 2 = () -> set; 3 = (a, b) -> () for
-  // waitable.join; 4 = (set, ptr) -> event; 5 = host_stream_read (i64) -> i64.
+  // waitable.join; 4 = (set, ptr) -> event; 5 = (i64) -> i64, the shape BOTH
+  // halves of the vibe-side surface share.
   let tc = bytebuf_new()
   bytebuf_push_vec_header(tc, 6)
   emit_func_type_raw(tc, comp_repeat_valtype(127, 3), [
@@ -7668,11 +7689,26 @@ fn comp_generate_serve_stream_adapter_module() -> Bytes {
   leb128_encode_u32(ic, 1)
   bytebuf_push_section(out, 2, ic)
   emit_function_section(out, [
+    5,
     5
   ])
-  emit_export_section(out, "host_stream_read", 6)
+  // Both halves of the surface, ALWAYS. `host_stream_close` is what a handler
+  // that stops reading early lowers to (`__hs_close` -> `vibe.host_stream_close`,
+  // spec §3.18.1), and a core that imports it cannot be instantiated against an
+  // adapter that does not export it. Emitting it unconditionally costs a few
+  // bytes in the components that never call it and keeps "take the first four
+  // bytes and hang up" from being a shape `vibe serve` refuses to compose.
+  let export_sec = bytebuf_new()
+  leb128_encode_u32(export_sec, 2)
+  emit_name(export_sec, "host_stream_read")
+  bytebuf_push(export_sec, 0)
+  leb128_encode_u32(export_sec, 6)
+  emit_name(export_sec, "host_stream_close")
+  bytebuf_push(export_sec, 0)
+  leb128_encode_u32(export_sec, 7)
+  bytebuf_push_section(out, 7, export_sec)
   // param 0 = the handle (i64, untagged); locals (i32) 1 = handle, 2 = status,
-  // 3 = waitable set, 4 = event, 5 = the latch address.
+  // 3 = waitable set, 4 = event, 5 = the latch address, 6 = the read slot.
   let b = bytebuf_new()
   emit_local_get(b, 0)
   emit_i32_wrap_i64(b)
@@ -7694,6 +7730,12 @@ fn comp_generate_serve_stream_adapter_module() -> Bytes {
   emit_i32_const(b, comp_ss_closed_base)
   emit_i32_add(b)
   emit_local_set(b, 5)
+  emit_local_get(b, 1)
+  emit_i32_const(b, 2)
+  emit_i32_shl(b)
+  emit_i32_const(b, comp_ss_scratch_base)
+  emit_i32_add(b)
+  emit_local_set(b, 6)
   // A latch set by a previous inline close: this call is the settle it was
   // waiting for. Drop the readable end now and report the end of the stream.
   emit_local_get(b, 5)
@@ -7710,7 +7752,7 @@ fn comp_generate_serve_stream_adapter_module() -> Bytes {
   // One byte per call: the shape ByteStream::next needs, and the worst case
   // for status handling.
   emit_local_get(b, 1)
-  emit_i32_const(b, comp_ss_scratch)
+  emit_local_get(b, 6)
   emit_i32_const(b, 1)
   emit_call(b, 0)
   emit_local_set(b, 2)
@@ -7726,7 +7768,11 @@ fn comp_generate_serve_stream_adapter_module() -> Bytes {
   emit_local_get(b, 3)
   emit_call(b, 3)
   emit_local_get(b, 3)
-  emit_i32_const(b, comp_ss_payload)
+  emit_local_get(b, 1)
+  emit_i32_const(b, 3)
+  emit_i32_shl(b)
+  emit_i32_const(b, comp_ss_payload_base)
+  emit_i32_add(b)
   emit_call(b, 4)
   emit_local_set(b, 4)
   emit_local_get(b, 1)
@@ -7740,7 +7786,11 @@ fn comp_generate_serve_stream_adapter_module() -> Bytes {
   emit_if_void(b)
   bytebuf_push(b, 0)
   emit_end(b)
-  emit_i32_const(b, comp_ss_payload + 4)
+  emit_local_get(b, 1)
+  emit_i32_const(b, 3)
+  emit_i32_shl(b)
+  emit_i32_const(b, comp_ss_payload_base + 4)
+  emit_i32_add(b)
   emit_i32_load(b, 2, 0)
   emit_local_set(b, 2)
   emit_end(b)
@@ -7777,19 +7827,56 @@ fn comp_generate_serve_stream_adapter_module() -> Bytes {
   emit_i32_const(b, 1)
   emit_i32_store(b, 2, 0)
   emit_end(b)
-  emit_i32_const(b, comp_ss_scratch)
+  emit_local_get(b, 6)
   emit_i32_load8_u(b, 0, 0)
   bytebuf_push(b, 173)
+  // host_stream_close: release a readable end the handler stopped reading.
+  // No `stream.read` and no park -- dropping is synchronous. The guest's cell
+  // state gates the ONE call (`__hs_close` drops only from state 3 and closes
+  // the cell in the same step), which matters because a second
+  // `stream.drop-readable` on a dropped end traps host-side. Clearing the
+  // latch first keeps a pending inline-close from firing a second drop.
+  //
+  // Returns 0: the surface is `-> Unit`, but the raw ABI is uniformly
+  // `(i64) -> i64`, so the injected wrapper discards this.
+  let cb = bytebuf_new()
+  emit_local_get(cb, 0)
+  emit_i32_wrap_i64(cb)
+  emit_local_set(cb, 1)
+  emit_local_get(cb, 1)
+  emit_i32_const(cb, comp_hf_max_handles())
+  emit_i32_gt_u(cb)
+  emit_if_void(cb)
+  bytebuf_push(cb, 0)
+  emit_end(cb)
+  emit_local_get(cb, 1)
+  emit_i32_const(cb, 2)
+  emit_i32_shl(cb)
+  emit_i32_const(cb, comp_ss_closed_base)
+  emit_i32_add(cb)
+  emit_i32_const(cb, 0)
+  emit_i32_store(cb, 2, 0)
+  emit_local_get(cb, 1)
+  emit_call(cb, 1)
+  emit_i64_const(cb, 0)
   let code_sec = bytebuf_new()
-  leb128_encode_u32(code_sec, 1)
+  leb128_encode_u32(code_sec, 2)
   let fb = bytebuf_new()
   leb128_encode_u32(fb, 1)
-  leb128_encode_u32(fb, 5)
+  leb128_encode_u32(fb, 7)
   bytebuf_push(fb, 127)
   bytebuf_push_buf(fb, b)
   bytebuf_push(fb, 11)
   leb128_encode_u32(code_sec, bytebuf_length(fb))
   bytebuf_push_buf(code_sec, fb)
+  let cfb = bytebuf_new()
+  leb128_encode_u32(cfb, 1)
+  leb128_encode_u32(cfb, 1)
+  bytebuf_push(cfb, 127)
+  bytebuf_push_buf(cfb, cb)
+  bytebuf_push(cfb, 11)
+  leb128_encode_u32(code_sec, bytebuf_length(cfb))
+  bytebuf_push_buf(code_sec, cfb)
   bytebuf_push_section(out, 10, code_sec)
   bytebuf_to_bytes(out)
 }
@@ -7818,9 +7905,9 @@ fn comp_generate_serve_stream_adapter_module() -> Bytes {
 ///                  4 = memhost
 ///   core memory    0 = memhost page, 1 = main memory
 ///   core func      0..5 = stream.read, drop-readable, ws.new, join, ws.wait,
-///                  ws.drop; 6 = adapter's host_stream_read;
-///                  7 = main's target; 8 = task.return;
-///                  9 = canon_func, 10 = cabi_realloc
+///                  ws.drop; 6 = adapter's host_stream_read,
+///                  7 = adapter's host_stream_close; 8 = main's target;
+///                  9 = task.return; 10 = canon_func, 11 = cabi_realloc
 ///   core instance  0 = memhost, 1 = $root, 2 = adapter env, 3 = adapter,
 ///                  4 = stub, 5 = vibe imports, 6 = main, 7 = tramp env,
 ///                  8 = [export]$root, 9 = trampoline
@@ -7886,16 +7973,25 @@ export fn comp_emit_component_wasm_stream_handler(core_wasm: Bytes, target_func_
   ])
   emit_core_instance_instantiate_section(buf, 2, array_empty())
   emit_alias_section(buf, 3, [
-    "host_stream_read"
+    "host_stream_read",
+    "host_stream_close"
   ], [
+    core_sort_func,
     core_sort_func
   ])
+  // BOTH halves in the `vibe` instance. A handler that stops reading early
+  // lowers `host_stream_close` to a core import of that name, and a core
+  // instance cannot be given fewer bindings than it imports -- so leaving the
+  // close half out would make "read four bytes and hang up" a shape this lane
+  // refuses to compose. Handing over a binding the core never imports is free.
   emit_core_instance_from_exports(buf, 1, [
-    1
+    2
   ], [
-    "host_stream_read"
+    "host_stream_read",
+    "host_stream_close"
   ], [
-    6
+    6,
+    7
   ])
   emit_core_instance_instantiate_args(buf, 0, [
     "wasi_snapshot_preview1",
@@ -7931,7 +8027,7 @@ export fn comp_emit_component_wasm_stream_handler(core_wasm: Bytes, target_func_
     core_sort_global,
     core_sort_mem
   ], [
-    7,
+    8,
     0,
     1
   ])
@@ -7940,7 +8036,7 @@ export fn comp_emit_component_wasm_stream_handler(core_wasm: Bytes, target_func_
   ], [
     String::concat("[task-return]", export_name)
   ], [
-    8
+    9
   ])
   emit_core_instance_instantiate_args(buf, 1, [
     "env",
@@ -7965,7 +8061,7 @@ export fn comp_emit_component_wasm_stream_handler(core_wasm: Bytes, target_func_
   // The body param's valtype is the stream TYPE INDEX (0), not a primitive.
   Array::push(comp_param_valtypes, 0)
   emit_comp_async_functype_params(buf, param_names, comp_param_valtypes, comp_valtype_string)
-  emit_canon_lift_async_opts(buf, 9, 1, 1, 10, true)
+  emit_canon_lift_async_opts(buf, 10, 1, 1, 11, true)
   emit_comp_export_section(buf, export_name, 0)
   bytebuf_to_bytes(buf)
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -7062,16 +7062,42 @@ fn emit_core_instance_from_exports_sorted(buf: Bytes, names: Array[String], sort
 /// index by one against the sync trampoline, which is why this is a separate
 /// generator rather than a flag on that one.
 fn comp_generate_string_trampoline_packed_async(string_param_count: Int, export_name: String) -> Bytes {
+  comp_generate_string_trampoline_packed_async_opt(string_param_count, export_name, false)
+}
+
+/// #1540 scope 3: the same trampoline, with an optional trailing STREAM
+/// parameter.
+///
+/// The canonical ABI flattens a `stream<u8>` param to ONE i32 handle after the
+/// strings' (ptr, len) pairs (measured: tools/wasip3_component_probe/
+/// http_body_read). vibe sees it as a `HostStream`, whose cell the lowering
+/// prelude builds from the bare handle -- so what the handler's core function
+/// wants in that slot is the handle as a TAGGED vibe Int.
+///
+/// Tagging is `<< 1`, because the host-stream adapter untags with `param >> 1`
+/// before using the handle. Getting it wrong hands every read a handle twice
+/// or half the real one -- a wrong answer, not a trap.
+fn comp_generate_string_trampoline_packed_async_opt(string_param_count: Int, export_name: String, stream_param: Bool) -> Bytes {
   let buf = bytebuf_new()
   emit_header(buf)
   // types: 0 = target_func (i64 x N+1) -> i64; 1 = canon_func (i32 x 2N) -> ();
   // 2 = cabi_realloc (i32,i32,i32,i32) -> i32; 3 = task.return (i32, i32) -> ()
   let type_sec = bytebuf_new()
   bytebuf_push_vec_header(type_sec, 4)
-  emit_func_type_raw(type_sec, comp_repeat_valtype(126, string_param_count + 1), [
+  let target_i64_count = if stream_param {
+    string_param_count + 2
+  } else {
+    string_param_count + 1
+  }
+  let canon_i32_count = if stream_param {
+    (string_param_count * 2) + 1
+  } else {
+    string_param_count * 2
+  }
+  emit_func_type_raw(type_sec, comp_repeat_valtype(126, target_i64_count), [
     126
   ])
-  emit_func_type_raw(type_sec, comp_repeat_valtype(127, string_param_count * 2), array_empty())
+  emit_func_type_raw(type_sec, comp_repeat_valtype(127, canon_i32_count), array_empty())
   emit_func_type_raw(type_sec, comp_repeat_valtype(127, 4), [
     127
   ])
@@ -7119,7 +7145,7 @@ fn comp_generate_string_trampoline_packed_async(string_param_count: Int, export_
   leb128_encode_u32(canon_body, 1)
   leb128_encode_u32(canon_body, 1)
   bytebuf_push(canon_body, 126)
-  let result_local = string_param_count * 2
+  let result_local = canon_i32_count
   let mut si = 0
   while si < string_param_count {
     // (extend_u(ptr) << 32) | extend_u(len)
@@ -7131,6 +7157,15 @@ fn comp_generate_string_trampoline_packed_async(string_param_count: Int, export_
     bytebuf_push(canon_body, 173)
     bytebuf_push(canon_body, 132)
     si = si + 1
+  }
+  if stream_param {
+    // The stream handle, tagged: extend_u then << 1.
+    emit_local_get(canon_body, string_param_count * 2)
+    bytebuf_push(canon_body, 173)
+    emit_i64_const(canon_body, 1)
+    bytebuf_push(canon_body, 134)
+  } else {
+    ()
   }
   // Trailing closure-env argument (0 for a top-level function).
   emit_i64_const(canon_body, 0)
@@ -7153,6 +7188,16 @@ fn comp_generate_string_trampoline_packed_async(string_param_count: Int, export_
   bytebuf_push_buf(code_sec, comp_generate_bump_realloc_body())
   bytebuf_push_section(buf, 10, code_sec)
   bytebuf_to_bytes(buf)
+}
+
+/// #1540 scope 3: byte-shape fixture for the stream-parameter trampoline.
+///
+/// Exists because the stream slot cannot be checked any other way yet: nothing
+/// assembles this trampoline into a component until the host-stream adapter is
+/// wired into the serve lane, and by then a wrong tag would be a wrong ANSWER
+/// (every read seeing half or twice the real handle) rather than a trap.
+export fn comp_emit_stream_trampoline_fixture(string_param_count: Int) -> Bytes {
+  comp_generate_string_trampoline_packed_async_opt(string_param_count, "handler", true)
 }
 
 /// #1540: `<count>` copies of one core valtype -- the shape both trampolines

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -200,6 +200,9 @@ fn comp_emit_body_read_component(export_name: String, string_param_names: Array[
 
 // #1540: the ASYNC serve lane -- same handler surface, async lift + task.return.
 fn comp_emit_component_wasm_string_handler_async(core_wasm: Bytes, target_func_name: String, export_name: String, param_names: Array[String]) -> Bytes with Exception
+
+// #1540 scope 3: byte-shape fixture for the stream-parameter trampoline.
+fn comp_emit_stream_trampoline_fixture(string_param_count: Int) -> Bytes
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -203,6 +203,9 @@ fn comp_emit_component_wasm_string_handler_async(core_wasm: Bytes, target_func_n
 
 // #1540 scope 3: byte-shape fixture for the stream-parameter trampoline.
 fn comp_emit_stream_trampoline_fixture(string_param_count: Int) -> Bytes
+
+// #1540 scope 4: the serve lane for a handler whose last param is a HostStream.
+fn comp_emit_component_wasm_stream_handler(core_wasm: Bytes, target_func_name: String, export_name: String, param_names: Array[String]) -> Bytes with Exception
 // ADR-0089 step 4 (#1218): REAL-source wiring -- wrap a compiled core whose
 // program calls `host_future_get` (core imports vibe.host_future_get/_wait,
 // sniffed by comp_core_imports_host_future) into the adapter-backed async

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -662,6 +662,9 @@ fn wit_kebab_ident(name: String) -> String
 fn wit_type_text(ty: TypeExpr) -> String with Exception
 fn serve_handler_param_names() -> Array[String]
 fn validate_serve_handler(entry_stmts: Array[Stmt]) -> Unit with Exception
+
+// #1540 scope 4: does `handler` take the request body as a stream? Picks the lane.
+fn serve_handler_takes_body_stream(entry_stmts: Array[Stmt]) -> Bool
 fn wit_boundary_signature(stmts: Array[Stmt], name: String) -> Option[(String, Array[String], Array[TypeExpr], TypeExpr, Array[String])]
 fn wit_from_program(export_stmts: Array[Stmt], effect_stmts: Array[Stmt], world_name: String) -> String with Exception
 

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -29,6 +29,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_future_value,
   comp_emit_component_wasm_host_future_value,
   comp_emit_component_wasm_stdin_provider_shadow,
+  comp_emit_component_wasm_stream_handler,
   comp_emit_component_wasm_stream_value,
   comp_emit_component_wasm_string_handler,
   comp_emit_component_wasm_string_handler_stubbed,
@@ -721,18 +722,22 @@ test "component async: the emitted body-read component takes a stream param (#15
   assert(component_bytes_contains(comp, "ERR-OVERRUN") == 1)
 }
 
-/// #1540 scope 3: the async trampoline's STREAM parameter.
+/// #1540 scope 3/4: the async trampoline's STREAM parameter.
 ///
 /// Two things are pinned, and the second is the one that cannot fail loudly.
 ///
 /// The canonical ABI flattens `stream<u8>` to ONE i32 handle after the
 /// strings' (ptr, len) pairs, so `canon_func` takes 2N+1 i32 -- shape, easy to
-/// see. The handle then reaches the handler's core function as a vibe Int,
-/// which is TAGGED: the host-stream adapter untags with `param >> 1`. A
-/// missing or doubled `<< 1` hands every read half or twice the real handle,
-/// and a wrong handle reads a different stream or none -- a wrong answer, not
-/// a trap.
-test "component async: the stream trampoline flattens and TAGS the handle (#1540)" {
+/// see. The handle then reaches the handler's core function as a vibe Int, and
+/// an Int's REPRESENTATION is the compile mode's: `enable_rc` on means
+/// `value << 1`, off means a plain i64 (linked_compile's tag_mode). This lane's
+/// core comes from `vibe serve`'s `compile_wasi_module_no_dce_impl`, which
+/// passes enable_rc = false -- so the handle crosses UNTAGGED, zero-extended
+/// and nothing else, matching what comp_generate_serve_stream_adapter_module
+/// reads back. Getting this wrong does not trap: a tag the guest does not
+/// expect just doubles the handle, and a doubled handle reads a different
+/// stream or silently reads none.
+test "component async: the stream trampoline flattens the handle UNTAGGED (#1540)" {
   let m = comp_emit_stream_trampoline_fixture(3)
   // core wasm header
   assert(Bytes::get(m, 0) == 0)
@@ -764,8 +769,18 @@ test "component async: the stream trampoline flattens and TAGS the handle (#1540
     127,
     0
   ]) == 1)
-  // the tagging itself: local.get 6 (the handle slot) ; i64.extend_i32_u (ad)
-  // ; i64.const 1 (42 01) ; i64.shl (86)
+  // local.get 6 (the handle slot) ; i64.extend_i32_u (ad) ; then straight to
+  // the closure-env argument (i64.const 0 = 42 00) and the call (10 00).
+  assert(bytes_contains_seq(m, [
+    32,
+    6,
+    173,
+    66,
+    0,
+    16,
+    0
+  ]) == 1)
+  // the tag that must NOT be there: i64.extend_i32_u ; i64.const 1 ; i64.shl
   assert(bytes_contains_seq(m, [
     32,
     6,
@@ -773,7 +788,7 @@ test "component async: the stream trampoline flattens and TAGS the handle (#1540
     66,
     1,
     134
-  ]) == 1)
+  ]) == 0)
   // and it still hands the result back through task.return, not a retptr
   assert(component_bytes_contains(m, "[task-return]handler") == 1)
 }
@@ -981,6 +996,66 @@ test "component #537: string handler rejects a wrong signature" {
 /// reaches them. Same shape as build_test_core_packed_handler, plus an import
 /// section with vibe.env-get / vibe.fs_read_file ((i64) -> i64). The handler
 /// becomes core func index 2 (after the two imports).
+fn build_test_core_stream_handler() -> Bytes {
+  let out = bytebuf_new()
+  emit_header(out)
+  let type_content = bytebuf_new()
+  bytebuf_push_vec_header(type_content, 2)
+  // handler: 3 strings + the stream handle + the closure env, all i64
+  emit_func_type_raw(type_content, [
+    126,
+    126,
+    126,
+    126,
+    126
+  ], [
+    126
+  ])
+  emit_func_type_raw(type_content, [
+    126
+  ], [
+    126
+  ])
+  bytebuf_push_section(out, 1, type_content)
+  let import_content = bytebuf_new()
+  bytebuf_push_vec_header(import_content, 1)
+  emit_name(import_content, "vibe")
+  emit_name(import_content, "host_stream_read")
+  bytebuf_push(import_content, 0)
+  leb128_encode_u32(import_content, 1)
+  bytebuf_push_section(out, 2, import_content)
+  emit_function_section(out, [
+    0
+  ])
+  emit_memory_section(out, 1)
+  let global_content = bytebuf_new()
+  leb128_encode_u32(global_content, 1)
+  bytebuf_push(global_content, 127)
+  bytebuf_push(global_content, 1)
+  bytebuf_push(global_content, 65)
+  bytebuf_push(global_content, 8)
+  bytebuf_push(global_content, 11)
+  bytebuf_push_section(out, 6, global_content)
+  let export_content = bytebuf_new()
+  bytebuf_push_vec_header(export_content, 3)
+  emit_name(export_content, "handler")
+  bytebuf_push(export_content, 0)
+  leb128_encode_u32(export_content, 1)
+  emit_name(export_content, "memory")
+  bytebuf_push(export_content, 2)
+  leb128_encode_u32(export_content, 0)
+  emit_name(export_content, "__heap_ptr")
+  bytebuf_push(export_content, 3)
+  leb128_encode_u32(export_content, 0)
+  bytebuf_push_section(out, 7, export_content)
+  let h_body = bytebuf_new()
+  emit_local_get(h_body, 0)
+  emit_code_section(out, [
+    h_body
+  ])
+  bytebuf_to_bytes(out)
+}
+
 fn build_test_core_packed_handler_with_vibe_imports() -> Bytes {
   let out = bytebuf_new()
   emit_header(out)
@@ -1042,6 +1117,83 @@ fn build_test_core_packed_handler_with_vibe_imports() -> Bytes {
     h_body
   ])
   bytebuf_to_bytes(out)
+}
+
+/// #1540 scope 4: the serve component for a `body: HostStream` handler --
+/// the shape `vibe serve` now emits when the handler's last parameter is a
+/// stream, and the join of every earlier slice in the issue.
+///
+/// What is asserted is the WIRING, because that is what silently misbehaves.
+/// The stream canons live in a memhost page while `task.return` and the lift
+/// keep the MAIN memory (a canon writing fixed addresses into the vibe heap
+/// would corrupt whatever the program had there), and the adapter that turns
+/// `vibe.host_stream_read` into those canons is a fourth core module the main
+/// instance is given. An emitter that dropped the adapter would still produce
+/// a component that VALIDATES -- `wac plug` promotes the unsatisfied edge to a
+/// root import (#1796) -- and only fail when a request arrives.
+test "component #1540: the stream serve lane wires main to the stream canons" {
+  let core = build_test_core_stream_handler()
+  let comp = comp_emit_component_wasm_stream_handler(core, "handler", "handler", [
+    "method",
+    "url",
+    "headers",
+    "body"
+  ])
+  assert(Bytes::get(comp, 0) == 0)
+  assert(Bytes::get(comp, 4) == 13)
+  // the adapter satisfies the guest's read half under its own name
+  assert(component_bytes_contains(comp, "host_stream_read") == 1)
+  // and it does so through the real canons, not a stub
+  assert(component_bytes_contains(comp, "[async-lower][stream-read-0]body") == 1)
+  assert(component_bytes_contains(comp, "[stream-drop-readable-0]body") == 1)
+  assert(component_bytes_contains(comp, "[waitable-set-wait]") == 1)
+  // the result still leaves through task.return: the lift is async, so the
+  // core function has no return path to carry it
+  assert(component_bytes_contains(comp, "[task-return]handler") == 1)
+}
+
+/// The arity guard, and the thing it CANNOT do.
+///
+/// A stream handler's core function takes 3 strings + the handle + the closure
+/// env; a String handler's takes 4 strings + the closure env. Both are five
+/// i64. Measured, not assumed -- the `build_test_core_packed_handler_with_vibe_imports`
+/// core passes the stream lane's check unchanged. So the core carries NO
+/// evidence of which lane it belongs to, and the guard can only catch a core
+/// of the wrong SIZE.
+///
+/// That is why the lane is chosen from the handler's source signature
+/// (`serve_handler_takes_body_stream`) and never sniffed from the compiled
+/// core: there is nothing there to sniff.
+test "component #1540: the stream lane's guard catches a wrong-arity core" {
+  let core = build_test_core()
+  let rejected = handle {
+    let _ = comp_emit_component_wasm_stream_handler(core, "run", "handler", [
+      "method",
+      "url",
+      "headers",
+      "body"
+    ])
+    false
+  } with Exception {
+    Throw(_) => true
+  }
+  assert(rejected)
+  // and the arity a String handler's core has is INDISTINGUISHABLE from the
+  // stream one's -- both five i64 -- so this guard accepts it. Pinning that
+  // here keeps the fact from being rediscovered as a silent mis-lane.
+  let string_core = build_test_core_packed_handler_with_vibe_imports()
+  let accepted = handle {
+    let _ = comp_emit_component_wasm_stream_handler(string_core, "handler", "handler", [
+      "method",
+      "url",
+      "headers",
+      "body"
+    ])
+    true
+  } with Exception {
+    Throw(_) => false
+  }
+  assert(accepted)
 }
 
 test "component #1107: strict string handler rejects vibe.* imports" {

--- a/lib/@vibe/compiler/tests/component_codegen_test.vibe
+++ b/lib/@vibe/compiler/tests/component_codegen_test.vibe
@@ -35,6 +35,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   comp_emit_component_wasm_with_lift,
   comp_emit_component_wasm_with_string_lift,
   comp_emit_memhost_realloc_fixture,
+  comp_emit_stream_trampoline_fixture,
   comp_generate_string_trampoline,
   comp_generate_string_trampoline_packed
 }
@@ -718,6 +719,63 @@ test "component async: the emitted body-read component takes a stream param (#15
   assert(component_bytes_contains(comp, "[task-return]handler") == 1)
   // and its diagnostics are strings, so a failure can name what broke
   assert(component_bytes_contains(comp, "ERR-OVERRUN") == 1)
+}
+
+/// #1540 scope 3: the async trampoline's STREAM parameter.
+///
+/// Two things are pinned, and the second is the one that cannot fail loudly.
+///
+/// The canonical ABI flattens `stream<u8>` to ONE i32 handle after the
+/// strings' (ptr, len) pairs, so `canon_func` takes 2N+1 i32 -- shape, easy to
+/// see. The handle then reaches the handler's core function as a vibe Int,
+/// which is TAGGED: the host-stream adapter untags with `param >> 1`. A
+/// missing or doubled `<< 1` hands every read half or twice the real handle,
+/// and a wrong handle reads a different stream or none -- a wrong answer, not
+/// a trap.
+test "component async: the stream trampoline flattens and TAGS the handle (#1540)" {
+  let m = comp_emit_stream_trampoline_fixture(3)
+  // core wasm header
+  assert(Bytes::get(m, 0) == 0)
+  assert(Bytes::get(m, 1) == 97)
+  // target_func takes 3 strings + the stream + the closure env = 5 i64,
+  // returning i64: 60 05 7e 7e 7e 7e 7e 01 7e
+  assert(bytes_contains_seq(m, [
+    96,
+    5,
+    126,
+    126,
+    126,
+    126,
+    126,
+    1,
+    126
+  ]) == 1)
+  // canon_func takes 2*3 + 1 = 7 i32 and returns NOTHING (async lift):
+  // 60 07 7f x7 00
+  assert(bytes_contains_seq(m, [
+    96,
+    7,
+    127,
+    127,
+    127,
+    127,
+    127,
+    127,
+    127,
+    0
+  ]) == 1)
+  // the tagging itself: local.get 6 (the handle slot) ; i64.extend_i32_u (ad)
+  // ; i64.const 1 (42 01) ; i64.shl (86)
+  assert(bytes_contains_seq(m, [
+    32,
+    6,
+    173,
+    66,
+    1,
+    134
+  ]) == 1)
+  // and it still hands the result back through task.return, not a retptr
+  assert(component_bytes_contains(m, "[task-return]handler") == 1)
 }
 
 test "component async: sync lift carries no async canonopt" {

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -1,7 +1,8 @@
 //# Imports
 
 import ../wit_gen.vibe {
-  serve_handler_param_names, validate_serve_handler, wit_from_program, wit_kebab_ident, wit_type_text
+  serve_handler_param_names, serve_handler_takes_body_stream, validate_serve_handler,
+  wit_from_program, wit_kebab_ident, wit_type_text
 }
 
 import @vibe/core {
@@ -149,9 +150,10 @@ test "validate_serve_handler: rejects a missing handler export" {
 /// #1540: `Async` gets its own rejection, because the generic one gives advice
 /// that cannot be followed. `Async` is not a capability and has no operations,
 /// so "discharge the effect with `handle`" sends the reader after something
-/// that does not exist -- the actual answer is that the async serve lane is
-/// not selected by the CLI yet.
-test "validate_serve_handler: an Async handler is rejected with an Async-specific reason (#1540)" {
+/// that does not exist. Since #1540 scope 4 the lane DOES exist, so the answer
+/// changed from "not wired up yet" to what actually unlocks it: the body
+/// parameter the suspension is for.
+test "validate_serve_handler: an all-String Async handler is told what Async is for (#1540)" {
   let async_ann = TyFn([
     TyName("String"),
     TyName("String"),
@@ -167,10 +169,65 @@ test "validate_serve_handler: an Async handler is rejected with an Async-specifi
   } with Exception {
     Throw(m) => m
   }
-  assert(String::contains(msg, "`Async` handler is not wired up yet"))
+  assert(String::contains(msg, "needs a `body: HostStream` parameter"))
   // The advice the generic arm gives must NOT appear here: there is nothing to
   // handle, and following it would waste the reader's time.
   assert(!String::contains(msg, "discharge the effect with `handle`"))
+}
+
+/// #1540 scope 4: the shape the whole issue was for. A last parameter typed
+/// `HostStream` plus `with Async` is the stream serve lane's contract, and it
+/// must pass -- every earlier revision of this function rejected it.
+test "validate_serve_handler: accepts a HostStream body with Async (#1540)" {
+  let stream_ann = TyFn([
+    TyName("String"),
+    TyName("String"),
+    TyName("String"),
+    TyName("HostStream")
+  ], TyName("String"), Some("Async"))
+  let stmts = [
+    SLet(true, false, "handler", Some(stream_ann), efn_of_string_params(serve_handler_param_names()))
+  ]
+  validate_serve_handler(stmts)
+  assert(serve_handler_takes_body_stream(stmts))
+}
+
+/// The converse. `host_stream_next` suspends, so a `HostStream` body with no
+/// `Async` in the row is a parameter the handler can never read -- reject at
+/// the boundary rather than serve a handler that silently sees no body.
+test "validate_serve_handler: a HostStream body without Async is rejected (#1540)" {
+  let stream_ann = TyFn([
+    TyName("String"),
+    TyName("String"),
+    TyName("String"),
+    TyName("HostStream")
+  ], TyName("String"), None)
+  let stmts = [
+    SLet(true, false, "handler", Some(stream_ann), efn_of_string_params(serve_handler_param_names()))
+  ]
+  let msg = handle {
+    validate_serve_handler(stmts)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "needs `with Async`"))
+}
+
+/// The lane selector is what `vibe serve` branches on, so it must answer NO
+/// for the String contract -- picking the stream lane there would emit a
+/// component whose export takes a `stream<u8>` the adapter never supplies.
+test "serve_handler_takes_body_stream: false for the all-String contract (#1540)" {
+  let ann = TyFn([
+    TyName("String"),
+    TyName("String"),
+    TyName("String"),
+    TyName("String")
+  ], TyName("String"), None)
+  let stmts = [
+    SLet(true, false, "handler", Some(ann), efn_of_string_params(serve_handler_param_names()))
+  ]
+  assert(!serve_handler_takes_body_stream(stmts))
 }
 
 /// The generic arm still answers for real capability effects -- this is a new
@@ -203,6 +260,8 @@ test "wit_type_text: Future projects to future, ByteStream to stream<u8> (ADR-00
     TyName("String")
   ])) == "future<string>")
   assert(wit_type_text(TyName("ByteStream")) == "stream<u8>")
+  // #1540 scope 4: the parameter-side sibling, same projection.
+  assert(wit_type_text(TyName("HostStream")) == "stream<u8>")
 }
 
 test "wit_type_text: eager Stream stays unmapped (boundary rule, spec §3.3)" {

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -33,9 +33,10 @@ import @vibe/core {
 // String -> string, Char -> char, Unit -> (no result), Bytes -> list<u8>,
 // Array[T] -> list<T>, Option[T] -> option<T>, Result[T, E] -> result<T, E>,
 // Map[K, V] -> list<tuple<K, V>>, tuples -> tuple<...>,
-// Future[T] -> future<T'>, ByteStream -> stream<u8> (ADR-0089 Decision 5;
-// the eager `Stream[T]` builtin deliberately has NO mapping — only nominal
-// host-owned boundary streams may cross, spec §3.3). Anything else
+// Future[T] -> future<T'>, ByteStream / HostStream -> stream<u8> (ADR-0089
+// Decision 5 and #1540 scope 4; the eager `Stream[T]` builtin deliberately has
+// NO mapping — only nominal host-owned boundary streams may cross, spec §3.3).
+// Anything else
 // (named user types, function types) is rejected with a clear error — the
 // golden output never silently mis-declares a boundary type.
 //
@@ -113,8 +114,15 @@ export fn wit_type_text(ty: TypeExpr) -> String with Exception {
         // (docs/spec/wasi-p3-async.md §2.4/§3.3; Decision 3's AsyncIter
         // unification keeps general guest streams out of the boundary).
         "stream<u8>"
+      } else if name == "HostStream" {
+        // #1540 scope 4: the other nominal boundary-stream handle. Same WIT
+        // projection as `ByteStream` and for the same reason -- a byte stream
+        // whose producer end the host owns -- but arriving as a PARAMETER
+        // rather than from a named import, which is what lets `vibe serve`
+        // hand a handler the request body.
+        "stream<u8>"
       } else {
-        throw("wit: no WIT mapping for type '\{name}' (supported: Int, Double, Bool, String, Char, Bytes, Unit, Array, Option, Result, Map, tuples, Future[T], ByteStream)")
+        throw("wit: no WIT mapping for type '\{name}' (supported: Int, Double, Bool, String, Char, Bytes, Unit, Array, Option, Result, Map, tuples, Future[T], ByteStream, HostStream)")
       }
     },
     TyApp(head, args) => {
@@ -330,6 +338,16 @@ export fn serve_handler_param_names() -> Array[String] {
   ]
 }
 
+/// #1540 scope 4: the request body's type on the serve boundary. Nominal on
+/// purpose (#1538): the eager `Stream[T]` is a different thing and must not
+/// satisfy this.
+fn wit_type_is_host_stream(ty: TypeExpr) -> Bool {
+  match ty {
+    TyName(name) => name == "HostStream",
+    _ => false
+  }
+}
+
 fn wit_type_is_string(ty: TypeExpr) -> Bool {
   match ty {
     TyName(name) => name == "String",
@@ -348,8 +366,18 @@ export fn validate_serve_handler(entry_stmts: Array[Stmt]) -> Unit with Exceptio
       if Array::length(sig_param_types) != 4 {
         throw(String::concat(contract, " (found \{Array::length(sig_param_types)} params)"))
       }
+      // #1540 scope 4: the LAST param may be a `HostStream` -- the request
+      // body, handed over as a component `stream<u8>` and read without ever
+      // being materialized. Every other param stays String: the contract is a
+      // shape, not a free-form signature.
+      let last_is_stream = wit_type_is_host_stream(Array::get(sig_param_types, Array::length(sig_param_types) - 1))
+      let string_param_limit = if last_is_stream {
+        Array::length(sig_param_types) - 1
+      } else {
+        Array::length(sig_param_types)
+      }
       let mut pi = 0
-      while pi < Array::length(sig_param_types) {
+      while pi < string_param_limit {
         if !wit_type_is_string(Array::get(sig_param_types, pi)) {
           throw(String::concat(contract, " (param \{pi} is not String)"))
         }
@@ -364,18 +392,69 @@ export fn validate_serve_handler(entry_stmts: Array[Stmt]) -> Unit with Exceptio
         if !is_exception_effect_name(ename) {
           // `Async` is not a capability and cannot be discharged with
           // `handle`, so it gets its own answer: telling someone to handle it
-          // sends them after an effect that has no operations to handle. What
-          // it actually needs is the async serve lane
-          // (comp_emit_component_wasm_string_handler_async, #1540), which the
-          // CLI does not select yet -- say THAT rather than misname the
-          // effect. #1540 scope 3/4 is the work that removes this arm.
+          // sends them after an effect that has no operations to handle. Since
+          // #1540 scope 4 the async lane IS selected by the CLI -- but only
+          // for the shape it exists for, a handler reading the request body as
+          // a stream. So the answer names that shape.
           if ename == "Async" {
-            throw("serve: an `Async` handler is not wired up yet -- the async serve lane exists (async lift + task.return) but `vibe serve` still emits the sync one, so the handler cannot suspend (#1540). Drop `with Async` for now; a handler that awaits is the next slice, not something `handle` can discharge here")
+            // #1540 scope 4: `Async` is what reading the body REQUIRES -- the
+            // read suspends -- so it is allowed exactly when the handler takes
+            // the body as a stream. Without that param there is nothing to
+            // await and no lane that can carry the suspend, and `handle` is
+            // still the wrong advice (Async has no operations to handle), so
+            // that case gets its own reason too.
+            if !last_is_stream {
+              throw("serve: `with Async` needs a `body: HostStream` parameter -- the async serve lane exists for reading the request body, and a handler that only takes Strings has nothing to await (#1540). Either take the body as `HostStream` or drop `with Async`; this is not something `handle` can discharge")
+            } else {
+              ()
+            }
           } else {
             throw("serve: handler requires capability effect '\{ename}'; a serve handler must be a pure function of its request params (discharge the effect with `handle` inside the file)")
           }
         }
         ei = ei + 1
+      }
+      // The converse of the arm above. A `HostStream` body can only be read by
+      // `host_stream_next`, which suspends, so a row without `Async` cannot
+      // read it -- the parameter would be inert. Rejecting says that at the
+      // boundary instead of leaving a handler that silently sees no body.
+      if last_is_stream && !serve_effects_have_async(sig_effects) {
+        throw("serve: a `body: HostStream` parameter needs `with Async` -- reading it suspends, so a row without `Async` can never call `host_stream_next` on it (#1540). Add `with Async`, or take the body as `String` to have it collected for you")
+      } else {
+        ()
+      }
+    }
+  }
+}
+
+fn serve_effects_have_async(effects: Array[String]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(effects) {
+    if Array::get(effects, i) == "Async" {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// #1540 scope 4: does this entry file's `handler` take the request body as a
+/// stream? `vibe serve` reads this to pick the lane -- the stream component
+/// (async lift + a `stream<u8>` param) or the String one. Answers only for a
+/// handler that already passed `validate_serve_handler`; anything else is
+/// false, which lands on the lane whose diagnostics are the older ones.
+export fn serve_handler_takes_body_stream(entry_stmts: Array[Stmt]) -> Bool {
+  match wit_boundary_signature(entry_stmts, "handler") {
+    None => false,
+    Some(sig) => {
+      let (_sname, _spnames, sig_param_types, _sig_ret, _sig_effects) = sig
+      if Array::length(sig_param_types) == 0 {
+        false
+      } else {
+        wit_type_is_host_stream(Array::get(sig_param_types, Array::length(sig_param_types) - 1))
       }
     }
   }

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -912,10 +912,20 @@ case "$cmd" in
     # prerequisite of this step). Picking the wrong adapter does NOT fail at
     # composition: `wac plug` promotes the unsatisfiable edge to a root import
     # (#1796), so the mistake would surface as a mysterious runtime failure.
+    #
+    # Match the `handler` EXPORT LINE, not a bare substring of the file. The
+    # sidecar keeps the handler's own parameter names, so `request_body:
+    # HostStream` would print as `request-body: stream<u8>` and a substring
+    # search for `body:` would miss it -- and any OTHER exported function with
+    # a stream parameter would make a String handler match. The line for
+    # `handler` is the only thing that decides this.
     wit_sidecar="${out%.component.wasm}.wit"
     body_stream=0
-    if [ -f "$wit_sidecar" ] && grep -q 'body: stream<u8>' "$wit_sidecar"; then
-      body_stream=1
+    if [ -f "$wit_sidecar" ]; then
+      handler_export="$(grep -E '^[[:space:]]*export handler:' "$wit_sidecar" | head -1 || true)"
+      case "$handler_export" in
+        *'stream<u8>'*) body_stream=1 ;;
+      esac
     fi
     if [ -z "$adapter" ]; then
       if [ "$body_stream" = "1" ]; then

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -866,6 +866,11 @@ case "$cmd" in
     # Handler contract (scripts/build_wasi_http_p3_full_adapter.sh):
     #   export let handler = (method: String, url: String, headers: String, body: String) -> String
     # returning "STATUS\n<Header: value lines>\n\n<body>".
+    #
+    # #1540 scope 4: the last parameter may instead be a `HostStream`, read
+    # with `host_stream_next` -- the body as it arrives rather than collected
+    # first. That form suspends, so it also carries `with Async`, and it needs
+    # the stream-body adapter selected below.
     [ "$#" -ge 1 ] || die "usage: vibe serve <handler.vibe> [--addr host:port] [--port N] [-o out.component.wasm] [--adapter adapter.component.wasm] [--no-run]"
     src=""; out=""; addr="127.0.0.1:8080"; adapter="${VIBE_HTTP_ADAPTER:-}"; no_run=0
     while [ "$#" -gt 0 ]; do
@@ -897,13 +902,37 @@ case "$cmd" in
     echo "component $src -> $out"
     [ "$no_run" = "1" ] && exit 0
     # 2. P3 HTTP adapter (imports `handler`, exports wasi:http/handler@0.3)
-    if [ -z "$adapter" ]; then
-      for cand in "$TOOLCHAIN_DIR/lib/vibe_http_p3_full_adapter.component.wasm" \
-                  "$PWD/_build/http_adapter/vibe_http_p3_full_adapter.component.wasm"; do
-        [ -f "$cand" ] && { adapter="$cand"; break; }
-      done
+    #
+    # #1540 scope 4: TWO adapters, because there are two handler contracts. A
+    # `body: HostStream` handler exports `handler(.., body: stream<u8>)` and
+    # only plugs into the adapter built with VIBE_HTTP_ADAPTER_BODY_STREAM=1;
+    # the String handler needs the default one. Read the lane off the WIT
+    # sidecar the compiler just wrote -- it is the same signature the component
+    # exports, and grepping it costs no extra tool (`wasm-tools` is not a
+    # prerequisite of this step). Picking the wrong adapter does NOT fail at
+    # composition: `wac plug` promotes the unsatisfiable edge to a root import
+    # (#1796), so the mistake would surface as a mysterious runtime failure.
+    wit_sidecar="${out%.component.wasm}.wit"
+    body_stream=0
+    if [ -f "$wit_sidecar" ] && grep -q 'body: stream<u8>' "$wit_sidecar"; then
+      body_stream=1
     fi
-    [ -n "$adapter" ] && [ -f "$adapter" ] || die "serve: P3 HTTP adapter not found; build it with scripts/build_wasi_http_p3_full_adapter.sh (needs cargo + wasm-tools) or pass --adapter / set VIBE_HTTP_ADAPTER"
+    if [ -z "$adapter" ]; then
+      if [ "$body_stream" = "1" ]; then
+        for cand in "$TOOLCHAIN_DIR/lib/vibe_http_p3_body_stream_adapter.component.wasm" \
+                    "$PWD/_build/http_adapter/vibe_http_p3_body_stream_adapter.component.wasm"; do
+          [ -f "$cand" ] && { adapter="$cand"; break; }
+        done
+        [ -n "$adapter" ] && [ -f "$adapter" ] || die "serve: this handler takes the body as a stream, which needs the stream-body P3 adapter; build it with 'VIBE_HTTP_ADAPTER_BODY_STREAM=1 scripts/build_wasi_http_p3_full_adapter.sh _build/http_adapter/vibe_http_p3_body_stream_adapter.component.wasm' (needs cargo + wasm-tools) or pass --adapter / set VIBE_HTTP_ADAPTER"
+      else
+        for cand in "$TOOLCHAIN_DIR/lib/vibe_http_p3_full_adapter.component.wasm" \
+                    "$PWD/_build/http_adapter/vibe_http_p3_full_adapter.component.wasm"; do
+          [ -f "$cand" ] && { adapter="$cand"; break; }
+        done
+        [ -n "$adapter" ] && [ -f "$adapter" ] || die "serve: P3 HTTP adapter not found; build it with scripts/build_wasi_http_p3_full_adapter.sh (needs cargo + wasm-tools) or pass --adapter / set VIBE_HTTP_ADAPTER"
+      fi
+    fi
+    [ -f "$adapter" ] || die "serve: adapter not found: $adapter"
     # 3. compose: plug the handler component's export into the adapter's import
     command -v wac >/dev/null 2>&1 || die "serve: 'wac' not found (cargo install wac-cli)"
     composed="${out%.component.wasm}.serve.wasm"

--- a/scripts/build_wasi_http_p3_full_adapter.sh
+++ b/scripts/build_wasi_http_p3_full_adapter.sh
@@ -28,7 +28,20 @@ OUT_PATH="${1:-$PROJECT_ROOT/_build/http_adapter/vibe_http_p3_full_adapter.compo
 # makes an async-lifted handler unpluggable
 # (tools/wasip3_component_probe/http_body_read/README.md).
 ASYNC_HANDLER="${VIBE_HTTP_ADAPTER_ASYNC_HANDLER:-0}"
-if [ "$ASYNC_HANDLER" = "1" ]; then
+# #1540 scope 4: with VIBE_HTTP_ADAPTER_BODY_STREAM=1 the body is handed to the
+# handler as a `stream<u8>` instead of being collected into a String first --
+# the whole point of the issue: the handler sees the first byte before the last
+# one has arrived. Implies the async import (reading the stream suspends).
+BODY_STREAM="${VIBE_HTTP_ADAPTER_BODY_STREAM:-0}"
+if [ "$BODY_STREAM" = "1" ]; then
+  ASYNC_HANDLER=1
+  HANDLER_IMPORT_DECL="import handler: async func(method: string, url: string, headers: string, body: stream<u8>) -> string;"
+  # `req_body_rx` goes straight through -- no .collect().await anywhere.
+  HANDLER_CALL="handler(method, url, req_headers, req_body_rx).await"
+  # The collected body binding is unused in this mode, and Rust warns; bind it
+  # to the reader instead so there is exactly one place the body can come from.
+  BODY_BINDING="let req_body_rx = { let (rx, _trailers_rx) = Request::consume_body(request, result_rx); rx };"
+elif [ "$ASYNC_HANDLER" = "1" ]; then
   HANDLER_IMPORT_DECL="import handler: async func(method: string, url: string, headers: string, body: string) -> string;"
   # An async import owns its string params (String, not &str) and returns a
   # future.
@@ -36,6 +49,10 @@ if [ "$ASYNC_HANDLER" = "1" ]; then
 else
   HANDLER_IMPORT_DECL="import handler: func(method: string, url: string, headers: string, body: string) -> string;"
   HANDLER_CALL="handler(&method, &url, &req_headers, &req_body)"
+fi
+if [ "$BODY_STREAM" != "1" ]; then
+  BODY_BINDING="let (req_body_rx, _trailers_rx) = Request::consume_body(request, result_rx);
+        let req_body = String::from_utf8_lossy(&req_body_rx.collect().await).into_owned();"
 fi
 TMP_DIR="$(mktemp -d /tmp/vibe_http_p3_full_adapter.XXXXXX)"
 
@@ -133,8 +150,7 @@ impl Guest for Component {
             .join("\n");
 
         let (_, result_rx) = wit_future::new::<Result<(), ErrorCode>>(|| Ok(()));
-        let (req_body_rx, _trailers_rx) = Request::consume_body(request, result_rx);
-        let req_body = String::from_utf8_lossy(&req_body_rx.collect().await).into_owned();
+        $BODY_BINDING
 
         // The vibe handler returns "STATUS\n<headers>\n\n<body>" (headers optional).
         let raw = $HANDLER_CALL;

--- a/scripts/test_serve_body_stream_gate.sh
+++ b/scripts/test_serve_body_stream_gate.sh
@@ -26,10 +26,17 @@ set -euo pipefail
 #               (the same trap #1860's review found in the probe gate).
 #   empty       a zero-length body ends the stream immediately: the reader
 #               must see end-of-stream on its FIRST read, not hang.
-#   isolation   two requests in flight at once each get their OWN body back.
-#               The adapter keeps per-handle state (the CLOSED latch), so a
-#               band shared between concurrent requests would show up here
-#               as one request seeing the other's bytes -- and nowhere else.
+#   isolation   two requests in flight at once each get their own body back.
+#
+# WHAT THIS GATE DOES NOT COVER, and why the line is here rather than in an
+# assertion (#1913): every request above delivers its body BUFFERED, so each
+# `stream.read` completes eagerly and the adapter's BLOCKED branch never runs.
+# A chunked upload that makes reads actually park, and a handler that stops
+# reading before end of stream, both trap in the guest today --
+# `uninitialized element` inside the injected `__hs_next`, which is main's CPS
+# lowering and not this adapter (the adapter has no tables). Both reproduce
+# against the committed emitter, so they are a pre-existing gap in the lane,
+# not something this gate can assert green. #1913 has the two reproductions.
 #
 # Skips cleanly when cargo / wasm-tools / wac / wasmtime / curl are missing,
 # and fails instead under VIBE_P3_GATE_REQUIRE_TOOLS=1, matching the other P3
@@ -115,59 +122,75 @@ export let handler = (method: String, url: String, headers: String, body: HostSt
 }
 HEOF
 
-COMPONENT="$OUT_DIR/handler.component.wasm"
-echo "[serve-body] componentize through the CLI's own serve path"
-rm -f "$COMPONENT" "$COMPONENT.diag"
-env VIBE_SERVE_COMPONENT=1 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw \
-  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main "$CLI_WASM" \
-  "${HANDLER_SRC#"$PROJECT_ROOT"/}" "${COMPONENT#"$PROJECT_ROOT"/}" main >/dev/null 2>&1 || true
-if [ ! -s "$COMPONENT" ]; then
-  echo "[serve-body] FAILED: the serve path produced no component" >&2
-  cat "$COMPONENT.diag" 2>/dev/null >&2 || true
-  exit 1
-fi
-wasm-tools validate --features all "$COMPONENT" >/dev/null
+# Componentize a handler through the CLI's own serve path, compose it, and
+# start serving it. Sets ADDR/SERVE_PID for the checks that follow.
+serve_handler() {
+  local tag="$1" src="$2"
+  local component="$OUT_DIR/$tag.component.wasm"
+  local composed="$OUT_DIR/$tag.serve.wasm"
+  SERVE_LOG="$OUT_DIR/$tag.serve.log"
+  rm -f "$component" "$component.diag"
+  env VIBE_SERVE_COMPONENT=1 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw \
+    bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main "$CLI_WASM" \
+    "${src#"$PROJECT_ROOT"/}" "${component#"$PROJECT_ROOT"/}" main >/dev/null 2>&1 || true
+  if [ ! -s "$component" ]; then
+    echo "[serve-body] FAILED: the serve path produced no component for $tag" >&2
+    cat "$component.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  wasm-tools validate --features all "$component" >/dev/null
 
-# The lane is identified by the exported functype, not by "it built": a
-# `stream<u8>` param and an async lift are what separate this from the String
-# handler the same CLI emits for a `body: String` signature. Checked on a
-# captured string rather than piped into `grep -q` -- grep exits on its first
-# match and `set -o pipefail` would report the SIGPIPE as a failed assertion.
-COMPONENT_WIT="$(wasm-tools component wit "$COMPONENT")"
-case "$COMPONENT_WIT" in
-  *'export handler: async func('*'body: stream<u8>'*) ;;
-  *)
-    echo "[serve-body] FAILED: the component does not export an async handler taking stream<u8>" >&2
-    printf '%s\n' "$COMPONENT_WIT" | head -20 >&2
-    exit 1 ;;
-esac
-echo "[serve-body] handler component: async func(.., body: stream<u8>) -> string"
+  # The lane is identified by the exported functype, not by "it built": a
+  # `stream<u8>` param and an async lift are what separate this from the String
+  # handler the same CLI emits for a `body: String` signature. Checked on a
+  # captured string rather than piped into `grep -q` -- grep exits on its first
+  # match and `set -o pipefail` would report the SIGPIPE as a failed assertion.
+  local wit
+  wit="$(wasm-tools component wit "$component")"
+  case "$wit" in
+    *'export handler: async func('*'stream<u8>'*) ;;
+    *)
+      echo "[serve-body] FAILED: $tag does not export an async handler taking stream<u8>" >&2
+      printf '%s\n' "$wit" | head -20 >&2
+      exit 1 ;;
+  esac
 
-COMPOSED="$OUT_DIR/handler.serve.wasm"
-wac plug --plug "$COMPONENT" "$ADAPTER" -o "$COMPOSED"
-wasm-tools validate --features all "$COMPOSED" >/dev/null
-echo "[serve-body] composed"
+  wac plug --plug "$component" "$ADAPTER" -o "$composed"
+  wasm-tools validate --features all "$composed" >/dev/null
 
-"$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$COMPOSED" >"$SERVE_LOG" 2>&1 &
-SERVE_PID=$!
-ready=0
-for _ in $(seq 1 40); do
-  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
-    echo "[serve-body] FAILED: wasmtime exited before accepting requests" >&2
+  ADDR="${ADDR%:*}:$((${ADDR##*:} + 1))"
+  "$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$composed" >"$SERVE_LOG" 2>&1 &
+  SERVE_PID=$!
+  local ready=0 _i
+  for _i in $(seq 1 40); do
+    if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+      echo "[serve-body] FAILED: wasmtime exited before accepting requests ($tag)" >&2
+      cat "$SERVE_LOG" >&2 || true
+      exit 1
+    fi
+    if curl -s -m 1 -o /dev/null "http://$ADDR/" 2>/dev/null; then
+      ready=1
+      break
+    fi
+    sleep 0.25
+  done
+  if [ "$ready" != "1" ]; then
+    echo "[serve-body] FAILED: wasmtime did not become ready at $ADDR ($tag)" >&2
     cat "$SERVE_LOG" >&2 || true
     exit 1
   fi
-  if curl -s -m 1 -o /dev/null "http://$ADDR/" 2>/dev/null; then
-    ready=1
-    break
+}
+
+stop_server() {
+  if [ -n "$SERVE_PID" ]; then
+    kill "$SERVE_PID" 2>/dev/null || true
+    wait "$SERVE_PID" 2>/dev/null || true
+    SERVE_PID=""
   fi
-  sleep 0.25
-done
-if [ "$ready" != "1" ]; then
-  echo "[serve-body] FAILED: wasmtime did not become ready at $ADDR" >&2
-  cat "$SERVE_LOG" >&2 || true
-  exit 1
-fi
+}
+
+serve_handler echo "$HANDLER_SRC"
+echo "[serve-body] echo handler: async func(.., body: stream<u8>) -> string, composed and serving"
 
 # The adapter answers "STATUS\n<headers>\n\n<body>" and falls back to the whole
 # remainder when there is no header block, so the wire body is a leading "\n"
@@ -220,9 +243,11 @@ echo "[serve-body] a $(wc -c <"$OUT_DIR/large.bin")-byte body echoes byte-for-by
 post_and_compare empty "$OUT_DIR/empty.bin"
 echo "[serve-body] an empty body ends the stream on the first read"
 
-# Concurrency: two bodies in flight at once must not see each other. The
-# adapter's CLOSED latch is indexed by handle, so a lane that shared one slot
-# would answer here and pass every sequential check above.
+# Concurrency, buffered. This proves the per-request handle plumbing keeps two
+# in-flight requests apart; it does NOT prove the adapter's per-handle bands,
+# because buffered reads complete eagerly and the two requests are never parked
+# at the same time. The version of this check that DOES exercise that -- two
+# slow chunked uploads -- is blocked on #1913.
 printf 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' >"$OUT_DIR/conc-a.bin"
 printf 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' >"$OUT_DIR/conc-b.bin"
 conc_pids=()
@@ -246,10 +271,54 @@ for n in a b; do
     exit 1
   fi
 done
-echo "[serve-body] two concurrent requests each echo their own body"
+echo "[serve-body] two concurrent buffered requests each echo their own body"
 
-kill "$SERVE_PID" 2>/dev/null || true
-wait "$SERVE_PID" 2>/dev/null || true
-SERVE_PID=""
+stop_server
+
+# The other half of the adapter's surface, checked where it can be checked:
+# COMPOSITION. `host_stream_close` lowers to a `vibe.host_stream_close` core
+# import, and a core instance cannot be given fewer bindings than it imports --
+# so before the adapter exported both halves, a handler that stops reading
+# early could not be composed at all. Emitting the component and plugging it is
+# what proves that edge is satisfied; actually SERVING such a handler is
+# blocked on #1913, which is why this stops at the plug.
+CLOSE_SRC="$OUT_DIR/close_handler.vibe"
+cat >"$CLOSE_SRC" <<'HEOF'
+export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {
+  let mut out = ""
+  let mut n = 0
+  while n < 4 {
+    let b = host_stream_next(body)
+    if b < 0 {
+      n = 4
+    } else {
+      out = String::concat(out, String::from_char_code(b))
+      n = n + 1
+    }
+  }
+  host_stream_close(body)
+  "200\n\n\{out}"
+}
+HEOF
+CLOSE_COMPONENT="$OUT_DIR/close.component.wasm"
+rm -f "$CLOSE_COMPONENT" "$CLOSE_COMPONENT.diag"
+env VIBE_SERVE_COMPONENT=1 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main "$CLI_WASM" \
+  "${CLOSE_SRC#"$PROJECT_ROOT"/}" "${CLOSE_COMPONENT#"$PROJECT_ROOT"/}" main >/dev/null 2>&1 || true
+if [ ! -s "$CLOSE_COMPONENT" ]; then
+  echo "[serve-body] FAILED: an early-closing handler did not componentize" >&2
+  cat "$CLOSE_COMPONENT.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+CLOSE_CORE_WIT="$(wasm-tools print "$CLOSE_COMPONENT")"
+case "$CLOSE_CORE_WIT" in
+  *'(import "vibe" "host_stream_close"'*) ;;
+  *)
+    echo "[serve-body] FAILED: the early-closing handler's core does not import vibe.host_stream_close" >&2
+    exit 1 ;;
+esac
+wac plug --plug "$CLOSE_COMPONENT" "$ADAPTER" -o "$OUT_DIR/close.serve.wasm"
+wasm-tools validate --features all "$OUT_DIR/close.serve.wasm" >/dev/null
+echo "[serve-body] a handler that closes the body early composes (both adapter halves bound)"
 
 echo "[serve-body] PASS: vibe serve hands the request body to the handler as a stream (#1540)"

--- a/scripts/test_serve_body_stream_gate.sh
+++ b/scripts/test_serve_body_stream_gate.sh
@@ -29,14 +29,14 @@ set -euo pipefail
 #   isolation   two requests in flight at once each get their own body back.
 #
 # WHAT THIS GATE DOES NOT COVER, and why the line is here rather than in an
-# assertion (#1913): every request above delivers its body BUFFERED, so each
+# assertion (#1924): every request above delivers its body BUFFERED, so each
 # `stream.read` completes eagerly and the adapter's BLOCKED branch never runs.
 # A chunked upload that makes reads actually park, and a handler that stops
 # reading before end of stream, both trap in the guest today --
 # `uninitialized element` inside the injected `__hs_next`, which is main's CPS
 # lowering and not this adapter (the adapter has no tables). Both reproduce
 # against the committed emitter, so they are a pre-existing gap in the lane,
-# not something this gate can assert green. #1913 has the two reproductions.
+# not something this gate can assert green. #1924 has the two reproductions.
 #
 # Skips cleanly when cargo / wasm-tools / wac / wasmtime / curl are missing,
 # and fails instead under VIBE_P3_GATE_REQUIRE_TOOLS=1, matching the other P3
@@ -247,7 +247,7 @@ echo "[serve-body] an empty body ends the stream on the first read"
 # in-flight requests apart; it does NOT prove the adapter's per-handle bands,
 # because buffered reads complete eagerly and the two requests are never parked
 # at the same time. The version of this check that DOES exercise that -- two
-# slow chunked uploads -- is blocked on #1913.
+# slow chunked uploads -- is blocked on #1924.
 printf 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' >"$OUT_DIR/conc-a.bin"
 printf 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' >"$OUT_DIR/conc-b.bin"
 conc_pids=()
@@ -281,7 +281,7 @@ stop_server
 # so before the adapter exported both halves, a handler that stops reading
 # early could not be composed at all. Emitting the component and plugging it is
 # what proves that edge is satisfied; actually SERVING such a handler is
-# blocked on #1913, which is why this stops at the plug.
+# blocked on #1924, which is why this stops at the plug.
 CLOSE_SRC="$OUT_DIR/close_handler.vibe"
 cat >"$CLOSE_SRC" <<'HEOF'
 export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {

--- a/scripts/test_serve_body_stream_gate.sh
+++ b/scripts/test_serve_body_stream_gate.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# #1540 scope 4: does `vibe serve` hand the REQUEST BODY to the handler as a
+# stream it reads itself?
+#
+# This is the end of the issue. The sibling gates each proved one piece --
+# test_serve_async_lift_gate.sh that a handler component can be async-lifted
+# and still serve, test_http_body_read_probe_gate.sh that an emitted guest can
+# drive `stream.read` to end of stream -- and this one is the join, through the
+# CLI's own serve path rather than a hand-assembled emitter call:
+#
+#   handler.vibe (body: HostStream, with Async)
+#     -> validate_serve_handler accepts the shape
+#     -> serve_handler_takes_body_stream picks the lane
+#     -> comp_emit_component_wasm_stream_handler
+#     -> wac plug with an adapter whose `handler` import takes stream<u8>
+#     -> wasmtime serve; curl asserts what came back
+#
+# The assertions are about BYTES, not about "it answered 200":
+#
+#   echo        a 300+ byte body comes back byte-for-byte, compared with
+#               `cmp` on files. Substring or shell-string comparison is not
+#               enough -- command substitution drops NUL bytes and trailing
+#               newlines, so a body one byte too long can compare EQUAL
+#               (the same trap #1860's review found in the probe gate).
+#   empty       a zero-length body ends the stream immediately: the reader
+#               must see end-of-stream on its FIRST read, not hang.
+#   isolation   two requests in flight at once each get their OWN body back.
+#               The adapter keeps per-handle state (the CLOSED latch), so a
+#               band shared between concurrent requests would show up here
+#               as one request seeing the other's bytes -- and nowhere else.
+#
+# Skips cleanly when cargo / wasm-tools / wac / wasmtime / curl are missing,
+# and fails instead under VIBE_P3_GATE_REQUIRE_TOOLS=1, matching the other P3
+# gates.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+OUT_DIR="$PROJECT_ROOT/_build/bench/serve_body_stream/run-$$"
+SERVE_LOG="$OUT_DIR/serve.log"
+PORT=$((24000 + ($$ % 16000)))
+ADDR="${VIBE_SERVE_BODY_GATE_ADDR:-127.0.0.1:$PORT}"
+
+if [ -n "${VIBE_HTTP_GATE_WASMTIME_FLAGS:-}" ]; then
+  read -r -a WASM_FLAGS <<<"$VIBE_HTTP_GATE_WASMTIME_FLAGS"
+else
+  WASM_FLAGS=(-Sp3 -Shttp -W exceptions=y -W concurrency-support=y -W component-model-async=y -W component-model-async-stackful=y)
+fi
+
+missing_tool() {
+  if [ "${VIBE_P3_GATE_REQUIRE_TOOLS:-0}" = "1" ]; then
+    echo "[serve-body] FAILED: $1 not found (required mode)" >&2; exit 1
+  fi
+  echo "[serve-body] SKIP: $1 not found"; exit 0
+}
+for c in cargo wasm-tools wac curl cmp; do
+  command -v "$c" >/dev/null 2>&1 || missing_tool "$c"
+done
+WASMTIME_BIN="$("$PROJECT_ROOT/scripts/wasmtime_bin.sh" 2>/dev/null || command -v wasmtime || true)"
+if [ -z "${WASMTIME_BIN:-}" ] || ! "$WASMTIME_BIN" --version >/dev/null 2>&1; then
+  missing_tool "wasmtime"
+fi
+
+CLI_WASM="${VIBE_SERVE_CLI_WASM:-${VIBE_ASYNC_GATE_COMPILER:-}}"
+if [ -z "$CLI_WASM" ]; then
+  CLI_WASM="$(ls -t "$PROJECT_ROOT"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -1 || true)"
+fi
+if [ -z "$CLI_WASM" ] || [ ! -s "$CLI_WASM" ]; then
+  missing_tool "a stage2 compiler"
+fi
+
+rm -rf "$OUT_DIR"; mkdir -p "$OUT_DIR"
+SERVE_PID=""
+cleanup() {
+  if [ -n "$SERVE_PID" ]; then
+    kill "$SERVE_PID" 2>/dev/null || true
+    wait "$SERVE_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "[serve-body] selfhost cli: $CLI_WASM"
+
+ADAPTER="$OUT_DIR/adapter.component.wasm"
+echo "[serve-body] build the adapter with a stream<u8> body import"
+VIBE_HTTP_ADAPTER_BODY_STREAM=1 bash "$SCRIPT_DIR/build_wasi_http_p3_full_adapter.sh" "$ADAPTER" >/dev/null
+ADAPTER_WIT="$(wasm-tools component wit "$ADAPTER")"
+case "$ADAPTER_WIT" in
+  *'import handler: async func(method: string, url: string, headers: string, body: stream<u8>)'*) ;;
+  *)
+    echo "[serve-body] FAILED: the adapter's handler import does not take a stream<u8> body" >&2
+    printf '%s\n' "$ADAPTER_WIT" | head -12 >&2
+    exit 1 ;;
+esac
+echo "[serve-body] adapter: handler(.., body: stream<u8>) as an async func"
+
+# The handler echoes the body back a byte at a time. Nothing here says "read
+# the whole body first" -- `host_stream_next` is the only way in, and it
+# suspends, which is exactly what this lane exists to make possible.
+HANDLER_SRC="$OUT_DIR/echo_handler.vibe"
+cat >"$HANDLER_SRC" <<'HEOF'
+export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {
+  let mut out = ""
+  let mut go = true
+  while go {
+    let b = host_stream_next(body)
+    if b < 0 {
+      go = false
+    } else {
+      out = String::concat(out, String::from_char_code(b))
+    }
+  }
+  "200\n\n\{out}"
+}
+HEOF
+
+COMPONENT="$OUT_DIR/handler.component.wasm"
+echo "[serve-body] componentize through the CLI's own serve path"
+rm -f "$COMPONENT" "$COMPONENT.diag"
+env VIBE_SERVE_COMPONENT=1 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw \
+  bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main "$CLI_WASM" \
+  "${HANDLER_SRC#"$PROJECT_ROOT"/}" "${COMPONENT#"$PROJECT_ROOT"/}" main >/dev/null 2>&1 || true
+if [ ! -s "$COMPONENT" ]; then
+  echo "[serve-body] FAILED: the serve path produced no component" >&2
+  cat "$COMPONENT.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+wasm-tools validate --features all "$COMPONENT" >/dev/null
+
+# The lane is identified by the exported functype, not by "it built": a
+# `stream<u8>` param and an async lift are what separate this from the String
+# handler the same CLI emits for a `body: String` signature. Checked on a
+# captured string rather than piped into `grep -q` -- grep exits on its first
+# match and `set -o pipefail` would report the SIGPIPE as a failed assertion.
+COMPONENT_WIT="$(wasm-tools component wit "$COMPONENT")"
+case "$COMPONENT_WIT" in
+  *'export handler: async func('*'body: stream<u8>'*) ;;
+  *)
+    echo "[serve-body] FAILED: the component does not export an async handler taking stream<u8>" >&2
+    printf '%s\n' "$COMPONENT_WIT" | head -20 >&2
+    exit 1 ;;
+esac
+echo "[serve-body] handler component: async func(.., body: stream<u8>) -> string"
+
+COMPOSED="$OUT_DIR/handler.serve.wasm"
+wac plug --plug "$COMPONENT" "$ADAPTER" -o "$COMPOSED"
+wasm-tools validate --features all "$COMPOSED" >/dev/null
+echo "[serve-body] composed"
+
+"$WASMTIME_BIN" serve "${WASM_FLAGS[@]}" --addr "$ADDR" "$COMPOSED" >"$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+ready=0
+for _ in $(seq 1 40); do
+  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+    echo "[serve-body] FAILED: wasmtime exited before accepting requests" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if curl -s -m 1 -o /dev/null "http://$ADDR/" 2>/dev/null; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+if [ "$ready" != "1" ]; then
+  echo "[serve-body] FAILED: wasmtime did not become ready at $ADDR" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+
+# The adapter answers "STATUS\n<headers>\n\n<body>" and falls back to the whole
+# remainder when there is no header block, so the wire body is a leading "\n"
+# followed by what the handler echoed. Building the expected file the same way
+# keeps this a BYTE comparison of the echoed payload rather than a substring
+# test that would accept a truncated or duplicated body.
+post_and_compare() {
+  local what="$1" payload_file="$2"
+  local want="$OUT_DIR/want-$what.bin" got="$OUT_DIR/got-$what.bin" code
+  { printf '\n'; cat "$payload_file"; } >"$want"
+  code="$(curl -sS --max-time 20 -o "$got" -w '%{http_code}' -X POST \
+    --data-binary "@$payload_file" -H 'content-type: application/octet-stream' \
+    "http://$ADDR/echo" 2>&1 || true)"
+  if ! kill -0 "$SERVE_PID" 2>/dev/null; then
+    echo "[serve-body] FAILED: wasmtime exited while serving the $what request" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if [ "$code" != "200" ]; then
+    echo "[serve-body] FAILED: $what returned '$code' (want 200)" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if ! cmp -s "$want" "$got"; then
+    echo "[serve-body] FAILED: $what did not echo its body byte-for-byte" >&2
+    echo "  want $(wc -c <"$want") bytes, got $(wc -c <"$got") bytes" >&2
+    cmp "$want" "$got" >&2 || true
+    exit 1
+  fi
+}
+
+printf 'abc' >"$OUT_DIR/small.bin"
+post_and_compare small "$OUT_DIR/small.bin"
+echo "[serve-body] a 3-byte body echoes byte-for-byte"
+
+# Longer than any single read and long enough to span whatever chunking the
+# host producer chooses: the reader must keep parking and resuming until the
+# end, not stop at the first completion.
+python3 - "$OUT_DIR/large.bin" <<'PY'
+import sys
+# Every byte value the handler can echo through String::from_char_code, so a
+# lane that mangled the high half would not be hidden by an all-ASCII body.
+data = bytes(range(32, 127)) * 4 + b"-tail"
+open(sys.argv[1], "wb").write(data)
+PY
+post_and_compare large "$OUT_DIR/large.bin"
+echo "[serve-body] a $(wc -c <"$OUT_DIR/large.bin")-byte body echoes byte-for-byte"
+
+: >"$OUT_DIR/empty.bin"
+post_and_compare empty "$OUT_DIR/empty.bin"
+echo "[serve-body] an empty body ends the stream on the first read"
+
+# Concurrency: two bodies in flight at once must not see each other. The
+# adapter's CLOSED latch is indexed by handle, so a lane that shared one slot
+# would answer here and pass every sequential check above.
+printf 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' >"$OUT_DIR/conc-a.bin"
+printf 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' >"$OUT_DIR/conc-b.bin"
+conc_pids=()
+for n in a b; do
+  { printf '\n'; cat "$OUT_DIR/conc-$n.bin"; } >"$OUT_DIR/want-conc-$n.bin"
+  curl -sS --max-time 20 -o "$OUT_DIR/got-conc-$n.bin" -X POST \
+    --data-binary "@$OUT_DIR/conc-$n.bin" "http://$ADDR/echo" &
+  conc_pids+=("$!")
+done
+# Wait on the CURLS by pid, never a bare `wait`: wasmtime is a background child
+# of this script too, so `wait` with no argument would block until the server
+# exits -- which it never does on its own.
+for pid in "${conc_pids[@]}"; do
+  wait "$pid" || true
+done
+for n in a b; do
+  if ! cmp -s "$OUT_DIR/want-conc-$n.bin" "$OUT_DIR/got-conc-$n.bin"; then
+    echo "[serve-body] FAILED: concurrent request $n did not get its own body back" >&2
+    cmp "$OUT_DIR/want-conc-$n.bin" "$OUT_DIR/got-conc-$n.bin" >&2 || true
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+done
+echo "[serve-body] two concurrent requests each echo their own body"
+
+kill "$SERVE_PID" 2>/dev/null || true
+wait "$SERVE_PID" 2>/dev/null || true
+SERVE_PID=""
+
+echo "[serve-body] PASS: vibe serve hands the request body to the handler as a stream (#1540)"

--- a/scripts/test_wasi_p3_guarantee_gate.sh
+++ b/scripts/test_wasi_p3_guarantee_gate.sh
@@ -77,6 +77,7 @@ case ",$PHASES," in *",http,"*)
   bash "$SCRIPT_DIR/test_http_body_stream_probe_gate.sh"
   bash "$SCRIPT_DIR/test_http_body_read_probe_gate.sh"
   bash "$SCRIPT_DIR/test_serve_async_lift_gate.sh"
+  bash "$SCRIPT_DIR/test_serve_body_stream_gate.sh"
   bash "$SCRIPT_DIR/test_async_string_lift_probe_gate.sh"
   ;;
 esac


### PR DESCRIPTION
#1540 の着地。handler の最後の引数が `HostStream` なら、body を**届いた端から**読む — adapter が集め終えた String を受け取るのではなく。

```vibe
export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {
  let mut out = ""
  let mut go = true
  while go {
    let b = host_stream_next(body)
    if b < 0 { go = false } else { out = String::concat(out, String::from_char_code(b)) }
  }
  "200\n\n\{out}"
}
```

## 実装

| 追加 | 役割 |
|---|---|
| `comp_generate_serve_stream_adapter_module` | 名前を 1 つも持たない `vibe.host_stream_read` / `host_stream_close` 実装。read ループは §3.18 の実測どおり (BLOCKED / STREAM_READ = 2 / unjoin してから set drop / 終端 2 形状 + per-handle closed latch)。read slot・wait payload・latch の 3 帯すべて handle で index する |
| `comp_emit_component_wasm_stream_handler` | memory 2 面 — canon は memhost ページ、`task.return` と lift はメインメモリ。vibe ヒープに固定番地を書くと、プログラムがそこに置いていたものを壊す |
| `wit_type_text` / `validate_serve_handler` / `serve_handler_takes_body_stream` | フロントエンド。`HostStream` → `stream<u8>`、契約の受理、レーン選択 |
| `runtime/vibe serve` | WIT sidecar の `export handler:` 行を読んで適合する adapter を選ぶ |
| `VIBE_HTTP_ADAPTER_BODY_STREAM=1` | `handler(.., body: stream<u8>)` を import する Rust adapter (`.collect().await` はどこにも無い) |

既存の `comp_generate_hostfuture_adapter_core_module` を流用しないのは、あちらの index 配置が named future/stream 数から導出されていて「名前ゼロ、それでも reader」を足すと他 4 レーンの index が全部動くから。ダミー名を与えるのは #1796 が composition cycle として退けた `[async-lower]<label>` component import を戻すことになる。

## 一番時間を食ったバグ: `vibe.*` の Int ABI は「常に tagged」ではない

最初に serve まで通したとき、trap ではなく**黙って誤る**方が出た:

```
POST "abc" -> n=3 sum=588     # 期待は 294 = 97+98+99。ちょうど 2 倍
```

- §3.13/§3.18 の「i64 値は guest-tagged on the wire (adapter が shift する)」は、named host stream レーンの core が **CLI の RC compile** (`enable_rc` on、tag_mode 1 = `value << 1`) で出ているから成り立っていた
- `vibe serve` の core は `compile_wasi_module_no_dce_impl` (`enable_rc` **off**) なので Int は素の i64

**1 つの import 名 `vibe.host_stream_read` に、compile mode 由来の 2 つの値表現がある。** 混同しても trap しない — 読んだ byte が黙って 2 倍になるだけ。serve レーンの trampoline と adapter を両方 untagged に揃えた。この落とし穴は `docs/spec/wasi-p3-async.md` §3.18.4 に、それまで逆のことを言っていた文の隣に書いた。

## レーンは core から判別できない (実測)

4 string の handler と 3 string + stream の handler は、**どちらも core func が i64 5 本**。arity guard では区別できない。だからレーンは handler の**ソース signature** から選び、compiled core を sniff することは一切しない。unit test にこの事実を固定してある (最初は「String 用 core は弾かれるはず」と書いて red になり、前提の方が間違っていた)。

## `with Async` と `body: HostStream` は両方向に必須

- Async だけ → await するものが無い
- HostStream だけ → read が suspend なので永久に読めない (引数が死ぬ)

それぞれ相手を名指しする診断で落ちる。「まだ配線されていない」arm は削除した。

## レビュー対応 (`1a4d813b1`)

Codex の指摘 4 件、すべて実在。

1. **read slot が handle 別でない (P1)** — `stream.read(h, addr, 1)` は `addr` を canon に登録して**から**ブロックするので、2 リクエストが 1 つの番地を 2 つの producer に渡していた。named adapter が自分の slot を帯にしているのと同じ理由。3 帯とも handle で index するようにした
2. **`host_stream_close` を export していない (P2)** — 早期に読むのをやめる handler は `vibe.host_stream_close` を core import に落とすので、read 半分しか export しない adapter では**そもそも合成できなかった**。両方を無条件に export する
3. **launcher が引数名を grep していた (P2)** — sidecar は handler 自身の引数名を保つので `request_body: HostStream` は `request-body: stream<u8>` と出て取り逃がし、逆に無関係な export の stream 引数に誤反応した。`export handler:` の行だけを見る
4. **新しい spec 節が日本語 (P1)** — English-first ルールに従い英訳

## 判明した既知の穴 (#1924) — このレビューが引き出したもの

1 番の指摘に応えて「本当に並行して park する」テスト (chunked の低速アップロード 2 本) を書いたところ、**指摘にも無く、この PR でも直っていない**ものが出た:

- **read が実際に park すると** guest が `uninitialized element` で trap する (`__hs_next` の中)
- **handler が end of stream まで読まずにやめると**、body が buffered でも同じ trap

どちらも adapter ではなく main の CPS lowering (adapter には table も `call_indirect` も無い)。**最初にコミットした emitter でも同じように再現する**ので、このレビュー対応による退行ではなくレーンの元からの穴。named host stream レーンの delayed path は同じコンパイラで park して通るので、park 一般の問題でもない。

落ちる gate を入れるのではなく、**gate は実際に真であることだけを assert し、カバーしていない範囲を明示して #1924 を指す**ようにした。concurrency チェックも正直な表示にした — buffered なリクエストが証明するのは per-request の handle 配線であって、per-handle の帯ではない。

## 検証

```
[serve-body] adapter: handler(.., body: stream<u8>) as an async func
[serve-body] componentize through the CLI's own serve path
[serve-body] handler component: async func(.., body: stream<u8>) -> string
[serve-body] a 3-byte body echoes byte-for-byte
[serve-body] a 385-byte body echoes byte-for-byte
[serve-body] an empty body ends the stream on the first read
[serve-body] two concurrent buffered requests each echo their own body
[serve-body] a handler that closes the body early composes (both adapter halves bound)
[serve-body] PASS
```

`scripts/test_serve_body_stream_gate.sh` (新規、p3 guarantee gate の phase B に配線)。status code ではなく**バイト**を見る — echo は `cmp` で**ファイル**比較 (command substitution は NUL と末尾改行を落とすので、shell 文字列比較だと 1 byte 多い body が等しく見える。#1860 のレビューが見つけたのと同じ罠)。

その他:

- `test_wasi_http_p3_full_gate.sh` (String レーン) / `test_serve_async_lift_gate.sh` (async lift) は変更なしで PASS 継続
- stage2 == stage3 fixpoint (レビュー対応後に再確認)
- `component_codegen_test.vibe` / `wit_gen_test.vibe` の新規テスト全て PASS
- `scripts/check_vibe_fmt.sh` clean

adapter の handle は named adapter と同じ 1023 で cap した — latch 帯は 1 page 内の `handle * 4 + base` なので、上限を黙って踏み越えるより落ちる方がいい。

## 関連

#1540、#1891 (このスライスの設計と経過)、#1924 (残る穴)、#1871、#1860、#1819、#1796