### PR TITLE
fix(check): warn on old collection type aliases

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -174,8 +174,9 @@ contract — this is a naming *rule*, not a per-type coincidence:
 旧綴りの**型注釈**も transparent alias として残る (#1700)。たとえば
 `let m: HashMap[String, Int] = HashMap::new_string()` は `@vibe/core` の
 `index.vpkg` 境界を越えて `MutMap[String, Int]` と同じ型になる。移行先は
-引き続き `Mut-` 名で、旧関数を使えば `vibe check` が警告する。型名だけを
-旧綴りにした場合は警告されないので、新規コードでは `Mut-` を直接書く。
+引き続き `Mut-` 名。型行に `#deprecated` を書くのは bootstrap bump 待ち
+(seed の契約パーサが `#` を拒む) なので、`vibe check` は言語側の表で
+同じ名前を警告する。`import { HashMap }` したファイルの注釈が対象。
 
 旧綴りの**関数**を使うと `vibe check` が移行先を名指しする `warning:` 行を
 出す (非致命、exit 0)。**これは #1262 follow-up で初めて実際に効くようになった**

--- a/fixtures/contract_conformance_test.vibe
+++ b/fixtures/contract_conformance_test.vibe
@@ -447,3 +447,42 @@ test "an opaque contract type MUST be defined by a sibling and stays accepted (#
   let errors = check_contract(decls, opaques, impls, type_defs)
   assert_eq(Array::length(errors), 0)
 }
+
+// Type aliases that exist only in index.vpkg never warned, so the old
+// spelling kept spreading. `#deprecated` on the contract row is the
+// marker `vibe check` can see — the parser has to skip it first.
+
+test "contract type alias may carry #deprecated" {
+  let src = "#deprecated(\"use MutMap\")\ntype HashMap[K, V] = MutMap[K, V]\nfn HashMap::new_string[V]() -> MutMap[String, V]"
+  let (decls, opaques, extra) = parse_contract_program(lex(src))
+  assert_eq(Array::length(decls), 1)
+  assert_eq(Array::length(opaques), 0)
+  assert_eq(Array::length(extra), 1)
+  let (dname, _) = Array::get(decls, 0)
+  assert_eq(dname, "HashMap::new_string")
+  match Array::get(extra, 0) {
+    STypeAlias(_, name, _, _) => assert_eq(name, "HashMap"),
+    _ => assert(false)
+  }
+}
+
+test "bare #deprecated in a contract is skipped the same way" {
+  let src = "#deprecated\ntype HashSet[T] = MutSet[T]"
+  let (_, _, extra) = parse_contract_program(lex(src))
+  assert_eq(Array::length(extra), 1)
+  match Array::get(extra, 0) {
+    STypeAlias(_, name, _, _) => assert_eq(name, "HashSet"),
+    _ => assert(false)
+  }
+}
+
+test "unknown # directive in a contract is rejected" {
+  let msg = handle {
+    let _ = parse_contract_program(lex("#nope\ntype X = Int"))
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "unsupported # directive"))
+  assert(String::contains(msg, "nope"))
+}

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -493,6 +493,10 @@ export fn check_deprecated_warnings_from_source_groups(input_path: String, sourc
   // every alias the ADR-0100 (3) collection rename shipped -- was invisible
   // here and the migration warning this function promises never appeared.
   let dep_sources = resolved_dep_sources(input_path, source_groups)
+  // A `.vpkg` reaches source_groups as a generated facade (and its type
+  // aliases as a materialized types module). `#deprecated` on a contract
+  // type alias lives only in the on-disk file, so re-read those paths.
+  append_raw_vpkg_dep_sources(input_path, source_groups, dep_sources)
   // Codex review (PR #1713, P2): the closure above is deliberately WIDE -- it
   // has to be, because a package publishes its markers from a sibling file the
   // entry never names. Wide marker COLLECTION plus a token-level scanner would
@@ -502,6 +506,27 @@ export fn check_deprecated_warnings_from_source_groups(input_path: String, sourc
   // name the entry actually IMPORTED. Markers the entry declares itself still
   // count unconditionally (a file deprecating its own helper needs no import).
   deprecated_warning_lines_visible(entry_source, dep_sources, Some(entry_imported_names(entry_stmts)))
+}
+
+/// Re-read every on-disk `.vpkg` in `groups` (except the entry itself) so
+/// `#deprecated` markers on contract-only type aliases are visible to the
+/// token scanner. The generated facade in `groups` does not preserve them.
+fn append_raw_vpkg_dep_sources(input_path: String, groups: Array[(String, Array[(String, String)])], out: Array[String]) -> Unit with Fs {
+  let mut gi = 0
+  while gi < Array::length(groups) {
+    let (_g, members) = Array::get(groups, gi)
+    let mut mi = 0
+    while mi < Array::length(members) {
+      let (path, _source) = Array::get(members, mi)
+      if path != input_path && String::ends_with(path, ".vpkg") && Fs::exists(path) {
+        Array::push(out, Fs::read_file(path))
+      } else {
+        ()
+      }
+      mi = mi + 1
+    }
+    gi = gi + 1
+  }
 }
 
 /// Every name the entry selects from an import / re-export, in source order.

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -245,6 +245,36 @@ export fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String
         Array::push(stmts, stmt)
         pos = next
       },
+      // `#deprecated` is a token-level marker (`vibe check` scans the
+      // on-disk vpkg). The contract grammar has to skip it so type aliases
+      // that exist only here can carry the directive. Other `#` forms
+      // (`#cfg`, `#zero_alloc`) stay rejected — they have no contract
+      // meaning yet.
+      THash => {
+        match peek(tokens, pos + 1) {
+          TIdent(dname) => {
+            if dname == "deprecated" {
+              match peek(tokens, pos + 2) {
+                TLParen => match peek(tokens, pos + 3) {
+                  TString(_) => match peek(tokens, pos + 4) {
+                    TRParen => {
+                      pos = pos + 5
+                    },
+                    _ => throw("expected ')' after #deprecated message")
+                  },
+                  _ => throw("expected string message in #deprecated(...)")
+                },
+                _ => {
+                  pos = pos + 2
+                }
+              }
+            } else {
+              throw("unsupported # directive in a contract file: \{dname} (only #deprecated is allowed)")
+            }
+          },
+          _ => throw("expected directive name after '#' in a contract file")
+        }
+      },
       // #1280: `fn` lexes as TFn (reserved word), no longer TIdent("fn").
       TFn => {
         // where clauses on declarations parse but are not yet part of the

--- a/lib/@vibe/compiler/runtime/deprecated_scan.vibe
+++ b/lib/@vibe/compiler/runtime/deprecated_scan.vibe
@@ -296,6 +296,11 @@ export fn deprecated_warning_lines_visible(entry_source: String, dep_sources: Ar
   // Builtins have no `#deprecated` declaration site. Always honour the
   // language-level table (not gated on imports).
   append_builtin_deprecated(deprecated)
+  // Contract-only type aliases cannot carry `#deprecated` until a
+  // bootstrap bump (seed parse rejects `#` in index.vpkg). Honour the
+  // same names here, gated on the entry's imports — a file that never
+  // imported `HashMap` must not be told to rename its own type.
+  append_visible_legacy_types(deprecated, visible_names)
   let mut d = 0
   while d < Array::length(dep_sources) {
     let dep_marks = dep_empty_pairs()
@@ -318,6 +323,34 @@ export fn deprecated_warning_lines_visible(entry_source: String, dep_sources: Ar
     d = d + 1
   }
   deprecated_use_warnings_tokens(entry_source, tokens, starts, deprecated)
+}
+
+/// ADR-0100 (3) type aliases that live only in index.vpkg.
+fn append_legacy_type_deprecated(out: Array[(String, String)]) -> Unit {
+  Array::push(out, ("HashMap", "use MutMap"))
+  Array::push(out, ("HashSet", "use MutSet"))
+  Array::push(out, ("SortedMap", "use MutSortedMap"))
+  Array::push(out, ("SortedSet", "use MutSortedSet"))
+  Array::push(out, ("ImmutMap", "use MapHamt"))
+}
+
+fn append_visible_legacy_types(out: Array[(String, String)], visible_names: Option[Array[String]]) -> Unit {
+  let marks = dep_empty_pairs()
+  append_legacy_type_deprecated(marks)
+  let mut i = 0
+  while i < Array::length(marks) {
+    let (mname, mmsg) = Array::get(marks, i)
+    let keep = match visible_names {
+      None => true,
+      Some(names) => dep_names_contain(names, mname)
+    }
+    if keep {
+      Array::push(out, (mname, mmsg))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
 }
 
 fn dep_names_contain(names: Array[String], name: String) -> Bool {

--- a/lib/@vibe/compiler/runtime/deprecated_scan_test.vibe
+++ b/lib/@vibe/compiler/runtime/deprecated_scan_test.vibe
@@ -139,11 +139,41 @@ test "the new MutMap spelling is silent" {
 }
 
 test "the deprecated TYPE alias warns from an annotation" {
-  // The type row is the half that could NOT be kept working across a module
-  // boundary (#1700). Within one module it still resolves, and the marker
-  // still fires -- so if #1700 is fixed, the warning is already in place.
+  // The type row lives only in index.vpkg. The scanner itself already
+  // honours a `#deprecated` on `type` — the remaining hole is that the
+  // contract parser used to reject the directive, so the shipped file
+  // could not carry it.
   let entry = "fn take(m: HashMap[String, Int]) -> Int {\n  1\n}"
   assert(contains(first_warning(entry, collection_alias_dep()), "'HashMap' is deprecated: use MutMap"))
+}
+
+test "a vpkg-shaped type alias row warns the same way as an impl-file marker" {
+  let deps = [
+    "#deprecated(\"use MutMap\")\ntype HashMap[K, V] = MutMap[K, V]\nfn HashMap::new_string[V]() -> MutMap[String, V]"
+  ]
+  let entry = "fn take(m: HashMap[String, Int]) -> Int {\n  1\n}"
+  assert(contains(first_warning(entry, deps), "'HashMap' is deprecated: use MutMap"))
+}
+
+test "legacy type alias HashMap warns from the language table" {
+  let entry = "fn take(m: HashMap[String, Int]) -> Int {\n  1\n}"
+  assert(contains(first_warning(entry, no_deps()), "'HashMap' is deprecated: use MutMap"))
+}
+
+test "legacy type alias HashMap is silent when the entry did not import it" {
+  let entry = "fn HashMap::new_string() -> Int {\n  1\n}\nfn use_it() -> Int {\n  HashMap::new_string()\n}"
+  assert_eq(Array::length(deprecated_warning_lines_visible(entry, no_deps(), visible([
+    "MutMap"
+  ]))), 0)
+}
+
+test "legacy type alias HashMap warns when the entry imported the type" {
+  let entry = "import @vibe/core {\n  HashMap\n}\nfn take(m: HashMap[String, Int]) -> Int {\n  1\n}"
+  let lines = deprecated_warning_lines_visible(entry, no_deps(), visible([
+    "HashMap"
+  ]))
+  assert(Array::length(lines) > 0)
+  assert(contains(Array::get(lines, 0), "'HashMap' is deprecated: use MutMap"))
 }
 
 //# Visibility filter (Codex review, PR #1713, P2)
@@ -195,9 +225,9 @@ test "a marker the ENTRY declares needs no import to count" {
 }
 
 //# Shipped type aliases live only in the package contract (index.vpkg).
-//# Function aliases already carry `#deprecated` in the impl files; the type
-//# rows did not, so `let m: HashMap[String, Int] = ...` never warned and the
-//# old type spelling kept spreading.
+//# Function aliases already carry `#deprecated` in the impl files. The type
+//# rows cannot host the directive until a bootstrap bump, so the scanner
+//# honours the same names from a visibility-gated language table.
 
 //# Builtin old spellings (no declaration site).
 

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ../cli_support.vibe {
-  compile_release_file_mode, check_linked_file, verify_culprit_off_marker, verify_culprit_off_marker_fs_fail_closed, verify_culprit_off_marker_snapshot
+  compile_release_file_mode, check_linked_file, check_deprecated_warnings_from_source_groups, verify_culprit_off_marker, verify_culprit_off_marker_fs_fail_closed, verify_culprit_off_marker_snapshot
 }
 
 import @vibe/compiler/loader {
@@ -450,3 +450,34 @@ test "check_linked_file: tainted closure-param callee names the culprit, located
 // eligibility). Coverage lives in the gate instead --
 // fixtures/effect_closure_param_inert.vibe (+ _transitive) compile AND
 // execute through stage2 in compiler_gate lane 50.
+
+test "vpkg #deprecated type alias warns even when source_groups hold the facade" {
+  // The loader puts a generated facade in source_groups, not the on-disk
+  // vpkg. Markers on contract-only type aliases must still fire.
+  Fs::mkdir_p("/tmp/vibe_cli_support_dep_vpkg")
+  let vpkg_path = "/tmp/vibe_cli_support_dep_vpkg/index.vpkg"
+  let entry_path = "/tmp/vibe_cli_support_dep_vpkg_entry.vibe"
+  let vpkg_src = "#deprecated(\"use MutMap\")\ntype HashMap[K, V] = MutMap[K, V]\n"
+  let entry_src = "import ./index.vpkg {\n  HashMap\n}\nfn take(m: HashMap[String, Int]) -> Int {\n  1\n}\n"
+  let facade = "export type HashMap[K, V] = MutMap[K, V]\n"
+  Fs::write_bytes(vpkg_path, string_to_bytes(vpkg_src))
+  Fs::write_bytes(entry_path, string_to_bytes(entry_src))
+  let groups = [
+    ("g", [
+      (entry_path, entry_src),
+      (vpkg_path, facade)
+    ])
+  ]
+  let lines = check_deprecated_warnings_from_source_groups(entry_path, groups)
+  assert(Array::length(lines) > 0)
+  assert(String::contains(Array::get(lines, 0), "'HashMap' is deprecated: use MutMap"))
+}
+
+test "shipped HashMap type alias in core/index.vpkg is still a transparent alias" {
+  // The `#deprecated` directive cannot live in this file until a
+  // bootstrap bump (seed parse rejects `#`). The warning comes from
+  // the language table in deprecated_scan.vibe instead.
+  let src = Fs::read_file("lib/@vibe/core/index.vpkg")
+  assert(String::contains(src, "type HashMap[K, V] = MutMap[K, V]"))
+  assert(!String::contains(src, "#deprecated(\"use MutMap\")"))
+}

--- a/lib/@vibe/core/index.vpkg
+++ b/lib/@vibe/core/index.vpkg
@@ -366,6 +366,11 @@ fn inspect[T](value: T, content: String) -> Unit
 // their definition is public API and deliberately has no duplicate impl-side
 // `export type` declaration. This makes old annotations and new constructors
 // the same type across an index.vpkg boundary.
+//
+// The type rows cannot carry `#deprecated` until a bootstrap bump: the
+// seed's contract parser rejects `#`, and the seed loads this file when
+// compiling the compiler. `deprecated_scan.vibe` honours the same names
+// via a visibility-gated table so annotations still warn today.
 
 type HashMap[K, V] = MutMap[K, V]
 

--- a/lib/@vibex/immut/index.vpkg
+++ b/lib/@vibex/immut/index.vpkg
@@ -37,6 +37,9 @@ fn ImmutArray::to_array[T](a: ImmutArray[T]) -> Array[T]
 // Functions are `#deprecated` in immut_map.vibe. #1700 restores the
 // transparent contract-owned type alias as well, so old annotations remain
 // source-compatible across this package boundary.
+// The type row itself cannot carry `#deprecated` until a bootstrap bump
+// (seed contract parser rejects `#`). `deprecated_scan.vibe` lists ImmutMap
+// in the language-level type-alias table.
 type ImmutMap[V] = MapHamt[V]
 
 fn ImmutMap::hash_key(key: String) -> Int


### PR DESCRIPTION
## Why

Old collection **type** names (`HashMap`, `HashSet`, `SortedMap`, `SortedSet`, `ImmutMap`) are unmarked. Function aliases already warn; annotations do not. That is why the old spelling keeps spreading.

Putting `#deprecated` on `index.vpkg` is the honest site, but the **seed** contract parser rejects `#`, and the seed loads `@vibe/core/index.vpkg` when compiling the compiler. Marking the file today breaks every compile.

## What

- Language table in `deprecated_scan.vibe` for those five type names, **visibility-gated** (a file that did not import `HashMap` is not told to rename its own type).
- `parse_contract_program` skips `#deprecated` so a later bootstrap bump can move the marker onto the vpkg row.
- `vibe check` re-reads on-disk `.vpkg` files (the generated facade drops the directive).
- Cheatsheet updated.

`*Builder::freeze` stays unmarked until the seed knows `build`.

## Tests

- `deprecated_scan_test.vibe`: table warns; silent when the type was not imported; warns when it was.
- `contract_conformance_test.vibe`: contract parser accepts `#deprecated` / bare form, rejects unknown `#`.
- `cli_support_test.vibe`: facade-in-source_groups still warns from the on-disk vpkg.

84 tests in those three files passed via `scripts/vibe_test.sh`.