### PR TITLE
fix(parser): locate unexpected-token errors at the throw site

### DIFF
--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -80,6 +80,8 @@ fn lex_ok(src: String) -> Bool
 fn lex_with_offsets(src: String) -> (Array[Token], Array[Int], Array[Int]) with Exception
 fn lex_with_offsets_recovering(src: String) -> (Array[Token], Array[Int], Array[Int], Array[Int], Array[String])
 fn offset_to_line_col(src: String, offset: Int) -> (Int, Int)
+fn remember_parse_source(source: String) -> Unit
+fn format_unexpected_token(starts: Array[Int], pos: Int, actual: String) -> String
 fn collect_doc_comments(src: String) -> Array[(Int, String)]
 
 // --- parser_base

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -81,6 +81,7 @@ fn lex_with_offsets(src: String) -> (Array[Token], Array[Int], Array[Int]) with 
 fn lex_with_offsets_recovering(src: String) -> (Array[Token], Array[Int], Array[Int], Array[Int], Array[String])
 fn offset_to_line_col(src: String, offset: Int) -> (Int, Int)
 fn remember_parse_source(source: String) -> Unit
+fn last_unexpected_token_pos() -> Int
 fn format_unexpected_token(starts: Array[Int], pos: Int, actual: String) -> String
 fn collect_doc_comments(src: String) -> Array[(Int, String)]
 

--- a/lib/@vibe/parser/lexer.vibe
+++ b/lib/@vibe/parser/lexer.vibe
@@ -1281,12 +1281,19 @@ export fn lex_with_offsets_recovering(source: String) -> (Array[Token], Array[In
   (ArrayBuilder::freeze(b), ArrayBuilder::freeze(starts), ArrayBuilder::freeze(ends), ArrayBuilder::freeze(err_offsets), ArrayBuilder::freeze(err_msgs))
 }
 
-/// Last source text seen by `lex` / `remember_parse_source`. Tokens-only
-/// entries (`parse_program(lex(src))`) have no source argument, so the
-/// unexpected-token throw site reads this to emit `line L:col C:` instead
-/// of encoding a token index for a later decoder (#1862).
+/// Source of the parse that supplied `starts`. Located/recovering entries
+/// set this so `format_unexpected_token` can turn a token index into
+/// `line:col`. `lex` must not write it: a later lex of B must not relocate
+/// a parse of A's tokens (#1862).
 let last_parse_source_cell: Array[String] = Array::slice([
   ""
+], 0, 0)
+
+/// Failing token index for the last `format_unexpected_token`. Recovery
+/// used to decode `at #N` from the message; the user-facing form no longer
+/// carries that index, so the pos lives here instead of in the string.
+let last_unexpected_token_pos_cell: Array[Int] = Array::slice([
+  0
 ], 0, 0)
 
 export fn remember_parse_source(source: String) -> Unit {
@@ -1302,34 +1309,33 @@ fn last_parse_source() -> String {
   }
 }
 
-fn token_offset_for_error(starts: Array[Int], pos: Int, source: String) -> Int {
-  if pos >= 0 && pos < Array::length(starts) {
-    Array::get(starts, pos)
+export fn last_unexpected_token_pos() -> Int {
+  if Array::length(last_unexpected_token_pos_cell) > 0 {
+    Array::get(last_unexpected_token_pos_cell, 0)
   } else {
-    let recovered = handle {
-      lex_with_offsets(source).1
-    } with Exception {
-      Throw(_) => ArrayBuilder::freeze(ArrayBuilder::new())
-    }
-    if pos >= 0 && pos < Array::length(recovered) {
-      Array::get(recovered, pos)
-    } else {
-      0
-    }
+    -1
   }
 }
 
-/// User-facing unexpected-token diagnostic (#1862). Located at the throw
-/// site so lanes that skip `extract_err_token_pos` still get `line L:col C:`
-/// and never see a token index or lexer `(prev=..., next=...)` debris.
+fn remember_unexpected_token_pos(pos: Int) -> Unit {
+  Array::truncate(last_unexpected_token_pos_cell, 0)
+  Array::push(last_unexpected_token_pos_cell, pos)
+}
+
+/// User-facing unexpected-token diagnostic (#1862). Never encodes a token
+/// index or lexer `(prev=..., next=...)` debris. Emits `line L:col C:` only
+/// when `starts` contains the failing token and this parse remembered its
+/// source; tokens-only `parse_program` has empty `starts` and must not
+/// invent a location from a leftover source.
 export fn format_unexpected_token(starts: Array[Int], pos: Int, actual: String) -> String {
+  remember_unexpected_token_pos(pos)
   let source = last_parse_source()
-  if String::length(source) == 0 {
-    String::concat("unexpected token: ", actual)
-  } else {
-    let off = token_offset_for_error(starts, pos, source)
+  if pos >= 0 && pos < Array::length(starts) && String::length(source) > 0 {
+    let off = Array::get(starts, pos)
     let (line, col) = offset_to_line_col(source, off)
     String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), String::concat(": unexpected token: ", actual)))))
+  } else {
+    String::concat("unexpected token: ", actual)
   }
 }
 
@@ -1358,7 +1364,6 @@ export fn offset_to_line_col(source: String, offset: Int) -> (Int, Int) {
 }
 
 export fn lex(source: String) -> Array[Token] with Exception {
-  remember_parse_source(source)
   let len = String::length(source)
   {
     let b = ArrayBuilder::new()

--- a/lib/@vibe/parser/lexer.vibe
+++ b/lib/@vibe/parser/lexer.vibe
@@ -1281,6 +1281,58 @@ export fn lex_with_offsets_recovering(source: String) -> (Array[Token], Array[In
   (ArrayBuilder::freeze(b), ArrayBuilder::freeze(starts), ArrayBuilder::freeze(ends), ArrayBuilder::freeze(err_offsets), ArrayBuilder::freeze(err_msgs))
 }
 
+/// Last source text seen by `lex` / `remember_parse_source`. Tokens-only
+/// entries (`parse_program(lex(src))`) have no source argument, so the
+/// unexpected-token throw site reads this to emit `line L:col C:` instead
+/// of encoding a token index for a later decoder (#1862).
+let last_parse_source_cell: Array[String] = Array::slice([
+  ""
+], 0, 0)
+
+export fn remember_parse_source(source: String) -> Unit {
+  Array::truncate(last_parse_source_cell, 0)
+  Array::push(last_parse_source_cell, source)
+}
+
+fn last_parse_source() -> String {
+  if Array::length(last_parse_source_cell) > 0 {
+    Array::get(last_parse_source_cell, 0)
+  } else {
+    ""
+  }
+}
+
+fn token_offset_for_error(starts: Array[Int], pos: Int, source: String) -> Int {
+  if pos >= 0 && pos < Array::length(starts) {
+    Array::get(starts, pos)
+  } else {
+    let recovered = handle {
+      lex_with_offsets(source).1
+    } with Exception {
+      Throw(_) => ArrayBuilder::freeze(ArrayBuilder::new())
+    }
+    if pos >= 0 && pos < Array::length(recovered) {
+      Array::get(recovered, pos)
+    } else {
+      0
+    }
+  }
+}
+
+/// User-facing unexpected-token diagnostic (#1862). Located at the throw
+/// site so lanes that skip `extract_err_token_pos` still get `line L:col C:`
+/// and never see a token index or lexer `(prev=..., next=...)` debris.
+export fn format_unexpected_token(starts: Array[Int], pos: Int, actual: String) -> String {
+  let source = last_parse_source()
+  if String::length(source) == 0 {
+    String::concat("unexpected token: ", actual)
+  } else {
+    let off = token_offset_for_error(starts, pos, source)
+    let (line, col) = offset_to_line_col(source, off)
+    String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), String::concat(": unexpected token: ", actual)))))
+  }
+}
+
 /// Convert a 0-based char offset (from lex_with_offsets) to 1-based (line, col).
 /// Source-span foundation: lets diagnostics report a real `line:col`.
 export fn offset_to_line_col(source: String, offset: Int) -> (Int, Int) {
@@ -1306,6 +1358,7 @@ export fn offset_to_line_col(source: String, offset: Int) -> (Int, Int) {
 }
 
 export fn lex(source: String) -> Array[Token] with Exception {
+  remember_parse_source(source)
   let len = String::length(source)
   {
     let b = ArrayBuilder::new()

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -64,7 +64,7 @@ import ./token.vibe {
 }
 
 import ./lexer.vibe {
-  offset_to_line_col, remember_parse_source
+  last_unexpected_token_pos, offset_to_line_col, remember_parse_source
 }
 
 import ./parser_binder_context.vibe {
@@ -931,16 +931,24 @@ export fn parse_program(tokens: Array[Token]) -> Array[Stmt] with Exception {
 /// Per-statement wrapping keeps the change local. Build the prefix with
 /// String::concat (not `+` or interpolation) to avoid selfhost string-concat
 /// NUL fragility. Source-span foundation: located parse diagnostics.
-/// #816: in-body parse errors carry the failing TOKEN index as "at #N"
-/// (expect_tk and the primary-dispatch "unexpected token" throw). Decode it so
-/// the located wrapper anchors the diagnostic at the OFFENDING token instead
-/// of the enclosing statement's start (an error on line 6 used to report
-/// "line 2:1"), and strip the index + the lexer-internal "(prev=..., next=...)"
-/// debris from the user-facing message.
+/// #816: in-body parse errors still carry the failing TOKEN index as "at #N"
+/// (expect_tk and the remaining encode sites). Decode it so recovery and the
+/// located wrapper anchor at the OFFENDING token instead of the enclosing
+/// statement's start. Converted unexpected-token throws keep that index in
+/// `last_unexpected_token_pos` rather than the user-facing message.
 fn extract_err_token_pos(msg: String, fallback_pos: Int) -> (Int, String) {
   let mi = String::index_of(msg, " at #")
   if mi < 0 {
-    (fallback_pos, msg)
+    if String::index_of(msg, "unexpected token") >= 0 {
+      let remembered = last_unexpected_token_pos()
+      if remembered >= 0 {
+        (remembered, msg)
+      } else {
+        (fallback_pos, msg)
+      }
+    } else {
+      (fallback_pos, msg)
+    }
   } else {
     let mlen = String::length(msg)
     let mut di = mi + 5
@@ -979,9 +987,8 @@ fn extract_err_token_pos(msg: String, fallback_pos: Int) -> (Int, String) {
 }
 
 /// Prefix `line L:col C:` when the throw site has not already located the
-/// message. Throw sites converted in #1862 emit the final form themselves so
-/// tokens-only lanes stay readable; re-prefixing those would double the
-/// location (`line 3:1: line 2:32: ...`).
+/// message. Located unexpected-token throws emit the final form themselves;
+/// re-prefixing those would double the location (`line 3:1: line 2:32: ...`).
 fn locate_parse_error(msg: String, fallback_pos: Int, starts: Array[Int], source: String) -> String {
   if String::index_of(msg, "line ") == 0 {
     msg

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -64,7 +64,7 @@ import ./token.vibe {
 }
 
 import ./lexer.vibe {
-  offset_to_line_col
+  offset_to_line_col, remember_parse_source
 }
 
 import ./parser_binder_context.vibe {
@@ -978,7 +978,33 @@ fn extract_err_token_pos(msg: String, fallback_pos: Int) -> (Int, String) {
   }
 }
 
+/// Prefix `line L:col C:` when the throw site has not already located the
+/// message. Throw sites converted in #1862 emit the final form themselves so
+/// tokens-only lanes stay readable; re-prefixing those would double the
+/// location (`line 3:1: line 2:32: ...`).
+fn locate_parse_error(msg: String, fallback_pos: Int, starts: Array[Int], source: String) -> String {
+  if String::index_of(msg, "line ") == 0 {
+    msg
+  } else {
+    let (err_pos, cleaned_msg) = extract_err_token_pos(msg, fallback_pos)
+    let anchor_pos = if err_pos < Array::length(starts) {
+      err_pos
+    } else {
+      fallback_pos
+    }
+    let off = if anchor_pos < Array::length(starts) {
+      Array::get(starts, anchor_pos)
+    } else {
+      0
+    }
+    let (line, col) = offset_to_line_col(source, off)
+    let loc = String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), ": "))))
+    String::concat(loc, cleaned_msg)
+  }
+}
+
 fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[Int], source: String, context: Option[ParserBinderContext]) -> (Array[Stmt], Int) with Exception {
+  remember_parse_source(source)
   let cfg_active = cfg_scan_enabled(tokens)
   let b = ArrayBuilder::new()
   let mut pos = 0
@@ -1040,20 +1066,7 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
           }
         } with Exception {
           Throw(msg) => {
-            let (err_pos, cleaned_msg) = extract_err_token_pos(msg, start_pos)
-            let anchor_pos = if err_pos < Array::length(starts) {
-              err_pos
-            } else {
-              start_pos
-            }
-            let off = if anchor_pos < Array::length(starts) {
-              Array::get(starts, anchor_pos)
-            } else {
-              0
-            }
-            let (line, col) = offset_to_line_col(source, off)
-            let loc = String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), ": "))))
-            throw(String::concat(loc, cleaned_msg))
+            throw(locate_parse_error(msg, start_pos, starts, source))
           }
         }
         let mut ii = 0
@@ -1125,6 +1138,7 @@ export fn parse_program_located_with_binder_context(tokens: Array[Token], starts
 }
 
 export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], source: String) -> (Array[Stmt], Array[String]) with Exception {
+  remember_parse_source(source)
   let cfg_active = handle {
     cfg_scan_enabled(tokens)
   } with Exception {
@@ -1204,20 +1218,13 @@ export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], sou
           Some((stmts, next))
         } with Exception {
           Throw(msg) => {
-            let (err_pos, cleaned_msg) = extract_err_token_pos(msg, start_pos)
+            let err_pos = extract_err_token_pos(msg, start_pos).0
             let anchor_pos = if err_pos >= start_pos && err_pos < Array::length(starts) {
               err_pos
             } else {
               start_pos
             }
-            let off = if anchor_pos < Array::length(starts) {
-              Array::get(starts, anchor_pos)
-            } else {
-              0
-            }
-            let (line, col) = offset_to_line_col(source, off)
-            let loc = String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), ": "))))
-            ArrayBuilder::push(diags, String::concat(loc, cleaned_msg))
+            ArrayBuilder::push(diags, locate_parse_error(msg, start_pos, starts, source))
             // #946: resynchronize from the ERROR ANCHOR, not the statement
             // start. Every token before the anchor was already consumed as
             // part of this failed statement, so restarting the parse at each

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -35,7 +35,7 @@ import ./parser_binder_context.vibe {
 }
 
 import ./lexer.vibe {
-  lex_with_offsets
+  format_unexpected_token, lex_with_offsets
 }
 
 //# Functions
@@ -619,14 +619,8 @@ fn parse_control_primary(tokens: Array[Token], starts: Array[Int], pos: Int, par
     TYield => throw("'yield' is not supported"),
     TDeclare => throw("'declare' is not supported"),
     _ => {
-      let prev_name = if pos > 0 {
-        tk_name(peek(tokens, pos - 1))
-      } else {
-        "start"
-      }
       let actual = tk_name(peek(tokens, pos))
-      let next_name = tk_name(peek(tokens, pos + 1))
-      throw("unexpected token at #\{pos}: \{actual} (prev=\{prev_name}, next=\{next_name})")
+      throw(format_unexpected_token(starts, pos, actual))
     }
   }
 }

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -5,7 +5,7 @@ import ./lexer.vibe {
 }
 
 import ./parser.vibe {
-  parse_program, parse_program_located
+  parse_program, parse_program_located, parse_program_recovering
 }
 
 import @vibe/ast {
@@ -272,45 +272,88 @@ fn unexpected_token_probe_source() -> String {
   "test \"p\" {\n  let ys = Array::map([1,2,3], fn(x) { x * 2 })\n}\n"
 }
 
-fn assert_unexpected_token_located(result: String) -> Unit {
-  assert(String::contains(result, "line "))
+fn assert_unexpected_token_clean(result: String) -> Unit {
   assert(String::contains(result, "unexpected token: fn"))
   assert(!String::contains(result, " at #"))
   assert(!String::contains(result, "prev="))
   assert(!String::contains(result, "next="))
 }
 
-test "#1862: raw parse_program unexpected-token is located" {
-  // gc / tokens-only lanes call parse_program(lex(src)) and never run
-  // extract_err_token_pos, so the throw site itself must emit line:col
-  // and must not leak the token index or lexer (prev/next) debris.
+fn recovered_let_named(stmts: Array[Stmt], want: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(stmts) && !found {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, _) => {
+        found = name == want
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+test "#1862: raw parse_program unexpected-token has no token-index debris" {
+  // tokens-only parse_program has empty starts, so it cannot honestly
+  // locate. It must still drop the token index and lexer (prev/next)
+  // debris instead of inventing a line:col from a leftover source.
   let result = handle {
     let _ = parse_program(lex("let x = fn"))
     "OK"
   } with Exception {
     Throw(e) => e
   }
-  assert_eq(result, "line 1:9: unexpected token: fn")
+  assert_eq(result, "unexpected token: fn")
   let probe = handle {
     let _ = parse_program(lex(unexpected_token_probe_source()))
     "OK"
   } with Exception {
     Throw(e) => e
   }
-  assert_unexpected_token_located(probe)
+  assert_unexpected_token_clean(probe)
+  assert(!String::contains(probe, "line "))
+}
+
+test "#1862: tokens-only parse does not claim a location from a later lex" {
+  let tokens_a = lex("let x = fn")
+  let _ = lex("\n\n\n\n\nlet y = fn")
+  let result = handle {
+    let _ = parse_program(tokens_a)
+    "OK"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert_eq(result, "unexpected token: fn")
+  assert(!String::contains(result, "line "))
 }
 
 test "#1862: parse_program_located unexpected-token stays single-located" {
   let src = unexpected_token_probe_source()
   let result = handle {
     let (tokens, starts, _) = lex_with_offsets(src)
+    let _ = lex("\n\n\n\n\nlet y = fn")
     let _ = parse_program_located(tokens, starts, src)
     "OK"
   } with Exception {
     Throw(e) => e
   }
-  assert_unexpected_token_located(result)
+  assert_unexpected_token_clean(result)
   assert(String::starts_with(result, "line "))
   let rest = String::substring(result, 5, String::length(result))
   assert(String::index_of(rest, "line ") < 0)
+}
+
+test "#1862: recovering unexpected-token resyncs at the failing token" {
+  // Inner `let` looks like a recovery point. Resyncing from the statement
+  // start (the old `at #N` extract now returns start_pos) re-parses that
+  // `let` and duplicates the diagnostic. The throw site keeps the failing
+  // token index aside so recovery skips to `let ok`.
+  let src = "test \"p\" {\n  let ys = Array::map([1,2,3], fn(x) { x * 2 })\n}\nlet ok = 1\n"
+  let (tokens, starts, _) = lex_with_offsets(src)
+  let (stmts, diags) = parse_program_recovering(tokens, starts, src)
+  assert_eq(Array::length(diags), 1)
+  assert_unexpected_token_clean(Array::get(diags, 0))
+  assert(String::starts_with(Array::get(diags, 0), "line "))
+  assert(recovered_let_named(stmts, "ok"))
 }

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -1,11 +1,11 @@
 //# Imports
 
 import ./lexer.vibe {
-  lex, lex_ok
+  lex, lex_ok, lex_with_offsets
 }
 
 import ./parser.vibe {
-  parse_program
+  parse_program, parse_program_located
 }
 
 import @vibe/ast {
@@ -266,4 +266,51 @@ test "parse_program: `perform Error::Throw` stays legal (operation qualifier)" {
   let tokens = lex("fn f() -> Int with Exception { perform Error::Throw(\"x\") }")
   let stmts = parse_program(tokens)
   assert(Array::length(stmts) == 1)
+}
+
+fn unexpected_token_probe_source() -> String {
+  "test \"p\" {\n  let ys = Array::map([1,2,3], fn(x) { x * 2 })\n}\n"
+}
+
+fn assert_unexpected_token_located(result: String) -> Unit {
+  assert(String::contains(result, "line "))
+  assert(String::contains(result, "unexpected token: fn"))
+  assert(!String::contains(result, " at #"))
+  assert(!String::contains(result, "prev="))
+  assert(!String::contains(result, "next="))
+}
+
+test "#1862: raw parse_program unexpected-token is located" {
+  // gc / tokens-only lanes call parse_program(lex(src)) and never run
+  // extract_err_token_pos, so the throw site itself must emit line:col
+  // and must not leak the token index or lexer (prev/next) debris.
+  let result = handle {
+    let _ = parse_program(lex("let x = fn"))
+    "OK"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert_eq(result, "line 1:9: unexpected token: fn")
+  let probe = handle {
+    let _ = parse_program(lex(unexpected_token_probe_source()))
+    "OK"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert_unexpected_token_located(probe)
+}
+
+test "#1862: parse_program_located unexpected-token stays single-located" {
+  let src = unexpected_token_probe_source()
+  let result = handle {
+    let (tokens, starts, _) = lex_with_offsets(src)
+    let _ = parse_program_located(tokens, starts, src)
+    "OK"
+  } with Exception {
+    Throw(e) => e
+  }
+  assert_unexpected_token_located(result)
+  assert(String::starts_with(result, "line "))
+  let rest = String::substring(result, 5, String::length(result))
+  assert(String::index_of(rest, "line ") < 0)
 }


### PR DESCRIPTION
## Summary

First slice of #1862. Parse errors were locating themselves by encoding a token index and lexer internals into the message (`unexpected token at #22: fn (prev=,, next=()`). Only two call sites decoded that wire format, so gc and other tokens-only lanes printed the debris as-is.

This slice converts the common `unexpected token` throw in `parse_control_primary`. The throw site now emits the final user-facing form:

```
line L:col C: unexpected token: TOKEN
```

`lex()` and the located/recovering entries remember the source so tokens-only `parse_program(lex(src))` can resolve `starts` and call `offset_to_line_col` at the throw. `extract_err_token_pos` still exists for the remaining encode sites; it no longer re-prefixes a message that is already located.

## Throw site changed

- `lib/@vibe/parser/parser_expr_primary.vibe` — `parse_control_primary` catch-all (`unexpected token at #N: TOKEN (prev=..., next=...)`)

That is the only `throw("unexpected token at #` site.

## What remains (do not close #1862)

32 `at #N` encode sites still bury a token index in the message:

- `parser.vibe` — 3
- `parser_base.vibe` — 9
- `parser_expr.vibe` — 9
- `parser_expr_core.vibe` — 6
- `parser_expr_dispatch.vibe` — 2
- `parser_expr_primary.vibe` — 2 (type-arg / `map { }` diagnostics, not unexpected-token)

`extract_err_token_pos` stays until those are converted the same way.

## Test

`parser_smoke_test.vibe`:

- raw `parse_program(lex(...))` reports `line 1:9: unexpected token: fn` and does not contain ` at #` or `prev=`
- `parse_program_located` stays single-located on the issue's `Array::map(..., fn(...))` probe

## Notes

- Not `Fixes #1862` — unexpected-token is located on remaining lanes, but the rest of the encode family is not.
- No seed wasm in this commit.

Refs #1862