### PR TITLE
feat(core): Array::make and spare-slot None grow (#1847)

### DIFF
--- a/lib/@vibe/core/array.vibe
+++ b/lib/@vibe/core/array.vibe
@@ -9,3 +9,38 @@
 export fn array_empty[T]() -> Array[T] {
   ArrayBuilder::freeze(ArrayBuilder::new())
 }
+
+/// Allocate `n` slots filled with `init`. Unused capacity in a growable
+/// collection should pass `None` / `T::default()`, not the value being
+/// pushed (#1847). `n <= 0` is empty.
+export fn Array::make[T](n: Int, init: T) -> Array[T] {
+  let b = ArrayBuilder::new()
+  let count = if n > 0 {
+    n
+  } else {
+    0
+  }
+  let mut i = 0
+  while i < count {
+    ArrayBuilder::push(b, init)
+    i = i + 1
+  }
+  ArrayBuilder::freeze(b)
+}
+
+/// Allocate `n` slots, each `f(i)`. Use this when each slot must be a
+/// fresh value (shared `init` would alias one object). `n <= 0` is empty.
+export fn Array::make_with[T](n: Int, f: (Int) -> T) -> Array[T] {
+  let b = ArrayBuilder::new()
+  let count = if n > 0 {
+    n
+  } else {
+    0
+  }
+  let mut i = 0
+  while i < count {
+    ArrayBuilder::push(b, f(i))
+    i = i + 1
+  }
+  ArrayBuilder::freeze(b)
+}

--- a/lib/@vibe/core/array_test.vibe
+++ b/lib/@vibe/core/array_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./array.vibe {
-  array_empty, Array::make, Array::make_with
+  Array::make, Array::make_with, array_empty
 }
 
 //# Misc

--- a/lib/@vibe/core/array_test.vibe
+++ b/lib/@vibe/core/array_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./array.vibe {
-  array_empty
+  array_empty, Array::make, Array::make_with
 }
 
 //# Misc
@@ -24,4 +24,41 @@ test "array_empty infers its element type from usage" {
   let a: Array[String] = array_empty()
   Array::push(a, "x")
   assert(eq(Array::get(a, 0), "x"))
+}
+
+test "Array::make fills n slots with the given init, not a pusher later" {
+  let a = Array::make(4, 0)
+  assert(eq(Array::length(a), 4))
+  assert(eq(Array::get(a, 0), 0))
+  assert(eq(Array::get(a, 3), 0))
+  Array::set(a, 0, 99)
+  assert(eq(Array::get(a, 1), 0))
+  assert(eq(Array::get(a, 2), 0))
+  assert(eq(Array::get(a, 3), 0))
+}
+
+test "Array::make of None is the shared empty-slot encoding" {
+  let none_slot: Option[Int] = None
+  let a = Array::make(3, none_slot)
+  assert(eq(Array::length(a), 3))
+  assert(Array::get(a, 0) is None)
+  assert(Array::get(a, 2) is None)
+  Array::set(a, 1, Some(7))
+  assert(Array::get(a, 0) is None)
+  assert(Array::get(a, 1) == Some(7))
+}
+
+test "Array::make n<=0 is empty" {
+  let a: Array[Int] = Array::make(0, 1)
+  assert(eq(Array::length(a), 0))
+  let b: Array[Int] = Array::make(0 - 3, 1)
+  assert(eq(Array::length(b), 0))
+}
+
+test "Array::make_with fills by index" {
+  let a = Array::make_with(4, (i: Int) -> i * 10)
+  assert(eq(Array::length(a), 4))
+  assert(eq(Array::get(a, 0), 0))
+  assert(eq(Array::get(a, 1), 10))
+  assert(eq(Array::get(a, 3), 30))
 }

--- a/lib/@vibe/core/deque.vibe
+++ b/lib/@vibe/core/deque.vibe
@@ -7,18 +7,21 @@
 // indices wrap modulo capacity, so both ends push/pop in O(1) and the
 // buffer doubles on overflow (amortized O(1) growth).
 //
-// Generic-allocation note: vibe has no way to conjure a default value of
-// an arbitrary `T`, so the backing buffer starts EMPTY and is only
-// (re)allocated inside a push — where an element of type `T` is in hand
-// to fill the fresh slots. `with_capacity(n)` therefore records `n` as a
-// hint consumed by the first push rather than allocating up front.
-// Popped slots keep their old element until overwritten (values are
-// retained, not freed, until the slot is reused or the deque grows).
+// Generic allocation (#1847): spare slots are `None`, allocated with
+// `Array::make(n, None)`. Grow does not copy the just-pushed value into
+// unused capacity. `with_capacity(n)` is still a hint consumed by the
+// first push. Pop / clear write `None` so vacated slots drop the value.
+
+//# Imports
+
+import ./array.vibe {
+  Array::make, array_empty
+}
 
 //# Types
 
 export struct Deque[T] {
-  mut buf: Array[T];
+  mut buf: Array[Option[T]];
   mut head: Int;
   mut len: Int;
   mut cap_hint: Int
@@ -26,15 +29,17 @@ export struct Deque[T] {
 
 //# Internal helpers
 
-fn deque_empty_buf[T]() -> Array[T] {
-  ArrayBuilder::freeze(ArrayBuilder::new())
+fn deque_none[T]() -> Option[T] {
+  None
+}
+
+fn deque_empty_buf[T]() -> Array[Option[T]] {
+  array_empty()
 }
 
 /// Reallocate to the next capacity, linearizing the ring (head -> 0).
-/// `filler` (the element being pushed) fills the fresh slots — see the
-/// generic-allocation note above. Only called when the buffer is full,
-/// so `len > 0` implies `old_cap > 0` (no modulo-by-zero in the copy).
-fn deque_grow[T](d: Deque[T], filler: T) -> Unit {
+/// Spare slots stay `None`. Only called when the buffer is full.
+fn deque_grow[T](d: Deque[T]) -> Unit {
   let old_cap = Array::length(d.buf)
   let new_cap = if old_cap > 0 {
     old_cap * 2
@@ -43,13 +48,7 @@ fn deque_grow[T](d: Deque[T], filler: T) -> Unit {
   } else {
     8
   }
-  let b = ArrayBuilder::new()
-  let mut i = 0
-  while i < new_cap {
-    ArrayBuilder::push(b, filler)
-    i = i + 1
-  }
-  let nbuf = ArrayBuilder::freeze(b)
+  let nbuf = Array::make(new_cap, deque_none())
   let mut j = 0
   while j < d.len {
     Array::set(nbuf, j, Array::get(d.buf, (d.head + j) % old_cap))
@@ -71,8 +70,7 @@ export fn Deque::new[T]() -> Deque[T] {
 }
 
 /// `n` is a capacity HINT: the backing buffer is allocated by the first
-/// push (see the generic-allocation note), which uses `n` as the initial
-/// capacity. `n <= 0` behaves like `new()`.
+/// push as `Array::make(n, None)`. `n <= 0` behaves like `new()`.
 export fn Deque::with_capacity[T](n: Int) -> Deque[T] {
   Deque::{
     buf: deque_empty_buf(),
@@ -96,20 +94,20 @@ export fn Deque::is_empty[T](d: Deque[T]) -> Bool {
 
 export fn Deque::push_back[T](d: Deque[T], x: T) -> Unit {
   if d.len >= Array::length(d.buf) {
-    deque_grow(d, x)
+    deque_grow(d)
   }
   let cap = Array::length(d.buf)
-  Array::set(d.buf, (d.head + d.len) % cap, x)
+  Array::set(d.buf, (d.head + d.len) % cap, Some(x))
   d.len = d.len + 1
 }
 
 export fn Deque::push_front[T](d: Deque[T], x: T) -> Unit {
   if d.len >= Array::length(d.buf) {
-    deque_grow(d, x)
+    deque_grow(d)
   }
   let cap = Array::length(d.buf)
   d.head = (d.head + cap - 1) % cap
-  Array::set(d.buf, d.head, x)
+  Array::set(d.buf, d.head, Some(x))
   d.len = d.len + 1
 }
 
@@ -118,9 +116,10 @@ export fn Deque::pop_front[T](d: Deque[T]) -> Option[T] {
     None
   } else {
     let v = Array::get(d.buf, d.head)
+    Array::set(d.buf, d.head, deque_none())
     d.head = (d.head + 1) % Array::length(d.buf)
     d.len = d.len - 1
-    Some(v)
+    v
   }
 }
 
@@ -129,9 +128,11 @@ export fn Deque::pop_back[T](d: Deque[T]) -> Option[T] {
     None
   } else {
     let cap = Array::length(d.buf)
-    let v = Array::get(d.buf, (d.head + d.len - 1) % cap)
+    let idx = (d.head + d.len - 1) % cap
+    let v = Array::get(d.buf, idx)
+    Array::set(d.buf, idx, deque_none())
     d.len = d.len - 1
-    Some(v)
+    v
   }
 }
 
@@ -139,7 +140,7 @@ export fn Deque::front[T](d: Deque[T]) -> Option[T] {
   if d.len == 0 {
     None
   } else {
-    Some(Array::get(d.buf, d.head))
+    Array::get(d.buf, d.head)
   }
 }
 
@@ -148,7 +149,7 @@ export fn Deque::back[T](d: Deque[T]) -> Option[T] {
     None
   } else {
     let cap = Array::length(d.buf)
-    Some(Array::get(d.buf, (d.head + d.len - 1) % cap))
+    Array::get(d.buf, (d.head + d.len - 1) % cap)
   }
 }
 
@@ -158,7 +159,7 @@ export fn Deque::get[T](d: Deque[T], i: Int) -> Option[T] {
   if i < 0 || i >= d.len {
     None
   } else {
-    Some(Array::get(d.buf, (d.head + i) % Array::length(d.buf)))
+    Array::get(d.buf, (d.head + i) % Array::length(d.buf))
   }
 }
 
@@ -168,16 +169,24 @@ export fn Deque::to_array[T](d: Deque[T]) -> Array[T] {
   let cap = Array::length(d.buf)
   let mut i = 0
   while i < d.len {
-    ArrayBuilder::push(b, Array::get(d.buf, (d.head + i) % cap))
+    match Array::get(d.buf, (d.head + i) % cap) {
+      Some(v) => ArrayBuilder::push(b, v),
+      None => ()
+    }
     i = i + 1
   }
   ArrayBuilder::freeze(b)
 }
 
-/// Drop all elements. The backing buffer is KEPT (its capacity is
-/// reused by later pushes); the old elements stay referenced by the
-/// buffer until overwritten.
+/// Drop all elements. Vacated slots are `None` so they do not retain
+/// the old values. Capacity is kept for later pushes.
 export fn Deque::clear[T](d: Deque[T]) -> Unit {
+  let cap = Array::length(d.buf)
+  let mut i = 0
+  while i < d.len {
+    Array::set(d.buf, (d.head + i) % cap, deque_none())
+    i = i + 1
+  }
   d.head = 0
   d.len = 0
 }

--- a/lib/@vibe/core/deque_test.vibe
+++ b/lib/@vibe/core/deque_test.vibe
@@ -219,3 +219,22 @@ test "generic elements: tuples survive growth" {
   }
   assert(Deque::length(d) == 2)
 }
+
+test "grow spare slots are not the just-pushed value" {
+  let d = Deque::with_capacity(2)
+  Deque::push_back(d, 1)
+  Deque::push_back(d, 2)
+  Deque::push_back(d, 99)
+  let mut n99 = 0
+  let mut i = 0
+  while i < Array::length(d.buf) {
+    match Array::get(d.buf, i) {
+      Some(99) => {
+        n99 = n99 + 1
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  assert(eq(n99, 1))
+}

--- a/lib/@vibe/core/hashmap.vibe
+++ b/lib/@vibe/core/hashmap.vibe
@@ -25,6 +25,10 @@
 
 //# Imports
 
+import ./array.vibe {
+  Array::make
+}
+
 import ./key.vibe {
   eq_int, eq_string, hash_int, hash_string
 }
@@ -44,24 +48,12 @@ export struct MutMap[K, V] {
 //# Internal helpers
 
 fn alloc_states(cap: Int) -> Array[Int] {
-  let b = ArrayBuilder::new()
-  let mut i = 0
-  while i < cap {
-    ArrayBuilder::push(b, 0)
-    i = i + 1
-  }
-  ArrayBuilder::freeze(b)
+  Array::make(cap, 0)
 }
 
 fn alloc_slots[T](cap: Int) -> Array[Option[T]] {
-  let b = ArrayBuilder::new()
-  let mut i = 0
-  while i < cap {
-    let none_slot: Option[T] = None
-    ArrayBuilder::push(b, none_slot)
-    i = i + 1
-  }
-  ArrayBuilder::freeze(b)
+  let none_slot: Option[T] = None
+  Array::make(cap, none_slot)
 }
 
 fn home_index[K, V](m: MutMap[K, V], k: K, cap: Int) -> Int {

--- a/lib/@vibe/core/hashmap_test.vibe
+++ b/lib/@vibe/core/hashmap_test.vibe
@@ -252,3 +252,25 @@ test "generic explicit constructor with_capacity" {
   assert_eq(get_or(m, 8, "?"), "eight")
   assert_eq(MutMap::size(m), 3)
 }
+
+test "rehash spare key slots stay None, not a copy of the last insert" {
+  let m: MutMap[Int, Int] = MutMap::with_capacity_int(8)
+  let mut i = 0
+  while i < 20 {
+    MutMap::set(m, i, i)
+    i = i + 1
+  }
+  MutMap::set(m, 99, 99)
+  let mut n99 = 0
+  let mut j = 0
+  while j < Array::length(m.keys) {
+    match Array::get(m.keys, j) {
+      Some(99) => {
+        n99 = n99 + 1
+      },
+      _ => ()
+    }
+    j = j + 1
+  }
+  assert(eq(n99, 1))
+}

--- a/lib/@vibe/core/index.vpkg
+++ b/lib/@vibe/core/index.vpkg
@@ -111,6 +111,8 @@ fn encode_uleb128(n: Int) -> Bytes
 
 // --- array
 fn array_empty[T]() -> Array[T]
+fn Array::make[T](n: Int, init: T) -> Array[T]
+fn Array::make_with[T](n: Int, f: (Int) -> T) -> Array[T]
 
 // --- sorted_index (#1353: lifted from compiler/core; stable name sort +
 // leftmost bsearch. compiler/core re-exports these so existing

--- a/lib/@vibe/core/pqueue.vibe
+++ b/lib/@vibe/core/pqueue.vibe
@@ -9,45 +9,47 @@
 // ordering guarantee among themselves (the heap is not stable).
 //
 // Representation: `buf` is the implicit-tree array (children of `i` at
-// `2i+1` / `2i+2`), `len` the live element count. Same generic-allocation
-// scheme as core deque: no default value of an arbitrary `T` exists, so
-// the buffer starts empty and grows inside `push`, where the pushed
-// element fills the fresh slots. Popped slots keep their old element
-// until overwritten.
+// `2i+1` / `2i+2`), `len` the live element count. Spare slots are `None`
+// via `Array::make` (#1847). Grow does not copy the just-pushed value
+// into unused capacity.
 //
 // Complexity: push / pop O(log n), peek O(1), from_array O(n) (Floyd
 // heapify), to_sorted_array O(n log n).
 
+//# Imports
+
+import ./array.vibe {
+  Array::make, array_empty
+}
+
 //# Types
 
 export struct PriorityQueue[T] {
-  mut buf: Array[T];
+  mut buf: Array[Option[T]];
   mut len: Int;
   cmp: (T, T) -> Int
 }
 
 //# Internal helpers
 
-fn pq_empty_buf[T]() -> Array[T] {
-  ArrayBuilder::freeze(ArrayBuilder::new())
+fn pq_none[T]() -> Option[T] {
+  None
 }
 
-/// Double the backing buffer (or allocate the first one), using `filler`
-/// — the element being pushed — for the fresh slots.
-fn pq_grow[T](q: PriorityQueue[T], filler: T) -> Unit {
+fn pq_empty_buf[T]() -> Array[Option[T]] {
+  array_empty()
+}
+
+/// Double the backing buffer (or allocate the first one). Spare slots
+/// stay `None`; the pusher is not copied into unused capacity.
+fn pq_grow[T](q: PriorityQueue[T]) -> Unit {
   let old_cap = Array::length(q.buf)
   let new_cap = if old_cap > 0 {
     old_cap * 2
   } else {
     8
   }
-  let b = ArrayBuilder::new()
-  let mut i = 0
-  while i < new_cap {
-    ArrayBuilder::push(b, filler)
-    i = i + 1
-  }
-  let nbuf = ArrayBuilder::freeze(b)
+  let nbuf = Array::make(new_cap, pq_none())
   let mut j = 0
   while j < q.len {
     Array::set(nbuf, j, Array::get(q.buf, j))
@@ -62,12 +64,22 @@ fn pq_swap[T](q: PriorityQueue[T], i: Int, j: Int) -> Unit {
   Array::set(q.buf, j, tmp)
 }
 
+fn pq_cmp_slots[T](q: PriorityQueue[T], i: Int, j: Int) -> Int {
+  match Array::get(q.buf, i) {
+    Some(a) => match Array::get(q.buf, j) {
+      Some(b) => (q.cmp)(a, b),
+      None => 0
+    },
+    None => 0
+  }
+}
+
 /// Bubble the element at `start` up until its parent is not greater.
 fn pq_sift_up[T](q: PriorityQueue[T], start: Int) -> Unit {
   let mut i = start
   while i > 0 {
     let parent = (i - 1) / 2
-    if (q.cmp)(Array::get(q.buf, i), Array::get(q.buf, parent)) < 0 {
+    if pq_cmp_slots(q, i, parent) < 0 {
       pq_swap(q, i, parent)
       i = parent
     } else {
@@ -84,10 +96,10 @@ fn pq_sift_down[T](q: PriorityQueue[T], start: Int) -> Unit {
     let l = 2 * i + 1
     let r = 2 * i + 2
     let mut best = i
-    if l < q.len && (q.cmp)(Array::get(q.buf, l), Array::get(q.buf, best)) < 0 {
+    if l < q.len && pq_cmp_slots(q, l, best) < 0 {
       best = l
     }
-    if r < q.len && (q.cmp)(Array::get(q.buf, r), Array::get(q.buf, best)) < 0 {
+    if r < q.len && pq_cmp_slots(q, r, best) < 0 {
       best = r
     }
     if best == i {
@@ -157,9 +169,9 @@ export fn PriorityQueue::is_empty[T](q: PriorityQueue[T]) -> Bool {
 
 export fn PriorityQueue::push[T](q: PriorityQueue[T], x: T) -> Unit {
   if q.len >= Array::length(q.buf) {
-    pq_grow(q, x)
+    pq_grow(q)
   }
-  Array::set(q.buf, q.len, x)
+  Array::set(q.buf, q.len, Some(x))
   q.len = q.len + 1
   pq_sift_up(q, q.len - 1)
 }
@@ -168,7 +180,7 @@ export fn PriorityQueue::peek[T](q: PriorityQueue[T]) -> Option[T] {
   if q.len == 0 {
     None
   } else {
-    Some(Array::get(q.buf, 0))
+    Array::get(q.buf, 0)
   }
 }
 
@@ -180,9 +192,12 @@ export fn PriorityQueue::pop[T](q: PriorityQueue[T]) -> Option[T] {
     q.len = q.len - 1
     if q.len > 0 {
       Array::set(q.buf, 0, Array::get(q.buf, q.len))
+      Array::set(q.buf, q.len, pq_none())
       pq_sift_down(q, 0)
+    } else {
+      Array::set(q.buf, 0, pq_none())
     }
-    Some(top)
+    top
   }
 }
 
@@ -190,14 +205,14 @@ export fn PriorityQueue::pop[T](q: PriorityQueue[T]) -> Option[T] {
 /// The input array is COPIED — the caller's array is not modified.
 export fn PriorityQueue::from_array[T](arr: Array[T], cmp: (T, T) -> Int) -> PriorityQueue[T] {
   let n = Array::length(arr)
-  let b = ArrayBuilder::new()
+  let nbuf = Array::make(n, pq_none())
   let mut i = 0
   while i < n {
-    ArrayBuilder::push(b, Array::get(arr, i))
+    Array::set(nbuf, i, Some(Array::get(arr, i)))
     i = i + 1
   }
   let q = PriorityQueue::{
-    buf: ArrayBuilder::freeze(b),
+    buf: nbuf,
     len: n,
     cmp: cmp
   }
@@ -212,14 +227,14 @@ export fn PriorityQueue::from_array[T](arr: Array[T], cmp: (T, T) -> Int) -> Pri
 /// Dequeue order as an array (cmp-ascending). NON-DESTRUCTIVE: works on
 /// a private copy of the heap, so `q` is unchanged. O(n log n).
 export fn PriorityQueue::to_sorted_array[T](q: PriorityQueue[T]) -> Array[T] {
-  let b = ArrayBuilder::new()
+  let nbuf = Array::make(q.len, pq_none())
   let mut i = 0
   while i < q.len {
-    ArrayBuilder::push(b, Array::get(q.buf, i))
+    Array::set(nbuf, i, Array::get(q.buf, i))
     i = i + 1
   }
   let scratch = PriorityQueue::{
-    buf: ArrayBuilder::freeze(b),
+    buf: nbuf,
     len: q.len,
     cmp: q.cmp
   }
@@ -236,9 +251,13 @@ export fn PriorityQueue::to_sorted_array[T](q: PriorityQueue[T]) -> Array[T] {
   ArrayBuilder::freeze(out)
 }
 
-/// Drop all elements. The backing buffer is KEPT (capacity is reused);
-/// old elements stay referenced by the buffer until overwritten.
+/// Drop all elements. Vacated slots are `None`. Capacity is kept.
 export fn PriorityQueue::clear[T](q: PriorityQueue[T]) -> Unit {
+  let mut i = 0
+  while i < q.len {
+    Array::set(q.buf, i, pq_none())
+    i = i + 1
+  }
   q.len = 0
 }
 

--- a/lib/@vibe/core/pqueue_test.vibe
+++ b/lib/@vibe/core/pqueue_test.vibe
@@ -258,3 +258,25 @@ test "explicit dict: strings ordered by length" {
     None => assert(false)
   }
 }
+
+test "grow spare slots are not the just-pushed value" {
+  let q = PriorityQueue::new_int_min()
+  let mut i = 0
+  while i < 8 {
+    PriorityQueue::push(q, i)
+    i = i + 1
+  }
+  PriorityQueue::push(q, 99)
+  let mut n99 = 0
+  let mut j = 0
+  while j < Array::length(q.buf) {
+    match Array::get(q.buf, j) {
+      Some(99) => {
+        n99 = n99 + 1
+      },
+      _ => ()
+    }
+    j = j + 1
+  }
+  assert(eq(n99, 1))
+}


### PR DESCRIPTION
## Summary

Closes #1847. Generic collections no longer grow by copying the just-pushed value into unused slots.

- `Array::make[T](n, init)` and `Array::make_with[T](n, f)` are the shared backing-store allocator in `@vibe/core`.
- `Deque` and `PriorityQueue` store `Array[Option[T]]`. Grow is `Array::make(n, None)`. Pop/clear write `None`.
- `MutMap` `alloc_slots` / `alloc_states` call `Array::make` instead of a hand-rolled ArrayBuilder loop.

Tests drive those shipped functions and count that a just-pushed `99` occupies one slot after grow/rehash.

## Does not close #1848

No MutMap hot-path inventory or self-compile before/after in this PR.

## Test plan

- [x] `bash scripts/vibe_test.sh lib/@vibe/core/array_test.vibe lib/@vibe/core/deque_test.vibe lib/@vibe/core/pqueue_test.vibe lib/@vibe/core/hashmap_test.vibe` (twice, identical)
- [x] hashset_test + default_test