### PR TITLE
fix(lsp): stop mapping unlocated return-type errors to 0:0 (#1941)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -106,6 +106,28 @@ fn off_marker_len(off: Int, len: Int) -> String {
   }
 }
 
+/// #1941: a return-type mismatch whose tail is a literal has no `[@off=]`
+/// (EInt/EString/EBool/EFloat carry no offset). Tag the enclosing binding
+/// name so `locate_type_error` can recover the `fn` / `let` name token
+/// instead of falling through to the synthetic `0:0` LSP range. Only
+/// rewrites errors that still have no side-channel marker. Exported for
+/// checker_stmt's top-level SLet path (the leftover `fn f() -> Int { "s" }`).
+export fn attach_unlocated_return_fn_marker(errors: Array[String], from: Int, name: String) -> Unit {
+  if String::length(name) == 0 {
+    ()
+  } else {
+    let n = Array::length(errors)
+    let mut i = from
+    while i < n {
+      let msg = Array::get(errors, i)
+      if String::starts_with(msg, "return type mismatch") && String::index_of(msg, " [@") < 0 {
+        Array::set(errors, i, String::concat(msg, String::concat(" [@fn=", String::concat(name, "]"))))
+      }
+      i = i + 1
+    }
+  }
+}
+
 /// ADR-0090 MutBytes: reject a known-wrong receiver head instead of letting
 /// codegen alias the op onto Bytes::* and reinterpret an arbitrary value as
 /// a buffer pointer (Codex review on #1801). Unresolved vars and CtUnknown
@@ -4345,7 +4367,9 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
         cur = right
       },
       ELet(name, val, body, _) => {
+        let err_before = Array::length(errors)
         let (vt, ns, nc) = ce(val, cenv, defs, s1, c1, errors, tytab, capture, lane)
+        attach_unlocated_return_fn_marker(errors, err_before, name)
         // #938 value restriction: a builder is a MUTABLE container, so its
         // element var must stay un-quantified — generalizing
         // `CtNamed("ArrayBuilder", [v])` would re-instantiate a fresh v at
@@ -4371,7 +4395,9 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
         cur = body
       },
       ELetMut(name, val, body, _) => {
+        let err_before = Array::length(errors)
         let (vt, ns, nc) = ce(val, cenv, defs, s1, c1, errors, tytab, capture, lane)
+        attach_unlocated_return_fn_marker(errors, err_before, name)
         // `loop` desugars to `let mut __loop_result = 0; while true { ...
         // __loop_result = <break value> ... }` (parser_expr_primary.vibe) —
         // the 0 is only a slot placeholder, but binding its CtInt here pinned
@@ -4400,7 +4426,9 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
       },
       ELetRec(name, val, body) => {
         let (tv, c1b) = fresh_var(c1)
+        let err_before = Array::length(errors)
         let (vt, ns, nc) = ce(val, env_bind(cenv, name, tv), defs, s1, c1b, errors, tytab, capture, lane)
+        attach_unlocated_return_fn_marker(errors, err_before, name)
         let s2 = match unify(tv, vt, ns) {
           Some(su) => su,
           None => ns
@@ -8621,8 +8649,10 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // effectful value flowing into a pure-typed slot) via
           // effect_row_dropped, so this loosens nothing that was load-bearing.
           // Anchor on the body's TAIL expression -- the value actually being
-          // returned. -1 (unlocated, as before) when the tail is a literal:
-          // EInt/EString/EBool/EFloat carry no offset in the AST.
+          // returned. -1 when the tail is a literal: EInt/EString/EBool/EFloat
+          // carry no offset in the AST. The enclosing SLet/ELet then tags
+          // the error with `[@fn=name]` so locate_type_error can recover the
+          // function name token (#1941) instead of a synthetic 0:0 range.
           let ns = check_assignable(resolved_ret, bt, s2, errors, "return type mismatch", tail_expr_off(body))
           (merge_capture_provenance(subst_apply(ns, resolved_ret), subst_apply(ns, bt)), ns)
         },

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -55,6 +55,7 @@ import @vibe/compiler/core {
 
 import ./checker.vibe {
   TypedOccurrenceRoleLaneCapture,
+  attach_unlocated_return_fn_marker,
   bind_function_dependency_contracts,
   check_assignable,
   check_expr,
@@ -1431,11 +1432,13 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
     }
     let (new_env, s1, c1) = match stmt {
       SLet(_, is_rec, name, ann, val) => {
+        let err_before = Array::length(errors)
         let (vt, ns0, nc) = if is_rec {
           check_expr_capture(val, env_bind(env, name, CtUnknown), defs, s, c, errors, tytab, role_lane_capture, "Primary")
         } else {
           check_expr_capture(val, env, defs, s, c, errors, tytab, role_lane_capture, "Primary")
         }
+        attach_unlocated_return_fn_marker(errors, err_before, name)
         // The value must be assignable to a declared annotation (previously
         // unchecked — `let x: Int = "s"` was accepted).
         let (ns, t) = match ann {
@@ -1484,7 +1487,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // miscompiles cross-function references); reject it, but keep
         // checking/binding below for error recovery.
         Array::push(errors, top_level_reject_msg("top-level `let mut` bindings are not allowed; move it into fn main", val))
+        let err_before = Array::length(errors)
         let (vt, ns0, nc) = check_expr_capture(val, env, defs, s, c, errors, tytab, role_lane_capture, "Primary")
+        attach_unlocated_return_fn_marker(errors, err_before, name)
         let ns = match ann {
           Some(te) => check_assignable(resolve_type_expr(te, defs), subst_apply(ns0, vt), ns0, errors, String::concat("binding type mismatch for ", name), 0 - 1),
           None => ns0

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -129,6 +129,7 @@ fn lookup_string2(name: String) -> Option[Type]
 fn lookup_io(name: String) -> Option[Type]
 
 // --- checker.vibe
+fn attach_unlocated_return_fn_marker(errors: Array[String], from: Int, name: String) -> Unit
 fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -465,8 +465,7 @@ fn compile_source_for_rc_flag(source: String, entry_name: String, rc_flag: Strin
 /// which source text the offset indexes (the FS-compile lane compiles MERGED
 /// module text) must degrade to the unlocated message -- never print the raw
 /// marker (#1445's leaked `[@off=135]` is the failure mode this guards against).
-fn strip_off_marker(msg: String) -> String {
-  let marker = " [@off="
+fn strip_side_marker(msg: String, marker: String) -> String {
   let mi = String::index_of(msg, marker)
   if mi < 0 {
     msg
@@ -480,6 +479,10 @@ fn strip_off_marker(msg: String) -> String {
       String::concat(String::substring(msg, 0, mi), String::substring(msg, inner_start + rel + 1, String::length(msg)))
     }
   }
+}
+
+fn strip_off_marker(msg: String) -> String {
+  strip_side_marker(strip_side_marker(msg, " [@off="), " [@fn=")
 }
 
 /// On a parse/type/codegen error the checker throws a formatted diagnostic
@@ -509,7 +512,7 @@ fn emit_compile_diag(output_path: String, msg: String) -> Int with Fs {
 /// compile-path message. Only a diagnostic that states where it came from gets a
 /// position from this.
 fn emit_compile_diag_located(output_path: String, msg: String, source: String) -> Int with Fs {
-  if String::contains(msg, " [@off=") {
+  if String::contains(msg, " [@off=") || String::contains(msg, " [@fn=") {
     emit_compile_diag(output_path, locate_type_error(source, msg))
   } else {
     emit_compile_diag(output_path, msg)

--- a/lib/@vibe/compiler/runtime/range_agreement_test.vibe
+++ b/lib/@vibe/compiler/runtime/range_agreement_test.vibe
@@ -3,11 +3,16 @@
 // #1941 first locked agreement: a type-error range from `check_program` +
 // `offset_to_line_col` (the primitives `vibe check` / `locate_type_error`
 // use) and a `binding_occurrences` span (the primitive `vibe binding-at`
-// uses) must slice the same source token. Leftover: JSON 0..1, grep line:0,
-// synthetic 0:0.
+// uses) must slice the same source token. Return-type mismatches on a
+// literal tail now recover the `fn` name (not synthetic 0:0). Leftover:
+// grep `line:0`; remaining unlocated type errors still take 0..1.
 
 import ./binding_at.vibe {
   binding_occurrences
+}
+
+import ./typecheck_fs.vibe {
+  collect_all_diagnostics
 }
 
 import @vibe/compiler/checker {
@@ -114,4 +119,38 @@ test "check and binding-at slice the same unknown identifier quux" {
   assert(col > 0)
   let occ = binding_occurrences(src, line, col)
   assert(occ_contains(occ, start, endo))
+}
+
+/// `fn f() -> Int { "s" }` — the tail is an `EString` with no offset, so
+/// `tail_expr_off` is -1. The diagnostic must still carry `line L:C:` and
+/// must not claim column 1 unless that is truly the function name.
+test "return-type mismatch on a literal is located at the fn name (#1941)" {
+  let src = "fn f() -> Int { \"s\" }"
+  let diags = collect_all_diagnostics(src)
+  assert(Array::length(diags) == 1)
+  let msg = Array::get(diags, 0)
+  assert(String::contains(msg, "return type mismatch"))
+  assert(String::contains(msg, "line "))
+  assert(String::contains(msg, "line 1:1:") == false)
+  let name_off = String::index_of(src, "fn f") + 3
+  assert(String::substring(src, name_off, name_off + 1) == "f")
+  let (line, col) = offset_to_line_col(src, name_off)
+  let want = String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), "-"))))
+  assert(String::contains(msg, want))
+}
+
+/// A preceding well-typed `fn` must not steal the range. First-`fn` scan
+/// would point at `ok`; the recovered name is `f`.
+test "return-type mismatch points at the culpable fn, not an earlier fn (#1941)" {
+  let src = "fn ok() -> Int { 1 }\nfn f() -> Int { \"s\" }"
+  let diags = collect_all_diagnostics(src)
+  assert(Array::length(diags) == 1)
+  let msg = Array::get(diags, 0)
+  assert(String::contains(msg, "return type mismatch"))
+  let name_off = String::index_of(src, "fn f") + 3
+  assert(String::substring(src, name_off, name_off + 1) == "f")
+  let (line, col) = offset_to_line_col(src, name_off)
+  let want = String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), "-"))))
+  assert(String::contains(msg, want))
+  assert(String::contains(msg, "line 1:4:") == false)
 }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3463,6 +3463,128 @@ fn parse_offset_digits(msg: String, start: Int, end: Int) -> Int {
     }
   }
 }
+/// Whole-word identifier character (ASCII letter / digit / underscore).
+fn loc_ident_char(c: Int) -> Bool {
+  c >= 97 && c <= 122 || (c >= 65 && c <= 90) || (c >= 48 && c <= 57) || c == 95
+}
+
+fn loc_space_char(c: Int) -> Bool {
+  c == 32 || c == 9 || c == 10 || c == 13
+}
+
+fn loc_skip_ws_back(source: String, off: Int) -> Int {
+  let mut i = off
+  while i > 0 && loc_space_char(String::char_code_at(source, i - 1)) {
+    i = i - 1
+  }
+  i
+}
+
+fn loc_word_at(source: String, off: Int, name: String) -> Bool {
+  let nlen = String::length(name)
+  let slen = String::length(source)
+  if nlen == 0 || off < 0 || off + nlen > slen {
+    false
+  } else if String::substring(source, off, off + nlen) != name {
+    false
+  } else {
+    let left_ok = off == 0 || !loc_ident_char(String::char_code_at(source, off - 1))
+    let right_ok = off + nlen == slen || !loc_ident_char(String::char_code_at(source, off + nlen))
+    left_ok && right_ok
+  }
+}
+
+fn loc_kw_before(source: String, off: Int, kw: String) -> Bool {
+  let i = loc_skip_ws_back(source, off)
+  let klen = String::length(kw)
+  if i < klen {
+    false
+  } else if String::substring(source, i - klen, i) != kw {
+    false
+  } else {
+    i - klen == 0 || !loc_ident_char(String::char_code_at(source, i - klen - 1))
+  }
+}
+
+/// Recover the source offset of a declaration name tagged `[@fn=name]`.
+/// Prefer `fn name`, then `let name` / `let mut name`, then the first
+/// whole-word occurrence. -1 when the name cannot be found.
+fn find_fn_anchor_off(source: String, name: String) -> Int {
+  let nlen = String::length(name)
+  if nlen == 0 {
+    0 - 1
+  } else {
+    let slen = String::length(source)
+    let mut i = 0
+    let mut fn_off = 0 - 1
+    let mut let_off = 0 - 1
+    let mut first_off = 0 - 1
+    while i + nlen <= slen {
+      if loc_word_at(source, i, name) {
+        if first_off < 0 {
+          first_off = i
+        } else {
+          ()
+        }
+        if fn_off < 0 && loc_kw_before(source, i, "fn") {
+          fn_off = i
+        } else {
+          ()
+        }
+        if let_off < 0 {
+          if loc_kw_before(source, i, "let") {
+            let_off = i
+          } else if loc_kw_before(source, i, "mut") {
+            let before_name = loc_skip_ws_back(source, i)
+            if loc_kw_before(source, before_name - 3, "let") {
+              let_off = i
+            } else {
+              ()
+            }
+          } else {
+            ()
+          }
+        } else {
+          ()
+        }
+        i = i + nlen
+      } else {
+        i = i + 1
+      }
+    }
+    if fn_off >= 0 {
+      fn_off
+    } else if let_off >= 0 {
+      let_off
+    } else {
+      first_off
+    }
+  }
+}
+
+/// Decode ` [@fn=name]` (the #1941 fallback when a return-type mismatch has
+/// no AST offset). Always strips the marker. When `name` is found in
+/// `source`, prefix the exact name span; otherwise fall through to the
+/// first-occurrence heuristic on the cleaned message.
+fn locate_fn_name_marker(source: String, msg: String, mi: Int) -> String {
+  let marker = " [@fn="
+  let inner_start = mi + String::length(marker)
+  let rel_end = String::index_of(String::substring(msg, inner_start, String::length(msg)), "]")
+  if rel_end < 0 {
+    locate_type_error_heuristic(source, String::substring(msg, 0, mi))
+  } else {
+    let close = inner_start + rel_end
+    let name = String::substring(msg, inner_start, close)
+    let stripped = String::concat(String::substring(msg, 0, mi), String::substring(msg, close + 1, String::length(msg)))
+    let off = find_fn_anchor_off(source, name)
+    if off >= 0 {
+      String::concat(offset_line_col_range_prefix(source, off, off + String::length(name)), stripped)
+    } else {
+      locate_type_error_heuristic(source, stripped)
+    }
+  }
+}
+
 /// Decode (and ALWAYS strip) the ` [@off=N]` marker the checker may have
 /// appended. If N is a valid in-range offset, prefix the stripped message with
 /// its exact `line:col`. Otherwise strip the marker and fall through to the
@@ -3471,8 +3593,13 @@ fn parse_offset_digits(msg: String, start: Int, end: Int) -> Int {
 export fn locate_type_error(source: String, msg: String) -> String {
   let marker = " [@off="
   let mi = String::index_of(msg, marker)
+  let fn_mi = String::index_of(msg, " [@fn=")
   if mi < 0 {
-    locate_type_error_heuristic(source, msg)
+    if fn_mi < 0 {
+      locate_type_error_heuristic(source, msg)
+    } else {
+      locate_fn_name_marker(source, msg, fn_mi)
+    }
   } else {
     let inner_start = mi + String::length(marker)
     let rel_end = String::index_of(String::substring(msg, inner_start, String::length(msg)), "]")

--- a/lib/@vibe/lsp/lsp_diagnostics_test.vibe
+++ b/lib/@vibe/lsp/lsp_diagnostics_test.vibe
@@ -20,9 +20,10 @@
 // `line L:C-E:` from `[@off=N:M]`, but the JSON/LSP encoder used to treat
 // `C-E` as a non-numeric column and collapse to `0..1`. The quux test
 // below requires the encoder to slice the same token #2024 locked.
-// Leftover on #1941: grep `line:0`, synthetic `0:0` instead of an
-// unavailable marker, type-at on binders/callees. Return-type mismatches
-// still take the no-position fallback (the snapshot below).
+// Return-type mismatches on an offset-less literal (`EString`) now recover
+// the enclosing `fn` name instead of the synthetic `0:0-0:1` fallback.
+// Leftover on #1941: grep `line:0`; remaining unlocated type errors
+// (anonymous lambdas whose tail is a literal) still take the 0..1 fallback.
 
 //# Imports
 
@@ -50,13 +51,32 @@ test "lsp diagnostics: a parse error carries its position and error severity" {
   inspect(lsp_diagnostics_json_string("fn f( -> Int { 1 }"), "[{\"range\":{\"start\":{\"line\":0,\"character\":6},\"end\":{\"line\":0,\"character\":7}},\"severity\":1,\"source\":\"vibe\",\"message\":\"expected parameter name token=->\",\"data\":null}]",)
 }
 
-test "lsp diagnostics: a message with no position falls back to the file start" {
-  // Type errors without `[@off=]` still carry no `line L:C:` prefix
-  // (#1567 leftover / #1941 synthetic 0:0). Unknown names like `quux`
-  // are located; this snapshot is the no-position fallback. Pinned as
-  // CURRENT behaviour, not as desired -- when those messages get a
-  // position this snapshot changes.
-  inspect(lsp_diagnostics_json_string("fn f() -> Int { \"s\" }"), "[{\"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":0,\"character\":1}},\"severity\":1,\"source\":\"vibe\",\"message\":\"return type mismatch: expected Int, got String\",\"data\":null}]",)
+test "lsp diagnostics: return-type mismatch on a literal points at the fn name (#1941)" {
+  // `tail_expr_off(EString)` is -1, so this used to take `lsp_diag_fallback`
+  // and lie as `0:0-0:1`. The checker now tags the enclosing `fn` name;
+  // `collect_all_diagnostics` emits `line L:C-E:` and JSON slices `f`.
+  let src = "fn f() -> Int { \"s\" }"
+  let token = "f"
+  let start = String::index_of(src, "fn f") + 3
+  let endo = start + String::length(token)
+  assert(start >= 0)
+  assert(String::substring(src, start, endo) == token)
+  inspect(lsp_diagnostics_json_string(src), "[{\"range\":{\"start\":{\"line\":0,\"character\":3},\"end\":{\"line\":0,\"character\":4}},\"severity\":1,\"source\":\"vibe\",\"message\":\"return type mismatch: expected Int, got String\",\"data\":null}]",)
+  let parsed = Json::parse(lsp_diagnostics_json_string(src))
+  assert(Json::length(parsed) == 1)
+  let range = Json::field(Json::index(parsed, 0), "range")
+  let rs = Json::field(range, "start")
+  let re = Json::field(range, "end")
+  let sl = Double::to_int(Json::number(Json::field(rs, "line")))
+  let sc = Double::to_int(Json::number(Json::field(rs, "character")))
+  let el = Double::to_int(Json::number(Json::field(re, "line")))
+  let ec = Double::to_int(Json::number(Json::field(re, "character")))
+  assert(sl == 0)
+  assert(el == 0)
+  assert(sc == start)
+  assert(ec == endo)
+  assert(String::substring(src, sc, ec) == token)
+  assert(!(sl == 0 && sc == 0 && el == 0 && ec <= 1))
 }
 
 test "lsp diagnostics: columns are UTF-16 code units, not bytes (#1672)" {

--- a/lib/@vibe/lsp/lsp_server.vibe
+++ b/lib/@vibe/lsp/lsp_server.vibe
@@ -618,10 +618,10 @@ fn lsp_parse_diag_line(source: String, msg: String) -> Json {
   }
 }
 
-/// Messages with no `line L:` prefix still land on `0..1`. That is the
-/// leftover #1941 synthetic-`0:0` lie, not a real span -- keep it until
-/// those diagnostics grow an unavailable/synthetic marker instead of a
-/// plausible range.
+/// Messages with no `line L:` prefix still land on `0..1`. Return-type
+/// mismatches on a named `fn` now carry a real span (#1941); remaining
+/// unlocated type errors (anonymous literal tails) still take this
+/// fallback. Leftover: an explicit synthetic/unavailable marker.
 fn lsp_diag_fallback(msg: String) -> Json {
   JObj(Map::from_pairs([
     ("range", jrange(0, 0, 0, 1)),


### PR DESCRIPTION
Refs #1941.

## Summary

Next short knife of #1941 after #2040. Return-type range only — no EString offset field, no grep change, no type-error format rewrite.

`fn f() -> Int { "s" }` produces `return type mismatch: expected Int, got String` with no `line L:C:` prefix because `tail_expr_off(EString)` is `-1`. JSON/LSP then took `lsp_diag_fallback` and lied as a real `0:0-0:1` range.

Option 1: when the tail has no offset, tag the error with the enclosing `fn` / `let` name (`[@fn=f]`). `locate_type_error` recovers that name token (prefer `fn f`, then `let f`) and emits `line L:C-E:`. JSON now slices `f` at `0:3-0:4`. Pointing at the function name is better than a fake `0:0`.

Did not add an EString offset field.

## Measured

Before (pinned as current in `lsp_diagnostics_test.vibe`):

```
[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":1}},...,"message":"return type mismatch: expected Int, got String"}]
```

`collect_all_diagnostics` had no `line ` prefix.

After:

```
[{"range":{"start":{"line":0,"character":3},"end":{"line":0,"character":4}},...,"message":"return type mismatch: expected Int, got String"}]
```

`collect_all_diagnostics` emits `line 1:4-5:` (the `f` token). A preceding `fn ok() -> Int { 1 }` does not steal the range.

## Tests

TDD: changed the LSP snapshot first (red: still `0:0-0:1`), then the checker/locator.

```
bash scripts/vibe_test.sh lib/@vibe/lsp/lsp_diagnostics_test.vibe lib/@vibe/compiler/runtime/range_agreement_test.vibe
```

2/2 files, 10 tests passed. Related `locate_type_error` / parity / cli_support tests also green (82 tests).

## Leftover

- Anonymous lambdas whose tail is a literal still have no name to recover and still take the `0:0-0:1` fallback.
- Remaining unlocated type errors still lack an explicit synthetic/unavailable marker.
- Grep `line:0` (other #1941 leftover).