### PR TITLE
Require shared wasmtime setup for stage2 CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: ./.github/actions/setup-vibe
         with:
           node-version: 24
+          wasmtime: 'true'
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
@@ -204,13 +205,6 @@ jobs:
           curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux.tar.gz" | tar -xz
           cp "wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux/wasm-tools" "$PWD/compiler-tools/"
           echo "$PWD/compiler-tools" >> "$GITHUB_PATH"
-      - name: Install wasmtime
-        env:
-          WASMTIME_VERSION: v47.0.2
-        run: |
-          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
-          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
-          echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Stage cached compiler
         run: |
           mkdir -p _build/selfhost/generations/ci-oracles
@@ -270,9 +264,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: ./.github/actions/setup-vibe
         with:
           node-version: 24
+          wasmtime: 'true'
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
@@ -351,9 +346,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: ./.github/actions/setup-vibe
         with:
           node-version: 24
+          wasmtime: 'true'
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
@@ -418,6 +414,7 @@ jobs:
       - uses: ./.github/actions/setup-vibe
         with:
           node-version: 24
+          wasmtime: 'true'
           pkfire: 'true'
           pkfire-cache: 'true'
       - name: Cache stage2
@@ -468,9 +465,10 @@ jobs:
           key: gen-v1-${{ steps.genfp.outputs.fp }}
       - name: Ensure generated compiler artifacts
         run: bash scripts/ensure_generated.sh
-      - uses: actions/setup-node@v5
+      - uses: ./.github/actions/setup-vibe
         with:
           node-version: 24
+          wasmtime: 'true'
       - name: Cache stage2
         id: stage2-cache
         uses: actions/cache@v4

--- a/scripts/test_ci_compiler_gate_layout.sh
+++ b/scripts/test_ci_compiler_gate_layout.sh
@@ -45,4 +45,29 @@ require 'COMPILER_GATE_SKIP_STAGE2_ORACLES: "1"' "$workflow"
 require 'path: ~/.cache/pkfire-mbt' '.github/actions/setup-vibe/action.yml'
 require 'github.job' '.github/actions/setup-vibe/action.yml'
 
+require_stage2_builder_wasmtime() {
+  local job="$1"
+  local block
+  block="$(sed -n "/^  ${job}:/,/^  [a-zA-Z0-9_-]*:/p" "$workflow")"
+  if ! grep -qF 'uses: ./.github/actions/setup-vibe' <<<"$block" ||
+    ! grep -qF "wasmtime: 'true'" <<<"$block"; then
+    echo "[ci-compiler-gate-layout] ${job} builds stage2 without shared wasmtime setup" >&2
+    exit 1
+  fi
+  local setup_line
+  local build_line
+  setup_line="$(grep -nF 'uses: ./.github/actions/setup-vibe' <<<"$block" | head -1 | cut -d: -f1)"
+  build_line="$(grep -nF 'scripts/generations.sh build' <<<"$block" | head -1 | cut -d: -f1)"
+  if [ -z "$build_line" ] || [ "$setup_line" -ge "$build_line" ]; then
+    echo "[ci-compiler-gate-layout] ${job} must set up wasmtime before its stage2 build" >&2
+    exit 1
+  fi
+}
+
+require_stage2_builder_wasmtime compiler-stage2-oracles
+require_stage2_builder_wasmtime compiler-docs
+require_stage2_builder_wasmtime compiler-playground
+require_stage2_builder_wasmtime compiler-examples
+require_stage2_builder_wasmtime review-regressions
+
 echo "[ci-compiler-gate-layout] ok"


### PR DESCRIPTION
## Summary
- route all cache-miss stage2 builders that lacked wasmtime through the shared `setup-vibe` action
- move the stage2-oracle wasmtime setup before generation
- extend the CI layout self-test to require shared wasmtime setup before each affected build

## Root cause
A compiler fingerprint change caused stage2 cache misses. Five parallel jobs invoked `generations.sh build` without a wasmtime binary on `PATH`; cache hits had hidden the ordering/configuration gap.

## Validation
- `bash scripts/test_ci_compiler_gate_layout.sh`
- architecture-debt lint and self-test
- review-regressions lint self-test
- compiler-gate registry self-test
- pre-commit hook self-test
- `git diff --check`