### PR TITLE
feat(normalize): pre-scan skip for tuple let-mut unbox (#1935)

### DIFF
--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -89,4 +89,5 @@ fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception
 // Split an eligible tuple-literal `let mut` (the shape every `loop (s = (a, b))`
 // lowers to at parse time) into N scalar `let mut`s. Runs at both linear
 // codegen entries, after the checker.
+fn has_unbox_tuple_candidate(stmts: Array[Stmt]) -> Bool
 fn unbox_tuple_loop_params(stmts: Array[Stmt]) -> Unit

--- a/lib/@vibe/compiler/normalize/unbox_tuple_loop.vibe
+++ b/lib/@vibe/compiler/normalize/unbox_tuple_loop.vibe
@@ -47,7 +47,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt
+  Expr, Pat, Stmt, expr_children
 }
 
 import @vibe/core {
@@ -990,9 +990,69 @@ fn utl_drive(e: Expr) -> Expr {
   }
 }
 
-/// Split every eligible tuple `let mut` in `stmts` into scalar `let mut`s,
-/// IN PLACE. Run at both linear codegen entries, after the checker.
-export fn unbox_tuple_loop_params(stmts: Array[Stmt]) -> Unit {
+fn utl_tuple_arity_ok(e: Expr) -> Bool {
+  match e {
+    ETuple(elems) => {
+      let n = Array::length(elems)
+      n >= 2 && n <= 8
+    },
+    _ => false
+  }
+}
+
+fn has_unbox_tuple_candidate_expr(e: Expr) -> Bool {
+  match e {
+    ELetMut(_, init, body, _) => if utl_tuple_arity_ok(init) {
+      true
+    } else {
+      has_unbox_tuple_candidate_expr(init) || has_unbox_tuple_candidate_expr(body)
+    },
+    _ => {
+      let kids = expr_children(e)
+      let mut i = 0
+      let mut hit = false
+      while i < Array::length(kids) && !hit {
+        if has_unbox_tuple_candidate_expr(Array::get(kids, i)) {
+          hit = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      hit
+    }
+  }
+}
+
+/// #1935: cheap candidate pre-scan. True iff some `ELetMut` is initialized
+/// with a 2..8-ary tuple (the only shape `utl_try` will consider). Must not
+/// false-negative: a missed candidate would skip the rewrite.
+export fn has_unbox_tuple_candidate(stmts: Array[Stmt]) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(stmts) && !hit {
+    let st = Array::get(stmts, i)
+    let here = match st {
+      SLet(_, _, _, _, body) => has_unbox_tuple_candidate_expr(body),
+      SLetMut(_, _, body) => has_unbox_tuple_candidate_expr(body),
+      SExpr(e) => has_unbox_tuple_candidate_expr(e),
+      STest(_, body) => has_unbox_tuple_candidate_expr(body),
+      SBench(_, body) => has_unbox_tuple_candidate_expr(body),
+      SLetPat(_, body) => has_unbox_tuple_candidate_expr(body),
+      SModule(_, _, inner) => has_unbox_tuple_candidate(inner),
+      _ => false
+    }
+    if here {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn unbox_tuple_loop_params_drive(stmts: Array[Stmt]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     let st = Array::get(stmts, i)
@@ -1004,11 +1064,22 @@ export fn unbox_tuple_loop_params(stmts: Array[Stmt]) -> Unit {
       SBench(name, body) => Array::set(stmts, i, SBench(name, utl_drive(body))),
       SLetPat(p, body) => Array::set(stmts, i, SLetPat(p, utl_drive(body))),
       SModule(exp, name, inner) => {
-        unbox_tuple_loop_params(inner)
+        unbox_tuple_loop_params_drive(inner)
         Array::set(stmts, i, SModule(exp, name, inner))
       },
       _ => ()
     }
     i = i + 1
+  }
+}
+
+/// Split every eligible tuple `let mut` in `stmts` into scalar `let mut`s,
+/// IN PLACE. Run at both linear codegen entries, after the checker.
+/// #1935: skip the walk when no 2..8-ary tuple `let mut` exists.
+export fn unbox_tuple_loop_params(stmts: Array[Stmt]) -> Unit {
+  if !has_unbox_tuple_candidate(stmts) {
+    ()
+  } else {
+    unbox_tuple_loop_params_drive(stmts)
   }
 }

--- a/lib/@vibe/compiler/normalize/unbox_tuple_loop_test.vibe
+++ b/lib/@vibe/compiler/normalize/unbox_tuple_loop_test.vibe
@@ -1,0 +1,110 @@
+// #1935: candidate pre-scan for tuple `let mut` unbox. False negatives
+// would skip a rewrite; these fixtures pin positive / negative / nested /
+// shadowing on the shipped walker.
+
+import @vibe/compiler/core {
+  Expr, Pat, Stmt
+}
+
+import ./unbox_tuple_loop.vibe {
+  has_unbox_tuple_candidate, unbox_tuple_loop_params
+}
+
+fn tuple2(a: Expr, b: Expr) -> Expr {
+  ETuple([
+    a,
+    b
+  ])
+}
+
+fn tuple_let_mut(name: String, body: Expr) -> Expr {
+  ELetMut(name, tuple2(EInt(0), EInt(1)), body, 0)
+}
+
+fn destr_body() -> Expr {
+  let arms: Array[(Pat, Expr)] = [
+    (PTuple([
+      PBind("a"),
+      PBind("b")
+    ]), EIdent("a", 0))
+  ]
+  EMatch(EIdent("s", 0), arms)
+}
+
+test "pre-scan negative: no let mut" {
+  let stmts: Array[Stmt] = [
+    SExpr(EInt(1))
+  ]
+  assert(!has_unbox_tuple_candidate(stmts))
+}
+
+test "pre-scan negative: scalar let mut" {
+  let stmts: Array[Stmt] = [
+    SExpr(ELetMut("n", EInt(0), EIdent("n", 0), 0))
+  ]
+  assert(!has_unbox_tuple_candidate(stmts))
+}
+
+test "pre-scan negative: arity-1 tuple is not an unbox candidate" {
+  let stmts: Array[Stmt] = [
+    SExpr(ELetMut("s", ETuple([
+      EInt(0)
+    ]), EIdent("s", 0), 0))
+  ]
+  assert(!has_unbox_tuple_candidate(stmts))
+}
+
+test "pre-scan positive: tuple let mut at statement root" {
+  let stmts: Array[Stmt] = [
+    SExpr(tuple_let_mut("s", destr_body()))
+  ]
+  assert(has_unbox_tuple_candidate(stmts))
+}
+
+test "pre-scan positive: nested inside a function body" {
+  let fn_e = EFn([
+  ], [
+  ], [
+  ], None, None, tuple_let_mut("s", destr_body()))
+  let stmts: Array[Stmt] = [
+    SExpr(fn_e)
+  ]
+  assert(has_unbox_tuple_candidate(stmts))
+}
+
+test "pre-scan positive: nested inside SModule" {
+  let inner: Array[Stmt] = [
+    SExpr(tuple_let_mut("s", destr_body()))
+  ]
+  let stmts: Array[Stmt] = [
+    SModule(false, "M", inner)
+  ]
+  assert(has_unbox_tuple_candidate(stmts))
+}
+
+test "pre-scan positive: inner scalar shadow does not hide an outer tuple candidate" {
+  let inner = ELetMut("s", EInt(9), EIdent("s", 0), 0)
+  let stmts: Array[Stmt] = [
+    SExpr(tuple_let_mut("s", inner))
+  ]
+  assert(has_unbox_tuple_candidate(stmts))
+}
+
+test "unbox still rewrites an eligible tuple let mut after the pre-scan" {
+  let stmts: Array[Stmt] = [
+    SExpr(tuple_let_mut("s", destr_body()))
+  ]
+  unbox_tuple_loop_params(stmts)
+  match Array::get(stmts, 0) {
+    SExpr(e) => match e {
+      ELetMut(name, init, _, _) => {
+        assert(name != "s" || match init {
+          ETuple(_) => false,
+          _ => true
+        })
+      },
+      _ => assert(true)
+    },
+    _ => assert(false)
+  }
+}


### PR DESCRIPTION
## Summary

#1935 asked for a no-false-negative candidate pre-scan so unbox / escape / borrow analysis does not walk every function. This slice covers the first shipped pass: tuple `let mut` unbox (`unbox_tuple_loop_params`).

- `has_unbox_tuple_candidate` is true iff some `ELetMut` is initialized with a 2..8-ary tuple (the only shape `utl_try` considers).
- `unbox_tuple_loop_params` returns immediately when the scan is false; otherwise the existing drive is unchanged.
- Tests pin negative (no mut / scalar / arity-1), positive (root / nested fn / SModule), shadowing (inner scalar does not hide an outer tuple), and that an eligible form still rewrites.

## Does not close #1935

Still open: escape/borrow pre-scan, on/off wasm identity, selfcompile heap A/B.

## Test plan

- [x] bash scripts/vibe_test.sh lib/@vibe/compiler/normalize/unbox_tuple_loop_test.vibe (twice)
- [x] uniquify_shadowed_bindings_test still passes
