### PR TITLE
Cache active-region checker state

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -12,6 +12,7 @@ import @vibe/compiler/core {
   collect_tvars,
   env_bind,
   env_bind_mut,
+  env_cache_binding,
   env_lookup,
   exception_effect_kind,
   exception_effect_labels_equal,
@@ -1834,16 +1835,9 @@ export fn bind_function_dependency_contracts(env: TypeEnv, name: String, value: 
 }
 
 fn env_has_active_region(env: TypeEnv) -> Bool {
-  match env {
-    EnvEmpty => false,
-    EnvBind(name, _, rest) => name == "__active_region__" || env_has_active_region(rest),
-    EnvTraitDef(_, _, _, _, rest, _, _) => env_has_active_region(rest),
-    EnvTraitImpl(_, _, rest) => env_has_active_region(rest),
-    EnvMutCell(_, _, rest) => env_has_active_region(rest),
-    EnvTraitImplGen(_, _, _, _, rest) => env_has_active_region(rest),
-    EnvTypeDefs(_, _, rest) => env_has_active_region(rest),
-    EnvCached(_, _, rest) => env_has_active_region(rest),
-    EnvFlat(_) => false
+  match env_lookup(env, "__active_region__") {
+    Some(_) => true,
+    None => false
   }
 }
 
@@ -7131,7 +7125,13 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             EFn(_, _, fn_params, _, _, fn_body) => if Array::length(fn_params) == 1 {
               let (binder_name, _) = Array::get(fn_params, 0)
               let region_ty = CtNamed(skolem_name, [])
-              let env_body = env_bind(env_bind(env_bind(env, "__capture_boundary__", CtUnit), binder_name, region_ty), "__active_region__", region_ty)
+              // Region-sensitive checks run many times in a deep body. Cache
+              // the marker once at the boundary so those checks use the
+              // existing indexed TypeEnv lookup instead of rescanning every
+              // lexical binding. env_bind keeps this cache at the head for
+              // ordinary region-local names, and a nested region rebuilds it.
+              let env_body_uncached = env_bind(env_bind(env_bind(env, "__capture_boundary__", CtUnit), binder_name, region_ty), "__active_region__", region_ty)
+              let env_body = env_cache_binding(env_body_uncached, "__active_region__", region_ty)
               // The specialized region path checks the literal lambda body
               // directly. Preserve both structural edges from the outer call:
               // argument child 1, then EFn body child 0.

--- a/lib/@vibe/compiler/checker_bench.vibe
+++ b/lib/@vibe/compiler/checker_bench.vibe
@@ -1,7 +1,12 @@
 //# Imports
 
 import ./checker_hotspot_probe.vibe {
-  probe_check_chained_lets, probe_check_deep_binop, probe_check_large_match, probe_check_nested_if, probe_check_seq_chain
+  probe_check_chained_lets,
+  probe_check_deep_binop,
+  probe_check_deep_region_closure,
+  probe_check_large_match,
+  probe_check_nested_if,
+  probe_check_seq_chain
 }
 
 bench "check_chained_lets_64" {
@@ -39,6 +44,14 @@ bench "check_large_match_48" {
 bench "check_seq_chain_96" {
   let _ = handle {
     probe_check_seq_chain()
+  } with Exception {
+    Throw(_) => 0
+  }
+}
+
+bench "check_deep_region_closure_128" {
+  let _ = handle {
+    probe_check_deep_region_closure()
   } with Exception {
     Throw(_) => 0
   }

--- a/lib/@vibe/compiler/checker_hotspot_probe.vibe
+++ b/lib/@vibe/compiler/checker_hotspot_probe.vibe
@@ -89,6 +89,22 @@ fn build_seq_chain(n: Int) -> Expr {
   acc
 }
 
+fn build_deep_region_closure(n: Int) -> Expr {
+  let mut i = n
+  let mut closure_count = 32
+  let mut body = EFn(array_empty(), array_empty(), array_empty(), None, None, EInt(1))
+  while closure_count > 1 {
+    body = ESeq(EFn(array_empty(), array_empty(), array_empty(), None, None, EInt(closure_count)), body)
+    closure_count = closure_count - 1
+  }
+  while i > 0 {
+    body = ELet(int_var_name(i), EInt(i), body, -1)
+    i = i - 1
+  }
+  let region_body = EFn(array_empty(), array_empty(), [("r", None)], None, None, body)
+  ECall(EIdent("__region_run", -1), [region_body], -1)
+}
+
 fn check_to_int_flag(expr: Expr) -> Int with Exception {
   let ty = run_check(expr, EnvEmpty)
   if types_equal(ty, CtInt) {
@@ -116,4 +132,12 @@ export fn probe_check_large_match() -> Int with Exception {
 
 export fn probe_check_seq_chain() -> Int with Exception {
   check_to_int_flag(build_seq_chain(96))
+}
+
+export fn probe_check_deep_region_closure() -> Int with Exception {
+  let ty = run_check(build_deep_region_closure(128), EnvEmpty)
+  match ty {
+    CtFn(_, CtInt, _) => 1,
+    _ => 0
+  }
 }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -202,6 +202,7 @@ fn dce_keep_flags(stmts: Array[Stmt], entry_names: Array[String]) -> Array[Bool]
 // --- types
 fn env_bind(env: TypeEnv, name: String, ty: Type) -> TypeEnv
 fn env_bind_with_origin(env: TypeEnv, name: String, ty: Type, origin: BindingOrigin) -> TypeEnv
+fn env_cache_binding(env: TypeEnv, name: String, ty: Type) -> TypeEnv
 fn env_value_binding(ty: Type) -> EnvValueBinding
 fn env_value_binding_with_origin(ty: Type, origin: BindingOrigin) -> EnvValueBinding
 fn env_bind_mut(env: TypeEnv, name: String, ty: Type, escapes: Bool) -> TypeEnv

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -149,6 +149,13 @@ export fn env_bind(env: TypeEnv, name: String, ty: Type) -> TypeEnv {
   env_bind_with_origin(env, name, ty, BindingOriginUnavailable)
 }
 
+/// Add a one-name lookup index while preserving the authoritative environment
+/// chain. This is useful for checker-owned sentinels that are queried often
+/// but must not alter lexical binding order or the persistent TypeEnv format.
+export fn env_cache_binding(env: TypeEnv, name: String, ty: Type) -> TypeEnv {
+  EnvCached([name], [env_value_binding(ty)], env)
+}
+
 export fn env_bind_with_origin(env: TypeEnv, name: String, ty: Type, origin: BindingOrigin) -> TypeEnv {
   let binding = env_value_binding_with_origin(ty, origin)
   match env {

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -426,6 +426,7 @@ fn format_errors(errors: Array[CheckError]) -> String
 // --- checker_hotspot_probe.vibe
 fn probe_check_chained_lets() -> Int with Exception
 fn probe_check_deep_binop() -> Int with Exception
+fn probe_check_deep_region_closure() -> Int with Exception
 fn probe_check_nested_if() -> Int with Exception
 fn probe_check_large_match() -> Int with Exception
 fn probe_check_seq_chain() -> Int with Exception

--- a/lib/@vibe/compiler/tests/checker_hotspot_probe_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_hotspot_probe_test.vibe
@@ -4,6 +4,10 @@ import ../checker_hotspot_probe.vibe {
   probe_check_deep_region_closure
 }
 
+import @vibe/core {
+  inspect
+}
+
 test "deep region closure retains checker semantics" {
-  assert(probe_check_deep_region_closure() == 1)
+  inspect(probe_check_deep_region_closure(), "1")
 }

--- a/lib/@vibe/compiler/tests/checker_hotspot_probe_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_hotspot_probe_test.vibe
@@ -1,0 +1,9 @@
+//# Imports
+
+import ../checker_hotspot_probe.vibe {
+  probe_check_deep_region_closure
+}
+
+test "deep region closure retains checker semantics" {
+  assert(probe_check_deep_region_closure() == 1)
+}

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -16,6 +16,7 @@ import @vibe/compiler/core {
   env_bind_mut,
   env_bind_with_origin,
   env_cache,
+  env_cache_binding,
   env_flat_bindings,
   env_lookup,
   env_lookup_binding,
@@ -60,6 +61,24 @@ test "env_lookup not found" {
     Some(_) => assert(false),
     None => assert(true)
   }
+}
+
+test "single-binding cache preserves lookup and shadowing" {
+  let env = env_bind(EnvEmpty, "outer", CtInt)
+  let cached = env_cache_binding(env, "sentinel", CtChar)
+  assert(match env_lookup(cached, "sentinel") {
+    Some(ty) => types_equal(ty, CtChar),
+    None => false
+  })
+  assert(match env_lookup(cached, "outer") {
+    Some(ty) => types_equal(ty, CtInt),
+    None => false
+  })
+  let shadowed = env_bind(cached, "sentinel", CtBool)
+  assert(match env_lookup(shadowed, "sentinel") {
+    Some(ty) => types_equal(ty, CtBool),
+    None => false
+  })
 }
 
 test "env_lookup shadows outer" {

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -66,19 +66,19 @@ test "env_lookup not found" {
 test "single-binding cache preserves lookup and shadowing" {
   let env = env_bind(EnvEmpty, "outer", CtInt)
   let cached = env_cache_binding(env, "sentinel", CtChar)
-  assert(match env_lookup(cached, "sentinel") {
-    Some(ty) => types_equal(ty, CtChar),
-    None => false
-  })
-  assert(match env_lookup(cached, "outer") {
-    Some(ty) => types_equal(ty, CtInt),
-    None => false
-  })
+  inspect(match env_lookup(cached, "sentinel") {
+    Some(ty) => type_to_string(ty),
+    None => "None"
+  }, "Char")
+  inspect(match env_lookup(cached, "outer") {
+    Some(ty) => type_to_string(ty),
+    None => "None"
+  }, "Int")
   let shadowed = env_bind(cached, "sentinel", CtBool)
-  assert(match env_lookup(shadowed, "sentinel") {
-    Some(ty) => types_equal(ty, CtBool),
-    None => false
-  })
+  inspect(match env_lookup(shadowed, "sentinel") {
+    Some(ty) => type_to_string(ty),
+    None => "None"
+  }, "Bool")
 }
 
 test "env_lookup shadows outer" {


### PR DESCRIPTION
Closes #2209.

## Summary

- add a one-binding `TypeEnv` index that preserves the authoritative environment chain
- index the active-region sentinel once at each region boundary
- replace repeated recursive active-region scans with the existing indexed lookup
- add a deep-region checker probe, benchmark, and lookup/semantic regression tests

The change reuses the existing `EnvCached` representation, so it does not add a `TypeEnv` variant or change the persistent codec. Nested regions build their own sentinel index.

## Validation

- fresh stage2 generation passed
- 4 focused files / 100 tests passed (`types_test`, checker hotspot probe, MutList region signatures, cross-module region contracts)
- pre-commit review/architecture/doc gates passed
- full affected fallback ran 1016 files: 1002 passed; the 14 failures were pre-existing missing generated bundle/adapter files in the fresh worktree

## Benchmark

`check_deep_region_closure_128`, 200 iterations, 32 closure checks under 128 lexical bindings:

- before: min 777.96 us/op, p50 1.23 ms/op, 211.5 KiB/op
- after: min 667.92 us/op, p50 686.17 us/op, 232.2 KiB/op

The stable minimum improves by about 14%. Median improved in this run but was sensitive to host load. The one-name index adds about 20.8 KiB/op in this deliberately deep probe because each later persistent bind preserves the cache head; this tradeoff is recorded here rather than hidden.