### PR TITLE
Fail closed when off-build typecheck runner crashes

### DIFF
--- a/scripts/check_offbuild_typecheck.sh
+++ b/scripts/check_offbuild_typecheck.sh
@@ -83,6 +83,7 @@ total=0
 skipped=0
 failed=0
 out="$(mktemp -u)"
+runner_err="$out.stderr"
 while IFS= read -r f; do
   [ -n "$f" ] || continue
   if printf '%s' "$f" | grep -Eq "$EXCLUDE_RE"; then
@@ -90,20 +91,29 @@ while IFS= read -r f; do
     continue
   fi
   total=$((total + 1))
-  rm -f "$out" "$out.diag"
+  rm -f "$out" "$out.diag" "$runner_err"
   runner_status=0
   VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw VIBE_CHECK_ONLY=1 \
     timeout 300 bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$STAGE2" "$f" "$out" __no_entry__ >/dev/null 2>&1 || runner_status=$?
+    --invoke cli_main "$STAGE2" "$f" "$out" __no_entry__ >/dev/null 2>"$runner_err" || runner_status=$?
   if [ -s "$out.diag" ]; then
     failed=$((failed + 1))
     echo "[offbuild-typecheck] FAIL $f" >&2
     head -3 "$out.diag" >&2
+    if [ "$runner_status" -ne 0 ]; then
+      echo "[offbuild-typecheck] runner also exited $runner_status" >&2
+      head -3 "$runner_err" >&2
+    fi
   elif [ "$runner_status" -ne 0 ]; then
     failed=$((failed + 1))
-    echo "[offbuild-typecheck] FAIL $f: compiler runner exited $runner_status without a diagnostic" >&2
+    if [ "$runner_status" -eq 124 ]; then
+      echo "[offbuild-typecheck] FAIL $f: compiler runner timed out after 300 seconds without a diagnostic" >&2
+    else
+      echo "[offbuild-typecheck] FAIL $f: compiler runner exited $runner_status without a diagnostic" >&2
+    fi
+    head -3 "$runner_err" >&2
   fi
-  rm -f "$out" "$out.diag"
+  rm -f "$out" "$out.diag" "$runner_err"
 done < "$listing"
 
 if [ "$failed" -gt 0 ]; then

--- a/scripts/check_offbuild_typecheck.sh
+++ b/scripts/check_offbuild_typecheck.sh
@@ -91,13 +91,17 @@ while IFS= read -r f; do
   fi
   total=$((total + 1))
   rm -f "$out" "$out.diag"
+  runner_status=0
   VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw VIBE_CHECK_ONLY=1 \
     timeout 300 bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$STAGE2" "$f" "$out" __no_entry__ >/dev/null 2>&1 || true
+    --invoke cli_main "$STAGE2" "$f" "$out" __no_entry__ >/dev/null 2>&1 || runner_status=$?
   if [ -s "$out.diag" ]; then
     failed=$((failed + 1))
     echo "[offbuild-typecheck] FAIL $f" >&2
     head -3 "$out.diag" >&2
+  elif [ "$runner_status" -ne 0 ]; then
+    failed=$((failed + 1))
+    echo "[offbuild-typecheck] FAIL $f: compiler runner exited $runner_status without a diagnostic" >&2
   fi
   rm -f "$out" "$out.diag"
 done < "$listing"

--- a/scripts/check_offbuild_typecheck.sh
+++ b/scripts/check_offbuild_typecheck.sh
@@ -100,7 +100,10 @@ while IFS= read -r f; do
     failed=$((failed + 1))
     echo "[offbuild-typecheck] FAIL $f" >&2
     head -3 "$out.diag" >&2
-    if [ "$runner_status" -ne 0 ]; then
+    if [ "$runner_status" -eq 124 ]; then
+      echo "[offbuild-typecheck] runner also timed out after 300 seconds" >&2
+      head -3 "$runner_err" >&2
+    elif [ "$runner_status" -ne 0 ]; then
       echo "[offbuild-typecheck] runner also exited $runner_status" >&2
       head -3 "$runner_err" >&2
     fi
@@ -114,6 +117,10 @@ while IFS= read -r f; do
     head -3 "$runner_err" >&2
   fi
   rm -f "$out" "$out.diag" "$runner_err"
+  if [ "$runner_status" -eq 124 ]; then
+    echo "[offbuild-typecheck] aborting after runner timeout; remaining sources were not checked" >&2
+    exit 1
+  fi
 done < "$listing"
 
 if [ "$failed" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- preserve the compiler runner exit status instead of discarding it with `|| true`
- fail when a crash or timeout produces no diagnostic sidecar
- retain and print runner stderr, identify 300-second timeouts, and count each source only once

## Why

The off-manifest typecheck gate previously reported success when the compiler runner crashed, was killed, or timed out without writing `.diag`. That is the cold-cache failure shape identified in #2135.

## Validation

- invalid wasm: exits 1, reports runner status and WebAssembly error, no success summary
- fake `timeout` returning 124: exits 1 and reports the 300-second timeout
- explicit checkout stage2 after generated prerequisites: 66/66 sources pass, 3 excluded
- `bash -n scripts/check_offbuild_typecheck.sh`
- `git diff --check`
- independent review and follow-up re-review: no blocking findings

Closes #2135