### PR TITLE
test: migrate effect_sh fixture debt (#1973)

### DIFF
--- a/fixtures/effect_sh_test.vibe
+++ b/fixtures/effect_sh_test.vibe
@@ -1,0 +1,9 @@
+// #1973: was fixtures/runtime/effect_sh.vibe + __DATA__.last "()".
+// The interpreter last-value was unit; the unit-test lane's `sh` returns
+// String and does not capture stdout, so the value is "".
+// The old `effects: ["ShellExec(\"echo hi\")"]` field has no inspect
+// equivalent — inspect does not record a ShellExec log.
+
+test "sh echo hi returns empty string" {
+  inspect(sh("echo hi"), "")
+}

--- a/fixtures/runtime/effect_sh.vibe
+++ b/fixtures/runtime/effect_sh.vibe
@@ -1,6 +1,0 @@
-{
-  sh("echo hi")
-}
-
-__DATA__
-{"last": "()", "effects": ["ShellExec(\"echo hi\")"]}

--- a/scripts/runtime_fixture_debt.tsv
+++ b/scripts/runtime_fixture_debt.tsv
@@ -5,4 +5,3 @@
 # debt row in the same change.
 fixtures/err_import_collides_with_local_let.vibe	generator debt: hoisting the import ahead of the top-level let changes the name-collision contract into block shadowing
 fixtures/generic_explicit_type_arg.vibe	compile debt: explicit type argument Int is rejected in this spelling
-fixtures/runtime/effect_sh.vibe	runtime debt: generated expected-value assertion traps


### PR DESCRIPTION
Last #1973 effect/handler TSV row.

`fixtures/runtime/effect_sh.vibe` expected `__DATA__.last "()"` plus `effects: ["ShellExec(\"echo hi\")"]`. The generated unit-lane assertion trapped because that last-value is stale.

## Measured

Seed `vibe test` on a probe of `inspect(sh("echo hi"), "()")`:

- Host import / Process works. The call does not trap.
- The return is not unit. `sh` is `String` in the registry and does not capture stdout, so `__to_string(sh("echo hi"))` is `""`.

Migrated to `fixtures/effect_sh_test.vibe` with `inspect(sh("echo hi"), "")`. Did not invent a ShellExec inspector or a new `sh` runtime. Did not grant new capabilities.

Deleted the `__DATA__` fixture and its TSV row. `scripts/runtime_fixture_debt.tsv` now has only the two #1967 rows (`err_import_collides_with_local_let`, `generic_explicit_type_arg`). **No effect/handler debt rows remain.** After this merges, #1973 can close.

## Test plan

- [x] `bash scripts/vibe_test.sh fixtures/effect_sh_test.vibe` — 1/1
- [x] `bash scripts/check_fixture_execution.sh` — 444 test-block fixtures; 230 runtime expectations active, 2 reasoned debt

Refs #1973.