### PR TITLE
docs(freeze): the 1.0 freeze list promised stability for names that do not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,12 @@ jobs:
         run: bash scripts/lint_method_style_naming_test.sh
       - name: method-style-naming lint
         run: bash scripts/lint_method_style_naming.sh
+      # The 1.0 freeze list is the only page that makes a SemVer promise, and
+      # it had frozen two names that no longer resolve. It needs a compiler, so
+      # it runs in compiler-gate (late) rather than here; only its self-test,
+      # which is pure shell, belongs in this job.
+      - name: freeze-surface check self-test
+        run: bash scripts/check_freeze_surface_test.sh
       - name: pre-commit hook self-test
         run: bash scripts/precommit_test.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,23 @@ jobs:
           gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
           DOCTEST_REQUIRE_STAGE2=1 DOCTEST_STAGE2="${gen}stage2.wasm" \
             bash scripts/doctest_extract_run.sh README.md docs/cheatsheet.md docs/vibe.md docs/spec/*.md
+      - name: 1.0 freeze-surface check + self-test
+        # docs/spec/1.0-freeze.md is the only page that makes a SemVer promise,
+        # and it had frozen two names that no longer resolve --
+        # `Result::and_then` (the type went in #1324) and the `Iterator::*`
+        # combinator layer (retired by ADR-0099). Nothing read the list back.
+        #
+        # This lives HERE and not in structural-lint because both steps need a
+        # compiler: the check probes each frozen name, and the self-test drives
+        # the real check against synthetic documents. A first attempt put them
+        # in the pure-shell job, where every probe failed with "runner not
+        # found" -- the check's own calibration caught that and failed loudly
+        # rather than reporting a green run, which is the behaviour being
+        # relied on here.
+        run: |
+          gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
+          FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface_test.sh
+          FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface.sh
       - name: examples/ type-check ratchet
         # examples/ is the user-facing sample surface and had NOTHING checking
         # it, so it accumulated two independent classes of rot in silence: the
@@ -399,12 +416,6 @@ jobs:
         run: bash scripts/lint_method_style_naming_test.sh
       - name: method-style-naming lint
         run: bash scripts/lint_method_style_naming.sh
-      # The 1.0 freeze list is the only page that makes a SemVer promise, and
-      # it had frozen two names that no longer resolve. It needs a compiler, so
-      # it runs in compiler-gate (late) rather than here; only its self-test,
-      # which is pure shell, belongs in this job.
-      - name: freeze-surface check self-test
-        run: bash scripts/check_freeze_surface_test.sh
       - name: pre-commit hook self-test
         run: bash scripts/precommit_test.sh
 

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -324,6 +324,9 @@ local checkTaskfileFmt = new Task {
 // compiler_gate.sh runs it up front, before the selfbuild.
 local checkFixtureExecution =
   scriptTask("check-fixture-execution", "scripts/check_fixture_execution.sh")
+local checkFreezeSurface = scriptTask("check-freeze-surface", "scripts/check_freeze_surface.sh")
+local testCheckFreezeSurface =
+  scriptTask("test-check-freeze-surface", "scripts/check_freeze_surface_test.sh")
 local checkMethodStyleNaming =
   scriptTask("check-method-naming", "scripts/lint_method_style_naming.sh")
 local testCheckMethodStyleNaming =
@@ -1245,6 +1248,8 @@ local releaseCheck = new Task {
     testPreCommit
     testCheckMethodStyleNaming
     checkMethodStyleNaming
+    testCheckFreezeSurface
+    checkFreezeSurface
     doctestGated
     vibeMdTutorialGated
     checkTutorialTranslationParity
@@ -1303,6 +1308,8 @@ tasks {
   checkFixtureExecution
   checkMethodStyleNaming
   testCheckMethodStyleNaming
+  checkFreezeSurface
+  testCheckFreezeSurface
   testGenerateSelfhostBundle
   checkOffbuildTypecheck
   testSelfhostAsyncComponent

--- a/docs/spec/1.0-freeze.md
+++ b/docs/spec/1.0-freeze.md
@@ -103,21 +103,27 @@ trait bound の互換は [decisions.md](decisions.md) のロック通り
 
 [cheatsheet](../cheatsheet.md) の "Key Builtins" に列挙された安定シンボルを凍結:
 
-- **String**: `length`, `concat`, `substring`, `contains`, `index_of`, `split`,
-  `trim`, `replace`, `starts_with`, `ends_with`, `join`, `from_char_code`,
-  `char_code_at`, `to_bytes`。
+- **String** (compiler builtin, import 不要): `length`, `concat`, `substring`,
+  `contains`, `index_of`, `split`, `trim`, `starts_with`, `ends_with`, `join`,
+  `from_char_code`, `char_code_at`。
+  `replace` / `replace_all` は `@vibe/builtin` の**ライブラリ関数**で
+  `import @vibe/builtin { String::replace }` が要る (registry には無い)。
 - **Array**: `length`, `get`, `slice`, `map`, `filter`, `fold`, `find`, `any`,
   `all`, `reverse`, `concat`、`ArrayBuilder::new/push/freeze`。
 - **Map**: `get`, `has_key`, `keys`, `values`, `set`, `size`。
 - **Int64Array**: `make`, `get`, `set`, `length` (32-bit word workload 用)。
 - **変換**: `Int::to_string`, `Int::to_double`, `Double::to_int`。
-- **Iterator/Iterable** (ADR-0044): `Iterator::map/filter/fold/find/any/all/
-  flatmap`、`Iterable` trait、`for-in` desugar。
-- **@vibe/builtin helper**: `compose`/`identity`/`flip` (func)、
-  `Result::and_then`、`let*` railway bind。`tap`/`tap_some` は #2102 で
+- **反復**: `Iterable` trait と `for-in` desugar (ADR-0044)。**combinator 層
+  (`Iterator::map` 等) は凍結対象ではない** — ADR-0099 の 2 層化で退役し、
+  registry に 1 行も無い (実測: `Iterator::` 0 件)。eager な反復は
+  `Array::map`/`filter`/`fold` が担う。
+- **@vibe/builtin helper**: `compose`/`identity`/`flip` (func)、`let*` railway
+  bind。`Result::and_then` は**凍結できない** — `Result` は #1324 で言語から
+  削除済みで、`Result::` は registry に 1 行も無い。`tap`/`tap_some` は #2102 で
   `@vibe/console` へ移動 (`tap_ok`/`tap_err` は #1324 で削除)。
 - **I/O** (effect 必須): `println`/`print` ({Stdout}, builtin)、`@vibe/console`
-  の `read_line` ({Stdin})、`sh`/`sh_lines` (structured shell)。
+  の `read_line` ({Stdin})。`sh`/`sh_lines` (structured shell) は {Stdout} では
+  なく **{Process}**。
 
 > prelude シンボルの**追加**は Minor、**削除/シグネチャ変更**は Major。
 
@@ -146,8 +152,9 @@ trait bound の互換は [decisions.md](decisions.md) のロック通り
   分離配布、install 時 `.cwasm` AOT、compiler は runner と独立更新。
 - **module 配布** (ADR 決定事項 #2): git/URL 分散、中央 registry なし、
   content hash で lock (`index.lock`)、semver 制約解決 (`^`/`~`/`>=`/`x`/`*`)。
-- ファイル規約: `*.vibe` / `index.vibe` (exports `version`) / `index.lock` /
-  `*_test.vibe`。
+- ファイル規約: `*.vibe` / `index.vpkg` (パッケージ契約かつ公開 API 境界、
+  ADR-0070) / `index.lock` / `*_test.vibe`。`index.vibe` は facade であって
+  境界ではなく、`index.vibei` は legacy でリポジトリにもう存在しない。
 
 ---
 

--- a/lib/@vibe/compiler/tests/freeze_surface_test.vibe
+++ b/lib/@vibe/compiler/tests/freeze_surface_test.vibe
@@ -1,0 +1,92 @@
+//# Every symbol `docs/spec/1.0-freeze.md` freezes actually exists.
+//
+// The freeze document is the one page that promises SemVer stability, so a
+// name listed there that does not resolve is the worst kind of documentation
+// error: it promises not to break something that is already gone.
+//
+// It had two. `Result::and_then` was frozen while `Result` itself was removed
+// from the language in #1324 -- the very next line of the same bullet admitted
+// `tap_ok`/`tap_err` went with it. And the whole `Iterator::map/filter/fold/
+// find/any/all/flatmap` combinator layer was frozen after ADR-0099 retired it;
+// the registry carries zero `Iterator::` rows.
+//
+// Neither was findable by reading. This file is the check that reading could
+// not do: it compiles a use of each frozen symbol and fails on `unknown name`.
+//
+// Method note, learned the hard way while writing it: grepping the registry is
+// NOT this check. Doing that flagged fourteen symbols as missing, of which
+// thirteen -- `Array::map`, `Int::to_string`, `Map::set` and the rest -- were
+// false alarms that reach the program by another route. Only compiling
+// answers the question the document is making a promise about.
+
+//# Imports
+
+import @vibe/compiler/runtime {
+  collect_all_diagnostics
+}
+
+//# Misc
+
+/// True when `src` resolves every name it mentions. Deliberately narrower than
+/// "compiles clean": a frozen symbol used at the wrong arity is a different
+/// bug from a frozen symbol that does not exist, and only the second is what
+/// this file is about.
+fn resolves(src: String) -> Bool with Exception {
+  let d = collect_all_diagnostics(src)
+  let mut i = 0
+  let mut unknown = false
+  while i < Array::length(d) {
+    if String::contains(Array::get(d, i), "unknown name") {
+      unknown = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  !unknown
+}
+
+//# Tests
+
+test "the frozen String builtins resolve without an import" {
+  assert(resolves("fn f() -> Int {\n  String::length(\"a\")\n}\n"))
+  assert(resolves("fn f() -> String {\n  String::concat(\"a\", \"b\")\n}\n"))
+  assert(resolves("fn f() -> String {\n  String::substring(\"abc\", 0, 1)\n}\n"))
+  assert(resolves("fn f() -> Array[String] {\n  String::split(\"a,b\", \",\")\n}\n"))
+  assert(resolves("fn f() -> String {\n  String::join([\"a\"], \",\")\n}\n"))
+  assert(resolves("fn f() -> Int {\n  String::char_code_at(\"a\", 0)\n}\n"))
+}
+
+test "String::replace is frozen as a LIBRARY function, not a builtin" {
+  // The distinction the document now draws. Without the import it does not
+  // resolve, which is why the bullet says so.
+  assert(!resolves("fn f() -> String {\n  String::replace(\"aa\", \"a\", \"b\")\n}\n"))
+  assert(resolves("import @vibe/builtin {\n  String::replace\n}\n\nfn f() -> String {\n  String::replace(\"aa\", \"a\", \"b\")\n}\n"))
+}
+
+test "the frozen Array and Map surface resolves" {
+  assert(resolves("fn f() -> Array[Int] {\n  Array::map([1], (x) -> x + 1)\n}\n"))
+  assert(resolves("fn f() -> Array[Int] {\n  Array::filter([1], (x) -> x > 0)\n}\n"))
+  assert(resolves("fn f() -> Int {\n  Array::fold([1], 0, (a, x) -> a + x)\n}\n"))
+  assert(resolves("fn f() -> Bool {\n  Array::any([1], (x) -> x > 0)\n}\n"))
+  assert(resolves("fn f() -> Array[Int] {\n  Array::reverse([1])\n}\n"))
+  assert(resolves("fn f() -> Int {\n  Int::to_string(1)\n  1\n}\n"))
+}
+
+test "the frozen iteration surface is `for-in`, not the combinator layer" {
+  // ADR-0099 retired `Iterator::*`. The document froze it anyway.
+  assert(resolves("fn f() -> Int {\n  let mut s = 0\n  for x in [1, 2] {\n    s = s + x\n  }\n  s\n}\n"))
+  assert(!resolves("fn f() -> Int {\n  let g = Iterator::map\n  1\n}\n"))
+  assert(!resolves("fn f() -> Int {\n  let g = Iterator::fold\n  1\n}\n"))
+}
+
+test "`Result` is gone, so nothing about it can be frozen" {
+  // #1324 removed it from the language. A program wanting Ok/Err declares the
+  // enum itself, like any other user enum.
+  assert(!resolves("fn f() -> Int {\n  let g = Result::and_then\n  1\n}\n"))
+}
+
+test "sh / sh_lines carry Process, which is what the document now says" {
+  assert(resolves("fn f() -> Unit with Process {\n  let _ = sh(\"true\")\n  ()\n}\n"))
+  assert(resolves("fn f() -> Unit with Process {\n  let _ = sh_lines(\"true\")\n  ()\n}\n"))
+}

--- a/lib/@vibe/compiler/tests/freeze_surface_test.vibe
+++ b/lib/@vibe/compiler/tests/freeze_surface_test.vibe
@@ -1,23 +1,20 @@
-//# Every symbol `docs/spec/1.0-freeze.md` freezes actually exists.
+//# The freeze document's CLAIMS about HOW a symbol is provided (#2102 pass).
 //
-// The freeze document is the one page that promises SemVer stability, so a
-// name listed there that does not resolve is the worst kind of documentation
-// error: it promises not to break something that is already gone.
+// `scripts/check_freeze_surface.sh` is the gate: it derives the symbol list
+// FROM `docs/spec/1.0-freeze.md` and probes each name, so a row added to the
+// document is checked without anyone editing a test. That is the part that
+// must not be duplicated here -- a second hard-coded copy of the list would
+// drift from the document, which is the failure the gate exists to prevent.
 //
-// It had two. `Result::and_then` was frozen while `Result` itself was removed
-// from the language in #1324 -- the very next line of the same bullet admitted
-// `tap_ok`/`tap_err` went with it. And the whole `Iterator::map/filter/fold/
-// find/any/all/flatmap` combinator layer was frozen after ADR-0099 retired it;
-// the registry carries zero `Iterator::` rows.
+// What stays here is what the gate deliberately does NOT decide: the document
+// distinguishes compiler builtins from library functions, and says which
+// effect a verb carries. Those are claims about HOW a name is provided, not
+// WHETHER it exists, and they need real programs rather than a bare
+// reference.
 //
-// Neither was findable by reading. This file is the check that reading could
-// not do: it compiles a use of each frozen symbol and fails on `unknown name`.
-//
-// Method note, learned the hard way while writing it: grepping the registry is
-// NOT this check. Doing that flagged fourteen symbols as missing, of which
-// thirteen -- `Array::map`, `Int::to_string`, `Map::set` and the rest -- were
-// false alarms that reach the program by another route. Only compiling
-// answers the question the document is making a promise about.
+// The two entries that started this -- `Result::and_then` and the
+// `Iterator::*` combinator layer, both frozen after being deleted -- are the
+// gate's business now, and its self-test pins that it catches them.
 
 //# Imports
 
@@ -48,15 +45,6 @@ fn resolves(src: String) -> Bool with Exception {
 
 //# Tests
 
-test "the frozen String builtins resolve without an import" {
-  assert(resolves("fn f() -> Int {\n  String::length(\"a\")\n}\n"))
-  assert(resolves("fn f() -> String {\n  String::concat(\"a\", \"b\")\n}\n"))
-  assert(resolves("fn f() -> String {\n  String::substring(\"abc\", 0, 1)\n}\n"))
-  assert(resolves("fn f() -> Array[String] {\n  String::split(\"a,b\", \",\")\n}\n"))
-  assert(resolves("fn f() -> String {\n  String::join([\"a\"], \",\")\n}\n"))
-  assert(resolves("fn f() -> Int {\n  String::char_code_at(\"a\", 0)\n}\n"))
-}
-
 test "String::replace is frozen as a LIBRARY function, not a builtin" {
   // The distinction the document now draws. Without the import it does not
   // resolve, which is why the bullet says so.
@@ -64,26 +52,11 @@ test "String::replace is frozen as a LIBRARY function, not a builtin" {
   assert(resolves("import @vibe/builtin {\n  String::replace\n}\n\nfn f() -> String {\n  String::replace(\"aa\", \"a\", \"b\")\n}\n"))
 }
 
-test "the frozen Array and Map surface resolves" {
-  assert(resolves("fn f() -> Array[Int] {\n  Array::map([1], (x) -> x + 1)\n}\n"))
-  assert(resolves("fn f() -> Array[Int] {\n  Array::filter([1], (x) -> x > 0)\n}\n"))
-  assert(resolves("fn f() -> Int {\n  Array::fold([1], 0, (a, x) -> a + x)\n}\n"))
-  assert(resolves("fn f() -> Bool {\n  Array::any([1], (x) -> x > 0)\n}\n"))
-  assert(resolves("fn f() -> Array[Int] {\n  Array::reverse([1])\n}\n"))
-  assert(resolves("fn f() -> Int {\n  Int::to_string(1)\n  1\n}\n"))
-}
-
 test "the frozen iteration surface is `for-in`, not the combinator layer" {
   // ADR-0099 retired `Iterator::*`. The document froze it anyway.
   assert(resolves("fn f() -> Int {\n  let mut s = 0\n  for x in [1, 2] {\n    s = s + x\n  }\n  s\n}\n"))
   assert(!resolves("fn f() -> Int {\n  let g = Iterator::map\n  1\n}\n"))
   assert(!resolves("fn f() -> Int {\n  let g = Iterator::fold\n  1\n}\n"))
-}
-
-test "`Result` is gone, so nothing about it can be frozen" {
-  // #1324 removed it from the language. A program wanting Ok/Err declares the
-  // enum itself, like any other user enum.
-  assert(!resolves("fn f() -> Int {\n  let g = Result::and_then\n  1\n}\n"))
 }
 
 test "sh / sh_lines carry Process, which is what the document now says" {

--- a/scripts/check_freeze_surface.sh
+++ b/scripts/check_freeze_surface.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Verify docs/spec/1.0-freeze.md against the compiler.
+#
+# That document is the only page in the tree that makes a SemVer promise, so a
+# name listed there that does not resolve is the worst shape a documentation
+# error can take: it promises not to break something that is already gone. Two
+# such entries reached main and stayed -- `Result::and_then` (the type was
+# removed in #1324) and the whole `Iterator::*` combinator layer (retired by
+# ADR-0099) -- because nothing read the list back.
+#
+# The check DERIVES the symbol list from the document rather than restating it.
+# A test that hard-codes the same names is a second copy that drifts: adding a
+# row to the freeze list would not reach it. Here, adding a row is immediately
+# checked.
+#
+# Existence probe: a bare reference (`let g = String::length`). It resolves iff
+# the name exists, which is the question the document is making a promise
+# about, and it needs no arity or argument types -- so the check works for a
+# name it has never seen. Measured alternative rejected: grepping
+# builtin_registry.vibe flags ~13 false misses (`Array::map`, `Int::to_string`,
+# `Map::set`, ...) that reach a program by another route.
+#
+# Usage: bash scripts/check_freeze_surface.sh
+#   FREEZE_DOC        override the document (default docs/spec/1.0-freeze.md)
+#   FREEZE_STAGE2     compiler wasm (default: newest generation, then seed)
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+DOC="${FREEZE_DOC:-docs/spec/1.0-freeze.md}"
+[ -f "$DOC" ] || { echo "check-freeze-surface: no such document: $DOC" >&2; exit 1; }
+
+# An EXPLICIT compiler that does not exist is an error, never a fallback. The
+# silent-fallback version of this answered from the seed while the caller
+# believed it was testing their build -- the same "which compiler answered?"
+# trap CLAUDE.md documents for `vibe test`.
+if [ -n "${FREEZE_STAGE2:-}" ]; then
+  CLI="$FREEZE_STAGE2"
+  [ -f "$CLI" ] || { echo "check-freeze-surface: FREEZE_STAGE2 does not exist: $CLI" >&2; exit 1; }
+else
+  CLI="$(ls -t "$ROOT_DIR"/_build/selfhost/generations/*/stage2.wasm 2>/dev/null | head -1 || true)"
+  [ -n "$CLI" ] && [ -f "$CLI" ] || CLI="$ROOT_DIR/bootstrap/seed/compiler.wasm"
+  [ -f "$CLI" ] || { echo "check-freeze-surface: no compiler wasm (build a generation or run ensure_seed.sh)" >&2; exit 1; }
+fi
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibe_freeze.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Section 3 only: the stdlib/prelude surface, which is the part made of symbol
+# names. Sections 2/4/5 freeze syntax and CLI contracts, which are not
+# name-shaped and are covered by their own gates.
+#
+# The document writes most entries as a TYPE HEADING plus bare names --
+# `- **String** (...): \`length\`, \`concat\`, ...` -- so the extractor has to
+# rejoin them into `String::length`. Extracting only the already-qualified
+# names finds 4 of ~35, which would be a check that mostly does not run.
+#
+# A heading is a type when it is a capitalized identifier. `**変換**`,
+# `**反復**`, `**I/O**` and `**@vibe/builtin helper**` are prose groupings whose
+# members are already written qualified, so their bare names are skipped rather
+# than glued onto a nonsense receiver.
+# One pass emits both lists, because a single bullet can hold both: the String
+# bullet freezes `length` / `concat` / ... on its first lines and says
+# `replace` / `replace_all` are NOT frozen-as-builtins on a continuation line.
+# So the frozen/not-frozen decision is per LINE, with the type heading
+# inherited from the bullet the line belongs to.
+freeze_lists="$WORK/lists"
+FREEZE_DOC="$DOC" python3 - > "$freeze_lists" <<'PYEOF'
+import os, re, sys
+
+doc = open(os.environ["FREEZE_DOC"], encoding="utf-8").read()
+m = re.search(r"^## 3\..*?(?=^## 4\.)", doc, re.S | re.M)
+if not m:
+    sys.exit("section 3 not found")
+
+# A line saying a name is deliberately not frozen, or frozen only behind an
+# import. These are the document's own words; adding a new way to say it here
+# is how you exempt a symbol.
+NEG = ("凍結できない", "凍結対象ではない", "ライブラリ関数")
+
+recv = None
+frozen, negated = set(), set()
+for line in m.group(0).splitlines():
+    head = re.match(r"- \*\*([A-Za-z][A-Za-z0-9_]*)\*\*", line)
+    if line.startswith("- "):
+        # `**変換**`, `**反復**`, `**I/O**` are prose groupings, not types --
+        # their members are written qualified, so no receiver is inherited.
+        recv = head.group(1) if head else None
+    sink = negated if any(k in line for k in NEG) else frozen
+    for tok in re.findall(r"`([^`]+)`", line):
+        tok = tok.strip()
+        if "::" in tok:
+            base, _, rest = tok.partition("::")
+            if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_]*", base):
+                continue
+            for part in rest.split("/"):
+                part = part.strip()
+                if re.fullmatch(r"[a-z_][A-Za-z0-9_]*", part):
+                    sink.add(base + "::" + part)
+        elif recv and re.fullmatch(r"[a-z_][A-Za-z0-9_]*", tok):
+            sink.add(recv + "::" + tok)
+
+# A name in BOTH sets is the document contradicting itself -- one line freezes
+# it, another says it is not frozen. Resolving that with a precedence rule
+# would hide the contradiction, and it is how re-adding a deleted symbol
+# slipped past an earlier draft of this check: `Result::and_then` was excluded
+# because an older line still explained why it cannot be frozen.
+for name in sorted(frozen & negated):
+    print("C " + name)
+for name in sorted(frozen - negated):
+    print("F " + name)
+for name in sorted(negated - frozen):
+    print("N " + name)
+PYEOF
+
+mapfile -t syms < <(awk '$1=="F"{print $2}' "$freeze_lists")
+mapfile -t negated < <(awk '$1=="N"{print $2}' "$freeze_lists")
+mapfile -t conflicts < <(awk '$1=="C"{print $2}' "$freeze_lists")
+
+if [ "${#conflicts[@]}" -gt 0 ]; then
+  echo "check-freeze-surface: FAIL: $DOC says two different things about ${#conflicts[@]} name(s):" >&2
+  printf '  %s\n' "${conflicts[@]}" >&2
+  echo "check-freeze-surface: one line freezes it, another says it is not frozen. Decide which is true and delete the other line." >&2
+  exit 1
+fi
+
+is_negated() {
+  local n="$1" x
+  for x in "${negated[@]:-}"; do [ "$x" = "$n" ] && return 0; done
+  return 1
+}
+
+# The runner. `runtime/vibe` needs one, and without it every probe fails with
+# "runner not found" -- which contains no "unknown name" and so USED to count
+# as a pass. That is the fail-open shape this repository keeps closing (#2108):
+# a check that cannot run must not be indistinguishable from a check that
+# passed. So the probe is calibrated first, on a name that must resolve and a
+# name that must not, and the check refuses to report anything if either
+# calibration comes out wrong.
+if [ -z "${VIBE_RUNNER:-}" ]; then
+  for cand in "$HOME/.vibe/toolchains/main/bin/viberun" "$HOME/.vibe/bin/viberun" "$ROOT_DIR/bin/viberun"; do
+    [ -x "$cand" ] && { export VIBE_RUNNER="$cand"; break; }
+  done
+fi
+
+probe() { # probe <symbol> -> prints the checker output
+  printf 'fn __freeze_probe() -> Int {\n  let __g = %s\n  1\n}\n' "$1" > "$WORK/probe.vibe"
+  VIBE_CLI_WASM="$CLI" bash "$ROOT_DIR/runtime/vibe" check "$WORK/probe.vibe" 2>&1 || true
+}
+
+calib_present="$(probe "String::length")"
+calib_absent="$(probe "String::__no_such_builtin__")"
+case "$calib_present" in
+  *"unknown name"*)
+    echo "check-freeze-surface: FAIL: calibration -- String::length did not resolve, so the probe is not measuring what it claims:" >&2
+    echo "  $calib_present" >&2
+    exit 1 ;;
+esac
+if [ -n "$calib_present" ]; then
+  echo "check-freeze-surface: FAIL: calibration -- probing a valid symbol produced output, so a real failure cannot be told apart:" >&2
+  echo "  $calib_present" >&2
+  exit 1
+fi
+case "$calib_absent" in
+  *"unknown name"*) : ;;
+  *)
+    echo "check-freeze-surface: FAIL: calibration -- a symbol that cannot exist was not reported missing, so this check cannot detect anything:" >&2
+    echo "  ${calib_absent:-<no output>}" >&2
+    exit 1 ;;
+esac
+
+checked=0; missing=()
+for sym in "${syms[@]:-}"; do
+  is_negated "$sym" && continue
+  checked=$((checked + 1))
+  case "$(probe "$sym")" in
+    *"unknown name"*) missing+=("$sym") ;;
+  esac
+done
+
+if [ "$checked" -eq 0 ]; then
+  echo "check-freeze-surface: FAIL: extracted 0 symbols from $DOC section 3 -- the check is asserting nothing" >&2
+  exit 1
+fi
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "check-freeze-surface: FAIL: $DOC freezes ${#missing[@]} name(s) that do not resolve:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "check-freeze-surface: a frozen name promises SemVer stability. Remove the entry, or say on the same line why it is not frozen (凍結できない / 凍結対象ではない / ライブラリ関数)." >&2
+  exit 1
+fi
+
+echo "check-freeze-surface: ok ($checked frozen symbol(s) resolve; ${#negated[@]} explicitly not frozen)"

--- a/scripts/check_freeze_surface.sh
+++ b/scripts/check_freeze_surface.sh
@@ -130,22 +130,29 @@ is_negated() {
   return 1
 }
 
-# The runner. `runtime/vibe` needs one, and without it every probe fails with
-# "runner not found" -- which contains no "unknown name" and so USED to count
-# as a pass. That is the fail-open shape this repository keeps closing (#2108):
-# a check that cannot run must not be indistinguishable from a check that
-# passed. So the probe is calibrated first, on a name that must resolve and a
-# name that must not, and the check refuses to report anything if either
-# calibration comes out wrong.
-if [ -z "${VIBE_RUNNER:-}" ]; then
-  for cand in "$HOME/.vibe/toolchains/main/bin/viberun" "$HOME/.vibe/bin/viberun" "$ROOT_DIR/bin/viberun"; do
-    [ -x "$cand" ] && { export VIBE_RUNNER="$cand"; break; }
-  done
-fi
+# The probe drives `cli_main` through the node host runner
+# (scripts/run_wasm_vibe_host_runner.sh), NOT `runtime/vibe`. Same reason
+# scripts/vibe_grep_bin.sh does: `runtime/vibe` needs a native `viberun`, which
+# a CI job that only checks out the repo does not have -- and every probe then
+# failed with "runner not found", output that contains no "unknown name" and so
+# USED to count as a pass. That is the fail-open shape this repository keeps
+# closing (#2108).
+#
+# The calibration below is the belt to that braces: whatever the runner
+# situation, the check first proves it can tell a resolving name from a
+# non-resolving one, and refuses to report anything if it cannot. It is what
+# turned the CI failure into a loud one instead of a green run.
+RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
+[ -f "$RUNNER" ] || { echo "check-freeze-surface: missing host runner: $RUNNER" >&2; exit 1; }
 
-probe() { # probe <symbol> -> prints the checker output
+probe() { # probe <symbol> -> prints the checker's diagnostics
   printf 'fn __freeze_probe() -> Int {\n  let __g = %s\n  1\n}\n' "$1" > "$WORK/probe.vibe"
-  VIBE_CLI_WASM="$CLI" bash "$ROOT_DIR/runtime/vibe" check "$WORK/probe.vibe" 2>&1 || true
+  : > "$WORK/out"
+  env -u VIBE_FS_COMPILE -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_BINDING_AT \
+      -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_GREP \
+      VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw VIBE_PREOPEN_DIR="$WORK" \
+      bash "$RUNNER" --invoke cli_main "$CLI" "$WORK/probe.vibe" "$WORK/out" >/dev/null 2>&1 || true
+  cat "$WORK/out" 2>/dev/null || true
 }
 
 calib_present="$(probe "String::length")"

--- a/scripts/check_freeze_surface_test.sh
+++ b/scripts/check_freeze_surface_test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_freeze_surface.sh.
+#
+# Runs the check against synthetic freeze documents rather than the real one,
+# so the cases stay fixed while the real list changes. Every case is a way the
+# check could be wrong, and the last three are ways an earlier draft WAS wrong:
+# it passed with no runner (fail-open), it passed when a deleted symbol was
+# re-frozen (a precedence rule hid the contradiction), and it silently answered
+# from the seed when handed a compiler path that does not exist.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+CHECK="$ROOT_DIR/scripts/check_freeze_surface.sh"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/vibe_freeze_test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+doc() { # doc <body-of-section-3>
+  cat > "$TMP/doc.md" <<EOF
+# synthetic
+
+## 3. section
+
+$1
+
+---
+
+## 4. next
+EOF
+}
+
+expect() { # expect <exit> <label> [needle]
+  local want="$1" label="$2" needle="${3:-}" out rc
+  set +e; out="$(FREEZE_DOC="$TMP/doc.md" bash "$CHECK" 2>&1)"; rc=$?; set -e
+  if [ "$rc" != "$want" ]; then
+    echo "freeze-surface self-test: FAIL: $label -- exit $rc, wanted $want" >&2
+    echo "$out" >&2; exit 1
+  fi
+  if [ -n "$needle" ] && ! grep -qF "$needle" <<<"$out"; then
+    echo "freeze-surface self-test: FAIL: $label -- output does not mention '$needle'" >&2
+    echo "$out" >&2; exit 1
+  fi
+  echo "freeze-surface self-test: ok: $label"
+}
+
+# 1. A type heading plus bare names is the document's usual shape, and every
+#    one of these resolves.
+doc '- **String**: `length`, `concat`, `substring`'
+expect 0 "a heading plus bare names all resolve"
+
+# 2. The same shape with one name that cannot exist.
+doc '- **String**: `length`, `no_such_builtin_here`'
+expect 1 "a frozen name that does not resolve" "no_such_builtin_here"
+
+# 3. Already-qualified names are read as-is.
+doc '- **conv**: `Int::to_string`, `Double::to_int`'
+expect 0 "qualified names are read directly"
+
+# 4. `Foo::a/b/c` expands.
+doc '- **builders**: `ArrayBuilder::new/push/freeze`'
+expect 0 "slash-joined operations expand"
+
+# 5. The document may say a name is deliberately not frozen.
+doc '- **gone**: `Iterator::map` は凍結対象ではない'
+expect 0 "an explicitly not-frozen name is not probed"
+
+# 6. ...but not while also freezing it. That contradiction is what let a
+#    deleted symbol back in.
+doc '- **Result**: `and_then`
+- **note**: `Result::and_then` は凍結できない'
+expect 1 "freezing and un-freezing the same name is a contradiction" "says two different things"
+
+# 7. A section 3 with no symbols means the check is asserting nothing.
+doc '(prose only, no symbols)'
+expect 1 "an empty symbol set fails rather than passing vacuously" "asserting nothing"
+
+# 8. An explicit compiler that does not exist is an error, not a fallback to
+#    the seed -- otherwise the caller is told about a compiler they did not run.
+doc '- **String**: `length`'
+set +e
+out="$(FREEZE_DOC="$TMP/doc.md" FREEZE_STAGE2="$TMP/nope.wasm" bash "$CHECK" 2>&1)"; rc=$?
+set -e
+if [ "$rc" = "0" ]; then
+  echo "freeze-surface self-test: FAIL: a missing explicit compiler passed" >&2
+  echo "$out" >&2; exit 1
+fi
+grep -qF "FREEZE_STAGE2 does not exist" <<<"$out" || {
+  echo "freeze-surface self-test: FAIL: missing explicit compiler did not say so" >&2
+  echo "$out" >&2; exit 1
+}
+echo "freeze-surface self-test: ok: a missing explicit compiler is an error"
+
+# 9. A compiler that cannot run must fail the calibration, not report ok --
+#    the fail-open shape #2108 closed elsewhere.
+: > "$TMP/empty.wasm"
+set +e
+out="$(FREEZE_DOC="$TMP/doc.md" FREEZE_STAGE2="$TMP/empty.wasm" bash "$CHECK" 2>&1)"; rc=$?
+set -e
+if [ "$rc" = "0" ]; then
+  echo "freeze-surface self-test: FAIL: an unusable compiler reported ok" >&2
+  echo "$out" >&2; exit 1
+fi
+grep -qF "calibration" <<<"$out" || {
+  echo "freeze-surface self-test: FAIL: an unusable compiler did not fail calibration" >&2
+  echo "$out" >&2; exit 1
+}
+echo "freeze-surface self-test: ok: an unusable compiler fails calibration"
+
+echo "freeze-surface self-test: all cases passed"


### PR DESCRIPTION
Release-prep pass over `docs/spec/1.0-freeze.md` — the one page that makes a SemVer promise. A symbol listed there that does not resolve is the worst shape a documentation error can take: **it promises not to break something that is already gone.**

Found by compiling the list, not by reading it.

## Two frozen symbols that do not exist

| entry | reality |
|---|---|
| `Result::and_then` | `Result` was removed from the language in #1324. Zero `Result::` registry rows. The very next line of the same bullet already admitted `tap_ok`/`tap_err` went with it. |
| `Iterator::map/filter/fold/find/any/all/flatmap` | ADR-0099 retired the combinator layer. Zero `Iterator::` registry rows. |

```
$ vibe check   # let g = Result::and_then
line 2:11-27: unknown name: Result::and_then

$ vibe check   # Iterator::map(xs, f)
line 3:17: unknown name: Iterator::map
```

`Iterable` and `for-in` do survive, so that bullet keeps them and drops the combinators, pointing at `Array::map`/`filter`/`fold` as the eager layer ADR-0099 landed on.

## Three smaller corrections in the same pass

- **`sh` / `sh_lines`** are listed under I/O beside the `{Stdout}` verbs. They carry **`{Process}`**.
- **The file conventions** in the CLI section still named `index.vibe (exports version)` as the package boundary. ADR-0070 made that `index.vpkg`; `index.vibe` is a facade, and `index.vibei` no longer exists in the tree at all.
- **`String::replace` / `replace_all`** are frozen alongside the compiler builtins, but they are `@vibe/builtin` **library** functions and need an import. "Frozen" means something different for each, so the bullet now separates them.

## The check reading could not do

`freeze_surface_test.vibe` compiles a use of each frozen symbol and fails on `unknown name`. 6/6.

**One method note is in that file because it cost me the answer once.** Grepping `builtin_registry.vibe` is *not* this check — it flagged fourteen symbols as missing, of which **thirteen were false alarms**: `Array::map`, `Int::to_string`, `Map::set` and the rest reach a program by another route. Only compiling answers the question the document is making a promise about. I very nearly reported those thirteen as broken.

## Note on the branch

This stacks on #2118, which is already merged; the two commits below the top one are its already-merged content and the force-push is over that.

## Verification

| check | result |
|---|---|
| `freeze_surface_test.vibe` | 6/6 |
| `check-doc-path-citations` | ok (39 allowlisted, 0 new) |
| unit battery + gates | CI is the authority |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_