### PR TITLE
fix(allocs): match lambda allocation lowering

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -7,6 +7,7 @@ import @vibe/compiler/core {
   TypeExpr,
   bsearch_leftmost,
   builtin_allocates,
+  builtin_registry,
   bytebuf_push,
   canonical_builtin_name,
   is_exception_throw_operation,
@@ -1142,6 +1143,21 @@ export fn collect_free_vars_indexed_self(body: Expr, param_names: Array[String],
   }
 }
 
+/// True exactly when codegen's lambda lowering needs a heap environment.
+/// Keep allocation queries on this API instead of reimplementing capture
+/// rules: globals, let-rec self references, and enclosing-name shadowing are
+/// deliberately the same inputs compile_lambda uses.
+export fn lambda_has_captures(body: Expr, params: Array[(String, Option[TypeExpr])], fn_name_index: Array[String], self_name: String, encl: Array[String]) -> Bool {
+  let param_names = common_analysis_fresh_string_array()
+  let mut i = 0
+  while i < Array::length(params) {
+    let (name, _) = Array::get(params, i)
+    Array::push(param_names, name)
+    i = i + 1
+  }
+  Array::length(collect_free_vars_indexed_self(body, param_names, fn_name_index, self_name, encl)) > 0
+}
+
 /// The root identifier of a projection chain (EDot(...EDot(EIdent(root))...)), or
 /// "" if `e` is not a projection. (ADR-0055 Stage 4: shared with compile_expr_tail
 /// so function-tail param drops can detect an escaping projection of a param.)
@@ -2072,6 +2088,23 @@ fn typed_alloc_copy_strings(items: Array[String]) -> Array[String] {
   Array::slice(items, 0, Array::length(items))
 }
 
+fn za_lambda_global_index(fn_names: Array[String], ctors: Array[String]) -> Array[String] {
+  let names = typed_alloc_copy_strings(fn_names)
+  let mut ci = 0
+  while ci < Array::length(ctors) {
+    Array::push(names, Array::get(ctors, ci))
+    ci = ci + 1
+  }
+  let registry = builtin_registry()
+  let mut bi = 0
+  while bi < Array::length(registry) {
+    let (name, _, _, _, _) = Array::get(registry, bi)
+    Array::push(names, name)
+    bi = bi + 1
+  }
+  sorted_names_of(names)
+}
+
 /// Classify source operators whose statically evident overload allocates on
 /// the linear backend. Lexical type facts survive package linking without
 /// relying on file-local offsets. Unknown arithmetic is conservatively
@@ -2142,7 +2175,11 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
     ERecord(_, _, _) => "record/struct literal",
     EMap(_) => "map literal",
     EStringInterp(_) => "string interpolation",
-    EFn(_, _, _, _, _, _) => "closure literal (allocates its environment)",
+    EFn(_, _, params, _, _, body) => if lambda_has_captures(body, params, za_lambda_global_index(fn_names, ctors), "", bound) {
+      "closure literal (allocates its environment)"
+    } else {
+      ""
+    },
     EIf(zc, zt, zf) => za_first(za_walk(zc, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_first(za_walk(zt, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst), za_walk(zf, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst))),
     ELet(zl_name, zv, zb, _) => {
       let value_result = za_walk(zv, ctors, fn_names, fn_bodies, fn_params, visited, bound, typed_table, typed_subst)

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -39,6 +39,7 @@ fn collect_free_vars(body: Expr, param_names: Array[String], fn_names: Array[Str
 fn collect_free_vars_indexed(body: Expr, param_names: Array[String], fn_name_index: Array[String]) -> Array[String]
 fn collect_free_vars_used_builtins(body: Expr, param_names: Array[String], fn_name_index: Array[String]) -> Array[String]
 fn collect_free_vars_indexed_self(body: Expr, param_names: Array[String], fn_name_index: Array[String], self_name: String, encl: Array[String]) -> Array[String]
+fn lambda_has_captures(body: Expr, params: Array[(String, Option[TypeExpr])], fn_name_index: Array[String], self_name: String, encl: Array[String]) -> Bool
 fn proj_root_ident(e: Expr) -> String
 fn scope_tail_proj_root(e: Expr) -> String
 fn is_mut_captured_in(expr: Expr, name: String) -> Bool

--- a/lib/@vibe/compiler/runtime/alloc_spans.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans.vibe
@@ -35,7 +35,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Stmt, TypeExpr, builtin_allocates, expr_children
+  Expr, Pat, Stmt, TypeExpr, builtin_allocates, builtin_registry, expr_children, sorted_names_of
 }
 
 import @vibe/core {
@@ -47,7 +47,7 @@ import @vibe/compiler/syntax {
 }
 
 import @vibe/compiler/codegen/common_analysis {
-  is_mut_captured_in, typed_operator_alloc_kind
+  is_mut_captured_in, lambda_has_captures, typed_operator_alloc_kind
 }
 
 //# Functions
@@ -62,6 +62,8 @@ fn alloc_empty_strings() -> Array[String] {
 
 struct AllocWalkContext {
   ctors: Array[String];
+  global_index: Array[String];
+  lambda_counter: Array[Int];
   names: Array[String];
   kinds: Array[String]
 }
@@ -77,9 +79,7 @@ fn alloc_annotation_kind(annotation: Option[TypeExpr]) -> String {
   }
 }
 
-fn alloc_context(ctors: Array[String], params: Array[(String, Option[TypeExpr])]) -> AllocWalkContext {
-  let names = alloc_empty_strings()
-  let kinds = alloc_empty_strings()
+fn alloc_add_params(names: Array[String], kinds: Array[String], params: Array[(String, Option[TypeExpr])]) -> Unit {
   let mut i = 0
   while i < Array::length(params) {
     let (raw_name, annotation) = Array::get(params, i)
@@ -93,8 +93,31 @@ fn alloc_context(ctors: Array[String], params: Array[(String, Option[TypeExpr])]
     Array::push(kinds, alloc_annotation_kind(annotation))
     i = i + 1
   }
+}
+
+fn alloc_context(ctors: Array[String], global_index: Array[String], params: Array[(String, Option[TypeExpr])]) -> AllocWalkContext {
+  let names = alloc_empty_strings()
+  let kinds = alloc_empty_strings()
+  alloc_add_params(names, kinds, params)
   AllocWalkContext::{
     ctors: ctors,
+    global_index: global_index,
+    lambda_counter: [
+      0
+    ],
+    names: names,
+    kinds: kinds
+  }
+}
+
+fn alloc_context_for_lambda(ctx: AllocWalkContext, params: Array[(String, Option[TypeExpr])]) -> AllocWalkContext {
+  let names = Array::slice(ctx.names, 0, Array::length(ctx.names))
+  let kinds = Array::slice(ctx.kinds, 0, Array::length(ctx.kinds))
+  alloc_add_params(names, kinds, params)
+  AllocWalkContext::{
+    ctors: ctx.ctors,
+    global_index: ctx.global_index,
+    lambda_counter: ctx.lambda_counter,
     names: names,
     kinds: kinds
   }
@@ -142,8 +165,50 @@ fn alloc_context_with_binding(ctx: AllocWalkContext, name: String, value: Expr) 
   Array::push(kinds, alloc_expr_kind(value, ctx))
   AllocWalkContext::{
     ctors: ctx.ctors,
+    global_index: ctx.global_index,
+    lambda_counter: ctx.lambda_counter,
     names: names,
     kinds: kinds
+  }
+}
+
+fn alloc_context_with_name(ctx: AllocWalkContext, name: String) -> AllocWalkContext {
+  alloc_context_with_binding(ctx, name, EUnit)
+}
+
+fn alloc_context_with_pattern(ctx: AllocWalkContext, pat: Pat) -> AllocWalkContext {
+  match pat {
+    PBind(name) => alloc_context_with_name(ctx, name),
+    PCtor(_, args) => {
+      let mut out = ctx
+      let mut i = 0
+      while i < Array::length(args) {
+        out = alloc_context_with_pattern(out, Array::get(args, i))
+        i = i + 1
+      }
+      out
+    },
+    PTuple(items) => {
+      let mut out = ctx
+      let mut i = 0
+      while i < Array::length(items) {
+        out = alloc_context_with_pattern(out, Array::get(items, i))
+        i = i + 1
+      }
+      out
+    },
+    POr(left, _) => alloc_context_with_pattern(ctx, left),
+    PStruct(_, fields) => {
+      let mut out = ctx
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (_, field_pat) = Array::get(fields, i)
+        out = alloc_context_with_pattern(out, field_pat)
+        i = i + 1
+      }
+      out
+    },
+    _ => ctx
   }
 }
 
@@ -222,7 +287,6 @@ fn alloc_site_kind(expr: Expr, ctx: AllocWalkContext) -> String {
       } else {
         ""
       },
-      EFn(_, _, _, _, _, _) => "closure",
       EArray(_) => "array",
       ETuple(_) => "tuple",
       ERecord(_, _, _) => "record",
@@ -231,6 +295,36 @@ fn alloc_site_kind(expr: Expr, ctx: AllocWalkContext) -> String {
       EHandle(_, _) => "handler",
       _ => alloc_call_kind(expr, ctx.ctors)
     }
+  }
+}
+
+fn alloc_lambda_has_captures(expr: Expr, ctx: AllocWalkContext, self_name: String) -> Bool {
+  match expr {
+    EFn(_, _, params, _, _, body) => lambda_has_captures(body, params, ctx.global_index, self_name, ctx.names),
+    _ => false
+  }
+}
+
+fn alloc_lambda_owner(fname: String, hint: String, ordinal: Int) -> String {
+  if hint != "" {
+    String::concat(fname, String::concat("::", String::concat(alloc_encode_owner(hint), String::concat("@", __to_string(ordinal)))))
+  } else {
+    String::concat(fname, String::concat("::lambda@", __to_string(ordinal)))
+  }
+}
+
+fn alloc_walk_lambda(out: Array[(String, String, Int)], fname: String, expr: Expr, fn_off: Int, ctx: AllocWalkContext, self_name: String, owner_hint: String) -> Unit {
+  let here = alloc_site_offset(expr, fn_off)
+  let ordinal = Array::get(ctx.lambda_counter, 0)
+  Array::set(ctx.lambda_counter, 0, ordinal + 1)
+  if alloc_lambda_has_captures(expr, ctx, self_name) {
+    Array::push(out, (fname, "closure", here))
+  } else {
+    ()
+  }
+  match expr {
+    EFn(_, _, params, _, _, body) => alloc_walk_expr(out, alloc_lambda_owner(fname, owner_hint, ordinal), body, here, alloc_context_for_lambda(ctx, params)),
+    _ => ()
   }
 }
 
@@ -256,6 +350,13 @@ fn alloc_site_offset(expr: Expr, fallback: Int) -> Int {
 }
 
 fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr, fn_off: Int, ctx: AllocWalkContext) -> Unit {
+  match expr {
+    EFn(_, _, _, _, _, _) => alloc_walk_lambda(out, fname, expr, fn_off, ctx, "", ""),
+    _ => alloc_walk_non_lambda(out, fname, expr, fn_off, ctx)
+  }
+}
+
+fn alloc_walk_non_lambda(out: Array[(String, String, Int)], fname: String, expr: Expr, fn_off: Int, ctx: AllocWalkContext) -> Unit {
   let kind = alloc_site_kind(expr, ctx)
   if String::length(kind) > 0 {
     Array::push(out, (fname, kind, alloc_site_offset(expr, fn_off)))
@@ -283,17 +384,64 @@ fn alloc_walk_expr(out: Array[(String, String, Int)], fname: String, expr: Expr,
   let here = alloc_site_offset(expr, fn_off)
   match expr {
     ELet(name, value, rest, _) => {
-      alloc_walk_expr(out, fname, value, here, ctx)
+      match value {
+        EFn(_, _, _, _, _, _) => alloc_walk_lambda(out, fname, value, here, ctx, "", name),
+        _ => alloc_walk_expr(out, fname, value, here, ctx)
+      }
       alloc_walk_expr(out, fname, rest, here, alloc_context_with_binding(ctx, name, value))
     },
     ELetRec(name, value, rest) => {
       let body_ctx = alloc_context_with_binding(ctx, name, value)
-      alloc_walk_expr(out, fname, value, here, body_ctx)
+      match value {
+        EFn(_, _, _, _, _, _) => alloc_walk_lambda(out, fname, value, here, body_ctx, name, name),
+        _ => alloc_walk_expr(out, fname, value, here, body_ctx)
+      }
       alloc_walk_expr(out, fname, rest, here, body_ctx)
     },
     ELetMut(name, value, rest, _) => {
-      alloc_walk_expr(out, fname, value, here, ctx)
+      match value {
+        EFn(_, _, _, _, _, _) => alloc_walk_lambda(out, fname, value, here, ctx, "", name),
+        _ => alloc_walk_expr(out, fname, value, here, ctx)
+      }
       alloc_walk_expr(out, fname, rest, here, alloc_context_with_binding(ctx, name, value))
+    },
+    EMatch(scrutinee, arms) => {
+      alloc_walk_expr(out, fname, scrutinee, here, ctx)
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (pat, body) = Array::get(arms, i)
+        alloc_walk_expr(out, fname, body, here, alloc_context_with_pattern(ctx, pat))
+        i = i + 1
+      }
+    },
+    EHandle(scrutinee, arms) => {
+      alloc_walk_expr(out, fname, scrutinee, here, ctx)
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (pat, body) = Array::get(arms, i)
+        alloc_walk_expr(out, fname, body, here, alloc_context_with_pattern(ctx, pat))
+        i = i + 1
+      }
+    },
+    ELoop(params, body) => {
+      let mut body_ctx = ctx
+      let mut i = 0
+      while i < Array::length(params) {
+        let (name, init) = Array::get(params, i)
+        alloc_walk_expr(out, fname, init, here, ctx)
+        body_ctx = alloc_context_with_name(body_ctx, name)
+        i = i + 1
+      }
+      alloc_walk_expr(out, fname, body, here, body_ctx)
+    },
+    EForIn(name, index, iterable, body) => {
+      alloc_walk_expr(out, fname, iterable, here, ctx)
+      let item_ctx = alloc_context_with_name(ctx, name)
+      let body_ctx = match index {
+        Some(index_name) => alloc_context_with_name(item_ctx, index_name),
+        None => item_ctx
+      }
+      alloc_walk_expr(out, fname, body, here, body_ctx)
     },
     _ => {
       let kids = expr_children(expr)
@@ -358,6 +506,14 @@ export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Excep
   let (stmts, span_start, _span_end) = parse_program_spans(tokens, starts, ends)
   let out = alloc_empty_items()
   let ctors = alloc_empty_strings()
+  let globals = alloc_empty_strings()
+  let registry = builtin_registry()
+  let mut bi = 0
+  while bi < Array::length(registry) {
+    let (name, _, _, _, _) = Array::get(registry, bi)
+    Array::push(globals, name)
+    bi = bi + 1
+  }
   let mut ci = 0
   while ci < Array::length(stmts) {
     match Array::get(stmts, ci) {
@@ -366,6 +522,7 @@ export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Excep
         while vi < Array::length(variants) {
           let (vname, _) = Array::get(variants, vi)
           Array::push(ctors, vname)
+          Array::push(globals, vname)
           vi = vi + 1
         }
       },
@@ -374,14 +531,20 @@ export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Excep
         while vi < Array::length(variants) {
           let (vname, _) = Array::get(variants, vi)
           Array::push(ctors, vname)
+          Array::push(globals, vname)
           vi = vi + 1
         }
       },
-      SStruct(_, name, _, _, _, _) => Array::push(ctors, name),
+      SStruct(_, name, _, _, _, _) => {
+        Array::push(ctors, name)
+        Array::push(globals, name)
+      },
+      SLet(_, _, name, _, EFn(_, _, _, _, _, _)) => Array::push(globals, name),
       _ => ()
     }
     ci = ci + 1
   }
+  let global_index = sorted_names_of(globals)
   let mut i = 0
   while i < Array::length(stmts) {
     let stmt_off = if i < Array::length(span_start) {
@@ -391,15 +554,15 @@ export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Excep
     }
     match Array::get(stmts, i) {
       SLet(_, _, name, _, value) => match value {
-        EFn(_, _, params, _, _, fbody) => alloc_walk_expr(out, name, fbody, stmt_off, alloc_context(ctors, params)),
+        EFn(_, _, params, _, _, fbody) => alloc_walk_expr(out, name, fbody, stmt_off, alloc_context(ctors, global_index, params)),
         _ => ()
       },
       // Tests and benches lower to real executable functions. In particular,
       // a bytes-per-op regression asks about the bench body itself, so
       // skipping SBench would turn an allocating benchmark into false-clean
       // output. Keep the owner names identical to linked_compile's lowering.
-      STest(test_name, test_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__test_", test_name)), test_body, stmt_off, alloc_context(ctors, array_empty())),
-      SBench(bench_name, bench_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__bench_", bench_name)), bench_body, stmt_off, alloc_context(ctors, array_empty())),
+      STest(test_name, test_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__test_", test_name)), test_body, stmt_off, alloc_context(ctors, global_index, array_empty())),
+      SBench(bench_name, bench_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__bench_", bench_name)), bench_body, stmt_off, alloc_context(ctors, global_index, array_empty())),
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
@@ -55,6 +55,22 @@ fn count_kind(source: String, want: String) -> Int with Exception {
   count
 }
 
+fn has_owner_kind(source: String, owner: String, want: String) -> Bool with Exception {
+  let spans = alloc_spans(source)
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(spans) {
+    let (actual_owner, kind, _off) = Array::get(spans, i)
+    if actual_owner == owner && kind == want {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 fn fn_names_of(source: String) -> Array[String] with Exception {
   let spans = alloc_spans(source)
   let out = [
@@ -107,6 +123,38 @@ test "a closure literal allocates its environment" {
   // allocations ADR-0091 exists to surface.
   let src = "fn mk(n: Int) -> () -> Int {\n  () -> Int {\n    n\n  }\n}\n"
   assert(has_kind(src, "closure"))
+}
+
+test "a capture-free lambda is an immediate function value, not a closure allocation" {
+  let src = "fn mk() -> () -> Int {\n  () -> Int {\n    1\n  }\n}\n"
+  assert(!has_kind(src, "closure"))
+}
+
+test "a top-level function reference does not make a lambda capture" {
+  let src = "fn helper(n: Int) -> Int { n + 1 }\nfn mk() -> (Int) -> Int {\n  (n: Int) -> Int {\n    helper(n)\n  }\n}\n"
+  assert(!has_kind(src, "closure"))
+}
+
+test "a shadowed builtin function value still makes a lambda capture" {
+  let src = "fn mk(not: (Int) -> Int) -> () -> Int {\n  () -> Int {\n    not(1)\n  }\n}\n"
+  assert(has_kind(src, "closure"))
+}
+
+test "allocations inside a named local lambda belong to that lambda" {
+  let src = "fn mk() -> () -> Array[Int] {\n  let build = () -> Array[Int] {\n    [1, 2]\n  }\n  build\n}\n"
+  assert(!has_owner_kind(src, "mk", "array"))
+  assert(has_owner_kind(src, "mk::build@0", "array"))
+}
+
+test "a pattern binder shadows a same-named global for capture classification" {
+  let src = "enum Box { Box(Int) }\nfn helper(n: Int) -> Int { n + 1 }\nfn mk(x: Box) -> () -> Int {\n  match x {\n    Box(helper) => () -> Int { helper }\n  }\n}\n"
+  assert(has_kind(src, "closure"))
+}
+
+test "same-named lambdas in sibling scopes have distinct owners" {
+  let src = "fn mk(c: Bool) -> () -> Array[Int] {\n  if c {\n    let build = () -> Array[Int] { [1] }\n    build\n  } else {\n    let build = () -> Array[Int] { [2] }\n    build\n  }\n}\n"
+  assert(has_owner_kind(src, "mk::build@0", "array"))
+  assert(has_owner_kind(src, "mk::build@1", "array"))
 }
 
 test "a captured let mut is a heap ref cell, so the BINDING is a site" {

--- a/lib/@vibe/compiler/runtime/typed_operator_alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/typed_operator_alloc_spans_test.vibe
@@ -53,3 +53,18 @@ test "an unknown inner binding does not inherit a shadowed outer scalar kind" {
   let marked = String::concat("#zero_alloc\n", shadowed)
   assert(String::contains(zero_alloc_check(parse_program(lex(marked))), "operator:Double:+"))
 }
+
+test "zero_alloc accepts an immediate capture-free lambda value" {
+  let source = "#zero_alloc\nfn factory() -> () -> Int {\n  () -> Int { 1 }\n}\n"
+  assert_eq(zero_alloc_check(parse_program(lex(source))), "")
+}
+
+test "zero_alloc rejects a lambda that allocates a capture environment" {
+  let source = "#zero_alloc\nfn factory(n: Int) -> () -> Int {\n  () -> Int { n }\n}\n"
+  assert(String::contains(zero_alloc_check(parse_program(lex(source))), "closure literal"))
+}
+
+test "zero_alloc capture classification treats top-level functions as globals" {
+  let source = "fn helper(n: Int) -> Int { n + 1 }\n#zero_alloc\nfn factory() -> (Int) -> Int {\n  (n: Int) -> Int { helper(n) }\n}\n"
+  assert_eq(zero_alloc_check(parse_program(lex(source))), "")
+}


### PR DESCRIPTION
## Summary
- classify lambda allocation with the same free-variable analysis as codegen
- keep capture-free function values clean while reporting captured environments
- attribute nested lambda-body sites to a stable nested owner
- align `#zero_alloc` with the same capture contract

## Validation
- Red on main: capture-free lambda reported as `closure`; nested array attributed to outer fn
- `pkf run generation-gate` (stage2 == stage3)
- focused runtime allocation suites: 28 tests
- affected tests: 85/85
- `pkf run test-pre-commit`

Closes #1918