### PR TITLE
Let a match or handle arm body be a bare assignment (#2197)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -633,6 +633,32 @@ A | B               // or-pattern
 x if x > 0          // guard (match arm only)
 ```
 
+### Arm bodies
+
+An arm body is an expression, and **an assignment counts** (#2197) -- `_ => ok =
+false` needs no braces, and neither do the compound operators or a field or
+index target. The braced form is the same program.
+
+```vibe
+let demo_arm_assign: (Int) -> Int = (n) -> {
+  let mut total = 0
+  let xs = [1, 2, 3]
+  match n {
+    0 => total = 10,
+    1 => total += 5,
+    2 => xs[0] = 9,
+    _ => total = n
+  }
+  total + Array::get(xs, 0)
+}
+```
+
+This used to be a parse error whose position pointed at the enclosing
+declaration (`unexpected in pattern: =`), because the body stopped at the `=`
+and the arm collector read that token as the NEXT arm's pattern. An
+unassignable target now says `invalid assignment target`, the same message the
+statement position gives.
+
 ### Destructuring let
 
 パターン `let` (tuple destructure `let (a, b) = ..`、named-struct destructure
@@ -1931,30 +1957,6 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
 
 判断に迷いやすい規則をここに集める。**すべて現行 stage2 で実測したもの**で、
 仕様書の記述ではない。同じことを二度調べ直さないための場所。
-
-### A match arm body cannot be a bare assignment
-
-`_ => ok = false` is rejected; `_ => { ok = false }` is accepted. Both the
-committed seed and the current stage2 answer the same way (measured
-2026-08-22), so this is the language, not a bootstrap lag. Rust accepts the
-unbraced form, which is why it gets reached for.
-
-```vibe skip
-// skip: this is a parse error, shown for the message it produces
-match n {
-  2 => ok = false,
-  _ => ok = true
-}
-```
-
-```
-line 1:1: unexpected in pattern: =
-```
-
-The diagnostic is worth knowing precisely because it is bad on both counts the
-CLI policy names: the position is the **enclosing declaration**, not the arm,
-and the message names an internal parser state rather than the edit that fixes
-it (add the braces). Tracked as #2197.
 
 ### A `handle` that type-checks can still fail to compile
 

--- a/lib/@vibe/compiler/tests/match_arm_assign_test.vibe
+++ b/lib/@vibe/compiler/tests/match_arm_assign_test.vibe
@@ -1,0 +1,144 @@
+//# #2197: a match or handle arm body may be a bare assignment.
+//#
+//# The braced form (`_ => { ok = false }`) always worked. The unbraced one is
+//# what Rust accepts and what readers reach for, and it used to fail with
+//# `unexpected in pattern: =` anchored at the enclosing declaration -- the arm
+//# body stopped at the `=`, so the arm collector read that token as the next
+//# arm's PATTERN. These tests pin both that it parses and that it assigns.
+
+struct Point {
+  mut x: Int;
+  mut y: Int
+}
+
+test "match arm body is a bare assignment" {
+  let mut ok = false
+  match 1 {
+    2 => ok = false,
+    _ => ok = true
+  }
+  assert(ok)
+}
+
+test "the arm that does not match does not assign" {
+  let mut n = 0
+  match 7 {
+    1 => n = 100,
+    7 => n = 42,
+    _ => n = 200
+  }
+  assert(n == 42)
+}
+
+test "a bare assignment arm still separates on the comma" {
+  let mut xs = [0]
+  match 1 {
+    1 => xs = [1, 2, 3],
+    _ => xs = [9]
+  }
+  assert(Array::length(xs) == 3)
+}
+
+fn pick_second(a: Int, b: Int) -> Int {
+  let _ = a
+  b
+}
+
+test "a call with its own commas in the assigned value" {
+  let mut n = 0
+  match 1 {
+    1 => n = pick_second(3, 8),
+    _ => n = 0
+  }
+  assert(n == 8)
+}
+
+test "compound assignment as an arm body" {
+  let mut n = 10
+  match 1 {
+    1 => n += 5,
+    _ => n -= 5
+  }
+  assert(n == 15)
+}
+
+test "every compound operator" {
+  let mut a = 10
+  match 0 {
+    _ => a -= 4
+  }
+  let mut b = 10
+  match 0 {
+    _ => b *= 3
+  }
+  let mut c = 10
+  match 0 {
+    _ => c /= 2
+  }
+  let mut d = 10
+  match 0 {
+    _ => d %= 3
+  }
+  assert(a == 6 && b == 30 && c == 5 && d == 1)
+}
+
+test "field assignment as an arm body" {
+  let p = Point::{ x: 1, y: 2 }
+  match 1 {
+    1 => p.x = 40,
+    _ => p.y = 50
+  }
+  assert(p.x == 40 && p.y == 2)
+}
+
+test "index assignment as an arm body" {
+  let xs = [1, 2, 3]
+  match 1 {
+    1 => xs[1] = 20,
+    _ => xs[2] = 30
+  }
+  assert(Array::get(xs, 1) == 20 && Array::get(xs, 2) == 3)
+}
+
+test "a guarded arm may also assign" {
+  let mut n = 0
+  let g = false
+  match 1 {
+    1 if g => n = 1,
+    _ => n = 2
+  }
+  assert(n == 2)
+}
+
+test "the last arm needs no trailing comma" {
+  let mut n = 0
+  match 3 {
+    1 => n = 1,
+    _ => n = 3
+  }
+  assert(n == 3)
+}
+
+test "the braced form still works and agrees" {
+  let mut a = 0
+  match 1 {
+    _ => a = 5
+  }
+  let mut b = 0
+  match 1 {
+    _ => {
+      b = 5
+    }
+  }
+  assert(a == b)
+}
+
+test "a handler arm body may be a bare assignment" {
+  let mut seen = ""
+  handle {
+    throw("boom")
+  } with Exception {
+    Throw(e) => seen = e
+  }
+  assert(seen == "boom")
+}

--- a/lib/@vibe/compiler/tests/parser_controlflow_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_controlflow_test.vibe
@@ -45,3 +45,36 @@ test "parse else call expr without braces" {
   }
   assert(result == "if cond { x } else { f(y) }")
 }
+
+//# #2197: a bare assignment as a match / handle arm body
+
+test "parse match arm body as a bare assignment" {
+  let result = handle {
+    parse_print("match x { 1 => ok = false, _ => ok = true }")
+  } with Exception {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(result == "match x { 1 => { ok = false; () }, _ => { ok = true; () } }")
+}
+
+test "parse match arm body as a compound assignment" {
+  let result = handle {
+    parse_print("match x { _ => n += 1 }")
+  } with Exception {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(result == "match x { _ => { n += 1; () } }")
+}
+
+/// An assignment token can never begin a pattern, so `=` after an arm body is
+/// always an assignment attempt -- an unassignable target gets the same message
+/// a block statement gets, not `unexpected in pattern: =` at the enclosing
+/// declaration (#2197).
+test "an unassignable match arm assignment target is named as such" {
+  let result = handle {
+    parse_print("match x { _ => 1 = 2 }")
+  } with Exception {
+    Throw(e) => String::concat("ERROR: ", e)
+  }
+  assert(result == "ERROR: invalid assignment target")
+}

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -289,6 +289,84 @@ fn desugar_guarded(arms: Array[(Pat, Expr, Expr)], i: Int, scrut: Expr, context:
   }
 }
 
+/// #2197: the compound-assignment token's operator, or None when `tk` is not
+/// one. Kept separate so the arm-body tail below states each target shape once
+/// instead of once per operator, the way parse_block_steps has to.
+fn arm_assign_op(tk: Token) -> Option[String] {
+  match tk {
+    TPlusEq => Some("+"),
+    TMinusEq => Some("-"),
+    TStarEq => Some("*"),
+    TSlashEq => Some("/"),
+    TPercentEq => Some("%"),
+    _ => None
+  }
+}
+
+/// #2197: let a match/handle arm body be a bare assignment -- `_ => ok = false`,
+/// the spelling Rust accepts and readers reach for. An arm body parses as an
+/// EXPRESSION, so the assignment token was left unconsumed and the arm
+/// collector then read `=` as the NEXT arm's pattern, reporting
+/// `unexpected in pattern: =` anchored at the enclosing declaration rather than
+/// at the arm.
+///
+/// `body` is the already-parsed arm body and `at` the position after it. When
+/// no assignment token follows, this returns them unchanged. The targets and
+/// their desugars are exactly parse_block_steps' (a name, a field via
+/// `__set_field`, an index via `Array::set`); the continuation is EUnit, which
+/// is what an assignment already evaluates to, so no type rule changes.
+///
+/// A pattern can never begin with `=` or `+=`, so an assignment token in this
+/// position is always an assignment attempt -- an unassignable target gets the
+/// same `invalid assignment target` a block statement gets, not the pattern
+/// error.
+fn parse_arm_assign_tail(tokens: Array[Token], body: Expr, at: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
+  let tk = peek(tokens, at)
+  match arm_assign_op(tk) {
+    Some(op) => match body {
+      EIdent(name, _) => {
+        let (val, next) = parse_recur(tokens, at + 1, 0, context)
+        (EAssignOp(name, op, val, EUnit), next)
+      },
+      _ => throw("invalid assignment target")
+    },
+    None => match tk {
+      TEq => match body {
+        EIdent(name, _) => {
+          let (val, next) = parse_recur(tokens, at + 1, 0, context)
+          (EAssign(name, val, EUnit), next)
+        },
+        EDot(obj, field, _, _) => {
+          let (val, next) = parse_recur(tokens, at + 1, 0, context)
+          let set_args = empty_exprs()
+          Array::push(set_args, obj)
+          Array::push(set_args, EString(field))
+          Array::push(set_args, val)
+          (ECall(EIdent("__set_field", -1), set_args, -1), next)
+        },
+        ECall(idx_callee, idx_args, _) => {
+          let is_index = match idx_callee {
+            EIdent(icn, _) => icn == "__index",
+            _ => false
+          }
+          if is_index && Array::length(idx_args) == 2 {
+            let (val, next) = parse_recur(tokens, at + 1, 0, context)
+            let set_args = empty_exprs()
+            Array::push(set_args, Array::get(idx_args, 0))
+            Array::push(set_args, Array::get(idx_args, 1))
+            Array::push(set_args, val)
+            (ECall(EIdent("Array::set", -1), set_args, -1), next)
+          } else {
+            throw("invalid assignment target")
+          }
+        },
+        _ => throw("invalid assignment target")
+      },
+      _ => (body, at)
+    }
+  }
+}
+
 /// #666: parse all match arms into `b` as (pattern, guard|EBool(true), body).
 /// A negative return encodes `-end - 1` when any arm carries a guard, avoiding
 /// an allocation-only mutable Bool cell on the ordinary no-capture path.
@@ -312,7 +390,9 @@ fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: Arr
   }
   let arrow = expect_tk(tokens, after_g, "=>")
   let body_mark = binder_capture_mark(context)
-  let (body, bn) = parse_recur(tokens, arrow, 0, context)
+  let (raw_body, raw_bn) = parse_recur(tokens, arrow, 0, context)
+  // #2197: `_ => ok = false` -- the assignment is part of THIS arm's body.
+  let (body, bn) = parse_arm_assign_tail(tokens, raw_body, raw_bn, parse_recur, context)
   let body_rows = binder_capture_take_from(context, body_mark)
   ArrayBuilder::push(b, (pat, arm_guard, body))
   match row_b {
@@ -382,7 +462,9 @@ fn parse_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, effect_n
   let (pat, pat_next) = parse_pattern_with_binder_context(tokens, pos, context)
   let qualified_pat = qualify_handle_arm_pattern(effect_name, pat, context)
   let arrow_pos = expect_tk(tokens, pat_next, "=>")
-  let (expr, next) = parse_recur(tokens, arrow_pos, 0, context)
+  // #2197: a handler body is an arm body too -- same bare-assignment tail.
+  let (raw_expr, raw_next) = parse_recur(tokens, arrow_pos, 0, context)
+  let (expr, next) = parse_arm_assign_tail(tokens, raw_expr, raw_next, parse_recur, context)
   ((qualified_pat, expr), next)
 }
 
@@ -407,7 +489,9 @@ fn parse_qualified_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int
     _ => throw("handler-set arms must name a fully qualified operation such as `Exception::Throw(_)`")
   }
   let arrow_pos = expect_tk(tokens, pat_next, "=>")
-  let (expr, next) = parse_recur(tokens, arrow_pos, 0, context)
+  // #2197: a handler body is an arm body too -- same bare-assignment tail.
+  let (raw_expr, raw_next) = parse_recur(tokens, arrow_pos, 0, context)
+  let (expr, next) = parse_arm_assign_tail(tokens, raw_expr, raw_next, parse_recur, context)
   ((qualified_pat, expr), next)
 }
 


### PR DESCRIPTION
Closes #2197.

## What was wrong

`_ => ok = false` was a parse error; only the braced `_ => { ok = false }` was accepted. Rust accepts the unbraced form, which is why it gets reached for — the issue was filed after it cost a bisect through a 9000-line file.

An arm body parses as an **expression**, so the assignment token was left unconsumed and the arm collector then read `=` as the **next arm's pattern**. That is why the message was `unexpected in pattern: =` anchored at the enclosing declaration rather than at the arm: by the time it fired, the parser was looking at a pattern, in a different place.

## What changed

`parse_arm_assign_tail` consumes an assignment tail after an arm body, wired into all three arm parsers (`collect_match_arms`, `parse_handle_arm`, `parse_qualified_handle_arm`). Targets and desugars are exactly the block-statement path's — a name to `EAssign`, a field via `__set_field`, an index via `Array::set` — plus the five compound operators. The continuation is `EUnit`, which is what an assignment already evaluates to, so no type rule changes and the braced form stays the same program.

A pattern can never begin with `=` or `+=`, so an assignment token in that position is always an assignment attempt. An unassignable target therefore gets `invalid assignment target`, the same message the statement position gives, instead of the pattern error.

## Measured, before -> after

| arm body | before | after |
|---|---|---|
| `_ => ok = false` | `unexpected in pattern: =` | assigns |
| `_ => n += 1` | parse error | assigns |
| `_ => p.x = 40` | parse error | assigns |
| `_ => xs[1] = 20` | parse error | assigns |
| `_ => 1 = 2` | `unexpected in pattern: =` | `invalid assignment target` |
| `_ => { ok = false }` | worked | unchanged, same program |

## Test

Red is pinned rather than asserted from memory: the new `match_arm_assign_test.vibe` (12 tests) fails to **compile** on the committed seed with the issue's exact message at line 14, and passes on a stage2 built from this tree. Three printer round-trip tests in `parser_controlflow_test.vibe` cover the desugar shape and the negative case.

## Docs

The cheatsheet's 落とし穴 entry for this is **deleted** rather than amended — the pitfall no longer exists — and replaced by an "Arm bodies" subsection under Pattern Matching whose example is doctest-compiled.

## Verification

- stage2 == stage3, byte-identical
- `scripts/compiler_gate.sh` exit 0
- `scripts/unit_test_runner.sh` 1018/1018

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_