### PR TITLE
fix(check): warn on remaining legacy builtin spellings

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -925,7 +925,7 @@ higher-order effect evidence (#1536); do not treat `read_chunk` as directly
 iterable. This surface is component-only (linear/RC); GC, standalone core,
 `host_stream_named("stdin")`, and mixed named-provider composition are
 rejected. Legacy `stdin_stream(chunk_size)` is standalone-capable and
-unchanged.
+`#deprecated` (`use StdinStream::read_chunk`).
 
 **Naming.** Effect names are CamelCase. A standard provider builtin is a plain
 `Effect::snake_case` function call; a declared operation is CamelCase and is

--- a/lib/@vibe/compiler/core/builtin_name.vibe
+++ b/lib/@vibe/compiler/core/builtin_name.vibe
@@ -75,6 +75,10 @@ export fn builtin_deprecated_message(name: String) -> Option[String] {
     "Env::Get" => Some("use Env::get"),
     "Env::ArgsLen" => Some("use Env::args_len"),
     "Env::ArgsGet" => Some("use Env::args_get"),
+    "Profiler::NowUs" => Some("use Profiler::now_us"),
+    "Profiler::HeapBytes" => Some("use Profiler::heap_bytes"),
+    "Map::has" => Some("use Map::has_key"),
+    "map_has" => Some("use Map::has_key"),
     _ => None
   }
 }
@@ -104,7 +108,11 @@ export fn append_builtin_deprecated(out: Array[(String, String)]) -> Unit {
     "Fs::Rename",
     "Env::Get",
     "Env::ArgsLen",
-    "Env::ArgsGet"
+    "Env::ArgsGet",
+    "Profiler::NowUs",
+    "Profiler::HeapBytes",
+    "Map::has",
+    "map_has"
   ]
   let mut i = 0
   while i < Array::length(names) {

--- a/lib/@vibe/compiler/runtime/deprecated_scan_test.vibe
+++ b/lib/@vibe/compiler/runtime/deprecated_scan_test.vibe
@@ -247,3 +247,37 @@ test "StringBuilder::freeze stays silent until a bootstrap bump" {
   let entry = "fn n() -> Array[Int] {\n  ArrayBuilder::freeze(ArrayBuilder::new())\n}"
   assert_eq(warn_count(entry, no_deps()), 0)
 }
+
+test "Profiler::NowUs warns and names now_us" {
+  let entry = "fn n() -> Int {\n  Profiler::NowUs()\n}"
+  let lines = deprecated_warning_lines(entry, no_deps())
+  assert_eq(Array::length(lines), 1)
+  assert(contains(Array::get(lines, 0), "'Profiler::NowUs' is deprecated: use Profiler::now_us"))
+}
+
+test "Profiler::now_us is silent" {
+  let entry = "fn n() -> Int {\n  Profiler::now_us()\n}"
+  assert_eq(warn_count(entry, no_deps()), 0)
+}
+
+test "Map::has warns and names has_key" {
+  let entry = "fn n(m: Map[String, Int], k: String) -> Bool {\n  Map::has(m, k)\n}"
+  let lines = deprecated_warning_lines(entry, no_deps())
+  assert_eq(Array::length(lines), 1)
+  assert(contains(Array::get(lines, 0), "'Map::has' is deprecated: use Map::has_key"))
+}
+
+test "Map::has_key and MutMap::has stay silent" {
+  let entry = "fn n(m: Map[String, Int], k: String) -> Bool {\n  Map::has_key(m, k)\n}"
+  assert_eq(warn_count(entry, no_deps()), 0)
+  let entry2 = "fn n() -> Bool {\n  MutMap::has(MutMap::new_string(), \"a\")\n}"
+  assert_eq(warn_count(entry2, no_deps()), 0)
+}
+
+test "stdin_stream alias warns and names StdinStream::read_chunk" {
+  let deps = [
+    "#deprecated(\"use StdinStream::read_chunk\")\nexport fn stdin_stream(chunk_size: Int) -> Int {\n  chunk_size\n}"
+  ]
+  let entry = "fn n() -> Int {\n  stdin_stream(4)\n}"
+  assert(contains(first_warning(entry, deps), "'stdin_stream' is deprecated: use StdinStream::read_chunk"))
+}

--- a/lib/@vibe/console/byte_stream.vibe
+++ b/lib/@vibe/console/byte_stream.vibe
@@ -19,6 +19,7 @@ import ./io.vibe {
 /// bytes per step. Each pull is one bounded host read (short reads preserved);
 /// the stream ends (`None`) at EOF. The stream cursor is shared host state, so a
 /// stream is single-pass.
+#deprecated("use StdinStream::read_chunk")
 export fn stdin_stream(chunk_size: Int) -> (() -> Option[String] with Stdin) {
   () -> Option[String] with Stdin {
     let chunk = read_n(chunk_size)


### PR DESCRIPTION
Continues the #deprecated work. Old names that still compiled without a warning:

- \`Profiler::NowUs\` / \`Profiler::HeapBytes\` → \`now_us\` / \`heap_bytes\`
- \`Map::has\` / \`map_has\` → \`Map::has_key\` (\`MutMap::has\` is current and silent)
- \`stdin_stream\` → \`StdinStream::read_chunk\` (#1956 first slice: deprecate, do not remove)

\`Stream::next\` / \`String::to_bytes\` / \`Stream::to_string\` stay unmarked until #1954 has a replacement spelling. \`*Builder::freeze\` still waits on bootstrap.

## Tests

\`deprecated_scan_test.vibe\`: 28 passed via seed compiling the library.