### PR TITLE
refactor(rc): single source of truth for the borrow-returning builtin list (#1979)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -10,6 +10,7 @@ import @vibe/compiler/core {
   builtin_registry,
   bytebuf_push,
   canonical_builtin_name,
+  is_borrow_ret_builtin,
   is_exception_throw_operation,
   sorted_names_of
 }
@@ -1175,7 +1176,7 @@ export fn proj_root_ident(e: Expr) -> String {
 /// like `.field` does. Kept in sync with classify_let_value_heap's own
 /// hardcoded list (codegen/expr/compile_expr_tail.vibe).
 fn borrow_ret_builtin_name(nm: String) -> Bool {
-  nm == "Array::get" || nm == "MutList::get" || nm == "__index" || nm == "Map::get" || nm == "__rec_field"
+  is_borrow_ret_builtin(nm)
 }
 
 /// The container a borrow-returning tail reads from: an identifier, a

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -17,6 +17,7 @@ import @vibe/compiler/core {
   bytebuf_push_vec_header,
   bytebuf_to_bytes,
   canonical_builtin_name,
+  is_borrow_ret_builtin,
   is_exception_operation_name,
   is_exception_throw_operation,
   leb128_encode_s64,
@@ -433,7 +434,7 @@ export fn cc_is_borrow_ret_call(e: Expr, ctx: CompileCtx) -> Bool {
   match e {
     ECall(callee, _, _) =>
     match callee {
-      EIdent(f, _) => f == "Array::get" || f == "MutList::get" || f == "Map::get" || f == "__index" || f == "__rec_field" || bsearch_leftmost(ctx.borrow_ret_names, f) >= 0,
+      EIdent(f, _) => is_borrow_ret_builtin(f) || bsearch_leftmost(ctx.borrow_ret_names, f) >= 0,
       _ => false
     },
     _ => false

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
@@ -12,6 +12,7 @@ import @vibe/compiler/core {
   bytebuf_push_section,
   bytebuf_push_vec_header,
   bytebuf_to_bytes,
+  is_borrow_ret_builtin,
   leb128_encode_s64,
   leb128_encode_u32
 }
@@ -946,7 +947,7 @@ fn classify_let_value_heap(buf: Bytes, value: Expr, name: String, local_idx: Int
       let callee = get_ecall_callee(value)
       let is_borrow_ret = if is_eident(callee) {
         let cn = get_eident_name(callee)
-        cn == "Array::get" || cn == "MutList::get" || cn == "__index" || cn == "Map::get" || cn == "__rec_field" || bsearch_leftmost(ctx.borrow_ret_names, cn) >= 0
+        is_borrow_ret_builtin(cn) || bsearch_leftmost(ctx.borrow_ret_names, cn) >= 0
       } else {
         false
       }
@@ -1103,7 +1104,7 @@ fn value_has_borrowed_branch_tail(e: Expr, ctx: CompileCtx) -> Bool {
     EIdent(x, _) => array_contains_str(ctx.loop_borrowed_names, x) && !array_contains_str(ctx.ref_cell_names, x),
     EDot(_, _, _, _) => true,
     ECall(callee, _, _) => match callee {
-      EIdent(cn, _) => cn == "Array::get" || cn == "MutList::get" || cn == "__index" || cn == "Map::get" || cn == "__rec_field" || bsearch_leftmost(ctx.borrow_ret_names, cn) >= 0,
+      EIdent(cn, _) => is_borrow_ret_builtin(cn) || bsearch_leftmost(ctx.borrow_ret_names, cn) >= 0,
       _ => false
     },
     EIf(_, t, el) => value_has_borrowed_branch_tail(t, ctx) || value_has_borrowed_branch_tail(el, ctx),

--- a/lib/@vibe/compiler/codegen/expr/compile_match.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_match.vibe
@@ -12,6 +12,7 @@ import @vibe/compiler/core {
   bytebuf_push_section,
   bytebuf_push_vec_header,
   bytebuf_to_bytes,
+  is_borrow_ret_builtin,
   leb128_encode_s64,
   leb128_encode_u32
 }
@@ -243,7 +244,7 @@ fn mr_is_borrow_ret_call(e: Expr, ctx: CompileCtx) -> Bool {
   match e {
     ECall(callee, _, _) =>
     match callee {
-      EIdent(f, _) => f == "Array::get" || f == "Map::get" || f == "__index" || f == "__rec_field" || bsearch_leftmost(ctx.borrow_ret_names, f) >= 0,
+      EIdent(f, _) => is_borrow_ret_builtin(f) || bsearch_leftmost(ctx.borrow_ret_names, f) >= 0,
       _ => false
     },
     _ => false

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -684,18 +684,17 @@ export fn builtin_allocates(name: String) -> Bool {
 /// SINGLE SOURCE OF TRUTH (#1979): the perceus classifiers
 /// (is_borrow_ret_fname, compute_borrow_returning_names' seed) and every
 /// codegen call-shape check (compile_call / compile_match /
-/// compile_expr_tail / common_analysis) consume THIS predicate or list. The
-/// set used to live as five hardcoded copies, and two of them drifted when
-/// MutList::get landed — a wrapper of the missing builtin then classifies as
-/// owned-returning and RC callers drop an interior view: silent double-free,
-/// caught only by review (#1932). Add new borrow-returning builtins HERE and
-/// nowhere else.
-export fn is_borrow_ret_builtin(name: String) -> Bool {
-  name == "Array::get" || name == "MutList::get" || name == "Map::get" || name == "__index" || name == "__rec_field"
-}
-
-/// The same set as a fresh array, for seeding compute_borrow_returning_names'
-/// fixed-point worklist (which pushes discovered user functions into it).
+/// compile_expr_tail / common_analysis) reach the set through this function or
+/// the predicate below, which SCANS it -- there is one spelling of the names,
+/// not two that must be kept equal. The set used to live as five hardcoded
+/// copies, and two of them drifted when MutList::get landed: a wrapper of the
+/// missing builtin then classifies as owned-returning and RC callers drop an
+/// interior view, a silent double-free caught only by review (#1932). Add new
+/// borrow-returning builtins HERE and nowhere else.
+///
+/// Returns a fresh array on each call because
+/// compute_borrow_returning_names' fixed-point worklist pushes discovered user
+/// functions into the one it is given.
 export fn borrow_ret_builtin_names() -> Array[String] {
   [
     "Array::get",
@@ -704,6 +703,28 @@ export fn borrow_ret_builtin_names() -> Array[String] {
     "__index",
     "__rec_field"
   ]
+}
+
+/// Membership in `borrow_ret_builtin_names`, for the direct-call classifiers.
+///
+/// A linear scan rather than the `||` chain this replaced: the chain was a
+/// second spelling of the list above, so adding a builtin to one and not the
+/// other silently reintroduced exactly the drift this consolidation exists to
+/// remove -- and the two partial updates fail in opposite directions (miss it
+/// in the list and wrappers of it classify as owned; miss it in the predicate
+/// and direct calls do). Five string compares over a five-element array is the
+/// same work the chain did, plus the array.
+export fn is_borrow_ret_builtin(name: String) -> Bool {
+  let names = borrow_ret_builtin_names()
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = true
+    }
+    i = i + 1
+  }
+  found
 }
 
 /// The enumerated non-allocating set. Grouped by why they are free.

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -675,6 +675,37 @@ export fn builtin_allocates(name: String) -> Bool {
   !builtin_is_non_allocating(name)
 }
 
+/// The borrow-RETURNING builtins: their result is an interior view sharing a
+/// call argument's refcount (an element read in place), never a fresh owned
+/// reference. Callers must not plan an independent drop for a binding of such
+/// a result, and functions whose tails reduce to these are themselves
+/// borrow-returning (#707).
+///
+/// SINGLE SOURCE OF TRUTH (#1979): the perceus classifiers
+/// (is_borrow_ret_fname, compute_borrow_returning_names' seed) and every
+/// codegen call-shape check (compile_call / compile_match /
+/// compile_expr_tail / common_analysis) consume THIS predicate or list. The
+/// set used to live as five hardcoded copies, and two of them drifted when
+/// MutList::get landed — a wrapper of the missing builtin then classifies as
+/// owned-returning and RC callers drop an interior view: silent double-free,
+/// caught only by review (#1932). Add new borrow-returning builtins HERE and
+/// nowhere else.
+export fn is_borrow_ret_builtin(name: String) -> Bool {
+  name == "Array::get" || name == "MutList::get" || name == "Map::get" || name == "__index" || name == "__rec_field"
+}
+
+/// The same set as a fresh array, for seeding compute_borrow_returning_names'
+/// fixed-point worklist (which pushes discovered user functions into it).
+export fn borrow_ret_builtin_names() -> Array[String] {
+  [
+    "Array::get",
+    "MutList::get",
+    "Map::get",
+    "__index",
+    "__rec_field"
+  ]
+}
+
 /// The enumerated non-allocating set. Grouped by why they are free.
 fn builtin_is_non_allocating(name: String) -> Bool {
   // Pure scalar reads and predicates over an existing value.

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -124,6 +124,8 @@ fn canonical_builtin_name(name: String) -> String
 // --- builtin_registry
 fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)]
 fn builtin_allocates(name: String) -> Bool
+fn is_borrow_ret_builtin(name: String) -> Bool
+fn borrow_ret_builtin_names() -> Array[String]
 fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
 fn lookup_registry_builtin(name: String) -> Option[Type]
 fn registry_builtin_arity(name: String) -> Int

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -9,7 +9,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, TypeExpr, bsearch_leftmost, is_exception_throw_operation
+  Expr, Pat, Stmt, TypeExpr, borrow_ret_builtin_names, bsearch_leftmost, is_borrow_ret_builtin, is_exception_throw_operation
 }
 
 //# Types
@@ -414,7 +414,7 @@ fn array_contains_str_pctx(arr: Array[String], s: String) -> Bool {
 /// pctx_names, so the names sit here unprefixed and a miss costs only the
 /// fixed set.
 fn is_borrow_ret_fname(ctx: PCtx, fname: String) -> Bool {
-  fname == "Array::get" || fname == "MutList::get" || fname == "Map::get" || fname == "__index" || fname == "__rec_field" || bsearch_leftmost(ctx.pctx_names, fname) >= 0
+  is_borrow_ret_builtin(fname) || bsearch_leftmost(ctx.pctx_names, fname) >= 0
 }
 
 /// #707: fixed-point closure over top-level function definitions, starting
@@ -785,17 +785,12 @@ fn strip_wrappers_for_borrow_ret(e: Expr) -> Expr {
 }
 
 export fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String] {
-  // Seed with the same builtin set is_borrow_ret_fname hardcodes -- omitting
-  // one (MutList::get was missing until #1932 review) makes both the inline
-  // branch-tail check and the #1915 spine-binding resolution classify that
-  // builtin's result as owned, and RC callers then drop an interior view.
-  let known: Array[String] = [
-    "Array::get",
-    "MutList::get",
-    "Map::get",
-    "__index",
-    "__rec_field"
-  ]
+  // Seeded from the shared single-source-of-truth list (#1979) -- a seed that
+  // drifts from is_borrow_ret_builtin (MutList::get was missing until #1932
+  // review) makes both the inline branch-tail check and the #1915
+  // spine-binding resolution classify that builtin's result as owned, and RC
+  // callers then drop an interior view.
+  let known: Array[String] = borrow_ret_builtin_names()
   let mut changed = true
   while changed {
     changed = false

--- a/lib/@vibe/compiler/tests/borrow_returning_names_test.vibe
+++ b/lib/@vibe/compiler/tests/borrow_returning_names_test.vibe
@@ -16,6 +16,10 @@ import @vibe/compiler/perceus {
   compute_borrow_returning_names
 }
 
+import @vibe/compiler/core {
+  borrow_ret_builtin_names, is_borrow_ret_builtin
+}
+
 fn borrow_set_of(src: String) -> Array[String] with Exception {
   compute_borrow_returning_names(parse_program(lex(src)))
 }
@@ -70,4 +74,33 @@ test "MutList::get binding returned through if branches stays borrow-returning" 
   // classify this binding owned and make RC callers drop an interior view.
   let src = "fn head(l: Array[Array[Int]], i: Int) -> Array[Int] {\n  let v = MutList::get(l, i)\n  if i >= 0 {\n    v\n  } else {\n    v\n  }\n}\n"
   inspect(contains(borrow_set_of(src), "head"), "true")
+}
+
+//# #1979 review: the two exported APIs must not be two spellings of the set.
+//#
+//# `is_borrow_ret_builtin` classifies DIRECT calls; `borrow_ret_builtin_names`
+//# seeds the wrapper fixed point. When they were an independent `||` chain and
+//# an independent array literal, a builtin added to one and not the other
+//# silently reintroduced the drift the consolidation removed -- and the two
+//# partial updates fail in OPPOSITE directions, so neither is the safe one to
+//# forget. The predicate now scans the list, and this pins that: an entry the
+//# classifiers cannot see is the shape whose failure mode is an RC double-free
+//# of an interior view.
+test "every borrow-returning builtin name is recognized by the predicate" {
+  let names = borrow_ret_builtin_names()
+  let mut i = 0
+  let mut all = true
+  while i < Array::length(names) {
+    if !is_borrow_ret_builtin(Array::get(names, i)) {
+      all = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  inspect(all, "true")
+  // A non-member must not be recognized -- otherwise `all` above would hold
+  // for a predicate that simply returns true.
+  inspect(is_borrow_ret_builtin("Array::push"), "false")
+  inspect(Array::length(names) > 0, "true")
 }


### PR DESCRIPTION
## Summary

Closes #1979.

The borrow-returning builtin set (`Array::get`, `MutList::get`, `Map::get`, `__index`, `__rec_field`) lived as **seven** hardcoded copies:

- `is_borrow_ret_fname` and the `compute_borrow_returning_names` seed (perceus/perceus.vibe)
- `borrow_ret_builtin_name` (common_analysis.vibe)
- `borrows_this`'s callee check (compile_call.vibe)
- `mr_is_borrow_ret_call` (compile_match.vibe)
- two chains in compile_expr_tail.vibe

Two had already drifted when `MutList::get` landed: the classifier seed (caught by review on #1932) and **`compile_match.vibe`'s copy — a live drift found while consolidating**. That site still classified a `MutList::get(...)` scrutinee as an owned call result; the failure mode of that direction is an RC double-free of an interior view when the owning container is reclaimed.

All seven sites now consume `core/builtin_registry`'s new `is_borrow_ret_builtin` predicate (the classifier seed takes `borrow_ret_builtin_names()`, since its worklist mutates the array), so adding a borrow-returning builtin is a one-place change with a doc comment stating exactly that. The `compile_match` site gaining `MutList::get` is the only behavioral delta, and it moves in the safe direction (a view treated as a view).

## Validation

- `seed → stage1 → stage2 → stage3` selfbuild: fixpoint holds (stage2 == stage3, `c39c789b6fee`)
- Full local unit suite: **664/664 files pass**
- `scripts/compiler_gate.sh` full run green (including the 40d RC reclamation guard with both #1915 builder shapes)
- RC leak fixtures re-measured unchanged (builder loop bare/if-else tails stay reclaimed); classifier unit tests (`borrow_returning_names_test`, `may_return_view_fns_test`, `perceus_rc_test`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CunRRnvmDfVWw5MzzmjjbQ)_