### PR TITLE
docs: name Console as the current tty capability

### DIFF
--- a/book/ja/05_effects.vibe.md
+++ b/book/ja/05_effects.vibe.md
@@ -169,7 +169,11 @@ fn main with Stdout {
 apply_twice = 40
 ```
 
-ホスト I/O (`Fs` / `Env` / `Http` など) も同じ仕組みの組み込みエフェクト。
-handler は checker 用で、実行時は host import に直接 lower される。
+ホスト I/O (`Fs` / `Env` / `Http` / **`Console`**) は capability で、
+代数 effect ではない。tty の現行名は `Console`（`Console::write_stream` /
+`read_stream` / `write_err_stream` と `*_char`）。上の例の `Stdout` は
+まだ受理される **legacy ラベル**で、同じ host import を共有するが
+`Console::*` とは相互に認可しない。詳細は英語版
+[Capabilities](../src/10_capabilities.vibe.md)。
 
 次章: [06 テスト](06_tests-ja.vibe.md)

--- a/book/src/01_getting_started.vibe.md
+++ b/book/src/01_getting_started.vibe.md
@@ -24,13 +24,16 @@ You get a `vibe` dispatcher, a `viberun` host, and the stdlib under
 
 ## Hello
 
-A program is a `fn main` with an explicit effect row. `Stdout` is a
-capability: the function says it will write, and the runtime must grant it.
+A program is a `fn main` with an explicit effect row. The current tty
+capability is **`Console`**. This hello still says `Stdout` because the
+prelude helper `stdout_write` carries that **legacy** label (same host
+import as `Console::write_stream`; the two names do not authorize each
+other). See [Capabilities](10_capabilities.vibe.md).
 
-Two spellings are legal. The **bare** `with Stdout` is the usual hello.
-The **split** form `with () allows Stdout` says the same thing more
-loudly: nothing algebraic, one capability. Mixing a capability into
-`with` *after* you wrote `allows` is a parse error
+Two spellings are legal. The **bare** `with Stdout` is the usual hello
+for prelude helpers. The **split** form `with () allows Stdout` says the
+same thing more loudly: nothing algebraic, one capability. Mixing a
+capability into `with` *after* you wrote `allows` is a parse error
 (`Stdout` must appear in `allows`, not `with`).
 
 ```vibe run

--- a/book/src/05_effects.vibe.md
+++ b/book/src/05_effects.vibe.md
@@ -176,9 +176,13 @@ fn main with Stdout {
 apply_twice = 40
 ```
 
-Host I/O (`Fs`, `Env`, `Http` and friends) are **capabilities**, not
+Host I/O (`Fs`, `Env`, `Http`, **`Console`**) are **capabilities**, not
 algebraic effects. On a *split* signature they belong in `allows`, not
-`with`. See [Capabilities](10_capabilities.vibe.md).
+`with`. The current tty capability is `Console` (`Console::write_stream`,
+`read_stream`, `write_err_stream`, and the `*_char` pair). `Stdout` /
+`Stdin` / `Stderr` in the examples above are still-accepted **legacy
+labels** that share those host imports; they do not authorize `Console::*`
+and the other way around. See [Capabilities](10_capabilities.vibe.md).
 
 Next: [Capabilities](10_capabilities.vibe.md). The package/test tour is
 [Modules](07_modules_packages.vibe.md) then [Tests](06_tests.vibe.md).

--- a/book/src/10_capabilities.vibe.md
+++ b/book/src/10_capabilities.vibe.md
@@ -55,6 +55,51 @@ A function that only calls `greet` must itself mention `Stdout`. The
 capability does not appear by magic at `main` — it is inferred from
 calls and then checked against what you wrote.
 
+`stdout_write` is a prelude helper on the **legacy** `Stdout` label.
+The current tty capability — the name a grant prompt should say — is
+`Console`. Both compile today; they share the host imports
+(`vibe.stdout_write_stream` and friends) and they do **not** authorize
+each other.
+
+## The current tty name is `Console`
+
+Six operations, one effect:
+
+| operation | legacy label | host import |
+|---|---|---|
+| `Console::write_stream` | `Stdout::write_stream` | `vibe.stdout_write_stream` |
+| `Console::write_char` | `Stdout::write_char` | `vibe.stdout_write_char` |
+| `Console::write_err_stream` | `Stderr::write_stream` | `vibe.stderr_write_stream` |
+| `Console::write_err_char` | `Stderr::write_char` | `vibe.stderr_write_char` |
+| `Console::read_stream` | `Stdin::read_stream` | `vibe.stdin_read_stream` |
+| `Console::read_char` | `Stdin::read_char` | `vibe.stdin_read_char` |
+
+`Stdin` / `Stdout` / `Stderr` stay accepted until the seed bump retires
+them. A row must name the label whose operation it calls:
+`with Stdout { Console::write_stream(...) }` is a row mismatch.
+
+`with Console` covers the six operations in the **row**. Instantiate
+grants stay per-operation: `allows Console::write_stream` does not
+grant `Console::read_stream` (#1496). Do not read the merge as one
+authority for read+write+stderr.
+
+```vibe run
+fn main with Console {
+  Console::write_stream("hello, console\n")
+}
+```
+
+```output
+hello, console
+```
+
+```vibe skip
+// skip: legacy Stdout does not authorize Console::* (distinct labels)
+fn main with Stdout {
+  Console::write_stream("no")
+}
+```
+
 ## `with` vs `allows`
 
 `with` is the row of **emitted operations** (algebraic / core ambient).

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -13,6 +13,8 @@ retired in #594; see `docs/archive/moonbit-retirement.md`).
 // checker reports `unknown function: String::stdout_write`).
 import @vibe/prelude { stdout_write }
 
+// prelude `stdout_write` still carries the legacy `Stdout` label.
+// The current tty capability is `Console` (`Console::write_stream`).
 fn main with Stdout {
   stdout_write("hello world\n")
 }
@@ -881,7 +883,7 @@ its declarations and `handle` expressions.
 
 | policy | execution owner | current standard labels |
 |---|---|---|
-| host-provider metadata | host / provider outside the Wasm boundary | `Fs` `Http` `Socket` `Env` `Console` `Stdin` `Stdout` `Stderr` `Process` `Profiler` `Llm` |
+| host-provider metadata | host / provider outside the Wasm boundary | `Fs` `Http` `Socket` `Env` `Console` (`Stdin`/`Stdout`/`Stderr` = still-accepted legacy labels, same host imports) `Process` `Profiler` `Llm` |
 | entry-boundary exception policy | entry boundary diagnoses an escaping exception | `Exception` / `Exception[E]` (`Error` was retired as a row spelling in #1461) |
 | runtime scheduling policy | runtime itself | `Async` |
 
@@ -1534,16 +1536,25 @@ prelude wrapper: `add`, `sub`, `mul`, `div`, `eq`, `lt`, `not`, `and`, `or`。
 `Float::to_double`, `Double::to_int`, `Double::to_float`,
 `to_string: (Any) -> String`。
 
-**I/O** (effect 必須):
+**I/O** (effect 必須). tty の現行名は `Console`。`Stdin` / `Stdout` /
+`Stderr` は同じ host import を共有する **legacy ラベル**で、row は相互に
+認可しない。`allows Console::write_stream` は `Console::read_stream` を
+許さない (#1496)。
 
 | 関数 | シグネチャ | effect |
 |---|---|---|
 | `sh` | `(String) -> Unit` | `Process` |
 | `sh_lines` | `(String) -> Array[String]` | `Process` |
-| `Stdout::write_stream` | `(String) -> Unit` | `Stdout` |
-| `Stdout::write_char` | `(Int) -> Unit` | `Stdout` |
-| `Stdin::read_stream` | `(Int) -> String` | `Stdin` |
-| `Stdin::read_char` | `() -> Int` | `Stdin` |
+| `Console::write_stream` | `(String) -> Unit` | `Console` |
+| `Console::write_char` | `(Int) -> Unit` | `Console` |
+| `Console::write_err_stream` | `(String) -> Unit` | `Console` |
+| `Console::write_err_char` | `(Int) -> Unit` | `Console` |
+| `Console::read_stream` | `(Int) -> String` | `Console` |
+| `Console::read_char` | `() -> Int` | `Console` |
+| `Stdout::write_stream` | `(String) -> Unit` | `Stdout` (legacy) |
+| `Stdout::write_char` | `(Int) -> Unit` | `Stdout` (legacy) |
+| `Stdin::read_stream` | `(Int) -> String` | `Stdin` (legacy) |
+| `Stdin::read_char` | `() -> Int` | `Stdin` (legacy) |
 | `Stdin::read_via_stream` | `() -> StdinStream` | `Stdin` |
 | `StdinStream::next` | `(StdinStream) -> Int` (EOF 後は `-1`) | `Async` |
 | `StdinStream::close` | `(StdinStream) -> Unit` (成功後は冪等) | `Async` |
@@ -1895,8 +1906,8 @@ test "n" with { Fs } { .. }    // NG: braced row は #1429 で削除 — `with F
 ```
 
 **名前付き `test` / `bench` は名前の後に effect row を書ける** (#1508)。宣言した
-row は ambient row (`{ Fs, Env, Stdin, Stdout, Stderr, Console, Process,
-Profiler, Error, Exception }`) を**置換ではなく拡張**する — `with Http` を
+row は ambient row (`{ Fs, Env, Console, Stdin, Stdout, Stderr, Process,
+Profiler, Error, Exception }`; `Console` が tty の現行名、旧三つは legacy) を**置換ではなく拡張**する — `with Http` を
 書いても `assert` に必要な `Exception` などの既定は残る。無名 `test { .. }` /
 `bench { .. }` には row を書けない (row を対応付ける名前が無い)。
 

--- a/docs/effect-taxonomy-entry-policy.md
+++ b/docs/effect-taxonomy-entry-policy.md
@@ -32,7 +32,7 @@ effect operation を、次の四分類で扱う（`runtime effect` は #1458 の
 
 | 分類 | 誰が discharge するか | 許諾で揺れるか | メンバー |
 |---|---|---|---|
-| **capability effect** | host / provider (wasm 境界の外) | 揺れる | Fs, Http, Socket, Env, Console, Stdin, Stdout, Stderr, Process, Profiler, Llm |
+| **capability effect** | host / provider (wasm 境界の外) | 揺れる | Fs, Http, Socket, Env, Console (tty 現行; Stdin/Stdout/Stderr は同じ host import の legacy ラベル), Process, Profiler, Llm |
 | **algebraic effect** | プログラム内の `handle` | 無関係 | Log, State, Ask, ParseRecur, … (表に無い名前はすべてここ) |
 | **core ambient effect** | 誰も discharge しない (entry が abortive に処理する) | 無関係 | Exception[E] / Error |
 | **runtime effect** | runtime そのもの | 無関係 | Async |


### PR DESCRIPTION
## Summary

User-facing tty docs now name **one** current capability, `Console`, with the six shipped operations (`read_stream` / `read_char` / `write_stream` / `write_char` / `write_err_stream` / `write_err_char`). `Stdin` / `Stdout` / `Stderr` are labeled still-accepted **legacy** spellings that share the same host imports and do **not** authorize `Console::*`.

`allows Console::write_stream` stays independent of `Console::read_stream` (issue 1496). Existing prelude `stdout_write` examples keep `with Stdout`.

Does not finish issue 1460: Phase 2 seed bump and Phase 3 `lib/` rewrite stay open. Do not treat this PR as closing that issue.

## Test plan

- [x] `bash scripts/vibe_md.sh check` on touched `.vibe.md` (10 pass / 0 fail / 7 skip, twice)
- [x] Console example at `book/src/10_capabilities.vibe.md:87` PASS
- [x] `console_capability_test.vibe` (4 tests, including no cross-authorization)
- [ ] CI `compiler-gate` + `ci-required`