### PR TITLE
Specialize known compiler String equality

### DIFF
--- a/lib/@vibe/compiler/codegen/common_extractors/common_extractors.vibe
+++ b/lib/@vibe/compiler/codegen/common_extractors/common_extractors.vibe
@@ -476,7 +476,7 @@ export fn str_table_lookup(strs: Array[String], s: String) -> Int with Exception
   let mut i = 0
   let mut found = -1
   while i < len {
-    if Array::get(strs, i) == s {
+    if String::equals(Array::get(strs, i), s) {
       found = i
       i = len
     } else {
@@ -541,7 +541,7 @@ export fn array_contains_str(arr: Array[String], s: String) -> Bool {
   let mut i = 0
   let mut found = false
   while i < len {
-    if Array::get(arr, i) == s {
+    if String::equals(Array::get(arr, i), s) {
       found = true
       i = len
     } else {

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -197,13 +197,13 @@ export fn env_mut_escape(env: TypeEnv, name: String) -> Option[Bool] {
       EnvEmpty => {
         done = true
       },
-      EnvMutCell(n, escapes, rest) => if n == name {
+      EnvMutCell(n, escapes, rest) => if String::equals(n, name) {
         result = Some(escapes)
         done = true
       } else {
         cur = rest
       },
-      EnvBind(n, _, rest) => if n == name {
+      EnvBind(n, _, rest) => if String::equals(n, name) {
         done = true
       } else {
         cur = rest
@@ -467,7 +467,7 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
       EnvEmpty => {
         done = true
       },
-      EnvBind(n, binding, rest) => if n == name {
+      EnvBind(n, binding, rest) => if String::equals(n, name) {
         result = Some(binding)
         done = true
       } else {
@@ -492,7 +492,7 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
         let mut j = 0
         while j < Array::length(bindings) && !done {
           let (n, binding) = Array::get(bindings, j)
-          if n == name {
+          if String::equals(n, name) {
             result = Some(binding)
             done = true
           } else {

--- a/lib/@vibe/compiler/tests/checker_stmt_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_stmt_test.vibe
@@ -179,3 +179,19 @@ test "check_program returns env" {
     None => assert(false)
   }
 }
+
+test "environment lookup preserves exact UTF-8 name equality" {
+  let env = env_bind(env_bind(EnvEmpty, "café", CtString), "東京", CtInt)
+  match env_lookup(env, "café") {
+    Some(t) => assert(types_equal(t, CtString)),
+    None => assert(false)
+  }
+  match env_lookup(env, "東京") {
+    Some(t) => assert(types_equal(t, CtInt)),
+    None => assert(false)
+  }
+  match env_lookup(env, "cafe") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}


### PR DESCRIPTION
Closes #2212.

## Summary

- route String-table lookup and `Array[String]` membership through `String::equals`
- route the hottest TypeEnv binding-name comparisons through `String::equals`
- keep generic structural equality and all non-String comparisons unchanged
- add exact UTF-8 environment-name lookup coverage, including a negative ASCII lookalike case

The specialization is limited to functions whose parameter and storage contracts statically prove both operands are `String`.

## Validation

- formatter checks and `git diff --check` pass
- named seed -> stage1 -> stage2 selfhost builds succeed before and after
- focused `checker_stmt_test.vibe` compiles and executes successfully, including the new UTF-8 test
- the same full-closure `codegen_lexer_test.vibe` compile succeeds before and after
- generated stage2 Wasm changes six call sites from generic equality to dedicated String equality: `call $__rt_eq` 4,393 -> 4,387; `call $__rt_str_eq` 26 -> 32

## Performance

Five unprofiled runs of the same full-closure compile had an equal 1.49 s median before and after (no measurable wall-time regression at this scope). Named CPU profiles measured generic `__rt_eq` self time at 181.7 ms before and 152.2 ms after; sampling totals differed (1,116 vs 1,280), so the emitted-Wasm call-site count is the deterministic acceptance signal and the profile is directional.