### PR TITLE
Honor local callable shadowing on the wasm-gc lane

### DIFF
--- a/fixtures/gc_local_top_level_shadow_test.vibe
+++ b/fixtures/gc_local_top_level_shadow_test.vibe
@@ -10,21 +10,10 @@ fn top_level_control() -> Int {
   value()
 }
 
-fn __tuple_ptr() -> Int {
-  7
-}
-
 test "local closure shadows top-level function" {
   let value = () -> Int {
     1
   }
   inspect(value(), "1")
   inspect(top_level_control(), "9")
-}
-
-test "backend scratch slots cannot shadow source functions" {
-  // Tuple lowering allocates an internal pointer slot before its elements.
-  // That slot must not participate in source-level callable lookup.
-  let pair = (__tuple_ptr(), 3)
-  inspect(pair.0, "7")
 }

--- a/fixtures/gc_local_top_level_shadow_test.vibe
+++ b/fixtures/gc_local_top_level_shadow_test.vibe
@@ -1,0 +1,19 @@
+// A local callable follows the same lexical shadowing rule as an identifier.
+// The wasm-gc call path used to resolve the top-level function table first,
+// so the first inspect received 9 while the linear lane correctly received 1.
+// Keep the top-level-only control to ensure direct calls remain direct (#2160).
+fn value() -> Int {
+  9
+}
+
+fn top_level_control() -> Int {
+  value()
+}
+
+test "local closure shadows top-level function" {
+  let value = () -> Int {
+    1
+  }
+  inspect(value(), "1")
+  inspect(top_level_control(), "9")
+}

--- a/fixtures/gc_local_top_level_shadow_test.vibe
+++ b/fixtures/gc_local_top_level_shadow_test.vibe
@@ -10,10 +10,21 @@ fn top_level_control() -> Int {
   value()
 }
 
+fn __tuple_ptr() -> Int {
+  7
+}
+
 test "local closure shadows top-level function" {
   let value = () -> Int {
     1
   }
   inspect(value(), "1")
   inspect(top_level_control(), "9")
+}
+
+test "backend scratch slots cannot shadow source functions" {
+  // Tuple lowering allocates an internal pointer slot before its elements.
+  // That slot must not participate in source-level callable lookup.
+  let pair = (__tuple_ptr(), 3)
+  inspect(pair.0, "7")
 }

--- a/fixtures/gc_scratch_name_collision.vibe
+++ b/fixtures/gc_scratch_name_collision.vibe
@@ -5,7 +5,26 @@ fn __tuple_ptr() -> Int {
   7
 }
 
+fn __env() -> Int {
+  8
+}
+
+fn direct_array(xs: Array[Int]) -> Array[Int] {
+  xs
+}
+
 test "backend scratch slots cannot shadow source functions" {
   let pair = (__tuple_ptr(), 3)
   inspect(pair.0, "7")
+  let inside_lambda = () -> Int {
+    __env()
+  }
+  inspect(inside_lambda(), "8")
+}
+
+test "direct ABI proof respects local callable shadowing" {
+  let direct_array = (_xs: Array[Int]) -> Array[Int] {
+    [4]
+  }
+  inspect(Array::get(direct_array([1]), 0), "4")
 }

--- a/fixtures/gc_scratch_name_collision.vibe
+++ b/fixtures/gc_scratch_name_collision.vibe
@@ -1,0 +1,11 @@
+// GC-only regression: tuple lowering allocates an internal pointer slot before
+// compiling its elements. Backend scratch slots must not participate in
+// source-level callable lookup (#2160).
+fn __tuple_ptr() -> Int {
+  7
+}
+
+test "backend scratch slots cannot shadow source functions" {
+  let pair = (__tuple_ptr(), 3)
+  inspect(pair.0, "7")
+}

--- a/fixtures/gc_scratch_name_collision.vibe
+++ b/fixtures/gc_scratch_name_collision.vibe
@@ -31,6 +31,8 @@ test "direct ABI proof respects local callable shadowing" {
     [4]
   }
   inspect(Array::get(direct_array([1]), 0), "4")
+  let ys = direct_array([1])
+  inspect(Array::get(ys, 0), "4")
 }
 
 test "non-recursive binder is hidden in its initializer" {

--- a/fixtures/gc_scratch_name_collision.vibe
+++ b/fixtures/gc_scratch_name_collision.vibe
@@ -13,6 +13,10 @@ fn direct_array(xs: Array[Int]) -> Array[Int] {
   xs
 }
 
+fn initializer_target() -> Int {
+  9
+}
+
 test "backend scratch slots cannot shadow source functions" {
   let pair = (__tuple_ptr(), 3)
   inspect(pair.0, "7")
@@ -27,4 +31,9 @@ test "direct ABI proof respects local callable shadowing" {
     [4]
   }
   inspect(Array::get(direct_array([1]), 0), "4")
+}
+
+test "non-recursive binder is hidden in its initializer" {
+  let initializer_target = initializer_target()
+  inspect(initializer_target, "9")
 }

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -2064,7 +2064,7 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_str
             Array::push(local_names, pname)
             ppi = ppi + 1
           }
-          Array::push(local_names, "__env")
+          Array::push(local_names, "[gc-temp]__env")
           let param_count = Array::length(params) + 1
           // #724 round 2: seed the aggregate-shape log from annotated params.
           // #744 gc mirror: seed float tracking from annotated Float/Double

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -3147,9 +3147,12 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       else {
         let fn_len2 = Array::length(ctx.func_table.names)
         let eff_fname = gc_direct_abi_twin_callee(ctx, fname)
+        let local_callee_idx = find_local_slot(local_names, fname)
         let mut fn_idx_in_list = -1
         let mut __fi = 0
-        while __fi < fn_len2 {
+        // A lexical binding shadows a same-named top-level function. Identifier
+        // expressions already use this ordering; calls must do the same (#2160).
+        while local_callee_idx < 0 && __fi < fn_len2 {
           if Array::get(ctx.func_table.names, __fi) == eff_fname {
             fn_idx_in_list = __fi
             __fi = fn_len2
@@ -3186,10 +3189,14 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
           // unknown constructor, not a local closure -- fail with a clear
           // message instead of resolve_local's "undefined variable".
           let c0 = String::char_code_at(fname, 0)
-          if c0 >= 65 && c0 <= 90 {
+          if local_callee_idx < 0 && c0 >= 65 && c0 <= 90 {
             throw("GC codegen: unknown constructor or function: \{fname}")
           }
-          let local_idx2 = resolve_local(local_names, fname, "gc_call")
+          let local_idx2 = if local_callee_idx >= 0 {
+            local_callee_idx
+          } else {
+            resolve_local(local_names, fname, "gc_call")
+          }
           let num_args = Array::length(args)
           let fn_val_local = next_local
           let slot_local = next_local + 1

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -365,7 +365,7 @@ fn gc_expr_is_native_array_ref(expr: Expr, local_names: Array[String], ctx: Comp
     EDot(EIdent(ns_obj, _), ns_field, _, _) => gc_ctor_field_is_ref(ctx.gc_ctor_table, gc_slot_map_get(ctx.gc_native_struct_scope, find_local_slot(local_names, ns_obj)), ns_field),
     ECall(EIdent(name, _), _, _) => {
       let idx = gc_direct_abi_call_index(ctx, name)
-      idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx)
+      find_local_slot(local_names, name) < 0 && idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx)
     },
     EIf(_, then_e, else_e) => gc_join_is_native_ref(then_e, else_e, local_names, ctx),
     _ => false
@@ -385,7 +385,7 @@ export fn gc_expr_can_compile_native_array_ref(expr: Expr, local_names: Array[St
     EDot(EIdent(ns_obj, _), ns_field, _, _) => gc_ctor_field_is_ref(ctx.gc_ctor_table, gc_slot_map_get(ctx.gc_native_struct_scope, find_local_slot(local_names, ns_obj)), ns_field),
     ECall(EIdent(name, _), _, _) => {
       let idx = gc_direct_abi_call_index(ctx, name)
-      idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx)
+      find_local_slot(local_names, name) < 0 && idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx)
     },
     EIf(_, then_e, else_e) => gc_expr_can_compile_native_array_ref(then_e, local_names, ctx) && gc_expr_can_compile_native_array_ref(else_e, local_names, ctx),
     _ => false
@@ -406,7 +406,7 @@ fn gc_expr_is_lane_proven_ref(expr: Expr, local_names: Array[String], ctx: Compi
     },
     ECall(EIdent(name, _), _, _) => {
       let idx = gc_direct_abi_call_index(ctx, name)
-      idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx)
+      find_local_slot(local_names, name) < 0 && idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx)
     },
     EIf(_, then_e, else_e) => gc_expr_is_lane_proven_ref(then_e, local_names, ctx) && gc_expr_is_lane_proven_ref(else_e, local_names, ctx),
     _ => false
@@ -473,7 +473,7 @@ export fn gc_compile_native_array_ref(buf: Bytes, expr: Expr, local_names: Array
     ECall(callee, args, _) => match callee {
       EIdent(name, _) => {
         let idx = gc_direct_abi_call_index(ctx, name)
-        if idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx) {
+        if find_local_slot(local_names, name) < 0 && idx >= 0 && Array::get(ctx.gc_direct_abi_return_refs, idx) {
           compile_call_gc(buf, callee, args, local_names, next_local, ctx, ld, ce)
         } else {
           throw("gc direct ABI proof mismatch: call does not return a native array")

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -452,7 +452,7 @@ export fn gc_compile_native_array_ref(buf: Bytes, expr: Expr, local_names: Array
     },
     EArray(elems) => {
       let slot = next_local
-      Array::push(local_names, "__gc_direct_array_arg")
+      Array::push(local_names, "[gc-temp]__gc_direct_array_arg")
       Array::push(ctx.gc_native_array_locals, slot)
       Array::push(ctx.gc_native_array_local_types, slot)
       emit_i32_const(buf, Array::length(elems))
@@ -760,7 +760,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let fc = Array::get(ctx.gc_ctor_table.field_counts, ctor_lookup_idx)
         let obj_size = 8 + fc * 8
         let ptr_local = next_local
-        Array::push(local_names, "__ctor_ptr")
+        Array::push(local_names, "[gc-temp]__ctor_ptr")
         emit_global_get(buf, 0)
         emit_i64_extend_i32_u(buf)
         emit_local_set(buf, ptr_local)
@@ -829,7 +829,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         while fi_c < Array::length(actual_args) {
           nl_c = ce(buf, Array::get(actual_args, fi_c), local_names, nl_c, ld)
           let val_local = nl_c
-          Array::push(local_names, "__ctor_val")
+          Array::push(local_names, "[gc-temp]__ctor_val")
           emit_local_set(buf, val_local)
           nl_c = nl_c + 1
           emit_local_get(buf, ptr_local)
@@ -852,11 +852,11 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let end_local = next_local + 2
         let ptr_local = next_local + 3
         let cap_local = next_local + 4
-        Array::push(local_names, "__slice_obj")
-        Array::push(local_names, "__slice_start")
-        Array::push(local_names, "__slice_end")
-        Array::push(local_names, "__slice_ptr")
-        Array::push(local_names, "__slice_cap")
+        Array::push(local_names, "[gc-temp]__slice_obj")
+        Array::push(local_names, "[gc-temp]__slice_start")
+        Array::push(local_names, "[gc-temp]__slice_end")
+        Array::push(local_names, "[gc-temp]__slice_ptr")
+        Array::push(local_names, "[gc-temp]__slice_cap")
         let mut nl = next_local + 5
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, obj_local)
@@ -907,10 +907,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let idx_local = next_local + 1
         let ptr_local = next_local + 2
         let cap_local = next_local + 3
-        Array::push(local_names, "__index_obj")
-        Array::push(local_names, "__index_idx")
-        Array::push(local_names, "__index_ptr")
-        Array::push(local_names, "__index_cap")
+        Array::push(local_names, "[gc-temp]__index_obj")
+        Array::push(local_names, "[gc-temp]__index_idx")
+        Array::push(local_names, "[gc-temp]__index_ptr")
+        Array::push(local_names, "[gc-temp]__index_cap")
         let mut nl = next_local + 4
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, obj_local)
@@ -1033,11 +1033,11 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
             emit_i64_const(buf, -2)
             emit_i64_and(buf)
             let obj_l = nl
-            Array::push(local_names, "__setf_obj")
+            Array::push(local_names, "[gc-temp]__setf_obj")
             emit_local_set(buf, obj_l)
             nl = ce(buf, Array::get(args, 2), local_names, nl + 1, ld)
             let val_l = nl
-            Array::push(local_names, "__setf_val")
+            Array::push(local_names, "[gc-temp]__setf_val")
             emit_local_set(buf, val_l)
             let mut di = 0
             while di < Array::length(dispatch) {
@@ -1094,9 +1094,9 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let obj_local = next_local
         let ptr_local = next_local + 1
         let cap_local = next_local + 2
-        Array::push(local_names, "__len_obj")
-        Array::push(local_names, "__len_ptr")
-        Array::push(local_names, "__len_cap")
+        Array::push(local_names, "[gc-temp]__len_obj")
+        Array::push(local_names, "[gc-temp]__len_ptr")
+        Array::push(local_names, "[gc-temp]__len_cap")
         let mut nl = next_local + 3
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, obj_local)
@@ -1166,10 +1166,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let res_l = nl + 1
         let cnt_l = nl + 2
         let i_l = nl + 3
-        Array::push(local_names, "__values_map")
-        Array::push(local_names, "__values_res")
-        Array::push(local_names, "__values_cnt")
-        Array::push(local_names, "__values_i")
+        Array::push(local_names, "[gc-temp]__values_map")
+        Array::push(local_names, "[gc-temp]__values_res")
+        Array::push(local_names, "[gc-temp]__values_cnt")
+        Array::push(local_names, "[gc-temp]__values_i")
         emit_local_set(buf, map_l)
         emit_call_resolved(buf, ctx, arr_new_fi)
         emit_local_set(buf, res_l)
@@ -1252,10 +1252,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let res_local = next_local + 1
         let len_local = next_local + 2
         let i_local = next_local + 3
-        Array::push(local_names, "__tb_str")
-        Array::push(local_names, "__tb_res")
-        Array::push(local_names, "__tb_len")
-        Array::push(local_names, "__tb_idx")
+        Array::push(local_names, "[gc-temp]__tb_str")
+        Array::push(local_names, "[gc-temp]__tb_res")
+        Array::push(local_names, "[gc-temp]__tb_len")
+        Array::push(local_names, "[gc-temp]__tb_idx")
         let mut nl = next_local + 4
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, str_local)
@@ -1345,7 +1345,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       else if fname == "Map::size" {
         let nl = ce(buf, Array::get(args, 0), local_names, next_local, ld)
         let map_local = nl
-        Array::push(local_names, "__size_map")
+        Array::push(local_names, "[gc-temp]__size_map")
         emit_local_set(buf, map_local)
         emit_local_get(buf, map_local)
         emit_i64_const(buf, -2)
@@ -1392,14 +1392,14 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let slot_local = next_local + 5
         let env_local = next_local + 6
         let elem_local = next_local + 7
-        Array::push(local_names, "__map_arr")
-        Array::push(local_names, "__map_fn")
-        Array::push(local_names, "__map_res")
-        Array::push(local_names, "__map_len")
-        Array::push(local_names, "__map_i")
-        Array::push(local_names, "__map_slot")
-        Array::push(local_names, "__map_env")
-        Array::push(local_names, "__map_elem")
+        Array::push(local_names, "[gc-temp]__map_arr")
+        Array::push(local_names, "[gc-temp]__map_fn")
+        Array::push(local_names, "[gc-temp]__map_res")
+        Array::push(local_names, "[gc-temp]__map_len")
+        Array::push(local_names, "[gc-temp]__map_i")
+        Array::push(local_names, "[gc-temp]__map_slot")
+        Array::push(local_names, "[gc-temp]__map_env")
+        Array::push(local_names, "[gc-temp]__map_elem")
         let mut nl = next_local + 8
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, arr_local)
@@ -1452,14 +1452,14 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let slot_local = next_local + 5
         let env_local = next_local + 6
         let elem_local = next_local + 7
-        Array::push(local_names, "__filter_arr")
-        Array::push(local_names, "__filter_fn")
-        Array::push(local_names, "__filter_res")
-        Array::push(local_names, "__filter_len")
-        Array::push(local_names, "__filter_i")
-        Array::push(local_names, "__filter_slot")
-        Array::push(local_names, "__filter_env")
-        Array::push(local_names, "__filter_elem")
+        Array::push(local_names, "[gc-temp]__filter_arr")
+        Array::push(local_names, "[gc-temp]__filter_fn")
+        Array::push(local_names, "[gc-temp]__filter_res")
+        Array::push(local_names, "[gc-temp]__filter_len")
+        Array::push(local_names, "[gc-temp]__filter_i")
+        Array::push(local_names, "[gc-temp]__filter_slot")
+        Array::push(local_names, "[gc-temp]__filter_env")
+        Array::push(local_names, "[gc-temp]__filter_elem")
         let mut nl = next_local + 8
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, arr_local)
@@ -1511,13 +1511,13 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let i_local = next_local + 4
         let slot_local = next_local + 5
         let env_local = next_local + 6
-        Array::push(local_names, "__fold_arr")
-        Array::push(local_names, "__fold_acc")
-        Array::push(local_names, "__fold_fn")
-        Array::push(local_names, "__fold_len")
-        Array::push(local_names, "__fold_i")
-        Array::push(local_names, "__fold_slot")
-        Array::push(local_names, "__fold_env")
+        Array::push(local_names, "[gc-temp]__fold_arr")
+        Array::push(local_names, "[gc-temp]__fold_acc")
+        Array::push(local_names, "[gc-temp]__fold_fn")
+        Array::push(local_names, "[gc-temp]__fold_len")
+        Array::push(local_names, "[gc-temp]__fold_i")
+        Array::push(local_names, "[gc-temp]__fold_slot")
+        Array::push(local_names, "[gc-temp]__fold_env")
         let mut nl = next_local + 7
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, arr_local)
@@ -1562,10 +1562,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let res_local = next_local + 1
         let len_local = next_local + 2
         let i_local = next_local + 3
-        Array::push(local_names, "__rev_arr")
-        Array::push(local_names, "__rev_res")
-        Array::push(local_names, "__rev_len")
-        Array::push(local_names, "__rev_i")
+        Array::push(local_names, "[gc-temp]__rev_arr")
+        Array::push(local_names, "[gc-temp]__rev_res")
+        Array::push(local_names, "[gc-temp]__rev_len")
+        Array::push(local_names, "[gc-temp]__rev_i")
         let mut nl = next_local + 4
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, arr_local)
@@ -1613,13 +1613,13 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let slot_local = next_local + 4
         let env_local = next_local + 5
         let res_local = next_local + 6
-        Array::push(local_names, "__any_arr")
-        Array::push(local_names, "__any_fn")
-        Array::push(local_names, "__any_len")
-        Array::push(local_names, "__any_i")
-        Array::push(local_names, "__any_slot")
-        Array::push(local_names, "__any_env")
-        Array::push(local_names, "__any_res")
+        Array::push(local_names, "[gc-temp]__any_arr")
+        Array::push(local_names, "[gc-temp]__any_fn")
+        Array::push(local_names, "[gc-temp]__any_len")
+        Array::push(local_names, "[gc-temp]__any_i")
+        Array::push(local_names, "[gc-temp]__any_slot")
+        Array::push(local_names, "[gc-temp]__any_env")
+        Array::push(local_names, "[gc-temp]__any_res")
         let mut nl = next_local + 7
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, arr_local)
@@ -1669,13 +1669,13 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let slot_local = next_local + 4
         let env_local = next_local + 5
         let res_local = next_local + 6
-        Array::push(local_names, "__all_arr")
-        Array::push(local_names, "__all_fn")
-        Array::push(local_names, "__all_len")
-        Array::push(local_names, "__all_i")
-        Array::push(local_names, "__all_slot")
-        Array::push(local_names, "__all_env")
-        Array::push(local_names, "__all_res")
+        Array::push(local_names, "[gc-temp]__all_arr")
+        Array::push(local_names, "[gc-temp]__all_fn")
+        Array::push(local_names, "[gc-temp]__all_len")
+        Array::push(local_names, "[gc-temp]__all_i")
+        Array::push(local_names, "[gc-temp]__all_slot")
+        Array::push(local_names, "[gc-temp]__all_env")
+        Array::push(local_names, "[gc-temp]__all_res")
         let mut nl = next_local + 7
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, arr_local)
@@ -1735,14 +1735,14 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let env_local = next_local + 5
         let elem_local = next_local + 6
         let res_local = next_local + 7
-        Array::push(local_names, "__find_arr")
-        Array::push(local_names, "__find_fn")
-        Array::push(local_names, "__find_len")
-        Array::push(local_names, "__find_i")
-        Array::push(local_names, "__find_slot")
-        Array::push(local_names, "__find_env")
-        Array::push(local_names, "__find_elem")
-        Array::push(local_names, "__find_res")
+        Array::push(local_names, "[gc-temp]__find_arr")
+        Array::push(local_names, "[gc-temp]__find_fn")
+        Array::push(local_names, "[gc-temp]__find_len")
+        Array::push(local_names, "[gc-temp]__find_i")
+        Array::push(local_names, "[gc-temp]__find_slot")
+        Array::push(local_names, "[gc-temp]__find_env")
+        Array::push(local_names, "[gc-temp]__find_elem")
+        Array::push(local_names, "[gc-temp]__find_res")
         let mut nl = next_local + 8
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, arr_local)
@@ -1770,7 +1770,9 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         emit_closure_call_tail(buf, env_local, slot_local, ctx.closure_type_base, 1)
         emit_i32_wrap_i64(buf)
         emit_if_void(buf)
-        nl = ce(buf, ECall(EIdent("Some", -1), [EIdent("__find_elem", -1)], -1), local_names, nl, ld)
+        nl = ce(buf, ECall(EIdent("Some", -1), [
+          EIdent("[gc-temp]__find_elem", -1)
+        ], -1), local_names, nl, ld)
         emit_local_set(buf, res_local)
         emit_br(buf, 2)
         emit_end(buf)
@@ -1793,11 +1795,11 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let end_local = next_local + 2
         let new_arr_local = next_local + 3
         let i_local = next_local + 4
-        Array::push(local_names, "__slice_arr")
-        Array::push(local_names, "__slice_start")
-        Array::push(local_names, "__slice_end")
-        Array::push(local_names, "__slice_new")
-        Array::push(local_names, "__slice_i")
+        Array::push(local_names, "[gc-temp]__slice_arr")
+        Array::push(local_names, "[gc-temp]__slice_start")
+        Array::push(local_names, "[gc-temp]__slice_end")
+        Array::push(local_names, "[gc-temp]__slice_new")
+        Array::push(local_names, "[gc-temp]__slice_i")
         let mut nl = next_local + 5
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, arr_local)
@@ -1840,11 +1842,11 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let new_arr_local = next_local + 2
         let i_local = next_local + 3
         let len_local = next_local + 4
-        Array::push(local_names, "__concat_a")
-        Array::push(local_names, "__concat_b")
-        Array::push(local_names, "__concat_new")
-        Array::push(local_names, "__concat_i")
-        Array::push(local_names, "__concat_len")
+        Array::push(local_names, "[gc-temp]__concat_a")
+        Array::push(local_names, "[gc-temp]__concat_b")
+        Array::push(local_names, "[gc-temp]__concat_new")
+        Array::push(local_names, "[gc-temp]__concat_i")
+        Array::push(local_names, "[gc-temp]__concat_len")
         let mut nl = next_local + 5
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, a_local)
@@ -1921,10 +1923,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let src_local = next_local + 1
         let i_local = next_local + 2
         let len_local = next_local + 3
-        Array::push(local_names, "__pushall_dst")
-        Array::push(local_names, "__pushall_src")
-        Array::push(local_names, "__pushall_i")
-        Array::push(local_names, "__pushall_len")
+        Array::push(local_names, "[gc-temp]__pushall_dst")
+        Array::push(local_names, "[gc-temp]__pushall_src")
+        Array::push(local_names, "[gc-temp]__pushall_i")
+        Array::push(local_names, "[gc-temp]__pushall_len")
         let mut nl = next_local + 4
         nl = ce(buf, Array::get(args, 0), local_names, nl, ld)
         emit_local_set(buf, dst_local)
@@ -2032,8 +2034,8 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         nl = ce(buf, Array::get(args, 1), local_names, nl, ld)
         let eq_a = nl
         let eq_b = nl + 1
-        Array::push(local_names, "__eq_a")
-        Array::push(local_names, "__eq_b")
+        Array::push(local_names, "[gc-temp]__eq_a")
+        Array::push(local_names, "[gc-temp]__eq_b")
         emit_local_set(buf, eq_b)
         emit_local_set(buf, eq_a)
         emit_local_get(buf, eq_a)
@@ -2133,7 +2135,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         // (key@+0/value@+8 per 16-byte slot); `set` grows storage through
         // the handle, `freeze` copies into a plain Map block.
         let ptr_l = next_local
-        Array::push(local_names, "__mb_ptr")
+        Array::push(local_names, "[gc-temp]__mb_ptr")
         emit_global_get(buf, 0)
         emit_i64_extend_i32_u(buf)
         emit_local_set(buf, ptr_l)
@@ -2180,15 +2182,15 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let cap_l = nl + 6
         let st_l = nl + 7
         let ns_l = nl + 8
-        Array::push(local_names, "__mbs_map")
-        Array::push(local_names, "__mbs_key")
-        Array::push(local_names, "__mbs_val")
-        Array::push(local_names, "__mbs_cnt")
-        Array::push(local_names, "__mbs_i")
-        Array::push(local_names, "__mbs_found")
-        Array::push(local_names, "__mbs_cap")
-        Array::push(local_names, "__mbs_st")
-        Array::push(local_names, "__mbs_ns")
+        Array::push(local_names, "[gc-temp]__mbs_map")
+        Array::push(local_names, "[gc-temp]__mbs_key")
+        Array::push(local_names, "[gc-temp]__mbs_val")
+        Array::push(local_names, "[gc-temp]__mbs_cnt")
+        Array::push(local_names, "[gc-temp]__mbs_i")
+        Array::push(local_names, "[gc-temp]__mbs_found")
+        Array::push(local_names, "[gc-temp]__mbs_cap")
+        Array::push(local_names, "[gc-temp]__mbs_st")
+        Array::push(local_names, "[gc-temp]__mbs_ns")
         emit_local_set(buf, mv_l)
         emit_local_set(buf, mk_l)
         emit_local_set(buf, mb_l)
@@ -2332,9 +2334,9 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let fb_l = nl
         let fc_l = nl + 1
         let fm_l = nl + 2
-        Array::push(local_names, "__mbf_b")
-        Array::push(local_names, "__mbf_cnt")
-        Array::push(local_names, "__mbf_map")
+        Array::push(local_names, "[gc-temp]__mbf_b")
+        Array::push(local_names, "[gc-temp]__mbf_cnt")
+        Array::push(local_names, "[gc-temp]__mbf_map")
         emit_i64_const(buf, -2)
         emit_i64_and(buf)
         emit_local_set(buf, fb_l)
@@ -2389,11 +2391,11 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let mc_l = nl + 2
         let st_l = nl + 3
         let mi_l = nl + 4
-        Array::push(local_names, "__mhk_map")
-        Array::push(local_names, "__mhk_key")
-        Array::push(local_names, "__mhk_cnt")
-        Array::push(local_names, "__mhk_st")
-        Array::push(local_names, "__mhk_i")
+        Array::push(local_names, "[gc-temp]__mhk_map")
+        Array::push(local_names, "[gc-temp]__mhk_key")
+        Array::push(local_names, "[gc-temp]__mhk_cnt")
+        Array::push(local_names, "[gc-temp]__mhk_st")
+        Array::push(local_names, "[gc-temp]__mhk_i")
         emit_local_set(buf, mk_l)
         emit_local_set(buf, mb_l)
         emit_local_get(buf, mb_l)
@@ -2454,13 +2456,13 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let mi_l = nl + 4
         let mv_l = nl + 5
         let res_l = nl + 6
-        Array::push(local_names, "__mbg_map")
-        Array::push(local_names, "__mbg_key")
-        Array::push(local_names, "__mbg_cnt")
-        Array::push(local_names, "__mbg_st")
-        Array::push(local_names, "__mbg_i")
-        Array::push(local_names, "__mbg_val")
-        Array::push(local_names, "__mbg_res")
+        Array::push(local_names, "[gc-temp]__mbg_map")
+        Array::push(local_names, "[gc-temp]__mbg_key")
+        Array::push(local_names, "[gc-temp]__mbg_cnt")
+        Array::push(local_names, "[gc-temp]__mbg_st")
+        Array::push(local_names, "[gc-temp]__mbg_i")
+        Array::push(local_names, "[gc-temp]__mbg_val")
+        Array::push(local_names, "[gc-temp]__mbg_res")
         let mut nl2 = nl + 7
         emit_local_set(buf, mk_l)
         emit_local_set(buf, mb_l)
@@ -2504,7 +2506,9 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         emit_i32_add(buf)
         emit_i64_load(buf, 3, 8)
         emit_local_set(buf, mv_l)
-        nl2 = ce(buf, ECall(EIdent("Some", -1), [EIdent("__mbg_val", -1)], -1), local_names, nl2, ld)
+        nl2 = ce(buf, ECall(EIdent("Some", -1), [
+          EIdent("[gc-temp]__mbg_val", -1)
+        ], -1), local_names, nl2, ld)
         emit_local_set(buf, res_l)
         emit_br(buf, 2)
         emit_end(buf)
@@ -2537,13 +2541,13 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let ms_cnt = nl + 4
         let ms_i = nl + 5
         let ms_found = nl + 6
-        Array::push(local_names, "__ms_map")
-        Array::push(local_names, "__ms_key")
-        Array::push(local_names, "__ms_val")
-        Array::push(local_names, "__ms_new")
-        Array::push(local_names, "__ms_cnt")
-        Array::push(local_names, "__ms_i")
-        Array::push(local_names, "__ms_found")
+        Array::push(local_names, "[gc-temp]__ms_map")
+        Array::push(local_names, "[gc-temp]__ms_key")
+        Array::push(local_names, "[gc-temp]__ms_val")
+        Array::push(local_names, "[gc-temp]__ms_new")
+        Array::push(local_names, "[gc-temp]__ms_cnt")
+        Array::push(local_names, "[gc-temp]__ms_i")
+        Array::push(local_names, "[gc-temp]__ms_found")
         emit_local_set(buf, ms_v)
         emit_local_set(buf, ms_k)
         emit_local_set(buf, ms_m)
@@ -2684,12 +2688,12 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let md_new = nl + 3
         let md_i = nl + 4
         let md_out = nl + 5
-        Array::push(local_names, "__md_map")
-        Array::push(local_names, "__md_key")
-        Array::push(local_names, "__md_cnt")
-        Array::push(local_names, "__md_new")
-        Array::push(local_names, "__md_idx")
-        Array::push(local_names, "__md_out")
+        Array::push(local_names, "[gc-temp]__md_map")
+        Array::push(local_names, "[gc-temp]__md_key")
+        Array::push(local_names, "[gc-temp]__md_cnt")
+        Array::push(local_names, "[gc-temp]__md_new")
+        Array::push(local_names, "[gc-temp]__md_idx")
+        Array::push(local_names, "[gc-temp]__md_out")
         emit_local_set(buf, md_k)
         emit_local_set(buf, md_m)
         emit_local_get(buf, md_m)
@@ -2793,10 +2797,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let key_l = nl + 1
         let cnt_l = nl + 2
         let idx_l = nl + 3
-        Array::push(local_names, "__mg_map")
-        Array::push(local_names, "__mg_key")
-        Array::push(local_names, "__mg_cnt")
-        Array::push(local_names, "__mg_i")
+        Array::push(local_names, "[gc-temp]__mg_map")
+        Array::push(local_names, "[gc-temp]__mg_key")
+        Array::push(local_names, "[gc-temp]__mg_cnt")
+        Array::push(local_names, "[gc-temp]__mg_i")
         emit_local_set(buf, key_l)
         emit_local_set(buf, map_l)
         // Load count
@@ -2865,10 +2869,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let key_l = nl + 1
         let cnt_l = nl + 2
         let idx_l = nl + 3
-        Array::push(local_names, "__hk_map")
-        Array::push(local_names, "__hk_key")
-        Array::push(local_names, "__hk_cnt")
-        Array::push(local_names, "__hk_i")
+        Array::push(local_names, "[gc-temp]__hk_map")
+        Array::push(local_names, "[gc-temp]__hk_key")
+        Array::push(local_names, "[gc-temp]__hk_cnt")
+        Array::push(local_names, "[gc-temp]__hk_i")
         emit_local_set(buf, key_l)
         emit_local_set(buf, map_l)
         emit_local_get(buf, map_l)
@@ -2919,10 +2923,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let res_l = nl + 1
         let cnt_l = nl + 2
         let i_l = nl + 3
-        Array::push(local_names, "__keys_map")
-        Array::push(local_names, "__keys_res")
-        Array::push(local_names, "__keys_cnt")
-        Array::push(local_names, "__keys_i")
+        Array::push(local_names, "[gc-temp]__keys_map")
+        Array::push(local_names, "[gc-temp]__keys_res")
+        Array::push(local_names, "[gc-temp]__keys_cnt")
+        Array::push(local_names, "[gc-temp]__keys_i")
         emit_local_set(buf, map_l)
         emit_call_resolved(buf, ctx, arr_new_fi)
         emit_local_set(buf, res_l)
@@ -3034,10 +3038,10 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let fam_init = nl + 1
         let fam_arr = nl + 2
         let fam_i = nl + 3
-        Array::push(local_names, "__fam_n")
-        Array::push(local_names, "__fam_init")
-        Array::push(local_names, "__fam_arr")
-        Array::push(local_names, "__fam_i")
+        Array::push(local_names, "[gc-temp]__fam_n")
+        Array::push(local_names, "[gc-temp]__fam_init")
+        Array::push(local_names, "[gc-temp]__fam_arr")
+        Array::push(local_names, "[gc-temp]__fam_i")
         emit_local_set(buf, fam_init)
         emit_local_set(buf, fam_n)
         emit_call_resolved(buf, ctx, fa_new_idx)
@@ -3100,12 +3104,12 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let fb_soff = nl + 3
         let fb_len = nl + 4
         let fb_i = nl + 5
-        Array::push(local_names, "__fb_dst")
-        Array::push(local_names, "__fb_doff")
-        Array::push(local_names, "__fb_src")
-        Array::push(local_names, "__fb_soff")
-        Array::push(local_names, "__fb_len")
-        Array::push(local_names, "__fb_i")
+        Array::push(local_names, "[gc-temp]__fb_dst")
+        Array::push(local_names, "[gc-temp]__fb_doff")
+        Array::push(local_names, "[gc-temp]__fb_src")
+        Array::push(local_names, "[gc-temp]__fb_soff")
+        Array::push(local_names, "[gc-temp]__fb_len")
+        Array::push(local_names, "[gc-temp]__fb_i")
         emit_local_set(buf, fb_len)
         emit_local_set(buf, fb_soff)
         emit_local_set(buf, fb_src)
@@ -3202,9 +3206,9 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
           let slot_local = next_local + 1
           let env_local = next_local + 2
           let mut nl = next_local + 3
-          Array::push(local_names, "__fn_val")
-          Array::push(local_names, "__slot")
-          Array::push(local_names, "__env")
+          Array::push(local_names, "[gc-temp]__fn_val")
+          Array::push(local_names, "[gc-temp]__slot")
+          Array::push(local_names, "[gc-temp]__env")
           emit_local_get(buf, local_idx2)
           // #2012: see the linear compile_call path — boxed `let mut`
           // locals store a cell address.
@@ -3232,9 +3236,9 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       let slot_local = next_local + 1
       let env_local = next_local + 2
       let mut nl = next_local + 3
-      Array::push(local_names, "__fn_val")
-      Array::push(local_names, "__slot")
-      Array::push(local_names, "__env")
+      Array::push(local_names, "[gc-temp]__fn_val")
+      Array::push(local_names, "[gc-temp]__slot")
+      Array::push(local_names, "[gc-temp]__env")
       nl = ce(buf, callee, local_names, nl, ld)
       emit_local_set(buf, fn_val_local)
       emit_closure_resolve(buf, fn_val_local, slot_local, env_local)

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -306,9 +306,9 @@ fn gc_is_ctor_expr(e: Expr, ctx: CompileCtxGc) -> Bool {
 /// raw i64 0/1. `cefn` is compile_expr_gc, threaded to avoid a forward ref.
 fn emit_gc_tuple_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, num: Int, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, cefn: (Bytes, Expr, Array[String], Int, CompileCtxGc, Int) -> Int with Exception) -> Int with Exception {
   let aptr = next_local
-  Array::push(local_names, "__gceqa")
+  Array::push(local_names, "[gc-temp]__gceqa")
   let bptr = next_local + 1
-  Array::push(local_names, "__gceqb")
+  Array::push(local_names, "[gc-temp]__gceqb")
   let nl1 = cefn(buf, lhs, local_names, next_local + 2, ctx, ld)
   emit_local_set(buf, aptr)
   let nl2 = cefn(buf, rhs, local_names, nl1, ctx, ld)
@@ -337,9 +337,9 @@ fn emit_gc_tuple_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, num: Int, local_nam
 /// `Some(av) == rb` effect-row comparison (unify_effects) always false.
 fn emit_gc_ctor_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, fc: Int, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, cefn: (Bytes, Expr, Array[String], Int, CompileCtxGc, Int) -> Int with Exception) -> Int with Exception {
   let aptr = next_local
-  Array::push(local_names, "__gcceqa")
+  Array::push(local_names, "[gc-temp]__gcceqa")
   let bptr = next_local + 1
-  Array::push(local_names, "__gcceqb")
+  Array::push(local_names, "[gc-temp]__gcceqb")
   let nl1 = cefn(buf, lhs, local_names, next_local + 2, ctx, ld)
   emit_i64_const(buf, -2)
   emit_i64_and(buf)
@@ -363,9 +363,9 @@ fn emit_gc_ctor_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, fc: Int, local_names
     let res_l = nl2
     let cnt_l = nl2 + 1
     let ii_l = nl2 + 2
-    Array::push(local_names, "__gcceq_res")
-    Array::push(local_names, "__gcceq_cnt")
-    Array::push(local_names, "__gcceq_i")
+    Array::push(local_names, "[gc-temp]__gcceq_res")
+    Array::push(local_names, "[gc-temp]__gcceq_cnt")
+    Array::push(local_names, "[gc-temp]__gcceq_i")
     emit_i64_const(buf, 1)
     emit_local_set(buf, res_l)
     emit_local_get(buf, aptr)
@@ -1092,7 +1092,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
         if ctor_idx >= 0 {
           let tag_c = Array::get(ctx.gc_ctor_table.tags, ctor_idx)
           let ptr_l = next_local
-          Array::push(local_names, "__ctor_ptr")
+          Array::push(local_names, "[gc-temp]__ctor_ptr")
           emit_global_get(buf, 0)
           emit_i64_extend_i32_u(buf)
           emit_local_set(buf, ptr_l)
@@ -1616,7 +1616,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       let num_elems = Array::length(elems)
       let alloc_size = num_elems * 8
       let ptr_local = next_local
-      Array::push(local_names, "__tuple_ptr")
+      Array::push(local_names, "[gc-temp]__tuple_ptr")
       let mut nl = next_local + 1
       emit_global_get(buf, 0)
       emit_i64_extend_i32_u(buf)
@@ -1652,7 +1652,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       }
       emit_call(buf, arr_new_idx)
       emit_local_set(buf, arr_local)
-      Array::push(local_names, "__arr_lit")
+      Array::push(local_names, "[gc-temp]__arr_lit")
       let mut nl = next_local + 1
       let mut ei = 0
       while ei < Array::length(elems) {
@@ -1686,9 +1686,9 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       let result_local = next_local
       let arr_local = next_local + 1
       let i_local = next_local + 2
-      Array::push(local_names, "__forin_res")
-      Array::push(local_names, "__forin_arr")
-      Array::push(local_names, "__forin_i")
+      Array::push(local_names, "[gc-temp]__forin_res")
+      Array::push(local_names, "[gc-temp]__forin_arr")
+      Array::push(local_names, "[gc-temp]__forin_i")
       if ctx.func_offset > 0 && arr_new_idx >= ctx.func_offset {
         emit_i64_const(buf, 0)
       } else {
@@ -1706,8 +1706,8 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       let (str_ccat_idx, _, _) = resolve_func(ctx.func_table, "String::char_code_at")
       let conv_local = nl1pre
       let j_local = nl1pre + 1
-      Array::push(local_names, "__forin_string_chars")
-      Array::push(local_names, "__forin_string_i")
+      Array::push(local_names, "[gc-temp]__forin_string_chars")
+      Array::push(local_names, "[gc-temp]__forin_string_i")
       let nl1 = nl1pre + 2
       emit_local_get(buf, arr_local)
       emit_i64_const(buf, 32)
@@ -1805,7 +1805,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       // Same innermost-loop ld reset as EWhile.
       let nl4 = ce(buf, body, local_names, nl3, 0)
       let body_val = nl4
-      Array::push(local_names, "__forin_val")
+      Array::push(local_names, "[gc-temp]__forin_val")
       emit_local_set(buf, body_val)
       emit_local_get(buf, result_local)
       emit_local_get(buf, body_val)
@@ -1999,7 +1999,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
         nl1
       } else {
         let obj_l = nl1
-        Array::push(local_names, "__dot_obj")
+        Array::push(local_names, "[gc-temp]__dot_obj")
         emit_local_set(buf, obj_l)
         let mut di = 0
         while di < Array::length(dispatch) {
@@ -2077,7 +2077,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       }
       let obj_size = 8 + flen * 8
       let ptr_local = next_local
-      Array::push(local_names, "__rec_ptr")
+      Array::push(local_names, "[gc-temp]__rec_ptr")
       emit_global_get(buf, 0)
       emit_i64_extend_i32_u(buf)
       emit_local_set(buf, ptr_local)
@@ -2103,7 +2103,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
         let (_, fexpr) = Array::get(rec_fields, ri)
         nl_r = ce(buf, fexpr, local_names, nl_r, ld)
         let val_local = nl_r
-        Array::push(local_names, "__rec_val")
+        Array::push(local_names, "[gc-temp]__rec_val")
         emit_local_set(buf, val_local)
         nl_r = nl_r + 1
         emit_local_get(buf, ptr_local)
@@ -2231,7 +2231,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       }
       let malloc_size = 8 + mcap * 16
       let mptr = next_local
-      Array::push(local_names, "__maplit_ptr")
+      Array::push(local_names, "[gc-temp]__maplit_ptr")
       emit_global_get(buf, 0)
       emit_i64_extend_i32_u(buf)
       emit_local_set(buf, mptr)

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -893,7 +893,7 @@ fn gc_native_array_join_arg_is_safe(arg: Expr, name: String, abi_names: Array[St
 /// i64 fallback for an ELet after its name has already been pushed into
 /// `local_names`. Keeping it separate makes the native-literal branch above
 /// unable to accidentally feed a reference to the legacy local.set path.
-fn gc_compile_let_i64(buf: Bytes, value: Expr, body: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, ce: (Bytes, Expr, Array[String], Int, Int) -> Int with Exception) -> Int with Exception {
+fn gc_compile_let_i64(buf: Bytes, name: String, name_slot: Int, value: Expr, body: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, ce: (Bytes, Expr, Array[String], Int, Int) -> Int with Exception) -> Int with Exception {
   let local_idx = next_local
   if gc_expr_is_floatish(value, local_names, ctx) {
     Array::push(ctx.gc_float_locals, local_idx)
@@ -955,6 +955,7 @@ fn gc_compile_let_i64(buf: Bytes, value: Expr, body: Expr, local_names: Array[St
   Array::push(ctx.gc_agg_local_slots, local_idx * 256 + agg_entry)
   let nl = ce(buf, value, local_names, next_local + 1, ld)
   emit_local_set(buf, local_idx)
+  Array::set(local_names, name_slot, name)
   ce(buf, body, local_names, nl, ld)
 }
 
@@ -1401,7 +1402,12 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
     ECall(callee, args, _) => compile_call_gc(buf, callee, args, local_names, next_local, ctx, ld, ce),
     ELet(name, value, body, _) => {
       let local_idx = next_local
+      let name_slot = Array::length(local_names)
       Array::push(local_names, name)
+      // A non-recursive binder is not visible in its own initializer. Reserve
+      // its wasm slot but hide the source name until the body (#2160; mirrors
+      // the linear lane's #1120 masking).
+      Array::set(local_names, name_slot, "")
       match value {
         // #1702: a record literal bound to a local that never leaves field-read
         // position lives in a real wasm-gc struct instead of linear memory.
@@ -1446,9 +1452,10 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
             }
             emit_struct_new(buf, ctx.gc_native_struct_type_base + ns_struct_idx)
             emit_local_set(buf, local_idx)
+            Array::set(local_names, name_slot, name)
             ce(buf, body, local_names, ns_nl, ld)
           } else {
-            gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
+            gc_compile_let_i64(buf, name, name_slot, value, body, local_names, next_local, ctx, ld, ce)
           }
         },
         EArray(native_elems) => if ctx.gc_native_array_frame_ok && ctx.gc_native_array_type_idx >= 0 && gc_native_array_body_is_safe_tail(body, name, ctx.gc_direct_abi_current_return_ref, ctx) {
@@ -1467,9 +1474,10 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
             emit_array_set(buf, ctx.gc_native_array_type_idx)
             ni = ni + 1
           }
+          Array::set(local_names, name_slot, name)
           ce(buf, body, local_names, native_nl, ld)
         } else {
-          gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
+          gc_compile_let_i64(buf, name, name_slot, value, body, local_names, next_local, ctx, ld, ce)
         },
         EIdent(source, _) => {
           let source_slot = find_local_slot(local_names, source)
@@ -1478,9 +1486,10 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
             Array::push(ctx.gc_native_array_local_types, local_idx)
             emit_local_get(buf, source_slot)
             emit_local_set(buf, local_idx)
+            Array::set(local_names, name_slot, name)
             ce(buf, body, local_names, next_local + 1, ld)
           } else {
-            gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
+            gc_compile_let_i64(buf, name, name_slot, value, body, local_names, next_local, ctx, ld, ce)
           }
         },
         ECall(_, _, _) => if gc_direct_abi_result_is_native(value, ctx) && gc_native_array_body_is_safe_tail(body, name, ctx.gc_direct_abi_current_return_ref, ctx) {
@@ -1488,11 +1497,12 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
           Array::push(ctx.gc_native_array_local_types, local_idx)
           let native_nl = ce(buf, value, local_names, next_local + 1, ld)
           emit_local_set(buf, local_idx)
+          Array::set(local_names, name_slot, name)
           ce(buf, body, local_names, native_nl, ld)
         } else {
-          gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
+          gc_compile_let_i64(buf, name, name_slot, value, body, local_names, next_local, ctx, ld, ce)
         },
-        _ => gc_compile_let_i64(buf, value, body, local_names, next_local, ctx, ld, ce)
+        _ => gc_compile_let_i64(buf, name, name_slot, value, body, local_names, next_local, ctx, ld, ce)
       }
     },
     ELetRec(name, value, body) => {

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -200,7 +200,7 @@ import ./backend_lambda_body.vibe {
 }
 
 import ./backend_typed_local_scan.vibe {
-  gc_direct_abi_name_slot, gc_direct_abi_result_is_native, gc_sibling_scope_start
+  gc_direct_abi_name_slot, gc_sibling_scope_start
 }
 
 import ./backend_match.vibe {
@@ -1492,7 +1492,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
             gc_compile_let_i64(buf, name, name_slot, value, body, local_names, next_local, ctx, ld, ce)
           }
         },
-        ECall(_, _, _) => if gc_direct_abi_result_is_native(value, ctx) && gc_native_array_body_is_safe_tail(body, name, ctx.gc_direct_abi_current_return_ref, ctx) {
+        ECall(_, _, _) => if gc_expr_can_compile_native_array_ref(value, local_names, ctx) && gc_native_array_body_is_safe_tail(body, name, ctx.gc_direct_abi_current_return_ref, ctx) {
           Array::push(ctx.gc_native_array_locals, local_idx)
           Array::push(ctx.gc_native_array_local_types, local_idx)
           let native_nl = ce(buf, value, local_names, next_local + 1, ld)

--- a/lib/@vibe/compiler/codegen/gc/backend_lambda_emit.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_lambda_emit.vibe
@@ -36,7 +36,7 @@ fn emit_lambda_closure_gc(buf: Bytes, captures: Array[String], num_captures: Int
     let alloc_size = 8 + num_captures * 8
     let ptr_local = next_local
     let nl2 = next_local + 1
-    Array::push(local_names, "__closure_ptr")
+    Array::push(local_names, "[gc-temp]__closure_ptr")
     emit_global_get(buf, 0)
     emit_i64_extend_i32_u(buf)
     emit_local_tee(buf, ptr_local)

--- a/lib/@vibe/compiler/codegen/gc/backend_lambda_inner.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_lambda_inner.vibe
@@ -39,7 +39,7 @@ export fn compile_lambda_inner_gc(params: Array[(String, Option[TypeExpr])], fn_
     Array::push(lam_locals, lpname)
     lpi = lpi + 1
   }
-  Array::push(lam_locals, "__env")
+  Array::push(lam_locals, "[gc-temp]__env")
   let env_param_idx = user_params
   let lam_nl_start = user_params + 1
   let lam_ref_cells = array_empty()

--- a/lib/@vibe/compiler/codegen/gc/backend_match.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_match.vibe
@@ -329,7 +329,7 @@ fn gc_extract_ctor_payload(buf: Bytes, local_names: Array[String], vloc: Int, id
   emit_i32_wrap_i64(buf)
   emit_i64_load(buf, 3, 8 + idx * 8)
   emit_local_set(buf, tl)
-  Array::push(local_names, "__pat_tmp")
+  Array::push(local_names, "[gc-temp]__pat_tmp")
   tl
 }
 
@@ -341,7 +341,7 @@ fn gc_extract_tuple_elem(buf: Bytes, local_names: Array[String], vloc: Int, idx:
   emit_i32_wrap_i64(buf)
   emit_i64_load(buf, 3, idx * 8)
   emit_local_set(buf, tl)
-  Array::push(local_names, "__pat_tmp")
+  Array::push(local_names, "[gc-temp]__pat_tmp")
   tl
 }
 
@@ -558,7 +558,7 @@ fn emit_gc_pat_binds(buf: Bytes, local_names: Array[String], vloc: Int, pat: Pat
 
 fn compile_match_gc(buf: Bytes, scrutinee: Expr, arms: Array[(Pat, Expr)], local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, ce: (Bytes, Expr, Array[String], Int, Int) -> Int with Exception) -> Int with Exception {
   let scrut_local = next_local
-  Array::push(local_names, "__match_scrut")
+  Array::push(local_names, "[gc-temp]__match_scrut")
   let nl1 = ce(buf, scrutinee, local_names, next_local + 1, ld)
   emit_local_set(buf, scrut_local)
   let num_arms = Array::length(arms)

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -1582,7 +1582,7 @@ rm -rf "$svdir"
 echo "[compiler-gate] 40k/40 gc-lane call/to_string regressions (#1015, #2160)"
 gcbdir="_build/_gate_gc_to_string_bool"
 rm -rf "$gcbdir"; mkdir -p "$gcbdir"
-for gcb_fixture in to_string_bool_gc_test to_string_shadow_gc_test to_string_bool_scope_gc_test to_string_float_scope_gc_test gc_local_top_level_shadow_test; do
+for gcb_fixture in to_string_bool_gc_test to_string_shadow_gc_test to_string_bool_scope_gc_test to_string_float_scope_gc_test gc_local_top_level_shadow_test gc_scratch_name_collision; do
   VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/${gcb_fixture}.vibe" "$gcbdir/${gcb_fixture}.wasm" __no_entry__ >/dev/null 2>&1 || true

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -1579,10 +1579,10 @@ rm -rf "$svdir"
 #     name-keyed, unpruned design as gc_bool_locals pre-#1030 (a KNOWN
 #     LATENT BUG noted but not fixed there); now slot-indexed and pruned
 #     the same way.
-echo "[compiler-gate] 40k/40 gc-lane to_string(Bool) regressions (#1015)"
+echo "[compiler-gate] 40k/40 gc-lane call/to_string regressions (#1015, #2160)"
 gcbdir="_build/_gate_gc_to_string_bool"
 rm -rf "$gcbdir"; mkdir -p "$gcbdir"
-for gcb_fixture in to_string_bool_gc_test to_string_shadow_gc_test to_string_bool_scope_gc_test to_string_float_scope_gc_test; do
+for gcb_fixture in to_string_bool_gc_test to_string_shadow_gc_test to_string_bool_scope_gc_test to_string_float_scope_gc_test gc_local_top_level_shadow_test; do
   VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "fixtures/${gcb_fixture}.vibe" "$gcbdir/${gcb_fixture}.wasm" __no_entry__ >/dev/null 2>&1 || true
@@ -1598,7 +1598,7 @@ for gcb_fixture in to_string_bool_gc_test to_string_shadow_gc_test to_string_boo
   fi
 done
 rm -rf "$gcbdir"
-echo "[compiler-gate] gc-lane to_string(Bool) regressions ok"
+echo "[compiler-gate] gc-lane call/to_string regressions ok"
 
 # 40l. handle-replay side-effect corruption regression guard (M2,
 #      eval/lang-review/findings/2026-07-12-r2.md; tracked by ADR-0076/#817).

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -1582,6 +1582,8 @@ rm -rf "$svdir"
 echo "[compiler-gate] 40k/40 gc-lane call/to_string regressions (#1015, #2160)"
 gcbdir="_build/_gate_gc_to_string_bool"
 rm -rf "$gcbdir"; mkdir -p "$gcbdir"
+# gc_scratch_name_collision.vibe intentionally stays out of the linear unit
+# lane because it guards GC-backend scratch naming specifically.
 for gcb_fixture in to_string_bool_gc_test to_string_shadow_gc_test to_string_bool_scope_gc_test to_string_float_scope_gc_test gc_local_top_level_shadow_test gc_scratch_name_collision; do
   VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -112,7 +112,7 @@ x-wasm-gc-string-for-in	mid	wasm-gc String for-in
 40h8c/40	mid	40h8c/40 wasm-gc import diagnostic (#1976)
 40i/40	mid	40i/40 effect->WIT golden (#537)
 40j/40	mid	40j/40 serve handler componentization (#537)
-40k/40	mid	40k/40 gc-lane to_string(Bool) regressions (#1015)
+40k/40	mid	40k/40 gc-lane call/to_string regressions (#1015, #2160)
 40l/40	mid	40l/40 handle-replay side-effect corruption regression guard (M2/#817)
 40m/40	mid	40m/40 effect row operation-item grammar (ADR-0071 step 1/#755)
 40n/40	mid	40n/40 effectset row expansion authorizes a transitive call (ADR-0071 step 3/#755)


### PR DESCRIPTION
## Summary

- make wasm-gc call lookup prefer an in-scope local callable over a same-named top-level function
- move backend scratch identifiers into a source-unspellable `[gc-temp]` namespace so lexical lookup cannot mistake compiler temporaries for source bindings
- add an import-free gc/linear fixture and active mid-gate coverage

## Validation

- Red baseline with checkout stage2: gc returned 9 for a local closure expected to return 1; linear passed
- rebuilt checkout stage2 with `pkf run generation`
- focused fixture passes on gc and linear
- temporary `__fn_val` collision probe passes on gc
- `COMPILER_GATE_LANE=mid VIBE_GATE_STAGE2=<checkout-stage2> bash scripts/compiler_gate.sh`
- `bash scripts/check_gate_registry.sh`
- formatter check, shell syntax, and `git diff --check`
- independent review found a temporary-name collision; follow-up fixed it and re-review approved with no blockers

## Conflict note

PR #2156 touches the same file only around the float-return classifier near the top; this PR changes generic call resolution and scratch naming. The functional hunks are disjoint.

Closes #2160