### PR TITLE
fix(runtime): sort RC classifier sets before the Perceus planner

### DIFF
--- a/lib/@vibe/compiler/runtime/rc_query.vibe
+++ b/lib/@vibe/compiler/runtime/rc_query.vibe
@@ -124,19 +124,37 @@ fn rcq_push_line(acc: StringBuilder, first: Array[Bool], line: String) -> Unit {
 /// set. Empty string = no special sets. Sets are the same four
 /// linked_compile threads into every Perceus plan: borrow_ret,
 /// borrow_param, view_ret, scalar_ret.
-export fn rc_classify_source(source: String) -> String with Exception {
-  let stmts = parse_program(lex(source))
-  rcq_run_prelude(stmts)
-  let borrow_ret = compute_borrow_returning_names(stmts)
-  let masks: Array[Int] = [
-  ]
-  let borrow_param = compute_borrow_param_user_fns(stmts, [
+fn rcq_entry_exclude() -> Array[String] {
+  [
     "main",
     "_start",
     "cli_main"
-  ], masks)
-  let view_ret = compute_may_return_view_fns(stmts)
-  let scalar_ret = compute_scalar_returning_names(stmts)
+  ]
+}
+
+/// Same classifier sets linked_compile threads into every Perceus plan,
+/// including the sorted_names_of wrapping the planner bsearch_leftmosts.
+fn rcq_borrow_ret(stmts: Array[Stmt]) -> Array[String] {
+  sorted_names_of(compute_borrow_returning_names(stmts))
+}
+
+fn rcq_view_ret(stmts: Array[Stmt]) -> Array[String] {
+  sorted_names_of(compute_may_return_view_fns(stmts))
+}
+
+fn rcq_scalar_ret(stmts: Array[Stmt]) -> Array[String] {
+  sorted_names_of(compute_scalar_returning_names(stmts))
+}
+
+export fn rc_classify_source(source: String) -> String with Exception {
+  let stmts = parse_program(lex(source))
+  rcq_run_prelude(stmts)
+  let borrow_ret = rcq_borrow_ret(stmts)
+  let masks: Array[Int] = [
+  ]
+  let borrow_param = compute_borrow_param_user_fns(stmts, rcq_entry_exclude(), masks)
+  let view_ret = rcq_view_ret(stmts)
+  let scalar_ret = rcq_scalar_ret(stmts)
   let names = rcq_user_fn_names(stmts)
   let acc = StringBuilder::new()
   let first: Array[Bool] = [
@@ -207,15 +225,11 @@ fn rcq_emit_fn_plan(acc: StringBuilder, first: Array[Bool], fname: String, param
 export fn rc_plan_source(source: String, fn_filter: String) -> String with Exception {
   let stmts = parse_program(lex(source))
   rcq_run_prelude(stmts)
-  let borrow_ret = compute_borrow_returning_names(stmts)
+  let borrow_ret = rcq_borrow_ret(stmts)
   let masks: Array[Int] = [
   ]
-  let borrow_param = compute_borrow_param_user_fns(stmts, [
-    "main",
-    "_start",
-    "cli_main"
-  ], masks)
-  let view_ret = compute_may_return_view_fns(stmts)
+  let borrow_param = compute_borrow_param_user_fns(stmts, rcq_entry_exclude(), masks)
+  let view_ret = rcq_view_ret(stmts)
   let acc = StringBuilder::new()
   let first: Array[Bool] = [
     true

--- a/lib/@vibe/compiler/runtime/rc_query_test.vibe
+++ b/lib/@vibe/compiler/runtime/rc_query_test.vibe
@@ -88,6 +88,21 @@ test "rc_plan_source: --fn filters to that function" {
   assert(!String::contains(out, "pair "))
 }
 
+test "rc_plan_source: later-discovered wrapper is still a view" {
+  // compute_* emit discovery order. linked_compile wraps borrow_ret /
+  // view_ret in sorted_names_of before build_perceus_plan_with_params,
+  // because the planner bsearch_leftmosts those arrays. zebra-then-apple
+  // is unsorted; apple-then-zebra happens to be sorted. The compile plan
+  // for use_apple is the same either way: apple returns a view, so `v`
+  // is not dropped.
+  let zebra_first = "fn zebra(a: Array[Array[Int]], i: Int) -> Array[Int] {\n  Array::get(a, i)\n}\n\nfn apple(a: Array[Array[Int]], i: Int) -> Array[Int] {\n  Array::get(a, i)\n}\n\nfn use_apple(a: Array[Array[Int]]) -> Int {\n  let v = apple(a, 0)\n  Array::length(v)\n}\n"
+  let apple_first = "fn apple(a: Array[Array[Int]], i: Int) -> Array[Int] {\n  Array::get(a, i)\n}\n\nfn zebra(a: Array[Array[Int]], i: Int) -> Array[Int] {\n  Array::get(a, i)\n}\n\nfn use_apple(a: Array[Array[Int]]) -> Int {\n  let v = apple(a, 0)\n  Array::length(v)\n}\n"
+  let out = rc_plan_source(zebra_first, "use_apple")
+  let flipped = rc_plan_source(apple_first, "use_apple")
+  assert_eq(out, flipped)
+  assert(!String::contains(out, "use_apple v drop"))
+}
+
 test "rc_plan_source: missing function throws" {
   let src = "fn keep(t: Array[Int]) -> Array[Int] {\n  t\n}\n"
   let caught = handle {


### PR DESCRIPTION
## Summary

`rc_plan_source` now wraps `compute_borrow_returning_names` and `compute_may_return_view_fns` in `sorted_names_of`, the same way `linked_compile` does before `build_perceus_plan_with_params`. The planner membership tests are `bsearch_leftmost`; discovery order (`zebra` then `apple`) missed the later name and emitted a drop compile would not.

Related: issue 1981 (reopened after 2095).

## Test plan

- [x] Red: `rc_plan_source: later-discovered wrapper is still a view` traps without the sort
- [x] Green: `bash scripts/vibe_test.sh lib/@vibe/compiler/runtime/rc_query_test.vibe` (8 tests, twice)
- [ ] CI `compiler-gate` + `ci-required`