### PR TITLE
Move tooling and accounting tests under tests/gates

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -151,9 +151,9 @@ local testSelfcompileHeapPolicy = new Task {
 local testCoverageDriverExposure = new Task {
   name = "test-coverage-driver-exposure"
   description = "exact-path coverage-driver exposure positive/negative integration test"
-  cmd = "bash scripts/tests/coverage_driver_exposure_test.sh"
+  cmd = "bash tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh"
   inputs {
-    "scripts/tests/coverage_driver_exposure_test.sh"
+    "tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh"
     "scripts/coverage/cov_units.vibe"
     "lib/@vibe/compiler/cli_adapter.vibe"
     "lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe"
@@ -292,11 +292,11 @@ local checkHostRuntimeContract = new Task {
   name = "check-host-runtime-contract"
   description = "fail-closed conformance check for the documented vibe.* core host ABI"
   cmd =
-    "python3 scripts/check_host_runtime_contract.py && python3 scripts/tests/host_runtime_contract_test.py"
+    "python3 scripts/check_host_runtime_contract.py && python3 tests/gates/tooling-accounting/host-runtime/host_runtime_contract_test.py"
   inputs {
     "docs/wasm/host-runtime-contract.json"
     "scripts/check_host_runtime_contract.py"
-    "scripts/tests/host_runtime_contract_test.py"
+    "tests/gates/tooling-accounting/host-runtime/host_runtime_contract_test.py"
     "lib/@vibe/compiler/codegen/wasi/linked_compile.vibe"
     "runtime/viberun/src/main.rs"
     "scripts/wasm_vibe_host_runner.js"
@@ -430,7 +430,7 @@ local testPerfReport = new Task {
 local testCoverageScripts = new Task {
   name = "test-coverage-scripts"
   cmd =
-    "node --test scripts/coverage_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/select_test_shard.test.mjs && python3 scripts/coverage_suite_report_test.py && python3 scripts/coverage_tracks_test.py && bash scripts/tests/coverage_drivers_test.sh && bash scripts/tests/coverage_pipeline_contract_test.sh"
+    "node --test scripts/coverage_suite_next_branches.test.mjs scripts/coverage_wasm_source.test.mjs scripts/select_test_shard.test.mjs && python3 scripts/coverage_suite_report_test.py && python3 scripts/coverage_tracks_test.py && bash tests/gates/tooling-accounting/coverage/coverage_drivers_test.sh && bash tests/gates/tooling-accounting/coverage/coverage_pipeline_contract_test.sh"
   inputs {
     "scripts/**/*.mjs"
     "scripts/coverage_suite_report.py"
@@ -440,8 +440,8 @@ local testCoverageScripts = new Task {
     "scripts/coverage_corpus.sh"
     "scripts/coverage_drivers.sh"
     "scripts/coverage_local_merge_run.sh"
-    "scripts/tests/coverage_drivers_test.sh"
-    "scripts/tests/coverage_pipeline_contract_test.sh"
+    "tests/gates/tooling-accounting/coverage/coverage_drivers_test.sh"
+    "tests/gates/tooling-accounting/coverage/coverage_pipeline_contract_test.sh"
   }
 }
 

--- a/tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh
+++ b/tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh
@@ -2,7 +2,7 @@
 # #1633: compiler-owned exact-path coverage-driver exposure.
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 cd "$ROOT"
 SEED="${VIBE_COV_SEED:-bootstrap/seed/compiler.wasm}"
 RUNNER="scripts/run_wasm_vibe_host_runner.sh"

--- a/tests/gates/tooling-accounting/coverage/coverage_drivers_test.sh
+++ b/tests/gates/tooling-accounting/coverage/coverage_drivers_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 cd "$ROOT"
 VIBE_COVERAGE_DRIVERS_LIB_ONLY=1 source scripts/coverage_drivers.sh
 

--- a/tests/gates/tooling-accounting/coverage/coverage_pipeline_contract_test.sh
+++ b/tests/gates/tooling-accounting/coverage/coverage_pipeline_contract_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 cd "$ROOT"
 
 TMP="$(mktemp -d)"

--- a/tests/gates/tooling-accounting/host-runtime/host_runtime_contract_test.py
+++ b/tests/gates/tooling-accounting/host-runtime/host_runtime_contract_test.py
@@ -4,7 +4,8 @@ import json
 import unittest
 from pathlib import Path
 
-SCRIPT = Path(__file__).parents[1] / "check_host_runtime_contract.py"
+ROOT = Path(__file__).parents[4]
+SCRIPT = ROOT / "scripts/check_host_runtime_contract.py"
 spec = importlib.util.spec_from_file_location("host_contract", SCRIPT)
 module = importlib.util.module_from_spec(spec)
 assert spec.loader
@@ -71,7 +72,7 @@ leb128_encode_u32(import_content, 3)'''
         self.assertEqual(module.node_imports(node), {"env-get", "fs_exists"})
 
     def test_manifest_is_valid_json(self):
-        manifest = Path(__file__).parents[2] / "docs/wasm/host-runtime-contract.json"
+        manifest = ROOT / "docs/wasm/host-runtime-contract.json"
         self.assertEqual(json.loads(manifest.read_text())["schema"], 1)
 
 


### PR DESCRIPTION
## Summary

- move three referenced coverage/accounting tests from `scripts/tests/` to `tests/gates/tooling-accounting/coverage/`
- move the referenced host-runtime contract test to `tests/gates/tooling-accounting/host-runtime/`
- update repository-root calculations and all Taskfile commands/inputs
- retain the two currently unreferenced scripts for a separate reachability decision

Part of #2001. Does not close the umbrella.

## Validation

Exact head `b81d7a198d4f76e64f831a135a57a603d31282a9`:

- `pkf run test-coverage-scripts`
- `pkf run check-host-runtime-contract` — 7 tests passed
- moved coverage driver and pipeline tests passed directly
- `pkf run check-taskfile-fmt`
- `pkf format --check Taskfile.pkl`
- `pkf run check-doc-path-citations`
- `pkf run test-doc-path-citations`
- no active references to the former four paths
- independent verifier: ACCEPT, no silently disconnected coverage

`test-coverage-driver-exposure` fails at the same traitenv compile step on the parent and relocated copies, so it is a pre-existing baseline defect rather than a relocation regression.

`pkf run release-check` reached the known macOS BSD `xargs` gate-92 limitation.
