### PR TITLE
fix(grep): do not match throw when the pattern says perform (#1943)

### DIFF
--- a/lib/@vibe/compiler/runtime/grep.vibe
+++ b/lib/@vibe/compiler/runtime/grep.vibe
@@ -103,9 +103,15 @@ export struct GrepHit {
 /// A compiled pattern: the parsed template plus the metavariable names it
 /// declares, in source order (so `--where` can reject a name the pattern
 /// never captures instead of silently filtering nothing out).
+///
+/// `origin` is `"throw"` or `"perform"` when the pattern string's first
+/// identifier (after whitespace) is that keyword, else `""`. `throw(x)` and
+/// `perform Exception::Throw(x)` parse to the same AST, so a keyword-named
+/// pattern has to consult the source token at each hit (#1943).
 export struct GrepPattern {
   template: Expr;
-  vars: Array[String]
+  vars: Array[String];
+  origin: String
 }
 
 /// Everything the typed filters need about ONE file. `type_error` is "" when
@@ -317,6 +323,31 @@ fn grep_check_holes(items: Array[Expr]) -> Unit with Exception {
   }
 }
 
+/// The pattern string's first identifier after leading whitespace, when that
+/// identifier is `throw` or `perform`. Anything else — a metavar, a wrapping
+/// call, a different name — is `""` and does not filter hits.
+fn grep_pattern_origin(pattern: String) -> String {
+  let len = String::length(pattern)
+  let mut i = 0
+  while i < len && (String::char_code_at(pattern, i) == ' ' || String::char_code_at(pattern, i) == 9 || String::char_code_at(pattern, i) == 10 || String::char_code_at(pattern, i) == 13) {
+    i = i + 1
+  }
+  if i >= len || !grep_is_ident_char(String::char_code_at(pattern, i)) {
+    ""
+  } else {
+    let start = i
+    while i < len && grep_is_ident_char(String::char_code_at(pattern, i)) {
+      i = i + 1
+    }
+    let word = String::substring(pattern, start, i)
+    if word == "throw" || word == "perform" {
+      word
+    } else {
+      ""
+    }
+  }
+}
+
 /// Parse a pattern into its template expression. A pattern that parses to
 /// anything other than exactly one expression statement is rejected here with
 /// the shape it actually produced, rather than being matched against nothing.
@@ -340,7 +371,7 @@ export fn grep_compile_pattern(pattern: String) -> GrepPattern with Exception {
       SExpr(e) => {
         grep_validate_holes(e)
         GrepPattern::{
-          template: e, vars: vars
+          template: e, vars: vars, origin: grep_pattern_origin(pattern)
         }
       },
       _ => throw("grep pattern: must be a single EXPRESSION — declaration patterns (`fn`, top-level `let`, `enum`, ...) are not supported yet; use `vibe symbols` for declarations")
@@ -2044,12 +2075,60 @@ fn grep_render_json(ctx: GrepTyped, typed: Bool, hit: GrepHit, line: Int, col: I
 
 //# Functions — per-file driver
 
+/// Whole-word `throw` / `perform` at `offset`, or `""` when the bytes there
+/// are some other token (or the offset is unlocated).
+fn grep_source_keyword_at(source: String, offset: Int) -> String {
+  let len = String::length(source)
+  if offset < 0 || offset >= len {
+    ""
+  } else if offset > 0 && grep_is_ident_char(String::char_code_at(source, offset - 1)) {
+    ""
+  } else if grep_source_word_at(source, offset, "throw") {
+    "throw"
+  } else if grep_source_word_at(source, offset, "perform") {
+    "perform"
+  } else {
+    ""
+  }
+}
+
+fn grep_source_word_at(source: String, offset: Int, word: String) -> Bool {
+  let len = String::length(source)
+  let wlen = String::length(word)
+  if offset + wlen > len {
+    false
+  } else if String::substring(source, offset, offset + wlen) != word {
+    false
+  } else {
+    offset + wlen == len || !grep_is_ident_char(String::char_code_at(source, offset + wlen))
+  }
+}
+
+fn grep_keep_origin_hits(source: String, origin: String, hits: Array[GrepHit]) -> Array[GrepHit] {
+  if origin == "" {
+    hits
+  } else {
+    let kept = grep_empty_hits()
+    let mut i = 0
+    while i < Array::length(hits) {
+      let hit = Array::get(hits, i)
+      if grep_source_keyword_at(source, hit.offset) == origin {
+        Array::push(kept, hit)
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    kept
+  }
+}
+
 export fn grep_file_hits(path: String, source: String, pat: GrepPattern) -> Array[GrepHit] with Exception {
   let (tokens, starts, _) = lex_with_offsets(source)
   let stmts = parse_program_located(tokens, starts, source)
   let out = grep_empty_hits()
   grep_walk_stmts(stmts, pat, path, out)
-  out
+  grep_keep_origin_hits(source, pat.origin, out)
 }
 
 export fn grep_needs_typing(wheres: Array[String], where_rows: Array[String], only: String) -> Bool {

--- a/lib/@vibe/compiler/runtime/grep_test.vibe
+++ b/lib/@vibe/compiler/runtime/grep_test.vibe
@@ -289,3 +289,34 @@ test "grep typed filters fail closed when a structurally matching file is ill-ty
   let ok = "let good: Int = 42\nlet arr = [\n  1\n]\nlet n = Array::length(arr)\n"
   inspect(scan_where(ok, "Array::length($(x:exp))", "$x : Array[Int]"), "a.vibe:5:9: Array::length(arr)\t$x=arr\n")
 }
+
+// #1943: `throw(x)` parses to the same AST as `perform Exception::Throw(x)`,
+// and the printer re-sugars both (plus `Error::Throw`) back to `throw(x)`.
+// A pattern that names one keyword must keep only sites that spell that
+// keyword; a pattern that names neither still matches both.
+fn throw_perform_src() -> String {
+  "fn f() -> Int {\n  throw(\"e\")\n}\nfn g() -> Int {\n  perform Exception::Throw(\"e\")\n}\nfn h() -> Int {\n  perform Error::Throw(\"e\")\n}\n"
+}
+
+test "grep: `throw` matches only the source `throw` site" {
+  inspect(scan(throw_perform_src(), "throw($(x:exp))"), "a.vibe:2:3: throw(\"e\")\t$x=\"e\"\n")
+}
+
+test "grep: `perform Exception::Throw` matches only the `perform` site" {
+  inspect(scan(throw_perform_src(), "perform Exception::Throw($(x:exp))"), "a.vibe:5:3: throw(\"e\")\t$x=\"e\"\n")
+}
+
+test "grep: `perform $(op:exp)` matches `perform`, not `throw`" {
+  inspect(scan(throw_perform_src(), "perform $(op:exp)"), "a.vibe:5:3: throw(\"e\")\t$op=Exception::Throw(\"e\")\na.vibe:8:3: throw(\"e\")\t$op=Error::Throw(\"e\")\n")
+}
+
+test "grep: `$(x:exp)` still matches both `throw` and `perform`" {
+  let out = scan(throw_perform_src(), "$(x:exp)")
+  inspect(String::contains(out, "a.vibe:2:3:"), "1")
+  inspect(String::contains(out, "a.vibe:5:3:"), "1")
+  inspect(String::contains(out, "a.vibe:8:3:"), "1")
+}
+
+test "grep: `perform Error::Throw` matches only that perform spelling" {
+  inspect(scan(throw_perform_src(), "perform Error::Throw($(x:exp))"), "a.vibe:8:3: throw(\"e\")\t$x=\"e\"\n")
+}


### PR DESCRIPTION
Refs #1943.

## Summary

Leftover slice of #1943: distinguish source `perform` from source `throw` when the pattern asks for either. No declaration patterns, no capture ranges.

`throw(x)` is parsed as `perform Exception::Throw(x)` — the same AST as the explicit spelling. Both sides of grep go through the ordinary parser, so a `throw(...)` pattern and a `perform Exception::Throw(...)` pattern compiled to the same template and matched both sites. The printer still re-sugars both back to `throw(x)` (untouched).

Fix: classify the pattern string's first identifier after whitespace (`throw` / `perform` / neither), store it on `GrepPattern.origin`, and after the structural match keep a hit only when the file source at `hit.offset` is that whole-word keyword. Applied in `grep_file_hits`, so `grep_scan_source` and the FS sweep both see it. No new AST fields, no EThrow, desugar unchanged.

## Test

`lib/@vibe/compiler/runtime/grep_test.vibe` — fixture with `throw("e")`, `perform Exception::Throw("e")`, and `perform Error::Throw("e")`.

Measured before (Red):

- `throw($(x:exp))` → 2 hits (throw + `Exception::Throw` perform)
- `perform Exception::Throw($(x:exp))` → 2 hits (same pair)
- `perform $(op:exp)` → 3 hits (throw + both performs)
- `perform Error::Throw($(x:exp))` → 1 hit (already isolated structurally)
- `$(x:exp)` → still includes both keywords

After: throw / Exception perform / Error perform are one site each; `perform $(op:exp)` keeps both perform sites and drops throw; `$(x:exp)` still matches all three.

`bash scripts/vibe_test.sh lib/@vibe/compiler/runtime/grep_test.vibe`

## Leftover on #1943

- Useful partial handle / declaration patterns, or reject them with actionable syntax
- Complete capture ranges and an explicit synthetic/source distinction