### PR TITLE
Preserve Double representation across let-bound continuations

### DIFF
--- a/fixtures/float_resume_value_test.vibe
+++ b/fixtures/float_resume_value_test.vibe
@@ -1,0 +1,57 @@
+// #2188: a Double crossing a continuation keeps its representation whether
+// `resume` is called directly or first bound as an ordinary closure value.
+effect Ask {
+  Get(Int) -> Int
+}
+
+fn helper() -> Double with Ask {
+  let _ = perform Ask::Get(1)
+  2.5
+}
+
+fn via_resume_value() -> String {
+  handle {
+    __to_string(helper())
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+
+fn via_direct_resume() -> String {
+  handle {
+    __to_string(helper())
+  } with Ask {
+    Get(n) => resume(n)
+  }
+}
+
+fn int_helper() -> Int with Ask {
+  let n = perform Ask::Get(1)
+  n + 5
+}
+
+fn int_via_resume_value() -> String {
+  handle {
+    __to_string(int_helper())
+  } with Ask {
+    Get(n) => {
+      let k = resume
+      k(n)
+    }
+  }
+}
+
+test "a Double crosses a let-bound continuation" {
+  inspect(via_resume_value(), "2.5")
+}
+
+test "the direct resume control keeps the same Double" {
+  inspect(via_direct_resume(), "2.5")
+}
+
+test "an Int crossing the same continuation stays an Int" {
+  inspect(int_via_resume_value(), "6")
+}

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -8455,6 +8455,18 @@ fn scps_mk_fn1(param: String, body: Expr) -> Expr {
   EFn(array_empty_str(), scps_empty_tbs(), ps, None, None, body)
 }
 
+/// A one-parameter continuation that preserves the source callee's declared
+/// result type. The suspend split runs after checking, so this annotation is
+/// codegen provenance rather than a new typing claim. In particular, a
+/// `Double` returned by a needing call must still mark the bubble callback's
+/// local slot as floatish; dropping the annotation made `let k = resume;
+/// k(v)` stringify the raw f64 bits through the Int path (#2188).
+fn scps_mk_fn1_typed(param: String, ty: Option[TypeExpr], body: Expr) -> Expr {
+  let ps = scps_empty_params()
+  Array::push(ps, (param, ty))
+  EFn(array_empty_str(), scps_empty_tbs(), ps, None, None, body)
+}
+
 fn scps_mk_fn2(p1: String, p2: String, body: Expr) -> Expr {
   let ps = scps_empty_params()
   Array::push(ps, (p1, None))
@@ -10326,7 +10338,7 @@ fn scps_split_tail(e: Expr, sctx: (String, Array[String], Array[String], Int, Ar
                   let (bok, bexpr) = scps_split_tail(b, sctx, ctx, st)
                   (bok, ECall(EIdent(scps_bubble_name(eff), -1), [
                     ECall(EIdent(scps_clone_name(eff, vn), -1), vargs, -1),
-                    scps_mk_fn1(x, bexpr)
+                    scps_mk_fn1_typed(x, scps_call_ret_ty(v, ctx, e), bexpr)
                   ], -1))
                 }
               } else if vc != "" {


### PR DESCRIPTION
Closes #2188.

## Summary

- preserve a needing callee's declared result type on the synthesized CPS bubble callback parameter
- keep the annotation as post-check codegen provenance rather than a new typing claim
- add linear-lane regressions for let-bound and direct `resume` forms, plus an Int control

## Why this does not overlap #2185

#2185 changes the top-level float-return classifier in `common_analysis`. This fix changes only suspend continuation lowering in `inline_direct_perform` and adds a dedicated fixture.

## Verification

- Red on the committed seed: `366`, then `RuntimeError: unreachable`
- fresh stage2 generation passed
- focused continuation fixtures passed (4 tests across 2 files)
- `pkf run test-affected` fell back to the full battery: 1014/1014 passed
- formatter checks and `git diff --check` passed