### PR TITLE
fix(lint): do not report ok when review AST tier is skipped

### DIFF
--- a/scripts/lint_review_regressions.sh
+++ b/scripts/lint_review_regressions.sh
@@ -231,10 +231,12 @@ if [ -n "$violations" ] || [ "$ast_tool_error" -eq 1 ]; then
   exit 1
 fi
 
-# Say which tiers ran. `ok` alone could not distinguish a clean scan from a
-# scan that never happened.
+# Say which tiers ran. `ok` must mean the AST tier actually ran. A skipped
+# AST tier is still exit 0 (remote sessions must be able to commit) but the
+# summary must not claim `ok` -- a caller grepping the last line has to be
+# able to tell this from a clean scan (#1988).
 if [ "$ast_skipped" -eq 1 ]; then
-  echo "review-regressions lint: ok (AST tier SKIPPED -- text tier only)"
+  echo "review-regressions lint: WARNING -- AST tier skipped (text tier only; this is not a clean scan)"
 else
   echo "review-regressions lint: ok"
 fi

--- a/scripts/lint_review_regressions_test.sh
+++ b/scripts/lint_review_regressions_test.sh
@@ -347,14 +347,20 @@ fi
 
 # 1. The skip has to say so in the SUMMARY, not only on stderr. A caller that
 #    reads the last line (a human scanning hook output, a script) otherwise
-#    cannot tell the two apart.
+#    cannot tell the two apart. #1988: that line must not start with or equal
+#    `ok` -- empty/`ok` output means the AST tier actually ran.
 if ! VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" \
   "$CHECK_SCRIPT" >"$TMP_ROOT/skip-summary.out" 2>&1; then
   echo "review-regressions lint self-test: an unrunnable grep must still exit 0 by default" >&2
   exit 1
 fi
-if ! rg -q 'ok \(AST tier SKIPPED' "$TMP_ROOT/skip-summary.out"; then
-  echo "review-regressions lint self-test: a skipped AST tier reported a bare 'ok'" >&2
+if ! rg -q 'WARNING -- AST tier skipped \(text tier only; this is not a clean scan\)' "$TMP_ROOT/skip-summary.out"; then
+  echo "review-regressions lint self-test: a skipped AST tier did not print the WARNING summary" >&2
+  cat "$TMP_ROOT/skip-summary.out" >&2
+  exit 1
+fi
+if rg -q '^review-regressions lint: ok' "$TMP_ROOT/skip-summary.out"; then
+  echo "review-regressions lint self-test: a skipped AST tier still claimed ok" >&2
   cat "$TMP_ROOT/skip-summary.out" >&2
   exit 1
 fi


### PR DESCRIPTION
Refs #1988.

## What changed

Option 2 only: make the skip loud. Do not claim `ok` when the review-regressions AST tier did not run.

When `vibe grep` is unusable (typical remote session: `runtime/vibe` exists, no runner), the lint still **exits 0** so remote sessions can commit. CI already sets `VIBE_REVIEW_LINT_REQUIRE_AST=1` and still fails as today.

The summary line no longer starts with or equals `ok`:

```
review-regressions lint: WARNING -- AST tier skipped (text tier only; this is not a clean scan)
```

Empty / `ok` output now means the AST tier actually ran. Existing stderr skip lines are unchanged.

## Tests

TDD on `scripts/lint_review_regressions_test.sh`:

- Red: assert the WARNING wording and reject `^review-regressions lint: ok` against the old script (failed as expected).
- Green: `bash scripts/lint_review_regressions_test.sh` passes.

`scripts/precommit_test.sh` has no `AST tier SKIPPED` assertions.

## Leftover

Option 1 is still open: a SessionStart hook that provides a working `vibe grep` binary (`VIBE_REVIEW_LINT_GREP_BIN` / stage2-backed invoker) so the AST tier actually runs in remote sessions instead of only warning.