### PR TITLE
Prevent region capture provenance escapes

### DIFF
--- a/docs/region-mutable-state.md
+++ b/docs/region-mutable-state.md
@@ -235,22 +235,19 @@ region の外に出られない。検査は TaskGroup の雛形を一般化す�
   (`fixtures/region_arena_ok.vibe`、42)と negative
   (`fixtures/err_region_escape_return_value.vibe`、needle
   "region escapes its scope")を固定。
-- **closure capture (#1725、2026-08-14)**: §4 の「捕獲した closure が region
-  型に感染する」は **row 統合前提なので Phase 1 では働かない** —— 型は捕獲を
-  記録しないので、`region r { let l = MutList::empty(r); () -> Array[Int] {
-  MutList::to_array(l) } }` の結果型は `() -> Array[Int]` で skolem 走査から
-  見えず、region 値が closure の環境に隠れて脱出できた。arena が入れば
-  use-after-free なので stopgap を入れてある:
-  `checker/checker_escape.vibe :: region_token_escapes_in_closure` が
-  「region body の**結果そのもの**が closure literal で、region token から
-  直に束縛された名前(とその別名)を捕獲している」形だけを reject する。
-  **capture 自体は正当**(region 内で完結する closure は普通に書く)なので
-  過剰approx にしないことが要件で、汚染は「token に言及する初期化式」と
-  「汚染名の裸の別名」に限り、shadowing は最後の束縛が勝つ。取りこぼし:
-  outer binding / container 経由、helper 関数経由。gate 75 が両方向
-  (`fixtures/err_region_escape_closure_capture.vibe` /
-  `fixtures/region_ok_closure_local.vibe`)を pin。**正しい規則は §4 の
-  row 感染**で、arena スライスの前提はそちら。
+- **Closure capture provenance (#1725, #1938)**: a checked function row carries
+  an internal, source-unforgeable region provenance label. A direct capture is
+  `#region_n`; a capture through an inference variable is `#capture[v]` and
+  resolves when ordinary type substitution binds `v`. These labels are not
+  runtime effects and are excluded from effect-set compatibility, but they
+  survive generalization, explicit return annotations, helper calls and
+  containers. The region boundary therefore uses the same zonked-type scan for
+  direct values and closures. Assignment into an outer cell is rejected while
+  the active-region marker is present in `TypeEnv`. Capture itself remains
+  legal: a closure consumed inside the region, a copied-out value, and a
+  shadowing binding carry no escaping provenance. Gate 75 pins the five escape
+  witnesses (outer assignment, container, helper, nested closure, alias chain)
+  and their positive counterparts.
 - **既知ギャップ(Phase 1 で許容、ADR 本文の設計は不変)**: effect row 統合
   (§3)は未着手 — 別 pass の effect 検査は lambda wrapper を見るため、
   region body 内の effect は enclosing fn に帰属しない。outer-binding scan は

--- a/docs/region-mutable-state.md
+++ b/docs/region-mutable-state.md
@@ -235,19 +235,6 @@ region の外に出られない。検査は TaskGroup の雛形を一般化す�
   (`fixtures/region_arena_ok.vibe`、42)と negative
   (`fixtures/err_region_escape_return_value.vibe`、needle
   "region escapes its scope")を固定。
-- **Closure capture provenance (#1725, #1938)**: a checked function row carries
-  an internal, source-unforgeable region provenance label. A direct capture is
-  `#region_n`; a capture through an inference variable is `#capture[v]` and
-  resolves when ordinary type substitution binds `v`. These labels are not
-  runtime effects and are excluded from effect-set compatibility, but they
-  survive generalization, explicit return annotations, helper calls and
-  containers. The region boundary therefore uses the same zonked-type scan for
-  direct values and closures. Assignment into an outer cell is rejected while
-  the active-region marker is present in `TypeEnv`. Capture itself remains
-  legal: a closure consumed inside the region, a copied-out value, and a
-  shadowing binding carry no escaping provenance. Gate 75 pins the five escape
-  witnesses (outer assignment, container, helper, nested closure, alias chain)
-  and their positive counterparts.
 - **既知ギャップ(Phase 1 で許容、ADR 本文の設計は不変)**: effect row 統合
   (§3)は未着手 — 別 pass の effect 検査は lambda wrapper を見るため、
   region body 内の effect は enclosing fn に帰属しない。outer-binding scan は

--- a/fixtures/err_region_escape_aggregate_struct.vibe
+++ b/fixtures/err_region_escape_aggregate_struct.vibe
@@ -1,0 +1,17 @@
+struct AggregateSlot {
+  callback: () -> Array[Int]
+}
+
+test "aggregate tails preserve nominal field provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    [
+      AggregateSlot::{
+        callback: () -> Array[Int] {
+          MutList::to_array(values)
+        }
+      }
+    ]
+  }
+  let _ = Array::get(escaped, 0).callback()
+}

--- a/fixtures/err_region_escape_alias_chain.vibe
+++ b/fixtures/err_region_escape_alias_chain.vibe
@@ -1,0 +1,12 @@
+// #1938: capture provenance survives arbitrary alias depth.
+//   error_contains: "region escapes its scope"
+fn build() -> () -> Array[Int] {
+  region r {
+    let first = MutList::empty(r)
+    let second = first
+    let third = second
+    () -> Array[Int] {
+      MutList::to_array(third)
+    }
+  }
+}

--- a/fixtures/err_region_escape_alias_result.vibe
+++ b/fixtures/err_region_escape_alias_result.vibe
@@ -1,0 +1,20 @@
+struct AliasResultSlot {
+  callback: () -> Array[Int]
+}
+
+fn alias_result_identity[T](value: T) -> T {
+  value
+}
+
+test "alias-result contracts preserve nominal payload provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    let slot = AliasResultSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }
+    alias_result_identity(slot)
+  }
+  let _ = escaped.callback()
+}

--- a/fixtures/err_region_escape_array_alias_write.vibe
+++ b/fixtures/err_region_escape_array_alias_write.vibe
@@ -1,0 +1,11 @@
+test "aliases preserve the destination lifetime" {
+  let outer: Array[() -> Array[Int]] = []
+  let _ = region r {
+    let alias = outer
+    let values = MutList::empty(r)
+    Array::push(alias, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_array_write.vibe
+++ b/fixtures/err_region_escape_array_write.vibe
@@ -1,0 +1,15 @@
+fn build() -> Array[() -> Array[Int]] {
+  let outer: Array[() -> Array[Int]] = []
+  let _ = region r {
+    let values = MutList::empty(r)
+    Array::push(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+  outer
+}
+
+test "outer arrays cannot retain region-backed closures" {
+  let _ = build()
+}

--- a/fixtures/err_region_escape_bound_struct.vibe
+++ b/fixtures/err_region_escape_bound_struct.vibe
@@ -1,0 +1,16 @@
+struct BoundSlot {
+  callback: () -> Array[Int]
+}
+
+test "bound nominal values preserve field provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    let slot = BoundSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }
+    slot
+  }
+  let _ = escaped.callback()
+}

--- a/fixtures/err_region_escape_call_alias_write.vibe
+++ b/fixtures/err_region_escape_call_alias_write.vibe
@@ -1,0 +1,15 @@
+fn identity[T](value: T) -> T {
+  value
+}
+
+test "pure aliases preserve the destination lifetime" {
+  let outer: Array[() -> Array[Int]] = []
+  let _ = region r {
+    let alias = identity(outer)
+    let values = MutList::empty(r)
+    Array::push(alias, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_callback_defer.vibe
+++ b/fixtures/err_region_escape_callback_defer.vibe
@@ -1,0 +1,15 @@
+fn defer[T](callback: () -> T) -> () -> T {
+  () -> T {
+    callback()
+  }
+}
+
+test "captured callback dependencies survive nested closures" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    defer(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_callback_return.vibe
+++ b/fixtures/err_region_escape_callback_return.vibe
@@ -1,0 +1,15 @@
+fn invoke_nested(callback: () -> () -> Array[Int]) -> () -> Array[Int] {
+  callback()
+}
+
+test "callback return values retain parameter provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    invoke_nested(() -> () -> Array[Int] {
+      () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_conditional_alias_result.vibe
+++ b/fixtures/err_region_escape_conditional_alias_result.vibe
@@ -1,0 +1,27 @@
+struct ConditionalAliasSlot {
+  callback: () -> Array[Int]
+}
+
+fn choose_alias[T](first: T, second: T) -> T {
+  if true {
+    first
+  } else {
+    second
+  }
+}
+
+test "conditional alias results preserve every possible dependency" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    choose_alias(ConditionalAliasSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }, ConditionalAliasSlot::{
+      callback: () -> Array[Int] {
+        []
+      }
+    })
+  }
+  let _ = escaped.callback()
+}

--- a/fixtures/err_region_escape_constructor_helper.vibe
+++ b/fixtures/err_region_escape_constructor_helper.vibe
@@ -1,0 +1,24 @@
+struct ConstructorSlot {
+  callback: () -> Array[Int]
+}
+
+enum ConstructorWrapper[T] {
+  ConstructorPack(T)
+}
+
+fn constructor_pack[T](value: T) -> ConstructorWrapper[T] {
+  ConstructorPack(value)
+}
+
+test "constructor helpers preserve payload provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    constructor_pack(ConstructorSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let ConstructorPack(slot) = escaped
+  let _ = slot.callback()
+}

--- a/fixtures/err_region_escape_container.vibe
+++ b/fixtures/err_region_escape_container.vibe
@@ -1,0 +1,12 @@
+// #1938: a container cannot hide a closure that captures region storage.
+//   error_contains: "region escapes its scope"
+fn build() -> Array[() -> Array[Int]] {
+  region r {
+    let values = MutList::empty(r)
+    [
+      () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    ]
+  }
+}

--- a/fixtures/err_region_escape_deque_back_write.vibe
+++ b/fixtures/err_region_escape_deque_back_write.vibe
@@ -1,0 +1,20 @@
+struct Deque[T] {
+  mut marker: Int
+}
+
+fn Deque::push_back[T](d: Deque[T], x: T) -> Unit {
+  ()
+}
+
+test "Deque::push_back cannot retain region closures" {
+  let outer: Deque[() -> Array[Int]] = Deque::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    Deque::push_back(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_deque_dot_write.vibe
+++ b/fixtures/err_region_escape_deque_dot_write.vibe
@@ -1,0 +1,16 @@
+import @vibe/core {
+  type Deque, Deque::front, Deque::new, Deque::push_back
+}
+
+test "Deque dot writes reject region-backed callbacks" {
+  let outer: Deque[() -> Array[Int]] = Deque::new()
+  let _ = region r {
+    let values = MutList::empty(r)
+    outer.push_back(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+  let Some(callback) = Deque::front(outer)
+  let _ = callback()
+}

--- a/fixtures/err_region_escape_deque_front_write.vibe
+++ b/fixtures/err_region_escape_deque_front_write.vibe
@@ -1,0 +1,20 @@
+struct Deque[T] {
+  mut marker: Int
+}
+
+fn Deque::push_front[T](d: Deque[T], x: T) -> Unit {
+  ()
+}
+
+test "Deque::push_front cannot retain region closures" {
+  let outer: Deque[() -> Array[Int]] = Deque::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    Deque::push_front(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_deque_write.vibe
+++ b/fixtures/err_region_escape_deque_write.vibe
@@ -1,0 +1,16 @@
+import @vibe/core {
+  type Deque, Deque::front, Deque::new, Deque::push_back
+}
+
+test "Deque writes reject region-backed callbacks" {
+  let outer: Deque[() -> Array[Int]] = Deque::new()
+  let _ = region r {
+    let values = MutList::empty(r)
+    Deque::push_back(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+  let Some(callback) = Deque::front(outer)
+  let _ = callback()
+}

--- a/fixtures/err_region_escape_direct_call_alias_write.vibe
+++ b/fixtures/err_region_escape_direct_call_alias_write.vibe
@@ -1,0 +1,14 @@
+fn direct_identity[T](value: T) -> T {
+  value
+}
+
+test "call-shaped destinations preserve the outer lifetime" {
+  let outer: Array[() -> Array[Int]] = []
+  let _ = region r {
+    let values = MutList::empty(r)
+    Array::push(direct_identity(outer), () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_early_return.vibe
+++ b/fixtures/err_region_escape_early_return.vibe
@@ -1,0 +1,21 @@
+fn maybe_return(callback: () -> Array[Int]) -> () -> Array[Int] {
+  if true {
+    return () -> Array[Int] {
+      callback()
+    }
+  }
+  () -> Array[Int] {
+    [
+    ]
+  }
+}
+
+test "explicit return paths preserve callback provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    maybe_return(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_enum_aggregate.vibe
+++ b/fixtures/err_region_escape_enum_aggregate.vibe
@@ -1,0 +1,21 @@
+struct EnumSlot {
+  callback: () -> Array[Int]
+}
+
+enum Envelope[T] {
+  Wrap(T)
+}
+
+test "first-class enum constructors preserve payload provenance" {
+  let wrap = Wrap
+  let escaped = region r {
+    let values = MutList::empty(r)
+    wrap(EnumSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let Wrap(slot) = escaped
+  let _ = slot.callback()
+}

--- a/fixtures/err_region_escape_enum_alias.vibe
+++ b/fixtures/err_region_escape_enum_alias.vibe
@@ -1,0 +1,13 @@
+enum EnumAliasBox {
+  EnumAliasHold(() -> Array[Int])
+}
+
+fn build_enum_alias() -> EnumAliasBox {
+  region r {
+    let values = MutList::empty(r)
+    let held = EnumAliasBox::EnumAliasHold(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+    held
+  }
+}

--- a/fixtures/err_region_escape_enum_container.vibe
+++ b/fixtures/err_region_escape_enum_container.vibe
@@ -1,0 +1,12 @@
+enum EnumContainerBox { EnumContainerHold(() -> Array[Int]) }
+
+fn build_enum_container() -> Array[EnumContainerBox] {
+  region r {
+    let values = MutList::empty(r)
+    [
+      EnumContainerBox::EnumContainerHold(() -> Array[Int] {
+        MutList::to_array(values)
+      })
+    ]
+  }
+}

--- a/fixtures/err_region_escape_enum_outer_assignment.vibe
+++ b/fixtures/err_region_escape_enum_outer_assignment.vibe
@@ -1,0 +1,14 @@
+enum EnumAssignmentBox { EnumAssignmentHold(() -> Array[Int]) }
+
+fn build_enum_outer_assignment() -> Int {
+  let mut escaped = EnumAssignmentBox::EnumAssignmentHold(() -> Array[Int] {
+    []
+  })
+  region r {
+    let values = MutList::empty(r)
+    escaped = EnumAssignmentBox::EnumAssignmentHold(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_enum_payload.vibe
+++ b/fixtures/err_region_escape_enum_payload.vibe
@@ -1,0 +1,10 @@
+enum EnumPayloadBox { EnumPayloadHold(() -> Array[Int]) }
+
+fn build_enum_payload() -> EnumPayloadBox {
+  region r {
+    let values = MutList::empty(r)
+    EnumPayloadBox::EnumPayloadHold(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+  }
+}

--- a/fixtures/err_region_escape_field_write.vibe
+++ b/fixtures/err_region_escape_field_write.vibe
@@ -1,0 +1,23 @@
+struct Slot {
+  mut callback: () -> Array[Int]
+}
+
+fn build() -> Slot {
+  let outer = Slot::{
+    callback: () -> Array[Int] {
+      []
+    }
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    outer.callback = () -> Array[Int] {
+      MutList::to_array(values)
+    }
+    0
+  }
+  outer
+}
+
+test "outer fields cannot retain region-backed closures" {
+  let _ = build()
+}

--- a/fixtures/err_region_escape_generalized_local_callee.vibe
+++ b/fixtures/err_region_escape_generalized_local_callee.vibe
@@ -1,0 +1,13 @@
+test "generalized local callees preserve capture provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    let read = (unused) -> Array[Int] {
+      let _ = unused
+      MutList::to_array(values)
+    }
+    () -> Array[Int] {
+      read(0)
+    }
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_generic_defer.vibe
+++ b/fixtures/err_region_escape_generic_defer.vibe
@@ -1,0 +1,15 @@
+fn defer[T, U](value: T, project: (T) -> U) -> () -> U {
+  () -> U {
+    project(value)
+  }
+}
+
+test "generic captures retain dependent provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    defer(values, (xs) -> Array[Int] {
+      MutList::to_array(xs)
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_global_helper.vibe
+++ b/fixtures/err_region_escape_global_helper.vibe
@@ -1,0 +1,15 @@
+// #1938: dependent capture provenance must be recorded where a generic
+// helper is defined, before any call site supplies a region-tagged value.
+//   error_contains: "region escapes its scope"
+fn capture[T, R](value: MutList[T, R]) -> () -> Array[T] {
+  () -> Array[T] {
+    MutList::to_array(value)
+  }
+}
+
+fn build() -> () -> Array[Int] {
+  region r {
+    let values = MutList::empty(r)
+    capture(values)
+  }
+}

--- a/fixtures/err_region_escape_hashmap_alias_write.vibe
+++ b/fixtures/err_region_escape_hashmap_alias_write.vibe
@@ -1,0 +1,20 @@
+struct MutMap[K, V] {
+  mut marker: Int
+}
+
+fn HashMap::set[K, V](m: MutMap[K, V], k: K, v: V) -> Unit {
+  ()
+}
+
+test "legacy HashMap::set keeps retaining-write checks" {
+  let outer: MutMap[Int, () -> Array[Int]] = MutMap::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    HashMap::set(outer, 0, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_hashset_alias_write.vibe
+++ b/fixtures/err_region_escape_hashset_alias_write.vibe
@@ -1,0 +1,20 @@
+struct MutSet[T] {
+  mut marker: Int
+}
+
+fn HashSet::add[T](s: MutSet[T], x: T) -> Unit {
+  ()
+}
+
+test "legacy HashSet::add keeps retaining-write checks" {
+  let outer: MutSet[() -> Array[Int]] = MutSet::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    HashSet::add(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_helper.vibe
+++ b/fixtures/err_region_escape_helper.vibe
@@ -1,0 +1,13 @@
+// #1938: capture provenance must survive a locally inferred helper call.
+//   error_contains: "region escapes its scope"
+fn build() -> () -> Array[Int] {
+  region r {
+    let values = MutList::empty(r)
+    let capture = (value) -> () -> Array[Int] {
+      () -> Array[Int] {
+        MutList::to_array(value)
+      }
+    }
+    capture(values)
+  }
+}

--- a/fixtures/err_region_escape_inline_call_alias_write.vibe
+++ b/fixtures/err_region_escape_inline_call_alias_write.vibe
@@ -1,0 +1,13 @@
+test "inline pure aliases preserve the destination lifetime" {
+  let outer: Array[() -> Array[Int]] = []
+  let _ = region r {
+    let alias = ((value: Array[() -> Array[Int]]) -> Array[() -> Array[Int]] {
+      value
+    })(outer)
+    let values = MutList::empty(r)
+    Array::push(alias, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_inline_projection.vibe
+++ b/fixtures/err_region_escape_inline_projection.vibe
@@ -1,0 +1,17 @@
+struct InlineSlot {
+  callback: () -> Array[Int]
+}
+
+test "inline nominal projection preserves callback provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    ((slot: InlineSlot) -> () -> Array[Int] {
+      slot.callback
+    })(InlineSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_local_callee.vibe
+++ b/fixtures/err_region_escape_local_callee.vibe
@@ -1,0 +1,12 @@
+test "direct local closure calls preserve capture provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    let read = () -> Array[Int] {
+      MutList::to_array(values)
+    }
+    () -> Array[Int] {
+      read()
+    }
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_monomorphic_callback.vibe
+++ b/fixtures/err_region_escape_monomorphic_callback.vibe
@@ -1,0 +1,16 @@
+fn pass(f: () -> Array[Int]) -> () -> Array[Int] {
+  f
+}
+
+fn build() -> () -> Array[Int] {
+  region r {
+    let values = MutList::empty(r)
+    pass(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+  }
+}
+
+test "monomorphic callback result cannot erase region provenance" {
+  let _ = build()
+}

--- a/fixtures/err_region_escape_multi_payload_constructor.vibe
+++ b/fixtures/err_region_escape_multi_payload_constructor.vibe
@@ -1,0 +1,24 @@
+struct MultiPayloadSlot {
+  callback: () -> Array[Int]
+}
+
+enum MultiPayloadWrapper[A, B] {
+  MultiPayloadPair(A, B)
+}
+
+fn multi_payload_pack[A, B](first: A, second: B) -> MultiPayloadWrapper[A, B] {
+  MultiPayloadPair(first, second)
+}
+
+test "constructor helpers preserve every payload dependency" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    multi_payload_pack(MultiPayloadSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }, 0)
+  }
+  let MultiPayloadPair(slot, _) = escaped
+  let _ = slot.callback()
+}

--- a/fixtures/err_region_escape_multiple_regions.vibe
+++ b/fixtures/err_region_escape_multiple_regions.vibe
@@ -1,0 +1,20 @@
+// #1938: dependent capture provenance retains every region in a captured
+// aggregate. The inner value must not escape merely because the outer value
+// appears first in the tuple.
+//   error_contains: "region escapes its scope"
+fn capture_pair[A, RA, B, RB](pair: (MutList[A, RA], MutList[B, RB])) -> () -> (Array[A], Array[B]) {
+  () -> (Array[A], Array[B]) {
+    let (outer_values, inner_values) = pair
+    (MutList::to_array(outer_values), MutList::to_array(inner_values))
+  }
+}
+
+fn build() -> () -> (Array[Int], Array[Int]) {
+  region outer {
+    let outer_values = MutList::empty(outer)
+    region inner {
+      let inner_values = MutList::empty(inner)
+      capture_pair((outer_values, inner_values))
+    }
+  }
+}

--- a/fixtures/err_region_escape_mutlist_write.vibe
+++ b/fixtures/err_region_escape_mutlist_write.vibe
@@ -1,0 +1,13 @@
+test "outer region lists cannot retain inner region closures" {
+  region outer_region {
+    let outer: MutList[() -> Array[Int], outer_region] = MutList::empty(outer_region)
+    let _ = region inner_region {
+      let inner = MutList::empty(inner_region)
+      MutList::push(outer, () -> Array[Int] {
+        MutList::to_array(inner)
+      })
+      0
+    }
+    0
+  }
+}

--- a/fixtures/err_region_escape_mutmap_key_write.vibe
+++ b/fixtures/err_region_escape_mutmap_key_write.vibe
@@ -1,0 +1,20 @@
+struct MutMap[K, V] {
+  mut marker: Int
+}
+
+fn MutMap::set[K, V](m: MutMap[K, V], k: K, v: V) -> Unit {
+  ()
+}
+
+test "MutMap keys cannot retain region closures" {
+  let outer: MutMap[() -> Array[Int], Int] = MutMap::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    MutMap::set(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    }, 0)
+    0
+  }
+}

--- a/fixtures/err_region_escape_mutmap_value_write.vibe
+++ b/fixtures/err_region_escape_mutmap_value_write.vibe
@@ -1,0 +1,20 @@
+struct MutMap[K, V] {
+  mut marker: Int
+}
+
+fn MutMap::set[K, V](m: MutMap[K, V], k: K, v: V) -> Unit {
+  ()
+}
+
+test "MutMap values cannot retain region closures" {
+  let outer: MutMap[Int, () -> Array[Int]] = MutMap::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    MutMap::set(outer, 0, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_mutmap_write.vibe
+++ b/fixtures/err_region_escape_mutmap_write.vibe
@@ -1,0 +1,16 @@
+import @vibe/core {
+  type MutMap, MutMap::get, MutMap::new_int, MutMap::set
+}
+
+test "MutMap writes reject region-backed callbacks" {
+  let outer: MutMap[Int, () -> Array[Int]] = MutMap::new_int()
+  let _ = region r {
+    let values = MutList::empty(r)
+    MutMap::set(outer, 0, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+  let Some(callback) = MutMap::get(outer, 0)
+  let _ = callback()
+}

--- a/fixtures/err_region_escape_mutset_write.vibe
+++ b/fixtures/err_region_escape_mutset_write.vibe
@@ -1,0 +1,20 @@
+struct MutSet[T] {
+  mut marker: Int
+}
+
+fn MutSet::add[T](s: MutSet[T], x: T) -> Unit {
+  ()
+}
+
+test "MutSet cannot retain region closures" {
+  let outer: MutSet[() -> Array[Int]] = MutSet::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    MutSet::add(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_named_projection.vibe
+++ b/fixtures/err_region_escape_named_projection.vibe
@@ -1,0 +1,19 @@
+struct Slot {
+  callback: () -> Array[Int]
+}
+
+fn unwrap(slot: Slot) -> () -> Array[Int] {
+  slot.callback
+}
+
+test "nominal field projection preserves callback provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    unwrap(Slot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_named_projection_alias.vibe
+++ b/fixtures/err_region_escape_named_projection_alias.vibe
@@ -1,0 +1,20 @@
+struct AliasedSlot {
+  callback: () -> Array[Int]
+}
+
+fn unwrap_aliased(slot: AliasedSlot) -> () -> Array[Int] {
+  let callback = slot.callback
+  callback
+}
+
+test "local aliases preserve nominal field provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    unwrap_aliased(AliasedSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_named_struct.vibe
+++ b/fixtures/err_region_escape_named_struct.vibe
@@ -1,0 +1,14 @@
+struct Slot {
+  callback: () -> Array[Int]
+}
+
+test "named struct fields cannot hide region-backed closures" {
+  let _ = region r {
+    let values = MutList::empty(r)
+    Slot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }
+  }
+}

--- a/fixtures/err_region_escape_named_struct_bound.vibe
+++ b/fixtures/err_region_escape_named_struct_bound.vibe
@@ -1,0 +1,16 @@
+struct BoundSlot {
+  callback: () -> Array[Int]
+}
+
+test "bound named structs preserve field provenance" {
+  let _ = region r {
+    let values = MutList::empty(r)
+    let slot = BoundSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }
+    let alias = slot
+    alias
+  }
+}

--- a/fixtures/err_region_escape_named_struct_field_alias.vibe
+++ b/fixtures/err_region_escape_named_struct_field_alias.vibe
@@ -1,0 +1,17 @@
+struct FieldSlot {
+  callback: () -> Array[Int]
+}
+
+test "bound named struct fields preserve provenance through aliases" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    let slot = FieldSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }
+    let alias = slot
+    alias.callback
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_nested_closure.vibe
+++ b/fixtures/err_region_escape_nested_closure.vibe
@@ -1,0 +1,12 @@
+// #1938: nesting another closure must not erase capture provenance.
+//   error_contains: "region escapes its scope"
+fn build() -> () -> () -> Array[Int] {
+  region r {
+    let values = MutList::empty(r)
+    () -> () -> Array[Int] {
+      () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }
+  }
+}

--- a/fixtures/err_region_escape_nested_nominal_param.vibe
+++ b/fixtures/err_region_escape_nested_nominal_param.vibe
@@ -1,0 +1,19 @@
+struct CallbackBox[T] {
+  value: T
+}
+
+fn box_callback(box: CallbackBox[() -> Array[Int]]) -> () -> Array[Int] {
+  box.value
+}
+
+test "nominally nested callback parameters retain provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    box_callback(CallbackBox::{
+      value: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_nested_record_param.vibe
+++ b/fixtures/err_region_escape_nested_record_param.vibe
@@ -1,0 +1,15 @@
+fn keep_record[T](value: T) -> T {
+  value
+}
+
+test "record-nested callback parameters retain provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    keep_record(record {
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let _ = escaped.callback()
+}

--- a/fixtures/err_region_escape_nested_tuple_param.vibe
+++ b/fixtures/err_region_escape_nested_tuple_param.vibe
@@ -1,0 +1,13 @@
+fn first_callback(pair: (() -> Array[Int], Int)) -> () -> Array[Int] {
+  pair.0
+}
+
+test "tuple-nested callback parameters retain provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    first_callback((() -> Array[Int] {
+      MutList::to_array(values)
+    }, 0))
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_option_aggregate.vibe
+++ b/fixtures/err_region_escape_option_aggregate.vibe
@@ -1,0 +1,16 @@
+struct OptionSlot {
+  callback: () -> Array[Int]
+}
+
+test "Option constructors preserve nominal field provenance" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    Some(OptionSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let Some(slot) = escaped
+  let _ = slot.callback()
+}

--- a/fixtures/err_region_escape_outer_assignment.vibe
+++ b/fixtures/err_region_escape_outer_assignment.vibe
@@ -1,0 +1,17 @@
+// #1938: assigning a region-capturing closure into an outer cell must fail.
+//   error_contains: "region escapes its scope"
+fn build() -> () -> Array[Int] {
+  let mut leaked = () -> Array[Int] {
+    [
+    ]
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    MutList::push(values, 1)
+    leaked = () -> Array[Int] {
+      MutList::to_array(values)
+    }
+    0
+  }
+  leaked
+}

--- a/fixtures/err_region_escape_param_forwarding.vibe
+++ b/fixtures/err_region_escape_param_forwarding.vibe
@@ -1,0 +1,17 @@
+fn forward(f: () -> Array[Int]) -> () -> Array[Int] {
+  f
+}
+
+fn forward_twice(f: () -> Array[Int]) -> () -> Array[Int] {
+  forward(f)
+}
+
+test "parameter provenance survives helper composition" {
+  let escaped = region r {
+    let values = MutList::empty(r)
+    forward_twice(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+  }
+  let _ = escaped()
+}

--- a/fixtures/err_region_escape_priority_queue_write.vibe
+++ b/fixtures/err_region_escape_priority_queue_write.vibe
@@ -1,0 +1,20 @@
+struct PriorityQueue[T] {
+  mut marker: Int
+}
+
+fn PriorityQueue::push[T](q: PriorityQueue[T], x: T) -> Unit {
+  ()
+}
+
+test "PriorityQueue cannot retain region closures" {
+  let outer: PriorityQueue[() -> Array[Int]] = PriorityQueue::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    PriorityQueue::push(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_record.vibe
+++ b/fixtures/err_region_escape_record.vibe
@@ -1,0 +1,10 @@
+test "record fields cannot hide region-backed closures" {
+  let _ = region r {
+    let values = MutList::empty(r)
+    record {
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }
+  }
+}

--- a/fixtures/err_region_escape_result_aggregate.vibe
+++ b/fixtures/err_region_escape_result_aggregate.vibe
@@ -1,0 +1,21 @@
+struct ResultSlot {
+  callback: () -> Array[Int]
+}
+
+enum RegionResult[T, E] {
+  RegionOk(T);
+  RegionErr(E)
+}
+
+test "qualified Result-like constructors preserve payload provenance" {
+  let escaped: RegionResult[ResultSlot, String] = region r {
+    let values = MutList::empty(r)
+    RegionResult::RegionOk(ResultSlot::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    })
+  }
+  let RegionOk(slot) = escaped
+  let _ = slot.callback()
+}

--- a/fixtures/err_region_escape_sortedmap_alias_write.vibe
+++ b/fixtures/err_region_escape_sortedmap_alias_write.vibe
@@ -1,0 +1,20 @@
+struct MutSortedMap[K, V] {
+  mut marker: Int
+}
+
+fn SortedMap::set[K, V](m: MutSortedMap[K, V], k: K, v: V) -> Unit {
+  ()
+}
+
+test "legacy SortedMap::set keeps retaining-write checks" {
+  let outer: MutSortedMap[Int, () -> Array[Int]] = MutSortedMap::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    SortedMap::set(outer, 0, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_sortedmap_key_write.vibe
+++ b/fixtures/err_region_escape_sortedmap_key_write.vibe
@@ -1,0 +1,20 @@
+struct MutSortedMap[K, V] {
+  mut marker: Int
+}
+
+fn MutSortedMap::set[K, V](m: MutSortedMap[K, V], k: K, v: V) -> Unit {
+  ()
+}
+
+test "MutSortedMap keys cannot retain region closures" {
+  let outer: MutSortedMap[() -> Array[Int], Int] = MutSortedMap::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    MutSortedMap::set(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    }, 0)
+    0
+  }
+}

--- a/fixtures/err_region_escape_sortedmap_value_write.vibe
+++ b/fixtures/err_region_escape_sortedmap_value_write.vibe
@@ -1,0 +1,20 @@
+struct MutSortedMap[K, V] {
+  mut marker: Int
+}
+
+fn MutSortedMap::set[K, V](m: MutSortedMap[K, V], k: K, v: V) -> Unit {
+  ()
+}
+
+test "MutSortedMap values cannot retain region closures" {
+  let outer: MutSortedMap[Int, () -> Array[Int]] = MutSortedMap::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    MutSortedMap::set(outer, 0, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_sortedset_alias_write.vibe
+++ b/fixtures/err_region_escape_sortedset_alias_write.vibe
@@ -1,0 +1,20 @@
+struct MutSortedSet[T] {
+  mut marker: Int
+}
+
+fn SortedSet::add[T](s: MutSortedSet[T], x: T) -> Unit {
+  ()
+}
+
+test "legacy SortedSet::add keeps retaining-write checks" {
+  let outer: MutSortedSet[() -> Array[Int]] = MutSortedSet::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    SortedSet::add(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_sortedset_write.vibe
+++ b/fixtures/err_region_escape_sortedset_write.vibe
@@ -1,0 +1,20 @@
+struct MutSortedSet[T] {
+  mut marker: Int
+}
+
+fn MutSortedSet::add[T](s: MutSortedSet[T], x: T) -> Unit {
+  ()
+}
+
+test "MutSortedSet cannot retain region closures" {
+  let outer: MutSortedSet[() -> Array[Int]] = MutSortedSet::{
+    marker: 0
+  }
+  let _ = region r {
+    let values = MutList::empty(r)
+    MutSortedSet::add(outer, () -> Array[Int] {
+      MutList::to_array(values)
+    })
+    0
+  }
+}

--- a/fixtures/err_region_escape_struct_alias.vibe
+++ b/fixtures/err_region_escape_struct_alias.vibe
@@ -1,0 +1,15 @@
+struct StructAliasWrap {
+  callback: () -> Array[Int]
+}
+
+fn build_struct_alias() -> StructAliasWrap {
+  region r {
+    let values = MutList::empty(r)
+    let wrapped = StructAliasWrap::{
+      callback: () -> Array[Int] {
+        MutList::to_array(values)
+      }
+    }
+    wrapped
+  }
+}

--- a/fixtures/err_region_escape_struct_container.vibe
+++ b/fixtures/err_region_escape_struct_container.vibe
@@ -1,0 +1,16 @@
+struct StructContainerWrap {
+  callback: () -> Array[Int]
+}
+
+fn build_struct_container() -> Array[StructContainerWrap] {
+  region r {
+    let values = MutList::empty(r)
+    [
+      StructContainerWrap::{
+        callback: () -> Array[Int] {
+          MutList::to_array(values)
+        }
+      }
+    ]
+  }
+}

--- a/fixtures/region_ok_capture_provenance.vibe
+++ b/fixtures/region_ok_capture_provenance.vibe
@@ -1,0 +1,42 @@
+// #1938 positive witnesses: provenance follows values, not syntax. A generic
+// helper instantiated with a scalar is clean; an explicit copy-out is clean;
+// and a shadowing binder does not inherit the hidden region value.
+fn scalar_helper() -> Int {
+  let f = region r {
+    let capture = (value) -> () -> Int {
+      () -> Int {
+        value
+      }
+    }
+    let _ = MutList::empty(r)
+    capture(9)
+  }
+  f()
+}
+
+fn copied_closure() -> Int {
+  let f = region r {
+    let values = MutList::empty(r)
+    MutList::push(values, 7)
+    let copied = MutList::to_array(values)
+    () -> Int {
+      Array::get(copied, 0)
+    }
+  }
+  f()
+}
+
+fn shadowed_capture() -> Int {
+  let f = region r {
+    let value = MutList::empty(r)
+    let value = 5
+    () -> Int {
+      value
+    }
+  }
+  f()
+}
+
+test "region capture provenance positives" {
+  inspect(scalar_helper() + copied_closure() + shadowed_capture(), "21")
+}

--- a/fixtures/region_ok_capture_provenance.vibe
+++ b/fixtures/region_ok_capture_provenance.vibe
@@ -76,6 +76,22 @@ fn region_local_container_writes() -> Int {
   }
 }
 
+fn ignore_callback(f: () -> Array[Int]) -> () -> Array[Int] {
+  () -> Array[Int] {
+    []
+  }
+}
+
+fn ignored_capture_is_clean() -> Int {
+  let clean = region r {
+    let values = MutList::empty(r)
+    ignore_callback(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+  }
+  Array::length(clean())
+}
+
 test "region capture provenance positives" {
-  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes(), "55")
+  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + ignored_capture_is_clean(), "55")
 }

--- a/fixtures/region_ok_capture_provenance.vibe
+++ b/fixtures/region_ok_capture_provenance.vibe
@@ -94,6 +94,25 @@ fn region_local_call_alias_write() -> Int {
   }
 }
 
+enum LocalCarrier {
+  LocalHold(() -> Array[Int])
+}
+
+fn parameterless_local_carrier_assignment() -> Int {
+  region r {
+    let values = MutList::empty(r)
+    MutList::push(values, 19)
+    let mut local = LocalCarrier::LocalHold(() -> Array[Int] {
+      []
+    })
+    local = LocalCarrier::LocalHold(() -> Array[Int] {
+      MutList::to_array(values)
+    })
+    let LocalHold(callback) = local
+    Array::get(callback(), 0)
+  }
+}
+
 fn ignore_callback(f: () -> Array[Int]) -> () -> Array[Int] {
   () -> Array[Int] {
     [
@@ -138,5 +157,5 @@ fn local_callee_shadow_is_clean() -> Int {
 }
 
 test "region capture provenance positives" {
-  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + region_local_call_alias_write() + ignored_capture_is_clean() + parameter_shadow_is_clean() + local_callee_shadow_is_clean(), "77")
+  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + region_local_call_alias_write() + parameterless_local_carrier_assignment() + ignored_capture_is_clean() + parameter_shadow_is_clean() + local_callee_shadow_is_clean(), "96")
 }

--- a/fixtures/region_ok_capture_provenance.vibe
+++ b/fixtures/region_ok_capture_provenance.vibe
@@ -60,7 +60,8 @@ fn region_local_container_writes() -> Int {
   region r {
     let values = MutList::empty(r)
     MutList::push(values, 13)
-    let local_array: Array[() -> Int] = []
+    let local_array: Array[() -> Int] = [
+    ]
     Array::push(local_array, () -> Int {
       Array::get(MutList::to_array(values), 0)
     })
@@ -78,7 +79,8 @@ fn region_local_container_writes() -> Int {
 
 fn ignore_callback(f: () -> Array[Int]) -> () -> Array[Int] {
   () -> Array[Int] {
-    []
+    [
+    ]
   }
 }
 
@@ -102,6 +104,22 @@ fn parameter_shadow_is_clean() -> Int {
   clean(4)
 }
 
+fn local_callee_shadow_is_clean() -> Int {
+  let clean = region r {
+    let values = MutList::empty(r)
+    let read = () -> Array[Int] {
+      MutList::to_array(values)
+    }
+    () -> Int {
+      let read = () -> Int {
+        1
+      }
+      read()
+    }
+  }
+  clean()
+}
+
 test "region capture provenance positives" {
-  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + ignored_capture_is_clean() + parameter_shadow_is_clean(), "59")
+  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + ignored_capture_is_clean() + parameter_shadow_is_clean() + local_callee_shadow_is_clean(), "60")
 }

--- a/fixtures/region_ok_capture_provenance.vibe
+++ b/fixtures/region_ok_capture_provenance.vibe
@@ -92,6 +92,16 @@ fn ignored_capture_is_clean() -> Int {
   Array::length(clean())
 }
 
+fn parameter_shadow_is_clean() -> Int {
+  let clean = region r {
+    let value = MutList::empty(r)
+    (value: Int) -> Int {
+      value
+    }
+  }
+  clean(4)
+}
+
 test "region capture provenance positives" {
-  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + ignored_capture_is_clean(), "55")
+  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + ignored_capture_is_clean() + parameter_shadow_is_clean(), "59")
 }

--- a/fixtures/region_ok_capture_provenance.vibe
+++ b/fixtures/region_ok_capture_provenance.vibe
@@ -77,6 +77,23 @@ fn region_local_container_writes() -> Int {
   }
 }
 
+fn local_identity[T](value: T) -> T {
+  value
+}
+
+fn region_local_call_alias_write() -> Int {
+  region r {
+    let values = MutList::empty(r)
+    MutList::push(values, 17)
+    let local_array: Array[() -> Int] = [
+    ]
+    Array::push(local_identity(local_array), () -> Int {
+      Array::get(MutList::to_array(values), 0)
+    })
+    Array::get(local_array, 0)()
+  }
+}
+
 fn ignore_callback(f: () -> Array[Int]) -> () -> Array[Int] {
   () -> Array[Int] {
     [
@@ -121,5 +138,5 @@ fn local_callee_shadow_is_clean() -> Int {
 }
 
 test "region capture provenance positives" {
-  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + ignored_capture_is_clean() + parameter_shadow_is_clean() + local_callee_shadow_is_clean(), "60")
+  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes() + region_local_call_alias_write() + ignored_capture_is_clean() + parameter_shadow_is_clean() + local_callee_shadow_is_clean(), "77")
 }

--- a/fixtures/region_ok_capture_provenance.vibe
+++ b/fixtures/region_ok_capture_provenance.vibe
@@ -52,6 +52,30 @@ fn region_local_assignment() -> Int {
   }
 }
 
+struct LocalSlot {
+  mut callback: () -> Int
+}
+
+fn region_local_container_writes() -> Int {
+  region r {
+    let values = MutList::empty(r)
+    MutList::push(values, 13)
+    let local_array: Array[() -> Int] = []
+    Array::push(local_array, () -> Int {
+      Array::get(MutList::to_array(values), 0)
+    })
+    let local_slot = LocalSlot::{
+      callback: () -> Int {
+        0
+      }
+    }
+    local_slot.callback = () -> Int {
+      Array::get(MutList::to_array(values), 0)
+    }
+    Array::get(local_array, 0)() + local_slot.callback()
+  }
+}
+
 test "region capture provenance positives" {
-  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment(), "29")
+  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment() + region_local_container_writes(), "55")
 }

--- a/fixtures/region_ok_capture_provenance.vibe
+++ b/fixtures/region_ok_capture_provenance.vibe
@@ -37,6 +37,21 @@ fn shadowed_capture() -> Int {
   f()
 }
 
+fn region_local_assignment() -> Int {
+  region r {
+    let values = MutList::empty(r)
+    MutList::push(values, 8)
+    let mut local = () -> Int {
+      0
+    }
+    local = () -> Int {
+      Array::get(MutList::to_array(values), 0)
+    }
+    let observed = local
+    observed()
+  }
+}
+
 test "region capture provenance positives" {
-  inspect(scalar_helper() + copied_closure() + shadowed_capture(), "21")
+  inspect(scalar_helper() + copied_closure() + shadowed_capture() + region_local_assignment(), "29")
 }

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -113,7 +113,7 @@ fn canonical_effect_labels(text: String) -> Array[String] {
       depth = depth - 1
     } else if c == 44 && depth == 0 {
       let label = String::trim(String::substring(text, start, i))
-      if String::length(label) > 0 {
+      if String::length(label) > 0 && !canonical_is_provenance_label(label) {
         Array::push(raw, canonical_exception_effect_name(label))
       }
       start = i + 1
@@ -121,10 +121,14 @@ fn canonical_effect_labels(text: String) -> Array[String] {
     i = i + 1
   }
   let last = String::trim(String::substring(text, start, String::length(text)))
-  if String::length(last) > 0 {
+  if String::length(last) > 0 && !canonical_is_provenance_label(last) {
     Array::push(raw, canonical_exception_effect_name(last))
   }
   sorted_unique_strings(raw)
+}
+
+fn canonical_is_provenance_label(label: String) -> Bool {
+  String::starts_with(label, "#region_") || String::starts_with(label, "#capture[") || String::starts_with(label, "#param[") || String::starts_with(label, "#aliasparam[") || String::starts_with(label, "#fieldparam[")
 }
 
 fn canonical_is_effect_var(name: String) -> Bool {
@@ -190,10 +194,13 @@ fn canonical_effect(s: Subst, effect: Option[String]) -> String {
         Some(name)
       }
       match resolved {
-        Some(text) => if String::length(text) == 0 {
-          canonical_node("EP", array_empty())
-        } else {
-          canonical_node("ER", canonical_effect_labels(text))
+        Some(text) => {
+          let labels = canonical_effect_labels(text)
+          if String::length(text) == 0 || Array::length(labels) == 0 {
+            canonical_node("EP", array_empty())
+          } else {
+            canonical_node("ER", labels)
+          }
         },
         None => canonical_node("EV", [
           name
@@ -895,17 +902,19 @@ fn canonical_effect_with_params(s: Subst, effect: Option[String], params: Array[
         Some(name)
       }
       match resolved {
-        Some(text) => if String::length(text) == 0 {
-          canonical_node("EP", array_empty())
-        } else {
+        Some(text) => {
           let labels = canonical_effect_labels(text)
-          let normalized = array_empty()
-          let mut i = 0
-          while i < Array::length(labels) {
-            Array::push(normalized, canonical_effect_label_with_params(Array::get(labels, i), params))
-            i = i + 1
+          if String::length(text) == 0 || Array::length(labels) == 0 {
+            canonical_node("EP", array_empty())
+          } else {
+            let normalized = array_empty()
+            let mut i = 0
+            while i < Array::length(labels) {
+              Array::push(normalized, canonical_effect_label_with_params(Array::get(labels, i), params))
+              i = i + 1
+            }
+            canonical_node("ER", sorted_unique_strings(normalized))
           }
-          canonical_node("ER", sorted_unique_strings(normalized))
         },
         None => canonical_node("EV", [
           canonical_effect_label_with_params(name, params)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -1418,7 +1418,7 @@ fn direct_result_param_index(body: Expr, params: Array[(String, Option[TypeExpr]
   }
 }
 
-fn direct_result_field_param_index(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Option[Int] {
+fn result_field_param_index(body: Expr, params: Array[(String, Option[TypeExpr])], alias_names: Array[String], alias_indices: Array[Int]) -> Option[Int] {
   match body {
     EDot(EIdent(name, _), _, _, _) => {
       let mut found = None
@@ -1431,6 +1431,117 @@ fn direct_result_field_param_index(body: Expr, params: Array[(String, Option[Typ
         i = i + 1
       }
       found
+    },
+    EIdent(name, _) => {
+      let mut found = None
+      let mut i = 0
+      while i < Array::length(alias_names) {
+        if Array::get(alias_names, i) == name {
+          found = Some(Array::get(alias_indices, i))
+        }
+        i = i + 1
+      }
+      found
+    },
+    ELet(name, value, rest, _) => {
+      let next_names = for alias in alias_names {
+        alias
+      }
+      let next_indices = for index in alias_indices {
+        index
+      }
+      match result_field_param_index(value, params, alias_names, alias_indices) {
+        Some(index) => {
+          Array::push(next_names, name)
+          Array::push(next_indices, index)
+        },
+        None => ()
+      }
+      result_field_param_index(rest, params, next_names, next_indices)
+    },
+    ESeq(_, right) => result_field_param_index(right, params, alias_names, alias_indices),
+    EIf(_, then_expr, else_expr) => match result_field_param_index(then_expr, params, alias_names, alias_indices) {
+      Some(index) => Some(index),
+      None => result_field_param_index(else_expr, params, alias_names, alias_indices)
+    },
+    _ => None
+  }
+}
+
+fn direct_result_field_param_index(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Option[Int] {
+  result_field_param_index(body, params, array_empty(), array_empty())
+}
+
+fn collect_explicit_return_types(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, out: Array[Type], ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Unit {
+  match expr {
+    EFn(_, _, _, _, _, _) => (),
+    EReturn(value) => {
+      let throwaway = array_empty()
+      let throwtab = array_empty()
+      let (value_ty, next_s, _) = ce(value, env, defs, s, c, throwaway, throwtab)
+      Array::push(out, subst_apply(next_s, value_ty))
+    },
+    ELet(name, value, body, _) => {
+      let throwaway = array_empty()
+      let throwtab = array_empty()
+      let (value_ty, next_s, next_c) = ce(value, env, defs, s, c, throwaway, throwtab)
+      collect_explicit_return_types(body, env_bind(env, name, value_ty), defs, next_s, next_c, out, ce)
+    },
+    ELetMut(name, value, body, _) => {
+      let throwaway = array_empty()
+      let throwtab = array_empty()
+      let (value_ty, next_s, next_c) = ce(value, env, defs, s, c, throwaway, throwtab)
+      collect_explicit_return_types(body, env_bind_mut(env, name, value_ty, false), defs, next_s, next_c, out, ce)
+    },
+    _ => {
+      for child in expr_children(expr) {
+        collect_explicit_return_types(child, env, defs, s, c, out, ce)
+      }
+      ()
+    }
+  }
+}
+
+fn is_enum_ctor_name(name: String, defs: Array[TypeDef]) -> Bool {
+  let separator = String::last_index_of(name, "::")
+  let member = if separator >= 0 {
+    String::substring(name, separator + 2, String::length(name))
+  } else {
+    name
+  }
+  let mut found = name == "Some"
+  for type_def in defs {
+    match type_def {
+      TDEnum(_, _, variants) => {
+        for variant in variants {
+          let (variant_name, _) = variant
+          if variant_name == member {
+            found = true
+          }
+        }
+        ()
+      },
+      _ => ()
+    }
+  }
+  found
+}
+
+fn direct_result_enum_payload_param_index(body: Expr, params: Array[(String, Option[TypeExpr])], defs: Array[TypeDef]) -> Option[Int] {
+  match body {
+    ECall(EIdent(ctor_name, _), args, _) => if is_enum_ctor_name(ctor_name, defs) {
+      let mut found = None
+      for call_arg in args {
+        match direct_result_param_index(call_arg, params) {
+          Some(index) => {
+            found = Some(index)
+          },
+          None => ()
+        }
+      }
+      found
+    } else {
+      None
     },
     _ => None
   }
@@ -8368,7 +8479,9 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         None => env_bind(fn_env, "__return__", CtUnknown)
       }
       let (bt, s2, c2) = check_expr_capture(body, body_env, defs, s1, c1, errors, tytab, capture, lane)
-      let (final_ret, s3) = match ret_ty {
+      let explicit_return_types = array_empty()
+      collect_explicit_return_types(body, body_env, defs, s2, c2, explicit_return_types, check_expr)
+      let (base_ret, s3) = match ret_ty {
         Some(te) => {
           let resolved = resolve_type_expr_shadowed(te, defs, tparams)
           let resolved_ret = resolve_tparams_in(resolved, fn_env)
@@ -8399,6 +8512,10 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         },
         None => (subst_apply(s2, bt), s2)
       }
+      let mut final_ret = base_ret
+      for explicit_ret in explicit_return_types {
+        final_ret = merge_capture_provenance(final_ret, subst_apply(s3, explicit_ret))
+      }
       let capture_effect = closure_capture_row(effect, body, params, fn_env, s3)
       let checked_effect = match direct_result_param_index(body, params) {
         Some(index) => merge_provenance_row(capture_effect, Some(String::concat("#aliasparam[", String::concat(__to_string(index), "]")))),
@@ -8406,7 +8523,10 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       }
       let dependency_effect = match direct_result_field_param_index(body, params) {
         Some(index) => merge_provenance_row(checked_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]")))),
-        None => checked_effect
+        None => match direct_result_enum_payload_param_index(body, params, defs) {
+          Some(index) => merge_provenance_row(checked_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]")))),
+          None => checked_effect
+        }
       }
       (CtFn(param_types, final_ret, dependency_effect), s3, c2)
     },

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -1286,6 +1286,7 @@ fn container_write_crosses_region(target: Expr, ty: Type, env: TypeEnv) -> Bool 
     } else {
       false
     },
+    ECall(_, _, _) => expression_aliases_outer_binding(target, env) && type_mentions_active_region(ty, env),
     _ => false
   }
 }
@@ -1527,24 +1528,32 @@ fn is_enum_ctor_name(name: String, defs: Array[TypeDef]) -> Bool {
   found
 }
 
-fn direct_result_enum_payload_param_index(body: Expr, params: Array[(String, Option[TypeExpr])], defs: Array[TypeDef]) -> Option[Int] {
+fn direct_result_enum_payload_param_indices(body: Expr, params: Array[(String, Option[TypeExpr])], defs: Array[TypeDef]) -> Array[Int] {
+  let found = array_empty()
   match body {
     ECall(EIdent(ctor_name, _), args, _) => if is_enum_ctor_name(ctor_name, defs) {
-      let mut found = None
       for call_arg in args {
         match direct_result_param_index(call_arg, params) {
           Some(index) => {
-            found = Some(index)
+            let mut seen = false
+            for existing in found {
+              if existing == index {
+                seen = true
+              }
+            }
+            if !seen {
+              Array::push(found, index)
+            }
           },
           None => ()
         }
       }
-      found
     } else {
-      None
+      ()
     },
-    _ => None
+    _ => ()
   }
+  found
 }
 
 export fn bind_function_dependency_contracts(env: TypeEnv, name: String, value: Expr) -> TypeEnv {
@@ -4646,6 +4655,12 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
               found = true
             }
             i = i + 1
+          }
+          match alias_result_param_index(callee_ty) {
+            Some(index) => if index >= 0 && index < Array::length(args) && tail_named_record_mentions_region(Array::get(args, index), env, defs, s1, c1, region_name, ce) {
+              found = true
+            },
+            None => ()
           }
           match callee_effect {
             Some(row) => for raw in String::split(row, ",") {
@@ -8563,17 +8578,18 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         } else {
           checked_effect
         },
-        None => match direct_result_enum_payload_param_index(body, params, defs) {
-          Some(index) => if type_can_carry_region(if index >= 0 && index < Array::length(param_types) {
-            subst_apply(s3, Array::get(param_types, index))
-          } else {
-            CtUnit
-          }) {
-            merge_provenance_row(checked_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]"))))
-          } else {
-            checked_effect
-          },
-          None => checked_effect
+        None => {
+          let mut enum_dependency_effect = checked_effect
+          for index in direct_result_enum_payload_param_indices(body, params, defs) {
+            if type_can_carry_region(if index >= 0 && index < Array::length(param_types) {
+              subst_apply(s3, Array::get(param_types, index))
+            } else {
+              CtUnit
+            }) {
+              enum_dependency_effect = merge_provenance_row(enum_dependency_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]"))))
+            }
+          }
+          enum_dependency_effect
         }
       }
       (CtFn(param_types, final_ret, dependency_effect), s3, c2)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -812,6 +812,18 @@ fn type_mentions_named(ty: Type, name: String) -> Bool {
     },
     CtArray(e) => type_mentions_named(e, name),
     CtOption(e) => type_mentions_named(e, name),
+    CtRecord(fields) => {
+      let mut found = false
+      for field in fields {
+        let (_, field_ty) = field
+        if type_mentions_named(field_ty, name) {
+          found = true
+        } else {
+          ()
+        }
+      }
+      found
+    },
     CtFn(ps, ret, eff) => {
       let mut found = type_mentions_named(ret, name)
       match eff {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -35,6 +35,7 @@ import @vibe/compiler/core {
   type_implements_trait,
   type_name_has_iterator_impl,
   type_to_string,
+  types_equal,
   unify
 }
 
@@ -1184,6 +1185,22 @@ fn assignment_crosses_region(name: String, ty: Type, env: TypeEnv) -> Bool {
   }
 }
 
+/// A mutable aggregate inherits the lifetime of its binding. Writes through a
+/// region-local binding are safe; a binding outside the active region must not
+/// retain a value whose closure provenance names that region.
+fn container_write_crosses_region(target: Expr, ty: Type, env: TypeEnv) -> Bool {
+  match target {
+    EIdent(name, _) => assignment_crosses_region(name, ty, env),
+    EDot(obj, _, _, _) => container_write_crosses_region(obj, ty, env),
+    ECall(EIdent("__index", _), args, _) => if Array::length(args) > 0 {
+      container_write_crosses_region(Array::get(args, 0), ty, env)
+    } else {
+      false
+    },
+    _ => false
+  }
+}
+
 fn env_has_active_region(env: TypeEnv) -> Bool {
   match env {
     EnvEmpty => false,
@@ -2329,6 +2346,53 @@ fn unify_call_args(param_tys: Array[Type], arg_tys: Array[Type], s: Subst, error
     ui = ui + 1
   }
   out
+}
+
+/// Ordinary unification intentionally ignores checker-only capture labels.
+/// When a concrete callback parameter is also returned, restore the argument's
+/// provenance on the corresponding result node after argument checking.
+fn propagate_matching_call_provenance(result: Type, param: Type, actual: Type) -> Type {
+  if types_equal(result, param) {
+    merge_capture_provenance(result, actual)
+  } else {
+    match result {
+      CtFn(params, ret, effect) => {
+        let mapped = array_empty()
+        for item in params {
+          Array::push(mapped, propagate_matching_call_provenance(item, param, actual))
+        }
+        CtFn(mapped, propagate_matching_call_provenance(ret, param, actual), effect)
+      },
+      CtArray(elem) => CtArray(propagate_matching_call_provenance(elem, param, actual)),
+      CtOption(elem) => CtOption(propagate_matching_call_provenance(elem, param, actual)),
+      CtTuple(items) => {
+        let mapped = array_empty()
+        for item in items {
+          Array::push(mapped, propagate_matching_call_provenance(item, param, actual))
+        }
+        CtTuple(mapped)
+      },
+      CtNamed(name, args) => {
+        let mapped = array_empty()
+        for arg in args {
+          Array::push(mapped, propagate_matching_call_provenance(arg, param, actual))
+        }
+        CtNamed(name, mapped)
+      },
+      _ => result
+    }
+  }
+}
+
+fn call_result_with_provenance(ret: Type, param_tys: Array[Type], arg_tys: Array[Type], s: Subst) -> Type {
+  let mut result = subst_apply(s, ret)
+  let len = min_int(Array::length(param_tys), Array::length(arg_tys))
+  let mut i = 0
+  while i < len {
+    result = propagate_matching_call_provenance(result, subst_apply(s, Array::get(param_tys, i)), subst_apply(s, Array::get(arg_tys, i)))
+    i = i + 1
+  }
+  result
 }
 
 /// #844: recognize the EXACT synthetic call shape `parser_expr_dispatch.vibe`'s
@@ -3854,6 +3918,31 @@ fn field_write_mut_check(name: String, args: Array[Expr], env: TypeEnv, defs: Ar
   }
 }
 
+/// Mutable container operations are assignments with a non-syntactic target.
+/// Check their stored argument against the same region lifetime rule as
+/// `EAssign`; operations that only store scalar bytes/indices need no entry.
+fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Unit {
+  let value_index = if name == "Array::push" || name == "ArrayBuilder::push" || name == "Array::push_all" {
+    1
+  } else if name == "Array::set" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "MapBuilder::set" || name == "__set_field" {
+    2
+  } else {
+    0 - 1
+  }
+  if value_index >= 0 && Array::length(args) > value_index {
+    let throwaway = array_empty()
+    let throwtab = array_empty()
+    let (val_ty, s1, _) = ce(Array::get(args, value_index), env, defs, s, c, throwaway, throwtab)
+    if container_write_crosses_region(Array::get(args, 0), subst_apply(s1, val_ty), env) {
+      Array::push(errors, String::concat("region escapes its scope: a container write stores a value that captures this region into an outer binding", off_marker(tail_expr_off(Array::get(args, value_index)))))
+    } else {
+      ()
+    }
+  } else {
+    ()
+  }
+}
+
 /// `obj[i]` desugars to `__index(obj, i)`, typed fully polymorphically, so
 /// indexing a non-indexable scalar (`let n = 5; n[0]`) was accepted silently.
 /// Report when `obj` resolves to a concrete scalar that cannot be indexed
@@ -4832,6 +4921,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         // remains structural child 0 under core::expr_children.
         typed_occurrence_capture_skip_children(capture, 1)
         field_write_mut_check(name, args, env, defs, s, c, errors, tytab, check_expr)
+        retaining_write_region_check(name, args, env, defs, s, c, errors, check_expr)
         index_target_check(name, args, env, defs, s, c, errors, check_expr)
         if name == "perform" {
           if Array::length(args) == 1 {
@@ -6140,8 +6230,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                         Array::push(errors, String::concat(String::concat("function arity mismatch for ", String::concat(name, String::concat(": expected ", String::concat(__to_string(plen2), String::concat(" args, got ", __to_string(alen3)))))), off_marker_len(callee_off, String::length(name))))
                       }
                       let s3 = unify_call_args(call_param_tys, arg_tys, s2, errors, name, callee_off)
-                      let call_ret = Array::get(ret_box, 0)
-                      (tab_call_ty(tytab, call_off, subst_apply(s3, call_ret), capture, lane), s3, c2)
+                      let call_ret = call_result_with_provenance(Array::get(ret_box, 0), call_param_tys, arg_tys, s3)
+                      (tab_call_ty(tytab, call_off, call_ret, capture, lane), s3, c2)
                     },
                     CtStruct(sname) => (tab_call_ty(tytab, call_off, CtStruct(sname), capture, lane), s2, c2),
                     other => {
@@ -6300,7 +6390,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                     Some(t) => t,
                     None => call_ret
                   }
-                  (tab_call_ty(tytab, call_off, subst_apply(s4, selected_ret), capture, lane), s4, c3)
+                  let result_ty = call_result_with_provenance(selected_ret, call_param_tys, arg_tys, s4)
+                  (tab_call_ty(tytab, call_off, result_ty, capture, lane), s4, c3)
                 },
                 _ => {
                   // No method/builtin `T::method` resolved. If the receiver is a
@@ -6322,7 +6413,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                         Array::push(errors, String::concat(String::concat("function arity mismatch for ", String::concat(qualified, String::concat(": expected ", String::concat(__to_string(Array::length(fpts)), String::concat(" args, got ", __to_string(Array::length(explicit))))))), off_marker_len(call_off, String::length(qualified))))
                       }
                       let s4 = unify_call_args(fpts, explicit, s3, errors, qualified, call_off)
-                      (tab_call_ty(tytab, call_off, subst_apply(s4, fret), capture, lane), s4, c3)
+                      let result_ty = call_result_with_provenance(fret, fpts, explicit, s4)
+                      (tab_call_ty(tytab, call_off, result_ty, capture, lane), s4, c3)
                     },
                     _ => match direct_ret {
                       Some(t) => (tab_call_ty(tytab, call_off, t, capture, lane), s3, c3),
@@ -6483,8 +6575,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                         Array::push(errors, String::concat(String::concat("function arity mismatch for ", String::concat(callee_name0, String::concat(": expected ", String::concat(__to_string(plen2), String::concat(" args, got ", __to_string(alen3)))))), off_marker_len(call_off, String::length(callee_name0))))
                       }
                       let s3 = unify_call_args(call_param_tys, arg_tys, s2, errors, callee_name0, call_off)
-                      let call_ret = Array::get(ret_box, 0)
-                      (tab_call_ty(tytab, call_off, subst_apply(s3, call_ret), capture, lane), s3, c2)
+                      let call_ret = call_result_with_provenance(Array::get(ret_box, 0), call_param_tys, arg_tys, s3)
+                      (tab_call_ty(tytab, call_off, call_ret, capture, lane), s3, c2)
                     },
                     CtStruct(sname) => (tab_call_ty(tytab, call_off, CtStruct(sname), capture, lane), s2, c2),
                     _ => (tab_call_ty(tytab, call_off, CtUnknown, capture, lane), s2, c2)
@@ -6521,8 +6613,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                     Array::push(errors, String::concat(String::concat("function arity mismatch for <expr>: expected ", String::concat(__to_string(plen2), String::concat(" args, got ", __to_string(alen3)))), off_marker(call_off)))
                   }
                   let s3 = unify_call_args(call_param_tys, arg_tys, s2, errors, "<expr>", call_off)
-                  let call_ret = Array::get(ret_box, 0)
-                  (tab_call_ty(tytab, call_off, subst_apply(s3, call_ret), capture, lane), s3, c2)
+                  let call_ret = call_result_with_provenance(Array::get(ret_box, 0), call_param_tys, arg_tys, s3)
+                  (tab_call_ty(tytab, call_off, call_ret, capture, lane), s3, c2)
                 },
                 CtStruct(sname) => (tab_call_ty(tytab, call_off, CtStruct(sname), capture, lane), s2, c2),
                 _ => (tab_call_ty(tytab, call_off, CtUnknown, capture, lane), s2, c2)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -864,7 +864,7 @@ fn merge_provenance_row(expected: Option[String], actual: Option[String]) -> Opt
   match actual {
     Some(row) => for raw in String::split(row, ",") {
       let label = String::trim(raw)
-      if (String::starts_with(label, "#region_") || String::starts_with(label, "#capture[") || String::starts_with(label, "#param[")) && !string_array_has(labels, label) {
+      if (String::starts_with(label, "#region_") || String::starts_with(label, "#capture[") || String::starts_with(label, "#param[") || String::starts_with(label, "#aliasparam[") || String::starts_with(label, "#fieldparam[")) && !string_array_has(labels, label) {
         Array::push(labels, label)
       }
     },
@@ -1361,6 +1361,14 @@ fn expression_aliases_outer_binding(expr: Expr, env: TypeEnv) -> Bool {
           },
           None => false
         }
+      },
+      None => false
+    },
+    ECall(EFn(_, _, params, _, _, body), args, _) => match direct_result_param_index(body, params) {
+      Some(index) => if index >= 0 && index < Array::length(args) {
+        expression_aliases_outer_binding(Array::get(args, index), env)
+      } else {
+        false
       },
       None => false
     },

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -59,7 +59,7 @@ import ./checker_resolve.vibe {
 }
 
 import ./checker_spawnable.vibe {
-  check_spawnable_captures, closure_free_names
+  check_spawnable_captures, closure_bare_callee_names, closure_free_names
 }
 
 import ./checker_escape.vibe {
@@ -1126,7 +1126,7 @@ fn append_row_label(labels: Array[String], label: String) -> Unit {
 /// `#capture[v]` resolves to `#region_n` only if call-site unification binds v
 /// to a region-tagged type. This is what makes helper functions structural
 /// rather than another literal-name pattern.
-fn closure_capture_row(effect: Option[String], body: Expr, env: TypeEnv, s: Subst) -> Option[String] {
+fn closure_capture_row(effect: Option[String], body: Expr, params: Array[(String, Option[TypeExpr])], env: TypeEnv, s: Subst) -> Option[String] {
   let labels = match effect {
     Some(row) => for raw in String::split(row, ",") {
       String::trim(raw)
@@ -1134,7 +1134,7 @@ fn closure_capture_row(effect: Option[String], body: Expr, env: TypeEnv, s: Subs
     None => array_empty()
   }
   let active_region = env_has_active_region(env)
-  let captured_names = closure_free_names(body)
+  let captured_names = closure_free_names(body, params)
   let seen_names = array_empty()
   let mut i = 0
   while i < Array::length(captured_names) {
@@ -1144,23 +1144,58 @@ fn closure_capture_row(effect: Option[String], body: Expr, env: TypeEnv, s: Subs
       match env_lookup(env, name) {
         Some(raw_ty) => {
           let ty = subst_apply(s, raw_ty)
-          let regions = array_empty()
-          collect_region_skolems(ty, regions)
+          let provenance = array_empty()
+          collect_internal_provenance(ty, provenance)
           let vars = collect_tvars(ty)
-          let region_relevant = Array::length(regions) > 0 || Array::length(vars) > 0
-          if region_relevant {
-            for region_name in regions {
-              append_row_label(labels, region_name)
-            }
-            for var_id in vars {
-              append_row_label(labels, String::concat("#capture[", String::concat(__to_string(var_id), "]")))
-            }
+          for label in provenance {
+            append_row_label(labels, label)
+          }
+          for var_id in vars {
+            append_row_label(labels, String::concat("#capture[", String::concat(__to_string(var_id), "]")))
           }
         },
         None => ()
       }
     }
     i = i + 1
+  }
+  // A bare callee is omitted by the ordinary free-name walk so top-level
+  // calls do not make every closure capture the global environment. Two
+  // callee classes still carry value provenance: a callback parameter, and a
+  // concrete region-backed local closure while checking a region body.
+  for callee in closure_bare_callee_names(body) {
+    let mut is_param = false
+    for param in params {
+      let (raw_name, _) = param
+      let nlen = String::length(raw_name)
+      let param_name = if nlen > 0 {
+        let last = String::char_code_at(raw_name, nlen - 1)
+        if last == '~' || last == '?' {
+          raw_name[0: nlen - 1]
+        } else raw_name
+      } else raw_name
+      if callee == param_name {
+        is_param = true
+      }
+    }
+    match env_lookup(env, callee) {
+      Some(raw_ty) => {
+        let ty = subst_apply(s, raw_ty)
+        let provenance = array_empty()
+        collect_internal_provenance(ty, provenance)
+        for label in provenance {
+          if String::starts_with(label, "#param[") || (active_region && String::starts_with(label, "#region_")) {
+            append_row_label(labels, label)
+          }
+        }
+        if is_param {
+          for var_id in collect_tvars(ty) {
+            append_row_label(labels, String::concat("#capture[", String::concat(__to_string(var_id), "]")))
+          }
+        }
+      },
+      None => ()
+    }
   }
   if Array::length(labels) == 0 {
     None
@@ -1265,13 +1300,132 @@ fn binding_predates_active_region(name: String, env: TypeEnv) -> Bool {
   }
 }
 
+fn alias_result_param_index(ty: Type) -> Option[Int] {
+  match ty {
+    CtForAll(_, _, body) => alias_result_param_index(body),
+    CtFn(_, _, effect) => match effect {
+      Some(row) => {
+        let mut found = None
+        for raw in String::split(row, ",") {
+          let label = String::trim(raw)
+          if String::starts_with(label, "#aliasparam[") {
+            let close = String::index_of(label, "]")
+            let mut id = 0
+            let mut p = 12
+            while p < close {
+              id = id * 10 + (String::char_code_at(label, p) - 48)
+              p = p + 1
+            }
+            found = Some(id)
+          }
+        }
+        found
+      },
+      None => None
+    },
+    _ => None
+  }
+}
+
+fn decimal_index(text: String) -> Int {
+  let mut out = 0
+  let mut i = 0
+  while i < String::length(text) {
+    out = out * 10 + (String::char_code_at(text, i) - 48)
+    i = i + 1
+  }
+  out
+}
+
 fn expression_aliases_outer_binding(expr: Expr, env: TypeEnv) -> Bool {
   match expr {
     EIdent(name, _) => binding_predates_active_region(name, env) || match env_lookup(env, String::concat("__region_outer_alias__", name)) {
       Some(_) => true,
       None => false
     },
+    ECall(EIdent(callee, _), args, _) => match env_lookup(env, callee) {
+      Some(callee_ty) => match env_lookup(env, String::concat("__alias_contract__", callee)) {
+        Some(CtNamed(index_text, _)) => {
+          let index = decimal_index(index_text)
+          if index >= 0 && index < Array::length(args) {
+            expression_aliases_outer_binding(Array::get(args, index), env)
+          } else {
+            false
+          }
+        },
+        _ => match alias_result_param_index(callee_ty) {
+          Some(index) => if index >= 0 && index < Array::length(args) {
+            expression_aliases_outer_binding(Array::get(args, index), env)
+          } else {
+            false
+          },
+          None => false
+        }
+      },
+      None => false
+    },
     _ => false
+  }
+}
+
+fn direct_result_param_index(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Option[Int] {
+  match body {
+    EIdent(name, _) => {
+      let mut found = None
+      let mut i = 0
+      while i < Array::length(params) {
+        let (raw_name, _) = Array::get(params, i)
+        let nlen = String::length(raw_name)
+        let param_name = if nlen > 0 {
+          let last = String::char_code_at(raw_name, nlen - 1)
+          if last == '~' || last == '?' {
+            raw_name[0: nlen - 1]
+          } else raw_name
+        } else raw_name
+        if name == param_name {
+          found = Some(i)
+        }
+        i = i + 1
+      }
+      found
+    },
+    _ => None
+  }
+}
+
+fn direct_result_field_param_index(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Option[Int] {
+  match body {
+    EDot(EIdent(name, _), _, _, _) => {
+      let mut found = None
+      let mut i = 0
+      while i < Array::length(params) {
+        let (raw_name, _) = Array::get(params, i)
+        if name == raw_name {
+          found = Some(i)
+        }
+        i = i + 1
+      }
+      found
+    },
+    _ => None
+  }
+}
+
+export fn bind_function_dependency_contracts(env: TypeEnv, name: String, value: Expr) -> TypeEnv {
+  match value {
+    EFn(_, _, params, _, _, body) => {
+      let with_alias = match direct_result_param_index(body, params) {
+        Some(index) => env_bind(env, String::concat("__alias_contract__", name), CtNamed(__to_string(index), [
+        ])),
+        None => env
+      }
+      match direct_result_field_param_index(body, params) {
+        Some(index) => env_bind(with_alias, String::concat("__field_contract__", name), CtNamed(__to_string(index), [
+        ])),
+        None => with_alias
+      }
+    },
+    _ => env
   }
 }
 
@@ -2456,7 +2610,7 @@ fn collect_internal_provenance(ty: Type, out: Array[String]) -> Unit {
       match effect {
         Some(row) => for raw in String::split(row, ",") {
           let label = String::trim(raw)
-          if (String::starts_with(label, "#region_") || String::starts_with(label, "#capture[")) && !string_array_has(out, label) {
+          if (String::starts_with(label, "#region_") || String::starts_with(label, "#capture[") || String::starts_with(label, "#param[")) && !string_array_has(out, label) {
             Array::push(out, label)
           }
         },
@@ -2476,14 +2630,83 @@ fn collect_internal_provenance(ty: Type, out: Array[String]) -> Unit {
       let (_, field_ty) = field
       collect_internal_provenance(field_ty, out)
     },
-    CtNamed(_, args) => for arg in args {
-      collect_internal_provenance(arg, out)
+    CtNamed(name, args) => {
+      if String::starts_with(name, "#region_") && !string_array_has(out, name) {
+        Array::push(out, name)
+      }
+      for arg in args {
+        collect_internal_provenance(arg, out)
+      }
     },
     _ => ()
   }
 }
 
-fn resolve_param_provenance(ty: Type, arg_tys: Array[Type]) -> Type {
+fn type_has_param_marker(ty: Type, marker: Int) -> Bool {
+  let wanted = String::concat("#param[", String::concat(__to_string(marker), "]"))
+  match ty {
+    CtFn(params, ret, effect) => {
+      let mut found = match effect {
+        Some(row) => string_array_has(for raw in String::split(row, ",") {
+          String::trim(raw)
+        }, wanted),
+        None => false
+      }
+      for param in params {
+        if type_has_param_marker(param, marker) {
+          found = true
+        }
+      }
+      found || type_has_param_marker(ret, marker)
+    },
+    CtArray(elem) => type_has_param_marker(elem, marker),
+    CtOption(elem) => type_has_param_marker(elem, marker),
+    CtTuple(items) => {
+      let mut found = false
+      for item in items {
+        if type_has_param_marker(item, marker) {
+          found = true
+        }
+      }
+      found
+    },
+    CtRecord(fields) => {
+      let mut found = false
+      for field in fields {
+        let (_, field_ty) = field
+        if type_has_param_marker(field_ty, marker) {
+          found = true
+        }
+      }
+      found
+    },
+    CtNamed(_, args) => {
+      let mut found = false
+      for arg in args {
+        if type_has_param_marker(arg, marker) {
+          found = true
+        }
+      }
+      found
+    },
+    _ => false
+  }
+}
+
+fn param_marker_argument(marker: Int, param_tys: Array[Type], arg_tys: Array[Type]) -> Option[Type] {
+  let len = min_int(Array::length(param_tys), Array::length(arg_tys))
+  let mut i = 0
+  let mut found = None
+  while i < len {
+    if type_has_param_marker(Array::get(param_tys, i), marker) {
+      found = Some(Array::get(arg_tys, i))
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn resolve_param_provenance(ty: Type, param_tys: Array[Type], arg_tys: Array[Type]) -> Type {
   match ty {
     CtFn(params, ret, effect) => {
       let labels = array_empty()
@@ -2491,10 +2714,9 @@ fn resolve_param_provenance(ty: Type, arg_tys: Array[Type]) -> Type {
         Some(row) => for raw in String::split(row, ",") {
           let label = String::trim(raw)
           match param_marker_index(label) {
-            Some(index) => if index < Array::length(arg_tys) {
-              collect_internal_provenance(Array::get(arg_tys, index), labels)
-            } else {
-              ()
+            Some(marker) => match param_marker_argument(marker, param_tys, arg_tys) {
+              Some(arg_ty) => collect_internal_provenance(arg_ty, labels),
+              None => Array::push(labels, label)
             },
             None => Array::push(labels, label)
           }
@@ -2502,36 +2724,39 @@ fn resolve_param_provenance(ty: Type, arg_tys: Array[Type]) -> Type {
         None => ()
       }
       let mapped_params = for param in params {
-        resolve_param_provenance(param, arg_tys)
+        resolve_param_provenance(param, param_tys, arg_tys)
       }
       let resolved_effect = if Array::length(labels) == 0 {
         None
       } else {
         Some(String::join(labels, ", "))
       }
-      CtFn(mapped_params, resolve_param_provenance(ret, arg_tys), resolved_effect)
+      CtFn(mapped_params, resolve_param_provenance(ret, param_tys, arg_tys), resolved_effect)
     },
-    CtArray(elem) => CtArray(resolve_param_provenance(elem, arg_tys)),
-    CtOption(elem) => CtOption(resolve_param_provenance(elem, arg_tys)),
+    CtArray(elem) => CtArray(resolve_param_provenance(elem, param_tys, arg_tys)),
+    CtOption(elem) => CtOption(resolve_param_provenance(elem, param_tys, arg_tys)),
     CtTuple(items) => CtTuple(for item in items {
-      resolve_param_provenance(item, arg_tys)
+      resolve_param_provenance(item, param_tys, arg_tys)
     }),
     CtRecord(fields) => CtRecord(for field in fields {
       let (name, field_ty) = field
-      (name, resolve_param_provenance(field_ty, arg_tys))
+      (name, resolve_param_provenance(field_ty, param_tys, arg_tys))
     }),
     CtNamed(name, args) => CtNamed(name, for arg in args {
-      resolve_param_provenance(arg, arg_tys)
+      resolve_param_provenance(arg, param_tys, arg_tys)
     }),
     _ => ty
   }
 }
 
-fn call_result_with_provenance(ret: Type, _param_tys: Array[Type], arg_tys: Array[Type], s: Subst) -> Type {
+fn call_result_with_provenance(ret: Type, param_tys: Array[Type], arg_tys: Array[Type], s: Subst) -> Type {
+  let resolved_params = for param in param_tys {
+    subst_apply(s, param)
+  }
   let resolved_args = for arg in arg_tys {
     subst_apply(s, arg)
   }
-  resolve_param_provenance(subst_apply(s, ret), resolved_args)
+  resolve_param_provenance(subst_apply(s, ret), resolved_params, resolved_args)
 }
 
 /// #844: recognize the EXACT synthetic call shape `parser_expr_dispatch.vibe`'s
@@ -3915,6 +4140,7 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
         }
         let aliases_outer = expression_aliases_outer_binding(val, cenv)
         cenv = env_bind(cenv, name, gen)
+        cenv = bind_function_dependency_contracts(cenv, name, val)
         if aliases_outer {
           cenv = env_bind(cenv, String::concat("__region_outer_alias__", name), CtUnit)
         } else {
@@ -3962,6 +4188,7 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
         }
         let gen = generalize(s2, tv)
         cenv = env_bind(cenv, name, gen)
+        cenv = bind_function_dependency_contracts(cenv, name, val)
         s1 = s2
         c1 = nc
         typed_occurrence_capture_enter_virtual_child(capture, 1, Array::length(expr_children(body)))
@@ -4111,6 +4338,70 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
       let (_, s1, c1) = ce(left, env, defs, s, c, throwaway, throwtab)
       tail_named_record_mentions_region(right, env, defs, s1, c1, region_name, ce)
     },
+    ECall(callee, args, _) => {
+      let throwaway = array_empty()
+      let throwtab = array_empty()
+      let (callee_ty, s1, c1) = ce(callee, env, defs, s, c, throwaway, throwtab)
+      match subst_apply(s1, callee_ty) {
+        CtFn(param_tys, ret_ty, callee_effect) => {
+          let resolved_ret = subst_apply(s1, ret_ty)
+          let mut found = false
+          let limit = min_int(Array::length(param_tys), Array::length(args))
+          let mut i = 0
+          while i < limit {
+            let markers = array_empty()
+            collect_internal_provenance(Array::get(param_tys, i), markers)
+            let mut depends = false
+            for marker_label in markers {
+              match param_marker_index(marker_label) {
+                Some(marker) => if type_has_param_marker(resolved_ret, marker) {
+                  depends = true
+                } else {
+                  ()
+                },
+                None => ()
+              }
+            }
+            if depends && tail_named_record_mentions_region(Array::get(args, i), env, defs, s1, c1, region_name, ce) {
+              found = true
+            }
+            i = i + 1
+          }
+          match callee_effect {
+            Some(row) => for raw in String::split(row, ",") {
+              let label = String::trim(raw)
+              if String::starts_with(label, "#fieldparam[") {
+                let close = String::index_of(label, "]")
+                let mut index = 0
+                let mut p = 12
+                while p < close {
+                  index = index * 10 + (String::char_code_at(label, p) - 48)
+                  p = p + 1
+                }
+                if index >= 0 && index < Array::length(args) && tail_named_record_mentions_region(Array::get(args, index), env, defs, s1, c1, region_name, ce) {
+                  found = true
+                }
+              }
+            },
+            None => ()
+          }
+          match callee {
+            EIdent(callee_name, _) => match env_lookup(env, String::concat("__field_contract__", callee_name)) {
+              Some(CtNamed(index_text, _)) => {
+                let index = decimal_index(index_text)
+                if index >= 0 && index < Array::length(args) && tail_named_record_mentions_region(Array::get(args, index), env, defs, s1, c1, region_name, ce) {
+                  found = true
+                }
+              },
+              _ => ()
+            },
+            _ => ()
+          }
+          found
+        },
+        _ => false
+      }
+    },
     ERecord(name, fields, _) => if name != "" {
       let mut found = false
       let mut s1 = s
@@ -4132,7 +4423,12 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
     } else {
       false
     },
-    _ => false
+    _ => {
+      let throwaway = array_empty()
+      let throwtab = array_empty()
+      let (expr_ty, next_s, _) = ce(expr, env, defs, s, c, throwaway, throwtab)
+      type_mentions_named(subst_apply(next_s, expr_ty), region_name)
+    }
   }
 }
 
@@ -6145,7 +6441,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               let (binder_name, _) = Array::get(fn_params, 0)
               let region_ty = CtNamed(skolem_name, [
               ])
-              let env_body = env_bind(env_bind(env, binder_name, region_ty), "__active_region__", region_ty)
+              let env_body = env_bind(env_bind(env_bind(env, "__capture_boundary__", CtUnit), binder_name, region_ty), "__active_region__", region_ty)
               // The specialized region path checks the literal lambda body
               // directly. Preserve both structural edges from the outer call:
               // argument child 1, then EFn body child 0.
@@ -7792,17 +8088,27 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // Synthetic accesses (dot_off < 0) are skipped. #645: the field token's
           // own offset gets the same entry, so hovering the field NAME (not just
           // the base) resolves the projection type.
+          let dependent_field_ty = match obj {
+            EIdent(base_name, _) => match env_lookup(env, String::concat("__param_marker__", base_name)) {
+              Some(CtNamed(marker_label, _)) => add_param_capture_dependency(field_ty, match param_marker_index(marker_label) {
+                Some(marker) => marker,
+                None => 0 - 1
+              }),
+              _ => field_ty
+            },
+            _ => field_ty
+          }
           if dot_off >= 0 {
-            tab_dot_projection_ty(tytab, dot_off, field_ty, capture, lane)
+            tab_dot_projection_ty(tytab, dot_off, dependent_field_ty, capture, lane)
           } else {
             ()
           }
           if field_off >= 0 && field_off != dot_off {
-            tab_dot_field_name_ty(tytab, field_off, field_ty, capture, lane)
+            tab_dot_field_name_ty(tytab, field_off, dependent_field_ty, capture, lane)
           } else {
             ()
           }
-          (field_ty, s1, c1)
+          (dependent_field_ty, s1, c1)
         }
       }
     },
@@ -7840,7 +8146,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         tpi = tpi + 1
       }
       let plen = Array::length(params)
-      let mut fn_env = tp_env
+      let mut fn_env = env_bind(tp_env, "__capture_boundary__", CtUnit)
       let mut s1 = s0
       let mut c1 = c0
       let param_types = array_empty()
@@ -7868,15 +8174,18 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           }
         }
         let marked_pt = match pt {
-          CtFn(_, _, _) => add_param_capture_dependency(pt, pi),
-          CtArray(_) => add_param_capture_dependency(pt, pi),
-          CtOption(_) => add_param_capture_dependency(pt, pi),
+          CtFn(_, _, _) => add_param_capture_dependency(pt, nc),
+          CtArray(_) => add_param_capture_dependency(pt, nc),
+          CtOption(_) => add_param_capture_dependency(pt, nc),
           _ => pt
         }
+        let marked_nc = nc + 1
         fn_env = env_bind(fn_env, name, marked_pt)
+        fn_env = env_bind(fn_env, String::concat("__param_marker__", name), CtNamed(String::concat("#param[", String::concat(__to_string(nc), "]")), [
+        ]))
         Array::push(param_types, marked_pt)
         s1 = ns
-        c1 = nc
+        c1 = marked_nc
         pi = pi + 1
       }
       // Bind the function's annotated return type under a sentinel so an
@@ -7928,8 +8237,16 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         },
         None => (subst_apply(s2, bt), s2)
       }
-      let checked_effect = closure_capture_row(effect, body, env, s3)
-      (CtFn(param_types, final_ret, checked_effect), s3, c2)
+      let capture_effect = closure_capture_row(effect, body, params, fn_env, s3)
+      let checked_effect = match direct_result_param_index(body, params) {
+        Some(index) => merge_provenance_row(capture_effect, Some(String::concat("#aliasparam[", String::concat(__to_string(index), "]")))),
+        None => capture_effect
+      }
+      let dependency_effect = match direct_result_field_param_index(body, params) {
+        Some(index) => merge_provenance_row(checked_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]")))),
+        None => checked_effect
+      }
+      (CtFn(param_types, final_ret, dependency_effect), s3, c2)
     },
     EBreak(opt) => {
       // `break` is only meaningful inside a loop. Loop bodies bind the

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -1813,7 +1813,7 @@ fn effect_label_is_exempt(lbl: String) -> Bool {
   // opt-in and carries real information, so dropping it through a pure-typed
   // slot is exactly the #939 hole this check exists to catch. Nothing in the
   // codebase writes a kinded label, so no existing program changes verdict.
-  if String::starts_with(lbl, "#region_") || String::starts_with(lbl, "#capture[") {
+  if String::starts_with(lbl, "#region_") || String::starts_with(lbl, "#capture[") || String::starts_with(lbl, "#param[") || String::starts_with(lbl, "#aliasparam[") || String::starts_with(lbl, "#fieldparam[") {
     true
   } else if (is_exception_effect_name(lbl) && String::length(exception_effect_kind(lbl)) == 0) || lbl == "Async" {
     true
@@ -2728,6 +2728,24 @@ fn param_marker_index(label: String) -> Option[Int] {
     }
   } else {
     None
+  }
+}
+
+/// Scalar / unit types cannot later mention a region, so a function that
+/// merely returns such a parameter must stay a pure `None` row. Attaching
+/// `#aliasparam` there made identity `(x: Int) -> x` look effectful and
+/// then fail #939 drop-checks (`inc` into a `with Logger` slot, Parallel::map).
+fn type_can_carry_region(ty: Type) -> Bool {
+  match ty {
+    CtFn(_, _, _) => true,
+    CtArray(_) => true,
+    CtOption(_) => true,
+    CtTuple(_) => true,
+    CtRecord(_) => true,
+    CtNamed(_, _) => true,
+    CtVar(_) => true,
+    CtForAll(_, _, _) => true,
+    _ => false
   }
 }
 
@@ -8518,13 +8536,40 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       }
       let capture_effect = closure_capture_row(effect, body, params, fn_env, s3)
       let checked_effect = match direct_result_param_index(body, params) {
-        Some(index) => merge_provenance_row(capture_effect, Some(String::concat("#aliasparam[", String::concat(__to_string(index), "]")))),
+        Some(index) => {
+          let pty = if index >= 0 && index < Array::length(param_types) {
+            subst_apply(s3, Array::get(param_types, index))
+          } else {
+            CtUnit
+          }
+          if type_can_carry_region(pty) {
+            merge_provenance_row(capture_effect, Some(String::concat("#aliasparam[", String::concat(__to_string(index), "]"))))
+          } else {
+            capture_effect
+          }
+        },
         None => capture_effect
       }
       let dependency_effect = match direct_result_field_param_index(body, params) {
-        Some(index) => merge_provenance_row(checked_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]")))),
+        Some(index) => if type_can_carry_region(if index >= 0 && index < Array::length(param_types) {
+          subst_apply(s3, Array::get(param_types, index))
+        } else {
+          CtUnit
+        }) {
+          merge_provenance_row(checked_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]"))))
+        } else {
+          checked_effect
+        },
         None => match direct_result_enum_payload_param_index(body, params, defs) {
-          Some(index) => merge_provenance_row(checked_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]")))),
+          Some(index) => if type_can_carry_region(if index >= 0 && index < Array::length(param_types) {
+            subst_apply(s3, Array::get(param_types, index))
+          } else {
+            CtUnit
+          }) {
+            merge_provenance_row(checked_effect, Some(String::concat("#fieldparam[", String::concat(__to_string(index), "]"))))
+          } else {
+            checked_effect
+          },
           None => checked_effect
         }
       }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -35,7 +35,6 @@ import @vibe/compiler/core {
   type_implements_trait,
   type_name_has_iterator_impl,
   type_to_string,
-  types_equal,
   unify
 }
 
@@ -865,7 +864,7 @@ fn merge_provenance_row(expected: Option[String], actual: Option[String]) -> Opt
   match actual {
     Some(row) => for raw in String::split(row, ",") {
       let label = String::trim(raw)
-      if (String::starts_with(label, "#region_") || String::starts_with(label, "#capture[")) && !string_array_has(labels, label) {
+      if (String::starts_with(label, "#region_") || String::starts_with(label, "#capture[") || String::starts_with(label, "#param[")) && !string_array_has(labels, label) {
         Array::push(labels, label)
       }
     },
@@ -919,6 +918,29 @@ fn merge_capture_provenance(expected: Type, actual: Type) -> Type {
           i = i + 1
         }
         CtTuple(items)
+      },
+      _ => expected
+    },
+    CtRecord(efields) => match actual {
+      CtRecord(afields) => {
+        let fields = array_empty()
+        let mut i = 0
+        while i < Array::length(efields) {
+          let (name, field_ty) = Array::get(efields, i)
+          let merged = if i < Array::length(afields) {
+            let (actual_name, actual_ty) = Array::get(afields, i)
+            if name == actual_name {
+              merge_capture_provenance(field_ty, actual_ty)
+            } else {
+              field_ty
+            }
+          } else {
+            field_ty
+          }
+          Array::push(fields, (name, merged))
+          i = i + 1
+        }
+        CtRecord(fields)
       },
       _ => expected
     },
@@ -1125,7 +1147,7 @@ fn closure_capture_row(effect: Option[String], body: Expr, env: TypeEnv, s: Subs
           let regions = array_empty()
           collect_region_skolems(ty, regions)
           let vars = collect_tvars(ty)
-          let region_relevant = Array::length(regions) > 0 || (Array::length(vars) > 0 && (active_region || type_has_region_handle_shape(ty)))
+          let region_relevant = Array::length(regions) > 0 || Array::length(vars) > 0
           if region_relevant {
             for region_name in regions {
               append_row_label(labels, region_name)
@@ -1202,12 +1224,52 @@ fn assignment_crosses_region(name: String, ty: Type, env: TypeEnv) -> Bool {
 /// retain a value whose closure provenance names that region.
 fn container_write_crosses_region(target: Expr, ty: Type, env: TypeEnv) -> Bool {
   match target {
-    EIdent(name, _) => assignment_crosses_region(name, ty, env),
+    EIdent(name, _) => assignment_crosses_region(name, ty, env) || match env_lookup(env, String::concat("__region_outer_alias__", name)) {
+      Some(_) => type_mentions_active_region(ty, env),
+      None => false
+    },
     EDot(obj, _, _, _) => container_write_crosses_region(obj, ty, env),
     ECall(EIdent("__index", _), args, _) => if Array::length(args) > 0 {
       container_write_crosses_region(Array::get(args, 0), ty, env)
     } else {
       false
+    },
+    _ => false
+  }
+}
+
+fn binding_predates_active_region(name: String, env: TypeEnv) -> Bool {
+  match env {
+    EnvEmpty => false,
+    EnvBind(n, _, rest) => if n == name {
+      false
+    } else if n == "__active_region__" {
+      match env_lookup(rest, name) {
+        Some(_) => true,
+        None => false
+      }
+    } else {
+      binding_predates_active_region(name, rest)
+    },
+    EnvMutCell(n, _, rest) => if n == name {
+      false
+    } else {
+      binding_predates_active_region(name, rest)
+    },
+    EnvTraitDef(_, _, _, _, rest, _, _) => binding_predates_active_region(name, rest),
+    EnvTraitImpl(_, _, rest) => binding_predates_active_region(name, rest),
+    EnvTraitImplGen(_, _, _, _, rest) => binding_predates_active_region(name, rest),
+    EnvTypeDefs(_, _, rest) => binding_predates_active_region(name, rest),
+    EnvCached(_, _, rest) => binding_predates_active_region(name, rest),
+    EnvFlat(_) => false
+  }
+}
+
+fn expression_aliases_outer_binding(expr: Expr, env: TypeEnv) -> Bool {
+  match expr {
+    EIdent(name, _) => binding_predates_active_region(name, env) || match env_lookup(env, String::concat("__region_outer_alias__", name)) {
+      Some(_) => true,
+      None => false
     },
     _ => false
   }
@@ -2360,51 +2422,116 @@ fn unify_call_args(param_tys: Array[Type], arg_tys: Array[Type], s: Subst, error
   out
 }
 
-/// Ordinary unification intentionally ignores checker-only capture labels.
-/// When a concrete callback parameter is also returned, restore the argument's
-/// provenance on the corresponding result node after argument checking.
-fn propagate_matching_call_provenance(result: Type, param: Type, actual: Type) -> Type {
-  if types_equal(result, param) {
-    merge_capture_provenance(result, actual)
-  } else {
-    match result {
-      CtFn(params, ret, effect) => {
-        let mapped = array_empty()
-        for item in params {
-          Array::push(mapped, propagate_matching_call_provenance(item, param, actual))
-        }
-        CtFn(mapped, propagate_matching_call_provenance(ret, param, actual), effect)
-      },
-      CtArray(elem) => CtArray(propagate_matching_call_provenance(elem, param, actual)),
-      CtOption(elem) => CtOption(propagate_matching_call_provenance(elem, param, actual)),
-      CtTuple(items) => {
-        let mapped = array_empty()
-        for item in items {
-          Array::push(mapped, propagate_matching_call_provenance(item, param, actual))
-        }
-        CtTuple(mapped)
-      },
-      CtNamed(name, args) => {
-        let mapped = array_empty()
-        for arg in args {
-          Array::push(mapped, propagate_matching_call_provenance(arg, param, actual))
-        }
-        CtNamed(name, mapped)
-      },
-      _ => result
+fn param_marker_index(label: String) -> Option[Int] {
+  if String::starts_with(label, "#param[") {
+    let close = String::index_of(label, "]")
+    if close > 7 {
+      let mut id = 0
+      let mut p = 7
+      while p < close {
+        id = id * 10 + (String::char_code_at(label, p) - 48)
+        p = p + 1
+      }
+      Some(id)
+    } else {
+      None
     }
+  } else {
+    None
   }
 }
 
-fn call_result_with_provenance(ret: Type, param_tys: Array[Type], arg_tys: Array[Type], s: Subst) -> Type {
-  let mut result = subst_apply(s, ret)
-  let len = min_int(Array::length(param_tys), Array::length(arg_tys))
-  let mut i = 0
-  while i < len {
-    result = propagate_matching_call_provenance(result, subst_apply(s, Array::get(param_tys, i)), subst_apply(s, Array::get(arg_tys, i)))
-    i = i + 1
+fn add_param_capture_dependency(ty: Type, index: Int) -> Type {
+  match ty {
+    CtFn(params, ret, effect) => CtFn(params, ret, merge_provenance_row(effect, Some(String::concat("#param[", String::concat(__to_string(index), "]"))))),
+    CtArray(elem) => CtArray(add_param_capture_dependency(elem, index)),
+    CtOption(elem) => CtOption(add_param_capture_dependency(elem, index)),
+    _ => ty
   }
-  result
+}
+
+fn collect_internal_provenance(ty: Type, out: Array[String]) -> Unit {
+  match ty {
+    CtFn(params, ret, effect) => {
+      match effect {
+        Some(row) => for raw in String::split(row, ",") {
+          let label = String::trim(raw)
+          if (String::starts_with(label, "#region_") || String::starts_with(label, "#capture[")) && !string_array_has(out, label) {
+            Array::push(out, label)
+          }
+        },
+        None => ()
+      }
+      for param in params {
+        collect_internal_provenance(param, out)
+      }
+      collect_internal_provenance(ret, out)
+    },
+    CtArray(elem) => collect_internal_provenance(elem, out),
+    CtOption(elem) => collect_internal_provenance(elem, out),
+    CtTuple(items) => for item in items {
+      collect_internal_provenance(item, out)
+    },
+    CtRecord(fields) => for field in fields {
+      let (_, field_ty) = field
+      collect_internal_provenance(field_ty, out)
+    },
+    CtNamed(_, args) => for arg in args {
+      collect_internal_provenance(arg, out)
+    },
+    _ => ()
+  }
+}
+
+fn resolve_param_provenance(ty: Type, arg_tys: Array[Type]) -> Type {
+  match ty {
+    CtFn(params, ret, effect) => {
+      let labels = array_empty()
+      match effect {
+        Some(row) => for raw in String::split(row, ",") {
+          let label = String::trim(raw)
+          match param_marker_index(label) {
+            Some(index) => if index < Array::length(arg_tys) {
+              collect_internal_provenance(Array::get(arg_tys, index), labels)
+            } else {
+              ()
+            },
+            None => Array::push(labels, label)
+          }
+        },
+        None => ()
+      }
+      let mapped_params = for param in params {
+        resolve_param_provenance(param, arg_tys)
+      }
+      let resolved_effect = if Array::length(labels) == 0 {
+        None
+      } else {
+        Some(String::join(labels, ", "))
+      }
+      CtFn(mapped_params, resolve_param_provenance(ret, arg_tys), resolved_effect)
+    },
+    CtArray(elem) => CtArray(resolve_param_provenance(elem, arg_tys)),
+    CtOption(elem) => CtOption(resolve_param_provenance(elem, arg_tys)),
+    CtTuple(items) => CtTuple(for item in items {
+      resolve_param_provenance(item, arg_tys)
+    }),
+    CtRecord(fields) => CtRecord(for field in fields {
+      let (name, field_ty) = field
+      (name, resolve_param_provenance(field_ty, arg_tys))
+    }),
+    CtNamed(name, args) => CtNamed(name, for arg in args {
+      resolve_param_provenance(arg, arg_tys)
+    }),
+    _ => ty
+  }
+}
+
+fn call_result_with_provenance(ret: Type, _param_tys: Array[Type], arg_tys: Array[Type], s: Subst) -> Type {
+  let resolved_args = for arg in arg_tys {
+    subst_apply(s, arg)
+  }
+  resolve_param_provenance(subst_apply(s, ret), resolved_args)
 }
 
 /// #844: recognize the EXACT synthetic call shape `parser_expr_dispatch.vibe`'s
@@ -3786,7 +3913,13 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
         } else {
           generalize(ns, vt)
         }
+        let aliases_outer = expression_aliases_outer_binding(val, cenv)
         cenv = env_bind(cenv, name, gen)
+        if aliases_outer {
+          cenv = env_bind(cenv, String::concat("__region_outer_alias__", name), CtUnit)
+        } else {
+          ()
+        }
         s1 = ns
         c1 = nc
         typed_occurrence_capture_enter_virtual_child(capture, 1, Array::length(expr_children(body)))
@@ -3934,7 +4067,7 @@ fn field_write_mut_check(name: String, args: Array[Expr], env: TypeEnv, defs: Ar
 /// Check their stored argument against the same region lifetime rule as
 /// `EAssign`; operations that only store scalar bytes/indices need no entry.
 fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Unit {
-  let value_index = if name == "Array::push" || name == "ArrayBuilder::push" || name == "Array::push_all" {
+  let value_index = if name == "Array::push" || name == "ArrayBuilder::push" || name == "Array::push_all" || name == "MutList::push" {
     1
   } else if name == "Array::set" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "MapBuilder::set" || name == "__set_field" {
     2
@@ -3952,6 +4085,54 @@ fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, d
     }
   } else {
     ()
+  }
+}
+
+/// Nominal struct identity intentionally omits field types. Reconstruct only
+/// the tail record literal's local let environment so a region-return check can
+/// inspect the actual field values without changing the public nominal type.
+fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, region_name: String, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Bool {
+  match expr {
+    ELet(name, val, body, _) => {
+      let throwaway = array_empty()
+      let throwtab = array_empty()
+      let (val_ty, s1, c1) = ce(val, env, defs, s, c, throwaway, throwtab)
+      tail_named_record_mentions_region(body, env_bind(env, name, val_ty), defs, s1, c1, region_name, ce)
+    },
+    ELetMut(name, val, body, _) => {
+      let throwaway = array_empty()
+      let throwtab = array_empty()
+      let (val_ty, s1, c1) = ce(val, env, defs, s, c, throwaway, throwtab)
+      tail_named_record_mentions_region(body, env_bind_mut(env, name, val_ty, false), defs, s1, c1, region_name, ce)
+    },
+    ESeq(left, right) => {
+      let throwaway = array_empty()
+      let throwtab = array_empty()
+      let (_, s1, c1) = ce(left, env, defs, s, c, throwaway, throwtab)
+      tail_named_record_mentions_region(right, env, defs, s1, c1, region_name, ce)
+    },
+    ERecord(name, fields, _) => if name != "" {
+      let mut found = false
+      let mut s1 = s
+      let mut c1 = c
+      for field in fields {
+        let (_, value) = field
+        let throwaway = array_empty()
+        let throwtab = array_empty()
+        let (field_ty, next_s, next_c) = ce(value, env, defs, s1, c1, throwaway, throwtab)
+        if type_mentions_named(subst_apply(next_s, field_ty), region_name) {
+          found = true
+        } else {
+          ()
+        }
+        s1 = next_s
+        c1 = next_c
+      }
+      found
+    } else {
+      false
+    },
+    _ => false
   }
 }
 
@@ -5973,7 +6154,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               let (body_ty, s1, c1) = check_expr_capture(fn_body, env_body, defs, s, c + 1, errors, tytab, capture, lane)
               typed_occurrence_capture_restore_frame_depth(capture, virtual_parent_depth)
               let zonked_ret = subst_apply(s1, body_ty)
-              if type_mentions_named(zonked_ret, skolem_name) {
+              if type_mentions_named(zonked_ret, skolem_name) || tail_named_record_mentions_region(fn_body, env_body, defs, s, c + 1, skolem_name, check_expr) {
                 Array::push(errors, String::concat("region escapes its scope: the value returned from this region body still depends on the region's own token", off_marker_len(callee_off, String::length(name))))
               } else {
                 ()
@@ -7686,8 +7867,14 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             (tv, s1, nc2)
           }
         }
-        fn_env = env_bind(fn_env, name, pt)
-        Array::push(param_types, pt)
+        let marked_pt = match pt {
+          CtFn(_, _, _) => add_param_capture_dependency(pt, pi),
+          CtArray(_) => add_param_capture_dependency(pt, pi),
+          CtOption(_) => add_param_capture_dependency(pt, pi),
+          _ => pt
+        }
+        fn_env = env_bind(fn_env, name, marked_pt)
+        Array::push(param_types, marked_pt)
         s1 = ns
         c1 = nc
         pi = pi + 1

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -59,7 +59,7 @@ import ./checker_resolve.vibe {
 }
 
 import ./checker_spawnable.vibe {
-  check_spawnable_captures
+  check_spawnable_captures, closure_free_names
 }
 
 import ./checker_escape.vibe {
@@ -1029,6 +1029,55 @@ fn collect_region_skolems(ty: Type, out: Array[String]) -> Unit {
   }
 }
 
+/// Region-backed handles can erase the captured region from a closure's
+/// result through operations such as `to_array`. Recognize that nominal shape
+/// even when a helper is checked before a region-tagged call site exists.
+fn type_has_region_handle_shape(ty: Type) -> Bool {
+  match ty {
+    CtNamed(name, args) => {
+      let mut found = name == "MutList" || name == "MutBytes"
+      for arg in args {
+        if type_has_region_handle_shape(arg) {
+          found = true
+        }
+      }
+      found
+    },
+    CtFn(params, ret, _) => {
+      let mut found = type_has_region_handle_shape(ret)
+      for param in params {
+        if type_has_region_handle_shape(param) {
+          found = true
+        }
+      }
+      found
+    },
+    CtArray(elem) => type_has_region_handle_shape(elem),
+    CtOption(elem) => type_has_region_handle_shape(elem),
+    CtTuple(items) => {
+      let mut found = false
+      for item in items {
+        if type_has_region_handle_shape(item) {
+          found = true
+        }
+      }
+      found
+    },
+    CtRecord(fields) => {
+      let mut found = false
+      for field in fields {
+        let (_, field_ty) = field
+        if type_has_region_handle_shape(field_ty) {
+          found = true
+        }
+      }
+      found
+    },
+    CtForAll(_, _, body) => type_has_region_handle_shape(body),
+    _ => false
+  }
+}
+
 fn append_row_label(labels: Array[String], label: String) -> Unit {
   if !string_array_has(labels, label) {
     Array::push(labels, label)
@@ -1049,26 +1098,22 @@ fn closure_capture_row(effect: Option[String], body: Expr, env: TypeEnv, s: Subs
     },
     None => array_empty()
   }
-  let bindings = array_empty()
-  collect_env_bindings(env, bindings)
+  let active_region = env_has_active_region(env)
+  let captured_names = closure_free_names(body)
   let seen_names = array_empty()
   let mut i = 0
-  while i < Array::length(bindings) {
-    let (name, raw_ty) = Array::get(bindings, i)
+  while i < Array::length(captured_names) {
+    let name = Array::get(captured_names, i)
     if !string_array_has(seen_names, name) {
       Array::push(seen_names, name)
-      let ty = subst_apply(s, raw_ty)
-      match ty {
-        CtForAll(_, _, _) => (),
-        _ => {
+      match env_lookup(env, name) {
+        Some(raw_ty) => {
+          let ty = subst_apply(s, raw_ty)
           let regions = array_empty()
           collect_region_skolems(ty, regions)
           let vars = collect_tvars(ty)
-          // Almost every visible binding in the compiler is concrete. Check
-          // the cheap type predicate BEFORE walking the closure body; doing
-          // one full free-variable traversal per imported binding makes
-          // self-compilation quadratic.
-          if (Array::length(regions) > 0 || Array::length(vars) > 0) && expr_free_in(body, name) {
+          let region_relevant = Array::length(regions) > 0 || (Array::length(vars) > 0 && (active_region || type_has_region_handle_shape(ty)))
+          if region_relevant {
             for region_name in regions {
               append_row_label(labels, region_name)
             }
@@ -1076,7 +1121,8 @@ fn closure_capture_row(effect: Option[String], body: Expr, env: TypeEnv, s: Subs
               append_row_label(labels, String::concat("#capture[", String::concat(__to_string(var_id), "]")))
             }
           }
-        }
+        },
+        None => ()
       }
     }
     i = i + 1
@@ -1105,6 +1151,35 @@ fn type_mentions_active_region(ty: Type, env: TypeEnv) -> Bool {
     EnvTraitImplGen(_, _, _, _, rest) => type_mentions_active_region(ty, rest),
     EnvTypeDefs(_, _, rest) => type_mentions_active_region(ty, rest),
     EnvCached(_, _, rest) => type_mentions_active_region(ty, rest),
+    EnvFlat(_) => false
+  }
+}
+
+/// A target declared before the relevant active-region marker can outlive the
+/// region; a target found first in the environment chain is region-local.
+fn assignment_crosses_region(name: String, ty: Type, env: TypeEnv) -> Bool {
+  match env {
+    EnvEmpty => false,
+    EnvBind(n, binding, rest) => if n == name {
+      false
+    } else if n == "__active_region__" {
+      match binding.ty {
+        CtNamed(region_name, _) => type_mentions_named(ty, region_name) || assignment_crosses_region(name, ty, rest),
+        _ => assignment_crosses_region(name, ty, rest)
+      }
+    } else {
+      assignment_crosses_region(name, ty, rest)
+    },
+    EnvMutCell(n, _, rest) => if n == name {
+      false
+    } else {
+      assignment_crosses_region(name, ty, rest)
+    },
+    EnvTraitDef(_, _, _, _, rest, _, _) => assignment_crosses_region(name, ty, rest),
+    EnvTraitImpl(_, _, rest) => assignment_crosses_region(name, ty, rest),
+    EnvTraitImplGen(_, _, _, _, rest) => assignment_crosses_region(name, ty, rest),
+    EnvTypeDefs(_, _, rest) => assignment_crosses_region(name, ty, rest),
+    EnvCached(_, _, rest) => assignment_crosses_region(name, ty, rest),
     EnvFlat(_) => false
   }
 }
@@ -6524,7 +6599,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
     },
     EAssign(name, val, body) => {
       let (vt, s1, c1) = check_expr_capture(val, env, defs, s, c, errors, tytab, capture, lane)
-      if type_mentions_active_region(subst_apply(s1, vt), env) {
+      if assignment_crosses_region(name, subst_apply(s1, vt), env) {
         Array::push(errors, String::concat("region escapes its scope: an assignment stores a value that captures this region into an outer binding", off_marker(tail_expr_off(val))))
       }
       // The assigned value must be assignable to the variable's type
@@ -7562,11 +7637,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         },
         None => (subst_apply(s2, bt), s2)
       }
-      let checked_effect = if env_has_active_region(env) {
-        closure_capture_row(effect, body, env, s3)
-      } else {
-        effect
-      }
+      let checked_effect = closure_capture_row(effect, body, env, s3)
       (CtFn(param_types, final_ret, checked_effect), s3, c2)
     },
     EBreak(opt) => {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -881,15 +881,21 @@ fn merge_provenance_row(expected: Option[String], actual: Option[String]) -> Opt
 /// same checker-only row used by field-projection helpers, so direct,
 /// qualified, imported, and first-class enum constructors share one contract.
 export fn constructor_dependency_row(arity: Int) -> Option[String] {
-  let labels = array_empty()
-  let mut i = 0
-  while i < arity {
-    Array::push(labels, String::concat("#fieldparam[", String::concat(__to_string(i), "]")))
-    i = i + 1
-  }
-  if Array::length(labels) == 0 {
+  if arity <= 0 {
     None
+  } else if arity == 1 {
+    Some("#fieldparam[0]")
+  } else if arity == 2 {
+    Some("#fieldparam[0], #fieldparam[1]")
+  } else if arity == 3 {
+    Some("#fieldparam[0], #fieldparam[1], #fieldparam[2]")
   } else {
+    let labels = array_empty()
+    let mut i = 0
+    while i < arity {
+      Array::push(labels, String::concat("#fieldparam[", String::concat(__to_string(i), "]")))
+      i = i + 1
+    }
     Some(String::join(labels, ", "))
   }
 }
@@ -1176,10 +1182,6 @@ fn closure_capture_row(effect: Option[String], body: Expr, params: Array[(String
     }
     i = i + 1
   }
-  // A bare callee is omitted by the ordinary free-name walk so top-level
-  // calls do not make every closure capture the global environment. Two
-  // callee classes still carry value provenance: a callback parameter, and a
-  // concrete region-backed local closure while checking a region body.
   for callee in closure_bare_callee_names(body) {
     let mut is_param = false
     for param in params {
@@ -1330,37 +1332,37 @@ fn push_unique_dependency_index(out: Array[Int], index: Int) -> Unit {
   }
 }
 
-fn alias_result_param_indices(ty: Type) -> Array[Int] {
-  let found = array_empty()
+fn alias_result_reaches_outer_binding(ty: Type, args: Array[Expr], env: TypeEnv) -> Bool {
   match ty {
-    CtForAll(_, _, body) => {
-      for index in alias_result_param_indices(body) {
-        push_unique_dependency_index(found, index)
-      }
-      ()
-    },
+    CtForAll(_, _, body) => alias_result_reaches_outer_binding(body, args, env),
     CtFn(_, _, effect) => match effect {
-      Some(row) => {
+      Some(row) => if String::contains(row, "#aliasparam[") {
+        let mut found = false
         for raw in String::split(row, ",") {
-          let label = String::trim(raw)
-          if String::starts_with(label, "#aliasparam[") {
-            let close = String::index_of(label, "]")
-            let mut id = 0
-            let mut p = 12
-            while p < close {
-              id = id * 10 + (String::char_code_at(label, p) - 48)
-              p = p + 1
+          if !found {
+            let label = String::trim(raw)
+            if String::starts_with(label, "#aliasparam[") {
+              let close = String::index_of(label, "]")
+              let mut id = 0
+              let mut p = 12
+              while p < close {
+                id = id * 10 + (String::char_code_at(label, p) - 48)
+                p = p + 1
+              }
+              if id >= 0 && id < Array::length(args) && expression_aliases_outer_binding(Array::get(args, id), env) {
+                found = true
+              }
             }
-            push_unique_dependency_index(found, id)
           }
         }
-        ()
+        found
+      } else {
+        false
       },
-      None => ()
+      None => false
     },
-    _ => ()
+    _ => false
   }
-  found
 }
 
 fn decimal_index(text: String) -> Int {
@@ -1391,10 +1393,8 @@ fn expression_aliases_outer_binding(expr: Expr, env: TypeEnv) -> Bool {
           },
           _ => ()
         }
-        for index in alias_result_param_indices(callee_ty) {
-          if index >= 0 && index < Array::length(args) && expression_aliases_outer_binding(Array::get(args, index), env) {
-            found = true
-          }
+        if !found && alias_result_reaches_outer_binding(callee_ty, args, env) {
+          found = true
         }
         found
       },
@@ -1413,8 +1413,7 @@ fn expression_aliases_outer_binding(expr: Expr, env: TypeEnv) -> Bool {
   }
 }
 
-fn result_param_indices(body: Expr, params: Array[(String, Option[TypeExpr])], alias_names: Array[String], alias_indices: Array[Int]) -> Array[Int] {
-  let found = array_empty()
+fn collect_result_param_indices(body: Expr, params: Array[(String, Option[TypeExpr])], alias_names: Array[String], alias_indices: Array[Int], found: Array[Int]) -> Unit {
   match body {
     EIdent(name, _) => {
       let mut i = 0
@@ -1441,43 +1440,33 @@ fn result_param_indices(body: Expr, params: Array[(String, Option[TypeExpr])], a
       }
     },
     ELet(name, value, rest, _) => {
-      let next_names = for alias in alias_names {
-        alias
+      let found_mark = Array::length(found)
+      let alias_mark = Array::length(alias_names)
+      collect_result_param_indices(value, params, alias_names, alias_indices, found)
+      let mut i = found_mark
+      while i < Array::length(found) {
+        Array::push(alias_names, name)
+        Array::push(alias_indices, Array::get(found, i))
+        i = i + 1
       }
-      let next_indices = for index in alias_indices {
-        index
-      }
-      for index in result_param_indices(value, params, alias_names, alias_indices) {
-        Array::push(next_names, name)
-        Array::push(next_indices, index)
-      }
-      for index in result_param_indices(rest, params, next_names, next_indices) {
-        push_unique_dependency_index(found, index)
-      }
-      ()
+      Array::truncate(found, found_mark)
+      collect_result_param_indices(rest, params, alias_names, alias_indices, found)
+      Array::truncate(alias_names, alias_mark)
+      Array::truncate(alias_indices, alias_mark)
     },
-    ESeq(_, right) => {
-      for index in result_param_indices(right, params, alias_names, alias_indices) {
-        push_unique_dependency_index(found, index)
-      }
-      ()
-    },
+    ESeq(_, right) => collect_result_param_indices(right, params, alias_names, alias_indices, found),
     EIf(_, then_expr, else_expr) => {
-      for index in result_param_indices(then_expr, params, alias_names, alias_indices) {
-        push_unique_dependency_index(found, index)
-      }
-      for index in result_param_indices(else_expr, params, alias_names, alias_indices) {
-        push_unique_dependency_index(found, index)
-      }
-      ()
+      collect_result_param_indices(then_expr, params, alias_names, alias_indices, found)
+      collect_result_param_indices(else_expr, params, alias_names, alias_indices, found)
     },
     _ => ()
   }
-  found
 }
 
 fn direct_result_param_indices(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Array[Int] {
-  result_param_indices(body, params, array_empty(), array_empty())
+  let found = array_empty()
+  collect_result_param_indices(body, params, array_empty(), array_empty(), found)
+  found
 }
 
 fn direct_result_param_index(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Option[Int] {
@@ -1515,20 +1504,18 @@ fn result_field_param_index(body: Expr, params: Array[(String, Option[TypeExpr])
       found
     },
     ELet(name, value, rest, _) => {
-      let next_names = for alias in alias_names {
-        alias
-      }
-      let next_indices = for index in alias_indices {
-        index
-      }
+      let mark = Array::length(alias_names)
       match result_field_param_index(value, params, alias_names, alias_indices) {
         Some(index) => {
-          Array::push(next_names, name)
-          Array::push(next_indices, index)
+          Array::push(alias_names, name)
+          Array::push(alias_indices, index)
         },
         None => ()
       }
-      result_field_param_index(rest, params, next_names, next_indices)
+      let found = result_field_param_index(rest, params, alias_names, alias_indices)
+      Array::truncate(alias_names, mark)
+      Array::truncate(alias_indices, mark)
+      found
     },
     ESeq(_, right) => result_field_param_index(right, params, alias_names, alias_indices),
     EIf(_, then_expr, else_expr) => match result_field_param_index(then_expr, params, alias_names, alias_indices) {
@@ -1543,34 +1530,20 @@ fn direct_result_field_param_index(body: Expr, params: Array[(String, Option[Typ
   result_field_param_index(body, params, array_empty(), array_empty())
 }
 
-fn collect_explicit_return_types(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, out: Array[Type], ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Unit {
-  match expr {
-    EFn(_, _, _, _, _, _) => (),
-    EReturn(value) => {
-      let throwaway = array_empty()
-      let throwtab = array_empty()
-      let (value_ty, next_s, _) = ce(value, env, defs, s, c, throwaway, throwtab)
-      Array::push(out, subst_apply(next_s, value_ty))
-    },
-    ELet(name, value, body, _) => {
-      let throwaway = array_empty()
-      let throwtab = array_empty()
-      let (value_ty, next_s, next_c) = ce(value, env, defs, s, c, throwaway, throwtab)
-      collect_explicit_return_types(body, env_bind(env, name, value_ty), defs, next_s, next_c, out, ce)
-    },
-    ELetMut(name, value, body, _) => {
-      let throwaway = array_empty()
-      let throwtab = array_empty()
-      let (value_ty, next_s, next_c) = ce(value, env, defs, s, c, throwaway, throwtab)
-      collect_explicit_return_types(body, env_bind_mut(env, name, value_ty, false), defs, next_s, next_c, out, ce)
-    },
-    _ => {
-      for child in expr_children(expr) {
-        collect_explicit_return_types(child, env, defs, s, c, out, ce)
-      }
-      ()
+fn return_provenance_key(id: Int) -> Int {
+  0 - id - 1000000000
+}
+
+fn return_provenance_was_written(tytab: Array[(Int, Type)], id: Int) -> Bool {
+  let wanted = return_provenance_key(id)
+  let mut found = false
+  for entry in tytab {
+    let (off, _) = entry
+    if off == wanted {
+      found = true
     }
   }
+  found
 }
 
 fn is_enum_ctor_name(name: String, defs: Array[TypeDef]) -> Bool {
@@ -1601,15 +1574,15 @@ fn is_enum_ctor_name(name: String, defs: Array[TypeDef]) -> Bool {
 fn direct_result_enum_payload_param_indices(body: Expr, params: Array[(String, Option[TypeExpr])], defs: Array[TypeDef]) -> Array[Int] {
   let found = array_empty()
   match body {
-    ECall(EIdent(ctor_name, _), args, _) => if is_enum_ctor_name(ctor_name, defs) {
+    ECall(EIdent(ctor_name, _), args, _) => {
+      let alias_names = array_empty()
+      let alias_indices = array_empty()
       for call_arg in args {
-        for index in direct_result_param_indices(call_arg, params) {
-          push_unique_dependency_index(found, index)
-        }
+        collect_result_param_indices(call_arg, params, alias_names, alias_indices, found)
       }
-      ()
-    } else {
-      ()
+      if Array::length(found) > 0 && !is_enum_ctor_name(ctor_name, defs) {
+        Array::truncate(found, 0)
+      }
     },
     _ => ()
   }
@@ -2990,13 +2963,19 @@ fn resolve_param_provenance(ty: Type, param_tys: Array[Type], arg_tys: Array[Typ
 }
 
 fn call_result_with_provenance(ret: Type, param_tys: Array[Type], arg_tys: Array[Type], s: Subst) -> Type {
-  let resolved_params = for param in param_tys {
-    subst_apply(s, param)
+  let resolved_ret = subst_apply(s, ret)
+  match resolved_ret {
+    CtFn(_, _, _)|CtArray(_)|CtOption(_)|CtTuple(_)|CtRecord(_)|CtNamed(_, _) => {
+      let resolved_params = for param in param_tys {
+        subst_apply(s, param)
+      }
+      let resolved_args = for arg in arg_tys {
+        subst_apply(s, arg)
+      }
+      resolve_param_provenance(resolved_ret, resolved_params, resolved_args)
+    },
+    _ => resolved_ret
   }
-  let resolved_args = for arg in arg_tys {
-    subst_apply(s, arg)
-  }
-  resolve_param_provenance(subst_apply(s, ret), resolved_params, resolved_args)
 }
 
 /// #844: recognize the EXACT synthetic call shape `parser_expr_dispatch.vibe`'s
@@ -4716,10 +4695,27 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
             }
             i = i + 1
           }
-          for index in alias_result_param_indices(callee_ty) {
-            if index >= 0 && index < Array::length(args) && tail_named_record_mentions_region(Array::get(args, index), env, defs, s1, c1, region_name, ce) {
-              found = true
-            }
+          match callee_effect {
+            Some(row) => if String::contains(row, "#aliasparam[") {
+              for raw in String::split(row, ",") {
+                let label = String::trim(raw)
+                if String::starts_with(label, "#aliasparam[") {
+                  let close = String::index_of(label, "]")
+                  let mut index = 0
+                  let mut p = 12
+                  while p < close {
+                    index = index * 10 + (String::char_code_at(label, p) - 48)
+                    p = p + 1
+                  }
+                  if index >= 0 && index < Array::length(args) && tail_named_record_mentions_region(Array::get(args, index), env, defs, s1, c1, region_name, ce) {
+                    found = true
+                  }
+                }
+              }
+            } else {
+              ()
+            },
+            None => ()
           }
           match callee_effect {
             Some(row) => for raw in String::split(row, ",") {
@@ -8594,13 +8590,13 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       // to the LAMBDA — checking it against the OUTER annotation wrongly
       // rejected it once the #941 railway-conflict report landed. CtUnknown
       // unifies with anything, so the EReturn check is inert for it.
-      let body_env = match ret_ty {
+      let annotated_body_env = match ret_ty {
         Some(rte) => env_bind(fn_env, "__return__", resolve_tparams_in(resolve_type_expr_shadowed(rte, defs, tparams), fn_env)),
         None => env_bind(fn_env, "__return__", CtUnknown)
       }
-      let (bt, s2, c2) = check_expr_capture(body, body_env, defs, s1, c1, errors, tytab, capture, lane)
-      let explicit_return_types = array_empty()
-      collect_explicit_return_types(body, body_env, defs, s2, c2, explicit_return_types, check_expr)
+      let (return_provenance, return_c) = fresh_var(c1)
+      let body_env = env_bind(annotated_body_env, "__return_provenance__", return_provenance)
+      let (bt, s2, c2) = check_expr_capture(body, body_env, defs, s1, return_c, errors, tytab, capture, lane)
       let (base_ret, s3) = match ret_ty {
         Some(te) => {
           let resolved = resolve_type_expr_shadowed(te, defs, tparams)
@@ -8633,8 +8629,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         None => (subst_apply(s2, bt), s2)
       }
       let mut final_ret = base_ret
-      for explicit_ret in explicit_return_types {
-        final_ret = merge_capture_provenance(final_ret, subst_apply(s3, explicit_ret))
+      match return_provenance {
+        CtVar(return_id) => if return_provenance_was_written(tytab, return_id) {
+          final_ret = merge_capture_provenance(final_ret, subst_apply(s3, return_provenance))
+        },
+        _ => ()
       }
       let capture_effect = closure_capture_row(effect, body, params, fn_env, s3)
       let mut checked_effect = capture_effect
@@ -8999,13 +8998,25 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         },
         None => ()
       }
+      let s2 = match env_lookup(env, "__return_provenance__") {
+        Some(CtVar(id)) => {
+          Array::push(tytab, (return_provenance_key(id), CtUnit))
+          let previous = subst_apply(s1, CtVar(id))
+          let merged = match previous {
+            CtVar(_) => subst_apply(s1, et),
+            _ => merge_capture_provenance(previous, subst_apply(s1, et))
+          }
+          SubstBind(id, merged, s1)
+        },
+        _ => s1
+      }
       // The expression value of `return e` is `e`'s type, not CtUnknown. A lambda
       // whose body is a bare `return e` (`(n) -> { return n }`) otherwise inferred
       // a CtUnknown return type, so when its type came from OUTER unification
       // (`let g: (Int) -> String = (n) -> { return n }`) the return/result
       // mismatch was hidden — the no-`return` form `(n) -> { n }` is rejected, so
       // the `return` form must be too. Propagating `et` makes them identical.
-      (et, s1, c1)
+      (et, s2, c1)
     },
     EMap(mpairs) => {
       // #938: map literals were entirely untyped (fell through to CtUnknown),

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -2743,7 +2743,10 @@ fn type_can_carry_region(ty: Type) -> Bool {
     CtTuple(_) => true,
     CtRecord(_) => true,
     CtNamed(_, _) => true,
+    CtStruct(_) => true,
+    CtEnum(_) => true,
     CtVar(_) => true,
+    CtUnknown => true,
     CtForAll(_, _, _) => true,
     _ => false
   }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -9,6 +9,7 @@ import @vibe/compiler/core {
   TypeEnv,
   TypeExpr,
   canonical_builtin_name,
+  collect_tvars,
   env_bind,
   env_bind_mut,
   env_lookup,
@@ -62,7 +63,7 @@ import ./checker_spawnable.vibe {
 }
 
 import ./checker_escape.vibe {
-  mut_binding_escapes, region_token_escapes_in_closure
+  expr_free_in, mut_binding_escapes
 }
 
 //# Functions
@@ -810,8 +811,21 @@ fn type_mentions_named(ty: Type, name: String) -> Bool {
     },
     CtArray(e) => type_mentions_named(e, name),
     CtOption(e) => type_mentions_named(e, name),
-    CtFn(ps, ret, _) => {
+    CtFn(ps, ret, eff) => {
       let mut found = type_mentions_named(ret, name)
+      match eff {
+        Some(row) => {
+          let labels = String::split(row, ",")
+          let mut ei = 0
+          while ei < Array::length(labels) {
+            if String::trim(Array::get(labels, ei)) == name {
+              found = true
+            }
+            ei = ei + 1
+          }
+        },
+        None => ()
+      }
       let mut i = 0
       while i < Array::length(ps) {
         if type_mentions_named(Array::get(ps, i), name) {
@@ -825,6 +839,93 @@ fn type_mentions_named(ty: Type, name: String) -> Bool {
     },
     CtForAll(_, _, body) => type_mentions_named(body, name),
     _ => false
+  }
+}
+
+fn merge_provenance_row(expected: Option[String], actual: Option[String]) -> Option[String] {
+  let labels = match expected {
+    Some(row) => for raw in String::split(row, ",") {
+      String::trim(raw)
+    },
+    None => array_empty()
+  }
+  match actual {
+    Some(row) => for raw in String::split(row, ",") {
+      let label = String::trim(raw)
+      if (String::starts_with(label, "#region_") || String::starts_with(label, "#capture[")) && !string_array_has(labels, label) {
+        Array::push(labels, label)
+      }
+    },
+    None => array_empty()
+  }
+  if Array::length(labels) == 0 {
+    None
+  } else {
+    Some(String::join(labels, ", "))
+  }
+}
+
+/// An explicit return annotation constrains the public shape but must not
+/// erase checker-only capture provenance synthesized on the returned value.
+fn merge_capture_provenance(expected: Type, actual: Type) -> Type {
+  match expected {
+    CtFn(eps, eret, eeff) => match actual {
+      CtFn(aps, aret, aeff) => {
+        let params = array_empty()
+        let mut i = 0
+        while i < Array::length(eps) {
+          if i < Array::length(aps) {
+            Array::push(params, merge_capture_provenance(Array::get(eps, i), Array::get(aps, i)))
+          } else {
+            Array::push(params, Array::get(eps, i))
+          }
+          i = i + 1
+        }
+        CtFn(params, merge_capture_provenance(eret, aret), merge_provenance_row(eeff, aeff))
+      },
+      _ => expected
+    },
+    CtArray(ee) => match actual {
+      CtArray(ae) => CtArray(merge_capture_provenance(ee, ae)),
+      _ => expected
+    },
+    CtOption(ee) => match actual {
+      CtOption(ae) => CtOption(merge_capture_provenance(ee, ae)),
+      _ => expected
+    },
+    CtTuple(es) => match actual {
+      CtTuple(as_) => {
+        let items = array_empty()
+        let mut i = 0
+        while i < Array::length(es) {
+          if i < Array::length(as_) {
+            Array::push(items, merge_capture_provenance(Array::get(es, i), Array::get(as_, i)))
+          } else {
+            Array::push(items, Array::get(es, i))
+          }
+          i = i + 1
+        }
+        CtTuple(items)
+      },
+      _ => expected
+    },
+    CtNamed(name, eargs) => match actual {
+      CtNamed(aname, aargs) => if name == aname {
+        let args = array_empty()
+        let mut i = 0
+        while i < Array::length(eargs) {
+          if i < Array::length(aargs) {
+            Array::push(args, merge_capture_provenance(Array::get(eargs, i), Array::get(aargs, i)))
+          } else {
+            Array::push(args, Array::get(eargs, i))
+          }
+          i = i + 1
+        }
+        CtNamed(name, args)
+      } else expected,
+      _ => expected
+    },
+    _ => expected
   }
 }
 
@@ -864,6 +965,161 @@ fn collect_env_bindings(env: TypeEnv, acc: Array[(String, Type)]) -> Unit {
       }
       collect_env_bindings(rest, acc)
     }
+  }
+}
+
+fn string_array_has(items: Array[String], wanted: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) {
+    if Array::get(items, i) == wanted {
+      found = true
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn collect_region_skolems(ty: Type, out: Array[String]) -> Unit {
+  match ty {
+    CtNamed(name, args) => {
+      if String::starts_with(name, "#region_") && !string_array_has(out, name) {
+        Array::push(out, name)
+      }
+      for arg in args {
+        collect_region_skolems(arg, out)
+      }
+      ()
+    },
+    CtFn(params, ret, eff) => {
+      for param in params {
+        collect_region_skolems(param, out)
+      }
+      collect_region_skolems(ret, out)
+      match eff {
+        Some(row) => {
+          for raw in String::split(row, ",") {
+            let label = String::trim(raw)
+            if String::starts_with(label, "#region_") && !string_array_has(out, label) {
+              Array::push(out, label)
+            }
+          }
+          ()
+        },
+        None => ()
+      }
+    },
+    CtArray(elem) => collect_region_skolems(elem, out),
+    CtOption(elem) => collect_region_skolems(elem, out),
+    CtTuple(items) => {
+      for item in items {
+        collect_region_skolems(item, out)
+      }
+      ()
+    },
+    CtRecord(fields) => {
+      for field in fields {
+        let (_, field_ty) = field
+        collect_region_skolems(field_ty, out)
+      }
+      ()
+    },
+    CtForAll(_, _, body) => collect_region_skolems(body, out),
+    _ => ()
+  }
+}
+
+fn append_row_label(labels: Array[String], label: String) -> Unit {
+  if !string_array_has(labels, label) {
+    Array::push(labels, label)
+  }
+}
+
+/// Add closure-capture provenance to the checked row. The labels beginning
+/// with `#` are not effects and cannot be written by source; core/types keeps
+/// them through ordinary substitution while excluding them from effect-set
+/// compatibility. A captured inference variable is dependent provenance:
+/// `#capture[v]` resolves to `#region_n` only if call-site unification binds v
+/// to a region-tagged type. This is what makes helper functions structural
+/// rather than another literal-name pattern.
+fn closure_capture_row(effect: Option[String], body: Expr, env: TypeEnv, s: Subst) -> Option[String] {
+  let labels = match effect {
+    Some(row) => for raw in String::split(row, ",") {
+      String::trim(raw)
+    },
+    None => array_empty()
+  }
+  let bindings = array_empty()
+  collect_env_bindings(env, bindings)
+  let seen_names = array_empty()
+  let mut i = 0
+  while i < Array::length(bindings) {
+    let (name, raw_ty) = Array::get(bindings, i)
+    if !string_array_has(seen_names, name) {
+      Array::push(seen_names, name)
+      let ty = subst_apply(s, raw_ty)
+      match ty {
+        CtForAll(_, _, _) => (),
+        _ => {
+          let regions = array_empty()
+          collect_region_skolems(ty, regions)
+          let vars = collect_tvars(ty)
+          // Almost every visible binding in the compiler is concrete. Check
+          // the cheap type predicate BEFORE walking the closure body; doing
+          // one full free-variable traversal per imported binding makes
+          // self-compilation quadratic.
+          if (Array::length(regions) > 0 || Array::length(vars) > 0) && expr_free_in(body, name) {
+            for region_name in regions {
+              append_row_label(labels, region_name)
+            }
+            for var_id in vars {
+              append_row_label(labels, String::concat("#capture[", String::concat(__to_string(var_id), "]")))
+            }
+          }
+        }
+      }
+    }
+    i = i + 1
+  }
+  if Array::length(labels) == 0 {
+    None
+  } else {
+    Some(String::join(labels, ", "))
+  }
+}
+
+fn type_mentions_active_region(ty: Type, env: TypeEnv) -> Bool {
+  match env {
+    EnvEmpty => false,
+    EnvBind(name, binding, rest) => if name == "__active_region__" {
+      match binding.ty {
+        CtNamed(region_name, _) => type_mentions_named(ty, region_name) || type_mentions_active_region(ty, rest),
+        _ => type_mentions_active_region(ty, rest)
+      }
+    } else {
+      type_mentions_active_region(ty, rest)
+    },
+    EnvTraitDef(_, _, _, _, rest, _, _) => type_mentions_active_region(ty, rest),
+    EnvTraitImpl(_, _, rest) => type_mentions_active_region(ty, rest),
+    EnvMutCell(_, _, rest) => type_mentions_active_region(ty, rest),
+    EnvTraitImplGen(_, _, _, _, rest) => type_mentions_active_region(ty, rest),
+    EnvTypeDefs(_, _, rest) => type_mentions_active_region(ty, rest),
+    EnvCached(_, _, rest) => type_mentions_active_region(ty, rest),
+    EnvFlat(_) => false
+  }
+}
+
+fn env_has_active_region(env: TypeEnv) -> Bool {
+  match env {
+    EnvEmpty => false,
+    EnvBind(name, _, rest) => name == "__active_region__" || env_has_active_region(rest),
+    EnvTraitDef(_, _, _, _, rest, _, _) => env_has_active_region(rest),
+    EnvTraitImpl(_, _, rest) => env_has_active_region(rest),
+    EnvMutCell(_, _, rest) => env_has_active_region(rest),
+    EnvTraitImplGen(_, _, _, _, rest) => env_has_active_region(rest),
+    EnvTypeDefs(_, _, rest) => env_has_active_region(rest),
+    EnvCached(_, _, rest) => env_has_active_region(rest),
+    EnvFlat(_) => false
   }
 }
 
@@ -1101,7 +1357,9 @@ fn effect_label_is_exempt(lbl: String) -> Bool {
   // opt-in and carries real information, so dropping it through a pure-typed
   // slot is exactly the #939 hole this check exists to catch. Nothing in the
   // codebase writes a kinded label, so no existing program changes verdict.
-  if (is_exception_effect_name(lbl) && String::length(exception_effect_kind(lbl)) == 0) || lbl == "Async" {
+  if String::starts_with(lbl, "#region_") || String::starts_with(lbl, "#capture[") {
+    true
+  } else if (is_exception_effect_name(lbl) && String::length(exception_effect_kind(lbl)) == 0) || lbl == "Async" {
     true
   } else if len == 1 {
     String::char_code_at(lbl, 0) >= 97 && String::char_code_at(lbl, 0) <= 122
@@ -5527,8 +5785,9 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           match Array::get(args, 0) {
             EFn(_, _, fn_params, _, _, fn_body) => if Array::length(fn_params) == 1 {
               let (binder_name, _) = Array::get(fn_params, 0)
-              let env_body = env_bind(env, binder_name, CtNamed(skolem_name, [
-              ]))
+              let region_ty = CtNamed(skolem_name, [
+              ])
+              let env_body = env_bind(env_bind(env, binder_name, region_ty), "__active_region__", region_ty)
               // The specialized region path checks the literal lambda body
               // directly. Preserve both structural edges from the outer call:
               // argument child 1, then EFn body child 0.
@@ -5539,19 +5798,6 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               let zonked_ret = subst_apply(s1, body_ty)
               if type_mentions_named(zonked_ret, skolem_name) {
                 Array::push(errors, String::concat("region escapes its scope: the value returned from this region body still depends on the region's own token", off_marker_len(callee_off, String::length(name))))
-              } else {
-                ()
-              }
-              // #1725: the type check above cannot see a region value that
-              // leaves inside a CLOSURE -- `region r { let l =
-              // MutList::empty(r); () -> Array[Int] { MutList::to_array(l) } }`
-              // has result type `() -> Array[Int]`, which mentions no skolem,
-              // because types do not record captures. Harmless while MutList
-              // is a checker-only phantom; a use-after-free once the arena
-              // releases at region end. See checker_escape.vibe for why this
-              // companion check is deliberately narrow.
-              if region_token_escapes_in_closure(fn_body, binder_name) {
-                Array::push(errors, String::concat("region escapes its scope: a closure returned from this region body captures a value built from the region's own token -- return `MutList::freeze(..)` / `MutList::to_array(..)` / `MutBytes::to_bytes(..)` instead of a closure over it", off_marker_len(callee_off, String::length(name))))
               } else {
                 ()
               }
@@ -6278,6 +6524,9 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
     },
     EAssign(name, val, body) => {
       let (vt, s1, c1) = check_expr_capture(val, env, defs, s, c, errors, tytab, capture, lane)
+      if type_mentions_active_region(subst_apply(s1, vt), env) {
+        Array::push(errors, String::concat("region escapes its scope: an assignment stores a value that captures this region into an outer binding", off_marker(tail_expr_off(val))))
+      }
       // The assigned value must be assignable to the variable's type
       // (previously unchecked — `y = "s"` for `let mut y = 1` was accepted).
       let s1b = match env_lookup(env, name) {
@@ -7309,11 +7558,16 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // returned. -1 (unlocated, as before) when the tail is a literal:
           // EInt/EString/EBool/EFloat carry no offset in the AST.
           let ns = check_assignable(resolved_ret, bt, s2, errors, "return type mismatch", tail_expr_off(body))
-          (subst_apply(ns, resolved_ret), ns)
+          (merge_capture_provenance(subst_apply(ns, resolved_ret), subst_apply(ns, bt)), ns)
         },
         None => (subst_apply(s2, bt), s2)
       }
-      (CtFn(param_types, final_ret, effect), s3, c2)
+      let checked_effect = if env_has_active_region(env) {
+        closure_capture_row(effect, body, env, s3)
+      } else {
+        effect
+      }
+      (CtFn(param_types, final_ret, checked_effect), s3, c2)
     },
     EBreak(opt) => {
       // `break` is only meaningful inside a loop. Loop bodies bind the

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -298,7 +298,7 @@ fn resolve_qualified_ctor_ident(name: String, env: TypeEnv, defs: Array[TypeDef]
             if Array::length(payloads) == 0 {
               Some(CtEnum(ename))
             } else {
-              Some(CtFn(payloads, CtEnum(ename), None))
+              Some(CtFn(payloads, CtEnum(ename), constructor_dependency_row(Array::length(payloads))))
             }
           } else {
             // The imported bare constructor is the checked `CtForAll` scheme.
@@ -869,6 +869,23 @@ fn merge_provenance_row(expected: Option[String], actual: Option[String]) -> Opt
       }
     },
     None => array_empty()
+  }
+  if Array::length(labels) == 0 {
+    None
+  } else {
+    Some(String::join(labels, ", "))
+  }
+}
+
+/// Constructor results retain every payload. Record that dependency in the
+/// same checker-only row used by field-projection helpers, so direct,
+/// qualified, imported, and first-class enum constructors share one contract.
+export fn constructor_dependency_row(arity: Int) -> Option[String] {
+  let labels = array_empty()
+  let mut i = 0
+  while i < arity {
+    Array::push(labels, String::concat("#fieldparam[", String::concat(__to_string(i), "]")))
+    i = i + 1
   }
   if Array::length(labels) == 0 {
     None
@@ -2605,9 +2622,21 @@ fn param_marker_index(label: String) -> Option[Int] {
 
 fn add_param_capture_dependency(ty: Type, index: Int) -> Type {
   match ty {
-    CtFn(params, ret, effect) => CtFn(params, ret, merge_provenance_row(effect, Some(String::concat("#param[", String::concat(__to_string(index), "]"))))),
+    CtFn(params, ret, effect) => CtFn(for param in params {
+      add_param_capture_dependency(param, index)
+    }, add_param_capture_dependency(ret, index), merge_provenance_row(effect, Some(String::concat("#param[", String::concat(__to_string(index), "]"))))),
     CtArray(elem) => CtArray(add_param_capture_dependency(elem, index)),
     CtOption(elem) => CtOption(add_param_capture_dependency(elem, index)),
+    CtTuple(items) => CtTuple(for item in items {
+      add_param_capture_dependency(item, index)
+    }),
+    CtRecord(fields) => CtRecord(for field in fields {
+      let (name, field_ty) = field
+      (name, add_param_capture_dependency(field_ty, index))
+    }),
+    CtNamed(name, args) => CtNamed(name, for arg in args {
+      add_param_capture_dependency(arg, index)
+    }),
     _ => ty
   }
 }
@@ -4301,14 +4330,18 @@ fn field_write_mut_check(name: String, args: Array[Expr], env: TypeEnv, defs: Ar
 /// Mutable container operations are assignments with a non-syntactic target.
 /// Check their stored argument against the same region lifetime rule as
 /// `EAssign`; operations that only store scalar bytes/indices need no entry.
-fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Unit {
-  let value_index = if name == "Array::push" || name == "ArrayBuilder::push" || name == "Array::push_all" || name == "MutList::push" {
+fn retaining_write_value_index(name: String) -> Int {
+  if name == "Array::push" || name == "ArrayBuilder::push" || name == "Array::push_all" || name == "MutList::push" || name == "Deque::push_back" || name == "Deque::push_front" {
     1
-  } else if name == "Array::set" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "MapBuilder::set" || name == "__set_field" {
+  } else if name == "Array::set" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "MapBuilder::set" || name == "MutMap::set" || name == "__set_field" {
     2
   } else {
     0 - 1
   }
+}
+
+fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Unit {
+  let value_index = retaining_write_value_index(name)
   if value_index >= 0 && Array::length(args) > value_index {
     let throwaway = array_empty()
     let throwtab = array_empty()
@@ -4326,13 +4359,25 @@ fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, d
 /// Nominal struct identity intentionally omits field types. Reconstruct only
 /// the tail record literal's local let environment so a region-return check can
 /// inspect the actual field values without changing the public nominal type.
+fn tail_returns_binding(expr: Expr, name: String) -> Bool {
+  match expr {
+    EIdent(found, _) => found == name,
+    ELet(_, _, body, _) => tail_returns_binding(body, name),
+    ELetMut(_, _, body, _) => tail_returns_binding(body, name),
+    ELetRec(_, _, body) => tail_returns_binding(body, name),
+    ESeq(_, right) => tail_returns_binding(right, name),
+    EIf(_, then_expr, else_expr) => tail_returns_binding(then_expr, name) || tail_returns_binding(else_expr, name),
+    _ => false
+  }
+}
+
 fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, region_name: String, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Bool {
   match expr {
     ELet(name, val, body, _) => {
       let throwaway = array_empty()
       let throwtab = array_empty()
       let (val_ty, s1, c1) = ce(val, env, defs, s, c, throwaway, throwtab)
-      tail_named_record_mentions_region(body, env_bind(env, name, val_ty), defs, s1, c1, region_name, ce)
+      (tail_returns_binding(body, name) && tail_named_record_mentions_region(val, env, defs, s, c, region_name, ce)) || tail_named_record_mentions_region(body, env_bind(env, name, val_ty), defs, s1, c1, region_name, ce)
     },
     ELetMut(name, val, body, _) => {
       let throwaway = array_empty()
@@ -4350,6 +4395,15 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
       let throwaway = array_empty()
       let throwtab = array_empty()
       let (callee_ty, s1, c1) = ce(callee, env, defs, s, c, throwaway, throwtab)
+      let mut builtin_constructor_found = false
+      match callee {
+        EIdent("Some", _) => for arg in args {
+          if tail_named_record_mentions_region(arg, env, defs, s1, c1, region_name, ce) {
+            builtin_constructor_found = true
+          }
+        },
+        _ => ()
+      }
       match subst_apply(s1, callee_ty) {
         CtFn(param_tys, ret_ty, callee_effect) => {
           let resolved_ret = subst_apply(s1, ret_ty)
@@ -4405,9 +4459,9 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
             },
             _ => ()
           }
-          found
+          found || builtin_constructor_found
         },
-        _ => false
+        _ => builtin_constructor_found
       }
     },
     ERecord(name, fields, _) => if name != "" {
@@ -4430,6 +4484,24 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
       found
     } else {
       false
+    },
+    EArray(items) => {
+      let mut found = false
+      for item in items {
+        if tail_named_record_mentions_region(item, env, defs, s, c, region_name, ce) {
+          found = true
+        }
+      }
+      found
+    },
+    ETuple(items) => {
+      let mut found = false
+      for item in items {
+        if tail_named_record_mentions_region(item, env, defs, s, c, region_name, ce) {
+          found = true
+        }
+      }
+      found
     },
     _ => {
       let throwaway = array_empty()
@@ -6853,6 +6925,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               }
               let (mt, s2, c2) = method_ty
               let all_args = prepend_expr(obj, args)
+              retaining_write_region_check(qualified, all_args, env, defs, s2, c2, errors, check_expr)
               let alen = Array::length(all_args)
               let arg_tys = array_empty()
               Array::push(arg_tys, obj_ty)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -2637,6 +2637,7 @@ fn add_param_capture_dependency(ty: Type, index: Int) -> Type {
     CtNamed(name, args) => CtNamed(name, for arg in args {
       add_param_capture_dependency(arg, index)
     }),
+    CtForAll(vars, bounds, body) => CtForAll(vars, bounds, add_param_capture_dependency(body, index)),
     _ => ty
   }
 }
@@ -2675,6 +2676,7 @@ fn collect_internal_provenance(ty: Type, out: Array[String]) -> Unit {
         collect_internal_provenance(arg, out)
       }
     },
+    CtForAll(_, _, body) => collect_internal_provenance(body, out),
     _ => ()
   }
 }
@@ -4327,29 +4329,49 @@ fn field_write_mut_check(name: String, args: Array[Expr], env: TypeEnv, defs: Ar
   }
 }
 
-/// Mutable container operations are assignments with a non-syntactic target.
-/// Check their stored argument against the same region lifetime rule as
-/// `EAssign`; operations that only store scalar bytes/indices need no entry.
-fn retaining_write_value_index(name: String) -> Int {
-  if name == "Array::push" || name == "ArrayBuilder::push" || name == "Array::push_all" || name == "MutList::push" || name == "Deque::push_back" || name == "Deque::push_front" {
+/// Argument positions retained by a mutable operation, encoded as a two-bit
+/// mask for positions 1 and 2. This is the single checker-owned inventory for
+/// shipped primitives and standard-library mutable wrappers; aliases are listed
+/// beside their canonical spelling.
+fn retaining_write_argument_mask(source_name: String) -> Int {
+  let name = canonical_builtin_name(source_name)
+  if name == "Array::push" || name == "ArrayBuilder::push" || name == "Array::push_all" || name == "MutList::push" || name == "MutSet::add" || name == "HashSet::add" || name == "MutSortedSet::add" || name == "SortedSet::add" || name == "PriorityQueue::push" || name == "Deque::push_back" || name == "Deque::push_front" {
     1
-  } else if name == "Array::set" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "MapBuilder::set" || name == "MutMap::set" || name == "__set_field" {
+  } else if name == "Array::set" || name == "FixedArray::set" || name == "FixedArray::unsafe_set" || name == "__set_field" {
     2
+  } else if name == "MapBuilder::set" || name == "MutMap::set" || name == "HashMap::set" || name == "MutSortedMap::set" || name == "SortedMap::set" {
+    3
   } else {
-    0 - 1
+    0
   }
 }
 
+/// Mutable container operations are assignments with a non-syntactic target.
+/// Check every stored argument against the same region lifetime rule as
+/// `EAssign`; skip the duplicate type walk entirely outside a region.
 fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Unit {
-  let value_index = retaining_write_value_index(name)
-  if value_index >= 0 && Array::length(args) > value_index {
-    let throwaway = array_empty()
-    let throwtab = array_empty()
-    let (val_ty, s1, _) = ce(Array::get(args, value_index), env, defs, s, c, throwaway, throwtab)
-    if container_write_crosses_region(Array::get(args, 0), subst_apply(s1, val_ty), env) {
-      Array::push(errors, String::concat("region escapes its scope: a container write stores a value that captures this region into an outer binding", off_marker(tail_expr_off(Array::get(args, value_index)))))
-    } else {
-      ()
+  if env_has_active_region(env) && Array::length(args) > 0 {
+    let retained = retaining_write_argument_mask(name)
+    let mut value_index = 1
+    while value_index <= 2 {
+      let is_retained = if value_index == 1 {
+        retained == 1 || retained == 3
+      } else {
+        retained == 2 || retained == 3
+      }
+      if is_retained && value_index < Array::length(args) {
+        let throwaway = array_empty()
+        let throwtab = array_empty()
+        let (val_ty, s1, _) = ce(Array::get(args, value_index), env, defs, s, c, throwaway, throwtab)
+        if container_write_crosses_region(Array::get(args, 0), subst_apply(s1, val_ty), env) {
+          Array::push(errors, String::concat("region escapes its scope: a container write stores a value that captures this region into an outer binding", off_marker(tail_expr_off(Array::get(args, value_index)))))
+        } else {
+          ()
+        }
+      } else {
+        ()
+      }
+      value_index = value_index + 1
     }
   } else {
     ()
@@ -4359,6 +4381,68 @@ fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, d
 /// Nominal struct identity intentionally omits field types. Reconstruct only
 /// the tail record literal's local let environment so a region-return check can
 /// inspect the actual field values without changing the public nominal type.
+fn named_record_provenance_key(name: String) -> String {
+  String::concat("__region_named_record__", name)
+}
+
+/// Bind the structural field types of a nominal record initializer under a
+/// checker-private key. Nominal identity remains `CtStruct`; only the region
+/// tail check reads this detached provenance view. Bare aliases copy the view.
+fn bind_named_record_provenance(name: String, val: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> TypeEnv {
+  match val {
+    ERecord(record_name, fields, _) => if record_name != "" {
+      let field_types = array_empty()
+      for field in fields {
+        let (field_name, value) = field
+        let throwaway = array_empty()
+        let throwtab = array_empty()
+        let (field_ty, field_s, _) = ce(value, env, defs, s, c, throwaway, throwtab)
+        Array::push(field_types, (field_name, subst_apply(field_s, field_ty)))
+      }
+      env_bind(env, named_record_provenance_key(name), CtRecord(field_types))
+    } else {
+      env
+    },
+    EIdent(alias, _) => match env_lookup(env, named_record_provenance_key(alias)) {
+      Some(provenance) => env_bind(env, named_record_provenance_key(name), provenance),
+      None => env
+    },
+    _ => env
+  }
+}
+
+fn named_record_tail_mentions_region(expr: Expr, env: TypeEnv, region_name: String) -> Bool {
+  match expr {
+    EIdent(name, _) => match env_lookup(env, named_record_provenance_key(name)) {
+      Some(provenance) => type_mentions_named(provenance, region_name),
+      None => false
+    },
+    EDot(obj, field, _, _) => match obj {
+      EIdent(name, _) => match env_lookup(env, named_record_provenance_key(name)) {
+        Some(CtRecord(fields)) => {
+          let mut found = false
+          for entry in fields {
+            let (field_name, field_ty) = entry
+            if field_name == field && type_mentions_named(field_ty, region_name) {
+              found = true
+            } else {
+              ()
+            }
+          }
+          found
+        },
+        _ => false
+      },
+      _ => false
+    },
+    _ => false
+  }
+}
+
+/// Nominal struct identity intentionally omits field types. Preserve a private
+/// structural view through local bindings and aliases so whole-value and field
+/// tails cannot erase region provenance.
+
 fn tail_returns_binding(expr: Expr, name: String) -> Bool {
   match expr {
     EIdent(found, _) => found == name,
@@ -4377,13 +4461,15 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
       let throwaway = array_empty()
       let throwtab = array_empty()
       let (val_ty, s1, c1) = ce(val, env, defs, s, c, throwaway, throwtab)
-      (tail_returns_binding(body, name) && tail_named_record_mentions_region(val, env, defs, s, c, region_name, ce)) || tail_named_record_mentions_region(body, env_bind(env, name, val_ty), defs, s1, c1, region_name, ce)
+      let next_env = bind_named_record_provenance(name, val, env_bind(env, name, val_ty), defs, s1, c1, ce)
+      (tail_returns_binding(body, name) && tail_named_record_mentions_region(val, env, defs, s, c, region_name, ce)) || tail_named_record_mentions_region(body, next_env, defs, s1, c1, region_name, ce)
     },
     ELetMut(name, val, body, _) => {
       let throwaway = array_empty()
       let throwtab = array_empty()
       let (val_ty, s1, c1) = ce(val, env, defs, s, c, throwaway, throwtab)
-      tail_named_record_mentions_region(body, env_bind_mut(env, name, val_ty, false), defs, s1, c1, region_name, ce)
+      let next_env = bind_named_record_provenance(name, val, env_bind_mut(env, name, val_ty, false), defs, s1, c1, ce)
+      tail_named_record_mentions_region(body, next_env, defs, s1, c1, region_name, ce)
     },
     ESeq(left, right) => {
       let throwaway = array_empty()
@@ -4507,7 +4593,7 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
       let throwaway = array_empty()
       let throwtab = array_empty()
       let (expr_ty, next_s, _) = ce(expr, env, defs, s, c, throwaway, throwtab)
-      type_mentions_named(subst_apply(next_s, expr_ty), region_name)
+      named_record_tail_mentions_region(expr, env, region_name) || type_mentions_named(subst_apply(next_s, expr_ty), region_name)
     }
   }
 }
@@ -8254,12 +8340,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             (tv, s1, nc2)
           }
         }
-        let marked_pt = match pt {
-          CtFn(_, _, _) => add_param_capture_dependency(pt, nc),
-          CtArray(_) => add_param_capture_dependency(pt, nc),
-          CtOption(_) => add_param_capture_dependency(pt, nc),
-          _ => pt
-        }
+        let marked_pt = add_param_capture_dependency(pt, nc)
         let marked_nc = nc + 1
         fn_env = env_bind(fn_env, name, marked_pt)
         fn_env = env_bind(fn_env, String::concat("__param_marker__", name), CtNamed(String::concat("#param[", String::concat(__to_string(nc), "]")), [

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -1318,12 +1318,29 @@ fn binding_predates_active_region(name: String, env: TypeEnv) -> Bool {
   }
 }
 
-fn alias_result_param_index(ty: Type) -> Option[Int] {
+fn push_unique_dependency_index(out: Array[Int], index: Int) -> Unit {
+  let mut found = false
+  for existing in out {
+    if existing == index {
+      found = true
+    }
+  }
+  if !found {
+    Array::push(out, index)
+  }
+}
+
+fn alias_result_param_indices(ty: Type) -> Array[Int] {
+  let found = array_empty()
   match ty {
-    CtForAll(_, _, body) => alias_result_param_index(body),
+    CtForAll(_, _, body) => {
+      for index in alias_result_param_indices(body) {
+        push_unique_dependency_index(found, index)
+      }
+      ()
+    },
     CtFn(_, _, effect) => match effect {
       Some(row) => {
-        let mut found = None
         for raw in String::split(row, ",") {
           let label = String::trim(raw)
           if String::starts_with(label, "#aliasparam[") {
@@ -1334,15 +1351,16 @@ fn alias_result_param_index(ty: Type) -> Option[Int] {
               id = id * 10 + (String::char_code_at(label, p) - 48)
               p = p + 1
             }
-            found = Some(id)
+            push_unique_dependency_index(found, id)
           }
         }
-        found
+        ()
       },
-      None => None
+      None => ()
     },
-    _ => None
+    _ => ()
   }
+  found
 }
 
 fn decimal_index(text: String) -> Int {
@@ -1362,42 +1380,43 @@ fn expression_aliases_outer_binding(expr: Expr, env: TypeEnv) -> Bool {
       None => false
     },
     ECall(EIdent(callee, _), args, _) => match env_lookup(env, callee) {
-      Some(callee_ty) => match env_lookup(env, String::concat("__alias_contract__", callee)) {
-        Some(CtNamed(index_text, _)) => {
-          let index = decimal_index(index_text)
-          if index >= 0 && index < Array::length(args) {
-            expression_aliases_outer_binding(Array::get(args, index), env)
-          } else {
-            false
-          }
-        },
-        _ => match alias_result_param_index(callee_ty) {
-          Some(index) => if index >= 0 && index < Array::length(args) {
-            expression_aliases_outer_binding(Array::get(args, index), env)
-          } else {
-            false
+      Some(callee_ty) => {
+        let mut found = false
+        match env_lookup(env, String::concat("__alias_contract__", callee)) {
+          Some(CtNamed(index_text, _)) => {
+            let index = decimal_index(index_text)
+            if index >= 0 && index < Array::length(args) {
+              found = expression_aliases_outer_binding(Array::get(args, index), env)
+            }
           },
-          None => false
+          _ => ()
         }
+        for index in alias_result_param_indices(callee_ty) {
+          if index >= 0 && index < Array::length(args) && expression_aliases_outer_binding(Array::get(args, index), env) {
+            found = true
+          }
+        }
+        found
       },
       None => false
     },
-    ECall(EFn(_, _, params, _, _, body), args, _) => match direct_result_param_index(body, params) {
-      Some(index) => if index >= 0 && index < Array::length(args) {
-        expression_aliases_outer_binding(Array::get(args, index), env)
-      } else {
-        false
-      },
-      None => false
+    ECall(EFn(_, _, params, _, _, body), args, _) => {
+      let mut found = false
+      for index in direct_result_param_indices(body, params) {
+        if index >= 0 && index < Array::length(args) && expression_aliases_outer_binding(Array::get(args, index), env) {
+          found = true
+        }
+      }
+      found
     },
     _ => false
   }
 }
 
-fn direct_result_param_index(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Option[Int] {
+fn result_param_indices(body: Expr, params: Array[(String, Option[TypeExpr])], alias_names: Array[String], alias_indices: Array[Int]) -> Array[Int] {
+  let found = array_empty()
   match body {
     EIdent(name, _) => {
-      let mut found = None
       let mut i = 0
       while i < Array::length(params) {
         let (raw_name, _) = Array::get(params, i)
@@ -1409,13 +1428,64 @@ fn direct_result_param_index(body: Expr, params: Array[(String, Option[TypeExpr]
           } else raw_name
         } else raw_name
         if name == param_name {
-          found = Some(i)
+          push_unique_dependency_index(found, i)
         }
         i = i + 1
       }
-      found
+      let mut alias_i = 0
+      while alias_i < Array::length(alias_names) {
+        if name == Array::get(alias_names, alias_i) {
+          push_unique_dependency_index(found, Array::get(alias_indices, alias_i))
+        }
+        alias_i = alias_i + 1
+      }
     },
-    _ => None
+    ELet(name, value, rest, _) => {
+      let next_names = for alias in alias_names {
+        alias
+      }
+      let next_indices = for index in alias_indices {
+        index
+      }
+      for index in result_param_indices(value, params, alias_names, alias_indices) {
+        Array::push(next_names, name)
+        Array::push(next_indices, index)
+      }
+      for index in result_param_indices(rest, params, next_names, next_indices) {
+        push_unique_dependency_index(found, index)
+      }
+      ()
+    },
+    ESeq(_, right) => {
+      for index in result_param_indices(right, params, alias_names, alias_indices) {
+        push_unique_dependency_index(found, index)
+      }
+      ()
+    },
+    EIf(_, then_expr, else_expr) => {
+      for index in result_param_indices(then_expr, params, alias_names, alias_indices) {
+        push_unique_dependency_index(found, index)
+      }
+      for index in result_param_indices(else_expr, params, alias_names, alias_indices) {
+        push_unique_dependency_index(found, index)
+      }
+      ()
+    },
+    _ => ()
+  }
+  found
+}
+
+fn direct_result_param_indices(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Array[Int] {
+  result_param_indices(body, params, array_empty(), array_empty())
+}
+
+fn direct_result_param_index(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Option[Int] {
+  let indices = direct_result_param_indices(body, params)
+  if Array::length(indices) > 0 {
+    Some(Array::get(indices, 0))
+  } else {
+    None
   }
 }
 
@@ -1533,21 +1603,11 @@ fn direct_result_enum_payload_param_indices(body: Expr, params: Array[(String, O
   match body {
     ECall(EIdent(ctor_name, _), args, _) => if is_enum_ctor_name(ctor_name, defs) {
       for call_arg in args {
-        match direct_result_param_index(call_arg, params) {
-          Some(index) => {
-            let mut seen = false
-            for existing in found {
-              if existing == index {
-                seen = true
-              }
-            }
-            if !seen {
-              Array::push(found, index)
-            }
-          },
-          None => ()
+        for index in direct_result_param_indices(call_arg, params) {
+          push_unique_dependency_index(found, index)
         }
       }
+      ()
     } else {
       ()
     },
@@ -4656,11 +4716,10 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
             }
             i = i + 1
           }
-          match alias_result_param_index(callee_ty) {
-            Some(index) => if index >= 0 && index < Array::length(args) && tail_named_record_mentions_region(Array::get(args, index), env, defs, s1, c1, region_name, ce) {
+          for index in alias_result_param_indices(callee_ty) {
+            if index >= 0 && index < Array::length(args) && tail_named_record_mentions_region(Array::get(args, index), env, defs, s1, c1, region_name, ce) {
               found = true
-            },
-            None => ()
+            }
           }
           match callee_effect {
             Some(row) => for raw in String::split(row, ",") {
@@ -4743,6 +4802,31 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
       named_record_tail_mentions_region(expr, env, region_name) || type_mentions_named(subst_apply(next_s, expr_ty), region_name)
     }
   }
+}
+
+fn expression_mentions_active_region_scan(expr: Expr, cur: TypeEnv, full: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Bool {
+  match cur {
+    EnvEmpty => false,
+    EnvBind(name, binding, rest) => if name == "__active_region__" {
+      match binding.ty {
+        CtNamed(region_name, _) => tail_named_record_mentions_region(expr, full, defs, s, c, region_name, ce) || expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce),
+        _ => expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce)
+      }
+    } else {
+      expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce)
+    },
+    EnvMutCell(_, _, rest) => expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce),
+    EnvTraitDef(_, _, _, _, rest, _, _) => expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce),
+    EnvTraitImpl(_, _, rest) => expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce),
+    EnvTraitImplGen(_, _, _, _, rest) => expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce),
+    EnvTypeDefs(_, _, rest) => expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce),
+    EnvCached(_, _, rest) => expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce),
+    EnvFlat(_) => false
+  }
+}
+
+fn expression_mentions_active_region(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Bool {
+  expression_mentions_active_region_scan(expr, env, env, defs, s, c, ce)
 }
 
 /// `obj[i]` desugars to `__index(obj, i)`, typed fully polymorphically, so
@@ -7494,7 +7578,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
     },
     EAssign(name, val, body) => {
       let (vt, s1, c1) = check_expr_capture(val, env, defs, s, c, errors, tytab, capture, lane)
-      if assignment_crosses_region(name, subst_apply(s1, vt), env) {
+      if assignment_crosses_region(name, subst_apply(s1, vt), env) || (binding_predates_active_region(name, env) && expression_mentions_active_region(val, env, defs, s1, c1, check_expr)) {
         Array::push(errors, String::concat("region escapes its scope: an assignment stores a value that captures this region into an outer binding", off_marker(tail_expr_off(val))))
       }
       // The assigned value must be assignable to the variable's type
@@ -8553,20 +8637,16 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         final_ret = merge_capture_provenance(final_ret, subst_apply(s3, explicit_ret))
       }
       let capture_effect = closure_capture_row(effect, body, params, fn_env, s3)
-      let checked_effect = match direct_result_param_index(body, params) {
-        Some(index) => {
-          let pty = if index >= 0 && index < Array::length(param_types) {
-            subst_apply(s3, Array::get(param_types, index))
-          } else {
-            CtUnit
-          }
-          if type_can_carry_region(pty) {
-            merge_provenance_row(capture_effect, Some(String::concat("#aliasparam[", String::concat(__to_string(index), "]"))))
-          } else {
-            capture_effect
-          }
-        },
-        None => capture_effect
+      let mut checked_effect = capture_effect
+      for index in direct_result_param_indices(body, params) {
+        let pty = if index >= 0 && index < Array::length(param_types) {
+          subst_apply(s3, Array::get(param_types, index))
+        } else {
+          CtUnit
+        }
+        if type_can_carry_region(pty) {
+          checked_effect = merge_provenance_row(checked_effect, Some(String::concat("#aliasparam[", String::concat(__to_string(index), "]"))))
+        }
       }
       let dependency_effect = match direct_result_field_param_index(body, params) {
         Some(index) => if type_can_carry_region(if index >= 0 && index < Array::length(param_types) {

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -731,7 +731,7 @@ fn effect_row_parse(eff: Option[String]) -> Option[Array[String]] {
       let mut i = 0
       while i < Array::length(raw) {
         let label = canonical_exception_effect_name(String::trim(Array::get(raw, i)))
-        let internal_provenance = String::starts_with(label, "#region_") || String::starts_with(label, "#capture[") || String::starts_with(label, "#param[")
+        let internal_provenance = String::starts_with(label, "#region_") || String::starts_with(label, "#capture[") || String::starts_with(label, "#param[") || String::starts_with(label, "#aliasparam[") || String::starts_with(label, "#fieldparam[")
         if String::length(label) > 0 && !internal_provenance && !effect_row_has_label(Some(labels), label) {
           Array::push(labels, label)
         }

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -731,7 +731,8 @@ fn effect_row_parse(eff: Option[String]) -> Option[Array[String]] {
       let mut i = 0
       while i < Array::length(raw) {
         let label = canonical_exception_effect_name(String::trim(Array::get(raw, i)))
-        if String::length(label) > 0 && !effect_row_has_label(Some(labels), label) {
+        let internal_provenance = String::starts_with(label, "#region_") || String::starts_with(label, "#capture[") || String::starts_with(label, "#param[")
+        if String::length(label) > 0 && !internal_provenance && !effect_row_has_label(Some(labels), label) {
           Array::push(labels, label)
         }
         i = i + 1

--- a/lib/@vibe/compiler/checker/checker_escape.vibe
+++ b/lib/@vibe/compiler/checker/checker_escape.vibe
@@ -30,10 +30,6 @@ import @vibe/compiler/core {
   Expr, Pat, TypeExpr
 }
 
-import @vibe/core {
-  array_empty
-}
-
 //# Functions
 
 /// True when `pat` binds `name` (and therefore shadows an outer `let mut` of
@@ -244,6 +240,13 @@ fn esc_free_in(expr: Expr, name: String) -> Bool {
   }
 }
 
+/// Public checker query used when synthesizing closure provenance. This is
+/// the same strict, shadowing-aware free-variable judgment as `let mut`
+/// enforcement; region capture must not grow a second binder walk.
+export fn expr_free_in(expr: Expr, name: String) -> Bool {
+  esc_free_in(expr, name)
+}
+
 fn esc_scan_list(items: Array[Expr], name: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -375,157 +378,4 @@ fn esc_scan(expr: Expr, name: String) -> Bool {
 /// inside it that shadows it, is correctly not this binding.
 export fn mut_binding_escapes(body: Expr, name: String) -> Bool {
   esc_scan(body, name)
-}
-
-//# Region-token capture (#1725 / ADR-0090)
-//#
-//# ADR-0090's escape check scans the region body's RESULT TYPE for the region
-//# skolem. That misses a closure: `region r { let l = MutList::empty(r); () ->
-//# Array[Int] { MutList::to_array(l) } }` has result type `() -> Array[Int]`,
-//# which mentions no skolem -- the taint sits in the closure's captured
-//# environment, and types do not record captures. The region value then leaves
-//# both the region and the enclosing function. Harmless while `MutList` is a
-//# checker-only phantom (nothing is freed at region end); a use-after-free the
-//# moment the arena + watermark release lands.
-//#
-//# This is a deliberately NARROW first cut, and it UNDER-approximates on
-//# purpose. An escape check is enforcement, and ADR-0100 (1) fixes the
-//# enforcement direction as "stay silent when unsure" -- a false positive here
-//# rejects a valid program. So it fires only when the region body's RESULT is
-//# a closure literal, and that closure holds either
-//#
-//#   - the region TOKEN itself (it can then call `MutList::empty(r)` after the
-//#     region ended, allocating from a segment whose watermark was handed
-//#     back), or
-//#   - a name the body bound to region memory (`MutList::empty(<token>)` or a
-//#     bare alias of one).
-//#
-//# What it does NOT catch (all still open on #1725): a tainted closure stored
-//# into an outer binding or a container rather than returned; region memory
-//# arriving through a helper (`let l = mk(r)` -- the initialiser is not
-//# syntactically `MutList::empty`); and any form needing the real rule, which
-//# is "a closure capturing a region value must not itself escape the region".
-//# That rule wants the region argument kind ADR-0071 reserved in the effect
-//# row, so a function that touches region memory carries `r` and the EXISTING
-//# type-based check sees it. This check is a stopgap that closes the
-//# demonstrated holes; it is not that design.
-
-/// A binding is region-tainted only when its initialiser EVALUATES TO region
-/// memory: a `MutList::empty(<token>)` call, or a bare alias of an
-/// already-tainted name (`let l2 = l`).
-///
-/// Both narrowings matter, in opposite directions.
-///
-/// "Mentions a tainted name" would be the obvious rule for the alias case and
-/// is wrong: `let n = MutList::length(l)` mentions `l` but is an `Int` that
-/// copies out cleanly, and a closure over `n` is safe. `MutList` exposes no
-/// such accessor today, which is exactly why the loose rule would be a
-/// false-positive trap waiting for the next builtin rather than a bug you can
-/// see.
-///
-/// "Mentions the token anywhere" is wrong the same way, and that one IS
-/// writable today (Codex review on #1730): `let n = if c { let l =
-/// MutList::empty(r); 42 } else { 0 }` mentions `r` during evaluation but
-/// yields an `Int`. What matters is the initialiser's RESULT, not what its
-/// evaluation touched. Deciding that in general wants types; recognising the
-/// one syntactic form that certainly produces region memory does not, and
-/// enforcement is the "silent when unsure" side (ADR-0100 (1)). The cost is
-/// that region memory arriving through a helper (`let l = mk(r)`) is not
-/// tainted -- a miss, in the documented direction.
-fn esc_is_region_tainted_init(val: Expr, token: String, names: Array[String], flags: Array[Bool]) -> Bool {
-  match val {
-    EIdent(n, _) => esc_taint_of(names, flags, n),
-    ECall(callee, args, _) => match callee {
-      EIdent(name, _) => (name == "MutList::empty" || name == "MutBytes::empty") && esc_free_in_args(args, token),
-      _ => false
-    },
-    _ => false
-  }
-}
-
-fn esc_free_in_args(args: Array[Expr], name: String) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(args) {
-    if esc_free_in(Array::get(args, i), name) {
-      found = true
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  found
-}
-
-/// Latest-binding-wins lookup over the spine's binding record: every `let` in
-/// the spine appends (name, taint) in source order, so scanning from the END
-/// answers "is this name region memory HERE" and shadowing falls out of the
-/// order instead of needing its own rule. Without this, `let l =
-/// MutList::empty(r)` followed by `let l = 0` would leave `l` tainted and a
-/// closure over the Int would be rejected.
-fn esc_taint_of(names: Array[String], flags: Array[Bool], name: String) -> Bool {
-  let mut i = Array::length(names) - 1
-  let mut found = false
-  let mut done = false
-  while i >= 0 {
-    if !done && Array::get(names, i) == name {
-      found = Array::get(flags, i)
-      done = true
-    } else {
-      ()
-    }
-    i = i - 1
-  }
-  found
-}
-
-/// Walk the region body's `let` spine, recording every binding it makes with
-/// whether that binding is region memory, and return the spine's RESULT
-/// expression.
-fn esc_region_spine(body: Expr, token: String, names: Array[String], flags: Array[Bool]) -> Expr {
-  match body {
-    ELet(n, val, rest, _) => {
-      Array::push(flags, esc_is_region_tainted_init(val, token, names, flags))
-      Array::push(names, n)
-      esc_region_spine(rest, token, names, flags)
-    },
-    ELetMut(n, val, rest, _) => {
-      Array::push(flags, esc_is_region_tainted_init(val, token, names, flags))
-      Array::push(names, n)
-      esc_region_spine(rest, token, names, flags)
-    },
-    ESeq(_, rest) => esc_region_spine(rest, token, names, flags),
-    _ => body
-  }
-}
-
-/// True when the region body's RESULT is a closure that captures a value the
-/// body bound from the region token `token` -- i.e. a region value escaping
-/// inside a closure's environment, which the result-TYPE check cannot see.
-export fn region_token_escapes_in_closure(body: Expr, token: String) -> Bool {
-  let names: Array[String] = array_empty()
-  let flags: Array[Bool] = array_empty()
-  let result = esc_region_spine(body, token, names, flags)
-  match result {
-    EFn(_, _, params, _, _, fn_body) => {
-      // The token ITSELF escaping is the sharpest case and needs no taint
-      // analysis at all: a closure holding `r` can call `MutList::empty(r)`
-      // after the region ended, allocating from a segment whose watermark has
-      // already been handed back (Codex review on #1730). No outer binding is
-      // involved, so the spine walk below cannot see it.
-      let mut found = !esc_params_bind(params, token) && esc_free_in(fn_body, token)
-      let mut i = 0
-      while i < Array::length(names) {
-        let name = Array::get(names, i)
-        if esc_taint_of(names, flags, name) && !esc_params_bind(params, name) && esc_free_in(fn_body, name) {
-          found = true
-        } else {
-          ()
-        }
-        i = i + 1
-      }
-      found
-    },
-    _ => false
-  }
 }

--- a/lib/@vibe/compiler/checker/checker_spawnable.vibe
+++ b/lib/@vibe/compiler/checker/checker_spawnable.vibe
@@ -356,10 +356,103 @@ export fn closure_free_names(body: Expr, params: Array[(String, Option[TypeExpr]
   sp_collect_free_vars(body, bound)
 }
 
+fn sp_collect_bare_callees(expr: Expr, bound: Array[String], out: Array[String]) -> Unit {
+  match expr {
+    ECall(callee, args, _) => {
+      match callee {
+        EIdent(name, _) => if !sp_array_contains_str(bound, name) {
+          sp_add_unique(out, name)
+        } else {
+          ()
+        },
+        _ => sp_collect_bare_callees(callee, bound, out)
+      }
+      for arg in args {
+        sp_collect_bare_callees(arg, bound, out)
+      }
+    },
+    ELet(name, val, body, _) => {
+      sp_collect_bare_callees(val, bound, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      sp_collect_bare_callees(body, bound, out)
+      Array::truncate(bound, mark)
+    },
+    ELetMut(name, val, body, _) => {
+      sp_collect_bare_callees(val, bound, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      sp_collect_bare_callees(body, bound, out)
+      Array::truncate(bound, mark)
+    },
+    ELetRec(name, val, body) => {
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      sp_collect_bare_callees(val, bound, out)
+      sp_collect_bare_callees(body, bound, out)
+      Array::truncate(bound, mark)
+    },
+    EFn(_, _, params, _, _, body) => {
+      let mark = Array::length(bound)
+      for param in params {
+        let (name, _) = param
+        Array::push(bound, name)
+      }
+      sp_collect_bare_callees(body, bound, out)
+      Array::truncate(bound, mark)
+    },
+    ELoop(params, body) => {
+      let mark = Array::length(bound)
+      for param in params {
+        let (name, init) = param
+        sp_collect_bare_callees(init, bound, out)
+        Array::push(bound, name)
+      }
+      sp_collect_bare_callees(body, bound, out)
+      Array::truncate(bound, mark)
+    },
+    EForIn(name, index_name, iter, body) => {
+      sp_collect_bare_callees(iter, bound, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      match index_name {
+        Some(index) => Array::push(bound, index),
+        None => ()
+      }
+      sp_collect_bare_callees(body, bound, out)
+      Array::truncate(bound, mark)
+    },
+    EMatch(scrutinee, arms) => {
+      sp_collect_bare_callees(scrutinee, bound, out)
+      for arm in arms {
+        let (pat, body) = arm
+        let mark = Array::length(bound)
+        sp_collect_pat_bindings(pat, bound)
+        sp_collect_bare_callees(body, bound, out)
+        Array::truncate(bound, mark)
+      }
+    },
+    EHandle(scrutinee, arms) => {
+      sp_collect_bare_callees(scrutinee, bound, out)
+      for arm in arms {
+        let (pat, body) = arm
+        let mark = Array::length(bound)
+        sp_collect_pat_bindings(pat, bound)
+        sp_collect_bare_callees(body, bound, out)
+        Array::truncate(bound, mark)
+      }
+    },
+    _ => for child in expr_children(expr) {
+      sp_collect_bare_callees(child, bound, out)
+    }
+  }
+  ()
+}
+
 export fn closure_bare_callee_names(body: Expr) -> Array[String] {
-  sp_collect_free_vars(body, [
-    "__include_bare_callees__"
-  ])
+  let out = sp_empty_strings()
+  sp_collect_bare_callees(body, sp_empty_strings(), out)
+  out
 }
 
 /// A same-region endpoint. Two shapes both count: both sides are the SAME

--- a/lib/@vibe/compiler/checker/checker_spawnable.vibe
+++ b/lib/@vibe/compiler/checker/checker_spawnable.vibe
@@ -179,7 +179,11 @@ fn sp_collect_free_vars(expr: Expr, bound: Array[String]) -> Array[String] {
     },
     ECall(callee, args, _) => {
       match callee {
-        EIdent(_, _) => (),
+        EIdent(name, _) => if sp_array_contains_str(bound, "__include_bare_callees__") && !sp_array_contains_str(bound, name) {
+          sp_add_unique(result, name)
+        } else {
+          ()
+        },
         _ => sp_append_all(result, sp_collect_free_vars(callee, bound))
       }
       let mut i = 0
@@ -352,21 +356,10 @@ export fn closure_free_names(body: Expr, params: Array[(String, Option[TypeExpr]
   sp_collect_free_vars(body, bound)
 }
 
-fn sp_collect_bare_callees(expr: Expr, out: Array[String]) -> Unit {
-  match expr {
-    ECall(EIdent(name, _), _, _) => sp_add_unique(out, name),
-    _ => ()
-  }
-  for child in expr_children(expr) {
-    sp_collect_bare_callees(child, out)
-  }
-  ()
-}
-
 export fn closure_bare_callee_names(body: Expr) -> Array[String] {
-  let out = sp_empty_strings()
-  sp_collect_bare_callees(body, out)
-  out
+  sp_collect_free_vars(body, [
+    "__include_bare_callees__"
+  ])
 }
 
 /// A same-region endpoint. Two shapes both count: both sides are the SAME

--- a/lib/@vibe/compiler/checker/checker_spawnable.vibe
+++ b/lib/@vibe/compiler/checker/checker_spawnable.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Subst, Type, TypeDef, TypeEnv, env_lookup, env_mut_escape, subst_apply, type_to_string
+  Expr, Pat, Subst, Type, TypeDef, TypeEnv, TypeExpr, env_lookup, env_mut_escape, expr_children, subst_apply, type_to_string
 }
 
 import @vibe/core {
@@ -110,19 +110,10 @@ fn sp_collect_pat_bindings(pat: Pat, out: Array[String]) -> Unit {
 }
 
 /// Free variables of `expr`, given the names already `bound` by enclosing
-/// closure params / lets / match arms. A call's CALLEE, when it is a bare
-/// identifier, is NOT counted as a capture: it is either a compiler
-/// builtin (`Array::set`), a top-level function (`helper()`), or a
-/// constructor (`Some(x)`) -- none of these need an environment slot
-/// captured at runtime. This intentionally also excludes a directly-called
-/// LOCAL closure variable (`let cb = ...; TaskGroup::spawn(n, () -> {
-/// cb() })`) from capture analysis -- a documented, accepted gap (this
-/// checker has no indirect-call capture analysis yet), matching the
-/// project's existing precedent for this class of limitation (see
-/// TaskGroup::run's alias-bypass gap, checker.vibe). A callee that is NOT a
-/// bare identifier (`EDot` receiver, `ECall` result, ...) is walked
-/// normally -- `sender.send_wait(v)` still captures `sender` via the EDot
-/// arm below.
+/// closure params / lets / match arms. Call callees are ordinary value uses:
+/// a directly-called local closure occupies an environment slot just like a
+/// closure passed as an argument. Builtins and top-level functions disappear
+/// later because they have no region-bearing local binding.
 fn sp_collect_free_vars(expr: Expr, bound: Array[String]) -> Array[String] {
   let result = sp_empty_strings()
   match expr {
@@ -341,8 +332,41 @@ fn sp_collect_free_vars(expr: Expr, bound: Array[String]) -> Array[String] {
 /// Free value names captured by a closure body. Capture provenance uses this
 /// once per closure and then performs direct TypeEnv lookups, avoiding an
 /// O(all visible bindings x body size) scan during self-compilation.
-export fn closure_free_names(body: Expr) -> Array[String] {
-  sp_collect_free_vars(body, sp_empty_strings())
+export fn closure_free_names(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Array[String] {
+  let bound = sp_empty_strings()
+  for param in params {
+    let (raw_name, _) = param
+    let len = String::length(raw_name)
+    let name = if len > 0 {
+      let last = String::char_code_at(raw_name, len - 1)
+      if last == 126 || last == 63 {
+        String::substring(raw_name, 0, len - 1)
+      } else {
+        raw_name
+      }
+    } else {
+      raw_name
+    }
+    Array::push(bound, name)
+  }
+  sp_collect_free_vars(body, bound)
+}
+
+fn sp_collect_bare_callees(expr: Expr, out: Array[String]) -> Unit {
+  match expr {
+    ECall(EIdent(name, _), _, _) => sp_add_unique(out, name),
+    _ => ()
+  }
+  for child in expr_children(expr) {
+    sp_collect_bare_callees(child, out)
+  }
+  ()
+}
+
+export fn closure_bare_callee_names(body: Expr) -> Array[String] {
+  let out = sp_empty_strings()
+  sp_collect_bare_callees(body, out)
+  out
 }
 
 /// A same-region endpoint. Two shapes both count: both sides are the SAME

--- a/lib/@vibe/compiler/checker/checker_spawnable.vibe
+++ b/lib/@vibe/compiler/checker/checker_spawnable.vibe
@@ -50,32 +50,6 @@ fn sp_add_unique(arr: Array[String], v: String) -> Unit {
   }
 }
 
-fn sp_append_all(dst: Array[String], src: Array[String]) -> Unit {
-  let mut i = 0
-  while i < Array::length(src) {
-    Array::push(dst, Array::get(src, i))
-    i = i + 1
-  }
-}
-
-fn sp_clone_strings(items: Array[String]) -> Array[String] {
-  let out = sp_empty_strings()
-  sp_append_all(out, items)
-  out
-}
-
-fn sp_bound_with(bound: Array[String], extras: Array[String]) -> Array[String] {
-  let out = sp_clone_strings(bound)
-  sp_append_all(out, extras)
-  out
-}
-
-fn sp_bound_with_one(bound: Array[String], name: String) -> Array[String] {
-  let out = sp_clone_strings(bound)
-  Array::push(out, name)
-  out
-}
-
 fn sp_collect_pat_bindings(pat: Pat, out: Array[String]) -> Unit {
   match pat {
     PBind(name) => Array::push(out, name),
@@ -114,223 +88,119 @@ fn sp_collect_pat_bindings(pat: Pat, out: Array[String]) -> Unit {
 /// a directly-called local closure occupies an environment slot just like a
 /// closure passed as an argument. Builtins and top-level functions disappear
 /// later because they have no region-bearing local binding.
-fn sp_collect_free_vars(expr: Expr, bound: Array[String]) -> Array[String] {
-  let result = sp_empty_strings()
+
+fn sp_collect_free_vars_into(expr: Expr, bound: Array[String], out: Array[String]) -> Unit {
   match expr {
-    EIdent(name, _) => {
-      if sp_array_contains_str(bound, name) {
-        ()
-      } else {
-        sp_add_unique(result, name)
-      }
-      result
-    },
-    EInt(_) => result,
-    EFloat(_) => result,
-    EString(_) => result,
-    EBool(_) => result,
-    EUnit => result,
-    ELet(name, val, body, _) => {
-      sp_append_all(result, sp_collect_free_vars(val, bound))
-      sp_append_all(result, sp_collect_free_vars(body, sp_bound_with_one(bound, name)))
-      result
-    },
-    ELetRec(name, val, body) => {
-      let nb = sp_bound_with_one(bound, name)
-      sp_append_all(result, sp_collect_free_vars(val, nb))
-      sp_append_all(result, sp_collect_free_vars(body, nb))
-      result
-    },
-    ELetMut(name, val, body, _) => {
-      sp_append_all(result, sp_collect_free_vars(val, bound))
-      sp_append_all(result, sp_collect_free_vars(body, sp_bound_with_one(bound, name)))
-      result
-    },
-    EAssign(name, val, cont) => {
-      if sp_array_contains_str(bound, name) {
-        ()
-      } else {
-        sp_add_unique(result, name)
-      }
-      sp_append_all(result, sp_collect_free_vars(val, bound))
-      sp_append_all(result, sp_collect_free_vars(cont, bound))
-      result
-    },
-    EAssignOp(name, _, val, cont) => {
-      if sp_array_contains_str(bound, name) {
-        ()
-      } else {
-        sp_add_unique(result, name)
-      }
-      sp_append_all(result, sp_collect_free_vars(val, bound))
-      sp_append_all(result, sp_collect_free_vars(cont, bound))
-      result
-    },
-    EFn(_, _, params, _, _, body) => {
-      let pnames = sp_empty_strings()
-      let mut i = 0
-      while i < Array::length(params) {
-        let (pname, _) = Array::get(params, i)
-        Array::push(pnames, pname)
-        i = i + 1
-      }
-      sp_append_all(result, sp_collect_free_vars(body, sp_bound_with(bound, pnames)))
-      result
+    EIdent(name, _) => if !sp_array_contains_str(bound, name) {
+      sp_add_unique(out, name)
+    } else {
+      ()
     },
     ECall(callee, args, _) => {
       match callee {
-        EIdent(name, _) => if sp_array_contains_str(bound, "__include_bare_callees__") && !sp_array_contains_str(bound, name) {
-          sp_add_unique(result, name)
-        } else {
-          ()
-        },
-        _ => sp_append_all(result, sp_collect_free_vars(callee, bound))
+        EIdent(_, _) => (),
+        _ => sp_collect_free_vars_into(callee, bound, out)
       }
-      let mut i = 0
-      while i < Array::length(args) {
-        sp_append_all(result, sp_collect_free_vars(Array::get(args, i), bound))
-        i = i + 1
+      for arg in args {
+        sp_collect_free_vars_into(arg, bound, out)
       }
-      result
     },
-    EIf(cond, then_e, else_e) => {
-      sp_append_all(result, sp_collect_free_vars(cond, bound))
-      sp_append_all(result, sp_collect_free_vars(then_e, bound))
-      sp_append_all(result, sp_collect_free_vars(else_e, bound))
-      result
+    ELet(name, val, body, _) => {
+      sp_collect_free_vars_into(val, bound, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      sp_collect_free_vars_into(body, bound, out)
+      Array::truncate(bound, mark)
     },
-    ESeq(a, b) => {
-      sp_append_all(result, sp_collect_free_vars(a, bound))
-      sp_append_all(result, sp_collect_free_vars(b, bound))
-      result
+    ELetMut(name, val, body, _) => {
+      sp_collect_free_vars_into(val, bound, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      sp_collect_free_vars_into(body, bound, out)
+      Array::truncate(bound, mark)
     },
-    EBinOp(_, left, right) => {
-      sp_append_all(result, sp_collect_free_vars(left, bound))
-      sp_append_all(result, sp_collect_free_vars(right, bound))
-      result
+    ELetRec(name, val, body) => {
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      sp_collect_free_vars_into(val, bound, out)
+      sp_collect_free_vars_into(body, bound, out)
+      Array::truncate(bound, mark)
     },
-    EUnaryOp(_, operand) => {
-      sp_append_all(result, sp_collect_free_vars(operand, bound))
-      result
+    EAssign(name, val, cont) => {
+      if !sp_array_contains_str(bound, name) {
+        sp_add_unique(out, name)
+      }
+      sp_collect_free_vars_into(val, bound, out)
+      sp_collect_free_vars_into(cont, bound, out)
     },
-    EWhile(cond, body) => {
-      sp_append_all(result, sp_collect_free_vars(cond, bound))
-      sp_append_all(result, sp_collect_free_vars(body, bound))
-      result
+    EAssignOp(name, _, val, cont) => {
+      if !sp_array_contains_str(bound, name) {
+        sp_add_unique(out, name)
+      }
+      sp_collect_free_vars_into(val, bound, out)
+      sp_collect_free_vars_into(cont, bound, out)
+    },
+    EFn(_, _, params, _, _, body) => {
+      let mark = Array::length(bound)
+      for param in params {
+        let (name, _) = param
+        Array::push(bound, name)
+      }
+      sp_collect_free_vars_into(body, bound, out)
+      Array::truncate(bound, mark)
     },
     ELoop(params, body) => {
-      let mut b2 = sp_clone_strings(bound)
-      let mut i = 0
-      while i < Array::length(params) {
-        let (name, init) = Array::get(params, i)
-        sp_append_all(result, sp_collect_free_vars(init, b2))
-        b2 = sp_bound_with_one(b2, name)
-        i = i + 1
+      let mark = Array::length(bound)
+      for param in params {
+        let (name, init) = param
+        sp_collect_free_vars_into(init, bound, out)
+        Array::push(bound, name)
       }
-      sp_append_all(result, sp_collect_free_vars(body, b2))
-      result
+      sp_collect_free_vars_into(body, bound, out)
+      Array::truncate(bound, mark)
     },
     EForIn(name, index_name, iter, body) => {
-      sp_append_all(result, sp_collect_free_vars(iter, bound))
-      let b2 = sp_bound_with_one(bound, name)
-      let b3 = match index_name {
-        Some(ixn) => sp_bound_with_one(b2, ixn),
-        None => b2
-      }
-      sp_append_all(result, sp_collect_free_vars(body, b3))
-      result
-    },
-    EMatch(scrut, arms) => {
-      sp_append_all(result, sp_collect_free_vars(scrut, bound))
-      let mut ai = 0
-      while ai < Array::length(arms) {
-        let (pat, arm_body) = Array::get(arms, ai)
-        let pat_binds = sp_empty_strings()
-        sp_collect_pat_bindings(pat, pat_binds)
-        sp_append_all(result, sp_collect_free_vars(arm_body, sp_bound_with(bound, pat_binds)))
-        ai = ai + 1
-      }
-      result
-    },
-    EHandle(body, arms) => {
-      sp_append_all(result, sp_collect_free_vars(body, bound))
-      let mut ai = 0
-      while ai < Array::length(arms) {
-        let (pat, arm_body) = Array::get(arms, ai)
-        let pat_binds = sp_empty_strings()
-        sp_collect_pat_bindings(pat, pat_binds)
-        sp_append_all(result, sp_collect_free_vars(arm_body, sp_bound_with(bound, pat_binds)))
-        ai = ai + 1
-      }
-      result
-    },
-    ETuple(elems) => {
-      let mut i = 0
-      while i < Array::length(elems) {
-        sp_append_all(result, sp_collect_free_vars(Array::get(elems, i), bound))
-        i = i + 1
-      }
-      result
-    },
-    EArray(elems) => {
-      let mut i = 0
-      while i < Array::length(elems) {
-        sp_append_all(result, sp_collect_free_vars(Array::get(elems, i), bound))
-        i = i + 1
-      }
-      result
-    },
-    ERecord(_, fields, _) => {
-      let mut i = 0
-      while i < Array::length(fields) {
-        let (_, fval) = Array::get(fields, i)
-        sp_append_all(result, sp_collect_free_vars(fval, bound))
-        i = i + 1
-      }
-      result
-    },
-    EDot(obj, _, _, _) => {
-      sp_append_all(result, sp_collect_free_vars(obj, bound))
-      result
-    },
-    EReturn(e) => {
-      sp_append_all(result, sp_collect_free_vars(e, bound))
-      result
-    },
-    ELabeledArg(_, _, e) => {
-      sp_append_all(result, sp_collect_free_vars(e, bound))
-      result
-    },
-    EBreak(opt) => {
-      match opt {
-        Some(e) => sp_append_all(result, sp_collect_free_vars(e, bound)),
+      sp_collect_free_vars_into(iter, bound, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      match index_name {
+        Some(index) => Array::push(bound, index),
         None => ()
       }
-      result
+      sp_collect_free_vars_into(body, bound, out)
+      Array::truncate(bound, mark)
     },
-    EContinue(exprs) => {
-      let mut i = 0
-      while i < Array::length(exprs) {
-        sp_append_all(result, sp_collect_free_vars(Array::get(exprs, i), bound))
-        i = i + 1
+    EMatch(scrutinee, arms) => {
+      sp_collect_free_vars_into(scrutinee, bound, out)
+      for arm in arms {
+        let (pat, body) = arm
+        let mark = Array::length(bound)
+        sp_collect_pat_bindings(pat, bound)
+        sp_collect_free_vars_into(body, bound, out)
+        Array::truncate(bound, mark)
       }
-      result
     },
-    EMap(fields) => {
-      let mut i = 0
-      while i < Array::length(fields) {
-        let (_, fval) = Array::get(fields, i)
-        sp_append_all(result, sp_collect_free_vars(fval, bound))
-        i = i + 1
+    EHandle(scrutinee, arms) => {
+      sp_collect_free_vars_into(scrutinee, bound, out)
+      for arm in arms {
+        let (pat, body) = arm
+        let mark = Array::length(bound)
+        sp_collect_pat_bindings(pat, bound)
+        sp_collect_free_vars_into(body, bound, out)
+        Array::truncate(bound, mark)
       }
-      result
     },
-    ESpread(e) => {
-      sp_append_all(result, sp_collect_free_vars(e, bound))
-      result
-    },
-    EStringInterp(_) => result
+    _ => for child in expr_children(expr) {
+      sp_collect_free_vars_into(child, bound, out)
+    }
   }
+  ()
+}
+
+fn sp_collect_free_vars(expr: Expr, bound: Array[String]) -> Array[String] {
+  let out = sp_empty_strings()
+  sp_collect_free_vars_into(expr, bound, out)
+  out
 }
 
 /// Free value names captured by a closure body. Capture provenance uses this

--- a/lib/@vibe/compiler/checker/checker_spawnable.vibe
+++ b/lib/@vibe/compiler/checker/checker_spawnable.vibe
@@ -338,6 +338,13 @@ fn sp_collect_free_vars(expr: Expr, bound: Array[String]) -> Array[String] {
   }
 }
 
+/// Free value names captured by a closure body. Capture provenance uses this
+/// once per closure and then performs direct TypeEnv lookups, avoiding an
+/// O(all visible bindings x body size) scan during self-compilation.
+export fn closure_free_names(body: Expr) -> Array[String] {
+  sp_collect_free_vars(body, sp_empty_strings())
+}
+
 /// A same-region endpoint. Two shapes both count: both sides are the SAME
 /// `CtNamed` region skolem (compared by name -- the skolem `#region_<n>` is
 /// a plain string, see checker.vibe's `type_mentions_named`); OR both sides

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -59,6 +59,7 @@ import ./checker.vibe {
   check_assignable,
   check_expr,
   check_expr_capture,
+  constructor_dependency_row,
   fn_return_env_name,
   is_array_builder_ty,
   is_region_tagged_ty,
@@ -1651,7 +1652,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
               Array::push(resolved_args, arg_ty)
               ai = ai + 1
             }
-            CtFn(resolved_args, ctor_result_type, None)
+            CtFn(resolved_args, ctor_result_type, constructor_dependency_row(Array::length(resolved_args)))
           }
           let exported_ctor_ty = if param_len == 0 {
             ctor_ty
@@ -1771,7 +1772,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
               Array::push(resolved_args, resolve_type_expr(Array::get(vtypes, ai), defs))
               ai = ai + 1
             }
-            CtFn(resolved_args, ctor_result_type, None)
+            CtFn(resolved_args, ctor_result_type, constructor_dependency_row(Array::length(resolved_args)))
           }
           env1 = env_bind(env1, vname, ctor_ty)
           match ctor_ty {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -55,6 +55,7 @@ import @vibe/compiler/core {
 
 import ./checker.vibe {
   TypedOccurrenceRoleLaneCapture,
+  bind_function_dependency_contracts,
   check_assignable,
   check_expr,
   check_expr_capture,
@@ -1471,7 +1472,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             }
           }
         }
-        let env1 = env_bind(env, name, t)
+        let env1 = bind_function_dependency_contracts(env_bind(env, name, t), name, val)
         capture_statement_root_type(capture, statement_path, "SLet", vt)
         (bind_value_or_annotation_return(env1, name, val, ann, defs), ns, nc)
       },

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -166,7 +166,7 @@ fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow: Array[
 
 // --- checker_escape.vibe (#1262 / ADR-0100 (1))
 fn mut_binding_escapes(body: Expr, name: String) -> Bool
-fn region_token_escapes_in_closure(body: Expr, token: String) -> Bool
+fn expr_free_in(expr: Expr, name: String) -> Bool
 
 // --- checker_spawnable.vibe (#1081 step 3 Phase B)
 fn check_spawnable_captures(env: TypeEnv, s: Subst, defs: Array[TypeDef], f_expr: Expr, r_here: Type) -> Array[String]

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -143,6 +143,7 @@ fn is_array_builder_ty(t: Type) -> Bool
 fn is_region_tagged_ty(t: Type) -> Bool
 fn pat_binds_resume(p: Pat) -> Bool
 fn reject_resume_outside_handler(e: Expr, sh: Bool, errors: Array[String]) -> Unit
+fn constructor_dependency_row(arity: Int) -> Option[String]
 // Cross-file checker capability. Opaque and unconstructable at the package
 // boundary; only the successful observation entry points allocate one.
 opaque type TypedOccurrenceRoleLaneCapture

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -169,6 +169,7 @@ fn mut_binding_escapes(body: Expr, name: String) -> Bool
 fn expr_free_in(expr: Expr, name: String) -> Bool
 
 // --- checker_spawnable.vibe (#1081 step 3 Phase B)
+fn closure_free_names(body: Expr) -> Array[String]
 fn check_spawnable_captures(env: TypeEnv, s: Subst, defs: Array[TypeDef], f_expr: Expr, r_here: Type) -> Array[String]
 
 // --- checked_expression_structure_core.vibe

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -169,7 +169,9 @@ fn mut_binding_escapes(body: Expr, name: String) -> Bool
 fn expr_free_in(expr: Expr, name: String) -> Bool
 
 // --- checker_spawnable.vibe (#1081 step 3 Phase B)
-fn closure_free_names(body: Expr) -> Array[String]
+fn closure_free_names(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Array[String]
+fn closure_bare_callee_names(body: Expr) -> Array[String]
+fn bind_function_dependency_contracts(env: TypeEnv, name: String, value: Expr) -> TypeEnv
 fn check_spawnable_captures(env: TypeEnv, s: Subst, defs: Array[TypeDef], f_expr: Expr, r_here: Type) -> Array[String]
 
 // --- checked_expression_structure_core.vibe

--- a/lib/@vibe/compiler/core/effect_provenance_test.vibe
+++ b/lib/@vibe/compiler/core/effect_provenance_test.vibe
@@ -1,0 +1,18 @@
+import ./types.vibe {
+  Type, instantiate
+}
+
+test "instantiate freshens effect variables beside capture provenance" {
+  let scheme = CtForAll([], [], CtFn([], CtUnit, Some("e, #capture[3]")))
+  let (first, c1, _) = instantiate(scheme, 10)
+  let (second, c2, _) = instantiate(scheme, c1)
+  match first {
+    CtFn(_, _, Some(row)) => inspect(row, "$10, #capture[3]"),
+    _ => assert_true(false)
+  }
+  match second {
+    CtFn(_, _, Some(row)) => inspect(row, "$11, #capture[3]"),
+    _ => assert_true(false)
+  }
+  inspect(c2, "12")
+}

--- a/lib/@vibe/compiler/core/effect_provenance_test.vibe
+++ b/lib/@vibe/compiler/core/effect_provenance_test.vibe
@@ -3,7 +3,10 @@ import ./types.vibe {
 }
 
 test "instantiate freshens effect variables beside capture provenance" {
-  let scheme = CtForAll([], [], CtFn([], CtUnit, Some("e, #capture[3]")))
+  let scheme = CtForAll([
+  ], [
+  ], CtFn([
+  ], CtUnit, Some("e, #capture[3]")))
   let (first, c1, _) = instantiate(scheme, 10)
   let (second, c2, _) = instantiate(scheme, c1)
   match first {

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1506,17 +1506,22 @@ fn collect_effect_vars_walk(t: Type, out: Array[String]) -> Int {
   match t {
     CtFn(params, ret, eff) => {
       match eff {
-        Some(name) => if is_effect_var_name(name) {
-          let mut seen = false
-          let mut k = 0
-          while k < Array::length(out) {
-            if Array::get(out, k) == name {
-              seen = true
+        Some(row) => {
+          for raw in String::split(row, ",") {
+            let name = String::trim(raw)
+            if is_effect_var_name(name) {
+              let mut seen = false
+              let mut k = 0
+              while k < Array::length(out) {
+                if Array::get(out, k) == name {
+                  seen = true
+                }
+                k = k + 1
+              }
+              if !seen {
+                Array::push(out, name)
+              }
             }
-            k = k + 1
-          }
-          if !seen {
-            Array::push(out, name)
           }
         },
         None => ()
@@ -1565,6 +1570,14 @@ fn rename_eff_name(name: String, pairs: Array[(String, String)]) -> String {
   out
 }
 
+fn rename_effect_row(row: String, pairs: Array[(String, String)]) -> String {
+  let labels = array_empty()
+  for raw in String::split(row, ",") {
+    Array::push(labels, rename_eff_name(String::trim(raw), pairs))
+  }
+  String::join(labels, ", ")
+}
+
 fn rename_effect_vars(t: Type, pairs: Array[(String, String)]) -> Type {
   match t {
     CtFn(params, ret, eff) => {
@@ -1575,7 +1588,7 @@ fn rename_effect_vars(t: Type, pairs: Array[(String, String)]) -> Type {
         i = i + 1
       }
       let new_eff = match eff {
-        Some(name) => Some(rename_eff_name(name, pairs)),
+        Some(row) => Some(rename_effect_row(row, pairs)),
         None => None
       }
       CtFn(new_params, rename_effect_vars(ret, pairs), new_eff)

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1084,8 +1084,8 @@ fn resolve_effect_opt(s: Subst, eff: Option[String]) -> Option[String] {
                   }
                 }
               } else match resolved_ty {
-                  CtVar(new_id) => Array::push(resolved, String::concat("#capture[", String::concat(__to_string(new_id), "]"))),
-                  _ => ()
+                CtVar(new_id) => Array::push(resolved, String::concat("#capture[", String::concat(__to_string(new_id), "]"))),
+                _ => ()
               }
             },
             None => Array::push(resolved, label)

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1075,12 +1075,17 @@ fn resolve_effect_opt(s: Subst, eff: Option[String]) -> Option[String] {
           match subst_lookup(s, id) {
             Some(bound_ty) => {
               let resolved_ty = subst_apply(s, bound_ty)
-              match first_region_skolem(resolved_ty) {
-                Some(region_name) => Array::push(resolved, region_name),
-                None => match resolved_ty {
+              let region_names = array_empty()
+              collect_region_skolems_in_type(resolved_ty, region_names)
+              if Array::length(region_names) > 0 {
+                for region_name in region_names {
+                  if !string_array_contains(resolved, region_name) {
+                    Array::push(resolved, region_name)
+                  }
+                }
+              } else match resolved_ty {
                   CtVar(new_id) => Array::push(resolved, String::concat("#capture[", String::concat(__to_string(new_id), "]"))),
                   _ => ()
-                }
               }
             },
             None => Array::push(resolved, label)
@@ -1105,69 +1110,59 @@ fn resolve_effect_opt(s: Subst, eff: Option[String]) -> Option[String] {
 /// containers. `#capture[n]` is dependent on inference variable n and becomes
 /// the concrete `#region_n` label when that variable is unified with a
 /// region-tagged type.
-fn first_region_skolem(ty: Type) -> Option[String] {
+fn string_array_contains(items: Array[String], wanted: String) -> Bool {
+  let mut found = false
+  for item in items {
+    if item == wanted {
+      found = true
+    }
+  }
+  found
+}
+
+fn collect_region_skolems_in_type(ty: Type, out: Array[String]) -> Unit {
   match ty {
     CtNamed(name, args) => if String::starts_with(name, "#region_") {
-      Some(name)
-    } else {
-      let mut out = None
-      let mut i = 0
-      while i < Array::length(args) && out is None {
-        out = first_region_skolem(Array::get(args, i))
-        i = i + 1
+      if !string_array_contains(out, name) {
+        Array::push(out, name)
       }
-      out
+    } else {
+      for arg in args {
+        collect_region_skolems_in_type(arg, out)
+      }
     },
     CtFn(params, ret, eff) => {
-      let mut out = match eff {
+      match eff {
         Some(row) => {
-          let labels = String::split(row, ",")
-          let mut found = None
-          let mut i = 0
-          while i < Array::length(labels) && found is None {
-            let label = String::trim(Array::get(labels, i))
-            if String::starts_with(label, "#region_") {
-              found = Some(label)
+          for raw in String::split(row, ",") {
+            let label = String::trim(raw)
+            if String::starts_with(label, "#region_") && !string_array_contains(out, label) {
+              Array::push(out, label)
             }
-            i = i + 1
           }
-          found
         },
-        None => None
+        None => ()
       }
-      let mut i = 0
-      while i < Array::length(params) && out is None {
-        out = first_region_skolem(Array::get(params, i))
-        i = i + 1
+      for param in params {
+        collect_region_skolems_in_type(param, out)
       }
-      match out {
-        Some(_) => out,
-        None => first_region_skolem(ret)
-      }
+      collect_region_skolems_in_type(ret, out)
     },
-    CtArray(elem) => first_region_skolem(elem),
-    CtOption(elem) => first_region_skolem(elem),
+    CtArray(elem) => collect_region_skolems_in_type(elem, out),
+    CtOption(elem) => collect_region_skolems_in_type(elem, out),
     CtTuple(items) => {
-      let mut out = None
-      let mut i = 0
-      while i < Array::length(items) && out is None {
-        out = first_region_skolem(Array::get(items, i))
-        i = i + 1
+      for item in items {
+        collect_region_skolems_in_type(item, out)
       }
-      out
     },
     CtRecord(fields) => {
-      let mut out = None
-      let mut i = 0
-      while i < Array::length(fields) && out is None {
-        let (_, field_ty) = Array::get(fields, i)
-        out = first_region_skolem(field_ty)
-        i = i + 1
+      for field in fields {
+        let (_, field_ty) = field
+        collect_region_skolems_in_type(field_ty, out)
       }
-      out
     },
-    CtForAll(_, _, body) => first_region_skolem(body),
-    _ => None
+    CtForAll(_, _, body) => collect_region_skolems_in_type(body, out),
+    _ => ()
   }
 }
 
@@ -1370,7 +1365,7 @@ export fn type_to_string(ty: Type) -> String {
       }
       let ret_text = type_to_string(ret)
       let base = String::concat("(", String::concat(joined, String::concat(") -> ", ret_text)))
-      match effect_name {
+      match semantic_effect_opt(effect_name) {
         // #1429: this text lands in type-mismatch messages, so it has to be
         // the spelling the reader would type. Rows are stored comma-joined;
         // the syntax is `+`-separated.

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1959,7 +1959,7 @@ fn effect_label_base_set(labels: Array[String]) -> Array[String] {
   let mut i = 0
   while i < Array::length(labels) {
     let raw = Array::get(labels, i)
-    let provenance = String::starts_with(raw, "#region_") || String::starts_with(raw, "#capture[")
+    let provenance = String::starts_with(raw, "#region_") || String::starts_with(raw, "#capture[") || String::starts_with(raw, "#param[")
     let base = effect_label_base_name(raw)
     let mut seen = false
     let mut j = 0
@@ -2009,7 +2009,7 @@ fn effect_opt_is_var(eff: Option[String]) -> Bool {
   let mut count = 0
   let mut variable = false
   for label in labels {
-    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") {
+    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") && !String::starts_with(label, "#param[") {
       count = count + 1
       variable = is_effect_var_name(label)
     }
@@ -2021,7 +2021,7 @@ fn semantic_effect_opt(eff: Option[String]) -> Option[String] {
   let labels = effect_label_list(eff)
   let semantic = array_empty()
   for label in labels {
-    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") {
+    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") && !String::starts_with(label, "#param[") {
       Array::push(semantic, label)
     }
   }

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1045,7 +1045,9 @@ fn subst_eff_lookup(s: Subst, name: String) -> Option[String] {
 fn resolve_effect_opt(s: Subst, eff: Option[String]) -> Option[String] {
   match eff {
     None => None,
-    Some(row) => {
+    Some(row) => if String::index_of(row, ",") < 0 && String::trim(row) == row && !is_effect_var_name(row) && !String::starts_with(row, "#capture[") {
+      Some(row)
+    } else {
       let labels = String::split(row, ",")
       let resolved = array_empty()
       let mut i = 0
@@ -2018,17 +2020,24 @@ fn effect_opt_is_var(eff: Option[String]) -> Bool {
 }
 
 fn semantic_effect_opt(eff: Option[String]) -> Option[String] {
-  let labels = effect_label_list(eff)
-  let semantic = array_empty()
-  for label in labels {
-    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") && !String::starts_with(label, "#param[") && !String::starts_with(label, "#aliasparam[") && !String::starts_with(label, "#fieldparam[") {
-      Array::push(semantic, label)
+  match eff {
+    None => None,
+    Some(row) => if String::index_of(row, ",") < 0 && String::trim(row) == row && !String::starts_with(row, "#") {
+      Some(row)
+    } else {
+      let labels = effect_label_list(eff)
+      let semantic = array_empty()
+      for label in labels {
+        if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") && !String::starts_with(label, "#param[") && !String::starts_with(label, "#aliasparam[") && !String::starts_with(label, "#fieldparam[") {
+          Array::push(semantic, label)
+        }
+      }
+      if Array::length(semantic) == 0 {
+        None
+      } else {
+        Some(String::join(semantic, ", "))
+      }
     }
-  }
-  if Array::length(semantic) == 0 {
-    None
-  } else {
-    Some(String::join(semantic, ", "))
   }
 }
 

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1959,7 +1959,7 @@ fn effect_label_base_set(labels: Array[String]) -> Array[String] {
   let mut i = 0
   while i < Array::length(labels) {
     let raw = Array::get(labels, i)
-    let provenance = String::starts_with(raw, "#region_") || String::starts_with(raw, "#capture[") || String::starts_with(raw, "#param[")
+    let provenance = String::starts_with(raw, "#region_") || String::starts_with(raw, "#capture[") || String::starts_with(raw, "#param[") || String::starts_with(raw, "#aliasparam[") || String::starts_with(raw, "#fieldparam[")
     let base = effect_label_base_name(raw)
     let mut seen = false
     let mut j = 0
@@ -2009,7 +2009,7 @@ fn effect_opt_is_var(eff: Option[String]) -> Bool {
   let mut count = 0
   let mut variable = false
   for label in labels {
-    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") && !String::starts_with(label, "#param[") {
+    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") && !String::starts_with(label, "#param[") && !String::starts_with(label, "#aliasparam[") && !String::starts_with(label, "#fieldparam[") {
       count = count + 1
       variable = is_effect_var_name(label)
     }
@@ -2021,7 +2021,7 @@ fn semantic_effect_opt(eff: Option[String]) -> Option[String] {
   let labels = effect_label_list(eff)
   let semantic = array_empty()
   for label in labels {
-    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") && !String::starts_with(label, "#param[") {
+    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") && !String::starts_with(label, "#param[") && !String::starts_with(label, "#aliasparam[") && !String::starts_with(label, "#fieldparam[") {
       Array::push(semantic, label)
     }
   }

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1045,18 +1045,129 @@ fn subst_eff_lookup(s: Subst, name: String) -> Option[String] {
 fn resolve_effect_opt(s: Subst, eff: Option[String]) -> Option[String] {
   match eff {
     None => None,
-    Some(name) => if is_effect_var_name(name) {
-      match subst_eff_lookup(s, name) {
-        Some(val) => if String::length(val) == 0 {
-          None
-        } else {
-          Some(val)
-        },
-        None => eff
+    Some(row) => {
+      let labels = String::split(row, ",")
+      let resolved = array_empty()
+      let mut i = 0
+      while i < Array::length(labels) {
+        let label = String::trim(Array::get(labels, i))
+        if is_effect_var_name(label) {
+          match subst_eff_lookup(s, label) {
+            Some(bound) => if String::length(bound) > 0 {
+              for part in String::split(bound, ",") {
+                let trimmed = String::trim(part)
+                if String::length(trimmed) > 0 {
+                  Array::push(resolved, trimmed)
+                }
+              }
+              ()
+            },
+            None => Array::push(resolved, label)
+          }
+        } else if String::starts_with(label, "#capture[") {
+          let close = String::index_of(label, "]")
+          let mut id = 0
+          let mut p = 9
+          while p < close {
+            id = id * 10 + (String::char_code_at(label, p) - 48)
+            p = p + 1
+          }
+          match subst_lookup(s, id) {
+            Some(bound_ty) => {
+              let resolved_ty = subst_apply(s, bound_ty)
+              match first_region_skolem(resolved_ty) {
+                Some(region_name) => Array::push(resolved, region_name),
+                None => match resolved_ty {
+                  CtVar(new_id) => Array::push(resolved, String::concat("#capture[", String::concat(__to_string(new_id), "]"))),
+                  _ => ()
+                }
+              }
+            },
+            None => Array::push(resolved, label)
+          }
+        } else if String::length(label) > 0 {
+          Array::push(resolved, label)
+        }
+        i = i + 1
       }
-    } else {
-      eff
+      if Array::length(resolved) == 0 {
+        None
+      } else {
+        Some(String::join(resolved, ", "))
+      }
     }
+  }
+}
+
+/// Region provenance is carried in a function's checked row as an internal
+/// unforgeable label. It is not a runtime effect: the row is simply the one
+/// structured slot already preserved by substitution, generalization and
+/// containers. `#capture[n]` is dependent on inference variable n and becomes
+/// the concrete `#region_n` label when that variable is unified with a
+/// region-tagged type.
+fn first_region_skolem(ty: Type) -> Option[String] {
+  match ty {
+    CtNamed(name, args) => if String::starts_with(name, "#region_") {
+      Some(name)
+    } else {
+      let mut out = None
+      let mut i = 0
+      while i < Array::length(args) && out is None {
+        out = first_region_skolem(Array::get(args, i))
+        i = i + 1
+      }
+      out
+    },
+    CtFn(params, ret, eff) => {
+      let mut out = match eff {
+        Some(row) => {
+          let labels = String::split(row, ",")
+          let mut found = None
+          let mut i = 0
+          while i < Array::length(labels) && found is None {
+            let label = String::trim(Array::get(labels, i))
+            if String::starts_with(label, "#region_") {
+              found = Some(label)
+            }
+            i = i + 1
+          }
+          found
+        },
+        None => None
+      }
+      let mut i = 0
+      while i < Array::length(params) && out is None {
+        out = first_region_skolem(Array::get(params, i))
+        i = i + 1
+      }
+      match out {
+        Some(_) => out,
+        None => first_region_skolem(ret)
+      }
+    },
+    CtArray(elem) => first_region_skolem(elem),
+    CtOption(elem) => first_region_skolem(elem),
+    CtTuple(items) => {
+      let mut out = None
+      let mut i = 0
+      while i < Array::length(items) && out is None {
+        out = first_region_skolem(Array::get(items, i))
+        i = i + 1
+      }
+      out
+    },
+    CtRecord(fields) => {
+      let mut out = None
+      let mut i = 0
+      while i < Array::length(fields) && out is None {
+        let (_, field_ty) = Array::get(fields, i)
+        out = first_region_skolem(field_ty)
+        i = i + 1
+      }
+      out
+    },
+    CtForAll(_, _, body) => first_region_skolem(body),
+    _ => None
   }
 }
 
@@ -1839,7 +1950,9 @@ fn effect_label_base_set(labels: Array[String]) -> Array[String] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(labels) {
-    let base = effect_label_base_name(Array::get(labels, i))
+    let raw = Array::get(labels, i)
+    let provenance = String::starts_with(raw, "#region_") || String::starts_with(raw, "#capture[")
+    let base = effect_label_base_name(raw)
     let mut seen = false
     let mut j = 0
     while j < Array::length(out) {
@@ -1848,7 +1961,7 @@ fn effect_label_base_set(labels: Array[String]) -> Array[String] {
       }
       j = j + 1
     }
-    if !seen {
+    if !seen && !provenance {
       Array::push(out, base)
     }
     i = i + 1
@@ -1884,9 +1997,30 @@ fn effect_label_sets_equal(left: Option[String], right: Option[String]) -> Bool 
 }
 
 fn effect_opt_is_var(eff: Option[String]) -> Bool {
-  match eff {
-    Some(name) => is_effect_var_name(name),
-    None => false
+  let labels = effect_label_list(eff)
+  let mut count = 0
+  let mut variable = false
+  for label in labels {
+    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") {
+      count = count + 1
+      variable = is_effect_var_name(label)
+    }
+  }
+  count == 1 && variable
+}
+
+fn semantic_effect_opt(eff: Option[String]) -> Option[String] {
+  let labels = effect_label_list(eff)
+  let semantic = array_empty()
+  for label in labels {
+    if !String::starts_with(label, "#region_") && !String::starts_with(label, "#capture[") {
+      Array::push(semantic, label)
+    }
+  }
+  if Array::length(semantic) == 0 {
+    None
+  } else {
+    Some(String::join(semantic, ", "))
   }
 }
 
@@ -1915,8 +2049,8 @@ fn effect_names_compatible(left: Option[String], right: Option[String]) -> Bool 
 /// (#626 criterion 4 — no longer an unconditional wildcard). Returns the extended
 /// substitution, or None on a genuine effect-set conflict.
 fn unify_effects(ea: Option[String], eb: Option[String], s: Subst) -> Option[Subst] {
-  let ra = resolve_effect_opt(s, ea)
-  let rb = resolve_effect_opt(s, eb)
+  let ra = semantic_effect_opt(resolve_effect_opt(s, ea))
+  let rb = semantic_effect_opt(resolve_effect_opt(s, eb))
   let a_is_var = match ra {
     Some(n) => is_effect_var_name(n),
     None => false

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -253,6 +253,7 @@ fn incremental_typecheck_telemetry_json() -> String
 fn incremental_invalidation_trace_json(entry_path: String, run_nonce: String) -> String with Exception + Fs
 // Test-only seam for malformed transparent STrait provenance.
 fn incremental_trait_generic_provenance_markers_for_test(header_params: Array[String], method_params: Array[String], generic_bounds: Array[(String, Array[String])], method_count: Int, method_gens: Array[(String, Array[String], Array[(String, Array[String])])]) -> String
+fn incremental_interface_effect_set_for_test(effect_name: Option[String], ids: Array[Int], names: Array[String]) -> String
 // Test-only semantic seam for the exact dependency projection used by
 // ModuleJob.dep_envs and TDRE5. Throws when a resolved dependency row is absent.
 fn projected_import_env_for_test(source: String, path: String, deps: Array[String], full_cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1702,7 +1702,7 @@ fn interface_sorted_unique(items: Array[String]) -> Array[String] {
   unique
 }
 
-fn interface_effect_set(effect_name: Option[String]) -> String {
+fn interface_effect_set_with_vars(effect_name: Option[String], ids: Array[Int], names: Array[String]) -> String {
   match effect_name {
     None => "[]",
     Some(raw) => {
@@ -1711,7 +1711,27 @@ fn interface_effect_set(effect_name: Option[String]) -> String {
       let mut i = 0
       while i < Array::length(pieces) {
         let label = String::trim(Array::get(pieces, i))
-        if String::length(label) > 0 {
+        if String::starts_with(label, "#capture[") {
+          let close = String::index_of(label, "]")
+          let mut capture_id = 0
+          let mut p = 9
+          while p < close {
+            capture_id = capture_id * 10 + (String::char_code_at(label, p) - 48)
+            p = p + 1
+          }
+          let mut found = false
+          let mut vi = 0
+          while vi < Array::length(ids) && !found {
+            if Array::get(ids, vi) == capture_id {
+              Array::push(labels, String::concat("#capture[", String::concat(Array::get(names, vi), "]")))
+              found = true
+            } else {
+              vi = vi + 1
+            }
+          }
+        } else if String::starts_with(label, "#region_") {
+          ()
+        } else if String::length(label) > 0 {
           Array::push(labels, label)
         } else {
           ()
@@ -1721,6 +1741,16 @@ fn interface_effect_set(effect_name: Option[String]) -> String {
       String::concat("[", String::concat(String::join(interface_sorted_unique(labels), ","), "]"))
     }
   }
+}
+
+fn interface_effect_set(effect_name: Option[String]) -> String {
+  interface_effect_set_with_vars(effect_name, array_empty(), array_empty())
+}
+
+/// Test-only seam for the public interface row projection. Checker provenance
+/// must remain in checked types without perturbing public API fingerprints.
+export fn incremental_interface_effect_set_for_test(effect_name: Option[String], ids: Array[Int], names: Array[String]) -> String {
+  interface_effect_set_with_vars(effect_name, ids, names)
 }
 
 fn interface_lookup_var(ids: Array[Int], names: Array[String], id: Int) -> String {
@@ -1777,7 +1807,7 @@ fn interface_canonical_type(ty: Type, ids: Array[Int], names: Array[String]) -> 
       kacc
     },
     CtNamed(name, args) => String::concat("named:", String::concat(interface_segment(name), types(args, ids, names))),
-    CtFn(params, ret, effects) => String::concat("fn:", String::concat(types(params, ids, names), String::concat(interface_segment(interface_canonical_type(ret, ids, names)), interface_effect_set(effects)))),
+    CtFn(params, ret, effects) => String::concat("fn:", String::concat(types(params, ids, names), String::concat(interface_segment(interface_canonical_type(ret, ids, names)), interface_effect_set_with_vars(effects, ids, names)))),
     CtForAll(vars, bounds, body) => {
       let all_ids = Array::slice(ids, 0, Array::length(ids))
       let all_names = Array::slice(names, 0, Array::length(names))

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1729,7 +1729,7 @@ fn interface_effect_set_with_vars(effect_name: Option[String], ids: Array[Int], 
               vi = vi + 1
             }
           }
-        } else if String::starts_with(label, "#region_") {
+        } else if String::starts_with(label, "#region_") || String::starts_with(label, "#param[") || String::starts_with(label, "#aliasparam[") || String::starts_with(label, "#fieldparam[") {
           ()
         } else if String::length(label) > 0 {
           Array::push(labels, label)

--- a/lib/@vibe/compiler/tests/interface_trait_provenance_test.vibe
+++ b/lib/@vibe/compiler/tests/interface_trait_provenance_test.vibe
@@ -11,18 +11,18 @@ import @vibe/core {
 //# Trait interface provenance
 
 test "interface effect fingerprints ignore checker provenance ids" {
-  let first = incremental_interface_effect_set_for_test(Some("Log, #capture[37], #param[2], #fieldparam[0], #region_4"), [
+  let first = incremental_interface_effect_set_for_test(Some("Log, #capture[37], #param[2], #aliasparam[8], #fieldparam[0], #region_4"), [
     37
   ], [
     "q0"
   ])
-  let shifted = incremental_interface_effect_set_for_test(Some("#capture[91], #param[2], #fieldparam[0], #region_12, Log"), [
+  let shifted = incremental_interface_effect_set_for_test(Some("#capture[91], #param[97], #aliasparam[103], #fieldparam[41], #region_12, Log"), [
     91
   ], [
     "q0"
   ])
-  inspect(first, "[#capture[q0],#fieldparam[0],#param[2],Log]")
-  inspect(shifted, "[#capture[q0],#fieldparam[0],#param[2],Log]")
+  inspect(first, "[#capture[q0],Log]")
+  inspect(shifted, "[#capture[q0],Log]")
   assert(first == shifted)
 }
 

--- a/lib/@vibe/compiler/tests/interface_trait_provenance_test.vibe
+++ b/lib/@vibe/compiler/tests/interface_trait_provenance_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/runtime {
-  incremental_trait_generic_provenance_markers_for_test
+  incremental_interface_effect_set_for_test, incremental_trait_generic_provenance_markers_for_test
 }
 
 import @vibe/core {
@@ -9,6 +9,22 @@ import @vibe/core {
 }
 
 //# Trait interface provenance
+
+test "interface effect fingerprints ignore checker provenance ids" {
+  let first = incremental_interface_effect_set_for_test(Some("Log, #capture[37], #param[2], #fieldparam[0], #region_4"), [
+    37
+  ], [
+    "q0"
+  ])
+  let shifted = incremental_interface_effect_set_for_test(Some("#capture[91], #param[2], #fieldparam[0], #region_12, Log"), [
+    91
+  ], [
+    "q0"
+  ])
+  inspect(first, "[#capture[q0],#fieldparam[0],#param[2],Log]")
+  inspect(shifted, "[#capture[q0],#fieldparam[0],#param[2],Log]")
+  assert(first == shifted)
+}
 
 test "trait interface marks malformed method generic provenance" {
   let valid = incremental_trait_generic_provenance_markers_for_test(array_empty(), [

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -143,6 +143,13 @@ fn projected_checked_env(source: String, path: String, deps: Array[String], full
   check_program_with_projected_import_env_result(parse_program_with_path(path, source), import_env).final_env
 }
 
+test "imported helpers retain region dependency contracts" {
+  let dep_source = "export struct Slot { callback: () -> Array[Int] }\nexport fn unwrap(slot: Slot) -> () -> Array[Int] {\n  let callback = slot.callback\n  callback\n}"
+  let main_source = "import ./dep.vibe { Slot, unwrap }\nlet escaped = region r {\n  let values = MutList::empty(r)\n  unwrap(Slot::{ callback: () -> Array[Int] { MutList::to_array(values) } })\n}\nlet _ = escaped()"
+  let message = typecheck_db_pair_error(dep_source, main_source)
+  assert(String::contains(message, "region escapes its scope"))
+}
+
 fn assert_module_origin(env: TypeEnv, bound_name: String, expected_path: String, expected_source_name: String) -> Unit {
   match env_lookup_binding(env, bound_name) {
     Some(binding) => match binding.origin {

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -337,6 +337,12 @@ test "type_to_string composite" {
   assert(type_to_string(CtFn([
     CtInt
   ], CtString, Some("Exception"))) == "(Int) -> String with Exception")
+  assert(type_to_string(CtFn([
+    CtInt
+  ], CtString, Some("Exception, #region_7, #capture[3]"))) == "(Int) -> String with Exception")
+  assert(type_to_string(CtFn([
+    CtInt
+  ], CtString, Some("#region_7"))) == "(Int) -> String")
   assert(type_to_string(CtForAll([
     0
   ], array_empty(), CtVar(0))) == "forall ?t0. ?t0")

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9611,11 +9611,14 @@ for r90_fixture in \
   fixtures/err_region_escape_local_callee.vibe \
   fixtures/err_region_escape_callback_defer.vibe \
   fixtures/err_region_escape_named_projection.vibe \
+  fixtures/err_region_escape_named_projection_alias.vibe \
   fixtures/err_region_escape_call_alias_write.vibe \
   fixtures/err_region_escape_inline_projection.vibe \
   fixtures/err_region_escape_inline_call_alias_write.vibe \
   fixtures/err_region_escape_aggregate_struct.vibe \
   fixtures/err_region_escape_callback_return.vibe \
+  fixtures/err_region_escape_early_return.vibe \
+  fixtures/err_region_escape_constructor_helper.vibe \
   fixtures/err_region_escape_bound_struct.vibe \
   fixtures/err_region_escape_mutmap_write.vibe \
   fixtures/err_region_escape_deque_write.vibe \

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9592,7 +9592,7 @@ fi
 # #1938: capture provenance is part of the checked function type, not a
 # terminal-lambda syntax check. Pin every laundering shape that the old
 # stopgap missed (plus a deep alias witness).
-for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record generic_defer named_struct mutlist_write array_alias_write; do
+for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record generic_defer named_struct mutlist_write array_alias_write local_callee callback_defer named_projection call_alias_write; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9592,7 +9592,7 @@ fi
 # #1938: capture provenance is part of the checked function type, not a
 # terminal-lambda syntax check. Pin every laundering shape that the old
 # stopgap missed (plus a deep alias witness).
-for r90_escape in outer_assignment container helper nested_closure alias_chain; do
+for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9592,7 +9592,7 @@ fi
 # #1938: capture provenance is part of the checked function type, not a
 # terminal-lambda syntax check. Pin every laundering shape that the old
 # stopgap missed (plus a deep alias witness).
-for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write; do
+for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9618,6 +9618,10 @@ for r90_fixture in \
   fixtures/err_region_escape_aggregate_struct.vibe \
   fixtures/err_region_escape_callback_return.vibe \
   fixtures/err_region_escape_early_return.vibe \
+  fixtures/err_region_escape_generalized_local_callee.vibe \
+  fixtures/err_region_escape_direct_call_alias_write.vibe \
+  fixtures/err_region_escape_alias_result.vibe \
+  fixtures/err_region_escape_multi_payload_constructor.vibe \
   fixtures/err_region_escape_constructor_helper.vibe \
   fixtures/err_region_escape_bound_struct.vibe \
   fixtures/err_region_escape_mutmap_write.vibe \

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9592,7 +9592,7 @@ fi
 # #1938: capture provenance is part of the checked function type, not a
 # terminal-lambda syntax check. Pin every laundering shape that the old
 # stopgap missed (plus a deep alias witness).
-for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record generic_defer named_struct mutlist_write array_alias_write local_callee callback_defer named_projection call_alias_write; do
+for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record generic_defer named_struct mutlist_write array_alias_write local_callee callback_defer named_projection call_alias_write inline_projection inline_call_alias_write; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9592,7 +9592,7 @@ fi
 # #1938: capture provenance is part of the checked function type, not a
 # terminal-lambda syntax check. Pin every laundering shape that the old
 # stopgap missed (plus a deep alias witness).
-for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record; do
+for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record generic_defer named_struct mutlist_write array_alias_write; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9592,7 +9592,7 @@ fi
 # #1938: capture provenance is part of the checked function type, not a
 # terminal-lambda syntax check. Pin every laundering shape that the old
 # stopgap missed (plus a deep alias witness).
-for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record generic_defer named_struct mutlist_write array_alias_write local_callee callback_defer named_projection call_alias_write inline_projection inline_call_alias_write; do
+for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record generic_defer named_struct mutlist_write array_alias_write local_callee callback_defer named_projection call_alias_write inline_projection inline_call_alias_write aggregate_struct callback_return bound_struct mutmap_write deque_write deque_dot_write option_aggregate enum_aggregate result_aggregate; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9592,20 +9592,72 @@ fi
 # #1938: capture provenance is part of the checked function type, not a
 # terminal-lambda syntax check. Pin every laundering shape that the old
 # stopgap missed (plus a deep alias witness).
-for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write record generic_defer named_struct mutlist_write array_alias_write local_callee callback_defer named_projection call_alias_write inline_projection inline_call_alias_write aggregate_struct callback_return bound_struct mutmap_write deque_write deque_dot_write option_aggregate enum_aggregate result_aggregate; do
+for r90_fixture in \
+  fixtures/err_region_escape_outer_assignment.vibe \
+  fixtures/err_region_escape_container.vibe \
+  fixtures/err_region_escape_helper.vibe \
+  fixtures/err_region_escape_global_helper.vibe \
+  fixtures/err_region_escape_multiple_regions.vibe \
+  fixtures/err_region_escape_nested_closure.vibe \
+  fixtures/err_region_escape_alias_chain.vibe \
+  fixtures/err_region_escape_monomorphic_callback.vibe \
+  fixtures/err_region_escape_array_write.vibe \
+  fixtures/err_region_escape_field_write.vibe \
+  fixtures/err_region_escape_record.vibe \
+  fixtures/err_region_escape_generic_defer.vibe \
+  fixtures/err_region_escape_named_struct.vibe \
+  fixtures/err_region_escape_mutlist_write.vibe \
+  fixtures/err_region_escape_array_alias_write.vibe \
+  fixtures/err_region_escape_local_callee.vibe \
+  fixtures/err_region_escape_callback_defer.vibe \
+  fixtures/err_region_escape_named_projection.vibe \
+  fixtures/err_region_escape_call_alias_write.vibe \
+  fixtures/err_region_escape_inline_projection.vibe \
+  fixtures/err_region_escape_inline_call_alias_write.vibe \
+  fixtures/err_region_escape_aggregate_struct.vibe \
+  fixtures/err_region_escape_callback_return.vibe \
+  fixtures/err_region_escape_bound_struct.vibe \
+  fixtures/err_region_escape_mutmap_write.vibe \
+  fixtures/err_region_escape_deque_write.vibe \
+  fixtures/err_region_escape_option_aggregate.vibe \
+  fixtures/err_region_escape_result_aggregate.vibe \
+  fixtures/err_region_escape_enum_aggregate.vibe \
+  fixtures/err_region_escape_deque_dot_write.vibe \
+  fixtures/err_region_escape_param_forwarding.vibe \
+  fixtures/err_region_escape_nested_tuple_param.vibe \
+  fixtures/err_region_escape_nested_record_param.vibe \
+  fixtures/err_region_escape_nested_nominal_param.vibe \
+  fixtures/err_region_escape_named_struct_bound.vibe \
+  fixtures/err_region_escape_named_struct_field_alias.vibe \
+  fixtures/err_region_escape_mutmap_key_write.vibe \
+  fixtures/err_region_escape_mutmap_value_write.vibe \
+  fixtures/err_region_escape_mutset_write.vibe \
+  fixtures/err_region_escape_sortedmap_key_write.vibe \
+  fixtures/err_region_escape_sortedmap_value_write.vibe \
+  fixtures/err_region_escape_sortedset_write.vibe \
+  fixtures/err_region_escape_priority_queue_write.vibe \
+  fixtures/err_region_escape_deque_back_write.vibe \
+  fixtures/err_region_escape_deque_front_write.vibe \
+  fixtures/err_region_escape_hashmap_alias_write.vibe \
+  fixtures/err_region_escape_hashset_alias_write.vibe \
+  fixtures/err_region_escape_sortedmap_alias_write.vibe \
+  fixtures/err_region_escape_sortedset_alias_write.vibe; do
+  r90_escape="${r90_fixture#fixtures/err_region_escape_}"
+  r90_escape="${r90_escape%.vibe}"
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true
+    "$r90_fixture" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ -s "$r90dir/${r90_escape}.wasm" ]; then
-    echo "[compiler-gate] FAIL: err_region_escape_${r90_escape}.vibe compiled successfully -- region capture provenance was lost (#1938)" >&2
+    echo "[compiler-gate] FAIL: $r90_fixture compiled successfully -- region capture provenance was lost (#1938)" >&2
     exit 1
   fi
   if ! grep -qF 'region escapes its scope' "$r90dir/${r90_escape}.wasm.diag" 2>/dev/null; then
-    echo "[compiler-gate] FAIL: err_region_escape_${r90_escape}.vibe did not produce the expected diagnostic (#1938)" >&2
+    echo "[compiler-gate] FAIL: $r90_fixture did not produce the expected diagnostic (#1938)" >&2
     cat "$r90dir/${r90_escape}.wasm.diag" 2>/dev/null >&2 || true
     exit 1
   fi
 done
+
 # The false-positive guard: a closure that captures a region value but stays
 # inside the region is valid, and the body still exits via freeze. It also
 # covers shadowing and an initialiser that merely touches the token while

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9621,7 +9621,14 @@ for r90_fixture in \
   fixtures/err_region_escape_generalized_local_callee.vibe \
   fixtures/err_region_escape_direct_call_alias_write.vibe \
   fixtures/err_region_escape_alias_result.vibe \
+  fixtures/err_region_escape_conditional_alias_result.vibe \
   fixtures/err_region_escape_multi_payload_constructor.vibe \
+  fixtures/err_region_escape_enum_alias.vibe \
+  fixtures/err_region_escape_enum_container.vibe \
+  fixtures/err_region_escape_enum_outer_assignment.vibe \
+  fixtures/err_region_escape_enum_payload.vibe \
+  fixtures/err_region_escape_struct_alias.vibe \
+  fixtures/err_region_escape_struct_container.vibe \
   fixtures/err_region_escape_constructor_helper.vibe \
   fixtures/err_region_escape_bound_struct.vibe \
   fixtures/err_region_escape_mutmap_write.vibe \

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9592,7 +9592,7 @@ fi
 # #1938: capture provenance is part of the checked function type, not a
 # terminal-lambda syntax check. Pin every laundering shape that the old
 # stopgap missed (plus a deep alias witness).
-for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain; do
+for r90_escape in outer_assignment container helper global_helper multiple_regions nested_closure alias_chain monomorphic_callback array_write field_write; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -9589,6 +9589,23 @@ if ! grep -qF 'region escapes its scope' "$r90dir/tok.wasm.diag" 2>/dev/null; th
   cat "$r90dir/tok.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+# #1938: capture provenance is part of the checked function type, not a
+# terminal-lambda syntax check. Pin every laundering shape that the old
+# stopgap missed (plus a deep alias witness).
+for r90_escape in outer_assignment container helper nested_closure alias_chain; do
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "fixtures/err_region_escape_${r90_escape}.vibe" "$r90dir/${r90_escape}.wasm" __no_entry__ >/dev/null 2>&1 || true
+  if [ -s "$r90dir/${r90_escape}.wasm" ]; then
+    echo "[compiler-gate] FAIL: err_region_escape_${r90_escape}.vibe compiled successfully -- region capture provenance was lost (#1938)" >&2
+    exit 1
+  fi
+  if ! grep -qF 'region escapes its scope' "$r90dir/${r90_escape}.wasm.diag" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: err_region_escape_${r90_escape}.vibe did not produce the expected diagnostic (#1938)" >&2
+    cat "$r90dir/${r90_escape}.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
 # The false-positive guard: a closure that captures a region value but stays
 # inside the region is valid, and the body still exits via freeze. It also
 # covers shadowing and an initialiser that merely touches the token while
@@ -9603,6 +9620,18 @@ if [ ! -s "$r90dir/caplocal.wasm" ]; then
 fi
 if ! r90_cap_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/caplocal.wasm" 2>&1)"; then
   echo "[compiler-gate] FAIL: region_ok_closure_local.vibe got '$r90_cap_out' (want 55)" >&2
+  exit 1
+fi
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  fixtures/region_ok_capture_provenance.vibe "$r90dir/provenance_ok.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$r90dir/provenance_ok.wasm" ]; then
+  echo "[compiler-gate] FAIL: region_ok_capture_provenance.vibe did not compile -- capture provenance over-approximated (#1938)" >&2
+  cat "$r90dir/provenance_ok.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/provenance_ok.wasm" >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: region_ok_capture_provenance.vibe snapshots failed (#1938)" >&2
   exit 1
 fi
 # ADR-0090's sanctioned exits COPY. The rest of the FrozenArray surface is


### PR DESCRIPTION
## Summary

- carry source-unforgeable region capture provenance through checked function rows and ordinary type substitution
- preserve provenance across helper calls, explicit return annotations, nested closures, aliases, and containers
- reject assignments that store active-region captures into outer bindings and remove the syntax-specific closure stopgap
- add negative and positive regression fixtures for all escape witnesses

## Tests

- `pkf run generation`
- `pkf run test-affected -- --changed-from origin/main` (full fallback, 665/665 files passed)
- focused region provenance fixtures (5 negative, 3 positive)
- `bash scripts/ensure_generated.sh --check`
- pre-commit review-derived lint gates
- `pkf run test` passed through the complete #1938 region gate and later stopped at the unrelated existing BSD `xargs: command line cannot be assembled, too long` failure in fixture typecheck gate 92

Closes #1938