### PR TITLE
fix(grep): accept --help instead of unknown flag (#1943)

### DIFF
--- a/runtime/vibe
+++ b/runtime/vibe
@@ -1537,7 +1537,9 @@ case "$cmd" in
   grep)
     # vibe grep [flags] --pattern '<pattern>' [paths...]        (#1572)
     #
-    # Structural AST search. Unlike moongrep / ast-grep, the filters run on the
+    # Structural AST search. Metavariables are `$(name:kind)`, kind = exp / id / const / arg / args / pat / type.
+    # `$(_:kind)` is anonymous.
+    # Unlike moongrep / ast-grep, the filters run on the
     # CHECKER's answers, not on the grammar alone:
     #   --where '$x : Array[Int]'    the capture's INFERRED type (`_` wildcard)
     #   --where '$f = Iterator::map' the capture's RESOLVED name (sees through
@@ -1560,6 +1562,12 @@ case "$cmd" in
     g_paths=()
     while [ "$#" -gt 0 ]; do
       case "$1" in
+        --help|-h)
+          # Same content-anchored print as `vibe help`: the comment block
+          # immediately above this case is the user-facing text.
+          sed -n '/^    # vibe grep \[flags\]/,/^    g_pattern=/p' "$LAUNCHER" | sed '/^    g_pattern=/d; s/^    # \{0,1\}//'
+          exit 0
+          ;;
         --pattern) [ "$#" -ge 2 ] || die "vibe grep: --pattern needs an argument"; g_pattern="$2"; shift 2 ;;
         --pattern=*) g_pattern="${1#--pattern=}"; shift ;;
         --json|--output-json) g_json=1; shift ;;

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -11966,6 +11966,7 @@ rm -rf "$dvdir"
 echo "[compiler-gate] desugar-emitted builtins resolve in both lanes ok"
 
 echo "[compiler-gate] 98/104 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
+bash "$ROOT_DIR/scripts/test_vibe_grep_help.sh"
 # grep_test.vibe covers the pattern language and the filters through
 # grep_scan_source (no Fs). What only the REAL adapter mode exercises is the
 # filesystem tier: sweeping a directory, and resolving a capture's type through

--- a/scripts/test_vibe_grep_help.sh
+++ b/scripts/test_vibe_grep_help.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# `vibe grep --help` / `-h` is a report, not "unknown flag" (#1943).
+# Pure launcher: a dummy runner is enough to pass the startup check.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe-grep-help.XXXXXX")"
+cleanup() {
+  local status=$?
+  rm -rf "$TMP_DIR"
+  exit "$status"
+}
+trap cleanup EXIT
+
+LAUNCHER="$ROOT_DIR/runtime/vibe"
+RUNNER="$TMP_DIR/dummy-runner"
+OUT="$TMP_DIR/stdout.txt"
+ERR="$TMP_DIR/stderr.txt"
+
+printf '%s\n' '#!/usr/bin/env bash' 'echo "runner-should-not-run" >&2' 'exit 41' > "$RUNNER"
+chmod +x "$RUNNER"
+
+run_help() {
+  local flag="$1"
+  : > "$OUT"
+  : > "$ERR"
+  local status=0
+  VIBE_RUNNER="$RUNNER" bash "$LAUNCHER" grep "$flag" > "$OUT" 2> "$ERR" || status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "[vibe-grep-help] FAIL: grep $flag exited $status (want 0)" >&2
+    cat "$ERR" >&2
+    exit 1
+  fi
+  if grep -q 'unknown flag' "$ERR" "$OUT"; then
+    echo "[vibe-grep-help] FAIL: grep $flag still reports unknown flag" >&2
+    cat "$ERR" "$OUT" >&2
+    exit 1
+  fi
+  if [ -s "$ERR" ]; then
+    echo "[vibe-grep-help] FAIL: grep $flag wrote to stderr" >&2
+    cat "$ERR" >&2
+    exit 1
+  fi
+  if grep -q 'runner-should-not-run' "$OUT" "$ERR"; then
+    echo "[vibe-grep-help] FAIL: grep $flag invoked the runner" >&2
+    exit 1
+  fi
+}
+
+need() {
+  if ! grep -qF -- "$1" "$OUT"; then
+    echo "[vibe-grep-help] FAIL: help missing '$1'" >&2
+    cat "$OUT" >&2
+    exit 1
+  fi
+}
+
+run_help --help
+need '$(name:kind)'
+need 'exp / id / const / arg / args / pat / type'
+need '--where'
+need '--where-row'
+need '--only-ill-typed'
+need '--only-well-typed'
+need '--json'
+need 'Empty output = no match'
+need 'bad pattern'
+
+run_help -h
+need '$(name:kind)'
+need '--where'
+
+echo "[vibe-grep-help] ok"


### PR DESCRIPTION
Refs #1943.

## Summary

Leftover slice of #1943: `--help` only. No perform-vs-throw matching, skipped-file silence, or capture ranges.

`runtime/vibe` `grep)` treated `-*)` as `die "vibe grep: unknown flag: $1"`, so `vibe grep --help` / `-h` failed. Accept those flags, print the existing case comment to stdout (same content-anchored `sed` style as `vibe help`), and exit 0.

Help now includes the pattern language (`$(name:kind)` kinds), `--where` / `--where-row` / `--only-*` / `--json`, empty output = no match, and that a bad pattern is an error. `vibe grep` with no `--pattern` still dies on the current usage line.

## Test

`scripts/test_vibe_grep_help.sh` (wired into `compiler_gate.sh` next to the existing grep step). Dummy runner only — `--help` must not invoke it. Red was `unknown flag` + exit 1.

## Leftover on #1943

- Distinguish source `perform` from source `throw`
- Useful partial handle / declaration patterns, or reject them with actionable syntax
- Report skipped/unparseable files without aborting a repo sweep
- Complete capture ranges and an explicit synthetic/source distinction