### PR TITLE
fix(async): component realloc がヒープを奇数のまま返していた (#1924)

### DIFF
--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -7243,10 +7243,32 @@ fn comp_generate_bump_realloc_body() -> Bytes {
   bytebuf_push(realloc_body, 107)
   bytebuf_push(realloc_body, 113)
   emit_local_set(realloc_body, 4)
-  // __heap_ptr = p + new_size
+  // __heap_ptr = p + new_size, ROUNDED UP TO 8.
+  //
+  // The rounding is the whole point, not tidiness. This allocator hands out
+  // space in the MAIN module's memory and writes back MAIN's `__heap_ptr`, and
+  // main's own allocator keeps that pointer 8-aligned -- it starts at 80 and
+  // every bump is `(x + 7) & -8`. vibe's value representation depends on that:
+  // pointers carry tags in their low bits (`obj | 1` for the effect-handler
+  // object the suspend lowering builds, a 2-bit tag on values), so an ODD heap
+  // pointer makes `ptr | 1` a no-op and the matching `& -2` hand back
+  // `ptr - 1`. The read that follows lands one byte off and the program
+  // dereferences garbage.
+  //
+  // Leaving `p + new_size` unrounded made that depend on the LENGTH OF THE
+  // LIFTED STRINGS: `vibe serve` lifts method/url/headers through here before
+  // the handler runs, so a request whose strings summed to an odd length
+  // corrupted the handler's first heap object and an even one did not. It
+  // looked like a bug about suspending stream reads (#1924) because a chunked
+  // upload and a buffered one send different `content-length` /
+  // `transfer-encoding` headers -- different lengths, different parity.
   emit_local_get(realloc_body, 4)
   emit_local_get(realloc_body, 3)
   emit_i32_add(realloc_body)
+  emit_i32_const(realloc_body, 7)
+  emit_i32_add(realloc_body)
+  emit_i32_const(realloc_body, 0 - 8)
+  bytebuf_push(realloc_body, 113)
   bytebuf_push(realloc_body, 36)
   leb128_encode_u32(realloc_body, 0)
   // if (__heap_ptr > memory.size << 16) memory.grow(pages needed)

--- a/scripts/test_serve_body_stream_gate.sh
+++ b/scripts/test_serve_body_stream_gate.sh
@@ -299,14 +299,19 @@ if ! cmp -s "$OUT_DIR/want-slow.bin" "$OUT_DIR/got-slow.bin"; then
 fi
 echo "[serve-body] a chunked body whose reads park echoes byte-for-byte"
 
-# Request-string length parity. Sweeping the URL length covers every residue
-# mod 8 of what `cabi_realloc` leaves in `__heap_ptr`; before #1924 was
-# understood, the odd ones trapped and the even ones passed.
+# Request-string length parity: ONE string varies, by ONE byte per iteration.
+#
+# That is the whole design of this loop, and it is easy to get wrong. Padding
+# the URL and a header together advances the total by two each time, which
+# holds the parity FIXED and turns a sweep that looks like it covers eight
+# residues into one that covers four of the same parity -- it would pass, or
+# fail, uniformly against the pre-#1924 allocator instead of showing both.
+# Only the URL grows here, one byte at a time, so the lifted-string total takes
+# every residue mod 8 of what `cabi_realloc` leaves in `__heap_ptr`.
 for pad in 0 1 2 3 4 5 6 7; do
   path="echo"
   [ "$pad" = "0" ] || path="echo$(printf 'a%.0s' $(seq 1 "$pad"))"
   code="$(curl -sS --max-time 20 -o "$OUT_DIR/got-pad$pad.bin" -w '%{http_code}' -X POST \
-    -H "x-pad: $(printf 'z%.0s' $(seq 0 "$pad"))" \
     --data-binary 'abc' "http://$ADDR/$path" 2>&1 || true)"
   if [ "$code" != "200" ]; then
     echo "[serve-body] FAILED: url pad $pad returned '$code' (want 200) -- request-string length must not change the answer (#1924)" >&2

--- a/scripts/test_serve_body_stream_gate.sh
+++ b/scripts/test_serve_body_stream_gate.sh
@@ -27,16 +27,17 @@ set -euo pipefail
 #   empty       a zero-length body ends the stream immediately: the reader
 #               must see end-of-stream on its FIRST read, not hang.
 #   isolation   two requests in flight at once each get their own body back.
-#
-# WHAT THIS GATE DOES NOT COVER, and why the line is here rather than in an
-# assertion (#1924): every request above delivers its body BUFFERED, so each
-# `stream.read` completes eagerly and the adapter's BLOCKED branch never runs.
-# A chunked upload that makes reads actually park, and a handler that stops
-# reading before end of stream, both trap in the guest today --
-# `uninitialized element` inside the injected `__hs_next`, which is main's CPS
-# lowering and not this adapter (the adapter has no tables). Both reproduce
-# against the committed emitter, so they are a pre-existing gap in the lane,
-# not something this gate can assert green. #1924 has the two reproductions.
+#   parking     a CHUNKED upload, delivered a byte at a time, so `stream.read`
+#               returns BLOCKED and the adapter's park branch actually runs.
+#               Every buffered case above completes eagerly and never enters it.
+#   parity      the same body under request strings of EVERY length mod 8.
+#               This is the one that looks pointless and is not: the lifted
+#               method/url/headers pass through the trampoline's `cabi_realloc`,
+#               which writes back MAIN's `__heap_ptr`, and vibe tags pointers in
+#               their low bits. An allocator that left that pointer odd
+#               corrupted the handler's first heap object -- so the lane worked
+#               or trapped depending on how long the URL was (#1924). A gate
+#               that only ever sends one URL cannot see that at all.
 #
 # Skips cleanly when cargo / wasm-tools / wac / wasmtime / curl are missing,
 # and fails instead under VIBE_P3_GATE_REQUIRE_TOOLS=1, matching the other P3
@@ -273,15 +274,62 @@ for n in a b; do
 done
 echo "[serve-body] two concurrent buffered requests each echo their own body"
 
+# The parking path. Buffered uploads complete every read eagerly, so nothing
+# above ever reaches the adapter's BLOCKED branch; a chunked upload fed a byte
+# at a time does. `-T -` rather than `--data-binary @-`: curl reads a
+# `--data-binary` body to the end before sending it, to compute Content-Length,
+# which buffers away the very thing under test.
+slow_feed() {
+  local text="$1" i=0
+  while [ "$i" -lt "${#text}" ]; do
+    printf '%s' "${text:$i:1}"
+    i=$((i + 1))
+    sleep 0.05
+  done
+}
+SLOW_BODY="0123456789"
+printf '\n%s' "$SLOW_BODY" >"$OUT_DIR/want-slow.bin"
+slow_feed "$SLOW_BODY" | curl -sS --max-time 60 -o "$OUT_DIR/got-slow.bin" -X POST -T - \
+  "http://$ADDR/echo" || true
+if ! cmp -s "$OUT_DIR/want-slow.bin" "$OUT_DIR/got-slow.bin"; then
+  echo "[serve-body] FAILED: a chunked body whose reads park did not echo byte-for-byte" >&2
+  cmp "$OUT_DIR/want-slow.bin" "$OUT_DIR/got-slow.bin" >&2 || true
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+echo "[serve-body] a chunked body whose reads park echoes byte-for-byte"
+
+# Request-string length parity. Sweeping the URL length covers every residue
+# mod 8 of what `cabi_realloc` leaves in `__heap_ptr`; before #1924 was
+# understood, the odd ones trapped and the even ones passed.
+for pad in 0 1 2 3 4 5 6 7; do
+  path="echo"
+  [ "$pad" = "0" ] || path="echo$(printf 'a%.0s' $(seq 1 "$pad"))"
+  code="$(curl -sS --max-time 20 -o "$OUT_DIR/got-pad$pad.bin" -w '%{http_code}' -X POST \
+    -H "x-pad: $(printf 'z%.0s' $(seq 0 "$pad"))" \
+    --data-binary 'abc' "http://$ADDR/$path" 2>&1 || true)"
+  if [ "$code" != "200" ]; then
+    echo "[serve-body] FAILED: url pad $pad returned '$code' (want 200) -- request-string length must not change the answer (#1924)" >&2
+    cat "$SERVE_LOG" >&2 || true
+    exit 1
+  fi
+  if ! cmp -s "$OUT_DIR/want-small.bin" "$OUT_DIR/got-pad$pad.bin"; then
+    echo "[serve-body] FAILED: url pad $pad did not echo its body byte-for-byte (#1924)" >&2
+    cmp "$OUT_DIR/want-small.bin" "$OUT_DIR/got-pad$pad.bin" >&2 || true
+    exit 1
+  fi
+done
+echo "[serve-body] the answer is the same for request strings of every length mod 8"
+
 stop_server
 
 # The other half of the adapter's surface, checked where it can be checked:
 # COMPOSITION. `host_stream_close` lowers to a `vibe.host_stream_close` core
 # import, and a core instance cannot be given fewer bindings than it imports --
 # so before the adapter exported both halves, a handler that stops reading
-# early could not be composed at all. Emitting the component and plugging it is
-# what proves that edge is satisfied; actually SERVING such a handler is
-# blocked on #1924, which is why this stops at the plug.
+# early could not be composed at all. Both are checked: the core really does
+# import the close half, and the handler then serves and answers with exactly
+# the bytes it chose to read.
 CLOSE_SRC="$OUT_DIR/close_handler.vibe"
 cat >"$CLOSE_SRC" <<'HEOF'
 export let handler = (method: String, url: String, headers: String, body: HostStream) -> String with Async {
@@ -317,8 +365,22 @@ case "$CLOSE_CORE_WIT" in
     echo "[serve-body] FAILED: the early-closing handler's core does not import vibe.host_stream_close" >&2
     exit 1 ;;
 esac
-wac plug --plug "$CLOSE_COMPONENT" "$ADAPTER" -o "$OUT_DIR/close.serve.wasm"
-wasm-tools validate --features all "$OUT_DIR/close.serve.wasm" >/dev/null
-echo "[serve-body] a handler that closes the body early composes (both adapter halves bound)"
+serve_handler close "$CLOSE_SRC"
+printf '\nabcd' >"$OUT_DIR/want-close.bin"
+close_code="$(curl -sS --max-time 20 -o "$OUT_DIR/got-close.bin" -w '%{http_code}' -X POST \
+  --data-binary 'abcdefghij' "http://$ADDR/echo" || true)"
+if [ "$close_code" != "200" ]; then
+  echo "[serve-body] FAILED: the early-closing handler returned '$close_code' (want 200)" >&2
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+if ! cmp -s "$OUT_DIR/want-close.bin" "$OUT_DIR/got-close.bin"; then
+  echo "[serve-body] FAILED: the early-closing handler did not answer with its first 4 bytes" >&2
+  cmp "$OUT_DIR/want-close.bin" "$OUT_DIR/got-close.bin" >&2 || true
+  cat "$SERVE_LOG" >&2 || true
+  exit 1
+fi
+stop_server
+echo "[serve-body] a handler that reads 4 bytes and closes the body composes, serves, and answers abcd"
 
 echo "[serve-body] PASS: vibe serve hands the request body to the handler as a stream (#1540)"


### PR DESCRIPTION
`vibe serve` があるリクエストには 500、別のリクエストには 200 を返していた。軸は #1924 が書いていた「park する read」ではなく、**URL の長さ**だった。

buffered のまま URL / ヘッダの長さだけ変えたスイープ:

| pad長 | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| HTTP | **500** | 200 | **500** | 200 | **500** | 200 |

## 原因

trampoline の `cabi_realloc` は **main のメモリ**を配り、**main の `__heap_ptr`** を書き戻す:

```
p    = (heap + align - 1) & -align   ← 開始位置は整列する
heap = p + new_size                  ← 終了位置を整列せずに書き戻す
```

main 自身の allocator は 80 始まりで常に `(x + 7) & -8` を保っており、vibe の値表現がそれに依存している — ポインタは下位ビットにタグを載せる。**奇数のヒープポインタは suspend lowering の `obj | 1` を無効化し、対になる `& -2` が `obj - 1` を返す。** 1バイトずれた場所を読み、effect handler を呼ぶ `call_indirect` にゴミが入って `uninitialized element`。

`vibe serve` は handler を呼ぶ前に method/url/headers をこの realloc 経由で lift するので、**文字列長の合計の偶奇**でリクエストの成否が決まっていた。書き戻しに `(x + 7) & -8` を足すだけで直る。ヘルパは sync/async 両 serve lane が共有しているので両方直る。

## park に見えた理由と、それを潰した測定

chunked と buffered ではヘッダが違う（`content-length: 10` / `transfer-encoding: chunked`）。**長さの違いであってスケジューリングの違いではなかった。**

切り分けに使った3つの測定は記録しておく価値がある:

1. **named host stream lane は無傷** — 単発 read / 2回 read / drain / 早期停止 × RC on/off × eager/park(`@60`) の全組み合わせで trap なし。suspend lowering 自体は無実
2. **手書き probe (`http_body_read`) も無傷** — 同じ canon・同じ async lift・同じ stackful park で、1バイトずつの chunked upload を **1017ms で完走**。この adapter 経由の park も無実
3. **`cabi_realloc` は main の `__heap_ptr` を bump している**と判明 → 「2つの allocator が重なる」説が消え、整列だけが両 lane の差になり得る要因として残った

## gate

症状ではなく**軸**を見る形にした:

- **URL 長を mod 8 で全通りスイープ**（body 固定）— 1つの URL しか送らない gate には、このクラスのバグは原理的に見えない
- **park する chunked upload** — buffered は全部 eager に完了するので、adapter の BLOCKED 分岐に一度も入らない
- **早期 close ハンドラを実際にサーブ** — 以前は plug までで止めていた

```
[serve-body] a 3-byte body echoes byte-for-byte
[serve-body] a 385-byte body echoes byte-for-byte
[serve-body] an empty body ends the stream on the first read
[serve-body] two concurrent buffered requests each echo their own body
[serve-body] a chunked body whose reads park echoes byte-for-byte
[serve-body] the answer is the same for request strings of every length mod 8
[serve-body] a handler that reads 4 bytes and closes the body composes, serves, and answers abcd
[serve-body] PASS
```

`test_wasi_http_p3_full_gate.sh` (String lane) と `test_serve_async_lift_gate.sh` は変更なしで PASS 継続。stage2 == stage3 fixpoint も確認済み。

## 副産物

切り分け中に **#1930** を起票した: named lane を `VIBE_RC=0` で使うと adapter の `<<1` が余分になり、**読んだバイトが黙って 2 倍**になる（10→20、42→84）。落ちないので P0。既存 gate は RC on しか通さないため見えていなかった。

## 関連

#1924、#1540、#1930、#1912

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_