### PR TITLE
Stop gating on diluted entry-weighted coverage rates

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -117,6 +117,14 @@ entry ごとの program 固有**なので entry 間で比較してはいけな�
 `branch.per_fn[fn].mask` (branch 1つにつき `'1'`/`'0'` 1文字、ordinal 昇順)
 がこの ordinal を公開しており、report 側はこれを OR して union を出す。
 
+Entry-weighted rates are reported for historical continuity, but they are not
+gated by default. Adding one test entry adds its whole import closure to their
+denominator, so a larger test suite can lower those rates while both the
+covered-function and covered-branch counts increase. The default gate instead
+uses absolute hit ratchets plus the source-union rate. Set
+`VIBE_SUITE_MIN_POINT_RATE` or `VIBE_SUITE_MIN_BRANCH_RATE` only for an explicit
+diagnostic experiment that needs an entry-weighted floor.
+
 > **重要 — この指標が測っているのは「テストプログラム自身の実行」であって
 > 「テストで検証された機能」ではない。**
 >

--- a/scripts/coverage_suite.sh
+++ b/scripts/coverage_suite.sh
@@ -36,21 +36,21 @@
 # treating top_branch_union_gaps as a to-do list.
 #
 # Thresholds (percent, env-overridable; this file is the ONE place they are
-# defined — raise them as coverage improves, lowering needs a rationale in
-# the PR):
-#   VIBE_SUITE_MIN_POINT_RATE        — minimum entry-weighted FUNCTION rate
+# defined):
+#   VIBE_SUITE_MIN_POINT_RATE        — opt-in entry-weighted FUNCTION floor
 #   VIBE_SUITE_MIN_LINE_RATE         — minimum CASE PASS rate (entries green)
-#   VIBE_SUITE_MIN_BRANCH_RATE       — minimum entry-weighted BRANCH rate
+#   VIBE_SUITE_MIN_BRANCH_RATE       — opt-in entry-weighted BRANCH floor
 #   VIBE_SUITE_MIN_FN_HIT            — minimum ABSOLUTE covered functions
 #   VIBE_SUITE_MIN_BRANCH_HIT        — minimum ABSOLUTE covered branches
 #   VIBE_SUITE_MIN_BRANCH_UNION_HIT  — minimum UNION covered branches
 #   VIBE_SUITE_MIN_BRANCH_UNION_RATE — minimum UNION branch rate
 #
-# Among the ENTRY-WEIGHTED metrics the ABSOLUTE minimums are the primary
-# ratchet: adding a test entry can only raise them, while their RATE floors
-# would punish it (a new entry grows the denominator by its whole import
-# closure). Those rates are kept as loose floors. The UNION rate has no such
-# problem and is ratcheted directly.
+# Among the ENTRY-WEIGHTED metrics only the ABSOLUTE minimums are ratchets:
+# adding a test entry can only raise them, while rate floors punish it (a new
+# entry grows the denominator by its whole import closure). The rates remain
+# in the report and can be gated explicitly through the env overrides, but
+# their defaults are zero. The UNION rate has no such problem and is ratcheted
+# directly.
 #
 # Baseline (2026-07-03, 93 allowlist entries, full-visibility #716 stage2):
 #   functions 2263/6491 (34.86%), branches 3814/41967 (9.09%), cases 92/93
@@ -111,9 +111,16 @@ cd "$ROOT"
 # just under current; the ABSOLUTE mins (the real ratchet) are RAISED to
 # just under current instead (12,000 -> 42,000 fn, 29,000 -> 113,000
 # branch), which protects strictly more coverage than the old floors did.
-MIN_POINT="${VIBE_SUITE_MIN_POINT_RATE:-13}"
+#
+# Rebased 2026-08-21: with 1,008 entries, the entry-weighted rates diluted to
+# 12.35% / 5.50% while absolute hits reached 111,304 / 282,489 and source
+# union stayed at 88.42% / 58.73%. Main had been red before and after #2156
+# despite every one of the 1,008 entries passing. Repeatedly lowering a rate
+# whose denominator grows with each entry is not a ratchet, so the default
+# rate floors are retired. Absolute-hit and union ratchets below remain active.
+MIN_POINT="${VIBE_SUITE_MIN_POINT_RATE:-0}"
 MIN_LINE="${VIBE_SUITE_MIN_LINE_RATE:-97}"
-MIN_BRANCH="${VIBE_SUITE_MIN_BRANCH_RATE:-6}"
+MIN_BRANCH="${VIBE_SUITE_MIN_BRANCH_RATE:-0}"
 MIN_FN_HIT="${VIBE_SUITE_MIN_FN_HIT:-42000}"
 MIN_BRANCH_HIT="${VIBE_SUITE_MIN_BRANCH_HIT:-113000}"
 # #1556: branch UNION floors. Unlike the entry-weighted numbers above, these

--- a/scripts/coverage_suite_report_test.py
+++ b/scripts/coverage_suite_report_test.py
@@ -1,4 +1,5 @@
 import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -7,6 +8,30 @@ from coverage_suite_report import build_report
 
 
 class CoverageSuiteReportTest(unittest.TestCase):
+    def test_default_gate_uses_union_and_absolute_ratchets_not_weighted_rates(self):
+        script = (Path(__file__).parent / "coverage_suite.sh").read_text()
+
+        def default_for(name):
+            match = re.search(
+                rf'^{name}="\$\{{VIBE_SUITE_[A-Z_]+:-([^}}]+)\}}"$',
+                script,
+                re.MULTILINE,
+            )
+            self.assertIsNotNone(match, f"missing default for {name}")
+            return match.group(1)
+
+        # Entry-weighted rates are denominator-diluted whenever a test imports
+        # more code. Keep them observable and opt-in, but do not fail main by
+        # default on values that are not source coverage.
+        self.assertEqual(default_for("MIN_POINT"), "0")
+        self.assertEqual(default_for("MIN_BRANCH"), "0")
+
+        # The monotonic absolute-hit and source-union ratchets remain active.
+        self.assertGreater(int(default_for("MIN_FN_HIT")), 0)
+        self.assertGreater(int(default_for("MIN_BRANCH_HIT")), 0)
+        self.assertGreater(int(default_for("MIN_BRANCH_UNION_HIT")), 0)
+        self.assertGreater(float(default_for("MIN_BRANCH_UNION")), 0)
+
     def write_cov(self, directory, entry, *, hit, total, hit_fns, missed_fns, branch_hit=0, branch_total=0,
                   branch_per_fn=None):
         path = directory / (entry.replace("/", "_").removesuffix(".vibe") + ".json")


### PR DESCRIPTION
## Summary

- keep entry-weighted function and branch rates in the coverage report, but make their failure floors opt-in
- retain the case-pass, absolute-hit, and source-union ratchets as default gates
- add a contract test that prevents the non-source rate floors from being silently re-enabled
- document why entry-weighted rates dilute as the test suite grows

## Root cause

The main-only coverage job failed before and after #2156 even though every test passed and both absolute coverage hits and source-union coverage increased. Each new test entry adds its complete import closure to the entry-weighted denominator, so the fixed 13% / 6% floors are not monotonic ratchets.

## Verification

- `python3 scripts/coverage_suite_report_test.py`
- coverage helper test suite: 16 Node tests + 7 Python tests
- `bash -n scripts/coverage_suite.sh`
- `bash scripts/check_doc_commands.sh`
- `git diff --check`
- full coverage suite with the stage2 artifact from main merge commit `57a02bfb`: 1008/1008 files, 7304 tests, branch union 58.57%, function union 88.39%, gate OK

The local full run reported entry-weighted 12.05% / 5.36%; these remain visible but no longer fail the default gate.

The pre-existing dirty `deps/wasmtime` submodule is not included.