### PR TITLE
Return non-zero status for uncaught exceptions

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -454,6 +454,8 @@ local testMeasureFsHeap = scriptTask("test-measure-fs-heap", "scripts/measure_fs
 local testRunCachedVibe = scriptTask("test-run-cached-vibe", "scripts/run_cached_vibe_test.sh")
 local testSelfhostGenerations = scriptTask("test-generations", "scripts/generations_test.sh")
 local testVibeRun = scriptTask("test-vibe-run", "scripts/vibe_run_smoke.sh")
+local testUncaughtExceptionExit =
+  scriptTask("test-uncaught-exception-exit", "scripts/test_uncaught_exception_exit.sh")
 local testVibeTest = scriptTask("test-vibe-test", "scripts/vibe_test_smoke.sh")
 local testVibeFmt = scriptTask("test-vibe-fmt", "scripts/vibe_fmt_smoke.sh")
 local testVibeNormalizeSmoke =
@@ -1319,6 +1321,7 @@ tasks {
   testSelfhostGenerations
   testSelfhostUnit
   testVibeRun
+  testUncaughtExceptionExit
   testVibeTest
   testVibeFmt
   testVibeNormalizeSmoke

--- a/docs/vibe.md
+++ b/docs/vibe.md
@@ -74,7 +74,7 @@ Exception-rowed callback parameter all require the caller to declare or
 `handle` it.
 An entry declared `with Exception` gets a runtime boundary handler: an
 escaping Throw becomes `vibe: uncaught error: <msg>` on stderr and an
-unsuccessful (1) entry result. Remaining #944 tail: the builtin-call exception
+unsuccessful process outcome. Remaining #944 tail: the builtin-call exception
 carve-out (sub-decision) and the temporary `VIBE_CHECK_ERROR_ROW=0` opt-out.
 
 ```

--- a/fixtures/entry_error_boundary.vibe
+++ b/fixtures/entry_error_boundary.vibe
@@ -1,10 +1,10 @@
 // #944 (ADR-0073 stage C, "entry boundary A"): an ENTRY function may carry
 // `with Exception` under checked-Error, and an Error::Throw escaping the
 // entry must become a DIAGNOSED, unsuccessful process outcome -- stderr
-// gets "vibe: uncaught error: <msg>" and the entry evaluates to 1 --
+// gets "vibe: uncaught error: <msg>" and every launcher exits non-zero --
 // instead of a raw WebAssembly.Exception leaking past the entry into the
-// host runtime. lc_wrap_entry_error_boundary (codegen/wasi/
-// linked_compile.vibe) wraps the entry body in `handle .. with Exception`
+// host runtime. wrap_entry_exception_boundary (normalize/
+// desugar_trait_dict.vibe) wraps the entry body in `handle .. with Exception`
 // post-check, so the checker still sees the honest row and inner handles
 // still win (an Error discharged INSIDE the entry never reaches the
 // boundary handler).
@@ -15,7 +15,7 @@
 // spliced the arm resumptively, discarding its value -- and is pinned
 // separately by fixtures/effect_handle_error_nontail.vibe now that Error
 // arms are excluded from that pass.
-//   main throws "boom" -> boundary handler -> stderr diag, entry value 1
-export let main = () -> Int with Exception {
+//   main throws "boom" -> boundary handler -> stderr diag, process failure
+fn main() -> Unit with Exception {
   throw("boom")
 }

--- a/fixtures/err_entry_boundary_typed_payload.vibe
+++ b/fixtures/err_entry_boundary_typed_payload.vibe
@@ -1,5 +1,5 @@
 // #1372 review (Codex P1): the compiler-generated entry boundary
-// (linked_compile.vibe's lc_wrap_entry_error_boundary) catches the ERASED
+// (`wrap_entry_exception_boundary`) catches the ERASED
 // `Error::Throw`, and under ADR-0085 that arm also catches every typed
 // `Exception[E]` -- the runtime carries a single abortive tag with NO kind
 // discriminator, and the erased `Error` spelling is deliberately compatible

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -55,6 +55,7 @@ export ../../normalize {
   exn_kind_read_expr,
   exn_msg_read_expr,
   ensure_exn_kind_cell,
+  wrap_entry_exception_boundary,
   desugar_railway_binds,
   desugar_derives,
   desugar_hoist_local_lambdas,

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -235,6 +235,7 @@ fn unbox_tuple_loop_params(stmts: Array[Stmt]) -> Unit
 fn exn_kind_read_expr() -> Expr
 fn exn_msg_read_expr() -> Expr
 fn ensure_exn_kind_cell(stmts: Array[Stmt]) -> Unit
+fn wrap_entry_exception_boundary(stmts: Array[Stmt], entry_name: String) -> Unit
 // --- self_tail_call
 fn rewrite_self_tail_calls(stmts: Array[Stmt]) -> Unit
 

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -62,7 +62,8 @@ import @vibe/compiler/codegen/common_base {
   region_saves_base_of,
   resolve_func,
   resolve_local,
-  rewrite_self_tail_calls
+  rewrite_self_tail_calls,
+  wrap_entry_exception_boundary
 }
 
 import @vibe/compiler/codegen/common_extractors {
@@ -967,6 +968,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // EFn def so calls do not route through a 0-param thunk registration
   // (invalid wasm for any call arity). See import_alias_rewrite.vibe.
   rewrite_top_level_fn_alias_refs(stmts)
+  wrap_entry_exception_boundary(stmts, entry_name)
   // #tco: see codegen/common_base/self_tail_call.vibe's doc comment (same
   // rewrite as the linear backend's call site in codegen/wasi/linked_compile.vibe).
   rewrite_self_tail_calls(stmts)
@@ -1479,9 +1481,9 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   // wrong: the first build that appended imports but left hbo behind produced
   // modules that validated nowhere ("not enough arguments on the stack for
   // call"), because every generated-body index still pointed low.
-  let use_host = stmts_use_builtin(stmts, fn_names_list, "Env::get") || stmts_use_builtin(stmts, fn_names_list, "Env::args_len") || stmts_use_builtin(stmts, fn_names_list, "Env::args_get") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::exists") || stmts_use_builtin(stmts, fn_names_list, "Fs::stat_token") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::publish_immutable_text") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_bytes") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_bytes") || stmts_use_builtin(stmts, fn_names_list, "Profiler::now_us") || stmts_use_builtin(stmts, fn_names_list, "Fs::remove") || stmts_use_builtin(stmts, fn_names_list, "Fs::rename") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_dir") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_file") || stmts_use_builtin(stmts, fn_names_list, "Stdout::write_stream") || stmts_use_builtin(stmts, fn_names_list, "Fs::readdir") || stmts_use_builtin(stmts, fn_names_list, "Stdin::read_char") || stmts_use_builtin(stmts, fn_names_list, "Stdin::read_stream") || stmts_use_builtin(stmts, fn_names_list, "vibe_process_exit_raw")
+  let use_host = stmts_use_builtin(stmts, fn_names_list, "Env::get") || stmts_use_builtin(stmts, fn_names_list, "Env::args_len") || stmts_use_builtin(stmts, fn_names_list, "Env::args_get") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::exists") || stmts_use_builtin(stmts, fn_names_list, "Fs::stat_token") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_file") || stmts_use_builtin(stmts, fn_names_list, "Fs::publish_immutable_text") || stmts_use_builtin(stmts, fn_names_list, "Fs::write_bytes") || stmts_use_builtin(stmts, fn_names_list, "Fs::read_bytes") || stmts_use_builtin(stmts, fn_names_list, "Profiler::now_us") || stmts_use_builtin(stmts, fn_names_list, "Fs::remove") || stmts_use_builtin(stmts, fn_names_list, "Fs::rename") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_dir") || stmts_use_builtin(stmts, fn_names_list, "Fs::is_file") || stmts_use_builtin(stmts, fn_names_list, "Stdout::write_stream") || stmts_use_builtin(stmts, fn_names_list, "Fs::readdir") || stmts_use_builtin(stmts, fn_names_list, "Stdin::read_char") || stmts_use_builtin(stmts, fn_names_list, "Stdin::read_stream") || stmts_use_builtin(stmts, fn_names_list, "vibe_process_exit_raw") || stmts_use_builtin(stmts, fn_names_list, "Stderr::write_stream")
   let hbo = if use_host {
-    20
+    21
   } else {
     0
   }
@@ -1715,7 +1717,11 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       // stopping point: the flat compiler source calls it (cli_adapter.vibe
       // ends `main` with it), so codegen hit an unresolved name here while
       // every builtin LOWERING was already in place.
-      ("vibe_process_exit_raw", 1, 20, 0)
+      ("vibe_process_exit_raw", 1, 20, 0),
+      // The shared uncaught-exception boundary diagnoses on stderr before
+      // trapping. Keep this append-only so every older absolute import index
+      // remains stable.
+      ("Stderr::write_stream", 1, 21, 0)
     ]
     let mut __hd = 0
     while __hd < Array::length(host_defs) {
@@ -2450,7 +2456,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
     // 4=(i64,i64)->i64, 5=()->i64, 6=(i64,i64)->()) -- the linear backend's
     // raw tagged ABI.
     let imp_content = bytebuf_new()
-    bytebuf_push_vec_header(imp_content, 21)
+    bytebuf_push_vec_header(imp_content, 22)
     emit_name(imp_content, "wasi_snapshot_preview1")
     emit_name(imp_content, "fd_write")
     bytebuf_push(imp_content, 0)
@@ -2477,7 +2483,8 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
       ("fs_read_dir", 3),
       ("stdin_read_char", 5),
       ("stdin_read_stream", 3),
-      ("process_exit", 1)
+      ("process_exit", 1),
+      ("stderr_write_stream", 1)
     ]
     let mut __hi = 0
     while __hi < Array::length(host_imports) {

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -169,10 +169,7 @@ import @vibe/compiler/codegen/common_base {
   emit_rc_dup_guarded,
   emit_str_ref,
   empty_dbg_prov,
-  ensure_exn_kind_cell,
   evidence_dict_pass,
-  exn_kind_read_expr,
-  exn_msg_read_expr,
   expr_tag,
   fn_type_param_types,
   forin_discard_pass,
@@ -208,7 +205,8 @@ import @vibe/compiler/codegen/common_base {
   resolve_func,
   resolve_local,
   rewrite_self_tail_calls,
-  suspend_cps_pass
+  suspend_cps_pass,
+  wrap_entry_exception_boundary
 }
 
 import @vibe/compiler/codegen/common_extractors {
@@ -762,13 +760,6 @@ fn lc_row_has_label(eff: Option[String], label: String) -> Bool {
   }
 }
 
-/// #1461: the requested label is the canonical erased spelling. The comparison
-/// inside lc_row_has_label is exception_effect_labels_equal, so a row still
-/// spelled `Error` matches this just as it did before the flip.
-fn lc_row_has_error(eff: Option[String]) -> Bool {
-  lc_row_has_label(eff, "Exception")
-}
-
 fn lc_is_stdin_provider_surface(name: String) -> Bool {
   name == "Stdin::read_via_stream" || name == "StdinStream::next" || name == "StdinStream::close" || name == "StdinStream::read_chunk"
 }
@@ -954,122 +945,6 @@ fn lc_entry_declares_async(stmts: Array[Stmt], entry_name: String) -> Bool {
     i = i + 1
   }
   found
-}
-
-/// #944 (ADR-0073 stage C): the runtime outermost Error handler. When the
-/// ENTRY function's own declared row carries `Error` (`fn main with
-/// { Error }` is allowed under checked-Error), an escaping `Exception::Throw`
-/// must become a diagnosed, unsuccessful process outcome -- not a raw
-/// `WebAssembly.Exception` leaking past the entry into the host. Rewrites
-/// the entry function's body, post-check/pre-codegen, into
-///
-///   handle { <body> } with Exception {
-///     Throw(msg) => { Stderr::...(diagnostic); 1 }
-///   }
-///
-/// so the existing (well-exercised) `with Exception` handle lowering does all
-/// the work -- no new codegen. The arm never resumes (Error is
-/// non-resumable, #640), so replay semantics are irrelevant here. Entries
-/// with no `Error` in their row are untouched: under default-on checked
-/// Error (stage B) they cannot leak a Throw in the first place. The
-/// `__no_entry__` test-runner lane never matches an SLet by this name, so
-/// test `_start` synthesis (whose trap-on-assert semantics the unit-test
-/// runner depends on) is untouched.
-fn lc_wrap_entry_error_boundary(stmts: Array[Stmt], entry_name: String) -> Unit {
-  let mut i = 0
-  let mut wrapped_any = false
-  while i < Array::length(stmts) {
-    match Array::get(stmts, i) {
-      SLet(exported, is_rec, name, ty, EFn(tps, tbs, params, ret, eff, body)) => if name == entry_name && lc_row_has_error(eff) {
-        // #1372 review (Codex P1): the bound payload is NOT necessarily a
-        // String. ADR-0085's runtime carries a single abortive tag with no
-        // kind, so this erased `Exception::Throw` arm also catches every typed
-        // `Exception[E]` -- including the `TaskError` that #1324's
-        // `TaskGroup::run` throws. Writing that enum pointer straight to
-        // `Stderr::write_stream` decoded it as a packed `(ptr<<32)|len`
-        // string and dumped the whole data segment.
-        //
-        // #1374: the throw site now records the payload's static type name in
-        // the exception-kind cell, so this arm can tell the cases apart:
-        //
-        //   String / Int   `__to_string` is FAITHFUL -- ADR-0058's int/string
-        //                  discrimination (`64 <= ptr && ptr + len <=
-        //                  memory_size`) is the identity on a real string and
-        //                  renders an int as its decimal. Unchanged output.
-        //   ""             the throw site could not resolve a type name, so
-        //                  the payload might be either. Keep #1375's
-        //                  conservative `__to_string`: bounded, never a read
-        //                  of arbitrary memory.
-        //   anything else  a value whose bytes are NOT text (an enum, a
-        //                  struct). Print the KIND, not a decimal that reads
-        //                  like a message.
-        //
-        // #1392 slice 3: the throw site now ALSO renders the payload, where its
-        // static type is still known, so the "anything else" case prints the
-        // VALUE (`Failed("io")`) rather than just its type. The kind branch
-        // survives as the fallback for a rendered string the throw site could
-        // not produce -- a payload whose type resolved to a declared type with
-        // no `T::to_string` renders through the pointer heuristic, and printing
-        // `<Kind>` is still better than a decimal there.
-        let kind_ident = EIdent("__entry_err_kind", -1)
-        let msg_ident = EIdent("__entry_err_rendered", -1)
-        let printable = EBinOp("||", ECall(EIdent("String::equals", -1), [
-          kind_ident,
-          EString("")
-        ], -1), EBinOp("||", ECall(EIdent("String::equals", -1), [
-          kind_ident,
-          EString("String")
-        ], -1), ECall(EIdent("String::equals", -1), [
-          kind_ident,
-          EString("Int")
-        ], -1)))
-        // A non-empty slot means the throw site found a STRUCTURAL renderer --
-        // it writes nothing when all it could produce was the pointer
-        // heuristic's own output, precisely so this test can be a plain
-        // emptiness check rather than an impossible "is this decimal real"
-        // one.
-        let rendered_ok = EBinOp("!=", ECall(EIdent("String::length", -1), [
-          msg_ident
-        ], -1), EInt(0))
-        let text = EIf(printable, ECall(EIdent("__to_string", -1), [
-          EIdent("__entry_err_msg", -1)
-        ], -1), EIf(rendered_ok, msg_ident, ECall(EIdent("String::concat", -1), [
-          EString("<"),
-          ECall(EIdent("String::concat", -1), [
-            kind_ident,
-            EString(">")
-          ], -1)
-        ], -1)))
-        let diag = ELet("__entry_err_kind", exn_kind_read_expr(), ELet("__entry_err_rendered", exn_msg_read_expr(), ESeq(ECall(EIdent("Stderr::write_stream", -1), [
-          EString("vibe: uncaught error: ")
-        ], -1), ESeq(ECall(EIdent("Stderr::write_stream", -1), [
-          text
-        ], -1), ESeq(ECall(EIdent("Stderr::write_stream", -1), [
-          EString("\n")
-        ], -1), EInt(1)))), -1), -1)
-        let wrapped = EHandle(body, [
-          (PCtor("Exception::Throw", [
-            PBind("__entry_err_msg")
-          ]), diag)
-        ])
-        Array::set(stmts, i, SLet(exported, is_rec, name, ty, EFn(tps, tbs, params, ret, eff, wrapped)))
-        wrapped_any = true
-      } else {
-        ()
-      },
-      _ => ()
-    }
-    i = i + 1
-  }
-  // #1374: this pass runs AFTER desugar_trait_dicts, so the cell it just
-  // synthesized a reader for is only guaranteed to exist for a program that
-  // itself throws. An entry whose `Error` row comes from an imported module's
-  // throw is exactly the case where it would not.
-  if wrapped_any {
-    ensure_exn_kind_cell(stmts)
-  } else {
-    ()
-  }
 }
 
 /// ADR-0089 Decision 1, increment 1 (#1218): make `sleep` a real
@@ -3582,11 +3457,11 @@ export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked
     await_poll_pass(stmts, lc_stmts_call_host_future(stmts), lc_waiter_hooks_available(stmts, linked_imports))
     rewrite_self_tail_calls(stmts)
     // #944 (ADR-0073 stage C): entry-boundary Error handler -- see
-    // lc_wrap_entry_error_boundary's doc comment. Runs BEFORE the effect
+    // wrap_entry_exception_boundary's doc comment. Runs BEFORE the effect
     // passes below so the synthesized handle is visible to them like any
     // hand-written one, and before collect_used_builtin_names so the
     // diagnostic's Stderr host import is collected.
-    lc_wrap_entry_error_boundary(stmts, entry_name)
+    wrap_entry_exception_boundary(stmts, entry_name)
     let async_sleep_boundary_err = lc_inject_async_sleep_boundary(stmts, entry_name)
     if async_sleep_boundary_err != "" {
       Array::push(errs, async_sleep_boundary_err)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -1631,17 +1631,44 @@ fn comp_generate_wasi_fd_write_stub() -> Bytes {
 /// core instances: 0=wasi-stub, 1=main(+wasi), 2=cm(task-return), 3=env(run),
 /// 4=trampoline. core funcs: 0=task.return, 1=main.run, 2=trampoline.run.
 export fn comp_emit_component_wasm_async_trampolined_p1(main_core_wasm: Bytes, export_name: String, comp_result_valtype: Int) -> Bytes {
+  let needs_stderr = comp_core_imports_func(main_core_wasm, "vibe", "stderr_write_stream")
   let buf = bytebuf_new()
   emit_component_header(buf)
   emit_core_module_section(buf, main_core_wasm)
   emit_core_module_section(buf, comp_generate_async_trampoline(comp_valtype_to_core(comp_result_valtype)))
-  emit_core_module_section(buf, comp_generate_wasi_fd_write_stub())
+  if needs_stderr {
+    // The exception boundary only needs this import on its failing path. A
+    // local trapping stub keeps the self-contained component valid and
+    // preserves the same non-zero outcome as core launchers; components that
+    // do not carry the boundary retain their exact pre-existing bytes.
+    emit_core_module_section(buf, comp_generate_host_stub_module([
+      "stderr_write_stream"
+    ], [
+      [
+        1,
+        126,
+        0
+      ]
+    ]))
+  } else {
+    emit_core_module_section(buf, comp_generate_wasi_fd_write_stub())
+  }
   emit_core_instance_instantiate_section(buf, 2, array_empty())
-  emit_core_instance_instantiate_args(buf, 0, [
-    "wasi_snapshot_preview1"
-  ], [
-    0
-  ])
+  if needs_stderr {
+    emit_core_instance_instantiate_args(buf, 0, [
+      "wasi_snapshot_preview1",
+      "vibe"
+    ], [
+      0,
+      0
+    ])
+  } else {
+    emit_core_instance_instantiate_args(buf, 0, [
+      "wasi_snapshot_preview1"
+    ], [
+      0
+    ])
+  }
   emit_canon_task_return(buf, comp_result_valtype)
   emit_core_instance_from_exports(buf, 1, [
     1
@@ -1678,6 +1705,23 @@ export fn comp_emit_component_wasm_async_trampolined_p1(main_core_wasm: Bytes, e
   emit_canon_lift_async_section(buf, 2, 0)
   emit_comp_export_section(buf, export_name, 0)
   bytebuf_to_bytes(buf)
+}
+
+fn comp_core_imports_func(core_wasm: Bytes, module_name: String, func_name: String) -> Bool {
+  let modules = array_empty()
+  let names = array_empty()
+  let type_indices = new_int_array()
+  let type_sigs = array_empty()
+  let count = parse_core_imports(core_wasm, modules, names, type_indices, type_sigs)
+  let mut found = false
+  let mut i = 0
+  while i < count {
+    if Array::get(modules, i) == module_name && Array::get(names, i) == func_name {
+      found = true
+    }
+    i = i + 1
+  }
+  found
 }
 
 /// #1230 M1b-3c-1b: component valtype for u32, matching the

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1,7 +1,17 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, TypeEnv, TypeExpr, expr_children, is_exception_throw_operation, sort_perm_by_names, str_lt, trait_method_sig_binders_deep
+  Expr,
+  Pat,
+  Stmt,
+  TypeEnv,
+  TypeExpr,
+  expr_children,
+  is_exception_effect_name,
+  is_exception_throw_operation,
+  sort_perm_by_names,
+  str_lt,
+  trait_method_sig_binders_deep
 }
 
 import @vibe/core {
@@ -673,7 +683,7 @@ fn exn_kind_cell_stmt() -> Stmt {
 }
 
 /// What `__exn_kind()` lowers to. Exported because the compiler-synthesized
-/// entry boundary (lc_wrap_entry_error_boundary) is built AFTER this pass and
+/// entry boundary (`wrap_entry_exception_boundary`) is built AFTER this pass and
 /// so has to spell the lowered form itself.
 export fn exn_kind_read_expr() -> Expr {
   ECall(EIdent("Array::get", -1), [
@@ -715,6 +725,107 @@ export fn ensure_exn_kind_cell(stmts: Array[Stmt]) -> Unit {
     ()
   } else {
     Array::push(stmts, exn_kind_cell_stmt())
+  }
+}
+
+/// Install the process boundary for an entry whose declared row carries
+/// `Exception` (including the legacy `Error` alias and typed exceptions).
+///
+/// An escaping throw is not an ordinary return value. The old boundary
+/// diagnosed it and returned `1`, which worked only for hosts that invoked the
+/// entry export directly. Hosts that execute the conventional result-less
+/// `_start` dropped that value and reported success. Trap after emitting the
+/// diagnostic instead: every core/component launcher already maps a wasm trap
+/// to a non-zero process status, while an inner handler still prevents this
+/// boundary from running.
+export fn wrap_entry_exception_boundary(stmts: Array[Stmt], entry_name: String) -> Unit {
+  let mut i = 0
+  let mut wrapped_any = false
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(exported, is_rec, name, ty, EFn(tps, tbs, params, ret, eff, body)) => if name == entry_name && entry_row_has_exception(eff) {
+        let payload_name = dinsp_fresh_name("__entry_err_msg", body, body)
+        let kind_name = dinsp_fresh_name("__entry_err_kind", body, body)
+        let rendered_name = dinsp_fresh_name("__entry_err_rendered", body, body)
+        let kind_ident = EIdent(kind_name, -1)
+        let msg_ident = EIdent(rendered_name, -1)
+        let printable = EBinOp("||", ECall(EIdent("String::equals", -1), [
+          kind_ident,
+          EString("")
+        ], -1), EBinOp("||", ECall(EIdent("String::equals", -1), [
+          kind_ident,
+          EString("String")
+        ], -1), ECall(EIdent("String::equals", -1), [
+          kind_ident,
+          EString("Int")
+        ], -1)))
+        let rendered_ok = EBinOp("!=", ECall(EIdent("String::length", -1), [
+          msg_ident
+        ], -1), EInt(0))
+        let text = EIf(printable, ECall(EIdent("__to_string", -1), [
+          EIdent(payload_name, -1)
+        ], -1), EIf(rendered_ok, msg_ident, ECall(EIdent("String::concat", -1), [
+          EString("<"),
+          ECall(EIdent("String::concat", -1), [
+            kind_ident,
+            EString(">")
+          ], -1)
+        ], -1)))
+        let fail = ECall(EIdent("assert_true", -1), [
+          EBool(false)
+        ], -1)
+        let diag = ELet(kind_name, exn_kind_read_expr(), ELet(rendered_name, exn_msg_read_expr(), ESeq(ECall(EIdent("Stderr::write_stream", -1), [
+          EString("vibe: uncaught error: ")
+        ], -1), ESeq(ECall(EIdent("Stderr::write_stream", -1), [
+          text
+        ], -1), ESeq(ECall(EIdent("Stderr::write_stream", -1), [
+          EString("\n")
+        ], -1), fail))), -1), -1)
+        let wrapped = EHandle(body, [
+          (PCtor("Exception::Throw", [
+            PBind(payload_name)
+          ]), diag)
+        ])
+        Array::set(stmts, i, SLet(exported, is_rec, name, ty, EFn(tps, tbs, params, ret, eff, wrapped)))
+        wrapped_any = true
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  if wrapped_any {
+    ensure_exn_kind_cell(stmts)
+  } else {
+    ()
+  }
+}
+
+fn entry_row_has_exception(eff: Option[String]) -> Bool {
+  match eff {
+    Some(row) => {
+      let mut found = false
+      let mut start = 0
+      let n = String::length(row)
+      let mut i = 0
+      while i <= n {
+        let at_sep = if i == n {
+          true
+        } else {
+          String::char_code_at(row, i) == 44
+        }
+        if at_sep {
+          if is_exception_effect_name(String::trim(String::substring(row, start, i))) {
+            found = true
+          }
+          start = i + 1
+        }
+        i = i + 1
+      }
+      found
+    },
+    None => false
   }
 }
 

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -53,6 +53,7 @@ fn collect_undispatchable_trait_method_errors(stmts: Array[Stmt], env: TypeEnv) 
 fn exn_kind_read_expr() -> Expr
 fn exn_msg_read_expr() -> Expr
 fn ensure_exn_kind_cell(stmts: Array[Stmt]) -> Unit
+fn wrap_entry_exception_boundary(stmts: Array[Stmt], entry_name: String) -> Unit
 fn desugar_railway_binds(stmts: Array[Stmt]) -> Unit
 fn desugar_derives(stmts: Array[Stmt]) -> Unit
 fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit

--- a/scripts/builtin_parity_classification.tsv
+++ b/scripts/builtin_parity_classification.tsv
@@ -28,7 +28,6 @@ Profiler::HeapBytes	linear-only	host-import	host/linear-memory import; the gc la
 Profiler::NowUs	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Profiler::heap_bytes	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stderr::write_char	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
-Stderr::write_stream	linear-only	host-import	host/linear-memory import; the gc lane is the pure-test lane and gates these out as a group
 Stdin::read_via_stream	linear-only	async-component-only	#1539 public acquisition route; the GC callsite arm is a loud rejection, not an implementation
 StdinStream::read_chunk	linear-only	async-component-only	#1539 compiler-owned direct chunk operation; the GC callsite arm is a loud rejection, not an implementation
 StdinStream::close	linear-only	async-component-only	#1539 public lifecycle route; the GC callsite arm is a loud rejection, not an implementation

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -7137,13 +7137,13 @@ rm -rf "$g944dir"
 echo "[compiler-gate] opt-in checked-Error row discipline ok (#944 stage A)"
 
 # 44c. #944 (ADR-0073 stage C, "entry boundary A"): an entry declared
-#      `with Error` whose Throw escapes must produce the stderr
-#      diagnostic and evaluate to 1 (unsuccessful outcome) instead of
-#      leaking a raw WebAssembly.Exception out of the entry.
+#      `with Error` whose Throw escapes must produce the stderr diagnostic and
+#      a non-zero shell status, including through the result-less `_start`
+#      launcher ABI.
 echo "[compiler-gate] 44c/44 entry-boundary Error handler (#944 stage C)"
 g944cdir="_build/_gate_944c"
 rm -rf "$g944cdir"; mkdir -p "$g944cdir"
-# #1571: the entry-boundary behaviour (stderr diagnostic + entry value) is
+# #1571: the entry-boundary behaviour (stderr diagnostic + process status) is
 # asserted below, so the fixture carries no `__DATA__` tail any more and is
 # compiled AS-IS -- no `sed` strip, no temp copy.
 rm -f "$g944cdir/out.wasm"
@@ -7155,9 +7155,8 @@ if [ ! -s "$g944cdir/out.wasm" ]; then
   cat "$g944cdir/out.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-g944c_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$g944cdir/out.wasm" 2>"$g944cdir/stderr.txt" | tail -1)"
-if [ "$g944c_out" != "1" ]; then
-  echo "[compiler-gate] FAIL: entry_error_boundary got '$g944c_out' (want 1) -- boundary handler value regressed (#944 stage C)" >&2
+if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g944cdir/out.wasm" >"$g944cdir/stdout.txt" 2>"$g944cdir/stderr.txt"; then
+  echo "[compiler-gate] FAIL: entry_error_boundary exited 0 through _start (#1945)" >&2
   exit 1
 fi
 if ! grep -q "vibe: uncaught error: boom" "$g944cdir/stderr.txt"; then
@@ -7191,12 +7190,11 @@ if [ ! -s "$g944cdir/typed.wasm" ]; then
   cat "$g944cdir/typed.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-g944c_typed_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$g944cdir/typed.wasm" 2>"$g944cdir/typed_stderr.txt" | tail -1)"
-if [ "$g944c_typed_out" != "1" ]; then
-  echo "[compiler-gate] FAIL: typed-payload entry boundary got '$g944c_typed_out' (want 1)" >&2
+if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g944cdir/typed.wasm" >"$g944cdir/typed_stdout.txt" 2>"$g944cdir/typed_stderr.txt"; then
+  echo "[compiler-gate] FAIL: typed-payload entry boundary exited 0 (#1945)" >&2
   exit 1
 fi
-if ! grep -qxF 'vibe: uncaught error: <Boom>' "$g944cdir/typed_stderr.txt"; then
+if [ "$(head -n 1 "$g944cdir/typed_stderr.txt")" != 'vibe: uncaught error: <Boom>' ]; then
   echo "[compiler-gate] FAIL: a TYPED exception escaping the entry did not name its kind -- the boundary is reading the payload as a string, or the #1374 kind side channel is not reaching it" >&2
   head -c 400 "$g944cdir/typed_stderr.txt" >&2 || true
   exit 1
@@ -7212,18 +7210,18 @@ if [ ! -s "$g944cdir/strp.wasm" ]; then
   cat "$g944cdir/strp.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-g944c_strp_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$g944cdir/strp.wasm" 2>"$g944cdir/strp_stderr.txt" | tail -1)"
-if [ "$g944c_strp_out" != "1" ]; then
-  echo "[compiler-gate] FAIL: String-payload entry boundary got '$g944c_strp_out' (want 1)" >&2
+if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g944cdir/strp.wasm" >"$g944cdir/strp_stdout.txt" 2>"$g944cdir/strp_stderr.txt"; then
+  echo "[compiler-gate] FAIL: String-payload entry boundary exited 0 (#1945)" >&2
   exit 1
 fi
-if ! grep -qxF 'vibe: uncaught error: plain boom' "$g944cdir/strp_stderr.txt"; then
+if [ "$(head -n 1 "$g944cdir/strp_stderr.txt")" != 'vibe: uncaught error: plain boom' ]; then
   echo "[compiler-gate] FAIL: a String exception escaping the entry no longer prints verbatim -- #1374's kind dispatch changed the common case (want 'vibe: uncaught error: plain boom')" >&2
   head -c 400 "$g944cdir/strp_stderr.txt" >&2 || true
   exit 1
 fi
 rm -rf "$g944cdir"
 echo "[compiler-gate] entry-boundary Error handler ok (#944 stage C, typed payload #1372, kind channel #1374)"
+bash scripts/test_uncaught_exception_exit.sh "$stage2_wasm"
 
 # 44d. #1087: a NON-tail `throw` inline in a `handle .. with Error` body
 #      must abort the body -- the arm's value (1) is the handle's result,
@@ -10707,7 +10705,11 @@ exn_msg_expect() {
     exit 1
   fi
   local got
-  got="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$exnmsgdir/$name.wasm" 2>&1 | grep "uncaught error" | head -1)"
+  if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$exnmsgdir/$name.wasm" >"$exnmsgdir/$name.stdout" 2>"$exnmsgdir/$name.stderr"; then
+    echo "[compiler-gate] FAIL: $name uncaught exception exited 0 (#1945)" >&2
+    exit 1
+  fi
+  got="$(grep "uncaught error" "$exnmsgdir/$name.stderr" | head -1)"
   if [ "$got" != "vibe: uncaught error: $want" ]; then
     echo "[compiler-gate] FAIL: $name got '$got' (want 'vibe: uncaught error: $want') (#1392 slice 3)" >&2
     exit 1

--- a/scripts/test_uncaught_exception_exit.sh
+++ b/scripts/test_uncaught_exception_exit.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Shell-level regression for #1945. The boundary must survive launchers that
+# execute result-less `_start`, and it must agree across linear, wasm-gc, and
+# the basic async Component Model wrapper.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+newest_stage2_artifact() {
+  local generations_dir="$1"
+  ls -t "$generations_dir"/*/stage2.wasm 2>/dev/null | head -1 || true
+}
+
+# A bootstrap may leave a newer directory before it publishes stage2.wasm.
+# Pin selection to artifact mtimes, not generation-directory mtimes.
+selector_regression() {
+  local fixture expected got
+  fixture="$(mktemp -d "$ROOT_DIR/_build/exception_exit_selector.XXXXXX")"
+  mkdir -p "$fixture/old" "$fixture/new" "$fixture/interrupted"
+  : >"$fixture/old/stage2.wasm"
+  : >"$fixture/new/stage2.wasm"
+  touch -t 202601010101 "$fixture/old/stage2.wasm"
+  touch -t 202601020101 "$fixture/new/stage2.wasm"
+  touch -t 202601030101 "$fixture/interrupted"
+  expected="$fixture/new/stage2.wasm"
+  got="$(newest_stage2_artifact "$fixture")"
+  rm -rf "$fixture"
+  if [ "$got" != "$expected" ]; then
+    echo "[exception-exit] stage2 selection got '$got', expected '$expected'" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$ROOT_DIR/_build"
+selector_regression
+
+COMPILER="${1:-${VIBE_EXCEPTION_EXIT_COMPILER:-}}"
+if [ -z "$COMPILER" ]; then
+  COMPILER="$(newest_stage2_artifact "$ROOT_DIR/_build/selfhost/generations")"
+fi
+[ -f "$COMPILER" ] || { echo "[exception-exit] missing stage2 compiler: $COMPILER" >&2; exit 2; }
+
+WORK="$ROOT_DIR/_build/exception_exit"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+cat >"$WORK/uncaught.vibe" <<'EOF'
+fn main() -> Unit with Exception {
+  throw("shell boom")
+}
+EOF
+cat >"$WORK/handled.vibe" <<'EOF'
+fn main() -> Unit {
+  let _ = handle { throw("handled") } with Exception { Throw(_) => () }
+}
+EOF
+cat >"$WORK/explicit.vibe" <<'EOF'
+fn main() -> Unit with Process {
+  vibe_process_exit_raw(7)
+}
+EOF
+
+compile_core() {
+  local backend="$1" name="$2" out="$WORK/${name}_${backend}.wasm"
+  if [ "$backend" = "gc" ]; then
+    env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_BACKEND=gc \
+      bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$COMPILER" \
+      "$WORK/$name.vibe" "$out" main >/dev/null
+  else
+    env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FS_COMPILE=1 \
+      bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$COMPILER" \
+      "$WORK/$name.vibe" "$out" main >/dev/null
+  fi
+}
+
+run_core() {
+  local backend="$1" name="$2" expected="$3"
+  local out="$WORK/${name}_${backend}.stdout" err="$WORK/${name}_${backend}.stderr"
+  set +e
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$WORK/${name}_${backend}.wasm" >"$out" 2>"$err"
+  local code=$?
+  set -e
+  if [ "$code" -ne "$expected" ]; then
+    echo "[exception-exit] $backend/$name status=$code, expected $expected" >&2
+    sed -n '1,8p' "$err" >&2 || true
+    exit 1
+  fi
+  if [ "$name" = "uncaught" ] && [ "$(head -n 1 "$err")" != "vibe: uncaught error: shell boom" ]; then
+    echo "[exception-exit] $backend uncaught diagnostic mismatch" >&2
+    sed -n '1,8p' "$err" >&2 || true
+    exit 1
+  fi
+}
+
+for backend in linear gc; do
+  for name in uncaught handled explicit; do
+    compile_core "$backend" "$name"
+  done
+  run_core "$backend" uncaught 1
+  run_core "$backend" handled 0
+  run_core "$backend" explicit 7
+done
+
+if command -v wasmtime >/dev/null 2>&1; then
+  cat >"$WORK/component.vibe" <<'EOF'
+let run: () -> Int with Async + Exception = () -> {
+  throw("component boom")
+}
+EOF
+  component="$WORK/component.wasm"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$COMPILER" \
+    "$WORK/component.vibe" "$component" run >/dev/null
+  set +e
+  wasmtime -W exceptions=y -W concurrency-support=y -W component-model-async=y \
+    -W component-model-async-stackful=y --invoke 'run()' "$component" \
+    >"$WORK/component.stdout" 2>"$WORK/component.stderr"
+  component_code=$?
+  set -e
+  if [ "$component_code" -eq 0 ]; then
+    echo "[exception-exit] component uncaught exception exited 0" >&2
+    exit 1
+  fi
+fi
+
+echo "[exception-exit] ok (linear/gc status+diagnostic, handled=0, explicit=7, component non-zero)"


### PR DESCRIPTION
## Summary

- move the uncaught-exception entry boundary into the shared normalization path so linear and wasm-gc backends agree
- diagnose an uncaught value and trap instead of returning a value that `_start` discards
- keep handled exceptions successful and preserve explicit process-exit statuses
- make basic async components valid when the boundary adds the stderr import
- add a shell-level regression covering output and status across linear, wasm-gc, and component launchers

## Validation

- `pkf run generation-gate`
- `pkf run test-affected -- --changed-from origin/main` (665/665)
- `pkf run test-uncaught-exception-exit`
- `pkf run test-async-component`
- `pkf run check-host-runtime-contract`
- `pkf run pre-commit`
- `pkf run check-taskfile-fmt`
- `scripts/check_vibe_fmt.sh` with the bundled modern Bash
- `pkf run release-check` passed the changed exception gates and continued through compiler gate 91; gate 92 hit the existing macOS command-size limit: `xargs: command line cannot be assembled, too long`

Closes #1945
