### PR TITLE
refactor(normalize): report checker pretransform changes

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -2301,7 +2301,7 @@ fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
 /// AST as `StdinStream::next(..)`, so existing Async authority checks apply;
 /// value imports remain distinct and are rejected at the merged compile
 /// boundary rather than becoming first-class provider operations.
-fn canonicalize_stdin_provider_type_import_heads(stmts: Array[Stmt]) -> Unit {
+fn canonicalize_stdin_provider_type_import_heads_reporting_change(stmts: Array[Stmt]) -> Bool {
   let aliases: Array[(String, String)] = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
@@ -2325,18 +2325,28 @@ fn canonicalize_stdin_provider_type_import_heads(stmts: Array[Stmt]) -> Unit {
     }
     i = i + 1
   }
+  let mut changed = false
   if Array::length(aliases) > 0 {
     let mut k = 0
     while k < Array::length(stmts) {
       match Array::get(stmts, k) {
         SImport(_, _) => (),
-        _ => Array::set(stmts, k, rewrite_import_alias_stmt(Array::get(stmts, k), aliases))
+        _ => {
+          Array::set(stmts, k, rewrite_import_alias_stmt(Array::get(stmts, k), aliases))
+          changed = true
+        }
       }
       k = k + 1
     }
   } else {
     ()
   }
+  changed
+}
+
+fn canonicalize_stdin_provider_type_import_heads(stmts: Array[Stmt]) -> Unit {
+  let _changed = canonicalize_stdin_provider_type_import_heads_reporting_change(stmts)
+  ()
 }
 
 /// Reject stdin provider operation values before inference can replace the

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -550,7 +550,8 @@ fn annotate_params_from_sig(params: Array[(String, Option[TypeExpr])], ptypes: A
 /// `[X: Bound]` binder, re-attach the binder to the EFn and annotate its params
 /// with the trait method's declared types. Idempotent: an EFn that already
 /// carries type_params was injected on a prior run and is skipped.
-fn inject_method_generics(stmts: Array[Stmt], impl_map: Array[(String, String)], gen_table: Array[(String, Array[(String, Array[String], Array[(String, Array[String])])])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])]) -> Unit {
+fn inject_method_generics_reporting_change(stmts: Array[Stmt], impl_map: Array[(String, String)], gen_table: Array[(String, Array[(String, Array[String], Array[(String, Array[String])])])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])]) -> Bool {
+  let mut changed = false
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
@@ -565,6 +566,7 @@ fn inject_method_generics(stmts: Array[Stmt], impl_map: Array[(String, String)],
                   let new_params = annotate_params_from_sig(params, ptypes)
                   let new_efn = EFn(mtparams, mtbounds, new_params, ret, eff, fbody)
                   Array::set(stmts, i, SLet(exp, isrec, qname, ann, new_efn))
+                  changed = true
                 },
                 None => ()
               }
@@ -580,6 +582,7 @@ fn inject_method_generics(stmts: Array[Stmt], impl_map: Array[(String, String)],
     }
     i = i + 1
   }
+  changed
 }
 
 /// Re-attach trait-method `[X: Bound]` binders to impl free functions, given a
@@ -587,23 +590,33 @@ fn inject_method_generics(stmts: Array[Stmt], impl_map: Array[(String, String)],
 /// idempotent. Shared by `desugar_trait_dicts` (pre-codegen) and `check_program`
 /// (so the FS-compile path, which type-checks before the desugar runs, also sees
 /// the binder and can resolve `X::method`).
-fn inject_trait_method_generics_with(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])]) -> Unit {
+fn inject_trait_method_generics_with_reporting_change(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])]) -> Bool {
   let method_gen_table = collect_trait_method_gens(stmts)
   if Array::length(method_gen_table) > 0 {
     let impl_map = collect_impl_trait_map(stmts)
-    inject_method_generics(stmts, impl_map, method_gen_table, traits)
+    inject_method_generics_reporting_change(stmts, impl_map, method_gen_table, traits)
   } else {
-    ()
+    false
   }
+}
+
+fn inject_trait_method_generics_with(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])]) -> Unit {
+  let _changed = inject_trait_method_generics_with_reporting_change(stmts, traits)
+  ()
 }
 
 /// Self-contained entry for callers that have not flattened the trait table
 /// (the checker). Builds its own (flattened) method-trait table from `stmts`.
-export fn inject_trait_method_generics(stmts: Array[Stmt]) -> Unit {
+export fn inject_trait_method_generics_reporting_change(stmts: Array[Stmt]) -> Bool {
   let traits_raw = collect_method_traits(stmts)
   let supers_map = collect_trait_supers(stmts)
   let traits = flatten_traits(traits_raw, supers_map)
-  inject_trait_method_generics_with(stmts, traits)
+  inject_trait_method_generics_with_reporting_change(stmts, traits)
+}
+
+export fn inject_trait_method_generics(stmts: Array[Stmt]) -> Unit {
+  let _changed = inject_trait_method_generics_reporting_change(stmts)
+  ()
 }
 
 // #1324 removed the #760(2) `inject_prelude_result` pass (and its
@@ -4099,16 +4112,24 @@ fn lower_try_op(val: Expr) -> Expr {
 /// NOT run) and — idempotently — the codegen `desugar_trait_dicts`. It is inert
 /// for programs that use no `let*`/`?` (no sentinels present). `var_types` tracks
 /// locals so `let* x = some_opt` then `let* y = uses(x)` resolves x's type.
-fn railway_rw(expr: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr {
+fn railway_rw(expr: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)], changed: Option[Array[Bool]]) -> Expr {
   match expr {
     ECall(callee, args, off) => {
       let k = try_sentinel(callee, args)
       if k == 0 {
+        match changed {
+          Some(cell) => {
+            Array::set(cell, 0, true)
+          },
+          None => {
+            ()
+          }
+        }
         let val = Array::get(args, 0)
         match Array::get(args, 1) {
           EFn(_, _, ps, _, _, rest) => {
             let (name, _) = Array::get(ps, 0)
-            let rwval = railway_rw(val, struct_sets, var_types, fn_returns)
+            let rwval = railway_rw(val, struct_sets, var_types, fn_returns, changed)
             // #1064: `name` binds to the UNWRAPPED payload (`Some(name)`'s
             // field), never to a value of `inferred`'s own type (the
             // wrapper "Option"/"Result" of `val`) -- recording name ->
@@ -4126,22 +4147,40 @@ fn railway_rw(expr: Expr, struct_sets: Array[(String, Array[String])], var_types
             // untracked, falling through infer_arg_type_name to `None`,
             // which keeps the plain scalar `==`/`!=` codegen path.
             let body_vars = extend_var_types(var_types, name, railway_bind_payload_type(val, struct_sets, var_types, fn_returns))
-            let rwrest = railway_rw(rest, struct_sets, body_vars, fn_returns)
+            let rwrest = railway_rw(rest, struct_sets, body_vars, fn_returns, changed)
             lower_try_bind(rwval, name, rwrest)
           },
           _ => EUnit
         }
       } else if k == 1 {
+        match changed {
+          Some(cell) => {
+            Array::set(cell, 0, true)
+          },
+          None => {
+            ()
+          }
+        }
         let val = Array::get(args, 0)
-        let rwval = railway_rw(val, struct_sets, var_types, fn_returns)
+        let rwval = railway_rw(val, struct_sets, var_types, fn_returns, changed)
         lower_try_op(rwval)
       } else {
         let rwargs = for a in args {
-          railway_rw(a, struct_sets, var_types, fn_returns)
+          railway_rw(a, struct_sets, var_types, fn_returns, changed)
         }
         match map_index_rewrite(callee, args, rwargs, struct_sets, var_types, fn_returns) {
-          Some(map_get) => map_get,
-          None => ECall(railway_rw(callee, struct_sets, var_types, fn_returns), rwargs, off)
+          Some(map_get) => {
+            match changed {
+              Some(cell) => {
+                Array::set(cell, 0, true)
+              },
+              None => {
+                ()
+              }
+            }
+            map_get
+          },
+          None => ECall(railway_rw(callee, struct_sets, var_types, fn_returns, changed), rwargs, off)
         }
       }
     },
@@ -4150,21 +4189,21 @@ fn railway_rw(expr: Expr, struct_sets: Array[(String, Array[String])], var_types
     EString(_) => expr,
     EBool(_) => expr,
     EUnit => expr,
-    ESpread(e) => ESpread(railway_rw(e, struct_sets, var_types, fn_returns)),
+    ESpread(e) => ESpread(railway_rw(e, struct_sets, var_types, fn_returns, changed)),
     EStringInterp(_) => expr,
     EIdent(_, _) => expr,
     ETuple(elems) => ETuple(for e in elems {
-      railway_rw(e, struct_sets, var_types, fn_returns)
+      railway_rw(e, struct_sets, var_types, fn_returns, changed)
     }),
     EArray(elems) => EArray(for e in elems {
-      railway_rw(e, struct_sets, var_types, fn_returns)
+      railway_rw(e, struct_sets, var_types, fn_returns, changed)
     }),
     ERecord(rn, fields, targs) => {
       let out = array_empty()
       let mut i = 0
       while i < Array::length(fields) {
         let (fname, fval) = Array::get(fields, i)
-        Array::push(out, (fname, railway_rw(fval, struct_sets, var_types, fn_returns)))
+        Array::push(out, (fname, railway_rw(fval, struct_sets, var_types, fn_returns, changed)))
         i = i + 1
       }
       ERecord(rn, out, targs)
@@ -4174,26 +4213,26 @@ fn railway_rw(expr: Expr, struct_sets: Array[(String, Array[String])], var_types
       let mut i = 0
       while i < Array::length(fields) {
         let (k, v) = Array::get(fields, i)
-        Array::push(out, (k, railway_rw(v, struct_sets, var_types, fn_returns)))
+        Array::push(out, (k, railway_rw(v, struct_sets, var_types, fn_returns, changed)))
         i = i + 1
       }
       EMap(out)
     },
-    EIf(c, t, e) => EIf(railway_rw(c, struct_sets, var_types, fn_returns), railway_rw(t, struct_sets, var_types, fn_returns), railway_rw(e, struct_sets, var_types, fn_returns)),
+    EIf(c, t, e) => EIf(railway_rw(c, struct_sets, var_types, fn_returns, changed), railway_rw(t, struct_sets, var_types, fn_returns, changed), railway_rw(e, struct_sets, var_types, fn_returns, changed)),
     ELet(name, val, body, soff) => {
-      let new_val = railway_rw(val, struct_sets, var_types, fn_returns)
+      let new_val = railway_rw(val, struct_sets, var_types, fn_returns, changed)
       let body_vars = extend_var_types(var_types, name, anon_or_infer(val, struct_sets, var_types, fn_returns))
-      ELet(name, new_val, railway_rw(body, struct_sets, body_vars, fn_returns), soff)
+      ELet(name, new_val, railway_rw(body, struct_sets, body_vars, fn_returns, changed), soff)
     },
-    ELetRec(name, val, body) => ELetRec(name, railway_rw(val, struct_sets, var_types, fn_returns), railway_rw(body, struct_sets, var_types, fn_returns)),
+    ELetRec(name, val, body) => ELetRec(name, railway_rw(val, struct_sets, var_types, fn_returns, changed), railway_rw(body, struct_sets, var_types, fn_returns, changed)),
     ELetMut(name, val, body, soff) => {
-      let new_val = railway_rw(val, struct_sets, var_types, fn_returns)
+      let new_val = railway_rw(val, struct_sets, var_types, fn_returns, changed)
       let body_vars = extend_var_types(var_types, name, anon_or_infer(val, struct_sets, var_types, fn_returns))
-      ELetMut(name, new_val, railway_rw(body, struct_sets, body_vars, fn_returns), soff)
+      ELetMut(name, new_val, railway_rw(body, struct_sets, body_vars, fn_returns, changed), soff)
     },
-    EAssign(name, val, cont) => EAssign(name, railway_rw(val, struct_sets, var_types, fn_returns), railway_rw(cont, struct_sets, var_types, fn_returns)),
-    EAssignOp(name, op, val, cont) => EAssignOp(name, op, railway_rw(val, struct_sets, var_types, fn_returns), railway_rw(cont, struct_sets, var_types, fn_returns)),
-    ESeq(a, b) => ESeq(railway_rw(a, struct_sets, var_types, fn_returns), railway_rw(b, struct_sets, var_types, fn_returns)),
+    EAssign(name, val, cont) => EAssign(name, railway_rw(val, struct_sets, var_types, fn_returns, changed), railway_rw(cont, struct_sets, var_types, fn_returns, changed)),
+    EAssignOp(name, op, val, cont) => EAssignOp(name, op, railway_rw(val, struct_sets, var_types, fn_returns, changed), railway_rw(cont, struct_sets, var_types, fn_returns, changed)),
+    ESeq(a, b) => ESeq(railway_rw(a, struct_sets, var_types, fn_returns, changed), railway_rw(b, struct_sets, var_types, fn_returns, changed)),
     EMatch(scrut, arms) => {
       let out = array_empty()
       let mut i = 0
@@ -4204,45 +4243,55 @@ fn railway_rw(expr: Expr, struct_sets: Array[(String, Array[String])], var_types
         // checker, so the arm body's `binding.field` reads rewrite to
         // positional `__rec_field` here too.
         let arm_vars = arm_binder_var_types(scrut, p, var_types)
-        Array::push(out, (p, railway_rw(b, struct_sets, arm_vars, fn_returns)))
+        Array::push(out, (p, railway_rw(b, struct_sets, arm_vars, fn_returns, changed)))
         i = i + 1
       }
-      EMatch(railway_rw(scrut, struct_sets, var_types, fn_returns), out)
+      EMatch(railway_rw(scrut, struct_sets, var_types, fn_returns, changed), out)
     },
     EHandle(scrut, arms) => {
       let out = array_empty()
       let mut i = 0
       while i < Array::length(arms) {
         let (p, b) = Array::get(arms, i)
-        Array::push(out, (p, railway_rw(b, struct_sets, var_types, fn_returns)))
+        Array::push(out, (p, railway_rw(b, struct_sets, var_types, fn_returns, changed)))
         i = i + 1
       }
-      EHandle(railway_rw(scrut, struct_sets, var_types, fn_returns), out)
+      EHandle(railway_rw(scrut, struct_sets, var_types, fn_returns, changed), out)
     },
-    EWhile(c, b) => EWhile(railway_rw(c, struct_sets, var_types, fn_returns), railway_rw(b, struct_sets, var_types, fn_returns)),
+    EWhile(c, b) => EWhile(railway_rw(c, struct_sets, var_types, fn_returns, changed), railway_rw(b, struct_sets, var_types, fn_returns, changed)),
     ELoop(params, body) => ELoop(for param in params {
       let (name, init) = param
-      (name, railway_rw(init, struct_sets, var_types, fn_returns))
-    }, railway_rw(body, struct_sets, var_types, fn_returns)),
-    EForIn(name, idx, iter, body) => EForIn(name, idx, railway_rw(iter, struct_sets, var_types, fn_returns), railway_rw(body, struct_sets, var_types, fn_returns)),
-    EBinOp(op, l, r) => EBinOp(op, railway_rw(l, struct_sets, var_types, fn_returns), railway_rw(r, struct_sets, var_types, fn_returns)),
-    EUnaryOp(op, e) => EUnaryOp(op, railway_rw(e, struct_sets, var_types, fn_returns)),
-    EFn(tp, bs, ps, ret, eff, body) => EFn(tp, bs, ps, ret, eff, railway_rw(body, struct_sets, seed_var_types(ps, tp, var_types), fn_returns)),
+      (name, railway_rw(init, struct_sets, var_types, fn_returns, changed))
+    }, railway_rw(body, struct_sets, var_types, fn_returns, changed)),
+    EForIn(name, idx, iter, body) => EForIn(name, idx, railway_rw(iter, struct_sets, var_types, fn_returns, changed), railway_rw(body, struct_sets, var_types, fn_returns, changed)),
+    EBinOp(op, l, r) => EBinOp(op, railway_rw(l, struct_sets, var_types, fn_returns, changed), railway_rw(r, struct_sets, var_types, fn_returns, changed)),
+    EUnaryOp(op, e) => EUnaryOp(op, railway_rw(e, struct_sets, var_types, fn_returns, changed)),
+    EFn(tp, bs, ps, ret, eff, body) => EFn(tp, bs, ps, ret, eff, railway_rw(body, struct_sets, seed_var_types(ps, tp, var_types), fn_returns, changed)),
     EDot(obj, field, off, fdoff) => {
-      let robj = railway_rw(obj, struct_sets, var_types, fn_returns)
+      let robj = railway_rw(obj, struct_sets, var_types, fn_returns, changed)
       match anon_dot_rewrite(obj, field, off, robj, var_types) {
-        Some(rw) => rw,
+        Some(rw) => {
+          match changed {
+            Some(cell) => {
+              Array::set(cell, 0, true)
+            },
+            None => {
+              ()
+            }
+          }
+          rw
+        },
         None => EDot(robj, field, off, fdoff)
       }
     },
-    ELabeledArg(label, name, body) => ELabeledArg(label, name, railway_rw(body, struct_sets, var_types, fn_returns)),
-    EReturn(e) => EReturn(railway_rw(e, struct_sets, var_types, fn_returns)),
+    ELabeledArg(label, name, body) => ELabeledArg(label, name, railway_rw(body, struct_sets, var_types, fn_returns, changed)),
+    EReturn(e) => EReturn(railway_rw(e, struct_sets, var_types, fn_returns, changed)),
     EBreak(opt) => match opt {
-      Some(e) => EBreak(Some(railway_rw(e, struct_sets, var_types, fn_returns))),
+      Some(e) => EBreak(Some(railway_rw(e, struct_sets, var_types, fn_returns, changed))),
       None => expr
     },
     EContinue(exprs) => EContinue(for e in exprs {
-      railway_rw(e, struct_sets, var_types, fn_returns)
+      railway_rw(e, struct_sets, var_types, fn_returns, changed)
     })
   }
 }
@@ -4285,29 +4334,41 @@ fn collect_toplevel_anon_records(stmts: Array[Stmt], struct_sets: Array[(String,
 /// `collect_toplevel_anon_records` — so `EFn`/`ELet`'s existing var_types
 /// threading (which already covers a SINGLE statement's own nested scopes)
 /// extends across top-level statement boundaries too.
-fn railway_rw_stmt(s: Stmt, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)], toplevel_vars: Array[(String, String)]) -> Stmt {
+fn railway_rw_stmt(s: Stmt, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)], toplevel_vars: Array[(String, String)], changed: Option[Array[Bool]]) -> Stmt {
   match s {
-    SLet(exp, isrec, fname, ann, body) => SLet(exp, isrec, fname, ann, railway_rw(body, struct_sets, toplevel_vars, fn_returns)),
-    SLetMut(name, ty, e) => SLetMut(name, ty, railway_rw(e, struct_sets, toplevel_vars, fn_returns)),
-    STest(name, body) => STest(name, railway_rw(body, struct_sets, toplevel_vars, fn_returns)),
-    SBench(name, body) => SBench(name, railway_rw(body, struct_sets, toplevel_vars, fn_returns)),
-    SExpr(e) => SExpr(railway_rw(e, struct_sets, toplevel_vars, fn_returns)),
+    SLet(exp, isrec, fname, ann, body) => SLet(exp, isrec, fname, ann, railway_rw(body, struct_sets, toplevel_vars, fn_returns, changed)),
+    SLetMut(name, ty, e) => SLetMut(name, ty, railway_rw(e, struct_sets, toplevel_vars, fn_returns, changed)),
+    STest(name, body) => STest(name, railway_rw(body, struct_sets, toplevel_vars, fn_returns, changed)),
+    SBench(name, body) => SBench(name, railway_rw(body, struct_sets, toplevel_vars, fn_returns, changed)),
+    SExpr(e) => SExpr(railway_rw(e, struct_sets, toplevel_vars, fn_returns, changed)),
     SModule(exp, name, body) => SModule(exp, name, for inner in body {
-      railway_rw_stmt(inner, struct_sets, fn_returns, toplevel_vars)
+      railway_rw_stmt(inner, struct_sets, fn_returns, toplevel_vars, changed)
     }),
     _ => s
   }
 }
 
-export fn desugar_railway_binds(stmts: Array[Stmt]) -> Unit {
+fn desugar_railway_binds_impl(stmts: Array[Stmt], changed: Option[Array[Bool]]) -> Unit {
   let struct_sets = collect_struct_field_sets(stmts)
   let fn_returns = collect_fn_returns(stmts)
   let toplevel_vars = collect_toplevel_anon_records(stmts, struct_sets)
   let mut i = 0
   while i < Array::length(stmts) {
-    Array::set(stmts, i, railway_rw_stmt(Array::get(stmts, i), struct_sets, fn_returns, toplevel_vars))
+    Array::set(stmts, i, railway_rw_stmt(Array::get(stmts, i), struct_sets, fn_returns, toplevel_vars, changed))
     i = i + 1
   }
+}
+
+export fn desugar_railway_binds_reporting_change(stmts: Array[Stmt]) -> Bool {
+  let changed = [
+    false
+  ]
+  desugar_railway_binds_impl(stmts, Some(changed))
+  Array::get(changed, 0)
+}
+
+export fn desugar_railway_binds(stmts: Array[Stmt]) -> Unit {
+  desugar_railway_binds_impl(stmts, None)
 }
 
 // ---- #1392: string interpolation renders a derive(Show) value structurally ----
@@ -10756,7 +10817,8 @@ fn dinsp_mentions_binder(expr: Expr) -> Bool {
 ///
 /// Only statements that actually contain an `inspect(..)` call are rebuilt --
 /// see dinsp_uses for why that guard is load-bearing rather than cosmetic.
-export fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit {
+export fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool {
+  let mut changed = false
   if dinsp_binds_inspect(stmts) {
     ()
   } else {
@@ -10765,12 +10827,19 @@ export fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit {
       let stmt = Array::get(stmts, i)
       if dinsp_stmt_uses(stmt) {
         Array::set(stmts, i, dinsp_stmt(stmt))
+        changed = true
       } else {
         ()
       }
       i = i + 1
     }
   }
+  changed
+}
+
+export fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit {
+  let _changed = desugar_inspect_calls_reporting_change(stmts)
+  ()
 }
 
 /// In-place labeled-argument reordering over a whole program. Rebuilds only the

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -46,6 +46,7 @@ fn normalize_dot_calls(stmts: Array[Stmt]) -> Array[Stmt]
 // verbatim from codegen/common_base; common_base re-exports these contracts for
 // source compatibility with existing codegen callers.
 fn inject_trait_method_generics(stmts: Array[Stmt]) -> Unit
+fn inject_trait_method_generics_reporting_change(stmts: Array[Stmt]) -> Bool
 // #1858: checker-facing mirror of build_gens' witness-threading capability —
 // a bounded generic whose body references `T::m` without a witness-carrying
 // parameter is reported here instead of ICE-ing in codegen.
@@ -54,6 +55,7 @@ fn exn_kind_read_expr() -> Expr
 fn exn_msg_read_expr() -> Expr
 fn ensure_exn_kind_cell(stmts: Array[Stmt]) -> Unit
 fn desugar_railway_binds(stmts: Array[Stmt]) -> Unit
+fn desugar_railway_binds_reporting_change(stmts: Array[Stmt]) -> Bool
 fn desugar_derives(stmts: Array[Stmt]) -> Unit
 fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit
 fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit
@@ -71,6 +73,7 @@ fn normalized_program_binder_authority_nodes(authority: NormalizedProgramBinderA
 // `assert_true` form BEFORE checking, so the snapshot assertion needs no
 // import and every pre-codegen scan sees ordinary calls.
 fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit
+fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool
 fn desugar_array_spread(stmts: Array[Stmt]) -> Unit
 fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception
 

--- a/lib/@vibe/compiler/tests/normalize_transform_change_status_test.vibe
+++ b/lib/@vibe/compiler/tests/normalize_transform_change_status_test.vibe
@@ -1,12 +1,19 @@
 //# Imports
 
+import @vibe/compiler/checker {
+  check_program
+}
+
 import @vibe/compiler/core {
-  Stmt
+  Expr, Stmt, expr_children
 }
 
 import @vibe/compiler/normalize {
+  desugar_inspect_calls,
   desugar_inspect_calls_reporting_change,
+  desugar_railway_binds,
   desugar_railway_binds_reporting_change,
+  inject_trait_method_generics,
   inject_trait_method_generics_reporting_change
 }
 
@@ -20,6 +27,89 @@ fn parse(source: String) -> Array[Stmt] with Exception {
   parse_program(lex(source))
 }
 
+fn first_check_error(stmts: Array[Stmt]) -> String {
+  handle {
+    let _ = check_program(stmts)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+fn expr_contains_call(expr: Expr, expected: String) -> Bool {
+  let direct = match expr {
+    ECall(EIdent(name, _), _, _) => name == expected,
+    _ => false
+  }
+  if direct {
+    true
+  } else {
+    let mut found = false
+    for child in expr_children(expr) {
+      if expr_contains_call(child, expected) {
+        found = true
+      }
+    }
+    found
+  }
+}
+
+fn expr_contains_match(expr: Expr) -> Bool {
+  let direct = match expr {
+    EMatch(_, _) => true,
+    _ => false
+  }
+  if direct {
+    true
+  } else {
+    let mut found = false
+    for child in expr_children(expr) {
+      if expr_contains_match(child) {
+        found = true
+      }
+    }
+    found
+  }
+}
+
+fn program_contains_call(stmts: Array[Stmt], expected: String) -> Bool {
+  let mut found = false
+  for stmt in stmts {
+    match stmt {
+      SLet(_, _, _, _, value) => if expr_contains_call(value, expected) {
+        found = true
+      },
+      SLetMut(_, _, value) => if expr_contains_call(value, expected) {
+        found = true
+      },
+      SExpr(value) => if expr_contains_call(value, expected) {
+        found = true
+      },
+      _ => ()
+    }
+  }
+  found
+}
+
+fn program_contains_match(stmts: Array[Stmt]) -> Bool {
+  let mut found = false
+  for stmt in stmts {
+    match stmt {
+      SLet(_, _, _, _, value) => if expr_contains_match(value) {
+        found = true
+      },
+      SLetMut(_, _, value) => if expr_contains_match(value) {
+        found = true
+      },
+      SExpr(value) => if expr_contains_match(value) {
+        found = true
+      },
+      _ => ()
+    }
+  }
+  found
+}
+
 //# Tests
 
 test "transform status is false when every transform is inert" {
@@ -29,10 +119,41 @@ test "transform status is false when every transform is inert" {
   inspect(desugar_inspect_calls_reporting_change(stmts), "false")
 }
 
-test "railway status changes only on the exact rewrite invocation" {
+test "railway bind status changes only on the exact rewrite invocation" {
   let stmts = parse("let main = () -> { let* x = Some(1); x }")
   inspect(desugar_railway_binds_reporting_change(stmts), "true")
+  inspect(program_contains_call(stmts, "__try_bind"), "false")
+  inspect(program_contains_match(stmts), "true")
   inspect(desugar_railway_binds_reporting_change(stmts), "false")
+}
+
+test "railway try-op reports the exact production rewrite" {
+  let stmts = parse("let unwrap = (x: Option[Int]) -> Option[Int] { Some(x?) }")
+  inspect(desugar_railway_binds_reporting_change(stmts), "true")
+  inspect(program_contains_call(stmts, "__try_op"), "false")
+  inspect(program_contains_match(stmts), "true")
+  inspect(desugar_railway_binds_reporting_change(stmts), "false")
+}
+
+test "map index reports the exact production rewrite" {
+  let stmts = parse("let main = () -> Int { let m: Map[String, Int] = Map::from_pairs([(\"a\", 1)]); m[\"a\"] }")
+  inspect(desugar_railway_binds_reporting_change(stmts), "true")
+  inspect(program_contains_call(stmts, "__index"), "false")
+  inspect(program_contains_call(stmts, "Map::get"), "true")
+  inspect(desugar_railway_binds_reporting_change(stmts), "false")
+}
+
+test "malformed and wrong-arity railway sentinels stay inert" {
+  let bind_missing = parse("let main = () -> { __try_bind(Some(1)) }")
+  inspect(desugar_railway_binds_reporting_change(bind_missing), "false")
+  let bind_non_closure = parse("let main = () -> { __try_bind(Some(1), 2) }")
+  inspect(desugar_railway_binds_reporting_change(bind_non_closure), "false")
+  let bind_wrong_params = parse("let main = () -> { __try_bind(Some(1), (x, y) -> { x }) }")
+  inspect(desugar_railway_binds_reporting_change(bind_wrong_params), "false")
+  let op_missing = parse("let main = () -> { __try_op() }")
+  inspect(desugar_railway_binds_reporting_change(op_missing), "false")
+  let op_extra = parse("let main = () -> { __try_op(Some(1), Some(2)) }")
+  inspect(desugar_railway_binds_reporting_change(op_extra), "false")
 }
 
 test "anonymous record projection reports the exact railway rewrite" {
@@ -57,4 +178,68 @@ test "trait generic injection reports its exact write and then idempotence" {
   let stmts = parse(source)
   inspect(inject_trait_method_generics_reporting_change(stmts), "true")
   inspect(inject_trait_method_generics_reporting_change(stmts), "false")
+}
+
+test "wrapper-rewrite parity uses the same production fixed points" {
+  let trait_source = "trait Show { show(Self) -> String }\ntrait Logger { write_object: [X: Show](Self, X) -> String }\nstruct Box { value: Int }\nimpl Logger for Box { write_object(self, x) -> String { X::show(x) } }"
+  let trait_ordinary = parse(trait_source)
+  let trait_reporting = parse(trait_source)
+  inject_trait_method_generics(trait_ordinary)
+  inspect(inject_trait_method_generics_reporting_change(trait_ordinary), "false")
+  inspect(inject_trait_method_generics_reporting_change(trait_reporting), "true")
+  inspect(inject_trait_method_generics_reporting_change(trait_reporting), "false")
+  let railway_source = "let unwrap = (x: Option[Int]) -> Option[Int] { Some(x?) }"
+  let railway_ordinary = parse(railway_source)
+  let railway_reporting = parse(railway_source)
+  desugar_railway_binds(railway_ordinary)
+  inspect(desugar_railway_binds_reporting_change(railway_ordinary), "false")
+  inspect(program_contains_call(railway_ordinary, "__try_op"), "false")
+  inspect(program_contains_match(railway_ordinary), "true")
+  inspect(desugar_railway_binds_reporting_change(railway_reporting), "true")
+  inspect(program_contains_call(railway_reporting, "__try_op"), "false")
+  inspect(program_contains_match(railway_reporting), "true")
+  inspect(desugar_railway_binds_reporting_change(railway_reporting), "false")
+  let inspect_source = "let main = () -> { inspect(1, \"1\") }"
+  let inspect_ordinary = parse(inspect_source)
+  let inspect_reporting = parse(inspect_source)
+  desugar_inspect_calls(inspect_ordinary)
+  inspect(desugar_inspect_calls_reporting_change(inspect_ordinary), "false")
+  inspect(desugar_inspect_calls_reporting_change(inspect_reporting), "true")
+  inspect(desugar_inspect_calls_reporting_change(inspect_reporting), "false")
+}
+
+test "wrapper-inert parity remains unchanged" {
+  let source = "let main = () -> { 1 }"
+  let trait_ordinary = parse(source)
+  let trait_reporting = parse(source)
+  inject_trait_method_generics(trait_ordinary)
+  inspect(inject_trait_method_generics_reporting_change(trait_ordinary), "false")
+  inspect(inject_trait_method_generics_reporting_change(trait_reporting), "false")
+  let railway_ordinary = parse(source)
+  let railway_reporting = parse(source)
+  desugar_railway_binds(railway_ordinary)
+  inspect(desugar_railway_binds_reporting_change(railway_ordinary), "false")
+  inspect(desugar_railway_binds_reporting_change(railway_reporting), "false")
+  let inspect_ordinary = parse(source)
+  let inspect_reporting = parse(source)
+  desugar_inspect_calls(inspect_ordinary)
+  inspect(desugar_inspect_calls_reporting_change(inspect_ordinary), "false")
+  inspect(desugar_inspect_calls_reporting_change(inspect_reporting), "false")
+}
+
+test "checker diagnostic parity matches pre-reported inert and railway inputs" {
+  let inert_source = "let main = () -> Int { \"not an int\" }"
+  let inert_ordinary = parse(inert_source)
+  let inert_pre_reported = parse(inert_source)
+  inspect(desugar_railway_binds_reporting_change(inert_pre_reported), "false")
+  let inert_message = first_check_error(inert_ordinary)
+  inspect(inert_message != "", "true")
+  inspect(inert_message == first_check_error(inert_pre_reported), "true")
+  let railway_source = "let bad = (x: Option[String]) -> Option[Int] { Some(x?) }"
+  let railway_ordinary = parse(railway_source)
+  let railway_pre_reported = parse(railway_source)
+  inspect(desugar_railway_binds_reporting_change(railway_pre_reported), "true")
+  let railway_message = first_check_error(railway_ordinary)
+  inspect(railway_message != "", "true")
+  inspect(railway_message == first_check_error(railway_pre_reported), "true")
 }

--- a/lib/@vibe/compiler/tests/normalize_transform_change_status_test.vibe
+++ b/lib/@vibe/compiler/tests/normalize_transform_change_status_test.vibe
@@ -1,0 +1,60 @@
+//# Imports
+
+import @vibe/compiler/core {
+  Stmt
+}
+
+import @vibe/compiler/normalize {
+  desugar_inspect_calls_reporting_change,
+  desugar_railway_binds_reporting_change,
+  inject_trait_method_generics_reporting_change
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Helpers
+
+fn parse(source: String) -> Array[Stmt] with Exception {
+  parse_program(lex(source))
+}
+
+//# Tests
+
+test "transform status is false when every transform is inert" {
+  let stmts = parse("let main = () -> { 1 }")
+  inspect(inject_trait_method_generics_reporting_change(stmts), "false")
+  inspect(desugar_railway_binds_reporting_change(stmts), "false")
+  inspect(desugar_inspect_calls_reporting_change(stmts), "false")
+}
+
+test "railway status changes only on the exact rewrite invocation" {
+  let stmts = parse("let main = () -> { let* x = Some(1); x }")
+  inspect(desugar_railway_binds_reporting_change(stmts), "true")
+  inspect(desugar_railway_binds_reporting_change(stmts), "false")
+}
+
+test "anonymous record projection reports the exact railway rewrite" {
+  let stmts = parse("let main = () -> { let r = record { name: \"vibe\" }; r.name }")
+  inspect(desugar_railway_binds_reporting_change(stmts), "true")
+  inspect(desugar_railway_binds_reporting_change(stmts), "false")
+}
+
+test "inspect status changes only when inspect lowering writes a statement" {
+  let stmts = parse("let main = () -> { inspect(1, \"1\") }")
+  inspect(desugar_inspect_calls_reporting_change(stmts), "true")
+  inspect(desugar_inspect_calls_reporting_change(stmts), "false")
+}
+
+test "bound inspect remains inert and reports unchanged" {
+  let stmts = parse("let inspect = (x, expected) -> { x }; let main = () -> { inspect(1, \"1\") }")
+  inspect(desugar_inspect_calls_reporting_change(stmts), "false")
+}
+
+test "trait generic injection reports its exact write and then idempotence" {
+  let source = "trait Show { show(Self) -> String }\ntrait Logger { write_object: [X: Show](Self, X) -> String }\nstruct Box { value: Int }\nimpl Logger for Box { write_object(self, x) -> String { X::show(x) } }"
+  let stmts = parse(source)
+  inspect(inject_trait_method_generics_reporting_change(stmts), "true")
+  inspect(inject_trait_method_generics_reporting_change(stmts), "false")
+}


### PR DESCRIPTION
## Summary

- add exact same-control-flow changed/inert reporting for checker prefix transforms
- report trait-generic injection, railway lowering, and inspect lowering from the exact production write branches
- keep stdin alias reporting private to the checker
- preserve existing Unit APIs and production transform/diagnostic ordering
- add production-oracle coverage for successful, inert, malformed, idempotent, wrapper-parity, and diagnostic-parity cases

This is a bounded prerequisite for checker occurrence provenance. It does **not** expose a partial provenance observation or change TypeEnv/public persistence.

## Safety properties

- no AST equality comparison, replay, post-pass, or second status scan
- no module-global status
- ordinary railway normalization passes `None` and allocates no status cell
- reporting railway mode uses one invocation-local sticky cell
- `false` means no supported production rewrite branch executed
- malformed/wrong-arity railway sentinels remain inert
- no public stdin reporting API
- existing labeled-authority and scalar-compaction architecture remains separate

## Validation

Independently reproduced on exact range `dc2c666e..3d87daf`:

- focused suite: **7 files / 57 tests**
- full unit suite: **666 / 666 files**
- structural parser/normalizer checks: passed
- allocation rows: **1,908 / 4,764 / 98,912 / 116,128 B/op**
- stage2 == stage3: `932f15ea20cdef204259db10d33d16eca792a52d9b6dd71ec9c843a6255b9759`
- selfcompile heap: **1,077,965,968**, 10,857,672 below cap
- exact-parent diagnostics/stdout/stderr/exits: 3 / 3 identical
- generated freshness and formatter: passed
- compiler gate passes through gate 91 and reaches gate 92; local macOS BSD `xargs` then hits the known command-size limitation
