### PR TITLE
Name all five TypeExpr variants in the equality field test

### DIFF
--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -8,6 +8,14 @@ struct Box[T] {
   value: T
 } derive (Eq)
 
+struct UnitParen {
+  u: ()
+} derive (Eq)
+
+struct UnitNamed {
+  u: Unit
+} derive (Eq)
+
 enum Boxed {
   BoxedPoint(Point)
 } derive (Eq)
@@ -460,4 +468,30 @@ test "a generic struct literal with a scalar type argument resolves" {
     value: 9
   })
   assert(xs != ys)
+}
+
+test "both spellings of a Unit field resolve" {
+  // `u: ()` reaches the field test as `TyUnit` and `u: Unit` as a `TyName`.
+  // They name the same type, so they have to answer the same -- while `TyUnit`
+  // fell to a catch-all, the parenthesised spelling trapped where the named one
+  // answered (#2192 review). The annotated `Array[UnitParen]` answers `true`
+  // for both, which is what says the trap was a gap and not the contract.
+  let xs = []
+  let ys = []
+  Array::push(xs, UnitParen::{
+    u: ()
+  })
+  Array::push(ys, UnitParen::{
+    u: ()
+  })
+  assert(xs == ys)
+  let ps = []
+  let qs = []
+  Array::push(ps, UnitNamed::{
+    u: ()
+  })
+  Array::push(qs, UnitNamed::{
+    u: ()
+  })
+  assert(ps == qs)
 }

--- a/fixtures/structural_eq_untyped_empty_fn_field_trap.vibe
+++ b/fixtures/structural_eq_untyped_empty_fn_field_trap.vibe
@@ -1,0 +1,36 @@
+//# ADR-0097 fail-closed: a declared field holding a function.
+//#
+//# A closure has no equality but identity, so `F::equals` compares the field
+//# with a raw `==` and answers by reference. Admitting `F` would let an
+//# unannotated binding return a reference-based answer where the contract says
+//# it fails closed, so the field test rejects `TyFn` and `==` traps.
+//#
+//# The rejection is deliberate rather than an omission: it costs a trap on a
+//# shape nobody writes, and the alternative cannot be told apart from a content
+//# answer at the call site.
+
+struct F {
+  f: () -> Int
+} derive (Eq)
+
+fn mk1() -> () -> Int {
+  () -> {
+    1
+  }
+}
+
+export fn _start() -> Int {
+  let left = []
+  Array::push(left, F::{
+    f: mk1()
+  })
+  let right = []
+  Array::push(right, F::{
+    f: mk1()
+  })
+  if left == right {
+    1
+  } else {
+    0
+  }
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8231,7 +8231,17 @@ fn eq_ty_field_is_content_comparable(t: TypeExpr, tparams: Array[String]) -> Boo
       }
     },
     TyTuple(ts) => eq_tys_all_content_comparable(ts, tparams),
-    _ => false
+    // `()` and `Unit` name the same type and must answer the same. They do not
+    // arrive the same way: `u: Unit` is a `TyName` the arm above already
+    // admits, `u: ()` is `TyUnit`, and while it fell to a catch-all the second
+    // spelling trapped where the first answered (#2192 review, measured -- the
+    // annotated `Array[U]` answers `true` for both).
+    TyUnit => true,
+    // A closure field is compared by identity, which is the only equality a
+    // function has. Rejecting it costs a trap on a shape nobody writes; the
+    // alternative is adopting a name whose `::equals` answers by reference,
+    // and the caller cannot tell the two apart from the outside.
+    TyFn(_, _, _) => false
   }
 }
 


### PR DESCRIPTION
Follow-up to #2192, from two review findings that arrived after it merged. Both were the same defect: a catch-all in `eq_ty_field_is_content_comparable` deciding cases nobody had written down — and it got them in opposite directions.

## `TyUnit` was rejected, so `()` and `Unit` disagreed

They name the same type. Measured on `2a0a8c1c`, the same program with the field spelled two ways:

| field | unannotated `let xs = []` | annotated `Array[T]` |
|---|---|---|
| `u: Unit` (`TyName`) | `true` | `true` |
| `u: ()` (`TyUnit`) | **trap** | `true` |

The annotated column is what makes this a gap rather than the contract: the comparison is correct, only one spelling could not reach it. `TyUnit => true`.

## `TyFn` was right by accident

The finding was accurate against `0f0da9dc`, where the catch-all meant "not unsafe". #2192 inverted this function's polarity to an allow-list, where the same catch-all means "not shown to be content-comparable" — so `TyFn` fell out of the wrong side into the right one, and a struct with a closure field already traps (measured on `2a0a8c1c`).

Right by accident is not decided, so it is now an explicit `false`. Identity is the only equality a closure has, and a caller cannot tell "compared by reference" from "compared by content" at the call site, so the trap is the honest answer for a shape this pass cannot show is content-compared.

## The structural fix

With both named, the match is exhaustive over `TypeExpr`'s five variants and the catch-all is gone. A sixth variant now stops the file compiling instead of being silently classified — the same guard `lib/@vibe/ast/ast_eq_test.vibe`'s `typeexpr_tag` already uses for this enum, and the reason both findings existed at all.

## Verification

- **fixpoint**: `cmp stage2.wasm stage3.wasm` byte-identical
- **gate**: `VIBE_STAGE2_WASM=… bash scripts/compiler_gate.sh` → exit 0
- all eleven `fixtures/structural_eq_untyped_empty_*_trap.vibe` fixtures fail closed, including the new `..._fn_field_trap.vibe`
- the 18-shape and 11-field surveys from #2192 are unchanged
- new test "both spellings of a Unit field resolve" asserts the **pair** — either spelling on its own would have passed throughout, which is how the disagreement survived

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_