### PR TITLE
Fix GC return classification before generic erasure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,7 +867,8 @@ jobs:
             fixtures/eq_structural_aggregates_test.vibe \
             fixtures/map_builder_growth_test.vibe \
             fixtures/struct_field_collision_test.vibe \
-            fixtures/float_return_to_string_gc_test.vibe
+            fixtures/float_return_to_string_gc_test.vibe \
+            fixtures/float_return_review_gc.vibe
 
   # The 467-file selfhost unit-test battery (#531/#535), weight-balanced into
   # parallel shards (scripts/unit_test_weights.tsv drives the LPT partition

--- a/fixtures/float_return_review_gc.vibe
+++ b/fixtures/float_return_review_gc.vibe
@@ -1,0 +1,34 @@
+// GC-only regressions for #2182 review. The linear lane does not yet carry
+// checker-confirmed call-result types, so this file is registered explicitly
+// in the two GC fixture lists instead of using the repository-wide `_test`
+// suffix.
+
+type GenericValue = Double
+
+fn generic_return[GenericValue](x: GenericValue) -> GenericValue {
+  x
+}
+
+effect FloatProbe {
+  Read -> Double
+}
+
+fn hoisted_float_return() -> String with FloatProbe {
+  let local = () -> Double with FloatProbe {
+    perform FloatProbe::Read
+  }
+  __to_string(local())
+}
+
+test "#2182 review gc: a generic call uses its instantiated return type" {
+  assert_true(__to_string(generic_return(2.5)) == "2.5")
+}
+
+test "#2182 review gc: an effectful hoisted lambda retains its float return" {
+  let rendered = handle {
+    hoisted_float_return()
+  } with FloatProbe {
+    Read => resume(2.5)
+  }
+  assert_true(rendered == "2.5")
+}

--- a/fixtures/float_return_review_gc.vibe
+++ b/fixtures/float_return_review_gc.vibe
@@ -26,6 +26,15 @@ fn hoisted_float_return() -> String with FloatProbe {
   __to_string(local())
 }
 
+fn Double::whole(x: Double) -> Int {
+  Double::to_int(x)
+}
+
+fn render_int_array_after_try(value: Option[Double]) -> Option[String] {
+  let _unwrapped = value?
+  Some(__to_string([1, 2]))
+}
+
 test "#2182 review gc: a generic call uses its instantiated return type" {
   assert_true(__to_string(generic_return(2.5)) == "2.5")
 }
@@ -41,4 +50,16 @@ test "#2182 review gc: an effectful hoisted lambda retains its float return" {
     Read => resume(2.5)
   }
   assert_true(rendered == "2.5")
+}
+
+test "#2182 review gc: a Double receiver does not classify an Int call result as float" {
+  let d = 2.5
+  assert_true(__to_string(d.whole()) == "2")
+}
+
+test "#2182 review gc: a synthetic Double occurrence does not classify synthetic Int calls as float" {
+  match render_int_array_after_try(Some(2.5)) {
+    Some(rendered) => assert_true(rendered == "[1, 2]"),
+    None => assert_true(false)
+  }
 }

--- a/fixtures/float_return_review_gc.vibe
+++ b/fixtures/float_return_review_gc.vibe
@@ -9,6 +9,12 @@ fn generic_return[GenericValue](x: GenericValue) -> GenericValue {
   x
 }
 
+type UserPrefixedValue = Double
+
+fn __hoisted_lam_user[UserPrefixedValue](x: Int) -> UserPrefixedValue {
+  x
+}
+
 effect FloatProbe {
   Read -> Double
 }
@@ -22,6 +28,10 @@ fn hoisted_float_return() -> String with FloatProbe {
 
 test "#2182 review gc: a generic call uses its instantiated return type" {
   assert_true(__to_string(generic_return(2.5)) == "2.5")
+}
+
+test "#2182 review gc: a user hoist-prefix name keeps binder shadowing" {
+  assert_true(__to_string(__hoisted_lam_user(7)) == "7")
 }
 
 test "#2182 review gc: an effectful hoisted lambda retains its float return" {

--- a/fixtures/float_return_to_string_gc_test.vibe
+++ b/fixtures/float_return_to_string_gc_test.vibe
@@ -72,6 +72,12 @@ fn as_f32_gc() -> f32 {
   2.5
 }
 
+type ShadowedDouble = Double
+
+fn shadowed_return[ShadowedDouble](x: Int) -> ShadowedDouble {
+  x
+}
+
 //# Tests
 
 test "#2158 gc: a call to a `-> Double` function stringifies as a Double" {
@@ -130,4 +136,8 @@ test "#2166 gc: a parameterized alias onto Double is classified" {
 test "#2166 gc: the f64 and f32 spellings are floats" {
   assert_true(__to_string(as_f64_gc()) == "2.5")
   assert_true(__to_string(as_f32_gc()) == "2.5")
+}
+
+test "#2178 gc: a return type parameter shadows a Double alias" {
+  assert_true(__to_string(shadowed_return(7)) == "7")
 }

--- a/lib/@vibe/compiler/_cli_gc_entry.vibe
+++ b/lib/@vibe/compiler/_cli_gc_entry.vibe
@@ -4,7 +4,7 @@ import @vibe/compiler/syntax {
   lex, parse_program
 }
 import @vibe/compiler/checker {
-  check_program
+  check_program_result, checked_program_double_occurrence_offsets
 }
 import @vibe/compiler/codegen/gc {
   compile_wasi_module_gc,
@@ -40,7 +40,8 @@ fn cli_main() -> Int with Exception + Fs + Env {
     let source = perform Fs::ReadFile(input_path)
     let tokens = lex(source)
     let stmts = parse_program(tokens)
-    let _ = check_program(stmts)
+    let checked = check_program_result(stmts)
+    let gc_float_call_offsets = checked_program_double_occurrence_offsets(checked)
     // #1015: this entry never strips generic type params, so `stmts` here
     // is still the pre-strip shape gc_to_string_resolves_to_show_wrapper
     // needs (see its doc comment / gc_only.vibe's call for why ORDER
@@ -48,7 +49,7 @@ fn cli_main() -> Int with Exception + Fs + Env {
     let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
     let direct_abi_generic_names = gc_direct_abi_pre_erasure_generic_names(stmts)
     let gc_float_ret_fn_names = gc_float_returning_names_pre_erasure(stmts)
-    let bytes = compile_wasi_module_gc(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
+    let bytes = compile_wasi_module_gc(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names, gc_float_call_offsets)
     Fs::write_bytes(output_path, bytes)
     0
   }

--- a/lib/@vibe/compiler/_cli_gc_entry.vibe
+++ b/lib/@vibe/compiler/_cli_gc_entry.vibe
@@ -7,7 +7,10 @@ import @vibe/compiler/checker {
   check_program
 }
 import @vibe/compiler/codegen/gc {
-  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc,
+  gc_direct_abi_pre_erasure_generic_names,
+  gc_float_returning_names_pre_erasure,
+  gc_to_string_resolves_to_show_wrapper
 }
 
 //# Functions
@@ -44,7 +47,8 @@ fn cli_main() -> Int with Exception + Fs + Env {
     // matters when a strip pass IS in the pipeline).
     let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
     let direct_abi_generic_names = gc_direct_abi_pre_erasure_generic_names(stmts)
-    let bytes = compile_wasi_module_gc(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_generic_names)
+    let gc_float_ret_fn_names = gc_float_returning_names_pre_erasure(stmts)
+    let bytes = compile_wasi_module_gc(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
     Fs::write_bytes(output_path, bytes)
     0
   }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -9357,7 +9357,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       }
       let s2 = match env_lookup(env, "__return_provenance__") {
         Some(CtVar(id)) => {
-          Array::push(tytab, (return_provenance_key(id), CtUnit))
+          append_legacy_typed_occurrence(tytab, return_provenance_key(id), CtUnit, capture, "ReturnProvenance", "SyntheticRewrite")
           let previous = subst_apply(s1, CtVar(id))
           let merged = match previous {
             CtVar(_) => subst_apply(s1, et),

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -41,6 +41,7 @@ export ./checker_stmt.vibe {
   check_program,
   check_program_binder_occurrence_observation,
   check_program_direct_expression_return_observation,
+  check_program_double_call_result_observation,
   check_program_result,
   check_program_statement_root_type_observation,
   check_program_type_defs_observation,
@@ -57,6 +58,5 @@ export ./checker_stmt.vibe {
   check_program_with_env_typed_occurrence_role_lane_observation,
   check_program_with_env_typed_occurrence_statement_observation,
   check_program_with_projected_import_env_result,
-  check_stmts,
-  checked_program_double_occurrence_offsets
+  check_stmts
 }

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -57,5 +57,6 @@ export ./checker_stmt.vibe {
   check_program_with_env_typed_occurrence_role_lane_observation,
   check_program_with_env_typed_occurrence_statement_observation,
   check_program_with_projected_import_env_result,
-  check_stmts
+  check_stmts,
+  checked_program_double_occurrence_offsets
 }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3878,6 +3878,39 @@ export fn check_program_result(stmts: Array[Stmt]) -> CheckedProgram with Except
   check_program_type_defs_observation_impl(stmts, None, None).checked_program
 }
 
+/// Exact source offsets whose checker-confirmed expression result is Double.
+/// Consumers still decide which expression roles they care about; in
+/// particular, GC codegen consults this only for ECall offsets. Keeping the
+/// checker substitution here avoids reconstructing generic instantiations
+/// from an erased AST.
+export fn checked_program_double_occurrence_offsets(checked: CheckedProgram) -> Array[Int] {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(checked.typed_occurrences) {
+    let (off, raw_ty) = Array::get(checked.typed_occurrences, i)
+    match subst_apply(checked.final_subst, raw_ty) {
+      CtDouble => {
+        let mut seen = false
+        let mut j = 0
+        while j < Array::length(out) {
+          if Array::get(out, j) == off {
+            seen = true
+            j = Array::length(out)
+          } else {
+            j = j + 1
+          }
+        }
+        if !seen {
+          Array::push(out, off)
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 /// Compatibility API: preserve the historical TypeEnv result and error
 /// behavior while delegating through the successful production result.
 export fn check_program(stmts: Array[Stmt]) -> TypeEnv with Exception {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3878,37 +3878,58 @@ export fn check_program_result(stmts: Array[Stmt]) -> CheckedProgram with Except
   check_program_type_defs_observation_impl(stmts, None, None).checked_program
 }
 
-/// Exact source offsets whose checker-confirmed expression result is Double.
-/// Consumers still decide which expression roles they care about; in
-/// particular, GC codegen consults this only for ECall offsets. Keeping the
-/// checker substitution here avoids reconstructing generic instantiations
-/// from an erased AST.
-export fn checked_program_double_occurrence_offsets(checked: CheckedProgram) -> Array[Int] {
-  let out: Array[Int] = []
-  let mut i = 0
-  while i < Array::length(checked.typed_occurrences) {
-    let (off, raw_ty) = Array::get(checked.typed_occurrences, i)
-    match subst_apply(checked.final_subst, raw_ty) {
-      CtDouble => {
-        let mut seen = false
-        let mut j = 0
-        while j < Array::length(out) {
-          if Array::get(out, j) == off {
-            seen = true
-            j = Array::length(out)
-          } else {
-            j = j + 1
-          }
-        }
-        if !seen {
-          Array::push(out, off)
-        }
-      },
-      _ => ()
-    }
-    i = i + 1
+/// Check once and retain only source-located primary call results whose
+/// checker-confirmed instantiated type is Double. Offset alone is not enough:
+/// a dot-call receiver and its non-Double result can share the same offset.
+export fn check_program_double_call_result_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int])] with Exception {
+  let capture = TypedOccurrenceRoleLaneCapture::{
+    entries: array_empty(),
+    provenance_entries: array_empty(),
+    statement_path: array_empty(),
+    frame_paths: array_empty(),
+    frame_next_children: array_empty(),
+    frame_expected_children: array_empty(),
+    frame_direct_recorded: array_empty(),
+    direct_entries: array_empty(),
+    direct_enabled: false,
+    frame_depth: 0,
+    complete: true
   }
-  out
+  let checked = check_program_type_defs_observation_impl(stmts, None, Some(capture)).checked_program
+  if Array::length(capture.entries) != Array::length(checked.typed_occurrences) {
+    None
+  } else {
+    let out: Array[Int] = []
+    let mut i = 0
+    while i < Array::length(checked.typed_occurrences) {
+      let (off, raw_ty) = Array::get(checked.typed_occurrences, i)
+      let (role, lane) = Array::get(capture.entries, i)
+      match subst_apply(checked.final_subst, raw_ty) {
+        CtDouble => {
+          if off >= 0 && role == "CallResult" && lane == "Primary" {
+            let mut seen = false
+            let mut j = 0
+            while j < Array::length(out) {
+              if Array::get(out, j) == off {
+                seen = true
+                j = Array::length(out)
+              } else {
+                j = j + 1
+              }
+            }
+            if !seen {
+              Array::push(out, off)
+            }
+          } else {
+            ()
+          }
+        },
+        _ => ()
+      }
+      i = i + 1
+    }
+    Some((checked, out))
+  }
 }
 
 /// Compatibility API: preserve the historical TypeEnv result and error

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -247,7 +247,7 @@ type CheckedProgram
 type CheckedProgramTypeDefsObservation
 fn check_stmts(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)]) -> (TypeEnv, Subst, Int)
 fn check_program_result(stmts: Array[Stmt]) -> CheckedProgram with Exception
-fn checked_program_double_occurrence_offsets(checked: CheckedProgram) -> Array[Int]
+fn check_program_double_call_result_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int])] with Exception
 fn check_program_type_defs_observation(stmts: Array[Stmt]) -> CheckedProgramTypeDefsObservation with Exception
 fn check_program_typed_occurrence_statement_observation(stmts: Array[Stmt]) -> Option[CheckedTypedOccurrenceStatementObservation] with Exception
 fn check_program_statement_root_type_observation(stmts: Array[Stmt]) -> Option[CheckedStatementRootTypeObservation] with Exception

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -247,6 +247,7 @@ type CheckedProgram
 type CheckedProgramTypeDefsObservation
 fn check_stmts(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)]) -> (TypeEnv, Subst, Int)
 fn check_program_result(stmts: Array[Stmt]) -> CheckedProgram with Exception
+fn checked_program_double_occurrence_offsets(checked: CheckedProgram) -> Array[Int]
 fn check_program_type_defs_observation(stmts: Array[Stmt]) -> CheckedProgramTypeDefsObservation with Exception
 fn check_program_typed_occurrence_statement_observation(stmts: Array[Stmt]) -> Option[CheckedTypedOccurrenceStatementObservation] with Exception
 fn check_program_statement_root_type_observation(stmts: Array[Stmt]) -> Option[CheckedStatementRootTypeObservation] with Exception

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -858,6 +858,10 @@ export struct CompileCtxGc {
   // bits as an Int. Same silent-wrong the linear lane had; fixing only linear
   // left it live under VIBE_TEST_BACKEND=gc (#2156 review).
   gc_float_ret_fns: Array[String];
+  // Checker-confirmed Double expression offsets. GC consults this only for
+  // ECall nodes, so generic functions are classified per instantiation
+  // instead of once by their erased declaration name (#2182 review).
+  gc_float_call_offsets: Array[Int];
   // #1015: gc twin of the linear lane's int_local_slots kind-3 (boolish)
   // tracking -- locals (params/lets) KNOWN to hold a Bool. Bool and Int
   // share the same gc-lane numeric representation (no distinguishing

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -1033,14 +1033,29 @@ export fn gc_float_returning_names_pre_erasure(stmts: Array[Stmt]) -> Array[Stri
   compute_float_returning_names(stmts)
 }
 
-/// Add only functions synthesized by lambda hoisting. Reclassifying ordinary
-/// declarations after erasure would lose type-parameter shadowing evidence.
-export fn gc_add_hoisted_float_returning_names(stmts: Array[Stmt], names: Array[String]) -> Unit {
+/// Top-level function declaration identities before lambda hoisting.
+export fn gc_top_level_function_names(stmts: Array[Stmt]) -> Array[String] {
+  let out: Array[String] = []
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, EFn(_, _, _, _, _, _)) => Array::push(out, name),
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// Add only declarations synthesized by lambda hoisting. The before-set is
+/// the provenance boundary: spelling is not authority because users may
+/// legally declare names beginning with `__hoisted_lam_`.
+export fn gc_add_hoisted_float_returning_names(stmts: Array[Stmt], before_names: Array[String], names: Array[String]) -> Unit {
   let post_desugar = compute_float_returning_names(stmts)
   let mut i = 0
   while i < Array::length(post_desugar) {
     let name = Array::get(post_desugar, i)
-    if String::starts_with(name, "__hoisted_lam_") && !array_contains_str(names, name) {
+    if !array_contains_str(before_names, name) && !array_contains_str(names, name) {
       Array::push(names, name)
     }
     i = i + 1

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -1029,9 +1029,13 @@ fn gc_unresolved_import_message(err: String, stmts: Array[Stmt]) -> Option[Strin
   }
 }
 
-export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String]) -> Bytes with Exception {
+export fn gc_float_returning_names_pre_erasure(stmts: Array[Stmt]) -> Array[String] {
+  compute_float_returning_names(stmts)
+}
+
+export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String]) -> Bytes with Exception {
   handle {
-    compile_wasi_module_gc_impl(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_generic_names)
+    compile_wasi_module_gc_impl(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
   } with Exception {
     Throw(err) => match gc_unresolved_import_message(err, stmts) {
       Some(better) => throw(better),
@@ -1040,7 +1044,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   }
 }
 
-fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String]) -> Bytes with Exception {
+fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String]) -> Bytes with Exception {
   // #805: inline-wasm fns are linear-backend only — reject before any work.
   gc_reject_inline_wasm(stmts)
   gc_add_ref_twins(stmts)
@@ -1079,8 +1083,6 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_str
     ()
   }
   let fn_names_list = array_empty()
-  // #2158: one shared walk, in common_analysis (#2156 review).
-  let gc_float_ret_fn_names = compute_float_returning_names(stmts)
   let fn_param_counts = array_empty()
   let fn_needs_env_list = array_empty()
   let user_func_stmts = array_empty()

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -1033,9 +1033,23 @@ export fn gc_float_returning_names_pre_erasure(stmts: Array[Stmt]) -> Array[Stri
   compute_float_returning_names(stmts)
 }
 
-export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String]) -> Bytes with Exception {
+/// Add only functions synthesized by lambda hoisting. Reclassifying ordinary
+/// declarations after erasure would lose type-parameter shadowing evidence.
+export fn gc_add_hoisted_float_returning_names(stmts: Array[Stmt], names: Array[String]) -> Unit {
+  let post_desugar = compute_float_returning_names(stmts)
+  let mut i = 0
+  while i < Array::length(post_desugar) {
+    let name = Array::get(post_desugar, i)
+    if String::starts_with(name, "__hoisted_lam_") && !array_contains_str(names, name) {
+      Array::push(names, name)
+    }
+    i = i + 1
+  }
+}
+
+export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String], gc_float_call_offsets: Array[Int]) -> Bytes with Exception {
   handle {
-    compile_wasi_module_gc_impl(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
+    compile_wasi_module_gc_impl(stmts, entry_name, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names, gc_float_call_offsets)
   } with Exception {
     Throw(err) => match gc_unresolved_import_message(err, stmts) {
       Some(better) => throw(better),
@@ -1044,7 +1058,7 @@ export fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_s
   }
 }
 
-fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String]) -> Bytes with Exception {
+fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String], gc_float_call_offsets: Array[Int]) -> Bytes with Exception {
   // #805: inline-wasm fns are linear-backend only — reject before any work.
   gc_reject_inline_wasm(stmts)
   gc_add_ref_twins(stmts)
@@ -2207,6 +2221,7 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_str
             gc_global_names: gc_global_names_l,
             gc_float_locals: gc_float_slots_f,
             gc_float_ret_fns: gc_float_ret_fn_names,
+            gc_float_call_offsets: gc_float_call_offsets,
             gc_bool_locals: gc_bool_slots_f,
             gc_native_array_locals: direct_param_slots_f,
             gc_native_array_local_types: array_empty(),
@@ -2305,6 +2320,7 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_str
       gc_global_names: gc_global_names_l,
       gc_float_locals: array_empty(),
       gc_float_ret_fns: gc_float_ret_fn_names,
+      gc_float_call_offsets: gc_float_call_offsets,
       gc_bool_locals: array_empty(),
       gc_native_array_locals: array_empty(),
       gc_native_array_local_types: array_empty(),

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -291,8 +291,8 @@ fn bc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -
     },
     EBinOp(op, l, r) => (op == "+" || op == "-" || op == "*" || op == "/") && (bc_expr_is_floatish(l, local_names, ctx) || bc_expr_is_floatish(r, local_names, ctx)),
     EUnaryOp(op, x) => op == "-" && bc_expr_is_floatish(x, local_names, ctx),
-    ECall(fcallee, _, _) => match fcallee {
-      EIdent(cn, _) => cn == "Int::to_double" || cn == "Double::from_i64_bits" || cn == "Float::to_double" || cn == "Double::to_float" || cn == "Int::to_float" || gc_fn_returns_float(local_names, ctx, cn),
+    ECall(fcallee, _, call_off) => match fcallee {
+      EIdent(cn, _) => array_contains_int(ctx.gc_float_call_offsets, call_off) || cn == "Int::to_double" || cn == "Double::from_i64_bits" || cn == "Float::to_double" || cn == "Double::to_float" || cn == "Int::to_float" || gc_fn_returns_float(local_names, ctx, cn),
       _ => false
     },
     _ => false

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -257,8 +257,8 @@ fn gc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -
     },
     EBinOp(op, l, r) => (op == "+" || op == "-" || op == "*" || op == "/") && (gc_expr_is_floatish(l, local_names, ctx) || gc_expr_is_floatish(r, local_names, ctx)),
     EUnaryOp(op, x) => op == "-" && gc_expr_is_floatish(x, local_names, ctx),
-    ECall(fcallee, _, _) => match fcallee {
-      EIdent(cn, _) => cn == "Int::to_double" || cn == "Double::from_i64_bits" || cn == "Float::to_double" || cn == "Double::to_float" || cn == "Int::to_float" || gc_fn_returns_float(local_names, ctx, cn),
+    ECall(fcallee, _, call_off) => match fcallee {
+      EIdent(cn, _) => array_contains_int(ctx.gc_float_call_offsets, call_off) || cn == "Int::to_double" || cn == "Double::from_i64_bits" || cn == "Float::to_double" || cn == "Double::to_float" || cn == "Int::to_float" || gc_fn_returns_float(local_names, ctx, cn),
       _ => false
     },
     _ => false

--- a/lib/@vibe/compiler/codegen/gc/backend_lambda_ctx.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_lambda_ctx.vibe
@@ -32,6 +32,7 @@ fn make_lambda_ctx_gc(ctx: CompileCtxGc, ref_cell_names: Array[String], ref_loca
     // Double/Bool params, seeded separately after this call returns).
     gc_float_locals: array_empty(),
     gc_float_ret_fns: ctx.gc_float_ret_fns,
+    gc_float_call_offsets: ctx.gc_float_call_offsets,
     gc_bool_locals: array_empty(),
     // #1332: lambda records now DO carry typed-local metadata into the module
     // body declaration pass (gc_lambda_native_array_locals, appended by

--- a/lib/@vibe/compiler/codegen/gc/gc.vibe
+++ b/lib/@vibe/compiler/codegen/gc/gc.vibe
@@ -1,5 +1,6 @@
 import ./backend_body.vibe {
   compile_wasi_module_gc,
+  gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
   gc_to_string_resolves_to_show_wrapper
@@ -7,6 +8,7 @@ import ./backend_body.vibe {
 
 export {
   compile_wasi_module_gc,
+  gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
   gc_to_string_resolves_to_show_wrapper

--- a/lib/@vibe/compiler/codegen/gc/gc.vibe
+++ b/lib/@vibe/compiler/codegen/gc/gc.vibe
@@ -1,7 +1,13 @@
 import ./backend_body.vibe {
-  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc,
+  gc_direct_abi_pre_erasure_generic_names,
+  gc_float_returning_names_pre_erasure,
+  gc_to_string_resolves_to_show_wrapper
 }
 
 export {
-  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc,
+  gc_direct_abi_pre_erasure_generic_names,
+  gc_float_returning_names_pre_erasure,
+  gc_to_string_resolves_to_show_wrapper
 }

--- a/lib/@vibe/compiler/codegen/gc/gc.vibe
+++ b/lib/@vibe/compiler/codegen/gc/gc.vibe
@@ -3,7 +3,8 @@ import ./backend_body.vibe {
   gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
-  gc_to_string_resolves_to_show_wrapper
+  gc_to_string_resolves_to_show_wrapper,
+  gc_top_level_function_names
 }
 
 export {
@@ -11,5 +12,6 @@ export {
   gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
-  gc_to_string_resolves_to_show_wrapper
+  gc_to_string_resolves_to_show_wrapper,
+  gc_top_level_function_names
 }

--- a/lib/@vibe/compiler/codegen/gc/index.vpkg
+++ b/lib/@vibe/compiler/codegen/gc/index.vpkg
@@ -20,7 +20,8 @@ generated_hash =
 // backend_builtins_*.vibe (array/numeric/print/string body generators),
 // backend_lambda_*.vibe (wasm-gc lambda codegen).
 
-fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String]) -> Bytes with Exception
+fn gc_float_returning_names_pre_erasure(stmts: Array[Stmt]) -> Array[String]
+fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String]) -> Bytes with Exception
 fn gc_direct_abi_pre_erasure_generic_names(stmts: Array[Stmt]) -> Array[String]
 fn gc_to_string_resolves_to_show_wrapper(stmts: Array[Stmt]) -> Bool
 fn gc_gen_arr_len_body() -> Bytes

--- a/lib/@vibe/compiler/codegen/gc/index.vpkg
+++ b/lib/@vibe/compiler/codegen/gc/index.vpkg
@@ -21,7 +21,8 @@ generated_hash =
 // backend_lambda_*.vibe (wasm-gc lambda codegen).
 
 fn gc_float_returning_names_pre_erasure(stmts: Array[Stmt]) -> Array[String]
-fn gc_add_hoisted_float_returning_names(stmts: Array[Stmt], names: Array[String]) -> Unit
+fn gc_top_level_function_names(stmts: Array[Stmt]) -> Array[String]
+fn gc_add_hoisted_float_returning_names(stmts: Array[Stmt], before_names: Array[String], names: Array[String]) -> Unit
 fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String], gc_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn gc_direct_abi_pre_erasure_generic_names(stmts: Array[Stmt]) -> Array[String]
 fn gc_to_string_resolves_to_show_wrapper(stmts: Array[Stmt]) -> Bool

--- a/lib/@vibe/compiler/codegen/gc/index.vpkg
+++ b/lib/@vibe/compiler/codegen/gc/index.vpkg
@@ -21,7 +21,8 @@ generated_hash =
 // backend_lambda_*.vibe (wasm-gc lambda codegen).
 
 fn gc_float_returning_names_pre_erasure(stmts: Array[Stmt]) -> Array[String]
-fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String]) -> Bytes with Exception
+fn gc_add_hoisted_float_returning_names(stmts: Array[Stmt], names: Array[String]) -> Unit
+fn compile_wasi_module_gc(stmts: Array[Stmt], entry_name: String, gc_to_string_is_wrapper: Bool, direct_abi_generic_names: Array[String], gc_float_ret_fn_names: Array[String], gc_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn gc_direct_abi_pre_erasure_generic_names(stmts: Array[Stmt]) -> Array[String]
 fn gc_to_string_resolves_to_show_wrapper(stmts: Array[Stmt]) -> Bool
 fn gc_gen_arr_len_body() -> Bytes

--- a/lib/@vibe/compiler/codegen_gc.vibe
+++ b/lib/@vibe/compiler/codegen_gc.vibe
@@ -5,7 +5,8 @@ import @vibe/compiler/codegen/gc {
   gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
-  gc_to_string_resolves_to_show_wrapper
+  gc_to_string_resolves_to_show_wrapper,
+  gc_top_level_function_names
 }
 
 //# Misc
@@ -15,5 +16,6 @@ export {
   gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
-  gc_to_string_resolves_to_show_wrapper
+  gc_to_string_resolves_to_show_wrapper,
+  gc_top_level_function_names
 }

--- a/lib/@vibe/compiler/codegen_gc.vibe
+++ b/lib/@vibe/compiler/codegen_gc.vibe
@@ -1,11 +1,17 @@
 //# Imports
 
 import @vibe/compiler/codegen/gc {
-  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc,
+  gc_direct_abi_pre_erasure_generic_names,
+  gc_float_returning_names_pre_erasure,
+  gc_to_string_resolves_to_show_wrapper
 }
 
 //# Misc
 
 export {
-  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc,
+  gc_direct_abi_pre_erasure_generic_names,
+  gc_float_returning_names_pre_erasure,
+  gc_to_string_resolves_to_show_wrapper
 }

--- a/lib/@vibe/compiler/codegen_gc.vibe
+++ b/lib/@vibe/compiler/codegen_gc.vibe
@@ -2,6 +2,7 @@
 
 import @vibe/compiler/codegen/gc {
   compile_wasi_module_gc,
+  gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
   gc_to_string_resolves_to_show_wrapper
@@ -11,6 +12,7 @@ import @vibe/compiler/codegen/gc {
 
 export {
   compile_wasi_module_gc,
+  gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
   gc_to_string_resolves_to_show_wrapper

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -20,7 +20,8 @@ import @vibe/compiler/codegen/gc {
   gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
-  gc_to_string_resolves_to_show_wrapper
+  gc_to_string_resolves_to_show_wrapper,
+  gc_top_level_function_names
 }
 
 // #847 Phase C exception: this file drives the wasm-gc backend
@@ -363,6 +364,7 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   // erasure below removes them, a return type parameter that shadows a
   // Double alias is indistinguishable from that alias and is misclassified.
   let gc_float_ret_fn_names = gc_float_returning_names_pre_erasure(stmts)
+  let gc_pre_hoist_fn_names = gc_top_level_function_names(stmts)
   // Same effective order as the linear lane: strip source-level generic
   // params, then the trait-dict desugar (compile_wasi_module_linked_impl
   // runs it as its first step).
@@ -371,6 +373,6 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   // Trait-dict desugaring hoists capture-free effectful lambdas after the
   // pre-erasure snapshot. Add only those generated declarations; ordinary
   // declarations must keep the binder-aware pre-erasure answer.
-  gc_add_hoisted_float_returning_names(stmts, gc_float_ret_fn_names)
+  gc_add_hoisted_float_returning_names(stmts, gc_pre_hoist_fn_names, gc_float_ret_fn_names)
   compile_wasi_module_gc(stmts, effective_entry, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names, gc_float_call_offsets)
 }

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -1,14 +1,14 @@
 //# Imports
 
 import @vibe/compiler/syntax {
-  Token, lex, parse_program, parse_stmt
+  Token, lex, lex_with_offsets, parse_program, parse_program_located, parse_stmt
 }
 
 import @vibe/core {
   array_empty
 }
 import @vibe/compiler/checker {
-  check_program
+  check_program_result, checked_program_double_occurrence_offsets
 }
 
 import @vibe/compiler/codegen {
@@ -17,6 +17,7 @@ import @vibe/compiler/codegen {
 
 import @vibe/compiler/codegen/gc {
   compile_wasi_module_gc,
+  gc_add_hoisted_float_returning_names,
   gc_direct_abi_pre_erasure_generic_names,
   gc_float_returning_names_pre_erasure,
   gc_to_string_resolves_to_show_wrapper
@@ -330,8 +331,8 @@ fn lower_test_blocks_gc(stmts: Array[Stmt], entry_name: String) -> String with E
 /// etc.); without it the gc lane compared ctor POINTERS, so the gc-compiled
 /// checker's Option/effect-row comparisons were silently wrong.
 export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes with Exception {
-  let tokens = lex(source)
-  let stmts = parse_program(tokens)
+  let (tokens, starts, _) = lex_with_offsets(source)
+  let stmts = parse_program_located(tokens, starts, source)
   expand_interp_stmts(stmts)
   // #683: lower test/bench blocks BEFORE the check so the synthesized
   // `__test_*` lets and the no-entry `_start` runner are type-checked like
@@ -347,7 +348,8 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   // `lowered_test_ambient_effects` recognizes these two prefixes, so the
   // grant survives the lowering without changing what CODEGEN sees.
   let effective_entry = lower_test_blocks_gc(stmts, entry_name)
-  let _ = check_program(stmts)
+  let checked = check_program_result(stmts)
+  let gc_float_call_offsets = checked_program_double_occurrence_offsets(checked)
   // #1015: MUST run before strip_generic_type_params below -- that pass
   // unconditionally zeroes every top-level generic fn's type_params/bounds
   // (erasure, not specific to `to_string`), so checking the Show-bounded
@@ -366,5 +368,9 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   // runs it as its first step).
   strip_generic_type_params(stmts)
   desugar_trait_dicts(stmts)
-  compile_wasi_module_gc(stmts, effective_entry, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
+  // Trait-dict desugaring hoists capture-free effectful lambdas after the
+  // pre-erasure snapshot. Add only those generated declarations; ordinary
+  // declarations must keep the binder-aware pre-erasure answer.
+  gc_add_hoisted_float_returning_names(stmts, gc_float_ret_fn_names)
+  compile_wasi_module_gc(stmts, effective_entry, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names, gc_float_call_offsets)
 }

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -8,7 +8,7 @@ import @vibe/core {
   array_empty
 }
 import @vibe/compiler/checker {
-  check_program_result, checked_program_double_occurrence_offsets
+  check_program_double_call_result_observation
 }
 
 import @vibe/compiler/codegen {
@@ -349,8 +349,10 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   // `lowered_test_ambient_effects` recognizes these two prefixes, so the
   // grant survives the lowering without changing what CODEGEN sees.
   let effective_entry = lower_test_blocks_gc(stmts, entry_name)
-  let checked = check_program_result(stmts)
-  let gc_float_call_offsets = checked_program_double_occurrence_offsets(checked)
+  let (checked, gc_float_call_offsets) = match check_program_double_call_result_observation(stmts) {
+    Some(observation) => observation,
+    None => throw("internal compiler error: incomplete GC call-result type observation")
+  }
   // #1015: MUST run before strip_generic_type_params below -- that pass
   // unconditionally zeroes every top-level generic fn's type_params/bounds
   // (erasure, not specific to `to_string`), so checking the Show-bounded

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -16,7 +16,10 @@ import @vibe/compiler/codegen {
 }
 
 import @vibe/compiler/codegen/gc {
-  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc,
+  gc_direct_abi_pre_erasure_generic_names,
+  gc_float_returning_names_pre_erasure,
+  gc_to_string_resolves_to_show_wrapper
 }
 
 // #847 Phase C exception: this file drives the wasm-gc backend
@@ -354,10 +357,14 @@ export fn compile_source_gc_only(source: String, entry_name: String) -> Bytes wi
   // See the doc comment on gc_to_string_resolves_to_show_wrapper.
   let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
   let direct_abi_generic_names = gc_direct_abi_pre_erasure_generic_names(stmts)
+  // #2178: this table must retain the function's type binders. Once the
+  // erasure below removes them, a return type parameter that shadows a
+  // Double alias is indistinguishable from that alias and is misclassified.
+  let gc_float_ret_fn_names = gc_float_returning_names_pre_erasure(stmts)
   // Same effective order as the linear lane: strip source-level generic
   // params, then the trait-dict desugar (compile_wasi_module_linked_impl
   // runs it as its first step).
   strip_generic_type_params(stmts)
   desugar_trait_dicts(stmts)
-  compile_wasi_module_gc(stmts, effective_entry, gc_to_string_is_wrapper, direct_abi_generic_names)
+  compile_wasi_module_gc(stmts, effective_entry, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
 }

--- a/lib/@vibe/compiler/tests/codegen_test_support.vibe
+++ b/lib/@vibe/compiler/tests/codegen_test_support.vibe
@@ -5,7 +5,10 @@ import @vibe/compiler/codegen {
 }
 
 import @vibe/compiler/codegen/gc {
-  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc,
+  gc_direct_abi_pre_erasure_generic_names,
+  gc_float_returning_names_pre_erasure,
+  gc_to_string_resolves_to_show_wrapper
 }
 
 import @vibe/compiler/syntax {
@@ -56,7 +59,8 @@ export fn compile_wasi_gc(source: String, entry: String) -> Bytes with Exception
   // needs.
   let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
   let direct_abi_generic_names = gc_direct_abi_pre_erasure_generic_names(stmts)
-  compile_wasi_module_gc(stmts, entry, gc_to_string_is_wrapper, direct_abi_generic_names)
+  let gc_float_ret_fn_names = gc_float_returning_names_pre_erasure(stmts)
+  compile_wasi_module_gc(stmts, entry, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
 }
 
 export fn compile_wasi_with_imports(import_sources: Array[String], source: String, entry: String) -> Bytes with Exception {

--- a/lib/@vibe/compiler/tests/codegen_test_support.vibe
+++ b/lib/@vibe/compiler/tests/codegen_test_support.vibe
@@ -1,5 +1,9 @@
 //# Imports
 
+import @vibe/core {
+  array_empty
+}
+
 import @vibe/compiler/codegen {
   compile_module, compile_wasi_module, compile_wasi_module_rc
 }
@@ -60,7 +64,7 @@ export fn compile_wasi_gc(source: String, entry: String) -> Bytes with Exception
   let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
   let direct_abi_generic_names = gc_direct_abi_pre_erasure_generic_names(stmts)
   let gc_float_ret_fn_names = gc_float_returning_names_pre_erasure(stmts)
-  compile_wasi_module_gc(stmts, entry, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
+  compile_wasi_module_gc(stmts, entry, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names, array_empty())
 }
 
 export fn compile_wasi_with_imports(import_sources: Array[String], source: String, entry: String) -> Bytes with Exception {

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -19,7 +19,7 @@ import @vibe/compiler/codegen/wasi {
 }
 
 import ../codegen_gc.vibe {
-  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_to_string_resolves_to_show_wrapper
+  compile_wasi_module_gc, gc_direct_abi_pre_erasure_generic_names, gc_float_returning_names_pre_erasure, gc_to_string_resolves_to_show_wrapper
 }
 
 import @vibe/compiler/codegen {
@@ -55,7 +55,8 @@ fn gc_err(src: String) -> String {
     // shape gc_to_string_resolves_to_show_wrapper needs.
     let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
     let direct_abi_generic_names = gc_direct_abi_pre_erasure_generic_names(stmts)
-    let _ = compile_wasi_module_gc(stmts, "__no_entry__", gc_to_string_is_wrapper, direct_abi_generic_names)
+    let gc_float_ret_fn_names = gc_float_returning_names_pre_erasure(stmts)
+    let _ = compile_wasi_module_gc(stmts, "__no_entry__", gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
     ""
   } with Exception {
     Throw(msg) => msg

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -1,5 +1,9 @@
 //# Imports
 
+import @vibe/core {
+  array_empty
+}
+
 // #805 (ADR-0072): inline wasm — `fn f(a: Int, b: Int) -> Int = wasm "..."`.
 // Reject-cases (parse-level v0.3 slice restrictions, gc-backend rejection,
 // malformed WAT with a located error) plus the assembler's byte-level
@@ -56,7 +60,7 @@ fn gc_err(src: String) -> String {
     let gc_to_string_is_wrapper = gc_to_string_resolves_to_show_wrapper(stmts)
     let direct_abi_generic_names = gc_direct_abi_pre_erasure_generic_names(stmts)
     let gc_float_ret_fn_names = gc_float_returning_names_pre_erasure(stmts)
-    let _ = compile_wasi_module_gc(stmts, "__no_entry__", gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names)
+    let _ = compile_wasi_module_gc(stmts, "__no_entry__", gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names, array_empty())
     ""
   } with Exception {
     Throw(msg) => msg

--- a/scripts/test_gc_selfbuild.sh
+++ b/scripts/test_gc_selfbuild.sh
@@ -312,7 +312,8 @@ if VIBE_TEST_CLI_WASM="$CLI_WASM" VIBE_TEST_BACKEND=gc \
     fixtures/eq_structural_aggregates_test.vibe \
     fixtures/map_builder_growth_test.vibe \
     fixtures/struct_field_collision_test.vibe \
-    fixtures/float_return_to_string_gc_test.vibe > "$gcfx_log" 2>&1; then
+    fixtures/float_return_to_string_gc_test.vibe \
+    fixtures/float_return_review_gc.vibe > "$gcfx_log" 2>&1; then
   sed 's/^/[gc-selfbuild]   /' "$gcfx_log"
   echo "[gc-selfbuild] gc runtime fixtures ok"
 else


### PR DESCRIPTION
Closes #2178.

## Summary
- classify wasm-gc float-returning functions before generic type parameters are erased
- pass the pre-erasure classification explicitly into GC code generation
- cover a return type parameter that shadows a `Double` alias

## Validation
- fresh selfhost generation
- focused GC fixture (including the new regression)
- linear backend fixture
- CI wasm-gc fixture set (4/4)
- focused compiler unit tests (3/3)
- `pkf run test-affected` (1011/1011)
- formatter checks and `git diff --check`