### PR TITLE
A typo in a type annotation stops being a silent wildcard (#2125)

### DIFF
--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -32,15 +32,13 @@
 #     is not a mix, stays accepted". The debt row was aimed at a rule the
 #     project had already moved off on purpose.
 #
-#   scoped_ref_param_{,nested_}decl_forbidden  still debt-accepts, but NOT for
-#     the recorded reason. `Ref[T]` does not exist in the selfhost compiler --
-#     no such builtin type, no use anywhere in lib/. These fixtures compile
-#     because an UNRESOLVED type name in a signature is accepted at all
-#     (`(r: Frobnicate[Int]) -> Int` and `(r: Frobnicate) -> Int` both compile,
-#     measured). The missing check is name resolution in type position, which
-#     is a different and much wider question than Ref escape analysis (compare
-#     ADR-0094's 実測 5: a row label is not checked to name a real effect
-#     either). Do not "restore" a Ref escape check to close these.
+#   scoped_ref_param_{,nested_}decl_forbidden  now `reject`, but NOT for the
+#     recorded reason. `Ref[T]` does not exist in the selfhost compiler -- no
+#     such builtin type, no use anywhere in lib/. These fixtures used to
+#     compile because an UNRESOLVED type name in a signature was accepted at
+#     all. #2125 made that a diagnostic, so they are rejected as "unknown type
+#     `Ref`" -- name resolution in type position, not Ref escape analysis. Do
+#     not "restore" a Ref escape check to close these.
 #
 #   polymorphic_recursion_unsupported  was debt-accepts; reclassified `ok`. The
 #     retired host could not do polymorphic recursion; the selfhost compiler
@@ -113,8 +111,8 @@ parse_let_annotation_colon	ok
 parse_loop_expr	ok	
 polymorphic_recursion_unsupported	ok	
 property_access_ambiguous_function_vs_field	ok	
-scoped_ref_param_decl_forbidden	debt-accepts	type: scoped Ref[T] cannot escape: function parameter
-scoped_ref_param_nested_decl_forbidden	debt-accepts	type: scoped Ref[T] cannot escape: function parameter
+scoped_ref_param_decl_forbidden	reject	unknown type `Ref` in parameter `r`
+scoped_ref_param_nested_decl_forbidden	reject	unknown type `Ref` in parameter `f`
 suberror_brace_ctor_arity_mismatch	reject	function arity mismatch for Io: expected 1 args, got 0
 suberror_brace_payload_type_mismatch	reject	argument type mismatch for Parse: expected Int, got String
 suberror_brace_raise_ok	ok	
@@ -246,7 +244,7 @@ err_type_divide_by_zero	debt-accepts
 err_type_eq_operator_requires_eq_bound	debt-accepts	
 err_type_member_receiver_mismatch	debt-accepts	
 err_type_ord_operator_requires_ord_bound	debt-accepts	
-err_type_undefined_type	debt-accepts	
+err_type_undefined_type	reject	unknown type `NonExistent` in parameter `x`
 err_import_kind_mismatch_trait	debt-accepts	
 
 # --- adopted from fixtures/ after a mechanical rewrite (#1571) -------------

--- a/lib/@vibe/builtin/lazy_iter_test.vibe
+++ b/lib/@vibe/builtin/lazy_iter_test.vibe
@@ -1,6 +1,7 @@
 //# Imports
 
 import ./lazy_iter.vibe {
+  LazyIter,
   lazy_iter_all,
   lazy_iter_any,
   lazy_iter_arr,

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -14,6 +14,15 @@ import @vibe/core {
   array_empty
 }
 
+// #2125: the two observation wrappers below annotate parameters with types
+// this package's contract declares BODYLESS (`type CheckedProgram`). A
+// bodyless declaration has no `TypeDef`, so the annotation used to resolve to
+// a bare `CtNamed` -- indistinguishable from a typo, and unchecked. Import
+// the real declarations from the sibling that owns them.
+import ./checker_stmt.vibe {
+  CheckedProgram, CheckedProgramTypeDefsObservation
+}
+
 //# Encoding helpers
 
 fn canonical_piece(text: String) -> String {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -55,7 +55,7 @@ import ./checker_pattern.vibe {
 }
 
 import ./checker_resolve.vibe {
-  resolve_type_expr, resolve_type_expr_shadowed, subst_type_params
+  collect_unknown_type_names, resolve_type_expr, resolve_type_expr_shadowed, subst_type_params
 }
 
 import ./checker_spawnable.vibe {
@@ -128,12 +128,76 @@ export fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, na
       // `find_fn_anchor_off` already prefers `fn name` then `let name`, so the
       // binder is recoverable from the name alone.
       let unlocated = String::index_of(msg, " [@") < 0
-      let anchorable = String::starts_with(msg, "return type mismatch") || String::starts_with(msg, "binding type mismatch for ")
+      // #2125: `unknown type` is reported from a function literal's parameter
+      // and return annotations, which carry no offset of their own -- so it
+      // anchors on the declaration name exactly like the two above.
+      let anchorable = String::starts_with(msg, "return type mismatch") || String::starts_with(msg, "binding type mismatch for ") || String::starts_with(msg, "unknown type `")
       if anchorable && unlocated {
         Array::set(errors, i, String::concat(msg, String::concat(" [@fn=", String::concat(name, "]"))))
       }
       i = i + 1
     }
+  }
+}
+
+/// #2125: true when a trait in scope declares `name` as one of ITS OWN type
+/// parameters -- the `T` of `trait Iterator[T] { next(Self) -> Option[T] }`.
+///
+/// Such a name is deliberately unresolvable, and that is not an oversight: the
+/// uniform representation ERASES a trait's element params, so every use is
+/// relaxed to `CtUnknown` (see `relax_unknown_named`). An `impl` method spells
+/// them in its own signature -- `next(self) -> Option[(T, LazyIter)]` -- with
+/// no binder of its own to shadow them, so it reaches annotation resolution
+/// looking exactly like a typo. Scoped to names some trait actually declares,
+/// rather than exempting `impl` bodies wholesale, so a genuine typo inside one
+/// is still reported.
+fn env_trait_declares_type_param(env: TypeEnv, name: String) -> Bool {
+  match env {
+    EnvEmpty => false,
+    EnvBind(_, _, rest) => env_trait_declares_type_param(rest, name),
+    EnvTraitDef(_, params, _, _, rest, header_params, _) => string_array_has(params, name) || string_array_has(header_params, name) || env_trait_declares_type_param(rest, name),
+    EnvTraitImpl(_, _, rest) => env_trait_declares_type_param(rest, name),
+    EnvTraitImplGen(_, params, _, _, rest) => string_array_has(params, name) || env_trait_declares_type_param(rest, name),
+    EnvMutCell(_, _, rest) => env_trait_declares_type_param(rest, name),
+    EnvTypeDefs(_, _, rest) => env_trait_declares_type_param(rest, name),
+    EnvCached(_, _, rest) => env_trait_declares_type_param(rest, name),
+    EnvFlat(_) => false
+  }
+}
+
+/// #2125: report every type name in `te` that resolves to NOTHING, so a typo
+/// stops behaving as a wildcard. `resolve_type_expr_shadowed` turns such a
+/// name into `CtNamed(name, [])` -- the same shape as an un-instantiated
+/// generic formal, whose unify failures `check_assignable` must tolerate so as
+/// not to over-reject polymorphic code.
+///
+/// `shadow` is not the authority on what a formal is: a lambda nested in a
+/// generic function resolves its own parameters with its OWN (empty)
+/// `tparams`, so the enclosing `T` is invisible there. The ENV is, and it
+/// answers two questions at once, which is why the test is "bound at all"
+/// rather than "bound to a `CtVar`":
+///   - a type formal is bound to a `CtVar` by whichever binder introduced it
+///     (that is exactly what `resolve_tparams_in` reads), so this covers every
+///     binder including ones nobody has enumerated;
+///   - a REGION TOKEN is bound as an ordinary value and is spelled in
+///     type-argument position (`MutList[T, outer_region]`, ADR-0090), so it
+///     reaches this walk looking like a type name and is not one.
+export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, where_label: String, errors: Array[String]) -> Unit {
+  let out = array_empty()
+  collect_unknown_type_names(te, defs, shadow, out)
+  let mut i = 0
+  while i < Array::length(out) {
+    let name = Array::get(out, i)
+    let bound_in_env = match env_lookup(env, name) {
+      Some(_) => true,
+      None => false
+    }
+    if bound_in_env || env_trait_declares_type_param(env, name) {
+      ()
+    } else {
+      Array::push(errors, String::concat(String::concat(String::concat("unknown type `", name), "` in "), where_label))
+    }
+    i = i + 1
   }
 }
 
@@ -7489,6 +7553,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             // equality. `env` already binds each formal to a fresh `CtVar` (see
             // the EFn arm's `tp_env`), so the mapping is available right here.
             let resolved = resolve_tparams_in(resolve_type_expr(ann_te, defs), env)
+            // #2125: a body-level `let y: Intt = ..` annotation. `shadow` is
+            // empty here by construction (the ascription lambda carries no
+            // formals of its own); the env is what knows the enclosing
+            // declaration's, which is exactly the #2130 mapping above.
+            report_unknown_type_names(ann_te, defs, array_empty(), env, "a local let annotation", errors)
             let actual = subst_apply(ns0, at)
             // #981: `check_assignable` now runs the #844 same-name concrete
             // `CtNamed` check itself (its tolerate branch calls
@@ -8678,6 +8747,9 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             // still finds `CtNamed(<tparam>, [])` to map onto the fresh var.
             let resolved = resolve_type_expr_shadowed(te, defs, tparams)
             let pt2 = resolve_tparams_in(resolved, fn_env)
+            // #2125: an unresolvable name here becomes a wildcard at every
+            // call site, so `f("s")` and `f(1)` both pass the SAME slot.
+            report_unknown_type_names(te, defs, tparams, fn_env, String::concat(String::concat("parameter `", name), "`"), errors)
             (pt2, s1, c1)
           },
           None => {
@@ -8709,7 +8781,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       // rejected it once the #941 railway-conflict report landed. CtUnknown
       // unifies with anything, so the EReturn check is inert for it.
       let annotated_body_env = match ret_ty {
-        Some(rte) => env_bind(fn_env, "__return__", resolve_tparams_in(resolve_type_expr_shadowed(rte, defs, tparams), fn_env)),
+        Some(rte) => {
+          // #2125: see the parameter arm above.
+          report_unknown_type_names(rte, defs, tparams, fn_env, "the return type", errors)
+          env_bind(fn_env, "__return__", resolve_tparams_in(resolve_type_expr_shadowed(rte, defs, tparams), fn_env))
+        },
         None => env_bind(fn_env, "__return__", CtUnknown)
       }
       let (return_provenance, return_c) = fresh_var(c1)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -148,9 +148,34 @@ export fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, na
 /// relaxed to `CtUnknown` (see `relax_unknown_named`). An `impl` method spells
 /// them in its own signature -- `next(self) -> Option[(T, LazyIter)]` -- with
 /// no binder of its own to shadow them, so it reaches annotation resolution
-/// looking exactly like a typo. Scoped to names some trait actually declares,
-/// rather than exempting `impl` bodies wholesale, so a genuine typo inside one
-/// is still reported.
+/// looking exactly like a typo.
+///
+/// Doubly scoped, because either half alone is a hole: only names some trait
+/// actually declares (so a genuine typo inside an impl method is still
+/// reported), and only inside an impl method's body (so merely DECLARING
+/// `trait Iter[T]` does not excuse `fn f(x: T)` in the same file -- it did,
+/// measured, until `env_in_impl_method_body` gated this).
+/// #2125: the env key under which an `impl` method's body is checked. An impl
+/// method is parsed as `let <Type>::<method> = (..) -> ..` (parser.vibe's
+/// `parse_impl_methods`), and only in THAT body may a trait's own erased type
+/// parameter appear unbound -- see `env_trait_declares_type_param`. Bound only
+/// around the value being checked, never into the environment the statement
+/// returns, so it cannot reach a published or cached env.
+let impl_method_body_env_key: String = "__impl_method_body__"
+
+/// #2125: is this annotation being resolved inside an `impl` method's body?
+export fn env_in_impl_method_body(env: TypeEnv) -> Bool {
+  match env_lookup(env, impl_method_body_env_key) {
+    Some(_) => true,
+    None => false
+  }
+}
+
+/// #2125: mark `env` as an `impl` method's body environment.
+export fn env_mark_impl_method_body(env: TypeEnv) -> TypeEnv {
+  env_bind(env, impl_method_body_env_key, CtUnit)
+}
+
 fn env_trait_declares_type_param(env: TypeEnv, name: String) -> Bool {
   match env {
     EnvEmpty => false,
@@ -171,28 +196,42 @@ fn env_trait_declares_type_param(env: TypeEnv, name: String) -> Bool {
 /// generic formal, whose unify failures `check_assignable` must tolerate so as
 /// not to over-reject polymorphic code.
 ///
-/// `shadow` is not the authority on what a formal is: a lambda nested in a
-/// generic function resolves its own parameters with its OWN (empty)
-/// `tparams`, so the enclosing `T` is invisible there. The ENV is, and it
-/// answers two questions at once, which is why the test is "bound at all"
-/// rather than "bound to a `CtVar`":
-///   - a type formal is bound to a `CtVar` by whichever binder introduced it
-///     (that is exactly what `resolve_tparams_in` reads), so this covers every
-///     binder including ones nobody has enumerated;
-///   - a REGION TOKEN is bound as an ordinary value and is spelled in
-///     type-argument position (`MutList[T, outer_region]`, ADR-0090), so it
-///     reaches this walk looking like a type name and is not one.
-export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, where_label: String, errors: Array[String]) -> Unit {
+/// Every exemption below is a BINDER in scope for this annotation, which is
+/// the whole rule -- an unresolved name that no binder introduces is a typo:
+///
+///   1. a type formal. `shadow` is not the authority on what one is: a lambda
+///      nested in a generic function resolves its own parameters with its OWN
+///      (empty) `tparams`, so the enclosing `T` is invisible there. The env is
+///      -- whichever binder introduced the formal bound it to a `CtVar`, which
+///      is exactly what `resolve_tparams_in` reads.
+///   2. a REGION TOKEN bound by an enclosing `region r { .. }` (ADR-0090). It
+///      is an ordinary value binding spelled in type-argument position
+///      (`MutList[Int, r]`), so it reaches this walk looking like a type name.
+///      Recognised by the rigid skolem the region binder binds it to
+///      (`#region_<n>`, a name no source can spell), NOT by "some value has
+///      this name" -- that would let `let Intt = 1` excuse `x: Intt`.
+///   3. a region ROW VARIABLE declared by this very signature:
+///      `fn fill(l: MutList[Int, r]) -> Unit with r`. Nothing binds `r` as a
+///      value there; the binder is the row, so the call site passes its
+///      labels in `row_binders`.
+///   4. a trait's own erased type parameter -- and ONLY inside an `impl`
+///      method's body, where the binder is the impl. See
+///      `env_trait_declares_type_param`.
+export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit {
   let out = array_empty()
   collect_unknown_type_names(te, defs, shadow, out)
   let mut i = 0
   while i < Array::length(out) {
     let name = Array::get(out, i)
-    let bound_in_env = match env_lookup(env, name) {
-      Some(_) => true,
+    let bound_by_binder = match env_lookup(env, name) {
+      Some(t) => match t {
+        CtVar(_) => true,
+        CtNamed(bound_name, _) => String::starts_with(bound_name, "#region_"),
+        _ => false
+      },
       None => false
     }
-    if bound_in_env || env_trait_declares_type_param(env, name) {
+    if bound_by_binder || string_array_has(row_binders, name) || (env_in_impl_method_body(env) && env_trait_declares_type_param(env, name)) {
       ()
     } else {
       Array::push(errors, String::concat(String::concat(String::concat("unknown type `", name), "` in "), where_label))
@@ -7557,7 +7596,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             // empty here by construction (the ascription lambda carries no
             // formals of its own); the env is what knows the enclosing
             // declaration's, which is exactly the #2130 mapping above.
-            report_unknown_type_names(ann_te, defs, array_empty(), env, "a local let annotation", errors)
+            report_unknown_type_names(ann_te, defs, array_empty(), env, array_empty(), "a local let annotation", errors)
             let actual = subst_apply(ns0, at)
             // #981: `check_assignable` now runs the #844 same-name concrete
             // `CtNamed` check itself (its tolerate branch calls
@@ -8730,6 +8769,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       let mut fn_env = env_bind(tp_env, "__capture_boundary__", CtUnit)
       let mut s1 = s0
       let mut c1 = c0
+      // #2125: this signature's OWN effect row. A region row variable is
+      // declared there and nowhere else -- `fn fill(l: MutList[Int, r]) ->
+      // Unit with r` binds `r` by the row, so the annotations below must not
+      // read it as a type name (#1863's helper signatures are exactly this).
+      let declared_row_binders = row_labels(effect)
       let param_types = array_empty()
       let mut pi = 0
       while pi < plen {
@@ -8749,7 +8793,17 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             let pt2 = resolve_tparams_in(resolved, fn_env)
             // #2125: an unresolvable name here becomes a wildcard at every
             // call site, so `f("s")` and `f(1)` both pass the SAME slot.
-            report_unknown_type_names(te, defs, tparams, fn_env, String::concat(String::concat("parameter `", name), "`"), errors)
+            //
+            // A `__dict_`-prefixed parameter is already rejected outright by
+            // the #1869 reserved-prefix rule (desugar_trait_dict.vibe), and
+            // that is the actionable edit -- reporting its annotation on top
+            // would only bury it, since a witness dictionary's type has no
+            // TypeDef either.
+            if String::starts_with(name, "__dict_") {
+              ()
+            } else {
+              report_unknown_type_names(te, defs, tparams, fn_env, declared_row_binders, String::concat(String::concat("parameter `", name), "`"), errors)
+            }
             (pt2, s1, c1)
           },
           None => {
@@ -8783,7 +8837,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       let annotated_body_env = match ret_ty {
         Some(rte) => {
           // #2125: see the parameter arm above.
-          report_unknown_type_names(rte, defs, tparams, fn_env, "the return type", errors)
+          report_unknown_type_names(rte, defs, tparams, fn_env, declared_row_binders, "the return type", errors)
           env_bind(fn_env, "__return__", resolve_tparams_in(resolve_type_expr_shadowed(rte, defs, tparams), fn_env))
         },
         None => env_bind(fn_env, "__return__", CtUnknown)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -32,6 +32,7 @@ import @vibe/compiler/core {
   subst_apply,
   subst_bounds_for,
   trait_method_sig_binders_deep,
+  type_constructor_name,
   type_implements_trait,
   type_name_has_iterator_impl,
   type_to_string,
@@ -140,53 +141,106 @@ export fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, na
   }
 }
 
-/// #2125: true when a trait in scope declares `name` as one of ITS OWN type
-/// parameters -- the `T` of `trait Iterator[T] { next(Self) -> Option[T] }`.
-///
-/// Such a name is deliberately unresolvable, and that is not an oversight: the
-/// uniform representation ERASES a trait's element params, so every use is
-/// relaxed to `CtUnknown` (see `relax_unknown_named`). An `impl` method spells
-/// them in its own signature -- `next(self) -> Option[(T, LazyIter)]` -- with
-/// no binder of its own to shadow them, so it reaches annotation resolution
-/// looking exactly like a typo.
-///
-/// Doubly scoped, because either half alone is a hole: only names some trait
-/// actually declares (so a genuine typo inside an impl method is still
-/// reported), and only inside an impl method's body (so merely DECLARING
-/// `trait Iter[T]` does not excuse `fn f(x: T)` in the same file -- it did,
-/// measured, until `env_in_impl_method_body` gated this).
-/// #2125: the env key under which an `impl` method's body is checked. An impl
-/// method is parsed as `let <Type>::<method> = (..) -> ..` (parser.vibe's
-/// `parse_impl_methods`), and only in THAT body may a trait's own erased type
-/// parameter appear unbound -- see `env_trait_declares_type_param`. Bound only
-/// around the value being checked, never into the environment the statement
-/// returns, so it cannot reach a published or cached env.
-let impl_method_body_env_key: String = "__impl_method_body__"
+/// #2125: the env key prefix under which an `impl` method's body carries the
+/// trait type parameters its signature may legally leave unbound. One key per
+/// NAME, bound only around the value being checked -- never into the
+/// environment the statement returns -- so it cannot reach a published or
+/// cached env.
+let trait_erased_type_param_prefix: String = "__trait_erased_tp__"
 
-/// #2125: is this annotation being resolved inside an `impl` method's body?
-export fn env_in_impl_method_body(env: TypeEnv) -> Bool {
-  match env_lookup(env, impl_method_body_env_key) {
-    Some(_) => true,
-    None => false
+/// True when some entry of `methods` declares a method named `method_name`.
+fn trait_methods_declare(methods: Array[(String, Array[TypeExpr], TypeExpr)], method_name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(methods) && !found {
+    let (mname, _, _) = Array::get(methods, i)
+    if mname == method_name {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// True when `env` records an impl of `trait_name` for the type named
+/// `type_name` -- the binder that licenses the trait's erased parameters
+/// inside that impl's methods.
+fn env_has_trait_impl_for(env: TypeEnv, trait_name: String, type_name: String) -> Bool {
+  match env {
+    EnvEmpty => false,
+    EnvBind(_, _, rest) => env_has_trait_impl_for(rest, trait_name, type_name),
+    EnvTraitDef(_, _, _, _, rest, _, _) => env_has_trait_impl_for(rest, trait_name, type_name),
+    EnvTraitImpl(tn, target, rest) => (tn == trait_name && type_constructor_name(target) == type_name) || env_has_trait_impl_for(rest, trait_name, type_name),
+    EnvTraitImplGen(tn, _, _, target, rest) => (tn == trait_name && type_constructor_name(target) == type_name) || env_has_trait_impl_for(rest, trait_name, type_name),
+    EnvMutCell(_, _, rest) => env_has_trait_impl_for(rest, trait_name, type_name),
+    EnvTypeDefs(_, _, rest) => env_has_trait_impl_for(rest, trait_name, type_name),
+    EnvCached(_, _, rest) => env_has_trait_impl_for(rest, trait_name, type_name),
+    EnvFlat(_) => false
   }
 }
 
-/// #2125: mark `env` as an `impl` method's body environment.
-export fn env_mark_impl_method_body(env: TypeEnv) -> TypeEnv {
-  env_bind(env, impl_method_body_env_key, CtUnit)
+fn collect_impl_erased_type_params(chain: TypeEnv, full: TypeEnv, type_name: String, method_name: String, out: Array[String]) -> Unit {
+  match chain {
+    EnvEmpty => (),
+    EnvBind(_, _, rest) => collect_impl_erased_type_params(rest, full, type_name, method_name, out),
+    EnvTraitDef(trait_name, params, _, methods, rest, header_params, _) => {
+      if trait_methods_declare(methods, method_name) && env_has_trait_impl_for(full, trait_name, type_name) {
+        let mut pi = 0
+        while pi < Array::length(params) {
+          Array::push(out, Array::get(params, pi))
+          pi = pi + 1
+        }
+        let mut hi = 0
+        while hi < Array::length(header_params) {
+          Array::push(out, Array::get(header_params, hi))
+          hi = hi + 1
+        }
+      } else {
+        ()
+      }
+      collect_impl_erased_type_params(rest, full, type_name, method_name, out)
+    },
+    EnvTraitImpl(_, _, rest) => collect_impl_erased_type_params(rest, full, type_name, method_name, out),
+    EnvTraitImplGen(_, _, _, _, rest) => collect_impl_erased_type_params(rest, full, type_name, method_name, out),
+    EnvMutCell(_, _, rest) => collect_impl_erased_type_params(rest, full, type_name, method_name, out),
+    EnvTypeDefs(_, _, rest) => collect_impl_erased_type_params(rest, full, type_name, method_name, out),
+    EnvCached(_, _, rest) => collect_impl_erased_type_params(rest, full, type_name, method_name, out),
+    EnvFlat(_) => ()
+  }
 }
 
-fn env_trait_declares_type_param(env: TypeEnv, name: String) -> Bool {
-  match env {
-    EnvEmpty => false,
-    EnvBind(_, _, rest) => env_trait_declares_type_param(rest, name),
-    EnvTraitDef(_, params, _, _, rest, header_params, _) => string_array_has(params, name) || string_array_has(header_params, name) || env_trait_declares_type_param(rest, name),
-    EnvTraitImpl(_, _, rest) => env_trait_declares_type_param(rest, name),
-    EnvTraitImplGen(_, params, _, _, rest) => string_array_has(params, name) || env_trait_declares_type_param(rest, name),
-    EnvMutCell(_, _, rest) => env_trait_declares_type_param(rest, name),
-    EnvTypeDefs(_, _, rest) => env_trait_declares_type_param(rest, name),
-    EnvCached(_, _, rest) => env_trait_declares_type_param(rest, name),
-    EnvFlat(_) => false
+/// #2125: bind the erased type parameters an IMPL METHOD's signature may
+/// legally spell without a binder of its own -- the `T` of
+/// `trait Iterator[T]` in `impl Iterator for LazyIter { next(self) ->
+/// Option[(T, LazyIter)] }`. The uniform representation erases those
+/// parameters and `relax_unknown_named` relaxes every use to `CtUnknown`, so
+/// they resolve to nothing and look exactly like a typo.
+///
+/// Codex on #2147 (round 2): PROVENANCE, not a name shape. `parse_impl_methods`
+/// lowers an impl to `let <Type>::<method> = (..) -> ..` emitted after its
+/// `SImpl`, so the impl is already in the env when the method is checked --
+/// this asks the env the question the impl answers: does a trait in scope
+/// declare a method of THIS name, carry type parameters, and have an impl for
+/// THIS type? A qualified name alone is not that question, and treating it as
+/// one exempted every associated function: `fn Array::bad(x: T) -> Int { 1 }`
+/// compiled clean whenever any in-scope trait declared a `T` (measured).
+export fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> TypeEnv {
+  let sep = String::index_of(binding_name, "::")
+  if sep < 0 {
+    env
+  } else {
+    let type_name = String::substring(binding_name, 0, sep)
+    let method_name = String::substring(binding_name, sep + 2, String::length(binding_name))
+    let names = array_empty()
+    collect_impl_erased_type_params(env, env, type_name, method_name, names)
+    let mut out = env
+    let mut i = 0
+    while i < Array::length(names) {
+      out = env_bind(out, String::concat(trait_erased_type_param_prefix, Array::get(names, i)), CtUnit)
+      i = i + 1
+    }
+    out
   }
 }
 
@@ -214,9 +268,9 @@ fn env_trait_declares_type_param(env: TypeEnv, name: String) -> Bool {
 ///      `fn fill(l: MutList[Int, r]) -> Unit with r`. Nothing binds `r` as a
 ///      value there; the binder is the row, so the call site passes its
 ///      labels in `row_binders`.
-///   4. a trait's own erased type parameter -- and ONLY inside an `impl`
-///      method's body, where the binder is the impl. See
-///      `env_trait_declares_type_param`.
+///   4. a trait's own erased type parameter, and only where an actual IMPL
+///      binds it -- see `trait_erased_type_param_env`, which asks the env for
+///      the impl rather than inferring one from the binding's name.
 export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit {
   let out = array_empty()
   collect_unknown_type_names(te, defs, shadow, out)
@@ -231,7 +285,11 @@ export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: 
       },
       None => false
     }
-    if bound_by_binder || string_array_has(row_binders, name) || (env_in_impl_method_body(env) && env_trait_declares_type_param(env, name)) {
+    let trait_erased_by_impl = match env_lookup(env, String::concat(trait_erased_type_param_prefix, name)) {
+      Some(_) => true,
+      None => false
+    }
+    if bound_by_binder || string_array_has(row_binders, name) || trait_erased_by_impl {
       ()
     } else {
       Array::push(errors, String::concat(String::concat(String::concat("unknown type `", name), "` in "), where_label))
@@ -2011,6 +2069,39 @@ fn effect_label_is_exempt(lbl: String) -> Bool {
   } else {
     true
   }
+}
+
+/// #2147 review (round 2): the row entries that are effect VARIABLES -- the
+/// only entries a row declares as binders. Mirrors `is_effect_var_name`
+/// (core/types.vibe), which is file-private there; three other copies in the
+/// tree already spell it out the same way.
+fn row_label_is_variable(label: String) -> Bool {
+  let len = String::length(label)
+  if len == 1 {
+    // A source-level effect variable: a single lowercase letter (`with e`).
+    String::char_code_at(label, 0) >= 97 && String::char_code_at(label, 0) <= 122
+  } else if len >= 2 {
+    // A FRESH effect variable minted by `instantiate` (`$N`).
+    String::char_code_at(label, 0) == 36
+  } else {
+    false
+  }
+}
+
+fn row_variable_labels(row: Option[String]) -> Array[String] {
+  let out = array_empty()
+  let labels = row_labels(row)
+  let mut i = 0
+  while i < Array::length(labels) {
+    let label = Array::get(labels, i)
+    if row_label_is_variable(label) {
+      Array::push(out, label)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
 }
 
 fn row_labels(row: Option[String]) -> Array[String] {
@@ -8769,11 +8860,17 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       let mut fn_env = env_bind(tp_env, "__capture_boundary__", CtUnit)
       let mut s1 = s0
       let mut c1 = c0
-      // #2125: this signature's OWN effect row. A region row variable is
-      // declared there and nowhere else -- `fn fill(l: MutList[Int, r]) ->
-      // Unit with r` binds `r` by the row, so the annotations below must not
-      // read it as a type name (#1863's helper signatures are exactly this).
-      let declared_row_binders = row_labels(effect)
+      // #2125: the row VARIABLES this signature's own effect row declares.
+      // A region row variable is declared there and nowhere else --
+      // `fn fill(l: MutList[Int, r]) -> Unit with r` binds `r` by the row, so
+      // the annotations below must not read it as a type name (#1863's helper
+      // signatures are exactly this).
+      //
+      // Codex on #2147 (round 2): VARIABLES only. A concrete label in the same
+      // row binds nothing, and taking the whole row let
+      // `fn f(x: Async) -> Int with Async` keep `Async` as a wildcard
+      // `CtNamed` (measured) -- the very shape this issue is about.
+      let declared_row_binders = row_variable_labels(effect)
       let param_types = array_empty()
       let mut pi = 0
       while pi < plen {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -56,7 +56,7 @@ import ./checker_pattern.vibe {
 }
 
 import ./checker_resolve.vibe {
-  collect_unknown_type_names, resolve_type_expr, resolve_type_expr_shadowed, subst_type_params
+  collect_unknown_type_names, collect_unknown_type_names_regionwise, resolve_type_expr, resolve_type_expr_shadowed, subst_type_params
 }
 
 import ./checker_spawnable.vibe {
@@ -258,29 +258,57 @@ export fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> Typ
 ///      (empty) `tparams`, so the enclosing `T` is invisible there. The env is
 ///      -- whichever binder introduced the formal bound it to a `CtVar`, which
 ///      is exactly what `resolve_tparams_in` reads.
-///   2. a REGION TOKEN bound by an enclosing `region r { .. }` (ADR-0090). It
-///      is an ordinary value binding spelled in type-argument position
-///      (`MutList[Int, r]`), so it reaches this walk looking like a type name.
-///      Recognised by the rigid skolem the region binder binds it to
-///      (`#region_<n>`, a name no source can spell), NOT by "some value has
-///      this name" -- that would let `let Intt = 1` excuse `x: Intt`.
-///   3. a region ROW VARIABLE declared by this very signature:
-///      `fn fill(l: MutList[Int, r]) -> Unit with r`. Nothing binds `r` as a
-///      value there; the binder is the row, so the call site passes its
-///      labels in `row_binders`.
-///   4. a trait's own erased type parameter, and only where an actual IMPL
+///   2. a trait's own erased type parameter, and only where an actual IMPL
 ///      binds it -- see `trait_erased_type_param_env`, which asks the env for
 ///      the impl rather than inferring one from the binding's name.
+///
+/// Those two are TYPES, so they are exempt wherever a type may appear. The
+/// other two binders are NOT types, so their exemption is positional as well
+/// as name-based -- `collect_unknown_type_names_regionwise` accepts them only
+/// in a region-argument slot (Codex round 3 on #2147; before that,
+/// `fn f(x: r) -> Int with r { 1 }` accepted both `f(1)` and `f("s")`):
+///
+///   3. a REGION TOKEN bound by an enclosing `region r { .. }` (ADR-0090),
+///      spelled in the region slot of `MutList[Int, r]`. Recognised by the
+///      rigid skolem the region binder binds it to (`#region_<n>`, a name no
+///      source can spell), NOT by "some value has this name" -- that would let
+///      `let Intt = 1` excuse `x: Intt`.
+///   4. a region ROW VARIABLE declared by this very signature:
+///      `fn fill(l: MutList[Int, r]) -> Unit with r`. Nothing binds `r` as a
+///      value there; the binder is the row, so the call site passes its
+///      variables in `row_binders`.
 export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  // Which of the unresolved names are region-ish binders at all. Asked over
+  // the name candidates first because the positional walk below takes a set,
+  // and `#region_` skolem membership is an env question this file owns.
+  let candidates = array_empty()
+  collect_unknown_type_names(te, defs, shadow, candidates)
+  let region_binders = array_empty()
+  let mut ci = 0
+  while ci < Array::length(candidates) {
+    let candidate = Array::get(candidates, ci)
+    let is_region_token = match env_lookup(env, candidate) {
+      Some(t) => match t {
+        CtNamed(bound_name, _) => String::starts_with(bound_name, "#region_"),
+        _ => false
+      },
+      None => false
+    }
+    if (is_region_token || string_array_has(row_binders, candidate)) && !string_array_has(region_binders, candidate) {
+      Array::push(region_binders, candidate)
+    } else {
+      ()
+    }
+    ci = ci + 1
+  }
   let out = array_empty()
-  collect_unknown_type_names(te, defs, shadow, out)
+  collect_unknown_type_names_regionwise(te, defs, shadow, region_binders, out)
   let mut i = 0
   while i < Array::length(out) {
     let name = Array::get(out, i)
-    let bound_by_binder = match env_lookup(env, name) {
+    let is_type_formal = match env_lookup(env, name) {
       Some(t) => match t {
         CtVar(_) => true,
-        CtNamed(bound_name, _) => String::starts_with(bound_name, "#region_"),
         _ => false
       },
       None => false
@@ -289,7 +317,7 @@ export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: 
       Some(_) => true,
       None => false
     }
-    if bound_by_binder || string_array_has(row_binders, name) || trait_erased_by_impl {
+    if is_type_formal || trait_erased_by_impl {
       ()
     } else {
       Array::push(errors, String::concat(String::concat(String::concat("unknown type `", name), "` in "), where_label))

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -156,11 +156,13 @@ export fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow:
 /// `resolve_builtin`, so they are indistinguishable from a typo by lookup
 /// alone and have to be named.
 ///
-/// This list is EMPIRICAL, not a design: it is what a Red run of
-/// `collect_unknown_type_names` over `lib/**` reported as unresolved while the
-/// tree compiled clean. Adding a compiler-owned type without adding it here
-/// makes every annotation that mentions it an error, which is a loud failure,
-/// not a silent one.
+/// This list is EMPIRICAL, not a design: it is what Red runs of
+/// `collect_unknown_type_names` over `lib/**` and `fixtures/**` reported as
+/// unresolved while the tree compiled clean. Adding a compiler-owned type
+/// without adding it here makes every annotation that mentions it an error,
+/// which is a loud failure, not a silent one -- `PromptText` joined the list
+/// that way (`declare PromptText::new(String) -> PromptText`,
+/// builtins/declarations.vibe, names a type `resolve_builtin` does not carry).
 fn is_wellknown_nominal_head(name: String) -> Bool {
   name == "Future"
   || name == "Stream"
@@ -180,6 +182,7 @@ fn is_wellknown_nominal_head(name: String) -> Bool {
   || name == "FrozenArray"
   || name == "FixedArray"
   || name == "Attempt"
+  || name == "PromptText"
   || name == "Self"
 }
 

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -203,9 +203,51 @@ fn is_wellknown_nominal_head(name: String) -> Bool {
 /// This is the separate question, asked where a declaration INTRODUCES an
 /// annotation and an error sink is in hand.
 export fn collect_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], out: Array[String]) -> Unit {
+  collect_unknown_type_names_walk(te, defs, shadow, array_empty(), false, out)
+}
+
+/// `Array` and `Option` are structural heads that `resolve_type_expr_shadowed`
+/// special-cases before any lookup, so they are never unknown -- and their
+/// arguments are ELEMENT types, never a region slot.
+fn ty_head_is_structural(name: String) -> Bool {
+  name == "Array" || name == "Option"
+}
+
+fn type_name_list_contains(names: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) && !found {
+    if Array::get(names, i) == name {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// #2125 (Codex round 3 on #2147): as `collect_unknown_type_names`, but a name
+/// in `region_binders` is accepted AT A REGION-ARGUMENT POSITION and nowhere
+/// else.
+///
+/// A region token and a row variable are not types. Exempting them by NAME
+/// therefore re-opened this issue's own hole wherever one was written where a
+/// type belongs -- measured before this: `fn f(x: r) -> Int with r { 1 }`
+/// accepted both `f(1)` and `f("s")`, and `region r { let x: r = 1 }` accepted
+/// `let y: r = "s"` beside it.
+///
+/// The region slot is the LAST type argument of a non-structural application
+/// (`MutList[Int, r]`, `MutMap[K, V, r]`, `TaskGroup[T, r]`) -- the same
+/// last-argument convention `is_region_tagged_ty` reads in checker.vibe. A
+/// name in any other position is a type reference and is looked up like one.
+export fn collect_unknown_type_names_regionwise(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], region_binders: Array[String], out: Array[String]) -> Unit {
+  collect_unknown_type_names_walk(te, defs, shadow, region_binders, false, out)
+}
+
+fn collect_unknown_type_names_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], region_binders: Array[String], at_region_slot: Bool, out: Array[String]) -> Unit {
   match te {
     TyUnit => (),
-    TyName(name) => if is_shadowed_tyvar(shadow, name) {
+    TyName(name) => if is_shadowed_tyvar(shadow, name) || (at_region_slot && type_name_list_contains(region_binders, name)) {
       ()
     } else {
       match resolve_builtin(name) {
@@ -221,12 +263,17 @@ export fn collect_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow:
       }
     },
     TyApp(name, args) => {
-      for a in args {
-        collect_unknown_type_names(a, defs, shadow, out)
+      // Only this application's own LAST argument is a region slot; the flag
+      // never propagates further down, and each nested application recomputes
+      // it for its own arguments.
+      let last_index = Array::length(args) - 1
+      let head_takes_region_slot = !ty_head_is_structural(name)
+      let mut i = 0
+      while i < Array::length(args) {
+        collect_unknown_type_names_walk(Array::get(args, i), defs, shadow, region_binders, head_takes_region_slot && i == last_index, out)
+        i = i + 1
       }
-      // `Array` and `Option` are structural heads that `resolve_type_expr_shadowed`
-      // special-cases before any lookup, so they are never unknown.
-      if name == "Array" || name == "Option" || is_shadowed_tyvar(shadow, name) {
+      if ty_head_is_structural(name) || is_shadowed_tyvar(shadow, name) {
         ()
       } else {
         match find_typedef(defs, name) {
@@ -239,15 +286,21 @@ export fn collect_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow:
         }
       }
     },
-    TyTuple(elems) => for e in elems {
-      collect_unknown_type_names(e, defs, shadow, out)
+    TyTuple(elems) => {
+      let mut i = 0
+      while i < Array::length(elems) {
+        collect_unknown_type_names_walk(Array::get(elems, i), defs, shadow, region_binders, false, out)
+        i = i + 1
+      }
     },
     TyFn(params, ret, _) => {
-      for p in params {
-        collect_unknown_type_names(p, defs, shadow, out)
+      let mut i = 0
+      while i < Array::length(params) {
+        collect_unknown_type_names_walk(Array::get(params, i), defs, shadow, region_binders, false, out)
+        i = i + 1
       }
       let ret_box = Array::slice([ret], 0, 1)
-      collect_unknown_type_names(Array::get(ret_box, 0), defs, shadow, out)
+      collect_unknown_type_names_walk(Array::get(ret_box, 0), defs, shadow, region_binders, false, out)
     }
   }
 }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -68,6 +68,7 @@ import ./checker.vibe {
   pat_binds_resume,
   preserve_generic_instantiation,
   reject_resume_outside_handler,
+  report_unknown_type_names,
   typed_occurrence_capture_begin_statement,
   typed_occurrence_capture_end_statement
 }
@@ -1535,6 +1536,13 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             // -1 (unlocated, as before) for a literal RHS -- EInt/EString/
             // EBool/EFloat carry no offset in the AST.
             let ann_err_before = Array::length(errors)
+            // #2125: a top-level binding's annotation. Reported HERE and not
+            // at the forward-reference hoist above, which runs before any
+            // declaration in this list has been walked -- at that point every
+            // locally declared alias and effect name is still absent from
+            // `defs` and would be reported as unknown. Inside the
+            // `ann_err_before` window so the binder name anchors it.
+            report_unknown_type_names(te, defs, array_empty(), env, String::concat(String::concat("the annotation of `", name), "`"), errors)
             let ns_b = check_assignable(resolved_te, actual_v, ns0, errors, String::concat("binding type mismatch for ", name), top_stmt_expr_off(val))
             // #1941: a literal value carries no offset, so anchor the binder
             // name instead of emitting the one unlocated diagnostic left in

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1050,6 +1050,70 @@ fn local_type_def_names(stmts: Array[Stmt]) -> Array[String] {
   names
 }
 
+/// #2125: index of the first `TypeDef` in `defs` named `name`, or
+/// -1. Mirrors `find_typedef`'s first-match-wins rule.
+fn typedef_index_of(defs: Array[TypeDef], name: String) -> Int {
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < Array::length(defs) && found < 0 {
+    let matched = match Array::get(defs, i) {
+      TDEnum(n, _, _) => n == name,
+      TDStruct(n, _, _, _) => n == name,
+      TDAlias(n, _, _) => n == name,
+      TDEffect(n, _, _) => n == name,
+      TDEffectSet(n, _) => n == name
+    }
+    if matched {
+      found = i
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// #2125: claim a `defs` slot for every enum/struct/suberror
+/// DECLARED IN THIS statement list, before anything resolves a type
+/// expression. Without it, `resolve_type_expr` falls through to
+/// `CtNamed(name, [])` for (a) a type's reference to ITSELF (its payloads are
+/// resolved before its own `Array::push(defs, ..)`) and (b) a reference to a
+/// type declared later in the same list. Both are indistinguishable from an
+/// un-instantiated generic formal, which `check_assignable` tolerates.
+///
+/// `STypeAlias` is deliberately NOT pre-claimed: a placeholder alias body
+/// would be a lie (an alias resolves THROUGH to its target, so an empty
+/// placeholder would silently retarget every early reference), whereas a
+/// placeholder enum/struct only needs its head to resolve. A forward
+/// reference to a later alias therefore stays unresolved.
+fn preclaim_local_type_defs(stmts: Array[Stmt], from: Int, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> Unit {
+  let mut i = from
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SEnum(_, name, params, _, _) => if typedef_index_of(defs, name) < 0 {
+        Array::push(defs, TDEnum(name, params, array_empty()))
+        Array::push(type_def_binders, array_empty())
+      } else {
+        ()
+      },
+      SSuberror(_, name, _) => if typedef_index_of(defs, name) < 0 {
+        Array::push(defs, TDEnum(name, array_empty(), array_empty()))
+        Array::push(type_def_binders, array_empty())
+      } else {
+        ()
+      },
+      SStruct(_, name, _, _, mut_fields, tparams) => if typedef_index_of(defs, name) < 0 {
+        Array::push(defs, TDStruct(name, array_empty(), mut_fields, tparams))
+        Array::push(type_def_binders, array_empty())
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
 fn string_array_contains(items: Array[String], wanted: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -1274,6 +1338,8 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
     }
   }
   let mut idx = i
+  // #2125: see preclaim_local_type_defs.
+  preclaim_local_type_defs(stmts, idx, defs, type_def_binders)
   let mut cur_env = env
   let mut cur_s = s
   let mut cur_c = c
@@ -1625,6 +1691,14 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // The local TDEnum uses this check's ids; published authority retains
         // the name-parameterized shape and rebinds it at each importer.
         let published_variants = array_empty()
+        // #2125: this enum's slot in `defs` is already claimed (see
+        // preclaim_local_type_defs), so a recursive occurrence of `name` in
+        // its own payloads resolves to `CtEnum(name)` instead of falling
+        // through to `CtNamed(name, [])`. The ctor-signature loop below
+        // resolves the same payload text AFTER the registration and therefore
+        // already saw the resolved form; the two disagreed.
+        let self_def_index = typedef_index_of(defs, name)
+        Array::set(type_def_binders, self_def_index, param_var_ids)
         let mut vi = 0
         while vi < Array::length(variants) {
           let (vname, vtypes) = Array::get(variants, vi)
@@ -1643,8 +1717,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           Array::push(published_variants, (vname, named_vtypes))
           vi = vi + 1
         }
-        Array::push(defs, TDEnum(name, params, resolved_variants))
-        Array::push(type_def_binders, param_var_ids)
+        Array::set(defs, self_def_index, TDEnum(name, params, resolved_variants))
         let mut env1 = env_bind(env, name, CtEnum(name))
         let mut ci2 = 0
         while ci2 < Array::length(variants) {
@@ -1767,6 +1840,8 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         let ctor_result_type = CtEnum(name)
         let resolved_variants = array_empty()
         let mut vi = 0
+        // #2125: see the SEnum arm.
+        let self_suberr_index = typedef_index_of(defs, name)
         while vi < Array::length(variants) {
           let (vname, vtypes) = Array::get(variants, vi)
           let resolved_vtypes = array_empty()
@@ -1778,8 +1853,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           Array::push(resolved_variants, (vname, resolved_vtypes))
           vi = vi + 1
         }
-        Array::push(defs, TDEnum(name, array_empty(), resolved_variants))
-        Array::push(type_def_binders, array_empty())
+        Array::set(defs, self_suberr_index, TDEnum(name, array_empty(), resolved_variants))
         let mut env1 = env_bind(env, name, CtEnum(name))
         let mut ci2 = 0
         while ci2 < Array::length(variants) {
@@ -1813,6 +1887,10 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
       SStruct(exported, name, field_defs, derives, mut_fields, tparams) => {
         validate_derives(derives, errors)
         let resolved_fields = array_empty()
+        // #2125: this struct's slot is already claimed before its own field
+        // types are resolved, so a recursive occurrence resolves to
+        // `CtStruct(name)`.
+        let self_struct_index = typedef_index_of(defs, name)
         let mut fi = 0
         while fi < Array::length(field_defs) {
           let (fname, ftype_expr) = Array::get(field_defs, fi)
@@ -1826,8 +1904,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // #829: record the declared type params — a param name resolves above
         // to a rigid `CtNamed(param, [])` (no such typedef/builtin), which is
         // exactly what the checker's literal instantiation substitutes.
-        Array::push(defs, TDStruct(name, resolved_fields, mut_fields, tparams))
-        Array::push(type_def_binders, array_empty())
+        Array::set(defs, self_struct_index, TDStruct(name, resolved_fields, mut_fields, tparams))
         let field_types = array_empty()
         let mut fj = 0
         while fj < Array::length(resolved_fields) {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -62,6 +62,7 @@ import ./checker.vibe {
   check_expr,
   check_expr_capture,
   constructor_dependency_row,
+  env_mark_impl_method_body,
   fn_return_env_name,
   is_array_builder_ty,
   is_region_tagged_ty,
@@ -1051,10 +1052,11 @@ fn local_type_def_names(stmts: Array[Stmt]) -> Array[String] {
   names
 }
 
-/// #2125: index of the first `TypeDef` in `defs` named `name`, or
-/// -1. Mirrors `find_typedef`'s first-match-wins rule.
-fn typedef_index_of(defs: Array[TypeDef], name: String) -> Int {
-  let mut i = 0
+/// #2125: index of the first `TypeDef` in `defs` at or after `from` named
+/// `name`, or -1. With `from = 0` this mirrors `find_typedef`'s
+/// first-match-wins rule.
+fn typedef_index_of_from(defs: Array[TypeDef], name: String, from: Int) -> Int {
+  let mut i = from
   let mut found = 0 - 1
   while i < Array::length(defs) && found < 0 {
     let matched = match Array::get(defs, i) {
@@ -1074,6 +1076,48 @@ fn typedef_index_of(defs: Array[TypeDef], name: String) -> Int {
   found
 }
 
+/// #2125: the `defs` slot THIS declaration owns. Codex review on #2147: the
+/// arms below overwrite their slot with `Array::set`, so taking any
+/// same-named slot would let one declaration replace another's definition --
+/// a nested statement list shares the caller's `defs` array (the `SModule`
+/// arm recurses with it), and a repeated name inside one list would resolve
+/// to whichever declaration ran last instead of the first, as `find_typedef`
+/// promises.
+///
+/// So a declaration only ever takes a slot that (a) this list's own pre-pass
+/// claimed -- everything at or after `preclaim_from` -- and (b) no earlier
+/// declaration in this list has taken. Otherwise it appends its own, which is
+/// exactly what the code did before the pre-pass existed.
+fn own_typedef_slot(defs: Array[TypeDef], type_def_binders: Array[Array[Int]], taken: Array[Int], name: String, preclaim_from: Int, placeholder: TypeDef) -> Int {
+  let mut idx = typedef_index_of_from(defs, name, preclaim_from)
+  while idx >= 0 && int_array_contains(taken, idx) {
+    idx = typedef_index_of_from(defs, name, idx + 1)
+  }
+  if idx >= 0 {
+    Array::push(taken, idx)
+    idx
+  } else {
+    Array::push(defs, placeholder)
+    Array::push(type_def_binders, array_empty())
+    let fresh = Array::length(defs) - 1
+    Array::push(taken, fresh)
+    fresh
+  }
+}
+
+fn int_array_contains(items: Array[Int], wanted: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) && !found {
+    if Array::get(items, i) == wanted {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
 /// #2125: claim a `defs` slot for every enum/struct/suberror
 /// DECLARED IN THIS statement list, before anything resolves a type
 /// expression. Without it, `resolve_type_expr` falls through to
@@ -1087,27 +1131,28 @@ fn typedef_index_of(defs: Array[TypeDef], name: String) -> Int {
 /// placeholder would silently retarget every early reference), whereas a
 /// placeholder enum/struct only needs its head to resolve. A forward
 /// reference to a later alias therefore stays unresolved.
+/// ONE SLOT PER DECLARATION, not per name (Codex review on #2147). Claiming
+/// unconditionally is what makes `own_typedef_slot` able to hand every
+/// declaration a slot of its own, and it reproduces the pre-#2125 `defs`
+/// ORDER exactly: the old code pushed one entry per declaration at the point
+/// the walk reached it, and `find_typedef` is first-match-wins, so a name that
+/// an enclosing list or a repeat in this list already declared keeps
+/// resolving to that earlier entry either way.
 fn preclaim_local_type_defs(stmts: Array[Stmt], from: Int, defs: Array[TypeDef], type_def_binders: Array[Array[Int]]) -> Unit {
   let mut i = from
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SEnum(_, name, params, _, _) => if typedef_index_of(defs, name) < 0 {
+      SEnum(_, name, params, _, _) => {
         Array::push(defs, TDEnum(name, params, array_empty()))
         Array::push(type_def_binders, array_empty())
-      } else {
-        ()
       },
-      SSuberror(_, name, _) => if typedef_index_of(defs, name) < 0 {
+      SSuberror(_, name, _) => {
         Array::push(defs, TDEnum(name, array_empty(), array_empty()))
         Array::push(type_def_binders, array_empty())
-      } else {
-        ()
       },
-      SStruct(_, name, _, _, mut_fields, tparams) => if typedef_index_of(defs, name) < 0 {
+      SStruct(_, name, _, _, mut_fields, tparams) => {
         Array::push(defs, TDStruct(name, array_empty(), mut_fields, tparams))
         Array::push(type_def_binders, array_empty())
-      } else {
-        ()
       },
       _ => ()
     }
@@ -1340,7 +1385,10 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
   }
   let mut idx = i
   // #2125: see preclaim_local_type_defs.
+  let preclaim_from = Array::length(defs)
   preclaim_local_type_defs(stmts, idx, defs, type_def_binders)
+  // Slots this list's declarations have already taken (see own_typedef_slot).
+  let taken_type_def_slots = array_empty()
   let mut cur_env = env
   let mut cur_s = s
   let mut cur_c = c
@@ -1514,10 +1562,20 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
     let (new_env, s1, c1) = match stmt {
       SLet(_, is_rec, name, ann, val) => {
         let err_before = Array::length(errors)
-        let (vt, ns0, nc) = if is_rec {
-          check_expr_capture(val, env_bind(env, name, CtUnknown), defs, s, c, errors, tytab, role_lane_capture, "Primary")
+        // #2125: an `impl` method is parsed as `let <Type>::<method> = ..`
+        // (parser.vibe's parse_impl_methods), and its signature may spell the
+        // trait's own erased type parameter with no binder of its own. Mark
+        // the environment the VALUE is checked in -- never `env1` below, so
+        // the marker cannot reach a published or cached environment.
+        let val_env = if String::contains(name, "::") {
+          env_mark_impl_method_body(env)
         } else {
-          check_expr_capture(val, env, defs, s, c, errors, tytab, role_lane_capture, "Primary")
+          env
+        }
+        let (vt, ns0, nc) = if is_rec {
+          check_expr_capture(val, env_bind(val_env, name, CtUnknown), defs, s, c, errors, tytab, role_lane_capture, "Primary")
+        } else {
+          check_expr_capture(val, val_env, defs, s, c, errors, tytab, role_lane_capture, "Primary")
         }
         attach_unlocated_decl_name_marker(errors, err_before, name)
         // The value must be assignable to a declared annotation (previously
@@ -1542,7 +1600,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             // locally declared alias and effect name is still absent from
             // `defs` and would be reported as unknown. Inside the
             // `ann_err_before` window so the binder name anchors it.
-            report_unknown_type_names(te, defs, array_empty(), env, String::concat(String::concat("the annotation of `", name), "`"), errors)
+            report_unknown_type_names(te, defs, array_empty(), env, array_empty(), String::concat(String::concat("the annotation of `", name), "`"), errors)
             let ns_b = check_assignable(resolved_te, actual_v, ns0, errors, String::concat("binding type mismatch for ", name), top_stmt_expr_off(val))
             // #1941: a literal value carries no offset, so anchor the binder
             // name instead of emitting the one unlocated diagnostic left in
@@ -1705,7 +1763,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // through to `CtNamed(name, [])`. The ctor-signature loop below
         // resolves the same payload text AFTER the registration and therefore
         // already saw the resolved form; the two disagreed.
-        let self_def_index = typedef_index_of(defs, name)
+        let self_def_index = own_typedef_slot(defs, type_def_binders, taken_type_def_slots, name, preclaim_from, TDEnum(name, params, array_empty()))
         Array::set(type_def_binders, self_def_index, param_var_ids)
         let mut vi = 0
         while vi < Array::length(variants) {
@@ -1849,7 +1907,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         let resolved_variants = array_empty()
         let mut vi = 0
         // #2125: see the SEnum arm.
-        let self_suberr_index = typedef_index_of(defs, name)
+        let self_suberr_index = own_typedef_slot(defs, type_def_binders, taken_type_def_slots, name, preclaim_from, TDEnum(name, array_empty(), array_empty()))
         while vi < Array::length(variants) {
           let (vname, vtypes) = Array::get(variants, vi)
           let resolved_vtypes = array_empty()
@@ -1898,7 +1956,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // #2125: this struct's slot is already claimed before its own field
         // types are resolved, so a recursive occurrence resolves to
         // `CtStruct(name)`.
-        let self_struct_index = typedef_index_of(defs, name)
+        let self_struct_index = own_typedef_slot(defs, type_def_binders, taken_type_def_slots, name, preclaim_from, TDStruct(name, array_empty(), mut_fields, tparams))
         let mut fi = 0
         while fi < Array::length(field_defs) {
           let (fname, ftype_expr) = Array::get(field_defs, fi)

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -62,7 +62,6 @@ import ./checker.vibe {
   check_expr,
   check_expr_capture,
   constructor_dependency_row,
-  env_mark_impl_method_body,
   fn_return_env_name,
   is_array_builder_ty,
   is_region_tagged_ty,
@@ -70,6 +69,7 @@ import ./checker.vibe {
   preserve_generic_instantiation,
   reject_resume_outside_handler,
   report_unknown_type_names,
+  trait_erased_type_param_env,
   typed_occurrence_capture_begin_statement,
   typed_occurrence_capture_end_statement
 }
@@ -1564,14 +1564,11 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         let err_before = Array::length(errors)
         // #2125: an `impl` method is parsed as `let <Type>::<method> = ..`
         // (parser.vibe's parse_impl_methods), and its signature may spell the
-        // trait's own erased type parameter with no binder of its own. Mark
-        // the environment the VALUE is checked in -- never `env1` below, so
-        // the marker cannot reach a published or cached environment.
-        let val_env = if String::contains(name, "::") {
-          env_mark_impl_method_body(env)
-        } else {
-          env
-        }
+        // trait's own erased type parameter with no binder of its own. Bind
+        // those names -- and only the ones an actual impl licenses -- into the
+        // environment the VALUE is checked in, never `env1` below, so they
+        // cannot reach a published or cached environment.
+        let val_env = trait_erased_type_param_env(env, name)
         let (vt, ns0, nc) = if is_rec {
           check_expr_capture(val, env_bind(val_env, name, CtUnknown), defs, s, c, errors, tytab, role_lane_capture, "Primary")
         } else {

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -167,6 +167,7 @@ fn check_qualified_pattern_refs(refs: Array[(String, String)], defs: Array[TypeD
 // --- checker_resolve.vibe
 fn subst_type_params(ty: Type, params: Array[String], args: Array[Type]) -> Type
 fn collect_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], out: Array[String]) -> Unit
+fn collect_unknown_type_names_regionwise(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], region_binders: Array[String], out: Array[String]) -> Unit
 fn resolve_type_expr(te: TypeExpr, defs: Array[TypeDef]) -> Type
 fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String]) -> Type
 

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -134,7 +134,9 @@ fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, name: Str
 fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type
-fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, where_label: String, errors: Array[String]) -> Unit
+fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit
+fn env_in_impl_method_body(env: TypeEnv) -> Bool
+fn env_mark_impl_method_body(env: TypeEnv) -> TypeEnv
 fn fn_return_env_name(name: String) -> String
 fn enum_def_env_name(name: String) -> String
 fn enum_def_env_target(binding_name: String) -> Option[String]

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -135,8 +135,7 @@ fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String
 fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type
 fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit
-fn env_in_impl_method_body(env: TypeEnv) -> Bool
-fn env_mark_impl_method_body(env: TypeEnv) -> TypeEnv
+fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> TypeEnv
 fn fn_return_env_name(name: String) -> String
 fn enum_def_env_name(name: String) -> String
 fn enum_def_env_target(binding_name: String) -> Option[String]

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -134,6 +134,7 @@ fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, name: Str
 fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type
+fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, where_label: String, errors: Array[String]) -> Unit
 fn fn_return_env_name(name: String) -> String
 fn enum_def_env_name(name: String) -> String
 fn enum_def_env_target(binding_name: String) -> Option[String]

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -20,6 +20,7 @@ import @vibe/core {
 
 import @vibe/compiler/core {
   ExportRenamePlan,
+  Stmt,
   append_import_alias_rewritten_non_import_stmts_with_renames,
   append_non_import_stmts_without_alias_rewrite,
   apply_export_renames_stmts,

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile_test.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile_test.vibe
@@ -1,3 +1,7 @@
+import @vibe/compiler/core {
+  Stmt
+}
+
 import @vibe/compiler/syntax {
   lex, parse_program
 }

--- a/lib/@vibe/compiler/tests/checker_for_in_value_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_for_in_value_test.vibe
@@ -58,7 +58,15 @@ test "#1559: an unclassifiable for iterand is rejected as a statement" {
   // A generic `T` is instantiated to a fresh var (same shape as an untyped
   // builtin return). Use a nullary named type with no typedef so the
   // statement-position check can tell it from `String::split`.
-  let source = "fn consume(it: NotAnIter) -> Unit {\n  for x in it { let _ = x; () }\n  ()\n}\nfn main() -> Unit { () }\n"
+  //
+  // #2125: this used to spell that type `NotAnIter` -- a name nothing
+  // declares -- which is now itself a diagnostic, and a louder one, so the
+  // `for` classifier never got to run. `Attempt` is a REAL compiler-owned
+  // nominal head that resolves to the same `CtNamed(name, [])` shape with no
+  // `TypeDef` behind it (is_wellknown_nominal_head, checker_resolve.vibe), so
+  // the case under test is unchanged and no longer rides on the hole #2125
+  // closed.
+  let source = "fn consume(it: Attempt) -> Unit {\n  for x in it { let _ = x; () }\n  ()\n}\nfn main() -> Unit { () }\n"
   let msg = first_check_error(source)
   assert(String::contains(msg, "cannot classify this `for` iterand"))
   assert(String::contains(msg, "annotate"))

--- a/lib/@vibe/compiler/tests/fixture_test_support.vibe
+++ b/lib/@vibe/compiler/tests/fixture_test_support.vibe
@@ -29,7 +29,7 @@ import ../parser.vibe {
 }
 
 import @vibe/compiler/runtime {
-  db_new, db_set_source, db_typecheck
+  TypeDb, db_new, db_set_source, db_typecheck
 }
 
 //# Types

--- a/lib/@vibe/compiler/tests/local_type_def_preclaim_test.vibe
+++ b/lib/@vibe/compiler/tests/local_type_def_preclaim_test.vibe
@@ -127,6 +127,19 @@ test "#2125: a duplicate local struct name is still reported" {
   inspect(first_desugared_check_error(src), content = "duplicate declaration: S::equals")
 }
 
+test "#2147 review: a repeated type name keeps first-declaration-wins" {
+  // Codex on #2147: the arms `Array::set` their slot, so a declaration must
+  // own the slot it fills. Taking any same-named slot let the SECOND
+  // declaration replace the FIRST's definition -- measured on the first
+  // enforcement commit, `s.a` reported `unknown field 'a' on struct S`
+  // although the first declaration declares it. `find_typedef` is
+  // first-match-wins, and this pins that it still is.
+  let src = "struct S {\n  a: Int\n}\n\nstruct S {\n  b: String\n}\n\nfn f(s: S) -> Int {\n  s.a\n}\n"
+  inspect(first_check_error(src), content = "")
+  let shadowed = "struct S {\n  a: Int\n}\n\nstruct S {\n  b: String\n}\n\nfn f(s: S) -> String {\n  s.b\n}\n"
+  inspect(first_check_error(shadowed), content = "unknown field 'b' on struct S")
+}
+
 //# The deliberate omission
 
 test "#2125: a type alias is deliberately NOT pre-claimed" {

--- a/lib/@vibe/compiler/tests/local_type_def_preclaim_test.vibe
+++ b/lib/@vibe/compiler/tests/local_type_def_preclaim_test.vibe
@@ -1,0 +1,142 @@
+//# Imports
+
+// #2125: `defs` was filled in WALK ORDER, so a type expression resolved before
+// its own declaration was registered fell through
+// `resolve_type_expr_shadowed`'s `None` branch to `CtNamed(name, [])` --
+// spelled exactly like an un-instantiated generic formal, which
+// `check_assignable` must tolerate so as not to over-reject polymorphic code.
+// A locally declared type name therefore stopped being checked at every site
+// reached before its declaration.
+//
+// `preclaim_local_type_defs` (checker/checker_stmt.vibe) claims a `defs` slot
+// for every enum / struct / suberror declared in the statement list before the
+// walk starts, so the head always resolves; each declaration's arm then
+// `Array::set`s its own slot instead of pushing.
+//
+// These tests pin both halves of that change:
+//   - the behavioural win -- a forward reference to an annotated top-level
+//     binding is type-checked again, and a self-recursive type agrees with
+//     itself across the two sites that resolve the same payload text;
+//   - the reporting that now runs against the PLACEHOLDER defs the pre-pass
+//     installs (#1078 constructor-name collisions, duplicate declarations),
+//     which must keep firing in both declaration orders.
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+import @vibe/compiler/codegen {
+  desugar_trait_dicts
+}
+
+//# Functions
+
+/// The first checker diagnostic for `source`, or "" when it type-checks.
+/// Positions are added by `locate_type_error` at the CLI boundary, so the
+/// payload here is the bare message.
+fn first_check_error(source: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+/// As `first_check_error`, but with the derive desugar run first -- the shape
+/// the FS-compile lane checks. A duplicate `enum`/`struct` NAME is reported
+/// through the `T::equals` that `derive`/structural-equality generation emits
+/// per declaration, so it is only visible on this side of the desugar.
+fn first_desugared_check_error(source: String) -> String {
+  handle {
+    let stmts = parse_program(lex(source))
+    desugar_trait_dicts(stmts)
+    let _ = check_program(stmts)
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+//# The behavioural wins
+
+test "#2125: a self-recursive enum agrees with itself" {
+  // Before the pre-pass the payload text `T2` was resolved on BOTH sides of
+  // this enum's own `Array::push(defs, ..)`: the `TDEnum` read
+  // `CtNamed(T2, [])` (pattern destructuring) while the constructor signature
+  // read `CtEnum(T2)` (construction). They only agreed because a `CtNamed`
+  // head is tolerated.
+  let src = "enum T2 { A; B(String, T2) }\n\nfn f(t: T2) -> T2 {\n  match t {\n    A => t,\n    B(_, rest) => B(\"x\", rest)\n  }\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2125: a self-recursive enum's payload types are still enforced" {
+  // The other direction of the same agreement: swapping the payloads must be
+  // rejected, so the fix is not "the recursive slot became a wildcard".
+  let src = "enum T2 { A; B(String, T2) }\n\nfn f(t: T2) -> T2 {\n  match t {\n    A => t,\n    B(_, rest) => B(rest, \"x\")\n  }\n}\n"
+  inspect(first_check_error(src), content = "argument type mismatch for B: expected String, got T2")
+}
+
+test "#2125: a self-recursive struct resolves its own field type" {
+  let src = "struct Node { label: String; kids: Array[Node] }\n\nfn label_of(n: Node) -> String {\n  n.label\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2125: a forward reference to an annotated top-level binding is checked" {
+  // The silent-wrong this issue is about, reachable from ordinary source: the
+  // top-level `let` hoist (checker_stmt.vibe) resolves `rows`'s annotation
+  // before the walk reaches `enum Color`, so `Color` used to become a
+  // `CtNamed` that unified with anything at an assignable position.
+  let src = "enum Color { Red }\n\nenum Other { X }\n\nfn a() -> Other {\n  rows\n}\n\nlet rows: Color = Color::Red\n"
+  inspect(first_check_error(src), content = "return type mismatch: expected Other, got Color [@fn=a]")
+}
+
+test "#2125: the same program with the binding declared first is unchanged" {
+  let src = "enum Color { Red }\n\nenum Other { X }\n\nlet rows: Color = Color::Red\n\nfn a() -> Other {\n  rows\n}\n"
+  inspect(first_check_error(src), content = "return type mismatch: expected Other, got Color [@fn=a]")
+}
+
+//# Reporting that runs against the placeholder defs
+
+test "#1078: a constructor-name collision is reported in both orders" {
+  // `find_other_enum_declaring_variant` scans `defs`, which now holds
+  // PLACEHOLDER `TDEnum`s (empty variant lists) for declarations the walk has
+  // not reached yet. The scan runs from each enum's own arm, after that arm
+  // filled its slot, so the later declaration still sees the earlier one's
+  // real variants -- a collision is caught whichever enum is written first.
+  let first = "enum E1 { Mk; Other1 }\n\nenum E2 { Mk; Other2 }\n"
+  let second = "enum E2 { Mk; Other2 }\n\nenum E1 { Mk; Other1 }\n"
+  inspect(String::contains(first_check_error(first), "constructor name collision: Mk"), content = "true")
+  inspect(String::contains(first_check_error(second), "constructor name collision: Mk"), content = "true")
+}
+
+test "#2125: a duplicate local enum name is still reported" {
+  // The pre-pass claims ONE slot for a repeated name (`typedef_index_of` is
+  // first-match-wins, mirroring `find_typedef`), and both arms `Array::set`
+  // it. Duplicate reporting is independent of that slot and must keep firing.
+  let src = "enum D { A1 }\n\nenum D { B1 }\n"
+  inspect(first_desugared_check_error(src), content = "duplicate declaration: D::equals")
+}
+
+test "#2125: a duplicate local struct name is still reported" {
+  let src = "struct S { x: Int }\n\nstruct S { y: Int }\n"
+  inspect(first_desugared_check_error(src), content = "duplicate declaration: S::equals")
+}
+
+//# The deliberate omission
+
+test "#2125: a type alias is deliberately NOT pre-claimed" {
+  // An alias resolves THROUGH to its target, so a placeholder body would be a
+  // lie -- every reference reached before the real declaration would silently
+  // retarget. An enum/struct placeholder only needs its head. The cost is
+  // that a forward reference to a LATER alias stays unresolved, i.e. this
+  // program is still accepted although `rows` is a String and `a` returns
+  // Int. Pinned deliberately: change this expectation only together with a
+  // decision about how an alias head should be pre-claimed.
+  let src = "fn a() -> Int {\n  rows\n}\n\nlet rows: MyAlias = \"s\"\n\ntype MyAlias = String\n"
+  inspect(first_check_error(src), content = "")
+}

--- a/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
+++ b/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
@@ -107,6 +107,41 @@ test "#2125: a trait's own element type parameter is not a typo" {
   inspect(first_check_error(src), content = "")
 }
 
+test "#2147 review: declaring a trait does not excuse a plain function" {
+  // Codex on #2147: the exemption for a trait's erased element parameter must
+  // not leak out of the impl that binds it. Measured before the fix: merely
+  // declaring `trait Iter[T]` made `T` an accepted annotation ANYWHERE in the
+  // file, which is the wildcard this issue is about.
+  let src = "trait Iter[T] {\n  step(Self) -> Option[T]\n}\n\nfn f(x: T) -> Int {\n  1\n}\n"
+  inspect(first_check_error(src), content = "unknown type `T` in parameter `x` [@fn=f]")
+}
+
+test "#2147 review: a value of the same name does not excuse a typo" {
+  // Codex on #2147: the env answers "is this a binder", and an ordinary value
+  // binding is not one for a TYPE. Only a `CtVar` (a type formal) and a region
+  // token's rigid `#region_` skolem are.
+  let src = "let Intt = 1\n\nfn f(x: Intt) -> Int {\n  1\n}\n"
+  inspect(first_check_error(src), content = "unknown type `Intt` in parameter `x` [@fn=f]")
+}
+
+test "#1863: a region ROW variable declared by this signature is not a typo" {
+  // `r` is bound by the function's own effect row, not by any enclosing
+  // `region r { .. }`, so nothing binds it as a value where the parameter is
+  // resolved. The row is the binder.
+  let src = "fn fill(l: MutList[Int, r]) -> Unit with r {\n  MutList::push(l, 1)\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#1869: a reserved `__dict_` parameter reports the reserved name, not its type" {
+  // The witness-dictionary type has no `TypeDef` either, so both rules fire on
+  // the same parameter. The reserved name is the actionable edit, so the
+  // annotation stays quiet and #1869's diagnostic is the one that surfaces.
+  let src = "trait Default {\n  default() -> Self\n}\n\nimpl Default for Int {\n  default() -> Int {\n    0\n  }\n}\n\nfn sneaky[T: Default](__dict_Default_T: DefaultDict[T]) -> T {\n  T::default()\n}\n"
+  let msg = first_check_error(src)
+  inspect(String::contains(msg, "reserved"), content = "true")
+  inspect(String::contains(msg, "unknown type"), content = "false")
+}
+
 test "#2125: a region token in type-argument position is not a typo" {
   // ADR-0090: `MutList[T, r]`'s second argument names the region TOKEN, which
   // is an ordinary value binding, not a type.

--- a/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
+++ b/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
@@ -163,6 +163,31 @@ test "#1869: a reserved `__dict_` parameter reports the reserved name, not its t
   inspect(String::contains(msg, "unknown type"), content = "false")
 }
 
+test "#2147 review: a row variable is not a type HEAD" {
+  // Codex on #2147 (round 3): the region/row exemptions were name-based, so a
+  // row variable written where a TYPE belongs was excused and the parameter
+  // went back to being a wildcard. Measured before the fix: this compiled, and
+  // both `f(1)` and `f("s")` passed the same slot.
+  let src = "fn f(x: r) -> Int with r {\n  1\n}\n"
+  inspect(first_check_error(src), content = "unknown type `r` in parameter `x` [@fn=f]")
+}
+
+test "#2147 review: a region token is not a type HEAD either" {
+  // The skolem-token half of the same blindness: inside `region r { .. }`,
+  // `r` is bound (to the rigid `#region_<n>` skolem), so a bare `x: r`
+  // annotation was excused. Measured before the fix: `let y: r = "s"` beside
+  // `let x: r = 1` was accepted.
+  let src = "fn main() -> Int {\n  region r {\n    let x: r = 1\n    0\n  }\n}\n"
+  inspect(String::contains(first_check_error(src), "unknown type `r`"), content = "true")
+}
+
+test "#2147 review: the region SLOT of a container still accepts the token" {
+  // The position the exemption exists for, both spellings: the row variable
+  // in a signature (#1863, above) and the skolem token inside its own region.
+  let src = "fn main() -> Int {\n  region r {\n    let xs: MutList[Int, r] = MutList::empty(r)\n    MutList::push(xs, 1)\n    MutList::length(xs)\n  }\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
 test "#2125: a region token in type-argument position is not a typo" {
   // ADR-0090: `MutList[T, r]`'s second argument names the region TOKEN, which
   // is an ordinary value binding, not a type.

--- a/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
+++ b/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
@@ -1,0 +1,125 @@
+//# Imports
+
+// #2125 step 3: an unknown type name used to be accepted wherever a type may
+// appear, and the annotation then behaved as a WILDCARD at argument positions
+// -- `fn takes(x: Intt) -> Int { 1 }` accepted both `takes(1)` and
+// `takes("s")`, with `vibe check` exiting 0.
+//
+// `collect_unknown_type_names` (checker_resolve.vibe) is the detection half
+// and is pinned by `unknown_type_name_test.vibe`. This file pins the
+// ENFORCEMENT half: `report_unknown_type_names` wired into the annotation
+// sites that introduce a type -- a function literal's parameters and return
+// type, a local `let` annotation, and a top-level binding's annotation.
+//
+// The negative cases matter as much as the positives. A name that resolves to
+// nothing is not automatically a typo, and each of the shapes below is a
+// legitimate one that an over-eager rule rejects:
+//   - a generic formal, INCLUDING one only the enclosing declaration binds
+//     (a nested lambda resolves its own parameters with its own, empty,
+//     type-parameter list, so `shadow` cannot answer this -- the env can);
+//   - a trait's own element type parameter, which the uniform representation
+//     erases and `relax_unknown_named` deliberately relaxes to `CtUnknown`;
+//   - a region token, which is spelled in type-argument position
+//     (`MutList[T, r]`, ADR-0090) and is a value, not a type;
+//   - a compiler-owned nominal head with no `TypeDef` behind it
+//     (`is_wellknown_nominal_head`).
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+/// The first checker diagnostic for `source`, or "" when it type-checks.
+/// A ` [@fn=name]` suffix is the #1941 side-channel marker: the annotation
+/// carries no offset of its own, so the diagnostic anchors on the declaration
+/// name and `locate_type_error` turns that into a real `line:col` at the CLI
+/// boundary.
+fn first_check_error(source: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+//# Reported
+
+test "#2125: a typo in a parameter annotation is reported" {
+  inspect(first_check_error("fn takes(x: Intt) -> Int {\n  1\n}\n"), content = "unknown type `Intt` in parameter `x` [@fn=takes]")
+}
+
+test "#2125: the annotation is no longer a wildcard at the call site" {
+  // The headline shape: the SAME slot accepted both an Int and a String.
+  let src = "fn takes(x: Intt) -> Int {\n  1\n}\n\nfn main() -> Unit {\n  let _ = takes(1)\n  let _ = takes(\"s\")\n  ()\n}\n"
+  inspect(first_check_error(src), content = "unknown type `Intt` in parameter `x` [@fn=takes]")
+}
+
+test "#2125: a typo in a return type is reported" {
+  inspect(first_check_error("fn f() -> Intt {\n  1\n}\n"), content = "unknown type `Intt` in the return type [@fn=f]")
+}
+
+test "#2125: a typo in a local let annotation is reported" {
+  inspect(first_check_error("fn f() -> Int {\n  let y: Intt = 1\n  2\n}\n"), content = "unknown type `Intt` in a local let annotation [@fn=y]")
+}
+
+test "#2125: a typo in a top-level binding's annotation is reported" {
+  inspect(first_check_error("let x: Intt = 1\n"), content = "unknown type `Intt` in the annotation of `x` [@fn=x]")
+}
+
+test "#2125: an unknown APPLIED head is reported too" {
+  // `Frobnicate[Int]` resolves to `CtNamed(\"Frobnicate\", [Int])` -- the
+  // TyApp arm falls through the same way the TyName arm does.
+  inspect(first_check_error("fn g(x: Frobnicate[Int]) -> Int {\n  1\n}\n"), content = "unknown type `Frobnicate` in parameter `x` [@fn=g]")
+}
+
+test "#2125: an unknown name nested inside a known head is reported" {
+  inspect(first_check_error("fn g(xs: Array[Intt]) -> Int {\n  1\n}\n"), content = "unknown type `Intt` in parameter `xs` [@fn=g]")
+}
+
+//# Not reported
+
+test "#2125: a generic formal is not a typo" {
+  inspect(first_check_error("fn f[T](x: T) -> T {\n  x\n}\n"), content = "")
+}
+
+test "#2125: a formal reached only through the ENV is not a typo" {
+  // The lambda binds no type parameters of its own, so `shadow` is empty at
+  // its parameter annotation and the enclosing `T` is invisible to it. The
+  // env still binds `T` to the formal's `CtVar`.
+  let src = "fn outer[T](xs: Array[T]) -> Int {\n  let g = (a: T) -> Int {\n    1\n  }\n  g(Array::get(xs, 0))\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2125: a body-level annotation naming a formal is not a typo" {
+  inspect(first_check_error("fn f[T](x: T) -> T {\n  let y: T = x\n  y\n}\n"), content = "")
+}
+
+test "#2125: a trait's own element type parameter is not a typo" {
+  // `T` in the impl method's signature is `trait Iterator[T]`'s, and the impl
+  // block binds nothing to shadow it.
+  let src = "trait Iterator[T] {\n  next(Self) -> Option[(T, Self)]\n}\n\nstruct LazyIter[T] {\n  pull: (Int) -> Option[(T, Int)];\n  state: Int\n}\n\nimpl Iterator for LazyIter {\n  next(self) -> Option[(T, LazyIter)] {\n    match (self.pull)(self.state) {\n      Some(p) => {\n        let (v, ns) = p\n        Some((v, LazyIter::{ pull: self.pull, state: ns }))\n      },\n      None => None\n    }\n  }\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2125: a region token in type-argument position is not a typo" {
+  // ADR-0090: `MutList[T, r]`'s second argument names the region TOKEN, which
+  // is an ordinary value binding, not a type.
+  let src = "fn f() -> Int {\n  region r {\n    let xs: MutList[Int, r] = MutList::empty(r)\n    MutList::length(xs)\n  }\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2125: a compiler-owned nominal head with no TypeDef is not a typo" {
+  inspect(first_check_error("fn f(b: StringBuilder) -> Int {\n  1\n}\n"), content = "")
+  inspect(first_check_error("fn f(b: FixedArray[Int]) -> Int {\n  1\n}\n"), content = "")
+}
+
+test "#2125: a real declared type is not a typo, in either order" {
+  inspect(first_check_error("struct P {\n  x: Int\n}\n\nfn f(p: P) -> Int {\n  p.x\n}\n"), content = "")
+  inspect(first_check_error("fn f(p: P) -> Int {\n  p.x\n}\n\nstruct P {\n  x: Int\n}\n"), content = "")
+}

--- a/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
+++ b/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
@@ -124,6 +124,27 @@ test "#2147 review: a value of the same name does not excuse a typo" {
   inspect(first_check_error(src), content = "unknown type `Intt` in parameter `x` [@fn=f]")
 }
 
+test "#2147 review: a qualified associated function is not an impl method" {
+  // Codex on #2147 (round 2): the exemption for a trait's erased parameters
+  // must come from an actual impl, not from the binding name having a `::`.
+  // `Array::bad` is an ordinary associated function -- no impl of `Iter` for
+  // `Array`, and `Iter` declares `step`, not `bad`. Measured before the fix:
+  // this compiled clean.
+  let src = "trait Iter[T] {\n  step(Self) -> Option[T]\n}\n\nfn Array::bad(x: T) -> Int {\n  1\n}\n"
+  inspect(first_check_error(src), content = "unknown type `T` in parameter `x` [@fn=Array::bad]")
+}
+
+test "#2147 review: a CONCRETE label in the row is not a binder" {
+  // Codex on #2147 (round 2): only a row VARIABLE is declared by the row.
+  // Taking every label let a concrete effect name double as a type: measured
+  // before the fix, both of these compiled clean and the parameter was a
+  // wildcard again.
+  let async_src = "fn f(x: Async) -> Int with Async {\n  1\n}\n"
+  inspect(first_check_error(async_src), content = "unknown type `Async` in parameter `x` [@fn=f]")
+  let fs_src = "fn g(x: Fs) -> Int with Fs {\n  1\n}\n"
+  inspect(first_check_error(fs_src), content = "unknown type `Fs` in parameter `x` [@fn=g]")
+}
+
 test "#1863: a region ROW variable declared by this signature is not a typo" {
   // `r` is bound by the function's own effect row, not by any enclosing
   // `region r { .. }`, so nothing binds it as a value where the parameter is

--- a/lib/@vibex/shell/from_csv.vibe
+++ b/lib/@vibex/shell/from_csv.vibe
@@ -15,7 +15,7 @@ import @vibe/builtin {
 }
 
 import @vibe/json {
-  Json::parse
+  Json, Json::parse
 }
 
 //# Functions

--- a/lib/@vibex/shell/from_yaml.vibe
+++ b/lib/@vibex/shell/from_yaml.vibe
@@ -15,7 +15,7 @@ import @vibe/builtin {
 }
 
 import @vibe/json {
-  Json::parse
+  Json, Json::parse
 }
 
 //# Functions

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -1835,7 +1835,7 @@ export let lazy_iter_arr = [T](xs: Array[T]) -> LazyIter[T] {
 EOF
 # (a) positive: direct element arithmetic compiles + runs (10+20+30+40 = 100).
 cat > "$eidir/pos.vibe" <<'EOF'
-import ./li.vibe { lazy_iter_arr }
+import ./li.vibe { LazyIter, lazy_iter_arr }
 let sum_direct = (src: LazyIter[Int]) -> Int {
   let mut total = 0
   for x in src { total = total + x }
@@ -1858,7 +1858,7 @@ if [ "$ei_out" != "100" ]; then
 fi
 # (b) negative: Int accumulator + String element must be a type error.
 cat > "$eidir/neg.vibe" <<'EOF'
-import ./li.vibe { lazy_iter_arr }
+import ./li.vibe { LazyIter, lazy_iter_arr }
 let bad = (src: LazyIter[String]) -> Int {
   let mut total = 0
   for x in src { total = total + x }


### PR DESCRIPTION
Part of #2125. Two commits: the pre-pass the last issue comment verified, then the enforcement it unblocked.

## 1. `preclaim_local_type_defs` — a locally declared type resolves before the walk reaches it

`defs` was filled in WALK ORDER, so a type expression resolved before its own declaration was registered fell through `resolve_type_expr_shadowed`'s `None` branch to `CtNamed(name, [])` — the same shape as an un-instantiated generic formal, which `check_assignable` must tolerate. Two sites were exposed:

- **a type's reference to ITSELF** — a declaration's payload text is resolved on both sides of its own `Array::push(defs, ..)`, so pattern destructuring read `CtNamed(T, [])` while construction read `CtEnum(T)`;
- **a forward reference** — the top-level `let` hoist resolves annotations against the partial `defs`.

The second was a silent-wrong reachable from ordinary source. Measured on the pristine stage2 at `d290dda`:

| program | before | after |
|---|---|---|
| `enum Color{Red}` / `enum Other{X}` / `fn a() -> Other { rows }` / `let rows: Color = Color::Red` declared **after** `a` | accepted | `return type mismatch: expected Other, got Color`, positioned |
| same, `let rows` declared **before** | rejected | rejected |

The pre-pass claims a `defs` slot (placeholder body) for every enum / struct / suberror declared in the statement list; each arm then `Array::set`s its own slot instead of pushing, so index alignment with `type_def_binders` and `find_typedef`'s first-match order are unchanged. `STypeAlias` is deliberately **not** pre-claimed — an alias resolves *through* to its target, so a placeholder body would silently retarget every early reference.

The three open items from the issue comment each got a test: #1078 constructor-name collisions still fire in **both** declaration orders, duplicate enum/struct names are still reported, and the alias omission is pinned with its reason. 9 tests in `local_type_def_preclaim_test.vibe`, red-checked with the fix reverted.

## 2. Enforcement — an unknown type name is a positioned diagnostic

`report_unknown_type_names` wires the already-landed `collect_unknown_type_names` to the error sink at the annotation sites that INTRODUCE a type: a function literal's parameters and return type, a local `let` annotation, and a top-level binding's annotation.

```console
$ vibe check u.vibe          # fn takes(x: Intt) -> Int { 1 }
line 1:4-9: unknown type `Intt` in parameter `x`
```

**`shadow` is not the authority on what a formal is** — a lambda nested in a generic function resolves its own parameters with its own, empty, type-parameter list. The env is, and the test is "bound at all" rather than "bound to a `CtVar`", because it answers two questions at once: a formal is bound to a `CtVar` by whichever binder introduced it, and a **region token** is bound as an ordinary value while being spelled in type-argument position (`MutList[Int, r]`, ADR-0090). A trait's own element type parameter needs one more exemption — the uniform representation erases it and an `impl` method spells it with no binder of its own — scoped to names some trait in scope actually declares, so a genuine typo inside an impl is still reported.

### Corpus

A sweep of all 938 non-generated `.vibe` files under `lib/` reported **5 distinct names in 317 files**. Every one was a real annotation naming a type the file never imports. Seven import additions were the whole fix and the sweep is now empty. Two gate fixtures annotated `LazyIter[..]` while importing only `lazy_iter_arr`; importing the type as well keeps what they test (the `impl` still lives in the imported module, out of the importer's env).

### Ratchet

As #138 intends, three `debt-accepts` rows promoted to `reject`: `err_type_undefined_type`, `scoped_ref_param_decl_forbidden`, `scoped_ref_param_nested_decl_forbidden`. The `Ref[T]` pair is rejected for **name resolution**, not for Ref escape analysis — the note in `expected.tsv` was rewritten to say so. `err_type_enum_wrong_variant_pattern` (the value-level sibling) stays debt. Known debt 28 → 25.

### Not enforced yet: struct fields and enum payloads

Both were implemented and then reverted in this branch, for a measured reason: the loader's generated `_build/vibe_vpkg_types/types_*.vibe` modules print a contract's struct definitions with **no imports for the types their fields reference**, so 195 of the 938 swept files failed on exactly that, on three names (`PerceusActionKind`, `TypeEnv`, `Json`). That is the same shape as #2136 — generated code that type-checks only because of this hole — and wants its own change to how the loader materializes a `.vpkg`'s type module. Until then those two positions keep today's behaviour, which is why this is *Part of* and not *Closes* #2125.

## Verification

- self-build stage0 → stage1 → stage2 green, `stage2 == stage3` fixpoint
- `scripts/compiler_gate.sh` → `[compiler-gate] ok` (229 typecheck fixtures, 25 known debt)
- `scripts/check_vibe_fmt.sh` → 1013 files, 0 new violations
- 23 new tests across two files, both red-checked with their change reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyrvqhAB9EdeV8HdNVTDFC

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyrvqhAB9EdeV8HdNVTDFC)_