### PR TITLE
Give a nameless callee's call node an offset (#2231, partial)

### DIFF
--- a/fixtures/float_call_offset_source_lane.vibe
+++ b/fixtures/float_call_offset_source_lane.vibe
@@ -105,6 +105,22 @@ test "#2158 offsets: an Int-returning call is NOT reclassified" {
   assert_true(__to_string(int_pair().0) == "3")
 }
 
+test "#2231: a call whose callee is not a name at all" {
+  // The ECall offset is the key `float_call_offsets` uses, and the checker
+  // records an occurrence only when it is >= 0. `callee_offset` returns -1 for
+  // a callee that is not a name, an `EDot` or a call -- so an
+  // immediately-invoked lambda had no offset to be recorded under, and the
+  // Double it returns printed its raw f64 bits (`372`). The call node now
+  // falls back to the offset of the `(` that opens its argument list, which no
+  // other call node can share.
+  //
+  // The callee's OWN offset is still preferred where it exists: `[@off=N:M]`
+  // diagnostics point at the callee (#1514), the better edit point.
+  assert_true(__to_string((() -> {
+    2.5
+  })()) == "2.5")
+}
+
 test "#2158 offsets: a parenthesised callee is still a name" {
   // #2226 review asked for the offset lookup to be hoisted above
   // `if is_eident(callee)`, since the table is keyed by the CALL NODE and
@@ -113,19 +129,19 @@ test "#2158 offsets: a parenthesised callee is still a name" {
   // `EIdent` callee -- it is the control that says the hoist did not break the
   // shapes that already worked.
   //
-  // A callee that is genuinely NOT an identifier still renders raw bits, and
-  // the cause is upstream of this file: the call node carries no source
-  // offset, so the checker never records its Double answer and there is
-  // nothing for the hoisted lookup to find. Measured on this branch's stage2:
+  // Measured on this branch's stage2, after the offset fallback:
   //
-  //   f()                  -> 2.5   (identifier)
-  //   (f)()                -> 2.5   (same AST)
-  //   g(1.25)              -> 2.5   (alias binding)
-  //   (mkh().f)()          -> 348   field callee
-  //   (() -> { 2.5 })()    -> 372   immediately-invoked lambda
+  //   f()                  -> 2.5   identifier
+  //   (f)()                -> 2.5   same AST
+  //   dbl(1.25)            -> 2.5   alias binding
+  //   (() -> { 2.5 })()    -> 2.5   immediately-invoked lambda (was 372)
+  //   (mkh().f)()          -> 624   field callee -- STILL WRONG
   //
-  // Tracked as #2231. Not asserted here, because asserting the current answer
-  // would pin a wrong one.
+  // The field callee's ECall does carry an offset (`callee_offset` reads the
+  // `EDot`'s field-name token), so the fallback is not what it needs: the
+  // checker does not record that call as a primary `CallResult`. Separate
+  // cause, same issue -- #2231 stays open for it, and it is not asserted here
+  // because asserting the current answer would pin a wrong one.
   let f = () -> {
     2.5
   }

--- a/lib/@vibe/parser/parser_expr_core.vibe
+++ b/lib/@vibe/parser/parser_expr_core.vibe
@@ -445,7 +445,20 @@ fn map_from_pairs_fields(args: Array[Expr], pos: Int) -> Array[(String, Expr)] w
   }
 }
 
-fn build_call_expr(expr: Expr, args: Array[Expr], pos: Int) -> Expr with Exception {
+/// #2231: `lparen_off` is the source offset of the `(` that opens this call's
+/// argument list, used ONLY when the callee carries none of its own.
+///
+/// The ECall offset is the key `CompileCtx.float_call_offsets` uses to hand
+/// codegen the checker's per-call-site `Double` answer (#2158), and the
+/// checker records an occurrence only when the offset is >= 0. A callee that
+/// is not a name has no offset to lend -- an immediately-invoked lambda is the
+/// smallest such shape -- so its call was never recorded, and a `Double`
+/// returned through one printed its raw f64 bits.
+///
+/// The callee's own offset is still preferred where it exists: `[@off=N:M]`
+/// diagnostics point at the callee (#1514), which is the better edit point,
+/// and moving every call to the `(` would move all of them.
+fn build_call_expr(expr: Expr, args: Array[Expr], pos: Int, lparen_off: Int) -> Expr with Exception {
   let ctor_name = match expr {
     EIdent(name, _) => name,
     _ => ""
@@ -459,7 +472,12 @@ fn build_call_expr(expr: Expr, args: Array[Expr], pos: Int) -> Expr with Excepti
   } else if ctor_name == "Map::from_pairs" {
     EMap(map_from_pairs_fields(args, pos))
   } else {
-    ECall(expr, args, callee_offset(expr))
+    let own = callee_offset(expr)
+    ECall(expr, args, if own >= 0 {
+      own
+    } else {
+      lparen_off
+    })
   }
 }
 
@@ -491,7 +509,7 @@ fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr,
       EForIn(_, _, _, _) => (expr, pos),
       EHandle(_, _) => (expr, pos),
       _ => match peek(tokens, pos + 1) {
-        TRParen => parse_postfix(tokens, starts, pos + 2, build_call_expr(expr, empty_exprs(), pos), parse_recur, context),
+        TRParen => parse_postfix(tokens, starts, pos + 2, build_call_expr(expr, empty_exprs(), pos, field_offset_at(starts, pos)), parse_recur, context),
         _ => {
           let b = ArrayBuilder::new()
           let row_marks = match context {
@@ -515,7 +533,7 @@ fn parse_postfix(tokens: Array[Token], starts: Array[Int], pos: Int, expr: Expr,
           } else {
             args
           }
-          parse_postfix(tokens, starts, close_pos, build_call_expr(expr, call_args, pos), parse_recur, context)
+          parse_postfix(tokens, starts, close_pos, build_call_expr(expr, call_args, pos, field_offset_at(starts, pos)), parse_recur, context)
         }
       },
     },


### PR DESCRIPTION
## What

`callee_offset(callee)` returns `-1` for a callee that is not `EIdent` / `EDot` / `ECall`. An immediately-invoked lambda is exactly that shape, so its `ECall` node carried no offset, was never recorded in `CompileCtx.float_call_offsets` (#2158 records only when `off >= 0`), and its `Double` result printed as raw bits.

`build_call_expr` now takes the `(` token's offset and uses it when the callee has no offset of its own. Both call sites pass `field_offset_at(starts, pos)`.

## Measured, source lane, before -> after

```
f()                  2.5 -> 2.5   identifier
(f)()                2.5 -> 2.5   same AST
dbl(1.25)            2.5 -> 2.5   alias binding
(() -> { 2.5 })()    372 -> 2.5   immediately-invoked lambda
(mkh().f)()          348 -> 624   field callee, STILL WRONG
```

## What this does not fix

The last row. That call node already carries an offset (from the `EDot`'s field-name token), so the fallback is not what it needs -- the checker does not record that call as a primary `CallResult` at all. **#2231 stays open for it**, and the number moving from 348 to 624 is only the offset moving; it is still the raw bits. The fixture deliberately does not assert that row, because asserting today's answer would pin a wrong one.

## Test

`fixtures/float_call_offset_source_lane.vibe` gains `"#2231: a call whose callee is not a name at all"`, asserting the IIFE. The measured table above lives in a comment next to it.

## Verification

- fixpoint: stage2 == stage3, byte-identical
- `scripts/compiler_gate.sh` exit 0
- `scripts/unit_test_runner.sh` 1017/1017

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_