### PR TITLE
Fix companion transport: stale duplicate binding shadowed the real scheme (#1908)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -425,13 +425,9 @@ prepend). A *compound* placeholder such as `_ * 2` is a section lambda
 `List::length(xs)` when `xs`'s type is a USER type and the method is declared
 as a top-level fn in the **`Type::method` spelling** (`fn List::length(xs:
 List) -> Int`) — importing just the type is enough
-(`import ./list.vibe { List }` makes `xs |> length` work). The receiver
-must come from an ANNOTATED binding (`let xs: List[Int] = ...`): the
-dispatch heuristic reads `let x: T = ...` and param annotations, not a
-companion call's return type, so `List::of3(1,2,3) |> length` directly is
-`unknown name: length` (#1908; the indexed `for i, x in <companion call>`
-misses the iter protocol the same way). A BARE top-level
-`fn total(l: MyList)` is *not* a method: it keeps
+(`import ./list.vibe { List }` makes `List::of3(1,2,3) |> length`
+work — the companion call's return type drives the dispatch, #1908).
+A BARE top-level `fn total(l: MyList)` is *not* a method: it keeps
 normal call semantics (`total(l)`, and `l |> total` — the pipe is just a call),
 but `l.total()` does not resolve to it and reports a located
 ``no method `total` on `MyList` `` diagnostic (#953). A struct FIELD of the same

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -235,11 +235,28 @@ fn is_selected_type_companion(name: String, ty: Type, type_surface: Array[String
 fn bind_enum_constructor_companions(acc: TypeEnv, resolved: String, dep_bindings: Array[(String, Type)], enum_name: String, trait_mappings: Array[(String, String)]) -> TypeEnv {
   let qual_prefix = String::concat(enum_name, "::")
   let mut out = acc
+  // #1908: the dep's flat bindings can carry a name twice — the authoritative
+  // generalized scheme first, then a stale shadowed duplicate from the dep's
+  // own checking (e.g. the pre-generalization recursion binding of an `fn
+  // T::method`, still an unresolved var). `env_lookup_flat` answers with the
+  // FIRST entry, so an explicit `import { T::method }` transported the real
+  // scheme — but this loop bound every occurrence, and binds shadow earlier
+  // binds, so the LAST (stale, var-typed) duplicate won. The importing
+  // checker then typed `T::method(...)` as `?`, which silently disabled
+  // method-style dispatch on the result (`T::of(..) |> length` reported
+  // `unknown name: length`) and indexed-for classification. Bind each
+  // companion once, from its first flat entry, matching env_lookup_flat.
+  let seen = array_empty()
   let mut i = 0
   while i < Array::length(dep_bindings) {
     let (candidate_name, candidate_ty) = Array::get(dep_bindings, i)
     if candidate_name != enum_name && starts_with_upper(candidate_name) && (type_returns_name(candidate_ty, enum_name) || String::starts_with(candidate_name, qual_prefix)) {
-      out = env_bind_with_origin(out, candidate_name, trait_projection_map_type_bounds(candidate_ty, trait_mappings), BindingOriginModuleExport(resolved, candidate_name))
+      if contains_str(seen, candidate_name) {
+        ()
+      } else {
+        Array::push(seen, candidate_name)
+        out = env_bind_with_origin(out, candidate_name, trait_projection_map_type_bounds(candidate_ty, trait_mappings), BindingOriginModuleExport(resolved, candidate_name))
+      }
     }
     i = i + 1
   }

--- a/lib/@vibe/core/list_test.vibe
+++ b/lib/@vibe/core/list_test.vibe
@@ -125,17 +125,16 @@ test "List::contains_by" {
 
 test "list method style via type members" {
   // #1080: importing the List type binds its `List::` companions, so
-  // method-style pipes resolve without importing bare names. The receiver
-  // needs an annotated binding — the method-dispatch heuristic reads
-  // `let x: T = ...`, not the companion call's return type (#1908).
-  let xs: List[Int] = List::of3(1, 2, 3)
+  // method-style pipes resolve without importing bare names. #1908: the
+  // companion call's return type drives dispatch — no annotation needed.
+  let xs = List::of3(1, 2, 3)
   assert(eq(xs |> length, 3))
   assert(eq(xs |> sum, 6))
 }
 
 test "List iter / zip / flatmap" {
   let threshold = 0
-  let nums: List[Int] = List::of3(1, 2, 3)
+  let nums = List::of3(1, 2, 3)
   let count = List::iter(nums, (x: Int) -> Bool {
     x > threshold
   })
@@ -144,7 +143,7 @@ test "List iter / zip / flatmap" {
   })
   assert(eq(count, 3))
   assert(eq(count_method, 3))
-  let letters: List[String] = List::of3("a", "b", "c")
+  let letters = List::of3("a", "b", "c")
   let paired = List::zip(letters, List::of3(10, 20, 30))
   let paired_method = letters |> zip(List::of3(10, 20, 30))
   assert(eq(List::length(paired), 3))
@@ -157,7 +156,7 @@ test "List iter / zip / flatmap" {
     Some(("a", 10)) => assert(true),
     _ => assert(false)
   }
-  let odds: List[Int] = List::of3(1, 3, 5)
+  let odds = List::of3(1, 3, 5)
   let duplicated = List::flatmap(odds, (x: Int) -> List[Int] {
     List::append(List::singleton(x), List::singleton(x + 1))
   })
@@ -180,12 +179,10 @@ test "list for-in iterable" {
 
 test "list for-in iterable with index" {
   // #726 review follow-up: the indexed-Iterable for desugar must bind the
-  // optional index name (`for i, x in ...`) to the loop counter. Annotated
-  // binding: the indexed-protocol classification reads `let x: T = ...`,
-  // not the companion call's return type (#1908).
+  // optional index name (`for i, x in ...`) to the loop counter. #1908
+  // regression: the companion-call iterand types without an annotation.
   let mut weighted = 0
-  let xs: List[Int] = List::of3(10, 20, 30)
-  for i, x in xs {
+  for i, x in List::of3(10, 20, 30) {
     weighted = weighted + i * x
   }
   // 0*10 + 1*20 + 2*30 = 80

--- a/lib/@vibe/core/list_type_import_test.vibe
+++ b/lib/@vibe/core/list_type_import_test.vibe
@@ -7,8 +7,10 @@ import ./list.vibe {
 //# Misc
 
 test "list_method_with_type_import_only" {
-  // Annotated binding: method-style dispatch reads `let x: T = ...` (#1908).
-  let xs: List[Int] = List::of3(1, 2, 3)
+  // #1908 regression: the companion call's return type must drive
+  // method-style dispatch without an annotated binding.
+  let xs = List::of3(1, 2, 3)
   assert(eq(xs |> length, 3))
   assert(eq(xs |> sum, 6))
+  assert(eq(List::of3(4, 5, 6) |> length, 3))
 }


### PR DESCRIPTION
Closes #1908.

## Root cause

A dependency's flat value environment can carry a function name twice: the authoritative generalized scheme first, then a stale duplicate left by the dependency's own checking (the pre-generalization recursion binding of an `fn T::method`, still an unresolved var). `env_lookup_flat` answers with the FIRST entry — the documented duplicate-resolution rule ("duplicate names resolve through the same first-binding lookup used by the checker", `incremental_checked_env_identity`) — so an explicit `import { T::method }` transported the real scheme. But `bind_enum_constructor_companions`, which auto-binds `T::*` companions when the type `T` is imported (#1080), bound **every** flat occurrence in order; binds shadow earlier binds, so the last (stale, var-typed) duplicate won.

The importing checker then typed `T::method(...)` as an unresolved variable, which silently disabled everything keyed on the receiver's type:

- method-style dispatch: `List::of3(1,2,3) |> length` → `unknown name: length`
- indexed for-in classification: `for i, x in List::of3(..)` → "this iterator lowering would drop the index"
- companion arity/argument checking: `Box::of2(1)` against a 2-arg signature was **tolerated** (silent-wrong)

Constructors were unaffected because they have no recursion pre-bind and therefore no duplicate — which is why ctor pipes worked while companion pipes failed, and why #1908 only surfaced after #1843 removed the bare `list_*` imports that had been masking the companion path.

## Fix

Bind each companion once, from its first flat entry, matching the `env_lookup_flat` precedence. One-function change in `runtime/typecheck_fs.vibe`.

## Verification

Isolated two-file probes (dep exporting enum + `T::` companions, importer with only the type imported), all against the rebuilt stage2:

| probe | before | after |
|---|---|---|
| `Mono::pick() \|> tag` | unknown name: tag | clean |
| `Box::of2(1, 2) \|> length` (generic) | unknown name: length | clean |
| `Mono::tag(x, 9)` (arity misuse, auto-bound) | tolerated silently | arity error |
| `Box::of2(1)` (arity misuse, auto-bound) | tolerated silently | arity error |
| explicit `import { Box, Box::of2 }` misuse | arity error | arity error (unchanged) |
| ctor pipe `Full(..) \|> length` | clean | clean (unchanged) |

The list tests drop their #1908 annotated-binding workarounds and become the regression coverage (`list_type_import_test.vibe` now pipes a direct companion call); the cheatsheet caveat is replaced by the fixed behavior. Full `scripts/compiler_gate.sh` green locally on the rebuilt stage2, including the stricter checking now applied to auto-bound companion calls across the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC)_