### PR TITLE
fix(codegen): load boxed let mut before calling a function value

### DIFF
--- a/fixtures/captured_mut_lambda_test.vibe
+++ b/fixtures/captured_mut_lambda_test.vibe
@@ -1,0 +1,26 @@
+// #2012: assigning a lambda into a closure-captured `let mut`, then
+// calling it, must not trap. Same-shape assignment outside a closure
+// already works.
+
+test "assigning a lambda outside a closure then calling it" {
+  let mut g = (x: Int, y: Int) -> Int {
+    x - y
+  }
+  g = (x: Int, y: Int) -> Int {
+    x - y - 1
+  }
+  inspect(g(10, 3), "6")
+}
+
+test "assigning a lambda from a closure then calling it" {
+  let mut g = (x: Int, y: Int) -> Int {
+    x - y
+  }
+  let bump = () -> Unit {
+    g = (x: Int, y: Int) -> Int {
+      x - y - 1
+    }
+  }
+  bump()
+  inspect(g(10, 3), "6")
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -5400,6 +5400,15 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
         Array::push(local_names, "__slot")
         Array::push(local_names, "__env")
         emit_local_get(buf, local_idx2)
+        // #2012: a captured `let mut` local holds a cell address, not the
+        // function value. Load the i64 in the cell before closure_resolve
+        // or the cell pointer is used as a table index.
+        if array_contains_str(ctx.ref_cell_names, fname) {
+          emit_i32_wrap_i64(buf)
+          emit_i64_load(buf, 3, 0)
+        } else {
+          ()
+        }
         emit_local_set(buf, fn_val_local)
         emit_closure_resolve(buf, fn_val_local, slot_local, env_local)
         let mut ci = 0

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -76,6 +76,7 @@ import @vibe/compiler/codegen/common_base {
 
 import @vibe/compiler/codegen/common_extractors {
   array_contains_int,
+  array_contains_str,
   emit_assignop_op,
   emit_memory_copy,
   find_catchall_idx,
@@ -3205,6 +3206,14 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
           Array::push(local_names, "__slot")
           Array::push(local_names, "__env")
           emit_local_get(buf, local_idx2)
+          // #2012: see the linear compile_call path — boxed `let mut`
+          // locals store a cell address.
+          if array_contains_str(ctx.ref_cell_names, fname) {
+            emit_i32_wrap_i64(buf)
+            emit_i64_load(buf, 3, 0)
+          } else {
+            ()
+          }
           emit_local_set(buf, fn_val_local)
           emit_closure_resolve(buf, fn_val_local, slot_local, env_local)
           let mut ci = 0

--- a/lib/@vibe/compiler/tests/codegen_heap_e2e_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_heap_e2e_test.vibe
@@ -56,6 +56,11 @@ fn assert_result_all_backends(src: String, entry: String, label: String, expecte
 
 //# Misc
 
+test "heap e2e: captured let mut lambda reassignment then call" {
+  let src = "let main: () -> Int = () -> {\n  let mut g = (x: Int, y: Int) -> Int { x - y }\n  let bump = () -> Unit { g = (x: Int, y: Int) -> Int { x - y - 1 } }\n  bump()\n  g(10, 3)\n}"
+  assert_result(src, "main", "captured_mut_lambda", "6")
+}
+
 test "heap e2e: tuple field access" {
   let src = "let main: () -> Int = () -> {\n  let t = (3, 4)\n  t.0 + t.1\n}"
   assert_result(src, "main", "tuple", "7")


### PR DESCRIPTION
Fixes #2012.

A `let mut` holding a function, reassigned from a closure, then called,
compiled clean and trapped at run time (`table index is out of bounds`).
Assignment outside a closure already worked.

The escape/box path stores the function in a heap cell. The call site
did `local.get` of that local and fed it to `closure_resolve`, so the
**cell address** was treated as `(table_slot<<2)|2`. Load the i64 in
the cell first, the same way a boxed read already does.

Linear `compile_call` and gc `backend_call` both get the load.

## Tests

- `codegen_heap_e2e_test` compiles the issue repro through `compile_wasi`
  / RC and runs it; expected `6`.
- `fixtures/captured_mut_lambda_test.vibe` is the same program for the
  stage2 unit lane (seed still traps — it does not contain this codegen).