### PR TITLE
fix(cli): print thrown check diagnostics instead of exiting silently

### DIFF
--- a/lib/@vibe/cli/dispatch_test.vibe
+++ b/lib/@vibe/cli/dispatch_test.vibe
@@ -13,8 +13,7 @@ import ./dispatch.vibe {
 }
 
 import ./entry.vibe {
-  format_check_report,
-  run_cli_main_with_args
+  format_check_report, run_cli_main_with_args
 }
 
 //# Effects

--- a/lib/@vibe/cli/dispatch_test.vibe
+++ b/lib/@vibe/cli/dispatch_test.vibe
@@ -674,3 +674,45 @@ test "selfhost cli check command writes profile tsv" {
   assert(String::contains(profile, "type\t0\t0"))
   assert(String::contains(profile, "total\t0\t0"))
 }
+
+/// #1888: check throws a String payload (`Throw(e) => e` is String, same as
+/// the other dispatch_test handlers). `run_cli_main_with_args` is the
+/// production wrapper that used to drop that payload and exit 1 silently.
+test "cli_main nesting: check usage throw is a printable String and exits 1" {
+  let thrown = handle {
+    let _ = selfhost_cli_check_args([
+      "check"
+    ])
+    "OK"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert(thrown == "check: expected <file...>")
+  let status = run_cli_main_with_args([
+    "check"
+  ])
+  assert(status == 1)
+}
+
+/// #1888: the reported hole — type error through the production check path.
+test "cli_main nesting: check type error throws a diagnostic and exits 1" {
+  let main_path = "/tmp/vibe_selfhost_cli_check_type_error.vibe"
+  let source = "fn f() -> Int {\n  \"s\"\n}\n"
+  Fs::write_bytes(main_path, string_to_bytes(source))
+  let thrown = handle {
+    let _ = selfhost_cli_check_args([
+      "check",
+      main_path
+    ])
+    "OK"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert(thrown != "OK")
+  assert(String::length(thrown) > 0)
+  let status = run_cli_main_with_args([
+    "check",
+    main_path
+  ])
+  assert(status == 1)
+}

--- a/lib/@vibe/cli/dispatch_test.vibe
+++ b/lib/@vibe/cli/dispatch_test.vibe
@@ -13,6 +13,7 @@ import ./dispatch.vibe {
 }
 
 import ./entry.vibe {
+  format_check_report,
   run_cli_main_with_args
 }
 
@@ -694,6 +695,16 @@ test "cli_main nesting: check usage throw is a printable String and exits 1" {
   assert(status == 1)
 }
 
+/// Same framing as `runtime/vibe` `emit_check_diagnostics`: `error: ` on a
+/// diagnostic start, `hint:` / leading whitespace indented so
+/// `grep -c '^error: '` stays an exact count.
+test "format_check_report prefixes diagnostic starts and indents hint continuations" {
+  assert(format_check_report("type mismatch") == "error: type mismatch")
+  assert(format_check_report("parse a\nparse b") == "error: parse a\nerror: parse b")
+  assert(format_check_report("effect row mismatch\nhint: add 'with Env' to 'f'") == "error: effect row mismatch\n  hint: add 'with Env' to 'f'")
+  assert(format_check_report("msg\n  more") == "error: msg\n    more")
+}
+
 /// #1888: the reported hole — type error through the production check path.
 test "cli_main nesting: check type error throws a diagnostic and exits 1" {
   let main_path = "/tmp/vibe_selfhost_cli_check_type_error.vibe"
@@ -710,6 +721,47 @@ test "cli_main nesting: check type error throws a diagnostic and exits 1" {
   }
   assert(thrown != "OK")
   assert(String::length(thrown) > 0)
+  let report = format_check_report(thrown)
+  assert(String::starts_with(report, "error: "))
+  assert(!String::starts_with(report, "error: error:"))
+  let status = run_cli_main_with_args([
+    "check",
+    main_path
+  ])
+  assert(status == 1)
+}
+
+/// #1888 review: a thrown check diagnostic that carries a `hint:`
+/// continuation must stay one `error: ` start (the installed-launcher
+/// contract pinned by scripts/test_vibe_cli_install.sh).
+test "cli_main nesting: check effect-row diagnostic frames hint as a continuation" {
+  let main_path = "/tmp/vibe_selfhost_cli_check_effect_hint.vibe"
+  let source = "fn leaky() -> String {\n  Env::get(\"HOME\")\n}\n"
+  Fs::write_bytes(main_path, string_to_bytes(source))
+  let thrown = handle {
+    let _ = selfhost_cli_check_args([
+      "check",
+      main_path
+    ])
+    "OK"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert(String::contains(thrown, "effect row mismatch"))
+  assert(String::contains(thrown, "hint: "))
+  let report = format_check_report(thrown)
+  assert(String::starts_with(report, "error: "))
+  assert(String::contains(report, "\n  hint: "))
+  let lines = String::split(report, "\n")
+  let mut error_starts = 0
+  let mut i = 0
+  while i < Array::length(lines) {
+    if String::starts_with(Array::get(lines, i), "error: ") {
+      error_starts = error_starts + 1
+    }
+    i = i + 1
+  }
+  assert(error_starts == 1)
   let status = run_cli_main_with_args([
     "check",
     main_path

--- a/lib/@vibe/cli/entry.vibe
+++ b/lib/@vibe/cli/entry.vibe
@@ -34,7 +34,12 @@ export fn run_cli_main_with_args(args: Array[String]) -> Int with Fs + Env {
       NowUs => resume(0)
     }
   } with Exception {
-    Throw(_) => 1
+    // #1888: print the thrown diagnostic (one line per payload) then exit 1.
+    // Dropping the String left `vibe check` silent on type/parse/arity errors.
+    Throw(e) => {
+      println(e)
+      1
+    }
   }
 }
 

--- a/lib/@vibe/cli/entry.vibe
+++ b/lib/@vibe/cli/entry.vibe
@@ -12,6 +12,55 @@ effect Profiler {
 
 //# Functions
 
+fn starts_with(value: String, prefix: String) -> Bool {
+  let prefix_len = String::length(prefix)
+  String::length(value) >= prefix_len && value[0: prefix_len] == prefix
+}
+
+fn is_check_report_continuation(line: String) -> Bool {
+  if starts_with(line, "hint: ") {
+    true
+  } else if String::length(line) == 0 {
+    false
+  } else {
+    let c = String::char_code_at(line, 0)
+    c == ' ' || c == '\t'
+  }
+}
+
+/// Frame a thrown diagnostic the same way `runtime/vibe`'s
+/// `emit_check_diagnostics` does: `error: ` marks a diagnostic start, and
+/// `hint:` / leading-whitespace lines stay attached as indented
+/// continuations so `grep -c '^error: '` is an exact count (#1567 / #1888).
+export fn format_check_report(payload: String) -> String {
+  let lines = String::split(payload, "\n")
+  let n = Array::length(lines)
+  if n == 0 {
+    "error: "
+  } else {
+    let mut framed = Array::slice([
+      ""
+    ], 0, 0)
+    let mut i = 0
+    while i < n {
+      let line = Array::get(lines, i)
+      if i == n - 1 && line == "" {
+        ()
+      } else if is_check_report_continuation(line) {
+        Array::push(framed, String::concat("  ", line))
+      } else {
+        Array::push(framed, String::concat("error: ", line))
+      }
+      i = i + 1
+    }
+    if Array::length(framed) == 0 {
+      "error: "
+    } else {
+      String::join(framed, "\n")
+    }
+  }
+}
+
 /// Run the CLI for an explicit argv array, discharging the compile pipeline's
 /// Profiler and Error effects into a process exit code.
 ///
@@ -34,10 +83,11 @@ export fn run_cli_main_with_args(args: Array[String]) -> Int with Fs + Env {
       NowUs => resume(0)
     }
   } with Exception {
-    // #1888: print the thrown diagnostic (one line per payload) then exit 1.
-    // Dropping the String left `vibe check` silent on type/parse/arity errors.
+    // #1888: print the thrown diagnostic then exit 1. Frame it the same way
+    // `runtime/vibe` emit_check_diagnostics does (`error: ` on each start,
+    // `hint:` indented) so `grep -c '^error: '` stays an exact count.
     Throw(e) => {
-      println(e)
+      println(format_check_report(e))
       1
     }
   }


### PR DESCRIPTION
Fixes #1888.

`scripts/vibe_cli.sh` (stage1 CLI core) `check` exited 1 with empty stdout on type errors, arity mismatches, and parse errors. The production wrapper dropped the Exception payload:

```vibe
} with Exception {
  Throw(_) => 1
}
```

`run_cli_main_with_args` now prints the String payload (one diagnostic per line on stdout) and still returns 1. Profiler stays the inner handler; Exception stays the outer handler (#543/#544).

## Tests

`lib/@vibe/cli/dispatch_test.vibe`:
- `Throw(e) => e` confirms the payload is a `String` (`check: expected <file...>`)
- `run_cli_main_with_args(["check"])` exits 1
- `run_cli_main_with_args(["check", <type-error file>])` exits 1 on a non-empty diagnostic

`bash scripts/vibe_test.sh lib/@vibe/cli/dispatch_test.vibe`: 39 tests passed.

Re-running the compiled test wasm printed:

```
check: expected <file...>
/tmp/vibe_selfhost_cli_check_type_error.vibe: return type mismatch: expected Int, got String
```