### PR TITLE
docs: first tutorial program works without repo lib

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -455,6 +455,8 @@ local testMeasureFsHeap = scriptTask("test-measure-fs-heap", "scripts/measure_fs
 local testRunCachedVibe = scriptTask("test-run-cached-vibe", "scripts/run_cached_vibe_test.sh")
 local testSelfhostGenerations = scriptTask("test-generations", "scripts/generations_test.sh")
 local testVibeRun = scriptTask("test-vibe-run", "scripts/vibe_run_smoke.sh")
+local testInstallHelloSmoke =
+  scriptTask("test-install-hello-smoke", "scripts/test_vibe_install_hello.sh")
 local testUncaughtExceptionExit =
   scriptTask("test-uncaught-exception-exit", "scripts/test_uncaught_exception_exit.sh")
 local testVibeTest = scriptTask("test-vibe-test", "scripts/vibe_test_smoke.sh")
@@ -1323,6 +1325,7 @@ tasks {
   testSelfhostGenerations
   testSelfhostUnit
   testVibeRun
+  testInstallHelloSmoke
   testUncaughtExceptionExit
   testVibeTest
   testVibeFmt

--- a/docs/install.md
+++ b/docs/install.md
@@ -45,6 +45,9 @@ echo 'fn main with Stdout { Stdout::write_stream("42\\n") }' > hello.vibex
 vibe run hello.vibex        # -> 42
 ```
 
+The tutorial's first program is this same host-builtin form; see
+[docs/tutorial/README.md](tutorial/README.md) (#1949).
+
 ### Install layout (rustup-style toolchains, #755)
 
 ```

--- a/docs/tutorial/01_values_functions-ja.vibe.md
+++ b/docs/tutorial/01_values_functions-ja.vibe.md
@@ -12,6 +12,11 @@ English version: [01_values_functions.vibe.md](01_values_functions.vibe.md) (can
 
 束縛は `let`。型注釈は省略できる (推論される)。
 
+`import @vibe/prelude` はリポジトリの `lib/` か pin 済みパッケージが必要です。
+ツリーの外では [install.md](../install.md) と同じホスト組み込み
+`Stdout::write_stream` を使います:
+`fn main with Stdout { Stdout::write_stream("42\n") }`。
+
 ```vibe run
 import @vibe/prelude {
   stdout_write

--- a/docs/tutorial/01_values_functions.vibe.md
+++ b/docs/tutorial/01_values_functions.vibe.md
@@ -13,6 +13,11 @@ locally, run
 
 `let` binds. The type annotation is optional — it is inferred.
 
+`import @vibe/prelude` needs the repository `lib/` or a pinned package.
+Outside the tree, use the host builtin `Stdout::write_stream` as in
+[install.md](../install.md):
+`fn main with Stdout { Stdout::write_stream("42\n") }`.
+
 ```vibe run
 import @vibe/prelude {
   stdout_write

--- a/docs/tutorial/README-ja.md
+++ b/docs/tutorial/README-ja.md
@@ -20,6 +20,20 @@ bash scripts/vibe_md.sh write docs/tutorial/*.vibe.md   # 実行して ```output
 pkf run vibe-md-tutorial                                # check を task 化したもの
 ```
 
+## 最初のプログラム（インストールした toolchain だけ）
+
+リポジトリの `lib/` なしで、**インストールした toolchain だけで**動く
+コピー＆ペースト用のプログラムは [docs/install.md](../install.md) と同じ
+ホスト組み込みの hello です:
+
+```bash
+echo 'fn main with Stdout { Stdout::write_stream("42\\n") }' > hello.vibex
+vibe run hello.vibex        # -> 42
+```
+
+各章の `import @vibe/prelude` はリポジトリまたは pin 済みパッケージが必要で、
+素のインストールにはそのパッケージは含まれません。
+
 | 章 | テーマ |
 | --- | --- |
 | [01 値と関数](01_values_functions-ja.vibe.md) | let / mut / 基本型 / 文字列補間 / fn / ラムダ |

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -20,6 +20,20 @@ bash scripts/vibe_md.sh write docs/tutorial/*.vibe.md   # run, and rewrite the `
 pkf run vibe-md-tutorial                                # the same check as a task
 ```
 
+## First program (installed toolchain)
+
+The copy/paste program that works with **only the installed toolchain** —
+no repository `lib/` — is the host-builtin hello from
+[docs/install.md](../install.md):
+
+```bash
+echo 'fn main with Stdout { Stdout::write_stream("42\\n") }' > hello.vibex
+vibe run hello.vibex        # -> 42
+```
+
+`import @vibe/prelude` in the chapters below needs the repo or a pinned
+package. A fresh install does not ship that package.
+
 | Chapter | Topic |
 | --- | --- |
 | [01 Values and functions](01_values_functions.vibe.md) | let / mut / primitive types / interpolation / fn / lambdas |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -59,7 +59,8 @@ The selfhost `vibe` subcommands as scripts (used by `pkf run` + tests).
 - **Runtime / mem / perf:** `test_vibe_{alloc_site,mem,bench}.sh`,
   `test_gc_selfbuild.sh`, `test_name_section.sh`, `test_simd_emit_wasmtime.sh`
 - **Host ABI / library / install:** `test_host_abi.js`, `test_vibe_library.sh`,
-  `test_vibe_cli_install.sh`, `test_wasm_vibe_wasmtime.sh`
+  `test_vibe_cli_install.sh`, `test_vibe_install_hello.sh` (#1949 first-program
+  smoke, no repo `lib/`), `test_wasm_vibe_wasmtime.sh`
 - **Async / http / process:** `test_real_async_host.sh`, `test_wasi_http_p3_full_gate.sh`
 
 ## Coverage

--- a/scripts/test_vibe_install_hello.sh
+++ b/scripts/test_vibe_install_hello.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# #1949: the documented first program must compile and run from a directory
+# that cannot see the repository lib/ tree. Host-builtin Stdout::write_stream
+# only — the installed toolchain does not ship @vibe/prelude.
+#
+# A full `vibe run hello.vibex` needs the install layout (viberun +
+# vibe-cli.wasm). This matches scripts/vibe_run_smoke.sh (seed compile +
+# host runner) but cds into a temp dir and preopens only that dir so
+# workspace lib/ is not on the search path.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibe-install-hello.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+printf 'fn main with Stdout { Stdout::write_stream("42\\n") }\n' > "$WORK/hello.vibex"
+
+# Hide repo lib / any inherited VIBE_LIB so a prelude import would fail.
+unset VIBE_LIB || true
+export VIBE_HOME="$WORK/empty-home"
+mkdir -p "$VIBE_HOME"
+
+bash "$ROOT_DIR/scripts/ensure_seed.sh"
+seed="$ROOT_DIR/bootstrap/seed/compiler.wasm"
+
+cd "$WORK"
+
+VIBE_PREOPEN_DIR="$WORK" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
+  --invoke cli_main "$seed" "hello.vibex" "hello.wasm" "main" >/dev/null
+
+if [ ! -s "$WORK/hello.wasm" ]; then
+  echo "[install-hello-smoke] FAIL: compile produced no wasm" >&2
+  if [ -s "$WORK/hello.wasm.diag" ]; then
+    cat "$WORK/hello.wasm.diag" >&2
+  fi
+  exit 1
+fi
+
+out="$(VIBE_PREOPEN_DIR="$WORK" VIBE_RUNNER_EXIT_WITH_RESULT=1 \
+  bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" --invoke main "hello.wasm" \
+  | tr -d '\r' | sed -n '1p')"
+out="${out%"${out##*[![:space:]]}"}"
+
+if [ "$out" != "42" ]; then
+  echo "[install-hello-smoke] FAIL: expected 42, got '$out'" >&2
+  exit 1
+fi
+
+echo "[install-hello-smoke] ok (stdout=42, no repo lib/)"


### PR DESCRIPTION
Refs #1949.

The first documented copy/paste program is now the same host-builtin hello as `docs/install.md`. That form works with only an installed toolchain; `@vibe/prelude` still needs the repo `lib/` or a pinned package.

## Changes
- Tutorial README (+ ja): put the install.md hello first, labeled as the program that works without repo `lib/`. Chapter table unchanged.
- Chapter 01 (+ ja): short note above the first `import @vibe/prelude` block. Runnable prelude examples are unchanged.
- `docs/install.md`: one-line pointer to the tutorial note. Same hello, not a third one.
- `scripts/test_vibe_install_hello.sh`: writes the hello to a temp dir, compiles/runs it via the seed + host runner (same path as `vibe_run_smoke.sh`), preopens only that dir so repo `lib/` is not visible, asserts stdout is `42`. Wired as `pkf run test-install-hello-smoke` next to `test-vibe-run`. Not added to `compiler_gate` / `release-check` (those do not run the sibling smokes).

## Leftover
Option 1 (install `@vibe/prelude` with the toolchain) is not done. This slice is option 2 only.