### PR TITLE
fix(checker): hold every unqualified effectful builtin to the row discipline (#2107)

### DIFF
--- a/bench/binary_size/fizzbuzz.vibe
+++ b/bench/binary_size/fizzbuzz.vibe
@@ -13,7 +13,7 @@ fn fizzbuzz_line(n: Int) -> String {
   }
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let mut i = 1
   while i <= 100 {
     println(fizzbuzz_line(i))

--- a/bench/binary_size/hello_world.vibe
+++ b/bench/binary_size/hello_world.vibe
@@ -1,7 +1,7 @@
 // #1056 binary-size regression bench: minimal program (single println call).
 // See bench/binary_size/README.md.
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   println("Hello, world!")
   0
 }

--- a/bench/exec/base64.vibe
+++ b/bench/exec/base64.vibe
@@ -41,7 +41,7 @@ fn encode(data: Bytes) -> String {
   s
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let data = Bytes::new()
   let mut seed = 7
   let mut i = 0

--- a/bench/exec/expr_eval.vibe
+++ b/bench/exec/expr_eval.vibe
@@ -53,7 +53,7 @@ fn size(e: Expr) -> Int {
   }
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let mut total = 0
   let mut nodes = 0
   let mut salt = 1

--- a/bench/exec/higher_order.vibe
+++ b/bench/exec/higher_order.vibe
@@ -12,7 +12,7 @@ fn apply_n(f: (Int) -> Int, x: Int, n: Int) -> Int {
   acc
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let xs: Array[Int] = [
   ]
   let mut i = 0

--- a/bench/exec/int_wrap.vibe
+++ b/bench/exec/int_wrap.vibe
@@ -9,7 +9,7 @@ fn opaque(x: Int) -> Int {
   x + 0
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let max = opaque(4611686018427387903)
   let b61 = opaque(2305843009213693951) + 1
   println(Int::to_string(b61 + b61))

--- a/bench/exec/json_scan.vibe
+++ b/bench/exec/json_scan.vibe
@@ -25,7 +25,7 @@ fn build_doc(n: Int) -> String {
   String::concat(s, "]")
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let doc = build_doc(300)
   let n = String::length(doc)
   let mut i = 0

--- a/bench/exec/records_pipeline.vibe
+++ b/bench/exec/records_pipeline.vibe
@@ -33,7 +33,7 @@ fn apply_tx(a: Account, amount: Int) -> Account {
   }
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let accounts: Array[Account] = [
   ]
   let mut i = 0

--- a/bench/exec/sieve.vibe
+++ b/bench/exec/sieve.vibe
@@ -2,7 +2,7 @@
 // Bytes with a growth loop, then prime gap statistics.
 // Deterministic output; see bench/exec/README.md.
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let limit = 20000
   let flags = Bytes::new()
   let mut i = 0

--- a/bench/exec/sort_ints.vibe
+++ b/bench/exec/sort_ints.vibe
@@ -49,7 +49,7 @@ fn binary_search(xs: Array[Int], key: Int) -> Bool {
   hit
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let xs: Array[Int] = [
   ]
   let mut seed = 42

--- a/bench/exec/string_ops.vibe
+++ b/bench/exec/string_ops.vibe
@@ -37,7 +37,7 @@ fn scan_needles(s: String) -> Int {
   found
 }
 
-let main = () -> Int {
+let main = () -> Int with Stdout {
   let s = build_words(400)
   let parts = String::split(s, ",")
   let mut sub_hash = 0

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -9,16 +9,20 @@ retired in #594; see `docs/archive/moonbit-retirement.md`).
 ## Quick Start
 
 ```vibe
-// `stdout_write` is a prelude helper, not a builtin — import it (otherwise the
-// checker reports `unknown function: String::stdout_write`).
-import @vibe/prelude { stdout_write }
-
-// prelude `stdout_write` still carries the legacy `Stdout` label.
-// The current tty capability is `Console` (`Console::write_stream`).
+// `println` is a builtin — no import — and it carries the `Stdout`
+// capability, so the entry declares it. A function that declares no row may
+// not print (#2107).
 fn main with Stdout {
-  stdout_write("hello world\n")
+  println("hello world")
 }
 ```
+
+`print` is the same without the trailing newline. `@vibe/console` publishes the
+rest of the tty surface (`eprint` / `eprintln` on `Stderr`, `read_line`,
+`read_all`), and `@vibe/prelude`'s older `stdout_write` / `stdout_writeln`
+still compile. The row is spelled `Stdout` here because that is what these
+lower onto today; the current tty capability is `Console`
+(`Console::write_stream`), and #1460 moves them there.
 
 ```bash
 vibe run hello.vibex       # compile & execute
@@ -229,8 +233,6 @@ note above); reach for `ArrayBuilder` (build-then-freeze accumulation) or
 ## Functions
 
 ```vibe
-import @vibe/prelude { stdout_write }   // for hello() below
-
 // Top-level named functions: `fn` (#727, ADR-0064). Full annotations
 // required (param types + return type); recursion needs no `rec`.
 fn add(x: Int, y: Int) -> Int { x + y }
@@ -239,7 +241,7 @@ fn fact(n: Int) -> Int {
 }
 fn identity[T](x: T) -> T { x }                // generic
 fn show[T: Eq + Ord](x: T) -> T { x }          // trait bounds
-fn hello() -> Unit with Stdout { stdout_write("hi\n") }
+fn hello() -> Unit with Stdout { println("hi") }
 // #1429: the effect row has exactly one spelling, plus one for the empty row.
 //   with A + B      the row
 //   with ()         the explicitly empty row
@@ -1443,7 +1445,9 @@ the linear and GC backends):
 **I/O** (require effects):
 <!-- doctest-skip: 未定義名 (s) + effect context 無しの呼び出しシグネチャ一覧 -->
 ```vibe skip
-stdout_write(s)    // with Stdout
+println(s)         // with Stdout - builtin, no import
+print(s)           // with Stdout - no trailing newline
+stdout_write(s)    // with Stdout - @vibe/prelude
 stdin_read_line()  // with Stdin
 sh("ls -la")       // with Stdout - shell command
 sh_lines("ls")     // -> Array[String]

--- a/fixtures/effect_effectset_expansion.vibe
+++ b/fixtures/effect_effectset_expansion.vibe
@@ -56,9 +56,18 @@ test "effectset row expansion authorizes the transitive operation requirement" {
   // deliberately NOT the expected value: the inner handler must win). This
   // exact shape -- calling a self-discharging fn from under another handle
   // for the same effect -- was rejected before #1595.
-  handle {
-    inspect(run_effectset(), "42")
+  //
+  // #2107: `inspect` is called on the RESULT, outside the handled body. It is
+  // imported here (so `desugar_inspect_calls` leaves it alone) and it carries
+  // `with Stdout` now that the print builtins do, and a call to a row-carrying
+  // function inside a handled body is not eligible for the direct-perform
+  // lowering -- measured, and true of any such callee, not of this one. The
+  // property being pinned is the CALL to the self-discharging fn under another
+  // handle for the same effect, which is exactly what stays inside.
+  let got = handle {
+    run_effectset()
   } with Ask {
     Get => resume(0)
   }
+  inspect(got, "42")
 }

--- a/fixtures/effect_effectset_expansion.vibe
+++ b/fixtures/effect_effectset_expansion.vibe
@@ -56,18 +56,9 @@ test "effectset row expansion authorizes the transitive operation requirement" {
   // deliberately NOT the expected value: the inner handler must win). This
   // exact shape -- calling a self-discharging fn from under another handle
   // for the same effect -- was rejected before #1595.
-  //
-  // #2107: `inspect` is called on the RESULT, outside the handled body. It is
-  // imported here (so `desugar_inspect_calls` leaves it alone) and it carries
-  // `with Stdout` now that the print builtins do, and a call to a row-carrying
-  // function inside a handled body is not eligible for the direct-perform
-  // lowering (#2109) -- measured, and true of any such callee, not of this one. The
-  // property being pinned is the CALL to the self-discharging fn under another
-  // handle for the same effect, which is exactly what stays inside.
-  let got = handle {
-    run_effectset()
+  handle {
+    inspect(run_effectset(), "42")
   } with Ask {
     Get => resume(0)
   }
-  inspect(got, "42")
 }

--- a/fixtures/effect_effectset_expansion.vibe
+++ b/fixtures/effect_effectset_expansion.vibe
@@ -61,7 +61,7 @@ test "effectset row expansion authorizes the transitive operation requirement" {
   // imported here (so `desugar_inspect_calls` leaves it alone) and it carries
   // `with Stdout` now that the print builtins do, and a call to a row-carrying
   // function inside a handled body is not eligible for the direct-perform
-  // lowering -- measured, and true of any such callee, not of this one. The
+  // lowering (#2109) -- measured, and true of any such callee, not of this one. The
   // property being pinned is the CALL to the self-discharging fn under another
   // handle for the same effect, which is exactly what stays inside.
   let got = handle {

--- a/fixtures/effect_effectset_param_expansion.vibe
+++ b/fixtures/effect_effectset_param_expansion.vibe
@@ -54,7 +54,7 @@ test "effectset expansion covers a callback parameter's own row" {
   // here (so `desugar_inspect_calls` leaves it alone) and carries `with
   // Stdout` now that the print builtins do, and a call to a row-carrying
   // function inside a handled body is not eligible for the direct-perform
-  // lowering. What this fixture pins stays inside the handle.
+  // lowering (#2109). What this fixture pins stays inside the handle.
   let got = handle {
     run_param_effectset()
   } with Ask {

--- a/fixtures/effect_effectset_param_expansion.vibe
+++ b/fixtures/effect_effectset_param_expansion.vibe
@@ -50,9 +50,15 @@ test "effectset expansion covers a callback parameter's own row" {
   // (resume(0) is deliberately NOT the expected value: the inner handler
   // must win). Calling a self-discharging fn from under another handle for
   // the same effect was rejected before #1595.
-  handle {
-    inspect(run_param_effectset(), "42")
+  // #2107: `inspect` runs on the RESULT, outside the handle. It is imported
+  // here (so `desugar_inspect_calls` leaves it alone) and carries `with
+  // Stdout` now that the print builtins do, and a call to a row-carrying
+  // function inside a handled body is not eligible for the direct-perform
+  // lowering. What this fixture pins stays inside the handle.
+  let got = handle {
+    run_param_effectset()
   } with Ask {
     Get => resume(0)
   }
+  inspect(got, "42")
 }

--- a/fixtures/effect_effectset_param_expansion.vibe
+++ b/fixtures/effect_effectset_param_expansion.vibe
@@ -50,15 +50,9 @@ test "effectset expansion covers a callback parameter's own row" {
   // (resume(0) is deliberately NOT the expected value: the inner handler
   // must win). Calling a self-discharging fn from under another handle for
   // the same effect was rejected before #1595.
-  // #2107: `inspect` runs on the RESULT, outside the handle. It is imported
-  // here (so `desugar_inspect_calls` leaves it alone) and carries `with
-  // Stdout` now that the print builtins do, and a call to a row-carrying
-  // function inside a handled body is not eligible for the direct-perform
-  // lowering (#2109). What this fixture pins stays inside the handle.
-  let got = handle {
-    run_param_effectset()
+  handle {
+    inspect(run_param_effectset(), "42")
   } with Ask {
     Get => resume(0)
   }
-  inspect(got, "42")
 }

--- a/fixtures/effect_row_operation_item.vibe
+++ b/fixtures/effect_row_operation_item.vibe
@@ -34,9 +34,15 @@ test "an operation-qualified row item parses, checks, and runs" {
   // (resume(0) is deliberately NOT the expected value: the inner handler
   // must win). Calling a self-discharging fn from under another handle for
   // the same effect was rejected before #1595.
-  handle {
-    inspect(run_operation_row(), "42")
+  // #2107: `inspect` runs on the RESULT, outside the handle. It is imported
+  // here (so `desugar_inspect_calls` leaves it alone) and carries `with
+  // Stdout` now that the print builtins do, and a call to a row-carrying
+  // function inside a handled body is not eligible for the direct-perform
+  // lowering. What this fixture pins stays inside the handle.
+  let got = handle {
+    run_operation_row()
   } with Ask {
     Get => resume(0)
   }
+  inspect(got, "42")
 }

--- a/fixtures/effect_row_operation_item.vibe
+++ b/fixtures/effect_row_operation_item.vibe
@@ -38,7 +38,7 @@ test "an operation-qualified row item parses, checks, and runs" {
   // here (so `desugar_inspect_calls` leaves it alone) and carries `with
   // Stdout` now that the print builtins do, and a call to a row-carrying
   // function inside a handled body is not eligible for the direct-perform
-  // lowering. What this fixture pins stays inside the handle.
+  // lowering (#2109). What this fixture pins stays inside the handle.
   let got = handle {
     run_operation_row()
   } with Ask {

--- a/fixtures/effect_row_operation_item.vibe
+++ b/fixtures/effect_row_operation_item.vibe
@@ -34,15 +34,9 @@ test "an operation-qualified row item parses, checks, and runs" {
   // (resume(0) is deliberately NOT the expected value: the inner handler
   // must win). Calling a self-discharging fn from under another handle for
   // the same effect was rejected before #1595.
-  // #2107: `inspect` runs on the RESULT, outside the handle. It is imported
-  // here (so `desugar_inspect_calls` leaves it alone) and carries `with
-  // Stdout` now that the print builtins do, and a call to a row-carrying
-  // function inside a handled body is not eligible for the direct-perform
-  // lowering (#2109). What this fixture pins stays inside the handle.
-  let got = handle {
-    run_operation_row()
+  handle {
+    inspect(run_operation_row(), "42")
   } with Ask {
     Get => resume(0)
   }
-  inspect(got, "42")
 }

--- a/fixtures/effect_self_discharging_callee.vibe
+++ b/fixtures/effect_self_discharging_callee.vibe
@@ -46,15 +46,9 @@ test "calling a self-discharging fn from a row-carrying caller compiles and runs
   // The wrapping handle discharges `main`'s declared row for the test
   // block (a test's own row cannot authorize Ask); `selfd`'s inner handler
   // must win, so resume(0) is deliberately NOT the expected value.
-  // #2107: `inspect` runs on the RESULT, outside the handle. It is imported
-  // here (so `desugar_inspect_calls` leaves it alone) and carries `with
-  // Stdout` now that the print builtins do, and a call to a row-carrying
-  // function inside a handled body is not eligible for the direct-perform
-  // lowering (#2109). What this fixture pins stays inside the handle.
-  let got = handle {
-    run_selfd()
+  handle {
+    inspect(run_selfd(), "42")
   } with Ask {
     Get => resume(0)
   }
-  inspect(got, "42")
 }

--- a/fixtures/effect_self_discharging_callee.vibe
+++ b/fixtures/effect_self_discharging_callee.vibe
@@ -46,9 +46,15 @@ test "calling a self-discharging fn from a row-carrying caller compiles and runs
   // The wrapping handle discharges `main`'s declared row for the test
   // block (a test's own row cannot authorize Ask); `selfd`'s inner handler
   // must win, so resume(0) is deliberately NOT the expected value.
-  handle {
-    inspect(run_selfd(), "42")
+  // #2107: `inspect` runs on the RESULT, outside the handle. It is imported
+  // here (so `desugar_inspect_calls` leaves it alone) and carries `with
+  // Stdout` now that the print builtins do, and a call to a row-carrying
+  // function inside a handled body is not eligible for the direct-perform
+  // lowering. What this fixture pins stays inside the handle.
+  let got = handle {
+    run_selfd()
   } with Ask {
     Get => resume(0)
   }
+  inspect(got, "42")
 }

--- a/fixtures/effect_self_discharging_callee.vibe
+++ b/fixtures/effect_self_discharging_callee.vibe
@@ -50,7 +50,7 @@ test "calling a self-discharging fn from a row-carrying caller compiles and runs
   // here (so `desugar_inspect_calls` leaves it alone) and carries `with
   // Stdout` now that the print builtins do, and a call to a row-carrying
   // function inside a handled body is not eligible for the direct-perform
-  // lowering. What this fixture pins stays inside the handle.
+  // lowering (#2109). What this fixture pins stays inside the handle.
   let got = handle {
     run_selfd()
   } with Ask {

--- a/fixtures/gc_backend_smoke_test.vibe
+++ b/fixtures/gc_backend_smoke_test.vibe
@@ -198,7 +198,11 @@ let double_to_int_batch: () -> Int = () -> {
   Double::to_int(nan) + Double::to_int(pinf) + Double::to_int(ninf) + Double::to_int(3.7) * 10 + 7
 }
 
-export let main = () -> Int {
+// #2107: `with Stdout` because `assert_eq` expands to a failure branch that
+// prints, and the print builtins now carry their row. Inside a `test` block
+// the standard test effect set grants it; this entry is a plain function, so
+// it declares it.
+export let main = () -> Int with Stdout {
   let check: (Int) -> Int = (sp) -> {
     let a = if is_pos(sp) {
       1

--- a/fixtures/interp_function_return_missing_show_error.vibe
+++ b/fixtures/interp_function_return_missing_show_error.vibe
@@ -10,6 +10,9 @@ fn hidden() -> Hidden {
   }
 }
 
-export let main = () -> Unit {
+// #2107: `with Stdout` because `println` carries it now. Without the row the
+// entry fails on the row instead, and the diagnostic this fixture exists to
+// pin -- "cannot interpolate a value of type `Hidden`" -- never gets reached.
+export let main = () -> Unit with Stdout {
   println("\{hidden()}")
 }

--- a/fixtures/parser_binder_slot_authority_test.vibe
+++ b/fixtures/parser_binder_slot_authority_test.vibe
@@ -26,7 +26,7 @@ import ../lib/@vibe/parser {
 
 //# Helpers
 
-fn expect_source_slot(slot: BinderAuthoritySlot, role_tag: Int, name: String, start: Int, end: Int, source: String) -> Unit {
+fn expect_source_slot(slot: BinderAuthoritySlot, role_tag: Int, name: String, start: Int, end: Int, source: String) -> Unit with Stdout {
   let actual_role_tag = match binder_authority_slot_role(slot) {
     StatementLetBinder => 1,
     StatementLetMutBinder => 2,

--- a/lib/@vibe/cli/entry.vibe
+++ b/lib/@vibe/cli/entry.vibe
@@ -73,7 +73,9 @@ export fn format_check_report(payload: String) -> String {
 /// cli_main and the dispatch_test.vibe regression tests both go through this
 /// single wrapper, so the tests observe the real handler order — flipping it
 /// here fails them.
-export fn run_cli_main_with_args(args: Array[String]) -> Int with Fs + Env {
+/// #2107: `Stdout` is in the row because the Exception arm below prints the
+/// diagnostic. It was reachable without it while `println` claimed to be pure.
+export fn run_cli_main_with_args(args: Array[String]) -> Int with Fs + Env + Stdout {
   handle {
     handle {
       selfhost_cli_dispatch_args(args)
@@ -91,6 +93,6 @@ export fn run_cli_main_with_args(args: Array[String]) -> Int with Fs + Env {
   }
 }
 
-export fn cli_main() -> Int with Fs + Env {
+export fn cli_main() -> Int with Fs + Env + Stdout {
   run_cli_main_with_args(collect_cli_args())
 }

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1268,23 +1268,30 @@ fn builtin_call_op_label(name: String, eff: String) -> String {
   }
 }
 
-/// #626 criterion 3 (call-site propagation, builtin slice): calling an effectful
-/// BUILTIN (e.g. `Fs::read_file`, `Env::args_len`) requires the enclosing
-/// function to declare that effect, exactly like `perform`. Returns the required
-/// effect, or None for pure builtins / non-builtins. `Error` (the 441-site throw
-/// discipline) and `Async` (composition-allowed; handled by the async pass) are
-/// deliberately excluded from this slice.
-fn builtin_call_effect(name: String) -> Option[String] {
-  // `sh`/`sh_lines` and the checker_visible `vibe_*_raw` dunder builtins
-  // (Codex review, PR #909) are the only UNQUALIFIED effectful builtins:
-  // they lower to real `vibe.*` host imports that execute shell commands or
-  // terminate the process, so calling them directly must require
-  // `{ Process }` just like a qualified builtin -- otherwise they could run
-  // from a pure function or a bare top-level expression undeclared. Every
-  // name here is checker_visible=true in builtin_registry.vibe (directly
-  // callable from source); vibe_sh_lines_raw is checker_visible=false (only
-  // synthesized internally, never typed by user source) so it needs no
-  // entry. Checked before the `::` fast path below.
+/// The complete set of UNQUALIFIED builtins that carry an effect row, and the
+/// row each one carries. Everything else effectful in the registry is spelled
+/// `Effect::op`, which `builtin_call_effect` resolves through `lookup_builtin`;
+/// an unqualified name never reaches that lookup (the fast path there answers
+/// None without it, on purpose -- the scan is over ~450 rows and runs on every
+/// call in the program), so an unqualified effectful builtin that is missing
+/// from this list is invisible to the row discipline entirely.
+///
+/// #2107: ten of them were. `println` / `print` lower onto
+/// `Stdout::write_stream` / `Stdout::write_char`, the `vibe_tcp_*_raw` four
+/// open and drive sockets, the `vibe_http_*_raw` five make outbound requests,
+/// and `vibe_fs_stat_token_raw` stats a path -- all callable from a function
+/// declaring no row at all, with a clean `vibe check` and a real host import
+/// in the emitted module. Only the `sh` family had ever been listed.
+///
+/// `sleep` is deliberately absent: it carries `Async`, which
+/// `is_entry_runtime_managed_effect` excludes at the caller anyway.
+///
+/// `builtin_registry_unqualified_row_test.vibe` derives this set from the
+/// registry and fails if a new row appears that this list does not name, so it
+/// cannot silently fall behind again.
+fn unqualified_builtin_effect(name: String) -> Option[String] {
+  // vibe_sh_lines_raw is checker_visible=false (only synthesized internally,
+  // never typed by user source), so it needs no entry.
   if name == "sh" || name == "sh_lines"
   || name == "vibe_sh_capture_raw"
   || name == "vibe_sh_capture_exit_code_raw"
@@ -1293,10 +1300,46 @@ fn builtin_call_effect(name: String) -> Option[String] {
   || name == "vibe_sh_capture_close_raw"
   || name == "vibe_process_exit_raw" {
     Some("Process")
+  } else if name == "println" || name == "print" {
+    Some("Stdout")
+  } else if name == "vibe_fs_stat_token_raw" {
+    Some("Fs")
+  } else if name == "vibe_tcp_connect_raw" || name == "vibe_tcp_read_raw"
+  || name == "vibe_tcp_write_raw" || name == "vibe_tcp_close_raw" {
+    Some("Socket")
+  } else if name == "vibe_http_request_raw"
+  || name == "vibe_http_response_status_raw"
+  || name == "vibe_http_response_header_raw"
+  || name == "vibe_http_response_body_raw"
+  || name == "vibe_http_close_raw" {
+    Some("Http")
+  } else {
+    None
+  }
+}
+
+/// #626 criterion 3 (call-site propagation, builtin slice): calling an effectful
+/// BUILTIN (e.g. `Fs::read_file`, `Env::args_len`) requires the enclosing
+/// function to declare that effect, exactly like `perform`. Returns the required
+/// effect, or None for pure builtins / non-builtins. `Error` (the 441-site throw
+/// discipline) and `Async` (composition-allowed; handled by the async pass) are
+/// deliberately excluded from this slice.
+fn builtin_call_effect(name: String) -> Option[String] {
+  let unqualified = unqualified_builtin_effect(name)
+  if unqualified != None {
+    match unqualified {
+      Some(eff) => if is_entry_runtime_managed_effect(eff) {
+        None
+      } else {
+        Some(eff)
+      },
+      None => None
+    }
   } else if String::index_of(name, "::") < 0 {
     // Fast path: every OTHER effectful builtin in this slice is a QUALIFIED name
     // (`Fs::read_file`, `Env::args_len`, `Stdin::...`, `Stdout::...`, ...), so a
-    // callee with no `::` can never be one. Skipping `lookup_builtin` for the
+    // callee with no `::` can never be one -- `unqualified_builtin_effect` above
+    // is the complete list of the exceptions. Skipping `lookup_builtin` for the
     // (vastly more common) unqualified calls keeps the pass cheap enough to run
     // over the whole compiler source within the seed's heap during self-build.
     None

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -3371,6 +3371,36 @@ export fn check_perform_effects_expr(root: Expr, root_declared: Array[String], r
   check_perform_effects_expr_tx(root, root_declared, root_in_handle, no_str_labels(), no_ov_effs(), no_str_labels(), no_ov_effs())
 }
 
+/// #2107: the ambient test grant, for a `test` / `bench` body that has already
+/// been lowered to a function.
+///
+/// The wasm-gc lane rewrites `test "x" { .. }` into `let __test_x = () -> { .. }`
+/// BEFORE the check (entry/source_compile/gc_only) -- it has to, because a
+/// `handle` inside a test block is only eligible for the ADR-0076 direct-perform
+/// lowering once the block is a named top-level fn. The STest / SBench arms in
+/// check_perform_effects_stmt_tx therefore never see those bodies, and without
+/// this the identical source checks differently on the two lanes: on gc every
+/// assertion in a test wanted `with Stdout` from a function with no row to
+/// declare.
+///
+/// Keyed on the name because the alternative -- writing the row onto the
+/// synthesized function -- changes what CODEGEN reads, and the eligibility pass
+/// above reads exactly that. The two prefixes are compiler-synthesized and
+/// reserved; `cli_support.vibe`, `codegen/wasi/linked_compile.vibe` and
+/// `codegen/gc/backend_body.vibe` already key off them the same way. The test's
+/// own `with` row (#1508) is looked up under its original name, so
+/// `test "x" with Http` keeps widening the grant after lowering.
+fn lowered_test_ambient_effects(fn_name: String) -> Array[String] {
+  let n = String::length(fn_name)
+  if String::starts_with(fn_name, "__test_") {
+    test_ambient_effects(String::substring(fn_name, 7, n))
+  } else if String::starts_with(fn_name, "__bench_") {
+    test_ambient_effects(String::substring(fn_name, 8, n))
+  } else {
+    no_str_labels()
+  }
+}
+
 fn check_perform_effects_binding_tx(fn_name: String, ty: Option[TypeExpr], body: Expr, fn_names: Array[String], fn_effs: Array[Array[String]], fn_param_effs: Array[Array[Array[String]]]) -> Array[EffectError] {
   let sig_labels = sig_type_effect_labels(ty)
   set_entry_allows_authority(is_program_entry_name(fn_name) && String::length(effect_row_allows_text(raw_fn_effect_string(ty, body))) > 0)
@@ -3392,7 +3422,7 @@ fn check_perform_effects_binding_tx(fn_name: String, ty: Option[TypeExpr], body:
       // parameters up on its own.
       let merged_params = merge_param_types_with_sig(ty, params)
       let (ov_names, ov_effs) = build_param_overlay(merged_params, fn_names)
-      check_perform_effects_expr_tx_in(fn_name, fbody, labels_union(sig_labels, labels_union(effect_row_labels(effect_row_parse(eff)), effect_row_allows_labels(eff))), false, fn_names, fn_effs, fn_param_effs, ov_names, ov_effs, throw_kind_bind_params(no_kind_binds(), merged_params))
+      check_perform_effects_expr_tx_in(fn_name, fbody, labels_union(lowered_test_ambient_effects(fn_name), labels_union(sig_labels, labels_union(effect_row_labels(effect_row_parse(eff)), effect_row_allows_labels(eff)))), false, fn_names, fn_effs, fn_param_effs, ov_names, ov_effs, throw_kind_bind_params(no_kind_binds(), merged_params))
     },
     _ => {
       // #1451: a non-EFn binding declares no arrow of its own; clear the cell so

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1268,6 +1268,20 @@ fn builtin_call_op_label(name: String, eff: String) -> String {
   }
 }
 
+/// #2107: does a definition in the program own this name, making the builtin
+/// of the same name unreachable at this call site? A lexical binding (closure
+/// parameter, `let`) or a top-level function both shadow it, the same way
+/// codegen resolves a source definition ahead of its builtin lowering.
+fn source_definition_shadows_builtin(name: String, lexical_callee: Option[Array[String]], fn_names: Array[String], fn_effs: Array[Array[String]]) -> Bool {
+  match lexical_callee {
+    Some(_) => true,
+    None => match lookup_fn_effs(fn_names, fn_effs, name) {
+      Some(_) => true,
+      None => false
+    }
+  }
+}
+
 /// The complete set of UNQUALIFIED builtins that carry an effect row, and the
 /// row each one carries. Everything else effectful in the registry is spelled
 /// `Effect::op`, which `builtin_call_effect` resolves through `lookup_builtin`;
@@ -2703,6 +2717,17 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
                 },
                 _ => ()
               }
+            } else if source_definition_shadows_builtin(name, lexical_callee, fn_names, fn_effs) {
+              // #2107: a source definition of this name wins, so the builtin's
+              // row is not the one to require -- the callee's OWN declared row
+              // is, and the transitive check below reads it. Codegen has the
+              // same rule for the print builtins (`cc_ft_has(ctx.func_table,
+              // fname)` in expr/compile_call.vibe, #929) and the gate pins it:
+              // `fn println(s: String) -> Unit { print("S\n") }` must compile
+              // and win over the builtin lowering. Without this the checker
+              // would demand `with Stdout` from callers of a user function that
+              // merely reuses the name.
+              ()
             } else {
               match builtin_call_effect(name) {
                 Some(eff) => {

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -3579,6 +3579,7 @@ fn edp_plan_migrations(stmts: Array[Stmt], effect_defs: Array[(String, Array[(St
       let pf_inert = Array::concat(plan_base_inert, empty_str_array())
       edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pf_inert, row_labels)
       edp_append_perform_free_row_fns(stmts, fn_defs, ename, pf_inert, row_labels)
+      edp_append_effect_irrelevant_row_fns(fn_defs, ename, pf_inert, row_labels)
       let needing_full = array_empty()
       let mut pfi = 0
       while pfi < Array::length(needing_sd) {
@@ -3744,6 +3745,7 @@ fn edp_any_handle_owner_cp(stmts: Array[Stmt], ename: String, needing: Array[Str
   edp_append_free_host_inert_names(stmts, pure_fns)
   edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pure_fns, row_labels)
   edp_append_perform_free_row_fns(stmts, fn_defs, ename, pure_fns, row_labels)
+  edp_append_effect_irrelevant_row_fns(fn_defs, ename, pure_fns, row_labels)
   let es_names = array_empty()
   let es_members_list = array_empty()
   edp_es_collect_into(stmts, es_names, es_members_list)
@@ -4475,6 +4477,10 @@ fn edp_has_unsafe_construct_sc(expr: Expr, needing: Array[String], ename: String
           true
         } else if edp_is_pure_builtin_call(nm) {
           edp_exprs_have_unsafe_construct(args, needing, ename, pure_fns, ls_names, ls_flags)
+        } else if edp_builtin_is_first_order(nm) {
+          // #2109: effectful, but it cannot run a user closure, so it cannot
+          // hide a perform of `ename` from this handle.
+          edp_exprs_have_unsafe_construct(args, needing, ename, pure_fns, ls_names, ls_flags)
         } else if edp_str_array_contains(needing, nm) {
           edp_exprs_have_unsafe_construct(args, needing, ename, pure_fns, ls_names, ls_flags)
         } else if edp_str_array_contains(pure_fns, nm) {
@@ -4520,6 +4526,58 @@ fn edp_has_unsafe_construct_sc(expr: Expr, needing: Array[String], ename: String
     // leaving it as a plausible-looking gap for a future reader to
     // re-investigate from scratch.
     _ => false
+  }
+}
+
+/// #2109: is this builtin FIRST-ORDER -- does its signature take no function
+/// anywhere in its parameters?
+///
+/// A builtin cannot itself `perform` a user effect (host operations are not
+/// user code), so the only way one can hide a perform from an enclosing
+/// `handle` is by CALLING a closure the program handed it. `Array::foreach`
+/// and friends do exactly that and must stay opaque; `println`, `Fs::read_file`
+/// and the rest of the first-order host surface cannot. Read off the registry
+/// signature rather than a hand-kept list, so a new host builtin is classified
+/// the moment it is declared.
+///
+/// This is what makes `handle { println("x") f() } with Ask { .. }` compile.
+/// It did not, on either lane, and the diagnostic said the handled body may
+/// "perform directly, call a named top-level `fn`, or call a closure literal
+/// that carries an effect row annotation" -- three forms, none of which
+/// describes a print.
+fn edp_type_has_fn(t: Type) -> Bool {
+  match t {
+    CtFn(_, _, _) => true,
+    CtArray(e) => edp_type_has_fn(e),
+    CtOption(e) => edp_type_has_fn(e),
+    CtTuple(es) => edp_types_have_fn(es),
+    CtNamed(_, args) => edp_types_have_fn(args),
+    CtForAll(_, _, body) => edp_type_has_fn(body),
+    _ => false
+  }
+}
+
+fn edp_types_have_fn(ts: Array[Type]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(ts) {
+    if edp_type_has_fn(Array::get(ts, i)) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn edp_builtin_is_first_order(nm: String) -> Bool {
+  match lookup_registry_builtin(nm) {
+    Some(ty) => match ty {
+      CtFn(params, _, _) => !edp_types_have_fn(params),
+      _ => false
+    },
+    None => false
   }
 }
 
@@ -4671,6 +4729,65 @@ fn edp_pure_fn_names(fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], 
 /// safety scans already thread everywhere.
 fn edp_name_is_host_raw_shape(nm: String) -> Bool {
   String::starts_with(nm, "vibe_") && String::ends_with(nm, "_raw")
+}
+
+/// #2109: a top-level fn whose declared row does not mention `ename` cannot
+/// PERFORM it, so a call to it hides nothing from a `handle .. with ename`.
+///
+/// The row is complete by construction: the checker requires every effect a
+/// body can require -- directly, transitively, or through a parameter's own
+/// row (#626, #885) -- to appear in the declaring signature, and this pass
+/// runs after it. A callee declaring `with Stdout` therefore cannot reach a
+/// `perform Ask::Get`, and treating the call as opaque only made ordinary code
+/// uncompilable: `handle { println("x") f() } with Ask { .. }` and every
+/// `assert_eq` inside a handled body were rejected with a diagnostic that
+/// enumerates three legal forms the program already satisfies.
+///
+/// Row VARIABLES are excluded, and that exclusion is the reason this is sound
+/// rather than merely plausible: a polymorphic row can be instantiated with
+/// the handled effect at the call site, and the perform then happens inside
+/// the callee where the handler cannot see it. Effect names are CamelCase
+/// (#1458), so a lowercase-initial label is taken to be a variable -- the
+/// conservative direction.
+fn edp_label_is_row_var(label: String) -> Bool {
+  String::length(label) > 0 && String::char_code_at(label, 0) >= 97 && String::char_code_at(label, 0) <= 122
+}
+
+fn edp_row_labels_have_var(labels: Array[String]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(labels) {
+    if edp_label_is_row_var(Array::get(labels, i)) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn edp_append_effect_irrelevant_row_fns(fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], ename: String, pure_fns: Array[String], row_labels: Array[Array[String]]) -> Unit {
+  let mut i = 0
+  while i < Array::length(fn_defs) {
+    let (_, _, _, name, _, _) = Array::get(fn_defs, i)
+    let labels = Array::get(row_labels, i)
+    if Array::length(labels) == 0 {
+      // Row-free: edp_pure_fn_names already listed it.
+      ()
+    } else if edp_str_array_contains(labels, ename) {
+      // Carries the effect: the needing / perform-free / self-discharging
+      // machinery decides this one, and it must keep deciding it.
+      ()
+    } else if edp_row_labels_have_var(labels) {
+      ()
+    } else if edp_str_array_contains(pure_fns, name) {
+      ()
+    } else {
+      Array::push(pure_fns, name)
+    }
+    i = i + 1
+  }
 }
 
 /// ADR-0076 追記34 V2: a row-E function that provably cannot PERFORM E --
@@ -5431,6 +5548,7 @@ fn edp_all_sites_eligible(stmts: Array[Stmt], ename: String, needing: Array[Stri
     edp_append_free_host_inert_names(stmts, pure_fns)
     edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pure_fns, row_labels)
     edp_append_perform_free_row_fns(stmts, fn_defs, ename, pure_fns, row_labels)
+    edp_append_effect_irrelevant_row_fns(fn_defs, ename, pure_fns, row_labels)
     let es_names = array_empty()
     let es_members_list = array_empty()
     edp_es_collect_into(stmts, es_names, es_members_list)
@@ -7252,6 +7370,7 @@ fn edp_apply_migration(stmts: Array[Stmt], ename: String, ops: Array[(String, Ar
   edp_append_free_host_inert_names(stmts, pure_fns)
   edp_append_self_discharging_row_fns(stmts, fn_defs, ename, pure_fns, row_labels)
   edp_append_perform_free_row_fns(stmts, fn_defs, ename, pure_fns, row_labels)
+  edp_append_effect_irrelevant_row_fns(fn_defs, ename, pure_fns, row_labels)
   let es_names = array_empty()
   let es_members_list = array_empty()
   edp_es_collect_into(stmts, es_names, es_members_list)

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -418,8 +418,17 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("assert", CtFn(reg_p1(CtBool), CtUnit, None), false, true, true),
   ("assert_true", CtFn(reg_p1(CtBool), CtUnit, None), false, true, true),
   ("assert_eq", CtFn(reg_p2(reg_any(), reg_any()), CtUnit, None), false, true, true),
-  ("println", CtFn(reg_p1(CtString), CtUnit, None), false, true, true),
-  ("print", CtFn(reg_p1(CtString), CtUnit, None), false, true, true),
+  // #2107: `Stdout`, not `None`. Codegen lowers both names straight onto the
+  // tty host imports (`Stdout::write_stream` / `Stdout::write_char` --
+  // expr/compile_call.vibe, gc/backend_call.vibe), and `builtin_purity`
+  // already classifies them impure, so a `None` row here was the checker
+  // alone claiming these are pure. It let a `fn main with ()` write to
+  // stdout with a clean `vibe check`: an authority escape, silent, on the
+  // one print spelling that needs no import. `Stdout` rather than `Console`
+  // because that is what the lowering names today -- these move with
+  // everything else in #1460's Phase 3 sweep.
+  ("println", CtFn(reg_p1(CtString), CtUnit, Some("Stdout")), false, true, true),
+  ("print", CtFn(reg_p1(CtString), CtUnit, Some("Stdout")), false, true, true),
   ("map_has", CtFn(reg_p2(reg_opaque("Map"), CtString), CtBool, None), false, true, true)
 ]
 

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -259,20 +259,21 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   let tokens = lex(source)
   let stmts = parse_program(tokens)
   expand_interp_stmts(stmts)
-  // #683 lowered test/bench blocks BEFORE the check, on the stated grounds
-  // that "pre-check rewriting is equivalent here". It is not, and #2107 is
-  // where that showed: the checker grants a `test` / `bench` body the standard
-  // test effect set (`test_ambient_effects`, keyed off the STest/SBench node),
-  // so lowering first hands the checker an ordinary row-free function and the
-  // grant never applies. Every assertion in a gc-lane test then wanted
-  // `with Stdout` from a function that has no row to declare -- a lane
-  // divergence with nothing to catch it until a builtin's row changed.
+  // #683: lower test/bench blocks BEFORE the check so the synthesized
+  // `__test_*` lets and the no-entry `_start` runner are type-checked like
+  // ordinary functions.
   //
-  // The linear lane checks STest bodies directly and rewrites inside codegen.
-  // Same order here: check first, lower after, so both lanes grant the same
-  // ambient row to the same code.
-  let _ = check_program(stmts)
+  // The order matters in both directions, so neither is free to change:
+  // lowering FIRST is what makes a `handle` written inside a test block
+  // eligible for the ADR-0076 direct-perform lowering (it wants a named
+  // top-level `fn`; `fixtures/effect_effectset_expansion.vibe` is that
+  // shape and compiles on this lane only for this reason), while the
+  // checker's ambient test-effect grant is keyed off the STest / SBench
+  // node this erases. #2107 closed the second half in the checker instead:
+  // `lowered_test_ambient_effects` recognizes these two prefixes, so the
+  // grant survives the lowering without changing what CODEGEN sees.
   let effective_entry = lower_test_blocks_gc(stmts, entry_name)
+  let _ = check_program(stmts)
   // #1015: MUST run before strip_generic_type_params below -- that pass
   // unconditionally zeroes every top-level generic fn's type_params/bounds
   // (erasure, not specific to `to_string`), so checking the Show-bounded

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -259,12 +259,20 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   let tokens = lex(source)
   let stmts = parse_program(tokens)
   expand_interp_stmts(stmts)
-  // #683: lower test/bench blocks BEFORE the check so the synthesized
-  // `__test_*` lets and the no-entry `_start` runner are type-checked like
-  // ordinary functions (the linear lane checks STest bodies directly and
-  // rewrites inside codegen; pre-check rewriting is equivalent here).
-  let effective_entry = lower_test_blocks_gc(stmts, entry_name)
+  // #683 lowered test/bench blocks BEFORE the check, on the stated grounds
+  // that "pre-check rewriting is equivalent here". It is not, and #2107 is
+  // where that showed: the checker grants a `test` / `bench` body the standard
+  // test effect set (`test_ambient_effects`, keyed off the STest/SBench node),
+  // so lowering first hands the checker an ordinary row-free function and the
+  // grant never applies. Every assertion in a gc-lane test then wanted
+  // `with Stdout` from a function that has no row to declare -- a lane
+  // divergence with nothing to catch it until a builtin's row changed.
+  //
+  // The linear lane checks STest bodies directly and rewrites inside codegen.
+  // Same order here: check first, lower after, so both lanes grant the same
+  // ambient row to the same code.
   let _ = check_program(stmts)
+  let effective_entry = lower_test_blocks_gc(stmts, entry_name)
   // #1015: MUST run before strip_generic_type_params below -- that pass
   // unconditionally zeroes every top-level generic fn's type_params/bounds
   // (erasure, not specific to `to_string`), so checking the Show-bounded

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -5362,18 +5362,23 @@ fn lower_assert_eq(args: Array[Expr], gens: Array[(String, Array[(String, String
   // simd_skip_ws_test). `vibe test` now keeps stdout on FAIL so the
   // diagnostic still reaches vt_fail_detail.
   //
-  // #2107: `print_str`, not `println`. `println` carries `Stdout` now that
-  // the checker holds the print builtins to the row discipline, and this
-  // branch is SYNTHESIZED -- expanding it into `println` would mean every
-  // pure function containing an `assert_eq` acquires a capability it never
-  // asked for, which is the wrong reading of what this output is. An
-  // assertion's failure text is the harness reporting on its way to a trap,
-  // the same class as the runtime's own uncaught-exception message, and no
-  // row covers that either. `print_str` is the registry's codegen-internal
-  // printer (checker_visible=false, present in both lane tables), so it is
-  // unreachable from user source and carries no row by construction. The
-  // message already ends in "\n", which is the only thing `println` added.
-  let fail = ESeq(ECall(EIdent("print_str", -1), [msg], -1), ECall(EIdent("assert_true", -1), [
+  // #2107: `println` here means `assert_eq` REQUIRES `Stdout` in the
+  // function containing it -- this expansion runs before the checker, so the
+  // row lands on the caller. That is the honest reading (the branch really
+  // does write to the console) and it is the same rule `inspect` follows.
+  // In practice it costs nothing: a `test` / `bench` block is granted the
+  // standard test effect set, which includes Stdout, and that is where
+  // assertions live. A plain function asserting outside a test block declares
+  // `with Stdout`, as `fixtures/gc_backend_smoke_test.vibe` now does.
+  //
+  // The internal printer `print_str` looks like the way to avoid that and is
+  // not: its wasm signature takes two params (the string as a pair), it is
+  // `checker_visible=false`, and codegen only ever emits it with that ABI
+  // from a lowering -- a vibe-level call to it is `unknown name` at the
+  // checker and a broken module past it. Introducing a rowless vibe-callable
+  // printer just to keep this branch quiet would re-open the exact escape
+  // #2107 closed, one dunder away.
+  let fail = ESeq(ECall(EIdent("println", -1), [msg], -1), ECall(EIdent("assert_true", -1), [
     EBool(false)
   ], -1))
   let cmp = rewrite_expr(EBinOp("==", actual, expected), gens, traits, struct_sets, dict_binds, vars2, fn_returns)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -5356,12 +5356,24 @@ fn lower_assert_eq(args: Array[Expr], gens: Array[(String, Array[(String, String
   let actual_s = assert_eq_render(actual, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
   let expected_s = assert_eq_render(expected, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
   let msg = assert_eq_concat(EString("assert_eq failed\n  expected: "), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\n")))))
-  // println, not Stderr::write_stream: the gc lane only reserves host
+  // stdout, not Stderr::write_stream: the gc lane only reserves host
   // imports when the source already used one, and flipping that on a
   // SIMD-only file shifts every generated-body index (gc-gate
   // simd_skip_ws_test). `vibe test` now keeps stdout on FAIL so the
   // diagnostic still reaches vt_fail_detail.
-  let fail = ESeq(ECall(EIdent("println", -1), [msg], -1), ECall(EIdent("assert_true", -1), [
+  //
+  // #2107: `print_str`, not `println`. `println` carries `Stdout` now that
+  // the checker holds the print builtins to the row discipline, and this
+  // branch is SYNTHESIZED -- expanding it into `println` would mean every
+  // pure function containing an `assert_eq` acquires a capability it never
+  // asked for, which is the wrong reading of what this output is. An
+  // assertion's failure text is the harness reporting on its way to a trap,
+  // the same class as the runtime's own uncaught-exception message, and no
+  // row covers that either. `print_str` is the registry's codegen-internal
+  // printer (checker_visible=false, present in both lane tables), so it is
+  // unreachable from user source and carries no row by construction. The
+  // message already ends in "\n", which is the only thing `println` added.
+  let fail = ESeq(ECall(EIdent("print_str", -1), [msg], -1), ECall(EIdent("assert_true", -1), [
     EBool(false)
   ], -1))
   let cmp = rewrite_expr(EBinOp("==", actual, expected), gens, traits, struct_sets, dict_binds, vars2, fn_returns)

--- a/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
+++ b/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
@@ -1,3 +1,11 @@
+//# `assert_eq` and the Stdout row (#2107)
+//
+// Every `main` compiled here declares `with Stdout`. The expansion under test
+// is `if a == b { () } else { println(msg); assert_true(false) }`, and the
+// print builtins carry their row now, so the row lands on the function
+// containing the assertion. A `test` block gets it from the standard test
+// effect set -- these are hand-written entry lambdas, so they say it.
+
 //# Imports
 
 import @vibe/compiler/entry/source_compile {
@@ -38,7 +46,7 @@ fn bytes_contains(hay: Bytes, needle: String) -> Bool {
 }
 
 fn compile_assert_eq_main(body: String) -> Bytes with Exception {
-  compile_source_wasi(String::concat("let main: () -> Int = () -> {\n  ", String::concat(body, "\n  0\n}")), "main")
+  compile_source_wasi(String::concat("let main: () -> Int with Stdout = () -> {\n  ", String::concat(body, "\n  0\n}")), "main")
 }
 
 fn assert_compiled_eq_diag(bytes: Bytes) -> Unit {
@@ -73,12 +81,12 @@ test "assert_eq failure compiles expected and actual for a tuple" {
 }
 
 test "assert_eq failure compiles expected and actual for a Show struct" {
-  let bytes = compile_source_wasi("struct Point { x: Int; y: Int } derive(Eq, Show)\nlet main: () -> Int = () -> {\n  assert_eq(Point::{ x: 1, y: 2 }, Point::{ x: 1, y: 9 })\n  0\n}", "main")
+  let bytes = compile_source_wasi("struct Point { x: Int; y: Int } derive(Eq, Show)\nlet main: () -> Int with Stdout = () -> {\n  assert_eq(Point::{ x: 1, y: 2 }, Point::{ x: 1, y: 9 })\n  0\n}", "main")
   assert_compiled_eq_diag(bytes)
 }
 
 test "assert_eq failure compiles a fallback for an unrenderable value" {
-  let bytes = compile_source_wasi("struct Opaque { n: Int } derive(Eq)\nlet main: () -> Int = () -> {\n  assert_eq(Opaque::{ n: 1 }, Opaque::{ n: 2 })\n  0\n}", "main")
+  let bytes = compile_source_wasi("struct Opaque { n: Int } derive(Eq)\nlet main: () -> Int with Stdout = () -> {\n  assert_eq(Opaque::{ n: 1 }, Opaque::{ n: 2 })\n  0\n}", "main")
   assert(bytes_contains(bytes, "assert_eq failed"))
   assert(bytes_contains(bytes, "<unprintable>"))
 }
@@ -86,7 +94,7 @@ test "assert_eq failure compiles a fallback for an unrenderable value" {
 /// Same lowering, then execute it. `vibe test` keeps stderr and discards
 /// stdout, so the diagnostic has to land on stderr for `vt_fail_detail`.
 test "assert_eq lowering still compiles on the gc lane" {
-  let bytes = compile_source_gc_only("let main: () -> Int = () -> {\n  assert_eq(1, 1)\n  0\n}", "main")
+  let bytes = compile_source_gc_only("let main: () -> Int with Stdout = () -> {\n  assert_eq(1, 1)\n  0\n}", "main")
   assert(Bytes::length(bytes) > 8)
 }
 

--- a/lib/@vibe/compiler/tests/builtin_registry_unqualified_row_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_registry_unqualified_row_test.vibe
@@ -1,0 +1,156 @@
+//# Every unqualified effectful builtin is subject to the row discipline
+//# (#2107).
+//
+// `builtin_call_effect` (checker/checker_effects.vibe) answers "which effect
+// does calling this builtin require". For a QUALIFIED name it reads the answer
+// out of the registry via `lookup_builtin`. For an unqualified one it cannot:
+// that lookup is a linear scan over ~450 rows and would run on every call in
+// the program, so the unqualified path answers None without consulting
+// anything, and the handful of unqualified builtins that ARE effectful are
+// listed by hand in `unqualified_builtin_effect`.
+//
+// A hand-written list next to a registry that keeps growing is a list that
+// falls behind, and it had: ten names carried a row in the registry and were
+// missing from it, so `println`, `print`, the four `vibe_tcp_*_raw`, the five
+// `vibe_http_*_raw` and `vibe_fs_stat_token_raw` could all be called from a
+// function declaring no row at all -- clean `vibe check`, real host import in
+// the emitted module.
+//
+// So this test does not restate the list. It DERIVES the set from the registry
+// and checks the checker actually enforces each one, which is a property the
+// next added builtin cannot quietly break.
+
+//# Imports
+
+import @vibe/compiler/core {
+  Type, builtin_registry_typed
+}
+
+import @vibe/compiler/runtime {
+  collect_all_diagnostics
+}
+
+//# Misc
+
+/// A literal of the right shape for one parameter, so the synthesized call
+/// type-checks far enough to reach the effect pass.
+fn arg_literal(ty: Type) -> String {
+  match ty {
+    CtString => "\"x\"",
+    CtBool => "true",
+    CtDouble => "0.0",
+    _ => "0"
+  }
+}
+
+fn arg_list(params: Array[Type]) -> String {
+  let mut out = ""
+  let mut i = 0
+  while i < Array::length(params) {
+    if i > 0 {
+      out = "\{out}, "
+    } else {
+      ()
+    }
+    out = "\{out}\{arg_literal(Array::get(params, i))}"
+    i = i + 1
+  }
+  out
+}
+
+/// `NAME(args)` in a function that declares `row`, with the call's value
+/// discarded so a return-type mismatch cannot stand in for the diagnostic we
+/// are actually looking for.
+fn call_source(name: String, params: Array[Type], row: String) -> String {
+  let head = if String::length(row) == 0 {
+    "fn f() -> Unit {"
+  } else {
+    "fn f() -> Unit with \{row} {"
+  }
+  "\{head}\n  \{name}(\{arg_list(params)})\n  ()\n}\n"
+}
+
+fn has_row_mismatch(src: String) -> Bool with Exception {
+  let d = collect_all_diagnostics(src)
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(d) {
+    if String::contains(Array::get(d, i), "effect row mismatch") {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// (name, params, effect) for every checker-visible registry builtin whose
+/// name has no `::` and whose signature carries an effect label. `Async` is
+/// dropped: the entry/runtime execution policy owns it, and
+/// `builtin_call_effect` excludes it for qualified names too, so it is not a
+/// row the caller is ever asked to declare.
+fn unqualified_effectful_rows() -> Array[(String, Array[Type], String)] {
+  let rows = builtin_registry_typed()
+  let out = []
+  let mut i = 0
+  while i < Array::length(rows) {
+    let (name, ty, _lin, _gc, visible) = Array::get(rows, i)
+    if visible && String::index_of(name, "::") < 0 {
+      match ty {
+        CtFn(params, _, Some(eff)) => if eff == "Async" || eff == "Error" || eff == "Exception" {
+          ()
+        } else {
+          Array::push(out, (name, params, eff))
+        },
+        _ => ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+//# Tests
+
+test "the registry still has unqualified effectful builtins to check" {
+  // Guards the guard: if this ever reads 0, the loop below is asserting
+  // nothing and the test has stopped meaning anything.
+  assert(Array::length(unqualified_effectful_rows()) >= 15)
+}
+
+test "calling one without a row is an effect row mismatch" {
+  let rows = unqualified_effectful_rows()
+  let mut i = 0
+  while i < Array::length(rows) {
+    let (name, params, eff) = Array::get(rows, i)
+    if has_row_mismatch(call_source(name, params, "")) {
+      ()
+    } else {
+      // Name the offender: a bare `assert(false)` here would send the reader
+      // back to the registry to work out which row is unguarded.
+      println("unqualified effectful builtin escapes the row check: \{name} (carries \{eff}); add it to unqualified_builtin_effect in checker/checker_effects.vibe")
+      assert(false)
+    }
+    i = i + 1
+  }
+}
+
+test "declaring the row it carries makes the call legal" {
+  // The other half: the requirement has to be satisfiable by the label the
+  // registry names, or the diagnostic above is unactionable.
+  let rows = unqualified_effectful_rows()
+  let mut i = 0
+  while i < Array::length(rows) {
+    let (name, params, eff) = Array::get(rows, i)
+    if has_row_mismatch(call_source(name, params, eff)) {
+      println("declaring `with \{eff}` did not satisfy \{name}'s own registry row")
+      assert(false)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -32,7 +32,7 @@ fn first_located_check_error(source: String) -> String {
 }
 
 test "#1683: a declared user effect cannot escape main" {
-  let source = "effect Ask {\n  Get() -> Int\n}\n\nfn main() -> Unit with Ask::Get {\n  let x = perform Ask::Get()\n  println(\"\\{x}\")\n}\n"
+  let source = "effect Ask {\n  Get() -> Int\n}\n\nfn main() -> Unit with Ask::Get + Stdout {\n  let x = perform Ask::Get()\n  println(\"\\{x}\")\n}\n"
   let msg = first_located_check_error(source)
   assert(String::contains(msg, "line 6:"))
   assert(String::contains(msg, "entry point 'main' cannot discharge { Ask::Get }"))

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -175,7 +175,7 @@ test "check_linked_file: handle body calling a local closure fails eligibility a
 
 test "check_linked_file: an unowned user effect is rejected at the entry boundary (#1683)" {
   let path = "/tmp/vibe_cli_support_check_entry_effect.vibe"
-  Fs::write_bytes(path, string_to_bytes("effect Ask {\n  Get() -> Int\n}\n\nfn main() -> Unit with Ask::Get {\n  let x = perform Ask::Get()\n  println(\"\\{x}\")\n}\n"))
+  Fs::write_bytes(path, string_to_bytes("effect Ask {\n  Get() -> Int\n}\n\nfn main() -> Unit with Ask::Get + Stdout {\n  let x = perform Ask::Get()\n  println(\"\\{x}\")\n}\n"))
   let msg = handle {
     let _ = check_linked_file(path)
     ""

--- a/lib/@vibe/compiler/tests/codegen_body_cache_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_test.vibe
@@ -92,14 +92,14 @@ fn assert_slice_identical(source: String) -> Unit with Exception {
 }
 
 test "replay: a program with no lambdas at all" {
-  assert_replay_identical("fn add(a: Int, b: Int) -> Int {\n  a + b\n}\n\nfn main {\n  println(Int::to_string(add(2, 3)))\n}\n",)
+  assert_replay_identical("fn add(a: Int, b: Int) -> Int {\n  a + b\n}\n\nfn main with Stdout {\n  println(Int::to_string(add(2, 3)))\n}\n",)
 }
 
 test "replay: lambdas in several functions, so the plan spans owners" {
   // Each function contributes lambdas, so the planned lambda ranges are
   // non-trivial and a replayed body's baked-in table_slot immediates only stay
   // correct because the plan -- not the emission order -- assigned them.
-  assert_replay_identical("fn twice(f: (Int) -> Int, x: Int) -> Int {\n  f(f(x))\n}\n\nfn bump(n: Int) -> Int {\n  twice((v) -> {\n    v + n\n  }, n)\n}\n\nfn scale(n: Int) -> Int {\n  twice((v) -> {\n    v * 2\n  }, n)\n}\n\nfn main {\n  println(Int::to_string(bump(3) + scale(4)))\n}\n",)
+  assert_replay_identical("fn twice(f: (Int) -> Int, x: Int) -> Int {\n  f(f(x))\n}\n\nfn bump(n: Int) -> Int {\n  twice((v) -> {\n    v + n\n  }, n)\n}\n\nfn scale(n: Int) -> Int {\n  twice((v) -> {\n    v * 2\n  }, n)\n}\n\nfn main with Stdout {\n  println(Int::to_string(bump(3) + scale(4)))\n}\n",)
 }
 
 test "replay: closures reaching call_indirect record table slots" {
@@ -109,24 +109,24 @@ test "replay: closures reaching call_indirect record table slots" {
   // the element section, and a replayed function never runs the appends -- so
   // until the cache carried them, the replayed module's element section was
   // smaller than the compiled one's and this case failed on a byte mismatch.
-  assert_replay_identical("fn apply_all(fs: Array[(Int) -> Int], x: Int) -> Int {\n  let mut acc = x\n  let mut i = 0\n  while i < Array::length(fs) {\n    let f = Array::get(fs, i)\n    acc = f(acc)\n    i = i + 1\n  }\n  acc\n}\n\nfn main {\n  let fs = [\n    (v) -> {\n      v + 1\n    },\n    (v) -> {\n      v * 3\n    },\n    (v) -> {\n      v - 2\n    }\n  ]\n  println(Int::to_string(apply_all(fs, 5)))\n}\n",)
+  assert_replay_identical("fn apply_all(fs: Array[(Int) -> Int], x: Int) -> Int {\n  let mut acc = x\n  let mut i = 0\n  while i < Array::length(fs) {\n    let f = Array::get(fs, i)\n    acc = f(acc)\n    i = i + 1\n  }\n  acc\n}\n\nfn main with Stdout {\n  let fs = [\n    (v) -> {\n      v + 1\n    },\n    (v) -> {\n      v * 3\n    },\n    (v) -> {\n      v - 2\n    }\n  ]\n  println(Int::to_string(apply_all(fs, 5)))\n}\n",)
 }
 
 test "replay: nested lambdas, where an inner one advances the enclosing counter" {
-  assert_replay_identical("fn make_adder(n: Int) -> (Int) -> Int {\n  (x) -> {\n    let inner = (y) -> {\n      y + n\n    }\n    inner(x) + n\n  }\n}\n\nfn main {\n  let f = make_adder(2)\n  println(Int::to_string(f(10)))\n}\n",)
+  assert_replay_identical("fn make_adder(n: Int) -> (Int) -> Int {\n  (x) -> {\n    let inner = (y) -> {\n      y + n\n    }\n    inner(x) + n\n  }\n}\n\nfn main with Stdout {\n  let f = make_adder(2)\n  println(Int::to_string(f(10)))\n}\n",)
 }
 
 test "replay: module-level thunks, which take the non-EFn body path" {
-  assert_replay_identical("let table: Array[Int] = [\n  1,\n  2,\n  3,\n  4\n]\n\nfn total() -> Int {\n  let mut s = 0\n  let mut i = 0\n  while i < Array::length(table) {\n    s = s + Array::get(table, i)\n    i = i + 1\n  }\n  s\n}\n\nfn main {\n  println(Int::to_string(total()))\n}\n",)
+  assert_replay_identical("let table: Array[Int] = [\n  1,\n  2,\n  3,\n  4\n]\n\nfn total() -> Int {\n  let mut s = 0\n  let mut i = 0\n  while i < Array::length(table) {\n    s = s + Array::get(table, i)\n    i = i + 1\n  }\n  s\n}\n\nfn main with Stdout {\n  println(Int::to_string(total()))\n}\n",)
 }
 
 test "slice: lambdas spread across functions, harvested in two halves" {
   // The split lands inside the function list, so the second slice starts at a
   // nonzero planned lambda base -- the case where a worker's live lambda table
   // and the plan would disagree if the skipped functions did not pad it.
-  assert_slice_identical("fn twice(f: (Int) -> Int, x: Int) -> Int {\n  f(f(x))\n}\n\nfn bump(n: Int) -> Int {\n  twice((v) -> {\n    v + n\n  }, n)\n}\n\nfn scale(n: Int) -> Int {\n  twice((v) -> {\n    v * 2\n  }, n)\n}\n\nfn shift(n: Int) -> Int {\n  twice((v) -> {\n    v - 1\n  }, n)\n}\n\nfn main {\n  println(Int::to_string(bump(3) + scale(4) + shift(5)))\n}\n",)
+  assert_slice_identical("fn twice(f: (Int) -> Int, x: Int) -> Int {\n  f(f(x))\n}\n\nfn bump(n: Int) -> Int {\n  twice((v) -> {\n    v + n\n  }, n)\n}\n\nfn scale(n: Int) -> Int {\n  twice((v) -> {\n    v * 2\n  }, n)\n}\n\nfn shift(n: Int) -> Int {\n  twice((v) -> {\n    v - 1\n  }, n)\n}\n\nfn main with Stdout {\n  println(Int::to_string(bump(3) + scale(4) + shift(5)))\n}\n",)
 }
 
 test "slice: closures reaching call_indirect, so slots merge across slices" {
-  assert_slice_identical("fn apply_all(fs: Array[(Int) -> Int], x: Int) -> Int {\n  let mut acc = x\n  let mut i = 0\n  while i < Array::length(fs) {\n    let f = Array::get(fs, i)\n    acc = f(acc)\n    i = i + 1\n  }\n  acc\n}\n\nfn first_set() -> Array[(Int) -> Int] {\n  [\n    (v) -> {\n      v + 1\n    },\n    (v) -> {\n      v * 3\n    }\n  ]\n}\n\nfn second_set() -> Array[(Int) -> Int] {\n  [\n    (v) -> {\n      v - 2\n    },\n    (v) -> {\n      v * 5\n    }\n  ]\n}\n\nfn main {\n  println(Int::to_string(apply_all(first_set(), 5) + apply_all(second_set(), 7)))\n}\n",)
+  assert_slice_identical("fn apply_all(fs: Array[(Int) -> Int], x: Int) -> Int {\n  let mut acc = x\n  let mut i = 0\n  while i < Array::length(fs) {\n    let f = Array::get(fs, i)\n    acc = f(acc)\n    i = i + 1\n  }\n  acc\n}\n\nfn first_set() -> Array[(Int) -> Int] {\n  [\n    (v) -> {\n      v + 1\n    },\n    (v) -> {\n      v * 3\n    }\n  ]\n}\n\nfn second_set() -> Array[(Int) -> Int] {\n  [\n    (v) -> {\n      v - 2\n    },\n    (v) -> {\n      v * 5\n    }\n  ]\n}\n\nfn main with Stdout {\n  println(Int::to_string(apply_all(first_set(), 5) + apply_all(second_set(), 7)))\n}\n",)
 }

--- a/lib/@vibe/compiler/tests/handle_body_row_callee_test.vibe
+++ b/lib/@vibe/compiler/tests/handle_body_row_callee_test.vibe
@@ -1,0 +1,98 @@
+//# A handled body may call a row-carrying function (#2109).
+//
+// ADR-0076's eligibility rule is about STATIC VISIBILITY of performs: the
+// handler has to see every `perform E::op` it covers, so the handled body may
+// not reach one through something this pass cannot resolve. The
+// implementation read that as "the callee carries a row at all", which is a
+// different question and a much bigger set. Measured before the fix, on both
+// lanes: a rowless callee in the handled body compiled, a rowless GENERIC one
+// compiled, and one declaring `with Stdout` did not.
+//
+// So printing or asserting anywhere inside a `handle` was impossible --
+// `assert_eq` and `inspect` expand to a `println` call, and four fixtures in
+// this repository had to hoist the call out of the handle rather than be
+// fixed.
+//
+// Two facts make the narrower rule sound, and both are pinned below:
+//
+//   * a declared row is COMPLETE. The checker requires every effect a body can
+//     require -- directly, transitively, or through a parameter's own row
+//     (#626, #885) -- to appear in the signature, so a callee declaring only
+//     `Stdout` cannot reach a `perform Ask::Get`.
+//   * a row VARIABLE is not complete: it can be instantiated with the handled
+//     effect at the call site, and the perform then happens inside the callee.
+//     That case has to keep failing.
+
+//# Imports
+
+import @vibe/compiler/entry/source_compile {
+  compile_source_wasi
+}
+
+import @vibe/compiler/entry/source_compile/gc_only {
+  compile_source_gc_only
+}
+
+//# Misc
+
+/// The shared prelude: an effect, a function that performs it, and a
+/// `handle` in a test block -- the shape every case below varies.
+fn program(body: String) -> String {
+  "effect Ask {\n  Get -> Int\n}\n\nlet f = () -> Int with Ask::Get {\n  perform Ask::Get\n}\n\n\{body}"
+}
+
+fn compiles_linear(src: String) -> Bool {
+  handle {
+    let bytes = compile_source_wasi(src, "__no_entry__")
+    Bytes::length(bytes) > 8
+  } with Exception {
+    Throw(_) => false
+  }
+}
+
+fn compiles_gc(src: String) -> Bool {
+  handle {
+    let bytes = compile_source_gc_only(src, "__no_entry__")
+    Bytes::length(bytes) > 8
+  } with Exception {
+    Throw(_) => false
+  }
+}
+
+fn compiles_both(src: String) -> Bool with Exception {
+  compiles_linear(src) && compiles_gc(src)
+}
+
+//# Tests
+
+test "a callee carrying an unrelated row is callable from a handled body" {
+  let src = program("let side = (n: Int) -> Int with Stdout {\n  println(\"side\")\n  n\n}\n\ntest \"t\" {\n  let r = handle {\n    side(f())\n  } with Ask {\n    Get => resume(42)\n  }\n  assert_eq(r, 42)\n}\n")
+  assert(compiles_both(src))
+}
+
+test "a print builtin is callable from a handled body" {
+  // The builtin half of the same rule: `println` cannot run a user closure,
+  // so it cannot hide a perform either. Read off the registry signature, not
+  // a hand-kept list -- `edp_builtin_is_first_order`.
+  let src = program("test \"t\" {\n  let r = handle {\n    println(\"x\")\n    f()\n  } with Ask {\n    Get => resume(42)\n  }\n  assert_eq(r, 42)\n}\n")
+  assert(compiles_both(src))
+}
+
+test "assert_eq and inspect work inside a handled body" {
+  // Both expand to a `println` call before the checker runs, which is how the
+  // rejection reached ordinary test code in the first place.
+  let with_assert = program("test \"t\" {\n  handle {\n    assert_eq(f(), 42)\n  } with Ask {\n    Get => resume(42)\n  }\n}\n")
+  let with_inspect = program("test \"t\" {\n  handle {\n    inspect(f(), \"42\")\n  } with Ask {\n    Get => resume(42)\n  }\n}\n")
+  assert(compiles_both(with_assert))
+  assert(compiles_both(with_inspect))
+}
+
+test "a rowless callee still compiles, generic or not" {
+  // The control: these compiled before the fix too, and must keep doing so --
+  // if they ever stop, the change below them broke something wider than the
+  // rule under test.
+  let plain = program("let side = (n: Int) -> Int {\n  n\n}\n\ntest \"t\" {\n  let r = handle {\n    side(f())\n  } with Ask {\n    Get => resume(42)\n  }\n  assert_eq(r, 42)\n}\n")
+  let generic = program("let side = [T](n: T) -> T {\n  n\n}\n\ntest \"t\" {\n  let r = handle {\n    side(f())\n  } with Ask {\n    Get => resume(42)\n  }\n  assert_eq(r, 42)\n}\n")
+  assert(compiles_both(plain))
+  assert(compiles_both(generic))
+}

--- a/lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe
+++ b/lib/@vibe/compiler/tests/normalize_labeled_arg_binder_authority_test.vibe
@@ -45,7 +45,7 @@ fn normalized_authority(source: String) -> Option[NormalizedProgramBinderAuthori
   }
 }
 
-fn expect_no_authority(source: String) -> Unit with Exception {
+fn expect_no_authority(source: String) -> Unit with Exception + Stdout {
   match normalize_source(source) {
     Some(result) => match labeled_arg_binder_authority_normalization_authority(result) {
       Some(_) => inspect(false, "true"),
@@ -55,7 +55,7 @@ fn expect_no_authority(source: String) -> Unit with Exception {
   }
 }
 
-fn expect_authority(source: String) -> Unit with Exception {
+fn expect_authority(source: String) -> Unit with Exception + Stdout {
   match normalize_source(source) {
     Some(result) => match labeled_arg_binder_authority_normalization_authority(result) {
       Some(_) => inspect(true, "true"),
@@ -65,7 +65,7 @@ fn expect_authority(source: String) -> Unit with Exception {
   }
 }
 
-fn expect_ordinary_parity(source: String) -> Unit with Exception {
+fn expect_ordinary_parity(source: String) -> Unit with Exception + Stdout {
   match (parse_source_located_with_binder_authority(source), parse_source_located_with_binder_authority(source)) {
     (Some(ordinary_source), Some(paired_source)) => {
       let ordinary = located_program_binder_authority_program(ordinary_source)

--- a/lib/@vibe/compiler/tests/parser_binder_context_contract_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_binder_context_contract_test.vibe
@@ -77,7 +77,7 @@ fn forged_shape(starts_stack: Array[Array[Int]], ends_stack: Array[Array[Int]], 
   }
 }
 
-fn assert_expression_context_parity(source: String) -> Unit with Exception {
+fn assert_expression_context_parity(source: String) -> Unit with Exception + Stdout {
   let (tokens, starts, _) = lex_with_offsets(source)
   let (legacy, legacy_next) = parse_impl(tokens, starts, 0, 0)
   let (none, none_next) = parse_impl_with_binder_context(tokens, starts, 0, 0, None)
@@ -89,7 +89,7 @@ fn assert_expression_context_parity(source: String) -> Unit with Exception {
   inspect(forged_next == legacy_next, "true")
 }
 
-fn assert_statement_context_parity(source: String) -> Unit with Exception {
+fn assert_statement_context_parity(source: String) -> Unit with Exception + Stdout {
   let (tokens, starts, _) = lex_with_offsets(source)
   let (legacy, legacy_next) = parse_stmt_preserving(tokens, starts, 0)
   let (none, none_next) = parse_stmt_preserving_with_binder_context(tokens, starts, 0, None)

--- a/lib/@vibe/compiler/tests/print_builtin_row_test.vibe
+++ b/lib/@vibe/compiler/tests/print_builtin_row_test.vibe
@@ -1,0 +1,78 @@
+//# The ambient `println` / `print` builtins carry the `Stdout` row (#2107).
+//
+// They used to carry none. The registry entry read
+// `CtFn(reg_p1(CtString), CtUnit, None)` -- the same "pure" spelling `assert`
+// and `map_has` use -- while codegen lowered both names straight onto
+// `Stdout::write_stream` / `Stdout::write_char`, and `builtin_purity` already
+// classified them impure. The checker was the only part of the compiler
+// claiming these are pure, and it is the part that decides what compiles: a
+// `fn main with ()` printed to stdout with a clean `vibe check`.
+//
+// That is the whole capability model failing on one name. Authority is
+// carried by the row and fixed at instantiate (ADR-0075/0084/0088), and
+// `--allow-*` const-folds from the row -- none of which can hold if the tty
+// is reachable from a row that does not mention it. So what is pinned here is
+// not "println works" but "println is subject to the row discipline like
+// every other host operation".
+
+//# Imports
+
+import @vibe/compiler/runtime {
+  collect_all_diagnostics
+}
+
+//# Misc
+
+fn diags(src: String) -> Array[String] with Exception {
+  collect_all_diagnostics(src)
+}
+
+fn ok(src: String) -> Bool with Exception {
+  Array::length(diags(src)) == 0
+}
+
+//# Tests
+
+test "a row-free function may not print" {
+  let d = diags("fn f() -> Unit {\n  println(\"x\")\n}\n")
+  assert(Array::length(d) == 1)
+  assert(String::contains(Array::get(d, 0), "Stdout"))
+  let e = diags("fn f() -> Unit {\n  print(\"x\")\n}\n")
+  assert(Array::length(e) == 1)
+  assert(String::contains(Array::get(e, 0), "Stdout"))
+}
+
+test "the row makes it legal, and nothing else has to change" {
+  assert(ok("fn f() -> Unit with Stdout {\n  println(\"x\")\n}\n"))
+  assert(ok("fn f() -> Unit with Stdout {\n  print(\"x\")\n}\n"))
+}
+
+test "the requirement travels through a caller" {
+  // The escape was reachable one call deep just as easily: a helper that
+  // prints, called from a function that declares nothing.
+  assert(!ok("fn shout(s: String) -> Unit {\n  println(s)\n}\n\nfn f() -> Unit {\n  shout(\"x\")\n}\n"))
+  assert(ok("fn shout(s: String) -> Unit with Stdout {\n  println(s)\n}\n\nfn f() -> Unit with Stdout {\n  shout(\"x\")\n}\n"))
+}
+
+test "an explicitly pure entry may not print" {
+  // The reported shape (#2107): `with ()` is a claim, and the checker has to
+  // hold the print verb to it.
+  assert(!ok("fn shout(s: String) -> Unit {\n  println(s)\n}\n\nfn main with () {\n  shout(\"leaked\")\n}\n"))
+}
+
+test "a different capability does not authorize printing" {
+  // `Stdin` is the neighbouring tty row and grants nothing here; the same
+  // separation `console_capability_test.vibe` pins between Console and the
+  // legacy three.
+  assert(!ok("fn f() -> Unit with Stdin {\n  println(\"x\")\n}\n"))
+  assert(!ok("fn f() -> Unit with Fs {\n  println(\"x\")\n}\n"))
+}
+
+test "inspect still expands without an import" {
+  // `desugar_inspect_calls` rewrites `inspect(..)` into `__to_string` /
+  // `println` / `assert_true` before the checker runs (#1571), which is why
+  // the snapshot assertion needs no import. Giving println a row must not
+  // cost that: a `test` block is granted the standard test effect set, which
+  // includes Stdout.
+  assert(ok("test \"snap\" {\n  inspect(1 + 1, \"2\")\n}\n"))
+}

--- a/lib/@vibe/compiler/tests/print_builtin_row_test.vibe
+++ b/lib/@vibe/compiler/tests/print_builtin_row_test.vibe
@@ -76,3 +76,15 @@ test "inspect still expands without an import" {
   // includes Stdout.
   assert(ok("test \"snap\" {\n  inspect(1 + 1, \"2\")\n}\n"))
 }
+
+test "a source definition of the name owns it" {
+  // Codegen resolves a source definition ahead of the builtin lowering
+  // (`cc_ft_has(ctx.func_table, fname)`, #929), so the checker must not
+  // require the BUILTIN's row for a call that reaches a user function. A
+  // program that defines a pure `println` and calls it declares nothing.
+  assert(ok("fn println(s: String) -> Unit {\n  ()\n}\n\nfn f() -> Unit {\n  println(\"x\")\n}\n"))
+  // ...and a user definition that really does print still has to say so,
+  // because the `print` INSIDE it is the builtin.
+  assert(!ok("fn println(s: String) -> Unit {\n  print(\"S\")\n}\n"))
+  assert(ok("fn println(s: String) -> Unit with Stdout {\n  print(\"S\")\n}\n"))
+}

--- a/lib/@vibe/core/assert.vibe
+++ b/lib/@vibe/core/assert.vibe
@@ -58,7 +58,13 @@ export fn assert_false(b: Bool) -> Unit {
   assert_true(!b)
 }
 
-export fn inspect[T](value: T, content: String) -> Unit {
+/// #2107: `with Stdout` because the mismatch branch prints. It reads as a
+/// pure assertion and is not one -- the row was only absent because the
+/// `println` it calls used to claim to be pure. Callers are test blocks,
+/// which are granted the standard test effect set, and the far more common
+/// path does not import this at all: `desugar_inspect_calls` expands
+/// `inspect(..)` in place before the checker runs (#1571).
+export fn inspect[T](value: T, content: String) -> Unit with Stdout {
   let actual = __to_string(value)
   if actual == content {
     ()

--- a/lib/@vibe/core/index.vpkg
+++ b/lib/@vibe/core/index.vpkg
@@ -368,7 +368,7 @@ fn MutSortedSet::difference[T](a: MutSortedSet[T], b: MutSortedSet[T]) -> MutSor
 
 // --- assert (#1061)
 fn assert_false(b: Bool) -> Unit
-fn inspect[T](value: T, content: String) -> Unit
+fn inspect[T](value: T, content: String) -> Unit with Stdout
 
 // --- collections: deprecated legacy spellings (ADR-0100 (3) / #1262).
 //

--- a/scripts/check_gate_registry.sh
+++ b/scripts/check_gate_registry.sh
@@ -13,6 +13,11 @@
 #   - section banners in a lane script with no registry row
 #   - registry rows whose title is not announced by that lane
 #   - fixture paths the lane names that do not exist
+#   - a compile whose failure the lane checks (`if [ ! -s .. ]`) but which can
+#     abort the lane before that check (#2107 fallout: three separate gate
+#     steps died at exit 1 with no message at all, because `set -e` killed the
+#     lane on the compile itself and the step's own FAIL echo was one line too
+#     late to run)
 #
 # Usage:
 #   bash scripts/check_gate_registry.sh
@@ -143,6 +148,39 @@ for lane in $GATE_LANES; do
         ;;
     esac
   done < <(grep -oE '"(fixtures|lib|docs|scripts|tests)/[^"$]+"' "$script" | tr -d '"' || true)
+done
+
+# A lane step that COMPILES something and then checks the artifact
+# (`if [ ! -s .. ]`) must not let the compile itself end the lane: under
+# `set -e` a failing compiler invocation exits before the step's own `FAIL`
+# message, so the lane reports nothing but exit 1 and the reader is left
+# bisecting to find which step it was. `|| true` on the invocation hands the
+# verdict to the check that was written for it.
+for lane in $GATE_LANES; do
+  script="$(gate_lane_script "$lane")"
+  [ -f "$script" ] || continue
+  awk -v script="$script" '
+    # remember the line where a runner invocation starts
+    /run_wasm_vibe_host_runner\.sh/ && $0 !~ /^[ \t]*#/ { in_cmd = 1 }
+    in_cmd {
+      cmd_tail = $0
+      if ($0 ~ /\\$/) { next }        # continued -- keep looking for the tail
+      in_cmd = 0
+      guarded = (cmd_tail ~ /\|\|/ || cmd_tail ~ /&&/ || cmd_tail ~ /=\"\$\(/)
+      if (!guarded) { pending = NR; pending_line = cmd_tail }
+      next
+    }
+    pending && $0 ~ /^[ \t]*$/ { next }
+    pending {
+      if ($0 ~ /^[ \t]*if \[ ! -s /) {
+        printf "[gate-registry] FAIL: %s:%d compiles then checks the artifact, but a failed compile aborts the lane before that check -- add `|| true`\n", script, pending > "/dev/stderr"
+        bad = 1
+      }
+      pending = 0
+      next
+    }
+    END { exit(bad ? 1 : 0) }
+  ' "$script" || fail=1
 done
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/check_gate_registry_test.sh
+++ b/scripts/check_gate_registry_test.sh
@@ -67,6 +67,37 @@ if awk -F'\t' '
   fail=1
 fi
 
+# #2107 fallout: a compile whose failure the lane checks must not be able to
+# abort the lane before the check. Red case built by REMOVING the guard from a
+# live step, so the test breaks if the rule stops being enforced rather than if
+# some synthetic sample drifts.
+lanecopy="$tmp/mid_run.sh"
+cp tests/gates/mid/run.sh "$lanecopy"
+python3 - "$lanecopy" <<'PYEOF'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+old = '"fixtures/v128_intrinsics_test.vibe" "$vdir/v128.wasm" __no_entry__ >/dev/null 2>&1 || true'
+assert s.count(old) == 1, "the guarded step this Red case removes has moved"
+open(p, 'w').write(s.replace(old, old[:-len(" || true")], 1))
+PYEOF
+cp tests/gates/mid/run.sh "$tmp/mid_run.orig.sh"
+cp "$lanecopy" tests/gates/mid/run.sh
+set +e
+bash scripts/check_gate_registry.sh >/tmp/gate_registry_test.out 2>&1
+unguarded_rc=$?
+set -e
+cp "$tmp/mid_run.orig.sh" tests/gates/mid/run.sh
+if [ "$unguarded_rc" -eq 0 ]; then
+  echo "FAIL: an unguarded compile-then-check step was accepted" >&2
+  fail=1
+else
+  assert_contains "add \`|| true\`"
+fi
+
+# ...and the restored tree is clean again, so the Red case left nothing behind.
+assert_ok "restored lane" bash scripts/check_gate_registry.sh
+
 if [ "$fail" -ne 0 ]; then
   exit 1
 fi

--- a/scripts/test_gc_selfbuild.sh
+++ b/scripts/test_gc_selfbuild.sh
@@ -196,7 +196,7 @@ for probe in "$OUT_DIR"/probes/*.vibe; do
   rm -f "$gc_wasm" "$gc_wasm.diag" "$lin_wasm" "$lin_wasm.diag"
   env VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$CLI_WASM" \
-    "${probe#"$ROOT_DIR"/}" "${gc_wasm#"$ROOT_DIR"/}" main >/dev/null 2>&1
+    "${probe#"$ROOT_DIR"/}" "${gc_wasm#"$ROOT_DIR"/}" main >/dev/null 2>&1 || true
   if [ ! -s "$gc_wasm" ]; then
     fail=$((fail+1)); failures+=("$name: COMPILE: $(cat "$gc_wasm.diag" 2>/dev/null || echo '(no diag)')")
     continue

--- a/scripts/test_vibe_install_hello.sh
+++ b/scripts/test_vibe_install_hello.sh
@@ -28,7 +28,7 @@ cd "$WORK"
 
 VIBE_PREOPEN_DIR="$WORK" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-  --invoke cli_main "$seed" "hello.vibex" "hello.wasm" "main" >/dev/null
+  --invoke cli_main "$seed" "hello.vibex" "hello.wasm" "main" >/dev/null || true
 
 if [ ! -s "$WORK/hello.wasm" ]; then
   echo "[install-hello-smoke] FAIL: compile produced no wasm" >&2

--- a/scripts/wasm_validate/exec_probe.vibex
+++ b/scripts/wasm_validate/exec_probe.vibex
@@ -9,7 +9,7 @@ import @vibex/wasm_runtime {
   exec_module_with_args
 }
 
-fn main with Fs {
+fn main with Fs + Stdout {
   let (ec, res) = exec_module_with_args(
     Fs::read_bytes("_build/val_target.wasm"),
     "f",

--- a/scripts/wasm_validate/probe.vibex
+++ b/scripts/wasm_validate/probe.vibex
@@ -6,7 +6,7 @@ import @vibex/wasm_parser {
   validate_structure
 }
 
-fn main with Fs {
+fn main with Fs + Stdout {
   match validate_structure(Fs::read_bytes("_build/val_target.wasm")) {
     None => println("ACCEPT"),
     Some(reason) => println(String::concat("REJECT ", reason))

--- a/scripts/wasm_validate/walk_probe.vibex
+++ b/scripts/wasm_validate/walk_probe.vibex
@@ -13,7 +13,7 @@ import @vibex/wasm_parser {
   get_code_body_range, list_sections, next_instruction, parse_code_entries
 }
 
-fn main with Fs {
+fn main with Fs + Stdout {
   let bytes = Fs::read_bytes("_build/val_target.wasm")
   let secs = list_sections(bytes)
   let mut i = 0

--- a/tests/gates/bootstrap/run.sh
+++ b/tests/gates/bootstrap/run.sh
@@ -105,7 +105,7 @@ for heap_backend in rc bump; do
     VIBE_RC="$heap_rc" VIBE_PROFILE_MEMORY_MARKS=1 \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "$heapmarkdir/input.vibe" "$heapmarkdir/$heap_backend.wasm" _start \
-    >/dev/null 2>"$heap_log"
+    >/dev/null 2>"$heap_log" || true
   if [ ! -s "$heapmarkdir/$heap_backend.wasm" ] \
     || ! grep -q "name=start" "$heap_log" \
     || ! grep -q "name=$heap_boundary" "$heap_log"; then

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -2779,12 +2779,17 @@ for pp_rc in 0 1; do
     echo "[compiler-gate] FAIL: print primitives output '$pp_out' under VIBE_RC=$pp_rc (expected 'hello gate|fortytwo|42|A|'; #929/#930 regressed)" >&2; exit 1
   fi
 done
+# #2107: both rows are declared because both functions really do print --
+# `print` carries `Stdout` now that the checker holds the print builtins to
+# the row discipline. What this fixture pins is unchanged: the SOURCE
+# definition of `println` wins over the builtin lowering, so the program
+# prints "S" rather than "ignored".
 cat > "$ppdir/shadow.vibe" <<'EOF'
-fn println(s: String) -> Unit {
+fn println(s: String) -> Unit with Stdout {
   print("S\n")
 }
 
-fn main() -> Unit {
+fn main() -> Unit with Stdout {
   println("ignored")
 }
 EOF

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -330,7 +330,7 @@ echo "[compiler-gate] generic-struct contract arity regression ok"
 echo "[compiler-gate] 6b2b explicit struct type args (#886)"
 stdir="_build/_gate_struct_targs"
 rm -rf "$stdir"; mkdir -p "$stdir"
-printf 'struct Pair[T] {\n  a: T;\n  b: T\n}\n\nstruct Bag[T] {\n  xs: Array[T]\n}\n\nexport let _start: () -> Unit = () -> {\n  let p = Pair[Int]::{ a: 1, b: 2 }\n  assert_eq(p.a + p.b, 3)\n  let g = Bag[Int]::{ xs: [] }\n  Array::push(g.xs, 42)\n  assert_eq(Array::get(g.xs, 0), 42)\n  let n = Pair[Array[Int]]::{ a: [1, 2], b: [] }\n  assert_eq(Array::length(n.a), 2)\n}\n' > "$stdir/ok.vibe"
+printf 'struct Pair[T] {\n  a: T;\n  b: T\n}\n\nstruct Bag[T] {\n  xs: Array[T]\n}\n\nexport let _start: () -> Unit with Stdout = () -> {\n  let p = Pair[Int]::{ a: 1, b: 2 }\n  assert_eq(p.a + p.b, 3)\n  let g = Bag[Int]::{ xs: [] }\n  Array::push(g.xs, 42)\n  assert_eq(Array::get(g.xs, 0), 42)\n  let n = Pair[Array[Int]]::{ a: [1, 2], b: [] }\n  assert_eq(Array::length(n.a), 2)\n}\n' > "$stdir/ok.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$stdir/ok.vibe" "$stdir/ok.wasm" _start >/dev/null 2>&1 || true
@@ -341,7 +341,7 @@ fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$stdir/ok.wasm" >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: explicit struct type args (#886) compiled but trapped at runtime" >&2; exit 1
 fi
-printf 'struct Pair[T] {\n  a: T;\n  b: T\n}\n\nexport let _start: () -> Unit = () -> {\n  let p = Pair[Int, String]::{ a: 1, b: 2 }\n  assert_eq(p.a, 1)\n}\n' > "$stdir/arity.vibe"
+printf 'struct Pair[T] {\n  a: T;\n  b: T\n}\n\nexport let _start: () -> Unit with Stdout = () -> {\n  let p = Pair[Int, String]::{ a: 1, b: 2 }\n  assert_eq(p.a, 1)\n}\n' > "$stdir/arity.vibe"
 if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$stdir/arity.vibe" "$stdir/arity.wasm" _start >/dev/null 2>&1 \
@@ -352,7 +352,7 @@ if ! grep -q "expects 1 type argument(s), got 2" "$stdir/arity.wasm.diag" 2>/dev
   echo "[compiler-gate] FAIL: type-arg arity rejection lacks the expected diagnostic (#886)" >&2
   cat "$stdir/arity.wasm.diag" 2>/dev/null >&2; exit 1
 fi
-printf 'struct Pair[T] {\n  a: T;\n  b: T\n}\n\nexport let _start: () -> Unit = () -> {\n  let p = Pair[String]::{ a: 1, b: 2 }\n  assert_eq(p.a, "x")\n}\n' > "$stdir/pin.vibe"
+printf 'struct Pair[T] {\n  a: T;\n  b: T\n}\n\nexport let _start: () -> Unit with Stdout = () -> {\n  let p = Pair[String]::{ a: 1, b: 2 }\n  assert_eq(p.a, "x")\n}\n' > "$stdir/pin.vibe"
 if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$stdir/pin.vibe" "$stdir/pin.wasm" _start >/dev/null 2>&1 \

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -23,7 +23,7 @@ printf 'export let add = (a: Int, b: Int) -> Int { a + b }\n' > "$fsdir/helper.v
 printf 'import ./helper.vibe { add }\nexport let _start = () -> Int { add(40, 2) }\n' > "$fsdir/main.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$fsdir/main.vibe" "$fsdir/main.wasm" _start
+  "$fsdir/main.vibe" "$fsdir/main.wasm" _start || true
 if [ ! -s "$fsdir/main.wasm" ]; then
   echo "[compiler-gate] FAIL: multi-file FS-compile produced no wasm" >&2
   exit 1
@@ -79,7 +79,7 @@ export let _start: () -> Int with Fs = () -> {
 VEOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$drdir/main.vibe" "$drdir/main.wasm" _start >/dev/null 2>&1
+  "$drdir/main.vibe" "$drdir/main.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$drdir/main.wasm" ]; then
   echo "[compiler-gate] FAIL: deep-resume regression program did not compile" >&2
   cat "$drdir/main.wasm.diag" >&2 2>/dev/null || true
@@ -153,7 +153,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$tdir/pass_test.vibe" "$tdir/pass_test.wasm" __no_entry__ >/dev/null 2>&1
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$tdir/fail_test.vibe" "$tdir/fail_test.wasm" __no_entry__ >/dev/null 2>&1
+  "$tdir/fail_test.vibe" "$tdir/fail_test.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$tdir/pass_test.wasm" ] || [ ! -s "$tdir/fail_test.wasm" ]; then
   echo "[compiler-gate] FAIL: test-block compile produced no wasm" >&2; exit 1
 fi
@@ -180,7 +180,7 @@ rm -rf "$ndir"; mkdir -p "$ndir"
 printf 'let dead: () -> Int = () -> { 0 }\nlet helper: () -> Int = () -> { 1 }\nexport let run: () -> Int = () -> { helper() }\n' > "$ndir/in.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_NORMALIZE=1 \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$ndir/in.vibe" "$ndir/out.vibe" >/dev/null 2>&1
+  "$ndir/in.vibe" "$ndir/out.vibe" >/dev/null 2>&1 || true
 if [ ! -s "$ndir/out.vibe" ]; then
   echo "[compiler-gate] FAIL: normalize produced no output" >&2; exit 1
 fi
@@ -205,7 +205,7 @@ fi
 printf 'fn checked_inc(x: Int) -> Int where { requires: x >= 0, ensures: result > x } { x + 1 }\nexport fn run() -> Int { checked_inc(41) }\nexport { run }\n' > "$ndir/keep_fn.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_NORMALIZE=1 \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$ndir/keep_fn.vibe" "$ndir/keep_fn.out.vibe" >/dev/null 2>&1
+  "$ndir/keep_fn.vibe" "$ndir/keep_fn.out.vibe" >/dev/null 2>&1 || true
 if [ ! -s "$ndir/keep_fn.out.vibe" ]; then
   echo "[compiler-gate] FAIL: fn-bearing source was not normalized (#727)" >&2; exit 1
 fi
@@ -237,7 +237,7 @@ cp "$ndir/out.vibe" "$ndir/compile.vibe"
 printf '\nexport let _start: () -> Int = () -> { run() }\n' >> "$ndir/compile.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$ndir/compile.vibe" "$ndir/out.wasm" _start >/dev/null 2>&1
+  "$ndir/compile.vibe" "$ndir/out.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$ndir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: normalized output does not compile" >&2
   cat "$ndir/compile.vibe" >&2; exit 1
@@ -1016,7 +1016,7 @@ EOF
 # Expected: 11 + 21 + 10 + 20 = 62
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$pdir/litpat.vibe" "$pdir/litpat.wasm" _start >/dev/null 2>&1
+  "$pdir/litpat.vibe" "$pdir/litpat.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$pdir/litpat.wasm" ]; then
   echo "[compiler-gate] FAIL: literal sub-pattern program did not compile" >&2; exit 1
 fi
@@ -1042,7 +1042,7 @@ rm -rf "$ldir"; mkdir -p "$ldir"
 printf 'let sum: (x~: Int, y~: Int) -> Int = (x~, y~) -> { x + y }\nexport let run: () -> Int = () -> { sum(x=1, y=2) }\nexport { run }\n' > "$ldir/in.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_NORMALIZE=1 \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$ldir/in.vibe" "$ldir/out.vibe" >/dev/null 2>&1
+  "$ldir/in.vibe" "$ldir/out.vibe" >/dev/null 2>&1 || true
 if [ ! -s "$ldir/out.vibe" ]; then
   echo "[compiler-gate] FAIL: labeled-param normalize produced no output" >&2; exit 1
 fi
@@ -1120,7 +1120,7 @@ EOF
 # The bound `x` in Some(x) must compile (no trap), and Some must not route to None.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$ndir/nested.vibe" "$ndir/nested.wasm" _start >/dev/null 2>&1
+  "$ndir/nested.vibe" "$ndir/nested.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$ndir/nested.wasm" ]; then
   echo "[compiler-gate] FAIL: nested ctor sub-pattern program did not compile (#608 regressed: codegen trap)" >&2; exit 1
 fi
@@ -1147,7 +1147,7 @@ export let _start: () -> Int = () -> { early() + 1 }
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$wdir/fwd.vibe" "$wdir/fwd.wasm" _start >/dev/null 2>&1
+  "$wdir/fwd.vibe" "$wdir/fwd.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$wdir/fwd.wasm" ]; then
   echo "[compiler-gate] FAIL: forward-reference program did not compile (#602 regressed: checker trap)" >&2; exit 1
 fi
@@ -1191,7 +1191,7 @@ EOF
 # 3*1000 + 52*100 + 3*10 + 0 = 3000 + 5200 + 30 = 8230
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$idir/interp.vibe" "$idir/interp.wasm" _start >/dev/null 2>&1
+  "$idir/interp.vibe" "$idir/interp.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$idir/interp.wasm" ]; then
   echo "[compiler-gate] FAIL: interpolation program did not compile" >&2; exit 1
 fi
@@ -1226,12 +1226,12 @@ test "pos" {
 EOF
 VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$cdir/cov_test.vibe" "$cdir/cov_test.wasm" __no_entry__ >/dev/null 2>&1
+  "$cdir/cov_test.vibe" "$cdir/cov_test.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$cdir/cov_test.wasm" ]; then
   echo "[compiler-gate] FAIL: coverage build produced no wasm (#cov regressed)" >&2; exit 1
 fi
 VIBE_COV_OUT="$cdir/cov.json" VIBE_PREOPEN_DIR="$ROOT_DIR" \
-  bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$cdir/cov_test.wasm" >/dev/null 2>&1
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$cdir/cov_test.wasm" >/dev/null 2>&1 || true
 if [ ! -s "$cdir/cov.json" ]; then
   echo "[compiler-gate] FAIL: no coverage report produced (vibe_cov section missing?)" >&2; exit 1
 fi
@@ -1289,7 +1289,7 @@ EOF
 # Expected: 42 + 42 + 42 + 84 + (10+20) + (7+8) + (42+43) = 340
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$mbtdir/mbt.vibe" "$mbtdir/mbt.wasm" _start >/dev/null 2>&1
+  "$mbtdir/mbt.vibe" "$mbtdir/mbt.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$mbtdir/mbt.wasm" ]; then
   echo "[compiler-gate] FAIL: trait dict-passing program did not compile" >&2
   cat "$mbtdir/mbt.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1332,7 +1332,7 @@ EOF
 # Expected: 84 (both Int and String witnesses resolved -> correct shown strings)
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$mgdir/mg.vibe" "$mgdir/mg.wasm" _start >/dev/null 2>&1
+  "$mgdir/mg.vibe" "$mgdir/mg.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$mgdir/mg.wasm" ]; then
   echo "[compiler-gate] FAIL: rank-1 trait-method generic program did not compile" >&2
   cat "$mgdir/mg.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1364,7 +1364,7 @@ rm -rf "$ufcsdir"; mkdir -p "$ufcsdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/trait_bound_ufcs_method.vibe "$ufcsdir/ufcs.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/trait_bound_ufcs_method.vibe "$ufcsdir/ufcs.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$ufcsdir/ufcs.wasm" ]; then
   echo "[compiler-gate] FAIL: UFCS-on-bounded-tparam program did not compile" >&2
   cat "$ufcsdir/ufcs.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1397,7 +1397,7 @@ EOF
 # Expected: -1 + 1 + 0 + len("P { x: 7, y: 9 }")=16 -> 16
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$drvdir/drv.vibe" "$drvdir/drv.wasm" _start >/dev/null 2>&1
+  "$drvdir/drv.vibe" "$drvdir/drv.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$drvdir/drv.wasm" ]; then
   echo "[compiler-gate] FAIL: derive program did not compile" >&2
   cat "$drvdir/drv.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1437,7 +1437,7 @@ run_test_block_fixtures() {
     rm -f "$fxout" "$fxout.diag"
     VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
       bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-      "$fx" "$fxout" __no_entry__ >/dev/null 2>&1
+      "$fx" "$fxout" __no_entry__ >/dev/null 2>&1 || true
     if [ ! -s "$fxout" ]; then
       echo "[compiler-gate] FAIL: $fx did not compile ($label)" >&2
       cat "$fxout.diag" 2>/dev/null >&2; exit 1
@@ -1499,7 +1499,7 @@ for eqtrap_src in fixtures/structural_eq_untyped_empty_*_trap.vibe; do
   eqtrap_wasm="$eqtrapdir/$eqtrap_name.wasm"
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "$eqtrap_src" "$eqtrap_wasm" _start >/dev/null 2>&1
+    "$eqtrap_src" "$eqtrap_wasm" _start >/dev/null 2>&1 || true
   if [ ! -s "$eqtrap_wasm" ]; then
     echo "[compiler-gate] FAIL: $eqtrap_src did not compile" >&2
     cat "$eqtrap_wasm.diag" 2>/dev/null >&2
@@ -1606,7 +1606,7 @@ EOF
 # Expected: (1+2+3+4) + (1+2+3+4) + (1+2+3+4) = 30
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$itdir/iter.vibe" "$itdir/iter.wasm" _start >/dev/null 2>&1
+  "$itdir/iter.vibe" "$itdir/iter.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$itdir/iter.wasm" ]; then
   echo "[compiler-gate] FAIL: Iterator trait program did not compile" >&2
   cat "$itdir/iter.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1677,7 +1677,7 @@ EOF
 # Expected: 20 + 20 + 7 = 47
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$lcdir/lc.vibe" "$lcdir/lc.wasm" _start >/dev/null 2>&1
+  "$lcdir/lc.vibe" "$lcdir/lc.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$lcdir/lc.wasm" ]; then
   echo "[compiler-gate] FAIL: lazy combinators program did not compile" >&2
   cat "$lcdir/lc.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1732,7 +1732,7 @@ export let _start: () -> Int = () -> { lazy_iter_count(lazy_iter_arr([10, 20, 30
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$xidir/main.vibe" "$xidir/main.wasm" _start >/dev/null 2>&1
+  "$xidir/main.vibe" "$xidir/main.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$xidir/main.wasm" ]; then
   echo "[compiler-gate] FAIL: cross-import trait-iterator program did not compile" >&2
   exit 1
@@ -1788,7 +1788,7 @@ EOF
 # Expected: async iterator 10+20+30 = 60, pull closure 1+2+3+4 = 10 -> 70.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$fadir/fa.vibe" "$fadir/fa.wasm" _start >/dev/null 2>&1
+  "$fadir/fa.vibe" "$fadir/fa.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$fadir/fa.wasm" ]; then
   echo "[compiler-gate] FAIL: async for-loop program did not compile" >&2
   cat "$fadir/fa.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1845,7 +1845,7 @@ export let _start: () -> Int = () -> { sum_direct(lazy_iter_arr([10, 20, 30, 40]
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$eidir/pos.vibe" "$eidir/pos.wasm" _start >/dev/null 2>&1
+  "$eidir/pos.vibe" "$eidir/pos.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$eidir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: element-type positive program did not compile" >&2
   cat "$eidir/pos.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1894,7 +1894,7 @@ for suite in lib/@vibe/prelude/lazy_iter_test.vibe lib/@vibe/prelude/async_iter_
   # the test-runner `_start` synthesis (unknown entry names are compile errors).
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "$suite" "$out" __no_entry__ >/dev/null 2>&1
+    "$suite" "$out" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$out" ]; then
     echo "[compiler-gate] FAIL: $suite did not compile" >&2
     cat "$out.diag" 2>/dev/null >&2; exit 1
@@ -1930,7 +1930,7 @@ export let _start: () -> Int = () -> { total([10, 20, 30, 40]) + total(Box::{ v:
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$gidir/pos.vibe" "$gidir/pos.wasm" _start >/dev/null 2>&1
+  "$gidir/pos.vibe" "$gidir/pos.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$gidir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: generic-impl positive program did not compile" >&2
   cat "$gidir/pos.wasm.diag" 2>/dev/null >&2; exit 1
@@ -1984,7 +1984,7 @@ let use_it = [U: Show2](x: U) -> Int { U::show2(x) }'
 } > "$gjdir/pos.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$gjdir/pos.vibe" "$gjdir/pos.wasm" _start >/dev/null 2>&1
+  "$gjdir/pos.vibe" "$gjdir/pos.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$gjdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: dict-of-dict positive program did not compile" >&2
   cat "$gjdir/pos.wasm.diag" 2>/dev/null >&2; exit 1
@@ -2103,7 +2103,7 @@ EOF
 # fails to compile the bare-tuple binding).
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$nldir/nestedlit.vibe" "$nldir/nestedlit.wasm" _start >/dev/null 2>&1
+  "$nldir/nestedlit.vibe" "$nldir/nestedlit.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$nldir/nestedlit.wasm" ]; then
   echo "[compiler-gate] FAIL: nested literal sub-pattern program did not compile" >&2; exit 1
 fi

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -5327,7 +5327,7 @@ rm -rf "$inspdir"; mkdir -p "$inspdir"
 # the arguments already reference. With a fixed temp name this compared the
 # literal against ITSELF and passed; the assertion has to see "wrong".
 cat > "$inspdir/hygiene.vibe" <<'INSPH'
-fn main() -> Int {
+fn main() -> Int with Stdout {
   let __vibe_inspect_actual = "wrong"
   inspect(1, __vibe_inspect_actual)
   0

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -30,7 +30,7 @@ fn main with Stdout {
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$a69dir/ok_fnmain.vibe" "$a69dir/ok_fnmain.wasm" main >/dev/null 2>&1
+  "$a69dir/ok_fnmain.vibe" "$a69dir/ok_fnmain.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$a69dir/ok_fnmain.wasm" ]; then
   echo "[compiler-gate] FAIL: fn main {} sugar did not compile" >&2
   cat "$a69dir/ok_fnmain.wasm.diag" 2>/dev/null >&2 || true
@@ -53,7 +53,7 @@ EOF
 rm -f "$a69dir/int_main.wasm"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$a69dir/int_main.vibe" "$a69dir/int_main.wasm" main >/dev/null 2>&1
+  "$a69dir/int_main.vibe" "$a69dir/int_main.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$a69dir/int_main.wasm" ]; then
   echo "[compiler-gate] FAIL: Int-returning let main did not compile" >&2
   cat "$a69dir/int_main.wasm.diag" 2>/dev/null >&2 || true
@@ -157,7 +157,7 @@ EOF
 rm -f "$g830dir/fnbody_record_destr.wasm"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g830dir/fnbody_record_destr.vibe" "$g830dir/fnbody_record_destr.wasm" _start >/dev/null 2>&1
+  "$g830dir/fnbody_record_destr.vibe" "$g830dir/fnbody_record_destr.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g830dir/fnbody_record_destr.wasm" ]; then
   echo "[compiler-gate] FAIL: function-body 'let record { .. } = ..' did not compile" >&2
   cat "$g830dir/fnbody_record_destr.wasm.diag" 2>/dev/null >&2 || true
@@ -247,7 +247,7 @@ export let _start: () -> Int = () -> { y.v }
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g844dir/ok_bare_roundtrip.vibe" "$g844dir/ok_bare_roundtrip.wasm" _start >/dev/null 2>&1
+  "$g844dir/ok_bare_roundtrip.vibe" "$g844dir/ok_bare_roundtrip.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g844dir/ok_bare_roundtrip.wasm" ]; then
   echo "[compiler-gate] FAIL: bare-to-bare generic-struct annotation round-trip over-rejected (#844 fix too aggressive)" >&2
   cat "$g844dir/ok_bare_roundtrip.wasm.diag" 2>/dev/null >&2; exit 1
@@ -266,7 +266,7 @@ export let _start: () -> Int = () -> { y.v + 1 }
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g844dir/ok_matching.vibe" "$g844dir/ok_matching.wasm" _start >/dev/null 2>&1
+  "$g844dir/ok_matching.vibe" "$g844dir/ok_matching.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g844dir/ok_matching.wasm" ]; then
   echo "[compiler-gate] FAIL: explicit matching generic-struct instantiation over-rejected (#844 fix too aggressive)" >&2
   cat "$g844dir/ok_matching.wasm.diag" 2>/dev/null >&2; exit 1
@@ -460,7 +460,7 @@ EOF
 rm -f "$g859dir/fnbody_tuple_destr.wasm"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$g859dir/fnbody_tuple_destr.vibe" "$g859dir/fnbody_tuple_destr.wasm" _start >/dev/null 2>&1
+  "$g859dir/fnbody_tuple_destr.vibe" "$g859dir/fnbody_tuple_destr.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g859dir/fnbody_tuple_destr.wasm" ]; then
   echo "[compiler-gate] FAIL: function-body 'let (a, b) = ..' did not compile" >&2
   cat "$g859dir/fnbody_tuple_destr.wasm.diag" 2>/dev/null >&2 || true
@@ -763,7 +763,7 @@ c1062dir="_build/_gate_ctor_double_field_rc"
 rm -rf "$c1062dir"; mkdir -p "$c1062dir"
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/rc_ctor_double_field_match_test.vibe" "$c1062dir/c1062.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/rc_ctor_double_field_match_test.vibe" "$c1062dir/c1062.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$c1062dir/c1062.wasm" ]; then
   echo "[compiler-gate] FAIL: ctor Double-field match fixture did not compile under RC" >&2
   cat "$c1062dir/c1062.wasm.diag" 2>/dev/null >&2 || true
@@ -2530,7 +2530,7 @@ cp scripts/fixtures/parallel_project_sample/leaf.vibe \
    scripts/fixtures/parallel_project_sample/main.vibe "$plandir/src/"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_MODULE_PLAN=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$plandir/src/main.vibe" "$plandir/plan.txt" __no_entry__ >/dev/null 2>&1
+  "$plandir/src/main.vibe" "$plandir/plan.txt" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$plandir/plan.txt" ]; then
   echo "[compiler-gate] FAIL: VIBE_MODULE_PLAN produced no manifest$([ -s "$plandir/plan.txt.diag" ] && echo ": $(cat "$plandir/plan.txt.diag")")" >&2
   exit 1
@@ -2563,7 +2563,7 @@ echo "[compiler-gate] module plan matches per-file discovery on the fixture (3 m
 # Structural check on a real graph: one spawn, no oracle needed.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_MODULE_PLAN=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  lib/@vibe/compiler/tests/codegen_lexer_test.vibe "$plandir/big.txt" __no_entry__ >/dev/null 2>&1
+  lib/@vibe/compiler/tests/codegen_lexer_test.vibe "$plandir/big.txt" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$plandir/big.txt" ]; then
   echo "[compiler-gate] FAIL: VIBE_MODULE_PLAN produced no manifest for the compiler's own graph$([ -s "$plandir/big.txt.diag" ] && echo ": $(cat "$plandir/big.txt.diag")")" >&2
   exit 1
@@ -2612,7 +2612,7 @@ for bag_be in gc linear; do
   [ "$bag_be" = "gc" ] && bag_env="VIBE_BACKEND=gc"
   env $bag_env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_bytes_append_grow.vibe" "$bagdir/$bag_be.wasm" main >/dev/null 2>&1
+    "fixtures/gc_bytes_append_grow.vibe" "$bagdir/$bag_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$bagdir/$bag_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_bytes_append_grow.vibe did not compile on the $bag_be backend" >&2
     cat "$bagdir/$bag_be.wasm.diag" 2>/dev/null >&2 || true
@@ -3569,7 +3569,7 @@ rm -rf "$g1340dir"; mkdir -p "$g1340dir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_generic_row_instantiation.vibe "$g1340dir/pos.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_generic_row_instantiation.vibe "$g1340dir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$g1340dir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_generic_row_instantiation.vibe did not compile (with State[Int] row grammar or generic registration regressed)" >&2
   cat "$g1340dir/pos.wasm.diag" 2>/dev/null >&2 || true
@@ -3634,7 +3634,7 @@ rm -rf "$opb"; mkdir -p "$opb"
 # no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_builtin_operation_row.vibe "$opb/pos.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_builtin_operation_row.vibe "$opb/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$opb/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: with Fs::read_file no longer authorizes the Fs::read_file builtin (#1343)" >&2
   cat "$opb/pos.wasm.diag" 2>/dev/null >&2 || true
@@ -3677,7 +3677,7 @@ let main = () -> Int {
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$opb/bare.vibe" "$opb/bare.wasm" main >/dev/null 2>&1
+  "$opb/bare.vibe" "$opb/bare.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$opb/bare.wasm" ]; then
   echo "[compiler-gate] FAIL: the bare effect row stopped granting all of its operations (#1343 must be a pure widening)" >&2
   cat "$opb/bare.wasm.diag" 2>/dev/null >&2 || true
@@ -3703,7 +3703,7 @@ rm -rf "$afdir"; mkdir -p "$afdir"
 # no `__DATA__` strip, no temp copy, and no expected value in shell.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_async_for_row.vibe "$afdir/pos.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_async_for_row.vibe "$afdir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$afdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_async_for_row.vibe did not compile -- a declared `with Async` row must still accept the async for loop (#1358)" >&2
   cat "$afdir/pos.wasm.diag" 2>/dev/null >&2 || true
@@ -3850,7 +3850,7 @@ let main = () -> Unit with Stdout + Env {
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$lcdir/pos.vibe" "$lcdir/pos.wasm" main >/dev/null 2>&1
+  "$lcdir/pos.vibe" "$lcdir/pos.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$lcdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: declaring the local closure's row must satisfy the leak check (#1361)" >&2
   cat "$lcdir/pos.wasm.diag" 2>/dev/null >&2 || true
@@ -3866,7 +3866,7 @@ let main = () -> Unit with Stdout {
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$lcdir/pure.vibe" "$lcdir/pure.wasm" main >/dev/null 2>&1
+  "$lcdir/pure.vibe" "$lcdir/pure.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$lcdir/pure.wasm" ]; then
   echo "[compiler-gate] FAIL: a PURE local closure must stay free of any row requirement (#1361 must not over-require)" >&2
   cat "$lcdir/pure.wasm.diag" 2>/dev/null >&2 || true
@@ -3926,7 +3926,7 @@ let main = () -> Int {
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$hsdir/live.vibe" "$hsdir/live.wasm" main >/dev/null 2>&1
+  "$hsdir/live.vibe" "$hsdir/live.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$hsdir/live.wasm" ]; then
   echo "[compiler-gate] FAIL: a handle whose body DOES reach the effect must still compile (#1347 must not over-reject)" >&2
   cat "$hsdir/live.wasm.diag" 2>/dev/null >&2 || true
@@ -3959,7 +3959,7 @@ let main = () -> Int {
 EOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$hsdir/param.vibe" "$hsdir/param.wasm" main >/dev/null 2>&1
+  "$hsdir/param.vibe" "$hsdir/param.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$hsdir/param.wasm" ]; then
   echo "[compiler-gate] FAIL: a handled body whose only callee is a row-carrying PARAMETER (or annotated local) must compile -- #1347 must consult the #885/#1361 overlay, not just top-level bindings" >&2
   cat "$hsdir/param.wasm.diag" 2>/dev/null >&2 || true
@@ -4013,7 +4013,7 @@ rm -rf "$excdir"; mkdir -p "$excdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/exception_typed_row.vibe "$excdir/pos.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/exception_typed_row.vibe "$excdir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$excdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: exception_typed_row.vibe did not compile (Exception[E] rows / kinded handle / erased alias regressed)" >&2
   cat "$excdir/pos.wasm.diag" 2>/dev/null >&2 || true
@@ -4418,7 +4418,7 @@ witresdir="_build/_gate_wit_result"
 rm -rf "$witresdir"; mkdir -p "$witresdir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/wit_gen_result.vibe" "$witresdir/fixture.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/wit_gen_result.vibe" "$witresdir/fixture.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$witresdir/fixture.wasm" ]; then
   echo "[compiler-gate] FAIL: fixtures/wit_gen_result.vibe did not FS-compile -- the @vibe/wit_runtime import does not resolve or does not type-check (#1324)" >&2
   cat "$witresdir/fixture.wasm.diag" 2>/dev/null >&2 || true
@@ -4426,7 +4426,7 @@ if [ ! -s "$witresdir/fixture.wasm" ]; then
 fi
 VIBE_EMIT_WIT=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/wit_gen_result.vibe" "$witresdir/out.wit" main >/dev/null 2>&1
+  "fixtures/wit_gen_result.vibe" "$witresdir/out.wit" main >/dev/null 2>&1 || true
 if [ ! -s "$witresdir/out.wit" ]; then
   echo "[compiler-gate] FAIL: VIBE_EMIT_WIT produced no output for the @vibe/wit_runtime fixture (#1324)" >&2
   cat "$witresdir/out.wit.diag" 2>/dev/null >&2 || true
@@ -4615,7 +4615,7 @@ test "gamma_ok" {
 PBEOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$pbdir/pb_test.vibe" "$pbdir/pb.wasm" __no_entry__ >/dev/null 2>&1
+  "$pbdir/pb_test.vibe" "$pbdir/pb.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$pbdir/pb.wasm" ]; then
   echo "[compiler-gate] FAIL: per-block test fixture did not compile (#819)" >&2
   cat "$pbdir/pb.wasm.diag" 2>/dev/null >&2 || true

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -4270,12 +4270,12 @@ enum Boom {
   Bang(Int)
 }
 
-fn Boom::to_string(self: Boom) -> String {
+fn Boom::to_string(self: Boom) -> String with Stdout {
   println("FORMATTER RAN")
   "boom"
 }
 
-let _start = () -> Int {
+let _start = () -> Int with Stdout {
   println("interp=\{Bang(1)}")
   handle {
     throw(Bang(1))

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -4480,32 +4480,32 @@ res_case() {
 }
 res_case basic ok 'resource Posts : S3::Bucket
 
-fn main {
+fn main with Stdout {
   println("ok")
 }
 '
 res_case unqualified err 'resource Posts : Bucket
 
-fn main {
+fn main with Stdout {
   println("ok")
 }
 ' 'must be qualified'
 res_case duplicate err 'resource Posts : S3::Bucket
 resource Posts : S3::Table
 
-fn main {
+fn main with Stdout {
   println("ok")
 }
 ' 'already declared'
 res_case singleton err 'resource Home : Process::Root
 
-fn main {
+fn main with Stdout {
   println("ok")
 }
 ' 'singleton'
 res_case exported err 'export resource Posts : S3::Bucket
 
-fn main {
+fn main with Stdout {
   println("ok")
 }
 ' 'cannot be exported'
@@ -4514,7 +4514,7 @@ fn main {
 # position, so nothing that used the name breaks.
 res_case as_name ok 'let resource = 1
 
-fn main {
+fn main with Stdout {
   println("ok")
 }
 '
@@ -4759,7 +4759,7 @@ en_case() {
 #    no way to WRITE a qualified reference to an imported constructor.
 en_case qualified ok 'import ./dep.vibe { Box, Mk, Nil }
 
-fn main {
+fn main with Stdout {
   let b = Box::Mk(7)
   let r = match b {
     Mk(n) => n,
@@ -4774,7 +4774,7 @@ fn main {
 #    one: a hole in checking, not a message-quality complaint.
 en_case payload_checked err 'import ./dep.vibe { Box, Mk, Nil }
 
-fn main {
+fn main with Stdout {
   let b = Mk(7)
   match b {
     Mk(n) => println(String::concat(n, "!")),
@@ -4787,7 +4787,7 @@ fn main {
 #    variant trapped at runtime instead.
 en_case exhaustive err 'import ./dep.vibe { Box, Mk }
 
-fn main {
+fn main with Stdout {
   let b = Mk(7)
   let r = match b {
     Mk(n) => n
@@ -4803,7 +4803,7 @@ fn main {
 #    env_lookup that could not see the imported scheme.
 en_case parameterized ok 'import ./dep.vibe { Attempt, Got, Missed }
 
-fn main {
+fn main with Stdout {
   let a = Got(3)
   let r = match a {
     Got(v) => v,
@@ -4814,7 +4814,7 @@ fn main {
 '
 en_case parameterized_qualified ok 'import ./dep.vibe { Attempt, Got, Missed }
 
-fn main {
+fn main with Stdout {
   let a = Attempt::Got(3)
   let r = match a {
     Attempt::Got(v) => v,
@@ -4842,7 +4842,7 @@ fn second() -> String {
   }
 }
 
-fn main {
+fn main with Stdout {
   println(String::concat(__to_string(first()), second()))
 }
 '
@@ -4854,7 +4854,7 @@ fn main {
 #     `Box` is a real enum here, just not the one that owns `Missed`.
 en_case pattern_qualifier_wrong_enum err 'import ./dep.vibe { Attempt, Box, Got, Missed }
 
-fn main {
+fn main with Stdout {
   let a = Got(3)
   let r = match a {
     Got(v) => v,
@@ -4875,7 +4875,7 @@ fn shout(s: String) -> String with Log {
   s
 }
 
-fn main {
+fn main with Stdout {
   let r = handle {
     shout("hi")
   } with Log {
@@ -4898,7 +4898,7 @@ enum Color {
   Green
 }
 
-fn main {
+fn main with Stdout {
   let c = Red
   match c {
     Red => println("red"),
@@ -4917,7 +4917,7 @@ enum B {
   Mk(String)
 }
 
-fn main {
+fn main with Stdout {
   println("unreachable")
 }
 ' 'constructor name collision'
@@ -5394,14 +5394,14 @@ fi
 # the observable: the rewrite runs a snapshot assertion instead and traps.
 cat > "$inspdir/shadow_pat.vibe" <<'INSPP'
 enum Box {
-  B((Int, String) -> Unit)
+  B((Int, String) -> Unit with Stdout)
 }
 
-fn shout(v: Int, c: String) -> Unit {
+fn shout(v: Int, c: String) -> Unit with Stdout {
   println(c)
 }
 
-fn main() -> Int {
+fn main() -> Int with Stdout {
   match B(shout) {
     B(inspect) => {
       inspect(1, "SIDE EFFECT RAN")

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -21,7 +21,7 @@ vdir="_build/_gate_v128"
 rm -rf "$vdir"; mkdir -p "$vdir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/v128_intrinsics_test.vibe" "$vdir/v128.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/v128_intrinsics_test.vibe" "$vdir/v128.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$vdir/v128.wasm" ]; then
   echo "[compiler-gate] FAIL: v128 intrinsics test did not compile" >&2
   cat "$vdir/v128.wasm.diag" 2>/dev/null >&2 || true
@@ -44,7 +44,7 @@ swdir="_build/_gate_simd_skip_ws"
 rm -rf "$swdir"; mkdir -p "$swdir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/simd_skip_ws_test.vibe" "$swdir/sw.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/simd_skip_ws_test.vibe" "$swdir/sw.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$swdir/sw.wasm" ]; then
   echo "[compiler-gate] FAIL: simd_skip_ws test did not compile" >&2
   cat "$swdir/sw.wasm.diag" 2>/dev/null >&2 || true
@@ -65,7 +65,7 @@ sssdir="_build/_gate_simd_string_special"
 rm -rf "$sssdir"; mkdir -p "$sssdir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/simd_scan_string_special_test.vibe" "$sssdir/sss.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/simd_scan_string_special_test.vibe" "$sssdir/sss.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$sssdir/sss.wasm" ]; then
   echo "[compiler-gate] FAIL: SIMD string-special test did not compile" >&2
   cat "$sssdir/sss.wasm.diag" 2>/dev/null >&2 || true
@@ -86,7 +86,7 @@ sledir="_build/_gate_simd_line_end"
 rm -rf "$sledir"; mkdir -p "$sledir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/simd_scan_line_end_test.vibe" "$sledir/sle.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/simd_scan_line_end_test.vibe" "$sledir/sle.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$sledir/sle.wasm" ]; then
   echo "[compiler-gate] FAIL: SIMD line-end test did not compile" >&2
   cat "$sledir/sle.wasm.diag" 2>/dev/null >&2 || true
@@ -109,7 +109,7 @@ rcdir="_build/_gate_region_capture"
 rm -rf "$rcdir"; mkdir -p "$rcdir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/region_capture_test.vibe" "$rcdir/rc.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/region_capture_test.vibe" "$rcdir/rc.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$rcdir/rc.wasm" ]; then
   echo "[compiler-gate] FAIL: region_capture test did not compile" >&2
   cat "$rcdir/rc.wasm.diag" 2>/dev/null >&2 || true
@@ -357,7 +357,7 @@ shdir="_build/_gate_rc_shadow_sleep"
 rm -rf "$shdir"; mkdir -p "$shdir"
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/rc_user_shadowed_sleep_test.vibe" "$shdir/sh.wasm" main >/dev/null 2>&1
+  "fixtures/rc_user_shadowed_sleep_test.vibe" "$shdir/sh.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$shdir/sh.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_user_shadowed_sleep fixture did not compile under VIBE_RC" >&2
   cat "$shdir/sh.wasm.diag" 2>/dev/null >&2 || true
@@ -383,7 +383,7 @@ lkdir="_build/_gate_rc_leak"
 rm -rf "$lkdir"; mkdir -p "$lkdir"
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/rc_reclaim_leak_test.vibe" "$lkdir/rc.wasm" main >/dev/null 2>&1
+  "fixtures/rc_reclaim_leak_test.vibe" "$lkdir/rc.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$lkdir/rc.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_reclaim_leak fixture did not compile under VIBE_RC" >&2
   cat "$lkdir/rc.wasm.diag" 2>/dev/null >&2 || true
@@ -418,7 +418,7 @@ v2dir="_build/_gate_v128_rc"
 rm -rf "$v2dir"; mkdir -p "$v2dir"
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/v128_intrinsics_test.vibe" "$v2dir/v128rc.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/v128_intrinsics_test.vibe" "$v2dir/v128rc.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$v2dir/v128rc.wasm" ]; then
   echo "[compiler-gate] FAIL: v128 intrinsics test did not compile under RC" >&2
   cat "$v2dir/v128rc.wasm.diag" 2>/dev/null >&2 || true
@@ -447,7 +447,7 @@ shdir="_build/_gate_rc_shadow"
 rm -rf "$shdir"; mkdir -p "$shdir"
 VIBE_RC=shadow VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/rc_shadow_regression_test.vibe" "$shdir/shadow.wasm" main >/dev/null 2>&1
+  "fixtures/rc_shadow_regression_test.vibe" "$shdir/shadow.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$shdir/shadow.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_shadow_regression fixture did not compile under VIBE_RC=shadow" >&2
   cat "$shdir/shadow.wasm.diag" 2>/dev/null >&2 || true
@@ -487,7 +487,7 @@ do
   ca_base="$(basename "$ca" .vibe)"
   VIBE_RC=shadow VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "$ca" "$cadir/$ca_base.wasm" __no_entry__ >/dev/null 2>&1
+    "$ca" "$cadir/$ca_base.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$cadir/$ca_base.wasm" ]; then
     echo "[compiler-gate] FAIL: $ca did not compile under VIBE_RC=shadow (#1986)" >&2
     cat "$cadir/$ca_base.wasm.diag" 2>/dev/null >&2 || true
@@ -534,7 +534,7 @@ gcdir="_build/_gate_gc"
 rm -rf "$gcdir"; mkdir -p "$gcdir"
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/gc_backend_smoke_test.vibe" "$gcdir/smoke.wasm" main >/dev/null 2>&1
+  "fixtures/gc_backend_smoke_test.vibe" "$gcdir/smoke.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gcdir/smoke.wasm" ]; then
   echo "[compiler-gate] FAIL: gc backend smoke did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcdir/smoke.wasm.diag" 2>/dev/null >&2 || true
@@ -571,7 +571,7 @@ for gccap_lane in linear-rc0 linear-rc1 gc; do
   esac
   env -u VIBE_FS_COMPILE VIBE_RC="$gccap_rc" VIBE_BACKEND="$gccap_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_closure_builtin_capture_test.vibe" "$gccapdir/$gccap_lane.wasm" __no_entry__ >/dev/null 2>&1
+    "fixtures/gc_closure_builtin_capture_test.vibe" "$gccapdir/$gccap_lane.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gccapdir/$gccap_lane.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_closure_builtin_capture_test.vibe did not compile on $gccap_lane" >&2
     cat "$gccapdir/$gccap_lane.wasm.diag" 2>/dev/null >&2 || true
@@ -604,7 +604,7 @@ for gcalias_lane in linear-rc0 linear-rc1 gc; do
   esac
   env -u VIBE_FS_COMPILE VIBE_RC="$gcalias_rc" VIBE_BACKEND="$gcalias_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_closure_builtin_alias_test.vibe" "$gcaliasdir/$gcalias_lane.wasm" __no_entry__ >/dev/null 2>&1
+    "fixtures/gc_closure_builtin_alias_test.vibe" "$gcaliasdir/$gcalias_lane.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcaliasdir/$gcalias_lane.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_closure_builtin_alias_test.vibe did not compile on $gcalias_lane" >&2
     cat "$gcaliasdir/$gcalias_lane.wasm.diag" 2>/dev/null >&2 || true
@@ -638,7 +638,7 @@ gcabi_out=""
 for gcabi_be in linear gc; do
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcabi_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_host_abi_declaration.vibe" "$gcabidir/$gcabi_be.wasm" main >/dev/null 2>&1
+    "fixtures/gc_host_abi_declaration.vibe" "$gcabidir/$gcabi_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gcabidir/$gcabi_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_host_abi_declaration.vibe did not compile on the $gcabi_be backend (#1814)" >&2
     cat "$gcabidir/$gcabi_be.wasm.diag" 2>/dev/null >&2 || true
@@ -688,7 +688,7 @@ for gchb_be in linear gc; do
   printf 'y\n' > _build/gc_host_builtins_probe/rd/f2
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gchb_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_host_builtins.vibe" "$gchbdir/$gchb_be.wasm" main >/dev/null 2>&1
+    "fixtures/gc_host_builtins.vibe" "$gchbdir/$gchb_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gchbdir/$gchb_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_host_builtins.vibe did not compile on the $gchb_be backend (#1262)" >&2
     cat "$gchbdir/$gchb_be.wasm.diag" 2>/dev/null >&2 || true
@@ -721,7 +721,7 @@ printf 'x\n' > _build/gc_host_builtins_probe/rd/f1
 printf 'y\n' > _build/gc_host_builtins_probe/rd/f2
 env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$gchbdir/rdclosure.vibe" "$gchbdir/rdclosure.wasm" main >/dev/null 2>&1
+  "$gchbdir/rdclosure.vibe" "$gchbdir/rdclosure.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gchbdir/rdclosure.wasm" ]; then
   echo "[compiler-gate] FAIL: Fs::readdir inside a closure did not compile on the gc lane -- is it still listed in gc_direct_abi_names()? (#1262)" >&2
   cat "$gchbdir/rdclosure.wasm.diag" 2>/dev/null >&2 || true
@@ -757,7 +757,7 @@ rm -rf "$gcrgdir"; mkdir -p "$gcrgdir"
 for gcrg_be in linear gc; do
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcrg_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_region_arena_free.vibe" "$gcrgdir/$gcrg_be.wasm" __no_entry__ >/dev/null 2>&1
+    "fixtures/gc_region_arena_free.vibe" "$gcrgdir/$gcrg_be.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcrgdir/$gcrg_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_region_arena_free.vibe did not compile on the $gcrg_be backend (#1262)" >&2
     cat "$gcrgdir/$gcrg_be.wasm.diag" 2>/dev/null >&2 || true
@@ -792,7 +792,7 @@ gcardir="_build/_gate_gc_arena"
 rm -rf "$gcardir"; mkdir -p "$gcardir"
 env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/region_arena_bounded.vibe" "$gcardir/bounded.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/region_arena_bounded.vibe" "$gcardir/bounded.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcardir/bounded.wasm" ]; then
   echo "[compiler-gate] FAIL: region_arena_bounded.vibe did not compile on the gc backend (#1262)" >&2
   cat "$gcardir/bounded.wasm.diag" 2>/dev/null >&2 || true
@@ -823,7 +823,7 @@ fi
 # read 3,208 B).
 env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/region_bytes_arena_bounded.vibe" "$gcardir/bbounded.wasm" __no_entry__ >/dev/null 2>&1
+  "fixtures/region_bytes_arena_bounded.vibe" "$gcardir/bbounded.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcardir/bbounded.wasm" ]; then
   echo "[compiler-gate] FAIL: region_bytes_arena_bounded.vibe did not compile on the gc backend (#1262)" >&2
   cat "$gcardir/bbounded.wasm.diag" 2>/dev/null >&2 || true
@@ -859,7 +859,7 @@ rm -rf "$gcarudir"; mkdir -p "$gcarudir"
 # 70-punch loop the heap delta observes.
 env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/region_throw_unwind_test.vibe" "$gcarudir/unwind.wasm" main >/dev/null 2>&1
+  "fixtures/region_throw_unwind_test.vibe" "$gcarudir/unwind.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gcarudir/unwind.wasm" ]; then
   echo "[compiler-gate] FAIL: region_throw_unwind_test.vibe did not compile on the gc backend (#1937)" >&2
   cat "$gcarudir/unwind.wasm.diag" 2>/dev/null >&2 || true
@@ -897,7 +897,7 @@ gcmd_out=""
 for gcmd_be in linear gc; do
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcmd_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_map_delete.vibe" "$gcmddir/$gcmd_be.snap.wasm" __no_entry__ >/dev/null 2>&1
+    "fixtures/gc_map_delete.vibe" "$gcmddir/$gcmd_be.snap.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcmddir/$gcmd_be.snap.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_map_delete.vibe did not compile on the $gcmd_be backend (#1262)" >&2
     cat "$gcmddir/$gcmd_be.snap.wasm.diag" 2>/dev/null >&2 || true
@@ -944,7 +944,7 @@ gcsi_out=""
 for gcsi_be in linear gc; do
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcsi_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_stdin_int_parse.vibe" "$gcsidir/$gcsi_be.snap.wasm" __no_entry__ >/dev/null 2>&1
+    "fixtures/gc_stdin_int_parse.vibe" "$gcsidir/$gcsi_be.snap.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcsidir/$gcsi_be.snap.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_stdin_int_parse.vibe did not compile on the $gcsi_be backend (#1262)" >&2
     cat "$gcsidir/$gcsi_be.snap.wasm.diag" 2>/dev/null >&2 || true
@@ -991,7 +991,7 @@ rm -rf "$gcpedir"; mkdir -p "$gcpedir"
 for gcpe_be in linear gc; do
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcpe_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_process_exit.vibe" "$gcpedir/$gcpe_be.wasm" main >/dev/null 2>&1
+    "fixtures/gc_process_exit.vibe" "$gcpedir/$gcpe_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gcpedir/$gcpe_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_process_exit.vibe did not compile on the $gcpe_be backend (#1262)" >&2
     cat "$gcpedir/$gcpe_be.wasm.diag" 2>/dev/null >&2 || true
@@ -1033,7 +1033,7 @@ rm -rf "$gcssdir"; mkdir -p "$gcssdir"
 for gcss_be in linear gc; do
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcss_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_sibling_slot_reuse.vibe" "$gcssdir/mixed.$gcss_be.wasm" main >/dev/null 2>&1
+    "fixtures/gc_sibling_slot_reuse.vibe" "$gcssdir/mixed.$gcss_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gcssdir/mixed.$gcss_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_sibling_slot_reuse.vibe did not compile on the $gcss_be backend (#1985)" >&2
     cat "$gcssdir/mixed.$gcss_be.wasm.diag" 2>/dev/null >&2 || true
@@ -1046,7 +1046,7 @@ for gcss_be in linear gc; do
   fi
   env -u VIBE_FS_COMPILE VIBE_BACKEND="$gcss_be" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/gc_nested_branch_locals.vibe" "$gcssdir/nested.$gcss_be.wasm" main >/dev/null 2>&1
+    "fixtures/gc_nested_branch_locals.vibe" "$gcssdir/nested.$gcss_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gcssdir/nested.$gcss_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_nested_branch_locals.vibe did not compile on the $gcss_be backend (#1985)" >&2
     cat "$gcssdir/nested.$gcss_be.wasm.diag" 2>/dev/null >&2 || true
@@ -1079,7 +1079,7 @@ gcstrdir="_build/_gate_gc_string_forin"
 rm -rf "$gcstrdir"; mkdir -p "$gcstrdir"
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/gc_for_in_string_test.vibe" "$gcstrdir/out.wasm" main >/dev/null 2>&1
+  "fixtures/gc_for_in_string_test.vibe" "$gcstrdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gcstrdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc String for-in fixture did not compile" >&2
   cat "$gcstrdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1106,7 +1106,7 @@ gcedir="_build/_gate_gc_evidence_dict"
 rm -rf "$gcedir"; mkdir -p "$gcedir"
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/gc_backend_effect_evidence_dict.vibe" "$gcedir/out.wasm" main >/dev/null 2>&1
+  "fixtures/gc_backend_effect_evidence_dict.vibe" "$gcedir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gcedir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc_backend_effect_evidence_dict.vibe did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcedir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1146,7 +1146,7 @@ rm -rf "$gcdeaddir"; mkdir -p "$gcdeaddir"
 # does not force one.
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_local_closure_by_value_wrapper.vibe "$gcdeaddir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_local_closure_by_value_wrapper.vibe "$gcdeaddir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcdeaddir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_wrapper.vibe did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcdeaddir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1187,7 +1187,7 @@ gcselfdir="_build/_gate_gc_self_discharge"
 rm -rf "$gcselfdir"; mkdir -p "$gcselfdir"
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_effectset_expansion.vibe "$gcselfdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_effectset_expansion.vibe "$gcselfdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcselfdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe did not compile under VIBE_BACKEND=gc (self-discharging drop or #1595 call-inertness regressed)" >&2
   cat "$gcselfdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1224,7 +1224,7 @@ for sdc_backend in "" gc; do
   rm -f "$sdcdir/out.wasm" "$sdcdir/out.wasm.diag"
   env ${sdc_backend:+VIBE_BACKEND="$sdc_backend"} VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    fixtures/effect_self_discharging_callee.vibe "$sdcdir/out.wasm" __no_entry__ >/dev/null 2>&1
+    fixtures/effect_self_discharging_callee.vibe "$sdcdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$sdcdir/out.wasm" ]; then
     echo "[compiler-gate] FAIL: effect_self_discharging_callee.vibe did not compile${sdc_backend:+ under VIBE_BACKEND=$sdc_backend} (#1595 call-inertness regressed)" >&2
     cat "$sdcdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1284,7 +1284,7 @@ rm -rf "$gcclosdir"; mkdir -p "$gcclosdir"
 # actual/expected and fails the run.
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_closure_literal.vibe "$gcclosdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_closure_literal.vibe "$gcclosdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcclosdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_closure_literal.vibe did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcclosdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1316,7 +1316,7 @@ rm -rf "$gcidxdir"; mkdir -p "$gcidxdir"
 # actual/expected and fails the run.
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/gc_backend_effect_pure_builtin_index.vibe "$gcidxdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/gc_backend_effect_pure_builtin_index.vibe "$gcidxdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcidxdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc_backend_effect_pure_builtin_index.vibe did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcidxdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1346,7 +1346,7 @@ rm -rf "$gcsuberrdir"; mkdir -p "$gcsuberrdir"
 # actual/expected and fails the run.
 VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/gc_backend_suberror_ctor.vibe "$gcsuberrdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/gc_backend_suberror_ctor.vibe "$gcsuberrdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcsuberrdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc_backend_suberror_ctor.vibe did not compile under VIBE_BACKEND=gc" >&2
   cat "$gcsuberrdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1494,7 +1494,7 @@ witdir="_build/_gate_wit"
 rm -rf "$witdir"; mkdir -p "$witdir"
 VIBE_EMIT_WIT=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/wit_gen_http.vibe" "$witdir/out.wit" main >/dev/null 2>&1
+  "fixtures/wit_gen_http.vibe" "$witdir/out.wit" main >/dev/null 2>&1 || true
 if [ ! -s "$witdir/out.wit" ]; then
   echo "[compiler-gate] FAIL: VIBE_EMIT_WIT produced no output" >&2
   cat "$witdir/out.wit.diag" 2>/dev/null >&2 || true
@@ -1520,7 +1520,7 @@ rm -rf "$svdir"; mkdir -p "$svdir"
 VIBE_SERVE_COMPONENT=1 VIBE_SERVE_WIT_OUT="$svdir/handler.wit" \
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/serve_handler_smoke.vibe" "$svdir/handler.component.wasm" main >/dev/null 2>&1
+  "fixtures/serve_handler_smoke.vibe" "$svdir/handler.component.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$svdir/handler.component.wasm" ]; then
   echo "[compiler-gate] FAIL: VIBE_SERVE_COMPONENT produced no component" >&2
   cat "$svdir/handler.component.wasm.diag" 2>/dev/null >&2 || true
@@ -1585,7 +1585,7 @@ rm -rf "$gcbdir"; mkdir -p "$gcbdir"
 for gcb_fixture in to_string_bool_gc_test to_string_shadow_gc_test to_string_bool_scope_gc_test to_string_float_scope_gc_test; do
   VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "fixtures/${gcb_fixture}.vibe" "$gcbdir/${gcb_fixture}.wasm" __no_entry__ >/dev/null 2>&1
+    "fixtures/${gcb_fixture}.vibe" "$gcbdir/${gcb_fixture}.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcbdir/${gcb_fixture}.wasm" ]; then
     echo "[compiler-gate] FAIL: gc-lane regression fixture ${gcb_fixture}.vibe did not compile" >&2
     cat "$gcbdir/${gcb_fixture}.wasm.diag" 2>/dev/null >&2 || true
@@ -1625,7 +1625,7 @@ rm -rf "$m2dir"; mkdir -p "$m2dir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_replay_corruption.vibe "$m2dir/m2.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_replay_corruption.vibe "$m2dir/m2.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$m2dir/m2.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_replay_corruption.vibe did not compile" >&2
   cat "$m2dir/m2.wasm.diag" 2>/dev/null >&2 || true
@@ -1658,7 +1658,7 @@ a71dir="_build/_gate_effectset_row_item"
 rm -rf "$a71dir"; mkdir -p "$a71dir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_row_operation_item.vibe "$a71dir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_row_operation_item.vibe "$a71dir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$a71dir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_row_operation_item.vibe did not compile (with Effect::op row-item grammar regressed, or #1595 self-discharging call-inertness regressed)" >&2
   cat "$a71dir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1693,7 +1693,7 @@ a71bdir="_build/_gate_effectset_expand"
 rm -rf "$a71bdir"; mkdir -p "$a71bdir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_effectset_expansion.vibe "$a71bdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_effectset_expansion.vibe "$a71bdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$a71bdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe did not compile -- effectset row expansion regressed" >&2
   cat "$a71bdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1773,7 +1773,7 @@ a71ddir="_build/_gate_effectset_param_expand"
 rm -rf "$a71ddir"; mkdir -p "$a71ddir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_effectset_param_expansion.vibe "$a71ddir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_effectset_param_expansion.vibe "$a71ddir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$a71ddir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_effectset_param_expansion.vibe did not compile -- parameter-type effectset expansion regressed" >&2
   cat "$a71ddir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1808,7 +1808,7 @@ rm -rf "$a71edir"; mkdir -p "$a71edir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_operation_level_discharge.vibe "$a71edir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_operation_level_discharge.vibe "$a71edir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$a71edir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_operation_level_discharge.vibe did not compile -- handler operation-level discharge regressed" >&2
   cat "$a71edir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1839,7 +1839,7 @@ a71fdir="_build/_gate_effectset_contract"
 rm -rf "$a71fdir"; mkdir -p "$a71fdir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/contract_effectset_vpkg_main.vibe" "$a71fdir/out.wasm" main >/dev/null 2>&1
+  "fixtures/contract_effectset_vpkg_main.vibe" "$a71fdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$a71fdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: contract_effectset_vpkg_main.vibe did not compile -- effectset contract passthrough regressed" >&2
   cat "$a71fdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1870,7 +1870,7 @@ a71gdir="_build/_gate_effectset_sig_alias"
 rm -rf "$a71gdir"; mkdir -p "$a71gdir"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/contract_effectset_signature_alias_main.vibe" "$a71gdir/out.wasm" main >/dev/null 2>&1
+  "fixtures/contract_effectset_signature_alias_main.vibe" "$a71gdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$a71gdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: contract_effectset_signature_alias_main.vibe did not compile -- effectset-aware contract signature matching regressed" >&2
   cat "$a71gdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1902,7 +1902,7 @@ witesdir="_build/_gate_wit_effectset"
 rm -rf "$witesdir"; mkdir -p "$witesdir"
 VIBE_EMIT_WIT=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "fixtures/wit_gen_effectset.vibe" "$witesdir/out.wit" main >/dev/null 2>&1
+  "fixtures/wit_gen_effectset.vibe" "$witesdir/out.wit" main >/dev/null 2>&1 || true
 if [ ! -s "$witesdir/out.wit" ]; then
   echo "[compiler-gate] FAIL: VIBE_EMIT_WIT produced no output for wit_gen_effectset.vibe" >&2
   cat "$witesdir/out.wit.diag" 2>/dev/null >&2 || true
@@ -1934,7 +1934,7 @@ rm -rf "$edpdir"; mkdir -p "$edpdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence.vibe "$edpdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence.vibe "$edpdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence.vibe did not compile" >&2
   cat "$edpdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -1974,7 +1974,7 @@ rm -rf "$edpbdir"; mkdir -p "$edpbdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_branch.vibe "$edpbdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_branch.vibe "$edpbdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpbdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_branch.vibe did not compile" >&2
   cat "$edpbdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2010,7 +2010,7 @@ rm -rf "$edpemdir"; mkdir -p "$edpemdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_error_mix.vibe "$edpemdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_error_mix.vibe "$edpemdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpemdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_error_mix.vibe did not compile" >&2
   cat "$edpemdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2051,7 +2051,7 @@ rm -rf "$edpmedir"; mkdir -p "$edpmedir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_multi_effect_row_nested.vibe "$edpmedir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_multi_effect_row_nested.vibe "$edpmedir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpmedir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_multi_effect_row_nested.vibe did not compile" >&2
   cat "$edpmedir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2082,7 +2082,7 @@ rm -rf "$edpnhdir"; mkdir -p "$edpnhdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_multi_effect_nested_handles.vibe "$edpnhdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_multi_effect_nested_handles.vibe "$edpnhdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpnhdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_multi_effect_nested_handles.vibe did not compile" >&2
   cat "$edpnhdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2128,7 +2128,7 @@ rm -rf "$edpletdir"; mkdir -p "$edpletdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_let_bound.vibe "$edpletdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_let_bound.vibe "$edpletdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpletdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_let_bound.vibe did not compile" >&2
   cat "$edpletdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2162,7 +2162,7 @@ rm -rf "$edppurdir"; mkdir -p "$edppurdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_pure_helper.vibe "$edppurdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_pure_helper.vibe "$edppurdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edppurdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_pure_helper.vibe did not compile" >&2
   cat "$edppurdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2195,7 +2195,7 @@ rm -rf "$edpdotdir"; mkdir -p "$edpdotdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_struct_field.vibe "$edpdotdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_struct_field.vibe "$edpdotdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpdotdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_struct_field.vibe did not compile" >&2
   cat "$edpdotdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2229,7 +2229,7 @@ rm -rf "$edpclodir"; mkdir -p "$edpclodir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_closure_literal.vibe "$edpclodir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_closure_literal.vibe "$edpclodir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpclodir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_closure_literal.vibe did not compile" >&2
   cat "$edpclodir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2269,7 +2269,7 @@ rm -rf "$edpesdir"; mkdir -p "$edpesdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_effectset_alias.vibe "$edpesdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_effectset_alias.vibe "$edpesdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpesdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_effectset_alias.vibe did not compile" >&2
   cat "$edpesdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2298,7 +2298,7 @@ rm -rf "$edpqodir"; mkdir -p "$edpqodir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_qualified_op.vibe "$edpqodir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_qualified_op.vibe "$edpqodir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpqodir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_qualified_op.vibe did not compile" >&2
   cat "$edpqodir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2329,7 +2329,7 @@ rm -rf "$edprvdir"; mkdir -p "$edprvdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_row_variable_tail.vibe "$edprvdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_row_variable_tail.vibe "$edprvdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edprvdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_row_variable_tail.vibe did not compile" >&2
   cat "$edprvdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2362,7 +2362,7 @@ rm -rf "$edplccfdir"; mkdir -p "$edplccfdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_handle_call_evidence_local_closure_capture_free.vibe "$edplccfdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_handle_call_evidence_local_closure_capture_free.vibe "$edplccfdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edplccfdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_local_closure_capture_free.vibe did not compile" >&2
   cat "$edplccfdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2395,7 +2395,7 @@ rm -rf "$lcccdir"; mkdir -p "$lcccdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_local_closure_capture_conversion.vibe "$lcccdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_local_closure_capture_conversion.vibe "$lcccdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$lcccdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_capture_conversion.vibe did not compile" >&2
   cat "$lcccdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2427,7 +2427,7 @@ rm -rf "$lcbvwdir"; mkdir -p "$lcbvwdir"
 # for this same fixture above).
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_local_closure_by_value_wrapper.vibe "$lcbvwdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_local_closure_by_value_wrapper.vibe "$lcbvwdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$lcbvwdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_wrapper.vibe did not compile" >&2
   cat "$lcbvwdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2459,7 +2459,7 @@ rm -rf "$lcwrvdir"; mkdir -p "$lcwrvdir"
 # actual vs expected from inside the run, so the output is surfaced on failure.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_local_closure_wrapper_referenced_as_value.vibe "$lcwrvdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_local_closure_wrapper_referenced_as_value.vibe "$lcwrvdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$lcwrvdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_wrapper_referenced_as_value.vibe did not compile" >&2
   cat "$lcwrvdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2489,7 +2489,7 @@ rm -rf "$lcwadir"; mkdir -p "$lcwadir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/local_closure_wrapper_wrong_arity_not_inlined.vibe "$lcwadir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/local_closure_wrapper_wrong_arity_not_inlined.vibe "$lcwadir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$lcwadir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: local_closure_wrapper_wrong_arity_not_inlined.vibe did not compile" >&2
   cat "$lcwadir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2526,7 +2526,7 @@ rm -rf "$illhadir"; mkdir -p "$illhadir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_inline_lambda_literal_hof_arg.vibe "$illhadir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_inline_lambda_literal_hof_arg.vibe "$illhadir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$illhadir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_inline_lambda_literal_hof_arg.vibe did not compile" >&2
   cat "$illhadir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2555,7 +2555,7 @@ rm -rf "$illladir"; mkdir -p "$illladir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_inline_lambda_literal_labeled_arg.vibe "$illladir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_inline_lambda_literal_labeled_arg.vibe "$illladir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$illladir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_inline_lambda_literal_labeled_arg.vibe did not compile" >&2
   cat "$illladir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2585,7 +2585,7 @@ rm -rf "$dtpwsdir"; mkdir -p "$dtpwsdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/dtpw_wrapper_shadowed_by_parameter.vibe "$dtpwsdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/dtpw_wrapper_shadowed_by_parameter.vibe "$dtpwsdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$dtpwsdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: dtpw_wrapper_shadowed_by_parameter.vibe did not compile" >&2
   cat "$dtpwsdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2617,7 +2617,7 @@ rm -rf "$edpsdir"; mkdir -p "$edpsdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/evidence_dict_needing_shadowed_by_local.vibe "$edpsdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/evidence_dict_needing_shadowed_by_local.vibe "$edpsdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpsdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: evidence_dict_needing_shadowed_by_local.vibe did not compile" >&2
   cat "$edpsdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2656,7 +2656,7 @@ rm -rf "$edpgdir"; mkdir -p "$edpgdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_local_closure_by_value_hof_general.vibe "$edpgdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_local_closure_by_value_hof_general.vibe "$edpgdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpgdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_hof_general.vibe did not compile" >&2
   cat "$edpgdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2689,7 +2689,7 @@ rm -rf "$edpedir"; mkdir -p "$edpedir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_local_closure_by_value_hof_escaping.vibe "$edpedir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_local_closure_by_value_hof_escaping.vibe "$edpedir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpedir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_hof_escaping.vibe did not compile" >&2
   cat "$edpedir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2713,7 +2713,7 @@ rm -rf "$cbvsdir"; mkdir -p "$cbvsdir"
 for cbvs_rc in 1 0; do
   VIBE_RC="$cbvs_rc" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    fixtures/closure_by_value_store_test.vibe "$cbvsdir/out.wasm" __no_entry__ >/dev/null 2>&1
+    fixtures/closure_by_value_store_test.vibe "$cbvsdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$cbvsdir/out.wasm" ]; then
     echo "[compiler-gate] FAIL: closure_by_value_store_test.vibe did not compile under VIBE_RC=$cbvs_rc" >&2
     cat "$cbvsdir/out.wasm.diag" 2>/dev/null >&2 || true
@@ -2749,7 +2749,7 @@ rm -rf "$edphdir"; mkdir -p "$edphdir"
 # actual/expected and fails the run.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  fixtures/effect_local_closure_handle_owner_param.vibe "$edphdir/out.wasm" __no_entry__ >/dev/null 2>&1
+  fixtures/effect_local_closure_handle_owner_param.vibe "$edphdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edphdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_handle_owner_param.vibe did not compile" >&2
   cat "$edphdir/out.wasm.diag" 2>/dev/null >&2 || true


### PR DESCRIPTION
Closes #2107.

Found while measuring #2100/#2101 — "who owns the hello print verb, and what row does it carry" had an answer nobody would want.

## Symptom

```vibe
fn shout(s: String) -> Unit {
  println(s)
}

fn main with () {
  shout("leaked from a pure entry")
}
```

```console
$ vibe check leak.vibex; echo $?
0
$ vibe run leak.vibex
leaked from a pure entry
```

An entry declared **pure** prints, with no import, no row, and no diagnostic.

## Mechanism — two parts, and the second is the real one

**The registry row was wrong.** `builtin_registry.vibe` declared `println`/`print` as `CtFn(..., None)` — the "pure" spelling `assert` and `map_has` carry — while codegen lowers both onto `Stdout::write_stream` / `Stdout::write_char` (#929) and `builtin_purity` already classified them impure. The checker held the weakest of the three claims, and the checker decides what compiles.

**Fixing that row changed nothing.** `builtin_call_effect` answers `None` for any callee without `::` *without consulting the registry*, deliberately — that lookup is a linear scan over ~450 rows and would run on every call in the program. The unqualified builtins that are effectful were listed by hand, under a comment stating the invariant the list depended on: "`sh`/`sh_lines` and the checker_visible `vibe_*_raw` dunder builtins are the only UNQUALIFIED effectful builtins."

Derived from the registry there are **20**. The list named **8**.

| builtin | row it carries |
|---|---|
| `vibe_fs_stat_token_raw` | `Fs` |
| `vibe_tcp_connect_raw` / `_read_` / `_write_` / `_close_raw` | `Socket` |
| `vibe_http_request_raw` / `_response_status_` / `_response_header_` / `_response_body_` / `_close_raw` | `Http` |
| `println`, `print` | `Stdout` |
| `sleep` | `Async` — correctly excluded (entry-runtime-managed) |

Measured on `24beb69`, each called from a function declaring no row:

```
tcp_connect  : 0 diagnostic(s)
http_request : 0 diagnostic(s)
fs_stat_token: 0 diagnostic(s)
Fs::read_file: 1 diagnostic(s)   <- the qualified control, correctly rejected
```

So a row-free function could open a TCP connection, drive it, and make an outbound HTTP request. `Socket` and `Http` are capabilities the `--allow-*` const-fold + DCE story is built around, and they were reachable from a signature mentioning neither.

## Fix

1. the registry rows for `println` / `print` say `Stdout`;
2. `unqualified_builtin_effect` is now the complete list, consulted **before** the fast path, so that path keeps the cost profile it exists for;
3. a source definition of a builtin's name wins, lexical or top-level — codegen already resolves one ahead of its builtin lowering (`cc_ft_has`, #929), and requiring the builtin's row at every call site would force `with Stdout` on callers of a user function that merely reuses the name.

`builtin_registry_unqualified_row_test.vibe` does not restate the list: it **derives** the set from the registry and asserts, per entry, that calling it without a row is an effect row mismatch and that declaring the label the registry names satisfies it. A new unqualified effectful builtin fails it by name, with the file to edit in the message. `print_builtin_row_test.vibe` pins the reported shapes, the shadow rule, and that `inspect` still expands without an import. Both files were checked Red.

## Four more real defects the fix exposed

Each was a place where something printed without saying so, or where two lanes disagreed. None was introduced here.

1. **`@vibe/core`'s `inspect` printed from a row-free signature** — it reads as a pure assertion and is not. Caught by the gate's store-install E2E.
2. **The CLI entry printed from `with Fs + Env`** — `run_cli_main_with_args`'s Exception arm prints the thrown diagnostic (#1888). The program that reports every compile error in this toolchain reached the console undeclared. The selfhost gate never sees it: the self-build compiles the flat merged source and does not take that file through the FS-compile lane.
3. **The gc lane's `test` blocks never got the ambient test effect set.** `compile_source_gc_only` lowers `test "x" { .. }` to `let __test_x = ..` BEFORE the check, and the checker's grant (`test_ambient_effects`) is keyed off the STest node. Reordering to check-first fixes that and breaks `handle` eligibility (ADR-0076 wants a named top-level `fn`, which a test block only becomes after lowering — gate step 40h4). So the lowering keeps its order and the checker learns the lowered shape: `lowered_test_ambient_effects` grants the same row to `__test_*` / `__bench_*`, keyed on the name because writing the row onto the synthesized function changes what codegen reads.
4. **`assert_eq` expands to a `println` call**, so it requires `Stdout` in the function containing it. Honest, and the same rule `inspect` follows; of ~1300 assertion sites all but a handful are inside `test`/`bench` blocks, which are granted the row.

The one alternative that looked cleaner does not exist: `print_str`, the registry's codegen-internal printer, takes the string as two wasm params and is `checker_visible=false`, so a vibe-level call to it is `unknown name` at the checker (CI caught that on both lanes). Introducing a rowless vibe-callable printer to keep the assertion branch quiet would reopen this escape one dunder away.

## Sweep

The remaining commits declare `Stdout` where a program in this repository prints from a row-free function. Done by scanning for the shape — all four spellings, since `inspect(..)` and `assert_eq(..)` reach `println` through a desugar — rather than one gate step at a time:

* fixtures, four of which also needed `inspect` hoisted out of a `handle` body (a call to a row-carrying callee inside a handled body is not eligible for the direct-perform lowering — measured: rowless compiles, rowless generic compiles, `with Stdout` does not);
* gate heredocs in `tests/gates/{early,late}/run.sh`, including one where the row also had to go on an enum payload's function TYPE;
* `bench/exec/*` and `bench/binary_size/*`;
* embedded source strings in compiler tests, and test helpers called from `test` blocks — the ambient grant stops at the block.

One of those mattered beyond compiling: `fixtures/interp_function_return_missing_show_error.vibe` is a NEGATIVE fixture that was still rejected, but on the row instead of on ``cannot interpolate a value of type `Hidden` `` — a masked assertion is a silently weakened test.

## Docs slice for #2100 / #2101

The cheatsheet hello was six lines, four of them apologising for the import. It is now:

```vibe
fn main with Stdout {
  println("hello world")
}
```

Import-free (#2100) and spelled `println` (#2101) — the first slice both issues asked for, and honest only because of the row fix. `stdout_write` keeps compiling. Neither issue is closed here: #2100's availability rule and #2102's namespace cut are still open questions, and this only moves what the docs teach.

## Verification (final tree, `d8eea4f`)

| check | result |
|---|---|
| `scripts/compiler_gate.sh` (incl. stage2/stage3 fixpoint) | **ok** |
| `scripts/unit_test_runner.sh` | **986/986** files passed |
| `scripts/check_vibe_fmt.sh` | 998 files, 0 violations |
| doctest (stage2 from this checkout, required) | 122 blocks, 0 fail |
| `vibe_md.sh check` (book/src + book/ja) | 94 blocks, 0 fail |
| examples typecheck | 16 examples, 0 new failures |
| tutorial translation parity | ok (20 chapters) |
| `vibe_fmt_smoke.sh` / `vibe_test_smoke.sh` | ok |

Two things are red in this sandbox and reproduce identically on the base commit, so they are not from this change: `pkf run release-check` dies early because nix's `LD_LIBRARY_PATH` breaks `/usr/bin/sort` under `pkf` (the same scripts pass run directly), and `lint_method_style_naming.sh` reports the same 49 pre-existing violations on `main`.