### PR TITLE
Fix one half of #1899: a labeled parameter's name reaches the capture scan unstripped

### DIFF
--- a/fixtures/labeled_arg_in_block_test.vibe
+++ b/fixtures/labeled_arg_in_block_test.vibe
@@ -1,0 +1,52 @@
+// #1899: a lambda with LABELED parameters, bound by a `let` inside a block,
+// returned 0 from every call -- with no diagnostic.
+//
+// A labeled parameter reaches codegen named `x~` (parser_base.vibe's
+// parse_one_param_with_binder_context), while the body binds and refers to
+// plain `x`. compile_lambda strips that marker for the wasm locals and for
+// `norm_params`, but handed the RAW name to the capture scan, so the body's `x`
+// matched nothing bound, was recorded as a free variable, and got captured from
+// an enclosing scope that has no such binding. Capturing is a legal operation,
+// so nothing downstream could tell the capture was bogus: the program compiled,
+// ran, and returned 0.
+//
+// Top-level `let f = (x~: Int) -> ...` never showed it, because that becomes a
+// func-table function rather than a closure and does not take this path. Which
+// is why fixtures/labeled_arg_basic.vibe -- top-level, and declaring the right
+// answer in `__DATA__` -- could sit in the repository being correct and prove
+// nothing about the broken case.
+//
+// So these are all written INSIDE a test block on purpose. Moving any of them
+// to the top level makes it pass for the wrong reason.
+
+fn plain_in_block() -> Int {
+  let p = (x: Int, y: Int) -> Int {
+    x + y
+  }
+  p(10, 20)
+}
+
+let top_labeled = (x~: Int, y~: Int) -> Int {
+  x + y
+}
+
+test "labeled parameters bound in a block" {
+  let add = (x~: Int, y~: Int) -> Int {
+    x + y
+  }
+  // Both call forms: the bug was in the lambda, not in label reordering, so
+  // the positional call was equally broken.
+  inspect(add(x = 10, y = 20), "30")
+  inspect(add(10, 20), "30")
+  // The marker strip must not go the other way and swallow a REAL capture:
+  // `n` is genuinely free in this lambda and still has to ride the environment.
+  let n = 5
+  let with_capture = (x~: Int) -> Int {
+    x + n
+  }
+  inspect(with_capture(x = 10), "15")
+  // Unlabeled and top-level always worked; they are here so a future change
+  // that "fixes" the labeled case by breaking these cannot pass.
+  inspect(plain_in_block(), "30")
+  inspect(top_labeled(x = 10, y = 20), "30")
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
@@ -250,6 +250,24 @@ import ./compile_match.vibe {
 /// tagged (n<<1), so `+`, `-`, `%` preserve the tag for free, but `*` yields
 /// ab<<2 (shift right once) and `/` yields a/b untagged (shift left once).
 /// The raw emit_assignop_op alone silently doubled `x *= 2` results under RC.
+/// #1899: local copy of compile_lambda.vibe's `strip_param_label_marker` --
+/// see its doc comment for why this is copied rather than imported. A labeled
+/// (`x~`) or optional (`x?`) parameter binds plain `x` in the body, and the
+/// capture scan has to be told the name the body actually uses.
+fn cet_strip_param_label_marker(n: String) -> String {
+  let ln = String::length(n)
+  if ln > 0 {
+    let c = String::char_code_at(n, ln - 1)
+    if c == '~' || c == '?' {
+      n[0: ln - 1]
+    } else {
+      n
+    }
+  } else {
+    n
+  }
+}
+
 fn emit_assignop_rc_tag_fix(buf: Bytes, enable_rc: Bool, op: String) -> Unit {
   if enable_rc && op == "*" {
     emit_i64_const(buf, 1)
@@ -1425,11 +1443,15 @@ export fn compile_expr_tail(buf: Bytes, expr: Expr, local_names: Array[String], 
     if is_efn(value) {
       let params = get_efn_params(value)
       let fn_body = get_efn_body(value)
+      // #1899: strip the label marker, exactly as compile_lambda does. This
+      // recomputation has to agree with its `captures` or self_cap_idx points
+      // at the wrong slot -- so fixing only one side is worse than fixing
+      // neither.
       let param_names_bp = array_empty()
       let mut bpi = 0
       while bpi < Array::length(params) {
         let (pn, _) = Array::get(params, bpi)
-        Array::push(param_names_bp, pn)
+        Array::push(param_names_bp, cet_strip_param_label_marker(pn))
         bpi = bpi + 1
       }
       // #875 fix 2: same force-include as compile_lambda's own capture

--- a/lib/@vibe/compiler/codegen/expr/compile_lambda.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_lambda.vibe
@@ -223,12 +223,47 @@ import @vibe/compiler/codegen/wasm_emit {
 
 //# Functions
 
+/// #1899: a parameter's binding name, with the label marker removed.
+///
+/// `x~: Int` (labeled) and `x?: Int` (optional) reach codegen as the parameter
+/// names `x~` and `x?`; the body binds and refers to `x`. Every consumer that
+/// answers "what does this lambda bind" has to agree on that, or a name that IS
+/// bound looks free.
+///
+/// Deliberately file-local, and copied verbatim into compile_expr_tail.vibe
+/// rather than exported: a brand-new cross-file export and its first
+/// cross-file caller in the same commit are silently dropped by the
+/// merge/flatten tool (the gotcha `edp_strip_tilde` in
+/// codegen/common_base/inline_direct_perform.vibe records).
+fn strip_param_label_marker(n: String) -> String {
+  let ln = String::length(n)
+  if ln > 0 {
+    let c = String::char_code_at(n, ln - 1)
+    if c == '~' || c == '?' {
+      n[0: ln - 1]
+    } else {
+      n
+    }
+  } else {
+    n
+  }
+}
+
 export fn compile_lambda(buf: Bytes, params: Array[(String, Option[TypeExpr])], fn_body: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, compile_fn: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception {
+  // #1899: the capture scan must be told the parameters under the SAME names
+  // the body uses. A labeled parameter is parsed as `x~` and an optional one as
+  // `x?` (parser_base.vibe's parse_one_param_with_binder_context), while the
+  // body refers to plain `x` -- and `lam_locals` / `norm_params` below already
+  // strip the marker for exactly that reason. Passing the raw name here instead
+  // made every labeled parameter miss, so the body's `x` was recorded as a FREE
+  // variable and captured from the enclosing scope, which is empty: the call
+  // returned 0, with no diagnostic, because capturing is a legal operation and
+  // nothing downstream can tell the capture was bogus.
   let param_names_arr = array_empty()
   let mut pi = 0
   while pi < Array::length(params) {
     let (pname, _) = Array::get(params, pi)
-    Array::push(param_names_arr, pname)
+    Array::push(param_names_arr, strip_param_label_marker(pname))
     pi = pi + 1
   }
   // #875 fix 2: consume the "currently-compiling let-rec closure's own name"


### PR DESCRIPTION
**This does not close #1899.** It fixes one of two independent bugs behind that report; the other is still open and still silent-wrong. Details at the bottom.

## The half that is fixed

```vibe
let add = (x~: Int, y~: Int) -> Int { x + y }
add(x = 10, y = 20)   // 0, with no diagnostic
```

A labeled parameter is parsed as the name `x~`, an optional one as `x?` (`parser_base.vibe`'s `parse_one_param_with_binder_context`), while the body binds and refers to plain `x`. `compile_lambda` already strips that marker **twice** — for `lam_locals` (the wasm locals) and for `norm_params` — but handed the **raw** name to `collect_free_vars_indexed_self` thirty lines earlier.

So the scan was told the lambda binds `x~`, the body's `x` matched nothing, and `x` was recorded as a **free variable** and captured from an enclosing scope that has no such binding.

Nothing downstream could catch it, which is why there was no diagnostic: capturing a variable is a legal operation, the types check, codegen succeeds, and the arithmetic just answers 0. Same shape as #1811 — a name form disagreeing with the actual binding, feeding a bogus capture — with a label marker in place of a builtin alias.

### Fixed at both sites

`compile_expr_tail.vibe:1428` builds the same array for the same scan, and its own comment says that computation *"must match compile_lambda's `captures` EXACTLY to find the right self_cap_idx slot"*. Fixing one side alone would trade this bug for a wrong self-capture slot. The helper is file-local and copied rather than exported, because a brand-new cross-file export and its first cross-file caller in one commit are silently dropped by the merge/flatten tool (the gotcha `edp_strip_tilde` records).

### Measured, linear lane

| case | before | after |
|---|---:|---:|
| block-local labeled, `add(x = 10, y = 20)` | **0** | 30 |
| block-local labeled, `add(10, 20)` | **0** | 30 |
| block-local unlabeled | 30 | 30 |
| top-level labeled | 30 | 30 |
| labeled **+ a real capture** `x + n` | — | 15 |

The last row is the guard against over-stripping: `n` is genuinely free and must still ride the environment. The two stage2 builds differ (`3b45002f` → `17967c24`), so those are measurements of different compilers, not a cached artifact.

`scripts/compiler_gate.sh` → `[compiler-gate] ok`, 0 FAIL.

### The regression pin

`fixtures/labeled_arg_in_block_test.vibe` puts all five cases **inside a test block**, which is the part that was untested. `fixtures/labeled_arg_basic.vibe` declared the right answer in `__DATA__` and was written at top level, so it could sit in the repository being correct while proving nothing about the broken case — exactly the gap #1855 is about.

---

## The half that is NOT fixed

```vibe
let s = (x~: Int, y~: Int) -> Int { x - y }
s(y = 3, x = 10)   // -7, silently, instead of 7
```

Labels given **out of declaration order** are not reordered for a block-local lambda, so the arguments are passed in written order. Top-level is correct. Still no diagnostic, so still P0.

`relabel_expr`'s ECall arm bails out entirely when the callee is in `shadows`, which a block-local binding always is — correct as far as "do not apply the top-level table to a local binding", but it leaves a local labeled lambda with no table at all. `collect_fn_param_labels`' own doc comment says it indexes top-level functions only.

I attempted this in the same branch and **reverted it**: the implementation was present in the built compiler (all helpers survive flattening) and provably did not fire — a probe with a top-level `s` shadowed by a block-local `s` returned 310, meaning no reordering by either table, where reordering would give 1003. Committing code that demonstrably does nothing is worse than not committing it, so the branch carries only the verified half.

Two things I got wrong on the way, both worth recording:

* My first round of verification used `add(x = 10, y = 20)` — labels **in declaration order**, where a missing reorder still gives the right answer. That is why the second half survived my "fix verified" claim.
* One of my scoping probes used `x + y`. Addition commutes, so it passed whether or not reordering happened. **Never test argument order with a commutative operator.**

## Related, same family

Three tables are top-level-only, and a block-local lambda is invisible to all of them: `collect_fn_param_labels` (this issue's second half), `collect_optional_param_fns`, and the checker's equivalent. The optional one has its own symptom — a block-local `(a: Int, b?: Int)` called as `o(7)` fails with `function arity mismatch for o: expected 2 args, got 1`, while the same declaration at top level works. That one at least has a diagnostic with `line:col`, so it is P1 (can't write it) rather than P0. Filing separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_