### PR TITLE
feat(cli): add vibe rc-classify and vibe rc-plan queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,6 +364,13 @@ vibe escapes file.vibe
 # 常に既定の部分集合
 vibe escapes --strict file.vibe
 
+# RC classifier sets and Perceus plan (issue 1981). Same prelude +
+# compute_* / build_perceus_plan_with_params as linked_compile.
+# `NAME SET[,SET...]` / `FN BINDING ACTION COUNT`. Empty = nothing special.
+vibe rc-classify file.vibe
+vibe rc-plan file.vibe
+vibe rc-plan --fn make file.vibe
+
 # 解決済みの import closure (1行1パス、依存先が先、自分自身は除く。#988)。
 # ローダ自身の収集結果 = ビルドが実際にコンパイルする集合なので、実解決
 # (index.vibe facade・.vpkg contract とその兄弟実装・@scope/pkg の

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -292,6 +292,8 @@ vibe normalize --stdout <file.vibe>   # print the result (no write)
 | `finalize` | Refactor scratch/db source (`--db`, `--export`, `--library`, `--print`, `--dry-run`) |
 | `apply <file>` | Resolve lock + graph head and apply artifacts |
 | `symbols [--json] <file>` | List symbols and index inclusion status |
+| `rc-classify <file>` | RC classifier sets (`NAME SET[,SET...]`; empty = none) |
+| `rc-plan [--fn NAME] <file>` | Perceus plan (`FN BINDING ACTION COUNT`; empty = no actions) |
 | `explain-import <file>` | Visualize import ref normalization and lock lookup |
 | `clean` | Remove build artifacts |
 | `lsp` | Start LSP server (stdin/stdout) |

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -34,6 +34,8 @@ import @vibe/compiler/runtime {
   incremental_typecheck_telemetry_json,
   locate_type_error,
   module_plan_manifest_fs,
+  rc_classify_source,
+  rc_plan_source,
   run_module_job_dir,
   run_publish_env_cache_dir,
   set_collect_module_diagnostics,
@@ -1385,6 +1387,29 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
         escape_spans(src)
       }
       Fs::write_bytes(output_path, adapter_string_to_bytes(join_escape_spans(esc)))
+      0
+    } with Exception {
+      Throw(msg) => emit_compile_diag(output_path, msg)
+    }
+  }
+  // `vibe rc-classify` / `vibe rc-plan` (issue 1981): the same classifier
+  // sets and Perceus plan linked_compile computes after
+  // effect_lowering_prelude. Empty output = nothing special. A thrown
+  // Error goes to the `.diag` sidecar so "the query broke" stays
+  // distinguishable from "no special sets / no actions".
+  if Env::get("VIBE_RC_CLASSIFY") == "1" {
+    return handle {
+      let src = Fs::read_file(input_path)
+      Fs::write_bytes(output_path, adapter_string_to_bytes(rc_classify_source(src)))
+      0
+    } with Exception {
+      Throw(msg) => emit_compile_diag(output_path, msg)
+    }
+  }
+  if Env::get("VIBE_RC_PLAN") == "1" {
+    return handle {
+      let src = Fs::read_file(input_path)
+      Fs::write_bytes(output_path, adapter_string_to_bytes(rc_plan_source(src, Env::get("VIBE_RC_PLAN_FN"))))
       0
     } with Exception {
       Throw(msg) => emit_compile_diag(output_path, msg)

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -206,6 +206,7 @@ runtime	runtime/doc_at.vibe
 runtime	runtime/symbol_spans.vibe
 runtime	runtime/alloc_spans.vibe
 runtime	runtime/escape_spans.vibe
+runtime	runtime/rc_query.vibe
 runtime	runtime/grep.vibe
 runtime	runtime/grep_fs.vibe
 runtime	runtime/deprecated_scan.vibe

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -8,11 +8,13 @@ deps = {
   @vibe/compiler/checker/artifacts : 0.0.1
   @vibe/compiler/codegen : 0.0.1
   @vibe/compiler/codegen/common_analysis : 0.0.1
+  @vibe/compiler/codegen/wasi : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/entry/source_compile/wasi_only : 0.0.1
   @vibe/compiler/incremental : 0.0.1
   @vibe/compiler/loader : 0.0.1
   @vibe/compiler/module_graph : 0.0.1
+  @vibe/compiler/perceus : 0.0.1
   @vibe/compiler/runtime/eval_loader : 0.0.1
   @vibe/compiler/syntax : 0.0.1
   @vibe/core : 0.2.0
@@ -158,6 +160,11 @@ fn symbol_spans(source: String) -> Array[(String, Int, Int, Int)] with Exception
 fn alloc_spans(source: String) -> Array[(String, String, Int)] with Exception
 fn escape_spans(source: String) -> Array[(String, Int, Int)] with Exception
 fn escape_spans_strict(source: String) -> Array[(String, Int, Int)] with Exception
+
+// --- rc_query.vibe (issue 1981): `vibe rc-classify` / `vibe rc-plan`.
+// Same prelude + classifier / planner functions as linked_compile.
+fn rc_classify_source(source: String) -> String with Exception
+fn rc_plan_source(source: String, fn_filter: String) -> String with Exception
 
 // --- grep.vibe (#1572): `vibe grep` — AST pattern search whose filters run on
 // the CHECKER's answers (a capture's inferred type / effect row / resolved

--- a/lib/@vibe/compiler/runtime/rc_query.vibe
+++ b/lib/@vibe/compiler/runtime/rc_query.vibe
@@ -1,0 +1,249 @@
+//# `vibe rc-classify` / `vibe rc-plan` (issue 1981).
+//#
+//# The compile pipeline already answers two questions on every build:
+//# which classifier sets a function is in, and what Perceus dup/drop
+//# plan it gets. Those answers lived only inside linked_compile. This
+//# query runs the SAME prelude + the SAME compute_* / planner functions
+//# and prints the result as line-oriented text. Empty output means
+//# nothing special (no classifier membership / no plan actions).
+
+import @vibe/core {
+  array_empty, sorted_names_of
+}
+
+import @vibe/compiler/core {
+  Expr, Stmt, TypeExpr
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+import @vibe/compiler/codegen/wasi {
+  effect_lowering_prelude
+}
+
+import @vibe/compiler/codegen/common_analysis {
+  compute_borrow_param_user_fns, compute_may_return_view_fns
+}
+
+import @vibe/compiler/perceus {
+  PerceusAction,
+  build_perceus_plan_with_params,
+  compute_borrow_returning_names,
+  compute_scalar_returning_names,
+  pa_is_alias_dup,
+  pa_is_drop,
+  pa_is_dup
+}
+
+fn rcq_contains(names: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn rcq_user_fn_names(stmts: Array[Stmt]) -> Array[String] {
+  let raw: Array[String] = [
+  ]
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, value) => match value {
+        EFn(_, _, _, _, _, _) => Array::push(raw, name),
+        _ => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  sorted_names_of(raw)
+}
+
+fn rcq_run_prelude(stmts: Array[Stmt]) -> Unit with Exception {
+  let linked: Array[(String, String, Int, Int)] = [
+  ]
+  let iw_names: Array[String] = [
+  ]
+  let iw_wats: Array[String] = [
+  ]
+  let errs = effect_lowering_prelude(stmts, "main", linked, iw_names, iw_wats)
+  if Array::length(errs) > 0 {
+    throw(Array::get(errs, 0))
+  } else {
+    ()
+  }
+}
+
+fn rcq_join_tags(tags: Array[String]) -> String {
+  let acc = StringBuilder::new()
+  let mut i = 0
+  while i < Array::length(tags) {
+    if i > 0 {
+      StringBuilder::push(acc, ",")
+    } else {
+      ()
+    }
+    StringBuilder::push(acc, Array::get(tags, i))
+    i = i + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
+fn rcq_action_name(a: PerceusAction) -> String {
+  if pa_is_dup(a) {
+    "dup"
+  } else if pa_is_drop(a) {
+    "drop"
+  } else if pa_is_alias_dup(a) {
+    "alias_dup"
+  } else {
+    "other"
+  }
+}
+
+fn rcq_push_line(acc: StringBuilder, first: Array[Bool], line: String) -> Unit {
+  if Array::get(first, 0) {
+    StringBuilder::push(acc, line)
+    Array::set(first, 0, false)
+  } else {
+    StringBuilder::push(acc, "\n")
+    StringBuilder::push(acc, line)
+  }
+}
+
+/// NAME SET[,SET...] per user function that is in at least one classifier
+/// set. Empty string = no special sets. Sets are the same four
+/// linked_compile threads into every Perceus plan: borrow_ret,
+/// borrow_param, view_ret, scalar_ret.
+export fn rc_classify_source(source: String) -> String with Exception {
+  let stmts = parse_program(lex(source))
+  rcq_run_prelude(stmts)
+  let borrow_ret = compute_borrow_returning_names(stmts)
+  let masks: Array[Int] = [
+  ]
+  let borrow_param = compute_borrow_param_user_fns(stmts, [
+    "main",
+    "_start",
+    "cli_main"
+  ], masks)
+  let view_ret = compute_may_return_view_fns(stmts)
+  let scalar_ret = compute_scalar_returning_names(stmts)
+  let names = rcq_user_fn_names(stmts)
+  let acc = StringBuilder::new()
+  let first: Array[Bool] = [
+    true
+  ]
+  let mut i = 0
+  while i < Array::length(names) {
+    let name = Array::get(names, i)
+    let tags: Array[String] = [
+    ]
+    if rcq_contains(borrow_ret, name) {
+      Array::push(tags, "borrow_ret")
+    } else {
+      ()
+    }
+    if rcq_contains(borrow_param, name) {
+      Array::push(tags, "borrow_param")
+    } else {
+      ()
+    }
+    if rcq_contains(view_ret, name) {
+      Array::push(tags, "view_ret")
+    } else {
+      ()
+    }
+    if rcq_contains(scalar_ret, name) {
+      Array::push(tags, "scalar_ret")
+    } else {
+      ()
+    }
+    if Array::length(tags) > 0 {
+      rcq_push_line(acc, first, String::concat(name, String::concat(" ", rcq_join_tags(tags))))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
+fn rcq_emit_fn_plan(acc: StringBuilder, first: Array[Bool], fname: String, params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret: Array[String], borrow_param: Array[String], masks: Array[Int], view_ret: Array[String]) -> Unit {
+  let plan = build_perceus_plan_with_params(params, body, borrow_ret, borrow_param, masks, view_ret)
+  let mut i = 0
+  while i < Array::length(plan) {
+    let a = Array::get(plan, i)
+    let action = rcq_action_name(a)
+    let binding = a.name
+    let mut count = 1
+    let mut j = i + 1
+    while j < Array::length(plan) {
+      let b = Array::get(plan, j)
+      if b.name == binding && rcq_action_name(b) == action {
+        count = count + 1
+        j = j + 1
+      } else {
+        j = Array::length(plan)
+      }
+    }
+    let line = String::concat(fname, String::concat(" ", String::concat(binding, String::concat(" ", String::concat(action, String::concat(" ", __to_string(count)))))))
+    rcq_push_line(acc, first, line)
+    i = i + count
+  }
+}
+
+/// FN BINDING ACTION COUNT per collapsed Perceus action. `fn_filter` empty
+/// means every user function; a non-empty filter that names no function
+/// throws so "the query broke" stays distinguishable from an empty plan.
+export fn rc_plan_source(source: String, fn_filter: String) -> String with Exception {
+  let stmts = parse_program(lex(source))
+  rcq_run_prelude(stmts)
+  let borrow_ret = compute_borrow_returning_names(stmts)
+  let masks: Array[Int] = [
+  ]
+  let borrow_param = compute_borrow_param_user_fns(stmts, [
+    "main",
+    "_start",
+    "cli_main"
+  ], masks)
+  let view_ret = compute_may_return_view_fns(stmts)
+  let acc = StringBuilder::new()
+  let first: Array[Bool] = [
+    true
+  ]
+  let mut matched = false
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, value) => match value {
+        EFn(_, _, params, _, _, body) => {
+          let take = fn_filter == "" || fn_filter == name
+          if take {
+            matched = true
+            rcq_emit_fn_plan(acc, first, name, params, body, borrow_ret, borrow_param, masks, view_ret)
+          } else {
+            ()
+          }
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  if fn_filter != "" && !matched {
+    throw(String::concat("rc-plan: function not found: ", fn_filter))
+  } else {
+    ()
+  }
+  StringBuilder::freeze(acc)
+}

--- a/lib/@vibe/compiler/runtime/rc_query_test.vibe
+++ b/lib/@vibe/compiler/runtime/rc_query_test.vibe
@@ -1,0 +1,100 @@
+//# `rc_classify_source` / `rc_plan_source` (issue 1981):
+//# the same perceus plan / classifier sets linked_compile uses, as
+//# line-oriented query text. Tests call those shipped functions, not a
+//# second walk.
+
+import ./rc_query.vibe {
+  rc_classify_source, rc_plan_source
+}
+
+fn classify_has_set(out: String, name: String, set: String) -> Bool {
+  let prefix = String::concat(name, " ")
+  let lines = String::split(out, "\n")
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(lines) {
+    let line = Array::get(lines, i)
+    if String::starts_with(line, prefix) {
+      let rest = String::substring(line, String::length(prefix), String::length(line))
+      let tags = String::split(rest, ",")
+      let mut j = 0
+      while j < Array::length(tags) {
+        if Array::get(tags, j) == set {
+          found = true
+        } else {
+          ()
+        }
+        j = j + 1
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn classify_has_name(out: String, name: String) -> Bool {
+  let prefix = String::concat(name, " ")
+  let lines = String::split(out, "\n")
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(lines) {
+    if String::starts_with(Array::get(lines, i), prefix) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+test "rc_classify_source: a file with no functions is empty" {
+  let src = "let x = 1\n"
+  assert_eq(rc_classify_source(src), "")
+}
+
+test "rc_classify_source: a let-signed Int function is scalar_ret" {
+  // compute_scalar_returning_names reads the SLet signature, not the
+  // `fn` sugar's EFn return slot. `let f: (...) -> Int = ...` is the
+  // form linked_compile actually classifies.
+  let src = "let add: (Int, Int) -> Int = (a: Int, b: Int) -> Int { a + b }\n"
+  let out = rc_classify_source(src)
+  assert(classify_has_set(out, "add", "scalar_ret"))
+}
+
+test "rc_classify_source: a thin Array::get wrapper is borrow_ret" {
+  let src = "enum Tok {\n  TEof;\n  TInt(Int)\n}\n\nfn peek(tokens: Array[Tok], pos: Int) -> Tok {\n  if pos < Array::length(tokens) {\n    Array::get(tokens, pos)\n  } else {\n    TEof\n  }\n}\n"
+  let out = rc_classify_source(src)
+  assert(classify_has_set(out, "peek", "borrow_ret"))
+}
+
+test "rc_classify_source: an annotated builder is not view_ret" {
+  let src = "fn make(n: Int) -> Array[Int] {\n  let out: Array[Int] = []\n  let mut i = 0\n  while i < n {\n    Array::push(out, i)\n    i = i + 1\n  }\n  out\n}\n"
+  let out = rc_classify_source(src)
+  assert(!classify_has_set(out, "make", "view_ret"))
+}
+
+test "rc_plan_source: a twice-used heap binding emits a dup" {
+  let src = "fn pair(t: Array[Int]) -> (Array[Int], Array[Int]) {\n  (t, t)\n}\n"
+  let out = rc_plan_source(src, "pair")
+  assert(String::contains(out, "pair t dup "))
+}
+
+test "rc_plan_source: --fn filters to that function" {
+  let src = "fn keep(t: Array[Int]) -> Array[Int] {\n  t\n}\n\nfn pair(t: Array[Int]) -> (Array[Int], Array[Int]) {\n  (t, t)\n}\n"
+  let out = rc_plan_source(src, "keep")
+  assert(!String::contains(out, "pair "))
+}
+
+test "rc_plan_source: missing function throws" {
+  let src = "fn keep(t: Array[Int]) -> Array[Int] {\n  t\n}\n"
+  let caught = handle {
+    let _ = rc_plan_source(src, "missing")
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+  assert(String::contains(caught, "missing"))
+}

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -58,6 +58,12 @@
 #                                         captures -- the ones codegen boxes into
 #                                         a heap ref cell instead of a wasm local
 #                                         (NAME START END per line; empty = none)
+#   vibe rc-classify <file.vibe>          print RC classifier sets, one
+#                                         `NAME SET[,SET...]` line per user
+#                                         function (empty = no special sets)
+#   vibe rc-plan [--fn NAME] <file.vibe>  print the Perceus plan, one
+#                                         `FN BINDING ACTION COUNT` line
+#                                         (empty = no actions)
 #   vibe allocs <file.vibe>               print possible heap-allocation sites
 #                                         (FN KIND OFFSET per line; empty = none)
 #   vibe deps [--direct] <file.vibe>      print the resolved import closure, one
@@ -296,6 +302,11 @@ case "${1:-help}" in
   symbols)
     case "${2:-}" in
       --legend|--help|-h) need_runner=0 ;;
+    esac
+    ;;
+  rc-classify|rc-plan)
+    case "${2:-}" in
+      --help|-h) need_runner=0 ;;
     esac
     ;;
 esac
@@ -1396,6 +1407,96 @@ case "$cmd" in
       "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
     if [ -s "$out.diag" ]; then
       echo "error: $(cat "$out.diag")" >&2
+    fi
+    if [ -s "$out" ]; then cat "$out"; fi
+    ;;
+  rc-classify)
+    # vibe rc-classify <file.vibe>
+    # Print the RC classifier sets linked_compile computes after
+    # effect_lowering_prelude, one `NAME SET[,SET...]` line per user
+    # function that is in at least one of borrow_ret / borrow_param /
+    # view_ret / scalar_ret. Empty output = no special sets.
+    case "${1:-}" in
+      --help|-h)
+        printf '%s\n' \
+          'usage: vibe rc-classify <file.vibe>' \
+          'NAME SET[,SET...] per user function. Empty output = no special sets.' \
+          'Sets: borrow_ret, borrow_param, view_ret, scalar_ret.'
+        exit 0
+        ;;
+    esac
+    [ "$#" -ge 1 ] || die "usage: vibe rc-classify <file.vibe>"
+    src="$1"
+    [ -f "$src" ] || die "not found: $src"
+    cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
+    out="$(mktemp -t vibe-rc-classify-XXXXXX)"
+    trap 'rm -f "$out" "$out.diag"' EXIT
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
+        -u VIBE_RC_PLAN -u VIBE_RC_PLAN_FN -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
+        -u VIBE_EMIT_MODULE_SOURCE \
+      VIBE_RC_CLASSIFY=1 \
+      VIBE_IMPORT_ABI=raw \
+      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
+    if [ -s "$out.diag" ]; then
+      echo "error: $(cat "$out.diag")" >&2
+      exit 1
+    fi
+    if [ -s "$out" ]; then cat "$out"; fi
+    ;;
+  rc-plan)
+    # vibe rc-plan [--fn NAME] <file.vibe>
+    # Print the Perceus dup/drop plan for each user function, one
+    # `FN BINDING ACTION COUNT` line. ACTION is dup / drop / alias_dup.
+    # Consecutive identical (fn, binding, action) rows collapse into COUNT.
+    # Empty output = no actions. --fn restricts to one function; a missing
+    # name is an error, not an empty plan.
+    rc_plan_fn=""
+    src=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --help|-h)
+          printf '%s\n' \
+            'usage: vibe rc-plan [--fn NAME] <file.vibe>' \
+            'FN BINDING ACTION COUNT per collapsed Perceus action.' \
+            'Empty output = no actions. ACTION is dup, drop, or alias_dup.'
+          exit 0
+          ;;
+        --fn)
+          [ "$#" -ge 2 ] || die "usage: vibe rc-plan [--fn NAME] <file.vibe>"
+          rc_plan_fn="$2"
+          shift 2
+          ;;
+        --fn=*)
+          rc_plan_fn="${1#--fn=}"
+          shift
+          ;;
+        -*)
+          die "vibe rc-plan: unknown flag: $1"
+          ;;
+        *)
+          [ -z "$src" ] || die "usage: vibe rc-plan [--fn NAME] <file.vibe>"
+          src="$1"
+          shift
+          ;;
+      esac
+    done
+    [ -n "$src" ] || die "usage: vibe rc-plan [--fn NAME] <file.vibe>"
+    [ -f "$src" ] || die "not found: $src"
+    cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
+    out="$(mktemp -t vibe-rc-plan-XXXXXX)"
+    trap 'rm -f "$out" "$out.diag"' EXIT
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
+        -u VIBE_RC_CLASSIFY -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
+        -u VIBE_EMIT_MODULE_SOURCE \
+      VIBE_RC_PLAN=1 \
+      VIBE_RC_PLAN_FN="$rc_plan_fn" \
+      VIBE_IMPORT_ABI=raw \
+      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
+    if [ -s "$out.diag" ]; then
+      echo "error: $(cat "$out.diag")" >&2
+      exit 1
     fi
     if [ -s "$out" ]; then cat "$out"; fi
     ;;

--- a/scripts/test_vibe_rc_help.sh
+++ b/scripts/test_vibe_rc_help.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# `vibe rc-classify --help` / `vibe rc-plan --help` are reports, not "unknown
+# command". Pure launcher: a dummy runner is enough to pass the startup check.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe-rc-help.XXXXXX")"
+cleanup() {
+  local status=$?
+  rm -rf "$TMP_DIR"
+  exit "$status"
+}
+trap cleanup EXIT
+
+LAUNCHER="$ROOT_DIR/runtime/vibe"
+RUNNER="$TMP_DIR/dummy-runner"
+OUT="$TMP_DIR/stdout.txt"
+ERR="$TMP_DIR/stderr.txt"
+
+printf '%s\n' '#!/usr/bin/env bash' 'echo "runner-should-not-run" >&2' 'exit 41' > "$RUNNER"
+chmod +x "$RUNNER"
+
+run_help() {
+  local verb="$1"
+  local flag="$2"
+  : > "$OUT"
+  : > "$ERR"
+  local status=0
+  VIBE_RUNNER="$RUNNER" bash "$LAUNCHER" "$verb" "$flag" > "$OUT" 2> "$ERR" || status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "[vibe-rc-help] FAIL: $verb $flag exited $status (want 0)" >&2
+    cat "$ERR" >&2
+    exit 1
+  fi
+  if grep -q 'unknown' "$ERR" "$OUT"; then
+    echo "[vibe-rc-help] FAIL: $verb $flag still reports unknown" >&2
+    cat "$ERR" "$OUT" >&2
+    exit 1
+  fi
+  if [ -s "$ERR" ]; then
+    echo "[vibe-rc-help] FAIL: $verb $flag wrote to stderr" >&2
+    cat "$ERR" >&2
+    exit 1
+  fi
+  if grep -q 'runner-should-not-run' "$OUT" "$ERR"; then
+    echo "[vibe-rc-help] FAIL: $verb $flag invoked the runner" >&2
+    exit 1
+  fi
+}
+
+need() {
+  local verb="$1"
+  local needle="$2"
+  if ! grep -q -- "$needle" "$OUT"; then
+    echo "[vibe-rc-help] FAIL: $verb --help missing '$needle'" >&2
+    cat "$OUT" >&2
+    exit 1
+  fi
+}
+
+run_help rc-classify --help
+need rc-classify 'NAME SET'
+run_help rc-classify -h
+need rc-classify 'borrow_ret'
+
+run_help rc-plan --help
+need rc-plan 'FN BINDING ACTION COUNT'
+run_help rc-plan -h
+need rc-plan 'alias_dup'
+
+echo "[vibe-rc-help] ok"

--- a/scripts/vibe_grep_bin.sh
+++ b/scripts/vibe_grep_bin.sh
@@ -160,6 +160,7 @@ run_grep() {
     # plus the pattern/filter env vars, then cli_main(input, output).
     if ! env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS \
+        -u VIBE_RC_CLASSIFY -u VIBE_RC_PLAN -u VIBE_RC_PLAN_FN \
         -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         VIBE_GREP=1 \
         VIBE_GREP_PATTERN="$g_pattern" \

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -5176,6 +5176,7 @@ echo "[compiler-gate] desugar-emitted builtins resolve in both lanes ok"
 
 echo "[compiler-gate] 98/104 \`vibe grep\`'s typed filters resolve imports like \`vibe check\` (#1572)"
 bash "$ROOT_DIR/scripts/test_vibe_grep_help.sh"
+bash "$ROOT_DIR/scripts/test_vibe_rc_help.sh"
 # grep_test.vibe covers the pattern language and the filters through
 # grep_scan_source (no Fs). What only the REAL adapter mode exercises is the
 # filesystem tier: sweeping a directory, and resolving a capture's type through


### PR DESCRIPTION
## Summary

Add two line-oriented compiler queries that print what `linked_compile` already computes after `effect_lowering_prelude`:

- `vibe rc-classify <file.vibe>` — `NAME SET[,SET...]` for each user function in `borrow_ret` / `borrow_param` / `view_ret` / `scalar_ret`. Empty = no special sets.
- `vibe rc-plan [--fn NAME] <file.vibe>` — `FN BINDING ACTION COUNT` from `build_perceus_plan_with_params`. Empty = no actions. A missing `--fn` name is an error, not an empty plan.

Both call the same `compute_*` / planner functions the compile pipeline uses. Tests drive `rc_classify_source` / `rc_plan_source` (the functions the adapter writes), not a second walk.

Related: issue 1981.

## Test plan

- [x] `bash scripts/vibe_test.sh lib/@vibe/compiler/runtime/rc_query_test.vibe` (7 tests, twice)
- [x] `bash scripts/test_vibe_rc_help.sh`
- [ ] CI `compiler-gate` + `ci-required`