### PR TITLE
test: migrate Stream::next retarget hygiene fixture (#1973)

### DIFF
--- a/docs/effect-evidence-passing.md
+++ b/docs/effect-evidence-passing.md
@@ -2754,7 +2754,7 @@ retarget であり、`host_stream_next`、row-variable callee、literal-param fl
 この slice の範囲外のまま。
 
 fixtures: `effect_stream_next_suspend_retarget.vibe` (want 42; `Some(41)` と
-argument の一回評価を pin)、`effect_stream_next_retarget_hygiene.vibe`
+argument の一回評価を pin)、`effect_stream_next_retarget_hygiene_test.vibe`
 (`__sn_next` collision、shadowed `Future::ready`、empty layout を pin)。
 
 ### 追記42 (2026-08-09): sequence HEAD の let 連鎖を継続 spine へ float する (#1536 (a) v3)

--- a/fixtures/effect_stream_next_retarget_hygiene_test.vibe
+++ b/fixtures/effect_stream_next_retarget_hygiene_test.vibe
@@ -1,7 +1,9 @@
+// #1973: was fixtures/effect_stream_next_retarget_hygiene.vibe + __DATA__.last "7".
 // #1536 retarget regressions: the generated target must not collide with this
 // user binding, and the generated body must not call this shadowed builtin.
 // The empty stream's ready Future cell is [0, None], so its await takes the
 // None fallback (7), not the shadow's Some(99).
+
 let Future::ready = (_x) -> [
   Some(0),
   Some(99)
@@ -9,7 +11,7 @@ let Future::ready = (_x) -> [
 
 let __sn_next = (_s) -> Future::ready(Some(88))
 
-let _start = () -> Int {
+fn empty_stream_next() -> Int {
   handle {
     match await(Stream::next([
     ])) {
@@ -23,9 +25,7 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{
-  "last": "7"
+test "empty Stream::next is None even when Future::ready and __sn_next are shadowed" {
+  inspect(empty_stream_next(), "7")
 }

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -7854,10 +7854,8 @@ scps_run_expect "effect_closure_param_inert_transitive.vibe" "5" "inertdeleg"
 # CPS evaluates a resume-value Async handler. The fixture also pins its
 # Array-backed ready Future[Option[T]] result and one evaluation (Some(41)+1).
 scps_run_expect "effect_stream_next_suspend_retarget.vibe" "42" "streamnext"
-# Fresh synthetic target and direct [ready, payload] cell: a user
-# `__sn_next` must not capture the retarget and shadowed Future::ready must
-# not change empty-stream layout (None fallback = 7).
-scps_run_expect "effect_stream_next_retarget_hygiene.vibe" "7" "streamnexthygiene"
+# Hygiene pin (user `__sn_next` + shadowed Future::ready, empty layout = 7)
+# now lives in fixtures/effect_stream_next_retarget_hygiene_test.vibe (#1973).
 # #1723: a local pure closure shadows a top-level function whose callback
 # parameter carries the suspend effect. The prepass must leave the literal on
 # the plain convention; Done-wrapping it returns a step pointer instead of 8.

--- a/scripts/runtime_fixture_debt.tsv
+++ b/scripts/runtime_fixture_debt.tsv
@@ -31,7 +31,6 @@ fixtures/effect_seq_head_block_suspend.vibe	compile debt: generated block placem
 fixtures/effect_seq_head_if_suspend.vibe	compile debt: generated block placement leaves a local fn in an invalid position
 fixtures/effect_seq_head_match_suspend.vibe	compile debt: generated block placement leaves a local fn in an invalid position
 fixtures/effect_seq_head_reserved_name_collision.vibe	compile debt: generated block placement leaves a local fn in an invalid position
-fixtures/effect_stream_next_retarget_hygiene.vibe	compile debt: stale effect operation declaration syntax is rejected
 fixtures/effect_tail_selection_input_suspend.vibe	compile debt: one closure raw-performs multiple suspend-class effects
 fixtures/effect_trivial_wrapper_needing_call.vibe	compile debt: generated block placement leaves a local fn in an invalid position
 fixtures/err_import_collides_with_local_let.vibe	generator debt: hoisting the import ahead of the top-level let changes the name-collision contract into block shadowing


### PR DESCRIPTION
Partial slice of #1973. One cluster only: the `Stream::next` retarget hygiene pin.

## What happened to the row

`fixtures/effect_stream_next_retarget_hygiene.vibe` was listed as compile debt (`stale effect operation declaration syntax is rejected`). That reason is stale.

Current `Stream::next` + `handle … with Async` already works. Stage2 compiles the empty-stream program and prints `7`. The user `__sn_next` binding and the shadowed `Future::ready` do not steal the synthetic retarget.

Rewrote it as `fixtures/effect_stream_next_retarget_hygiene_test.vibe` with `inspect(..., "7")`. Deleted the `__DATA__` fixture, its TSV row, and the `compiler_gate` `_start` copy (the inspect test is now in the unit lane).

Not taken: two-binder `resume` arms (open #2025), `effect_row_*`, generated-lane placement (`effect_needing_*`, `effect_seq_head_*`), or higher-order handle holes.

## Test plan

- [x] `bash scripts/vibe_test.sh fixtures/effect_stream_next_retarget_hygiene_test.vibe` (seed and stage2)
- [x] generator inventory (`VIBE_RUNTIME_FIXTURE_INVENTORY=all`) — no stale debt row
- [x] `bash scripts/check_fixture_execution.sh`

Refs #1973.