### PR TITLE
fix(checker): five more diagnostics anchor on the value that is wrong (#1941)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -2607,6 +2607,26 @@ fn effect_is_declared(defs: Array[TypeDef], eff: String) -> Bool {
   }
 }
 
+/// Where the record literal WROTE the value for field `name`, or -1 when the
+/// field is absent or its value carries no offset (a literal -- see
+/// ADR-0108). The sibling of `lookup_actual_field_ty`: that one answers what
+/// type the literal gave a field, this one answers where to point when the
+/// answer is wrong.
+fn lookup_field_expr_off(fields: Array[(String, Expr)], name: String) -> Int {
+  let mut i = 0
+  let mut out = 0 - 1
+  while i < Array::length(fields) {
+    let (fname, fval) = Array::get(fields, i)
+    if fname == name {
+      out = tail_expr_off(fval)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 fn lookup_actual_field_ty(actual: Array[(String, Type)], name: String) -> Option[Type] {
   let mut i = 0
   let mut out = None
@@ -6614,7 +6634,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           let (obj_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
           let (val_ty, s2, c2) = check_expr_capture(Array::get(args, 1), env, defs, s1, c1, errors, tytab, capture, lane)
           let s3 = match subst_apply(s2, obj_ty) {
-            CtArray(elem) => check_assignable(subst_apply(s2, elem), subst_apply(s2, val_ty), s2, errors, "Array::push value type mismatch", 0 - 1),
+            CtArray(elem) => check_assignable(subst_apply(s2, elem), subst_apply(s2, val_ty), s2, errors, "Array::push value type mismatch", tail_expr_off(Array::get(args, 1))),
             _ => s2
           }
           (tab_call_ty(tytab, call_off, CtUnit, capture, lane), s3, c2)
@@ -6642,7 +6662,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             ()
           }
           let s4 = match subst_apply(s3, obj_ty) {
-            CtArray(elem) => check_assignable(subst_apply(s3, elem), subst_apply(s3, val_ty), s3, errors, "Array::set value type mismatch", 0 - 1),
+            CtArray(elem) => check_assignable(subst_apply(s3, elem), subst_apply(s3, val_ty), s3, errors, "Array::set value type mismatch", tail_expr_off(Array::get(args, 2))),
             _ => s3
           }
           (tab_call_ty(tytab, call_off, CtUnit, capture, lane), s4, c3)
@@ -7632,7 +7652,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       // The assigned value must be assignable to the variable's type
       // (previously unchecked — `y = "s"` for `let mut y = 1` was accepted).
       let s1b = match env_lookup(env, name) {
-        Some(var_ty) => check_assignable(var_ty, subst_apply(s1, vt), s1, errors, String::concat("assignment type mismatch for ", name), 0 - 1),
+        Some(var_ty) => check_assignable(var_ty, subst_apply(s1, vt), s1, errors, String::concat("assignment type mismatch for ", name), tail_expr_off(val)),
         None => s1
       }
       check_expr_capture(body, env, defs, s1b, c1, errors, tytab, capture, lane)
@@ -7746,7 +7766,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                   _ => if rk != 0 {
                     si
                   } else {
-                    check_assignable(result_ty, r2, si, errors, "match arms have incompatible types", 0 - 1)
+                    check_assignable(result_ty, r2, si, errors, "match arms have incompatible types", tail_expr_off(body))
                   }
                 }
               }
@@ -8921,7 +8941,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                 match lookup_actual_field_ty(field_tys, dn) {
                   Some(aty) => {
                     // Value type check (ground-gated like check_record_fields).
-                    s1 = check_assignable(dty, subst_apply(s1, aty), s1, errors, String::concat("struct field type mismatch for ", dn), 0 - 1)
+                    s1 = check_assignable(dty, subst_apply(s1, aty), s1, errors, String::concat("struct field type mismatch for ", dn), lookup_field_expr_off(fields, dn))
                   },
                   None => Array::push(errors, String::concat("missing field `", String::concat(dn, String::concat("` in construction of struct ", rn))))
                 }

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -85,3 +85,37 @@ test "a literal operand still reports without a position, and says nothing false
   assert(String::contains(d, "if condition must be Bool"))
   assert(!String::contains(d, "line "))
 }
+
+test "an incompatible struct field value points at that value" {
+  //   `  let p = P::{ x: s }` -- `s` is column 19.
+  let src = "struct P { x: Int }\n\nfn f() -> Int {\n  let s = \"a\"\n  let p = P::{ x: s }\n  1\n}\n"
+  assert(String::contains(first_diag(src), "struct field type mismatch for x"))
+  assert(anchored_at(src, 5, 19))
+}
+
+test "Array::push and Array::set point at the pushed/stored value" {
+  // Not at the array and not at the call: the array is fine, the value is
+  // what has the wrong type.
+  let push_src = "fn f() -> Int {\n  let a = [1]\n  let s = \"a\"\n  Array::push(a, s)\n  1\n}\n"
+  assert(String::contains(first_diag(push_src), "Array::push value type mismatch"))
+  assert(anchored_at(push_src, 4, 18))
+  let set_src = "fn f() -> Int {\n  let a = [1]\n  let s = \"a\"\n  Array::set(a, 0, s)\n  1\n}\n"
+  assert(String::contains(first_diag(set_src), "Array::set value type mismatch"))
+  assert(anchored_at(set_src, 4, 20))
+}
+
+test "mismatched match arms point at the arm body that disagrees" {
+  // Same shape as the `if` branches above: the first arm's type is the
+  // expectation, so the anchor belongs on the arm being checked against it.
+  let src = "fn f(n: Int) -> Int {\n  let s = \"a\"\n  match n {\n    0 => 1,\n    _ => s\n  }\n}\n"
+  assert(String::contains(first_diag(src), "match arms have incompatible types"))
+  assert(anchored_at(src, 5, 10))
+}
+
+test "an assignment of the wrong type points at the value, not the variable" {
+  // The `region escapes its scope` diagnostic one line above in the same
+  // EAssign arm already anchored this way; this one had been left at -1.
+  let src = "fn f() -> Int {\n  let mut n = 1\n  let s = \"a\"\n  n = s\n  n\n}\n"
+  assert(String::contains(first_diag(src), "assignment type mismatch for n"))
+  assert(anchored_at(src, 4, 7))
+}


### PR DESCRIPTION
Second slice of the audit #2113 started. Each of these reproduces with an **identifier** value, so the offset exists in the AST and was simply never passed to `check_assignable`.

| program | before | after |
|---|---|---|
| `P::{ x: s }` | `struct field type mismatch for x` | `line 5:19` |
| `Array::push(a, s)` | `Array::push value type mismatch` | `line 4:18` |
| `Array::set(a, 0, s)` | `Array::set value type mismatch` | `line 4:20` |
| `match n { _ => s }` | `match arms have incompatible types` | `line 5:10` |
| `n = s` | `assignment type mismatch for n` | `line 4:7` |

Every column lands on `s`. The tests assert the **column**, not the presence of a `line:` prefix — pointing at the wrong token satisfies the weaker check.

## Two anchor choices worth stating

**`match` arms anchor on the arm body being checked**, matching what #2113 did for `if` branches: the first arm's type is the expectation, so the diagnostic belongs on the arm that disagrees with it, not on the `match`.

**`Array::push` / `Array::set` anchor on the value**, not the array and not the call. The array is fine; the value is what has the wrong type.

## The clearest oversight

The assignment case had the answer sitting three lines above it in the same `EAssign` arm:

```vibe
Array::push(errors, String::concat("region escapes its scope: ...", off_marker(tail_expr_off(val))))
...
Some(var_ty) => check_assignable(var_ty, ..., 0 - 1),   // <- this one
```

Same `val`, same arm, one anchored and one not.

`lookup_field_expr_off` is new and is the sibling of the existing `lookup_actual_field_ty`: that one answers what type a record literal gave a field, this one answers where the field was written.

## What is left, and why it is a different job

**Eight `check_assignable` sites still pass `-1`** (13 → 8 with this PR). They are not the same shape: `check_field_assignability` and the array/tuple element helpers take *types* with no expression in scope, so locating them means threading an anchor through a helper signature rather than reading one that is already there. Left for a slice that can do that deliberately, rather than smuggled in here.

Separately, the literal case remains unlocatable at any of these sites — `EInt` / `EString` / `EBool` / `EFloat` carry no offset slot in the AST (ADR-0108), pinned by the boundary test #2113 added.

## Verification

Against stage2 built from this checkout:

- `diagnostic_anchor_test.vibe` **9/9**, with all five new columns hand-checked against the source text
- **Red confirmed** by reverting `checker.vibe` alone. As in #2113, swapping `VIBE_TEST_CLI_WASM` does *not* establish Red — the test imports `collect_all_diagnostics` from source, so it exercises the working tree whichever compiler wasm is passed.
- full unit battery + all four gates running locally; CI is the authority and this PR should not merge before it is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_