### PR TITLE
Optimize one transitive borrowed wrapper layer

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -2887,6 +2887,100 @@ fn bp_param_base_name(raw: String) -> String {
   }
 }
 
+/// Cheap worklist predicate for the bounded transitive borrow round. A false
+/// positive (for example a shadowed direct callee) only causes re-analysis;
+/// a false negative would lose an optimization, so inspect every AST child.
+fn bp_calls_round0_borrow(e: Expr, round0_names: Array[String]) -> Bool {
+  match e {
+    EInt(_) => false,
+    EFloat(_) => false,
+    EString(_) => false,
+    EBool(_) => false,
+    EUnit => false,
+    EStringInterp(_) => false,
+    EIdent(_, _) => false,
+    ECall(callee, args, _) => {
+      let mut found = match callee {
+        EIdent(fname, _) => bsearch_leftmost(round0_names, fname) >= 0,
+        _ => bp_calls_round0_borrow(callee, round0_names)
+      }
+      let mut i = 0
+      while !found && i < Array::length(args) {
+        found = bp_calls_round0_borrow(Array::get(args, i), round0_names)
+        i = i + 1
+      }
+      found
+    },
+    ETuple(items) => bp_calls_round0_borrow_list(items, round0_names),
+    EArray(items) => bp_calls_round0_borrow_list(items, round0_names),
+    ERecord(_, fields, _) => bp_calls_round0_borrow_fields(fields, round0_names),
+    EMap(fields) => bp_calls_round0_borrow_fields(fields, round0_names),
+    EIf(c, t, f) => bp_calls_round0_borrow(c, round0_names) || bp_calls_round0_borrow(t, round0_names) || bp_calls_round0_borrow(f, round0_names),
+    ELet(_, v, b, _) => bp_calls_round0_borrow(v, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    ELetRec(_, v, b) => bp_calls_round0_borrow(v, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    ELetMut(_, v, b, _) => bp_calls_round0_borrow(v, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    EAssign(_, v, b) => bp_calls_round0_borrow(v, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    EAssignOp(_, _, v, b) => bp_calls_round0_borrow(v, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    ESeq(a, b) => bp_calls_round0_borrow(a, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    EMatch(scr, arms) => bp_calls_round0_borrow(scr, round0_names) || bp_calls_round0_borrow_arms(arms, round0_names),
+    EHandle(body, arms) => bp_calls_round0_borrow(body, round0_names) || bp_calls_round0_borrow_arms(arms, round0_names),
+    EWhile(c, b) => bp_calls_round0_borrow(c, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    ELoop(inits, b) => {
+      let mut found = false
+      let mut i = 0
+      while !found && i < Array::length(inits) {
+        let (_, init) = Array::get(inits, i)
+        found = bp_calls_round0_borrow(init, round0_names)
+        i = i + 1
+      }
+      found || bp_calls_round0_borrow(b, round0_names)
+    },
+    EForIn(_, _, iter, b) => bp_calls_round0_borrow(iter, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    EBinOp(_, a, b) => bp_calls_round0_borrow(a, round0_names) || bp_calls_round0_borrow(b, round0_names),
+    EUnaryOp(_, a) => bp_calls_round0_borrow(a, round0_names),
+    EFn(_, _, _, _, _, body) => bp_calls_round0_borrow(body, round0_names),
+    EDot(obj, _, _, _) => bp_calls_round0_borrow(obj, round0_names),
+    ELabeledArg(_, _, v) => bp_calls_round0_borrow(v, round0_names),
+    EReturn(v) => bp_calls_round0_borrow(v, round0_names),
+    EBreak(Some(v)) => bp_calls_round0_borrow(v, round0_names),
+    EBreak(None) => false,
+    EContinue(args) => bp_calls_round0_borrow_list(args, round0_names),
+    ESpread(v) => bp_calls_round0_borrow(v, round0_names)
+  }
+}
+
+fn bp_calls_round0_borrow_list(items: Array[Expr], round0_names: Array[String]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(items) {
+    found = bp_calls_round0_borrow(Array::get(items, i), round0_names)
+    i = i + 1
+  }
+  found
+}
+
+fn bp_calls_round0_borrow_fields(fields: Array[(String, Expr)], round0_names: Array[String]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(fields) {
+    let (_, value) = Array::get(fields, i)
+    found = bp_calls_round0_borrow(value, round0_names)
+    i = i + 1
+  }
+  found
+}
+
+fn bp_calls_round0_borrow_arms(arms: Array[(Pat, Expr)], round0_names: Array[String]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(arms) {
+    let (_, body) = Array::get(arms, i)
+    found = bp_calls_round0_borrow(body, round0_names)
+    i = i + 1
+  }
+  found
+}
+
 /// ADR-0092 borrow-inference: for every top-level fn, which of its
 /// parameters are only ever READ. Each such position's ABI flips to
 /// borrowed, program-wide and in lockstep: the caller's plan counts an
@@ -2920,9 +3014,14 @@ fn bp_param_base_name(raw: String) -> String {
 ///     conventional entry names: the host invokes them without consulting
 ///     the set either)
 ///
-/// `md_consume_count` is used WITHOUT a user borrow set on purpose: this
-/// computation must not consume its own output (a fixpoint would make each
-/// position's eligibility depend on positions still being decided).
+/// Round 0 uses `md_consume_count` without a user borrow set and exactly
+/// preserves the original conservative result. One bounded transitive round
+/// then reads that immutable snapshot through `md_consume_count_pre`; it never
+/// consumes masks being decided in the same round. Only bodies that actually
+/// call a round-0 borrowed function are revisited. A local callee shadow zeros
+/// that function's mask before counting, preserving the owned-call fallback.
+/// This deliberately stops after one extra layer: deeper closure is a possible
+/// future worklist extension, while every intermediate result stays sound.
 ///
 /// Returns the SORTED name array of fns with a non-zero mask and fills
 /// `out_masks` aligned to it, so a single `bsearch_leftmost` on the names
@@ -2936,8 +3035,7 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
   let nonident_pos = array_empty()
   let _ = ca_walk_stmts_nonident_args(stmts, nonident_fns, nonident_pos)
   // Fold the (callee, position) pairs into one mask per callee of the
-  // positions that must STAY owned, so the per-function loop below is a
-  // single hash lookup instead of a scan of the whole pair list.
+  // positions that must STAY owned, so both rounds share the same index.
   let nonident: MutMap[String, Int] = MutMap::new_string()
   let mut ni = 0
   while ni < Array::length(nonident_fns) {
@@ -2954,8 +3052,6 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
     }
     ni = ni + 1
   }
-  // Same shape as compute_may_return_view_fns below: the set is complete
-  // before this loop starts and was then linearly scanned once per function.
   let valued_srt = sorted_names_of(valued)
   let excluded_srt = sorted_names_of(exclude)
   let names = array_empty()
@@ -3002,9 +3098,71 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
     }
     si = si + 1
   }
-  // Sort the names, then re-read each mask by name. Rebuilding the mask
-  // array from the SORTED names (rather than sorting two arrays in step)
-  // makes misalignment unrepresentable.
+  let round0_names = sorted_names_of(names)
+  let round0_masks: Array[Int] = [
+  ]
+  let mut rmi = 0
+  while rmi < Array::length(round0_names) {
+    Array::push(round0_masks, match MutMap::get(masks, Array::get(round0_names, rmi)) {
+      Some(m) => m,
+      None => 0
+    })
+    rmi = rmi + 1
+  }
+  // One transitive step captures most of the useful wrapper chains while
+  // keeping the analysis bounded. Read only the complete round-0 snapshot;
+  // updates land in `masks` for the final result and never feed this round.
+  si = 0
+  while si < Array::length(stmts) {
+    match Array::get(stmts, si) {
+      SLet(_, _, fname, _, fval) => match fval {
+        EFn(_, _, fps, _, _, fbody) => if bsearch_leftmost(valued_srt, fname) < 0 && bsearch_leftmost(excluded_srt, fname) < 0 && bp_calls_round0_borrow(fbody, round0_names) {
+          let owned_bits = match MutMap::get(nonident, fname) {
+            Some(m) => m,
+            None => 0
+          }
+          let prev_mask = match MutMap::get(masks, fname) {
+            Some(m) => m,
+            None => 0
+          }
+          let mut mask = prev_mask
+          let body_masks = md_shadow_zeroed_bmasks(fbody, round0_names, round0_masks)
+          let mut pi = 0
+          let np = Array::length(fps)
+          let lim = if np < bmask_max_param() {
+            np
+          } else {
+            bmask_max_param()
+          }
+          while pi < lim {
+            let (praw, _) = Array::get(fps, pi)
+            let pn = bp_param_base_name(praw)
+            if !bmask_has(mask, pi) && pn != "" && !bmask_has(owned_bits, pi) && md_consume_count_pre(fbody, pn, round0_names, body_masks) == 0 && !is_mut_captured_in(fbody, pn) {
+              mask = mask|(1<<pi)
+            } else {
+              ()
+            }
+            pi = pi + 1
+          }
+          if mask != prev_mask {
+            if prev_mask == 0 {
+              Array::push(names, fname)
+            } else {
+              ()
+            }
+            MutMap::set(masks, fname, mask)
+          } else {
+            ()
+          }
+        } else {
+          ()
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    si = si + 1
+  }
   let names_srt = sorted_names_of(names)
   let mut oi = 0
   while oi < Array::length(names_srt) {

--- a/lib/@vibe/compiler/tests/borrow_param_transitive_test.vibe
+++ b/lib/@vibe/compiler/tests/borrow_param_transitive_test.vibe
@@ -1,0 +1,70 @@
+import @vibe/compiler/core {
+  Expr, Stmt
+}
+
+import @vibe/compiler/codegen/common_analysis {
+  compute_borrow_param_user_fns
+}
+
+fn one_param_fn(name: String, param: String, body: Expr) -> Stmt {
+  SLet(false, false, name, None, EFn([
+  ], [
+  ], [
+    (param, None)
+  ], None, None, body))
+}
+
+fn mask_for(names: Array[String], masks: Array[Int], name: String) -> Int {
+  let mut i = 0
+  let mut found = 0
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = Array::get(masks, i)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+test "one transitive wrapper layer inherits a borrowed parameter" {
+  let leaf = one_param_fn("leaf", "xs", ECall(EIdent("Array::length", -1), [
+    EIdent("xs", -1)
+  ], -1))
+  let wrapper = one_param_fn("wrapper", "xs", ECall(EIdent("leaf", -1), [
+    EIdent("xs", -1)
+  ], -1))
+  let masks: Array[Int] = [
+  ]
+  let names = compute_borrow_param_user_fns([
+    leaf,
+    wrapper
+  ], [
+  ], masks)
+  assert_eq(mask_for(names, masks, "leaf"), 1)
+  assert_eq(mask_for(names, masks, "wrapper"), 1)
+}
+
+test "a local callee shadow does not inherit the top-level borrow ABI" {
+  let reader = one_param_fn("reader", "xs", ECall(EIdent("Array::length", -1), [
+    EIdent("xs", -1)
+  ], -1))
+  let local_reader = EFn([
+  ], [
+  ], [
+    ("value", None)
+  ], None, None, EIdent("value", -1))
+  let shadowed = one_param_fn("shadowed", "xs", ELet("reader", local_reader, ECall(EIdent("reader", -1), [
+    EIdent("xs", -1)
+  ], -1), -1))
+  let masks: Array[Int] = [
+  ]
+  let names = compute_borrow_param_user_fns([
+    reader,
+    shadowed
+  ], [
+  ], masks)
+  assert_eq(mask_for(names, masks, "reader"), 1)
+  assert_eq(mask_for(names, masks, "shadowed"), 0)
+}


### PR DESCRIPTION
## Summary

- preserve the existing conservative round-0 borrow inference
- add one bounded transitive round over an immutable round-0 snapshot
- keep local callee shadows on the owned ABI and only revisit relevant wrappers

## Verification

- Red: the old analysis did not infer a wrapper around a borrowed leaf
- `pkf run generation-gate` (stage2 == stage3)
- focused borrow/fmt regressions: 30 tests
- full unit battery: 660/660
- `pkf run test-pre-commit`
- selfcompile heap: 1,064,388,672 bytes (below 1,105,822,775 policy ceiling)
- parser_expr wasm: 392,608 -> 390,427 bytes (-0.56%)

Closes #1740
