### PR TITLE
fix(test-affected): tolerate empty selector arrays on Bash 3.2 (#1970)

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -450,6 +450,7 @@ local refreshSelfhostBatchWeights =
 local testSelfhostBatchWeights =
   scriptTask("test-batch-weights", "scripts/refresh_batch_weight_seed_test.sh")
 local testFlakerRun = scriptTask("test-flaker-run", "scripts/flaker_run_test.sh")
+local testAffectedShell = scriptTask("test-affected-shell", "scripts/test_affected_test.sh")
 local testMeasureFsHeap = scriptTask("test-measure-fs-heap", "scripts/measure_fs_heap_test.sh")
 local testRunCachedVibe = scriptTask("test-run-cached-vibe", "scripts/run_cached_vibe_test.sh")
 local testSelfhostGenerations = scriptTask("test-generations", "scripts/generations_test.sh")
@@ -1316,6 +1317,7 @@ tasks {
   refreshSelfhostBatchWeights
   testSelfhostBatchWeights
   testFlakerRun
+  testAffectedShell
   testMeasureFsHeap
   testRunCachedVibe
   testSelfhostGenerations

--- a/scripts/test_affected.sh
+++ b/scripts/test_affected.sh
@@ -39,7 +39,12 @@ selected="$(mktemp -t vibe-affected-XXXXXX)"
 trap 'rm -f "$selected"' EXIT
 
 set +e
-node scripts/affected_tests.mjs "${sel_args[@]}" > "$selected"
+# Bash 3.2 + `set -u`: empty "${arr[@]}" is unbound (#1970).
+if [ "${#sel_args[@]}" -gt 0 ]; then
+  node scripts/affected_tests.mjs "${sel_args[@]}" > "$selected"
+else
+  node scripts/affected_tests.mjs > "$selected"
+fi
 sel_rc=$?
 set -e
 

--- a/scripts/test_affected_test.sh
+++ b/scripts/test_affected_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# #1970: an empty selector list must not trip Bash 3.2 `set -u`.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/vibe-test-affected.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# Intercept node so the test stays a shell contract, not a graph walk.
+# The argv sink is baked into the stub; the parent script does not export it.
+cat >"$TMP/node" <<EOF
+#!/usr/bin/env bash
+printf '%s\\n' "\$@" >"$TMP/argv.last"
+exit 2
+EOF
+chmod +x "$TMP/node"
+
+# macOS ships Bash 3.2; that is the version that treats empty "${arr[@]}"
+# as unbound under `set -u`. Prefer it when present.
+if [ -x /bin/bash ]; then
+  BASH_BIN=/bin/bash
+else
+  BASH_BIN=bash
+fi
+
+set +e
+PATH="$TMP:$PATH" "$BASH_BIN" "$ROOT/scripts/test_affected.sh" --dry-run \
+  >"$TMP/out.empty" 2>"$TMP/err.empty"
+empty_rc=$?
+set -e
+
+if grep -q 'unbound variable' "$TMP/err.empty"; then
+  echo "test_affected_test: empty selector list unbound under $BASH_BIN (#1970)" >&2
+  cat "$TMP/err.empty" >&2
+  exit 1
+fi
+if [ "$empty_rc" -ne 0 ]; then
+  echo "test_affected_test: empty --dry-run should exit 0 after undetermined selection, got $empty_rc" >&2
+  cat "$TMP/err.empty" >&2
+  exit 1
+fi
+cp "$TMP/argv.last" "$TMP/argv.empty"
+if [ ! -s "$TMP/argv.empty" ]; then
+  echo "test_affected_test: expected the selector to be invoked with no extra args" >&2
+  exit 1
+fi
+if grep -q -- '--changed' "$TMP/argv.empty"; then
+  echo "test_affected_test: empty invocation forwarded selector flags" >&2
+  cat "$TMP/argv.empty" >&2
+  exit 1
+fi
+
+set +e
+PATH="$TMP:$PATH" "$BASH_BIN" "$ROOT/scripts/test_affected.sh" --dry-run --explain \
+  >"$TMP/out.explain" 2>"$TMP/err.explain"
+explain_rc=$?
+set -e
+cp "$TMP/argv.last" "$TMP/argv.explain"
+if [ "$explain_rc" -ne 0 ]; then
+  echo "test_affected_test: --explain --dry-run should exit 0, got $explain_rc" >&2
+  cat "$TMP/err.explain" >&2
+  exit 1
+fi
+if ! grep -qx -- '--explain' "$TMP/argv.explain"; then
+  echo "test_affected_test: --explain was not forwarded to the selector" >&2
+  cat "$TMP/argv.explain" >&2
+  exit 1
+fi
+
+echo "test_affected_test: ok"


### PR DESCRIPTION
Fixes #1970.

`pkf run test-affected` with no selector args dies on macOS Bash 3.2:

```
scripts/test_affected.sh: line 42: sel_args[@]: unbound variable
```

`set -u` plus empty `"${sel_args[@]}"`. Skip the expansion when the array is empty. Regression in `scripts/test_affected_test.sh` drives the real script under `/bin/bash` with a stub `node`.