### PR TITLE
fix(async): make the convention-mixing refusal say something a user can act on (#2065)

### DIFF
--- a/docs/wasip3-effect-alignment.md
+++ b/docs/wasip3-effect-alignment.md
@@ -314,7 +314,7 @@ trampoline を将来 `wasi:http/service` の
    `test_async_sleep_component_gate.sh` の主張。あわせて
    self-contained wrap が満たせない host import を **fail closed** に
    した — 以前は instantiate 不能な component を書いて exit 0 していた。
-   残り: TaskGroup 併用 (mixing guard reject のまま)。
+   残り: TaskGroup 併用 (mixing guard reject のまま — #2065)。**#2065 で実測**: convention の不一致は綴りだけで、boundary arm の `resume(v)` を名前に束縛すれば同じ handler が suspend-class になり guard は何も拒否しなくなる。露出するのは本当の壁のほうで、suspend-class boundary は entry body 全体の split 適格性を要求し、TaskGroup への入口は全部 `TaskGroup::run[T, rg, e](body: (TaskGroup[rg, e]) -> T with e)` = **row 変数の下の関数型パラメータ** を通る (#1727 の残り 1、健全性の線)。したがって依存は #1727 → #2065 であって park_kind ではない。
    **Decision 3 の named host streams も landed (spec §3.18)**: D3 終端
    probe (§3.17) の実測を受けて、`host_stream_named("body") ->
    HostStream` (pure、cell `[3, handle]`。当初は `Stream[Int]` だったが

--- a/fixtures/err_async_boundary_mixed_convention.vibe
+++ b/fixtures/err_async_boundary_mixed_convention.vibe
@@ -7,6 +7,18 @@
 /// miscompile. The supported shapes are: row-free entry + TaskGroup (the
 /// library discharges Async itself), or Async-row entry without
 /// suspend-class handlers (sequential sleep via the boundary).
+///
+/// #2065 measured why the two cannot simply be reconciled. The convention
+/// mismatch is only a SPELLING: the boundary arm is tail-resumptive because it
+/// writes `resume(v)` in callee position, and binding `resume` to a name first
+/// makes the identical handler suspend-class -- at which point this guard has
+/// nothing to reject. What that uncovers is the real wall: a suspend-class
+/// boundary requires the whole entry body to be split-eligible, and every route
+/// into a TaskGroup runs through
+/// `TaskGroup::run[T, rg, e](body: (TaskGroup[rg, e]) -> T with e)` -- a
+/// function-typed parameter under a ROW VARIABLE, which #1727 records as a
+/// soundness line rather than a gap. So no program is unblocked by flipping the
+/// spelling, and this fixture stays a rejection until #1727 lands.
 import @vibe/concurrent {
   TaskGroup, TaskHandle
 }

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -986,9 +986,11 @@ fn lc_entry_declares_async(stmts: Array[Stmt], entry_name: String) -> Bool {
 ///      sleep) preserves the blocking semantics. A program that ALSO uses
 ///      suspend-class Async handlers (e.g. TaskGroup) under an
 ///      Async-carrying entry row is rejected by the existing
-///      convention-mixing guard -- handle Async yourself before the entry
-///      in that case (fixture err_async_boundary_mixed_convention pins the
-///      message).
+///      convention-mixing guard -- drop `Async` from the entry row and let
+///      TaskGroup discharge it, or keep the Async entry and skip the tasks
+///      (fixture err_async_boundary_mixed_convention pins the message; the
+///      guard's own comment records why the two cannot be reconciled short
+///      of #1727).
 ///
 /// Keyed on the entry row (like lc_wrap_entry_error_boundary): programs
 /// whose entry row has no `Async` -- including the `__no_entry__`
@@ -3091,8 +3093,25 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
   let sleep_machinery = calls_sleep && !user_defines_sleep && (entry_has_async || has_async_handle)
   let hf_machinery = calls_host_future && !user_defines_host_future && entry_has_async
   let hs_machinery = calls_host_stream && !user_defines_host_stream && entry_has_async
+  // #2065: the old advice here was "handle Async inside the entry instead",
+  // which cannot be followed in the component lane -- an entry MUST carry
+  // `Async` for the async lift to be selected at all, so a user building an
+  // async component was told to do the one thing that would stop it being a
+  // component. Say what is actually true instead.
+  //
+  // Measured (#2065): the convention mismatch is NOT the blocker it looks
+  // like. The boundary arm is tail-resumptive only because it spells
+  // `resume(v)` in callee position; binding `resume` to a name first makes the
+  // same handler suspend-class (`scps_arm_refs_resume_value`), and then this
+  // guard has nothing to reject. What that exposes is the real wall: a
+  // suspend-class boundary requires the WHOLE entry body to be split-eligible,
+  // and every route into a TaskGroup goes through
+  // `TaskGroup::run[T, rg, e](body: (TaskGroup[rg, e]) -> T with e)` -- a
+  // function-typed parameter carrying a ROW VARIABLE, which is #1727's
+  // remaining gap 1 and a soundness line rather than an oversight. So the
+  // refusal stands; only its wording was wrong.
   if entry_has_async && (sleep_machinery || hf_machinery || hs_machinery) && has_spawn_suspend {
-    "Async entry boundary and TaskGroup::spawn_suspend are mixing the step convention; handle Async inside the entry instead"
+    "the entry's Async boundary and TaskGroup::spawn_suspend are mixing the step convention for one effect. Either drop `Async` from the entry row and let TaskGroup discharge it (row-free entry + TaskGroup::run), or keep the Async entry and use `sleep`/`await` directly instead of spawning tasks. Both together need #1727 (a row-variable callee taking a function cannot be proven suspend-eligible), tracked in #2065"
   } else {
     // Keying (#1218, tightened after gate 19 regressed on the first cut):
     //


### PR DESCRIPTION
A small diagnostic change, with a measurement behind it that re-points #2065.

## The message

The guard said:

> Async entry boundary and TaskGroup::spawn_suspend are mixing the step convention; **handle Async inside the entry instead**

given to someone whose entry **must** carry `Async` for the async lift to be selected at all. In the component lane it asked for the one thing that would stop the program being a component.

Now:

> the entry's Async boundary and TaskGroup::spawn_suspend are mixing the step convention for one effect. Either drop `Async` from the entry row and let TaskGroup discharge it (row-free entry + `TaskGroup::run`), or keep the Async entry and use `sleep`/`await` directly instead of spawning tasks. Both together need #1727 (a row-variable callee taking a function cannot be proven suspend-eligible), tracked in #2065

It keeps the `mixing the step convention` substring the gate greps for, so the three existing negative lanes are unchanged.

## The measurement behind it

I tried to remove the refusal before settling for rewording it.

**The convention mismatch is only a spelling.** ADR-0076 classifies a handle arm as suspend-class iff `resume` appears somewhere other than the immediate callee position (`scps_arm_refs_resume_value`, `inline_direct_perform.vibe:8673`). The injected boundary writes `resume(v)` in callee position. Binding `resume` to a name first is semantically identical — settle once, resume once — and makes the same handler suspend-class. I built that, gated on `has_spawn_suspend` so non-mixing programs keep their bytes, and deleted the guard.

**The mixing diagnostic disappeared**, and the refusal moved to:

```
a handler arm captures `resume` as a value (suspend class, ADR-0076 Phase 3a/3b),
but the handle body calls something this suspend lowering cannot see through
(a local closure, a method-style callee, a nested handle, or a function whose
declared row has a row variable) -- ... (#817)
```

A suspend-class boundary requires the **whole entry body** to be split-eligible. And every route into a TaskGroup runs through

```vibe
export fn TaskGroup::run[T, rg, e](body: (TaskGroup[rg, e]) -> T with e) -> T with Exception[TaskError] + e
```

a function-typed parameter under a **row variable** — #1727's remaining gap 1, which that issue is explicit is *a soundness line, not a hole*. Groups are minted nowhere else (`adopt` needs one), so there is no narrower API and no simpler body that the flip unblocks.

I reverted the experiment rather than land machinery that enables nothing. It is recorded at the guard site and on `err_async_boundary_mixed_convention.vibe`, so the next person starts from the real blocker.

## What this changes about #2065

Its dependency is **#1727**, not the third `park_kind`. Eligibility refuses these programs before the scheduler is ever reached; the `park_kind` work is still needed for a spawned task to *await a host waitable*, but it is not what is failing today. Full write-up on the issue: https://github.com/mizchi/vibe-lang/issues/2065#issuecomment-5314334040

## Verification

- `bash scripts/compiler_gate.sh` → exit 0, including gate 77's three negative lanes (`err_async_boundary_mixed_convention`, `err_async_boundary_mixed_operand`, `async_boundary_user_sleep_test`)
- the rejected program leaves no artifact behind, and the new text is what it emits
- `scripts/vibe_fmt.sh --check` clean on both touched files
- `pkf run pre-commit` passed

No behaviour change: the same programs are accepted and refused as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwospM2pqZv8ifD8tHRbNV)_