### PR TITLE
Fix #1890: a failed generation compile reported the build as successful

### DIFF
--- a/scripts/generations.sh
+++ b/scripts/generations.sh
@@ -796,6 +796,24 @@ command_build() {
   local stage1="$out_dir/stage1.wasm"
   local stage2="$out_dir/stage2.wasm"
   local stage3="$out_dir/stage3.wasm"
+  # Retract the previous build's answer before producing a new one. The stage
+  # artifacts are deleted by the compile functions as they go, but the manifest
+  # is written only at the very end -- so a build that dies partway used to
+  # leave the PREVIOUS generation.json in place, still claiming
+  # `stage2_distribution_candidate=true` with hashes for artifacts that are now
+  # gone. That is not a cosmetic staleness: `status` reports from this file,
+  # and compiler_gate.sh picks the newest generation directory and reads its
+  # generation.json (scripts/compiler_gate.sh:108). Removing it first makes a
+  # failed build read as `generation.status=not-built` rather than as the
+  # previous build's success.
+  rm -f "$out_dir/generation.json"
+  # Same reasoning for a stage3 left by an earlier --stage3 run: this build is
+  # not producing one, and the manifest correctly reports stage3_equal_stage2
+  # as null, so an old stage3.wasm sitting next to a fresh stage2 can only
+  # mislead whoever looks in the directory.
+  if [ "$build_stage3" != "1" ]; then
+    rm -f "$stage3"
+  fi
   cp "$SEED_ARTIFACT_PATH" "$stage0"
   validate_wasm_if_available stage0 "$stage0"
   run_generation_compile "stage0(seed) -> stage1" "$stage0" "$entry" "$stage1" "$entry_name"

--- a/scripts/generations.sh
+++ b/scripts/generations.sh
@@ -74,6 +74,21 @@ die() {
   exit 1
 }
 
+# A failed compile says why in `<out>.diag`, not on stderr: the compiler writes
+# diagnostics to that sidecar and the runner prints only its exit status. So a
+# bare `die` here would report that the build stopped without reporting what the
+# compiler objected to, and the .diag would then be overwritten by the next run.
+die_compile() {
+  local label="$1"
+  local out="$2"
+  shift 2
+  if [ -s "$out.diag" ]; then
+    echo "selfhost generations: $label diagnostics ($out.diag):" >&2
+    cat "$out.diag" >&2
+  fi
+  die "$label $*"
+}
+
 sha256_file() {
   if command -v sha256sum >/dev/null 2>&1; then
     sha256sum "$1" | cut -d' ' -f1
@@ -298,6 +313,19 @@ run_cli_compile() {
   fi
   mkdir -p "$(dirname "$out")"
   echo "[selfhost-gen] $label (invoke cli_main)"
+  # Delete the previous artifact before compiling, and check the compile's exit
+  # status explicitly rather than inferring success from the artifact existing
+  # (#1890). Both are needed, and neither is redundant with `set -e`:
+  #
+  # run_generation_compile invokes this function in a `... || rc=$?` list, and
+  # bash disables `set -e` for the whole dynamic extent of a function called
+  # that way. So a failing subshell below does NOT abort the script -- control
+  # reaches the check underneath it. That check used to be `[ -s "$out" ]`
+  # alone, which a stale .wasm left by an earlier build into the same
+  # generation directory satisfies. The build then reported success while the
+  # artifact it "produced" predated the source it was supposed to compile.
+  rm -f "$out" "$out.diag"
+  local compile_rc=0
   (
     cd "$PROJECT_ROOT"
     VIBE_PREOPEN_DIR="$PROJECT_ROOT" \
@@ -312,8 +340,9 @@ run_cli_compile() {
         "$(rel_path "$entry")" \
         "$(rel_path "$out")" \
         "$compile_entry_name"
-  )
-  [ -s "$out" ] || die "$label did not produce output: $out"
+  ) || compile_rc=$?
+  [ "$compile_rc" -eq 0 ] || die_compile "$label" "$out" "compile failed (exit $compile_rc)"
+  [ -s "$out" ] || die_compile "$label" "$out" "did not produce output: $out"
 }
 
 use_selfbuild_invoke() {
@@ -442,7 +471,8 @@ run_selfbuild_compile() {
   fi
   mkdir -p "$(dirname "$out")" "$(dirname "$SELFBUILD_OUT")"
   echo "[selfhost-gen] $label (invoke $selfbuild_export)"
-  rm -f "$SELFBUILD_OUT"
+  rm -f "$SELFBUILD_OUT" "$SELFBUILD_OUT.diag" "$out"
+  local compile_rc=0
   (
     cd "$PROJECT_ROOT"
     VIBE_IMPORT_ABI="$import_abi" \
@@ -450,10 +480,13 @@ run_selfbuild_compile() {
       VIBE_DISABLE_PERSISTENT_ARTIFACT_CACHE="${VIBE_DISABLE_PERSISTENT_ARTIFACT_CACHE:-$DISABLE_PERSISTENT_ARTIFACT_CACHE}" \
       VIBE_NODE_WASM_FLAGS="$node_flags" \
       bash "$RUNNER_SCRIPT" --invoke "$selfbuild_export" "$compiler"
-  )
-  [ -s "$SELFBUILD_OUT" ] || die "$label did not produce recursive output: $SELFBUILD_OUT"
+  ) || compile_rc=$?
+  [ "$compile_rc" -eq 0 ] || \
+    die_compile "$label" "$SELFBUILD_OUT" "compile failed (exit $compile_rc)"
+  [ -s "$SELFBUILD_OUT" ] || \
+    die_compile "$label" "$SELFBUILD_OUT" "did not produce recursive output: $SELFBUILD_OUT"
   cp "$SELFBUILD_OUT" "$out"
-  [ -s "$out" ] || die "$label did not produce output: $out"
+  [ -s "$out" ] || die_compile "$label" "$out" "did not produce output: $out"
 }
 
 # Each stage hop is one span (docs/tracing-design.md step 0). This is the

--- a/scripts/generations_test.sh
+++ b/scripts/generations_test.sh
@@ -236,3 +236,84 @@ if ! rg -q "split CLI generation requires a bootstrap bump" "$CLI_ROOT/split.std
 fi
 
 echo "selfhost generations split-cli-entry guard self-test: ok"
+
+# #1890: a failed compile must fail the build, even when an earlier build left
+# an artifact at the same path. The runner reports failure by exit status and
+# writes the diagnostics to `<out>.diag`, so a build that only asks "does the
+# output file exist?" reports success for a stale artifact -- and the stage2 it
+# then hands to the gate predates the source it was supposed to compile.
+FAIL_ROOT="$TMP_ROOT/failing_compile"
+mkdir -p "$FAIL_ROOT/bootstrap" "$FAIL_ROOT/_build/selfhost/seed" \
+  "$FAIL_ROOT/lib/@vibe/compiler" "$FAIL_ROOT/out"
+printf 'export let main = () -> Int { 0 }\n' > "$FAIL_ROOT/lib/@vibe/compiler/index.vibe"
+printf 'seed-compiler\n' > "$FAIL_ROOT/_build/selfhost/seed/selfhost_compiler.wasm"
+fail_seed_sha="$(shasum -a 256 "$FAIL_ROOT/_build/selfhost/seed/selfhost_compiler.wasm" | awk '{print $1}')"
+
+cat > "$FAIL_ROOT/bootstrap/seed.json" <<EOF
+{
+  "schema": 1,
+  "policy": "rust-style-stage0-stage1-stage2",
+  "seed": {
+    "name": "fail-seed",
+    "tag": "fail-seed-tag",
+    "source_commit": "abc123",
+    "entry": "lib/@vibe/compiler/index.vibe",
+    "entry_name": "cli_main",
+    "artifact": {
+      "path": "_build/selfhost/seed/selfhost_compiler.wasm",
+      "sha256": "$fail_seed_sha"
+    }
+  }
+}
+EOF
+
+# Exactly what the real runner does on a compile error: non-zero exit, the
+# reason in the .diag sidecar, and no .wasm.
+cat > "$FAIL_ROOT/fail_runner.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out="$5"
+mkdir -p "$(dirname "$out")"
+printf 'synthetic compile error for the #1890 regression test\n' > "$out.diag"
+exit 1
+EOF
+chmod +x "$FAIL_ROOT/fail_runner.sh"
+
+# The artifacts from "the previous build", which is what made the failure
+# invisible: the generation directory is named after the commit, so a rebuild at
+# the same commit (different backend, different flags) lands on top of a
+# complete set of stage outputs. Every stage has to be stale for the build to
+# report success, which is exactly what a repeat build gives it.
+printf 'stale-wasm-from-an-earlier-build\n' > "$FAIL_ROOT/out/stage1.wasm"
+printf 'stale-wasm-from-an-earlier-build\n' > "$FAIL_ROOT/out/stage2.wasm"
+
+set +e
+VIBE_PROJECT_ROOT="$FAIL_ROOT" \
+VIBE_GENERATION_RUNNER_SCRIPT="$FAIL_ROOT/fail_runner.sh" \
+VIBE_GENERATION_VALIDATE_WASM=0 \
+VIBE_GENERATION_VALIDATE_RUN=0 \
+  bash "$SCRIPT" build --manifest "$FAIL_ROOT/bootstrap/seed.json" \
+    --out-dir "$FAIL_ROOT/out" >"$FAIL_ROOT/fail.stdout" 2>"$FAIL_ROOT/fail.stderr"
+fail_status=$?
+set -e
+if [ "$fail_status" -eq 0 ]; then
+  echo "expected a failing compile to fail the build (#1890)" >&2
+  exit 1
+fi
+if ! rg -q "compile failed \(exit 1\)" "$FAIL_ROOT/fail.stderr"; then
+  echo "expected the compile's exit status to be reported" >&2
+  cat "$FAIL_ROOT/fail.stderr" >&2
+  exit 1
+fi
+# Without this the terminal shows only that the build stopped, never why.
+if ! rg -q "synthetic compile error" "$FAIL_ROOT/fail.stderr"; then
+  echo "expected the .diag contents on stderr" >&2
+  cat "$FAIL_ROOT/fail.stderr" >&2
+  exit 1
+fi
+if [ -e "$FAIL_ROOT/out/stage1.wasm" ]; then
+  echo "expected the stale artifact to be removed before compiling" >&2
+  exit 1
+fi
+
+echo "selfhost generations failed-compile self-test: ok"

--- a/scripts/generations_test.sh
+++ b/scripts/generations_test.sh
@@ -286,6 +286,8 @@ chmod +x "$FAIL_ROOT/fail_runner.sh"
 # report success, which is exactly what a repeat build gives it.
 printf 'stale-wasm-from-an-earlier-build\n' > "$FAIL_ROOT/out/stage1.wasm"
 printf 'stale-wasm-from-an-earlier-build\n' > "$FAIL_ROOT/out/stage2.wasm"
+# ...including its manifest, which is what `status` and compiler_gate.sh read.
+printf '{"result":{"stage2_distribution_candidate":true}}\n' > "$FAIL_ROOT/out/generation.json"
 
 set +e
 VIBE_PROJECT_ROOT="$FAIL_ROOT" \
@@ -313,6 +315,22 @@ if ! rg -q "synthetic compile error" "$FAIL_ROOT/fail.stderr"; then
 fi
 if [ -e "$FAIL_ROOT/out/stage1.wasm" ]; then
   echo "expected the stale artifact to be removed before compiling" >&2
+  exit 1
+fi
+# A failed build must not leave the previous build's verdict standing: the
+# manifest is written last, so without retracting it up front the directory
+# still answers "stage2 is a distribution candidate" for artifacts it no
+# longer has.
+if [ -e "$FAIL_ROOT/out/generation.json" ]; then
+  echo "expected the previous generation.json to be retracted before building" >&2
+  cat "$FAIL_ROOT/out/generation.json" >&2
+  exit 1
+fi
+fail_status_out="$(VIBE_PROJECT_ROOT="$FAIL_ROOT" bash "$SCRIPT" status \
+  --manifest "$FAIL_ROOT/bootstrap/seed.json" --out-dir "$FAIL_ROOT/out")"
+if ! echo "$fail_status_out" | rg -q "^generation\.status=not-built$"; then
+  echo "expected status to report not-built after a failed build" >&2
+  echo "$fail_status_out" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #1890.

`scripts/generations.sh build` returned **exit 0** with every stage compile failing, and presented a stale artifact as the `stage2 candidate`.

## The mechanism is not "the exit code is not checked"

The issue's diagnosis says `run_cli_compile` does not look at `cli_main`'s exit code. Each part in isolation is in fact correct, which is what makes this worth writing down:

| link | measured |
|---|---|
| `wasm_vibe_host_runner.js` on a failed compile | **exit 1**, writes `<out>.diag`, no `.wasm` |
| `run_wasm_vibe_host_runner.sh` | ends in `exec node …`, so it propagates |
| `scripts/generations.sh` | line 2 is `set -euo pipefail` |

What defeats all three is the **call site**:

```sh
cli) run_cli_compile ... || rc=$? ;;
```

Bash disables errexit for the whole dynamic extent of a function invoked on the left of `||`. So the failing subshell inside `run_cli_compile` did not abort, and control reached its only assertion:

```sh
[ -s "$out" ] || die "$label did not produce output: $out"
```

which a stale `.wasm` satisfies. The generation directory is named after the commit, so a rebuild at the same commit — a different backend, different flags — lands on a **complete** set of previous stage outputs and every stage passes this check. `rc` was therefore always 0: the line written to read the status is the line that destroyed it.

## The fix

**Per compile** (`run_cli_compile`, `run_selfbuild_compile`): check the status explicitly, and delete the previous artifact before compiling so the existence check cannot answer for a compile that never ran. Either alone stops this case; both are cheap and they fail differently — one catches a compile that failed, the other a compile that silently produced nothing.

`run_selfbuild_compile` already did `rm -f` on its recursive output, which made it *accidentally* safe against this exact scenario; it was still one `cp` away from the same failure and still said nothing about why a compile died.

**Per build** (`command_build`): retract the previous `generation.json` before the first compile. Raised in review — deleting the stage artifacts without touching the manifest left a failed build still advertising `stage2_distribution_candidate=true` for artifacts it no longer had, since the manifest is written last. That file is on the gate's path: `compiler_gate.sh` selects the newest generation directory and reads its `generation.json` (`scripts/compiler_gate.sh:108`). A failed build now reads as `generation.status=not-built`. A `stage3.wasm` from an earlier `--stage3` run goes too when this build is not producing one — the manifest already reports `stage3_equal_stage2: null`, so the leftover file could only mislead a reader of the directory, which is how #1890 was diagnosed in the first place.

**On death**, print the `.diag`. The compiler writes diagnostics to that sidecar rather than stderr, so the terminal previously showed a bare `1` with nothing marking it as a return value — the display problem the issue notes as the reason this stayed invisible:

```
[selfhost-gen] stage0(seed) -> stage1 (invoke cli_main)
selfhost generations: stage0(seed) -> stage1 diagnostics (…/stage1.wasm.diag):
lib/@vibe/compiler/index.vibe: type error: expected Int, found String
selfhost generations: stage0(seed) -> stage1 compile failed (exit 1)
exit=1
```

## Verification

**The regression test reproduces the bug against the pre-fix script.** It drives the real `generations.sh` with a runner that fails the way the real one does (non-zero exit, reason in `<out>.diag`, no `.wasm`) over a generation directory pre-populated with a previous build: stale artifacts at every stage path, plus its `generation.json`.

| script | result |
|---|---|
| pre-fix (`origin/main`) | **exit 0** — `expected a failing compile to fail the build (#1890)` |
| first commit only | exit 1, but `expected the previous generation.json to be retracted before building` |
| both commits | exit 1 at stage1, diagnostic on stderr, `status` answers `not-built` |

An intermediate version of the test staged a stale artifact only at `stage1`, and the pre-fix script *did* fail — at **stage2**, with the wrong reason. That near-miss is the shape of the bug: it needs a complete previous build to go fully silent, which is exactly what a repeat build at the same commit provides.

**A real build still works.** `bash scripts/generations.sh build`: exit 0, stage1 and stage2 rebuilt fresh and sha-identical (`17967c24…`, the fixpoint), `stage3_equal_stage2: null` correctly reported since `--stage3` was not requested. The `rm -f` ran against a directory that already held artifacts, so this exercised the new path rather than a clean directory.

`scripts/generations_test.sh` (`pkf run test-generations`) passes, including the four pre-existing cases.

## Related

Sibling instances of this same errexit-vs-`||` family were fixed in `compiler_gate.sh` and `test_gc_selfbuild.sh` by #1933. GitHub links that PR to this issue, but its merge commit touches only those two files — `generations.sh`, which is what #1890 is about, was untouched, and the bug reproduces on `origin/main` today.