### PR TITLE
Give a block-local lambda its own labels and optionals (#1899, #1952)

### DIFF
--- a/fixtures/labeled_local_lambda_scope_test.vibe
+++ b/fixtures/labeled_local_lambda_scope_test.vibe
@@ -1,0 +1,120 @@
+// #1899 (second half) and #1952: a lambda bound by a `let` INSIDE a block got
+// no parameter table at all, so its labels were never reordered and its
+// omitted optional arguments were never filled in.
+//
+// `collect_fn_param_labels` and `collect_optional_param_fns` index top-level
+// statements only, and `relabel_expr`'s ECall arm bailed out for any callee in
+// `shadows`. The bail-out is right as far as "do not apply a top-level
+// function's labels to a local binding that merely shares its name" -- but it
+// left a local labeled lambda with nothing, and the two halves failed
+// differently: labels were applied in WRITTEN order with no diagnostic (P0),
+// while an omitted optional reached the checker as `function arity mismatch`
+// (P1).
+//
+// Everything here is written with SUBTRACTION on purpose. `x + y` gives the
+// right answer whether or not the arguments were reordered, which is how the
+// first half of #1899 survived a "fix verified" claim.
+
+fn block_local_labels() -> Int {
+  let s = (x~: Int, y~: Int) -> Int { x - y }
+  s(y = 3, x = 10)
+}
+
+fn block_local_optional() -> Int {
+  let o = (a: Int, b?: Int) -> Int {
+    match b {
+      Some(v) => a - v,
+      None => a
+    }
+  }
+  o(7)
+}
+
+fn block_local_optional_supplied() -> Int {
+  let o = (a: Int, b?: Int) -> Int {
+    match b {
+      Some(v) => a - v,
+      None => a
+    }
+  }
+  o(10, 3)
+}
+
+// A local lambda's labels must not leak onto an unrelated binding that reuses
+// its name. `s` in the match arm is a PATTERN BINDER: it has no entry of its
+// own, and the outer entry has to be rejected because it is no longer the
+// innermost binding of that name.
+//
+// This case is load-bearing and was measured: with the innermost-index check
+// removed from the lookup, it returns -7 instead of 7.
+fn mask_by_match_binder() -> Int {
+  let s = (x~: Int, y~: Int) -> Int { x - y }
+  match Some((x~: Int, y~: Int) -> Int { y - x }) {
+    Some(s) => s(y = 3, x = 10),
+    None => 0
+  }
+}
+
+// ...and the outer binding comes back into force once the masking one ends.
+fn restored_after_mask() -> Int {
+  let s = (x~: Int, y~: Int) -> Int { x - y }
+  let _masked = mask_by_match_binder()
+  s(y = 3, x = 10)
+}
+
+// A local binding shadowing a top-level function of the same name takes the
+// LOCAL labels, not the top-level table's.
+let dup = (x~: Int, y~: Int) -> Int { x - y }
+
+fn local_wins_over_top_level() -> Int {
+  let dup = (x~: Int, y~: Int) -> Int { y - x }
+  dup(y = 3, x = 10)
+}
+
+// A recursive local binding is in scope inside its own body, so the entry has
+// to be pushed before that body is walked.
+fn rec_labeled() -> Int {
+  let rec down = (n~: Int, acc~: Int) -> Int {
+    if n <= 0 {
+      acc
+    } else {
+      down(acc = acc + n, n = n - 1)
+    }
+  }
+  down(acc = 0, n = 4)
+}
+
+// The over-strip guard from #1925: `n` is genuinely free here and must still
+// ride the closure environment.
+fn real_capture() -> Int {
+  let n = 5
+  let f = (x~: Int) -> Int { x + n }
+  f(x = 10)
+}
+
+// Top level always worked. These are here so a future change that "fixes" the
+// local case by breaking the top-level one cannot pass.
+fn top_level_labels() -> Int {
+  dup(y = 3, x = 10)
+}
+
+fn top_level_optional(a: Int, b?: Int) -> Int {
+  match b {
+    Some(v) => a - v,
+    None => a
+  }
+}
+
+test "labeled and optional parameters on a block-local lambda" {
+  inspect(block_local_labels(), "7")
+  inspect(block_local_optional(), "7")
+  inspect(block_local_optional_supplied(), "7")
+  inspect(mask_by_match_binder(), "7")
+  inspect(restored_after_mask(), "7")
+  inspect(local_wins_over_top_level(), "-7")
+  inspect(rec_labeled(), "10")
+  inspect(real_capture(), "15")
+  inspect(top_level_labels(), "7")
+  inspect(top_level_optional(7), "7")
+  inspect(top_level_optional(10, 3), "7")
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9496,6 +9496,92 @@ fn stmts_have_optional_fn(_stmts: Array[Stmt]) -> Bool {
 }
 
 ///|
+/// #1899/#1952: the labels and optional flags of lambdas bound by a `let`
+/// INSIDE a block, which the two top-level tables above cannot see.
+///
+/// `collect_fn_param_labels` and `collect_optional_param_fns` both index
+/// top-level statements only, and the `ECall` arm of `relabel_expr` bails out
+/// for any callee found in `shadows`. That bail-out is right as far as it goes
+/// -- do not apply a top-level function's labels to a local binding that
+/// merely shares its name -- but it left a local labeled lambda with no table
+/// at all, so nothing reordered its arguments and nothing filled in its
+/// omitted optionals. Both failed silently at first: written-order arguments
+/// compiled and ran (#1899, P0), and an omitted optional reached the checker
+/// as `function arity mismatch` (#1952, P1).
+///
+/// A module cell for the same reason `optional_param_tbl_cell` is one:
+/// `relabel_expr` recurses from ~30 sites.
+///
+/// Each entry records the index its name occupies in `shadows`, and that is
+/// what makes shadowing work. A later binding of the same name -- `let s = 5`
+/// after `let s = (x~: Int) -> ...`, a parameter, a match binder -- pushes
+/// onto `shadows` at a higher index, so this entry is no longer the innermost
+/// binding of that name, the lookup below rejects it, and the old bail-out
+/// stands. Without the index a local lambda's labels would leak onto a
+/// completely unrelated value that happens to reuse its name.
+let local_fn_tbl_cell: Array[(String, Array[String], Array[Bool], Int)] = array_empty()
+
+///|
+/// Record a `let`-bound lambda's parameter shape. Non-lambda bindings are
+/// deliberately not recorded: they have no labels, and their presence in
+/// `shadows` is what masks any outer entry.
+fn local_fn_tbl_push(name: String, v: Expr, at: Int) -> Unit {
+  match v {
+    EFn(_, _, params, _, _, _) => {
+      let labels = empty_str_array()
+      let flags = array_empty()
+      let mut i = 0
+      while i < Array::length(params) {
+        let (pn, _) = Array::get(params, i)
+        // strip_label_tilde removes a trailing `~` OR `?`, so an optional
+        // parameter contributes its bare name as a label as well as its flag.
+        Array::push(labels, strip_label_tilde(pn))
+        let pl = String::length(pn)
+        Array::push(flags, pl > 0 && __slice(pn, pl - 1, pl) == "?")
+        i = i + 1
+      }
+      Array::push(local_fn_tbl_cell, (name, labels, flags, at))
+    },
+    _ => ()
+  }
+}
+
+///|
+fn local_fn_tbl_truncate(mark: Int) -> Unit {
+  Array::truncate(local_fn_tbl_cell, mark)
+}
+
+///|
+/// The entry for `fname`, but only when it is still the innermost binding of
+/// that name. Returns (labels, optional flags).
+fn local_fn_tbl_lookup(fname: String, shadows: Array[String]) -> Option[(Array[String], Array[Bool])] {
+  let mut innermost = 0 - 1
+  let mut i = 0
+  while i < Array::length(shadows) {
+    if Array::get(shadows, i) == fname {
+      innermost = i
+    }
+    i = i + 1
+  }
+  if innermost < 0 {
+    None
+  } else {
+    let mut j = Array::length(local_fn_tbl_cell) - 1
+    let mut found = None
+    while j >= 0 {
+      let (n, labels, flags, at) = Array::get(local_fn_tbl_cell, j)
+      if n == fname && at == innermost {
+        found = Some((labels, flags))
+        j = 0 - 1
+      } else {
+        j = j - 1
+      }
+    }
+    found
+  }
+}
+
+///|
 /// Every top-level function that declares at least one optional (`z?`)
 /// parameter, with one flag per parameter. Functions with no optional
 /// parameter are left out so the ECall arm's lookup misses immediately for
@@ -9882,10 +9968,20 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       }
       let final_args = if any_labeled_arg {
         match callee {
-          EIdent(fname, _) => if str_array_contains(shadows, fname) {
-            rargs
-          } else {
-            match lookup_param_labels(tbl, fname) {
+          EIdent(fname, _) => {
+            // Where the labels come from is the ONLY thing shadowing changes
+            // (#1899). A locally bound callee must not take the top-level
+            // table -- but if the local binding is itself a labeled lambda, it
+            // has labels of its own, and before this it got none at all.
+            let labels_opt = if str_array_contains(shadows, fname) {
+              match local_fn_tbl_lookup(fname, shadows) {
+                Some((labels, _)) => Some(labels),
+                None => None
+              }
+            } else {
+              lookup_param_labels(tbl, fname)
+            }
+            match labels_opt {
               Some(labels) => match reorder_labeled_args(rargs, labels) {
                 Some(reordered) => strip_labeled_wrappers(reordered),
                 None => strip_in_position_labels(rargs, labels)
@@ -9937,23 +10033,34 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       EMap(out)
     },
     EIf(c, t, e) => EIf(relabel_expr(c, tbl, shadows), relabel_expr(t, tbl, shadows), relabel_expr(e, tbl, shadows)),
+    // The three binding arms keep local_fn_tbl_cell in step with `shadows`
+    // (#1899/#1952): push the lambda's parameter shape at the index `name`
+    // takes in `shadows`, and drop it again on the same scope exit.
     ELet(name, v, b, soff) => {
       let rv = relabel_expr(v, tbl, shadows)
       let mark = Array::length(shadows)
+      let lmark = Array::length(local_fn_tbl_cell)
       let local_mark = optional_local_enter(name, v)
       Array::push(shadows, name)
+      local_fn_tbl_push(name, v, mark)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      local_fn_tbl_truncate(lmark)
       optional_local_leave(local_mark)
       ELet(name, rv, rb, soff)
     },
     ELetRec(name, v, b) => {
       let mark = Array::length(shadows)
+      let lmark = Array::length(local_fn_tbl_cell)
       let local_mark = optional_local_enter(name, v)
       Array::push(shadows, name)
+      // Pushed before `v` is walked, not after: the binding is in scope inside
+      // its own body, so a recursive labeled call has to see the entry too.
+      local_fn_tbl_push(name, v, mark)
       let rv = relabel_expr(v, tbl, shadows)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      local_fn_tbl_truncate(lmark)
       optional_local_leave(local_mark)
       ELetRec(name, rv, rb)
     },
@@ -9962,6 +10069,16 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       let mark = Array::length(shadows)
       let local_mark = optional_local_enter(name, v)
       Array::push(shadows, name)
+      // Deliberately NOT registered. A `let mut` can be reassigned to another
+      // type-compatible lambda whose parameter NAMES differ, and this table
+      // would still describe the initializer -- reordering a later call by
+      // stale names, or filling an omitted optional the new lambda does not
+      // have. Invalidating on EAssign does not fix it either: an assignment
+      // inside a branch or a loop only reaches its own continuation, so a call
+      // after the `if` would still read the stale entry. Without a flow
+      // analysis the honest answer is to leave a mutable binding unresolved,
+      // which is what happened before #1899 and is never wrong -- only
+      // unhelpful.
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
       optional_local_leave(local_mark)
@@ -10118,10 +10235,21 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       }
       let resolved = if any_labeled {
         match callee {
-          EIdent(fname, _) => if str_array_contains(shadows, fname) {
-            rargs
-          } else {
-            match lookup_param_labels(tbl, fname) {
+          EIdent(fname, _) => {
+            // Must agree with relabel_expr's ECall arm exactly: the two lanes
+            // relabel the same programs, and a disagreement is a difference in
+            // meaning between them. Only the SOURCE of the labels is
+            // shadow-dependent (#1899); the reorder below, including the
+            // binder-authority child remapping, is unchanged.
+            let labels_opt = if str_array_contains(shadows, fname) {
+              match local_fn_tbl_lookup(fname, shadows) {
+                Some((labels, _)) => Some(labels),
+                None => None
+              }
+            } else {
+              lookup_param_labels(tbl, fname)
+            }
+            match labels_opt {
               Some(labels) => if labeled_reorder_candidate(rargs, labels) {
                 let reordered = empty_expr_array()
                 let used = for _ in rargs {
@@ -10229,15 +10357,20 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       paired_expect_node(node, AuthorityExprIf, 0, 3, poisoned)
       EIf(relabel_expr_paired_child(cond, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(yes, tbl, shadows, node, 1, poisoned), relabel_expr_paired_child(no, tbl, shadows, node, 2, poisoned))
     },
+    // Kept in step with relabel_expr's binding arms (#1899/#1952): the two
+    // lanes must agree about which local lambdas are in scope.
     ELet(name, value, body, offset) => {
       paired_expect_node(node, AuthorityExprLet, 1, 2, poisoned)
       paired_expect_slot(node, 0, ExpressionLetBinder, name, poisoned)
       let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
       let mark = Array::length(shadows)
+      let lmark = Array::length(local_fn_tbl_cell)
       let local_mark = optional_local_enter(name, value)
       Array::push(shadows, name)
+      local_fn_tbl_push(name, value, mark)
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
       Array::truncate(shadows, mark)
+      local_fn_tbl_truncate(lmark)
       optional_local_leave(local_mark)
       ELet(name, rvalue, rbody, offset)
     },
@@ -10245,11 +10378,14 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       paired_expect_node(node, AuthorityExprLetRec, 1, 2, poisoned)
       paired_expect_slot(node, 0, ExpressionLetRecBinder, name, poisoned)
       let mark = Array::length(shadows)
+      let lmark = Array::length(local_fn_tbl_cell)
       let local_mark = optional_local_enter(name, value)
       Array::push(shadows, name)
+      local_fn_tbl_push(name, value, mark)
       let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
       Array::truncate(shadows, mark)
+      local_fn_tbl_truncate(lmark)
       optional_local_leave(local_mark)
       ELetRec(name, rvalue, rbody)
     },
@@ -10260,6 +10396,7 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       let mark = Array::length(shadows)
       let local_mark = optional_local_enter(name, value)
       Array::push(shadows, name)
+      // Not registered -- see the ELetMut arm of relabel_expr.
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
       Array::truncate(shadows, mark)
       optional_local_leave(local_mark)
@@ -10564,6 +10701,23 @@ fn stmt_has_labeled_arg(stmt: Stmt) -> Bool {
 ///
 /// Enumerated (no `_ =>` catch-all for the recursive shapes) so a new `Expr`
 /// variant is a compile error here instead of a silently unscanned subtree.
+///|
+/// True when any parameter is declared optional (`z?`). The marker survives on
+/// the parameter NAME at this stage -- see parse_one_param_with_binder_context.
+fn dinsp_params_optional(params: Array[(String, Option[TypeExpr])]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(params) {
+    let (pn, _) = Array::get(params, i)
+    let pl = String::length(pn)
+    if pl > 0 && __slice(pn, pl - 1, pl) == "?" {
+      found = true
+    }
+    i = i + 1
+  }
+  found
+}
+
 fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
   let here = if mode == 0 {
     match expr {
@@ -10599,8 +10753,16 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       _ => false
     }
   } else if mode == 3 {
+    // "Does this statement need the relabel walk?" -- the only user is
+    // stmt_has_labeled_arg. A labeled argument is one reason; a lambda that
+    // declares an optional parameter is the other (#1952). Without the second,
+    // a statement whose only feature is a block-local `(a: Int, b?: Int)` was
+    // skipped outright, and the omitted argument reached the checker as an
+    // arity error. The top-level equivalent is handled by `walk_all`, which is
+    // computed from collect_optional_param_fns and so cannot see this one.
     match expr {
       ELabeledArg(_, _, _) => true,
+      EFn(_, _, params, _, _, _) => dinsp_params_optional(params),
       _ => false
     }
   } else if mode == 4 {
@@ -11110,6 +11272,7 @@ export fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit {
 /// labeled argument.
 export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   Array::truncate(optional_param_local_cell, 0)
+  Array::truncate(local_fn_tbl_cell, 0)
   let tbl = collect_fn_param_labels(stmts)
   // #1500: optional-parameter call sites are rewritten by the same walk (see
   // the ECall arm of relabel_expr). Unlike labeled arguments, an omitted
@@ -11120,25 +11283,31 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   let opt_tbl = collect_optional_param_fns(stmts)
   optional_param_tbl_set(opt_tbl)
   let walk_all = Array::length(opt_tbl) > 0 || stmts_have_optional_fn(stmts)
-  if Array::length(tbl) == 0 && !walk_all {
-    ()
-  } else {
-    let mut i = 0
-    while i < Array::length(stmts) {
-      if walk_all || stmt_has_labeled_arg(Array::get(stmts, i)) {
-        Array::set(stmts, i, relabel_stmt(Array::get(stmts, i), tbl))
-      } else {
-        ()
-      }
-      i = i + 1
+  // No `if Array::length(tbl) == 0` early-out. It was an optimisation that had
+  // become a correctness hole once local lambdas got labels of their own
+  // (#1899/#1952): collect_fn_param_labels indexes `SLet`s, so a file whose
+  // only top-level statements are `test` blocks has an EMPTY table, and the
+  // whole walk was skipped -- including the block-local labeled lambdas inside
+  // those tests. stmt_has_labeled_arg already gates each statement, so
+  // dropping the early-out costs one scalar scan per statement in the case
+  // where nothing needs relabelling.
+  let mut i = 0
+  while i < Array::length(stmts) {
+    if walk_all || stmt_has_labeled_arg(Array::get(stmts, i)) {
+      Array::set(stmts, i, relabel_stmt(Array::get(stmts, i), tbl))
+    } else {
+      ()
     }
+    i = i + 1
   }
   optional_param_tbl_set(array_empty())
   Array::truncate(optional_param_local_cell, 0)
+  Array::truncate(local_fn_tbl_cell, 0)
 }
 
 fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityNode], poisoned: Array[Bool]) -> Unit {
   Array::truncate(optional_param_local_cell, 0)
+  Array::truncate(local_fn_tbl_cell, 0)
   let tbl = collect_fn_param_labels(stmts)
   let opt_tbl = collect_optional_param_fns(stmts)
   optional_param_tbl_set(opt_tbl)
@@ -11166,6 +11335,7 @@ fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityN
   }
   optional_param_tbl_set(array_empty())
   Array::truncate(optional_param_local_cell, 0)
+  Array::truncate(local_fn_tbl_cell, 0)
 }
 
 export fn normalize_labeled_args_with_binder_authority(source: LocatedProgramBinderAuthority) -> LabeledArgBinderAuthorityNormalization {

--- a/lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe
+++ b/lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe
@@ -55,6 +55,16 @@ fn expect_no_authority(source: String) -> Unit with Exception {
   }
 }
 
+fn expect_authority(source: String) -> Unit with Exception {
+  match normalize_source(source) {
+    Some(result) => match labeled_arg_binder_authority_normalization_authority(result) {
+      Some(_) => inspect(true, "true"),
+      None => inspect(false, "true")
+    },
+    None => inspect(false, "true")
+  }
+}
+
 fn expect_ordinary_parity(source: String) -> Unit with Exception {
   match (parse_source_located_with_binder_authority(source), parse_source_located_with_binder_authority(source)) {
     (Some(ordinary_source), Some(paired_source)) => {
@@ -182,9 +192,29 @@ test "poison matrix is complete or none and ordinary output stays identical" {
 }
 
 test "lexical shadowing suppresses top-level resolution in every scoped lane" {
-  expect_no_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { let f = (y: Int) -> Int { y }; f(y=1) }")
+  // The invariant is that the TOP-LEVEL `f`'s parameter name never resolves a
+  // call to a local `f`. The first line used to be written as `f(y=1)`, which
+  // stopped distinguishing the two once a local lambda gained labels of its
+  // own (#1899): `y` is the LOCAL parameter, so a pass could resolve it
+  // correctly and still be recorded as suppression. `x=` is the top-level
+  // name, and the local binding has nothing to bind it to.
+  expect_no_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { let f = (y: Int) -> Int { y }; f(x=1) }")
   expect_no_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { match 1 { f => f(x=1) } }")
   expect_no_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { for f in [1] { f(x=1) }; 0 }")
+}
+
+test "a shadowing local lambda resolves against its OWN parameter names" {
+  // #1899: a shadowed callee used to get no parameter table at all, so this
+  // produced no authority even though the local binding declares `y`.
+  //
+  // Note this is not a new permission for unlabeled parameters: at top level a
+  // labeled argument has always resolved against a plain parameter, because
+  // collect_fn_param_labels records every parameter name (tilde-stripped)
+  // rather than only the marked ones. Measured on the pinned seed as well as
+  // on a current stage2. The local case is catching up with it.
+  expect_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { let f = (y: Int) -> Int { y }; f(y=1) }")
+  // A match binder and a for-in binder are not lambdas, so they still get no
+  // table -- they are covered as suppression above.
 }
 
 test "source and normalized programs are recursively detached" {


### PR DESCRIPTION
Closes #1899. Closes #1952.

A lambda bound by a `let` **inside a block** had no parameter table at all, so its labeled arguments were never reordered and its omitted optional arguments were never filled in:

```vibe
let s = (x~: Int, y~: Int) -> Int { x - y }
s(y = 3, x = 10)        // -7, silently, instead of 7        #1899, P0

let o = (a: Int, b?: Int) -> Int { ... }
o(7)                    // function arity mismatch           #1952, P1
```

Top level was always correct. `collect_fn_param_labels` and `collect_optional_param_fns` index top-level statements only, and `relabel_expr`'s `ECall` arm bailed out for any callee found in `shadows`. That bail-out is right as far as it goes — do not apply a top-level function's labels to a local binding that merely shares its name — but it left a local labeled lambda with *nothing*.

## Shadowing is the whole difficulty

The local table records the index each name occupies in `shadows`, and a lookup only answers when that entry is still the **innermost** binding of the name. A later binding — `let s = 5`, a parameter, a match binder — sits at a higher index, the entry stops matching, and the old bail-out stands.

That check is load-bearing, and I measured it rather than assuming: with `at == innermost` removed, the outer lambda's labels leak onto a match binder and the fixture's masking case returns **-7 instead of 7**.

| build | `mask_by_match_binder()` |
|---|---:|
| with the index check | 7 |
| index check removed | **-7** |

## Both lanes change together

`relabel_expr` and `relabel_expr_paired` relabel the same programs, so a disagreement between them is a difference in meaning — the same trap as the `compile_lambda` / `compile_expr_tail` pair in #1925. Each is restructured so the **only** shadow-dependent part is where the labels come from; the reorder itself, including the paired lane's binder-authority child remapping, is untouched.

## Two gates also had to widen

Both were silent rather than wrong-looking, which is why the local case had never been reached:

- **`stmt_has_labeled_arg`** (`dinsp_scan` mode 3) decides whether a statement needs the walk at all. An omitted optional argument leaves no syntactic trace at the call site, so a statement whose only feature was a block-local `(a: Int, b?: Int)` was skipped outright. The top-level equivalent is handled by `walk_all`, which is computed from `collect_optional_param_fns` and cannot see a local one.
- **`desugar_labeled_args`** skipped the entire program when the top-level table was empty. An optimisation until local lambdas got labels of their own — `collect_fn_param_labels` indexes `SLet`s, so a file whose top-level statements are all `test` blocks has an empty table, and nothing inside those tests was walked.

## Verification

**Measured through a stage2 built from this checkout, not the seed.** The seed predates #1925 and answers `0` where this case reports `-7` — that discrepancy is how the second half survived a "fix verified" claim once already (see the correction on #1899).

| step | result |
|---|---|
| baseline before the change, through the compiler about to be rebuilt | `-7` (#1899), `arity mismatch` (#1952) |
| after | `7`, `7` |
| the written-order expectation `-7` | flipped from **passing to failing**, so the value demonstrably moved |
| `fixtures/labeled_arg_in_block_test.vibe` (#1925) | still green |
| new fixture against the unfixed compiler | red |
| `scripts/compiler_gate.sh` | **104/104, 0 FAIL** |

Subtraction throughout, deliberately: `x + y` gives the right answer whether or not the arguments were reordered.

`fixtures/labeled_local_lambda_scope_test.vibe` pins all of it — both bugs, the masking case and its restoration, a recursive labeled binding, a local binding beating a same-named top-level one, the over-strip guard from #1925, and the top-level cases so a future change cannot "fix" the local path by breaking those. It follows the `*_test.vibe` convention, so `unit_test_runner.sh --list` picks it up with no registration.

## Note on the gate

`pkf run test` cannot complete in this container for an unrelated reason: under `pkf`'s PATH a nix-shim `sort` dies with `GLIBC_ABI_DT_X86_64_PLT not found`, the same family as the `sha256sum` shim fixed in #1977. `scripts/check_builtin_parity.sh` passes standalone (exit 0), and running `scripts/compiler_gate.sh` directly — where `sort` works — gives `[compiler-gate] ok`. Not addressed here; it is an environment/PATH issue rather than a repository one.

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_