### PR TITLE
refactor(normalize): extract desugar_array_spread from the 12k kitchen-sink file (#1849)

### DIFF
--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -271,6 +271,7 @@ loader	loader/loader.vibe
 normalize	normalize/index.vpkg
 normalize	normalize/normalize.vibe
 normalize	normalize/desugar_trait_dict.vibe
+normalize	normalize/desugar_array_spread.vibe
 normalize	normalize/unbox_tuple_loop.vibe
 normalize	codegen/common_base/self_tail_call.vibe
 normalize	codegen/common_base/inline_direct_perform.vibe

--- a/lib/@vibe/compiler/normalize/desugar_array_spread.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_array_spread.vibe
@@ -1,0 +1,180 @@
+// Array-literal spread lowering (#790, #1849).
+// Extracted from desugar_trait_dict.vibe. `desugar_derives` and
+// `desugar_hoist_local_lambdas` both call into helpers the kitchen-sink
+// file still owns (`eq_for_typed`, `dinsp_scan`, `collect_pat_binders`),
+// so pulling either would cycle or duplicate. This pass only needs the
+// AST types and `array_empty`.
+
+//# Imports
+
+import @vibe/compiler/core {
+  Expr, Pat, Stmt
+}
+
+import @vibe/core {
+  array_empty
+}
+
+//# Functions
+
+///|
+/// #790: lower array-literal spreads `[a, ...xs, b]` into an `Array::concat` chain
+/// of segments (`Array::concat(Array::concat([a], xs), [b])`). The parser accepts
+/// `...expr` inside an array literal (ESpread), but the active desugar pipeline
+/// never lowered it, so codegen reached ESpread and threw "unsupported expression
+/// in codegen". Ported from the legacy desugar.vibe (spread-only; no other legacy
+/// transforms). `das_arms` is mutually recursive with `das_expr`.
+fn das_expr(expr: Expr) -> Expr {
+  match expr {
+    EArray(elems) => {
+      let mut has_spread = false
+      let mut si0 = 0
+      while si0 < Array::length(elems) {
+        match Array::get(elems, si0) {
+          ESpread(_) => {
+            has_spread = true
+          },
+          _ => ()
+        }
+        si0 = si0 + 1
+      }
+      if has_spread {
+        let segments = array_empty()
+        let mut buf = array_empty()
+        let mut si = 0
+        while si < Array::length(elems) {
+          let elem = Array::get(elems, si)
+          match elem {
+            ESpread(inner) => {
+              if Array::length(buf) > 0 {
+                Array::push(segments, EArray(for e in buf {
+                  das_expr(e)
+                }))
+                buf = array_empty()
+              } else {
+                ()
+              }
+              Array::push(segments, das_expr(inner))
+            },
+            _ => Array::push(buf, elem)
+          }
+          si = si + 1
+        }
+        if Array::length(buf) > 0 {
+          Array::push(segments, EArray(for e in buf {
+            das_expr(e)
+          }))
+        } else {
+          ()
+        }
+        let mut acc = Array::get(segments, 0)
+        let mut fi = 1
+        while fi < Array::length(segments) {
+          acc = ECall(EIdent("Array::concat", 0 - 1), [
+            acc,
+            Array::get(segments, fi)
+          ], 0 - 1)
+          fi = fi + 1
+        }
+        acc
+      } else {
+        EArray(for e in elems {
+          das_expr(e)
+        })
+      }
+    },
+    ETuple(es) => ETuple(for e in es {
+      das_expr(e)
+    }),
+    ERecord(rn, fs, targs) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(fs) {
+        let (k, v) = Array::get(fs, i)
+        Array::push(out, (k, das_expr(v)))
+        i = i + 1
+      }
+      ERecord(rn, out, targs)
+    },
+    EMap(fs) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(fs) {
+        let (k, v) = Array::get(fs, i)
+        Array::push(out, (k, das_expr(v)))
+        i = i + 1
+      }
+      EMap(out)
+    },
+    EIf(c, t, e) => EIf(das_expr(c), das_expr(t), das_expr(e)),
+    ELet(n, v, b, soff) => ELet(n, das_expr(v), das_expr(b), soff),
+    ELetRec(n, v, b) => ELetRec(n, das_expr(v), das_expr(b)),
+    ELetMut(n, v, b, soff) => ELetMut(n, das_expr(v), das_expr(b), soff),
+    EAssign(n, v, c) => EAssign(n, das_expr(v), das_expr(c)),
+    EAssignOp(n, op, v, c) => EAssignOp(n, op, das_expr(v), das_expr(c)),
+    ESeq(a, b) => ESeq(das_expr(a), das_expr(b)),
+    EMatch(s, arms) => EMatch(das_expr(s), das_arms(arms)),
+    EHandle(s, arms) => EHandle(das_expr(s), das_arms(arms)),
+    EWhile(c, b) => EWhile(das_expr(c), das_expr(b)),
+    ELoop(params, b) => ELoop(for param in params {
+      let (name, init) = param
+      (name, das_expr(init))
+    }, das_expr(b)),
+    EForIn(n, idxn, it, b) => EForIn(n, idxn, das_expr(it), das_expr(b)),
+    ECall(callee, args, off) => ECall(das_expr(callee), for a in args {
+      das_expr(a)
+    }, off),
+    EBinOp(op, l, r) => EBinOp(op, das_expr(l), das_expr(r)),
+    EUnaryOp(op, e) => EUnaryOp(op, das_expr(e)),
+    EFn(tp, tb, params, rt, eff, body) => EFn(tp, tb, params, rt, eff, das_expr(body)),
+    EDot(o, f, off, fdoff) => EDot(das_expr(o), f, off, fdoff),
+    ELabeledArg(l, m, e) => ELabeledArg(l, m, das_expr(e)),
+    EReturn(e) => EReturn(das_expr(e)),
+    EBreak(opt) => match opt {
+      Some(e) => EBreak(Some(das_expr(e))),
+      None => expr
+    },
+    EContinue(es) => EContinue(for e in es {
+      das_expr(e)
+    }),
+    ESpread(inner) => ESpread(das_expr(inner)),
+    _ => expr
+  }
+}
+
+///|
+fn das_arms(arms: Array[(Pat, Expr)]) -> Array[(Pat, Expr)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (p, b) = Array::get(arms, i)
+    Array::push(out, (p, das_expr(b)))
+    i = i + 1
+  }
+  out
+}
+
+///|
+fn das_stmt(stmt: Stmt) -> Stmt {
+  match stmt {
+    SLet(ex, rc, name, ty, body) => SLet(ex, rc, name, ty, das_expr(body)),
+    SLetMut(name, ty, body) => SLetMut(name, ty, das_expr(body)),
+    STest(name, body) => STest(name, das_expr(body)),
+    SBench(name, body) => SBench(name, das_expr(body)),
+    SExpr(e) => SExpr(das_expr(e)),
+    SLetPat(pat, e) => SLetPat(pat, das_expr(e)),
+    _ => stmt
+  }
+}
+
+///|
+/// In-place lowering of array-literal spreads across the whole program (#790).
+export fn desugar_array_spread(stmts: Array[Stmt]) -> Unit {
+  let n = Array::length(stmts)
+  let mut i = 0
+  while i < n {
+    Array::set(stmts, i, das_stmt(Array::get(stmts, i)))
+    i = i + 1
+  }
+}
+

--- a/lib/@vibe/compiler/normalize/desugar_array_spread_test.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_array_spread_test.vibe
@@ -1,0 +1,108 @@
+// Normalize-facing lock for `desugar_array_spread` (#1849). The kitchen-sink
+// file used to own this pass; the test imports the package contract so a
+// missing implementation fails to compile.
+
+import @vibe/compiler/core {
+  Expr, Stmt
+}
+
+import @vibe/compiler/normalize {
+  desugar_array_spread
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+fn parse(source: String) -> Array[Stmt] with Exception {
+  parse_program(lex(source))
+}
+
+fn expr_has_spread(expr: Expr) -> Bool {
+  match expr {
+    ESpread(_) => true,
+    EArray(es) => {
+      let mut hit = false
+      for e in es {
+        if expr_has_spread(e) {
+          hit = true
+        } else {
+          ()
+        }
+      }
+      hit
+    },
+    ECall(c, args, _) => {
+      let mut hit = expr_has_spread(c)
+      for a in args {
+        if expr_has_spread(a) {
+          hit = true
+        } else {
+          ()
+        }
+      }
+      hit
+    },
+    _ => false
+  }
+}
+
+fn expr_calls(expr: Expr, name: String) -> Bool {
+  match expr {
+    ECall(EIdent(n, _), args, _) => {
+      let mut hit = n == name
+      for a in args {
+        if expr_calls(a, name) {
+          hit = true
+        } else {
+          ()
+        }
+      }
+      hit
+    },
+    ECall(c, args, _) => {
+      let mut hit = expr_calls(c, name)
+      for a in args {
+        if expr_calls(a, name) {
+          hit = true
+        } else {
+          ()
+        }
+      }
+      hit
+    },
+    EArray(es) => {
+      let mut hit = false
+      for e in es {
+        if expr_calls(e, name) {
+          hit = true
+        } else {
+          ()
+        }
+      }
+      hit
+    },
+    _ => false
+  }
+}
+
+fn let_body(stmt: Stmt) -> Expr {
+  match stmt {
+    SLet(_, _, _, _, e) => e,
+    _ => EUnit
+  }
+}
+
+test "desugar_array_spread is a no-op without a spread" {
+  let stmts = parse("let xs = [1, 2]")
+  desugar_array_spread(stmts)
+  assert_eq(Array::length(stmts), 1)
+}
+
+test "desugar_array_spread lowers ...xs into Array::concat" {
+  let stmts = parse("let xs = [1, 2]\nlet ys = [0, ...xs, 3]")
+  desugar_array_spread(stmts)
+  let body = let_body(Array::get(stmts, 1))
+  assert(!expr_has_spread(body))
+  assert(expr_calls(body, "Array::concat"))
+}

--- a/lib/@vibe/compiler/normalize/desugar_derives_test.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_derives_test.vibe
@@ -1,0 +1,52 @@
+// Normalize-facing lock for `desugar_derives` (#1849). The kitchen-sink file
+// used to own this pass; the test imports the package contract so a missing
+// implementation fails to compile rather than silently skipping generation.
+
+import @vibe/compiler/core {
+  Stmt
+}
+
+import @vibe/compiler/normalize {
+  desugar_derives
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+fn parse(source: String) -> Array[Stmt] with Exception {
+  parse_program(lex(source))
+}
+
+fn has_top_level_fn(stmts: Array[Stmt], name: String) -> Bool {
+  let mut found = false
+  for stmt in stmts {
+    match stmt {
+      SLet(_, _, n, _, _) => if n == name {
+        found = true
+      } else {
+        ()
+      },
+      _ => ()
+    }
+  }
+  found
+}
+
+test "desugar_derives emits Point::equals for a struct" {
+  let stmts = parse("struct Point { x: Int; y: Int } derive(Eq)")
+  desugar_derives(stmts)
+  assert(has_top_level_fn(stmts, "Point::equals"))
+}
+
+test "desugar_derives emits Point::to_string for derive(Show)" {
+  let stmts = parse("struct Point { x: Int; y: Int } derive(Show)")
+  desugar_derives(stmts)
+  assert(has_top_level_fn(stmts, "Point::to_string"))
+}
+
+test "desugar_derives emits Color::equals for an enum" {
+  let stmts = parse("enum Color { Red; Green; Blue } derive(Eq)")
+  desugar_derives(stmts)
+  assert(has_top_level_fn(stmts, "Color::equals"))
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -35,6 +35,17 @@ import @vibe/parser {
   located_program_binder_authority_program
 }
 
+import ./desugar_array_spread.vibe {
+  desugar_array_spread
+}
+
+// Array-literal spread lives in desugar_array_spread.vibe (#1849).
+// Re-export so `import ./desugar_trait_dict.vibe { desugar_array_spread }`
+// still resolves.
+export ./desugar_array_spread.vibe {
+  desugar_array_spread
+}
+
 //# Functions
 
 enum StoredNormalizedBinderAuthority {
@@ -12088,167 +12099,6 @@ export fn normalize_labeled_args_with_binder_authority(source: LocatedProgramBin
   }
   LabeledArgBinderAuthorityNormalization::{
     stored: StoredLabeledArgBinderAuthorityNormalizationValue(program, normalized)
-  }
-}
-
-///|
-/// #790: lower array-literal spreads `[a, ...xs, b]` into an `Array::concat` chain
-/// of segments (`Array::concat(Array::concat([a], xs), [b])`). The parser accepts
-/// `...expr` inside an array literal (ESpread), but the active desugar pipeline
-/// never lowered it, so codegen reached ESpread and threw "unsupported expression
-/// in codegen". Ported from the legacy desugar.vibe (spread-only; no other legacy
-/// transforms). `das_arms` is mutually recursive with `das_expr`.
-fn das_expr(expr: Expr) -> Expr {
-  match expr {
-    EArray(elems) => {
-      let mut has_spread = false
-      let mut si0 = 0
-      while si0 < Array::length(elems) {
-        match Array::get(elems, si0) {
-          ESpread(_) => {
-            has_spread = true
-          },
-          _ => ()
-        }
-        si0 = si0 + 1
-      }
-      if has_spread {
-        let segments = array_empty()
-        let mut buf = empty_expr_array()
-        let mut si = 0
-        while si < Array::length(elems) {
-          let elem = Array::get(elems, si)
-          match elem {
-            ESpread(inner) => {
-              if Array::length(buf) > 0 {
-                Array::push(segments, EArray(for e in buf {
-                  das_expr(e)
-                }))
-                buf = empty_expr_array()
-              } else {
-                ()
-              }
-              Array::push(segments, das_expr(inner))
-            },
-            _ => Array::push(buf, elem)
-          }
-          si = si + 1
-        }
-        if Array::length(buf) > 0 {
-          Array::push(segments, EArray(for e in buf {
-            das_expr(e)
-          }))
-        } else {
-          ()
-        }
-        let mut acc = Array::get(segments, 0)
-        let mut fi = 1
-        while fi < Array::length(segments) {
-          acc = ECall(EIdent("Array::concat", 0 - 1), [
-            acc,
-            Array::get(segments, fi)
-          ], 0 - 1)
-          fi = fi + 1
-        }
-        acc
-      } else {
-        EArray(for e in elems {
-          das_expr(e)
-        })
-      }
-    },
-    ETuple(es) => ETuple(for e in es {
-      das_expr(e)
-    }),
-    ERecord(rn, fs, targs) => {
-      let out = array_empty()
-      let mut i = 0
-      while i < Array::length(fs) {
-        let (k, v) = Array::get(fs, i)
-        Array::push(out, (k, das_expr(v)))
-        i = i + 1
-      }
-      ERecord(rn, out, targs)
-    },
-    EMap(fs) => {
-      let out = array_empty()
-      let mut i = 0
-      while i < Array::length(fs) {
-        let (k, v) = Array::get(fs, i)
-        Array::push(out, (k, das_expr(v)))
-        i = i + 1
-      }
-      EMap(out)
-    },
-    EIf(c, t, e) => EIf(das_expr(c), das_expr(t), das_expr(e)),
-    ELet(n, v, b, soff) => ELet(n, das_expr(v), das_expr(b), soff),
-    ELetRec(n, v, b) => ELetRec(n, das_expr(v), das_expr(b)),
-    ELetMut(n, v, b, soff) => ELetMut(n, das_expr(v), das_expr(b), soff),
-    EAssign(n, v, c) => EAssign(n, das_expr(v), das_expr(c)),
-    EAssignOp(n, op, v, c) => EAssignOp(n, op, das_expr(v), das_expr(c)),
-    ESeq(a, b) => ESeq(das_expr(a), das_expr(b)),
-    EMatch(s, arms) => EMatch(das_expr(s), das_arms(arms)),
-    EHandle(s, arms) => EHandle(das_expr(s), das_arms(arms)),
-    EWhile(c, b) => EWhile(das_expr(c), das_expr(b)),
-    ELoop(params, b) => ELoop(for param in params {
-      let (name, init) = param
-      (name, das_expr(init))
-    }, das_expr(b)),
-    EForIn(n, idxn, it, b) => EForIn(n, idxn, das_expr(it), das_expr(b)),
-    ECall(callee, args, off) => ECall(das_expr(callee), for a in args {
-      das_expr(a)
-    }, off),
-    EBinOp(op, l, r) => EBinOp(op, das_expr(l), das_expr(r)),
-    EUnaryOp(op, e) => EUnaryOp(op, das_expr(e)),
-    EFn(tp, tb, params, rt, eff, body) => EFn(tp, tb, params, rt, eff, das_expr(body)),
-    EDot(o, f, off, fdoff) => EDot(das_expr(o), f, off, fdoff),
-    ELabeledArg(l, m, e) => ELabeledArg(l, m, das_expr(e)),
-    EReturn(e) => EReturn(das_expr(e)),
-    EBreak(opt) => match opt {
-      Some(e) => EBreak(Some(das_expr(e))),
-      None => expr
-    },
-    EContinue(es) => EContinue(for e in es {
-      das_expr(e)
-    }),
-    ESpread(inner) => ESpread(das_expr(inner)),
-    _ => expr
-  }
-}
-
-///|
-fn das_arms(arms: Array[(Pat, Expr)]) -> Array[(Pat, Expr)] {
-  let out = array_empty()
-  let mut i = 0
-  while i < Array::length(arms) {
-    let (p, b) = Array::get(arms, i)
-    Array::push(out, (p, das_expr(b)))
-    i = i + 1
-  }
-  out
-}
-
-///|
-fn das_stmt(stmt: Stmt) -> Stmt {
-  match stmt {
-    SLet(ex, rc, name, ty, body) => SLet(ex, rc, name, ty, das_expr(body)),
-    SLetMut(name, ty, body) => SLetMut(name, ty, das_expr(body)),
-    STest(name, body) => STest(name, das_expr(body)),
-    SBench(name, body) => SBench(name, das_expr(body)),
-    SExpr(e) => SExpr(das_expr(e)),
-    SLetPat(pat, e) => SLetPat(pat, das_expr(e)),
-    _ => stmt
-  }
-}
-
-///|
-/// In-place lowering of array-literal spreads across the whole program (#790).
-export fn desugar_array_spread(stmts: Array[Stmt]) -> Unit {
-  let n = Array::length(stmts)
-  let mut i = 0
-  while i < n {
-    Array::set(stmts, i, das_stmt(Array::get(stmts, i)))
-    i = i + 1
   }
 }
 

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -41,10 +41,13 @@ fn uniquify_shadowed_bindings_fresh(expr: Expr, counter: Array[Int], seen: Array
 // normalize_stmts) so it's unit-testable on a bare Stmt list.
 fn normalize_dot_calls(stmts: Array[Stmt]) -> Array[Stmt]
 
-// --- desugar_trait_dict.vibe (#1440 phase 2)
+// --- desugar_trait_dict.vibe (#1440 phase 2) + desugar_array_spread.vibe (#1849)
 // Shared pre-check and pre-codegen AST rewrites. The implementation moved
 // verbatim from codegen/common_base; common_base re-exports these contracts for
-// source compatibility with existing codegen callers.
+// source compatibility with existing codegen callers. `desugar_array_spread`
+// lives in its own file; desugar_trait_dict.vibe imports and re-exports it.
+// (`desugar_derives` / `desugar_hoist_local_lambdas` stay in the kitchen-sink
+// file: both call helpers that file still owns, so extracting them cycles.)
 fn inject_trait_method_generics(stmts: Array[Stmt]) -> Unit
 fn inject_trait_method_generics_reporting_change(stmts: Array[Stmt]) -> Bool
 // #1858: checker-facing mirror of build_gens' witness-threading capability —


### PR DESCRIPTION
One bounded slice of #1849: split a real pass out of `desugar_trait_dict.vibe` (12,708 lines).

## Why not `desugar_derives`

That was the first target. Its generators (`gen_eq_fn`, `show_for_typed`, `collect_bare_array_eq_keys`, …) call helpers the `==` rewrite still owns (`eq_for_typed`, `type_key`, `arr_equals_name`, `is_scalar_type_name`, `concat2`). Normalize siblings do **not** share private names. Importing the helpers from the kitchen-sink file while that file imports the new pass is a cycle; promoting the helpers to `export fn` without a vpkg row is a contract violation.

`desugar_hoist_local_lambdas` has the same shape: `dlh_marker_only_called_directly` calls `dinsp_scan`, and the hoist walk calls `collect_pat_binders`.

`desugar_array_spread` is the next self-contained large-enough pass. It only needs `Expr`/`Pat`/`Stmt` and `array_empty`.

## What moved

- New `lib/@vibe/compiler/normalize/desugar_array_spread.vibe` (`das_expr` / `das_arms` / `das_stmt` / `desugar_array_spread`).
- `desugar_trait_dict.vibe` imports and re-exports the pass so `import ./desugar_trait_dict.vibe { desugar_array_spread }` still resolves.
- Manifest row next to `desugar_trait_dict.vibe`. `index.vpkg` already declared the fn.

## Line counts

| file | before | after |
| --- | ---: | ---: |
| `desugar_trait_dict.vibe` | 12708 | 12558 (−150) |
| `desugar_array_spread.vibe` | — | 180 |

## Tests (seed compiler, `VIBE_FS_COMPILE=1`)

Red: renaming the export to `desugar_array_spread_hidden` makes the package test fail (`imported name 'desugar_array_spread' is not exported`).

Green:

- `lib/@vibe/compiler/normalize/desugar_array_spread_test.vibe` (no-op + `...xs` → `Array::concat`)
- `lib/@vibe/compiler/normalize/desugar_derives_test.vibe` (package still exports `desugar_derives`)
- `lib/@vibe/compiler/normalize/uniquify_shadowed_bindings_test.vibe`
- `fixtures/derive_eq_test.vibe`

Does not close #1849 (`inline_direct_perform.vibe` is still 14k; this is one file).