### PR TITLE
test: move four more suspend fixtures off __DATA__ onto inspect (#1571)

### DIFF
--- a/fixtures/effect_assignment_rhs_suspend.vibe
+++ b/fixtures/effect_assignment_rhs_suspend.vibe
@@ -25,9 +25,9 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{
-  "last": "41112"
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`.
+test "assignment RHS suspends once then continues once" {
+  inspect(_start(), "41112")
 }

--- a/fixtures/effect_closure_param_inert.vibe
+++ b/fixtures/effect_closure_param_inert.vibe
@@ -48,7 +48,9 @@ let _start = () -> Int {
     }
   }
 }
-_start()
 
-__DATA__
-{"last":"5"}
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`.
+test "a row-free closure param stays a plain call inside the clone" {
+  inspect(_start(), "5")
+}

--- a/fixtures/effect_resume_store_scheduler.vibe
+++ b/fixtures/effect_resume_store_scheduler.vibe
@@ -32,7 +32,9 @@ let _start = () -> Int {
   // r3 = 30: resuming b=20 completed the body (10 + 20).
   (0 - r1) * 10000 + (0 - r2) * 100 + r3
 }
-_start()
 
-__DATA__
-{"last":"10230"}
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`.
+test "stored resume drives the remaining body as a scheduler" {
+  inspect(_start(), "10230")
+}

--- a/fixtures/effect_stream_next_suspend_retarget.vibe
+++ b/fixtures/effect_stream_next_suspend_retarget.vibe
@@ -26,9 +26,9 @@ let _start = () -> Int {
   }
   value + Array::get(evals, 0)
 }
-_start()
 
-__DATA__
-{
-  "last": "42"
+// #1571: the expected value lives here, not in a `__DATA__` tail, and is
+// updatable with `vibe test --update`.
+test "Stream::next retargets before suspend CPS judges the handler" {
+  inspect(_start(), "42")
 }

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -1051,7 +1051,7 @@ scps_run_inspect() {
     exit 1
   fi
 }
-scps_run_expect "effect_resume_store_scheduler.vibe" "10230" "sched"
+scps_run_inspect "effect_resume_store_scheduler.vibe" "sched"
 scps_run_inspect "effect_resume_value_postprocess.vibe" "post"
 # Phase 3b yield bubbling now lives in
 # fixtures/effect_resume_call_bubbling_test.vibe (#1973).
@@ -1107,13 +1107,13 @@ scps_check_reject() {
 # the clone; want 5), including the delegation shape (pick_any forwards
 # its own param into pick's slot; want 5). One site passing a PERFORMING
 # literal taints the slot and the rejection stays.
-scps_run_expect "effect_closure_param_inert.vibe" "5" "inertparam"
+scps_run_inspect "effect_closure_param_inert.vibe" "inertparam"
 # Delegation pin now lives in
 # fixtures/effect_closure_param_inert_transitive_test.vibe (#1973).
 # #1536 (a), eager Stream slice: Stream::next must retarget before suspend
 # CPS evaluates a resume-value Async handler. The fixture also pins its
 # Array-backed ready Future[Option[T]] result and one evaluation (Some(41)+1).
-scps_run_expect "effect_stream_next_suspend_retarget.vibe" "42" "streamnext"
+scps_run_inspect "effect_stream_next_suspend_retarget.vibe" "streamnext"
 # Hygiene pin (user `__sn_next` + shadowed Future::ready, empty layout = 7)
 # now lives in fixtures/effect_stream_next_retarget_hygiene_test.vibe (#1973).
 # #1723: a local pure closure shadows a top-level function whose callback
@@ -1143,7 +1143,7 @@ scps_run_expect "effect_seq_head_match_scrutinee_suspend.vibe" "3210" "seqheadma
 # fixtures/effect_tail_selection_input_suspend_test.vibe (#1973).
 # #1536 direct plain-assignment RHS: name the resumed value on the CPS spine,
 # then assign and continue once.
-scps_run_expect "effect_assignment_rhs_suspend.vibe" "41112" "assignrhs"
+scps_run_inspect "effect_assignment_rhs_suspend.vibe" "assignrhs"
 # #1536 direct while condition: resume into the existing recursive loop
 # closure once per condition check.
 scps_run_expect "effect_while_condition_suspend.vibe" "3217" "whilecond"


### PR DESCRIPTION
Refs #1571. Does not close it — hundreds of `__DATA__` fixtures remain.

## What

Move four more suspend-CPS fixtures off a `__DATA__` tail onto in-source `inspect(...)` tests, matching #2070.

| fixture | want |
|---|---|
| `fixtures/effect_resume_store_scheduler.vibe` | `10230` |
| `fixtures/effect_closure_param_inert.vibe` | `5` |
| `fixtures/effect_stream_next_suspend_retarget.vibe` | `42` |
| `fixtures/effect_assignment_rhs_suspend.vibe` | `41112` |

Each keeps its existing `_start` logic. The trailing `_start()` eval and the `__DATA__` tail are gone; a `test` block now drives the run:

```vibe
test "..." {
  inspect(_start(), "<want>")
}
```

`inspect` is desugared before the checker, so no import is required.

## Gate

`tests/gates/late/run.sh` no longer `sed '/^__DATA__$/,$d'` these four.

- **Switched `scps_run_expect` → `scps_run_inspect`**:
  - `effect_resume_store_scheduler.vibe` / `"10230"` / `sched`
  - `effect_closure_param_inert.vibe` / `"5"` / `inertparam`
  - `effect_stream_next_suspend_retarget.vibe` / `"42"` / `streamnext`
  - `effect_assignment_rhs_suspend.vibe` / `"41112"` / `assignrhs`

Compile the fixture AS-IS with `__no_entry__` (no sed, no temp copy) and run the synthesized test runner. A mismatch prints inspect's own actual/expected.

`scps_run_expect` remains for the fixtures that still carry `__DATA__`.

## Verified

Compiled each fixture with the committed seed (`bootstrap/seed/compiler.wasm`) and ran `_start`. All four inspect tests passed (empty output, exit 0):

```
COMPILE_OK fixtures/effect_resume_store_scheduler.vibe
COMPILE_OK fixtures/effect_closure_param_inert.vibe
COMPILE_OK fixtures/effect_stream_next_suspend_retarget.vibe
COMPILE_OK fixtures/effect_assignment_rhs_suspend.vibe
RUN effect_resume_store_scheduler        OK exit=0 output=
RUN effect_closure_param_inert           OK exit=0 output=
RUN effect_stream_next_suspend_retarget  OK exit=0 output=
RUN effect_assignment_rhs_suspend        OK exit=0 output=
```

Empty output is the inspect-pass convention (mismatch would print actual/expected and fail the run).