### PR TITLE
fix(lint): SessionStart provides a working vibe grep (#1988)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -171,6 +171,16 @@ fi
 if [ -f "$PROJECT_DIR/scripts/ensure_generated.sh" ]; then
   if (cd "$PROJECT_DIR" && bash scripts/ensure_generated.sh >/dev/null 2>&1); then
     echo "[session-start] generated compiler artifacts ready"
+    # #1988: `runtime/vibe` does not run in remote sessions (no bin/viberun).
+    # Persist a host-runner invoker only after a real grep probe succeeds, so
+    # we never hand review-lint a lying VIBE_REVIEW_LINT_GREP_BIN.
+    GREP_BIN="$PROJECT_DIR/scripts/vibe_grep_bin.sh"
+    if [ -f "$GREP_BIN" ] && bash "$GREP_BIN" --probe >/dev/null 2>&1; then
+      persist_env "VIBE_REVIEW_LINT_GREP_BIN=$GREP_BIN"
+      echo "[session-start] review-lint grep: $GREP_BIN"
+    else
+      echo "[session-start] WARNING: vibe grep probe failed; leaving VIBE_REVIEW_LINT_GREP_BIN unset (review AST tier will skip)" >&2
+    fi
   else
     echo "[session-start] WARNING: ensure_generated.sh failed; run it manually before building" >&2
   fi

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -270,6 +270,8 @@ local lintReviewRegressions =
   scriptTask("lint-review-regressions", "scripts/lint_review_regressions.sh")
 local testLintReviewRegressions =
   scriptTask("test-lint-review-regressions", "scripts/lint_review_regressions_test.sh")
+local testSessionStartGrep =
+  scriptTask("test-session-start-grep", "scripts/session_start_grep_test.sh")
 local testPreCommit = scriptTask("test-pre-commit", "scripts/precommit_test.sh")
 local testReviewLintVibex = new Task {
   name = "test-review-lint-vibex"
@@ -1236,6 +1238,7 @@ local releaseCheck = new Task {
     testDocPathCitations
     testLintArchitecture
     testLintReviewRegressions
+    testSessionStartGrep
     testPreCommit
     checkMethodStyleNaming
     doctestGated
@@ -1284,6 +1287,7 @@ tasks {
   testLintArchitecture
   lintReviewRegressions
   testLintReviewRegressions
+  testSessionStartGrep
   testPreCommit
   testReviewLintVibex
   lintTrackedExperimentNames

--- a/scripts/session_start_grep_test.sh
+++ b/scripts/session_start_grep_test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Self-test for #1988 option 1: SessionStart must persist a working
+# VIBE_REVIEW_LINT_GREP_BIN, and scripts/vibe_grep_bin.sh must speak
+# `vibe grep` without a native runtime/vibe runner.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$ROOT_DIR/.claude/hooks/session-start.sh"
+GREP_BIN="$ROOT_DIR/scripts/vibe_grep_bin.sh"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/vibe_session_start_grep.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "session-start-grep self-test: FAIL: $*" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Invoker: fail closed, no `ok`, same CLI surface review_lint.vibex uses.
+# ---------------------------------------------------------------------------
+if [ ! -f "$GREP_BIN" ]; then
+  fail "missing $GREP_BIN"
+fi
+
+: > "$TMP/probe.vibe"
+printf 'fn probe() {\n  0\n}\n' > "$TMP/probe.vibe"
+
+run_grep() {
+  local status=0
+  : > "$TMP/grep.out"
+  : > "$TMP/grep.err"
+  VIBE_CLI_WASM="${VIBE_CLI_WASM-}" \
+    bash "$GREP_BIN" "$@" >"$TMP/grep.out" 2>"$TMP/grep.err" || status=$?
+  return "$status"
+}
+
+# Explicit missing compiler: do not fall through to a lying success.
+if VIBE_CLI_WASM="$TMP/missing-compiler.wasm" run_grep grep --pattern 'fn($(x:exp))' "$TMP/probe.vibe"; then
+  fail "vibe_grep_bin.sh succeeded with a missing VIBE_CLI_WASM"
+fi
+if grep -qx 'ok' "$TMP/grep.out" "$TMP/grep.err"; then
+  fail "vibe_grep_bin.sh printed ok after a missing compiler"
+fi
+
+# Missing pattern is a usage error, not a silent skip.
+if run_grep grep "$TMP/probe.vibe"; then
+  fail "vibe_grep_bin.sh accepted grep without --pattern"
+fi
+
+# --help must not need wasm (cheap probe surface).
+if ! VIBE_CLI_WASM="$TMP/missing-compiler.wasm" run_grep grep --help; then
+  fail "vibe_grep_bin.sh grep --help should exit 0 without a compiler"
+fi
+if ! grep -q -- '--pattern' "$TMP/grep.out"; then
+  fail "vibe_grep_bin.sh --help did not mention --pattern"
+fi
+if grep -q 'runner-should-not-run' "$TMP/grep.out" "$TMP/grep.err"; then
+  fail "vibe_grep_bin.sh --help invoked a runner"
+fi
+
+# --probe with an unusable compiler must fail closed.
+if VIBE_CLI_WASM="$TMP/missing-compiler.wasm" run_grep --probe; then
+  fail "vibe_grep_bin.sh --probe succeeded without a compiler"
+fi
+if grep -qx 'ok' "$TMP/grep.out" "$TMP/grep.err"; then
+  fail "vibe_grep_bin.sh --probe printed ok after failure"
+fi
+
+# ---------------------------------------------------------------------------
+# SessionStart persist / honesty.
+# ---------------------------------------------------------------------------
+FAKE="$TMP/fake-project"
+mkdir -p "$FAKE/scripts"
+
+cat > "$FAKE/scripts/ensure_generated.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE/scripts/ensure_generated.sh"
+
+cat > "$FAKE/scripts/install_wasmtime_release.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "session-start-grep self-test: install_wasmtime_release.sh should not run" >&2
+exit 1
+EOF
+chmod +x "$FAKE/scripts/install_wasmtime_release.sh"
+
+cat > "$FAKE/scripts/vibe_grep_bin.sh" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--probe" ]; then
+  if [ -f "$(dirname "$0")/.probe-fail" ]; then
+    echo "probe failed" >&2
+    exit 1
+  fi
+  exit 0
+fi
+echo "ok"
+exit 0
+EOF
+chmod +x "$FAKE/scripts/vibe_grep_bin.sh"
+
+run_hook() {
+  local env_file="$1"
+  : > "$env_file"
+  HOME="$TMP/home" \
+    CLAUDE_CODE_REMOTE=true \
+    CLAUDE_PROJECT_DIR="$FAKE" \
+    CLAUDE_ENV_FILE="$env_file" \
+    bash "$HOOK"
+}
+
+# Local sessions must not persist anything.
+: > "$TMP/local.env"
+if ! HOME="$TMP/home" CLAUDE_PROJECT_DIR="$FAKE" CLAUDE_ENV_FILE="$TMP/local.env" bash "$HOOK"; then
+  fail "SessionStart without CLAUDE_CODE_REMOTE exited non-zero"
+fi
+if [ -s "$TMP/local.env" ]; then
+  fail "SessionStart without CLAUDE_CODE_REMOTE wrote $TMP/local.env"
+fi
+
+# Successful probe persists the invoker path.
+if ! out="$(run_hook "$TMP/ok.env" 2>&1)"; then
+  echo "$out" >&2
+  fail "SessionStart with a working probe exited non-zero"
+fi
+if ! grep -q "VIBE_REVIEW_LINT_GREP_BIN=$FAKE/scripts/vibe_grep_bin.sh" "$TMP/ok.env"; then
+  echo "$out" >&2
+  cat "$TMP/ok.env" >&2
+  fail "SessionStart did not persist VIBE_REVIEW_LINT_GREP_BIN after a successful probe"
+fi
+
+# Failed probe: WARNING, var unset (same honesty as #2034).
+: > "$FAKE/scripts/.probe-fail"
+if ! out="$(run_hook "$TMP/fail.env" 2>&1)"; then
+  echo "$out" >&2
+  fail "SessionStart with a failed probe must still exit 0"
+fi
+if grep -q 'VIBE_REVIEW_LINT_GREP_BIN=' "$TMP/fail.env"; then
+  echo "$out" >&2
+  cat "$TMP/fail.env" >&2
+  fail "SessionStart persisted VIBE_REVIEW_LINT_GREP_BIN after a failed probe"
+fi
+if ! printf '%s\n' "$out" | grep -q 'WARNING'; then
+  echo "$out" >&2
+  fail "SessionStart did not print a WARNING when the grep probe failed"
+fi
+
+# ensure_generated failure: do not persist a lying path.
+rm -f "$FAKE/scripts/.probe-fail"
+cat > "$FAKE/scripts/ensure_generated.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+if ! out="$(run_hook "$TMP/nogen.env" 2>&1)"; then
+  echo "$out" >&2
+  fail "SessionStart with a failed ensure_generated must still exit 0"
+fi
+if grep -q 'VIBE_REVIEW_LINT_GREP_BIN=' "$TMP/nogen.env"; then
+  echo "$out" >&2
+  cat "$TMP/nogen.env" >&2
+  fail "SessionStart persisted VIBE_REVIEW_LINT_GREP_BIN after ensure_generated failed"
+fi
+
+echo "session-start-grep self-test: ok"

--- a/scripts/vibe_grep_bin.sh
+++ b/scripts/vibe_grep_bin.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# `vibe grep` invoker for checkouts that have no native `runtime/vibe` runner.
+#
+# review_lint.vibex calls `$GREP_BIN grep --json --pattern '<pat>' <root>`.
+# This script speaks that CLI and drives `cli_main` through the same host
+# runner the unit/gate scripts use (`scripts/run_wasm_vibe_host_runner.sh`),
+# not `bin/viberun`. Exit non-zero if grep cannot run. Do not print `ok`.
+#
+# Used as VIBE_REVIEW_LINT_GREP_BIN from the SessionStart hook (#1988).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+die() {
+  echo "vibe-grep-bin: $*" >&2
+  exit 1
+}
+
+print_help() {
+  cat <<'EOF'
+vibe grep [flags] --pattern '<pattern>' [paths...]
+
+Structural AST search. Metavariables are `$(name:kind)`, kind = exp / id / const / arg / args / pat / type.
+Unlike moongrep / ast-grep, the filters run on the CHECKER's answers, not on the grammar alone:
+  --where '$x : Array[Int]'    the capture's INFERRED type (`_` wildcard)
+  --where '$f = Iterator::map' the capture's RESOLVED name
+  --where-row '$f with Async' / '$f without Async'
+                               the capture's effect ROW
+  --only-ill-typed / --only-well-typed
+                               keep matches in declarations that do (not) type-check
+  --json                       emit matches as a JSON array
+
+Empty output = no match. A report, not a failure: only a bad pattern or a
+bad filter is an error. This invoker fails closed if the compiler wasm or
+host runner cannot run grep at all.
+EOF
+}
+
+pick_cli_wasm() {
+  if [ -n "${VIBE_CLI_WASM:-}" ]; then
+    if [ -f "$VIBE_CLI_WASM" ]; then
+      printf '%s' "$VIBE_CLI_WASM"
+      return 0
+    fi
+    die "compiler wasm not found: $VIBE_CLI_WASM"
+  fi
+  local candidate
+  candidate="$(ls -t "$ROOT_DIR"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -1 || true)"
+  if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+    printf '%s' "$candidate"
+    return 0
+  fi
+  candidate="$(ls -t "$ROOT_DIR"/_build/selfhost/generations/*/stage1.wasm 2>/dev/null | head -1 || true)"
+  if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+    printf '%s' "$candidate"
+    return 0
+  fi
+  if [ -f "$ROOT_DIR/_build/ci-artifacts/stage2.wasm" ]; then
+    printf '%s' "$ROOT_DIR/_build/ci-artifacts/stage2.wasm"
+    return 0
+  fi
+  if [ -f "$ROOT_DIR/bootstrap/seed/compiler.wasm" ]; then
+    printf '%s' "$ROOT_DIR/bootstrap/seed/compiler.wasm"
+    return 0
+  fi
+  die "no compiler wasm (set VIBE_CLI_WASM, build a stage, or run scripts/ensure_seed.sh)"
+}
+
+run_grep() {
+  local g_pattern="" g_json=0 g_only="" g_where="" g_where_row=""
+  local g_paths=()
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --help|-h)
+        print_help
+        exit 0
+        ;;
+      --pattern)
+        [ "$#" -ge 2 ] || die "vibe grep: --pattern needs an argument"
+        g_pattern="$2"
+        shift 2
+        ;;
+      --pattern=*)
+        g_pattern="${1#--pattern=}"
+        shift
+        ;;
+      --json|--output-json)
+        g_json=1
+        shift
+        ;;
+      --where)
+        [ "$#" -ge 2 ] || die "vibe grep: --where needs an argument"
+        g_where="$g_where$2"$'\n'
+        shift 2
+        ;;
+      --where=*)
+        g_where="$g_where${1#--where=}"$'\n'
+        shift
+        ;;
+      --where-row)
+        [ "$#" -ge 2 ] || die "vibe grep: --where-row needs an argument"
+        g_where_row="$g_where_row$2"$'\n'
+        shift 2
+        ;;
+      --where-row=*)
+        g_where_row="$g_where_row${1#--where-row=}"$'\n'
+        shift
+        ;;
+      --only-ill-typed)
+        g_only="ill"
+        shift
+        ;;
+      --only-well-typed)
+        g_only="well"
+        shift
+        ;;
+      --)
+        shift
+        while [ "$#" -gt 0 ]; do
+          g_paths+=("$1")
+          shift
+        done
+        ;;
+      -*)
+        die "vibe grep: unknown flag: $1"
+        ;;
+      *)
+        g_paths+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  [ -n "$g_pattern" ] || die "usage: vibe grep --pattern '<pattern>' [--where '\$x : T'] [--where-row '\$f with E'] [--only-ill-typed|--only-well-typed] [--json] [paths...]"
+  [ "${#g_paths[@]}" -gt 0 ] || g_paths=(".")
+  if [ "$g_json" = "1" ] && [ "${#g_paths[@]}" -gt 1 ]; then
+    die "vibe grep --json: one path at a time (JSON output is a single array)"
+  fi
+
+  local runner="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
+  [ -f "$runner" ] || die "missing host runner: $runner"
+
+  local cli
+  cli="$(pick_cli_wasm)"
+
+  local out err status g_path
+  out="$(mktemp -t vibe-grep-XXXXXX)"
+  err="$(mktemp -t vibe-grep-err-XXXXXX)"
+  trap 'rm -f "$out" "$out.diag" "$out.warn" "$err"' RETURN
+
+  for g_path in "${g_paths[@]}"; do
+    [ -e "$g_path" ] || die "not found: $g_path"
+    : >"$out"
+    : >"$out.diag"
+    : >"$out.warn"
+    : >"$err"
+    status=0
+    # Same adapter-mode contract as runtime/vibe's `grep)` case: VIBE_GREP=1
+    # plus the pattern/filter env vars, then cli_main(input, output).
+    if ! env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS \
+        -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
+        VIBE_GREP=1 \
+        VIBE_GREP_PATTERN="$g_pattern" \
+        VIBE_GREP_WHERE="$g_where" \
+        VIBE_GREP_WHERE_ROW="$g_where_row" \
+        VIBE_GREP_ONLY="$g_only" \
+        VIBE_GREP_JSON="$g_json" \
+        VIBE_IMPORT_ABI=raw \
+        VIBE_PREOPEN_DIR="${VIBE_PREOPEN_DIR:-$ROOT_DIR}" \
+        bash "$runner" --invoke cli_main "$cli" "$g_path" "$out" >/dev/null 2>"$err"; then
+      status=$?
+    fi
+    if [ -s "$out.diag" ]; then
+      echo "error: $(cat "$out.diag")" >&2
+      die "grep failed"
+    fi
+    if [ "$status" -ne 0 ] && [ ! -s "$out" ]; then
+      if [ -s "$err" ]; then
+        cat "$err" >&2
+      fi
+      die "grep could not run (cli=$cli status=$status)"
+    fi
+    if [ -s "$out.warn" ]; then
+      cat "$out.warn" >&2
+    fi
+    if [ -s "$out" ]; then
+      cat "$out"
+    fi
+  done
+}
+
+run_probe() {
+  local probe_dir probe_file output trimmed
+  probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibe-grep-probe.XXXXXX")"
+  probe_file="$probe_dir/probe.vibe"
+  # A call site, not a `fn ($(x:exp))` shape: `fn` is a declaration keyword
+  # and that pattern is a parse error. The gate uses this same call pattern.
+  cat > "$probe_file" <<'EOF'
+fn probe(x: Int) -> Int {
+  x
+}
+
+fn run() -> Int {
+  probe(1)
+}
+EOF
+  # A real pattern against a tiny file: --help only proves the shell parsed.
+  # JSON so a compiler that ignored VIBE_GREP and emitted wasm is rejected.
+  if ! output="$(run_grep --json --pattern '$(f:id)($(a:args))' "$probe_file")"; then
+    rm -rf "$probe_dir"
+    return 1
+  fi
+  rm -rf "$probe_dir"
+  trimmed="$(printf '%s' "$output" | tr -d '[:space:]')"
+  case "$trimmed" in
+    \[*)
+      # Require a real hit so a stub that always writes `[]` cannot pass.
+      if printf '%s' "$output" | grep -q 'probe(1)'; then
+        return 0
+      fi
+      echo "vibe-grep-bin: probe did not find probe(1)" >&2
+      return 1
+      ;;
+    *)
+      echo "vibe-grep-bin: probe output is not a grep JSON result" >&2
+      return 1
+      ;;
+  esac
+}
+
+if [ "${1:-}" = "grep" ]; then
+  shift
+fi
+
+case "${1:-}" in
+  --probe)
+    run_probe
+    ;;
+  --help|-h)
+    print_help
+    ;;
+  *)
+    run_grep "$@"
+    ;;
+esac


### PR DESCRIPTION
Refs #1988.

## What changed

Option 1: SessionStart now persists a working `vibe grep` so the review-lint AST tier can run in remote sessions, instead of only warning (#2034).

- `scripts/vibe_grep_bin.sh` speaks the same CLI `review_lint.vibex` uses (`grep --json --pattern ... <root>`).
- It drives `cli_main` through `scripts/run_wasm_vibe_host_runner.sh` (same host runner as the unit/gate scripts), not a missing native `runtime/vibe`.
- Fail closed: non-zero if the compiler wasm or runner cannot run grep. Does not print `ok`.
- After `ensure_generated` succeeds, SessionStart probes with a real JSON pattern on a tiny file. Persist `VIBE_REVIEW_LINT_GREP_BIN` only if that probe finds a hit. On failure, print a WARNING and leave the var unset (same honesty as #2034).
- Does not build a stage2 in SessionStart. Does not change `review_lint.vibex` patterns.

The suggested `fn($(x:exp))` probe shape is a parse error (`fn` is a declaration keyword). The probe uses the gate's call pattern `$(f:id)($(a:args))` against a file that contains `probe(1)`.

## Tests

TDD on `scripts/session_start_grep_test.sh`:

- Invoker fail-closed with a missing `VIBE_CLI_WASM`, no `ok`, `--help` without wasm.
- SessionStart persists the invoker only after a successful probe.
- Failed probe and failed `ensure_generated` leave the var unset and print WARNING.
- `CLAUDE_CODE_REMOTE` unset is a no-op.

Local seed probe (`bash scripts/vibe_grep_bin.sh --probe`) succeeded on this machine.

## Leftover

None for #1988 once this merges. If a remote checkout's seed/CLI cannot run grep, the hook leaves the var unset and #2034's loud skip remains the honest fallback.