### PR TITLE
fix(test): print expected and actual on assert_eq failure

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -109,7 +109,8 @@ vibe run     <file.vibex> [-- args]   compile the fixed `main` entry then run
 vibe compile <file.vibe> -o <out>     compile to a .wasm
 vibe build   <file.vibe> -o <out>     alias of compile
 vibe check   <file.vibe|file.vibex>   parse + typecheck (no output kept)
-vibe test    <file_test.vibe>...      compile + run test {} blocks
+vibe test    <file_test.vibe|dir>...  compile + run test {} blocks
+                                      (a directory expands to *_test.vibe)
 vibe fetch   [project_dir]            vendor git/URL deps from vibe.deps + lock
 vibe lsp                              start the stdio LSP server (diagnostics)
 vibe context-pack [--out FILE]        emit cheatsheet + verified golden examples

--- a/docs/tutorial/06_tests-ja.vibe.md
+++ b/docs/tutorial/06_tests-ja.vibe.md
@@ -22,8 +22,8 @@ String も内容で比較されるので、連結・関数の返り値・変数�
 
 ```bash
 vibe test file_test.vibe             # 1 ファイル
-vibe test a_test.vibe b_test.vibe    # 複数ファイル (ディレクトリは渡せない —
-                                     # 引数はファイルのみ、glob はシェルで展開する)
+vibe test a_test.vibe b_test.vibe    # 複数ファイル
+vibe test tests/                     # ディレクトリ以下の *_test.vibe 全部
 ```
 
 ## CLI ツーリング

--- a/docs/tutorial/06_tests.vibe.md
+++ b/docs/tutorial/06_tests.vibe.md
@@ -22,8 +22,8 @@ concatenations, function results, and values reached through a variable.
 
 ```bash
 vibe test file_test.vibe             # one file
-vibe test a_test.vibe b_test.vibe    # several files (directories are not accepted --
-                                     # arguments are files only; let the shell expand globs)
+vibe test a_test.vibe b_test.vibe    # several files
+vibe test tests/                     # every *_test.vibe under a directory
 ```
 
 ## CLI tooling

--- a/docs/vibe.md
+++ b/docs/vibe.md
@@ -919,7 +919,7 @@ CLI:
   `pkf run run -- <args>`.
 - `vibe run <file>` executes a script (ignores `test {}`).
 - Interactive evaluation lives under `vibe shell` / `vibe shell-stdin`.
-- `vibe test <file...>` runs test blocks and prints a report.
+- `vibe test <file|dir...>` runs test blocks and prints a report. A directory expands to every `*_test.vibe` under it.
 - `vibe compile [--wasm | --wasm-js-string | --wasm-mvp | --component | --wit | --wit-component] [-o out] <file>`
   emits IR (default) or wasm bytes.
   - `--wasm` = linear-memory backend (production default). `--wasm-gc` is not yet

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -3041,12 +3041,10 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       nl
     }
     else if fname == "assert_eq" {
-      // #756: lower as `assert(a == b)` — the synthesized `==` rides
-      // emit_eq_value's operand classification (intish fast-path, #724 agg
-      // slots, runtime `eq` fall-back). The old raw i64.eq compared the
-      // (ptr<<32)|len STRING repr by pointer, so a heap string the static
-      // classifier can't see (e.g. a tuple-destructured binding) failed
-      // against an equal-content literal while `a == b` passed.
+      // Fallback only. The shipped path rewrites `assert_eq` in
+      // desugar_trait_dicts (expected/actual on stderr, then trap). This
+      // arm stays for lanes that skip that pass (compile_module): still
+      // `assert(a == b)` so #756's value-aware `==` is what compares.
       let nl = ce(buf, EBinOp("==", Array::get(args, 0), Array::get(args, 1)), local_names, next_local, ctx, ld)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -3016,10 +3016,9 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         nl
       }
       else if fname == "assert_eq" {
-        // Keep parity with the linear lowering: compiling the synthesized
-        // equality expression routes strings and aggregate bindings through
-        // the backend's value-aware equality path instead of a raw call-site
-        // representation comparison.
+        // Fallback only. The shipped path rewrites `assert_eq` in
+        // desugar_trait_dicts. Keep parity with the linear fallback:
+        // synthesized `==` uses the backend's value-aware equality path.
         let nl = ce(buf, EBinOp("==", Array::get(args, 0), Array::get(args, 1)), local_names, next_local, ld)
         emit_i64_eqz(buf)
         emit_if_void(buf)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -5291,9 +5291,12 @@ fn lower_assert_eq(args: Array[Expr], gens: Array[(String, Array[(String, String
   let actual_s = assert_eq_render(actual, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
   let expected_s = assert_eq_render(expected, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
   let msg = assert_eq_concat(EString("assert_eq failed\n  expected: "), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\n")))))
-  // Stderr, not stdout: `vibe test` discards stdout. Then trap so the
-  // existing `__test_` frame and `RuntimeError` path stay intact.
-  let fail = ESeq(ECall(EIdent("Stderr::write_stream", -1), [
+  // println, not Stderr::write_stream: the gc lane only reserves host
+  // imports when the source already used one, and flipping that on a
+  // SIMD-only file shifts every generated-body index (gc-gate
+  // simd_skip_ws_test). `vibe test` now keeps stdout on FAIL so the
+  // diagnostic still reaches vt_fail_detail.
+  let fail = ESeq(ECall(EIdent("println", -1), [
     msg
   ], -1), ECall(EIdent("assert_true", -1), [
     EBool(false)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -5218,6 +5218,90 @@ fn interp_take_repl(r: Option[Expr]) -> Expr {
   }
 }
 
+/// #1946 leftover: a two-argument `assert_eq` call. The builtin is still
+/// what the checker sees (effect-free); this pass rewrites it after check so
+/// a failure can print both sides without adding Stderr/Exception to the
+/// source row.
+fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
+  match callee {
+    EIdent(n, _) => n == "assert_eq" && Array::length(args) == 2,
+    _ => false
+  }
+}
+
+fn assert_eq_concat(a: Expr, b: Expr) -> Expr {
+  ECall(EIdent("String::concat", -1), [
+    a,
+    b
+  ], -1)
+}
+
+/// Render one `assert_eq` operand. Reuses the throw-site renderer
+/// (`derived_only`) so a missing Show becomes `<unprintable>` instead of a
+/// pointer decimal or a compile error.
+fn assert_eq_render(arg: Expr, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+  let target = interp_show_target(arg, true, struct_sets, var_types, fn_returns)
+  if target != "" {
+    ECall(EIdent(target, -1), Array::slice([
+      arg
+    ], 0, 1), -1)
+  } else {
+    let expanded = interp_expand(arg, true, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+    if interp_has_repl(expanded) {
+      interp_take_repl(expanded)
+    } else {
+      match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
+        Some(tn) => if is_scalar_type_name(tn) {
+          ECall(EIdent("__to_string", -1), Array::slice([
+            arg
+          ], 0, 1), -1)
+        } else {
+          EString("<unprintable>")
+        },
+        None => {
+          let as_scalar = match arg {
+            EInt(_) => true,
+            EBool(_) => true,
+            EString(_) => true,
+            EFloat(_) => true,
+            _ => false
+          }
+          if as_scalar {
+            ECall(EIdent("__to_string", -1), Array::slice([
+              arg
+            ], 0, 1), -1)
+          } else {
+            EString("<unprintable>")
+          }
+        }
+      }
+    }
+  }
+}
+
+fn lower_assert_eq(args: Array[Expr], gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+  let a2 = rewrite_expr(Array::get(args, 0), gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+  let b2 = rewrite_expr(Array::get(args, 1), gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+  let an = dinsp_fresh_name("__assert_eq_actual", a2, b2)
+  let en = dinsp_fresh_name("__assert_eq_expected", a2, b2)
+  let vars1 = bind_shapes(extend_var_types(var_types, an, infer_arg_type_name(a2, struct_sets, var_types, fn_returns)), an, a2, struct_sets, fn_returns)
+  let vars2 = bind_shapes(extend_var_types(vars1, en, infer_arg_type_name(b2, struct_sets, vars1, fn_returns)), en, b2, struct_sets, fn_returns)
+  let actual = EIdent(an, -1)
+  let expected = EIdent(en, -1)
+  let actual_s = assert_eq_render(actual, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
+  let expected_s = assert_eq_render(expected, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
+  let msg = assert_eq_concat(EString("assert_eq failed\n  expected: "), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\n")))))
+  // Stderr, not stdout: `vibe test` discards stdout. Then trap so the
+  // existing `__test_` frame and `RuntimeError` path stay intact.
+  let fail = ESeq(ECall(EIdent("Stderr::write_stream", -1), [
+    msg
+  ], -1), ECall(EIdent("assert_true", -1), [
+    EBool(false)
+  ], -1))
+  let cmp = rewrite_expr(EBinOp("==", actual, expected), gens, traits, struct_sets, dict_binds, vars2, fn_returns)
+  ELet(an, a2, ELet(en, b2, EIf(cmp, EUnit, fail), -1), -1)
+}
+
 /// The core rewriter. `dict_binds` is non-empty only inside a transformed
 /// generic's body (so `T::method` resolves to a dict field); call-site dict
 /// threading applies everywhere a transformed generic is called. `var_types`
@@ -5325,6 +5409,8 @@ fn rewrite_expr(expr: Expr, gens: Array[(String, Array[(String, String, Int)])],
       } else if interp_has_repl(interp_repl) {
         // #1392: the interpolation of a value this pass can render.
         interp_take_repl(interp_repl)
+      } else if is_assert_eq_call(callee, args) {
+        lower_assert_eq(args, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
       } else if !exn_kind_suppressed() && is_exception_kind_read(callee, args) {
         // #1374: `__exn_kind()` is a checker-only intrinsic (typed
         // `() -> String` in checker/builtins_misc.vibe, no wasm body) -- it

--- a/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
+++ b/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
@@ -4,6 +4,10 @@ import @vibe/compiler/entry/source_compile {
   compile_source_wasi
 }
 
+import @vibe/compiler/entry/source_compile/gc_only {
+  compile_source_gc_only
+}
+
 //# Helpers
 
 fn bytes_contains(hay: Bytes, needle: String) -> Bool {
@@ -46,7 +50,7 @@ fn assert_compiled_eq_diag(bytes: Bytes) -> Unit {
 fn capture_failing_assert_eq(body: String) -> String with Exception + Fs + Process {
   let bytes = compile_assert_eq_main(body)
   Fs::write_bytes("_build/vibe_test/assert_eq_fail_probe.wasm", bytes)
-  let _ = sh("bash -c 'scripts/run_wasm_vibe_host_runner.sh _build/vibe_test/assert_eq_fail_probe.wasm >/dev/null 2>_build/vibe_test/assert_eq_fail_probe.err || true'")
+  let _ = sh("bash -c 'scripts/run_wasm_vibe_host_runner.sh _build/vibe_test/assert_eq_fail_probe.wasm >_build/vibe_test/assert_eq_fail_probe.err 2>&1 || true'")
   Fs::read_file("_build/vibe_test/assert_eq_fail_probe.err")
 }
 
@@ -81,6 +85,11 @@ test "assert_eq failure compiles a fallback for an unrenderable value" {
 
 /// Same lowering, then execute it. `vibe test` keeps stderr and discards
 /// stdout, so the diagnostic has to land on stderr for `vt_fail_detail`.
+test "assert_eq lowering still compiles on the gc lane" {
+  let bytes = compile_source_gc_only("let main: () -> Int = () -> {\n  assert_eq(1, 1)\n  0\n}", "main")
+  assert(Bytes::length(bytes) > 8)
+}
+
 test "assert_eq failure prints expected and actual on stderr" {
   let err = capture_failing_assert_eq("assert_eq(1, 2)")
   inspect(String::contains(err, "assert_eq failed"), "true")

--- a/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
+++ b/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
@@ -1,0 +1,89 @@
+//# Imports
+
+import @vibe/compiler/entry/source_compile {
+  compile_source_wasi
+}
+
+//# Helpers
+
+fn bytes_contains(hay: Bytes, needle: String) -> Bool {
+  let nlen = String::length(needle)
+  let hlen = Bytes::length(hay)
+  if nlen == 0 {
+    true
+  } else if nlen > hlen {
+    false
+  } else {
+    let mut found = false
+    let mut i = 0
+    while i + nlen <= hlen && !found {
+      let mut ok = true
+      let mut j = 0
+      while j < nlen && ok {
+        ok = Bytes::get(hay, i + j) == String::char_code_at(needle, j)
+        j = j + 1
+      }
+      if ok {
+        found = true
+      } else {
+        i = i + 1
+      }
+    }
+    found
+  }
+}
+
+fn compile_assert_eq_main(body: String) -> Bytes with Exception {
+  compile_source_wasi(String::concat("let main: () -> Int = () -> {\n  ", String::concat(body, "\n  0\n}")), "main")
+}
+
+fn assert_compiled_eq_diag(bytes: Bytes) -> Unit {
+  assert(bytes_contains(bytes, "assert_eq failed"))
+  assert(bytes_contains(bytes, "expected:"))
+  assert(bytes_contains(bytes, "actual:"))
+}
+
+fn capture_failing_assert_eq(body: String) -> String with Exception + Fs + Process {
+  let bytes = compile_assert_eq_main(body)
+  Fs::write_bytes("_build/vibe_test/assert_eq_fail_probe.wasm", bytes)
+  let _ = sh("bash -c 'scripts/run_wasm_vibe_host_runner.sh _build/vibe_test/assert_eq_fail_probe.wasm >/dev/null 2>_build/vibe_test/assert_eq_fail_probe.err || true'")
+  Fs::read_file("_build/vibe_test/assert_eq_fail_probe.err")
+}
+
+//# Tests
+
+/// Drive the shipped compile path (`compile_source_wasi` ->
+/// `desugar_trait_dicts` -> both backends' ordinary calls), not a
+/// reimplementation of the diagnostic. A failing `assert_eq` must emit
+/// both sides as data-section text so the runner can print them.
+test "assert_eq failure compiles expected and actual for a scalar" {
+  assert_compiled_eq_diag(compile_assert_eq_main("assert_eq(1, 2)"))
+}
+
+test "assert_eq failure compiles expected and actual for a String" {
+  assert_compiled_eq_diag(compile_assert_eq_main("assert_eq(\"aa\", \"bb\")"))
+}
+
+test "assert_eq failure compiles expected and actual for a tuple" {
+  assert_compiled_eq_diag(compile_assert_eq_main("assert_eq((1, 2), (1, 3))"))
+}
+
+test "assert_eq failure compiles expected and actual for a Show struct" {
+  let bytes = compile_source_wasi("struct Point { x: Int; y: Int } derive(Eq, Show)\nlet main: () -> Int = () -> {\n  assert_eq(Point::{ x: 1, y: 2 }, Point::{ x: 1, y: 9 })\n  0\n}", "main")
+  assert_compiled_eq_diag(bytes)
+}
+
+test "assert_eq failure compiles a fallback for an unrenderable value" {
+  let bytes = compile_source_wasi("struct Opaque { n: Int } derive(Eq)\nlet main: () -> Int = () -> {\n  assert_eq(Opaque::{ n: 1 }, Opaque::{ n: 2 })\n  0\n}", "main")
+  assert(bytes_contains(bytes, "assert_eq failed"))
+  assert(bytes_contains(bytes, "<unprintable>"))
+}
+
+/// Same lowering, then execute it. `vibe test` keeps stderr and discards
+/// stdout, so the diagnostic has to land on stderr for `vt_fail_detail`.
+test "assert_eq failure prints expected and actual on stderr" {
+  let err = capture_failing_assert_eq("assert_eq(1, 2)")
+  inspect(String::contains(err, "assert_eq failed"), "true")
+  inspect(String::contains(err, "expected: 2"), "true")
+  inspect(String::contains(err, "actual:   1"), "true")
+}

--- a/lib/@vibe/core/assert.vibe
+++ b/lib/@vibe/core/assert.vibe
@@ -13,13 +13,21 @@
 // this file itself. Keep the two in step -- the expansion is this function,
 // spelled as AST.
 //
-// assert/assert_true/assert_eq are compiler builtins (checker +
-// both codegen backends) that trap with no message on failure; there is
-// no runtime string-formatting machinery backing them. assert_false and
-// inspect are deliberately plain library functions built on top of those
-// builtins plus the generic __to_string builtin (already used this way by
-// set.vibe / map.vibe), not new compiler builtins -- no codegen/checker
-// changes needed to add them.
+// assert/assert_true are compiler builtins (checker + both codegen
+// backends) that trap with no message on failure. assert_eq is the same
+// builtin to the checker (effect-free); after check, desugar_trait_dicts
+// rewrites a failing call to print
+//   assert_eq failed
+//     expected: <rendered>
+//     actual:   <rendered>
+// on stderr and then trap. Scalars and String go through __to_string,
+// tuples/Show structs reuse the throw-site renderer, and anything else
+// is `<unprintable>`. The diagnostic is on stderr because `vibe test`
+// discards stdout. assert_false and inspect are deliberately plain
+// library functions built on top of those builtins plus the generic
+// __to_string builtin (already used this way by set.vibe / map.vibe),
+// not new compiler builtins -- no codegen/checker changes needed to
+// add them.
 //
 // inspect(value, content) is a minimal inline-snapshot assertion: it
 // stringifies `value` and compares it against the `content` literal

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -86,8 +86,9 @@
 #                                         canonicalize a source file in place
 #                                         (--check: exit 1 if not normalized;
 #                                          --stdout: print, don't write)
-#   vibe test    <file_test.vibe>...      compile + run test {} blocks
-#   vibe test --update <file_test.vibe>... auto-patch stale inspect(value,
+#   vibe test    <file_test.vibe|dir>...  compile + run test {} blocks
+#                                         (a directory expands to *_test.vibe)
+#   vibe test --update <file_test.vibe|dir>... auto-patch stale inspect(value,
 #                                         content) snapshots to the actual
 #                                         value on a failing run, then
 #                                         recompile+rerun (MoonBit
@@ -600,6 +601,10 @@ condense_test_trap() {
       seen_test = 1
       failing = substr($0, RSTART + 7, RLENGTH - 7)
     }
+    $0 == "assert_eq failed" || $0 ~ /^  expected:/ || $0 ~ /^  actual:/ {
+      ndiag++
+      diags[ndiag] = "  " $0
+    }
     !seen_reason && /RuntimeError:|wasm trap:/ {
       seen_reason = 1
       reason = $0
@@ -622,6 +627,7 @@ condense_test_trap() {
     }
     END {
       if (failing != "") print "  failing test: " failing
+      for (i = 1; i <= ndiag; i++) print diags[i]
       if (reason != "")  print "  trap: " reason
       for (i = 1; i <= nframes; i++) print frames[i]
     }
@@ -1619,7 +1625,7 @@ case "$cmd" in
     esac
     ;;
   test)
-    # `vibe test [--no-cache] [--update] <file_test.vibe>...`
+    # `vibe test [--no-cache] [--update] [--jobs N] <file_test.vibe|dir>...`
     #
     # Pure-test result cache (#634, ADR-0026): a file whose `test {}` blocks are
     # all transitively effect-free is a deterministic function of its source +
@@ -1657,18 +1663,33 @@ case "$cmd" in
     [ "$jobs" -ge 1 ] || die "--jobs must be a positive integer, got: $jobs"
     # shellcheck disable=SC2086
     set -- $files
-    [ "$#" -ge 1 ] || die "usage: vibe test [--no-cache] [--update] [--jobs N] <file_test.vibe> [more_test.vibe...]"
-    # Codex review, PR #1175: validate every path up front and abort before
-    # running anything, rather than discovering a missing file mid-run. The
-    # original serial loop's own `[ -f "$src" ] || die ...` only fail-fast
-    # aborted from the missing file onward -- files earlier in the argument
-    # list had already compiled and run (potentially executing effectful
-    # tests) by the time a later typo'd path was discovered. Checking all
-    # paths first is strictly fail-faster than that, and gives the serial
-    # and parallel drivers below identical semantics for a bad invocation.
+    [ "$#" -ge 1 ] || die "usage: vibe test [--no-cache] [--update] [--jobs N] <file_test.vibe | dir> [more...]"
+    # Expand directories to every *_test.vibe under them (same as
+    # scripts/vibe_test.sh). Validate every path up front and abort before
+    # running anything, rather than discovering a missing file mid-run.
+    # The original serial loop's own `[ -f "$src" ] || die ...` only
+    # fail-fast aborted from the missing file onward -- files earlier in
+    # the argument list had already compiled and run (potentially
+    # executing effectful tests) by the time a later typo'd path was
+    # discovered. Checking all paths first is strictly fail-faster than
+    # that, and gives the serial and parallel drivers below identical
+    # semantics for a bad invocation.
+    _test_files=()
     for src in "$@"; do
-      [ -f "$src" ] || die "not found: $src"
+      if [ -d "$src" ]; then
+        while IFS= read -r f; do
+          _test_files+=("$f")
+        done < <(find "$src" -type f -name '*_test.vibe' | sort)
+      elif [ -f "$src" ]; then
+        _test_files+=("$src")
+      else
+        die "not found: $src"
+      fi
     done
+    if [ "${#_test_files[@]}" -eq 0 ]; then
+      die "vibe test: no test files found"
+    fi
+    set -- "${_test_files[@]}"
     tcache="${VIBE_TEST_CACHE:-$VIBE_HOME/cache/test}"
 
     # Runs one test file's compile+run+cache-check, printing its own ok/FAIL

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -383,13 +383,13 @@ vt_worker() {
   local run_err="$vt_results/$flat.err"
   if [ "$backend" = "gc" ]; then
     if timeout 60 wasmtime run -W gc=y,function-references=y,exceptions=y \
-        --invoke _start "$ROOT_DIR/$out_rel" >/dev/null 2>"$run_err"; then
+        --invoke _start "$ROOT_DIR/$out_rel" >"$run_err" 2>&1; then
       run_ok=1
     fi
   else
     if VIBE_COV_OUT="$cov_out" VIBE_PREOPEN_DIR="$ROOT_DIR" \
         bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-        --invoke _start "$out_rel" >/dev/null 2>"$run_err"; then
+        --invoke _start "$out_rel" >"$run_err" 2>&1; then
       run_ok=1
     fi
   fi

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -280,6 +280,10 @@ vt_fail_detail() {
     }
     # First trap-reason line (backtrace frames never contain these markers;
     # strip anyhow chain numbering / runner prefixes).
+    $0 == "assert_eq failed" || $0 ~ /^  expected:/ || $0 ~ /^  actual:/ {
+      ndiag++
+      diags[ndiag] = "       " $0
+    }
     !seen_reason && /RuntimeError:|wasm trap:/ {
       seen_reason = 1
       reason = $0
@@ -305,6 +309,7 @@ vt_fail_detail() {
     }
     END {
       if (failing != "") print "       failing test: " failing
+      for (i = 1; i <= ndiag; i++) print diags[i]
       if (reason != "")  print "       trap: " reason
       for (i = 1; i <= nframes; i++) print frames[i]
     }

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -98,6 +98,48 @@ error while executing at wasm backtrace:
 EOF
 echo "[vibe-test-smoke] ok (guest __test_ prefix is not the failing-test name)"
 
+# #1946 leftover: vt_fail_detail must surface the assert_eq diagnostic that
+# the guest writes to stderr (vibe test discards stdout).
+assert_canned_assert_eq_diag() {
+  local errf="$WORK/canned_assert_eq.err" out
+  cat > "$errf" <<'EOF'
+assert_eq failed
+  expected: 2
+  actual:   1
+RuntimeError: unreachable
+    at __test_bad (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+  out="$(vt_fail_detail "$errf" "" "canned.vibe")"
+  if ! printf '%s\n' "$out" | rg -q --fixed-strings "assert_eq failed"; then
+    echo "[vibe-test-smoke] FAIL: canned assert_eq missing 'assert_eq failed'" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$out" | rg -q --fixed-strings "expected: 2"; then
+    echo "[vibe-test-smoke] FAIL: canned assert_eq missing expected value" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$out" | rg -q --fixed-strings "actual:   1"; then
+    echo "[vibe-test-smoke] FAIL: canned assert_eq missing actual value" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+assert_canned_assert_eq_diag
+echo "[vibe-test-smoke] ok (assert_eq expected/actual surfaced on FAIL)"
+
+# Directory input: scripts/vibe_test.sh already expands *_test.vibe; lock it.
+mkdir -p "$WORK/dir_in"
+printf 'test "in dir" {\n  assert_eq(1, 1)\n}\n' > "$WORK/dir_in/foo_test.vibe"
+if ! VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+    bash "$ROOT_DIR/scripts/vibe_test.sh" "$WORK/dir_in" >/dev/null 2>&1; then
+  echo "[vibe-test-smoke] FAIL: vibe_test.sh did not accept a directory" >&2
+  exit 1
+fi
+echo "[vibe-test-smoke] ok (directory input expands *_test.vibe)"
+
 # The seed-compiler notice. A green run through the committed seed says nothing
 # about a compiler change in this checkout, and the two are indistinguishable
 # from the result -- so the run has to say which compiler answered whenever the


### PR DESCRIPTION
Leftover #1946 (quoted names already landed in #1995).

`assert_eq` failures now print both sides before trapping:

```
assert_eq failed
  expected: 2
  actual:   1
```

The rewrite lives in `desugar_trait_dicts` (after check, same pass as throw-site rendering), so both backends see ordinary `==` / `Stderr::write_stream` / `assert_true` calls. Scalars and `String` go through `__to_string`; tuples and `derive(Show)` structs reuse the existing renderer; anything else is `<unprintable>`. The diagnostic is on stderr because `vibe test` discards stdout. `vt_fail_detail` / `condense_test_trap` keep those lines on FAIL.

`vibe test` now accepts a directory and expands `*_test.vibe` under it, matching `scripts/vibe_test.sh`. Tutorial, install help, and `runtime/vibe` usage say the same thing.

## Test

`lib/@vibe/compiler/tests/assert_eq_failure_test.vibe` drives the shipped `compile_source_wasi` path (not a reimplementation):

- compile-time: scalar / String / tuple / Show struct / unrenderable all emit the diagnostic labels
- run-time: compile a failing `assert_eq(1, 2)`, execute it, and require stderr to contain `expected: 2` and `actual:   1`

`scripts/vibe_test_smoke.sh` also locks canned `vt_fail_detail` output and directory input.

No seed wasm.