### PR TITLE
test: migrate generic explicit type-arg fixture debt (#1967)

### DIFF
--- a/fixtures/generic_explicit_type_arg.vibe
+++ b/fixtures/generic_explicit_type_arg.vibe
@@ -1,5 +1,0 @@
-let identity = [T](x: T) -> T { x }
-identity[Int](42)
-
-__DATA__
-{"last": "42"}

--- a/fixtures/generic_explicit_type_arg_test.vibe
+++ b/fixtures/generic_explicit_type_arg_test.vibe
@@ -1,0 +1,11 @@
+// #1967: was fixtures/generic_explicit_type_arg.vibe + __DATA__.last "42".
+// Stale `let identity = [T](x: T) -> T { x }` + `identity[Int](42)` is still
+// rejected. Current `fn identity[T](x: T) -> T` keeps the claimed value.
+
+fn identity[T](x: T) -> T {
+  x
+}
+
+test "generic identity infers Int" {
+  inspect(identity(42), "42")
+}

--- a/scripts/runtime_fixture_debt.tsv
+++ b/scripts/runtime_fixture_debt.tsv
@@ -4,4 +4,3 @@
 # stop being runtime candidates, so a migrated/deleted fixture must remove its
 # debt row in the same change.
 fixtures/err_import_collides_with_local_let.vibe	generator debt: hoisting the import ahead of the top-level let changes the name-collision contract into block shadowing
-fixtures/generic_explicit_type_arg.vibe	compile debt: explicit type argument Int is rejected in this spelling


### PR DESCRIPTION
## Summary

Leftover #1967 / #1966 slice: migrate `generic_explicit_type_arg`.

- Delete `fixtures/generic_explicit_type_arg.vibe` (`let identity = [T](...)` + `identity[Int](42)` + `__DATA__.last "42"`)
- Add `fixtures/generic_explicit_type_arg_test.vibe`: current `fn identity[T](x: T) -> T` keeps the claimed `42`
- Stale `identity[Int](42)` is still rejected (`unknown name: Int`). Explicit type arguments are not added as a language feature
- Remove the TSV compile-debt row

Skipped:

- `err_import_collides_with_local_let` — a `fn`/`test` wrapper that keeps `let abs` then `import { abs }` still compiles then traps OOB. Import after a local `let` inside `test` is `unexpected token: import`. Stripped original hits ADR-0069 (`top-level expressions are not allowed`). `fn main { abs(-1) }` is a Unit return mismatch, not the collision. No inspect or diagnostic snapshot preserves that contract. TSV row stays.

Did not touch effect/handler rows (#1973).

## Tests

```
bash scripts/vibe_test.sh fixtures/generic_explicit_type_arg_test.vibe
bash scripts/check_fixture_execution.sh
```

Seed: 1/1 passed. Fixture-execution: 1 reasoned debt, all accounted for.

Refs #1967.