### PR TITLE
Bootstrap import-kind parser support

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -851,7 +851,7 @@ local selfhostGenerationGate = new Task {
 local selfhostPostGenerationGate = new Task {
   name = "post-generation-gate"
   description = "internal: complete selfhost operation gates that must run after stage generation"
-  cmd = "bash scripts/gate.sh --post-generation"
+  cmd = "bash scripts/compiler_gate.sh early mid late"
   cache = false
   visibility = "internal"
   inputs {

--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "simd-line-comment-2026-08-16",
-    "tag": "seed/simd-line-comment-2026-08-16",
-    "source_commit": "85d6b1d2efdd7b18edc037dfb18ea1a1ce528d86",
+    "name": "import-kind-phase-a-2026-08-21",
+    "tag": "seed/import-kind-phase-a-2026-08-21",
+    "source_commit": "9c32a798552c3add7f2546fff2854d1f5f7ddc9f",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "bfd18afa548c7e745e9046a8340fdcf5cfec361cec9973615111d2f27d8ed758"
+      "sha256": "5f07e22111e097528ae1cc8bede7483bd5fc8412260f0ed71e69870243bb8245"
     },
     "runtime": {
       "runner": "node",

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -308,56 +308,46 @@ parse できることを確認した上で、bump なしで通している。**�
 > tree を直接解決させ (`VIBE_EMIT_MERGED_SOURCE`)、成果物の tracking もやめた
 > ので、この世代遅れも `drift detected` ゲートも今は存在しない。
 
-### bootstrap bump の手順 (更新版)
+### Bootstrap bump procedure
 
-`seed-release.yml` は **tag push ではなく `workflow_dispatch`** で手動起動する
-— tag を push した時点の commit の `bootstrap/seed.json` はすでに「新しい」
-seed を指しているため (`adopt` がそう書き換える)、tag push を trigger に
-すると CI がその新しい seed 自身の (まだ存在しない) release から stage0 を
-fetch しようとする自己参照になってしまう。`workflow_dispatch` の
-`prior_seed_ref` 入力で「どの既存 (公開済み) seed を stage0 として使うか」を
-明示することでこれを避ける。
+Run `seed-release.yml` manually through **`workflow_dispatch`, not a tag push**.
+After adoption, `bootstrap/seed.json` already points at the new seed. A tag-push
+job would therefore try to fetch the new seed's not-yet-published release as
+its own stage0. The required `prior_seed_ref` input breaks that cycle by naming
+an existing, published seed to use as stage0.
 
-1. `scripts/generations.sh build --stage3` で stage2 candidate を作り、
-   gate (上記) を通す。
-2. `scripts/generations.sh adopt --artifact <stage2.wasm> --name <name> \
-   --tag seed/<name> --source-commit <commit>` — `bootstrap/seed.json` を
-   更新 (artifact は `bootstrap/seed/compiler.wasm` へコピー、sha256/tag を
-   記録)。**`--tag` には必ず `seed/` prefix を付ける**。
-3. `bootstrap/seed.json` の更新を独立 commit にして PR、merge。
-4. merge 後、GitHub Actions の `seed-release` workflow を `workflow_dispatch`
-   で手動起動する。入力:
-   - `tag`: ステップ2で指定した `seed/<name>`。
-   - `source_ref`: merge commit (省略時はデフォルトブランチの HEAD)。
-   - `prior_seed_ref`: **必須**。`source_ref` 自身の `bootstrap/seed.json`
-     は (adopt がそう書き換えるので) 常にこれから publish しようとしている
-     「新しい」seed 自身を指しており、stage0 として使えない — 省略可能な
-     self-reference は存在しない。2 通りのケースがある:
-     - **#1000 part 2 の移行時点の最初の release**: `bootstrap/seed/compiler.wasm`
-       (または旧名 `selfhost_compiler.wasm`) がまだ git-tracked だった
-       commit (この移行 PR より前の main の任意の commit) を指す。CI は
-       その commit から artifact を `git show` で直接取り出す (release 不要)。
-     - **それ以降の通常の bump**: source を実際に変える前、直近の
-       `seed/*` release がまだ有効だった commit を指す。CI はその commit の
-       `bootstrap/seed.json` を一時的に読み込み、そこに pin された release
-       から `scripts/ensure_seed.sh` で fetch する。
-   - CI はどちらのケースかを自動判定 (`prior_seed_ref` で対象パスが
-     git-tracked かどうかを試す) し、prior artifact を確保 →
-     `scripts/generations.sh build --stage3` で決定論的に再構築 →
-     `scripts/generations.sh adopt` でこのワークスペース限定 (uncommitted)
-     に artifact を確定 → asset を publish。
-5. 公開された release は **prerelease** として Releases 一覧に載る。以降、
-   `bootstrap/seed.json` の pin を見た全ての CI/ローカル環境が
-   `scripts/ensure_seed.sh` 経由でこの release から自動的に fetch する。
-   (この repo は GitHub の "immutable releases" 設定が有効なため、
-   release は一旦 `draft: true` で作成して asset を添付し、その直後の
-   別ステップで `gh release edit --draft=false` により publish する
-   — `prerelease: true` だけだと asset upload 前に `release.published`
-   が発火し、asset 添付が `immutable release` エラーで失敗するため。
-   同じ tag への再 dispatch は、その tag の release が既に publish 済み
-   なら (immutable のため二度と draft に戻せない) ワークフロー冒頭の
-   preflight で早期に fail する — 対処は `gh release delete <tag> --yes
-   --cleanup-tag` で削除してから再実行するか、別の tag を使うこと。)
+1. Build a stage2 candidate with `scripts/generations.sh build --stage3` and
+   pass the gates above.
+2. Run `scripts/generations.sh adopt --artifact <stage2.wasm> --name <name> \
+   --tag seed/<name> --source-commit <commit>`. This updates
+   `bootstrap/seed.json`, copies the artifact to `bootstrap/seed/compiler.wasm`,
+   and records its sha256 and tag. The tag must have the `seed/` prefix.
+3. Commit the `bootstrap/seed.json` update separately, but do not merge the PR
+   yet. Fresh CI runners fetch the seed from the new tag, so every bootstrap
+   bump gate returns 404 until that release exists.
+4. Dispatch the GitHub Actions `seed-release` workflow with that commit as
+   `source_ref`:
+   - `tag`: the `seed/<name>` chosen in step 2.
+   - `source_ref`: the committed bootstrap-bump branch revision.
+   - `prior_seed_ref`: required. It cannot default to `source_ref`, whose own
+     manifest already points at the unpublished new seed. Use one of:
+     - For the initial #1000 part 2 migration, a commit that still tracks
+       `bootstrap/seed/compiler.wasm` (or the old `selfhost_compiler.wasm`).
+       CI extracts the artifact directly with `git show`.
+     - For normal later bumps, a commit from before the source change whose
+       `bootstrap/seed.json` points at the latest valid published `seed/*`
+       release. CI temporarily reads that manifest and fetches its artifact.
+   - CI detects which case applies, acquires the prior artifact, rebuilds
+     deterministically through stage3, adopts the candidate in its workspace,
+     and publishes the assets.
+5. Verify that the released compiler sha256 matches `bootstrap/seed.json`, then
+   create or rerun the PR and merge only after CI is Green.
+6. The published release appears as a **prerelease**. All CI and local callers
+   that read the pin can then fetch it through `scripts/ensure_seed.sh`.
+   Because immutable releases are enabled, the workflow first creates a draft,
+   attaches every asset, and only then publishes it with
+   `gh release edit --draft=false`. Re-dispatching an already-published tag
+   fails at preflight; delete that release and tag or choose a new tag.
 
 ### 既存の git 履歴中のバイナリ blob
 

--- a/docs/operation-gate.md
+++ b/docs/operation-gate.md
@@ -91,8 +91,8 @@ The old `pkf run selfhost-trial-gate` compatibility alias was removed in
 That task checks the following together:
 
 - `generation-gate`: fixed seed -> stage1 -> stage2 -> stage3
-- `post-generation-gate` (`scripts/gate.sh --post-generation` -> `compiler_gate.sh`):
-  the full sign-off set
+- `post-generation-gate` (`scripts/compiler_gate.sh early mid late`): the
+  non-bootstrap sign-off lanes, using the stage produced by `generation-gate`
 
 The old host-comparison lanes (`test-selfhost-corpus-gate` / `perf-kpi` /
 `rss-kpi` / component parity) were retired with their scripts when the

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -3,6 +3,7 @@ version = 0.0.1
 description =
   #|@vibe/compiler/core — ADR-0070 / #897 compiler-internal contract. This is
 deps = {
+  @vibe/ast : 0.0.1
   @vibe/core : 0.2.0
 }
 

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -97,9 +97,8 @@ generated_hash =
 // allocated), exactly like checker_facade.vibe's redundant re-export block.
 //
 // No import cycle: core/'s only compiler-internal dependency (beyond its
-// own siblings) is ../module_graph_path.vibe (a top-level compiler file,
-// imported by import_alias_rewrite.vibe), which itself only imports the
-// external @vibe/core package -- it does not import core/ back.
+// own siblings) is module_graph_path.vibe. It imports the external
+// @vibe/core and @vibe/ast packages, but does not import compiler/core back.
 
 // --- ast (cross-package re-export from @vibe/ast, see header)
 type Expr

--- a/lib/@vibe/compiler/core/module_graph_path.vibe
+++ b/lib/@vibe/compiler/core/module_graph_path.vibe
@@ -1,6 +1,9 @@
 import @vibe/core {
   array_empty
 }
+import @vibe/ast {
+  struct ImportItem
+}
 
 //# Functions
 

--- a/scripts/test_trace_spans.sh
+++ b/scripts/test_trace_spans.sh
@@ -34,14 +34,16 @@ VIBE_TRACE_OUT="$T" bash scripts/trace_span.sh outer bash -c "
   VIBE_TRACE_OUT='$T' bash scripts/trace_span.sh inner1 true
   VIBE_TRACE_OUT='$T' bash scripts/trace_span.sh inner2 true
 " || bad "nested run failed"
-[ "$(wc -l < "$T")" = "3" ] || bad "expected 3 spans, got $(wc -l < "$T")"
+span_count="$(wc -l < "$T" | tr -d '[:space:]')"
+[ "$span_count" = "3" ] || bad "expected 3 spans, got $span_count"
 outer_sid="$(sed -n 's/.*"sid":"\([0-9a-f]*\)","pid":"","name":"outer".*/\1/p' "$T")"
 [ -n "$outer_sid" ] || bad "outer span is not a root (empty pid)"
 for child in inner1 inner2; do
   pid="$(sed -n "s/.*\"pid\":\"\([0-9a-f]*\)\",\"name\":\"$child\".*/\1/p" "$T")"
   [ "$pid" = "$outer_sid" ] || bad "$child parented to '$pid', want outer '$outer_sid'"
 done
-[ "$(cut -d'"' -f4 < "$T" | sort -u | wc -l)" = "1" ] || bad "spans span more than one trace id"
+trace_count="$(cut -d'"' -f4 < "$T" | sort -u | wc -l | tr -d '[:space:]')"
+[ "$trace_count" = "1" ] || bad "spans span more than one trace id"
 
 # 4. A malformed inherited traceparent starts a NEW trace instead of
 #    propagating a bogus id -- reparenting everything under a wrong trace is

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -2566,15 +2566,16 @@ echo "[compiler-gate] index bounds checks ok"
 #      reachable by a silent fallback, which compiled fine and then trapped at
 #      runtime (call_indirect on the stream's array pointer). #1350 removed the
 #      `for await` syntax and made the UNCLASSIFIED fallback the plain array
-#      loop -- which is the correct lowering for the eager Array-backed
-#      `Stream` (ADR-0012) -- so the hazard is now structural rather than
+#      loop. #1954 later replaced the structural `Stream[Int]` spelling with
+#      nominal `ByteStream`, while retaining its byte-iteration lowering, so
+#      the hazard is now structural rather than
 #      diagnostic: BOTH the annotated and the unannotated param must compile
 #      and run to 42.
 echo "[compiler-gate] 27d/27 async for-loop classification (#827/#1350)"
 fadir="_build/_gate_forawait"
 rm -rf "$fadir"; mkdir -p "$fadir"
 cat > "$fadir/ok_annot.vibe" <<'EOF'
-let consume: (Stream[Int]) -> Int = (s) -> {
+let consume: (ByteStream) -> Int = (s) -> {
   let mut sum = 0
   for x in s {
     sum = sum + x
@@ -2640,11 +2641,11 @@ for fa_case in ok_annot ok_unannot ok_unannot_factory ok_unannot_closure_factory
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "$fadir/$fa_case.vibe" "$fadir/$fa_case.wasm" _start >/dev/null 2>&1 || true
   if [ ! -s "$fadir/$fa_case.wasm" ]; then
-    echo "[compiler-gate] FAIL: $fa_case for-loop over a Stream did not compile" >&2; exit 1
+    echo "[compiler-gate] FAIL: $fa_case byte-stream for-loop did not compile" >&2; exit 1
   fi
   fa_out="$(bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$fadir/$fa_case.wasm" 2>/dev/null | tail -n 1)"
   if [ "$fa_out" != "42" ]; then
-    echo "[compiler-gate] FAIL: $fa_case returned '$fa_out' (expected 42 -- the array loop is the right lowering for an eager Stream; a pull-closure fallback would trap)" >&2; exit 1
+    echo "[compiler-gate] FAIL: $fa_case returned '$fa_out' (expected 42 -- ByteStream uses byte iteration; a pull-closure fallback would trap)" >&2; exit 1
   fi
 done
 rm -rf "$fadir"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -4553,12 +4553,13 @@ tc_names="$(grep -v '^#' fixtures/typecheck/expected.tsv | cut -f1)"
 # adopted from the repository root -- one directly under fixtures/. Resolving
 # in that order avoids moving 139 files and keeps names unique (checked: the
 # two directories share none).
-printf '%s\n' $tc_names | xargs -P "$(nproc 2>/dev/null || echo 4)" -I{} env \
+printf '%s\n' $tc_names | xargs -P "$(nproc 2>/dev/null || echo 4)" -n 1 env \
   ROOT_DIR="$ROOT_DIR" stage2_wasm="$stage2_wasm" tcdir="$tcdir" \
-  bash -c 'src="fixtures/typecheck/{}.vibe"; [ -f "$src" ] || src="fixtures/{}.vibe"
+  bash -c 'name="$1"
+    src="fixtures/typecheck/$name.vibe"; [ -f "$src" ] || src="fixtures/$name.vibe"
     VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "$src" "$tcdir/{}.wasm" __no_entry__ >/dev/null 2>&1 || true'
+    "$src" "$tcdir/$name.wasm" __no_entry__ >/dev/null 2>&1 || true' _
 tc_fail=0
 tc_debt=0
 while IFS=$'\t' read -r tcname tcstatus tcneedle; do


### PR DESCRIPTION
## Summary

- adopt a fixpoint seed built from the merged import-kind Phase A implementation
- repair the post-generation task to invoke the current early, mid, and late lanes
- make macOS gate execution robust against xargs command substitution limits and padded wc output

## Validation

- stage0 = stage1 = stage2 = stage3: 5f07e22111e097528ae1cc8bede7483bd5fc8412260f0ed71e69870243bb8245
- generation samples pass at every stage
- compiler gate early and mid lanes pass
- compiler gate late lane passes
- check_gate_registry_test passes
- trace span focused test passes
- shell syntax and git diff checks pass

The seed manifest change is kept in its own commit.