### PR TITLE
feat(checker): `Console` authorizes the legacy tty labels, and the book moves to it (#2102)

### DIFF
--- a/book/ja/01_values_functions.vibe.md
+++ b/book/ja/01_values_functions.vibe.md
@@ -16,7 +16,7 @@ English version: [01_values_functions.vibe.md](01_values_functions.vibe.md) (can
 `Stdout` row が必要になる — [Capabilities](../src/10_capabilities.vibe.md) 参照。
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let x: Int = 42
   // 63-bit tagged (#1877)。リテラル上限 2^62-1
   let d: Double = 3.14
@@ -55,7 +55,7 @@ vibe は純粋がデフォルト。ローカルな可変状態は `let mut` で�
 値として出す。
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let y = {
     let mut v = 0
     v += 1
@@ -115,7 +115,7 @@ let scaled: (x~: Int, y~: Int) -> Int = (x~, y~) -> {
   x * 10 + y
 }
 
-fn main with Stdout {
+fn main with Console {
   println("add(1, 2) = \{add(1, 2)}")
   println("fact(5) = \{fact(5)}")
   println("identity(7) = \{identity(7)}")
@@ -147,7 +147,7 @@ fn greet(name: String, times?: Int) -> String {
   String::concat(name, String::concat(" x", __to_string(n)))
 }
 
-fn main with Stdout {
+fn main with Console {
   println(greet("hi"))
   println(greet("hi", 3))
 }
@@ -161,7 +161,7 @@ hi x3
 ## ラムダ短縮形とプレースホルダ
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let xs = [
     1,
     2,

--- a/book/ja/02_control_flow.vibe.md
+++ b/book/ja/02_control_flow.vibe.md
@@ -7,7 +7,7 @@ English version: [02_control_flow.vibe.md](02_control_flow.vibe.md) (canonical)
 ## if は式
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let v = if 1 < 2 {
     "yes"
   } else {
@@ -44,7 +44,7 @@ fn find_first_neg(arr: Array[Int]) -> Int {
   return -1
 }
 
-fn main with Stdout {
+fn main with Console {
   println("find_first_neg([3, 1, -2, 5]) = \{find_first_neg([3, 1, -2, 5])}")
   println("find_first_neg([1, 2]) = \{find_first_neg([1, 2])}")
 }
@@ -61,7 +61,7 @@ find_first_neg([1, 2]) = -1
 可変変数なしで畳み込みが書ける。
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let sum = loop (i = 0, acc = 0) {
     if i >= 10 {
       break acc
@@ -102,7 +102,7 @@ symmetric with this — it takes the loop's single result value, so
 これは今も有効。
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let r = loop (i = 0, acc = 0) {
     if i >= 3 {
       break (acc, i)
@@ -122,7 +122,7 @@ r = (3, 3)
 ## for-in は Array を返す
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let doubled = for x in [
     1,
     2,
@@ -166,7 +166,7 @@ fn pair(a: Int, b: Int) -> Int {
   a * 10 + b
 }
 
-fn main with Stdout {
+fn main with Console {
   let trimmed_len = "  hi  " |> String::trim |> String::length
   let arr_len = [
     1,

--- a/book/ja/03_data.vibe.md
+++ b/book/ja/03_data.vibe.md
@@ -7,7 +7,7 @@ English version: [03_data.vibe.md](03_data.vibe.md) (canonical)
 ## tuple / array / record
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let t = (1, "two", true)
   println("t.0 = \{t.0}")
   let a = [
@@ -49,7 +49,7 @@ struct Point {
   x: Int; y: Int
 } derive (Eq, Ord, Show)
 
-fn main with Stdout {
+fn main with Console {
   let p = Point::{
     x: 1, y: 2
   }
@@ -82,7 +82,7 @@ fn area(s: Shape) -> Int {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   println("area(Circle(2)) = \{area(Circle(2))}")
   println("area(Rect(6, 7)) = \{area(Rect(6, 7))}")
 }
@@ -105,7 +105,7 @@ fn classify(n: Int) -> String {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   println("classify(0) = \{classify(0)}")
   println("classify(2) = \{classify(2)}")
   println("classify(-5) = \{classify(-5)}")
@@ -150,7 +150,7 @@ let Version::{
   major: 0, minor: 3
 }
 
-fn main with Stdout {
+fn main with Console {
   println("sum = \{left + right}, \{name} \{major}.\{minor}")
 }
 ```
@@ -164,7 +164,7 @@ sum = 42, vibe 0.3
 同じ形は関数本体でも使える (`is` 式による絞り込みと組み合わせられる)。
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let (a, b) = (1, 2)
   println("a + b = \{a + b}")
   let opt = Some(41)
@@ -194,7 +194,7 @@ compiler test に固定してある。使い分けは「1回作って以後読�
 `ArrayBuilder`、既にある `Array` を伸ばすなら `Array::push`」。
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let arr = {
     let bld = ArrayBuilder::new()
     ArrayBuilder::push(bld, 1)

--- a/book/ja/04_option.vibe.md
+++ b/book/ja/04_option.vibe.md
@@ -24,7 +24,7 @@ fn unwrap_or(o: Option[Int], fallback: Int) -> Int {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   println("half(10) unwrap_or -1 = \{unwrap_or(half(10), -1)}")
   println("half(3)  unwrap_or -1 = \{unwrap_or(half(3), -1)}")
 }
@@ -63,7 +63,7 @@ fn sum_halves(a: Int, b: Int) -> Option[Int] {
   Some(x + y)
 }
 
-fn main with Stdout {
+fn main with Console {
   println("sum_halves(4, 6) unwrap_or -1 = \{unwrap_or(sum_halves(4, 6), -1)}")
   println("sum_halves(4, 3) unwrap_or -1 = \{unwrap_or(sum_halves(4, 3), -1)}")
 }
@@ -101,7 +101,7 @@ fn first_half(a: Int, b: Int) -> Option[Int] {
   Some(x)
 }
 
-fn main with Stdout {
+fn main with Console {
   println("first_half(4, 6) unwrap_or -1 = \{unwrap_or(first_half(4, 6), -1)}")
   println("first_half(4, 3) unwrap_or -1 = \{unwrap_or(first_half(4, 3), -1)}")
 }
@@ -142,7 +142,7 @@ fn double_or_zero(o: Option[Int]) -> Int {
   // v はここで使える
 }
 
-fn main with Stdout {
+fn main with Console {
   println("double_or_zero(Some(21)) = \{double_or_zero(Some(21))}")
   println("double_or_zero(None) = \{double_or_zero(None)}")
 }
@@ -164,7 +164,7 @@ fn half(n: Int) -> Option[Int] {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   println("half(10) is Some(_) = \{half(10) is Some(_)}")
   // true
   println("half(3) is None = \{half(3) is None}")

--- a/book/ja/05_effects.vibe.md
+++ b/book/ja/05_effects.vibe.md
@@ -160,8 +160,9 @@ apply_twice = 40
 ホスト I/O (`Fs` / `Env` / `Http` / **`Console`**) は capability で、
 代数 effect ではない。tty の現行名は `Console`（`Console::write_stream` /
 `read_stream` / `write_err_stream` と `*_char`）。上の例の `Stdout` は
-まだ受理される **legacy ラベル**で、同じ host import を共有するが
-`Console::*` とは相互に認可しない。詳細は英語版
+まだ受理される **legacy ラベル**で、同じ host import を共有する。
+`Console` を宣言すれば legacy ラベルも認可されるが、逆は成立しない
+（`Console` の方が広い capability のため）。詳細は英語版
 [Capabilities](../src/10_capabilities.vibe.md)。
 
 次章: [06 テスト](06_tests-ja.vibe.md)

--- a/book/ja/05_effects.vibe.md
+++ b/book/ja/05_effects.vibe.md
@@ -23,7 +23,7 @@ fn risky(x: Int) -> Int with Exception {
   100 / x
 }
 
-fn main with Stdout {
+fn main with Console {
   let safe = handle {
     risky(0)
   } with Exception {
@@ -80,7 +80,7 @@ fn answer_of(q: String) -> Int with Ask {
   perform Ask::Value(q) + 1
 }
 
-fn main with Stdout {
+fn main with Console {
   // handler が resume(v) で perform 地点に値を返す (one-shot tail-resumptive)
   let v = handle {
     answer_of("life")
@@ -148,7 +148,7 @@ fn apply_twice(f~: (Int) -> Int with e, x~: Int) -> Int with e {
   f(f(x))
 }
 
-fn main with Stdout {
+fn main with Console {
   println("apply_twice = \{apply_twice(f=(n) -> n * 2, x=10)}")
 }
 ```

--- a/book/ja/07_modules_packages.vibe.md
+++ b/book/ja/07_modules_packages.vibe.md
@@ -44,7 +44,7 @@ import ./support/mathx.vibe {
   triple
 }
 
-fn main with Stdout {
+fn main with Console {
   println("triple(14) = \{triple(14)}")
 }
 ```
@@ -64,7 +64,7 @@ import @vibe/core {
   hex_encode, sha1
 }
 
-fn main with Stdout {
+fn main with Console {
   println("length(sha1(\"vibe\")) = \{String::length(sha1("vibe"))}")
   println("hex_encode(\"hi\") = \{hex_encode("hi")}")
 }

--- a/book/src/01_getting_started.vibe.md
+++ b/book/src/01_getting_started.vibe.md
@@ -25,9 +25,10 @@ You get a `vibe` dispatcher, a `viberun` host, and the stdlib under
 ## Hello
 
 A program is a `fn main` with an explicit effect row. The current tty
-capability is **`Console`**. This hello still says `Stdout` because the
-`println` builtin carries that **legacy** label (same host import as
-`Console::write_stream`; the two names do not authorize each other). See
+capability is **`Console`**, and that is what this hello declares. The
+`println` builtin still carries the **legacy** `Stdout` label internally;
+declaring `Console` authorizes it, because `Console` is the union of the
+legacy three. The reverse does not hold — see
 [Capabilities](10_capabilities.vibe.md).
 
 Two spellings are legal. The **bare** `with Console` is the usual hello.

--- a/book/src/01_getting_started.vibe.md
+++ b/book/src/01_getting_started.vibe.md
@@ -30,14 +30,14 @@ capability is **`Console`**. This hello still says `Stdout` because the
 `Console::write_stream`; the two names do not authorize each other). See
 [Capabilities](10_capabilities.vibe.md).
 
-Two spellings are legal. The **bare** `with Stdout` is the usual hello.
-The **split** form `with () allows Stdout` says the same thing more
+Two spellings are legal. The **bare** `with Console` is the usual hello.
+The **split** form `with () allows Console` says the same thing more
 loudly: nothing algebraic, one capability. Mixing a
 capability into `with` *after* you wrote `allows` is a parse error
 (`Stdout` must appear in `allows`, not `with`).
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   println("hello, vibe")
 }
 ```
@@ -47,8 +47,9 @@ hello, vibe
 ```
 
 `println` is a builtin -- no import -- and its row is not optional: drop
-`with Stdout` and the checker reports an effect row mismatch naming
-`Stdout` (#2107). The same program as a script file is usually named
+`with Console` and the checker reports an effect row mismatch. It names
+`Stdout`, the label the builtin carries internally; `Console` is the
+current capability and authorizes it (#2107, #2102). The same program as a script file is usually named
 `hello.vibex` and run with `vibe run hello.vibex`.
 
 ## Check, then run

--- a/book/src/01_values_functions.vibe.md
+++ b/book/src/01_values_functions.vibe.md
@@ -18,7 +18,7 @@ locally, run
 [Capabilities](10_capabilities.vibe.md).
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let x: Int = 42
   // 63-bit tagged (#1877); literals go up to 2^62-1
   let d: Double = 3.14
@@ -57,7 +57,7 @@ vibe is pure by default. Local mutable state goes in a `let mut`, and leaves the
 block as a value.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let y = {
     let mut v = 0
     v += 1
@@ -119,7 +119,7 @@ let scaled: (x~: Int, y~: Int) -> Int = (x~, y~) -> {
   x * 10 + y
 }
 
-fn main with Stdout {
+fn main with Console {
   println("add(1, 2) = \{add(1, 2)}")
   println("fact(5) = \{fact(5)}")
   println("identity(7) = \{identity(7)}")
@@ -161,7 +161,7 @@ fn greet(name: String, times?: Int) -> String {
   String::concat(name, String::concat(" x", __to_string(n)))
 }
 
-fn main with Stdout {
+fn main with Console {
   println(greet("hi"))
   println(greet("hi", 3))
 }
@@ -175,7 +175,7 @@ hi x3
 ## Lambda shorthand and placeholders
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let xs = [
     1,
     2,

--- a/book/src/02_control_flow.vibe.md
+++ b/book/src/02_control_flow.vibe.md
@@ -7,7 +7,7 @@ Previous: [01 Values and functions](01_values_functions.vibe.md)
 ## `if` is an expression
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let v = if 1 < 2 {
     "yes"
   } else {
@@ -46,7 +46,7 @@ fn find_first_neg(arr: Array[Int]) -> Int {
   return -1
 }
 
-fn main with Stdout {
+fn main with Console {
   println("find_first_neg([3, 1, -2, 5]) = \{find_first_neg([3, 1, -2, 5])}")
   println("find_first_neg([1, 2]) = \{find_first_neg([1, 2])}")
 }
@@ -63,7 +63,7 @@ find_first_neg([1, 2]) = -1
 `break result`. It writes a fold without any mutable variable.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let sum = loop (i = 0, acc = 0) {
     if i >= 10 {
       break acc
@@ -105,7 +105,7 @@ A `continue` with no arguments at all means "go round again with every parameter
 unchanged", and that still works.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let r = loop (i = 0, acc = 0) {
     if i >= 3 {
       break (acc, i)
@@ -125,7 +125,7 @@ r = (3, 3)
 ## `for-in` returns an Array
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let doubled = for x in [
     1,
     2,
@@ -170,7 +170,7 @@ fn pair(a: Int, b: Int) -> Int {
   a * 10 + b
 }
 
-fn main with Stdout {
+fn main with Console {
   let trimmed_len = "  hi  " |> String::trim |> String::length
   let arr_len = [
     1,

--- a/book/src/03_data.vibe.md
+++ b/book/src/03_data.vibe.md
@@ -7,7 +7,7 @@ Previous: [02 Control flow](02_control_flow.vibe.md)
 ## tuple / array / record
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let t = (1, "two", true)
   println("t.0 = \{t.0}")
   let a = [
@@ -50,7 +50,7 @@ struct Point {
   x: Int; y: Int
 } derive (Eq, Ord, Show)
 
-fn main with Stdout {
+fn main with Console {
   let p = Point::{
     x: 1, y: 2
   }
@@ -83,7 +83,7 @@ fn area(s: Shape) -> Int {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   println("area(Circle(2)) = \{area(Circle(2))}")
   println("area(Rect(6, 7)) = \{area(Rect(6, 7))}")
 }
@@ -106,7 +106,7 @@ fn classify(n: Int) -> String {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   println("classify(0) = \{classify(0)}")
   println("classify(2) = \{classify(2)}")
   println("classify(-5) = \{classify(-5)}")
@@ -153,7 +153,7 @@ let Version::{
   major: 0, minor: 3
 }
 
-fn main with Stdout {
+fn main with Console {
   println("sum = \{left + right}, \{name} \{major}.\{minor}")
 }
 ```
@@ -168,7 +168,7 @@ The same shapes work in a function body, and combine with narrowing via the `is`
 expression.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let (a, b) = (1, 2)
   println("a + b = \{a + b}")
   let opt = Some(41)
@@ -200,7 +200,7 @@ compiler tests as the contract from
 you are growing an `Array` that already exists.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let arr = {
     let bld = ArrayBuilder::new()
     ArrayBuilder::push(bld, 1)

--- a/book/src/04_option.vibe.md
+++ b/book/src/04_option.vibe.md
@@ -24,7 +24,7 @@ fn unwrap_or(o: Option[Int], fallback: Int) -> Int {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   println("half(10) unwrap_or -1 = \{unwrap_or(half(10), -1)}")
   println("half(3)  unwrap_or -1 = \{unwrap_or(half(3), -1)}")
 }
@@ -64,7 +64,7 @@ fn sum_halves(a: Int, b: Int) -> Option[Int] {
   Some(x + y)
 }
 
-fn main with Stdout {
+fn main with Console {
   println("sum_halves(4, 6) unwrap_or -1 = \{unwrap_or(sum_halves(4, 6), -1)}")
   println("sum_halves(4, 3) unwrap_or -1 = \{unwrap_or(sum_halves(4, 3), -1)}")
 }
@@ -102,7 +102,7 @@ fn first_half(a: Int, b: Int) -> Option[Int] {
   Some(x)
 }
 
-fn main with Stdout {
+fn main with Console {
   println("first_half(4, 6) unwrap_or -1 = \{unwrap_or(first_half(4, 6), -1)}")
   println("first_half(4, 3) unwrap_or -1 = \{unwrap_or(first_half(4, 3), -1)}")
 }
@@ -146,7 +146,7 @@ fn double_or_zero(o: Option[Int]) -> Int {
   // v is available here
 }
 
-fn main with Stdout {
+fn main with Console {
   println("double_or_zero(Some(21)) = \{double_or_zero(Some(21))}")
   println("double_or_zero(None) = \{double_or_zero(None)}")
 }
@@ -168,7 +168,7 @@ fn half(n: Int) -> Option[Int] {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   println("half(10) is Some(_) = \{half(10) is Some(_)}")
   // true
   println("half(3) is None = \{half(3) is None}")

--- a/book/src/05_effects.vibe.md
+++ b/book/src/05_effects.vibe.md
@@ -26,7 +26,7 @@ fn risky(x: Int) -> Int with Exception {
   100 / x
 }
 
-fn main with Stdout {
+fn main with Console {
   let safe = handle {
     risky(0)
   } with Exception {
@@ -86,7 +86,7 @@ fn answer_of(q: String) -> Int with Ask {
   perform Ask::Value(q) + 1
 }
 
-fn main with Stdout {
+fn main with Console {
   // the handler returns a value to the perform site via resume(v) (one-shot tail-resumptive)
   let v = handle {
     answer_of("life")
@@ -155,7 +155,7 @@ fn apply_twice(f~: (Int) -> Int with e, x~: Int) -> Int with e {
   f(f(x))
 }
 
-fn main with Stdout {
+fn main with Console {
   println("apply_twice = \{apply_twice(f=(n) -> n * 2, x=10)}")
 }
 ```

--- a/book/src/05_effects.vibe.md
+++ b/book/src/05_effects.vibe.md
@@ -168,9 +168,10 @@ Host I/O (`Fs`, `Env`, `Http`, **`Console`**) are **capabilities**, not
 algebraic effects. On a *split* signature they belong in `allows`, not
 `with`. The current tty capability is `Console` (`Console::write_stream`,
 `read_stream`, `write_err_stream`, and the `*_char` pair). `Stdout` /
-`Stdin` / `Stderr` in the examples above are still-accepted **legacy
-labels** that share those host imports; they do not authorize `Console::*`
-and the other way around. See [Capabilities](10_capabilities.vibe.md).
+`Stdin` / `Stderr` are still-accepted **legacy labels** that share those
+host imports. Declaring `Console` authorizes them; declaring one of them
+does **not** authorize `Console::*`, because `Console` is the wider
+capability. See [Capabilities](10_capabilities.vibe.md).
 
 Next: [Capabilities](10_capabilities.vibe.md). The package/test tour is
 [Modules](07_modules_packages.vibe.md) then [Tests](06_tests.vibe.md).

--- a/book/src/07_modules_packages.vibe.md
+++ b/book/src/07_modules_packages.vibe.md
@@ -48,7 +48,7 @@ import ./support/mathx.vibe {
   triple
 }
 
-fn main with Stdout {
+fn main with Console {
   println("triple(14) = \{triple(14)}")
 }
 ```
@@ -68,7 +68,7 @@ import @vibe/core {
   hex_encode, sha1
 }
 
-fn main with Stdout {
+fn main with Console {
   println("length(sha1(\"vibe\")) = \{String::length(sha1("vibe"))}")
   println("hex_encode(\"hi\") = \{hex_encode("hi")}")
 }

--- a/book/src/08_types_strings.vibe.md
+++ b/book/src/08_types_strings.vibe.md
@@ -14,7 +14,7 @@ Arithmetic overflow wraps as 63-bit two's complement on **every** backend
 describing a tag layout the compiler no longer uses.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let max = 4611686018427387903
   println("max = \{max}")
   println("max + 1 = \{max + 1}")
@@ -53,7 +53,7 @@ printout looks like an integer bit pattern.
 is bytes, so the type is bytes (ADR-0098).
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let s = "hello"
   println("s[0] = \{s[0]}")
   println("from_char_code = \{String::from_char_code(s[0])}")
@@ -91,7 +91,7 @@ struct Point {
   x: Int; y: Int
 } derive (Show)
 
-fn main with Stdout {
+fn main with Console {
   let p = Point::{
     x: 3, y: 4
   }

--- a/book/src/09_mutation.vibe.md
+++ b/book/src/09_mutation.vibe.md
@@ -22,7 +22,7 @@ A `let mut` binding is writable until the block ends. The block itself is
 still an expression: it produces a value.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let y = {
     let mut v = 0
     v += 1
@@ -46,7 +46,7 @@ fn grow(xs: Array[Int]) -> Unit {
   Array::push(xs, 9)
 }
 
-fn main with Stdout {
+fn main with Console {
   let xs = [
     1
   ]

--- a/book/src/10_capabilities.vibe.md
+++ b/book/src/10_capabilities.vibe.md
@@ -13,7 +13,7 @@ permission got there.
 
 ```vibe skip
 // skip: signatures only — not a complete program
-fn greet(name: String) -> Unit with Stdout
+fn greet(name: String) -> Unit with Console
 fn slurp(path: String) -> String with Exception + Fs
 fn read_var(name: String) -> String with Exception + Env
 ```
@@ -34,11 +34,11 @@ to mention. `--allow-*` flags const-fold and DCE the denied capability
 away: code that needed it is not in the artifact.
 
 ```vibe run
-fn greet(name: String) -> Unit with Stdout {
+fn greet(name: String) -> Unit with Console {
   println("hi \{name}")
 }
 
-fn main with Stdout {
+fn main with Console {
   greet("vibe")
 }
 ```
@@ -47,15 +47,19 @@ fn main with Stdout {
 hi vibe
 ```
 
-A function that only calls `greet` must itself mention `Stdout`. The
+A function that only calls `greet` must itself mention `Console`. The
 capability does not appear by magic at `main` — it is inferred from
 calls and then checked against what you wrote.
 
-The `println` / `print` builtins carry the **legacy** `Stdout` label.
-The current tty capability — the name a grant prompt should say — is
-`Console`. Both compile today; they share the host imports
-(`vibe.stdout_write_stream` and friends) and they do **not** authorize
-each other.
+The `println` / `print` builtins still carry the **legacy** `Stdout`
+label internally. `Console` is the current tty capability — the name a
+grant prompt should say — and declaring it authorizes the legacy three,
+which is why the row above reads `with Console` (#2102).
+
+The containment is **one-way**, and deliberately so: `Console` owns six
+operations and `Stdout` owns two of them, so a row declaring only
+`Stdout` may not reach `Console::read_stream`. A write-only program does
+not acquire read authority by way of a migration alias.
 
 ## The current tty name is `Console`
 
@@ -71,7 +75,7 @@ Six operations, one effect:
 | `Console::read_char` | `Stdin::read_char` | `vibe.stdin_read_char` |
 
 `Stdin` / `Stdout` / `Stderr` stay accepted until the seed bump retires
-them. A row must name the label whose operation it calls:
+them, and `with Console` covers all three. The reverse does not hold:
 `with Stdout { Console::write_stream(...) }` is a row mismatch.
 
 `with Console` covers the six operations in the **row**. Instantiate
@@ -91,7 +95,7 @@ hello, console
 
 ```vibe skip
 // skip: legacy Stdout does not authorize Console::* (distinct labels)
-fn main with Stdout {
+fn main with Console {
   Console::write_stream("no")
 }
 ```
@@ -108,7 +112,7 @@ The parser stores the split as the emitted row plus a `#allows` marker,
 not as `with A + C`.
 
 ```vibe run
-fn main with () allows Stdout {
+fn main with () allows Console {
   println("authority is a separate clause")
 }
 ```
@@ -118,9 +122,9 @@ authority is a separate clause
 ```
 
 `Stdout` in a *split* signature belongs in `allows`. Writing
-`fn main() -> Int with Stdout allows Fs::read_file?` is rejected:
+`fn main() -> Int with Console allows Fs::read_file?` is rejected:
 "`Stdout` is a capability effect and must appear in the `allows`
-clause, not `with`". The hello-world `fn main with Stdout` is the
+clause, not `with`". The hello-world `fn main with Console` is the
 **bare** form and stays legal.
 
 ## Optional capability and `perform?`
@@ -138,7 +142,7 @@ keep it in `skip` — do not pretend it runs.
 
 ```vibe skip
 // skip: checker accepts Attempt[String, String]; codegen does not bind perform?
-fn main() -> Int with () allows Stdout + Fs::read_file? {
+fn main() -> Int with () allows Console + Fs::read_file? {
   let a = perform? Fs::read_file("config.json")
   match a {
     NotGranted => 0,

--- a/book/src/12_cli.vibe.md
+++ b/book/src/12_cli.vibe.md
@@ -43,7 +43,7 @@ fn add(x: Int, y: Int) -> Int {
   x + y
 }
 
-fn main with Stdout {
+fn main with Console {
   println("\{add(2, 40)}")
 }
 ```

--- a/book/src/15_collections.vibe.md
+++ b/book/src/15_collections.vibe.md
@@ -19,7 +19,7 @@ wasm-gc.
 ## `Array`
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let xs = [
     1,
     2,
@@ -46,7 +46,7 @@ sees the new length. Prefer `ArrayBuilder` when you accumulate once and
 then only read.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let b = ArrayBuilder::new()
   ArrayBuilder::push(b, 10)
   ArrayBuilder::push(b, 20)
@@ -62,7 +62,7 @@ built length = 2, [0] = 10
 ## `StringBuilder`
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let b = StringBuilder::new()
   StringBuilder::push(b, "hello ")
   StringBuilder::push(b, "vibe")
@@ -92,7 +92,7 @@ fn unwrap_or(o: Option[Int], fallback: Int) -> Int {
   }
 }
 
-fn main with Stdout {
+fn main with Console {
   let m: MutMap[String, Int] = MutMap::new_string()
   MutMap::set(m, "a", 1)
   MutMap::set(m, "b", 2)

--- a/book/src/16_generics.vibe.md
+++ b/book/src/16_generics.vibe.md
@@ -18,7 +18,7 @@ fn identity[T](x: T) -> T {
   x
 }
 
-fn main with Stdout {
+fn main with Console {
   let b = Box::{
     v: 41
   }
@@ -43,7 +43,7 @@ enum Color {
   Red; Green; Blue
 } derive (Eq, Show)
 
-fn main with Stdout {
+fn main with Console {
   println("eq = \{Color::Red == Color::Red}")
   println("neq = \{Color::Red == Color::Blue}")
   println("show = \{Color::Green}")
@@ -79,7 +79,7 @@ fn size_of[T: Measured](x: T) -> Int {
   T::measure(x)
 }
 
-fn main with Stdout {
+fn main with Console {
   let xs = [
     1,
     2,

--- a/book/src/17_iteration.vibe.md
+++ b/book/src/17_iteration.vibe.md
@@ -15,7 +15,7 @@ removed; suspend lives on the effect row).
 ## Eager array tools
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let xs = [
     1,
     2,
@@ -54,7 +54,7 @@ closure or a trait iterator is statement-shaped: you cannot write
 marks the slot.
 
 ```vibe run
-fn main with Stdout {
+fn main with Console {
   let n = "  vibe  " |> String::trim |> String::length
   let xs = [
     1,

--- a/book/src/18_equality.vibe.md
+++ b/book/src/18_equality.vibe.md
@@ -19,7 +19,7 @@ fn same_ints(a: Array[Int], b: Array[Int]) -> Bool {
   a == b
 }
 
-fn main with Stdout {
+fn main with Console {
   println("lits = \{[1, 2] == [1, 2]}")
   let a = [
     1,

--- a/book/src/19_a_small_program.vibe.md
+++ b/book/src/19_a_small_program.vibe.md
@@ -55,7 +55,7 @@ fn top_word(words: Array[String]) -> Tally {
   best
 }
 
-fn main with Stdout {
+fn main with Console {
   let words = [
     "vibe",
     "wasm",
@@ -83,7 +83,7 @@ kinds = 3
 
 What this program is deliberately showing:
 
-- `fn main with Stdout` is the only capability the program needs.
+- `fn main with Console` is the only capability the program needs.
 - Failure that is part of the meaning would be `with Exception`, not
   a `Result` wrapper. Absence of a key is `Option`, unwrapped with
   `match`.

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -875,10 +875,38 @@ fn row_base_membership(labels: Array[String], eff_name: String) -> Bool {
   }
 }
 
+/// #1460 is merging `Stdin` / `Stdout` / `Stderr` into one `Console`
+/// capability, and until that lands both spellings have to work. The merge
+/// direction is what makes this CONTAINMENT rather than the alias equality
+/// `exception_effect_labels_equal` uses for `Error` / `Exception`: measured on
+/// the registry, `Console` owns six operations (`read_stream`, `read_char`,
+/// `write_stream`, `write_char`, `write_err_stream`, `write_err_char`) while
+/// the legacy three own three, two and two of them.
+///
+/// So a declared `Console` authorizes a legacy label, and the reverse is
+/// deliberately ABSENT. Letting `with Stdout` authorize a `Console` operation
+/// would hand a write-only program `Console::read_stream` -- the capability
+/// escape class #2107/#2108 closed, reintroduced through a migration alias.
+/// The negative case is pinned in `console_migration_row_test.vibe`.
+///
+/// One coverage gap this does not paper over: `Stdin::read_via_stream`
+/// (#1539's StdinStream) has no `Console::` counterpart, so `Console` is not
+/// yet a complete replacement for `Stdin` at the operation level. That is
+/// #1460's problem to close, not this predicate's to hide.
+fn is_legacy_console_label(name: String) -> Bool {
+  name == "Stdin" || name == "Stdout" || name == "Stderr"
+}
+
+fn console_authorizes_legacy(labels: Array[String], eff_name: String) -> Bool {
+  is_legacy_console_label(eff_name) && effect_row_has_label(Some(labels), "Console")
+}
+
 fn decl_authorizes_effect(labels: Array[String], eff_name: String) -> Bool {
   // All concrete label checks, including Async above, go through this same
   // exact-membership primitive rather than substring matching.
   if effect_row_has_label(Some(labels), eff_name) {
+    true
+  } else if console_authorizes_legacy(labels, eff_name) {
     true
   } else if is_exception_effect_name(eff_name) {
     // ADR-0085 Phase 3 (#1344): the exception effect is authorized by KIND.

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1693,6 +1693,16 @@ fn authority_covers_operation(auth: String, emitted: String) -> Bool {
     true
   } else if String::index_of(auth, "::") < 0 && standard_provider_owns_operation(emitted) {
     effect_name_of_op(emitted) == auth
+  } else if auth == "Console" && is_legacy_console_label(effect_name_of_op(emitted)) {
+    // The instantiate-grant half of #2102's containment. `allows` is a
+    // SEPARATE authorization path from the `with` row (ADR-0075/0084/0088:
+    // authority is fixed once, at instantiate), so teaching only
+    // `decl_authorizes_effect` left the split form unable to express what the
+    // bare form could -- `fn main with () allows Console { println(..) }` was
+    // rejected while `fn main with Console { println(..) }` compiled. Same
+    // one-way rule and same reason: `Console` is the union, the legacy labels
+    // are subsets, and the reverse would widen authority.
+    true
   } else {
     false
   }

--- a/lib/@vibe/compiler/tests/console_capability_test.vibe
+++ b/lib/@vibe/compiler/tests/console_capability_test.vibe
@@ -48,13 +48,23 @@ test "Console is a checked capability, not an ambient one" {
   assert(String::contains(Array::get(d, 0), "Console"))
 }
 
-test "Console and the legacy stream effects do not authorize each other" {
-  // The migration property. `Console` is its own label until Phase 3 removes
-  // the legacy three, so a row must name the one whose operation it calls.
+test "Console subsumes the legacy stream effects, and they do not subsume it" {
+  // This test used to assert the relation was symmetric -- neither label
+  // authorizing the other -- and #2102 deliberately opened one direction of
+  // it. The reason is in the book: the docs call `Console` current and
+  // `Stdout` legacy, while `println` carries `Stdout`, so the label a reader
+  // is told to prefer could not be used with the verb they are taught.
+  //
+  // The direction that opened. `Console` owns all six operations, so it is
+  // the union and may authorize a legacy one.
+  assert(ok("fn f() -> Unit with Console {\n  Stdout::write_stream(\"x\")\n}\n"))
+  assert(ok("fn f() -> Unit with Console {\n  Stderr::write_stream(\"x\")\n}\n"))
+  // The direction that did NOT, and must not: `Stdout` owns two of the six.
+  // Opening this would let a write-only row reach `Console::read_stream` --
+  // the capability escape class #2107/#2108 closed, reintroduced through a
+  // migration alias.
   assert(!ok("fn f() -> Unit with Stdout {\n  Console::write_stream(\"x\")\n}\n"))
-  assert(!ok("fn f() -> Unit with Console {\n  Stdout::write_stream(\"x\")\n}\n"))
   assert(!ok("fn f() -> Unit with Stderr {\n  Console::write_err_stream(\"x\")\n}\n"))
-  assert(!ok("fn f() -> Unit with Console {\n  Stderr::write_stream(\"x\")\n}\n"))
   // ...and the legacy spellings still work on their own, unchanged.
   assert(ok("fn f() -> Unit with Stdout {\n  Stdout::write_stream(\"x\")\n}\n"))
   assert(ok("fn f() -> Unit with Stderr {\n  Stderr::write_stream(\"x\")\n}\n"))

--- a/lib/@vibe/compiler/tests/console_migration_row_test.vibe
+++ b/lib/@vibe/compiler/tests/console_migration_row_test.vibe
@@ -81,3 +81,19 @@ test "the legacy spelling keeps working while the migration runs" {
   assert(ok("fn main with Stdout {\n  println(\"x\")\n}\n"))
   assert(ok("fn main with Stdout {\n  Stdout::write_stream(\"x\")\n}\n"))
 }
+
+test "the split `allows` form gets the same containment" {
+  // `allows` is a SEPARATE authorization path from the `with` row
+  // (ADR-0075/0084/0088: authority is fixed once, at instantiate), so
+  // teaching only `decl_authorizes_effect` left the split form unable to
+  // express what the bare form could. The book's own `with () allows Console`
+  // example caught this -- it failed `vibe_md check` while the bare form
+  // passed.
+  assert(ok("fn main with () allows Console {\n  println(\"x\")\n}\n"))
+  assert(ok("fn main with () allows Stdout {\n  println(\"x\")\n}\n"))
+}
+
+test "the escape stays closed on the allows path too" {
+  assert(!ok("fn main with () allows Stdout {\n  let s = Console::read_stream(1)\n  ()\n}\n"))
+  assert(!ok("fn main with () allows Fs {\n  println(\"x\")\n}\n"))
+}

--- a/lib/@vibe/compiler/tests/console_migration_row_test.vibe
+++ b/lib/@vibe/compiler/tests/console_migration_row_test.vibe
@@ -1,0 +1,83 @@
+//# `Console` authorizes the legacy tty labels, and not the other way (#2102).
+//
+// #1460 is merging `Stdin` / `Stdout` / `Stderr` into one `Console`
+// capability. Until that lands, the docs call `Console` current and `Stdout`
+// legacy -- while the ergonomic verb was welded to the legacy label:
+//
+//     fn main with Stdout  { println("x") }   compiled
+//     fn main with Console { println("x") }   effect row mismatch
+//
+// So the book taught `Stdout` fifty times, in a chapter that tells the reader
+// `Stdout` is legacy. Not a docs bug: `println` carries `Stdout`, so `Console`
+// simply did not authorize it.
+//
+// The fix is CONTAINMENT, not the alias equality `Error`/`Exception` uses
+// (`exception_effect_labels_equal`). Measured on builtin_registry.vibe:
+//
+//     Console  read_stream read_char write_stream write_char
+//              write_err_stream write_err_char                 -- 6
+//     Stdin    read_stream read_char read_via_stream           -- 3
+//     Stdout   write_stream write_char                         -- 2
+//     Stderr   write_stream write_char                         -- 2
+//
+// `Console` is the union, so it may authorize the legacy three. The REVERSE
+// must not hold, and the negative tests below are the point of this file: a
+// symmetric alias would let a program declaring only `Stdout` reach
+// `Console::read_stream` -- a write-only row acquiring read authority, which
+// is the capability escape class #2107/#2108 closed.
+
+//# Imports
+
+import @vibe/compiler/runtime {
+  collect_all_diagnostics
+}
+
+//# Misc
+
+fn ok(src: String) -> Bool with Exception {
+  Array::length(collect_all_diagnostics(src)) == 0
+}
+
+//# Tests
+
+test "Console authorizes the print builtins the book needs" {
+  // The whole reason this change exists: the taught verb works under the
+  // taught label.
+  assert(ok("fn main with Console {\n  println(\"x\")\n}\n"))
+  assert(ok("fn main with Console {\n  print(\"x\")\n}\n"))
+}
+
+test "Console authorizes a legacy operation of any of the three" {
+  assert(ok("fn main with Console {\n  Stdout::write_stream(\"x\")\n}\n"))
+  assert(ok("fn main with Console {\n  Stderr::write_stream(\"x\")\n}\n"))
+  assert(ok("fn main with Console {\n  let s = Stdin::read_stream(1)\n  ()\n}\n"))
+}
+
+test "a legacy label does NOT acquire Console's wider authority" {
+  // The containment is one-way. `Stdout` owns two write operations; if this
+  // ever passes, a write-only row has gained read authority and the merge
+  // alias has become a capability escape.
+  assert(!ok("fn main with Stdout {\n  let s = Console::read_stream(1)\n  ()\n}\n"))
+  assert(!ok("fn main with Stdout {\n  Console::write_stream(\"x\")\n}\n"))
+}
+
+test "one legacy label does not authorize another" {
+  // Unchanged by this rule, and worth pinning next to it: the merge is not a
+  // licence for `Stdout` to reach `Stdin`.
+  assert(!ok("fn main with Stdout {\n  let s = Stdin::read_stream(1)\n  ()\n}\n"))
+  assert(!ok("fn main with Stdin {\n  println(\"x\")\n}\n"))
+}
+
+test "an unrelated capability still authorizes nothing here" {
+  // The control. Without it, a rule that authorized everything would satisfy
+  // every positive assertion above.
+  assert(!ok("fn main with Fs {\n  println(\"x\")\n}\n"))
+  assert(!ok("fn main with Env {\n  let s = Stdin::read_stream(1)\n  ()\n}\n"))
+}
+
+test "the legacy spelling keeps working while the migration runs" {
+  // ~190 lib sites and 50 book sites still say `with Stdout`. They must not
+  // need touching for this change to land.
+  assert(ok("fn main with Stdout {\n  println(\"x\")\n}\n"))
+  assert(ok("fn main with Stdout {\n  Stdout::write_stream(\"x\")\n}\n"))
+}


### PR DESCRIPTION
The docs call `Console` the current tty capability and `Stdout` legacy. The book then taught `Stdout` **78 times**, in chapters that tell the reader `Stdout` is legacy — because the ergonomic verb was welded to the legacy label:

```
fn main with Stdout  { println("x") }    compiled
fn main with Console { println("x") }    effect row mismatch
```

Not a docs bug to fix in prose. `println` carries `Stdout`, so `Console` did not authorize it, and the label the reader is told to prefer could not be used with the verb the reader is taught. The only spelling that worked under `Console` was the verbose `Console::write_stream`.

## The rule: containment, not an alias

`decl_authorizes_effect` now accepts a declared `Console` for a required `Stdin` / `Stdout` / `Stderr`. That is #1429's "accept both spellings" migration stage — but as **containment**, not the alias equality `Error`/`Exception` gets from `exception_effect_labels_equal`, because #1460 is a 3-into-1 **merge**, not a rename. Measured on `builtin_registry.vibe`:

| label | operations | count |
|---|---|---:|
| `Console` | read_stream, read_char, write_stream, write_char, write_err_stream, write_err_char | 6 |
| `Stdin` | read_stream, read_char, read_via_stream | 3 |
| `Stdout` | write_stream, write_char | 2 |
| `Stderr` | write_stream, write_char | 2 |

`Console` is the union, so it may authorize the legacy three. **The reverse is deliberately absent, and that is the part worth reviewing.** A symmetric alias would let a program declaring only `Stdout` reach `Console::read_stream` — a write-only row acquiring read authority, which is exactly the capability escape class #2107/#2108 closed.

Nothing has to migrate for this to land: `with Stdout` keeps working at all ~190 lib sites, which a test pins.

## Two things I got wrong first, both caught by existing checks

**The `allows` path was a separate check.** The first commit only taught the `with` row. `allows` is a different authorization path — ADR-0075/0084/0088 fix authority once, at instantiate — so the split form could not express what the bare form could:

```
fn main with Console            { println("x") }   compiled
fn main with () allows Console  { println("x") }   rejected
```

`authority_covers_operation` now carries the same one-way containment, and the escape stays closed there too. **The book found this, not a test I wrote**: `10_capabilities` teaches the split form, and `vibe_md check` failed on that one block while the other 79 passed.

**An existing test asserted the symmetric rule.** `console_capability_test.vibe` pinned "Console and the legacy stream effects do not authorize each other" — exactly the half this change opens. The unit battery caught it. It is **rewritten, not deleted**: half of it still holds and that half is the important one, so it now names both directions explicitly and says why the assertion changed, rather than reading as a weakened test.

## The book

87 row mentions across en and ja: `with Stdout` / `allows Stdout` → `with Console` / `allows Console`. The paired ` ```output ` blocks are untouched, because the programs print the same thing.

**Prose was hand-edited, and a bulk regex over prose is how you get this wrong.** The sweep turned

> `with Stdout { Console::write_stream(...) }` is a row mismatch

— a true sentence about the legacy label — into one claiming that a form which now compiles is an error.

Three further passages stated the old symmetric rule and the row sweep could not have caught them, since none contains `with Stdout`:

| file | text |
|---|---|
| `01_getting_started` | "the two names do not authorize each other" |
| `05_effects` | "they do not authorize `Console::*` and the other way around" |
| `book/ja/05_effects` | 「`Console::*` とは相互に認可しない」 |

All now state the containment and its direction. Worth noting for the gate's sake: `check-tutorial-translation-parity` compares recorded **output**, not prose, so it could not have caught the ja one — it was found by hand after fixing the English.

## Not in scope

This is #2102's *compatibility* half, not its ask. The issue wants `Console` to stop being a top-level language name at all — which requires moving the `with`/`allows` classification out of the parser, since `is_capability_effect_name` decides it by name before any import resolution exists. Analysis is on the issue.

`Stdin::read_via_stream` (#1539's StdinStream) has no `Console::` counterpart, so `Console` is not yet a complete operation-level replacement for `Stdin`. The comment says so rather than letting the predicate imply otherwise — it is #1460's to close.

## Verification

All against stage2 built from this checkout:

| check | result |
|---|---|
| unit battery | **990/990 passed** |
| gate `bootstrap` | ok — `stage2 == stage3` fixpoint holds, whole compiler compiles as one unit under RC |
| gate `early` | ok — 39/39 multi-feature end-to-end smoke |
| gate `mid` | ok — 40/40 (285) |
| gate `late` | ok |
| `console_migration_row_test.vibe` | 8/8 — positive, negative, and unrelated-capability controls |
| `console_capability_test.vibe` | 4/4 after the rewrite |
| `vibe_md check` (book, en+ja) | 94 blocks, **80 pass, 0 fail**, 14 skip |
| `check-tutorial-translation-parity` | ok, 20 chapters |

The `bootstrap` result is the one that mattered most here — this changes a checker authorization rule, so the compiler re-authorizing itself to a `stage2 == stage3` fixpoint is the real evidence it is sound.

Red confirmed by reverting `checker_effects.vibe` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe