### PR TITLE
fix(install): materialize @vibe/prelude into VIBE_LIB

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -35,7 +35,8 @@ This will:
 3. AOT-compile it to `vibe-cli.cwasm` for this machine,
 4. install the launcher into the toolchain + the dispatcher onto your `PATH`,
 5. materialize the stdlib packages (`@vibe/core` / `@vibe/ast` /
-   `@vibe/parser`) into `$VIBE_HOME/lib`, hash-verified (`vibe hash`).
+   `@vibe/parser` / `@vibe/prelude` / `@vibe/wit_runtime`) into
+   `$VIBE_HOME/lib`, hash-verified (`vibe hash`).
 
 Then:
 
@@ -66,7 +67,7 @@ $VIBE_HOME/                 (default: ~/.vibe)
 │       ├── vibe-cli.cwasm  # host-specific AOT build (`vibe self update`)
 │       └── lsp_server.js…  # editor tooling
 ├── lib/
-│   └── @vibe/{core,ast,parser}/   # stdlib packages — the default VIBE_LIB
+│   └── @vibe/{core,ast,parser,prelude,wit_runtime}/   # stdlib packages — the default VIBE_LIB
 │                                  # resolution root (ADR-0065 #751), SHARED
 │                                  # across toolchains (content-addressed)
 └── cache/                  # package fetch cache (#754) — shared

--- a/docs/tutorial/01_values_functions-ja.vibe.md
+++ b/docs/tutorial/01_values_functions-ja.vibe.md
@@ -12,10 +12,8 @@ English version: [01_values_functions.vibe.md](01_values_functions.vibe.md) (can
 
 束縛は `let`。型注釈は省略できる (推論される)。
 
-`import @vibe/prelude` はリポジトリの `lib/` か pin 済みパッケージが必要です。
-ツリーの外では [install.md](../install.md) と同じホスト組み込み
-`Stdout::write_stream` を使います:
-`fn main with Stdout { Stdout::write_stream("42\n") }`。
+`import @vibe/prelude` はインストール済み toolchain（`~/.vibe/lib`）にも
+リポジトリの `lib/` にもあります。
 
 ```vibe run
 import @vibe/prelude {

--- a/docs/tutorial/01_values_functions.vibe.md
+++ b/docs/tutorial/01_values_functions.vibe.md
@@ -13,10 +13,8 @@ locally, run
 
 `let` binds. The type annotation is optional — it is inferred.
 
-`import @vibe/prelude` needs the repository `lib/` or a pinned package.
-Outside the tree, use the host builtin `Stdout::write_stream` as in
-[install.md](../install.md):
-`fn main with Stdout { Stdout::write_stream("42\n") }`.
+`import @vibe/prelude` is on an installed toolchain (`~/.vibe/lib`) as
+well as in the repository `lib/`.
 
 ```vibe run
 import @vibe/prelude {

--- a/docs/tutorial/README-ja.md
+++ b/docs/tutorial/README-ja.md
@@ -31,8 +31,8 @@ echo 'fn main with Stdout { Stdout::write_stream("42\\n") }' > hello.vibex
 vibe run hello.vibex        # -> 42
 ```
 
-各章の `import @vibe/prelude` はリポジトリまたは pin 済みパッケージが必要で、
-素のインストールにはそのパッケージは含まれません。
+各章の `import @vibe/prelude` はインストール済み toolchain（`~/.vibe/lib`）
+にもリポジトリの `lib/` にもあります。
 
 | 章 | テーマ |
 | --- | --- |

--- a/docs/tutorial/README.md
+++ b/docs/tutorial/README.md
@@ -31,8 +31,8 @@ echo 'fn main with Stdout { Stdout::write_stream("42\\n") }' > hello.vibex
 vibe run hello.vibex        # -> 42
 ```
 
-`import @vibe/prelude` in the chapters below needs the repo or a pinned
-package. A fresh install does not ship that package.
+`import @vibe/prelude` in the chapters below resolves from an installed
+toolchain (`~/.vibe/lib`) as well as from the repository `lib/`.
 
 | Chapter | Topic |
 | --- | --- |

--- a/install/install.sh
+++ b/install/install.sh
@@ -13,7 +13,7 @@
 #   $VIBE_HOME/toolchain                      default toolchain name
 #   $VIBE_HOME/toolchains/<name>/bin/{vibe,viberun}
 #   $VIBE_HOME/toolchains/<name>/lib/{vibe-cli.wasm,vibe-cli.cwasm,lsp...}
-#   $VIBE_HOME/lib/@vibe/{core,ast,parser,wit_runtime}
+#   $VIBE_HOME/lib/@vibe/{core,ast,parser,prelude,wit_runtime}
 #   $VIBE_HOME/cache/...
 #
 # Usage:
@@ -347,10 +347,11 @@ fi
 if [ "$DO_STDLIB" = "1" ]; then
   # @vibe/wit_runtime is in this list because it is USER-FACING: #1324 removed
   # `Result` from the language, and a WIT-facing fallible export has to import
-  # it (docs/effect-wit-mapping.md tells users to). A package documented for
-  # users but materialized only in a repo checkout would resolve in dev and
-  # fail on an installed toolchain.
-  for pkg in @vibe/core @vibe/ast @vibe/parser @vibe/wit_runtime; do
+  # it (docs/effect-wit-mapping.md tells users to). @vibe/prelude is the same
+  # class (#1949): chapter-01's `import @vibe/prelude { stdout_write }` is the
+  # documented form. A package documented for users but materialized only in a
+  # repo checkout would resolve in dev and fail on an installed toolchain.
+  for pkg in @vibe/core @vibe/ast @vibe/parser @vibe/prelude @vibe/wit_runtime; do
     src="$ROOT_DIR/lib/$pkg"
     [ -f "$src/index.vpkg" ] || [ -f "$src/index.vibei" ] || { say "stdlib $pkg missing in checkout; skipped"; continue; }
     src_hash="$("$TC_DIR/bin/vibe" hash "$src" | awk '/^package /{print $2}')"

--- a/scripts/test_vibe_install_hello.sh
+++ b/scripts/test_vibe_install_hello.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # #1949: the documented first program must compile and run from a directory
 # that cannot see the repository lib/ tree. Host-builtin Stdout::write_stream
-# only — the installed toolchain does not ship @vibe/prelude.
+# only — this smoke does not install. The installed-toolchain prelude import
+# is pinned in tests/integration/install/install_test.sh.
 #
 # A full `vibe run hello.vibex` needs the install layout (viberun +
 # vibe-cli.wasm). This matches scripts/vibe_run_smoke.sh (seed compile +

--- a/tests/integration/install/install_test.sh
+++ b/tests/integration/install/install_test.sh
@@ -51,6 +51,9 @@ VIBE="$VIBE_BIN_DIR/vibe"
 # users to import it for a WIT-facing fallible export, so an installed
 # toolchain that lacks it makes documented code fail to resolve.
 [ -f "$VIBE_HOME/lib/@vibe/wit_runtime/index.vpkg" ] || { echo "FAIL: stdlib @vibe/wit_runtime not materialized" >&2; exit 1; }
+# @vibe/prelude is user-facing (#1949): chapter-01's first import form is
+# `import @vibe/prelude { stdout_write }`. A fresh install must ship it.
+[ -f "$VIBE_HOME/lib/@vibe/prelude/index.vpkg" ] || { echo "FAIL: stdlib @vibe/prelude not materialized" >&2; exit 1; }
 echo "ok: install produced launcher + .cwasm + default toolchain + stdlib"
 pass=$((pass + 1))
 
@@ -67,6 +70,16 @@ printf 'test "bad" {\n  assert_eq(2 + 2, 5)\n}\n' > "$proj/fail_test.vibe"
 check "vibe run hello" "42" "$(run_number "$proj/hello.vibex")"
 # run: multi-file import resolution
 check "vibe run app (import)" "42" "$(run_number "$proj/app.vibex")"
+
+# #1949: chapter-01 prelude import must work from a temp project with only
+# the installed toolchain. cd so repo lib/ is not the workspace lib, and
+# drop an inherited VIBE_LIB so resolution is $VIBE_HOME/lib.
+printf 'import @vibe/prelude {\n  stdout_write\n}\nfn main with Stdout {\n  stdout_write("42\\n")\n}\n' > "$proj/prelude_hello.vibex"
+(
+  cd "$proj"
+  unset VIBE_LIB || true
+  check "vibe run prelude import (no repo lib/)" "42" "$(run_number "$proj/prelude_hello.vibex")"
+)
 
 # compile: produces a wasm
 "$VIBE" compile "$proj/hello.vibex" -o "$proj/hello.wasm" >/dev/null 2>&1 || true


### PR DESCRIPTION
Refs #1949.

Option 1 leftover: install `@vibe/prelude` with the toolchain so the chapter-01 form `import @vibe/prelude { stdout_write }` works in a fresh empty directory.

## Changes
- `install/install.sh`: add `@vibe/prelude` to the materialized stdlib loop (same copy rules as core/ast/parser/wit_runtime: `index.vpkg` + non-test/non-bench `*.vibe`). Header comment lists the new set.
- `docs/install.md`: layout and materialize list include `prelude` (and `wit_runtime`).
- `tests/integration/install/install_test.sh`: assert `$VIBE_HOME/lib/@vibe/prelude/index.vpkg`, then `vibe run` the chapter-01 import from a temp project after `cd` so repo `lib/` is not the workspace lib. Expects stdout `42`.
- Tutorial leftover: one-line note in chapter 01 (+ ja) and the tutorial README leftover sentence. Examples are unchanged.

## Smoke
In a temp dir with only the installed toolchain (`VIBE_HOME` prefix, `VIBE_LIB` unset, cwd is not the repo):

```
import @vibe/prelude {
  stdout_write
}
fn main with Stdout {
  stdout_write("42\n")
}
```

`vibe run` prints `42`. `tests/integration/install/install_test.sh` is 55/0 including this case. Host-builtin `scripts/test_vibe_install_hello.sh` still passes.

#1949 can close: both documented first programs now work with only an installed toolchain.