### PR TITLE
feat(checker): import-crossing per-fn #zero_alloc summaries

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1696,6 +1696,9 @@ fn add_one(x: Int) -> Int {
 - Modes: bare `#zero_alloc` (general heap only), `#zero_alloc(strict)`
   (region/arena too), `#zero_alloc(assume)` (caller trust boundary;
   inspectable source allocations in the assume body are still errors).
+- Import merge keeps a per-fn summary `(name, mode, site)`. An imported
+  `#zero_alloc(assume)` fn is trusted by the importer; the assume fn's own
+  summary still reports allocations in its body.
 - It applies to `fn` and `export fn`, and no other declaration.
 - Legacy `@zero_alloc` remains accepted for migration, but new code should use
   the `#` directive spelling shared with other declaration metadata.

--- a/docs/zero-alloc-check.md
+++ b/docs/zero-alloc-check.md
@@ -140,6 +140,10 @@ RC default のまま `#zero_alloc` は成立する。
   top-level fn 呼びは推移的に走査(visited set で再帰安全)。
   診断は `zero_alloc: fn 'X' may allocate: <site>`(経由呼び出しは
   `call to 'Y' which may allocate: ...` で連鎖)。
+  `zero_alloc_fn_summaries` は import merge 後の top-level fn ごとに
+  `(name, mode, site)` を返す (#1936)。`collect_merged_stmts` した
+  プログラムでも、imported assume は mode=`assume` で呼ぶ側から信頼され、
+  assume 本体の確保は fail-closed のままその行に残る。
 - **既知ギャップ(Phase 1 で許容)**: per-fn サマリの codegen 計装
   (ADR 本文 step 1 の「確保サイト計装」)は未着手 — 検査は lexical 型伝播を
   伴う AST 走査で先行。module body 内の fn、wasm-gc backend、

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -2420,6 +2420,69 @@ fn za_walk(e: Expr, ctors: Array[String], fn_names: Array[String], fn_bodies: Ar
   }
 }
 
+fn za_stmt_marker_mode(stmt: Stmt) -> String {
+  match stmt {
+    SExpr(me) => match me {
+      EIdent(mname, _) => if mname == "@zero_alloc_strict" {
+        "strict"
+      } else if mname == "@zero_alloc_assume" {
+        "assume"
+      } else if String::starts_with(mname, "@zero_alloc") {
+        "bare"
+      } else {
+        ""
+      },
+      _ => ""
+    },
+    _ => ""
+  }
+}
+
+fn za_eval_named_fn(name: String, mode: String, assume_names: Array[String], ctors: Array[String], fn_names: Array[String], fn_bodies: Array[Expr], fn_params: Array[Array[String]]) -> String {
+  let mut fidx = 0 - 1
+  let mut fi = 0
+  while fi < Array::length(fn_names) {
+    if Array::get(fn_names, fi) == name {
+      fidx = fi
+      fi = Array::length(fn_names)
+    } else {
+      fi = fi + 1
+    }
+  }
+  if fidx < 0 {
+    ""
+  } else {
+    let visited = array_empty()
+    if mode == "strict" {
+      Array::push(visited, "@za:strict")
+    } else if mode == "assume" {
+      Array::push(visited, "@za:assume")
+    } else {
+      Array::push(visited, "@za:")
+    }
+    let mut aj = 0
+    while aj < Array::length(assume_names) {
+      Array::push(visited, Array::get(assume_names, aj))
+      aj = aj + 1
+    }
+    Array::push(visited, name)
+    let seed_bound = array_empty()
+    let seed_typed_names = array_empty()
+    let seed_typed_kinds = array_empty()
+    let seed_ps = Array::get(fn_params, fidx)
+    let mut sbi = 0
+    while sbi < Array::length(seed_ps) {
+      let seed_fact = Array::get(seed_ps, sbi)
+      let seed_name = za_param_fact_name(seed_fact)
+      Array::push(seed_bound, seed_name)
+      Array::push(seed_typed_names, seed_name)
+      Array::push(seed_typed_kinds, za_param_fact_kind(seed_fact))
+      sbi = sbi + 1
+    }
+    za_walk(Array::get(fn_bodies, fidx), ctors, fn_names, fn_bodies, fn_params, visited, seed_bound, seed_typed_names, seed_typed_kinds)
+  }
+}
+
 /// ADR-0091 Phase 1: enforce `#zero_alloc` markers. The parser normalizes the
 /// canonical directive (and legacy `@zero_alloc`) to a top-level `SExpr`
 /// statement, which the linear backend drops, and it must IMMEDIATELY precede
@@ -2523,50 +2586,9 @@ export fn zero_alloc_check(stmts: Array[Stmt]) -> String {
       if target_name == "" {
         msg = "zero_alloc: '#zero_alloc' must immediately precede a fn declaration"
       } else {
-        let mut fi2 = 0
-        let mut fidx2 = 0 - 1
-        while fi2 < Array::length(fn_names) {
-          if Array::get(fn_names, fi2) == target_name {
-            fidx2 = fi2
-            fi2 = Array::length(fn_names)
-          } else {
-            fi2 = fi2 + 1
-          }
-        }
-        if fidx2 >= 0 {
-          let visited = array_empty()
-          if za_mode == "strict" {
-            Array::push(visited, "@za:strict")
-          } else if za_mode == "assume" {
-            Array::push(visited, "@za:assume")
-          } else {
-            Array::push(visited, "@za:")
-          }
-          let mut aj = 0
-          while aj < Array::length(assume_names) {
-            Array::push(visited, Array::get(assume_names, aj))
-            aj = aj + 1
-          }
-          Array::push(visited, target_name)
-          let seed_bound = array_empty()
-          let seed_typed_names = array_empty()
-          let seed_typed_kinds = array_empty()
-          let seed_ps = Array::get(fn_params, fidx2)
-          let mut sbi = 0
-          while sbi < Array::length(seed_ps) {
-            let seed_fact = Array::get(seed_ps, sbi)
-            let seed_name = za_param_fact_name(seed_fact)
-            Array::push(seed_bound, seed_name)
-            Array::push(seed_typed_names, seed_name)
-            Array::push(seed_typed_kinds, za_param_fact_kind(seed_fact))
-            sbi = sbi + 1
-          }
-          let r = za_walk(Array::get(fn_bodies, fidx2), ctors, fn_names, fn_bodies, fn_params, visited, seed_bound, seed_typed_names, seed_typed_kinds)
-          if r != "" {
-            msg = String::concat("zero_alloc: fn '", String::concat(target_name, String::concat("' may allocate: ", r)))
-          } else {
-            ()
-          }
+        let r = za_eval_named_fn(target_name, za_mode, assume_names, ctors, fn_names, fn_bodies, fn_params)
+        if r != "" {
+          msg = String::concat("zero_alloc: fn '", String::concat(target_name, String::concat("' may allocate: ", r)))
         } else {
           ()
         }
@@ -2577,6 +2599,84 @@ export fn zero_alloc_check(stmts: Array[Stmt]) -> String {
     mi = mi + 1
   }
   msg
+}
+
+/// #1936: one row per top-level fn after import merge: (name, mode, site).
+/// mode is "" / "bare" / "strict" / "assume". site is empty when that fn is
+/// proven allocation-free under its own mode. Not called from the compile
+/// hot path — only walk every fn when a caller asks for the summary table.
+export fn zero_alloc_fn_summaries(stmts: Array[Stmt]) -> Array[(String, String, String)] {
+  let fn_names = array_empty()
+  let fn_bodies = array_empty()
+  let fn_params = array_empty()
+  let fn_modes = array_empty()
+  let ctors = array_empty()
+  let assume_names = array_empty()
+  let mut si = 0
+  let mut prev_mode = ""
+  while si < Array::length(stmts) {
+    let stmt = Array::get(stmts, si)
+    let marker = za_stmt_marker_mode(stmt)
+    if marker != "" {
+      prev_mode = marker
+    } else {
+      match stmt {
+        SLet(_, _, lname, _, lval) => match lval {
+          EFn(_, _, efn_params, _, _, fb) => {
+            Array::push(fn_names, lname)
+            Array::push(fn_bodies, fb)
+            Array::push(fn_params, za_param_facts(efn_params))
+            Array::push(fn_modes, prev_mode)
+            if prev_mode == "assume" {
+              Array::push(assume_names, lname)
+            } else {
+              ()
+            }
+            prev_mode = ""
+          },
+          _ => {
+            prev_mode = ""
+          }
+        },
+        SEnum(_, _, _, variants, _) => {
+          prev_mode = ""
+          let mut vi = 0
+          while vi < Array::length(variants) {
+            let (vname, _) = Array::get(variants, vi)
+            Array::push(ctors, vname)
+            vi = vi + 1
+          }
+        },
+        SSuberror(_, _, sub_variants) => {
+          prev_mode = ""
+          let mut vi2 = 0
+          while vi2 < Array::length(sub_variants) {
+            let (vname2, _) = Array::get(sub_variants, vi2)
+            Array::push(ctors, vname2)
+            vi2 = vi2 + 1
+          }
+        },
+        SStruct(_, sname, _, _, _, _) => {
+          prev_mode = ""
+          Array::push(ctors, sname)
+        },
+        _ => {
+          prev_mode = ""
+        }
+      }
+    }
+    si = si + 1
+  }
+  let rows = array_empty()
+  let mut ri = 0
+  while ri < Array::length(fn_names) {
+    let name = Array::get(fn_names, ri)
+    let mode = Array::get(fn_modes, ri)
+    let site = za_eval_named_fn(name, mode, assume_names, ctors, fn_names, fn_bodies, fn_params)
+    Array::push(rows, (name, mode, site))
+    ri = ri + 1
+  }
+  rows
 }
 
 //# ADR-0092 borrow-inference slice 1: per-fn borrowed arg0

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -50,6 +50,7 @@ fn md_consume_count_b(e: Expr, name: String, bfns: Array[String], bmasks: Array[
 fn md_shadow_zeroed_bmasks(e: Expr, bfns: Array[String], bmasks: Array[Int]) -> Array[Int]
 fn md_consume_count_pre(e: Expr, name: String, bfns: Array[String], bmasks_zeroed: Array[Int]) -> Int
 fn zero_alloc_check(stmts: Array[Stmt]) -> String
+fn zero_alloc_fn_summaries(stmts: Array[Stmt]) -> Array[(String, String, String)]
 fn typed_operator_alloc_kind(expr: Expr, names: Array[String], kinds: Array[String]) -> String
 fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String]
 fn bmask_max_param() -> Int

--- a/lib/@vibe/compiler/runtime/zero_alloc_import_summary_test.vibe
+++ b/lib/@vibe/compiler/runtime/zero_alloc_import_summary_test.vibe
@@ -1,0 +1,93 @@
+// #1936: per-fn #zero_alloc summaries must survive collect_merged_stmts
+// (the shipped import-merge used by vibe check / FS compile).
+
+import @vibe/compiler/codegen/common_analysis {
+  zero_alloc_check, zero_alloc_fn_summaries
+}
+
+import @vibe/compiler/loader {
+  collect_merged_stmts
+}
+
+fn summary_mode(rows: Array[(String, String, String)], name: String) -> String {
+  let mut i = 0
+  let mut found = ""
+  while i < Array::length(rows) {
+    let (n, mode, _) = Array::get(rows, i)
+    if n == name {
+      found = mode
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn summary_site(rows: Array[(String, String, String)], name: String) -> String {
+  let mut i = 0
+  let mut found = ""
+  while i < Array::length(rows) {
+    let (n, _, site) = Array::get(rows, i)
+    if n == name {
+      found = site
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+test "#1936: imported allocator appears in per-fn summaries and the check diagnostic" {
+  let dep = "export fn dirty() -> Array[Int] {\n  [1, 2]\n}\n"
+  let main = "import ./dep.vibe { dirty }\n#zero_alloc\nfn hot() -> Array[Int] {\n  dirty()\n}\n"
+  let merged = collect_merged_stmts([
+    ("dep.vibe", dep),
+    ("main.vibe", main)
+  ])
+  let rows = zero_alloc_fn_summaries(merged)
+  assert_eq(summary_mode(rows, "dirty"), "")
+  assert(String::contains(summary_site(rows, "dirty"), "array literal"))
+  assert_eq(summary_mode(rows, "hot"), "bare")
+  assert(String::contains(summary_site(rows, "hot"), "dirty"))
+  assert(String::contains(summary_site(rows, "hot"), "array literal"))
+  let msg = zero_alloc_check(merged)
+  assert(String::contains(msg, "zero_alloc"))
+  assert(String::contains(msg, "hot"))
+  assert(String::contains(msg, "dirty"))
+  assert(String::contains(msg, "array literal"))
+}
+
+test "#1936: imported assume is a trusted summary and does not fail the importer" {
+  let dep = "#zero_alloc(assume)\nexport fn host_shim(x: Int) -> Int {\n  x + 1\n}\n"
+  let main = "import ./dep.vibe { host_shim }\n#zero_alloc\nfn hot(x: Int) -> Int {\n  host_shim(x)\n}\n"
+  let merged = collect_merged_stmts([
+    ("dep.vibe", dep),
+    ("main.vibe", main)
+  ])
+  let rows = zero_alloc_fn_summaries(merged)
+  assert_eq(summary_mode(rows, "host_shim"), "assume")
+  assert_eq(summary_site(rows, "host_shim"), "")
+  assert_eq(summary_mode(rows, "hot"), "bare")
+  assert_eq(summary_site(rows, "hot"), "")
+  assert_eq(zero_alloc_check(merged), "")
+}
+
+test "#1936: imported assume stays fail-closed on its own summary" {
+  let dep = "#zero_alloc(assume)\nexport fn dirty() -> Array[Int] {\n  [1, 2]\n}\n"
+  let main = "import ./dep.vibe { dirty }\n#zero_alloc\nfn hot() -> Array[Int] {\n  dirty()\n}\n"
+  let merged = collect_merged_stmts([
+    ("dep.vibe", dep),
+    ("main.vibe", main)
+  ])
+  let rows = zero_alloc_fn_summaries(merged)
+  assert_eq(summary_mode(rows, "dirty"), "assume")
+  assert(String::contains(summary_site(rows, "dirty"), "array literal"))
+  assert_eq(summary_mode(rows, "hot"), "bare")
+  assert_eq(summary_site(rows, "hot"), "")
+  let msg = zero_alloc_check(merged)
+  assert(String::contains(msg, "zero_alloc"))
+  assert(String::contains(msg, "dirty"))
+  assert(String::contains(msg, "array literal"))
+}


### PR DESCRIPTION
## Why

#1936 still lacked module/import-crossing per-fn `#zero_alloc` summaries after #2076. Same-file modes worked; a merged import graph had no queryable `(name, mode, site)` table.

## What

- Add shipped `zero_alloc_fn_summaries` next to `zero_alloc_check`.
- Tests drive `collect_merged_stmts` (the FS compile / `vibe check` merge) plus the shipped analysis:
  - imported allocator is visible in the importer's diagnostic and in both summaries
  - imported `#zero_alloc(assume)` is trusted by the importer
  - assume stays fail-closed on its own body/summary
- Compile hot path still uses `zero_alloc_check` only (does not walk every unmarked fn).

## Out of scope

- Module-body functions, wasm-gc, codegen allocation-site instrumentation.
- #1936 stays open.

## Test plan

- [x] `vibe test` on `zero_alloc_import_summary_test.vibe` + `typed_operator_alloc_spans_test.vibe` (twice)
- [ ] CI `compiler-gate` + `ci-required`