### PR TITLE
fix: single-file Show interpolation and block-local optional params

### DIFF
--- a/fixtures/optional_param_test.vibe
+++ b/fixtures/optional_param_test.vibe
@@ -44,3 +44,14 @@ test "a partial suffix of optionals is filled" {
   assert(two(1, 2) == 3)
   assert(two(1, 2, 3) == 6)
 }
+
+test "a block-local lambda optional may be omitted" {
+  let o = (a: Int, b?: Int) -> Int {
+    match b {
+      Some(v) => a + v,
+      None => a
+    }
+  }
+  assert(o(7) == 7)
+  assert(o(7, 5) == 12)
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9370,6 +9370,86 @@ fn optional_param_flags(fname: String) -> Option[Array[Bool]] {
   }
 }
 
+// #1952: block-local `let o = (a, b?) -> ...` is in `shadows`, so the
+// top-level table must not apply — but the local function still needs fill.
+// Innermost binding wins; leave pops with the matching `shadows` mark.
+let optional_param_local_cell: Array[(String, Array[Bool])] = array_empty()
+
+fn efn_optional_flags(e: Expr) -> Option[Array[Bool]] {
+  match e {
+    EFn(_, _, params, _, _, _) => {
+      let flags = array_empty()
+      let mut any = false
+      let mut pi = 0
+      while pi < Array::length(params) {
+        let (pn, _) = Array::get(params, pi)
+        let pl = String::length(pn)
+        let is_opt = pl > 0 && pn[pl - 1: pl] == "?"
+        if is_opt {
+          any = true
+        } else {
+          ()
+        }
+        Array::push(flags, is_opt)
+        pi = pi + 1
+      }
+      if any {
+        Some(flags)
+      } else {
+        None
+      }
+    },
+    _ => None
+  }
+}
+
+fn optional_local_enter(name: String, v: Expr) -> Int {
+  let mark = Array::length(optional_param_local_cell)
+  match efn_optional_flags(v) {
+    Some(flags) => Array::push(optional_param_local_cell, (name, flags)),
+    None => ()
+  }
+  mark
+}
+
+fn optional_local_leave(mark: Int) -> Unit {
+  Array::truncate(optional_param_local_cell, mark)
+}
+
+fn optional_local_flags(fname: String) -> Option[Array[Bool]] {
+  let mut i = Array::length(optional_param_local_cell)
+  let mut found = None
+  while i > 0 {
+    i = i - 1
+    let (n, flags) = Array::get(optional_param_local_cell, i)
+    if n == fname {
+      found = Some(flags)
+      i = 0
+    } else {
+      ()
+    }
+  }
+  found
+}
+
+fn optional_flags_for_call(fname: String, shadows: Array[String]) -> Option[Array[Bool]] {
+  match optional_local_flags(fname) {
+    Some(flags) => Some(flags),
+    None => if str_array_contains(shadows, fname) {
+      None
+    } else {
+      optional_param_flags(fname)
+    }
+  }
+}
+
+fn stmts_have_optional_fn(_stmts: Array[Stmt]) -> Bool {
+  // Nested `let o = (a, b?) ->` leaves no top-level table entry. Walking
+  // every statement is cheap next to typecheck and is what makes #1952
+  // work in a file that has no top-level optional fn.
+  true
+}
+
 ///|
 /// Every top-level function that declares at least one optional (`z?`)
 /// parameter, with one flag per parameter. Functions with no optional
@@ -9774,13 +9854,9 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
         rargs
       }
       let opt_args = match callee {
-        EIdent(fname, _) => if str_array_contains(shadows, fname) {
-          final_args
-        } else {
-          match optional_param_flags(fname) {
-            Some(flags) => optional_fill_args(final_args, flags),
-            None => final_args
-          }
+        EIdent(fname, _) => match optional_flags_for_call(fname, shadows) {
+          Some(flags) => optional_fill_args(final_args, flags),
+          None => final_args
         },
         _ => final_args
       }
@@ -9819,25 +9895,31 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
     ELet(name, v, b, soff) => {
       let rv = relabel_expr(v, tbl, shadows)
       let mark = Array::length(shadows)
+      let local_mark = optional_local_enter(name, v)
       Array::push(shadows, name)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       ELet(name, rv, rb, soff)
     },
     ELetRec(name, v, b) => {
       let mark = Array::length(shadows)
+      let local_mark = optional_local_enter(name, v)
       Array::push(shadows, name)
       let rv = relabel_expr(v, tbl, shadows)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       ELetRec(name, rv, rb)
     },
     ELetMut(name, v, b, soff) => {
       let rv = relabel_expr(v, tbl, shadows)
       let mark = Array::length(shadows)
+      let local_mark = optional_local_enter(name, v)
       Array::push(shadows, name)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       ELetMut(name, rv, rb, soff)
     },
     EAssign(name, v, c) => EAssign(name, relabel_expr(v, tbl, shadows), relabel_expr(c, tbl, shadows)),
@@ -10016,13 +10098,9 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
         rargs
       }
       let final_args = match callee {
-        EIdent(fname, _) => if str_array_contains(shadows, fname) {
-          resolved
-        } else {
-          match optional_param_flags(fname) {
-            Some(flags) => optional_fill_args_paired(resolved, flags, poisoned),
-            None => resolved
-          }
+        EIdent(fname, _) => match optional_flags_for_call(fname, shadows) {
+          Some(flags) => optional_fill_args_paired(resolved, flags, poisoned),
+          None => resolved
         },
         _ => resolved
       }
@@ -10090,19 +10168,23 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       paired_expect_slot(node, 0, ExpressionLetBinder, name, poisoned)
       let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
       let mark = Array::length(shadows)
+      let local_mark = optional_local_enter(name, value)
       Array::push(shadows, name)
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       ELet(name, rvalue, rbody, offset)
     },
     ELetRec(name, value, body) => {
       paired_expect_node(node, AuthorityExprLetRec, 1, 2, poisoned)
       paired_expect_slot(node, 0, ExpressionLetRecBinder, name, poisoned)
       let mark = Array::length(shadows)
+      let local_mark = optional_local_enter(name, value)
       Array::push(shadows, name)
       let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       ELetRec(name, rvalue, rbody)
     },
     ELetMut(name, value, body, offset) => {
@@ -10110,9 +10192,11 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       paired_expect_slot(node, 0, ExpressionLetMutBinder, name, poisoned)
       let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
       let mark = Array::length(shadows)
+      let local_mark = optional_local_enter(name, value)
       Array::push(shadows, name)
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       ELetMut(name, rvalue, rbody, offset)
     },
     EAssign(name, value, cont) => {
@@ -10966,8 +11050,8 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   // stmt_has_labeled_arg finds.
   let opt_tbl = collect_optional_param_fns(stmts)
   optional_param_tbl_set(opt_tbl)
-  let walk_all = Array::length(opt_tbl) > 0
-  if Array::length(tbl) == 0 {
+  let walk_all = Array::length(opt_tbl) > 0 || stmts_have_optional_fn(stmts)
+  if Array::length(tbl) == 0 && !walk_all {
     ()
   } else {
     let mut i = 0
@@ -10981,6 +11065,7 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
     }
   }
   optional_param_tbl_set(array_empty())
+  Array::truncate(optional_param_local_cell, 0)
 }
 
 fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityNode], poisoned: Array[Bool]) -> Unit {
@@ -11010,6 +11095,7 @@ fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityN
     i = i + 1
   }
   optional_param_tbl_set(array_empty())
+  Array::truncate(optional_param_local_cell, 0)
 }
 
 export fn normalize_labeled_args_with_binder_authority(source: LocatedProgramBinderAuthority) -> LabeledArgBinderAuthorityNormalization {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9403,13 +9403,54 @@ fn efn_optional_flags(e: Expr) -> Option[Array[Bool]] {
   }
 }
 
+fn optional_flags_any(flags: Array[Bool]) -> Bool {
+  let mut i = 0
+  let mut any = false
+  while i < Array::length(flags) {
+    if Array::get(flags, i) {
+      any = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  any
+}
+
 fn optional_local_enter(name: String, v: Expr) -> Int {
   let mark = Array::length(optional_param_local_cell)
   match efn_optional_flags(v) {
     Some(flags) => Array::push(optional_param_local_cell, (name, flags)),
-    None => ()
+    None => Array::push(optional_param_local_cell, (name, array_empty()))
   }
   mark
+}
+
+fn optional_local_enter_names(shadows: Array[String], from: Int) -> Int {
+  let mark = Array::length(optional_param_local_cell)
+  let mut i = from
+  while i < Array::length(shadows) {
+    Array::push(optional_param_local_cell, (Array::get(shadows, i), array_empty()))
+    i = i + 1
+  }
+  mark
+}
+
+fn optional_local_replace(name: String, v: Expr) -> Unit {
+  let mut i = Array::length(optional_param_local_cell)
+  while i > 0 {
+    i = i - 1
+    let (n, _) = Array::get(optional_param_local_cell, i)
+    if n == name {
+      match efn_optional_flags(v) {
+        Some(flags) => Array::set(optional_param_local_cell, i, (name, flags)),
+        None => Array::set(optional_param_local_cell, i, (name, array_empty()))
+      }
+      i = 0
+    } else {
+      ()
+    }
+  }
 }
 
 fn optional_local_leave(mark: Int) -> Unit {
@@ -9434,7 +9475,11 @@ fn optional_local_flags(fname: String) -> Option[Array[Bool]] {
 
 fn optional_flags_for_call(fname: String, shadows: Array[String]) -> Option[Array[Bool]] {
   match optional_local_flags(fname) {
-    Some(flags) => Some(flags),
+    Some(flags) => if optional_flags_any(flags) {
+      Some(flags)
+    } else {
+      None
+    },
     None => if str_array_contains(shadows, fname) {
       None
     } else {
@@ -9922,8 +9967,14 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       optional_local_leave(local_mark)
       ELetMut(name, rv, rb, soff)
     },
-    EAssign(name, v, c) => EAssign(name, relabel_expr(v, tbl, shadows), relabel_expr(c, tbl, shadows)),
-    EAssignOp(name, op, v, c) => EAssignOp(name, op, relabel_expr(v, tbl, shadows), relabel_expr(c, tbl, shadows)),
+    EAssign(name, v, c) => {
+      optional_local_replace(name, v)
+      EAssign(name, relabel_expr(v, tbl, shadows), relabel_expr(c, tbl, shadows))
+    },
+    EAssignOp(name, op, v, c) => {
+      optional_local_replace(name, v)
+      EAssignOp(name, op, relabel_expr(v, tbl, shadows), relabel_expr(c, tbl, shadows))
+    },
     ESeq(a, b) => ESeq(relabel_expr(a, tbl, shadows), relabel_expr(b, tbl, shadows)),
     EMatch(scrut, arms) => {
       let rscrut = relabel_expr(scrut, tbl, shadows)
@@ -9932,9 +9983,12 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       while i < Array::length(arms) {
         let (p, b) = Array::get(arms, i)
         let mark = Array::length(shadows)
+        let local_mark = Array::length(optional_param_local_cell)
         collect_pat_binders(p, shadows)
+        let _entered = optional_local_enter_names(shadows, mark)
         Array::push(out, (p, relabel_expr(b, tbl, shadows)))
         Array::truncate(shadows, mark)
+        optional_local_leave(local_mark)
         i = i + 1
       }
       EMatch(rscrut, out)
@@ -9946,9 +10000,12 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       while i < Array::length(arms) {
         let (p, b) = Array::get(arms, i)
         let mark = Array::length(shadows)
+        let local_mark = Array::length(optional_param_local_cell)
         collect_pat_binders(p, shadows)
+        let _entered = optional_local_enter_names(shadows, mark)
         Array::push(out, (p, relabel_expr(b, tbl, shadows)))
         Array::truncate(shadows, mark)
+        optional_local_leave(local_mark)
         i = i + 1
       }
       EHandle(rscrut, out)
@@ -9960,38 +10017,47 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
         (name, relabel_expr(init, tbl, shadows))
       }
       let mark = Array::length(shadows)
+      let local_mark = Array::length(optional_param_local_cell)
       let mut pi = 0
       while pi < Array::length(params) {
         let (pname, _) = Array::get(params, pi)
         Array::push(shadows, pname)
         pi = pi + 1
       }
+      let _entered = optional_local_enter_names(shadows, mark)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       ELoop(rinits, rb)
     },
     EForIn(name, idx, iter, b) => {
       let riter = relabel_expr(iter, tbl, shadows)
       let mark = Array::length(shadows)
+      let local_mark = Array::length(optional_param_local_cell)
       Array::push(shadows, name)
       match idx {
         Some(ix) => Array::push(shadows, ix),
         None => ()
       }
+      let _entered = optional_local_enter_names(shadows, mark)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       EForIn(name, idx, riter, rb)
     },
     EFn(tp, bnds, params, rt, eff, b) => {
       let mark = Array::length(shadows)
+      let local_mark = Array::length(optional_param_local_cell)
       let mut pi = 0
       while pi < Array::length(params) {
         let (pn, _) = Array::get(params, pi)
         Array::push(shadows, strip_label_tilde(pn))
         pi = pi + 1
       }
+      let _entered = optional_local_enter_names(shadows, mark)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      optional_local_leave(local_mark)
       EFn(tp, bnds, params, rt, eff, rb)
     },
     EDot(obj, field, off, fdoff) => EDot(relabel_expr(obj, tbl, shadows), field, off, fdoff),
@@ -10201,10 +10267,12 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
     },
     EAssign(name, value, cont) => {
       paired_expect_node(node, AuthorityExprAssign, 0, 2, poisoned)
+      optional_local_replace(name, value)
       EAssign(name, relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(cont, tbl, shadows, node, 1, poisoned))
     },
     EAssignOp(name, op, value, cont) => {
       paired_expect_node(node, AuthorityExprAssignOp, 0, 2, poisoned)
+      optional_local_replace(name, value)
       EAssignOp(name, op, relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(cont, tbl, shadows, node, 1, poisoned))
     },
     ESeq(first, second) => {
@@ -11041,6 +11109,7 @@ export fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit {
 /// top-level statements that the allocation-free scalar scan finds contain a
 /// labeled argument.
 export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
+  Array::truncate(optional_param_local_cell, 0)
   let tbl = collect_fn_param_labels(stmts)
   // #1500: optional-parameter call sites are rewritten by the same walk (see
   // the ECall arm of relabel_expr). Unlike labeled arguments, an omitted
@@ -11069,6 +11138,7 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
 }
 
 fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityNode], poisoned: Array[Bool]) -> Unit {
+  Array::truncate(optional_param_local_cell, 0)
   let tbl = collect_fn_param_labels(stmts)
   let opt_tbl = collect_optional_param_fns(stmts)
   optional_param_tbl_set(opt_tbl)

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -9,6 +9,7 @@ deps = {
   @vibe/compiler/codegen : 0.0.1
   @vibe/compiler/codegen/common_analysis : 0.0.1
   @vibe/compiler/core : 0.0.1
+  @vibe/compiler/entry/source_compile/wasi_only : 0.0.1
   @vibe/compiler/loader : 0.0.1
   @vibe/compiler/runtime/eval_loader : 0.0.1
   @vibe/compiler/syntax : 0.0.1

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -67,6 +67,13 @@ import @vibe/compiler/codegen {
   compile_inline_wat
 }
 
+// #1948: the same Show-interpolation contract `vibe check` runs via
+// `expand_interp_stmts` after typecheck. `--single-file` used to stop at
+// `check_program` and certify `"\{no_show}"` as clean.
+import @vibe/compiler/entry/source_compile/wasi_only {
+  expand_interp_stmts
+}
+
 import @vibe/compiler/loader {
   ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs
 }
@@ -5003,6 +5010,10 @@ export fn collect_all_diagnostics(source: String) -> Array[String] with Exceptio
     } else {
       handle {
         let _env = check_program(stmts)
+        // #1948: full `vibe check` rejects a missing Show renderer here via
+        // check_linked_file -> expand_interp_stmts. The single-file lane
+        // must run the same pass or it reports clean for the same source.
+        expand_interp_stmts(stmts)
         // #946(4): the type checker never touches inline-wasm bodies (they're
         // opaque `%wasm(...)` marker calls until codegen extracts them — see
         // collect_inline_wasm_fns above), so a clean typecheck says nothing

--- a/lib/@vibe/compiler/tests/interp_show_single_file_diag_test.vibe
+++ b/lib/@vibe/compiler/tests/interp_show_single_file_diag_test.vibe
@@ -1,0 +1,36 @@
+//# Imports
+
+// #1948: `vibe check --single-file` must reject interpolation of a declared
+// aggregate with no Show renderer, same contract as full `vibe check`.
+import @vibe/compiler/runtime {
+  collect_all_diagnostics
+}
+
+//# Misc
+
+fn diags(src: String) -> Array[String] with Exception {
+  collect_all_diagnostics(src)
+}
+
+fn joined(src: String) -> String with Exception {
+  String::join(diags(src), "\n")
+}
+
+//# Tests
+
+fn interp_of(name: String) -> String {
+  // `"\{name}"` without writing an interpolation in THIS file.
+  String::concat("\"", String::concat("\\", String::concat("{", String::concat(name, "}\""))))
+}
+
+test "single-file diagnostics reject interpolating a type with no Show renderer" {
+  let src = String::concat("enum Hidden {\n  A\n}\nfn show_it() -> String {\n  let h = Hidden::A\n  ", String::concat(interp_of("h"), "\n}\n"))
+  let text = joined(src)
+  assert(String::contains(text, "cannot interpolate a value of type `Hidden`"))
+  assert(String::contains(text, "derive(Show)"))
+}
+
+test "single-file diagnostics accept interpolating a type with derive(Show)" {
+  let src = String::concat("enum Shown {\n  A\n} derive (Show)\nfn show_it() -> String {\n  let h = Shown::A\n  ", String::concat(interp_of("h"), "\n}\n"))
+  assert(Array::length(diags(src)) == 0)
+}

--- a/lib/@vibe/compiler/tests/optional_param_local_lambda_test.vibe
+++ b/lib/@vibe/compiler/tests/optional_param_local_lambda_test.vibe
@@ -39,3 +39,34 @@ test "block-local optional lambda is not an arity mismatch" {
   assert(String::contains(text, "arity mismatch") == false)
   assert(Array::length(diags(local_optional_src())) == 0)
 }
+
+fn shadow_non_optional_src() -> String {
+  let match_arms = " Some(v) => a + v, None => a "
+  let match_e = String::concat("\n    match b ", String::concat(brace(match_arms), "\n  "))
+  let outer = String::concat("\n  let o = (a: Int, b?: Int) -> Int ", brace(match_e))
+  let inner = String::concat("\n  let o = (x: Int) -> Int ", brace("\n    x\n  "))
+  let body = String::concat(outer, String::concat(inner, "\n  o(7)\n"))
+  String::concat("fn main() -> Int ", String::concat(brace(body), "\n"))
+}
+
+fn shadow_required_pair_src() -> String {
+  let match_arms = " Some(v) => a + v, None => a "
+  let match_e = String::concat("\n    match b ", String::concat(brace(match_arms), "\n  "))
+  let outer = String::concat("\n  let o = (a: Int, b?: Int) -> Int ", brace(match_e))
+  let inner_arms = " Some(v) => a * v, None => 0 "
+  let inner_match = String::concat("\n    match b ", String::concat(brace(inner_arms), "\n  "))
+  let inner = String::concat("\n  let o = (a: Int, b: Option[Int]) -> Int ", brace(inner_match))
+  let body = String::concat(outer, String::concat(inner, "\n  o(7)\n"))
+  String::concat("fn main() -> Int ", String::concat(brace(body), "\n"))
+}
+
+test "nearer non-optional binding is not filled from the outer optional" {
+  let text = String::join(diags(shadow_non_optional_src()), "\n")
+  assert(String::contains(text, "arity mismatch") == false)
+  assert(Array::length(diags(shadow_non_optional_src())) == 0)
+}
+
+test "nearer required second argument is still an arity mismatch" {
+  let text = String::join(diags(shadow_required_pair_src()), "\n")
+  assert(String::contains(text, "arity mismatch"))
+}

--- a/lib/@vibe/compiler/tests/optional_param_local_lambda_test.vibe
+++ b/lib/@vibe/compiler/tests/optional_param_local_lambda_test.vibe
@@ -1,0 +1,41 @@
+//# Imports
+
+// #1952: a block-local lambda with `b?` must accept an omitted argument,
+// same as a top-level `fn`.
+import @vibe/compiler/runtime {
+  collect_all_diagnostics
+}
+
+//# Misc
+
+fn diags(src: String) -> Array[String] with Exception {
+  collect_all_diagnostics(src)
+}
+
+fn lbrace() -> String {
+  String::from_char_code(123)
+}
+
+fn rbrace() -> String {
+  String::from_char_code(125)
+}
+
+fn brace(s: String) -> String {
+  String::concat(lbrace(), String::concat(s, rbrace()))
+}
+
+fn local_optional_src() -> String {
+  let match_arms = " Some(v) => a + v, None => a "
+  let match_e = String::concat("\n    match b ", String::concat(brace(match_arms), "\n  "))
+  let lambda = String::concat("\n  let o = (a: Int, b?: Int) -> Int ", brace(match_e))
+  let body = String::concat(lambda, "\n  o(7)\n")
+  String::concat("fn main() -> Int ", String::concat(brace(body), "\n"))
+}
+
+//# Tests
+
+test "block-local optional lambda is not an arity mismatch" {
+  let text = String::join(diags(local_optional_src()), "\n")
+  assert(String::contains(text, "arity mismatch") == false)
+  assert(Array::length(diags(local_optional_src())) == 0)
+}


### PR DESCRIPTION
Fixes #1948.
Fixes #1952.

## #1948 (P0)

`vibe check --single-file` used `collect_all_diagnostics` and stopped after `check_program`. Full `vibe check` then runs `expand_interp_stmts`, which rejects interpolating a declared aggregate with no Show renderer. Same source was therefore clean in the editor lane and rejected in the compile lane.

`collect_all_diagnostics` now runs the same `expand_interp_stmts` pass after typecheck.

## #1952

`collect_optional_param_fns` only walked top-level `fn`, and the `ECall` arm skipped any name in `shadows`. A block-local `let o = (a: Int, b?: Int) -> ...` therefore kept arity 2 and `o(7)` failed.

Local `EFn` flags are pushed on `ELet`/`ELetRec`/`ELetMut` and consulted before the top-level table.

## Tests

- `lib/@vibe/compiler/tests/interp_show_single_file_diag_test.vibe`
- `lib/@vibe/compiler/tests/optional_param_local_lambda_test.vibe`
- `fixtures/optional_param_test.vibe` (end-to-end once stage2 is rebuilt)