### PR TITLE
Enforce unknown-type reporting at struct fields and enum payloads (#2125)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1230,7 +1230,7 @@ fn collect_trait_dict_erasures(stmts: Array[Stmt]) -> Array[(String, String, Arr
 /// the exemption travels with the text through every lane -- per-module,
 /// cached, or injected into a whole-program merge (where the names resolve
 /// anyway and the exemption is inert).
-fn collect_deferred_type_name_sentinels(stmts: Array[Stmt]) -> Array[String] {
+fn collect_deferred_type_name_sentinels(stmts: Array[Stmt]) -> Array[(Array[String], Array[String])] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
@@ -1238,16 +1238,33 @@ fn collect_deferred_type_name_sentinels(stmts: Array[Stmt]) -> Array[String] {
       SLet(_, _, lname, _, value) => if String::starts_with(lname, "__vpkg_deferred_type_names_") {
         match value {
           EString(names) => {
+            // `<protected decls> : <deferred names>` -- names before the `:`
+            // are the declarations the exemption applies to (Codex round 3 on
+            // #2162: unscoped, a merge-lane sentinel excused an unrelated
+            // declaration misspelling one of these names). A sentinel with no
+            // `:` protects nothing.
+            let protected = array_empty()
+            let deferred = array_empty()
             let parts = String::split(names, " ")
+            let mut seen_sep = false
             let mut pi = 0
             while pi < Array::length(parts) {
               let p = Array::get(parts, pi)
-              if p == "" || string_array_contains(out, p) {
+              if p == ":" {
+                seen_sep = true
+              } else if p == "" {
                 ()
+              } else if seen_sep {
+                Array::push(deferred, p)
               } else {
-                Array::push(out, p)
+                Array::push(protected, p)
               }
               pi = pi + 1
+            }
+            if seen_sep && Array::length(deferred) > 0 {
+              Array::push(out, (protected, deferred))
+            } else {
+              ()
             }
           },
           _ => ()
@@ -1260,6 +1277,22 @@ fn collect_deferred_type_name_sentinels(stmts: Array[Stmt]) -> Array[String] {
     i = i + 1
   }
   out
+}
+
+/// The deferred names whose sentinel protects `decl_name`, or empty.
+fn deferred_names_for_decl(rows: Array[(Array[String], Array[String])], decl_name: String) -> Array[String] {
+  let mut i = 0
+  let mut found = array_empty()
+  while i < Array::length(rows) {
+    let (protected, deferred) = Array::get(rows, i)
+    if string_array_contains(protected, decl_name) {
+      found = deferred
+      i = Array::length(rows)
+    } else {
+      i = i + 1
+    }
+  }
+  found
 }
 
 /// #2125 (field/payload enforcement): the shadow list for a DECLARATION's
@@ -2015,7 +2048,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           while ti < Array::length(vtypes) {
             // #2125: an unknown name in a payload otherwise becomes a wildcard
             // `CtNamed` -- same hole as the annotation sites.
-            report_unknown_type_names(Array::get(vtypes, ti), defs, decl_report_shadow(params, array_empty(), deferred_type_names), env, array_empty(), String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
+            report_unknown_type_names(Array::get(vtypes, ti), defs, decl_report_shadow(params, array_empty(), deferred_names_for_decl(deferred_type_names, name)), env, array_empty(), String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
             // #1512: `params` shadow `defs`, so the substitution below still
             // finds `CtNamed(<param>, [])` when an import bound that name.
             let named_vt = resolve_type_expr_shadowed(Array::get(vtypes, ti), defs, params)
@@ -2211,7 +2244,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           // desugar's output); those are shadowed under the provenance
           // `collect_trait_dict_erasures` establishes.
           let dict_erased = trait_dict_erasure_for(trait_dict_erasures, name, fname)
-          let report_shadow = decl_report_shadow(tparams, dict_erased, deferred_type_names)
+          let report_shadow = decl_report_shadow(tparams, dict_erased, deferred_names_for_decl(deferred_type_names, name))
           report_unknown_type_names(ftype_expr, defs, report_shadow, env, array_empty(), String::concat(String::concat(String::concat("field `", fname), "` of struct `"), String::concat(name, "`")), errors)
           // #1512: `tparams` shadow `defs` -- the #829 comment below assumes a
           // param name resolves to a rigid `CtNamed(param, [])` because no

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1164,6 +1164,142 @@ fn preclaim_local_type_defs(stmts: Array[Stmt], from: Int, defs: Array[TypeDef],
   }
 }
 
+/// #2125 (field enforcement): erased names each trait's synthesized
+/// `<Trait>Dict` witness struct may spell in its fields -- `Self`, the
+/// trait's type parameters, and each method's own generic binders.
+/// `desugar_trait_dict`'s `make_dict_struct_stmt` copies the trait method
+/// signatures verbatim; the pass runs after checking in the ordinary lane,
+/// but whole-program lanes re-check its output, so the checker does see
+/// those fields. Provenance, not name shape alone (the #1869/#2147 lesson):
+/// the struct name must be the trait's dict spelling AND the field must be a
+/// method that trait declares. One row per trait:
+/// (dict struct name, method names, erased names).
+fn collect_trait_dict_erasures(stmts: Array[Stmt]) -> Array[(String, Array[String], Array[String])] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      STrait(_, tname, _, methods, method_gens, tparams) => {
+        let mnames = array_empty()
+        let mut mi = 0
+        while mi < Array::length(methods) {
+          let (mname, _, _) = Array::get(methods, mi)
+          Array::push(mnames, mname)
+          mi = mi + 1
+        }
+        let erased = array_empty()
+        Array::push(erased, "Self")
+        let mut ti = 0
+        while ti < Array::length(tparams) {
+          Array::push(erased, Array::get(tparams, ti))
+          ti = ti + 1
+        }
+        let mut gi = 0
+        while gi < Array::length(method_gens) {
+          let (_, gnames, _) = Array::get(method_gens, gi)
+          let mut gni = 0
+          while gni < Array::length(gnames) {
+            Array::push(erased, Array::get(gnames, gni))
+            gni = gni + 1
+          }
+          gi = gi + 1
+        }
+        Array::push(out, (String::concat(tname, "Dict"), mnames, erased))
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #2125 (field/payload enforcement): the deferred-name sentinels in this
+/// statement list. A materialized vpkg types module references names it can
+/// neither declare nor import (a contract-`opaque` name defined in a sibling
+/// impl -- types -> impl would be an import cycle -- or a name from another
+/// package); those resolve to the intentional bare-`CtNamed` contract
+/// artifact, and `contract_types_module_text` carries them IN-BAND as a
+/// `let __vpkg_deferred_type_names_<uniq>__: String = "N1 N2"` binding, so
+/// the exemption travels with the text through every lane -- per-module,
+/// cached, or injected into a whole-program merge (where the names resolve
+/// anyway and the exemption is inert).
+fn collect_deferred_type_name_sentinels(stmts: Array[Stmt]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, lname, _, value) => if String::starts_with(lname, "__vpkg_deferred_type_names_") {
+        match value {
+          EString(names) => {
+            let parts = String::split(names, " ")
+            let mut pi = 0
+            while pi < Array::length(parts) {
+              let p = Array::get(parts, pi)
+              if p == "" || string_array_contains(out, p) {
+                ()
+              } else {
+                Array::push(out, p)
+              }
+              pi = pi + 1
+            }
+          },
+          _ => ()
+        }
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #2125 (field/payload enforcement): the shadow list for a DECLARATION's
+/// unknown-type report -- the declaration's own type parameters, any
+/// trait-dict erased names, plus this statement list's deferred-name
+/// sentinels (see `collect_deferred_type_name_sentinels`).
+fn decl_report_shadow(tparams: Array[String], dict_erased: Array[String], deferred: Array[String]) -> Array[String] {
+  if Array::length(dict_erased) == 0 && Array::length(deferred) == 0 {
+    tparams
+  } else {
+    let s2 = array_empty()
+    let mut si = 0
+    while si < Array::length(tparams) {
+      Array::push(s2, Array::get(tparams, si))
+      si = si + 1
+    }
+    let mut di = 0
+    while di < Array::length(dict_erased) {
+      Array::push(s2, Array::get(dict_erased, di))
+      di = di + 1
+    }
+    let mut fi = 0
+    while fi < Array::length(deferred) {
+      Array::push(s2, Array::get(deferred, fi))
+      fi = fi + 1
+    }
+    s2
+  }
+}
+
+/// The erased-name row for `struct_name`/`field_name`, or empty when no
+/// trait in this statement list declares that dict/method pair.
+fn trait_dict_erasure_for(erasures: Array[(String, Array[String], Array[String])], struct_name: String, field_name: String) -> Array[String] {
+  let mut i = 0
+  let mut found = array_empty()
+  while i < Array::length(erasures) {
+    let (dname, mnames, erased) = Array::get(erasures, i)
+    if dname == struct_name && string_array_contains(mnames, field_name) {
+      found = erased
+      i = Array::length(erasures)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
 fn string_array_contains(items: Array[String], wanted: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -1478,6 +1614,12 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
   // #2125: see preclaim_local_type_defs.
   let preclaim_from = Array::length(defs)
   preclaim_local_type_defs(stmts, idx, defs, type_def_binders)
+  // #2125 (field enforcement): see collect_trait_dict_erasures. Computed from
+  // the statement LIST because reorder_type_decls_first hoists a synthesized
+  // `<Trait>Dict` struct above its trait declaration, so the env cannot
+  // answer at the struct's own check point.
+  let trait_dict_erasures = collect_trait_dict_erasures(stmts)
+  let deferred_type_names = collect_deferred_type_name_sentinels(stmts)
   // Slots this list's declarations have already taken (see own_typedef_slot).
   let taken_type_def_slots = array_empty()
   let mut cur_env = env
@@ -1864,6 +2006,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           let named_vtypes = array_empty()
           let mut ti = 0
           while ti < Array::length(vtypes) {
+            // #2125: an unknown name in a payload otherwise becomes a wildcard
+            // `CtNamed` -- same hole as the annotation sites.
+            report_unknown_type_names(Array::get(vtypes, ti), defs, decl_report_shadow(params, array_empty(), deferred_type_names), env, array_empty(), String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
             // #1512: `params` shadow `defs`, so the substitution below still
             // finds `CtNamed(<param>, [])` when an import bound that name.
             let named_vt = resolve_type_expr_shadowed(Array::get(vtypes, ti), defs, params)
@@ -2052,6 +2197,15 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         let mut fi = 0
         while fi < Array::length(field_defs) {
           let (fname, ftype_expr) = Array::get(field_defs, fi)
+          // #2125: an unknown name in a field type otherwise becomes a
+          // wildcard `CtNamed` -- same hole as the annotation sites. A
+          // synthesized `<Trait>Dict` witness struct spells `Self` and the
+          // trait's erased params verbatim (whole-program lanes re-check the
+          // desugar's output); those are shadowed under the provenance
+          // `collect_trait_dict_erasures` establishes.
+          let dict_erased = trait_dict_erasure_for(trait_dict_erasures, name, fname)
+          let report_shadow = decl_report_shadow(tparams, dict_erased, deferred_type_names)
+          report_unknown_type_names(ftype_expr, defs, report_shadow, env, array_empty(), String::concat(String::concat(String::concat("field `", fname), "` of struct `"), String::concat(name, "`")), errors)
           // #1512: `tparams` shadow `defs` -- the #829 comment below assumes a
           // param name resolves to a rigid `CtNamed(param, [])` because no
           // typedef/builtin claims it, which an import alias otherwise breaks.

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1174,37 +1174,44 @@ fn preclaim_local_type_defs(stmts: Array[Stmt], from: Int, defs: Array[TypeDef],
 /// the struct name must be the trait's dict spelling AND the field must be a
 /// method that trait declares. One row per trait:
 /// (dict struct name, method names, erased names).
-fn collect_trait_dict_erasures(stmts: Array[Stmt]) -> Array[(String, Array[String], Array[String])] {
+fn collect_trait_dict_erasures(stmts: Array[Stmt]) -> Array[(String, String, Array[String])] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       STrait(_, tname, _, methods, method_gens, tparams) => {
-        let mnames = array_empty()
+        let dict_name = String::concat(tname, "Dict")
+        // One row PER METHOD (Codex on #2162): `Self` and the trait's own
+        // params are trait-wide, but a method's generic binders are in scope
+        // only for that method's field -- a trait-wide union let field `a`
+        // spell method `b`'s binder and stay a wildcard.
         let mut mi = 0
         while mi < Array::length(methods) {
           let (mname, _, _) = Array::get(methods, mi)
-          Array::push(mnames, mname)
+          let erased = array_empty()
+          Array::push(erased, "Self")
+          let mut ti = 0
+          while ti < Array::length(tparams) {
+            Array::push(erased, Array::get(tparams, ti))
+            ti = ti + 1
+          }
+          let mut gi = 0
+          while gi < Array::length(method_gens) {
+            let (gmname, gnames, _) = Array::get(method_gens, gi)
+            if gmname == mname {
+              let mut gni = 0
+              while gni < Array::length(gnames) {
+                Array::push(erased, Array::get(gnames, gni))
+                gni = gni + 1
+              }
+            } else {
+              ()
+            }
+            gi = gi + 1
+          }
+          Array::push(out, (dict_name, mname, erased))
           mi = mi + 1
         }
-        let erased = array_empty()
-        Array::push(erased, "Self")
-        let mut ti = 0
-        while ti < Array::length(tparams) {
-          Array::push(erased, Array::get(tparams, ti))
-          ti = ti + 1
-        }
-        let mut gi = 0
-        while gi < Array::length(method_gens) {
-          let (_, gnames, _) = Array::get(method_gens, gi)
-          let mut gni = 0
-          while gni < Array::length(gnames) {
-            Array::push(erased, Array::get(gnames, gni))
-            gni = gni + 1
-          }
-          gi = gi + 1
-        }
-        Array::push(out, (String::concat(tname, "Dict"), mnames, erased))
       },
       _ => ()
     }
@@ -1285,12 +1292,12 @@ fn decl_report_shadow(tparams: Array[String], dict_erased: Array[String], deferr
 
 /// The erased-name row for `struct_name`/`field_name`, or empty when no
 /// trait in this statement list declares that dict/method pair.
-fn trait_dict_erasure_for(erasures: Array[(String, Array[String], Array[String])], struct_name: String, field_name: String) -> Array[String] {
+fn trait_dict_erasure_for(erasures: Array[(String, String, Array[String])], struct_name: String, field_name: String) -> Array[String] {
   let mut i = 0
   let mut found = array_empty()
   while i < Array::length(erasures) {
-    let (dname, mnames, erased) = Array::get(erasures, i)
-    if dname == struct_name && string_array_contains(mnames, field_name) {
+    let (dname, mname, erased) = Array::get(erasures, i)
+    if dname == struct_name && mname == field_name {
       found = erased
       i = Array::length(erasures)
     } else {

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -883,6 +883,16 @@ export let vpkg_types_module_marker: String = "// vibe: vpkg contract types modu
 /// contract-`opaque` name whose definition lives in a sibling impl
 /// (types -> impl would be an import cycle), or a name from another package.
 /// Those resolve to the intentional bare `CtNamed` contract artifact.
+///
+/// This is textual, not provenance-checked, BY NECESSITY (Codex on #2162
+/// asked for opaque/import provenance): contract conformance is textual and
+/// a cross-package name has no declaration channel in the contract at all --
+/// measured, `TypeEnv` in incremental's `ModuleJob` is spelled with no
+/// `opaque` and no import anywhere in that index.vpkg. The residual is that
+/// a typo INSIDE a contract's transparent type keeps its pre-enforcement
+/// wildcard behavior (every other position now reports); the sentinel
+/// enumerates that residual greppably, and closing it needs a contract-level
+/// provenance declaration first.
 fn ctm_deferred_type_names(tds: Array[Stmt]) -> Array[String] {
   let declared = array_empty()
   let referenced = array_empty()

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -878,12 +878,149 @@ export fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt] {
 /// `contract_facade_marker` / `vpkg_shared_import_marker`).
 export let vpkg_types_module_marker: String = "// vibe: vpkg contract types module (#1840)\n"
 
+/// #2125: the type-name heads `tds` reference minus the names `tds` declare
+/// -- the names this module can neither declare nor import: a
+/// contract-`opaque` name whose definition lives in a sibling impl
+/// (types -> impl would be an import cycle), or a name from another package.
+/// Those resolve to the intentional bare `CtNamed` contract artifact.
+fn ctm_deferred_type_names(tds: Array[Stmt]) -> Array[String] {
+  let declared = array_empty()
+  let referenced = array_empty()
+  let mut i = 0
+  while i < Array::length(tds) {
+    match Array::get(tds, i) {
+      SStruct(_, sname, fields, _, _, stp) => {
+        Array::push(declared, sname)
+        let mut ti = 0
+        while ti < Array::length(stp) {
+          Array::push(declared, Array::get(stp, ti))
+          ti = ti + 1
+        }
+        let mut fi = 0
+        while fi < Array::length(fields) {
+          let (_, fte) = Array::get(fields, fi)
+          ctm_collect_type_expr_heads(fte, referenced)
+          fi = fi + 1
+        }
+      },
+      SEnum(_, ename, eparams, variants, _) => {
+        Array::push(declared, ename)
+        let mut pi = 0
+        while pi < Array::length(eparams) {
+          Array::push(declared, Array::get(eparams, pi))
+          pi = pi + 1
+        }
+        let mut vi = 0
+        while vi < Array::length(variants) {
+          let (_, vtypes) = Array::get(variants, vi)
+          let mut vti = 0
+          while vti < Array::length(vtypes) {
+            ctm_collect_type_expr_heads(Array::get(vtypes, vti), referenced)
+            vti = vti + 1
+          }
+          vi = vi + 1
+        }
+      },
+      STypeAlias(_, aname, aparams, body) => {
+        Array::push(declared, aname)
+        let mut api = 0
+        while api < Array::length(aparams) {
+          Array::push(declared, Array::get(aparams, api))
+          api = api + 1
+        }
+        ctm_collect_type_expr_heads(body, referenced)
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  let out = array_empty()
+  let mut ri = 0
+  while ri < Array::length(referenced) {
+    let n = Array::get(referenced, ri)
+    let is_builtin = match resolve_builtin(n) {
+      Some(_) => true,
+      None => n == "Array" || n == "Option"
+    }
+    if is_builtin || ctm_str_list_has(declared, n) || ctm_str_list_has(out, n) {
+      ()
+    } else {
+      Array::push(out, n)
+    }
+    ri = ri + 1
+  }
+  out
+}
+
+fn ctm_collect_type_expr_heads(te: TypeExpr, out: Array[String]) -> Unit {
+  match te {
+    TyUnit => (),
+    TyName(n) => Array::push(out, n),
+    TyApp(n, args) => {
+      Array::push(out, n)
+      let mut i = 0
+      while i < Array::length(args) {
+        ctm_collect_type_expr_heads(Array::get(args, i), out)
+        i = i + 1
+      }
+    },
+    TyTuple(elems) => {
+      let mut i = 0
+      while i < Array::length(elems) {
+        ctm_collect_type_expr_heads(Array::get(elems, i), out)
+        i = i + 1
+      }
+    },
+    TyFn(params, ret, _) => {
+      let mut i = 0
+      while i < Array::length(params) {
+        ctm_collect_type_expr_heads(Array::get(params, i), out)
+        i = i + 1
+      }
+      ctm_collect_type_expr_heads(ret, out)
+    }
+  }
+}
+
+fn ctm_str_list_has(items: Array[String], wanted: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) && !found {
+    if Array::get(items, i) == wanted {
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// #2125: the sentinel binding name prefix the checker's field/payload
+/// unknown-type enforcement recognises (see checker_stmt's
+/// `collect_deferred_type_name_sentinels`). Spelled here once; the checker
+/// mirrors the spelling.
+export let vpkg_deferred_type_names_prefix: String = "__vpkg_deferred_type_names_"
+
 /// #1840: the materialized types module's source text — the contract's
 /// type-family definitions verbatim (they are already exported by
 /// `classify_contract_stmts`), behind the idempotency marker.
-export fn contract_types_module_text(tds: Array[Stmt]) -> String {
+///
+/// #2125: when the definitions reference names the module can neither declare
+/// nor import, a sentinel `let <prefix><uniq>__: String = "N1 N2"` binding
+/// carries them IN-BAND, so every lane that checks this text — per-module,
+/// cached, or injected into a whole-program merge — exempts exactly those
+/// names at field/payload positions without any process-lifetime registry.
+/// `uniq` keeps the binding name collision-free when several contracts'
+/// modules meet in one merge.
+export fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String {
   let lines = array_empty()
   Array::push(lines, vpkg_types_module_marker)
+  let deferred = ctm_deferred_type_names(tds)
+  if Array::length(deferred) == 0 {
+    ()
+  } else {
+    Array::push(lines, "let \{vpkg_deferred_type_names_prefix}\{uniq}__: String = \"\{String::join(deferred, " ")}\"\n")
+  }
   let mut i = 0
   while i < Array::length(tds) {
     Array::push(lines, print_stmt(Array::get(tds, i)))

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -893,23 +893,30 @@ export let vpkg_types_module_marker: String = "// vibe: vpkg contract types modu
 /// wildcard behavior (every other position now reports); the sentinel
 /// enumerates that residual greppably, and closing it needs a contract-level
 /// provenance declaration first.
-fn ctm_deferred_type_names(tds: Array[Stmt]) -> Array[String] {
+/// Returns (declared type names, deferred names). A declaration's own
+/// generic binders shadow its references LOCALLY only (Codex round 3 on
+/// #2162: a module-wide `declared` let `struct Box[Counter]`'s binder hide
+/// `struct Holder`'s reference to the contract-`opaque` `Counter`, dropping
+/// it from the sentinel and rejecting a valid contract).
+fn ctm_deferred_type_names(tds: Array[Stmt]) -> (Array[String], Array[String]) {
   let declared = array_empty()
   let referenced = array_empty()
   let mut i = 0
   while i < Array::length(tds) {
+    let scratch = array_empty()
+    let binders = array_empty()
     match Array::get(tds, i) {
       SStruct(_, sname, fields, _, _, stp) => {
         Array::push(declared, sname)
         let mut ti = 0
         while ti < Array::length(stp) {
-          Array::push(declared, Array::get(stp, ti))
+          Array::push(binders, Array::get(stp, ti))
           ti = ti + 1
         }
         let mut fi = 0
         while fi < Array::length(fields) {
           let (_, fte) = Array::get(fields, fi)
-          ctm_collect_type_expr_heads(fte, referenced)
+          ctm_collect_type_expr_heads(fte, scratch)
           fi = fi + 1
         }
       },
@@ -917,7 +924,7 @@ fn ctm_deferred_type_names(tds: Array[Stmt]) -> Array[String] {
         Array::push(declared, ename)
         let mut pi = 0
         while pi < Array::length(eparams) {
-          Array::push(declared, Array::get(eparams, pi))
+          Array::push(binders, Array::get(eparams, pi))
           pi = pi + 1
         }
         let mut vi = 0
@@ -925,7 +932,7 @@ fn ctm_deferred_type_names(tds: Array[Stmt]) -> Array[String] {
           let (_, vtypes) = Array::get(variants, vi)
           let mut vti = 0
           while vti < Array::length(vtypes) {
-            ctm_collect_type_expr_heads(Array::get(vtypes, vti), referenced)
+            ctm_collect_type_expr_heads(Array::get(vtypes, vti), scratch)
             vti = vti + 1
           }
           vi = vi + 1
@@ -935,12 +942,22 @@ fn ctm_deferred_type_names(tds: Array[Stmt]) -> Array[String] {
         Array::push(declared, aname)
         let mut api = 0
         while api < Array::length(aparams) {
-          Array::push(declared, Array::get(aparams, api))
+          Array::push(binders, Array::get(aparams, api))
           api = api + 1
         }
-        ctm_collect_type_expr_heads(body, referenced)
+        ctm_collect_type_expr_heads(body, scratch)
       },
       _ => ()
+    }
+    let mut si = 0
+    while si < Array::length(scratch) {
+      let sn = Array::get(scratch, si)
+      if ctm_str_list_has(binders, sn) {
+        ()
+      } else {
+        Array::push(referenced, sn)
+      }
+      si = si + 1
     }
     i = i + 1
   }
@@ -959,7 +976,7 @@ fn ctm_deferred_type_names(tds: Array[Stmt]) -> Array[String] {
     }
     ri = ri + 1
   }
-  out
+  (declared, out)
 }
 
 fn ctm_collect_type_expr_heads(te: TypeExpr, out: Array[String]) -> Unit {
@@ -1025,11 +1042,15 @@ export let vpkg_deferred_type_names_prefix: String = "__vpkg_deferred_type_names
 export fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String {
   let lines = array_empty()
   Array::push(lines, vpkg_types_module_marker)
-  let deferred = ctm_deferred_type_names(tds)
+  let (decl_names, deferred) = ctm_deferred_type_names(tds)
   if Array::length(deferred) == 0 {
     ()
   } else {
-    Array::push(lines, "let \{vpkg_deferred_type_names_prefix}\{uniq}__: String = \"\{String::join(deferred, " ")}\"\n")
+    // `<declared> : <deferred>` -- the checker scopes the exemption to the
+    // declarations named BEFORE the `:` (Codex round 3 on #2162: in a
+    // whole-program merge an unscoped sentinel would excuse an unrelated
+    // declaration that misspelled or forgot to import one of these names).
+    Array::push(lines, "let \{vpkg_deferred_type_names_prefix}\{uniq}__: String = \"\{String::join(decl_names, " ")} : \{String::join(deferred, " ")}\"\n")
   }
   let mut i = 0
   while i < Array::length(tds) {

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -55,7 +55,8 @@ fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(S
 
 // --- materialized types module (#1840)
 fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
-fn contract_types_module_text(tds: Array[Stmt]) -> String
+fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String
+let vpkg_deferred_type_names_prefix: String
 fn contract_types_item_names(tds: Array[Stmt]) -> Array[String]
 fn contract_types_module_line(keyword: String, types_path: String, tds: Array[Stmt]) -> String
 

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1021,7 +1021,22 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String 
   if Array::length(tds) == 0 {
     ""
   } else {
-    let text = contract_types_module_text(tds)
+    // #2125: `uniq` keeps the deferred-names sentinel binding (see
+    // contract_types_module_text) collision-free across contracts whose
+    // modules meet in one whole-program merge.
+    let uniq_sb = StringBuilder::new()
+    let mut uci = 0
+    while uci < String::length(vpkg_path) {
+      let uc = String::char_code_at(vpkg_path, uci)
+      let u_ident = (uc >= '0' && uc <= '9') || (uc >= 'a' && uc <= 'z') || (uc >= 'A' && uc <= 'Z') || uc == '_'
+      if u_ident {
+        StringBuilder::push(uniq_sb, vpkg_path[uci: uci + 1])
+      } else {
+        StringBuilder::push(uniq_sb, "_")
+      }
+      uci = uci + 1
+    }
+    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb))
     let raw_key = compact_string_fingerprint(String::concat(vpkg_path, String::concat("|", text)))
     // Identifier-safe basename: the import-path grammar (parser_base.vibe's
     // collect_import_path) lexes path segments as identifier/keyword tokens,
@@ -1128,7 +1143,7 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       // types module live under different roots when VIBE_BUILD_CACHE_DIR
       // rebases the caches, so one can survive a clean of the other. A
       // missing file falls through to full regeneration (idempotent write).
-      let cached_hit = if String::starts_with(cached_prefix, "v2\n") {
+      let cached_hit = if String::starts_with(cached_prefix, "v3\n") {
         let rest = cached_prefix[3: String::length(cached_prefix)]
         let nl = String::index_of(rest, "\n")
         if nl < 0 {
@@ -1152,7 +1167,7 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       } else {
         ""
       }
-      if cached_hit != "" || String::starts_with(cached_prefix, "v2\n\n") {
+      if cached_hit != "" || String::starts_with(cached_prefix, "v3\n\n") {
         cached_hit
       } else {
         let vpkg_raw = Fs::read_file(vpkg_path)
@@ -1171,7 +1186,7 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
           let types_rel = relative_spelling_from_dir(dir_of_path(vpkg_path), types_path)
           String::concat(contract_types_module_line("import", types_rel, contract_type_family_defs(vpkg_type_defs)), shared_text)
         }
-        Fs::write_file(prefix_cache_path, String::concat("v2\n", String::concat(types_path, String::concat("\n", prefix_text))))
+        Fs::write_file(prefix_cache_path, String::concat("v3\n", String::concat(types_path, String::concat("\n", prefix_text))))
         prefix_text
       }
     }
@@ -1926,7 +1941,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // verify the file still exists (see the prefix cache's twin comment). A
   // missing file falls through to full regeneration, which re-materializes
   // it idempotently.
-  if String::starts_with(cached_facade, "v2\n") {
+  if String::starts_with(cached_facade, "v3\n") {
     let fc_rest = cached_facade[3: String::length(cached_facade)]
     let fc_nl = String::index_of(fc_rest, "\n")
     if fc_nl >= 0 {
@@ -2040,7 +2055,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // the fingerprint pass and the reads above — see the comment at
   // fresh_fp_sb's construction).
   let fresh_closure_fp = compact_string_fingerprint(StringBuilder::freeze(fresh_fp_sb))
-  Fs::write_file(persistent_contract_facade_cache_path(path, fresh_closure_fp), String::concat("v2\n", String::concat(facade_types_path, String::concat("\n", facade_final))))
+  Fs::write_file(persistent_contract_facade_cache_path(path, fresh_closure_fp), String::concat("v3\n", String::concat(facade_types_path, String::concat("\n", facade_final))))
   facade_final
 }
 

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1023,14 +1023,18 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String 
   } else {
     // #2125: `uniq` keeps the deferred-names sentinel binding (see
     // contract_types_module_text) collision-free across contracts whose
-    // modules meet in one whole-program merge.
+    // modules meet in one whole-program merge. Fingerprint of the contract
+    // path, not a sanitized spelling of it -- character replacement is not
+    // injective (`a/b` and `a_b` collapse, Codex on #2162), and two equal
+    // binding names would be duplicate declarations in the merge.
+    let uniq_fp = compact_string_fingerprint(vpkg_path)
     let uniq_sb = StringBuilder::new()
     let mut uci = 0
-    while uci < String::length(vpkg_path) {
-      let uc = String::char_code_at(vpkg_path, uci)
+    while uci < String::length(uniq_fp) {
+      let uc = String::char_code_at(uniq_fp, uci)
       let u_ident = (uc >= '0' && uc <= '9') || (uc >= 'a' && uc <= 'z') || (uc >= 'A' && uc <= 'Z') || uc == '_'
       if u_ident {
-        StringBuilder::push(uniq_sb, vpkg_path[uci: uci + 1])
+        StringBuilder::push(uniq_sb, uniq_fp[uci: uci + 1])
       } else {
         StringBuilder::push(uniq_sb, "_")
       }

--- a/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
+++ b/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
@@ -312,6 +312,16 @@ test "#2162 review: a method's generic binder is scoped to its own field" {
   inspect(first_check_error(crossed), content = "unknown type `Y` in field `a` of struct `Tr2Dict`")
 }
 
+test "#2162 review round 3: a sentinel exempts only the declarations it names" {
+  // The `<protected> : <deferred>` sentinel format scopes the exemption: in
+  // a whole-program merge an unscoped sentinel would excuse an UNRELATED
+  // declaration misspelling one of the deferred names.
+  let scoped = "let __vpkg_deferred_type_names_t__: String = \"Prot : Missing\"\n\nstruct Prot {\n  x: Missing\n}\n"
+  inspect(first_check_error(scoped), content = "")
+  let unrelated = "let __vpkg_deferred_type_names_t__: String = \"Prot : Missing\"\n\nstruct Prot {\n  x: Missing\n}\n\nstruct Local {\n  y: Missing\n}\n"
+  inspect(first_check_error(unrelated), content = "unknown type `Missing` in field `y` of struct `Local`")
+}
+
 test "#2147 review round 4: Self inside a trait declaration stays legal" {
   // The one place `Self` is a type. Trait-method signatures are resolved by
   // the trait machinery, not by `report_unknown_type_names`' annotation

--- a/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
+++ b/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
@@ -275,6 +275,33 @@ test "#2159 review: an alias of an ordinary struct still has no region slot" {
   inspect(first_check_error(src), content = "unknown type `r` in parameter `x` [@fn=f]")
 }
 
+test "#2125 fields: a typo in a struct field type is reported" {
+  inspect(first_check_error("struct B {\n  x: Intt\n}\n"), content = "unknown type `Intt` in field `x` of struct `B`")
+}
+
+test "#2125 payloads: a typo in an enum payload is reported" {
+  inspect(first_check_error("enum E {\n  V(Wrong)\n}\n"), content = "unknown type `Wrong` in the payload of `E::V`")
+}
+
+test "#2125 fields: a struct's own type parameter is not a typo" {
+  inspect(first_check_error("struct Box2[T] {\n  v: T\n}\n\nfn use_it(b: Box2[Int]) -> Int {\n  1\n}\n"), content = "")
+}
+
+test "#2125 fields: a trait-dict witness struct's erased names are not typos" {
+  // Whole-program lanes re-check desugar_trait_dict's output, where the
+  // `<Trait>Dict` struct spells `Self` (and the trait's params) verbatim.
+  // Exempt under provenance: the struct name is the trait's dict spelling AND
+  // the field is a method that trait declares.
+  let dict_ok = "trait Default3 {\n  default3() -> Self\n}\n\nstruct Default3Dict {\n  default3: () -> Self\n}\n"
+  inspect(first_check_error(dict_ok), content = "")
+  // No such trait: the same struct is ordinary and `Self` is a wildcard.
+  let no_trait = "struct Default3Dict {\n  default3: () -> Self\n}\n"
+  inspect(first_check_error(no_trait), content = "unknown type `Self` in field `default3` of struct `Default3Dict`")
+  // Trait exists but the field is not one of its methods: still reported.
+  let wrong_field = "trait Default3 {\n  default3() -> Self\n}\n\nstruct Default3Dict {\n  other: () -> Self\n}\n"
+  inspect(first_check_error(wrong_field), content = "unknown type `Self` in field `other` of struct `Default3Dict`")
+}
+
 test "#2147 review round 4: Self inside a trait declaration stays legal" {
   // The one place `Self` is a type. Trait-method signatures are resolved by
   // the trait machinery, not by `report_unknown_type_names`' annotation

--- a/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
+++ b/lib/@vibe/compiler/tests/unknown_type_name_enforced_test.vibe
@@ -302,6 +302,16 @@ test "#2125 fields: a trait-dict witness struct's erased names are not typos" {
   inspect(first_check_error(wrong_field), content = "unknown type `Self` in field `other` of struct `Default3Dict`")
 }
 
+test "#2162 review: a method's generic binder is scoped to its own field" {
+  // Codex on #2162: a trait-wide union of method binders let field `a` spell
+  // method `b`'s binder and stay a wildcard. Each dict field carries only its
+  // own method's binders (plus `Self` and the trait's params).
+  let own = "trait Tr2 {\n  a[X](Self) -> X\n  b[Y](Self) -> Y\n}\n\nstruct Tr2Dict {\n  a: (Self) -> X\n}\n"
+  inspect(first_check_error(own), content = "")
+  let crossed = "trait Tr2 {\n  a[X](Self) -> X\n  b[Y](Self) -> Y\n}\n\nstruct Tr2Dict {\n  a: (Self) -> Y\n}\n"
+  inspect(first_check_error(crossed), content = "unknown type `Y` in field `a` of struct `Tr2Dict`")
+}
+
 test "#2147 review round 4: Self inside a trait declaration stays legal" {
   // The one place `Self` is a type. Trait-method signatures are resolved by
   // the trait machinery, not by `report_unknown_type_names`' annotation


### PR DESCRIPTION
Closes #2125. The last two annotation positions where a typo silently became a wildcard `CtNamed` — deliberately scoped out of #2147 pending the vpkg types-module question, resolved here.

```console
$ vibe check b.vibe          # struct B { x: Intt }
b.vibe: unknown type `Intt` in field `x` of struct `B`
$ vibe check e.vibe          # enum E { V(Wrong) }
e.vibe: unknown type `Wrong` in the payload of `E::V`
```

Two generated-code shapes legitimately spell names nothing declares; each gets a provenance-scoped exemption (the standing lesson from #2147/#2159's five review rounds: key on the binder or provenance, never a name shape alone).

## 1. Trait-dict witness structs

`desugar_trait_dict`'s `make_dict_struct_stmt` copies trait method signatures verbatim — `Self`, the trait's params, method-level binders — into the `<Trait>Dict` struct, and whole-program lanes re-check that output (the first probe build died on `DefaultDict { default: () -> Self }`). `collect_trait_dict_erasures` scans the **statement list** — `reorder_type_decls_first` hoists the synthesized struct above its trait, so the env cannot answer at the struct's check point (measured: the env-based version still failed) — and exempts a field only when the struct name is the trait's dict spelling AND the field is a method that trait declares.

## 2. Materialized vpkg types modules

A contract's types module references names it can neither declare nor import: a contract-`opaque` name whose definition lives in a sibling impl (types → impl would be an import cycle — `PerceusActionKind`), or a name from another package (`TypeEnv` in incremental's `ModuleJob`). Those resolve to the intentional bare-`CtNamed` contract artifact — the same convention the facade uses for non-builtin opaques.

`contract_types_module_text` now carries them **in-band** as a sentinel binding:

```
let __vpkg_deferred_type_names_<uniq>__: String = "PerceusActionKind"
```

and the checker's field/payload report sites treat the listed names as shadowed (function/let annotation enforcement is unaffected). In-band because the exemption must travel with the text through every lane — per-module, cached, or injected into a whole-program merge, where the names resolve anyway and the sentinel is inert. A process-lifetime registry was tried first and **measured flaky**: which process runs contract materialization depends on cache state, and a fresh check process reached cached stubs with an empty registry — 105 unit-test files red with the same diagnostic, and the same probe flipping green/red between runs. The facade/prefix cache rows bump `v2` → `v3` so stale facades pointing at sentinel-less stubs regenerate.

## Known limits (stated, not silent)

- Field/payload reports anchor on no `fn`/`let` name, so they carry the file but **no position** yet — extending the #1941 anchor to type declarations is follow-up work.
- The sentinel is a reserved dunder spelling; writing one by hand in ordinary source opts that file's fields out for the listed names — an explicit, greppable escape hatch, same class as the `__dict_` carve-out.
- The fully honest end state for the types module remains a bodyless `opaque type` declaration in the module grammar; the sentinel documents exactly which names await it.

## Verification

- self-build stage0→1→2 green
- `scripts/compiler_gate.sh` → `[compiler-gate] ok`
- `scripts/unit_test_runner.sh` → **1006/1006** (the registry attempt's 105 failures all cleared)
- perceus-consumer probe green in both **cold** (fresh materialization) and **warm** (pre-existing stub) states — the flakiness axis the registry failed on
- fmt clean on touched files; 5 new test blocks (36 total in `unknown_type_name_enforced_test.vibe`): field/payload positives, struct-tparam negative, and the trait-dict exemption's three faces (exempt under provenance, reported without the trait, reported for a non-method field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyrvqhAB9EdeV8HdNVTDFC

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyrvqhAB9EdeV8HdNVTDFC)_