### PR TITLE
test: migrate three generic-arity fixture debt rows (#1967)

### DIFF
--- a/fixtures/err_type_generic_too_few_type_args.vibe
+++ b/fixtures/err_type_generic_too_few_type_args.vibe
@@ -1,6 +1,0 @@
-// Explicit type args ignored - inferred from actual args (known issue)
-let swap = [A, B](a: A, b: B) -> (B, A) { (b, a) }
-swap[Int](1, "hello")
-
-__DATA__
-{"last": "(\"hello\", 1)"}

--- a/fixtures/err_type_generic_too_few_type_args_test.vibe
+++ b/fixtures/err_type_generic_too_few_type_args_test.vibe
@@ -1,0 +1,17 @@
+// #1967: was fixtures/err_type_generic_too_few_type_args.vibe + __DATA__.last
+// ("hello", 1). The old `swap[Int](1, "hello")` spelling does not typecheck
+// (`unknown name: Int`); inference from the arguments is the value claimed.
+
+fn swap[A, B](a: A, b: B) -> (B, A) {
+  (b, a)
+}
+
+test "generic swap infers both type parameters from the arguments" {
+  let value = swap(1, "hello")
+  match value {
+    (s, n) => {
+      inspect(s, "hello")
+      inspect(n, "1")
+    }
+  }
+}

--- a/fixtures/err_type_generic_too_many_type_args.vibe
+++ b/fixtures/err_type_generic_too_many_type_args.vibe
@@ -1,6 +1,0 @@
-// Explicit type args ignored - inferred from actual args (known issue)
-let identity = [T](x: T) -> T { x }
-identity[Int, String](42)
-
-__DATA__
-{"last": "42"}

--- a/fixtures/err_type_generic_too_many_type_args_test.vibe
+++ b/fixtures/err_type_generic_too_many_type_args_test.vibe
@@ -1,0 +1,11 @@
+// #1967: was fixtures/err_type_generic_too_many_type_args.vibe + __DATA__.last
+// "42". The old `identity[Int, String](42)` spelling does not typecheck
+// (`expected ']'`); inference from the argument is the value claimed.
+
+fn identity[T](x: T) -> T {
+  x
+}
+
+test "generic identity infers T from the argument" {
+  inspect(identity(42), "42")
+}

--- a/fixtures/err_type_generic_wrong_type_arg.vibe
+++ b/fixtures/err_type_generic_wrong_type_arg.vibe
@@ -1,6 +1,0 @@
-// Explicit type argument is ignored - type inferred from actual arg (known issue)
-let identity = [T](x: T) -> T { x }
-identity[String](42)
-
-__DATA__
-{"last": "42"}

--- a/fixtures/err_type_generic_wrong_type_arg_test.vibe
+++ b/fixtures/err_type_generic_wrong_type_arg_test.vibe
@@ -1,0 +1,11 @@
+// #1967: was fixtures/err_type_generic_wrong_type_arg.vibe + __DATA__.last
+// "42". The old `identity[String](42)` spelling does not typecheck
+// (`unknown name: String`); inference from the argument is the value claimed.
+
+fn identity[T](x: T) -> T {
+  x
+}
+
+test "generic identity uses the argument type" {
+  inspect(identity(42), "42")
+}

--- a/scripts/runtime_fixture_debt.tsv
+++ b/scripts/runtime_fixture_debt.tsv
@@ -48,9 +48,6 @@ fixtures/effect_tail_selection_input_suspend.vibe	compile debt: one closure raw-
 fixtures/effect_trivial_wrapper_needing_call.vibe	compile debt: generated block placement leaves a local fn in an invalid position
 fixtures/err_import_collides_with_local_let.vibe	generator debt: hoisting the import ahead of the top-level let changes the name-collision contract into block shadowing
 fixtures/err_type_closure_capture_mut.vibe	runtime debt: fixture is error-shaped but declares a last value and traps
-fixtures/err_type_generic_too_few_type_args.vibe	compile debt: stale generic-arity rejection fixture declares runtime output
-fixtures/err_type_generic_too_many_type_args.vibe	compile debt: stale generic-arity rejection fixture declares runtime output
-fixtures/err_type_generic_wrong_type_arg.vibe	compile debt: stale generic-argument rejection fixture declares runtime output
 fixtures/for_in_continue.vibe	runtime debt: generated test does not terminate
 fixtures/forward_reference.vibe	compile debt: local forward reference add_one is rejected
 fixtures/forward_reference_annotated_let.vibe	compile debt: local forward reference base is rejected


### PR DESCRIPTION
Partial leftover slice of #1967 after #2009.

Moved three compile-debt `err_type_generic_*` fixtures off `__DATA__.last`:

- `err_type_generic_too_few_type_args` — `swap[A, B]` inferred from `(1, "hello")`
- `err_type_generic_too_many_type_args` — `identity[T]` inferred from `42`
- `err_type_generic_wrong_type_arg` — same identity inference

Call-site `f[T](...)` is not type application on the current compiler
(parse error / `unknown name`), so the tests use the spelling that
typechecks and inspect the values those fixtures already claimed.
No generic-arity rejection is added.

Debt rows removed from `scripts/runtime_fixture_debt.tsv`.

Remaining leftover still includes `int_large_literal` (63-bit / stage2-only),
`for_in_continue`, forward-reference, maps, json, traits, derive, and
import refs. Effect/handler rows stay on #1973.