### PR TITLE
fix(lsp): decode line L:C-E ranges in JSON diagnostics (#1941)

### DIFF
--- a/lib/@vibe/lsp/lsp_diagnostics_test.vibe
+++ b/lib/@vibe/lsp/lsp_diagnostics_test.vibe
@@ -15,11 +15,23 @@
 // still rendered, just in the wrong place.
 //
 // These are snapshots of the real wire output, not hand-written JSON.
+//
+// #1941 next knife after #2024: `locate_type_error` already emits
+// `line L:C-E:` from `[@off=N:M]`, but the JSON/LSP encoder used to treat
+// `C-E` as a non-numeric column and collapse to `0..1`. The quux test
+// below requires the encoder to slice the same token #2024 locked.
+// Leftover on #1941: grep `line:0`, synthetic `0:0` instead of an
+// unavailable marker, type-at on binders/callees. Return-type mismatches
+// still take the no-position fallback (the snapshot below).
 
 //# Imports
 
 import .{
   lsp_diagnostics_json_string
+}
+
+import @vibe/json {
+  Json
 }
 
 //# Tests
@@ -39,10 +51,11 @@ test "lsp diagnostics: a parse error carries its position and error severity" {
 }
 
 test "lsp diagnostics: a message with no position falls back to the file start" {
-  // Type errors still carry no `line L:C:` prefix (#1567's remaining half), so
-  // they take the fallback path and land on 0:0. Pinned as CURRENT behaviour,
-  // not as desired behaviour -- when #1567 gives type errors a position this
-  // snapshot changes, which is the point of having it.
+  // Type errors without `[@off=]` still carry no `line L:C:` prefix
+  // (#1567 leftover / #1941 synthetic 0:0). Unknown names like `quux`
+  // are located; this snapshot is the no-position fallback. Pinned as
+  // CURRENT behaviour, not as desired -- when those messages get a
+  // position this snapshot changes.
   inspect(lsp_diagnostics_json_string("fn f() -> Int { \"s\" }"), "[{\"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":0,\"character\":1}},\"severity\":1,\"source\":\"vibe\",\"message\":\"return type mismatch: expected Int, got String\",\"data\":null}]",)
 }
 
@@ -60,4 +73,34 @@ test "lsp diagnostics: an ASCII line is unaffected by the UTF-16 conversion" {
   // The conversion must be identity when there is nothing multibyte to convert
   // -- a fix that shifted ASCII columns would be worse than the bug.
   inspect(lsp_diagnostics_json_string("let a = 1\nfn f( -> Int { 1 }"), "[{\"range\":{\"start\":{\"line\":1,\"character\":6},\"end\":{\"line\":1,\"character\":7}},\"severity\":1,\"source\":\"vibe\",\"message\":\"expected parameter name token=->\",\"data\":null}]",)
+}
+
+/// Identifier `quux` is the #2024 / #1941 range-agreement token.
+/// `vibe check --single-file --json` and LSP publishDiagnostics share
+/// `lsp_diagnostics_json_string`. The range must slice `quux`, not collapse
+/// to 0-width or the `0..1` fallback.
+test "json diagnostics slice the same unknown identifier quux (#1941)" {
+  let src = "let x = quux\n"
+  let token = "quux"
+  let start = String::index_of(src, token)
+  let endo = start + String::length(token)
+  assert(start >= 0)
+  assert(String::substring(src, start, endo) == token)
+  let parsed = Json::parse(lsp_diagnostics_json_string(src))
+  assert(Json::length(parsed) == 1)
+  let range = Json::field(Json::index(parsed, 0), "range")
+  let rs = Json::field(range, "start")
+  let re = Json::field(range, "end")
+  let sl = Double::to_int(Json::number(Json::field(rs, "line")))
+  let sc = Double::to_int(Json::number(Json::field(rs, "character")))
+  let el = Double::to_int(Json::number(Json::field(re, "line")))
+  let ec = Double::to_int(Json::number(Json::field(re, "character")))
+  assert(el > sl || ec > sc)
+  assert(!(sl == 0 && sc == 0 && el == 0 && ec <= 1))
+  assert(sl == 0)
+  assert(el == 0)
+  assert(sc == start)
+  assert(ec == endo)
+  assert(String::substring(src, sc, ec) == token)
+  assert(Json::string(Json::field(Json::index(parsed, 0), "message")) == "unknown name: quux")
 }

--- a/lib/@vibe/lsp/lsp_server.vibe
+++ b/lib/@vibe/lsp/lsp_server.vibe
@@ -441,7 +441,7 @@ fn lsp_offset_to_pos(source: String, offset: Int) -> (Int, Int) {
   (line0, lsp_byte_col_to_utf16(source, line_start, byte_col0))
 }
 
-//# Diagnostics: parsing "line L:C: message" into an LSP Diagnostic
+//# Diagnostics: parsing "line L:C:" / "line L:C-E:" into an LSP Diagnostic
 
 /// #820 sub-item 2 (structured fix-it, minimal slice): recover the
 /// effect-row-mismatch's structured fields (target function name, the
@@ -542,15 +542,21 @@ fn lsp_diag_severity(text: String) -> Int {
   }
 }
 
-/// `line L:C: message` -> LSP Diagnostic.
+/// `line L:C: message` or `line L:C-E: message` -> LSP Diagnostic.
 ///
-/// `C` is a BYTE column (that is what the compiler's diagnostics carry, and
-/// what every other consumer of these strings wants). LSP positions are UTF-16
-/// code units, so it has to be converted against the source -- passing the byte
-/// column straight through puts the editor's caret too far right on any line
-/// with non-ASCII before the error, and silently: the diagnostic still renders,
-/// just at the wrong place. `let 日本 = 1` reports byte column 10 for `本`
-/// where LSP wants 8.
+/// `C` / `E` are BYTE columns (that is what the compiler's diagnostics carry,
+/// and what every other consumer of these strings wants). `locate_type_error`
+/// emits the `C-E` form from `[@off=N:M]` when start and end share a line
+/// (#1941). Treating `C-E` as one integer used to fail `lsp_parse_uint_or`
+/// and collapse the range to the `0..1` fallback -- a confident lie about
+/// a token the checker already located. Point-only `line L:C:` still
+/// highlights one character (`C` .. `C+1`), same as before.
+///
+/// LSP positions are UTF-16 code units, so each column has to be converted
+/// against the source -- passing the byte column straight through puts the
+/// editor's caret too far right on any line with non-ASCII before the error,
+/// and silently: the diagnostic still renders, just at the wrong place.
+/// `let 日本 = 1` reports byte column 10 for `本` where LSP wants 8.
 fn lsp_parse_diag_line(source: String, msg: String) -> Json {
   if String::starts_with(msg, "line ") {
     let after = msg[5: String::length(msg)]
@@ -564,10 +570,20 @@ fn lsp_parse_diag_line(source: String, msg: String) -> Json {
       if colon2 < 0 {
         lsp_diag_fallback(msg)
       } else {
-        let col_str = rest1[0: colon2]
+        let col_field = rest1[0: colon2]
         let text = String::trim(rest1[colon2 + 1: String::length(rest1)])
         let line1 = lsp_parse_uint_or(line_str, 1)
-        let col1 = lsp_parse_uint_or(col_str, 1)
+        let dash = String::index_of(col_field, "-")
+        let col1 = if dash < 0 {
+          lsp_parse_uint_or(col_field, 1)
+        } else {
+          lsp_parse_uint_or(col_field[0: dash], 1)
+        }
+        let end_col1 = if dash < 0 {
+          0
+        } else {
+          lsp_parse_uint_or(col_field[dash + 1: String::length(col_field)], 0)
+        }
         let line0 = if line1 > 0 {
           line1 - 1
         } else {
@@ -578,12 +594,18 @@ fn lsp_parse_diag_line(source: String, msg: String) -> Json {
         } else {
           0
         }
-        let col0 = lsp_byte_col_to_utf16(source, lsp_line_start_offset(source, line0), byte_col0)
+        let line_start = lsp_line_start_offset(source, line0)
+        let col0 = lsp_byte_col_to_utf16(source, line_start, byte_col0)
+        let end_col0 = if end_col1 > col1 {
+          lsp_byte_col_to_utf16(source, line_start, end_col1 - 1)
+        } else {
+          col0 + 1
+        }
         // #820 sub-item 2: `data` follows the LSP Diagnostic.data convention
         // (present, JNull when there's no structured fix -- e.g. every
         // diagnostic that isn't an effect-row mismatch).
         JObj(Map::from_pairs([
-          ("range", jrange(line0, col0, line0, col0 + 1)),
+          ("range", jrange(line0, col0, line0, end_col0)),
           ("severity", jnum_int(lsp_diag_severity(text))),
           ("source", JStr("vibe")),
           ("message", JStr(text)),
@@ -596,6 +618,10 @@ fn lsp_parse_diag_line(source: String, msg: String) -> Json {
   }
 }
 
+/// Messages with no `line L:` prefix still land on `0..1`. That is the
+/// leftover #1941 synthetic-`0:0` lie, not a real span -- keep it until
+/// those diagnostics grow an unavailable/synthetic marker instead of a
+/// plausible range.
 fn lsp_diag_fallback(msg: String) -> Json {
   JObj(Map::from_pairs([
     ("range", jrange(0, 0, 0, 1)),
@@ -735,9 +761,10 @@ export fn lsp_diagnostics_safe(source: String) -> Json {
 /// shape (range/severity/source/message) rather than inventing a parallel
 /// structured format -- one machine-readable diagnostic representation for
 /// both the editor protocol and the CLI, built by parsing the same
-/// `collect_all_diagnostics` "line L:C: message" strings every other
-/// diagnostics consumer (plain-text `vibe diagnostics`, this LSP handler)
-/// already produces. Output-layer-only: no checker/lexer/parser changes.
+/// `collect_all_diagnostics` "line L:C:" / "line L:C-E:" strings every
+/// other diagnostics consumer (plain-text `vibe diagnostics`, this LSP
+/// handler) already produces. Output-layer-only: no checker/lexer/parser
+/// changes. `C-E` is the exclusive-end column from `[@off=N:M]` (#1941).
 export fn lsp_diagnostics_json_string(source: String) -> String {
   Json::stringify(lsp_diagnostics_safe(source))
 }


### PR DESCRIPTION
## Summary

Next short knife of #1941 after #2024. Not a rewrite of every command.

`locate_type_error` already turns `[@off=N:M]` into `line L:C-E:`. The JSON/LSP encoder (`lsp_parse_diag_line`, shared by `vibe check --single-file --json` and `publishDiagnostics`) treated `C-E` as one integer, failed `lsp_parse_uint_or`, and collapsed to the `0..1` fallback. That is a confident lie about a token the checker already located.

This PR parses the end column so a one-line `let x = quux` slices `quux` — the same offsets #2024 locked between `check_program` and `binding-at`. Point-only `line L:C:` still highlights one character.

## Tests

```
bash scripts/vibe_test.sh lib/@vibe/lsp/lsp_diagnostics_test.vibe
```

1/1 files, 7 tests passed.

## Leftover

- grep `line:0`
- synthetic `0:0` instead of an unavailable marker (return-type mismatch still uses the no-position `0..1` fallback)
- type-at on binders/callees