### PR TITLE
Preserve heap sampler phase

### DIFF
--- a/runtime/viberun/src/main.rs
+++ b/runtime/viberun/src/main.rs
@@ -1131,6 +1131,14 @@ fn advance_epoch_deadline(mut deadline: Instant, interval: Duration, now: Instan
     deadline
 }
 
+fn heap_sample_due(deadline: &mut Instant, interval: Duration, now: Instant) -> bool {
+    if now < *deadline {
+        return false;
+    }
+    *deadline = advance_epoch_deadline(*deadline, interval, now);
+    true
+}
+
 #[derive(Debug, Clone)]
 struct GuestCpuClock {
     accumulated_guest: Duration,
@@ -1412,10 +1420,13 @@ fn run(args: Vec<String>) -> Result<i32> {
             }
         }
         store.set_epoch_deadline(1);
-        let mut last_heap = Instant::now();
+        let mut next_heap_sample = heap_interval.map(|interval| Instant::now() + interval);
         store.epoch_deadline_callback(move |mut ctx| {
             let now = Instant::now();
-            if heap_interval.is_some_and(|interval| now.duration_since(last_heap) >= interval) {
+            if heap_interval
+                .zip(next_heap_sample.as_mut())
+                .is_some_and(|(interval, deadline)| heap_sample_due(deadline, interval, now))
+            {
                 if let Some(g) = ctx.data().sample_global {
                     let v = match g.get(&mut ctx) {
                         Val::I32(x) => x as u32 as u64,
@@ -1425,7 +1436,6 @@ fn run(args: Vec<String>) -> Result<i32> {
                     let t = ctx.data().sample_start.elapsed().as_nanos();
                     ctx.data_mut().samples.push((t, v));
                 }
-                last_heap = now;
             }
             let guest_delta = ctx
                 .data_mut()
@@ -4785,6 +4795,26 @@ mod tests {
             start + Duration::from_millis(20),
         );
         assert_eq!(next.duration_since(start), Duration::from_micros(20_002));
+    }
+
+    #[test]
+    fn heap_sample_deadline_preserves_phase_after_callback_jitter() {
+        let start = Instant::now();
+        let interval = Duration::from_millis(1);
+        let mut deadline = start + interval;
+
+        assert!(heap_sample_due(
+            &mut deadline,
+            interval,
+            start + Duration::from_micros(1_100),
+        ));
+        assert_eq!(deadline, start + Duration::from_millis(2));
+        assert!(heap_sample_due(
+            &mut deadline,
+            interval,
+            start + Duration::from_millis(2),
+        ));
+        assert_eq!(deadline, start + Duration::from_millis(3));
     }
 
     #[test]

--- a/scripts/lint_guest_profile_contract.sh
+++ b/scripts/lint_guest_profile_contract.sh
@@ -43,6 +43,8 @@ require 'CallHook::ReturningFromHost' "$runner" "host return is not tracked"
 require 'CallHook::CallingWasm' "$runner" "outer harness-to-guest entry is not tracked"
 require 'CallHook::ReturningFromWasm' "$runner" "outer guest-to-harness return is not tracked"
 forbid 'last_guest|guest_profiler_last_sample' "$runner" "wall-clock/reset sampling state reintroduced"
+require 'fn heap_sample_due' "$runner" "heap sampler absolute-deadline state is missing"
+forbid 'last_heap' "$runner" "heap sampler wall-clock rebasing was reintroduced"
 
 # CLI values must distinguish omission from an explicitly empty value, preserve
 # the argv separator, and reject destructive source/output aliasing.

--- a/scripts/lint_guest_profile_contract_test.sh
+++ b/scripts/lint_guest_profile_contract_test.sh
@@ -21,4 +21,14 @@ fi
 grep -q 'missing shared GuestCpuClock' "$TMP_ROOT/out" \
   || { echo "guest-profile contract self-test: missing diagnostic" >&2; exit 1; }
 
+sed 's/fn heap_sample_due/fn removed_heap_sample_due/' \
+  "$ROOT/runtime/viberun/src/main.rs" > "$TMP_ROOT/runtime/viberun/src/main.rs"
+if VIBE_GUEST_PROFILE_LINT_ROOT="$TMP_ROOT" \
+  bash "$ROOT/scripts/lint_guest_profile_contract.sh" >"$TMP_ROOT/out" 2>&1; then
+  echo "guest-profile contract self-test: missing heap deadline unexpectedly passed" >&2
+  exit 1
+fi
+grep -q 'heap sampler absolute-deadline state is missing' "$TMP_ROOT/out" \
+  || { echo "guest-profile contract self-test: missing heap deadline diagnostic" >&2; exit 1; }
+
 echo "guest-profile contract self-test: ok"


### PR DESCRIPTION
Follow-up to #2208 after it merged while the final review fix was in progress.

- preserve the heap sampler’s absolute deadline across callback jitter
- add a regression test for a late 1 ms callback followed by the 2 ms tick
- add a static contract lint preventing wall-clock rebasing from returning

Validation:
- `cargo test --manifest-path runtime/viberun/Cargo.toml` (11 passed)
- `bash scripts/lint_guest_profile_contract.sh`
- `bash scripts/lint_guest_profile_contract_test.sh`
- pre-commit review-derived lint gates