### PR TITLE
fix(grep): mark synthetic matches instead of 0:0 (#1941)

### DIFF
--- a/lib/@vibe/compiler/runtime/grep.vibe
+++ b/lib/@vibe/compiler/runtime/grep.vibe
@@ -1997,9 +1997,16 @@ fn grep_int(n: Int) -> String {
 }
 
 /// `path:line:col: <matched text>` followed by tab-separated `$var=<text>`
-/// captures — one match per line, fixed field order, greppable.
+/// captures — one match per line, fixed field order, greppable. A fully
+/// synthetic subtree (offset < 0) prints `<synthetic>` instead of a
+/// plausible `0:0` (#1941).
 fn grep_render_line(hit: GrepHit, line: Int, col: Int) -> String {
-  let head = String::concat(hit.path, String::concat(":", String::concat(grep_int(line), String::concat(":", String::concat(grep_int(col), String::concat(": ", hit.text))))))
+  let loc = if hit.offset >= 0 {
+    String::concat(grep_int(line), String::concat(":", grep_int(col)))
+  } else {
+    "<synthetic>"
+  }
+  let head = String::concat(hit.path, String::concat(":", String::concat(loc, String::concat(": ", hit.text))))
   let mut out = head
   let mut i = 0
   while i < Array::length(hit.captures) {

--- a/lib/@vibe/compiler/runtime/grep_test.vibe
+++ b/lib/@vibe/compiler/runtime/grep_test.vibe
@@ -128,7 +128,7 @@ test "grep: `id` only takes identifiers, `const` only literals" {
 
 test "grep: `id` captures a compound-assignment target, not its operator" {
   let src = "let mut counter = 0\ncounter += 2\n"
-  inspect(scan(src, "$(target:id) += 2"), "a.vibe:0:0: { counter += 2; () }\t$target=counter\n")
+  inspect(scan(src, "$(target:id) += 2"), "a.vibe:<synthetic>: { counter += 2; () }\t$target=counter\n")
 }
 
 test "grep: a repeated metavariable must agree, `_` never has to" {


### PR DESCRIPTION
Refs #1941.

## Summary

Next short knife of #1941 after #2029. Grep text only — no AST field, no assign-op desugaring, no LSP JSON.

A compound assignment desugars to `{ counter += 2; () }`. `EAssignOp` has no offset field, and the walked children are `EInt` / `EUnit`, so `grep_expr_span` is `(-1, -1)`. The text formatter turned that into `a.vibe:0:0:`, which looks like a real position.

When `hit.offset < 0`, print `path:<synthetic>:` instead.

JSON already reports `start: -1` for these hits; this PR does not change it.

## Tests

TDD on `lib/@vibe/compiler/runtime/grep_test.vibe`:

- Red: expected `a.vibe:<synthetic>:`; actual was `a.vibe:0:0:`.
- Green:

```
bash scripts/vibe_test.sh lib/@vibe/compiler/runtime/grep_test.vibe
```

1/1 files, 26 tests passed.

## Leftover

- type-at on binders/callees
- return-type mismatches still take the no-position `0..1` fallback