### PR TITLE
Classify unit and function fields for inferred equality

### DIFF
--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -8,6 +8,10 @@ struct Box[T] {
   value: T
 } derive (Eq)
 
+struct UnitField {
+  value: ()
+} derive (Eq)
+
 enum Boxed {
   BoxedPoint(Point)
 } derive (Eq)
@@ -76,6 +80,14 @@ test "unannotated empty bindings stay structural after a push" {
   Array::push(left, 1)
   assert(left != right)
   Array::push(right, 1)
+  assert(left == right)
+}
+
+test "a unit field remains content-comparable" {
+  let left = []
+  let right = []
+  Array::push(left, UnitField::{ value: () })
+  Array::push(right, UnitField::{ value: () })
   assert(left == right)
 }
 

--- a/fixtures/structural_eq_untyped_empty_function_field_trap.vibe
+++ b/fixtures/structural_eq_untyped_empty_function_field_trap.vibe
@@ -1,0 +1,26 @@
+//# ADR-0097 fail-closed: a declared comparator that reaches a function field
+//# must not be adopted as the inferred element shape of `let xs = []`.
+//# Generated equality has no content comparator for separately allocated
+//# closures, so answering by their identity would be silently wrong.
+
+struct Wrapper {
+  f: (Int) -> Int
+} derive (Eq)
+
+fn make_adder(n: Int) -> (Int) -> Int {
+  (x) -> {
+    x + n
+  }
+}
+
+export fn _start() -> Int {
+  let left = []
+  Array::push(left, Wrapper::{ f: make_adder(1) })
+  let right = []
+  Array::push(right, Wrapper::{ f: make_adder(1) })
+  if left == right {
+    1
+  } else {
+    0
+  }
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8231,6 +8231,8 @@ fn eq_ty_field_is_content_comparable(t: TypeExpr, tparams: Array[String]) -> Boo
       }
     },
     TyTuple(ts) => eq_tys_all_content_comparable(ts, tparams),
+    TyUnit => true,
+    TyFn(_, _, _) => false,
     _ => false
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2192 review findings.

- admit `TyUnit` fields as content-comparable, matching the `Unit` named spelling
- explicitly reject `TyFn` fields from inferred equality shapes
- add regressions for Unit-field equality and function-field fail-closed behavior

The function-field report was already fail-closed on merged `main` after the allow-list refactor in `2a0a8c1cc`; the new fixture pins that behavior. The Unit-field report reproduced and is fixed here.

## Verification

- Red: the Unit-field test trapped on `main`
- Green: `structural_eq_contexts_test.vibe` passes
- function-field fixture traps as required
- stage2/stage3 are byte-identical
- formatter and pre-commit gates pass

Follow-up for post-merge review threads:
- https://github.com/mizchi/vibe-lang/pull/2192#discussion_r3836219657
- https://github.com/mizchi/vibe-lang/pull/2192#discussion_r3836265120