### PR TITLE
fix(checker): give the structural type errors that had an offset all along (#1941)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -5805,7 +5805,9 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         CtBool => (),
         CtUnknown => (),
         CtVar(_) => (),
-        _ => Array::push(errors, "if condition must be Bool")
+        // Anchor on the CONDITION, not the `if`: that is the expression whose
+        // type is wrong, and it is what the reader has to change (#1941).
+        _ => Array::push(errors, String::concat("if condition must be Bool", off_marker(railway_expr_off(cond))))
       }
       let (tt, s2, c2) = check_expr_capture(then_e, env, defs, s1, c1, errors, tytab, capture, lane)
       let (et, s3, c3) = check_expr_capture(else_e, env, defs, s2, c2, errors, tytab, capture, lane)
@@ -5825,7 +5827,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         CtUnit => (s3, CtUnit),
         _ => match ret {
           CtUnit => (s3, CtUnit),
-          _ => (check_assignable(rtt, ret, s3, errors, "if branches have incompatible types", 0 - 1), tt)
+          _ => (check_assignable(rtt, ret, s3, errors, "if branches have incompatible types", railway_expr_off(else_e)), tt)
         }
       }
       (if_ty, s3b, c3)
@@ -9033,7 +9035,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           }
         } else {
           if check_elems {
-            s1 = check_assignable(elem_ty, subst_apply(s1, it), s1, errors, "array elements have incompatible types", 0 - 1)
+            s1 = check_assignable(elem_ty, subst_apply(s1, it), s1, errors, "array elements have incompatible types", railway_expr_off(Array::get(items, ai)))
           } else {
             ()
           }
@@ -9110,7 +9112,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           mchk_v = map_literal_ground(subst_apply(ms1, mvt))
         } else {
           if mchk_v {
-            ms1 = check_assignable(mvty, subst_apply(ms1, mvt), ms1, errors, "map literal values have incompatible types", 0 - 1)
+            ms1 = check_assignable(mvty, subst_apply(ms1, mvt), ms1, errors, "map literal values have incompatible types", railway_expr_off(mve))
           } else {
             ()
           }

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -1,0 +1,87 @@
+//# Structural type errors carry a source position (#1941 / #1567).
+//
+// The checker had two classes of unlocated diagnostic, and they need different
+// answers:
+//
+//   * the offset does not EXIST. `1 + "s"` has nowhere to point: `EInt` /
+//     `EString` / `EBool` / `EFloat` carry no offset slot in the AST
+//     (lib/@vibe/ast/index.vpkg), which is the same root cause that makes a
+//     `vibe grep` range a lower bound (ADR-0108). Fixing that is an AST change
+//     across ~6100 constructor sites, and `off_marker` correctly emits nothing
+//     rather than inventing a position.
+//   * the offset exists and nobody THREADED it. `if n { .. }` with `n: Int`
+//     reported `if condition must be Bool` with no position at all, even though
+//     the condition is an `EIdent` carrying its own offset.
+//
+// This file pins the second class. Every case here has an identifier operand,
+// so a missing position is a wiring bug and not the AST gap -- and each one
+// asserts the COLUMN, because "has a line:col" is satisfied by pointing at the
+// wrong token.
+//
+// Why it matters beyond tidiness: an unlocated diagnostic JSON-encodes as the
+// empty range `0:0-0:0` with `data.synthetic: true` (#2050). That is honest,
+// but it puts the editor's squiggle on character 1 of the file for some of the
+// most common mistakes in the language.
+
+//# Imports
+
+import @vibe/compiler/runtime {
+  collect_all_diagnostics
+}
+
+//# Misc
+
+fn first_diag(src: String) -> String with Exception {
+  let d = collect_all_diagnostics(src)
+  if Array::length(d) == 0 {
+    ""
+  } else {
+    Array::get(d, 0)
+  }
+}
+
+/// `true` when the first diagnostic carries exactly `line <line>:<col>`.
+fn anchored_at(src: String, line: Int, col: Int) -> Bool with Exception {
+  String::contains(first_diag(src), "line \{line}:\{col}")
+}
+
+//# Tests
+
+test "an if condition that is not Bool points at the condition" {
+  //     1234567
+  //   `  if n {` -- `n` is column 6.
+  let src = "fn f() -> Int {\n  let n = 1\n  if n { 2 } else { 3 }\n}\n"
+  assert(String::contains(first_diag(src), "if condition must be Bool"))
+  assert(anchored_at(src, 3, 6))
+}
+
+test "mismatched if branches point at the else branch" {
+  // The `then` type is the expectation and `else` is checked against it, so
+  // the else arm is the operand that disagrees.
+  let src = "fn f() -> Bool {\n  let n = 1\n  let s = \"x\"\n  if true { n } else { s }\n}\n"
+  assert(String::contains(first_diag(src), "if branches have incompatible types"))
+  assert(anchored_at(src, 4, 24))
+}
+
+test "an incompatible array element points at that element" {
+  let src = "fn f() -> Int {\n  let s = \"x\"\n  let a = [1, s]\n  1\n}\n"
+  assert(String::contains(first_diag(src), "array elements have incompatible types"))
+  assert(anchored_at(src, 3, 15))
+}
+
+test "an incompatible map value points at that value" {
+  let src = "fn f() -> Int {\n  let s = \"x\"\n  let m = Map::from_pairs([(\"a\", 1), (\"b\", s)])\n  1\n}\n"
+  assert(String::contains(first_diag(src), "map literal values have incompatible types"))
+  assert(anchored_at(src, 3, 44))
+}
+
+test "a literal operand still reports without a position, and says nothing false" {
+  // The AST gap, pinned as the boundary of the fix above. `off_marker` emits
+  // nothing for -1, so the message is exactly what it was -- no `line 0:0`, no
+  // guessed anchor. If this case ever GAINS a position, literals grew offsets
+  // and the comment at the top of this file needs rewriting.
+  let src = "fn f() -> Int {\n  if 1 { 2 } else { 3 }\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if condition must be Bool"))
+  assert(!String::contains(d, "line "))
+}


### PR DESCRIPTION
`vibe check` reports some type errors with a position and some with none, and the split is not the one you would guess.

Measured on main — every operand below is an `EIdent` carrying its own offset:

| program | diagnostic |
|---|---|
| `if n { .. }` where `n: Int` | `if condition must be Bool` — **no position** |
| `[1, s]` where `s: String` | `array elements have incompatible types` — **no position** |
| `if c { n } else { s }` | `if branches have incompatible types` — **no position** |
| `Map::from_pairs([.., ("b", s)])` | `map literal values have incompatible types` — **no position** |

The diagnostics simply never asked for the offset. `if condition must be Bool` was pushed as a bare string; the other three passed a literal `0 - 1` as `check_assignable`'s anchor. **16 of the 36 `check_assignable` call sites still do.**

## After

```
line 3:6:  if condition must be Bool
line 3:15: array elements have incompatible types: expected Int, got String
line 4:24: if branches have incompatible types: expected Int, got String
line 3:44: map literal values have incompatible types: expected Int, got String
```

Each anchors on the operand that is actually wrong — the condition, the offending element, the offending map value, and for mismatched `if` branches the **else** arm, since the `then` type is the expectation and `else` is what gets checked against it. Every test asserts the **column**, because "has a `line:col`" is satisfied by pointing at the wrong token.

## The boundary, pinned as its own test

This is the half of the problem that is wiring. The other half is not:

```vibe
if 1 { 2 } else { 3 }   // still reports with no position
```

`EInt` / `EString` / `EBool` / `EFloat` carry no offset slot in the AST at all — the same root cause that makes a `vibe grep` range a lower bound (ADR-0108), across ~6100 constructor sites. `off_marker` is right to emit nothing rather than invent a position, and a test asserts the message stays position-free so nobody "fixes" it with a guess. If that case ever gains a position, literals grew offsets and the file's header comment needs rewriting.

## Why it matters

An unlocated diagnostic JSON-encodes as the empty range `0:0-0:0` with `data.synthetic: true` (#2050). That is honest, but it puts the editor's squiggle on character 1 of the file for some of the most common mistakes in the language. CLAUDE.md lists this as a live violation of the CLI-as-query-surface policy ("型エラーに `line:col` が付かない").

## Verification

All against stage2 built from this checkout, not the seed:

- unit battery **988/988**
- gates **bootstrap / early / mid / late** green, `stage2 == stage3` fixpoint holds
- `check_vibe_fmt` 1000 files, 0 violations
- `fixtures/typecheck/expected.tsv` unaffected — its `if_condition_non_bool` fixture uses a literal condition, and rows match by needle

**Red confirmed by reverting `checker.vibe` alone.** Worth flagging: swapping `VIBE_TEST_CLI_WASM` does *not* establish Red here — the test imports `collect_all_diagnostics` from source, so it exercises the working tree whichever compiler wasm is passed. I checked that first and got a false green.

## About the perf report's non-zero rows

The perf comment shows small real drift, and it is input size rather than a regression:

| metric | Δ |
|---|---|
| `B/op parse_checker_vibe` | +0.04% |
| `B/op parse_only_checker_vibe` | +0.05% |
| flat module source bytes | +0.01% |

`probe_parse_checker_vibe` parses `lib/@vibe/compiler/checker/checker.vibe` literally — `parse_program_count(lex(Fs::read_file(...)))`. This PR grows that file from 412,889 to 413,164 bytes (**+0.067%**), so the bench allocates proportionally more for the extra tokens. Every fuel and heap number for actual program execution is ±0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe