### PR TITLE
test: lock exception-through-region values (#1937)

### DIFF
--- a/fixtures/region_throw_outside_test.vibe
+++ b/fixtures/region_throw_outside_test.vibe
@@ -1,0 +1,17 @@
+// #1937: values are correct when an exception punches through a region
+// and is handled outside. Watermark / depth restore on that path is still
+// missing — `compile_call` / `backend_call` emit enter, body, exit with no
+// try_table catch, so 64 unwinds fill the save table. This file only locks
+// the value contract so a later catch-and-exit cannot silently change it.
+
+test "exception through region is handled outside" {
+  let result = handle {
+    region r {
+      throw("x")
+      1
+    }
+  } with Exception {
+    Throw(_) => 7
+  }
+  inspect(result, "7")
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1286,6 +1286,9 @@ export fn compile_call(buf: Bytes, callee: Expr, args: Array[Expr], local_names:
     let r = ce(buf, ECall(Array::get(args, 0), [
       EInt(0)
     ], -1), local_names, next_local, ctx, ld)
+    // #1937: this exit is the success path only. A throw from the body
+    // skips it, so watermark/depth are not restored. Needs try_table
+    // catch -> exit -> rethrow (same protocol as EHandle).
     if ctx.region_ptr_addr >= 0 {
       emit_region_exit(buf, ctx.region_ptr_addr)
     } else {

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -591,6 +591,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let region_r = ce(buf, ECall(Array::get(args, 0), [
           EInt(0)
         ], -1), local_names, next_local, ld)
+        // #1937: success-path exit only. A throw from the body skips it.
         // Emitted with the body's result already on the stack: every
         // instruction in the exit consumes only its own operands, so the
         // result rides through untouched.


### PR DESCRIPTION
## Summary

#1937 is a runtime unwind hole, not a value bug. This slice:

- locks that `handle { region r { throw(...) } } with Exception` still returns the handler value
- comments the linear and gc `__region_run` lowerings: `emit_region_exit` is success-path only

The actual fix is try_table catch → exit → rethrow (same protocol as `EHandle`). Not implemented here.

## Tests

```
bash scripts/vibe_test.sh fixtures/region_throw_outside_test.vibe
```

1/1 passed.