### PR TITLE
Classify float returns by the checker's resolution instead of by name (#2166)

### DIFF
--- a/fixtures/float_return_to_string_gc_test.vibe
+++ b/fixtures/float_return_to_string_gc_test.vibe
@@ -51,6 +51,27 @@ fn aliased_twice() -> AliasedTwice {
   2.5
 }
 
+// #2166: the parameterized-alias gap, on the gc lane too. Both lanes read the
+// SAME table (compute_float_returning_names), so the fix that made
+// `Box[Double]` resolve is shared -- but that is exactly the assumption the
+// #2158 split disproved once already, so it is measured here rather than
+// inferred from the linear file. Before the fix: 384 on both lanes.
+type BoxGc[T] = T
+
+fn via_generic_gc() -> BoxGc[Double] {
+  2.5
+}
+
+// `f64`/`f32` have always resolved to Double; the old name scan listed only
+// "Double" and "Float", so these rendered raw bits on both lanes.
+fn as_f64_gc() -> f64 {
+  2.5
+}
+
+fn as_f32_gc() -> f32 {
+  2.5
+}
+
 //# Tests
 
 test "#2158 gc: a call to a `-> Double` function stringifies as a Double" {
@@ -100,4 +121,13 @@ test "#2156 review gc: a `type` alias onto Double is classified" {
 
 test "#2156 review gc: an alias chain is followed" {
   assert_true(__to_string(aliased_twice()) == "2.5")
+}
+
+test "#2166 gc: a parameterized alias onto Double is classified" {
+  assert_true(__to_string(via_generic_gc()) == "2.5")
+}
+
+test "#2166 gc: the f64 and f32 spellings are floats" {
+  assert_true(__to_string(as_f64_gc()) == "2.5")
+  assert_true(__to_string(as_f32_gc()) == "2.5")
 }

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Type, TypeDef, TypeExpr, find_typedef, resolve_builtin
+  Type, TypeDef, TypeExpr, find_typedef, resolve_builtin, resolve_type_alias_params, resolve_type_expr_core_shadowed
 }
 
 import @vibe/core {
@@ -14,47 +14,9 @@ import @vibe/core {
 /// The alias body was resolved with its params as free `CtNamed(<param>, _)`
 /// names; replace each by the corresponding actual argument (recursively).
 export fn subst_type_params(ty: Type, params: Array[String], args: Array[Type]) -> Type {
-  match ty {
-    CtNamed(name, targs) => {
-      let mut idx = 0 - 1
-      let mut i = 0
-      while i < Array::length(params) {
-        if Array::get(params, i) == name {
-          idx = i
-        }
-        i = i + 1
-      }
-      if idx >= 0 && idx < Array::length(args) {
-        Array::get(args, idx)
-      } else {
-        CtNamed(name, for a in targs {
-          subst_type_params(a, params, args)
-        })
-      }
-    },
-    CtArray(e) => CtArray(subst_type_params(e, params, args)),
-    CtOption(e) => CtOption(subst_type_params(e, params, args)),
-    CtTuple(es) => CtTuple(for e in es {
-      subst_type_params(e, params, args)
-    }),
-    CtFn(ps, ret, eff) => {
-      let subst_params: (Array[Type]) -> Array[Type] = (types) -> {
-        let out = array_empty()
-        let mut i = 0
-        while i < Array::length(types) {
-          Array::push(out, subst_type_params(Array::get(types, i), params, args))
-          i = i + 1
-        }
-        out
-      }
-      CtFn(subst_params(ps), subst_type_params(ret, params, args), eff)
-    },
-    _ => ty
-  }
+  resolve_type_alias_params(ty, params, args)
 }
 
-/// True when `name` is one of the type formals bound by the declaration whose
-/// body we are resolving. See `resolve_type_expr_shadowed`.
 fn is_shadowed_tyvar(shadow: Array[String], name: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -85,70 +47,7 @@ export fn resolve_type_expr(te: TypeExpr, defs: Array[TypeDef]) -> Type {
 /// lookup below finds it, and `Box[Int]` becomes `Hue`. A formal is a binder,
 /// so it wins over both `defs` and the builtins -- the shadow check runs first.
 export fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String]) -> Type {
-  match te {
-    TyUnit => CtUnit,
-    TyName(name) => if is_shadowed_tyvar(shadow, name) {
-      CtNamed(name, array_empty())
-    } else {
-      match resolve_builtin(name) {
-        Some(t) => t,
-        None => match find_typedef(defs, name) {
-          Some(td) => match td {
-            TDEnum(n, _, _) => CtEnum(n),
-            TDStruct(n, _, _, _) => CtStruct(n),
-            TDAlias(_, _, t) => t,
-            TDEffect(_, _, _) => CtNamed(name, array_empty()),
-            TDEffectSet(_, _) => CtNamed(name, array_empty())
-          },
-          None => CtNamed(name, array_empty())
-        }
-      }
-    },
-    TyApp(name, args) => {
-      let ra = for a in args {
-        resolve_type_expr_shadowed(a, defs, shadow)
-      }
-      if name == "Array" {
-        if Array::length(ra) == 1 {
-          CtArray(Array::get(ra, 0))
-        }
-        else CtNamed(name, ra)
-      } else if name == "Option" {
-        if Array::length(ra) == 1 {
-          CtOption(Array::get(ra, 0))
-        }
-        else CtNamed(name, ra)
-      } else if is_shadowed_tyvar(shadow, name) {
-        // `T[X]` where `T` is a formal: higher-kinded application is not
-        // supported, but the head is still the formal's -- never expand it as
-        // whatever `defs` happens to bind that name to.
-        CtNamed(name, ra)
-      } else {
-        // Expand a parameterized type alias `Foo[A] = Body` applied as `Foo[X]`
-        // by substituting its formal params; otherwise it stays nominal.
-        match find_typedef(defs, name) {
-          Some(td) => match td {
-            TDAlias(_, params, body) => subst_type_params(body, params, ra),
-            _ => CtNamed(name, ra)
-          },
-          None => CtNamed(name, ra)
-        }
-      }
-    },
-    TyTuple(elems) => {
-      let r = for e in elems {
-        resolve_type_expr_shadowed(e, defs, shadow)
-      }
-      CtTuple(r)
-    },
-    TyFn(params, ret, effect_name) => {
-      let ret_box = Array::slice([ret], 0, 1)
-      let rp = for p in params {
-        resolve_type_expr_shadowed(p, defs, shadow)
-      }
-      CtFn(rp, resolve_type_expr_shadowed(Array::get(ret_box, 0), defs, shadow), effect_name)
-    }
-  }
+  resolve_type_expr_core_shadowed(te, defs, shadow)
 }
 
 /// #2125: nominal heads the compiler owns itself. They resolve to

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -1,9 +1,5 @@
 //# Imports
 
-import @vibe/compiler/checker {
-  resolve_type_expr_shadowed
-}
-
 import @vibe/compiler/core {
   Expr,
   Pat,
@@ -18,6 +14,7 @@ import @vibe/compiler/core {
   canonical_builtin_name,
   is_borrow_ret_builtin,
   is_exception_throw_operation,
+  resolve_type_expr_core_shadowed,
   sorted_names_of,
   type_to_string
 }
@@ -4007,7 +4004,7 @@ export fn compute_float_returning_names(stmts: Array[Stmt]) -> Array[String] {
       match value {
         EFn(tparams, _, _, ret, _, _) =>
         match ret {
-          Some(rt) => match resolve_type_expr_shadowed(rt, defs, tparams) {
+          Some(rt) => match resolve_type_expr_core_shadowed(rt, defs, tparams) {
             CtDouble => Array::push(out, name),
             _ => ()
           },
@@ -4088,7 +4085,7 @@ fn collect_alias_type_defs(stmts: Array[Stmt]) -> Array[TypeDef] {
     let mut j = 0
     while j < n {
       let ps = Array::get(alias_params, j)
-      let resolved = resolve_type_expr_shadowed(Array::get(alias_targets, j), defs, ps)
+      let resolved = resolve_type_expr_core_shadowed(Array::get(alias_targets, j), defs, ps)
       Array::push(next, TDAlias(Array::get(alias_names, j), ps, resolved))
       sig = String::concat(sig, String::concat(type_to_string(resolved), " |#| "))
       j = j + 1

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -1,9 +1,15 @@
 //# Imports
 
+import @vibe/compiler/checker {
+  resolve_type_expr_shadowed
+}
+
 import @vibe/compiler/core {
   Expr,
   Pat,
   Stmt,
+  Type,
+  TypeDef,
   TypeExpr,
   bsearch_leftmost,
   builtin_allocates,
@@ -3958,78 +3964,50 @@ export fn region_mutlist_exit_copy(arg: Expr) -> Expr {
   region_array_value_copy(ECall(EIdent("ArrayBuilder::freeze", -1), [arg], -1), "__mutlist_exit")
 }
 
-/// #2158: names of user functions whose DECLARED return type is `Double` or
-/// `Float`, with `type` aliases resolved.
+/// #2158: names of user functions whose declared return type is a float.
 ///
 /// codegen is untyped, so a call `half(5.0)` is just an ECall; without this
-/// table the syntactic floatish classifiers cannot tell it from an
-/// Int-valued call and `__to_string` falls through to a runtime bit-pattern
-/// heuristic that renders an f64 as a plausible-looking integer.
+/// table the syntactic floatish classifiers cannot tell it from an Int-valued
+/// call and `__to_string` falls through to a runtime bit-pattern heuristic
+/// that renders an f64 as a plausible-looking integer.
 ///
-/// ONE copy on purpose. This started as an inline walk in wasi's pre-pass,
-/// was duplicated into the gc pre-pass when the fix had to be made twice, and
-/// the alias gap below then had to be found in both (#2156 review). The walk
-/// is cheap and the stmt list is right here in either caller.
+/// ONE copy on purpose. This started as an inline walk in wasi's pre-pass, was
+/// duplicated into the gc pre-pass when the fix had to be made twice, and the
+/// alias gap then had to be found in both (#2156 review). The walk is cheap
+/// and the stmt list is right here in every caller.
 ///
-/// Aliases: `type MyD = Double; fn f() -> MyD` returns a Double, and matching
-/// the raw spelling `TyName("Double")` missed it -- `__to_string(f())`
-/// printed 180 for 2.5. Only zero-parameter aliases are followed; a
-/// parameterized alias does not itself name Double. Chain length is bounded by
-/// the alias count, so a cycle terminates without capping valid chains -- see
-/// float_ret_name_is_floatish.
+/// The classification is the CHECKER's, not a name match (#2166). Each
+/// declared return type goes through `resolve_type_expr_shadowed` -- the same
+/// entry point `check_stmts` uses for an `STypeAlias` body -- and the answer
+/// is whether that resolves to `CtDouble`. This replaced a hand-written scan
+/// that compared the spelling against "Double"/"Float" and walked
+/// zero-parameter aliases by name. Four separate special cases dissolved into
+/// the resolver, three of them previously WRONG:
 ///
-/// WHAT THIS DOES NOT COVER, and why that is a boundary rather than a bug list:
-/// this is a SYNTACTIC over-approximation, because codegen has no types. A
-/// return written through a parameterized alias -- `type Box[T] = T;
-/// fn value() -> Box[Double]` -- is a `TyApp`, not a `TyName`, and is missed:
-/// `__to_string(value())` prints 180 rather than 2.5 (measured, #2166).
-///
-/// Covering it means substituting type arguments into an alias target here,
-/// i.e. re-deriving a piece of the type system inside an untyped pass, and the
-/// next shape after that needs the next piece. The thing that actually closes
-/// the class is the checker's normalized return type reaching codegen. Until
-/// then this table covers what it can name directly, and #2166 tracks the rest
-/// -- rather than growing an ad-hoc resolver one reported shape at a time.
+///   * a PARAMETERIZED alias -- `type Box[T] = T; fn f() -> Box[Double]` is a
+///     `TyApp`, which a name-keyed table structurally cannot follow. Printed
+///     384 for 2.5 (#2166). Resolution substitutes the type arguments.
+///   * the spellings `f64` and `f32`, which `resolve_builtin` has always
+///     unified with Double and the name scan never listed. `fn f() -> f64`
+///     printed 192 for 2.5 -- measured while fixing #2166, previously unfiled.
+///   * alias CHAINS -- resolution is transitive, so there is no hop walk and
+///     no step bound to get wrong (an earlier bound of a flat 16 printed 176
+///     for a 16-hop chain).
+///   * a type PARAMETER shadowing an alias -- `type D = Double; fn id[D](x: D)
+///     -> D` returns the variable, not a float. That is the `shadow` argument,
+///     which is what it is for; it needed an explicit guard before.
 export fn compute_float_returning_names(stmts: Array[Stmt]) -> Array[String] {
-  let alias_names: Array[String] = []
-  let alias_targets: Array[String] = []
-  let mut ai = 0
-  while ai < Array::length(stmts) {
-    match Array::get(stmts, ai) {
-      STypeAlias(_, aname, aparams, atarget) => if Array::length(aparams) == 0 {
-        Array::push(alias_names, aname)
-        Array::push(alias_targets, match atarget {
-          TyName(tn) => tn,
-          _ => ""
-        })
-      } else {
-        ()
-      },
-      _ => ()
-    }
-    ai = ai + 1
-  }
+  let defs = collect_alias_type_defs(stmts)
   let out: Array[String] = []
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SLet(_, _, name, _, value) =>
       match value {
-        // The function's OWN type parameters shadow any alias of the same
-        // name: with `type D = Double`, `fn id[D](x: D) -> D` returns the
-        // type variable, not a float. Following the alias recorded `id` as
-        // float-returning and `__to_string(id(1))` printed 0 instead of 1
-        // (#2156 review, measured). A bare type variable that shadows
-        // nothing is already excluded -- it resolves to no primitive.
         EFn(tparams, _, _, ret, _, _) =>
         match ret {
-          Some(rt) =>
-          match rt {
-            TyName(rtn) => if !array_contains_str(tparams, rtn) && float_ret_name_is_floatish(alias_names, alias_targets, rtn) {
-              Array::push(out, name)
-            } else {
-              ()
-            },
+          Some(rt) => match resolve_type_expr_shadowed(rt, defs, tparams) {
+            CtDouble => Array::push(out, name),
             _ => ()
           },
           None => ()
@@ -4043,48 +4021,55 @@ export fn compute_float_returning_names(stmts: Array[Stmt]) -> Array[String] {
   out
 }
 
-/// Does `n` name Double/Float, directly or through zero-parameter aliases?
+/// The alias table `compute_float_returning_names` resolves against.
 ///
-/// The step bound is `alias count + 1`, which is the exact acyclic maximum: a
-/// chain that never revisits an alias cannot be longer than the number of
-/// aliases. So no valid chain is rejected, and a cycle still terminates.
+/// Built order-INDEPENDENTLY, deliberately unlike `check_stmts`. The checker
+/// does not pre-claim an `STypeAlias` (a placeholder alias body would be a lie
+/// -- an alias resolves THROUGH to its target, so an empty placeholder would
+/// silently retarget every early reference), so a forward reference to a later
+/// alias stays unresolved there. codegen must not inherit that: today
+/// `fn f() -> Later { 2.5 }` above `type Later = Double` compiles and renders
+/// 2.5, and answering "not a float" for it would be a silent-wrong regression
+/// -- the exact class this table exists to close. Measured before the change,
+/// not assumed.
 ///
-/// It was a flat 16, and that WAS a depth policy despite the comment claiming
-/// otherwise -- worse, the primitive test ran only at the top of the loop, so
-/// reaching the bound by increment exited without testing the name just
-/// stepped to. A 16-alias chain onto Double printed 176 instead of 2.5
-/// (#2156 review, measured). `done` is now a separate flag so the test runs
-/// after every hop including the last.
-fn float_ret_name_is_floatish(alias_names: Array[String], alias_targets: Array[String], n: String) -> Bool {
-  let limit = Array::length(alias_names) + 1
-  let mut cur = n
-  let mut steps = 0
-  let mut found = false
-  let mut done = false
-  while !done {
-    if cur == "Double" || cur == "Float" {
-      found = true
-      done = true
-    } else if steps >= limit {
-      done = true
-    } else {
-      let mut k = Array::length(alias_names) - 1
-      let mut next = ""
-      while k >= 0 {
-        if Array::get(alias_names, k) == cur {
-          next = Array::get(alias_targets, k)
-          k = -1
-        } else {
-          k = k - 1
-        }
-      }
-      if String::length(next) == 0 {
-        done = true
-      } else {
-        cur = next
-        steps = steps + 1
-      }
+/// So every alias body is resolved against every other, repeated until no
+/// unresolved hop can remain: `n + 1` passes over `n` aliases is the acyclic
+/// maximum, since a chain that never revisits an alias is at most `n` long. A
+/// cycle simply stops changing. `n` is single digits per compilation unit (32
+/// aliases in all of `lib/`), so the quadratic pass count costs nothing.
+///
+/// Only aliases are collected: a struct or enum return type is never a float,
+/// so their TypeDefs cannot change an answer here.
+fn collect_alias_type_defs(stmts: Array[Stmt]) -> Array[TypeDef] {
+  let alias_names: Array[String] = []
+  let alias_params: Array[Array[String]] = []
+  let alias_targets: Array[TypeExpr] = []
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      STypeAlias(_, aname, aparams, atarget) => {
+        Array::push(alias_names, aname)
+        Array::push(alias_params, aparams)
+        Array::push(alias_targets, atarget)
+      },
+      _ => ()
     }
+    i = i + 1
   }
-  found
+  let n = Array::length(alias_names)
+  let mut defs: Array[TypeDef] = []
+  let mut pass = 0
+  while pass <= n {
+    let next: Array[TypeDef] = []
+    let mut j = 0
+    while j < n {
+      let ps = Array::get(alias_params, j)
+      Array::push(next, TDAlias(Array::get(alias_names, j), ps, resolve_type_expr_shadowed(Array::get(alias_targets, j), defs, ps)))
+      j = j + 1
+    }
+    defs = next
+    pass = pass + 1
+  }
+  defs
 }

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -18,7 +18,8 @@ import @vibe/compiler/core {
   canonical_builtin_name,
   is_borrow_ret_builtin,
   is_exception_throw_operation,
-  sorted_names_of
+  sorted_names_of,
+  type_to_string
 }
 
 import @vibe/core {
@@ -4021,33 +4022,47 @@ export fn compute_float_returning_names(stmts: Array[Stmt]) -> Array[String] {
   out
 }
 
-/// The alias table `compute_float_returning_names` resolves against.
+/// The type table `compute_float_returning_names` resolves against.
 ///
-/// Built order-INDEPENDENTLY, deliberately unlike `check_stmts`. The checker
-/// does not pre-claim an `STypeAlias` (a placeholder alias body would be a lie
-/// -- an alias resolves THROUGH to its target, so an empty placeholder would
-/// silently retarget every early reference), so a forward reference to a later
-/// alias stays unresolved there. codegen must not inherit that: today
-/// `fn f() -> Later { 2.5 }` above `type Later = Double` compiles and renders
-/// 2.5, and answering "not a float" for it would be a silent-wrong regression
-/// -- the exact class this table exists to close. Measured before the change,
-/// not assumed.
+/// It mirrors what `check_stmts` has in `defs` when it resolves a return
+/// annotation, in two respects that both matter for the answer:
 ///
-/// So every alias body is resolved against every other, repeated until no
-/// unresolved hop can remain: `n + 1` passes over `n` aliases is the acyclic
-/// maximum, since a chain that never revisits an alias is at most `n` long. A
-/// cycle simply stops changing. `n` is single digits per compilation unit (32
-/// aliases in all of `lib/`), so the quadratic pass count costs nothing.
+/// (1) NOMINAL PRECEDENCE. `preclaim_local_type_defs` pushes an enum/struct
+/// placeholder for every declaration before any alias is resolved, and
+/// `find_typedef` is first-match-wins, so a name declared as BOTH a struct and
+/// an alias resolves to the struct. Collecting aliases alone would pick the
+/// alias and could classify a struct-returning function as float-returning
+/// (#2177 review). Placeholders are therefore pushed first, in statement
+/// order, exactly as the checker pushes them.
 ///
-/// Only aliases are collected: a struct or enum return type is never a float,
-/// so their TypeDefs cannot change an answer here.
+/// (2) ORDER INDEPENDENCE for the aliases themselves -- and here it
+/// deliberately differs from `check_stmts`, which does NOT pre-claim an
+/// `STypeAlias` (a placeholder alias body would be a lie: an alias resolves
+/// THROUGH to its target, so an empty placeholder would silently retarget
+/// every early reference). A forward reference to a later alias stays
+/// unresolved there. codegen must not inherit that: measured before the
+/// change, `fn f() -> Later { 2.5 }` above `type Later = Double` compiles and
+/// renders 2.5 today, and answering "not a float" for it would be a
+/// silent-wrong regression -- the exact class this table exists to close.
+///
+/// So alias bodies are re-resolved until the table stops changing, capped at
+/// `n + 1` passes: a chain that never revisits an alias is at most `n` long,
+/// so that is the acyclic maximum, and a cycle stops changing on its own. The
+/// early exit is what keeps the common case cheap -- with no forward
+/// reference the table is stable after the first pass and the second one ends
+/// it, instead of running all `n + 1` (#2177 review). Measured: the flat
+/// module source the compiler actually compiles has 5 aliases.
 fn collect_alias_type_defs(stmts: Array[Stmt]) -> Array[TypeDef] {
+  let nominal: Array[TypeDef] = []
   let alias_names: Array[String] = []
   let alias_params: Array[Array[String]] = []
   let alias_targets: Array[TypeExpr] = []
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
+      SEnum(_, ename, eparams, _, _) => Array::push(nominal, TDEnum(ename, eparams, array_empty())),
+      SSuberror(_, sname, _) => Array::push(nominal, TDEnum(sname, array_empty(), array_empty())),
+      SStruct(_, stname, _, _, mut_fields, tparams) => Array::push(nominal, TDStruct(stname, array_empty(), mut_fields, tparams)),
       STypeAlias(_, aname, aparams, atarget) => {
         Array::push(alias_names, aname)
         Array::push(alias_params, aparams)
@@ -4058,18 +4073,33 @@ fn collect_alias_type_defs(stmts: Array[Stmt]) -> Array[TypeDef] {
     i = i + 1
   }
   let n = Array::length(alias_names)
-  let mut defs: Array[TypeDef] = []
+  let mut defs = nominal
+  let mut prev = ""
   let mut pass = 0
-  while pass <= n {
+  let mut done = false
+  while !done {
     let next: Array[TypeDef] = []
+    let mut k = 0
+    while k < Array::length(nominal) {
+      Array::push(next, Array::get(nominal, k))
+      k = k + 1
+    }
+    let mut sig = ""
     let mut j = 0
     while j < n {
       let ps = Array::get(alias_params, j)
-      Array::push(next, TDAlias(Array::get(alias_names, j), ps, resolve_type_expr_shadowed(Array::get(alias_targets, j), defs, ps)))
+      let resolved = resolve_type_expr_shadowed(Array::get(alias_targets, j), defs, ps)
+      Array::push(next, TDAlias(Array::get(alias_names, j), ps, resolved))
+      sig = String::concat(sig, String::concat(type_to_string(resolved), " |#| "))
       j = j + 1
     }
     defs = next
     pass = pass + 1
+    if sig == prev || pass > n {
+      done = true
+    } else {
+      prev = sig
+    }
   }
   defs
 }

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -3,7 +3,6 @@ version = 0.0.1
 description =
   #|@vibe/compiler/codegen/common_analysis — free-variable / string-literal /
 deps = {
-  @vibe/compiler/checker : 0.0.1
   @vibe/compiler/codegen/common_extractors : 0.0.1
   @vibe/compiler/codegen/wasm_emit : 0.0.1
   @vibe/compiler/core : 0.0.1

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -3,6 +3,7 @@ version = 0.0.1
 description =
   #|@vibe/compiler/codegen/common_analysis — free-variable / string-literal /
 deps = {
+  @vibe/compiler/checker : 0.0.1
   @vibe/compiler/codegen/common_extractors : 0.0.1
   @vibe/compiler/codegen/wasm_emit : 0.0.1
   @vibe/compiler/core : 0.0.1

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -228,6 +228,8 @@ fn trait_defined(env: TypeEnv, name: String) -> Bool
 fn type_to_string(ty: Type) -> String
 fn env_lookup_flat(bindings: Array[(String, Type)], name: String) -> Option[Type]
 fn resolve_builtin(name: String) -> Option[Type]
+fn resolve_type_alias_params(ty: Type, params: Array[String], args: Array[Type]) -> Type
+fn resolve_type_expr_core_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String]) -> Type
 fn subst_add_bound(s: Subst, id: Int, bounds: Array[String]) -> Subst
 fn instantiate(ty: Type, c: Int) -> (Type, Int, Array[(Int, Array[String])])
 fn trait_is_subtrait(env: TypeEnv, sub: String, super_name: String) -> Bool

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1454,6 +1454,105 @@ export fn resolve_builtin(name: String) -> Option[Type] {
   else None
 }
 
+/// Substitute the formal parameters of a resolved type alias.
+///
+/// This lives in core because both the checker and later compiler passes need
+/// the same canonical TypeExpr resolution without importing the whole checker.
+export fn resolve_type_alias_params(ty: Type, params: Array[String], args: Array[Type]) -> Type {
+  match ty {
+    CtNamed(name, targs) => {
+      let mut idx = 0 - 1
+      let mut i = 0
+      while i < Array::length(params) {
+        if Array::get(params, i) == name {
+          idx = i
+        }
+        i = i + 1
+      }
+      if idx >= 0 && idx < Array::length(args) {
+        Array::get(args, idx)
+      } else {
+        CtNamed(name, for a in targs {
+          resolve_type_alias_params(a, params, args)
+        })
+      }
+    },
+    CtArray(e) => CtArray(resolve_type_alias_params(e, params, args)),
+    CtOption(e) => CtOption(resolve_type_alias_params(e, params, args)),
+    CtTuple(es) => CtTuple(for e in es {
+      resolve_type_alias_params(e, params, args)
+    }),
+    CtFn(ps, ret, eff) => CtFn(for p in ps {
+      resolve_type_alias_params(p, params, args)
+    }, resolve_type_alias_params(ret, params, args), eff),
+    _ => ty
+  }
+}
+
+fn type_expr_name_is_shadowed(shadow: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(shadow) {
+    if Array::get(shadow, i) == name {
+      found = true
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// Resolve a source type expression while preserving the enclosing type
+/// binders. This is the shared semantic authority used by the checker and by
+/// typed classification in later compiler passes.
+export fn resolve_type_expr_core_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String]) -> Type {
+  match te {
+    TyUnit => CtUnit,
+    TyName(name) => if type_expr_name_is_shadowed(shadow, name) {
+      CtNamed(name, array_empty())
+    } else {
+      match resolve_builtin(name) {
+        Some(t) => t,
+        None => match find_typedef(defs, name) {
+          Some(td) => match td {
+            TDEnum(n, _, _) => CtEnum(n),
+            TDStruct(n, _, _, _) => CtStruct(n),
+            TDAlias(_, _, t) => t,
+            TDEffect(_, _, _) => CtNamed(name, array_empty()),
+            TDEffectSet(_, _) => CtNamed(name, array_empty())
+          },
+          None => CtNamed(name, array_empty())
+        }
+      }
+    },
+    TyApp(name, args) => {
+      let ra = for a in args {
+        resolve_type_expr_core_shadowed(a, defs, shadow)
+      }
+      if name == "Array" && Array::length(ra) == 1 {
+        CtArray(Array::get(ra, 0))
+      } else if name == "Option" && Array::length(ra) == 1 {
+        CtOption(Array::get(ra, 0))
+      } else if type_expr_name_is_shadowed(shadow, name) {
+        CtNamed(name, ra)
+      } else {
+        match find_typedef(defs, name) {
+          Some(td) => match td {
+            TDAlias(_, params, body) => resolve_type_alias_params(body, params, ra),
+            _ => CtNamed(name, ra)
+          },
+          None => CtNamed(name, ra)
+        }
+      }
+    },
+    TyTuple(elems) => CtTuple(for e in elems {
+      resolve_type_expr_core_shadowed(e, defs, shadow)
+    }),
+    TyFn(params, ret, effect_name) => CtFn(for p in params {
+      resolve_type_expr_core_shadowed(p, defs, shadow)
+    }, resolve_type_expr_core_shadowed(ret, defs, shadow), effect_name)
+  }
+}
+
 export fn subst_add_bound(s: Subst, id: Int, bounds: Array[String]) -> Subst {
   SubstBound(id, bounds, s)
 }

--- a/lib/@vibe/compiler/tests/float_return_to_string_test.vibe
+++ b/lib/@vibe/compiler/tests/float_return_to_string_test.vibe
@@ -145,6 +145,45 @@ test "#2156 review: a local binding SHADOWS the float-return table" {
   assert_true(__to_string(value()) == "1")
 }
 
+// #2166: a return through a PARAMETERIZED alias. `Box[Double]` is a `TyApp`,
+// which the old name-keyed table structurally could not follow -- it compared
+// the spelling against "Double"/"Float" and walked zero-parameter aliases by
+// name. `__to_string(via_generic())` printed 384 for 2.5, on BOTH backends.
+// The classification now goes through the checker's `resolve_type_expr_shadowed`,
+// which substitutes the type arguments into the alias body.
+type Box[T] = T
+
+type PairFst[A, B] = A
+
+fn via_generic() -> Box[Double] {
+  2.5
+}
+
+fn via_pair() -> PairFst[Double, Int] {
+  2.5
+}
+
+// `resolve_builtin` has always unified `f64`/`f32` with Double; the name scan
+// listed only "Double" and "Float", so these printed raw bits (192 for 2.5).
+// Found while fixing #2166 -- previously unfiled.
+fn as_f64() -> f64 {
+  2.5
+}
+
+fn as_f32() -> f32 {
+  2.5
+}
+
+// A forward reference to an alias declared LATER. The checker deliberately
+// does not pre-claim an `STypeAlias`, so this stays unresolved there -- but it
+// compiles and renders 2.5 today, so the codegen table resolves aliases
+// order-independently and must keep doing so. Pins that.
+fn forward_aliased() -> DeclaredLater {
+  2.5
+}
+
+type DeclaredLater = Double
+
 test "#2156 review: the shadow is scoped -- the top-level name still works" {
   // The counterpart: masking must key on the binding actually in scope, not
   // disable the table for the name everywhere it appears.
@@ -184,4 +223,23 @@ test "#2156 review: a type parameter shadows a float alias" {
   // parameter of that name shadows it -- the return is the type variable,
   // not a float. Following the alias printed 0 instead of 1.
   assert_true(__to_string(id_tp(1)) == "1")
+}
+
+test "#2166: a parameterized alias onto Double is classified" {
+  assert_true(__to_string(via_generic()) == "2.5")
+  let a = via_generic()
+  assert_true(__to_string(a) == "2.5")
+}
+
+test "#2166: a two-parameter alias selecting its first argument" {
+  assert_true(__to_string(via_pair()) == "2.5")
+}
+
+test "#2166: the f64 and f32 spellings are floats" {
+  assert_true(__to_string(as_f64()) == "2.5")
+  assert_true(__to_string(as_f32()) == "2.5")
+}
+
+test "#2166: an alias declared AFTER the function that returns it" {
+  assert_true(__to_string(forward_aliased()) == "2.5")
 }

--- a/lib/@vibe/compiler/tests/float_return_to_string_test.vibe
+++ b/lib/@vibe/compiler/tests/float_return_to_string_test.vibe
@@ -184,6 +184,20 @@ fn forward_aliased() -> DeclaredLater {
 
 type DeclaredLater = Double
 
+// #2177 review: a name declared as BOTH a `Double` alias and a struct. The
+// checker preclaims the struct and `find_typedef` is first-match-wins, so
+// `-> Collide` is the STRUCT -- the alias table must agree, or a
+// struct-returning function gets recorded as float-returning. The collector
+// therefore pushes nominal placeholders before the aliases, in the same order
+// `preclaim_local_type_defs` does.
+type Collide = Double
+
+struct Collide { value: Int } derive (Show)
+
+fn returns_struct() -> Collide {
+  Collide::{ value: 7 }
+}
+
 test "#2156 review: the shadow is scoped -- the top-level name still works" {
   // The counterpart: masking must key on the binding actually in scope, not
   // disable the table for the name everywhere it appears.
@@ -242,4 +256,10 @@ test "#2166: the f64 and f32 spellings are floats" {
 
 test "#2166: an alias declared AFTER the function that returns it" {
   assert_true(__to_string(forward_aliased()) == "2.5")
+}
+
+test "#2177 review: a struct outranks a same-named Double alias" {
+  // Renders through the Show renderer. If the alias won, `returns_struct`
+  // would be in the float table and this would render f64 bits instead.
+  assert_true(__to_string(returns_struct()) == "Collide { value: 7 }")
 }


### PR DESCRIPTION
Closes #2166.

codegen is untyped, so a call to a `-> Double` function is just an `ECall`. `compute_float_returning_names` is the stand-in for the declared return type — without it `__to_string` falls through to a runtime bit-pattern heuristic and renders an f64 as a plausible-looking integer.

It did that by comparing the return type's **spelling** against `"Double"`/`"Float"` and walking zero-parameter `type` aliases by name. A name-keyed table structurally cannot follow `type Box[T] = T; fn f() -> Box[Double]` — that return is a `TyApp`, not a `TyName` — so `__to_string(f())` printed `384` for `2.5`, on both backends.

## The fix is to stop guessing spellings

Each declared return type now goes through the checker's `resolve_type_expr_shadowed` — the same entry point `check_stmts` uses for an `STypeAlias` body — and the answer is whether it resolves to `CtDouble`.

This is the direction #2166 asked for ("the checker's normalized return type reaching codegen ... rather than growing an ad-hoc resolver one reported shape at a time"), at the smallest scope that actually delivers it. `check_program`'s `TypeEnv` is discarded at every call site today (`let _ = check_program(stmts)`), so threading the full checker result is a spine change; calling the resolver the checker itself calls is not.

Four special cases dissolve into the resolver, **three of them previously wrong**:

| case | before | after |
|---|---|---|
| parameterized alias `Box[Double]` (#2166) | `384` | `2.5` |
| two-parameter alias `Pair[Double, Int]` | `384` | `2.5` |
| the `f64` / `f32` spellings | `192` | `2.5` |
| alias **chains** | correct, via a hand-written hop walk and step bound | transitive; walk and bound deleted |
| a type **parameter** shadowing an alias | correct, via an explicit guard | that is what `shadow` is for; guard deleted |

### `f64` / `f32` was not in the issue

`resolve_builtin` has always unified `Double`, `f64`, `Float` and `f32`. The name scan listed two of the four, so `fn f() -> f64 { 2.5 }` rendered `192` on both lanes. Found while measuring #2166, previously unfiled — the blind spot was wider than the issue recorded, which is the argument against patching spellings one at a time.

### One thing measured rather than inherited

The alias table is built **order-independently, deliberately unlike `check_stmts`**. The checker does not pre-claim an `STypeAlias` (a placeholder alias body would be a lie — an alias resolves *through* to its target), so a forward reference to a later alias stays unresolved there.

Measured before changing anything: `fn f() -> Later { 2.5 }` above `type Later = Double` compiles and renders `2.5` today. Inheriting the checker's statement-order limitation would have turned that into raw bits — a silent-wrong regression, the exact class this table exists to close. `n + 1` passes over `n` aliases is the acyclic maximum; `n` is single digits per compilation unit (32 aliases in all of `lib/`), so the quadratic pass count costs nothing.

## The new package edge

`codegen/common_analysis` now imports `@vibe/compiler/checker`. `checker_resolve` imports only `core`, so this pulls in no cycle and no weight, and `resolve_type_expr_shadowed` was already in the checker's public contract.

The gate caught the missing declaration — `compiler_gate.sh` step 60 failed with `import of @vibe/compiler/checker not declared in deps` before `index.vpkg` was updated. Working as intended.

## Verification

Every shape measured on **both lanes**, before and after, against a stage2 built from this tree (not the seed):

| shape | lin/before | lin/after | gc/before | gc/after |
|---|---|---|---|---|
| parameterized alias | FAIL | ok | FAIL | ok |
| two-param alias | FAIL | ok | FAIL | ok |
| `f64` / `f32` | FAIL | ok | FAIL | ok |
| zero-param alias | ok | ok | ok | ok |
| forward alias | ok | ok | ok | ok |
| direct `Double` / `Float` | ok | ok | ok | ok |

- **stage2 == stage3 FIXPOINT_OK**
- `compiler_gate.sh` → **104/104**, 0 failures
- `unit_test_runner.sh` → **1008/1008**
- `float_return_to_string_test.vibe` → 18/18 (was 14); `fixtures/float_return_to_string_gc_test.vibe` → green on both lanes
- every new test **Red-tested** against the pre-fix compiler first

## Found while measuring, filed not fixed

A type parameter shadowing a float alias (`type D = Double; fn id[D](x: D) -> D`) renders `id_tp(1)` as `0` on the **wasm-gc** lane. Measured identical before and after this change, so it is pre-existing and unrelated — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_