### PR TITLE
feat(checker): fold a Diag::Report slice into MutList::empty

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -63,7 +63,7 @@ import ./checker_spawnable.vibe {
 }
 
 import ./checker_escape.vibe {
-  expr_free_in, mut_binding_escapes
+  diag_report_into, expr_free_in, mut_binding_escapes
 }
 
 //# Functions
@@ -6248,7 +6248,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           if is_region_token {
             ()
           } else {
-            Array::push(errors, String::concat("MutList::empty requires the region token bound by `region r { ... }` (the token is second-class and cannot be forged or passed through function parameters)", off_marker_len(callee_off, String::length(name))))
+            diag_report_into(errors, String::concat("MutList::empty requires the region token bound by `region r { ... }` (the token is second-class and cannot be forged or passed through function parameters)", off_marker_len(callee_off, String::length(name))))
           }
           (tab_call_ty(tytab, call_off, CtNamed("MutList", Array::slice([
             CtUnknown,

--- a/lib/@vibe/compiler/checker/checker_escape.vibe
+++ b/lib/@vibe/compiler/checker/checker_escape.vibe
@@ -30,6 +30,10 @@ import @vibe/compiler/core {
   Expr, Pat, TypeExpr
 }
 
+import @vibe/core {
+  array_empty
+}
+
 //# Functions
 
 /// True when `pat` binds `name` (and therefore shadows an outer `let mut` of
@@ -378,4 +382,51 @@ fn esc_scan(expr: Expr, name: String) -> Bool {
 /// inside it that shadows it, is correctly not this binding.
 export fn mut_binding_escapes(body: Expr, name: String) -> Bool {
   esc_scan(body, name)
+}
+
+//# #1951 Diag::Report — compiler-private diagnostic effect.
+//
+// One bounded slice (MutList::empty region-token) reports through this
+// effect. Handlers are local to these helpers: collect-all appends into the
+// caller-owned errors array, fail-fast returns the payload via resume.
+// No global sink, and checker.vibe does not wrap its giant functions in a
+// handle (that blew selfcompile heap).
+
+effect Diag {
+  Report(String) -> String
+}
+
+export fn diag_report_into(errors: Array[String], msg: String) -> Unit {
+  let _ = handle {
+    perform Diag::Report(msg)
+  } with Diag {
+    Report(m) => {
+      Array::push(errors, m)
+      resume(m)
+    }
+  }
+}
+
+export fn diag_collect_all(msg: String) -> Array[String] {
+  let out = array_empty()
+  diag_report_into(out, msg)
+  out
+}
+
+export fn diag_collect_all_many(msgs: Array[String]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(msgs) {
+    diag_report_into(out, Array::get(msgs, i))
+    i = i + 1
+  }
+  out
+}
+
+export fn diag_fail_fast(msg: String) -> String {
+  handle {
+    perform Diag::Report(msg)
+  } with Diag {
+    Report(m) => resume(m)
+  }
 }

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -169,6 +169,10 @@ fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow: Array[
 // --- checker_escape.vibe (#1262 / ADR-0100 (1))
 fn mut_binding_escapes(body: Expr, name: String) -> Bool
 fn expr_free_in(expr: Expr, name: String) -> Bool
+fn diag_report_into(errors: Array[String], msg: String) -> Unit
+fn diag_collect_all(msg: String) -> Array[String]
+fn diag_collect_all_many(msgs: Array[String]) -> Array[String]
+fn diag_fail_fast(msg: String) -> String
 
 // --- checker_spawnable.vibe (#1081 step 3 Phase B)
 fn closure_free_names(body: Expr, params: Array[(String, Option[TypeExpr])]) -> Array[String]

--- a/lib/@vibe/compiler/tests/checker_diag_report_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_diag_report_test.vibe
@@ -47,7 +47,13 @@ test "#1951: collect-all and fail-fast agree on a payload" {
 }
 
 test "#1951: accumulator and Diag handler agree on the MutList corpus" {
-  let kinds = ["empty0", "empty1", "str", "two", "ok"]
+  let kinds = [
+    "empty0",
+    "empty1",
+    "str",
+    "two",
+    "ok"
+  ]
   let acc = array_empty()
   let mut i = 0
   while i < Array::length(kinds) {

--- a/lib/@vibe/compiler/tests/checker_diag_report_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_diag_report_test.vibe
@@ -1,11 +1,10 @@
-// #1951: Diag::Report collect-all vs fail-fast payload contract.
-// A handle in checker.vibe blew selfcompile heap (1,165,374,504 >
-// 1,164,658,668), so the effect lives in this test and the MutList::empty
-// slice stays on the existing accumulator. Abortive `Report(m) => m` binds
-// the empty string; tail `resume(m)` delivers the payload.
+// #1951: shipped Diag::Report slice. Collect-all / fail-fast live in the
+// checker package. The MutList::empty region-token site reports through
+// Diag into the existing errors array (no global sink, no handle wrapped
+// around checker.vibe).
 
 import @vibe/compiler/checker {
-  check_program
+  check_program, diag_collect_all, diag_collect_all_many, diag_fail_fast
 }
 
 import @vibe/compiler/syntax {
@@ -25,32 +24,21 @@ fn first_check_error(source: String) -> String {
   }
 }
 
-effect Diag {
-  Report(String) -> String
-}
-
-fn diag_collect_all(msg: String) -> Array[String] {
-  let out = array_empty()
-  let _ = handle {
-    perform Diag::Report(msg)
-  } with Diag {
-    Report(m) => {
-      Array::push(out, m)
-      resume(m)
-    }
-  }
-  out
-}
-
-fn diag_fail_fast(msg: String) -> String {
-  handle {
-    perform Diag::Report(msg)
-  } with Diag {
-    Report(m) => resume(m)
+fn corpus_source(kind: String) -> String {
+  if kind == "empty0" {
+    "fn main() -> Int {\n  let xs = MutList::empty(0)\n  0\n}\n"
+  } else if kind == "empty1" {
+    "fn main() -> Int {\n  let xs = MutList::empty(1)\n  0\n}\n"
+  } else if kind == "str" {
+    "fn main() -> Int {\n  let xs = MutList::empty(\"x\")\n  0\n}\n"
+  } else if kind == "two" {
+    "fn main() -> Int {\n  let xs = MutList::empty(0)\n  let ys = MutList::empty(1)\n  0\n}\n"
+  } else {
+    "fn main() -> Int {\n  region r {\n    let xs = MutList::empty(r)\n    MutList::length(xs)\n  }\n}\n"
   }
 }
 
-test "#1951: collect-all and fail-fast agree on the payload" {
+test "#1951: collect-all and fail-fast agree on a payload" {
   let msg = "MutList::empty requires the region token bound by `region r { ... }`"
   let collected = diag_collect_all(msg)
   assert_eq(Array::length(collected), 1)
@@ -58,8 +46,35 @@ test "#1951: collect-all and fail-fast agree on the payload" {
   assert_eq(diag_fail_fast(msg), msg)
 }
 
-test "#1951: MutList::empty(0) still reports the region-token diagnostic" {
-  let source = "fn main() -> Int {\n  let xs = MutList::empty(0)\n  0\n}\n"
-  let msg = first_check_error(source)
-  assert(String::contains(msg, "MutList::empty requires the region token"))
+test "#1951: accumulator and Diag handler agree on the MutList corpus" {
+  let kinds = ["empty0", "empty1", "str", "two", "ok"]
+  let acc = array_empty()
+  let mut i = 0
+  while i < Array::length(kinds) {
+    let kind = Array::get(kinds, i)
+    let src = corpus_source(kind)
+    let msg = first_check_error(src)
+    if kind == "ok" {
+      assert_eq(msg, "")
+    } else {
+      assert(String::contains(msg, "MutList::empty requires the region token"))
+      Array::push(acc, msg)
+    }
+    i = i + 1
+  }
+  let via_diag = diag_collect_all_many(acc)
+  assert_eq(Array::length(via_diag), Array::length(acc))
+  let mut j = 0
+  while j < Array::length(acc) {
+    assert_eq(Array::get(via_diag, j), Array::get(acc, j))
+    assert_eq(diag_fail_fast(Array::get(acc, j)), Array::get(acc, j))
+    j = j + 1
+  }
+}
+
+test "#1951: two MutList::empty forgeries keep source order in the first diagnostic" {
+  let two = first_check_error(corpus_source("two"))
+  let first = first_check_error(corpus_source("empty0"))
+  assert(String::contains(two, "MutList::empty requires the region token"))
+  assert_eq(two, first)
 }


### PR DESCRIPTION
## Why

#1951 needs a compiler-private `Diag::Report` effect with collect-all and fail-fast handlers, plus one bounded checker slice. Wrapping `checker.vibe` in a handle previously measured `heap_ptr_bytes 1,165,374,504` and failed the then-gate.

## What

- Define `Diag` and the handlers in existing `checker_escape.vibe` (no new compiler file, no handle around `checker.vibe`).
- `MutList::empty` region-token diagnostic reports via `diag_report_into` into the caller-owned errors array.
- No global sink.
- Tests drive shipped `check_program` + `diag_collect_all` / `diag_fail_fast` on a corpus (`empty(0)`, `empty(1)`, string, two sites, clean `region r`).

## Heap / wall

- Current baseline `1,165,371,696`, gate `1,281,908,865`.
- The reverted handle-in-`checker.vibe` number (`1,165,374,504`) is already under that gate; this slice is smaller.
- Corpus `vibe test` wall: 1.17s.
- CI `Selfcompile KPI heap gate` is the official heap number.

## Out of scope

- Migrating the other ~245 error-array parameters.
- #1951 stays open.

## Test plan

- [x] Red: import of `diag_collect_all` failed (`is not exported`)
- [x] Green: `checker_diag_report_test.vibe` + `checker_mutlist_region_sig_test.vibe` twice (6 tests)
- [ ] CI `compiler-gate` + `ci-required`