### PR TITLE
fix(rc): stop leaking builder-shaped returns — ascription-wrapper blindness in view/borrow-ret inference (#1915 R5)

### DIFF
--- a/fixtures/rc_reclaim_leak_test.vibe
+++ b/fixtures/rc_reclaim_leak_test.vibe
@@ -19,9 +19,14 @@
 // VIBE_RC=1 + VIBE_FS_COMPILE=1 (the `vibe run` path), measures __heap_ptr via
 // scripts/measure_selfhost_heap.mjs, and asserts heap_used stays below a small
 // bound. At N=20000 a leak would be hundreds of KB; reclamation keeps it tiny.
-enum Tree { Leaf(Int); Node(Tree, Tree) }
+enum Tree {
+  Leaf(Int);
+  Node(Tree, Tree)
+}
 
-struct Box { items: Array[Int] }
+struct Box {
+  items: Array[Int]
+}
 
 let sumt = (t: Tree) -> Int {
   match t {
@@ -61,13 +66,32 @@ let consume_in_loop = (a: Array[Int]) -> Int {
   s
 }
 
+// #1915 builder-return leak guard: the standard builder shape — an ANNOTATED
+// fresh binding (`let out: Array[Int] = []`; the ascription parses to an
+// identity application `((__asc: T) -> __asc)(e)`) returned by name — must not
+// land the function in the may-return-view set. Misclassified, every CALLER
+// suppresses the scope-end drop of the OWNED result and leaks one array per
+// call, scaling heap_used with N.
+let build_arr = (n: Int) -> Array[Int] {
+  let out: Array[Int] = [
+  ]
+  let mut j = 0
+  while j < n {
+    Array::push(out, j)
+    j = j + 1
+  }
+  out
+}
+
 let main = () -> Int {
   let mut total = 0
   let mut i = 0
   while i < 20000 {
     let t = (i, i + 1)
     let mut c = 0
-    let bump = () -> { c = c + 1 }
+    let bump = () -> {
+      c = c + 1
+    }
     bump()
     let tr = Node(Leaf(i), Leaf(i + 1))
     // #704 projection-ownership reclamation guard: `Array::get(b.items, _)`
@@ -75,7 +99,13 @@ let main = () -> Int {
     // must NOT be rc_dup'd at the call site (the builtin never drops it) — else
     // one reference leaks per iteration and heap scales with N. The struct `b`
     // and its array reclaim each iteration only when that dup is suppressed.
-    let b = Box::{ items: [i, i + 1, i + 2] }
+    let b = Box::{
+      items: [
+        i,
+        i + 1,
+        i + 2
+      ]
+    }
     let first = Array::get(b.items, 0)
     // #703 unused-matched-field guard (drives `ignore_children`, which binds but
     // never references the heap children — see its definition above).
@@ -90,15 +120,25 @@ let main = () -> Int {
     // #703-2 borrow-only matched-field guard: `xs` is bound and referenced, but
     // only as the borrowed arg0 of `Array::length` — never consumed. Its #702
     // dup must be suppressed (md_consumes) or the array leaks each iteration.
-    let blen = match Some([i, i + 1]) {
+    let blen = match Some([
+      i,
+      i + 1
+    ]) {
       Some(xs) => Array::length(xs),
       None => 0
     }
     // #706 leak guard (see consume_in_loop above): a fresh array literal
     // consumed 3x inside consume_in_loop's own while loop, unreachable after
     // this call returns.
-    let looped = consume_in_loop([i, i + 1, i + 2])
-    total = total + t.0 + t.1 + c + sumt(tr) + first + ignored + inlined + blen + looped
+    let looped = consume_in_loop([
+      i,
+      i + 1,
+      i + 2
+    ])
+    // #1915 leak guard (see build_arr above): the returned builder array is
+    // owned by `built` and must be reclaimed at scope end each iteration.
+    let built = build_arr(3)
+    total = total + t.0 + t.1 + c + sumt(tr) + first + ignored + inlined + blen + looped + Array::length(built)
     i = i + 1
   }
   total

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -3210,9 +3210,15 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
       true
     },
     ECall(callee, args, _) => {
+      let mut arg0_fresh = false
       let mut i = 0
       while i < Array::length(args) {
-        let _ = mrv_fresh(Array::get(args, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        let af = mrv_fresh(Array::get(args, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        if i == 0 {
+          arg0_fresh = af
+        } else {
+          ()
+        }
         i = i + 1
       }
       match callee {
@@ -3228,6 +3234,34 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
           // uppercase, but a non-view builtin returns fresh too, so the
           // distinction does not matter here.)
           true
+        },
+        EFn(_, _, wfps, _, _, wbody) => {
+          // #1915: `let x: T = e` parses to the identity application
+          // `((__asc: T) -> __asc)(e)` (ascribe_wrap, parser_expr_dispatch.vibe)
+          // -- a checker-only ascription device, so the call's freshness is the
+          // argument's. Treating the non-ident callee as untrackable here put
+          // every function tail-returning an annotated fresh binding (`let out:
+          // Array[Int] = []; ...; out` -- the standard builder shape) into the
+          // may-return-view set, and every caller then leaked the owned result
+          // (view-call scope-end drop suppression, one object per call).
+          // Recognized structurally (single param returned unchanged), not by
+          // the `__asc` name, so a hand-written identity lambda gets the same
+          // precision; anything else stays untrackable as before.
+          let ident_ret = if Array::length(wfps) == 1 && Array::length(args) == 1 {
+            let (wpn, _) = Array::get(wfps, 0)
+            match wbody {
+              EIdent(bn, _) => bn == wpn,
+              _ => false
+            }
+          } else {
+            false
+          }
+          if ident_ret {
+            arg0_fresh
+          } else {
+            let _ = mrv_fresh(callee, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+            false
+          }
         },
         _ => {
           let _ = mrv_fresh(callee, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -383,6 +383,19 @@ fn is_borrow_ret_fname(ctx: PCtx, fname: String) -> Bool {
 /// non-heap-tagged values), never corrupt -- the failure mode this whole fix
 /// targets is a double-free from treating a genuinely-borrowed value as owned,
 /// not a leak from treating a small/rare owned value as borrowed.
+/// #1915 refinement: that fallback's reach was wrong. A bare ident branch tail
+/// is also the most common OWNED-return shape (`let out: Array[T] = []; ...
+/// if c { out } else { out }` builders), and "leak one small sentinel" became
+/// "leak one builder array per call, in every caller". So an ident tail is now
+/// RESOLVED through the wrapper-spine `let` bindings (spine_names/spine_vals,
+/// collected by collect_spine_let_vals): a binding provably holding an owned
+/// heap value (container literal, or a call to a non-borrow-returning name --
+/// the same verdicts an INLINE branch tail of that shape already gets from
+/// this walk) rejects the function, while a view binding, a parameter, a
+/// `let mut`, a shadowed name, or anything unresolvable keeps today's safe
+/// fallback. Resolution can only flip leak -> reclaim, never view -> owned:
+/// the owned verdicts mirror what the value expression would classify as if
+/// written inline in tail position.
 /// Iterative (NOT self-recursive) worklist walk over child expressions, rather
 /// than a `let rec` recursive-descent function. Also: the `ECall` case matches
 /// its callee via a NESTED constructor pattern one step at a time (`ECall(e,
@@ -403,7 +416,161 @@ fn is_borrow_ret_fname(ctx: PCtx, fname: String) -> Bool {
 /// True root cause not isolated; swap either workaround for the "more natural"
 /// form only after confirming compute_borrow_returning_names_test.vibe (or an
 /// equivalent derive(Ord) regression) still passes.
-fn tail_is_borrow_ret_safe(known: Array[String], e0: Expr) -> Bool {
+/// #1915: collect the wrapper-spine `let` bindings (name -> value) of a
+/// function body so tail_is_borrow_ret_safe can resolve a bare ident branch
+/// tail to the value it names. Only immutable, once-bound spine lets are
+/// trusted; `let mut` / `let rec` targets, assignment targets, and re-bound
+/// (shadowed) names go to `excluded` -- resolution must never flip a genuine
+/// view to owned (the double-free direction), so anything ambiguous stays
+/// unresolvable. Iterative spine walk, mirroring strip_wrappers_for_borrow_ret.
+fn collect_spine_let_vals(e0: Expr, names: Array[String], vals: Array[Expr], excluded: Array[String]) -> Int {
+  let mut e = e0
+  let mut looping = true
+  while looping {
+    looping = false
+    match e {
+      ELet(n, v, b, _) => {
+        if array_contains_str_pctx(names, n) || array_contains_str_pctx(excluded, n) {
+          Array::push(excluded, n)
+        } else {
+          Array::push(names, n)
+          Array::push(vals, v)
+        }
+        e = b
+        looping = true
+      },
+      ELetMut(n, _, b, _) => {
+        Array::push(excluded, n)
+        e = b
+        looping = true
+      },
+      ELetRec(n, _, b) => {
+        Array::push(excluded, n)
+        e = b
+        looping = true
+      },
+      ESeq(_, b) => {
+        e = b
+        looping = true
+      },
+      EAssign(n, _, b) => {
+        Array::push(excluded, n)
+        e = b
+        looping = true
+      },
+      EAssignOp(n, _, _, b) => {
+        Array::push(excluded, n)
+        e = b
+        looping = true
+      },
+      _ => ()
+    }
+  }
+  0
+}
+
+/// #1915: does the spine binding named `nm0` provably hold an OWNED heap
+/// value? Owned verdicts mirror what the same value expression would get as
+/// an INLINE branch tail in tail_is_borrow_ret_safe (container literal, call
+/// to a non-borrow-returning name); anything else -- excluded/absent names,
+/// view calls, `perform`, ident chains that leave the spine -- resolves to
+/// false, keeping the pre-#1915 safe fallback. The local-let ascription
+/// wrapper `((__asc: T) -> __asc)(v)` (ascribe_wrap, parser_expr_dispatch)
+/// is peeled first so an annotated binding classifies as its value. Callee
+/// matching is one step at a time, and both loops are iterative -- see the
+/// shape workarounds documented on tail_is_borrow_ret_safe.
+fn spine_ident_returns_owned(known: Array[String], names: Array[String], vals: Array[Expr], excluded: Array[String], nm0: String) -> Bool {
+  let mut nm = nm0
+  let mut hops = 0
+  let mut owned = false
+  let mut done = false
+  while !done && hops < 8 {
+    hops = hops + 1
+    if array_contains_str_pctx(excluded, nm) {
+      done = true
+    } else {
+      let mut idx = 0 - 1
+      let mut i = 0
+      while i < Array::length(names) {
+        if Array::get(names, i) == nm {
+          idx = i
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      if idx < 0 {
+        done = true
+      } else {
+        let mut v = Array::get(vals, idx)
+        let mut unwrapping = true
+        while unwrapping {
+          unwrapping = false
+          match v {
+            ECall(wc, wargs, _) =>
+            match wc {
+              EFn(_, _, wfps, _, _, wbody) => if Array::length(wfps) == 1 && Array::length(wargs) == 1 {
+                let (wpn, _) = Array::get(wfps, 0)
+                match wbody {
+                  EIdent(bn, _) => if bn == wpn {
+                    v = Array::get(wargs, 0)
+                    unwrapping = true
+                  } else {
+                    ()
+                  },
+                  _ => ()
+                }
+              } else {
+                ()
+              },
+              _ => ()
+            },
+            _ => ()
+          }
+        }
+        match v {
+          EArray(_) => {
+            owned = true
+            done = true
+          },
+          ETuple(_) => {
+            owned = true
+            done = true
+          },
+          ERecord(_, _, _) => {
+            owned = true
+            done = true
+          },
+          EMap(_) => {
+            owned = true
+            done = true
+          },
+          ECall(c2, _, _) =>
+          match c2 {
+            EIdent(f, _) => if f == "perform" || array_contains_str_pctx(known, f) {
+              done = true
+            } else {
+              owned = true
+              done = true
+            },
+            _ => {
+              done = true
+            }
+          },
+          EIdent(next_nm, _) => {
+            nm = next_nm
+          },
+          _ => {
+            done = true
+          }
+        }
+      }
+    }
+  }
+  owned
+}
+
+fn tail_is_borrow_ret_safe(known: Array[String], e0: Expr, spine_names: Array[String], spine_vals: Array[Expr], spine_excluded: Array[String]) -> Bool {
   // ADR-0090 / #1770: the worklist grows while being consumed in-place and
   // only the Bool verdict escapes, so its growth garbage goes to the region
   // arena (MutList) instead of the main heap. Bump lane only; under RC the
@@ -415,9 +582,34 @@ fn tail_is_borrow_ret_safe(known: Array[String], e0: Expr) -> Bool {
     let mut i = 0
     while i < MutList::length(worklist) {
       match MutList::get(worklist, i) {
-        ELet(_, _, b, _) => MutList::push(worklist, b),
-        ELetMut(_, _, b, _) => MutList::push(worklist, b),
-        ELetRec(_, _, b) => MutList::push(worklist, b),
+        // #1915: an inner binding that reuses a spine name shadows it for any
+        // ident tail walked after this point -- resolution through the spine
+        // map would read the WRONG value, so retire the name (over-excluding
+        // across sibling branches only ever restores the safe fallback).
+        ELet(n, _, b, _) => {
+          if array_contains_str_pctx(spine_names, n) {
+            Array::push(spine_excluded, n)
+          } else {
+            ()
+          }
+          MutList::push(worklist, b)
+        },
+        ELetMut(n, _, b, _) => {
+          if array_contains_str_pctx(spine_names, n) {
+            Array::push(spine_excluded, n)
+          } else {
+            ()
+          }
+          MutList::push(worklist, b)
+        },
+        ELetRec(n, _, b) => {
+          if array_contains_str_pctx(spine_names, n) {
+            Array::push(spine_excluded, n)
+          } else {
+            ()
+          }
+          MutList::push(worklist, b)
+        },
         ESeq(_, b) => MutList::push(worklist, b),
         EAssign(_, _, b) => MutList::push(worklist, b),
         EAssignOp(_, _, _, b) => MutList::push(worklist, b),
@@ -428,7 +620,21 @@ fn tail_is_borrow_ret_safe(known: Array[String], e0: Expr) -> Bool {
         EMatch(_, arms) => {
           let mut ai = 0
           while ai < Array::length(arms) {
-            let (_p, ae) = Array::get(arms, ai)
+            let (p, ae) = Array::get(arms, ai)
+            // #1915: pattern bindings shadow spine names the same way inner
+            // lets do (see the ELet case above).
+            let pnames: Array[String] = [
+            ]
+            pat_names(p, pnames)
+            let mut pi = 0
+            while pi < Array::length(pnames) {
+              if array_contains_str_pctx(spine_names, Array::get(pnames, pi)) {
+                Array::push(spine_excluded, Array::get(pnames, pi))
+              } else {
+                ()
+              }
+              pi = pi + 1
+            }
             MutList::push(worklist, ae)
             ai = ai + 1
           }
@@ -474,7 +680,15 @@ fn tail_is_borrow_ret_safe(known: Array[String], e0: Expr) -> Bool {
             all_safe = false
           }
         },
-        EIdent(_, _) => (),
+        // #1915: a bare ident tail resolving to a spine binding that provably
+        // holds an owned heap value (builder/literal/owned call) rejects the
+        // function -- callers must keep their scope-end drop. Sentinels,
+        // params, views, and unresolvable names keep the safe fallback.
+        EIdent(nm, _) => if spine_ident_returns_owned(known, spine_names, spine_vals, spine_excluded, nm) {
+          all_safe = false
+        } else {
+          ()
+        },
         // #715: a throwing tail (the ubiquitous `match x { Ctor(..) => field, _
         // => throw("not X") }` shape used by every common_extractors.vibe
         // accessor) never actually produces a value along that path, so it
@@ -545,9 +759,22 @@ export fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String] {
                 EMatch(_, _) => true,
                 _ => false
               }
-              if eligible_shape && tail_is_borrow_ret_safe(known, top) {
-                Array::push(known, name)
-                changed = true
+              if eligible_shape {
+                // #1915: the spine bindings resolve bare ident branch tails
+                // to the values they name (see tail_is_borrow_ret_safe).
+                let sp_names: Array[String] = [
+                ]
+                let sp_vals: Array[Expr] = [
+                ]
+                let sp_excluded: Array[String] = [
+                ]
+                let _ = collect_spine_let_vals(body, sp_names, sp_vals, sp_excluded)
+                if tail_is_borrow_ret_safe(known, top, sp_names, sp_vals, sp_excluded) {
+                  Array::push(known, name)
+                  changed = true
+                } else {
+                  ()
+                }
               } else {
                 ()
               }

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -484,7 +484,11 @@ fn spine_ident_returns_owned(known: Array[String], names: Array[String], vals: A
   let mut hops = 0
   let mut owned = false
   let mut done = false
-  while !done && hops < 8 {
+  // The ident chain visits a fresh spine binding per hop (a repeated name
+  // would have landed in `excluded` at collection), so the binding count
+  // bounds the walk -- no fixed cap that could silently truncate a long
+  // alias chain back into the safe (leaking) fallback.
+  while !done && hops <= Array::length(names) {
     hops = hops + 1
     if array_contains_str_pctx(excluded, nm) {
       done = true
@@ -727,8 +731,13 @@ fn strip_wrappers_for_borrow_ret(e: Expr) -> Expr {
 }
 
 export fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String] {
+  // Seed with the same builtin set is_borrow_ret_fname hardcodes -- omitting
+  // one (MutList::get was missing until #1932 review) makes both the inline
+  // branch-tail check and the #1915 spine-binding resolution classify that
+  // builtin's result as owned, and RC callers then drop an interior view.
   let known: Array[String] = [
     "Array::get",
+    "MutList::get",
     "Map::get",
     "__index",
     "__rec_field"

--- a/lib/@vibe/compiler/tests/borrow_returning_names_test.vibe
+++ b/lib/@vibe/compiler/tests/borrow_returning_names_test.vibe
@@ -1,0 +1,65 @@
+//# #1915 regression: compute_borrow_returning_names vs bare-ident branch
+//# tails. The #707 fallback accepted ANY bare ident inside an if/match branch
+//# tail as "safe to never drop" (designed for nullary-ctor sentinels like
+//# TEof), but the same shape is also the most common owned-return in the
+//# codebase (`let out: Array[Int] = []; ... if c { out } else { out }`), and
+//# a borrow-returning classification makes every caller skip the scope-end
+//# drop of an owned result -- one leaked object per call. The ident is now
+//# resolved through the wrapper-spine `let` bindings; only provably-owned
+//# bindings reject the function, everything ambiguous keeps the fallback.
+
+import @vibe/parser {
+  lex, parse_program
+}
+
+import @vibe/compiler/perceus {
+  compute_borrow_returning_names
+}
+
+fn borrow_set_of(src: String) -> Array[String] with Exception {
+  compute_borrow_returning_names(parse_program(lex(src)))
+}
+
+fn contains(names: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+test "builder returned through if branches is not borrow-returning" {
+  let src = "fn make(n: Int) -> Array[Int] {\n  let out: Array[Int] = []\n  let mut i = 0\n  while i < n {\n    Array::push(out, i)\n    i = i + 1\n  }\n  if n >= 0 {\n    out\n  } else {\n    out\n  }\n}\n"
+  assert_true(!contains(borrow_set_of(src), "make"))
+}
+
+test "owned-call binding returned through if branches is not borrow-returning" {
+  let src = "fn helper(n: Int) -> Array[Int] {\n  [1, 2, 3]\n}\n\nfn make(n: Int) -> Array[Int] {\n  let out = helper(n)\n  if n >= 0 {\n    out\n  } else {\n    out\n  }\n}\n"
+  assert_true(!contains(borrow_set_of(src), "make"))
+}
+
+test "sentinel fallback around a borrowed access stays borrow-returning" {
+  // The #707 peek shape: a bounds-check guard around Array::get with a bare
+  // nullary-ctor identifier as the out-of-range fallback. The ident does not
+  // resolve to a spine binding, so the safe fallback must survive.
+  let src = "enum Tok {\n  TEof;\n  TInt(Int)\n}\n\nfn peek(tokens: Array[Tok], pos: Int) -> Tok {\n  if pos < Array::length(tokens) {\n    Array::get(tokens, pos)\n  } else {\n    TEof\n  }\n}\n"
+  assert_true(contains(borrow_set_of(src), "peek"))
+}
+
+test "mut binding reassigned to a view stays borrow-returning" {
+  // A `let mut` target is never resolved (its final value is flow-dependent);
+  // rejecting it here would make callers drop a genuinely borrowed result.
+  let src = "fn pick(a: Array[Array[Int]], i: Int) -> Array[Int] {\n  let mut out = Array::get(a, 0)\n  if i > 0 {\n    out = Array::get(a, i)\n  } else {\n    ()\n  }\n  if i >= 0 {\n    out\n  } else {\n    out\n  }\n}\n"
+  assert_true(contains(borrow_set_of(src), "pick"))
+}
+
+test "borrowed-call binding returned through if branches stays borrow-returning" {
+  let src = "fn head(a: Array[Array[Int]], i: Int) -> Array[Int] {\n  let v = Array::get(a, i)\n  if i >= 0 {\n    v\n  } else {\n    v\n  }\n}\n"
+  assert_true(contains(borrow_set_of(src), "head"))
+}

--- a/lib/@vibe/compiler/tests/borrow_returning_names_test.vibe
+++ b/lib/@vibe/compiler/tests/borrow_returning_names_test.vibe
@@ -36,12 +36,12 @@ fn contains(names: Array[String], name: String) -> Bool {
 
 test "builder returned through if branches is not borrow-returning" {
   let src = "fn make(n: Int) -> Array[Int] {\n  let out: Array[Int] = []\n  let mut i = 0\n  while i < n {\n    Array::push(out, i)\n    i = i + 1\n  }\n  if n >= 0 {\n    out\n  } else {\n    out\n  }\n}\n"
-  assert_true(!contains(borrow_set_of(src), "make"))
+  inspect(contains(borrow_set_of(src), "make"), "false")
 }
 
 test "owned-call binding returned through if branches is not borrow-returning" {
   let src = "fn helper(n: Int) -> Array[Int] {\n  [1, 2, 3]\n}\n\nfn make(n: Int) -> Array[Int] {\n  let out = helper(n)\n  if n >= 0 {\n    out\n  } else {\n    out\n  }\n}\n"
-  assert_true(!contains(borrow_set_of(src), "make"))
+  inspect(contains(borrow_set_of(src), "make"), "false")
 }
 
 test "sentinel fallback around a borrowed access stays borrow-returning" {
@@ -49,17 +49,25 @@ test "sentinel fallback around a borrowed access stays borrow-returning" {
   // nullary-ctor identifier as the out-of-range fallback. The ident does not
   // resolve to a spine binding, so the safe fallback must survive.
   let src = "enum Tok {\n  TEof;\n  TInt(Int)\n}\n\nfn peek(tokens: Array[Tok], pos: Int) -> Tok {\n  if pos < Array::length(tokens) {\n    Array::get(tokens, pos)\n  } else {\n    TEof\n  }\n}\n"
-  assert_true(contains(borrow_set_of(src), "peek"))
+  inspect(contains(borrow_set_of(src), "peek"), "true")
 }
 
 test "mut binding reassigned to a view stays borrow-returning" {
   // A `let mut` target is never resolved (its final value is flow-dependent);
   // rejecting it here would make callers drop a genuinely borrowed result.
   let src = "fn pick(a: Array[Array[Int]], i: Int) -> Array[Int] {\n  let mut out = Array::get(a, 0)\n  if i > 0 {\n    out = Array::get(a, i)\n  } else {\n    ()\n  }\n  if i >= 0 {\n    out\n  } else {\n    out\n  }\n}\n"
-  assert_true(contains(borrow_set_of(src), "pick"))
+  inspect(contains(borrow_set_of(src), "pick"), "true")
 }
 
 test "borrowed-call binding returned through if branches stays borrow-returning" {
   let src = "fn head(a: Array[Array[Int]], i: Int) -> Array[Int] {\n  let v = Array::get(a, i)\n  if i >= 0 {\n    v\n  } else {\n    v\n  }\n}\n"
-  assert_true(contains(borrow_set_of(src), "head"))
+  inspect(contains(borrow_set_of(src), "head"), "true")
+}
+
+test "MutList::get binding returned through if branches stays borrow-returning" {
+  // #1932 review: the `known` seed must carry the same builtins
+  // is_borrow_ret_fname hardcodes -- MutList::get was missing, which would
+  // classify this binding owned and make RC callers drop an interior view.
+  let src = "fn head(l: Array[Array[Int]], i: Int) -> Array[Int] {\n  let v = MutList::get(l, i)\n  if i >= 0 {\n    v\n  } else {\n    v\n  }\n}\n"
+  inspect(contains(borrow_set_of(src), "head"), "true")
 }

--- a/lib/@vibe/compiler/tests/may_return_view_fns_test.vibe
+++ b/lib/@vibe/compiler/tests/may_return_view_fns_test.vibe
@@ -1,0 +1,63 @@
+//# #1915 regression: compute_may_return_view_fns vs the local-let ascription
+//# wrapper. A local `let x: T = e` parses to the identity application
+//# `((__asc: T) -> __asc)(e)` (ascribe_wrap, parser_expr_dispatch.vibe).
+//# mrv_fresh used to treat the non-ident callee as untrackable, so every
+//# function tail-returning an ANNOTATED fresh binding -- the standard builder
+//# shape `let out: Array[Int] = []; ...; out` -- was classified
+//# may-return-view, and every caller then suppressed the scope-end drop of an
+//# OWNED result (one leaked object per call; the single largest contributor
+//# found while attributing the #1875 self-compile heap high-water).
+
+import @vibe/parser {
+  lex, parse_program
+}
+
+import @vibe/compiler/codegen/common_analysis {
+  compute_may_return_view_fns
+}
+
+fn view_set_of(src: String) -> Array[String] {
+  compute_may_return_view_fns(parse_program(lex(src)))
+}
+
+fn contains(names: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+test "annotated builder returned by name is not view" {
+  let src = "fn make(n: Int) -> Array[Int] {\n  let out: Array[Int] = []\n  let mut i = 0\n  while i < n {\n    Array::push(out, i)\n    i = i + 1\n  }\n  out\n}\n"
+  assert_true(!contains(view_set_of(src), "make"))
+}
+
+test "annotated literal returned by name is not view" {
+  let src = "fn make(n: Int) -> Array[Int] {\n  let out: Array[Int] = [1, 2, 3]\n  out\n}\n"
+  assert_true(!contains(view_set_of(src), "make"))
+}
+
+test "annotated borrow-returning binding stays view" {
+  // The ascription see-through must delegate to the ARGUMENT's freshness,
+  // not blanket-trust the wrapper: an annotated binding of a borrowed view
+  // (`Array::get`) is still a view when returned.
+  let src = "fn head(a: Array[Array[Int]]) -> Array[Int] {\n  let v: Array[Int] = Array::get(a, 0)\n  v\n}\n"
+  assert_true(contains(view_set_of(src), "head"))
+}
+
+test "unannotated view binding stays view" {
+  let src = "fn head(a: Array[Array[Int]]) -> Array[Int] {\n  let v = Array::get(a, 0)\n  v\n}\n"
+  assert_true(contains(view_set_of(src), "head"))
+}
+
+test "param passthrough stays view" {
+  let src = "fn id_arr(a: Array[Int]) -> Array[Int] {\n  let v: Array[Int] = a\n  v\n}\n"
+  assert_true(contains(view_set_of(src), "id_arr"))
+}

--- a/lib/@vibe/compiler/tests/may_return_view_fns_test.vibe
+++ b/lib/@vibe/compiler/tests/may_return_view_fns_test.vibe
@@ -36,12 +36,12 @@ fn contains(names: Array[String], name: String) -> Bool {
 
 test "annotated builder returned by name is not view" {
   let src = "fn make(n: Int) -> Array[Int] {\n  let out: Array[Int] = []\n  let mut i = 0\n  while i < n {\n    Array::push(out, i)\n    i = i + 1\n  }\n  out\n}\n"
-  assert_true(!contains(view_set_of(src), "make"))
+  inspect(contains(view_set_of(src), "make"), "false")
 }
 
 test "annotated literal returned by name is not view" {
   let src = "fn make(n: Int) -> Array[Int] {\n  let out: Array[Int] = [1, 2, 3]\n  out\n}\n"
-  assert_true(!contains(view_set_of(src), "make"))
+  inspect(contains(view_set_of(src), "make"), "false")
 }
 
 test "annotated borrow-returning binding stays view" {
@@ -49,15 +49,15 @@ test "annotated borrow-returning binding stays view" {
   // not blanket-trust the wrapper: an annotated binding of a borrowed view
   // (`Array::get`) is still a view when returned.
   let src = "fn head(a: Array[Array[Int]]) -> Array[Int] {\n  let v: Array[Int] = Array::get(a, 0)\n  v\n}\n"
-  assert_true(contains(view_set_of(src), "head"))
+  inspect(contains(view_set_of(src), "head"), "true")
 }
 
 test "unannotated view binding stays view" {
   let src = "fn head(a: Array[Array[Int]]) -> Array[Int] {\n  let v = Array::get(a, 0)\n  v\n}\n"
-  assert_true(contains(view_set_of(src), "head"))
+  inspect(contains(view_set_of(src), "head"), "true")
 }
 
 test "param passthrough stays view" {
   let src = "fn id_arr(a: Array[Int]) -> Array[Int] {\n  let v: Array[Int] = a\n  v\n}\n"
-  assert_true(contains(view_set_of(src), "id_arr"))
+  inspect(contains(view_set_of(src), "id_arr"), "true")
 }

--- a/lib/@vibe/compiler/tests/may_return_view_fns_test.vibe
+++ b/lib/@vibe/compiler/tests/may_return_view_fns_test.vibe
@@ -16,7 +16,7 @@ import @vibe/compiler/codegen/common_analysis {
   compute_may_return_view_fns
 }
 
-fn view_set_of(src: String) -> Array[String] {
+fn view_set_of(src: String) -> Array[String] with Exception {
   compute_may_return_view_fns(parse_program(lex(src)))
 }
 

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4378,7 +4378,7 @@ if [ "$sh_out" != "42" ]; then
   exit 1
 fi
 echo "[compiler-gate] RC user-shadowed builtin name ok (#1746)"
-echo "[compiler-gate] 40d/40 RC reclamation leak guard (tuple+cell+closure+enum+loop-consume)"
+echo "[compiler-gate] 40d/40 RC reclamation leak guard (tuple+cell+closure+enum+loop-consume+builder-return)"
 lkdir="_build/_gate_rc_leak"
 rm -rf "$lkdir"; mkdir -p "$lkdir"
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -4395,8 +4395,8 @@ lk_result="$(printf '%s' "$lk_json" | sed -n 's/.*"result":\([0-9]*\).*/\1/p')"
 if [ -z "$lk_used" ]; then
   echo "[compiler-gate] FAIL: could not measure rc_reclaim_leak heap ($lk_json)" >&2; exit 1
 fi
-if [ "$lk_result" != "3200280000" ]; then
-  echo "[compiler-gate] FAIL: rc_reclaim_leak wrong result $lk_result (want 3200280000)" >&2; exit 1
+if [ "$lk_result" != "3200340000" ]; then
+  echo "[compiler-gate] FAIL: rc_reclaim_leak wrong result $lk_result (want 3200340000)" >&2; exit 1
 fi
 if [ "$lk_used" -ge 2000 ]; then
   echo "[compiler-gate] FAIL: rc_reclaim_leak heap_used=$lk_used >= 2000 (RC reclamation regressed; ~800000 == full leak)" >&2; exit 1


### PR DESCRIPTION
## Summary

#1915: any function tail-returning the standard builder shape (`let out: Array[Int] = []; ...; out`) had its call results **never dropped by any caller** — one leaked owned object per call (measured 8,284 B/call for a 1000-element builder). Bisecting the emitted wasm of minimal twins showed the discriminator is the **type annotation on the local binding**: a local `let x: T = e` parses to the identity application `((__asc: T) -> __asc)(e)` (`ascribe_wrap`), and two whole-program classifiers were blind to that wrapper. This PR fixes both:

1. **`compute_may_return_view_fns` (`mrv_fresh`)** treated the non-ident callee as untrackable, so every annotated fresh binding classified non-fresh and the enclosing function joined the may-return-view set — callers then suppress the binding's scope-end drop unconditionally (the documented "bounded, safe direction" leak, except builders make it one object per call, every caller). `mrv_fresh` now recognizes a single-param identity lambda structurally and delegates the call's freshness to its argument. An ascribed *view* (borrowed builtin result, param passthrough) still classifies view.

2. **`compute_borrow_returning_names` (`tail_is_borrow_ret_safe`)** accepted ANY bare ident inside an if/match branch tail as "safe to never drop" (the #707 sentinel fallback for `peek`'s `TEof`) — which also swallowed `if c { out } else { out }` builders. The walk now resolves a bare ident branch tail through the function's wrapper-spine `let` bindings: a binding provably holding an owned heap value (container literal with the ascription wrapper peeled, or a call to a non-borrow-returning name — the same verdicts an inline tail of that shape already gets) rejects the function. `let mut` targets, reassigned/shadowed names (inner lets and match-pattern bindings retire spine names during the walk), params, view calls, and anything unresolvable keep the safe fallback, so resolution can only flip leak → reclaim, never view → owned.

On the compiler's own sources the fixes remove 26 functions from the borrow-returning set (217 → 191) and 16 from the may-return-view set (1063 → 1047) — 42 functions whose call results are now correctly dropped.

Measured on the repro fixtures (stage2, RC lane, ×100 calls, heap delta):

| shape | before | after |
|---|---:|---:|
| builder loop, bare `out` tail (1000 elems) | 828,400 (leaks every call) | 8,284 (1 bounded residual) |
| annotated literal binding, bare tail | 14,800 | 148 (1 bounded residual) |
| owned-call binding, bare tail | 0 | 0 |
| unannotated literal binding, bare tail | 148 | 0 |

## Remaining (kept open on #1915)

A third, independent mechanism still leaks the `builder loop + if/else tail` combination: the planner provisions one dup per *textual* branch mention of the binding and codegen emits them unconditionally at the binding site, while only one branch executes at runtime — the imbalance only materializes when a loop borrow-use of the binding is also present (without the loop the same if/else shape balances). Full wat evidence is in the issue thread; it is a per-use-pairing/emission question in the planner, not a classification question, so it is out of scope here.

## Validation

- `seed → stage1 → stage2 → stage3` selfbuild with the fix: **fixpoint holds** (stage2 == stage3, `15b282792479`)
- `scripts/compiler_gate.sh` direct run: **all steps pass**, including the extended 40d RC reclamation guard (`pkf run test` fails in this container on the known pkf-env nix glibc `sort: GLIBC_ABI_DT_X86_64_PLT` issue before reaching the gate — environmental, pre-existing)
- New unit tests green: `may_return_view_fns_test.vibe` (ascribed builder/literal not view; ascribed view, unannotated view, param passthrough stay view), `borrow_returning_names_test.vibe` (builder and owned-call if-tails rejected; sentinel `TEof` fallback, `let mut` reassignment, borrowed-call binding stay borrow-returning)
- Gate 40d fixture `rc_reclaim_leak_test.vibe` gains a builder-return loop whose leak would scale `heap_used` with N (expected result updated 3200280000 → 3200340000)
- Self-compile heap KPI (`measure_fs_heap.sh --cold --backend rc`): peak 2565.6 → 2566.3 MiB (unchanged within noise — the full-CLI cold-compile high-water is dominated by AST/codegen buffers, not these 42 functions' return values; the per-call leak in *user* programs is the real payoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_