### PR TITLE
Fix and gate the selfhost CLI core build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,21 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
+      - name: Install wasm-tools
+        # test_cli_core.sh validates every generated core module independently.
+        # Keep this pinned to the same version used by the gc and wasi-p3 jobs.
+        env:
+          WASM_TOOLS_VERSION: "1.253.0"
+        run: |
+          set -euo pipefail
+          mkdir -p "$PWD/compiler-tools"
+          if curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux.tar.gz" | tar -xz; then
+            cp "wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux/wasm-tools" "$PWD/compiler-tools/"
+          else
+            cargo install wasm-tools --locked --version "$WASM_TOOLS_VERSION" --root "$PWD/compiler-tools-cargo"
+            cp "$PWD/compiler-tools-cargo/bin/wasm-tools" "$PWD/compiler-tools/"
+          fi
+          echo "$PWD/compiler-tools" >> "$GITHUB_PATH"
       - name: Compiler gate (bootstrap + fixpoint)
         # Fixture lanes run as compiler-gate-lanes (matrix) so they do not
         # sit on this job's critical path. This job keeps the seed->stage3

--- a/lib/@vibe/cli/main.vibex
+++ b/lib/@vibe/cli/main.vibex
@@ -31,7 +31,7 @@ import @vibe/process {
   Process
 }
 
-fn main with Fs + Env + Process {
+fn main with Fs + Env + Process + Stdout {
   let code = run_cli_main_with_args(collect_cli_args())
   if code != 0 {
     vibe_process_exit_raw(code)

--- a/scripts/build_cli_core.sh
+++ b/scripts/build_cli_core.sh
@@ -59,11 +59,6 @@ if [ ! -f "$ENTRY_PATH" ]; then
   exit 1
 fi
 
-# Compiler package implementations include generated bundles that are absent
-# from a pristine checkout. Direct callers (including scripts/vibe_cli.sh)
-# must not depend on another gate having populated them first.
-bash "$SCRIPT_DIR/ensure_generated.sh" >&2
-
 rel_path() {
   local path="$1"
   case "$path" in
@@ -132,6 +127,12 @@ if [ "$needs_rebuild" -eq 0 ]; then
   printf '%s\n' "$STAGE1_CORE_WASM"
   exit 0
 fi
+
+# Compiler package implementations include generated bundles that are absent
+# from a pristine checkout. Direct rebuild callers (including vibe_cli.sh)
+# must not depend on another gate having populated them first. Keep this after
+# the no-rebuild return: `never` with an existing artifact must remain offline.
+bash "$SCRIPT_DIR/ensure_generated.sh" >&2
 
 mkdir -p "$(dirname "$STAGE1_CORE_WASM")"
 

--- a/scripts/build_cli_core.sh
+++ b/scripts/build_cli_core.sh
@@ -59,6 +59,11 @@ if [ ! -f "$ENTRY_PATH" ]; then
   exit 1
 fi
 
+# Compiler package implementations include generated bundles that are absent
+# from a pristine checkout. Direct callers (including scripts/vibe_cli.sh)
+# must not depend on another gate having populated them first.
+bash "$SCRIPT_DIR/ensure_generated.sh" >&2
+
 rel_path() {
   local path="$1"
   case "$path" in

--- a/scripts/pkfire/gates_shard.sh
+++ b/scripts/pkfire/gates_shard.sh
@@ -40,9 +40,10 @@ case "$shard" in
     # `set -e` and everything after it silently never ran:
     #   test_selfhost_cli_component_preview2.sh, test_selfhost_cli_command_parity.sh,
     #   test_selfhost_cli_direct_parity.sh, test_selfhost_cutover_gate.sh
-    # test_cli_core.sh exists but depends on build_cli_core.sh
-    # which was also never committed (recorded in #766 / PR #804). Restore each
-    # from its spec contract before re-adding to this list.
+    # The split CLI core is a supported entry point used by vibe_cli.sh. Keep
+    # its build and command surface in the CLI shard so its effect row and
+    # generated-source prerequisites cannot rot unnoticed (#2148).
+    bash scripts/test_cli_core.sh
     bash scripts/test_cli_preview2_package.sh
     bash scripts/test_cli_command_component.sh
     bash scripts/test_cli_direct_component.sh

--- a/scripts/pkfire/gates_shard.sh
+++ b/scripts/pkfire/gates_shard.sh
@@ -40,10 +40,8 @@ case "$shard" in
     # `set -e` and everything after it silently never ran:
     #   test_selfhost_cli_component_preview2.sh, test_selfhost_cli_command_parity.sh,
     #   test_selfhost_cli_direct_parity.sh, test_selfhost_cutover_gate.sh
-    # The split CLI core is a supported entry point used by vibe_cli.sh. Keep
-    # its build and command surface in the CLI shard so its effect row and
-    # generated-source prerequisites cannot rot unnoticed (#2148).
-    bash scripts/test_cli_core.sh
+    # test_cli_core.sh runs in the active compiler-gate bootstrap lane. Do not
+    # duplicate its multi-command selfhost build in this legacy manual shard.
     bash scripts/test_cli_preview2_package.sh
     bash scripts/test_cli_command_component.sh
     bash scripts/test_cli_direct_component.sh

--- a/scripts/test_cli_core.sh
+++ b/scripts/test_cli_core.sh
@@ -93,6 +93,16 @@ run_stage() {
   fi
 }
 
+run_wasm_validate() {
+  local name="$1"
+  local wasm="$2"
+  if command -v wasm-tools >/dev/null 2>&1; then
+    run_stage "$name" wasm-tools validate "$wasm"
+  else
+    echo "[selfhost-cli-core] skip: $name (wasm-tools not installed)"
+  fi
+}
+
 run_stage_capture_stdout() {
   local name="$1"
   local out_path="$2"
@@ -213,7 +223,7 @@ if [ ! -f "$COMMAND_CALLSTACK_TSV" ] || ! grep -Eq $'^compile\t[0-9]+\t[1-9][0-9
   exit 1
 fi
 
-run_stage "validate command-style compile-lite wasm" wasm-tools validate "$COMMAND_OUTPUT_WASM" || exit $?
+run_wasm_validate "validate command-style compile-lite wasm" "$COMMAND_OUTPUT_WASM" || exit $?
 
 run_stage_capture_stdout "run command-style compile-lite wasm produced by selfhost core cli" \
   "$COMMAND_OUTPUT_RUN_LOG" \
@@ -252,7 +262,7 @@ if [ ! -f "$COMPILE_COMMAND_OUTPUT_WASM" ]; then
   exit 1
 fi
 
-run_stage "validate command-style compile wasm" wasm-tools validate "$COMPILE_COMMAND_OUTPUT_WASM" || exit $?
+run_wasm_validate "validate command-style compile wasm" "$COMPILE_COMMAND_OUTPUT_WASM" || exit $?
 
 run_stage_capture_stdout "run command-style compile wasm produced by selfhost core cli" \
   "$COMPILE_COMMAND_OUTPUT_RUN_LOG" \
@@ -291,7 +301,7 @@ if [ ! -f "$BUILD_COMMAND_OUTPUT_WASM" ]; then
   exit 1
 fi
 
-run_stage "validate command-style build wasm" wasm-tools validate "$BUILD_COMMAND_OUTPUT_WASM" || exit $?
+run_wasm_validate "validate command-style build wasm" "$BUILD_COMMAND_OUTPUT_WASM" || exit $?
 
 run_stage_capture_stdout "run command-style build wasm produced by selfhost core cli" \
   "$BUILD_COMMAND_OUTPUT_RUN_LOG" \
@@ -362,8 +372,8 @@ if [ ! -f "$DEBUG_LIB_WASM" ]; then
   exit 1
 fi
 
-run_stage "validate linked debug main wasm" wasm-tools validate "$DEBUG_OUTPUT_WASM" || exit $?
-run_stage "validate linked debug library wasm" wasm-tools validate "$DEBUG_LIB_WASM" || exit $?
+run_wasm_validate "validate linked debug main wasm" "$DEBUG_OUTPUT_WASM" || exit $?
+run_wasm_validate "validate linked debug library wasm" "$DEBUG_LIB_WASM" || exit $?
 
 run_stage_capture_stdout "run linked debug wasm produced by selfhost core cli" \
   "$DEBUG_OUTPUT_RUN_LOG" \
@@ -409,8 +419,8 @@ if [ ! -f "$DEBUG_STRING_LIB_WASM" ]; then
   exit 1
 fi
 
-run_stage "validate linked debug string main wasm" wasm-tools validate "$DEBUG_STRING_OUTPUT_WASM" || exit $?
-run_stage "validate linked debug string library wasm" wasm-tools validate "$DEBUG_STRING_LIB_WASM" || exit $?
+run_wasm_validate "validate linked debug string main wasm" "$DEBUG_STRING_OUTPUT_WASM" || exit $?
+run_wasm_validate "validate linked debug string library wasm" "$DEBUG_STRING_LIB_WASM" || exit $?
 
 run_stage_capture_stdout "run linked debug string wasm produced by selfhost core cli" \
   "$DEBUG_STRING_OUTPUT_RUN_LOG" \

--- a/tests/gates/bootstrap/run.sh
+++ b/tests/gates/bootstrap/run.sh
@@ -85,6 +85,14 @@ print(f"[compiler-gate] fixpoint ok: stage2==stage3 ({s2[:12]})")
 PY
 
 stage2_wasm="${latest_gen}stage2.wasm"
+
+# #2148: build and exercise the supported split CLI entry with the stage2 from
+# this checkout. This caught the entry's missing Stdout row and keeps direct
+# build prerequisites plus the compile/build/check command surface live.
+echo "[compiler-gate] 3cli/3 selfhost split CLI core"
+VIBE_CLI_CORE_BASE_COMPILER="$stage2_wasm" \
+  bash scripts/test_cli_core.sh
+
 # #1553: a real compiled-CLI smoke. The protocol test above validates the
 # measurement wrapper with a fake runner; this proves the freshly self-hosted
 # CLI actually selects both marked helpers and emits their required codegen

--- a/tests/gates/bootstrap/run.sh
+++ b/tests/gates/bootstrap/run.sh
@@ -90,7 +90,7 @@ stage2_wasm="${latest_gen}stage2.wasm"
 # this checkout. This caught the entry's missing Stdout row and keeps direct
 # build prerequisites plus the compile/build/check command surface live.
 echo "[compiler-gate] 3cli/3 selfhost split CLI core"
-VIBE_CLI_CORE_BASE_COMPILER="$stage2_wasm" \
+VIBE_CLI_CORE_BASE_COMPILER="$stage2_wasm" VIBE_RC=1 \
   bash scripts/test_cli_core.sh
 
 # #1553: a real compiled-CLI smoke. The protocol test above validates the

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -6,6 +6,7 @@ x-parser-binder-context-spine	bootstrap	parser binder-context spine
 1-2/3	bootstrap	1-2/3 generated compiler artifacts
 2a/3	bootstrap	2a/3 FS heap measurement protocol
 3/3	bootstrap	3/3 selfbuild seed->stage1->stage2->stage3
+3cli/3	bootstrap	3cli/3 selfhost split CLI core
 3a/3	bootstrap	3a/3 FS heap mark lane smoke
 3a/3-2	bootstrap	3a/3 artifact-input trace oracle
 3b/3	bootstrap	3b/3 RC entry-result parity (#1696)


### PR DESCRIPTION
## Summary

- add the inferred `Stdout` effect to the split CLI entry
- generate compiler bundle artifacts when `build_cli_core.sh` is called from a pristine checkout
- restore `test_cli_core.sh` to the CLI gate shard so this supported path cannot rot unnoticed

## Validation

- reproduced the original `missing { Stdout }` diagnostic before the change
- `VIBE_CLI_CORE_BASE_COMPILER=... bash scripts/build_cli_core.sh`
- `VIBE_CLI_CORE_STAGE_TIMEOUT_SEC=600 bash scripts/test_cli_core.sh`
- `bash scripts/vibe_fmt.sh --check lib/@vibe/cli/main.vibex`
- `bash scripts/check_task_inputs.sh`

Closes #2148