### PR TITLE
feat(checker): type perform? as Attempt under optional allows (#1961)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -1709,6 +1709,12 @@ fn head_kind(t: Type) -> Int {
     CtRecord(_) => 14,
     CtNamed(name, _) => if name == "MutList" {
       15
+    } else if name == "Attempt" {
+      // #1961 / ADR-0088: `perform?` yields `Attempt[T, E]`, a compiler-owned
+      // named type. Kind 0 would let `fn main() -> String { perform? ... }`
+      // unify-fail and then be swallowed — `type_no_named` is false and
+      // `nominal_name_of` treats a still-open `T` as non-concrete.
+      16
     } else {
       0
     },
@@ -2188,10 +2194,10 @@ fn nominal_name_of(t: Type) -> Option[String] {
     CtOption(_) => Some("Option"),
     CtEnum(n) => Some(n),
     CtStruct(n) => Some(n),
-    CtNamed(n, _) => if n == "HostStream" {
-      // Compiler-owned and always concrete despite the nullary CtNamed shape.
-      // This makes HostStream conflict with #1539's internal StdinStream
-      // identity instead of passing through the generic-name tolerance.
+    CtNamed(n, _) => if n == "HostStream" || n == "Attempt" {
+      // Compiler-owned and always concrete despite an open type argument
+      // (`HostStream` is nullary; `Attempt[T, E]` may still hold a fresh
+      // var for T when the inner capability has no declared signature).
       Some(n)
     } else if type_fully_concrete(t) {
       Some(n)
@@ -5838,8 +5844,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         field_write_mut_check(name, args, env, defs, s, c, errors, tytab, check_expr)
         retaining_write_region_check(name, args, env, defs, s, c, errors, check_expr)
         index_target_check(name, args, env, defs, s, c, errors, check_expr)
-        if name == "perform" {
-          if Array::length(args) == 1 {
+        if name == "perform" || name == "perform?" {
+          let (pty, ps, pc) = if Array::length(args) == 1 {
             match Array::get(args, 0) {
               ECall(op_callee, opargs, _) => {
                 // #640 Stage 2: `throw(x)` parses to this exact shape
@@ -6021,6 +6027,32 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             }
           } else {
             (CtUnknown, s, c)
+          }
+          if name == "perform?" {
+            let attempt_t = if Array::length(args) == 1 {
+              match Array::get(args, 0) {
+                ECall(op_callee, _, _) => match op_callee {
+                  EIdent(op_qname, _) => match direct_builtin_return(canonical_builtin_name(op_qname)) {
+                    Some(bt) => bt,
+                    None => pty
+                  },
+                  _ => pty
+                },
+                EIdent(op_qname, _) => match direct_builtin_return(canonical_builtin_name(op_qname)) {
+                  Some(bt) => bt,
+                  None => pty
+                },
+                _ => pty
+              }
+            } else {
+              pty
+            }
+            (CtNamed("Attempt", [
+              attempt_t,
+              CtString
+            ]), ps, pc)
+          } else {
+            (pty, ps, pc)
           }
         } else if name == "resume" {
           let alen = Array::length(args)

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -91,7 +91,8 @@ export enum EffectError {
   // ADR-0102 / #1678: defense in depth for AST producers that bypass the
   // source parser. EHandle does not retain its source effect name, so this
   // diagnostic deliberately names the structural problem instead.
-  EEEmptyHandle
+  EEEmptyHandle;
+  EEPerformQuestionRequiresOptional(String, Int)
 }
 
 //# Functions
@@ -205,7 +206,15 @@ export fn effect_error_to_string(err: EffectError) -> String {
       let tail = String::concat(eff, "::..` and calls an opaque function value. A continuation captured by another handler carries THAT handler with it, so wrapping its invocation in a new `handle` does not switch handlers (non-scoped resumption is unsupported -- ADR-0089 Part A, #1347). Drive the continuation without the wrapping handle, or handle the effect where it is performed")
       String::concat("handle of effect '", String::concat(eff, String::concat("' can never fire: this body reaches no `perform ", tail)))
     },
-    EEEmptyHandle => "handler must contain at least one arm; an empty handler cannot discharge an effect"
+    EEEmptyHandle => "handler must contain at least one arm; an empty handler cannot discharge an effect",
+    EEPerformQuestionRequiresOptional(operation, off) => {
+      let body = String::concat("`perform?` requires optional `allows ", String::concat(operation, "?`; write that grade, or use plain `perform`"))
+      if off >= 0 {
+        String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
+      } else {
+        body
+      }
+    }
   }
 }
 
@@ -1528,6 +1537,37 @@ fn authority_covers_operation(auth: String, emitted: String) -> Bool {
   }
 }
 
+fn decl_authorizes_optional_op(labels: Array[String], op_name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(labels) && !found {
+    let lab = Array::get(labels, i)
+    if authority_is_optional(lab) {
+      let core = strip_authority_grade(lab)
+      if core == op_name || core == effect_name_of_op(op_name) || authority_covers_operation(core, op_name) {
+        found = true
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn perform_question_op_name(arg: Expr) -> Option[String] {
+  match arg {
+    ECall(op_callee, _, _) => match op_callee {
+      EIdent(op_name, _) => Some(op_name),
+      _ => None
+    },
+    EIdent(op_name, _) => Some(op_name),
+    _ => None
+  }
+}
+
 fn entry_user_operation_requires_handler(label: String) -> Bool {
   // #1961: a source-declared operation is algebraic even when its spelling
   // matches a host provider. Exact collisions are rejected separately and
@@ -1667,7 +1707,21 @@ fn collect_unhandled_entry_ops(root: Expr) -> Array[String] {
       ECall(callee, args, _) => {
         match callee {
           EIdent(name, _) => {
-            if name == "perform" && Array::length(args) == 1 {
+            if name == "perform?" && Array::length(args) == 1 {
+              // Optional perform does not emit a required unhandled op.
+              // Walk only the operation arguments so the inner builtin is
+              // not counted as a required host call.
+              match Array::get(args, 0) {
+                ECall(_, opargs, _) => {
+                  let mut oi = 0
+                  while oi < Array::length(opargs) {
+                    Array::push(stack, (Array::get(opargs, oi), discharged))
+                    oi = oi + 1
+                  }
+                },
+                _ => ()
+              }
+            } else if name == "perform" && Array::length(args) == 1 {
               match Array::get(args, 0) {
                 ECall(op_callee, _, _) => match op_callee {
                   EIdent(op_name, _) => {
@@ -1688,6 +1742,12 @@ fn collect_unhandled_entry_ops(root: Expr) -> Array[String] {
                 },
                 _ => ()
               }
+              Array::push(stack, (callee, discharged))
+              let mut ai = 0
+              while ai < Array::length(args) {
+                Array::push(stack, (Array::get(args, ai), discharged))
+                ai = ai + 1
+              }
             } else {
               match builtin_call_effect(name) {
                 Some(eff) => {
@@ -1700,15 +1760,22 @@ fn collect_unhandled_entry_ops(root: Expr) -> Array[String] {
                 },
                 None => ()
               }
+              Array::push(stack, (callee, discharged))
+              let mut pai = 0
+              while pai < Array::length(args) {
+                Array::push(stack, (Array::get(args, pai), discharged))
+                pai = pai + 1
+              }
             }
           },
-          _ => ()
-        }
-        Array::push(stack, (callee, discharged))
-        let mut ai = 0
-        while ai < Array::length(args) {
-          Array::push(stack, (Array::get(args, ai), discharged))
-          ai = ai + 1
+          _ => {
+            Array::push(stack, (callee, discharged))
+            let mut ai = 0
+            while ai < Array::length(args) {
+              Array::push(stack, (Array::get(args, ai), discharged))
+              ai = ai + 1
+            }
+          }
         }
       },
       _ => {
@@ -2420,7 +2487,26 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
             // Some([]) means a pure local binding; only None may fall through
             // to the module-level function table.
             let lexical_callee = lookup_fn_effs(ov_names, ov_effs, name)
-            if name == "perform" && Array::length(args) == 1 {
+            if name == "perform?" && Array::length(args) == 1 {
+              match perform_question_op_name(Array::get(args, 0)) {
+                Some(op_name) => if decl_authorizes_optional_op(declared, op_name) {
+                  ()
+                } else {
+                  Array::push(errors, EEPerformQuestionRequiresOptional(op_name, call_off))
+                },
+                None => ()
+              }
+              match Array::get(args, 0) {
+                ECall(_, opargs, _) => {
+                  let mut oi = 0
+                  while oi < Array::length(opargs) {
+                    Array::push(stack, (Array::get(opargs, oi), declared, in_handle, ov_names, ov_effs, kinds))
+                    oi = oi + 1
+                  }
+                },
+                _ => ()
+              }
+            } else if name == "perform" && Array::length(args) == 1 {
               match Array::get(args, 0) {
                 ECall(op_callee, opargs, _) => match op_callee {
                   EIdent(op_name, _) => {
@@ -2620,11 +2706,25 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
           },
           _ => ()
         }
-        Array::push(stack, (callee, declared, in_handle, ov_names, ov_effs, kinds))
-        let mut ai = 0
-        while ai < Array::length(args) {
-          Array::push(stack, (Array::get(args, ai), declared, in_handle, ov_names, ov_effs, kinds))
-          ai = ai + 1
+        match callee {
+          EIdent(cname, _) => if cname == "perform?" {
+            ()
+          } else {
+            Array::push(stack, (callee, declared, in_handle, ov_names, ov_effs, kinds))
+            let mut ai = 0
+            while ai < Array::length(args) {
+              Array::push(stack, (Array::get(args, ai), declared, in_handle, ov_names, ov_effs, kinds))
+              ai = ai + 1
+            }
+          },
+          _ => {
+            Array::push(stack, (callee, declared, in_handle, ov_names, ov_effs, kinds))
+            let mut bi = 0
+            while bi < Array::length(args) {
+              Array::push(stack, (Array::get(args, bi), declared, in_handle, ov_names, ov_effs, kinds))
+              bi = bi + 1
+            }
+          }
         }
       },
       EFn(_, _, params, _, effect, body) => {

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -216,6 +216,31 @@ test "#1961: lexically handled ::-less user Console needs no provider" {
   assert_eq(first_check_error(source), "")
 }
 
+test "#1961: perform? on optional allows typechecks as Attempt" {
+  let source = "fn main() -> Int with () allows Fs::read_file? {\n  let a = perform? Fs::read_file(\"x\")\n  0\n}\n"
+  assert_eq(first_check_error(source), "")
+}
+
+test "#1961: perform? cannot be used as the operation result type" {
+  let source = "fn main() -> String with () allows Fs::read_file? {\n  perform? Fs::read_file(\"x\")\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "return type mismatch"))
+  assert(String::contains(msg, "Attempt"))
+}
+
+test "#1961: perform? cannot unify with a scalar let-binding" {
+  let source = "fn main() -> Int with () allows Fs::read_file? {\n  let s: String = perform? Fs::read_file(\"x\")\n  0\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "Attempt"))
+}
+
+test "#1961: perform? on a required allows is rejected" {
+  let source = "fn main() -> Int with () allows Fs::read_file {\n  let a = perform? Fs::read_file(\"x\")\n  0\n}\n"
+  let msg = first_check_error(source)
+  assert(String::contains(msg, "perform?"))
+  assert(String::contains(msg, "optional"))
+}
+
 test "#1961: transcript of handled / unhandled / impersonation diagnostics" {
   let handled = "effect Ask { Get() -> Int }\nfn main() -> Int with Ask::Get allows Fs {\n  handle { perform Ask::Get() } with Ask { Get() => resume(1) }\n}\n"
   let unhandled = "effect Ask { Get() -> Int }\nfn main() -> Int with Ask::Get allows Fs {\n  perform Ask::Get()\n}\n"

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -475,6 +475,13 @@ fn parse_perform_primary(tokens: Array[Token], starts: Array[Int], pos: Int, par
     TComma => (EIdent("perform", -1), pos + 1),
     TSemicolon => (EIdent("perform", -1), pos + 1),
     TEof => (EIdent("perform", -1), pos + 1),
+    TQuestion => {
+      // ADR-0088: `perform? Op(...)` is not postfix `expr?` (`__try_op`).
+      let (arg, next_pos) = parse_recur(tokens, pos + 2, 10, context)
+      (ECall(EIdent("perform?", offset_at(starts, pos)), [
+        arg
+      ], offset_at(starts, pos)), next_pos)
+    },
     _ => {
       // `perform` binds tighter than binary operators: parse only the
       // effect-op application (primary + postfix), not a trailing binary


### PR DESCRIPTION
Stacked on #2088. Does **not** close #1961.

## Hole

ADR-0088 `perform? Op(...)` must return `Attempt[T, E]` and is legal only on an optional `allows` grade. Before this, `perform?` was postfix `expr?` (`__try_op`) after the `perform` soft keyword, so the checker never saw the grade and a `String` return silently accepted the value.

The wrap itself was not enough: `Attempt[?t, String]` is a `CtNamed` whose `T` is still a fresh var when the inner capability has no declared effect signature. `check_assignable` treated that as kind 0 and swallowed `expected String, got Attempt[...]`.

## Change

- Parse `perform?` in `parse_perform_primary` before railway `?`
- Type it as `Attempt[T, String]`; `T` comes from the op signature or `direct_builtin_return`
- `perform?` requires `allows Op?` (`EEPerformQuestionRequiresOptional`); it does not count as a required unhandled host call
- Give `Attempt` the same concrete `head_kind` treatment as `MutList`, and a `nominal_name_of` exemption like `HostStream`

## Tests

`lib/@vibe/compiler/tests/checker_entry_effect_test.vibe` — 30 tests, two consecutive `vibe test` runs green:

- optional `allows Fs::read_file?` typechecks
- `-> String { perform? Fs::read_file(...) }` reports `return type mismatch` + `Attempt`
- `let s: String = perform? ...` is rejected
- required `allows Fs::read_file` (no `?`) is rejected

## Remaining on #1961

TUI / runner instantiate preflight (BindingLock at apply time). WIT host identity is #2088.

Refs #1961