### PR TITLE
feat(normalize): preserve binder authority through labeled args

### DIFF
--- a/fixtures/parser_binder_slot_authority_test.vibe
+++ b/fixtures/parser_binder_slot_authority_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ../lib/@vibe/ast {
-  Expr, Stmt
+  Expr, Pat, Stmt, TypeExpr
 }
 
 import ../lib/@vibe/parser {
@@ -16,7 +16,9 @@ import ../lib/@vibe/parser {
   binder_authority_node_slots,
   binder_authority_slot_binder,
   binder_authority_slot_role,
+  detach_stmts,
   located_program_binder_authority_nodes,
+  located_program_binder_authority_program,
   located_program_binder_authority_rows,
   parse_source_located_with_binder_authority,
   validate_program_binder_rows
@@ -204,6 +206,133 @@ test "forgeable sidecar nodes remain data and do not mint parser authority" {
   inspect(Array::length(binder_authority_node_slots(forged)), "1")
   inspect(Array::length(binder_authority_node_children(forged)), "0")
   // There is intentionally no resolver, AST scan, or authority-accepting API.
+}
+
+test "AST detachment traverses statement pattern type and expression families" {
+  let original: Array[Stmt] = [
+    SModule(true, "M", [
+      STypeAlias(true, "Box", [
+        "T"
+      ], TyApp("Pair", [
+        TyTuple([
+          TyName("T")
+        ])
+      ])),
+      SLetPat(PStruct("Pair", [
+        ("value", PCtor("Some", [
+          PBind("same")
+        ]))
+      ]), EFn([
+        "T"
+      ], [
+        ("T", [
+          "Bound"
+        ])
+      ], [
+        ("same", Some(TyTuple([
+          TyName("T")
+        ])))
+      ], Some(TyName("T")), None, ERecord("Pair", [
+        ("value", EMatch(EInt(1), [
+          (PBind("same"), EArray([
+            EInt(2)
+          ]))
+        ]))
+      ], [
+        TyName("T")
+      ])))
+    ])
+  ]
+  let detached = detach_stmts(original)
+  match Array::get(original, 0) {
+    SModule(_, _, stmts) => {
+      Array::truncate(stmts, 1)
+      match Array::get(stmts, 0) {
+        STypeAlias(_, _, params, TyApp(_, args)) => {
+          Array::truncate(params, 0)
+          Array::truncate(args, 0)
+        },
+        _ => inspect(false, "true")
+      }
+    },
+    _ => inspect(false, "true")
+  }
+  Array::truncate(original, 0)
+  match Array::get(detached, 0) {
+    SModule(_, "M", stmts) => {
+      inspect(Array::length(stmts), "2")
+      match Array::get(stmts, 0) {
+        STypeAlias(_, "Box", params, TyApp("Pair", args)) => {
+          inspect(Array::length(params), "1")
+          inspect(Array::length(args), "1")
+        },
+        _ => inspect(false, "true")
+      }
+      match Array::get(stmts, 1) {
+        SLetPat(PStruct(_, fields), EFn(type_params, bounds, params, _, _, ERecord(_, expr_fields, type_args))) => {
+          inspect(Array::length(fields), "1")
+          inspect(Array::length(type_params), "1")
+          inspect(Array::length(bounds), "1")
+          inspect(Array::length(params), "1")
+          inspect(Array::length(expr_fields), "1")
+          inspect(Array::length(type_args), "1")
+        },
+        _ => inspect(false, "true")
+      }
+    },
+    _ => inspect(false, "true")
+  }
+}
+
+test "aggregate program materialization recursively detaches params calls fields and arms" {
+  let source = "fn target(x: Int, y: Int) -> Int { 0 }\nfn main() -> Int { target(y=match 1 { same => same }, x=Pair::{ value: 1 }) }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => {
+      let first = located_program_binder_authority_program(authority)
+      match Array::get(first, 0) {
+        SLet(_, _, _, _, EFn(_, _, params, _, _, _)) => Array::set(params, 0, ("forged", None)),
+        _ => inspect(false, "true")
+      }
+      match Array::get(first, 1) {
+        SLet(_, _, _, _, EFn(_, _, _, _, _, ECall(_, args, _))) => {
+          match Array::get(args, 0) {
+            ELabeledArg(_, _, EMatch(_, arms)) => Array::truncate(arms, 0),
+            _ => inspect(false, "true")
+          }
+          match Array::get(args, 1) {
+            ELabeledArg(_, _, ERecord(_, fields, _)) => Array::truncate(fields, 0),
+            _ => inspect(false, "true")
+          }
+          Array::set(args, 0, Array::get(args, 1))
+          Array::truncate(args, 1)
+        },
+        _ => inspect(false, "true")
+      }
+      let second = located_program_binder_authority_program(authority)
+      match Array::get(second, 0) {
+        SLet(_, _, _, _, EFn(_, _, params, _, _, _)) => {
+          inspect(Array::get(params, 0).0, "x")
+          inspect(Array::length(params), "2")
+        },
+        _ => inspect(false, "true")
+      }
+      match Array::get(second, 1) {
+        SLet(_, _, _, _, EFn(_, _, _, _, _, ECall(_, args, _))) => {
+          inspect(Array::length(args), "2")
+          match Array::get(args, 0) {
+            ELabeledArg("y", _, EMatch(_, arms)) => inspect(Array::length(arms), "1"),
+            _ => inspect(false, "true")
+          }
+          match Array::get(args, 1) {
+            ELabeledArg("x", _, ERecord(_, fields, _)) => inspect(Array::length(fields), "1"),
+            _ => inspect(false, "true")
+          }
+        },
+        _ => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
 }
 
 test "aggregate node materialization is recursively detached across repeated access" {

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -8,6 +8,7 @@ vibe_parser	../../../lib/@vibe/parser/float_format.vibe
 vibe_parser	../../../lib/@vibe/parser/lexer.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_base.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_binder_context.vibe
+vibe_parser	../../../lib/@vibe/parser/ast_detach.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_binder_authority.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_expr_primary.vibe
 vibe_parser	../../../lib/@vibe/parser/parser_expr_core.vibe

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8,7 +8,174 @@ import @vibe/core {
   array_empty
 }
 
+import @vibe/parser {
+  BinderAuthorityNode,
+  BinderAuthorityNodeKind,
+  BinderAuthoritySlot,
+  BinderSemanticRole,
+  LocatedProgramBinderAuthority,
+  SourceBinder,
+  binder_authority_node_children,
+  binder_authority_node_kind,
+  binder_authority_node_slots,
+  binder_authority_slot_binder,
+  binder_authority_slot_role,
+  detach_stmts,
+  located_program_binder_authority_nodes,
+  located_program_binder_authority_program
+}
+
 //# Functions
+
+enum StoredNormalizedBinderAuthority {
+  StoredNormalizedAuthorityNil;
+  StoredNormalizedAuthoritySlot(BinderAuthoritySlot, StoredNormalizedBinderAuthority);
+  StoredNormalizedAuthorityNode(BinderAuthorityNodeKind, StoredNormalizedBinderAuthority, StoredNormalizedBinderAuthority);
+  StoredNormalizedAuthorityChild(StoredNormalizedBinderAuthority, StoredNormalizedBinderAuthority)
+}
+
+export struct NormalizedProgramBinderAuthority {
+  nodes: StoredNormalizedBinderAuthority
+}
+
+enum StoredLabeledArgBinderAuthorityNormalization {
+  StoredLabeledArgBinderAuthorityNormalizationValue(Array[Stmt], Option[NormalizedProgramBinderAuthority])
+}
+
+export struct LabeledArgBinderAuthorityNormalization {
+  stored: StoredLabeledArgBinderAuthorityNormalization
+}
+
+fn paired_poison(poisoned: Array[Bool]) -> Unit {
+  Array::set(poisoned, 0, true)
+}
+
+fn paired_child_or_self(node: BinderAuthorityNode, index: Int, poisoned: Array[Bool]) -> BinderAuthorityNode {
+  let children = binder_authority_node_children(node)
+  if index < 0 || index >= Array::length(children) {
+    paired_poison(poisoned)
+    node
+  } else {
+    Array::get(children, index)
+  }
+}
+
+fn paired_expect_node(node: BinderAuthorityNode, kind: BinderAuthorityNodeKind, slots: Int, children: Int, poisoned: Array[Bool]) -> Unit {
+  let actual_slots = binder_authority_node_slots(node)
+  let actual_children = binder_authority_node_children(node)
+  if binder_authority_node_kind(node) != kind || Array::length(actual_slots) != slots || Array::length(actual_children) != children {
+    paired_poison(poisoned)
+  } else {
+    ()
+  }
+  for slot in actual_slots {
+    match binder_authority_slot_binder(slot) {
+      Synthetic(_, _) => paired_poison(poisoned),
+      SourceToken(_, _, _) => ()
+    }
+  }
+  ()
+}
+
+fn paired_expect_slot(node: BinderAuthorityNode, index: Int, role: BinderSemanticRole, name: String, poisoned: Array[Bool]) -> Unit {
+  let slots = binder_authority_node_slots(node)
+  if index < 0 || index >= Array::length(slots) {
+    paired_poison(poisoned)
+  } else {
+    let slot = Array::get(slots, index)
+    let actual_name = match binder_authority_slot_binder(slot) {
+      SourceToken(n, _, _) => n,
+      Synthetic(n, _) => {
+        paired_poison(poisoned)
+        n
+      }
+    }
+    if binder_authority_slot_role(slot) != role || actual_name != name {
+      paired_poison(poisoned)
+    } else {
+      ()
+    }
+  }
+}
+
+fn stored_normalized_authority_slots(slots: Array[BinderAuthoritySlot], at: Int) -> StoredNormalizedBinderAuthority {
+  if at >= Array::length(slots) {
+    StoredNormalizedAuthorityNil
+  } else {
+    StoredNormalizedAuthoritySlot(Array::get(slots, at), stored_normalized_authority_slots(slots, at + 1))
+  }
+}
+
+fn stored_normalized_authority_node(node: BinderAuthorityNode) -> StoredNormalizedBinderAuthority {
+  StoredNormalizedAuthorityNode(binder_authority_node_kind(node), stored_normalized_authority_slots(binder_authority_node_slots(node), 0), stored_normalized_authority_nodes(binder_authority_node_children(node), 0))
+}
+
+fn stored_normalized_authority_nodes(nodes: Array[BinderAuthorityNode], at: Int) -> StoredNormalizedBinderAuthority {
+  if at >= Array::length(nodes) {
+    StoredNormalizedAuthorityNil
+  } else {
+    StoredNormalizedAuthorityChild(stored_normalized_authority_node(Array::get(nodes, at)), stored_normalized_authority_nodes(nodes, at + 1))
+  }
+}
+
+fn append_normalized_materialized_slots(stored: StoredNormalizedBinderAuthority, out: ArrayBuilder[BinderAuthoritySlot]) -> Unit {
+  match stored {
+    StoredNormalizedAuthoritySlot(slot, rest) => {
+      ArrayBuilder::push(out, slot)
+      append_normalized_materialized_slots(rest, out)
+    },
+    _ => ()
+  }
+}
+
+fn normalized_materialize_authority_node(stored: StoredNormalizedBinderAuthority) -> BinderAuthorityNode {
+  match stored {
+    StoredNormalizedAuthorityNode(kind, slots, children) => {
+      let slot_out = ArrayBuilder::new()
+      append_normalized_materialized_slots(slots, slot_out)
+      let child_out = ArrayBuilder::new()
+      append_normalized_materialized_nodes(children, child_out)
+      BinderAuthorityNode::{
+        kind,
+        slots: ArrayBuilder::freeze(slot_out),
+        children: ArrayBuilder::freeze(child_out)
+      }
+    },
+    _ => BinderAuthorityNode::{
+      kind: AuthorityExprUnit,
+      slots: ArrayBuilder::freeze(ArrayBuilder::new()),
+      children: ArrayBuilder::freeze(ArrayBuilder::new())
+    }
+  }
+}
+
+fn append_normalized_materialized_nodes(stored: StoredNormalizedBinderAuthority, out: ArrayBuilder[BinderAuthorityNode]) -> Unit {
+  match stored {
+    StoredNormalizedAuthorityChild(node, rest) => {
+      ArrayBuilder::push(out, normalized_materialize_authority_node(node))
+      append_normalized_materialized_nodes(rest, out)
+    },
+    _ => ()
+  }
+}
+
+export fn labeled_arg_binder_authority_normalization_program(result: LabeledArgBinderAuthorityNormalization) -> Array[Stmt] {
+  match result.stored {
+    StoredLabeledArgBinderAuthorityNormalizationValue(program, _) => detach_stmts(program)
+  }
+}
+
+export fn labeled_arg_binder_authority_normalization_authority(result: LabeledArgBinderAuthorityNormalization) -> Option[NormalizedProgramBinderAuthority] {
+  match result.stored {
+    StoredLabeledArgBinderAuthorityNormalizationValue(_, authority) => authority
+  }
+}
+
+export fn normalized_program_binder_authority_nodes(authority: NormalizedProgramBinderAuthority) -> Array[BinderAuthorityNode] {
+  let out = ArrayBuilder::new()
+  append_normalized_materialized_nodes(authority.nodes, out)
+  ArrayBuilder::freeze(out)
+}
 
 // Dictionary-passing desugaring for method-bearing traits (#641 PR-3
 // components 3+4). Runs pre-check, after string-interpolation expansion. It is
@@ -9144,7 +9311,6 @@ fn optional_fill_args(args: Array[Expr], flags: Array[Bool]) -> Array[Expr] {
   }
 }
 
-///|
 fn lookup_param_labels(tbl: Array[(String, Array[String])], fname: String) -> Option[Array[String]] {
   let mut i = 0
   let mut found = None
@@ -9160,84 +9326,74 @@ fn lookup_param_labels(tbl: Array[(String, Array[String])], fname: String) -> Op
   found
 }
 
-///|
-/// Reorder a fully-labeled arg list into `param_labels` order. None when the call
-/// is not a candidate (arity mismatch, some arg not labeled, or a label matches no
-/// parameter) — the caller then leaves the args untouched.
-fn reorder_labeled_args(args: Array[Expr], param_labels: Array[String]) -> Option[Array[Expr]] {
+fn labeled_reorder_candidate(args: Array[Expr], param_labels: Array[String]) -> Bool {
   if Array::length(args) != Array::length(param_labels) {
-    None
+    false
   } else {
     let mut all_labeled = true
     let mut i = 0
     while i < Array::length(args) {
-      let is_lbl = match Array::get(args, i) {
-        ELabeledArg(_, _, _) => true,
-        _ => false
-      }
-      if is_lbl {
-        ()
-      } else {
-        all_labeled = false
+      match Array::get(args, i) {
+        ELabeledArg(_, _, _) => (),
+        _ => {
+          all_labeled = false
+        }
       }
       i = i + 1
     }
-    if !all_labeled {
-      None
-    } else {
-      let out = empty_expr_array()
-      let mut ok = true
-      let mut pj = 0
-      while pj < Array::length(param_labels) {
-        let want = Array::get(param_labels, pj)
-        let mut fk = -1
-        let mut k = 0
-        while k < Array::length(args) {
-          match Array::get(args, k) {
-            ELabeledArg(lbl, _, _) => if lbl == want && fk < 0 {
-              fk = k
-            } else {
-              ()
-            },
-            _ => ()
-          }
-          k = k + 1
-        }
-        if fk < 0 {
-          ok = false
-          pj = Array::length(param_labels)
-        } else {
-          Array::push(out, Array::get(args, fk))
-          pj = pj + 1
-        }
-      }
-      if ok {
-        Some(out)
+    all_labeled
+  }
+}
+
+fn labeled_source_index(args: Array[Expr], wanted: String) -> Int {
+  let mut found = -1
+  let mut i = 0
+  while i < Array::length(args) {
+    match Array::get(args, i) {
+      ELabeledArg(label, _, _) => if label == wanted && found < 0 {
+        found = i
       } else {
-        None
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn label_matches_position(arg: Expr, labels: Array[String], index: Int) -> Bool {
+  match arg {
+    ELabeledArg(label, _, _) => index < Array::length(labels) && Array::get(labels, index) == label,
+    _ => false
+  }
+}
+
+fn reorder_labeled_args(args: Array[Expr], param_labels: Array[String]) -> Option[Array[Expr]] {
+  if !labeled_reorder_candidate(args, param_labels) {
+    None
+  } else {
+    let out = empty_expr_array()
+    let mut ok = true
+    let mut pj = 0
+    while pj < Array::length(param_labels) {
+      let fk = labeled_source_index(args, Array::get(param_labels, pj))
+      if fk < 0 {
+        ok = false
+        pj = Array::length(param_labels)
+      } else {
+        Array::push(out, Array::get(args, fk))
+        pj = pj + 1
       }
+    }
+    if ok {
+      Some(out)
+    } else {
+      None
     }
   }
 }
 
-///|
-/// #986 (Codex P2-2 on #993): is `name` lexically shadowed at this point? The
-/// table indexes TOP-LEVEL functions only, so a local binding of the same name
-/// (`let f = (y) -> ..` / a fn param / a pattern bind) must suppress both the
-/// reorder and the label-name validation — the call resolves to the local
-/// value, whose parameter names the table knows nothing about.
-
-///|
-/// Strip the ELabeledArg wrappers off a VALIDATED arg list (labels confirmed to
-/// match their positions — either via a successful full reorder, or
-/// individually below). Codegen binds positionally and ignores labels, so this
-/// is semantically neutral there; for the checker it is the RESOLUTION MARKER:
-/// a stripped arg participates in strict positional unification, while a
-/// surviving ELabeledArg means "label correspondence unknown here" and types
-/// tolerantly (see check_expr's ELabeledArg arm) — the erroneous local shapes
-/// are reported by name (check_labeled_arg_names_stmts), and import-resolved
-/// callees (whose param names this module cannot see, Codex P2-1 on #993) are
-/// no longer falsely rejected by position.
 fn strip_labeled_wrappers(args: Array[Expr]) -> Array[Expr] {
   let out = empty_expr_array()
   let mut i = 0
@@ -9251,19 +9407,13 @@ fn strip_labeled_wrappers(args: Array[Expr]) -> Array[Expr] {
   out
 }
 
-///|
-/// For a call that could NOT be fully reordered (partial labeling, or some
-/// label mismatched): strip only the labeled args whose label already matches
-/// the parameter at their own position — those are positionally correct
-/// decorative labels and must stay strictly type-checked. Mismatched ones are
-/// kept for the name-validation walk to report.
 fn strip_in_position_labels(args: Array[Expr], labels: Array[String]) -> Array[Expr] {
   let out = empty_expr_array()
   let mut i = 0
   while i < Array::length(args) {
     let arg = Array::get(args, i)
     match arg {
-      ELabeledArg(lbl, m, v) => if i < Array::length(labels) && Array::get(labels, i) == lbl {
+      ELabeledArg(lbl, m, v) => if label_matches_position(arg, labels, i) {
         Array::push(out, v)
       } else {
         Array::push(out, ELabeledArg(lbl, m, v))
@@ -9275,7 +9425,146 @@ fn strip_in_position_labels(args: Array[Expr], labels: Array[String]) -> Array[E
   out
 }
 
-///|
+fn paired_expect_pat(pat: Pat, node: BinderAuthorityNode, poisoned: Array[Bool]) -> Unit {
+  match pat {
+    PBind(name) => {
+      paired_expect_node(node, AuthorityPatBind, 1, 0, poisoned)
+      paired_expect_slot(node, 0, PatternBinder, name, poisoned)
+    },
+    PCtor(_, pats) => {
+      paired_expect_node(node, AuthorityPatCtor, 0, Array::length(pats), poisoned)
+      let mut i = 0
+      while i < Array::length(pats) {
+        paired_expect_pat(Array::get(pats, i), paired_child_or_self(node, i, poisoned), poisoned)
+        i = i + 1
+      }
+    },
+    PTuple(pats) => {
+      paired_expect_node(node, AuthorityPatTuple, 0, Array::length(pats), poisoned)
+      let mut i = 0
+      while i < Array::length(pats) {
+        paired_expect_pat(Array::get(pats, i), paired_child_or_self(node, i, poisoned), poisoned)
+        i = i + 1
+      }
+    },
+    PStruct(_, fields) => {
+      paired_expect_node(node, AuthorityPatStruct, 0, Array::length(fields), poisoned)
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (_, child) = Array::get(fields, i)
+        paired_expect_pat(child, paired_child_or_self(node, i, poisoned), poisoned)
+        i = i + 1
+      }
+    },
+    POr(_, _) => paired_poison(poisoned),
+    PWild => paired_expect_node(node, AuthorityPatWild, 0, 0, poisoned),
+    PInt(_) => paired_expect_node(node, AuthorityPatInt, 0, 0, poisoned),
+    PFloat(_) => paired_expect_node(node, AuthorityPatFloat, 0, 0, poisoned),
+    PString(_) => paired_expect_node(node, AuthorityPatString, 0, 0, poisoned),
+    PBool(_) => paired_expect_node(node, AuthorityPatBool, 0, 0, poisoned)
+  }
+}
+
+fn paired_promote_wrapper(parent: BinderAuthorityNode, index: Int, poisoned: Array[Bool]) -> Unit {
+  let wrapper = paired_child_or_self(parent, index, poisoned)
+  paired_expect_node(wrapper, AuthorityExprLabeledArg, 0, 1, poisoned)
+  let children = binder_authority_node_children(wrapper)
+  if binder_authority_node_kind(wrapper) == AuthorityExprLabeledArg && Array::length(binder_authority_node_slots(wrapper)) == 0 && Array::length(children) == 1 {
+    Array::set(parent.children, index, Array::get(children, 0))
+  } else {
+    paired_poison(poisoned)
+  }
+}
+
+fn strip_labeled_wrappers_paired(args: Array[Expr], node: BinderAuthorityNode, poisoned: Array[Bool]) -> Array[Expr] {
+  let out = empty_expr_array()
+  let mut i = 0
+  while i < Array::length(args) {
+    match Array::get(args, i) {
+      ELabeledArg(_, _, value) => {
+        paired_promote_wrapper(node, i + 1, poisoned)
+        Array::push(out, value)
+      },
+      other => Array::push(out, other)
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn strip_in_position_labels_paired(args: Array[Expr], labels: Array[String], node: BinderAuthorityNode, poisoned: Array[Bool]) -> Array[Expr] {
+  let out = empty_expr_array()
+  let mut i = 0
+  while i < Array::length(args) {
+    let arg = Array::get(args, i)
+    match arg {
+      ELabeledArg(label, marker, value) => if label_matches_position(arg, labels, i) {
+        paired_promote_wrapper(node, i + 1, poisoned)
+        Array::push(out, value)
+      } else {
+        Array::push(out, ELabeledArg(label, marker, value))
+      },
+      other => Array::push(out, other)
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn paired_poison_surviving_labels(args: Array[Expr], poisoned: Array[Bool]) -> Unit {
+  let mut i = 0
+  while i < Array::length(args) {
+    match Array::get(args, i) {
+      ELabeledArg(_, _, _) => paired_poison(poisoned),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+fn optional_fill_args_paired(args: Array[Expr], flags: Array[Bool], poisoned: Array[Bool]) -> Array[Expr] {
+  let np = Array::length(flags)
+  let na = Array::length(args)
+  if na > np {
+    args
+  } else {
+    let mut fillable = true
+    let mut k = na
+    while k < np {
+      if !Array::get(flags, k) {
+        fillable = false
+      } else {
+        ()
+      }
+      k = k + 1
+    }
+    if !fillable {
+      args
+    } else {
+      let out = empty_expr_array()
+      let mut i = 0
+      while i < np {
+        if i < na {
+          let arg = Array::get(args, i)
+          if Array::get(flags, i) && !opt_arg_already_option(arg) {
+            paired_poison(poisoned)
+            Array::push(out, ECall(EIdent("Some", 0 - 1), [
+              arg
+            ], 0 - 1))
+          } else {
+            Array::push(out, arg)
+          }
+        } else {
+          paired_poison(poisoned)
+          Array::push(out, EIdent("None", 0 - 1))
+        }
+        i = i + 1
+      }
+      out
+    }
+  }
+}
+
 fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[String]) -> Expr {
   match expr {
     ECall(callee, args, off) => {
@@ -9283,10 +9572,6 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
         relabel_expr(a, tbl, shadows)
       }
       let rcallee = relabel_expr(callee, tbl, shadows)
-      // #986: `tbl` now holds EVERY top-level function (not just `~`-labeled
-      // ones), so gate the linear table scan on the call actually carrying a
-      // labeled argument — labeled calls are rare, plain calls are the entire
-      // program.
       let mut any_labeled_arg = false
       let mut la_i = 0
       while la_i < Array::length(rargs) {
@@ -9316,8 +9601,6 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       } else {
         rargs
       }
-      // #1500: fill / wrap optional parameters AFTER label reordering, so the
-      // flags line up with declared parameter order.
       let opt_args = match callee {
         EIdent(fname, _) => if str_array_contains(shadows, fname) {
           final_args
@@ -9471,7 +9754,6 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
   }
 }
 
-///|
 fn relabel_stmt(stmt: Stmt, tbl: Array[(String, Array[String])]) -> Stmt {
   match stmt {
     SLet(ex, rc, name, ty, body) => SLet(ex, rc, name, ty, relabel_expr(body, tbl, empty_str_array())),
@@ -9484,6 +9766,430 @@ fn relabel_stmt(stmt: Stmt, tbl: Array[(String, Array[String])]) -> Stmt {
       relabel_stmt(s, tbl)
     }),
     _ => stmt
+  }
+}
+
+fn relabel_expr_paired_child(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[String], node: BinderAuthorityNode, index: Int, poisoned: Array[Bool]) -> Expr {
+  relabel_expr_paired(expr, tbl, shadows, paired_child_or_self(node, index, poisoned), poisoned)
+}
+
+fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[String], node: BinderAuthorityNode, poisoned: Array[Bool]) -> Expr {
+  match expr {
+    ECall(callee, args, off) => {
+      paired_expect_node(node, AuthorityExprCall, 0, Array::length(args) + 1, poisoned)
+      let original_children = binder_authority_node_children(node)
+      let mut ai = 0
+      let rargs = for arg in args {
+        let child = paired_child_or_self(node, ai + 1, poisoned)
+        ai = ai + 1
+        relabel_expr_paired(arg, tbl, shadows, child, poisoned)
+      }
+      let rcallee = relabel_expr_paired_child(callee, tbl, shadows, node, 0, poisoned)
+      let mut any_labeled = false
+      let mut li = 0
+      while li < Array::length(rargs) {
+        match Array::get(rargs, li) {
+          ELabeledArg(_, _, _) => {
+            any_labeled = true
+          },
+          _ => ()
+        }
+        li = li + 1
+      }
+      let resolved = if any_labeled {
+        match callee {
+          EIdent(fname, _) => if str_array_contains(shadows, fname) {
+            rargs
+          } else {
+            match lookup_param_labels(tbl, fname) {
+              Some(labels) => if labeled_reorder_candidate(rargs, labels) {
+                let reordered = empty_expr_array()
+                let used = for _ in rargs {
+                  false
+                }
+                let mut ok = true
+                let mut pi = 0
+                while pi < Array::length(labels) {
+                  let source = labeled_source_index(rargs, Array::get(labels, pi))
+                  if source < 0 {
+                    paired_poison(poisoned)
+                    ok = false
+                    pi = Array::length(labels)
+                  } else {
+                    Array::push(reordered, Array::get(rargs, source))
+                    if Array::get(used, source) || source + 1 >= Array::length(original_children) {
+                      paired_poison(poisoned)
+                    } else {
+                      Array::set(used, source, true)
+                      Array::set(node.children, pi + 1, Array::get(original_children, source + 1))
+                    }
+                    pi = pi + 1
+                  }
+                }
+                if ok {
+                  strip_labeled_wrappers_paired(reordered, node, poisoned)
+                } else {
+                  strip_in_position_labels_paired(rargs, labels, node, poisoned)
+                }
+              } else {
+                paired_poison(poisoned)
+                strip_in_position_labels_paired(rargs, labels, node, poisoned)
+              },
+              None => rargs
+            }
+          },
+          _ => rargs
+        }
+      } else {
+        rargs
+      }
+      let final_args = match callee {
+        EIdent(fname, _) => if str_array_contains(shadows, fname) {
+          resolved
+        } else {
+          match optional_param_flags(fname) {
+            Some(flags) => optional_fill_args_paired(resolved, flags, poisoned),
+            None => resolved
+          }
+        },
+        _ => resolved
+      }
+      paired_poison_surviving_labels(final_args, poisoned)
+      ECall(rcallee, final_args, off)
+    },
+    EBinOp(op, left, right) => {
+      paired_expect_node(node, AuthorityExprBinOp, 0, 2, poisoned)
+      EBinOp(op, relabel_expr_paired_child(left, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(right, tbl, shadows, node, 1, poisoned))
+    },
+    EUnaryOp(op, value) => {
+      paired_expect_node(node, AuthorityExprUnaryOp, 0, 1, poisoned)
+      EUnaryOp(op, relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned))
+    },
+    ETuple(items) => {
+      paired_expect_node(node, AuthorityExprTuple, 0, Array::length(items), poisoned)
+      let mut i = 0
+      ETuple(for item in items {
+        let child = paired_child_or_self(node, i, poisoned)
+        i = i + 1
+        relabel_expr_paired(item, tbl, shadows, child, poisoned)
+      })
+    },
+    EArray(items) => {
+      paired_expect_node(node, AuthorityExprArray, 0, Array::length(items), poisoned)
+      let mut i = 0
+      EArray(for item in items {
+        let child = paired_child_or_self(node, i, poisoned)
+        i = i + 1
+        relabel_expr_paired(item, tbl, shadows, child, poisoned)
+      })
+    },
+    ESpread(value) => {
+      paired_expect_node(node, AuthorityExprSpread, 0, 1, poisoned)
+      ESpread(relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned))
+    },
+    ERecord(name, fields, types) => {
+      paired_expect_node(node, AuthorityExprRecord, 0, Array::length(fields), poisoned)
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (field, value) = Array::get(fields, i)
+        Array::push(out, (field, relabel_expr_paired_child(value, tbl, shadows, node, i, poisoned)))
+        i = i + 1
+      }
+      ERecord(name, out, types)
+    },
+    EMap(fields) => {
+      paired_expect_node(node, AuthorityExprMap, 0, Array::length(fields), poisoned)
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (key, value) = Array::get(fields, i)
+        Array::push(out, (key, relabel_expr_paired_child(value, tbl, shadows, node, i, poisoned)))
+        i = i + 1
+      }
+      EMap(out)
+    },
+    EIf(cond, yes, no) => {
+      paired_expect_node(node, AuthorityExprIf, 0, 3, poisoned)
+      EIf(relabel_expr_paired_child(cond, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(yes, tbl, shadows, node, 1, poisoned), relabel_expr_paired_child(no, tbl, shadows, node, 2, poisoned))
+    },
+    ELet(name, value, body, offset) => {
+      paired_expect_node(node, AuthorityExprLet, 1, 2, poisoned)
+      paired_expect_slot(node, 0, ExpressionLetBinder, name, poisoned)
+      let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
+      let mark = Array::length(shadows)
+      Array::push(shadows, name)
+      let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
+      Array::truncate(shadows, mark)
+      ELet(name, rvalue, rbody, offset)
+    },
+    ELetRec(name, value, body) => {
+      paired_expect_node(node, AuthorityExprLetRec, 1, 2, poisoned)
+      paired_expect_slot(node, 0, ExpressionLetRecBinder, name, poisoned)
+      let mark = Array::length(shadows)
+      Array::push(shadows, name)
+      let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
+      let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
+      Array::truncate(shadows, mark)
+      ELetRec(name, rvalue, rbody)
+    },
+    ELetMut(name, value, body, offset) => {
+      paired_expect_node(node, AuthorityExprLetMut, 1, 2, poisoned)
+      paired_expect_slot(node, 0, ExpressionLetMutBinder, name, poisoned)
+      let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
+      let mark = Array::length(shadows)
+      Array::push(shadows, name)
+      let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
+      Array::truncate(shadows, mark)
+      ELetMut(name, rvalue, rbody, offset)
+    },
+    EAssign(name, value, cont) => {
+      paired_expect_node(node, AuthorityExprAssign, 0, 2, poisoned)
+      EAssign(name, relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(cont, tbl, shadows, node, 1, poisoned))
+    },
+    EAssignOp(name, op, value, cont) => {
+      paired_expect_node(node, AuthorityExprAssignOp, 0, 2, poisoned)
+      EAssignOp(name, op, relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(cont, tbl, shadows, node, 1, poisoned))
+    },
+    ESeq(first, second) => {
+      paired_expect_node(node, AuthorityExprSeq, 0, 2, poisoned)
+      ESeq(relabel_expr_paired_child(first, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(second, tbl, shadows, node, 1, poisoned))
+    },
+    EMatch(scrutinee, arms) => {
+      paired_expect_node(node, AuthorityExprMatch, 0, 1 + Array::length(arms) * 2, poisoned)
+      let rscrutinee = relabel_expr_paired_child(scrutinee, tbl, shadows, node, 0, poisoned)
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (pat, body) = Array::get(arms, i)
+        paired_expect_pat(pat, paired_child_or_self(node, 1 + i * 2, poisoned), poisoned)
+        let mark = Array::length(shadows)
+        collect_pat_binders(pat, shadows)
+        Array::push(out, (pat, relabel_expr_paired_child(body, tbl, shadows, node, 2 + i * 2, poisoned)))
+        Array::truncate(shadows, mark)
+        i = i + 1
+      }
+      EMatch(rscrutinee, out)
+    },
+    EHandle(scrutinee, arms) => {
+      paired_expect_node(node, AuthorityExprHandle, 0, 1 + Array::length(arms) * 2, poisoned)
+      let rscrutinee = relabel_expr_paired_child(scrutinee, tbl, shadows, node, 0, poisoned)
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(arms) {
+        let (pat, body) = Array::get(arms, i)
+        paired_expect_pat(pat, paired_child_or_self(node, 1 + i * 2, poisoned), poisoned)
+        let mark = Array::length(shadows)
+        collect_pat_binders(pat, shadows)
+        Array::push(out, (pat, relabel_expr_paired_child(body, tbl, shadows, node, 2 + i * 2, poisoned)))
+        Array::truncate(shadows, mark)
+        i = i + 1
+      }
+      EHandle(rscrutinee, out)
+    },
+    EWhile(cond, body) => {
+      paired_expect_node(node, AuthorityExprWhile, 0, 2, poisoned)
+      EWhile(relabel_expr_paired_child(cond, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned))
+    },
+    ELoop(_, _) => {
+      paired_poison(poisoned)
+      relabel_expr(expr, tbl, shadows)
+    },
+    EForIn(name, index, iterable, body) => {
+      let slot_count = match index {
+        Some(_) => 2,
+        None => 1
+      }
+      paired_expect_node(node, AuthorityExprForIn, slot_count, 2, poisoned)
+      paired_expect_slot(node, 0, ExpressionForValueBinder, name, poisoned)
+      match index {
+        Some(index_name) => paired_expect_slot(node, 1, ExpressionForIndexBinder, index_name, poisoned),
+        None => ()
+      }
+      let riterable = relabel_expr_paired_child(iterable, tbl, shadows, node, 0, poisoned)
+      let mark = Array::length(shadows)
+      Array::push(shadows, name)
+      match index {
+        Some(index_name) => Array::push(shadows, index_name),
+        None => ()
+      }
+      let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
+      Array::truncate(shadows, mark)
+      EForIn(name, index, riterable, rbody)
+    },
+    EFn(type_params, bounds, params, ret, effects, body) => {
+      paired_expect_node(node, AuthorityExprFn, Array::length(type_params) + Array::length(params), 1, poisoned)
+      let mut ti = 0
+      while ti < Array::length(type_params) {
+        paired_expect_slot(node, ti, ExpressionFunctionTypeParameterBinder, Array::get(type_params, ti), poisoned)
+        ti = ti + 1
+      }
+      let mark = Array::length(shadows)
+      let mut pi = 0
+      while pi < Array::length(params) {
+        let (name, _) = Array::get(params, pi)
+        paired_expect_slot(node, Array::length(type_params) + pi, ExpressionFunctionParameterBinder, name, poisoned)
+        Array::push(shadows, strip_label_tilde(name))
+        pi = pi + 1
+      }
+      let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 0, poisoned)
+      Array::truncate(shadows, mark)
+      EFn(type_params, bounds, params, ret, effects, rbody)
+    },
+    EDot(object, field, offset, field_offset) => {
+      paired_expect_node(node, AuthorityExprDot, 0, 1, poisoned)
+      EDot(relabel_expr_paired_child(object, tbl, shadows, node, 0, poisoned), field, offset, field_offset)
+    },
+    ELabeledArg(label, marker, value) => {
+      paired_expect_node(node, AuthorityExprLabeledArg, 0, 1, poisoned)
+      ELabeledArg(label, marker, relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned))
+    },
+    EReturn(value) => {
+      paired_expect_node(node, AuthorityExprReturn, 0, 1, poisoned)
+      EReturn(relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned))
+    },
+    EBreak(value) => match value {
+      Some(inner) => {
+        paired_expect_node(node, AuthorityExprBreak, 0, 1, poisoned)
+        EBreak(Some(relabel_expr_paired_child(inner, tbl, shadows, node, 0, poisoned)))
+      },
+      None => {
+        paired_expect_node(node, AuthorityExprBreak, 0, 0, poisoned)
+        expr
+      }
+    },
+    EContinue(values) => {
+      paired_expect_node(node, AuthorityExprContinue, 0, Array::length(values), poisoned)
+      let mut i = 0
+      EContinue(for value in values {
+        let child = paired_child_or_self(node, i, poisoned)
+        i = i + 1
+        relabel_expr_paired(value, tbl, shadows, child, poisoned)
+      })
+    },
+    EInt(_) => {
+      paired_expect_node(node, AuthorityExprInt, 0, 0, poisoned)
+      expr
+    },
+    EFloat(_) => {
+      paired_expect_node(node, AuthorityExprFloat, 0, 0, poisoned)
+      expr
+    },
+    EString(_) => {
+      paired_expect_node(node, AuthorityExprString, 0, 0, poisoned)
+      expr
+    },
+    EBool(_) => {
+      paired_expect_node(node, AuthorityExprBool, 0, 0, poisoned)
+      expr
+    },
+    EIdent(_, _) => {
+      paired_expect_node(node, AuthorityExprIdent, 0, 0, poisoned)
+      expr
+    },
+    EStringInterp(_) => {
+      paired_expect_node(node, AuthorityExprStringInterp, 0, 0, poisoned)
+      expr
+    },
+    EUnit => {
+      paired_expect_node(node, AuthorityExprUnit, 0, 0, poisoned)
+      expr
+    }
+  }
+}
+
+fn relabel_stmt_paired(stmt: Stmt, tbl: Array[(String, Array[String])], node: BinderAuthorityNode, poisoned: Array[Bool]) -> Stmt {
+  match stmt {
+    SLet(exported, recursive, name, ty, body) => {
+      paired_expect_node(node, AuthorityStmtLet, 1, 1, poisoned)
+      paired_expect_slot(node, 0, StatementLetBinder, name, poisoned)
+      SLet(exported, recursive, name, ty, relabel_expr_paired_child(body, tbl, empty_str_array(), node, 0, poisoned))
+    },
+    SLetMut(name, ty, body) => {
+      paired_expect_node(node, AuthorityStmtLetMut, 1, 1, poisoned)
+      paired_expect_slot(node, 0, StatementLetMutBinder, name, poisoned)
+      SLetMut(name, ty, relabel_expr_paired_child(body, tbl, empty_str_array(), node, 0, poisoned))
+    },
+    STest(name, body) => {
+      paired_expect_node(node, AuthorityStmtTest, 0, 1, poisoned)
+      STest(name, relabel_expr_paired_child(body, tbl, empty_str_array(), node, 0, poisoned))
+    },
+    SBench(name, body) => {
+      paired_expect_node(node, AuthorityStmtBench, 0, 1, poisoned)
+      SBench(name, relabel_expr_paired_child(body, tbl, empty_str_array(), node, 0, poisoned))
+    },
+    SExample(name, body) => {
+      paired_expect_node(node, AuthorityStmtExample, 0, 1, poisoned)
+      SExample(name, relabel_expr_paired_child(body, tbl, empty_str_array(), node, 0, poisoned))
+    },
+    SExpr(body) => {
+      paired_expect_node(node, AuthorityStmtExpr, 0, 1, poisoned)
+      SExpr(relabel_expr_paired_child(body, tbl, empty_str_array(), node, 0, poisoned))
+    },
+    SExternLet(name, _) => {
+      paired_expect_node(node, AuthorityStmtExternLet, 1, 0, poisoned)
+      paired_expect_slot(node, 0, StatementExternBinder, name, poisoned)
+      stmt
+    },
+    SImport(_, items) => {
+      paired_expect_node(node, AuthorityStmtImport, Array::length(items), 0, poisoned)
+      let mut i = 0
+      while i < Array::length(items) {
+        let item = Array::get(items, i)
+        let local = match item.1 {
+          Some(alias) => alias,
+          None => item.0
+        }
+        paired_expect_slot(node, i, StatementImportBinder, local, poisoned)
+        i = i + 1
+      }
+      stmt
+    },
+    SAliasDecl(name, _) => {
+      paired_expect_node(node, AuthorityStmtAliasDecl, 1, 0, poisoned)
+      paired_expect_slot(node, 0, StatementAliasBinder, name, poisoned)
+      stmt
+    },
+    STypeAlias(_, name, params, _) => {
+      paired_expect_node(node, AuthorityStmtTypeAlias, 1 + Array::length(params), 0, poisoned)
+      paired_expect_slot(node, 0, StatementTypeBinder, name, poisoned)
+      let mut i = 0
+      while i < Array::length(params) {
+        paired_expect_slot(node, i + 1, StatementTypeParameterBinder, Array::get(params, i), poisoned)
+        i = i + 1
+      }
+      stmt
+    },
+    SEffectSet(_, name, _) => {
+      paired_expect_node(node, AuthorityStmtEffectSet, 1, 0, poisoned)
+      paired_expect_slot(node, 0, StatementEffectSetBinder, name, poisoned)
+      stmt
+    },
+    SResource(name, _) => {
+      paired_expect_node(node, AuthorityStmtResource, 1, 0, poisoned)
+      paired_expect_slot(node, 0, StatementResourceBinder, name, poisoned)
+      stmt
+    },
+    SExport(_) => {
+      paired_expect_node(node, AuthorityStmtExport, 0, 0, poisoned)
+      stmt
+    },
+    SReExport(_, _) => {
+      paired_expect_node(node, AuthorityStmtReExport, 0, 0, poisoned)
+      stmt
+    },
+    SQualifiedPatternRefs(_) => {
+      paired_expect_node(node, AuthorityStmtQualifiedPatternRefs, 0, 0, poisoned)
+      stmt
+    },
+    STestEffectRows(_) => {
+      paired_expect_node(node, AuthorityStmtTestEffectRows, 0, 0, poisoned)
+      stmt
+    },
+    _ => {
+      paired_poison(poisoned)
+      relabel_stmt(stmt, tbl)
+    }
   }
 }
 
@@ -10095,6 +10801,54 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
     }
   }
   optional_param_tbl_set(array_empty())
+}
+
+fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityNode], poisoned: Array[Bool]) -> Unit {
+  let tbl = collect_fn_param_labels(stmts)
+  let opt_tbl = collect_optional_param_fns(stmts)
+  optional_param_tbl_set(opt_tbl)
+  if Array::length(roots) != Array::length(stmts) {
+    paired_poison(poisoned)
+  } else {
+    ()
+  }
+  let sentinel = BinderAuthorityNode::{
+    kind: AuthorityExprUnit,
+    slots: [
+    ],
+    children: [
+    ]
+  }
+  let mut i = 0
+  while i < Array::length(stmts) {
+    let root = if i < Array::length(roots) {
+      Array::get(roots, i)
+    } else {
+      sentinel
+    }
+    Array::set(stmts, i, relabel_stmt_paired(Array::get(stmts, i), tbl, root, poisoned))
+    i = i + 1
+  }
+  optional_param_tbl_set(array_empty())
+}
+
+export fn normalize_labeled_args_with_binder_authority(source: LocatedProgramBinderAuthority) -> LabeledArgBinderAuthorityNormalization {
+  let program = located_program_binder_authority_program(source)
+  let roots = located_program_binder_authority_nodes(source)
+  let poisoned = [
+    false
+  ]
+  desugar_labeled_args_paired(program, roots, poisoned)
+  let normalized = if Array::get(poisoned, 0) {
+    None
+  } else {
+    Some(NormalizedProgramBinderAuthority::{
+      nodes: stored_normalized_authority_nodes(roots, 0)
+    })
+  }
+  LabeledArgBinderAuthorityNormalization::{
+    stored: StoredLabeledArgBinderAuthorityNormalizationValue(program, normalized)
+  }
 }
 
 ///|

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -7854,65 +7854,12 @@ fn dlh_with(arr: Array[String], name: String) -> Array[String] {
 }
 
 ///|
-/// Local membership test — avoids depending on `array_contains_str` (defined in
-/// other compiler modules and NOT imported here; it resolves in the concatenated
-/// sources bundle but is `unknown name` in the strict per-module module_source
-/// merge that the FS-compile lane type-checks).
-fn dlh_contains(arr: Array[String], name: String) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(arr) {
-    if Array::get(arr, i) == name {
-      found = true
-      i = Array::length(arr)
-    } else {
-      i = i + 1
-    }
-  }
-  found
-}
-
-///|
 fn dlh_strip_tilde(n: String) -> String {
   let ln = String::length(n)
   if ln > 0 && n[ln - 1: ln] == "~" {
     n[0: ln - 1]
   } else {
     n
-  }
-}
-
-///|
-fn dlh_pat_binds(p: Pat, out: Array[String]) -> Unit {
-  match p {
-    PBind(n) => Array::push(out, n),
-    PCtor(_, args) => {
-      let mut i = 0
-      while i < Array::length(args) {
-        dlh_pat_binds(Array::get(args, i), out)
-        i = i + 1
-      }
-    },
-    PTuple(ps) => {
-      let mut i = 0
-      while i < Array::length(ps) {
-        dlh_pat_binds(Array::get(ps, i), out)
-        i = i + 1
-      }
-    },
-    POr(a, b) => {
-      dlh_pat_binds(a, out)
-      dlh_pat_binds(b, out)
-    },
-    PStruct(_, fields) => {
-      let mut i = 0
-      while i < Array::length(fields) {
-        let (_, fp) = Array::get(fields, i)
-        dlh_pat_binds(fp, out)
-        i = i + 1
-      }
-    },
-    _ => ()
   }
 }
 
@@ -8031,7 +7978,7 @@ fn dlh_collect_performed_effect_names(expr: Expr, out: Array[String]) -> Unit {
               Some((h, _)) => h,
               None => qn
             }
-            if dlh_contains(out, ename) {
+            if str_array_contains(out, ename) {
               ()
             } else {
               Array::push(out, ename)
@@ -8150,7 +8097,7 @@ fn dlh_has_perform_arms(arms: Array[(Pat, Expr)]) -> Bool {
 /// non-top-level name (capture or bare-helper call) and must not be hoisted.
 fn dlh_scan_free(expr: Expr, bound: Array[String], bad: Array[String]) -> Unit {
   match expr {
-    EIdent(n, _) => if dlh_name_ok(n) || dlh_contains(bound, n) {
+    EIdent(n, _) => if dlh_name_ok(n) || str_array_contains(bound, n) {
       ()
     } else {
       Array::push(bad, n)
@@ -8225,7 +8172,7 @@ fn dlh_scan_free(expr: Expr, bound: Array[String], bad: Array[String]) -> Unit {
       dlh_scan_free(b, dlh_with(bound, name), bad)
     },
     EAssign(name, v, c) => {
-      if dlh_name_ok(name) || dlh_contains(bound, name) {
+      if dlh_name_ok(name) || str_array_contains(bound, name) {
         ()
       } else {
         Array::push(bad, name)
@@ -8234,7 +8181,7 @@ fn dlh_scan_free(expr: Expr, bound: Array[String], bad: Array[String]) -> Unit {
       dlh_scan_free(c, bound, bad)
     },
     EAssignOp(name, _, v, c) => {
-      if dlh_name_ok(name) || dlh_contains(bound, name) {
+      if dlh_name_ok(name) || str_array_contains(bound, name) {
         ()
       } else {
         Array::push(bad, name)
@@ -8306,7 +8253,7 @@ fn dlh_scan_arms(arms: Array[(Pat, Expr)], bound: Array[String], bad: Array[Stri
     let (p, b) = Array::get(arms, i)
     let mut ab = bound
     let pb = empty_str_array()
-    dlh_pat_binds(p, pb)
+    collect_pat_binders(p, pb)
     let mut j = 0
     while j < Array::length(pb) {
       ab = dlh_with(ab, Array::get(pb, j))
@@ -8451,8 +8398,8 @@ fn dlh_subst_arms(arms: Array[(Pat, Expr)], from: String, to: String) -> Array[(
   while i < Array::length(arms) {
     let (p, b) = Array::get(arms, i)
     let pb = empty_str_array()
-    dlh_pat_binds(p, pb)
-    let shadow = dlh_contains(pb, from)
+    collect_pat_binders(p, pb)
+    let shadow = str_array_contains(pb, from)
     Array::push(out, (p, if shadow {
       b
     } else {
@@ -8482,162 +8429,9 @@ fn dlh_subst_arms(arms: Array[(Pat, Expr)], from: String, to: String) -> Array[(
 /// deliberately simple, non-shadow-aware walk -- safe, because a fresh
 /// unique marker can never collide with an unrelated binding the way
 /// `name` itself could.
-fn dlh_mocd_scan(expr: Expr, marker: String, bad: Array[Bool]) -> Unit {
-  match expr {
-    EIdent(n, _) => if n == marker {
-      Array::set(bad, 0, true)
-    } else {
-      ()
-    },
-    ECall(callee, args, _) => {
-      match callee {
-        EIdent(n, _) => if n == marker {
-          ()
-        } else {
-          dlh_mocd_scan(callee, marker, bad)
-        },
-        _ => dlh_mocd_scan(callee, marker, bad)
-      }
-      let mut i = 0
-      while i < Array::length(args) {
-        dlh_mocd_scan(Array::get(args, i), marker, bad)
-        i = i + 1
-      }
-    },
-    EBinOp(_, l, r) => {
-      dlh_mocd_scan(l, marker, bad)
-      dlh_mocd_scan(r, marker, bad)
-    },
-    EUnaryOp(_, e) => dlh_mocd_scan(e, marker, bad),
-    ETuple(es) => {
-      let mut i = 0
-      while i < Array::length(es) {
-        dlh_mocd_scan(Array::get(es, i), marker, bad)
-        i = i + 1
-      }
-    },
-    EArray(es) => {
-      let mut i = 0
-      while i < Array::length(es) {
-        dlh_mocd_scan(Array::get(es, i), marker, bad)
-        i = i + 1
-      }
-    },
-    ESpread(e) => dlh_mocd_scan(e, marker, bad),
-    EContinue(es) => {
-      let mut i = 0
-      while i < Array::length(es) {
-        dlh_mocd_scan(Array::get(es, i), marker, bad)
-        i = i + 1
-      }
-    },
-    ERecord(_, fs, _) => {
-      let mut i = 0
-      while i < Array::length(fs) {
-        let (_, v) = Array::get(fs, i)
-        dlh_mocd_scan(v, marker, bad)
-        i = i + 1
-      }
-    },
-    EMap(fs) => {
-      let mut i = 0
-      while i < Array::length(fs) {
-        let (_, v) = Array::get(fs, i)
-        dlh_mocd_scan(v, marker, bad)
-        i = i + 1
-      }
-    },
-    EIf(c, t, e) => {
-      dlh_mocd_scan(c, marker, bad)
-      dlh_mocd_scan(t, marker, bad)
-      dlh_mocd_scan(e, marker, bad)
-    },
-    ELet(_, v, b, _) => {
-      dlh_mocd_scan(v, marker, bad)
-      dlh_mocd_scan(b, marker, bad)
-    },
-    ELetRec(_, v, b) => {
-      dlh_mocd_scan(v, marker, bad)
-      dlh_mocd_scan(b, marker, bad)
-    },
-    ELetMut(_, v, b, _) => {
-      dlh_mocd_scan(v, marker, bad)
-      dlh_mocd_scan(b, marker, bad)
-    },
-    EAssign(n, v, c) => {
-      if n == marker {
-        Array::set(bad, 0, true)
-      } else {
-        ()
-      }
-      dlh_mocd_scan(v, marker, bad)
-      dlh_mocd_scan(c, marker, bad)
-    },
-    EAssignOp(n, _, v, c) => {
-      if n == marker {
-        Array::set(bad, 0, true)
-      } else {
-        ()
-      }
-      dlh_mocd_scan(v, marker, bad)
-      dlh_mocd_scan(c, marker, bad)
-    },
-    ESeq(a, b) => {
-      dlh_mocd_scan(a, marker, bad)
-      dlh_mocd_scan(b, marker, bad)
-    },
-    EWhile(c, b) => {
-      dlh_mocd_scan(c, marker, bad)
-      dlh_mocd_scan(b, marker, bad)
-    },
-    EForIn(_, _, it, b) => {
-      dlh_mocd_scan(it, marker, bad)
-      dlh_mocd_scan(b, marker, bad)
-    },
-    EDot(o, _, _, _) => dlh_mocd_scan(o, marker, bad),
-    ELabeledArg(_, _, e) => dlh_mocd_scan(e, marker, bad),
-    EReturn(e) => dlh_mocd_scan(e, marker, bad),
-    EBreak(opt) => match opt {
-      Some(e) => dlh_mocd_scan(e, marker, bad),
-      None => ()
-    },
-    EFn(_, _, _, _, _, body) => dlh_mocd_scan(body, marker, bad),
-    EMatch(s, arms) => {
-      dlh_mocd_scan(s, marker, bad)
-      dlh_mocd_scan_arms(arms, marker, bad)
-    },
-    EHandle(s, arms) => {
-      dlh_mocd_scan(s, marker, bad)
-      dlh_mocd_scan_arms(arms, marker, bad)
-    },
-    ELoop(params, b) => {
-      let mut i = 0
-      while i < Array::length(params) {
-        let (_, init) = Array::get(params, i)
-        dlh_mocd_scan(init, marker, bad)
-        i = i + 1
-      }
-      dlh_mocd_scan(b, marker, bad)
-    },
-    _ => ()
-  }
-}
-
-fn dlh_mocd_scan_arms(arms: Array[(Pat, Expr)], marker: String, bad: Array[Bool]) -> Unit {
-  let mut i = 0
-  while i < Array::length(arms) {
-    let (_, b) = Array::get(arms, i)
-    dlh_mocd_scan(b, marker, bad)
-    i = i + 1
-  }
-}
 
 fn dlh_marker_only_called_directly(expr: Expr, marker: String) -> Bool {
-  let bad = [
-    false
-  ]
-  dlh_mocd_scan(expr, marker, bad)
-  !Array::get(bad, 0)
+  !dinsp_scan(expr, 4, marker)
 }
 
 /// Rewrite every `ECall(EIdent(marker), args, off)` into `ECall(EIdent(fresh),
@@ -8737,7 +8531,7 @@ fn dlh_dedup_names(names: Array[String]) -> Array[String] {
   let mut i = 0
   while i < Array::length(names) {
     let n = Array::get(names, i)
-    if dlh_contains(out, n) {
+    if str_array_contains(out, n) {
       ()
     } else {
       Array::push(out, n)
@@ -8763,149 +8557,13 @@ fn dlh_dedup_names(names: Array[String]) -> Array[String] {
 /// diverging means pass-by-value and capture-by-reference are behaviorally
 /// identical for this specific program, whatever the declaration said.
 fn dlh_names_ever_assigned(expr: Expr, names: Array[String]) -> Bool {
-  let bad = [
-    false
-  ]
-  dlh_naa_scan(expr, names, bad)
-  Array::get(bad, 0)
-}
-
-fn dlh_naa_scan(expr: Expr, names: Array[String], bad: Array[Bool]) -> Unit {
-  match expr {
-    EAssign(n, v, c) => {
-      if dlh_contains(names, n) {
-        Array::set(bad, 0, true)
-      } else {
-        ()
-      }
-      dlh_naa_scan(v, names, bad)
-      dlh_naa_scan(c, names, bad)
-    },
-    EAssignOp(n, _, v, c) => {
-      if dlh_contains(names, n) {
-        Array::set(bad, 0, true)
-      } else {
-        ()
-      }
-      dlh_naa_scan(v, names, bad)
-      dlh_naa_scan(c, names, bad)
-    },
-    ECall(callee, args, _) => {
-      dlh_naa_scan(callee, names, bad)
-      let mut i = 0
-      while i < Array::length(args) {
-        dlh_naa_scan(Array::get(args, i), names, bad)
-        i = i + 1
-      }
-    },
-    EBinOp(_, l, r) => {
-      dlh_naa_scan(l, names, bad)
-      dlh_naa_scan(r, names, bad)
-    },
-    EUnaryOp(_, e) => dlh_naa_scan(e, names, bad),
-    ETuple(es) => {
-      let mut i = 0
-      while i < Array::length(es) {
-        dlh_naa_scan(Array::get(es, i), names, bad)
-        i = i + 1
-      }
-    },
-    EArray(es) => {
-      let mut i = 0
-      while i < Array::length(es) {
-        dlh_naa_scan(Array::get(es, i), names, bad)
-        i = i + 1
-      }
-    },
-    ESpread(e) => dlh_naa_scan(e, names, bad),
-    EContinue(es) => {
-      let mut i = 0
-      while i < Array::length(es) {
-        dlh_naa_scan(Array::get(es, i), names, bad)
-        i = i + 1
-      }
-    },
-    ERecord(_, fs, _) => {
-      let mut i = 0
-      while i < Array::length(fs) {
-        let (_, v) = Array::get(fs, i)
-        dlh_naa_scan(v, names, bad)
-        i = i + 1
-      }
-    },
-    EMap(fs) => {
-      let mut i = 0
-      while i < Array::length(fs) {
-        let (_, v) = Array::get(fs, i)
-        dlh_naa_scan(v, names, bad)
-        i = i + 1
-      }
-    },
-    EIf(c, t, e) => {
-      dlh_naa_scan(c, names, bad)
-      dlh_naa_scan(t, names, bad)
-      dlh_naa_scan(e, names, bad)
-    },
-    ELet(_, v, b, _) => {
-      dlh_naa_scan(v, names, bad)
-      dlh_naa_scan(b, names, bad)
-    },
-    ELetRec(_, v, b) => {
-      dlh_naa_scan(v, names, bad)
-      dlh_naa_scan(b, names, bad)
-    },
-    ELetMut(_, v, b, _) => {
-      dlh_naa_scan(v, names, bad)
-      dlh_naa_scan(b, names, bad)
-    },
-    ESeq(a, b) => {
-      dlh_naa_scan(a, names, bad)
-      dlh_naa_scan(b, names, bad)
-    },
-    EWhile(c, b) => {
-      dlh_naa_scan(c, names, bad)
-      dlh_naa_scan(b, names, bad)
-    },
-    EForIn(_, _, it, b) => {
-      dlh_naa_scan(it, names, bad)
-      dlh_naa_scan(b, names, bad)
-    },
-    EDot(o, _, _, _) => dlh_naa_scan(o, names, bad),
-    ELabeledArg(_, _, e) => dlh_naa_scan(e, names, bad),
-    EReturn(e) => dlh_naa_scan(e, names, bad),
-    EBreak(opt) => match opt {
-      Some(e) => dlh_naa_scan(e, names, bad),
-      None => ()
-    },
-    EFn(_, _, _, _, _, body) => dlh_naa_scan(body, names, bad),
-    EMatch(s, arms) => {
-      dlh_naa_scan(s, names, bad)
-      dlh_naa_scan_arms(arms, names, bad)
-    },
-    EHandle(s, arms) => {
-      dlh_naa_scan(s, names, bad)
-      dlh_naa_scan_arms(arms, names, bad)
-    },
-    ELoop(params, b) => {
-      let mut i = 0
-      while i < Array::length(params) {
-        let (_, init) = Array::get(params, i)
-        dlh_naa_scan(init, names, bad)
-        i = i + 1
-      }
-      dlh_naa_scan(b, names, bad)
-    },
-    _ => ()
-  }
-}
-
-fn dlh_naa_scan_arms(arms: Array[(Pat, Expr)], names: Array[String], bad: Array[Bool]) -> Unit {
   let mut i = 0
-  while i < Array::length(arms) {
-    let (_, b) = Array::get(arms, i)
-    dlh_naa_scan(b, names, bad)
+  let mut found = false
+  while !found && i < Array::length(names) {
+    found = dinsp_scan(expr, 5, Array::get(names, i))
     i = i + 1
   }
+  found
 }
 
 /// A closure literal's DECLARED effect row is non-empty.
@@ -9568,53 +9226,6 @@ fn reorder_labeled_args(args: Array[Expr], param_labels: Array[String]) -> Optio
 /// (`let f = (y) -> ..` / a fn param / a pattern bind) must suppress both the
 /// reorder and the label-name validation — the call resolves to the local
 /// value, whose parameter names the table knows nothing about.
-fn relabel_shadowed(shadows: Array[String], name: String) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(shadows) {
-    if Array::get(shadows, i) == name {
-      found = true
-      i = Array::length(shadows)
-    } else {
-      i = i + 1
-    }
-  }
-  found
-}
-
-///|
-fn relabel_pat_binds(pat: Pat, shadows: Array[String]) -> Unit {
-  match pat {
-    PBind(n) => Array::push(shadows, n),
-    PCtor(_, ps) => {
-      let mut i = 0
-      while i < Array::length(ps) {
-        relabel_pat_binds(Array::get(ps, i), shadows)
-        i = i + 1
-      }
-    },
-    PTuple(ps) => {
-      let mut i = 0
-      while i < Array::length(ps) {
-        relabel_pat_binds(Array::get(ps, i), shadows)
-        i = i + 1
-      }
-    },
-    POr(a, b) => {
-      relabel_pat_binds(a, shadows)
-      relabel_pat_binds(b, shadows)
-    },
-    PStruct(_, fields) => {
-      let mut i = 0
-      while i < Array::length(fields) {
-        let (_, fp) = Array::get(fields, i)
-        relabel_pat_binds(fp, shadows)
-        i = i + 1
-      }
-    },
-    _ => ()
-  }
-}
 
 ///|
 /// Strip the ELabeledArg wrappers off a VALIDATED arg list (labels confirmed to
@@ -9689,7 +9300,7 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       }
       let final_args = if any_labeled_arg {
         match callee {
-          EIdent(fname, _) => if relabel_shadowed(shadows, fname) {
+          EIdent(fname, _) => if str_array_contains(shadows, fname) {
             rargs
           } else {
             match lookup_param_labels(tbl, fname) {
@@ -9708,7 +9319,7 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       // #1500: fill / wrap optional parameters AFTER label reordering, so the
       // flags line up with declared parameter order.
       let opt_args = match callee {
-        EIdent(fname, _) => if relabel_shadowed(shadows, fname) {
+        EIdent(fname, _) => if str_array_contains(shadows, fname) {
           final_args
         } else {
           match optional_param_flags(fname) {
@@ -9784,7 +9395,7 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       while i < Array::length(arms) {
         let (p, b) = Array::get(arms, i)
         let mark = Array::length(shadows)
-        relabel_pat_binds(p, shadows)
+        collect_pat_binders(p, shadows)
         Array::push(out, (p, relabel_expr(b, tbl, shadows)))
         Array::truncate(shadows, mark)
         i = i + 1
@@ -9798,7 +9409,7 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       while i < Array::length(arms) {
         let (p, b) = Array::get(arms, i)
         let mark = Array::length(shadows)
-        relabel_pat_binds(p, shadows)
+        collect_pat_binders(p, shadows)
         Array::push(out, (p, relabel_expr(b, tbl, shadows)))
         Array::truncate(shadows, mark)
         i = i + 1
@@ -9877,113 +9488,18 @@ fn relabel_stmt(stmt: Stmt, tbl: Array[(String, Array[String])]) -> Stmt {
 }
 
 ///|
-/// #986: read-only containment scan — does this expr contain any ELabeledArg?
-/// Used to gate the (allocating) relabel_stmt rebuild per top-level statement,
+/// #986: allocation-free containment scan used to gate the allocating
+/// relabel_stmt rebuild per top-level statement,
 /// since collect_fn_param_labels now indexes EVERY top-level function and the
 /// old `tbl empty -> skip` fast path no longer fires for ordinary programs.
-fn expr_has_labeled_arg(expr: Expr) -> Bool {
-  match expr {
-    ELabeledArg(_, _, _) => true,
-    ECall(callee, args, _) => {
-      let mut found = expr_has_labeled_arg(callee)
-      let mut i = 0
-      while i < Array::length(args) {
-        if found {
-          i = Array::length(args)
-        } else {
-          found = expr_has_labeled_arg(Array::get(args, i))
-          i = i + 1
-        }
-      }
-      found
-    },
-    EBinOp(_, l, r) => expr_has_labeled_arg(l) || expr_has_labeled_arg(r),
-    EUnaryOp(_, e) => expr_has_labeled_arg(e),
-    ETuple(elems) => arr_has_labeled_arg(elems),
-    EArray(elems) => arr_has_labeled_arg(elems),
-    ESpread(e) => expr_has_labeled_arg(e),
-    ERecord(_, fields, _) => pairs_have_labeled_arg(fields),
-    EMap(fields) => pairs_have_labeled_arg(fields),
-    EIf(c, t, e) => expr_has_labeled_arg(c) || expr_has_labeled_arg(t) || expr_has_labeled_arg(e),
-    ELet(_, v, b, _) => expr_has_labeled_arg(v) || expr_has_labeled_arg(b),
-    ELetRec(_, v, b) => expr_has_labeled_arg(v) || expr_has_labeled_arg(b),
-    ELetMut(_, v, b, _) => expr_has_labeled_arg(v) || expr_has_labeled_arg(b),
-    EAssign(_, v, k) => expr_has_labeled_arg(v) || expr_has_labeled_arg(k),
-    EAssignOp(_, _, v, k) => expr_has_labeled_arg(v) || expr_has_labeled_arg(k),
-    ESeq(a, b) => expr_has_labeled_arg(a) || expr_has_labeled_arg(b),
-    EMatch(scrut, arms) => expr_has_labeled_arg(scrut) || arms_have_labeled_arg(arms),
-    EHandle(scrut, arms) => expr_has_labeled_arg(scrut) || arms_have_labeled_arg(arms),
-    EWhile(c, b) => expr_has_labeled_arg(c) || expr_has_labeled_arg(b),
-    ELoop(inits, b) => pairs_have_labeled_arg(inits) || expr_has_labeled_arg(b),
-    EForIn(_, _, iter, b) => expr_has_labeled_arg(iter) || expr_has_labeled_arg(b),
-    EFn(_, _, _, _, _, b) => expr_has_labeled_arg(b),
-    EDot(obj, _, _, _) => expr_has_labeled_arg(obj),
-    EReturn(e) => expr_has_labeled_arg(e),
-    EBreak(opt) => match opt {
-      Some(e) => expr_has_labeled_arg(e),
-      None => false
-    },
-    EContinue(exprs) => arr_has_labeled_arg(exprs),
-    _ => false
-  }
-}
-
-///|
-fn arr_has_labeled_arg(exprs: Array[Expr]) -> Bool {
-  let mut found = false
-  let mut i = 0
-  while i < Array::length(exprs) {
-    if found {
-      i = Array::length(exprs)
-    } else {
-      found = expr_has_labeled_arg(Array::get(exprs, i))
-      i = i + 1
-    }
-  }
-  found
-}
-
-///|
-fn pairs_have_labeled_arg(pairs: Array[(String, Expr)]) -> Bool {
-  let mut found = false
-  let mut i = 0
-  while i < Array::length(pairs) {
-    if found {
-      i = Array::length(pairs)
-    } else {
-      let (_, v) = Array::get(pairs, i)
-      found = expr_has_labeled_arg(v)
-      i = i + 1
-    }
-  }
-  found
-}
-
-///|
-fn arms_have_labeled_arg(arms: Array[(Pat, Expr)]) -> Bool {
-  let mut found = false
-  let mut i = 0
-  while i < Array::length(arms) {
-    if found {
-      i = Array::length(arms)
-    } else {
-      let (_, b) = Array::get(arms, i)
-      found = expr_has_labeled_arg(b)
-      i = i + 1
-    }
-  }
-  found
-}
-
-///|
 fn stmt_has_labeled_arg(stmt: Stmt) -> Bool {
   match stmt {
-    SLet(_, _, _, _, body) => expr_has_labeled_arg(body),
-    SLetMut(_, _, body) => expr_has_labeled_arg(body),
-    STest(_, body) => expr_has_labeled_arg(body),
-    SBench(_, body) => expr_has_labeled_arg(body),
-    SExpr(e) => expr_has_labeled_arg(e),
-    SLetPat(_, e) => expr_has_labeled_arg(e),
+    SLet(_, _, _, _, body) => dinsp_scan(body, 3, ""),
+    SLetMut(_, _, body) => dinsp_scan(body, 3, ""),
+    STest(_, body) => dinsp_scan(body, 3, ""),
+    SBench(_, body) => dinsp_scan(body, 3, ""),
+    SExpr(e) => dinsp_scan(e, 3, ""),
+    SLetPat(_, e) => dinsp_scan(e, 3, ""),
     SModule(_, _, ms) => {
       let mut found = false
       let mut i = 0
@@ -10001,10 +9517,13 @@ fn stmt_has_labeled_arg(stmt: Stmt) -> Bool {
   }
 }
 
-/// Read-only scan for one of three questions, in ONE explicit-variant walk:
+/// Read-only scan for one of six questions, in ONE explicit-variant walk:
 ///   mode 0 -- does this contain a two-argument `inspect(..)` call?
 ///   mode 1 -- does this BIND the name `inspect` (a let / for / fn parameter)?
 ///   mode 2 -- does this mention `name` at all, as a reference or a binder?
+///   mode 3 -- does this contain a labeled-argument wrapper?
+///   mode 4 -- is `name` used anywhere except as a direct call callee?
+///   mode 5 -- is `name` targeted by an assignment or assignment-op?
 ///
 /// The variants are enumerated by hand rather than recursed through
 /// `expr_children`, and that is the whole point: `expr_children` ALLOCATES a
@@ -10035,7 +9554,7 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       EHandle(_, arms) => dinsp_arms_bind(arms, "inspect"),
       _ => false
     }
-  } else {
+  } else if mode == 2 {
     match expr {
       EIdent(n, _) => n == name,
       ELet(n, _, _, _) => n == name,
@@ -10047,6 +9566,24 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       EFn(_, _, params, _, _, _) => dinsp_params_bind(params, name),
       EMatch(_, arms) => dinsp_arms_bind(arms, name),
       EHandle(_, arms) => dinsp_arms_bind(arms, name),
+      _ => false
+    }
+  } else if mode == 3 {
+    match expr {
+      ELabeledArg(_, _, _) => true,
+      _ => false
+    }
+  } else if mode == 4 {
+    match expr {
+      EIdent(n, _) => n == name,
+      EAssign(n, _, _) => n == name,
+      EAssignOp(n, _, _, _) => n == name,
+      _ => false
+    }
+  } else {
+    match expr {
+      EAssign(n, _, _) => n == name,
+      EAssignOp(n, _, _, _) => n == name,
       _ => false
     }
   }
@@ -10077,7 +9614,18 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       EWhile(c, b) => dinsp_scan(c, mode, name) || dinsp_scan(b, mode, name),
       ELoop(params, b) => dinsp_scan_fields(params, mode, name) || dinsp_scan(b, mode, name),
       EForIn(_, _, it, b) => dinsp_scan(it, mode, name) || dinsp_scan(b, mode, name),
-      ECall(callee, args, _) => dinsp_scan(callee, mode, name) || dinsp_scan_list(args, mode, name),
+      ECall(callee, args, _) => if mode == 4 {
+        match callee {
+          EIdent(n, _) => if n == name {
+            dinsp_scan_list(args, mode, name)
+          } else {
+            dinsp_scan(callee, mode, name) || dinsp_scan_list(args, mode, name)
+          },
+          _ => dinsp_scan(callee, mode, name) || dinsp_scan_list(args, mode, name)
+        }
+      } else {
+        dinsp_scan(callee, mode, name) || dinsp_scan_list(args, mode, name)
+      },
       EBinOp(_, l, r) => dinsp_scan(l, mode, name) || dinsp_scan(r, mode, name),
       EUnaryOp(_, v) => dinsp_scan(v, mode, name),
       EFn(_, _, _, _, _, body) => dinsp_scan(body, mode, name),
@@ -10520,8 +10068,8 @@ export fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit {
 }
 
 /// In-place labeled-argument reordering over a whole program. Rebuilds only the
-/// top-level statements that actually contain a labeled argument (see
-/// expr_has_labeled_arg).
+/// top-level statements that the allocation-free scalar scan finds contain a
+/// labeled argument.
 export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   let tbl = collect_fn_param_labels(stmts)
   // #1500: optional-parameter call sites are rewritten by the same walk (see
@@ -10779,8 +10327,8 @@ fn dtpw_expr_binds_name(expr: Expr, name: String) -> Bool {
       while i < Array::length(arms) && !found {
         let (p, b) = Array::get(arms, i)
         let bound = array_empty()
-        dlh_pat_binds(p, bound)
-        if dlh_contains(bound, name) || dtpw_expr_binds_name(b, name) {
+        collect_pat_binders(p, bound)
+        if str_array_contains(bound, name) || dtpw_expr_binds_name(b, name) {
           found = true
         } else {
           ()
@@ -10795,8 +10343,8 @@ fn dtpw_expr_binds_name(expr: Expr, name: String) -> Bool {
       while i < Array::length(arms) && !found {
         let (p, b) = Array::get(arms, i)
         let bound = array_empty()
-        dlh_pat_binds(p, bound)
-        if dlh_contains(bound, name) || dtpw_expr_binds_name(b, name) {
+        collect_pat_binders(p, bound)
+        if str_array_contains(bound, name) || dtpw_expr_binds_name(b, name) {
           found = true
         } else {
           ()
@@ -10941,7 +10489,7 @@ fn dtpw_collect_wrappers(stmts: Array[Stmt]) -> Array[String] {
 fn dtpw_inline_expr(expr: Expr, wrappers: Array[String]) -> Expr {
   match expr {
     ECall(callee, args, off) => match callee {
-      EIdent(wn, _) => if dlh_contains(wrappers, wn) && Array::length(args) == 1 {
+      EIdent(wn, _) => if str_array_contains(wrappers, wn) && Array::length(args) == 1 {
         ECall(dtpw_inline_expr(Array::get(args, 0), wrappers), array_empty(), off)
       } else {
         ECall(dtpw_inline_expr(callee, wrappers), for a in args {

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -7,6 +7,7 @@ deps = {
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/syntax : 0.0.1
   @vibe/core : 0.2.0
+  @vibe/parser : 0.1.0
 }
 
 generated_hash =
@@ -56,6 +57,16 @@ fn desugar_railway_binds(stmts: Array[Stmt]) -> Unit
 fn desugar_derives(stmts: Array[Stmt]) -> Unit
 fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit
 fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit
+
+// Opt-in authority-aware labeled-argument normalization. Only the opaque
+// source-owning parser aggregate may enter; forgeable public node arrays never
+// authorize this API or the complete-or-none normalized aggregate.
+opaque type LabeledArgBinderAuthorityNormalization
+opaque type NormalizedProgramBinderAuthority
+fn normalize_labeled_args_with_binder_authority(source: LocatedProgramBinderAuthority) -> LabeledArgBinderAuthorityNormalization
+fn labeled_arg_binder_authority_normalization_program(result: LabeledArgBinderAuthorityNormalization) -> Array[Stmt]
+fn labeled_arg_binder_authority_normalization_authority(result: LabeledArgBinderAuthorityNormalization) -> Option[NormalizedProgramBinderAuthority]
+fn normalized_program_binder_authority_nodes(authority: NormalizedProgramBinderAuthority) -> Array[BinderAuthorityNode]
 // #1571: expand `inspect(value, content)` to its `__to_string`/`println`/
 // `assert_true` form BEFORE checking, so the snapshot assertion needs no
 // import and every pre-codegen scan sees ordinary calls.

--- a/lib/@vibe/compiler/tests/codegen_parser_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_parser_test.vibe
@@ -36,6 +36,7 @@ test "wasi: parser.vibe import - compile and run" {
     "lib/@vibe/parser/lexer.vibe",
     "lib/@vibe/parser/parser_base.vibe",
     "lib/@vibe/parser/parser_binder_context.vibe",
+    "lib/@vibe/parser/ast_detach.vibe",
     "lib/@vibe/parser/parser_binder_authority.vibe",
     "lib/@vibe/parser/parser_expr_primary.vibe",
     "lib/@vibe/parser/parser_expr_core.vibe",

--- a/lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe
+++ b/lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe
@@ -1,0 +1,258 @@
+//# Imports
+
+import @vibe/compiler/core {
+  Expr, Stmt
+}
+
+import @vibe/compiler/normalize {
+  LabeledArgBinderAuthorityNormalization,
+  NormalizedProgramBinderAuthority,
+  desugar_labeled_args,
+  labeled_arg_binder_authority_normalization_authority,
+  labeled_arg_binder_authority_normalization_program,
+  normalize_labeled_args_with_binder_authority,
+  normalized_program_binder_authority_nodes
+}
+
+import @vibe/parser {
+  BinderAuthorityNode,
+  BinderAuthorityNodeKind,
+  BinderAuthoritySlot,
+  BinderSemanticRole,
+  SourceBinder,
+  binder_authority_node_children,
+  binder_authority_node_kind,
+  binder_authority_node_slots,
+  binder_authority_slot_binder,
+  located_program_binder_authority_nodes,
+  located_program_binder_authority_program,
+  parse_source_located_with_binder_authority
+}
+
+//# Helpers
+
+fn normalize_source(source: String) -> Option[LabeledArgBinderAuthorityNormalization] with Exception {
+  match parse_source_located_with_binder_authority(source) {
+    Some(authority) => Some(normalize_labeled_args_with_binder_authority(authority)),
+    None => None
+  }
+}
+
+fn normalized_authority(source: String) -> Option[NormalizedProgramBinderAuthority] with Exception {
+  match normalize_source(source) {
+    Some(result) => labeled_arg_binder_authority_normalization_authority(result),
+    None => None
+  }
+}
+
+fn expect_no_authority(source: String) -> Unit with Exception {
+  match normalize_source(source) {
+    Some(result) => match labeled_arg_binder_authority_normalization_authority(result) {
+      Some(_) => inspect(false, "true"),
+      None => inspect(true, "true")
+    },
+    None => inspect(false, "true")
+  }
+}
+
+fn expect_ordinary_parity(source: String) -> Unit with Exception {
+  match (parse_source_located_with_binder_authority(source), parse_source_located_with_binder_authority(source)) {
+    (Some(ordinary_source), Some(paired_source)) => {
+      let ordinary = located_program_binder_authority_program(ordinary_source)
+      desugar_labeled_args(ordinary)
+      let paired = normalize_labeled_args_with_binder_authority(paired_source)
+      inspect(ordinary == labeled_arg_binder_authority_normalization_program(paired), "true")
+    },
+    _ => inspect(false, "true")
+  }
+}
+
+fn node_tag(node: BinderAuthorityNode) -> Int {
+  match binder_authority_node_kind(node) {
+    AuthorityStmtLet => 1,
+    AuthorityStmtExample => 2,
+    AuthorityExprFn => 3,
+    AuthorityStmtTest => 8,
+    AuthorityExprCall => 4,
+    AuthorityExprIdent => 5,
+    AuthorityExprInt => 6,
+    AuthorityExprLet => 7,
+    _ => 99
+  }
+}
+
+fn slot_start(node: BinderAuthorityNode, index: Int) -> Int {
+  match binder_authority_slot_binder(Array::get(binder_authority_node_slots(node), index)) {
+    SourceToken(_, start, _) => start,
+    _ => -1
+  }
+}
+
+fn call_from_root(roots: Array[BinderAuthorityNode], root: Int) -> BinderAuthorityNode {
+  let stmt = Array::get(roots, root)
+  let body = Array::get(binder_authority_node_children(stmt), 0)
+  Array::get(binder_authority_node_children(body), 0)
+}
+
+//# Tests
+
+test "same source index moves AST and authority while wrappers promote" {
+  let source = "fn target(x: Int, y: Int) -> Int { x }\nfn main() -> Int { target(y={ let nested = 2; nested }, x=1) }"
+  match normalize_source(source) {
+    Some(result) => {
+      match Array::get(labeled_arg_binder_authority_normalization_program(result), 1) {
+        SLet(_, _, _, _, EFn(_, _, _, _, _, ECall(_, args, _))) => {
+          match Array::get(args, 0) {
+            EInt(1) => inspect(true, "true"),
+            _ => inspect(false, "true")
+          }
+          match Array::get(args, 1) {
+            ELet("nested", EInt(2), _, _) => inspect(true, "true"),
+            _ => inspect(false, "true")
+          }
+        },
+        _ => inspect(false, "true")
+      }
+      match labeled_arg_binder_authority_normalization_authority(result) {
+        Some(authority) => {
+          let call = call_from_root(normalized_program_binder_authority_nodes(authority), 1)
+          let children = binder_authority_node_children(call)
+          inspect(node_tag(call), "4")
+          inspect(node_tag(Array::get(children, 0)), "5")
+          inspect(node_tag(Array::get(children, 1)), "6")
+          inspect(node_tag(Array::get(children, 2)), "7")
+        },
+        None => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "example source keeps paired body authority through its production STest lowering" {
+  let source = "fn target(x: Int, y: Int) -> Int { x }\nexample \"labels\" { target(y=2, x=1) }"
+  match normalize_source(source) {
+    Some(result) => {
+      match Array::get(labeled_arg_binder_authority_normalization_program(result), 1) {
+        STest("labels", ECall(_, args, _)) => match (Array::get(args, 0), Array::get(args, 1)) {
+          (EInt(1), EInt(2)) => inspect(true, "true"),
+          _ => inspect(false, "true")
+        },
+        _ => inspect(false, "true")
+      }
+      match labeled_arg_binder_authority_normalization_authority(result) {
+        Some(authority) => {
+          let roots = normalized_program_binder_authority_nodes(authority)
+          inspect(node_tag(Array::get(roots, 1)), "8")
+          let call = Array::get(binder_authority_node_children(Array::get(roots, 1)), 0)
+          inspect(node_tag(call), "4")
+          inspect(node_tag(Array::get(binder_authority_node_children(call), 1)), "6")
+        },
+        None => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "positional topology remains callee first" {
+  match normalized_authority("fn target(x: Int, y: Int) -> Int { x }\nfn main() -> Int { target(1, 2) }") {
+    Some(authority) => {
+      let children = binder_authority_node_children(call_from_root(normalized_program_binder_authority_nodes(authority), 1))
+      inspect(node_tag(Array::get(children, 0)), "5")
+      inspect(node_tag(Array::get(children, 1)), "6")
+      inspect(node_tag(Array::get(children, 2)), "6")
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "poison matrix is complete or none and ordinary output stays identical" {
+  let valid = "fn f(x: Int, y: Int) -> Int { x }\nfn main() -> Int { f(y=2, x=1) }"
+  expect_ordinary_parity(valid)
+  expect_ordinary_parity("fn f(x?: Int) -> Int { 0 }\nfn main() -> Int { f() }")
+  expect_no_authority("fn f(x?: Int) -> Int { 0 }\nfn main() -> Int { f(1) }")
+  expect_no_authority("fn f(x?: Int) -> Int { 0 }\nfn main() -> Int { f() }")
+  expect_no_authority("fn f(x: Int, y: Int) -> Int { x }\nfn main() -> Int { f(x=1, x=2) }")
+  expect_no_authority("fn f(x: Int, y: Int) -> Int { x }\nfn main() -> Int { f(x=1) }")
+  expect_no_authority("fn f(x: Int, y: Int) -> Int { x }\nfn main() -> Int { f(z=1, y=2) }")
+  expect_no_authority("fn f(x: Int, y: Int) -> Int { x }\nfn main() -> Int { f(x=1, 2) }")
+  // Parser represents this annotated local binding with a Synthetic slot.
+  expect_no_authority("let f = () -> { let x: Int = 1; x }")
+}
+
+test "lexical shadowing suppresses top-level resolution in every scoped lane" {
+  expect_no_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { let f = (y: Int) -> Int { y }; f(y=1) }")
+  expect_no_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { match 1 { f => f(x=1) } }")
+  expect_no_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { for f in [1] { f(x=1) }; 0 }")
+}
+
+test "source and normalized programs are recursively detached" {
+  let source = "fn target(x: (Int) -> Int, y: (Int) -> Int) -> Int { 0 }\nfn main() -> Int { target(y=(same: Int) -> Int { 0 }, x=(same: Int) -> Int { 0 }) }"
+  match parse_source_located_with_binder_authority(source) {
+    Some(source_authority) => {
+      let public_program = located_program_binder_authority_program(source_authority)
+      match Array::get(public_program, 1) {
+        SLet(_, _, _, _, EFn(_, _, _, _, _, ECall(_, args, _))) => {
+          let first = Array::get(args, 0)
+          Array::set(args, 0, Array::get(args, 1))
+          Array::set(args, 1, first)
+          Array::truncate(args, 1)
+        },
+        _ => inspect(false, "true")
+      }
+      let public_nodes = located_program_binder_authority_nodes(source_authority)
+      Array::truncate(public_nodes, 1)
+      let result = normalize_labeled_args_with_binder_authority(source_authority)
+      match labeled_arg_binder_authority_normalization_authority(result) {
+        Some(authority) => {
+          let call = call_from_root(normalized_program_binder_authority_nodes(authority), 1)
+          let children = binder_authority_node_children(call)
+          inspect(Array::length(children), "3")
+          inspect(slot_start(Array::get(children, 1), 0) > slot_start(Array::get(children, 2), 0), "true")
+          let first_view = labeled_arg_binder_authority_normalization_program(result)
+          match Array::get(first_view, 1) {
+            SLet(_, _, _, _, EFn(_, _, _, _, _, ECall(_, args, _))) => Array::truncate(args, 0),
+            _ => inspect(false, "true")
+          }
+          let second_view = labeled_arg_binder_authority_normalization_program(result)
+          match Array::get(second_view, 1) {
+            SLet(_, _, _, _, EFn(_, _, _, _, _, ECall(_, args, _))) => inspect(Array::length(args), "2"),
+            _ => inspect(false, "true")
+          }
+        },
+        None => inspect(false, "true")
+      }
+    },
+    None => inspect(false, "true")
+  }
+}
+
+test "authority inspection mutation cannot alter private retained topology" {
+  match normalized_authority("fn target(x: Int, y: Int) -> Int { x }\nfn main() -> Int { target(y=2, x=1) }") {
+    Some(authority) => {
+      let first = normalized_program_binder_authority_nodes(authority)
+      let call = call_from_root(first, 1)
+      let forged = BinderAuthorityNode::{
+        kind: AuthorityExprUnit,
+        slots: [
+          BinderAuthoritySlot::{
+            role: PatternBinder,
+            binder: SourceToken("forged", 0, 6)
+          }
+        ],
+        children: [
+        ]
+      }
+      Array::set(call.children, 0, forged)
+      Array::truncate(call.children, 1)
+      Array::truncate(first, 1)
+      let second = normalized_program_binder_authority_nodes(authority)
+      let call_again = call_from_root(second, 1)
+      inspect(node_tag(call_again), "4")
+      inspect(Array::length(call_again.children), "3")
+      inspect(node_tag(Array::get(call_again.children, 0)), "5")
+    },
+    None => inspect(false, "true")
+  }
+}

--- a/lib/@vibe/parser/ast_detach.vibe
+++ b/lib/@vibe/parser/ast_detach.vibe
@@ -1,0 +1,182 @@
+import @vibe/ast {
+  Expr, Pat, Stmt, TypeExpr
+}
+
+fn detach_strings(values: Array[String]) -> Array[String] {
+  Array::slice(values, 0, Array::length(values))
+}
+
+fn detach_optional_type_expr(value: Option[TypeExpr]) -> Option[TypeExpr] {
+  match value {
+    Some(ty) => Some(detach_type_expr(ty)),
+    None => None
+  }
+}
+
+fn detach_optional_expr(value: Option[Expr]) -> Option[Expr] {
+  match value {
+    Some(expr) => Some(detach_expr(expr)),
+    None => None
+  }
+}
+
+fn detach_pat(pat: Pat) -> Pat {
+  match pat {
+    PWild => pat,
+    PBind(_) => pat,
+    PInt(_) => pat,
+    PFloat(_) => pat,
+    PString(_) => pat,
+    PBool(_) => pat,
+    PCtor(name, args) => PCtor(name, for arg in args {
+      detach_pat(arg)
+    }),
+    PTuple(items) => PTuple(for item in items {
+      detach_pat(item)
+    }),
+    POr(left, right) => POr(detach_pat(left), detach_pat(right)),
+    PStruct(name, fields) => PStruct(name, for field in fields {
+      (field.0, detach_pat(field.1))
+    })
+  }
+}
+
+fn detach_type_expr(ty: TypeExpr) -> TypeExpr {
+  match ty {
+    TyName(_) => ty,
+    TyApp(name, args) => TyApp(name, for arg in args {
+      detach_type_expr(arg)
+    }),
+    TyFn(params, result, effect) => TyFn(for param in params {
+      detach_type_expr(param)
+    }, detach_type_expr(result), effect),
+    TyTuple(items) => TyTuple(for item in items {
+      detach_type_expr(item)
+    }),
+    TyUnit => ty
+  }
+}
+
+fn detach_expr_array(items: Array[Expr]) -> Array[Expr] {
+  for item in items {
+    detach_expr(item)
+  }
+}
+
+fn detach_named_exprs(items: Array[(String, Expr)]) -> Array[(String, Expr)] {
+  for item in items {
+    (item.0, detach_expr(item.1))
+  }
+}
+
+fn detach_arms(arms: Array[(Pat, Expr)]) -> Array[(Pat, Expr)] {
+  for arm in arms {
+    (detach_pat(arm.0), detach_expr(arm.1))
+  }
+}
+
+fn detach_type_expr_array(items: Array[TypeExpr]) -> Array[TypeExpr] {
+  for item in items {
+    detach_type_expr(item)
+  }
+}
+
+fn detach_bounds(bounds: Array[(String, Array[String])]) -> Array[(String, Array[String])] {
+  for bound in bounds {
+    (bound.0, detach_strings(bound.1))
+  }
+}
+
+fn detach_expr(expr: Expr) -> Expr {
+  match expr {
+    EInt(_) => expr,
+    EFloat(_) => expr,
+    EString(_) => expr,
+    EBool(_) => expr,
+    EIdent(_, _) => expr,
+    ETuple(items) => ETuple(detach_expr_array(items)),
+    EArray(items) => EArray(detach_expr_array(items)),
+    ERecord(name, fields, type_args) => ERecord(name, detach_named_exprs(fields), detach_type_expr_array(type_args)),
+    EIf(cond, yes, no) => EIf(detach_expr(cond), detach_expr(yes), detach_expr(no)),
+    ELet(name, value, body, offset) => ELet(name, detach_expr(value), detach_expr(body), offset),
+    ELetRec(name, value, body) => ELetRec(name, detach_expr(value), detach_expr(body)),
+    ELetMut(name, value, body, offset) => ELetMut(name, detach_expr(value), detach_expr(body), offset),
+    EAssign(name, value, body) => EAssign(name, detach_expr(value), detach_expr(body)),
+    EAssignOp(name, op, value, body) => EAssignOp(name, op, detach_expr(value), detach_expr(body)),
+    ESeq(first, second) => ESeq(detach_expr(first), detach_expr(second)),
+    EMatch(value, arms) => EMatch(detach_expr(value), detach_arms(arms)),
+    EHandle(value, arms) => EHandle(detach_expr(value), detach_arms(arms)),
+    EWhile(cond, body) => EWhile(detach_expr(cond), detach_expr(body)),
+    ELoop(params, body) => ELoop(for param in params {
+      (param.0, detach_expr(param.1))
+    }, detach_expr(body)),
+    EForIn(name, index, iter, body) => EForIn(name, index, detach_expr(iter), detach_expr(body)),
+    ECall(callee, args, offset) => ECall(detach_expr(callee), detach_expr_array(args), offset),
+    EBinOp(op, left, right) => EBinOp(op, detach_expr(left), detach_expr(right)),
+    EUnaryOp(op, value) => EUnaryOp(op, detach_expr(value)),
+    EFn(type_params, bounds, params, result, effect, body) => EFn(detach_strings(type_params), detach_bounds(bounds), for param in params {
+      (param.0, detach_optional_type_expr(param.1))
+    }, detach_optional_type_expr(result), effect, detach_expr(body)),
+    EDot(value, field, offset, field_offset) => EDot(detach_expr(value), field, offset, field_offset),
+    ELabeledArg(label, name, value) => ELabeledArg(label, name, detach_expr(value)),
+    EReturn(value) => EReturn(detach_expr(value)),
+    EBreak(value) => EBreak(detach_optional_expr(value)),
+    EContinue(values) => EContinue(detach_expr_array(values)),
+    EMap(items) => EMap(detach_named_exprs(items)),
+    ESpread(value) => ESpread(detach_expr(value)),
+    EStringInterp(parts) => EStringInterp(detach_strings(parts)),
+    EUnit => expr
+  }
+}
+
+fn detach_variant_types(items: Array[(String, Array[TypeExpr])]) -> Array[(String, Array[TypeExpr])] {
+  for item in items {
+    (item.0, detach_type_expr_array(item.1))
+  }
+}
+
+fn detach_methods(items: Array[(String, Array[TypeExpr], TypeExpr)]) -> Array[(String, Array[TypeExpr], TypeExpr)] {
+  for item in items {
+    (item.0, detach_type_expr_array(item.1), detach_type_expr(item.2))
+  }
+}
+
+fn detach_stmt(stmt: Stmt) -> Stmt {
+  match stmt {
+    SLet(exported, recursive, name, ty, value) => SLet(exported, recursive, name, detach_optional_type_expr(ty), detach_expr(value)),
+    SLetMut(name, ty, value) => SLetMut(name, detach_optional_type_expr(ty), detach_expr(value)),
+    SEnum(exported, name, params, variants, derives) => SEnum(exported, name, detach_strings(params), detach_variant_types(variants), detach_strings(derives)),
+    SSuberror(exported, name, variants) => SSuberror(exported, name, detach_variant_types(variants)),
+    SStruct(exported, name, fields, derives, mutable_fields, params) => SStruct(exported, name, for field in fields {
+      (field.0, detach_type_expr(field.1))
+    }, detach_strings(derives), detach_strings(mutable_fields), detach_strings(params)),
+    STypeAlias(exported, name, params, target) => STypeAlias(exported, name, detach_strings(params), detach_type_expr(target)),
+    STrait(exported, name, supers, methods, method_generics, params) => STrait(exported, name, detach_strings(supers), detach_methods(methods), for item in method_generics {
+      (item.0, detach_strings(item.1), detach_bounds(item.2))
+    }, detach_strings(params)),
+    SImpl(type_params, bounds, trait_name, target_name) => SImpl(detach_strings(type_params), detach_bounds(bounds), trait_name, target_name),
+    SExternLet(name, ty) => SExternLet(name, detach_type_expr(ty)),
+    SImport(path, items) => SImport(path, Array::slice(items, 0, Array::length(items))),
+    STest(name, body) => STest(name, detach_expr(body)),
+    SBench(name, body) => SBench(name, detach_expr(body)),
+    SExample(name, body) => SExample(name, detach_expr(body)),
+    SExpr(body) => SExpr(detach_expr(body)),
+    SExport(names) => SExport(detach_strings(names)),
+    SReExport(path, items) => SReExport(path, Array::slice(items, 0, Array::length(items))),
+    SAliasDecl(_, _) => stmt,
+    SQualifiedPatternRefs(items) => SQualifiedPatternRefs(Array::slice(items, 0, Array::length(items))),
+    STestEffectRows(items) => STestEffectRows(Array::slice(items, 0, Array::length(items))),
+    SLetPat(pat, value) => SLetPat(detach_pat(pat), detach_expr(value)),
+    SModule(exported, name, stmts) => SModule(exported, name, detach_stmts(stmts)),
+    SEffectDef(exported, name, params, operations) => SEffectDef(exported, name, detach_strings(params), detach_methods(operations)),
+    SEffectSet(exported, name, members) => SEffectSet(exported, name, detach_strings(members)),
+    SResource(_, _) => stmt,
+    SFnDecl(exported, name, value, requires, ensures) => SFnDecl(exported, name, detach_expr(value), detach_expr_array(requires), detach_expr_array(ensures))
+  }
+}
+
+export fn detach_stmts(stmts: Array[Stmt]) -> Array[Stmt] {
+  for stmt in stmts {
+    detach_stmt(stmt)
+  }
+}

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -63,6 +63,8 @@ fn binder_capture_is_eligible(context: ParserBinderContext) -> Bool
 fn binder_capture_rows(context: ParserBinderContext) -> Array[SourceBinder]
 fn validate_program_binder_rows(program: Array[Stmt], rows: Array[SourceBinder], source: String) -> Bool
 
+fn detach_stmts(stmts: Array[Stmt]) -> Array[Stmt]
+
 // --- polyfill
 
 // --- token

--- a/lib/@vibe/parser/parser_binder_authority.vibe
+++ b/lib/@vibe/parser/parser_binder_authority.vibe
@@ -4,6 +4,10 @@ import @vibe/ast {
   Expr, Pat, Stmt
 }
 
+import ./ast_detach.vibe {
+  detach_stmts
+}
+
 import ./lexer.vibe {
   lex_with_offsets
 }
@@ -118,6 +122,10 @@ export struct BinderAuthorityNode {
   children: Array[BinderAuthorityNode]
 }
 
+enum StoredLocatedProgram {
+  StoredLocatedProgramValue(Array[Stmt])
+}
+
 /// Private persistent representation retained by the validated aggregate.
 /// No mutable Array is reachable from this topology. Public forgeable nodes
 /// are materialized only as detached data copies at the accessor boundary.
@@ -131,7 +139,7 @@ enum StoredBinderAuthority {
 /// Atomically produced exact-source parse result, compatibility rows, and the
 /// sidecar built in the same exhaustive walk against that exact final AST.
 export struct LocatedProgramBinderAuthority {
-  program: Array[Stmt];
+  program: StoredLocatedProgram;
   binders: Array[SourceBinder];
   nodes: StoredBinderAuthority
 }
@@ -159,7 +167,9 @@ export fn binder_authority_slot_binder(slot: BinderAuthoritySlot) -> SourceBinde
 }
 
 export fn located_program_binder_authority_program(authority: LocatedProgramBinderAuthority) -> Array[Stmt] {
-  Array::slice(authority.program, 0, Array::length(authority.program))
+  match authority.program {
+    StoredLocatedProgramValue(program) => detach_stmts(program)
+  }
 }
 
 export fn located_program_binder_authority_rows(authority: LocatedProgramBinderAuthority) -> Array[SourceBinder] {
@@ -793,7 +803,7 @@ export fn parse_source_located_with_binder_authority(source: String) -> Option[L
   } && binder_capture_is_eligible(context) {
     match build_program_binder_authority(program, rows, source) {
       Some(nodes) => Some(LocatedProgramBinderAuthority::{
-        program,
+        program: StoredLocatedProgramValue(program),
         binders: rows,
         nodes: stored_authority_nodes(nodes, 0)
       }),

--- a/tests/labeled_arg_binder_authority_structure_test.mjs
+++ b/tests/labeled_arg_binder_authority_structure_test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const root = new URL("../", import.meta.url);
+const normalizer = readFileSync(new URL("lib/@vibe/compiler/normalize/desugar_trait_dict.vibe", root), "utf8");
+const detach = readFileSync(new URL("lib/@vibe/parser/ast_detach.vibe", root), "utf8");
+const normalizeFacade = readFileSync(new URL("lib/@vibe/compiler/normalize/index.vpkg", root), "utf8");
+const parserFacade = readFileSync(new URL("lib/@vibe/parser/index.vpkg", root), "utf8");
+
+function maskNonCode(source) {
+  const out = [...source];
+  let string = false;
+  let escaped = false;
+  let comment = false;
+  for (let i = 0; i < out.length; i++) {
+    const c = source[i];
+    const n = source[i + 1] ?? "";
+    if (comment) {
+      if (c === "\n") comment = false;
+      else out[i] = " ";
+    } else if (string) {
+      if (escaped) escaped = false;
+      else if (c === "\\") escaped = true;
+      else if (c === '"') string = false;
+      if (c !== "\n") out[i] = " ";
+    } else if (c === "/" && n === "/") {
+      comment = true;
+      out[i] = out[i + 1] = " ";
+      i++;
+    } else if (c === '"') {
+      string = true;
+      out[i] = " ";
+    }
+  }
+  return out.join("");
+}
+
+function functionBody(source, name) {
+  const masked = maskNonCode(source);
+  const match = new RegExp(`(?:export\\s+)?fn\\s+${name}\\s*\\(`).exec(masked);
+  assert.ok(match, `${name} definition missing`);
+  const open = masked.indexOf("{", match.index);
+  assert.notEqual(open, -1, `${name} body missing`);
+  let depth = 0;
+  for (let i = open; i < masked.length; i++) {
+    if (masked[i] === "{") depth++;
+    else if (masked[i] === "}" && --depth === 0) return source.slice(open + 1, i);
+  }
+  assert.fail(`${name} body unterminated`);
+}
+
+function outerArms(source, name) {
+  const body = functionBody(source, name);
+  const masked = maskNonCode(body);
+  const starts = [];
+  let brace = 0;
+  for (let i = 0; i < masked.length; i++) {
+    if (masked[i] === "{") brace++;
+    else if (masked[i] === "}") brace--;
+    if (brace !== 1 || (i > 0 && masked[i - 1] !== "\n")) continue;
+    const m = /^    ([A-Z][A-Za-z0-9_]*|_)(?:\([^\n]*\))? =>/.exec(masked.slice(i));
+    if (m) starts.push({ name: m[1], index: i });
+  }
+  return new Map(starts.map((entry, i) => [entry.name, body.slice(entry.index, starts[i + 1]?.index ?? body.length)]));
+}
+
+function exactKeys(map, expected, label) {
+  assert.deepEqual([...map.keys()].filter((x) => x !== "_").sort(), [...expected].sort(), label);
+}
+
+const ordinary = [
+  ["optional_fill_args", "fn optional_fill_args(args: Array[Expr], flags: Array[Bool]) -> Array[Expr]"],
+  ["reorder_labeled_args", "fn reorder_labeled_args(args: Array[Expr], param_labels: Array[String]) -> Option[Array[Expr]]"],
+  ["strip_labeled_wrappers", "fn strip_labeled_wrappers(args: Array[Expr]) -> Array[Expr]"],
+  ["strip_in_position_labels", "fn strip_in_position_labels(args: Array[Expr], labels: Array[String]) -> Array[Expr]"],
+  ["relabel_expr", "fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[String]) -> Expr"],
+  ["relabel_stmt", "fn relabel_stmt(stmt: Stmt, tbl: Array[(String, Array[String])]) -> Stmt"],
+  ["desugar_labeled_args", "export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit"],
+];
+for (const [name, signature] of ordinary) {
+  assert.ok(normalizer.includes(signature), signature);
+  assert.doesNotMatch(functionBody(normalizer, name), /paired_|BinderAuthority|detach_stmts|located_program_binder_authority|callback|LabeledArgAuthorityWalk/);
+}
+assert.match(functionBody(normalizer, "desugar_labeled_args"), /stmt_has_labeled_arg/);
+assert.doesNotMatch(functionBody(normalizer, "desugar_labeled_args"), /desugar_labeled_args_paired/);
+
+for (const [name, result] of [["labeled_reorder_candidate", "Bool"], ["labeled_source_index", "Int"], ["label_matches_position", "Bool"]]) {
+  assert.match(normalizer, new RegExp(`fn ${name}\\([^)]*\\) -> ${result}`));
+  assert.doesNotMatch(functionBody(normalizer, name), /Some\(|None|ArrayBuilder|array_empty|callback/);
+}
+
+const callArm = outerArms(normalizer, "relabel_expr_paired").get("ECall");
+assert.match(callArm, /let source = labeled_source_index\(rargs, Array::get\(labels, pi\)\)/);
+assert.match(callArm, /Array::push\(reordered, Array::get\(rargs, source\)\)/);
+assert.match(callArm, /Array::set\(node.children, pi \+ 1, Array::get\(original_children, source \+ 1\)\)/);
+assert.match(callArm, /Array::get\(used, source\)/);
+const promote = functionBody(normalizer, "paired_promote_wrapper");
+assert.match(promote, /AuthorityExprLabeledArg/);
+assert.match(promote, /Array::length\(binder_authority_node_slots\(wrapper\)\) == 0/);
+assert.match(promote, /Array::length\(children\) == 1/);
+
+assert.match(normalizeFacade, /normalize_labeled_args_with_binder_authority\(source: LocatedProgramBinderAuthority\)/);
+assert.doesNotMatch(normalizeFacade, /normalize_labeled_args_with_binder_authority\([^)]*(BinderAuthorityNode|BinderAuthoritySlot|Array\[)/);
+assert.match(parserFacade, /fn detach_stmts\(stmts: Array\[Stmt\]\) -> Array\[Stmt\]/);
+
+const pats = ["PWild", "PBind", "PInt", "PFloat", "PString", "PBool", "PCtor", "PTuple", "POr", "PStruct"];
+const types = ["TyName", "TyApp", "TyFn", "TyTuple", "TyUnit"];
+const exprs = ["EInt", "EFloat", "EString", "EBool", "EIdent", "ETuple", "EArray", "ERecord", "EIf", "ELet", "ELetRec", "ELetMut", "EAssign", "EAssignOp", "ESeq", "EMatch", "EHandle", "EWhile", "ELoop", "EForIn", "ECall", "EBinOp", "EUnaryOp", "EFn", "EDot", "ELabeledArg", "EReturn", "EBreak", "EContinue", "EMap", "ESpread", "EStringInterp", "EUnit"];
+const stmts = ["SLet", "SLetMut", "SEnum", "SSuberror", "SStruct", "STypeAlias", "STrait", "SImpl", "SExternLet", "SImport", "STest", "SBench", "SExample", "SExpr", "SExport", "SReExport", "SAliasDecl", "SQualifiedPatternRefs", "STestEffectRows", "SLetPat", "SModule", "SEffectDef", "SEffectSet", "SResource", "SFnDecl"];
+exactKeys(outerArms(detach, "detach_pat"), pats, "10 Pat detachment arms");
+exactKeys(outerArms(detach, "detach_type_expr"), types, "5 TypeExpr detachment arms");
+exactKeys(outerArms(detach, "detach_expr"), exprs, "33 Expr detachment arms");
+exactKeys(outerArms(detach, "detach_stmt"), stmts, "25 Stmt detachment arms");
+for (const name of ["detach_pat", "detach_type_expr", "detach_expr", "detach_stmt"]) assert.doesNotMatch(functionBody(detach, name), /_ =>/);
+
+const pairedPats = outerArms(normalizer, "paired_expect_pat");
+exactKeys(pairedPats, pats, "10 paired Pat arms");
+assert.match(pairedPats.get("POr"), /paired_poison/);
+const pairedExprs = outerArms(normalizer, "relabel_expr_paired");
+exactKeys(pairedExprs, exprs, "33 paired Expr arms");
+assert.match(pairedExprs.get("ELoop"), /paired_poison[\s\S]*relabel_expr\(expr, tbl, shadows\)/);
+for (const name of ["EMatch", "EHandle"]) assert.match(pairedExprs.get(name), /node, 0[\s\S]*1 \+ i \* 2[\s\S]*2 \+ i \* 2/);
+
+const pairedStmts = outerArms(normalizer, "relabel_stmt_paired");
+exactKeys(pairedStmts, ["SLet", "SLetMut", "STest", "SBench", "SExample", "SExpr", "SExternLet", "SImport", "SAliasDecl", "STypeAlias", "SEffectSet", "SResource", "SExport", "SReExport", "SQualifiedPatternRefs", "STestEffectRows"], "paired supported Stmt arms");
+assert.match(pairedStmts.get("SExample"), /AuthorityStmtExample[\s\S]*relabel_expr_paired_child/);
+assert.match(pairedStmts.get("_"), /paired_poison[\s\S]*relabel_stmt/);
+
+const driver = functionBody(normalizer, "desugar_labeled_args_paired");
+assert.match(driver, /Array::length\(roots\) != Array::length\(stmts\)[\s\S]*paired_poison/);
+assert.match(driver, /let sentinel = BinderAuthorityNode/);
+assert.match(driver, /while i < Array::length\(stmts\)/);
+assert.match(driver, /else \{\s*sentinel\s*\}/);
+assert.doesNotMatch(driver, /relabel_stmt\(/);
+assert.doesNotMatch(normalizer, /Option\[LabeledArgAuthorityWalk\]|struct LabeledArgAuthorityWalk/);
+
+console.log("labeled binder authority structure: ok");

--- a/tests/normalizer_scalar_scan_compaction_test.mjs
+++ b/tests/normalizer_scalar_scan_compaction_test.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const source = fs.readFileSync(new URL("../lib/@vibe/compiler/normalize/desugar_trait_dict.vibe", import.meta.url), "utf8");
+const astContract = fs.readFileSync(new URL("../lib/@vibe/ast/index.vpkg", import.meta.url), "utf8");
+
+// Mask non-code without changing offsets. Search indexes from this text are safe
+// to use against the original source; this is the regression boundary that the
+// rejected first oracle violated by deleting comment bytes.
+function maskNonCode(text, maskStrings = true) {
+  const out = [...text];
+  let state = "code";
+  let escaped = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (state === "string") {
+      if (maskStrings && ch !== "\n") out[i] = " ";
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') state = "code";
+    } else if (state === "comment") {
+      if (ch === "\n") state = "code";
+      else out[i] = " ";
+    } else if (ch === '"') {
+      state = "string";
+      if (maskStrings) out[i] = " ";
+    } else if (ch === "/" && next === "/") {
+      state = "comment";
+      out[i] = " ";
+      out[i + 1] = " ";
+      i += 1;
+    }
+  }
+  return out.join("");
+}
+
+function balanced(text, openIndex) {
+  assert.equal(text[openIndex], "{", `expected { at ${openIndex}`);
+  let depth = 0;
+  let state = "code";
+  let escaped = false;
+  for (let i = openIndex; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (state === "string") {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') state = "code";
+      continue;
+    }
+    if (state === "comment") {
+      if (ch === "\n") state = "code";
+      continue;
+    }
+    if (ch === '"') state = "string";
+    else if (ch === "/" && next === "/") { state = "comment"; i += 1; }
+    else if (ch === "{") depth += 1;
+    else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) return { body: text.slice(openIndex + 1, i), end: i + 1 };
+    }
+  }
+  assert.fail(`unterminated block at ${openIndex}`);
+}
+
+function canonical(text) {
+  return maskNonCode(text, false).replace(/\s+/g, " ").trim();
+}
+
+function splitTopLevel(text, separator) {
+  const parts = [];
+  const stack = [];
+  const closing = { "(": ")", "[": "]", "{": "}" };
+  let state = "code";
+  let escaped = false;
+  let start = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (state === "string") {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') state = "code";
+      continue;
+    }
+    if (state === "comment") {
+      if (ch === "\n") state = "code";
+      continue;
+    }
+    if (ch === '"') state = "string";
+    else if (ch === "/" && next === "/") { state = "comment"; i += 1; }
+    else if (closing[ch]) stack.push(closing[ch]);
+    else if (stack.at(-1) === ch) stack.pop();
+    else if (ch === separator && stack.length === 0) {
+      if (canonical(text.slice(start, i))) parts.push(text.slice(start, i));
+      start = i + 1;
+    }
+  }
+  assert.equal(stack.length, 0, `unbalanced text split on ${separator}`);
+  if (canonical(text.slice(start))) parts.push(text.slice(start));
+  return parts;
+}
+
+function splitArrow(arm) {
+  const masked = maskNonCode(arm);
+  const stack = [];
+  const closing = { "(": ")", "[": "]", "{": "}" };
+  for (let i = 0; i + 1 < masked.length; i += 1) {
+    const ch = masked[i];
+    if (closing[ch]) stack.push(closing[ch]);
+    else if (stack.at(-1) === ch) stack.pop();
+    else if (ch === "=" && masked[i + 1] === ">" && stack.length === 0) {
+      return { pattern: canonical(arm.slice(0, i)), body: canonical(arm.slice(i + 2)) };
+    }
+  }
+  assert.fail(`missing top-level => in ${canonical(arm)}`);
+}
+
+function functionPartsIn(text, name) {
+  const masked = maskNonCode(text);
+  const start = masked.indexOf(`fn ${name}(`);
+  assert.notEqual(start, -1, `${name} must exist`);
+  const open = masked.indexOf("{", start);
+  const block = balanced(text, open);
+  return { header: canonical(text.slice(start, open)), body: block.body, text: text.slice(start, block.end) };
+}
+
+function parseMatchAt(text, matchIndex) {
+  const open = maskNonCode(text).indexOf("{", matchIndex);
+  assert.notEqual(open, -1, "match must have a code brace");
+  return splitTopLevel(balanced(text, open).body, ",").map(splitArrow);
+}
+
+function matchExprArms(body) {
+  const masked = maskNonCode(body);
+  const re = /\bmatch\s+expr\s*\{/g;
+  const result = [];
+  let found;
+  while ((found = re.exec(masked)) !== null) result.push(parseMatchAt(body, found.index));
+  return result;
+}
+
+function enumConstructors(name) {
+  const masked = maskNonCode(astContract);
+  const start = masked.indexOf(`export enum ${name}`);
+  assert.notEqual(start, -1, `${name} enum must exist`);
+  const open = masked.indexOf("{", start);
+  return splitTopLevel(balanced(astContract, open).body, ";").map((decl) => {
+    const found = canonical(decl).match(/^([A-Z][A-Za-z0-9_]*)/);
+    assert.ok(found, `constructor missing in ${decl}`);
+    return found[1];
+  });
+}
+
+function assertArms(actual, expected, label) {
+  assert.equal(actual.length, expected.length, `${label}: arm count`);
+  for (let i = 0; i < expected.length; i += 1) {
+    assert.ok(expected[i].role, `${label}[${i}] needs a semantic role`);
+    assert.equal(actual[i].pattern, canonical(expected[i].pattern), `${label}/${expected[i].role}: pattern`);
+    assert.equal(actual[i].body, canonical(expected[i].body), `${label}/${expected[i].role}: ordered body`);
+  }
+}
+
+function assertCanonicalBody(part, expected, label) {
+  assert.equal(canonical(part.body), canonical(expected), label);
+}
+
+function definitionCount(name) {
+  return [...maskNonCode(source).matchAll(new RegExp(`\\bfn\\s+${name}\\s*\\(`, "g"))].length;
+}
+
+const scan = functionPartsIn(source, "dinsp_scan");
+const marker = functionPartsIn(source, "dlh_marker_only_called_directly");
+const assigned = functionPartsIn(source, "dlh_names_ever_assigned");
+const collector = functionPartsIn(source, "collect_pat_binders");
+const contains = functionPartsIn(source, "str_array_contains");
+
+for (const kept of ["dinsp_scan", "collect_pat_binders", "str_array_contains"]) assert.equal(definitionCount(kept), 1, `${kept} unique`);
+for (const removed of ["dlh_mocd_scan", "dlh_naa_scan", "dlh_pat_binds", "relabel_pat_binds", "dlh_contains", "relabel_shadowed", "expr_has_labeled_arg", "arr_has_labeled_arg", "pairs_have_labeled_arg", "arms_have_labeled_arg"]) assert.equal(definitionCount(removed), 0, `${removed} removed`);
+assertCanonicalBody(marker, "!dinsp_scan(expr, 4, marker)", "direct marker wrapper");
+assertCanonicalBody(assigned, `let mut i = 0 let mut found = false while !found && i < Array::length(names) { found = dinsp_scan(expr, 5, Array::get(names, i)) i = i + 1 } found`, "many-name scalar assignment wrapper");
+assert.doesNotMatch(marker.text + assigned.text + scan.text, /Array\[Bool\]|\[\s*false\s*\]|Array::set|expr_children|->\s*Option|->\s*\(/);
+
+const modeArms = [
+  [
+    { role: "inspect-call", pattern: "ECall(callee, args, _)", body: `match callee { EIdent(n, _) => n == "inspect" && Array::length(args) == 2, _ => false }` },
+    { role: "inspect-default", pattern: "_", body: "false" }
+  ],
+  [
+    { role: "let-binder", pattern: "ELet(n, _, _, _)", body: `n == "inspect"` },
+    { role: "letrec-binder", pattern: "ELetRec(n, _, _)", body: `n == "inspect"` },
+    { role: "letmut-binder", pattern: "ELetMut(n, _, _, _)", body: `n == "inspect"` },
+    { role: "for-binder", pattern: "EForIn(v, _, _, _)", body: `v == "inspect"` },
+    { role: "parameter-binder", pattern: "EFn(_, _, params, _, _, _)", body: `dinsp_params_bind(params, "inspect")` },
+    { role: "match-binder", pattern: "EMatch(_, arms)", body: `dinsp_arms_bind(arms, "inspect")` },
+    { role: "handle-binder", pattern: "EHandle(_, arms)", body: `dinsp_arms_bind(arms, "inspect")` },
+    { role: "binder-default", pattern: "_", body: "false" }
+  ],
+  [
+    { role: "identifier", pattern: "EIdent(n, _)", body: "n == name" },
+    { role: "let-name", pattern: "ELet(n, _, _, _)", body: "n == name" },
+    { role: "letrec-name", pattern: "ELetRec(n, _, _)", body: "n == name" },
+    { role: "letmut-name", pattern: "ELetMut(n, _, _, _)", body: "n == name" },
+    { role: "assign-target", pattern: "EAssign(n, _, _)", body: "n == name" },
+    { role: "assignop-target", pattern: "EAssignOp(n, _, _, _)", body: "n == name" },
+    { role: "for-name", pattern: "EForIn(v, _, _, _)", body: "v == name" },
+    { role: "parameter-name", pattern: "EFn(_, _, params, _, _, _)", body: "dinsp_params_bind(params, name)" },
+    { role: "match-name", pattern: "EMatch(_, arms)", body: "dinsp_arms_bind(arms, name)" },
+    { role: "handle-name", pattern: "EHandle(_, arms)", body: "dinsp_arms_bind(arms, name)" },
+    { role: "mention-default", pattern: "_", body: "false" }
+  ],
+  [
+    { role: "labeled-wrapper-self", pattern: "ELabeledArg(_, _, _)", body: "true" },
+    { role: "labeled-default", pattern: "_", body: "false" }
+  ],
+  [
+    { role: "marker-value", pattern: "EIdent(n, _)", body: "n == name" },
+    { role: "marker-assign", pattern: "EAssign(n, _, _)", body: "n == name" },
+    { role: "marker-assignop", pattern: "EAssignOp(n, _, _, _)", body: "n == name" },
+    { role: "marker-default", pattern: "_", body: "false" }
+  ],
+  [
+    { role: "captured-assign", pattern: "EAssign(n, _, _)", body: "n == name" },
+    { role: "captured-assignop", pattern: "EAssignOp(n, _, _, _)", body: "n == name" },
+    { role: "assignment-default", pattern: "_", body: "false" }
+  ]
+];
+
+const recursiveArms = [
+  ["int-leaf", "EInt(_)", "false"], ["float-leaf", "EFloat(_)", "false"], ["string-leaf", "EString(_)", "false"], ["bool-leaf", "EBool(_)", "false"], ["unit-leaf", "EUnit", "false"], ["identifier-leaf", "EIdent(_, _)", "false"], ["interpolation-opaque", "EStringInterp(_)", "false"],
+  ["tuple-items", "ETuple(items)", "dinsp_scan_list(items, mode, name)"], ["array-items", "EArray(items)", "dinsp_scan_list(items, mode, name)"], ["record-values", "ERecord(_, fields, _)", "dinsp_scan_fields(fields, mode, name)"], ["map-values", "EMap(fields)", "dinsp_scan_fields(fields, mode, name)"],
+  ["if-condition-then-else", "EIf(c, t, f)", "dinsp_scan(c, mode, name) || dinsp_scan(t, mode, name) || dinsp_scan(f, mode, name)"], ["let-value-body", "ELet(_, v, b, _)", "dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name)"], ["letrec-value-body", "ELetRec(_, v, b)", "dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name)"], ["letmut-value-body", "ELetMut(_, v, b, _)", "dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name)"], ["assign-value-continuation", "EAssign(_, v, b)", "dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name)"], ["assignop-value-continuation", "EAssignOp(_, _, v, b)", "dinsp_scan(v, mode, name) || dinsp_scan(b, mode, name)"], ["sequence-head-tail", "ESeq(a, b)", "dinsp_scan(a, mode, name) || dinsp_scan(b, mode, name)"],
+  ["match-scrutinee-arms", "EMatch(sc, arms)", "dinsp_scan(sc, mode, name) || dinsp_scan_arms(arms, mode, name)"], ["handle-scrutinee-arms", "EHandle(sc, arms)", "dinsp_scan(sc, mode, name) || dinsp_scan_arms(arms, mode, name)"], ["while-condition-body", "EWhile(c, b)", "dinsp_scan(c, mode, name) || dinsp_scan(b, mode, name)"], ["loop-initializers-body", "ELoop(params, b)", "dinsp_scan_fields(params, mode, name) || dinsp_scan(b, mode, name)"], ["for-iterable-body", "EForIn(_, _, it, b)", "dinsp_scan(it, mode, name) || dinsp_scan(b, mode, name)"],
+  ["call-callee-then-args-with-direct-marker-exemption", "ECall(callee, args, _)", `if mode == 4 { match callee { EIdent(n, _) => if n == name { dinsp_scan_list(args, mode, name) } else { dinsp_scan(callee, mode, name) || dinsp_scan_list(args, mode, name) }, _ => dinsp_scan(callee, mode, name) || dinsp_scan_list(args, mode, name) } } else { dinsp_scan(callee, mode, name) || dinsp_scan_list(args, mode, name) }`],
+  ["binary-left-right", "EBinOp(_, l, r)", "dinsp_scan(l, mode, name) || dinsp_scan(r, mode, name)"], ["unary-value", "EUnaryOp(_, v)", "dinsp_scan(v, mode, name)"], ["function-body", "EFn(_, _, _, _, _, body)", "dinsp_scan(body, mode, name)"], ["dot-object", "EDot(inner, _, _, _)", "dinsp_scan(inner, mode, name)"], ["labeled-child", "ELabeledArg(_, _, v)", "dinsp_scan(v, mode, name)"], ["return-value", "EReturn(v)", "dinsp_scan(v, mode, name)"], ["optional-break", "EBreak(opt)", "match opt { Some(v) => dinsp_scan(v, mode, name), None => false }"], ["continue-values", "EContinue(args)", "dinsp_scan_list(args, mode, name)"], ["spread-value", "ESpread(v)", "dinsp_scan(v, mode, name)"]
+].map(([role, pattern, body]) => ({ role, pattern, body }));
+
+const scanMatches = matchExprArms(scan.body);
+assert.equal(scanMatches.length, 7, "six mode leaf matches and one recursive match");
+for (let mode = 0; mode < 6; mode += 1) assertArms(scanMatches[mode], modeArms[mode], `mode ${mode}`);
+assertArms(scanMatches[6], recursiveArms, "recursive Expr descent");
+const recursiveConstructors = scanMatches[6].map(({ pattern }) => pattern.match(/^([A-Z][A-Za-z0-9_]*)/)?.[1]);
+assert.deepEqual(new Set(recursiveConstructors), new Set(enumConstructors("Expr")), "all current Expr constructors covered");
+assert.equal(recursiveConstructors.length, new Set(recursiveConstructors).size, "no duplicate Expr arms");
+
+const patIndex = maskNonCode(collector.body).search(/\bmatch\s+p\s*\{/);
+assert.notEqual(patIndex, -1);
+const patArms = parseMatchAt(collector.body, patIndex);
+const expectedPatArms = [
+  { role: "bind", pattern: "PBind(n)", body: "Array::push(out, n)" },
+  { role: "constructor-index-order", pattern: "PCtor(_, args)", body: "{ let mut i = 0 while i < Array::length(args) { collect_pat_binders(Array::get(args, i), out) i = i + 1 } }" },
+  { role: "tuple-index-order", pattern: "PTuple(elems)", body: "{ let mut i = 0 while i < Array::length(elems) { collect_pat_binders(Array::get(elems, i), out) i = i + 1 } }" },
+  { role: "or-left-right", pattern: "POr(a, b)", body: "{ collect_pat_binders(a, out) collect_pat_binders(b, out) }" },
+  { role: "struct-field-order", pattern: "PStruct(_, fields)", body: "{ let mut i = 0 while i < Array::length(fields) { let (_, fp) = Array::get(fields, i) collect_pat_binders(fp, out) i = i + 1 } }" },
+  { role: "non-binding", pattern: "_", body: "()" }
+];
+assertArms(patArms, expectedPatArms, "collect_pat_binders");
+assert.deepEqual(enumConstructors("Pat"), ["PWild", "PBind", "PInt", "PFloat", "PString", "PBool", "PCtor", "PTuple", "POr", "PStruct"], "current Pat inventory classified by exact arms plus leaf fallback");
+
+assert.equal(contains.header, "fn str_array_contains(arr: Array[String], val: String) -> Bool");
+const membershipBody = `let mut i = 0 let mut found = false while i < Array::length(arr) { if Array::get(arr, i) == val { found = true i = Array::length(arr) } else { i = i + 1 } } found`;
+assertCanonicalBody(contains, membershipBody, "membership equality/early-exit loop");
+const helperBodies = new Map([
+  ["dinsp_scan_list", `let mut i = 0 let mut found = false while !found && i < Array::length(items) { found = dinsp_scan(Array::get(items, i), mode, name) i = i + 1 } found`],
+  ["dinsp_scan_fields", `let mut i = 0 let mut found = false while !found && i < Array::length(fields) { let (_, v) = Array::get(fields, i) found = dinsp_scan(v, mode, name) i = i + 1 } found`],
+  ["dinsp_scan_arms", `let mut i = 0 let mut found = false while !found && i < Array::length(arms) { let (_, v) = Array::get(arms, i) found = dinsp_scan(v, mode, name) i = i + 1 } found`]
+]);
+for (const [name, body] of helperBodies) assertCanonicalBody(functionPartsIn(source, name), body, `${name} exact ordered loop`);
+
+function expectMutationFailure(label, check) {
+  assert.throws(check, assert.AssertionError, `${label} must be rejected`);
+}
+const wrongChild = scan.body.replace("dinsp_scan(c, mode, name) || dinsp_scan(t, mode, name) || dinsp_scan(f, mode, name)", "dinsp_scan(t, mode, name) || dinsp_scan(c, mode, name) || dinsp_scan(f, mode, name)");
+expectMutationFailure("swapped recursive child", () => assertArms(matchExprArms(wrongChild)[6], recursiveArms, "mutated Expr"));
+const wrongDirect = scan.body.replace("ECall(callee, args, _) => if mode == 4 {", "ECall(callee, args, _) => if mode == 5 {");
+expectMutationFailure("wrong direct-callee mode", () => assertArms(matchExprArms(wrongDirect)[6], recursiveArms, "mutated call"));
+const wrongPat = collector.body.replace("collect_pat_binders(a, out)\n      collect_pat_binders(b, out)", "collect_pat_binders(b, out)\n      collect_pat_binders(a, out)");
+expectMutationFailure("reversed POr binder order", () => assertArms(parseMatchAt(wrongPat, maskNonCode(wrongPat).search(/\bmatch\s+p\s*\{/)), expectedPatArms, "mutated Pat"));
+expectMutationFailure("membership comparator", () => assert.equal(canonical(contains.body.replace("== val", "!= val")), canonical(membershipBody)));
+
+const synthetic = `fn probe(expr: Expr) -> Bool {
+  let escaped = "quoted \\\" match expr { [ ( ) ] }"
+  if true {
+    // this deliberately long comment shifts indexes in a deleting comment stripper: {{{ [[[(())]]] }}}
+    match expr {
+      EInt(_) => false,
+      ECall(_, _, _) => { let nested = ["}", "{"] false }
+    }
+  } else { false }
+}`;
+const syntheticBody = functionPartsIn(synthetic, "probe").body;
+const syntheticMatches = matchExprArms(syntheticBody);
+assert.equal(syntheticMatches.length, 1);
+assert.deepEqual(syntheticMatches[0].map(({ pattern }) => pattern), ["EInt(_)", "ECall(_, _, _)"]);
+function deletingStrip(text) { return text.replace(/\/\/[^\n]*/g, ""); }
+expectMutationFailure("deleted-comment coordinate mismatch", () => {
+  const brokenIndex = deletingStrip(syntheticBody).search(/\bmatch\s+expr\s*\{/);
+  const broken = parseMatchAt(syntheticBody, brokenIndex);
+  assert.deepEqual(broken.map(({ pattern }) => pattern), ["EInt(_)", "ECall(_, _, _)"]);
+});
+assert.equal(maskNonCode(syntheticBody).length, syntheticBody.length, "masking preserves every source offset");
+
+console.log("normalizer scalar scan production structure: ok");


### PR DESCRIPTION
## Summary

- consolidate repeated normalizer binder/effect scans into allocation-free scalar helpers
- retain parser-authored binder topology in opaque, detached aggregates
- add a separate authority-aware labeled-argument emitter that moves AST arguments and authority children from the same source index
- fail closed with complete-or-none authority publication for synthetic, optional, malformed, unsupported, or mismatched topology
- keep ordinary labeled normalization signatures, direct gate, behavior, and allocations unchanged

## Safety properties

- ordinary and paired emitters are structurally separated
- public `BinderAuthorityNode` / `BinderAuthoritySlot` values remain inspection-only and cannot mint authority
- source and normalized program views recursively detach nested mutable AST arrays
- retained authority topology is private, persistent, and array-free
- explicit `SExample`, root-mismatch sentinel traversal, `POr`, `ELoop`, and unsupported-lane poison behavior
- structural inventories ratcheted at 10 `Pat` / 5 `TypeExpr` / 33 `Expr` / 25 `Stmt`

## Validation

Independently reproduced on exact reconstructed head `b0dbd850`:

- focused authority/parser/checker suite: 5 files / 58 tests
- full unit suite: 660 / 660 files
- ordinary allocations: **1,908 B/op**
- parse + normalize: **4,764 B/op**
- parser empty/query: **98,912 / 116,128 B/op**
- stage2 == stage3: `4691872de4b664e71327d9094cab73d9bd7d547c01e8995167dbb6086470d138`
- selfcompile heap: **1,057,812,552**, 31,011,088 below the fixed cap
- exact-parent diagnostics: 3 / 3 byte- and exit-identical
- generated freshness, formatter, production structural oracles, compile-negative forgeable ingress, and diff/scope checks pass
- `compiler_gate.sh` passes through gate 91, then hits the known macOS BSD `xargs` command-size limitation at gate 92

The branch was reconstructed as two coherent commits on main `055b778`; subsequent main changes through `572558a` do not overlap this PR's paths.
