### PR TITLE
fix: 検証スクリプトが「黙って誤る」欠陥を 3 件直す (#1890, #1262)

### DIFF
--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -14,6 +14,45 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$ROOT_DIR"
 
+# --- exit-status helpers -----------------------------------------------------
+#
+# This script runs under `set -euo pipefail`, so a command whose non-zero exit
+# is DATA rather than a failure must never be called bare. Written bare, the
+# script dies at that line and the carefully-worded FAIL branch below it is
+# unreachable -- the gate reports nothing about why it stopped.
+#
+# Two real instances of this were in the tree (#1262):
+#
+#   - the `vibe check @scope/pkg` section, whose FAIL branch exists precisely
+#     to avoid "a diagnostic-free failure", was itself made diagnostic-free;
+#   - the process-exit section, where SUCCESS is a non-zero status (7), was
+#     fully INVERTED: it died when the fixture was correct and sailed past when
+#     the lowering had regressed to a no-op. It passed only when broken.
+#
+# Use `gate_status` whenever the exit code is something you want to READ.
+# Use plain `cmd` when a non-zero status genuinely means "abort the gate".
+# `|| true` remains fine where the status is deliberately ignored and a later
+# check (output file exists, content matches) is what decides.
+
+# gate_status <var> <cmd...> -- run cmd, assign its exit status to <var>.
+# Never aborts, so the caller's own assertion is always reached.
+gate_status() {
+  local __var="$1"; shift
+  local __rc=0
+  "$@" >/dev/null 2>&1 || __rc=$?
+  printf -v "$__var" '%s' "$__rc"
+}
+
+# gate_status_out <var> <outfile> <cmd...> -- same, but keep stdout+stderr in
+# <outfile> so a FAIL branch can show what actually happened.
+gate_status_out() {
+  local __var="$1"; local __out="$2"; shift 2
+  local __rc=0
+  "$@" >"$__out" 2>&1 || __rc=$?
+  printf -v "$__var" '%s' "$__rc"
+}
+# -----------------------------------------------------------------------------
+
 echo "[compiler-gate] 0/3 builtin parity (#415 B-3)"
 bash scripts/check_builtin_parity.sh
 
@@ -4918,14 +4957,9 @@ for gcpe_be in linear gc; do
     cat "$gcpedir/$gcpe_be.wasm.diag" 2>/dev/null >&2 || true
     exit 1
   fi
-  # `if` guard, not a bare call: this script runs under `set -euo pipefail`,
-  # and the SUCCESS case here is a NON-ZERO status (7). A bare call would kill
-  # the gate exactly when the fixture behaves correctly -- and, worse, a
-  # regression that made the exit a no-op would return 0 and sail past. The
-  # detector was inverted: it passed only when broken. The condition part of
-  # `if` is exempt from errexit, so the status reaches the assertion.
-  gcpe_rc=0
-  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcpedir/$gcpe_be.wasm" >/dev/null 2>&1 || gcpe_rc=$?
+  # SUCCESS here is a NON-ZERO status (7), so the exit code is DATA -- read it
+  # with gate_status (see the helper's header for what a bare call did).
+  gate_status gcpe_rc env VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcpedir/$gcpe_be.wasm"
   if [ "$gcpe_rc" -ne 7 ]; then
     echo "[compiler-gate] FAIL: gc_process_exit.vibe exited $gcpe_rc on the $gcpe_be backend (want 7; 0 = the exit lowering is a no-op and the program fell through) (#1262)" >&2
     exit 1
@@ -12223,10 +12257,13 @@ fn main() -> Int {
   MutMap::size(m)
 }
 CHKPKG
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+# Read the status rather than calling bare: the FAIL branch below exists to
+# keep this surface from producing "a diagnostic-free failure", and under
+# errexit a bare call made that branch unreachable -- the exact thing it
+# guards against.
+gate_status chk_rc env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$chkpkgdir/entry.vibe" "$chkpkgdir/check.out" main >/dev/null 2>&1
-chk_rc=$?
+  "$chkpkgdir/entry.vibe" "$chkpkgdir/check.out" main
 # (a) it must SUCCEED. A crash here used to produce exit 1 with an empty
 # output AND an empty .diag -- indistinguishable from a diagnostic-free
 # failure, which is the one thing this surface must never be.

--- a/scripts/test_gc_selfbuild.sh
+++ b/scripts/test_gc_selfbuild.sh
@@ -28,6 +28,21 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$ROOT_DIR"
 
+# The compiler is a deeply-recursive program, and node's DEFAULT stack is not
+# enough to type-check the flat bundle -- on it BOTH lanes die with
+# "expression too deeply nested (stack overflow while type-checking)" long
+# before codegen runs. scripts/generations.sh (the real build) therefore uses
+# --stack-size=131072, and this script must use the same one.
+#
+# Without it this script does not merely fail: it MISREPORTS THE FRONTIER,
+# which is its entire job. It reports a host stack limit as if it were the gc
+# lane's limit, and it does so PESSIMISTICALLY -- "not even type-checking
+# works" reads as far-behind when the lane in fact reaches the self-compile
+# fixpoint. Anyone acting on that goes hunting for problems that are already
+# solved (#1262: it happened).
+: "${VIBE_NODE_WASM_FLAGS:=--experimental-wasm-exnref --stack-size=${VIBE_GC_SELFBUILD_NODE_STACK_SIZE:-131072}}"
+export VIBE_NODE_WASM_FLAGS
+
 CLI_WASM="${1:-${VIBE_GC_SELFBUILD_CLI_WASM:-}}"
 if [ -z "$CLI_WASM" ]; then
   CLI_WASM="$(ls -t "$ROOT_DIR"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -1 || true)"


### PR DESCRIPTION
検証スクリプトが**嘘をつく**タイプの欠陥を 3 件。どれも失敗を報告するのではなく、**誤った内容を自信をもって報告する** — [docs/issue-triage.md](docs/issue-triage.md) の P0 =「黙って誤る」に当たる形。

3 件とも同じ根から出ている: **`set -e` の効く範囲と、終了コードを読む場所の食い違い**。

## 1. `generations.sh`: 失敗したビルドを成功として報告 (#1890, P0)

`generations.sh build` が exit 0 を返し `stage2 candidate: ...` まで表示するのに、stage0→stage1 と stage1→stage2 の**両方が失敗している**状態を踏んだ。

runner 自体は失敗時に終了コード 1 を返し `.diag` も書く。ではなぜ `set -euo pipefail` の下で完走したのか:

```sh
run_generation_compile:
  cli) run_cli_compile ... || rc=$? ;;
```

`||` の左辺は **errexit の対象外**なので、`run_cli_compile` の中身は set -e の保護下に無い。サブシェルが非 0 で終わってもスクリプトは死なず、成否判定が `[ -s "$out" ]` だけになる。generation ディレクトリは commit sha 由来なので、**同じ commit で 2 回ビルドすると 1 回目の .wasm が残っており**、失敗した compile がそれを拾って成功扱いになる。前世代の linear stage2 が「stage2 candidate」として提示されていた。

証拠 (mtime): 失敗を記録した `.diag` のほうが `.wasm` より **3 分半新しい**。

| file | mtime | 対応する `.diag` |
|---|---|---|
| `stage1.wasm` | 20:31:49 | **20:35:23** |
| `stage2.wasm` | 20:32:27 | **20:36:04** |

直し方: compile 前に `rm -f "$out" "$out.diag"`、終了コードを**明示的に**検査、失敗時に `.diag` を stderr へ。`run_selfbuild_compile` は既に `rm -f` していたので、同じ扱いを cli invoke モードにも与えた形。

## 2. `compiler_gate.sh`: errexit で FAIL 分岐が到達不能

#1900 で `40h-9` の罠は直したが、**同じ罠が節 103 に残っている** (そのコミットが #1900 のマージに含まれなかった)。

```console
$ git show origin/main:scripts/compiler_gate.sh | grep -c gate_status
0
```

節 103 が特に問題なのは、その FAIL 分岐が何のために書かれたかによる:

> (a) it must SUCCEED. A crash here used to produce exit 1 with an empty output AND an empty .diag -- **indistinguishable from a diagnostic-free failure, which is the one thing this surface must never be.**

「診断の無い失敗だけは避けたい」と書いてある分岐そのものが、errexit で到達不能になっていた。

`gate_status` / `gate_status_out` を追加して書き直し、使い分けをヘッダに明記:

| 状況 | 書き方 |
|---|---|
| 終了コードを**読みたい** | `gate_status` |
| 非 0 が本当に「gate を止める」意味 | 裸の呼び出し |
| 意図的に無視し、後続の存在確認や内容比較で判定 | `\|\| true` のまま |

**スコープは意図的に絞った。** 12,278 行・runner 呼び出し 571 回の一括整理はしていない (差分が巨大になり退行時の切り分けが不能になる)。`|| true` の 511 箇所も罠ではない (ステータスを捨てて後続で判定する設計) ので触っていない。

## 3. `test_gc_selfbuild.sh`: ホストのスタック上限を gc の限界として報告

`--stack-size` を一切設定せず node の既定で走るが、コンパイラは深い再帰を含むので既定スタックでは flat bundle の型検査中に**両レーンとも**落ちる。実際のビルド (`generations.sh`) が `--stack-size=131072` を使っているのはこのため。

結果として、このスクリプトは単に失敗するのではなく **frontier を誤って報告していた** — それはこのスクリプトの存在理由そのものである。

```
修正前 (環境変数なし):
  frontier: expression too deeply nested (stack overflow while type-checking)

修正後 (環境変数なし):
  BUNDLE COMPILED: 3079097 bytes
  RUN E2E OK: gc-compiled compiler output is byte-identical to the linear compiler's (P4.5 done)
  SELF-COMPILE FIXPOINT OK: byte-identical to the linear compiler's output (2212938 bytes)
```

誤りの向きが**悲観方向**なのが厄介で、「型検査すら通らない」と読める。実際には **gc レーンは self-compile fixpoint に到達している**。この誤報告を信じると既に解決済みの問題を追いかけることになる — #1262 の作業中に実際にそうなった。

## 副産物: gc 自己ビルドは既に完成していた

3 の修正で測り直した結果、`RUN E2E OK` + `SELF-COMPILE FIXPOINT OK` (linear とバイト一致) が出た。

自分は直前に「gc 製コンパイラは `memory access out of bounds` で落ちる」と報告していたが、**それは誤りで、原因は呼び出し方だった** — gc 製コンパイラの entry は `_start` (argv は "vibe" host import 経由) で、`cli_main` で呼んでいた。`.claude/skills/selfhost-miscompile-bisect` に明記されているが、skill を読む前に手作業で probe を組んでいた。

この 3 件は、まさにその誤診断を生んだ基盤側の欠陥にあたる。

## 検証

- **#1890**: 修正前後を同じ条件 (出力が既に存在する状態で compile が失敗) で比較
  ```
  修正前: rc=0                                  <- 失敗を成功と誤報告
  修正後: rc=1 + FATAL: failed (exit 1): ...    <- 正しく失敗し理由も出る
  ```
  正常系の退行なし: `generations.sh build` が GEN=0 で完走し全 stage 成功。成果物が**今回の実行で新規生成**され (09:27-09:28)、`.diag` が 0 件であることまで確認 (前回問題になった「wasm が diag より古い」状態でないこと)
- **`compiler_gate.sh`**: フルゲート完走 → GATE=0 / FAIL 0 件。対象節が実際に走ったことをログの自前出力行で確認
  ```
  305: [compiler-gate] wasm-gc process exit ok (linear + gc, exit status 7)
  659: [compiler-gate] 103/104 vibe check resolves @scope/pkg imports, ...
  ```
- **ヘルパ単体** (`set -e` 下): 7 / 0 / 134 を正しく読め、出力保持も動作し、スクリプトが生存
- **節 103**: 失敗を注入して FAIL 分岐に到達し診断が出ることを確認
- **`test_gc_selfbuild.sh`**: 環境変数を渡さずに実行し、`--stack-size` を明示的に渡した実行と BUNDLE / RUN E2E / FIXPOINT の全行が**完全一致**することを確認。probe の失敗 0 件
- `bash -n` 構文チェック通過 (3 スクリプトとも)

Closes #1890