### PR TITLE
perf(codegen): compile discard-position for-in without the comprehension result array (#1916)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -244,6 +244,11 @@ fn inline_direct_performs(stmts: Array[Stmt]) -> Unit
 // --- evidence_dict_pass
 fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[String]
 
+// --- forin_discard_pass (#1916): wrap every discard-position `for` as
+// `ESeq(for .., EUnit)` so the linear ESeq lowering compiles it without the
+// comprehension result array. Runs at the end of effect_lowering_prelude.
+fn forin_discard_pass(stmts: Array[Stmt]) -> Unit
+
 // --- suspend_cps_pass (ADR-0076 Phase 3a, #817)
 fn suspend_cps_pass(stmts: Array[Stmt]) -> Array[String]
 

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -1349,7 +1349,11 @@ enum EdpReadQuery {
   RQLiteralNeeds((String, Array[String], Array[String], Int, Array[String]));
   RQTrigger;
   RQHandlesEffect(String);
-  RQNeedingValueArg(Array[String])
+  RQNeedingValueArg(Array[String]);
+  // #1916: does the tree contain any EForIn? Gates forin_discard_pass's
+  // per-statement rebuild without allocating (expr_children-based recursion
+  // allocates a children array per node, which defeats the pass's purpose).
+  RQContainsForIn
 }
 
 fn edp_rq_is_count(q: EdpReadQuery) -> Bool {
@@ -1679,6 +1683,10 @@ fn edp_rq_local(q: EdpReadQuery, e: Expr) -> Int {
       } else {
         0
       },
+      _ => 0
+    },
+    RQContainsForIn => match e {
+      EForIn(_, _, _, _) => 1,
       _ => 0
     },
     RQNeedingValueArg(names) => match e {
@@ -14647,19 +14655,7 @@ fn awp_rewrite_arms(arms: Array[(Pat, Expr)], ctr: Array[Int]) -> Array[(Pat, Ex
 /// EHandle stays untouched (conservative -- its arms/body feed the Error
 /// handler codegen).
 fn fdp_has_forin(e: Expr) -> Bool {
-  match e {
-    EForIn(_, _, _, _) => true,
-    _ => {
-      let kids = expr_children(e)
-      let mut i = 0
-      let mut found = false
-      while !found && i < Array::length(kids) {
-        found = fdp_has_forin(Array::get(kids, i))
-        i = i + 1
-      }
-      found
-    }
-  }
+  edp_rq_fold(RQContainsForIn, e) > 0
 }
 
 fn fdp_ret_is_unit(ret: Option[TypeExpr]) -> Bool {
@@ -14671,6 +14667,17 @@ fn fdp_ret_is_unit(ret: Option[TypeExpr]) -> Bool {
 }
 
 fn fdp_expr(e: Expr, discard: Bool) -> Expr {
+  // Subtrees without any `for` need no wraps: share them instead of
+  // rebuilding (the rebuild's own allocation would otherwise rival the
+  // churn this pass removes).
+  if !fdp_has_forin(e) {
+    e
+  } else {
+    fdp_expr_rebuild(e, discard)
+  }
+}
+
+fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
   match e {
     EForIn(nm, idx, it, b) => {
       let it2 = fdp_expr(it, false)

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -14677,6 +14677,66 @@ fn fdp_expr(e: Expr, discard: Bool) -> Expr {
   }
 }
 
+/// #1923 review (Codex P2): a function body is typically one deep
+/// right-nested let/seq spine, so per-node recursion re-scans the remaining
+/// tail at every level (O(N^2)) and risks the wasm call stack on generated
+/// code (the same hazard check_seq_spine exists for in the checker). Walk
+/// the spine iteratively: each head value is gated and processed exactly
+/// once, the non-spine tail once, and the nodes are folded back
+/// right-to-left.
+fn fdp_spine(root: Expr, discard: Bool) -> Expr {
+  let parts: Array[Expr] = [
+  ]
+  let mut cur = root
+  let mut walking = true
+  while walking {
+    match cur {
+      ESeq(_, b) => {
+        Array::push(parts, cur)
+        cur = b
+      },
+      ELet(_, _, b, _) => {
+        Array::push(parts, cur)
+        cur = b
+      },
+      ELetRec(_, _, b) => {
+        Array::push(parts, cur)
+        cur = b
+      },
+      ELetMut(_, _, b, _) => {
+        Array::push(parts, cur)
+        cur = b
+      },
+      EAssign(_, _, b) => {
+        Array::push(parts, cur)
+        cur = b
+      },
+      EAssignOp(_, _, _, b) => {
+        Array::push(parts, cur)
+        cur = b
+      },
+      _ => {
+        walking = false
+      }
+    }
+  }
+  let mut acc = fdp_expr(cur, discard)
+  let mut i = Array::length(parts) - 1
+  while i >= 0 {
+    acc = match Array::get(parts, i) {
+      ESeq(a, _) => ESeq(fdp_expr(a, true), acc),
+      ELet(n, v, _, off) => ELet(n, fdp_expr(v, false), acc, off),
+      ELetRec(n, v, _) => ELetRec(n, fdp_expr(v, false), acc),
+      ELetMut(n, v, _, off) => ELetMut(n, fdp_expr(v, false), acc, off),
+      EAssign(n, v, _) => EAssign(n, fdp_expr(v, false), acc),
+      EAssignOp(n, op, v, _) => EAssignOp(n, op, fdp_expr(v, false), acc),
+      _ => acc
+    }
+    i = i - 1
+  }
+  acc
+}
+
 fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
   match e {
     EForIn(nm, idx, it, b) => {
@@ -14689,15 +14749,16 @@ fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
         EForIn(nm, idx, it2, fdp_expr(b, false))
       }
     },
-    ESeq(a, b) => ESeq(fdp_expr(a, true), fdp_expr(b, discard)),
-    ELet(n, v, b, off) => ELet(n, fdp_expr(v, false), fdp_expr(b, discard), off),
-    ELetRec(n, v, b) => ELetRec(n, fdp_expr(v, false), fdp_expr(b, discard)),
-    ELetMut(n, v, b, off) => ELetMut(n, fdp_expr(v, false), fdp_expr(b, discard), off),
-    EAssign(n, v, b) => EAssign(n, fdp_expr(v, false), fdp_expr(b, discard)),
-    EAssignOp(n, op, v, b) => EAssignOp(n, op, fdp_expr(v, false), fdp_expr(b, discard)),
+    ESeq(_, _) => fdp_spine(e, discard),
+    ELet(_, _, _, _) => fdp_spine(e, discard),
+    ELetRec(_, _, _) => fdp_spine(e, discard),
+    ELetMut(_, _, _, _) => fdp_spine(e, discard),
+    EAssign(_, _, _) => fdp_spine(e, discard),
+    EAssignOp(_, _, _, _) => fdp_spine(e, discard),
     EIf(c, t, el) => EIf(fdp_expr(c, false), fdp_expr(t, discard), fdp_expr(el, discard)),
     EMatch(s, arms) => {
-      let arms2: Array[(Pat, Expr)] = []
+      let arms2: Array[(Pat, Expr)] = [
+      ]
       let mut i = 0
       while i < Array::length(arms) {
         let (p, ex) = Array::get(arms, i)
@@ -14708,7 +14769,8 @@ fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
     },
     EWhile(c, b) => EWhile(fdp_expr(c, false), fdp_expr(b, true)),
     ELoop(pairs, b) => {
-      let pairs2: Array[(String, Expr)] = []
+      let pairs2: Array[(String, Expr)] = [
+      ]
       let mut i = 0
       while i < Array::length(pairs) {
         let (n, v) = Array::get(pairs, i)
@@ -14719,7 +14781,8 @@ fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
     },
     EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, fdp_expr(b, fdp_ret_is_unit(ret))),
     ECall(callee, args, off) => {
-      let args2: Array[Expr] = []
+      let args2: Array[Expr] = [
+      ]
       let mut i = 0
       while i < Array::length(args) {
         Array::push(args2, fdp_expr(Array::get(args, i), false))
@@ -14737,7 +14800,8 @@ fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
       None => e
     },
     EContinue(args) => {
-      let args2: Array[Expr] = []
+      let args2: Array[Expr] = [
+      ]
       let mut i = 0
       while i < Array::length(args) {
         Array::push(args2, fdp_expr(Array::get(args, i), false))
@@ -14746,7 +14810,8 @@ fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
       EContinue(args2)
     },
     ETuple(items) => {
-      let items2: Array[Expr] = []
+      let items2: Array[Expr] = [
+      ]
       let mut i = 0
       while i < Array::length(items) {
         Array::push(items2, fdp_expr(Array::get(items, i), false))
@@ -14755,7 +14820,8 @@ fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
       ETuple(items2)
     },
     EArray(items) => {
-      let items2: Array[Expr] = []
+      let items2: Array[Expr] = [
+      ]
       let mut i = 0
       while i < Array::length(items) {
         Array::push(items2, fdp_expr(Array::get(items, i), false))
@@ -14764,7 +14830,8 @@ fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
       EArray(items2)
     },
     ERecord(nm, fields, targs) => {
-      let fields2: Array[(String, Expr)] = []
+      let fields2: Array[(String, Expr)] = [
+      ]
       let mut i = 0
       while i < Array::length(fields) {
         let (n, v) = Array::get(fields, i)
@@ -14774,7 +14841,8 @@ fn fdp_expr_rebuild(e: Expr, discard: Bool) -> Expr {
       ERecord(nm, fields2, targs)
     },
     EMap(fields) => {
-      let fields2: Array[(String, Expr)] = []
+      let fields2: Array[(String, Expr)] = [
+      ]
       let mut i = 0
       while i < Array::length(fields) {
         let (n, v) = Array::get(fields, i)

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -14619,3 +14619,199 @@ fn awp_rewrite_arms(arms: Array[(Pat, Expr)], ctr: Array[Int]) -> Array[(Pat, Ex
     (p, awp_tail(ex, ctr))
   }
 }
+
+/// --- #1916: discard-position `for` normalization ------------------------
+///
+/// A statement-position `for` still compiles as a comprehension: the linear
+/// lowering materializes a result array per execution, and the discarded
+/// array never gets a drop, so every whole-program walk written with
+/// statement `for` loops pays permanent bump-heap growth per node (the
+/// #1875 R4 measurement: ~2.1MB per used effect in one such walk alone).
+///
+/// The codegen fix lives in compile_expr_tail.vibe's ESeq head (a `for`
+/// whose value is dropped right after compiles via compile_forin_loop's
+/// no-collect form). This pass funnels every OTHER syntactic discard
+/// position into that one shape by wrapping the loop as
+/// `ESeq(for .., EUnit)`: statement roots (SExpr / test / bench bodies),
+/// sequence heads recursively, while bodies, let/assign continuations,
+/// if/match tails under a discarded context, and the body tail of a
+/// function whose declared return type is Unit. The wrap changes the
+/// loop's VALUE from the collected array to `()` -- legal exactly because
+/// the context provably discards it (for declared-Unit bodies the checker
+/// has already forced the value to Unit).
+///
+/// Runs at the END of effect_lowering_prelude, after every effect pass:
+/// the trait-iterator / pull / HostStream `for` shapes are already
+/// rewritten to Unit-valued whiles by then (#1679), so any surviving
+/// EForIn is the residual builtin lowering this optimization targets.
+/// EHandle stays untouched (conservative -- its arms/body feed the Error
+/// handler codegen).
+fn fdp_has_forin(e: Expr) -> Bool {
+  match e {
+    EForIn(_, _, _, _) => true,
+    _ => {
+      let kids = expr_children(e)
+      let mut i = 0
+      let mut found = false
+      while !found && i < Array::length(kids) {
+        found = fdp_has_forin(Array::get(kids, i))
+        i = i + 1
+      }
+      found
+    }
+  }
+}
+
+fn fdp_ret_is_unit(ret: Option[TypeExpr]) -> Bool {
+  match ret {
+    Some(TyUnit) => true,
+    Some(TyName(n)) => n == "Unit",
+    _ => false
+  }
+}
+
+fn fdp_expr(e: Expr, discard: Bool) -> Expr {
+  match e {
+    EForIn(nm, idx, it, b) => {
+      let it2 = fdp_expr(it, false)
+      if discard {
+        // The no-collect form drops the body value each iteration, so the
+        // body tail is itself a discard position.
+        ESeq(EForIn(nm, idx, it2, fdp_expr(b, true)), EUnit)
+      } else {
+        EForIn(nm, idx, it2, fdp_expr(b, false))
+      }
+    },
+    ESeq(a, b) => ESeq(fdp_expr(a, true), fdp_expr(b, discard)),
+    ELet(n, v, b, off) => ELet(n, fdp_expr(v, false), fdp_expr(b, discard), off),
+    ELetRec(n, v, b) => ELetRec(n, fdp_expr(v, false), fdp_expr(b, discard)),
+    ELetMut(n, v, b, off) => ELetMut(n, fdp_expr(v, false), fdp_expr(b, discard), off),
+    EAssign(n, v, b) => EAssign(n, fdp_expr(v, false), fdp_expr(b, discard)),
+    EAssignOp(n, op, v, b) => EAssignOp(n, op, fdp_expr(v, false), fdp_expr(b, discard)),
+    EIf(c, t, el) => EIf(fdp_expr(c, false), fdp_expr(t, discard), fdp_expr(el, discard)),
+    EMatch(s, arms) => {
+      let arms2: Array[(Pat, Expr)] = []
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (p, ex) = Array::get(arms, i)
+        Array::push(arms2, (p, fdp_expr(ex, discard)))
+        i = i + 1
+      }
+      EMatch(fdp_expr(s, false), arms2)
+    },
+    EWhile(c, b) => EWhile(fdp_expr(c, false), fdp_expr(b, true)),
+    ELoop(pairs, b) => {
+      let pairs2: Array[(String, Expr)] = []
+      let mut i = 0
+      while i < Array::length(pairs) {
+        let (n, v) = Array::get(pairs, i)
+        Array::push(pairs2, (n, fdp_expr(v, false)))
+        i = i + 1
+      }
+      ELoop(pairs2, fdp_expr(b, false))
+    },
+    EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, fdp_expr(b, fdp_ret_is_unit(ret))),
+    ECall(callee, args, off) => {
+      let args2: Array[Expr] = []
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(args2, fdp_expr(Array::get(args, i), false))
+        i = i + 1
+      }
+      ECall(fdp_expr(callee, false), args2, off)
+    },
+    EBinOp(op, l, r) => EBinOp(op, fdp_expr(l, false), fdp_expr(r, false)),
+    EUnaryOp(op, x) => EUnaryOp(op, fdp_expr(x, false)),
+    EDot(o, f, a, b2) => EDot(fdp_expr(o, false), f, a, b2),
+    ELabeledArg(k, n, v) => ELabeledArg(k, n, fdp_expr(v, false)),
+    EReturn(x) => EReturn(fdp_expr(x, false)),
+    EBreak(opt) => match opt {
+      Some(x) => EBreak(Some(fdp_expr(x, false))),
+      None => e
+    },
+    EContinue(args) => {
+      let args2: Array[Expr] = []
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(args2, fdp_expr(Array::get(args, i), false))
+        i = i + 1
+      }
+      EContinue(args2)
+    },
+    ETuple(items) => {
+      let items2: Array[Expr] = []
+      let mut i = 0
+      while i < Array::length(items) {
+        Array::push(items2, fdp_expr(Array::get(items, i), false))
+        i = i + 1
+      }
+      ETuple(items2)
+    },
+    EArray(items) => {
+      let items2: Array[Expr] = []
+      let mut i = 0
+      while i < Array::length(items) {
+        Array::push(items2, fdp_expr(Array::get(items, i), false))
+        i = i + 1
+      }
+      EArray(items2)
+    },
+    ERecord(nm, fields, targs) => {
+      let fields2: Array[(String, Expr)] = []
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (n, v) = Array::get(fields, i)
+        Array::push(fields2, (n, fdp_expr(v, false)))
+        i = i + 1
+      }
+      ERecord(nm, fields2, targs)
+    },
+    EMap(fields) => {
+      let fields2: Array[(String, Expr)] = []
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (n, v) = Array::get(fields, i)
+        Array::push(fields2, (n, fdp_expr(v, false)))
+        i = i + 1
+      }
+      EMap(fields2)
+    },
+    ESpread(x) => ESpread(fdp_expr(x, false)),
+    _ => e
+  }
+}
+
+export fn forin_discard_pass(stmts: Array[Stmt]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(ex, isrec, nm, ty, expr) => if fdp_has_forin(expr) {
+        Array::set(stmts, i, SLet(ex, isrec, nm, ty, fdp_expr(expr, false)))
+      } else {
+        ()
+      },
+      SLetMut(nm, ty, expr) => if fdp_has_forin(expr) {
+        Array::set(stmts, i, SLetMut(nm, ty, fdp_expr(expr, false)))
+      } else {
+        ()
+      },
+      SExpr(expr) => if fdp_has_forin(expr) {
+        Array::set(stmts, i, SExpr(fdp_expr(expr, true)))
+      } else {
+        ()
+      },
+      STest(tn, expr) => if fdp_has_forin(expr) {
+        Array::set(stmts, i, STest(tn, fdp_expr(expr, true)))
+      } else {
+        ()
+      },
+      SBench(bn, expr) => if fdp_has_forin(expr) {
+        Array::set(stmts, i, SBench(bn, fdp_expr(expr, true)))
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
@@ -233,7 +233,7 @@ import ./compile_call.vibe {
 }
 
 import ./compile_expr_tail2.vibe {
-  compile_expr_tail2
+  compile_expr_tail2, compile_forin_loop
 }
 
 import ./compile_lambda.vibe {
@@ -1767,7 +1767,14 @@ export fn compile_expr_tail(buf: Bytes, expr: Expr, local_names: Array[String], 
     let first = get_eseq_first(expr)
     let second = get_eseq_second(expr)
     emit_dbg_line_for(buf, first, ctx)
-    let nl = compile_expr(buf, first, local_names, next_local, ctx, ld)
+    // #1916: a `for` at the head of a sequence is statement-shaped (same
+    // classification the checker uses, #1679) -- its comprehension result is
+    // discarded right here by the emit_drop below, so compile it in the
+    // no-collect form instead of materializing an array nobody reads.
+    let nl = match first {
+      EForIn(_, _, _, _) => compile_forin_loop(buf, first, local_names, next_local, ctx, ld, compile_expr, false),
+      _ => compile_expr(buf, first, local_names, next_local, ctx, ld)
+    }
     emit_drop(buf)
     compile_expr(buf, second, local_names, nl, ctx, ld)
   } else {

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail2.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail2.vibe
@@ -471,209 +471,209 @@ export fn compile_expr_tail2(buf: Bytes, expr: Expr, local_names: Array[String],
 /// allocated (the slot holds i64 0), the body value is dropped instead of
 /// pushed, and the loop's value is that 0.
 export fn compile_forin_loop(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_expr: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception, collect: Bool) -> Int with Exception {
-    let names_len_at_forin = Array::length(local_names)
-    let var_name = get_eforin_name(expr)
-    let iter_expr = get_eforin_iter(expr)
-    let body = get_eforin_body(expr)
-    // #715: mirror EWhile's (#706) loop-borrowed-names protection. The outer
-    // locals live at loop entry are re-consumed on every iteration via the
-    // back-edge (`br 0`), so a consuming use of one inside the body must dup
-    // to survive past the first iteration. Names declared inside the body
-    // (var_name, index_name, __forin_* temps) are appended past lb_base and
-    // never added here, matching EWhile.
-    let lb_base = Array::length(ctx.loop_borrowed_names)
-    if ctx.enable_rc {
-      let mut lbi = 0
-      while lbi < names_len_at_forin {
-        Array::push(ctx.loop_borrowed_names, Array::get(local_names, lbi))
-        lbi = lbi + 1
-      }
-    } else {
-      ()
+  let names_len_at_forin = Array::length(local_names)
+  let var_name = get_eforin_name(expr)
+  let iter_expr = get_eforin_iter(expr)
+  let body = get_eforin_body(expr)
+  // #715: mirror EWhile's (#706) loop-borrowed-names protection. The outer
+  // locals live at loop entry are re-consumed on every iteration via the
+  // back-edge (`br 0`), so a consuming use of one inside the body must dup
+  // to survive past the first iteration. Names declared inside the body
+  // (var_name, index_name, __forin_* temps) are appended past lb_base and
+  // never added here, matching EWhile.
+  let lb_base = Array::length(ctx.loop_borrowed_names)
+  if ctx.enable_rc {
+    let mut lbi = 0
+    while lbi < names_len_at_forin {
+      Array::push(ctx.loop_borrowed_names, Array::get(local_names, lbi))
+      lbi = lbi + 1
     }
-    let (arr_new_fi, _, _) = resolve_func(ctx.func_table, "array_new")
-    let (arr_len_fi, _, _) = resolve_func(ctx.func_table, "Array::length")
-    let (arr_get_fi, _, _) = resolve_func(ctx.func_table, "Array::get")
-    let (arr_push_fi, _, _) = resolve_func(ctx.func_table, "Array::push")
-    let result_local = next_local
-    let arr_local = next_local + 1
-    let i_local = next_local + 2
-    Array::push(local_names, "__forin_res")
-    Array::push(local_names, "__forin_arr")
-    Array::push(local_names, "__forin_i")
-    if collect {
-      emit_call(buf, arr_new_fi)
-    } else {
-      emit_i64_const(buf, 0)
-    }
-    emit_local_set(buf, result_local)
-    let nl1pre = compile_expr(buf, iter_expr, local_names, next_local + 3, ctx, ld)
-    emit_local_set(buf, arr_local)
-    // #807: for-in over a String silently iterated zero times — the loop
-    // below reads `Array::length` from the value, but a String is an
-    // `(offset << 32) | length` fat pointer, not an array pointer. Array
-    // values (rc-tagged or not) are 32-bit heap pointers whose high 32 bits
-    // are zero, so dispatch on the high bits at runtime (same fat-pointer
-    // discrimination family as `__to_string`, ADR-0058) and materialize the
-    // string's bytes into a fresh Array[Int] of char codes before the shared
-    // array loop. The offset-0 interned string ("") misclassifies as an
-    // array whose length load reads zeroed memory — 0 iterations either way,
-    // so it stays correct. String offsets are < 2^31, so the arithmetic
-    // shift never sign-extends. Under RC the materialized array is not
-    // dropped at loop exit (same as the iterated value today).
-    let (str_len_fi, _, _) = resolve_func(ctx.func_table, "String::length")
-    let (str_ccat_fi, _, _) = resolve_func(ctx.func_table, "String::char_code_at")
-    let conv_local = nl1pre
-    let j_local = nl1pre + 1
-    Array::push(local_names, "__forin_conv")
-    Array::push(local_names, "__forin_j")
-    let nl1 = nl1pre + 2
-    emit_local_get(buf, arr_local)
-    emit_i64_const(buf, 32)
-    emit_i64_shr_s(buf)
-    emit_i64_eqz(buf)
-    emit_if_void(buf)
-    emit_else(buf)
+  } else {
+    ()
+  }
+  let (arr_new_fi, _, _) = resolve_func(ctx.func_table, "array_new")
+  let (arr_len_fi, _, _) = resolve_func(ctx.func_table, "Array::length")
+  let (arr_get_fi, _, _) = resolve_func(ctx.func_table, "Array::get")
+  let (arr_push_fi, _, _) = resolve_func(ctx.func_table, "Array::push")
+  let result_local = next_local
+  let arr_local = next_local + 1
+  let i_local = next_local + 2
+  Array::push(local_names, "__forin_res")
+  Array::push(local_names, "__forin_arr")
+  Array::push(local_names, "__forin_i")
+  if collect {
     emit_call(buf, arr_new_fi)
-    emit_local_set(buf, conv_local)
+  } else {
     emit_i64_const(buf, 0)
-    emit_local_set(buf, j_local)
-    emit_block_void(buf)
-    emit_loop_void(buf)
-    emit_local_get(buf, j_local)
-    emit_local_get(buf, arr_local)
-    emit_call(buf, str_len_fi)
-    if ctx.enable_rc {
-      emit_i64_const(buf, 1)
-      emit_i64_shr_s(buf)
-    } else {
-      ()
-    }
-    emit_i64_ge_s(buf)
-    emit_br_if(buf, 1)
-    emit_local_get(buf, conv_local)
-    emit_local_get(buf, arr_local)
-    emit_local_get(buf, j_local)
-    if ctx.enable_rc {
-      emit_i64_const(buf, 1)
-      emit_i64_shl(buf)
-    } else {
-      ()
-    }
-    emit_call(buf, str_ccat_fi)
-    emit_call(buf, arr_push_fi)
-    emit_local_get(buf, j_local)
+  }
+  emit_local_set(buf, result_local)
+  let nl1pre = compile_expr(buf, iter_expr, local_names, next_local + 3, ctx, ld)
+  emit_local_set(buf, arr_local)
+  // #807: for-in over a String silently iterated zero times — the loop
+  // below reads `Array::length` from the value, but a String is an
+  // `(offset << 32) | length` fat pointer, not an array pointer. Array
+  // values (rc-tagged or not) are 32-bit heap pointers whose high 32 bits
+  // are zero, so dispatch on the high bits at runtime (same fat-pointer
+  // discrimination family as `__to_string`, ADR-0058) and materialize the
+  // string's bytes into a fresh Array[Int] of char codes before the shared
+  // array loop. The offset-0 interned string ("") misclassifies as an
+  // array whose length load reads zeroed memory — 0 iterations either way,
+  // so it stays correct. String offsets are < 2^31, so the arithmetic
+  // shift never sign-extends. Under RC the materialized array is not
+  // dropped at loop exit (same as the iterated value today).
+  let (str_len_fi, _, _) = resolve_func(ctx.func_table, "String::length")
+  let (str_ccat_fi, _, _) = resolve_func(ctx.func_table, "String::char_code_at")
+  let conv_local = nl1pre
+  let j_local = nl1pre + 1
+  Array::push(local_names, "__forin_conv")
+  Array::push(local_names, "__forin_j")
+  let nl1 = nl1pre + 2
+  emit_local_get(buf, arr_local)
+  emit_i64_const(buf, 32)
+  emit_i64_shr_s(buf)
+  emit_i64_eqz(buf)
+  emit_if_void(buf)
+  emit_else(buf)
+  emit_call(buf, arr_new_fi)
+  emit_local_set(buf, conv_local)
+  emit_i64_const(buf, 0)
+  emit_local_set(buf, j_local)
+  emit_block_void(buf)
+  emit_loop_void(buf)
+  emit_local_get(buf, j_local)
+  emit_local_get(buf, arr_local)
+  emit_call(buf, str_len_fi)
+  if ctx.enable_rc {
     emit_i64_const(buf, 1)
-    emit_i64_add(buf)
-    emit_local_set(buf, j_local)
-    emit_br(buf, 0)
-    emit_end(buf)
-    emit_end(buf)
-    emit_local_get(buf, conv_local)
-    emit_local_set(buf, arr_local)
-    emit_end(buf)
-    emit_i64_const(buf, 0)
-    emit_local_set(buf, i_local)
-    emit_block_void(buf)
-    emit_loop_void(buf)
-    emit_local_get(buf, i_local)
-    emit_local_get(buf, arr_local)
-    emit_call(buf, arr_len_fi)
-    // `i_local` is a raw counter (init 0, step 1). Under RC `Array::length`
-    // returns a tagged Int (`len << 1`), so untag it to compare against the raw
-    // counter — otherwise the loop runs twice per element (#704). The index is
-    // re-tagged at the `Array::get` site below.
-    if ctx.enable_rc {
-      emit_i64_const(buf, 1)
-      emit_i64_shr_s(buf)
-    }
-    emit_i64_ge_s(buf)
-    emit_br_if(buf, 1)
-    // Indexed `for i, x in arr`: bind the loop counter to the user index name
-    // before the value var (gc backend parity — backend_expr.vibe). The counter
-    // `i_local` is a raw i64; under RC ints are `value << 1`, so shift to match
-    // the user-visible Int representation (same as EInt codegen).
-    let index_name = get_eforin_index(expr)
-    let var_local = match index_name {
-      Some(idx_name) => {
-        emit_local_get(buf, i_local)
-        if ctx.enable_rc {
-          emit_i64_const(buf, 1)
-          emit_i64_shl(buf)
-        }
-        emit_local_set(buf, nl1)
-        Array::push(local_names, idx_name)
-        nl1 + 1
-      },
-      None => nl1
-    }
-    emit_local_get(buf, arr_local)
-    emit_local_get(buf, i_local)
-    // Re-tag the raw counter to a vibe Int (`i << 1`) so `Array::get` (which
-    // untags its index under RC) reads the correct element (#704).
-    if ctx.enable_rc {
-      emit_i64_const(buf, 1)
-      emit_i64_shl(buf)
-    }
-    emit_call(buf, arr_get_fi)
-    emit_local_set(buf, var_local)
-    Array::push(local_names, var_name)
-    // #715: `var_name` is bound to `Array::get(arr, i)`'s result every
-    // iteration -- a BORROWED view into `arr_local`, exactly like a
-    // hand-written `let var_name = Array::get(arr, i)` (compile_expr_tail.vibe's
-    // is_borrow_ret handling, which deliberately leaves such a let untracked
-    // and instead dups at each owning consuming use via the loop_borrowed_names
-    // piggyback -- see its #708-follow-up comment). EForIn's implicit bind
-    // skipped that registration entirely, so a body that passes `var_name` to a
-    // function taking ownership of its argument (e.g. a self-recursive call
-    // like `resolve_type_expr(p, defs)`) let the callee drop a reference the
-    // array still owns -- a same-address free while `arr_local` still points at
-    // it, corrupting the free list once `arr_local` is later dropped or reread.
-    // Reuse the same ctx.loop_borrowed_names mechanism (cc_is_loop_borrowed_ident
-    // in compile_call.vibe) so owning uses of `var_name` inside `body` get the
-    // missing dup; the existing `Array::truncate(ctx.loop_borrowed_names, lb_base)`
-    // below already restores the outer state since this push lands after lb_base.
-    if ctx.enable_rc {
-      Array::push(ctx.loop_borrowed_names, var_name)
-    } else {
-      ()
-    }
-    let nl2 = var_local + 1
-    // Same innermost-loop ld reset as EWhile (see compile_expr_tail3).
-    let nl3 = compile_expr(buf, body, local_names, nl2, ctx, 0)
-    let body_val = nl3
-    Array::push(local_names, "__forin_val")
-    if collect {
-      emit_local_set(buf, body_val)
-      emit_local_get(buf, result_local)
-      emit_local_get(buf, body_val)
-      emit_call(buf, arr_push_fi)
-    } else {
-      // Discard form: the body value is not collected. A plain stack drop
-      // matches what ESeq does with a discarded head today (no rc release
-      // -- releasing here could double-free a borrowed body value).
-      emit_drop(buf)
-    }
-    emit_local_get(buf, i_local)
+    emit_i64_shr_s(buf)
+  } else {
+    ()
+  }
+  emit_i64_ge_s(buf)
+  emit_br_if(buf, 1)
+  emit_local_get(buf, conv_local)
+  emit_local_get(buf, arr_local)
+  emit_local_get(buf, j_local)
+  if ctx.enable_rc {
     emit_i64_const(buf, 1)
-    emit_i64_add(buf)
-    emit_local_set(buf, i_local)
-    emit_br(buf, 0)
-    emit_end(buf)
-    emit_end(buf)
-    Array::truncate(ctx.loop_borrowed_names, lb_base)
+    emit_i64_shl(buf)
+  } else {
+    ()
+  }
+  emit_call(buf, str_ccat_fi)
+  emit_call(buf, arr_push_fi)
+  emit_local_get(buf, j_local)
+  emit_i64_const(buf, 1)
+  emit_i64_add(buf)
+  emit_local_set(buf, j_local)
+  emit_br(buf, 0)
+  emit_end(buf)
+  emit_end(buf)
+  emit_local_get(buf, conv_local)
+  emit_local_set(buf, arr_local)
+  emit_end(buf)
+  emit_i64_const(buf, 0)
+  emit_local_set(buf, i_local)
+  emit_block_void(buf)
+  emit_loop_void(buf)
+  emit_local_get(buf, i_local)
+  emit_local_get(buf, arr_local)
+  emit_call(buf, arr_len_fi)
+  // `i_local` is a raw counter (init 0, step 1). Under RC `Array::length`
+  // returns a tagged Int (`len << 1`), so untag it to compare against the raw
+  // counter — otherwise the loop runs twice per element (#704). The index is
+  // re-tagged at the `Array::get` site below.
+  if ctx.enable_rc {
+    emit_i64_const(buf, 1)
+    emit_i64_shr_s(buf)
+  }
+  emit_i64_ge_s(buf)
+  emit_br_if(buf, 1)
+  // Indexed `for i, x in arr`: bind the loop counter to the user index name
+  // before the value var (gc backend parity — backend_expr.vibe). The counter
+  // `i_local` is a raw i64; under RC ints are `value << 1`, so shift to match
+  // the user-visible Int representation (same as EInt codegen).
+  let index_name = get_eforin_index(expr)
+  let var_local = match index_name {
+    Some(idx_name) => {
+      emit_local_get(buf, i_local)
+      if ctx.enable_rc {
+        emit_i64_const(buf, 1)
+        emit_i64_shl(buf)
+      }
+      emit_local_set(buf, nl1)
+      Array::push(local_names, idx_name)
+      nl1 + 1
+    },
+    None => nl1
+  }
+  emit_local_get(buf, arr_local)
+  emit_local_get(buf, i_local)
+  // Re-tag the raw counter to a vibe Int (`i << 1`) so `Array::get` (which
+  // untags its index under RC) reads the correct element (#704).
+  if ctx.enable_rc {
+    emit_i64_const(buf, 1)
+    emit_i64_shl(buf)
+  }
+  emit_call(buf, arr_get_fi)
+  emit_local_set(buf, var_local)
+  Array::push(local_names, var_name)
+  // #715: `var_name` is bound to `Array::get(arr, i)`'s result every
+  // iteration -- a BORROWED view into `arr_local`, exactly like a
+  // hand-written `let var_name = Array::get(arr, i)` (compile_expr_tail.vibe's
+  // is_borrow_ret handling, which deliberately leaves such a let untracked
+  // and instead dups at each owning consuming use via the loop_borrowed_names
+  // piggyback -- see its #708-follow-up comment). EForIn's implicit bind
+  // skipped that registration entirely, so a body that passes `var_name` to a
+  // function taking ownership of its argument (e.g. a self-recursive call
+  // like `resolve_type_expr(p, defs)`) let the callee drop a reference the
+  // array still owns -- a same-address free while `arr_local` still points at
+  // it, corrupting the free list once `arr_local` is later dropped or reread.
+  // Reuse the same ctx.loop_borrowed_names mechanism (cc_is_loop_borrowed_ident
+  // in compile_call.vibe) so owning uses of `var_name` inside `body` get the
+  // missing dup; the existing `Array::truncate(ctx.loop_borrowed_names, lb_base)`
+  // below already restores the outer state since this push lands after lb_base.
+  if ctx.enable_rc {
+    Array::push(ctx.loop_borrowed_names, var_name)
+  } else {
+    ()
+  }
+  let nl2 = var_local + 1
+  // Same innermost-loop ld reset as EWhile (see compile_expr_tail3).
+  let nl3 = compile_expr(buf, body, local_names, nl2, ctx, 0)
+  let body_val = nl3
+  Array::push(local_names, "__forin_val")
+  if collect {
+    emit_local_set(buf, body_val)
     emit_local_get(buf, result_local)
-    // Restore the outer scope. The loop's internal bindings (result/arr/i, the
-    // optional index name, the value name, and the body temp) must not leak into
-    // later identifier lookups, which scan local_names from the end and would
-    // otherwise resolve a shadowed outer var to a stale loop slot. Mirror
-    // compile_match: truncate back to the entry length, then pad with placeholders
-    // up to the high-water local count so slot numbering is preserved.
-    let final_nl = nl3 + 1
-    Array::truncate(local_names, names_len_at_forin)
-    while Array::length(local_names) < final_nl {
-      Array::push(local_names, "")
-    }
-    final_nl
+    emit_local_get(buf, body_val)
+    emit_call(buf, arr_push_fi)
+  } else {
+    // Discard form: the body value is not collected. A plain stack drop
+    // matches what ESeq does with a discarded head today (no rc release
+    // -- releasing here could double-free a borrowed body value).
+    emit_drop(buf)
+  }
+  emit_local_get(buf, i_local)
+  emit_i64_const(buf, 1)
+  emit_i64_add(buf)
+  emit_local_set(buf, i_local)
+  emit_br(buf, 0)
+  emit_end(buf)
+  emit_end(buf)
+  Array::truncate(ctx.loop_borrowed_names, lb_base)
+  emit_local_get(buf, result_local)
+  // Restore the outer scope. The loop's internal bindings (result/arr/i, the
+  // optional index name, the value name, and the body temp) must not leak into
+  // later identifier lookups, which scan local_names from the end and would
+  // otherwise resolve a shadowed outer var to a stale loop slot. Mirror
+  // compile_match: truncate back to the entry length, then pad with placeholders
+  // up to the high-water local count so slot numbering is preserved.
+  let final_nl = nl3 + 1
+  Array::truncate(local_names, names_len_at_forin)
+  while Array::length(local_names) < final_nl {
+    Array::push(local_names, "")
+  }
+  final_nl
 }
 

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail2.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail2.vibe
@@ -456,6 +456,21 @@ export fn compile_expr_tail2(buf: Bytes, expr: Expr, local_names: Array[String],
       nl
     }
   } else if __tag == 18 {
+    compile_forin_loop(buf, expr, local_names, next_local, ctx, ld, compile_expr, true)
+  } else {
+    compile_expr_tail3(buf, expr, local_names, next_local, ctx, ld, compile_expr)
+  }
+}
+
+/// #1916: the EForIn lowering, shared by the value form (collect=true --
+/// the comprehension result array) and the discard form (collect=false --
+/// statement position via forin_discard_pass, where the result array was
+/// pure allocation churn AND a leak: the discarded array never got a drop).
+/// collect=false keeps the identical local/block layout (so break/continue
+/// depths and slot numbering match) and differs only in: no result array is
+/// allocated (the slot holds i64 0), the body value is dropped instead of
+/// pushed, and the loop's value is that 0.
+export fn compile_forin_loop(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_expr: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception, collect: Bool) -> Int with Exception {
     let names_len_at_forin = Array::length(local_names)
     let var_name = get_eforin_name(expr)
     let iter_expr = get_eforin_iter(expr)
@@ -486,7 +501,11 @@ export fn compile_expr_tail2(buf: Bytes, expr: Expr, local_names: Array[String],
     Array::push(local_names, "__forin_res")
     Array::push(local_names, "__forin_arr")
     Array::push(local_names, "__forin_i")
-    emit_call(buf, arr_new_fi)
+    if collect {
+      emit_call(buf, arr_new_fi)
+    } else {
+      emit_i64_const(buf, 0)
+    }
     emit_local_set(buf, result_local)
     let nl1pre = compile_expr(buf, iter_expr, local_names, next_local + 3, ctx, ld)
     emit_local_set(buf, arr_local)
@@ -624,10 +643,17 @@ export fn compile_expr_tail2(buf: Bytes, expr: Expr, local_names: Array[String],
     let nl3 = compile_expr(buf, body, local_names, nl2, ctx, 0)
     let body_val = nl3
     Array::push(local_names, "__forin_val")
-    emit_local_set(buf, body_val)
-    emit_local_get(buf, result_local)
-    emit_local_get(buf, body_val)
-    emit_call(buf, arr_push_fi)
+    if collect {
+      emit_local_set(buf, body_val)
+      emit_local_get(buf, result_local)
+      emit_local_get(buf, body_val)
+      emit_call(buf, arr_push_fi)
+    } else {
+      // Discard form: the body value is not collected. A plain stack drop
+      // matches what ESeq does with a discarded head today (no rc release
+      // -- releasing here could double-free a borrowed body value).
+      emit_drop(buf)
+    }
     emit_local_get(buf, i_local)
     emit_i64_const(buf, 1)
     emit_i64_add(buf)
@@ -649,7 +675,5 @@ export fn compile_expr_tail2(buf: Bytes, expr: Expr, local_names: Array[String],
       Array::push(local_names, "")
     }
     final_nl
-  } else {
-    compile_expr_tail3(buf, expr, local_names, next_local, ctx, ld, compile_expr)
-  }
 }
+

--- a/lib/@vibe/compiler/codegen/expr/index.vpkg
+++ b/lib/@vibe/compiler/codegen/expr/index.vpkg
@@ -39,6 +39,7 @@ fn expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Boo
 fn expr_is_intish(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Bool with Exception
 fn compile_expr_tail(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_expr: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception
 fn compile_expr_tail2(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_expr: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception
+fn compile_forin_loop(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_expr: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception, collect: Bool) -> Int with Exception
 fn compile_expr_tail3(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_expr: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception
 fn compile_expr_tail4(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_expr: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception
 fn compile_expr_tail5(buf: Bytes, expr: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_expr: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -175,6 +175,7 @@ import @vibe/compiler/codegen/common_base {
   exn_msg_read_expr,
   expr_tag,
   fn_type_param_types,
+  forin_discard_pass,
   get_arm_body,
   get_arm_pat,
   get_ebinop_op,
@@ -3636,6 +3637,15 @@ export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked
         }
       }
     }
+  }
+  // #1916: normalize discard-position `for` loops into the ESeq-head shape
+  // the linear lowering compiles without the comprehension result array.
+  // Last on purpose: every effect pass above sees the original tree, and by
+  // now the non-residual `for` shapes are already Unit-valued whiles (#1679).
+  if Array::length(errs) == 0 {
+    forin_discard_pass(stmts)
+  } else {
+    ()
   }
   errs
 }


### PR DESCRIPTION
## Summary

Fixes the #1916 lowering gap: a statement-position `for` compiled as a full comprehension — the linear `EForIn` lowering materialized a result array per execution, and the discarded array never got a drop, so it was both churn and a permanent leak. The measured costs (micro-fixtures on stage2, `Profiler::heap_bytes`):

| shape | before | after |
|---|---:|---:|
| discarded `for` over 10k `Array[Int]`, ×100 calls | 13,116,400 (leaks) | **0** |
| recursive `-> Unit` visitor with `for`-over-children arms (6^6-node tree), per call | 783,804 | **0** |
| value-position `for` (`let ys = for …`) | unchanged | unchanged |

This is the structural version of what #1909 hand-fixed for one hot edp walk: the natural spelling of a read-only walk no longer pays an allocation per node.

## How

- `compile_expr_tail2.vibe`: the `EForIn` lowering is extracted into `compile_forin_loop(collect: Bool)`. `collect=false` keeps the identical block/local layout (break/continue depths, slot numbering) and differs only in: no result array (the slot holds i64 0), the body value is dropped, and the loop's value is 0. `collect=true` is byte-for-byte the old lowering.
- `compile_expr_tail.vibe`: an `ESeq`-head `for` — the same statement-shaped classification the checker uses (#1679) — compiles through the no-collect form; its value is dropped by the very next instruction.
- `forin_discard_pass` (end of `effect_lowering_prelude`, linear lane): funnels the other syntactic discard positions — statement roots, test/bench bodies, `while` bodies, let/assign continuations, if/match tails under a discarded context, declared-`Unit` fn body tails — into that one `ESeq`-head shape by wrapping the loop as `ESeq(for …, EUnit)`. Runs last, after every effect pass, when the only surviving `EForIn`s are the residual builtin lowering (#1679). `EHandle` is left untouched (conservative).
- The pass gates its per-statement rebuild on an allocation-free `RQContainsForIn` read query and shares any subtree without a `for` (a first cut used `expr_children`, whose per-node children arrays cost 9.5MB on the KPI compile — measured and removed).

## Verification

- stage2 == stage3 fixpoint on the rebuilt generations.
- Micro-fixture behavior identical (sums/lengths byte-for-byte, only heap deltas change).
- Self-compile KPI (codegen_lexer_test, warm, deterministic): 581,323,128 with this change; baseline comparison against current main and the full operation gate are running now — results will be posted on this thread before this is ready to merge.

Note: unlike #1909 this is deliberately **not** output-preserving (that is the point — discarded loops compile to less code), so the validation story is fixtures + gates rather than byte-compare.

## Related

- #1915 (R5 candidate) remains: builder-shaped returns are never dropped by callers; that leak class is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_