### PR TITLE
fix(symbols): include fn, test, and bench declarations (#1944)

### DIFF
--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -28,7 +28,7 @@ the `vibe lsp` command. It provides:
 | --- | --- |
 | **Diagnostics** | Parser error-recovery surfaces *all* top-level syntax errors at once (not just the first), plus the located type error for a clean parse. |
 | **Hover** | Typed hover — shows the inferred type of the identifier under the cursor, including locals and parameters (per-node type table). |
-| **Document symbols** | AST-accurate outline (`vibe symbols`) — functions, values, structs, enums, traits, type aliases, effects, and module-nested declarations, with correct `SymbolKind`s. Handles multi-line declarations; ignores names in strings/comments. |
+| **Document symbols** | AST-accurate outline (`vibe symbols`) — functions, values, structs, enums, traits, type aliases, effects, tests, benches, impls, and module-nested declarations, with correct `SymbolKind`s. Handles multi-line declarations; ignores names in strings/comments. Tests/benches are Function (12); `impl Trait for T` is one Method (6) named after `T`. |
 | **Go to definition** | AST-accurate declaration span (`vibe symbols`), with a line-regex fallback for older compilers. |
 | **References / Rename** | AST-accurate via scope-aware binding occurrences (no string/comment false matches; distinguishes shadowed bindings). |
 | **Completion** | Identifier and member completion. |
@@ -64,7 +64,10 @@ vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array 
   `START END` are char offsets of the declaration name. Because it walks the
   parsed AST (not a line regex) it handles multi-line declarations and
   module-nested symbols and never reports a name that only appears in a string
-  or comment.
+  or comment. Tests and benches are Function (12). An empty test/bench name
+  is outlined as the keyword `test`/`bench`. An `impl Trait for T` is one
+  Method (6) named after `T` — the impl statement does not carry method
+  children.
 - **`--single-file` analyzes ONE file and does not follow its imports**, so on a
   file with imports it reports names it cannot see as undefined. A file that is
   perfectly valid under a plain `vibe check` can come back with

--- a/lib/@vibe/compiler/runtime/symbol_spans.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans.vibe
@@ -104,19 +104,37 @@ fn sym_let_kind(body: Expr) -> Int {
   }
 }
 
+/// Stable outline name for a test/bench: the quoted name, or the keyword when
+/// the parser handed back an empty string (unnamed `test { }` / `bench { }`
+/// are rejected; `test ""` is the stand-in). Omitting would leave a hole.
+fn sym_block_name(name: String, keyword: String) -> String {
+  if String::length(name) == 0 {
+    keyword
+  } else {
+    name
+  }
+}
+
 /// Emit the symbol for one statement within the window [floor, hi). SModule emits
 /// the module name (kind 2 = Module) then recurses into its body, threading the
 /// SAME advancing floor so nested declarations are located in source order.
+/// Tests/benches use Function (12) -- LSP has no Test kind. An `impl Trait for T`
+/// is one Method (6) named after T: SImpl carries no method children
+/// (`parse_program_spans` skips the body).
 fn sym_walk_stmt(out: Array[(String, Int, Int, Int)], source: String, stmt: Stmt, floor: Array[Int], hi: Int) -> Unit {
   match stmt {
     SLet(_, _, name, _, body) => sym_emit(out, source, name, sym_let_kind(body), floor, hi),
+    SFnDecl(_, name, _, _, _) => sym_emit(out, source, name, 12, floor, hi),
     SLetMut(name, _, _) => sym_emit(out, source, name, 13, floor, hi),
     SEnum(_, name, _, _, _) => sym_emit(out, source, name, 10, floor, hi),
     SSuberror(_, name, _) => sym_emit(out, source, name, 10, floor, hi),
     SStruct(_, name, _, _, _, _) => sym_emit(out, source, name, 23, floor, hi),
     STypeAlias(_, name, _, _) => sym_emit(out, source, name, 26, floor, hi),
     STrait(_, name, _, _, _, _) => sym_emit(out, source, name, 11, floor, hi),
+    SImpl(_, _, _, type_name) => sym_emit(out, source, type_name, 6, floor, hi),
     SEffectDef(_, name, _, _) => sym_emit(out, source, name, 24, floor, hi),
+    STest(name, _) => sym_emit(out, source, sym_block_name(name, "test"), 12, floor, hi),
+    SBench(name, _) => sym_emit(out, source, sym_block_name(name, "bench"), 12, floor, hi),
     SModule(_, name, body) => {
       sym_emit(out, source, name, 2, floor, hi)
       let mut j = 0

--- a/lib/@vibe/compiler/runtime/symbol_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans_test.vibe
@@ -13,11 +13,68 @@ import ./symbol_spans.vibe {
 
 //# Functions
 
+fn sym_has(syms: Array[(String, Int, Int, Int)], name: String, kind: Int) -> Bool {
+  let mut found = false
+  let mut i = 0
+  while i < Array::length(syms) {
+    let (n, k, _, _) = Array::get(syms, i)
+    if n == name && k == kind {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn sym_fmt(syms: Array[(String, Int, Int, Int)]) -> String {
+  let acc = StringBuilder::new()
+  let mut i = 0
+  while i < Array::length(syms) {
+    let (n, k, _, _) = Array::get(syms, i)
+    if i > 0 {
+      StringBuilder::push(acc, ", ")
+    } else {
+      ()
+    }
+    StringBuilder::push(acc, n)
+    StringBuilder::push(acc, " ")
+    StringBuilder::push(acc, __to_string(k))
+    i = i + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
 //# Misc
 
 test "symbol_spans: a clean file returns its declarations" {
   let syms = symbol_spans("export fn f(x: Int) -> Int { x + 1 }\n")
   assert(Array::length(syms) == 1)
+  assert(sym_has(syms, "f", 12))
+}
+
+test "symbol_spans: fn, named test, and named bench are outlined (#1944)" {
+  let src = "fn add(a: Int, b: Int) -> Int { a + b }\ntest \"adds\" { let _ = add(1, 2) }\nbench \"once\" { let _ = add(1, 1) }\n"
+  let syms = symbol_spans(src)
+  inspect(sym_fmt(syms), "add 12, adds 12, once 12")
+  assert(sym_has(syms, "add", 12))
+  assert(sym_has(syms, "adds", 12))
+  assert(sym_has(syms, "once", 12))
+}
+
+test "symbol_spans: empty test/bench names emit the keyword so outline is not empty (#1944)" {
+  // The parser rejects unnamed `test { }` / `bench { }` (needs a string
+  // literal). An empty string is the stable stand-in for that missing name.
+  let src = "test \"\" { let _ = 1 }\nbench \"\" { let _ = 1 }\n"
+  let syms = symbol_spans(src)
+  inspect(sym_fmt(syms), "test 12, bench 12")
+}
+
+test "symbol_spans: impl is one Method symbol named after the target type (#1944)" {
+  let src = "trait Show { }\nstruct Point { x: Int }\nimpl Show for Point { }\n"
+  let syms = symbol_spans(src)
+  inspect(sym_fmt(syms), "Show 11, Point 23, Point 6")
 }
 
 test "symbol_spans: a genuinely empty (comments-only) file returns an empty list, not an error" {

--- a/scripts/test_vibe_symbols.sh
+++ b/scripts/test_vibe_symbols.sh
@@ -95,6 +95,18 @@ else
   bad "symbols should report 'main' as function(12); got: $out_ef"
 fi
 
+# 7. #1944: test / bench / impl are outlined (Function 12 / Function 12 /
+#    Method 6 named after the impl target).
+tb="$WORK/testbench.vibe"
+printf 'fn add(a: Int, b: Int) -> Int { a + b }\ntest "adds" { let _ = add(1, 2) }\nbench "once" { let _ = add(1, 1) }\ntrait Show { }\nstruct Point { x: Int }\nimpl Show for Point { }\n' > "$tb"
+out_tb="$("$VIBE" symbols "$tb" 2>/dev/null || true)"
+if has_sym "$out_tb" add 12 && has_sym "$out_tb" adds 12 && has_sym "$out_tb" once 12 \
+   && has_sym "$out_tb" Show 11 && has_sym "$out_tb" Point 23 && has_sym "$out_tb" Point 6; then
+  ok "symbols lists fn/test/bench/impl with correct kinds"
+else
+  bad "symbols should find add/adds/once/Show/Point+impl; got: $out_tb"
+fi
+
 echo "----"
 echo "passed: $pass, failed: $fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Refs #1944.

## Summary

Leftover slice of #1944: `vibe symbols` omitted anything that was not a `let`/type declaration. `sym_walk_stmt` now matches `SFnDecl`, `STest`, `SBench`, and `SImpl`.

Kinds (existing LSP numbers, no new scheme):

- `fn` / `export fn` / named `test` / named `bench`: Function (12)
- empty `test ""` / `bench ""` name: still Function (12), outlined as the keyword `test` / `bench` so the outline is not empty
- `impl Trait for T`: one Method (6) named after `T` (`SImpl` has no method children; `parse_program_spans` skips the body)

Output stays one `(name, kind, start, end)` record per line.

`export fn f` still returns exactly one Function symbol (it is `SLet`+`EFn` after `parse_stmt`).

## Tests

TDD on `lib/@vibe/compiler/runtime/symbol_spans_test.vibe`:

- Red: `inspect` expected `add 12, adds 12, once 12`; actual was `add 12`.
- Green:

```
bash scripts/vibe_test.sh lib/@vibe/compiler/runtime/symbol_spans_test.vibe
```

1/1 files, 6 tests passed.

`scripts/test_vibe_symbols.sh` gained the same fn/test/bench/impl case. Not run here: it rebuilds a fresh compiler via `install/install.sh`.

## Leftover (still #1944)

- `vibe doc-at` still misses struct documentation
- `vibe allocs` still prints URL-encoded internal owners (`__test_<name>`)
- no machine-readable kind legend