### PR TITLE
feat(checker): parse allows optional grade and freeze BindingLock

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1468,16 +1468,58 @@ export fn standard_provider_owns_operation(label: String) -> Bool {
 /// A bare provider name (`Fs`) is authority for that namespace. A qualified
 /// label is authority only when it is an exact registry-owned operation
 /// (`Console::write_stream`). `Console::Get` is not frozen as host Console.
-export fn is_instantiate_authority(label: String) -> Bool {
-  if String::index_of(label, "::") < 0 {
-    has_standard_host_provider(label)
+fn strip_authority_grade(label: String) -> String {
+  let n = String::length(label)
+  if n > 0 && String::char_code_at(label, n - 1) == 63 {
+    String::substring(label, 0, n - 1)
   } else {
-    standard_provider_owns_operation(label)
+    label
   }
 }
 
+fn authority_is_optional(label: String) -> Bool {
+  let n = String::length(label)
+  n > 0 && String::char_code_at(label, n - 1) == 63
+}
+
+export fn is_instantiate_authority(label: String) -> Bool {
+  let core = strip_authority_grade(label)
+  if String::index_of(core, "::") < 0 {
+    has_standard_host_provider(core)
+  } else {
+    standard_provider_owns_operation(core)
+  }
+}
+
+/// #1961 / ADR-0088 L2: freeze optional resolution before run.
+/// Required owned operations are Granted; Optional ones are NotGranted
+/// (non-TTY instantiate default). Labels that are not instantiate
+/// authority are dropped — check_entry_declared_effects already rejects them.
+export fn freeze_binding_lock(labels: Array[String]) -> Array[(String, String)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(labels) {
+    let lab = Array::get(labels, i)
+    if is_instantiate_authority(lab) {
+      let core = strip_authority_grade(lab)
+      let status = if authority_is_optional(lab) {
+        "NotGranted"
+      } else {
+        "Granted"
+      }
+      Array::push(out, (core, status))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 fn authority_covers_operation(auth: String, emitted: String) -> Bool {
-  if auth == emitted {
+  if authority_is_optional(auth) {
+    false
+  } else if auth == emitted {
     true
   } else if String::index_of(auth, "::") < 0 && standard_provider_owns_operation(emitted) {
     effect_name_of_op(emitted) == auth

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -289,6 +289,7 @@ fn effect_error_to_string(err: EffectError) -> String
 fn effect_row_contains_label(eff: Option[String], wanted: String) -> Bool
 fn standard_provider_owns_operation(label: String) -> Bool
 fn is_instantiate_authority(label: String) -> Bool
+fn freeze_binding_lock(labels: Array[String]) -> Array[(String, String)]
 fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> Array[EffectError]
 fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectError]
 fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError]

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -1,7 +1,7 @@
 //# Entry-boundary effect admission (#1683)
 
 import @vibe/compiler/checker {
-  check_program, is_instantiate_authority, standard_provider_owns_operation
+  check_program, freeze_binding_lock, is_instantiate_authority, standard_provider_owns_operation
 }
 
 import @vibe/compiler/syntax {
@@ -151,6 +151,46 @@ test "#1961: allows Console::Get cannot be frozen as instantiate authority" {
   assert(String::contains(msg, "Console::Get"))
   assert(String::contains(msg, "instantiate"))
   assert(!String::contains(msg, "host capability effect"))
+}
+
+test "#1961: optional allows does not authorize a required operation" {
+  let source = "fn main() -> String with () allows Fs::read_file? {\n  Fs::read_file(\"x\")\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "Fs::read_file"))
+  assert(String::contains(msg, "allows"))
+  assert(String::contains(msg, "authorized"))
+}
+
+test "#1961: required allows still authorizes the required operation" {
+  let source = "fn main() -> String with () allows Fs::read_file {\n  Fs::read_file(\"x\")\n}\n"
+  assert_eq(first_check_error(source), "")
+}
+
+test "#1961: BindingLock freeze is Granted for required and NotGranted for optional" {
+  let lock = freeze_binding_lock([
+    "Fs::read_file",
+    "Console::write_stream?"
+  ])
+  assert_eq(Array::length(lock), 2)
+  let mut saw_optional = false
+  let mut saw_required = false
+  let mut i = 0
+  while i < Array::length(lock) {
+    let (name, status) = Array::get(lock, i)
+    if name == "Console::write_stream" {
+      assert_eq(status, "NotGranted")
+      saw_optional = true
+    } else if name == "Fs::read_file" {
+      assert_eq(status, "Granted")
+      saw_required = true
+    } else {
+      assert(false)
+    }
+    i = i + 1
+  }
+  assert(saw_optional)
+  assert(saw_required)
+  assert(!is_instantiate_authority("Console::Get?"))
 }
 
 test "#1961: allows Console::write_stream does not grant console input" {

--- a/lib/@vibe/compiler/tests/parser_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_test.vibe
@@ -1017,17 +1017,14 @@ test "#1345: classification uses the base effect name, and excludes Async" {
   assert(String::contains(async_cap, "not a capability effect"))
 }
 
-test "#1345: the `?` grade suffix does NOT parse yet" {
-  // Deliberately absent: the checker compares row items as opaque labels, so
-  // `Cfg::Read?` would be a different effect from `Cfg::Read` and a function
-  // declaring the Optional form would be told to declare BOTH. `?` ships with
-  // the slice that gives it meaning (strict grade matching / `perform?`).
+test "#1345: the `?` grade suffix parses on allows items" {
   let out = handle {
     print_program(parse_program(lex("let f: (Int) -> Int with () allows Fs::read_file? = (x) -> { x }")))
   } with Exception {
     Throw(e) => String::concat("ERROR: ", e)
   }
-  assert(String::starts_with(out, "ERROR: "))
+  assert(!String::starts_with(out, "ERROR: "))
+  assert(String::contains(out, "allows Fs::read_file?"))
 }
 
 test "#1429: a parenthesized non-empty row is rejected by name" {

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -1085,23 +1085,13 @@ fn parse_effect_item(tokens: Array[Token], pos: Int) -> (String, Int) with Excep
   }
 }
 
-/// #1345 / ADR-0088: the `?` GRADE suffix (`Fs::Read[Cfg]?` = Optional) is
-/// NOT parsed yet, on purpose.
+/// #1345 / ADR-0088 / #1961: `?` is the Optional grade and is legal only on
+/// an `allows` item (`allows Fs::read_file?`). The checker treats `Op?` as
+/// not authorizing a required perform/call. `?` is still rejected on the
+/// `with` row so it cannot become a second emitted-effect spelling.
 ///
-/// It was implemented and then pulled back out of this slice, because the
-/// checker has no grade model: it compares row items as opaque labels, so
-/// `Cfg::Read?` and `Cfg::Read` are two DIFFERENT effects to it. A function
-/// declaring the Optional form and performing the operation gets
-///
-///   declared { Cfg::Read? }, requires { Cfg::Read }
-///   hint: add 'with Cfg::Read + Cfg::Read?'
-///
-/// -- syntax that parses but produces a nonsense diagnostic is worse than
-/// syntax that does not parse. `?` belongs with the slice that gives it
-/// meaning (strict grade matching, `perform?` -> Attempt[T, E]).
-///
-/// `allows` is shipped as independent authority (#1961): `with A allows C`
-/// is stored as the emitted row plus a `#allows` marker, not as `with A + C`.
+/// `allows` is independent authority: `with A allows C` is stored as the
+/// emitted row plus a `#allows` marker, not as `with A + C`.
 
 /// #1429: the braceless row `A + B`. Items are separated by `+` and the row
 /// ends at the first token that is not `+` -- which is why the separator is
@@ -1112,12 +1102,28 @@ fn parse_effect_item(tokens: Array[Token], pos: Int) -> (String, Int) with Excep
 /// with no lookahead. `+` is also already the language's "and another one"
 /// separator, in trait bounds (`[T: A + B]`).
 fn collect_effect_names_plus(tokens: Array[Token], pos: Int, acc: String) -> (String, Int) with Exception {
-  let (item, after_item) = parse_effect_item(tokens, pos)
+  collect_effect_names_plus_grade(tokens, pos, acc, false)
+}
+
+fn collect_allows_names_plus(tokens: Array[Token], pos: Int, acc: String) -> (String, Int) with Exception {
+  collect_effect_names_plus_grade(tokens, pos, acc, true)
+}
+
+fn collect_effect_names_plus_grade(tokens: Array[Token], pos: Int, acc: String, allow_optional: Bool) -> (String, Int) with Exception {
+  let (item0, after_item0) = parse_effect_item(tokens, pos)
+  let (item, after_item) = if allow_optional {
+    match peek(tokens, after_item0) {
+      TQuestion => (String::concat(item0, "?"), after_item0 + 1),
+      _ => (item0, after_item0)
+    }
+  } else {
+    (item0, after_item0)
+  }
   let new_acc = if String::length(acc) == 0 {
     item
   } else "\{acc}, \{item}"
   match peek(tokens, after_item) {
-    TPlus => collect_effect_names_plus(tokens, after_item + 1, new_acc),
+    TPlus => collect_effect_names_plus_grade(tokens, after_item + 1, new_acc, allow_optional),
     _ => (new_acc, after_item)
   }
 }
@@ -1272,7 +1278,7 @@ export fn parse_effect_row(tokens: Array[Token], pos: Int) -> (String, Int) with
   let (row, after_row) = parse_effect_row_base(tokens, pos)
   match peek(tokens, after_row) {
     TIdent(kw) => if kw == "allows" {
-      let (caps, after_caps) = collect_effect_names_plus(tokens, after_row + 1, "")
+      let (caps, after_caps) = collect_allows_names_plus(tokens, after_row + 1, "")
       // ADR-0088 decision 1's classification check. It runs HERE, at parse
       // time, because this is the only place the split still exists: the two
       // clauses fold into one row on the next line and nothing downstream can


### PR DESCRIPTION
## Summary
Next closeable #1961 hole after #2084: Optional \`?\` grade on \`allows\` and BindingLock freeze.

- \`allows Fs::read_file?\` parses and prints as Optional
- Optional does not authorize a required \`Fs::read_file\` call
- Required \`allows Fs::read_file\` still authorizes the call
- \`freeze_binding_lock\` is Granted for required owned ops and NotGranted for Optional (non-TTY instantiate default)
- Identity is unchanged: \`Console::Get?\` is not instantiate authority

TUI preflight and \`perform?\` are still out of this slice.

## Test plan
- \`parser_test.vibe\` #1345 now expects parse success
- \`checker_entry_effect_test.vibe\` optional-reject / required-accept / freeze lock