### PR TITLE
Three P0 silent-wrong fixes: empty String::join rendering, `for` over a plain struct, type-param shadowing (#2143, #2152, #2141)

### DIFF
--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -370,3 +370,14 @@ handle_perform_inside_annotated_closure	ok
 handle_callee_closure_parameter	ok
 handle_perform_inside_unannotated_closure	reject	cannot discharge { Ask }
 handle_callee_local_binding_alias	reject	can never fire
+
+# --- #2152: `for` over a declared type with no iteration protocol. The
+# residual array-loop fallback read the value as an array pointer (one
+# iteration, garbage binding, no diagnostic). The for-loop desugar -- which
+# runs on the merged sources, so every protocol impl the program has is
+# visible -- now throws. Two controls pin the protocols that must keep
+# classifying: indexed (`iter_length`+`iter_get`, #736) and `impl Iterator`.
+for_over_plain_struct_rejected	reject	declares no iteration protocol
+for_over_plain_enum_rejected	reject	declares no iteration protocol
+for_over_indexed_iterable_struct	ok
+for_over_iterator_impl_struct	ok

--- a/fixtures/typecheck/for_over_indexed_iterable_struct.vibe
+++ b/fixtures/typecheck/for_over_indexed_iterable_struct.vibe
@@ -1,0 +1,28 @@
+// #2152 control: a struct WITH the indexed-Iterable protocol
+// (`C::iter_length` + `C::iter_get`, #736) still classifies to the indexed
+// loop -- the rejection fires only when no protocol matched.
+
+struct Pair {
+  a: Int;
+  b: Int
+}
+
+fn Pair::iter_length(p: Pair) -> Int {
+  2
+}
+
+fn Pair::iter_get(p: Pair, i: Int) -> Int {
+  if i == 0 {
+    p.a
+  } else {
+    p.b
+  }
+}
+
+fn total(p: Pair) -> Int {
+  let mut n = 0
+  for x in p {
+    n = n + x
+  }
+  n
+}

--- a/fixtures/typecheck/for_over_iterator_impl_struct.vibe
+++ b/fixtures/typecheck/for_over_iterator_impl_struct.vibe
@@ -1,0 +1,32 @@
+// #2152 control: a struct with an `impl Iterator` (`next`) classifies to the
+// trait iterator loop -- the rejection fires only when no protocol matched.
+
+trait Iterator[T] {
+  next(Self) -> Option[(T, Self)]
+}
+
+struct Counter {
+  upto: Int;
+  at: Int
+}
+
+impl Iterator for Counter {
+  next(self) -> Option[(T, Counter)] {
+    if self.at < self.upto {
+      Some((self.at, Counter::{
+        upto: self.upto,
+        at: self.at + 1
+      }))
+    } else {
+      None
+    }
+  }
+}
+
+fn total(upto: Int) -> Int {
+  let mut n = 0
+  for x in Counter::{ upto: upto, at: 0 } {
+    n = n + x
+  }
+  n
+}

--- a/fixtures/typecheck/for_over_plain_enum_rejected.vibe
+++ b/fixtures/typecheck/for_over_plain_enum_rejected.vibe
@@ -1,0 +1,16 @@
+// #2152 (enum shape): iterating a plain enum value had the same silent-wrong
+// lowering as a plain struct -- the residual array loop read the value as an
+// array pointer. Same rejection, same message.
+
+enum Color {
+  Red;
+  Green
+}
+
+fn consume(c: Color) -> Int {
+  let mut n = 0
+  for x in c {
+    n = n + 1
+  }
+  n
+}

--- a/fixtures/typecheck/for_over_plain_struct_rejected.vibe
+++ b/fixtures/typecheck/for_over_plain_struct_rejected.vibe
@@ -1,0 +1,18 @@
+// #2152: a `for` over a value of a plain declared struct -- no iteration
+// protocol at all -- used to slip through to the residual array loop, which
+// read the struct as an array pointer: the body ran once with the loop
+// variable bound to garbage, and the program completed with wrong values.
+// The for-loop desugar (which sees the merged sources, so every protocol
+// function the program has) now rejects it.
+
+struct S {
+  a: Int
+}
+
+fn consume(it: S) -> Int {
+  let mut n = 0
+  for x in it {
+    n = n + 1
+  }
+  n
+}

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3514,12 +3514,25 @@ fn tps_names_contains(names: Array[String], name: String) -> Bool {
   found
 }
 
-fn tps_report(tparams: Array[String], local_types: Array[String], where_label: String, errors: Array[String]) -> Unit {
+fn tps_report(tparams: Array[String], local_types: Array[String], where_label: String, anchor: String, errors: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(tparams) {
     let tp = Array::get(tparams, i)
     if tps_names_contains(local_types, tp) {
-      Array::push(errors, String::concat("type parameter `", String::concat(tp, String::concat("` of ", String::concat(where_label, String::concat(" shadows the declared type `", String::concat(tp, "`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")))))))
+      // The ` [@fn=name]` suffix is the #1941 side-channel marker: binder
+      // lists carry no offset of their own, so the diagnostic anchors on the
+      // declaration name and locate_type_error turns it into a real line:col
+      // at the CLI boundary (find_fn_anchor_off prefers `fn name`/`let name`
+      // and falls back to the name's first occurrence, which for a struct or
+      // enum label is its declaration). Attached only when the label names a
+      // real identifier -- a test's string title is not a word the locator
+      // can find, and an unresolved marker is stripped, never printed.
+      let located = if String::length(anchor) > 0 {
+        String::concat(" [@fn=", String::concat(anchor, "]"))
+      } else {
+        ""
+      }
+      Array::push(errors, String::concat("type parameter `", String::concat(tp, String::concat("` of ", String::concat(where_label, String::concat(" shadows the declared type `", String::concat(tp, String::concat("`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)", located))))))))
     } else {
       ()
     }
@@ -3527,15 +3540,15 @@ fn tps_report(tparams: Array[String], local_types: Array[String], where_label: S
   }
 }
 
-fn tps_scan_expr(e: Expr, local_types: Array[String], where_label: String, errors: Array[String]) -> Unit {
+fn tps_scan_expr(e: Expr, local_types: Array[String], where_label: String, anchor: String, errors: Array[String]) -> Unit {
   match e {
-    EFn(tparams, _, _, _, _, _) => tps_report(tparams, local_types, where_label, errors),
+    EFn(tparams, _, _, _, _, _) => tps_report(tparams, local_types, where_label, anchor, errors),
     _ => ()
   }
   let kids = expr_children(e)
   let mut i = 0
   while i < Array::length(kids) {
-    tps_scan_expr(Array::get(kids, i), local_types, where_label, errors)
+    tps_scan_expr(Array::get(kids, i), local_types, where_label, anchor, errors)
     i = i + 1
   }
 }
@@ -3552,14 +3565,14 @@ fn collect_type_param_shadowing_errors(stmts: Array[Stmt], errors: Array[String]
     let mut i = 0
     while i < Array::length(stmts) {
       match Array::get(stmts, i) {
-        SStruct(_, name, _, _, _, tparams) => tps_report(tparams, local_types, tps_decl_label("struct", name), errors),
-        SEnum(_, name, tparams, _, _) => tps_report(tparams, local_types, tps_decl_label("enum", name), errors),
-        SLet(_, _, name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), errors),
-        SLetMut(name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), errors),
-        SLetPat(_, e) => tps_scan_expr(e, local_types, "a `let` pattern binding", errors),
-        SExpr(e) => tps_scan_expr(e, local_types, "a top-level expression", errors),
-        STest(name, e) => tps_scan_expr(e, local_types, tps_decl_label("test", name), errors),
-        SBench(name, e) => tps_scan_expr(e, local_types, tps_decl_label("bench", name), errors),
+        SStruct(_, name, _, _, _, tparams) => tps_report(tparams, local_types, tps_decl_label("struct", name), name, errors),
+        SEnum(_, name, tparams, _, _) => tps_report(tparams, local_types, tps_decl_label("enum", name), name, errors),
+        SLet(_, _, name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), name, errors),
+        SLetMut(name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), name, errors),
+        SLetPat(_, e) => tps_scan_expr(e, local_types, "a `let` pattern binding", "", errors),
+        SExpr(e) => tps_scan_expr(e, local_types, "a top-level expression", "", errors),
+        STest(name, e) => tps_scan_expr(e, local_types, tps_decl_label("test", name), "", errors),
+        SBench(name, e) => tps_scan_expr(e, local_types, tps_decl_label("bench", name), "", errors),
         _ => ()
       }
       i = i + 1

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3471,6 +3471,102 @@ export fn check_stmts(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: Array[
 /// Run the production whole-program check and retain every successful output
 /// the checker actually produces. This deliberately does not use the
 /// hover-only `check_program_type_table` path.
+/// #2141 (interim guard): reject a type-parameter binder that shares its
+/// spelling with a struct/enum declared in the SAME module. The desugar's
+/// generated generic helpers resolve type names by SPELLING
+/// (`dtd_type_param_names` subtracts declared type names program-wide), so a
+/// formal `T` next to a declared `struct T` makes
+/// `fn same[T](a: Array[T], b: Array[T]) { a == b }` compare with the
+/// STRUCT's semantics over non-struct elements -- `same([1,2], [1,3])`
+/// answered true with no diagnostic anywhere. Until that classification is
+/// scope-precise, the collision itself is rejected at the binder.
+///
+/// LOCAL declarations only, on purpose: a formal shadowing an IMPORTED type
+/// is measured behaviorally harmless (the helper over-binds and element
+/// comparison stays structural; pinned by
+/// derive_array_helper_interference_test.vibe), and rejecting it would break
+/// working programs whose dependency happens to export a colliding name.
+fn tps_local_type_names(stmts: Array[Stmt]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SStruct(_, name, _, _, _, _) => Array::push(out, name),
+      SEnum(_, name, _, _, _) => Array::push(out, name),
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn tps_names_contains(names: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) && !found {
+    if Array::get(names, i) == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn tps_report(tparams: Array[String], local_types: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(tparams) {
+    let tp = Array::get(tparams, i)
+    if tps_names_contains(local_types, tp) {
+      Array::push(errors, String::concat("type parameter `", String::concat(tp, String::concat("` of ", String::concat(where_label, String::concat(" shadows the declared type `", String::concat(tp, "`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")))))))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}
+
+fn tps_scan_expr(e: Expr, local_types: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  match e {
+    EFn(tparams, _, _, _, _, _) => tps_report(tparams, local_types, where_label, errors),
+    _ => ()
+  }
+  let kids = expr_children(e)
+  let mut i = 0
+  while i < Array::length(kids) {
+    tps_scan_expr(Array::get(kids, i), local_types, where_label, errors)
+    i = i + 1
+  }
+}
+
+fn tps_decl_label(kind: String, name: String) -> String {
+  String::concat(kind, String::concat(" `", String::concat(name, "`")))
+}
+
+fn collect_type_param_shadowing_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
+  let local_types = tps_local_type_names(stmts)
+  if Array::length(local_types) == 0 {
+    ()
+  } else {
+    let mut i = 0
+    while i < Array::length(stmts) {
+      match Array::get(stmts, i) {
+        SStruct(_, name, _, _, _, tparams) => tps_report(tparams, local_types, tps_decl_label("struct", name), errors),
+        SEnum(_, name, tparams, _, _) => tps_report(tparams, local_types, tps_decl_label("enum", name), errors),
+        SLet(_, _, name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), errors),
+        SLetMut(name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), errors),
+        SLetPat(_, e) => tps_scan_expr(e, local_types, "a `let` pattern binding", errors),
+        SExpr(e) => tps_scan_expr(e, local_types, "a top-level expression", errors),
+        STest(name, e) => tps_scan_expr(e, local_types, tps_decl_label("test", name), errors),
+        SBench(name, e) => tps_scan_expr(e, local_types, tps_decl_label("bench", name), errors),
+        _ => ()
+      }
+      i = i + 1
+    }
+  }
+}
+
 fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[CheckerStatementCapture], role_lane_capture: Option[TypedOccurrenceRoleLaneCapture]) -> CheckedProgramTypeDefsObservation with Exception {
   // Rank-1 method generics (#684): re-attach trait-method `[X: Bound]` binders
   // to impl free functions before checking, so `X::method` in an impl body
@@ -3507,6 +3603,8 @@ fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[
   // pre-codegen scan, so the snapshot assertion is import-free (see
   // desugar_inspect_calls).
   desugar_inspect_calls(stmts)
+  // #2141: loud guard at the binder, before checking -- see the pass doc.
+  collect_type_param_shadowing_errors(stmts, frozen_errors)
   let empty_defs = array_empty()
   let type_def_binders = array_empty()
   let seeded_raw_env = if trait_defined(EnvEmpty, "Eq") {
@@ -3850,6 +3948,8 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       desugar_labeled_args(stmts)
       // #1571: see check_program.
       desugar_inspect_calls(stmts)
+      // #2141: loud guard at the binder, before checking -- see the pass doc.
+      collect_type_param_shadowing_errors(stmts, frozen_errors)
       let empty_defs = array_empty()
       let type_def_binders = array_empty()
       // #1455: register the imported enums BEFORE checking, so

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
@@ -478,11 +478,21 @@ export fn gen_string_join_body(enable_rc: Bool, arr_len_idx: Int, arr_get_idx: I
   }
   emit_i32_wrap_i64(b)
   emit_local_set(b, 2)
-  // empty array -> empty string (0)
+  // empty array -> the canonical empty-string shape `(ptr << 32) | 0` with a
+  // REAL pointer (the current bump pointer; length 0, so nothing is read
+  // through it and no allocation happens). The previous `i64.const 0` was
+  // indistinguishable from the tagged Int 0, so the value compared and
+  // concatenated as an empty string but RENDERED as `0` --
+  // `"\{String::join([], ",")}"` printed `0` (#2143). Every other
+  // empty-string producer (literal, substring, trim, split) already carries
+  // a real pointer; join was the only 0-shaped empty.
   emit_local_get(b, 2)
   emit_i32_eqz(b)
   emit_if_i64(b)
-  emit_i64_const(b, 0)
+  emit_global_get(b, 0)
+  emit_i64_extend_i32_u(b)
+  emit_i64_const(b, 32)
+  emit_i64_shl(b)
   emit_else(b)
   // sep_len = lo32(sep); sep_ptr = hi32(sep)
   emit_local_get(b, 1)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -4334,7 +4334,7 @@ fn classify_indexed_for_loop(name: String, idx: Option[String], iter: Expr, rite
         // so every protocol function the program has is in `fn_returns` --
         // a miss here is a real miss, and it throws instead of iterating
         // garbage.
-        throw(for_no_protocol_msg(tn))
+        throw(String::concat(for_no_protocol_msg(tn), for_iterand_off_marker(iter)))
       }
     } else {
       EForIn(name, idx, riter, rbody)
@@ -4347,6 +4347,30 @@ fn classify_indexed_for_loop(name: String, idx: Option[String], iter: Expr, rite
 /// iteration protocol. Leads with the edits that make the loop work.
 fn for_no_protocol_msg(tn: String) -> String {
   String::concat("cannot iterate a `", String::concat(tn, String::concat("` value in `for`: define `", String::concat(tn, String::concat("::iter_length` + `", String::concat(tn, String::concat("::iter_get`, or `impl Iterator for ", String::concat(tn, String::concat("` with a `next` method, or loop over an Array of its elements -- `", String::concat(tn, "` declares no iteration protocol, so the loop has nothing to draw elements from (#2152)"))))))))))
+}
+
+/// #2152 (Codex P2 on the PR): transport the iterand's source offset as the
+/// standard ` [@off=N]` side-channel marker when the AST carries one.
+/// Measured 2026-08-21: the compile entries parse with the PLAIN
+/// `parse_program(lex(..))` (no starts array => every node's offset is -1,
+/// the pitfall cli_support.vibe documents for read_program), so in those
+/// lanes this is a no-op today -- the marker resolves as soon as a lane
+/// parses located (the check walk already does; wiring compile is #1514 /
+/// #1567's job). Safe by construction either way: emit_compile_diag strips
+/// an unresolved marker, so it can never leak (#1445's failure mode) or name
+/// a wrong position against merged module text (#1596's fail-closed rule).
+fn for_iterand_off_marker(iter: Expr) -> String {
+  let off = match iter {
+    EIdent(_, o) => o,
+    ECall(_, _, o) => o,
+    EDot(_, _, o, _) => o,
+    _ => 0 - 1
+  }
+  if off >= 0 {
+    String::concat(" [@off=", String::concat(__to_string(off), "]"))
+  } else {
+    ""
+  }
 }
 
 /// `for x in iter { body }` -- the ONE for-loop classification (#1350 folded

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -4292,7 +4292,7 @@ fn for_await_is_pull_source(inner: Expr, fn_returns: Array[(String, String)]) ->
 /// Array-backed `Stream`, ADR-0012), not the pull loop that used to
 /// call_indirect an array pointer. The pull loop fires only on a POSITIVE
 /// function-shaped classification.
-fn classify_trait_free_for_loop(name: String, idx: Option[String], iter: Expr, riter: Expr, rbody: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr {
+fn classify_trait_free_for_loop(name: String, idx: Option[String], iter: Expr, riter: Expr, rbody: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   match infer_arg_type_name(iter, struct_sets, var_types, fn_returns) {
     Some(tn) => if tn == "HostStream" {
       build_host_stream_for(name, riter, rbody)
@@ -4318,15 +4318,35 @@ fn classify_trait_free_for_loop(name: String, idx: Option[String], iter: Expr, r
 /// protocol is plain named `C::iter_length`/`C::iter_get` functions, e.g.
 /// @vibe/core's List), so it also runs for trait-free programs where the
 /// next/iter classification stays gated off.
-fn classify_indexed_for_loop(name: String, idx: Option[String], iter: Expr, riter: Expr, rbody: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr {
+fn classify_indexed_for_loop(name: String, idx: Option[String], iter: Expr, riter: Expr, rbody: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   match infer_arg_type_name(iter, struct_sets, var_types, fn_returns) {
-    Some(tn) => if struct_set_has(struct_sets, tn) && fn_exists(fn_returns, String::concat(tn, "::iter_length")) && fn_exists(fn_returns, String::concat(tn, "::iter_get")) {
-      build_indexed_iter_for(name, idx, tn, riter, rbody)
+    Some(tn) => if struct_set_has(struct_sets, tn) {
+      if fn_exists(fn_returns, String::concat(tn, "::iter_length")) && fn_exists(fn_returns, String::concat(tn, "::iter_get")) {
+        build_indexed_iter_for(name, idx, tn, riter, rbody)
+      } else {
+        // #2152: a declared struct/enum with NO iteration protocol used to
+        // fall through to the residual EForIn array loop, which read the
+        // value as an array pointer -- one iteration binding garbage, no
+        // diagnostic. The checker cannot own this rejection: its env may
+        // not see an `impl Iterator` living in a dependency (the classifier
+        // comment at its `for` arm says why it answers `CtStruct => 0`
+        // without a protocol check). THIS pass runs on the merged sources,
+        // so every protocol function the program has is in `fn_returns` --
+        // a miss here is a real miss, and it throws instead of iterating
+        // garbage.
+        throw(for_no_protocol_msg(tn))
+      }
     } else {
       EForIn(name, idx, riter, rbody)
     },
     None => EForIn(name, idx, riter, rbody)
   }
+}
+
+/// #2152: the rejection message for a `for` over a declared type with no
+/// iteration protocol. Leads with the edits that make the loop work.
+fn for_no_protocol_msg(tn: String) -> String {
+  String::concat("cannot iterate a `", String::concat(tn, String::concat("` value in `for`: define `", String::concat(tn, String::concat("::iter_length` + `", String::concat(tn, String::concat("::iter_get`, or `impl Iterator for ", String::concat(tn, String::concat("` with a `next` method, or loop over an Array of its elements -- `", String::concat(tn, "` declares no iteration protocol, so the loop has nothing to draw elements from (#2152)"))))))))))
 }
 
 /// `for x in iter { body }` -- the ONE for-loop classification (#1350 folded
@@ -4346,7 +4366,7 @@ fn classify_indexed_for_loop(name: String, idx: Option[String], iter: Expr, rite
 /// function value -- a call_indirect on a non-array pointer, i.e. a runtime
 /// trap. So this strictly turns a trap into a working loop (#827's own
 /// reasoning, now applied to the single surface).
-fn classify_sync_for_loop(name: String, idx: Option[String], iter: Expr, riter: Expr, rbody: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr {
+fn classify_sync_for_loop(name: String, idx: Option[String], iter: Expr, riter: Expr, rbody: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   match infer_arg_type_name(iter, struct_sets, var_types, fn_returns) {
     Some(tn) => if tn == "HostStream" {
       build_host_stream_for(name, riter, rbody)

--- a/lib/@vibe/compiler/tests/string_join_empty_test.vibe
+++ b/lib/@vibe/compiler/tests/string_join_empty_test.vibe
@@ -1,0 +1,40 @@
+//# Imports
+
+// #2143: `String::join` over an empty array returned the literal i64 0 --
+// indistinguishable from the tagged Int 0 -- so the value compared,
+// concatenated and measured as an empty string but RENDERED as `0` in
+// interpolation and `inspect`. The empty case now carries a real pointer
+// with length 0, like every other empty-string producer (literal,
+// substring, trim, split).
+
+//# Functions
+
+fn joined_empty() -> String {
+  let acc: Array[String] = []
+  String::join(acc, ",")
+}
+
+//# Tests
+
+test "#2143: empty join renders as the empty string" {
+  let s = joined_empty()
+  inspect("[\{s}]", content = "[]")
+}
+
+test "#2143: empty join still behaves as the empty string elsewhere" {
+  let s = joined_empty()
+  inspect(String::length(s), content = "0")
+  inspect(s == "", content = "true")
+  inspect(String::concat(s, "x"), content = "x")
+}
+
+test "#2143: freezing an empty StringBuilder renders empty too" {
+  // StringBuilder::freeze lowers to String::join(parts, ""), so the same
+  // 0-shaped empty reached it.
+  let sb = StringBuilder::new()
+  inspect("[\{StringBuilder::freeze(sb)}]", content = "[]")
+}
+
+test "#2143: a nonempty join is unaffected" {
+  inspect(String::join(["a", "b"], ","), content = "a,b")
+}

--- a/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
+++ b/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
@@ -1,0 +1,77 @@
+//# Imports
+
+// #2141 (interim guard): a generic `==` over `Array[T]` silently miscompared
+// when the formal `T` shared its spelling with a locally declared `struct T`
+// -- the synthesized array-equals helper subtracts declared type names from
+// the binder set program-wide, so the helper was emitted UNBOUND, its
+// annotations resolved to the struct, and `same([1,2], [1,3])` answered true
+// with `vibe check` clean. Until the classification is scope-precise, the
+// collision itself is rejected at the binder
+// (collect_type_param_shadowing_errors, checker_stmt.vibe).
+//
+// The boundary is LOCAL declarations only: a formal shadowing an IMPORTED
+// type is measured behaviorally harmless (the helper over-binds; element
+// comparison stays structural) and is pinned as accepted by
+// derive_array_helper_interference_test.vibe. These tests pin both sides.
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+/// The first checker diagnostic for `source`, or "" when it type-checks.
+fn first_check_error(source: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    ""
+  } with Exception {
+    Throw(msg) => msg
+  }
+}
+
+//# Rejected
+
+test "#2141: the issue's repro is rejected at the binder" {
+  let src = "struct T {\n  v: Int\n}\n\nfn same[T](a: Array[T], b: Array[T]) -> Bool {\n  a == b\n}\n"
+  inspect(first_check_error(src), content = "type parameter `T` of declaration `same` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")
+}
+
+test "#2141: an enum collides the same way" {
+  let src = "enum E {\n  A;\n  B\n}\n\nfn f[E](x: E) -> E {\n  x\n}\n"
+  inspect(first_check_error(src), content = "type parameter `E` of declaration `f` shadows the declared type `E`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")
+}
+
+test "#2141: a struct's own type parameter list is guarded too" {
+  // `struct Box[T]` next to `struct T` feeds the same spelling-keyed helper
+  // classification (its derive helpers read the element type by name).
+  let src = "struct T {\n  v: Int\n}\n\nstruct Box[T] {\n  xs: Array[T]\n}\n"
+  inspect(first_check_error(src), content = "type parameter `T` of struct `Box` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")
+}
+
+test "#2141: a nested lambda binder is guarded" {
+  let src = "struct T {\n  v: Int\n}\n\nfn outer() -> Int {\n  let g = [T](x: T) -> T {\n    x\n  }\n  g(1)\n}\n"
+  inspect(first_check_error(src), content = "type parameter `T` of declaration `outer` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")
+}
+
+//# Accepted
+
+test "#2141: a generic formal with no colliding declaration stays legal" {
+  inspect(first_check_error("fn id[T](x: T) -> T {\n  x\n}\n"), content = "")
+}
+
+test "#2141: a declared struct next to a DIFFERENTLY spelled formal stays legal" {
+  let src = "struct T {\n  v: Int\n}\n\nfn same[U](a: Array[U], b: Array[U]) -> Bool {\n  a == b\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2141: renaming the formal makes the issue's program answer correctly" {
+  // The guard's actionable edit, applied: the program from the issue with the
+  // formal renamed compiles clean.
+  let src = "struct T {\n  v: Int\n}\n\nfn same[U](a: Array[U], b: Array[U]) -> Bool {\n  a == b\n}\n\nfn probe() -> Bool {\n  !same([1, 2], [1, 3])\n}\n"
+  inspect(first_check_error(src), content = "")
+}

--- a/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
+++ b/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
@@ -38,24 +38,24 @@ fn first_check_error(source: String) -> String {
 
 test "#2141: the issue's repro is rejected at the binder" {
   let src = "struct T {\n  v: Int\n}\n\nfn same[T](a: Array[T], b: Array[T]) -> Bool {\n  a == b\n}\n"
-  inspect(first_check_error(src), content = "type parameter `T` of declaration `same` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")
+  inspect(first_check_error(src), content = "type parameter `T` of declaration `same` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141) [@fn=same]")
 }
 
 test "#2141: an enum collides the same way" {
   let src = "enum E {\n  A;\n  B\n}\n\nfn f[E](x: E) -> E {\n  x\n}\n"
-  inspect(first_check_error(src), content = "type parameter `E` of declaration `f` shadows the declared type `E`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")
+  inspect(first_check_error(src), content = "type parameter `E` of declaration `f` shadows the declared type `E`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141) [@fn=f]")
 }
 
 test "#2141: a struct's own type parameter list is guarded too" {
   // `struct Box[T]` next to `struct T` feeds the same spelling-keyed helper
   // classification (its derive helpers read the element type by name).
   let src = "struct T {\n  v: Int\n}\n\nstruct Box[T] {\n  xs: Array[T]\n}\n"
-  inspect(first_check_error(src), content = "type parameter `T` of struct `Box` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")
+  inspect(first_check_error(src), content = "type parameter `T` of struct `Box` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141) [@fn=Box]")
 }
 
 test "#2141: a nested lambda binder is guarded" {
   let src = "struct T {\n  v: Int\n}\n\nfn outer() -> Int {\n  let g = [T](x: T) -> T {\n    x\n  }\n  g(1)\n}\n"
-  inspect(first_check_error(src), content = "type parameter `T` of declaration `outer` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141)")
+  inspect(first_check_error(src), content = "type parameter `T` of declaration `outer` shadows the declared type `T`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141) [@fn=outer]")
 }
 
 //# Accepted


### PR DESCRIPTION
Closes #2143. Closes #2152. Refs #2141 (this lands the issue's interim loud guard; the scope-precise binder classification stays open).

Three commits, one per issue, each independently validated (self-build stage0→1→2, `scripts/compiler_gate.sh`, full `scripts/unit_test_runner.sh` sweep against the rebuilt stage2).

## 1. `String::join` over an empty array returns a real empty string, not the i64 0 (#2143)

`gen_string_join_body`'s empty case returned the literal `i64.const 0` — indistinguishable from the tagged Int 0 — so the value compared, concatenated and measured as an empty string but **rendered** as `0`: `"\{String::join(items, ",")}"` with empty `items` printed `0`, silently. `StringBuilder::freeze` lowers to `String::join(parts, "")`, so an empty builder's freeze carried the same shape.

The empty case now returns `(ptr << 32) | 0` with a **real pointer** (the current bump pointer; length 0, so nothing is ever read through it and no allocation happens) — matching every other empty-string producer (literal, `substring`, `trim`, `split`). A sweep of the builtin bodies found join to be the only 0-shaped empty.

Tests: `string_join_empty_test.vibe` (4), green on **both backends** (linear + `VIBE_TEST_BACKEND=gc`); the rendering test reproduces `[0]` on the committed seed as baseline.

## 2. Reject `for` over a declared type with no iteration protocol (#2152)

A `for x in s` over a plain declared struct (or enum) passed the checker and fell through to the residual EForIn array loop, which read the value as an array pointer: the body ran exactly once with the loop variable bound to garbage, and the program completed with wrong values.

The checker cannot own this rejection — its classifier answers `CtStruct => 0` without a protocol check because an `impl Iterator` living in a dependency is invisible to a single module's import env. The for-loop desugar runs on the merged sources, so a protocol miss there is a real miss: `classify_indexed_for_loop` (the shared last stop of both the trait and trait-free classification paths) now throws an actionable error instead of lowering to the garbage loop.

Fixtures (`fixtures/typecheck/` + `expected.tsv`): plain struct and plain enum rejected; two controls pin the protocols that must keep classifying — indexed (`iter_length` + `iter_get`, #736) and `impl Iterator` with `next`. The issue's exact repro now fails compile in the `vibe test` lane with the new message (was: passed, `consume(S::{a:3}) == 0`).

## 3. Reject a type-parameter binder that shadows a locally declared type (#2141, interim guard)

Generic `==` over `Array[T]` silently miscompared when the formal `T` shared its spelling with a declared `struct T`: the synthesized array-equals helper's binder classification (#2136) subtracts declared type names program-wide, so the helper was emitted with an empty binder list, its annotations resolved to the struct, and `same([1, 2], [1, 3])` answered true with `vibe check` clean.

`collect_type_param_shadowing_errors` (checker_stmt) rejects, before checking, any type-parameter binder — fn/let, struct, enum, or nested lambda — whose spelling collides with a struct/enum declared in the **same module**, with a rename-first message, wired into both checker paths so `vibe check` reports it. The boundary is local declarations on purpose: a formal shadowing an **imported** type is measured behaviorally harmless (the helper over-binds and element comparison stays structural) and stays accepted — `derive_array_helper_interference_test.vibe` still passes, since imported types arrive through the env, not the module's stmts.

Tests: `type_param_shadowing_guard_test.vibe` (7) — the issue's exact repro, enum and struct-tparam collisions, a nested lambda binder, and three accepted controls including the issue's program with the formal renamed.

## Verification (whole branch)

- self-build stage0→1→2 green after each commit (no false positive in the compiler's own sources)
- `scripts/compiler_gate.sh` → ok (233 typecheck fixture verdicts including the 4 new rows, 25 known debt)
- `scripts/unit_test_runner.sh` against the rebuilt stage2 → **1008/1008**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyrvqhAB9EdeV8HdNVTDFC