### PR TITLE
perf(lexer): scan long line comments with SIMD

### DIFF
--- a/bench/regression/baseline.json
+++ b/bench/regression/baseline.json
@@ -11,6 +11,10 @@
     "bytes_per_op": 160640,
     "ns_p50": 0
   },
+  "lexer_comment_bench.vibe": {
+    "bytes_per_op": 75456,
+    "ns_p50": 189584
+  },
   "lexer_string_bench.vibe": {
     "bytes_per_op": 125440,
     "ns_p50": 0

--- a/bench/regression/lexer_comment_bench.vibe
+++ b/bench/regression/lexer_comment_bench.vibe
@@ -1,0 +1,27 @@
+// Ratchets the line-comment hot path. Long ordinary runs cross many SIMD
+// chunks; short comments keep the scalar prefix representative of real code.
+import @vibe/parser {
+  lex
+}
+
+fn make_source() -> String {
+  let mut source = ""
+  let mut i = 0
+  while i < 32 {
+    source = source + "// abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789\nlet value = 123\n// short\n"
+    i = i + 1
+  }
+  source
+}
+
+let source = make_source()
+
+bench "lexer_comment_heavy" {
+  let mut total = 0
+  let mut i = 0
+  while i < 16 {
+    total = total + Array::length(lex(source))
+    i = i + 1
+  }
+  let _ = total
+}

--- a/docs/report/parser-simd-scan-2026-08-15.md
+++ b/docs/report/parser-simd-scan-2026-08-15.md
@@ -110,6 +110,13 @@ The isolated 1 KiB LF benchmark measured 42 ns p50 for the fused scanner and
 lanes. This roughly 41x primitive headroom is sufficient to proceed to the
 seed/integration phase; it is not yet a lexer-level result.
 
+After the seed bump, `skip_until_newline` keeps the first 16 comment bytes on
+the scalar path and hands longer runs to the fused scanner. A comment-heavy
+lexer workload improved from 252,708 ns to 189,584 ns p50 (about 25%) while
+remaining at 75,456 B/op. A short-comment control measured 66,792 ns on the
+scalar implementation and 65,917 ns after integration, with 30,464 B/op in
+both lanes, so the scalar prefix avoids a short-input regression.
+
 Do not start with a full classify/compress token tape. `Token` is still a rich
 enum and identifiers/string tokens materialize substrings, so making every
 punctuation position into a bitmap would add a second representation before

--- a/lib/@vibe/compiler/tests/lexer_test.vibe
+++ b/lib/@vibe/compiler/tests/lexer_test.vibe
@@ -719,6 +719,17 @@ test "lex_comment_before_code" {
   ]))
 }
 
+/// Pins the scalar/SIMD handoff around one full v128 chunk. The lexer remains
+/// byte-indexed, so a multibyte comment must stop at the same LF byte and an
+/// EOF-terminated comment must not invent a newline token.
+test "lex_long_line_comments_preserve_boundaries" {
+  inspect(nth_token_name("// 0123456789abcde\nlet x = 1", 0), "TLet")
+  inspect(nth_token_name("// 0123456789abcdef\nlet x = 1", 0), "TLet")
+  inspect(nth_token_name("// 0123456789abcdef0123456789abcdef\n42", 0), "TInt(42)")
+  inspect(nth_token_name("// 日本語0123456789abcdef\nvalue", 0), "TIdent(value)")
+  inspect(nth_token_name("// 0123456789abcdef0123456789abcdef", 0), "TEof")
+}
+
 test "lex_alias_identifier" {
   assert(lex_match("@mymod", [
     TIdent("@mymod"),

--- a/lib/@vibe/parser/lexer.vibe
+++ b/lib/@vibe/parser/lexer.vibe
@@ -639,7 +639,9 @@ fn join_doc_lines(lines: Array[String]) -> String {
 fn skip_until_newline(s: String, len: Int, i: Int) -> Int {
   let mut out = i
   let mut done = false
-  while out < len && !done {
+  // Most source comments are short. Keep one SIMD chunk scalar so they avoid
+  // the builtin-call/setup cost; long ordinary runs hand off at byte 16.
+  while out < len && out - i < 16 && !done {
     if String::char_code_at(s, out) == '\n' {
       out = out + 1
       done = true
@@ -647,7 +649,16 @@ fn skip_until_newline(s: String, len: Int, i: Int) -> Int {
       out = out + 1
     }
   }
-  out
+  if done || out >= len {
+    out
+  } else {
+    let line_end = simd_scan_line_end_str(s, out, len)
+    if line_end < len {
+      line_end + 1
+    } else {
+      len
+    }
+  }
 }
 
 /// Pack `(next_offset, saw_newline)` into one tagged Int. This is on every

--- a/scripts/bench_regression.mjs
+++ b/scripts/bench_regression.mjs
@@ -33,7 +33,7 @@ const ITERS = process.env.BENCH_ITERS || "300";
 const update = process.argv.includes("--update");
 
 // The fixture set the gate covers (must run cleanly on the linear backend).
-const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe", "lexer_keyword_bench.vibe", "lexer_string_bench.vibe", "parser_empty_metadata_bench.vibe", "parser_query_bench.vibe"];
+const FIXTURES = ["pure_bench.vibe", "alloc_bench.vibe", "lexer_keyword_bench.vibe", "lexer_string_bench.vibe", "lexer_comment_bench.vibe", "parser_empty_metadata_bench.vibe", "parser_query_bench.vibe"];
 
 function runBench(file) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- keep the first 16 comment bytes scalar, then use simd_scan_line_end_str for long ordinary runs
- pin 15/16/32-byte, UTF-8, LF, and EOF semantics with inspect snapshots
- add a deterministic allocation regression fixture and record the A/B result

## Performance
- comment-heavy p50: 252,708 ns -> 189,584 ns (~25% faster)
- comment-heavy allocation: 75,456 B/op -> 75,456 B/op
- short-comment control p50: 66,792 ns -> 65,917 ns
- short-comment allocation: 30,464 B/op -> 30,464 B/op

## Validation
- fresh stage2 == stage3
- lexer focused: 91 tests Green
- affected: 205/205 Green
- 7 benchmark allocation gates Green
- precommit/fmt/generated freshness/diff checks Green

Closes #1902