### PR TITLE
Use indexed function lookup in scalar return classification

### DIFF
--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
@@ -60,6 +60,7 @@ import @vibe/compiler/codegen/common_base {
   emit_str_ref,
   expr_tag,
   find_local_slot,
+  func_table_index_of,
   get_arm_body,
   get_arm_pat,
   get_ebinop_op,
@@ -983,7 +984,7 @@ fn classify_let_value_heap(buf: Bytes, value: Expr, name: String, local_idx: Int
       let is_builtin_scalar_ret = if is_eident(callee) {
         let cn = get_eident_name(callee)
         let is_always_registered = cn == "Array::length" || cn == "Bytes::length" || cn == "String::length" || cn == "eq"
-        let is_user_shadowed = !is_always_registered && array_contains_str(ctx.func_table.names, cn)
+        let is_user_shadowed = !is_always_registered && func_table_index_of(ctx.func_table, cn) >= 0
         !is_user_shadowed && (cn == "Array::length" || cn == "Bytes::length" || cn == "String::length" || cn == "Map::has_key" || cn == "MapBuilder::has_key" || cn == "Array::contains" || cn == "eq" || cn == "not" || cn == "add" || cn == "sub" || cn == "mul" || cn == "lt")
       } else {
         false


### PR DESCRIPTION
Closes #2210.

## Summary

- replace the remaining `ctx.func_table.names` linear membership scan in `classify_let_value_heap` with `func_table_index_of`
- preserve first-match and shadowing behavior through the existing stable sorted FuncTable index
- leave ordered scope/capture arrays unchanged

The other profiled callers named in #2210 already use sorted membership indexes on current `main`; this patch targets the remaining program-wide immutable function-table scan.

## Validation

- `bash scripts/vibe_fmt.sh --check lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe`
- named seed -> stage1 -> stage2 selfhost build succeeded before and after
- identical full-closure `codegen_lexer_test.vibe` compile succeeded before and after with persistent artifact cache disabled
- focused codegen tests, including `codegen_test.vibe`, `codegen_lexer_test.vibe`, and `codegen_heap_e2e_test.vibe`, passed in the full unit run
- full unit run: 1001/1015 passed; the 14 failures are existing generated-bundle/cache-fixture failures (missing `cli_adapter_bundle.vibe` / `compiler_sources_bundle.vibe` and related cache assertions), unrelated to this one-file codegen change

## Profile

Named cold profiles of the same full-closure compile used 2,662 samples before and 1,497 after. Aggregate `array_contains_str` self time moved from 63.4 ms to 41.0 ms; the changed classification path no longer calls it and instead uses the prebuilt FuncTable index. The aggregate includes unrelated scope arrays, which intentionally remain linear because their ordering is semantic.