### PR TITLE
Detect same-named traits defined differently by two packages (#1910)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1314,6 +1314,18 @@ import . { helper }          // own directory's index (same resolution)
 // qualified access is an independent mechanism and remains.
 ```
 
+### Same-named traits from two packages are rejected (#1910)
+
+When one compile unit can see two **different** `trait` definitions with the
+same name — imported explicitly, or pulled in implicitly because an imported
+value carries a `[T: Trait]` bound — the checker reports
+`trait 'Hash' has two different definitions: '<site1>' and '<site2>'` instead
+of letting import order pick one silently. The fix is in the message: alias
+one side (`import ./a.vibe { trait Hash as TheirHash }`) or import only one.
+The *same* definition reached through re-export paths is not a conflict, and
+two different traits forced onto one local name via explicit aliases is the
+separate `ambiguous trait import alias` error.
+
 ### Qualified names
 
 どの記号が識別子の一部になるかは文脈で決まる。

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -76,7 +76,13 @@ import @vibe/graph {
 }
 
 import @vibe/compiler/syntax {
-  lex_with_offsets, lex_with_offsets_recovering, offset_to_line_col, parse_program_located, parse_program_recovering, token_to_string
+  lex_with_offsets,
+  lex_with_offsets_recovering,
+  offset_to_line_col,
+  parse_program_located,
+  parse_program_recovering,
+  print_type_expr,
+  token_to_string
 }
 
 import @vibe/compiler/runtime/eval_loader {
@@ -340,11 +346,11 @@ fn trait_projection_add_mapping(mappings: Array[(String, String)], canonical: St
 /// Keep these claims across every import in a module: otherwise two unrelated
 /// traits imported as the same local name would leave one definition and the
 /// other's impls/methods in the TypeEnv, depending on import order.
-fn trait_projection_claim_local(claims: Array[(String, String, Bool)], canonical: String) -> Option[String] {
+fn trait_projection_claim_local(claims: Array[(String, String, Bool, String)], canonical: String) -> Option[String] {
   let mut i = 0
   let mut found = None
   while i < Array::length(claims) && found == None {
-    let (candidate_canonical, local_name, _) = Array::get(claims, i)
+    let (candidate_canonical, local_name, _, _) = Array::get(claims, i)
     if candidate_canonical == canonical {
       found = Some(local_name)
     } else {
@@ -354,13 +360,13 @@ fn trait_projection_claim_local(claims: Array[(String, String, Bool)], canonical
   found
 }
 
-fn trait_projection_claim_owner(claims: Array[(String, String, Bool)], local_name: String) -> Option[(String, Bool)] {
+fn trait_projection_claim_owner(claims: Array[(String, String, Bool, String)], local_name: String) -> Option[(String, Bool, String)] {
   let mut i = 0
   let mut found = None
   while i < Array::length(claims) && found == None {
-    let (canonical, candidate_local, explicit_alias) = Array::get(claims, i)
+    let (canonical, candidate_local, explicit_alias, fingerprint) = Array::get(claims, i)
     if candidate_local == local_name {
-      found = Some((canonical, explicit_alias))
+      found = Some((canonical, explicit_alias, fingerprint))
     } else {
       i = i + 1
     }
@@ -368,28 +374,109 @@ fn trait_projection_claim_owner(claims: Array[(String, String, Bool)], local_nam
   found
 }
 
-fn trait_projection_claim_mappings(claims: Array[(String, String, Bool)], resolved: String, mappings: Array[(String, String)], unresolved: Array[String]) -> Unit {
+/// Serialize a trait's definition shape (auto marker, params, supers, method
+/// signatures, per-method generic bounds) so two same-named traits imported
+/// from different modules can be compared for identity. Equal fingerprints
+/// mean one definition seen through re-export paths; differing fingerprints
+/// mean two distinct traits sharing a spelling (#1910), which must not be
+/// resolved silently by import order.
+fn trait_projection_def_fingerprint(env: TypeEnv, name: String) -> String {
+  match env {
+    EnvEmpty => "",
+    EnvBind(_, _, rest) => trait_projection_def_fingerprint(rest, name),
+    EnvTraitDef(candidate, supers, is_auto, methods, rest, params, method_gens) => if candidate == name {
+      let mut out = if is_auto {
+        "auto"
+      } else {
+        "trait"
+      }
+      let mut i = 0
+      while i < Array::length(params) {
+        out = String::concat(out, String::concat(";param=", Array::get(params, i)))
+        i = i + 1
+      }
+      i = 0
+      while i < Array::length(supers) {
+        out = String::concat(out, String::concat(";super=", Array::get(supers, i)))
+        i = i + 1
+      }
+      i = 0
+      while i < Array::length(methods) {
+        let (mname, args, ret) = Array::get(methods, i)
+        out = String::concat(out, String::concat(";method=", mname))
+        let mut j = 0
+        while j < Array::length(args) {
+          out = String::concat(out, String::concat(":", print_type_expr(Array::get(args, j))))
+          j = j + 1
+        }
+        out = String::concat(out, String::concat("->", print_type_expr(ret)))
+        i = i + 1
+      }
+      i = 0
+      while i < Array::length(method_gens) {
+        let (mname, gparams, bounds) = Array::get(method_gens, i)
+        out = String::concat(out, String::concat(";gen=", mname))
+        let mut j = 0
+        while j < Array::length(gparams) {
+          out = String::concat(out, String::concat(":", Array::get(gparams, j)))
+          j = j + 1
+        }
+        j = 0
+        while j < Array::length(bounds) {
+          let (bparam, labels) = Array::get(bounds, j)
+          out = String::concat(out, String::concat(";bound=", bparam))
+          let mut k = 0
+          while k < Array::length(labels) {
+            out = String::concat(out, String::concat(":", Array::get(labels, k)))
+            k = k + 1
+          }
+          j = j + 1
+        }
+        i = i + 1
+      }
+      out
+    } else {
+      trait_projection_def_fingerprint(rest, name)
+    },
+    EnvTraitImpl(_, _, rest) => trait_projection_def_fingerprint(rest, name),
+    EnvMutCell(_, _, rest) => trait_projection_def_fingerprint(rest, name),
+    EnvTraitImplGen(_, _, _, _, rest) => trait_projection_def_fingerprint(rest, name),
+    EnvTypeDefs(_, _, rest) => trait_projection_def_fingerprint(rest, name),
+    EnvFlat(_) => "",
+    EnvCached(_, _, rest) => trait_projection_def_fingerprint(rest, name)
+  }
+}
+
+fn trait_projection_claim_mappings(claims: Array[(String, String, Bool, String)], resolved: String, dep_env: TypeEnv, mappings: Array[(String, String)], unresolved: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(mappings) {
     let (source_name, local_name) = Array::get(mappings, i)
     let canonical = String::concat(String::concat(resolved, "::"), source_name)
     let explicit_alias = source_name != local_name
+    let fingerprint = trait_projection_def_fingerprint(dep_env, source_name)
     match (trait_projection_claim_local(claims, canonical), trait_projection_claim_owner(claims, local_name)) {
       (Some(existing), _) => if existing != local_name {
         Array::push(unresolved, String::concat(String::concat(String::concat("ambiguous trait import '", canonical), "': aliases '"), String::concat(existing, String::concat("' and '", String::concat(local_name, "'")))))
       } else {
         ()
       },
-      (None, Some((owner, owner_explicit))) => if owner != canonical && (owner_explicit || explicit_alias) {
+      (None, Some((owner, owner_explicit, owner_fingerprint))) => if owner != canonical && (owner_explicit || explicit_alias) {
         // Same-spelled, unaliased traits retain the language's historical
         // name-based identity across re-export modules. An explicit alias is
         // different: merging two canonical names through it would silently
         // mix their impl and method authority.
         Array::push(unresolved, String::concat(String::concat(String::concat("ambiguous trait import alias '", local_name), "': used for '"), String::concat(owner, String::concat("' and '", String::concat(canonical, "'")))))
       } else {
-        Array::push(claims, (canonical, local_name, explicit_alias))
+        if owner != canonical && owner_fingerprint != fingerprint {
+          // #1910: unaliased name-based identity is only safe when both
+          // spellings are the same definition. Two packages defining a
+          // same-named trait differently must not be merged by import order.
+          Array::push(unresolved, String::concat(String::concat(String::concat("trait '", local_name), "' has two different definitions: '"), String::concat(owner, String::concat("' and '", String::concat(canonical, String::concat("' — alias one with 'trait ", String::concat(local_name, " as <NewName>' or import only one")))))))
+        } else {
+          Array::push(claims, (canonical, local_name, explicit_alias, fingerprint))
+        }
       },
-      (None, None) => Array::push(claims, (canonical, local_name, explicit_alias))
+      (None, None) => Array::push(claims, (canonical, local_name, explicit_alias, fingerprint))
     }
     i = i + 1
   }
@@ -948,7 +1035,7 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
   out
 }
 
-fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String, Bool)]) -> TypeEnv {
+fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[(String, Option[String])], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String, Bool, String)]) -> TypeEnv {
   let cached = lookup_env_cache(cache, resolved)
   let dep_env = match cached {
     Some(e) => e,
@@ -959,7 +1046,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
   // Explicit trait aliases must be known before values are bound: a selected
   // value can mention the trait before its `trait X as Local` row appears.
   let trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, unresolved)
-  trait_projection_claim_mappings(trait_claims, resolved, trait_mappings, unresolved)
+  trait_projection_claim_mappings(trait_claims, resolved, dep_env, trait_mappings, unresolved)
   // Whether the dependency was CHECKED, not whether it happens to bind any
   // values. A module that exports only types or only traits is checked and
   // cached, and its flat value environment is legitimately empty -- deriving

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -381,10 +381,46 @@ fn trait_projection_claim_owner(claims: Array[(String, String, Bool, String)], l
 /// mean two distinct traits sharing a spelling (#1910), which must not be
 /// resolved silently by import order.
 fn trait_projection_def_fingerprint(env: TypeEnv, name: String) -> String {
-  match env {
+  trait_projection_def_fingerprint_scan(env, env, name, array_empty())
+}
+
+/// Referenced trait labels (supers, method-generic bounds) are compared by
+/// their own definition shape, not by spelling: a facade that re-exports
+/// `Child` while aliasing its supertrait publishes `Child: P`, and that
+/// spelling difference must not read as two different `Child` definitions.
+/// A label already on the traversal path is emitted as `rec@<position>` so
+/// repeated references stay position-stable; a label with no definition in
+/// the environment keeps its spelling (`?<label>`), which is canonical
+/// exactly because it cannot be projected under an alias.
+fn trait_projection_ref_fingerprint(full: TypeEnv, label: String, visited: Array[String]) -> String {
+  let mut idx = 0
+  let mut found = -1
+  while idx < Array::length(visited) {
+    if Array::get(visited, idx) == label {
+      found = idx
+      idx = Array::length(visited)
+    } else {
+      idx = idx + 1
+    }
+  }
+  if found >= 0 {
+    String::concat("rec@", __to_string(found))
+  } else {
+    let sub = trait_projection_def_fingerprint_scan(full, full, label, visited)
+    if sub == "" {
+      String::concat("?", label)
+    } else {
+      String::concat("(", String::concat(sub, ")"))
+    }
+  }
+}
+
+fn trait_projection_def_fingerprint_scan(cur: TypeEnv, full: TypeEnv, name: String, visited: Array[String]) -> String {
+  match cur {
     EnvEmpty => "",
-    EnvBind(_, _, rest) => trait_projection_def_fingerprint(rest, name),
+    EnvBind(_, _, rest) => trait_projection_def_fingerprint_scan(rest, full, name, visited),
     EnvTraitDef(candidate, supers, is_auto, methods, rest, params, method_gens) => if candidate == name {
+      Array::push(visited, name)
       let mut out = if is_auto {
         "auto"
       } else {
@@ -397,7 +433,7 @@ fn trait_projection_def_fingerprint(env: TypeEnv, name: String) -> String {
       }
       i = 0
       while i < Array::length(supers) {
-        out = String::concat(out, String::concat(";super=", Array::get(supers, i)))
+        out = String::concat(out, String::concat(";super=", trait_projection_ref_fingerprint(full, Array::get(supers, i), visited)))
         i = i + 1
       }
       i = 0
@@ -427,7 +463,7 @@ fn trait_projection_def_fingerprint(env: TypeEnv, name: String) -> String {
           out = String::concat(out, String::concat(";bound=", bparam))
           let mut k = 0
           while k < Array::length(labels) {
-            out = String::concat(out, String::concat(":", Array::get(labels, k)))
+            out = String::concat(out, String::concat(":", trait_projection_ref_fingerprint(full, Array::get(labels, k), visited)))
             k = k + 1
           }
           j = j + 1
@@ -436,14 +472,14 @@ fn trait_projection_def_fingerprint(env: TypeEnv, name: String) -> String {
       }
       out
     } else {
-      trait_projection_def_fingerprint(rest, name)
+      trait_projection_def_fingerprint_scan(rest, full, name, visited)
     },
-    EnvTraitImpl(_, _, rest) => trait_projection_def_fingerprint(rest, name),
-    EnvMutCell(_, _, rest) => trait_projection_def_fingerprint(rest, name),
-    EnvTraitImplGen(_, _, _, _, rest) => trait_projection_def_fingerprint(rest, name),
-    EnvTypeDefs(_, _, rest) => trait_projection_def_fingerprint(rest, name),
+    EnvTraitImpl(_, _, rest) => trait_projection_def_fingerprint_scan(rest, full, name, visited),
+    EnvMutCell(_, _, rest) => trait_projection_def_fingerprint_scan(rest, full, name, visited),
+    EnvTraitImplGen(_, _, _, _, rest) => trait_projection_def_fingerprint_scan(rest, full, name, visited),
+    EnvTypeDefs(_, _, rest) => trait_projection_def_fingerprint_scan(rest, full, name, visited),
     EnvFlat(_) => "",
-    EnvCached(_, _, rest) => trait_projection_def_fingerprint(rest, name)
+    EnvCached(_, _, rest) => trait_projection_def_fingerprint_scan(rest, full, name, visited)
   }
 }
 

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -729,6 +729,37 @@ test "db_typecheck_fs: one trait reached through a re-export module is not a con
   }
 }
 
+test "db_typecheck_fs: a re-export that aliases the supertrait is still the same trait" {
+  // Codex review on PR #1965: the facade publishes `Child: P` after
+  // `trait Parent as P`, so comparing supers by spelling would misread the
+  // re-exported `Child` as a second, different definition. References are
+  // compared by their own definition shape instead.
+  let base_path = "/tmp/vibe_compiler_trait_reexport_super_alias_base.vibe"
+  let facade_path = "/tmp/vibe_compiler_trait_reexport_super_alias_facade.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_reexport_super_alias_main.vibe"
+  let base_src = "export trait Parent { pa(Self) -> Int }\nexport trait Child: Parent { ch(Self) -> Int }\nimpl Parent for Int { pa(self) -> Int { 1 } }\nimpl Child for Int { ch(self) -> Int { 2 } }"
+  let facade_src = "import ./vibe_compiler_trait_reexport_super_alias_base.vibe { trait Parent as P, trait Child }\nexport { Child }"
+  let main_src = "import ./vibe_compiler_trait_reexport_super_alias_base.vibe { trait Child }\nimport ./vibe_compiler_trait_reexport_super_alias_facade.vibe { trait Child }\nexport fn use_it[T: Child](x: T) -> Int { let _ = x; 0 }\nexport let result = use_it(1)"
+  Fs::write_bytes(base_path, string_to_bytes(base_src))
+  Fs::write_bytes(facade_path, string_to_bytes(facade_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let base_fp = build_test_fingerprint(base_src, array_empty())
+  let facade_fp = build_test_fingerprint(facade_src, [
+    (base_path, base_fp)
+  ])
+  remove_typecheck_fs_cache(base_path, base_src, base_fp)
+  remove_typecheck_fs_cache(facade_path, facade_src, facade_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (base_path, base_fp),
+    (facade_path, facade_fp)
+  ]))
+  let checked = db_typecheck_fs(db_set_source(db_set_source(db_set_source(db_new(), base_path, base_src), facade_path, facade_src), main_path, main_src), main_path)
+  match db_check_env(checked, main_path) {
+    Some(env) => assert(trait_defined(env, "Child")),
+    None => assert(false)
+  }
+}
+
 test "db_typecheck_fs: source update bypasses current-run cache" {
   let path = "/tmp/vibe_compiler_type_db_fs_source_update.vibe"
   let source1 = "export let value = 1"

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -644,6 +644,91 @@ test "db_typecheck_fs: duplicate trait aliases are rejected as ambiguous" {
   assert(String::contains(error, "ambiguous trait import 'Marker'"))
 }
 
+test "db_typecheck_fs: same-named traits with different definitions from two packages are rejected" {
+  let first_path = "/tmp/vibe_compiler_trait_dup_def_first.vibe"
+  let second_path = "/tmp/vibe_compiler_trait_dup_def_second.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_dup_def_main.vibe"
+  let first_src = "export trait Hash { hash(Self) -> Int }\nimpl Hash for Int { hash(self) -> Int { self } }"
+  let second_src = "export trait Hash"
+  let main_src = "import ./vibe_compiler_trait_dup_def_first.vibe { trait Hash }\nimport ./vibe_compiler_trait_dup_def_second.vibe { trait Hash }"
+  Fs::write_bytes(first_path, string_to_bytes(first_src))
+  Fs::write_bytes(second_path, string_to_bytes(second_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let first_fp = build_test_fingerprint(first_src, array_empty())
+  let second_fp = build_test_fingerprint(second_src, array_empty())
+  remove_typecheck_fs_cache(first_path, first_src, first_fp)
+  remove_typecheck_fs_cache(second_path, second_src, second_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (first_path, first_fp),
+    (second_path, second_fp)
+  ]))
+  let error = handle {
+    let db = db_set_source(db_set_source(db_set_source(db_new(), first_path, first_src), second_path, second_src), main_path, main_src)
+    let _ = db_typecheck_fs(db, main_path)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(String::contains(error, "trait 'Hash' has two different definitions"))
+}
+
+test "db_typecheck_fs: differing traits selected through value bounds are rejected" {
+  // The #1844 drift shape: neither trait is imported explicitly -- both are
+  // pulled in implicitly because imported values carry `[T: Hash]` bounds.
+  let first_path = "/tmp/vibe_compiler_trait_dup_bound_first.vibe"
+  let second_path = "/tmp/vibe_compiler_trait_dup_bound_second.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_dup_bound_main.vibe"
+  let first_src = "export trait Hash { hash(Self) -> Int }\nimpl Hash for Int { hash(self) -> Int { self } }\nexport fn by_hash[T: Hash](x: T) -> Int { let _ = x; 1 }"
+  let second_src = "export trait Hash\nimpl Hash for Int\nexport fn also_hash[T: Hash](x: T) -> Int { let _ = x; 2 }"
+  let main_src = "import ./vibe_compiler_trait_dup_bound_first.vibe { by_hash }\nimport ./vibe_compiler_trait_dup_bound_second.vibe { also_hash }"
+  Fs::write_bytes(first_path, string_to_bytes(first_src))
+  Fs::write_bytes(second_path, string_to_bytes(second_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let first_fp = build_test_fingerprint(first_src, array_empty())
+  let second_fp = build_test_fingerprint(second_src, array_empty())
+  remove_typecheck_fs_cache(first_path, first_src, first_fp)
+  remove_typecheck_fs_cache(second_path, second_src, second_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (first_path, first_fp),
+    (second_path, second_fp)
+  ]))
+  let error = handle {
+    let db = db_set_source(db_set_source(db_set_source(db_new(), first_path, first_src), second_path, second_src), main_path, main_src)
+    let _ = db_typecheck_fs(db, main_path)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(String::contains(error, "trait 'Hash' has two different definitions"))
+}
+
+test "db_typecheck_fs: one trait reached through a re-export module is not a conflict" {
+  let base_path = "/tmp/vibe_compiler_trait_reexport_base.vibe"
+  let facade_path = "/tmp/vibe_compiler_trait_reexport_facade.vibe"
+  let main_path = "/tmp/vibe_compiler_trait_reexport_main.vibe"
+  let base_src = "export trait Marker { tag(Self) -> Int }\nimpl Marker for Int { tag(self) -> Int { 1 } }"
+  let facade_src = "import ./vibe_compiler_trait_reexport_base.vibe { trait Marker }\nexport { Marker }"
+  let main_src = "import ./vibe_compiler_trait_reexport_base.vibe { trait Marker }\nimport ./vibe_compiler_trait_reexport_facade.vibe { trait Marker }\nexport fn use_it[T: Marker](x: T) -> Int { let _ = x; 0 }\nexport let result = use_it(1)"
+  Fs::write_bytes(base_path, string_to_bytes(base_src))
+  Fs::write_bytes(facade_path, string_to_bytes(facade_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let base_fp = build_test_fingerprint(base_src, array_empty())
+  let facade_fp = build_test_fingerprint(facade_src, [
+    (base_path, base_fp)
+  ])
+  remove_typecheck_fs_cache(base_path, base_src, base_fp)
+  remove_typecheck_fs_cache(facade_path, facade_src, facade_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (base_path, base_fp),
+    (facade_path, facade_fp)
+  ]))
+  let checked = db_typecheck_fs(db_set_source(db_set_source(db_set_source(db_new(), base_path, base_src), facade_path, facade_src), main_path, main_src), main_path)
+  match db_check_env(checked, main_path) {
+    Some(env) => assert(trait_defined(env, "Marker")),
+    None => assert(false)
+  }
+}
+
 test "db_typecheck_fs: source update bypasses current-run cache" {
   let path = "/tmp/vibe_compiler_type_db_fs_source_update.vibe"
   let source1 = "export let value = 1"


### PR DESCRIPTION
## Summary

Closes #1910 — the recurrence-prevention check requested by #1844 item 3.

Unaliased same-named traits imported from different modules were merged by name-based identity. That is only safe when both spellings are the *same* definition seen through re-export paths; two packages defining a same-named trait **differently** (the #1844 drift: a marker `trait Hash` vs @vibe/core's method-bearing one) were resolved silently by whichever import came first — a silent-wrong outcome by the project's own taxonomy.

## Change

`lib/@vibe/compiler/runtime/typecheck_fs.vibe` — the trait projection claims (#1549) now carry a **definition fingerprint** (auto marker, params, supers, method signatures via `print_type_expr`, per-method generic bounds), computed from the dependency's `EnvTraitDef` node at claim time. When an unaliased claim collides with a different canonical source:

- equal fingerprints → historical re-export behavior is kept (one definition, several paths — no conflict);
- differing fingerprints → new diagnostic naming both definition sites, with the fix in the message:

```
trait 'Hash' has two different definitions: '<site1>' and '<site2>' — alias one with 'trait Hash as <NewName>' or import only one
```

The existing `ambiguous trait import` / `ambiguous trait import alias` errors are unchanged.

## Coverage

New tests in `lib/@vibe/compiler/tests/type_db_cross_module_test.vibe`:

| case | expectation |
|---|---|
| explicit `{ trait Hash }` imports of two differing definitions | rejected with the new diagnostic |
| traits selected implicitly through imported values' `[T: Hash]` bounds (the exact #1844 shape) | rejected with the new diagnostic |
| one trait reached both directly and through a re-export facade | no conflict, checks clean |

`docs/cheatsheet.md` documents the diagnostic in the Module System section.

## Verification

- `scripts/compiler_gate.sh` (seed → stage1 → stage2 → stage3 fixpoint + full test suite) run locally on the rebuilt stage2.
- Both edited `.vibe` files formatted with `scripts/vibe_fmt.sh` (CI `vibe-fmt-check` is required).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdLViMpRmEwsqxYMCzh8uC)_