### PR TITLE
Stop two checks from answering about something they did not check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -600,6 +600,46 @@ pkf run test-local -- --profile scheduled   # 全テスト (データ蓄積用)
 
 `pkf run test` は全テスト実行。commit 前の最終確認や CI 用。
 
+### Which compiler answered? — `vibe test` runs on the seed by default
+
+`scripts/vibe_test.sh` compiles with the **committed seed**
+(`cli_wasm="${VIBE_TEST_CLI_WASM:-$seed}"`), not with the compiler sources in
+your checkout. That default is right for library code and wrong for a change to
+the compiler, and **the two are indistinguishable from the result** — the file
+compiles, the tests run, and you get a confident answer about a compiler that
+does not contain your change.
+
+A measured instance, one file, `x - y` through a labeled-argument lambda:
+
+| compiler | result |
+|---|---:|
+| committed seed | 0 — a bug fixed in #1925 |
+| stage2 from the same checkout | -7 — the still-open half of #1899 |
+
+Neither run reports an error. So: **when you are testing a compiler change, pass
+the compiler explicitly.**
+
+```bash
+VIBE_TEST_CLI_WASM=_build/selfhost/generations/<gen>_$(git rev-parse --short HEAD)/stage2.wasm \
+  bash scripts/vibe_test.sh <file>
+```
+
+`vibe_test.sh` now prints a stderr notice whenever the checkout is ahead of the
+seed under `lib/@vibe/compiler|cli` and no explicit compiler was given
+(suppressed by setting `VIBE_TEST_CLI_WASM`, or by
+`VIBE_TEST_QUIET_COMPILER_NOTE=1`). Pinned by `scripts/vibe_test_smoke.sh`
+(`pkf run test-vibe-test`).
+
+Two related rules, both learned the same way:
+
+- **Establish the baseline before changing anything.** Run the failing case
+  first and confirm it reproduces *through the compiler you are about to
+  rebuild*. If it does not reproduce, you are measuring the wrong compiler, not
+  looking at a fixed bug.
+- **Never test argument order with a commutative operator.** `x + y` gives the
+  right answer whether or not arguments were reordered; use `x - y`. A
+  reordering bug survived a "fix verified" claim this way (#1899).
+
 ## Before Commit
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -625,7 +625,7 @@ VIBE_TEST_CLI_WASM=_build/selfhost/generations/<gen>_$(git rev-parse --short HEA
 ```
 
 `vibe_test.sh` now prints a stderr notice whenever the checkout is ahead of the
-seed under `lib/@vibe/compiler|cli` and no explicit compiler was given
+seed under `lib/@vibe|@vibex` and no explicit compiler was given
 (suppressed by setting `VIBE_TEST_CLI_WASM`, or by
 `VIBE_TEST_QUIET_COMPILER_NOTE=1`). Pinned by `scripts/vibe_test_smoke.sh`
 (`pkf run test-vibe-test`).

--- a/scripts/build_cli_wasm.sh
+++ b/scripts/build_cli_wasm.sh
@@ -27,7 +27,10 @@ out="${1:-$ROOT_DIR/dist/cli/vibe-cli.wasm}"
 mkdir -p "$(dirname "$out")"
 
 sha256_file() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum "$1" | cut -d' ' -f1
   else
     shasum -a 256 "$1" | awk '{print $1}'

--- a/scripts/build_compiler_seed_assets.sh
+++ b/scripts/build_compiler_seed_assets.sh
@@ -26,9 +26,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 sha256_file() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum "$1" | cut -d' ' -f1
-  elif command -v shasum >/dev/null 2>&1; then
+  elif shasum -a 256 </dev/null >/dev/null 2>&1; then
     shasum -a 256 "$1" | awk '{print $1}'
   else
     echo "build-compiler-seed-assets: sha256sum or shasum is required" >&2

--- a/scripts/build_release_assets.sh
+++ b/scripts/build_release_assets.sh
@@ -73,7 +73,10 @@ rm -f "$compiler_fragment"
 
 (
   cd "$OUT_DIR"
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" "$MANIFEST_NAME" \
       > "$CHECKSUM_NAME"
   else

--- a/scripts/build_seed_release_assets.sh
+++ b/scripts/build_seed_release_assets.sh
@@ -74,7 +74,10 @@ rm -f "$compiler_fragment"
 
 (
   cd "$OUT_DIR"
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" "$MANIFEST_NAME" \
       > "$CHECKSUM_NAME"
   else

--- a/scripts/ensure_seed.sh
+++ b/scripts/ensure_seed.sh
@@ -30,9 +30,12 @@ PROJECT_ROOT="${VIBE_PROJECT_ROOT:-$(dirname "$SCRIPT_DIR")}"
 die() { echo "ensure-seed: $*" >&2; exit 1; }
 
 sha256_file() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum "$1" | cut -d' ' -f1
-  elif command -v shasum >/dev/null 2>&1; then
+  elif shasum -a 256 </dev/null >/dev/null 2>&1; then
     shasum -a 256 "$1" | awk '{print $1}'
   else
     die "sha256sum or shasum is required"

--- a/scripts/fetch_compiler.sh
+++ b/scripts/fetch_compiler.sh
@@ -44,9 +44,12 @@ PROJECT_ROOT="${VIBE_PROJECT_ROOT:-$(dirname "$SCRIPT_DIR")}"
 die() { echo "fetch-compiler: $*" >&2; exit 1; }
 
 sha256_file() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum "$1" | cut -d' ' -f1
-  elif command -v shasum >/dev/null 2>&1; then
+  elif shasum -a 256 </dev/null >/dev/null 2>&1; then
     shasum -a 256 "$1" | awk '{print $1}'
   else
     die "sha256sum or shasum is required"

--- a/scripts/generate_bundle.sh
+++ b/scripts/generate_bundle.sh
@@ -91,7 +91,10 @@ CODEGEN_FP_FILE="$COMPILER_DIR/cache/codegen_fingerprint.vibe"
 # `shasum`). Both print the hash first, so `cut -c1-16` yields the same 16 hex
 # chars on either — the fingerprint value is unchanged.
 sha256_stdin() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum
   else
     shasum -a 256

--- a/scripts/generations.sh
+++ b/scripts/generations.sh
@@ -90,9 +90,12 @@ die_compile() {
 }
 
 sha256_file() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum "$1" | cut -d' ' -f1
-  elif command -v shasum >/dev/null 2>&1; then
+  elif shasum -a 256 </dev/null >/dev/null 2>&1; then
     shasum -a 256 "$1" | awk '{print $1}'
   else
     die "sha256sum or shasum is required"

--- a/scripts/measure_fs_heap.sh
+++ b/scripts/measure_fs_heap.sh
@@ -159,7 +159,10 @@ case "$BACKEND" in
 esac
 
 sha256_file() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum "$1" | awk '{print $1}'
   else
     shasum -a 256 "$1" | awk '{print $1}'
@@ -167,7 +170,10 @@ sha256_file() {
 }
 
 sha256_stream() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum | awk '{print $1}'
   else
     shasum -a 256 | awk '{print $1}'

--- a/scripts/vibe_md.vibex
+++ b/scripts/vibe_md.vibex
@@ -496,7 +496,10 @@ fn doctest_no_cache() -> Bool with Env {
 // same fallback runtime/vibe's own `_sha256_file` uses for the `vibe test`
 // pure-test cache.
 fn sha256_file(path: String) -> String with Process {
-  let cmd = "if command -v sha256sum >/dev/null 2>&1; then sha256sum \{shq(path)} | cut -d' ' -f1; else shasum -a 256 \{shq(path)} | awk '{print $1}'; fi"
+  // Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is
+  // on PATH but dies on a glibc mismatch passes an existence check and then
+  // fails every call, so the fallback never engages.
+  let cmd = "if sha256sum </dev/null >/dev/null 2>&1; then sha256sum \{shq(path)} | cut -d' ' -f1; else shasum -a 256 \{shq(path)} | awk '{print $1}'; fi"
   let r = sh_capture(cmd)
   String::trim(r.stdout)
 }

--- a/scripts/vibe_pkg.sh
+++ b/scripts/vibe_pkg.sh
@@ -154,7 +154,10 @@ pkg_hash_of() {
 # RFC6962, so proofs transfer 1:1 to a future @vibe/core verifier.)
 
 _sha256_stdin() {
-  if command -v sha256sum >/dev/null 2>&1; then
+  # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
+  # PATH but dies on a glibc mismatch passes an existence check and then fails
+  # every call, so the fallback never engages and the caller dies instead.
+  if sha256sum </dev/null >/dev/null 2>&1; then
     sha256sum | cut -d' ' -f1
   else
     shasum -a 256 | awk '{print $1}'

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -95,9 +95,29 @@ try:
     print(json.load(open(sys.argv[1]))["seed"].get("source_commit", ""))
 except Exception:
     print("")' "$ROOT_DIR/bootstrap/seed.json" 2>/dev/null || true)"
-  # Only compiler/CLI sources matter here: a seed that is behind on docs or
-  # fixtures compiles this checkout's test files exactly as a current one would.
-  compiler_paths=(lib/@vibe/compiler lib/@vibe/cli)
+  # Over-approximate the compiler's inputs, for the reason
+  # scripts/ensure_generated.sh:117 already gives about its own fingerprint:
+  # the flatten walks cli_adapter.vibe's entire import closure, which reaches
+  # well past lib/@vibe/compiler. compiler_sources_manifest.tsv lists
+  # @vibe/ast, parser, core, cache, graph, json and lsp as compiler sources,
+  # so a change confined to lib/@vibe/parser/lexer.vibe is a compiler change
+  # that lib/@vibe/compiler|cli cannot see. Over-approximating costs an
+  # occasional notice on a library-only edit; under-approximating stays silent
+  # for exactly the case this notice exists to catch.
+  #
+  # No exclusion list. ensure_generated.sh needs one because it hashes the
+  # working tree directly; git does not, and the two things that would have
+  # been on it are already handled:
+  #
+  #   - the five build outputs are gitignored (.gitignore:57-61), so they
+  #     cannot show up as uncommitted;
+  #   - tests and benches would only ever inflate the commit count, and the
+  #     notice reports "you are ahead", not a precise figure.
+  #
+  # Measured over the current seed window, excluding them changes 44 to 44 --
+  # while narrowing to lib/@vibe/compiler|cli changes it to 42, which is the
+  # under-approximation this notice exists to avoid.
+  compiler_paths=(lib/@vibe lib/@vibex)
   behind=""
   if [ -n "$seed_src_commit" ] && \
     git -C "$ROOT_DIR" cat-file -e "$seed_src_commit^{commit}" 2>/dev/null; then
@@ -115,7 +135,7 @@ except Exception:
       [ -n "$gap" ] && gap="$gap and "
       gap="$gap$dirty uncommitted file(s)"
     fi
-    echo "[vibe-test] compiler: the committed seed -- $gap ahead of it under lib/@vibe/compiler|cli." >&2
+    echo "[vibe-test] compiler: the committed seed -- $gap ahead of it under lib/@vibe|@vibex." >&2
     echo "[vibe-test]   This run CANNOT observe those changes; a green result here says nothing about them." >&2
     echo "[vibe-test]   To test this checkout's compiler:" >&2
     echo "[vibe-test]     VIBE_TEST_CLI_WASM=_build/selfhost/generations/<gen>_\$(git rev-parse --short HEAD)/stage2.wasm" >&2

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -72,6 +72,56 @@ if [ ! -f "$cli_wasm" ]; then
   fi
   exit 2
 fi
+
+# Say, up front, which compiler answered -- and whether that compiler is older
+# than the compiler sources in this checkout.
+#
+# The seed default is right for testing library code and wrong for testing a
+# change to the compiler, and the two are indistinguishable from the result.
+# There is already a note for this below, but it fires only when a file FAILS
+# to compile. The dangerous case is the opposite one: the file compiles, the
+# tests run, and the seed returns a confident answer about a compiler that does
+# not contain your change. Measured instance, one file, `x - y` through a
+# labeled-argument lambda: the seed says 0 (a bug fixed in #1925) and a stage2
+# built from the same checkout says -7 (#1899). Neither run reports an error.
+# Nothing in the output distinguished them, so the wrong one was believed --
+# and the same mistake had already been made twice in that session.
+#
+# `[ensure-seed] ... bootstrap/seed/compiler.wasm` is printed above and is not
+# enough: it names the file without saying that the file is behind.
+if [ -z "${VIBE_TEST_CLI_WASM:-}" ] && [ "${VIBE_TEST_QUIET_COMPILER_NOTE:-0}" != "1" ]; then
+  seed_src_commit="$(python3 -c 'import json,sys
+try:
+    print(json.load(open(sys.argv[1]))["seed"].get("source_commit", ""))
+except Exception:
+    print("")' "$ROOT_DIR/bootstrap/seed.json" 2>/dev/null || true)"
+  # Only compiler/CLI sources matter here: a seed that is behind on docs or
+  # fixtures compiles this checkout's test files exactly as a current one would.
+  compiler_paths=(lib/@vibe/compiler lib/@vibe/cli)
+  behind=""
+  if [ -n "$seed_src_commit" ] && \
+    git -C "$ROOT_DIR" cat-file -e "$seed_src_commit^{commit}" 2>/dev/null; then
+    behind="$(git -C "$ROOT_DIR" rev-list --count "$seed_src_commit"..HEAD \
+      -- "${compiler_paths[@]}" 2>/dev/null || true)"
+  fi
+  # Uncommitted edits count too, and are the case where the gap is likeliest to
+  # be the thing under test.
+  dirty="$(git -C "$ROOT_DIR" status --porcelain -- "${compiler_paths[@]}" 2>/dev/null \
+    | wc -l | tr -d ' ')"
+  if [ "${behind:-0}" != "0" ] || [ "${dirty:-0}" != "0" ]; then
+    gap=""
+    [ "${behind:-0}" != "0" ] && gap="$behind commit(s)"
+    if [ "${dirty:-0}" != "0" ]; then
+      [ -n "$gap" ] && gap="$gap and "
+      gap="$gap$dirty uncommitted file(s)"
+    fi
+    echo "[vibe-test] compiler: the committed seed -- $gap ahead of it under lib/@vibe/compiler|cli." >&2
+    echo "[vibe-test]   This run CANNOT observe those changes; a green result here says nothing about them." >&2
+    echo "[vibe-test]   To test this checkout's compiler:" >&2
+    echo "[vibe-test]     VIBE_TEST_CLI_WASM=_build/selfhost/generations/<gen>_\$(git rev-parse --short HEAD)/stage2.wasm" >&2
+  fi
+fi
+
 covdir="$outdir/coverage"
 if [ "$coverage" = "1" ]; then
   mkdir -p "$covdir"

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -21,3 +21,64 @@ if bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/fail_test.vibe" >/dev/null 2>&1;
 fi
 
 echo "[vibe-test-smoke] ok (pass-file=0, fail-file!=0)"
+
+# The seed-compiler notice. A green run through the committed seed says nothing
+# about a compiler change in this checkout, and the two are indistinguishable
+# from the result -- so the run has to say which compiler answered whenever the
+# checkout is ahead of the seed under lib/@vibe/compiler|cli. It goes to stderr
+# so nothing parsing stdout is affected, and it must not turn a passing file
+# into a failing one.
+seed_src_commit="$(python3 -c 'import json,sys
+try:
+    print(json.load(open(sys.argv[1]))["seed"].get("source_commit", ""))
+except Exception:
+    print("")' "$ROOT_DIR/bootstrap/seed.json" 2>/dev/null || true)"
+ahead=0
+if [ -n "$seed_src_commit" ] && git cat-file -e "$seed_src_commit^{commit}" 2>/dev/null; then
+  n="$(git rev-list --count "$seed_src_commit"..HEAD -- lib/@vibe/compiler lib/@vibe/cli 2>/dev/null || echo 0)"
+  [ "${n:-0}" != "0" ] && ahead=1
+fi
+if [ "$(git status --porcelain -- lib/@vibe/compiler lib/@vibe/cli 2>/dev/null | wc -l | tr -d ' ')" != "0" ]; then
+  ahead=1
+fi
+
+notice_err="$WORK/notice.stderr"
+if ! bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/pass_test.vibe" >/dev/null 2>"$notice_err"; then
+  echo "[vibe-test-smoke] FAIL: the compiler notice must not fail a passing file" >&2
+  cat "$notice_err" >&2
+  exit 1
+fi
+if [ "$ahead" = "1" ]; then
+  if ! rg -q "compiler: the committed seed" "$notice_err"; then
+    echo "[vibe-test-smoke] FAIL: checkout is ahead of the seed but no compiler notice was printed" >&2
+    cat "$notice_err" >&2
+    exit 1
+  fi
+  # Naming the file is not the point -- `[ensure-seed]` already does that. The
+  # notice exists to say the seed is BEHIND, and to give the way out.
+  if ! rg -q "CANNOT observe" "$notice_err" || ! rg -q "VIBE_TEST_CLI_WASM=" "$notice_err"; then
+    echo "[vibe-test-smoke] FAIL: the notice must state the consequence and the override" >&2
+    cat "$notice_err" >&2
+    exit 1
+  fi
+  # An explicit choice of compiler is not a mistake, and neither is an explicit
+  # request for quiet.
+  for silent_env in "VIBE_TEST_CLI_WASM=$ROOT_DIR/bootstrap/seed/compiler.wasm" \
+                    "VIBE_TEST_QUIET_COMPILER_NOTE=1"; do
+    if env "$silent_env" bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/pass_test.vibe" \
+        2>&1 >/dev/null | rg -q "compiler: the committed seed"; then
+      echo "[vibe-test-smoke] FAIL: notice printed despite $silent_env" >&2
+      exit 1
+    fi
+  done
+  echo "[vibe-test-smoke] ok (seed notice present, suppressed on explicit compiler/quiet)"
+else
+  # A checkout sitting exactly on the seed's compiler sources has nothing to
+  # warn about, and warning anyway would train the reader to ignore it.
+  if rg -q "compiler: the committed seed" "$notice_err"; then
+    echo "[vibe-test-smoke] FAIL: checkout matches the seed but the notice was printed" >&2
+    cat "$notice_err" >&2
+    exit 1
+  fi
+  echo "[vibe-test-smoke] ok (checkout matches the seed; no notice, as expected)"
+fi

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -38,10 +38,14 @@ echo "[vibe-test-smoke] ok (pass-file=0, fail-file!=0)"
 #
 # So the probe lives in lib/@vibe/parser on purpose: it is the case the
 # narrower predicate missed.
-PROBE="$ROOT_DIR/lib/@vibe/parser/_seed_gap_probe.vibe"
+PROBE="$ROOT_DIR/lib/@vibe/parser/_seed_gap_probe.tmp"
 cleanup_probe() { rm -f "$PROBE"; }
 trap 'cleanup_probe; rm -rf "$WORK"' EXIT
-printf '// transient: scripts/vibe_test_smoke.sh seed-gap probe\n' > "$PROBE"
+# Deliberately NOT a .vibe file. The pathspec filters by directory, not by
+# extension, so a .tmp exercises the same predicate -- while staying invisible
+# to every *.vibe glob in the tree (vibe-fmt-check lints lib/**/*.vibe), so a
+# task running beside this one cannot trip over it.
+printf 'transient: scripts/vibe_test_smoke.sh seed-gap probe\n' > "$PROBE"
 
 notice_err="$WORK/notice.stderr"
 if ! bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/pass_test.vibe" >/dev/null 2>"$notice_err"; then

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -25,22 +25,23 @@ echo "[vibe-test-smoke] ok (pass-file=0, fail-file!=0)"
 # The seed-compiler notice. A green run through the committed seed says nothing
 # about a compiler change in this checkout, and the two are indistinguishable
 # from the result -- so the run has to say which compiler answered whenever the
-# checkout is ahead of the seed under lib/@vibe/compiler|cli. It goes to stderr
-# so nothing parsing stdout is affected, and it must not turn a passing file
-# into a failing one.
-seed_src_commit="$(python3 -c 'import json,sys
-try:
-    print(json.load(open(sys.argv[1]))["seed"].get("source_commit", ""))
-except Exception:
-    print("")' "$ROOT_DIR/bootstrap/seed.json" 2>/dev/null || true)"
-ahead=0
-if [ -n "$seed_src_commit" ] && git cat-file -e "$seed_src_commit^{commit}" 2>/dev/null; then
-  n="$(git rev-list --count "$seed_src_commit"..HEAD -- lib/@vibe/compiler lib/@vibe/cli 2>/dev/null || echo 0)"
-  [ "${n:-0}" != "0" ] && ahead=1
-fi
-if [ "$(git status --porcelain -- lib/@vibe/compiler lib/@vibe/cli 2>/dev/null | wc -l | tr -d ' ')" != "0" ]; then
-  ahead=1
-fi
+# checkout is ahead of the seed. It goes to stderr so nothing parsing stdout is
+# affected, and it must not turn a passing file into a failing one.
+#
+# Probed BEHAVIOURALLY, with a file that makes the checkout ahead, rather than
+# by recomputing "is this checkout ahead?" here. An earlier version of this
+# test did recompute it, duplicating vibe_test.sh's path list -- which meant
+# the test agreed with the script by construction and could not catch the
+# script checking the wrong paths. It was checking lib/@vibe/compiler|cli only,
+# and a compiler change confined to lib/@vibe/parser (a compiler source: see
+# lib/@vibe/compiler/compiler_sources_manifest.tsv) went unwarned.
+#
+# So the probe lives in lib/@vibe/parser on purpose: it is the case the
+# narrower predicate missed.
+PROBE="$ROOT_DIR/lib/@vibe/parser/_seed_gap_probe.vibe"
+cleanup_probe() { rm -f "$PROBE"; }
+trap 'cleanup_probe; rm -rf "$WORK"' EXIT
+printf '// transient: scripts/vibe_test_smoke.sh seed-gap probe\n' > "$PROBE"
 
 notice_err="$WORK/notice.stderr"
 if ! bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/pass_test.vibe" >/dev/null 2>"$notice_err"; then
@@ -48,37 +49,41 @@ if ! bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/pass_test.vibe" >/dev/null 2>"
   cat "$notice_err" >&2
   exit 1
 fi
-if [ "$ahead" = "1" ]; then
-  if ! rg -q "compiler: the committed seed" "$notice_err"; then
-    echo "[vibe-test-smoke] FAIL: checkout is ahead of the seed but no compiler notice was printed" >&2
-    cat "$notice_err" >&2
-    exit 1
-  fi
-  # Naming the file is not the point -- `[ensure-seed]` already does that. The
-  # notice exists to say the seed is BEHIND, and to give the way out.
-  if ! rg -q "CANNOT observe" "$notice_err" || ! rg -q "VIBE_TEST_CLI_WASM=" "$notice_err"; then
-    echo "[vibe-test-smoke] FAIL: the notice must state the consequence and the override" >&2
-    cat "$notice_err" >&2
-    exit 1
-  fi
-  # An explicit choice of compiler is not a mistake, and neither is an explicit
-  # request for quiet.
-  for silent_env in "VIBE_TEST_CLI_WASM=$ROOT_DIR/bootstrap/seed/compiler.wasm" \
-                    "VIBE_TEST_QUIET_COMPILER_NOTE=1"; do
-    if env "$silent_env" bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/pass_test.vibe" \
-        2>&1 >/dev/null | rg -q "compiler: the committed seed"; then
-      echo "[vibe-test-smoke] FAIL: notice printed despite $silent_env" >&2
-      exit 1
-    fi
-  done
-  echo "[vibe-test-smoke] ok (seed notice present, suppressed on explicit compiler/quiet)"
-else
-  # A checkout sitting exactly on the seed's compiler sources has nothing to
-  # warn about, and warning anyway would train the reader to ignore it.
-  if rg -q "compiler: the committed seed" "$notice_err"; then
-    echo "[vibe-test-smoke] FAIL: checkout matches the seed but the notice was printed" >&2
-    cat "$notice_err" >&2
-    exit 1
-  fi
-  echo "[vibe-test-smoke] ok (checkout matches the seed; no notice, as expected)"
+if ! rg -q "compiler: the committed seed" "$notice_err"; then
+  echo "[vibe-test-smoke] FAIL: a compiler source is modified but no seed notice was printed" >&2
+  echo "  (probe: ${PROBE#"$ROOT_DIR"/})" >&2
+  cat "$notice_err" >&2
+  exit 1
 fi
+# Assert on the UNCOMMITTED clause, not merely on the notice appearing. Any
+# checkout past a seed bump is already some commits ahead, so the notice fires
+# with or without the probe -- asserting its presence proves nothing about
+# which paths are checked. Only the uncommitted count can distinguish them:
+# the probe is the sole uncommitted file, and a predicate that does not cover
+# lib/@vibe/parser reports zero of them.
+if ! rg -q "uncommitted file" "$notice_err"; then
+  echo "[vibe-test-smoke] FAIL: a modified compiler source outside lib/@vibe/compiler was not counted" >&2
+  echo "  (probe: ${PROBE#"$ROOT_DIR"/} -- it is a compiler source; see lib/@vibe/compiler/compiler_sources_manifest.tsv)" >&2
+  cat "$notice_err" >&2
+  exit 1
+fi
+# Naming the file is not the point -- `[ensure-seed]` already does that. The
+# notice exists to say the seed is BEHIND, and to give the way out.
+if ! rg -q "CANNOT observe" "$notice_err" || ! rg -q "VIBE_TEST_CLI_WASM=" "$notice_err"; then
+  echo "[vibe-test-smoke] FAIL: the notice must state the consequence and the override" >&2
+  cat "$notice_err" >&2
+  exit 1
+fi
+# An explicit choice of compiler is not a mistake, and neither is an explicit
+# request for quiet.
+for silent_env in "VIBE_TEST_CLI_WASM=$ROOT_DIR/bootstrap/seed/compiler.wasm" \
+                  "VIBE_TEST_QUIET_COMPILER_NOTE=1"; do
+  if env "$silent_env" bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/pass_test.vibe" \
+      2>&1 >/dev/null | rg -q "compiler: the committed seed"; then
+    echo "[vibe-test-smoke] FAIL: notice printed despite $silent_env" >&2
+    exit 1
+  fi
+done
+cleanup_probe
+
+echo "[vibe-test-smoke] ok (seed notice fires on a compiler source outside lib/@vibe/compiler, suppressed on explicit compiler/quiet)"


### PR DESCRIPTION
Follow-up to #1939 (#1890). Both of these are the same shape as that bug: the answer looks fine and is about the wrong thing.

## 1. `vibe test` did not say which compiler answered

`scripts/vibe_test.sh` compiles with the **committed seed** by default — `cli_wasm="${VIBE_TEST_CLI_WASM:-$seed}"`. That is right for library code and wrong for a change to the compiler, and **the two are indistinguishable from the result**: the file compiles, the tests run, and the seed returns a confident answer about a compiler that does not contain the change.

Measured, one file, `x - y` through a labeled-argument lambda:

| compiler | result |
|---|---:|
| committed seed | **0** — a bug fixed in #1925 |
| stage2 from the same checkout | **-7** — the still-open half of #1899 |

Neither run reports an error. This cost three wrong conclusions in one session, including a "fix verified" claim on #1899 that the merged PR body had to walk back.

The existing note fires only when `compile_fails > 0`. That is the **safe** direction — a file that fails to compile under an old seed announces itself. The dangerous direction is a green run, and nothing was said there.

Now, whenever the checkout is ahead of the seed under `lib/@vibe` / `lib/@vibex` and no compiler was named:

```
[vibe-test] compiler: the committed seed -- 44 commit(s) ahead of it under lib/@vibe|@vibex.
[vibe-test]   This run CANNOT observe those changes; a green result here says nothing about them.
[vibe-test]   To test this checkout's compiler:
[vibe-test]     VIBE_TEST_CLI_WASM=_build/selfhost/generations/<gen>_$(git rev-parse --short HEAD)/stage2.wasm
```

Counts commits since the seed's `source_commit` plus uncommitted files under those paths. On **stderr**, so nothing parsing stdout is affected. Silent when a compiler is named explicitly (an explicit choice is not a mistake) or under `VIBE_TEST_QUIET_COMPILER_NOTE=1`. `compiler_gate.sh` passes `VIBE_TEST_CLI_WASM="$stage2_wasm"` at nearly every call site, so the gate is unaffected.

`[ensure-seed] ... bootstrap/seed/compiler.wasm` was already printed and was not enough: it names the file without saying the file is behind.

### The paths, after review

The first commit checked `lib/@vibe/compiler` and `lib/@vibe/cli` only. That is an under-approximation, and Codex caught it: `lib/@vibe/compiler/compiler_sources_manifest.tsv` lists `@vibe/ast`, `parser`, `core`, `cache`, `graph`, `json` and `lsp` among the compiler's 317 inputs, so a change confined to `lib/@vibe/parser/lexer.vibe` is a compiler change that left both counts at zero. Over the current seed window the narrow predicate counts **42** commits and `lib/@vibe lib/@vibex` counts **44**.

Widened rather than derived from the manifest, because `ensure_generated.sh:117` had already settled this for its own fingerprint and the manifest is not the boundary: *"the flatten walks cli_adapter.vibe's whole import closure, which reaches past the manifest rows [...] over-approximate"*, since *"under-approximating reintroduces exactly the staleness this replaces."*

No exclusion list. `ensure_generated.sh` needs one because it hashes the working tree directly; git does not — the five build outputs are gitignored (`.gitignore:57-61`) so they cannot appear as uncommitted, and excluding tests/benches changes 44 to 44.

### The test earned its own fix

`scripts/vibe_test_smoke.sh` initially recomputed "is this checkout ahead?" with its own copy of the path list, so it agreed with the script by construction and could not catch the script checking the wrong paths. It now probes behaviourally with a transient file under `lib/@vibe/parser` — the case that was missed.

That alone was still not enough: **the first behavioural version passed against the narrow predicate too.** Any checkout past a seed bump is already some commits ahead, so the notice fires either way and asserting its presence proves nothing. The assertion is on the *uncommitted* clause, which only a predicate covering `lib/@vibe/parser` can produce.

| `compiler_paths` | smoke test |
|---|---|
| `lib/@vibe/compiler lib/@vibe/cli` (the reported bug) | **red** |
| `lib/@vibe lib/@vibex` | green |

The probe is a `.tmp`, not a `.vibe`: the pathspec filters by directory rather than extension, so it exercises the same predicate while staying invisible to every `*.vibe` glob in the tree (`vibe-fmt-check` lints `lib/**/*.vibe`).

## 2. `sha256sum` was selected by existence and then never ran

`if command -v sha256sum` is satisfied by a nix-shim binary that is on PATH and dies on a glibc mismatch. The `shasum` fallback directly below it never engages, and the caller dies instead. Eleven copies of the pattern.

Not hypothetical — **`pkf run test-vibe-test` failed on a clean tree**, before any change of mine:

```
sha256sum: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_ABI_DT_X86_64_PLT' not found
[vibe-test-smoke] FAIL: passing test file did not succeed
```

and the review-regressions lint had been reporting `ok (AST tier SKIPPED -- text tier only)` for the same reason, i.e. one of its two tiers silently not running. After this change that lint reports a plain `ok`, and `test-vibe-test` / `test-generations` both pass under `pkf`.

The fix is to probe by **running** the tool rather than by looking for it. The repository already learned this once — `scripts/lint_review_regressions.sh` says so in its own comment: *"one cheap call answers 'can this run' instead of 'does this file look like it could'"*. The probe reads `/dev/null`, so in the two stream-hashing helpers (`_sha256_stdin`, `sha256_stream`) it cannot consume the caller's stdin.

## Documentation

`AGENTS.md` gains a section under Local Test Execution recording which compiler `vibe test` uses and how to override it, plus the two habits that produced the wrong measurements:

- **Establish the baseline through the compiler you are about to rebuild.** If the failing case does not reproduce first, you are measuring the wrong compiler, not looking at a fixed bug.
- **Never test argument order with a commutative operator.** `x + y` gives the right answer whether or not arguments were reordered. A reordering bug survived a "fix verified" claim this way.

## Verification

| check | result |
|---|---|
| `pkf run test-vibe-test` | ✅ (was **failing on clean main** in this environment) |
| `pkf run test-generations` | ✅ |
| `pkf run pre-commit` | ✅ — review lint now runs its AST tier instead of skipping it |
| `pkf run vibe-md-tutorial` | ✅ (exercises the `.vibex` copy of the probe) |
| smoke assertions vs. the unfixed script, and vs. the narrow predicate | ✅ red in both |

`scripts/vibe_md.vibex` was already unformatted before this edit and `scripts/` is outside the `vibe-fmt-check` gate (`lib/**` only), so that is unchanged either way.