### PR TITLE
test: drop stale import-collision runtime debt (#1967)

### DIFF
--- a/fixtures/err_import_collides_with_local_let.vibe
+++ b/fixtures/err_import_collides_with_local_let.vibe
@@ -1,7 +1,0 @@
-let abs = (x: Int) -> Int { x }
-import @vibe/prelude {  abs  }
-
-abs(-1)
-
-__DATA__
-{"last":"-1"}

--- a/scripts/runtime_fixture_debt.tsv
+++ b/scripts/runtime_fixture_debt.tsv
@@ -3,4 +3,3 @@
 # reason. The generator rejects duplicates, malformed rows, and entries that
 # stop being runtime candidates, so a migrated/deleted fixture must remove its
 # debt row in the same change.
-fixtures/err_import_collides_with_local_let.vibe	generator debt: hoisting the import ahead of the top-level let changes the name-collision contract into block shadowing


### PR DESCRIPTION
## Summary

Leftover #1967 / #1966 slice: the last TSV row is a stale runtime fixture, not a missing value.

- Delete `fixtures/err_import_collides_with_local_let.vibe` (`let abs = (x: Int) -> Int { x }` then `import @vibe/prelude { abs }` then `abs(-1)` + `__DATA__.last "-1"`)
- Remove the last `scripts/runtime_fixture_debt.tsv` data row. The file is now header comments only

This is not a value we can keep:

- Original order with `fn main() -> Int { abs(-1) }` compiles, then traps OOB. `last: "-1"` is a lie
- Stripped original hits ADR-0069 (`top-level expressions are not allowed`)
- `fn main { abs(-1) }` is `return type mismatch: expected (), got Int`
- Import after a local `let` inside `test` is `unexpected token: import` / `expected test name string`
- Generator hoisting still turns the name-collision contract into block shadowing
- No inspect or `check_source_err_contains` snapshot preserves that contract. Import-collision checking is unchanged

Did not touch effect/handler rows (#1973). Did not invent `identity[Int]` or change the generator hoist.

## Tests

```
bash scripts/check_fixture_execution.sh
node scripts/generate_runtime_fixture_tests.test.mjs
```

Fixture-execution: 230 runtime expectations active, **0 reasoned debt**, all accounted for. Header-only TSV is accepted.

After merge, #1967 and #1966 can close: no non-effect runtime/compile-debt rows remain.

Refs #1967 #1966.