### PR TITLE
test: migrate three generic fixture debt rows (#1967)

### DIFF
--- a/fixtures/generic_multiple_calls.vibe
+++ b/fixtures/generic_multiple_calls.vibe
@@ -1,8 +1,0 @@
-let identity = [T](x: T) -> T { x }
-let a = identity(42)
-let b = identity("hello")
-let c = identity(true)
-(a, b, c)
-
-__DATA__
-{"last": "(42, \"hello\", true)"}

--- a/fixtures/generic_multiple_calls_test.vibe
+++ b/fixtures/generic_multiple_calls_test.vibe
@@ -1,0 +1,13 @@
+// #1967: was fixtures/generic_multiple_calls.vibe + __DATA__.last
+// (42, "hello", true). Inspect components; tuple __to_string is not stable.
+
+fn identity[T](x: T) -> T {
+  x
+}
+
+test "generic identity works on Int String and Bool" {
+  inspect(identity(42), "42")
+  inspect(identity("hello"), "hello")
+  assert(identity(true))
+  assert(!identity(false))
+}

--- a/fixtures/generic_two_params.vibe
+++ b/fixtures/generic_two_params.vibe
@@ -1,5 +1,0 @@
-let pair = [A, B](a: A, b: B) -> (A, B) { (a, b) }
-pair(1, "hello")
-
-__DATA__
-{"last": "(1, \"hello\")"}

--- a/fixtures/generic_two_params_test.vibe
+++ b/fixtures/generic_two_params_test.vibe
@@ -1,0 +1,15 @@
+// #1967: was fixtures/generic_two_params.vibe + __DATA__.last (1, "hello").
+
+fn pair[A, B](a: A, b: B) -> (A, B) {
+  (a, b)
+}
+
+test "generic pair keeps both arguments" {
+  let value = pair(1, "hello")
+  match value {
+    (n, s) => {
+      inspect(n, "1")
+      inspect(s, "hello")
+    }
+  }
+}

--- a/fixtures/generic_wrap_array.vibe
+++ b/fixtures/generic_wrap_array.vibe
@@ -1,5 +1,0 @@
-let wrap = [T](x: T) -> Array[T] { [x] }
-wrap(42)
-
-__DATA__
-{"last": "[42]"}

--- a/fixtures/generic_wrap_array_test.vibe
+++ b/fixtures/generic_wrap_array_test.vibe
@@ -1,0 +1,13 @@
+// #1967: was fixtures/generic_wrap_array.vibe + __DATA__.last [42].
+
+fn wrap[T](x: T) -> Array[T] {
+  [
+    x
+  ]
+}
+
+test "generic wrap puts the value in a one-element array" {
+  let xs = wrap(42)
+  inspect(Array::length(xs), "1")
+  inspect(xs[0], "42")
+}

--- a/scripts/runtime_fixture_debt.tsv
+++ b/scripts/runtime_fixture_debt.tsv
@@ -58,9 +58,6 @@ fixtures/forward_reference_mutual.vibe	compile debt: mutually recursive local re
 fixtures/forward_reference_no_ret_annotation.vibe	compile debt: local forward reference add_one is rejected
 fixtures/from_to_lines.vibe	compile debt: Lines::parse reaches codegen unresolved
 fixtures/generic_explicit_type_arg.vibe	compile debt: explicit type argument Int is rejected in this spelling
-fixtures/generic_multiple_calls.vibe	runtime debt: generated expected-value assertion traps
-fixtures/generic_two_params.vibe	runtime debt: generated expected-value assertion traps
-fixtures/generic_wrap_array.vibe	runtime debt: generated expected-value assertion traps
 fixtures/handle_mutable_in_handler.vibe	runtime debt: generated expected-value assertion traps
 fixtures/import_symbol_ref.vibe	compile debt: stale import symbol-list syntax is rejected
 fixtures/import_version_ref.vibe	compile debt: stale versioned import syntax is rejected


### PR DESCRIPTION
Partial leftover slice of #1967 after #2005.

Moved three non-effect runtime-debt fixtures off `__DATA__.last`:

- `generic_multiple_calls` — identity on Int / String / Bool
- `generic_two_params` — pair constructor
- `generic_wrap_array` — wrap into a one-element array

Inspect components rather than the old tuple/array debug printer.
Debt rows removed from `scripts/runtime_fixture_debt.tsv`. Remaining
non-effect rows stay on #1967.