### PR TITLE
Add function-union coverage ratchets

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -169,6 +169,10 @@ ratchet: `VIBE_SUITE_MIN_BRANCH_UNION_HIT` (絶対数) と
 `VIBE_SUITE_MIN_BRANCH_UNION_RATE` (率)。entry を足すと分母がその import
 closure ぶん増える entry-weighted rate と違い、union の rate は
 「テストを足せば上がる」ので率のラチェットとして意味を持つ。
+Function union is protected symmetrically by
+`VIBE_SUITE_MIN_FUNCTION_UNION_HIT` and
+`VIBE_SUITE_MIN_FUNCTION_UNION_RATE`; disabling the diluted entry-weighted
+function rate must not remove the source-function regression gate.
 
 ### コンパイラ自身を計測
 

--- a/scripts/coverage_suite.sh
+++ b/scripts/coverage_suite.sh
@@ -42,6 +42,8 @@
 #   VIBE_SUITE_MIN_BRANCH_RATE       — opt-in entry-weighted BRANCH floor
 #   VIBE_SUITE_MIN_FN_HIT            — minimum ABSOLUTE covered functions
 #   VIBE_SUITE_MIN_BRANCH_HIT        — minimum ABSOLUTE covered branches
+#   VIBE_SUITE_MIN_FUNCTION_UNION_HIT — minimum UNION covered functions
+#   VIBE_SUITE_MIN_FUNCTION_UNION_RATE — minimum UNION function rate
 #   VIBE_SUITE_MIN_BRANCH_UNION_HIT  — minimum UNION covered branches
 #   VIBE_SUITE_MIN_BRANCH_UNION_RATE — minimum UNION branch rate
 #
@@ -123,10 +125,10 @@ MIN_LINE="${VIBE_SUITE_MIN_LINE_RATE:-97}"
 MIN_BRANCH="${VIBE_SUITE_MIN_BRANCH_RATE:-0}"
 MIN_FN_HIT="${VIBE_SUITE_MIN_FN_HIT:-42000}"
 MIN_BRANCH_HIT="${VIBE_SUITE_MIN_BRANCH_HIT:-113000}"
-# #1556: branch UNION floors. Unlike the entry-weighted numbers above, these
-# count each source branch once no matter how many entries link it, so the
-# rate is the one the issue's "branch coverage >= 60%" target is stated
-# against. Raise as coverage improves; lowering needs a rationale in the PR.
+# Union floors count each source function/branch once no matter how many
+# entries link it. Unlike entry-weighted rates, these are source metrics and
+# can be ratcheted directly. Raise as coverage improves; lowering needs a
+# rationale in the PR.
 #
 # Baseline (2026-08-13, 575 entries, all green, at 85f2ace): branch union
 # 25,131/45,638 (55.07%), function union 12,820/14,907 (86.00%). Note how far
@@ -148,9 +150,13 @@ MIN_BRANCH_HIT="${VIBE_SUITE_MIN_BRANCH_HIT:-113000}"
 # unchanged (55.07%) -- numerator and denominator grew together, which is what
 # de-merging distinct functions should do.
 #
-# Unlike the entry-weighted RATE floors, this rate is safe to ratchet: adding a
-# test entry cannot dilute it (a branch is counted once no matter how many
-# entries link it), so a new entry can only hold it level or push it up.
+# #2175 review: retiring the diluted function-rate floor without a function
+# union ratchet would leave only MIN_FN_HIT=42,000 against 111,304 weighted
+# hits. Current source-function union is 16,040/18,147 (88.39%) locally and
+# 16,046/18,147 (88.42%) in CI. Keep a small reproducibility margin while
+# preventing a large loss of actually executed source functions.
+MIN_FUNCTION_UNION_HIT="${VIBE_SUITE_MIN_FUNCTION_UNION_HIT:-15800}"
+MIN_FUNCTION_UNION="${VIBE_SUITE_MIN_FUNCTION_UNION_RATE:-88}"
 MIN_BRANCH_UNION_HIT="${VIBE_SUITE_MIN_BRANCH_UNION_HIT:-26000}"
 MIN_BRANCH_UNION="${VIBE_SUITE_MIN_BRANCH_UNION_RATE:-57}"
 
@@ -264,4 +270,4 @@ esac
 VIBE_TEST_CLI_WASM="$cli_abs" bash scripts/vibe_test.sh --coverage "${entries[@]}" \
   | tee "$run_log" || true
 
-python3 scripts/coverage_suite_report.py "$run_log" "$COV_DIR" "$REPORT" "$MIN_POINT" "$MIN_LINE" "$MIN_BRANCH" "$MIN_FN_HIT" "$MIN_BRANCH_HIT" "$MIN_BRANCH_UNION_HIT" "$MIN_BRANCH_UNION"
+python3 scripts/coverage_suite_report.py "$run_log" "$COV_DIR" "$REPORT" "$MIN_POINT" "$MIN_LINE" "$MIN_BRANCH" "$MIN_FN_HIT" "$MIN_BRANCH_HIT" "$MIN_BRANCH_UNION_HIT" "$MIN_BRANCH_UNION" "$MIN_FUNCTION_UNION_HIT" "$MIN_FUNCTION_UNION"

--- a/scripts/coverage_suite_report.py
+++ b/scripts/coverage_suite_report.py
@@ -192,13 +192,16 @@ def build_report(run_log, cov_dir):
 
 
 def main(argv):
-    # The last two (branch-union ratchet, #1556) are optional so an older
-    # caller keeps working; omitting them measures and prints without gating.
+    # Union ratchets are optional so an older caller keeps working; omitting
+    # them measures and prints without gating.
     run_log, cov_dir, report_path, min_point, min_line, min_branch, min_fn_hit, min_branch_hit = argv[:8]
     min_branch_union_hit, min_branch_union_rate = (argv[8:] + ["0", "0"])[:2]
+    min_function_union_hit, min_function_union_rate = (argv[10:] + ["0", "0"])[:2]
     min_point, min_line, min_branch = map(float, (min_point, min_line, min_branch))
     min_fn_hit, min_branch_hit = int(min_fn_hit), int(min_branch_hit)
     min_branch_union_hit, min_branch_union_rate = int(min_branch_union_hit), float(min_branch_union_rate)
+    min_function_union_hit = int(min_function_union_hit)
+    min_function_union_rate = float(min_function_union_rate)
     report = build_report(run_log, cov_dir)
     os.makedirs(os.path.dirname(report_path), exist_ok=True)
     with open(report_path, "w", encoding="utf-8") as output:
@@ -228,6 +231,12 @@ def main(argv):
         failures.append(f"entry-weighted covered functions {function['hit']} < min {min_fn_hit} (FN_HIT ratchet)")
     if branch["hit"] < min_branch_hit:
         failures.append(f"entry-weighted covered branches {branch['hit']} < min {min_branch_hit} (BRANCH_HIT ratchet)")
+    if union["hit"] < min_function_union_hit:
+        failures.append(
+            f"union covered functions {union['hit']} < min {min_function_union_hit} (FUNCTION_UNION_HIT ratchet)")
+    if union["rate"] < min_function_union_rate:
+        failures.append(
+            f"function union coverage {union['rate']}% < min {min_function_union_rate}% (FUNCTION_UNION)")
     # #1556: the branch-union floors are the metric the 60% target is stated
     # against.  Skipped when the union is only a lower bound -- gating on a
     # number the run could not measure exactly would fail for the wrong reason.

--- a/scripts/coverage_suite_report_test.py
+++ b/scripts/coverage_suite_report_test.py
@@ -1,10 +1,12 @@
+import io
 import json
 import re
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
-from coverage_suite_report import build_report
+from coverage_suite_report import build_report, main
 
 
 class CoverageSuiteReportTest(unittest.TestCase):
@@ -29,8 +31,47 @@ class CoverageSuiteReportTest(unittest.TestCase):
         # The monotonic absolute-hit and source-union ratchets remain active.
         self.assertGreater(int(default_for("MIN_FN_HIT")), 0)
         self.assertGreater(int(default_for("MIN_BRANCH_HIT")), 0)
+        self.assertGreater(int(default_for("MIN_FUNCTION_UNION_HIT")), 0)
+        self.assertGreater(float(default_for("MIN_FUNCTION_UNION")), 0)
         self.assertGreater(int(default_for("MIN_BRANCH_UNION_HIT")), 0)
         self.assertGreater(float(default_for("MIN_BRANCH_UNION")), 0)
+
+        invocation = re.search(
+            r'^python3 scripts/coverage_suite_report\.py .+$',
+            script,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(invocation)
+        self.assertIn('"$MIN_FUNCTION_UNION_HIT"', invocation.group(0))
+        self.assertIn('"$MIN_FUNCTION_UNION"', invocation.group(0))
+
+    def test_function_union_ratchets_fail_independently_of_weighted_rates(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            cov = root / "coverage"
+            cov.mkdir()
+            log = root / "run.log"
+            report = root / "report.json"
+            log.write_text("ok   test_a.vibe\n")
+            self.write_cov(
+                cov,
+                "test_a.vibe",
+                hit=100,
+                total=100,
+                hit_fns=["covered"],
+                missed_fns=["missed"],
+            )
+            output = io.StringIO()
+            with redirect_stdout(output):
+                result = main([
+                    str(log), str(cov), str(report),
+                    "0", "0", "0", "0", "0", "0", "0",
+                    "2", "60",
+                ])
+
+        self.assertEqual(result, 1)
+        self.assertIn("FUNCTION_UNION_HIT ratchet", output.getvalue())
+        self.assertIn("FUNCTION_UNION)", output.getvalue())
 
     def write_cov(self, directory, entry, *, hit, total, hit_fns, missed_fns, branch_hit=0, branch_total=0,
                   branch_per_fn=None):


### PR DESCRIPTION
## Summary

Follow-up to #2175 after review identified that retiring the diluted entry-weighted function-rate floor left no source-function rate ratchet.

- add function-union absolute-hit and rate floors
- keep the entry-weighted rate observable but opt-in
- test that function-union regression fails even when weighted coverage is 100%
- preserve the existing branch-union, absolute-hit, and case-pass ratchets

## Baseline

- local: `16040/18147` function union (`88.39%`)
- CI: `16046/18147` function union (`88.42%`)
- floors: `15800` hits and `88%`

## Verification

- `python3 scripts/coverage_suite_report_test.py` — 10 tests pass
- `bash -n scripts/coverage_suite.sh`
- `bash scripts/check_doc_commands.sh`
- full 1008-entry report replay: function union 88.39%, branch union 58.57%, gate OK
- `git diff --check`

Addresses https://github.com/mizchi/vibe-lang/pull/2175#discussion_r3829384312.