### PR TITLE
fix(grep): warn on unparseable files instead of silent skip (#1943)

### DIFF
--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -276,11 +276,13 @@ trailing punctuation and literals are not counted. Use `text`, not `[start,
 end)`, when you need to know what the match was.
 
 A file that does not parse is skipped, not fatal: a repo sweep must not stop at
-the first work-in-progress file. Recursion skips `_build`, `node_modules`,
-`dist`, `target`, dot-directories, and `deps` (where `vibe fetch` vendors
-packages — and, since relative imports nest, each vendored package's own
-`deps` below that). Naming one of those directly still searches it:
-`vibe grep --pattern '…' deps` asks for exactly that.
+the first work-in-progress file. The skip is reported on stderr
+(`warning: grep: skipped \`path\` because it could not be parsed`) so empty
+stdout still means no matches, not silently skipped input. Recursion skips
+`_build`, `node_modules`, `dist`, `target`, dot-directories, and `deps` (where
+`vibe fetch` vendors packages — and, since relative imports nest, each
+vendored package's own `deps` below that). Naming one of those directly still
+searches it: `vibe grep --pattern '…' deps` asks for exactly that.
 
 ---
 

--- a/lib/@vibe/compiler/runtime/grep_fs.vibe
+++ b/lib/@vibe/compiler/runtime/grep_fs.vibe
@@ -232,11 +232,16 @@ export fn grep_scan_fs_report(root: String, pattern: String, wheres: Array[Strin
     let path = Array::get(files, i)
     let source = Fs::read_file(path)
     // A file that does not parse is not a match and not a failure: a repo
-    // sweep must not stop at the first work-in-progress file.
+    // sweep must not stop at the first work-in-progress file. Report the
+    // skip on the warning sidecar so empty stdout still means no matches,
+    // not silently skipped input (#1943).
     let hits = handle {
       grep_file_hits(path, source, pat)
     } with Exception {
-      Throw(_) => grep_empty_hits()
+      Throw(_) => {
+        Array::push(warnings, String::concat("warning: grep: skipped `", String::concat(path, "` because it could not be parsed")))
+        grep_empty_hits()
+      }
     }
     if Array::length(hits) > 0 {
       let ctx = if typed {

--- a/lib/@vibe/compiler/runtime/grep_fs_test.vibe
+++ b/lib/@vibe/compiler/runtime/grep_fs_test.vibe
@@ -1,0 +1,38 @@
+//# Imports
+
+// Filesystem-tier `vibe grep` (#1572 / #1943). Lives next to grep_fs.vibe
+// rather than in grep_test.vibe: this file has to import grep_fs, and
+// grep_fs imports typecheck_fs, whose `ModuleJob` is declared on the
+// package contract. grep_test.vibe stays on the no-Fs seam so it can
+// keep driving the pattern language as a plain sibling leaf import.
+
+import ./grep_fs.vibe {
+  grep_scan_fs_report
+}
+
+import @vibe/core {
+  array_empty, inspect
+}
+
+//# Functions
+
+fn no_strings() -> Array[String] {
+  array_empty()
+}
+
+//# Tests
+
+test "grep_scan_fs_report: unparseable file is skipped with a warning, not an abort (#1943)" {
+  // The unparseable file is first in directory order so a silent abort
+  // would drop the good file too. Empty stdout still means no matches;
+  // the skip itself belongs on the warning sidecar.
+  let dir = "_build/vibe_grep_unparsed_sweep"
+  let bad = String::concat(dir, "/a_unparsed.vibe")
+  let good = String::concat(dir, "/b_good.vibe")
+  Fs::mkdir_p(dir)
+  Fs::write_file(bad, "fn broken( {\n")
+  Fs::write_file(good, "let n = Array::length([1])\n")
+  let (hits, warn) = grep_scan_fs_report(dir, "Array::length($(x:exp))", no_strings(), no_strings(), "", false)
+  inspect(hits, String::concat(good, ":1:9: Array::length([1])\t$x=[1]\n"))
+  inspect(warn, String::concat("warning: grep: skipped `", String::concat(bad, "` because it could not be parsed\n")))
+}


### PR DESCRIPTION
Refs #1943.

## Summary

Leftover slice of #1943: report skipped/unparseable files without aborting a repository sweep. No perform-vs-throw matching, no declaration patterns, no capture ranges.

`grep_scan_fs_report` already treated a parse/match throw as "not a match" and kept sweeping, but it swallowed the exception with no warning. Typed-tier type errors already push `warning: grep: skipped \`path\` because it could not be typed: ...` and the CLI prints `$out.warn` on stderr. Parse failures now do the same:

`warning: grep: skipped \`<path>\` because it could not be parsed`

The warning stays on the sidecar (stderr via the existing CLI path). Empty matches stdout still means no matches, not silently skipped input.

## Test

`lib/@vibe/compiler/runtime/grep_fs_test.vibe` scans a directory with one unparseable `.vibe` file (first in directory order) and one good file. Matches still come from the good file; the report's warning string contains the bad path. Red was an empty warning sidecar.

## Leftover on #1943

- Distinguish source `perform` from source `throw`
- Useful partial handle / declaration patterns, or reject them with actionable syntax
- Complete capture ranges and an explicit synthetic/source distinction