### PR TITLE
fix(allocs): use source test and bench names as owners (#1944)

### DIFF
--- a/lib/@vibe/compiler/runtime/alloc_spans.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans.vibe
@@ -230,9 +230,9 @@ fn alloc_hex_nibble(n: Int) -> String {
 }
 
 /// Encode an owner as one whitespace-free output field. Test and bench names
-/// are arbitrary string literals, so their lowered function names may contain
-/// spaces, newlines, tabs, or `%` itself. Percent-encoding those bytes keeps
-/// `FN KIND OFFSET` exactly three fields and remains reversible.
+/// are arbitrary string literals, so they may contain spaces, newlines, tabs,
+/// or `%` itself. Percent-encoding those bytes keeps `FN KIND OFFSET` exactly
+/// three fields and remains reversible.
 fn alloc_encode_owner(name: String) -> String {
   let out = StringBuilder::new()
   let mut i = 0
@@ -248,6 +248,16 @@ fn alloc_encode_owner(name: String) -> String {
     i = i + 1
   }
   StringBuilder::freeze(out)
+}
+
+/// Source owner for a test/bench: the quoted name, or the keyword when the
+/// parser handed back an empty string (same stand-in as symbols #2038).
+fn alloc_block_owner(name: String, keyword: String) -> String {
+  if String::length(name) == 0 {
+    alloc_encode_owner(keyword)
+  } else {
+    alloc_encode_owner(name)
+  }
 }
 
 /// The allocating-call name for `expr`, or "" when the call is not one.
@@ -560,9 +570,10 @@ export fn alloc_spans(source: String) -> Array[(String, String, Int)] with Excep
       // Tests and benches lower to real executable functions. In particular,
       // a bytes-per-op regression asks about the bench body itself, so
       // skipping SBench would turn an allocating benchmark into false-clean
-      // output. Keep the owner names identical to linked_compile's lowering.
-      STest(test_name, test_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__test_", test_name)), test_body, stmt_off, alloc_context(ctors, global_index, array_empty())),
-      SBench(bench_name, bench_body) => alloc_walk_expr(out, alloc_encode_owner(String::concat("__bench_", bench_name)), bench_body, stmt_off, alloc_context(ctors, global_index, array_empty())),
+      // output. Owner is the source name (empty → keyword, same as symbols
+      // #2038), still percent-encoded so FN stays one field (#1944).
+      STest(test_name, test_body) => alloc_walk_expr(out, alloc_block_owner(test_name, "test"), test_body, stmt_off, alloc_context(ctors, global_index, array_empty())),
+      SBench(bench_name, bench_body) => alloc_walk_expr(out, alloc_block_owner(bench_name, "bench"), bench_body, stmt_off, alloc_context(ctors, global_index, array_empty())),
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/alloc_spans_test.vibe
@@ -236,11 +236,22 @@ test "sites are attributed to the enclosing top-level function" {
 test "test and bench bodies use whitespace-free allocation owners" {
   // `allocs` is also the diagnostics surface for bytes-per-op regressions;
   // silently skipping SBench would make precisely that use case report clean.
+  // Owner is the source name, still percent-encoded so FN stays one field (#1944).
   let src = "test \"makes array\" {\n  let xs = [1, 2]\n  assert_eq(Array::length(xs), 2)\n}\nbench \"line\\nbreak 100%\" {\n  [3, 4]\n}\n"
   let names = fn_names_of(src)
   assert_eq(Array::length(names), 2)
-  assert_eq(Array::get(names, 0), "__test_makes%20array")
-  assert_eq(Array::get(names, 1), "__bench_line%0Abreak%20100%25")
+  assert_eq(Array::get(names, 0), "makes%20array")
+  assert_eq(Array::get(names, 1), "line%0Abreak%20100%25")
+}
+
+test "empty test and bench names use the keyword as owner (#1944)" {
+  // Same stand-in as symbols (#2038): unnamed `test { }` / `bench { }` are
+  // rejected, so `test ""` / `bench ""` are the empty-name fixture.
+  let src = "test \"\" {\n  [1]\n}\nbench \"\" {\n  [2]\n}\n"
+  let names = fn_names_of(src)
+  assert_eq(Array::length(names), 2)
+  assert_eq(Array::get(names, 0), "test")
+  assert_eq(Array::get(names, 1), "bench")
 }
 
 test "an unclassified callee is reported, not skipped" {


### PR DESCRIPTION
Refs #1944.

## Summary

Leftover slice of #1944: `vibe allocs` printed URL-encoded internal owners (`__test_<name>`, `__bench_<name>`) instead of source names.

Owner field is now the **source name**, still percent-encoded so `FN KIND OFFSET` stays three fields:

- test `"makes array"` → `makes%20array`
- bench `"line\nbreak 100%"` → `line%0Abreak%20100%25`
- empty `test ""` / `bench ""` → keyword `test` / `bench` (same stand-in as symbols #2038)

`alloc_encode_owner` is unchanged. Lowered wasm export names (`__test_*` / `__bench_*`) are unchanged.

## Tests

TDD on `lib/@vibe/compiler/runtime/alloc_spans_test.vibe`:

- Red: expected `makes%20array` / `line%0Abreak%20100%25`; actual was `__test_makes%20array` / `__bench_line%0Abreak%20100%25`.
- Green:

```
bash scripts/vibe_test.sh lib/@vibe/compiler/runtime/alloc_spans_test.vibe
```

1/1 files, 24 tests passed.

No `scripts/test_vibe_allocs.sh`. `scripts/test_vibe_allocs_launcher.sh` does not pin owner names and was not run (it uses a mock runner).

## Leftover (still #1944)

- `vibe doc-at` still misses struct documentation
- no machine-readable kind legend