### PR TITLE
fix(typecheck): insert missing vpkg types-stub environments

### DIFF
--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1141,6 +1141,14 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
         } else {
           let cached_types_path = rest[0: nl]
           if cached_types_path == "" || Fs::exists(cached_types_path) {
+            // Same registry note as the facade-cache hit: a warm prefix
+            // used to skip ensure_vpkg_types_module_fs, so collect_merged
+            // and the typecheck source set never saw the stub (#1921).
+            if cached_types_path == "" {
+              ()
+            } else {
+              vpkg_types_registry_note(vpkg_path, cached_types_path, Fs::read_file(cached_types_path))
+            }
             rest[nl + 1: String::length(rest)]
           } else {
             ""
@@ -1211,6 +1219,48 @@ export fn ingest_source_text_fs(path: String, raw: String) -> String with Except
 /// @vibe/core import never rewrote). Ingest every collected source once here,
 /// the single point all collection branches (manifest, caches, recursive walk)
 /// flow through.
+fn grouped_sources_group_for_path(groups: Array[(String, Array[(String, String)])], path: String) -> String {
+  let mut found = ""
+  let mut gi = 0
+  while gi < Array::length(groups) && found == "" {
+    let (gname, sources) = Array::get(groups, gi)
+    let mut si = 0
+    while si < Array::length(sources) && found == "" {
+      let (sp, _) = Array::get(sources, si)
+      if sp == path {
+        found = gname
+      } else {
+        si = si + 1
+      }
+    }
+    gi = gi + 1
+  }
+  found
+}
+
+/// #1840/#1921: collect_merged_stmts already re-injects materialized vpkg
+/// types modules into a fixed source set. The typecheck walk seeds only
+/// what collect_source_groups_fs returns, so a compiler_sources_manifest
+/// that lists the contract but not `_build/vibe_vpkg_types/` left the stub
+/// in header deps and missing from the coordinator env cache.
+/// Attach the stub to the contract's existing group so manifest group order
+/// (entry last) stays intact.
+fn append_registered_vpkg_types_sources(groups: Array[(String, Array[(String, String)])]) -> Unit {
+  let mut ri = 0
+  while ri < Array::length(vpkg_types_registry_paths) {
+    let r_contract = Array::get(vpkg_types_registry_contracts, ri)
+    let r_path = Array::get(vpkg_types_registry_paths, ri)
+    let contract_group = grouped_sources_group_for_path(groups, r_contract)
+    let types_group = grouped_sources_group_for_path(groups, r_path)
+    if contract_group != "" && types_group == "" {
+      push_grouped_source(groups, contract_group, r_path, Array::get(vpkg_types_registry_texts, ri))
+    } else {
+      ()
+    }
+    ri = ri + 1
+  }
+}
+
 fn ingest_grouped_sources_fs(groups: Array[(String, Array[(String, String)])]) -> Array[(String, Array[(String, String)])] with Exception + Fs {
   let out = empty_grouped_sources()
   let mut gi = 0
@@ -1224,6 +1274,7 @@ fn ingest_grouped_sources_fs(groups: Array[(String, Array[(String, String)])]) -
     }
     gi = gi + 1
   }
+  append_registered_vpkg_types_sources(out)
   out
 }
 

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -79,7 +79,7 @@ import @vibe/compiler/loader {
 }
 
 import @vibe/graph {
-  RippleDb, plan_module_order, ripple_get_deps, ripple_get_fingerprint, ripple_get_source, ripple_record_eval
+  RippleDb, plan_module_order, ripple_get_deps, ripple_get_fingerprint, ripple_get_source, ripple_record_eval, ripple_set_source
 }
 
 import @vibe/compiler/syntax {
@@ -1229,6 +1229,27 @@ fn ensure_env_cache_for_paths(rdb: RippleDb, env_cache: Array[(String, TypeEnv)]
     i = i + 1
   }
   cache
+}
+
+fn is_vpkg_types_stub_path(path: String) -> Bool {
+  String::index_of(path, "vibe_vpkg_types/") >= 0
+}
+
+/// A materialized #1840 types stub can appear in a module's resolved deps
+/// without ever being seeded (manifest collect lists the contract, not the
+/// generated `_build/vibe_vpkg_types/` file). Load it from disk so the
+/// walk can check it instead of projecting a missing env row (#1921).
+fn load_planned_module_source(rdb: RippleDb, path: String) -> (RippleDb, Option[String]) with Exception + Fs {
+  match ripple_get_source(rdb, path) {
+    Some(source) => (rdb, Some(source)),
+    None =>
+    if is_vpkg_types_stub_path(path) && Fs::exists(path) {
+      let source = ingest_source_text_fs(path, Fs::read_file(path))
+      (ripple_set_source(rdb, path, source), Some(source))
+    } else {
+      (rdb, None)
+    }
+  }
 }
 
 /// Project the coordinator's accumulated environment cache onto exactly the
@@ -4317,11 +4338,12 @@ fn dep_source_cache_is_current(dep_source_cache: Array[(String, String)], path: 
 /// RippleDb), so siblings could not be dispatched independently no matter
 /// what the host could do.
 fn step_module_fs(plan_leaf_fps: Array[(String, String)], plan_edges: Array[(String, Array[String])], fps: Array[(String, String)], rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
-  match ripple_get_source(rdb, path) {
-    None => (String::concat("missing:", path), rdb, env_cache, dep_source_cache, parse_count),
+  let (rdb_loaded, loaded_source) = load_planned_module_source(rdb, path)
+  match loaded_source {
+    None => (String::concat("missing:", path), rdb_loaded, env_cache, dep_source_cache, parse_count),
     Some(source) => {
       let reusable = if dep_source_cache_is_current(dep_source_cache, path, source) {
-        match ripple_get_fingerprint(rdb, path) {
+        match ripple_get_fingerprint(rdb_loaded, path) {
           Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
             Some(_) => Some(fingerprint),
             None => None
@@ -4350,23 +4372,25 @@ fn step_module_fs(plan_leaf_fps: Array[(String, String)], plan_edges: Array[(Str
             ()
           }
           incremental_typecheck_telemetry_add(7, 1)
-          (cached_fingerprint, rdb, env_cache, dep_source_cache, parse_count)
+          (cached_fingerprint, rdb_loaded, env_cache, dep_source_cache, parse_count)
         }
         None =>
         match lookup_string_pair(plan_leaf_fps, path) {
           Some(leaf_fingerprint) =>
-          commit_leaf_fingerprint_fs(rdb, env_cache, dep_source_cache, parse_count, path, source, leaf_fingerprint),
+          commit_leaf_fingerprint_fs(rdb_loaded, env_cache, dep_source_cache, parse_count, path, source, leaf_fingerprint),
           None =>
           match plan_deps_of(plan_edges, path) {
             Some(planned_deps) =>
-            commit_with_deps_fs(fps, rdb, env_cache, upsert_string_pair(dep_source_cache, path, source), parse_count, path, source, planned_deps),
-            // Unreachable: every path in the schedule was either given an
-            // edge entry by the plan or interned as some planned module's
-            // dependency, and the three short-circuits above are the plan's
-            // own. A module that reaches here has no dependency fingerprints
-            // to fold, so there is nothing to fall back TO now that the walk
-            // does not recurse -- say so instead of inventing one.
-            None => throw(String::concat("type_db: module missing from the import plan: ", path))
+            commit_with_deps_fs(fps, rdb_loaded, env_cache, upsert_string_pair(dep_source_cache, path, source), parse_count, path, source, planned_deps),
+            // Types stubs interned only as someone else's dep have no plan
+            // edge: plan_import_graph_fs skipped them because they were not
+            // in the ripple db. They are leaves (type-family defs only).
+            None =>
+            if is_vpkg_types_stub_path(path) {
+              commit_with_deps_fs(fps, rdb_loaded, env_cache, upsert_string_pair(dep_source_cache, path, source), parse_count, path, source, empty_stack())
+            } else {
+              throw(String::concat("type_db: module missing from the import plan: ", path))
+            }
           }
         }
       }

--- a/lib/@vibe/compiler/tests/cache_probe_loader_manifest_groups_bench_test.vibe
+++ b/lib/@vibe/compiler/tests/cache_probe_loader_manifest_groups_bench_test.vibe
@@ -25,10 +25,13 @@ test "bench: loader manifest groups encoded" {
   assert(eq(indexed_encoded, prebuilt_indexed_encoded))
   // #769: `encoded` (collect_source_groups_fs) additionally applies
   // move_entry_last_grouped -- the entry file is split out of its manifest
-  // group into its own trailing group, so it carries the SAME source count
-  // but ONE MORE group than the raw builders. The old `encoded ==
-  // indexed_encoded` pin predates that regrouping.
-  assert(eq(source_count, indexed_encoded % 1000))
+  // group into its own trailing group, so it carries ONE MORE group than
+  // the raw builders. The old `encoded == indexed_encoded` pin predates
+  // that regrouping.
+  // #1921: collect_source_groups_fs also re-injects materialized vpkg
+  // types stubs into the contract's existing group. Raw builders do not,
+  // so source_count can be larger; group_count stays +1.
+  assert(source_count >= indexed_encoded % 1000)
   assert(eq(group_count, indexed_encoded / 1000 + 1))
   assert(group_count > 0)
   assert(source_count > 30)

--- a/lib/@vibe/compiler/tests/type_db_vpkg_types_stub_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_vpkg_types_stub_test.vibe
@@ -1,0 +1,227 @@
+//# Imports
+
+import ../type_db.vibe {
+  db_check_env, db_new, db_set_source, db_typecheck_fs
+}
+
+import @vibe/compiler/cache {
+  compact_string_fingerprint,
+  persistent_dep_list_cache_path,
+  persistent_leaf_fingerprint_cache_path,
+  persistent_module_header_cache_path,
+  persistent_type_env_cache_path
+}
+
+import @vibe/compiler/core {
+  env_lookup
+}
+
+import @vibe/compiler/loader {
+  collect_source_groups_fs, ingest_source_text_fs
+}
+
+import @vibe/core {
+  array_empty
+}
+
+//# Functions
+
+fn string_to_bytes(s: String) -> Bytes {
+  let out = Bytes::new()
+  let len = String::length(s)
+  let mut i = 0
+  while i < len {
+    Bytes::push(out, String::char_code_at(s, i))
+    i = i + 1
+  }
+  out
+}
+
+fn remove_file_if_exists(path: String) -> Unit with Fs {
+  if Fs::exists(path) {
+    Fs::remove(path)
+  } else {
+    ()
+  }
+}
+
+fn build_test_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
+  let mut i = 0
+  while i < Array::length(dep_fps) {
+    let (dep_path, dep_fp) = Array::get(dep_fps, i)
+    acc = compact_string_fingerprint(String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp)))))
+    i = i + 1
+  }
+  acc
+}
+
+fn remove_typecheck_fs_cache(path: String, source: String, fingerprint: String) -> Unit with Fs {
+  let source_fp = compact_string_fingerprint(source)
+  remove_file_if_exists(persistent_dep_list_cache_path(path, source_fp))
+  remove_file_if_exists(persistent_module_header_cache_path(path, source_fp))
+  remove_file_if_exists(persistent_leaf_fingerprint_cache_path(path, source_fp))
+  remove_file_if_exists(persistent_type_env_cache_path(fingerprint))
+}
+
+fn vpkg_types_stub_path_from_text(text: String) -> String {
+  let marker = "_build/vibe_vpkg_types/"
+  let idx = String::index_of(text, marker)
+  if idx < 0 {
+    ""
+  } else {
+    let rest = text[idx: String::length(text)]
+    let end = String::index_of(rest, ".vibe")
+    if end < 0 {
+      ""
+    } else {
+      rest[0: end + 5]
+    }
+  }
+}
+
+fn grouped_source_paths_joined(groups: Array[(String, Array[(String, String)])]) -> String {
+  let out = array_empty()
+  let mut gi = 0
+  while gi < Array::length(groups) {
+    let (_, sources) = Array::get(groups, gi)
+    let mut si = 0
+    while si < Array::length(sources) {
+      let (path, _) = Array::get(sources, si)
+      Array::push(out, path)
+      si = si + 1
+    }
+    gi = gi + 1
+  }
+  String::join(out, "\n")
+}
+
+fn write_probe_package(dir: String, extra_export: Bool) -> (String, String, String, String, String) with Fs {
+  let pkg_dir = String::concat(dir, "/pkg")
+  let vpkg_path = String::concat(pkg_dir, "/index.vpkg")
+  let impl_path = String::concat(pkg_dir, "/impl.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  let extra_decl = if extra_export {
+    "\nfn probe_one_more_fn() -> Int\n"
+  } else {
+    ""
+  }
+  let extra_impl = if extra_export {
+    "\nexport fn probe_one_more_fn() -> Int {\n  2\n}\n"
+  } else {
+    ""
+  }
+  let vpkg_src = String::concat("enum Hue {\n  Crimson;\n  Teal(Int)\n}\n\nfn paint() -> Int\n", extra_decl)
+  let impl_src = String::concat("export fn paint() -> Int {\n  1\n}\n", extra_impl)
+  let main_src = "import ./pkg { type Hue, paint }\nexport let n = paint()\n"
+  Fs::mkdir_p(pkg_dir)
+  Fs::write_bytes(vpkg_path, string_to_bytes(vpkg_src))
+  Fs::write_bytes(impl_path, string_to_bytes(impl_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  (vpkg_path, impl_path, main_path, vpkg_src, impl_src)
+}
+
+fn seed_package_without_types_stub(vpkg_path: String, impl_path: String, main_path: String) -> (String, String) with Exception + Fs {
+  let vpkg_ingested = ingest_source_text_fs(vpkg_path, Fs::read_file(vpkg_path))
+  let impl_ingested = ingest_source_text_fs(impl_path, Fs::read_file(impl_path))
+  let main_ingested = ingest_source_text_fs(main_path, Fs::read_file(main_path))
+  let stub_path = vpkg_types_stub_path_from_text(vpkg_ingested)
+  assert(stub_path != "")
+  assert(Fs::exists(stub_path))
+  remove_typecheck_fs_cache(vpkg_path, vpkg_ingested, build_test_fingerprint(vpkg_ingested, array_empty()))
+  remove_typecheck_fs_cache(impl_path, impl_ingested, build_test_fingerprint(impl_ingested, array_empty()))
+  remove_typecheck_fs_cache(main_path, main_ingested, build_test_fingerprint(main_ingested, array_empty()))
+  remove_typecheck_fs_cache(stub_path, Fs::read_file(stub_path), build_test_fingerprint(Fs::read_file(stub_path), array_empty()))
+  (vpkg_ingested, stub_path)
+}
+
+fn typecheck_seeded_without_stub(vpkg_path: String, vpkg_ingested: String, impl_path: String, main_path: String) -> String with Fs {
+  handle {
+    let impl_ingested = ingest_source_text_fs(impl_path, Fs::read_file(impl_path))
+    let main_ingested = ingest_source_text_fs(main_path, Fs::read_file(main_path))
+    let db = db_set_source(db_set_source(db_set_source(db_new(), vpkg_path, vpkg_ingested), impl_path, impl_ingested), main_path, main_ingested)
+    let checked = db_typecheck_fs(db, main_path)
+    match db_check_env(checked, main_path) {
+      Some(env) =>
+      match env_lookup(env, "n") {
+        Some(_) => "",
+        None => "missing binding: n"
+      },
+      None => "missing checked environment"
+    }
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+//# Tests
+
+/// #1921: the coordinator plans a materialized vpkg types stub as a resolved
+/// dep, but a source set that only contains the contract/impl/importer never
+/// inserts that stub into the env cache. Adding any export to a sibling
+/// package (common_base in the wild) is just the trigger that forces a cold
+/// recheck through this hole.
+test "db_typecheck_fs: types stub missing from the seeded set is still inserted (#1921)" {
+  let dir = "_build/vibe_1921_typedb_stub_seed"
+  let (vpkg_path, impl_path, main_path, _, _) = write_probe_package(dir, false)
+  let (vpkg_ingested, stub_path) = seed_package_without_types_stub(vpkg_path, impl_path, main_path)
+  let err = typecheck_seeded_without_stub(vpkg_path, vpkg_ingested, impl_path, main_path)
+  assert(!String::contains(err, "type_db: missing resolved dependency environment"))
+  assert(err == "")
+  assert(String::starts_with(stub_path, "_build/vibe_vpkg_types/"))
+}
+
+test "db_typecheck_fs: adding an extra vpkg export still inserts the types stub (#1921)" {
+  let dir = "_build/vibe_1921_typedb_stub_export"
+  let (vpkg_path, impl_path, main_path, _, _) = write_probe_package(dir, false)
+  let (vpkg_ingested, _) = seed_package_without_types_stub(vpkg_path, impl_path, main_path)
+  assert(typecheck_seeded_without_stub(vpkg_path, vpkg_ingested, impl_path, main_path) == "")
+  let (vpkg_path2, impl_path2, main_path2, _, _) = write_probe_package(dir, true)
+  let (vpkg_ingested2, stub_path2) = seed_package_without_types_stub(vpkg_path2, impl_path2, main_path2)
+  let err = typecheck_seeded_without_stub(vpkg_path2, vpkg_ingested2, impl_path2, main_path2)
+  assert(!String::contains(err, "type_db: missing resolved dependency environment"))
+  assert(err == "")
+  assert(Fs::exists(stub_path2))
+}
+
+/// compiler_sources_manifest.tsv is a fixed source set: it lists the
+/// contract and its impls, never the generated `_build/vibe_vpkg_types/`
+/// stub. That is the vibe-check hole for any compiler file whose closure
+/// reaches `@vibe/compiler/core`.
+test "collect_source_groups_fs: manifest collection injects the types stub (#1921)" {
+  let dir = "_build/vibe_1921_typedb_stub_manifest"
+  let (vpkg_path, impl_path, main_path, _, _) = write_probe_package(dir, true)
+  let manifest_path = String::concat(dir, "/compiler_sources_manifest.tsv")
+  Fs::write_bytes(manifest_path, string_to_bytes("# group\tpath\npkg\tpkg/index.vpkg\npkg\tpkg/impl.vibe\nentry\tmain.vibe\n"))
+  let _ = ingest_source_text_fs(vpkg_path, Fs::read_file(vpkg_path))
+  let groups = collect_source_groups_fs(main_path)
+  let paths = grouped_source_paths_joined(groups)
+  assert(String::contains(paths, vpkg_path))
+  assert(String::contains(paths, impl_path))
+  assert(String::contains(paths, main_path))
+  assert(String::contains(paths, "_build/vibe_vpkg_types/"))
+  handle {
+    let mut db = db_new()
+    let mut gi = 0
+    while gi < Array::length(groups) {
+      let (_, sources) = Array::get(groups, gi)
+      let mut si = 0
+      while si < Array::length(sources) {
+        let (path, source) = Array::get(sources, si)
+        db = db_set_source(db, path, source)
+        si = si + 1
+      }
+      gi = gi + 1
+    }
+    let checked = db_typecheck_fs(db, main_path)
+    match db_check_env(checked, main_path) {
+      Some(_) => (),
+      None => assert(false)
+    }
+  } with Exception {
+    Throw(msg) => {
+      assert(!String::contains(msg, "type_db: missing resolved dependency environment"))
+      assert(false)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1921.

`compiler_sources_manifest.tsv` is a fixed source set: it lists the contract and impls, never the generated `_build/vibe_vpkg_types/` stub. After ingest, header deps name that stub, but the typecheck walk never seeded it. `ensure_env_cache_for_path` then silently yielded no row and `project_exact_dependency_envs` threw.

Adding any export to `@vibe/compiler/codegen/common_base` is only the trigger — it invalidates persistent type-env rows and forces a cold recheck through the hole. Seed / unmodified stage2 stayed clean because those rows were warm.

## Fix

- Re-inject registered types stubs into `collect_source_groups_fs` (same idea as `collect_merged_stmts`), attached to the contract's existing manifest group so entry-last order stays intact.
- Note the stub on the prefix-cache hit path (the facade-cache hit already did this).
- Walk backstop: if a planned `vibe_vpkg_types/` dep has no ripple source, ingest it from disk and check it as a leaf.

## Test

In-process, no generation:

- seed the contract/impl/importer **without** the stub → typecheck succeeds
- add an extra vpkg export (the common_base shape) → still succeeds
- local manifest that omits the stub → collect includes `_build/vibe_vpkg_types/` and typecheck succeeds

`bash scripts/vibe_test.sh lib/@vibe/compiler/tests/type_db_vpkg_types_stub_test.vibe` (plus neighboring loader/type_db files). Production `vibe check` on `instructions.vibe` still wants a stage2 confirmation; this slice isolates the missing insertion without one.