### PR TITLE
Diagnostics and rendering fixes from the book read-through eval (#2198, #2200, #2201, #2202, #2205)

### DIFF
--- a/book/en/12_tests.vibe.md
+++ b/book/en/12_tests.vibe.md
@@ -47,13 +47,11 @@ FAIL demo_test.vibe
        assert_eq failed
          expected: 43
          actual:   42
-       trap: RuntimeError: unreachable
 [vibe-test] 0 passed, 1 failed (1 files, 1 tests)
 ```
 
-The trailing `trap:` line is the assert's implementation showing
-through, not a second failure (#2202 tracks removing it, along with
-giving the report a line number).
+The report does not yet carry a line number, so two asserts with the
+same expected value in one test are indistinguishable (#2202).
 
 `assert_eq(actual, expected)` works for any type that can be compared,
 and compares strings by content — so you can assert directly on a

--- a/book/ja/12_tests.vibe.md
+++ b/book/ja/12_tests.vibe.md
@@ -46,12 +46,11 @@ FAIL demo_test.vibe
        assert_eq failed
          expected: 43
          actual:   42
-       trap: RuntimeError: unreachable
 [vibe-test] 0 passed, 1 failed (1 files, 1 tests)
 ```
 
-末尾の `trap:` 行は assert の実装が透けて見えているだけで、2つ目の失敗
-ではありません (この行の除去と、レポートへの行番号付与は #2202)。
+レポートにはまだ行番号が付かないので、同じ期待値の assert が1つの
+テストに2つあると区別できません (#2202)。
 
 `assert_eq(actual, expected)` は比較可能な任意の型で使え、文字列は内容で
 比較します — なので連結の結果や関数の戻り値に対して、何も変換せずそのまま

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6021,6 +6021,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             None => {
               if name == "__try_v" {
                 Array::push(errors, String::concat("`?` could not unwrap this value (the lowered binder is not in scope)", off_marker(ident_off)))
+              } else if name == "_" {
+                // #2201: `_` is syntax the reader used in the wrong position,
+                // not a name they thought existed -- "unknown name: _" answers
+                // the wrong question. Name its two expression roles instead.
+                Array::push(errors, String::concat("`_` is not a value here: it is only a pipe slot (in the call directly after `|>`) or a lambda section (as part of a larger expression, e.g. `_ * 2`)", off_marker_len(ident_off, 1)))
               } else {
                 Array::push(errors, String::concat(String::concat("unknown name: ", name), off_marker_len(ident_off, String::length(name))))
               }
@@ -6043,7 +6048,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         CtVar(_) => (),
         // Anchor on the CONDITION, not the `if`: that is the expression whose
         // type is wrong, and it is what the reader has to change (#1941).
-        _ => Array::push(errors, String::concat("if condition must be Bool", off_marker(railway_expr_off(cond))))
+        // Naming the actual type is the other half of the repair (#2200): for
+        // `flag?: Bool` the condition is Option[Bool], and without "got ..."
+        // the message reads as agreeing with the reader who believes flag IS
+        // a Bool.
+        _ => Array::push(errors, String::concat("if condition must be Bool, got ", String::concat(type_to_string(resolved_ct), off_marker(railway_expr_off(cond)))))
       }
       let (tt, s2, c2) = check_expr_capture(then_e, env, defs, s1, c1, errors, tytab, capture, lane)
       let (et, s3, c3) = check_expr_capture(else_e, env, defs, s2, c2, errors, tytab, capture, lane)
@@ -6063,7 +6072,24 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         CtUnit => (s3, CtUnit),
         _ => match ret {
           CtUnit => (s3, CtUnit),
-          _ => (check_assignable(rtt, ret, s3, errors, "if branches have incompatible types", railway_expr_off(else_e)), tt)
+          _ => {
+            // #2198: a literal else-branch carries no offset, which left this
+            // diagnostic file-only. Keep the else anchor when it exists (pinned
+            // by diagnostic_anchor_test), else fall back to the then-branch
+            // tail, else to the condition -- coarser, but still on the `if`.
+            let else_off = railway_expr_off(else_e)
+            let branch_off = if else_off >= 0 {
+              else_off
+            } else {
+              let then_off = tail_expr_off(then_e)
+              if then_off >= 0 {
+                then_off
+              } else {
+                railway_expr_off(cond)
+              }
+            }
+            (check_assignable(rtt, ret, s3, errors, "if branches have incompatible types", branch_off), tt)
+          }
         }
       }
       (if_ty, s3b, c3)
@@ -7904,7 +7930,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         // unguarded arm exists — or by a literal empty `match x { }`. Both
         // reach codegen as an unconditional `unreachable`: every guard failing
         // at runtime trapped with no source location. Reject at compile time.
-        Array::push(errors, "non-exhaustive match: no unguarded arm covers the scrutinee (all guards may fail — add an unguarded arm or `_`)")
+        Array::push(errors, String::concat("non-exhaustive match: no unguarded arm covers the scrutinee (all guards may fail — add an unguarded arm or `_`)", off_marker(railway_expr_off(scrutinee))))
         (CtUnknown, s1, c1)
       }
       else {
@@ -8056,7 +8082,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                   if found {
                     ()
                   } else {
-                    Array::push(errors, String::concat("non-exhaustive match: variant `", String::concat(vname, String::concat("` of enum ", String::concat(en, " is not handled (add it or a `_` arm)")))))
+                    Array::push(errors, String::concat("non-exhaustive match: variant `", String::concat(vname, String::concat("` of enum ", String::concat(en, String::concat(" is not handled (add it or a `_` arm)", off_marker(railway_expr_off(scrutinee))))))))
                   }
                   vi = vi + 1
                 }
@@ -8107,12 +8133,12 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                 ()
               } else {
                 if !flat_names_contain(opt_covered, "Some") {
-                  Array::push(errors, "non-exhaustive match: variant `Some` of Option is not handled (add it or a `_` arm)")
+                  Array::push(errors, String::concat("non-exhaustive match: variant `Some` of Option is not handled (add it or a `_` arm)", off_marker(railway_expr_off(scrutinee))))
                 } else {
                   ()
                 }
                 if !flat_names_contain(opt_covered, "None") {
-                  Array::push(errors, "non-exhaustive match: variant `None` of Option is not handled (add it or a `_` arm)")
+                  Array::push(errors, String::concat("non-exhaustive match: variant `None` of Option is not handled (add it or a `_` arm)", off_marker(railway_expr_off(scrutinee))))
                 } else {
                   ()
                 }
@@ -8136,12 +8162,12 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                 ()
               } else {
                 if !flat_names_contain(bool_covered, "true") {
-                  Array::push(errors, "non-exhaustive match: `true` is not handled for a Bool scrutinee (add it or a `_` arm)")
+                  Array::push(errors, String::concat("non-exhaustive match: `true` is not handled for a Bool scrutinee (add it or a `_` arm)", off_marker(railway_expr_off(scrutinee))))
                 } else {
                   ()
                 }
                 if !flat_names_contain(bool_covered, "false") {
-                  Array::push(errors, "non-exhaustive match: `false` is not handled for a Bool scrutinee (add it or a `_` arm)")
+                  Array::push(errors, String::concat("non-exhaustive match: `false` is not handled for a Bool scrutinee (add it or a `_` arm)", off_marker(railway_expr_off(scrutinee))))
                 } else {
                   ()
                 }

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -984,12 +984,22 @@ fn namespace_private_name(path: String, name: String) -> String {
 /// spelling into the rendered string (`Point_dep_... { x: 3 }` in user
 /// output). This table lets the derive generators recover the source name.
 ///
-/// The table is scoped to ONE merged program (Codex round 2 on #2213): each
-/// merge driver resets it before populating, and desugar_trait_dicts clears
-/// it after the derive generators have read it. Left to accumulate across
-/// compilations in a long-lived process, it would both grow without bound
-/// and mis-render a LATER program's genuine type whose name equals a former
-/// mangled name (`Point_dep_a_vibe` rendering as `Point`).
+/// The table is scoped to ONE merged program (Codex rounds 2-3 on #2213):
+/// each merge driver resets it before populating, and desugar_trait_dicts
+/// clears it after the derive generators have read it. Left to accumulate
+/// across compilations in a long-lived process, it would both grow without
+/// bound and mis-render a LATER program's genuine type whose name equals a
+/// former mangled name (`Point_dep_a_vibe` rendering as `Point`).
+///
+/// Accepted residual: a merge that never reaches desugar (a query helper
+/// like closure_merged_stmt_count, or a check-only text merge) leaves its
+/// entries behind until the next merge or desugar clears them. Mis-rendering
+/// through that window needs a SUBSEQUENT single-file program that both
+/// declares a type spelled exactly like one of those mangled names
+/// (`X_dep_<sanitized-path>`) and derives Show on it, in the same process --
+/// the growth is bounded (every driver resets on entry), and carrying the
+/// mapping inside the AST instead is the invasive fix (#2205 option (c)) not
+/// taken here.
 let namespace_rename_originals: Array[(String, String)] = array_empty()
 
 /// Reset the #2205 rename table. Called by each merge driver before it

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -978,6 +978,37 @@ fn namespace_private_name(path: String, name: String) -> String {
   String::concat(name, String::concat("_dep_", sanitize_namespace_path(path)))
 }
 
+/// #2205: (mangled -> original) for private TYPE and CONSTRUCTOR renames.
+/// `derive(Show)` expands after the merge rename has already run, so the
+/// renamed declaration is the only spelling it can see -- and it bakes that
+/// spelling into the rendered string (`Point_dep_... { x: 3 }` in user
+/// output). This table lets the derive generators recover the source name.
+/// Append-only and never reset: a mangled name is `original ++ "_dep_" ++
+/// sanitized-path`, so one key can only ever map to one original, and a
+/// duplicate append records the identical pair.
+let namespace_rename_originals: Array[(String, String)] = array_empty()
+
+fn record_namespace_rename_original(original: String, mangled: String) -> Unit {
+  Array::push(namespace_rename_originals, (mangled, original))
+}
+
+/// The source spelling of a possibly merge-renamed type/constructor name.
+/// Returns the name unchanged when it was never renamed by this process.
+export fn namespace_rename_original(name: String) -> String {
+  let mut i = 0
+  let mut found = name
+  while i < Array::length(namespace_rename_originals) {
+    let (mangled, original) = Array::get(namespace_rename_originals, i)
+    if mangled == name {
+      found = original
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 fn namespace_private_name_with_suffix(namespace_suffix: String, name: String) -> String {
   String::concat(name, String::concat("_dep_", namespace_suffix))
 }
@@ -1276,16 +1307,22 @@ fn collect_private_type_renames(path: String, stmts: Array[Stmt], namespace_suff
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SEnum(false, name, _, _, _) => if !string_array_contains(exported, name) {
-        Array::push(renames, (name, namespace_private_name_lazy(path, name, namespace_suffix_box)))
+        let mangled = namespace_private_name_lazy(path, name, namespace_suffix_box)
+        record_namespace_rename_original(name, mangled)
+        Array::push(renames, (name, mangled))
       },
       SStruct(false, name, _, _, _, _) => if !string_array_contains(exported, name) {
-        Array::push(renames, (name, namespace_private_name_lazy(path, name, namespace_suffix_box)))
+        let mangled = namespace_private_name_lazy(path, name, namespace_suffix_box)
+        record_namespace_rename_original(name, mangled)
+        Array::push(renames, (name, mangled))
       },
       STypeAlias(false, name, _, _) => if !string_array_contains(exported, name) {
         Array::push(renames, (name, namespace_private_name_lazy(path, name, namespace_suffix_box)))
       },
       SSuberror(false, name, _) => if !string_array_contains(exported, name) {
-        Array::push(renames, (name, namespace_private_name_lazy(path, name, namespace_suffix_box)))
+        let mangled = namespace_private_name_lazy(path, name, namespace_suffix_box)
+        record_namespace_rename_original(name, mangled)
+        Array::push(renames, (name, mangled))
       },
       _ => ()
     }
@@ -1303,7 +1340,9 @@ fn collect_private_ctor_renames(path: String, stmts: Array[Stmt], type_renames: 
         let mut j = 0
         while j < Array::length(ctors) {
           let (ctor_name, _) = Array::get(ctors, j)
-          Array::push(renames, (ctor_name, namespace_private_name_lazy(path, ctor_name, namespace_suffix_box)))
+          let mangled = namespace_private_name_lazy(path, ctor_name, namespace_suffix_box)
+          record_namespace_rename_original(ctor_name, mangled)
+          Array::push(renames, (ctor_name, mangled))
           j = j + 1
         }
       },
@@ -1311,7 +1350,9 @@ fn collect_private_ctor_renames(path: String, stmts: Array[Stmt], type_renames: 
         let mut j = 0
         while j < Array::length(ctors) {
           let (ctor_name, _) = Array::get(ctors, j)
-          Array::push(renames, (ctor_name, namespace_private_name_lazy(path, ctor_name, namespace_suffix_box)))
+          let mangled = namespace_private_name_lazy(path, ctor_name, namespace_suffix_box)
+          record_namespace_rename_original(ctor_name, mangled)
+          Array::push(renames, (ctor_name, mangled))
           j = j + 1
         }
       },

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -983,10 +983,20 @@ fn namespace_private_name(path: String, name: String) -> String {
 /// renamed declaration is the only spelling it can see -- and it bakes that
 /// spelling into the rendered string (`Point_dep_... { x: 3 }` in user
 /// output). This table lets the derive generators recover the source name.
-/// Append-only and never reset: a mangled name is `original ++ "_dep_" ++
-/// sanitized-path`, so one key can only ever map to one original, and a
-/// duplicate append records the identical pair.
+///
+/// The table is scoped to ONE merged program (Codex round 2 on #2213): each
+/// merge driver resets it before populating, and desugar_trait_dicts clears
+/// it after the derive generators have read it. Left to accumulate across
+/// compilations in a long-lived process, it would both grow without bound
+/// and mis-render a LATER program's genuine type whose name equals a former
+/// mangled name (`Point_dep_a_vibe` rendering as `Point`).
 let namespace_rename_originals: Array[(String, String)] = array_empty()
+
+/// Reset the #2205 rename table. Called by each merge driver before it
+/// populates, and by desugar_trait_dicts once the derive generators are done.
+export fn namespace_rename_originals_reset() -> Unit {
+  Array::truncate(namespace_rename_originals, 0)
+}
 
 fn record_namespace_rename_original(original: String, mangled: String) -> Unit {
   Array::push(namespace_rename_originals, (mangled, original))

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -1008,6 +1008,22 @@ export fn namespace_rename_originals_reset() -> Unit {
   Array::truncate(namespace_rename_originals, 0)
 }
 
+/// #2205 (Codex round 4 on #2213): metadata-only replay of the private
+/// type/constructor renames for a file whose merged TEXT came from a cache.
+/// The merge that would have recorded the (mangled -> original) pairs never
+/// runs on a cache hit, so the grouped merge replays just the recording
+/// (the same collects the rename pass runs, minus any rewriting) to keep
+/// derive(Show) rendering identical between cold and warm caches. Running
+/// the collects on the RAW stmts is equivalent for this purpose: the value
+/// rename that normally precedes them never changes a type or constructor
+/// declaration name.
+export fn record_namespace_rename_originals_for_file(path: String, stmts: Array[Stmt]) -> Unit {
+  let namespace_suffix_box = [""]
+  let exported = collect_exported_value_names(stmts)
+  let type_renames = collect_private_type_renames(path, stmts, namespace_suffix_box, exported)
+  let _ = collect_private_ctor_renames(path, stmts, type_renames, namespace_suffix_box, exported)
+}
+
 fn record_namespace_rename_original(original: String, mangled: String) -> Unit {
   Array::push(namespace_rename_originals, (mangled, original))
 }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -270,6 +270,9 @@ fn namespace_rename_original(name: String) -> String
 // Scope the #2205 table to one merged program: merge drivers call this
 // before populating, desugar_trait_dicts after consuming.
 fn namespace_rename_originals_reset() -> Unit
+// Metadata-only replay of a file's private type/ctor renames, for merged
+// text served from a cache (the merge that records them never ran).
+fn record_namespace_rename_originals_for_file(path: String, stmts: Array[Stmt]) -> Unit
 fn namespace_exported_name(path: String, name: String) -> String
 fn collect_export_def_value_names(stmts: Array[Stmt]) -> Array[String]
 fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array[Stmt]], entry_path: String) -> ExportRenamePlan

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -267,6 +267,9 @@ fn namespace_private_value_stmts(path: String, stmts: Array[Stmt]) -> Array[Stmt
 // #2205: source spelling of a merge-renamed private type/ctor name, for
 // derive(Show) output (returns the input unchanged when never renamed).
 fn namespace_rename_original(name: String) -> String
+// Scope the #2205 table to one merged program: merge drivers call this
+// before populating, desugar_trait_dicts after consuming.
+fn namespace_rename_originals_reset() -> Unit
 fn namespace_exported_name(path: String, name: String) -> String
 fn collect_export_def_value_names(stmts: Array[Stmt]) -> Array[String]
 fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array[Stmt]], entry_path: String) -> ExportRenamePlan

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -264,6 +264,9 @@ fn append_import_alias_rewritten_non_import_stmts_skipping(merged: Array[Stmt], 
 fn append_import_alias_rewritten_non_import_stmts(merged: Array[Stmt], stmts: Array[Stmt]) -> Unit
 fn rewrite_imported_value_stmt_to_local(stmt: Stmt, original: String, local: String) -> Option[Stmt]
 fn namespace_private_value_stmts(path: String, stmts: Array[Stmt]) -> Array[Stmt]
+// #2205: source spelling of a merge-renamed private type/ctor name, for
+// derive(Show) output (returns the input unchanged when never renamed).
+fn namespace_rename_original(name: String) -> String
 fn namespace_exported_name(path: String, name: String) -> String
 fn collect_export_def_value_names(stmts: Array[Stmt]) -> Array[String]
 fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array[Stmt]], entry_path: String) -> ExportRenamePlan

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -33,6 +33,7 @@ import @vibe/compiler/core {
   export_plan_renames_for,
   import_value_rename_locals,
   namespace_private_value_stmts,
+  namespace_rename_originals_reset,
   resolution_env_seed,
   resolve_import_path,
   rewrite_imported_value_stmt_to_local,
@@ -290,6 +291,8 @@ fn append_merged_stmts_for_file(merged: Array[Stmt], path: String, stmts: Array[
 }
 
 fn build_merged_stmts_from_sources(entry_path: String, sources: Array[(String, String)]) -> Array[Stmt] with Exception {
+  // #2205: the rename table describes ONE merged program.
+  namespace_rename_originals_reset()
   let merged = array_empty()
   let source_count = Array::length(sources)
   let (file_paths, file_stmts) = parse_sources_for_merge(sources)
@@ -318,6 +321,8 @@ fn build_merged_stmts_from_sources(entry_path: String, sources: Array[(String, S
 }
 
 fn build_grouped_merged_stmts(source_groups: Array[(String, Array[(String, String)])]) -> Array[Stmt] with Exception {
+  // #2205: the rename table describes ONE merged program.
+  namespace_rename_originals_reset()
   let merged = array_empty()
   // #716: the plan spans ALL groups (imports cross group boundaries), so the
   // flat source list is parsed once here and reused per group.
@@ -401,6 +406,8 @@ fn file_newline_offsets(src: String) -> Array[Int] {
 /// contributes; the append calls themselves mirror build_merged_stmts_from_sources
 /// exactly, so `merged` is identical to the normal path.
 fn build_grouped_merged_stmts_prov(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[Array[Int]], Array[Int]) with Exception {
+  // #2205: the rename table describes ONE merged program.
+  namespace_rename_originals_reset()
   let merged = array_empty()
   let files = array_empty()
   let file_nls = array_empty()

--- a/lib/@vibe/compiler/entry/compiler/fs_compile/fs_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/fs_compile/fs_compile.vibe
@@ -34,6 +34,7 @@ import @vibe/compiler/core {
   export_plan_renames_for,
   import_value_rename_locals,
   namespace_private_value_stmts,
+  namespace_rename_originals_reset,
   resolve_import_path,
   rewrite_imported_value_stmt_to_local
 }
@@ -312,6 +313,8 @@ fn build_merge_fingerprint_inline(sources: Array[(String, String)]) -> String {
 }
 
 fn build_merged_stmts_inline(sources: Array[(String, String)]) -> Array[Stmt] with Exception {
+  // #2205: the rename table describes ONE merged program.
+  namespace_rename_originals_reset()
   let merged = empty_stmt_array()
   let source_count = Array::length(sources)
   // #716: parse once, then build the whole-program export-rename plan (last

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -32,6 +32,7 @@ import @vibe/compiler/core {
   export_plan_renames_for,
   import_value_rename_locals,
   namespace_private_value_stmts,
+  namespace_rename_originals_reset,
   path_set_add,
   path_set_contains,
   path_set_new,
@@ -541,6 +542,8 @@ export fn coverage_driver_program_source_fs(entry_path: String, driver_path: Str
 /// carries the #716 visibility guarantees. Comments are dropped (printer
 /// output) — acceptable for a generated bundle artifact.
 export fn merged_program_source_fs(entry_path: String) -> String with Exception + Fs {
+  // #2205: the rename table describes ONE merged program.
+  namespace_rename_originals_reset()
   let stmts = empty_stmt_array()
   let visited = path_set_new()
   collect_merged_stmts_recursive(entry_path, stmts, visited)
@@ -548,6 +551,8 @@ export fn merged_program_source_fs(entry_path: String) -> String with Exception 
 }
 
 export fn compile_file_wasi_only(entry_path: String, entry_name: String) -> Bytes with Exception + Fs {
+  // #2205: the rename table describes ONE merged program.
+  namespace_rename_originals_reset()
   let stmts = empty_stmt_array()
   let visited = path_set_new()
   collect_merged_stmts_recursive(entry_path, stmts, visited)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -10,6 +10,7 @@ import @vibe/compiler/core {
   expr_children,
   is_exception_effect_name,
   is_exception_throw_operation,
+  namespace_rename_original,
   sort_perm_by_names,
   str_lt,
   trait_method_sig_binders_deep
@@ -7131,7 +7132,11 @@ fn gen_arr_to_string_fn(elem_ty: TypeExpr, known_types: Array[String]) -> Stmt {
 /// `let P::to_string = (self: P) -> String { "P { x: " ++ show(x) ++ ", ... }" }`
 fn gen_show_fn(tname: String, fields: Array[(String, TypeExpr)], known_types: Array[String]) -> Stmt {
   let segs = empty_expr_array()
-  Array::push(segs, EString(String::concat(tname, " { ")))
+  // #2205: this pass runs after the module-merge rename, so `tname` may be
+  // the mangled `Point_dep_<path>` spelling -- render the SOURCE name (the
+  // generated fn's own name stays mangled; only the string the user sees
+  // recovers the original).
+  Array::push(segs, EString(String::concat(namespace_rename_original(tname), " { ")))
   let mut i = 0
   while i < Array::length(fields) {
     let (fname, fty) = Array::get(fields, i)
@@ -7735,10 +7740,12 @@ fn gen_enum_show_fn(ename: String, variants: Array[(String, Array[TypeExpr])], k
       fi = fi + 1
     }
     let body = if nf == 0 {
-      EString(vname)
+      // #2205: render the source constructor name, not the merge-renamed one
+      // (same as gen_show_fn above; the PCtor pattern below keeps `vname`).
+      EString(namespace_rename_original(vname))
     } else {
       let segs = empty_expr_array()
-      Array::push(segs, EString(String::concat(vname, "(")))
+      Array::push(segs, EString(String::concat(namespace_rename_original(vname), "(")))
       let mut si = 0
       while si < nf {
         let sep = if si == 0 {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -5797,14 +5797,16 @@ fn lower_assert_eq(args: Array[Expr], gens: Array[(String, Array[(String, String
   let expected = EIdent(en, -1)
   let actual_s = assert_eq_render(actual, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
   let expected_s = assert_eq_render(expected, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
-  // The trailing `__vibe_assert_abort__` line is a machine marker for the
-  // test harness (#2202, Codex round 2 on #2213): the abort that follows is
-  // this assert's own deliberate trap, so the condensers in
-  // scripts/vibe_test.sh / runtime/vibe can suppress the trap echo without
-  // guessing from the message text -- rendered values may contain newlines,
-  // and a test's own output may imitate the block, so text alone cannot
-  // distinguish the shapes. The condensers hide the marker line.
-  let msg = assert_eq_concat(EString("assert_eq failed\n  expected: "), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\n__vibe_assert_abort__")))))
+  // The trailing `assert failed: aborting` line closes the diagnostic and
+  // says what happens next -- the trap that follows is this assert's own
+  // deliberate abort, not a second failure. It doubles as the marker the
+  // test condensers (scripts/vibe_test.sh / runtime/vibe) key on to
+  // suppress the trap echo (#2202, Codex rounds 2-3 on #2213): rendered
+  // values may contain newlines and a test's own output may imitate the
+  // block, so the block text alone cannot identify the abort. The
+  // condensers hide the line; in a plain `vibe run` it reads as ordinary
+  // diagnostic prose rather than harness protocol.
+  let msg = assert_eq_concat(EString("assert_eq failed\n  expected: "), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\nassert failed: aborting")))))
   // stdout, not Stderr::write_stream: the gc lane only reserves host
   // imports when the source already used one, and flipping that on a
   // SIMD-only file shifts every generated-body index (gc-gate

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -11,6 +11,7 @@ import @vibe/compiler/core {
   is_exception_effect_name,
   is_exception_throw_operation,
   namespace_rename_original,
+  namespace_rename_originals_reset,
   sort_perm_by_names,
   str_lt,
   trait_method_sig_binders_deep
@@ -5796,7 +5797,14 @@ fn lower_assert_eq(args: Array[Expr], gens: Array[(String, Array[(String, String
   let expected = EIdent(en, -1)
   let actual_s = assert_eq_render(actual, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
   let expected_s = assert_eq_render(expected, gens, traits, struct_sets, dict_binds, vars2, fn_returns)
-  let msg = assert_eq_concat(EString("assert_eq failed\n  expected: "), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\n")))))
+  // The trailing `__vibe_assert_abort__` line is a machine marker for the
+  // test harness (#2202, Codex round 2 on #2213): the abort that follows is
+  // this assert's own deliberate trap, so the condensers in
+  // scripts/vibe_test.sh / runtime/vibe can suppress the trap echo without
+  // guessing from the message text -- rendered values may contain newlines,
+  // and a test's own output may imitate the block, so text alone cannot
+  // distinguish the shapes. The condensers hide the marker line.
+  let msg = assert_eq_concat(EString("assert_eq failed\n  expected: "), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\n__vibe_assert_abort__")))))
   // stdout, not Stderr::write_stream: the gc lane only reserves host
   // imports when the source already used one, and flipping that on a
   // SIMD-only file shifts every generated-body index (gc-gate
@@ -13181,6 +13189,12 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
   eq_tuple_uid_reset()
   eq_known_types_reset(stmts)
   desugar_derives(stmts)
+  // #2205: the derive generators above are the only readers of the merge
+  // rename table; clear it so a LATER compilation in this process (e.g. a
+  // single-file lane, which runs no merge and therefore no reset) cannot see
+  // stale entries. A second run of this pass over the same program
+  // regenerates nothing and never reads the table.
+  namespace_rename_originals_reset()
   // Flatten supertrait methods into each trait so `[T: B]` (for `trait B: A`)
   // dispatches both B's and A's methods through one witness dictionary. When the
   // program declares no method-bearing trait `traits` is empty, the dict-passing

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -21,6 +21,7 @@ import @vibe/compiler/core {
   import_value_rename_locals,
   namespace_private_value_stmts,
   namespace_rename_originals_reset,
+  record_namespace_rename_originals_for_file,
   resolve_import_path,
   resolve_import_path_candidates,
   rewrite_imported_value_stmt_to_local,
@@ -645,8 +646,10 @@ fn parse_merge_sources(sources: Array[(String, String)]) -> (Array[String], Arra
 /// `collision_sources` spans the whole program so a collision-def import that
 /// crosses a group boundary still resolves.
 fn build_merged_source_with_plan(entry_path: String, sources: Array[(String, String)], file_paths: Array[String], file_stmts: Array[Array[Stmt]], plan: ExportRenamePlan, collision_sources: Array[(String, String)]) -> String with Exception {
-  // #2205: the rename table describes ONE merged program.
-  namespace_rename_originals_reset()
+  // #2205: no reset here -- db_grouped_merged_source calls this once per
+  // cache-missing GROUP, and a per-call reset would discard the mappings of
+  // every earlier group (Codex round 4 on #2213). The whole-merge entry
+  // points (build_merged_source, db_grouped_merged_source) reset instead.
   let merged = empty_stmt_array()
   let source_count = Array::length(sources)
   let mut si = 0
@@ -682,6 +685,8 @@ fn build_merged_source_with_plan(entry_path: String, sources: Array[(String, Str
 }
 
 fn build_merged_source(entry_path: String, sources: Array[(String, String)]) -> String with Exception {
+  // #2205: the rename table describes ONE merged program.
+  namespace_rename_originals_reset()
   let (file_paths, file_stmts) = parse_merge_sources(sources)
   let plan_entry = if entry_path == "" {
     if Array::length(file_paths) > 0 {
@@ -736,6 +741,11 @@ export fn db_grouped_merged_source(db: TypeDb, groups: Array[(String, Array[(Str
       // Keep per-group results in side buffers, then append cache misses
       // once. Rebuilding the full cache on every group miss is O(N^2) for
       // the ~150-group compiler manifest.
+      // #2205: one reset for the WHOLE grouped merge (a per-group reset
+      // would discard every earlier group's mappings); cache-hit groups
+      // replay their metadata below, since the merge that records it does
+      // not run for them.
+      namespace_rename_originals_reset()
       let group_sources = empty_strings()
       let mut grouped_fingerprint = "merged-groups"
       let new_group_cache_entries = empty_string_triples()
@@ -776,6 +786,22 @@ export fn db_grouped_merged_source(db: TypeDb, groups: Array[(String, Array[(Str
         let cache_key = String::concat("merged-group|", group_name)
         match lookup_source_cache(merged_cache, cache_key, fingerprint) {
           Some(source) => {
+            // #2205: the cached TEXT already contains the mangled names, but
+            // the merge that records (mangled -> original) for derive(Show)
+            // never runs on a hit -- replay just the metadata from the
+            // already-parsed stmts so rendering matches a cold cache. The
+            // entry file keeps its private names in the merge, so it is
+            // skipped here too.
+            let mut ri = 0
+            while ri < Array::length(sources) {
+              let rpath = Array::get(flat_paths, group_start + ri)
+              if rpath == plan_entry {
+                ()
+              } else {
+                record_namespace_rename_originals_for_file(rpath, Array::get(flat_stmts, group_start + ri))
+              }
+              ri = ri + 1
+            }
             Array::push(group_sources, source)
           },
           None =>

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -20,6 +20,7 @@ import @vibe/compiler/core {
   export_plan_renames_for,
   import_value_rename_locals,
   namespace_private_value_stmts,
+  namespace_rename_originals_reset,
   resolve_import_path,
   resolve_import_path_candidates,
   rewrite_imported_value_stmt_to_local,
@@ -644,6 +645,8 @@ fn parse_merge_sources(sources: Array[(String, String)]) -> (Array[String], Arra
 /// `collision_sources` spans the whole program so a collision-def import that
 /// crosses a group boundary still resolves.
 fn build_merged_source_with_plan(entry_path: String, sources: Array[(String, String)], file_paths: Array[String], file_stmts: Array[Array[Stmt]], plan: ExportRenamePlan, collision_sources: Array[(String, String)]) -> String with Exception {
+  // #2205: the rename table describes ONE merged program.
+  namespace_rename_originals_reset()
   let merged = empty_stmt_array()
   let source_count = Array::length(sources)
   let mut si = 0

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -55,12 +55,31 @@ test "an if condition that is not Bool points at the condition" {
   assert(anchored_at(src, 3, 6))
 }
 
+test "an if condition that is not Bool names the actual type" {
+  // #2200: "must be Bool" alone reads as agreeing with the reader who
+  // believes the condition IS a Bool (`flag?: Bool` arrives as Option[Bool]).
+  let src = "fn f() -> Int {\n  let n = 1\n  if n { 2 } else { 3 }\n}\n"
+  assert(String::contains(first_diag(src), "if condition must be Bool, got Int"))
+  let opt_src = "fn f(flag?: Bool) -> Int {\n  if flag { 1 } else { 0 }\n}\n"
+  assert(String::contains(first_diag(opt_src), "if condition must be Bool, got Option[Bool]"))
+}
+
 test "mismatched if branches point at the else branch" {
   // The `then` type is the expectation and `else` is checked against it, so
   // the else arm is the operand that disagrees.
   let src = "fn f() -> Bool {\n  let n = 1\n  let s = \"x\"\n  if true { n } else { s }\n}\n"
   assert(String::contains(first_diag(src), "if branches have incompatible types"))
   assert(anchored_at(src, 4, 24))
+}
+
+test "mismatched if branches with a literal else still anchor on the if" {
+  // #2198: a literal else carries no offset of its own, which used to leave
+  // this diagnostic file-only. The fallback anchors on the then-branch tail
+  // (`s`, column 13) -- coarser than the disagreeing operand, but on the
+  // right expression.
+  let src = "fn f() -> Bool {\n  let s = \"x\"\n  if true { s } else { 1 }\n}\n"
+  assert(String::contains(first_diag(src), "if branches have incompatible types"))
+  assert(anchored_at(src, 3, 13))
 }
 
 test "an incompatible array element points at that element" {
@@ -118,6 +137,43 @@ test "an assignment of the wrong type points at the value, not the variable" {
   let src = "fn f() -> Int {\n  let mut n = 1\n  let s = \"a\"\n  n = s\n  n\n}\n"
   assert(String::contains(first_diag(src), "assignment type mismatch for n"))
   assert(anchored_at(src, 4, 7))
+}
+
+//# Non-exhaustive matches anchor on the scrutinee (#2198)
+
+test "a non-exhaustive enum match points at the scrutinee" {
+  // ch02/ch07 of the book sell exhaustiveness with "the errors point at
+  // every match that now has a hole" -- without a line the error names the
+  // hole but does not point at it. `s` is column 9 of the match line.
+  let src = "enum Shape {\n  Circle(Int);\n  Rect(Int, Int);\n  Triangle(Int, Int)\n}\n\nfn area(s: Shape) -> Int {\n  match s {\n    Circle(r) => 3 * r * r,\n    Rect(w, h) => w * h\n  }\n}\n"
+  assert(String::contains(first_diag(src), "variant `Triangle` of enum Shape is not handled"))
+  assert(anchored_at(src, 8, 9))
+}
+
+test "a non-exhaustive Option match points at the scrutinee" {
+  let src = "fn f(o: Option[Int]) -> Int {\n  match o {\n    Some(v) => v,\n    Some(_) => 0\n  }\n}\n"
+  assert(String::contains(first_diag(src), "variant `None` of Option is not handled"))
+  assert(anchored_at(src, 2, 9))
+}
+
+test "a non-exhaustive Bool match points at the scrutinee" {
+  let src = "fn f(b: Bool) -> Int {\n  match b {\n    true => 1,\n    true => 2\n  }\n}\n"
+  assert(String::contains(first_diag(src), "`false` is not handled for a Bool scrutinee"))
+  assert(anchored_at(src, 2, 9))
+}
+
+//# A bare `_` outside a pipe names its two roles (#2201)
+
+test "a bare underscore argument explains pipe slot and lambda section" {
+  // `_` is syntax used in the wrong position, not a name the reader thought
+  // existed -- "unknown name: _" answered the wrong question.
+  let src = "fn f() -> Int {\n  let xs = [1, 2, 3]\n  let ys = Array::map(_, 9)\n  0\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "`_` is not a value here"))
+  assert(String::contains(d, "pipe slot"))
+  assert(String::contains(d, "lambda section"))
+  assert(!String::contains(d, "unknown name: _"))
+  assert(anchored_at(src, 3, 23))
 }
 
 //# Effect-shaped sites (#1941, third slice)

--- a/lib/@vibe/compiler/tests/grouped_merge_rename_metadata_test.vibe
+++ b/lib/@vibe/compiler/tests/grouped_merge_rename_metadata_test.vibe
@@ -1,0 +1,33 @@
+//# #2205 (Codex round 4 on #2213): cache-hit groups keep rename metadata
+//
+// db_grouped_merged_source serves an unchanged group's merged TEXT from its
+// cache, so the merge that records (mangled -> original) for derive(Show)
+// never runs for that group. The metadata is replayed from the
+// already-parsed stmts instead; without the replay (or with a per-group
+// reset inside build_merged_source_with_plan) a warm cache rendered a
+// private struct's internal `_dep_...` name while a cold cache rendered the
+// source name -- the same program, two different outputs.
+
+import @vibe/compiler/runtime {
+  db_grouped_merged_source, db_new
+}
+
+import @vibe/compiler/core {
+  namespace_rename_original
+}
+
+test "cold and warm grouped merges both record rename metadata" {
+  let groups = [
+    ("g1", [("dep_a.vibe", "struct Point {\n  x: Int\n} derive (Show)\n")]),
+    ("g2", [("main.vibe", "fn main() -> Int {\n  1\n}\n")])
+  ]
+  let (src1, _, db1) = db_grouped_merged_source(db_new(), groups)
+  // Cold: g1 was merged for real, which records Point's mangled spelling.
+  assert_eq(namespace_rename_original("Point_dep_dep_a_vibe"), "Point")
+  let (src2, _, db2) = db_grouped_merged_source(db1, groups)
+  let _ = db2
+  assert_eq(src1, src2)
+  // Warm: g1 came from the cache; the replay must have recorded the same
+  // mapping after the whole-merge reset.
+  assert_eq(namespace_rename_original("Point_dep_dep_a_vibe"), "Point")
+}

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -669,17 +669,39 @@ condense_test_trap() {
       sub(/[[:space:]]+$/, "", failing)
       if (failing != "") seen_test = 1
     }
-    $0 == "assert_eq failed" || $0 ~ /^  expected:/ || $0 ~ /^  actual:/ {
+    # Assert-abort recognizer (#2202): suppression requires a COMPLETE
+    # consecutive failed/expected/actual block followed by the trap reason
+    # with only crash-debug / blank lines between (keep in lockstep with
+    # scripts/vibe_test.sh vt_fail_detail).
+    { __blk = 0 }
+    $0 == "assert_eq failed" {
+      __blk = 1
+      ablk = 1
+      ndiag++
+      diags[ndiag] = "  " $0
+    }
+    $0 ~ /^  expected:/ {
+      __blk = 1
+      if (ablk == 1) ablk = 2
+      ndiag++
+      diags[ndiag] = "  " $0
+    }
+    $0 ~ /^  actual:/ {
+      __blk = 1
+      if (ablk == 2) ablk = 3
       ndiag++
       diags[ndiag] = "  " $0
     }
     !seen_reason && /RuntimeError:|wasm trap:/ {
+      __blk = 1
       seen_reason = 1
+      assert_abort = (ablk == 3)
       reason = $0
       sub(/^[[:space:]]+/, "", reason)
       sub(/^[0-9]+: /, "", reason)
       sub(/^viberun: /, "", reason)
     }
+    !seen_reason && ablk > 0 && __blk == 0 && $0 != "" && $0 !~ /^\[crash debug\]/ { ablk = 0 }
     nframes < 6 {
       fn = ""
       if (match($0, /^[[:space:]]+at [A-Za-z0-9_$.]+ \(wasm:/)) {
@@ -698,9 +720,10 @@ condense_test_trap() {
       for (i = 1; i <= ndiag; i++) print diags[i]
       # An assert failure aborts via a deliberate `unreachable` trap; once the
       # assert block above already told the story, echoing that trap reads as
-      # a second, unexplained failure (#2202). Any OTHER trap reason after an
-      # assert diag is still real and still printed.
-      if (reason != "" && !(ndiag > 0 && reason ~ /unreachable/)) print "  trap: " reason
+      # a second, unexplained failure (#2202). Any OTHER trap -- a different
+      # reason, or an unreachable that does not directly follow a complete
+      # assert block -- is still real and still printed.
+      if (reason != "" && !(assert_abort && reason ~ /unreachable/)) print "  trap: " reason
       for (i = 1; i <= nframes; i++) print frames[i]
     }
   ' "$errf")"

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -692,16 +692,25 @@ condense_test_trap() {
       ndiag++
       diags[ndiag] = "  " $0
     }
+    # The generated assert_eq abort marker -- definitive, multiline-proof
+    # (keep in lockstep with scripts/vibe_test.sh). Hidden from the report.
+    $0 == "__vibe_assert_abort__" {
+      __blk = 1
+      pending_abort = 1
+    }
     !seen_reason && /RuntimeError:|wasm trap:/ {
       __blk = 1
       seen_reason = 1
-      assert_abort = (ablk == 3)
+      assert_abort = (ablk == 3 || pending_abort == 1)
       reason = $0
       sub(/^[[:space:]]+/, "", reason)
       sub(/^[0-9]+: /, "", reason)
       sub(/^viberun: /, "", reason)
     }
-    !seen_reason && ablk > 0 && __blk == 0 && $0 != "" && $0 !~ /^\[crash debug\]/ { ablk = 0 }
+    !seen_reason && __blk == 0 && $0 != "" && $0 !~ /^\[crash debug\]/ {
+      ablk = 0
+      pending_abort = 0
+    }
     nframes < 6 {
       fn = ""
       if (match($0, /^[[:space:]]+at [A-Za-z0-9_$.]+ \(wasm:/)) {

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -692,9 +692,10 @@ condense_test_trap() {
       ndiag++
       diags[ndiag] = "  " $0
     }
-    # The generated assert_eq abort marker -- definitive, multiline-proof
-    # (keep in lockstep with scripts/vibe_test.sh). Hidden from the report.
-    $0 == "__vibe_assert_abort__" {
+    # The closing line of the generated assert_eq abort -- definitive,
+    # multiline-proof (keep in lockstep with scripts/vibe_test.sh). Hidden
+    # from the report.
+    $0 == "assert failed: aborting" {
       __blk = 1
       pending_abort = 1
     }

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -696,7 +696,11 @@ condense_test_trap() {
     END {
       if (failing != "") print "  failing test: " pct_decode(failing)
       for (i = 1; i <= ndiag; i++) print diags[i]
-      if (reason != "")  print "  trap: " reason
+      # An assert failure aborts via a deliberate `unreachable` trap; once the
+      # assert block above already told the story, echoing that trap reads as
+      # a second, unexplained failure (#2202). Any OTHER trap reason after an
+      # assert diag is still real and still printed.
+      if (reason != "" && !(ndiag > 0 && reason ~ /unreachable/)) print "  trap: " reason
       for (i = 1; i <= nframes; i++) print frames[i]
     }
   ' "$errf")"

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -332,20 +332,33 @@ vt_fail_detail() {
       ndiag++
       diags[ndiag] = "       " $0
     }
+    # The machine marker the generated assert_eq abort prints as its final
+    # line (see lower_assert_eq in normalize/desugar_trait_dict.vibe): the
+    # definitive signal, immune to multiline rendered values and to output
+    # that imitates the block. Hidden from the report. The consecutive-block
+    # recognizer above stays for tests compiled by a seed that predates the
+    # marker.
+    $0 == "__vibe_assert_abort__" {
+      __blk = 1
+      pending_abort = 1
+    }
     # First trap-reason line (backtrace frames never contain these markers;
     # strip anyhow chain numbering / runner prefixes).
     !seen_reason && /RuntimeError:|wasm trap:/ {
       __blk = 1
       seen_reason = 1
-      assert_abort = (ablk == 3)
+      assert_abort = (ablk == 3 || pending_abort == 1)
       reason = $0
       sub(/^[[:space:]]+/, "", reason)
       sub(/^[0-9]+: /, "", reason)
       sub(/^viberun: /, "", reason)
     }
-    # Any other non-blank, non-crash-debug line between the block and the
-    # trap breaks the adjacency: the trap is then not the assert abort.
-    !seen_reason && ablk > 0 && __blk == 0 && $0 != "" && $0 !~ /^\[crash debug\]/ { ablk = 0 }
+    # Any other non-blank, non-crash-debug line between the block/marker and
+    # the trap breaks the adjacency: the trap is then not the assert abort.
+    !seen_reason && __blk == 0 && $0 != "" && $0 !~ /^\[crash debug\]/ {
+      ablk = 0
+      pending_abort = 0
+    }
     # Wasm backtrace frames (node: `at <fn> (wasm://...)`, wasmtime:
     # `N: 0x.. - <unknown>!<fn>`), capped, annotated via the funcmap.
     nframes < 6 {

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -339,7 +339,11 @@ vt_fail_detail() {
     END {
       if (failing != "") print "       failing test: " pct_decode(failing)
       for (i = 1; i <= ndiag; i++) print diags[i]
-      if (reason != "")  print "       trap: " reason
+      # An assert failure aborts via a deliberate `unreachable` trap; once the
+      # assert block above already told the story, echoing that trap reads as
+      # a second, unexplained failure (#2202). Any OTHER trap reason after an
+      # assert diag is still real and still printed.
+      if (reason != "" && !(ndiag > 0 && reason ~ /unreachable/)) print "       trap: " reason
       for (i = 1; i <= nframes; i++) print frames[i]
     }
   ' "$errf"

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -332,13 +332,13 @@ vt_fail_detail() {
       ndiag++
       diags[ndiag] = "       " $0
     }
-    # The machine marker the generated assert_eq abort prints as its final
-    # line (see lower_assert_eq in normalize/desugar_trait_dict.vibe): the
-    # definitive signal, immune to multiline rendered values and to output
-    # that imitates the block. Hidden from the report. The consecutive-block
-    # recognizer above stays for tests compiled by a seed that predates the
-    # marker.
-    $0 == "__vibe_assert_abort__" {
+    # The closing line the generated assert_eq abort prints (lower_assert_eq
+    # in normalize/desugar_trait_dict.vibe): the definitive signal, immune to
+    # multiline rendered values and to output that imitates the block. Hidden
+    # from the report (the block above already told the story). The
+    # consecutive-block recognizer stays for tests compiled by a seed that
+    # predates the marker.
+    $0 == "assert failed: aborting" {
       __blk = 1
       pending_abort = 1
     }

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -307,19 +307,45 @@ vt_fail_detail() {
       sub(/[[:space:]]+$/, "", failing)
       if (failing != "") seen_test = 1
     }
-    # First trap-reason line (backtrace frames never contain these markers;
-    # strip anyhow chain numbering / runner prefixes).
-    $0 == "assert_eq failed" || $0 ~ /^  expected:/ || $0 ~ /^  actual:/ {
+    # Assert-abort recognizer (#2202). Suppressing the trailing trap must not
+    # trust arbitrary captured output that happens to contain these lines (a
+    # test can println them and then hit a REAL unrelated trap): it requires a
+    # COMPLETE consecutive failed/expected/actual block, followed by the trap
+    # reason with only the host crash-debug dump or blank lines in between --
+    # the exact shape the generated assert_eq abort produces.
+    { __blk = 0 }
+    $0 == "assert_eq failed" {
+      __blk = 1
+      ablk = 1
       ndiag++
       diags[ndiag] = "       " $0
     }
+    $0 ~ /^  expected:/ {
+      __blk = 1
+      if (ablk == 1) ablk = 2
+      ndiag++
+      diags[ndiag] = "       " $0
+    }
+    $0 ~ /^  actual:/ {
+      __blk = 1
+      if (ablk == 2) ablk = 3
+      ndiag++
+      diags[ndiag] = "       " $0
+    }
+    # First trap-reason line (backtrace frames never contain these markers;
+    # strip anyhow chain numbering / runner prefixes).
     !seen_reason && /RuntimeError:|wasm trap:/ {
+      __blk = 1
       seen_reason = 1
+      assert_abort = (ablk == 3)
       reason = $0
       sub(/^[[:space:]]+/, "", reason)
       sub(/^[0-9]+: /, "", reason)
       sub(/^viberun: /, "", reason)
     }
+    # Any other non-blank, non-crash-debug line between the block and the
+    # trap breaks the adjacency: the trap is then not the assert abort.
+    !seen_reason && ablk > 0 && __blk == 0 && $0 != "" && $0 !~ /^\[crash debug\]/ { ablk = 0 }
     # Wasm backtrace frames (node: `at <fn> (wasm://...)`, wasmtime:
     # `N: 0x.. - <unknown>!<fn>`), capped, annotated via the funcmap.
     nframes < 6 {
@@ -341,9 +367,10 @@ vt_fail_detail() {
       for (i = 1; i <= ndiag; i++) print diags[i]
       # An assert failure aborts via a deliberate `unreachable` trap; once the
       # assert block above already told the story, echoing that trap reads as
-      # a second, unexplained failure (#2202). Any OTHER trap reason after an
-      # assert diag is still real and still printed.
-      if (reason != "" && !(ndiag > 0 && reason ~ /unreachable/)) print "       trap: " reason
+      # a second, unexplained failure (#2202). Any OTHER trap -- a different
+      # reason, or an unreachable that does not directly follow a complete
+      # assert block -- is still real and still printed.
+      if (reason != "" && !(assert_abort && reason ~ /unreachable/)) print "       trap: " reason
       for (i = 1; i <= nframes; i++) print frames[i]
     }
   ' "$errf"

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -248,7 +248,56 @@ EOF
   fi
 }
 assert_bare_trap_still_reported
-echo "[vibe-test-smoke] ok (assert abort trap suppressed; bare trap still reported)"
+
+# #2202 boundary (Codex P2 on #2213): user output that IMITATES the assert
+# block, followed by other output and then a REAL unrelated trap, must not
+# have that trap suppressed -- suppression requires the block to directly
+# precede the trap (only crash-debug / blank lines between).
+assert_imitated_block_keeps_real_trap() {
+  local errf="$WORK/canned_fake_assert.err" out
+  cat > "$errf" <<'EOF'
+assert_eq failed
+  expected: 2
+  actual:   1
+some ordinary println output after the fake block
+RuntimeError: unreachable
+    at __test_bad (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+  out="$(vt_fail_detail "$errf" "" "canned.vibe")"
+  if ! printf '%s\n' "$out" | rg -q --fixed-strings "trap: RuntimeError: unreachable"; then
+    echo "[vibe-test-smoke] FAIL: real trap after an imitated assert block was suppressed (#2202)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+assert_imitated_block_keeps_real_trap
+
+# #2202: the real abort shape has the host's crash-debug dump (and a blank
+# line) between the assert block and the trap reason -- those must not break
+# the adjacency, or the suppression never fires on a real failure.
+assert_real_shape_with_crash_debug_suppressed() {
+  local errf="$WORK/canned_real_assert.err" out
+  cat > "$errf" <<'EOF'
+assert_eq failed
+  expected: 5
+  actual:   4
+
+[crash debug] heap_ptr=480 (0x1e0), memory_size=4194304 (64 pages) / unreachable
+[crash debug] mem[0..32]: 00 00 00 00
+RuntimeError: unreachable
+    at __test_bad (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+  out="$(vt_fail_detail "$errf" "" "canned.vibe")"
+  if printf '%s\n' "$out" | rg -q --fixed-strings "trap:"; then
+    echo "[vibe-test-smoke] FAIL: real assert abort (with crash-debug between) still echoed its trap (#2202)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+assert_real_shape_with_crash_debug_suppressed
+echo "[vibe-test-smoke] ok (assert abort trap suppressed; bare/imitated traps still reported)"
 
 # Directory input: scripts/vibe_test.sh already expands *_test.vibe; lock it.
 mkdir -p "$WORK/dir_in"

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -220,9 +220,35 @@ EOF
     printf '%s\n' "$out" >&2
     exit 1
   fi
+  # #2202: the assert's own abort trap must NOT be echoed after the assert
+  # block -- it read as a second, unexplained failure.
+  if printf '%s\n' "$out" | rg -q --fixed-strings "trap:"; then
+    echo "[vibe-test-smoke] FAIL: assert_eq failure still echoes its own abort trap (#2202)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
 }
 assert_canned_assert_eq_diag
 echo "[vibe-test-smoke] ok (assert_eq expected/actual surfaced on FAIL)"
+
+# #2202 boundary: a trap with NO assert diagnostic (a real crash) must still
+# print its reason -- the suppression is only for the assert's own abort.
+assert_bare_trap_still_reported() {
+  local errf="$WORK/canned_bare_trap.err" out
+  cat > "$errf" <<'EOF'
+RuntimeError: unreachable
+    at __test_bad (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+  out="$(vt_fail_detail "$errf" "" "canned.vibe")"
+  if ! printf '%s\n' "$out" | rg -q --fixed-strings "trap: RuntimeError: unreachable"; then
+    echo "[vibe-test-smoke] FAIL: bare trap (no assert diag) lost its trap: line" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+assert_bare_trap_still_reported
+echo "[vibe-test-smoke] ok (assert abort trap suppressed; bare trap still reported)"
 
 # Directory input: scripts/vibe_test.sh already expands *_test.vibe; lock it.
 mkdir -p "$WORK/dir_in"

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -300,7 +300,7 @@ assert_real_shape_with_crash_debug_suppressed
 
 # #2202 (Codex round 2 on #2213): a rendered value may contain newlines, so
 # the block is not always consecutive -- the generated abort therefore prints
-# a machine marker (`__vibe_assert_abort__`) as its final line, and the
+# a machine marker (`assert failed: aborting`) as its final line, and the
 # recognizer trusts the marker. The marker itself must not appear in the
 # report.
 assert_multiline_value_with_marker_suppressed() {
@@ -311,7 +311,7 @@ assert_eq failed
 c
   actual:   a
 b
-__vibe_assert_abort__
+assert failed: aborting
 [crash debug] heap_ptr=496 (0x1f0), memory_size=4194304 (64 pages) / unreachable
 RuntimeError: unreachable
     at __test_bad (wasm://wasm/00000000:wasm-function[3]:0x42)
@@ -323,7 +323,7 @@ EOF
     printf '%s\n' "$out" >&2
     exit 1
   fi
-  if printf '%s\n' "$out" | rg -q --fixed-strings "__vibe_assert_abort__"; then
+  if printf '%s\n' "$out" | rg -q --fixed-strings "assert failed: aborting"; then
     echo "[vibe-test-smoke] FAIL: the assert abort marker leaked into the report (#2202)" >&2
     printf '%s\n' "$out" >&2
     exit 1
@@ -336,7 +336,7 @@ assert_multiline_value_with_marker_suppressed
 assert_stale_marker_keeps_real_trap() {
   local errf="$WORK/canned_stale_marker.err" out
   cat > "$errf" <<'EOF'
-__vibe_assert_abort__
+assert failed: aborting
 some unrelated output afterwards
 RuntimeError: unreachable
     at __test_bad (wasm://wasm/00000000:wasm-function[3]:0x42)

--- a/scripts/vibe_test_smoke.sh
+++ b/scripts/vibe_test_smoke.sh
@@ -297,6 +297,58 @@ EOF
   fi
 }
 assert_real_shape_with_crash_debug_suppressed
+
+# #2202 (Codex round 2 on #2213): a rendered value may contain newlines, so
+# the block is not always consecutive -- the generated abort therefore prints
+# a machine marker (`__vibe_assert_abort__`) as its final line, and the
+# recognizer trusts the marker. The marker itself must not appear in the
+# report.
+assert_multiline_value_with_marker_suppressed() {
+  local errf="$WORK/canned_multiline_assert.err" out
+  cat > "$errf" <<'EOF'
+assert_eq failed
+  expected: a
+c
+  actual:   a
+b
+__vibe_assert_abort__
+[crash debug] heap_ptr=496 (0x1f0), memory_size=4194304 (64 pages) / unreachable
+RuntimeError: unreachable
+    at __test_bad (wasm://wasm/00000000:wasm-function[3]:0x42)
+    at _start (wasm://wasm/00000000:wasm-function[1]:0x10)
+EOF
+  out="$(vt_fail_detail "$errf" "" "canned.vibe")"
+  if printf '%s\n' "$out" | rg -q --fixed-strings "trap:"; then
+    echo "[vibe-test-smoke] FAIL: multiline assert abort (with marker) still echoed its trap (#2202)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$out" | rg -q --fixed-strings "__vibe_assert_abort__"; then
+    echo "[vibe-test-smoke] FAIL: the assert abort marker leaked into the report (#2202)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+assert_multiline_value_with_marker_suppressed
+
+# ...and a marker that is NOT adjacent to the trap (other output after it)
+# must not suppress: the trap is then something else.
+assert_stale_marker_keeps_real_trap() {
+  local errf="$WORK/canned_stale_marker.err" out
+  cat > "$errf" <<'EOF'
+__vibe_assert_abort__
+some unrelated output afterwards
+RuntimeError: unreachable
+    at __test_bad (wasm://wasm/00000000:wasm-function[3]:0x42)
+EOF
+  out="$(vt_fail_detail "$errf" "" "canned.vibe")"
+  if ! printf '%s\n' "$out" | rg -q --fixed-strings "trap: RuntimeError: unreachable"; then
+    echo "[vibe-test-smoke] FAIL: real trap after a stale abort marker was suppressed (#2202)" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+}
+assert_stale_marker_keeps_real_trap
 echo "[vibe-test-smoke] ok (assert abort trap suppressed; bare/imitated traps still reported)"
 
 # Directory input: scripts/vibe_test.sh already expands *_test.vibe; lock it.

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -139,6 +139,59 @@ if ! echo "$mi_diag" | grep -qE '^line [0-9]+:[0-9]+: cannot resolve import .*do
 fi
 echo "[compiler-gate] missing-import diagnostic ok: $mi_diag"
 
+# 4d. derive(Show) source-name rendering across the merge rename (#2205): a
+#     PRIVATE struct/enum in an imported module is renamed by the merge
+#     (`Point` -> `Point_dep_<path>`), and derive(Show) expands after that
+#     rename -- so the rendered string leaked the compiler-internal name into
+#     user output (`Point_dep_... { x: 3, y: 4 }`), silently diverging from
+#     the single-file lane. The rename side table (namespace_rename_original)
+#     must recover the source spelling for struct names and enum constructors
+#     (both payload and nullary), while the generated fn's own name stays
+#     mangled.
+echo "[compiler-gate] 4d derive(Show) source-name rendering across merge rename (#2205)"
+dsdir="_build/_gate_derive_show_rename"
+rm -rf "$dsdir"; mkdir -p "$dsdir"
+cat > "$dsdir/dep.vibe" <<'VEOF'
+struct Point {
+  x: Int;
+  y: Int
+} derive (Show)
+
+enum Color {
+  Lone;
+  Mix(Int, Int)
+} derive (Show)
+
+export fn render() -> String {
+  let p = Point::{ x: 3, y: 4 }
+  let c = Mix(1, 2)
+  let l = Lone
+  "\{p}|\{c}|\{l}"
+}
+VEOF
+cat > "$dsdir/main.vibe" <<'VEOF'
+import ./dep.vibe { render }
+
+fn main with Console {
+  println(render())
+}
+VEOF
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dsdir/main.vibe" "$dsdir/main.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$dsdir/main.wasm" ]; then
+  echo "[compiler-gate] FAIL: derive(Show) rename sample did not compile" >&2
+  cat "$dsdir/main.wasm.diag" >&2 2>/dev/null || true
+  exit 1
+fi
+dsout="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$dsdir/main.wasm" 2>/dev/null)"
+rm -rf "$dsdir"
+if [ "$dsout" != "Point { x: 3, y: 4 }|Mix(1, 2)|Lone" ]; then
+  echo "[compiler-gate] FAIL: derive(Show) rendered '$dsout' (expected 'Point { x: 3, y: 4 }|Mix(1, 2)|Lone') — #2205 merge-renamed name leaking" >&2
+  exit 1
+fi
+echo "[compiler-gate] derive(Show) source-name rendering ok"
+
 # 5. test-block regression (#594): a file with only `test {}` blocks (no entry)
 #    must compile to a valid module whose `_start` runs every test; a passing
 #    file exits clean and a failing assert traps. Guards the codegen fix that

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -16,6 +16,7 @@ x-parser-binder-context-spine	bootstrap	parser binder-context spine
 4/4	early	4/4 multi-file FS-compile regression
 4b	early	4b deep-recursion effect resume regression (#737)
 4c	early	4c missing-import diagnostic regression (#831)
+4d	early	4d derive(Show) source-name rendering across merge rename (#2205)
 5/5	early	5/5 test-block compile+run regression
 6/6	early	6/6 normalize compile+run regression
 6b	early	6b contract package + boundary regression (#729)


### PR DESCRIPTION
Fixes the easily-fixable subset of the issues filed by the round-1 book read-through eval (PR #2196), one commit per concern.

## checker: three diagnostic upgrades

- **#2200** — `if condition must be Bool` now appends `, got <type>`. Measured on probe p10: `line 5:6: if condition must be Bool, got Option[Bool]` — the actual type is the entire repair for the `flag?: Bool` case.
- **#2201** — a bare `_` in expression position reports its two roles instead of `unknown name: _`: ``line 10:23-24: `_` is not a value here: it is only a pipe slot (in the call directly after `|>`) or a lambda section (as part of a larger expression, e.g. `_ * 2`)`` (probe p12).
- **#2198** — the flat non-exhaustive-match diagnostics (enum variant, Option `Some`/`None`, Bool `true`/`false`, zero-arm guard residual) now anchor on the scrutinee, the same way the Maranget witness already did. Probe p08: `line 12:9: non-exhaustive match: variant `Triangle` of enum Shape is not handled …`. The if-branch mismatch gains a fallback anchor (then-branch tail, then condition) when the else branch is a literal.

  Still open in #2198: the all-literal `if` (probe p11's exact shape) stays unlocated — literals carry no offset slot in the AST, the boundary `diagnostic_anchor_test.vibe` pins deliberately — and the interpolation-needs-Show diagnostic still lacks a file because the compile path writes thrown strings verbatim (#1514).

All pinned in `diagnostic_anchor_test.vibe` (6 new tests, 19/19 pass).

## vibe test: assert failures no longer echo their own abort trap (#2202)

The condensers in `scripts/vibe_test.sh` and `runtime/vibe` printed `trap: RuntimeError: unreachable` after the assert report — the assert's implementation (abort via trap) leaking as a second, unexplained failure.

Final mechanism, after three Codex review rounds: the generated `assert_eq` abort closes its diagnostic with a human-readable line `assert failed: aborting` (lower_assert_eq), and the condensers suppress the trap echo when that line — or, for tests compiled by the pre-marker seed, a complete consecutive `failed/expected/actual` block — directly precedes the trap (only the host crash-debug dump / blank lines in between). Multiline rendered values, imitated blocks followed by other output, and bare traps are all handled; the shapes are locked in `vibe_test_smoke.sh`. In-band text can still be forged by a program that deliberately prints the exact sentinel and then traps on purpose — #2219 tracks deleting the seed-era text fallback at the next bootstrap bump and whether abort provenance should move out-of-band. Book ch12's recorded output updated (the missing-line-number half of #2202 stays open).

## derive(Show): render the source type name, not the merge-renamed one (#2205, P0)

The module-merge lane renames a private struct/enum before `derive(Show)` expands, so the generated renderer baked the mangled spelling into user output. Measured Red on the pre-change stage2 (two-file FS-lane program):

```
Point_dep__build_scratch_show_dep_dep_vibe { x: 3, y: 4 }
Mix_dep__build_scratch_show_dep_dep_vibe(1, 2) Red_dep__build_scratch_show_dep_dep_vibe
```

Fix: a `(mangled -> original)` side table recorded where the private type/ctor renames are minted (`core/import_alias_rewrite.vibe`), looked up by `gen_show_fn` / `gen_enum_show_fn` for the rendered string literal only — the generated fn's own name stays mangled. The table is scoped to one merged program: every merge driver (file_compile, fs_compile, merge_sources, runtime.vibe's cached text merge) resets at its whole-merge entry, `db_grouped_merged_source` replays metadata for cache-hit groups from the already-parsed stmts (verified Red → Green, `grouped_merge_rename_metadata_test.vibe`), and `desugar_trait_dicts` clears the table after the derive generators consume it. Pinned by new early gate **4d**, which compiles a two-file FS-lane program and asserts the exact rendered output (`Point { x: 3, y: 4 }|Mix(1, 2)|Lone`).

Not addressed here (noted on the issue): the second face of #2205 — a qualified `Point::to_string(p)` call on a private type does not compile on the merged lane because derived methods' qualified heads are never rewritten, which is what silently takes book ch05 off the merge lane.

## Not attempted

- **#2199** (OOB trap message) — needs string-table seeding plus threading into the generated builtin body; not an easy fix. New measurement while scoping it: the gc lane already traps with wasm's own `out of bounds array access` (names the operation), so the gap is linear-lane-specific.
- **#2203** (from_char_code naming) — a deprecation-ladder design decision, left to triage.
- **#2206** (line-leading operator continuation) — needs the parser to record token line-position; documented pitfall stands (book ch20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG