### PR TITLE
fix(desugar): reorder labeled calls on let mut lambdas (#1994)

### DIFF
--- a/fixtures/labeled_local_lambda_scope_test.vibe
+++ b/fixtures/labeled_local_lambda_scope_test.vibe
@@ -16,7 +16,9 @@
 // first half of #1899 survived a "fix verified" claim.
 
 fn block_local_labels() -> Int {
-  let s = (x~: Int, y~: Int) -> Int { x - y }
+  let s = (x~: Int, y~: Int) -> Int {
+    x - y
+  }
   s(y = 3, x = 10)
 }
 
@@ -48,8 +50,12 @@ fn block_local_optional_supplied() -> Int {
 // This case is load-bearing and was measured: with the innermost-index check
 // removed from the lookup, it returns -7 instead of 7.
 fn mask_by_match_binder() -> Int {
-  let s = (x~: Int, y~: Int) -> Int { x - y }
-  match Some((x~: Int, y~: Int) -> Int { y - x }) {
+  let s = (x~: Int, y~: Int) -> Int {
+    x - y
+  }
+  match Some((x~: Int, y~: Int) -> Int {
+    y - x
+  }) {
     Some(s) => s(y = 3, x = 10),
     None => 0
   }
@@ -57,17 +63,23 @@ fn mask_by_match_binder() -> Int {
 
 // ...and the outer binding comes back into force once the masking one ends.
 fn restored_after_mask() -> Int {
-  let s = (x~: Int, y~: Int) -> Int { x - y }
+  let s = (x~: Int, y~: Int) -> Int {
+    x - y
+  }
   let _masked = mask_by_match_binder()
   s(y = 3, x = 10)
 }
 
 // A local binding shadowing a top-level function of the same name takes the
 // LOCAL labels, not the top-level table's.
-let dup = (x~: Int, y~: Int) -> Int { x - y }
+let dup = (x~: Int, y~: Int) -> Int {
+  x - y
+}
 
 fn local_wins_over_top_level() -> Int {
-  let dup = (x~: Int, y~: Int) -> Int { y - x }
+  let dup = (x~: Int, y~: Int) -> Int {
+    y - x
+  }
   dup(y = 3, x = 10)
 }
 
@@ -88,7 +100,9 @@ fn rec_labeled() -> Int {
 // ride the closure environment.
 fn real_capture() -> Int {
   let n = 5
-  let f = (x~: Int) -> Int { x + n }
+  let f = (x~: Int) -> Int {
+    x + n
+  }
   f(x = 10)
 }
 
@@ -98,13 +112,19 @@ fn real_capture() -> Int {
 // updates the table; a call after `if` is a known residual (no flow
 // analysis) and is not pinned here.
 fn mutable_initializer() -> Int {
-  let mut g = (x~: Int, y~: Int) -> Int { x - y }
+  let mut g = (x~: Int, y~: Int) -> Int {
+    x - y
+  }
   g(y = 3, x = 10)
 }
 
 fn mutable_reassigned() -> Int {
-  let mut g = (x~: Int, y~: Int) -> Int { x - y }
-  g = (y~: Int, x~: Int) -> Int { x - y }
+  let mut g = (x~: Int, y~: Int) -> Int {
+    x - y
+  }
+  g = (y~: Int, x~: Int) -> Int {
+    x - y
+  }
   g(y = 3, x = 10)
 }
 

--- a/fixtures/labeled_local_lambda_scope_test.vibe
+++ b/fixtures/labeled_local_lambda_scope_test.vibe
@@ -94,6 +94,20 @@ fn real_capture() -> Int {
 
 // Top level always worked. These are here so a future change that "fixes" the
 // local case by breaking the top-level one cannot pass.
+// #1994: a `let mut` lambda is still a lambda. Sequential assignment
+// updates the table; a call after `if` is a known residual (no flow
+// analysis) and is not pinned here.
+fn mutable_initializer() -> Int {
+  let mut g = (x~: Int, y~: Int) -> Int { x - y }
+  g(y = 3, x = 10)
+}
+
+fn mutable_reassigned() -> Int {
+  let mut g = (x~: Int, y~: Int) -> Int { x - y }
+  g = (y~: Int, x~: Int) -> Int { x - y }
+  g(y = 3, x = 10)
+}
+
 fn top_level_labels() -> Int {
   dup(y = 3, x = 10)
 }
@@ -114,6 +128,8 @@ test "labeled and optional parameters on a block-local lambda" {
   inspect(local_wins_over_top_level(), "-7")
   inspect(rec_labeled(), "10")
   inspect(real_capture(), "15")
+  inspect(mutable_initializer(), "7")
+  inspect(mutable_reassigned(), "7")
   inspect(top_level_labels(), "7")
   inspect(top_level_optional(7), "7")
   inspect(top_level_optional(10, 3), "7")

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9525,7 +9525,7 @@ let local_fn_tbl_cell: Array[(String, Array[String], Array[Bool], Int)] = array_
 /// Record a `let`-bound lambda's parameter shape. Non-lambda bindings are
 /// deliberately not recorded: they have no labels, and their presence in
 /// `shadows` is what masks any outer entry.
-fn local_fn_tbl_push(name: String, v: Expr, at: Int) -> Unit {
+fn local_fn_tbl_shape(v: Expr) -> Option[(Array[String], Array[Bool])] {
   match v {
     EFn(_, _, params, _, _, _) => {
       let labels = empty_str_array()
@@ -9540,9 +9540,54 @@ fn local_fn_tbl_push(name: String, v: Expr, at: Int) -> Unit {
         Array::push(flags, pl > 0 && __slice(pn, pl - 1, pl) == "?")
         i = i + 1
       }
-      Array::push(local_fn_tbl_cell, (name, labels, flags, at))
+      Some((labels, flags))
     },
-    _ => ()
+    _ => None
+  }
+}
+
+fn local_fn_tbl_push(name: String, v: Expr, at: Int) -> Unit {
+  match local_fn_tbl_shape(v) {
+    Some((labels, flags)) => Array::push(local_fn_tbl_cell, (name, labels, flags, at)),
+    None => ()
+  }
+}
+
+/// #1994: sequential `g = (y~, x~) -> ...` updates the entry for the
+/// innermost `g`. A non-lambda RHS invalidates it. Assignment inside a
+/// branch still only reaches that branch's continuation.
+fn local_fn_tbl_replace(name: String, v: Expr, shadows: Array[String]) -> Unit {
+  let mut innermost = 0 - 1
+  let mut i = 0
+  while i < Array::length(shadows) {
+    if Array::get(shadows, i) == name {
+      innermost = i
+    }
+    i = i + 1
+  }
+  if innermost < 0 {
+    ()
+  } else {
+    let mut j = Array::length(local_fn_tbl_cell) - 1
+    let mut found = false
+    while j >= 0 {
+      let (n, _, _, at) = Array::get(local_fn_tbl_cell, j)
+      if n == name && at == innermost {
+        match local_fn_tbl_shape(v) {
+          Some((labels, flags)) => Array::set(local_fn_tbl_cell, j, (name, labels, flags, at)),
+          None => Array::set(local_fn_tbl_cell, j, (name, empty_str_array(), array_empty(), at))
+        }
+        found = true
+        j = 0 - 1
+      } else {
+        j = j - 1
+      }
+    }
+    if !found {
+      local_fn_tbl_push(name, v, innermost)
+    } else {
+      ()
+    }
   }
 }
 
@@ -10067,30 +10112,30 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
     ELetMut(name, v, b, soff) => {
       let rv = relabel_expr(v, tbl, shadows)
       let mark = Array::length(shadows)
+      let lmark = Array::length(local_fn_tbl_cell)
       let local_mark = optional_local_enter(name, v)
       Array::push(shadows, name)
-      // Deliberately NOT registered. A `let mut` can be reassigned to another
-      // type-compatible lambda whose parameter NAMES differ, and this table
-      // would still describe the initializer -- reordering a later call by
-      // stale names, or filling an omitted optional the new lambda does not
-      // have. Invalidating on EAssign does not fix it either: an assignment
-      // inside a branch or a loop only reaches its own continuation, so a call
-      // after the `if` would still read the stale entry. Without a flow
-      // analysis the honest answer is to leave a mutable binding unresolved,
-      // which is what happened before #1899 and is never wrong -- only
-      // unhelpful.
+      // #1994: register the initializer, then `local_fn_tbl_replace` on
+      // sequential assign. A call after an assignment that sits in a
+      // sibling branch is still unresolved — that needs flow analysis.
+      local_fn_tbl_push(name, v, mark)
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
+      local_fn_tbl_truncate(lmark)
       optional_local_leave(local_mark)
       ELetMut(name, rv, rb, soff)
     },
     EAssign(name, v, c) => {
       optional_local_replace(name, v)
-      EAssign(name, relabel_expr(v, tbl, shadows), relabel_expr(c, tbl, shadows))
+      let rv = relabel_expr(v, tbl, shadows)
+      local_fn_tbl_replace(name, v, shadows)
+      EAssign(name, rv, relabel_expr(c, tbl, shadows))
     },
     EAssignOp(name, op, v, c) => {
       optional_local_replace(name, v)
-      EAssignOp(name, op, relabel_expr(v, tbl, shadows), relabel_expr(c, tbl, shadows))
+      let rv = relabel_expr(v, tbl, shadows)
+      local_fn_tbl_replace(name, v, shadows)
+      EAssignOp(name, op, rv, relabel_expr(c, tbl, shadows))
     },
     ESeq(a, b) => ESeq(relabel_expr(a, tbl, shadows), relabel_expr(b, tbl, shadows)),
     EMatch(scrut, arms) => {
@@ -10394,23 +10439,29 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       paired_expect_slot(node, 0, ExpressionLetMutBinder, name, poisoned)
       let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
       let mark = Array::length(shadows)
+      let lmark = Array::length(local_fn_tbl_cell)
       let local_mark = optional_local_enter(name, value)
       Array::push(shadows, name)
-      // Not registered -- see the ELetMut arm of relabel_expr.
+      local_fn_tbl_push(name, value, mark)
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
       Array::truncate(shadows, mark)
+      local_fn_tbl_truncate(lmark)
       optional_local_leave(local_mark)
       ELetMut(name, rvalue, rbody, offset)
     },
     EAssign(name, value, cont) => {
       paired_expect_node(node, AuthorityExprAssign, 0, 2, poisoned)
       optional_local_replace(name, value)
-      EAssign(name, relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(cont, tbl, shadows, node, 1, poisoned))
+      let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
+      local_fn_tbl_replace(name, value, shadows)
+      EAssign(name, rvalue, relabel_expr_paired_child(cont, tbl, shadows, node, 1, poisoned))
     },
     EAssignOp(name, op, value, cont) => {
       paired_expect_node(node, AuthorityExprAssignOp, 0, 2, poisoned)
       optional_local_replace(name, value)
-      EAssignOp(name, op, relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(cont, tbl, shadows, node, 1, poisoned))
+      let rvalue = relabel_expr_paired_child(value, tbl, shadows, node, 0, poisoned)
+      local_fn_tbl_replace(name, value, shadows)
+      EAssignOp(name, op, rvalue, relabel_expr_paired_child(cont, tbl, shadows, node, 1, poisoned))
     },
     ESeq(first, second) => {
       paired_expect_node(node, AuthorityExprSeq, 0, 2, poisoned)

--- a/lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe
+++ b/lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe
@@ -203,6 +203,17 @@ test "lexical shadowing suppresses top-level resolution in every scoped lane" {
   expect_no_authority("fn f(x: Int) -> Int { x }\nfn main() -> Int { for f in [1] { f(x=1) }; 0 }")
 }
 
+test "a let-mut lambda uses its own labels and updates them on assign" {
+  // #1994: `let mut` used to stay unregistered so a later labeled call was
+  // left in written order (silent-wrong: (x~, y~) called as y=3, x=10 gave
+  // -7). Sequential assignment can update the table: the continuation of
+  // EAssign is the only place the new value is visible without flow analysis.
+  expect_authority("fn main() -> Int { let mut g = (x~: Int, y~: Int) -> Int { x - y }; g(y=3, x=10) }")
+  expect_authority("fn main() -> Int { let mut g = (x~: Int, y~: Int) -> Int { x - y }; g = (y~: Int, x~: Int) -> Int { x - y }; g(y=3, x=10) }")
+  expect_ordinary_parity("fn main() -> Int { let mut g = (x~: Int, y~: Int) -> Int { x - y }; g(y=3, x=10) }")
+  expect_ordinary_parity("fn main() -> Int { let mut g = (x~: Int, y~: Int) -> Int { x - y }; g = (y~: Int, x~: Int) -> Int { x - y }; g(y=3, x=10) }")
+}
+
 test "a shadowing local lambda resolves against its OWN parameter names" {
   // #1899: a shadowed callee used to get no parameter table at all, so this
   // produced no authority even though the local binding declares `y`.


### PR DESCRIPTION
Closes #1994.

A `let mut` lambda's labeled arguments were applied in written order,
silently. `let mut g = (x~, y~) -> { x - y }; g(y=3, x=10)` compiled
and returned **-7**.

#1991 left `let mut` unregistered because a later assignment can change
parameter names, and updating only the EAssign continuation cannot see a
call after an `if`. That is honest but leaves the sequential case wrong.

This registers the initializer and updates the table on sequential
`g = (y~, x~) -> ...`. The issue's own program then returns **7**.
A call after a branch assignment is still a residual (no flow analysis).

Verified: `normalize_labeled_arg_binder_authority_test` through the
pinned seed (ordinary and paired lanes). Runtime inspects are in
`fixtures/labeled_local_lambda_scope_test.vibe` for the stage2 CI lane.