### PR TITLE
Drop a `let mut` lambda's labels when a branch re-labels it (#1994 follow-up)

### DIFF
--- a/fixtures/labeled_mut_lambda_scope_test.vibe
+++ b/fixtures/labeled_mut_lambda_scope_test.vibe
@@ -1,51 +1,27 @@
-// #1994: a lambda bound by `let mut` got no parameter table, so a labeled call
-// to it was never reordered -- the arguments bound in WRITTEN order, with no
-// diagnostic. `let mut g = (x~: Int, y~: Int) -> Int { x - y }` called as
-// `g(y = 3, x = 10)` returned -7.
+// #1994, second half. Registering a `let mut` lambda from its initializer and
+// replacing the entry on assignment (the first half) is exact while the
+// assignment DOMINATES what follows -- straight-line code. It is exact nowhere
+// else: the walk goes through an `if` arm once, execution may go through it
+// never; a loop body may run any number of times; a closure body runs
+// somewhere else entirely. The entry such a subtree leaves behind then
+// describes a lambda the binding may not hold, and the labeled call after it
+// was reordered by those stale names, with no diagnostic.
 //
-// #1899/#1952 gave block-local `let` bindings a table of their own but left the
-// mutable case out on purpose: a `let mut` can be reassigned to another
-// type-compatible lambda whose parameter NAMES differ (labels are not part of a
-// function's type), and a table built from the initializer would then reorder a
-// later call by stale names.
+// Leaving one of those subtrees now drops the entry again, so the binding goes
+// back to unresolved -- and a labeled call to an unresolved binding is
+// reported rather than compiled (labeled_mut_lambda_unstable_test.vibe).
 //
-// The rule now is flow-insensitive and needs no analysis: register the
-// initializer's labels when the whole scope AGREES on them -- every assignment
-// to the name binds a lambda declaring the same parameter names in the same
-// order -- so reassignment is invisible to reordering. A scope that disagrees
-// stays unregistered and its labeled calls are rejected instead of compiled
-// (see labeled_mut_lambda_unstable_test.vibe).
+// What still resolves is everything whose labels no assignment CHANGED, plus
+// every call an assignment has not reached yet. That is what this file pins.
 //
 // Everything here subtracts on purpose. `x + y` gives the right answer whether
 // or not the arguments were reordered, which is how the first half of #1899
 // survived a "fix verified" claim.
 
-// The core case: never reassigned, so the initializer describes every value the
-// binding can hold. This is the one that returned -7.
-fn mut_labels_no_reassign() -> Int {
-  let mut g = (x~: Int, y~: Int) -> Int {
-    x - y
-  }
-  g(y = 3, x = 10)
-}
-
-// Reassigned to a lambda declaring the SAME parameter names: the labels are
-// still the labels, so the call reorders and the second lambda runs.
-fn mut_reassigned_same_names() -> Int {
-  let mut g = (x~: Int, y~: Int) -> Int {
-    100 + x - y
-  }
-  g = (x~: Int, y~: Int) -> Int {
-    x - y
-  }
-  g(y = 3, x = 10)
-}
-
-// The assignment sits inside a branch, which is exactly the shape that makes
-// "invalidate the table when you walk an EAssign" unsound -- the walk reaches
-// the assignment whether or not the branch runs. Both answers here are only
-// reachable if the arguments were reordered (written order gives -7 / -8).
-fn mut_reassigned_in_branch(flip: Bool) -> Int {
+// An assignment in a branch that re-binds the SAME parameter names changes
+// nothing a label can observe, so it must not cost the binding its labels.
+// Written order gives -7 / -8 here; both answers below need the reorder.
+fn same_names_in_branch(flip: Bool) -> Int {
   let mut g = (x~: Int, y~: Int) -> Int {
     x - y
   }
@@ -59,61 +35,77 @@ fn mut_reassigned_in_branch(flip: Bool) -> Int {
   g(y = 3, x = 10)
 }
 
-// A positional call never depended on any of this, and must not start to.
-fn mut_positional() -> Int {
+// Same, from a loop body.
+fn same_names_in_loop() -> Int {
   let mut g = (x~: Int, y~: Int) -> Int {
-    100 + x - y
+    x - y + 1
   }
-  g = (y~: Int, x~: Int) -> Int {
-    x - y
+  let mut i = 0
+  while i < 1 {
+    g = (x~: Int, y~: Int) -> Int {
+      x - y
+    }
+    i = i + 1
   }
-  g(3, 10)
+  g(y = 3, x = 10)
 }
 
-// An inner binding that takes the name over is NOT a reassignment: the scan
-// skips its scope rather than giving up on the whole `let mut`, so the call
-// before it still resolves.
-fn later_let_does_not_poison() -> Int {
+// Same, from a closure body (#2012 made this shape runnable at all).
+fn same_names_in_closure() -> Int {
+  let mut g = (x~: Int, y~: Int) -> Int {
+    x - y + 1
+  }
+  let bump = () -> Unit {
+    g = (x~: Int, y~: Int) -> Int {
+      x - y
+    }
+  }
+  bump()
+  g(y = 3, x = 10)
+}
+
+// A call BEFORE a branch that changes the labels still resolves: at that point
+// the initializer is the only lambda the binding can hold. Only what follows
+// the branch is unresolved, so this must not become a false rejection.
+fn call_before_a_changing_branch(flip: Bool) -> Int {
   let mut g = (x~: Int, y~: Int) -> Int {
     x - y
   }
   let answer = g(y = 3, x = 10)
-  let g = 5
-  answer - g + 5
+  if flip {
+    g = (y~: Int, x~: Int) -> Int {
+      x - y
+    }
+  } else {
+    ()
+  }
+  answer
 }
 
-// ...and inside that inner scope the INNER labels win. With the outer entry
-// leaking, this returns -7.
-fn inner_let_masks_mut() -> Int {
+// A positional call never depended on any of this, and must not start to. The
+// two answers differ because the two lambdas take their parameters in
+// different orders -- which is exactly why the labeled form has no answer.
+fn positional_after_changing_branch(flip: Bool) -> Int {
   let mut g = (x~: Int, y~: Int) -> Int {
     x - y
   }
-  let _warm = g(y = 3, x = 10)
-  let g = (y~: Int, x~: Int) -> Int {
-    x - y
+  if flip {
+    g = (y~: Int, x~: Int) -> Int {
+      x - y
+    }
+  } else {
+    ()
   }
-  g(y = 3, x = 10)
+  g(10, 3)
 }
 
-// Optional omitted args on `let mut` still fail on the committed seed
-// (`expected 2 args, got 1`). Keep them off this fixture so the labeled
-// reorder cases can run in the seed unit lane.
-
-// The immutable case from #1899/#1952, unchanged.
-fn immutable_control() -> Int {
-  let g = (x~: Int, y~: Int) -> Int {
-    x - y
-  }
-  g(y = 3, x = 10)
-}
-
-test "labeled arguments on a `let mut` lambda" {
-  inspect(mut_labels_no_reassign(), "7")
-  inspect(mut_reassigned_same_names(), "7")
-  inspect(mut_reassigned_in_branch(false), "7")
-  inspect(mut_reassigned_in_branch(true), "6")
-  inspect(mut_positional(), "7")
-  inspect(later_let_does_not_poison(), "7")
-  inspect(inner_let_masks_mut(), "7")
-  inspect(immutable_control(), "7")
+test "labeled arguments on a `let mut` lambda a branch reassigns" {
+  inspect(same_names_in_branch(false), "7")
+  inspect(same_names_in_branch(true), "6")
+  inspect(same_names_in_loop(), "7")
+  inspect(same_names_in_closure(), "7")
+  inspect(call_before_a_changing_branch(false), "7")
+  inspect(call_before_a_changing_branch(true), "7")
+  inspect(positional_after_changing_branch(false), "7")
+  inspect(positional_after_changing_branch(true), "-7")
 }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -2906,7 +2906,7 @@ fn report_unresolved_mut_labeled_calls(errors: Array[String]) -> Unit {
   while i < Array::length(sites) {
     let (fname, off) = Array::get(sites, i)
     let marker = labeled_name_marker(off, String::length(fname))
-    Array::push(errors, String::concat("cannot resolve labeled arguments for ", String::concat(fname, String::concat(": it is a `let mut` binding that is assigned lambdas with different parameter names, so a label does not name a position — call ", String::concat(fname, String::concat(" positionally, or give every lambda assigned to ", String::concat(fname, String::concat(" the same parameter names", marker))))))))
+    Array::push(errors, String::concat("cannot resolve labeled arguments for ", String::concat(fname, String::concat(": a branch, loop or closure assigns it a lambda with different parameter names, so a label does not name a position here — call ", String::concat(fname, String::concat(" positionally, or give every lambda assigned to ", String::concat(fname, String::concat(" the same parameter names", marker))))))))
     i = i + 1
   }
 }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9793,25 +9793,30 @@ fn local_fn_tbl_push(name: String, v: Expr, at: Int) -> Unit {
 /// innermost `g`. A non-lambda RHS invalidates it. Assignment inside a
 /// branch still only reaches that branch's continuation.
 fn local_fn_tbl_replace(name: String, v: Expr, shadows: Array[String]) -> Unit {
-  let mut innermost = 0 - 1
-  let mut i = 0
-  while i < Array::length(shadows) {
-    if Array::get(shadows, i) == name {
-      innermost = i
-    }
-    i = i + 1
-  }
+  let innermost = innermost_shadow_index(name, shadows)
   if innermost < 0 {
+    ()
+  } else if unstable_mut_tbl_lookup(name, shadows) {
+    // Already unresolvable (a branch, loop or closure re-labelled it). Putting
+    // an entry back would hand a labeled call the labels of whichever
+    // assignment the WALK reached last.
     ()
   } else {
     let mut j = Array::length(local_fn_tbl_cell) - 1
     let mut found = false
+    let mut changed = false
     while j >= 0 {
-      let (n, _, _, at) = Array::get(local_fn_tbl_cell, j)
+      let (n, old_labels, _, at) = Array::get(local_fn_tbl_cell, j)
       if n == name && at == innermost {
         match local_fn_tbl_shape(v) {
-          Some((labels, flags)) => Array::set(local_fn_tbl_cell, j, (name, labels, flags, at)),
-          None => Array::set(local_fn_tbl_cell, j, (name, empty_str_array(), array_empty(), at))
+          Some((labels, flags)) => {
+            changed = !labels_equal(labels, old_labels)
+            Array::set(local_fn_tbl_cell, j, (name, labels, flags, at))
+          },
+          None => {
+            changed = Array::length(old_labels) > 0
+            Array::set(local_fn_tbl_cell, j, (name, empty_str_array(), array_empty(), at))
+          }
         }
         found = true
         j = 0 - 1
@@ -9821,6 +9826,14 @@ fn local_fn_tbl_replace(name: String, v: Expr, shadows: Array[String]) -> Unit {
     }
     if !found {
       local_fn_tbl_push(name, v, innermost)
+      // Whatever labels the binding has now came from here, so a subtree that
+      // does not dominate the rest must not keep them either.
+      changed = true
+    } else {
+      ()
+    }
+    if changed {
+      Array::push(relabel_assigned_cell, (name, innermost))
     } else {
       ()
     }
@@ -10030,6 +10043,91 @@ fn mut_binding_labels_broken(e: Expr, name: String, labels: Array[String]) -> Bo
 /// no resolution at all, so it must be reported rather than left to bind in
 /// written order, which is right only by luck.
 let unstable_mut_tbl_cell: Array[(String, Int)] = array_empty()
+
+///|
+/// Every assignment that CHANGED a binding's labels, as (name, index in
+/// `shadows`). A subtree whose walk does not dominate what follows notes the
+/// length on entry and hands what its walk appended to
+/// `poison_branch_assignments` on the way out. An assignment that re-binds the
+/// same parameter names is not recorded: it changes nothing a labeled call can
+/// observe, so it must not cost the binding its labels.
+let relabel_assigned_cell: Array[(String, Int)] = array_empty()
+
+///|
+fn innermost_shadow_index(name: String, shadows: Array[String]) -> Int {
+  let mut innermost = 0 - 1
+  let mut i = 0
+  while i < Array::length(shadows) {
+    if Array::get(shadows, i) == name {
+      innermost = i
+    }
+    i = i + 1
+  }
+  innermost
+}
+
+///|
+fn labels_equal(a: Array[String], b: Array[String]) -> Bool {
+  if Array::length(a) != Array::length(b) {
+    false
+  } else {
+    let mut i = 0
+    let mut same = true
+    while i < Array::length(a) {
+      if Array::get(a, i) != Array::get(b, i) {
+        same = false
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    same
+  }
+}
+
+///|
+fn local_fn_tbl_remove(name: String, at: Int) -> Unit {
+  let kept = array_empty()
+  let mut i = 0
+  while i < Array::length(local_fn_tbl_cell) {
+    let entry = Array::get(local_fn_tbl_cell, i)
+    let (n, _, _, a) = entry
+    if n == name && a == at {
+      ()
+    } else {
+      Array::push(kept, entry)
+    }
+    i = i + 1
+  }
+  Array::truncate(local_fn_tbl_cell, 0)
+  let mut j = 0
+  while j < Array::length(kept) {
+    Array::push(local_fn_tbl_cell, Array::get(kept, j))
+    j = j + 1
+  }
+}
+
+///|
+/// Leaving a subtree whose walk does not dominate what follows -- an `if` arm,
+/// a loop body, a closure body. Every binding it re-labelled and did not itself
+/// introduce (`at < mark`, the length of `shadows` on entry) loses its entry,
+/// because from here on nothing knows which lambda the binding holds. The
+/// continuation-only update `local_fn_tbl_replace` performs is exact while the
+/// assignment dominates what follows; this is where that stops being true.
+fn poison_branch_assignments(from: Int, mark: Int) -> Unit {
+  let mut i = from
+  while i < Array::length(relabel_assigned_cell) {
+    let (n, at) = Array::get(relabel_assigned_cell, i)
+    if at < mark {
+      local_fn_tbl_remove(n, at)
+      unstable_mut_tbl_push(n, at)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  Array::truncate(relabel_assigned_cell, from)
+}
 
 ///|
 fn unstable_mut_tbl_push(name: String, at: Int) -> Unit {
@@ -10583,7 +10681,16 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       }
       EMap(out)
     },
-    EIf(c, t, e) => EIf(relabel_expr(c, tbl, shadows), relabel_expr(t, tbl, shadows), relabel_expr(e, tbl, shadows)),
+    EIf(c, t, e) => {
+      let rc = relabel_expr(c, tbl, shadows)
+      // #1994: the arms are WALKED, not executed. Whatever they re-label must
+      // not go on describing the binding after the `if`.
+      let amark = Array::length(relabel_assigned_cell)
+      let rt = relabel_expr(t, tbl, shadows)
+      let re = relabel_expr(e, tbl, shadows)
+      poison_branch_assignments(amark, Array::length(shadows))
+      EIf(rc, rt, re)
+    },
     // The three binding arms keep local_fn_tbl_cell in step with `shadows`
     // (#1899/#1952): push the lambda's parameter shape at the index `name`
     // takes in `shadows`, and drop it again on the same scope exit.
@@ -10648,6 +10755,9 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
     ESeq(a, b) => ESeq(relabel_expr(a, tbl, shadows), relabel_expr(b, tbl, shadows)),
     EMatch(scrut, arms) => {
       let rscrut = relabel_expr(scrut, tbl, shadows)
+      // #1994: one arm runs; every arm is walked. See the EIf arm.
+      let amark = Array::length(relabel_assigned_cell)
+      let arms_mark = Array::length(shadows)
       let out = array_empty()
       let mut i = 0
       while i < Array::length(arms) {
@@ -10661,10 +10771,14 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
         optional_local_leave(local_mark)
         i = i + 1
       }
+      poison_branch_assignments(amark, arms_mark)
       EMatch(rscrut, out)
     },
     EHandle(scrut, arms) => {
       let rscrut = relabel_expr(scrut, tbl, shadows)
+      // #1994: a handler arm runs only when its operation is performed.
+      let amark = Array::length(relabel_assigned_cell)
+      let arms_mark = Array::length(shadows)
       let out = array_empty()
       let mut i = 0
       while i < Array::length(arms) {
@@ -10678,9 +10792,18 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
         optional_local_leave(local_mark)
         i = i + 1
       }
+      poison_branch_assignments(amark, arms_mark)
       EHandle(rscrut, out)
     },
-    EWhile(c, b) => EWhile(relabel_expr(c, tbl, shadows), relabel_expr(b, tbl, shadows)),
+    EWhile(c, b) => {
+      // #1994: the body runs zero or more times, so an assignment inside it
+      // describes the binding neither after the loop nor on the next round.
+      let amark = Array::length(relabel_assigned_cell)
+      let rc = relabel_expr(c, tbl, shadows)
+      let rb = relabel_expr(b, tbl, shadows)
+      poison_branch_assignments(amark, Array::length(shadows))
+      EWhile(rc, rb)
+    },
     ELoop(params, b) => {
       let rinits = for param in params {
         let (name, init) = param
@@ -10688,6 +10811,8 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       }
       let mark = Array::length(shadows)
       let local_mark = Array::length(optional_param_local_cell)
+      // #1994: see the EWhile arm.
+      let amark = Array::length(relabel_assigned_cell)
       let mut pi = 0
       while pi < Array::length(params) {
         let (pname, _) = Array::get(params, pi)
@@ -10698,12 +10823,15 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
       optional_local_leave(local_mark)
+      poison_branch_assignments(amark, mark)
       ELoop(rinits, rb)
     },
     EForIn(name, idx, iter, b) => {
       let riter = relabel_expr(iter, tbl, shadows)
       let mark = Array::length(shadows)
       let local_mark = Array::length(optional_param_local_cell)
+      // #1994: see the EWhile arm.
+      let amark = Array::length(relabel_assigned_cell)
       Array::push(shadows, name)
       match idx {
         Some(ix) => Array::push(shadows, ix),
@@ -10713,11 +10841,14 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
       optional_local_leave(local_mark)
+      poison_branch_assignments(amark, mark)
       EForIn(name, idx, riter, rb)
     },
     EFn(tp, bnds, params, rt, eff, b) => {
       let mark = Array::length(shadows)
       let local_mark = Array::length(optional_param_local_cell)
+      // #1994: a closure body is walked here and runs somewhere else, if ever.
+      let amark = Array::length(relabel_assigned_cell)
       let mut pi = 0
       while pi < Array::length(params) {
         let (pn, _) = Array::get(params, pi)
@@ -10728,6 +10859,7 @@ fn relabel_expr(expr: Expr, tbl: Array[(String, Array[String])], shadows: Array[
       let rb = relabel_expr(b, tbl, shadows)
       Array::truncate(shadows, mark)
       optional_local_leave(local_mark)
+      poison_branch_assignments(amark, mark)
       EFn(tp, bnds, params, rt, eff, rb)
     },
     EDot(obj, field, off, fdoff) => EDot(relabel_expr(obj, tbl, shadows), field, off, fdoff),
@@ -10915,7 +11047,13 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
     },
     EIf(cond, yes, no) => {
       paired_expect_node(node, AuthorityExprIf, 0, 3, poisoned)
-      EIf(relabel_expr_paired_child(cond, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(yes, tbl, shadows, node, 1, poisoned), relabel_expr_paired_child(no, tbl, shadows, node, 2, poisoned))
+      let rcond = relabel_expr_paired_child(cond, tbl, shadows, node, 0, poisoned)
+      // #1994: kept in step with relabel_expr's EIf arm.
+      let amark = Array::length(relabel_assigned_cell)
+      let ryes = relabel_expr_paired_child(yes, tbl, shadows, node, 1, poisoned)
+      let rno = relabel_expr_paired_child(no, tbl, shadows, node, 2, poisoned)
+      poison_branch_assignments(amark, Array::length(shadows))
+      EIf(rcond, ryes, rno)
     },
     // Kept in step with relabel_expr's binding arms (#1899/#1952): the two
     // lanes must agree about which local lambdas are in scope.
@@ -10985,6 +11123,9 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
     EMatch(scrutinee, arms) => {
       paired_expect_node(node, AuthorityExprMatch, 0, 1 + Array::length(arms) * 2, poisoned)
       let rscrutinee = relabel_expr_paired_child(scrutinee, tbl, shadows, node, 0, poisoned)
+      // #1994: kept in step with relabel_expr's EMatch arm.
+      let amark = Array::length(relabel_assigned_cell)
+      let arms_mark = Array::length(shadows)
       let out = array_empty()
       let mut i = 0
       while i < Array::length(arms) {
@@ -10996,11 +11137,15 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
         Array::truncate(shadows, mark)
         i = i + 1
       }
+      poison_branch_assignments(amark, arms_mark)
       EMatch(rscrutinee, out)
     },
     EHandle(scrutinee, arms) => {
       paired_expect_node(node, AuthorityExprHandle, 0, 1 + Array::length(arms) * 2, poisoned)
       let rscrutinee = relabel_expr_paired_child(scrutinee, tbl, shadows, node, 0, poisoned)
+      // #1994: kept in step with relabel_expr's EHandle arm.
+      let amark = Array::length(relabel_assigned_cell)
+      let arms_mark = Array::length(shadows)
       let out = array_empty()
       let mut i = 0
       while i < Array::length(arms) {
@@ -11012,11 +11157,17 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
         Array::truncate(shadows, mark)
         i = i + 1
       }
+      poison_branch_assignments(amark, arms_mark)
       EHandle(rscrutinee, out)
     },
     EWhile(cond, body) => {
       paired_expect_node(node, AuthorityExprWhile, 0, 2, poisoned)
-      EWhile(relabel_expr_paired_child(cond, tbl, shadows, node, 0, poisoned), relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned))
+      // #1994: kept in step with relabel_expr's EWhile arm.
+      let amark = Array::length(relabel_assigned_cell)
+      let rcond = relabel_expr_paired_child(cond, tbl, shadows, node, 0, poisoned)
+      let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
+      poison_branch_assignments(amark, Array::length(shadows))
+      EWhile(rcond, rbody)
     },
     ELoop(_, _) => {
       paired_poison(poisoned)
@@ -11035,6 +11186,8 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       }
       let riterable = relabel_expr_paired_child(iterable, tbl, shadows, node, 0, poisoned)
       let mark = Array::length(shadows)
+      // #1994: kept in step with relabel_expr's EForIn arm.
+      let amark = Array::length(relabel_assigned_cell)
       Array::push(shadows, name)
       match index {
         Some(index_name) => Array::push(shadows, index_name),
@@ -11042,6 +11195,7 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       }
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 1, poisoned)
       Array::truncate(shadows, mark)
+      poison_branch_assignments(amark, mark)
       EForIn(name, index, riterable, rbody)
     },
     EFn(type_params, bounds, params, ret, effects, body) => {
@@ -11052,6 +11206,8 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
         ti = ti + 1
       }
       let mark = Array::length(shadows)
+      // #1994: kept in step with relabel_expr's EFn arm.
+      let amark = Array::length(relabel_assigned_cell)
       let mut pi = 0
       while pi < Array::length(params) {
         let (name, _) = Array::get(params, pi)
@@ -11061,6 +11217,7 @@ fn relabel_expr_paired(expr: Expr, tbl: Array[(String, Array[String])], shadows:
       }
       let rbody = relabel_expr_paired_child(body, tbl, shadows, node, 0, poisoned)
       Array::truncate(shadows, mark)
+      poison_branch_assignments(amark, mark)
       EFn(type_params, bounds, params, ret, effects, rbody)
     },
     EDot(object, field, offset, field_offset) => {
@@ -11841,6 +11998,7 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   Array::truncate(optional_param_local_cell, 0)
   Array::truncate(local_fn_tbl_cell, 0)
   Array::truncate(unstable_mut_tbl_cell, 0)
+  Array::truncate(relabel_assigned_cell, 0)
   Array::truncate(unresolved_mut_labeled_cell, 0)
   let tbl = collect_fn_param_labels(stmts)
   // #1500: optional-parameter call sites are rewritten by the same walk (see
@@ -11873,12 +12031,14 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   Array::truncate(optional_param_local_cell, 0)
   Array::truncate(local_fn_tbl_cell, 0)
   Array::truncate(unstable_mut_tbl_cell, 0)
+  Array::truncate(relabel_assigned_cell, 0)
 }
 
 fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityNode], poisoned: Array[Bool]) -> Unit {
   Array::truncate(optional_param_local_cell, 0)
   Array::truncate(local_fn_tbl_cell, 0)
   Array::truncate(unstable_mut_tbl_cell, 0)
+  Array::truncate(relabel_assigned_cell, 0)
   Array::truncate(unresolved_mut_labeled_cell, 0)
   let tbl = collect_fn_param_labels(stmts)
   let opt_tbl = collect_optional_param_fns(stmts)
@@ -11909,6 +12069,7 @@ fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityN
   Array::truncate(optional_param_local_cell, 0)
   Array::truncate(local_fn_tbl_cell, 0)
   Array::truncate(unstable_mut_tbl_cell, 0)
+  Array::truncate(relabel_assigned_cell, 0)
 }
 
 export fn normalize_labeled_args_with_binder_authority(source: LocatedProgramBinderAuthority) -> LabeledArgBinderAuthorityNormalization {

--- a/lib/@vibe/compiler/tests/labeled_mut_lambda_unstable_test.vibe
+++ b/lib/@vibe/compiler/tests/labeled_mut_lambda_unstable_test.vibe
@@ -84,6 +84,43 @@ fn shadowed_later_src() -> String {
   main_fn(body)
 }
 
+/// A BRANCH assigns the other parameter order; the call is after the branch.
+/// The branch is walked, not executed, so nothing after it knows which lambda
+/// `g` holds.
+fn changing_branch_src() -> String {
+  let yes = brace(String::concat("\n    g = ", String::concat(yx_lambda(), "\n  ")))
+  let branch = String::concat("\n  if flip ", String::concat(yes, String::concat(" else ", brace(" () "))))
+  let body = String::concat("\n  let mut g = ", String::concat(xy_lambda(), String::concat(branch, "\n  g(y = 3, x = 10)\n")))
+  String::concat("fn main(flip: Bool) -> Int ", String::concat(brace(body), "\n"))
+}
+
+/// The same branch, called POSITIONALLY. Nothing resolves by name, so nothing
+/// can be misresolved.
+fn changing_branch_positional_src() -> String {
+  let yes = brace(String::concat("\n    g = ", String::concat(yx_lambda(), "\n  ")))
+  let branch = String::concat("\n  if flip ", String::concat(yes, String::concat(" else ", brace(" () "))))
+  let body = String::concat("\n  let mut g = ", String::concat(xy_lambda(), String::concat(branch, "\n  g(3, 10)\n")))
+  String::concat("fn main(flip: Bool) -> Int ", String::concat(brace(body), "\n"))
+}
+
+/// A branch that re-binds the SAME parameter names changes nothing a label can
+/// observe, so it must not cost the binding its labels.
+fn same_names_branch_src() -> String {
+  let yes = brace(String::concat("\n    g = ", String::concat(xy_lambda(), "\n  ")))
+  let branch = String::concat("\n  if flip ", String::concat(yes, String::concat(" else ", brace(" () "))))
+  let body = String::concat("\n  let mut g = ", String::concat(xy_lambda(), String::concat(branch, "\n  g(y = 3, x = 10)\n")))
+  String::concat("fn main(flip: Bool) -> Int ", String::concat(brace(body), "\n"))
+}
+
+/// The call sits BEFORE the changing branch, where the initializer is still the
+/// only lambda the binding can hold. Reporting it would be a false rejection.
+fn call_before_branch_src() -> String {
+  let yes = brace(String::concat("\n    g = ", String::concat(yx_lambda(), "\n  ")))
+  let branch = String::concat("\n  if flip ", String::concat(yes, String::concat(" else ", brace(" () "))))
+  let body = String::concat("\n  let mut g = ", String::concat(xy_lambda(), String::concat("\n  let answer = g(y = 3, x = 10)", String::concat(branch, "\n  answer\n"))))
+  String::concat("fn main(flip: Bool) -> Int ", String::concat(brace(body), "\n"))
+}
+
 fn joined(src: String) -> String with Exception {
   String::join(diags(src), "\n")
 }
@@ -111,4 +148,26 @@ test "a scope that agrees on the labels is not reported" {
   assert(Array::length(diags(agreeing_labeled_src())) == 0)
   assert(Array::length(diags(never_reassigned_src())) == 0)
   assert(Array::length(diags(shadowed_later_src())) == 0)
+}
+
+test "a labeled call after a branch that re-labels the binding is reported" {
+  let text = joined(changing_branch_src())
+  assert(String::contains(text, "cannot resolve labeled arguments for g"))
+  // The message has to say what to write instead, not name a pass.
+  assert(String::contains(text, "call g positionally"))
+  // ...and where: the call is on the source's sixth line. Without the location
+  // the report cannot be jumped to.
+  assert(String::contains(text, "line 6:3"))
+}
+
+test "a positional call after that branch is not reported" {
+  assert(Array::length(diags(changing_branch_positional_src())) == 0)
+}
+
+test "a branch that keeps the parameter names is not reported" {
+  assert(Array::length(diags(same_names_branch_src())) == 0)
+}
+
+test "a call the branch has not reached yet is not reported" {
+  assert(Array::length(diags(call_before_branch_src())) == 0)
 }


### PR DESCRIPTION
Follow-up to #2011, which landed the sequential half of #1994. This is the part that half leaves open, narrowed to where it actually bites.

## What is still wrong on `main`

Continuation-only replacement is exact while the assignment **dominates** what follows — straight-line code, which is what `labeled_local_lambda_scope_test` pins. It is exact nowhere else. The walk enters an `if` arm once; execution may enter it never. A loop body may run any number of times. A closure body runs somewhere else, if ever.

```vibe
fn branch_stale(flip: Bool) -> Int {
  let mut g = (x~: Int, y~: Int) -> Int { x - y }
  if flip {
    g = (y~: Int, x~: Int) -> Int { x - y }
  } else { () }
  g(x = 10, y = 3)
}
```

`branch_stale(false)` returns **-7**; 7 is correct. After the `if`, the table still holds the arm's `(y, x)`, so the call is reordered by labels belonging to a lambda `g` does not hold. Measured on a stage2 built from `126db0e07` (the #2011 merge), linear backend.

The reporting side is also unreachable there: nothing pushes to `unstable_mut_tbl_cell`, so `unstable_mut_tbl_lookup`, the `ECall` record and the checker's message can never fire.

## The rule

Leaving a subtree whose walk does not dominate what follows drops any entry whose labels an assignment inside it **changed**, and the binding goes back to unresolved. A labeled call to an unresolved binding is then reported with a location instead of compiled.

An assignment that re-binds the **same** parameter names changes nothing a label can observe, so it is not recorded and costs the binding nothing. That is what keeps the common shapes resolving, and it is why this does not repeat the flow-insensitive reject that broke the sequential fixtures earlier in #2011.

```
line 6:3-4: cannot resolve labeled arguments for g: a branch, loop or closure
assigns it a lambda with different parameter names, so a label does not name a
position here — call g positionally, or give every lambda assigned to g the
same parameter names
```

## Measurement

Through a stage2 built from this checkout, against one built from `main`:

| shape | main | here |
|---|---:|---|
| straight-line reassign (the #2011 case) | 7 | 7 — unchanged |
| branch assigns the same parameter names | 7 | 7 |
| branch assigns different names, call after | **-7** | **reported**, with `line:col` |
| call *before* that branch | 7 | 7 — not a false rejection |
| positional call | correct | correct |

Both directions are covered by tests: `fixtures/labeled_mut_lambda_scope_test.vibe` for the shapes that must keep resolving (branch, loop body, and closure body assignments that keep the names; a call the branch has not reached yet), and `lib/@vibe/compiler/tests/labeled_mut_lambda_unstable_test.vibe` for the report and its three non-reports.

Everything in the runtime fixture subtracts on purpose: `x + y` gives the right answer whether or not the arguments were reordered, which is how the first half of #1899 survived a "fix verified" claim.

## Regressions checked

`fixtures/labeled_local_lambda_scope_test.vibe` (sequential updates) and `lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe` both pass — those are exactly what the earlier reject broke. `fixtures/captured_mut_lambda_test.vibe` (#2012) passes too, since a closure body is one of the subtrees this touches.

`scripts/compiler_gate.sh` and `scripts/check_vibe_fmt.sh` are running against this base; I will confirm both in a comment. (`pkf run test` cannot reach the gate in this container — a broken `/usr/bin/sort` under pkfire's nix environment, reproducible on a clean `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk

---
_Generated by [Claude Code](https://claude.ai/code/session_016v6eS7sAtn3hh16x61Spqk)_