### PR TITLE
Reuse source fingerprints across profiled cache lookups

### DIFF
--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -728,7 +728,13 @@ export fn compile_file_fs_mode_profiled(entry_path: String, entry_name: String, 
 fn compile_file_fs_mode_cached_slow_profiled(db: TypeDb, entry_path: String, entry_name: String, mode: String, persistent_artifact_kind: String) -> (Bytes, TypeDb, Int, Int, Int, Int, Int) with Exception + Fs + Profiler {
   let load_start = profiler_now_us()
   let source_groups = collect_source_groups_fs(entry_path)
-  let persistent_artifact_fingerprint = build_file_compile_wasi_artifact_fingerprint_for_entry_path(source_groups, entry_path, entry_name, mode)
+  // The ingested source-group fingerprint is the authoritative identity for
+  // both cache layers. Keep it beside the collected sources instead of
+  // re-hashing every source once for the persistent lookup and again for the
+  // TypeDb lookup below. The `_from_group_fingerprint` constructor is
+  // byte-for-byte equivalent to the legacy source-taking constructor.
+  let source_groups_fingerprint = build_source_groups_fingerprint(source_groups)
+  let persistent_artifact_fingerprint = build_file_compile_wasi_artifact_fingerprint_from_group_fingerprint_for_entry_path(source_groups_fingerprint, entry_path, entry_name, mode)
   match load_persistent_artifact(persistent_artifact_kind, entry_name, persistent_artifact_fingerprint) {
     Some(bytes) => (bytes, db, elapsed_us_since(load_start), 0, 0, 0, 0),
     None => {
@@ -737,7 +743,7 @@ fn compile_file_fs_mode_cached_slow_profiled(db: TypeDb, entry_path: String, ent
       let next_db = prepare_file_fs_from_source_groups_persistent_cached(db, entry_path, source_groups)
       let type_us = elapsed_us_since(type_start)
       let bundle_start = profiler_now_us()
-      let merge_fingerprint = build_source_groups_fingerprint(source_groups)
+      let merge_fingerprint = source_groups_fingerprint
       let bundle_us = elapsed_us_since(bundle_start)
       let artifact_fingerprint = merge_fingerprint
       let artifact_kind = if mode == "mvp" {

--- a/lib/@vibe/compiler/tests/persistent_cache_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_cache_test.vibe
@@ -3,6 +3,7 @@
 import @vibe/compiler/cache {
   build_file_compile_module_artifact_fingerprint_for_entry_path,
   build_file_compile_wasi_artifact_fingerprint_for_entry_path,
+  build_file_compile_wasi_artifact_fingerprint_from_group_fingerprint_for_entry_path,
   build_source_groups_fingerprint,
   build_source_groups_fingerprint_from_compact_fingerprints,
   compact_string_fingerprint,
@@ -67,6 +68,17 @@ test "source-group compact fingerprint preserves paths and equals full fingerpri
   ]
   assert(eq(build_source_groups_fingerprint(groups), build_source_groups_fingerprint_from_compact_fingerprints(compact_groups)))
   assert(build_source_groups_fingerprint_from_compact_fingerprints(compact_groups) != build_source_groups_fingerprint_from_compact_fingerprints(renamed_groups))
+}
+
+test "precomputed source-group fingerprint preserves file artifact cache identity" {
+  let groups = [
+    ("dependency", [("/tmp/helper.vibe", "export let helper = 41")]),
+    ("entry_last", [("/tmp/main.vibe", "let main = helper + 1")])
+  ]
+  let group_fingerprint = build_source_groups_fingerprint(groups)
+  let legacy = build_file_compile_wasi_artifact_fingerprint_for_entry_path(groups, "/tmp/main.vibe", "main", "no-dce")
+  let propagated = build_file_compile_wasi_artifact_fingerprint_from_group_fingerprint_for_entry_path(group_fingerprint, "/tmp/main.vibe", "main", "no-dce")
+  assert(eq(legacy, propagated))
 }
 
 test "compilation input fingerprint distinguishes paths, order, and entry" {


### PR DESCRIPTION
Addresses the duplicate-hash portion of #2211.

The profiled cold cached compile path computed the same authoritative ingested source-group fingerprint twice: once while building the persistent artifact key, then again for the TypeDb artifact key. This change computes it once and propagates it to both consumers through the existing precomputed-fingerprint API.

Cache identity remains byte-for-byte compatible; a contract test compares the legacy source-taking constructor with the precomputed-fingerprint constructor.

Validation:
- fresh selfhost stage2 generation
- persistent_cache_test.vibe: 12/12 tests passed with the fresh stage2
- ingestion_stamp_oracle.mjs passed, including metadata changes, same-size replacement, deleted source, and index.vpkg-derived package handling
- full test battery: 1001/1015 passed; 14 baseline checkout failures are generated-bundle/manifest-cache fixtures (missing cli_adapter_bundle.vibe/compiler_sources_bundle.vibe and related contract facades), unrelated to these two edited files

Measured algorithmic change on the cold profiled cache-miss branch: source-group content hash passes 2 -> 1; cache-key algorithm and bytes are unchanged.