### PR TITLE
fix(lsp): mark unlocated diagnostic ranges synthetic (#1941)

### DIFF
--- a/lib/@vibe/lsp/lsp_diagnostics_test.vibe
+++ b/lib/@vibe/lsp/lsp_diagnostics_test.vibe
@@ -22,8 +22,9 @@
 // below requires the encoder to slice the same token #2024 locked.
 // Return-type mismatches on an offset-less literal (`EString`) now recover
 // the enclosing `fn` name instead of the synthetic `0:0-0:1` fallback.
-// Leftover on #1941: grep `line:0`; remaining unlocated type errors
-// (anonymous lambdas whose tail is a literal) still take the 0..1 fallback.
+// Remaining unlocated type errors (no `line L:` prefix) still need a valid
+// LSP range, but must mark it synthetic instead of looking like the first
+// character. Leftover on #1941: grep `line:0`.
 
 //# Imports
 
@@ -123,4 +124,31 @@ test "json diagnostics slice the same unknown identifier quux (#1941)" {
   assert(ec == endo)
   assert(String::substring(src, sc, ec) == token)
   assert(Json::string(Json::field(Json::index(parsed, 0), "message")) == "unknown name: quux")
+}
+
+/// `let x: Int = "s"` — the RHS is an `EString` with no AST offset, so
+/// `collect_all_diagnostics` emits no `line L:` prefix. Editors still need a
+/// valid range; the old fallback invented a plausible `0:0-0:1` (the first
+/// character). The range is now empty at the origin and `data.synthetic`
+/// marks it unavailable. Located diagnostics above must stay unchanged.
+test "unlocated type error uses an empty origin range marked synthetic (#1941)" {
+  let src = "let x: Int = \"s\""
+  inspect(lsp_diagnostics_json_string(src), "[{\"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":0,\"character\":0}},\"severity\":1,\"source\":\"vibe\",\"message\":\"binding type mismatch for x: expected Int, got String\",\"data\":{\"synthetic\":true}}]",)
+  let parsed = Json::parse(lsp_diagnostics_json_string(src))
+  assert(Json::length(parsed) == 1)
+  let diag = Json::index(parsed, 0)
+  let range = Json::field(diag, "range")
+  let rs = Json::field(range, "start")
+  let re = Json::field(range, "end")
+  let sl = Double::to_int(Json::number(Json::field(rs, "line")))
+  let sc = Double::to_int(Json::number(Json::field(rs, "character")))
+  let el = Double::to_int(Json::number(Json::field(re, "line")))
+  let ec = Double::to_int(Json::number(Json::field(re, "character")))
+  assert(sl == 0)
+  assert(sc == 0)
+  assert(el == 0)
+  assert(ec == 0)
+  let data = Json::field(diag, "data")
+  assert(Json::bool(Json::field(data, "synthetic")))
+  assert(Json::string(Json::field(diag, "message")) == "binding type mismatch for x: expected Int, got String")
 }

--- a/lib/@vibe/lsp/lsp_server.vibe
+++ b/lib/@vibe/lsp/lsp_server.vibe
@@ -618,17 +618,29 @@ fn lsp_parse_diag_line(source: String, msg: String) -> Json {
   }
 }
 
-/// Messages with no `line L:` prefix still land on `0..1`. Return-type
-/// mismatches on a named `fn` now carry a real span (#1941); remaining
-/// unlocated type errors (anonymous literal tails) still take this
-/// fallback. Leftover: an explicit synthetic/unavailable marker.
+/// Messages with no `line L:` prefix cannot claim a real source span.
+/// Editors still require a valid LSP range, so this uses an empty range at
+/// the origin (`0:0-0:0`) and marks `data.synthetic` so clients can tell it
+/// apart from a real first-character highlight. A structured effect-row
+/// fix already occupying `data` is kept: `synthetic` is merged in as a
+/// sibling field rather than replacing the payload.
+fn lsp_diag_fallback_data(msg: String) -> Json {
+  let fix = lsp_effect_row_mismatch_fix(msg)
+  match fix {
+    JObj(m) => JObj(Map::set(m, "synthetic", JBool(true))),
+    _ => JObj(Map::from_pairs([
+      ("synthetic", JBool(true))
+    ]))
+  }
+}
+
 fn lsp_diag_fallback(msg: String) -> Json {
   JObj(Map::from_pairs([
-    ("range", jrange(0, 0, 0, 1)),
+    ("range", jrange(0, 0, 0, 0)),
     ("severity", jnum_int(lsp_diag_severity(msg))),
     ("source", JStr("vibe")),
     ("message", JStr(msg)),
-    ("data", lsp_effect_row_mismatch_fix(msg))
+    ("data", lsp_diag_fallback_data(msg))
   ]))
 }
 


### PR DESCRIPTION
Refs #1941.

## Summary

Next short knife of #1941 after #2045. Fallback marker only — no located-diagnostic change, no grep change, no checker rewrite.

Named `fn f() -> Int { "s" }` already slices `f` (#2045). Remaining unlocated type errors (`let x: Int = "s"`, `1 + "s"`, …) still have no `line L:` prefix, so JSON/LSP took `lsp_diag_fallback` and lied as a plausible `0:0-0:1` (the first character).

Editors still require a valid range. The fallback is now an empty origin range (`0:0-0:0`) plus `data.synthetic: true`. If `data` already carries an effect-row fix (`add_with_clause`), `synthetic` is merged as a sibling field rather than replacing the payload.

Did not change located diagnostics (`line L:C:` / #2045 `[@fn=]` path). Did not change grep.

## Measured

Source that still hits fallback after #2045: `let x: Int = "s"` (`binding type mismatch`, `EString` offset `-1`, no `line ` prefix).

Before:

```
[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":1}},"severity":1,"source":"vibe","message":"binding type mismatch for x: expected Int, got String","data":null}]
```

After:

```
[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"severity":1,"source":"vibe","message":"binding type mismatch for x: expected Int, got String","data":{"synthetic":true}}]
```

`fn f() -> Int { "s" }` still slices `f` at `0:3-0:4` with `data: null`. Located effect-row mismatches still carry the `add_with_clause` fix and are not marked synthetic.

## Tests

TDD: changed the LSP snapshot first (red: still `0:0-0:1` / `data:null`), then `lsp_diag_fallback`.

```
bash scripts/vibe_test.sh lib/@vibe/lsp/lsp_diagnostics_test.vibe lib/@vibe/compiler/runtime/range_agreement_test.vibe
```

3 files, 12 tests passed (lsp package + range agreement).

## Leftover

- Grep `line:0` (other #1941 leftover).
- Unlocated type errors still have no real source span; they now say so instead of looking like the first character.