### PR TITLE
feat(checker): keep allows authority off the with row

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -9,6 +9,8 @@ import @vibe/compiler/core {
   TypeExpr,
   canonical_builtin_name,
   canonical_exception_effect_name,
+  effect_row_allows_text,
+  effect_row_emitted_text,
   entry_cache_safe_effects,
   env_lookup,
   exception_effect_labels_equal,
@@ -16,8 +18,6 @@ import @vibe/compiler/core {
   exception_label_kind,
   exception_throw_label_for_kind,
   expr_children,
-  effect_row_allows_text,
-  effect_row_emitted_text,
   is_entry_admitted_effect,
   is_entry_cache_safe_operation,
   is_entry_runtime_managed_effect,
@@ -2288,7 +2288,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                     // sibling operation of the same effect is already
                     // authorized at operation granularity, e.g. `with {
                     // Ask::Other }` + a bare `perform Ask::Get`).
-                    if is_program_entry_name(fn_name) && !in_handle && entry_user_operation_requires_handler(op_name) && decl_authorizes_op(root_declared, op_name) {
+                    if is_program_entry_name(fn_name) && !in_handle && !entry_allows_authority() && entry_user_operation_requires_handler(op_name) && decl_authorizes_op(root_declared, op_name) {
                       Array::push(errors, EEUndischargedEntryEffect(fn_name, op_name, effect_name_of_op(op_name), call_off))
                     } else if (!is_exception_effect_name(eff) || error_row_checked()) && !in_handle && !decl_authorizes_op(declared, required_op) {
                       Array::push(errors, make_contextual_row_error(fn_name, declared, [
@@ -2306,7 +2306,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                 // above, just without an args list to look past.
                 EIdent(op_name, _) => {
                   let eff = effect_name_of_op(op_name)
-                  if is_program_entry_name(fn_name) && !in_handle && entry_user_operation_requires_handler(op_name) && decl_authorizes_op(root_declared, op_name) {
+                  if is_program_entry_name(fn_name) && !in_handle && !entry_allows_authority() && entry_user_operation_requires_handler(op_name) && decl_authorizes_op(root_declared, op_name) {
                     Array::push(errors, EEUndischargedEntryEffect(fn_name, op_name, effect_name_of_op(op_name), call_off))
                   } else if (!is_exception_effect_name(eff) || error_row_checked()) && !in_handle && !decl_authorizes_op(declared, op_name) {
                     Array::push(errors, make_contextual_row_error(fn_name, declared, [
@@ -2539,7 +2539,15 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
         let body_declared = labels_union(declared, discharged)
         // Unknown wildcard arms stay conservative for the legacy surface,
         // but a structurally empty handler must not gain that permission.
-        let body_in_handle = in_handle || Array::length(discharged) > 0 || (Array::length(arms) > 0 && Array::length(discharged) == 0)
+        // Known discharge stays out of `in_handle`: that flag also skips the
+        // undeclared-effect check, so treating `handle Ask` as "inside a
+        // handle" lets `Logger` leak through (#626 criterion 2). Discharge
+        // of the named effect is already in `body_declared`.
+        let body_in_handle = if Array::length(arms) > 0 && Array::length(discharged) == 0 {
+          true
+        } else {
+          in_handle
+        }
         Array::push(stack, (body, body_declared, body_in_handle, ov_names, ov_effs, kinds))
         let mut ai = 0
         while ai < Array::length(arms) {
@@ -2835,6 +2843,26 @@ fn current_ret_fn_rows() -> Array[String] {
   }
 }
 
+// #1961: when an entry row has `allows`, `check_entry_declared_effects`
+// already owns unhandled ⊆ authorized (handlers subtracted). The perform
+// walk must not also emit EEUndischargedEntryEffect for those ops — that
+// check cannot see lexical discharge without setting `in_handle`, which
+// would reopen #626 criterion 2.
+let entry_allows_authority_cell = array_empty()
+
+fn set_entry_allows_authority(on: Bool) -> Unit {
+  Array::truncate(entry_allows_authority_cell, 0)
+  Array::push(entry_allows_authority_cell, if on {
+    1
+  } else {
+    0
+  })
+}
+
+fn entry_allows_authority() -> Bool {
+  Array::length(entry_allows_authority_cell) > 0 && Array::get(entry_allows_authority_cell, 0) == 1
+}
+
 /// #1451 (struct-field position): rows declared by a STRUCT FIELD's type, keyed
 /// `Struct::field`. Same defect as the return position and the same cause -- a
 /// closure literal stored into
@@ -2921,6 +2949,7 @@ export fn check_perform_effects_expr(root: Expr, root_declared: Array[String], r
 
 fn check_perform_effects_binding_tx(fn_name: String, ty: Option[TypeExpr], body: Expr, fn_names: Array[String], fn_effs: Array[Array[String]], fn_param_effs: Array[Array[Array[String]]]) -> Array[EffectError] {
   let sig_labels = sig_type_effect_labels(ty)
+  set_entry_allows_authority(is_program_entry_name(fn_name) && String::length(effect_row_allows_text(raw_fn_effect_string(ty, body))) > 0)
   match body {
     // #885: build the callback-parameter overlay for THIS binding's own
     // function value from its (possibly untyped, see merge_param_types_with_sig)

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -16,6 +16,8 @@ import @vibe/compiler/core {
   exception_label_kind,
   exception_throw_label_for_kind,
   expr_children,
+  effect_row_allows_text,
+  effect_row_emitted_text,
   is_entry_admitted_effect,
   is_entry_cache_safe_operation,
   is_entry_runtime_managed_effect,
@@ -74,6 +76,7 @@ export enum EffectError {
   // separate from concrete effects so the fix-it never suggests handling a
   // type-level row variable as though it were an effect declaration.
   EEUnresolvedEntryEffectRow(String, String, Int);
+  EEUnauthorizedEntryOperation(String, String, String, Int);
   EEProviderOperationCollision(String);
   EEAssignImmutable(String);
   // #1539: provider-owned stdin lifecycle operations cannot be transported as
@@ -173,6 +176,14 @@ export fn effect_error_to_string(err: EffectError) -> String {
     },
     EEUnresolvedEntryEffectRow(entry_name, variables, off) => {
       let body = String::concat("entry point '", String::concat(entry_name, String::concat("' has unresolved effect row { ", String::concat(variables, " }: entry rows must be concrete\nhint: close the entry row, or discharge each concrete effect with `handle` before it reaches the entry boundary"))))
+      if off >= 0 {
+        String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
+      } else {
+        body
+      }
+    },
+    EEUnauthorizedEntryOperation(entry_name, operation, allows, off) => {
+      let body = String::concat("entry point '", String::concat(entry_name, String::concat("' emits unhandled `", String::concat(operation, String::concat("` that is not authorized by `allows ", String::concat(allows, "`\nhint: handle the operation, or add it to the `allows` clause"))))))
       if off >= 0 {
         String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
       } else {
@@ -730,7 +741,7 @@ fn effect_row_parse(eff: Option[String]) -> Option[Array[String]] {
     None => None,
     Some(s) => {
       let labels = array_empty()
-      let raw = String::split(s, ",")
+      let raw = String::split(effect_row_emitted_text(s), ",")
       let mut i = 0
       while i < Array::length(raw) {
         let label = canonical_exception_effect_name(String::trim(Array::get(raw, i)))
@@ -1437,10 +1448,20 @@ fn entry_label_is_user_declared_operation(label: String) -> Bool {
   String::index_of(label, "::") > 0 && effect_row_has_label(Some(entry_user_effect_operations), label)
 }
 
-fn standard_provider_owns_operation(label: String) -> Bool {
+export fn standard_provider_owns_operation(label: String) -> Bool {
   match builtin_call_effect(label) {
     Some(owner) => is_entry_admitted_effect(owner) && label == canonical_builtin_name(label),
     None => false
+  }
+}
+
+fn authority_covers_operation(auth: String, emitted: String) -> Bool {
+  if auth == emitted {
+    true
+  } else if String::index_of(auth, "::") < 0 && standard_provider_owns_operation(emitted) {
+    effect_name_of_op(emitted) == auth
+  } else {
+    false
   }
 }
 
@@ -1542,25 +1563,116 @@ fn first_expr_offset(root: Expr) -> Int {
   first
 }
 
+fn raw_fn_effect_string(ty: Option[TypeExpr], body: Expr) -> String {
+  match ty {
+    Some(TyFn(_, _, Some(s))) => s,
+    _ => match body {
+      EFn(_, _, _, _, Some(s), _) => s,
+      _ => ""
+    }
+  }
+}
+
+fn collect_expr_handle_effects(root: Expr) -> Array[String] {
+  let out = no_str_labels()
+  let stack = Array::slice([
+    root
+  ], 0, 1)
+  while Array::length(stack) > 0 {
+    let n = Array::length(stack)
+    let expr = Array::get(stack, n - 1)
+    Array::truncate(stack, n - 1)
+    match expr {
+      EHandle(_, arms) => {
+        let discharged = collect_handle_effects(arms)
+        let mut i = 0
+        while i < Array::length(discharged) {
+          let lab = Array::get(discharged, i)
+          if effect_row_has_label(Some(out), lab) {
+            ()
+          } else {
+            Array::push(out, lab)
+          }
+          i = i + 1
+        }
+      },
+      _ => ()
+    }
+    let children = expr_children(expr)
+    let mut ci = 0
+    while ci < Array::length(children) {
+      Array::push(stack, Array::get(children, ci))
+      ci = ci + 1
+    }
+  }
+  out
+}
+
+fn label_is_handled(label: String, handled: Array[String]) -> Bool {
+  if effect_row_has_label(Some(handled), label) {
+    true
+  } else {
+    let base = effect_name_of_op(label)
+    effect_row_has_label(Some(handled), base)
+  }
+}
+
+fn label_is_authorized(label: String, auth: Array[String]) -> Bool {
+  let mut i = 0
+  let mut ok = false
+  while i < Array::length(auth) {
+    if authority_covers_operation(Array::get(auth, i), label) {
+      ok = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  ok
+}
+
 fn check_entry_declared_effects(fn_name: String, ty: Option[TypeExpr], body: Expr) -> Array[EffectError] {
   let errors = array_empty()
   if is_program_entry_name(fn_name) {
-    let labels = fn_binding_effects(ty, body)
-    let unresolved = entry_unresolved_labels(labels)
-    let bad = entry_unadmitted_labels(labels)
-    if Array::length(unresolved) > 0 || Array::length(bad) > 0 {
-      let inspect_body = match body {
-        EFn(_, _, _, _, _, fbody) => fbody,
-        _ => body
-      }
-      let off = first_expr_offset(inspect_body)
+    let raw = raw_fn_effect_string(ty, body)
+    let allows = effect_row_allows_text(raw)
+    let inspect_body = match body {
+      EFn(_, _, _, _, _, fbody) => fbody,
+      _ => body
+    }
+    let off = first_expr_offset(inspect_body)
+    if String::length(allows) > 0 {
+      let emitted = effect_row_labels(effect_row_parse(Some(raw)))
+      let auth = effect_row_labels(effect_row_parse(Some(allows)))
+      let handled = collect_expr_handle_effects(inspect_body)
+      let unresolved = entry_unresolved_labels(emitted)
       if Array::length(unresolved) > 0 {
         Array::push(errors, EEUnresolvedEntryEffectRow(fn_name, join_labels(unresolved), off))
       } else {
-        Array::push(errors, EEUndischargedEntryEffect(fn_name, join_labels(bad), join_labels(entry_handler_labels(bad)), off))
+        let mut ui = 0
+        while ui < Array::length(emitted) {
+          let lab = Array::get(emitted, ui)
+          if label_is_handled(lab, handled) || label_is_authorized(lab, auth) {
+            ()
+          } else {
+            Array::push(errors, EEUnauthorizedEntryOperation(fn_name, lab, allows, off))
+          }
+          ui = ui + 1
+        }
       }
     } else {
-      ()
+      let labels = fn_binding_effects(ty, body)
+      let unresolved = entry_unresolved_labels(labels)
+      let bad = entry_unadmitted_labels(labels)
+      if Array::length(unresolved) > 0 || Array::length(bad) > 0 {
+        if Array::length(unresolved) > 0 {
+          Array::push(errors, EEUnresolvedEntryEffectRow(fn_name, join_labels(unresolved), off))
+        } else {
+          Array::push(errors, EEUndischargedEntryEffect(fn_name, join_labels(bad), join_labels(entry_handler_labels(bad)), off))
+        }
+      } else {
+        ()
+      }
     }
   } else {
     ()
@@ -1646,7 +1758,7 @@ fn collect_handle_effects(arms: Array[(Pat, Expr)]) -> Array[String] {
 fn fn_binding_effects(ty: Option[TypeExpr], body: Expr) -> Array[String] {
   let sig = sig_type_effect_labels(ty)
   match body {
-    EFn(_, _, _, _, eff, _) => labels_union(sig, effect_row_labels(effect_row_parse(eff))),
+    EFn(_, _, _, _, eff, _) => labels_union(sig, labels_union(effect_row_labels(effect_row_parse(eff)), effect_row_allows_labels(eff))),
     _ => sig
   }
 }
@@ -2427,11 +2539,7 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
         let body_declared = labels_union(declared, discharged)
         // Unknown wildcard arms stay conservative for the legacy surface,
         // but a structurally empty handler must not gain that permission.
-        let body_in_handle = if Array::length(arms) > 0 && Array::length(discharged) == 0 {
-          true
-        } else {
-          in_handle
-        }
+        let body_in_handle = in_handle || Array::length(discharged) > 0 || (Array::length(arms) > 0 && Array::length(discharged) == 0)
         Array::push(stack, (body, body_declared, body_in_handle, ov_names, ov_effs, kinds))
         let mut ai = 0
         while ai < Array::length(arms) {
@@ -2612,9 +2720,23 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
   errors
 }
 
+fn effect_row_allows_labels(eff: Option[String]) -> Array[String] {
+  match eff {
+    None => no_str_labels(),
+    Some(s) => {
+      let allows = effect_row_allows_text(s)
+      if String::length(allows) == 0 {
+        no_str_labels()
+      } else {
+        effect_row_labels(effect_row_parse(Some(allows)))
+      }
+    }
+  }
+}
+
 fn sig_type_effect_labels(topt: Option[TypeExpr]) -> Array[String] {
   match topt {
-    Some(TyFn(_, _, eff)) => effect_row_labels(effect_row_parse(eff)),
+    Some(TyFn(_, _, eff)) => labels_union(effect_row_labels(effect_row_parse(eff)), effect_row_allows_labels(eff)),
     _ => effect_row_labels(effect_row_parse(None))
   }
 }

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -287,6 +287,7 @@ fn set_error_row_checked(on: Bool) -> Unit
 fn typing_semantics_seed() -> String
 fn effect_error_to_string(err: EffectError) -> String
 fn effect_row_contains_label(eff: Option[String], wanted: String) -> Bool
+fn standard_provider_owns_operation(label: String) -> Bool
 fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> Array[EffectError]
 fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectError]
 fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError]

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -53,6 +53,9 @@ export ./exception_effect.vibe {
 }
 
 export ./standard_effect_policy.vibe {
+  effect_row_allows_marker,
+  effect_row_allows_text,
+  effect_row_emitted_text,
   entry_cache_safe_effects,
   has_standard_effect_policy,
   has_standard_host_provider,
@@ -60,6 +63,7 @@ export ./standard_effect_policy.vibe {
   is_entry_cache_safe_operation,
   is_entry_runtime_managed_effect,
   is_runtime_scheduled_effect,
+  split_effect_row_authority,
   standard_effect_policy_names,
   standard_provider_default_resource_kind,
   test_bench_default_effects

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -165,6 +165,10 @@ fn standard_effect_policy_names() -> Array[String]
 fn test_bench_default_effects() -> Array[String]
 fn entry_cache_safe_effects() -> Array[String]
 fn is_entry_cache_safe_operation(label: String) -> Bool
+fn effect_row_allows_marker() -> String
+fn split_effect_row_authority(row: String) -> (String, String)
+fn effect_row_emitted_text(row: String) -> String
+fn effect_row_allows_text(row: String) -> String
 
 // --- polyfill
 fn __to_string(n: Int) -> String

--- a/lib/@vibe/compiler/core/standard_effect_policy.vibe
+++ b/lib/@vibe/compiler/core/standard_effect_policy.vibe
@@ -216,3 +216,30 @@ export fn is_entry_cache_safe_operation(label: String) -> Bool {
     label == "Console::write_stream" || label == "Console::write_char"
   }
 }
+
+/// Marker the parser stores between the emitted `with` row and the `allows`
+/// authority row. Same spelling as parser_base.encode.
+export fn effect_row_allows_marker() -> String {
+  "\n#allows "
+}
+
+export fn split_effect_row_authority(row: String) -> (String, String) {
+  let sep = effect_row_allows_marker()
+  let idx = String::index_of(row, sep)
+  if idx < 0 {
+    (row, "")
+  } else {
+    (String::substring(row, 0, idx), String::substring(row, idx + String::length(sep), String::length(row)))
+  }
+}
+
+export fn effect_row_emitted_text(row: String) -> String {
+  let (emitted, _) = split_effect_row_authority(row)
+  emitted
+}
+
+export fn effect_row_allows_text(row: String) -> String {
+  let (_, allows) = split_effect_row_authority(row)
+  allows
+}
+

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -1,7 +1,7 @@
 //# Entry-boundary effect admission (#1683)
 
 import @vibe/compiler/checker {
-  check_program
+  check_program, standard_provider_owns_operation
 }
 
 import @vibe/compiler/syntax {
@@ -89,6 +89,43 @@ test "#1961: a user effect cannot impersonate an exact host provider operation" 
   let msg = first_check_error(source)
   assert(String::contains(msg, "collides with a registry-owned host provider operation"))
   assert(String::contains(msg, "Fs::read_file"))
+}
+
+test "#1961: provider ownership is exact operation identity" {
+  assert(standard_provider_owns_operation("Console::write_stream"))
+  assert(standard_provider_owns_operation("Fs::read_file"))
+  assert(!standard_provider_owns_operation("Console::Get"))
+  assert(!standard_provider_owns_operation("Console"))
+  assert(!standard_provider_owns_operation("Fs"))
+  assert(!standard_provider_owns_operation("Ask::Get"))
+}
+
+test "#1961: allows is not a second spelling of with" {
+  let source = "effect Ask { Get() -> Int }\nfn main() -> Int with Ask::Get allows Fs {\n  perform Ask::Get()\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "Ask::Get"))
+  assert(String::contains(msg, "allows"))
+  assert(String::contains(msg, "authorized"))
+}
+
+test "#1961: lexically handled emit does not need allows authority" {
+  let source = "effect Ask { Get() -> Int }\nfn main() -> Int with Ask::Get allows Fs {\n  handle { perform Ask::Get() } with Ask { Get() => resume(1) }\n}\n"
+  assert_eq(first_check_error(source), "")
+}
+
+test "#1961: transcript of handled / unhandled / impersonation diagnostics" {
+  let handled = "effect Ask { Get() -> Int }\nfn main() -> Int with Ask::Get allows Fs {\n  handle { perform Ask::Get() } with Ask { Get() => resume(1) }\n}\n"
+  let unhandled = "effect Ask { Get() -> Int }\nfn main() -> Int with Ask::Get allows Fs {\n  perform Ask::Get()\n}\n"
+  let impersonation = "effect Fs { read_file(String) -> String }\nfn main() -> String with Fs::read_file {\n  perform Fs::read_file(\"x\")\n}\n"
+  let handled_msg = first_check_error(handled)
+  let unhandled_msg = first_check_error(unhandled)
+  let impersonation_msg = first_check_error(impersonation)
+  assert_eq(handled_msg, "")
+  assert(String::contains(unhandled_msg, "emits unhandled `Ask::Get`"))
+  assert(String::contains(unhandled_msg, "not authorized by `allows Fs`"))
+  assert(String::contains(unhandled_msg, "handle the operation, or add it to the `allows` clause"))
+  assert(String::contains(impersonation_msg, "collides with a registry-owned host provider operation"))
+  assert(String::contains(impersonation_msg, "Fs::read_file"))
 }
 
 test "#1683: an ordinary helper still receives the row-addition hint" {

--- a/lib/@vibe/compiler/tests/checker_perform_effects_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_perform_effects_test.vibe
@@ -214,6 +214,8 @@ test "handle does not discharge a different effect" {
     ]), EInt(0))
   ])
   let errors = check_perform_effects_expr(handle_expr, no_labels(), false)
+  // #1961 must not set in_handle for a known discharge: that flag also
+  // skips the undeclared-effect check and lets Logger leak (#626 c2).
   assert(Array::length(errors) > 0)
 }
 

--- a/lib/@vibe/compiler/tests/parser_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_test.vibe
@@ -881,10 +881,7 @@ test "#1429: `with ()` is the empty row and `with {}` is rejected" {
 
 //# #1345 / ADR-0088: the `allows` clause
 
-test "#1345: `allows` folds into the single row" {
-  // ADR-0088 decision 1: the split is a checked audit surface, not a second
-  // row representation, so `with A allows C` and `with A + C` are the SAME
-  // row and produce byte-identical output.
+test "#1961: `allows` is independent of `with`" {
   let split = handle {
     print_program(parse_program(lex("let f: (Int) -> Int with Log::Emit allows Fs::read_file = (x) -> { x }")))
   } with Exception {
@@ -896,11 +893,10 @@ test "#1345: `allows` folds into the single row" {
     Throw(e) => String::concat("ERROR: ", e)
   }
   assert(!String::starts_with(split, "ERROR: "))
-  assert(split == flat)
-  // The corollary, and a known gap: the printer cannot render the clause
-  // back, so `vibe normalize` ERASES it. Pinned here so that whoever adds
-  // AST-level preservation sees this assertion flip.
-  assert(!String::contains(split, "allows"))
+  assert(split != flat)
+  assert(String::contains(split, "allows"))
+  assert(String::contains(split, "Log::Emit"))
+  assert(String::contains(split, "Fs::read_file"))
 }
 
 test "#1345: `with () allows C` is the capability-only row" {
@@ -910,7 +906,7 @@ test "#1345: `with () allows C` is the capability-only row" {
     Throw(e) => String::concat("ERROR: ", e)
   }
   assert(!String::starts_with(out, "ERROR: "))
-  assert(String::contains(out, "with Fs::read_file"))
+  assert(String::contains(out, "allows Fs::read_file"))
 }
 
 test "#1345: `allows` works in type position too" {
@@ -922,7 +918,7 @@ test "#1345: `allows` works in type position too" {
     Throw(e) => String::concat("ERROR: ", e)
   }
   assert(!String::starts_with(out, "ERROR: "))
-  assert(String::contains(out, "with Log::Emit + Fs::read_file"))
+  assert(String::contains(out, "allows Fs::read_file"))
 }
 
 test "#1345: `allows` is contextual, not reserved" {

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -110,6 +110,33 @@ test "wit_from_program: undeclared capability effect renders as comment" {
   assert(String::contains(wit, "export stats: func(n: s64) -> s64;"))
 }
 
+test "#1961: WIT does not admit a non-owned operation as the host provider" {
+  let stats_ann = TyFn([
+    TyName("Int")
+  ], TyName("Int"), Some("Console::Get"))
+  let stmts = [
+    SLet(true, false, "stats", Some(stats_ann), EFn(no_strings(), array_empty(), [
+      ("n", Some(TyName("Int")))
+    ], Some(TyName("Int")), None, EUnit))
+  ]
+  let wit = wit_from_program(stmts, stmts, "caps")
+  assert(!String::contains(wit, "host capability effect 'Console'"))
+  assert(String::contains(wit, "export stats: func(n: s64) -> s64;"))
+}
+
+test "#1961: WIT admits an exact owned host operation" {
+  let stats_ann = TyFn([
+    TyName("Int")
+  ], TyName("Int"), Some("Console::write_stream"))
+  let stmts = [
+    SLet(true, false, "stats", Some(stats_ann), EFn(no_strings(), array_empty(), [
+      ("n", Some(TyName("Int")))
+    ], Some(TyName("Int")), None, EUnit))
+  ]
+  let wit = wit_from_program(stmts, stmts, "caps")
+  assert(String::contains(wit, "host capability effect 'Console'"))
+}
+
 test "validate_serve_handler: accepts the 4-string contract" {
   let stmts = [
     SLet(true, false, "handler", None, efn_of_string_params(serve_handler_param_names()))

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -1,7 +1,11 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Stmt, TypeExpr, is_entry_runtime_managed_effect, is_exception_effect_name
+  Expr, Stmt, TypeExpr, effect_row_emitted_text, has_standard_host_provider, is_entry_runtime_managed_effect, is_exception_effect_name
+}
+
+import @vibe/compiler/checker {
+  standard_provider_owns_operation
 }
 
 import @vibe/core {
@@ -211,13 +215,24 @@ fn wit_func_text(param_names: Array[String], param_types: Array[TypeExpr], ret: 
 
 /// Split a parsed effect row ("A, B") into names. The parser joins the
 /// `with A + B` list with ", " (parser_base.vibe collect_effect_names).
+fn wit_is_host_provider_label(label: String) -> Bool {
+  if standard_provider_owns_operation(label) {
+    true
+  } else if String::index_of(label, "::") >= 0 {
+    false
+  } else {
+    has_standard_host_provider(label) && !is_entry_runtime_managed_effect(label)
+  }
+}
+
 fn wit_split_effect_row(row: String) -> Array[String] {
   let out = array_empty()
-  let len = String::length(row)
+  let emitted = effect_row_emitted_text(row)
+  let len = String::length(emitted)
   let mut piece = ""
   let mut i = 0
   while i < len {
-    let c = String::char_code_at(row, i)
+    let c = String::char_code_at(emitted, i)
     if c == 44 {
       if String::length(piece) > 0 {
         Array::push(out, piece)
@@ -652,32 +667,31 @@ export fn wit_from_program(export_stmts: Array[Stmt], effect_stmts: Array[Stmt],
     let mut ei = 0
     while ei < Array::length(ex_effects) {
       let ename = Array::get(ex_effects, ei)
-      if !is_exception_effect_name(ename) {
-        let resolved = array_empty()
-        wit_resolve_effect_names_into(ename, wit_es_names, wit_es_members_list, resolved)
-        let mut ri = 0
-        while ri < Array::length(resolved) {
-          let rname = Array::get(resolved, ri)
-          // Standard entry/runtime handling produces no WIT world import.
-          // `Error`/`Exception[K]` escape through the entry boundary as a
-          // component trap rather than a provider requirement; `Async`
-          // surfaces through the export's `async func` lifting mode instead.
-          // core/standard_effect_policy.vibe centralizes this unchanged
-          // behavior for the checker and WIT generator.
-          //
-          // The deferred declaration-versus-provider inversion below
-          // (`def_idx < 0`) is intentionally unchanged: a declared `effect
-          // X { .. }` still maps to an interface while an undeclared label is
-          // treated as a host capability. This slice does not alter WIT
-          // mapping, provider selection, or handler semantics.
-          if is_entry_runtime_managed_effect(rname) {
-            ()
-          } else if !wit_array_contains(used_effects, rname) {
-            Array::push(used_effects, rname)
+      if !is_exception_effect_name(ename) && !is_entry_runtime_managed_effect(ename) {
+        if wit_is_host_provider_label(ename) {
+          let host = wit_effect_name_of(ename)
+          if !wit_array_contains(used_effects, host) {
+            Array::push(used_effects, host)
           } else {
             ()
           }
-          ri = ri + 1
+        } else {
+          let resolved = array_empty()
+          wit_resolve_effect_names_into(ename, wit_es_names, wit_es_members_list, resolved)
+          let mut ri = 0
+          while ri < Array::length(resolved) {
+            let rname = Array::get(resolved, ri)
+            if is_entry_runtime_managed_effect(rname) {
+              ()
+            } else if has_standard_host_provider(rname) && !wit_is_host_provider_label(ename) {
+              ()
+            } else if !wit_array_contains(used_effects, rname) {
+              Array::push(used_effects, rname)
+            } else {
+              ()
+            }
+            ri = ri + 1
+          }
         }
       } else {
         ()

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -1100,9 +1100,8 @@ fn parse_effect_item(tokens: Array[Token], pos: Int) -> (String, Int) with Excep
 /// syntax that does not parse. `?` belongs with the slice that gives it
 /// meaning (strict grade matching, `perform?` -> Attempt[T, E]).
 ///
-/// `allows` is different and IS shipped here: it desugars to the same single
-/// row, so `with A allows C` behaves exactly as `with A + C` -- there is no
-/// half-implemented behaviour behind it.
+/// `allows` is shipped as independent authority (#1961): `with A allows C`
+/// is stored as the emitted row plus a `#allows` marker, not as `with A + C`.
 
 /// #1429: the braceless row `A + B`. Items are separated by `+` and the row
 /// ends at the first token that is not `+` -- which is why the separator is
@@ -1174,15 +1173,9 @@ fn parse_effect_row_base(tokens: Array[Token], pos: Int) -> (String, Int) with E
 /// no gain. The position is unambiguous because nothing else may follow a row:
 /// a declaration continues with `{`, a `let` with `=`, a type with `,`/`)`.
 ///
-/// The two clauses desugar to ONE row (`A ∪ C`), which is ADR-0088 decision 1:
-/// the split is a checked audit surface, not a second row representation, so
-/// contract hash and WIT projection stay invariant under the spelling.
-///
-/// KNOWN GAP (this slice is the parser only): because the split is erased at
-/// parse time, the printer renders `with A + C` and `vibe normalize` therefore
-/// ERASES an `allows` clause. For a clause whose whole purpose is to make the
-/// capability surface visible, that is wrong -- preserving it needs the split
-/// carried in the AST, which is a later slice.
+/// #1961: the clauses stay distinct. The emitted `with` row and the `allows`
+/// authority are stored as `emitted + "\\n#allows " + caps` so checker / WIT
+/// can recover both. They are not unioned into one row.
 ///
 /// The classification check (ADR-0088 decision 1) DOES run -- see
 /// check_allows_clause_items / check_split_with_clause_items below. Still
@@ -1289,14 +1282,12 @@ export fn parse_effect_row(tokens: Array[Token], pos: Int) -> (String, Int) with
       // with the split.
       check_split_with_clause_items(row)
       check_allows_clause_items(caps)
-      let joined = if String::length(row) == 0 {
-        caps
-      } else if String::length(caps) == 0 {
+      let encoded = if String::length(caps) == 0 {
         row
       } else {
-        "\{row}, \{caps}"
+        String::concat(row, String::concat("\n#allows ", caps))
       }
-      (joined, after_caps)
+      (encoded, after_caps)
     } else {
       (row, after_row)
     },

--- a/lib/@vibe/parser/printer.vibe
+++ b/lib/@vibe/parser/printer.vibe
@@ -51,10 +51,23 @@ fn join(arr: Array[String], sep: String) -> String {
 /// printer) printed `with { Error }`, so running both on one file flipped the
 /// spelling back and forth.
 fn print_effect_row(e: String) -> String {
-  if String::length(e) == 0 {
-    " with ()"
+  let sep = "\n#allows "
+  let idx = String::index_of(e, sep)
+  if idx < 0 {
+    if String::length(e) == 0 {
+      " with ()"
+    } else {
+      String::concat(" with ", join(String::split(e, ", "), " + "))
+    }
   } else {
-    String::concat(" with ", join(String::split(e, ", "), " + "))
+    let emitted = String::substring(e, 0, idx)
+    let allows = String::substring(e, idx + String::length(sep), String::length(e))
+    let with_part = if String::length(emitted) == 0 {
+      " with ()"
+    } else {
+      String::concat(" with ", join(String::split(emitted, ", "), " + "))
+    }
+    String::concat(with_part, String::concat(" allows ", join(String::split(allows, ", "), " + ")))
   }
 }
 


### PR DESCRIPTION
## Why

#1961: `with` is emitted operations; `allows` is provider authority. They were the same row (`with A allows C` == `with A + C`). WIT admitted host providers by effect-name prefix, so `Console::Get` became host `Console`.

## What

- Parser stores `emitted + \"\\n#allows \" + caps` instead of unioning.
- Printer preserves `with A allows C`.
- Entry check: unhandled emit ⊆ allows. Handled operations need no allows item.
- Actionable diagnostic: `emits unhandled \`Ask::Get\` that is not authorized by \`allows Fs\``.
- WIT uses `standard_provider_owns_operation` (same identity as checker/cache). `Console::Get` is not a host Console import; `Console::write_stream` is.

## Tests

- `checker_entry_effect_test.vibe`: handled-accept, unhandled-reject, impersonation, operation identity
- `wit_gen_test.vibe`: non-owned op is not host-admitted
- `parser_test.vibe`: allows is not folded into `with A + C`

Two full `vibe test` runs of the entry + policy files: 32 tests, both green.

## Out of scope

- Grade matching, `allows` only at entry (still accepted anywhere a row appears).
- #1961 stays open for those.

## Test plan

- [x] Red: unhandled `with Ask::Get allows Fs` lacked `allows`/`authorized`; WIT admitted `Console::Get` as host Console
- [x] Green: 4 files / 122 tests, then 2x 32-test transcripts
- [ ] CI `compiler-gate` + `ci-required`