### PR TITLE
Scope-precise formal classification: a type parameter shadows any same-spelled declared type (#2141)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,16 @@ jobs:
         with:
           path: _build/_ci_shard_gen
           key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Install wasmtime
+        # #2184: must run BEFORE "Build stage2 on cache miss" -- the build's
+        # validate step shells out to the wasmtime binary. Later steps (the
+        # oracles, KPI, size ratchet) need it too, so it stays unconditional.
+        env:
+          WASMTIME_VERSION: v47.0.2
+        run: |
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Build stage2 on cache miss
         if: steps.stage2-cache.outputs.cache-hit != 'true'
         run: |
@@ -204,13 +214,6 @@ jobs:
           curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux.tar.gz" | tar -xz
           cp "wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux/wasm-tools" "$PWD/compiler-tools/"
           echo "$PWD/compiler-tools" >> "$GITHUB_PATH"
-      - name: Install wasmtime
-        env:
-          WASMTIME_VERSION: v47.0.2
-        run: |
-          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
-          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
-          echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Stage cached compiler
         run: |
           mkdir -p _build/selfhost/generations/ci-oracles
@@ -282,6 +285,21 @@ jobs:
         with:
           path: _build/_ci_shard_gen
           key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Install wasmtime (cold stage2 build only)
+        # #2184: generations.sh's "validate stageN compiler -> sample" step
+        # shells out to a wasmtime BINARY, so the cold-cache build below needs
+        # it on PATH. A warm cache skips the build and never touches it --
+        # which is how this job passed until the first fingerprint-moving
+        # change ran it cold: the stage2 cache key includes the compiler-source
+        # fingerprint, so EVERY compiler-touching PR takes the cold path.
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        env:
+          WASMTIME_VERSION: v47.0.2
+        run: |
+          set -euo pipefail
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Build stage2 on cache miss
         if: steps.stage2-cache.outputs.cache-hit != 'true'
         run: |
@@ -363,6 +381,21 @@ jobs:
         with:
           path: _build/_ci_shard_gen
           key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Install wasmtime (cold stage2 build only)
+        # #2184: generations.sh's "validate stageN compiler -> sample" step
+        # shells out to a wasmtime BINARY, so the cold-cache build below needs
+        # it on PATH. A warm cache skips the build and never touches it --
+        # which is how this job passed until the first fingerprint-moving
+        # change ran it cold: the stage2 cache key includes the compiler-source
+        # fingerprint, so EVERY compiler-touching PR takes the cold path.
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        env:
+          WASMTIME_VERSION: v47.0.2
+        run: |
+          set -euo pipefail
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Build stage2 on cache miss
         if: steps.stage2-cache.outputs.cache-hit != 'true'
         run: |
@@ -426,6 +459,21 @@ jobs:
         with:
           path: _build/_ci_shard_gen
           key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Install wasmtime (cold stage2 build only)
+        # #2184: generations.sh's "validate stageN compiler -> sample" step
+        # shells out to a wasmtime BINARY, so the cold-cache build below needs
+        # it on PATH. A warm cache skips the build and never touches it --
+        # which is how this job passed until the first fingerprint-moving
+        # change ran it cold: the stage2 cache key includes the compiler-source
+        # fingerprint, so EVERY compiler-touching PR takes the cold path.
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        env:
+          WASMTIME_VERSION: v47.0.2
+        run: |
+          set -euo pipefail
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Build stage2
         if: steps.stage2-cache.outputs.cache-hit != 'true'
         run: |
@@ -477,6 +525,21 @@ jobs:
         with:
           path: _build/_ci_shard_gen
           key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Install wasmtime (cold stage2 build only)
+        # #2184: generations.sh's "validate stageN compiler -> sample" step
+        # shells out to a wasmtime BINARY, so the cold-cache build below needs
+        # it on PATH. A warm cache skips the build and never touches it --
+        # which is how this job passed until the first fingerprint-moving
+        # change ran it cold: the stage2 cache key includes the compiler-source
+        # fingerprint, so EVERY compiler-touching PR takes the cold path.
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        env:
+          WASMTIME_VERSION: v47.0.2
+        run: |
+          set -euo pipefail
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Build stage2
         if: steps.stage2-cache.outputs.cache-hit != 'true'
         run: |

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3489,7 +3489,41 @@ fn tps_decl_label(kind: String, name: String) -> String {
   String::concat(kind, String::concat(" `", String::concat(name, "`")))
 }
 
+/// #2141 (Codex P1 on #2183): the `__Vfp_` prefix is the desugar's re-spelling
+/// of a type-parameter -- `is_marked_formal_name` treats any matching spelling
+/// as compiler-generated, so a USER-DECLARED type borrowing the prefix
+/// (`struct __Vfp_Point`) would be classified as a variable and its arrays
+/// silently compared with erased equality. Reserve the prefix at the one place
+/// user source can introduce a colliding meaning: a type DECLARATION. Binders
+/// and annotations need no rule of their own -- a binder spelled `__Vfp_X` is
+/// genuinely a formal (nothing declared can collide once declarations are
+/// rejected), and an undeclared annotation is already an unknown type (#2125).
+/// Generated code never declares a `__Vfp_`-prefixed type (helpers are `let`
+/// functions; witness structs are `<Trait>Dict`), so the post-desugar merged
+/// re-check lane stays clean.
+fn tps_reserved_prefix_report(kind: String, name: String, errors: Array[String]) -> Unit {
+  if String::starts_with(name, "__Vfp_") {
+    Array::push(errors, String::concat(kind, String::concat(" `", String::concat(name, "` uses the reserved `__Vfp_` prefix (compiler-generated type-variable spellings) -- rename the type (#2141)"))))
+  } else {
+    ()
+  }
+}
+
+fn collect_reserved_type_prefix_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SStruct(_, name, _, _, _, _) => tps_reserved_prefix_report("struct", name, errors),
+      SEnum(_, name, _, _, _) => tps_reserved_prefix_report("enum", name, errors),
+      STypeAlias(_, name, _, _) => tps_reserved_prefix_report("type alias", name, errors),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
 fn collect_type_param_shadowing_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
+  collect_reserved_type_prefix_errors(stmts, errors)
   let local_types = tps_local_type_names(stmts)
   if Array::length(local_types) == 0 {
     ()

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3418,17 +3418,25 @@ export fn check_stmts(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: Array[
 /// comparison stays structural; pinned by
 /// derive_array_helper_interference_test.vibe), and rejecting it would break
 /// working programs whose dependency happens to export a colliding name.
-fn tps_local_type_names(stmts: Array[Stmt]) -> Array[String] {
-  let out = array_empty()
+fn tps_local_type_names_into(stmts: Array[Stmt], out: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SStruct(_, name, _, _, _, _) => Array::push(out, name),
       SEnum(_, name, _, _, _) => Array::push(out, name),
+      // #2141: `module` blocks are rejected by the parser (#728), so source
+      // cannot produce an SModule -- recursed anyway so a synthetic or
+      // legacy producer stays covered.
+      SModule(_, _, body) => tps_local_type_names_into(body, out),
       _ => ()
     }
     i = i + 1
   }
+}
+
+fn tps_local_type_names(stmts: Array[Stmt]) -> Array[String] {
+  let out = array_empty()
+  tps_local_type_names_into(stmts, out)
   out
 }
 
@@ -3516,6 +3524,30 @@ fn collect_reserved_type_prefix_errors(stmts: Array[Stmt], errors: Array[String]
       SStruct(_, name, _, _, _, _) => tps_reserved_prefix_report("struct", name, errors),
       SEnum(_, name, _, _, _) => tps_reserved_prefix_report("enum", name, errors),
       STypeAlias(_, name, _, _) => tps_reserved_prefix_report("type alias", name, errors),
+      // #2141: unreachable from source (#728 removed module blocks);
+      // recursed for any synthetic/legacy producer.
+      SModule(_, _, body) => collect_reserved_type_prefix_errors(body, errors),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+fn tps_scan_stmts(stmts: Array[Stmt], local_types: Array[String], errors: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SStruct(_, name, _, _, _, tparams) => tps_report(tparams, local_types, tps_decl_label("struct", name), name, errors),
+      SEnum(_, name, tparams, _, _) => tps_report(tparams, local_types, tps_decl_label("enum", name), name, errors),
+      SLet(_, _, name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), name, errors),
+      SLetMut(name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), name, errors),
+      SLetPat(_, e) => tps_scan_expr(e, local_types, "a `let` pattern binding", "", errors),
+      SExpr(e) => tps_scan_expr(e, local_types, "a top-level expression", "", errors),
+      STest(name, e) => tps_scan_expr(e, local_types, tps_decl_label("test", name), "", errors),
+      SBench(name, e) => tps_scan_expr(e, local_types, tps_decl_label("bench", name), "", errors),
+      // #2141: unreachable from source (#728 removed module blocks);
+      // recursed for any synthetic/legacy producer.
+      SModule(_, _, body) => tps_scan_stmts(body, local_types, errors),
       _ => ()
     }
     i = i + 1
@@ -3528,21 +3560,7 @@ fn collect_type_param_shadowing_errors(stmts: Array[Stmt], errors: Array[String]
   if Array::length(local_types) == 0 {
     ()
   } else {
-    let mut i = 0
-    while i < Array::length(stmts) {
-      match Array::get(stmts, i) {
-        SStruct(_, name, _, _, _, tparams) => tps_report(tparams, local_types, tps_decl_label("struct", name), name, errors),
-        SEnum(_, name, tparams, _, _) => tps_report(tparams, local_types, tps_decl_label("enum", name), name, errors),
-        SLet(_, _, name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), name, errors),
-        SLetMut(name, _, e) => tps_scan_expr(e, local_types, tps_decl_label("declaration", name), name, errors),
-        SLetPat(_, e) => tps_scan_expr(e, local_types, "a `let` pattern binding", "", errors),
-        SExpr(e) => tps_scan_expr(e, local_types, "a top-level expression", "", errors),
-        STest(name, e) => tps_scan_expr(e, local_types, tps_decl_label("test", name), "", errors),
-        SBench(name, e) => tps_scan_expr(e, local_types, tps_decl_label("bench", name), "", errors),
-        _ => ()
-      }
-      i = i + 1
-    }
+    tps_scan_stmts(stmts, local_types, errors)
   }
 }
 

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -1295,6 +1295,33 @@ export fn agg_info_of_type_expr(ct: CtorTable, te: TypeExpr) -> Int {
   }
 }
 
+/// #2141: does `te`'s head name one of `tparams`? An annotation naming an
+/// enclosing binder's formal describes an ERASED value -- when the merged
+/// program also declares a struct under that spelling, annotation-driven
+/// shape seeding must not claim it, or `==` field-compares raw scalars.
+export fn ty_head_names_formal(te: TypeExpr, tparams: Array[String]) -> Bool {
+  let head = match te {
+    TyName(n) => n,
+    TyApp(n, _) => n,
+    _ => ""
+  }
+  if String::length(head) == 0 {
+    false
+  } else {
+    let mut i = 0
+    let mut found = false
+    while i < Array::length(tparams) && !found {
+      if Array::get(tparams, i) == head {
+        found = true
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    found
+  }
+}
+
 /// #724 round 2: program-wide (fn name -> aggregate return shape) table,
 /// filled from each top-level `let f: (..) -> R = (..) -> {..}`'s declared
 /// return type (the SLet annotation's TyFn ret, falling back to the EFn's
@@ -1306,7 +1333,7 @@ export fn compute_agg_returning(stmts: Array[Stmt], ct: CtorTable, out_names: Ar
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SLet(_, _, name, ann, value) => match value {
-        EFn(_, _, _, fn_ret, _, _) => {
+        EFn(efn_tparams, _, _, fn_ret, _, _) => {
           let ret = match ann {
             Some(at) => match at {
               TyFn(_, r, _) => Some(r),
@@ -1316,7 +1343,13 @@ export fn compute_agg_returning(stmts: Array[Stmt], ct: CtorTable, out_names: Ar
           }
           match ret {
             Some(rte) => {
-              let info = agg_info_of_type_expr(ct, rte)
+              // #2141: a return type naming the fn's own formal is erased --
+              // see ty_head_names_formal.
+              let info = if ty_head_names_formal(rte, efn_tparams) {
+                0
+              } else {
+                agg_info_of_type_expr(ct, rte)
+              }
               if info > 0 {
                 Array::push(out_names, name)
                 Array::push(out_infos, info)

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -122,6 +122,7 @@ fn agg_slot_lookup(arr: Array[Int], slot: Int) -> Int
 fn agg_expr_lookup(arr: Array[Int], exprs: Array[Expr], slot: Int) -> Expr
 fn agg_info_of_type_name(ct: CtorTable, tname: String) -> Int
 fn agg_info_of_type_expr(ct: CtorTable, te: TypeExpr) -> Int
+fn ty_head_names_formal(te: TypeExpr, tparams: Array[String]) -> Bool
 fn compute_agg_returning(stmts: Array[Stmt], ct: CtorTable, out_names: Array[String], out_infos: Array[Int]) -> Unit
 fn agg_ret_lookup(names: Array[String], infos: Array[Int], fname: String) -> Int
 fn find_local_slot(names: Array[String], name: String) -> Int

--- a/lib/@vibe/compiler/codegen/common_extractors/common_extractors.vibe
+++ b/lib/@vibe/compiler/codegen/common_extractors/common_extractors.vibe
@@ -113,6 +113,17 @@ export fn get_efn_params(expr: Expr) -> Array[(String, Option[TypeExpr])] with E
   }
 }
 
+/// The type-parameter binder list of an `EFn`. #2141: a param annotation that
+/// names one of these is an ERASED formal, not the same-spelled declared type
+/// the merged program may also carry -- annotation-driven shape seeding must
+/// skip it.
+export fn get_efn_tparams(expr: Expr) -> Array[String] with Exception {
+  match expr {
+    EFn(tparams, _, _, _, _, _) => tparams,
+    _ => throw("not EFn")
+  }
+}
+
 /// The DECLARED return type of an `EFn`, if it has one.
 ///
 /// codegen is otherwise untyped, so a declared `-> Double` is the only way a

--- a/lib/@vibe/compiler/codegen/common_extractors/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_extractors/index.vpkg
@@ -32,6 +32,7 @@ fn get_ebinop_lhs(expr: Expr) -> Expr with Exception
 fn get_ebinop_rhs(expr: Expr) -> Expr with Exception
 fn get_ecall_args(expr: Expr) -> Array[Expr] with Exception
 fn get_efn_params(expr: Expr) -> Array[(String, Option[TypeExpr])] with Exception
+fn get_efn_tparams(expr: Expr) -> Array[String] with Exception
 fn get_efn_ret(expr: Expr) -> Option[TypeExpr] with Exception
 fn get_eint_value(expr: Expr) -> Int with Exception
 fn get_eseq_first(expr: Expr) -> Expr with Exception

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -66,6 +66,7 @@ import @vibe/compiler/codegen/common_base {
   resolve_func,
   resolve_local,
   rewrite_self_tail_calls,
+  ty_head_names_formal,
   wrap_entry_exception_boundary
 }
 
@@ -2057,7 +2058,7 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_str
     let stmt = Array::get(user_func_stmts, bi)
     match stmt {
       SLet(_, _, gc_fn_name, gc_fn_ann, expr) => match expr {
-        EFn(_, _, params, _, _, body) => {
+        EFn(gc_fn_tparams, _, params, _, _, body) => {
           let body_buf = bytebuf_new()
           let local_names = array_empty()
           let gc_agg_slots_f = array_empty()
@@ -2101,17 +2102,23 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, gc_to_str
             }
             match pann {
               Some(pte) => {
-                let pinfo = agg_info_of_type_expr(CtorTable::{
-                  names: ctor_names_list,
-                  tags: ctor_tags_list,
-                  field_counts: ctor_field_counts_list,
-                  type_names: ctor_type_names_list,
-                  struct_names: struct_names,
-                  struct_field_names: struct_field_names,
-                  struct_field_is_ref: struct_field_is_ref,
-                  names_sorted: gc_ctor_names_sorted,
-                  names_sorted_pos: gc_ctor_names_sorted_pos
-                }, pte)
+                // #2141: a param annotated with the fn's own formal is erased
+                // -- see ty_head_names_formal (the linear lane's twin gate).
+                let pinfo = if ty_head_names_formal(pte, gc_fn_tparams) {
+                  0
+                } else {
+                  agg_info_of_type_expr(CtorTable::{
+                    names: ctor_names_list,
+                    tags: ctor_tags_list,
+                    field_counts: ctor_field_counts_list,
+                    type_names: ctor_type_names_list,
+                    struct_names: struct_names,
+                    struct_field_names: struct_field_names,
+                    struct_field_is_ref: struct_field_is_ref,
+                    names_sorted: gc_ctor_names_sorted,
+                    names_sorted_pos: gc_ctor_names_sorted_pos
+                  }, pte)
+                }
                 if pinfo > 0 {
                   Array::push(gc_agg_slots_f, psi * 256 + pinfo)
                 } else {

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -209,6 +209,7 @@ import @vibe/compiler/codegen/common_base {
   resolve_local,
   rewrite_self_tail_calls,
   suspend_cps_pass,
+  ty_head_names_formal,
   wrap_entry_exception_boundary
 }
 
@@ -233,6 +234,7 @@ import @vibe/compiler/codegen/common_extractors {
   get_ecall_callee,
   get_efloat_value,
   get_efn_params,
+  get_efn_tparams,
   get_eforin_body,
   get_eforin_iter,
   get_eforin_name,
@@ -3395,6 +3397,71 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
 /// check-lane caller must pass a merged AST it is about to discard.
 /// `iw_names`/`iw_wats` receive the extracted inline-wasm texts (the compile
 /// path emits them later; check discards them).
+
+/// #2141: the lc prelude's own generic strip (above) must re-spell stripped
+/// formals in annotations -- twin of preprocess_strip.vibe's strip_subst_ty.
+fn lc_strip_subst_ty(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
+  match ty {
+    TyName(n) => if lc_strip_names_contains(formals, n) {
+      TyName(String::concat("__Vfp_", n))
+    } else {
+      ty
+    },
+    TyApp(n, args) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(out, lc_strip_subst_ty(Array::get(args, i), formals))
+        i = i + 1
+      }
+      if lc_strip_names_contains(formals, n) {
+        TyApp(String::concat("__Vfp_", n), out)
+      } else {
+        TyApp(n, out)
+      }
+    },
+    TyTuple(ts) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(ts) {
+        Array::push(out, lc_strip_subst_ty(Array::get(ts, i), formals))
+        i = i + 1
+      }
+      TyTuple(out)
+    },
+    _ => ty
+  }
+}
+
+fn lc_strip_names_contains(names: Array[String], n: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) && !found {
+    if Array::get(names, i) == n {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn lc_strip_subst_params(params: Array[(String, Option[TypeExpr])], formals: Array[String]) -> Array[(String, Option[TypeExpr])] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(params) {
+    let (pname, pann) = Array::get(params, i)
+    let pann2 = match pann {
+      Some(te) => Some(lc_strip_subst_ty(te, formals)),
+      None => None
+    }
+    Array::push(out, (pname, pann2))
+    i = i + 1
+  }
+  out
+}
+
 export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked_imports: Array[(String, String, Int, Int)], iw_names: Array[String], iw_wats: Array[String]) -> Array[String] with Exception {
   let errs = lc_fresh_string_array()
   // ADR-0091 Phase 1: enforce `#zero_alloc` markers before any lowering
@@ -3775,7 +3842,19 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
       },
       SLet(sl_exp, sl_rec, sl_name, sl_ann, sl_expr) => match sl_expr {
         EFn(tparams, _, params, ret, eff, body) => if Array::length(tparams) > 0 {
-          Array::set(stmts, pi, SLet(sl_exp, sl_rec, sl_name, sl_ann, EFn(empty_tp, empty_bounds, params, ret, eff, body)))
+          // #2141: re-spell the stripped formals in the annotations
+          // (`__Vfp_<name>`) BEFORE dropping the binder. This strip runs
+          // ahead of the __bi param-shape seeding below, so an annotation
+          // still spelling `T` would let a same-spelled (merged-in) struct
+          // claim the erased param and `a == b` field-compare raw scalars
+          // (measured: `eqv[T](1, 2)` answered true; the seeding gate alone
+          // could not see it -- the binder list was already empty here).
+          let params2 = lc_strip_subst_params(params, tparams)
+          let ret2 = match ret {
+            Some(rte) => Some(lc_strip_subst_ty(rte, tparams)),
+            None => None
+          }
+          Array::set(stmts, pi, SLet(sl_exp, sl_rec, sl_name, sl_ann, EFn(empty_tp, empty_bounds, params2, ret2, eff, body)))
         }
         ,
         _ => ()
@@ -6399,6 +6478,11 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
           // #724 round 2: seed the aggregate-shape log from ANNOTATED params
           // (param slot i = local i), so `p == q` on tuple/struct/enum-typed
           // params compares structurally.
+          // #2141: a param annotated with the fn's OWN type parameter is an
+          // ERASED value even when the merged program declares a same-spelled
+          // struct -- seeding its shape made `eqv[T](a: T, b: T) { a == b }`
+          // field-compare raw scalars (measured: eqv(1, 2) answered true).
+          let __bi_tparams = get_efn_tparams(__bi_expr)
           let sig_ptypes = fn_type_param_types(__sf_slet_type)
           let mut psi = 0
           while psi < Array::length(lc_norm_params) {
@@ -6418,7 +6502,11 @@ export fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String
             }
             match pann {
               Some(pte) => {
-                let pinfo = agg_info_of_type_expr(compile_ctx.ctor_table, pte)
+                let pinfo = if ty_head_names_formal(pte, __bi_tparams) {
+                  0
+                } else {
+                  agg_info_of_type_expr(compile_ctx.ctor_table, pte)
+                }
                 if pinfo > 0 {
                   Array::push(compile_ctx.agg_local_slots, psi * 256 + pinfo)
                   // #811: agg_local_exprs is the index-aligned PARALLEL of

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -41,7 +41,7 @@ import @vibe/compiler/codegen/gc {
 // weight as before (core/ast.vibe added no real code of its own), still
 // skips types.vibe/import_alias_rewrite.vibe/dce.vibe/... entirely.
 import @vibe/ast {
-  Expr, Stmt
+  Expr, Stmt, TypeExpr
 }
 
 //# Functions
@@ -181,6 +181,72 @@ fn expand_interp_stmts(stmts: Array[Stmt]) -> Unit with Exception {
   desugar_trait_dicts(stmts)
 }
 
+/// #2141: see the wasi_only twin (preprocess_strip.vibe) -- a stripped
+/// binder's spelling left in an annotation lets a same-spelled imported
+/// struct claim the erased value at codegen's annotation-driven shape
+/// seeding. Re-spell the stripped formals (`__Vfp_<name>`).
+fn gc_strip_subst_ty(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
+  match ty {
+    TyName(n) => if gc_strip_names_contains(formals, n) {
+      TyName(String::concat("__Vfp_", n))
+    } else {
+      ty
+    },
+    TyApp(n, args) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(out, gc_strip_subst_ty(Array::get(args, i), formals))
+        i = i + 1
+      }
+      if gc_strip_names_contains(formals, n) {
+        TyApp(String::concat("__Vfp_", n), out)
+      } else {
+        TyApp(n, out)
+      }
+    },
+    TyTuple(ts) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(ts) {
+        Array::push(out, gc_strip_subst_ty(Array::get(ts, i), formals))
+        i = i + 1
+      }
+      TyTuple(out)
+    },
+    _ => ty
+  }
+}
+
+fn gc_strip_names_contains(names: Array[String], n: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) && !found {
+    if Array::get(names, i) == n {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn gc_strip_subst_params(params: Array[(String, Option[TypeExpr])], formals: Array[String]) -> Array[(String, Option[TypeExpr])] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(params) {
+    let (pname, pann) = Array::get(params, i)
+    let pann2 = match pann {
+      Some(te) => Some(gc_strip_subst_ty(te, formals)),
+      None => None
+    }
+    Array::push(out, (pname, pann2))
+    i = i + 1
+  }
+  out
+}
+
 fn strip_generic_type_params(stmts: Array[Stmt]) -> Unit {
   let empty_tp = array_empty()
   let empty_bounds = array_empty()
@@ -189,7 +255,12 @@ fn strip_generic_type_params(stmts: Array[Stmt]) -> Unit {
     match Array::get(stmts, i) {
       SLet(sl_exp, sl_rec, sl_name, sl_ann, sl_expr) => match sl_expr {
         EFn(tparams, _, params, ret, eff, body) => if Array::length(tparams) > 0 {
-          Array::set(stmts, i, SLet(sl_exp, sl_rec, sl_name, sl_ann, EFn(empty_tp, empty_bounds, params, ret, eff, body)))
+          let params2 = gc_strip_subst_params(params, tparams)
+          let ret2 = match ret {
+            Some(rte) => Some(gc_strip_subst_ty(rte, tparams)),
+            None => None
+          }
+          Array::set(stmts, i, SLet(sl_exp, sl_rec, sl_name, sl_ann, EFn(empty_tp, empty_bounds, params2, ret2, eff, body)))
         }
         ,
         _ => ()

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_strip.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_strip.vibe
@@ -10,6 +10,76 @@ import @vibe/core {
 
 //# Functions
 
+/// #2141: when a binder `[T]` is stripped below, an annotation still spelling
+/// `T` becomes a dangling name -- and codegen's annotation-driven shape
+/// seeding (linked_compile / backend_body param seeds, compute_agg_returning)
+/// then reads it against the MERGED ctor table, where a same-spelled imported
+/// `struct T` claims it and `a == b` on erased operands field-compares raw
+/// scalars (measured: `eqv[T](1, 2)` answered true). Re-spell the stripped
+/// formals (`__Vfp_<name>`, the same marking the trait-dict desugar uses) so
+/// no declared type can collide with them.
+fn strip_subst_ty(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
+  match ty {
+    TyName(n) => if strip_names_contains(formals, n) {
+      TyName(String::concat("__Vfp_", n))
+    } else {
+      ty
+    },
+    TyApp(n, args) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(out, strip_subst_ty(Array::get(args, i), formals))
+        i = i + 1
+      }
+      if strip_names_contains(formals, n) {
+        TyApp(String::concat("__Vfp_", n), out)
+      } else {
+        TyApp(n, out)
+      }
+    },
+    TyTuple(ts) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(ts) {
+        Array::push(out, strip_subst_ty(Array::get(ts, i), formals))
+        i = i + 1
+      }
+      TyTuple(out)
+    },
+    _ => ty
+  }
+}
+
+fn strip_names_contains(names: Array[String], n: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) && !found {
+    if Array::get(names, i) == n {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn strip_subst_params(params: Array[(String, Option[TypeExpr])], formals: Array[String]) -> Array[(String, Option[TypeExpr])] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(params) {
+    let (pname, pann) = Array::get(params, i)
+    let pann2 = match pann {
+      Some(te) => Some(strip_subst_ty(te, formals)),
+      None => None
+    }
+    Array::push(out, (pname, pann2))
+    i = i + 1
+  }
+  out
+}
+
 export fn strip_generic_type_params(stmts: Array[Stmt]) -> Unit {
   let empty_tp = array_empty()
   let empty_bounds = array_empty()
@@ -18,7 +88,14 @@ export fn strip_generic_type_params(stmts: Array[Stmt]) -> Unit {
     match Array::get(stmts, i) {
       SLet(sl_exp, sl_rec, sl_name, sl_ann, sl_expr) => match sl_expr {
         EFn(tparams, _, params, ret, eff, body) => if Array::length(tparams) > 0 {
-          Array::set(stmts, i, SLet(sl_exp, sl_rec, sl_name, sl_ann, EFn(empty_tp, empty_bounds, params, ret, eff, body)))
+          // #2141: re-spell the stripped formals in the annotations -- see
+          // strip_subst_ty.
+          let params2 = strip_subst_params(params, tparams)
+          let ret2 = match ret {
+            Some(rte) => Some(strip_subst_ty(rte, tparams)),
+            None => None
+          }
+          Array::set(stmts, i, SLet(sl_exp, sl_rec, sl_name, sl_ann, EFn(empty_tp, empty_bounds, params2, ret2, eff, body)))
         }
         ,
         _ => ()

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -7426,7 +7426,16 @@ fn result_eq_match(lhs: Expr, rhs: Expr) -> Expr {
 /// The runtime `eq` builtin is type-blind (it identity-compares aggregates), so
 /// structural equality MUST be resolved here at the AST level where the static
 /// type is known. (#695.)
-fn eq_for_typed(fty: TypeExpr, lhs: Expr, rhs: Expr, known_types: Array[String]) -> Expr {
+fn eq_for_typed(fty0: TypeExpr, lhs: Expr, rhs: Expr, known_types: Array[String]) -> Expr {
+  // #2141 (Codex round on #2183): re-spell in-scope formals for the WHOLE
+  // type at the entry, not per-arm -- a composite shape reaching typed-eq
+  // dispatch at rewrite time must never leave a sibling `TyName(<formal>)`
+  // unmarked for the `known_types` arm below. Measured: no current channel
+  // feeds such a shape (annotation shapes mentioning tparams are skipped at
+  // seed_var_types / collect_fn_eq_return_shape), so today this subsumes the
+  // Array-arm re-spelling; at generation time the scope stack is empty and
+  // this is the identity.
+  let fty = subst_scope_formals_ty(fty0)
   match fty {
     TyName(n) => if n == "Double" || n == "Float" {
       // Under RC a Double is a BOXED heap value, so a raw `==` between two
@@ -7520,12 +7529,13 @@ fn eq_for_typed(fty: TypeExpr, lhs: Expr, rhs: Expr, known_types: Array[String])
     },
     TyApp("Array", args) => if Array::length(args) == 1 {
       // #1526: the second (and last) site that references a helper.
-      // #2141: at a REWRITE-time call the lexical stack is live and re-spells
-      // an in-scope formal; at generation time the stack is empty and this is
-      // the identity (generated types are already re-spelled).
-      let elem2 = subst_scope_formals_ty(Array::get(args, 0))
-      arr_eq_needed_record(elem2)
-      ECall(EIdent(arr_equals_name(elem2), -1), Array::slice([lhs, rhs], 0, 2), -1)
+      // #2141: the entry re-spelling above already marked any in-scope formal
+      // in this element type.
+      arr_eq_needed_record(Array::get(args, 0))
+      ECall(EIdent(arr_equals_name(Array::get(args, 0)), -1), Array::slice([
+        lhs,
+        rhs
+      ], 0, 2), -1)
     } else {
       EBinOp("==", lhs, rhs)
     },

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6621,7 +6621,13 @@ fn rewrite_stmt(stmt: Stmt, gens: Array[(String, Array[(String, String, Int)])],
           let binds = dict_binds_of(threaded, traits)
           let new_params = thread_dict_params(threaded, params)
           let seeded = seed_var_types(params, tparams, toplevel_vars)
+          // #2141 (Codex P1 on #2183): this dict-threaded path unwraps the
+          // EFn itself, so rewrite_expr's EFn arm never pushes the binder
+          // frame for it -- a `[T: Trait]` formal colliding with an imported
+          // `struct T` still dispatched `T::equals` on erased operands.
+          scope_formals_push(tparams)
           let new_body = rewrite_expr(fbody, gens, traits, struct_sets, binds, seeded, fn_returns)
+          scope_formals_pop()
           SLet(exp, isrec, fname, ann, EFn(tparams, bounds, new_params, ret, eff, new_body))
         },
         _ => stmt

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1545,12 +1545,15 @@ fn is_concrete_or_known_type_name(t: String, struct_sets: Array[(String, Array[S
 /// compare, which orders a heap String's packed `(ptr<<32)|len` value by
 /// POINTER, not content (#973's `ord_clamp("m", "a", "z")` repro).
 fn is_erased_generic_operand(l: Expr, r: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Bool {
+  // #2141: an enclosing binder's formal is erased even when the (merged)
+  // program declares a same-spelled type -- the formal shadows it, so the
+  // concrete-name fast paths must not fire.
   let lg = match infer_arg_type_name(l, struct_sets, var_types, fn_returns) {
-    Some(t) => !is_concrete_or_known_type_name(t, struct_sets),
+    Some(t) => formal_in_scope(t) || !is_concrete_or_known_type_name(t, struct_sets),
     None => false
   }
   let rg = match infer_arg_type_name(r, struct_sets, var_types, fn_returns) {
-    Some(t) => !is_concrete_or_known_type_name(t, struct_sets),
+    Some(t) => formal_in_scope(t) || !is_concrete_or_known_type_name(t, struct_sets),
     None => false
   }
   lg || rg
@@ -3902,7 +3905,17 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
     match Array::get(stmts, i) {
       SLet(_, _, fname, _, body) => match body {
         EFn(tparams, _, _, ret, _, fbody) => {
-          Array::push(out, (fname, fn_return_head_of(ret, fbody)))
+          // #2141: a return head naming the fn's OWN formal is an erased
+          // value at every call site -- record it re-spelled so a same-spelled
+          // (merged-in) declared type can never claim the call's result for
+          // struct dispatch or a struct renderer (see subst_formals_ty).
+          let head = fn_return_head_of(ret, fbody)
+          let head2 = if str_array_contains(tparams, head) {
+            mark_formal_name(head)
+          } else {
+            head
+          }
+          Array::push(out, (fname, head2))
           collect_fn_eq_return_shape(out, fname, tparams, ret, fbody)
         },
         _ => ()
@@ -3914,7 +3927,14 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
       // consumers below.
       SFnDecl(_, fname, body, _, _) => match body {
         EFn(tparams, _, _, ret, _, fbody) => {
-          Array::push(out, (fname, fn_return_head_of(ret, fbody)))
+          // #2141: same re-spelling as the SLet arm above.
+          let head = fn_return_head_of(ret, fbody)
+          let head2 = if str_array_contains(tparams, head) {
+            mark_formal_name(head)
+          } else {
+            head
+          }
+          Array::push(out, (fname, head2))
           collect_fn_eq_return_shape(out, fname, tparams, ret, fbody)
         },
         _ => ()
@@ -5310,7 +5330,9 @@ fn interp_show_target(arg: Expr, derived_only: Bool, struct_sets: Array[(String,
       // THIS PASS generated -- see dtd_derived_renderers. Set at a throw site,
       // where the call is synthesized; clear at an interpolation, where the
       // user wrote it.
-      if !is_scalar_type_name(tn) && fn_exists(fn_returns, target) && target != Array::get(dtd_show_self_fn, 0) && (!derived_only || has_derived_renderer(tn)) {
+      // #2141: an enclosing binder's formal shadows a same-spelled declared
+      // type -- its values are NOT that struct, so its renderer must not fire.
+      if !is_scalar_type_name(tn) && !formal_in_scope(tn) && fn_exists(fn_returns, target) && target != Array::get(dtd_show_self_fn, 0) && (!derived_only || has_derived_renderer(tn)) {
         target
       } else {
         ""
@@ -5338,7 +5360,10 @@ fn interp_show_target(arg: Expr, derived_only: Bool, struct_sets: Array[(String,
 /// by name, and that is not a missing renderer.
 fn interp_missing_show_type(arg: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> String {
   match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
-    Some(tn) => if !is_scalar_type_name(tn) && struct_set_has(struct_sets, tn) && !fn_exists(fn_returns, String::concat(tn, "::to_string")) {
+    // #2141: an enclosing binder's formal shadows a same-spelled declared
+    // type. Its values are erased, not renderless-struct-shaped -- keep the
+    // old fallback rendering instead of throwing a false "missing Show".
+    Some(tn) => if !is_scalar_type_name(tn) && !formal_in_scope(tn) && struct_set_has(struct_sets, tn) && !fn_exists(fn_returns, String::concat(tn, "::to_string")) {
       tn
     } else {
       ""
@@ -6280,12 +6305,17 @@ fn rewrite_expr(expr: Expr, gens: Array[(String, Array[(String, String, Int)])],
         // resolves to is generated because the emission was RECORDED, not
         // because a second walk predicted the same thing -- see
         // `arr_eq_needed_record`.
-        let arr_elem = match infer_earray_elem_type(l) {
+        // #2141: an element type that names an enclosing binder's formal is
+        // re-spelled before it keys/records a helper -- see subst_formals_ty.
+        let arr_elem = match (match infer_earray_elem_type(l) {
           Some(t) => Some(t),
           None => match infer_earray_elem_type(r) {
             Some(t) => Some(t),
             None => eq_var_array_elem(l, r, var_types)
           }
+        }) {
+          Some(t) => Some(subst_scope_formals_ty(t)),
+          None => None
         }
         if empty_l || empty_r {
           let other = if empty_l {
@@ -6381,7 +6411,12 @@ fn rewrite_expr(expr: Expr, gens: Array[(String, Array[(String, String, Int)])],
                       None => infer_arg_type_name(r, struct_sets, var_types, fn_returns)
                     }
                     match ty {
-                      Some(t) => if struct_set_has(struct_sets, t) {
+                      // #2141: a spelling that is a type parameter of an
+                      // enclosing binder is a FORMAL here, whatever else the
+                      // (merged) program declares under that name -- the
+                      // struct dispatch would call `T::equals` on erased
+                      // operands and read garbage.
+                      Some(t) => if struct_set_has(struct_sets, t) && !formal_in_scope(t) {
                         let call = ECall(EIdent(String::concat(t, "::equals"), -1), [
                           rl,
                           rr
@@ -6491,7 +6526,13 @@ fn rewrite_expr(expr: Expr, gens: Array[(String, Array[(String, String, Int)])],
       }
     },
     EUnaryOp(op, e) => EUnaryOp(op, rewrite_expr(e, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),
-    EFn(tp, bs, ps, ret, eff, body) => EFn(tp, bs, ps, ret, eff, rewrite_expr(body, gens, traits, struct_sets, dict_binds, seed_var_types(ps, tp, var_types), fn_returns)),
+    EFn(tp, bs, ps, ret, eff, body) => {
+      // #2141: the binder frame scopes the body -- see dtd_scope_formals.
+      scope_formals_push(tp)
+      let rbody = rewrite_expr(body, gens, traits, struct_sets, dict_binds, seed_var_types(ps, tp, var_types), fn_returns)
+      scope_formals_pop()
+      EFn(tp, bs, ps, ret, eff, rbody)
+    },
     EDot(obj, field, off, fdoff) => {
       let robj = rewrite_expr(obj, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
       match anon_dot_rewrite(obj, field, off, robj, var_types) {
@@ -6786,6 +6827,154 @@ fn field_show_expr(fname: String, fty: TypeExpr, known_types: Array[String]) -> 
 // binding it would change a working program).
 let dtd_type_param_names: Array[String] = empty_str_array()
 
+// ---- #2141: the LEXICAL type-parameter scope during the rewrite ----
+//
+// `dtd_type_param_names` is a program-wide UNION minus declared type names, so
+// it cannot say "the `T` HERE is a formal" when the same spelling is also a
+// declared type. The #2141 guard rejects that collision for a LOCALLY declared
+// type, but an IMPORTED `struct T` next to a formal `T` is legal (pinned by
+// derive_array_helper_interference_test) -- and at the merged codegen run the
+// import IS in `struct_sets`, so spelling-keyed dispatch sent a formal-typed
+// `a == b` to `T::equals` and read garbage (measured: `eqv[T](1, 2)` answered
+// true).
+//
+// This stack is the scope-precise answer: `rewrite_expr`'s EFn arm pushes the
+// binder frame around the body and pops it after, so a decision site can ask
+// whether a spelling is a type parameter OF AN ENCLOSING BINDER -- where the
+// formal shadows any same-spelled declared type, exactly like a value binding
+// would.
+let dtd_scope_formals: Array[String] = empty_str_array()
+
+let dtd_scope_formal_marks: Array[Int] = [0]
+
+fn scope_formals_reset() -> Unit {
+  Array::truncate(dtd_scope_formals, 0)
+  Array::truncate(dtd_scope_formal_marks, 0)
+}
+
+fn scope_formals_push(tparams: Array[String]) -> Unit {
+  Array::push(dtd_scope_formal_marks, Array::length(dtd_scope_formals))
+  let mut i = 0
+  while i < Array::length(tparams) {
+    Array::push(dtd_scope_formals, Array::get(tparams, i))
+    i = i + 1
+  }
+}
+
+fn scope_formals_pop() -> Unit {
+  if Array::length(dtd_scope_formal_marks) == 0 {
+    ()
+  } else {
+    let mark = Array::get(dtd_scope_formal_marks, Array::length(dtd_scope_formal_marks) - 1)
+    Array::truncate(dtd_scope_formal_marks, Array::length(dtd_scope_formal_marks) - 1)
+    Array::truncate(dtd_scope_formals, mark)
+  }
+}
+
+fn formal_in_scope(n: String) -> Bool {
+  str_array_contains(dtd_scope_formals, n)
+}
+
+// #2141: a formal's spelling, re-spelled so no declared type can collide with
+// it. A generated helper's KEY, BINDER and element semantics all derive from
+// the element TypeExpr's spellings -- `Array[T]` where `T` is a formal next to
+// a (merged-in) `struct T` used to key the CONCRETE helper `__arr_equals__T`,
+// lose its binder to the #2136 subtraction, and compare elements with
+// `T::equals` (measured: `same[T]([1,2], [1,3])` answered true). Re-spelling
+// the formal at the classification site makes every downstream decision
+// follow: distinct key, bound binder (collect_ty_var_names recognizes the
+// prefix), and the raw `==` element compare a variable requires.
+let scope_formal_mark_prefix: String = "__Vfp_"
+
+fn mark_formal_name(n: String) -> String {
+  String::concat(scope_formal_mark_prefix, n)
+}
+
+fn is_marked_formal_name(n: String) -> Bool {
+  String::starts_with(n, scope_formal_mark_prefix)
+}
+
+/// Re-spell every name in `ty` that `is_formal` answers true for. Used with
+/// `formal_in_scope` at rewrite sites (the lexical stack is live there) and
+/// with a declaration's own tparams at the derive-generation sites (where the
+/// declaration IS the scope).
+fn subst_formals_ty(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
+  match ty {
+    TyName(n) => if str_array_contains(formals, n) {
+      TyName(mark_formal_name(n))
+    } else {
+      ty
+    },
+    TyApp(n, args) => {
+      let out = empty_type_exprs()
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(out, subst_formals_ty(Array::get(args, i), formals))
+        i = i + 1
+      }
+      if str_array_contains(formals, n) {
+        TyApp(mark_formal_name(n), out)
+      } else {
+        TyApp(n, out)
+      }
+    },
+    TyTuple(ts) => {
+      let out = empty_type_exprs()
+      let mut i = 0
+      while i < Array::length(ts) {
+        Array::push(out, subst_formals_ty(Array::get(ts, i), formals))
+        i = i + 1
+      }
+      TyTuple(out)
+    },
+    _ => ty
+  }
+}
+
+fn subst_scope_formals_ty(ty: TypeExpr) -> TypeExpr {
+  subst_formals_ty(ty, dtd_scope_formals)
+}
+
+/// #2141, derive side: a declaration's OWN tparams are the scope its field
+/// types were written in. Re-spell them before any generator reads the field
+/// types, so a `struct Box[T]` next to a same-spelled (merged-in) declared
+/// type generates variable-semantics helpers for `T`, not struct-semantics.
+fn subst_field_formals(fields: Array[(String, TypeExpr)], formals: Array[String]) -> Array[(String, TypeExpr)] {
+  if Array::length(formals) == 0 {
+    fields
+  } else {
+    let out = array_empty()
+    let mut i = 0
+    while i < Array::length(fields) {
+      let (fname, fty) = Array::get(fields, i)
+      Array::push(out, (fname, subst_formals_ty(fty, formals)))
+      i = i + 1
+    }
+    out
+  }
+}
+
+fn subst_variant_formals(variants: Array[(String, Array[TypeExpr])], formals: Array[String]) -> Array[(String, Array[TypeExpr])] {
+  if Array::length(formals) == 0 {
+    variants
+  } else {
+    let out = array_empty()
+    let mut i = 0
+    while i < Array::length(variants) {
+      let (vname, ftypes) = Array::get(variants, i)
+      let tys = empty_type_exprs()
+      let mut j = 0
+      while j < Array::length(ftypes) {
+        Array::push(tys, subst_formals_ty(Array::get(ftypes, j), formals))
+        j = j + 1
+      }
+      Array::push(out, (vname, tys))
+      i = i + 1
+    }
+    out
+  }
+}
+
 fn push_name_once(acc: Array[String], name: String) -> Unit {
   if str_array_contains(acc, name) {
     ()
@@ -6854,13 +7043,16 @@ fn type_param_names_reset(stmts: Array[Stmt], known_types: Array[String]) -> Uni
 /// order. (#2136.)
 fn collect_ty_var_names(ty: TypeExpr, acc: Array[String]) -> Unit {
   match ty {
-    TyName(n) => if str_array_contains(dtd_type_param_names, n) {
+    // #2141: a `__Vfp_`-marked name IS a formal by construction (see
+    // subst_formals_ty) -- the program-wide set cannot know it, since the
+    // marked spelling never appears in source.
+    TyName(n) => if str_array_contains(dtd_type_param_names, n) || is_marked_formal_name(n) {
       push_name_once(acc, n)
     } else {
       ()
     },
     TyApp(n, args) => {
-      if str_array_contains(dtd_type_param_names, n) {
+      if str_array_contains(dtd_type_param_names, n) || is_marked_formal_name(n) {
         push_name_once(acc, n)
       } else {
         ()
@@ -7322,11 +7514,12 @@ fn eq_for_typed(fty: TypeExpr, lhs: Expr, rhs: Expr, known_types: Array[String])
     },
     TyApp("Array", args) => if Array::length(args) == 1 {
       // #1526: the second (and last) site that references a helper.
-      arr_eq_needed_record(Array::get(args, 0))
-      ECall(EIdent(arr_equals_name(Array::get(args, 0)), -1), Array::slice([
-        lhs,
-        rhs
-      ], 0, 2), -1)
+      // #2141: at a REWRITE-time call the lexical stack is live and re-spells
+      // an in-scope formal; at generation time the stack is empty and this is
+      // the identity (generated types are already re-spelled).
+      let elem2 = subst_scope_formals_ty(Array::get(args, 0))
+      arr_eq_needed_record(elem2)
+      ECall(EIdent(arr_equals_name(elem2), -1), Array::slice([lhs, rhs], 0, 2), -1)
     } else {
       EBinOp("==", lhs, rhs)
     },
@@ -8525,7 +8718,10 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SStruct(_, name, fields, derives, _, _) => {
+      SStruct(_, name, fields0, derives, _, decl_tparams) => {
+        // #2141: the declaration's tparams scope its field types -- re-spell
+        // them before any generator reads them (see subst_field_formals).
+        let fields = subst_field_formals(fields0, decl_tparams)
         // `derive(Hash)` also needs the structural `to_string`: a Hash type's
         // stable Map-key string is its structural representation (#638), so
         // generate `to_string` for Show OR Hash.
@@ -8573,7 +8769,9 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
           ()
         }
       },
-      SEnum(_, ename, _, variants, derives) => {
+      SEnum(_, ename, decl_tparams, variants0, derives) => {
+        // #2141: same re-spelling as the SStruct arm, for payload types.
+        let variants = subst_variant_formals(variants0, decl_tparams)
         if (str_array_contains(derives, "Show") || str_array_contains(derives, "Hash")) && !top_level_fn_exists(stmts, qualified_name(ename, "to_string")) {
           Array::push(gen, gen_enum_show_fn(ename, variants, known_types))
           derived_renderer_record(ename)
@@ -8632,18 +8830,24 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
   let mut si = 0
   while si < Array::length(stmts) {
     match Array::get(stmts, si) {
-      SStruct(_, _, fields, _, _, _) => {
+      // #2141: read the fields/payloads through the same decl-tparams
+      // re-spelling the generator arms use, or this walk predicts an
+      // unsubstituted DUPLICATE helper next to the substituted one the
+      // generated `equals` actually calls.
+      SStruct(_, _, fields, _, _, decl_tparams) => {
+        let sfields = subst_field_formals(fields, decl_tparams)
         let mut fi = 0
-        while fi < Array::length(fields) {
-          let (_, fty) = Array::get(fields, fi)
+        while fi < Array::length(sfields) {
+          let (_, fty) = Array::get(sfields, fi)
           collect_array_elem_types(fty, elem_types, elem_keys)
           fi = fi + 1
         }
       },
-      SEnum(_, _, _, variants, _) => {
+      SEnum(_, _, decl_tparams, variants, _) => {
+        let svariants = subst_variant_formals(variants, decl_tparams)
         let mut vi = 0
-        while vi < Array::length(variants) {
-          let (_, ftypes) = Array::get(variants, vi)
+        while vi < Array::length(svariants) {
+          let (_, ftypes) = Array::get(svariants, vi)
           let mut ti = 0
           while ti < Array::length(ftypes) {
             collect_array_elem_types(Array::get(ftypes, ti), elem_types, elem_keys)
@@ -12948,6 +13152,9 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
   // #1526: same reason -- the recorded set must describe THIS run's output.
   arr_eq_needed_reset()
   bytes_eq_needed_reset()
+  // #2141: a throw mid-rewrite leaves frames on the lexical binder stack;
+  // reset so a later run on another program cannot see them.
+  scope_formals_reset()
   eq_tuple_uid_reset()
   eq_known_types_reset(stmts)
   desugar_derives(stmts)

--- a/lib/@vibe/compiler/tests/derive_array_helper_interference_test.vibe
+++ b/lib/@vibe/compiler/tests/derive_array_helper_interference_test.vibe
@@ -1,21 +1,20 @@
-// #2136 review follow-up: the helper type-variable classification reads a
-// program-wide set of type-parameter spellings (`dtd_type_param_names`), so an
-// UNRELATED generic function `fn id[T]` makes the spelling `T` count as a
-// variable even where it denotes a concrete imported type. The synthesized
-// array-equals helper for `Holder` below therefore binds `[T]`
-// (measured: `__arr_equals__T[T](Array[T],Array[T])`).
+// #2136 review follow-up, semantics updated by #2141: `Holder` below holds an
+// array of a concrete IMPORTED type `T` while an unrelated generic `fn id[T]`
+// binds the same spelling. These tests pin that the collision stays
+// BEHAVIORALLY harmless for the derive helper: element comparison remains
+// structural, so `derive(Eq)` on a struct holding an array of the imported
+// type keeps answering by content. If a classification change ever routes
+// this through erased/raw equality, these fail.
 //
-// These tests pin that the over-binding stays BEHAVIORALLY harmless: element
-// comparison remains structural, so `derive(Eq)` on a struct holding an array
-// of the imported type keeps answering by content. If a classification change
-// ever routes this through erased/raw equality, these fail.
-//
-// The inverse corner — a genuine formal sharing a spelling with a LOCALLY
-// declared struct (`struct T` + `fn same[T](..) { a == b }`) — stays unbound
-// (`__arr_equals__T[]`) and miscompares at runtime. That is a pre-existing
-// hole, identical on main's stage2 from before #2136's fix; it is filed
-// separately and deliberately not pinned here, because pinning a wrong answer
-// as expected would freeze it.
+// History: before #2141's scope-precise classification this held because the
+// program-wide binder set (`dtd_type_param_names`) made the helper OVER-bind
+// (`__arr_equals__T[T]`) -- accidentally structural. Now it holds by
+// construction: `Holder` declares no tparams, so its field's `T` is the
+// concrete type and keys the concrete helper, while a formal `T` elsewhere is
+// re-spelled (`__Vfp_T`) and keys its own generic helper. The inverse corner
+// -- a formal next to a LOCALLY declared `struct T` -- is rejected at the
+// binder (type_param_shadowing_guard_test), and the cross-module formal
+// collision is pinned correct by generic_formal_shadow_import_test.
 
 import ./derive_array_helper_interference_dep.vibe {
   T

--- a/lib/@vibe/compiler/tests/derive_array_helper_tparams_test.vibe
+++ b/lib/@vibe/compiler/tests/derive_array_helper_tparams_test.vibe
@@ -17,6 +17,11 @@
 // so they fail the moment a helper goes back to mentioning an unbound variable.
 // A concrete element type must stay MONOMORPHIC (empty list) — binding names
 // that are not variables would be the opposite bug.
+//
+// #2141: the bound variables are RE-SPELLED (`__Vfp_<name>`) at the sites
+// that classify them, so a formal can never collide with a same-spelled
+// declared type (and the generic helper key never collides with the
+// concrete one). The claims are unchanged; only the spellings moved.
 
 //# Imports
 
@@ -162,11 +167,11 @@ fn desugared_check_message(src: String) -> String {
 //# Misc
 
 test "2136: a generic struct's array-equality helper binds its element variable" {
-  inspect(generated_helper_sigs("struct Box[T] { xs: Array[T] } derive(Eq)\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals__T[T](Array[T],Array[T])")
+  inspect(generated_helper_sigs("struct Box[T] { xs: Array[T] } derive(Eq)\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals____Vfp_T[__Vfp_T](Array[__Vfp_T],Array[__Vfp_T])")
 }
 
 test "2136: a generic struct's array-show helper binds its element variable" {
-  inspect(generated_helper_sigs("struct Box[T] { xs: Array[T] } derive(Show)\nlet main = () -> Unit { () }", "__arr_to_string__"), content = "__arr_to_string__T[T](Array[T])")
+  inspect(generated_helper_sigs("struct Box[T] { xs: Array[T] } derive(Show)\nlet main = () -> Unit { () }", "__arr_to_string__"), content = "__arr_to_string____Vfp_T[__Vfp_T](Array[__Vfp_T])")
 }
 
 test "2136: a concrete element type keeps the helper monomorphic" {
@@ -174,19 +179,19 @@ test "2136: a concrete element type keeps the helper monomorphic" {
 }
 
 test "2136: a tuple element type binds every variable it mentions" {
-  inspect(generated_helper_sigs("struct Pair[A, B] { xs: Array[(A, B)] } derive(Eq)\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals__Tup_A_B[A,B](Array[(A,B)],Array[(A,B)])")
+  inspect(generated_helper_sigs("struct Pair[A, B] { xs: Array[(A, B)] } derive(Eq)\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals__Tup___Vfp_A___Vfp_B[__Vfp_A,__Vfp_B](Array[(__Vfp_A,__Vfp_B)],Array[(__Vfp_A,__Vfp_B)])")
 }
 
 test "2136: a nested array element type binds through every layer" {
-  inspect(generated_helper_sigs("struct Nest[T] { xs: Array[Array[T]] } derive(Eq)\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals__Array_T[T](Array[Array[T]],Array[Array[T]]); __arr_equals__T[T](Array[T],Array[T])")
+  inspect(generated_helper_sigs("struct Nest[T] { xs: Array[Array[T]] } derive(Eq)\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals__Array___Vfp_T[__Vfp_T](Array[Array[__Vfp_T]],Array[Array[__Vfp_T]]); __arr_equals____Vfp_T[__Vfp_T](Array[__Vfp_T],Array[__Vfp_T])")
 }
 
 test "2136: a generic enum payload binds its element variable" {
-  inspect(generated_helper_sigs("enum Tree[T] { Leaf(Array[T]); Node(T) } derive(Eq)\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals__T[T](Array[T],Array[T])")
+  inspect(generated_helper_sigs("enum Tree[T] { Leaf(Array[T]); Node(T) } derive(Eq)\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals____Vfp_T[__Vfp_T](Array[__Vfp_T],Array[__Vfp_T])")
 }
 
 test "2136: a generic function's bare-array `==` binds its element variable" {
-  inspect(generated_helper_sigs("fn same[T](a: Array[T], b: Array[T]) -> Bool { a == b }\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals__T[T](Array[T],Array[T])")
+  inspect(generated_helper_sigs("fn same[T](a: Array[T], b: Array[T]) -> Bool { a == b }\nlet main = () -> Unit { () }", "__arr_equals__"), content = "__arr_equals____Vfp_T[__Vfp_T](Array[__Vfp_T],Array[__Vfp_T])")
 }
 
 /// A declared type whose name happens to be spelled like a type parameter is

--- a/lib/@vibe/compiler/tests/generic_formal_scope_mechanism_test.vibe
+++ b/lib/@vibe/compiler/tests/generic_formal_scope_mechanism_test.vibe
@@ -1,0 +1,50 @@
+//# Imports
+
+// #2141 mechanism pins: the desugar's binder-scope stack decides whether a
+// spelling is a formal HERE, so `==` on formal-typed operands never takes a
+// same-spelled declared type's struct dispatch. These run the checkout's
+// desugar in-process on a merged-shaped stmt list (the guard is a checker
+// pass and is deliberately not involved), so they pin the classification
+// itself rather than end-to-end behavior -- that lives in
+// generic_formal_shadow_import_test.vibe.
+
+import @vibe/compiler/normalize {
+  desugar_trait_dicts
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program, print_program
+}
+
+//# Functions
+
+fn desugared(source: String) -> String with Exception {
+  let stmts = parse_program(lex(source))
+  desugar_trait_dicts(stmts)
+  print_program(stmts)
+}
+
+//# Tests
+
+test "#2141: unbounded formal ==  next to a declared struct stays undispatched" {
+  let src = "struct T {\n  v: Int\n}\n\nfn eqv[T](a: T, b: T) -> Bool {\n  a == b\n}\n"
+  inspect(String::contains(desugared(src), "T::equals(a, b)"), content = "false")
+}
+
+test "#2141 (Codex P1 on #2183): the dict-threaded generic path scopes its binders too" {
+  // A method-bearing bound routes the fn through rewrite_stmt's threaded arm,
+  // which unwraps the EFn itself -- the binder frame must be pushed there as
+  // well, or the collision dispatches `T::equals` on erased operands.
+  let src = "trait M {\n  m(Self) -> Int\n}\n\nstruct T {\n  v: Int\n}\n\nimpl M for T {\n  m(self) -> Int {\n    self.v\n  }\n}\n\nfn keq[T: M](a: T, b: T) -> Bool {\n  a == b\n}\n"
+  inspect(String::contains(desugared(src), "T::equals(a, b)"), content = "false")
+}
+
+test "#2141: the array helper for a formal keys and binds the re-spelled variable" {
+  let src = "struct T {\n  v: Int\n}\n\nfn same[T](a: Array[T], b: Array[T]) -> Bool {\n  a == b\n}\n"
+  let out = desugared(src)
+  inspect(String::contains(out, "__arr_equals____Vfp_T(a, b)"), content = "true")
+  // the struct's own `T::equals` DEFINITION legitimately exists; what must
+  // not exist is a dispatch of it from the formal's helper or call site
+  inspect(String::contains(out, "T::equals(a, b)"), content = "false")
+  inspect(String::contains(out, "T::equals(Array::get"), content = "false")
+}

--- a/lib/@vibe/compiler/tests/generic_formal_shadow_import_dep.vibe
+++ b/lib/@vibe/compiler/tests/generic_formal_shadow_import_dep.vibe
@@ -1,0 +1,10 @@
+// Dependency for generic_formal_shadow_import_test.vibe (#2141): a concrete
+// struct whose spelling collides with the importer's type parameters.
+
+export struct T {
+  v: Int
+}
+
+export fn mk(v: Int) -> T {
+  T::{ v: v }
+}

--- a/lib/@vibe/compiler/tests/generic_formal_shadow_import_test.vibe
+++ b/lib/@vibe/compiler/tests/generic_formal_shadow_import_test.vibe
@@ -1,0 +1,73 @@
+//# Imports
+
+// #2141 (scope-precise half): a type parameter that shares its spelling with
+// an IMPORTED struct is legal (the binder guard rejects only a LOCAL
+// collision, pinned by derive_array_helper_interference_test) -- but the
+// desugar's spelling-keyed dispatch used to send formal-typed operands to the
+// struct's semantics at the merged codegen run:
+//
+//   - `eqv[T](a, b) { a == b }` dispatched `T::equals` and read a field off
+//     erased scalars (measured: `eqv(1, 2)` answered true);
+//   - `same[T](a: Array[T], ..) { a == b }` keyed the CONCRETE helper
+//     `__arr_equals__T`, whose #2136 binder subtraction left it unbound and
+//     whose element compare was `T::equals` (measured: `same([1,2], [1,3])`
+//     answered true).
+//
+// The fix is lexical: `rewrite_expr` keeps a binder-scope stack, a spelling
+// that names an enclosing formal never takes the concrete fast paths, and an
+// element type naming a formal is re-spelled (`__Vfp_<name>`) before it keys,
+// binds, or bodies a generated helper -- so the generic helper stays generic
+// whatever the merged program declares under that spelling.
+
+import ./generic_formal_shadow_import_dep.vibe {
+  T, mk
+}
+
+//# Functions
+
+fn same[T](a: Array[T], b: Array[T]) -> Bool {
+  a == b
+}
+
+fn eqv[T](a: T, b: T) -> Bool {
+  a == b
+}
+
+fn omax[T: Ord](a: T, b: T) -> T {
+  if a < b {
+    b
+  } else {
+    a
+  }
+}
+
+//# Tests
+
+test "#2141: generic Array eq with colliding formal compares by content" {
+  inspect(same([1, 2], [1, 3]), content = "false")
+  inspect(same([1, 2], [1, 2]), content = "true")
+  inspect(same([1], [1, 2]), content = "false")
+}
+
+test "#2141: bare generic eq with colliding formal stays value-correct" {
+  inspect(eqv(1, 2), content = "false")
+  inspect(eqv(3, 3), content = "true")
+  inspect(eqv("a", "b"), content = "false")
+  inspect(eqv("x", "x"), content = "true")
+}
+
+test "#2141: erased Ord with colliding formal orders by content" {
+  // Without the scope check the collision made `T` look concrete, so `<`
+  // compiled a raw i64 compare -- on Strings that orders by POINTER (#973's
+  // failure shape, resurfaced through the collision).
+  inspect(omax("m", "z"), content = "z")
+  inspect(omax("z", "a"), content = "z")
+  inspect(omax(3, 7), content = "7")
+}
+
+test "#2141: the imported struct itself still compares structurally" {
+  let xs = [mk(1), mk(2)]
+  inspect(xs == [mk(1), mk(2)], content = "true")
+  inspect(xs == [mk(1), mk(3)], content = "false")
+  inspect(xs == [mk(1)], content = "false")
+}

--- a/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
+++ b/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
@@ -85,3 +85,4 @@ test "#2141: a user-written binder with the prefix stays legal" {
   // a formal -- the marking machinery treats it as the variable it is.
   inspect(first_check_error("fn id[__Vfp_X](x: __Vfp_X) -> __Vfp_X {\n  x\n}\n"), content = "")
 }
+

--- a/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
+++ b/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
@@ -75,3 +75,13 @@ test "#2141: renaming the formal makes the issue's program answer correctly" {
   let src = "struct T {\n  v: Int\n}\n\nfn same[U](a: Array[U], b: Array[U]) -> Bool {\n  a == b\n}\n\nfn probe() -> Bool {\n  !same([1, 2], [1, 3])\n}\n"
   inspect(first_check_error(src), content = "")
 }
+
+test "#2141: a type declaration cannot borrow the reserved __Vfp_ prefix" {
+  inspect(first_check_error("struct __Vfp_Point {\n  x: Int\n}\n"), content = "struct `__Vfp_Point` uses the reserved `__Vfp_` prefix (compiler-generated type-variable spellings) -- rename the type (#2141)")
+}
+
+test "#2141: a user-written binder with the prefix stays legal" {
+  // With declarations rejected, a binder spelled with the prefix is genuinely
+  // a formal -- the marking machinery treats it as the variable it is.
+  inspect(first_check_error("fn id[__Vfp_X](x: __Vfp_X) -> __Vfp_X {\n  x\n}\n"), content = "")
+}


### PR DESCRIPTION
Closes #2141 — the scope-precise half. The interim guard (merged in #2172) rejects a formal colliding with a **locally** declared type; this PR fixes the direction the guard deliberately allows: a formal colliding with an **imported** type (pinned legal by `derive_array_helper_interference_test`), which at the merged codegen run silently took the struct's semantics.

## Measured failures (pre-fix stage2, all silent-wrong)

- `eqv[T](a, b) { a == b }` with an imported `struct T` in scope answered **true for (1, 2)** — annotation-driven shape seeding field-compared raw scalars.
- `same[T](a: Array[T], ..) { a == b }` answered **true for ([1,2], [1,3])** — the array helper keyed the concrete `__arr_equals__T`, lost its binder to the #2136 program-wide subtraction, and compared elements with `T::equals`.
- Interpolating a call returning the callee's formal threw a false "missing Show" (or rendered through the struct's renderer).

## Fix — the classification becomes lexical, at every layer that reads a spelling

**desugar** (`desugar_trait_dict.vibe`)
- A binder-scope stack is pushed/popped around `EFn` bodies; the `==` struct dispatch, the erased-operand check (the #973 `<`/`+` lane), and the show/interp renderer dispatch all consult it before believing `struct_sets`.
- An element type naming an in-scope formal is **re-spelled** (`__Vfp_<name>`) before it keys, binds, or bodies a generated helper — the generic helper's key can never collide with the concrete one.
- The derive arms and the Array-elem prediction worklist re-spell a declaration's own tparams in its field/payload types (the worklist previously predicted an unsubstituted duplicate helper).
- `fn_returns` records a return head naming the fn's own formal re-spelled, so call results stop being claimed by same-spelled declared types.

**generic strip** (all three copies: `preprocess_strip.vibe`, `gc_only.vibe`, and the lc prelude in `linked_compile.vibe`)
- Stripping `[T]` used to leave annotations spelling a name nothing binds; codegen's annotation-driven shape seeding then read them against the merged ctor table. The strips now re-spell the stripped formals in param/return annotations. The lc-prelude copy is the one every FS/RC/test build runs, and it runs **before** the param seeding — which is why codegen-side gates alone measured insufficient.

**codegen** (`linked_compile.vibe`, `backend_body.vibe`, `common_base.vibe`)
- Defense-in-depth gates for any unstripped path: param-shape seeding and `compute_agg_returning` skip an annotation whose head names one of the fn's binders.

## Post-fix semantics

Measured **identical to the no-collision baseline** (formal spelled `U`): scalars compare by value, structs through an unbounded formal keep the erased compare, and the imported struct itself still compares structurally.

## Tests

- **New** `generic_formal_shadow_import_test.vibe` (+dep): Array eq, bare eq, erased `Ord` over String, and the imported struct's own equality — all through a colliding formal. Fails compile (false missing-Show) or miscompares on the pre-fix stage2.
- `derive_array_helper_tparams_test.vibe`: expectations moved to the re-spelled helper names; the claims are unchanged (13/13).
- `derive_array_helper_interference_test.vibe`: header updated — the pinned behavior now holds by construction, not by accidental over-binding.
- `gc_only.vibe` imports `TypeExpr` (its strip twin now names the constructors; 8 unit files check it per-module).

## Verification

- self-build stage0→1→2 green
- `scripts/compiler_gate.sh` → ok
- `scripts/unit_test_runner.sh` against the rebuilt stage2 → **1012/1012**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyrvqhAB9EdeV8HdNVTDFC

---
_Generated by [Claude Code](https://claude.ai/code/session_01LyrvqhAB9EdeV8HdNVTDFC)_