### PR TITLE
feat(wit): host admission shares instantiate identity (#1961)

### DIFF
--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -203,6 +203,19 @@ test "#1961: allows Console::write_stream does not grant console input" {
   assert(String::contains(msg, "authorized"))
 }
 
+test "#1961: ::-less user Console::Get is not a host-provider impersonation" {
+  let source = "effect Console { Get() -> Int }\nfn main() -> Int with Console::Get {\n  perform Console::Get()\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "Console::Get"))
+  assert(String::contains(msg, "handle"))
+  assert(!String::contains(msg, "collides with a registry-owned host provider operation"))
+}
+
+test "#1961: lexically handled ::-less user Console needs no provider" {
+  let source = "effect Console { Get() -> Int }\nfn main() -> Int {\n  handle { perform Console::Get() } with Console { Get() => resume(1) }\n}\n"
+  assert_eq(first_check_error(source), "")
+}
+
 test "#1961: transcript of handled / unhandled / impersonation diagnostics" {
   let handled = "effect Ask { Get() -> Int }\nfn main() -> Int with Ask::Get allows Fs {\n  handle { perform Ask::Get() } with Ask { Get() => resume(1) }\n}\n"
   let unhandled = "effect Ask { Get() -> Int }\nfn main() -> Int with Ask::Get allows Fs {\n  perform Ask::Get()\n}\n"

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -169,6 +169,18 @@ test "#1961: parsed allows Console does not become a host import" {
   assert(!String::contains(wit, "import console"))
 }
 
+test "#1961: a declared ::-less user effect is not host-admitted by provider name" {
+  // `effect Console` is a user effect. `with Console::Get` must not become
+  // the host Console provider, and must not be dropped: WIT should import
+  // the declared user interface.
+  let source = "effect Console { Get() -> Int }\nexport fn stats(n: Int) -> Int with Console::Get {\n  n\n}\n"
+  let stmts = parse_program(lex(source))
+  let wit = wit_from_program(stmts, stmts, "caps")
+  assert(!String::contains(wit, "host capability effect 'Console'"))
+  assert(String::contains(wit, "import console: interface"))
+  assert(String::contains(wit, "get: func() -> s64;"))
+}
+
 test "validate_serve_handler: accepts the 4-string contract" {
   let stmts = [
     SLet(true, false, "handler", None, efn_of_string_params(serve_handler_param_names()))

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/checker {
-  standard_provider_owns_operation
+  is_instantiate_authority
 }
 
 import @vibe/core {
@@ -216,13 +216,7 @@ fn wit_func_text(param_names: Array[String], param_types: Array[TypeExpr], ret: 
 /// Split a parsed effect row ("A, B") into names. The parser joins the
 /// `with A + B` list with ", " (parser_base.vibe collect_effect_names).
 fn wit_is_host_provider_label(label: String) -> Bool {
-  if standard_provider_owns_operation(label) {
-    true
-  } else if String::index_of(label, "::") >= 0 {
-    false
-  } else {
-    has_standard_host_provider(label) && !is_entry_runtime_managed_effect(label)
-  }
+  is_instantiate_authority(label)
 }
 
 fn wit_split_effect_row(row: String) -> Array[String] {
@@ -683,7 +677,7 @@ export fn wit_from_program(export_stmts: Array[Stmt], effect_stmts: Array[Stmt],
             let rname = Array::get(resolved, ri)
             if is_entry_runtime_managed_effect(rname) {
               ()
-            } else if has_standard_host_provider(rname) && !wit_is_host_provider_label(ename) {
+            } else if has_standard_host_provider(rname) && !wit_is_host_provider_label(ename) && !wit_array_contains(eff_names, rname) {
               ()
             } else if !wit_array_contains(used_effects, rname) {
               Array::push(used_effects, rname)


### PR DESCRIPTION
## Summary
#1961 remaining hole: WIT classified host imports by provider name, so a declared user effect Console referenced as Console::Get was dropped (neither user import nor host comment).

WIT now calls is_instantiate_authority (same predicate as BindingLock freeze). Declared user effects stay on the user-import path even when the prefix is a host provider.

## Tests
- wit_gen_test: declared effect Console + with Console::Get emits import console interface, not host Console
- checker_entry_effect_test: Console::Get is unhandled user effect, not impersonation
- existing handled / unhandled Ask::Get / allows Fs / Fs::read_file impersonation stay

Red: two new tests trapped. Green: 66 tests, twice.