### PR TITLE
feat(symbols): publish versioned SymbolKind legend (#1944)

### DIFF
--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -48,6 +48,7 @@ directly (useful for scripting or wiring a different editor):
 vibe type-at <file.vibe> <line> <col>     # inferred type of the identifier at 1-based (line,col)
 vibe binding-at <file.vibe> <line> <col>  # source spans (START END char offsets) of every occurrence of that binding
 vibe symbols <file.vibe>                  # declaration outline (NAME KIND START END per line)
+vibe symbols --legend                     # KIND NAME table (LSP SymbolKind v1, 2026-08-17)
 vibe check <file.vibe>                    # all diagnostics, one per line on stdout; empty output = clean, exit 1 if not
 vibe check --single-file <file.vibe>      # same, analysing the buffer ALONE (no FS import resolution)
 vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array of LSP Diagnostic objects (#820)
@@ -68,6 +69,25 @@ vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array 
   is outlined as the keyword `test`/`bench`. An `impl Trait for T` is one
   Method (6) named after `T` — the impl statement does not carry method
   children.
+- **SymbolKind legend v1 (2026-08-17).** `KIND` integers are LSP
+  [`SymbolKind`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind)
+  values. The machine-readable table is `vibe symbols --legend`: one
+  `KIND NAME` line per kind this command actually emits, no decoration,
+  never empty. `--help` / `-h` print usage and point at that table. A file
+  outline is unchanged when `--legend` is absent. Bump the version when a
+  KIND number is added or remapped; never reuse a number.
+
+  | KIND | LSP name | vibe declaration |
+  | --- | --- | --- |
+  | 2 | Module | `module` |
+  | 6 | Method | `impl Trait for T` (named after `T`) |
+  | 10 | Enum | `enum`, `suberror` |
+  | 11 | Interface | `trait` |
+  | 12 | Function | `fn`, `test`, `bench`, let-bound functions |
+  | 13 | Variable | other `let` / `let mut` |
+  | 23 | Struct | `struct` |
+  | 24 | Event | `effect` |
+  | 26 | TypeParameter | `type` alias |
 - **`--single-file` analyzes ONE file and does not follow its imports**, so on a
   file with imports it reports names it cannot see as undefined. A file that is
   perfectly valid under a plain `vibe check` can come back with

--- a/lib/@vibe/compiler/runtime/symbol_spans.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans.vibe
@@ -7,6 +7,18 @@
 // where `kind` is an LSP SymbolKind number and [start, end) is the source span
 // of the declaration NAME (char offsets).
 //
+// SymbolKind legend v1 (2026-08-17). KIND integers are LSP SymbolKind.
+// Machine-readable copy: `vibe symbols --legend` (one `KIND NAME` per line).
+//   2  Module         `module`
+//   6  Method         `impl Trait for T` (named after T)
+//   10 Enum           `enum`, `suberror`
+//   11 Interface      `trait`
+//   12 Function       `fn`, `test`, `bench`, let-bound functions
+//   13 Variable       other `let` / `let mut`
+//   23 Struct         `struct`
+//   24 Event          `effect`
+//   26 TypeParameter  `type` alias
+//
 // Why this beats the LSP server's previous line-regex scan: declarations are
 // taken from the real parsed AST, so multi-line declarations, declarations not
 // starting at column 0, and names that merely look like keywords inside strings

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -53,6 +53,7 @@
 #   vibe doc-at  <file.vibe> <line> <col> print the `///` doc comment at a position (#854)
 #   vibe binding-at <file.vibe> <line> <col> print binding occurrence spans (START END per line)
 #   vibe symbols <file.vibe>              print declaration outline (NAME KIND START END per line)
+#   vibe symbols --legend                 print KIND NAME table (LSP SymbolKind v1, 2026-08-17)
 #   vibe escapes [--strict] <file.vibe>   print the `let mut` bindings a closure
 #                                         captures -- the ones codegen boxes into
 #                                         a heap ref cell instead of a wasm local
@@ -286,8 +287,19 @@ tree_digest() {
 
 # Codex review (PR #1162): `context-pack` is pure shell (no wasm execution
 # at all -- see its case block below), so it must not be blocked by a
-# missing/unbuilt runner. Every other subcommand still requires it.
-if [ "${1:-help}" != "context-pack" ]; then
+# missing/unbuilt runner. `vibe symbols --legend|--help|-h` is the same:
+# a static KIND table / usage, no wasm (#1944). Every other subcommand
+# still requires the runner.
+need_runner=1
+case "${1:-help}" in
+  context-pack) need_runner=0 ;;
+  symbols)
+    case "${2:-}" in
+      --legend|--help|-h) need_runner=0 ;;
+    esac
+    ;;
+esac
+if [ "$need_runner" = 1 ]; then
   [ -x "$RUNNER" ] || die "runner not found or not executable: $RUNNER"
 fi
 
@@ -1289,11 +1301,38 @@ case "$cmd" in
     ;;
   symbols)
     # vibe symbols <file.vibe>
+    # vibe symbols --legend
     # Print the declaration outline, one `NAME KIND START END` per line (KIND =
     # LSP SymbolKind int, START/END = char offsets of the name). AST-accurate
     # (no line-regex scan): handles multi-line decls and module-nested symbols.
     # Empty output means the file declares no top-level symbols. Powers LSP
     # document-outline / go-to-definition.
+    # `--legend` prints the versioned KIND table (v1 / 2026-08-17): one
+    # `KIND NAME` per line, no decoration, never empty. `--help`/`-h` print
+    # usage plus a pointer at that table. Neither flag changes the file
+    # outline path below.
+    case "${1:-}" in
+      --legend)
+        printf '%s\n' \
+          '2 Module' \
+          '6 Method' \
+          '10 Enum' \
+          '11 Interface' \
+          '12 Function' \
+          '13 Variable' \
+          '23 Struct' \
+          '24 Event' \
+          '26 TypeParameter'
+        exit 0
+        ;;
+      --help|-h)
+        printf '%s\n' \
+          'usage: vibe symbols <file.vibe>' \
+          '       vibe symbols --legend' \
+          'KIND integers are LSP SymbolKind; print the table with `vibe symbols --legend`.'
+        exit 0
+        ;;
+    esac
     [ "$#" -ge 1 ] || die "usage: vibe symbols <file.vibe>"
     src="$1"
     [ -f "$src" ] || die "not found: $src"

--- a/scripts/test_vibe_symbols.sh
+++ b/scripts/test_vibe_symbols.sh
@@ -19,13 +19,35 @@ export VIBE_HOME="$WORK/home"
 export VIBE_BIN_DIR="$WORK/bin"
 unset RUST_BACKTRACE || true
 
-bash install/install.sh >/dev/null 2>&1
-VIBE="$VIBE_BIN_DIR/vibe"
-[ -x "$VIBE" ] || { echo "FAIL: launcher not installed" >&2; exit 1; }
-
 pass=0; fail=0
 ok()   { echo "ok: $1"; pass=$((pass + 1)); }
 bad()  { echo "FAIL: $1" >&2; fail=$((fail + 1)); }
+
+# 0. #1944 leftover: `vibe symbols --legend` is launcher-only (no wasm).
+#    Pin the versioned KIND table (v1 / 2026-08-17) against the source
+#    launcher so a missing/wrong table fails in <1s without install.sh.
+#    One `KIND NAME` per line, no decoration, never empty.
+LAUNCHER="$ROOT_DIR/runtime/vibe"
+legend="$(bash "$LAUNCHER" symbols --legend)"
+expected=$'2 Module\n6 Method\n10 Enum\n11 Interface\n12 Function\n13 Variable\n23 Struct\n24 Event\n26 TypeParameter'
+if [ "$legend" = "$expected" ]; then
+  ok "symbols --legend prints KIND NAME table"
+else
+  bad "symbols --legend mismatch; got: $legend"
+fi
+
+help_out="$(bash "$LAUNCHER" symbols --help 2>&1 || true)"
+h_out="$(bash "$LAUNCHER" symbols -h 2>&1 || true)"
+if printf '%s\n' "$help_out" | grep -q -- '--legend' \
+   && printf '%s\n' "$h_out" | grep -q -- '--legend'; then
+  ok "symbols --help/-h point at --legend"
+else
+  bad "symbols --help/-h should mention --legend; got: $help_out / $h_out"
+fi
+
+bash install/install.sh >/dev/null 2>&1
+VIBE="$VIBE_BIN_DIR/vibe"
+[ -x "$VIBE" ] || { echo "FAIL: launcher not installed" >&2; exit 1; }
 
 # field(line, n) -> the n-th whitespace-separated field of a `NAME KIND START END`
 # row. `has_sym out name kind` asserts a row with that NAME and KIND exists.


### PR DESCRIPTION
Refs #1944.

## Summary

Last leftover slice of #1944: numeric LSP `SymbolKind` values from `vibe symbols` had no machine-readable / versioned legend.

- Documented the table next to the `vibe symbols` contract in `docs/editor-and-debugging.md` as **v1 / 2026-08-17**. KIND integers are LSP `SymbolKind`.
- `vibe symbols --legend` prints the same table, one `KIND NAME` per line, no decoration, never empty. `--help` / `-h` print usage and point at that table.
- File outline output is unchanged when `--legend` is absent. KIND numbers are not remapped.

```
2 Module
6 Method
10 Enum
11 Interface
12 Function
13 Variable
23 Struct
24 Event
26 TypeParameter
```

`--legend` / `--help` / `-h` are launcher-only (no wasm), same exemption as `context-pack`.

## Tests

TDD on `scripts/test_vibe_symbols.sh`: the `--legend` / `--help` / `-h` assertions run against the source launcher before `install/install.sh`, so a missing table fails in <1s.

```
bash runtime/vibe symbols --legend
```

matches the expected table. Outline cases in the same script were not re-run here (they rebuild a fresh compiler via `install/install.sh`); the file query path is untouched.

## Leftover

This was the last leftover on #1944 (symbols outline #2038, allocs source names #2043, doc-at structs #2044). The issue can close after this merges.