### PR TITLE
fix(test): print quoted test names in trap FAIL detail (#1946)

### DIFF
--- a/runtime/vibe
+++ b/runtime/vibe
@@ -588,6 +588,34 @@ condense_test_trap() {
   [ -s "$errf" ] || return 0
   [ -f "$fm" ] || fm=""
   out="$(awk -v base="$base" -v fmfile="$fm" '
+    function hexval(c) {
+      if (c >= "0" && c <= "9") return c + 0
+      if (c >= "A" && c <= "F") return index("ABCDEF", c) + 9
+      if (c >= "a" && c <= "f") return index("abcdef", c) + 9
+      return -1
+    }
+    # Quoted names may appear percent-encoded (`has%20spaces`). Keep
+    # this decoder in lockstep with scripts/vibe_test.sh vt_fail_detail.
+    function pct_decode(s,    out, i, n, c, v1, v2) {
+      out = ""
+      n = length(s)
+      i = 1
+      while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == "%" && i + 2 <= n) {
+          v1 = hexval(substr(s, i + 1, 1))
+          v2 = hexval(substr(s, i + 2, 1))
+          if (v1 >= 0 && v2 >= 0) {
+            out = out sprintf("%c", v1 * 16 + v2)
+            i += 3
+            continue
+          }
+        }
+        out = out c
+        i++
+      }
+      return out
+    }
     BEGIN {
       if (fmfile != "") {
         while ((getline l < fmfile) > 0) {
@@ -597,9 +625,24 @@ condense_test_trap() {
         close(fmfile)
       }
     }
-    !seen_test && match($0, /__test_[A-Za-z0-9_]+/) {
-      seen_test = 1
-      failing = substr($0, RSTART + 7, RLENGTH - 7)
+    # First __test_<name> stack frame = the failing test. Quoted names
+    # keep spaces and Unicode in the wasm name section; some frames
+    # percent-encode those bytes (`has%20spaces`). Cut at the frame
+    # delimiter (` (wasm:` on Node/V8, EOL on wasmtime), not at the
+    # first non-[A-Za-z0-9_%] character (#1946). Guest stderr can
+    # contain `__test_` (e.g. `__test_!!!`); only Node `at ... (wasm:`
+    # and wasmtime `<unknown>!` frames count.
+    !seen_test && match($0, /at __test_/) {
+      rest = substr($0, RSTART + length("at __test_"))
+      if (match(rest, / \(wasm:/)) {
+        failing = substr(rest, 1, RSTART - 1)
+        if (failing != "") seen_test = 1
+      }
+    }
+    !seen_test && match($0, /<unknown>!__test_/) {
+      failing = substr($0, RSTART + length("<unknown>!__test_"))
+      sub(/[[:space:]]+$/, "", failing)
+      if (failing != "") seen_test = 1
     }
     $0 == "assert_eq failed" || $0 ~ /^  expected:/ || $0 ~ /^  actual:/ {
       ndiag++
@@ -626,7 +669,7 @@ condense_test_trap() {
       }
     }
     END {
-      if (failing != "") print "  failing test: " failing
+      if (failing != "") print "  failing test: " pct_decode(failing)
       for (i = 1; i <= ndiag; i++) print diags[i]
       if (reason != "")  print "  trap: " reason
       for (i = 1; i <= nframes; i++) print frames[i]

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -251,6 +251,34 @@ vt_fail_detail() {
   local errf="$1" fm="$2" base="$3"
   [ -s "$errf" ] || return 0
   awk -v base="$base" -v fmfile="$fm" '
+    function hexval(c) {
+      if (c >= "0" && c <= "9") return c + 0
+      if (c >= "A" && c <= "F") return index("ABCDEF", c) + 9
+      if (c >= "a" && c <= "f") return index("abcdef", c) + 9
+      return -1
+    }
+    # Quoted names may appear percent-encoded (`has%20spaces`). Keep
+    # this decoder in lockstep with runtime/vibe condense_test_trap.
+    function pct_decode(s,    out, i, n, c, v1, v2) {
+      out = ""
+      n = length(s)
+      i = 1
+      while (i <= n) {
+        c = substr(s, i, 1)
+        if (c == "%" && i + 2 <= n) {
+          v1 = hexval(substr(s, i + 1, 1))
+          v2 = hexval(substr(s, i + 2, 1))
+          if (v1 >= 0 && v2 >= 0) {
+            out = out sprintf("%c", v1 * 16 + v2)
+            i += 3
+            continue
+          }
+        }
+        out = out c
+        i++
+      }
+      return out
+    }
     BEGIN {
       if (fmfile != "") {
         while ((getline l < fmfile) > 0) {
@@ -261,9 +289,10 @@ vt_fail_detail() {
       }
     }
     # First __test_<name> stack frame = the failing test. Quoted names
-    # keep spaces and Unicode in the wasm name section; cut at the
-    # frame delimiter (` (wasm:` on Node/V8, EOL on wasmtime), not at
-    # the first non-[A-Za-z0-9_] character (#1946). Guest stderr can
+    # keep spaces and Unicode in the wasm name section; some frames
+    # percent-encode those bytes (`has%20spaces`). Cut at the frame
+    # delimiter (` (wasm:` on Node/V8, EOL on wasmtime), not at the
+    # first non-[A-Za-z0-9_%] character (#1946). Guest stderr can
     # contain `__test_` (e.g. `__test_!!!`); only Node `at ... (wasm:`
     # and wasmtime `<unknown>!` frames count.
     !seen_test && match($0, /at __test_/) {
@@ -308,7 +337,7 @@ vt_fail_detail() {
       }
     }
     END {
-      if (failing != "") print "       failing test: " failing
+      if (failing != "") print "       failing test: " pct_decode(failing)
       for (i = 1; i <= ndiag; i++) print diags[i]
       if (reason != "")  print "       trap: " reason
       for (i = 1; i <= nframes; i++) print frames[i]

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -48,6 +48,11 @@ assert_full_failing_name() {
 }
 assert_full_failing_name "$WORK/space_name_test.vibe" "has a space"
 assert_full_failing_name "$WORK/unicode_name_test.vibe" "café 日本語"
+# #1946 leftover: live file with a space in the quoted name, via assert_eq.
+# Decode of `%20` is pinned on canned dumps below; this run still has to
+# print the full source name and stay non-zero.
+printf 'test "has spaces" {\n  assert_eq(1, 0)\n}\n' > "$WORK/has_spaces_test.vibe"
+assert_full_failing_name "$WORK/has_spaces_test.vibe" "has spaces"
 echo "[vibe-test-smoke] ok (quoted test names preserved on FAIL)"
 
 # Guest stderr that happens to contain `__test_!!!` must not become the
@@ -97,6 +102,53 @@ error while executing at wasm backtrace:
    wasm trap: wasm `unreachable` instruction executed
 EOF
 echo "[vibe-test-smoke] ok (guest __test_ prefix is not the failing-test name)"
+
+# #1946 leftover: quoted names can appear percent-encoded in a frame
+# (`test "has spaces"` → `__test_has%20spaces`). The old
+# `__test_[A-Za-z0-9_]+` match stops at `%` and prints `has`. Both
+# condensers must decode `%XX` so the FAIL line shows the source name.
+# runtime/vibe is not sourceable (it is the user-facing launcher); extract
+# condense_test_trap the same way as vt_fail_detail.
+eval "$(sed -n '/^condense_test_trap() {/,/^}$/p' "$ROOT_DIR/runtime/vibe")"
+assert_canned_failing_name node_pct "has spaces" <<'EOF'
+RuntimeError: unreachable
+    at __test_has%20spaces (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+assert_canned_failing_name wasmtime_pct "has spaces" <<'EOF'
+error while executing at wasm backtrace:
+    0: 0x42 - <unknown>!__test_has%20spaces
+    1: 0x10 - <unknown>!_start
+   wasm trap: wasm `unreachable` instruction executed
+EOF
+assert_condense_failing_name() {
+  local label="$1" want="$2" errf out
+  errf="$WORK/canned_condense_${label}.err"
+  cat > "$errf"
+  out="$(condense_test_trap "$errf" "" "canned.vibe")"
+  if ! printf '%s\n' "$out" | rg -q --fixed-strings "failing test: $want"; then
+    echo "[vibe-test-smoke] FAIL: condense $label expected 'failing test: $want'" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+assert_condense_failing_name node_space "has spaces" <<'EOF'
+RuntimeError: unreachable
+    at __test_has spaces (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+assert_condense_failing_name node_pct "has spaces" <<'EOF'
+RuntimeError: unreachable
+    at __test_has%20spaces (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+assert_condense_failing_name wasmtime_pct "has spaces" <<'EOF'
+error while executing at wasm backtrace:
+    0: 0x42 - <unknown>!__test_has%20spaces
+    1: 0x10 - <unknown>!_start
+   wasm trap: wasm `unreachable` instruction executed
+EOF
+echo "[vibe-test-smoke] ok (percent-encoded quoted names decode on FAIL)"
 
 # #1946 leftover: vt_fail_detail must surface the assert_eq diagnostic that
 # the guest writes to stderr (vibe test discards stdout).


### PR DESCRIPTION
Leftover after #1995 (quoted names in `scripts/vibe_test.sh`) and #2010 (`assert_eq` expected/actual).

`runtime/vibe` `condense_test_trap` still cut `__test_[A-Za-z0-9_]+` at the first non-word character, so a quoted name such as `test "has spaces"` printed `failing test: has`. Some frames also percent-encode the wasm name (`__test_has%20spaces`).

This change keeps both condensers in sync:

- `runtime/vibe` `condense_test_trap`
- `scripts/vibe_test.sh` `vt_fail_detail`

Both extract the name through the stack-frame delimiter (Node `(wasm:`, wasmtime EOL) and percent-decode `%XX` so the FAIL line shows `has spaces`, not `has` or `has%20spaces`.

## Test

`bash scripts/vibe_test_smoke.sh` (`pkf run test-vibe-test`):

- live `test "has spaces" { assert_eq(1, 0) }` via `scripts/vibe_test.sh` prints `failing test: has spaces`
- canned Node/wasmtime dumps with `__test_has%20spaces` decode on both extractors
- existing pass/fail, Unicode, guest-prefix, assert_eq, and directory cases stay green

Red before the awk change (`failing test: has%20spaces` / `has`); green after.

## Not in this PR

Compiler lowering of test names is unchanged. No seed wasm.