### PR TITLE
Require literal cache disablement in task input ratchet

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -62,12 +62,11 @@ local ciCompilerGatePreflight = new Task {
   cmd =
     "bash tests/gates/bootstrap/preflight.sh && mkdir -p _build/pkfire && printf 'ok\\n' > _build/pkfire/ci-compiler-gate-preflight.ok"
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     ...scriptSources
     "tests/gates/**/*.sh"
     "tests/gates/registry.tsv"
     "fixtures/**/*.vibe"
-    "bootstrap/seed.json"
   }
   outputs { "_build/pkfire/ci-compiler-gate-preflight.ok" }
 }
@@ -78,7 +77,7 @@ local ciCheckExamplesTypecheck = new Task {
   cmd =
     "EXAMPLES_STAGE2=_build/_ci_shard_gen/stage2.wasm bash scripts/check_examples_typecheck.sh && mkdir -p _build/pkfire && printf 'ok\\n' > _build/pkfire/ci-check-examples-typecheck.ok"
   inputs {
-    ...vibeSources
+    ...compilerProbeInputs
     ...scriptSources
     "examples/**/*.vibe"
     "install/**/*"

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -247,7 +247,7 @@ for m in re.finditer(r"new Task \{", active_src):
     # after any change (#2138 review). `scriptTask` one-liners are excluded
     # above precisely because they DO inherit the defaults.
     cache_syntax = pkl_syntax_only(active_block)
-    if re.search(r"(?m)^[ \t]*cache[ \t]*=[ \t]*false[ \t]*(?:;[ \t]*)?(?:$|})", cache_syntax):
+    if re.search(r"(?m)^[ \t]*cache[ \t]*=[ \t]*false[ \t]*(?:;|$|})", cache_syntax):
         continue
     # From the COMMAND only. Reading the whole block also picked up scripts
     # named in `inputs`, which a task declares but does not run -- that flagged

--- a/scripts/check_task_inputs.sh
+++ b/scripts/check_task_inputs.sh
@@ -246,7 +246,8 @@ for m in re.finditer(r"new Task \{", active_src):
     # worst case, not the safe one: an empty cache key replays the first result
     # after any change (#2138 review). `scriptTask` one-liners are excluded
     # above precisely because they DO inherit the defaults.
-    if re.search(r"cache\s*=\s*false", pkl_syntax_only(active_block)):
+    cache_syntax = pkl_syntax_only(active_block)
+    if re.search(r"(?m)^[ \t]*cache[ \t]*=[ \t]*false[ \t]*(?:;[ \t]*)?(?:$|})", cache_syntax):
         continue
     # From the COMMAND only. Reading the whole block also picked up scripts
     # named in `inputs`, which a task declares but does not run -- that flagged

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -255,6 +255,12 @@ run_case "cache = false is accepted instead" 0 'local t = new Task {
   inputs { "docs/cheatsheet.md" }
 }'
 
+run_case "cache = false before same-line member is accepted" 0 'local t = new Task {
+  name = "probe"
+  cache = false; cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { "docs/cheatsheet.md" }
+}'
+
 # A task that does not reach the compiler is none of this gate's business.
 run_case "pure-text task is not flagged" 0 'local t = new Task {
   name = "probe"
@@ -325,4 +331,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (33 cases)"
+echo "check-task-inputs-test: ok (34 cases)"

--- a/scripts/check_task_inputs_test.sh
+++ b/scripts/check_task_inputs_test.sh
@@ -159,6 +159,13 @@ run_case "cache false text in string does not bypass inputs" 1 'local t = new Ta
   inputs { ...vibeSources }
 }'
 
+run_case "cache expression beginning with false does not bypass inputs" 1 'local t = new Task {
+  name = "probe"
+  cache = false || true
+  cmd = "bash scripts/check_freeze_surface.sh"
+  inputs { ...vibeSources }
+}'
+
 run_case "URL in command does not hide compiler invocation" 1 'local t = new Task {
   name = "probe"
   cmd = "printf https://example.invalid && bash scripts/check_freeze_surface.sh"
@@ -318,4 +325,4 @@ run_case "a script named only in inputs does not count as running it" 0 'local t
 }'
 
 [ "$fails" -eq 0 ] || exit 1
-echo "check-task-inputs-test: ok (32 cases)"
+echo "check-task-inputs-test: ok (33 cases)"


### PR DESCRIPTION
## Summary

- accept the cache exemption only when the complete assignment value is the literal `false`
- reject expressions such as `cache = false || true`
- migrate two compiler-touching CI tasks added concurrently with #2179 to `compilerProbeInputs`
- add a focused regression, bringing the synthetic suite to 33 cases

## Validation

- `bash scripts/check_task_inputs.sh`
- `bash scripts/check_task_inputs_test.sh`
- `pkf run check-task-inputs`
- `pkf run test-check-task-inputs`
- `pkf format --check Taskfile.pkl`
- `bash -n scripts/check_task_inputs.sh scripts/check_task_inputs_test.sh`
- `git diff --check`

Follow-up to the post-merge review on #2179.