### PR TITLE
docs: align ArrayBuilder terminal and handler reject example

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -149,7 +149,7 @@ contract — this is a naming *rule*, not a per-type coincidence:
 |---|---|---|
 | bare name | persistent/functional — every "mutating" op returns a NEW value, the receiver is untouched | `Map[K, V]`, `StringSet` (conceptually `Set[String]`) |
 | `Mut-` prefix | a deliberate MUTABLE variant with the same conceptual API — ops return `Unit` and mutate in place | `MutMap`, `MutSet`, `MutSortedMap`, `MutSortedSet` |
-| `XBuilder` suffix | a mutable, growable builder; not meant to be held onto — call **`::build`** to get the persistent value | `ArrayBuilder`, `MapBuilder`, `StringBuilder` |
+| `XBuilder` suffix | a mutable, growable builder; not meant to be held onto — finish with the **implemented** terminal: **`::freeze`** for `ArrayBuilder`/`MapBuilder`, **`::build`** for `StringBuilder` | `ArrayBuilder`, `MapBuilder`, `StringBuilder` |
 | `Frozen-` prefix | immutable AND `Send`-eligible (structurally, when its element type is `Send`) — a narrower, stronger claim than plain persistence, tied to the structured-concurrency model (ADR-0068, #906) | `FrozenArray[T]` |
 
 **2軸を分離する** (ADR-0100 (3), #1262)。ADR-0082 は `Hash-` / `Sorted-` の
@@ -197,6 +197,9 @@ a bare-named persistent type for ordinary functional-update code.
 `freeze` は「Frozen-(persistent + `Send`)を産む動詞」に予約されていて、
 Builder の終端はそれではない —— 旧綴りの最悪例が
 `ArrayBuilder::freeze -> Array` で、**freeze の結果が可変**だった。
+**現行 surface の実装終端**はまだ `ArrayBuilder::freeze` / `MapBuilder::freeze`
+だけ。`StringBuilder` だけが `build` を公開する (`freeze` と同じ registry
+row の alias)。`ArrayBuilder::build` / `MapBuilder::build` は未実装。
 
 ```vibe
 fn greeting() -> String {
@@ -766,7 +769,7 @@ let mv = m["key"]
 let arr2 = {
   let b = ArrayBuilder::new()
   ArrayBuilder::push(b, 1)
-  ArrayBuilder::freeze(b)     // -> Array[Int]
+  ArrayBuilder::freeze(b)     // implemented terminal; `build` is the planned/StringBuilder verb
 }
 
 // General-purpose containers live in @vibe/core — MutMap/MutSet (open
@@ -1644,7 +1647,7 @@ let arr = {
   let b = ArrayBuilder::new()
   ArrayBuilder::push(b, 1)
   ArrayBuilder::push(b, 2)
-  ArrayBuilder::freeze(b)
+  ArrayBuilder::freeze(b)     // implemented terminal; `build` is the planned/StringBuilder verb
 }
 
 // for-in as map

--- a/docs/tutorial/05_effects-ja.vibe.md
+++ b/docs/tutorial/05_effects-ja.vibe.md
@@ -108,6 +108,44 @@ v = 42
 失敗は `Exception` を使い、局所的な状態はまず `let mut` を検討する。判断基準は
 [Effects vs let mut](../guide/when-to-use-effects.md) を参照。
 
+## `handle` が見えるもの
+
+上の `handle { answer_of(...) }` が通るのは、`answer_of` が名前付き top-level
+`fn` だから。`handle` が覆うすべての `perform` は静的に見えていなければなら
+ない — 直接の `perform`、名前付き top-level `fn` の呼び出し、effect-row 注釈
+付きのクロージャリテラル。
+
+ローカル束縛を経由する呼び出しは perform を隠す。型検査は通ってもコンパイル
+は拒否される — 直すのは型ではなく呼び出し側。
+
+```vibe skip
+// skip: ineligible handle — a local closure hides the perform from the handler
+effect Ask {
+  Once() -> Int
+}
+
+fn ask_once() -> Int with Ask {
+  perform Ask::Once()
+}
+
+fn main() -> Int {
+  let bump = (x: Int) -> Int { x + 1 }
+  handle { bump(ask_once()) } with Ask {
+    Once() => resume(41)
+  }
+}
+// error (measured with `vibe check`): handle of effect 'Ask' cannot be compiled
+// here. Every perform this handle covers has to be statically visible to it, so
+// the handled body may only: perform directly, call a named top-level `fn`, or
+// call a closure literal that carries an effect row annotation. A call through
+// a local binding or a closure parameter hides the perform and is what this
+// rejects (here: the call to 'bump') -- move the `handle` into the function
+// that performs, or replace the indirect call with a direct one.
+```
+
+直し方は最後の文どおり: `handle` を perform する関数の中へ移すか、`bump(...)`
+を直接呼び出し (または top-level `fn`) に置き換える。
+
 ## エフェクト多相
 
 エフェクト行は変数にできる — 「渡された関数のエフェクトをそのまま持つ」

--- a/docs/tutorial/05_effects.vibe.md
+++ b/docs/tutorial/05_effects.vibe.md
@@ -115,6 +115,44 @@ one-shot/tail-resumptive. For ordinary failure use `Exception`, and for local
 state consider `let mut` first. The criteria are in
 [Effects vs let mut](../guide/when-to-use-effects.md).
 
+## What a `handle` can see
+
+`handle { answer_of(...) }` above compiles because `answer_of` is a named
+top-level `fn`. Every `perform` a `handle` covers has to be statically visible
+to it: a direct `perform`, a call to a named top-level `fn`, or a closure
+literal that carries an effect-row annotation.
+
+A call through a local binding hides the perform. That shape type-checks and is
+still rejected — rewrite the call, not the types.
+
+```vibe skip
+// skip: ineligible handle — a local closure hides the perform from the handler
+effect Ask {
+  Once() -> Int
+}
+
+fn ask_once() -> Int with Ask {
+  perform Ask::Once()
+}
+
+fn main() -> Int {
+  let bump = (x: Int) -> Int { x + 1 }
+  handle { bump(ask_once()) } with Ask {
+    Once() => resume(41)
+  }
+}
+// error (measured with `vibe check`): handle of effect 'Ask' cannot be compiled
+// here. Every perform this handle covers has to be statically visible to it, so
+// the handled body may only: perform directly, call a named top-level `fn`, or
+// call a closure literal that carries an effect row annotation. A call through
+// a local binding or a closure parameter hides the perform and is what this
+// rejects (here: the call to 'bump') -- move the `handle` into the function
+// that performs, or replace the indirect call with a direct one.
+```
+
+The last sentence is the rewrite: move the `handle` into the function that
+performs, or replace `bump(...)` with a direct call (or a top-level `fn`).
+
 ## Effect polymorphism
 
 An effect row can be a variable, which is how you write a higher-order function


### PR DESCRIPTION
Refs #1950.

## Problem

The cheatsheet collection table told readers to call `::build` for every `XBuilder`. That is only true for `StringBuilder`. `ArrayBuilder` and `MapBuilder` still terminate with `::freeze` on the current surface. The effects tutorial only showed happy-path `handle`.

## Changes

- Cheatsheet naming table: implemented terminals (`::freeze` for ArrayBuilder/MapBuilder, `::build` for StringBuilder).
- Cheatsheet ADR-0101 paragraph: current surface vs planned `build` verb. States that `ArrayBuilder::build` / `MapBuilder::build` are not implemented.
- Cheatsheet examples keep `ArrayBuilder::freeze` and note that this is the implemented terminal.
- Tutorial `05_effects` (+ ja): one ` ```vibe skip ` negative example for an ineligible local closure under `handle`, with the measured `vibe check` diagnostic (rewrite the call, not the types).
- `03_data` runnable examples already use `ArrayBuilder::freeze`; left unchanged.

## Measured

Smallest ineligible snippet (local `bump` wrapping `ask_once()` under `handle { ... } with Ask`) compiled with the checkout seed (`bootstrap/seed/compiler.wasm`, `VIBE_CHECK_ONLY=1`):

```
line 11:12-16: handle of effect 'Ask' cannot be compiled here. Every perform this handle covers has to be statically visible to it, so the handled body may only: perform directly, call a named top-level `fn`, or call a closure literal that carries an effect row annotation. A call through a local binding or a closure parameter hides the perform and is what this rejects (here: the call to 'bump') -- move the `handle` into the function that performs, or replace the indirect call with a direct one.
```

Registry check: `ArrayBuilder::freeze` / `MapBuilder::freeze` exist; `StringBuilder::build` aliases `StringBuilder::freeze`; no `ArrayBuilder::build` / `MapBuilder::build`.

## Verify

- `rg`: no tutorial block says `ArrayBuilder::build`
- `bash scripts/check_tutorial_translation_parity.sh` ok
- `bash scripts/vibe_md.sh check docs/tutorial/05_effects.vibe.md docs/tutorial/05_effects-ja.vibe.md` — 6 pass, 4 skip, 0 fail (seed)

## Leftover

- ADR-0101 `build` for ArrayBuilder/MapBuilder still needs a compiler change + bootstrap bump. Out of scope.
- `vibe check --single-file` still does not run handler eligibility (already documented in the cheatsheet 落とし穴).
- Did not run `vibe-md-tutorial-gated` (no checkout stage2 in this worktree). Existing ` ```vibe run ` blocks were not rewritten.