### PR TITLE
feat(checker): apply allows on helpers and freeze instantiate identity

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -18,6 +18,7 @@ import @vibe/compiler/core {
   exception_label_kind,
   exception_throw_label_for_kind,
   expr_children,
+  has_standard_host_provider,
   is_entry_admitted_effect,
   is_entry_cache_safe_operation,
   is_entry_runtime_managed_effect,
@@ -77,6 +78,7 @@ export enum EffectError {
   // type-level row variable as though it were an effect declaration.
   EEUnresolvedEntryEffectRow(String, String, Int);
   EEUnauthorizedEntryOperation(String, String, String, Int);
+  EEUnauthorizedInstantiateAuthority(String);
   EEProviderOperationCollision(String);
   EEAssignImmutable(String);
   // #1539: provider-owned stdin lifecycle operations cannot be transported as
@@ -183,13 +185,19 @@ export fn effect_error_to_string(err: EffectError) -> String {
       }
     },
     EEUnauthorizedEntryOperation(entry_name, operation, allows, off) => {
-      let body = String::concat("entry point '", String::concat(entry_name, String::concat("' emits unhandled `", String::concat(operation, String::concat("` that is not authorized by `allows ", String::concat(allows, "`\nhint: handle the operation, or add it to the `allows` clause"))))))
+      let who = if is_program_entry_name(entry_name) {
+        String::concat("entry point '", String::concat(entry_name, "'"))
+      } else {
+        String::concat("'", String::concat(entry_name, "'"))
+      }
+      let body = String::concat(who, String::concat(" emits unhandled `", String::concat(operation, String::concat("` that is not authorized by `allows ", String::concat(allows, "`\nhint: handle the operation, or add it to the `allows` clause")))))
       if off >= 0 {
         String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
       } else {
         body
       }
     },
+    EEUnauthorizedInstantiateAuthority(label) => String::concat("allows `", String::concat(label, "` cannot be frozen as instantiate authority: it is not a registry-owned host provider operation")),
     EEProviderOperationCollision(operation) => String::concat("user effect operation `", String::concat(operation, "` collides with a registry-owned host provider operation; rename the user operation so it cannot impersonate provider authority")),
     EEAssignImmutable(name) => String::concat("cannot assign to immutable binding `", String::concat(name, "` (declare it with `let mut`)")),
     EEStdinProviderValueReference(name) => String::concat("stdin provider operations are direct-call-only; wrap `", String::concat(name, "` in an explicitly effectful function")),
@@ -1456,6 +1464,18 @@ export fn standard_provider_owns_operation(label: String) -> Bool {
   }
 }
 
+/// #1961: instantiate freeze uses the same identity as WIT/cache/checker.
+/// A bare provider name (`Fs`) is authority for that namespace. A qualified
+/// label is authority only when it is an exact registry-owned operation
+/// (`Console::write_stream`). `Console::Get` is not frozen as host Console.
+export fn is_instantiate_authority(label: String) -> Bool {
+  if String::index_of(label, "::") < 0 {
+    has_standard_host_provider(label)
+  } else {
+    standard_provider_owns_operation(label)
+  }
+}
+
 fn authority_covers_operation(auth: String, emitted: String) -> Bool {
   if auth == emitted {
     true
@@ -1722,46 +1742,54 @@ fn label_is_authorized(label: String, auth: Array[String]) -> Bool {
 
 fn check_entry_declared_effects(fn_name: String, ty: Option[TypeExpr], body: Expr) -> Array[EffectError] {
   let errors = array_empty()
-  if is_program_entry_name(fn_name) {
-    let raw = raw_fn_effect_string(ty, body)
-    let allows = effect_row_allows_text(raw)
-    let inspect_body = match body {
-      EFn(_, _, _, _, _, fbody) => fbody,
-      _ => body
+  let raw = raw_fn_effect_string(ty, body)
+  let allows = effect_row_allows_text(raw)
+  let inspect_body = match body {
+    EFn(_, _, _, _, _, fbody) => fbody,
+    _ => body
+  }
+  let off = first_expr_offset(inspect_body)
+  if String::length(allows) > 0 {
+    let emitted = effect_row_labels(effect_row_parse(Some(raw)))
+    let auth = effect_row_labels(effect_row_parse(Some(allows)))
+    let mut ai = 0
+    while ai < Array::length(auth) {
+      let lab = Array::get(auth, ai)
+      if is_instantiate_authority(lab) {
+        ()
+      } else {
+        Array::push(errors, EEUnauthorizedInstantiateAuthority(lab))
+      }
+      ai = ai + 1
     }
-    let off = first_expr_offset(inspect_body)
-    if String::length(allows) > 0 {
-      let emitted = effect_row_labels(effect_row_parse(Some(raw)))
-      let auth = effect_row_labels(effect_row_parse(Some(allows)))
-      let unhandled = collect_unhandled_entry_ops(inspect_body)
-      let unresolved = entry_unresolved_labels(emitted)
+    let unhandled = collect_unhandled_entry_ops(inspect_body)
+    let unresolved = entry_unresolved_labels(emitted)
+    if Array::length(unresolved) > 0 {
+      Array::push(errors, EEUnresolvedEntryEffectRow(fn_name, join_labels(unresolved), off))
+    } else {
+      let mut ui = 0
+      while ui < Array::length(unhandled) {
+        let lab = Array::get(unhandled, ui)
+        if label_is_authorized(lab, auth) {
+          ()
+        } else {
+          Array::push(errors, EEUnauthorizedEntryOperation(fn_name, lab, allows, off))
+        }
+        ui = ui + 1
+      }
+    }
+  } else if is_program_entry_name(fn_name) {
+    let labels = fn_binding_effects(ty, body)
+    let unresolved = entry_unresolved_labels(labels)
+    let bad = entry_unadmitted_labels(labels)
+    if Array::length(unresolved) > 0 || Array::length(bad) > 0 {
       if Array::length(unresolved) > 0 {
         Array::push(errors, EEUnresolvedEntryEffectRow(fn_name, join_labels(unresolved), off))
       } else {
-        let mut ui = 0
-        while ui < Array::length(unhandled) {
-          let lab = Array::get(unhandled, ui)
-          if label_is_authorized(lab, auth) {
-            ()
-          } else {
-            Array::push(errors, EEUnauthorizedEntryOperation(fn_name, lab, allows, off))
-          }
-          ui = ui + 1
-        }
+        Array::push(errors, EEUndischargedEntryEffect(fn_name, join_labels(bad), join_labels(entry_handler_labels(bad)), off))
       }
     } else {
-      let labels = fn_binding_effects(ty, body)
-      let unresolved = entry_unresolved_labels(labels)
-      let bad = entry_unadmitted_labels(labels)
-      if Array::length(unresolved) > 0 || Array::length(bad) > 0 {
-        if Array::length(unresolved) > 0 {
-          Array::push(errors, EEUnresolvedEntryEffectRow(fn_name, join_labels(unresolved), off))
-        } else {
-          Array::push(errors, EEUndischargedEntryEffect(fn_name, join_labels(bad), join_labels(entry_handler_labels(bad)), off))
-        }
-      } else {
-        ()
-      }
+      ()
     }
   } else {
     ()

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -288,6 +288,7 @@ fn typing_semantics_seed() -> String
 fn effect_error_to_string(err: EffectError) -> String
 fn effect_row_contains_label(eff: Option[String], wanted: String) -> Bool
 fn standard_provider_owns_operation(label: String) -> Bool
+fn is_instantiate_authority(label: String) -> Bool
 fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> Array[EffectError]
 fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectError]
 fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError]

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -1,7 +1,7 @@
 //# Entry-boundary effect admission (#1683)
 
 import @vibe/compiler/checker {
-  check_program, standard_provider_owns_operation
+  check_program, is_instantiate_authority, standard_provider_owns_operation
 }
 
 import @vibe/compiler/syntax {
@@ -118,6 +118,39 @@ test "#1961: a handle that does not enclose the perform is not lexical" {
   let msg = first_check_error(source)
   assert(String::contains(msg, "emits unhandled `Ask::Get`"))
   assert(String::contains(msg, "not authorized by `allows Fs`"))
+}
+
+test "#1961: allows authorizes operations on a non-entry function" {
+  let source = "fn helper() -> Unit with () allows Console::write_stream {\n  Console::write_stream(\"hi\")\n}\nfn main() -> Int { 0 }\n"
+  assert_eq(first_check_error(source), "")
+}
+
+test "#1961: allows on a non-entry function still rejects unauthorized ops" {
+  let source = "fn helper() -> String with () allows Console::write_stream {\n  Console::read_stream(0)\n}\nfn main() -> Int { 0 }\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "helper"))
+  assert(String::contains(msg, "Console::read_stream"))
+  assert(String::contains(msg, "allows"))
+  assert(String::contains(msg, "authorized"))
+  assert(!String::contains(msg, "entry point"))
+}
+
+test "#1961: instantiate freeze uses exact operation identity" {
+  assert(is_instantiate_authority("Console::write_stream"))
+  assert(is_instantiate_authority("Fs::read_file"))
+  assert(is_instantiate_authority("Fs"))
+  assert(is_instantiate_authority("Stdout"))
+  assert(is_instantiate_authority("Console"))
+  assert(!is_instantiate_authority("Console::Get"))
+  assert(!is_instantiate_authority("Ask::Get"))
+}
+
+test "#1961: allows Console::Get cannot be frozen as instantiate authority" {
+  let source = "fn main() -> Int with () allows Console::Get {\n  0\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "Console::Get"))
+  assert(String::contains(msg, "instantiate"))
+  assert(!String::contains(msg, "host capability effect"))
 }
 
 test "#1961: allows Console::write_stream does not grant console input" {


### PR DESCRIPTION
## Summary
Remaining #1961 holes against the shipped checker:

- **Non-entry \`allows\`.** \`fn helper() with () allows Console::write_stream\` authorizes output and rejects \`Console::read_stream\` with the same unhandled/allows diagnostic (not an entry-only check).
- **Instantiate freeze.** \`is_instantiate_authority\` is the same identity as WIT/cache/checker: bare host providers (\`Fs\`) and exact owned operations (\`Console::write_stream\`). \`allows Console::Get\` cannot be frozen as host Console.

## Test plan
- \`checker_entry_effect_test.vibe\`
- helper write accepts; helper read rejects without saying \`entry point\`
- \`allows Console::Get\` rejects with instantiate authority diagnostic