### PR TITLE
Execute legacy runtime fixture expectations in the unit lane

### DIFF
--- a/fixtures/runtime/http_p3_client_test.vibe
+++ b/fixtures/runtime/http_p3_client_test.vibe
@@ -7,5 +7,3 @@ let status = Http::response_status(h)
 Http::close(h)
 
 status
-
-__DATA__

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,12 +90,14 @@ The selfhost `vibe` subcommands as scripts (used by `pkf run` + tests).
   was paid down in the 2026-07-28 bulk reformat). `vibe_fmt_apply.sh` (`pkf
   run fmt`) is the write-mode counterpart that applies the formatter across
   the tree; this script only lints.
-- `check_fixture_execution.sh` (+ `fixture_execution_exceptions.txt`) — every
-  `fixtures/**/*.vibe` carrying `test` blocks must be run by some lane (the
-  `unit_test_runner.sh` glob, a `fixtures/typecheck/expected.tsv` verdict row,
-  or a gate that names it) or be listed with a reason. Kills the state where a
-  fixture looks like coverage and is executed by nothing (#1587). Pure shell,
-  ~2s, runs at the top of `compiler_gate.sh` before the selfbuild.
+- `check_fixture_execution.sh` (+ `fixture_execution_exceptions.txt`,
+  `runtime_fixture_debt.tsv`) — every `fixtures/**/*.vibe` carrying `test`
+  blocks or a runtime `__DATA__.last` expectation must be run by some lane or
+  listed with a reason. `unit_test_runner.sh` regenerates the non-debt runtime
+  fixtures as ordinary `*_test.vibe` files on every inventory/run; new
+  expectations are active by default. Kills the state where a fixture looks
+  like coverage and is executed by nothing (#1587, #1855). Runs at the top of
+  `compiler_gate.sh` before the selfbuild.
 - `lint_architecture_debt.sh` (+ `architecture_debt_{rules.tsv,allowlist.txt}`),
   `lint_tracked_experiment_names.sh`
 - `verify_rc.sh`, `rc_corpus_parity.sh`, `rc_cutover_readiness.sh`
@@ -107,7 +109,10 @@ The selfhost `vibe` subcommands as scripts (used by `pkf run` + tests).
 - `build_release_assets.sh`, `build_wasi_http_p3_full_adapter.sh`, `precompile.sh`
 
 ## Generators / codegen data
-- `generate_runtime_fixture_tests.mjs`, `emit_async_lift_fixture.sh`
+- `generate_runtime_fixture_tests.mjs` — turns live `__DATA__.last` fixtures
+  into generated unit tests; `VIBE_RUNTIME_FIXTURE_INCLUDE_DEBT=1` makes list
+  mode include the explicitly reasoned debt inventory for audits.
+- `emit_async_lift_fixture.sh`
 
 ## Misc infra
 - `cache_clean.sh`, `flaker_run.sh` (+ `_test`), `measure_heap.mjs`

--- a/scripts/check_fixture_execution.sh
+++ b/scripts/check_fixture_execution.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Fixture execution coverage check (#1587).
 #
-# THE INVARIANT: a fixture that carries `test` blocks either runs somewhere, or
-# is listed with a reason. There is no third state.
+# THE INVARIANT: a fixture that carries `test` blocks or a runtime
+# `__DATA__.last` expectation either runs somewhere, or is listed with a
+# reason. There is no third state.
 #
 # The third state is what this exists to kill. Gates used to enumerate their
 # test-block fixtures by hand (`for fx in \` + a backslash-continued list), so
@@ -74,6 +75,24 @@ TEST_BLOCK_RE='^[[:space:]]*test([[:space:]]+"|[[:space:]]*\{|[[:space:]]+with[[
 
 # --- the accounted-for sets -------------------------------------------------
 unit_list="$(bash scripts/unit_test_runner.sh --list)"
+
+# #1855: the generator owns the exhaustive classification of runtime
+# expectations. Default list mode returns active tests; INCLUDE_DEBT returns
+# the complete candidate set and, in both modes, validates every debt row
+# (format, uniqueness, and non-staleness). New fixtures are active by default.
+runtime_fixture_active="$(VIBE_RUNTIME_FIXTURE_LIST_ONLY=1 \
+  VIBE_RUNTIME_FIXTURE_INVENTORY=active \
+  VIBE_RUNTIME_FIXTURE_INCLUDE_DEBT=0 \
+  VIBE_RUNTIME_FIXTURE_LIMIT=0 \
+  node scripts/generate_runtime_fixture_tests.mjs)"
+runtime_fixture_all="$(VIBE_RUNTIME_FIXTURE_LIST_ONLY=1 \
+  VIBE_RUNTIME_FIXTURE_INVENTORY=all \
+  VIBE_RUNTIME_FIXTURE_INCLUDE_DEBT=1 \
+  VIBE_RUNTIME_FIXTURE_LIMIT=0 \
+  node scripts/generate_runtime_fixture_tests.mjs)"
+runtime_active_count="$(printf '%s\n' "$runtime_fixture_active" | grep -c . || true)"
+runtime_all_count="$(printf '%s\n' "$runtime_fixture_all" | grep -c . || true)"
+runtime_debt_count=$((runtime_all_count - runtime_active_count))
 
 exceptions=""
 if [ -f "$EXCEPTIONS_FILE" ]; then
@@ -192,4 +211,4 @@ if [ "$violations" -gt 0 ]; then
   echo "[fixture-execution] $violations violation(s)" >&2
   exit 1
 fi
-echo "[fixture-execution] ok ($accounted test-block fixtures, all accounted for)"
+echo "[fixture-execution] ok ($accounted test-block fixtures; $runtime_active_count runtime expectations active, $runtime_debt_count reasoned debt; all accounted for)"

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -64,6 +64,7 @@ bash scripts/check_inline_builtin_capture.sh
 # #1587: a fixture with `test` blocks that no lane runs is coverage that does
 # not exist. Pure shell + grep (~2s), so it runs before the multi-minute
 # selfbuild rather than after it.
+node scripts/generate_runtime_fixture_tests.test.mjs
 bash scripts/check_fixture_execution.sh
 
 # #1821 / Codex review on #1822: the token formatter may conservatively miss

--- a/scripts/generate_runtime_fixture_tests.mjs
+++ b/scripts/generate_runtime_fixture_tests.mjs
@@ -15,34 +15,46 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { createHash } from "node:crypto";
 
 const ROOT = process.cwd();
-const GENERATED_DIR = path.join(
+const GENERATED_DIR = path.resolve(
   ROOT,
-  "lib/@vibe/compiler/_generated_runtime_fixtures",
+  process.env.VIBE_RUNTIME_FIXTURE_OUTPUT_DIR ||
+    "lib/@vibe/compiler/_generated_runtime_fixtures",
 );
+const DEBT_FILE = path.join(ROOT, "scripts/runtime_fixture_debt.tsv");
 
 // ---------------------------------------------------------------------------
 // Fixture discovery
 // ---------------------------------------------------------------------------
 
-/** Parse the __DATA__ JSON from a fixture file. Returns null if invalid. */
-function parseFixtureData(content) {
-  const idx = content.indexOf("__DATA__");
-  if (idx < 0) return null;
-  const dataStr = content.substring(idx + "__DATA__".length).trim();
+/** Find an exact __DATA__ marker line, independently of parsing its payload. */
+function fixtureDataMarker(content) {
+  const match = /^__DATA__[ \t]*\r?$/m.exec(content);
+  if (match === null) return null;
+  return { start: match.index, end: match.index + match[0].length };
+}
+
+/** Parse the __DATA__ JSON from a fixture file. Malformed payloads are fatal. */
+function parseFixtureData(content, filePath) {
+  const marker = fixtureDataMarker(content);
+  if (marker === null) return null;
+  const dataStr = content.substring(marker.end).trim();
   try {
     return JSON.parse(dataStr);
-  } catch {
-    return null;
+  } catch (error) {
+    throw new Error(
+      `${filePath}: __DATA__ marker must be followed by valid JSON: ${error.message}`,
+    );
   }
 }
 
 /** Return the source portion of a fixture (before __DATA__). */
 function fixtureSource(content) {
-  const idx = content.indexOf("__DATA__");
-  if (idx < 0) return content;
-  return content.substring(0, idx).trimEnd();
+  const marker = fixtureDataMarker(content);
+  if (marker === null) return content;
+  return content.substring(0, marker.start).trimEnd();
 }
 
 function splitTopLevelChunks(source) {
@@ -215,6 +227,20 @@ function isDeclarationChunk(chunk) {
   return trimmed.startsWith("let ") || trimmed.startsWith("let rec ");
 }
 
+// A fixture may end in a binding rather than a bare expression. The old
+// top-level evaluator still reported the value of that binding, so preserving
+// the declaration without reading it only proves that the fixture runs; it
+// does not prove its `__DATA__.last` expectation. Keep this deliberately
+// narrow: simple identifier bindings are safe to read after the declaration.
+// Anything more involved must be classified as debt instead of being silently
+// activated without an assertion.
+function simpleBindingName(chunk) {
+  const match = chunk
+    .trimStart()
+    .match(/^let\s+(?:rec\s+)?(?:mut\s+)?([a-z_][A-Za-z0-9_]*)\b/);
+  return match?.[1] ?? null;
+}
+
 // A chunk with no code in it. Wrapping one as an expression produced
 // `let _ = (\n// Basic effect declaration\n)`, which is a parse error -- the
 // comment is the whole chunk, so there is nothing for the parens to hold.
@@ -228,8 +254,6 @@ function isCommentOnlyChunk(chunk) {
  * A fixture is a runtime candidate when:
  *  - It has __DATA__ with a "last" key (expected runtime result)
  *  - It does NOT have "compile_error" or "error_contains"
- *  - The source does not use `perform ` (effect system not in selfhost WASM)
- *  - The source does not use `handle ` (effect handling)
  */
 function isRuntimeCandidate(filePath) {
   let content;
@@ -238,43 +262,72 @@ function isRuntimeCandidate(filePath) {
   } catch {
     return false;
   }
-  const data = parseFixtureData(content);
+  const data = parseFixtureData(content, path.relative(ROOT, filePath));
   if (!data || typeof data !== "object") return false;
   if (!("last" in data)) return false;
+  if (typeof data.last !== "string") {
+    throw new Error(
+      `${path.relative(ROOT, filePath)}: __DATA__.last must be a string`,
+    );
+  }
   if ("compile_error" in data || "error_contains" in data) return false;
-
-  const source = fixtureSource(content);
-  if (source.includes("perform ")) return false;
-  if (source.includes("handle ")) return false;
 
   return true;
 }
 
 function discoverCandidates() {
-  const dirs = [
-    { dir: path.join(ROOT, "fixtures"), prefix: "fixtures/" },
-    { dir: path.join(ROOT, "fixtures/runtime"), prefix: "fixtures/runtime/" },
-  ];
+  const fixturesDir = path.join(ROOT, "fixtures");
   const results = [];
-  for (const { dir, prefix } of dirs) {
-    if (!fs.existsSync(dir)) continue;
-    const entries = fs.readdirSync(dir).sort();
+  function visit(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
     for (const entry of entries) {
-      if (!entry.endsWith(".vibe")) continue;
-      const absPath = path.join(dir, entry);
-      // Skip subdirectories (e.g. fixtures/runtime is a subdir of fixtures)
-      try {
-        if (fs.statSync(absPath).isDirectory()) continue;
-      } catch {
-        continue;
-      }
-      if (isRuntimeCandidate(absPath)) {
-        results.push(prefix + entry);
+      const absPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(absPath);
+      } else if (entry.isFile() && entry.name.endsWith(".vibe")) {
+        // isRuntimeCandidate also audits any __DATA__ marker it encounters.
+        // A malformed payload must fail discovery even when it would not have
+        // contained a runtime `last` expectation.
+        if (isRuntimeCandidate(absPath)) {
+          results.push(path.relative(ROOT, absPath));
+        }
       }
     }
   }
+  if (fs.existsSync(fixturesDir)) visit(fixturesDir);
   results.sort();
   return results;
+}
+
+function readDebtPaths(allCandidates) {
+  if (!fs.existsSync(DEBT_FILE)) return new Set();
+  const candidates = new Set(allCandidates);
+  const debts = new Set();
+  const lines = fs.readFileSync(DEBT_FILE, "utf8").split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    const tab = line.indexOf("\t");
+    if (tab < 0 || !line.substring(tab + 1).trim()) {
+      throw new Error(
+        `${path.relative(ROOT, DEBT_FILE)}:${i + 1}: expected <fixture>\\t<reason>`,
+      );
+    }
+    const fixturePath = line.substring(0, tab).trim();
+    if (debts.has(fixturePath)) {
+      throw new Error(
+        `${path.relative(ROOT, DEBT_FILE)}:${i + 1}: duplicate fixture ${fixturePath}`,
+      );
+    }
+    if (!candidates.has(fixturePath)) {
+      throw new Error(
+        `${path.relative(ROOT, DEBT_FILE)}:${i + 1}: stale debt entry ${fixturePath}`,
+      );
+    }
+    debts.add(fixturePath);
+  }
+  return debts;
 }
 
 // ---------------------------------------------------------------------------
@@ -302,7 +355,7 @@ function buildSingleFixtureTestContent(fixturePath) {
   }
 
   const source = fixtureSource(content);
-  const data = parseFixtureData(content);
+  const data = parseFixtureData(content, fixturePath);
   const expectedLast = data?.last ?? null;
   const chunks = splitTopLevelChunks(source);
   const preludeChunks = [];
@@ -328,13 +381,20 @@ function buildSingleFixtureTestContent(fixturePath) {
   // passed when the fixture COMPILED AND RAN, whatever it computed -- a fixture
   // declaring "ok" and returning "ng" was green.
   //
-  // Only the last expression is the program's value; earlier ones are still
-  // evaluated for their effects and discarded.
+  // Only the last body chunk is the program's value; earlier expressions are
+  // still evaluated for their effects and discarded. Searching backwards for
+  // any expression is wrong when the fixture ends in a binding: it would
+  // assert an earlier value and silently ignore the final binding.
   let lastExprIdx = -1;
-  for (let i = bodyChunks.length - 1; i >= 0; i--) {
-    if (bodyChunks[i].kind === "expr") {
-      lastExprIdx = i;
-      break;
+  const finalBodyIdx = bodyChunks.length - 1;
+  if (finalBodyIdx >= 0 && bodyChunks[finalBodyIdx].kind === "expr") {
+    lastExprIdx = finalBodyIdx;
+  }
+  let finalBindingName = null;
+  if (lastExprIdx < 0 && finalBodyIdx >= 0) {
+    const finalChunk = bodyChunks[finalBodyIdx];
+    if (finalChunk.kind === "decl") {
+      finalBindingName = simpleBindingName(finalChunk.text);
     }
   }
   const renderedBody = bodyChunks.map((c, i) => {
@@ -344,6 +404,16 @@ function buildSingleFixtureTestContent(fixturePath) {
     }
     return `let _ = (\n${c.text}\n)`;
   });
+  if (expectedLast !== null && lastExprIdx < 0) {
+    if (finalBindingName === null) {
+      throw new Error(
+        `${fixturePath}: cannot assert __DATA__.last; end the fixture with an expression or a simple identifier binding, or add reasoned debt`,
+      );
+    }
+    renderedBody.push(
+      `assert_true(__to_string(${finalBindingName}) == ${vibeStringLiteral(displayForm(expectedLast))})`,
+    );
+  }
 
   const parts = [];
   if (preludeChunks.length > 0) {
@@ -376,15 +446,27 @@ function buildSingleFixtureTestContent(fixturePath) {
  * between fixture preludes. This function returns an array of
  * { fileName, content } objects.
  */
-function buildShardTestFiles(fixturePaths, shardStartIndex) {
+function stableTestFileName(fixturePath) {
+  const stem = path
+    .basename(fixturePath, path.extname(fixturePath))
+    .replace(/[^A-Za-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 48) || "fixture";
+  const pathHash = createHash("sha256").update(fixturePath).digest("hex").slice(0, 12);
+  return `runtime_fixture_${stem}_${pathHash}_test.vibe`;
+}
+
+function buildShardTestFiles(fixturePaths) {
   // Each fixture needs its own file to avoid top-level name conflicts
   // between different fixture preludes.
   const files = [];
-  for (let j = 0; j < fixturePaths.length; j++) {
-    const fixturePath = fixturePaths[j];
-    const fileIndex = shardStartIndex + j + 1;
-    const shardNum = String(fileIndex).padStart(2, "0");
-    const fileName = `runtime_fixture_success_${shardNum}_test.vibe`;
+  const fileNames = new Set();
+  for (const fixturePath of fixturePaths) {
+    const fileName = stableTestFileName(fixturePath);
+    if (fileNames.has(fileName)) {
+      throw new Error(`generated runtime fixture filename collision: ${fileName}`);
+    }
+    fileNames.add(fileName);
     const content = buildSingleFixtureTestContent(fixturePath);
     files.push({ fileName, content });
   }
@@ -397,12 +479,28 @@ function buildShardTestFiles(fixturePaths, shardStartIndex) {
 
 function main() {
   const listOnly = process.env.VIBE_RUNTIME_FIXTURE_LIST_ONLY === "1";
-  const limit = Number(
+  let limit = Number(
     process.env.VIBE_RUNTIME_FIXTURE_LIMIT || "0",
   );
+  const inventoryMode = process.env.VIBE_RUNTIME_FIXTURE_INVENTORY || "";
+  if (inventoryMode && inventoryMode !== "active" && inventoryMode !== "all") {
+    throw new Error("VIBE_RUNTIME_FIXTURE_INVENTORY must be active or all");
+  }
 
   if (listOnly) {
     let candidates = discoverCandidates();
+    const includeDebt = inventoryMode
+      ? inventoryMode === "all"
+      : process.env.VIBE_RUNTIME_FIXTURE_INCLUDE_DEBT === "1";
+    if (inventoryMode) limit = 0;
+    if (!includeDebt) {
+      const debtPaths = readDebtPaths(candidates);
+      candidates = candidates.filter((candidate) => !debtPaths.has(candidate));
+    } else {
+      // Audit the manifest in all-candidate mode too. A removed or migrated
+      // fixture must retire its debt row in the same change.
+      readDebtPaths(candidates);
+    }
     if (limit > 0) {
       candidates = candidates.slice(0, limit);
     }
@@ -434,7 +532,7 @@ function main() {
   // Generate one file per fixture to avoid top-level name conflicts.
   fs.mkdirSync(GENERATED_DIR, { recursive: true });
 
-  const files = buildShardTestFiles(fixturePaths, 0);
+  const files = buildShardTestFiles(fixturePaths);
   for (const { fileName, content } of files) {
     const filePath = path.join(GENERATED_DIR, fileName);
     fs.writeFileSync(filePath, content);

--- a/scripts/generate_runtime_fixture_tests.test.mjs
+++ b/scripts/generate_runtime_fixture_tests.test.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const generator = path.join(repoRoot, "scripts/generate_runtime_fixture_tests.mjs");
+const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vibe-runtime-fixture-test-"));
+
+function write(relativePath, content) {
+  const target = path.join(workspace, relativePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+}
+
+function run(extraEnv, expectedStatus = 0) {
+  const result = spawnSync(process.execPath, [generator], {
+    cwd: workspace,
+    env: { ...process.env, ...extraEnv },
+    encoding: "utf8",
+  });
+  assert.equal(result.status, expectedStatus, result.stderr || result.stdout);
+  return result;
+}
+
+function list(mode) {
+  return run({
+    VIBE_RUNTIME_FIXTURE_LIST_ONLY: "1",
+    VIBE_RUNTIME_FIXTURE_INVENTORY: mode,
+    // Inventory mode must be exhaustive and immune to ambient developer knobs.
+    VIBE_RUNTIME_FIXTURE_INCLUDE_DEBT: mode === "active" ? "1" : "0",
+    VIBE_RUNTIME_FIXTURE_LIMIT: "1",
+  }).stdout.trim().split("\n").filter(Boolean);
+}
+
+try {
+  const longName =
+    "same_name_with_a_very_long_suffix_that_must_be_truncated_without_losing_identity_aaaaaaaa.vibe";
+  write(
+    "fixtures/nested/final_binding.vibe",
+    '1\nlet x = 2\n\n__DATA__\n{"last":"2"}\n',
+  );
+  write(`fixtures/a/${longName}`, '3\n\n__DATA__\n{"last":"3"}\n');
+  write(`fixtures/b/${longName}`, '4\n\n__DATA__\n{"last":"4"}\n');
+  write(
+    "fixtures/err_import_collides_with_local_let.vibe",
+    'let abs = (x: Int) -> Int { x }\nimport @vibe/prelude { abs }\nabs(-1)\n\n__DATA__\n{"last":"-1"}\n',
+  );
+  write(
+    "scripts/runtime_fixture_debt.tsv",
+    "fixtures/err_import_collides_with_local_let.vibe\tgenerator debt: preserving top-level collision scope requires a dedicated lane\n",
+  );
+
+  const active = list("active");
+  const all = list("all");
+  assert.equal(active.length, 3);
+  assert.equal(all.length, 4);
+  assert(active.includes("fixtures/nested/final_binding.vibe"));
+  assert(!active.includes("fixtures/err_import_collides_with_local_let.vibe"));
+  assert(all.includes("fixtures/err_import_collides_with_local_let.vibe"));
+
+  const pathsOne = path.join(workspace, "paths-one.txt");
+  const pathsMany = path.join(workspace, "paths-many.txt");
+  write("paths-one.txt", "fixtures/nested/final_binding.vibe\n");
+  write(
+    "paths-many.txt",
+    `fixtures/a/${longName}\nfixtures/nested/final_binding.vibe\nfixtures/b/${longName}\n`,
+  );
+  const outOne = path.join(workspace, "out-one");
+  const outMany = path.join(workspace, "out-many");
+  run({
+    VIBE_RUNTIME_FIXTURE_PATHS_FILE: pathsOne,
+    VIBE_RUNTIME_FIXTURE_OUTPUT_DIR: outOne,
+  });
+  run({
+    VIBE_RUNTIME_FIXTURE_PATHS_FILE: pathsMany,
+    VIBE_RUNTIME_FIXTURE_OUTPUT_DIR: outMany,
+  });
+  const oneName = fs.readdirSync(outOne)[0];
+  assert(fs.existsSync(path.join(outMany, oneName)));
+  const generated = fs.readdirSync(outMany);
+  assert.equal(new Set(generated).size, 3);
+  assert(Math.max(...generated.map((name) => name.length)) <= 96);
+  const bindingTest = fs.readFileSync(path.join(outOne, oneName), "utf8");
+  assert.match(bindingTest, /let _ = \(\s*1\s*\)/);
+  assert.match(bindingTest, /assert_true\(__to_string\(x\) == "2"\)/);
+
+  write("fixtures/nested/malformed.vibe", "5\n\n__DATA__\nnot json\n");
+  const malformed = run(
+    {
+      VIBE_RUNTIME_FIXTURE_LIST_ONLY: "1",
+      VIBE_RUNTIME_FIXTURE_INVENTORY: "active",
+    },
+    1,
+  );
+  assert.match(malformed.stderr, /malformed\.vibe: __DATA__ marker must be followed by valid JSON/);
+  fs.rmSync(path.join(workspace, "fixtures/nested/malformed.vibe"));
+
+  write("fixtures/nested/non_string.vibe", '6\n\n__DATA__\n{"last":null}\n');
+  const nonString = run(
+    {
+      VIBE_RUNTIME_FIXTURE_LIST_ONLY: "1",
+      VIBE_RUNTIME_FIXTURE_INVENTORY: "active",
+    },
+    1,
+  );
+  assert.match(nonString.stderr, /non_string\.vibe: __DATA__\.last must be a string/);
+
+  process.stdout.write("runtime fixture generator self-test: ok\n");
+} finally {
+  fs.rmSync(workspace, { recursive: true, force: true });
+}

--- a/scripts/precommit_test.sh
+++ b/scripts/precommit_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+node "$SCRIPT_DIR/generate_runtime_fixture_tests.test.mjs"
 CHECK_SCRIPT="$SCRIPT_DIR/precommit.sh"
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/vibe_precommit_test.XXXXXX")"
 trap 'rm -rf "$TMP_ROOT"' EXIT

--- a/scripts/runtime_fixture_debt.tsv
+++ b/scripts/runtime_fixture_debt.tsv
@@ -1,0 +1,96 @@
+# Runtime fixtures with a `__DATA__.last` expectation that cannot yet run in
+# the generated unit-test lane (#1855). Each row needs a current, actionable
+# reason. The generator rejects duplicates, malformed rows, and entries that
+# stop being runtime candidates, so a migrated/deleted fixture must remove its
+# debt row in the same change.
+fixtures/derive_struct_eq_marker_impl.vibe	compile debt: LocalEq derive marker is no longer a known trait
+fixtures/derive_struct_ord_implies_eq.vibe	compile debt: LocalOrd derive marker is no longer a known trait
+fixtures/effect_closure_param_inert_transitive.vibe	compile debt: suspend lowering cannot see through the local predicate call
+fixtures/effect_cps_accumulate.vibe	compile debt: legacy two-binder continuation arm is rejected
+fixtures/effect_cps_collect_array.vibe	compile debt: legacy two-binder continuation arm is rejected
+fixtures/effect_cps_mut_adr021.vibe	compile debt: legacy two-binder continuation arm is rejected
+fixtures/effect_cps_product.vibe	compile debt: legacy two-binder continuation arm is rejected
+fixtures/effect_defunc_bitwise.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_defunc_general.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_defunc_subtract.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_for_await_suspend.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_generic_option.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_generic_reader.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_generic_state.vibe	runtime debt: generated expected-value assertion traps
+fixtures/effect_generic_writer.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_handle_nested.vibe	compile debt: nested handle hides the covered perform from evidence lowering
+fixtures/effect_handle_resume_in_block.vibe	compile debt: legacy two-binder continuation arm is rejected
+fixtures/effect_handle_resume_in_if_block.vibe	compile debt: legacy two-binder continuation arm is rejected
+fixtures/effect_higher_order_basic.vibe	compile debt: handle body calls an indirect local closure
+fixtures/effect_higher_order_compose.vibe	compile debt: closure-value evidence migration is not eligible
+fixtures/effect_higher_order_swap.vibe	compile debt: handle body calls an indirect local closure
+fixtures/effect_higher_order_test_double.vibe	compile debt: handle body calls an indirect local closure
+fixtures/effect_iife_needing_call.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_infer_basic.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_infer_multi.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_koka_higher_order_handler.vibe	compile debt: handle body calls an indirect local closure
+fixtures/effect_multishot.vibe	compile debt: stale handler syntax is rejected
+fixtures/effect_needing_call_in_row_slot.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_needing_call_in_row_slot_capture.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_needing_value_annotated.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_needing_value_escape_wrapped.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_resume_call_bubbling.vibe	compile debt: resume target sumup is unresolved
+fixtures/effect_resume_rowvar_wrapper_normalized.vibe	compile debt: open effect row is not admitted by the generated entry contract
+fixtures/effect_row_chain.vibe	compile debt: stale row-polymorphic handler syntax is rejected
+fixtures/effect_row_open.vibe	compile debt: stale open-row parameter syntax is rejected
+fixtures/effect_row_poly.vibe	compile debt: indirect row-polymorphic call hides the covered perform
+fixtures/effect_seq_head_block_suspend.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_seq_head_if_suspend.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_seq_head_match_suspend.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_seq_head_reserved_name_collision.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/effect_stream_next_retarget_hygiene.vibe	compile debt: stale effect operation declaration syntax is rejected
+fixtures/effect_tail_selection_input_suspend.vibe	compile debt: one closure raw-performs multiple suspend-class effects
+fixtures/effect_trivial_wrapper_needing_call.vibe	compile debt: generated block placement leaves a local fn in an invalid position
+fixtures/err_import_collides_with_local_let.vibe	generator debt: hoisting the import ahead of the top-level let changes the name-collision contract into block shadowing
+fixtures/err_type_closure_capture_mut.vibe	runtime debt: fixture is error-shaped but declares a last value and traps
+fixtures/err_type_generic_too_few_type_args.vibe	compile debt: stale generic-arity rejection fixture declares runtime output
+fixtures/err_type_generic_too_many_type_args.vibe	compile debt: stale generic-arity rejection fixture declares runtime output
+fixtures/err_type_generic_wrong_type_arg.vibe	compile debt: stale generic-argument rejection fixture declares runtime output
+fixtures/for_in_continue.vibe	runtime debt: generated test does not terminate
+fixtures/forward_reference.vibe	compile debt: local forward reference add_one is rejected
+fixtures/forward_reference_annotated_let.vibe	compile debt: local forward reference base is rejected
+fixtures/forward_reference_mutual.vibe	compile debt: mutually recursive local reference is rejected
+fixtures/forward_reference_no_ret_annotation.vibe	compile debt: local forward reference add_one is rejected
+fixtures/from_to_lines.vibe	compile debt: Lines::parse reaches codegen unresolved
+fixtures/generic_explicit_type_arg.vibe	compile debt: explicit type argument Int is rejected in this spelling
+fixtures/generic_filter.vibe	runtime debt: generated expected-value assertion traps
+fixtures/generic_multiple_calls.vibe	runtime debt: generated expected-value assertion traps
+fixtures/generic_swap.vibe	runtime debt: generated expected-value assertion traps
+fixtures/generic_two_params.vibe	runtime debt: generated expected-value assertion traps
+fixtures/generic_wrap_array.vibe	runtime debt: generated expected-value assertion traps
+fixtures/hex_literal.vibe	runtime debt: expected value predates current Int rendering
+fixtures/handle_mutable_in_handler.vibe	runtime debt: generated expected-value assertion traps
+fixtures/import_symbol_ref.vibe	compile debt: stale import symbol-list syntax is rejected
+fixtures/import_version_ref.vibe	compile debt: stale versioned import syntax is rejected
+fixtures/int_large_literal.vibe	runtime debt: expected value predates the 63-bit Int contract
+fixtures/json_parse.vibe	compile debt: Json::parse is not exported by the current JSON package
+fixtures/json_stringify.vibe	compile debt: Json::parse is not exported by the current JSON package
+fixtures/jsonl.vibe	compile debt: Json::parse_lines is not exported by the current JSON package
+fixtures/let_type_annotation_generic.vibe	compile debt: stale generic type annotation syntax is rejected
+fixtures/map_int_key.vibe	compile debt: MapBuilder::set no longer accepts the fixture's Int-key call shape
+fixtures/map_int_key_has_keys.vibe	compile debt: MapBuilder::set no longer accepts the fixture's Int-key call shape
+fixtures/prelude_to_string_parenthesized_literal_method.vibe	compile debt: builtin Double::to_string rejects dot-call syntax
+fixtures/runtime/effect_sh.vibe	runtime debt: generated expected-value assertion traps
+fixtures/show_to_string_method.vibe	compile debt: builtin Int::to_string rejects dot-call syntax
+fixtures/std_alias_int_short_api.vibe	compile debt: abs resolves to the Double API for this stale alias fixture
+fixtures/struct_method.vibe	compile debt: stale struct method declaration syntax is rejected
+fixtures/suberror_basic.vibe	compile debt: removed suberror syntax is rejected
+fixtures/suberror_catch.vibe	compile debt: removed suberror syntax is rejected
+fixtures/suberror_propagate.vibe	compile debt: removed suberror syntax is rejected
+fixtures/trait_bound_multi_basic.vibe	compile debt: current Show resolution rejects the String witness
+fixtures/trait_eq_operator_accepts_eq_bound_type_parameter.vibe	runtime debt: generated expected-value assertion traps
+fixtures/trait_eq_string_operator_runtime.vibe	runtime debt: generated expected-value assertion traps
+fixtures/trait_export_open_declares_open_trait.vibe	runtime debt: generated expected-value assertion traps
+fixtures/trait_export_sealed_trait_local_impl.vibe	runtime debt: generated expected-value assertion traps
+fixtures/trait_generic_impl_bound_basic.vibe	compile debt: current LocalEq resolution rejects the String witness
+fixtures/trait_hierarchy_ord_implies_eq_operator.vibe	runtime debt: generated expected-value assertion traps
+fixtures/trait_hierarchy_transitive_supertrait_operator.vibe	runtime debt: generated expected-value assertion traps
+fixtures/trait_impl_func_label_no_overlap.vibe	compile debt: stale impl target syntax is rejected
+fixtures/trait_impl_multi_bound_basic.vibe	compile debt: current LocalHash resolution rejects the String witness
+fixtures/trait_ord_operator_accepts_ord_bound_type_parameter.vibe	runtime debt: generated expected-value assertion traps
+fixtures/try_question_mark.vibe	compile debt: question-mark result no longer matches the declared Int return

--- a/scripts/unit_test_runner.sh
+++ b/scripts/unit_test_runner.sh
@@ -37,6 +37,37 @@ cd "$ROOT_DIR"
 
 RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
 
+# #1855: `__DATA__.last` is an executable expectation, not archival prose.
+# Generate every currently-live runtime fixture into the ordinary `*_test.vibe`
+# discovery lane before inventory/sharding. Known stale fixtures live in the
+# reasoned debt manifest read by the generator; every new candidate is active
+# by default, so forgetting to wire it cannot recreate the old silent state.
+RUNTIME_FIXTURE_GENERATED_DIR="$ROOT_DIR/_build/runtime_fixture_tests"
+generate_runtime_fixture_tests() {
+  local paths_file
+  paths_file="$(mktemp -t vibe-runtime-fixtures-XXXXXX)"
+  VIBE_RUNTIME_FIXTURE_LIST_ONLY=1 \
+    VIBE_RUNTIME_FIXTURE_INVENTORY=active \
+    VIBE_RUNTIME_FIXTURE_INCLUDE_DEBT=0 \
+    VIBE_RUNTIME_FIXTURE_LIMIT=0 \
+    node "$ROOT_DIR/scripts/generate_runtime_fixture_tests.mjs" > "$paths_file"
+  [ -s "$paths_file" ] || {
+    echo "[unit-test-runner] FAIL: runtime fixture generator selected no active fixtures" >&2
+    rm -f "$paths_file"
+    return 1
+  }
+  # This directory is generated and gitignored; deleting it cannot remove
+  # source. A clean rebuild also prevents a newly debt-listed fixture's old
+  # generated test from remaining discoverable.
+  rm -rf "$RUNTIME_FIXTURE_GENERATED_DIR"
+  VIBE_RUNTIME_FIXTURE_OUTPUT_DIR="$RUNTIME_FIXTURE_GENERATED_DIR" \
+    VIBE_RUNTIME_FIXTURE_PATHS_FILE="$paths_file" \
+    node "$ROOT_DIR/scripts/generate_runtime_fixture_tests.mjs" >/dev/null
+  echo "[unit-test-runner] generated $(wc -l < "$paths_file" | tr -d ' ') active runtime fixture tests" >&2
+  rm -f "$paths_file"
+}
+generate_runtime_fixture_tests
+
 # Files discover() finds that cannot run through this generic (compile with
 # __no_entry__, run _start, VIBE_FS_COMPILE=1) harness. Each entry needs a
 # concrete, current reason -- not "todo" or "flaky, skip for now". Check with
@@ -70,7 +101,11 @@ is_excluded() {
   return 1
 }
 
-discover() { find examples lib fixtures -name '*_test.vibe' 2>/dev/null | sed "s@^$ROOT_DIR/@@" | sed 's@^\./@@' | sort; }
+discover() {
+  find examples lib fixtures "$RUNTIME_FIXTURE_GENERATED_DIR" \
+    -name '*_test.vibe' 2>/dev/null \
+    | sed "s@^$ROOT_DIR/@@" | sed 's@^\./@@' | sort
+}
 
 mode="run"
 case "${1:-}" in


### PR DESCRIPTION
## Summary

Closes #1855.

The repository had 321 fixtures declaring a runtime expectation through __DATA__.last, but only a handful were named by any gate. The existing generator could already translate many fixtures, yet no test lane invoked it, and it excluded every source containing perform or handle before even reporting coverage. Adding or breaking an expectation therefore stayed silently clean.

## Change

- Generate live runtime fixtures before unit-test inventory and include them in normal discovery, sharding, caching, and affected-test selection.
- Include effect and handler fixtures in the complete inventory instead of dropping them before classification.
- Keep generated files under _build so formatter and source-tree gates cannot race with them.
- Make new runtime fixtures active by default.
- Add a validated reasoned debt manifest; malformed, duplicate, or stale debt rows fail closed.
- Extend check_fixture_execution to report both test-block and runtime-expectation coverage.

Current classification: 321 total = 231 active and passing + 90 explicit debt. The previous silent unchecked state is no longer representable. Expanding the effect inventory alone activated 61 additional passing fixtures.

Focused debt paydown continues in #1966, #1967, and #1973, aligned with the inspect snapshot migration in #1571.

## Validation

- Initial Red: non-effect inventory measured 170 pass / 44 fail; one failure did not terminate.
- Review Red: 107 effect/handler expectations were absent from the complete inventory.
- Green: generated active corpus 231/231 passes through unit_test_runner.
- check_fixture_execution: 323 test-block fixtures; 231 runtime expectations active; 90 reasoned debt; all accounted for.
- pkf run test-local: 255/255 selected tests passed after generating the five normal compiler artifacts.
- pkf run test-pre-commit.
- node --check, bash -n, and git diff --check.