### PR TITLE
docs: use StringBuilder::build in the effects guide (#1950)

### DIFF
--- a/docs/guide/when-to-use-effects.md
+++ b/docs/guide/when-to-use-effects.md
@@ -38,7 +38,7 @@ let join: (Array[String], String) -> String = (parts, sep) -> {
     StringBuilder::push(sb, part)
     first = false
   }
-  StringBuilder::freeze(sb)
+  StringBuilder::build(sb)
 }
 ```
 


### PR DESCRIPTION
Refs #1950.

The join example in `docs/guide/when-to-use-effects.md` still ended with `StringBuilder::freeze(sb)`. The implemented preferred terminal is `StringBuilder::build` (cheatsheet / ADR-0101; `freeze` is an alias). This PR changes that call only.

Did not touch ArrayBuilder examples or compiler source.

After this change, no user-facing guide/tutorial block teaches `StringBuilder::freeze` as the verb to write. Remaining mentions:

- `docs/cheatsheet.md` — alias note (`freeze` still works; write `build`)
- `docs/adr.md` / `docs/archive/` — decision and history

**Leftover (not this PR)**
- ADR-0101 still wants `build` as the family verb. `ArrayBuilder::build` / `MapBuilder::build` are not implemented; compiler source must keep `freeze` until a bootstrap bump.