### PR TITLE
Split compiler gate below five minutes

### DIFF
--- a/.github/actions/setup-vibe/action.yml
+++ b/.github/actions/setup-vibe/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: Cache vibe linked build artifacts (dist/cache)
     default: 'false'
   pkfire-cache:
-    description: Cache ~/.cache/pkfire (content-addressed task cache)
+    description: Cache ~/.cache/pkfire-mbt (content-addressed task cache)
     default: 'false'
 
 runs:
@@ -62,10 +62,11 @@ runs:
       if: inputs.pkfire-cache == 'true'
       uses: actions/cache@v5
       with:
-        path: ~/.cache/pkfire
-        key: pkfire-${{ runner.os }}-${{ hashFiles('Taskfile.pkl') }}-${{ github.sha }}
+        path: ~/.cache/pkfire-mbt
+        key: pkfire-${{ runner.os }}-${{ github.job }}-${{ hashFiles('Taskfile.pkl') }}-${{ github.sha }}
         restore-keys: |
-          pkfire-${{ runner.os }}-${{ hashFiles('Taskfile.pkl') }}-
+          pkfire-${{ runner.os }}-${{ github.job }}-${{ hashFiles('Taskfile.pkl') }}-
+          pkfire-${{ runner.os }}-${{ github.job }}-
           pkfire-${{ runner.os }}-
 
     # Cache wasmtime release tarball extraction. WASMTIME_VERSION is pinned

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,19 @@ jobs:
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Restore generated compiler artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+          key: gen-v1-${{ steps.genfp.outputs.fp }}
+      - name: Ensure generated compiler artifacts
+        run: bash scripts/ensure_generated.sh
       - name: Restore cached stage2
         id: stage2-cache
         uses: actions/cache@v4
@@ -191,6 +204,13 @@ jobs:
           curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux.tar.gz" | tar -xz
           cp "wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux/wasm-tools" "$PWD/compiler-tools/"
           echo "$PWD/compiler-tools" >> "$GITHUB_PATH"
+      - name: Install wasmtime
+        env:
+          WASMTIME_VERSION: v47.0.2
+        run: |
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Stage cached compiler
         run: |
           mkdir -p _build/selfhost/generations/ci-oracles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,57 @@ jobs:
         env:
           COMPILER_GATE_LANE: bootstrap
           COMPILER_GATE_SKIP_PREFLIGHT: "1"
+          COMPILER_GATE_SKIP_STAGE2_ORACLES: "1"
         run: bash scripts/compiler_gate.sh
+      - name: Stage stage2 for downstream gates (#821)
+        run: |
+          gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
+          mkdir -p _build/ci-artifacts
+          cp "${gen}stage2.wasm" _build/ci-artifacts/stage2.wasm
+      - name: Upload stage2 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiler-stage2
+          path: _build/ci-artifacts/stage2.wasm
+          if-no-files-found: error
+
+  compiler-stage2-oracles:
+    name: compiler-gate (stage2 oracles)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Generated compiler fingerprint
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Restore cached stage2
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Build stage2 on cache miss
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          bash scripts/ensure_seed.sh
+          bash scripts/ensure_generated.sh
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Install wasm-tools
+        env:
+          WASM_TOOLS_VERSION: "1.253.0"
+        run: |
+          mkdir -p "$PWD/compiler-tools"
+          curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux.tar.gz" | tar -xz
+          cp "wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux/wasm-tools" "$PWD/compiler-tools/"
+          echo "$PWD/compiler-tools" >> "$GITHUB_PATH"
+      - name: Stage cached compiler
+        run: |
+          mkdir -p _build/selfhost/generations/ci-oracles
+          cp _build/_ci_shard_gen/stage2.wasm _build/selfhost/generations/ci-oracles/stage2.wasm
+      - name: Stage2 consumer oracles
+        run: bash tests/gates/bootstrap/stage2_oracles.sh "$PWD/_build/_ci_shard_gen/stage2.wasm"
       - name: Upload incremental shadow decision diff (#1548)
         # compiler_gate.sh step 3aa writes the shadow planner vs current
         # compiler decision diff (only after a successful oracle run).
@@ -194,6 +244,34 @@ jobs:
         # test in here too so that path is gated (it was previously defined
         # but never invoked by any workflow).
         run: bash scripts/vibe_normalize_smoke.sh
+
+  compiler-docs:
+    name: compiler-gate (docs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Generated compiler fingerprint
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Restore cached stage2
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Build stage2 on cache miss
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          bash scripts/ensure_seed.sh
+          bash scripts/ensure_generated.sh
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Stage cached compiler
+        run: |
+          mkdir -p _build/selfhost/generations/ci-docs
+          cp _build/_ci_shard_gen/stage2.wasm _build/selfhost/generations/ci-docs/stage2.wasm
       - name: Tutorial executable-docs check (#1142)
         # book/**/*.vibe.md's ```vibe run blocks are compiled and run
         # against the freshly-built stage2 and their embedded ```output must
@@ -247,6 +325,34 @@ jobs:
           gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
           FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface_test.sh
           FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface.sh
+
+  compiler-playground:
+    name: compiler-gate (playground)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Generated compiler fingerprint
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Restore cached stage2
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Build stage2 on cache miss
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          bash scripts/ensure_seed.sh
+          bash scripts/ensure_generated.sh
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Stage cached compiler
+        run: |
+          mkdir -p _build/selfhost/generations/ci-playground
+          cp _build/_ci_shard_gen/stage2.wasm _build/selfhost/generations/ci-playground/stage2.wasm
       - name: playground preset type-check
         # playground/src/main.ts embeds its starter programs as TypeScript
         # template literals, so they are vibe source no vibe tool ever saw. Two
@@ -257,17 +363,6 @@ jobs:
         run: |
           gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
           PLAYGROUND_STAGE2="${gen}stage2.wasm" bash scripts/check_playground_presets.sh
-      - name: Stage stage2 for downstream gates (#821)
-        run: |
-          gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
-          mkdir -p _build/ci-artifacts
-          cp "${gen}stage2.wasm" _build/ci-artifacts/stage2.wasm
-      - name: Upload stage2 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: compiler-stage2
-          path: _build/ci-artifacts/stage2.wasm
-          if-no-files-found: error
 
   # The examples ratchet takes roughly four minutes and needs only a stage2,
   # not the bootstrap fixpoint. Start it at t=0 from the same content-addressed
@@ -1056,7 +1151,7 @@ jobs:
   # Aggregate required check (branch protection requires "ci-required").
   ci-required:
     name: ci-required
-    needs: [compiler-gate, compiler-gate-preflight, compiler-examples, review-regressions, compiler-gate-lanes, unit-tests, vibe-fmt-check, gc-gate, structural-lint]
+    needs: [compiler-gate, compiler-gate-preflight, compiler-stage2-oracles, compiler-docs, compiler-playground, compiler-examples, review-regressions, compiler-gate-lanes, unit-tests, vibe-fmt-check, gc-gate, structural-lint]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1068,6 +1163,18 @@ jobs:
           fi
           if [ "${{ needs.compiler-gate-preflight.result }}" != "success" ]; then
             echo "::error::compiler-gate-preflight did not succeed (${{ needs.compiler-gate-preflight.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.compiler-stage2-oracles.result }}" != "success" ]; then
+            echo "::error::compiler-stage2-oracles did not succeed (${{ needs.compiler-stage2-oracles.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.compiler-docs.result }}" != "success" ]; then
+            echo "::error::compiler-docs did not succeed (${{ needs.compiler-docs.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.compiler-playground.result }}" != "success" ]; then
+            echo "::error::compiler-playground did not succeed (${{ needs.compiler-playground.result }})"
             exit 1
           fi
           if [ "${{ needs.compiler-examples.result }}" != "success" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ on:
 # validation. No MoonBit toolchain is installed or used.
 #
 # Wall-time layout (#1849 / #2001: compiler_gate.sh is a thin aggregator):
-#   - compiler-gate           bootstrap lane (selfbuild + fixpoint) + KPI /
-#                             docs tooling that needs this job's generation
+#   - compiler-gate           selfbuild + fixpoint + short stage2 consumers
+#   - compiler-gate-preflight stage-independent bootstrap checks
+#   - compiler-examples       examples ratchet against a cached stage2
+#   - review-regressions      full-history PR lint against a cached stage2
 #   - compiler-gate-lanes     early/mid/late fixture lanes; each shard
 #                             self-builds stage2 from the committed flat
 #                             module source (cached, same as unit-tests)
@@ -24,16 +26,47 @@ on:
 # All jobs start at t=0; nothing on the required path serializes behind
 # another job.
 jobs:
+  compiler-gate-preflight:
+    name: compiler-gate (preflight)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-vibe
+        with:
+          node-version: 24
+          pkfire: 'true'
+          pkfire-cache: 'true'
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+      - name: Generated compiler artifacts (fingerprint)
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Cache generated compiler artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+          key: gen-v1-${{ steps.genfp.outputs.fp }}
+      - name: Ensure generated compiler artifacts
+        run: bash scripts/ensure_generated.sh
+      - name: Bootstrap preflight
+        run: pkf run ci-compiler-gate-preflight
+
   compiler-gate:
     name: compiler-gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          # #1870: the review-regressions lint step below diffs a RANGE
-          # (base...HEAD), which needs both sides and their merge base. The
-          # default shallow clone has neither.
-          fetch-depth: 0
       - name: Cache seed artifact
         uses: actions/cache@v4
         with:
@@ -112,36 +145,8 @@ jobs:
         # generation, and the docs/KPI steps below.
         env:
           COMPILER_GATE_LANE: bootstrap
+          COMPILER_GATE_SKIP_PREFLIGHT: "1"
         run: bash scripts/compiler_gate.sh
-      - name: Install ripgrep
-        # The lint step below probes and filters with `rg`. Only structural-lint
-        # installed it before, so the first run of this step failed with
-        # `rg: command not found` -> probe fails -> AST tier skipped ->
-        # REQUIRE_AST=1 -> red. That was the fail-closed path doing its job;
-        # the missing tool is the actual fix.
-        run: command -v rg >/dev/null || sudo apt-get install -y ripgrep
-      - name: Review-regressions lint (PR range)
-        # #1870. This lint used to run in exactly one place -- the pre-commit
-        # hook -- and structural-lint deliberately ran only its SELF-TEST,
-        # because the lint reads `git diff --cached` and CI stages nothing.
-        # That left its rules with no enforcement point that a `--no-verify`
-        # could not skip, and the hook itself silently dropped its AST tier on
-        # any checkout without a built runner, still printing "ok". A real
-        # drift reached main that way (#1809's rule, re-broken in #1861).
-        #
-        # Vacuity was a property of `--cached`, not of CI: given a range, the
-        # same lint has a real diff to read. It runs HERE rather than in
-        # structural-lint because the AST tier needs a stage2, which the gate
-        # above has just built -- so this costs seconds, not another build.
-        #
-        # REQUIRE_AST=1 makes a tier that cannot run a failure instead of a
-        # quiet pass. That is the whole point: a gate that reports success
-        # having checked nothing is worse than no gate.
-        if: github.event_name == 'pull_request'
-        env:
-          VIBE_REVIEW_LINT_RANGE: ${{ github.event.pull_request.base.sha }}...HEAD
-          VIBE_REVIEW_LINT_REQUIRE_AST: "1"
-        run: bash scripts/lint_review_regressions.sh
       - name: Upload incremental shadow decision diff (#1548)
         # compiler_gate.sh step 3aa writes the shadow planner vs current
         # compiler decision diff (only after a successful oracle run).
@@ -242,20 +247,6 @@ jobs:
           gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
           FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface_test.sh
           FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface.sh
-      - name: examples/ type-check ratchet
-        # examples/ is the user-facing sample surface and had NOTHING checking
-        # it, so it accumulated two independent classes of rot in silence: the
-        # #1429/#1461 syntax removals (six files) and ordinary type errors that
-        # predate them (two files). scripts/pkfire/examples_smoke.sh does not
-        # cover this -- it compiles four hand-picked files through
-        # _build/dist/selfhost_compiler.wasm, a path the current build layout no
-        # longer produces, and no workflow invokes it.
-        #
-        # Known failures are a printed ratchet, not a silent skip
-        # (scripts/examples_typecheck_known_failures.txt).
-        run: |
-          gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
-          EXAMPLES_STAGE2="${gen}stage2.wasm" bash scripts/check_examples_typecheck.sh
       - name: playground preset type-check
         # playground/src/main.ts embeds its starter programs as TypeScript
         # template literals, so they are vibe source no vibe tool ever saw. Two
@@ -277,6 +268,117 @@ jobs:
           name: compiler-stage2
           path: _build/ci-artifacts/stage2.wasm
           if-no-files-found: error
+
+  # The examples ratchet takes roughly four minutes and needs only a stage2,
+  # not the bootstrap fixpoint. Start it at t=0 from the same content-addressed
+  # stage2 cache as fixture and unit-test shards.
+  compiler-examples:
+    name: compiler-gate (examples)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+      - name: Generated compiler artifacts (fingerprint)
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Cache generated compiler artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+          key: gen-v1-${{ steps.genfp.outputs.fp }}
+      - name: Ensure generated compiler artifacts
+        run: bash scripts/ensure_generated.sh
+      - uses: ./.github/actions/setup-vibe
+        with:
+          node-version: 24
+          pkfire: 'true'
+          pkfire-cache: 'true'
+      - name: Cache stage2
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Build stage2
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
+            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: examples/ type-check ratchet
+        run: pkf run ci-check-examples-typecheck
+
+  # Range mode needs the PR merge base, while compiler-gate itself does not.
+  # Keeping the full-history checkout here removes about 50 seconds from the
+  # compiler-gate critical path without weakening the fail-closed AST tier.
+  review-regressions:
+    name: review-regressions
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+      - name: Generated compiler artifacts (fingerprint)
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Cache generated compiler artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+          key: gen-v1-${{ steps.genfp.outputs.fp }}
+      - name: Ensure generated compiler artifacts
+        run: bash scripts/ensure_generated.sh
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Cache stage2
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Build stage2
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
+            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Stage compiler for the AST lint
+        run: |
+          mkdir -p _build/selfhost/generations/ci-review
+          cp _build/_ci_shard_gen/stage2.wasm _build/selfhost/generations/ci-review/stage2.wasm
+      - name: Install ripgrep
+        run: command -v rg >/dev/null || sudo apt-get install -y ripgrep
+      - name: Review-regressions lint (PR range)
+        if: github.event_name == 'pull_request'
+        env:
+          VIBE_REVIEW_LINT_RANGE: ${{ github.event.pull_request.base.sha }}...HEAD
+          VIBE_REVIEW_LINT_REQUIRE_AST: "1"
+        run: bash scripts/lint_review_regressions.sh
 
   # Fixture lanes extracted from compiler_gate.sh (#1849 / #2001). Each
   # shard builds its own stage2 from the committed flat module source —
@@ -419,6 +521,8 @@ jobs:
         run: bash scripts/lint_review_regressions_test.sh
       - name: compiler-gate registry self-test
         run: bash scripts/check_gate_registry_test.sh
+      - name: compiler-gate CI layout self-test
+        run: bash scripts/test_ci_compiler_gate_layout.sh
       - name: doc path-citation lint self-test
         run: bash scripts/check_doc_path_citations_test.sh
       - name: doc path-citation lint
@@ -952,7 +1056,7 @@ jobs:
   # Aggregate required check (branch protection requires "ci-required").
   ci-required:
     name: ci-required
-    needs: [compiler-gate, compiler-gate-lanes, unit-tests, vibe-fmt-check, gc-gate, structural-lint]
+    needs: [compiler-gate, compiler-gate-preflight, compiler-examples, review-regressions, compiler-gate-lanes, unit-tests, vibe-fmt-check, gc-gate, structural-lint]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -960,6 +1064,18 @@ jobs:
         run: |
           if [ "${{ needs.compiler-gate.result }}" != "success" ]; then
             echo "::error::compiler-gate did not succeed (${{ needs.compiler-gate.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.compiler-gate-preflight.result }}" != "success" ]; then
+            echo "::error::compiler-gate-preflight did not succeed (${{ needs.compiler-gate-preflight.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.compiler-examples.result }}" != "success" ]; then
+            echo "::error::compiler-examples did not succeed (${{ needs.compiler-examples.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.review-regressions.result }}" != "success" ] && [ "${{ needs.review-regressions.result }}" != "skipped" ]; then
+            echo "::error::review-regressions did not succeed (${{ needs.review-regressions.result }})"
             exit 1
           fi
           if [ "${{ needs.compiler-gate-lanes.result }}" != "success" ]; then

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -42,6 +42,39 @@ local function scriptTask(taskName: String, script: String): Task = new Task {
   inputs { ...vibeSources; ...scriptSources }
 }
 
+// CI-only slices use fixed artifact paths so pkfire can hash the exact stage2
+// they consume and safely replay successful verdicts from its CAS.
+local ciCompilerGatePreflight = new Task {
+  name = "ci-compiler-gate-preflight"
+  description = "stage-independent compiler-gate preflight"
+  cmd =
+    "bash tests/gates/bootstrap/preflight.sh && mkdir -p _build/pkfire && printf 'ok\\n' > _build/pkfire/ci-compiler-gate-preflight.ok"
+  inputs {
+    ...vibeSources
+    ...scriptSources
+    "tests/gates/**/*.sh"
+    "tests/gates/registry.tsv"
+    "fixtures/**/*.vibe"
+    "bootstrap/seed.json"
+  }
+  outputs { "_build/pkfire/ci-compiler-gate-preflight.ok" }
+}
+
+local ciCheckExamplesTypecheck = new Task {
+  name = "ci-check-examples-typecheck"
+  description = "type-check examples against CI's content-addressed stage2"
+  cmd =
+    "EXAMPLES_STAGE2=_build/_ci_shard_gen/stage2.wasm bash scripts/check_examples_typecheck.sh && mkdir -p _build/pkfire && printf 'ok\\n' > _build/pkfire/ci-check-examples-typecheck.ok"
+  inputs {
+    ...vibeSources
+    ...scriptSources
+    "examples/**/*.vibe"
+    "install/**/*"
+    "_build/_ci_shard_gen/stage2.wasm"
+  }
+  outputs { "_build/pkfire/ci-check-examples-typecheck.ok" }
+}
+
 // === Quick Commands ===
 
 local fmt = new Task {
@@ -1570,6 +1603,8 @@ local checkRelease = new Task {
 // === Task registration ===
 
 tasks {
+  ciCompilerGatePreflight
+  ciCheckExamplesTypecheck
   fmt
   preCommit
   formalCheck

--- a/scripts/check_gate_registry.sh
+++ b/scripts/check_gate_registry.sh
@@ -56,6 +56,14 @@ known_lane() {
   return 1
 }
 
+lane_sources() {
+  local lane="$1"
+  printf '%s\n' "$(gate_lane_script "$lane")"
+  if [ "$lane" = "bootstrap" ]; then
+    printf '%s\n' "$ROOT_DIR/tests/gates/bootstrap/preflight.sh"
+  fi
+}
+
 is_success_banner() {
   local rest="$1"
   case "$rest" in
@@ -93,8 +101,8 @@ while IFS=$'\t' read -r id lane title; do
   if [ ! -f "$script" ]; then
     echo "[gate-registry] FAIL: missing lane entrypoint $script" >&2
     fail=1
-  elif ! grep -F -q "$title" "$script"; then
-    echo "[gate-registry] FAIL: id '$id' title not found in $script" >&2
+  elif ! xargs grep -F -q "$title" < <(lane_sources "$lane"); then
+    echo "[gate-registry] FAIL: id '$id' title not found in lane '$lane' sources" >&2
     fail=1
   fi
 done < "$REGISTRY"
@@ -112,7 +120,7 @@ if [ -z "$ids" ]; then
 fi
 
 for lane in $GATE_LANES; do
-  script="$(gate_lane_script "$lane")"
+  while IFS= read -r script; do
   if [ ! -f "$script" ]; then
     echo "[gate-registry] FAIL: missing lane entrypoint $script" >&2
     fail=1
@@ -148,6 +156,7 @@ for lane in $GATE_LANES; do
         ;;
     esac
   done < <(grep -oE '"(fixtures|lib|docs|scripts|tests)/[^"$]+"' "$script" | tr -d '"' || true)
+  done < <(lane_sources "$lane")
 done
 
 # A lane step that COMPILES something and then checks the artifact
@@ -157,7 +166,7 @@ done
 # bisecting to find which step it was. `|| true` on the invocation hands the
 # verdict to the check that was written for it.
 for lane in $GATE_LANES; do
-  script="$(gate_lane_script "$lane")"
+  while IFS= read -r script; do
   [ -f "$script" ] || continue
   awk -v script="$script" '
     # remember the line where a runner invocation starts
@@ -181,6 +190,7 @@ for lane in $GATE_LANES; do
     }
     END { exit(bad ? 1 : 0) }
   ' "$script" || fail=1
+  done < <(lane_sources "$lane")
 done
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/measure_fs_heap.sh
+++ b/scripts/measure_fs_heap.sh
@@ -67,6 +67,7 @@ GATE=0
 MAX_PAGES="${VIBE_FS_HEAP_MAX_PAGES:-}"
 OUT_DIR="${VIBE_FS_HEAP_OUT_DIR:-$PROJECT_ROOT/_build/measure_fs_heap}"
 RUNNER="${VIBE_FS_HEAP_RUNNER:-$SCRIPT_DIR/run_wasm_vibe_host_runner.sh}"
+SKIP_PREPARE="${VIBE_FS_HEAP_SKIP_PREPARE:-0}"
 KEEP_RUN_DIR="${VIBE_FS_HEAP_KEEP_RUN_DIR:-0}"
 RUN_DIR=""
 PAIR_DIR=""
@@ -74,6 +75,17 @@ WARM_NEXT=""
 LOCK_DIR=""
 LOCK_HELD=0
 ACTIVE_PID=""
+
+prepare_generated() {
+  if [ "$SKIP_PREPARE" = 1 ]; then
+    if [ "$RUNNER" = "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" ]; then
+      echo "measure_fs_heap: VIBE_FS_HEAP_SKIP_PREPARE=1 requires an explicit test runner" >&2
+      exit 2
+    fi
+    return 0
+  fi
+  bash "$SCRIPT_DIR/ensure_generated.sh" >&2
+}
 
 # Also sanitize the artifact-preparation step below: it executes the same host
 # runner and must not inherit controls that would perturb a later measurement.
@@ -210,7 +222,7 @@ if [ "$COMPARE" = 1 ]; then
   fi
   # Prepare deterministic ignored inputs before attesting the source snapshot.
   # Child lanes repeat this as a no-op freshness check.
-  bash "$SCRIPT_DIR/ensure_generated.sh" >&2
+  prepare_generated
   input_hash_before="$(compiler_input_hash)"
 
   # Both lanes consume one private snapshot, not the caller's mutable pathname.
@@ -271,7 +283,7 @@ RUN_DIR="$(mktemp -d "$OUT_DIR/run.XXXXXX")"
 # compiler bundles. A direct opt-in measurement must prepare them too; otherwise
 # a clean checkout would fail before reaching a memory boundary. These are build
 # outputs only and remain outside the commit.
-bash "$SCRIPT_DIR/ensure_generated.sh" >&2
+prepare_generated
 
 if [ -z "$BASE_COMPILER" ]; then
   BASE_COMPILER="$RUN_DIR/base_compiler.wasm"

--- a/scripts/measure_fs_heap_test.sh
+++ b/scripts/measure_fs_heap_test.sh
@@ -15,6 +15,12 @@ printf '\0asm\1\0\0\0' > "$BASE"
 RUNNER="$TMP_DIR/fake_runner.sh"
 RUN_LOG="$TMP_DIR/run.log"
 
+# The fake runner validates the measurement protocol and never imports the
+# compiler tree. Bundle preparation is production setup, not part of this
+# test's contract, and used to dominate this fast test with repeated 25 MB
+# regeneration.
+export VIBE_FS_HEAP_SKIP_PREPARE=1
+
 cat > "$RUNNER" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -62,6 +68,19 @@ if [ "${VIBE_PROFILE_MEMORY_MARKS:-}" = "1" ]; then
 fi
 EOF
 chmod +x "$RUNNER"
+
+# Skipping production bundle preparation is test-runner authority, not a way
+# to run the real measurement against stale generated inputs.
+set +e
+VIBE_FS_HEAP_OUT_DIR="$TMP_DIR/skip-prepare-real-runner" \
+  bash "$SCRIPT" --cold --base "$BASE" >"$TMP_DIR/skip-prepare.stdout" 2>"$TMP_DIR/skip-prepare.stderr"
+status=$?
+set -e
+if [ "$status" -eq 0 ]; then
+  echo "measure_fs_heap test: production runner accepted VIBE_FS_HEAP_SKIP_PREPARE=1" >&2
+  exit 1
+fi
+grep -q 'VIBE_FS_HEAP_SKIP_PREPARE=1 requires an explicit test runner' "$TMP_DIR/skip-prepare.stderr"
 
 # Ambient runner/compiler controls must not change the lane or its measured
 # guest pages. The marked/unmarked outputs are identical, so parity must pass.

--- a/scripts/test_ci_compiler_gate_layout.sh
+++ b/scripts/test_ci_compiler_gate_layout.sh
@@ -25,6 +25,9 @@ reject_compiler_gate_block() {
 
 require '^  compiler-gate-preflight:$' "$workflow"
 require '^  compiler-examples:$' "$workflow"
+require '^  compiler-stage2-oracles:$' "$workflow"
+require '^  compiler-docs:$' "$workflow"
+require '^  compiler-playground:$' "$workflow"
 require '^  review-regressions:$' "$workflow"
 require 'pkf run ci-compiler-gate-preflight' "$workflow"
 require 'pkf run ci-check-examples-typecheck' "$workflow"
@@ -35,6 +38,9 @@ require 'bash tests/gates/bootstrap/preflight.sh' "$bootstrap"
 reject_compiler_gate_block 'fetch-depth: 0'
 reject_compiler_gate_block 'check_examples_typecheck.sh'
 reject_compiler_gate_block 'lint_review_regressions.sh'
+reject_compiler_gate_block 'check_playground_presets.sh'
+reject_compiler_gate_block 'doctest_extract_run.sh'
+require 'COMPILER_GATE_SKIP_STAGE2_ORACLES: "1"' "$workflow"
 
 require 'path: ~/.cache/pkfire-mbt' '.github/actions/setup-vibe/action.yml'
 require 'github.job' '.github/actions/setup-vibe/action.yml'

--- a/scripts/test_ci_compiler_gate_layout.sh
+++ b/scripts/test_ci_compiler_gate_layout.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=".github/workflows/ci.yml"
+bootstrap="tests/gates/bootstrap/run.sh"
+
+require() {
+  local pattern="$1"
+  local file="$2"
+  if ! grep -qE "$pattern" "$file"; then
+    echo "[ci-compiler-gate-layout] missing '$pattern' in $file" >&2
+    exit 1
+  fi
+}
+
+reject_compiler_gate_block() {
+  local pattern="$1"
+  local block
+  block="$(sed -n '/^  compiler-gate:/,/^  [a-zA-Z0-9_-]*:/p' "$workflow")"
+  if grep -qE "$pattern" <<<"$block"; then
+    echo "[ci-compiler-gate-layout] compiler-gate still contains '$pattern'" >&2
+    exit 1
+  fi
+}
+
+require '^  compiler-gate-preflight:$' "$workflow"
+require '^  compiler-examples:$' "$workflow"
+require '^  review-regressions:$' "$workflow"
+require 'pkf run ci-compiler-gate-preflight' "$workflow"
+require 'pkf run ci-check-examples-typecheck' "$workflow"
+require 'pkfire-cache:' "$workflow"
+require 'fetch-depth: 0' "$workflow"
+require 'bash tests/gates/bootstrap/preflight.sh' "$bootstrap"
+
+reject_compiler_gate_block 'fetch-depth: 0'
+reject_compiler_gate_block 'check_examples_typecheck.sh'
+reject_compiler_gate_block 'lint_review_regressions.sh'
+
+require 'path: ~/.cache/pkfire-mbt' '.github/actions/setup-vibe/action.yml'
+require 'github.job' '.github/actions/setup-vibe/action.yml'
+
+echo "[ci-compiler-gate-layout] ok"

--- a/tests/gates/bootstrap/preflight.sh
+++ b/tests/gates/bootstrap/preflight.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fast, stage-independent bootstrap checks. CI runs this in parallel with the
+# selfbuild; the local bootstrap lane invokes it before building.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[compiler-gate] 0/3 builtin parity (#415 B-3)"
+bash scripts/check_builtin_parity.sh
+bash scripts/check_gate_registry.sh
+bash scripts/check_inline_builtin_capture.sh
+node scripts/generate_runtime_fixture_tests.test.mjs
+bash scripts/check_fixture_execution.sh
+bash scripts/vibe_fmt_parse_guard_test.sh
+
+echo "[compiler-gate] parser binder-context spine"
+node --test scripts/parser_binder_context_spine.test.mjs
+node scripts/test_immutable_publish_plumbing.js
+
+echo "[compiler-gate] 1-2/3 generated compiler artifacts"
+bash scripts/ensure_generated.sh
+
+echo "[compiler-gate] 2a/3 FS heap measurement protocol"
+bash scripts/measure_fs_heap_test.sh
+
+echo "[compiler-gate] bootstrap preflight ok"

--- a/tests/gates/bootstrap/run.sh
+++ b/tests/gates/bootstrap/run.sh
@@ -39,6 +39,16 @@ PY
 
 stage2_wasm="${latest_gen}stage2.wasm"
 
+VIBE_RC_BOOTSTRAP_REUSE_GEN="${latest_gen}generation.json" \
+  bash scripts/test_rc_bootstrap.sh
+
+# CI runs the stage2 consumer oracles in their own cached job. Keep the local
+# bootstrap lane complete by default, while letting the fixpoint job publish
+# its stage2 without serializing unrelated consumers behind the selfbuild.
+if [ "${COMPILER_GATE_SKIP_STAGE2_ORACLES:-0}" = "1" ]; then
+  exit 0
+fi
+
 # #2148: build and exercise the supported split CLI entry with the stage2 from
 # this checkout. This caught the entry's missing Stdout row and keeps direct
 # build prerequisites plus the compile/build/check command surface live.
@@ -133,5 +143,3 @@ VIBE_RC=0 node scripts/experimental_typing_env_reuse_oracle.mjs "$stage2_wasm"
 # ~1.7x wall, ~2.9x output size; see #705 final benchmark), not a
 # correctness blocker. seed->stage1 must still run bump: the pinned seed
 # predates RC ("not EFn" on VIBE_RC=1).
-VIBE_RC_BOOTSTRAP_REUSE_GEN="${latest_gen}generation.json" \
-  bash scripts/test_rc_bootstrap.sh

--- a/tests/gates/bootstrap/run.sh
+++ b/tests/gates/bootstrap/run.sh
@@ -8,56 +8,9 @@ GATES_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/lib.sh"
 # shellcheck disable=SC1090
 source "$GATES_LIB"
 
-
-echo "[compiler-gate] 0/3 builtin parity (#415 B-3)"
-bash scripts/check_builtin_parity.sh
-
-# #2001 Phase 0: the lane registry must stay exhaustive before any
-# selfbuild work. A missing row or a missing lane script is silent
-# coverage, which outranks a red selfbuild.
-bash scripts/check_gate_registry.sh
-
-# #1348: inline-dispatched builtins that the closure-capture analysis does not
-# know about are a latent miscompile (invalid module / null-function trap).
-# Static check, so it runs here with the other pre-build checks.
-bash scripts/check_inline_builtin_capture.sh
-
-# #1587: a fixture with `test` blocks that no lane runs is coverage that does
-# not exist. Pure shell + grep (~2s), so it runs before the multi-minute
-# selfbuild rather than after it.
-node scripts/generate_runtime_fixture_tests.test.mjs
-bash scripts/check_fixture_execution.sh
-
-# #1821 / Codex review on #1822: the token formatter may conservatively miss
-# an ambiguous `Name {` shape, but the public writer must never replace valid
-# source with a candidate that no parser accepts.
-bash scripts/vibe_fmt_parse_guard_test.sh
-
-# B2 parser binder-context routing is intentionally semantically inert, so its
-# no-fallback proof is structural. Keep the large source-body assertion table
-# out of the Vibe unit and run the strict scanner directly under Node.
-echo "[compiler-gate] parser binder-context spine"
-node --test scripts/parser_binder_context_spine.test.mjs
-
-# Capability-only gate for the future TDRE5 immutable cache publisher. The
-# builtin remains unused by compiler source until the bootstrap seed is bumped.
-node scripts/test_immutable_publish_plumbing.js
-
-echo "[compiler-gate] 1-2/3 generated compiler artifacts"
-# This used to be a SYNC CHECK: regenerate the five artifacts into a temp dir
-# and assert the committed copies matched byte for byte. The artifacts are no
-# longer committed (see scripts/ensure_generated.sh), so the same generation
-# now simply produces them -- identical work, minus a failure mode that could
-# only ever mean "someone forgot to run the regen".
-#
-# Warm (fingerprint unchanged since the last run) this is ~1s.
-bash scripts/ensure_generated.sh
-
-# #1553: exercise the measurement protocol with a fake runner. This validates
-# isolation and fail-closed parsing without running the costly real full-CLI
-# memory measurement, which remains opt-in via `pkf run measure-fs-heap`.
-echo "[compiler-gate] 2a/3 FS heap measurement protocol"
-bash scripts/measure_fs_heap_test.sh
+if [ "${COMPILER_GATE_SKIP_PREFLIGHT:-0}" != "1" ]; then
+  bash tests/gates/bootstrap/preflight.sh
+fi
 
 echo "[compiler-gate] 3/3 selfbuild seed->stage1->stage2->stage3"
 # ensure_generated just wrote the flat module source from the current tree, so

--- a/tests/gates/bootstrap/stage2_oracles.sh
+++ b/tests/gates/bootstrap/stage2_oracles.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stage2_wasm="${1:?usage: stage2_oracles.sh <stage2.wasm>}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[compiler-gate] selfhost split CLI core"
+VIBE_CLI_CORE_BASE_COMPILER="$stage2_wasm" VIBE_RC=1 bash scripts/test_cli_core.sh
+
+echo "[compiler-gate] FS heap mark lane smoke"
+heapmarkdir="_build/_gate_fs_heap_marks"
+rm -rf "$heapmarkdir"
+mkdir -p "$heapmarkdir"
+printf 'export let _start: () -> Int = () -> { 42 }\n' > "$heapmarkdir/input.vibe"
+for heap_backend in rc bump; do
+  heap_rc=1
+  heap_boundary=codegen_rc
+  if [ "$heap_backend" = bump ]; then
+    heap_rc=0
+    heap_boundary=codegen_bump
+  fi
+  heap_log="$heapmarkdir/$heap_backend.log"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    VIBE_RC="$heap_rc" VIBE_PROFILE_MEMORY_MARKS=1 \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$heapmarkdir/input.vibe" "$heapmarkdir/$heap_backend.wasm" _start \
+    >/dev/null 2>"$heap_log" || true
+  if [ ! -s "$heapmarkdir/$heap_backend.wasm" ] \
+    || ! grep -q "name=start" "$heap_log" \
+    || ! grep -q "name=$heap_boundary" "$heap_log"; then
+    echo "[compiler-gate] FAIL: compiled CLI did not emit selected $heap_backend heap marks" >&2
+    cat "$heap_log" >&2 || true
+    exit 1
+  fi
+done
+rm -rf "$heapmarkdir"
+
+VIBE_RC=0 node scripts/artifact_input_trace_oracle.mjs "$stage2_wasm"
+bash scripts/test_rc_entry_result_parity.sh "$stage2_wasm"
+mkdir -p _build/ci-artifacts
+VIBE_RC=0 \
+  VIBE_SHADOW_DECISION_DIFF_OUT="$ROOT_DIR/_build/ci-artifacts/incremental-shadow-decision-diff.json" \
+  node scripts/incremental_invalidation_oracle.mjs "$stage2_wasm"
+node scripts/ingestion_stamp_oracle.mjs "$stage2_wasm"
+VIBE_RC=0 node scripts/experimental_typing_env_reuse_oracle.mjs "$stage2_wasm"


### PR DESCRIPTION
## Summary

- split stage-independent preflight, examples, and range lint out of `compiler-gate`
- restore pkfire CAS through `actions/cache` using the actual MoonBit pkfire cache path
- avoid compiler bundle generation in the fake FS heap protocol test

## Measurements

- bootstrap selfbuild lane: 5m32s in recent CI logs, 3m15s locally after the split
- FS heap protocol test: about 2m14s in CI, 12s locally after removing unused bundle preparation

## Validation

- bootstrap seed -> stage1 -> stage2 -> stage3 fixpoint
- compiler-gate registry and CI layout self-tests
- FS heap protocol test
- Taskfile format and input checks
- actionlint and `git diff --check`