### PR TITLE
feat(query): observe written let-star binders

### DIFF
--- a/lib/@vibe/compiler/runtime/binding_at.vibe
+++ b/lib/@vibe/compiler/runtime/binding_at.vibe
@@ -405,8 +405,38 @@ fn bind_walk_expr(st: BindState, expr: Expr) -> Unit {
       bind_pop_scope(st, mark)
     },
     ECall(callee, args, _) => {
-      bind_walk_expr(st, callee)
-      bind_walk_exprs(st, args)
+      // `let* x = e` lowers to `__try_bind(e, (x) -> rest)`. Source order is
+      // the binder then the value; walking the call args as written would
+      // recover `x` after `e` and miss the written name.
+      match callee {
+        EIdent(cname, _) => if cname == "__try_bind" && Array::length(args) == 2 {
+          match Array::get(args, 1) {
+            EFn(_, _, params, _, _, body) => if Array::length(params) == 1 {
+              let (pname, _) = Array::get(params, 0)
+              let id = bind_recover_binder(st, pname)
+              bind_walk_expr(st, Array::get(args, 0))
+              let mark = Array::length(st.scope_names)
+              bind_push_binder(st, pname, id)
+              bind_walk_expr(st, body)
+              bind_pop_scope(st, mark)
+            } else {
+              bind_walk_expr(st, callee)
+              bind_walk_exprs(st, args)
+            },
+            _ => {
+              bind_walk_expr(st, callee)
+              bind_walk_exprs(st, args)
+            }
+          }
+        } else {
+          bind_walk_expr(st, callee)
+          bind_walk_exprs(st, args)
+        },
+        _ => {
+          bind_walk_expr(st, callee)
+          bind_walk_exprs(st, args)
+        }
+      }
     },
     EBinOp(_, l, r) => {
       bind_walk_expr(st, l)

--- a/lib/@vibe/compiler/runtime/editor_query_test.vibe
+++ b/lib/@vibe/compiler/runtime/editor_query_test.vibe
@@ -281,3 +281,29 @@ test "doc-at: hovering a fn declaration resolves its doc comment" {
   let src = "/// adds two numbers\nfn add(a: Int, b: Int) -> Int { a + b }\n"
   inspect(doc_at_source(src, 2, 4), "adds two numbers")
 }
+
+test "type-at: a comment let-star is not a binder" {
+  let src = "// let* dead = o\nfn f(o: Option[Int]) -> Option[Int] {\n  let* x = o\n  Some(x + 1)\n}\n"
+  assert(type_at_source(src, 1, 8) == "")
+}
+
+test "type-at: let-star binder has the unwrapped payload type" {
+  let src = "fn f(o: Option[Int]) -> Option[Int] {\n  let* x = o\n  Some(x + 1)\n}\n"
+  assert(type_at_source(src, 2, 8) == "Int")
+}
+
+test "binding-at: let-star binder includes the written name and its uses" {
+  let src = "fn f(o: Option[Int]) -> Option[Int] {\n  let* x = o\n  Some(x + 1)\n}\n"
+  let occ = binding_occurrences(src, 2, 8)
+  assert(occ_len(occ) >= 2)
+}
+
+test "binding-at: nested let-star binders are distinct" {
+  let src = "fn f(o: Option[Option[Int]]) -> Option[Int] {\n  let* outer = o\n  let* inner = outer\n  Some(inner)\n}\n"
+  let outer_occ = binding_occurrences(src, 2, 8)
+  let inner_occ = binding_occurrences(src, 3, 8)
+  assert(occ_len(outer_occ) >= 2)
+  assert(occ_len(inner_occ) >= 2)
+  assert(type_at_source(src, 2, 8) != "")
+  assert(type_at_source(src, 3, 8) != "")
+}

--- a/lib/@vibe/compiler/runtime/editor_query_test.vibe
+++ b/lib/@vibe/compiler/runtime/editor_query_test.vibe
@@ -282,6 +282,11 @@ test "doc-at: hovering a fn declaration resolves its doc comment" {
   inspect(doc_at_source(src, 2, 4), "adds two numbers")
 }
 
+test "type-at: function name is not stolen from a same-name call result" {
+  let src = "export let add = (a: Int, b: Int) -> Int { a + b }\nfn main() -> Int { add(1, 2) }\n"
+  assert(type_at_source(src, 1, 12) == "(Int, Int) -> Int")
+}
+
 test "type-at: a comment let-star is not a binder" {
   let src = "// let* dead = o\nfn f(o: Option[Int]) -> Option[Int] {\n  let* x = o\n  Some(x + 1)\n}\n"
   assert(type_at_source(src, 1, 8) == "")

--- a/lib/@vibe/compiler/runtime/grep.vibe
+++ b/lib/@vibe/compiler/runtime/grep.vibe
@@ -323,6 +323,49 @@ fn grep_check_holes(items: Array[Expr]) -> Unit with Exception {
   }
 }
 
+fn grep_skip_ws(pattern: String, from: Int) -> Int {
+  let len = String::length(pattern)
+  let mut i = from
+  while i < len && (String::char_code_at(pattern, i) == ' ' || String::char_code_at(pattern, i) == 9 || String::char_code_at(pattern, i) == 10 || String::char_code_at(pattern, i) == 13) {
+    i = i + 1
+  }
+  i
+}
+
+/// Index just past a leading `let*` (after whitespace), or -1.
+fn grep_let_star_after(pattern: String) -> Int {
+  let i = grep_skip_ws(pattern, 0)
+  let len = String::length(pattern)
+  if i + 4 <= len && String::substring(pattern, i, i + 4) == "let*" {
+    i + 4
+  } else {
+    -1
+  }
+}
+
+/// `let* $(x:id) = $(e:exp)` is a declaration in the parser, so rewrite it
+/// to the `__try_bind` call the file AST actually contains.
+fn grep_rewrite_let_star(pattern: String) -> String with Exception {
+  let after = grep_let_star_after(pattern)
+  if after < 0 {
+    pattern
+  } else {
+    let rest = String::substring(pattern, after, String::length(pattern))
+    let eq = String::index_of(rest, "=")
+    if eq < 0 {
+      throw("grep pattern: `let*` needs `let* $(x:id) = $(e:exp)`")
+    } else {
+      let lhs = String::trim(String::substring(rest, 0, eq))
+      let rhs = String::trim(String::substring(rest, eq + 1, String::length(rest)))
+      if String::length(lhs) == 0 || String::length(rhs) == 0 {
+        throw("grep pattern: `let*` needs `let* $(x:id) = $(e:exp)`")
+      } else {
+        String::concat("__try_bind(", String::concat(rhs, String::concat(", (", String::concat(lhs, ") -> $(_:exp))"))))
+      }
+    }
+  }
+}
+
 /// The pattern string's first identifier after leading whitespace, when that
 /// identifier is `throw` or `perform`. Anything else — a metavar, a wrapping
 /// call, a different name — is `""` and does not filter hits.
@@ -353,7 +396,8 @@ fn grep_pattern_origin(pattern: String) -> String {
 /// the shape it actually produced, rather than being matched against nothing.
 export fn grep_compile_pattern(pattern: String) -> GrepPattern with Exception {
   let vars = grep_empty_strings()
-  let expanded = grep_expand_metavars(pattern, vars)
+  let rewritten = grep_rewrite_let_star(pattern)
+  let expanded = grep_expand_metavars(rewritten, vars)
   // Prefix a lex/parse failure so the reader can tell "your PATTERN does not
   // parse" from "the file being searched does not parse" -- the two arrive on
   // the same channel and are otherwise indistinguishable.
@@ -370,8 +414,13 @@ export fn grep_compile_pattern(pattern: String) -> GrepPattern with Exception {
     match Array::get(stmts, 0) {
       SExpr(e) => {
         grep_validate_holes(e)
+        let origin = if grep_let_star_after(pattern) >= 0 {
+          "let*"
+        } else {
+          grep_pattern_origin(pattern)
+        }
         GrepPattern::{
-          template: e, vars: vars, origin: grep_pattern_origin(pattern)
+          template: e, vars: vars, origin: origin
         }
       },
       _ => throw("grep pattern: must be a single EXPRESSION — declaration patterns (`fn`, top-level `let`, `enum`, ...) are not supported yet; use `vibe symbols` for declarations")
@@ -1175,15 +1224,71 @@ fn grep_flatten(text: String) -> String {
   out
 }
 
+fn grep_is_try_bind(node: Expr) -> Bool {
+  match node {
+    ECall(callee, args, _) => match callee {
+      EIdent(n, _) => n == "__try_bind" && Array::length(args) == 2,
+      _ => false
+    },
+    _ => false
+  }
+}
+
+fn grep_try_bind_text(node: Expr) -> String {
+  match node {
+    ECall(_, args, _) => if Array::length(args) == 2 {
+      match Array::get(args, 1) {
+        EFn(_, _, params, _, _, _) => if Array::length(params) == 1 {
+          let (pname, _) = Array::get(params, 0)
+          String::concat("let* ", String::concat(pname, String::concat(" = ", print_expr(Array::get(args, 0)))))
+        } else {
+          ""
+        },
+        _ => ""
+      }
+    } else {
+      ""
+    },
+    _ => ""
+  }
+}
+
 fn grep_try_match(pat: GrepPattern, node: Expr, path: String, out: Array[GrepHit]) -> Unit with Exception {
   let binds = grep_empty_binds()
   if grep_match_expr(pat.template, node, binds) {
-    let (lo, hi) = grep_expr_span(node)
+    let (lo0, hi0) = grep_expr_span(node)
+    let (lo, hi) = if grep_is_try_bind(node) {
+      match node {
+        ECall(_, args, off) => {
+          let (vlo, vhi) = grep_expr_span(Array::get(args, 0))
+          let lo2 = if off >= 0 {
+            off
+          } else {
+            vlo
+          }
+          let hi2 = if vhi > lo2 {
+            vhi
+          } else {
+            hi0
+          }
+          (lo2, hi2)
+        },
+        _ => (lo0, hi0)
+      }
+    } else {
+      (lo0, hi0)
+    }
+    let raw = grep_try_bind_text(node)
+    let text = if String::length(raw) > 0 {
+      raw
+    } else {
+      grep_flatten(print_expr(node))
+    }
     Array::push(out, GrepHit::{
       path: path,
       offset: lo,
       end_offset: hi,
-      text: grep_flatten(print_expr(node)),
+      text: text,
       captures: binds
     })
   } else {
@@ -2087,6 +2192,8 @@ fn grep_source_keyword_at(source: String, offset: Int) -> String {
     "throw"
   } else if grep_source_word_at(source, offset, "perform") {
     "perform"
+  } else if grep_source_word_at(source, offset, "let") && offset + 4 <= len && String::char_code_at(source, offset + 3) == '*' {
+    "let*"
   } else {
     ""
   }

--- a/lib/@vibe/compiler/runtime/grep_test.vibe
+++ b/lib/@vibe/compiler/runtime/grep_test.vibe
@@ -320,3 +320,26 @@ test "grep: `$(x:exp)` still matches both `throw` and `perform`" {
 test "grep: `perform Error::Throw` matches only that perform spelling" {
   inspect(scan(throw_perform_src(), "perform Error::Throw($(x:exp))"), "a.vibe:8:3: throw(\"e\")\t$x=\"e\"\n")
 }
+
+fn let_star_src() -> String {
+  "fn f(o: Option[Int]) -> Option[Int] {\n  let* x = o\n  Some(x + 1)\n}\n"
+}
+
+test "grep: `let*` matches the written railway bind" {
+  let out = scan(let_star_src(), "let* $(x:id) = $(e:exp)")
+  assert(String::contains(out, "let*"))
+  assert(String::contains(out, "$x=x"))
+  assert(String::contains(out, "$e=o"))
+}
+
+test "grep: `let*` does not match a plain `let`" {
+  let src = "fn f(o: Option[Int]) -> Option[Int] {\n  let x = o\n  Some(1)\n}\n"
+  inspect(scan(src, "let* $(x:id) = $(e:exp)"), "")
+}
+
+test "grep: `let*` matches each written binder in a nested railway" {
+  let src = "fn f(o: Option[Option[Int]]) -> Option[Int] {\n  let* outer = o\n  let* inner = outer\n  Some(inner)\n}\n"
+  let out = scan(src, "let* $(x:id) = $(e:exp)")
+  assert(String::contains(out, "$x=outer"))
+  assert(String::contains(out, "$x=inner"))
+}

--- a/lib/@vibe/compiler/runtime/type_at.vibe
+++ b/lib/@vibe/compiler/runtime/type_at.vibe
@@ -28,7 +28,7 @@ import @vibe/compiler/checker {
 }
 
 import @vibe/compiler/syntax {
-  lex_with_offsets, offset_to_line_col, parse_program_located, parse_program_spans
+  Token, lex_with_offsets, offset_to_line_col, parse_program_located, parse_program_spans
 }
 
 //# Functions
@@ -456,6 +456,34 @@ fn tytab_lookup(table: Array[(Int, Type)], off: Int) -> Option[Type] {
 ///      and let/fn-binding definition sites whose offset is not an EIdent node).
 /// Returns "" when the position is not over a located identifier, or the name
 /// resolves nowhere. Any failure is swallowed and yields "".
+fn type_at_use_or_env(table: Array[(Int, Type)], hits: Array[IdentHit], name: String, chosen_off: Int, final_s: Subst, stmts: Array[Stmt]) -> String with Exception {
+  let mut use_ty = ""
+  let mut u = 0
+  while u < Array::length(hits) {
+    let (hname, hoff) = hit_name_off(Array::get(hits, u))
+    if hname == name && hoff != chosen_off {
+      match tytab_lookup(table, hoff) {
+        Some(t) => {
+          use_ty = type_to_string(subst_apply(final_s, t))
+        },
+        None => ()
+      }
+    } else {
+      ()
+    }
+    u = u + 1
+  }
+  if use_ty != "" {
+    use_ty
+  } else {
+    let env = check_program(stmts)
+    match env_lookup(env, name) {
+      Some(t) => type_to_string(t),
+      None => ""
+    }
+  }
+}
+
 export fn type_at_source(source: String, line: Int, col: Int) -> String {
   handle {
     let tgt = line_col_to_offset(source, line, col)
@@ -471,6 +499,34 @@ export fn type_at_source(source: String, line: Int, col: Int) -> String {
       let hits = empty_hits()
       // Identifier USES carry real offsets on their EIdent nodes.
       collect_stmts(stmts, hits)
+      let mut lsi = 0
+      let ls_ntok = Array::length(tokens)
+      while lsi + 2 < ls_ntok {
+        match Array::get(tokens, lsi) {
+          TLet => match Array::get(tokens, lsi + 1) {
+            TStar => match Array::get(tokens, lsi + 2) {
+              TIdent(ls_name) => {
+                let ls_off = Array::get(starts, lsi + 2)
+                if ls_off >= 0 {
+                  Array::push(hits, IdentHit(ls_name, ls_off))
+                } else {
+                  ()
+                }
+                lsi = lsi + 3
+              },
+              _ => {
+                lsi = lsi + 1
+              }
+            },
+            _ => {
+              lsi = lsi + 1
+            }
+          },
+          _ => {
+            lsi = lsi + 1
+          }
+        }
+      }
       // Identifier DEFINITIONS (let / fn binding names) carry none, so recover
       // their source offset from each statement's span and the source text.
       let (span_stmts, span_start, span_end) = parse_program_spans(tokens, starts, ends)
@@ -502,14 +558,7 @@ export fn type_at_source(source: String, line: Int, col: Int) -> String {
           }
           match table_hit {
             Some(rec_ty) => type_to_string(subst_apply(final_s, rec_ty)),
-            None => {
-              // 3. fall back to the top-level env (top-level / imported names).
-              let env = check_program(stmts)
-              match env_lookup(env, name) {
-                Some(t) => type_to_string(t),
-                None => ""
-              }
-            }
+            None => type_at_use_or_env(table, hits, name, chosen_off, final_s, stmts)
           }
         }
       }

--- a/lib/@vibe/compiler/runtime/type_at.vibe
+++ b/lib/@vibe/compiler/runtime/type_at.vibe
@@ -461,7 +461,7 @@ fn type_at_use_or_env(table: Array[(Int, Type)], hits: Array[IdentHit], name: St
   let mut u = 0
   while u < Array::length(hits) {
     let (hname, hoff) = hit_name_off(Array::get(hits, u))
-    if hname == name && hoff != chosen_off {
+    if hname == name && hoff != chosen_off && !hit_is_callee(Array::get(hits, u)) {
       match tytab_lookup(table, hoff) {
         Some(t) => {
           use_ty = type_to_string(subst_apply(final_s, t))

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -247,7 +247,7 @@ enum BlockStep {
   StepPatternElse(Pat, Expr, Expr, Array[SourceBinder]);
   StepStructDestr(Pat, Expr);
   StepRecordDestr(Pat, Expr);
-  StepBind(String, Expr)
+  StepBind(String, Expr, Int)
 }
 
 /// #666: desugar match-arm guards into existing constructs. `arms` is the
@@ -709,12 +709,12 @@ fn apply_block_step(step: BlockStep, rest: Expr, context: Option[ParserBinderCon
     // (`Result` or undeterminable) the original Result match
     //   `match val { Ok(x) => rest, Err(__bind_err) => Err(__bind_err) }`.
     // The continuation closure carries `x` + `rest` so `rest`'s scope is exact.
-    StepBind(name, val) => ECall(EIdent("__try_bind", -1), [
+    StepBind(name, val, off) => ECall(EIdent("__try_bind", off), [
       val,
       EFn(_no_tp(), _no_tb(), [
         (name, None)
       ], None, None, rest)
-    ], -1)
+    ], off)
   }
 }
 
@@ -972,7 +972,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
               if next_pos <= eq {
                 throw("internal parser error: block let* parser did not advance")
               } else {
-                ArrayBuilder::push(steps, StepBind(name, val))
+                ArrayBuilder::push(steps, StepBind(name, val, blk_offset_at(starts, p)))
                 p = next_pos
               }
             },


### PR DESCRIPTION
## Summary

`let*` was erased to `__try_bind` before query surfaces ran, so grep could not search for it and type-at/binding-at missed the written binder.

- Parser: `__try_bind` call carries the `let` token offset
- `vibe grep`: `let* $(x:id) = $(e:exp)` matches the written bind and prints `let* x = e`
- `vibe type-at` / `vibe binding-at`: recover the binder from `let` `*` IDENT tokens (comments excluded)

Related: issue 1942.

## Test plan

- [x] `editor_query_test.vibe` 27 tests, twice
- [x] `grep_test.vibe` 34 tests, twice
- [ ] CI `compiler-gate` + `ci-required`