### PR TITLE
fix(vibe-test): preserve quoted test names in FAIL output

### DIFF
--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -260,18 +260,22 @@ vt_fail_detail() {
         close(fmfile)
       }
     }
-    # First __test_<name> frame = the failing test. Quoted names keep
-    # spaces and Unicode in the wasm name section; cut at the frame
-    # delimiter (` (wasm:` on Node/V8, EOL on wasmtime), not at the
-    # first non-[A-Za-z0-9_] character (#1946).
-    !seen_test && match($0, /__test_/) {
-      rest = substr($0, RSTART + 7)
+    # First __test_<name> stack frame = the failing test. Quoted names
+    # keep spaces and Unicode in the wasm name section; cut at the
+    # frame delimiter (` (wasm:` on Node/V8, EOL on wasmtime), not at
+    # the first non-[A-Za-z0-9_] character (#1946). Guest stderr can
+    # contain `__test_` (e.g. `__test_!!!`); only Node `at ... (wasm:`
+    # and wasmtime `<unknown>!` frames count.
+    !seen_test && match($0, /at __test_/) {
+      rest = substr($0, RSTART + length("at __test_"))
       if (match(rest, / \(wasm:/)) {
         failing = substr(rest, 1, RSTART - 1)
-      } else {
-        failing = rest
-        sub(/[[:space:]]+$/, "", failing)
+        if (failing != "") seen_test = 1
       }
+    }
+    !seen_test && match($0, /<unknown>!__test_/) {
+      failing = substr($0, RSTART + length("<unknown>!__test_"))
+      sub(/[[:space:]]+$/, "", failing)
       if (failing != "") seen_test = 1
     }
     # First trap-reason line (backtrace frames never contain these markers;

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -260,10 +260,19 @@ vt_fail_detail() {
         close(fmfile)
       }
     }
-    # First __test_<name> frame = the failing test.
-    !seen_test && match($0, /__test_[A-Za-z0-9_]+/) {
-      seen_test = 1
-      failing = substr($0, RSTART + 7, RLENGTH - 7)
+    # First __test_<name> frame = the failing test. Quoted names keep
+    # spaces and Unicode in the wasm name section; cut at the frame
+    # delimiter (` (wasm:` on Node/V8, EOL on wasmtime), not at the
+    # first non-[A-Za-z0-9_] character (#1946).
+    !seen_test && match($0, /__test_/) {
+      rest = substr($0, RSTART + 7)
+      if (match(rest, / \(wasm:/)) {
+        failing = substr(rest, 1, RSTART - 1)
+      } else {
+        failing = rest
+        sub(/[[:space:]]+$/, "", failing)
+      }
+      if (failing != "") seen_test = 1
     }
     # First trap-reason line (backtrace frames never contain these markers;
     # strip anyhow chain numbering / runner prefixes).

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -50,6 +50,54 @@ assert_full_failing_name "$WORK/space_name_test.vibe" "has a space"
 assert_full_failing_name "$WORK/unicode_name_test.vibe" "café 日本語"
 echo "[vibe-test-smoke] ok (quoted test names preserved on FAIL)"
 
+# Guest stderr that happens to contain `__test_!!!` must not become the
+# reported name. The unanchored `__test_` match used to consume that
+# line first and print `failing test: !!!` instead of the later frame.
+printf 'test "real name" {\n  Stderr::write_stream("__test_!!!\\n")\n  assert(false)\n}\n' \
+  > "$WORK/guest_prefix_test.vibe"
+assert_full_failing_name "$WORK/guest_prefix_test.vibe" "real name"
+if rg -q --fixed-strings "failing test: !!!" "$WORK/name_guest_prefix_test.out"; then
+  echo "[vibe-test-smoke] FAIL: guest stderr __test_!!! was reported as the failing test" >&2
+  cat "$WORK/name_guest_prefix_test.out" >&2
+  exit 1
+fi
+
+# Same contract on canned Node / wasmtime dumps, so wasmtime is pinned
+# without a second backend compile. Drive vt_fail_detail directly —
+# vibe_test.sh is not sourceable (it runs tests on load).
+eval "$(sed -n '/^vt_fail_detail() {/,/^export -f vt_fail_detail$/p' \
+  "$ROOT_DIR/scripts/vibe_test.sh")"
+assert_canned_failing_name() {
+  local label="$1" want="$2" errf out
+  errf="$WORK/canned_${label}.err"
+  cat > "$errf"
+  out="$(vt_fail_detail "$errf" "" "canned.vibe")"
+  if ! printf '%s\n' "$out" | rg -q --fixed-strings "failing test: $want"; then
+    echo "[vibe-test-smoke] FAIL: canned $label expected 'failing test: $want'" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$out" | rg -q --fixed-strings "failing test: !!!"; then
+    echo "[vibe-test-smoke] FAIL: canned $label reported guest stderr as the name" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+assert_canned_failing_name node "real name" <<'EOF'
+__test_!!!
+RuntimeError: unreachable
+    at __test_real name (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+assert_canned_failing_name wasmtime "real name" <<'EOF'
+__test_!!!
+error while executing at wasm backtrace:
+    0: 0x42 - <unknown>!__test_real name
+    1: 0x10 - <unknown>!_start
+   wasm trap: wasm `unreachable` instruction executed
+EOF
+echo "[vibe-test-smoke] ok (guest __test_ prefix is not the failing-test name)"
+
 # The seed-compiler notice. A green run through the committed seed says nothing
 # about a compiler change in this checkout, and the two are indistinguishable
 # from the result -- so the run has to say which compiler answered whenever the

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -22,6 +22,34 @@ fi
 
 echo "[vibe-test-smoke] ok (pass-file=0, fail-file!=0)"
 
+# #1946: a quoted test name must appear in full on FAIL. The runner used to
+# match `__test_[A-Za-z0-9_]+` and cut the name at the first space (and drop
+# Unicode). Exit status stays non-zero; the line is still `failing test: ...`.
+printf 'test "has a space" {\n  assert(false)\n}\n' > "$WORK/space_name_test.vibe"
+printf 'test "café 日本語" {\n  assert(false)\n}\n' > "$WORK/unicode_name_test.vibe"
+assert_full_failing_name() {
+  local src="$1" want="$2" out rc
+  out="$WORK/name_$(basename "$src" .vibe).out"
+  set +e
+  VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+    bash "$ROOT_DIR/scripts/vibe_test.sh" "$src" >"$out" 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "[vibe-test-smoke] FAIL: '$want' did not fail (exit 0)" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+  if ! rg -q --fixed-strings "failing test: $want" "$out"; then
+    echo "[vibe-test-smoke] FAIL: expected 'failing test: $want' in the FAIL output" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+}
+assert_full_failing_name "$WORK/space_name_test.vibe" "has a space"
+assert_full_failing_name "$WORK/unicode_name_test.vibe" "café 日本語"
+echo "[vibe-test-smoke] ok (quoted test names preserved on FAIL)"
+
 # The seed-compiler notice. A green run through the committed seed says nothing
 # about a compiler change in this checkout, and the two are indistinguishable
 # from the result -- so the run has to say which compiler answered whenever the


### PR DESCRIPTION
Refs #1946 (name-preservation slice only).

`scripts/vibe_test.sh` condensed trap dumps with `__test_[A-Za-z0-9_]+`, so a quoted name such as `test "has a space"` was reported as `failing test: has`. The wasm name section already keeps the source spelling (spaces and Unicode). This change cuts the name at the stack-frame delimiter instead:

- Node/V8: text between `__test_` and ` (wasm:`
- wasmtime: text between `__test_` and EOL

Output stays one `failing test: <name>` line. A failing named test still exits non-zero.

## Test

`scripts/vibe_test_smoke.sh` now compiles two fixtures and greps the full name:

- `test "has a space" { assert(false) }`
- `test "café 日本語" { assert(false) }`

Red before the awk change (`failing test: has`); green after.

## Not in this PR

- `assert_eq` expected/actual rendering (`compile_call.vibe`) — later slice
- directory-input policy / doc agreement (cheatsheet vs `vibe test` vs tutorial)
- `runtime/vibe` `condense_test_trap` still uses the old regex; user-facing `vibe test` is unchanged

No seed wasm.