### PR TITLE
feat(checker): instantiate preflight rejects ungranted required ops (#1961)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1525,6 +1525,84 @@ export fn freeze_binding_lock(labels: Array[String]) -> Array[(String, String)] 
   out
 }
 
+fn host_grant_covers(host_granted: Array[String], core: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(host_granted) && !found {
+    let g = Array::get(host_granted, i)
+    if g == core {
+      found = true
+    } else if String::index_of(g, "::") < 0 && has_standard_host_provider(g) {
+      if core == g || effect_name_of_op(core) == g {
+        found = true
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn allow_flag_for_authority(core: String) -> String {
+  let provider = if String::index_of(core, "::") < 0 {
+    core
+  } else {
+    effect_name_of_op(core)
+  }
+  if provider == "Fs" {
+    "--allow-fs"
+  } else if provider == "Console" {
+    "--allow-console"
+  } else if provider == "Env" {
+    "--allow-env"
+  } else if provider == "Stdout" {
+    "--allow-stdout"
+  } else if provider == "Stdin" {
+    "--allow-stdin"
+  } else if provider == "Http" {
+    "--allow-http"
+  } else {
+    String::concat("--allow-", provider)
+  }
+}
+
+/// #1961 / ADR-0088 L3: non-TTY instantiate preflight.
+/// `host_granted` is what the composed host will actually inject this run.
+/// Required instantiate-authority labels missing from it abort before main,
+/// with the `--allow-*` spelling. Optional missing stay NotGranted; a
+/// granted optional becomes Granted. Labels that are not instantiate
+/// authority are dropped, same as freeze_binding_lock.
+export fn preflight_instantiate(labels: Array[String], host_granted: Array[String]) -> Array[(String, String)] with Exception {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(labels) {
+    let lab = Array::get(labels, i)
+    if is_instantiate_authority(lab) {
+      let core = strip_authority_grade(lab)
+      let granted = host_grant_covers(host_granted, core)
+      if authority_is_optional(lab) {
+        let status = if granted {
+          "Granted"
+        } else {
+          "NotGranted"
+        }
+        Array::push(out, (core, status))
+      } else if granted {
+        Array::push(out, (core, "Granted"))
+      } else {
+        throw(String::concat("instantiate preflight: required `", String::concat(core, String::concat("` is not granted; pass `", String::concat(allow_flag_for_authority(core), String::concat("` before main starts, or mark it optional (`allows ", String::concat(core, "?`)")))))))
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 fn authority_covers_operation(auth: String, emitted: String) -> Bool {
   if authority_is_optional(auth) {
     false

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -292,6 +292,7 @@ fn effect_row_contains_label(eff: Option[String], wanted: String) -> Bool
 fn standard_provider_owns_operation(label: String) -> Bool
 fn is_instantiate_authority(label: String) -> Bool
 fn freeze_binding_lock(labels: Array[String]) -> Array[(String, String)]
+fn preflight_instantiate(labels: Array[String], host_granted: Array[String]) -> Array[(String, String)] with Exception
 fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> Array[EffectError]
 fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectError]
 fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError]

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -1,7 +1,7 @@
 //# Entry-boundary effect admission (#1683)
 
 import @vibe/compiler/checker {
-  check_program, freeze_binding_lock, is_instantiate_authority, standard_provider_owns_operation
+  check_program, freeze_binding_lock, is_instantiate_authority, preflight_instantiate, standard_provider_owns_operation
 }
 
 import @vibe/compiler/syntax {
@@ -164,6 +164,64 @@ test "#1961: optional allows does not authorize a required operation" {
 test "#1961: required allows still authorizes the required operation" {
   let source = "fn main() -> String with () allows Fs::read_file {\n  Fs::read_file(\"x\")\n}\n"
   assert_eq(first_check_error(source), "")
+}
+
+test "#1961: instantiate preflight rejects a required op the host did not grant" {
+  let msg = handle {
+    let _ = preflight_instantiate([
+      "Fs::read_file"
+    ], [])
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "Fs::read_file"))
+  assert(String::contains(msg, "preflight"))
+  assert(String::contains(msg, "--allow-fs"))
+}
+
+test "#1961: instantiate preflight grants a required op the host provides" {
+  let lock = preflight_instantiate([
+    "Fs::read_file"
+  ], [
+    "Fs::read_file"
+  ])
+  assert_eq(Array::length(lock), 1)
+  let (name, status) = Array::get(lock, 0)
+  assert_eq(name, "Fs::read_file")
+  assert_eq(status, "Granted")
+}
+
+test "#1961: instantiate preflight leaves optional NotGranted without a host grant" {
+  let lock = preflight_instantiate([
+    "Fs::read_file?"
+  ], [])
+  assert_eq(Array::length(lock), 1)
+  let (name, status) = Array::get(lock, 0)
+  assert_eq(name, "Fs::read_file")
+  assert_eq(status, "NotGranted")
+}
+
+test "#1961: instantiate preflight can grant optional when the host provides it" {
+  let lock = preflight_instantiate([
+    "Console::write_stream?"
+  ], [
+    "Console::write_stream"
+  ])
+  assert_eq(Array::length(lock), 1)
+  let (name, status) = Array::get(lock, 0)
+  assert_eq(name, "Console::write_stream")
+  assert_eq(status, "Granted")
+}
+
+test "#1961: instantiate preflight drops labels that are not instantiate authority" {
+  let lock = preflight_instantiate([
+    "Console::Get",
+    "Ask::Get"
+  ], [
+    "Console"
+  ])
+  assert_eq(Array::length(lock), 0)
 }
 
 test "#1961: BindingLock freeze is Granted for required and NotGranted for optional" {

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -170,7 +170,8 @@ test "#1961: instantiate preflight rejects a required op the host did not grant"
   let msg = handle {
     let _ = preflight_instantiate([
       "Fs::read_file"
-    ], [])
+    ], [
+    ])
     ""
   } with Exception {
     Throw(m) => m
@@ -195,7 +196,8 @@ test "#1961: instantiate preflight grants a required op the host provides" {
 test "#1961: instantiate preflight leaves optional NotGranted without a host grant" {
   let lock = preflight_instantiate([
     "Fs::read_file?"
-  ], [])
+  ], [
+  ])
   assert_eq(Array::length(lock), 1)
   let (name, status) = Array::get(lock, 0)
   assert_eq(name, "Fs::read_file")


### PR DESCRIPTION
Stacked on #2089. Does **not** close #1961.

## Hole

ADR-0088 L3: instantiate must abort before `main` when a Required capability is not in the host grant set. `freeze_binding_lock` always marks Required as `Granted` (non-interactive apply default). The runner/TUI had nothing to call for the non-TTY abort.

## Change

`preflight_instantiate(labels, host_granted)` on the shipped checker:

- Required missing from `host_granted` → throw, names the op and `--allow-fs` / `--allow-console` / …
- Required present → `Granted`
- Optional missing → `NotGranted`
- Optional present → `Granted`
- `Console::Get` / other non-instantiate-authority labels are dropped

Same identity predicate as WIT/cache (`is_instantiate_authority`).

## Tests

Red: import of `preflight_instantiate` failed (`is not exported`).
Green: `checker_entry_effect_test.vibe` 35 tests, two consecutive runs.

## Remaining on #1961

The TTY grant-or-abort prompt itself. This PR is the checker predicate that prompt/non-TTY abort both call.

Refs #1961