### PR TITLE
fix(codegen): advance for-in index before continue (#1967)

### DIFF
--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail2.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail2.vibe
@@ -638,6 +638,13 @@ export fn compile_forin_loop(buf: Bytes, expr: Expr, local_names: Array[String],
   } else {
     ()
   }
+  // #1967: step the index before the body. `continue` is `br` to this
+  // loop header (`ld = 0`). If the increment stayed after the body, an
+  // even-element `continue` retried the same `i` forever.
+  emit_local_get(buf, i_local)
+  emit_i64_const(buf, 1)
+  emit_i64_add(buf)
+  emit_local_set(buf, i_local)
   let nl2 = var_local + 1
   // Same innermost-loop ld reset as EWhile (see compile_expr_tail3).
   let nl3 = compile_expr(buf, body, local_names, nl2, ctx, 0)
@@ -654,10 +661,6 @@ export fn compile_forin_loop(buf: Bytes, expr: Expr, local_names: Array[String],
     // -- releasing here could double-free a borrowed body value).
     emit_drop(buf)
   }
-  emit_local_get(buf, i_local)
-  emit_i64_const(buf, 1)
-  emit_i64_add(buf)
-  emit_local_set(buf, i_local)
   emit_br(buf, 0)
   emit_end(buf)
   emit_end(buf)

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -1796,6 +1796,13 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       emit_call(buf, arr_get_idx)
       emit_local_set(buf, var_local)
       Array::push(local_names, var_name)
+      // #1967: step the index before the body. `continue` is `br` to this
+      // loop header (`ld = 0`). If the increment stayed after the body, an
+      // even-element `continue` retried the same `i` forever.
+      emit_local_get(buf, i_local)
+      emit_i64_const(buf, 1)
+      emit_i64_add(buf)
+      emit_local_set(buf, i_local)
       let nl3 = var_local + 1
       // Same innermost-loop ld reset as EWhile.
       let nl4 = ce(buf, body, local_names, nl3, 0)
@@ -1810,10 +1817,6 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
         ()
       }
       emit_call(buf, arr_push_idx)
-      emit_local_get(buf, i_local)
-      emit_i64_const(buf, 1)
-      emit_i64_add(buf)
-      emit_local_set(buf, i_local)
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)

--- a/lib/@vibe/compiler/tests/codegen_heap_e2e_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_heap_e2e_test.vibe
@@ -61,6 +61,21 @@ test "heap e2e: captured let mut lambda reassignment then call" {
   assert_result(src, "main", "captured_mut_lambda", "6")
 }
 
+// #1967: `continue` in a collecting `for-in` used to `br` to the loop
+// header before `i = i + 1`, so an even element retried forever.
+// Increment after bind / before body so skip does not re-visit the same index.
+// Packed as 1 + 3*10 + 5*100 so a wrong collect (all five, or hang) cannot
+// accidentally match.
+test "heap e2e: for-in continue skips even collected values" {
+  let src = "let main: () -> Int = () -> {\n  let xs = for x in [1, 2, 3, 4, 5] {\n    if x % 2 == 0 { continue } else { }\n    x\n  }\n  Array::get(xs, 0) + Array::get(xs, 1) * 10 + Array::get(xs, 2) * 100\n}"
+  assert_result_all_backends(src, "main", "forin_continue_collect", "531")
+}
+
+test "heap e2e: for-in continue as a statement still advances" {
+  let src = "let main: () -> Int = () -> {\n  let mut n = 0\n  for x in [1, 2, 3, 4, 5] {\n    if x % 2 == 0 { continue } else { }\n    n = n + x\n  }\n  n\n}"
+  assert_result_all_backends(src, "main", "forin_continue_stmt", "9")
+}
+
 test "heap e2e: tuple field access" {
   let src = "let main: () -> Int = () -> {\n  let t = (3, 4)\n  t.0 + t.1\n}"
   assert_result(src, "main", "tuple", "7")


### PR DESCRIPTION
## Summary

`for x in xs { if ... { continue }; x }` hung. Diagnosis: both for-in lowerings emit `continue` as `br` to the loop header (`ld = 0`) and incremented `i` *after* the body, so an even element retried the same index.

Increment after bind / before body so skip-iteration does not re-visit `i`. Collect and statement forms both covered.

## Tests

```
bash scripts/vibe_test.sh lib/@vibe/compiler/tests/codegen_heap_e2e_test.vibe
```

149/149 passed, including:

- collecting `for-in` + `continue` → `[1, 3, 5]` packed as `531`
- statement `for-in` + `continue` → `n == 9`

All three backends (linear / rc / gc).

The existing `fixtures/for_in_continue.vibe` debt row stays: seed still compiles that fixture with the old lowering. Remove it after a seed bump.

Investigation on #1967. Not a snapshot migration.