### PR TITLE
Gate function-union coverage by absolute hits

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -121,7 +121,7 @@ Entry-weighted rates are reported for historical continuity, but they are not
 gated by default. Adding one test entry adds its whole import closure to their
 denominator, so a larger test suite can lower those rates while both the
 covered-function and covered-branch counts increase. The default gate instead
-uses absolute hit ratchets plus the source-union rate. Set
+uses absolute hit ratchets plus the explicit branch source-coverage KPI. Set
 `VIBE_SUITE_MIN_POINT_RATE` or `VIBE_SUITE_MIN_BRANCH_RATE` only for an explicit
 diagnostic experiment that needs an entry-weighted floor.
 
@@ -165,14 +165,13 @@ diagnostic experiment that needs an entry-weighted floor.
   `branch_union.exact` が `false` になり、値は**下限**として表示される。
   この場合 ratchet は測れなかった数値で落とさないようスキップされる
 
-ratchet: `VIBE_SUITE_MIN_BRANCH_UNION_HIT` (絶対数) と
-`VIBE_SUITE_MIN_BRANCH_UNION_RATE` (率)。entry を足すと分母がその import
-closure ぶん増える entry-weighted rate と違い、union の rate は
-「テストを足せば上がる」ので率のラチェットとして意味を持つ。
-Function union is protected symmetrically by
-`VIBE_SUITE_MIN_FUNCTION_UNION_HIT` and
-`VIBE_SUITE_MIN_FUNCTION_UNION_RATE`; disabling the diluted entry-weighted
-function rate must not remove the source-function regression gate.
+ratchet: `VIBE_SUITE_MIN_BRANCH_UNION_HIT` (absolute count) and
+`VIBE_SUITE_MIN_BRANCH_UNION_RATE` (the explicit #1556 branch-coverage KPI).
+The union removes repeated imports across entries, but its source universe can
+still expand when a test first imports a module. Function union therefore uses
+`VIBE_SUITE_MIN_FUNCTION_UNION_HIT` as its default monotonic ratchet; its rate
+is reported and can be enabled explicitly with
+`VIBE_SUITE_MIN_FUNCTION_UNION_RATE`, but defaults to zero.
 
 ### コンパイラ自身を計測
 

--- a/scripts/coverage_suite.sh
+++ b/scripts/coverage_suite.sh
@@ -43,7 +43,7 @@
 #   VIBE_SUITE_MIN_FN_HIT            — minimum ABSOLUTE covered functions
 #   VIBE_SUITE_MIN_BRANCH_HIT        — minimum ABSOLUTE covered branches
 #   VIBE_SUITE_MIN_FUNCTION_UNION_HIT — minimum UNION covered functions
-#   VIBE_SUITE_MIN_FUNCTION_UNION_RATE — minimum UNION function rate
+#   VIBE_SUITE_MIN_FUNCTION_UNION_RATE — opt-in UNION function rate
 #   VIBE_SUITE_MIN_BRANCH_UNION_HIT  — minimum UNION covered branches
 #   VIBE_SUITE_MIN_BRANCH_UNION_RATE — minimum UNION branch rate
 #
@@ -51,8 +51,9 @@
 # adding a test entry can only raise them, while rate floors punish it (a new
 # entry grows the denominator by its whole import closure). The rates remain
 # in the report and can be gated explicitly through the env overrides, but
-# their defaults are zero. The UNION rate has no such problem and is ratcheted
-# directly.
+# their defaults are zero. Union ABSOLUTE hits are monotonic across test-entry
+# expansion; rates are only default gates where a separate source-coverage KPI
+# explicitly requires one (the #1556 branch target).
 #
 # Baseline (2026-07-03, 93 allowlist entries, full-visibility #716 stage2):
 #   functions 2263/6491 (34.86%), branches 3814/41967 (9.09%), cases 92/93
@@ -126,9 +127,9 @@ MIN_BRANCH="${VIBE_SUITE_MIN_BRANCH_RATE:-0}"
 MIN_FN_HIT="${VIBE_SUITE_MIN_FN_HIT:-42000}"
 MIN_BRANCH_HIT="${VIBE_SUITE_MIN_BRANCH_HIT:-113000}"
 # Union floors count each source function/branch once no matter how many
-# entries link it. Unlike entry-weighted rates, these are source metrics and
-# can be ratcheted directly. Raise as coverage improves; lowering needs a
-# rationale in the PR.
+# entries link it. Their absolute hits are safe ratchets. Their source universe
+# can still expand when a test first imports a module, so only the #1556 branch
+# coverage KPI has a default rate floor; function-union rate remains opt-in.
 #
 # Baseline (2026-08-13, 575 entries, all green, at 85f2ace): branch union
 # 25,131/45,638 (55.07%), function union 12,820/14,907 (86.00%). Note how far
@@ -153,10 +154,11 @@ MIN_BRANCH_HIT="${VIBE_SUITE_MIN_BRANCH_HIT:-113000}"
 # #2175 review: retiring the diluted function-rate floor without a function
 # union ratchet would leave only MIN_FN_HIT=42,000 against 111,304 weighted
 # hits. Current source-function union is 16,040/18,147 (88.39%) locally and
-# 16,046/18,147 (88.42%) in CI. Keep a small reproducibility margin while
-# preventing a large loss of actually executed source functions.
+# 16,046/18,147 (88.42%) in CI. Protect the executed source-function count;
+# do not gate its rate because a newly imported module expands the denominator
+# without making any previously covered function uncovered (#2176 review).
 MIN_FUNCTION_UNION_HIT="${VIBE_SUITE_MIN_FUNCTION_UNION_HIT:-15800}"
-MIN_FUNCTION_UNION="${VIBE_SUITE_MIN_FUNCTION_UNION_RATE:-88}"
+MIN_FUNCTION_UNION="${VIBE_SUITE_MIN_FUNCTION_UNION_RATE:-0}"
 MIN_BRANCH_UNION_HIT="${VIBE_SUITE_MIN_BRANCH_UNION_HIT:-26000}"
 MIN_BRANCH_UNION="${VIBE_SUITE_MIN_BRANCH_UNION_RATE:-57}"
 

--- a/scripts/coverage_suite_report_test.py
+++ b/scripts/coverage_suite_report_test.py
@@ -32,7 +32,7 @@ class CoverageSuiteReportTest(unittest.TestCase):
         self.assertGreater(int(default_for("MIN_FN_HIT")), 0)
         self.assertGreater(int(default_for("MIN_BRANCH_HIT")), 0)
         self.assertGreater(int(default_for("MIN_FUNCTION_UNION_HIT")), 0)
-        self.assertGreater(float(default_for("MIN_FUNCTION_UNION")), 0)
+        self.assertEqual(default_for("MIN_FUNCTION_UNION"), "0")
         self.assertGreater(int(default_for("MIN_BRANCH_UNION_HIT")), 0)
         self.assertGreater(float(default_for("MIN_BRANCH_UNION")), 0)
 
@@ -45,7 +45,7 @@ class CoverageSuiteReportTest(unittest.TestCase):
         self.assertIn('"$MIN_FUNCTION_UNION_HIT"', invocation.group(0))
         self.assertIn('"$MIN_FUNCTION_UNION"', invocation.group(0))
 
-    def test_function_union_ratchets_fail_independently_of_weighted_rates(self):
+    def test_function_union_hit_ratchet_fails_independently_of_weighted_rates(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             cov = root / "coverage"
@@ -66,12 +66,12 @@ class CoverageSuiteReportTest(unittest.TestCase):
                 result = main([
                     str(log), str(cov), str(report),
                     "0", "0", "0", "0", "0", "0", "0",
-                    "2", "60",
+                    "2", "0",
                 ])
 
         self.assertEqual(result, 1)
         self.assertIn("FUNCTION_UNION_HIT ratchet", output.getvalue())
-        self.assertIn("FUNCTION_UNION)", output.getvalue())
+        self.assertNotIn("FUNCTION_UNION)", output.getvalue())
 
     def write_cov(self, directory, entry, *, hit, total, hit_fns, missed_fns, branch_hit=0, branch_total=0,
                   branch_per_fn=None):


### PR DESCRIPTION
## Summary

Follow-up to the missed P1 review on #2176.

- keep the function-union absolute-hit ratchet at 15,800
- make the function-union rate floor opt-in instead of defaulting to 88%
- retain function-union rate reporting
- clarify that a union removes repeated imports but its source universe can still expand

## Root cause

`function_union()` unions the functions visible through all test-entry import closures. A test that first imports a new module adds that module's missed functions to the denominator, so the rate can fall without any previously covered function becoming uncovered. The absolute union-hit count is monotonic for this expansion and remains the default regression ratchet.

The #1556 branch-union rate remains a default gate because it is an explicit source branch-coverage KPI; function union has no equivalent rate target.

## Verification

- `python3 scripts/coverage_suite_report_test.py` — 10/10
- `bash -n scripts/coverage_suite.sh`
- `bash scripts/check_doc_commands.sh`
- `git diff --check`
- replayed the 1008-entry report: function union 16040/18147, branch union 58.57%, gate OK

Addresses https://github.com/mizchi/vibe-lang/pull/2176#discussion_r3829892989.