### PR TITLE
test: punch region through exception 70 times (#1937)

### DIFF
--- a/fixtures/region_unwind_repeat_test.vibe
+++ b/fixtures/region_unwind_repeat_test.vibe
@@ -1,0 +1,26 @@
+// #1937 leftover: 70 exception punches exceed the old 64-slot save table.
+// Completing without trap is the lock — skipped exits used to fill the
+// table so later regions stopped reclaiming. Each punch is the #2027
+// shape (handle outside, throw inside region) and returns the handler
+// value. Seed lacks the try_table wrap and leaks heap, but this shape
+// does not hang or trap there.
+
+test "punch region through exception 70 times" {
+  let mut acc = 0
+  let mut last = 0
+  let mut k = 0
+  while k < 70 {
+    last = handle {
+      region r {
+        throw("x")
+        1
+      }
+    } with Exception {
+      Throw(_) => 7
+    }
+    acc = acc + last
+    k = k + 1
+  }
+  inspect(acc, "490")
+  inspect(last, "7")
+}


### PR DESCRIPTION
## Summary

#1937 leftover after #2033: a bounded punch inspect so 64+ skipped exits cannot silently return.

`handle { region r { throw(...) } }` 70 times (above the old 64-slot save table). Each punch returns the #2027 handler value `7`. Completing without trap is the lock; `inspect(acc, "490")` and `inspect(last, "7")` pin the values.

try_table is already on checkout/stage2 (#2033). This does not rewrite it. After 70 punches on checkout/stage2 the test finishes; no leak-as-trap showed up, so the wrap is left alone. RC unchanged.

## Tests

```
bash scripts/vibe_test.sh fixtures/region_unwind_repeat_test.vibe
VIBE_TEST_CLI_WASM=<stage2> bash scripts/vibe_test.sh fixtures/region_unwind_repeat_test.vibe
VIBE_TEST_BACKEND=gc VIBE_TEST_CLI_WASM=<stage2> bash scripts/vibe_test.sh fixtures/region_unwind_repeat_test.vibe
```

| compiler | linear | gc |
|---|---|---|
| seed (no try_table wrap) | 1/1, no hang/trap | — |
| #2033 stage2 / checkout stage2 | 1/1 | 1/1 |

Seed still leaks heap without the wrap (574708 B on the 70×500 allocating path). This file does not invent a heap-byte API.

## Leftover

- Nested-handle rethrow on the gc lane (`handle { handle { throw } with { throw } }`) is the pre-existing `EHandle` hole from #2033. Same failure without a region.
- Heap boundedness stays in `compiler_gate.sh` (`region_throw_unwind_test.vibe`); this slice is the inspect lock only.

Refs #1937.