### PR TITLE
Key compiler-probing gates on bootstrap seed

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -33,8 +33,8 @@ local scriptSources: Listing<String> = new {
   "scripts/**/*.vibex"
 }
 
-// Inputs shared by the cached release gates below whose verdict comes from the
-// checkout compiler. `vibeSources` covers the selfhost source, while the seed manifest selects the
+// Inputs shared by cached tasks whose verdict can come from the checkout
+// compiler. `vibeSources` covers the selfhost source, while the seed manifest selects the
 // bootstrap compiler that builds stage2. Omitting either can replay a cached
 // pass for a different compiler (#2165).
 local compilerProbeInputs: Listing<String> = new {
@@ -48,7 +48,10 @@ local compilerProbeInputs: Listing<String> = new {
 local function scriptTask(taskName: String, script: String): Task = new Task {
   name = taskName
   cmd = "bash \(script)"
-  inputs { ...vibeSources; ...scriptSources }
+  // Some wrappers reach the compiler indirectly. Keying the shared factory on
+  // the complete compiler identity is a safe over-approximation and prevents
+  // those dynamic calls from bypassing the hand-written-task ratchet (#2165).
+  inputs { ...compilerProbeInputs; ...scriptSources }
 }
 
 // === Quick Commands ===

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -33,8 +33,8 @@ local scriptSources: Listing<String> = new {
   "scripts/**/*.vibex"
 }
 
-// Inputs shared by every gate whose verdict comes from the checkout compiler.
-// `vibeSources` covers the selfhost source, while the seed manifest selects the
+// Inputs shared by the cached release gates below whose verdict comes from the
+// checkout compiler. `vibeSources` covers the selfhost source, while the seed manifest selects the
 // bootstrap compiler that builds stage2. Omitting either can replay a cached
 // pass for a different compiler (#2165).
 local compilerProbeInputs: Listing<String> = new {

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -33,6 +33,15 @@ local scriptSources: Listing<String> = new {
   "scripts/**/*.vibex"
 }
 
+// Inputs shared by every gate whose verdict comes from the checkout compiler.
+// `vibeSources` covers the selfhost source, while the seed manifest selects the
+// bootstrap compiler that builds stage2. Omitting either can replay a cached
+// pass for a different compiler (#2165).
+local compilerProbeInputs: Listing<String> = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+
 // --- Helper factories ---
 
 /// Single-script wrapper — common pattern.
@@ -404,14 +413,8 @@ local checkBookSkipBlocks = new Task {
   // out of scriptTask, one level up.
   inputs {
     ...scriptSources
-    ...vibeSources
+    ...compilerProbeInputs
     "book/**/*.md"
-    // vibeSources is lib/** only, so a SEED-ONLY bootstrap bump changes the
-    // stage2 selfhostGeneration builds while leaving this key untouched, and
-    // the previous verdict replays against a compiler that no longer exists
-    // (#2156 review). The sibling compiler-probing gates share this gap --
-    // filed as #2165 rather than changing their caching from this PR.
-    "bootstrap/seed.json"
   }
   // Same reason as check-rc-default and check-package-sibling-scope: the
   // verdict is the current compiler's, so the current compiler has to exist
@@ -481,7 +484,7 @@ local checkRcDefault = new Task {
   description = "the compiler's linear default backend, and the document that names it, agree"
   cmd = "bash scripts/check_rc_default.sh"
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     ...scriptSources
     "docs/spec/rc-cutover-readiness.md"
   }
@@ -528,7 +531,7 @@ local checkPackageSiblingScope = new Task {
   name = "check-package-sibling-scope"
   description = "export + contract entry + explicit ./import are all required to reach a sibling"
   cmd = "bash scripts/check_package_sibling_scope.sh"
-  inputs { ...vibeSources; ...scriptSources }
+  inputs { ...compilerProbeInputs; ...scriptSources }
   // Same reason as check-cheatsheet-signatures: the verdicts are the current
   // compiler's, so it has to be the current compiler that answers.
   deps { selfhostGeneration }
@@ -548,7 +551,7 @@ local checkCheatsheetSignatures = new Task {
   // tables without touching these three files would have replayed the old
   // verdict -- the compiler-side drift this task exists to catch, passing.
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     ...scriptSources
     "docs/cheatsheet.md"
     "scripts/cheatsheet_signature_probe.vibe"

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -842,14 +842,14 @@ local buildReleaseAssets = new Task {
   name = "build-release-assets"
   cmd = "bash scripts/build_release_assets.sh $@"
   acceptsArgs = true
-  inputs { ...vibeSources; ...scriptSources }
+  inputs { ...compilerProbeInputs; ...scriptSources }
 }
 
 local releaseTagPreflight = new Task {
   name = "release-tag-preflight"
   cmd = "bash scripts/build_release_assets.sh $@"
   acceptsArgs = true
-  inputs { ...vibeSources; ...scriptSources }
+  inputs { ...compilerProbeInputs; ...scriptSources }
 }
 
 local fetchCompiler = new Task {

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -167,10 +167,10 @@ local testCoverageDriverExposure = new Task {
   name = "test-coverage-driver-exposure"
   description = "exact-path coverage-driver exposure positive/negative integration test"
   cmd = "bash tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh"
-  // Runs a wrapper under tests/gates/** that invokes the compiler, so lib/**
-  // is part of the answer (#2138 review).
+  // Runs a wrapper under tests/gates/** that invokes the compiler, so the
+  // compiler identity is part of the answer (#2138 review, #2165).
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     "tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh"
     "scripts/coverage/cov_units.vibe"
     "lib/@vibe/compiler/cli_adapter.vibe"
@@ -351,13 +351,13 @@ local checkFreezeSurface = new Task {
   description = "the frozen surface list resolves, and matches the cheatsheet's Key Builtins"
   cmd = "bash scripts/check_freeze_surface.sh"
   // ADDITIVE, not a replacement: this gate asks the COMPILER whether every
-  // promised symbol still resolves, so lib/** is half the question. Swapping
-  // the default inputs for the documents alone would let a rename under
-  // lib/**/*.vibe drop a frozen builtin behind a cached pass -- the same
+  // promised symbol still resolves, so the compiler identity is half the
+  // question. Swapping the default inputs for the documents alone would let a
+  // compiler change drop a frozen builtin behind a cached pass -- the same
   // under-invalidation as the doc-only case, pointed the other way. Inputs may
   // over-approximate (a needless re-run is free); they may never under-.
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     ...scriptSources
     "docs/spec/stable-surface.md"
     "docs/cheatsheet.md"
@@ -501,7 +501,7 @@ local checkDocCommands = new Task {
   // were reported as unread -- the gate failing loudly rather than passing
   // vacuously, but wrong either way.
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     ...scriptSources
     "Taskfile.pkl"
     "*.md"
@@ -509,7 +509,7 @@ local checkDocCommands = new Task {
     "book/**/*.md"
     // Every README in the tree, wherever it lives -- the gate now scans them
     // all (#2138 review), so lib/@vibe/compiler/README.md going stale must
-    // invalidate this task the same way docs/ does. ...vibeSources covers
+    // invalidate this task the same way docs/ does. compilerProbeInputs covers
     // lib/**/*.vibe but not lib/**/README.md.
     "**/README.md"
     // The launcher IS the verb list: the gate parses `vibe help` and the
@@ -701,10 +701,10 @@ local testCoverageScripts = new Task {
   name = "test-coverage-scripts"
   cmd =
     "node --test scripts/coverage_suite_next_branches.test.mjs scripts/select_test_shard.test.mjs && python3 scripts/coverage_suite_report_test.py && python3 scripts/coverage_tracks_test.py && bash scripts/coverage_wasm_std_test.sh && bash tests/gates/tooling-accounting/coverage/coverage_drivers_test.sh && bash tests/gates/tooling-accounting/coverage/coverage_pipeline_contract_test.sh"
-  // Runs a wrapper under tests/gates/** that invokes the compiler, so lib/**
-  // is part of the answer (#2138 review).
+  // Runs a wrapper under tests/gates/** that invokes the compiler, so the
+  // compiler identity is part of the answer (#2138 review, #2165).
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     "scripts/**/*.mjs"
     "scripts/coverage_suite_report.py"
     "scripts/coverage_suite_report_test.py"
@@ -743,7 +743,7 @@ local testInstallHelloSmoke = new Task {
   // program instead of reading it; leaving either side out of the cache key
   // undoes that fix invisibly.
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     ...scriptSources
     "README.md"
     "docs/install.md"
@@ -828,7 +828,7 @@ local ciSelfhostGatesShard = new Task {
   name = "ci-gates-shard"
   cmd = "bash scripts/pkfire/gates_shard.sh $@"
   acceptsArgs = true
-  inputs { ...vibeSources; ...scriptSources }
+  inputs { ...compilerProbeInputs; ...scriptSources }
 }
 
 local ciSelfhostExamplesSmoke = scriptTask("ci-examples-smoke", "scripts/pkfire/examples_smoke.sh")
@@ -958,7 +958,7 @@ local coverageSelfhostSuiteBranch = new Task {
   name = "coverage-suite-branch"
   cmd =
     #"VIBE_SUITE_COVERAGE_DIR=_build/coverage/selfhost-suite-branch VIBE_SUITE_EXTRA_ENTRIES="$(node scripts/coverage_suite_next_branches.mjs --preset branch --format env)" scripts/coverage_suite.sh"#
-  inputs { ...vibeSources; ...scriptSources }
+  inputs { ...compilerProbeInputs; ...scriptSources }
   deps { selfhostGeneration }
 }
 
@@ -967,7 +967,7 @@ local coverageSelfhostSuiteBranchGate = new Task {
   cmd =
     #"VIBE_SUITE_COVERAGE_DIR=_build/coverage/selfhost-suite-branch VIBE_SUITE_EXTRA_ENTRIES="$(node scripts/coverage_suite_next_branches.mjs --preset branch --format env)" VIBE_SUITE_MIN_POINT_RATE="${1:-40}" VIBE_SUITE_MIN_LINE_RATE="${2:-93}" VIBE_SUITE_MIN_BRANCH_RATE="${3:-33}" scripts/coverage_suite.sh"#
   acceptsArgs = true
-  inputs { ...vibeSources; ...scriptSources }
+  inputs { ...compilerProbeInputs; ...scriptSources }
   deps { selfhostGeneration }
 }
 

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -89,10 +89,20 @@ AGGREGATOR_RE = re.compile(
     r"scripts/(?:compiler_gate\.sh|unit_test_runner\.sh|pkfire/gates_shard\.sh|"
     r"test_affected\.sh|coverage_suite\.sh|coverage_corpus\.sh)")
 # The line must also look like it is RUNNING something.
-EXEC_RE = re.compile(r"\b(bash|sh|env|exec|node|spawnSync|spawn|execSync|execFileSync)\b")
+EXEC_RE = re.compile(
+    r"(?:^|[;&|(\s])(?:bash|sh|env|exec|node|spawnSync|spawn|execSync|execFileSync)(?=\s|\()"
+)
 COMMENT_RE = re.compile(r"^\s*(#|//|\*)")
+SEED_RE = re.compile(r"bootstrap/seed(?:\.json|/compiler\.wasm)")
+SCRIPT_PATH_RE = re.compile(r"((?:scripts|tests|eval|bench)/[A-Za-z0-9_./-]+\.(?:sh|mjs))")
+SCRIPT_BASENAME_RE = re.compile(r"([A-Za-z0-9_.-]+\.(?:sh|mjs))")
 
-def reaches_compiler(script):
+def reaches_compiler(script, seen=None):
+    seen = set() if seen is None else seen
+    # A checker must not certify itself from regex literals or test fixtures.
+    if os.path.normpath(script) == "scripts/check_task_inputs.sh" or script in seen:
+        return False
+    seen.add(script)
     try:
         lines = open(script, encoding="utf-8", errors="replace").read().split("\n")
     except OSError:
@@ -100,8 +110,15 @@ def reaches_compiler(script):
     for line in lines:
         if COMMENT_RE.match(line):
             continue
-        if TOOL_RE.search(line) and EXEC_RE.search(line):
+        if SEED_RE.search(line) or (TOOL_RE.search(line) and EXEC_RE.search(line)):
             return True
+        if not EXEC_RE.search(line):
+            continue
+        nested = SCRIPT_PATH_RE.findall(line)
+        nested += [os.path.join(os.path.dirname(script), name) for name in SCRIPT_BASENAME_RE.findall(line)]
+        for child in nested:
+            if child != script and (AGGREGATOR_RE.search(child) or reaches_compiler(child, seen)):
+                return True
     return False
 
 # Hand-written `new Task { ... }` blocks only; scriptTask() one-liners inherit
@@ -133,7 +150,7 @@ for m in re.finditer(r"new Task \{", src):
     # a self-test whose command touches nothing.
     cmd_m = re.search(r'cmd\s*=\s*(#?)"(.*?)"\1', block, re.S)
     cmd = cmd_m.group(2) if cmd_m else ""
-    scripts = re.findall(r'((?:scripts|tests|eval|bench)/[A-Za-z0-9_./-]+\.(?:sh|mjs))', cmd)
+    scripts = SCRIPT_PATH_RE.findall(cmd)
     hot = [s for s in scripts if AGGREGATOR_RE.search(s) or reaches_compiler(s)]
     if not hot:
         continue

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -13,7 +13,8 @@
 # under-approximate (that costs a wrong answer).
 #
 # The rule: if a task's command reaches the compiler, its inputs must include
-# `vibeSources`, or it must set `cache = false`.
+# `vibeSources` directly or through `compilerProbeInputs`, or it must set
+# `cache = false`.
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
@@ -24,6 +25,19 @@ import re, sys, os
 # Overridable so the self-test can drive synthetic task blocks.
 TASKFILE = os.environ.get("TASK_INPUTS_TASKFILE", "Taskfile.pkl")
 src = open(TASKFILE, encoding="utf-8").read()
+
+# The shared compiler-probe input set is safe only while it contains both
+# halves of the compiler identity: selfhost sources and the bootstrap seed.
+probe_inputs_m = re.search(
+    r"local\s+compilerProbeInputs(?:\s*:[^=]+)?\s*=\s*new\s*\{(.*?)\}",
+    src,
+    re.S,
+)
+probe_inputs_safe = bool(
+    probe_inputs_m
+    and "vibeSources" in probe_inputs_m.group(1)
+    and '"bootstrap/seed.json"' in probe_inputs_m.group(1)
+)
 
 # A script "reaches the compiler" when it EXECUTES one of these, not when it
 # mentions one. A first cut matched any occurrence of `stage2` and flagged six
@@ -99,8 +113,11 @@ for m in re.finditer(r"new Task \{", src):
     if not hot:
         continue
     checked += 1
-    if "vibeSources" not in block:
-        why = "declares no `inputs` at all" if "inputs" not in block else "does not include `...vibeSources`"
+    has_compiler_inputs = "vibeSources" in block or (
+        "compilerProbeInputs" in block and probe_inputs_safe
+    )
+    if not has_compiler_inputs:
+        why = "declares no `inputs` at all" if "inputs" not in block else "does not include a complete compiler input set"
         fails.append((name, hot[0], why))
 
 for name, script, why in fails:
@@ -108,11 +125,11 @@ for name, script, why in fails:
           file=sys.stderr)
     print(f"  but it {why} and does not set `cache = false`. A change under", file=sys.stderr)
     print("  lib/**/*.vibe would replay a cached pass.", file=sys.stderr)
-    print("  Add `...vibeSources` to the list -- spelling inputs out should ADD to the",
+    print("  Add `...vibeSources` or `...compilerProbeInputs` to the list -- spelling inputs out should ADD to the",
           file=sys.stderr)
     print("  defaults, not replace them.", file=sys.stderr)
 
 if fails:
     sys.exit(1)
-print(f"check-task-inputs: ok ({checked} compiler-touching tasks with explicit inputs all key on lib/**)")
+print(f"check-task-inputs: ok ({checked} compiler-touching tasks with explicit inputs all key on compiler sources)")
 PY

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -147,7 +147,8 @@ for m in re.finditer(r"new Task \{", src):
             if depth == 0: break
         k += 1
     block = src[start:k + 1]
-    name_m = re.search(r'name\s*=\s*"([^"]+)"', block)
+    active_block = active_pkl(block)
+    name_m = re.search(r'name\s*=\s*"([^"]+)"', active_block)
     if not name_m:
         continue
     name = name_m.group(1)
@@ -155,21 +156,24 @@ for m in re.finditer(r"new Task \{", src):
     # worst case, not the safe one: an empty cache key replays the first result
     # after any change (#2138 review). `scriptTask` one-liners are excluded
     # above precisely because they DO inherit the defaults.
-    if re.search(r"cache\s*=\s*false", block):
+    if re.search(r"cache\s*=\s*false", active_block):
         continue
     # From the COMMAND only. Reading the whole block also picked up scripts
     # named in `inputs`, which a task declares but does not run -- that flagged
     # a self-test whose command touches nothing.
-    cmd_m = re.search(r'cmd\s*=\s*(#?)"(.*?)"\1', block, re.S)
+    cmd_m = re.search(r'cmd\s*=\s*(#?)"(.*?)"\1', active_block, re.S)
     cmd = cmd_m.group(2) if cmd_m else ""
     scripts = SCRIPT_PATH_RE.findall(cmd)
     hot = [s for s in scripts if AGGREGATOR_RE.search(s) or reaches_compiler(s)]
     if not hot:
         continue
     checked += 1
-    has_compiler_inputs = "compilerProbeInputs" in active_pkl(block) and probe_inputs_safe
+    inputs_m = re.search(r"inputs\s*\{(.*?)\}", active_block, re.S)
+    has_compiler_inputs = bool(
+        inputs_m and "compilerProbeInputs" in inputs_m.group(1) and probe_inputs_safe
+    )
     if not has_compiler_inputs:
-        why = "declares no `inputs` at all" if "inputs" not in block else "does not include a complete compiler input set"
+        why = "declares no `inputs` at all" if not inputs_m else "does not include a complete compiler input set"
         fails.append((name, hot[0], why))
 
 for name, script, why in fails:

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -28,8 +28,54 @@ INPUT_ROOT = os.environ.get("TASK_INPUTS_ROOT", ".")
 src = open(TASKFILE, encoding="utf-8").read()
 
 def active_pkl(text):
-    """Drop Pkl line comments before checking whether an input is active."""
-    return re.sub(r"//.*$", "", text, flags=re.M)
+    """Drop Pkl comments without treating comment markers in strings as syntax."""
+    out = []
+    i = 0
+    string_hashes = None
+    while i < len(text):
+        if string_hashes is not None:
+            close = '"' + ('#' * string_hashes)
+            if text.startswith(close, i):
+                out.append(close)
+                i += len(close)
+                string_hashes = None
+            elif string_hashes == 0 and text[i] == "\\" and i + 1 < len(text):
+                out.append(text[i:i + 2])
+                i += 2
+            else:
+                out.append(text[i])
+                i += 1
+            continue
+        if text.startswith("//", i):
+            newline = text.find("\n", i + 2)
+            if newline < 0:
+                break
+            out.append("\n")
+            i = newline + 1
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            comment = text[i + 2:] if end < 0 else text[i + 2:end]
+            out.append("\n" * comment.count("\n"))
+            i = len(text) if end < 0 else end + 2
+            continue
+        if text[i] == '"':
+            out.append('"')
+            string_hashes = 0
+            i += 1
+            continue
+        if text[i] == "#":
+            j = i
+            while j < len(text) and text[j] == "#":
+                j += 1
+            if j < len(text) and text[j] == '"':
+                out.append(text[i:j + 1])
+                string_hashes = j - i
+                i = j + 1
+                continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
 
 def has_spread(body, name):
     return bool(re.search(r"\.\.\.\s*" + re.escape(name) + r"\b", body))

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -26,6 +26,10 @@ import re, sys, os
 TASKFILE = os.environ.get("TASK_INPUTS_TASKFILE", "Taskfile.pkl")
 src = open(TASKFILE, encoding="utf-8").read()
 
+def active_pkl(text):
+    """Drop Pkl line comments before checking whether an input is active."""
+    return re.sub(r"//.*$", "", text, flags=re.M)
+
 # The shared compiler-probe input set is safe only while it contains both
 # halves of the compiler identity: selfhost sources and the bootstrap seed.
 probe_inputs_m = re.search(
@@ -33,10 +37,11 @@ probe_inputs_m = re.search(
     src,
     re.S,
 )
+probe_inputs_body = active_pkl(probe_inputs_m.group(1)) if probe_inputs_m else ""
 probe_inputs_safe = bool(
     probe_inputs_m
-    and "vibeSources" in probe_inputs_m.group(1)
-    and '"bootstrap/seed.json"' in probe_inputs_m.group(1)
+    and "vibeSources" in probe_inputs_body
+    and '"bootstrap/seed.json"' in probe_inputs_body
 )
 
 # scriptTask wrappers are deliberately classified as a group: some execute the
@@ -57,9 +62,10 @@ if script_task_decl:
         end += 1
     factory_block = src[brace : end + 1] if brace >= 0 and depth == 0 else ""
     script_task_inputs = re.search(r"inputs\s*\{(.*?)\}", factory_block, re.S)
+script_task_inputs_body = active_pkl(script_task_inputs.group(1)) if script_task_inputs else ""
 script_task_safe = bool(
     script_task_inputs
-    and "compilerProbeInputs" in script_task_inputs.group(1)
+    and "compilerProbeInputs" in script_task_inputs_body
     and probe_inputs_safe
 )
 script_task_bad = bool(script_task_decl and not script_task_safe)
@@ -155,7 +161,7 @@ for m in re.finditer(r"new Task \{", src):
     if not hot:
         continue
     checked += 1
-    has_compiler_inputs = "compilerProbeInputs" in block and probe_inputs_safe
+    has_compiler_inputs = "compilerProbeInputs" in active_pkl(block) and probe_inputs_safe
     if not has_compiler_inputs:
         why = "declares no `inputs` at all" if "inputs" not in block else "does not include a complete compiler input set"
         fails.append((name, hot[0], why))

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -24,6 +24,7 @@ import re, sys, os
 
 # Overridable so the self-test can drive synthetic task blocks.
 TASKFILE = os.environ.get("TASK_INPUTS_TASKFILE", "Taskfile.pkl")
+INPUT_ROOT = os.environ.get("TASK_INPUTS_ROOT", ".")
 src = open(TASKFILE, encoding="utf-8").read()
 
 def active_pkl(text):
@@ -102,6 +103,10 @@ COMMENT_RE = re.compile(r"^\s*(#|//|\*)")
 SEED_RE = re.compile(r"bootstrap/seed(?:\.json|/compiler\.wasm)")
 SCRIPT_PATH_RE = re.compile(r"((?:scripts|tests|eval|bench)/[A-Za-z0-9_./-]+\.(?:sh|mjs))")
 SCRIPT_BASENAME_RE = re.compile(r"([A-Za-z0-9_.-]+\.(?:sh|mjs))")
+DIRECT_SCRIPT_RE = re.compile(
+    r'(?:^|[;&|!(])\s*"?(?:\./|\.\./|\$[A-Za-z_][A-Za-z0-9_]*/|scripts/|tests/|eval/|bench/)'
+    r'[^"\s;|]+\.(?:sh|mjs)(?=["\s;|)]|$)'
+)
 
 def reaches_compiler(script, seen=None):
     seen = set() if seen is None else seen
@@ -110,7 +115,8 @@ def reaches_compiler(script, seen=None):
         return False
     seen.add(script)
     try:
-        lines = open(script, encoding="utf-8", errors="replace").read().split("\n")
+        path = os.path.join(INPUT_ROOT, script)
+        lines = open(path, encoding="utf-8", errors="replace").read().split("\n")
     except OSError:
         return False
     for line in lines:
@@ -118,7 +124,7 @@ def reaches_compiler(script, seen=None):
             continue
         if SEED_RE.search(line) or (TOOL_RE.search(line) and EXEC_RE.search(line)):
             return True
-        if not EXEC_RE.search(line):
+        if not EXEC_RE.search(line) and not DIRECT_SCRIPT_RE.search(line):
             continue
         nested = SCRIPT_PATH_RE.findall(line)
         nested += [os.path.join(os.path.dirname(script), name) for name in SCRIPT_BASENAME_RE.findall(line)]

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -39,6 +39,17 @@ probe_inputs_safe = bool(
     and '"bootstrap/seed.json"' in probe_inputs_m.group(1)
 )
 
+# scriptTask wrappers are deliberately classified as a group: some execute the
+# compiler through several shell layers, which text inspection cannot prove
+# individually. The shared factory must therefore carry the complete identity.
+script_task_m = re.search(
+    r"local\s+function\s+scriptTask\b.*?inputs\s*\{(.*?)\}", src, re.S
+)
+script_task_safe = bool(
+    script_task_m and "compilerProbeInputs" in script_task_m.group(1) and probe_inputs_safe
+)
+script_task_bad = bool(script_task_m and not script_task_safe)
+
 # A script "reaches the compiler" when it EXECUTES one of these, not when it
 # mentions one. A first cut matched any occurrence of `stage2` and flagged six
 # tasks that were fine: the word appears in a comment, in a JSON key
@@ -80,7 +91,7 @@ def reaches_compiler(script):
     return False
 
 # Hand-written `new Task { ... }` blocks only; scriptTask() one-liners inherit
-# the safe defaults.
+# the complete compiler identity checked above.
 fails = []
 checked = 0
 for m in re.finditer(r"new Task \{", src):
@@ -127,7 +138,12 @@ for name, script, why in fails:
           file=sys.stderr)
     print("  defaults, not replace them.", file=sys.stderr)
 
-if fails:
+if script_task_bad:
+    print("check-task-inputs: FAIL: scriptTask inputs do not include the complete", file=sys.stderr)
+    print("  `...compilerProbeInputs` set; indirect compiler wrappers can replay", file=sys.stderr)
+    print("  a cached pass after a bootstrap seed change.", file=sys.stderr)
+
+if fails or script_task_bad:
     sys.exit(1)
-print(f"check-task-inputs: ok ({checked} compiler-touching tasks with explicit inputs all key on compiler sources)")
+print(f"check-task-inputs: ok ({checked} compiler-touching tasks with explicit inputs and scriptTask all key on compiler sources)")
 PY

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -77,8 +77,46 @@ def active_pkl(text):
         i += 1
     return "".join(out)
 
+def pkl_syntax_only(text):
+    """Mask Pkl strings so path values cannot satisfy syntax-token checks."""
+    out = []
+    i = 0
+    string_hashes = None
+    while i < len(text):
+        if string_hashes is not None:
+            close = '"' + ('#' * string_hashes)
+            if text.startswith(close, i):
+                out.append(" " * len(close))
+                i += len(close)
+                string_hashes = None
+            elif string_hashes == 0 and text[i] == "\\" and i + 1 < len(text):
+                out.append("  ")
+                i += 2
+            else:
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            continue
+        if text[i] == '"':
+            out.append(" ")
+            string_hashes = 0
+            i += 1
+            continue
+        if text[i] == "#":
+            j = i
+            while j < len(text) and text[j] == "#":
+                j += 1
+            if j < len(text) and text[j] == '"':
+                out.append(" " * (j + 1 - i))
+                string_hashes = j - i
+                i = j + 1
+                continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
 def has_spread(body, name):
-    return bool(re.search(r"\.\.\.\s*" + re.escape(name) + r"\b", body))
+    syntax = pkl_syntax_only(body)
+    return bool(re.search(r"\.\.\.\s*" + re.escape(name) + r"\b", syntax))
 
 # The shared compiler-probe input set is safe only while it contains both
 # halves of the compiler identity: selfhost sources and the bootstrap seed.

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -12,9 +12,9 @@
 # over-approximate (a needless re-run costs time); they may never
 # under-approximate (that costs a wrong answer).
 #
-# The rule: if a task's command reaches the compiler, its inputs must include
-# `vibeSources` directly or through `compilerProbeInputs`, or it must set
-# `cache = false`.
+# The rule: if a cached task's command reaches the compiler, its inputs must
+# include `compilerProbeInputs` (selfhost sources + bootstrap seed), or it must
+# set `cache = false`.
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
@@ -113,9 +113,7 @@ for m in re.finditer(r"new Task \{", src):
     if not hot:
         continue
     checked += 1
-    has_compiler_inputs = "vibeSources" in block or (
-        "compilerProbeInputs" in block and probe_inputs_safe
-    )
+    has_compiler_inputs = "compilerProbeInputs" in block and probe_inputs_safe
     if not has_compiler_inputs:
         why = "declares no `inputs` at all" if "inputs" not in block else "does not include a complete compiler input set"
         fails.append((name, hot[0], why))
@@ -123,9 +121,9 @@ for m in re.finditer(r"new Task \{", src):
 for name, script, why in fails:
     print(f"check-task-inputs: FAIL: task `{name}` runs {script}, which reaches the compiler,",
           file=sys.stderr)
-    print(f"  but it {why} and does not set `cache = false`. A change under", file=sys.stderr)
-    print("  lib/**/*.vibe would replay a cached pass.", file=sys.stderr)
-    print("  Add `...vibeSources` or `...compilerProbeInputs` to the list -- spelling inputs out should ADD to the",
+    print(f"  but it {why} and does not set `cache = false`. A compiler identity", file=sys.stderr)
+    print("  change would replay a cached pass.", file=sys.stderr)
+    print("  Add `...compilerProbeInputs` to the list -- spelling inputs out should ADD to the",
           file=sys.stderr)
     print("  defaults, not replace them.", file=sys.stderr)
 

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -31,6 +31,9 @@ def active_pkl(text):
     """Drop Pkl line comments before checking whether an input is active."""
     return re.sub(r"//.*$", "", text, flags=re.M)
 
+def has_spread(body, name):
+    return bool(re.search(r"\.\.\.\s*" + re.escape(name) + r"\b", body))
+
 # The shared compiler-probe input set is safe only while it contains both
 # halves of the compiler identity: selfhost sources and the bootstrap seed.
 probe_inputs_m = re.search(
@@ -41,7 +44,7 @@ probe_inputs_m = re.search(
 probe_inputs_body = active_pkl(probe_inputs_m.group(1)) if probe_inputs_m else ""
 probe_inputs_safe = bool(
     probe_inputs_m
-    and "vibeSources" in probe_inputs_body
+    and has_spread(probe_inputs_body, "vibeSources")
     and '"bootstrap/seed.json"' in probe_inputs_body
 )
 
@@ -66,7 +69,7 @@ if script_task_decl:
 script_task_inputs_body = active_pkl(script_task_inputs.group(1)) if script_task_inputs else ""
 script_task_safe = bool(
     script_task_inputs
-    and "compilerProbeInputs" in script_task_inputs_body
+    and has_spread(script_task_inputs_body, "compilerProbeInputs")
     and probe_inputs_safe
 )
 script_task_bad = bool(script_task_decl and not script_task_safe)
@@ -170,7 +173,7 @@ for m in re.finditer(r"new Task \{", src):
     checked += 1
     inputs_m = re.search(r"inputs\s*\{(.*?)\}", active_block, re.S)
     has_compiler_inputs = bool(
-        inputs_m and "compilerProbeInputs" in inputs_m.group(1) and probe_inputs_safe
+        inputs_m and has_spread(inputs_m.group(1), "compilerProbeInputs") and probe_inputs_safe
     )
     if not has_compiler_inputs:
         why = "declares no `inputs` at all" if not inputs_m else "does not include a complete compiler input set"

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -102,6 +102,7 @@ AGGREGATOR_RE = re.compile(
 EXEC_RE = re.compile(
     r"(?:^|[;&|(\s])(?:bash|sh|env|exec|node|spawnSync|spawn|execSync|execFileSync)(?=\s|\()"
 )
+SOURCE_RE = re.compile(r"(?:^|[;&|(\s])(?:source|\.)\s+")
 COMMENT_RE = re.compile(r"^\s*(#|//|\*)")
 SEED_RE = re.compile(r"bootstrap/seed(?:\.json|/compiler\.wasm)")
 SCRIPT_PATH_RE = re.compile(r"((?:scripts|tests|eval|bench)/[A-Za-z0-9_./-]+\.(?:sh|mjs))")
@@ -127,7 +128,7 @@ def reaches_compiler(script, seen=None):
             continue
         if SEED_RE.search(line) or (TOOL_RE.search(line) and EXEC_RE.search(line)):
             return True
-        if not EXEC_RE.search(line) and not DIRECT_SCRIPT_RE.search(line):
+        if not EXEC_RE.search(line) and not DIRECT_SCRIPT_RE.search(line) and not SOURCE_RE.search(line):
             continue
         nested = SCRIPT_PATH_RE.findall(line)
         nested += [os.path.join(os.path.dirname(script), name) for name in SCRIPT_BASENAME_RE.findall(line)]

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -42,13 +42,27 @@ probe_inputs_safe = bool(
 # scriptTask wrappers are deliberately classified as a group: some execute the
 # compiler through several shell layers, which text inspection cannot prove
 # individually. The shared factory must therefore carry the complete identity.
-script_task_m = re.search(
-    r"local\s+function\s+scriptTask\b.*?inputs\s*\{(.*?)\}", src, re.S
-)
+script_task_decl = re.search(r"local\s+function\s+scriptTask\b", src)
+script_task_inputs = None
+if script_task_decl:
+    brace = src.find("{", script_task_decl.end())
+    depth, end = 0, brace
+    while brace >= 0 and end < len(src):
+        if src[end] == "{":
+            depth += 1
+        elif src[end] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        end += 1
+    factory_block = src[brace : end + 1] if brace >= 0 and depth == 0 else ""
+    script_task_inputs = re.search(r"inputs\s*\{(.*?)\}", factory_block, re.S)
 script_task_safe = bool(
-    script_task_m and "compilerProbeInputs" in script_task_m.group(1) and probe_inputs_safe
+    script_task_inputs
+    and "compilerProbeInputs" in script_task_inputs.group(1)
+    and probe_inputs_safe
 )
-script_task_bad = bool(script_task_m and not script_task_safe)
+script_task_bad = bool(script_task_decl and not script_task_safe)
 
 # A script "reaches the compiler" when it EXECUTES one of these, not when it
 # mentions one. A first cut matched any occurrence of `stage2` and flagged six

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -118,14 +118,16 @@ def has_spread(body, name):
     syntax = pkl_syntax_only(body)
     return bool(re.search(r"\.\.\.\s*" + re.escape(name) + r"\b", syntax))
 
+active_src = active_pkl(src)
+
 # The shared compiler-probe input set is safe only while it contains both
 # halves of the compiler identity: selfhost sources and the bootstrap seed.
 probe_inputs_m = re.search(
     r"local\s+compilerProbeInputs(?:\s*:[^=]+)?\s*=\s*new\s*\{(.*?)\}",
-    src,
+    active_src,
     re.S,
 )
-probe_inputs_body = active_pkl(probe_inputs_m.group(1)) if probe_inputs_m else ""
+probe_inputs_body = probe_inputs_m.group(1) if probe_inputs_m else ""
 probe_inputs_safe = bool(
     probe_inputs_m
     and has_spread(probe_inputs_body, "vibeSources")
@@ -135,22 +137,22 @@ probe_inputs_safe = bool(
 # scriptTask wrappers are deliberately classified as a group: some execute the
 # compiler through several shell layers, which text inspection cannot prove
 # individually. The shared factory must therefore carry the complete identity.
-script_task_decl = re.search(r"local\s+function\s+scriptTask\b", src)
+script_task_decl = re.search(r"local\s+function\s+scriptTask\b", active_src)
 script_task_inputs = None
 if script_task_decl:
-    brace = src.find("{", script_task_decl.end())
+    brace = active_src.find("{", script_task_decl.end())
     depth, end = 0, brace
-    while brace >= 0 and end < len(src):
-        if src[end] == "{":
+    while brace >= 0 and end < len(active_src):
+        if active_src[end] == "{":
             depth += 1
-        elif src[end] == "}":
+        elif active_src[end] == "}":
             depth -= 1
             if depth == 0:
                 break
         end += 1
-    factory_block = src[brace : end + 1] if brace >= 0 and depth == 0 else ""
+    factory_block = active_src[brace : end + 1] if brace >= 0 and depth == 0 else ""
     script_task_inputs = re.search(r"inputs\s*\{(.*?)\}", factory_block, re.S)
-script_task_inputs_body = active_pkl(script_task_inputs.group(1)) if script_task_inputs else ""
+script_task_inputs_body = script_task_inputs.group(1) if script_task_inputs else ""
 script_task_safe = bool(
     script_task_inputs
     and has_spread(script_task_inputs_body, "compilerProbeInputs")
@@ -225,16 +227,16 @@ def reaches_compiler(script, seen=None):
 # the complete compiler identity checked above.
 fails = []
 checked = 0
-for m in re.finditer(r"new Task \{", src):
+for m in re.finditer(r"new Task \{", active_src):
     start = m.start()
     depth, k = 0, start + len("new Task ") - 1
     while True:
-        if src[k] == "{": depth += 1
-        elif src[k] == "}":
+        if active_src[k] == "{": depth += 1
+        elif active_src[k] == "}":
             depth -= 1
             if depth == 0: break
         k += 1
-    block = src[start:k + 1]
+    block = active_src[start:k + 1]
     active_block = active_pkl(block)
     name_m = re.search(r'name\s*=\s*"([^"]+)"', active_block)
     if not name_m:
@@ -244,7 +246,7 @@ for m in re.finditer(r"new Task \{", src):
     # worst case, not the safe one: an empty cache key replays the first result
     # after any change (#2138 review). `scriptTask` one-liners are excluded
     # above precisely because they DO inherit the defaults.
-    if re.search(r"cache\s*=\s*false", active_block):
+    if re.search(r"cache\s*=\s*false", pkl_syntax_only(active_block)):
         continue
     # From the COMMAND only. Reading the whole block also picked up scripts
     # named in `inputs`, which a task declares but does not run -- that flagged

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -28,8 +28,8 @@ run_case "compiler task without vibeSources is rejected" 1 'local t = new Task {
   inputs { "docs/cheatsheet.md" }
 }'
 
-# The same, with vibeSources -> fine.
-run_case "compiler task with vibeSources passes" 0 'local t = new Task {
+# Selfhost sources alone omit the bootstrap compiler identity.
+run_case "compiler task with only vibeSources is rejected" 1 'local t = new Task {
   name = "probe"
   cmd = "bash scripts/check_freeze_surface.sh"
   inputs { ...vibeSources; "docs/cheatsheet.md" }
@@ -87,7 +87,7 @@ run_case "aggregator wrapper is treated as compiler-running" 1 'local t = new Ta
   inputs { "docs/cheatsheet.md" }
 }'
 
-run_case "aggregator wrapper with vibeSources passes" 0 'local t = new Task {
+run_case "aggregator wrapper with only vibeSources is rejected" 1 'local t = new Task {
   name = "probe"
   cmd = "bash scripts/compiler_gate.sh"
   inputs { ...vibeSources }

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -125,6 +125,19 @@ run_case "commented cache false does not bypass inputs" 1 'local t = new Task {
   inputs { ...vibeSources }
 }'
 
+run_case "block-commented cache false does not bypass inputs" 1 'local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  /* cache = false */
+  inputs { ...vibeSources }
+}'
+
+run_case "URL in command does not hide compiler invocation" 1 'local t = new Task {
+  name = "probe"
+  cmd = "printf https://example.invalid && bash scripts/check_freeze_surface.sh"
+  inputs { ...vibeSources }
+}'
+
 # The shared wrapper factory must not bypass the seed-aware input set.
 run_case "scriptTask with only vibeSources is rejected" 1 'local function scriptTask(taskName: String, script: String): Task = new Task {
   name = taskName
@@ -240,4 +253,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (24 cases)"
+echo "check-task-inputs-test: ok (26 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -56,6 +56,28 @@ local t = new Task {
   inputs { ...compilerProbeInputs; "docs/cheatsheet.md" }
 }'
 
+run_case "commented compilerProbeInputs source is rejected" 1 'local compilerProbeInputs = new {
+  // ...vibeSources
+  "bootstrap/seed.json"
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...compilerProbeInputs }
+}'
+
+run_case "commented task compilerProbeInputs is rejected" 1 'local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { // ...compilerProbeInputs
+    "docs/cheatsheet.md"
+  }
+}'
+
 # The shared wrapper factory must not bypass the seed-aware input set.
 run_case "scriptTask with only vibeSources is rejected" 1 'local function scriptTask(taskName: String, script: String): Task = new Task {
   name = taskName
@@ -137,4 +159,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (14 cases)"
+echo "check-task-inputs-test: ok (16 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -35,6 +35,27 @@ run_case "compiler task with vibeSources passes" 0 'local t = new Task {
   inputs { ...vibeSources; "docs/cheatsheet.md" }
 }'
 
+# Compiler-probing gates use the shared superset, which also keys on the seed.
+run_case "compiler task with complete compilerProbeInputs passes" 0 'local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...compilerProbeInputs; "docs/cheatsheet.md" }
+}'
+
+# Merely naming the helper is not enough: its seed half is part of the oracle.
+run_case "compilerProbeInputs without seed is rejected" 1 'local compilerProbeInputs = new {
+  ...vibeSources
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...compilerProbeInputs; "docs/cheatsheet.md" }
+}'
+
 # Caching off is the other legitimate answer.
 run_case "cache = false is accepted instead" 0 'local t = new Task {
   name = "probe"
@@ -81,4 +102,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (8 cases)"
+echo "check-task-inputs-test: ok (10 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -75,6 +75,16 @@ local t = new Task {
   inputs { ...compilerProbeInputs }
 }'
 
+run_case "compilerProbeInputs with spread-shaped string is rejected" 1 'local compilerProbeInputs = new {
+  "...vibeSources"
+  "bootstrap/seed.json"
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...compilerProbeInputs }
+}'
+
 run_case "commented compilerProbeInputs source is rejected" 1 'local compilerProbeInputs = new {
   // ...vibeSources
   "bootstrap/seed.json"
@@ -105,6 +115,16 @@ local t = new Task {
   name = "probe"
   cmd = "bash scripts/check_freeze_surface.sh"
   inputs { "compilerProbeInputs"; ...vibeSources }
+}'
+
+run_case "spread-shaped compilerProbeInputs string in inputs is rejected" 1 'local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { "...compilerProbeInputs"; ...vibeSources }
 }'
 
 run_case "compilerProbeInputs mentioned outside inputs is rejected" 1 'local compilerProbeInputs = new {
@@ -153,6 +173,16 @@ local function scriptTask(taskName: String, script: String): Task = new Task {
   name = taskName
   cmd = "bash \(script)"
   inputs { "compilerProbeInputs"; ...vibeSources }
+}'
+
+run_case "scriptTask with spread-shaped compilerProbeInputs string is rejected" 1 'local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+local function scriptTask(taskName: String, script: String): Task = new Task {
+  name = taskName
+  cmd = "bash \(script)"
+  inputs { "...compilerProbeInputs"; ...vibeSources }
 }'
 
 run_case "scriptTask without inputs is rejected" 1 'local function scriptTask(taskName: String, script: String): Task = new Task {
@@ -253,4 +283,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (26 cases)"
+echo "check-task-inputs-test: ok (29 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -195,6 +195,20 @@ run_tree_case "directly executed nested compiler wrapper is rejected" 1 'local t
   inputs { ...vibeSources }
 }'
 
+printf '%s\n' '#!/usr/bin/env bash' 'source scripts/inner.sh' > "$WORK/scripts/outer.sh"
+run_tree_case "source nested compiler wrapper is rejected" 1 'local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/outer.sh"
+  inputs { ...vibeSources }
+}'
+
+printf '%s\n' '#!/usr/bin/env bash' '. scripts/inner.sh' > "$WORK/scripts/outer.sh"
+run_tree_case "dot-source nested compiler wrapper is rejected" 1 'local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/outer.sh"
+  inputs { ...vibeSources }
+}'
+
 # Nested release wrappers reach the seed through another script; direct-only
 # inspection would miss this compiler identity dependency.
 run_case "nested seed wrapper with only vibeSources is rejected" 1 'local t = new Task {
@@ -226,4 +240,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (22 cases)"
+echo "check-task-inputs-test: ok (24 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -65,6 +65,16 @@ local t = new Task {
   inputs { ...compilerProbeInputs; "docs/cheatsheet.md" }
 }'
 
+run_case "compilerProbeInputs with vibeSources string is rejected" 1 'local compilerProbeInputs = new {
+  "vibeSources"
+  "bootstrap/seed.json"
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...compilerProbeInputs }
+}'
+
 run_case "commented compilerProbeInputs source is rejected" 1 'local compilerProbeInputs = new {
   // ...vibeSources
   "bootstrap/seed.json"
@@ -85,6 +95,16 @@ local t = new Task {
   inputs { // ...compilerProbeInputs
     "docs/cheatsheet.md"
   }
+}'
+
+run_case "compilerProbeInputs path string in inputs is rejected" 1 'local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { "compilerProbeInputs"; ...vibeSources }
 }'
 
 run_case "compilerProbeInputs mentioned outside inputs is rejected" 1 'local compilerProbeInputs = new {
@@ -110,6 +130,16 @@ run_case "scriptTask with only vibeSources is rejected" 1 'local function script
   name = taskName
   cmd = "bash \(script)"
   inputs { ...vibeSources; ...scriptSources }
+}'
+
+run_case "scriptTask with compilerProbeInputs string is rejected" 1 'local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+local function scriptTask(taskName: String, script: String): Task = new Task {
+  name = taskName
+  cmd = "bash \(script)"
+  inputs { "compilerProbeInputs"; ...vibeSources }
 }'
 
 run_case "scriptTask without inputs is rejected" 1 'local function scriptTask(taskName: String, script: String): Task = new Task {
@@ -196,4 +226,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (19 cases)"
+echo "check-task-inputs-test: ok (22 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -106,6 +106,14 @@ run_case "compiler task with no inputs at all is rejected" 1 'local t = new Task
   cmd = "bash scripts/check_freeze_surface.sh"
 }'
 
+# Nested release wrappers reach the seed through another script; direct-only
+# inspection would miss this compiler identity dependency.
+run_case "nested seed wrapper with only vibeSources is rejected" 1 'local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/build_release_assets.sh v0.0.0"
+  inputs { ...vibeSources; ...scriptSources }
+}'
+
 # An aggregator dispatches the lane scripts dynamically, so it contains none of
 # the tool names literally -- it has to be classified by name.
 run_case "aggregator wrapper is treated as compiler-running" 1 'local t = new Task {
@@ -129,4 +137,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (13 cases)"
+echo "check-task-inputs-test: ok (14 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -21,6 +21,15 @@ run_case() { # run_case <label> <expect-exit> <taskfile-body>
   [ "$got" = "$want" ] && note "$label" || bad "$label: expected exit $want, got $got"
 }
 
+run_tree_case() { # run_tree_case <label> <expect-exit> <taskfile-body>
+  local label="$1" want="$2" body="$3"
+  printf '%s\n' "$body" > "$WORK/Taskfile.pkl"
+  local got=0
+  TASK_INPUTS_ROOT="$WORK" TASK_INPUTS_TASKFILE="$WORK/Taskfile.pkl" \
+    bash scripts/check_task_inputs.sh >/dev/null 2>&1 || got=$?
+  [ "$got" = "$want" ] && note "$label" || bad "$label: expected exit $want, got $got"
+}
+
 # Runs the compiler, explicit inputs, no vibeSources -> the bug this exists for.
 run_case "compiler task without vibeSources is rejected" 1 'local t = new Task {
   name = "probe"
@@ -128,6 +137,16 @@ run_case "compiler task with no inputs at all is rejected" 1 'local t = new Task
   cmd = "bash scripts/check_freeze_surface.sh"
 }'
 
+# Directly executed scripts are calls too, even without a bash/node token.
+mkdir -p "$WORK/scripts"
+printf '%s\n' '#!/usr/bin/env bash' '"$SCRIPT_DIR/inner.sh"' > "$WORK/scripts/outer.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'bash scripts/vibe_run.sh sample.vibe' > "$WORK/scripts/inner.sh"
+run_tree_case "directly executed nested compiler wrapper is rejected" 1 'local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/outer.sh"
+  inputs { ...vibeSources }
+}'
+
 # Nested release wrappers reach the seed through another script; direct-only
 # inspection would miss this compiler identity dependency.
 run_case "nested seed wrapper with only vibeSources is rejected" 1 'local t = new Task {
@@ -159,4 +178,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (16 cases)"
+echo "check-task-inputs-test: ok (17 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -63,6 +63,16 @@ run_case "scriptTask with only vibeSources is rejected" 1 'local function script
   inputs { ...vibeSources; ...scriptSources }
 }'
 
+run_case "scriptTask without inputs is rejected" 1 'local function scriptTask(taskName: String, script: String): Task = new Task {
+  name = taskName
+  cmd = "bash \(script)"
+}
+local later = new Task {
+  name = "later"
+  cmd = "bash scripts/check_book_links.sh"
+  inputs { ...compilerProbeInputs }
+}'
+
 run_case "scriptTask with compilerProbeInputs passes" 0 'local compilerProbeInputs = new {
   ...vibeSources
   "bootstrap/seed.json"
@@ -119,4 +129,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (12 cases)"
+echo "check-task-inputs-test: ok (13 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -152,6 +152,13 @@ run_case "block-commented cache false does not bypass inputs" 1 'local t = new T
   inputs { ...vibeSources }
 }'
 
+run_case "cache false text in string does not bypass inputs" 1 'local t = new Task {
+  name = "probe"
+  description = "Unlike cache = false, this task is cached"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...vibeSources }
+}'
+
 run_case "URL in command does not hide compiler invocation" 1 'local t = new Task {
   name = "probe"
   cmd = "printf https://example.invalid && bash scripts/check_freeze_surface.sh"
@@ -163,6 +170,34 @@ run_case "scriptTask with only vibeSources is rejected" 1 'local function script
   name = taskName
   cmd = "bash \(script)"
   inputs { ...vibeSources; ...scriptSources }
+}'
+
+run_case "commented safe scriptTask does not hide unsafe live factory" 1 '/*
+local function scriptTask(taskName: String, script: String): Task = new Task {
+  name = taskName
+  cmd = "bash \(script)"
+  inputs { ...compilerProbeInputs }
+}
+*/
+local function scriptTask(taskName: String, script: String): Task = new Task {
+  name = taskName
+  cmd = "bash \(script)"
+  inputs { ...vibeSources }
+}'
+
+run_case "commented safe helper does not hide unsafe live helper" 1 '/*
+local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+*/
+local compilerProbeInputs = new {
+  ...vibeSources
+}
+local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...compilerProbeInputs }
 }'
 
 run_case "scriptTask with compilerProbeInputs string is rejected" 1 'local compilerProbeInputs = new {
@@ -283,4 +318,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (29 cases)"
+echo "check-task-inputs-test: ok (32 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -87,6 +87,24 @@ local t = new Task {
   }
 }'
 
+run_case "compilerProbeInputs mentioned outside inputs is rejected" 1 'local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+local t = new Task {
+  name = "probe"
+  description = "should use compilerProbeInputs"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...vibeSources }
+}'
+
+run_case "commented cache false does not bypass inputs" 1 'local t = new Task {
+  name = "probe"
+  cmd = "bash scripts/check_freeze_surface.sh"
+  // cache = false
+  inputs { ...vibeSources }
+}'
+
 # The shared wrapper factory must not bypass the seed-aware input set.
 run_case "scriptTask with only vibeSources is rejected" 1 'local function scriptTask(taskName: String, script: String): Task = new Task {
   name = taskName
@@ -178,4 +196,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (17 cases)"
+echo "check-task-inputs-test: ok (19 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -56,6 +56,23 @@ local t = new Task {
   inputs { ...compilerProbeInputs; "docs/cheatsheet.md" }
 }'
 
+# The shared wrapper factory must not bypass the seed-aware input set.
+run_case "scriptTask with only vibeSources is rejected" 1 'local function scriptTask(taskName: String, script: String): Task = new Task {
+  name = taskName
+  cmd = "bash \(script)"
+  inputs { ...vibeSources; ...scriptSources }
+}'
+
+run_case "scriptTask with compilerProbeInputs passes" 0 'local compilerProbeInputs = new {
+  ...vibeSources
+  "bootstrap/seed.json"
+}
+local function scriptTask(taskName: String, script: String): Task = new Task {
+  name = taskName
+  cmd = "bash \(script)"
+  inputs { ...compilerProbeInputs; ...scriptSources }
+}'
+
 # Caching off is the other legitimate answer.
 run_case "cache = false is accepted instead" 0 'local t = new Task {
   name = "probe"
@@ -102,4 +119,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (10 cases)"
+echo "check-task-inputs-test: ok (12 cases)"


### PR DESCRIPTION
Closes #2165.

## Summary
- add a shared `compilerProbeInputs` set containing selfhost sources and `bootstrap/seed.json`
- use it for all four cached gates whose oracle is the checkout stage2
- extend the task-input ratchet so the shared set is accepted only when both source and seed inputs remain present

## Validation
- `pkf format --check Taskfile.pkl`
- `pkf run check-taskfile-fmt`
- `bash scripts/check_task_inputs.sh`
- `bash scripts/check_task_inputs_test.sh`
- `bash -n scripts/check_task_inputs.sh scripts/check_task_inputs_test.sh`
- `git diff --check`
- `pkf info --json` confirms all four gates include `bootstrap/seed.json`, `lib/**`, and the generation dependency