### PR TITLE
test: move four suspend-CPS fixtures off __DATA__ onto inspect (#1571)

### DIFF
--- a/fixtures/effect_resume_store_loop.vibe
+++ b/fixtures/effect_resume_store_loop.vibe
@@ -43,7 +43,9 @@ let _start = () -> Int {
   let r3 = k2(7)
   r0 * 1000000 + r1 * 10000 + r2 * 100 + r3
 }
-_start()
 
-__DATA__
-{"last":"101020383"}
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`.
+test "while + let mut on the handle spine survive every resume" {
+  inspect(_start(), "101020383")
+}

--- a/fixtures/effect_resume_store_loop_nested_return.vibe
+++ b/fixtures/effect_resume_store_loop_nested_return.vibe
@@ -45,7 +45,9 @@ let _start = () -> Int {
   let k1 = Array::get(conts, 1)
   k1(6)
 }
-_start()
 
-__DATA__
-{"last":"112"}
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`.
+test "a nested closure return does not reject loop widening" {
+  inspect(_start(), "112")
+}

--- a/fixtures/effect_resume_store_loop_prefix.vibe
+++ b/fixtures/effect_resume_store_loop_prefix.vibe
@@ -41,7 +41,9 @@ let _start = () -> Int {
   let k1 = Array::get(conts, 1)
   k1(6)
 }
-_start()
 
-__DATA__
-{"last":"20000112"}
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`.
+test "a non-suspending prefix loop stays iterative" {
+  inspect(_start(), "20000112")
+}

--- a/fixtures/effect_resume_value_postprocess.vibe
+++ b/fixtures/effect_resume_value_postprocess.vibe
@@ -19,7 +19,9 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{"last":"1017"}
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`.
+test "post-processing after a resume via the value form" {
+  inspect(_start(), "1017")
+}

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -1031,8 +1031,28 @@ scps_run_expect() {
     exit 1
   fi
 }
+# #1571: fixtures that own their expectation as an `inspect` test block
+# compile AS-IS -- no `__DATA__` strip, no temp copy, and no expected value
+# in shell. Entry is `__no_entry__`, which synthesizes the test-block
+# runner; a mismatch prints inspect's own actual/expected and fails the run.
+scps_run_inspect() {
+  local fixture="$1" tag="$2"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "fixtures/$fixture" "$scpsdir/$tag.wasm" __no_entry__ >/dev/null 2>&1 || true
+  if [ ! -s "$scpsdir/$tag.wasm" ]; then
+    echo "[compiler-gate] FAIL: $fixture did not compile -- Phase 3a suspend lowering regressed" >&2
+    cat "$scpsdir/$tag.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! scps_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$scpsdir/$tag.wasm" 2>&1)"; then
+    echo "[compiler-gate] FAIL: $fixture tests failed -- Phase 3a suspend lowering regressed" >&2
+    echo "$scps_out" >&2
+    exit 1
+  fi
+}
 scps_run_expect "effect_resume_store_scheduler.vibe" "10230" "sched"
-scps_run_expect "effect_resume_value_postprocess.vibe" "1017" "post"
+scps_run_inspect "effect_resume_value_postprocess.vibe" "post"
 # Phase 3b yield bubbling now lives in
 # fixtures/effect_resume_call_bubbling_test.vibe (#1973).
 # Trivial row-var wrapper pin now lives in
@@ -1040,15 +1060,15 @@ scps_run_expect "effect_resume_value_postprocess.vibe" "1017" "post"
 # #1230 loop widening: `while` + `let mut` on the spine. 101020383 decodes
 # as r0=100/r1=101/r2=102/r3=183 -- the 183 is the pin that both `acc` and
 # `i` survived every suspend/resume round trip through their cells.
-scps_run_expect "effect_resume_store_loop.vibe" "101020383" "loop"
+scps_run_inspect "effect_resume_store_loop.vibe" "loop"
 # #1263 Codex P1: a non-suspending loop AHEAD of a suspending one must stay
 # iterative. The 200000-iteration prefix would blow the wasm call stack if it
 # were converted to the recursive lp() shape (rewrite_self_tail_calls runs
 # before suspend_cps_pass, so nothing flattens it back).
-scps_run_expect "effect_resume_store_loop_prefix.vibe" "20000112" "loopprefix"
+scps_run_inspect "effect_resume_store_loop_prefix.vibe" "loopprefix"
 # #1263 Codex P2: a nested closure is a control-flow boundary -- its `return`
 # targets the closure, not the loop being converted, so it must not reject.
-scps_run_expect "effect_resume_store_loop_nested_return.vibe" "112" "loopnestedret"
+scps_run_inspect "effect_resume_store_loop_nested_return.vibe" "loopnestedret"
 # one-shot violation: must NOT produce a value; the failure output carries
 # the one-shot stderr diagnostic before the assert trap.
 sed '/^_start()$/d' fixtures/effect_resume_one_shot_trap.vibe > "$scpsdir/once.vibe"


### PR DESCRIPTION
Refs #1571. Does not close it — hundreds of `__DATA__` fixtures remain.

## What

Move four first-class-resume (suspend-CPS) fixtures off a `__DATA__` tail onto in-source `inspect(...)` tests, matching `fixtures/effect_local_closure_wrapper_referenced_as_value.vibe`.

| fixture | want |
|---|---|
| `fixtures/effect_resume_value_postprocess.vibe` | `1017` |
| `fixtures/effect_resume_store_loop.vibe` | `101020383` |
| `fixtures/effect_resume_store_loop_prefix.vibe` | `20000112` |
| `fixtures/effect_resume_store_loop_nested_return.vibe` | `112` |

Each keeps its existing `_start` logic. The trailing `_start()` eval and the `__DATA__` tail are gone; a `test` block now drives the run:

```vibe
test "..." {
  inspect(_start(), "<want>")
}
```

`inspect` is desugared before the checker, so no import is required.

## Gate

`tests/gates/late/run.sh` no longer `sed '/^__DATA__$/,$d'` these four.

- **Removed `scps_run_expect` sites** (sed + temp copy + shell-side expected value):
  - `effect_resume_value_postprocess.vibe` / `"1017"` / `post`
  - `effect_resume_store_loop.vibe` / `"101020383"` / `loop`
  - `effect_resume_store_loop_prefix.vibe` / `"20000112"` / `loopprefix`
  - `effect_resume_store_loop_nested_return.vibe` / `"112"` / `loopnestedret`
- **Added `scps_run_inspect`**: compile the fixture AS-IS with `__no_entry__` (no sed, no temp copy) and run the synthesized test runner. A mismatch prints inspect's own actual/expected.

`scps_run_expect` remains for the fixtures that still carry `__DATA__` (including `effect_resume_store_scheduler.vibe`, left alone because it is owned by in-flight #2067).

## Verified

Compiled each fixture with the committed seed (`bootstrap/seed/compiler.wasm`) and ran `_start`. All four inspect tests passed (empty output, exit 0):

```
COMPILE_OK fixtures/effect_resume_value_postprocess.vibe
COMPILE_OK fixtures/effect_resume_store_loop.vibe
COMPILE_OK fixtures/effect_resume_store_loop_prefix.vibe
COMPILE_OK fixtures/effect_resume_store_loop_nested_return.vibe
RUN effect_resume_value_postprocess        OK exit=0 output=
RUN effect_resume_store_loop               OK exit=0 output=
RUN effect_resume_store_loop_prefix        OK exit=0 output=
RUN effect_resume_store_loop_nested_return OK exit=0 output=
```

Empty output is the inspect-pass convention (mismatch would print actual/expected and fail the run).