### PR TITLE
fix(rc): merge exclusive-branch dup budgets to per-binding max (#1915 mechanism 3)

### DIFF
--- a/fixtures/rc_reclaim_leak_test.vibe
+++ b/fixtures/rc_reclaim_leak_test.vibe
@@ -83,6 +83,27 @@ let build_arr = (n: Int) -> Array[Int] {
   out
 }
 
+// #1915 mechanism 3 leak guard: same builder, returned through an if/else
+// tail. The loop borrow-use keeps the binding's remaining > 1 at branch
+// entry, so each exclusive branch used to budget its OWN dup — both emitted
+// unconditionally at the binding site while only one branch executes, one
+// leaked array per call. pe_merge_exclusive_branch_dups folds the branch
+// budgets to a per-binding max.
+let build_arr_if = (n: Int) -> Array[Int] {
+  let out: Array[Int] = [
+  ]
+  let mut j = 0
+  while j < n {
+    Array::push(out, j)
+    j = j + 1
+  }
+  if n >= 0 {
+    out
+  } else {
+    out
+  }
+}
+
 let main = () -> Int {
   let mut total = 0
   let mut i = 0
@@ -138,7 +159,10 @@ let main = () -> Int {
     // #1915 leak guard (see build_arr above): the returned builder array is
     // owned by `built` and must be reclaimed at scope end each iteration.
     let built = build_arr(3)
-    total = total + t.0 + t.1 + c + sumt(tr) + first + ignored + inlined + blen + looped + Array::length(built)
+    // #1915 mechanism 3 (see build_arr_if above): the if/else-tail builder's
+    // result must also be reclaimed each iteration.
+    let built_if = build_arr_if(3)
+    total = total + t.0 + t.1 + c + sumt(tr) + first + ignored + inlined + blen + looped + Array::length(built) + Array::length(built_if)
     i = i + 1
   }
   total

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -62,7 +62,13 @@ struct PCtx {
   // interior view. With the borrow set empty this is never set, so the fix
   // is inert while lc_borrow_arg0_enabled is off.
   view_call_let: Array[Bool];
-  actions: Array[PerceusAction]
+  actions: Array[PerceusAction];
+  // Aligned with `actions`: the binding id each PaDup/PaDrop belongs to (-1
+  // for actions with no single binding id, e.g. PaAliasDup). Internal to the
+  // emission pass -- pe_merge_exclusive_branch_dups (#1915 mechanism 3) keys
+  // its per-branch dup merge on ids, not names, so a branch-local shadow of
+  // an outer name can never swallow the outer binding's dup budget.
+  action_ids: Array[Int]
 }
 
 struct HeapInferCtx {
@@ -106,9 +112,17 @@ fn name_in(arr: Array[String], s: String) -> Bool {
 }
 
 fn pe_push(ctx: PCtx, kind: PerceusActionKind, name: String) -> Int {
+  pe_push_for(ctx, kind, name, 0 - 1)
+}
+
+/// pe_push with the owning binding id recorded in `action_ids` (see the PCtx
+/// field comment). Callers that know the id (pe_use, pe_scope_end) use this
+/// so pe_merge_exclusive_branch_dups can key on ids instead of names.
+fn pe_push_for(ctx: PCtx, kind: PerceusActionKind, name: String, id: Int) -> Int {
   Array::push(ctx.actions, PerceusAction::{
     kind: kind, name: name
   })
+  Array::push(ctx.action_ids, id)
   0
 }
 
@@ -122,7 +136,7 @@ fn pe_use(ctx: PCtx, scope: Map[String, Int], name: String) -> Int {
     // ref" transfer would consume a reference the binding never acquired.
     let last_view_use = rem == 1 && Array::get(ctx.view_call_let, id)
     if (rem > 1 || last_view_use) && !Array::get(ctx.scalar, id) {
-      pe_push(ctx, PaDup, name)
+      pe_push_for(ctx, PaDup, name, id)
     } else {
       0
     }
@@ -160,6 +174,8 @@ fn pctx_new(borrow_ret_names: Array[String], borrow_param_fns: Array[String], bo
     view_call_let: [
     ],
     actions: [
+    ],
+    action_ids: [
     ],
   }
 }
@@ -290,11 +306,128 @@ fn pe_scope_end(ctx: PCtx, id: Int, name: String) -> Int {
     if Array::get(ctx.view_call_let, id) {
       ()
     } else {
-      pe_push(ctx, PaDrop, name)
+      pe_push_for(ctx, PaDrop, name, id)
     }
     Array::set(ctx.remaining, id, 0)
   }
   0
+}
+
+/// #1915 mechanism 3: exclusive branches each push their own PaDup for the
+/// same OUTER binding (the pe pass restores `remaining` per branch, so with
+/// remaining > 1 at branch entry -- e.g. after the #706 borrow-retention bump
+/// for a loop borrow-use -- EVERY branch's use dups), and codegen realizes
+/// every planned dup for a name unconditionally at the binding's declaration
+/// site (compile_expr_tail's rc_dup_names occurrence count). Only one branch
+/// executes at runtime, so the summed budget over-provisions references
+/// nothing ever spends -- one leaked object per call for the
+/// `builder loop + if/else tail` shape.
+///
+/// Merge the branch segments' dups for PRE-BRANCH bindings (id < outer_ids)
+/// down to the per-binding MAX across segments. The executed branch's own
+/// dups are always covered (max >= that branch's count), so the merge can
+/// only remove references no path spends: leak -> reclaim, never a new
+/// under-provision. Branch-LOCAL bindings (declared inside a segment) keep
+/// every action -- their declaration sites sit inside the branch body and are
+/// already conditional at runtime. Keying on ids (action_ids), not names,
+/// keeps a branch-local shadow of an outer name from swallowing the outer
+/// binding's budget.
+///
+/// `seg_starts` holds each branch segment's start index into `ctx.actions`
+/// (the k-th segment ends where segment k+1 starts; the last ends at the
+/// current actions length). Compaction preserves action order and truncates
+/// `actions`/`action_ids` in step.
+fn pe_merge_exclusive_branch_dups(ctx: PCtx, outer_ids: Int, seg_starts: Array[Int]) -> Int {
+  let total = Array::length(ctx.actions)
+  let nsegs = Array::length(seg_starts)
+  if nsegs < 2 {
+    0
+  } else {
+    let a0 = Array::get(seg_starts, 0)
+    // Fast path: no outer-binding dup in the whole region means nothing to
+    // merge (the common case -- avoids the two per-id arrays below).
+    let mut any = false
+    let mut scan = a0
+    while scan < total {
+      let sid = Array::get(ctx.action_ids, scan)
+      if sid >= 0 && sid < outer_ids && pa_is_dup(Array::get(ctx.actions, scan)) {
+        any = true
+      } else {
+        ()
+      }
+      scan = scan + 1
+    }
+    if !any {
+      0
+    } else {
+      let maxc = zeros(outer_ids)
+      let cur = zeros(outer_ids)
+      let mut k = 0
+      while k < nsegs {
+        let seg_from = Array::get(seg_starts, k)
+        let seg_to = if k + 1 < nsegs {
+          Array::get(seg_starts, k + 1)
+        } else {
+          total
+        }
+        let mut z = 0
+        while z < outer_ids {
+          Array::set(cur, z, 0)
+          z = z + 1
+        }
+        let mut i = seg_from
+        while i < seg_to {
+          let sid = Array::get(ctx.action_ids, i)
+          if sid >= 0 && sid < outer_ids && pa_is_dup(Array::get(ctx.actions, i)) {
+            Array::set(cur, sid, Array::get(cur, sid) + 1)
+            if Array::get(cur, sid) > Array::get(maxc, sid) {
+              Array::set(maxc, sid, Array::get(cur, sid))
+            } else {
+              ()
+            }
+          } else {
+            ()
+          }
+          i = i + 1
+        }
+        k = k + 1
+      }
+      // Compact: keep the first max[id] outer-binding dups region-wide (the
+      // consumer counts occurrences per name, so position within the region
+      // is immaterial); every other action is kept as-is.
+      let mut z2 = 0
+      while z2 < outer_ids {
+        Array::set(cur, z2, 0)
+        z2 = z2 + 1
+      }
+      let mut r = a0
+      let mut w = a0
+      while r < total {
+        let sid = Array::get(ctx.action_ids, r)
+        let keep = if sid >= 0 && sid < outer_ids && pa_is_dup(Array::get(ctx.actions, r)) {
+          Array::set(cur, sid, Array::get(cur, sid) + 1)
+          Array::get(cur, sid) <= Array::get(maxc, sid)
+        } else {
+          true
+        }
+        if keep {
+          if w < r {
+            Array::set(ctx.actions, w, Array::get(ctx.actions, r))
+            Array::set(ctx.action_ids, w, Array::get(ctx.action_ids, r))
+          } else {
+            ()
+          }
+          w = w + 1
+        } else {
+          ()
+        }
+        r = r + 1
+      }
+      Array::truncate(ctx.actions, w)
+      Array::truncate(ctx.action_ids, w)
+      0
+    }
+  }
 }
 
 fn next_seq_name(ctx: PCtx) -> String {
@@ -1733,6 +1866,13 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
     EIf(cond, then_e, else_e) => {
       pc_emit(ctx, scope, cond)
       let snap = copy_ints(ctx.remaining)
+      // #1915 mechanism 3: record the pre-branch id/action watermarks so the
+      // two branches' dups for OUTER bindings can be merged to a per-binding
+      // max afterwards (see pe_merge_exclusive_branch_dups).
+      let bd_outer = ctx.next_id
+      let bd_starts = [
+        Array::length(ctx.actions)
+      ]
       pc_emit(ctx, scope, then_e)
       // #1100 alloc cut: swap the prefix instead of taking a SECOND copy —
       // one pass both restores `remaining` to the pre-branch values (what
@@ -1748,6 +1888,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         Array::set(snap, sw, then_v)
         sw = sw + 1
       }
+      Array::push(bd_starts, Array::length(ctx.actions))
       pc_emit(ctx, scope, else_e)
       // #705: leave the MIN remaining over both branches. A binding consumed in
       // one branch (e.g. a param threaded into a ctor in the `then`) but not the
@@ -1766,7 +1907,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         }
         i = i + 1
       }
-      0
+      pe_merge_exclusive_branch_dups(ctx, bd_outer, bd_starts)
     },
     EWhile(cond, body) => {
       pc_emit(ctx, scope, cond)
@@ -1867,9 +2008,16 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         // at a lower remaining; leaving the LAST arm's (higher) value made the
         // scope-end drop double-free that binding on the arm that consumed it.
         let minrem = copy_ints(snap)
+        // #1915 mechanism 3: same exclusive-branch dup merge as EIf. Arm
+        // pattern bindings are declared inside their segment (id >= bd_outer)
+        // and keep every action.
+        let bd_outer = ctx.next_id
+        let bd_starts: Array[Int] = [
+        ]
         let mut a = 0
         while a < Array::length(arms) {
           let arm = Array::get(arms, a)
+          Array::push(bd_starts, Array::length(ctx.actions))
           restore_prefix(ctx.remaining, snap)
           let pnames: Array[String] = [
           ]
@@ -1903,7 +2051,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           a = a + 1
         }
         restore_prefix(ctx.remaining, minrem)
-        0
+        pe_merge_exclusive_branch_dups(ctx, bd_outer, bd_starts)
       }
     },
     EHandle(hbody, arms) => {

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -62,13 +62,7 @@ struct PCtx {
   // interior view. With the borrow set empty this is never set, so the fix
   // is inert while lc_borrow_arg0_enabled is off.
   view_call_let: Array[Bool];
-  actions: Array[PerceusAction];
-  // Aligned with `actions`: the binding id each PaDup/PaDrop belongs to (-1
-  // for actions with no single binding id, e.g. PaAliasDup). Internal to the
-  // emission pass -- pe_merge_exclusive_branch_dups (#1915 mechanism 3) keys
-  // its per-branch dup merge on ids, not names, so a branch-local shadow of
-  // an outer name can never swallow the outer binding's dup budget.
-  action_ids: Array[Int]
+  actions: Array[PerceusAction]
 }
 
 struct HeapInferCtx {
@@ -112,17 +106,9 @@ fn name_in(arr: Array[String], s: String) -> Bool {
 }
 
 fn pe_push(ctx: PCtx, kind: PerceusActionKind, name: String) -> Int {
-  pe_push_for(ctx, kind, name, 0 - 1)
-}
-
-/// pe_push with the owning binding id recorded in `action_ids` (see the PCtx
-/// field comment). Callers that know the id (pe_use, pe_scope_end) use this
-/// so pe_merge_exclusive_branch_dups can key on ids instead of names.
-fn pe_push_for(ctx: PCtx, kind: PerceusActionKind, name: String, id: Int) -> Int {
   Array::push(ctx.actions, PerceusAction::{
     kind: kind, name: name
   })
-  Array::push(ctx.action_ids, id)
   0
 }
 
@@ -136,7 +122,7 @@ fn pe_use(ctx: PCtx, scope: Map[String, Int], name: String) -> Int {
     // ref" transfer would consume a reference the binding never acquired.
     let last_view_use = rem == 1 && Array::get(ctx.view_call_let, id)
     if (rem > 1 || last_view_use) && !Array::get(ctx.scalar, id) {
-      pe_push_for(ctx, PaDup, name, id)
+      pe_push(ctx, PaDup, name)
     } else {
       0
     }
@@ -174,8 +160,6 @@ fn pctx_new(borrow_ret_names: Array[String], borrow_param_fns: Array[String], bo
     view_call_let: [
     ],
     actions: [
-    ],
-    action_ids: [
     ],
   }
 }
@@ -306,128 +290,65 @@ fn pe_scope_end(ctx: PCtx, id: Int, name: String) -> Int {
     if Array::get(ctx.view_call_let, id) {
       ()
     } else {
-      pe_push_for(ctx, PaDrop, name, id)
+      pe_push(ctx, PaDrop, name)
     }
     Array::set(ctx.remaining, id, 0)
   }
   0
 }
 
-/// #1915 mechanism 3: exclusive branches each push their own PaDup for the
-/// same OUTER binding (the pe pass restores `remaining` per branch, so with
-/// remaining > 1 at branch entry -- e.g. after the #706 borrow-retention bump
-/// for a loop borrow-use -- EVERY branch's use dups), and codegen realizes
-/// every planned dup for a name unconditionally at the binding's declaration
-/// site (compile_expr_tail's rc_dup_names occurrence count). Only one branch
-/// executes at runtime, so the summed budget over-provisions references
-/// nothing ever spends -- one leaked object per call for the
-/// `builder loop + if/else tail` shape.
-///
-/// Merge the branch segments' dups for PRE-BRANCH bindings (id < outer_ids)
-/// down to the per-binding MAX across segments. The executed branch's own
-/// dups are always covered (max >= that branch's count), so the merge can
-/// only remove references no path spends: leak -> reclaim, never a new
-/// under-provision. Branch-LOCAL bindings (declared inside a segment) keep
-/// every action -- their declaration sites sit inside the branch body and are
-/// already conditional at runtime. Keying on ids (action_ids), not names,
-/// keeps a branch-local shadow of an outer name from swallowing the outer
-/// binding's budget.
-///
-/// `seg_starts` holds each branch segment's start index into `ctx.actions`
-/// (the k-th segment ends where segment k+1 starts; the last ends at the
-/// current actions length). Compaction preserves action order and truncates
-/// `actions`/`action_ids` in step.
-fn pe_merge_exclusive_branch_dups(ctx: PCtx, outer_ids: Int, seg_starts: Array[Int]) -> Int {
-  let total = Array::length(ctx.actions)
-  let nsegs = Array::length(seg_starts)
-  if nsegs < 2 {
-    0
-  } else {
-    let a0 = Array::get(seg_starts, 0)
-    // Fast path: no outer-binding dup in the whole region means nothing to
-    // merge (the common case -- avoids the two per-id arrays below).
-    let mut any = false
-    let mut scan = a0
-    while scan < total {
-      let sid = Array::get(ctx.action_ids, scan)
-      if sid >= 0 && sid < outer_ids && pa_is_dup(Array::get(ctx.actions, scan)) {
-        any = true
-      } else {
-        ()
-      }
-      scan = scan + 1
-    }
-    if !any {
-      0
-    } else {
-      let maxc = zeros(outer_ids)
-      let cur = zeros(outer_ids)
-      let mut k = 0
-      while k < nsegs {
-        let seg_from = Array::get(seg_starts, k)
-        let seg_to = if k + 1 < nsegs {
-          Array::get(seg_starts, k + 1)
-        } else {
-          total
-        }
-        let mut z = 0
-        while z < outer_ids {
-          Array::set(cur, z, 0)
-          z = z + 1
-        }
-        let mut i = seg_from
-        while i < seg_to {
-          let sid = Array::get(ctx.action_ids, i)
-          if sid >= 0 && sid < outer_ids && pa_is_dup(Array::get(ctx.actions, i)) {
-            Array::set(cur, sid, Array::get(cur, sid) + 1)
-            if Array::get(cur, sid) > Array::get(maxc, sid) {
-              Array::set(maxc, sid, Array::get(cur, sid))
-            } else {
-              ()
-            }
-          } else {
-            ()
-          }
-          i = i + 1
-        }
-        k = k + 1
-      }
-      // Compact: keep the first max[id] outer-binding dups region-wide (the
-      // consumer counts occurrences per name, so position within the region
-      // is immaterial); every other action is kept as-is.
-      let mut z2 = 0
-      while z2 < outer_ids {
-        Array::set(cur, z2, 0)
-        z2 = z2 + 1
-      }
-      let mut r = a0
-      let mut w = a0
-      while r < total {
-        let sid = Array::get(ctx.action_ids, r)
-        let keep = if sid >= 0 && sid < outer_ids && pa_is_dup(Array::get(ctx.actions, r)) {
-          Array::set(cur, sid, Array::get(cur, sid) + 1)
-          Array::get(cur, sid) <= Array::get(maxc, sid)
-        } else {
-          true
-        }
-        if keep {
-          if w < r {
-            Array::set(ctx.actions, w, Array::get(ctx.actions, r))
-            Array::set(ctx.action_ids, w, Array::get(ctx.action_ids, r))
-          } else {
-            ()
-          }
-          w = w + 1
+/// #1915 mechanism 3 (see the EIf arm of pc_emit): both branches are the
+/// SAME bare identifier, so whichever branch executes performs the same
+/// single owned use — the emission pass walks it once instead of budgeting
+/// one dup per branch.
+fn eif_same_ident_branches(then_e: Expr, else_e: Expr) -> Bool {
+  match then_e {
+    EIdent(tn, _) =>
+    match else_e {
+      EIdent(en, _) => tn == en,
+      _ => false
+    },
+    _ => false
+  }
+}
+
+/// #1915 mechanism 3, match form: every arm body is the SAME bare identifier
+/// and no arm pattern rebinds that name (a rebinding arm would resolve the
+/// mention to its own payload, so the arms would not share one use). Such a
+/// match performs exactly one owned use of that ident at runtime.
+fn ematch_same_ident_arms(arms: Array[(Pat, Expr)]) -> Bool {
+  let mut nm = ""
+  let mut ok = Array::length(arms) > 1
+  let mut i = 0
+  while ok && i < Array::length(arms) {
+    let (p, body) = Array::get(arms, i)
+    match body {
+      EIdent(bn, _) => {
+        if nm == "" {
+          nm = bn
         } else {
           ()
         }
-        r = r + 1
+        if bn != nm {
+          ok = false
+        } else {
+          let pnames: Array[String] = [
+          ]
+          pat_names(p, pnames)
+          if array_contains_str_pctx(pnames, nm) {
+            ok = false
+          } else {
+            ()
+          }
+        }
+      },
+      _ => {
+        ok = false
       }
-      Array::truncate(ctx.actions, w)
-      Array::truncate(ctx.action_ids, w)
-      0
     }
+    i = i + 1
   }
+  ok && nm != ""
 }
 
 fn next_seq_name(ctx: PCtx) -> String {
@@ -1865,49 +1786,57 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
     },
     EIf(cond, then_e, else_e) => {
       pc_emit(ctx, scope, cond)
-      let snap = copy_ints(ctx.remaining)
-      // #1915 mechanism 3: record the pre-branch id/action watermarks so the
-      // two branches' dups for OUTER bindings can be merged to a per-binding
-      // max afterwards (see pe_merge_exclusive_branch_dups).
-      let bd_outer = ctx.next_id
-      let bd_starts = [
-        Array::length(ctx.actions)
-      ]
-      pc_emit(ctx, scope, then_e)
-      // #1100 alloc cut: swap the prefix instead of taking a SECOND copy —
-      // one pass both restores `remaining` to the pre-branch values (what
-      // restore_prefix did) and captures the then-branch's values into
-      // `snap`'s buffer (what the `then_rem` copy was for). Same values in
-      // the same places, one allocation instead of two per `if`; the
-      // branch-snapshot copies were the plan's largest allocation source
-      // on a full-closure compile.
-      let mut sw = 0
-      while sw < Array::length(snap) {
-        let then_v = Array::get(ctx.remaining, sw)
-        Array::set(ctx.remaining, sw, Array::get(snap, sw))
-        Array::set(snap, sw, then_v)
-        sw = sw + 1
-      }
-      Array::push(bd_starts, Array::length(ctx.actions))
-      pc_emit(ctx, scope, else_e)
-      // #705: leave the MIN remaining over both branches. A binding consumed in
-      // one branch (e.g. a param threaded into a ctor in the `then`) but not the
-      // other was previously left at the `else` branch's (higher) remaining, so
-      // the scope-end drop fired on a value the taken branch already moved out —
-      // a double free. Min means a binding consumed on ANY path is not
-      // re-dropped (the non-consuming path leaks one ref, which is safe) instead
-      // of the consuming path double-freeing (crash). Prefix-only (outer ids).
-      // (`snap` holds the THEN branch's values after the swap above.)
-      let mut i = 0
-      while i < Array::length(snap) {
-        if Array::get(snap, i) < Array::get(ctx.remaining, i) {
-          Array::set(ctx.remaining, i, Array::get(snap, i))
-        } else {
-          ()
+      // #1915 mechanism 3: `if c { out } else { out }` — every branch the
+      // SAME bare ident — is ONE owned use at runtime, whichever branch
+      // executes. Walking both branches pushed one PaDup per branch whenever
+      // remaining > 1 at branch entry (exactly what the #706 borrow-retention
+      // bump produces for a loop borrow-use), and codegen realizes every
+      // planned dup unconditionally at the binding's declaration site
+      // (rc_dup_names occurrence count) — the summed budget leaked one owned
+      // object per call for the standard `builder loop + if/else tail`
+      // shape. Walk the use once instead: the final `remaining` is identical
+      // to the old snap/min dance (each branch decremented by exactly one),
+      // only the duplicate sibling dup disappears. Anything but this exact
+      // shape keeps the general per-branch walk below unchanged.
+      if eif_same_ident_branches(then_e, else_e) {
+        pc_emit(ctx, scope, then_e)
+      } else {
+        let snap = copy_ints(ctx.remaining)
+        pc_emit(ctx, scope, then_e)
+        // #1100 alloc cut: swap the prefix instead of taking a SECOND copy —
+        // one pass both restores `remaining` to the pre-branch values (what
+        // restore_prefix did) and captures the then-branch's values into
+        // `snap`'s buffer (what the `then_rem` copy was for). Same values in
+        // the same places, one allocation instead of two per `if`; the
+        // branch-snapshot copies were the plan's largest allocation source
+        // on a full-closure compile.
+        let mut sw = 0
+        while sw < Array::length(snap) {
+          let then_v = Array::get(ctx.remaining, sw)
+          Array::set(ctx.remaining, sw, Array::get(snap, sw))
+          Array::set(snap, sw, then_v)
+          sw = sw + 1
         }
-        i = i + 1
+        pc_emit(ctx, scope, else_e)
+        // #705: leave the MIN remaining over both branches. A binding consumed in
+        // one branch (e.g. a param threaded into a ctor in the `then`) but not the
+        // other was previously left at the `else` branch's (higher) remaining, so
+        // the scope-end drop fired on a value the taken branch already moved out —
+        // a double free. Min means a binding consumed on ANY path is not
+        // re-dropped (the non-consuming path leaks one ref, which is safe) instead
+        // of the consuming path double-freeing (crash). Prefix-only (outer ids).
+        // (`snap` holds the THEN branch's values after the swap above.)
+        let mut i = 0
+        while i < Array::length(snap) {
+          if Array::get(snap, i) < Array::get(ctx.remaining, i) {
+            Array::set(ctx.remaining, i, Array::get(snap, i))
+          } else {
+            ()
+          }
+          i = i + 1
+        }
+        0
       }
-      pe_merge_exclusive_branch_dups(ctx, bd_outer, bd_starts)
     },
     EWhile(cond, body) => {
       pc_emit(ctx, scope, cond)
@@ -2001,6 +1930,43 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           j = j + 1
         }
         0
+      } else if ematch_same_ident_arms(arms) {
+        // #1915 mechanism 3 (see the EIf arm above): every arm body is the
+        // same bare ident, so the match performs exactly one owned use at
+        // runtime — walk the use once (first arm) instead of budgeting one
+        // dup per arm. Pattern bindings are still declared per arm in the
+        // same order as the counting pass (id alignment is load-bearing) and
+        // still get their scope-end handling.
+        let mut a = 0
+        while a < Array::length(arms) {
+          let arm = Array::get(arms, a)
+          let pnames: Array[String] = [
+          ]
+          pat_names(arm.0, pnames)
+          let mut s = scope
+          let pids: Array[Int] = [
+          ]
+          let mut k = 0
+          while k < Array::length(pnames) {
+            let nm = Array::get(pnames, k)
+            let pid = pe_declare(ctx, nm)
+            s = Map::set(s, nm, pid)
+            Array::push(pids, pid)
+            k = k + 1
+          }
+          if a == 0 {
+            pc_emit(ctx, s, arm.1)
+          } else {
+            ()
+          }
+          let mut j = 0
+          while j < Array::length(pids) {
+            pe_scope_end(ctx, Array::get(pids, j), Array::get(pnames, j))
+            j = j + 1
+          }
+          a = a + 1
+        }
+        0
       } else {
         let snap = copy_ints(ctx.remaining)
         // #705: track the MIN remaining over all arms (see EIf). An arm that
@@ -2008,16 +1974,9 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         // at a lower remaining; leaving the LAST arm's (higher) value made the
         // scope-end drop double-free that binding on the arm that consumed it.
         let minrem = copy_ints(snap)
-        // #1915 mechanism 3: same exclusive-branch dup merge as EIf. Arm
-        // pattern bindings are declared inside their segment (id >= bd_outer)
-        // and keep every action.
-        let bd_outer = ctx.next_id
-        let bd_starts: Array[Int] = [
-        ]
         let mut a = 0
         while a < Array::length(arms) {
           let arm = Array::get(arms, a)
-          Array::push(bd_starts, Array::length(ctx.actions))
           restore_prefix(ctx.remaining, snap)
           let pnames: Array[String] = [
           ]
@@ -2051,7 +2010,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           a = a + 1
         }
         restore_prefix(ctx.remaining, minrem)
-        pe_merge_exclusive_branch_dups(ctx, bd_outer, bd_starts)
+        0
       }
     },
     EHandle(hbody, arms) => {

--- a/lib/@vibe/compiler/tests/perceus_rc_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_rc_test.vibe
@@ -467,3 +467,71 @@ test "perceus: multi-alias dups all but the last (elision does not fire when use
   assert(count_drops(plan, "b") == 1)
   assert(count_drops(plan, "t") == 0)
 }
+
+/// #1915 mechanism 3: exclusive if-branches each mentioning an outer binding
+/// must budget the per-binding MAX across branches, not the sum. With the
+/// #706 borrow-retention bump active (the leading borrow keeps remaining > 1
+/// at branch entry) each branch's use used to push its own dup, and codegen
+/// realizes every planned dup unconditionally at the binding site while only
+/// one branch executes -- one leaked object per call for the
+/// `builder loop + if/else tail` shape.
+test "perceus: exclusive if-branch mentions merge to one dup" {
+  // let out = (1, 2); match out { _ => 0 }; if true { out } else { out }
+  let borrow_use = EMatch(EIdent("out", -1), [
+    (PWild, EInt(0))
+  ])
+  let tail = EIf(EBool(true), EIdent("out", -1), EIdent("out", -1))
+  let body = ELet("out", ETuple([
+    EInt(1),
+    EInt(2)
+  ]), ESeq(borrow_use, tail), -1)
+  let plan = build_perceus_plan(body)
+  inspect(count_dups(plan, "out"), "1")
+  inspect(count_drops(plan, "out"), "1")
+}
+
+/// #1915 mechanism 3, match form: the same merge applies across match arms.
+test "perceus: exclusive match-arm mentions merge to one dup" {
+  // let out = (1, 2); match out { _ => 0 }; match 1 { p => out, _ => out }
+  let borrow_use = EMatch(EIdent("out", -1), [
+    (PWild, EInt(0))
+  ])
+  let tail = EMatch(EInt(1), [
+    (PBind("p"), EIdent("out", -1)),
+    (PWild, EIdent("out", -1))
+  ])
+  let body = ELet("out", ETuple([
+    EInt(1),
+    EInt(2)
+  ]), ESeq(borrow_use, tail), -1)
+  let plan = build_perceus_plan(body)
+  inspect(count_dups(plan, "out"), "1")
+  inspect(count_drops(plan, "out"), "1")
+}
+
+/// #1915 mechanism 3 guard: the merge keys on binding IDs, so a branch-local
+/// shadow of the outer name keeps its own dup budget, and the outer binding
+/// keeps its else-branch dup.
+test "perceus: branch-local shadow keeps its dups through the merge" {
+  // let out = (1, 2); match out { _ => 0 };
+  // if true { let out = (3, 4); (out, out) } else { out }
+  let borrow_use = EMatch(EIdent("out", -1), [
+    (PWild, EInt(0))
+  ])
+  let shadow_body = ETuple([
+    EIdent("out", -1),
+    EIdent("out", -1)
+  ])
+  let then_e = ELet("out", ETuple([
+    EInt(3),
+    EInt(4)
+  ]), shadow_body, -1)
+  let tail = EIf(EBool(true), then_e, EIdent("out", -1))
+  let body = ELet("out", ETuple([
+    EInt(1),
+    EInt(2)
+  ]), ESeq(borrow_use, tail), -1)
+  let plan = build_perceus_plan(body)
+  // One dup for the shadow's double use + one for the outer else mention.
+  inspect(count_dups(plan, "out"), "2")
+}

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -4434,8 +4434,8 @@ lk_result="$(printf '%s' "$lk_json" | sed -n 's/.*"result":\([0-9]*\).*/\1/p')"
 if [ -z "$lk_used" ]; then
   echo "[compiler-gate] FAIL: could not measure rc_reclaim_leak heap ($lk_json)" >&2; exit 1
 fi
-if [ "$lk_result" != "3200340000" ]; then
-  echo "[compiler-gate] FAIL: rc_reclaim_leak wrong result $lk_result (want 3200340000)" >&2; exit 1
+if [ "$lk_result" != "3200400000" ]; then
+  echo "[compiler-gate] FAIL: rc_reclaim_leak wrong result $lk_result (want 3200400000)" >&2; exit 1
 fi
 if [ "$lk_used" -ge 2000 ]; then
   echo "[compiler-gate] FAIL: rc_reclaim_leak heap_used=$lk_used >= 2000 (RC reclamation regressed; ~800000 == full leak)" >&2; exit 1


### PR DESCRIPTION
## Summary

#1915 R6 — the third and last mechanism behind "builder-shaped returns are never dropped" (the first two landed in #1932). After #1932, the `builder loop + if/else tail` shape still leaked one owned object per call:

```vibe
fn loop_if(n: Int) -> Array[Int] {
  let out: Array[Int] = []
  let mut i = 0
  while i < n {
    Array::push(out, i)   // loop borrow-use → #706 borrow-retention bump
    i = i + 1
  }
  if n >= 0 { out } else { out }   // each branch budgeted its OWN dup
}
```

The perceus emission pass restores `remaining` per if/match branch (the #705 min-merge), but never reconciles the **actions**: with `remaining > 1` at branch entry — exactly what the #706 borrow-retention bump produces for a loop borrow-use — every exclusive branch pushed its own `PaDup` for the same outer binding. Codegen realizes every planned dup for a name **unconditionally at the binding's declaration site** (`rc_dup_names` occurrence count), while only one branch executes at runtime. The emitted wat shows two back-to-back guarded `rc_dup(out)` at the binding, one transfer + one drop at the tail, one caller drop — net +1 reference per call.

## Fix (narrow by design)

When **every branch of an `EIf` (every arm of a multi-arm `EMatch`) is the SAME bare identifier**, the construct performs exactly one owned use at runtime, whichever branch executes — so the emission pass walks that use **once** instead of budgeting one dup per branch. The final `remaining` is identical to the old per-branch snap/min dance (each branch decremented by exactly one); only the duplicate sibling dups disappear. For `EMatch`, arm pattern bindings are still declared per arm in counting-pass order (id alignment with `pc_count` is load-bearing) and keep their scope-end handling, and an arm whose pattern rebinds the ident disqualifies the shape.

Anything but this exact shape keeps the existing per-branch behavior, unchanged.

**Why not the general per-binding max-merge:** the first cut of this PR (`460e8421c`, replaced by `61b490316`) merged all exclusive-branch dup budgets to a per-binding max. It fixed the leak but under-provisioned some path in the checker/normalize sources — CI unit shards trapped with a freed-value dup inside `railway_rw` (free-list corruption at an EFn-rebuild's field dups) while the compiler gate stayed green. A broad accounting change whose failure mode is a double-free is the wrong trade; the narrow structural fix covers the shape that actually leaks (P0-adjacent: silent, unbounded) with no blast radius. The remaining general over-provision is leak-direction only and stays tracked on #1915's thread.

## Measured (stage2, RC lane, ×100 calls, heap delta)

| shape | before | after |
|---|---:|---:|
| builder loop + if/else tail (50 elems) | 60,400 (1 obj/call) | 604 (1 bounded residual) |
| builder loop + if/else tail (1000 elems) | 828,400 | 0 |
| builder loop + bare tail | 0 (fixed in #1932) | 0 |

## Validation

- `seed → stage1 → stage2 → stage3` selfbuild: **fixpoint holds** (stage2 == stage3, `e7754a8872c0`)
- `scripts/unit_test_runner.sh` full local run: **664/664 files pass** — including the three checked-artifact tests that trapped on the first cut
- `scripts/compiler_gate.sh` full run green, including the extended 40d RC reclamation guard
- Plan-level regression tests in `perceus_rc_test.vibe`: if-form and match-form merge to one dup; shadow guard proving a branch-local shadow keeps its own dup budget
- Gate 40d fixture `rc_reclaim_leak_test.vibe` gains the loop + if/else builder (expected result 3200340000 → 3200400000; measured `heap_used` 508 B at N=20000, bound 2000)
- CI: 19/19 checks green on `61b490316`; perf report all ±0

Closes the last open mechanism on #1915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ