### PR TITLE
fix(checker): the effect-shaped diagnostics anchor too (#1941)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4549,7 +4549,7 @@ fn field_write_mut_check(name: String, args: Array[Expr], env: TypeEnv, defs: Ar
                   // the CONCRETE field type; a non-applied receiver keeps the
                   // raw (rigid) type, which check_assignable tolerates.
                   let inst_fty = inst_struct_field_ty(fty, s_tparams, recv_targs)
-                  let _ = check_assignable(subst_apply(s, inst_fty), subst_apply(s, val_ty), s, errors, String::concat("type mismatch writing field `", String::concat(field, "`")), 0 - 1)
+                  let _ = check_assignable(subst_apply(s, inst_fty), subst_apply(s, val_ty), s, errors, String::concat("type mismatch writing field `", String::concat(field, "`")), tail_expr_off(Array::get(args, 2)))
                   ()
                 } else {
                   ()
@@ -5658,7 +5658,7 @@ fn check_resume_values(e: Expr, ret_ty: Type, env: TypeEnv, defs: Array[TypeDef]
           // `Print(s) => resume(0)` for `Print(String) -> Unit` stays legal).
           if nm == "resume" && !resume_shadowed && Array::length(args) == 1 && !(ret_ty is CtUnit) {
             let (aty, ns, _) = check_expr_capture(Array::get(args, 0), env, defs, s1, c, errors, tytab, capture, "AuxiliaryResumeValueRecheck")
-            s1 = check_assignable(ret_ty, subst_apply(ns, aty), ns, errors, "resume value type mismatch", 0 - 1)
+            s1 = check_assignable(ret_ty, subst_apply(ns, aty), ns, errors, "resume value type mismatch", tail_expr_off(Array::get(args, 0)))
           } else if nm == "resume" && !resume_shadowed && Array::length(args) == 0 && !(ret_ty is CtUnit) {
             // #828: `resume()` on a value-returning op used to reach codegen,
             // which indexes resume args[0] unconditionally — a compiler ICE
@@ -6759,7 +6759,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           let (fn_ty, s3, c3) = check_expr_capture(Array::get(args, 2), env, defs, s2, c2, errors, tytab, capture, lane)
           let s4 = match subst_apply(s3, fn_ty) {
             CtFn(ptys, _, _) => if Array::length(ptys) >= 1 {
-              check_assignable(subst_apply(s3, Array::get(ptys, 0)), subst_apply(s3, init_ty), s3, errors, "Array::fold accumulator type mismatch", 0 - 1)
+              check_assignable(subst_apply(s3, Array::get(ptys, 0)), subst_apply(s3, init_ty), s3, errors, "Array::fold accumulator type mismatch", tail_expr_off(Array::get(args, 1)))
             } else {
               s3
             },
@@ -8111,7 +8111,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                   if hres_now is CtUnknown {
                     hres = harm_now
                   } else {
-                    hs1 = check_assignable(hres_now, harm_now, hs1, errors, "handler arm value type mismatch with the handle body's type", 0 - 1)
+                    hs1 = check_assignable(hres_now, harm_now, hs1, errors, "handler arm value type mismatch with the handle body's type", tail_expr_off(hbody))
                   }
                   // resume(x): x must be assignable to the op's declared
                   // return type (ground-gated). Throwaway walk — nested
@@ -8154,7 +8154,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               if eres_now is CtUnknown {
                 hres = earm_now
               } else {
-                hs1 = check_assignable(eres_now, earm_now, hs1, errors, "handler arm value type mismatch with the handle body's type", 0 - 1)
+                hs1 = check_assignable(eres_now, earm_now, hs1, errors, "handler arm value type mismatch with the handle body's type", tail_expr_off(hbody))
               }
             } else {
               ()

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -119,3 +119,42 @@ test "an assignment of the wrong type points at the value, not the variable" {
   assert(String::contains(first_diag(src), "assignment type mismatch for n"))
   assert(anchored_at(src, 4, 7))
 }
+
+//# Effect-shaped sites (#1941, third slice)
+
+/// `handle { f() } with Ask { Get => <arm> }` where `f` performs `Ask::Get`.
+/// The three cases below differ only in the arm, so a column difference is
+/// the arm's, not the scaffolding's.
+fn handled(arm: String) -> String {
+  "effect Ask {\n  Get -> Int\n}\n\nfn f() -> Int with Ask::Get {\n  perform Ask::Get\n}\n\nfn g() -> Int {\n  let s = \"a\"\n  handle {\n    f()\n  } with Ask {\n    Get => \{arm}\n  }\n}\n"
+}
+
+test "a resumed value of the wrong type points at the resume argument" {
+  //   `    Get => resume(s)` -- `s` is column 19.
+  let src = handled("resume(s)")
+  assert(String::contains(first_diag(src), "resume value type mismatch"))
+  assert(anchored_at(src, 14, 19))
+}
+
+test "a handler arm's own value points at the arm body" {
+  // Not at `Get` and not at the `handle`: the arm's VALUE is what fails to
+  // agree with the handle body's type.
+  let src = handled("s")
+  assert(String::contains(first_diag(src), "handler arm value type mismatch"))
+  assert(anchored_at(src, 14, 12))
+}
+
+test "writing a struct field points at the written value" {
+  let src = "struct P { mut x: Int }\n\nfn f(p: P) -> Int {\n  let s = \"a\"\n  p.x = s\n  1\n}\n"
+  assert(String::contains(first_diag(src), "type mismatch writing field `x`"))
+  assert(anchored_at(src, 5, 9))
+}
+
+test "Array::fold points at the initial accumulator, not the callback" {
+  // `check_assignable(expected = the callback's first param type, actual =
+  // init's type)`, so `init` is the operand under test -- same rule as every
+  // other case in this file, and it is the argument a reader would change.
+  let src = "fn f() -> Int {\n  let a = [1]\n  let n = 0\n  Array::fold(a, n, (acc: String, x: Int) -> acc)\n  1\n}\n"
+  assert(String::contains(first_diag(src), "Array::fold accumulator type mismatch"))
+  assert(anchored_at(src, 4, 18))
+}


### PR DESCRIPTION
Third and last easy slice of the audit #2113 opened. Same rule as before: each of these reproduces with an **identifier** operand, so the offset was already in the AST and only had to be passed.

| program | before | after |
|---|---|---|
| `Get => resume(s)` | `resume value type mismatch` | `line 14:19` |
| `Get => s` | `handler arm value type mismatch …` | `line 14:12` |
| `p.x = s` | `type mismatch writing field \`x\`` | `line 5:9` |
| `Array::fold(a, n, f)` | `Array::fold accumulator type mismatch` | `line 4:18` |

Columns hand-checked against the source text: every one lands on the operand named above — not on `Get`, not on the `handle`, not on the call.

**`Array::fold` needed a choice.** The check compares the callback's first parameter type against `init`'s type, so `init` is the "actual" side — and it is also the argument a reader would edit. That matches how every other case in this file is anchored.

## Where the audit stands: 13 → 3

| slice | sites fixed | remaining |
|---|---:|---:|
| #2113 | 4 + 1 bare push | 13 → 8 |
| #2115 | 5 | 8 → 4 |
| this | 4 | 4 → **3** |

## The three that remain are a different job

```
check_record_fields(defs, actual: Array[(String, Type)], s, errors)
check_hof_param_vs_elem(recv_ty, fn_ty, pidx, s, errors, msg)   × 2
```

Both take **types** with no expression in scope, so locating them means adding an anchor parameter and threading it from every caller — a signature change with its own review surface, not a one-line read of something already there.

They are also not independently reachable in the obvious shapes. Measured: a tuple or array element mismatch under a local annotation surfaces as the **already located** `binding type mismatch for a local let` instead —

```
let u: (Int, Int) = t       -> line 3:23: binding type mismatch for a local let
let b: Array[String] = a    -> line 3:26: binding type mismatch for a local let
```

— so the user-visible payoff of threading them is smaller than the change costs. Worth doing deliberately, or worth deciding not to.

## Verification

Against stage2 built from this checkout:

| check | result |
|---|---|
| `diagnostic_anchor_test.vibe` | **13/13**, every new column hand-checked against the source |
| unit battery | **989/989 passed** |
| gate `bootstrap` | ok — `stage2 == stage3` fixpoint holds, whole compiler compiles as one unit under RC |
| gate `early` | ok — 39/39 multi-feature end-to-end smoke |
| gate `mid` | ok — 40/40 (285) |
| gate `late` | ok |

**Red confirmed by reverting `checker.vibe` alone** — as in the two earlier slices, swapping `VIBE_TEST_CLI_WASM` does *not* establish Red, since the test imports `collect_all_diagnostics` from source.

One process note: I started the regression before the `Array::fold` edit, noticed it was measuring the wrong tree, killed it and restarted against the final state rather than reporting the earlier run's result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe