### PR TITLE
fix(doc-at): resolve struct and type declaration docs (#1944)

### DIFF
--- a/lib/@vibe/compiler/runtime/binding_at.vibe
+++ b/lib/@vibe/compiler/runtime/binding_at.vibe
@@ -482,9 +482,10 @@ fn bind_record_module_binder(st: BindState, name: String) -> Unit {
   }
 }
 
-/// Walk a statement. Top-level value bindings (SLet/SLetMut) introduce a
-/// module-level name (key 0 => grouped file-wide); we record the binder's located
-/// NAME and walk the body. SModule recurses.
+/// Walk a statement. Top-level value bindings (SLet/SLetMut) and type/decl
+/// names (SStruct/SEnum/STypeAlias/SFnDecl/STrait/SEffectDef) introduce a
+/// module-level name (key 0 => grouped file-wide); we record the binder's
+/// located NAME and walk any expression bodies. SModule recurses.
 fn bind_walk_stmt(st: BindState, stmt: Stmt) -> Unit {
   match stmt {
     SLet(_, _, name, _, body) => {
@@ -495,6 +496,19 @@ fn bind_walk_stmt(st: BindState, stmt: Stmt) -> Unit {
       bind_record_module_binder(st, name)
       bind_walk_expr(st, body)
     },
+    SStruct(_, name, _, _, _, _) => bind_record_module_binder(st, name),
+    SEnum(_, name, _, _, _) => bind_record_module_binder(st, name),
+    STypeAlias(_, name, _, _) => bind_record_module_binder(st, name),
+    // Default parse_program_located lowers SFnDecl to SLet; keep the arm so
+    // a preserving parse still records the name and walks contracts.
+    SFnDecl(_, name, fn_value, reqs, enss) => {
+      bind_record_module_binder(st, name)
+      bind_walk_expr(st, fn_value)
+      bind_walk_exprs(st, reqs)
+      bind_walk_exprs(st, enss)
+    },
+    STrait(_, name, _, _, _, _) => bind_record_module_binder(st, name),
+    SEffectDef(_, name, _, _) => bind_record_module_binder(st, name),
     STest(_, body) => bind_walk_expr(st, body),
     SBench(_, body) => bind_walk_expr(st, body),
     SExpr(e) => bind_walk_expr(st, e),

--- a/lib/@vibe/compiler/runtime/editor_query_test.vibe
+++ b/lib/@vibe/compiler/runtime/editor_query_test.vibe
@@ -225,3 +225,59 @@ test "type-at: fn declaration name reports the function type" {
   inspect(type_at_source(src, 1, 4), "(Int, Int) -> Int")
   inspect(type_at_source(src, 1, 5), "(Int, Int) -> Int")
 }
+
+/// #1944 leftover: `doc_at_source` goes through `binding_occurrences`, and
+/// `bind_walk_stmt` only recorded `SLet` / `SLetMut`. Hovering a struct
+/// declaration name therefore produced zero occurrences and `""`.
+///   line 1 = "/// a 2-d point" (15 bytes + newline)
+///   line 2 = "struct Point { x: Int; y: Int }"
+///   `Point` starts at col 8 / offset 23.
+test "doc-at: hovering a struct declaration resolves its doc comment" {
+  let src = "/// a 2-d point\nstruct Point { x: Int; y: Int }\n"
+  inspect(doc_at_source(src, 2, 8), "a 2-d point")
+}
+
+test "binding-at: struct declaration name includes its declaration span" {
+  let src = "/// a 2-d point\nstruct Point { x: Int; y: Int }\n"
+  let occ = binding_occurrences(src, 2, 8)
+  assert(occ_contains(occ, 23, 28))
+}
+
+/// `enum` is `SEnum`, also dropped by `bind_walk_stmt`'s `_` arm.
+///   line 1 = "/// a color" (11 bytes + newline)
+///   line 2 = "enum Color { Red; Blue }"
+///   `Color` starts at col 6 / offset 17.
+test "doc-at: hovering an enum declaration resolves its doc comment" {
+  let src = "/// a color\nenum Color { Red; Blue }\n"
+  inspect(doc_at_source(src, 2, 6), "a color")
+}
+
+test "binding-at: enum declaration name includes its declaration span" {
+  let src = "/// a color\nenum Color { Red; Blue }\n"
+  let occ = binding_occurrences(src, 2, 6)
+  assert(occ_contains(occ, 17, 22))
+}
+
+/// `type` is `STypeAlias`.
+///   line 1 = "/// an id" (9 bytes + newline)
+///   line 2 = "type UserId = Int"
+///   `UserId` starts at col 6 / offset 15.
+test "doc-at: hovering a type alias declaration resolves its doc comment" {
+  let src = "/// an id\ntype UserId = Int\n"
+  inspect(doc_at_source(src, 2, 6), "an id")
+}
+
+test "binding-at: type alias declaration name includes its declaration span" {
+  let src = "/// an id\ntype UserId = Int\n"
+  let occ = binding_occurrences(src, 2, 6)
+  assert(occ_contains(occ, 15, 21))
+}
+
+/// `fn add(...)` is parsed as `SFnDecl` then lowered to `SLet` by
+/// `parse_program_located` (`lower_fn_decl_stmt`). Binding-at already
+/// recovers that `SLet`, so this should stay green without an `SFnDecl`
+/// arm. Pin it so a future parse-preserving change does not regress doc-at.
+test "doc-at: hovering a fn declaration resolves its doc comment" {
+  let src = "/// adds two numbers\nfn add(a: Int, b: Int) -> Int { a + b }\n"
+  inspect(doc_at_source(src, 2, 4), "adds two numbers")
+}


### PR DESCRIPTION
Refs #1944.

## Summary

Leftover slice of #1944: `vibe doc-at` returned `""` on a struct (and other type/decl) name because `doc_at_source` goes through `binding_occurrences`, and `bind_walk_stmt` only recorded `SLet` / `SLetMut`. `SStruct` / `SEnum` / `STypeAlias` / `SFnDecl` / `STrait` / `SEffectDef` fell through `_ => ()`, so hovering the declaration had zero occurrences.

`bind_walk_stmt` now records those module binders the same way as `SLet` (`bind_record_module_binder`). `SFnDecl` also walks `fn_value` / `requires` / `ensures`. Type decls have no expression bodies.

`fn` already worked: `parse_program_located` lowers `SFnDecl` to `SLet` via `lower_fn_decl_stmt`. Measured before the fix:

```
struct_doc=[] struct_occ=0
enum_doc=[] enum_occ=0
type_doc=[] type_occ=0
fn_doc=[adds two numbers] fn_occ=1
```

No allocs or symbol-kind changes in this slice.

## Tests

TDD on `lib/@vibe/compiler/runtime/editor_query_test.vibe`. Existing let-binding doc-at tests stay green.

```
bash scripts/vibe_test.sh lib/@vibe/compiler/runtime/editor_query_test.vibe
```

1/1 files, 23 tests passed.

## Leftover (still #1944)

- `vibe allocs` encoded test names — already landed in #2043
- no machine-readable kind legend